### PR TITLE
fix(premium-fetch): only attach Clerk Bearer on PREMIUM_RPC_PATHS (Pro 401 on FRED for tech/commodity)

### DIFF
--- a/src/services/premium-fetch.ts
+++ b/src/services/premium-fetch.ts
@@ -2,10 +2,38 @@
  * Fetch wrapper for premium RPC clients.
  *
  * Injects a Clerk Bearer token (or WORLDMONITOR_API_KEY as fallback) directly
- * into every request. This is the source-of-truth auth injection for premium
- * market endpoints — no reliance on the global fetch patch.
+ * into every request for premium endpoints. This is the source-of-truth auth
+ * injection for those routes — no reliance on the global fetch patch.
+ *
+ * IMPORTANT — Bearer injection is path-gated to PREMIUM_RPC_PATHS only.
+ * Many service clients (economic, supply-chain, …) wrap the WHOLE generated
+ * client with `premiumFetch` even though only a few of its methods target
+ * a premium path. For non-premium methods (FRED batch, BLS batch, BIS,
+ * energy, etc.) attaching `Authorization: Bearer …` actively harmed Pro
+ * users with no tester key:
+ *
+ *   1. premiumFetch sets Authorization → wm-session interceptor sees it
+ *      and steps aside (no `X-WorldMonitor-Key: wms_…` is attached).
+ *   2. Server gateway only resolves Bearer JWTs on tier-gated paths
+ *      (gateway.ts: `if (isTierGated) resolveClerkSession(...)`); for
+ *      non-tier-gated paths the JWT is ignored entirely.
+ *   3. api/_api-key.js `validateApiKey()` reads ONLY X-WorldMonitor-Key.
+ *      With no key present it returns { valid: false, required: true } →
+ *      gateway emits 401.
+ *
+ * Net effect: Pro users on subdomains whose localStorage didn't carry a
+ * tester key got 401s on FRED + BLS + BIS etc., while anon users (whose
+ * premiumFetch falls through to globalThis.fetch and the interceptor
+ * attaches wms_) saw the data normally — the inverse of the expected
+ * "Pro sees more" behaviour.
+ *
+ * Fix: don't attach Bearer for non-premium paths. Fall through to the
+ * unauth path so the wm-session interceptor handles the wms_ attach.
+ * API-key holders (step 1) and tester-key holders (step 2) are unaffected
+ * — those keys travel via X-WorldMonitor-Key which works on any path.
  */
 import * as Sentry from '@sentry/browser';
+import { PREMIUM_RPC_PATHS } from '@/shared/premium-paths';
 
 /**
  * Test seam — set in unit tests to inject key/token providers without needing
@@ -34,6 +62,26 @@ function reportServerError(res: Response, input: RequestInfo | URL): void {
       extra: { path, status: res.status },
     });
   } catch { /* ignore URL parse errors */ }
+}
+
+/**
+ * Whether `input` targets a path enumerated in PREMIUM_RPC_PATHS — the
+ * canonical list of routes that REQUIRE per-user pro auth. Tier-gated
+ * endpoints (`ENDPOINT_ENTITLEMENTS` in server/_shared/entitlement-check.ts)
+ * are a strict subset of PREMIUM_RPC_PATHS at the time of writing, so this
+ * one check covers both.
+ */
+function isPremiumRpcTarget(input: RequestInfo | URL): boolean {
+  try {
+    const href = input instanceof Request ? input.url : String(input);
+    const path = new URL(href, globalThis.location?.href ?? 'https://worldmonitor.app').pathname;
+    return PREMIUM_RPC_PATHS.has(path);
+  } catch {
+    // If we can't parse the URL, fall through to the strict path: keep
+    // attaching Bearer so premium endpoints stay authenticated. This
+    // preserves prior behaviour for malformed inputs.
+    return true;
+  }
 }
 
 function uniqueNonEmptyKeys(keys: Array<string | null | undefined>): string[] {
@@ -104,25 +152,34 @@ export async function premiumFetch(
     // 401 → try the next tester key, then fall through to Clerk if none work.
   }
 
-  // 3. Clerk Pro session token (fallback for users without tester keys, or when
-  //    none of the tester keys are in WORLDMONITOR_VALID_KEYS).
-  try {
-    let token: string | null = null;
-    if (_testProviders?.getClerkToken) {
-      token = await _testProviders.getClerkToken();
-    } else {
-      const { getClerkToken } = await import('@/services/clerk');
-      token = await getClerkToken();
-    }
-    if (token) {
-      existing.set('Authorization', `Bearer ${token}`);
-      const res = await globalThis.fetch(input, { ...init, headers: existing });
-      reportServerError(res, input);
-      return res;
-    }
-  } catch { /* not signed in — fall through */ }
+  // 3. Clerk Pro session token — ONLY for premium paths. For non-premium
+  //    endpoints, attaching Bearer would suppress the wm-session
+  //    interceptor's wms_ attach and produce a 401 (see the file-level
+  //    comment for the full chain). Falling through to step 4 instead lets
+  //    the interceptor attach wms_ and the gateway accept it.
+  if (isPremiumRpcTarget(input)) {
+    try {
+      let token: string | null = null;
+      if (_testProviders?.getClerkToken) {
+        token = await _testProviders.getClerkToken();
+      } else {
+        const { getClerkToken } = await import('@/services/clerk');
+        token = await getClerkToken();
+      }
+      if (token) {
+        existing.set('Authorization', `Bearer ${token}`);
+        const res = await globalThis.fetch(input, { ...init, headers: existing });
+        reportServerError(res, input);
+        return res;
+      }
+    } catch { /* not signed in — fall through */ }
+  }
 
-  // 4. No auth — let the request through (gateway will return 401).
+  // 4. No auth — let the request through.
+  // For NON-premium paths this lands on the wm-session interceptor (which
+  // attaches wms_) → gateway accepts → 200. For premium paths reached here
+  // (no API key, no tester key, no Clerk Bearer) the gateway will return
+  // 401, which is correct.
   const res = await globalThis.fetch(input, init);
   reportServerError(res, input);
   return res;

--- a/tests/premium-fetch.test.mts
+++ b/tests/premium-fetch.test.mts
@@ -31,7 +31,14 @@ function sentHeaders(callIndex = 0): Headers {
   return new Headers((call.arguments[1] as RequestInit | undefined)?.headers);
 }
 
-const TARGET = 'https://api.worldmonitor.app/api/some-premium-rpc';
+// Real path that lives in PREMIUM_RPC_PATHS — required because Bearer
+// injection is now path-gated. Using `some-premium-rpc` (a non-existent
+// path) made every "Clerk Bearer attached" assertion silently fail under
+// the new logic. See PREMIUM_RPC_PATHS in src/shared/premium-paths.ts.
+const TARGET = 'https://api.worldmonitor.app/api/sanctions/v1/list-sanctions-pressure';
+// A real PUBLIC path used to verify the path-gating bypass: hits below
+// fetch the same way but should NOT see Bearer attached.
+const PUBLIC_TARGET = 'https://api.worldmonitor.app/api/economic/v1/get-fred-series-batch';
 
 // ---------------------------------------------------------------------------
 // Suite
@@ -162,4 +169,56 @@ describe('premiumFetch', () => {
     assert.equal(sentHeaders().get('Authorization'), 'Bearer clerk-only-token');
     assert.equal(sentHeaders().get('X-WorldMonitor-Key'), null);
   });
+
+  // ---------------------------------------------------------------------
+  // Path-gated Bearer injection — regression for "Pro user 401s on FRED"
+  // ---------------------------------------------------------------------
+  //
+  // The same RPC client is wrapped with premiumFetch end-to-end even
+  // though only some methods target a premium path. Attaching a Clerk
+  // Bearer JWT to non-premium calls suppresses the wm-session
+  // interceptor's wms_ attach (premiumFetch sets Authorization → the
+  // interceptor steps aside) and the gateway only resolves Bearer JWTs
+  // on tier-gated paths. Result: Pro users without tester keys 401'd
+  // on every FRED / BLS / BIS call while anon users (whose premiumFetch
+  // falls through and the interceptor attaches wms_) saw the data.
+  //
+  // The fix: only attach Bearer when the path is in PREMIUM_RPC_PATHS.
+  // Public paths fall through so the wm-session interceptor handles
+  // wms_ attach.
+
+  it('non-premium path: Clerk JWT NOT attached, falls through to plain fetch', async () => {
+    setup({ testerKey: '', clerkToken: 'clerk-token-should-be-skipped' });
+    const res = await premiumFetch(PUBLIC_TARGET);
+    assert.equal(res.status, 200);
+    assert.equal(fetchMock.mock.calls.length, 1);
+    assert.equal(
+      sentHeaders().get('Authorization'),
+      null,
+      'Bearer must NOT be attached on non-premium paths — gateway only resolves it on tier-gated routes',
+    );
+    assert.equal(sentHeaders().get('X-WorldMonitor-Key'), null);
+  });
+
+  it('non-premium path: tester key still attached (works on any path)', async () => {
+    setup({ testerKey: 'valid-key', clerkToken: 'clerk-token' });
+    await premiumFetch(PUBLIC_TARGET);
+    assert.equal(sentHeaders(0).get('X-WorldMonitor-Key'), 'valid-key');
+    assert.equal(sentHeaders(0).get('Authorization'), null);
+  });
+
+  it('premium path: Clerk JWT IS attached (regression guard against over-gating)', async () => {
+    setup({ testerKey: '', clerkToken: 'clerk-only-token' });
+    await premiumFetch(TARGET);
+    assert.equal(sentHeaders().get('Authorization'), 'Bearer clerk-only-token');
+  });
+
+  it('non-premium path: pre-set Authorization still passes through unchanged', async () => {
+    // Caller-supplied auth was always passed through; verify the
+    // path-gating change didn't accidentally alter that contract.
+    setup({ testerKey: '', clerkToken: 'unused' });
+    await premiumFetch(PUBLIC_TARGET, { headers: { Authorization: 'Bearer caller-supplied' } });
+    assert.equal(sentHeaders().get('Authorization'), 'Bearer caller-supplied');
+  });
 });
+


### PR DESCRIPTION
## Symptom

User report: logged-in Pro users on **tech** and **commodity** variants saw *"Upstream API unavailable"* on the Macro Stress (economic) panel, with the console emitting repeated `get-fred-series-batch:1 ... 401` errors. Anonymous users on the **same** variants saw the data correctly. The **full** variant worked for Pro users.

The inverse-of-expected "anon sees more, Pro sees less" pattern was the smoking-gun signature.

## Root cause

Many RPC clients (`economic`, `supply-chain`, …) wrap the **whole** generated client with `premiumFetch` even though only a few methods target a path in `PREMIUM_RPC_PATHS`. The current `premiumFetch` attaches `Authorization: Bearer <jwt>` for **any** Pro caller, including on non-premium endpoints like `/api/economic/v1/get-fred-series-batch`.

For a Pro user with no tester key hitting a non-premium endpoint:

1. `premiumFetch` sets `Authorization` → the wm-session interceptor sees it and **steps aside**, never attaching `X-WorldMonitor-Key: wms_…` (`wm-session.ts:155-160`).
2. Server gateway only resolves Bearer JWTs on **tier-gated** paths (`gateway.ts:409 if (isTierGated) resolveClerkSession(...)`); for non-tier-gated paths the JWT is ignored entirely.
3. `validateApiKey()` reads ONLY `X-WorldMonitor-Key`. With no key present it returns `{ valid: false, required: true }` → gateway emits **401**.

For an **anon** user the same call falls through to plain `globalThis.fetch`, the interceptor attaches `wms_`, and the gateway accepts it.

The variant difference (full works) is consistent with: the user has `wm-pro-key` / `wm-widget-key` in `worldmonitor.app`'s localStorage, which the per-subdomain `tech.worldmonitor.app` / `commodity.worldmonitor.app` localStorage doesn't carry. Tester keys take precedence over Bearer in `premiumFetch:96`, so on full the tester key works; on subdomains it falls through to the broken Bearer path.

## Fix

Path-gate the Bearer attach: only fire it when the request URL's pathname is in `PREMIUM_RPC_PATHS`. Public paths fall through so the wm-session interceptor handles `wms_`. API-key holders (`WORLDMONITOR_API_KEY`, step 1) and tester-key holders (step 2) are unaffected — those auth shapes travel via `X-WorldMonitor-Key` which works on any path.

`ENDPOINT_ENTITLEMENTS` (the tier-gated set in `server/_shared/entitlement-check.ts`) is a strict subset of `PREMIUM_RPC_PATHS` at the time of writing, so the single membership check covers both gates.

## Behaviour change

| User type | Endpoint | Before | After |
|---|---|---|---|
| Pro (Bearer only) | non-premium | **401** | 200 (wms_ attached) |
| Pro (Bearer only) | premium | 200 (Bearer) | 200 (Bearer) — unchanged |
| Pro (tester key) | any | 200 — unchanged | 200 — unchanged |
| Anon (wms_) | non-premium | 200 — unchanged | 200 — unchanged |
| Anon (wms_) | premium | 401 — unchanged | 401 — unchanged |
| Desktop (`WORLDMONITOR_API_KEY`) | any | 200 — unchanged | 200 — unchanged |

## Tests

4 new regression assertions in `tests/premium-fetch.test.mts`:
- non-premium path: Clerk JWT **not** attached, falls through
- non-premium path: tester key still attached
- premium path: Clerk JWT **is** attached (over-gating regression guard)
- non-premium path: pre-set `Authorization` still passes through

Pre-fix verification: stashed only `src/services/premium-fetch.ts` and re-ran the test — `non-premium path: Clerk JWT NOT attached` fails as expected. Post-fix all 13 assertions pass.

Existing test target was renamed from a fake URL (`some-premium-rpc`) to a real entry in `PREMIUM_RPC_PATHS` (`list-sanctions-pressure`) so the existing "Bearer attached" assertions remain valid under the path-gated logic.

## Test plan

- [x] `npm run typecheck` — PASS
- [x] `npm run typecheck:api` — PASS
- [x] `npm run lint` — PASS (warnings only)
- [x] `npm run test:data` — PASS (7863/7863)
- [x] `tests/premium-fetch.test.mts` — PASS (13/13, including 4 new regression assertions)
- [x] Pre-fix regression test FAILS as expected
- [x] Pre-push strict gate (boundaries / rate-limit / premium-fetch / edge-bundles / version) — PASS
- [ ] Manual: open `tech.worldmonitor.app` as logged-in Pro, confirm Macro Stress (economic) panel renders, no `get-fred-series-batch` 401 in console
- [ ] Manual: open `commodity.worldmonitor.app` as logged-in Pro, confirm same
- [ ] Manual: open `worldmonitor.app` as logged-in Pro, confirm Macro Stress still renders (no regression)
- [ ] Manual: open `tech.worldmonitor.app` anonymously, confirm panel still renders (anon path unchanged)
- [ ] Manual: open `tech.worldmonitor.app` as logged-in Pro, confirm a premium endpoint (e.g. stock analysis) still works (Bearer still attached for premium paths)

## Tracks

Net effect: Pro users without tester keys now see public economic data (FRED, BLS, BIS, energy) on every subdomain, matching the behaviour anon users already had. Surfaces a class of bug parallel to PRs #3584 / #3588 (anon Pro-RPC 401 spam) — same auth-layer mismatch, opposite direction.