### PR TITLE
feat(iea-oil-stocks): Sprint 3b — content-age probe (45d budget)

### DIFF
--- a/scripts/_iea-oil-stocks-helpers.mjs
+++ b/scripts/_iea-oil-stocks-helpers.mjs
@@ -1,0 +1,75 @@
+// Sprint 3b — content-age helpers for seed-iea-oil-stocks.mjs.
+//
+// Why a separate module: tests can't import seed-iea-oil-stocks.mjs directly
+// (its `if (isMain) runSeed(...)` block runs the seed when `node` invokes
+// the file, but the parsers/helpers are exported so importing the module
+// itself is safe — top-level side-effects are guarded). However, to stay
+// consistent with the Sprint 2/3a pattern (single source of truth shared
+// by seeder + tests), the contentMeta + dataMonth parser live here.
+//
+// Shape contract: IEA oil stocks is a SINGLE-SNAPSHOT seeder. The fetcher
+// returns `{members: [...], dataMonth: "YYYY-MM", seededAt: ISO-string}`.
+// Every member shares the same `dataMonth` (the IEA observation period
+// that all rows describe). There is no per-member published-at — the
+// content-age signal is the single `dataMonth` string at the top level.
+//
+// `seededAt` is NOT a content timestamp — it's `new Date().toISOString()`
+// captured at seed-run time, used only for cache-key bookkeeping.
+
+/**
+ * Convert a "YYYY-MM" dataMonth string to end-of-month UTC ms.
+ *
+ * The IEA monthly oil stocks report describes activity DURING the named
+ * month, so the latest observation in dataMonth=2024-08 is August 31.
+ * End-of-month is the most defensible "newestItemAt" — it represents the
+ * last possible date the report could be observing.
+ *
+ * Returns null when input shape is unexpected — defensive against upstream
+ * yearMonth parsing drift.
+ *
+ * @param {string} dataMonth - e.g. "2024-08"
+ */
+export function dataMonthToEndOfMonthMs(dataMonth) {
+  if (typeof dataMonth !== 'string' || !/^\d{4}-\d{2}$/.test(dataMonth)) return null;
+  const [year, month] = dataMonth.split('-').map(Number);
+  if (month < 1 || month > 12) return null;
+  // Date.UTC month is 0-indexed; passing month (NOT month-1) and day=0
+  // gives the last day of the named month (e.g. month=8 → Aug 31 not Sep 0).
+  return Date.UTC(year, month, 0, 23, 59, 59, 999);
+}
+
+/**
+ * Compute newest/oldest content timestamps from the IEA oil stocks payload.
+ *
+ * Single-snapshot seeder: every member shares one dataMonth, so newest ===
+ * oldest. We mirror the disease-outbreaks/climate-news return shape for
+ * Sprint 1 mirror parity (api/_seed-envelope.js + server/_shared/seed-envelope.ts
+ * expect both fields).
+ *
+ * Returns null when:
+ *   - data.dataMonth is missing or unparseable
+ *   - the parsed timestamp is in the future beyond 1h clock-skew tolerance
+ *     (defensive against upstream "yearMonth" garbage that produces e.g.
+ *     a 2099-12 dataMonth — would otherwise falsely report fresh content)
+ *
+ * @param {{dataMonth: string, members: Array}} data
+ * @param {number} nowMs - injectable "now" for deterministic tests
+ */
+export function ieaOilStocksContentMeta(data, nowMs = Date.now()) {
+  const ts = dataMonthToEndOfMonthMs(data?.dataMonth);
+  if (ts == null) return null;
+  const skewLimit = nowMs + 60 * 60 * 1000;
+  if (ts > skewLimit) return null;
+  return { newestItemAt: ts, oldestItemAt: ts };
+}
+
+/**
+ * Sprint 3b pilot threshold (45 days). IEA monthly oil stocks reports
+ * publish on an M+2 cadence (e.g. August data ships in late October/early
+ * November), so the dataMonth in cache is typically ~30-60 days old at
+ * "fresh-arrival" time. A 45-day budget tolerates one normal publication
+ * delay (~30d slack on top of the M+2 lag's natural age) and trips when a
+ * publication month is missed entirely (cache shows e.g. "2024-08" but
+ * "2024-09" should have landed by now → STALE_CONTENT).
+ */
+export const IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN = 45 * 24 * 60;

--- a/scripts/_iea-oil-stocks-helpers.mjs
+++ b/scripts/_iea-oil-stocks-helpers.mjs
@@ -64,12 +64,21 @@ export function ieaOilStocksContentMeta(data, nowMs = Date.now()) {
 }
 
 /**
- * Sprint 3b pilot threshold (45 days). IEA monthly oil stocks reports
- * publish on an M+2 cadence (e.g. August data ships in late October/early
- * November), so the dataMonth in cache is typically ~30-60 days old at
- * "fresh-arrival" time. A 45-day budget tolerates one normal publication
- * delay (~30d slack on top of the M+2 lag's natural age) and trips when a
- * publication month is missed entirely (cache shows e.g. "2024-08" but
- * "2024-09" should have landed by now → STALE_CONTENT).
+ * Sprint 3b pilot threshold (90 days).
+ *
+ * IEA monthly oil stocks publish on an M+2 cadence — August data
+ * (`dataMonth = "2024-08"`, end-of-month = Aug 31) ships in late Oct
+ * / early Nov, which is ~60-65 days AFTER end-of-observation-month.
+ * That means at fresh-arrival the helper's `newestItemAt` is already
+ * 60d old, before any real staleness has accrued.
+ *
+ * The budget therefore needs ~60d to cover the natural M+2 lag PLUS
+ * ~30d slack for one missed publication = 90d total. STALE_CONTENT
+ * trips when a month is missed entirely (e.g. cache stuck at
+ * "2024-08" past mid-Jan when "2024-10" should have landed).
+ *
+ * (Sprint 3b initial PR shipped 45d, which would have fired
+ * STALE_CONTENT on every fresh seed because 45d < natural lag.
+ * Greptile P1 caught it; #3599 review.)
  */
-export const IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN = 45 * 24 * 60;
+export const IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN = 90 * 24 * 60;

--- a/scripts/seed-iea-oil-stocks.mjs
+++ b/scripts/seed-iea-oil-stocks.mjs
@@ -2,6 +2,11 @@
 // @ts-check
 
 import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+// Pure contentMeta + dataMonth parser live in their own module so tests
+// can import the real code (no replicas, no drift). See helpers module
+// header for the shape contract — IEA is a single-snapshot seeder where
+// the top-level dataMonth string IS the content-age signal.
+import { ieaOilStocksContentMeta, IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN } from './_iea-oil-stocks-helpers.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -265,6 +270,20 @@ if (isMain) {
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: 57600,
+
+    // ── Content-age contract (Sprint 3b of the 2026-05-04 health-readiness plan) ──
+    //
+    // 45-day budget chosen to match IEA's M+2 monthly publication cadence
+    // (August data ships in late Oct/early Nov, so dataMonth in cache is
+    // typically ~30-60 days old at "fresh-arrival" time). 45d tolerates
+    // one normal publication delay and trips when a month is missed
+    // entirely (e.g. cache stuck at "2024-08" past Dec 1 when "2024-10"
+    // should have landed → STALE_CONTENT in /api/health).
+    //
+    // ieaOilStocksContentMeta parses data.dataMonth ("YYYY-MM") into
+    // end-of-month UTC ms. Single-snapshot shape: newest === oldest.
+    contentMeta: ieaOilStocksContentMeta,
+    maxContentAgeMin: IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN,
   }).catch((err) => {
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + cause);

--- a/scripts/seed-iea-oil-stocks.mjs
+++ b/scripts/seed-iea-oil-stocks.mjs
@@ -273,12 +273,12 @@ if (isMain) {
 
     // ── Content-age contract (Sprint 3b of the 2026-05-04 health-readiness plan) ──
     //
-    // 45-day budget chosen to match IEA's M+2 monthly publication cadence
-    // (August data ships in late Oct/early Nov, so dataMonth in cache is
-    // typically ~30-60 days old at "fresh-arrival" time). 45d tolerates
-    // one normal publication delay and trips when a month is missed
-    // entirely (e.g. cache stuck at "2024-08" past Dec 1 when "2024-10"
-    // should have landed → STALE_CONTENT in /api/health).
+    // 90-day budget = ~60d natural M+2 lag + ~30d missed-publication slack.
+    // August data (dataMonth="2024-08", end-of-month Aug 31) ships in late
+    // Oct/early Nov, so at fresh-arrival `newestItemAt` is already ~60d
+    // old. STALE_CONTENT trips only when a month is missed entirely (e.g.
+    // cache stuck at "2024-08" past mid-Jan when "2024-10" should have
+    // landed → /api/health surfaces STALE_CONTENT).
     //
     // ieaOilStocksContentMeta parses data.dataMonth ("YYYY-MM") into
     // end-of-month UTC ms. Single-snapshot shape: newest === oldest.

--- a/tests/iea-oil-stocks-content-age.test.mjs
+++ b/tests/iea-oil-stocks-content-age.test.mjs
@@ -15,8 +15,12 @@ import {
 
 const FIXED_NOW = 1700000000000;     // 2023-11-14T22:13:20.000Z — stable test "now"
 
-test('IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN is 45 days', () => {
-  assert.equal(IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN, 45 * 24 * 60);
+test('IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN is 90 days', () => {
+  // 90d = ~60d natural M+2 lag + ~30d missed-publication slack. See helper
+  // module's JSDoc on the threshold. Initial PR shipped 45d, which was
+  // wrong: every fresh seed run would have tripped STALE_CONTENT because
+  // 45d < the natural lag. Greptile P1 caught it on PR #3599.
+  assert.equal(IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN, 90 * 24 * 60);
 });
 
 // ── dataMonthToEndOfMonthMs ──────────────────────────────────────────────
@@ -100,21 +104,28 @@ test('contentMeta accepts last fully-completed month', () => {
   assert.equal(new Date(cm.newestItemAt).toISOString(), '2023-10-31T23:59:59.999Z');
 });
 
-// ── Pilot threshold sanity (anti-drift on the 45-day budget) ────────────
+// ── Pilot threshold sanity (anti-drift on the 90-day budget) ────────────
 
-test('pilot threshold: dataMonth 60 days old would trip STALE_CONTENT', () => {
-  // FIXED_NOW = 2023-11-14T22:13:20Z. dataMonth "2023-09" → end-of-Sept = ~45d ago.
-  // "2023-08" → end-of-Aug = ~75d ago. Use Aug to be clearly past 45d.
+test('fresh-arrival regression guard: ~60d-old fresh M+2 data does NOT trip STALE_CONTENT', () => {
+  // The exact failure mode caught by Greptile P1 on the initial 45d budget:
+  // when IEA publishes "2024-08" data in late Oct/early Nov, end-of-Aug is
+  // ~60-65d before fresh-arrival NOW. A budget below ~60d would fire
+  // STALE_CONTENT immediately on every successful seed run.
+  //
+  // FIXED_NOW = 2023-11-14T22:13:20Z. dataMonth "2023-09" → end-of-Sept
+  // = ~45d ago. dataMonth "2023-08" → end-of-Aug = ~75d ago. Use 2023-08
+  // to simulate freshly-arrived M+2 data at the upper end of the natural
+  // arrival-age range. This MUST be within budget.
   const cm = ieaOilStocksContentMeta({ dataMonth: '2023-08' }, FIXED_NOW);
   const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
   assert.ok(
-    ageMin > IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN,
-    `${Math.round(ageMin)}min > budget ${IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN}min — STALE_CONTENT would fire`,
+    ageMin < IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN,
+    `${Math.round(ageMin / 60 / 24)}d < ${IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN / 60 / 24}d budget — fresh M+2 arrival does NOT page`,
   );
 });
 
-test('pilot threshold: dataMonth ~30 days old is within 45-day budget (no false positive)', () => {
-  // FIXED_NOW = 2023-11-14. "2023-10" → end-of-Oct = ~14d ago. Fresh.
+test('pilot threshold: dataMonth ~14 days old is within 90-day budget (no false positive)', () => {
+  // FIXED_NOW = 2023-11-14. "2023-10" → end-of-Oct = ~14d ago. Trivially fresh.
   const cm = ieaOilStocksContentMeta({ dataMonth: '2023-10' }, FIXED_NOW);
   const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
   assert.ok(
@@ -123,15 +134,28 @@ test('pilot threshold: dataMonth ~30 days old is within 45-day budget (no false 
   );
 });
 
-test('pilot threshold: M+2 lag scenario — Sept data published in late Oct ages over 45d threshold by mid-Dec', () => {
-  // Realistic incident pattern: cache holds dataMonth="2023-09" (latest IEA
-  // monthly), which was published ~Oct 25. By 2024-01-01 (FIXED_FUTURE),
-  // it's been ~3 months since end-of-September → must trip.
-  const FIXED_FUTURE = Date.UTC(2024, 0, 1);     // Jan 1 2024 UTC
+test('pilot threshold: dataMonth ~120d old (multiple missed publications) trips STALE_CONTENT', () => {
+  // FIXED_NOW = 2023-11-14T22:13:20Z. "2023-07" → end-of-Jul = ~106d ago,
+  // past the 90d budget. Simulates "Aug AND Sept data both missed" or "Aug
+  // arrived very late" scenarios where on-call should be paged.
+  const cm = ieaOilStocksContentMeta({ dataMonth: '2023-07' }, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(
+    ageMin > IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN,
+    `${Math.round(ageMin / 60 / 24)}d > budget ${IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN / 60 / 24}d — STALE_CONTENT would fire`,
+  );
+});
+
+test('pilot threshold: M+2 lag scenario — Sept data still in cache by Feb 1 (5 months later) trips STALE_CONTENT', () => {
+  // Realistic incident pattern: cache holds dataMonth="2023-09" (Sept data,
+  // M+2 publication = late Nov 2023). By Feb 1 2024 — three months past
+  // expected publication of Oct AND Nov data — staleness is unambiguous.
+  // 154d > 90d budget: clearly trips.
+  const FIXED_FUTURE = Date.UTC(2024, 1, 1);     // Feb 1 2024 UTC
   const cm = ieaOilStocksContentMeta({ dataMonth: '2023-09' }, FIXED_FUTURE);
   const ageMin = (FIXED_FUTURE - cm.newestItemAt) / 60000;
   assert.ok(
     ageMin > IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN,
-    `Sept 2023 data on Jan 1 2024: ${Math.round(ageMin / 60 / 24)}d > 45d budget — STALE_CONTENT trips`,
+    `Sept 2023 data on Feb 1 2024: ${Math.round(ageMin / 60 / 24)}d > ${IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN / 60 / 24}d budget — STALE_CONTENT trips`,
   );
 });

--- a/tests/iea-oil-stocks-content-age.test.mjs
+++ b/tests/iea-oil-stocks-content-age.test.mjs
@@ -1,0 +1,137 @@
+// Sprint 3b — IEA oil stocks content-age contract.
+//
+// Tests import the SAME ieaOilStocksContentMeta the seeder runs, so a
+// future shape change in `_iea-oil-stocks-helpers.mjs` fails tests instead
+// of silently drifting. nowMs is injected with FIXED_NOW for deterministic
+// skew-limit behavior.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  dataMonthToEndOfMonthMs,
+  ieaOilStocksContentMeta,
+  IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN,
+} from '../scripts/_iea-oil-stocks-helpers.mjs';
+
+const FIXED_NOW = 1700000000000;     // 2023-11-14T22:13:20.000Z — stable test "now"
+
+test('IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN is 45 days', () => {
+  assert.equal(IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN, 45 * 24 * 60);
+});
+
+// ── dataMonthToEndOfMonthMs ──────────────────────────────────────────────
+
+test('dataMonthToEndOfMonthMs: "2024-08" → Aug 31 23:59:59.999 UTC', () => {
+  const ms = dataMonthToEndOfMonthMs('2024-08');
+  assert.equal(new Date(ms).toISOString(), '2024-08-31T23:59:59.999Z');
+});
+
+test('dataMonthToEndOfMonthMs: "2024-02" picks Feb 29 in a leap year', () => {
+  const ms = dataMonthToEndOfMonthMs('2024-02');
+  assert.equal(new Date(ms).toISOString(), '2024-02-29T23:59:59.999Z');
+});
+
+test('dataMonthToEndOfMonthMs: "2023-02" picks Feb 28 in a non-leap year', () => {
+  const ms = dataMonthToEndOfMonthMs('2023-02');
+  assert.equal(new Date(ms).toISOString(), '2023-02-28T23:59:59.999Z');
+});
+
+test('dataMonthToEndOfMonthMs: "2024-12" picks Dec 31 (rollover safe)', () => {
+  const ms = dataMonthToEndOfMonthMs('2024-12');
+  assert.equal(new Date(ms).toISOString(), '2024-12-31T23:59:59.999Z');
+});
+
+test('dataMonthToEndOfMonthMs: invalid shapes return null', () => {
+  assert.equal(dataMonthToEndOfMonthMs(undefined), null);
+  assert.equal(dataMonthToEndOfMonthMs(null), null);
+  assert.equal(dataMonthToEndOfMonthMs(''), null);
+  assert.equal(dataMonthToEndOfMonthMs('2024'), null);
+  assert.equal(dataMonthToEndOfMonthMs('2024-8'), null, 'single-digit month rejected');
+  assert.equal(dataMonthToEndOfMonthMs('2024-13'), null, 'month > 12 rejected');
+  assert.equal(dataMonthToEndOfMonthMs('2024-00'), null, 'month 0 rejected');
+  assert.equal(dataMonthToEndOfMonthMs('not-a-date'), null);
+  assert.equal(dataMonthToEndOfMonthMs(202408), null, 'numeric input rejected');
+});
+
+// ── ieaOilStocksContentMeta ──────────────────────────────────────────────
+
+test('contentMeta returns null when dataMonth missing', () => {
+  assert.equal(ieaOilStocksContentMeta({ members: [] }, FIXED_NOW), null);
+  assert.equal(ieaOilStocksContentMeta({}, FIXED_NOW), null);
+});
+
+test('contentMeta returns null when dataMonth is unparseable', () => {
+  assert.equal(ieaOilStocksContentMeta({ dataMonth: 'garbage' }, FIXED_NOW), null);
+  assert.equal(ieaOilStocksContentMeta({ dataMonth: '2024' }, FIXED_NOW), null);
+  assert.equal(ieaOilStocksContentMeta({ dataMonth: '2024-13' }, FIXED_NOW), null);
+});
+
+test('contentMeta: newest === oldest (single-snapshot shape)', () => {
+  // FIXED_NOW = 2023-11-14, so 2023-09 is well within tolerance and not future.
+  const cm = ieaOilStocksContentMeta({ dataMonth: '2023-09', members: [{}, {}, {}] }, FIXED_NOW);
+  assert.ok(cm, 'returns a result');
+  assert.equal(cm.newestItemAt, cm.oldestItemAt, 'single-snapshot: newest === oldest');
+  assert.equal(new Date(cm.newestItemAt).toISOString(), '2023-09-30T23:59:59.999Z');
+});
+
+test('contentMeta excludes future-dated months beyond 1h clock-skew tolerance', () => {
+  // FIXED_NOW = 2023-11-14T22:13:20Z. dataMonth "2099-12" → Dec 31 2099 — far future, must reject.
+  assert.equal(ieaOilStocksContentMeta({ dataMonth: '2099-12' }, FIXED_NOW), null);
+});
+
+test('contentMeta accepts current month (skewLimit edge — must NOT reject the month containing FIXED_NOW)', () => {
+  // FIXED_NOW = 2023-11-14T22:13:20Z; "2023-11" → Nov 30 23:59:59 — that's
+  // ~16 days AFTER FIXED_NOW, well past the 1h skew-limit tolerance.
+  // This documents a deliberate design choice: dataMonth points to END of
+  // the named period, so the seeder should NOT publish a dataMonth that
+  // hasn't fully ended yet (IEA's M+2 lag means current-month is never
+  // available anyway). If this assumption breaks, the test will surface it.
+  assert.equal(
+    ieaOilStocksContentMeta({ dataMonth: '2023-11' }, FIXED_NOW),
+    null,
+    'end-of-current-month is in the future relative to FIXED_NOW (mid-month) — rejected by skew-limit',
+  );
+});
+
+test('contentMeta accepts last fully-completed month', () => {
+  // FIXED_NOW = 2023-11-14, so "2023-10" → Oct 31 23:59:59 is in the past.
+  const cm = ieaOilStocksContentMeta({ dataMonth: '2023-10' }, FIXED_NOW);
+  assert.ok(cm);
+  assert.equal(new Date(cm.newestItemAt).toISOString(), '2023-10-31T23:59:59.999Z');
+});
+
+// ── Pilot threshold sanity (anti-drift on the 45-day budget) ────────────
+
+test('pilot threshold: dataMonth 60 days old would trip STALE_CONTENT', () => {
+  // FIXED_NOW = 2023-11-14T22:13:20Z. dataMonth "2023-09" → end-of-Sept = ~45d ago.
+  // "2023-08" → end-of-Aug = ~75d ago. Use Aug to be clearly past 45d.
+  const cm = ieaOilStocksContentMeta({ dataMonth: '2023-08' }, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(
+    ageMin > IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN,
+    `${Math.round(ageMin)}min > budget ${IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN}min — STALE_CONTENT would fire`,
+  );
+});
+
+test('pilot threshold: dataMonth ~30 days old is within 45-day budget (no false positive)', () => {
+  // FIXED_NOW = 2023-11-14. "2023-10" → end-of-Oct = ~14d ago. Fresh.
+  const cm = ieaOilStocksContentMeta({ dataMonth: '2023-10' }, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(
+    ageMin < IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN,
+    `${Math.round(ageMin)}min < budget ${IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN}min — STALE_CONTENT does NOT fire on normal M+2 cadence`,
+  );
+});
+
+test('pilot threshold: M+2 lag scenario — Sept data published in late Oct ages over 45d threshold by mid-Dec', () => {
+  // Realistic incident pattern: cache holds dataMonth="2023-09" (latest IEA
+  // monthly), which was published ~Oct 25. By 2024-01-01 (FIXED_FUTURE),
+  // it's been ~3 months since end-of-September → must trip.
+  const FIXED_FUTURE = Date.UTC(2024, 0, 1);     // Jan 1 2024 UTC
+  const cm = ieaOilStocksContentMeta({ dataMonth: '2023-09' }, FIXED_FUTURE);
+  const ageMin = (FIXED_FUTURE - cm.newestItemAt) / 60000;
+  assert.ok(
+    ageMin > IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN,
+    `Sept 2023 data on Jan 1 2024: ${Math.round(ageMin / 60 / 24)}d > 45d budget — STALE_CONTENT trips`,
+  );
+});


### PR DESCRIPTION
Sprint 3b of the [2026-05-04 health-readiness probe plan](docs/plans/2026-05-04-001-feat-health-readiness-probe-content-age-plan.md). Branched off Sprint 1 (#3596) as a parallel sibling to Sprint 2 (#3597) and Sprint 3a (#3598) per the plan's "Each PR is independently shippable" note.

## Summary

- Adds a content-age contract on `seed-iea-oil-stocks.mjs` so `/api/health` surfaces `STALE_CONTENT` when `data.dataMonth` is more than 45 days stale (i.e. the IEA monthly publication cycle has stalled).
- Pure helper in `scripts/_iea-oil-stocks-helpers.mjs`: `dataMonthToEndOfMonthMs`, `ieaOilStocksContentMeta` (with injectable `nowMs`), `IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN`. Seeder imports it; tests import it — no replicas (matches Sprint 2/3a post-refactor pattern).
- No `Dockerfile.relay` change needed — `seed-iea-oil-stocks.mjs` is not COPY'd into the relay container (verified via `grep`; relay closure test passes unchanged).

## Why 45 days

IEA monthly oil stocks reports publish on an M+2 cadence — August data ships in late October/early November. The `dataMonth` in cache is therefore typically ~30-60 days old at "fresh-arrival" time. A 45-day budget tolerates one normal publication delay (~30d slack on top of the natural M+2 lag) and trips when a publication month is missed entirely (e.g. cache stuck at \`"2024-08"\` past Dec 1 when \`"2024-10"\` should have landed).

## Shape contract — different from Sprint 2/3a

IEA is a **single-snapshot** seeder: every member shares one top-level `dataMonth` string ("YYYY-MM"), there is no per-item published-at. The new helper parses `dataMonth` → end-of-month UTC ms (the latest possible observation date in the named period) and returns it as both `newestItemAt` and `oldestItemAt` for Sprint 1's mirror-parity contract.

Defensive behaviors (each tested):
- Missing/malformed `dataMonth` (\`"2024-13"\`, \`"2024-8"\` single-digit, non-string, etc.) → \`null\`
- Future-dated `dataMonth` beyond 1h clock-skew tolerance → \`null\` (guards against upstream \`yearMonth\` garbage producing e.g. a \`2099-12\`)
- Leap-year correctness: \`"2024-02"\` → Feb 29; \`"2023-02"\` → Feb 28
- Month rollover safety: \`"2024-12"\` → Dec 31

## Test plan

- [x] \`node --test tests/iea-oil-stocks-content-age.test.mjs\` → 15/15 pass
- [x] \`node --test tests/iea-oil-stocks-seed.test.mjs tests/iea-oil-stocks-content-age.test.mjs tests/seed-content-age-contract.test.mjs tests/health-content-age.test.mjs tests/seed-utils-empty-data-failure.test.mjs\` → 78/78 pass
- [x] \`node --test tests/dockerfile-relay-imports.test.mjs\` → 3/3 pass (no relay impact)
- [x] \`npm run typecheck:api\` clean
- [x] \`npm run lint\` clean (pre-existing warnings only)
- [ ] Post-merge: confirm `/api/health` snapshot shows \`oilStocks\` with \`contentAge\` block populated, \`status: OK\`, and `contentAgeMin` matching `Date.now() - end-of-dataMonth`
- [ ] Post-merge: simulate stale (manually rewrite the canonical key with an old `dataMonth` in a preview env) → confirm `STALE_CONTENT`