### PR TITLE
fix(seed-bis-data): bump TTL 12h→36h to match 3× cron-interval gold standard

### DIFF
--- a/scripts/seed-bis-data.mjs
+++ b/scripts/seed-bis-data.mjs
@@ -29,7 +29,24 @@ const KEYS = {
   credit:   'economic:bis:credit:v1',
 };
 
-const TTL = 43200; // 12 hours
+// 36 hours = 3× the bundle's 12h interval gate (seed-bundle-macro.mjs:5,
+// `intervalMs: 12 * HOUR`). Per the gold-standard "TTL >= 3× cron interval"
+// recipe — earlier TTL=43200 (12h) matched the gate exactly, so any cron
+// drift left the canonical key TTL'd-out for a window where /api/health
+// reported `economic:bis:policy:v1`/`eer:v1`/`credit:v1` as missing while
+// `seed-meta:economic:bis` still carried last-good `recordCount` (verified
+// 2026-05-06: seed-meta showed recordCount=11 + a recent fetchedAt, but
+// all 3 canonical GETs returned nil from Upstash because the bundle ran
+// ~13.7h after the last successful tick instead of exactly 12h). 36h
+// covers cron drift + one degraded-to-24h cycle (matches the rationale
+// already applied to bisDsr/bisProperty* maxStaleMin in api/health.js
+// circa 2026-04-27, just on the canonical-key-TTL side instead of the
+// health-threshold side).
+//
+// All 3 canonical writes (policy via atomicPublish, eer + credit via
+// writeExtraKey in afterPublish) reuse this constant, so the bump fixes
+// all three simultaneously.
+const TTL = 129600;
 
 async function fetchBisCSV(dataset, key) {
   const separator = key.includes('?') ? '&' : '?';


### PR DESCRIPTION
## Symptom

\`/api/health\` reported \`bisPolicy\`, \`bisExchange\`, \`bisCredit\` as \`EMPTY_ON_DEMAND\` with \`records: 0\`, but \`seed-meta:economic:bis\` showed \`recordCount: 11\` and a recent \`fetchedAt\`. Verified 2026-05-06 by direct Upstash GET:

\`\`\`
economic:bis:policy:v1   → (key does not exist)
economic:bis:eer:v1      → (key does not exist)
economic:bis:credit:v1   → (key does not exist)
seed-meta:economic:bis   → fetchedAt recent, recordCount: 11
\`\`\`

## Root cause: TTL == cron interval (zero margin)

\`scripts/seed-bis-data.mjs:32\` set \`TTL = 43200\` (12h). \`scripts/seed-bundle-macro.mjs:5\` configures the BIS-Data section with \`intervalMs: 12 * HOUR\`. Canonical-key TTL == cron interval — any cron drift (bundle ordering, queue delay, transient failure) leaves the canonical TTL'd-out for a window before the next successful run rewrites it.

The 13.7h \`seedAgeMin\` in /api/health (vs the 12h gate) IS the 1.7h drift window where canonical was missing. \`seed-meta\` survived the gap because its TTL is much longer (30+ days under runSeed's seedMetaTtl), which is why the meta correctly reflected last-good \`recordCount: 11\` while the canonical had vanished.

This is the **same shape** as the trap caught for \`bisDsr\`/\`bisProperty*\` at \`api/health.js:268-281\` in 2026-04-27 — that fix was on the \`maxStaleMin\` (health-threshold) side; this one applies the SAME 3× gold-standard recipe to the canonical-key TTL side, which had been overlooked.

## Fix

Bump \`TTL = 43200\` → \`TTL = 129600\` (36h = 3× the 12h gate). Covers cron drift + one degraded-to-24h cycle. All 3 canonical writes (policy via \`atomicPublish\`, eer + credit via \`writeExtraKey\` in \`afterPublish\`) reuse the same constant, so one bump fixes all three simultaneously. Pure-config fix; no code-path change.

## Verification

- [x] Direct Upstash GET confirmed all 3 canonical keys missing pre-fix
- [x] BIS upstream verified healthy 2026-05-06: \`WS_CBPOL\`/\`WS_EER\`/\`WS_TC\` all return 200 + valid CSV (11/12/12 countries under the seeder's exact query)
- [x] Seeder logic + parser run end-to-end against current upstream produce 11/12/12 records (no parser regression)
- [x] \`npm run typecheck:api\` clean
- [x] \`npm run lint\` clean
- [x] No existing seed-bis-data test (the diagnostic-via-Upstash-GET stays valid post-fix)
- [ ] Post-merge: confirm /api/health \`bisPolicy\`/\`bisExchange\`/\`bisCredit\` flip to \`status: OK\` within 12h of next bundle cron tick (Railway deploy + first cron run will repopulate canonical)

## Other minor health items (NOT in this PR)

- \`riskScoresLive\`: \`EMPTY_ON_DEMAND\` — on-demand RPC cache; expected to be empty if no recent Pro user hits it. No action needed.
- \`chokepoints\`: \`COVERAGE_PARTIAL\` 11/13 — transient upstream (portwatch/ArcGIS) lag; usually self-corrects.