### PR TITLE
fix(news-digest): bump freshness gate 48h → 96h (weekend-empty panels)

### DIFF
--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -37,15 +37,28 @@ const FEED_TIMEOUT_MS = 8_000;
 const OVERALL_DEADLINE_MS = 25_000;
 const BATCH_CONCURRENCY = 20;
 
-// U3 — hard freshness floor (default 48h, env override NEWS_MAX_AGE_HOURS).
+// U3 — hard freshness floor (default 96h, env override NEWS_MAX_AGE_HOURS).
 // Items older than this are dropped before scoring. The 24h `recencyScore`
 // component already treats anything older than 24h as zero recency, so the
-// 48h default is a soft buffer beyond that. Out-of-range / unparseable env
-// values fall back to the default silently. See R3 in
-// docs/plans/2026-04-26-001-fix-brief-static-page-contamination-plan.md.
+// freshness floor is purely a "don't surface week-old news" guard, not a
+// scoring input.
+//
+// 2026-05-03: bumped 48 → 96 after a production incident where every
+// single-source category panel (GitHub Trending: github.blog/feed/, Product
+// Hunt: producthunt.com/feed) went UNAVAILABLE over a weekend. Both feeds
+// publish on a weekday cadence; over a Sat-Sun window their newest item
+// sits at ~50-70h old, which the 48h floor wholesale dropped → category
+// renders zero items → panel reads "UNAVAILABLE". 96h covers a Fri→Mon
+// weekend with margin so we don't flip empty on Sunday-night dashboard
+// checks. The 24h recencyScore still naturally de-ranks 48-96h items vs
+// anything fresher, so the visible-but-de-ranked outcome is correct:
+// better than "no news" but lower priority than today.
+//
+// Out-of-range / unparseable env values fall back to the default silently.
+// See R3 in docs/plans/2026-04-26-001-fix-brief-static-page-contamination-plan.md.
 function resolveMaxAgeMs(): number {
   const raw = Number.parseInt(process.env.NEWS_MAX_AGE_HOURS ?? '', 10);
-  const hours = Number.isInteger(raw) && raw > 0 ? raw : 48;
+  const hours = Number.isInteger(raw) && raw > 0 ? raw : 96;
   return hours * 60 * 60 * 1000;
 }
 

--- a/tests/news-freshness-floor.test.mts
+++ b/tests/news-freshness-floor.test.mts
@@ -1,11 +1,14 @@
 // U3 from docs/plans/2026-04-26-001-fix-brief-static-page-contamination-plan.md
 //
-// Hard freshness floor (default 48h, env override `NEWS_MAX_AGE_HOURS`)
+// Hard freshness floor (default 96h, env override `NEWS_MAX_AGE_HOURS`)
 // applied in buildDigest before corroboration counting. Belt-and-suspenders
 // against feeds carrying valid-but-stale dates that would otherwise pass U2's
 // undated-drop gate. Tests the env-resolver helper directly; the in-flow
 // drop is exercised by parseRssXml + integration smoke (covered in PR-1
 // finalize via the existing smoke suite).
+//
+// Default bumped 48 → 96h on 2026-05-03 (PR #3577): see resolveMaxAgeMs()
+// header in list-feed-digest.ts for the weekend-empty-panel rationale.
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
@@ -30,7 +33,7 @@ function withEnv<T>(key: string, value: string | undefined, fn: () => T): T {
 describe('resolveMaxAgeMs — env override', () => {
   it('defaults to 48h when NEWS_MAX_AGE_HOURS is unset', () => {
     withEnv('NEWS_MAX_AGE_HOURS', undefined, () => {
-      assert.equal(resolveMaxAgeMs(), 48 * HOUR);
+      assert.equal(resolveMaxAgeMs(), 96 * HOUR);
     });
   });
 
@@ -42,25 +45,25 @@ describe('resolveMaxAgeMs — env override', () => {
 
   it('falls back to default for non-numeric values', () => {
     withEnv('NEWS_MAX_AGE_HOURS', 'foo', () => {
-      assert.equal(resolveMaxAgeMs(), 48 * HOUR);
+      assert.equal(resolveMaxAgeMs(), 96 * HOUR);
     });
   });
 
   it('falls back to default for empty string', () => {
     withEnv('NEWS_MAX_AGE_HOURS', '', () => {
-      assert.equal(resolveMaxAgeMs(), 48 * HOUR);
+      assert.equal(resolveMaxAgeMs(), 96 * HOUR);
     });
   });
 
   it('falls back to default for zero (out of range)', () => {
     withEnv('NEWS_MAX_AGE_HOURS', '0', () => {
-      assert.equal(resolveMaxAgeMs(), 48 * HOUR);
+      assert.equal(resolveMaxAgeMs(), 96 * HOUR);
     });
   });
 
   it('falls back to default for negative values', () => {
     withEnv('NEWS_MAX_AGE_HOURS', '-5', () => {
-      assert.equal(resolveMaxAgeMs(), 48 * HOUR);
+      assert.equal(resolveMaxAgeMs(), 96 * HOUR);
     });
   });
 
@@ -81,7 +84,7 @@ describe('freshness floor — boundary semantics', () => {
   // The freshness filter uses `publishedAt >= cutoff`. These boundary cases
   // document the inequality direction so a future refactor doesn't silently
   // flip the strictness.
-  it('48h boundary: cutoff = now - 48h, an item exactly at cutoff passes (>=)', () => {
+  it('default boundary: cutoff = now - 96h, an item exactly at cutoff passes (>=)', () => {
     withEnv('NEWS_MAX_AGE_HOURS', undefined, () => {
       const max = resolveMaxAgeMs();
       const cutoff = Date.now() - max;

--- a/tests/news-freshness-floor.test.mts
+++ b/tests/news-freshness-floor.test.mts
@@ -31,7 +31,7 @@ function withEnv<T>(key: string, value: string | undefined, fn: () => T): T {
 }
 
 describe('resolveMaxAgeMs — env override', () => {
-  it('defaults to 48h when NEWS_MAX_AGE_HOURS is unset', () => {
+  it('defaults to 96h when NEWS_MAX_AGE_HOURS is unset', () => {
     withEnv('NEWS_MAX_AGE_HOURS', undefined, () => {
       assert.equal(resolveMaxAgeMs(), 96 * HOUR);
     });


### PR DESCRIPTION
## Production diagnosis

Today is Sun 2026-05-03 ~05:30 UTC. The hard 48h freshness floor in \`resolveMaxAgeMs()\` drops every news-digest item published before ~Fri 2026-05-01 05:30 UTC. Audit of the failing-panel feeds (curl from local machine, real production data):

| Feed | Newest item | Age | 48h gate verdict |
|---|---|---|---|
| BBC Latin America | Thu 30 Apr 03:20 UTC | ~74h | **DROPPED** |
| Guardian Americas | Sun 03 May 05:31 | ~0h | fresh ✓ |
| Infobae | Sun 03 May 05:26 | ~0h | fresh ✓ |
| El Universo | Sun 03 May 05:08 | ~0h | fresh ✓ |
| Clarín | Sun 03 May 04:24 | ~1h | fresh ✓ |
| InSight Crime | Thu 30 Apr 20:38 | ~57h | **DROPPED** |
| **GitHub Blog** (only feed for \`github\` cat) | Thu 30 Apr 16:09 | ~61h | **DROPPED → category 0 items** |
| **Product Hunt** (only feed) | Sat 02 May 07:01 | ~46h | borderline |
| OilPrice | Sun 03 May 00:31 | ~5h | fresh ✓ |

## Why the panels are empty

Single-source category panels (\`github\`, \`producthunt\`) collapse the moment their one upstream goes >48h. github.blog and producthunt.com both publish on a weekday cadence — across a Sat-Sun window their newest item naturally drifts to 50-70h old. The 48h floor drops everything → category renders 0 items → panel reads UNAVAILABLE. Failure mode is **weekend-only**, masked Mon-Fri, which is why this only surfaced today (Sunday).

## Fix

Bump default 48h → 96h. Covers a Fri→Mon weekend with margin so weekend dashboard checks don't render empty. The 24h \`recencyScore\` component still naturally de-ranks 48-96h items vs anything fresher — visible-but-de-ranked is correct: better than "no news" but lower priority than today.

Operator override (\`NEWS_MAX_AGE_HOURS\` env var) is still honored; tightening back to 48h is a one-line env-var change without redeploy.

## Out of scope

**Latin America** has 4 of 7 fresh feeds (Guardian, Infobae, El Universo, Clarín), so the gate alone doesn't explain its 0-state — there's a second bug there (likely Vercel→upstream timeout, relay-fallback path failure, or cache poisoning). PR #3576 added per-feed observability that will pinpoint it once next-traffic logs land. Surgical follow-up after that.

## Test plan

- [x] \`npm run typecheck:api\` clean
- [ ] After deploy: GitHub Trending, Product Hunt panels render with 1+ items
- [ ] Latin America panel partially recovers (the 4 fresh feeds populate; the 3 stale ones — BBC, InSight Crime, Primicias — also pass under 96h)
- [ ] Within ~5 min (cache TTL_EMPTY for any poisoned categories), all panels stabilize