### PR TITLE
fix(seed-portwatch): retry-on-empty + log-on-empty so silent ArcGIS drops surface

### DIFF
--- a/scripts/seed-portwatch.mjs
+++ b/scripts/seed-portwatch.mjs
@@ -108,23 +108,90 @@ export function buildHistory(features) {
     .sort((a, b) => a.date.localeCompare(b.date));
 }
 
-export async function fetchAll() {
-  const sinceEpoch = Date.now() - HISTORY_DAYS * 24 * 60 * 60 * 1000;
+/**
+ * Run the chokepoint fetch pipeline with batched concurrency + sequential
+ * retry-on-empty. Extracted so tests can inject a mock `fetchPagesFn`
+ * without hitting the real ArcGIS API.
+ *
+ * Retry rationale (PR #3611, 2026-05-06):
+ *
+ * The previous implementation silently dropped any chokepoint whose
+ * upstream fetch returned `{features: []}` (empty 200) — a class of
+ * transient failure that ArcGIS produces under per-egress-IP rate limits.
+ * The pattern was bursty: 2 of 3 chokepoints in the same Promise.allSettled
+ * batch came back empty, with no log line and no retry, while a manual
+ * fetch from any other IP returned 179 features for the same query. The
+ * 0-record outcome propagated through `seedTransitSummaries` (ais-relay.cjs)
+ * → `dataAvailable: Boolean(cpData)` flipped false → /api/health flagged
+ * `chokepoints: COVERAGE_PARTIAL`.
+ *
+ * Two changes here:
+ *   1. **Log on empty**: surface the silent-drop path so Railway logs
+ *      tell us which chokepoint(s) returned 0 features, and how often.
+ *   2. **Sequential retry pass**: any chokepoint that came back empty
+ *      OR rejected on the concurrent first pass gets retried alone with
+ *      a small delay — stepping out of any rate-limit window the
+ *      concurrent batch may have hit. Recovers transients without
+ *      changing the steady-state code path.
+ *
+ * The retry is intentionally "1 attempt" — a permanent ArcGIS issue
+ * for a given chokepoint should still surface as missing in seed-meta
+ * recordCount so /api/health can flag it.
+ */
+export async function runFetchPipeline(chokepoints, sinceEpoch, fetchPagesFn, retryDelayMs = 500) {
   const result = {};
-  for (let i = 0; i < CHOKEPOINTS.length; i += CONCURRENCY) {
-    const batch = CHOKEPOINTS.slice(i, i + CONCURRENCY);
-    const settled = await Promise.allSettled(batch.map(cp => fetchAllPages(cp.name, sinceEpoch)));
+  const missing = [];
+
+  // First pass: concurrent batches.
+  for (let i = 0; i < chokepoints.length; i += CONCURRENCY) {
+    const batch = chokepoints.slice(i, i + CONCURRENCY);
+    const settled = await Promise.allSettled(batch.map(cp => fetchPagesFn(cp.name, sinceEpoch)));
     for (let j = 0; j < batch.length; j++) {
       const outcome = settled[j];
+      const cp = batch[j];
       if (outcome.status === 'rejected') {
-        console.warn(`  [PortWatch] ${batch[j].name}: ${outcome.reason?.message || outcome.reason}`);
+        console.warn(`  [PortWatch] ${cp.name}: rejected — ${outcome.reason?.message || outcome.reason}`);
+        missing.push(cp);
         continue;
       }
-      if (!outcome.value.length) continue;
+      if (!outcome.value.length) {
+        // Empty 200 — most often ArcGIS rate limit or transient. Queue for retry.
+        console.warn(`  [PortWatch] ${cp.name}: 0 features (empty 200) — queued for retry`);
+        missing.push(cp);
+        continue;
+      }
       const history = buildHistory(outcome.value);
-      result[batch[j].id] = { history, wowChangePct: computeWow(history) };
+      result[cp.id] = { history, wowChangePct: computeWow(history) };
     }
   }
+
+  // Second pass: sequential retry of any chokepoint that came back empty or rejected.
+  // Sequential (not concurrent) to step out of any rate-limit burst from the first pass.
+  if (missing.length > 0) {
+    console.warn(`[PortWatch] Retrying ${missing.length} chokepoint(s) sequentially: ${missing.map(c => c.id).join(', ')}`);
+    for (const cp of missing) {
+      if (retryDelayMs > 0) await new Promise(r => setTimeout(r, retryDelayMs));
+      try {
+        const features = await fetchPagesFn(cp.name, sinceEpoch);
+        if (features.length === 0) {
+          console.warn(`  [PortWatch] ${cp.name}: still 0 features after retry — dropping`);
+          continue;
+        }
+        const history = buildHistory(features);
+        result[cp.id] = { history, wowChangePct: computeWow(history) };
+        console.log(`  [PortWatch] ${cp.name}: recovered ${features.length} features on retry`);
+      } catch (e) {
+        console.warn(`  [PortWatch] ${cp.name}: retry rejected — ${e?.message || e}`);
+      }
+    }
+  }
+
+  return result;
+}
+
+export async function fetchAll() {
+  const sinceEpoch = Date.now() - HISTORY_DAYS * 24 * 60 * 60 * 1000;
+  const result = await runFetchPipeline(CHOKEPOINTS, sinceEpoch, fetchAllPages);
   if (Object.keys(result).length === 0) throw new Error('No chokepoints returned data');
   return result;
 }

--- a/tests/portwatch-retry-on-empty.test.mjs
+++ b/tests/portwatch-retry-on-empty.test.mjs
@@ -1,0 +1,202 @@
+// Tests for the portwatch retry-on-empty pipeline added in PR #3611.
+//
+// Background: ArcGIS occasionally returns `{features: []}` (empty 200) under
+// per-egress-IP rate limiting. The previous `fetchAll()` silently dropped any
+// chokepoint with zero features — no log, no retry. WM 2026-05-06 incident:
+// `cape_of_good_hope` and `gibraltar` were both in batch 2 of the
+// CONCURRENCY=3 stride, both came back empty, /api/health flagged
+// COVERAGE_PARTIAL with no diagnostic trail in Railway logs.
+//
+// `runFetchPipeline` (extracted for injection-testability) now:
+//   1. Logs each empty-result on the concurrent first pass (instead of
+//      silently dropping).
+//   2. Retries any rejected-or-empty chokepoint sequentially (with a small
+//      delay) to step out of rate-limit bursts.
+//   3. Logs recovery on retry success and "still 0 after retry" on
+//      retry-empty so operators can distinguish transient from permanent.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { runFetchPipeline } from '../scripts/seed-portwatch.mjs';
+
+// Minimal feature-shape factory — only the fields buildHistory cares about.
+function makeFeature(date, total = 100) {
+  return {
+    attributes: {
+      date,
+      n_container: 0, n_dry_bulk: 0, n_general_cargo: 0, n_roro: 0, n_tanker: 0,
+      n_total: total,
+      capacity_container: 0, capacity_dry_bulk: 0, capacity_general_cargo: 0,
+      capacity_roro: 0, capacity_tanker: 0,
+    },
+  };
+}
+
+// 14 days of features so computeWow doesn't return 0 (length < 14 short-circuit).
+function makeFullHistory() {
+  return Array.from({ length: 14 }, (_, i) => makeFeature(`2026-04-${String(i + 1).padStart(2, '0')}`, 100));
+}
+
+const CHOKEPOINTS = [
+  { name: 'Suez Canal',        id: 'suez' },
+  { name: 'Malacca Strait',    id: 'malacca_strait' },
+  { name: 'Strait of Hormuz',  id: 'hormuz_strait' },
+  { name: 'Cape of Good Hope', id: 'cape_of_good_hope' },
+  { name: 'Gibraltar Strait',  id: 'gibraltar' },
+  { name: 'Bosporus Strait',   id: 'bosphorus' },
+];
+
+// ── Steady-state happy path ──────────────────────────────────────────────
+
+test('healthy first pass: every chokepoint succeeds, no retry, all returned', async () => {
+  const calls = new Map();
+  const fetcher = async (name) => {
+    calls.set(name, (calls.get(name) || 0) + 1);
+    return makeFullHistory();
+  };
+  const result = await runFetchPipeline(CHOKEPOINTS, Date.now(), fetcher, 0);
+  assert.equal(Object.keys(result).length, CHOKEPOINTS.length, 'all 6 chokepoints in result');
+  for (const cp of CHOKEPOINTS) {
+    assert.equal(calls.get(cp.name), 1, `${cp.name} called exactly once (no retry)`);
+    assert.ok(result[cp.id]?.history?.length, `${cp.id} has history`);
+  }
+});
+
+// ── Recovery on empty 200 ────────────────────────────────────────────────
+
+test('recovery: chokepoint that returns empty on pass 1 succeeds on retry', async () => {
+  const callCounts = new Map();
+  const fetcher = async (name) => {
+    const n = (callCounts.get(name) || 0) + 1;
+    callCounts.set(name, n);
+    // Cape of Good Hope returns empty on first call, full on second.
+    if (name === 'Cape of Good Hope' && n === 1) return [];
+    return makeFullHistory();
+  };
+  const result = await runFetchPipeline(CHOKEPOINTS, Date.now(), fetcher, 0);
+  assert.ok(result['cape_of_good_hope'], 'cape_of_good_hope recovered via retry');
+  assert.equal(callCounts.get('Cape of Good Hope'), 2, 'Cape called twice (initial + retry)');
+  assert.equal(Object.keys(result).length, CHOKEPOINTS.length, 'all 6 chokepoints in result post-retry');
+});
+
+test('recovery: chokepoint that throws on pass 1 succeeds on retry', async () => {
+  const callCounts = new Map();
+  const fetcher = async (name) => {
+    const n = (callCounts.get(name) || 0) + 1;
+    callCounts.set(name, n);
+    if (name === 'Gibraltar Strait' && n === 1) throw new Error('ECONNRESET');
+    return makeFullHistory();
+  };
+  const result = await runFetchPipeline(CHOKEPOINTS, Date.now(), fetcher, 0);
+  assert.ok(result['gibraltar'], 'gibraltar recovered via retry after rejection');
+  assert.equal(callCounts.get('Gibraltar Strait'), 2, 'Gibraltar called twice');
+  assert.equal(Object.keys(result).length, CHOKEPOINTS.length, 'all 6 in result');
+});
+
+test('recovery: 2 of 3 in same batch return empty (the WM 2026-05-06 incident pattern), both recover', async () => {
+  // Mirrors the production pattern: cape_of_good_hope + gibraltar in the same
+  // CONCURRENCY=3 batch both returned empty 200s. Bosphorus (3rd in batch)
+  // succeeded. Verify both come back via retry.
+  const callCounts = new Map();
+  const fetcher = async (name) => {
+    const n = (callCounts.get(name) || 0) + 1;
+    callCounts.set(name, n);
+    if ((name === 'Cape of Good Hope' || name === 'Gibraltar Strait') && n === 1) return [];
+    return makeFullHistory();
+  };
+  const result = await runFetchPipeline(CHOKEPOINTS, Date.now(), fetcher, 0);
+  assert.ok(result['cape_of_good_hope'], 'cape recovered');
+  assert.ok(result['gibraltar'], 'gibraltar recovered');
+  assert.ok(result['bosphorus'], 'bosphorus untouched (was healthy on pass 1)');
+  assert.equal(callCounts.get('Bosporus Strait'), 1, 'bosphorus called only once');
+  assert.equal(Object.keys(result).length, CHOKEPOINTS.length, 'all 6 in result');
+});
+
+// ── Permanent failure handling ───────────────────────────────────────────
+
+test('permanent failure: chokepoint empty on both passes is dropped (no throw)', async () => {
+  const fetcher = async (name) => {
+    if (name === 'Cape of Good Hope') return [];     // permanently empty
+    return makeFullHistory();
+  };
+  const result = await runFetchPipeline(CHOKEPOINTS, Date.now(), fetcher, 0);
+  assert.equal(result['cape_of_good_hope'], undefined, 'cape dropped after retry-empty');
+  assert.equal(Object.keys(result).length, CHOKEPOINTS.length - 1, '5 of 6 returned');
+});
+
+test('permanent failure: chokepoint that throws on both passes is dropped (no throw)', async () => {
+  const fetcher = async (name) => {
+    if (name === 'Gibraltar Strait') throw new Error('ArcGIS 503');
+    return makeFullHistory();
+  };
+  const result = await runFetchPipeline(CHOKEPOINTS, Date.now(), fetcher, 0);
+  assert.equal(result['gibraltar'], undefined, 'gibraltar dropped after retry-rejection');
+  assert.equal(Object.keys(result).length, CHOKEPOINTS.length - 1);
+});
+
+test('all chokepoints fail on both passes: returns empty result (caller decides whether to throw)', async () => {
+  const fetcher = async () => [];
+  const result = await runFetchPipeline(CHOKEPOINTS, Date.now(), fetcher, 0);
+  assert.deepEqual(result, {}, 'empty result; the outer fetchAll() turns this into a throw');
+});
+
+// ── Retry execution ordering ─────────────────────────────────────────────
+
+test('retry pass is sequential, not concurrent (anti-thundering-herd)', async () => {
+  // Track in-flight-during-retry to verify sequential. If the retry pass were
+  // concurrent (Promise.all) and 3 cps need retry, all 3 would be in-flight at
+  // some moment. Sequential means at most 1.
+  let inFlight = 0;
+  let maxInFlight = 0;
+  const callCounts = new Map();
+  const fetcher = async (name) => {
+    const n = (callCounts.get(name) || 0) + 1;
+    callCounts.set(name, n);
+    inFlight++;
+    maxInFlight = Math.max(maxInFlight, inFlight);
+    try {
+      // First pass: 3 of the 6 cps return empty. The CONCURRENCY=3 batch
+      // means 3 in-flight together is expected on pass 1 — that's fine.
+      // We're checking the RETRY pass is sequential.
+      const empties = ['Cape of Good Hope', 'Gibraltar Strait', 'Bosporus Strait'];
+      if (empties.includes(name) && n === 1) return [];
+      return makeFullHistory();
+    } finally {
+      inFlight--;
+    }
+  };
+  await runFetchPipeline(CHOKEPOINTS, Date.now(), fetcher, 0);
+  // Pass 1 has CONCURRENCY=3 in-flight at peak. The retry pass adds 1 at a
+  // time (sequential). So the GLOBAL max stays at 3 — would be 6 if retry
+  // were concurrent (since 3 would race against pass-2 batches).
+  assert.ok(maxInFlight <= 3, `max in-flight=${maxInFlight}; retry pass must be sequential`);
+});
+
+test('retry honors retryDelayMs argument (small delay between retries)', async () => {
+  const timestamps = [];
+  const callCounts = new Map();
+  const fetcher = async (name) => {
+    const n = (callCounts.get(name) || 0) + 1;
+    callCounts.set(name, n);
+    if (n === 2) timestamps.push(Date.now());     // record retry-call timestamps
+    if ((name === 'Cape of Good Hope' || name === 'Gibraltar Strait') && n === 1) return [];
+    return makeFullHistory();
+  };
+  await runFetchPipeline(CHOKEPOINTS, Date.now(), fetcher, 50);
+  assert.equal(timestamps.length, 2, 'two retries fired');
+  const gap = timestamps[1] - timestamps[0];
+  assert.ok(gap >= 40, `retry gap ${gap}ms includes ≥40ms delay (the 50ms argument minus scheduler jitter)`);
+});
+
+// ── Output shape (no regression on existing fetchAll contract) ───────────
+
+test('output shape: each entry has {history, wowChangePct} (back-compat with consumers)', async () => {
+  const fetcher = async () => makeFullHistory();
+  const result = await runFetchPipeline(CHOKEPOINTS, Date.now(), fetcher, 0);
+  for (const cp of CHOKEPOINTS) {
+    const entry = result[cp.id];
+    assert.ok(entry, `${cp.id} present`);
+    assert.ok(Array.isArray(entry.history), `${cp.id}.history is array`);
+    assert.equal(typeof entry.wowChangePct, 'number', `${cp.id}.wowChangePct is number`);
+  }
+});

--- a/tests/portwatch-retry-on-empty.test.mjs
+++ b/tests/portwatch-retry-on-empty.test.mjs
@@ -185,7 +185,11 @@ test('retry honors retryDelayMs argument (small delay between retries)', async (
   await runFetchPipeline(CHOKEPOINTS, Date.now(), fetcher, 50);
   assert.equal(timestamps.length, 2, 'two retries fired');
   const gap = timestamps[1] - timestamps[0];
-  assert.ok(gap >= 40, `retry gap ${gap}ms includes ≥40ms delay (the 50ms argument minus scheduler jitter)`);
+  // Threshold = half the delay arg. Wider than 40ms to absorb scheduler
+  // jitter on slow/shared CI runners (Greptile P2 on PR #3611) without
+  // losing the signal that the delay actually fires (gap > 0 alone would
+  // pass even if retryDelayMs were ignored).
+  assert.ok(gap >= 25, `retry gap ${gap}ms includes ≥25ms delay (the 50ms argument minus scheduler jitter)`);
 });
 
 // ── Output shape (no regression on existing fetchAll contract) ───────────


### PR DESCRIPTION
## Symptom

\`/api/health\` reports \`chokepoints: COVERAGE_PARTIAL\` (11/13) for hours at a time despite ArcGIS having data for all 13. WM 2026-05-06: \`cape_of_good_hope\` and \`gibraltar\` both flagged \`dataAvailable: false\` in \`supply_chain:transit-summaries:v1\`, traced back to those two missing from \`supply_chain:portwatch:v1\` while every other chokepoint was healthy.

## Root cause

\`scripts/seed-portwatch.mjs:114-127\` (pre-fix):

\`\`\`js
const settled = await Promise.allSettled(batch.map(...));
for (let j = 0; j < batch.length; j++) {
  if (outcome.status === 'rejected') { console.warn(...); continue; }
  if (!outcome.value.length) continue;     // ← SILENTLY skipped, no log
  result[batch[j].id] = ...;
}
\`\`\`

When ArcGIS returns \`{features: []}\` (empty 200, the way per-egress-IP rate limits manifest from Railway), the chokepoint was silently dropped: **no log line, no retry**. The 0-record outcome propagated through \`seedTransitSummaries\` (ais-relay.cjs) → \`dataAvailable: Boolean(cpData)\` flipped false → /api/health reported \`COVERAGE_PARTIAL\` with no diagnostic trail.

The pattern was bursty: 2 of 3 chokepoints in the same \`CONCURRENCY=3\` batch came back empty (cape_of_good_hope, gibraltar — both in batch 2). Local fetch using the seeder's exact \`fetchAllPages\` returned 179 features for each, confirming upstream healthy + bug is in the seeder's silent-drop path under transient-throttling conditions.

## Fix

Two changes:

1. **Log on empty**: surface the silent-drop path in Railway logs so operators see WHICH chokepoint(s) returned 0 features and how often. No more invisible failures.
2. **Sequential retry pass**: any chokepoint rejected-or-empty on the concurrent first pass gets retried alone with a small delay, stepping out of any rate-limit burst. Retries log success/permanent-empty distinctly so transient vs structural failure is visible.

Pipeline extracted as \`runFetchPipeline(chokepoints, sinceEpoch, fetchPagesFn, retryDelayMs)\` so tests can inject a mock fetcher and verify retry behavior without hitting ArcGIS. \`fetchAll()\` is now a 2-line wrapper calling \`runFetchPipeline\` with the real fetcher, preserving the existing seeder contract (same input, same output shape, same caller-throws-on-all-empty behavior).

The retry is intentionally **1 attempt** — a permanent ArcGIS issue for a given chokepoint should still surface as missing in seed-meta recordCount so /api/health flags it. This isn't a band-aid for real upstream failures; it's a recovery path for transient throttling.

## Test plan

- [x] \`node --test tests/portwatch-retry-on-empty.test.mjs\` → 10/10 pass:
  - Healthy first pass → no retry calls
  - Recovery on empty 200 (single + multi-in-batch — the **WM 2026-05-06 incident pattern**)
  - Recovery on first-pass rejection
  - Permanent failure (empty on both passes) → drop, no throw
  - All-fail → empty result (caller decides whether to throw)
  - Retry pass is **SEQUENTIAL** (max in-flight stays at CONCURRENCY=3, not 6)
  - Retry honors retryDelayMs argument
  - Output shape unchanged (back-compat with consumers)
- [x] 167/167 across full portwatch test suite (no regressions)
- [x] \`npm run typecheck:api\` clean
- [x] \`npm run lint\` clean
- [x] \`seed-portwatch.mjs\` is NOT in Dockerfile.relay — no relay-COPY change needed
- [ ] Post-merge: confirm /api/health \`chokepoints\` flips to OK after the next 6h bundle cron tick (PW-Main interval)
- [ ] Post-merge: monitor Railway logs for 24-48h to quantify how often the retry path actually fires + whether recovery rate is high (transient) or low (real upstream issue)

## Related

- \`/api/health\` previously surfaced the partial via \`minRecordCount: 13\` in \`api/health.js:289\`. The health threshold was correctly tight (catches the symptom); this PR fixes the **upstream silent drop** that made the alert load-bearing rather than informational.
- Same shape of "silent zero-result drop" pattern that bit the BIS canonical-key TTL trap (#3610) — different mechanism (TTL vs fetch-empty) but identical "operator sees a degraded panel with no log trail" failure mode.