### PR TITLE
fix(user-prefs): bound Convex fetch below Vercel 25s wall-clock

### DIFF
--- a/api/_convex-error.js
+++ b/api/_convex-error.js
@@ -44,6 +44,14 @@ export function extractConvexErrorKind(err, msg) {
   // response with Retry-After so clients back off rather than treating
   // it as a permanent 500.
   if (msg.includes('"code":"ServiceUnavailable"')) return 'SERVICE_UNAVAILABLE';
+  // Client-side fetch timeout (AbortSignal.timeout fires) — Convex stalled
+  // long enough that we aborted before Vercel's 25s edge wall-clock could
+  // kill the function with a generic 500. Same remediation as the platform
+  // 503 (back off + retry), so reuse SERVICE_UNAVAILABLE. Sentry's
+  // `error_shape` classifier still discriminates these two cases via msg
+  // pattern (`transport_timeout` vs `convex_service_unavailable`).
+  const errName = /** @type {{ name?: string } | null | undefined} */ (err)?.name;
+  if (errName === 'TimeoutError' || errName === 'AbortError') return 'SERVICE_UNAVAILABLE';
   if (msg.includes('CONFLICT')) return 'CONFLICT';
   if (msg.includes('BLOB_TOO_LARGE')) return 'BLOB_TOO_LARGE';
   if (msg.includes('UNAUTHENTICATED')) return 'UNAUTHENTICATED';

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -55,7 +55,18 @@ export default async function handler(
     return jsonResponse({ error: 'Service unavailable' }, 503, cors);
   }
 
-  const client = new ConvexHttpClient(convexUrl);
+  // Bound the Convex round-trip below Vercel's 25s edge wall-clock so a
+  // stalled platform aborts cleanly into the SERVICE_UNAVAILABLE → 503 +
+  // Retry-After path instead of getting killed by Vercel with a generic
+  // 500 ("function did not return an initial response within 25s"), which
+  // bypasses our typed error plumbing entirely. 20s leaves headroom for
+  // the JWKS verify above + response packaging below. Injected via the
+  // public `fetch` constructor option (the `setFetchOptions` instance
+  // method is marked `@internal` in convex's d.ts and not safe to depend on).
+  const client = new ConvexHttpClient(convexUrl, {
+    fetch: (input, init) =>
+      fetch(input, { ...init, signal: init?.signal ?? AbortSignal.timeout(20_000) }),
+  });
   client.setAuth(token);
 
   if (req.method === 'GET') {


### PR DESCRIPTION
## Summary

- `ConvexHttpClient` has no default fetch timeout — when Convex stalls silently, fetch hangs until Vercel kills the edge function at 25s with a generic 500 (`"did not return an initial response within 25s"`), bypassing PR #3479's typed `SERVICE_UNAVAILABLE → 503 + Retry-After` plumbing because there's no error to classify.
- Inject `AbortSignal.timeout(20_000)` via the **public `fetch` constructor option**. The `setFetchOptions` instance method is `@internal` in convex's `.d.ts` (`tsc` rejects it) and is not safe to depend on.
- Map `TimeoutError` / `AbortError` to the existing `SERVICE_UNAVAILABLE` kind in `extractConvexErrorKind`. Sentry's `error_shape` regex (`transport_timeout` vs `convex_service_unavailable`) keeps the two cases in distinct fingerprints despite sharing the response code.
- 20s leaves ~5s headroom under Vercel's 25s budget for JWKS verify + response packaging + Sentry capture.

## Trigger

`2026-05-03 05:08:51 Error: Your function was stopped as it did not return an initial response within 25s — /api/user-prefs` with **zero** corresponding `convex_service_unavailable` Sentry events in window — proves upstream was hanging silent, not 503-ing.

## Test plan

- [x] `npm run typecheck:api` PASS
- [x] `npm run typecheck` PASS
- [x] `npm run lint` (no new findings; pre-existing complexity warning unchanged)
- [x] `npm run test:data` PASS
- [x] `node --test tests/edge-functions.test.mjs` PASS (182/182)
- [x] `tsx --test tests/user-prefs-sentry-context.test.mts` PASS (12/12)
- [x] `node --test tests/user-prefs-convex-error.test.mjs tests/cloud-prefs-retry-after.test.mjs` PASS
- [x] `npm run lint:md` PASS
- [x] `npm run version:check` PASS
- [x] esbuild bundle check across `api/*.js` PASS

## Follow-up (separate PR)

Sweep other `ConvexHttpClient` constructions for the same gap:

```
grep -rln "new ConvexHttpClient" api/ server/
```

Currently `server/worldmonitor/leads/v1/register-interest.ts` and `submit-contact.ts` lack timeouts. Lower urgency (lead-form path, not real-time sync) but same shape.