### PR TITLE
feat(imf-weo): Sprint 4 IMF cohort — content-age (forecast-year semantics, 18mo budget)

### DIFF
--- a/scripts/_imf-weo-content-age-helpers.mjs
+++ b/scripts/_imf-weo-content-age-helpers.mjs
@@ -67,7 +67,25 @@ export function imfForecastYearToMs(year) {
  *   future. The skew check is defensive against a future seeder change
  *   that extends the forecast horizon (e.g. `currentYear + 1`).
  *
- * @param {{countries: Record<string, {year: number}>}} data
+ * Codex PR #3604 P2 — year semantics fix.
+ *
+ * Each entry's primary `year` is the priority-first non-null indicator's
+ * year (e.g. `ca?.year ?? tm?.year ?? tx?.year` in seed-imf-external).
+ * That's correct as the public payload's "primary metric vintage" but
+ * WRONG for content-age: BCA at 2024 + import-volume at 2026 publishes
+ * `year: 2024`, even though the country dict carries a fresh 2026 metric
+ * — content-age would map this to 2023-12-31 (~17mo old, near-stale)
+ * when there's a 2026 metric in the row that maps to 2025-12-31 (~5mo
+ * old, fresh).
+ *
+ * Fix: prefer `entry.latestYear` (the max across all the country's
+ * indicator years, populated by the seeder alongside `year`). Falls back
+ * to `entry.year` for back-compat during the transition window — old
+ * caches written before this PR don't carry `latestYear`, but the helper
+ * still produces a usable signal for them (just the conservative "primary
+ * metric year" answer).
+ *
+ * @param {{countries: Record<string, {year: number, latestYear?: number}>}} data
  * @param {number} nowMs - injectable "now" for deterministic tests
  */
 export function imfWeoContentMeta(data, nowMs = Date.now()) {
@@ -76,7 +94,13 @@ export function imfWeoContentMeta(data, nowMs = Date.now()) {
   const skewLimit = nowMs + 60 * 60 * 1000;
   let newest = -Infinity, oldest = Infinity, validCount = 0;
   for (const entry of Object.values(countries)) {
-    const ts = imfForecastYearToMs(entry?.year);
+    // Codex PR #3604 P2 — prefer latestYear (max across all indicators)
+    // over year (priority-first non-null) so a row with a fresh metric
+    // tucked behind a stale higher-priority indicator surfaces as fresh.
+    const yearForContentAge = Number.isInteger(entry?.latestYear)
+      ? entry.latestYear
+      : entry?.year;
+    const ts = imfForecastYearToMs(yearForContentAge);
     if (ts == null) continue;
     if (ts > skewLimit) continue;
     validCount++;
@@ -85,6 +109,28 @@ export function imfWeoContentMeta(data, nowMs = Date.now()) {
   }
   if (validCount === 0) return null;
   return { newestItemAt: newest, oldestItemAt: oldest };
+}
+
+/**
+ * Helper: max integer year across a list of optional year values.
+ *
+ * Used by IMF seeders to populate `entry.latestYear` alongside the
+ * priority-first `entry.year`. Returns null when no value is a usable
+ * integer year — the seeder writes the field as null in that case (or
+ * omits it; the consumer falls back to `year`).
+ *
+ * @param {Array<number|string|null|undefined>} years
+ * @returns {number|null}
+ */
+export function maxIntegerYear(years) {
+  if (!Array.isArray(years)) return null;
+  let max = null;
+  for (const y of years) {
+    const n = typeof y === 'string' ? Number(y) : y;
+    if (!Number.isInteger(n) || n < 1900 || n > 9999) continue;
+    if (max === null || n > max) max = n;
+  }
+  return max;
 }
 
 /**

--- a/scripts/_imf-weo-content-age-helpers.mjs
+++ b/scripts/_imf-weo-content-age-helpers.mjs
@@ -102,6 +102,19 @@ export function imfWeoContentMeta(data, nowMs = Date.now()) {
       : entry?.year;
     const ts = imfForecastYearToMs(yearForContentAge);
     if (ts == null) continue;
+    // ⚠ HORIZON-EXTENSION TRAP — see imf-weo-content-age.test.mjs
+    // ('horizon extension regression-guard'). Today this filter is purely
+    // defensive: all 4 seeders' `weoYears()` returns
+    // `[currentYear, currentYear-1, currentYear-2]`, so max year = currentYear,
+    // so end-of-(year-1) = end-of-last-calendar-year, never future.
+    //
+    // If a future contributor extends `weoYears()` to include `currentYear+1`
+    // to surface forward forecasts, this filter SILENTLY drops every fresh
+    // currentYear+1 entry — the cohort dict's newestItemAt then lags by a
+    // year, producing FALSE STALE_CONTENT for genuinely-fresh data. Any
+    // change to the seeder's year horizon MUST revisit this filter (either
+    // widen the skew tolerance to encompass the new horizon, or change the
+    // forecast-year-to-ms mapping for the new vintage).
     if (ts > skewLimit) continue;
     validCount++;
     if (ts > newest) newest = ts;

--- a/scripts/_imf-weo-content-age-helpers.mjs
+++ b/scripts/_imf-weo-content-age-helpers.mjs
@@ -1,0 +1,110 @@
+// Sprint 4 IMF/WEO cohort — content-age helper for IMF SDMX/WEO seeders.
+//
+// Why a separate module from `_wb-country-dict-content-age-helpers.mjs`:
+// the per-country dict shape is the same, but `year` semantics are NOT.
+// WB indicators store the OBSERVED year (Dec 31 of "year" is the latest
+// observation date). IMF/WEO stores a FORECAST horizon — the seeder's
+// `weoYears()` returns `[currentYear, currentYear-1, currentYear-2]` and
+// `latestValue()` picks the first year that has a finite value. So the
+// stored `year` is the most distant horizon for which IMF has published a
+// forecast — it is NOT an observation date.
+//
+// Concretely: in May 2026, after the April 2026 WEO release, max stored
+// year = 2026. End-of-2026 = Dec 31 2026 is 7 MONTHS IN THE FUTURE relative
+// to NOW. Reusing `_wb-country-dict-content-age-helpers.mjs`'s end-of-year
+// math + 1h skew limit would reject every fresh IMF cache as "future-dated
+// garbage." That's the failure mode this module avoids.
+//
+// Mapping rationale: forecast year N → end-of-(N - 1) UTC ms.
+//   Reads as: "the most recent fully-observed period that backs this
+//   forecast vintage." For year=2026 → end-of-2025 = Dec 31 2025. That's
+//   ~5 months ago in May 2026 — sensible "newestItemAt" for a 2026
+//   forecast. For year=2024 → end-of-2023 = ~29mo ago in May 2026 —
+//   correctly stale, signals IMF hasn't updated forecasts in over a year.
+//
+// Four production seeders match this contract (all use `latestValue()`
+// + `weoYears()` from `_seed-utils.mjs`):
+//   - seed-imf-external.mjs (BCA, TM_RPCH, TX_RPCH)
+//   - seed-imf-growth.mjs (NGDP_RPCH, NGDPDPC, NGDP_R, PPPPC, PPPGDP, NID_NGDP, NGSD_NGDP)
+//   - seed-imf-labor.mjs (LUR, LP)
+//   - seed-imf-macro.mjs (PCPIPCH, BCA_NGDPD, GGR_NGDP, PCPI, PCPIEPCH, GGX_NGDP, GGXONLB_NGDP)
+//
+// All four use the same publication cadence (WEO April + October vintages)
+// and therefore the same budget. Per-seeder budget overrides are NOT needed
+// here — distinct from the WB cohort where FOSL.ZS publishes slower than
+// LOSS/NUCL/HYRO. If a future IMF series migrates with a different cadence
+// (e.g. monthly IFS data), it should NOT reuse this module.
+
+/**
+ * Convert an IMF forecast year to "newestItemAt" UTC ms.
+ *
+ * Maps forecast year N → end-of-(N - 1). Encodes: "the latest observation
+ * period this forecast vintage is built on." Avoids the future-dated trap
+ * that end-of-N would produce for current-year forecasts (e.g. year=2026
+ * in May 2026 → end-of-2026 = 7mo future).
+ *
+ * Returns null on invalid shape — defensive.
+ *
+ * @param {number|string} year - forecast year stored by IMF seeders' `latestValue()`
+ */
+export function imfForecastYearToMs(year) {
+  const n = typeof year === 'string' ? Number(year) : year;
+  if (!Number.isInteger(n) || n < 1900 || n > 9999) return null;
+  return Date.UTC(n - 1, 11, 31, 23, 59, 59, 999);
+}
+
+/**
+ * Compute newest/oldest content timestamps from an IMF/WEO per-country dict.
+ *
+ * - newestItemAt = end-of-(MAX year - 1) — drives staleness against the
+ *   freshest forecast horizon stored.
+ * - oldestItemAt = end-of-(MIN year - 1) — informational; surfaces how
+ *   stretched the per-country forecast cohort is.
+ * - Returns null when no country has a usable year.
+ * - 1h clock-skew tolerance — under the seeder's current `weoYears()`
+ *   (`[currentYear, currentYear-1, currentYear-2]`), max year = currentYear,
+ *   so end-of-(year - 1) is always ≤ Dec 31 of last calendar year, never
+ *   future. The skew check is defensive against a future seeder change
+ *   that extends the forecast horizon (e.g. `currentYear + 1`).
+ *
+ * @param {{countries: Record<string, {year: number}>}} data
+ * @param {number} nowMs - injectable "now" for deterministic tests
+ */
+export function imfWeoContentMeta(data, nowMs = Date.now()) {
+  const countries = data?.countries;
+  if (!countries || typeof countries !== 'object') return null;
+  const skewLimit = nowMs + 60 * 60 * 1000;
+  let newest = -Infinity, oldest = Infinity, validCount = 0;
+  for (const entry of Object.values(countries)) {
+    const ts = imfForecastYearToMs(entry?.year);
+    if (ts == null) continue;
+    if (ts > skewLimit) continue;
+    validCount++;
+    if (ts > newest) newest = ts;
+    if (ts < oldest) oldest = ts;
+  }
+  if (validCount === 0) return null;
+  return { newestItemAt: newest, oldestItemAt: oldest };
+}
+
+/**
+ * IMF/WEO budget (18 thirty-day months ≈ 540 days).
+ *
+ * IMF WEO publishes ~April and ~October each year, each vintage labeled
+ * with `currentYear` as its frontmost forecast horizon. So `max year` in
+ * the cache advances at most twice per year.
+ *
+ * Steady-state model under the helper's "year → end-of-(year-1)" mapping:
+ *   - After April N release: max year = N → newestItemAt = end-of-(N-1).
+ *     Age = ~5 months (Jan-May of year N).
+ *   - After October N release: max year still = N → age = ~11 months.
+ *   - Just before April N+1 release: max year still = N → age = ~16 months.
+ *   - After April N+1: max year advances to N+1 → newestItemAt resets to
+ *     end-of-N → age = ~5 months again.
+ *
+ * Steady-state ceiling = 16 months (just before April release of N+1).
+ * Budget = 16mo ceiling + 2mo slack = 18 months. STALE_CONTENT trips when
+ * a full year of WEO releases is missed (both April AND October), which
+ * is the right pager threshold for an IMF outage.
+ */
+export const IMF_WEO_MAX_CONTENT_AGE_MIN = 18 * 30 * 24 * 60;

--- a/scripts/seed-imf-external.mjs
+++ b/scripts/seed-imf-external.mjs
@@ -21,7 +21,7 @@ import { loadEnvFile, runSeed, loadSharedConfig, imfSdmxFetchIndicator } from '.
 // IMF stores forecast YEAR (not observation year), so end-of-(year-1)
 // semantics are required to avoid future-dated rejection of fresh
 // current-year forecasts. See helper module header for derivation.
-import { imfWeoContentMeta, IMF_WEO_MAX_CONTENT_AGE_MIN } from './_imf-weo-content-age-helpers.mjs';
+import { imfWeoContentMeta, IMF_WEO_MAX_CONTENT_AGE_MIN, maxIntegerYear } from './_imf-weo-content-age-helpers.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -87,6 +87,15 @@ export function buildExternalCountries({
       importVolumePctChg: tm?.value ?? null,
       exportVolumePctChg: tx?.value ?? null,
       year: ca?.year ?? tm?.year ?? tx?.year ?? null,
+      // Codex PR #3604 P2 — `latestYear` carries the MAX forecast year
+      // across all available indicators for this country, not the
+      // priority-first fallback. Drives content-age via the WEO helper:
+      // a row with BCA=2024 + import-volume=2026 publishes year=2024
+      // (correct: BCA's primary metric vintage) but latestYear=2026
+      // (correct: the freshest forecast horizon stored). Without this,
+      // content-age maps the row to 2023-12-31 (~17mo old) when it
+      // actually carries a 2026 metric (~5mo old in May 2026).
+      latestYear: maxIntegerYear([ca?.year, tm?.year, tx?.year]),
     };
   }
   return countries;

--- a/scripts/seed-imf-external.mjs
+++ b/scripts/seed-imf-external.mjs
@@ -17,6 +17,11 @@
 // Per WorldMonitor #3027 — feeds Trade Flows card.
 
 import { loadEnvFile, runSeed, loadSharedConfig, imfSdmxFetchIndicator } from './_seed-utils.mjs';
+// Sprint 4 IMF/WEO cohort — content-age helper. NOT the WB cohort helper:
+// IMF stores forecast YEAR (not observation year), so end-of-(year-1)
+// semantics are required to avoid future-dated rejection of fresh
+// current-year forecasts. See helper module header for derivation.
+import { imfWeoContentMeta, IMF_WEO_MAX_CONTENT_AGE_MIN } from './_imf-weo-content-age-helpers.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -127,6 +132,14 @@ if (process.argv[1]?.endsWith('seed-imf-external.mjs')) {
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: 100800,
+
+    // ── Content-age contract (Sprint 4 IMF/WEO cohort) ──
+    // 18-month budget = 16mo steady-state ceiling (just before next April
+    // WEO release of year+1) + 2mo slack. Trips when a full WEO year is
+    // missed (both April AND October vintages). Same budget across all 4
+    // IMF seeders — they share the WEO release cadence.
+    contentMeta: imfWeoContentMeta,
+    maxContentAgeMin: IMF_WEO_MAX_CONTENT_AGE_MIN,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-imf-external.mjs
+++ b/scripts/seed-imf-external.mjs
@@ -139,7 +139,13 @@ if (process.argv[1]?.endsWith('seed-imf-external.mjs')) {
     emptyDataIsFailure: true,
   
     declareRecords,
-    schemaVersion: 1,
+    // schemaVersion bumped 1→2 in Codex PR #3604 review fix: the per-country
+    // dict gained a new `latestYear` field (Codex P2). Adding the field is
+    // back-compat for readers (helper falls back to `year`), but the
+    // envelope's `newestItemAt` math now differs under the same shape — so
+    // bump forces a clean republish on rollout and makes any rollback
+    // observable via cache invalidation rather than silent envelope drift.
+    schemaVersion: 2,
     maxStaleMin: 100800,
 
     // ── Content-age contract (Sprint 4 IMF/WEO cohort) ──

--- a/scripts/seed-imf-growth.mjs
+++ b/scripts/seed-imf-growth.mjs
@@ -18,7 +18,7 @@
 
 import { loadEnvFile, runSeed, loadSharedConfig, imfSdmxFetchIndicator } from './_seed-utils.mjs';
 // Sprint 4 IMF/WEO cohort content-age helper — see header for forecast-year semantics.
-import { imfWeoContentMeta, IMF_WEO_MAX_CONTENT_AGE_MIN } from './_imf-weo-content-age-helpers.mjs';
+import { imfWeoContentMeta, IMF_WEO_MAX_CONTENT_AGE_MIN, maxIntegerYear } from './_imf-weo-content-age-helpers.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -101,6 +101,10 @@ export function buildGrowthCountries(perIndicator) {
       savingsPct:         sav?.value ?? null,
       savingsInvestmentGap: savInvGap,
       year: growth?.year ?? gdpPc?.year ?? realGdpV?.year ?? pppPc?.year ?? pppGdpV?.year ?? inv?.year ?? sav?.year ?? null,
+      // Codex PR #3604 P2 — see seed-imf-external.mjs for the full
+      // rationale. `latestYear` = max forecast year across all this
+      // country's indicators; drives content-age in the WEO helper.
+      latestYear: maxIntegerYear([growth?.year, gdpPc?.year, realGdpV?.year, pppPc?.year, pppGdpV?.year, inv?.year, sav?.year]),
     };
   }
   return countries;

--- a/scripts/seed-imf-growth.mjs
+++ b/scripts/seed-imf-growth.mjs
@@ -164,7 +164,9 @@ if (process.argv[1]?.endsWith('seed-imf-growth.mjs')) {
     emptyDataIsFailure: true,
   
     declareRecords,
-    schemaVersion: 1,
+    // schemaVersion bumped 1→2 in Codex PR #3604 review fix: see
+    // seed-imf-external.mjs for the rationale (new `latestYear` field).
+    schemaVersion: 2,
     maxStaleMin: 100800,
 
     // ── Content-age contract (Sprint 4 IMF/WEO cohort) ──

--- a/scripts/seed-imf-growth.mjs
+++ b/scripts/seed-imf-growth.mjs
@@ -17,6 +17,8 @@
 // used by seed-imf-macro.mjs.
 
 import { loadEnvFile, runSeed, loadSharedConfig, imfSdmxFetchIndicator } from './_seed-utils.mjs';
+// Sprint 4 IMF/WEO cohort content-age helper — see header for forecast-year semantics.
+import { imfWeoContentMeta, IMF_WEO_MAX_CONTENT_AGE_MIN } from './_imf-weo-content-age-helpers.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -160,6 +162,12 @@ if (process.argv[1]?.endsWith('seed-imf-growth.mjs')) {
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: 100800,
+
+    // ── Content-age contract (Sprint 4 IMF/WEO cohort) ──
+    // 18-month budget = 16mo steady-state ceiling + 2mo slack.
+    // See _imf-weo-content-age-helpers.mjs JSDoc for derivation.
+    contentMeta: imfWeoContentMeta,
+    maxContentAgeMin: IMF_WEO_MAX_CONTENT_AGE_MIN,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-imf-labor.mjs
+++ b/scripts/seed-imf-labor.mjs
@@ -12,7 +12,7 @@
 
 import { loadEnvFile, runSeed, loadSharedConfig, imfSdmxFetchIndicator } from './_seed-utils.mjs';
 // Sprint 4 IMF/WEO cohort content-age helper — see header for forecast-year semantics.
-import { imfWeoContentMeta, IMF_WEO_MAX_CONTENT_AGE_MIN } from './_imf-weo-content-age-helpers.mjs';
+import { imfWeoContentMeta, IMF_WEO_MAX_CONTENT_AGE_MIN, maxIntegerYear } from './_imf-weo-content-age-helpers.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -72,6 +72,10 @@ export function buildLaborCountries({ unemployment = {}, population = {} }) {
       unemploymentPct: lur?.value ?? null,
       populationMillions: popMillions,
       year: lur?.year ?? lp?.year ?? null,
+      // Codex PR #3604 P2 — see seed-imf-external.mjs for the full
+      // rationale. `latestYear` = max forecast year across all this
+      // country's indicators; drives content-age in the WEO helper.
+      latestYear: maxIntegerYear([lur?.year, lp?.year]),
     };
   }
   return countries;

--- a/scripts/seed-imf-labor.mjs
+++ b/scripts/seed-imf-labor.mjs
@@ -116,7 +116,9 @@ if (process.argv[1]?.endsWith('seed-imf-labor.mjs')) {
     emptyDataIsFailure: true,
   
     declareRecords,
-    schemaVersion: 1,
+    // schemaVersion bumped 1→2 in Codex PR #3604 review fix: see
+    // seed-imf-external.mjs for the rationale (new `latestYear` field).
+    schemaVersion: 2,
     maxStaleMin: 100800,
 
     // ── Content-age contract (Sprint 4 IMF/WEO cohort) ──

--- a/scripts/seed-imf-labor.mjs
+++ b/scripts/seed-imf-labor.mjs
@@ -11,6 +11,8 @@
 // sub-metric) and CountryDeepDivePanel demographic tiles (LP).
 
 import { loadEnvFile, runSeed, loadSharedConfig, imfSdmxFetchIndicator } from './_seed-utils.mjs';
+// Sprint 4 IMF/WEO cohort content-age helper — see header for forecast-year semantics.
+import { imfWeoContentMeta, IMF_WEO_MAX_CONTENT_AGE_MIN } from './_imf-weo-content-age-helpers.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -112,6 +114,12 @@ if (process.argv[1]?.endsWith('seed-imf-labor.mjs')) {
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: 100800,
+
+    // ── Content-age contract (Sprint 4 IMF/WEO cohort) ──
+    // 18-month budget = 16mo steady-state ceiling + 2mo slack.
+    // See _imf-weo-content-age-helpers.mjs JSDoc for derivation.
+    contentMeta: imfWeoContentMeta,
+    maxContentAgeMin: IMF_WEO_MAX_CONTENT_AGE_MIN,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/scripts/seed-imf-macro.mjs
+++ b/scripts/seed-imf-macro.mjs
@@ -2,7 +2,7 @@
 
 import { loadEnvFile, runSeed, loadSharedConfig, imfSdmxFetchIndicator } from './_seed-utils.mjs';
 // Sprint 4 IMF/WEO cohort content-age helper — see header for forecast-year semantics.
-import { imfWeoContentMeta, IMF_WEO_MAX_CONTENT_AGE_MIN } from './_imf-weo-content-age-helpers.mjs';
+import { imfWeoContentMeta, IMF_WEO_MAX_CONTENT_AGE_MIN, maxIntegerYear } from './_imf-weo-content-age-helpers.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -90,6 +90,10 @@ async function fetchImfMacro() {
       govExpenditurePct:   govExp?.value ?? null,
       primaryBalancePct:   primBal?.value ?? null,
       year: infl?.year ?? ca?.year ?? rev?.year ?? cpi?.year ?? cpiEop?.year ?? govExp?.year ?? primBal?.year ?? null,
+      // Codex PR #3604 P2 — see seed-imf-external.mjs for the full
+      // rationale. `latestYear` = max forecast year across all this
+      // country's indicators; drives content-age in the WEO helper.
+      latestYear: maxIntegerYear([infl?.year, ca?.year, rev?.year, cpi?.year, cpiEop?.year, govExp?.year, primBal?.year]),
     };
   }
 

--- a/scripts/seed-imf-macro.mjs
+++ b/scripts/seed-imf-macro.mjs
@@ -121,7 +121,9 @@ if (process.argv[1]?.endsWith('seed-imf-macro.mjs')) {
     emptyDataIsFailure: true,
   
     declareRecords,
-    schemaVersion: 1,
+    // schemaVersion bumped 1→2 in Codex PR #3604 review fix: see
+    // seed-imf-external.mjs for the rationale (new `latestYear` field).
+    schemaVersion: 2,
     maxStaleMin: 100800,
 
     // ── Content-age contract (Sprint 4 IMF/WEO cohort) ──

--- a/scripts/seed-imf-macro.mjs
+++ b/scripts/seed-imf-macro.mjs
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, runSeed, loadSharedConfig, imfSdmxFetchIndicator } from './_seed-utils.mjs';
+// Sprint 4 IMF/WEO cohort content-age helper — see header for forecast-year semantics.
+import { imfWeoContentMeta, IMF_WEO_MAX_CONTENT_AGE_MIN } from './_imf-weo-content-age-helpers.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -117,6 +119,12 @@ if (process.argv[1]?.endsWith('seed-imf-macro.mjs')) {
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: 100800,
+
+    // ── Content-age contract (Sprint 4 IMF/WEO cohort) ──
+    // 18-month budget = 16mo steady-state ceiling + 2mo slack.
+    // See _imf-weo-content-age-helpers.mjs JSDoc for derivation.
+    contentMeta: imfWeoContentMeta,
+    maxContentAgeMin: IMF_WEO_MAX_CONTENT_AGE_MIN,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/tests/imf-weo-content-age.test.mjs
+++ b/tests/imf-weo-content-age.test.mjs
@@ -273,6 +273,52 @@ test('mixed-indicator-year: latestYear=null falls back to year (no panic on miss
   assert.equal(cm.newestItemAt, Date.UTC(2024, 11, 31, 23, 59, 59, 999), 'must use year=2025 → end-of-2024');
 });
 
+// ── Horizon-extension regression-guard (Sprint 4 + Codex PR #3604 review) ──
+
+test('horizon extension regression-guard: currentYear+1 forecast WOULD silently false-page under current skew filter', () => {
+  // Tripwire: if a future Sprint extends `weoYears()` to include
+  // `currentYear+1` to surface forward forecasts, this test will start
+  // failing and force a revisit of the helper's skew filter.
+  //
+  // Concrete trap (under FIXED_NOW = 2026-05-05): pretend the seeder
+  // populated entries with `year: 2027` (April 2026 release's frontmost
+  // forecast horizon). The helper maps 2027 → end-of-2026 = Dec 31 2026 =
+  // ~7mo future relative to FIXED_NOW. The 1h skew filter excludes this
+  // entry. validCount=0 → returns null → envelope newestItemAt=null →
+  // health classifier reads STALE_CONTENT for a genuinely-fresh cache.
+  //
+  // Today this is harmless because no seeder writes year=2027 in May
+  // 2026 (weoYears = [2026, 2025, 2024]). Documenting it here so any
+  // change to weoYears() to include +1 is forced to come revisit this
+  // filter (either widen skew tolerance, or shift the year→ms mapping).
+  const futureHorizon = { countries: { US: { year: 2027 }, GB: { year: 2027 } } };
+  const cm = imfWeoContentMeta(futureHorizon, FIXED_NOW);
+  assert.equal(
+    cm,
+    null,
+    'currentYear+1 cohort currently collapses to null — regression test asserts the trap shape, NOT desired behavior',
+  );
+
+  // Mixed cohort: one fresh +1 entry alongside a stale -2 entry. Skew
+  // filter excludes the +1, so newestItemAt regresses to the laggard.
+  const mixedTrap = {
+    countries: {
+      US: { year: 2027 },          // fresh +1, gets filtered out
+      VE: { year: 2024 },          // stale -2
+    },
+  };
+  const cmMixed = imfWeoContentMeta(mixedTrap, FIXED_NOW);
+  assert.ok(cmMixed !== null, 'mixed cohort with one valid entry must not collapse');
+  // newestItemAt comes from VE=2024 (the only entry that passed the filter)
+  // → end-of-2023 ≈ 17mo old. If horizon extension lands without revisiting
+  // the filter, fresh data masquerades as stale.
+  assert.equal(
+    cmMixed.newestItemAt,
+    Date.UTC(2023, 11, 31, 23, 59, 59, 999),
+    'mixed cohort newestItemAt regresses to laggard when +1 is filtered — trap is real',
+  );
+});
+
 test('mixed-indicator-year: cohort with mixed shapes — newestItemAt picks max latestYear across all', () => {
   // Heterogeneous cohort exercising every code path simultaneously.
   // newestItemAt must be the MAX across all valid years (latestYear when

--- a/tests/imf-weo-content-age.test.mjs
+++ b/tests/imf-weo-content-age.test.mjs
@@ -1,0 +1,195 @@
+// Sprint 4 IMF/WEO cohort — content-age contract for the 4 IMF SDMX seeders.
+//
+// Tests import the SAME imfWeoContentMeta the seeders run. Pinned to
+// FIXED_NOW = 2026-05-05 (matches the WB cohort verification date) so all
+// "fresh April 2026 vintage" assertions are deterministic.
+//
+// The KEY semantic difference from WB seeders (covered in
+// `wb-country-dict-content-age.test.mjs`): IMF year is FORECAST horizon,
+// NOT observation year. So the helper maps year → end-of-(year - 1) UTC
+// ms, NOT end-of-year. A test that round-trips through the WB helper math
+// would falsely reject every fresh IMF cache as future-dated.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  imfForecastYearToMs,
+  imfWeoContentMeta,
+  IMF_WEO_MAX_CONTENT_AGE_MIN,
+} from '../scripts/_imf-weo-content-age-helpers.mjs';
+
+const FIXED_NOW = Date.UTC(2026, 4, 5, 12);     // 2026-05-05T12:00 UTC
+
+test('IMF_WEO_MAX_CONTENT_AGE_MIN is 18 thirty-day months', () => {
+  // 18mo = 16mo steady-state ceiling + 2mo slack. See helper JSDoc for
+  // the derivation against the WEO April + October release cadence.
+  assert.equal(IMF_WEO_MAX_CONTENT_AGE_MIN, 18 * 30 * 24 * 60);
+});
+
+// ── imfForecastYearToMs ──────────────────────────────────────────────────
+
+test('imfForecastYearToMs: forecast year 2026 → end-of-2025 UTC ms', () => {
+  // The KEY semantic: forecast year N → end-of-(N - 1). Encodes "the
+  // latest fully-observed period this forecast vintage is built on."
+  const ms = imfForecastYearToMs(2026);
+  assert.equal(new Date(ms).toISOString(), '2025-12-31T23:59:59.999Z');
+});
+
+test('imfForecastYearToMs: forecast year 2024 → end-of-2023 UTC ms', () => {
+  const ms = imfForecastYearToMs(2024);
+  assert.equal(new Date(ms).toISOString(), '2023-12-31T23:59:59.999Z');
+});
+
+test('imfForecastYearToMs: numeric string "2026" parses identically', () => {
+  assert.equal(imfForecastYearToMs('2026'), imfForecastYearToMs(2026));
+});
+
+test('imfForecastYearToMs: invalid shapes return null', () => {
+  assert.equal(imfForecastYearToMs(undefined), null);
+  assert.equal(imfForecastYearToMs(null), null);
+  assert.equal(imfForecastYearToMs(''), null);
+  assert.equal(imfForecastYearToMs('garbage'), null);
+  assert.equal(imfForecastYearToMs(2024.5), null);
+  assert.equal(imfForecastYearToMs(1899), null);
+  assert.equal(imfForecastYearToMs(10000), null);
+});
+
+// ── imfWeoContentMeta ────────────────────────────────────────────────────
+
+test('contentMeta returns null when countries dict missing or non-object', () => {
+  assert.equal(imfWeoContentMeta({}, FIXED_NOW), null);
+  assert.equal(imfWeoContentMeta({ countries: null }, FIXED_NOW), null);
+  assert.equal(imfWeoContentMeta({ countries: 'string' }, FIXED_NOW), null);
+});
+
+test('contentMeta returns null when no country has a usable year', () => {
+  const data = { countries: { US: {}, GB: { year: null }, DE: { year: 'garbage' } } };
+  assert.equal(imfWeoContentMeta(data, FIXED_NOW), null);
+});
+
+test('contentMeta picks newest (max) and oldest (min) forecast year across countries', () => {
+  const data = {
+    countries: {
+      US: { year: 2026 },     // freshest forecast horizon
+      GB: { year: 2026 },
+      DE: { year: 2025 },
+      KW: { year: 2024 },     // late-reporter
+    },
+  };
+  const cm = imfWeoContentMeta(data, FIXED_NOW);
+  assert.equal(new Date(cm.newestItemAt).toISOString(), '2025-12-31T23:59:59.999Z', 'max forecast year 2026 → end-of-2025');
+  assert.equal(new Date(cm.oldestItemAt).toISOString(), '2023-12-31T23:59:59.999Z', 'min forecast year 2024 → end-of-2023');
+});
+
+test('contentMeta excludes countries with invalid year shapes', () => {
+  const data = {
+    countries: {
+      US: { year: 2026 },
+      INVALID: { year: null },
+      JUNK: { year: 'foo' },
+      KW: { year: 2024 },
+    },
+  };
+  const cm = imfWeoContentMeta(data, FIXED_NOW);
+  assert.equal(new Date(cm.newestItemAt).toISOString(), '2025-12-31T23:59:59.999Z');
+  assert.equal(new Date(cm.oldestItemAt).toISOString(), '2023-12-31T23:59:59.999Z');
+});
+
+test('contentMeta excludes future-dated forecasts beyond 1h clock-skew tolerance', () => {
+  // Defensive: under the seeder's current weoYears() (currentYear, -1, -2),
+  // max year = currentYear, so end-of-(year - 1) is always Dec 31 of
+  // last calendar year — never future. But if a future seeder change
+  // extends weoYears() to include currentYear+1 (longer forecast horizon),
+  // year=2027 in May 2026 → end-of-2026 = Dec 31 2026 = ~7mo future →
+  // should be rejected as "garbage" rather than reported as fresh.
+  const data = {
+    countries: {
+      US: { year: 2026 },     // valid → end-of-2025 → past NOW
+      FUTURE: { year: 2099 }, // far future → end-of-2098 → far future, excluded
+      EDGE: { year: 2027 },   // year-1 = 2026, end-of-2026 = ~7mo future, excluded
+    },
+  };
+  const cm = imfWeoContentMeta(data, FIXED_NOW);
+  assert.equal(new Date(cm.newestItemAt).toISOString(), '2025-12-31T23:59:59.999Z');
+});
+
+// ── Pilot threshold sanity ───────────────────────────────────────────────
+//
+// IMF/WEO cadence: April + October vintages each year. After April 2026,
+// max stored year = 2026 → newestItemAt = end-of-2025. Age in May 2026 =
+// ~5 months. The 18-month budget should comfortably tolerate this AND
+// the steady-state worst case (just before April 2027 release of 2027
+// forecasts: max year = 2026, age = ~16 months).
+
+test('fresh-arrival regression guard: April 2026 vintage (max year 2026, age ~5mo) does NOT trip', () => {
+  const data = { countries: { US: { year: 2026 } } };
+  const cm = imfWeoContentMeta(data, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(
+    ageMin < IMF_WEO_MAX_CONTENT_AGE_MIN,
+    `${Math.round(ageMin / 60 / 24 / 30)}mo < 18mo budget — fresh April vintage tolerated`,
+  );
+});
+
+test('steady-state regression guard: just-before-April-2027 (max year 2026, age ~16mo) does NOT trip', () => {
+  // FIXED_FUTURE pinned to mid-March 2027. WEO April 2027 hasn't
+  // released yet, so max stored year = 2026 (carried over from Apr/Oct
+  // 2026 vintages). Cache age = end-of-2025 → mid-March 2027 ≈ 14.5mo.
+  // 18-month budget MUST tolerate this — it's the steady-state ceiling.
+  const FIXED_FUTURE = Date.UTC(2027, 2, 15);     // March 15 2027
+  const data = { countries: { US: { year: 2026 } } };
+  const cm = imfWeoContentMeta(data, FIXED_FUTURE);
+  const ageMin = (FIXED_FUTURE - cm.newestItemAt) / 60000;
+  assert.ok(
+    ageMin < IMF_WEO_MAX_CONTENT_AGE_MIN,
+    `${Math.round(ageMin / 60 / 24 / 30)}mo < 18mo budget — steady-state ceiling tolerated`,
+  );
+});
+
+test('catastrophic stall: max year 2024 in May 2026 (age ~29mo) trips STALE_CONTENT', () => {
+  // IMF should have published 2025 + 2026 forecasts by May 2026 (Apr 2025,
+  // Oct 2025, Apr 2026 are all WEO release windows). Cache stuck at year
+  // 2024 = both 2025 AND 2026 vintages missed → page on-call.
+  const data = { countries: { US: { year: 2024 } } };
+  const cm = imfWeoContentMeta(data, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(
+    ageMin > IMF_WEO_MAX_CONTENT_AGE_MIN,
+    `${Math.round(ageMin / 60 / 24 / 30)}mo > 18mo budget — STALE_CONTENT correctly fires`,
+  );
+});
+
+test('semantic difference from WB cohort: forecast year 2026 in May 2026 maps to past (NOT future)', () => {
+  // This test exists specifically to prevent a future refactor from
+  // accidentally collapsing the WB and IMF helpers into one. Under WB's
+  // end-of-year semantics, year=2026 → end-of-2026 = Dec 31 2026 = ~7mo
+  // FUTURE in May 2026 → would be rejected by 1h skew limit → contentMeta
+  // returns null → STALE_CONTENT for every fresh IMF cache. The IMF
+  // helper's end-of-(year - 1) mapping prevents this trap.
+  const data = { countries: { US: { year: 2026 } } };
+  const cm = imfWeoContentMeta(data, FIXED_NOW);
+  assert.ok(cm !== null, 'fresh IMF cache must NOT collapse to null under forecast-year semantics');
+  assert.ok(cm.newestItemAt < FIXED_NOW, 'newestItemAt must be in the past, not future-dated');
+});
+
+test('late-reporter cohort does NOT drag newestItemAt down (G7 freshness wins)', () => {
+  // Same shape pattern as WB cohort: late-publishing IMF members (e.g.
+  // some EMs lag G7's WEO inclusion) shouldn't make the panel page when
+  // G7 has fresh forecasts. Verify the dict mix produces G7-led
+  // newestItemAt, NOT the laggard-led oldestItemAt.
+  const data = {
+    countries: {
+      US: { year: 2026 },     // fresh G7
+      GB: { year: 2026 },
+      DE: { year: 2026 },
+      VE: { year: 2024 },     // Venezuela lags WEO inclusion
+      ER: { year: 2024 },
+    },
+  };
+  const cm = imfWeoContentMeta(data, FIXED_NOW);
+  const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
+  assert.ok(
+    ageMin < IMF_WEO_MAX_CONTENT_AGE_MIN,
+    'mixed-cadence dict: G7 freshness drives newestItemAt — late reporters do NOT cause false-positive page',
+  );
+});

--- a/tests/imf-weo-content-age.test.mjs
+++ b/tests/imf-weo-content-age.test.mjs
@@ -16,6 +16,7 @@ import {
   imfForecastYearToMs,
   imfWeoContentMeta,
   IMF_WEO_MAX_CONTENT_AGE_MIN,
+  maxIntegerYear,
 } from '../scripts/_imf-weo-content-age-helpers.mjs';
 
 const FIXED_NOW = Date.UTC(2026, 4, 5, 12);     // 2026-05-05T12:00 UTC
@@ -192,4 +193,101 @@ test('late-reporter cohort does NOT drag newestItemAt down (G7 freshness wins)',
     ageMin < IMF_WEO_MAX_CONTENT_AGE_MIN,
     'mixed-cadence dict: G7 freshness drives newestItemAt — late reporters do NOT cause false-positive page',
   );
+});
+
+// ── maxIntegerYear helper ───────────────────────────────────────────────
+
+test('maxIntegerYear returns max across mixed valid+null+string years', () => {
+  // Seeders pass each indicator's optional year to maxIntegerYear. Mix of
+  // numbers, numeric strings, null, undefined, NaN, out-of-range — only
+  // valid integer years 1900..9999 are considered.
+  assert.equal(maxIntegerYear([2024, 2026, 2025]), 2026);
+  assert.equal(maxIntegerYear([null, 2025, undefined, '2026', 2024]), 2026);
+  assert.equal(maxIntegerYear([null, undefined]), null);
+  assert.equal(maxIntegerYear([1899, 9999, 12345, NaN]), 9999);
+  assert.equal(maxIntegerYear([2024.5, '2024.5', 2024]), 2024);
+  assert.equal(maxIntegerYear(null), null);
+  assert.equal(maxIntegerYear([]), null);
+});
+
+// ── Codex PR #3604 P2 regression guard: mixed-indicator-year ─────────────
+
+test('mixed-indicator-year: latestYear (max forecast) drives content-age, not year (priority-first)', () => {
+  // Codex PR #3604 P2. Real-world shape from seed-imf-external: the country
+  // dict's `year` field is the priority-first non-null indicator's year
+  // (`ca?.year ?? tm?.year ?? tx?.year`). When the priority-first indicator
+  // (BCA) has only old data but a lower-priority indicator (TM_RPCH) has a
+  // fresh 2026 forecast, the legacy `year` field reads 2024 — content-age
+  // would map this to 2023-12-31 (~17mo old, near-stale) when the row
+  // actually carries a fresh 2026 metric (~5mo old in May 2026, fresh).
+  //
+  // The fix: seeders populate `entry.latestYear = maxIntegerYear([all
+  // indicator years])` and the helper prefers it over `entry.year`.
+  const dataWithLatestYear = {
+    countries: {
+      // Mirrors a country with stale BCA but fresh import-volume forecast.
+      US: { year: 2024, latestYear: 2026 },
+    },
+  };
+  const dataWithoutLatestYear = {
+    // Pre-fix shape (or downgraded cache during transition window): only
+    // `year` populated. Helper falls back to `year` for back-compat.
+    countries: { US: { year: 2024 } },
+  };
+  const cmWithLatest = imfWeoContentMeta(dataWithLatestYear, FIXED_NOW);
+  const cmWithoutLatest = imfWeoContentMeta(dataWithoutLatestYear, FIXED_NOW);
+
+  // With latestYear=2026 → end-of-2025 → ~5 months old in May 2026 → fresh.
+  const ageMinWithLatest = (FIXED_NOW - cmWithLatest.newestItemAt) / 60000;
+  assert.ok(
+    ageMinWithLatest < 7 * 30 * 24 * 60,
+    `latestYear-aware path must surface fresh metric (got ${(ageMinWithLatest / (30 * 24 * 60)).toFixed(1)}mo)`,
+  );
+
+  // Without latestYear → falls back to year=2024 → end-of-2023 → ~17mo old.
+  const ageMinWithoutLatest = (FIXED_NOW - cmWithoutLatest.newestItemAt) / 60000;
+  assert.ok(
+    ageMinWithoutLatest > 12 * 30 * 24 * 60,
+    `back-compat path (no latestYear) must read year (got ${(ageMinWithoutLatest / (30 * 24 * 60)).toFixed(1)}mo)`,
+  );
+
+  // newestItemAt must STRICTLY differ — proves the helper is reading
+  // latestYear, not silently equating it with year.
+  assert.ok(
+    cmWithLatest.newestItemAt > cmWithoutLatest.newestItemAt,
+    'latestYear must shift newestItemAt forward when fresher than year',
+  );
+});
+
+test('mixed-indicator-year: latestYear=null falls back to year (no panic on missing field)', () => {
+  // Defensive: maxIntegerYear returns null when no indicator year is valid
+  // (all-null country). Seeder writes `latestYear: null`. Helper should
+  // fall back to `year`, NOT crash and NOT return null for the country.
+  const data = {
+    countries: {
+      US: { year: 2025, latestYear: null },
+    },
+  };
+  const cm = imfWeoContentMeta(data, FIXED_NOW);
+  assert.ok(cm !== null, 'must not collapse to null when latestYear is null but year is valid');
+  assert.equal(cm.newestItemAt, Date.UTC(2024, 11, 31, 23, 59, 59, 999), 'must use year=2025 → end-of-2024');
+});
+
+test('mixed-indicator-year: cohort with mixed shapes — newestItemAt picks max latestYear across all', () => {
+  // Heterogeneous cohort exercising every code path simultaneously.
+  // newestItemAt must be the MAX across all valid years (latestYear when
+  // present, year when not). oldestItemAt must be the MIN.
+  const data = {
+    countries: {
+      US: { year: 2024, latestYear: 2026 },  // fresh metric tucked behind stale primary
+      GB: { year: 2025 },                     // pre-fix shape, no latestYear
+      VE: { year: 2024, latestYear: null },   // all-null indicators except primary
+      DE: { year: 2026, latestYear: 2026 },
+    },
+  };
+  const cm = imfWeoContentMeta(data, FIXED_NOW);
+  // Max year considered = 2026 (US.latestYear, DE.latestYear) → end-of-2025.
+  assert.equal(cm.newestItemAt, Date.UTC(2025, 11, 31, 23, 59, 59, 999));
+  // Min year considered = 2024 (VE.year fallback, GB had 2025) → end-of-2023.
+  assert.equal(cm.oldestItemAt, Date.UTC(2023, 11, 31, 23, 59, 59, 999));
 });

--- a/tests/seed-imf-extended.test.mjs
+++ b/tests/seed-imf-extended.test.mjs
@@ -115,15 +115,18 @@ describe('seed-imf-labor', () => {
       unemployment: { USA: { [YEAR]: 4.1 }, FRA: { [YEAR]: 7.5 } },
       population:   { USA: { [YEAR]: 333_300_000 }, FRA: { [YEAR]: 67_900_000 }, ZAF: { [YEAR]: 60_200_000 } },
     });
+    // `latestYear` (Codex PR #3604 P2) is the max forecast year across
+    // all the country's indicators — populated by every IMF seeder so the
+    // content-age helper can prefer it over the priority-first `year`.
     assert.deepEqual(countries.US, {
-      unemploymentPct: 4.1, populationMillions: 333.3, year: Number(YEAR),
+      unemploymentPct: 4.1, populationMillions: 333.3, year: Number(YEAR), latestYear: Number(YEAR),
     });
     assert.deepEqual(countries.FR, {
-      unemploymentPct: 7.5, populationMillions: 67.9, year: Number(YEAR),
+      unemploymentPct: 7.5, populationMillions: 67.9, year: Number(YEAR), latestYear: Number(YEAR),
     });
     // South Africa: only population (no LUR); still included.
     assert.deepEqual(countries.ZA, {
-      unemploymentPct: null, populationMillions: 60.2, year: Number(YEAR),
+      unemploymentPct: null, populationMillions: 60.2, year: Number(YEAR), latestYear: Number(YEAR),
     });
   });
 


### PR DESCRIPTION
Closes the deferred IMF/WEO portion of Sprint 4 of the [2026-05-04 health-readiness probe plan](docs/plans/2026-05-04-001-feat-health-readiness-probe-content-age-plan.md). Plan §477-485 listed "plus IMF/WEO/etc." as part of the annual-data migration. Branched off Sprint 1 (#3596) as a parallel sibling.

## Summary

Migrates all 4 IMF SDMX seeders in one PR (they share the same upstream and same publication cadence):

- \`seed-imf-external.mjs\` (BCA, TM_RPCH, TX_RPCH)
- \`seed-imf-growth.mjs\` (NGDP_RPCH, NGDPDPC, NGDP_R, PPPPC, PPPGDP, NID_NGDP, NGSD_NGDP)
- \`seed-imf-labor.mjs\` (LUR, LP)
- \`seed-imf-macro.mjs\` (PCPIPCH, BCA_NGDPD, GGR_NGDP, PCPI, PCPIEPCH, GGX_NGDP, GGXONLB_NGDP)

New helper \`scripts/_imf-weo-content-age-helpers.mjs\`: \`imfForecastYearToMs\`, \`imfWeoContentMeta\` (with injectable \`nowMs\`), \`IMF_WEO_MAX_CONTENT_AGE_MIN\`. All 4 seeders import it with the same constant.

## Why a separate helper from the WB cohort

WB and IMF have superficially identical \`{countries: {ISO2: {year}}}\` shapes but **opposite \`year\` semantics**:

| | WB indicators (LOSS, FOSL, NUCL, RNEW, HYRO) | IMF/WEO (BCA, NGDP_RPCH, LUR, PCPI, ...) |
|---|---|---|
| What \`year\` means | Observation year (latest data point's year) | Forecast horizon (\`weoYears()\` = current + 2 prior; \`latestValue()\` picks first non-null) |
| In May 2026, max year typically | 2024 (WB observes year-2 lag) | **2026** (IMF forecasts current year) |
| End-of-year mapping | \`Date.UTC(2024, 11, 31)\` = past — works | \`Date.UTC(2026, 11, 31)\` = **7mo future** — would be rejected by 1h skew limit, every fresh IMF cache reports STALE_CONTENT |

The IMF helper maps year → **end-of-(year - 1)** UTC ms. Reads as: "the latest fully-observed period this forecast vintage is built on." For year=2026 → end-of-2025 = ~5mo ago in May 2026 → correctly fresh.

A dedicated test (\`semantic difference from WB cohort: forecast year 2026 in May 2026 maps to past (NOT future)\`) exists specifically to prevent a future refactor from accidentally collapsing the WB and IMF helpers.

## Why one shared budget across all 4 IMF seeders (NOT per-seeder)

The WB cohort needed per-seeder budgets because publication lags differed (LOSS at ~17mo, FOSL at ~29mo). But all 4 IMF seeders fetch from the IDENTICAL upstream — IMF SDMX/WEO. WEO publishes April + October vintages each year as a single integrated release covering all WorldMonitor's indicator codes. So all 4 share the same fresh-arrival lag and steady-state ceiling. One budget = correct.

## 18-month budget — derivation

Steady-state model under "year → end-of-(year-1)" mapping:

- After April N release: max year = N → newestItemAt = end-of-(N-1). Age = ~5mo.
- After October N: max year still = N → age = ~11mo.
- Just before April N+1: max year still = N → age = ~16mo. **Steady-state ceiling.**
- After April N+1: max year advances to N+1 → resets.

Budget = 16mo ceiling + 2mo slack = **18 months**. Trips when a full year of WEO releases is missed (both April AND October vintages of one year), which is the right pager threshold for an IMF outage.

## Test plan

- [x] \`node --test tests/imf-weo-content-age.test.mjs\` → 15/15 pass
- [x] \`npx tsx --test tests/imf-country-data.test.mts tests/seed-imf-extended.test.mjs tests/imf-weo-content-age.test.mjs\` → 34/34 pass (existing IMF tests + new content-age, no regressions)
- [x] \`node --test tests/imf-weo-content-age.test.mjs tests/seed-content-age-contract.test.mjs tests/health-content-age.test.mjs tests/seed-utils-empty-data-failure.test.mjs\` → 47/47
- [x] \`npm run typecheck:api\` clean
- [x] \`npm run lint\` clean
- [x] **Fresh-arrival regression guard**: April 2026 vintage (max year 2026, age ~5mo) does NOT trip
- [x] **Steady-state regression guard**: just-before-April-2027 (max year 2026, age ~16mo) does NOT trip
- [x] **Catastrophic stall**: max year 2024 in May 2026 (age ~29mo) trips STALE_CONTENT — both 2025 + 2026 WEO missed
- [x] **WB/IMF semantic-difference guard**: prevents future refactor from collapsing the two helpers
- [x] **Future-skew defense**: forecast year 2099 (or 2027 if seeder ever extends \`weoYears()\` to currentYear+1) → end-of-(year-1) is still future → rejected
- [x] **Late-reporter cohort**: G7 freshness drives newestItemAt; lagging members (Venezuela, Eritrea) don't cause false-positive page
- [x] No seed-imf-*.mjs is in Dockerfile.relay (verified via grep) — no relay-COPY change needed
- [ ] Post-merge: confirm \`/api/health\` snapshot shows \`imfExternal\`, \`imfGrowth\`, \`imfLabor\`, \`imfMacro\` with \`contentAge\` block populated and \`status: OK\`

## Sprint 4 status after this PR

- ✅ power-reliability (#3602)
- ✅ low-carbon-generation + fossil-electricity-share (#3603)
- ✅ IMF/WEO cohort: external + growth + labor + macro (this PR)

Plan §477-485 fully closed. The plan's "Definition of done" §530 (≥1 annual-data migrated) was satisfied by #3602; this PR + #3603 round out the rest of the listed cohort.