### PR TITLE
fix(resilience-energy-v2): lower WB validate threshold 150 to 100

### DIFF
--- a/scripts/seed-fossil-electricity-share.mjs
+++ b/scripts/seed-fossil-electricity-share.mjs
@@ -70,7 +70,10 @@ async function fetchFossilElectricityShare() {
 }
 
 function validate(data) {
-  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 150;
+  // 150 → 100 on 2026-05-03 — see seed-power-reliability.mjs for rationale.
+  // Same WB late-reporter variation affects this indicator (EG.ELC.FOSL.ZS);
+  // canonical cache holds 209 countries.
+  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 100;
 }
 
 export function declareRecords(data) {

--- a/scripts/seed-low-carbon-generation.mjs
+++ b/scripts/seed-low-carbon-generation.mjs
@@ -113,7 +113,10 @@ async function fetchLowCarbonGeneration() {
 }
 
 function validate(data) {
-  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 150;
+  // 150 → 100 on 2026-05-03 — see seed-power-reliability.mjs for rationale.
+  // Same WB late-reporter variation affects this indicator;
+  // canonical cache holds 208 countries.
+  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 100;
 }
 
 export function declareRecords(data) {

--- a/scripts/seed-power-reliability.mjs
+++ b/scripts/seed-power-reliability.mjs
@@ -68,8 +68,17 @@ async function fetchPowerLosses() {
   return { countries, seededAt: new Date().toISOString() };
 }
 
+// Threshold lowered 150 → 100 on 2026-05-03: prior threshold sat at ~70%
+// of typical coverage (canonical key carries ~216 countries), so a normal
+// WB late-reporter blip that drops the fetch to 149 wholesale-rejected
+// the run. validateFn=false → atomicPublish skipped → seed-meta refreshed
+// with recordCount=0 (per the "quiet-period feeds" branch in runSeed) →
+// /api/health reports EMPTY_DATA even though the canonical key still
+// holds last-good 216-country data. 100 keeps a meaningful coverage
+// signal (anything below is a real upstream regression) while tolerating
+// the day-to-day WB variation in late-publishing economies.
 function validate(data) {
-  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 150;
+  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 100;
 }
 
 export function declareRecords(data) {


### PR DESCRIPTION
Production today: /api/health reports `powerLosses: status=EMPTY_DATA, records=0, seedAgeMin=138`. Canonical key holds 216 countries from a prior good run.

Root cause: 3 WB-driven seeders (power-reliability, fossil-electricity-share, low-carbon-generation) had validateFn requiring >=150 countries. Today's fetch from Railway IP got fewer (residential probe got 153 — right at edge). Validate fail -> atomicPublish skipped -> runSeed wrote seed-meta with recordCount 0 (the "quiet period" branch, intended for sparse news/events not annual WB indicators). Health reads seed-meta -> EMPTY_DATA. Consumers reading canonical key are unaffected.

Fix: lower threshold to >=100 in all 3. Anything below 100 is a real upstream regression; 100 absorbs WB late-reporter variation (KW/QA/AE publish 1-2y behind G7).

Recovery: next 06:00 UTC bundle tick. Manual Railway trigger gives instant.

Test plan:
- node -c on all 3 files
- After deploy + bundle: /api/health.powerLosses == OK
