### PR TITLE
obs(list-feed-digest): per-feed fetch-source log to triage zero-article panels

### DIFF
--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -294,11 +294,15 @@ async function fetchAndParseRss(
 
     // Try direct fetch first
     let text = await fetchRssText(feed.url, signal).catch(() => null);
+    let source: 'direct' | 'relay' | 'both-failed' = text ? 'direct' : 'both-failed';
+    let relayStatus: number | null = null;
+    let relayBodyShape: 'rss' | 'html-or-empty' | 'no-relay' | 'fetch-error' = 'no-relay';
 
     // Fallback: route through Railway relay (different IP, avoids Vercel blocks)
     if (!text) {
       const relayBase = getRelayBaseUrl();
       if (relayBase) {
+        relayBodyShape = 'fetch-error';
         const relayUrl = `${relayBase}/rss?url=${encodeURIComponent(feed.url)}`;
         const { controller, cleanup } = createTimeoutLinkedController(signal);
         try {
@@ -306,16 +310,34 @@ async function fetchAndParseRss(
             headers: getRelayHeaders({ Accept: RSS_ACCEPT }),
             signal: controller.signal,
           });
+          relayStatus = resp.status;
           if (resp.ok) {
             const relayText = await resp.text();
             // Relay can also return CF-challenge HTML if the relay's IP is
             // challenged — apply the same sniff to keep the cache clean.
-            if (looksLikeRssXml(relayText)) text = relayText;
+            if (looksLikeRssXml(relayText)) {
+              text = relayText;
+              source = 'relay';
+              relayBodyShape = 'rss';
+            } else {
+              relayBodyShape = 'html-or-empty';
+            }
           }
         } catch { /* relay also failed */ } finally {
           cleanup();
         }
       }
+    }
+
+    // Per-feed observability: surfaces which path won the fetch in Vercel
+    // function logs. Critical when panels show 0 items — without this
+    // breadcrumb you can't tell apart "direct blocked + relay env unset"
+    // from "direct blocked + relay 403/429" from "relay returned HTML".
+    // Filter logs by `[feed-fetch]` to triage. Volume: one line per cache
+    // miss per feed (capped by CACHE_TTL_EMPTY_S=300s + healthy=3600s).
+    if (source !== 'direct') {
+      const host = (() => { try { return new URL(feed.url).hostname; } catch { return 'invalid-url'; } })();
+      console.log(`[feed-fetch] variant=${variant} category=? host=${host} source=${source} relay_status=${relayStatus ?? 'n/a'} relay_shape=${relayBodyShape} feed=${feed.name}`);
     }
 
     if (!text) {


### PR DESCRIPTION
## Why

Production right now: news regional / topic panels (Latin America, GitHub Trending, IPO & SPAC, Product Hunt, Financial Regulation, Energy & Resources) all render UNAVAILABLE / 0 items.

I tested every upstream feed from a laptop — **all return valid RSS**:

\`\`\`
BBC Latin America              200, 14KB RSS
Guardian Americas              200, 67KB RSS
Infobae Americas               200, 953KB RSS
El Universo                    200, 142KB RSS
Clarín                         200, 9KB RSS
InSight Crime                  200, 284KB RSS
github.blog/feed/              200, 154KB RSS
producthunt.com/feed           200, 44KB Atom
oilprice.com/rss/main          200, 16KB RSS
rigzone.com/.../latest.aspx    200, 9KB RSS
sec.gov/...pressreleases.rss   200, 18KB RSS
news.google.com/rss/search?... 200, 135-152KB RSS
\`\`\`

Only Primicias is genuinely broken (301 redirect to /). So **the bug is in our pipeline, not the upstreams**.

## What this triages

Without observability, the Vercel log can't distinguish:

- Direct fetch from Vercel egress blocked AND \`WS_RELAY_URL\` env unset → relay fallback never fires
- Direct blocked AND relay returns 403 (allowlist mismatch) / 401 (RELAY_SHARED_SECRET drift)
- Direct blocked AND relay returns RSS — works
- Direct succeeds — works
- Relay returns 200 with HTML interstitial (CF challenge on relay's IP) — currently hidden, \`looksLikeRssXml\` rejects silently
- Vercel function timeout before fallback runs

This adds a single \`[feed-fetch]\` breadcrumb per cache miss with the four signals: \`source\` (direct/relay/both-failed), \`relay_status\`, \`relay_shape\` (rss/html-or-empty/fetch-error/no-relay), \`feed\` name.

## Volume

Emitted only on cache miss, AND only when \`source !== 'direct'\` (the happy path stays quiet). With \`CACHE_TTL_EMPTY_S=300s\` and \`CACHE_TTL_HEALTHY_S=3600s\`, log rate is self-throttled — one line per feed per 5min in the worst case.

## After deploy

Filter Vercel function logs for \`[feed-fetch]\`. Within 5-10 minutes of next user traffic, the actual failure mode will be obvious from the log lines. Then the remediation PR can be surgical (env-var fix, allowlist update, secret rotation, fetch-strategy change) rather than guessed.

## Test plan

- [x] \`npm run typecheck:api\` clean
- [ ] After merge: filter Vercel function logs by \`[feed-fetch]\`, identify dominant failure mode, ship remediation