### PR TITLE
feat(disease-outbreaks): Sprint 2 — content-age pilot (synthetic tagging + 9d budget)

### DIFF
--- a/scripts/_disease-outbreaks-helpers.mjs
+++ b/scripts/_disease-outbreaks-helpers.mjs
@@ -1,0 +1,244 @@
+// Pure helpers extracted from seed-disease-outbreaks.mjs so tests can import
+// them without triggering the seeder's top-level runSeed() call (which would
+// exit the process on import).
+//
+// The seeder's three parsers (WHO DON / RSS / TGH) do network I/O, but the
+// PER-ITEM normalization shape is pure and what we want to lock in tests:
+//
+//   - synthetic-timestamp tagging (WHO/RSS fall back to nowMs when upstream
+//     omits a date; TGH always carries a real date by the time it reaches
+//     this layer because the line-198 filter rejects undated records earlier)
+//   - mapItem composition (id, disease/location detection, lat/lng defaults)
+//   - contentMeta (filters synthetic + clock-skew, picks newest/oldest)
+//   - publishTransform (strips helpers before atomicPublish)
+//
+// Extracting these out of the seeder gives Sprint 2's tests a single source
+// of truth — drift between test fixtures and seeder shape is impossible
+// because the test imports the same code.
+
+import { extractCountryCode } from './shared/geo-extract.mjs';
+
+// WHO DON uses multi-word or hyphenated country names that the bigram scanner misses.
+// These override extractCountryCode for exact substring matches (checked first, case-insensitive).
+const WHO_NAME_OVERRIDES = {
+  'democratic republic of the congo': 'CD',
+  'dr congo': 'CD',
+  'timor-leste': 'TL',
+  'east timor': 'TL',
+  'papua new guinea': 'PG',
+  'kingdom of saudi arabia': 'SA',
+  'united kingdom': 'GB',
+};
+
+export function extractCountryCodeFull(text) {
+  const lower = text.toLowerCase();
+  for (const [name, iso2] of Object.entries(WHO_NAME_OVERRIDES)) {
+    if (lower.includes(name)) return iso2;
+  }
+  return extractCountryCode(text) ?? '';
+}
+
+export function stableHash(str) {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) h = (Math.imul(31, h) + str.charCodeAt(i)) | 0;
+  return Math.abs(h).toString(36);
+}
+
+/**
+ * Extract location string from WHO-style titles.
+ * Handles: "Disease – Country" (em-dash), "Disease - Country" (hyphen), "Disease in Country".
+ */
+export function extractLocationFromTitle(title) {
+  // WHO DON pattern: "Disease – Country" or "Disease - Country" (one or more dash-separated segments)
+  // Split on em-dash, en-dash, or " - " / " – " to get all segments, then take the last capitalized one.
+  const segments = title.split(/\s*[–—]\s*|\s+-\s+/);
+  if (segments.length >= 2) {
+    const last = segments[segments.length - 1].trim();
+    if (/^[A-Z]/.test(last)) return last;
+  }
+  // Fallback: "... in <Country/Region>"
+  const inMatch = title.match(/\bin\s+([A-Z][^,.(]+)/);
+  if (inMatch) return inMatch[1].trim();
+  return '';
+}
+
+export function detectAlertLevel(title, desc) {
+  const text = `${title} ${desc}`.toLowerCase();
+  if (text.includes('outbreak') || text.includes('emergency') || text.includes('epidemic') || text.includes('pandemic')) return 'alert';
+  if (text.includes('warning') || text.includes('spread') || text.includes('cases increasing')) return 'warning';
+  return 'watch';
+}
+
+export function detectDisease(title) {
+  const lower = title.toLowerCase();
+  const known = ['mpox', 'monkeypox', 'ebola', 'cholera', 'covid', 'dengue', 'measles',
+    'polio', 'marburg', 'lassa', 'plague', 'yellow fever', 'typhoid', 'influenza',
+    'avian flu', 'h5n1', 'h5n2', 'anthrax', 'rabies', 'meningitis', 'hepatitis',
+    'nipah', 'rift valley', 'crimean-congo', 'leishmaniasis', 'malaria', 'diphtheria',
+    'chikungunya', 'botulism', 'brucellosis', 'salmonella', 'listeria', 'e. coli',
+    'norovirus', 'legionella', 'campylobacter'];
+  for (const d of known) {
+    if (lower.includes(d)) return d.charAt(0).toUpperCase() + d.slice(1);
+  }
+  return 'Unknown Disease';
+}
+
+// ── Per-item normalization (shape contract for content-age) ──────────────
+//
+// All three parsers produce items in the SAME shape so contentMeta and
+// publishTransform can be uniform. The pre-publish in-memory shape carries:
+//   - publishedMs:                  non-null number (Date.now() fallback for
+//                                   UI/RPC consumer compat)
+//   - _originalPublishedMs:         parsed-ms or null (null when synthetic)
+//   - _publishedAtIsSynthetic:      boolean — true when publishedMs was a fallback
+// publishTransform strips the underscore-prefixed helpers before publish.
+
+/**
+ * Normalize one WHO DON API item.
+ * @param {object} item - raw WHO DON API entry: { Title, ItemDefaultUrl, PublicationDateAndTime }
+ * @param {number} nowMs - injectable "now" for deterministic tests; defaults to Date.now()
+ */
+export function whoNormalizeItem(item, nowMs = Date.now()) {
+  const origMs = item.PublicationDateAndTime ? new Date(item.PublicationDateAndTime).getTime() : null;
+  const hasOrig = origMs != null && Number.isFinite(origMs);
+  return {
+    title: (item.Title || '').trim(),
+    link: item.ItemDefaultUrl ? `https://www.who.int${item.ItemDefaultUrl}` : '',
+    desc: '',
+    publishedMs: hasOrig ? origMs : nowMs,
+    _originalPublishedMs: hasOrig ? origMs : null,
+    _publishedAtIsSynthetic: !hasOrig,
+    sourceName: 'WHO',
+  };
+}
+
+/**
+ * Normalize one RSS item (CDC HAN, Outbreak News Today).
+ * @param {object} parsed - { title, link, desc, pubDate, sourceName }
+ * @param {number} nowMs - injectable "now"
+ */
+export function rssNormalizeItem({ title, link, desc, pubDate, sourceName }, nowMs = Date.now()) {
+  const origMs = pubDate ? new Date(pubDate).getTime() : null;
+  const hasOrig = origMs != null && Number.isFinite(origMs);
+  return {
+    title, link, desc,
+    publishedMs: hasOrig ? origMs : nowMs,
+    sourceName,
+    _originalPublishedMs: hasOrig ? origMs : null,
+    _publishedAtIsSynthetic: !hasOrig,
+  };
+}
+
+/**
+ * Normalize one ThinkGlobalHealth record.
+ * Caller is expected to have already filtered out records with missing/unparseable dates
+ * (the seeder does this at line ~198), so TGH items are always non-synthetic.
+ * @param {object} rec - parsed TGH record
+ */
+export function tghNormalizeItem(rec) {
+  const publishedMs = new Date(rec.date).getTime();
+  // place_name from TGH is often "City, District, Country" — take only the first segment for display.
+  const cityName = (rec.placeName || '').split(',')[0].trim() || rec.country || '';
+  return {
+    title: `${rec.disease}${rec.country ? ` - ${rec.country}` : ''}`,
+    link: rec.sourceUrl || '',
+    desc: rec.summary ? rec.summary.slice(0, 300) : '',
+    publishedMs,
+    sourceName: 'ThinkGlobalHealth',
+    _country: rec.country || '',
+    _disease: rec.disease || '',
+    _location: cityName,
+    _lat: Number.isFinite(rec.lat) ? rec.lat : null,
+    _lng: Number.isFinite(rec.lng) ? rec.lng : null,
+    _cases: rec.cases ?? 0,
+    _originalPublishedMs: publishedMs,
+    _publishedAtIsSynthetic: false,
+  };
+}
+
+/**
+ * Map a normalized parser item to the cached `outbreaks[]` shape.
+ * Carries pre-publish helpers (`_publishedAtIsSynthetic`, `_originalPublishedMs`)
+ * for contentMeta to read at runSeed time. publishTransform strips them
+ * before atomicPublish so they never reach the canonical key or clients.
+ */
+export function mapItem(item) {
+  const location = item._location || extractLocationFromTitle(item.title)
+    || (item.sourceName === 'CDC' ? 'United States' : '');
+  const disease = item._disease || detectDisease(item.title);
+  const countryCode = item._country
+    ? (extractCountryCodeFull(item._country) || extractCountryCodeFull(location || item.title))
+    : extractCountryCodeFull(location || `${item.title} ${item.desc}`);
+  return {
+    id: `${item.sourceName.toLowerCase()}-${stableHash(item.link || item.title)}-${item.publishedMs}`,
+    disease,
+    location,
+    countryCode,
+    alertLevel: detectAlertLevel(item.title, item.desc),
+    summary: item.desc,
+    sourceUrl: item.link,
+    publishedAt: item.publishedMs,
+    sourceName: item.sourceName,
+    lat: item._lat ?? 0,
+    lng: item._lng ?? 0,
+    cases: item._cases || 0,
+    // PRE-PUBLISH HELPERS — see header comment.
+    _publishedAtIsSynthetic: item._publishedAtIsSynthetic === true,
+    _originalPublishedMs: item._originalPublishedMs ?? null,
+  };
+}
+
+// ── Content-age contract surfaces (Sprint 2) ─────────────────────────────
+
+/**
+ * Compute newest/oldest content timestamps from the disease-outbreaks payload.
+ *
+ * - Excludes items whose timestamp was synthetic (Date.now() fallback when
+ *   upstream omitted a date) — preserving them would falsely report content
+ *   as fresh and mask real upstream silence.
+ * - Excludes future-dated items beyond 1h clock-skew tolerance.
+ * - Returns null when no items have a usable timestamp — runSeed writes
+ *   newestItemAt: null, classifier reads as STALE_CONTENT.
+ *
+ * @param {{outbreaks: Array}} data
+ * @param {number} nowMs - injectable "now" for deterministic tests
+ */
+export function diseaseContentMeta(data, nowMs = Date.now()) {
+  const items = Array.isArray(data?.outbreaks) ? data.outbreaks : [];
+  let newest = -Infinity, oldest = Infinity, validCount = 0;
+  const skewLimit = nowMs + 60 * 60 * 1000;
+  for (const item of items) {
+    if (item._publishedAtIsSynthetic === true) continue;
+    const ts = item._originalPublishedMs;
+    if (typeof ts !== 'number' || !Number.isFinite(ts) || ts <= 0) continue;
+    if (ts > skewLimit) continue;
+    validCount++;
+    if (ts > newest) newest = ts;
+    if (ts < oldest) oldest = ts;
+  }
+  if (validCount === 0) return null;
+  return { newestItemAt: newest, oldestItemAt: oldest };
+}
+
+/**
+ * Strip pre-publish helper fields from every outbreak before atomicPublish.
+ * Helpers (_publishedAtIsSynthetic, _originalPublishedMs) MUST NOT appear in:
+ *   - the Redis canonical key (health:disease-outbreaks:v1)
+ *   - /api/bootstrap response (data.diseaseOutbreaks)
+ *   - list-disease-outbreaks RPC response
+ *   - the DiseaseOutbreakItem proto-generated type
+ */
+export function diseasePublishTransform(data) {
+  const outbreaks = Array.isArray(data?.outbreaks) ? data.outbreaks : [];
+  return {
+    ...data,
+    outbreaks: outbreaks.map((item) => {
+      const { _publishedAtIsSynthetic: _a, _originalPublishedMs: _b, ...rest } = item;
+      return rest;
+    }),
+  };
+}
+
+/** Sprint 2 pilot threshold (9 days). Single source of truth — exported so the
+ *  seeder uses the same constant the test asserts against. */
+export const DISEASE_MAX_CONTENT_AGE_MIN = 9 * 24 * 60;

--- a/scripts/seed-disease-outbreaks.mjs
+++ b/scripts/seed-disease-outbreaks.mjs
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
-import { extractCountryCode } from './shared/geo-extract.mjs';
 // Reuse the battle-tested schema-anchored parser from seed-vpd-tracker.mjs.
 // The 2026-04 webpack rebuild changed the TGH bundle from the legacy
 // `var a=[{Alert_ID:"..."}]` shape (unquoted keys) to `eval("var res = [...]")`
@@ -11,28 +10,20 @@ import { extractCountryCode } from './shared/geo-extract.mjs';
 // its top-level runSeed is guarded by `if (process.argv[1]?.endsWith(...))`,
 // so importing as a module just exposes the parsers.
 import { parseRealtimeAlerts } from './seed-vpd-tracker.mjs';
+// Pure helpers (parsers/mappers/contentMeta/publishTransform) live in their
+// own module so tests can import the real code instead of replicating it.
+// See `scripts/_disease-outbreaks-helpers.mjs` for the shape contract.
+import {
+  whoNormalizeItem,
+  rssNormalizeItem,
+  tghNormalizeItem,
+  mapItem,
+  diseaseContentMeta,
+  diseasePublishTransform,
+  DISEASE_MAX_CONTENT_AGE_MIN,
+} from './_disease-outbreaks-helpers.mjs';
 
 loadEnvFile(import.meta.url);
-
-// WHO DON uses multi-word or hyphenated country names that the bigram scanner misses.
-// These override extractCountryCode for exact substring matches (checked first, case-insensitive).
-const WHO_NAME_OVERRIDES = {
-  'democratic republic of the congo': 'CD',
-  'dr congo': 'CD',
-  'timor-leste': 'TL',
-  'east timor': 'TL',
-  'papua new guinea': 'PG',
-  'kingdom of saudi arabia': 'SA',
-  'united kingdom': 'GB',
-};
-
-function extractCountryCodeFull(text) {
-  const lower = text.toLowerCase();
-  for (const [name, iso2] of Object.entries(WHO_NAME_OVERRIDES)) {
-    if (lower.includes(name)) return iso2;
-  }
-  return extractCountryCode(text) ?? '';
-}
 
 const CANONICAL_KEY = 'health:disease-outbreaks:v1';
 const CACHE_TTL = 259200; // 72h (3 days) — 3× daily cron interval per gold standard; survives 2 consecutive missed runs
@@ -54,52 +45,6 @@ const TGH_LOOKBACK_DAYS = 90;
 
 const RSS_MAX_BYTES = 500_000; // guard against oversized responses before regex
 
-
-function stableHash(str) {
-  let h = 0;
-  for (let i = 0; i < str.length; i++) h = (Math.imul(31, h) + str.charCodeAt(i)) | 0;
-  return Math.abs(h).toString(36);
-}
-
-/**
- * Extract location string from WHO-style titles.
- * Handles: "Disease – Country" (em-dash), "Disease - Country" (hyphen), "Disease in Country".
- */
-function extractLocationFromTitle(title) {
-  // WHO DON pattern: "Disease – Country" or "Disease - Country" (one or more dash-separated segments)
-  // Split on em-dash, en-dash, or " - " / " – " to get all segments, then take the last capitalized one.
-  const segments = title.split(/\s*[–—]\s*|\s+-\s+/);
-  if (segments.length >= 2) {
-    const last = segments[segments.length - 1].trim();
-    if (/^[A-Z]/.test(last)) return last;
-  }
-  // Fallback: "... in <Country/Region>"
-  const inMatch = title.match(/\bin\s+([A-Z][^,.(]+)/);
-  if (inMatch) return inMatch[1].trim();
-  return '';
-}
-
-function detectAlertLevel(title, desc) {
-  const text = `${title} ${desc}`.toLowerCase();
-  if (text.includes('outbreak') || text.includes('emergency') || text.includes('epidemic') || text.includes('pandemic')) return 'alert';
-  if (text.includes('warning') || text.includes('spread') || text.includes('cases increasing')) return 'warning';
-  return 'watch';
-}
-
-function detectDisease(title) {
-  const lower = title.toLowerCase();
-  const known = ['mpox', 'monkeypox', 'ebola', 'cholera', 'covid', 'dengue', 'measles',
-    'polio', 'marburg', 'lassa', 'plague', 'yellow fever', 'typhoid', 'influenza',
-    'avian flu', 'h5n1', 'h5n2', 'anthrax', 'rabies', 'meningitis', 'hepatitis',
-    'nipah', 'rift valley', 'crimean-congo', 'leishmaniasis', 'malaria', 'diphtheria',
-    'chikungunya', 'botulism', 'brucellosis', 'salmonella', 'listeria', 'e. coli',
-    'norovirus', 'legionella', 'campylobacter'];
-  for (const d of known) {
-    if (lower.includes(d)) return d.charAt(0).toUpperCase() + d.slice(1);
-  }
-  return 'Unknown Disease';
-}
-
 /**
  * Fetch WHO Disease Outbreak News via their JSON API (RSS feed is dead since 2024).
  * Returns normalized items array.
@@ -114,25 +59,10 @@ async function fetchWhoDonApi() {
     const data = await resp.json();
     const items = data?.value;
     if (!Array.isArray(items)) { console.warn('[Disease] WHO DON API: unexpected response shape'); return []; }
-    return items.map((item) => {
-      // Tag synthetic-vs-real timestamps. WHO DON occasionally omits
-      // PublicationDateAndTime; falling back to Date.now() keeps publishedMs
-      // non-null (preserving the existing isNaN filter + UI consumer
-      // contract) but the parallel _originalPublishedMs / _publishedAtIsSynthetic
-      // pair lets contentMeta exclude these from newest-item-age calculations
-      // — otherwise an undated WHO item would falsely report content as fresh.
-      const origMs = item.PublicationDateAndTime ? new Date(item.PublicationDateAndTime).getTime() : null;
-      const hasOrig = origMs != null && Number.isFinite(origMs);
-      return {
-        title: (item.Title || '').trim(),
-        link: item.ItemDefaultUrl ? `https://www.who.int${item.ItemDefaultUrl}` : '',
-        desc: '',
-        publishedMs: hasOrig ? origMs : Date.now(),
-        _originalPublishedMs: hasOrig ? origMs : null,
-        _publishedAtIsSynthetic: !hasOrig,
-        sourceName: 'WHO',
-      };
-    }).filter(i => i.title && Number.isFinite(i.publishedMs));
+    // Per-item synthetic-tag normalization lives in _disease-outbreaks-helpers.mjs
+    // so tests can verify the exact contract without duplicating logic.
+    return items.map((item) => whoNormalizeItem(item))
+      .filter(i => i.title && Number.isFinite(i.publishedMs));
   } catch (e) {
     console.warn('[Disease] WHO DON API fetch error:', e?.message || e);
     return [];
@@ -160,19 +90,11 @@ async function fetchRssItems(url, sourceName) {
         .replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&').replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&nbsp;/g, ' ')
         .replace(/<[^>]+>/g, '').trim().slice(0, 300);
       const pubDate = (block.match(/<pubDate>(.*?)<\/pubDate>/) || [])[1]?.trim() || '';
-      // Same synthetic-tagging pattern as fetchWhoDonApi — the RSS parser
-      // also falls back to Date.now() when pubDate is missing/unparseable.
-      // Carry _originalPublishedMs / _publishedAtIsSynthetic so contentMeta
-      // can exclude those items from newest-item-age computation.
-      const origMs = pubDate ? new Date(pubDate).getTime() : null;
-      const hasOrig = origMs != null && Number.isFinite(origMs);
-      const publishedMs = hasOrig ? origMs : Date.now();
-      if (!title || !Number.isFinite(publishedMs)) continue;
-      items.push({
-        title, link, desc, publishedMs, sourceName,
-        _originalPublishedMs: hasOrig ? origMs : null,
-        _publishedAtIsSynthetic: !hasOrig,
-      });
+      // Per-item synthetic-tag normalization lives in _disease-outbreaks-helpers.mjs
+      // (rssNormalizeItem) so tests verify the exact contract without duplicating logic.
+      const normalized = rssNormalizeItem({ title, link, desc, pubDate, sourceName });
+      if (!normalized.title || !Number.isFinite(normalized.publishedMs)) continue;
+      items.push(normalized);
     }
     return items;
   } catch (e) {
@@ -218,26 +140,9 @@ async function fetchThinkGlobalHealth() {
       if (rec.lat == null || rec.lng == null || !rec.disease || !rec.date) continue;
       const publishedMs = new Date(rec.date).getTime();
       if (isNaN(publishedMs) || publishedMs < cutoff) continue;
-      // place_name from TGH is often "City, District, Country" — take only the first segment for display.
-      const cityName = (rec.placeName || '').split(',')[0].trim() || rec.country || '';
-      items.push({
-        title: `${rec.disease}${rec.country ? ` - ${rec.country}` : ''}`,
-        link: rec.sourceUrl || '',
-        desc: rec.summary ? rec.summary.slice(0, 300) : '',
-        publishedMs,
-        sourceName: 'ThinkGlobalHealth',
-        _country: rec.country || '',
-        _disease: rec.disease || '',
-        _location: cityName,
-        _lat: Number.isFinite(rec.lat) ? rec.lat : null,
-        _lng: Number.isFinite(rec.lng) ? rec.lng : null,
-        _cases: rec.cases ?? 0,
-        // TGH always carries a parsed date by line 198's filter; mirror the
-        // same shape as WHO/RSS so contentMeta + publishTransform can apply
-        // uniformly across all three sources.
-        _originalPublishedMs: publishedMs,
-        _publishedAtIsSynthetic: false,
-      });
+      // Per-item normalization lives in _disease-outbreaks-helpers.mjs
+      // (tghNormalizeItem) so tests verify the exact contract without duplicating logic.
+      items.push(tghNormalizeItem(rec));
     }
     console.log(`[Disease] ThinkGlobalHealth: ${records.length} total, ${items.length} in last ${TGH_LOOKBACK_DAYS}d`);
     return items;
@@ -245,41 +150,6 @@ async function fetchThinkGlobalHealth() {
     console.warn('[Disease] ThinkGlobalHealth fetch error:', e?.message || e);
     return [];
   }
-}
-
-function mapItem(item) {
-  const location = item._location || extractLocationFromTitle(item.title)
-    || (item.sourceName === 'CDC' ? 'United States' : '');
-  const disease = item._disease || detectDisease(item.title);
-  const countryCode = item._country
-    ? (extractCountryCodeFull(item._country) || extractCountryCodeFull(location || item.title))
-    : extractCountryCodeFull(location || `${item.title} ${item.desc}`);
-  return {
-    id: `${item.sourceName.toLowerCase()}-${stableHash(item.link || item.title)}-${item.publishedMs}`,
-    disease,
-    location,
-    countryCode,
-    alertLevel: detectAlertLevel(item.title, item.desc),
-    summary: item.desc,
-    sourceUrl: item.link,
-    publishedAt: item.publishedMs,
-    sourceName: item.sourceName,
-    lat: item._lat ?? 0,
-    lng: item._lng ?? 0,
-    cases: item._cases || 0,
-    // PRE-PUBLISH HELPERS (Sprint 2 — health-readiness content-age contract).
-    // Used by contentMeta at runSeed time to exclude items with synthetic
-    // (Date.now() fallback) timestamps from newest-item-age computation.
-    // Stripped by the publishTransform in runSeed opts BEFORE the canonical
-    // payload is written, so they NEVER appear in:
-    //   - resilience:disease-outbreaks:v1 canonical key
-    //   - /api/bootstrap response (data.diseaseOutbreaks)
-    //   - list-disease-outbreaks RPC response
-    //   - DiseaseOutbreakItem proto-generated type
-    // See plan Sprint 2 / Step 2.3 for the strip contract.
-    _publishedAtIsSynthetic: item._publishedAtIsSynthetic === true,
-    _originalPublishedMs: item._originalPublishedMs ?? null,
-  };
 }
 
 async function fetchDiseaseOutbreaks() {
@@ -349,58 +219,19 @@ runSeed('health', 'disease-outbreaks', CANONICAL_KEY, fetchDiseaseOutbreaks, {
 
   // ── Content-age contract (Sprint 2 of the 2026-05-04 health-readiness plan) ──
   //
-  // Sets a 9-day budget chosen so the 2026-05-04 incident — where the cache
-  // held 50 outbreaks all 11+ days old — would have correctly tripped
-  // STALE_CONTENT in /api/health. WHO Disease Outbreak News publishes
-  // 1-2/week (typical gap 3-5d), CDC HAN is sporadic but rarely silent for
-  // a full week, and TGH (post-#3593) provides daily ProMED items. 9 days
-  // tolerates a single quiet WHO/CDC week without paging on normal cadence.
+  // 9-day budget chosen so the 2026-05-04 incident — where the cache held
+  // 50 outbreaks all 11+ days old — would have correctly tripped STALE_CONTENT
+  // in /api/health. WHO Disease Outbreak News publishes 1-2/week (typical gap
+  // 3-5d), CDC HAN is sporadic but rarely silent for a full week, and TGH
+  // (post-#3593) provides daily ProMED items. 9 days tolerates a single quiet
+  // WHO/CDC week without paging on normal cadence.
   //
-  // contentMeta excludes items with `_publishedAtIsSynthetic: true` (those
-  // got a Date.now() fallback because the upstream omitted a date). Without
-  // this exclusion, undated items would falsely report content as fresh and
-  // mask a real upstream silence. Future-dated items beyond 1h clock-skew
-  // tolerance are also excluded — matches list-feed-digest's
-  // FUTURE_DATE_TOLERANCE_MS pattern.
-  //
-  // Returns null when no items have a usable timestamp — runSeed writes
-  // newestItemAt: null, classifier reads as STALE_CONTENT.
-  contentMeta: (data) => {
-    const items = Array.isArray(data?.outbreaks) ? data.outbreaks : [];
-    let newest = -Infinity, oldest = Infinity, validCount = 0;
-    const skewLimit = Date.now() + 60 * 60 * 1000;
-    for (const item of items) {
-      if (item._publishedAtIsSynthetic === true) continue;
-      const ts = item._originalPublishedMs;
-      if (typeof ts !== 'number' || !Number.isFinite(ts) || ts <= 0) continue;
-      if (ts > skewLimit) continue;
-      validCount++;
-      if (ts > newest) newest = ts;
-      if (ts < oldest) oldest = ts;
-    }
-    if (validCount === 0) return null;
-    return { newestItemAt: newest, oldestItemAt: oldest };
-  },
-  maxContentAgeMin: 9 * 24 * 60,
-
-  // Strip pre-publish helper fields BEFORE atomicPublish writes the canonical
-  // key. Per the Sprint 1 ordering contract, contentMeta has already run on
-  // the raw fetcher output by this point, so it's safe to drop these.
-  // _publishedAtIsSynthetic + _originalPublishedMs MUST NOT appear in:
-  //   - the canonical key (Redis read-back)
-  //   - /api/bootstrap response payload
-  //   - list-disease-outbreaks RPC response
-  //   - the DiseaseOutbreakItem proto-generated type
-  publishTransform: (data) => {
-    const outbreaks = Array.isArray(data?.outbreaks) ? data.outbreaks : [];
-    return {
-      ...data,
-      outbreaks: outbreaks.map((item) => {
-        const { _publishedAtIsSynthetic: _a, _originalPublishedMs: _b, ...rest } = item;
-        return rest;
-      }),
-    };
-  },
+  // diseaseContentMeta + diseasePublishTransform live in
+  // `_disease-outbreaks-helpers.mjs` so the test suite imports the same code
+  // the seeder runs (no drift). See helpers module header for their semantics.
+  contentMeta: diseaseContentMeta,
+  maxContentAgeMin: DISEASE_MAX_CONTENT_AGE_MIN,
+  publishTransform: diseasePublishTransform,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
   console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-disease-outbreaks.mjs
+++ b/scripts/seed-disease-outbreaks.mjs
@@ -114,13 +114,25 @@ async function fetchWhoDonApi() {
     const data = await resp.json();
     const items = data?.value;
     if (!Array.isArray(items)) { console.warn('[Disease] WHO DON API: unexpected response shape'); return []; }
-    return items.map((item) => ({
-      title: (item.Title || '').trim(),
-      link: item.ItemDefaultUrl ? `https://www.who.int${item.ItemDefaultUrl}` : '',
-      desc: '',
-      publishedMs: item.PublicationDateAndTime ? new Date(item.PublicationDateAndTime).getTime() : Date.now(),
-      sourceName: 'WHO',
-    })).filter(i => i.title && !isNaN(i.publishedMs));
+    return items.map((item) => {
+      // Tag synthetic-vs-real timestamps. WHO DON occasionally omits
+      // PublicationDateAndTime; falling back to Date.now() keeps publishedMs
+      // non-null (preserving the existing isNaN filter + UI consumer
+      // contract) but the parallel _originalPublishedMs / _publishedAtIsSynthetic
+      // pair lets contentMeta exclude these from newest-item-age calculations
+      // — otherwise an undated WHO item would falsely report content as fresh.
+      const origMs = item.PublicationDateAndTime ? new Date(item.PublicationDateAndTime).getTime() : null;
+      const hasOrig = origMs != null && Number.isFinite(origMs);
+      return {
+        title: (item.Title || '').trim(),
+        link: item.ItemDefaultUrl ? `https://www.who.int${item.ItemDefaultUrl}` : '',
+        desc: '',
+        publishedMs: hasOrig ? origMs : Date.now(),
+        _originalPublishedMs: hasOrig ? origMs : null,
+        _publishedAtIsSynthetic: !hasOrig,
+        sourceName: 'WHO',
+      };
+    }).filter(i => i.title && Number.isFinite(i.publishedMs));
   } catch (e) {
     console.warn('[Disease] WHO DON API fetch error:', e?.message || e);
     return [];
@@ -148,9 +160,19 @@ async function fetchRssItems(url, sourceName) {
         .replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&').replace(/&quot;/g, '"').replace(/&#39;/g, "'").replace(/&nbsp;/g, ' ')
         .replace(/<[^>]+>/g, '').trim().slice(0, 300);
       const pubDate = (block.match(/<pubDate>(.*?)<\/pubDate>/) || [])[1]?.trim() || '';
-      const publishedMs = pubDate ? new Date(pubDate).getTime() : Date.now();
-      if (!title || isNaN(publishedMs)) continue;
-      items.push({ title, link, desc, publishedMs, sourceName });
+      // Same synthetic-tagging pattern as fetchWhoDonApi — the RSS parser
+      // also falls back to Date.now() when pubDate is missing/unparseable.
+      // Carry _originalPublishedMs / _publishedAtIsSynthetic so contentMeta
+      // can exclude those items from newest-item-age computation.
+      const origMs = pubDate ? new Date(pubDate).getTime() : null;
+      const hasOrig = origMs != null && Number.isFinite(origMs);
+      const publishedMs = hasOrig ? origMs : Date.now();
+      if (!title || !Number.isFinite(publishedMs)) continue;
+      items.push({
+        title, link, desc, publishedMs, sourceName,
+        _originalPublishedMs: hasOrig ? origMs : null,
+        _publishedAtIsSynthetic: !hasOrig,
+      });
     }
     return items;
   } catch (e) {
@@ -210,6 +232,11 @@ async function fetchThinkGlobalHealth() {
         _lat: Number.isFinite(rec.lat) ? rec.lat : null,
         _lng: Number.isFinite(rec.lng) ? rec.lng : null,
         _cases: rec.cases ?? 0,
+        // TGH always carries a parsed date by line 198's filter; mirror the
+        // same shape as WHO/RSS so contentMeta + publishTransform can apply
+        // uniformly across all three sources.
+        _originalPublishedMs: publishedMs,
+        _publishedAtIsSynthetic: false,
       });
     }
     console.log(`[Disease] ThinkGlobalHealth: ${records.length} total, ${items.length} in last ${TGH_LOOKBACK_DAYS}d`);
@@ -240,6 +267,18 @@ function mapItem(item) {
     lat: item._lat ?? 0,
     lng: item._lng ?? 0,
     cases: item._cases || 0,
+    // PRE-PUBLISH HELPERS (Sprint 2 — health-readiness content-age contract).
+    // Used by contentMeta at runSeed time to exclude items with synthetic
+    // (Date.now() fallback) timestamps from newest-item-age computation.
+    // Stripped by the publishTransform in runSeed opts BEFORE the canonical
+    // payload is written, so they NEVER appear in:
+    //   - resilience:disease-outbreaks:v1 canonical key
+    //   - /api/bootstrap response (data.diseaseOutbreaks)
+    //   - list-disease-outbreaks RPC response
+    //   - DiseaseOutbreakItem proto-generated type
+    // See plan Sprint 2 / Step 2.3 for the strip contract.
+    _publishedAtIsSynthetic: item._publishedAtIsSynthetic === true,
+    _originalPublishedMs: item._originalPublishedMs ?? null,
   };
 }
 
@@ -307,6 +346,61 @@ runSeed('health', 'disease-outbreaks', CANONICAL_KEY, fetchDiseaseOutbreaks, {
   declareRecords,
   schemaVersion: 1,
   maxStaleMin: 2880,
+
+  // ── Content-age contract (Sprint 2 of the 2026-05-04 health-readiness plan) ──
+  //
+  // Sets a 9-day budget chosen so the 2026-05-04 incident — where the cache
+  // held 50 outbreaks all 11+ days old — would have correctly tripped
+  // STALE_CONTENT in /api/health. WHO Disease Outbreak News publishes
+  // 1-2/week (typical gap 3-5d), CDC HAN is sporadic but rarely silent for
+  // a full week, and TGH (post-#3593) provides daily ProMED items. 9 days
+  // tolerates a single quiet WHO/CDC week without paging on normal cadence.
+  //
+  // contentMeta excludes items with `_publishedAtIsSynthetic: true` (those
+  // got a Date.now() fallback because the upstream omitted a date). Without
+  // this exclusion, undated items would falsely report content as fresh and
+  // mask a real upstream silence. Future-dated items beyond 1h clock-skew
+  // tolerance are also excluded — matches list-feed-digest's
+  // FUTURE_DATE_TOLERANCE_MS pattern.
+  //
+  // Returns null when no items have a usable timestamp — runSeed writes
+  // newestItemAt: null, classifier reads as STALE_CONTENT.
+  contentMeta: (data) => {
+    const items = Array.isArray(data?.outbreaks) ? data.outbreaks : [];
+    let newest = -Infinity, oldest = Infinity, validCount = 0;
+    const skewLimit = Date.now() + 60 * 60 * 1000;
+    for (const item of items) {
+      if (item._publishedAtIsSynthetic === true) continue;
+      const ts = item._originalPublishedMs;
+      if (typeof ts !== 'number' || !Number.isFinite(ts) || ts <= 0) continue;
+      if (ts > skewLimit) continue;
+      validCount++;
+      if (ts > newest) newest = ts;
+      if (ts < oldest) oldest = ts;
+    }
+    if (validCount === 0) return null;
+    return { newestItemAt: newest, oldestItemAt: oldest };
+  },
+  maxContentAgeMin: 9 * 24 * 60,
+
+  // Strip pre-publish helper fields BEFORE atomicPublish writes the canonical
+  // key. Per the Sprint 1 ordering contract, contentMeta has already run on
+  // the raw fetcher output by this point, so it's safe to drop these.
+  // _publishedAtIsSynthetic + _originalPublishedMs MUST NOT appear in:
+  //   - the canonical key (Redis read-back)
+  //   - /api/bootstrap response payload
+  //   - list-disease-outbreaks RPC response
+  //   - the DiseaseOutbreakItem proto-generated type
+  publishTransform: (data) => {
+    const outbreaks = Array.isArray(data?.outbreaks) ? data.outbreaks : [];
+    return {
+      ...data,
+      outbreaks: outbreaks.map((item) => {
+        const { _publishedAtIsSynthetic: _a, _originalPublishedMs: _b, ...rest } = item;
+        return rest;
+      }),
+    };
+  },
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
   console.error('FATAL:', (err.message || err) + _cause);

--- a/tests/disease-outbreaks-seed.test.mjs
+++ b/tests/disease-outbreaks-seed.test.mjs
@@ -1,0 +1,345 @@
+// Sprint 2 — Disease-outbreaks content-age pilot (2026-05-04 health-readiness plan).
+//
+// Tests are split by LAYER per the Codex round 4-5 contract:
+//
+//   - PRE-PUBLISH (in-memory parser/mapItem): items MUST carry the helpers
+//     _publishedAtIsSynthetic and _originalPublishedMs so contentMeta can
+//     compute newest-item-age while excluding synthetic timestamps.
+//
+//   - POST-STRIP (canonical-key payload): items MUST NOT carry the helpers.
+//     publishTransform strips them before atomicPublish, so they never reach
+//     /api/bootstrap responses, list-disease-outbreaks RPC, or the
+//     DiseaseOutbreakItem proto type.
+//
+// Test against the SAME functions the seeder uses, importing them from a
+// fresh module under stubbed env (no Redis writes).
+
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = join(__filename, '..', '..');
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_EXIT = process.exit;
+const ORIGINAL_ENV = {
+  UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+  UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
+};
+
+beforeEach(() => {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.example.com';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  process.exit = ORIGINAL_EXIT;
+  if (ORIGINAL_ENV.UPSTASH_REDIS_REST_URL == null) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = ORIGINAL_ENV.UPSTASH_REDIS_REST_URL;
+  if (ORIGINAL_ENV.UPSTASH_REDIS_REST_TOKEN == null) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = ORIGINAL_ENV.UPSTASH_REDIS_REST_TOKEN;
+});
+
+// We don't import seed-disease-outbreaks.mjs directly because doing so triggers
+// the runSeed() top-level call that exits the process. Instead, we replicate
+// the EXACT inline shapes the seeder uses (post-Sprint 2 migration) and assert
+// the contract holds. If the seeder's parser/mapItem shape drifts from this
+// test, the seeder change MUST also update this test — that's intentional;
+// silent shape drift is exactly what this test is here to prevent.
+
+// ── Replicate the parser logic for assertion ────────────────────────────
+//
+// These functions mirror the seeder's WHO/RSS/TGH parser shapes. The intent
+// is that ANY change to those parsers must produce the same shape this test
+// asserts against — drift here surfaces at PR-review time.
+
+function whoMapPreservesContract(item, nowMs) {
+  const origMs = item.PublicationDateAndTime ? new Date(item.PublicationDateAndTime).getTime() : null;
+  const hasOrig = origMs != null && Number.isFinite(origMs);
+  return {
+    title: (item.Title || '').trim(),
+    link: item.ItemDefaultUrl ? `https://www.who.int${item.ItemDefaultUrl}` : '',
+    desc: '',
+    publishedMs: hasOrig ? origMs : nowMs,
+    _originalPublishedMs: hasOrig ? origMs : null,
+    _publishedAtIsSynthetic: !hasOrig,
+    sourceName: 'WHO',
+  };
+}
+
+function rssMapPreservesContract({ title, link, desc, pubDate, sourceName }, nowMs) {
+  const origMs = pubDate ? new Date(pubDate).getTime() : null;
+  const hasOrig = origMs != null && Number.isFinite(origMs);
+  return {
+    title, link, desc,
+    publishedMs: hasOrig ? origMs : nowMs,
+    sourceName,
+    _originalPublishedMs: hasOrig ? origMs : null,
+    _publishedAtIsSynthetic: !hasOrig,
+  };
+}
+
+function tghMapPreservesContract(rec) {
+  const publishedMs = new Date(rec.date).getTime();
+  return {
+    title: `${rec.disease}${rec.country ? ` - ${rec.country}` : ''}`,
+    link: rec.sourceUrl || '',
+    desc: rec.summary || '',
+    publishedMs,
+    sourceName: 'ThinkGlobalHealth',
+    _country: rec.country,
+    _disease: rec.disease,
+    _location: '',
+    _lat: rec.lat,
+    _lng: rec.lng,
+    _cases: rec.cases || 0,
+    _originalPublishedMs: publishedMs,
+    _publishedAtIsSynthetic: false,
+  };
+}
+
+// ── Pre-publish (in-memory) layer ────────────────────────────────────────
+
+test('WHO record without PublicationDateAndTime → in-memory item is tagged synthetic', () => {
+  const NOW = 1700000000000;
+  const inMemory = whoMapPreservesContract({ Title: 'Mpox - Country X', ItemDefaultUrl: '/mpox-x' }, NOW);
+  assert.equal(inMemory._publishedAtIsSynthetic, true);
+  assert.equal(inMemory._originalPublishedMs, null);
+  assert.equal(inMemory.publishedMs, NOW, 'publishedMs falls back to now() so existing isFinite filters + UI consumer contract still hold');
+});
+
+test('WHO record with valid PublicationDateAndTime → in-memory item is non-synthetic', () => {
+  const NOW = 1700000000000;
+  const PUB_ISO = '2026-04-23T15:30:00Z';
+  const PUB_MS = new Date(PUB_ISO).getTime();
+  const inMemory = whoMapPreservesContract({ Title: 'Mpox', ItemDefaultUrl: '/mpox', PublicationDateAndTime: PUB_ISO }, NOW);
+  assert.equal(inMemory._publishedAtIsSynthetic, false);
+  assert.equal(inMemory._originalPublishedMs, PUB_MS);
+  assert.equal(inMemory.publishedMs, PUB_MS);
+});
+
+test('RSS record without pubDate → in-memory item is tagged synthetic', () => {
+  const NOW = 1700000000000;
+  const inMemory = rssMapPreservesContract({ title: 'Outbreak', link: 'http://x', desc: '', pubDate: '', sourceName: 'CDC' }, NOW);
+  assert.equal(inMemory._publishedAtIsSynthetic, true);
+  assert.equal(inMemory._originalPublishedMs, null);
+  assert.equal(inMemory.publishedMs, NOW);
+});
+
+test('RSS record with valid pubDate → in-memory item is non-synthetic', () => {
+  const NOW = 1700000000000;
+  const PUB = 'Wed, 23 Apr 2026 15:30:00 GMT';
+  const PUB_MS = new Date(PUB).getTime();
+  const inMemory = rssMapPreservesContract({ title: 'Outbreak', link: 'http://x', desc: '', pubDate: PUB, sourceName: 'CDC' }, NOW);
+  assert.equal(inMemory._publishedAtIsSynthetic, false);
+  assert.equal(inMemory._originalPublishedMs, PUB_MS);
+  assert.equal(inMemory.publishedMs, PUB_MS);
+});
+
+test('TGH record always non-synthetic (line-198 filter rejects undated items earlier in the seeder)', () => {
+  const inMemory = tghMapPreservesContract({
+    Alert_ID: '1', lat: 12.3, lng: 45.6, disease: 'Cholera', country: 'X',
+    date: '4/23/2026', sourceUrl: 'http://x', summary: 's', cases: '5',
+  });
+  assert.equal(inMemory._publishedAtIsSynthetic, false);
+  assert.equal(typeof inMemory._originalPublishedMs, 'number');
+  assert.ok(inMemory._originalPublishedMs > 0);
+});
+
+// ── contentMeta behavior ─────────────────────────────────────────────────
+//
+// Replicate the seeder's contentMeta inline so test failures surface here
+// rather than at deploy time. The shape MUST match scripts/seed-disease-outbreaks.mjs.
+
+function diseaseContentMeta(data) {
+  const items = Array.isArray(data?.outbreaks) ? data.outbreaks : [];
+  let newest = -Infinity, oldest = Infinity, validCount = 0;
+  const skewLimit = Date.now() + 60 * 60 * 1000;
+  for (const item of items) {
+    if (item._publishedAtIsSynthetic === true) continue;
+    const ts = item._originalPublishedMs;
+    if (typeof ts !== 'number' || !Number.isFinite(ts) || ts <= 0) continue;
+    if (ts > skewLimit) continue;
+    validCount++;
+    if (ts > newest) newest = ts;
+    if (ts < oldest) oldest = ts;
+  }
+  if (validCount === 0) return null;
+  return { newestItemAt: newest, oldestItemAt: oldest };
+}
+
+test('contentMeta returns null when ALL items are synthetic', () => {
+  const NOW = Date.now();
+  const data = {
+    outbreaks: [
+      { id: 'a', publishedAt: NOW, _publishedAtIsSynthetic: true, _originalPublishedMs: null },
+      { id: 'b', publishedAt: NOW, _publishedAtIsSynthetic: true, _originalPublishedMs: null },
+    ],
+  };
+  assert.equal(diseaseContentMeta(data), null, 'all-synthetic → null → STALE_CONTENT');
+});
+
+test('contentMeta excludes synthetic items when mixed (does not let synthetic newest win)', () => {
+  const PAST = 1700000000000;
+  const data = {
+    outbreaks: [
+      // synthetic with VERY recent publishedMs (Date.now() fallback)
+      { id: 'a', publishedAt: Date.now(), _publishedAtIsSynthetic: true, _originalPublishedMs: null },
+      // real item, older but valid
+      { id: 'b', publishedAt: PAST, _publishedAtIsSynthetic: false, _originalPublishedMs: PAST },
+    ],
+  };
+  const result = diseaseContentMeta(data);
+  assert.equal(result.newestItemAt, PAST, 'synthetic must NOT influence newest — real older item wins');
+  assert.equal(result.oldestItemAt, PAST);
+});
+
+test('contentMeta picks newest and oldest from the non-synthetic set', () => {
+  const NEWEST = 1700000000000;
+  const OLDEST = 1690000000000;
+  const data = {
+    outbreaks: [
+      { _publishedAtIsSynthetic: false, _originalPublishedMs: OLDEST },
+      { _publishedAtIsSynthetic: false, _originalPublishedMs: NEWEST },
+      { _publishedAtIsSynthetic: false, _originalPublishedMs: (NEWEST + OLDEST) / 2 },
+    ],
+  };
+  const result = diseaseContentMeta(data);
+  assert.equal(result.newestItemAt, NEWEST);
+  assert.equal(result.oldestItemAt, OLDEST);
+});
+
+test('contentMeta excludes future-dated items beyond 1h clock-skew tolerance', () => {
+  const REAL_RECENT = Date.now() - 2 * 24 * 60 * 60 * 1000;
+  const FUTURE = Date.now() + 2 * 60 * 60 * 1000;    // 2h in the future
+  const data = {
+    outbreaks: [
+      { _publishedAtIsSynthetic: false, _originalPublishedMs: FUTURE },
+      { _publishedAtIsSynthetic: false, _originalPublishedMs: REAL_RECENT },
+    ],
+  };
+  const result = diseaseContentMeta(data);
+  assert.equal(result.newestItemAt, REAL_RECENT, 'future-dated item beyond 1h tolerance excluded — real most-recent wins');
+});
+
+test('contentMeta accepts items within 1h clock-skew tolerance', () => {
+  const NEAR_FUTURE = Date.now() + 30 * 60 * 1000;    // 30min ahead, within 1h tolerance
+  const data = {
+    outbreaks: [
+      { _publishedAtIsSynthetic: false, _originalPublishedMs: NEAR_FUTURE },
+    ],
+  };
+  const result = diseaseContentMeta(data);
+  assert.equal(result.newestItemAt, NEAR_FUTURE, 'NEAR_FUTURE within 1h tolerance is accepted');
+});
+
+// ── publishTransform strip ───────────────────────────────────────────────
+
+function diseasePublishTransform(data) {
+  const outbreaks = Array.isArray(data?.outbreaks) ? data.outbreaks : [];
+  return {
+    ...data,
+    outbreaks: outbreaks.map((item) => {
+      const { _publishedAtIsSynthetic: _a, _originalPublishedMs: _b, ...rest } = item;
+      return rest;
+    }),
+  };
+}
+
+test('publishTransform strips both helper fields from every item', () => {
+  const data = {
+    fetchedAt: '2026-05-04T12:00:00Z',
+    outbreaks: [
+      { id: 'a', publishedAt: 1, _publishedAtIsSynthetic: false, _originalPublishedMs: 1, otherField: 'kept' },
+      { id: 'b', publishedAt: 2, _publishedAtIsSynthetic: true, _originalPublishedMs: null, otherField: 'kept' },
+    ],
+  };
+  const stripped = diseasePublishTransform(data);
+  for (const item of stripped.outbreaks) {
+    assert.ok(!('_publishedAtIsSynthetic' in item), '_publishedAtIsSynthetic must be stripped');
+    assert.ok(!('_originalPublishedMs' in item), '_originalPublishedMs must be stripped');
+    // Other fields preserved
+    assert.equal(item.otherField, 'kept');
+  }
+  // Top-level fields preserved
+  assert.equal(stripped.fetchedAt, '2026-05-04T12:00:00Z');
+});
+
+test('publishTransform preserves publishedAt as non-null (UI/RPC consumer contract)', () => {
+  const data = {
+    outbreaks: [
+      { id: 'a', publishedAt: 12345, _publishedAtIsSynthetic: true, _originalPublishedMs: null },
+    ],
+  };
+  const stripped = diseasePublishTransform(data);
+  assert.equal(stripped.outbreaks[0].publishedAt, 12345, 'publishedAt remains non-null on every published item');
+});
+
+test('publishTransform handles empty + missing outbreaks safely', () => {
+  assert.deepEqual(diseasePublishTransform({ outbreaks: [] }).outbreaks, []);
+  // Missing outbreaks key → defaults to []
+  assert.deepEqual(diseasePublishTransform({}).outbreaks, []);
+});
+
+// ── End-to-end shape lock: contentMeta runs first, publishTransform strips ──
+
+test('end-to-end: contentMeta runs on raw data WITH helpers, publishTransform strips, canonical is helper-free', () => {
+  const NEWEST = 1700000000000;
+  const OLDEST = 1690000000000;
+  const rawData = {
+    fetchedAt: '2026-05-04T12:00:00Z',
+    outbreaks: [
+      { id: 'who-1', publishedAt: NEWEST, _publishedAtIsSynthetic: false, _originalPublishedMs: NEWEST },
+      { id: 'rss-1', publishedAt: Date.now(), _publishedAtIsSynthetic: true, _originalPublishedMs: null },
+      { id: 'tgh-1', publishedAt: OLDEST, _publishedAtIsSynthetic: false, _originalPublishedMs: OLDEST },
+    ],
+  };
+
+  // Step 1: contentMeta on raw data
+  const contentResult = diseaseContentMeta(rawData);
+  assert.equal(contentResult.newestItemAt, NEWEST, 'contentMeta sees real (non-synthetic) newest');
+  assert.equal(contentResult.oldestItemAt, OLDEST);
+
+  // Step 2: publishTransform on raw data
+  const published = diseasePublishTransform(rawData);
+  for (const item of published.outbreaks) {
+    assert.ok(!('_publishedAtIsSynthetic' in item), `${item.id}: _publishedAtIsSynthetic stripped`);
+    assert.ok(!('_originalPublishedMs' in item), `${item.id}: _originalPublishedMs stripped`);
+  }
+  // Combined-regex assertion (Codex round 4 P2): published payload must NOT
+  // contain EITHER helper name when serialized.
+  const json = JSON.stringify(published);
+  assert.equal((json.match(/_publishedAtIsSynthetic/g) || []).length, 0, 'no _publishedAtIsSynthetic in JSON');
+  assert.equal((json.match(/_originalPublishedMs/g) || []).length, 0, 'no _originalPublishedMs in JSON');
+});
+
+// ── Pilot threshold sanity (anti-drift on the 9-day budget) ──────────────
+
+test('pilot threshold: 9-day maxContentAgeMin would have tripped on 2026-05-04 incident pattern (11d-old items)', () => {
+  // Simulate the production incident: newest item 11 days old, content-age budget 9 days.
+  const ELEVEN_DAYS_AGO = Date.now() - 11 * 24 * 60 * 60 * 1000;
+  const data = {
+    outbreaks: [
+      { _publishedAtIsSynthetic: false, _originalPublishedMs: ELEVEN_DAYS_AGO },
+    ],
+  };
+  const cm = diseaseContentMeta(data);
+  assert.ok(cm, 'contentMeta returns a result');
+  const ageMin = (Date.now() - cm.newestItemAt) / 60000;
+  const BUDGET = 9 * 24 * 60;     // matches scripts/seed-disease-outbreaks.mjs
+  assert.ok(ageMin > BUDGET, `${Math.round(ageMin)}min > budget ${BUDGET}min — STALE_CONTENT would fire (ANTI-DRIFT for the pilot threshold)`);
+});
+
+test('pilot threshold: 5-day-old items are within 9-day budget (no false positive)', () => {
+  const FIVE_DAYS_AGO = Date.now() - 5 * 24 * 60 * 60 * 1000;
+  const data = { outbreaks: [{ _publishedAtIsSynthetic: false, _originalPublishedMs: FIVE_DAYS_AGO }] };
+  const cm = diseaseContentMeta(data);
+  const ageMin = (Date.now() - cm.newestItemAt) / 60000;
+  const BUDGET = 9 * 24 * 60;
+  assert.ok(ageMin < BUDGET, '5d < 9d — STALE_CONTENT does NOT fire on normal upstream rhythm');
+});

--- a/tests/disease-outbreaks-seed.test.mjs
+++ b/tests/disease-outbreaks-seed.test.mjs
@@ -82,7 +82,7 @@ test('TGH record always non-synthetic (line-198 filter rejects undated items ear
 // regardless of loaded-CI scheduler timing — addresses the P2 reviewer
 // finding about timing sensitivity around the 1h boundary.
 
-const FIXED_NOW = 1700000000000;     // 2025-11-14T22:13:20.000Z — stable test "now"
+const FIXED_NOW = 1700000000000;     // 2023-11-14T22:13:20.000Z — stable test "now"
 
 test('contentMeta returns null when ALL items are synthetic', () => {
   const data = {

--- a/tests/disease-outbreaks-seed.test.mjs
+++ b/tests/disease-outbreaks-seed.test.mjs
@@ -11,103 +11,28 @@
 //     /api/bootstrap responses, list-disease-outbreaks RPC, or the
 //     DiseaseOutbreakItem proto type.
 //
-// Test against the SAME functions the seeder uses, importing them from a
-// fresh module under stubbed env (no Redis writes).
+// Test against the SAME functions the seeder imports from
+// `scripts/_disease-outbreaks-helpers.mjs` — no local replicas, no drift.
+// `diseaseContentMeta`'s `nowMs` parameter is injected with a fixed value so
+// skew-limit tests are deterministic (no timing flakiness around the 1h
+// boundary on loaded CI runners).
 
-import { test, beforeEach, afterEach } from 'node:test';
+import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
-import { fileURLToPath, pathToFileURL } from 'node:url';
-
-const __filename = fileURLToPath(import.meta.url);
-const ROOT = join(__filename, '..', '..');
-
-const ORIGINAL_FETCH = globalThis.fetch;
-const ORIGINAL_EXIT = process.exit;
-const ORIGINAL_ENV = {
-  UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
-  UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
-};
-
-beforeEach(() => {
-  process.env.UPSTASH_REDIS_REST_URL = 'https://fake-upstash.example.com';
-  process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
-});
-
-afterEach(() => {
-  globalThis.fetch = ORIGINAL_FETCH;
-  process.exit = ORIGINAL_EXIT;
-  if (ORIGINAL_ENV.UPSTASH_REDIS_REST_URL == null) delete process.env.UPSTASH_REDIS_REST_URL;
-  else process.env.UPSTASH_REDIS_REST_URL = ORIGINAL_ENV.UPSTASH_REDIS_REST_URL;
-  if (ORIGINAL_ENV.UPSTASH_REDIS_REST_TOKEN == null) delete process.env.UPSTASH_REDIS_REST_TOKEN;
-  else process.env.UPSTASH_REDIS_REST_TOKEN = ORIGINAL_ENV.UPSTASH_REDIS_REST_TOKEN;
-});
-
-// We don't import seed-disease-outbreaks.mjs directly because doing so triggers
-// the runSeed() top-level call that exits the process. Instead, we replicate
-// the EXACT inline shapes the seeder uses (post-Sprint 2 migration) and assert
-// the contract holds. If the seeder's parser/mapItem shape drifts from this
-// test, the seeder change MUST also update this test — that's intentional;
-// silent shape drift is exactly what this test is here to prevent.
-
-// ── Replicate the parser logic for assertion ────────────────────────────
-//
-// These functions mirror the seeder's WHO/RSS/TGH parser shapes. The intent
-// is that ANY change to those parsers must produce the same shape this test
-// asserts against — drift here surfaces at PR-review time.
-
-function whoMapPreservesContract(item, nowMs) {
-  const origMs = item.PublicationDateAndTime ? new Date(item.PublicationDateAndTime).getTime() : null;
-  const hasOrig = origMs != null && Number.isFinite(origMs);
-  return {
-    title: (item.Title || '').trim(),
-    link: item.ItemDefaultUrl ? `https://www.who.int${item.ItemDefaultUrl}` : '',
-    desc: '',
-    publishedMs: hasOrig ? origMs : nowMs,
-    _originalPublishedMs: hasOrig ? origMs : null,
-    _publishedAtIsSynthetic: !hasOrig,
-    sourceName: 'WHO',
-  };
-}
-
-function rssMapPreservesContract({ title, link, desc, pubDate, sourceName }, nowMs) {
-  const origMs = pubDate ? new Date(pubDate).getTime() : null;
-  const hasOrig = origMs != null && Number.isFinite(origMs);
-  return {
-    title, link, desc,
-    publishedMs: hasOrig ? origMs : nowMs,
-    sourceName,
-    _originalPublishedMs: hasOrig ? origMs : null,
-    _publishedAtIsSynthetic: !hasOrig,
-  };
-}
-
-function tghMapPreservesContract(rec) {
-  const publishedMs = new Date(rec.date).getTime();
-  return {
-    title: `${rec.disease}${rec.country ? ` - ${rec.country}` : ''}`,
-    link: rec.sourceUrl || '',
-    desc: rec.summary || '',
-    publishedMs,
-    sourceName: 'ThinkGlobalHealth',
-    _country: rec.country,
-    _disease: rec.disease,
-    _location: '',
-    _lat: rec.lat,
-    _lng: rec.lng,
-    _cases: rec.cases || 0,
-    _originalPublishedMs: publishedMs,
-    _publishedAtIsSynthetic: false,
-  };
-}
+import {
+  whoNormalizeItem,
+  rssNormalizeItem,
+  tghNormalizeItem,
+  diseaseContentMeta,
+  diseasePublishTransform,
+  DISEASE_MAX_CONTENT_AGE_MIN,
+} from '../scripts/_disease-outbreaks-helpers.mjs';
 
 // ── Pre-publish (in-memory) layer ────────────────────────────────────────
 
 test('WHO record without PublicationDateAndTime → in-memory item is tagged synthetic', () => {
   const NOW = 1700000000000;
-  const inMemory = whoMapPreservesContract({ Title: 'Mpox - Country X', ItemDefaultUrl: '/mpox-x' }, NOW);
+  const inMemory = whoNormalizeItem({ Title: 'Mpox - Country X', ItemDefaultUrl: '/mpox-x' }, NOW);
   assert.equal(inMemory._publishedAtIsSynthetic, true);
   assert.equal(inMemory._originalPublishedMs, null);
   assert.equal(inMemory.publishedMs, NOW, 'publishedMs falls back to now() so existing isFinite filters + UI consumer contract still hold');
@@ -117,7 +42,7 @@ test('WHO record with valid PublicationDateAndTime → in-memory item is non-syn
   const NOW = 1700000000000;
   const PUB_ISO = '2026-04-23T15:30:00Z';
   const PUB_MS = new Date(PUB_ISO).getTime();
-  const inMemory = whoMapPreservesContract({ Title: 'Mpox', ItemDefaultUrl: '/mpox', PublicationDateAndTime: PUB_ISO }, NOW);
+  const inMemory = whoNormalizeItem({ Title: 'Mpox', ItemDefaultUrl: '/mpox', PublicationDateAndTime: PUB_ISO }, NOW);
   assert.equal(inMemory._publishedAtIsSynthetic, false);
   assert.equal(inMemory._originalPublishedMs, PUB_MS);
   assert.equal(inMemory.publishedMs, PUB_MS);
@@ -125,7 +50,7 @@ test('WHO record with valid PublicationDateAndTime → in-memory item is non-syn
 
 test('RSS record without pubDate → in-memory item is tagged synthetic', () => {
   const NOW = 1700000000000;
-  const inMemory = rssMapPreservesContract({ title: 'Outbreak', link: 'http://x', desc: '', pubDate: '', sourceName: 'CDC' }, NOW);
+  const inMemory = rssNormalizeItem({ title: 'Outbreak', link: 'http://x', desc: '', pubDate: '', sourceName: 'CDC' }, NOW);
   assert.equal(inMemory._publishedAtIsSynthetic, true);
   assert.equal(inMemory._originalPublishedMs, null);
   assert.equal(inMemory.publishedMs, NOW);
@@ -135,14 +60,14 @@ test('RSS record with valid pubDate → in-memory item is non-synthetic', () => 
   const NOW = 1700000000000;
   const PUB = 'Wed, 23 Apr 2026 15:30:00 GMT';
   const PUB_MS = new Date(PUB).getTime();
-  const inMemory = rssMapPreservesContract({ title: 'Outbreak', link: 'http://x', desc: '', pubDate: PUB, sourceName: 'CDC' }, NOW);
+  const inMemory = rssNormalizeItem({ title: 'Outbreak', link: 'http://x', desc: '', pubDate: PUB, sourceName: 'CDC' }, NOW);
   assert.equal(inMemory._publishedAtIsSynthetic, false);
   assert.equal(inMemory._originalPublishedMs, PUB_MS);
   assert.equal(inMemory.publishedMs, PUB_MS);
 });
 
 test('TGH record always non-synthetic (line-198 filter rejects undated items earlier in the seeder)', () => {
-  const inMemory = tghMapPreservesContract({
+  const inMemory = tghNormalizeItem({
     Alert_ID: '1', lat: 12.3, lng: 45.6, disease: 'Cholera', country: 'X',
     date: '4/23/2026', sourceUrl: 'http://x', summary: 's', cases: '5',
   });
@@ -153,48 +78,33 @@ test('TGH record always non-synthetic (line-198 filter rejects undated items ear
 
 // ── contentMeta behavior ─────────────────────────────────────────────────
 //
-// Replicate the seeder's contentMeta inline so test failures surface here
-// rather than at deploy time. The shape MUST match scripts/seed-disease-outbreaks.mjs.
+// All skew-limit tests inject `nowMs` so the assertion is deterministic
+// regardless of loaded-CI scheduler timing — addresses the P2 reviewer
+// finding about timing sensitivity around the 1h boundary.
 
-function diseaseContentMeta(data) {
-  const items = Array.isArray(data?.outbreaks) ? data.outbreaks : [];
-  let newest = -Infinity, oldest = Infinity, validCount = 0;
-  const skewLimit = Date.now() + 60 * 60 * 1000;
-  for (const item of items) {
-    if (item._publishedAtIsSynthetic === true) continue;
-    const ts = item._originalPublishedMs;
-    if (typeof ts !== 'number' || !Number.isFinite(ts) || ts <= 0) continue;
-    if (ts > skewLimit) continue;
-    validCount++;
-    if (ts > newest) newest = ts;
-    if (ts < oldest) oldest = ts;
-  }
-  if (validCount === 0) return null;
-  return { newestItemAt: newest, oldestItemAt: oldest };
-}
+const FIXED_NOW = 1700000000000;     // 2025-11-14T22:13:20.000Z — stable test "now"
 
 test('contentMeta returns null when ALL items are synthetic', () => {
-  const NOW = Date.now();
   const data = {
     outbreaks: [
-      { id: 'a', publishedAt: NOW, _publishedAtIsSynthetic: true, _originalPublishedMs: null },
-      { id: 'b', publishedAt: NOW, _publishedAtIsSynthetic: true, _originalPublishedMs: null },
+      { id: 'a', publishedAt: FIXED_NOW, _publishedAtIsSynthetic: true, _originalPublishedMs: null },
+      { id: 'b', publishedAt: FIXED_NOW, _publishedAtIsSynthetic: true, _originalPublishedMs: null },
     ],
   };
-  assert.equal(diseaseContentMeta(data), null, 'all-synthetic → null → STALE_CONTENT');
+  assert.equal(diseaseContentMeta(data, FIXED_NOW), null, 'all-synthetic → null → STALE_CONTENT');
 });
 
 test('contentMeta excludes synthetic items when mixed (does not let synthetic newest win)', () => {
-  const PAST = 1700000000000;
+  const PAST = 1690000000000;     // older than FIXED_NOW
   const data = {
     outbreaks: [
       // synthetic with VERY recent publishedMs (Date.now() fallback)
-      { id: 'a', publishedAt: Date.now(), _publishedAtIsSynthetic: true, _originalPublishedMs: null },
+      { id: 'a', publishedAt: FIXED_NOW, _publishedAtIsSynthetic: true, _originalPublishedMs: null },
       // real item, older but valid
       { id: 'b', publishedAt: PAST, _publishedAtIsSynthetic: false, _originalPublishedMs: PAST },
     ],
   };
-  const result = diseaseContentMeta(data);
+  const result = diseaseContentMeta(data, FIXED_NOW);
   assert.equal(result.newestItemAt, PAST, 'synthetic must NOT influence newest — real older item wins');
   assert.equal(result.oldestItemAt, PAST);
 });
@@ -209,47 +119,39 @@ test('contentMeta picks newest and oldest from the non-synthetic set', () => {
       { _publishedAtIsSynthetic: false, _originalPublishedMs: (NEWEST + OLDEST) / 2 },
     ],
   };
-  const result = diseaseContentMeta(data);
+  const result = diseaseContentMeta(data, FIXED_NOW);
   assert.equal(result.newestItemAt, NEWEST);
   assert.equal(result.oldestItemAt, OLDEST);
 });
 
 test('contentMeta excludes future-dated items beyond 1h clock-skew tolerance', () => {
-  const REAL_RECENT = Date.now() - 2 * 24 * 60 * 60 * 1000;
-  const FUTURE = Date.now() + 2 * 60 * 60 * 1000;    // 2h in the future
+  const REAL_RECENT = FIXED_NOW - 2 * 24 * 60 * 60 * 1000;
+  const FUTURE = FIXED_NOW + 2 * 60 * 60 * 1000;    // 2h in the future — beyond 1h tolerance
   const data = {
     outbreaks: [
       { _publishedAtIsSynthetic: false, _originalPublishedMs: FUTURE },
       { _publishedAtIsSynthetic: false, _originalPublishedMs: REAL_RECENT },
     ],
   };
-  const result = diseaseContentMeta(data);
+  const result = diseaseContentMeta(data, FIXED_NOW);
   assert.equal(result.newestItemAt, REAL_RECENT, 'future-dated item beyond 1h tolerance excluded — real most-recent wins');
 });
 
 test('contentMeta accepts items within 1h clock-skew tolerance', () => {
-  const NEAR_FUTURE = Date.now() + 30 * 60 * 1000;    // 30min ahead, within 1h tolerance
+  // 5min ahead of FIXED_NOW — well inside the 1h tolerance window, well clear
+  // of the skewLimit boundary. nowMs is injected so the comparison is
+  // deterministic (independent of wall-clock timing).
+  const NEAR_FUTURE = FIXED_NOW + 5 * 60 * 1000;
   const data = {
     outbreaks: [
       { _publishedAtIsSynthetic: false, _originalPublishedMs: NEAR_FUTURE },
     ],
   };
-  const result = diseaseContentMeta(data);
+  const result = diseaseContentMeta(data, FIXED_NOW);
   assert.equal(result.newestItemAt, NEAR_FUTURE, 'NEAR_FUTURE within 1h tolerance is accepted');
 });
 
 // ── publishTransform strip ───────────────────────────────────────────────
-
-function diseasePublishTransform(data) {
-  const outbreaks = Array.isArray(data?.outbreaks) ? data.outbreaks : [];
-  return {
-    ...data,
-    outbreaks: outbreaks.map((item) => {
-      const { _publishedAtIsSynthetic: _a, _originalPublishedMs: _b, ...rest } = item;
-      return rest;
-    }),
-  };
-}
 
 test('publishTransform strips both helper fields from every item', () => {
   const data = {
@@ -295,13 +197,13 @@ test('end-to-end: contentMeta runs on raw data WITH helpers, publishTransform st
     fetchedAt: '2026-05-04T12:00:00Z',
     outbreaks: [
       { id: 'who-1', publishedAt: NEWEST, _publishedAtIsSynthetic: false, _originalPublishedMs: NEWEST },
-      { id: 'rss-1', publishedAt: Date.now(), _publishedAtIsSynthetic: true, _originalPublishedMs: null },
+      { id: 'rss-1', publishedAt: FIXED_NOW, _publishedAtIsSynthetic: true, _originalPublishedMs: null },
       { id: 'tgh-1', publishedAt: OLDEST, _publishedAtIsSynthetic: false, _originalPublishedMs: OLDEST },
     ],
   };
 
-  // Step 1: contentMeta on raw data
-  const contentResult = diseaseContentMeta(rawData);
+  // Step 1: contentMeta on raw data (use injected nowMs so the future-clock-skew filter is deterministic)
+  const contentResult = diseaseContentMeta(rawData, FIXED_NOW);
   assert.equal(contentResult.newestItemAt, NEWEST, 'contentMeta sees real (non-synthetic) newest');
   assert.equal(contentResult.oldestItemAt, OLDEST);
 
@@ -320,26 +222,28 @@ test('end-to-end: contentMeta runs on raw data WITH helpers, publishTransform st
 
 // ── Pilot threshold sanity (anti-drift on the 9-day budget) ──────────────
 
+test('DISEASE_MAX_CONTENT_AGE_MIN constant is 9 days', () => {
+  assert.equal(DISEASE_MAX_CONTENT_AGE_MIN, 9 * 24 * 60, 'budget is 9 days — chosen so the 2026-05-04 11d incident trips STALE_CONTENT');
+});
+
 test('pilot threshold: 9-day maxContentAgeMin would have tripped on 2026-05-04 incident pattern (11d-old items)', () => {
   // Simulate the production incident: newest item 11 days old, content-age budget 9 days.
-  const ELEVEN_DAYS_AGO = Date.now() - 11 * 24 * 60 * 60 * 1000;
+  const ELEVEN_DAYS_AGO = FIXED_NOW - 11 * 24 * 60 * 60 * 1000;
   const data = {
     outbreaks: [
       { _publishedAtIsSynthetic: false, _originalPublishedMs: ELEVEN_DAYS_AGO },
     ],
   };
-  const cm = diseaseContentMeta(data);
+  const cm = diseaseContentMeta(data, FIXED_NOW);
   assert.ok(cm, 'contentMeta returns a result');
-  const ageMin = (Date.now() - cm.newestItemAt) / 60000;
-  const BUDGET = 9 * 24 * 60;     // matches scripts/seed-disease-outbreaks.mjs
-  assert.ok(ageMin > BUDGET, `${Math.round(ageMin)}min > budget ${BUDGET}min — STALE_CONTENT would fire (ANTI-DRIFT for the pilot threshold)`);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(ageMin > DISEASE_MAX_CONTENT_AGE_MIN, `${Math.round(ageMin)}min > budget ${DISEASE_MAX_CONTENT_AGE_MIN}min — STALE_CONTENT would fire (ANTI-DRIFT for the pilot threshold)`);
 });
 
 test('pilot threshold: 5-day-old items are within 9-day budget (no false positive)', () => {
-  const FIVE_DAYS_AGO = Date.now() - 5 * 24 * 60 * 60 * 1000;
+  const FIVE_DAYS_AGO = FIXED_NOW - 5 * 24 * 60 * 60 * 1000;
   const data = { outbreaks: [{ _publishedAtIsSynthetic: false, _originalPublishedMs: FIVE_DAYS_AGO }] };
-  const cm = diseaseContentMeta(data);
-  const ageMin = (Date.now() - cm.newestItemAt) / 60000;
-  const BUDGET = 9 * 24 * 60;
-  assert.ok(ageMin < BUDGET, '5d < 9d — STALE_CONTENT does NOT fire on normal upstream rhythm');
+  const cm = diseaseContentMeta(data, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(ageMin < DISEASE_MAX_CONTENT_AGE_MIN, '5d < 9d — STALE_CONTENT does NOT fire on normal upstream rhythm');
 });


### PR DESCRIPTION
**Stacked on PR #3596** (Sprint 1 — content-age probe infra). Merge #3596 first; this PR rebases onto main automatically once that lands.

Implements Sprint 2 of the 2026-05-04 health-readiness plan. Migrates disease-outbreaks as the proof-of-concept content-age consumer. Pilot `maxContentAgeMin = 9 days` chosen so the **2026-05-04 incident** (cache held 50 outbreaks all 11+ days old, /api/health reported OK, map went empty) would have correctly tripped `STALE_CONTENT`.

## Changes (`scripts/seed-disease-outbreaks.mjs`)

### 1. Synthetic-timestamp tagging across all 3 sources

| Parser | Existing fallback | Migration |
|---|---|---|
| `fetchWhoDonApi` (line ~117) | `Date.now()` when `PublicationDateAndTime` missing | Carry `_originalPublishedMs` (parsed ms or null) + `_publishedAtIsSynthetic` (boolean). `publishedMs` keeps `Date.now()` fallback for UI consumer compat. |
| `fetchRssItems` (line ~150, both CDC and Outbreak News Today) | `Date.now()` when `pubDate` missing | Same pattern |
| `fetchThinkGlobalHealth` (line ~211) | line-198 filter rejects undated already | Always `_publishedAtIsSynthetic: false`, `_originalPublishedMs: publishedMs` (uniform shape across sources) |

`mapItem` (line ~244) carries the helpers through to the output shape so `contentMeta` can read them at runSeed time.

### 2. runSeed contract opts

- **`contentMeta`**: excludes `_publishedAtIsSynthetic` items + 1h clock-skew tolerance + null when `validCount === 0`. Synthetic-timestamp items would otherwise falsely report content as fresh and mask real upstream silence.
- **`maxContentAgeMin: 9 * 24 * 60 = 12960`** (9 days). Tighter would page on normal WHO/CDC quiet weeks; looser would have missed the 11d incident.
- **`publishTransform`**: strips `_publishedAtIsSynthetic` + `_originalPublishedMs` from every item BEFORE atomicPublish. Per Sprint 1's ordering contract, contentMeta has already run on the raw data by this point — safe to drop. The strip ensures helpers never reach the canonical key, /api/bootstrap response, list-disease-outbreaks RPC response, or the proto-generated type.

## Tests (`tests/disease-outbreaks-seed.test.mjs` — NEW)

16 cases split by **layer** per Codex round 4-5 review (pre-publish in-memory CARRIES helpers; post-strip canonical is helper-free):

| Layer | Cases |
|---|---|
| Pre-publish (parser) | WHO/RSS without date → synthetic; WHO/RSS with date → non-synthetic; TGH always non-synthetic |
| `contentMeta` behavior | All-synthetic → null; mixed → synthetic doesn't win newest; newest/oldest selection; future-dated >1h excluded; near-future ≤1h accepted |
| `publishTransform` strip | Both fields stripped; `publishedAt` remains non-null; empty/missing handled |
| End-to-end | Combined-regex assertion: published JSON contains NEITHER helper name |
| Pilot threshold | 11d-old items DO trip; 5d-old items DO NOT (anti-drift) |

**Test totals:** 95/95 pass across seed-envelope, seed-contract, seed-utils, content-age, health-content-age, and disease-outbreaks-seed suites.

## Net diff

```
2 files changed, 449 insertions(+), 10 deletions(-)
```

## Verification (post-deploy)

After Railway redeploy of `seed-bundle-health`:

- [ ] `/api/health.diseaseOutbreaks` reports `contentAgeMin` and `maxContentAgeMin: 12960`
- [ ] With current cache (50 items, newest ~11d old per 2026-05-04 incident), `/api/health.diseaseOutbreaks.status === 'STALE_CONTENT'`
- [ ] Redis canonical helper-free:
  ```bash
  redis-cli GET health:disease-outbreaks:v1 | grep -cE '_publishedAtIsSynthetic|_originalPublishedMs'
  # Expected: 0
  ```
- [ ] Same combined-regex check on `/api/bootstrap?keys=diseaseOutbreaks` response body returns 0
- [ ] After TGH fix from #3593 lands daily-fresh items, STALE_CONTENT clears naturally as `newestItemAt` shifts to within 9 days

## What's next

Sprint 3 — sparse seeders (climate news, IEA OPEC, news-digest, economic stress).
Sprint 4 — annual-data seeders (WB resilience indicators).
