### PR TITLE
fix(customs-revenue): retry Treasury MTS with backoff to survive Railway-egress blips

### DIFF
--- a/pro-test/package-lock.json
+++ b/pro-test/package-lock.json
@@ -7139,21 +7139,6 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",

--- a/scripts/seed-supply-chain-trade.mjs
+++ b/scripts/seed-supply-chain-trade.mjs
@@ -620,15 +620,43 @@ async function fetchCustomsRevenue() {
   const fields = 'record_date,current_month_rcpt_outly_amt,current_fytd_rcpt_outly_amt,record_fiscal_year,record_calendar_year,record_calendar_month';
   const url = `${TREASURY_MTS_URL}?fields=${fields}&filter=classification_desc:eq:Customs%20Duties,record_date:gte:${threeYearsAgo}&sort=-record_date&page[size]=50`;
 
-  const resp = await fetch(url, {
-    headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
-    signal: AbortSignal.timeout(15_000),
-  });
-  if (!resp.ok) throw new Error(`Treasury MTS HTTP ${resp.status}`);
-  const json = await resp.json();
-  const rows = json.data;
-  if (!Array.isArray(rows) || rows.length === 0) throw new Error('Treasury MTS returned no data');
-  if (rows.length > 100) throw new Error(`Treasury MTS returned unexpected row count: ${rows.length}`);
+  // Treasury MTS occasionally trips up on Railway egress (transient connect /
+  // 5xx / TLS resets). 30+ hour stale windows traced back to a single rejected
+  // fetch followed by no retry until the next 6h cron tick — by which point
+  // the 24h data TTL had expired and the panel went empty. Three attempts
+  // with linear backoff (5s, 15s) plus the existing 15s per-attempt timeout
+  // covers the realistic transient envelope without blocking the bundle.
+  // The final rejection re-throws with attempt count + last status / error
+  // so the rejection log line at fetchAll() + Sentry have enough context to
+  // triage from health output alone.
+  let lastErr = null;
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      const resp = await fetch(url, {
+        headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+        signal: AbortSignal.timeout(15_000),
+      });
+      if (!resp.ok) throw new Error(`Treasury MTS HTTP ${resp.status}`);
+      const json = await resp.json();
+      const rows = json.data;
+      if (!Array.isArray(rows) || rows.length === 0) throw new Error('Treasury MTS returned no data');
+      if (rows.length > 100) throw new Error(`Treasury MTS returned unexpected row count: ${rows.length}`);
+      // Success — break out, fall through to parse below.
+      return parseCustomsRows(rows);
+    } catch (err) {
+      lastErr = err;
+      const msg = err?.message || String(err);
+      if (attempt < 3) {
+        const backoffMs = attempt * 5_000; // 5s, 10s
+        console.warn(`  Treasury customs attempt ${attempt}/3 failed (${msg}); retrying in ${backoffMs}ms`);
+        await new Promise((r) => setTimeout(r, backoffMs));
+      }
+    }
+  }
+  throw new Error(`Treasury MTS exhausted 3 attempts: ${lastErr?.message || lastErr}`);
+}
+
+function parseCustomsRows(rows) {
 
   const months = rows
     .map(r => {

--- a/scripts/seed-supply-chain-trade.mjs
+++ b/scripts/seed-supply-chain-trade.mjs
@@ -624,11 +624,18 @@ async function fetchCustomsRevenue() {
   // 5xx / TLS resets). 30+ hour stale windows traced back to a single rejected
   // fetch followed by no retry until the next 6h cron tick — by which point
   // the 24h data TTL had expired and the panel went empty. Three attempts
-  // with linear backoff (5s, 15s) plus the existing 15s per-attempt timeout
-  // covers the realistic transient envelope without blocking the bundle.
+  // with linear backoff (5s, 10s) plus the existing 15s per-attempt timeout
+  // give a worst-case ~60s budget per cron run, well within the bundle window.
   // The final rejection re-throws with attempt count + last status / error
   // so the rejection log line at fetchAll() + Sentry have enough context to
   // triage from health output alone.
+  //
+  // Deterministic failures (4xx other than 429, schema-drift row-count
+  // violation) skip the retry loop — they cannot recover by waiting.
+  // Marking them with `{ __retryable: false }` lets the catch block
+  // short-circuit instead of burning ~30s of cron time and emitting
+  // misleading "retrying in 5000ms" warns for what is actually a fixed
+  // upstream / contract-violation condition.
   let lastErr = null;
   for (let attempt = 1; attempt <= 3; attempt++) {
     try {
@@ -636,16 +643,35 @@ async function fetchCustomsRevenue() {
         headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
         signal: AbortSignal.timeout(15_000),
       });
-      if (!resp.ok) throw new Error(`Treasury MTS HTTP ${resp.status}`);
+      if (!resp.ok) {
+        // 4xx client errors (except 429 rate-limit) are deterministic — the
+        // request is malformed or the resource is gone; retry can't fix it.
+        const isClient4xx = resp.status >= 400 && resp.status < 500 && resp.status !== 429;
+        const err = new Error(`Treasury MTS HTTP ${resp.status}`);
+        if (isClient4xx) err.__retryable = false;
+        throw err;
+      }
       const json = await resp.json();
       const rows = json.data;
+      // Empty array MAY be transient (deploy gap, reseed window) — keep retryable.
       if (!Array.isArray(rows) || rows.length === 0) throw new Error('Treasury MTS returned no data');
-      if (rows.length > 100) throw new Error(`Treasury MTS returned unexpected row count: ${rows.length}`);
+      // Row-count > 100 means schema drift / new MTS response shape; second
+      // request will return the same number, so don't waste cron time.
+      if (rows.length > 100) {
+        const err = new Error(`Treasury MTS returned unexpected row count: ${rows.length}`);
+        err.__retryable = false;
+        throw err;
+      }
       // Success — break out, fall through to parse below.
       return parseCustomsRows(rows);
     } catch (err) {
       lastErr = err;
       const msg = err?.message || String(err);
+      // Skip the rest of the retry budget on deterministic failures.
+      if (err?.__retryable === false) {
+        console.warn(`  Treasury customs attempt ${attempt}/3 hit non-retryable error (${msg}); aborting retry`);
+        break;
+      }
       if (attempt < 3) {
         const backoffMs = attempt * 5_000; // 5s, 10s
         console.warn(`  Treasury customs attempt ${attempt}/3 failed (${msg}); retrying in ${backoffMs}ms`);

--- a/tests/customs-revenue.test.mjs
+++ b/tests/customs-revenue.test.mjs
@@ -50,6 +50,21 @@ describe('Customs revenue seed', () => {
     assert.match(seedSrc, /\.reverse\(\)/);
   });
 
+  it('retries the Treasury fetch with backoff to survive transient Railway-egress failures', () => {
+    // Single-attempt fetch left the customs branch failing for 30+ hours
+    // after a one-off transient blip — by the next 6h cron tick the data
+    // had TTL'd out (24h) and the panel went empty. Three attempts with
+    // 5s/10s linear backoff covers the realistic transient envelope.
+    assert.match(seedSrc, /attempt\s*<=\s*3/, 'retry loop must use a 3-attempt cap');
+    assert.match(seedSrc, /Treasury MTS exhausted 3 attempts/, 'final error must include attempt count for triage');
+    assert.match(seedSrc, /attempt \* 5_000/, 'backoff must be linear (5s, 10s) on attempt 1 and 2');
+  });
+
+  it('factors row parsing into a separate function so retry success path stays clean', () => {
+    assert.match(seedSrc, /function parseCustomsRows\(rows\)/);
+    assert.match(seedSrc, /return parseCustomsRows\(rows\);/);
+  });
+
   it('writes customs revenue as extra key with seed-meta', () => {
     assert.match(seedSrc, /writeExtraKeyWithMeta\(KEYS\.customsRevenue/);
   });

--- a/tests/customs-revenue.test.mjs
+++ b/tests/customs-revenue.test.mjs
@@ -65,6 +65,25 @@ describe('Customs revenue seed', () => {
     assert.match(seedSrc, /return parseCustomsRows\(rows\);/);
   });
 
+  it('marks 4xx (except 429) as non-retryable so deterministic failures short-circuit the retry loop', () => {
+    // Without this, a malformed URL or removed endpoint would burn 5s + 10s
+    // of backoff per cron run before propagating — and emit two misleading
+    // "retrying in …" warns that hide the real (deterministic) cause.
+    assert.match(
+      seedSrc,
+      /resp\.status\s*>=\s*400\s*&&\s*resp\.status\s*<\s*500\s*&&\s*resp\.status\s*!==\s*429/,
+      'expected 4xx-except-429 client-error short-circuit',
+    );
+    assert.match(seedSrc, /__retryable\s*=\s*false/, 'expected __retryable marker on the thrown error');
+    assert.match(seedSrc, /err\?\.__retryable\s*===\s*false/, 'expected catch block to honor the marker');
+  });
+
+  it('marks schema-drift row-count violation as non-retryable', () => {
+    // A second fetch will return the same upstream response shape — row-count
+    // violations are an upstream contract change, not transient.
+    assert.match(seedSrc, /rows\.length > 100[\s\S]{0,400}__retryable\s*=\s*false/);
+  });
+
   it('writes customs revenue as extra key with seed-meta', () => {
     assert.match(seedSrc, /writeExtraKeyWithMeta\(KEYS\.customsRevenue/);
   });


### PR DESCRIPTION
## Symptom

`/api/health` reports:

```json
"customsRevenue": {
  "status": "EMPTY",
  "records": 0,
  "seedAgeMin": 1845,
  "maxStaleMin": 1440
}
```

30+ hours past freshness floor, no records in cache.

## Diagnosis

| Layer | Finding |
|---|---|
| Treasury MTS upstream | **Healthy.** Direct probe with the seeder's exact URL + `CHROME_UA` returns 39 rows in <1s. |
| Railway cron service | **Alive.** Sibling fetchers in the same `seed-supply-chain-trade` bundle updating fine: `shippingRates` seedAgeMin=46m, `comtradeFlows` seedAgeMin=116m. |
| Customs branch | **Rejecting silently in `Promise.allSettled`.** The rejection warn at line 688 (`Treasury customs failed: …`) IS logged on Railway today, but a single transient blip with no retry → next 6h cron tick hits the same transient → `cu = null` → `if (cu)` skips the write → seed-meta + data both age out. |
| Data TTL vs meta TTL | `CUSTOMS_TTL=86400` (24h) for the data key; `writeSeedMeta` defaults to **7 days** for the meta. So after a single failure cycle the data TTL'd out (24h) while seed-meta kept reporting `fetchedAt: T-30h`, producing the misleading `EMPTY records=0 seedAgeMin=1845` health shape. |

Net: **one transient Railway-egress blip cascaded into 30+ hours of EMPTY panel data** because the fetch had no retry budget.

## Fix

Wrap `fetchCustomsRevenue` in a 3-attempt retry with linear 5s / 10s backoff. Existing 15s per-attempt timeout stays. Final rejection re-throws with attempt count + underlying error so the existing warn line carries enough context to triage from health output alone.

```js
for (let attempt = 1; attempt <= 3; attempt++) {
  try { ... return parseCustomsRows(rows); }
  catch (err) {
    lastErr = err;
    if (attempt < 3) {
      const backoffMs = attempt * 5_000;  // 5s, 10s
      console.warn(`  Treasury customs attempt ${attempt}/3 failed (${msg}); retrying in ${backoffMs}ms`);
      await new Promise((r) => setTimeout(r, backoffMs));
    }
  }
}
throw new Error(`Treasury MTS exhausted 3 attempts: ${lastErr?.message || lastErr}`);
```

Row parsing factored into `parseCustomsRows()` so the retry loop's success branch stays clean — retry returns the parsed result directly; only the fetch + validation steps repeat.

## Out of scope (deliberate)

- **Why the Railway transient happens** — likely IP-block / policy / connect-timeout. Without Railway log access from outside the network I can't trace the exact cause. The retry covers the realistic transient envelope; if the failure is persistent (e.g. a permanent IP block), Railway logs will now show `Treasury MTS exhausted 3 attempts: <reason>` and we can layer on a proxy fallback in a follow-up.
- **Data-vs-meta TTL drift** — `seed-meta` 7-day TTL outliving 24h data TTL produces the misleading "EMPTY but seedAgeMin small" health shape. Worth a separate cleanup pass; not load-bearing for this fix.

## Test plan

- [x] `npm run typecheck` — PASS
- [x] `npm run typecheck:api` — PASS
- [x] `npm run lint` — PASS (warnings only, all pre-existing)
- [x] `npm run test:data` — PASS (7865/7865)
- [x] Two new regression assertions in `tests/customs-revenue.test.mjs`:
  - retry must use a 3-attempt cap with linear `attempt * 5_000` backoff
  - parser must be factored out into `parseCustomsRows`
- [x] Pre-fix verification: stashed only `scripts/seed-supply-chain-trade.mjs` and re-ran the test — both new assertions FAIL as expected. Post-fix both PASS.
- [x] Pre-push strict gate (boundaries, rate-limit, premium-fetch, edge-bundles, version) — PASS
- [ ] Post-deploy: watch Railway logs for the next 24h to confirm:
  - Either the retry recovers the customs branch (data refreshes), OR
  - Logs surface a persistent `Treasury MTS exhausted 3 attempts: <reason>` so we can see the underlying cause and add a proxy fallback if needed.