### PR TITLE
fix(gateway): strip spoofable x-user-id header

### DIFF
--- a/server/__tests__/entitlement-check.test.ts
+++ b/server/__tests__/entitlement-check.test.ts
@@ -34,13 +34,6 @@ import {
 
 const FUTURE = Date.now() + 86400000 * 30;
 
-function makeRequest(
-  pathname: string,
-  headers: Record<string, string> = {},
-): Request {
-  return new Request(`https://worldmonitor.app${pathname}`, { headers });
-}
-
 function makeEntitlements(tier: number, planKey = "free") {
   return {
     planKey,
@@ -75,14 +68,12 @@ describe("gateway entitlement check", () => {
   });
 
   test("checkEntitlement returns null for ungated endpoint", async () => {
-    const req = makeRequest("/api/seismology/v1/list-earthquakes");
-    const result = await checkEntitlement(req, "/api/seismology/v1/list-earthquakes", {});
+    const result = await checkEntitlement(null, "/api/seismology/v1/list-earthquakes", {});
     expect(result).toBeNull();
   });
 
-  test("checkEntitlement returns 403 when no userId in request (fail-closed)", async () => {
-    const req = makeRequest("/api/market/v1/analyze-stock");
-    const result = await checkEntitlement(req, "/api/market/v1/analyze-stock", {});
+  test("checkEntitlement returns 403 when no resolved userId is provided (fail-closed)", async () => {
+    const result = await checkEntitlement(null, "/api/market/v1/analyze-stock", {});
     expect(result).not.toBeNull();
     expect(result!.status).toBe(403);
 
@@ -93,8 +84,7 @@ describe("gateway entitlement check", () => {
 
   test("checkEntitlement returns 403 when getEntitlements returns null (fail-closed)", async () => {
     // getCachedJson returns null by default (no Redis data, no Convex URL) -> null entitlements
-    const req = makeRequest("/api/market/v1/analyze-stock", { "x-user-id": "test-user" });
-    const result = await checkEntitlement(req, "/api/market/v1/analyze-stock", {});
+    const result = await checkEntitlement("test-user", "/api/market/v1/analyze-stock", {});
     expect(result).not.toBeNull();
     expect(result!.status).toBe(403);
 
@@ -106,8 +96,7 @@ describe("gateway entitlement check", () => {
   test("checkEntitlement returns 403 for insufficient tier", async () => {
     vi.mocked(getCachedJson).mockResolvedValueOnce(makeEntitlements(0));
 
-    const req = makeRequest("/api/market/v1/analyze-stock", { "x-user-id": "test-user" });
-    const result = await checkEntitlement(req, "/api/market/v1/analyze-stock", {});
+    const result = await checkEntitlement("test-user", "/api/market/v1/analyze-stock", {});
 
     expect(result).not.toBeNull();
     expect(result!.status).toBe(403);
@@ -124,16 +113,14 @@ describe("gateway entitlement check", () => {
     // analysis is marketed as a Pro feature and must accept tier >= 1.
     vi.mocked(getCachedJson).mockResolvedValueOnce(makeEntitlements(1, "pro_monthly"));
 
-    const req = makeRequest("/api/market/v1/analyze-stock", { "x-user-id": "test-user" });
-    const result = await checkEntitlement(req, "/api/market/v1/analyze-stock", {});
+    const result = await checkEntitlement("test-user", "/api/market/v1/analyze-stock", {});
     expect(result).toBeNull();
   });
 
   test("checkEntitlement returns null for sufficient tier", async () => {
     vi.mocked(getCachedJson).mockResolvedValueOnce(makeEntitlements(2, "api_starter"));
 
-    const req = makeRequest("/api/market/v1/analyze-stock", { "x-user-id": "test-user" });
-    const result = await checkEntitlement(req, "/api/market/v1/analyze-stock", {});
+    const result = await checkEntitlement("test-user", "/api/market/v1/analyze-stock", {});
     expect(result).toBeNull();
   });
 
@@ -154,8 +141,7 @@ describe("gateway entitlement check", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     try {
-      const req = makeRequest("/api/market/v1/analyze-stock", { "x-user-id": "test-user" });
-      const result = await checkEntitlement(req, "/api/market/v1/analyze-stock", {});
+      const result = await checkEntitlement("test-user", "/api/market/v1/analyze-stock", {});
       expect(result).toBeNull();
       expect(fetchMock).toHaveBeenCalledWith(
         "https://example-deployment.convex.site/api/internal-entitlements",

--- a/server/_shared/entitlement-check.ts
+++ b/server/_shared/entitlement-check.ts
@@ -176,7 +176,7 @@ async function _getEntitlementsImpl(userId: string): Promise<CachedEntitlements 
 }
 
 /**
- * Checks whether the current request is allowed based on tier entitlements.
+ * Checks whether the resolved user is allowed based on tier entitlements.
  *
  * Returns:
  *   - null if the request is allowed (unrestricted endpoint or sufficient tier)
@@ -184,7 +184,7 @@ async function _getEntitlementsImpl(userId: string): Promise<CachedEntitlements 
  *     or the user's tier is below the required tier (fail-closed)
  */
 export async function checkEntitlement(
-  request: Request,
+  userId: string | null | undefined,
   pathname: string,
   corsHeaders: Record<string, string>,
 ): Promise<Response | null> {
@@ -194,9 +194,8 @@ export async function checkEntitlement(
     return null;
   }
 
-  // Extract userId from request header (set by session middleware).
-  // Fail-closed: if no userId on a gated endpoint, block the request.
-  const userId = request.headers.get('x-user-id');
+  // Gateway auth resolution owns user identity. Do not read identity from
+  // request headers here; inbound headers are client-controlled.
   if (!userId) {
     return new Response(
       JSON.stringify({ error: 'Authentication required', requiredTier }),

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -301,13 +301,32 @@ import { PREMIUM_RPC_PATHS } from '../src/shared/premium-paths';
  */
 export type GatewayCtx = { waitUntil: (p: Promise<unknown>) => void };
 
+const INTERNAL_USER_ID_HEADER = 'x-user-id';
+
+function cloneRequestWithHeaders(request: Request, headers: Headers): Request {
+  return new Request(request, { headers });
+}
+
+function stripClientUserIdHeader(request: Request): Request {
+  if (!request.headers.has(INTERNAL_USER_ID_HEADER)) return request;
+  const headers = new Headers(request.headers);
+  headers.delete(INTERNAL_USER_ID_HEADER);
+  return cloneRequestWithHeaders(request, headers);
+}
+
+function withAuthenticatedUserId(request: Request, userId: string): Request {
+  const headers = new Headers(request.headers);
+  headers.set(INTERNAL_USER_ID_HEADER, userId);
+  return cloneRequestWithHeaders(request, headers);
+}
+
 export function createDomainGateway(
   routes: RouteDescriptor[],
 ): (req: Request, ctx?: GatewayCtx) => Promise<Response> {
   const router = createRouter(routes);
 
   return async function handler(originalRequest: Request, ctx?: GatewayCtx): Promise<Response> {
-    let request = originalRequest;
+    let request = stripClientUserIdHeader(originalRequest);
     const rawPathname = new URL(request.url).pathname;
     const pathname = rawPathname.length > 1 ? rawPathname.replace(/\/+$/, '') : rawPathname;
     const t0 = Date.now();
@@ -412,15 +431,7 @@ export function createDomainGateway(
       usage.sessionUserId = sessionUserId;
       usage.clerkOrgId = session?.orgId ?? null;
       if (sessionUserId) {
-        request = new Request(request.url, {
-          method: request.method,
-          headers: (() => {
-            const h = new Headers(request.headers);
-            h.set('x-user-id', sessionUserId);
-            return h;
-          })(),
-          body: request.body,
-        });
+        request = withAuthenticatedUserId(request, sessionUserId);
       }
     }
 
@@ -457,15 +468,7 @@ export function createDomainGateway(
         if (!sessionUserId) {
           sessionUserId = userKeyResult.userId;
           usage.sessionUserId = sessionUserId;
-          request = new Request(request.url, {
-            method: request.method,
-            headers: (() => {
-              const h = new Headers(request.headers);
-              h.set('x-user-id', sessionUserId);
-              return h;
-            })(),
-            body: request.body,
-          });
+          request = withAuthenticatedUserId(request, sessionUserId);
         }
       }
     }
@@ -512,6 +515,7 @@ export function createDomainGateway(
           if (session.userId) {
             sessionUserId = session.userId;
             usage.sessionUserId = session.userId;
+            request = withAuthenticatedUserId(request, session.userId);
           }
           // Accept EITHER a Clerk 'pro' role OR a Convex Dodo entitlement with
           // tier >= 1. The Dodo webhook pipeline writes Convex entitlements but
@@ -566,7 +570,7 @@ export function createDomainGateway(
     // freely mintable by any caller and are NOT user-bound (PR #3557 review).
     const isEnterpriseAuth = keyCheck.valid && wmKey && !isUserApiKey && keyCheck.kind === 'enterprise';
     if (!isEnterpriseAuth) {
-      const entitlementResponse = await checkEntitlement(request, pathname, corsHeaders);
+      const entitlementResponse = await checkEntitlement(sessionUserId, pathname, corsHeaders);
       if (entitlementResponse) {
         const entReason: RequestReason =
           entitlementResponse.status === 401 ? 'auth_401'

--- a/tests/premium-stock-gateway.test.mts
+++ b/tests/premium-stock-gateway.test.mts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { createServer, type Server } from 'node:http';
-import { afterEach, describe, it, before, after, mock } from 'node:test';
+import { afterEach, describe, it, before, after } from 'node:test';
 import { generateKeyPair, exportJWK, SignJWT } from 'jose';
 
 import { createDomainGateway } from '../server/gateway.ts';
@@ -132,6 +132,28 @@ describe('premium gateway API key enforcement', () => {
       assert.notEqual(res.status, 200, `wms_ MUST NOT unlock ${path} (got ${res.status})`);
     }
   });
+
+  it('strips client-supplied x-user-id before route handlers (#3548)', async () => {
+    const handler = createDomainGateway([
+      {
+        method: 'GET',
+        path: '/api/market/v1/list-market-quotes',
+        handler: async (req) => new Response(JSON.stringify({ userId: req.headers.get('x-user-id') }), { status: 200 }),
+      },
+    ]);
+
+    const res = await handler(new Request('https://worldmonitor.app/api/market/v1/list-market-quotes?symbols=AAPL', {
+      headers: {
+        Origin: 'https://worldmonitor.app',
+        'X-WorldMonitor-Key': SESSION_TOKEN,
+        'x-user-id': 'victim-user',
+      },
+    }));
+
+    assert.equal(res.status, 200);
+    const body = await res.json() as { userId: string | null };
+    assert.equal(body.userId, null);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -186,7 +208,7 @@ describe('premium gateway bearer token auth', () => {
       {
         method: 'GET',
         path: '/api/resilience/v1/get-resilience-score',
-        handler: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+        handler: async (req) => new Response(JSON.stringify({ ok: true, userId: req.headers.get('x-user-id') }), { status: 200 }),
       },
       {
         method: 'GET',
@@ -328,5 +350,21 @@ describe('premium gateway bearer token auth', () => {
       },
     }));
     assert.equal(rankingRes.status, 200);
+  });
+
+  it('rewrites client-supplied x-user-id on legacy bearer auth (#3548)', async () => {
+    const token = await signToken({ sub: 'user_pro', plan: 'pro' });
+
+    const res = await handler(new Request('https://worldmonitor.app/api/resilience/v1/get-resilience-score?countryCode=US', {
+      headers: {
+        Origin: 'https://worldmonitor.app',
+        Authorization: `Bearer ${token}`,
+        'x-user-id': 'victim-user',
+      },
+    }));
+
+    assert.equal(res.status, 200);
+    const body = await res.json() as { userId: string | null };
+    assert.equal(body.userId, 'user_pro');
   });
 });


### PR DESCRIPTION
## Summary

Closes #3548. Treat `x-user-id` as a gateway-internal identity header only: the gateway now removes any client-supplied value at request entry, re-adds it only after authenticated identity resolution, and passes the resolved `userId` explicitly into entitlement checks.

## Root cause

`checkEntitlement()` previously read `x-user-id` from `Request.headers`. The gateway overwrote that header on the Clerk and `wm_` user-key paths, but the legacy bearer path only updated local telemetry state. That left a fragile trust boundary: a downstream entitlement check could accidentally consume a spoofed client-supplied `x-user-id` instead of the authenticated principal.

## Changes

- Strip inbound `x-user-id` once at the start of `createDomainGateway()`.
- Centralize authenticated `x-user-id` injection through a small gateway helper.
- Re-add `x-user-id` after legacy bearer auth resolves `session.userId`.
- Change `checkEntitlement()` to take the resolved `userId` directly instead of reading request headers.
- Update entitlement helper tests for the explicit-user contract.
- Add gateway regression tests for both client header stripping and legacy bearer header rewrite.

## Validation

- [x] `npx tsx --test tests/premium-stock-gateway.test.mts` — 12/12 pass
- [x] `npx vitest run server/__tests__/entitlement-check.test.ts` — 12/12 pass
- [x] `npm run typecheck:api` — pass
- [x] `npm run typecheck` — pass
- [x] `git diff --check -- server/gateway.ts server/_shared/entitlement-check.ts server/__tests__/entitlement-check.test.ts tests/premium-stock-gateway.test.mts` — pass
- [x] `npx biome lint server/gateway.ts server/_shared/entitlement-check.ts server/__tests__/entitlement-check.test.ts tests/premium-stock-gateway.test.mts` — exits 0; reports the existing gateway complexity warning and existing optional-chain suggestion in `server/gateway.ts`

## Risk

Low behavioral risk for legitimate callers: the gateway still provides `x-user-id` to downstream route handlers after Clerk, user API key, or legacy bearer auth succeeds. The main compatibility risk is any handler that incorrectly relied on a client-supplied `x-user-id`; that path should now fail closed instead of granting entitlements on untrusted input.
