### PR TITLE
fix(seed-utils): runSeed mirrors canonical envelope into seed-meta on validate-fail

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -262,11 +262,15 @@ export async function atomicPublish(canonicalKey, data, validateFn, ttlSeconds, 
   return { payloadBytes, recordCount: Array.isArray(data) ? data.length : null };
 }
 
-export async function writeFreshnessMetadata(domain, resource, count, source, ttlSeconds) {
+export async function writeFreshnessMetadata(domain, resource, count, source, ttlSeconds, fetchedAtOverride) {
   const { url, token } = getRedisCredentials();
   const metaKey = `seed-meta:${domain}:${resource}`;
   const meta = {
-    fetchedAt: Date.now(),
+    // Default to now; callers that want to mirror an existing canonical
+    // envelope (validate-fail branch in runSeed) pass the canonical's
+    // original fetchedAt so health doesn't lie about freshness — see
+    // readCanonicalEnvelopeMeta() and the skipped-validate path below.
+    fetchedAt: typeof fetchedAtOverride === 'number' ? fetchedAtOverride : Date.now(),
     recordCount: count,
     sourceVersion: source || '',
   };
@@ -275,6 +279,47 @@ export async function writeFreshnessMetadata(domain, resource, count, source, tt
   const metaTtl = Math.max(86400 * 7, ttlSeconds || 0);
   await redisSet(url, token, metaKey, meta, metaTtl);
   return meta;
+}
+
+/**
+ * Read the canonical key's contract-mode envelope meta. Used by runSeed's
+ * validate-fail branch to mirror canonical state into seed-meta instead
+ * of overwriting it with recordCount=0 (which makes /api/health report
+ * EMPTY_DATA when the canonical key still holds last-good data — see
+ * PR #3581 for the production incident).
+ *
+ * Returns the {fetchedAt, recordCount, sourceVersion} block when canonicalKey
+ * is contract-mode (envelope dual-write) AND has a valid recordCount > 0.
+ * Returns null for legacy (bare-shape) keys, missing keys, parse errors,
+ * or zero envelopes — caller falls back to its existing default behavior.
+ *
+ * Defensive: any read/parse error → null. No throws bubble up.
+ */
+export async function readCanonicalEnvelopeMeta(canonicalKey) {
+  try {
+    const { url, token } = getRedisCredentials();
+    const resp = await fetch(`${url}/get/${encodeURIComponent(canonicalKey)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!resp.ok) return null;
+    const data = await resp.json();
+    if (!data || !data.result) return null;
+    let parsed;
+    try { parsed = JSON.parse(data.result); } catch { return null; }
+    if (!parsed || typeof parsed !== 'object') return null;
+    const seed = parsed._seed;
+    if (!seed || typeof seed !== 'object') return null;
+    if (typeof seed.fetchedAt !== 'number' || typeof seed.recordCount !== 'number') return null;
+    if (seed.recordCount <= 0) return null;
+    return {
+      fetchedAt: seed.fetchedAt,
+      recordCount: seed.recordCount,
+      sourceVersion: typeof seed.sourceVersion === 'string' ? seed.sourceVersion : '',
+    };
+  } catch {
+    return null;
+  }
 }
 
 export async function withRetry(fn, maxRetries = 3, delayMs = 1000) {
@@ -1058,8 +1103,42 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
         // Write seed-meta even when data is empty so health can distinguish
         // "seeder ran but nothing to publish" from "seeder stopped" (quiet-
         // period feeds: news, events, sparse indicators).
-        await writeFreshnessMetadata(domain, resource, 0, opts.sourceVersion, ttlSeconds);
-        console.log(`  SKIPPED: validation failed (empty data) — seed-meta refreshed, existing cache TTL extended`);
+        //
+        // BUT — when the canonical key still holds last-good contract-mode
+        // data with recordCount > 0, mirror its (fetchedAt, recordCount)
+        // into seed-meta instead of writing zero. This keeps /api/health
+        // reporting an accurate count when validateFn rejects a transient
+        // upstream blip (e.g. WB late-reporter variation that drops a
+        // resilience indicator from 153 → 149 countries when the floor was
+        // 150 — production incident 2026-05-03 for resilience:power-losses
+        // where canonical had 216 countries but seed-meta got overwritten
+        // with 0 → EMPTY_DATA). The mirrored fetchedAt is canonical's
+        // ORIGINAL fetch time, NOT now, so STALE_SEED still fires naturally
+        // once the canonical data ages past maxStaleMin — preserving the
+        // strict-floor honesty WITHOUT punishing a transient blip with a
+        // misleading zero.
+        //
+        // Falls back to writing 0 (legacy quiet-period behavior) when:
+        //   - canonical key is missing
+        //   - canonical envelope is malformed / legacy bare shape
+        //   - canonical envelope has recordCount <= 0
+        const canonicalMeta = await readCanonicalEnvelopeMeta(canonicalKey);
+        if (canonicalMeta) {
+          await writeFreshnessMetadata(
+            domain, resource, canonicalMeta.recordCount,
+            canonicalMeta.sourceVersion || opts.sourceVersion,
+            ttlSeconds,
+            canonicalMeta.fetchedAt,
+          );
+          console.log(
+            `  SKIPPED: validation failed (empty/partial fetch) — seed-meta mirrors canonical ` +
+            `(fetchedAt=${new Date(canonicalMeta.fetchedAt).toISOString()}, recordCount=${canonicalMeta.recordCount}); ` +
+            `existing cache TTL extended`,
+          );
+        } else {
+          await writeFreshnessMetadata(domain, resource, 0, opts.sourceVersion, ttlSeconds);
+          console.log(`  SKIPPED: validation failed (empty data) — seed-meta refreshed (recordCount=0), existing cache TTL extended`);
+        }
       }
       console.log(`\n=== Done (${Math.round(durationMs)}ms, no write) ===`);
       await releaseLock(`${domain}:${resource}`, runId);

--- a/tests/seed-utils-empty-data-failure.test.mjs
+++ b/tests/seed-utils-empty-data-failure.test.mjs
@@ -99,3 +99,99 @@ test('validation failure WITHOUT emptyDataIsFailure DOES refresh seed-meta (quie
     'seed-meta count=0 so health does not false-positive STALE_SEED',
   );
 });
+
+// PR #3582: When validateFn rejects a transient blip but canonical key still
+// holds a contract-mode envelope with recordCount > 0, seed-meta should mirror
+// the canonical's (fetchedAt, recordCount) rather than overwrite with zero.
+// Production motivation: resilience:power-losses 2026-05-03 — canonical had
+// 216 countries but a partial WB fetch (149 < 150 floor) caused validateFn
+// to reject; runSeed wrote recordCount=0 to seed-meta; /api/health flipped
+// EMPTY_DATA even though the canonical data was fine. The mirror behavior
+// keeps health honest while preserving STALE_SEED honesty (mirrored
+// fetchedAt is the canonical's ORIGINAL value, not now).
+function withCanonicalEnvelope({ canonicalKey, fetchedAt, recordCount, sourceVersion = 'test-v1' }) {
+  const envelope = {
+    _seed: {
+      fetchedAt,
+      recordCount,
+      sourceVersion,
+      schemaVersion: 1,
+      state: 'OK',
+    },
+    data: { items: Array.from({ length: recordCount }, (_, i) => ({ id: i })) },
+  };
+  return async (url, opts = {}) => {
+    const u = String(url);
+    const body = opts?.body ? (() => { try { return JSON.parse(opts.body); } catch { return opts.body; } })() : null;
+    recordedCalls.push({ url: u, method: opts?.method || 'GET', body });
+    // Match GET on the canonical key — return the envelope wrapped in {result}.
+    if (u.includes(`/get/${encodeURIComponent(canonicalKey)}`) || u.endsWith(`/get/${canonicalKey}`)) {
+      return new Response(JSON.stringify({ result: JSON.stringify(envelope) }), { status: 200 });
+    }
+    if (Array.isArray(body) && Array.isArray(body[0])) {
+      return new Response(JSON.stringify(body.map(() => ({ result: 0 }))), { status: 200 });
+    }
+    return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+  };
+}
+
+function lastMetaSetBody(resourceSuffix) {
+  const setCalls = recordedCalls.filter(c =>
+    Array.isArray(c.body)
+    && c.body[0] === 'SET'
+    && typeof c.body[1] === 'string'
+    && c.body[1] === `seed-meta:test:${resourceSuffix}`,
+  );
+  if (setCalls.length === 0) return null;
+  const last = setCalls[setCalls.length - 1];
+  // Body shape is ['SET', metaKey, JSON.stringify(meta), 'EX', ttl]
+  try { return JSON.parse(last.body[2]); } catch { return null; }
+}
+
+test('PR #3582: validation failure with non-empty canonical envelope MIRRORS its (fetchedAt, recordCount)', async () => {
+  const FROZEN_FETCHED_AT = 1700000000000; // arbitrary fixed past timestamp
+  const RECORD_COUNT = 216;
+  globalThis.fetch = withCanonicalEnvelope({
+    canonicalKey: 'test:partial-fetch:v1',
+    fetchedAt: FROZEN_FETCHED_AT,
+    recordCount: RECORD_COUNT,
+    sourceVersion: 'wb-power-losses-2026',
+  });
+
+  await runWithExitTrap(() =>
+    runSeed('test', 'partial-fetch', 'test:partial-fetch:v1', async () => ({ items: [] }), {
+      validateFn: (d) => d?.items?.length >= 10, // rejects (transient blip)
+      ttlSeconds: 3600,
+    }),
+  );
+
+  const meta = lastMetaSetBody('partial-fetch');
+  assert.ok(meta, 'seed-meta must be written (legacy quiet-period path) when canonical envelope exists');
+  assert.equal(
+    meta.recordCount, RECORD_COUNT,
+    `seed-meta.recordCount must MIRROR canonical (${RECORD_COUNT}), not be overwritten with 0 — ` +
+    'health-reported count should track last-good data, not the failed transient fetch',
+  );
+  assert.equal(
+    meta.fetchedAt, FROZEN_FETCHED_AT,
+    'seed-meta.fetchedAt must MIRROR canonical original fetchedAt (not Date.now()) — ' +
+    'STALE_SEED must still fire naturally when canonical truly ages past maxStaleMin',
+  );
+});
+
+test('PR #3582: validation failure with MISSING canonical falls back to recordCount=0 (legacy)', async () => {
+  // Default fetch mock returns {result: 'OK'} on GET, which fails JSON.parse
+  // inside readCanonicalEnvelopeMeta — so the helper returns null and runSeed
+  // falls through to the original quiet-period behavior. This proves the
+  // mirror logic is non-disruptive for legacy bare-shape / missing-key seeders.
+  await runWithExitTrap(() =>
+    runSeed('test', 'no-canonical', 'test:no-canonical:v1', async () => ({ items: [] }), {
+      validateFn: (d) => d?.items?.length >= 10,
+      ttlSeconds: 3600,
+    }),
+  );
+
+  const meta = lastMetaSetBody('no-canonical');
+  assert.ok(meta, 'seed-meta must still be written when no canonical envelope to mirror');
+  assert.equal(meta.recordCount, 0, 'falls back to recordCount=0 when canonical envelope is missing/malformed');
+});

--- a/tests/seed-utils-empty-data-failure.test.mjs
+++ b/tests/seed-utils-empty-data-failure.test.mjs
@@ -166,7 +166,7 @@ test('PR #3582: validation failure with non-empty canonical envelope MIRRORS its
   );
 
   const meta = lastMetaSetBody('partial-fetch');
-  assert.ok(meta, 'seed-meta must be written (legacy quiet-period path) when canonical envelope exists');
+  assert.ok(meta, 'seed-meta must be written (mirror path) when a valid canonical envelope exists');
   assert.equal(
     meta.recordCount, RECORD_COUNT,
     `seed-meta.recordCount must MIRROR canonical (${RECORD_COUNT}), not be overwritten with 0 — ` +


### PR DESCRIPTION
Follow-up to #3581. The architectural fix that PR #3581 hinted at.

## Problem

In `runSeed`, when `validateFn` rejects (no `emptyDataIsFailure`), the default branch wrote `seed-meta:<resource>` with `recordCount: 0` and `fetchedAt: Date.now()`. This made `/api/health` report **EMPTY_DATA** even when the canonical key still held last-good data with a fresh TTL.

Example from #3581: `resilience:power-losses:v1` had 216 countries cached (35-day TTL), but a transient WB late-reporter blip dropped today's fetch to <150 → validateFn rejected → seed-meta got recordCount=0 → /api/health showed EMPTY_DATA. Consumers reading the canonical key directly were unaffected; only the alarm was wrong.

The legacy "write 0" behavior was intentional for quiet-period feeds (news, events, sparse indicators) where empty-fetch IS the genuine state. But it was incorrect for steady-state indicators where transient fetch failures shouldn't poison health metadata.

## Fix

In the `publishResult.skipped && !emptyDataIsFailure` branch:
1. Probe canonical key for a contract-mode envelope (`_seed.recordCount > 0`).
2. If found, MIRROR its `(fetchedAt, recordCount, sourceVersion)` into seed-meta.
3. Otherwise, fall back to the existing `recordCount: 0` write (preserves quiet-period behavior).

Critical detail: the mirrored `fetchedAt` is the canonical's **original** fetch time, NOT now. So STALE_SEED still fires naturally once canonical truly ages past `maxStaleMin`. We're not masking real upstream outages — only avoiding false-positive EMPTY_DATA on transient blips.

## Backward compatibility

| Seeder type | Behavior |
|---|---|
| `emptyDataIsFailure: true` | unchanged (still no seed-meta write) |
| Quiet-period, no canonical | unchanged (writes recordCount=0) |
| Contract-mode, last-good canonical | NEW: mirrors envelope, health stays accurate |
| Legacy bare-shape canonical | unchanged (no envelope to mirror, falls back to 0) |

## API additions

- `readCanonicalEnvelopeMeta(canonicalKey)` exported from `_seed-utils.mjs`. Defensive: returns null on any read/parse error.
- `writeFreshnessMetadata` extended with optional `fetchedAtOverride` param. Existing callers pass nothing → behavior unchanged.

## Test plan

- [x] 4/4 tests pass in `tests/seed-utils-empty-data-failure.test.mjs`:
  - emptyDataIsFailure:true → no seed-meta write (existing)
  - empty canonical, no envelope → recordCount=0 (legacy quiet-period, existing)
  - non-empty canonical envelope → MIRRORS recordCount + fetchedAt (NEW)
  - missing canonical → falls back to 0 (NEW, anti-regression)
- [ ] After deploy + next bundle tick: verify /api/health.powerLosses reports accurate count even on validateFn-fail runs (combined with the threshold lower in #3581, this should rarely fire — but when it does, health stays honest)
