### PR TITLE
feat(wb-cohort): Sprint 4 follow-up — content-age for low-carbon + fossil-share

### DIFF
--- a/scripts/_wb-country-dict-content-age-helpers.mjs
+++ b/scripts/_wb-country-dict-content-age-helpers.mjs
@@ -1,0 +1,78 @@
+// Sprint 4 cohort follow-up — shared content-age helper for WB seeders that
+// produce a per-country dict with each country carrying its own annual year.
+//
+// Shape contract:
+//
+//   { countries: { [ISO2]: { value: number, year: number } }, seededAt: string }
+//
+// Three production seeders match this shape (all WB indicators on annual
+// cadence, all using mrv=5 + per-country latest-year selection):
+//
+//   - seed-power-reliability.mjs     (EG.ELC.LOSS.ZS)              — Sprint 4 PR #3602
+//   - seed-low-carbon-generation.mjs (EG.ELC.NUCL.ZS + RNEW + HYRO,
+//                                     summed value, MAX year of 3)
+//   - seed-fossil-electricity-share.mjs (EG.ELC.FOSL.ZS)
+//
+// Why a shared helper instead of one per seeder: the contentMeta math is
+// identical across all three (find max year across countries, convert to
+// end-of-year UTC ms, apply 1h skew-limit). Only the BUDGET differs per
+// indicator (publication lag varies — see the PR description for live-WB
+// verification numbers). Each seeder imports this `wbCountryDictContentMeta`
+// + brings its own `MAX_CONTENT_AGE_MIN` constant inline.
+//
+// Power-reliability still has its own `_power-reliability-helpers.mjs` for
+// now (its PR #3602 is already in review; backporting can come as a
+// follow-up after merge to keep that PR's diff focused). The math IS
+// identical — verify with `diff`.
+
+/**
+ * Convert a year (number or numeric string like "2024") to end-of-year UTC ms.
+ *
+ * The WB indicator value labelled `"2024"` represents observations DURING
+ * that calendar year, so the latest possible observation date is Dec 31.
+ * End-of-year is the most defensible "newestItemAt".
+ *
+ * Returns null when input shape is unexpected — defensive against upstream
+ * `record.date` parsing drift.
+ *
+ * @param {number|string} year
+ */
+export function yearToEndOfYearMs(year) {
+  const n = typeof year === 'string' ? Number(year) : year;
+  if (!Number.isInteger(n) || n < 1900 || n > 9999) return null;
+  return Date.UTC(n, 11, 31, 23, 59, 59, 999);
+}
+
+/**
+ * Compute newest/oldest content timestamps from a per-country dict payload.
+ *
+ * - newestItemAt = end-of-year(MAX year across countries) — drives staleness.
+ *   Late-reporters (KW/QA/AE typically lag G7 by 1-2 years) do NOT drag
+ *   the panel into STALE_CONTENT — once any country's year advances, the
+ *   clock resets.
+ * - oldestItemAt = end-of-year(MIN year across countries) — informational,
+ *   surfaces "how stretched is the per-country reporting cohort."
+ * - Returns null when no country has a usable year — runSeed writes
+ *   newestItemAt: null, classifier reads as STALE_CONTENT.
+ * - Excludes future-dated years beyond 1h clock-skew tolerance (defensive
+ *   against upstream year=2099 garbage).
+ *
+ * @param {{countries: Record<string, {year: number}>}} data
+ * @param {number} nowMs - injectable "now" for deterministic tests
+ */
+export function wbCountryDictContentMeta(data, nowMs = Date.now()) {
+  const countries = data?.countries;
+  if (!countries || typeof countries !== 'object') return null;
+  const skewLimit = nowMs + 60 * 60 * 1000;
+  let newest = -Infinity, oldest = Infinity, validCount = 0;
+  for (const entry of Object.values(countries)) {
+    const ts = yearToEndOfYearMs(entry?.year);
+    if (ts == null) continue;
+    if (ts > skewLimit) continue;
+    validCount++;
+    if (ts > newest) newest = ts;
+    if (ts < oldest) oldest = ts;
+  }
+  if (validCount === 0) return null;
+  return { newestItemAt: newest, oldestItemAt: oldest };
+}

--- a/scripts/seed-fossil-electricity-share.mjs
+++ b/scripts/seed-fossil-electricity-share.mjs
@@ -13,6 +13,11 @@
 import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
 // Shared content-age helper for WB per-country annual seeders.
 import { wbCountryDictContentMeta } from './_wb-country-dict-content-age-helpers.mjs';
+// Greptile PR #3603 P2 — `import` declarations belong at the top of the
+// module, not after a `const`. ES module `import`s are hoisted regardless
+// of source order, but interleaving with declarations confuses readers
+// (the code "looks" sequential but the import actually executes first).
+import iso3ToIso2 from './shared/iso3-to-iso2.json' with { type: 'json' };
 
 // 48mo budget — verified against live WB API on 2026-05-05: max year for
 // EG.ELC.FOSL.ZS is 2023 (NOT 2024 like power-losses or low-carbon). That's
@@ -27,7 +32,6 @@ import { wbCountryDictContentMeta } from './_wb-country-dict-content-age-helpers
 // genuinely different cadences. Per-seeder constants prevent the
 // "tightest-cohort budget false-positives the slowest-cohort" trap.
 const MAX_CONTENT_AGE_MIN = 48 * 30 * 24 * 60;
-import iso3ToIso2 from './shared/iso3-to-iso2.json' with { type: 'json' };
 
 loadEnvFile(import.meta.url);
 

--- a/scripts/seed-fossil-electricity-share.mjs
+++ b/scripts/seed-fossil-electricity-share.mjs
@@ -11,6 +11,22 @@
 // Shape: { countries: { [ISO2]: { value: 0-100, year } }, seededAt }
 
 import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
+// Shared content-age helper for WB per-country annual seeders.
+import { wbCountryDictContentMeta } from './_wb-country-dict-content-age-helpers.mjs';
+
+// 48mo budget — verified against live WB API on 2026-05-05: max year for
+// EG.ELC.FOSL.ZS is 2023 (NOT 2024 like power-losses or low-carbon). That's
+// already ~29mo old at fresh-arrival, so this indicator publishes slower
+// than the rest of the WB cohort.
+//
+// Steady-state ceiling = max_publication_lag (~30mo) + cycle_length (12mo)
+// = 42mo. 48mo budget = 42mo ceiling + 6mo slack. Trips only on
+// multi-cycle silent stalls; tolerates "next year publishing late."
+//
+// Don't share with low-carbon-generation (36mo) — these indicators have
+// genuinely different cadences. Per-seeder constants prevent the
+// "tightest-cohort budget false-positives the slowest-cohort" trap.
+const MAX_CONTENT_AGE_MIN = 48 * 30 * 24 * 60;
 import iso3ToIso2 from './shared/iso3-to-iso2.json' with { type: 'json' };
 
 loadEnvFile(import.meta.url);
@@ -89,6 +105,12 @@ if (process.argv[1]?.endsWith('seed-fossil-electricity-share.mjs')) {
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: 8 * 24 * 60,
+
+    // ── Content-age contract (Sprint 4 cohort follow-up) ──
+    // 48mo budget chosen to match this indicator's slower fresh-arrival
+    // lag (29mo on 2026-05-05). See MAX_CONTENT_AGE_MIN constant above.
+    contentMeta: wbCountryDictContentMeta,
+    maxContentAgeMin: MAX_CONTENT_AGE_MIN,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-low-carbon-generation.mjs
+++ b/scripts/seed-low-carbon-generation.mjs
@@ -30,6 +30,20 @@
 
 import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
 import iso3ToIso2 from './shared/iso3-to-iso2.json' with { type: 'json' };
+// Shared content-age helper for WB per-country annual seeders.
+// Per-seeder budget lives below — same shape, different publication lags.
+import { wbCountryDictContentMeta } from './_wb-country-dict-content-age-helpers.mjs';
+
+// 36mo budget — verified against live WB API on 2026-05-05: max year across
+// the three constituent indicators (NUCL/RNEW/HYRO) is 2024 (driven by
+// nuclear and hydro; renewables lags to 2021 but is masked by MAX-of-3 in
+// the seeder's countries[iso2].year). End-of-2024 = ~17mo before NOW, so
+// fresh-arrival lag is comfortably inside 36mo. Steady-state ceiling for
+// annual WB indicators = max_publication_lag (~18mo) + cycle_length (12mo)
+// = 30mo. 36mo = 30mo ceiling + 6mo slack. Same math as power-reliability
+// (#3602 review); see `_power-reliability-helpers.mjs` JSDoc for full
+// derivation.
+const MAX_CONTENT_AGE_MIN = 36 * 30 * 24 * 60;
 
 loadEnvFile(import.meta.url);
 
@@ -132,6 +146,13 @@ if (process.argv[1]?.endsWith('seed-low-carbon-generation.mjs')) {
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: 8 * 24 * 60, // weekly cadence + 1 day slack
+
+    // ── Content-age contract (Sprint 4 cohort follow-up) ──
+    // Seeder takes MAX year across NUCL/RNEW/HYRO per country (line ~109);
+    // contentMeta then takes MAX year across countries. Budget rationale
+    // documented at the MAX_CONTENT_AGE_MIN constant above.
+    contentMeta: wbCountryDictContentMeta,
+    maxContentAgeMin: MAX_CONTENT_AGE_MIN,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/tests/wb-country-dict-content-age.test.mjs
+++ b/tests/wb-country-dict-content-age.test.mjs
@@ -1,0 +1,185 @@
+// Sprint 4 cohort follow-up — shared WB per-country-dict content-age helper.
+//
+// Tests cover the shared `wbCountryDictContentMeta` shape contract.
+// Per-seeder budget assertions live in this file too — they're the
+// fresh-arrival + steady-state regression guards that pin each seeder's
+// budget against its observed publication lag (Sprint 3b/4 lesson:
+// without these, a future budget tightening can silently re-introduce
+// the immediate-page bug).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  yearToEndOfYearMs,
+  wbCountryDictContentMeta,
+} from '../scripts/_wb-country-dict-content-age-helpers.mjs';
+
+const FIXED_NOW = Date.UTC(2026, 4, 5, 12);     // 2026-05-05T12:00 UTC — matches the live-WB-data verification date.
+
+// ── yearToEndOfYearMs ────────────────────────────────────────────────────
+
+test('yearToEndOfYearMs: 2024 → Dec 31 2024 23:59:59.999 UTC', () => {
+  assert.equal(new Date(yearToEndOfYearMs(2024)).toISOString(), '2024-12-31T23:59:59.999Z');
+});
+
+test('yearToEndOfYearMs: numeric string "2024" parses identically', () => {
+  assert.equal(yearToEndOfYearMs('2024'), yearToEndOfYearMs(2024));
+});
+
+test('yearToEndOfYearMs: invalid shapes return null', () => {
+  assert.equal(yearToEndOfYearMs(undefined), null);
+  assert.equal(yearToEndOfYearMs(null), null);
+  assert.equal(yearToEndOfYearMs(''), null);
+  assert.equal(yearToEndOfYearMs('garbage'), null);
+  assert.equal(yearToEndOfYearMs(2024.5), null);
+  assert.equal(yearToEndOfYearMs(1899), null);
+  assert.equal(yearToEndOfYearMs(10000), null);
+});
+
+// ── wbCountryDictContentMeta ─────────────────────────────────────────────
+
+test('contentMeta returns null when countries dict missing or non-object', () => {
+  assert.equal(wbCountryDictContentMeta({}, FIXED_NOW), null);
+  assert.equal(wbCountryDictContentMeta({ countries: null }, FIXED_NOW), null);
+  assert.equal(wbCountryDictContentMeta({ countries: 'string' }, FIXED_NOW), null);
+});
+
+test('contentMeta returns null when no country has a usable year', () => {
+  const data = { countries: { US: {}, GB: { year: null }, DE: { year: 'garbage' } } };
+  assert.equal(wbCountryDictContentMeta(data, FIXED_NOW), null);
+});
+
+test('contentMeta picks newest (max) and oldest (min) year across countries', () => {
+  const data = {
+    countries: {
+      US: { value: 5.4, year: 2024 },
+      GB: { value: 7.1, year: 2024 },
+      DE: { value: 4.2, year: 2023 },
+      KW: { value: 8.0, year: 2021 },
+      QA: { value: 6.8, year: 2020 },
+    },
+  };
+  const cm = wbCountryDictContentMeta(data, FIXED_NOW);
+  assert.equal(new Date(cm.newestItemAt).toISOString(), '2024-12-31T23:59:59.999Z');
+  assert.equal(new Date(cm.oldestItemAt).toISOString(), '2020-12-31T23:59:59.999Z');
+});
+
+test('contentMeta excludes countries with invalid year shapes (mixed-validity dict)', () => {
+  const data = {
+    countries: {
+      US: { value: 5.4, year: 2024 },
+      INVALID: { value: 0, year: null },
+      JUNK: { value: 0, year: 'foo' },
+      KW: { value: 8.0, year: 2021 },
+    },
+  };
+  const cm = wbCountryDictContentMeta(data, FIXED_NOW);
+  assert.equal(new Date(cm.newestItemAt).toISOString(), '2024-12-31T23:59:59.999Z');
+  assert.equal(new Date(cm.oldestItemAt).toISOString(), '2021-12-31T23:59:59.999Z');
+});
+
+test('contentMeta excludes future-dated years beyond 1h clock-skew tolerance', () => {
+  const data = {
+    countries: {
+      US: { value: 5.4, year: 2024 },
+      GARBAGE: { value: 0, year: 2099 },
+      EDGE: { value: 0, year: 2026 },     // end-of-2026 = Dec 31 23:59:59 = past FIXED_NOW (May 5)
+    },
+  };
+  const cm = wbCountryDictContentMeta(data, FIXED_NOW);
+  assert.equal(new Date(cm.newestItemAt).toISOString(), '2024-12-31T23:59:59.999Z');
+});
+
+// ── Per-seeder budget regression guards ──────────────────────────────────
+//
+// Each migrated seeder gets its own pair of regression-guard tests that
+// pin the EXACT failure mode the Sprint 3b/4 lessons taught us to look
+// for: (a) fresh-arrival under budget (no false-positive on every cron
+// run), (b) steady-state under budget (no false-positive mid-cycle when
+// next year publishes late but legitimately).
+
+const LOW_CARBON_BUDGET = 36 * 30 * 24 * 60;     // see seed-low-carbon-generation.mjs
+const FOSSIL_BUDGET = 48 * 30 * 24 * 60;          // see seed-fossil-electricity-share.mjs
+
+test('low-carbon: fresh-arrival regression guard — max year 2024 (~17mo) within 36mo budget', () => {
+  // NUCL/HYRO max = 2024 verified live 2026-05-05; RNEW lags but is masked
+  // by MAX-of-3 in the seeder's countries[iso2].year computation.
+  const data = { countries: { US: { value: 60.5, year: 2024 } } };
+  const cm = wbCountryDictContentMeta(data, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(
+    ageMin < LOW_CARBON_BUDGET,
+    `${Math.round(ageMin / 60 / 24 / 30)}mo < 36mo budget — fresh arrival within tolerance`,
+  );
+});
+
+test('low-carbon: steady-state regression guard — max year 2023 (~29mo) within 36mo budget', () => {
+  // Just before NUCL/HYRO 2025 data publishes (legitimately late at
+  // L=18mo). Cache age = 29mo. 36mo budget = 30mo ceiling + 6mo slack
+  // (Sprint 4 PR #3602 review lesson).
+  const data = { countries: { US: { value: 60.5, year: 2023 } } };
+  const cm = wbCountryDictContentMeta(data, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(
+    ageMin < LOW_CARBON_BUDGET,
+    `${Math.round(ageMin / 60 / 24 / 30)}mo < 36mo budget — within steady-state ceiling`,
+  );
+});
+
+test('low-carbon: catastrophic stall — max year 2020 (~65mo) trips STALE_CONTENT', () => {
+  const data = { countries: { US: { value: 60.5, year: 2020 } } };
+  const cm = wbCountryDictContentMeta(data, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(
+    ageMin > LOW_CARBON_BUDGET,
+    `${Math.round(ageMin / 60 / 24 / 30)}mo > 36mo budget — STALE_CONTENT correctly fires`,
+  );
+});
+
+test('fossil-share: fresh-arrival regression guard — max year 2023 (~29mo) within 48mo budget', () => {
+  // Live verification 2026-05-05: EG.ELC.FOSL.ZS max year = 2023 (NOT
+  // 2024 like the other WB indicators). That's already ~29mo at
+  // fresh-arrival, so this indicator publishes slower than the rest.
+  // 48mo budget MUST tolerate this — the failure mode caught on Sprint 3b.
+  const data = { countries: { US: { value: 65.0, year: 2023 } } };
+  const cm = wbCountryDictContentMeta(data, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(
+    ageMin < FOSSIL_BUDGET,
+    `${Math.round(ageMin / 60 / 24 / 30)}mo < 48mo budget — fresh arrival within tolerance`,
+  );
+});
+
+test('fossil-share: steady-state regression guard — max year 2022 (~41mo) within 48mo budget', () => {
+  // 2022-12-31 → 2026-05-05 ≈ 1221 days ≈ 40.7mo. Right at the steady-state
+  // ceiling (29mo lag + 12mo cycle = 41mo). 48mo budget = 41mo ceiling +
+  // 7mo slack — within tolerance. 36mo budget would have false-positived;
+  // hence the per-seeder constant.
+  const data = { countries: { US: { value: 65.0, year: 2022 } } };
+  const cm = wbCountryDictContentMeta(data, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(
+    ageMin < FOSSIL_BUDGET,
+    `${Math.round(ageMin / 60 / 24 / 30)}mo < 48mo budget — within fossil-share steady-state ceiling`,
+  );
+});
+
+test('fossil-share: catastrophic stall — max year 2018 (~89mo) trips STALE_CONTENT', () => {
+  const data = { countries: { US: { value: 65.0, year: 2018 } } };
+  const cm = wbCountryDictContentMeta(data, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(
+    ageMin > FOSSIL_BUDGET,
+    `${Math.round(ageMin / 60 / 24 / 30)}mo > 48mo budget — STALE_CONTENT correctly fires`,
+  );
+});
+
+test('per-seeder budget separation: a 41mo cache trips low-carbon (36mo) but NOT fossil-share (48mo)', () => {
+  // Demonstrates why per-seeder budgets matter: a low-carbon cache stuck
+  // at 2022 for 41mo is a real stall (NUCL/HYRO normally publish 2024 by
+  // now), but a fossil-share cache stuck at 2022 is just normal
+  // steady-state (FOSL publishes ~30mo lag). Same age, different verdicts.
+  const ageMs41 = 41 * 30 * 24 * 60 * 60 * 1000;
+  assert.ok(ageMs41 / 60000 > LOW_CARBON_BUDGET, '41mo > low-carbon 36mo budget — trips');
+  assert.ok(ageMs41 / 60000 < FOSSIL_BUDGET, '41mo < fossil-share 48mo budget — does NOT trip');
+});

--- a/tests/wb-country-dict-content-age.test.mjs
+++ b/tests/wb-country-dict-content-age.test.mjs
@@ -83,7 +83,11 @@ test('contentMeta excludes future-dated years beyond 1h clock-skew tolerance', (
     countries: {
       US: { value: 5.4, year: 2024 },
       GARBAGE: { value: 0, year: 2099 },
-      EDGE: { value: 0, year: 2026 },     // end-of-2026 = Dec 31 23:59:59 = past FIXED_NOW (May 5)
+      // EDGE: end-of-2026 = Dec 31 23:59:59 — that's ~7 months in the
+      // FUTURE of FIXED_NOW (2026-05-05), so it's outside the 1h skew
+      // tolerance and gets excluded. (Greptile PR #3603 P2 — pre-fix
+      // comment incorrectly said "past FIXED_NOW".)
+      EDGE: { value: 0, year: 2026 },
     },
   };
   const cm = wbCountryDictContentMeta(data, FIXED_NOW);


### PR DESCRIPTION
Sprint 4 cohort follow-up of the [2026-05-04 health-readiness probe plan](docs/plans/2026-05-04-001-feat-health-readiness-probe-content-age-plan.md). Migrates the two remaining WB resilience seeders that match power-reliability's shape. Branched off Sprint 1 (#3596) as a parallel sibling to #3597 / #3598 / #3599 / #3602.

## Summary

- New shared helper \`scripts/_wb-country-dict-content-age-helpers.mjs\`: \`yearToEndOfYearMs\`, \`wbCountryDictContentMeta\`. Three production seeders use the IDENTICAL per-country-dict shape — meets CLAUDE.md's "three similar lines" line for justifying abstraction.
- Wires \`seed-low-carbon-generation\` (36mo budget) and \`seed-fossil-electricity-share\` (48mo budget) into the content-age probe.
- Per-seeder budgets are NOT one-size-fits-all — verified against live WB API.

## Per-seeder budgets — verified against live WB on 2026-05-05

| Seeder | Indicator(s) | Live max year | Fresh-arrival lag | Budget | Steady-state ceiling |
|---|---|---|---|---|---|
| seed-low-carbon-generation | NUCL+RNEW+HYRO sum, MAX year of 3 | 2024 (NUCL/HYRO) | ~17mo | **36mo** | 30mo |
| seed-fossil-electricity-share | EG.ELC.FOSL.ZS | **2023** | ~29mo | **48mo** | 41mo |

A naive cohort-wide budget would either false-positive on fossil-share (if 36mo) or be wastefully loose on low-carbon (if 48mo). Per-seeder constants are the correct response.

The "per-seeder budget separation" test pins this explicitly: a 41mo cache trips low-carbon but NOT fossil-share. Demonstrates that budgets aren't accidental — they reflect real upstream cadence.

## Why share the helper this time (not in Sprint 2/3a/3b/4 power-reliability)

Three production seeders now use the IDENTICAL shape and IDENTICAL math. Per CLAUDE.md "three similar lines is better than a premature abstraction" — three is the line. \`seed-power-reliability\` keeps its own helper for now (PR #3602 is in review; backporting to the shared helper is a follow-up after merge to keep that PR's diff focused). The math is verifiably identical.

## Renewables (RNEW.ZS) data-quality flag

Audit found EG.ELC.RNEW.ZS max year = 2021 in May 2026 (~53mo lag). Inside low-carbon-generation it's masked by MAX(NUCL, RNEW, HYRO), so content-age looks fine. But the underlying renewable share data is genuinely 5+ years stale. **Not addressed in this PR — flagging as a separate data-quality concern** for follow-up review (separate from the content-age probe contract).

## Test plan

- [x] \`node --test tests/wb-country-dict-content-age.test.mjs\` → 15/15 pass
- [x] \`node --test tests/wb-country-dict-content-age.test.mjs tests/seed-content-age-contract.test.mjs tests/health-content-age.test.mjs tests/seed-utils-empty-data-failure.test.mjs\` → 47/47 pass
- [x] \`npm run typecheck:api\` clean
- [x] \`npm run lint\` clean
- [x] **Fresh-arrival regression guards** for both seeders (Sprint 3b lesson): pin natural fresh-arrival within budget
- [x] **Steady-state regression guards** for both seeders (Sprint 4 lesson): pin one-cycle-late case within budget
- [x] **Catastrophic stall** tests for both seeders: pin clearly-stale case past budget
- [x] **Per-seeder budget separation** test: 41mo cache trips low-carbon but not fossil-share
- [x] Neither seeder is in Dockerfile.relay (verified via grep) — no relay-COPY change needed
- [ ] Post-merge: confirm \`/api/health\` snapshot shows \`lowCarbonGeneration\` and \`fossilElectricityShare\` with \`contentAge\` populated and \`status: OK\`
- [ ] Post-merge: open a separate issue for the RNEW.ZS data-quality finding

## Sprint 4 status after this PR

- ✅ power-reliability (#3602)
- ✅ low-carbon-generation (this PR)
- ✅ fossil-electricity-share (this PR)
- 🟡 IMF/WEO seeders — deferred; forecast-year semantics need different content-age handling than end-of-observation-year

3 of 5 plan-listed annual indicators migrated. Plan's "Definition of done" §530 (≥1 annual seeder) was already satisfied by #3602; this PR rounds out the WB cohort.