### PR TITLE
fix(gateway): detect both 'unavailable' and 'upstreamUnavailable' fallbacks for no-cache (P0)

### DIFF
--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -681,8 +681,26 @@ export function createDomainGateway(
 
       // Skip CDN caching for upstream-unavailable / empty responses so CF
       // doesn't serve stale error data for hours.
+      //
+      // Two field names are in active use across the RPC handlers because the
+      // codebase grew two fallback conventions in parallel:
+      //   - `upstreamUnavailable: true` — used by consumer-prices/intelligence/
+      //     trade handlers that return ad-hoc JSON shapes.
+      //   - `unavailable: true` — proto-typed handlers (every economic RPC
+      //     including get-macro-signals — `bool unavailable = N` in the proto).
+      // The original check only matched the first form, so proto-typed
+      // fallback responses were getting full `medium` cache tier (CF s-maxage
+      // 1200s, browser max-age 1800s). Production incident 2026-05-03: a
+      // 30-min window of auth bug (PR #3541's wm-session interceptor) caused
+      // every macroSignals RPC to return the fallback. Those responses got
+      // cached for 30 min. Even after auth was fixed (PR #3574), browsers
+      // and CF POPs kept serving "Upstream API unavailable" until the cache
+      // TTL expired naturally — 30 min of false-bad UX per affected user.
+      // Detecting both field names closes that window.
       const bodyStr = new TextDecoder().decode(bodyBytes);
-      const isUpstreamUnavailable = bodyStr.includes('"upstreamUnavailable":true');
+      const isUpstreamUnavailable =
+        bodyStr.includes('"upstreamUnavailable":true') ||
+        bodyStr.includes('"unavailable":true');
 
       if (mergedHeaders.get('X-No-Cache') || isUpstreamUnavailable) {
         mergedHeaders.set('Cache-Control', 'no-store');


### PR DESCRIPTION
## Production incident: 2026-05-03

Macro Stress panel renders \"Upstream API unavailable\" despite:
- Seeder writing every 15 min (\`Macro signals: 7 active, verdict=BUY\` in seed-economy log)
- Redis cache containing correct data (\`unavailable: false, totalCount: 7\`, all 7 signals populated)
- Production RPC returning correct data when curled directly (verified)
- \`/api/health\` reporting \`macroSignals: OK, records=7, seedAgeMin=12\`

Yet the user's browser shows the fallback. Why? **Cloudflare and the browser are serving a cached \`unavailable: true\` response from earlier today** when the wm-session interceptor bug (#3541) caused every macroSignals call to fail auth → fallback returned → cached as \"good\" by the gateway.

## Root cause

\`server/gateway.ts:685\` (pre-fix):

\`\`\`ts
const isUpstreamUnavailable = bodyStr.includes('\"upstreamUnavailable\":true');
\`\`\`

Two fallback conventions exist:

| Field name | Used by |
|---|---|
| \`upstreamUnavailable: true\` | ad-hoc JSON shapes (consumer-prices, intelligence, trade) |
| \`unavailable: true\` | proto-typed handlers (every economic RPC — \`bool unavailable = N\`) |

The detection only matched the first. Proto-typed fallback responses got the full \`medium\` cache tier:
- \`Cache-Control: public, max-age=1800\` → browser caches 30 min
- \`s-maxage=600\` → CF caches 10 min
- \`CDN-Cache-Control: s-maxage=1200\` → Vercel CDN caches 20 min

So the ~30-minute auth-bug window got memorialized as ~30 minutes of cached-bad responses. Auth fix deployed, but the cache layers kept serving stale until TTL expiry.

## Fix

One-line change: detect both field-name conventions.

\`\`\`ts
const isUpstreamUnavailable =
  bodyStr.includes('\"upstreamUnavailable\":true') ||
  bodyStr.includes('\"unavailable\":true');
\`\`\`

Healthy responses (\`unavailable: false\`) are unaffected. Only fallback responses (which should never be cached anyway) get \`Cache-Control: no-store\`.

## Affected RPCs

Every proto-typed handler returning a fallback when upstream is unavailable. Confirmed via \`grep 'bool unavailable' proto/worldmonitor/**/*.proto\`:

- get-macro-signals (the panel that surfaced the bug)
- get-ecb-fx-rates, get-economic-calendar, get-eu-yield-curve
- get-eu-fsi, get-eu-gas-storage, get-economic-stress
- get-eurostat-country-data, get-energy-crisis-policies
- get-oil-stocks-analysis
- ...and any other proto with \`bool unavailable = N\`

## Operator follow-up after merge

To unstick currently-cached bad responses without waiting up to 30 min for natural expiry:

\`\`\`
Cloudflare → Caching → Purge → Custom: api.worldmonitor.app/api/economic/v1/*
\`\`\`

(Or 'Purge Everything' if the dashboard supports it.)

## Test plan

- [x] \`npm run typecheck:api\` clean
- [ ] After deploy + CF purge: Macro Stress panel populates within seconds
- [ ] After deploy: any other panel that was rendering \"Upstream API unavailable\" stuck-state recovers