### PR TITLE
feat(climate-news): Sprint 3a — content-age probe (7d budget)

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -32,6 +32,7 @@ COPY scripts/_seed-utils.mjs ./scripts/_seed-utils.mjs
 COPY scripts/_seed-envelope-source.mjs ./scripts/_seed-envelope-source.mjs
 COPY scripts/_seed-contract.mjs ./scripts/_seed-contract.mjs
 COPY scripts/_country-resolver.mjs ./scripts/_country-resolver.mjs
+COPY scripts/_climate-news-helpers.mjs ./scripts/_climate-news-helpers.mjs
 COPY scripts/seed-climate-news.mjs ./scripts/seed-climate-news.mjs
 COPY scripts/seed-chokepoint-flows.mjs ./scripts/seed-chokepoint-flows.mjs
 COPY scripts/seed-ember-electricity.mjs ./scripts/seed-ember-electricity.mjs

--- a/scripts/_climate-news-helpers.mjs
+++ b/scripts/_climate-news-helpers.mjs
@@ -1,0 +1,56 @@
+// Sprint 3a — content-age helpers for seed-climate-news.mjs.
+//
+// Why a separate module instead of inlining in the seeder:
+//
+// Tests can't import `seed-climate-news.mjs` directly because its top-level
+// runSeed() call exits the process on import. Extracting the pure contentMeta
+// here is the same drift-prevention pattern Sprint 2 settled on for
+// disease-outbreaks (see `_disease-outbreaks-helpers.mjs` header) — the
+// seeder imports this, the test imports this, so a future change can't drift
+// silently between the two.
+//
+// Climate-news is simpler than disease-outbreaks: the seeder already filters
+// out items with `publishedAt: 0` at parse time (seed-climate-news.mjs:76 +
+// :132), so there is NO synthetic-tagging risk and NO publishTransform
+// stripping needed — `item.publishedAt` is always a real, parsed RSS pubDate
+// (or its fallback chain: pubDate → published → updated → dc:date).
+
+/**
+ * Compute newest/oldest content timestamps from the climate-news payload.
+ *
+ * - Reads `item.publishedAt` directly (no _originalPublishedMs/_synthetic
+ *   helpers because the seeder rejects undated items at parse time).
+ * - Excludes future-dated items beyond 1h clock-skew tolerance — matches the
+ *   tolerance disease-outbreaks (Sprint 2) and list-feed-digest's
+ *   FUTURE_DATE_TOLERANCE_MS use.
+ * - Returns null when no items have a usable timestamp — runSeed writes
+ *   newestItemAt: null, classifier reads as STALE_CONTENT.
+ *
+ * @param {{items: Array}} data
+ * @param {number} nowMs - injectable "now" for deterministic tests; defaults to Date.now()
+ */
+export function climateNewsContentMeta(data, nowMs = Date.now()) {
+  const items = Array.isArray(data?.items) ? data.items : [];
+  let newest = -Infinity, oldest = Infinity, validCount = 0;
+  const skewLimit = nowMs + 60 * 60 * 1000;
+  for (const item of items) {
+    const ts = item.publishedAt;
+    if (typeof ts !== 'number' || !Number.isFinite(ts) || ts <= 0) continue;
+    if (ts > skewLimit) continue;
+    validCount++;
+    if (ts > newest) newest = ts;
+    if (ts < oldest) oldest = ts;
+  }
+  if (validCount === 0) return null;
+  return { newestItemAt: newest, oldestItemAt: oldest };
+}
+
+/**
+ * Sprint 3a pilot threshold (7 days). Climate news from the listed feeds
+ * (Carbon Brief, Guardian Environment, NASA EO, UNEP, Phys.org, Copernicus,
+ * Inside Climate News, Climate Central, ReliefWeb) collectively publish daily
+ * to multiple-times-per-day. A 7-day budget tolerates a major holiday weekend
+ * across all sources without paging on normal cadence — and trips on a real
+ * upstream-aggregator outage where every feed's parse silently breaks.
+ */
+export const CLIMATE_NEWS_MAX_CONTENT_AGE_MIN = 7 * 24 * 60;

--- a/scripts/seed-climate-news.mjs
+++ b/scripts/seed-climate-news.mjs
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+// Pure contentMeta helper lives in its own module so tests can import the
+// real code (no replicas, no drift). See helpers module header for rationale.
+import { climateNewsContentMeta, CLIMATE_NEWS_MAX_CONTENT_AGE_MIN } from './_climate-news-helpers.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -205,6 +208,17 @@ runSeed('climate', 'news-intelligence', CANONICAL_KEY, fetchClimateNews, {
   declareRecords,
   schemaVersion: 1,
   maxStaleMin: 90,
+
+  // ── Content-age contract (Sprint 3a of the 2026-05-04 health-readiness plan) ──
+  //
+  // 7-day budget chosen so a real upstream-aggregator outage (every climate
+  // feed's parse breaks simultaneously, e.g. a webpack bundle change in our
+  // RSS regex matching) trips STALE_CONTENT, while a normal holiday-weekend
+  // cadence dip across the listed sources does not. seed-climate-news.mjs
+  // already filters items with publishedAt=0 at parse time, so contentMeta
+  // can read item.publishedAt directly — no synthetic-tagging needed.
+  contentMeta: climateNewsContentMeta,
+  maxContentAgeMin: CLIMATE_NEWS_MAX_CONTENT_AGE_MIN,
 }).catch((err) => {
   const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
   console.error('FATAL:', (err.message || err) + _cause);

--- a/tests/climate-news-content-age.test.mjs
+++ b/tests/climate-news-content-age.test.mjs
@@ -1,0 +1,105 @@
+// Sprint 3a — Climate-news content-age contract.
+//
+// Tests import the SAME climateNewsContentMeta the seeder runs, so a future
+// shape change in `_climate-news-helpers.mjs` fails tests instead of silently
+// drifting. nowMs is injected with FIXED_NOW for deterministic skew-limit
+// behavior (no wall-clock dependence on loaded CI runners).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  climateNewsContentMeta,
+  CLIMATE_NEWS_MAX_CONTENT_AGE_MIN,
+} from '../scripts/_climate-news-helpers.mjs';
+
+const FIXED_NOW = 1700000000000;     // 2025-11-14T22:13:20.000Z — stable test "now"
+
+test('CLIMATE_NEWS_MAX_CONTENT_AGE_MIN is 7 days', () => {
+  assert.equal(CLIMATE_NEWS_MAX_CONTENT_AGE_MIN, 7 * 24 * 60);
+});
+
+test('contentMeta returns null on empty items array', () => {
+  assert.equal(climateNewsContentMeta({ items: [] }, FIXED_NOW), null);
+});
+
+test('contentMeta returns null when items field is missing', () => {
+  assert.equal(climateNewsContentMeta({}, FIXED_NOW), null);
+});
+
+test('contentMeta picks newest and oldest from valid publishedAt', () => {
+  const NEWEST = FIXED_NOW - 1 * 86400_000;
+  const MID = FIXED_NOW - 3 * 86400_000;
+  const OLDEST = FIXED_NOW - 6 * 86400_000;
+  const data = {
+    items: [
+      { publishedAt: MID },
+      { publishedAt: NEWEST },
+      { publishedAt: OLDEST },
+    ],
+  };
+  const cm = climateNewsContentMeta(data, FIXED_NOW);
+  assert.equal(cm.newestItemAt, NEWEST);
+  assert.equal(cm.oldestItemAt, OLDEST);
+});
+
+test('contentMeta excludes items with publishedAt = 0 (defensive — seeder filter should have already dropped these)', () => {
+  const REAL = FIXED_NOW - 86400_000;
+  const data = { items: [{ publishedAt: 0 }, { publishedAt: REAL }] };
+  const cm = climateNewsContentMeta(data, FIXED_NOW);
+  assert.equal(cm.newestItemAt, REAL);
+  assert.equal(cm.oldestItemAt, REAL);
+});
+
+test('contentMeta excludes items with non-numeric publishedAt', () => {
+  const REAL = FIXED_NOW - 86400_000;
+  const data = {
+    items: [
+      { publishedAt: 'not-a-number' },
+      { publishedAt: null },
+      { publishedAt: undefined },
+      { publishedAt: NaN },
+      { publishedAt: REAL },
+    ],
+  };
+  const cm = climateNewsContentMeta(data, FIXED_NOW);
+  assert.equal(cm.newestItemAt, REAL);
+  assert.equal(cm.oldestItemAt, REAL);
+});
+
+test('contentMeta excludes future-dated items beyond 1h clock-skew tolerance', () => {
+  const REAL_RECENT = FIXED_NOW - 2 * 86400_000;
+  const FUTURE = FIXED_NOW + 2 * 60 * 60 * 1000;     // 2h ahead of NOW — beyond tolerance
+  const data = {
+    items: [
+      { publishedAt: FUTURE },
+      { publishedAt: REAL_RECENT },
+    ],
+  };
+  const cm = climateNewsContentMeta(data, FIXED_NOW);
+  assert.equal(cm.newestItemAt, REAL_RECENT, 'future-dated item beyond 1h tolerance excluded');
+});
+
+test('contentMeta accepts items within 1h clock-skew tolerance', () => {
+  const NEAR_FUTURE = FIXED_NOW + 5 * 60 * 1000;     // 5min ahead — well inside 1h tolerance
+  const data = { items: [{ publishedAt: NEAR_FUTURE }] };
+  const cm = climateNewsContentMeta(data, FIXED_NOW);
+  assert.equal(cm.newestItemAt, NEAR_FUTURE);
+});
+
+test('pilot threshold: 8-day-old newest item would trip STALE_CONTENT', () => {
+  // If the freshest item is 8 days old, the budget (7 days) is exceeded —
+  // /api/health classifyKey would emit STALE_CONTENT.
+  const EIGHT_DAYS_AGO = FIXED_NOW - 8 * 86400_000;
+  const data = { items: [{ publishedAt: EIGHT_DAYS_AGO }] };
+  const cm = climateNewsContentMeta(data, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(ageMin > CLIMATE_NEWS_MAX_CONTENT_AGE_MIN, `${Math.round(ageMin)}min > budget ${CLIMATE_NEWS_MAX_CONTENT_AGE_MIN}min — STALE_CONTENT would fire`);
+});
+
+test('pilot threshold: 3-day-old items are within 7-day budget (no false positive on normal cadence)', () => {
+  const THREE_DAYS_AGO = FIXED_NOW - 3 * 86400_000;
+  const data = { items: [{ publishedAt: THREE_DAYS_AGO }] };
+  const cm = climateNewsContentMeta(data, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(ageMin < CLIMATE_NEWS_MAX_CONTENT_AGE_MIN, '3d < 7d — STALE_CONTENT does NOT fire');
+});

--- a/tests/climate-news-content-age.test.mjs
+++ b/tests/climate-news-content-age.test.mjs
@@ -12,7 +12,7 @@ import {
   CLIMATE_NEWS_MAX_CONTENT_AGE_MIN,
 } from '../scripts/_climate-news-helpers.mjs';
 
-const FIXED_NOW = 1700000000000;     // 2025-11-14T22:13:20.000Z — stable test "now"
+const FIXED_NOW = 1700000000000;     // 2023-11-14T22:13:20.000Z — stable test "now"
 
 test('CLIMATE_NEWS_MAX_CONTENT_AGE_MIN is 7 days', () => {
   assert.equal(CLIMATE_NEWS_MAX_CONTENT_AGE_MIN, 7 * 24 * 60);


### PR DESCRIPTION
Sprint 3a of the [2026-05-04 health-readiness probe plan](docs/plans/2026-05-04-001-feat-health-readiness-probe-content-age-plan.md). Stacked on PR #3597 (Sprint 2 disease-outbreaks pilot).

## Summary

- Adds a content-age contract on `seed-climate-news.mjs` so `/api/health` surfaces `STALE_CONTENT` when the freshest cached climate-news item is older than 7 days.
- Pure helper lives in `scripts/_climate-news-helpers.mjs` (`climateNewsContentMeta` with injectable `nowMs` + `CLIMATE_NEWS_MAX_CONTENT_AGE_MIN`). Seeder imports it, test imports it — no replicas, no drift (matches the Sprint 2 post-refactor pattern from PR #3597).
- Dockerfile.relay COPY line for the new helper (caught by `tests/dockerfile-relay-imports.test.mjs`).

## Why 7 days

Carbon Brief, Guardian Environment, NASA EO, UNEP, Phys.org, Copernicus, Inside Climate News, Climate Central, and ReliefWeb collectively publish at multiple-times-per-day cadence. A 7-day budget tolerates a major holiday weekend across all sources without false-positive paging, and trips on a real upstream-aggregator outage (e.g. every feed's RSS regex stops matching because a publisher rebuilt their site).

## Why no synthetic-tagging needed (unlike disease-outbreaks Sprint 2)

`seed-climate-news.mjs:76` and `:132` already drop items with `publishedAt: 0` at parse time — \`if (!title || !url || !publishedAt) return;\`. So contentMeta reads `item.publishedAt` directly. No `_publishedAtIsSynthetic`/`_originalPublishedMs` helpers, no `publishTransform` stripping required.

## Test plan

- [x] `node --test tests/climate-news-content-age.test.mjs` → 10/10 pass
- [x] `node --test tests/dockerfile-relay-imports.test.mjs` → 3/3 pass (closure satisfied after Dockerfile.relay update)
- [x] Full content-age stack: 59/59 across Sprint 1+2+3a
- [x] `npm run typecheck:api` clean
- [x] `npm run lint` clean (pre-existing warnings only)
- [ ] Post-merge: confirm `/api/health` snapshot shows `climateNewsIntelligence` with `contentAge` block populated and `status: OK`
- [ ] Post-merge: simulate stale (manually set newest item to 8d ago in a preview env) → confirm `STALE_CONTENT`