### PR TITLE
fix(anon): skip Convex subscriptions when no Clerk session

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -107,7 +107,6 @@ import { loadWidgets, saveWidget } from '@/services/widget-store';
 import type { CustomWidgetSpec } from '@/services/widget-store';
 import { initEntitlementSubscription, destroyEntitlementSubscription, isEntitled, hasTier, getEntitlementState, onEntitlementChange, shouldReloadOnEntitlementChange } from '@/services/entitlements';
 import { initSubscriptionWatch, destroySubscriptionWatch } from '@/services/billing';
-import { getUserId } from '@/services/user-identity';
 import { initPaymentFailureBanner } from '@/components/payment-failure-banner';
 import { handleCheckoutReturn } from '@/services/checkout-return';
 import { initCheckoutOverlay, destroyCheckoutOverlay, showCheckoutSuccess, consumePostCheckoutFlag, clearCheckoutAttempt } from '@/services/checkout';
@@ -233,11 +232,42 @@ export class PanelLayoutManager implements AppModule {
       showCheckoutFailureBanner(returnResult.rawStatus);
     }
 
-    const userId = getUserId();
-    if (userId) {
+    // Always register the payment-failure-banner listener — onSubscriptionChange
+    // is an in-memory listener registry, doesn't open any network connection,
+    // and survives the destroy/reinit cycle on auth transitions (see
+    // billing.ts:124-126). Registering once here means the banner reacts when
+    // a user signs in mid-session and the App.ts auth-state subscription
+    // (App.ts:995-1006) starts the Convex subscription watch.
+    this.unsubscribePaymentFailureBanner = initPaymentFailureBanner();
+
+    // Defer Convex subscriptions until a real Clerk identity exists.
+    //
+    // `getUserId()` (user-identity.ts) always returns truthy for browser
+    // users — it falls back to an auto-generated `wm-anon-id` UUID — so the
+    // previous `if (userId)` gate never short-circuited. That meant every
+    // anonymous visitor opened a Convex WebSocket via getConvexClient()
+    // with `setAuth(getClerkToken)` returning null, which the Convex SDK
+    // could not authenticate, producing a constant
+    //   `WebSocket connection to wss://…/api/1.34.0/sync failed`
+    // reconnect loop in DevTools (todo #257 item 4). The subscriptions
+    // themselves never delivered useful state for anon users either:
+    //   - getEntitlementsForUser returns FREE_TIER_DEFAULTS without auth
+    //   - getSubscriptionForUser returns null without auth
+    // — so the loop was pure noise.
+    //
+    // For users who sign in mid-session, App.ts:1003-1006 destroys and
+    // re-initializes both subscriptions against the real Clerk userId, so
+    // skipping here is a no-op for the signed-in path.
+    //
+    // Note: PanelLayoutManager is constructed before initAuthState() awaits
+    // Clerk, so getAuthState().user is null even for users who will silently
+    // restore a Clerk session on this page load. Those users are picked up
+    // by subscribeAuthState a few hundred ms later via the same App.ts
+    // rebind path. Constructor-time anon is the common case.
+    if (getAuthState().user) {
+      const userId = getAuthState().user!.id;
       initEntitlementSubscription(userId).catch(() => {});
       initSubscriptionWatch(userId).catch(() => {});
-      this.unsubscribePaymentFailureBanner = initPaymentFailureBanner();
     }
 
     // Overlay success fires BEFORE the entitlement-watcher reload. The


### PR DESCRIPTION
## Summary

Stops the `WebSocket connection to wss://tacit-curlew-777.convex.cloud/api/1.34.0/sync failed` reconnect loop that anonymous (logged-out) users see in DevTools — repeats every few seconds for the lifetime of an anon session, disappears on login.

Root cause: `PanelLayoutManager`'s constructor calls
```ts
const userId = getUserId();
if (userId) {
  initEntitlementSubscription(userId).catch(() => {});
  initSubscriptionWatch(userId).catch(() => {});
  this.unsubscribePaymentFailureBanner = initPaymentFailureBanner();
}
```
but `getUserId()` (`src/services/user-identity.ts:60-73`) always returns truthy in the browser — it falls back to an auto-generated `wm-anon-id` UUID when no Clerk user and no legacy `wm-pro-key` are present. Every anon visitor was opening a Convex WebSocket via `getConvexClient()` with `setAuth(getClerkToken)` returning `null`, which the Convex SDK could not authenticate → reconnect loop. Errors disappeared on login because `App.ts:1003-1006` destroys and re-initializes the subscriptions against the real Clerk userId once the auth-state subscription fires.

The two server-side queries (`getEntitlementsForUser`, `getSubscriptionForUser`) both return safe defaults / `null` for unauthenticated callers, so the noisy WS was not even producing useful state.

## Changes

- Replace `if (getUserId())` with `if (getAuthState().user)` so the Convex subscriptions only start when a real Clerk identity exists. The auth-state subscription in `App.ts:995-1006` already handles the mid-session sign-in case, so this is a no-op for signed-in users.
- Move `initPaymentFailureBanner()` outside the gate — `onSubscriptionChange` is an in-memory listener registry (`src/services/billing.ts:98-111`), opens no network connection, and survives the destroy/reinit cycle (`billing.ts:124-126`). Registering early ensures the banner reacts on a later mid-session sign-in.
- Drop the now-unused `getUserId` import.

## Why not gate on `hasUserIdentity()`

`hasUserIdentity()` returns `true` for legacy `wm-pro-key` users, who never have a Clerk session — `setAuth(getClerkToken)` returns `null` for them too, reproducing the same loop. The gate must be a Clerk-session-present check, which `getAuthState().user` already provides.

## Constructor-vs-Clerk-load timing

`PanelLayoutManager` is constructed in `App.ts:824`, before `App.init()` awaits `initAuthState()` (line 960). So even users with a silently-restored Clerk session enter the constructor with `getAuthState().user === null`. Those users are picked up a few hundred ms later when `subscribeAuthState` fires the rebind in `App.ts:1003-1006`. No regression vs. the previous behavior, which also fired with the wrong (anon UUID) `userId` at constructor time.

Refs todo #257 item 4.

## Test plan

- [ ] DevTools console on anonymous load: no `WebSocket connection ... failed` repeat
- [ ] Sign in anonymously then in: subscriptions start (entitlement + billing), payment-failure banner reacts to `on_hold` state
- [ ] Sign out: existing destroy paths still fire (App.ts:1041-1044)
- [x] `npm run typecheck`
- [x] `npm run typecheck:api`
- [x] `npm run lint` (no new warnings)
- [x] `npm run test:data` (one pre-existing flake unrelated to this change: `news-classify-cache-prefix-audit` races with `bundle-runner` fixtures; passes when the test runs in isolation and the suite passes on a re-run)