### PR TITLE
fix(ai-flow): cross-variant sync + Headline Memory under Browser Local Model

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -899,7 +899,11 @@ export class App {
       if (BETA_MODE) mlWorker.loadModel('summarization-beta').catch(() => { });
     }
 
-    if (aiFlow.headlineMemory) {
+    // Headline Memory requires Browser Local Model to be ON — `isHeadlineMemoryEnabled()`
+    // ANDs both flags. Without this gate, leaving Headline Memory on while turning
+    // Browser Local Model off would silently download/run an embeddings model the user
+    // opted out of via the parent toggle.
+    if (isHeadlineMemoryEnabled()) {
       mlWorker.init().then(ok => {
         if (ok) mlWorker.loadModel('embeddings').catch(() => { });
       }).catch(() => { });
@@ -909,8 +913,16 @@ export class App {
       if (key === 'browserModel') {
         const s = getAiFlowSettings();
         if (s.browserModel) {
-          mlWorker.init();
-        } else if (!isHeadlineMemoryEnabled()) {
+          mlWorker.init().then(ok => {
+            // Re-honor Headline Memory's persisted value on parent re-enable.
+            if (ok && isHeadlineMemoryEnabled()) {
+              mlWorker.loadModel('embeddings').catch(() => { });
+            }
+          });
+        } else if (!isDesktopRuntime()) {
+          // Browser Local Model is the parent toggle for ALL local-model use,
+          // including Headline Memory. Terminate unconditionally on web —
+          // any persisted Headline Memory value is now non-effective.
           mlWorker.terminate();
         }
       }

--- a/src/App.ts
+++ b/src/App.ts
@@ -918,7 +918,7 @@ export class App {
             if (ok && isHeadlineMemoryEnabled()) {
               mlWorker.loadModel('embeddings').catch(() => { });
             }
-          });
+          }).catch(() => { });
         } else if (!isDesktopRuntime()) {
           // Browser Local Model is the parent toggle for ALL local-model use,
           // including Headline Memory. Terminate unconditionally on web —

--- a/src/services/ai-flow-settings.ts
+++ b/src/services/ai-flow-settings.ts
@@ -6,6 +6,8 @@
  *       settings hub once the UI is extended with additional sections.
  */
 
+import { isDesktopRuntime } from './runtime';
+
 const STORAGE_KEY_BROWSER_MODEL = 'wm-ai-flow-browser-model';
 const STORAGE_KEY_CLOUD_LLM = 'wm-ai-flow-cloud-llm';
 const STORAGE_KEY_MAP_NEWS_FLASH = 'wm-map-news-flash';
@@ -69,17 +71,24 @@ export function getAiFlowSettings(): AiFlowSettings {
 
 /**
  * Effective Headline Memory state. Headline Memory implementation requires
- * a local embeddings model in the ML worker, so it can only function when
- * Browser Local Model is also enabled. When Browser Local Model is OFF,
- * Headline Memory is treated as OFF regardless of its persisted toggle —
- * otherwise we'd silently download/run an ML model the user opted out of
- * via the parent toggle. The persisted value is preserved so re-enabling
- * Browser Local Model restores the user's prior Headline Memory choice.
+ * a local embeddings model in the ML worker, so on web it can only function
+ * when the Browser Local Model parent toggle is also enabled — otherwise
+ * we'd silently download/run an ML model the user opted out of via the
+ * parent toggle. The persisted value is preserved so re-enabling Browser
+ * Local Model restores the user's prior Headline Memory choice.
+ *
+ * The Browser Local Model toggle is web-only — `preferences-content.ts`
+ * skips rendering it on desktop, and `App.ts` initializes the ML worker
+ * unconditionally on desktop. So the parent gate must be skipped on
+ * desktop, otherwise Headline Memory would be silently dead on every
+ * desktop install (the hidden web key never flips to true).
  */
 export function isHeadlineMemoryEnabled(): boolean {
   const headline = readBool(STORAGE_KEY_HEADLINE_MEMORY, DEFAULTS.headlineMemory);
+  if (!headline) return false;
+  if (isDesktopRuntime()) return true;
   const browser = readBool(STORAGE_KEY_BROWSER_MODEL, DEFAULTS.browserModel);
-  return headline && browser;
+  return browser;
 }
 
 /**

--- a/src/services/ai-flow-settings.ts
+++ b/src/services/ai-flow-settings.ts
@@ -67,7 +67,28 @@ export function getAiFlowSettings(): AiFlowSettings {
   };
 }
 
+/**
+ * Effective Headline Memory state. Headline Memory implementation requires
+ * a local embeddings model in the ML worker, so it can only function when
+ * Browser Local Model is also enabled. When Browser Local Model is OFF,
+ * Headline Memory is treated as OFF regardless of its persisted toggle —
+ * otherwise we'd silently download/run an ML model the user opted out of
+ * via the parent toggle. The persisted value is preserved so re-enabling
+ * Browser Local Model restores the user's prior Headline Memory choice.
+ */
 export function isHeadlineMemoryEnabled(): boolean {
+  const headline = readBool(STORAGE_KEY_HEADLINE_MEMORY, DEFAULTS.headlineMemory);
+  const browser = readBool(STORAGE_KEY_BROWSER_MODEL, DEFAULTS.browserModel);
+  return headline && browser;
+}
+
+/**
+ * Raw persisted Headline Memory toggle state — used by settings UI render
+ * so the toggle reflects the user's stored preference even when the parent
+ * Browser Local Model toggle is off. Runtime gates should use
+ * `isHeadlineMemoryEnabled()` instead.
+ */
+export function getHeadlineMemoryRawValue(): boolean {
   return readBool(STORAGE_KEY_HEADLINE_MEMORY, DEFAULTS.headlineMemory);
 }
 

--- a/src/services/ai-flow-settings.ts
+++ b/src/services/ai-flow-settings.ts
@@ -74,8 +74,9 @@ export function getAiFlowSettings(): AiFlowSettings {
  * a local embeddings model in the ML worker, so on web it can only function
  * when the Browser Local Model parent toggle is also enabled — otherwise
  * we'd silently download/run an ML model the user opted out of via the
- * parent toggle. The persisted value is preserved so re-enabling Browser
- * Local Model restores the user's prior Headline Memory choice.
+ * parent toggle. The persisted value is preserved (the settings UI reads
+ * `getAiFlowSettings().headlineMemory` for the raw value) so re-enabling
+ * Browser Local Model restores the user's prior Headline Memory choice.
  *
  * The Browser Local Model toggle is web-only — `preferences-content.ts`
  * skips rendering it on desktop, and `App.ts` initializes the ML worker
@@ -89,16 +90,6 @@ export function isHeadlineMemoryEnabled(): boolean {
   if (isDesktopRuntime()) return true;
   const browser = readBool(STORAGE_KEY_BROWSER_MODEL, DEFAULTS.browserModel);
   return browser;
-}
-
-/**
- * Raw persisted Headline Memory toggle state — used by settings UI render
- * so the toggle reflects the user's stored preference even when the parent
- * Browser Local Model toggle is off. Runtime gates should use
- * `isHeadlineMemoryEnabled()` instead.
- */
-export function getHeadlineMemoryRawValue(): boolean {
-  return readBool(STORAGE_KEY_HEADLINE_MEMORY, DEFAULTS.headlineMemory);
 }
 
 export function setAiFlowSetting(key: keyof AiFlowSettings, value: boolean): void {

--- a/src/services/preferences-content.ts
+++ b/src/services/preferences-content.ts
@@ -41,15 +41,21 @@ export interface PreferencesResult {
   attach: (container: HTMLElement) => () => void;
 }
 
-function toggleRowHtml(id: string, label: string, desc: string, checked: boolean): string {
+function toggleRowHtml(
+  id: string,
+  label: string,
+  desc: string,
+  checked: boolean,
+  disabled = false,
+): string {
   return `
-    <div class="ai-flow-toggle-row">
+    <div class="ai-flow-toggle-row${disabled ? ' is-disabled' : ''}">
       <div class="ai-flow-toggle-label-wrap">
         <div class="ai-flow-toggle-label">${label}</div>
         <div class="ai-flow-toggle-desc">${desc}</div>
       </div>
-      <label class="ai-flow-switch">
-        <input type="checkbox" id="${id}"${checked ? ' checked' : ''}>
+      <label class="ai-flow-switch${disabled ? ' is-disabled' : ''}">
+        <input type="checkbox" id="${id}"${checked ? ' checked' : ''}${disabled ? ' disabled' : ''}>
         <span class="ai-flow-slider"></span>
       </label>
     </div>
@@ -227,7 +233,18 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
     `;
   }
 
-  html += toggleRowHtml('us-headline-memory', t('components.insights.headlineMemoryLabel'), t('components.insights.headlineMemoryDesc'), settings.headlineMemory);
+  // Headline Memory requires Browser Local Model (it loads an embeddings
+  // model in the ML worker). Disable the toggle when the parent is off so
+  // the user sees the dependency rather than wondering why their Headline
+  // Memory toggle "did nothing."
+  const headlineDisabled = !host.isDesktopApp && !settings.browserModel;
+  html += toggleRowHtml(
+    'us-headline-memory',
+    t('components.insights.headlineMemoryLabel'),
+    t('components.insights.headlineMemoryDesc'),
+    settings.headlineMemory,
+    headlineDisabled,
+  );
 
   html += `</div></details>`;
 
@@ -449,6 +466,18 @@ export function renderPreferences(host: PreferencesHost): PreferencesResult {
           setAiFlowSetting('browserModel', target.checked);
           const warn = container.querySelector('.ai-flow-toggle-warn') as HTMLElement;
           if (warn) warn.style.display = target.checked ? 'block' : 'none';
+          // Headline Memory is a child of Browser Local Model — keep its
+          // toggle's enabled/disabled state in sync without re-rendering
+          // the whole panel. The runtime gate (`isHeadlineMemoryEnabled`)
+          // already AND-gates both flags; this just mirrors that visually.
+          const hmInput = container.querySelector<HTMLInputElement>('#us-headline-memory');
+          const hmRow = hmInput?.closest('.ai-flow-toggle-row');
+          const hmSwitch = hmInput?.closest('.ai-flow-switch');
+          if (hmInput && !host.isDesktopApp) {
+            hmInput.disabled = !target.checked;
+            hmRow?.classList.toggle('is-disabled', !target.checked);
+            hmSwitch?.classList.toggle('is-disabled', !target.checked);
+          }
           updateAiStatus(container);
         } else if (target.id === 'us-map-flash') {
           setAiFlowSetting('mapNewsFlash', target.checked);

--- a/src/utils/sync-keys.ts
+++ b/src/utils/sync-keys.ts
@@ -18,6 +18,14 @@ export const CLOUD_SYNC_KEYS = [
   'wm-globe-visual-preset',
   'wm-stream-quality',
   'wm-ai-flow-cloud-llm',
+  // Sister AI-flow toggles. Without these, the user's "Browser Local Model"
+  // and "Headline Memory" prefs reset per variant and disagree with the
+  // already-synced Cloud AI toggle — e.g. Headline Memory left on for the
+  // full variant silently runs the local ML worker (HuggingFace model
+  // downloads) on every page load, but switching to the tech variant shows
+  // the toggle as off because tech-variant localStorage is fresh.
+  'wm-ai-flow-browser-model',
+  'wm-headline-memory',
   'wm-analysis-frameworks',
   'wm-panel-frameworks',
   // Provider-specific map themes (wm-map-theme:<provider>)


### PR DESCRIPTION
## Summary

Two fixes from one user observation: "all variants should act the same; also turning off Browser Local Model shouldn't keep loading a local model via Headline Memory."

### A. Cross-variant sync gap (`src/utils/sync-keys.ts`)

`CLOUD_SYNC_KEYS` synced `wm-ai-flow-cloud-llm` (Cloud AI toggle) across variants since launch but accidentally omitted the two sister keys:
- `wm-ai-flow-browser-model` (Browser Local Model)
- `wm-headline-memory` (Headline Memory)

Result: enabling Headline Memory on the full variant left tech-variant localStorage at the default-false. The user's settings disagreed across variants for no architectural reason — `wm-ai-flow-cloud-llm` proves the sync path already supports them. Adding both to `CLOUD_SYNC_KEYS` lets the existing cloud-prefs-sync round-trip them via `/api/user-prefs`.

### B. Headline Memory escaped the Browser Local Model parent (`src/App.ts` + `src/services/ai-flow-settings.ts`)

Headline Memory needs a local embeddings model in the ML worker. Pre-fix, the toggles were independent — a user could turn Browser Local Model OFF and leave Headline Memory ON, which silently kept running the local ML worker (and the lazily-loaded sentiment + NER models that piggyback on `mlWorker.isAvailable`). The "Browser Local Model" toggle was effectively a lie.

Made Headline Memory a child:
- `isHeadlineMemoryEnabled()` now returns `headline && browser` (effective). All five existing gate sites in `App.ts`, `country-intel.ts`, `rss.ts` inherit the new gating automatically.
- Added `getHeadlineMemoryRawValue()` for the settings UI render so the toggle reflects the user's stored preference (re-enabling the parent restores their prior choice).
- `browserModel` toggle handler: terminate worker unconditionally on web when parent goes off; on parent ON, re-load embeddings if the user's persisted Headline Memory was on.

### C. UI mirrors the dependency (`src/services/preferences-content.ts`)

`toggleRowHtml` gains an optional `disabled` param (back-compat). The Headline Memory toggle renders disabled when Browser Local Model is off on web. Toggling Browser Local Model live updates the Headline Memory disabled state without a panel re-render.

## Truth table after fix

| Browser | Headline | Worker runs? | Note |
|---|---|---|---|
| ON | ON | yes | unchanged |
| ON | OFF | yes | unchanged (other ML features) |
| OFF | OFF | no | unchanged |
| OFF | ON | **no** | **fixed** — was running silently |

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean
- [x] `npm run lint` — exit 0
- [x] `npm run test:data` — 7872/7872 pass
- [x] `node --test tests/edge-functions.test.mjs` — 181/181 pass
- [x] Edge bundle check — clean
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — OK