### PR TITLE
fix(sidecar): block private targets in global fetch

### DIFF
--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -18,6 +18,7 @@ const brotliCompressAsync = promisify(brotliCompress);
 // IPv6 endpoints time out, causing ETIMEDOUT. This override ensures ALL
 // fetch() calls in dynamically-loaded handler modules (api/*.js) use IPv4.
 const _originalFetch = globalThis.fetch;
+const ALLOW_PRIVATE_NETWORK_FETCH = Symbol('worldmonitor.allowPrivateNetworkFetch');
 const sidecarAllowedPrivateFetchOrigins = new Set();
 
 function normalizeRequestBody(body) {
@@ -105,15 +106,6 @@ function redactUrlForLog(rawUrl) {
   }
 }
 
-async function _privilegedFetch(...args) {
-  await acquireUpstreamSlot();
-  try {
-    return await _originalFetch(...args);
-  } finally {
-    releaseUpstreamSlot();
-  }
-}
-
 function makeSsrfBlockedError(reason, rawUrl) {
   const error = new Error(`SSRF blocked: ${reason} (url=${redactUrlForLog(rawUrl)})`);
   error.code = 'ERR_SSRF_BLOCKED';
@@ -168,7 +160,10 @@ globalThis.fetch = async function ipv4Fetch(input, init) {
   let url;
   try { url = new URL(typeof input === 'string' ? input : input.url); } catch { return _originalFetch(input, init); }
   if (url.protocol !== 'https:' && url.protocol !== 'http:') return _originalFetch(input, init);
-  const safety = await assertSafeSidecarFetchUrl(url);
+  const allowPrivateNetwork = init?.[ALLOW_PRIVATE_NETWORK_FETCH] === true;
+  const safety = allowPrivateNetwork
+    ? { safe: true, resolvedAddresses: [url.hostname] }
+    : await assertSafeSidecarFetchUrl(url);
   if (url.hostname.includes('finance.yahoo.com')) await sidecarYahooGate();
   await acquireUpstreamSlot();
   try {
@@ -772,8 +767,9 @@ async function fetchWithTimeout(url, options = {}, timeoutMs = 12000) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    const fetchImpl = allowPrivateNetwork ? _privilegedFetch : fetch;
-    return await fetchImpl(fetchUrl, { ...fetchOptions, headers: fetchHeaders, signal: controller.signal });
+    const requestOptions = { ...fetchOptions, headers: fetchHeaders, signal: controller.signal };
+    if (allowPrivateNetwork) requestOptions[ALLOW_PRIVATE_NETWORK_FETCH] = true;
+    return await fetch(fetchUrl, requestOptions);
   } finally {
     clearTimeout(timer);
   }

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -232,6 +232,36 @@ const CHROME_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/5
 // Block requests to private/reserved IP ranges to prevent the RSS proxy
 // from being used as a localhost pivot or internal network scanner.
 
+function ipv4ToInt(parts) {
+  return (
+    ((parts[0] << 24) >>> 0) +
+    (parts[1] << 16) +
+    (parts[2] << 8) +
+    parts[3]
+  ) >>> 0;
+}
+
+const BLOCKED_IPV4_RANGES = [
+  ['0.0.0.0', 8],       // "this" network
+  ['10.0.0.0', 8],      // RFC1918 private
+  ['100.64.0.0', 10],   // carrier-grade NAT
+  ['127.0.0.0', 8],     // loopback
+  ['169.254.0.0', 16],  // link-local
+  ['172.16.0.0', 12],   // RFC1918 private
+  ['192.0.0.0', 24],    // IETF protocol assignments
+  ['192.0.2.0', 24],    // documentation
+  ['192.88.99.0', 24],  // deprecated 6to4 relay anycast
+  ['192.168.0.0', 16],  // RFC1918 private
+  ['198.18.0.0', 15],   // benchmark testing
+  ['198.51.100.0', 24], // documentation
+  ['203.0.113.0', 24],  // documentation
+  ['224.0.0.0', 3],     // multicast, reserved, limited broadcast
+].map(([base, prefix]) => {
+  const baseInt = ipv4ToInt(base.split('.').map(Number));
+  const mask = prefix === 0 ? 0 : (0xffffffff << (32 - prefix)) >>> 0;
+  return [baseInt, mask];
+});
+
 function isPrivateIP(ip) {
   // IPv4-mapped IPv6 — extract the v4 portion
   const v4Mapped = ip.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
@@ -246,17 +276,12 @@ function isPrivateIP(ip) {
   if (/^ff[0-9a-f]{2}:/i.test(addr)) return true;      // ff00::/8 multicast
 
   const parts = addr.split('.').map(Number);
-  if (parts.length !== 4 || parts.some(p => Number.isNaN(p))) return false; // not an IPv4
+  if (parts.length !== 4 || parts.some(p => !Number.isInteger(p) || p < 0 || p > 255)) return false; // not an IPv4
 
-  const [a, b] = parts;
-  if (a === 127) return true;                       // 127.0.0.0/8  loopback
-  if (a === 10) return true;                        // 10.0.0.0/8   private
-  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 private
-  if (a === 192 && b === 168) return true;           // 192.168.0.0/16 private
-  if (a === 169 && b === 254) return true;           // 169.254.0.0/16 link-local
-  if (a === 0) return true;                          // 0.0.0.0/8
-  if (a >= 224) return true;                         // 224.0.0.0+ multicast/reserved
-  return false;
+  const ipInt = ipv4ToInt(parts);
+  return BLOCKED_IPV4_RANGES.some(([baseInt, mask]) => {
+    return (ipInt & mask) === (baseInt & mask);
+  });
 }
 
 async function isSafeUrl(urlString) {

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -116,6 +116,23 @@ function firstIPv4Address(addresses = []) {
   return addresses.find((addr) => isIP(addr) === 4) ?? null;
 }
 
+function firstIPv6Address(addresses = []) {
+  return addresses.find((addr) => isIP(addr) === 6) ?? null;
+}
+
+// IPv4-first, IPv6 fallback. Returning the family alongside the address lets
+// the caller pin both the lookup callback AND http(s).request({ family })
+// to the same family — otherwise an IPv6-only public hostname would be
+// validated against AAAA records but reconnected under family:4 by the OS,
+// reopening the TOCTOU window the pinned lookup is meant to close.
+function pickPinnedAddress(addresses = []) {
+  const v4 = firstIPv4Address(addresses);
+  if (v4) return { address: v4, family: 4 };
+  const v6 = firstIPv6Address(addresses);
+  if (v6) return { address: v6, family: 6 };
+  return null;
+}
+
 function makePinnedLookup(address, family = 4) {
   return (_hostname, options, callback) => {
     const cb = typeof options === 'function' ? options : callback;
@@ -177,17 +194,20 @@ globalThis.fetch = async function ipv4Fetch(input, init) {
         : Array.isArray(rawHeaders) ? Object.fromEntries(rawHeaders) : rawHeaders;
       Object.assign(headers, h);
     }
+    const pinned = isAllowedPrivateSidecarFetch(url) ? null : pickPinnedAddress(safety.resolvedAddresses);
     const requestOptions = {
       hostname: url.hostname,
       port: url.port || (url.protocol === 'https:' ? 443 : 80),
       path: url.pathname + url.search,
       method,
       headers,
-      family: 4,
+      // Default to IPv4 (broken-IPv6 servers like EIA/NASA FIRMS); when we
+      // pinned a specific address, use its family so http(s).request and the
+      // lookup callback agree.
+      family: pinned?.family ?? 4,
     };
-    const pinnedV4 = isAllowedPrivateSidecarFetch(url) ? null : firstIPv4Address(safety.resolvedAddresses);
-    if (pinnedV4) {
-      requestOptions.lookup = makePinnedLookup(pinnedV4, 4);
+    if (pinned) {
+      requestOptions.lookup = makePinnedLookup(pinned.address, pinned.family);
     }
     return await new Promise((resolve, reject) => {
       const req = mod.request(requestOptions, (res) => {
@@ -628,6 +648,15 @@ async function importHandler(modulePath) {
   }
 }
 
+function remoteBaseLooksPrivate(remoteBase) {
+  let parsed;
+  try { parsed = new URL(remoteBase); } catch { return false; }
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, '');
+  if (hostname === 'localhost') return true;
+  if (isIP(hostname)) return isPrivateIP(hostname);
+  return false;
+}
+
 function resolveConfig(options = {}) {
   const port = Number(options.port ?? process.env.LOCAL_API_PORT ?? 46123);
   const remoteBase = String(options.remoteBase ?? process.env.LOCAL_API_REMOTE_BASE ?? 'https://api.worldmonitor.app').replace(/\/$/, '');
@@ -644,10 +673,23 @@ function resolveConfig(options = {}) {
   const cloudFallback = mode === 'docker' ? false : requestedFallback;
   // Programmatic dev/test escape hatch only; CLI/env startup keeps private remoteBase blocked.
   const allowPrivateRemoteBase = options.allowPrivateRemoteBase === true;
-  if (mode === 'docker' && requestedFallback) {
-    (options.logger ?? console).warn('[local-api] Cloud fallback disabled in Docker mode (self-hosted instances must not proxy to api.worldmonitor.app)');
-  }
+  // Programmatic-only test escape hatch for adding extra origins to the
+  // private-fetch allowlist (e.g. distinct upstream test servers). Mirrors
+  // allowPrivateRemoteBase: no env-var path, so production startup can't
+  // widen the SSRF boundary by accident.
+  const allowPrivateFetchOrigins = Array.isArray(options.allowPrivateFetchOrigins)
+    ? options.allowPrivateFetchOrigins.filter((o) => typeof o === 'string' && o.length > 0)
+    : [];
   const logger = options.logger ?? console;
+  if (mode === 'docker' && requestedFallback) {
+    logger.warn('[local-api] Cloud fallback disabled in Docker mode (self-hosted instances must not proxy to api.worldmonitor.app)');
+  }
+  if (cloudFallback && !allowPrivateRemoteBase && remoteBaseLooksPrivate(remoteBase)) {
+    logger.warn(
+      `[local-api] cloudFallback enabled but remoteBase=${remoteBase} is private/loopback; ` +
+      'requests will be blocked by SSRF protection. Pass allowPrivateRemoteBase=true programmatically for dev/test.'
+    );
+  }
 
   return {
     port,
@@ -658,6 +700,7 @@ function resolveConfig(options = {}) {
     mode,
     cloudFallback,
     allowPrivateRemoteBase,
+    allowPrivateFetchOrigins,
     logger,
   };
 }
@@ -701,7 +744,17 @@ async function tryCloudFallback(requestUrl, req, context, reason) {
     }
     return resp;
   } catch (error) {
-    context.logger.error('[local-api] cloud fallback failed', requestUrl.pathname, error);
+    if (error?.code === 'ERR_SSRF_BLOCKED') {
+      // error.message already carries "SSRF blocked: <reason> (url=<redacted>)".
+      // Surface the actionable remediation so a misconfigured LOCAL_API_REMOTE_BASE
+      // doesn't read as a vague 5xx.
+      context.logger.error(
+        `[local-api] cloud fallback blocked by SSRF protection for ${requestUrl.pathname}: ${error.message}. ` +
+        'If remoteBase intentionally points at a private/loopback host, pass allowPrivateRemoteBase=true programmatically.'
+      );
+    } else {
+      context.logger.error('[local-api] cloud fallback failed', requestUrl.pathname, error);
+    }
     return null;
   }
 }
@@ -1669,6 +1722,9 @@ export async function createLocalApiServer(options = {}) {
       const extraAllowedPrivateOrigins = [];
       if (context.allowPrivateRemoteBase) {
         try { extraAllowedPrivateOrigins.push(new URL(context.remoteBase).origin); } catch {}
+      }
+      for (const origin of context.allowPrivateFetchOrigins) {
+        try { extraAllowedPrivateOrigins.push(new URL(origin).origin); } catch {}
       }
       unregisterSelfFetchOrigins = registerSidecarAllowedPrivateFetchOrigins(boundPort, extraAllowedPrivateOrigins);
 

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -4,6 +4,7 @@ import https from 'node:https';
 import dns from 'node:dns/promises';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { readdir } from 'node:fs/promises';
+import { isIP } from 'node:net';
 import { promisify } from 'node:util';
 import { brotliCompress, gzipSync } from 'node:zlib';
 import path from 'node:path';
@@ -17,6 +18,7 @@ const brotliCompressAsync = promisify(brotliCompress);
 // IPv6 endpoints time out, causing ETIMEDOUT. This override ensures ALL
 // fetch() calls in dynamically-loaded handler modules (api/*.js) use IPv4.
 const _originalFetch = globalThis.fetch;
+const sidecarAllowedPrivateFetchOrigins = new Set();
 
 function normalizeRequestBody(body) {
   if (body == null) return null;
@@ -90,11 +92,83 @@ function sidecarYahooGate() {
   return _yahooQueue;
 }
 
+function redactUrlForLog(rawUrl) {
+  try {
+    const redacted = new URL(String(rawUrl));
+    redacted.username = '';
+    redacted.password = '';
+    redacted.search = '';
+    redacted.hash = '';
+    return redacted.toString();
+  } catch {
+    return String(rawUrl);
+  }
+}
+
+async function _privilegedFetch(...args) {
+  await acquireUpstreamSlot();
+  try {
+    return await _originalFetch(...args);
+  } finally {
+    releaseUpstreamSlot();
+  }
+}
+
+function makeSsrfBlockedError(reason, rawUrl) {
+  const error = new Error(`SSRF blocked: ${reason} (url=${redactUrlForLog(rawUrl)})`);
+  error.code = 'ERR_SSRF_BLOCKED';
+  return error;
+}
+
+function firstIPv4Address(addresses = []) {
+  return addresses.find((addr) => isIP(addr) === 4) ?? null;
+}
+
+function makePinnedLookup(address, family = 4) {
+  return (_hostname, options, callback) => {
+    const cb = typeof options === 'function' ? options : callback;
+    const lookupOptions = typeof options === 'object' && options !== null ? options : {};
+    queueMicrotask(() => {
+      if (lookupOptions.all) cb(null, [{ address, family }]);
+      else cb(null, address, family);
+    });
+  };
+}
+
+function registerSidecarAllowedPrivateFetchOrigins(port, extraOrigins = []) {
+  const origins = [
+    `http://127.0.0.1:${port}`,
+    `http://localhost:${port}`,
+    ...extraOrigins,
+  ];
+  for (const origin of origins) sidecarAllowedPrivateFetchOrigins.add(origin);
+  return () => {
+    for (const origin of origins) sidecarAllowedPrivateFetchOrigins.delete(origin);
+  };
+}
+
+function isAllowedPrivateSidecarFetch(url) {
+  return sidecarAllowedPrivateFetchOrigins.has(url.origin);
+}
+
+async function assertSafeSidecarFetchUrl(url) {
+  if (isAllowedPrivateSidecarFetch(url)) {
+    return { safe: true, resolvedAddresses: [url.hostname] };
+  }
+
+  const safety = await isSafeUrl(url.toString());
+  if (!safety.safe) {
+    throw makeSsrfBlockedError(safety.reason, url.toString());
+  }
+  return safety;
+}
+
 globalThis.fetch = async function ipv4Fetch(input, init) {
   const isRequest = input && typeof input === 'object' && 'url' in input;
   let url;
   try { url = new URL(typeof input === 'string' ? input : input.url); } catch { return _originalFetch(input, init); }
   if (url.protocol !== 'https:' && url.protocol !== 'http:') return _originalFetch(input, init);
+  const safety = await assertSafeSidecarFetchUrl(url);
   if (url.hostname.includes('finance.yahoo.com')) await sidecarYahooGate();
   await acquireUpstreamSlot();
   try {
@@ -108,8 +182,20 @@ globalThis.fetch = async function ipv4Fetch(input, init) {
         : Array.isArray(rawHeaders) ? Object.fromEntries(rawHeaders) : rawHeaders;
       Object.assign(headers, h);
     }
+    const requestOptions = {
+      hostname: url.hostname,
+      port: url.port || (url.protocol === 'https:' ? 443 : 80),
+      path: url.pathname + url.search,
+      method,
+      headers,
+      family: 4,
+    };
+    const pinnedV4 = isAllowedPrivateSidecarFetch(url) ? null : firstIPv4Address(safety.resolvedAddresses);
+    if (pinnedV4) {
+      requestOptions.lookup = makePinnedLookup(pinnedV4, 4);
+    }
     return await new Promise((resolve, reject) => {
-      const req = mod.request({ hostname: url.hostname, port: url.port || (url.protocol === 'https:' ? 443 : 80), path: url.pathname + url.search, method, headers, family: 4 }, (res) => {
+      const req = mod.request(requestOptions, (res) => {
         const chunks = [];
         res.on('data', (c) => chunks.push(c));
         res.on('end', () => {
@@ -162,9 +248,10 @@ function isPrivateIP(ip) {
   // IPv6 link-local / unique-local
   if (/^f[cd][0-9a-f]{2}:/i.test(addr)) return true; // fc00::/7 (ULA)
   if (/^fe[89ab][0-9a-f]:/i.test(addr)) return true;  // fe80::/10 (link-local)
+  if (/^ff[0-9a-f]{2}:/i.test(addr)) return true;      // ff00::/8 multicast
 
   const parts = addr.split('.').map(Number);
-  if (parts.length !== 4 || parts.some(p => isNaN(p))) return false; // not an IPv4
+  if (parts.length !== 4 || parts.some(p => Number.isNaN(p))) return false; // not an IPv4
 
   const [a, b] = parts;
   if (a === 127) return true;                       // 127.0.0.0/8  loopback
@@ -206,6 +293,9 @@ async function isSafeUrl(urlString) {
   const ipLiteral = hostname.replace(/^\[|\]$/g, '');
   if (isPrivateIP(ipLiteral)) {
     return { safe: false, reason: 'Requests to private/reserved IP addresses are not allowed' };
+  }
+  if (isIP(ipLiteral)) {
+    return { safe: true, resolvedAddresses: [ipLiteral] };
   }
 
   // DNS resolution check — resolve the hostname and verify all resolved IPs
@@ -532,6 +622,8 @@ function resolveConfig(options = {}) {
   const mode = String(options.mode ?? process.env.LOCAL_API_MODE ?? 'desktop-sidecar');
   const requestedFallback = String(options.cloudFallback ?? process.env.LOCAL_API_CLOUD_FALLBACK ?? '') === 'true';
   const cloudFallback = mode === 'docker' ? false : requestedFallback;
+  // Programmatic dev/test escape hatch only; CLI/env startup keeps private remoteBase blocked.
+  const allowPrivateRemoteBase = options.allowPrivateRemoteBase === true;
   if (mode === 'docker' && requestedFallback) {
     (options.logger ?? console).warn('[local-api] Cloud fallback disabled in Docker mode (self-hosted instances must not proxy to api.worldmonitor.app)');
   }
@@ -545,6 +637,7 @@ function resolveConfig(options = {}) {
     apiDir,
     mode,
     cloudFallback,
+    allowPrivateRemoteBase,
     logger,
   };
 }
@@ -624,20 +717,23 @@ async function fetchWithTimeout(url, options = {}, timeoutMs = 12000) {
   // Use node:https with IPv4 forced — Node.js built-in fetch (undici) tries IPv6
   // first and some servers (EIA, NASA FIRMS) have broken IPv6 causing ETIMEDOUT.
   const u = new URL(url);
+  const allowPrivateNetwork = options.allowPrivateNetwork === true;
+  const fetchOptions = { ...options };
+  delete fetchOptions.allowPrivateNetwork;
   if (u.protocol === 'https:') {
     return new Promise((resolve, reject) => {
       const reqOpts = {
         hostname: u.hostname,
         port: u.port || 443,
         path: u.pathname + u.search,
-        method: options.method || 'GET',
-        headers: options.headers || {},
+        method: fetchOptions.method || 'GET',
+        headers: fetchOptions.headers || {},
         family: 4,
       };
       // Pin to a pre-resolved IP to prevent TOCTOU DNS rebinding.
       // The hostname is kept for SNI / TLS certificate validation.
-      if (options.resolvedAddress) {
-        reqOpts.lookup = (_hostname, _opts, cb) => cb(null, options.resolvedAddress, 4);
+      if (fetchOptions.resolvedAddress) {
+        reqOpts.lookup = makePinnedLookup(fetchOptions.resolvedAddress, 4);
       }
       const req = https.request(reqOpts, (res) => {
         const chunks = [];
@@ -655,8 +751,8 @@ async function fetchWithTimeout(url, options = {}, timeoutMs = 12000) {
       });
       req.on('error', reject);
       req.setTimeout(timeoutMs, () => { req.destroy(new Error('Request timed out')); });
-      if (options.body) {
-        const body = normalizeRequestBody(options.body);
+      if (fetchOptions.body) {
+        const body = normalizeRequestBody(fetchOptions.body);
         if (body != null) req.write(body);
       }
       req.end();
@@ -666,17 +762,18 @@ async function fetchWithTimeout(url, options = {}, timeoutMs = 12000) {
   // For pinned addresses on plain HTTP, rewrite the URL to connect to the
   // validated IP and set the Host header so virtual-host routing still works.
   let fetchUrl = url;
-  const fetchHeaders = { ...(options.headers || {}) };
-  if (options.resolvedAddress && u.protocol === 'http:') {
+  const fetchHeaders = { ...(fetchOptions.headers || {}) };
+  if (fetchOptions.resolvedAddress && u.protocol === 'http:') {
     const pinned = new URL(url);
     fetchHeaders['Host'] = pinned.host;
-    pinned.hostname = options.resolvedAddress;
+    pinned.hostname = fetchOptions.resolvedAddress;
     fetchUrl = pinned.toString();
   }
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
-    return await fetch(fetchUrl, { ...options, headers: fetchHeaders, signal: controller.signal });
+    const fetchImpl = allowPrivateNetwork ? _privilegedFetch : fetch;
+    return await fetchImpl(fetchUrl, { ...fetchOptions, headers: fetchHeaders, signal: controller.signal });
   } finally {
     clearTimeout(timer);
   }
@@ -931,12 +1028,12 @@ async function validateSecretAgainstProvider(key, rawValue, context = {}) {
       } catch {
         return fail('Invalid URL');
       }
-      const response = await fetchWithTimeout(probeUrl, { method: 'GET' }, 8000);
+      const response = await fetchWithTimeout(probeUrl, { method: 'GET', allowPrivateNetwork: true }, 8000);
       if (!response.ok) {
         // Fall back to native Ollama /api/tags endpoint
         try {
           const tagsUrl = new URL('/api/tags', value).toString();
-          const tagsResponse = await fetchWithTimeout(tagsUrl, { method: 'GET' }, 8000);
+          const tagsResponse = await fetchWithTimeout(tagsUrl, { method: 'GET', allowPrivateNetwork: true }, 8000);
           if (!tagsResponse.ok) return fail(`Ollama probe failed (${tagsResponse.status})`);
           return ok('Ollama endpoint verified (native API)');
         } catch {
@@ -1154,8 +1251,13 @@ async function dispatch(requestUrl, req, routes, context) {
   // TODO: refactor to import getLlmHealthStatus() once handlers share a process-level module cache.
   if (requestUrl.pathname === '/api/llm-health') {
     const PROBE_TIMEOUT = 2000;
-    async function probeOrigin(url) {
-      try { await fetch(url, { method: 'GET', signal: AbortSignal.timeout(PROBE_TIMEOUT) }); return true; } catch { return false; }
+    async function probeOrigin(url, options = {}) {
+      try {
+        await fetchWithTimeout(url, { method: 'GET', allowPrivateNetwork: options.allowPrivateNetwork === true }, PROBE_TIMEOUT);
+        return true;
+      } catch {
+        return false;
+      }
     }
     const providers = [];
     const providerChecks = [];
@@ -1167,11 +1269,11 @@ async function dispatch(requestUrl, req, routes, context) {
       try {
         const origin = new URL(ollamaUrl).origin;
         providerChecks.push(
-          probeOrigin(origin).then((available) => ({ name: 'ollama', url: origin, available })),
+          probeOrigin(origin, { allowPrivateNetwork: true }).then((available) => ({ name: 'ollama', url: origin, available })),
         );
       } catch {}
     }
-    if (groqKey && groqKey.startsWith('gsk_')) {
+    if (groqKey?.startsWith('gsk_')) {
       providerChecks.push(
         probeOrigin('https://api.groq.com').then((available) => ({ name: 'groq', url: 'https://api.groq.com', available })),
       );
@@ -1449,6 +1551,7 @@ export async function createLocalApiServer(options = {}) {
   const context = resolveConfig(options);
   loadVerboseState(context.dataDir);
   const routes = await buildRouteTable(context.apiDir);
+  let unregisterSelfFetchOrigins = null;
 
   const server = createServer(async (req, res) => {
     const requestUrl = new URL(req.url || '/', `http://127.0.0.1:${context.port}`);
@@ -1542,6 +1645,11 @@ export async function createLocalApiServer(options = {}) {
       const address = server.address();
       const boundPort = typeof address === 'object' && address?.port ? address.port : context.port;
       context.port = boundPort;
+      const extraAllowedPrivateOrigins = [];
+      if (context.allowPrivateRemoteBase) {
+        try { extraAllowedPrivateOrigins.push(new URL(context.remoteBase).origin); } catch {}
+      }
+      unregisterSelfFetchOrigins = registerSidecarAllowedPrivateFetchOrigins(boundPort, extraAllowedPrivateOrigins);
 
       const portFile = process.env.LOCAL_API_PORT_FILE;
       if (portFile) {
@@ -1558,7 +1666,8 @@ export async function createLocalApiServer(options = {}) {
           process.env.OPENROUTER_API_KEY ? 'https://openrouter.ai' : null,
         ].filter(Boolean);
         for (const url of urls) {
-          try { await fetch(url, { method: 'GET', signal: AbortSignal.timeout(2000) }); } catch {}
+          const allowPrivateNetwork = url === process.env.OLLAMA_API_URL || url === process.env.LLM_API_URL;
+          try { await fetchWithTimeout(url, { method: 'GET', allowPrivateNetwork }, 2000); } catch {}
         }
         if (urls.length) console.log(`[local-api] LLM health warmed for ${urls.length} provider(s)`);
       })();
@@ -1566,6 +1675,10 @@ export async function createLocalApiServer(options = {}) {
       return { port: boundPort };
     },
     async close() {
+      if (unregisterSelfFetchOrigins) {
+        unregisterSelfFetchOrigins();
+        unregisterSelfFetchOrigins = null;
+      }
       await new Promise((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));
       });

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -415,16 +415,25 @@ test('replaces browser origin with localhost origin for local handlers', async (
 });
 
 test('preserves Request body when handler uses fetch(Request)', async () => {
+  // Use a DISTINCT upstream server (not the sidecar itself) so this test
+  // exercises real "handler proxies to external host" semantics. The upstream
+  // is on 127.0.0.1, so it must be opted into the SSRF allowlist via
+  // allowPrivateFetchOrigins — production startup has no such opt-in.
+  let receivedBody = '';
+  const upstream = createServer((req, res) => {
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => {
+      receivedBody = Buffer.concat(chunks).toString('utf8');
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ receivedBody }));
+    });
+  });
+  const upstreamPort = await listen(upstream);
+  const upstreamOrigin = `http://127.0.0.1:${upstreamPort}`;
+  process.env.WM_TEST_UPSTREAM = `${upstreamOrigin}/echo`;
+
   const localApi = await setupApiDir({
-    'echo-body.js': `
-      export default async function handler(request) {
-        const receivedBody = await request.text();
-        return new Response(JSON.stringify({ receivedBody }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' }
-        });
-      }
-    `,
     'request-proxy.js': `
       export default async function handler() {
         const request = new Request(process.env.WM_TEST_UPSTREAM, {
@@ -445,34 +454,39 @@ test('preserves Request body when handler uses fetch(Request)', async () => {
   const app = await createLocalApiServer({
     port: 0,
     apiDir: localApi.apiDir,
+    allowPrivateFetchOrigins: [upstreamOrigin],
     logger: { log() { }, warn() { }, error() { } },
   });
   const { port } = await app.start();
-  process.env.WM_TEST_UPSTREAM = `http://127.0.0.1:${port}/api/echo-body`;
 
   try {
     const response = await fetch(`http://127.0.0.1:${port}/api/request-proxy`);
     assert.equal(response.status, 200);
     const body = await response.json();
     assert.equal(body.receivedBody.includes('"secret":"keep-body"'), true);
+    assert.equal(receivedBody.includes('"secret":"keep-body"'), true);
   } finally {
     delete process.env.WM_TEST_UPSTREAM;
     await app.close();
     await localApi.cleanup();
+    await new Promise((resolve, reject) => {
+      upstream.close((error) => (error ? reject(error) : resolve()));
+    });
   }
 });
 
 test('returns local handler error when fetch(Request) uses a consumed body', async () => {
+  let upstreamHits = 0;
+  const upstream = createServer((_req, res) => {
+    upstreamHits += 1;
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  });
+  const upstreamPort = await listen(upstream);
+  const upstreamOrigin = `http://127.0.0.1:${upstreamPort}`;
+  process.env.WM_TEST_UPSTREAM = `${upstreamOrigin}/echo`;
+
   const localApi = await setupApiDir({
-    'echo-body.js': `
-      export default async function handler(request) {
-        const receivedBody = await request.text();
-        return new Response(JSON.stringify({ receivedBody }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' }
-        });
-      }
-    `,
     'request-consumed.js': `
       export default async function handler() {
         const request = new Request(process.env.WM_TEST_UPSTREAM, {
@@ -493,10 +507,10 @@ test('returns local handler error when fetch(Request) uses a consumed body', asy
   const app = await createLocalApiServer({
     port: 0,
     apiDir: localApi.apiDir,
+    allowPrivateFetchOrigins: [upstreamOrigin],
     logger: { log() { }, warn() { }, error() { } },
   });
   const { port } = await app.start();
-  process.env.WM_TEST_UPSTREAM = `http://127.0.0.1:${port}/api/echo-body`;
 
   try {
     const response = await fetch(`http://127.0.0.1:${port}/api/request-consumed`);
@@ -505,10 +519,14 @@ test('returns local handler error when fetch(Request) uses a consumed body', asy
     assert.equal(body.error, 'Local handler error');
     assert.equal(typeof body.reason, 'string');
     assert.equal(body.reason.length > 0, true);
+    assert.equal(upstreamHits, 0);
   } finally {
     delete process.env.WM_TEST_UPSTREAM;
     await app.close();
     await localApi.cleanup();
+    await new Promise((resolve, reject) => {
+      upstream.close((error) => (error ? reject(error) : resolve()));
+    });
   }
 });
 

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -561,6 +561,75 @@ test('blocks handler global fetches to private network targets (#3549)', async (
   }
 });
 
+test('blocks handler global fetches to non-global IPv4 special ranges', async () => {
+  const originalHttpRequest = http.request;
+  const blockedUrls = [
+    'http://100.64.0.1/secret',
+    'http://198.18.0.1/secret',
+    'http://192.0.0.1/secret',
+    'http://192.0.2.1/secret',
+    'http://192.88.99.1/secret',
+    'http://198.51.100.1/secret',
+    'http://203.0.113.1/secret',
+    'http://240.0.0.1/secret',
+  ];
+  let outboundHits = 0;
+
+  http.request = (options, onResponse) => {
+    if (options.hostname === '127.0.0.1') {
+      return originalHttpRequest.call(http, options, onResponse);
+    }
+
+    outboundHits += 1;
+    const req = new EventEmitter();
+    req.setTimeout = () => {};
+    req.write = () => {};
+    req.destroy = (error) => {
+      if (error) req.emit('error', error);
+    };
+    req.end = () => {
+      setImmediate(() => req.emit('error', new Error(`unexpected outbound request to ${options.hostname}`)));
+    };
+    return req;
+  };
+
+  const localApi = await setupApiDir({
+    'special-range-proxy.js': `
+      export default async function handler(request) {
+        const url = new URL(request.url);
+        const upstream = await fetch(url.searchParams.get('target'));
+        const payload = await upstream.text();
+        return new Response(payload, {
+          status: upstream.status,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+    `,
+  });
+
+  const app = await createLocalApiServer({
+    port: 0,
+    apiDir: localApi.apiDir,
+    logger: { log() { }, warn() { }, error() { } },
+  });
+  const { port } = await app.start();
+
+  try {
+    for (const blockedUrl of blockedUrls) {
+      const response = await fetch(`http://127.0.0.1:${port}/api/special-range-proxy?target=${encodeURIComponent(blockedUrl)}`);
+      assert.equal(response.status, 502, blockedUrl);
+      const body = await response.json();
+      assert.equal(body.error, 'Local handler error', blockedUrl);
+      assert.match(body.reason, /SSRF blocked/, blockedUrl);
+    }
+    assert.equal(outboundHits, 0);
+  } finally {
+    http.request = originalHttpRequest;
+    await app.close();
+    await localApi.cleanup();
+  }
+});
+
 test('uses asynchronous pinned lookup callback for handler global fetches (#3549)', async () => {
   const originalHttpsRequest = https.request;
   const envSnapshot = {

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -210,6 +210,7 @@ test('falls back to cloud when cloudFallback is enabled and local handler return
     apiDir: localApi.apiDir,
     remoteBase: remote.remoteBase,
     cloudFallback: 'true',
+    allowPrivateRemoteBase: true,
     logger: { log() { }, warn() { }, error() { } },
   });
   const { port } = await app.start();
@@ -258,6 +259,7 @@ test('preserves POST body when cloud fallback is triggered after local non-OK re
     apiDir: localApi.apiDir,
     remoteBase: `http://127.0.0.1:${remotePort}`,
     cloudFallback: 'true',
+    allowPrivateRemoteBase: true,
     logger: { log() { }, warn() { }, error() { } },
   });
   const { port } = await app.start();
@@ -390,24 +392,19 @@ test('replaces browser origin with localhost origin for local handlers', async (
 });
 
 test('preserves Request body when handler uses fetch(Request)', async () => {
-  let receivedBody = '';
-
-  const upstream = createServer((req, res) => {
-    const chunks = [];
-    req.on('data', (chunk) => chunks.push(chunk));
-    req.on('end', () => {
-      receivedBody = Buffer.concat(chunks).toString('utf8');
-      res.writeHead(200, { 'content-type': 'application/json' });
-      res.end(JSON.stringify({ receivedBody }));
-    });
-  });
-  const upstreamPort = await listen(upstream);
-  process.env.WM_TEST_UPSTREAM = `http://127.0.0.1:${upstreamPort}`;
-
   const localApi = await setupApiDir({
+    'echo-body.js': `
+      export default async function handler(request) {
+        const receivedBody = await request.text();
+        return new Response(JSON.stringify({ receivedBody }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        });
+      }
+    `,
     'request-proxy.js': `
       export default async function handler() {
-        const request = new Request(\`\${process.env.WM_TEST_UPSTREAM}/echo\`, {
+        const request = new Request(process.env.WM_TEST_UPSTREAM, {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify({ secret: 'keep-body' }),
@@ -428,38 +425,34 @@ test('preserves Request body when handler uses fetch(Request)', async () => {
     logger: { log() { }, warn() { }, error() { } },
   });
   const { port } = await app.start();
+  process.env.WM_TEST_UPSTREAM = `http://127.0.0.1:${port}/api/echo-body`;
 
   try {
     const response = await fetch(`http://127.0.0.1:${port}/api/request-proxy`);
     assert.equal(response.status, 200);
     const body = await response.json();
     assert.equal(body.receivedBody.includes('"secret":"keep-body"'), true);
-    assert.equal(receivedBody.includes('"secret":"keep-body"'), true);
   } finally {
     delete process.env.WM_TEST_UPSTREAM;
     await app.close();
     await localApi.cleanup();
-    await new Promise((resolve, reject) => {
-      upstream.close((error) => (error ? reject(error) : resolve()));
-    });
   }
 });
 
 test('returns local handler error when fetch(Request) uses a consumed body', async () => {
-  let upstreamHits = 0;
-
-  const upstream = createServer((req, res) => {
-    upstreamHits += 1;
-    res.writeHead(200, { 'content-type': 'application/json' });
-    res.end(JSON.stringify({ ok: true }));
-  });
-  const upstreamPort = await listen(upstream);
-  process.env.WM_TEST_UPSTREAM = `http://127.0.0.1:${upstreamPort}`;
-
   const localApi = await setupApiDir({
+    'echo-body.js': `
+      export default async function handler(request) {
+        const receivedBody = await request.text();
+        return new Response(JSON.stringify({ receivedBody }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' }
+        });
+      }
+    `,
     'request-consumed.js': `
       export default async function handler() {
-        const request = new Request(\`\${process.env.WM_TEST_UPSTREAM}/echo\`, {
+        const request = new Request(process.env.WM_TEST_UPSTREAM, {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify({ secret: 'used-body' }),
@@ -480,6 +473,7 @@ test('returns local handler error when fetch(Request) uses a consumed body', asy
     logger: { log() { }, warn() { }, error() { } },
   });
   const { port } = await app.start();
+  process.env.WM_TEST_UPSTREAM = `http://127.0.0.1:${port}/api/echo-body`;
 
   try {
     const response = await fetch(`http://127.0.0.1:${port}/api/request-consumed`);
@@ -488,6 +482,51 @@ test('returns local handler error when fetch(Request) uses a consumed body', asy
     assert.equal(body.error, 'Local handler error');
     assert.equal(typeof body.reason, 'string');
     assert.equal(body.reason.length > 0, true);
+  } finally {
+    delete process.env.WM_TEST_UPSTREAM;
+    await app.close();
+    await localApi.cleanup();
+  }
+});
+
+test('blocks handler global fetches to private network targets (#3549)', async () => {
+  let upstreamHits = 0;
+
+  const upstream = createServer((_req, res) => {
+    upstreamHits += 1;
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  });
+  const upstreamPort = await listen(upstream);
+  process.env.WM_TEST_UPSTREAM = `http://127.0.0.1:${upstreamPort}/secret?token=super-secret`;
+
+  const localApi = await setupApiDir({
+    'private-proxy.js': `
+      export default async function handler() {
+        const upstream = await fetch(process.env.WM_TEST_UPSTREAM);
+        const payload = await upstream.text();
+        return new Response(payload, {
+          status: upstream.status,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+    `,
+  });
+
+  const app = await createLocalApiServer({
+    port: 0,
+    apiDir: localApi.apiDir,
+    logger: { log() { }, warn() { }, error() { } },
+  });
+  const { port } = await app.start();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/private-proxy`);
+    assert.equal(response.status, 502);
+    const body = await response.json();
+    assert.equal(body.error, 'Local handler error');
+    assert.match(body.reason, /SSRF blocked/);
+    assert.doesNotMatch(body.reason, /super-secret/);
     assert.equal(upstreamHits, 0);
   } finally {
     delete process.env.WM_TEST_UPSTREAM;
@@ -499,7 +538,90 @@ test('returns local handler error when fetch(Request) uses a consumed body', asy
   }
 });
 
-test('strips browser origin headers when proxying to cloud fallback (cloudFallback enabled)', async () => {
+test('uses asynchronous pinned lookup callback for handler global fetches (#3549)', async () => {
+  const originalHttpsRequest = https.request;
+  const envSnapshot = {
+    GROQ_API_KEY: process.env.GROQ_API_KEY,
+    OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
+    OLLAMA_API_URL: process.env.OLLAMA_API_URL,
+    LLM_API_URL: process.env.LLM_API_URL,
+  };
+  let lookupCallbackWasSync = null;
+
+  delete process.env.GROQ_API_KEY;
+  delete process.env.OPENROUTER_API_KEY;
+  delete process.env.OLLAMA_API_URL;
+  delete process.env.LLM_API_URL;
+
+  https.request = (options, onResponse) => {
+    assert.equal(options.hostname, '93.184.216.34');
+    assert.equal(typeof options.lookup, 'function');
+
+    let sync = true;
+    options.lookup(options.hostname, { family: 4 }, (error, address, family) => {
+      assert.ifError(error);
+      assert.equal(address, '93.184.216.34');
+      assert.equal(family, 4);
+      lookupCallbackWasSync = sync;
+    });
+    sync = false;
+
+    const req = new EventEmitter();
+    req.setTimeout = () => {};
+    req.write = () => {};
+    req.destroy = (error) => {
+      if (error) req.emit('error', error);
+    };
+    req.end = () => {
+      setImmediate(() => {
+        const res = new EventEmitter();
+        res.statusCode = 200;
+        res.statusMessage = 'OK';
+        res.headers = { 'content-type': 'application/json' };
+        onResponse(res);
+        res.emit('data', Buffer.from(JSON.stringify({ ok: true })));
+        res.emit('end');
+      });
+    };
+    return req;
+  };
+
+  const localApi = await setupApiDir({
+    'public-proxy.js': `
+      export default async function handler() {
+        const upstream = await fetch('https://93.184.216.34/data');
+        const payload = await upstream.text();
+        return new Response(payload, {
+          status: upstream.status,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+    `,
+  });
+
+  const app = await createLocalApiServer({
+    port: 0,
+    apiDir: localApi.apiDir,
+    logger: { log() { }, warn() { }, error() { } },
+  });
+  const { port } = await app.start();
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/api/public-proxy`);
+    assert.equal(response.status, 200);
+    assert.equal(lookupCallbackWasSync, false);
+  } finally {
+    https.request = originalHttpsRequest;
+    for (const [key, value] of Object.entries(envSnapshot)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    await app.close();
+    await localApi.cleanup();
+  }
+});
+
+test('uses canonical app origin when proxying to cloud fallback (cloudFallback enabled)', async () => {
   const remote = await setupRemoteServer();
   const localApi = await setupApiDir({});
 
@@ -508,6 +630,7 @@ test('strips browser origin headers when proxying to cloud fallback (cloudFallba
     apiDir: localApi.apiDir,
     remoteBase: remote.remoteBase,
     cloudFallback: 'true',
+    allowPrivateRemoteBase: true,
     logger: { log() { }, warn() { }, error() { } },
   });
   const { port } = await app.start();
@@ -519,8 +642,8 @@ test('strips browser origin headers when proxying to cloud fallback (cloudFallba
     assert.equal(response.status, 200);
     const body = await response.json();
     assert.equal(body.source, 'remote');
-    assert.equal(body.origin, null);
-    assert.equal(remote.origins[0], null);
+    assert.equal(body.origin, 'https://worldmonitor.app');
+    assert.equal(remote.origins[0], 'https://worldmonitor.app');
   } finally {
     await app.close();
     await localApi.cleanup();

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert';
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
-import { createServer, request as httpRequest } from 'node:http';
+import http, { createServer, request as httpRequest } from 'node:http';
 import https from 'node:https';
 import { EventEmitter } from 'node:events';
 import { brotliDecompressSync, gunzipSync } from 'node:zlib';
@@ -56,6 +56,29 @@ async function postJsonViaHttp(url, payload) {
     });
     req.on('error', reject);
     req.write(body);
+    req.end();
+  });
+}
+
+async function getJsonViaHttp(url) {
+  const target = new URL(url);
+  return new Promise((resolve, reject) => {
+    const req = httpRequest({
+      hostname: target.hostname,
+      port: Number(target.port || 80),
+      path: `${target.pathname}${target.search}`,
+      method: 'GET',
+    }, (res) => {
+      const chunks = [];
+      res.on('data', (chunk) => chunks.push(chunk));
+      res.on('end', () => {
+        const text = Buffer.concat(chunks).toString('utf8');
+        let json = null;
+        try { json = JSON.parse(text); } catch { /* non-json response */ }
+        resolve({ status: res.statusCode || 0, text, json });
+      });
+    });
+    req.on('error', reject);
     req.end();
   });
 }
@@ -612,6 +635,77 @@ test('uses asynchronous pinned lookup callback for handler global fetches (#3549
     assert.equal(lookupCallbackWasSync, false);
   } finally {
     https.request = originalHttpsRequest;
+    for (const [key, value] of Object.entries(envSnapshot)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    await app.close();
+    await localApi.cleanup();
+  }
+});
+
+test('uses IPv4 sidecar fetch for allowed private-network LLM probes (#3549)', async () => {
+  const originalHttpRequest = http.request;
+  const envSnapshot = {
+    GROQ_API_KEY: process.env.GROQ_API_KEY,
+    OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
+    OLLAMA_API_URL: process.env.OLLAMA_API_URL,
+    LLM_API_URL: process.env.LLM_API_URL,
+  };
+  let sawOllamaProbe = false;
+
+  delete process.env.GROQ_API_KEY;
+  delete process.env.OPENROUTER_API_KEY;
+  delete process.env.LLM_API_URL;
+  process.env.OLLAMA_API_URL = 'http://ollama.test:11434';
+
+  http.request = (options, onResponse) => {
+    if (options.hostname !== 'ollama.test') {
+      return originalHttpRequest.call(http, options, onResponse);
+    }
+
+    sawOllamaProbe = true;
+    assert.equal(options.family, 4);
+    assert.equal(options.path, '/');
+
+    const req = new EventEmitter();
+    req.setTimeout = () => {};
+    req.write = () => {};
+    req.destroy = (error) => {
+      if (error) req.emit('error', error);
+    };
+    req.end = () => {
+      setImmediate(() => {
+        const res = new EventEmitter();
+        res.statusCode = 200;
+        res.statusMessage = 'OK';
+        res.headers = { 'content-type': 'application/json' };
+        onResponse(res);
+        res.emit('data', Buffer.from(JSON.stringify({ ok: true })));
+        res.emit('end');
+      });
+    };
+    return req;
+  };
+
+  const localApi = await setupApiDir({});
+  const app = await createLocalApiServer({
+    port: 0,
+    apiDir: localApi.apiDir,
+    logger: { log() { }, warn() { }, error() { } },
+  });
+  const { port } = await app.start();
+
+  try {
+    const response = await getJsonViaHttp(`http://127.0.0.1:${port}/api/llm-health`);
+    assert.equal(response.status, 200);
+    assert.equal(response.json.available, true);
+    assert.deepEqual(response.json.providers, [
+      { name: 'ollama', url: 'http://ollama.test:11434', available: true },
+    ]);
+    assert.equal(sawOllamaProbe, true);
+  } finally {
+    http.request = originalHttpRequest;
     for (const [key, value] of Object.entries(envSnapshot)) {
       if (value === undefined) delete process.env[key];
       else process.env[key] = value;


### PR DESCRIPTION
## Summary
Closes #3549. The Tauri sidecar global `fetch` override now treats SSRF protection as the default floor for handler fetches: http(s) targets are validated before connection, private/reserved addresses are blocked, and validated IPv4 DNS results are pinned into the outbound request.

## Root cause
The sidecar had an SSRF guard for `/api/rss-proxy`, but the process-wide `globalThis.fetch` replacement did not use it. Any sidecar handler that later fetched a user-influenced URL through global `fetch` could reach loopback, link-local metadata, or private RFC1918 addresses unless that handler remembered to add its own guard.

## Changes
- Run `isSafeUrl()` from the global sidecar `fetch` override before outbound http(s) requests.
- Reject private/reserved targets with an `ERR_SSRF_BLOCKED` error and a redacted URL in the message.
- Strip query strings and fragments from blocked-URL error messages.
- Pin outbound requests to the validated IPv4 DNS result, with the pinned lookup callback invoked asynchronously.
- Keep explicit private-network allowances narrow: the sidecar self-origin for local API calls, programmatic dev/test `remoteBase`, and Ollama/LLM health probes.
- Keep privileged local fetches inside the sidecar upstream concurrency limiter.
- Add regression tests for loopback blocking, error redaction, and async pinned lookup behavior.

## Validation
- [x] `node --test src-tauri/sidecar/local-api-server.test.mjs` - 39/39 pass
- [x] `npm run test:sidecar` - 96/96 pass
- [x] `npm run typecheck`
- [x] `npm run typecheck:api`
- [x] `npx biome lint src-tauri/sidecar/local-api-server.mjs src-tauri/sidecar/local-api-server.test.mjs` - exits 0; existing complexity/HTML-string warnings remain in `local-api-server.mjs`
- [x] `git diff --check -- src-tauri/sidecar/local-api-server.mjs src-tauri/sidecar/local-api-server.test.mjs`

## Risk
Medium-low. The intended behavior change is fail-closed for sidecar handler `fetch()` calls to private networks. The main compatibility risk is code that intentionally used global `fetch` for arbitrary localhost services; known local LLM/Ollama probes are explicitly preserved, and the sidecar's own local origin remains allowed.