### PR TITLE
fix(anon): add regional-intelligence + trade-policy to WEB_PREMIUM_PANELS (lock-CTA invariant)

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -121,7 +121,23 @@ import type { AuthSession } from '@/services/auth-state';
 import { PanelGateReason, getPanelGateReason, hasPremiumAccess } from '@/services/panel-gating';
 import type { Panel } from '@/components/Panel';
 
-/** Panels that require premium access on web. Auth-based gating applies to these. */
+/**
+ * Panels that require premium access on web. Auth-based gating applies to
+ * these — `updatePanelGating()` calls `Panel.showGatedCta()` to render
+ * "Sign In to Unlock" / "Upgrade to Pro" for non-premium users.
+ *
+ * INVARIANT: every panel listed in `apiKeyPanels` (src/config/panels.ts
+ * `isPanelEntitled`) MUST appear here. If it's API-key-entitled but missing
+ * from this set, anonymous/free-Clerk users see the panel mount and run
+ * its loader (which writes empty/loading/error UI directly into the body)
+ * instead of the lock CTA. The PRO badge in the title still renders, so
+ * the symptom is "PRO badge + panel-internal loading or empty copy"
+ * which looks broken (e.g. Regional Intelligence rendering its empty-state
+ * "is being refreshed" message to anonymous users — see todo #257 item 8).
+ *
+ * The static test in tests/panel-config-guardrails.test.mjs enforces
+ * `apiKeyPanels ⊆ WEB_PREMIUM_PANELS` so this drift can't recur silently.
+ */
 const WEB_PREMIUM_PANELS = new Set([
   'stock-analysis',
   'stock-backtest',
@@ -131,6 +147,8 @@ const WEB_PREMIUM_PANELS = new Set([
   'chat-analyst',
   'wsb-ticker-scanner',
   'latest-brief',
+  'regional-intelligence',
+  'trade-policy',
 ]);
 
 /**

--- a/tests/panel-config-guardrails.test.mjs
+++ b/tests/panel-config-guardrails.test.mjs
@@ -87,6 +87,50 @@ describe('panel-config guardrails', () => {
     );
   });
 
+  it('every API-key-entitled premium panel is in WEB_PREMIUM_PANELS (anon lock-CTA invariant)', () => {
+    // Background: src/config/panels.ts has TWO premium-related lists:
+    //
+    //   (a) `apiKeyPanels` — panels that an API-key holder OR a Pro user
+    //       can access. Lives inside isPanelEntitled().
+    //   (b) `WEB_PREMIUM_PANELS` — panels that the web layout's
+    //       updatePanelGating() drives through Panel.showGatedCta() to
+    //       render the "Sign In to Unlock" / "Upgrade to Pro" CTA.
+    //
+    // If a panel is in (a) but NOT (b), API-key users can see it, but
+    // anonymous web users see the panel mount and run its loader (writing
+    // empty/loading/error UI directly into the body) instead of the lock
+    // CTA. The PRO badge still renders, producing a "PRO + visible loader"
+    // shape that looks broken to the user.
+    //
+    // Concrete regression that motivated this test: PR #3578 added a soft
+    // empty state to RegionalIntelligenceBoard. For anonymous users it
+    // wrote "Regional intelligence is being refreshed" into the body
+    // because regional-intelligence was in apiKeyPanels (so isPanelEntitled
+    // mounted it) but missing from WEB_PREMIUM_PANELS (so showGatedCta
+    // never fired). See todos/257-pending-p2-anon-broken-panels-sweep.md
+    // item 8.
+    const panelsSrc = readFileSync(resolve(__dirname, '../src/config/panels.ts'), 'utf-8');
+
+    const apiKeyPanelsMatch = panelsSrc.match(/const apiKeyPanels = \[([^\]]+)\];/);
+    assert.ok(apiKeyPanelsMatch, 'apiKeyPanels array not found in panels.ts');
+    const apiKeyPanels = [...apiKeyPanelsMatch[1].matchAll(/'([^']+)'/g)].map(m => m[1]);
+    assert.ok(apiKeyPanels.length > 0, 'apiKeyPanels parse returned no entries');
+
+    const webPremiumMatch = panelLayoutSrc.match(/const WEB_PREMIUM_PANELS = new Set\(\[([\s\S]*?)\]\);/);
+    assert.ok(webPremiumMatch, 'WEB_PREMIUM_PANELS not found in panel-layout.ts');
+    const webPremium = new Set([...webPremiumMatch[1].matchAll(/'([^']+)'/g)].map(m => m[1]));
+    assert.ok(webPremium.size > 0, 'WEB_PREMIUM_PANELS parse returned no entries');
+
+    const orphans = apiKeyPanels.filter(k => !webPremium.has(k));
+    assert.deepStrictEqual(
+      orphans,
+      [],
+      `apiKeyPanels members missing from WEB_PREMIUM_PANELS: ${orphans.join(', ')}\n` +
+      `Add these keys to src/app/panel-layout.ts WEB_PREMIUM_PANELS so anonymous/free users see the\n` +
+      `"Sign In to Unlock" CTA instead of the panel's own internal loading/empty/error state.`,
+    );
+  });
+
   it('panel keys are consistent across variant configs (no typos)', () => {
     const allKeys = new Map();
     for (const v of VARIANT_FILES) {

--- a/tests/panel-config-guardrails.test.mjs
+++ b/tests/panel-config-guardrails.test.mjs
@@ -111,14 +111,20 @@ describe('panel-config guardrails', () => {
     // item 8.
     const panelsSrc = readFileSync(resolve(__dirname, '../src/config/panels.ts'), 'utf-8');
 
+    // Accept both quote styles — biome currently enforces single quotes
+    // across the repo, but this guard is meant to outlive style drift.
+    // A double-quoted entry slipping past the regex would silently
+    // shrink the verified set and let an orphan re-appear.
+    const QUOTED = /['"]([^'"]+)['"]/g;
+
     const apiKeyPanelsMatch = panelsSrc.match(/const apiKeyPanels = \[([^\]]+)\];/);
     assert.ok(apiKeyPanelsMatch, 'apiKeyPanels array not found in panels.ts');
-    const apiKeyPanels = [...apiKeyPanelsMatch[1].matchAll(/'([^']+)'/g)].map(m => m[1]);
+    const apiKeyPanels = [...apiKeyPanelsMatch[1].matchAll(QUOTED)].map(m => m[1]);
     assert.ok(apiKeyPanels.length > 0, 'apiKeyPanels parse returned no entries');
 
     const webPremiumMatch = panelLayoutSrc.match(/const WEB_PREMIUM_PANELS = new Set\(\[([\s\S]*?)\]\);/);
     assert.ok(webPremiumMatch, 'WEB_PREMIUM_PANELS not found in panel-layout.ts');
-    const webPremium = new Set([...webPremiumMatch[1].matchAll(/'([^']+)'/g)].map(m => m[1]));
+    const webPremium = new Set([...webPremiumMatch[1].matchAll(QUOTED)].map(m => m[1]));
     assert.ok(webPremium.size > 0, 'WEB_PREMIUM_PANELS parse returned no entries');
 
     const orphans = apiKeyPanels.filter(k => !webPremium.has(k));


### PR DESCRIPTION
## Summary

`src/config/panels.ts` and `src/app/panel-layout.ts` carry **two premium-related lists** that have to stay in sync:

| List | Lives in | Purpose |
|---|---|---|
| `apiKeyPanels` | `panels.ts` `isPanelEntitled()` | API-key holders + Pro users may mount the panel |
| `WEB_PREMIUM_PANELS` | `panel-layout.ts` | `updatePanelGating()` → `Panel.showGatedCta()` paints "Sign In to Unlock" / "Upgrade to Pro" for non-premium |

`regional-intelligence` and `trade-policy` were in (a) but missing from (b). API-key users got the panels correctly. **Anonymous / free-Clerk web users got the panel mounted, its loader fired — writing empty / loading / error UI directly into the body — while the PRO badge in the header still rendered.** The combined "PRO + visible internal loader/empty copy" looks broken.

Concrete regression: PR #3578 added a soft empty state to `RegionalIntelligenceBoard`. For anonymous users it surfaced *"Regional intelligence is being refreshed. Try selecting another region above."* instead of the lock CTA. The existing `panel-config-guardrails.test.mjs` even has a comment claiming `regional-intelligence` was gated via `WEB_PREMIUM_PANELS` — the comment was aspirational; the actual set entry never landed.

Same root cause for Trade Policy stuck on "Loading…" forever for anonymous.

## Behaviour change

| User type | Before | After |
|---|---|---|
| Anonymous | Panel mounts, loader runs, body shows empty/loading state, PRO badge in title (looks broken) | `showGatedCta(ANONYMOUS)` — "Sign In to Unlock" CTA |
| Free Clerk | Same broken state as anon | `showGatedCta(FREE_TIER)` — "Upgrade to Pro" CTA |
| API-key holder (desktop) | Unchanged — panel works | Unchanged — `unlockPanel()` |
| Pro user | Unchanged | Unchanged |

## Invariant test

New `tests/panel-config-guardrails.test.mjs` assertion: `apiKeyPanels ⊆ WEB_PREMIUM_PANELS`. Verified by stashing only the `panel-layout.ts` change and running the test — it fails with exactly the two orphan keys before the fix, passes after:

```
AssertionError: apiKeyPanels members missing from WEB_PREMIUM_PANELS:
  regional-intelligence, trade-policy
```

This blocks the same drift from recurring silently.

## Tracks

`todos/257-pending-p2-anon-broken-panels-sweep.md` — items **2** (Trade Policy) and **8** (Regional Intelligence). Item 3 (WSB Ticker retry-state for anon) is unrelated — `wsb-ticker-scanner` was already in `WEB_PREMIUM_PANELS`. Likely a stale-state-on-signout edge case for that one; investigate separately.

## Test plan

- [x] `npm run typecheck` — PASS
- [x] `npm run typecheck:api` — PASS
- [x] `npm run lint` — PASS (warnings only)
- [x] `npm run test:data` — PASS (7848/7848, +1 new invariant test)
- [x] New invariant test passes ON the fix and FAILS without it (drift detection works)
- [x] Pre-push strict gate (boundaries, rate-limit, premium-fetch, edge-bundles, version) — PASS
- [ ] Manual: load app anonymously → Regional Intelligence shows "Sign In to Unlock", not "is being refreshed"
- [ ] Manual: load app anonymously → Trade Policy shows "Sign In to Unlock", not stuck loading
- [ ] Manual: log in as Pro → both panels populate as before