### PR TITLE
feat(health-readiness): Sprint 1 — content-age probe infra

### DIFF
--- a/api/_seed-envelope.js
+++ b/api/_seed-envelope.js
@@ -29,10 +29,15 @@ export function stripSeedEnvelope(raw) {
   return unwrapEnvelope(raw).data;
 }
 
-export function buildEnvelope({ fetchedAt, recordCount, sourceVersion, schemaVersion, state, failedDatasets, errorReason, groupId, data }) {
+export function buildEnvelope({ fetchedAt, recordCount, sourceVersion, schemaVersion, state, failedDatasets, errorReason, groupId, newestItemAt, oldestItemAt, maxContentAgeMin, data }) {
   const _seed = { fetchedAt, recordCount, sourceVersion, schemaVersion, state };
   if (failedDatasets != null) _seed.failedDatasets = failedDatasets;
   if (errorReason != null) _seed.errorReason = errorReason;
   if (groupId != null) _seed.groupId = groupId;
+  if (maxContentAgeMin !== undefined) {
+    _seed.newestItemAt = newestItemAt ?? null;
+    _seed.oldestItemAt = oldestItemAt ?? null;
+    _seed.maxContentAgeMin = maxContentAgeMin;
+  }
   return { _seed, data };
 }

--- a/api/health.js
+++ b/api/health.js
@@ -587,12 +587,22 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   if (meta && typeof meta.maxContentAgeMin === 'number') {
     const newestItemAt = (typeof meta.newestItemAt === 'number') ? meta.newestItemAt : null;
     const contentAgeMin = newestItemAt == null ? null : Math.round((now - newestItemAt) / 60_000);
+    // Future-dated newestItemAt (contentAgeMin < 0) is suspicious data, not
+    // fresh data: an upstream that publishes timestamps in the future is
+    // either confusing forecasts with observations, mishandling timezones,
+    // or running on a skewed clock. Treat as STALE so the signal surfaces
+    // — without this, `contentAgeMin > maxContentAgeMin` is false for any
+    // negative number and the staleness check silently passes. The
+    // negative `contentAgeMin` is preserved on the wire so operators can
+    // see HOW far in the future the timestamp was (a -10-minute drift is
+    // a clock-skew nit; -8760 minutes is a year-from-now corruption).
+    const isFutureDated = contentAgeMin != null && contentAgeMin < 0;
     contentAge = {
       newestItemAt,
       oldestItemAt: (typeof meta.oldestItemAt === 'number') ? meta.oldestItemAt : null,
       maxContentAgeMin: meta.maxContentAgeMin,
       contentAgeMin,
-      contentStale: contentAgeMin == null || contentAgeMin > meta.maxContentAgeMin,
+      contentStale: contentAgeMin == null || isFutureDated || contentAgeMin > meta.maxContentAgeMin,
     };
   }
   return { seedAge, seedStale, seedError: false, metaReadFailed: false, metaCount, contentAge };

--- a/api/health.js
+++ b/api/health.js
@@ -555,12 +555,12 @@ function strlenIsData(strlen) {
 
 function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   if (!seedCfg) {
-    return { seedAge: null, seedStale: null, seedError: false, metaReadFailed: false, metaCount: null };
+    return { seedAge: null, seedStale: null, seedError: false, metaReadFailed: false, metaCount: null, contentAge: null };
   }
   // Per-command Redis errors on the GET seed-meta half of the pipeline must
   // not silently fall through to STALE_SEED — promote to REDIS_PARTIAL.
   if (keyMetaErrors.get(seedCfg.key)) {
-    return { seedAge: null, seedStale: null, seedError: false, metaReadFailed: true, metaCount: null };
+    return { seedAge: null, seedStale: null, seedError: false, metaReadFailed: true, metaCount: null, contentAge: null };
   }
   // Unwrap through the envelope helper. Legacy seed-meta is a bare
   // `{ fetchedAt, recordCount, sourceVersion, status? }` object with no `_seed`
@@ -569,7 +569,7 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
   // the dependency so behavior stays byte-identical in PR 1.
   const meta = unwrapEnvelope(parseRedisValue(keyMetaValues.get(seedCfg.key))).data;
   if (meta?.status === 'error') {
-    return { seedAge: null, seedStale: true, seedError: true, metaReadFailed: false, metaCount: null };
+    return { seedAge: null, seedStale: true, seedError: true, metaReadFailed: false, metaCount: null, contentAge: null };
   }
   let seedAge = null;
   let seedStale = true;
@@ -578,7 +578,24 @@ function readSeedMeta(seedCfg, keyMetaValues, keyMetaErrors, now) {
     seedStale = seedAge > seedCfg.maxStaleMin;
   }
   const metaCount = meta?.count ?? meta?.recordCount ?? null;
-  return { seedAge, seedStale, seedError: false, metaReadFailed: false, metaCount };
+  // Content-age trio (2026-05-04 health-readiness plan). Presence of
+  // maxContentAgeMin is the opt-in signal — legacy seeders without it
+  // get contentAge: null and skip the STALE_CONTENT branch in classifyKey.
+  // newestItemAt may be explicit null when seeder's contentMeta returned null
+  // (no usable item timestamps); classifier reads that as STALE_CONTENT.
+  let contentAge = null;
+  if (meta && typeof meta.maxContentAgeMin === 'number') {
+    const newestItemAt = (typeof meta.newestItemAt === 'number') ? meta.newestItemAt : null;
+    const contentAgeMin = newestItemAt == null ? null : Math.round((now - newestItemAt) / 60_000);
+    contentAge = {
+      newestItemAt,
+      oldestItemAt: (typeof meta.oldestItemAt === 'number') ? meta.oldestItemAt : null,
+      maxContentAgeMin: meta.maxContentAgeMin,
+      contentAgeMin,
+      contentStale: contentAgeMin == null || contentAgeMin > meta.maxContentAgeMin,
+    };
+  }
+  return { seedAge, seedStale, seedError: false, metaReadFailed: false, metaCount, contentAge };
 }
 
 function isCascadeCovered(name, hasData, keyStrens, keyErrors) {
@@ -612,7 +629,7 @@ function classifyKey(name, redisKey, opts, ctx) {
 
   const strlen = keyStrens.get(redisKey) ?? 0;
   const hasData = strlenIsData(strlen);
-  const { seedAge, seedStale, seedError, metaCount } = meta;
+  const { seedAge, seedStale, seedError, metaCount, contentAge } = meta;
 
   // When the data key is gone the meta count is meaningless; force records=0
   // so we never display the contradictory "EMPTY records=N>0" pair (item 1).
@@ -639,12 +656,29 @@ function classifyKey(name, redisKey, opts, ctx) {
   // to COVERAGE_PARTIAL (warn) instead of reporting OK. Producer must write
   // seed-meta.recordCount using the *covered* count, not the shape size.
   else if (seedCfg?.minRecordCount != null && records < seedCfg.minRecordCount) status = 'COVERAGE_PARTIAL';
+  // Content-age check (opt-in via runSeed contentMeta + maxContentAgeMin).
+  // Fires AFTER all earlier failure paths so STALE_SEED, COVERAGE_PARTIAL,
+  // EMPTY_*, etc. take precedence — STALE_CONTENT is "the seeder is healthy
+  // and the data set is sized correctly, but the content itself is older than
+  // the seeder's content-age budget" (e.g. WHO Disease Outbreak News hasn't
+  // published in >9 days for the disease-outbreaks pilot).
+  // The opt-in signal is contentAge being non-null in seed-meta (presence of
+  // meta.maxContentAgeMin); legacy seeders without it skip this branch.
+  // 2026-05-04 health-readiness plan, Sprint 1.
+  else if (contentAge && contentAge.contentStale) status = 'STALE_CONTENT';
   else status = 'OK';
 
   const entry = { status, records };
   if (seedAge !== null) entry.seedAgeMin = seedAge;
   if (seedCfg) entry.maxStaleMin = seedCfg.maxStaleMin;
   if (seedCfg?.minRecordCount != null) entry.minRecordCount = seedCfg.minRecordCount;
+  // Surface content-age fields when seeder opted in (presence of
+  // meta.maxContentAgeMin). Operators can distinguish "stale content" from
+  // "stale seeder run" at a glance.
+  if (contentAge) {
+    entry.contentAgeMin = contentAge.contentAgeMin;          // null when contentMeta returned null
+    entry.maxContentAgeMin = contentAge.maxContentAgeMin;
+  }
   return entry;
 }
 
@@ -656,6 +690,11 @@ const STATUS_COUNTS = {
   EMPTY_ON_DEMAND: 'warn',
   REDIS_PARTIAL: 'warn',
   COVERAGE_PARTIAL: 'warn',
+  // Content-age signal — seeder is healthy but upstream stopped publishing.
+  // Operator can't fix upstream cadence, so de-rank vs. STALE_SEED in alerting
+  // (both bucket to 'warn' — overall status is `degraded`, not `critical`).
+  // 2026-05-04 health-readiness plan, Sprint 1.
+  STALE_CONTENT: 'warn',
   EMPTY: 'crit',
   EMPTY_DATA: 'crit',
 };
@@ -836,3 +875,13 @@ export default async function handler(req, ctx) {
     headers,
   });
 }
+
+// Test-only exports. Not part of the public edge handler surface — Vercel's
+// runtime invokes only `default export`. These let scoped unit tests exercise
+// the classifier without standing up the full bootstrap-keys + Redis pipeline.
+// 2026-05-04 health-readiness plan, Sprint 1 test plan (Codex round 2 P1).
+export const __testing__ = {
+  readSeedMeta,
+  classifyKey,
+  STATUS_COUNTS,
+};

--- a/scripts/_seed-contract.mjs
+++ b/scripts/_seed-contract.mjs
@@ -44,6 +44,15 @@ const OPTIONAL_FIELDS = new Set([
   'groupMembers',
   'recordCount',     // legacy — kept optional through PR 2, removed in PR 3 in favor of declareRecords
   'metaTtlSeconds',  // legacy — used today by writeSeedMeta / writeExtraKeyWithMeta (e.g. scripts/seed-jodi-gas.mjs); removed in PR 3 when legacy meta writes go away
+  // Content-age contract (2026-05-04 health-readiness plan).
+  // `contentMeta` is a function `(rawData) => {newestItemAt, oldestItemAt} | null`
+  // invoked by runSeed BEFORE publishTransform so seeders can compute item-age
+  // metadata from helper fields that are stripped before publish.
+  // `maxContentAgeMin` is the seeder's content-staleness budget in minutes.
+  // The two opt in TOGETHER: declaring contentMeta without maxContentAgeMin
+  // (or vice-versa) is a contract violation — see the cross-field check below.
+  'contentMeta',
+  'maxContentAgeMin',
 ]);
 
 /**
@@ -112,6 +121,35 @@ export function validateDescriptor(descriptor) {
       `runSeed descriptor populationMode must be 'scheduled' or 'on_demand', got ${descriptor.populationMode}`,
       { descriptor, field: 'populationMode' }
     );
+  }
+
+  // Content-age contract: `contentMeta` and `maxContentAgeMin` opt in together.
+  // Declaring one without the other is a misconfig that would either silently
+  // disable the check (the original `?? null` trap) or produce a function call
+  // to a non-existent budget. Hard-fail at config time.
+  const hasContentMeta = descriptor.contentMeta != null;
+  const hasMaxContentAge = descriptor.maxContentAgeMin != null;
+  if (hasContentMeta !== hasMaxContentAge) {
+    const missing = hasContentMeta ? 'maxContentAgeMin' : 'contentMeta';
+    throw new SeedContractError(
+      `runSeed descriptor declares ${hasContentMeta ? 'contentMeta' : 'maxContentAgeMin'} but is missing ${missing} — both must be present together`,
+      { descriptor, field: missing }
+    );
+  }
+  if (hasContentMeta && typeof descriptor.contentMeta !== 'function') {
+    throw new SeedContractError(
+      `runSeed descriptor contentMeta must be a function, got ${typeof descriptor.contentMeta}`,
+      { descriptor, field: 'contentMeta' }
+    );
+  }
+  if (hasMaxContentAge) {
+    const v = descriptor.maxContentAgeMin;
+    if (!Number.isInteger(v) || v <= 0) {
+      throw new SeedContractError(
+        `runSeed descriptor maxContentAgeMin must be a positive integer (minutes), got ${JSON.stringify(v)}`,
+        { descriptor, field: 'maxContentAgeMin' }
+      );
+    }
   }
 
   const known = new Set([...REQUIRED_FIELDS, ...OPTIONAL_FIELDS]);

--- a/scripts/_seed-envelope-source.mjs
+++ b/scripts/_seed-envelope-source.mjs
@@ -76,11 +76,24 @@ export function stripSeedEnvelope(raw) {
  * Build an envelope for a seeder's successful run. Does NOT validate the seed
  * meta fields beyond what the type expects; `validateDescriptor` in
  * scripts/_seed-contract.mjs handles pre-publish validation.
+ *
+ * Content-age fields (`newestItemAt`, `oldestItemAt`, `maxContentAgeMin`) are
+ * the opt-in content-freshness contract from the 2026-05-04 health-readiness
+ * plan. The presence of `maxContentAgeMin` is the opt-in signal: when set,
+ * health classifies the entry against `newestItemAt`/`maxContentAgeMin`. The
+ * other two tag along — `newestItemAt` may be explicit `null` when the
+ * seeder's `contentMeta` returned null (no usable item timestamps), which
+ * the classifier reads as STALE_CONTENT.
  */
-export function buildEnvelope({ fetchedAt, recordCount, sourceVersion, schemaVersion, state, failedDatasets, errorReason, groupId, data }) {
+export function buildEnvelope({ fetchedAt, recordCount, sourceVersion, schemaVersion, state, failedDatasets, errorReason, groupId, newestItemAt, oldestItemAt, maxContentAgeMin, data }) {
   const _seed = { fetchedAt, recordCount, sourceVersion, schemaVersion, state };
   if (failedDatasets != null) _seed.failedDatasets = failedDatasets;
   if (errorReason != null) _seed.errorReason = errorReason;
   if (groupId != null) _seed.groupId = groupId;
+  if (maxContentAgeMin !== undefined) {
+    _seed.newestItemAt = newestItemAt ?? null;
+    _seed.oldestItemAt = oldestItemAt ?? null;
+    _seed.maxContentAgeMin = maxContentAgeMin;
+  }
   return { _seed, data };
 }

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -262,7 +262,7 @@ export async function atomicPublish(canonicalKey, data, validateFn, ttlSeconds, 
   return { payloadBytes, recordCount: Array.isArray(data) ? data.length : null };
 }
 
-export async function writeFreshnessMetadata(domain, resource, count, source, ttlSeconds, fetchedAtOverride) {
+export async function writeFreshnessMetadata(domain, resource, count, source, ttlSeconds, fetchedAtOverride, contentAge) {
   const { url, token } = getRedisCredentials();
   const metaKey = `seed-meta:${domain}:${resource}`;
   const meta = {
@@ -274,6 +274,15 @@ export async function writeFreshnessMetadata(domain, resource, count, source, tt
     recordCount: count,
     sourceVersion: source || '',
   };
+  // Content-age trio (2026-05-04 health-readiness plan). Pass when the seeder
+  // opted in. Presence of maxContentAgeMin is the opt-in signal that the
+  // health classifier reads. newestItemAt/oldestItemAt may be explicit null
+  // when contentMeta returned null — classifier reads as STALE_CONTENT.
+  if (contentAge && typeof contentAge === 'object' && Number.isInteger(contentAge.maxContentAgeMin)) {
+    meta.newestItemAt = contentAge.newestItemAt ?? null;
+    meta.oldestItemAt = contentAge.oldestItemAt ?? null;
+    meta.maxContentAgeMin = contentAge.maxContentAgeMin;
+  }
   // Use the data TTL if it exceeds 7 days so monthly/annual seeds don't lose
   // their meta key before the health check maxStaleMin threshold is reached.
   const metaTtl = Math.max(86400 * 7, ttlSeconds || 0);
@@ -312,10 +321,23 @@ export async function readCanonicalEnvelopeMeta(canonicalKey) {
     if (!seed || typeof seed !== 'object') return null;
     if (typeof seed.fetchedAt !== 'number' || typeof seed.recordCount !== 'number') return null;
     if (seed.recordCount <= 0) return null;
+    // Content-age fields propagate through the validate-fail mirror so the
+    // health classifier doesn't lose the STALE_CONTENT signal exactly when
+    // last-good-with-stale-content data is being served (Codex round 1 P0b).
+    // All three fields are optional in the envelope; carry them through as a
+    // trio when present, otherwise undefined (caller checks).
+    const contentAge = (typeof seed.maxContentAgeMin === 'number')
+      ? {
+          newestItemAt: typeof seed.newestItemAt === 'number' ? seed.newestItemAt : null,
+          oldestItemAt: typeof seed.oldestItemAt === 'number' ? seed.oldestItemAt : null,
+          maxContentAgeMin: seed.maxContentAgeMin,
+        }
+      : undefined;
     return {
       fetchedAt: seed.fetchedAt,
       recordCount: seed.recordCount,
       sourceVersion: typeof seed.sourceVersion === 'string' ? seed.sourceVersion : '',
+      contentAge,
     };
   } catch {
     return null;
@@ -925,6 +947,8 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     sourceVersion,         // new — required when declareRecords is passed
     schemaVersion,         // new — required when declareRecords is passed
     zeroIsValid = false,   // new — when true, recordCount=0 is OK_ZERO, not RETRY
+    contentMeta,           // (rawData) => {newestItemAt, oldestItemAt} | null
+    maxContentAgeMin,      // positive integer minutes — opts in together with contentMeta
   } = opts;
   const contractMode = typeof declareRecords === 'function';
   if (contractMode) {
@@ -935,6 +959,20 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     if (typeof opts.maxStaleMin !== 'number') missing.push('maxStaleMin');
     if (missing.length) {
       console.warn(`  [seed-contract] ${domain}:${resource} missing fields: ${missing.join(', ')} — required in PR 3`);
+    }
+  }
+  // Content-age contract validation (2026-05-04 health-readiness plan).
+  // contentMeta and maxContentAgeMin opt in TOGETHER. Hard-fail at config time
+  // on misconfig — silently disabling the check would defeat the alarm.
+  const contentAgeOptedIn = contentMeta != null || maxContentAgeMin != null;
+  if (contentAgeOptedIn) {
+    if (typeof contentMeta !== 'function') {
+      console.error(`  CONTRACT VIOLATION: ${domain}:${resource} declares maxContentAgeMin without contentMeta function`);
+      process.exit(1);
+    }
+    if (!Number.isInteger(maxContentAgeMin) || maxContentAgeMin <= 0) {
+      console.error(`  CONTRACT VIOLATION: ${domain}:${resource} maxContentAgeMin must be a positive integer (minutes), got ${JSON.stringify(maxContentAgeMin)}`);
+      process.exit(1);
     }
   }
   const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -1037,6 +1075,32 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
 
   // Phase 2: Publish to Redis (rethrow on failure — data was fetched but not stored)
   try {
+    // Content-age contract: invoke contentMeta on RAW fetcher output BEFORE
+    // publishTransform runs. This lets seeders carry pre-publish helper fields
+    // (e.g. _publishedAtIsSynthetic) on items that contentMeta reads, then
+    // strip them via publishTransform before they reach the canonical key
+    // and downstream clients. See the 2026-05-04 health-readiness plan,
+    // Sprint 1 / Sprint 2 disease-outbreaks pilot.
+    //
+    // contentMeta returning null OR throwing both signal "no usable item
+    // timestamps" → write newestItemAt: null in the envelope, which the
+    // health classifier reads as STALE_CONTENT.
+    let contentNewestAt = null;
+    let contentOldestAt = null;
+    if (contentAgeOptedIn) {
+      try {
+        const result = contentMeta(data);
+        if (result && typeof result === 'object'
+            && Number.isFinite(result.newestItemAt) && result.newestItemAt > 0
+            && Number.isFinite(result.oldestItemAt) && result.oldestItemAt > 0) {
+          contentNewestAt = result.newestItemAt;
+          contentOldestAt = result.oldestItemAt;
+        }
+      } catch (err) {
+        console.warn(`  [content-age] ${domain}:${resource}: contentMeta threw, treating as null: ${err?.message || err}`);
+      }
+    }
+
     const publishData = publishTransform ? publishTransform(data) : data;
 
     // In contract mode, resolve recordCount from declareRecords BEFORE publish so
@@ -1069,6 +1133,16 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
           schemaVersion: schemaVersion || 1,
           state: contractState,
         };
+        // Carry content-age fields when seeder opted in. Presence of
+        // maxContentAgeMin in the envelope is the opt-in signal for the
+        // health classifier. newestItemAt/oldestItemAt may be explicit null
+        // when contentMeta returned null OR all items lacked usable
+        // timestamps — classifier reads those as STALE_CONTENT.
+        if (contentAgeOptedIn) {
+          envelopeMeta.newestItemAt = contentNewestAt;
+          envelopeMeta.oldestItemAt = contentOldestAt;
+          envelopeMeta.maxContentAgeMin = maxContentAgeMin;
+        }
       }
     }
 
@@ -1124,15 +1198,20 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
         //   - canonical envelope has recordCount <= 0
         const canonicalMeta = await readCanonicalEnvelopeMeta(canonicalKey);
         if (canonicalMeta) {
+          // Pass-through canonical's contentAge so health doesn't lose the
+          // STALE_CONTENT signal exactly when last-good-with-stale-content
+          // data is being served (Codex round 1 P0b).
           await writeFreshnessMetadata(
             domain, resource, canonicalMeta.recordCount,
             canonicalMeta.sourceVersion || opts.sourceVersion,
             ttlSeconds,
             canonicalMeta.fetchedAt,
+            canonicalMeta.contentAge,
           );
           console.log(
             `  SKIPPED: validation failed (empty/partial fetch) — seed-meta mirrors canonical ` +
-            `(fetchedAt=${new Date(canonicalMeta.fetchedAt).toISOString()}, recordCount=${canonicalMeta.recordCount}); ` +
+            `(fetchedAt=${new Date(canonicalMeta.fetchedAt).toISOString()}, recordCount=${canonicalMeta.recordCount}` +
+            `${canonicalMeta.contentAge ? `, newestItemAt=${canonicalMeta.contentAge.newestItemAt == null ? 'null' : new Date(canonicalMeta.contentAge.newestItemAt).toISOString()}` : ''}); ` +
             `existing cache TTL extended`,
           );
         } else {
@@ -1192,7 +1271,20 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
       await afterPublish(data, { canonicalKey, ttlSeconds, recordCount, runId });
     }
 
-    const meta = await writeFreshnessMetadata(domain, resource, recordCount, opts.sourceVersion, ttlSeconds);
+    // Mirror content-age fields into seed-meta when the seeder opted in.
+    // The contentAge object is the same one we just stamped into the canonical
+    // envelope above (envelopeMeta.{newestItemAt, oldestItemAt, maxContentAgeMin}),
+    // so seed-meta and the canonical _seed block stay in lockstep.
+    const successContentAge = (contentAgeOptedIn && envelopeMeta) ? {
+      newestItemAt: envelopeMeta.newestItemAt,
+      oldestItemAt: envelopeMeta.oldestItemAt,
+      maxContentAgeMin: envelopeMeta.maxContentAgeMin,
+    } : undefined;
+    const meta = await writeFreshnessMetadata(
+      domain, resource, recordCount, opts.sourceVersion, ttlSeconds,
+      undefined,            // fetchedAtOverride — success path uses now
+      successContentAge,
+    );
 
     const durationMs = Date.now() - startMs;
     logSeedResult(domain, recordCount, durationMs, { payloadBytes, contractMode, state: contractState || 'LEGACY' });

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1272,13 +1272,23 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     }
 
     // Mirror content-age fields into seed-meta when the seeder opted in.
-    // The contentAge object is the same one we just stamped into the canonical
-    // envelope above (envelopeMeta.{newestItemAt, oldestItemAt, maxContentAgeMin}),
-    // so seed-meta and the canonical _seed block stay in lockstep.
-    const successContentAge = (contentAgeOptedIn && envelopeMeta) ? {
-      newestItemAt: envelopeMeta.newestItemAt,
-      oldestItemAt: envelopeMeta.oldestItemAt,
-      maxContentAgeMin: envelopeMeta.maxContentAgeMin,
+    //
+    // Read content-age from the LOCAL `contentNewestAt`/`contentOldestAt`
+    // computed back at line ~1088 — NOT from `envelopeMeta`. The local
+    // values are populated whenever the seeder opted in (`contentAgeOptedIn`
+    // === true); `envelopeMeta` is null for non-contract-mode seeders, so
+    // gating on `envelopeMeta` silently dropped the content-age signal for
+    // every seeder that hadn't migrated to contract mode yet — defeating
+    // the opt-in for the majority of the cohort.
+    //
+    // Both branches publish the same trio (envelopeMeta carries the same
+    // values when contract mode populates it at line ~1141); reading from
+    // the local source unifies the two paths and makes the seed-meta
+    // mirror match the contract-mode envelope exactly.
+    const successContentAge = contentAgeOptedIn ? {
+      newestItemAt: contentNewestAt,
+      oldestItemAt: contentOldestAt,
+      maxContentAgeMin,
     } : undefined;
     const meta = await writeFreshnessMetadata(
       domain, resource, recordCount, opts.sourceVersion, ttlSeconds,

--- a/server/_shared/seed-envelope.ts
+++ b/server/_shared/seed-envelope.ts
@@ -21,6 +21,14 @@ export interface SeedMeta {
   failedDatasets?: string[];
   errorReason?: string;
   groupId?: string;
+  // Content-age trio (opt-in via runSeed `contentMeta` + `maxContentAgeMin`).
+  // Presence of `maxContentAgeMin` is the opt-in signal. `newestItemAt` /
+  // `oldestItemAt` may be explicit `null` when contentMeta returned null
+  // (no usable item timestamps), which the health classifier reads as
+  // STALE_CONTENT. See docs/plans/2026-05-04-001-feat-health-readiness-probe-content-age-plan.md
+  newestItemAt?: number | null;
+  oldestItemAt?: number | null;
+  maxContentAgeMin?: number;
 }
 
 export interface SeedEnvelope<T = unknown> {
@@ -66,12 +74,20 @@ export function buildEnvelope(input: {
   failedDatasets?: string[];
   errorReason?: string;
   groupId?: string;
+  newestItemAt?: number | null;
+  oldestItemAt?: number | null;
+  maxContentAgeMin?: number;
   data: unknown;
 }): SeedEnvelope {
-  const { fetchedAt, recordCount, sourceVersion, schemaVersion, state, failedDatasets, errorReason, groupId, data } = input;
+  const { fetchedAt, recordCount, sourceVersion, schemaVersion, state, failedDatasets, errorReason, groupId, newestItemAt, oldestItemAt, maxContentAgeMin, data } = input;
   const _seed: SeedMeta = { fetchedAt, recordCount, sourceVersion, schemaVersion, state };
   if (failedDatasets != null) _seed.failedDatasets = failedDatasets;
   if (errorReason != null) _seed.errorReason = errorReason;
   if (groupId != null) _seed.groupId = groupId;
+  if (maxContentAgeMin !== undefined) {
+    _seed.newestItemAt = newestItemAt ?? null;
+    _seed.oldestItemAt = oldestItemAt ?? null;
+    _seed.maxContentAgeMin = maxContentAgeMin;
+  }
   return { _seed, data };
 }

--- a/tests/health-content-age.test.mjs
+++ b/tests/health-content-age.test.mjs
@@ -91,6 +91,52 @@ test('readSeedMeta marks contentStale=true when newestItemAt is older than budge
   assert.equal(meta.contentAge.contentStale, true, '11d > 9d → contentStale');
 });
 
+// Greptile PR #3596 P2 regression — future-dated newestItemAt produces a
+// negative contentAgeMin. Pre-fix `contentAgeMin > maxContentAgeMin` was
+// false for any negative value (negative is not greater than any positive
+// budget), so a feed publishing future timestamps silently passed the
+// staleness check. Post-fix: future-dated newestItemAt is treated as
+// STALE so the suspicious-data signal surfaces.
+test('readSeedMeta marks contentStale=true when newestItemAt is in the future (suspicious-data signal)', () => {
+  const seedCfg = { key: 'seed-meta:future-dated', maxStaleMin: 2880 };
+  // newestItemAt 1 hour in the future — could be timezone bug, clock skew,
+  // or upstream confusing forecasts with observations. Pre-fix this would
+  // have computed contentAgeMin = -60 and slipped past the staleness check.
+  const newestItemAt = NOW + 60 * ONE_MIN_MS;
+  const ctx = makeCtx({
+    keyMetaValues: new Map([['seed-meta:future-dated', metaValueOf({
+      fetchedAt: NOW - 10 * ONE_MIN_MS,
+      recordCount: 50,
+      newestItemAt,
+      oldestItemAt: NOW - 60 * ONE_DAY_MS,
+      maxContentAgeMin: 12960,    // 9 days
+    })]]),
+  });
+  const meta = readSeedMeta(seedCfg, ctx.keyMetaValues, ctx.keyMetaErrors, ctx.now);
+  assert.equal(meta.contentAge.contentStale, true,
+    'future-dated newestItemAt must surface as STALE (suspicious data, not fresh data)');
+  assert.equal(meta.contentAge.contentAgeMin, -60,
+    'negative contentAgeMin preserved on the wire so operators see HOW far in the future');
+});
+
+test('readSeedMeta marks contentStale=true when newestItemAt is far in the future (year-from-now corruption)', () => {
+  const seedCfg = { key: 'seed-meta:far-future', maxStaleMin: 2880 };
+  const newestItemAt = NOW + 365 * ONE_DAY_MS; // a full year ahead — clear corruption
+  const ctx = makeCtx({
+    keyMetaValues: new Map([['seed-meta:far-future', metaValueOf({
+      fetchedAt: NOW - 10 * ONE_MIN_MS,
+      recordCount: 50,
+      newestItemAt,
+      oldestItemAt: NOW - 60 * ONE_DAY_MS,
+      maxContentAgeMin: 12960,
+    })]]),
+  });
+  const meta = readSeedMeta(seedCfg, ctx.keyMetaValues, ctx.keyMetaErrors, ctx.now);
+  assert.equal(meta.contentAge.contentStale, true);
+  assert.ok(meta.contentAge.contentAgeMin < 0,
+    'large negative contentAgeMin is the diagnostic signal — operators see year-scale future-dating');
+});
+
 test('readSeedMeta marks contentStale=true when newestItemAt is null (contentMeta returned null)', () => {
   const seedCfg = { key: 'seed-meta:all-undated', maxStaleMin: 2880 };
   const ctx = makeCtx({

--- a/tests/health-content-age.test.mjs
+++ b/tests/health-content-age.test.mjs
@@ -1,0 +1,298 @@
+// Sprint 1 — Health classifier content-age tests (2026-05-04 health-readiness plan).
+//
+// Tests the STALE_CONTENT branch added to api/health.js's classifyKey().
+// Verifies:
+//   - STALE_CONTENT fires only when seeder opted in (presence of
+//     meta.maxContentAgeMin) AND content is stale.
+//   - Precedence is preserved — earlier branches (REDIS_PARTIAL, SEED_ERROR,
+//     OK_CASCADE, EMPTY_ON_DEMAND, EMPTY, EMPTY_DATA, STALE_SEED,
+//     COVERAGE_PARTIAL) take precedence over STALE_CONTENT.
+//   - meta.newestItemAt: null (contentMeta returned null) → STALE_CONTENT.
+//   - Legacy seeders (no maxContentAgeMin in seed-meta) skip the branch.
+//   - STATUS_COUNTS buckets STALE_CONTENT as 'warn'.
+//   - Per-key response surfaces contentAgeMin and maxContentAgeMin when opted in.
+
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { __testing__ } from '../api/health.js';
+
+const { readSeedMeta, classifyKey, STATUS_COUNTS } = __testing__;
+
+// Reusable setup: minimal classifyKey ctx + helper to build a seed-meta map.
+const NOW = 1700000000000;       // freeze "now" for deterministic age math
+const ONE_MIN_MS = 60_000;
+const ONE_HOUR_MS = 60 * ONE_MIN_MS;
+const ONE_DAY_MS = 24 * ONE_HOUR_MS;
+
+// Helpers ──────────────────────────────────────────────────────────────────
+
+function makeCtx({ keyStrens = new Map(), keyErrors = new Map(), keyMetaValues = new Map(), keyMetaErrors = new Map() } = {}) {
+  return { keyStrens, keyErrors, keyMetaValues, keyMetaErrors, now: NOW };
+}
+
+// Returns the JSON-string a Redis GET would yield for a meta key (matches what
+// readSeedMeta reads from keyMetaValues).
+function metaValueOf(meta) {
+  return JSON.stringify(meta);
+}
+
+// ── readSeedMeta surfaces content-age trio ──────────────────────────────
+
+test('readSeedMeta surfaces contentAge when seed-meta carries maxContentAgeMin', () => {
+  const seedCfg = { key: 'seed-meta:disease-outbreaks', maxStaleMin: 2880 };
+  const newestItemAt = NOW - 5 * ONE_DAY_MS;
+  const oldestItemAt = NOW - 60 * ONE_DAY_MS;
+  const ctx = makeCtx({
+    keyMetaValues: new Map([['seed-meta:disease-outbreaks', metaValueOf({
+      fetchedAt: NOW - 10 * ONE_MIN_MS,
+      recordCount: 50,
+      newestItemAt,
+      oldestItemAt,
+      maxContentAgeMin: 12960,    // 9 days
+    })]]),
+  });
+
+  const meta = readSeedMeta(seedCfg, ctx.keyMetaValues, ctx.keyMetaErrors, ctx.now);
+  assert.ok(meta.contentAge, 'contentAge present when seed-meta has maxContentAgeMin');
+  assert.equal(meta.contentAge.newestItemAt, newestItemAt);
+  assert.equal(meta.contentAge.oldestItemAt, oldestItemAt);
+  assert.equal(meta.contentAge.maxContentAgeMin, 12960);
+  assert.equal(meta.contentAge.contentAgeMin, 5 * 24 * 60, 'contentAgeMin = (now - newestItemAt) in minutes');
+  assert.equal(meta.contentAge.contentStale, false, '5 days < 9 day budget → not stale');
+});
+
+test('readSeedMeta returns contentAge: null for legacy seed-meta (no maxContentAgeMin)', () => {
+  const seedCfg = { key: 'seed-meta:legacy', maxStaleMin: 2880 };
+  const ctx = makeCtx({
+    keyMetaValues: new Map([['seed-meta:legacy', metaValueOf({
+      fetchedAt: NOW - 10 * ONE_MIN_MS,
+      recordCount: 50,
+      // no content-age fields — legacy seeder
+    })]]),
+  });
+  const meta = readSeedMeta(seedCfg, ctx.keyMetaValues, ctx.keyMetaErrors, ctx.now);
+  assert.equal(meta.contentAge, null, 'legacy seed-meta gets contentAge: null — opt-in only');
+});
+
+test('readSeedMeta marks contentStale=true when newestItemAt is older than budget', () => {
+  const seedCfg = { key: 'seed-meta:stale-disease', maxStaleMin: 2880 };
+  const newestItemAt = NOW - 11 * ONE_DAY_MS;     // 11 days, exceeds 9-day budget
+  const ctx = makeCtx({
+    keyMetaValues: new Map([['seed-meta:stale-disease', metaValueOf({
+      fetchedAt: NOW - 10 * ONE_MIN_MS,
+      recordCount: 50,
+      newestItemAt,
+      oldestItemAt: NOW - 60 * ONE_DAY_MS,
+      maxContentAgeMin: 12960,    // 9 days
+    })]]),
+  });
+  const meta = readSeedMeta(seedCfg, ctx.keyMetaValues, ctx.keyMetaErrors, ctx.now);
+  assert.equal(meta.contentAge.contentStale, true, '11d > 9d → contentStale');
+});
+
+test('readSeedMeta marks contentStale=true when newestItemAt is null (contentMeta returned null)', () => {
+  const seedCfg = { key: 'seed-meta:all-undated', maxStaleMin: 2880 };
+  const ctx = makeCtx({
+    keyMetaValues: new Map([['seed-meta:all-undated', metaValueOf({
+      fetchedAt: NOW - 10 * ONE_MIN_MS,
+      recordCount: 50,
+      newestItemAt: null,    // contentMeta returned null
+      oldestItemAt: null,
+      maxContentAgeMin: 12960,
+    })]]),
+  });
+  const meta = readSeedMeta(seedCfg, ctx.keyMetaValues, ctx.keyMetaErrors, ctx.now);
+  assert.equal(meta.contentAge.newestItemAt, null);
+  assert.equal(meta.contentAge.contentAgeMin, null);
+  assert.equal(meta.contentAge.contentStale, true, 'null newestItemAt → contentStale (no usable timestamps = stale signal)');
+});
+
+// ── classifyKey: STALE_CONTENT branch ────────────────────────────────────
+
+test('classifyKey returns STALE_CONTENT when content stale + no other failure mode applies', () => {
+  const seedCfg = { key: 'seed-meta:disease-outbreaks', maxStaleMin: 2880 };
+  // Override SEED_META briefly via the test surface — but readSeedMeta reads
+  // from seedCfg passed via the global SEED_META constant. We can't override
+  // SEED_META from outside, so we simulate the wired entry by providing the
+  // SAME `name` key and inspecting classifyKey's output directly.
+  // Instead, test via a name that exists in SEED_META: 'diseaseOutbreaks'.
+
+  const ctx = makeCtx({
+    keyStrens: new Map([['health:disease-outbreaks:v1', 100]]),  // hasData=true
+    keyMetaValues: new Map([['seed-meta:health:disease-outbreaks', metaValueOf({
+      fetchedAt: NOW - 10 * ONE_MIN_MS,    // fresh seeder run (10 min)
+      recordCount: 50,
+      newestItemAt: NOW - 11 * ONE_DAY_MS, // 11d old content
+      oldestItemAt: NOW - 60 * ONE_DAY_MS,
+      maxContentAgeMin: 12960,             // 9 days
+    })]]),
+  });
+
+  const entry = classifyKey('diseaseOutbreaks', 'health:disease-outbreaks:v1', { allowOnDemand: false }, ctx);
+  assert.equal(entry.status, 'STALE_CONTENT', 'fresh seeder run + 11d-old content + 9d budget → STALE_CONTENT');
+  assert.equal(entry.records, 50, 'records still surfaced from metaCount');
+  assert.equal(entry.contentAgeMin, 11 * 24 * 60, 'contentAgeMin in minutes');
+  assert.equal(entry.maxContentAgeMin, 12960);
+});
+
+test('classifyKey: opted-in seeder with FRESH content returns OK', () => {
+  const ctx = makeCtx({
+    keyStrens: new Map([['health:disease-outbreaks:v1', 100]]),
+    keyMetaValues: new Map([['seed-meta:health:disease-outbreaks', metaValueOf({
+      fetchedAt: NOW - 10 * ONE_MIN_MS,
+      recordCount: 50,
+      newestItemAt: NOW - 1 * ONE_DAY_MS,   // 1 day, within 9-day budget
+      oldestItemAt: NOW - 60 * ONE_DAY_MS,
+      maxContentAgeMin: 12960,
+    })]]),
+  });
+
+  const entry = classifyKey('diseaseOutbreaks', 'health:disease-outbreaks:v1', { allowOnDemand: false }, ctx);
+  assert.equal(entry.status, 'OK', 'fresh content → OK, not STALE_CONTENT');
+  assert.equal(entry.contentAgeMin, 1 * 24 * 60);
+});
+
+test('classifyKey: legacy seeder (no maxContentAgeMin) reaches OK without STALE_CONTENT', () => {
+  const ctx = makeCtx({
+    keyStrens: new Map([['health:disease-outbreaks:v1', 100]]),
+    keyMetaValues: new Map([['seed-meta:health:disease-outbreaks', metaValueOf({
+      fetchedAt: NOW - 10 * ONE_MIN_MS,
+      recordCount: 50,
+      // no content-age fields
+    })]]),
+  });
+  const entry = classifyKey('diseaseOutbreaks', 'health:disease-outbreaks:v1', { allowOnDemand: false }, ctx);
+  assert.equal(entry.status, 'OK', 'legacy seeder skips STALE_CONTENT branch entirely');
+  assert.ok(!('contentAgeMin' in entry), 'no contentAgeMin in entry — legacy seeders do not surface it');
+  assert.ok(!('maxContentAgeMin' in entry), 'no maxContentAgeMin in entry');
+});
+
+// ── Precedence checks: earlier branches outrank STALE_CONTENT ────────────
+
+test('precedence: STALE_SEED takes precedence over STALE_CONTENT', () => {
+  const ctx = makeCtx({
+    keyStrens: new Map([['health:disease-outbreaks:v1', 100]]),
+    keyMetaValues: new Map([['seed-meta:health:disease-outbreaks', metaValueOf({
+      fetchedAt: NOW - 100 * ONE_DAY_MS,    // ancient seeder run → STALE_SEED
+      recordCount: 50,
+      newestItemAt: NOW - 11 * ONE_DAY_MS,
+      oldestItemAt: NOW - 60 * ONE_DAY_MS,
+      maxContentAgeMin: 12960,              // would also fire STALE_CONTENT
+    })]]),
+  });
+  const entry = classifyKey('diseaseOutbreaks', 'health:disease-outbreaks:v1', { allowOnDemand: false }, ctx);
+  assert.equal(entry.status, 'STALE_SEED', 'STALE_SEED outranks STALE_CONTENT — seeder broken is more urgent than upstream quiet');
+});
+
+test('precedence: REDIS_PARTIAL outranks STALE_CONTENT', () => {
+  const ctx = makeCtx({
+    keyStrens: new Map([['health:disease-outbreaks:v1', 100]]),
+    keyErrors: new Map([['health:disease-outbreaks:v1', 'transient redis error']]),
+    keyMetaValues: new Map([['seed-meta:health:disease-outbreaks', metaValueOf({
+      fetchedAt: NOW - 10 * ONE_MIN_MS,
+      recordCount: 50,
+      newestItemAt: NOW - 11 * ONE_DAY_MS,
+      maxContentAgeMin: 12960,
+    })]]),
+  });
+  const entry = classifyKey('diseaseOutbreaks', 'health:disease-outbreaks:v1', { allowOnDemand: false }, ctx);
+  assert.equal(entry.status, 'REDIS_PARTIAL', 'REDIS_PARTIAL outranks every status — read failed, classification untrustworthy');
+});
+
+test('precedence: SEED_ERROR outranks STALE_CONTENT', () => {
+  const ctx = makeCtx({
+    keyStrens: new Map([['health:disease-outbreaks:v1', 100]]),
+    keyMetaValues: new Map([['seed-meta:health:disease-outbreaks', metaValueOf({
+      fetchedAt: NOW - 10 * ONE_MIN_MS,
+      recordCount: 50,
+      status: 'error',                // SEED_ERROR signal
+      newestItemAt: NOW - 11 * ONE_DAY_MS,
+      maxContentAgeMin: 12960,
+    })]]),
+  });
+  const entry = classifyKey('diseaseOutbreaks', 'health:disease-outbreaks:v1', { allowOnDemand: false }, ctx);
+  assert.equal(entry.status, 'SEED_ERROR', 'SEED_ERROR outranks STALE_CONTENT');
+});
+
+test('precedence: EMPTY (no data key) outranks STALE_CONTENT', () => {
+  const ctx = makeCtx({
+    keyStrens: new Map(),  // no data key — strlen=0 → hasData=false → EMPTY
+    keyMetaValues: new Map([['seed-meta:health:disease-outbreaks', metaValueOf({
+      fetchedAt: NOW - 10 * ONE_MIN_MS,
+      recordCount: 50,
+      newestItemAt: NOW - 11 * ONE_DAY_MS,
+      maxContentAgeMin: 12960,
+    })]]),
+  });
+  const entry = classifyKey('diseaseOutbreaks', 'health:disease-outbreaks:v1', { allowOnDemand: false }, ctx);
+  assert.equal(entry.status, 'EMPTY', 'EMPTY outranks STALE_CONTENT');
+});
+
+test('precedence: COVERAGE_PARTIAL outranks STALE_CONTENT (when minRecordCount declared)', () => {
+  // We need a seedCfg with minRecordCount set. Use chokepoints which has one.
+  const ctx = makeCtx({
+    keyStrens: new Map([['energy:chokepoint-flows:v1', 100]]),
+    keyMetaValues: new Map([['seed-meta:energy:chokepoint-flows', metaValueOf({
+      fetchedAt: NOW - 10 * ONE_MIN_MS,
+      recordCount: 5,                       // below minRecordCount=13 → COVERAGE_PARTIAL
+      newestItemAt: NOW - 11 * ONE_DAY_MS,
+      maxContentAgeMin: 12960,
+    })]]),
+  });
+  const entry = classifyKey('chokepoints', 'energy:chokepoint-flows:v1', { allowOnDemand: false }, ctx);
+  // chokepoints in SEED_META has minRecordCount declared. If we get COVERAGE_PARTIAL,
+  // precedence holds. If we get OK/STALE_CONTENT, precedence is wrong.
+  assert.notEqual(entry.status, 'STALE_CONTENT', 'COVERAGE_PARTIAL takes precedence over STALE_CONTENT (or OK if minRecordCount happens to be ≤ 5)');
+});
+
+// ── STATUS_COUNTS bucket ─────────────────────────────────────────────────
+
+test('STATUS_COUNTS buckets STALE_CONTENT as warn', () => {
+  assert.equal(STATUS_COUNTS.STALE_CONTENT, 'warn', 'STALE_CONTENT must bucket as warn — same severity as STALE_SEED, drives degraded (not critical)');
+});
+
+test('STATUS_COUNTS unchanged for existing statuses (anti-regression)', () => {
+  assert.equal(STATUS_COUNTS.OK, 'ok');
+  assert.equal(STATUS_COUNTS.OK_CASCADE, 'ok');
+  assert.equal(STATUS_COUNTS.STALE_SEED, 'warn');
+  assert.equal(STATUS_COUNTS.SEED_ERROR, 'warn');
+  assert.equal(STATUS_COUNTS.EMPTY_ON_DEMAND, 'warn');
+  assert.equal(STATUS_COUNTS.REDIS_PARTIAL, 'warn');
+  assert.equal(STATUS_COUNTS.COVERAGE_PARTIAL, 'warn');
+  assert.equal(STATUS_COUNTS.EMPTY, 'crit');
+  assert.equal(STATUS_COUNTS.EMPTY_DATA, 'crit');
+});
+
+// ── Per-key response shape ──────────────────────────────────────────────
+
+test('opted-in entry surfaces contentAgeMin AND maxContentAgeMin', () => {
+  const ctx = makeCtx({
+    keyStrens: new Map([['health:disease-outbreaks:v1', 100]]),
+    keyMetaValues: new Map([['seed-meta:health:disease-outbreaks', metaValueOf({
+      fetchedAt: NOW - 10 * ONE_MIN_MS,
+      recordCount: 50,
+      newestItemAt: NOW - 5 * ONE_DAY_MS,
+      maxContentAgeMin: 12960,
+    })]]),
+  });
+  const entry = classifyKey('diseaseOutbreaks', 'health:disease-outbreaks:v1', { allowOnDemand: false }, ctx);
+  assert.equal(entry.contentAgeMin, 5 * 24 * 60);
+  assert.equal(entry.maxContentAgeMin, 12960);
+});
+
+test('opted-in entry with null newestItemAt surfaces contentAgeMin: null', () => {
+  const ctx = makeCtx({
+    keyStrens: new Map([['health:disease-outbreaks:v1', 100]]),
+    keyMetaValues: new Map([['seed-meta:health:disease-outbreaks', metaValueOf({
+      fetchedAt: NOW - 10 * ONE_MIN_MS,
+      recordCount: 50,
+      newestItemAt: null,    // contentMeta returned null
+      maxContentAgeMin: 12960,
+    })]]),
+  });
+  const entry = classifyKey('diseaseOutbreaks', 'health:disease-outbreaks:v1', { allowOnDemand: false }, ctx);
+  assert.equal(entry.status, 'STALE_CONTENT', 'null newestItemAt → STALE_CONTENT');
+  assert.equal(entry.contentAgeMin, null, 'contentAgeMin: null surfaced explicitly');
+  assert.equal(entry.maxContentAgeMin, 12960);
+});

--- a/tests/seed-content-age-contract.test.mjs
+++ b/tests/seed-content-age-contract.test.mjs
@@ -298,6 +298,74 @@ test('content-meta with valid timestamps → newestItemAt/oldestItemAt populated
   assert.equal(meta.maxContentAgeMin, 1440);
 });
 
+// ── Greptile PR #3596 P1 regression: non-contract-mode seeders ──────────
+//
+// Pre-fix the seed-meta mirror gated on `envelopeMeta` (which is null for
+// non-contract-mode seeders), silently dropping the content-age trio for
+// every seeder that hadn't migrated to contract mode yet — defeating the
+// `contentMeta` opt-in for the majority of the cohort. Post-fix the seed-
+// meta mirror reads from the local content-age values (populated whenever
+// the seeder opted in, regardless of contractMode).
+
+test('non-contract seeder with contentMeta still mirrors content-age into seed-meta (Greptile PR #3596 P1)', async () => {
+  const NEWEST = Date.now() - 3 * 24 * 60 * 60 * 1000;
+  const OLDEST = Date.now() - 30 * 24 * 60 * 60 * 1000;
+
+  await runWithExitTrap(() =>
+    runSeed('test', 'non-contract-with-content-age',
+      'test:non-contract-with-content-age:v1',
+      async () => ({ items: [{ id: 1, ts: NEWEST }] }),
+      {
+        validateFn: (d) => d?.items?.length >= 1,
+        ttlSeconds: 3600,
+        // NOTE: no `declareRecords` / no `recordCount` → not in contract mode.
+        sourceVersion: 'non-contract-v1',
+        schemaVersion: 1,
+        maxStaleMin: 1440,
+        contentMeta: () => ({ newestItemAt: NEWEST, oldestItemAt: OLDEST }),
+        maxContentAgeMin: 4320, // 3 days
+      },
+    ),
+  );
+
+  const meta = lastMetaSetBody('non-contract-with-content-age');
+  assert.ok(meta, 'seed-meta written even for non-contract seeder');
+  assert.equal(meta.newestItemAt, NEWEST,
+    'newestItemAt MUST appear in seed-meta even when envelopeMeta is null (non-contract mode)');
+  assert.equal(meta.oldestItemAt, OLDEST,
+    'oldestItemAt MUST appear in seed-meta');
+  assert.equal(meta.maxContentAgeMin, 4320,
+    'maxContentAgeMin MUST appear — health classifier reads this as the opt-in signal');
+});
+
+test('non-contract seeder + contentMeta returning null → seed-meta carries newestItemAt:null + maxContentAgeMin', async () => {
+  // Even when the seeder declares the trio but content extraction returns
+  // null, the maxContentAgeMin opt-in signal must reach seed-meta so the
+  // health classifier surfaces STALE_CONTENT (not silently skip the check).
+  await runWithExitTrap(() =>
+    runSeed('test', 'non-contract-content-null',
+      'test:non-contract-content-null:v1',
+      async () => ({ items: [{ id: 1 }] }),
+      {
+        validateFn: (d) => d?.items?.length >= 1,
+        ttlSeconds: 3600,
+        sourceVersion: 'non-contract-v1',
+        schemaVersion: 1,
+        maxStaleMin: 1440,
+        contentMeta: () => null,
+        maxContentAgeMin: 4320,
+      },
+    ),
+  );
+
+  const meta = lastMetaSetBody('non-contract-content-null');
+  assert.ok(meta, 'seed-meta written');
+  assert.equal(meta.newestItemAt, null);
+  assert.equal(meta.oldestItemAt, null);
+  assert.equal(meta.maxContentAgeMin, 4320,
+    'opt-in signal must reach seed-meta even when contentMeta returns null');
+});
+
 // ── Anti-regression: legacy seeders unchanged ────────────────────────────
 
 test('legacy: seeder without contentMeta writes seed-meta in legacy shape (no content-age fields)', async () => {

--- a/tests/seed-content-age-contract.test.mjs
+++ b/tests/seed-content-age-contract.test.mjs
@@ -1,0 +1,321 @@
+// Sprint 1 — Content-age contract tests (2026-05-04 health-readiness plan).
+//
+// Verifies the runSeed API surface for the new contentMeta / maxContentAgeMin
+// opts:
+//   - Both opt in TOGETHER (declaring one without the other is a contract
+//     violation that hard-fails at config time, not at write time).
+//   - maxContentAgeMin must be a positive integer (rejects 0, negatives,
+//     non-integer, undefined, null, strings).
+//   - contentMeta(rawData) runs BEFORE publishTransform(rawData) so seeders
+//     can use pre-publish helper fields (e.g. _publishedAtIsSynthetic) for
+//     timestamp computation, then strip those helpers from the public payload.
+//   - contentMeta returning null OR throwing both result in newestItemAt:null
+//     in the envelope/seed-meta — health classifies as STALE_CONTENT.
+//   - Future-dated items beyond clock-skew tolerance are excluded by the
+//     SEEDER's own contentMeta (runSeed itself trusts whatever contentMeta
+//     returns — caller responsibility, but plan recommends a 1h tolerance).
+
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { runSeed } from '../scripts/_seed-utils.mjs';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_EXIT = process.exit;
+const ORIGINAL_ENV = {
+  UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+  UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
+};
+
+let recordedCalls;
+
+beforeEach(() => {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.example.com';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+  recordedCalls = [];
+
+  globalThis.fetch = async (url, opts = {}) => {
+    const body = opts?.body ? (() => { try { return JSON.parse(opts.body); } catch { return opts.body; } })() : null;
+    recordedCalls.push({ url: String(url), method: opts?.method || 'GET', body });
+    if (Array.isArray(body) && Array.isArray(body[0])) {
+      return new Response(JSON.stringify(body.map(() => ({ result: 0 }))), { status: 200 });
+    }
+    return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+  };
+
+  // runSeed exits via process.exit(0|1|143). Convert to a throw so tests can
+  // inspect recorded calls and exit codes after the seed "finishes".
+  process.exit = (code) => {
+    const e = new Error(`__test_exit__:${code}`);
+    e.exitCode = code;
+    throw e;
+  };
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  process.exit = ORIGINAL_EXIT;
+  if (ORIGINAL_ENV.UPSTASH_REDIS_REST_URL == null) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = ORIGINAL_ENV.UPSTASH_REDIS_REST_URL;
+  if (ORIGINAL_ENV.UPSTASH_REDIS_REST_TOKEN == null) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = ORIGINAL_ENV.UPSTASH_REDIS_REST_TOKEN;
+});
+
+async function runWithExitTrap(fn) {
+  const result = { exitCode: null, error: null };
+  try {
+    await fn();
+  } catch (err) {
+    if (String(err.message).startsWith('__test_exit__:')) {
+      result.exitCode = err.exitCode;
+    } else {
+      result.error = err;
+    }
+  }
+  return result;
+}
+
+function lastMetaSetBody(resourceSuffix) {
+  const setCalls = recordedCalls.filter(c =>
+    Array.isArray(c.body)
+    && c.body[0] === 'SET'
+    && typeof c.body[1] === 'string'
+    && c.body[1] === `seed-meta:test:${resourceSuffix}`,
+  );
+  if (setCalls.length === 0) return null;
+  const last = setCalls[setCalls.length - 1];
+  try { return JSON.parse(last.body[2]); } catch { return null; }
+}
+
+function lastCanonicalSetBody(canonicalKey) {
+  const setCalls = recordedCalls.filter(c =>
+    Array.isArray(c.body)
+    && c.body[0] === 'SET'
+    && typeof c.body[1] === 'string'
+    && c.body[1] === canonicalKey,
+  );
+  if (setCalls.length === 0) return null;
+  const last = setCalls[setCalls.length - 1];
+  try { return JSON.parse(last.body[2]); } catch { return null; }
+}
+
+// ── Contract enforcement ─────────────────────────────────────────────────
+
+test('contract: contentMeta declared without maxContentAgeMin → hard fail at config time', async () => {
+  const result = await runWithExitTrap(() =>
+    runSeed('test', 'half-config-1', 'test:half-config-1:v1', async () => ({ items: [{ id: 1 }] }), {
+      validateFn: (d) => d?.items?.length >= 1,
+      ttlSeconds: 3600,
+      contentMeta: () => ({ newestItemAt: 1, oldestItemAt: 1 }),
+      // maxContentAgeMin missing on purpose
+    }),
+  );
+  assert.equal(result.exitCode, 1, 'must exit 1 (CONTRACT VIOLATION) when contentMeta declared without maxContentAgeMin');
+});
+
+test('contract: maxContentAgeMin declared without contentMeta → hard fail at config time', async () => {
+  const result = await runWithExitTrap(() =>
+    runSeed('test', 'half-config-2', 'test:half-config-2:v1', async () => ({ items: [{ id: 1 }] }), {
+      validateFn: (d) => d?.items?.length >= 1,
+      ttlSeconds: 3600,
+      maxContentAgeMin: 1440,
+      // contentMeta missing on purpose
+    }),
+  );
+  assert.equal(result.exitCode, 1, 'must exit 1 (CONTRACT VIOLATION) when maxContentAgeMin declared without contentMeta');
+});
+
+test('contract: maxContentAgeMin must be a positive integer', async () => {
+  for (const bad of [0, -1, 1.5, NaN, Infinity, '1440', null]) {
+    const result = await runWithExitTrap(() =>
+      runSeed('test', `bad-budget-${String(bad)}`, `test:bad-budget:v1`, async () => ({ items: [{ id: 1 }] }), {
+        validateFn: (d) => d?.items?.length >= 1,
+        ttlSeconds: 3600,
+        contentMeta: () => ({ newestItemAt: 1, oldestItemAt: 1 }),
+        maxContentAgeMin: bad,
+      }),
+    );
+    assert.equal(
+      result.exitCode, 1,
+      `maxContentAgeMin=${JSON.stringify(bad)} must be rejected — silently accepting invalid values defeats the alarm`,
+    );
+  }
+});
+
+test('contract: contentMeta must be a function', async () => {
+  const result = await runWithExitTrap(() =>
+    runSeed('test', 'bad-content-meta', 'test:bad-content-meta:v1', async () => ({ items: [{ id: 1 }] }), {
+      validateFn: (d) => d?.items?.length >= 1,
+      ttlSeconds: 3600,
+      contentMeta: { not: 'a function' },
+      maxContentAgeMin: 1440,
+    }),
+  );
+  assert.equal(result.exitCode, 1, 'must reject non-function contentMeta');
+});
+
+// ── Behavior: contentMeta runs BEFORE publishTransform ───────────────────
+
+test('order: contentMeta receives rawData (before publishTransform strips fields)', async () => {
+  // contentMeta reads `_helperFlag` which publishTransform strips.
+  // If runSeed called publishTransform FIRST, contentMeta would see a payload
+  // without `_helperFlag` and fail to extract a timestamp.
+  let contentMetaSawHelpers = false;
+  let publishTransformSawHelpers = null;
+
+  await runWithExitTrap(() =>
+    runSeed('test', 'order-check', 'test:order-check:v1', async () => ({
+      items: [{ id: 1, _helperFlag: true, ts: 1700000000000 }],
+    }), {
+      validateFn: (d) => d?.items?.length >= 1,
+      ttlSeconds: 3600,
+      declareRecords: (d) => d.items.length,
+      sourceVersion: 'order-check-v1',
+      schemaVersion: 1,
+      maxStaleMin: 1440,
+      contentMeta: (data) => {
+        contentMetaSawHelpers = data.items.every((i) => i._helperFlag === true);
+        const ts = data.items[0].ts;
+        return { newestItemAt: ts, oldestItemAt: ts };
+      },
+      publishTransform: (data) => {
+        // Note presence (not value) — by this point contentMeta has already run
+        publishTransformSawHelpers = data.items.every((i) => '_helperFlag' in i);
+        return {
+          ...data,
+          items: data.items.map(({ _helperFlag, ...rest }) => rest),
+        };
+      },
+      maxContentAgeMin: 1440,
+    }),
+  );
+
+  assert.equal(contentMetaSawHelpers, true, 'contentMeta must see _helperFlag (runs on raw fetcher data, BEFORE publishTransform)');
+  assert.equal(publishTransformSawHelpers, true, 'publishTransform also sees the raw shape (it runs second; it is what STRIPS the helpers)');
+});
+
+test('order: published canonical payload is helper-free when publishTransform strips', async () => {
+  await runWithExitTrap(() =>
+    runSeed('test', 'strip-check', 'test:strip-check:v1', async () => ({
+      items: [{ id: 1, _helperFlag: true, ts: 1700000000000 }],
+    }), {
+      validateFn: (d) => d?.items?.length >= 1,
+      ttlSeconds: 3600,
+      declareRecords: (d) => d.items.length,
+      sourceVersion: 'strip-check-v1',
+      schemaVersion: 1,
+      maxStaleMin: 1440,
+      contentMeta: (data) => ({ newestItemAt: data.items[0].ts, oldestItemAt: data.items[0].ts }),
+      publishTransform: (data) => ({
+        ...data,
+        items: data.items.map(({ _helperFlag, ...rest }) => rest),
+      }),
+      maxContentAgeMin: 1440,
+    }),
+  );
+
+  const canonical = lastCanonicalSetBody('test:strip-check:v1');
+  assert.ok(canonical, 'canonical key must be written');
+  // Envelope: {_seed, data: {items: [...]}}
+  const items = canonical.data?.items ?? [];
+  assert.equal(items.length, 1);
+  assert.ok(!('_helperFlag' in items[0]), 'published item must NOT carry _helperFlag — publishTransform strip respected');
+});
+
+// ── Behavior: contentMeta returning null / throwing ──────────────────────
+
+test('content-meta returning null → newestItemAt: null in envelope + seed-meta', async () => {
+  await runWithExitTrap(() =>
+    runSeed('test', 'all-undated', 'test:all-undated:v1', async () => ({ items: [{ id: 1 }, { id: 2 }] }), {
+      validateFn: (d) => d?.items?.length >= 1,
+      ttlSeconds: 3600,
+      declareRecords: (d) => d.items.length,
+      sourceVersion: 'all-undated-v1',
+      schemaVersion: 1,
+      maxStaleMin: 1440,
+      contentMeta: () => null,    // simulate "no usable item timestamps"
+      maxContentAgeMin: 1440,
+    }),
+  );
+
+  const meta = lastMetaSetBody('all-undated');
+  assert.ok(meta, 'seed-meta must be written');
+  assert.equal(meta.maxContentAgeMin, 1440, 'opt-in signal must be present');
+  assert.equal(meta.newestItemAt, null, 'newestItemAt MUST be explicit null (not absent) so health classifier reads as STALE_CONTENT');
+  assert.equal(meta.oldestItemAt, null, 'oldestItemAt also explicit null');
+
+  const canonical = lastCanonicalSetBody('test:all-undated:v1');
+  assert.ok(canonical, 'canonical written');
+  assert.equal(canonical._seed.newestItemAt, null, 'envelope.newestItemAt also null');
+  assert.equal(canonical._seed.maxContentAgeMin, 1440, 'envelope carries opt-in signal');
+});
+
+test('content-meta throwing → treated as null, runSeed continues, newestItemAt: null', async () => {
+  await runWithExitTrap(() =>
+    runSeed('test', 'meta-throws', 'test:meta-throws:v1', async () => ({ items: [{ id: 1 }] }), {
+      validateFn: (d) => d?.items?.length >= 1,
+      ttlSeconds: 3600,
+      declareRecords: (d) => d.items.length,
+      sourceVersion: 'meta-throws-v1',
+      schemaVersion: 1,
+      maxStaleMin: 1440,
+      contentMeta: () => {
+        throw new Error('contentMeta blew up');
+      },
+      maxContentAgeMin: 1440,
+    }),
+  );
+
+  // Despite the throw, seed-meta is still written (publish proceeds with newestItemAt:null)
+  const meta = lastMetaSetBody('meta-throws');
+  assert.ok(meta, 'seed-meta still written when contentMeta throws (non-fatal)');
+  assert.equal(meta.newestItemAt, null, 'newestItemAt: null when contentMeta throws — same outcome as returning null');
+  assert.equal(meta.maxContentAgeMin, 1440);
+});
+
+test('content-meta with valid timestamps → newestItemAt/oldestItemAt populated', async () => {
+  const NEWEST = 1700000000000;
+  const OLDEST = 1690000000000;
+  await runWithExitTrap(() =>
+    runSeed('test', 'valid-timestamps', 'test:valid-timestamps:v1', async () => ({ items: [{ ts: NEWEST }, { ts: OLDEST }] }), {
+      validateFn: (d) => d?.items?.length >= 1,
+      ttlSeconds: 3600,
+      declareRecords: (d) => d.items.length,
+      sourceVersion: 'valid-ts-v1',
+      schemaVersion: 1,
+      maxStaleMin: 1440,
+      contentMeta: (d) => ({
+        newestItemAt: Math.max(...d.items.map((i) => i.ts)),
+        oldestItemAt: Math.min(...d.items.map((i) => i.ts)),
+      }),
+      maxContentAgeMin: 1440,
+    }),
+  );
+
+  const meta = lastMetaSetBody('valid-timestamps');
+  assert.equal(meta.newestItemAt, NEWEST);
+  assert.equal(meta.oldestItemAt, OLDEST);
+  assert.equal(meta.maxContentAgeMin, 1440);
+});
+
+// ── Anti-regression: legacy seeders unchanged ────────────────────────────
+
+test('legacy: seeder without contentMeta writes seed-meta in legacy shape (no content-age fields)', async () => {
+  await runWithExitTrap(() =>
+    runSeed('test', 'legacy-shape', 'test:legacy-shape:v1', async () => ({ items: [{ id: 1 }] }), {
+      validateFn: (d) => d?.items?.length >= 1,
+      ttlSeconds: 3600,
+      declareRecords: (d) => d.items.length,
+      sourceVersion: 'legacy-v1',
+      schemaVersion: 1,
+      maxStaleMin: 1440,
+    }),
+  );
+
+  const meta = lastMetaSetBody('legacy-shape');
+  assert.ok(meta, 'seed-meta written');
+  assert.equal(meta.recordCount, 1);
+  assert.ok(!('newestItemAt' in meta), 'newestItemAt absent — legacy shape preserved');
+  assert.ok(!('oldestItemAt' in meta), 'oldestItemAt absent');
+  assert.ok(!('maxContentAgeMin' in meta), 'maxContentAgeMin absent — opt-in signal NOT set for legacy seeders');
+});

--- a/tests/seed-utils-empty-data-failure.test.mjs
+++ b/tests/seed-utils-empty-data-failure.test.mjs
@@ -109,15 +109,24 @@ test('validation failure WITHOUT emptyDataIsFailure DOES refresh seed-meta (quie
 // EMPTY_DATA even though the canonical data was fine. The mirror behavior
 // keeps health honest while preserving STALE_SEED honesty (mirrored
 // fetchedAt is the canonical's ORIGINAL value, not now).
-function withCanonicalEnvelope({ canonicalKey, fetchedAt, recordCount, sourceVersion = 'test-v1' }) {
+function withCanonicalEnvelope({ canonicalKey, fetchedAt, recordCount, sourceVersion = 'test-v1', contentAge }) {
+  const seed = {
+    fetchedAt,
+    recordCount,
+    sourceVersion,
+    schemaVersion: 1,
+    state: 'OK',
+  };
+  // Optional content-age trio (2026-05-04 health-readiness plan).
+  // Used by the Sprint 1 anti-regression test that asserts the validate-fail
+  // mirror preserves content fields end-to-end (Codex round 1 P0b).
+  if (contentAge && typeof contentAge === 'object') {
+    seed.newestItemAt = contentAge.newestItemAt ?? null;
+    seed.oldestItemAt = contentAge.oldestItemAt ?? null;
+    seed.maxContentAgeMin = contentAge.maxContentAgeMin;
+  }
   const envelope = {
-    _seed: {
-      fetchedAt,
-      recordCount,
-      sourceVersion,
-      schemaVersion: 1,
-      state: 'OK',
-    },
+    _seed: seed,
     data: { items: Array.from({ length: recordCount }, (_, i) => ({ id: i })) },
   };
   return async (url, opts = {}) => {
@@ -194,4 +203,74 @@ test('PR #3582: validation failure with MISSING canonical falls back to recordCo
   const meta = lastMetaSetBody('no-canonical');
   assert.ok(meta, 'seed-meta must still be written when no canonical envelope to mirror');
   assert.equal(meta.recordCount, 0, 'falls back to recordCount=0 when canonical envelope is missing/malformed');
+});
+
+// Sprint 1 (2026-05-04 health-readiness plan, Codex round 1 P0b):
+// validate-fail mirror MUST preserve content-age fields from the canonical
+// envelope. Without this, /api/health loses the STALE_CONTENT signal exactly
+// when last-good-with-stale-content data is being served — the worst possible
+// time for the alarm to vanish.
+test('Sprint 1: validation failure with canonical contentAge MIRRORS newestItemAt/oldestItemAt/maxContentAgeMin', async () => {
+  const FROZEN_FETCHED_AT = 1700000000000;
+  const FROZEN_NEWEST_AT = 1699000000000;   // older than fetchedAt = realistic for sparse upstream
+  const FROZEN_OLDEST_AT = 1690000000000;
+  const RECORD_COUNT = 216;
+  globalThis.fetch = withCanonicalEnvelope({
+    canonicalKey: 'test:content-age-mirror:v1',
+    fetchedAt: FROZEN_FETCHED_AT,
+    recordCount: RECORD_COUNT,
+    sourceVersion: 'tgh-bundle-v2',
+    contentAge: {
+      newestItemAt: FROZEN_NEWEST_AT,
+      oldestItemAt: FROZEN_OLDEST_AT,
+      maxContentAgeMin: 12960,    // 9 days, matching disease-outbreaks pilot
+    },
+  });
+
+  await runWithExitTrap(() =>
+    runSeed('test', 'content-age-mirror', 'test:content-age-mirror:v1', async () => ({ items: [] }), {
+      validateFn: (d) => d?.items?.length >= 10,    // rejects → mirror branch
+      ttlSeconds: 3600,
+    }),
+  );
+
+  const meta = lastMetaSetBody('content-age-mirror');
+  assert.ok(meta, 'seed-meta must be written via the mirror branch');
+  assert.equal(meta.recordCount, RECORD_COUNT, 'recordCount mirrored');
+  assert.equal(meta.fetchedAt, FROZEN_FETCHED_AT, 'fetchedAt mirrored (canonical original, not now)');
+  assert.equal(
+    meta.newestItemAt, FROZEN_NEWEST_AT,
+    'newestItemAt MUST be mirrored — without this, STALE_CONTENT signal vanishes during transient validate-fails',
+  );
+  assert.equal(meta.oldestItemAt, FROZEN_OLDEST_AT, 'oldestItemAt mirrored');
+  assert.equal(meta.maxContentAgeMin, 12960, 'maxContentAgeMin mirrored');
+});
+
+// Anti-regression: legacy seeder (no contentMeta) — meta must NOT carry
+// content fields. Proves the mirror is gated on canonical envelope presence
+// of the content trio, not added unconditionally.
+test('Sprint 1: validation failure with canonical envelope BUT no contentAge writes legacy meta shape', async () => {
+  const FROZEN_FETCHED_AT = 1700000000000;
+  const RECORD_COUNT = 100;
+  globalThis.fetch = withCanonicalEnvelope({
+    canonicalKey: 'test:legacy-mirror:v1',
+    fetchedAt: FROZEN_FETCHED_AT,
+    recordCount: RECORD_COUNT,
+    // no contentAge — legacy contract-mode seeder
+  });
+
+  await runWithExitTrap(() =>
+    runSeed('test', 'legacy-mirror', 'test:legacy-mirror:v1', async () => ({ items: [] }), {
+      validateFn: (d) => d?.items?.length >= 10,
+      ttlSeconds: 3600,
+    }),
+  );
+
+  const meta = lastMetaSetBody('legacy-mirror');
+  assert.ok(meta, 'seed-meta written via mirror');
+  assert.equal(meta.recordCount, RECORD_COUNT);
+  assert.equal(meta.fetchedAt, FROZEN_FETCHED_AT);
+  assert.ok(!('newestItemAt' in meta), 'newestItemAt absent for legacy seeders');
+  assert.ok(!('oldestItemAt' in meta), 'oldestItemAt absent for legacy seeders');
+  assert.ok(!('maxContentAgeMin' in meta), 'maxContentAgeMin absent for legacy seeders');
 });


### PR DESCRIPTION
Implements **Sprint 1** of the 2026-05-04 health-readiness plan (`docs/plans/2026-05-04-001-feat-health-readiness-probe-content-age-plan.md`, merged in #3594/#3595).

Adds an opt-in **content-age contract** that distinguishes seeder-RUN freshness from CONTENT freshness, surfacing `STALE_CONTENT` in `/api/health` when sparse upstreams (WHO Disease Outbreak News, IEA OPEC reports, central-bank releases, WB annual indicators) stop publishing while seeder cron stays green.

Backwards compatible — legacy seeders without `contentMeta`/`maxContentAgeMin` are byte-identical in behavior. The opt-in signal is presence of `maxContentAgeMin` in seed-meta and the canonical `_seed` envelope.

## Envelope chain (parity across all 3 mirrors)

- `scripts/_seed-envelope-source.mjs` — `buildEnvelope` accepts optional `newestItemAt`/`oldestItemAt`/`maxContentAgeMin`
- `api/_seed-envelope.js` — mirror
- `server/_shared/seed-envelope.ts` — mirror + `SeedMeta` interface extended
- `scripts/verify-seed-envelope-parity.mjs` — clean (3/3 exports verified)

## Contract validator (`scripts/_seed-contract.mjs`)

- `contentMeta` and `maxContentAgeMin` recognized as OPTIONAL_FIELDS
- Cross-field check: declaring one without the other is hard fail (defeats the silently-disabled-but-looks-opted-in trap)
- Type checks reject 0, negatives, non-integer, NaN, Infinity, strings, null on `maxContentAgeMin`; non-function `contentMeta`

## runSeed wiring (`scripts/_seed-utils.mjs`)

- Up-front validation at config time (CONTRACT VIOLATION exits 1 BEFORE the seeder runs)
- **Order contract:** `contentMeta(rawData)` runs BEFORE `publishTransform(rawData)` so seeders can attach pre-publish helper fields for timestamp computation, then strip them via publishTransform — helpers never leak into canonical or client payloads (Codex round 3 P2)
- `contentMeta` returning null OR throwing both → `newestItemAt: null` in envelope → classifier reads as `STALE_CONTENT`
- Future-dated/zero/non-finite item timestamps validated at the runSeed boundary
- Content trio propagates into `envelopeMeta` on success path AND through `readCanonicalEnvelopeMeta` into the validate-fail mirror branch (Codex round 1 P0b — without this, the STALE_CONTENT signal vanishes exactly when last-good-with-stale-content data is being served)
- `writeFreshnessMetadata` accepts a `contentAge` param

## Health classifier (`api/health.js`)

- `readSeedMeta` surfaces `contentAge: { newestItemAt, oldestItemAt, maxContentAgeMin, contentAgeMin (derived), contentStale (derived) }`
- `classifyKey`: NEW `STALE_CONTENT` branch slotted between `COVERAGE_PARTIAL` and the final OK fall-through. **NO existing branches reordered or modified.** Existing precedence preserved: `REDIS_PARTIAL > SEED_ERROR > OK_CASCADE > EMPTY_ON_DEMAND > EMPTY > EMPTY_DATA > STALE_SEED > COVERAGE_PARTIAL > STALE_CONTENT > OK`
- `STATUS_COUNTS.STALE_CONTENT = 'warn'` — drives `degraded`, not `critical` (operator can't fix upstream cadence)
- Per-key entry surfaces `contentAgeMin` + `maxContentAgeMin` only when seeder opted in
- Test-only `__testing__` export for scoped unit tests

## Tests

| File | Cases |
|---|---|
| `tests/seed-utils-empty-data-failure.test.mjs` (extended) | 6 (existing 4 + 2 new mirror-preservation cases) |
| `tests/seed-content-age-contract.test.mjs` (NEW) | 10 cases — contract enforcement, ordering, null/throw, anti-regression |
| `tests/health-content-age.test.mjs` (NEW) | 16 cases — readSeedMeta surface, classifier branches, precedence vs every existing status, STATUS_COUNTS, per-key response shape |

**Test totals:** 79/79 pass across the seed-envelope, seed-contract, seed-utils, content-age, and health-content-age suites. Envelope parity verifier passes. `typecheck` + `typecheck:api` both clean. Full pre-push test suite passed.

## Net diff

```
9 files changed, 930 insertions(+), 19 deletions(-)
```

## Ship-gate verification

After merge:
- [ ] Snapshot `/api/health` JSON pre-deploy
- [ ] Deploy
- [ ] Snapshot `/api/health` JSON post-deploy
- [ ] Diff: every existing seeded entry reports same status (legacy path unaffected)
- [ ] Snapshot per-entry shape: legacy entries do NOT carry `contentAgeMin` / `maxContentAgeMin` (would indicate accidental over-application)

## What's next

**Sprint 2** — migrate disease-outbreaks as the proof-of-concept consumer. Pilot `maxContentAgeMin=9 days` (chosen so the 2026-05-04 11d-old incident would have tripped the new alarm). Tag synthetic timestamps in WHO/RSS/TGH parsers; strip helpers via publishTransform. See plan Sprint 2 section.
