### PR TITLE
fix(anon): sweep slow-tier services for Pro-RPC fallback gating

### DIFF
--- a/src/services/supply-chain/index.ts
+++ b/src/services/supply-chain/index.ts
@@ -30,6 +30,7 @@ import {
 } from '@/generated/client/worldmonitor/supply_chain/v1/service_client';
 import { createCircuitBreaker } from '@/utils';
 import { getHydratedData } from '@/services/bootstrap';
+import { hasPremiumAccess } from '@/services/panel-gating';
 
 export type {
   GetShippingRatesResponse,
@@ -163,6 +164,12 @@ export async function fetchCountryChokepointIndex(
   iso2: string,
   hs2 = '27',
 ): Promise<GetCountryChokepointIndexResponse> {
+  // Anonymous (non-premium) users: skip the Pro-gated RPC. The path
+  // /api/supply-chain/v1/get-country-chokepoint-index is in
+  // PREMIUM_RPC_PATHS, so an anonymous client gets a deterministic 401
+  // and the catch returns this same emptyChokepointIndex anyway — minus
+  // the console-noise on every country-brief open. Mirrors PR #3584.
+  if (!hasPremiumAccess()) return { ...emptyChokepointIndex, iso2, hs2 };
   try {
     return await client.getCountryChokepointIndex({ iso2, hs2 });
   } catch {
@@ -232,6 +239,8 @@ export async function fetchBypassOptions(
   closurePct = 100,
 ): Promise<GetBypassOptionsResponse> {
   const empty: GetBypassOptionsResponse = { chokepointId, cargoType, closurePct, options: [], primaryChokepointWarRiskTier: 'WAR_RISK_TIER_UNSPECIFIED', fetchedAt: '' };
+  // Pro-gated path — see fetchCountryChokepointIndex.
+  if (!hasPremiumAccess()) return empty;
   try {
     return await client.getBypassOptions({ chokepointId, cargoType, closurePct });
   } catch {
@@ -250,6 +259,8 @@ export async function fetchCountryCostShock(
     warRiskTier: 'WAR_RISK_TIER_UNSPECIFIED',
     hasEnergyModel: false, unavailableReason: '', fetchedAt: '',
   };
+  // Pro-gated path — see fetchCountryChokepointIndex.
+  if (!hasPremiumAccess()) return empty;
   try {
     return await client.getCountryCostShock({ iso2, chokepointId, hs2 });
   } catch {
@@ -268,6 +279,8 @@ export async function fetchSectorDependency(
   iso2: string,
   hs2 = '27',
 ): Promise<GetSectorDependencyResponse> {
+  // Pro-gated path — see fetchCountryChokepointIndex.
+  if (!hasPremiumAccess()) return { ...emptySectorDependency, iso2, hs2 };
   try {
     return await client.getSectorDependency({ iso2, hs2 });
   } catch {
@@ -297,6 +310,8 @@ export interface FetchRouteExplorerLaneArgs {
 export async function fetchRouteExplorerLane(
   args: FetchRouteExplorerLaneArgs,
 ): Promise<GetRouteExplorerLaneResponse> {
+  // Pro-gated path — see fetchCountryChokepointIndex.
+  if (!hasPremiumAccess()) return { ...emptyRouteExplorerLane, ...args };
   try {
     return await client.getRouteExplorerLane(args);
   } catch {
@@ -325,6 +340,8 @@ export interface FetchRouteImpactArgs {
 export async function fetchRouteImpact(
   args: FetchRouteImpactArgs,
 ): Promise<GetRouteImpactResponse> {
+  // Pro-gated path — see fetchCountryChokepointIndex.
+  if (!hasPremiumAccess()) return { ...emptyRouteImpact };
   try {
     return await client.getRouteImpact(args);
   } catch {
@@ -335,6 +352,8 @@ export async function fetchRouteImpact(
 const emptyProducts: GetCountryProductsResponse = { iso2: '', products: [], fetchedAt: '' };
 
 export async function fetchCountryProducts(iso2: string): Promise<GetCountryProductsResponse> {
+  // Pro-gated path — see fetchCountryChokepointIndex.
+  if (!hasPremiumAccess()) return { ...emptyProducts, iso2 };
   try {
     return await client.getCountryProducts({ iso2 });
   } catch {
@@ -363,6 +382,10 @@ export async function fetchMultiSectorCostShock(
   closureDays: number,
   options?: { signal?: AbortSignal },
 ): Promise<GetMultiSectorCostShockResponse> {
+  // Pro-gated path — see fetchCountryChokepointIndex. Existing call sites
+  // already guard with hasPremiumAccess(); the service-layer check here
+  // is defense-in-depth to keep parity with sibling fetchers.
+  if (!hasPremiumAccess()) return { ...emptyMultiSectorShock, iso2, chokepointId, closureDays };
   try {
     return await client.getMultiSectorCostShock(
       { iso2, chokepointId, closureDays },


### PR DESCRIPTION
## Summary

Sweep of slow-tier service paths for the same hydrate-then-fail-silent
pattern fixed by PR #3583 (tech-readiness empty-as-error) and PR #3584
(sanctions / national-debt anon-Pro-RPC 401 spam). Addresses todo
`todos/257-pending-p2-anon-broken-panels-sweep.md` items 1 and 6.

The single net-new fix: 8 Pro-RPC fetchers in `src/services/supply-chain/index.ts`.
Anonymous users opening the country brief trigger `fetchMultiSectorExposure`
unconditionally, which fans out to 10 parallel `fetchCountryChokepointIndex`
calls — each one hits `/api/supply-chain/v1/get-country-chokepoint-index`
(in `PREMIUM_RPC_PATHS`), so anon gets 10 deterministic 401s in the
console on every country-brief open. Same shape as PR #3584.

Pattern mirrored exactly: `if (!hasPremiumAccess()) return EMPTY;`
BEFORE the RPC call, not inside the catch. Pro users unaffected.

## Files changed

- `src/services/supply-chain/index.ts` — added `hasPremiumAccess()`
  short-circuit to 8 Pro-RPC fetchers (`fetchCountryChokepointIndex`,
  `fetchBypassOptions`, `fetchCountryCostShock`, `fetchSectorDependency`,
  `fetchRouteExplorerLane`, `fetchRouteImpact`, `fetchCountryProducts`,
  `fetchMultiSectorCostShock`). Each returns the same empty fallback
  the catch block already returned for anon — purely silences
  console/Sentry noise.

## Audited and skipped (with reason)

| Service | Reason skipped |
| --- | --- |
| `src/services/progress-data.ts` | No RPC fall-through. Bootstrap → static fallback only. |
| `src/services/renewable-energy-data.ts` | Falls through to `fetchEnergyCapacityRpc` → `/api/economic/v1/get-energy-capacity` which is **not** in `PREMIUM_RPC_PATHS` (public for anon). |
| `src/components/WsbTickerScannerPanel.ts` | `fetchData` uses bootstrap-only path; no RPC fallback. Panel itself is Pro-locked via PR #3586 anyway. |
| `src/services/cached-theater-posture.ts` | `getTheaterPosture` is **not** premium. |
| `src/services/cached-risk-scores.ts` | `getRiskScores` is **not** premium. |
| `src/services/social-velocity.ts`, `security-advisories.ts`, `temporal-baseline.ts`, `thermal-escalation.ts`, `usa-spending.ts`, `disease-outbreaks.ts` | All target non-premium intelligence/economic paths. |
| `src/services/market-implications.ts` | `loadMarketImplications` already gates with `hasPremiumAccess()` at the call site (`data-loader.ts:1749`). |
| `src/services/trade/index.ts` (`fetchTariffTrends`, `fetchComtradeFlows`) | Already gated at the call site via `loadTradePolicy` short-circuit (`data-loader.ts:2806`). |
| `src/services/resilience.ts` | Both consumers (`loadResilienceRanking`, `ResilienceWidget`, RouteExplorer) gate via `hasPremiumAccess()` / `getGateReason()`. |
| `src/services/correlation-engine/engine.ts`, `src/components/DeductionPanel.ts`, `src/components/RegionalIntelligenceBoard.ts` | All gate `deductSituation` / `getRegional*` calls with `hasPremiumAccess()` at the call site. |
| `src/services/stock-analysis*.ts`, `src/services/stock-backtest.ts`, `src/services/insider-transactions.ts` | All consumed only inside `loadStockAnalysis` / `loadStockBacktest` which gate at `data-loader.ts:452-456`. |

## Out-of-scope follow-ups (NEW finding)

The original task description flagged news panels showing "UNAVAILABLE"
for anon users (e.g. "Cloud & Infrastructure", "Financial Regulation").
Investigation: those panels render via `NewsPanel.renderNews([])` → the
`unavailable` data badge is set when items array is empty. The upstream
is `/api/news/v1/list-feed-digest`, which is server-tier `'slow'` (not
in `PREMIUM_RPC_PATHS`) — anon users are NOT 401'd. Two distinct issues
that should be tracked separately:

1. The server digest doesn't include all client `FEEDS` categories on
   web; per-feed RSS fallback is gated by `isFeatureEnabled('newsPerFeedFallback')`
   (currently false on web). When the digest skips a category, anon and
   pro both fall to `renderNewsForCategory(category, [])` → "UNAVAILABLE".
2. The badge name "unavailable" is overloaded — it conflates "couldn't
   load" with "empty payload (no news in window)".

Recommend tracking those as a separate todo (e.g. "news per-category
empty pipeline / digest coverage drift") rather than expanding this PR.

## Reference PRs (canonical pattern)

- #3583 — tech-readiness empty payload no longer renders as red error
- #3584 — sanctions / national-debt anon-Pro-RPC 401 spam fix (commit `8ea929447`)

## Test plan

- [x] `npm run typecheck` ✅
- [x] `npm run typecheck:api` ✅
- [x] `npm run lint` ✅ (no new errors; pre-existing 233 warnings unchanged)
- [x] `npm run test:data` ✅ 7848 / 7848 pass
- [x] Pre-push strict gate (boundaries, rate-limit, premium-fetch, edge-bundles, version) ✅
- [ ] Anon page load → open country brief → no `401 /api/supply-chain/v1/get-country-chokepoint-index` in console (10× per open eliminated)
- [ ] Pro page load → open country brief → trade-exposure section still populates (sectors render, multi-sector cost shock fires)
- [ ] RouteExplorer (Pro panel) still functional for Pro user