### PR TITLE
fix(portwatch-port-activity): drop orderBy on EP3 — DateOnly server-side sort cliff

### DIFF
--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -240,7 +240,24 @@ async function paginateWindowInto(portAccumMap, iso3, where, windowKind, { signa
       // dynamically via resolveArcgisDateField() at run start.
       outFields: `portid,portname,ISO3,${df},portcalls_tanker,import_tanker,export_tanker`,
       returnGeometry: 'false',
-      orderByFields: `portid ASC,${df} ASC`,
+      // NO orderByFields — DateOnly sort cliff (WM 2026-05-06 trap).
+      // ArcGIS migrated Daily_Ports_Data's `date` column to
+      // `esriFieldTypeDateOnly`. Server-side sort on DateOnly is 10-15×
+      // slower than no-sort: BRA 60d page = 46.6s with `portid ASC,date ASC`
+      // vs 4.0s with no orderBy. With 174 countries × ≥3 pages each + a 90s
+      // per-country cap, every per-country fetch was timing out (36+ errors
+      // per bundle run, container SIGTERM'd at the 540s budget).
+      //
+      // The aggregation below (paginateWindowInto's portAccumMap) is
+      // ORDER-INDEPENDENT — it sums portcalls/import/export per portId
+      // without caring about row order. So we don't even need a client-side
+      // sort fallback. ArcGIS still provides a consistent default order
+      // (ObjectId ASC) across pages, so resultOffset pagination remains
+      // correct.
+      //
+      // If a future caller of this endpoint genuinely needs ordered output
+      // (e.g. for a "latest N" tail query), do the sort client-side after
+      // pagination completes — orderBy on the request side is a 10× tax.
       resultRecordCount: String(PAGE_SIZE),
       resultOffset: String(offset),
       outSR: '4326',

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -64,9 +64,37 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.doesNotMatch(src, /where:\s*`date_?\s*>\s*\$\{epochToTimestamp\(since\)\}`/);
   });
 
+  it('EP3 per-country query does NOT orderBy on the date field — DateOnly sort cliff', () => {
+    // WM 2026-05-06 trap: ArcGIS migrated Daily_Ports_Data's `date` column
+    // to esriFieldTypeDateOnly. Server-side sort on DateOnly is 10-15× slower
+    // than no-sort. With CONCURRENCY=12 and a 90s per-country cap, every
+    // per-country fetch was timing out (BRA 60d page = 46.6s with
+    // `portid ASC,date ASC` vs 4.0s with no orderBy → ~140s/country vs ~12s).
+    //
+    // The aggregation in paginateWindowInto is order-INdependent (sums into
+    // Map<portId, accum>), so dropping orderBy is safe AND fast. ArcGIS
+    // still returns rows in default ObjectId order across pages, so
+    // resultOffset pagination remains correct.
+    //
+    // If a future refactor genuinely needs ordered output, sort
+    // CLIENT-side after pagination — never re-add orderByFields with the
+    // ${df} (date) field on EP3, even with `${df} ASC` or `${df} DESC`.
+    assert.doesNotMatch(src, /orderByFields:\s*[`'][^`']*\$\{df\}/);
+    // Also forbid hardcoded date-field literals in the orderBy template.
+    assert.doesNotMatch(src, /orderByFields:\s*[`'][^`']*\b(date|date_)\s+(ASC|DESC)\b/i);
+  });
+
   it('EP4 refs query fetches all ports globally with where=1=1', () => {
     assert.match(src, /where:\s*'1=1'/);
     assert.match(src, /outFields:\s*'portid,ISO3,lat,lon'/);
+  });
+
+  it('EP4 refs query MAY orderBy portid (string field, not DateOnly)', () => {
+    // EP4 = PortWatch_ports_database (static port-reference table), no date
+    // column. Sorting by portid (string) is fine — the DateOnly cliff is
+    // specific to EP3. This test exists so a future "remove all orderBy
+    // everywhere" sweep doesn't blanket-remove this one.
+    assert.match(src, /orderByFields:\s*'portid ASC'/);
   });
 
   it('both paginators set returnGeometry:false', () => {


### PR DESCRIPTION
## Symptom

Bundle \`seed-bundle-portwatch-port-activity\` (Railway) running every 12h, container SIGTERM'd at the 540s budget on May 6 00:02 UTC. **36 errors across 4 batches** before timeout, all of the form:

\`\`\`
<ISO3>: The operation was aborted due to timeout
\`\`\`

\`/api/health\` flagged \`portwatchPortActivity: STALE_SEED 36h+\` (2 missed cron cycles).

May 4 + May 5 runs reported \`Cache: 174 hits, 0 misses\` + 10s duration — replaying cached payloads, never exercised the upstream path. The cliff hit on May 6 when all 174 per-country cache keys (synchronized 7-day TTL) expired together and forced real upstream fetches.

## Root cause

ArcGIS migrated \`Daily_Ports_Data\`'s \`date\` column to **\`esriFieldTypeDateOnly\`** (sometime in the prior 7 days, hidden by the cache cliff). Server-side sort on DateOnly is **10-15× slower** than no-sort.

Empirical measurements (BRA 60d window, 5,768 rows total, page size 2000):

| orderByFields | per-page | per-country |
|---|---|---|
| \`portid ASC,date ASC\` (current) | **46.6s** | ~140s ❌ over 90s cap |
| \`ObjectId ASC\` | 26.5s | ~80s ⚠ borderline |
| **(no orderBy at all)** | **4.0s** ✅ | ~12s comfortably under |

\`returnCountOnly\` is sub-second (the WHERE clause is fine; only the materialization+sort is slow), confirming this isn't a network/auth issue — specifically the DateOnly orderBy code path on the ArcGIS server.

## Fix

Drop \`orderByFields: \\\`portid ASC,${df} ASC\\\`\` from the EP3 \`paginateWindowInto\` request. The aggregation in that loop is **order-independent** — it sums into \`Map<portId, accum>\` per row without caring about row order. ArcGIS still provides a consistent default order (ObjectId ASC) across pages, so resultOffset pagination remains correct. **No client-side sort needed.**

Also adds an extensive comment explaining WHY orderBy is deliberately omitted, so a future contributor doesn't reintroduce it under the plausible-but-wrong "queries should be deterministically ordered" rule.

## Why this lurked invisibly for days

Per-item Redis cache (\`supply_chain:portwatch-ports:v1:<iso2>\` keys) with synchronized 7-day TTL because all keys were written in the same successful run. While cache was alive, every "successful" run was a ~10s no-op replay — \`Cache: 174 hits, 0 misses\` — and the upstream code path was never exercised.

The DateOnly migration may have happened days before the cliff but only became visible when the cache TTL'd out. (Saved as separate memory \`per-item-cache-cliff-masks-upstream-regression\` to flag this anti-pattern for other seeders. Possible follow-ups: randomize per-item TTL on write to de-sync expiry, or smoke-test ~5% upstream every tick.)

## Tests

- **Two new regression-guard tests** in \`tests/portwatch-port-activity-seed.test.mjs\`:
  1. EP3 query MUST NOT orderBy on the date field (\`\${df}\`) — locks the fix against future re-introduction
  2. EP4 (port-reference, no date column) MAY still orderBy portid — prevents an over-eager "remove all orderBy" sweep
- 70/70 portwatch-port-activity tests pass (was 68; added 2 guards)
- 159/159 across full portwatch suite (no regressions)
- \`npm run typecheck:api\` clean
- \`npm run lint\` clean
- \`seed-portwatch-port-activity.mjs\` is NOT in Dockerfile.relay — no relay-COPY change needed

## Test plan

- [x] Tests pass + lint/typecheck clean
- [ ] Post-merge: confirm \`/api/health\` flips \`portwatchPortActivity\` from STALE_SEED back to OK after the next 12h cron tick
- [ ] Post-merge: Railway logs for \`seed-bundle-portwatch-port-activity\` show real "Seeded N countries" lines instead of the cached-replay no-op pattern (\`Cache: 174 hits, 0 misses\` + 10s)
- [ ] Post-merge: per-country fetch latency drops from ~140s → ~12s — bundle's 540s budget gives ample headroom (174 countries / CONCURRENCY=12 / 15 batches × ~12s ≈ 180s total)

## Related memories saved

- \`arcgis-dateonly-orderby-pathologically-slow\` — generalises to any ArcGIS endpoint with \`esriFieldTypeDateOnly\` (always introspect schema via \`?f=json\` before assuming)
- \`per-item-cache-cliff-masks-upstream-regression\` — the outer trap that hid this for days