### PR TITLE
fix(tech-readiness): empty payload no longer renders as red error; add backoff retry

### DIFF
--- a/src/components/TechReadinessPanel.ts
+++ b/src/components/TechReadinessPanel.ts
@@ -50,13 +50,15 @@ export class TechReadinessPanel extends Panel {
       showCount: true,
       infoTooltip: t('components.techReadiness.infoTooltip'),
     });
+    this.hideCountBadge();
   }
 
-  public async refresh(): Promise<void> {
+  public async refresh(isRetry = false): Promise<void> {
     if (this.loading) return;
     if (Date.now() - this.lastFetch < this.REFRESH_INTERVAL && this.rankings.length > 0) {
       return;
     }
+    if (!isRetry) this.localRetryAttempt = 0;
 
     this.loading = true;
     this.clearRetryTimer();
@@ -66,7 +68,6 @@ export class TechReadinessPanel extends Panel {
       const result = await getTechReadinessRankings();
       if (!this.element?.isConnected) return;
       this.rankings = result;
-      this.setCount(result.length);
       if (result.length === 0) {
         // Server returned an empty payload (NOT a network failure — those
         // throw and land in the catch branch). Show a soft "refreshing"
@@ -96,7 +97,7 @@ export class TechReadinessPanel extends Panel {
       }
       this.showError(
         t('common.failedTechReadiness'),
-        () => void this.refresh(),
+        () => void this.refresh(true),
         Math.round(delayMs / 1000),
       );
     } finally {
@@ -116,6 +117,15 @@ export class TechReadinessPanel extends Panel {
     }
   }
 
+  private hideCountBadge(): void {
+    if (this.countEl) this.countEl.style.display = 'none';
+  }
+
+  private showCountBadge(count: number): void {
+    this.setCount(count);
+    if (this.countEl) this.countEl.style.display = '';
+  }
+
   /**
    * Returns the next backoff delay in ms, or null when MAX_RETRY_ATTEMPTS
    * is reached. Increments the counter as a side effect.
@@ -132,7 +142,7 @@ export class TechReadinessPanel extends Panel {
     if (delay === null) return;
     this.retryTimer = setTimeout(() => {
       this.retryTimer = null;
-      void this.refresh();
+      void this.refresh(true);
     }, delay);
   }
 
@@ -147,6 +157,7 @@ export class TechReadinessPanel extends Panel {
    * to keep the red header for the terminal error.
    */
   private renderTerminalError(): void {
+    this.hideCountBadge();
     this.setContent(`
       <div class="panel-error-state" style="padding:24px 16px;text-align:center">
         <div class="panel-error-msg" style="color:var(--danger,#e0654b);font-size:13px">
@@ -161,6 +172,7 @@ export class TechReadinessPanel extends Panel {
     // Soft empty state — distinct from showError() so the panel header
     // doesn't paint red on a benign empty payload. Caller schedules an
     // auto-retry; this is just the visual placeholder while we wait.
+    this.hideCountBadge();
     this.setContent(`
       <div class="panel-soft-empty" style="padding:24px 16px;color:var(--text-dim);font-size:12px;text-align:center;line-height:1.5">
         <div style="font-size:20px;margin-bottom:8px">⌛</div>
@@ -226,6 +238,7 @@ export class TechReadinessPanel extends Panel {
     // showError() flipped the panel into red error styling and gave the
     // user no recovery path on a benign empty payload.
     const top = this.rankings.slice(0, 25);
+    this.showCountBadge(this.rankings.length);
 
     const html = `
       <div class="tech-readiness-list">

--- a/src/components/TechReadinessPanel.ts
+++ b/src/components/TechReadinessPanel.ts
@@ -23,6 +23,15 @@ export class TechReadinessPanel extends Panel {
   private loading = false;
   private lastFetch = 0;
   private readonly REFRESH_INTERVAL = 6 * 60 * 60 * 1000; // 6 hours
+  /**
+   * Backoff timer for retrying after an empty/failed fetch. Without this,
+   * a single transient blip (slow-tier bootstrap abort + lazy-fetch fail)
+   * left the panel stuck in an empty/error state until the user restarted
+   * the app — refresh() is only fired at startup.
+   */
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private emptyRetryAttempt = 0;
+  private readonly MAX_RETRY_ATTEMPTS = 5;
 
   constructor() {
     super({
@@ -40,21 +49,77 @@ export class TechReadinessPanel extends Panel {
     }
 
     this.loading = true;
+    this.clearRetryTimer();
     this.showFetchingState();
 
     try {
-      this.rankings = await getTechReadinessRankings();
+      const result = await getTechReadinessRankings();
       if (!this.element?.isConnected) return;
+      this.rankings = result;
+      this.setCount(result.length);
+      if (result.length === 0) {
+        // Server returned an empty payload (NOT a network failure — those
+        // throw and land in the catch branch). Show a soft "refreshing"
+        // state and retry on backoff in case the seed-meta is briefly out
+        // of step with the underlying data key, instead of painting the
+        // panel red as a hard error. Don't stamp lastFetch — we want
+        // explicit retries, not a 6h cooldown on no data.
+        this.showSoftRefreshing();
+        this.scheduleRetry();
+        return;
+      }
       this.lastFetch = Date.now();
-      this.setCount(this.rankings.length);
+      this.emptyRetryAttempt = 0;
       this.render();
     } catch (error) {
       if (!this.element?.isConnected) return;
       console.error('[TechReadinessPanel] Error fetching data:', error);
-      this.showError(t('common.failedTechReadiness'));
+      // Pass an onRetry callback so Panel.showError renders an auto-retry
+      // countdown with exponential backoff (15s, 30s, 60s, ...). Previously
+      // the error state had no retry path at all — once it failed, the user
+      // had to restart the app to recover.
+      this.showError(t('common.failedTechReadiness'), () => void this.refresh());
     } finally {
       this.loading = false;
     }
+  }
+
+  override destroy(): void {
+    this.clearRetryTimer();
+    super.destroy();
+  }
+
+  private clearRetryTimer(): void {
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
+  }
+
+  private scheduleRetry(): void {
+    if (this.emptyRetryAttempt >= this.MAX_RETRY_ATTEMPTS) return;
+    // 30s → 60s → 2m → 4m → 5m (capped). Bounded so we don't hammer an
+    // upstream that's genuinely down, but quick enough that a user who
+    // tripped over a transient blip recovers without restarting the app.
+    const delays = [30_000, 60_000, 120_000, 240_000, 300_000];
+    const delay = delays[this.emptyRetryAttempt] ?? 300_000;
+    this.emptyRetryAttempt += 1;
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      void this.refresh();
+    }, delay);
+  }
+
+  private showSoftRefreshing(): void {
+    // Soft empty state — distinct from showError() so the panel header
+    // doesn't paint red on a benign empty payload. Caller schedules an
+    // auto-retry; this is just the visual placeholder while we wait.
+    this.setContent(`
+      <div class="panel-soft-empty" style="padding:24px 16px;color:var(--text-dim);font-size:12px;text-align:center;line-height:1.5">
+        <div style="font-size:20px;margin-bottom:8px">⌛</div>
+        <div>${escapeHtml(t('components.techReadiness.dataPreparing'))}</div>
+      </div>
+    `);
   }
 
   private showFetchingState(): void {
@@ -108,12 +173,11 @@ export class TechReadinessPanel extends Panel {
   }
 
   private render(): void {
-    if (this.rankings.length === 0) {
-      this.showError(t('common.noDataAvailable'));
-      return;
-    }
-
-    // Show top 25 countries
+    // Empty-result branch was removed: refresh() now routes empty payloads
+    // through showSoftRefreshing() + scheduleRetry() and only calls render()
+    // when there's data to show. Painting "no data available" via
+    // showError() flipped the panel into red error styling and gave the
+    // user no recovery path on a benign empty payload.
     const top = this.rankings.slice(0, 25);
 
     const html = `

--- a/src/components/TechReadinessPanel.ts
+++ b/src/components/TechReadinessPanel.ts
@@ -24,14 +24,24 @@ export class TechReadinessPanel extends Panel {
   private lastFetch = 0;
   private readonly REFRESH_INTERVAL = 6 * 60 * 60 * 1000; // 6 hours
   /**
-   * Backoff timer for retrying after an empty/failed fetch. Without this,
-   * a single transient blip (slow-tier bootstrap abort + lazy-fetch fail)
-   * left the panel stuck in an empty/error state until the user restarted
-   * the app — refresh() is only fired at startup.
+   * Local backoff state for retrying after an empty/failed fetch. Without
+   * this, a single transient blip (slow-tier bootstrap abort + lazy-fetch
+   * fail) left the panel stuck in an empty/error state until the user
+   * restarted the app — refresh() is only fired at startup.
+   *
+   * Crucially, this counter MUST be local. Panel's own retryAttempt is
+   * reset to 0 by every call to setContent() (e.g. via showFetchingState
+   * at the top of refresh()), so relying on Panel.showError's default
+   * `Math.min(15 * 2 ** retryAttempt, 180)` gave a flat 15s loop that
+   * hammered the upstream every cycle during a persistent outage.
    */
   private retryTimer: ReturnType<typeof setTimeout> | null = null;
-  private emptyRetryAttempt = 0;
+  private localRetryAttempt = 0;
   private readonly MAX_RETRY_ATTEMPTS = 5;
+  /** 30s → 60s → 2m → 4m → 5m (capped). Same delays for empty-payload
+   *  and error retries — both indicate "try again later," and we want
+   *  the same upstream-friendly cadence in either case. */
+  private readonly RETRY_DELAYS_MS: ReadonlyArray<number> = [30_000, 60_000, 120_000, 240_000, 300_000];
 
   constructor() {
     super({
@@ -69,16 +79,26 @@ export class TechReadinessPanel extends Panel {
         return;
       }
       this.lastFetch = Date.now();
-      this.emptyRetryAttempt = 0;
+      this.localRetryAttempt = 0;
       this.render();
     } catch (error) {
       if (!this.element?.isConnected) return;
       console.error('[TechReadinessPanel] Error fetching data:', error);
-      // Pass an onRetry callback so Panel.showError renders an auto-retry
-      // countdown with exponential backoff (15s, 30s, 60s, ...). Previously
-      // the error state had no retry path at all — once it failed, the user
-      // had to restart the app to recover.
-      this.showError(t('common.failedTechReadiness'), () => void this.refresh());
+      // Compute the backoff delay LOCALLY rather than letting Panel.showError
+      // fall back to its retryAttempt-based formula — that counter is
+      // reset by every showFetchingState() call at the top of refresh(),
+      // so the default flow gave a flat 15s retry loop that hammered the
+      // upstream every cycle.
+      const delayMs = this.nextRetryDelayMs();
+      if (delayMs === null) {
+        this.renderTerminalError();
+        return;
+      }
+      this.showError(
+        t('common.failedTechReadiness'),
+        () => void this.refresh(),
+        Math.round(delayMs / 1000),
+      );
     } finally {
       this.loading = false;
     }
@@ -96,18 +116,45 @@ export class TechReadinessPanel extends Panel {
     }
   }
 
+  /**
+   * Returns the next backoff delay in ms, or null when MAX_RETRY_ATTEMPTS
+   * is reached. Increments the counter as a side effect.
+   */
+  private nextRetryDelayMs(): number | null {
+    if (this.localRetryAttempt >= this.MAX_RETRY_ATTEMPTS) return null;
+    const delay = this.RETRY_DELAYS_MS[this.localRetryAttempt] ?? 300_000;
+    this.localRetryAttempt += 1;
+    return delay;
+  }
+
   private scheduleRetry(): void {
-    if (this.emptyRetryAttempt >= this.MAX_RETRY_ATTEMPTS) return;
-    // 30s → 60s → 2m → 4m → 5m (capped). Bounded so we don't hammer an
-    // upstream that's genuinely down, but quick enough that a user who
-    // tripped over a transient blip recovers without restarting the app.
-    const delays = [30_000, 60_000, 120_000, 240_000, 300_000];
-    const delay = delays[this.emptyRetryAttempt] ?? 300_000;
-    this.emptyRetryAttempt += 1;
+    const delay = this.nextRetryDelayMs();
+    if (delay === null) return;
     this.retryTimer = setTimeout(() => {
       this.retryTimer = null;
       void this.refresh();
     }, delay);
+  }
+
+  /**
+   * Render a terminal "out of retries" error state. Bypasses Panel.showError
+   * because calling that without an onRetry would re-fire the prior
+   * retryCallback (Panel only replaces retryCallback when onRetry is
+   * defined — passing undefined leaves the stale one in place and starts
+   * a new countdown).
+   *
+   * setContent() sync-resets setErrorState(false), so we re-flip it AFTER
+   * to keep the red header for the terminal error.
+   */
+  private renderTerminalError(): void {
+    this.setContent(`
+      <div class="panel-error-state" style="padding:24px 16px;text-align:center">
+        <div class="panel-error-msg" style="color:var(--danger,#e0654b);font-size:13px">
+          ${escapeHtml(t('common.failedTechReadiness'))}
+        </div>
+      </div>
+    `);
+    this.setErrorState(true);
   }
 
   private showSoftRefreshing(): void {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1605,6 +1605,7 @@
       "broadbandAccess": "Broadband Access",
       "rdExpenditure": "R&D Expenditure",
       "analyzingCountries": "Analyzing 200+ countries...",
+      "dataPreparing": "Refreshing tech readiness data — this will appear shortly.",
       "source": "Source: World Bank",
       "updated": "Updated: {{date}}",
       "infoTooltip": "<strong>Global Tech Readiness</strong><br>Composite score (0-100) based on World Bank data:<br><br><strong>Metrics shown:</strong><br>🌐 Internet Users (% of population)<br>📱 Mobile Subscriptions (per 100 people)<br>🔬 R&D Expenditure (% of GDP)<br><br><strong>Weights:</strong> R&D (35%), Internet (30%), Broadband (20%), Mobile (15%)<br><br><em>— = No recent data available</em><br><em>Source: World Bank Open Data (2019-2024)</em>"

--- a/src/services/economic/index.ts
+++ b/src/services/economic/index.ts
@@ -675,26 +675,30 @@ export async function getTechReadinessRankings(
 ): Promise<TechReadinessScore[]> {
   // Fast path: bootstrap-hydrated data available on first page load
   const hydrated = getHydratedData('techReadiness') as TechReadinessScore[] | undefined;
-  if (hydrated?.length && !countries) return hydrated;
+  if (hydrated?.length) {
+    return countries ? hydrated.filter(s => countries.includes(s.country)) : hydrated;
+  }
 
-  // Fallback: fetch the pre-computed seed key directly from bootstrap endpoint.
-  // Data is seeded by seed-wb-indicators.mjs — never call WB API from frontend.
-  try {
-    const resp = await fetch(toApiUrl('/api/bootstrap?keys=techReadiness'), {
-      signal: AbortSignal.timeout(5_000),
-    });
-    if (resp.ok) {
-      const { data } = (await resp.json()) as { data: { techReadiness?: TechReadinessScore[] } };
-      if (data.techReadiness?.length) {
-        const scores = countries
-          ? data.techReadiness.filter(s => countries.includes(s.country))
-          : data.techReadiness;
-        return scores;
-      }
-    }
-  } catch { /* fall through */ }
-
-  return [];
+  // Fallback: fetch the pre-computed seed key directly from the bootstrap
+  // endpoint. Data is seeded by seed-wb-indicators.mjs — never call the WB
+  // API from the frontend.
+  //
+  // Errors propagate. The previous shape collapsed HTTP failures, fetch
+  // aborts, and JSON parse errors into the same silent `return []` as a
+  // legitimate empty payload, so the panel could not distinguish "network
+  // failed, retry me" from "server says 0 records." That made a single
+  // transient blip render as a permanent empty state until app restart.
+  // Callers now decide UX: a thrown error → retry; an empty array →
+  // genuine empty state.
+  const resp = await fetch(toApiUrl('/api/bootstrap?keys=techReadiness'), {
+    signal: AbortSignal.timeout(5_000),
+  });
+  if (!resp.ok) {
+    throw new Error(`tech-readiness bootstrap HTTP ${resp.status}`);
+  }
+  const { data } = (await resp.json()) as { data: { techReadiness?: TechReadinessScore[] } };
+  const list = data.techReadiness ?? [];
+  return countries ? list.filter(s => countries.includes(s.country)) : list;
 }
 
 export async function getCountryComparison(

--- a/tests/tech-readiness-circuit-breakers.test.mjs
+++ b/tests/tech-readiness-circuit-breakers.test.mjs
@@ -29,6 +29,7 @@ import * as ts from 'typescript'; // TypeScript compiler API — available via t
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
 const economicPath = resolve(root, 'src/services/economic/index.ts');
+const techReadinessPanelPath = resolve(root, 'src/components/TechReadinessPanel.ts');
 
 function loadEconomicSourceFile() {
   return ts.createSourceFile(
@@ -38,6 +39,10 @@ function loadEconomicSourceFile() {
     true,
     ts.ScriptKind.TS,
   );
+}
+
+function loadTechReadinessPanelSource() {
+  return readFileSync(techReadinessPanelPath, 'utf-8');
 }
 
 function walk(node, visit) {
@@ -321,5 +326,30 @@ describe('getTechReadinessRankings — bootstrap-only data flow', () => {
     assert.ok(keys.has('IT.CEL.SETS.P2'), 'Mobile Subscriptions indicator must be present');
     assert.ok(keys.has('IT.NET.BBND.P2'), 'Fixed Broadband indicator must be present');
     assert.ok(keys.has('GB.XPD.RSDV.GD.ZS'), 'R&D Expenditure indicator must be present');
+  });
+});
+
+// ============================================================
+// 4. TechReadinessPanel: soft-refresh retry UX regressions
+// ============================================================
+
+describe('TechReadinessPanel — empty/error retry UX', () => {
+  const panelSrc = loadTechReadinessPanelSource();
+
+  it('does not set the count badge to 0 before the empty-result soft state', () => {
+    assert.doesNotMatch(
+      panelSrc,
+      /this\.setCount\(result\.length\)/,
+      'empty result must not write count badge 0 before showSoftRefreshing()',
+    );
+    assert.match(panelSrc, /this\.hideCountBadge\(\);[\s\S]*?this\.setContent\(`\s*<div class="panel-soft-empty"/);
+    assert.match(panelSrc, /this\.showCountBadge\(this\.rankings\.length\);/);
+  });
+
+  it('resets retry budget only on external refreshes, not scheduled retries', () => {
+    assert.match(panelSrc, /public async refresh\(isRetry = false\): Promise<void>/);
+    assert.match(panelSrc, /if \(!isRetry\) this\.localRetryAttempt = 0;/);
+    assert.match(panelSrc, /void this\.refresh\(true\);/);
+    assert.doesNotMatch(panelSrc, /void this\.refresh\(\);\s*\}, delay\);/);
   });
 });


### PR DESCRIPTION
## Summary

The Tech Readiness panel painted any empty rankings array as a hard error (red header, count badge `0`, "No data available") and offered no recovery path. Once a user hit it, the panel stayed broken until they restarted the app.

Three stacked defects, fixed together:

1. **`getTechReadinessRankings` now throws on network failure / non-OK HTTP / JSON parse errors.** Previously a blanket `catch { /* fall through */ }` swallowed everything and returned `[]`, indistinguishable from a genuine empty payload. Callers can now decide UX based on whether the call threw.

2. **Empty rankings no longer render through `Panel.showError()`.** That call flipped `setErrorState(true)`, painting the panel red — the wrong UI for a benign empty payload. Empty results now route through a new `showSoftRefreshing()` state.

3. **Bounded backoff retry on empty/error.** New `scheduleRetry()` with delays `30s → 60s → 2m → 4m → 5m` (capped at 5 attempts). The error path now passes an `onRetry` callback so `Panel.showError` renders the auto-retry countdown that other panels already have. The retry timer is cleared in `destroy()`.

## Why

Production data is healthy: `/api/health` reports `techReadiness: { status: OK, records: 255, seedAgeMin: ~120 }`. A direct probe of `/api/bootstrap?keys=techReadiness` returns 255 entries. The bug is on the frontend read path.

Most likely trigger: `src/services/bootstrap.ts` aborts the slow-tier bootstrap at **1,800 ms** in the browser. `techReadiness` lives in `SLOW_KEYS` alongside ~70 other keys (~500 KB total). On a slow network or cold-CF-cache fetch, that timeout fires, the hydration cache is empty, and the lazy fallback has a single 5s shot. If that fails too, the panel rendered red error with no recovery — for 6 hours, until a manual app restart.

This is the same shape as the regional-intelligence empty-state issue (PR #3578).

Tracked in `todos/256-pending-p1-tech-readiness-empty-as-error-no-retry.md`.

## Test plan

- [x] `npm run typecheck` — PASS
- [x] `npm run typecheck:api` — PASS
- [x] `npm run lint` — PASS (warnings only)
- [x] `npm run test:data` — PASS (7845/7845, including the existing 11 tech-readiness assertions)
- [x] `node --test tests/tech-readiness-circuit-breakers.test.mjs` — PASS
- [x] Pre-push hook (full strict gate including boundaries / rate-limit / premium-fetch / edge-bundles / version) — PASS
- [ ] Manual: simulate an empty bootstrap response → panel renders soft "Refreshing…" state, NOT red error
- [ ] Manual: simulate a 5xx on the lazy fetch → panel renders error with auto-retry countdown that successfully recovers
- [ ] Manual: confirm `destroy()` clears the retry timer (no stray retries after panel teardown)

## Follow-ups (not in this PR)

- Sweep sibling slow-tier panels with the same hydrate-then-fallback shape (`progressData`, `renewableEnergy`, `nationalDebt`, `wsbTickers`, etc.).
- Review `BOOTSTRAP_SLOW_TIMEOUT_MS = 1,800ms` against current p95 fetch latency for ~70-key payloads.