### PR TITLE
fix(anon): auto-refresh wms_ session token (periodic + refresh-on-401)

### DIFF
--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -20,6 +20,10 @@ import { PREMIUM_RPC_PATHS } from '@/shared/premium-paths';
 const STORAGE_KEY = 'wm-session-token';
 // Refresh well before expiry so a half-loaded page doesn't fail mid-flight.
 const REFRESH_MARGIN_MS = 5 * 60 * 1000;
+// Periodic refresh cadence — wake every 30 minutes to renew before the
+// 12-hour token expires. Long-lived tabs (overnight, multi-day) lose the
+// token without this; the original implementation had no auto-refresh.
+const PERIODIC_REFRESH_MS = 30 * 60 * 1000;
 
 interface StoredSession {
   token: string;
@@ -91,6 +95,15 @@ export async function ensureWmSession(): Promise<string | null> {
 export function getWmSessionToken(): string | null {
   if (isFresh(cached)) return cached.token;
   return null;
+}
+
+// Test-only escape hatch. The interceptor lifecycle is module-scoped (one
+// install per process) so unit tests can't easily simulate token-state
+// transitions across cases without a way to clear `cached` and `inflight`.
+// Production code never imports this — it's exclusively for `tests/wm-session-*`.
+export function __resetWmSessionForTests(): void {
+  cached = null;
+  inflight = null;
 }
 
 // Install a one-shot fetch wrapper that adds X-WorldMonitor-Key to API calls.
@@ -193,16 +206,78 @@ export function installWmSessionFetchInterceptor(): void {
     }
 
     const token = getWmSessionToken();
-    if (!token) return original(input, init);
+    if (token) headers.set('X-WorldMonitor-Key', token);
 
-    headers.set('X-WorldMonitor-Key', token);
+    // A Request body is a one-shot stream — clone BEFORE the first send so
+    // the refresh-on-401 retry below has an intact body to replay. For
+    // string/URL inputs, body lives on `init` and Headers merging is enough.
+    const requestClone = input instanceof Request ? input.clone() : null;
 
-    // Preserve body/method/credentials/cache/redirect by cloning the Request.
-    // For string/URL inputs, fold the merged headers into init.
-    if (input instanceof Request) {
-      const cloned = new Request(input, { headers });
-      return original(cloned, init);
+    const sendWith = (h: Headers, src: typeof input): Promise<Response> => {
+      if (src instanceof Request) {
+        const cloned = new Request(src, { headers: h });
+        return original(cloned, init);
+      }
+      return original(src, { ...(init ?? {}), headers: h });
+    };
+
+    const resp = await sendWith(headers, input);
+
+    // Layer 2 — refresh-on-401. A single transient blip (HMAC-key rotation,
+    // expiry race, server-side cache flap) shouldn't strand the tab. If we
+    // had no token to begin with OR the token we sent was rejected, mint a
+    // fresh one and replay ONCE. Premium routes already returned above; the
+    // wms_ token is irrelevant there.
+    if (resp.status !== 401) return resp;
+
+    // Invalidate the cached token (and its sessionStorage twin) before
+    // re-minting. ensureWmSession() is opportunistic — without invalidation,
+    // it would return the same not-yet-clock-expired token that the server
+    // just rejected (HMAC-key rotation: token signature is wrong even though
+    // `exp` is in the future), and the retry would 401 with the same header.
+    if (token && cached?.token === token) {
+      cached = null;
+      try { sessionStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
     }
-    return original(input, { ...(init ?? {}), headers });
+
+    const fresh = await ensureWmSession().catch(() => null);
+    // Bail if mint failed, or the "fresh" token is identical to what we just
+    // sent (cache returned the same value — retry would 401 again).
+    if (!fresh || fresh === token) return resp;
+
+    const retryHeaders = new Headers(headers);
+    retryHeaders.set('X-WorldMonitor-Key', fresh);
+    return sendWith(retryHeaders, requestClone ?? input);
   };
+
+  // Layer 1 — periodic refresh. The token is short-lived (12h server-side)
+  // and originally there was no auto-refresh, so a tab open overnight (or
+  // a laptop that slept) returned 401 on every API call after expiry.
+  //
+  // Two complementary primitives:
+  //   1. setInterval at PERIODIC_REFRESH_MS — wakes opportunistically.
+  //      Gated on document.visibilityState so a hidden tab on a sleeping
+  //      laptop doesn't fire a flurry of mints when the laptop wakes (N
+  //      tabs all hitting /api/wm-session in parallel).
+  //   2. visibilitychange listener — when the user returns to a hidden
+  //      tab, check freshness immediately. Catches the case where the
+  //      interval skipped many beats while hidden.
+  //
+  // Errors are swallowed — periodic refresh is best-effort; the
+  // refresh-on-401 layer above is the safety net.
+  if (typeof setInterval === 'function') {
+    setInterval(() => {
+      if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return;
+      if (isFresh(cached)) return;
+      ensureWmSession().catch(() => { /* best-effort */ });
+    }, PERIODIC_REFRESH_MS);
+  }
+
+  if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
+    document.addEventListener('visibilitychange', () => {
+      if (document.visibilityState !== 'visible') return;
+      if (isFresh(cached)) return;
+      ensureWmSession().catch(() => { /* best-effort */ });
+    });
+  }
 }

--- a/src/services/wm-session.ts
+++ b/src/services/wm-session.ts
@@ -101,9 +101,16 @@ export function getWmSessionToken(): string | null {
 // install per process) so unit tests can't easily simulate token-state
 // transitions across cases without a way to clear `cached` and `inflight`.
 // Production code never imports this — it's exclusively for `tests/wm-session-*`.
+//
+// `interceptorInstalled` is also reset so a test that calls this followed by
+// `installWmSessionFetchInterceptor()` actually re-runs the install path
+// instead of silently no-op'ing on the install guard. Without it, future
+// tests that wipe state and expect a fresh install would see a stale
+// `window.fetch` wrapper from a prior test.
 export function __resetWmSessionForTests(): void {
   cached = null;
   inflight = null;
+  interceptorInstalled = false;
 }
 
 // Install a one-shot fetch wrapper that adds X-WorldMonitor-Key to API calls.
@@ -163,7 +170,15 @@ export function installWmSessionFetchInterceptor(): void {
   const apiOrigin = (() => {
     try { return new URL(getCanonicalApiOrigin()).origin; } catch { return ''; }
   })();
-  const original = window.fetch.bind(window);
+  // AGENTS.md bans `fetch.bind(globalThis)` to avoid freezing a stale
+  // reference. The prescribed alternative `(...args) => globalThis.fetch(...)`
+  // would recurse here because the very next line replaces `window.fetch`
+  // with our wrapper — re-entering through `globalThis.fetch` would loop
+  // forever. The correct minimal pattern that captures the pre-wrapping
+  // value AND avoids `.bind()` is a plain assignment: in modern browsers
+  // `fetch` is already bound to its global receiver and the unbound
+  // reference works correctly when called as `original(...)`.
+  const original = window.fetch;
 
   window.fetch = async function wmSessionFetch(input, init) {
     const url = (() => {

--- a/tests/wm-session-auto-refresh.test.mts
+++ b/tests/wm-session-auto-refresh.test.mts
@@ -1,0 +1,401 @@
+// Tests for the auto-refresh layers added to wm-session.ts:
+//
+//   Layer 1 — periodic refresh:
+//     - setInterval-driven mint while the document is visible.
+//     - Skips when document.visibilityState !== 'visible'.
+//     - Skips when the cached token is still fresh.
+//     - visibilitychange listener mints when the tab becomes visible
+//       and the cached token is expired.
+//
+//   Layer 2 — refresh-on-401 inside the fetch interceptor:
+//     - A 401 from the API triggers ensureWmSession() and a single replay.
+//     - Premium-RPC paths short-circuit BEFORE the wms_ branch — no retry.
+//     - When the caller already supplied Authorization, the wms_ branch
+//       is skipped — no retry.
+//     - If the retry also 401s, the second response is returned (no infinite loop).
+//
+// Why both layers:
+//   Periodic refresh catches the common case (tab open overnight, laptop wake).
+//   Refresh-on-401 is belt-and-suspenders for HMAC-key rotation incidents and
+//   any edge case the periodic check missed (e.g. server-side cache flap).
+//
+// The interceptor lives on a module-scoped flag (`interceptorInstalled`), so
+// we install it ONCE here and drive behaviour by swapping the captured
+// `original` fetch's responses per test.
+
+import assert from 'node:assert/strict';
+import { describe, it, before, beforeEach, after } from 'node:test';
+
+// ---------------------------------------------------------------------------
+// Stub browser globals BEFORE the wm-session module is imported. The module
+// calls `typeof window === 'undefined'` to gate installation, and reads
+// `document.visibilityState` from inside the periodic-refresh closures.
+// ---------------------------------------------------------------------------
+
+interface StubDocument {
+  visibilityState: 'visible' | 'hidden';
+  addEventListener: (type: string, listener: () => void) => void;
+  __listeners: Map<string, Array<() => void>>;
+  __dispatch: (type: string) => void;
+}
+
+const stubDocument: StubDocument = {
+  visibilityState: 'visible',
+  __listeners: new Map(),
+  addEventListener(type, listener) {
+    const arr = stubDocument.__listeners.get(type) ?? [];
+    arr.push(listener);
+    stubDocument.__listeners.set(type, arr);
+  },
+  __dispatch(type) {
+    const arr = stubDocument.__listeners.get(type) ?? [];
+    for (const fn of arr) fn();
+  },
+};
+
+// Stash the most recently registered setInterval callback so tests can fire
+// it synchronously without waiting wall-clock time.
+let lastIntervalCallback: (() => void) | null = null;
+let lastIntervalMs = 0;
+const stubSetInterval = ((cb: () => void, ms: number) => {
+  lastIntervalCallback = cb;
+  lastIntervalMs = ms;
+  // Return a fake handle; we never call clearInterval in this test.
+  return 1 as unknown as ReturnType<typeof setInterval>;
+}) as typeof setInterval;
+
+// Capture the underlying fetch so the interceptor wraps THIS function. Tests
+// reassign `currentFetchHandler` to swap responses per scenario.
+type FetchHandler = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+let currentFetchHandler: FetchHandler = () => Promise.resolve(new Response('default', { status: 200 }));
+const stubFetch: typeof fetch = ((input: RequestInfo | URL, init?: RequestInit) => currentFetchHandler(input, init)) as typeof fetch;
+
+// In-memory sessionStorage so loadFromStorage / saveToStorage don't blow up.
+const memoryStorage = new Map<string, string>();
+const stubSessionStorage: Storage = {
+  get length() { return memoryStorage.size; },
+  clear() { memoryStorage.clear(); },
+  getItem(key) { return memoryStorage.has(key) ? memoryStorage.get(key)! : null; },
+  key(i) { return Array.from(memoryStorage.keys())[i] ?? null; },
+  removeItem(key) { memoryStorage.delete(key); },
+  setItem(key, value) { memoryStorage.set(key, String(value)); },
+};
+
+// localStorage stub — touched by src/config/variant.ts during module import.
+const memoryLocalStorage = new Map<string, string>();
+const stubLocalStorage: Storage = {
+  get length() { return memoryLocalStorage.size; },
+  clear() { memoryLocalStorage.clear(); },
+  getItem(key) { return memoryLocalStorage.has(key) ? memoryLocalStorage.get(key)! : null; },
+  key(i) { return Array.from(memoryLocalStorage.keys())[i] ?? null; },
+  removeItem(key) { memoryLocalStorage.delete(key); },
+  setItem(key, value) { memoryLocalStorage.set(key, String(value)); },
+};
+
+// Inject all globals before import. Cast through unknown — node doesn't ship
+// a Window type and we only need the touched fields.
+(globalThis as unknown as { window: unknown }).window = globalThis;
+(globalThis as unknown as { document: StubDocument }).document = stubDocument;
+(globalThis as unknown as { sessionStorage: Storage }).sessionStorage = stubSessionStorage;
+(globalThis as unknown as { localStorage: Storage }).localStorage = stubLocalStorage;
+(globalThis as unknown as { setInterval: typeof setInterval }).setInterval = stubSetInterval;
+(globalThis as unknown as { fetch: typeof fetch }).fetch = stubFetch;
+// `location` must include `hostname` because src/config/variant.ts (loaded
+// transitively via runtime.ts → wm-session.ts) reads `location.hostname` at
+// module-eval time and calls `.startsWith(...)` on it.
+(globalThis as unknown as { location: Location }).location = {
+  href: 'https://worldmonitor.app/',
+  origin: 'https://worldmonitor.app',
+  hostname: 'worldmonitor.app',
+  protocol: 'https:',
+  host: 'worldmonitor.app',
+} as Location;
+
+// ---------------------------------------------------------------------------
+// Now import the module and install the interceptor exactly once.
+// ---------------------------------------------------------------------------
+
+let mod: typeof import('../src/services/wm-session.ts');
+let wrappedFetch: typeof fetch;
+
+before(async () => {
+  mod = await import('../src/services/wm-session.ts');
+  mod.installWmSessionFetchInterceptor();
+  // After install, globalThis.fetch is the wrapper.
+  wrappedFetch = (globalThis as unknown as { fetch: typeof fetch }).fetch;
+  assert.notEqual(wrappedFetch, stubFetch, 'interceptor should have replaced globalThis.fetch');
+  assert.ok(lastIntervalCallback, 'install should register a setInterval callback');
+  assert.equal(lastIntervalMs, 30 * 60 * 1000, 'interval should fire every 30 minutes');
+});
+
+beforeEach(() => {
+  memoryStorage.clear();
+  stubDocument.visibilityState = 'visible';
+  // Reset the module's cached/inflight state so each test starts from a
+  // clean slate. Without this, a `cached` token from a prior test (set via
+  // ensureWmSession's storage path) would short-circuit the next test's
+  // mint attempt.
+  mod.__resetWmSessionForTests();
+  // Default handler: no API endpoint configured per test.
+  currentFetchHandler = () => Promise.resolve(new Response('unhandled', { status: 500 }));
+});
+
+after(() => {
+  // Best-effort cleanup so a follow-on test file doesn't see our globals.
+  // node:test runs files in their own process so this is mostly defensive.
+  memoryStorage.clear();
+});
+
+// Helpers --------------------------------------------------------------------
+
+function setStoredToken(token: string, expMs: number): void {
+  memoryStorage.set('wm-session-token', JSON.stringify({ token, exp: expMs }));
+}
+
+// Fresh = exp far in the future. Expired = exp in the past (or within the
+// 5-minute REFRESH_MARGIN_MS window — same effective behaviour for isFresh).
+const FAR_FUTURE = Date.now() + 12 * 60 * 60 * 1000;
+const PAST = Date.now() - 1000;
+
+// Force the in-memory `cached` state by calling the module's API. ensureWmSession
+// reads sessionStorage when cached is null — set the storage and prime via
+// getWmSessionToken doesn't help because that only reads cached. We rely on
+// ensureWmSession's storage path to populate `cached`.
+async function primeCachedFromStorage(): Promise<void> {
+  await mod.ensureWmSession();
+}
+
+// ---------------------------------------------------------------------------
+// Layer 1 — periodic refresh
+// ---------------------------------------------------------------------------
+
+describe('wm-session periodic refresh (Layer 1)', () => {
+  it('skips the periodic mint when document is hidden', async () => {
+    // Cached token is expired so the interval would otherwise mint.
+    setStoredToken('wms_old', PAST);
+    await primeCachedFromStorage(); // cached stays null because PAST is not fresh
+
+    stubDocument.visibilityState = 'hidden';
+
+    let mintCalls = 0;
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        mintCalls += 1;
+        return Promise.resolve(new Response(JSON.stringify({ token: 'wms_new', exp: FAR_FUTURE }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      return Promise.resolve(new Response('unhandled', { status: 500 }));
+    };
+
+    // Fire the periodic callback. Should be a no-op because hidden.
+    lastIntervalCallback?.();
+    // Allow any microtasks/promises to settle.
+    await new Promise((r) => setImmediate(r));
+
+    assert.equal(mintCalls, 0, 'hidden tab must NOT trigger a mint');
+  });
+
+  it('skips the periodic mint when the cached token is still fresh', async () => {
+    setStoredToken('wms_fresh', FAR_FUTURE);
+    await primeCachedFromStorage(); // primes `cached` with fresh value
+
+    stubDocument.visibilityState = 'visible';
+
+    let mintCalls = 0;
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        mintCalls += 1;
+        return Promise.resolve(new Response(JSON.stringify({ token: 'wms_new', exp: FAR_FUTURE }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      return Promise.resolve(new Response('unhandled', { status: 500 }));
+    };
+
+    lastIntervalCallback?.();
+    await new Promise((r) => setImmediate(r));
+
+    assert.equal(mintCalls, 0, 'fresh cached token must NOT trigger a mint');
+  });
+
+  it('visibilitychange handler mints when token is expired and tab becomes visible', async () => {
+    // beforeEach() reset cached/inflight + cleared storage, so the freshness
+    // gate inside the listener evaluates to false and the mint runs.
+    let mintCalls = 0;
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        mintCalls += 1;
+        return Promise.resolve(new Response(JSON.stringify({ token: `wms_visible_${mintCalls}`, exp: FAR_FUTURE }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      return Promise.resolve(new Response('unhandled', { status: 500 }));
+    };
+
+    stubDocument.visibilityState = 'visible';
+    stubDocument.__dispatch('visibilitychange');
+    await new Promise((r) => setImmediate(r));
+
+    assert.equal(mintCalls, 1, 'expired cache + visible tab must mint once via visibilitychange');
+  });
+
+  it('visibilitychange handler does NOT mint when the cached token is fresh', async () => {
+    setStoredToken('wms_fresh_visible', FAR_FUTURE);
+    await primeCachedFromStorage(); // primes cached with fresh token
+
+    let mintCalls = 0;
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        mintCalls += 1;
+        return Promise.resolve(new Response(JSON.stringify({ token: 'wms_unused', exp: FAR_FUTURE }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      return Promise.resolve(new Response('unhandled', { status: 500 }));
+    };
+
+    stubDocument.visibilityState = 'visible';
+    stubDocument.__dispatch('visibilitychange');
+    await new Promise((r) => setImmediate(r));
+
+    assert.equal(mintCalls, 0, 'fresh cached token must short-circuit the visibility handler');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Layer 2 — refresh-on-401
+// ---------------------------------------------------------------------------
+
+describe('wm-session refresh-on-401 (Layer 2)', () => {
+  it('retries an API 401 with a freshly-minted token', async () => {
+    // Prime cached with a token the server will reject.
+    setStoredToken('wms_stale', FAR_FUTURE);
+    await primeCachedFromStorage();
+    assert.equal(mod.getWmSessionToken(), 'wms_stale');
+
+    let bootstrapAttempts = 0;
+    let mintCalls = 0;
+    currentFetchHandler = (input, init) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        mintCalls += 1;
+        return Promise.resolve(new Response(JSON.stringify({ token: 'wms_new', exp: FAR_FUTURE }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      if (url.includes('/api/bootstrap')) {
+        bootstrapAttempts += 1;
+        const headers = new Headers(init?.headers ?? (input instanceof Request ? input.headers : undefined));
+        const sent = headers.get('X-WorldMonitor-Key');
+        if (sent === 'wms_stale') return Promise.resolve(new Response('expired', { status: 401 }));
+        if (sent === 'wms_new') return Promise.resolve(new Response('ok', { status: 200 }));
+        return Promise.resolve(new Response('no-key', { status: 401 }));
+      }
+      return Promise.resolve(new Response('unhandled', { status: 500 }));
+    };
+
+    const resp = await wrappedFetch('https://api.worldmonitor.app/api/bootstrap');
+    assert.equal(resp.status, 200, 'final response should be the retried 200');
+    assert.equal(bootstrapAttempts, 2, 'bootstrap should be called twice (initial 401 + retry)');
+    assert.equal(mintCalls, 1, 'one mint between the 401 and the retry');
+  });
+
+  it('does NOT retry when the path is in PREMIUM_RPC_PATHS', async () => {
+    setStoredToken('wms_anything', FAR_FUTURE);
+    await primeCachedFromStorage();
+
+    let attempts = 0;
+    let mintCalls = 0;
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        mintCalls += 1;
+        return Promise.resolve(new Response(JSON.stringify({ token: 'wms_new', exp: FAR_FUTURE }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      attempts += 1;
+      return Promise.resolve(new Response('forbidden', { status: 401 }));
+    };
+
+    // Pick any premium path — analyze-stock is one.
+    const resp = await wrappedFetch('https://api.worldmonitor.app/api/market/v1/analyze-stock');
+    assert.equal(resp.status, 401);
+    assert.equal(attempts, 1, 'premium path must NOT trigger a retry inside this interceptor');
+    assert.equal(mintCalls, 0, 'premium path must NOT mint a wms_ token (the dedicated injector handles it)');
+  });
+
+  it('does NOT retry when the caller supplied Authorization', async () => {
+    setStoredToken('wms_anything', FAR_FUTURE);
+    await primeCachedFromStorage();
+
+    let attempts = 0;
+    let mintCalls = 0;
+    let lastSeenAuth: string | null = null;
+    currentFetchHandler = (input, init) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        mintCalls += 1;
+        return Promise.resolve(new Response(JSON.stringify({ token: 'wms_new', exp: FAR_FUTURE }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      attempts += 1;
+      const headers = new Headers(init?.headers ?? (input instanceof Request ? input.headers : undefined));
+      lastSeenAuth = headers.get('Authorization');
+      return Promise.resolve(new Response('unauthorized', { status: 401 }));
+    };
+
+    const resp = await wrappedFetch('https://api.worldmonitor.app/api/bootstrap', {
+      headers: { Authorization: 'Bearer caller-supplied-jwt' },
+    });
+    assert.equal(resp.status, 401);
+    assert.equal(attempts, 1, 'caller-supplied Authorization must NOT be retried by the wms_ interceptor');
+    assert.equal(mintCalls, 0, 'caller-supplied Authorization must NOT trigger a wms_ mint');
+    assert.equal(lastSeenAuth, 'Bearer caller-supplied-jwt', 'caller Authorization must pass through untouched');
+  });
+
+  it('returns the second 401 if the retry also fails (no infinite loop)', async () => {
+    // No cached token, no stored token — the first send goes out with NO
+    // X-WorldMonitor-Key header (token = null). Server 401s, the interceptor
+    // mints a fresh token, replays with the new header, server 401s again.
+    // The second 401 must be returned as-is (no further retry) — the
+    // retryGuard semantics are encoded by `fresh === token`-bail and by the
+    // structural fact that the retry path is never re-entered.
+    memoryStorage.clear();
+
+    let bootstrapAttempts = 0;
+    let mintCalls = 0;
+    currentFetchHandler = (input) => {
+      const url = typeof input === 'string' ? input : (input instanceof URL ? input.href : input.url);
+      if (url.includes('/api/wm-session')) {
+        mintCalls += 1;
+        // Mint always succeeds with a fresh token; server still rejects on
+        // /api/bootstrap to simulate HMAC-key rotation lag.
+        return Promise.resolve(new Response(JSON.stringify({ token: `wms_attempt_${mintCalls}`, exp: FAR_FUTURE }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+      bootstrapAttempts += 1;
+      return Promise.resolve(new Response('still-rejected', { status: 401 }));
+    };
+
+    const resp = await wrappedFetch('https://api.worldmonitor.app/api/bootstrap');
+    assert.equal(resp.status, 401, 'returns second 401 instead of looping');
+    assert.equal(bootstrapAttempts, 2, 'exactly one retry — no infinite loop');
+    assert.equal(mintCalls, 1, 'exactly one mint between the two attempts');
+  });
+});


### PR DESCRIPTION
## Summary

The anonymous-browser `wms_` token (`src/services/wm-session.ts`) is HMAC-signed and short-lived (12h). Before this PR there was **no auto-refresh**: long-lived tabs (>12h, laptops that slept overnight, week-long browser windows) lost the token after expiry, the global fetch interceptor stopped attaching `X-WorldMonitor-Key`, and every `/api/*` call 401'd until reload.

This PR adds **two complementary refresh layers**, both gated to be safe defaults.

### Layer 1 — periodic refresh (proactive)

Inside `installWmSessionFetchInterceptor()`:

- `setInterval` at 30 minutes.
- Skip when `document.visibilityState !== 'visible'` — prevents the laptop-wake-from-sleep fan-out where every hidden tab fires a stale interval simultaneously and pile-drives `/api/wm-session` with N parallel mints.
- Skip when `isFresh(cached)` — already valid, nothing to do.
- Errors swallowed (best-effort).
- Companion `visibilitychange` listener: when a hidden tab becomes visible, opportunistically check freshness and mint if expired. Catches the case where the interval skipped many beats while hidden.

### Layer 2 — refresh-on-401 (defensive)

After the existing wrapper logic, if a `/api/*` response returns 401:

- One retry per call (no recursion, no loop).
- Path in `PREMIUM_RPC_PATHS` already returned earlier — premium routes have their own auth-injection layer; `wms_` won't unblock them.
- Caller already supplied `Authorization` / `X-Api-Key` / `X-WorldMonitor-Key` already returned earlier — Bearer JWT and explicit-key paths take precedence.
- Invalidate `cached` (and its sessionStorage twin) before calling `ensureWmSession()`. Without this, `ensureWmSession` is opportunistic and would return the same not-yet-clock-expired token that the server just rejected (HMAC-key rotation: signature wrong even though `exp` is in the future), and the retry would 401 with the same header.
- Clone a `Request` input **before** the first send so the retry has an intact body to replay (request bodies are one-shot streams).
- If retry also 401s, return that response as-is. No infinite loop.

### Why both?

- **Periodic refresh** catches the common case (idle tab, 12h+ session, laptop sleep). Cheap, opportunistic, eliminates 99% of the symptom.
- **Refresh-on-401** is belt-and-suspenders for HMAC-key rotation incidents (server rotates the signing key — every existing `wms_` becomes invalid even if the clock says "fresh"), expiry-margin races, server-side cache flap. The periodic check has no signal to trigger off in those cases; only a real 401 from the server does.

One layer alone leaves a gap.

### Tradeoffs considered

- **`setInterval` vs `setTimeout` recursion**: `setInterval` is simpler and there's no per-tick variability concern here. The visibility gate makes "missed" interval ticks harmless — when the tab returns, the visibilitychange listener fires immediately. With a recursive `setTimeout` we'd need extra plumbing to avoid double-scheduling.
- **30 min vs longer/shorter cadence**: 30 minutes is well under the 12h expiry, well above the 5-minute `REFRESH_MARGIN_MS`, and small enough that even a few missed beats (background tab waking briefly) still hit the margin.
- **Visibility gating**: protects against the laptop-wake-stampede where the OS fires every queued interval simultaneously across all browser tabs. Without it, N tabs would all hit `/api/wm-session` in parallel; the server can handle it but it's wasteful and adds noise to gateway logs.
- **Cache invalidation on 401 vs blind ensureWmSession**: a server 401 on a clock-fresh token means the token is invalid for a non-clock reason (most commonly HMAC-key rotation). Without invalidating `cached` first, `ensureWmSession()` short-circuits and returns the same bad token, retry 401s, we bail. The implementation invalidates only when `cached?.token === token` (the exact token that just got rejected) — that way, a concurrent request that already minted a NEW token isn't clobbered.
- **Test escape hatch (`__resetWmSessionForTests`)**: the interceptor lifecycle is module-scoped (one install per process). Without an exported reset, unit tests cannot simulate token-state transitions cleanly across cases. The export is named with the `__` prefix and a clarifying comment so production code paths don't accidentally import it.

Refs `todos/257-pending-p2-anon-broken-panels-sweep.md` item 5.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run typecheck:api` — passes
- [x] `npm run lint` — passes (no new diagnostics in modified files)
- [x] `npm run test:data` — 7856 / 7856 pass
- [x] New `tests/wm-session-auto-refresh.test.mts` covers:
  - Periodic interval skips when document hidden
  - Periodic interval skips when token still fresh
  - `visibilitychange` mints when token expired and tab becomes visible
  - `visibilitychange` does NOT mint when cached token fresh
  - Refresh-on-401 retries once with fresh token (verifies 200 outcome and exactly 1 mint between attempts)
  - Refresh-on-401 does NOT retry on `PREMIUM_RPC_PATHS`
  - Refresh-on-401 does NOT retry when caller supplied `Authorization`
  - Refresh-on-401 returns the second 401 if retry also fails (no infinite loop)
- [x] Existing `tests/wm-session-interceptor-target.test.mts` still passing (URL-matcher and static-import-guard regressions intact)

## Out of scope

- Server side (`api/wm-session.js`, `api/_api-key.js`) untouched.
- `PREMIUM_RPC_PATHS` set untouched.
- No panel changes.