### PR TITLE
fix(anon): stop calling Pro-gated RPCs for anonymous users (sanctions, national-debt)

### DIFF
--- a/src/services/economic/index.ts
+++ b/src/services/economic/index.ts
@@ -51,6 +51,7 @@ import { isFeatureAvailable } from '../runtime-config';
 import { dataFreshness } from '../data-freshness';
 import { getHydratedData } from '@/services/bootstrap';
 import { toApiUrl } from '@/services/runtime';
+import { hasPremiumAccess } from '@/services/panel-gating';
 
 // ---- Client + Circuit Breakers ----
 
@@ -752,6 +753,15 @@ async function _fetchNationalDebt(): Promise<GetNationalDebtResponse> {
       if (data.nationalDebt?.entries?.length) return data.nationalDebt;
     }
   } catch { /* fall through to RPC */ }
+
+  // Anonymous (non-premium) users: do NOT call the Pro-gated RPC.
+  // /api/economic/v1/get-national-debt is in PREMIUM_RPC_PATHS, so the
+  // call deterministically 401s for an anonymous client and the breaker
+  // returns emptyNationalDebtFallback anyway — same outcome as us, minus
+  // the Sentry/console noise on every page load.
+  if (!hasPremiumAccess()) {
+    return emptyNationalDebtFallback;
+  }
 
   try {
     return await nationalDebtBreaker.execute(async () => {

--- a/src/services/sanctions-pressure.ts
+++ b/src/services/sanctions-pressure.ts
@@ -2,6 +2,8 @@ import { createCircuitBreaker } from '@/utils';
 import { getRpcBaseUrl } from '@/services/rpc-client';
 import { premiumFetch } from '@/services/premium-fetch';
 import { getHydratedData } from '@/services/bootstrap';
+import { hasPremiumAccess } from '@/services/panel-gating';
+import { toApiUrl } from '@/services/runtime';
 import {
   SanctionsServiceClient,
   type SanctionsEntry as ProtoSanctionsEntry,
@@ -157,6 +159,31 @@ export async function fetchSanctionsPressure(): Promise<SanctionsPressureResult>
     const result = toResult(hydrated);
     latestSanctionsPressureResult = result;
     return result;
+  }
+
+  // Anonymous (non-premium) users: do NOT call the Pro-gated RPC. The
+  // RPC at /api/sanctions/v1/list-sanctions-pressure is in
+  // PREMIUM_RPC_PATHS, so an anonymous client gets a deterministic 401
+  // and the breaker fallback returns emptyResult anyway — same outcome
+  // as us, minus the Sentry/console noise. Try the public bootstrap
+  // endpoint as a second-best read path and surface whatever it serves
+  // (or emptyResult on any failure).
+  if (!hasPremiumAccess()) {
+    try {
+      const resp = await fetch(toApiUrl('/api/bootstrap?keys=sanctionsPressure'), {
+        signal: AbortSignal.timeout(5_000),
+      });
+      if (resp.ok) {
+        const { data } = (await resp.json()) as { data?: { sanctionsPressure?: ListSanctionsPressureResponse } };
+        const payload = data?.sanctionsPressure;
+        if (payload?.entries?.length || payload?.countries?.length || payload?.programs?.length) {
+          const result = toResult(payload);
+          latestSanctionsPressureResult = result;
+          return result;
+        }
+      }
+    } catch { /* fall through to emptyResult */ }
+    return emptyResult;
   }
 
   return breaker.execute(async () => {


### PR DESCRIPTION
## Summary

Anonymous (logged-out) browser users were getting deterministic 401s + Sentry/console spam on every page load because two services fell through to **Pro-gated RPCs** after the bootstrap hydration path missed:

- `fetchSanctionsPressure` → `client.listSanctionsPressure` (`/api/sanctions/v1/list-sanctions-pressure`)
- `getNationalDebtData` → `client.getNationalDebt` (`/api/economic/v1/get-national-debt`)

Both paths are in `PREMIUM_RPC_PATHS`, so the breaker fallback returned the same empty result anyway — minus the 401 noise.

### Behaviour change

| User type | Before | After |
|---|---|---|
| Anonymous (no session) | Bootstrap miss → call Pro RPC → 401 → Sentry event → `emptyResult` | Bootstrap miss → return `emptyResult` directly (sanctions tries the public `/api/bootstrap?keys=…` endpoint as a second read path first) |
| Pro user | RPC call succeeds, panel populates | Unchanged |

The Pro RPC path still runs end-to-end for anyone with `hasPremiumAccess() === true`.

## Why

User reported these console errors as anonymous, all of which disappear after login:

```
api.worldmonitor.app/api/sanctions/v1/list-sanctions-pressure?max_items=30:1
  Failed to load resource: the server responded with a status of 401 ()
sentry-qvMREiFU.js:15 [Sanctions Pressure] Failed: ApiError: Request failed with status 401
```

Same shape as the tech-readiness empty-state issue (PR #3583). When that PR + this one land, the "sweep sibling slow-tier panels" follow-up listed in `todos/256-…` is partially done. Remaining work (separate PR):

- Cloud & Infrastructure / Financial Regulation news panels rendering "UNAVAILABLE" for anonymous (data-freshness pipeline, not auth)
- Trade Policy panel stuck on "Loading…" forever for anonymous (premium-locked panel that never short-circuits)
- Convex WebSocket reconnection loop for anonymous users (separate concern; should not subscribe at all without auth)
- Anonymous session token expiry / interceptor-race recovery (out of scope here)

## Test plan

- [x] `npm run typecheck` — PASS
- [x] `npm run typecheck:api` — PASS
- [x] `npm run lint` — PASS (warnings only)
- [x] `npm run test:data` — PASS (7845/7845)
- [x] Pre-push strict gate — boundaries / rate-limit / premium-fetch / edge-bundles / version — PASS
- [ ] Manual: load the app anonymously, confirm no `list-sanctions-pressure` 401 in DevTools Network/Console
- [ ] Manual: load the app anonymously, confirm no `get-national-debt` 401
- [ ] Manual: log in as Pro, confirm Sanctions Pressure + National Debt panels populate as before