### PR TITLE
fix(news): align server finance digest key 'regulation' → 'fin-regulation'

### DIFF
--- a/server/worldmonitor/news/v1/_feeds.ts
+++ b/server/worldmonitor/news/v1/_feeds.ts
@@ -291,7 +291,15 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       { name: 'Trading Tech', url: gn('("algorithmic trading" OR "trading platform" OR "quantitative finance") when:7d') },
       { name: 'Blockchain Finance', url: gn('("blockchain finance" OR tokenization OR "digital securities" OR CBDC) when:7d') },
     ],
-    regulation: [
+    // Key MUST match the client-side category key in src/config/feeds.ts
+    // FINANCE_FEEDS (`'fin-regulation'`). The client iterates
+    // `Object.keys(FEEDS)` and looks up `digest.categories[category]` by the
+    // same key — a name drift here means the server returns the digest
+    // bucket but the client never finds it, and the panel renders empty.
+    // The panel name was renamed `regulation` → `fin-regulation` client-side
+    // in PR #3578-era work (App.ts:539-542 has a one-time storage migration
+    // for prior users), but this server-side key was never updated.
+    'fin-regulation': [
       { name: 'SEC', url: 'https://www.sec.gov/news/pressreleases.rss' },
       { name: 'Financial Regulation', url: gn('(SEC OR CFTC OR FINRA OR FCA) regulation OR enforcement when:3d') },
       { name: 'Banking Rules', url: gn('(Basel OR "capital requirements" OR "banking regulation") when:7d') },

--- a/tests/news-feed-key-parity.test.mts
+++ b/tests/news-feed-key-parity.test.mts
@@ -110,18 +110,44 @@ function extractVariantBlock(src: string, variantKey: string): string | null {
 // whose VALUE is an array literal (`<key>: [`). That excludes nested
 // objects and natural-language text that happens to contain a colon.
 // Both bare identifiers and quoted (kebab-case) keys are accepted.
+//
+// Brace-depth tracking: a key only counts when found at depth 0 of the
+// passed body. Otherwise a future feed entry shaped like
+// `{ name: '...', tags: ['a', 'b'] }` would emit a spurious `tags` key
+// for the test. The current feed maps use flat single-line objects so
+// this isn't observable yet, but the guard means the parity guard
+// stays correct under reasonable future formatting.
 function extractCategoryKeys(body: string): string[] {
   const keys: string[] = [];
-  // Anchor to a newline so we only match top-of-line property declarations,
-  // not a colon embedded mid-string. Either:
-  //   <leading-ws><identifier>: [
-  //   <leading-ws>'<kebab-or-anything>': [
-  //   <leading-ws>"<kebab-or-anything>": [
-  const re = /\n[ \t]+(?:'([^']+)'|"([^"]+)"|([a-zA-Z_$][a-zA-Z0-9_$]*))\s*:\s*\[/g;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(body)) !== null) {
-    const key = m[1] ?? m[2] ?? m[3];
-    if (key) keys.push(key);
+  // Anchor: <leading-ws><key>: [   where <key> is either a bare
+  // identifier or a single/double-quoted string.
+  const KEY_RE = /[ \t]+(?:'([^']+)'|"([^"]+)"|([a-zA-Z_$][a-zA-Z0-9_$]*))\s*:\s*\[/y;
+  let depth = 0;
+  let inString: '"' | "'" | '`' | null = null;
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i] ?? '';
+    // Crude string skip — string literals can contain `{` / `}` / `:` which would
+    // otherwise corrupt depth tracking. We don't need full template-literal
+    // expression handling because feed map values never contain ${...}.
+    if (inString) {
+      if (ch === '\\') { i++; continue; }
+      if (ch === inString) inString = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      inString = ch as '"' | "'" | '`';
+      continue;
+    }
+    if (ch === '{') { depth++; continue; }
+    if (ch === '}') { depth--; continue; }
+    if (depth !== 0) continue;
+    if (ch !== '\n') continue;
+    KEY_RE.lastIndex = i + 1;
+    const m = KEY_RE.exec(body);
+    if (m) {
+      const key = m[1] ?? m[2] ?? m[3];
+      if (key) keys.push(key);
+    }
   }
   return keys;
 }
@@ -162,12 +188,12 @@ describe('news feed key parity (client FEEDS ⇔ server VARIANT_FEEDS)', () => {
       // Sanity: every key in knownGapsClientOnly must actually be a real
       // gap. If a future server change covers one, drop it from the
       // allowlist so we don't carry phantom entries forever.
-      const stalewListed = knownGapsClientOnly.filter(k => serverKeys.has(k));
+      const staleListed = knownGapsClientOnly.filter(k => serverKeys.has(k));
       assert.deepStrictEqual(
-        stalewListed,
+        staleListed,
         [],
         `'${serverKey}' knownGapsClientOnly contains keys the server NOW covers: ` +
-        `${stalewListed.join(', ')}. Remove them from the allowlist so future drift can be detected.`,
+        `${staleListed.join(', ')}. Remove them from the allowlist so future drift can be detected.`,
       );
 
       // Sanity: every key in knownGapsClientOnly must still exist on the

--- a/tests/news-feed-key-parity.test.mts
+++ b/tests/news-feed-key-parity.test.mts
@@ -1,0 +1,184 @@
+// Static parity guard: client-side `FEEDS` category keys MUST match
+// server-side `VARIANT_FEEDS` keys for each variant.
+//
+// Background — concrete regression that motivated this test:
+//
+// The finance-variant Financial Regulation panel rendered empty for
+// every user (anon AND pro) because the client used category key
+// `'fin-regulation'` (in `src/config/feeds.ts` FINANCE_FEEDS, mirrored
+// by the panel config in `src/config/panels.ts` and a one-time storage
+// migration in `src/App.ts`) while the server still emitted the digest
+// bucket under key `'regulation'`. The client iterates
+// `Object.keys(FEEDS)` and does `digest.categories[category]`, so a
+// rename on one side without the other means the panel never finds its
+// items, the per-feed RSS fallback is gated off on web, and the body
+// renders `[]` → "No news available" + UNAVAILABLE pill.
+//
+// This guard locks the per-variant key set so any future drift fails
+// CI before reaching production.
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const CLIENT_FEEDS_PATH = resolve(__dirname, '../src/config/feeds.ts');
+const SERVER_FEEDS_PATH = resolve(__dirname, '../server/worldmonitor/news/v1/_feeds.ts');
+
+// Map client const names to the variant string used by the server.
+// The runtime selector in src/config/feeds.ts:927-937 routes
+// SITE_VARIANT === 'X' → X_FEEDS for each X in this list.
+//
+// `knownGapsClientOnly` is a documented allowlist of category keys
+// that exist client-side but have no server bucket today. Listed
+// keys still render empty / "UNAVAILABLE" on web — they're tracked
+// as deferred follow-ups (todos/257 item 9), not silent drift. Any
+// client key NOT in this allowlist must have a server match.
+const VARIANTS: Array<{ clientConst: string; serverKey: string; knownGapsClientOnly: string[] }> = [
+  {
+    clientConst: 'TECH_FEEDS',
+    serverKey: 'tech',
+    knownGapsClientOnly: [
+      // No tech-variant server buckets for these. Either add them
+      // server-side with curated RSS sources, or drop the panels
+      // client-side. Tracked in todos/257 item 9.
+      'podcasts',
+      'thinktanks',
+    ],
+  },
+  { clientConst: 'FINANCE_FEEDS', serverKey: 'finance', knownGapsClientOnly: [] },
+  { clientConst: 'COMMODITY_FEEDS', serverKey: 'commodity', knownGapsClientOnly: [] },
+  // FULL_FEEDS / HAPPY_FEEDS / ENERGY_FEEDS aren't asserted yet —
+  // those variants don't have a fully-aligned server bucket map at the
+  // time this test was written. Add them as the server catches up.
+];
+
+// Strip line + block comments so natural-language words in JSDoc/inline
+// notes can't masquerade as property keys.
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|\s)\/\/[^\n]*/g, '$1');
+}
+
+// Extract a top-level const block by name. Returns the body between the
+// outermost `{` and `}` so we can scan property keys safely.
+function extractConstObjectBody(src: string, constName: string): string | null {
+  const cleaned = stripComments(src);
+  const re = new RegExp(`(?:export\\s+)?const\\s+${constName}\\b[^=]*=\\s*\\{`);
+  const m = cleaned.match(re);
+  if (!m || typeof m.index !== 'number') return null;
+  const open = cleaned.indexOf('{', m.index);
+  if (open === -1) return null;
+  let depth = 0;
+  for (let i = open; i < cleaned.length; i++) {
+    if (cleaned[i] === '{') depth++;
+    else if (cleaned[i] === '}') {
+      depth--;
+      if (depth === 0) return cleaned.slice(open + 1, i);
+    }
+  }
+  return null;
+}
+
+// Extract the inner body for a named property of `VARIANT_FEEDS` whose
+// value is an object literal: `<variantKey>: { ... }`.
+function extractVariantBlock(src: string, variantKey: string): string | null {
+  const cleaned = stripComments(src);
+  // Match either bare or quoted variant key, but only at top of a line so
+  // we don't catch e.g. a comment-stripped sentence ending in `<word>: {`.
+  const re = new RegExp(`(?:^|\\n)\\s+(?:'${variantKey}'|"${variantKey}"|${variantKey})\\s*:\\s*\\{`, 'm');
+  const m = cleaned.match(re);
+  if (!m || typeof m.index !== 'number') return null;
+  const open = cleaned.indexOf('{', m.index);
+  if (open === -1) return null;
+  let depth = 0;
+  for (let i = open; i < cleaned.length; i++) {
+    if (cleaned[i] === '{') depth++;
+    else if (cleaned[i] === '}') {
+      depth--;
+      if (depth === 0) return cleaned.slice(open + 1, i);
+    }
+  }
+  return null;
+}
+
+// Pull category keys out of a variant body. We only count properties
+// whose VALUE is an array literal (`<key>: [`). That excludes nested
+// objects and natural-language text that happens to contain a colon.
+// Both bare identifiers and quoted (kebab-case) keys are accepted.
+function extractCategoryKeys(body: string): string[] {
+  const keys: string[] = [];
+  // Anchor to a newline so we only match top-of-line property declarations,
+  // not a colon embedded mid-string. Either:
+  //   <leading-ws><identifier>: [
+  //   <leading-ws>'<kebab-or-anything>': [
+  //   <leading-ws>"<kebab-or-anything>": [
+  const re = /\n[ \t]+(?:'([^']+)'|"([^"]+)"|([a-zA-Z_$][a-zA-Z0-9_$]*))\s*:\s*\[/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(body)) !== null) {
+    const key = m[1] ?? m[2] ?? m[3];
+    if (key) keys.push(key);
+  }
+  return keys;
+}
+
+describe('news feed key parity (client FEEDS ⇔ server VARIANT_FEEDS)', () => {
+  const clientSrc = readFileSync(CLIENT_FEEDS_PATH, 'utf-8');
+  const serverSrc = readFileSync(SERVER_FEEDS_PATH, 'utf-8');
+
+  for (const { clientConst, serverKey, knownGapsClientOnly } of VARIANTS) {
+    test(`${serverKey}: every client key has a matching server key`, () => {
+      const clientBody = extractConstObjectBody(clientSrc, clientConst);
+      assert.ok(clientBody, `failed to locate const ${clientConst} in client feeds.ts`);
+
+      const serverBody = extractVariantBlock(serverSrc, serverKey);
+      assert.ok(serverBody, `failed to locate VARIANT_FEEDS.${serverKey} in server _feeds.ts`);
+
+      const clientKeys = new Set(extractCategoryKeys(clientBody));
+      const serverKeys = new Set(extractCategoryKeys(serverBody));
+      assert.ok(clientKeys.size > 0, `client ${clientConst} parsed 0 keys`);
+      assert.ok(serverKeys.size > 0, `server VARIANT_FEEDS.${serverKey} parsed 0 keys`);
+
+      const known = new Set(knownGapsClientOnly);
+      const orphans = [...clientKeys]
+        .filter(k => !serverKeys.has(k) && !known.has(k))
+        .sort();
+      assert.deepStrictEqual(
+        orphans,
+        [],
+        `Client category keys missing on the server for variant '${serverKey}'.\n` +
+        `These categories will render empty + 'UNAVAILABLE' on the panel because the\n` +
+        `client looks up digest.categories[<key>] and the server emits a different key.\n\n` +
+        `Missing on server: ${orphans.join(', ')}\n\n` +
+        `Fix: rename the server-side key in server/worldmonitor/news/v1/_feeds.ts under\n` +
+        `VARIANT_FEEDS.${serverKey} to match the client. (Or add the key to\n` +
+        `\`knownGapsClientOnly\` in this test if the gap is intentional and tracked.)`,
+      );
+
+      // Sanity: every key in knownGapsClientOnly must actually be a real
+      // gap. If a future server change covers one, drop it from the
+      // allowlist so we don't carry phantom entries forever.
+      const stalewListed = knownGapsClientOnly.filter(k => serverKeys.has(k));
+      assert.deepStrictEqual(
+        stalewListed,
+        [],
+        `'${serverKey}' knownGapsClientOnly contains keys the server NOW covers: ` +
+        `${stalewListed.join(', ')}. Remove them from the allowlist so future drift can be detected.`,
+      );
+
+      // Sanity: every key in knownGapsClientOnly must still exist on the
+      // client. If it was renamed/dropped, the allowlist entry is stale.
+      const goneFromClient = knownGapsClientOnly.filter(k => !clientKeys.has(k));
+      assert.deepStrictEqual(
+        goneFromClient,
+        [],
+        `'${serverKey}' knownGapsClientOnly contains keys no longer in the client: ` +
+        `${goneFromClient.join(', ')}. Remove them from the allowlist.`,
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Summary

The Finance variant's **Financial Regulation** panel rendered empty + a red `UNAVAILABLE` pill for **every visitor** (anon AND pro). The cause was a client/server category-key mismatch in the news digest pipeline:

| | Key |
|---|---|
| Client (`src/config/feeds.ts` FINANCE_FEEDS) | `'fin-regulation'` |
| Client panel config (`src/config/panels.ts:478`) | `'fin-regulation'` |
| Client storage migration (`src/App.ts:542`) | `'regulation'` → `'fin-regulation'` |
| Server (`server/worldmonitor/news/v1/_feeds.ts:294`) | `'regulation'` ❌ |

`data-loader.ts:904` does `if (digest?.categories && category in digest.categories)` — keys diverge → digest miss → `isPerFeedFallbackEnabled()` is `false` on web → render `[]` → `NewsPanel` paints `'unavailable'`.

## Fix

Server-side rename only: `regulation` → `'fin-regulation'` in `VARIANT_FEEDS.finance`. The client side already shipped the rename (panel config + storage migration), so renaming server-side avoids forcing a second migration round-trip.

The lone other server reference to the string `'regulation'` (`_classifier.ts:145`) is a content-match KEYWORD, not a category key — unaffected.

## Static parity guard

New `tests/news-feed-key-parity.test.mts`:

- Asserts every client `Object.keys(FEEDS)` entry has a matching server `VARIANT_FEEDS[variant]` key for tech / finance / commodity variants.
- A documented `knownGapsClientOnly` allowlist holds entries that DO drift today, with a comment explaining each. Caught two pre-existing gaps (`podcasts`, `thinktanks` in tech variant) — those need curated server RSS sources to fix, so they're parked in the allowlist with a TODO pointer rather than slipped into this PR.
- Allowlist gets its own sanity asserts: no stale entries (key the server NOW covers) and no client-renamed entries. Drift in the allowlist itself fails CI.

Verified pre-fix the test fails with `Missing on server: fin-regulation`; post-fix all three variant assertions pass.

## Item 10 audit (`this.body.innerHTML` panels that bypass `_locked`)

Grepped `src/components/`. Only `RegionalIntelligenceBoard` writes to a private `this.body.innerHTML` ref. PR #3586 already neutralised the bug class for that panel — adding it to `WEB_PREMIUM_PANELS` makes `showGatedCta` paint the lock UI BEFORE `loadCurrent()` runs, so subsequent writes target a detached `this.body` and never reach the screen. **No code change needed for item 10 itself; audit closes clean.**

## Test plan

- [x] `npm run typecheck` — PASS
- [x] `npm run typecheck:api` — PASS
- [x] `npm run lint` — PASS (warnings only)
- [x] `npm run test:data` — PASS (7859/7859, +3 new variant parity tests)
- [x] Pre-fix: parity test FAILS with `Missing on server: fin-regulation`
- [x] Post-fix: parity test PASSES
- [x] Pre-push strict gate (boundaries, rate-limit, premium-fetch, edge-bundles, version) — PASS
- [ ] Manual: load `https://worldmonitor.app` finance variant anonymously → Financial Regulation panel renders headlines, no UNAVAILABLE pill
- [ ] Manual: log in as Pro → same panel renders identically
- [ ] Manual: trigger a deploy + cache warm-up → digest cache key `news:digest:v1:finance:en` repopulates with the new bucket name (Redis cache key on the digest endpoint is variant-keyed, not category-keyed, so the bucket rename takes effect on the next 15-min cache TTL or first cold fetch)

## Tracks

`todos/257-pending-p2-anon-broken-panels-sweep.md`:
- **Item 9** (news digest coverage drift + UNAVAILABLE badge semantics) — finance side closes here. The badge-semantics half (NewsPanel `renderNews([])` painting `'unavailable'` regardless of whether upstream errored vs window was empty) and the tech-variant `podcasts`/`thinktanks` gaps remain open.
- **Item 10** (`this.body.innerHTML` audit) — closes; only orphan was the one PR #3586 already handled.