### PR TITLE
fix(bootstrap): bump browser slow-tier timeout 1.8s -> 3.0s

### DIFF
--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -167,8 +167,17 @@ export async function fetchBootstrapData(): Promise<void> {
   const fastCtrl = new AbortController();
   const slowCtrl = new AbortController();
   const desktop = isDesktopRuntime();
+  // Tier abort budgets:
+  // - Fast tier (~10 keys, small payload) keeps an aggressive 1.2 s browser cap; it already meets that budget.
+  // - Slow tier carries ~70 bootstrap keys (~500 KB). The previous 1.8 s browser cap was below realistic p95
+  //   from a cold CF cache, so it aborted on slow connections. That left the hydration cache empty for those
+  //   keys, and downstream per-panel lazy fetches each got a doomed 5 s shot — half of which timed out under
+  //   the same conditions, leaving panels stuck in empty-state.
+  // - 3.0 s is a conservative bump to avoid that cascade. Further tuning should be driven by RUM / Sentry
+  //   data once available; do not move this without evidence.
+  // - Desktop budgets (5 s / 8 s) are unchanged — different network and dependency-loading constraints.
   const fastTimeout = setTimeout(() => fastCtrl.abort(), desktop ? 5_000 : 1_200);
-  const slowTimeout = setTimeout(() => slowCtrl.abort(), desktop ? 8_000 : 1_800);
+  const slowTimeout = setTimeout(() => slowCtrl.abort(), desktop ? 8_000 : 3_000);
 
   try {
     const [slowState, fastState] = await Promise.all([

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -189,11 +189,15 @@ describe('Frontend hydration (src/services/bootstrap.ts)', () => {
     }
   });
 
-  it('keeps web bootstrap tier timeouts under 2 seconds', () => {
+  it('keeps web bootstrap tier timeouts within budget', () => {
     const timeouts = Array.from(src.matchAll(/(\d[_\d]*)\)/g))
       .map((m) => parseInt(m[1].replace(/_/g, ''), 10))
-      .filter((n) => n === 1200 || n === 1800);
-    assert.deepEqual(timeouts, [1200, 1800], `Expected aggressive web bootstrap timeouts (1200, 1800)`);
+      .filter((n) => n === 1200 || n === 3000);
+    assert.deepEqual(
+      timeouts,
+      [1200, 3000],
+      `Expected web bootstrap timeouts (fast=1200, slow=3000) — slow tier was bumped from 1.8s to 3.0s to avoid hydration-cascade aborts`,
+    );
   });
 
   it('allows longer bootstrap timeouts for desktop runtime', () => {


### PR DESCRIPTION
## Summary

Bump the browser slow-tier bootstrap fetch abort budget from **1.8 s** to **3.0 s** in `src/services/bootstrap.ts`.

### Before

```ts
const fastTimeout = setTimeout(() => fastCtrl.abort(), desktop ? 5_000 : 1_200);
const slowTimeout = setTimeout(() => slowCtrl.abort(), desktop ? 8_000 : 1_800);
```

### After

```ts
// Tier abort budgets:
// - Fast tier (~10 keys, small payload) keeps an aggressive 1.2 s browser cap; it already meets that budget.
// - Slow tier carries ~70 bootstrap keys (~500 KB). The previous 1.8 s browser cap was below realistic p95
//   from a cold CF cache, so it aborted on slow connections. That left the hydration cache empty for those
//   keys, and downstream per-panel lazy fetches each got a doomed 5 s shot - half of which timed out under
//   the same conditions, leaving panels stuck in empty-state.
// - 3.0 s is a conservative bump to avoid that cascade. Further tuning should be driven by RUM / Sentry
//   data once available; do not move this without evidence.
// - Desktop budgets (5 s / 8 s) are unchanged - different network and dependency-loading constraints.
const fastTimeout = setTimeout(() => fastCtrl.abort(), desktop ? 5_000 : 1_200);
const slowTimeout = setTimeout(() => slowCtrl.abort(), desktop ? 8_000 : 3_000);
```

## Cascade we're fixing

1. Cold CF cache or slow connection -> slow-tier `/api/bootstrap?tier=slow` request can't return ~500 KB / ~70 keys within 1.8 s.
2. `slowCtrl.abort()` fires -> `slowState` populates with empty entries.
3. Hydration cache has no entries for those ~70 keys.
4. Each panel that mounts later does its own lazy `/api/bootstrap?keys=...` fetch with a 5 s budget.
5. Half of those lazy fetches time out under the same network conditions -> panels render empty-state indefinitely.

3.0 s buys enough headroom to land the slow tier in one shot under realistic p95 cold-cache conditions, eliminating step 2-5 entirely for the affected population.

## Tradeoff

- Marginally slower TTFB on slow connections (worst case +1.2 s before the slow tier gives up).
- In return: no empty-state cascade. Panels render with hydrated data instead of staying empty.

This is the right tradeoff: a slower-but-correct first paint beats a fast-but-empty one.

## Out of scope

- Further tuning (e.g. moving to 2.5 s, 3.5 s, or making it adaptive) needs RUM / Sentry timing data to drive. Not landing speculative tweaks here.
- Desktop budget (8 s) is untouched - different network + dependency-loading profile.
- Fast-tier budgets are untouched - small payload already meets the 1.2 s cap.

Refs `todos/257-pending-p2-anon-broken-panels-sweep.md` item 7.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run typecheck:api` passes
- [x] `npm run lint` passes (warnings only, all pre-existing)
- [x] `npm run test:data` passes (7848/7848)
- [x] Updated `tests/bootstrap.test.mjs` regex assertion for the new slow-tier literal (1800 -> 3000); existing `<= 5000ms` cap test still passes