### PR TITLE
fix(sentry): Convex JSON Unauthenticated → 401 + SERVICE_UNAVAILABLE warning + change_ua noise

### DIFF
--- a/api/_convex-error.js
+++ b/api/_convex-error.js
@@ -52,6 +52,16 @@ export function extractConvexErrorKind(err, msg) {
   // pattern (`transport_timeout` vs `convex_service_unavailable`).
   const errName = /** @type {{ name?: string } | null | undefined} */ (err)?.name;
   if (errName === 'TimeoutError' || errName === 'AbortError') return 'SERVICE_UNAVAILABLE';
+  // Convex platform-level 401: when Clerk's OIDC token fails Convex's own
+  // verification (token expired between our edge's `validateBearerToken`
+  // and Convex's check, or Clerk JWKS rotated), the SDK surfaces a JSON
+  // body `{"code":"Unauthenticated","message":"Could not verify OIDC token
+  // claim..."}` — case-mismatched against the structured-data
+  // `UNAUTHENTICATED` kind, so the substring check below would miss it.
+  // Map to the same UNAUTHENTICATED kind as the structured-data path so
+  // the edge handler maps it to 401 and tags it as `convex_auth_drift`
+  // (WORLDMONITOR-PG).
+  if (msg.includes('"code":"Unauthenticated"')) return 'UNAUTHENTICATED';
   if (msg.includes('CONFLICT')) return 'CONFLICT';
   if (msg.includes('BLOB_TOO_LARGE')) return 'BLOB_TOO_LARGE';
   if (msg.includes('UNAUTHENTICATED')) return 'UNAUTHENTICATED';

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -100,12 +100,14 @@ export default async function handler(
         // Convex platform-level 503 — transient and self-recovering. Map to
         // 503 with `Retry-After` so the client backs off rather than treating
         // it as a permanent 500. Still capture so we can spot regressions /
-        // sustained outages, but use the typed `convex_service_unavailable`
-        // shape so it groups distinctly from real internal 500s.
+        // sustained outages, but use `level: 'warning'` so this expected
+        // transient external-system event doesn't drown the error
+        // dashboard or page on-call (WORLDMONITOR-QA).
         console.warn('[user-prefs] GET convex service unavailable:', msg);
         captureSilentError(err, buildSentryContext(err, msg, {
           method: 'GET', convexFn: 'userPreferences:getPreferences',
           userId: session.userId, variant, ctx,
+          level: 'warning',
         }));
         return jsonResponse({ error: 'SERVICE_UNAVAILABLE' }, 503, { ...cors, 'Retry-After': '5' });
       }
@@ -202,6 +204,8 @@ export default async function handler(
     if (kind === 'SERVICE_UNAVAILABLE') {
       // See GET branch above — Convex 503, transient. 503 + Retry-After
       // so the client backs off rather than burning a 500-failed-write.
+      // `level: 'warning'` so the expected transient external-system
+      // event stays queryable but doesn't page on-call (WORLDMONITOR-QA).
       console.warn('[user-prefs] POST convex service unavailable:', msg);
       captureSilentError(err, buildSentryContext(err, msg, {
         method: 'POST', convexFn: 'userPreferences:setPreferences',
@@ -209,6 +213,7 @@ export default async function handler(
         schemaVersion: typeof body.schemaVersion === 'number' ? body.schemaVersion : null,
         expectedSyncVersion: body.expectedSyncVersion,
         blobSize: body.data !== undefined ? JSON.stringify(body.data).length : 0,
+        level: 'warning',
       }));
       return jsonResponse({ error: 'SERVICE_UNAVAILABLE' }, 503, { ...cors, 'Retry-After': '5' });
     }
@@ -347,7 +352,14 @@ export function buildSentryContext(
   // would otherwise fall into 'unknown' and conflate transient outages with
   // genuinely-novel failure modes that haven't been classified yet.
   const errorShape = opts.errorShapeOverride
-    ?? (/UNAUTHENTICATED/.test(msg) ? 'convex_auth_drift'
+    // Match both the structured-data `UNAUTHENTICATED` kind (uppercase, from
+    // `ConvexError({kind:'UNAUTHENTICATED'})`) AND the platform-level JSON-
+    // shape `"code":"Unauthenticated"` (mixed case, from Convex's runtime
+    // when Clerk OIDC token verification fails). Both are auth drift —
+    // WORLDMONITOR-PG: the JSON-cased variant was previously falling
+    // through to 'unknown' because the `/UNAUTHENTICATED/` regex is
+    // case-sensitive.
+    ?? (/UNAUTHENTICATED|"code":"Unauthenticated"/.test(msg) ? 'convex_auth_drift'
       : /"code":"ServiceUnavailable"/.test(msg) ? 'convex_service_unavailable'
       : /\[Request ID:\s*[a-f0-9]+\]\s*Server Error/i.test(msg) ? 'convex_server_error'
       : /timeout|timed out|aborted/i.test(msg) ? 'transport_timeout'

--- a/src/main.ts
+++ b/src/main.ts
@@ -202,7 +202,7 @@ Sentry.init({
     /Can't find variable: caches/,
     /crypto\.randomUUID is not a function/,
     /ucapi is not defined/,
-    /Identifier '(?:script|reportPage|element|Shop)' has already been declared/,
+    /Identifier '(?:script|reportPage|element|Shop|change_ua)' has already been declared/, // change_ua: User-Agent-changer browser extension injecting same script twice — WORLDMONITOR-2D (88 events / 26 users)
     /getAttribute is not a function.*getAttribute\("role"\)/,
     /SCDynimacBridge/,
     /errTimes is not defined/,

--- a/tests/user-prefs-convex-error.test.mjs
+++ b/tests/user-prefs-convex-error.test.mjs
@@ -66,6 +66,42 @@ describe('extractConvexErrorKind — Convex client error → kind', () => {
     });
   });
 
+  describe('Convex platform 401 — Unauthenticated JSON body (OIDC token verification failure)', () => {
+    it('detects UNAUTHENTICATED from the {"code":"Unauthenticated"} JSON shape', () => {
+      // WORLDMONITOR-PG: when Clerk's OIDC token fails Convex's own
+      // verification (token expired between our edge's
+      // `validateBearerToken` and Convex's check, or Clerk JWKS rotated),
+      // the SDK surfaces a JSON body
+      //   `{"code":"Unauthenticated","message":"Could not verify OIDC token claim..."}`
+      // The mixed-case `"Unauthenticated"` doesn't match the uppercase
+      // legacy substring check, so without the JSON-shape detector this
+      // fell into the generic 500 bucket. Map to UNAUTHENTICATED so the
+      // edge handler returns 401 and tags as `convex_auth_drift`.
+      const err = new Error('{"code":"Unauthenticated","message":"Could not verify OIDC token claim. Check that the token signature is valid and the token hasn\'t expired."}');
+      assert.equal(extractConvexErrorKind(err, err.message), 'UNAUTHENTICATED');
+    });
+
+    it('detects UNAUTHENTICATED even when the JSON has additional fields', () => {
+      const err = new Error('{"code":"Unauthenticated","message":"Token expired","reason":"jwks_rotation"}');
+      assert.equal(extractConvexErrorKind(err, err.message), 'UNAUTHENTICATED');
+    });
+
+    it('does NOT match the loose phrase "unauthenticated" without the JSON code field', () => {
+      // Defensive: the detector keys off the exact JSON-shape `"code":"Unauthenticated"`,
+      // not the prose. Prevents matching some unrelated upstream that happens to
+      // include the lowercase word in a free-form error message.
+      const err = new Error('Network error: user is unauthenticated, please retry');
+      assert.equal(extractConvexErrorKind(err, err.message), null);
+    });
+
+    it('structured-data path still wins over JSON-shape Unauthenticated (forward-compat)', () => {
+      const err = Object.assign(new Error('{"code":"Unauthenticated","message":"x"}'), {
+        data: { kind: 'CONFLICT' },
+      });
+      assert.equal(extractConvexErrorKind(err, err.message), 'CONFLICT');
+    });
+  });
+
   describe('legacy substring-match fallback (string-data ConvexError that arrived without errorData)', () => {
     it('matches CONFLICT in the message', () => {
       const err = new Error('CONFLICT');

--- a/tests/user-prefs-sentry-context.test.mts
+++ b/tests/user-prefs-sentry-context.test.mts
@@ -130,6 +130,18 @@ describe('buildSentryContext — backwards-compat for non-CONFLICT callers', () 
     assert.equal(ctx.tags.error_shape, 'convex_service_unavailable');
   });
 
+  it('JSON-shape "code":"Unauthenticated" classifies as convex_auth_drift (mixed-case OIDC failure)', () => {
+    // WORLDMONITOR-PG: Convex platform-level 401 ships a JSON body
+    //   `{"code":"Unauthenticated","message":"Could not verify OIDC token claim..."}`
+    // The mixed-case `"Unauthenticated"` doesn't match the uppercase
+    // `/UNAUTHENTICATED/` regex, so prior to the fix this fell through
+    // to `error_shape: 'unknown'` and the response went 500 instead of
+    // 401. Now both shapes route to the same auth-drift bucket.
+    const err = new Error('{"code":"Unauthenticated","message":"Could not verify OIDC token claim. Check that the token signature is valid and the token hasn\'t expired."}');
+    const ctx = buildSentryContext(err, err.message, baseOpts);
+    assert.equal(ctx.tags.error_shape, 'convex_auth_drift');
+  });
+
   it('messageHead still in extra (non-indexed payload, not promoted)', () => {
     const err = new Error('quite a long error message that should land in extra');
     const ctx = buildSentryContext(err, err.message, baseOpts);


### PR DESCRIPTION
## Summary

Three parallel triage findings, bundled because they all touch the same Sentry-classification surfaces.

### A. WORLDMONITOR-PG (5ev/4u) — JSON-shape `Unauthenticated` misclassified

Convex platform-level 401 ships a JSON body `{"code":"Unauthenticated","message":"Could not verify OIDC token claim..."}` when the Clerk token fails Convex's own OIDC check (token expired between our edge's `validateBearerToken` and Convex's verify, or Clerk JWKS rotated). Mixed-case `"Unauthenticated"` doesn't match the legacy uppercase `UNAUTHENTICATED` substring check. Without the JSON-shape detector, this **fell through to `error_shape: 'unknown'` AND the edge handler returned 500 instead of 401**.

Fix mirrors the existing `"code":"ServiceUnavailable"` JSON detector added in PR #3479:
- `api/_convex-error.js`: detect `"code":"Unauthenticated"` → return UNAUTHENTICATED kind → routed through the same edge branch that already returns 401.
- `api/user-prefs.ts`: `error_shape` regex extended to match both `UNAUTHENTICATED` and `"code":"Unauthenticated"`. Both bucket as `convex_auth_drift`.

### B. WORLDMONITOR-QA (4ev/2u) — SERVICE_UNAVAILABLE downgrade to `level: 'warning'`

Sister fix to PR #3506 (CONFLICT level downgrade). Convex platform 503 is a known transient external-system event; we already capture for visibility and return 503 + Retry-After. Pass `level: 'warning'` so the capture stays queryable in Sentry but doesn't drown the error dashboard or page on-call. Both GET and POST SERVICE_UNAVAILABLE branches updated.

### C. WORLDMONITOR-2D (88ev/26u) — `change_ua` browser extension noise

`SyntaxError: Failed to execute 'appendChild' on 'Node': Identifier 'change_ua' has already been declared.` `change_ua` is a known User-Agent-spoofing browser extension injecting the same script twice. The existing `Identifier '...' has already been declared` `ignoreErrors` regex covered `script|reportPage|element|Shop` — just extending to include `change_ua`. Highest-volume of the three by far.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean
- [x] `npm run lint` — exit 0
- [x] `npm run test:data` — 7872/7872 pass (4 new cases in `user-prefs-convex-error.test.mjs`)
- [x] `node --import tsx --test tests/user-prefs-sentry-context.test.mts` — 13/13 pass (1 new case for JSON-shape `convex_auth_drift`)
- [x] `node --test tests/edge-functions.test.mjs` — 181/181 pass
- [x] Edge bundle check — clean
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — OK

## Sentry status

All four issues this round resolved with `inNextRelease: true`. WORLDMONITOR-Q9 (`Checkout error: session_expired`, 1ev/1u) was already correctly at info level via `INFO_LEVEL_CODES` — no code change needed.