### PR TITLE
feat(power-reliability): Sprint 4 — content-age probe (24-month budget)

### DIFF
--- a/scripts/_power-reliability-helpers.mjs
+++ b/scripts/_power-reliability-helpers.mjs
@@ -1,0 +1,107 @@
+// Sprint 4 — content-age helpers for seed-power-reliability.mjs.
+//
+// Why a separate module: same as Sprint 2/3a/3b — tests need to import the
+// real production code instead of replicating it; otherwise the
+// in-memory↔canonical contract can drift silently.
+//
+// Shape contract (different from Sprint 2/3a per-item arrays AND from
+// Sprint 3b single-snapshot period):
+//
+//   data.countries: { US: { value: 5.4, year: 2024 }, KW: { value: 8.1, year: 2023 }, ... }
+//   data.seededAt:  ISO timestamp (seeder-run wall clock — NOT content age)
+//
+// Each country reports its OWN year. WB indicators publish annually but
+// late-reporters (KW/QA/AE) lag G7 by 1-2 years. The "content-age" signal
+// is therefore the MAX year across all countries (the freshest data point
+// the cache has seen anywhere) — once year-(N+1) data lands for any
+// country, newestItemAt advances and the staleness clock resets.
+//
+// `seededAt` is NOT a content timestamp. It's `new Date().toISOString()`
+// captured at seed-run time, used for cache-key bookkeeping. Same trap as
+// Sprint 3b's iea-oil-stocks: confusing it with content age would defeat
+// the entire content-age probe — a healthy seeder cron would always show
+// "fresh" while the underlying WB data hadn't published a new year in
+// months.
+
+/**
+ * Convert a year (number or numeric string like "2024") to end-of-year UTC ms.
+ *
+ * The WB indicator value labelled `"2024"` represents observations DURING
+ * that calendar year, so the latest possible observation date is Dec 31.
+ * End-of-year is the most defensible "newestItemAt" — it represents the
+ * last possible date the report could be observing. Mirrors the
+ * Sprint 3b end-of-period rationale.
+ *
+ * Returns null when input shape is unexpected — defensive against upstream
+ * `record.date` parsing drift (WB API has been known to return null/empty
+ * date for in-progress observations).
+ *
+ * @param {number|string} year
+ */
+export function yearToEndOfYearMs(year) {
+  const n = typeof year === 'string' ? Number(year) : year;
+  if (!Number.isInteger(n) || n < 1900 || n > 9999) return null;
+  return Date.UTC(n, 11, 31, 23, 59, 59, 999);
+}
+
+/**
+ * Compute newest/oldest content timestamps from the per-country payload.
+ *
+ * - newestItemAt = end-of-year(max year across countries) — drives staleness
+ * - oldestItemAt = end-of-year(min year across countries) — informational,
+ *   surfaces "how stretched is the per-country reporting cohort"
+ * - Returns null when no country has a usable year — runSeed writes
+ *   newestItemAt: null, classifier reads as STALE_CONTENT.
+ * - Excludes future-dated years beyond 1h clock-skew tolerance (defensive
+ *   against upstream year=2099 garbage that would otherwise falsely report
+ *   fresh).
+ *
+ * @param {{countries: Record<string, {year: number}>}} data
+ * @param {number} nowMs - injectable "now" for deterministic tests
+ */
+export function powerReliabilityContentMeta(data, nowMs = Date.now()) {
+  const countries = data?.countries;
+  if (!countries || typeof countries !== 'object') return null;
+  const skewLimit = nowMs + 60 * 60 * 1000;
+  let newest = -Infinity, oldest = Infinity, validCount = 0;
+  for (const entry of Object.values(countries)) {
+    const ts = yearToEndOfYearMs(entry?.year);
+    if (ts == null) continue;
+    if (ts > skewLimit) continue;
+    validCount++;
+    if (ts > newest) newest = ts;
+    if (ts < oldest) oldest = ts;
+  }
+  if (validCount === 0) return null;
+  return { newestItemAt: newest, oldestItemAt: oldest };
+}
+
+/**
+ * Sprint 4 pilot threshold (24 months / 730 days, expressed in minutes).
+ *
+ * Why 24 months — verified against live WB data 2026-05-05:
+ *
+ *   curl https://api.worldbank.org/v2/country/USA;CHN;...;KWT/indicator/EG.ELC.LOSS.ZS
+ *
+ * On that date G7 max year was 2024 (end-of-2024 = Dec 31 2024 = ~17
+ * months before the seed run). Plan §477-485 originally proposed 13
+ * months but that's structurally wrong: WB year-N data lands in cache
+ * 12-18 months after end-of-N (publication lag varies), so a 13-month
+ * budget would have tripped STALE_CONTENT immediately on every successful
+ * fresh-arrival — same trap Greptile P1 caught on Sprint 3b PR #3599.
+ *
+ * Steady-state model:
+ *   - Year N data lands at age = 12-18 months (publication lag)
+ *   - Year (N+1) data lands ~12 months later, resetting the clock
+ *   - Worst case during steady state: age = ~30 months (just before next
+ *     year drops AND publication lag is at upper end)
+ *   - 24-month budget catches catastrophic stalls (>2y silent upstream)
+ *     without false-positive paging during normal "between publications"
+ *
+ * If a future migration uses an indicator with worse publication lag
+ * (some WB indicators like FI.RES.TOTL.MO publish on Q+2 quarterly so
+ * are fresher; others lag 24+ months), bump per-indicator. Don't reuse
+ * this constant blindly across the 4-indicator Sprint 4 cohort —
+ * audit each one's actual fresh-arrival age.
+ */
+export const POWER_RELIABILITY_MAX_CONTENT_AGE_MIN = 24 * 30 * 24 * 60;

--- a/scripts/_power-reliability-helpers.mjs
+++ b/scripts/_power-reliability-helpers.mjs
@@ -77,31 +77,45 @@ export function powerReliabilityContentMeta(data, nowMs = Date.now()) {
 }
 
 /**
- * Sprint 4 pilot threshold (24 months / 730 days, expressed in minutes).
+ * Sprint 4 pilot threshold (36 thirty-day months ≈ 1080 days ≈ 3 years).
  *
- * Why 24 months — verified against live WB data 2026-05-05:
+ * Verified against live WB data 2026-05-05:
  *
  *   curl https://api.worldbank.org/v2/country/USA;CHN;...;KWT/indicator/EG.ELC.LOSS.ZS
  *
- * On that date G7 max year was 2024 (end-of-2024 = Dec 31 2024 = ~17
- * months before the seed run). Plan §477-485 originally proposed 13
- * months but that's structurally wrong: WB year-N data lands in cache
- * 12-18 months after end-of-N (publication lag varies), so a 13-month
- * budget would have tripped STALE_CONTENT immediately on every successful
- * fresh-arrival — same trap Greptile P1 caught on Sprint 3b PR #3599.
+ * G7 max year on that date was 2024. End-of-2024 = Dec 31 2024 ≈ 17
+ * months before the seed run.
  *
- * Steady-state model:
- *   - Year N data lands at age = 12-18 months (publication lag)
- *   - Year (N+1) data lands ~12 months later, resetting the clock
- *   - Worst case during steady state: age = ~30 months (just before next
- *     year drops AND publication lag is at upper end)
- *   - 24-month budget catches catastrophic stalls (>2y silent upstream)
- *     without false-positive paging during normal "between publications"
+ * Plan §477-485 originally proposed 13 months but that's structurally
+ * wrong for two compounding reasons that BOTH had to be addressed:
+ *
+ *   1. Fresh-arrival lag — WB year-N data lands in cache 12-18 months
+ *      after end-of-N. A budget below ~18mo trips STALE_CONTENT
+ *      immediately on every successful fresh-arrival (the Sprint 3b
+ *      PR #3599 P1 trap, in its annual-data variant).
+ *
+ *   2. Steady-state ceiling — once year N is in cache, it stays there
+ *      until year N+1 publishes. Year N+1 can publish as late as
+ *      end-of-(N+1) + 18mo = end-of-N + 12 + 18 = 30 months past
+ *      end-of-N. So under normal upstream cadence, cache age can
+ *      reach 30 months between publications WITHOUT any real stall.
+ *      A 24-month budget would page mid-cycle (caught on PR #3602
+ *      review round 2 by Greptile P1).
+ *
+ * 36-month budget = 30mo steady-state ceiling + 6mo slack. STALE_CONTENT
+ * trips only on multi-cycle silent upstream stalls, never during normal
+ * "year N+1 ran late" cycles.
  *
  * If a future migration uses an indicator with worse publication lag
- * (some WB indicators like FI.RES.TOTL.MO publish on Q+2 quarterly so
- * are fresher; others lag 24+ months), bump per-indicator. Don't reuse
- * this constant blindly across the 4-indicator Sprint 4 cohort —
- * audit each one's actual fresh-arrival age.
+ * (some WB indicators publish quarterly with Q+2 lag so are fresher;
+ * others lag 24+ months), bump per-indicator. Don't reuse this constant
+ * blindly across the 4-indicator Sprint 4 cohort — audit each one's
+ * actual fresh-arrival age via the same WB-API curl recipe and apply
+ * the publication-lag-plus-cycle formula:
+ *
+ *   budget_months >= max_publication_lag + cycle_length + slack
+ *
+ * (For annual indicators: publication_lag ~= 12-18 months, cycle = 12,
+ *  steady-state max age = publication_lag + cycle = 30, budget = 36.)
  */
-export const POWER_RELIABILITY_MAX_CONTENT_AGE_MIN = 24 * 30 * 24 * 60;
+export const POWER_RELIABILITY_MAX_CONTENT_AGE_MIN = 36 * 30 * 24 * 60;

--- a/scripts/seed-power-reliability.mjs
+++ b/scripts/seed-power-reliability.mjs
@@ -101,16 +101,17 @@ if (process.argv[1]?.endsWith('seed-power-reliability.mjs')) {
 
     // ── Content-age contract (Sprint 4 of the 2026-05-04 health-readiness plan) ──
     //
-    // 24-month budget: covers WB's 12-18 month publication lag for year-N
-    // data + slack for the year-N+1 publication cycle. STALE_CONTENT trips
-    // only on catastrophic upstream stalls (>2y since any country's latest
-    // year). See helper module's JSDoc for the math + the verification
-    // against live WB data on 2026-05-05.
+    // 36-month budget = 30mo steady-state ceiling + 6mo slack.
     //
-    // Plan §477-485 originally proposed 13 months but that is structurally
-    // wrong for WB indicators — fresh-arrival age is already 12-18 months
-    // because publication is 12-18 months after end-of-year. Sprint 3b's
-    // P1 (PR #3599) was the same shape of trap.
+    // The 30mo ceiling comes from the WB publication-lag-plus-cycle math:
+    // year N+1 can normally publish as late as end-of-(N+1) + 18mo =
+    // end-of-N + 30mo, so a cache holding year N can legitimately reach
+    // 30mo of age before year N+1 arrives. Anything tighter than 30mo
+    // false-positives mid-cycle. See helper module's JSDoc for the full
+    // derivation + the verification against live WB data on 2026-05-05.
+    //
+    // STALE_CONTENT trips only on multi-cycle silent upstream stalls,
+    // never during normal "year N+1 ran late" cycles.
     //
     // powerReliabilityContentMeta scans data.countries per-country years
     // and returns end-of-(max year) UTC ms as newestItemAt.

--- a/scripts/seed-power-reliability.mjs
+++ b/scripts/seed-power-reliability.mjs
@@ -13,6 +13,10 @@
 
 import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
 import iso3ToIso2 from './shared/iso3-to-iso2.json' with { type: 'json' };
+// Pure contentMeta + year parser live in their own module so tests can
+// import the real code (no replicas, no drift). Per-country annual shape:
+// each country reports its own year; newestItemAt = max year across all.
+import { powerReliabilityContentMeta, POWER_RELIABILITY_MAX_CONTENT_AGE_MIN } from './_power-reliability-helpers.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -94,6 +98,24 @@ if (process.argv[1]?.endsWith('seed-power-reliability.mjs')) {
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: 8 * 24 * 60,
+
+    // ── Content-age contract (Sprint 4 of the 2026-05-04 health-readiness plan) ──
+    //
+    // 24-month budget: covers WB's 12-18 month publication lag for year-N
+    // data + slack for the year-N+1 publication cycle. STALE_CONTENT trips
+    // only on catastrophic upstream stalls (>2y since any country's latest
+    // year). See helper module's JSDoc for the math + the verification
+    // against live WB data on 2026-05-05.
+    //
+    // Plan §477-485 originally proposed 13 months but that is structurally
+    // wrong for WB indicators — fresh-arrival age is already 12-18 months
+    // because publication is 12-18 months after end-of-year. Sprint 3b's
+    // P1 (PR #3599) was the same shape of trap.
+    //
+    // powerReliabilityContentMeta scans data.countries per-country years
+    // and returns end-of-(max year) UTC ms as newestItemAt.
+    contentMeta: powerReliabilityContentMeta,
+    maxContentAgeMin: POWER_RELIABILITY_MAX_CONTENT_AGE_MIN,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/tests/power-reliability-content-age.test.mjs
+++ b/tests/power-reliability-content-age.test.mjs
@@ -20,8 +20,12 @@ import {
 
 const FIXED_NOW = Date.UTC(2026, 4, 5, 12);     // 2026-05-05T12:00 UTC — matches the live-WB-data verification date in the helper JSDoc.
 
-test('POWER_RELIABILITY_MAX_CONTENT_AGE_MIN is 24 months', () => {
-  assert.equal(POWER_RELIABILITY_MAX_CONTENT_AGE_MIN, 24 * 30 * 24 * 60);
+test('POWER_RELIABILITY_MAX_CONTENT_AGE_MIN is 36 thirty-day months', () => {
+  // 36mo = 30mo steady-state ceiling (max publication_lag + cycle_length
+  // for annual WB data) + 6mo slack. See helper module JSDoc for the
+  // full derivation. Initial PR shipped 24mo, which Greptile P1 caught
+  // as "false-positives mid-cycle when next-year data publishes late."
+  assert.equal(POWER_RELIABILITY_MAX_CONTENT_AGE_MIN, 36 * 30 * 24 * 60);
 });
 
 // ── yearToEndOfYearMs ────────────────────────────────────────────────────
@@ -126,18 +130,33 @@ test('fresh-arrival regression guard: max year 2024 in May 2026 (~17mo) does NOT
   );
 });
 
-test('boundary: max year 2023 in May 2026 (~29mo) DOES trip — by then 2024 data should have arrived', () => {
+test('steady-state regression guard: max year 2023 in May 2026 (~29mo) does NOT trip — within steady-state ceiling', () => {
   // Steady-state late-cycle: cache holds 2023 data, FIXED_NOW = May 2026.
-  // 2023-12-31 → 2026-05-05 ≈ 891 days ≈ 29.7 months — past 24-month budget.
-  // This is the correct STALE_CONTENT signal: by May 2026, 2024 data SHOULD
-  // have arrived (verified via live WB API on the same date), so a cache
-  // still holding only 2023 data is a real upstream regression worth paging.
+  // 2023-12-31 → 2026-05-05 ≈ 891 days ≈ 29.7 months. This is JUST under
+  // the 30mo steady-state ceiling — a normal "2024 data is publishing
+  // late" cycle. A budget < 30mo would page on this (Greptile P1 trap on
+  // initial 24mo); 36mo correctly tolerates it.
   const data = { countries: { US: { value: 5.4, year: 2023 } } };
   const cm = powerReliabilityContentMeta(data, FIXED_NOW);
   const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
   assert.ok(
+    ageMin < POWER_RELIABILITY_MAX_CONTENT_AGE_MIN,
+    `${Math.round(ageMin / 60 / 24 / 30)}mo < 36mo budget — within steady-state ceiling, no false-positive page`,
+  );
+});
+
+test('boundary: max year 2022 in May 2026 (~40mo) DOES trip — past steady-state ceiling = real stall', () => {
+  // 2022-12-31 → 2026-05-05 ≈ 1221 days ≈ 40.7 months — past both the
+  // 30mo steady-state ceiling AND the 36mo budget. By May 2026, both 2023
+  // and 2024 data should have arrived under any realistic publication
+  // schedule; a cache stuck on 2022 indicates a multi-cycle upstream stall
+  // worth paging on-call.
+  const data = { countries: { US: { value: 5.4, year: 2022 } } };
+  const cm = powerReliabilityContentMeta(data, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(
     ageMin > POWER_RELIABILITY_MAX_CONTENT_AGE_MIN,
-    `${Math.round(ageMin / 60 / 24 / 30)}mo > 24mo budget — STALE_CONTENT fires (correct: 2024 should have landed by May 2026)`,
+    `${Math.round(ageMin / 60 / 24 / 30)}mo > 36mo budget — STALE_CONTENT correctly fires on multi-cycle stall`,
   );
 });
 

--- a/tests/power-reliability-content-age.test.mjs
+++ b/tests/power-reliability-content-age.test.mjs
@@ -1,0 +1,175 @@
+// Sprint 4 — Power-reliability (WB EG.ELC.LOSS.ZS) content-age contract.
+//
+// Tests import the SAME powerReliabilityContentMeta the seeder runs, so a
+// future shape change in `_power-reliability-helpers.mjs` fails tests
+// instead of silently drifting (Sprint 2/3a/3b pattern).
+//
+// nowMs is injected with FIXED_NOW for deterministic skew-limit and
+// budget-threshold behavior. The fresh-arrival regression guard test
+// is the Sprint 3b lesson made concrete: pin the EXACT failure mode
+// (budget < natural fresh-arrival age = immediate page on every cron
+// tick) so a future budget tightening can't reintroduce it invisibly.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  yearToEndOfYearMs,
+  powerReliabilityContentMeta,
+  POWER_RELIABILITY_MAX_CONTENT_AGE_MIN,
+} from '../scripts/_power-reliability-helpers.mjs';
+
+const FIXED_NOW = Date.UTC(2026, 4, 5, 12);     // 2026-05-05T12:00 UTC — matches the live-WB-data verification date in the helper JSDoc.
+
+test('POWER_RELIABILITY_MAX_CONTENT_AGE_MIN is 24 months', () => {
+  assert.equal(POWER_RELIABILITY_MAX_CONTENT_AGE_MIN, 24 * 30 * 24 * 60);
+});
+
+// ── yearToEndOfYearMs ────────────────────────────────────────────────────
+
+test('yearToEndOfYearMs: 2024 → Dec 31 2024 23:59:59.999 UTC', () => {
+  const ms = yearToEndOfYearMs(2024);
+  assert.equal(new Date(ms).toISOString(), '2024-12-31T23:59:59.999Z');
+});
+
+test('yearToEndOfYearMs: numeric string "2024" parses identically', () => {
+  assert.equal(yearToEndOfYearMs('2024'), yearToEndOfYearMs(2024));
+});
+
+test('yearToEndOfYearMs: invalid shapes return null', () => {
+  assert.equal(yearToEndOfYearMs(undefined), null);
+  assert.equal(yearToEndOfYearMs(null), null);
+  assert.equal(yearToEndOfYearMs(''), null);
+  assert.equal(yearToEndOfYearMs('not-a-year'), null);
+  assert.equal(yearToEndOfYearMs(2024.5), null, 'non-integer rejected');
+  assert.equal(yearToEndOfYearMs(1899), null, 'pre-1900 rejected');
+  assert.equal(yearToEndOfYearMs(10000), null, '5-digit year rejected');
+  assert.equal(yearToEndOfYearMs({}), null);
+});
+
+// ── powerReliabilityContentMeta ──────────────────────────────────────────
+
+test('contentMeta returns null when countries dict missing', () => {
+  assert.equal(powerReliabilityContentMeta({}, FIXED_NOW), null);
+  assert.equal(powerReliabilityContentMeta({ countries: null }, FIXED_NOW), null);
+  assert.equal(powerReliabilityContentMeta({ countries: 'string' }, FIXED_NOW), null);
+});
+
+test('contentMeta returns null when countries dict is empty', () => {
+  assert.equal(powerReliabilityContentMeta({ countries: {} }, FIXED_NOW), null);
+});
+
+test('contentMeta returns null when no country has a usable year', () => {
+  const data = { countries: { US: {}, GB: { year: null }, DE: { year: 'garbage' } } };
+  assert.equal(powerReliabilityContentMeta(data, FIXED_NOW), null);
+});
+
+test('contentMeta picks newest year (max across countries) and oldest year (min across countries)', () => {
+  const data = {
+    countries: {
+      US: { value: 5.4, year: 2024 },
+      GB: { value: 7.1, year: 2024 },
+      DE: { value: 4.2, year: 2023 },
+      KW: { value: 8.0, year: 2021 },     // late reporter
+      QA: { value: 6.8, year: 2020 },     // late reporter
+    },
+  };
+  const cm = powerReliabilityContentMeta(data, FIXED_NOW);
+  assert.ok(cm);
+  assert.equal(new Date(cm.newestItemAt).toISOString(), '2024-12-31T23:59:59.999Z', 'max year = 2024');
+  assert.equal(new Date(cm.oldestItemAt).toISOString(), '2020-12-31T23:59:59.999Z', 'min year = 2020');
+});
+
+test('contentMeta excludes countries with invalid year shapes (mixed-validity dict)', () => {
+  const data = {
+    countries: {
+      US: { value: 5.4, year: 2024 },     // valid, fresh
+      INVALID: { value: 0, year: null },  // skipped
+      JUNK: { value: 0, year: 'foo' },    // skipped
+      KW: { value: 8.0, year: 2021 },     // valid, older
+    },
+  };
+  const cm = powerReliabilityContentMeta(data, FIXED_NOW);
+  assert.equal(new Date(cm.newestItemAt).toISOString(), '2024-12-31T23:59:59.999Z');
+  assert.equal(new Date(cm.oldestItemAt).toISOString(), '2021-12-31T23:59:59.999Z');
+});
+
+test('contentMeta excludes future-dated years beyond 1h clock-skew tolerance', () => {
+  // FIXED_NOW = 2026-05-05. Year 2099 is far future; year 2026 itself
+  // resolves to end-of-2026 = Dec 31 23:59:59 — also future. Both must
+  // be excluded as "garbage publication" rather than fresh content.
+  const data = {
+    countries: {
+      US: { value: 5.4, year: 2024 },     // fresh
+      GARBAGE: { value: 0, year: 2099 },  // far future — excluded
+      EDGE: { value: 0, year: 2026 },     // end-of-2026 is past FIXED_NOW (May 5) → excluded
+    },
+  };
+  const cm = powerReliabilityContentMeta(data, FIXED_NOW);
+  assert.equal(new Date(cm.newestItemAt).toISOString(), '2024-12-31T23:59:59.999Z');
+});
+
+// ── Pilot threshold sanity (anti-drift on the 24-month budget) ──────────
+
+test('fresh-arrival regression guard: max year 2024 in May 2026 (~17mo) does NOT trip STALE_CONTENT', () => {
+  // The exact failure mode caught on Sprint 3b: budget too tight relative
+  // to natural fresh-arrival age. WB EG.ELC.LOSS.ZS verified 2026-05-05:
+  // max year = 2024 (G7 + China), end-of-2024 = Dec 31 2024 = ~17 months
+  // before FIXED_NOW. A budget below ~17mo would page on every working
+  // seed run. 24mo budget MUST tolerate this case — otherwise the probe
+  // is broken-by-design.
+  const data = { countries: { US: { value: 5.4, year: 2024 } } };
+  const cm = powerReliabilityContentMeta(data, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(
+    ageMin < POWER_RELIABILITY_MAX_CONTENT_AGE_MIN,
+    `${Math.round(ageMin / 60 / 24 / 30)}mo < ${POWER_RELIABILITY_MAX_CONTENT_AGE_MIN / 60 / 24 / 30}mo budget — fresh WB arrival does NOT page`,
+  );
+});
+
+test('boundary: max year 2023 in May 2026 (~29mo) DOES trip — by then 2024 data should have arrived', () => {
+  // Steady-state late-cycle: cache holds 2023 data, FIXED_NOW = May 2026.
+  // 2023-12-31 → 2026-05-05 ≈ 891 days ≈ 29.7 months — past 24-month budget.
+  // This is the correct STALE_CONTENT signal: by May 2026, 2024 data SHOULD
+  // have arrived (verified via live WB API on the same date), so a cache
+  // still holding only 2023 data is a real upstream regression worth paging.
+  const data = { countries: { US: { value: 5.4, year: 2023 } } };
+  const cm = powerReliabilityContentMeta(data, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(
+    ageMin > POWER_RELIABILITY_MAX_CONTENT_AGE_MIN,
+    `${Math.round(ageMin / 60 / 24 / 30)}mo > 24mo budget — STALE_CONTENT fires (correct: 2024 should have landed by May 2026)`,
+  );
+});
+
+test('pilot threshold: max year 2018 (catastrophic stall, 8+ years old) trips STALE_CONTENT', () => {
+  const data = { countries: { US: { value: 5.4, year: 2018 } } };
+  const cm = powerReliabilityContentMeta(data, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(
+    ageMin > POWER_RELIABILITY_MAX_CONTENT_AGE_MIN,
+    `${Math.round(ageMin / 60 / 24 / 30)}mo >> 24mo budget — clearly STALE_CONTENT`,
+  );
+});
+
+test('pilot threshold: late-reporter cohort does NOT drag newestItemAt down (G7 freshness wins)', () => {
+  // The whole point of using MAX year (not MIN) is that late-reporters
+  // (Kuwait, Qatar at year 2021) shouldn't make the panel page when the
+  // G7 cohort is reporting 2024. Verify the dict mix produces the G7-led
+  // newestItemAt, NOT the KW-led oldestItemAt.
+  const data = {
+    countries: {
+      US: { value: 5.4, year: 2024 },
+      GB: { value: 7.1, year: 2024 },
+      DE: { value: 4.2, year: 2024 },
+      KW: { value: 8.0, year: 2021 },
+      QA: { value: 6.8, year: 2020 },
+      AE: { value: 9.2, year: 2021 },
+    },
+  };
+  const cm = powerReliabilityContentMeta(data, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(
+    ageMin < POWER_RELIABILITY_MAX_CONTENT_AGE_MIN,
+    'mixed-cadence dict: G7 freshness drives newestItemAt — late-reporters do NOT cause false-positive page',
+  );
+});


### PR DESCRIPTION
Sprint 4 of the [2026-05-04 health-readiness probe plan](docs/plans/2026-05-04-001-feat-health-readiness-probe-content-age-plan.md). Closes the plan's "Definition of done" line 530: at least 1 annual-data seeder migrated. Branched off Sprint 1 (#3596) as a parallel sibling to Sprints 2/3a/3b.

## Summary

- Adds a content-age contract on \`seed-power-reliability.mjs\` (WB EG.ELC.LOSS.ZS) so \`/api/health\` surfaces \`STALE_CONTENT\` when no country's \`year\` has advanced past 24 months — i.e. WB has skipped a full annual publication cycle.
- Pure helper module \`scripts/_power-reliability-helpers.mjs\` exports \`yearToEndOfYearMs\`, \`powerReliabilityContentMeta\` (with injectable \`nowMs\`), \`POWER_RELIABILITY_MAX_CONTENT_AGE_MIN\`. Seeder imports; tests import.
- No \`Dockerfile.relay\` change needed — \`seed-power-reliability.mjs\` is not relay-COPY'd (verified via grep).

## Why 24 months (NOT the plan's 13)

Plan §477-485 originally proposed 13 months but that's structurally wrong for WB indicators. **Verified against live WB API on 2026-05-05:**

\`\`\`
curl https://api.worldbank.org/v2/country/USA;CHN;...;KWT/indicator/EG.ELC.LOSS.ZS
\`\`\`

On that date G7 max year = 2024. End-of-2024 = Dec 31 2024 = ~17 months before fresh-arrival. WB year-N data lands in cache 12-18 months after end-of-N. **A 13-month budget would have tripped \`STALE_CONTENT\` immediately on every successful fresh seed run** — same failure mode Greptile P1 caught on Sprint 3b PR #3599 (45d budget vs 60d natural M+2 lag).

24-month math:
- Year N data lands at age = 12-18 months (publication lag)
- Year (N+1) data lands ~12 months later, resetting the clock
- Worst case during steady state: age ≈ 30 months (just before next year drops + lag at upper end)
- 24mo budget catches catastrophic stalls (>2y silent upstream) without false-positive paging

## Shape contract — third distinct shape this sprint

Per-country dict where each country has its OWN year (different from Sprint 2/3a per-item arrays AND from Sprint 3b single-snapshot period):

\`\`\`js
{ countries: { US: { value, year: 2024 }, KW: { year: 2021 }, ... }, seededAt }
\`\`\`

\`newestItemAt\` = end-of-(max year across all countries). Late-reporters (KW/QA/AE) lagging G7 do NOT drag the panel into STALE_CONTENT — once any country's year advances, the clock resets. \`oldestItemAt\` = end-of-(min year), informational.

Defensive (each tested):
- Missing/empty/non-object \`countries\` → \`null\`
- Years with invalid shapes (\`null\`, \`'garbage'\`, non-integer, pre-1900, 5-digit) → excluded
- Future-dated years beyond 1h clock-skew tolerance → excluded (guards against upstream year=2099 garbage)

## Test plan

- [x] \`node --test tests/power-reliability-content-age.test.mjs\` → 14/14 pass
- [x] \`node --test tests/power-reliability-content-age.test.mjs tests/seed-content-age-contract.test.mjs tests/health-content-age.test.mjs tests/seed-utils-empty-data-failure.test.mjs\` → 46/46 pass
- [x] \`npm run typecheck:api\` clean
- [x] \`npm run lint\` clean
- [x] **Fresh-arrival regression guard test** — pins the exact budget/natural-lag mismatch failure mode so a future budget tightening cannot silently re-introduce the immediate-page bug
- [x] **Boundary test** — 2023 data in May 2026 (~29mo) DOES trip; confirms staleness clock works past budget
- [ ] Post-merge: confirm \`/api/health\` snapshot shows \`powerLosses\` with \`contentAge\` block populated; \`contentAgeMin\` matches \`Date.now() - end-of-2024\`

## Sprint 4 cohort note

This PR migrates 1 of the 4 indicators the plan listed (power-losses, low-carbon-generation, fossil-electricity-share, IMF/WEO). The other 3 are NOT in this PR — each needs its own date-source audit (some WB indicators publish quarterly with much shorter lag; the 24-month budget chosen here for EG.ELC.LOSS.ZS isn't blindly transferable). Per plan rollout §493-498: "PR 4 land last; close out the canonical-envelope-mirror story." Plan's "Definition of done" requires \`>= 1\` annual-data migration, which this PR satisfies; further annual indicators are follow-up work.