### PR TITLE
feat: digest/brief canonical contract — Sprint 1 Phase 1 (U1+U2+U3+U7)

### DIFF
--- a/scripts/lib/brief-compose.mjs
+++ b/scripts/lib/brief-compose.mjs
@@ -313,6 +313,20 @@ function digestStoryToUpstreamTopStory(s) {
     hash: typeof s?.hash === 'string' && s.hash.length > 0
       ? s.hash
       : (typeof s?.titleHash === 'string' ? s.titleHash : undefined),
+    // Sprint 1 / U3: canonical cluster-rep hash threaded into
+    // BriefStory.clusterId via filterTopStories. For multi-story
+    // clusters, materializeCluster (in brief-dedup-jaccard.mjs) sets
+    // `mergedHashes[]` on the rep — `mergedHashes[0]` is the
+    // deterministic cluster identity (sort: score DESC, mentionCount
+    // DESC, hash ASC), shared by every member that maps back to this
+    // rep. For singleton clusters (no clustering pass, or one-member
+    // result) `mergedHashes` is absent — fall back to the rep's own
+    // hash so singletons satisfy the plan invariant "clusterId equals
+    // the story's own hash" naturally.
+    clusterRepHash: Array.isArray(s?.mergedHashes) && s.mergedHashes.length > 0
+      && typeof s.mergedHashes[0] === 'string' && s.mergedHashes[0].length > 0
+      ? s.mergedHashes[0]
+      : (typeof s?.hash === 'string' && s.hash.length > 0 ? s.hash : undefined),
   };
 }
 

--- a/scripts/lib/brief-dedup-jaccard.mjs
+++ b/scripts/lib/brief-dedup-jaccard.mjs
@@ -70,11 +70,28 @@ export function jaccardSimilarity(setA, setB) {
  * downstream. Accepts an array of story refs (already a single
  * cluster) and returns one story object.
  *
+ * Sort key (Sprint 1 / U3):
+ *   1. currentScore DESC      — primary editorial-importance signal
+ *   2. mentionCount DESC      — multi-source corroboration tiebreak
+ *   3. hash ASC               — fully-deterministic final tiebreak
+ *
+ * The hash tiebreak makes the result independent of input order.
+ * Without it, two inputs with identical score+mentionCount would
+ * resolve to whichever was first in the caller's array — and that
+ * order can vary across ticks (Map iteration over a mutable
+ * embedding-by-hash store, shuffled cluster membership, etc.).
+ * Since `mergedHashes[0]` is now threaded into BriefStory.clusterId,
+ * a non-deterministic rep would break the U3 idempotency invariant
+ * (same upstream cluster across two ticks → identical clusterId).
+ *
  * @param {Array<{hash:string, currentScore:number, mentionCount:number}>} items
  */
 export function materializeCluster(items) {
   const sorted = [...items].sort(
-    (a, b) => b.currentScore - a.currentScore || b.mentionCount - a.mentionCount,
+    (a, b) =>
+      b.currentScore - a.currentScore
+      || b.mentionCount - a.mentionCount
+      || (a.hash < b.hash ? -1 : a.hash > b.hash ? 1 : 0),
   );
   const best = { ...sorted[0] };
   if (sorted.length > 1) {

--- a/scripts/lib/digest-orchestration-helpers.mjs
+++ b/scripts/lib/digest-orchestration-helpers.mjs
@@ -247,3 +247,48 @@ export function readTimeAgeCutoffMs(windowStartMs) {
   const STALE_BUFFER_MS = 24 * 60 * 60 * 1000;
   return windowStartMs - STALE_BUFFER_MS;
 }
+
+/**
+ * Sprint 1 / U2 — option (a) canonical-send mapping.
+ *
+ * Given the per-user winner record from the compose phase
+ * (briefByUser.get(userId), shape: `{ envelope, magazineUrl, chosenVariant,
+ * synthesisLevel }`) and the candidate rule list for that user, return
+ * the SINGLE rule whose channel body the send loop should use for this
+ * user-slot. Under option (a), the email body and the magazine URL
+ * BOTH come from this rule's pool — no per-rule fan-out, no
+ * winner-vs-non-winner channel divergence.
+ *
+ * Returns null when:
+ *   - briefByUser has no entry for this user (compose found no
+ *     non-empty pool — nothing to send).
+ *   - briefByUser entry has no chosenVariant (defensive; treat as
+ *     "no canonical winner identified" and skip the send).
+ *   - candidate list contains no rule whose `variant` matches
+ *     `chosenVariant` (rule was deleted between compose and send;
+ *     skip rather than misroute to a sibling rule).
+ *
+ * The send loop calls this BEFORE the per-rule isDue check — non-
+ * winner rules are dropped here, so the cron's `digest:last-sent:v1:
+ * ${userId}:${variant}` write only ever happens for the winner-variant
+ * key. Old non-winner-variant keys from pre-option-(a) sends remain in
+ * Redis until their 8d TTL elapses; they are orphan but harmless
+ * (nothing reads them after this change).
+ *
+ * Pure helper — no I/O.
+ *
+ * @param {{ chosenVariant?: string } | null | undefined} brief
+ * @param {Array<{ userId?: string; variant?: string }>} userRules — all rules for ONE user
+ * @returns {{ userId?: string; variant?: string } | null}
+ */
+export function selectCanonicalSendRule(brief, userRules) {
+  if (!brief || typeof brief.chosenVariant !== 'string' || brief.chosenVariant === '') {
+    return null;
+  }
+  if (!Array.isArray(userRules) || userRules.length === 0) return null;
+  for (const rule of userRules) {
+    if (!rule || typeof rule.variant !== 'string') continue;
+    if (rule.variant === brief.chosenVariant) return rule;
+  }
+  return null;
+}

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -43,6 +43,7 @@ import {
   pickWinningCandidateWithPool,
   readTimeAgeCutoffMs,
   runSynthesisWithFallback,
+  selectCanonicalSendRule,
   shouldDropTrackByAge,
   subjectForBrief,
 } from './lib/digest-orchestration-helpers.mjs';
@@ -1660,10 +1661,42 @@ async function main() {
   // digest delivery.
   const { briefByUser, composeSuccess, composeFailed } = await composeBriefsForRun(rules, nowMs);
 
+  // Sprint 1 / U2 — option (a) canonical-send mapping. Build a per-user
+  // rule index ONCE so each iteration of the send loop can resolve the
+  // user's canonical winner rule in O(1). The compose phase already
+  // identified the winner via pickWinningCandidateWithPool and stamped
+  // its variant into briefByUser[userId].chosenVariant; we use that as
+  // the per-user filter below to drop non-winner rules from the send
+  // fan-out. Rules without a string userId are skipped here so the
+  // index lookup in the loop is a single map.get() rather than a re-
+  // filter each iteration.
+  const userRulesByUserId = new Map();
+  for (const rule of rules) {
+    if (!rule || typeof rule.userId !== 'string') continue;
+    const list = userRulesByUserId.get(rule.userId);
+    if (list) list.push(rule);
+    else userRulesByUserId.set(rule.userId, [rule]);
+  }
+
   let sentCount = 0;
 
   for (const rule of rules) {
     if (!rule.userId || !rule.variant) continue;
+
+    // Sprint 1 / U2 — drop non-winner rules under option (a). The
+    // compose phase already picked ONE rule per user-slot; only that
+    // rule drives the send. Non-winner rules silently fall through
+    // here (their pools are absorbed into the winner's at the
+    // accumulator/dedup layer upstream — see brief-dedup.mjs). Users
+    // whose compose phase produced no winner (briefByUser miss, or
+    // chosenVariant absent) skip the send entirely; the next cron
+    // tick will recompose.
+    const briefForUser = briefByUser.get(rule.userId);
+    const canonicalRule = selectCanonicalSendRule(
+      briefForUser,
+      userRulesByUserId.get(rule.userId) ?? [],
+    );
+    if (!canonicalRule || canonicalRule !== rule) continue;
 
     const lastSentKey = `digest:last-sent:v1:${rule.userId}:${rule.variant}`;
     // Reuse the same getLastSentAt helper the compose pass used so
@@ -1710,26 +1743,31 @@ async function main() {
       continue;
     }
 
-    // Per-rule synthesis: each due rule's channel body must be
-    // internally consistent (lead derived from THIS rule's pool, not
-    // some other rule's). For multi-rule users, the compose flow
-    // picked ONE winning rule for the magazine envelope, but the
-    // send-loop body for a non-winner rule needs ITS OWN lead — else
-    // the email leads with one pool's narrative while listing stories
-    // from another pool. Cache absorbs the cost: when this is the
-    // winning rule, generateDigestProse hits the cache row written
-    // during the compose pass (same userId/sensitivity/pool/ctx) and
-    // no extra LLM call fires.
+    // Sprint 1 / U2 — option (a) canonical send.
     //
-    // The magazineUrl still points at the winner's envelope — that
-    // surface is the share-worthy alpha and remains a single brief
-    // per user per slot. Channel-body lead vs magazine lead may
-    // therefore differ for non-winner rules; users on those rules
-    // see their own coherent email + a magazine that shows the
-    // winner's editorial. Acceptable trade-off given multi-rule
-    // users are rare and the `(userId, issueSlot)` URL contract
-    // can't represent multiple per-rule briefs without an
-    // architectural change to the URL signer + Redis key.
+    // We are guaranteed to be on the WINNING rule for this user-slot
+    // (the canonical-rule filter above dropped every non-winner). So:
+    //
+    //   - The synthesis we run here against `stories` is the canonical
+    //     synthesis that backs the magazine envelope. generateDigestProse
+    //     hits the same cache row the compose phase wrote (same
+    //     userId/sensitivity/pool/ctx), so this is a cache read, not a
+    //     second LLM call.
+    //   - Every channel body — email HTML + plain text + Telegram +
+    //     Slack + Discord + webhook — reads from this single synthesis
+    //     output. There is no per-rule fan-out, no winner-vs-non-winner
+    //     channel divergence, and no separate per-rule magazine URL.
+    //   - The magazine URL (briefByUser[userId].magazineUrl) points at
+    //     the SAME rule's envelope this synthesis was derived from, so
+    //     subscribers experience full email-body ↔ magazine consistency
+    //     for the first time.
+    //
+    // Pre-U2 (PR <U2-pr> reference), this block ran a fresh synthesis
+    // per enabled rule and accepted "channel-body lead vs magazine lead
+    // may differ for non-winner rules" as a trade-off. Option (a) closes
+    // the divergence at the cost of multi-rule users seeing only the
+    // winner rule's content per slot — confirmed during planning as the
+    // intended subscriber-visible behaviour change.
     const brief = briefByUser.get(rule.userId);
     let briefSynthesis = null;  // full {lead, threads, signals} when synthesis succeeded
     let briefLead = null;       // string projection for non-email channels + parity log
@@ -1815,26 +1853,23 @@ async function main() {
       // (null !== '<envelope stub lead>'), flooding Sentry with
       // false positives. Greptile P1 on PR #3396.
       //
-      // Two distinct properties to track:
+      // Sprint 1 / U2 — option (a) made `winner_match=true` the
+      // UNIVERSAL invariant: the canonical-rule filter at the top of
+      // the loop ensures every send is the user's winning rule for
+      // this slot. Two consequences:
       //
-      // 1. CHANNEL parity (load-bearing): for ONE send, every channel
-      //    body of THIS rule (email HTML + plain text + Telegram +
-      //    Slack + Discord + webhook) reads the same `briefLead`
-      //    string. Verifiable by code review (single variable threaded
-      //    everywhere); logged here as `exec_len` for telemetry.
+      // 1. `winner_match=false` was previously "expected divergence
+      //    for a non-winner rule send"; under option (a) it can ONLY
+      //    indicate a bug — most likely briefByUser missing the user
+      //    OR chosenVariant drifting between compose and send. Treat
+      //    as a hard alarm, not a periodic mismatch warning.
+      // 2. `channels_equal=false` while `winner_match=true` retains
+      //    its pre-U2 meaning — canonical-synthesis cache row drift.
+      //    Same PARITY REGRESSION alarm semantics.
       //
-      // 2. WINNER parity (informational): when `winner_match=true`,
-      //    THIS rule is the same one the magazine envelope was
-      //    composed from — so channel lead == magazine lead (cache-
-      //    shared via generateDigestProse). When `winner_match=false`,
-      //    this is a non-winner rule send; channel lead reflects this
-      //    rule's pool while the magazine URL points at the winner's
-      //    editorial. Expected divergence, not a regression.
-      //
-      // PARITY REGRESSION fires only when winner_match=true AND the
-      // channel lead differs from the envelope lead (the canonical-
-      // synthesis cache row has drifted between compose and send
-      // passes — a real contract break).
+      // Both alarms warn on the same console.warn channel so Sentry's
+      // console-breadcrumb hook surfaces them without explicit
+      // captureMessage calls.
       if (AI_DIGEST_ENABLED && rule.aiDigestEnabled !== false) {
         const envLead = brief?.envelope?.data?.digest?.lead ?? '';
         const winnerVariant = brief?.chosenVariant ?? '';
@@ -1851,13 +1886,22 @@ async function main() {
             `channels_equal=${channelsEqual} ` +
             `public_lead_len=${publicLead.length}`,
         );
-        if (winnerMatch && !channelsEqual && briefLead && envLead) {
-          // Sentry alert candidate — winner_match=true means this rule
-          // composed the envelope, so its channel lead MUST match the
-          // envelope lead. Mismatch = canonical-synthesis cache drift
-          // or code regression. Logged loudly so Sentry's console-
-          // breadcrumb hook surfaces it without an explicit
-          // captureMessage call.
+        if (!winnerMatch) {
+          // Under option (a) this is unreachable in practice — the
+          // canonical-rule filter at the top of the loop drops every
+          // non-winner rule before this point. If we ever see it in
+          // production, the canonical-rule filter has been bypassed
+          // OR briefByUser/chosenVariant drifted between compose and
+          // send. Hard alarm.
+          console.warn(
+            `[digest] PARITY REGRESSION user=${rule.userId} — winner_match=false under option (a). ` +
+              `Expected: winner_variant=${winnerVariant || '<missing>'} === rule_variant=${rule.variant ?? 'full'}. ` +
+              `Investigate: canonical-rule filter bypass OR compose↔send chosenVariant drift.`,
+          );
+        } else if (!channelsEqual && briefLead && envLead) {
+          // Canonical-synthesis cache row drifted between compose and
+          // send passes — a real contract break. Same semantics as
+          // pre-U2 PARITY REGRESSION.
           console.warn(
             `[digest] PARITY REGRESSION user=${rule.userId} — winner-rule channel lead != envelope lead. ` +
               `Investigate: cache drift between compose pass and send pass?`,

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -1679,24 +1679,57 @@ async function main() {
   }
 
   let sentCount = 0;
+  // Sprint 1 / U2 hardening — track which users we've already warned
+  // about a compose-miss so each user gets ONE warn per cron tick, not
+  // one per rule iteration. See the briefForUser-missing branch below.
+  const composeMissUsers = new Set();
 
   for (const rule of rules) {
     if (!rule.userId || !rule.variant) continue;
 
-    // Sprint 1 / U2 — drop non-winner rules under option (a). The
-    // compose phase already picked ONE rule per user-slot; only that
-    // rule drives the send. Non-winner rules silently fall through
-    // here (their pools are absorbed into the winner's at the
-    // accumulator/dedup layer upstream — see brief-dedup.mjs). Users
-    // whose compose phase produced no winner (briefByUser miss, or
-    // chosenVariant absent) skip the send entirely; the next cron
-    // tick will recompose.
+    // Sprint 1 / U2 — drop non-winner rules under option (a) WHEN
+    // compose succeeded for this user. The compose phase already
+    // picked ONE rule per user-slot; only that rule drives the send.
+    // Non-winner rules silently fall through here (their pools are
+    // absorbed into the winner's at the accumulator/dedup layer
+    // upstream — see brief-dedup.mjs).
+    //
+    // Codex PR #3614 P1 — composeBriefsForRun returns an empty map
+    // when BRIEF_SIGNING_SECRET is missing OR brief compose is
+    // disabled OR a per-user compose error was caught upstream. The
+    // pre-fix canonical filter dropped EVERY rule for those users —
+    // turning a brief-compose outage / config disable into a digest-
+    // send outage. Now: when briefForUser is missing, the canonical
+    // filter is skipped and we fall through to the legacy per-rule
+    // send path (multi-rule divergence reappears for THAT USER ONLY
+    // for THIS TICK only — acceptable trade-off because silent
+    // suppression of an entire user's digest is worse than a one-
+    // tick divergence on the path back to recovery). magazineUrl
+    // resolves to null at line ~1793 (brief?.magazineUrl ?? null);
+    // the carousel + CTA paths already gate on magazineUrl being
+    // truthy, so this branch produces a brief-less email/text body
+    // that still delivers the curated story list.
     const briefForUser = briefByUser.get(rule.userId);
-    const canonicalRule = selectCanonicalSendRule(
-      briefForUser,
-      userRulesByUserId.get(rule.userId) ?? [],
-    );
-    if (!canonicalRule || canonicalRule !== rule) continue;
+    if (briefForUser) {
+      const canonicalRule = selectCanonicalSendRule(
+        briefForUser,
+        userRulesByUserId.get(rule.userId) ?? [],
+      );
+      if (!canonicalRule || canonicalRule !== rule) continue;
+    } else {
+      if (!composeMissUsers.has(rule.userId)) {
+        console.warn(
+          `[digest] compose-miss user=${rule.userId} — briefByUser has no entry. ` +
+            `Falling through to per-rule send (no magazineUrl, multi-rule users will see ` +
+            `pre-U2 per-rule body divergence for this tick). Investigate: ` +
+            `BRIEF_SIGNING_SECRET unset, brief compose disabled, OR composeBriefForUser ` +
+            `caught a per-user error (Sentry should carry the trace).`,
+        );
+        composeMissUsers.add(rule.userId);
+      }
+      // Fall through — no canonical filter; this rule iterates
+      // through isDue / isUserPro / buildDigest / send normally.
+    }
 
     const lastSentKey = `digest:last-sent:v1:${rule.userId}:${rule.variant}`;
     // Reuse the same getLastSentAt helper the compose pass used so

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -1801,7 +1801,10 @@ async function main() {
     // the divergence at the cost of multi-rule users seeing only the
     // winner rule's content per slot — confirmed during planning as the
     // intended subscriber-visible behaviour change.
-    const brief = briefByUser.get(rule.userId);
+    //
+    // Reuse briefForUser fetched above (Codex PR #3614 P2 — was a
+    // duplicate Map.get on the same key).
+    const brief = briefForUser;
     let briefSynthesis = null;  // full {lead, threads, signals} when synthesis succeeded
     let briefLead = null;       // string projection for non-email channels + parity log
     let synthesisLevel = 3;

--- a/server/_shared/brief-render.js
+++ b/server/_shared/brief-render.js
@@ -133,6 +133,11 @@ const ALLOWED_STORY_KEYS = new Set([
   'description',
   'source',
   'sourceUrl',
+  // v4+ stable per-story-cluster identity (see shared/brief-envelope.js
+  // version-history doc-block). Required on v4 envelopes — checked
+  // below in the per-story validator. Optional on v1-v3 envelopes
+  // still in TTL.
+  'clusterId',
   'whyMatters',
 ]);
 
@@ -342,6 +347,23 @@ export function assertBriefEnvelope(envelope) {
           `envelope.data.stories[${i}].sourceUrl ${/** @type {Error} */ (err).message}`,
         );
       }
+    }
+    // clusterId is REQUIRED on v4 (the canonical-contract bump that
+    // wires per-cluster identity into the delivered-log + CI invariant)
+    // and OPTIONAL on v1-v3 envelopes still in the 7-day TTL window.
+    // When present on any version it must be a non-empty string —
+    // empty strings would silently collapse delivered-log keys across
+    // clusters and break the `digest.cards ⊆ brief.cards` invariant.
+    if (env.version === BRIEF_ENVELOPE_VERSION) {
+      if (!isNonEmptyString(st.clusterId)) {
+        throw new Error(
+          `envelope.data.stories[${i}].clusterId must be a non-empty string on v${BRIEF_ENVELOPE_VERSION} envelopes (got ${JSON.stringify(st.clusterId)})`,
+        );
+      }
+    } else if (st.clusterId !== undefined && !isNonEmptyString(st.clusterId)) {
+      throw new Error(
+        `envelope.data.stories[${i}].clusterId, when present on v${env.version}, must be a non-empty string (got ${JSON.stringify(st.clusterId)})`,
+      );
     }
   });
 

--- a/server/_shared/brief-render.js
+++ b/server/_shared/brief-render.js
@@ -334,12 +334,19 @@ export function assertBriefEnvelope(envelope) {
         `envelope.data.stories[${i}].threatLevel must be one of critical|high|medium|low (got ${JSON.stringify(st.threatLevel)})`,
       );
     }
-    // sourceUrl is required on v2 and absent on v1. When present on
-    // either version, it must parse cleanly — a malformed URL would
-    // break the href. On v1 it's expected to be absent; a v1 envelope
-    // that somehow carries a sourceUrl is still validated (cheap
-    // defence against composer regressions).
-    if (env.version === BRIEF_ENVELOPE_VERSION || st.sourceUrl !== undefined) {
+    // sourceUrl is required from v2 onward and absent on v1. When
+    // present on v1, it must still parse cleanly — a malformed URL
+    // would break the href. A v1 envelope that somehow carries a
+    // sourceUrl is still validated (cheap defence against composer
+    // regressions).
+    //
+    // Codex PR #3614 P2 — pre-fix used `env.version === BRIEF_ENVELOPE_VERSION`
+    // which only required sourceUrl on the LATEST version. Pre-U1
+    // (when BRIEF_ENVELOPE_VERSION === 3) v2 envelopes were already
+    // exempted; the v4 bump made it worse by also exempting v3. Both
+    // are wrong per the v2+ contract. Switched to `env.version >= 2`
+    // so every supported v2/v3/v4/... envelope enforces sourceUrl.
+    if (env.version >= 2 || st.sourceUrl !== undefined) {
       try {
         validateSourceUrl(st.sourceUrl);
       } catch (err) {

--- a/shared/brief-envelope.d.ts
+++ b/shared/brief-envelope.d.ts
@@ -19,7 +19,7 @@
 // stripped at compose time. See PR #3143 for the notify-endpoint fix
 // that established this rule.
 
-export const BRIEF_ENVELOPE_VERSION: 3;
+export const BRIEF_ENVELOPE_VERSION: 4;
 
 /**
  * Versions the renderer accepts from Redis on READ. Always contains
@@ -120,6 +120,22 @@ export interface BriefStory {
    * remain banned in `data`.
    */
   sourceUrl?: string;
+  /**
+   * Stable per-story-cluster identity (v4+). Sourced from the rep
+   * `hash` of `mergedHashes[0]` after `materializeCluster` — survives
+   * wire rewordings at the upstream ingester's identity layer, stable
+   * across ticks (unlike the per-tick numeric `clusterId` produced by
+   * brief-dedup-replay-log). Drives the per-channel/per-cluster
+   * delivered-log key (`digest:sent:v1:{userId}:{channel}:{ruleId}:
+   * {clusterId}`) and the `digest.cards ⊆ brief.cards` CI invariant.
+   *
+   * REQUIRED on v4 envelopes (write-time enforced). OPTIONAL on
+   * v1-v3 envelopes still resident in Redis under the 7-day brief
+   * TTL window (read-time back-compat). Composers must never write
+   * an empty string — write-time validation rejects "" the same as
+   * undefined for v4.
+   */
+  clusterId?: string;
   /** Per-user LLM-generated rationale. */
   whyMatters: string;
 }

--- a/shared/brief-envelope.js
+++ b/shared/brief-envelope.js
@@ -40,9 +40,21 @@
  * content. v2 envelopes already in TTL stay readable through
  * SUPPORTED_ENVELOPE_VERSIONS.
  *
- * @type {3}
+ * v4 (2026-05-06, Sprint 1 canonical contract): BriefStory.clusterId
+ * added. Stable per-story-cluster identity (rep `hash` from
+ * `mergedHashes[0]` after `materializeCluster`) enabling the
+ * per-channel/per-cluster delivered-log (`digest:sent:v1:...`) and
+ * the `digest.cards ⊆ brief.cards` CI invariant. clusterId is
+ * REQUIRED on v4 envelopes (write-time) and OPTIONAL on v1-v3
+ * envelopes still resident in Redis under the 7-day brief TTL
+ * window (read-time back-compat). The 7-day window covers every
+ * downstream TTL: brief:* (7d), story:track:v1:* (7d),
+ * digest:accumulator:v1:* (shorter). U3 wires the value through
+ * compose; U1 only adds the field + assertion plumbing.
+ *
+ * @type {4}
  */
-export const BRIEF_ENVELOPE_VERSION = 3;
+export const BRIEF_ENVELOPE_VERSION = 4;
 
 /**
  * Versions the renderer still accepts from Redis on READ. Must always
@@ -53,4 +65,4 @@ export const BRIEF_ENVELOPE_VERSION = 3;
  *
  * @type {ReadonlySet<number>}
  */
-export const SUPPORTED_ENVELOPE_VERSIONS = new Set([1, 2, 3]);
+export const SUPPORTED_ENVELOPE_VERSIONS = new Set([1, 2, 3, 4]);

--- a/shared/brief-filter.js
+++ b/shared/brief-filter.js
@@ -266,6 +266,25 @@ export function filterTopStories({ stories, sensitivity, maxStories = 12, maxPer
       continue;
     }
 
+    // v4 clusterId: REQUIRED on every story (assertBriefEnvelope
+    // enforces non-empty). U1 ships a transitional placeholder
+    // sourced from the upstream story's per-story `hash` (already
+    // plumbed through digestStoryToUpstreamTopStory at
+    // scripts/lib/brief-compose.mjs). For singleton clusters this is
+    // the same value U3 will emit (per the plan: "singleton cluster
+    // — clusterId equals the story's own hash"). U3 swaps the
+    // upstream source to `mergedHashes[0]` from materializeCluster
+    // so multi-story clusters collapse to a single shared clusterId.
+    //
+    // Fallback path: when upstream omits `hash` (the news:insights
+    // path that doesn't go through digestStoryToUpstreamTopStory),
+    // derive a deterministic placeholder from the validated sourceUrl
+    // — always present at this point in the filter. The clusterId
+    // contract only requires non-empty + stable across ticks for the
+    // SAME upstream story; sourceUrl uniqueness is the upstream's
+    // own invariant.
+    const upstreamHash = typeof raw.hash === 'string' && raw.hash.length > 0 ? raw.hash : null;
+    const clusterId = upstreamHash ?? `url:${sourceUrl}`;
     out.push({
       category,
       country,
@@ -274,6 +293,7 @@ export function filterTopStories({ stories, sensitivity, maxStories = 12, maxPer
       description,
       source,
       sourceUrl,
+      clusterId,
       // Stubbed at Phase 3a. Phase 3b replaces this with an LLM-
       // generated per-user rationale. The renderer requires a non-
       // empty string, so we emit a generic fallback rather than

--- a/shared/brief-filter.js
+++ b/shared/brief-filter.js
@@ -267,24 +267,37 @@ export function filterTopStories({ stories, sensitivity, maxStories = 12, maxPer
     }
 
     // v4 clusterId: REQUIRED on every story (assertBriefEnvelope
-    // enforces non-empty). U1 ships a transitional placeholder
-    // sourced from the upstream story's per-story `hash` (already
-    // plumbed through digestStoryToUpstreamTopStory at
-    // scripts/lib/brief-compose.mjs). For singleton clusters this is
-    // the same value U3 will emit (per the plan: "singleton cluster
-    // — clusterId equals the story's own hash"). U3 swaps the
-    // upstream source to `mergedHashes[0]` from materializeCluster
-    // so multi-story clusters collapse to a single shared clusterId.
+    // enforces non-empty). Sprint 1 / U3 lands the canonical source:
+    // `raw.clusterRepHash` is `mergedHashes[0]` from materializeCluster
+    // (scripts/lib/brief-dedup-jaccard.mjs) — the deterministic
+    // cluster-rep hash shared across every member of a multi-story
+    // cluster. digestStoryToUpstreamTopStory at scripts/lib/brief-compose.mjs
+    // wires it onto the upstream story shape this filter consumes.
     //
-    // Fallback path: when upstream omits `hash` (the news:insights
-    // path that doesn't go through digestStoryToUpstreamTopStory),
-    // derive a deterministic placeholder from the validated sourceUrl
-    // — always present at this point in the filter. The clusterId
-    // contract only requires non-empty + stable across ticks for the
-    // SAME upstream story; sourceUrl uniqueness is the upstream's
-    // own invariant.
+    // Source preference (top wins):
+    //   1. raw.clusterRepHash — canonical, materializeCluster path.
+    //      Singleton clusters: equals the story's own hash by
+    //      construction (see digestStoryToUpstreamTopStory fallback).
+    //      Multi-story clusters: shared identity for every member.
+    //   2. raw.hash — back-compat for paths that bypass the cluster
+    //      materializer (e.g. composeBriefForRule against
+    //      news:insights:v1, which feeds raw upstream stories without
+    //      a clusterRepHash field). Singleton cluster identity is the
+    //      story's own hash, so the contract still holds.
+    //   3. `url:${sourceUrl}` — last-ditch deterministic fallback for
+    //      paths that omit hash entirely. sourceUrl is validated above
+    //      and is required for v2+ stories, so it is always present
+    //      at this point.
+    //
+    // The clusterId contract: non-empty string, stable across ticks
+    // for the SAME upstream cluster, distinct across distinct
+    // clusters. All three sources satisfy non-empty + stability; the
+    // ordering ensures multi-story clusters collapse to ONE shared
+    // clusterId (which raw.hash alone could not — it would give every
+    // member a distinct id).
+    const repHash = typeof raw.clusterRepHash === 'string' && raw.clusterRepHash.length > 0 ? raw.clusterRepHash : null;
     const upstreamHash = typeof raw.hash === 'string' && raw.hash.length > 0 ? raw.hash : null;
-    const clusterId = upstreamHash ?? `url:${sourceUrl}`;
+    const clusterId = repHash ?? upstreamHash ?? `url:${sourceUrl}`;
     out.push({
       category,
       country,

--- a/tests/brief-composer-rule-dedup.test.mjs
+++ b/tests/brief-composer-rule-dedup.test.mjs
@@ -341,4 +341,65 @@ describe('Sprint 1 U2 — multi-rule canonicalisation (option a) source guards',
       'send loop must document option (a) canonicalisation by name',
     );
   });
+
+  // Codex PR #3614 P1 regression — the canonical filter must NOT
+  // suppress digest delivery when briefByUser is empty (compose
+  // disabled, signing secret missing, per-user compose error caught).
+  // The fix gates the canonical filter on `if (briefForUser)` and
+  // falls through to the legacy per-rule send when missing, with a
+  // loud one-warn-per-user log so Sentry surfaces the compose-miss.
+  it('canonical filter is gated on briefForUser existence (compose-miss falls through)', () => {
+    // The fix shape: `if (briefForUser) { selectCanonicalSendRule(...) }`
+    // not `selectCanonicalSendRule(briefForUser, ...)` unconditionally.
+    // We assert the gating shape exists in the source.
+    assert.match(
+      cronSrc,
+      /if \(briefForUser\)\s*\{[\s\S]{0,400}?selectCanonicalSendRule/,
+      'canonical filter must be gated on briefForUser truthiness — Codex PR #3614 P1',
+    );
+  });
+
+  it('compose-miss path emits a loud one-per-user warn (not silent suppression)', () => {
+    // The fall-through path must be observable. We assert the warn
+    // string + the once-per-user dedup Set both exist in the source.
+    assert.match(
+      cronSrc,
+      /composeMissUsers/,
+      'cron must track which users have already been warned to dedup compose-miss logs to once per tick',
+    );
+    assert.match(
+      cronSrc,
+      /\[digest\] compose-miss user=/,
+      'cron must emit a [digest] compose-miss user=... warn line for Sentry breadcrumbs',
+    );
+    assert.match(
+      cronSrc,
+      /console\.warn[\s\S]{0,200}compose-miss/,
+      'compose-miss must use console.warn (not console.log) so Sentry promotes it to a breadcrumb',
+    );
+  });
+
+  it('compose-miss comment cites Codex PR #3614 P1 + names the failure modes', () => {
+    // Discoverability: a future operator hitting the warn must be
+    // able to find the rationale immediately. The docblock cites the
+    // review item by ID and names the three failure modes (signing
+    // secret, compose disabled, per-user compose error) so on-call
+    // can triage without spelunking through git history.
+    assert.match(
+      cronSrc,
+      /Codex PR #3614 P1/,
+      'fall-through docblock must cite the review item it addresses',
+    );
+    const flat = cronSrc.replace(/\s+/g, ' ');
+    assert.match(
+      flat,
+      /BRIEF_SIGNING_SECRET/,
+      'docblock must name BRIEF_SIGNING_SECRET as one of the compose-miss failure modes',
+    );
+    assert.match(
+      flat,
+      /per-user compose error/i,
+      'docblock must name caught-per-user-error as one of the compose-miss failure modes',
+    );
+  });
 });

--- a/tests/brief-composer-rule-dedup.test.mjs
+++ b/tests/brief-composer-rule-dedup.test.mjs
@@ -7,7 +7,7 @@
 //    brief key is user-scoped. Multi-variant users must produce exactly
 //    one brief per issue, with a deterministic tie-breaker.
 
-import { describe, it } from 'node:test';
+import { before, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   dedupeRulesByUser,
@@ -250,6 +250,95 @@ describe('aiDigestEnabled default parity', () => {
     assert.ok(
       src.includes('rule.aiDigestEnabled !== false'),
       'seed-digest-notifications.mjs must keep `rule.aiDigestEnabled !== false`',
+    );
+  });
+});
+
+// ── Sprint 1 / U2 — option (a) canonicalisation (source-level guards) ─────
+//
+// These are deliberately source-text assertions (not behavior assertions on
+// the live cron). The full integration shape — compose → send loop →
+// channel formatter — requires Upstash + Convex + Resend mocks that are
+// out of scope for this PR. The pure-function half of the U2 contract
+// lives in tests/digest-orchestration-helpers.test.mjs as the
+// `selectCanonicalSendRule` describe block; this block locks the
+// SOURCE-level invariants that protect the contract from regressing
+// silently in scripts/seed-digest-notifications.mjs.
+
+describe('Sprint 1 U2 — multi-rule canonicalisation (option a) source guards', () => {
+  let cronSrc;
+
+  before(async () => {
+    const fs = await import('node:fs/promises');
+    cronSrc = await fs.readFile(
+      new URL('../scripts/seed-digest-notifications.mjs', import.meta.url),
+      'utf8',
+    );
+  });
+
+  it('imports selectCanonicalSendRule from digest-orchestration-helpers', () => {
+    // The send loop MUST filter to the winner rule per user before the
+    // per-rule isDue + channel-fetch + synthesis cascade. Without this
+    // import, the cron is by definition fanning out to all rules per
+    // user (the pre-U2 divergence shape).
+    assert.match(
+      cronSrc,
+      /selectCanonicalSendRule/,
+      'cron must import the option-(a) canonical-rule selector helper',
+    );
+  });
+
+  it('does NOT carry the pre-U2 "Per-rule synthesis" comment block', () => {
+    // The comment block at lines 1713-1732 of pre-U2 source documented
+    // the divergence as an accepted trade-off ("Channel-body lead vs
+    // magazine lead may therefore differ for non-winner rules"). U2
+    // resolves the divergence; the comment must be replaced. If a
+    // future refactor reintroduces the per-rule fan-out shape, the
+    // commenter is likely to copy the old block back — this guard
+    // catches that. Tests strip newlines so cross-line phrases match.
+    const flat = cronSrc.replace(/\s+/g, ' ');
+    assert.doesNotMatch(
+      flat,
+      /Channel-body lead vs magazine lead may.{0,40}differ for non-winner rules/,
+      'cron must not carry the pre-U2 divergence-acceptance comment',
+    );
+    assert.doesNotMatch(
+      flat,
+      /the send-loop body for a non-winner rule needs.{0,20}ITS OWN lead/,
+      'cron must not carry the pre-U2 per-rule synthesis rationale',
+    );
+  });
+
+  it('parity log records winner_match as the universal expectation (option a invariant)', () => {
+    // The runtime parity log around lines 1838-1866 of pre-U2 source
+    // permitted winner_match=false as "expected divergence" for
+    // non-winner rule sends. Under option (a) every send IS the
+    // winner — winner_match=false now means a real bug. The log line
+    // and its surrounding comment must reflect the new universal
+    // invariant.
+    assert.match(
+      cronSrc,
+      /winner_match/,
+      'parity log must still emit winner_match for observability',
+    );
+    // The "Expected divergence, not a regression" reasoning is the
+    // pre-U2 trade-off acceptance language. Must be gone.
+    const flat = cronSrc.replace(/\s+/g, ' ');
+    assert.doesNotMatch(
+      flat,
+      /Expected divergence, not a regression/,
+      'pre-U2 "expected divergence" framing must be replaced by a universal-equality guarantee',
+    );
+  });
+
+  it('canonical-send mapping is documented near the send loop (option a docblock present)', () => {
+    // Discoverability: a future operator reading the send loop must
+    // immediately see WHY only one rule per user is processed. The
+    // replacement comment block names option (a) explicitly.
+    assert.match(
+      cronSrc,
+      /option \(a\)/i,
+      'send loop must document option (a) canonicalisation by name',
     );
   });
 });

--- a/tests/brief-from-digest-stories.test.mjs
+++ b/tests/brief-from-digest-stories.test.mjs
@@ -838,9 +838,17 @@ describe('Sprint 1 U7 — digest projection invariant: digest.cards ⊆ brief.ca
    * derivation. If the live code changes, this helper changes; the U3
    * integration test in this same file is the cross-check.
    *
-   *   1. mergedHashes[0]  — canonical materializeCluster path
-   *   2. hash             — back-compat for non-clustered producers
-   *   3. (test should never reach this — empty input throws)
+   *   1. mergedHashes[0]   — canonical materializeCluster path
+   *   2. hash              — back-compat for non-clustered producers
+   *   3. `url:${sourceUrl}`— last-ditch fallback (matches shared/brief-filter.js;
+   *                          covers paths that omit hash entirely, e.g. news:
+   *                          insights ingestion)
+   *
+   * Codex PR #3614 P2 — pre-fix this helper threw on the 3rd-level
+   * fallback case ("test should never reach this"), leaving the
+   * url:${sourceUrl} branch uncovered by the U7 invariant. Now mirrors
+   * the live filter's full three-tier logic so a future producer that
+   * triggers level-3 in production is structurally testable.
    *
    * @param {object} digestStory
    * @returns {string}
@@ -855,8 +863,11 @@ describe('Sprint 1 U7 — digest projection invariant: digest.cards ⊆ brief.ca
     if (typeof digestStory?.hash === 'string' && digestStory.hash.length > 0) {
       return digestStory.hash;
     }
+    if (typeof digestStory?.sourceUrl === 'string' && digestStory.sourceUrl.length > 0) {
+      return `url:${digestStory.sourceUrl}`;
+    }
     throw new Error(
-      `projectDigestEmitClusterId: digest story has neither mergedHashes[0] nor hash; ` +
+      `projectDigestEmitClusterId: digest story has no mergedHashes[0], hash, or sourceUrl; ` +
       `cannot derive clusterId for invariant check. Story: ${JSON.stringify(digestStory)}`,
     );
   }
@@ -1098,17 +1109,58 @@ describe('Sprint 1 U7 — digest projection invariant: digest.cards ⊆ brief.ca
 
   // ── Error path companion: missing-clusterId on digest side throws clearly ──
 
-  it('error path: digest story with neither mergedHashes nor hash throws a clear diagnostic', () => {
+  it('error path: digest story with no mergedHashes, hash, or sourceUrl throws a clear diagnostic', () => {
     // Defends against a producer regression: if a future buildDigest variant
-    // omits `hash` from the per-story shape AND there's no mergedHashes,
-    // projectDigestEmitClusterId throws BEFORE the subset check runs — the
-    // consequence is otherwise a `Set([undefined])` membership glitch that
-    // would fail the subset check with a confusing "undefined not in set"
-    // message rather than naming the producer regression.
+    // omits `hash` from the per-story shape AND there's no mergedHashes
+    // AND no sourceUrl, projectDigestEmitClusterId throws BEFORE the subset
+    // check runs — the consequence is otherwise a `Set([undefined])`
+    // membership glitch that would fail the subset check with a confusing
+    // "undefined not in set" message rather than naming the producer
+    // regression. (Note: we use `link` not `sourceUrl` here to keep the
+    // story shape clearly absent of all three sources; a future digest
+    // story carrying `sourceUrl` would correctly fall through to the
+    // level-3 url-fallback covered below.)
     assert.throws(
       () => projectDigestEmitClusterId({ title: 'no hash here', link: 'https://example.com/x' }),
       /cannot derive clusterId/,
     );
+  });
+
+  // Codex PR #3614 P2 — level-3 fallback `url:${sourceUrl}` parity.
+  // Pre-fix the test helper threw on this case ("test should never reach
+  // this"), leaving the level-3 branch in shared/brief-filter.js
+  // structurally untested. Now both helper and live filter agree.
+  it('level-3 fallback: digest story with only sourceUrl returns url:<sourceUrl> (Codex PR #3614 P2)', () => {
+    const cid = projectDigestEmitClusterId({
+      title: 'producer omits hash',
+      sourceUrl: 'https://example.com/news/x',
+    });
+    assert.equal(cid, 'url:https://example.com/news/x');
+  });
+
+  it('source preference order: mergedHashes[0] beats hash beats sourceUrl', () => {
+    // The three-tier order is load-bearing: a multi-story cluster MUST
+    // resolve to mergedHashes[0] even when hash and sourceUrl would also
+    // produce a valid clusterId. If the order ever flips, multi-story
+    // clusters would shatter back into per-story clusterIds and the
+    // delivered-log key shape would explode.
+    const allThree = projectDigestEmitClusterId({
+      mergedHashes: ['rep-hash-canonical'],
+      hash: 'own-hash-fallback',
+      sourceUrl: 'https://example.com/level-3',
+    });
+    assert.equal(allThree, 'rep-hash-canonical');
+
+    const hashAndUrl = projectDigestEmitClusterId({
+      hash: 'own-hash-fallback',
+      sourceUrl: 'https://example.com/level-3',
+    });
+    assert.equal(hashAndUrl, 'own-hash-fallback');
+
+    const urlOnly = projectDigestEmitClusterId({
+      sourceUrl: 'https://example.com/level-3',
+    });
+    assert.equal(urlOnly, 'url:https://example.com/level-3');
   });
 
   // ── Integration: real chain end-to-end through assertBriefEnvelope ──

--- a/tests/brief-from-digest-stories.test.mjs
+++ b/tests/brief-from-digest-stories.test.mjs
@@ -13,6 +13,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { composeBriefFromDigestStories, stripHeadlineSuffix } from '../scripts/lib/brief-compose.mjs';
+import { materializeCluster } from '../scripts/lib/brief-dedup-jaccard.mjs';
 
 const NOW = 1_745_000_000_000; // 2026-04-18 ish, deterministic
 
@@ -520,5 +521,252 @@ describe('composeBriefFromDigestStories — synthesis splice', () => {
     // A and C keep their original relative order (A then C).
     assert.equal(env.data.stories[1].headline, 'Unranked A');
     assert.equal(env.data.stories[2].headline, 'Unranked C');
+  });
+});
+
+// ── Sprint 1 / U3 — stable clusterId wiring (canonical cluster-rep hash) ──
+//
+// Covers the U3 invariant: every BriefStory carries a clusterId derived
+// from `mergedHashes[0]` (the canonical cluster-rep hash from
+// materializeCluster). Replaces U1's transitional placeholder which
+// sourced from the per-story `raw.hash` directly. For singletons the
+// values coincide; for multi-story clusters all members must share ONE
+// shared clusterId.
+
+describe('Sprint 1 U3 — stable clusterId wiring through compose path', () => {
+  it('singleton cluster: clusterId equals the story\'s own hash', () => {
+    const env = composeBriefFromDigestStories(
+      rule(),
+      [digestStory({ hash: 'singleton-hash-1' })],
+      { clusters: 0, multiSource: 0 },
+      { nowMs: NOW },
+    );
+    assert.ok(env);
+    assert.equal(env.data.stories.length, 1);
+    assert.equal(
+      env.data.stories[0].clusterId,
+      'singleton-hash-1',
+      'singleton clusterId must equal the story\'s own hash',
+    );
+  });
+
+  it('multi-story cluster: all members share ONE clusterId matching mergedHashes[0]', () => {
+    // Simulate a cluster post-materialiseCluster: a representative story
+    // carries the canonical mergedHashes[] of all members. The compose
+    // path receives a SINGLE rep per cluster, but the rep's mergedHashes
+    // array drives the clusterId so a downstream split (if introduced)
+    // would still collapse to the same identity.
+    const rep = materializeCluster([
+      { hash: 'h-A', currentScore: 100, mentionCount: 5 },
+      { hash: 'h-B', currentScore: 90, mentionCount: 3 },
+      { hash: 'h-C', currentScore: 80, mentionCount: 1 },
+    ]);
+    assert.ok(Array.isArray(rep.mergedHashes), 'rep must carry mergedHashes');
+    assert.equal(rep.mergedHashes.length, 3);
+    const env = composeBriefFromDigestStories(
+      rule(),
+      [{ ...rep, title: 'Cluster headline', link: 'https://example.com/x', severity: 'critical', sources: ['Reuters'] }],
+      { clusters: 1, multiSource: 1 },
+      { nowMs: NOW },
+    );
+    assert.ok(env);
+    assert.equal(env.data.stories.length, 1);
+    assert.equal(
+      env.data.stories[0].clusterId,
+      rep.mergedHashes[0],
+      'multi-story cluster: clusterId must equal mergedHashes[0]',
+    );
+    // Discriminator: it must NOT equal one of the non-rep member hashes.
+    assert.notEqual(env.data.stories[0].clusterId, 'h-B');
+    assert.notEqual(env.data.stories[0].clusterId, 'h-C');
+  });
+
+  it('idempotency: same upstream cluster across two cron ticks → identical clusterId', () => {
+    // Two ticks, same cluster membership. The rep's mergedHashes[0] is
+    // determined by materializeCluster's deterministic sort
+    // (currentScore desc → mentionCount desc → hash asc tiebreak). The
+    // input order is varied to prove the determinism does not depend on
+    // caller-side iteration order.
+    const tick1Items = [
+      { hash: 'aaa', currentScore: 100, mentionCount: 5 },
+      { hash: 'bbb', currentScore: 100, mentionCount: 5 },
+      { hash: 'ccc', currentScore: 100, mentionCount: 5 },
+    ];
+    const tick2Items = [...tick1Items].reverse(); // intentional shuffle
+    const rep1 = materializeCluster(tick1Items);
+    const rep2 = materializeCluster(tick2Items);
+    const env1 = composeBriefFromDigestStories(
+      rule(),
+      [{ ...rep1, title: 'X', link: 'https://example.com/x', severity: 'critical' }],
+      { clusters: 1, multiSource: 1 },
+      { nowMs: NOW },
+    );
+    const env2 = composeBriefFromDigestStories(
+      rule(),
+      [{ ...rep2, title: 'X', link: 'https://example.com/x', severity: 'critical' }],
+      { clusters: 1, multiSource: 1 },
+      { nowMs: NOW + 30 * 60 * 1000 }, // next cron tick (30 min later)
+    );
+    assert.ok(env1 && env2);
+    assert.equal(
+      env1.data.stories[0].clusterId,
+      env2.data.stories[0].clusterId,
+      'same cluster across two ticks must produce identical clusterId',
+    );
+  });
+
+  it('different upstream clusters never share a clusterId', () => {
+    const repA = materializeCluster([
+      { hash: 'cluster-a-1', currentScore: 100, mentionCount: 5 },
+      { hash: 'cluster-a-2', currentScore: 90, mentionCount: 3 },
+    ]);
+    const repB = materializeCluster([
+      { hash: 'cluster-b-1', currentScore: 100, mentionCount: 5 },
+      { hash: 'cluster-b-2', currentScore: 90, mentionCount: 3 },
+    ]);
+    const env = composeBriefFromDigestStories(
+      rule(),
+      [
+        { ...repA, title: 'Story A', link: 'https://example.com/a', severity: 'critical', sources: ['SrcA'] },
+        { ...repB, title: 'Story B', link: 'https://example.com/b', severity: 'critical', sources: ['SrcB'] },
+      ],
+      { clusters: 2, multiSource: 2 },
+      { nowMs: NOW },
+    );
+    assert.ok(env);
+    assert.equal(env.data.stories.length, 2);
+    assert.notEqual(
+      env.data.stories[0].clusterId,
+      env.data.stories[1].clusterId,
+      'distinct upstream clusters must surface distinct clusterIds',
+    );
+  });
+
+  it('every BriefStory in a v4 envelope has a non-empty clusterId (happy path)', () => {
+    const env = composeBriefFromDigestStories(
+      rule(),
+      [
+        digestStory({ hash: 'h1', title: 'A', sources: ['SrcA'] }),
+        digestStory({ hash: 'h2', title: 'B', sources: ['SrcB'] }),
+        digestStory({ hash: 'h3', title: 'C', sources: ['SrcC'] }),
+      ],
+      { clusters: 3, multiSource: 0 },
+      { nowMs: NOW },
+    );
+    assert.ok(env);
+    for (const s of env.data.stories) {
+      assert.ok(typeof s.clusterId === 'string' && s.clusterId.length > 0, `clusterId must be non-empty (got ${JSON.stringify(s.clusterId)})`);
+    }
+  });
+
+  it('integration: full chain materializeCluster → compose → assertBriefEnvelope passes', async () => {
+    // Exercises the real chain without mocking. assertBriefEnvelope is
+    // the v4 contract enforcer; running it on a real composed envelope
+    // proves U3 wiring lands clusterId where U1's read-side validator
+    // expects it.
+    const { assertBriefEnvelope } = await import('../server/_shared/brief-render.js');
+    const repAlpha = materializeCluster([
+      { hash: 'alpha-1', currentScore: 100, mentionCount: 5 },
+      { hash: 'alpha-2', currentScore: 80, mentionCount: 2 },
+    ]);
+    const repBeta = materializeCluster([
+      { hash: 'beta-1', currentScore: 70, mentionCount: 4 },
+    ]);
+    const env = composeBriefFromDigestStories(
+      rule(),
+      [
+        { ...repAlpha, title: 'Alpha cluster', link: 'https://example.com/alpha', severity: 'critical', sources: ['SrcA'] },
+        { ...repBeta,  title: 'Beta singleton', link: 'https://example.com/beta', severity: 'high', sources: ['SrcB'] },
+      ],
+      { clusters: 2, multiSource: 1 },
+      { nowMs: NOW },
+    );
+    assert.ok(env);
+    // Round-trips through the v4 contract enforcer (throws on missing/empty clusterId).
+    assertBriefEnvelope(env);
+    // Singleton matches own hash; multi-story matches mergedHashes[0].
+    const byHeadline = Object.fromEntries(env.data.stories.map((s) => [s.headline, s]));
+    assert.equal(byHeadline['Alpha cluster'].clusterId, repAlpha.mergedHashes[0]);
+    assert.equal(byHeadline['Beta singleton'].clusterId, 'beta-1');
+  });
+
+  it('falls back to raw.hash when mergedHashes is absent (back-compat with non-clustered producers)', () => {
+    // The news:insights:v1 path (composeBriefForRule) does not run
+    // through materializeCluster; stories arrive without mergedHashes.
+    // The clusterId source must gracefully fall back to raw.hash so
+    // every BriefStory still carries a non-empty clusterId.
+    const env = composeBriefFromDigestStories(
+      rule(),
+      [digestStory({ hash: 'plain-hash-no-merge' })], // no mergedHashes
+      { clusters: 0, multiSource: 0 },
+      { nowMs: NOW },
+    );
+    assert.ok(env);
+    assert.equal(env.data.stories[0].clusterId, 'plain-hash-no-merge');
+  });
+});
+
+// ── Sprint 1 / U3 — materializeCluster determinism guarantee ─────────────
+//
+// U3 requires deterministic rep selection so the same cluster across two
+// cron ticks produces an identical clusterId regardless of input order.
+// The pre-U3 sort had two keys (currentScore desc, mentionCount desc); a
+// hash tiebreak was added to make the result independent of TimSort's
+// stability + caller iteration order.
+
+describe('Sprint 1 U3 — materializeCluster determinism', () => {
+  it('breaks fully-tied items by hash ascending (stable across input orderings)', () => {
+    // Three items with identical score AND mentionCount. Pre-tiebreak
+    // implementation would return whichever was first in the input
+    // array; with the hash tiebreak it's always the lexicographically
+    // smallest hash.
+    const items = [
+      { hash: 'zzz', currentScore: 50, mentionCount: 3 },
+      { hash: 'aaa', currentScore: 50, mentionCount: 3 },
+      { hash: 'mmm', currentScore: 50, mentionCount: 3 },
+    ];
+    const rep = materializeCluster(items);
+    assert.equal(rep.hash, 'aaa', 'fully-tied items must resolve by hash ASC');
+    // Reverse the input order — same answer.
+    const repReversed = materializeCluster([...items].reverse());
+    assert.equal(repReversed.hash, 'aaa');
+    // Shuffle — same answer.
+    const repShuffled = materializeCluster([items[2], items[0], items[1]]);
+    assert.equal(repShuffled.hash, 'aaa');
+  });
+
+  it('mergedHashes[0] is stable under input reordering (the U3 wire-through invariant)', () => {
+    const items = [
+      { hash: 'h-x', currentScore: 100, mentionCount: 5 },
+      { hash: 'h-y', currentScore: 100, mentionCount: 5 },
+      { hash: 'h-z', currentScore: 100, mentionCount: 5 },
+    ];
+    const r1 = materializeCluster(items);
+    const r2 = materializeCluster([...items].reverse());
+    const r3 = materializeCluster([items[2], items[0], items[1]]);
+    assert.equal(r1.mergedHashes[0], r2.mergedHashes[0]);
+    assert.equal(r1.mergedHashes[0], r3.mergedHashes[0]);
+    // And it's the smallest hash (lexicographic tiebreak).
+    assert.equal(r1.mergedHashes[0], 'h-x');
+  });
+
+  it('preserves score-desc as primary key (no regression)', () => {
+    const rep = materializeCluster([
+      { hash: 'low',  currentScore: 10,  mentionCount: 1 },
+      { hash: 'high', currentScore: 100, mentionCount: 1 },
+      { hash: 'mid',  currentScore: 50,  mentionCount: 1 },
+    ]);
+    assert.equal(rep.hash, 'high');
+    assert.deepEqual(rep.mergedHashes, ['high', 'mid', 'low']);
+  });
+
+  it('preserves mentionCount-desc as secondary key (no regression)', () => {
+    const rep = materializeCluster([
+      { hash: 'few',  currentScore: 50, mentionCount: 1 },
+      { hash: 'lots', currentScore: 50, mentionCount: 10 },
+      { hash: 'mid',  currentScore: 50, mentionCount: 5 },
+    ]);
+    assert.equal(rep.hash, 'lots');
+    assert.deepEqual(rep.mergedHashes, ['lots', 'mid', 'few']);
   });
 });

--- a/tests/brief-from-digest-stories.test.mjs
+++ b/tests/brief-from-digest-stories.test.mjs
@@ -770,3 +770,375 @@ describe('Sprint 1 U3 — materializeCluster determinism', () => {
     assert.deepEqual(rep.mergedHashes, ['lots', 'mid', 'few']);
   });
 });
+
+// ── Sprint 1 / U7 — digest projection invariant: digest.cards ⊆ brief.cards ──
+//
+// CANONICAL INVARIANT RATIONALE (single source of truth — JSDoc and code
+// comments elsewhere should reference this header rather than re-state it):
+//
+//   For any single user-slot send under option (a), the set of clusterIds
+//   surfaced by the digest channel formatter (email plain-text + email HTML
+//   + Telegram + Slack + Discord + webhook bodies — all of which today read
+//   from the same `stories` array passed to `formatDigest`/`formatDigestHtml`
+//   in `scripts/seed-digest-notifications.mjs:1789-1791`) MUST be a structural
+//   subset of the clusterIds present on the canonical brief envelope's
+//   `BriefStory[]`.
+//
+//     set(digestCardClusterIds) ⊆ set(briefStoryClusterIds)
+//
+// What fires when this invariant breaks: U4's delivered-log writer (Sprint 1
+// Phase 2) keys on `digest:sent:v1:${userId}:${channel}:${ruleId}:${clusterId}`.
+// A digest card whose clusterId is NOT in the brief envelope cannot be matched
+// by anything reading from the magazine side — the cooldown evaluator (U5),
+// the replay harness (U6), and any future "story X went to user Y at time T"
+// reverse-lookup all walk via brief envelopes. An orphan digest clusterId is
+// invisible to every observer that uses the brief as canonical, so its
+// delivery is unaccounted for and its re-air the next tick is undetectable.
+// In Sprint 2's enforce mode, an orphan would also bypass the cooldown gate,
+// which is a silent suppression-bypass, not a visible bug.
+//
+// Why U2's option (a) makes this invariant universal (was previously per-rule):
+// pre-U2 the brief envelope and the channel body could legitimately reference
+// different rules' pools. Post-U2 (`scripts/lib/digest-orchestration-helpers.mjs`
+// `selectCanonicalSendRule`), the canonical winner rule's pool feeds BOTH
+// surfaces, so the invariant holds for every user.
+//
+// Why this test uses Option (C) — fixture unit test against `composeBriefFrom-
+// DigestStories` rather than driving the live `formatDigest`/`formatDigestHtml`
+// functions: those formatters emit text/HTML strings that do NOT carry
+// clusterId in any structured form (they're string templates). Extracting a
+// "card-list projection" from inline send-loop body construction would touch
+// U4/U5 implementation territory, which is out of U7 scope. Instead, this
+// test exercises the REAL chain (`materializeCluster` → `digestStoryToUpstream-
+// TopStory` → `filterTopStories` → `assertBriefEnvelope`) on the brief side,
+// and uses a small local helper (`projectDigestEmitClusterIds`) that mirrors
+// the canonical clusterId-derivation logic from `scripts/lib/brief-compose.mjs`
+// `digestStoryToUpstreamTopStory:316-329` — the SAME `mergedHashes[0] ?? hash`
+// fallback the live pipeline uses. If the live derivation diverges from the
+// projection (or vice-versa), the U3 idempotency test in this same file
+// catches it via the integration test against `assertBriefEnvelope`.
+//
+// Pragmatic note matching U2's source-text-guard precedent (test header in
+// `tests/digest-orchestration-helpers.test.mjs:574-589`): the worldmonitor
+// test suite has NO harness for mocking Upstash + Convex relay + Resend
+// together. A full integration test of the live cron's send loop would
+// require all three. Option (C) gives deterministic invariant coverage on
+// the structurally important path without that harness — and the error-path
+// test below ensures a future regression that re-introduces orphan emission
+// will fail loudly with an actionable message.
+
+describe('Sprint 1 U7 — digest projection invariant: digest.cards ⊆ brief.cards', () => {
+  /**
+   * Mirror of the canonical clusterId derivation in
+   * `scripts/lib/brief-compose.mjs::digestStoryToUpstreamTopStory` (lines
+   * 316-329). Returns the clusterId a digest card would need to match in
+   * the brief envelope's `BriefStory.clusterId` set.
+   *
+   * Source preference (top wins) — must stay in lockstep with the live
+   * derivation. If the live code changes, this helper changes; the U3
+   * integration test in this same file is the cross-check.
+   *
+   *   1. mergedHashes[0]  — canonical materializeCluster path
+   *   2. hash             — back-compat for non-clustered producers
+   *   3. (test should never reach this — empty input throws)
+   *
+   * @param {object} digestStory
+   * @returns {string}
+   */
+  function projectDigestEmitClusterId(digestStory) {
+    if (Array.isArray(digestStory?.mergedHashes)
+      && digestStory.mergedHashes.length > 0
+      && typeof digestStory.mergedHashes[0] === 'string'
+      && digestStory.mergedHashes[0].length > 0) {
+      return digestStory.mergedHashes[0];
+    }
+    if (typeof digestStory?.hash === 'string' && digestStory.hash.length > 0) {
+      return digestStory.hash;
+    }
+    throw new Error(
+      `projectDigestEmitClusterId: digest story has neither mergedHashes[0] nor hash; ` +
+      `cannot derive clusterId for invariant check. Story: ${JSON.stringify(digestStory)}`,
+    );
+  }
+
+  /**
+   * Project the digest emit clusterIds from the same `stories` array that
+   * `formatDigest`/`formatDigestHtml` would consume. This is the OUT-of-the-
+   * envelope side of the invariant — the IN-side comes from the composed
+   * brief envelope's `data.stories[].clusterId` field.
+   *
+   * @param {Array<object>} digestStories
+   * @returns {Set<string>}
+   */
+  function projectDigestEmitClusterIds(digestStories) {
+    const set = new Set();
+    for (const s of digestStories ?? []) set.add(projectDigestEmitClusterId(s));
+    return set;
+  }
+
+  /**
+   * Pull the set of clusterIds out of a composed brief envelope.
+   * @param {object} envelope
+   * @returns {Set<string>}
+   */
+  function envelopeClusterIds(envelope) {
+    const set = new Set();
+    for (const s of envelope?.data?.stories ?? []) {
+      if (typeof s?.clusterId === 'string' && s.clusterId.length > 0) set.add(s.clusterId);
+    }
+    return set;
+  }
+
+  /**
+   * Apply the invariant. Throws an Error naming the orphan clusterId(s) on
+   * violation — the message is the canonical operator-facing diagnostic for
+   * a regression in this contract.
+   *
+   * @param {Set<string>} digestEmitIds
+   * @param {Set<string>} briefIds
+   */
+  function assertDigestSubsetOfBrief(digestEmitIds, briefIds) {
+    const orphans = [];
+    for (const id of digestEmitIds) {
+      if (!briefIds.has(id)) orphans.push(id);
+    }
+    if (orphans.length > 0) {
+      throw new Error(
+        `digest projection invariant violated: ${orphans.length} digest card clusterId(s) ` +
+        `not present in brief envelope. orphans=[${orphans.map((o) => JSON.stringify(o)).join(', ')}]. ` +
+        `consequence: U4 delivered-log keys for these clusters are unmatchable from the magazine ` +
+        `side; cooldown evaluator and replay harness will treat each delivery as orphaned. ` +
+        `briefClusterIds=[${[...briefIds].map((b) => JSON.stringify(b)).join(', ')}]`,
+      );
+    }
+  }
+
+  // ── Happy path: 5-cluster digest pool → every digest clusterId in brief ──
+
+  it('5-cluster digest pool: every digest card clusterId is in the brief envelope', () => {
+    // Vary sources to avoid the source-topic cap (default 2 per source+
+    // category) — we want the brief envelope to surface all 5 clusters so
+    // the invariant test exercises the structural-subset path, not the
+    // brief filter dropping siblings.
+    const digestStories = [
+      digestStory({ hash: 'cluster-1', title: 'Story 1', sources: ['Reuters'] }),
+      digestStory({ hash: 'cluster-2', title: 'Story 2', sources: ['AP'] }),
+      digestStory({ hash: 'cluster-3', title: 'Story 3', sources: ['BBC'] }),
+      digestStory({ hash: 'cluster-4', title: 'Story 4', sources: ['Bloomberg'] }),
+      digestStory({ hash: 'cluster-5', title: 'Story 5', sources: ['Guardian'] }),
+    ];
+    const env = composeBriefFromDigestStories(
+      rule(),
+      digestStories,
+      { clusters: 5, multiSource: 0 },
+      { nowMs: NOW },
+    );
+    assert.ok(env, 'expected composed envelope');
+    assert.equal(env.data.stories.length, 5, '5-cluster pool must yield 5 brief stories');
+
+    const digestEmitIds = projectDigestEmitClusterIds(digestStories);
+    const briefIds = envelopeClusterIds(env);
+    assertDigestSubsetOfBrief(digestEmitIds, briefIds);
+    assert.equal(digestEmitIds.size, 5);
+    assert.equal(briefIds.size, 5);
+  });
+
+  // ── Edge: empty pool → trivially holds ──
+
+  it('empty digest pool: invariant trivially holds (no cards on either side)', () => {
+    const env = composeBriefFromDigestStories(rule(), [], { clusters: 0, multiSource: 0 }, { nowMs: NOW });
+    assert.equal(env, null, 'empty pool must produce null envelope (caller skips send)');
+    const digestEmitIds = projectDigestEmitClusterIds([]);
+    // No brief envelope → empty brief id set. Invariant on the empty set is
+    // vacuously true. The send loop's `if (!storyListPlain) continue;` guard
+    // (seed-digest-notifications.mjs:1790) ensures no channel body is emitted
+    // when there's nothing to send.
+    assertDigestSubsetOfBrief(digestEmitIds, new Set());
+    assert.equal(digestEmitIds.size, 0);
+  });
+
+  // ── Edge: rep-hash duplicates collapse to unique clusterIds ──
+
+  it('multi-story clusters collapse: 3 reps each carrying mergedHashes → 3 unique clusterIds, all in brief', () => {
+    // Three multi-story clusters, each with 3 members. The digest emit set
+    // is one entry per rep (3 clusterIds), and the brief envelope also
+    // surfaces one BriefStory per rep with the same shared clusterId per
+    // cluster. No member-hash leaks into either side.
+    const repA = materializeCluster([
+      { hash: 'A1', currentScore: 100, mentionCount: 5 },
+      { hash: 'A2', currentScore: 90, mentionCount: 3 },
+      { hash: 'A3', currentScore: 80, mentionCount: 1 },
+    ]);
+    const repB = materializeCluster([
+      { hash: 'B1', currentScore: 100, mentionCount: 5 },
+      { hash: 'B2', currentScore: 95, mentionCount: 4 },
+    ]);
+    const repC = materializeCluster([
+      { hash: 'C1', currentScore: 100, mentionCount: 5 },
+    ]); // singleton — mergedHashes[0] === hash
+    const digestStories = [
+      { ...repA, title: 'Cluster A', link: 'https://example.com/a', severity: 'critical', sources: ['SrcA'] },
+      { ...repB, title: 'Cluster B', link: 'https://example.com/b', severity: 'high', sources: ['SrcB'] },
+      { ...repC, title: 'Cluster C', link: 'https://example.com/c', severity: 'critical', sources: ['SrcC'] },
+    ];
+    const env = composeBriefFromDigestStories(
+      rule(),
+      digestStories,
+      { clusters: 3, multiSource: 2 },
+      { nowMs: NOW },
+    );
+    assert.ok(env);
+    const digestEmitIds = projectDigestEmitClusterIds(digestStories);
+    const briefIds = envelopeClusterIds(env);
+    assertDigestSubsetOfBrief(digestEmitIds, briefIds);
+    assert.equal(digestEmitIds.size, 3, 'three distinct clusterIds expected');
+    // Each digest emit clusterId must be the rep\'s mergedHashes[0], NOT a
+    // non-rep member hash. Canonical determinism check.
+    assert.ok(digestEmitIds.has(repA.mergedHashes[0]));
+    assert.ok(digestEmitIds.has(repB.mergedHashes[0]));
+    assert.ok(digestEmitIds.has(repC.mergedHashes[0]));
+    assert.ok(!digestEmitIds.has('A2'));
+    assert.ok(!digestEmitIds.has('A3'));
+    assert.ok(!digestEmitIds.has('B2'));
+  });
+
+  // ── Edge: single-rule user (no canonicalization needed) ──
+
+  it('single-rule user: invariant holds the same way (no U2 collapse path needed)', () => {
+    // selectCanonicalSendRule is a no-op identity for single-rule users.
+    // The digest emit set and brief envelope set come from the same
+    // `stories` pool with no additional U2 transformation, so the
+    // structural-subset relationship is the same as the multi-rule case.
+    const digestStories = [
+      digestStory({ hash: 'single-1', title: 'Solo 1', sources: ['Reuters'] }),
+      digestStory({ hash: 'single-2', title: 'Solo 2', sources: ['AP'] }),
+    ];
+    const env = composeBriefFromDigestStories(
+      rule(),
+      digestStories,
+      { clusters: 2, multiSource: 0 },
+      { nowMs: NOW },
+    );
+    assert.ok(env);
+    assertDigestSubsetOfBrief(
+      projectDigestEmitClusterIds(digestStories),
+      envelopeClusterIds(env),
+    );
+  });
+
+  // ── Edge: multi-rule user canonicalized to one winner via U2 ──
+  //
+  // Under option (a), the send loop drops every non-winner rule via
+  // `selectCanonicalSendRule` (`scripts/lib/digest-orchestration-helpers.mjs:284`).
+  // The canonical winner's `stories` pool is the SAME pool fed to BOTH
+  // `composeBriefFromDigestStories` (via the compose phase's digestFor
+  // closure) AND to `formatDigest`/`formatDigestHtml` in the send loop. The
+  // invariant therefore holds whether or not the user has multiple rules —
+  // U2's collapse ensures the winner's pool drives both surfaces. This test
+  // exercises that path explicitly: simulate the WINNER's pool (the one
+  // that survives `selectCanonicalSendRule`) and confirm the structural
+  // subset relationship.
+  it('multi-rule user post-U2 canonicalization: winner pool digest emit ⊆ winner pool brief envelope', () => {
+    const winnerRule = rule({ variant: 'tech', sensitivity: 'high' });
+    // The winner's pool (only this pool is used for both surfaces post-U2).
+    const winnerStories = [
+      digestStory({ hash: 'tech-1', title: 'AI chip ban deepens', sources: ['Reuters'] }),
+      digestStory({ hash: 'tech-2', title: 'Quantum breakthrough at MIT', sources: ['Nature'] }),
+      digestStory({ hash: 'tech-3', title: 'New ARM core in iPhone', sources: ['Bloomberg'] }),
+    ];
+    const env = composeBriefFromDigestStories(
+      winnerRule,
+      winnerStories,
+      { clusters: 3, multiSource: 0 },
+      { nowMs: NOW },
+    );
+    assert.ok(env);
+    assert.equal(env.data.stories.length, 3);
+    assertDigestSubsetOfBrief(
+      projectDigestEmitClusterIds(winnerStories),
+      envelopeClusterIds(env),
+    );
+  });
+
+  // ── Error path: synthetic orphan must fail with actionable message ──
+
+  it('error path: a synthetic orphan clusterId in the digest emit fails with an actionable message', () => {
+    // Test-time-only contrived state: the digest emit set contains a
+    // clusterId that is NOT in the brief envelope. This is the regression
+    // shape U7 catches — if a future change re-introduces per-rule channel
+    // bodies (regressing U2) or routes the formatter to a different pool
+    // than compose, the orphan would surface here.
+    const digestStories = [
+      digestStory({ hash: 'present-1', title: 'Present in both', sources: ['Reuters'] }),
+    ];
+    const env = composeBriefFromDigestStories(
+      rule(),
+      digestStories,
+      { clusters: 1, multiSource: 0 },
+      { nowMs: NOW },
+    );
+    assert.ok(env);
+    const briefIds = envelopeClusterIds(env);
+    // Inject an orphan into the digest emit set. The brief side is
+    // unchanged — this is the asymmetric divergence we want to catch.
+    const orphanedDigestIds = new Set([...projectDigestEmitClusterIds(digestStories), 'orphan-cluster-X']);
+    assert.throws(
+      () => assertDigestSubsetOfBrief(orphanedDigestIds, briefIds),
+      (err) => {
+        // Message must (a) name the orphan clusterId, (b) name the
+        // operational consequence (delivered-log unmatchable), (c) include
+        // the brief id set for diff-ability.
+        return /orphan-cluster-X/.test(err.message)
+          && /delivered-log/.test(err.message)
+          && /briefClusterIds=/.test(err.message);
+      },
+      'orphan-detection error must name the orphan clusterId, the consequence, and the brief id set',
+    );
+  });
+
+  // ── Error path companion: missing-clusterId on digest side throws clearly ──
+
+  it('error path: digest story with neither mergedHashes nor hash throws a clear diagnostic', () => {
+    // Defends against a producer regression: if a future buildDigest variant
+    // omits `hash` from the per-story shape AND there's no mergedHashes,
+    // projectDigestEmitClusterId throws BEFORE the subset check runs — the
+    // consequence is otherwise a `Set([undefined])` membership glitch that
+    // would fail the subset check with a confusing "undefined not in set"
+    // message rather than naming the producer regression.
+    assert.throws(
+      () => projectDigestEmitClusterId({ title: 'no hash here', link: 'https://example.com/x' }),
+      /cannot derive clusterId/,
+    );
+  });
+
+  // ── Integration: real chain end-to-end through assertBriefEnvelope ──
+
+  it('integration: real chain (materializeCluster → compose → assertBriefEnvelope) preserves the invariant', async () => {
+    const { assertBriefEnvelope } = await import('../server/_shared/brief-render.js');
+    const repAlpha = materializeCluster([
+      { hash: 'alpha-1', currentScore: 100, mentionCount: 5 },
+      { hash: 'alpha-2', currentScore: 80, mentionCount: 2 },
+    ]);
+    const repBeta = materializeCluster([
+      { hash: 'beta-1', currentScore: 70, mentionCount: 4 },
+    ]);
+    const digestStories = [
+      { ...repAlpha, title: 'Alpha cluster', link: 'https://example.com/alpha', severity: 'critical', sources: ['SrcA'] },
+      { ...repBeta, title: 'Beta singleton', link: 'https://example.com/beta', severity: 'high', sources: ['SrcB'] },
+    ];
+    const env = composeBriefFromDigestStories(
+      rule(),
+      digestStories,
+      { clusters: 2, multiSource: 1 },
+      { nowMs: NOW },
+    );
+    assert.ok(env);
+    // First, prove the envelope is contractually valid (v4 + clusterId on
+    // every story). Then prove the projection invariant on top.
+    assertBriefEnvelope(env);
+    assertDigestSubsetOfBrief(
+      projectDigestEmitClusterIds(digestStories),
+      envelopeClusterIds(env),
+    );
+  });
+});

--- a/tests/brief-magazine-render.test.mjs
+++ b/tests/brief-magazine-render.test.mjs
@@ -38,6 +38,11 @@ function story(overrides = {}) {
       'Tehran publicly reopened the Strait of Hormuz to commercial shipping today.',
     source: 'Multiple wires',
     sourceUrl: 'https://example.com/hormuz-open',
+    // v4: clusterId required. Tests that exercise clusterId-specific
+    // failure modes override this field directly. Default fixture must
+    // remain a VALID v4 envelope so the bulk of the suite keeps testing
+    // rendering, not validation.
+    clusterId: 'cluster-energy-hormuz-001',
     whyMatters:
       'Hormuz is roughly a fifth of global seaborne oil — a 9% move in a single session is a repricing, not a wobble.',
     ...overrides,
@@ -414,14 +419,16 @@ describe('renderBriefMagazine — envelope validation', () => {
 });
 
 describe('BRIEF_ENVELOPE_VERSION', () => {
-  it('is the literal 3 (bump requires cross-producer coordination)', () => {
-    // Bumped 2 → 3 (2026-04-25) when BriefDigest gained the optional
-    // `publicLead` field for the share-URL surface. v2 envelopes still
-    // in the 7-day TTL window remain readable — see
-    // SUPPORTED_ENVELOPE_VERSIONS = [1, 2, 3]. Test below covers v1
-    // back-compat; v2 back-compat is exercised by the missing-publicLead
-    // path in the BriefDigest validator (publicLead === undefined is OK).
-    assert.equal(BRIEF_ENVELOPE_VERSION, 3);
+  it('is the literal 4 (bump requires cross-producer coordination)', () => {
+    // Bumped 3 → 4 (2026-05-06, Sprint 1 canonical contract) when
+    // BriefStory gained the required `clusterId` field. v1-v3
+    // envelopes still in the 7-day TTL window remain readable — see
+    // SUPPORTED_ENVELOPE_VERSIONS = [1, 2, 3, 4] — but composers
+    // ONLY ever emit version=4 from this point. clusterId is the
+    // stable rep `hash` (mergedHashes[0]) per the Sprint-1 plan;
+    // U3 wires the value, U1 (this commit) only adds the schema +
+    // assertion plumbing.
+    assert.equal(BRIEF_ENVELOPE_VERSION, 4);
   });
 });
 
@@ -467,17 +474,131 @@ describe('renderBriefMagazine — v3 publicLead field (Codex Round-3 Medium #2)'
   });
 });
 
+describe('renderBriefMagazine — v4 clusterId field (Sprint 1 canonical contract)', () => {
+  /**
+   * Build a v4-shaped envelope: every story carries `clusterId`. The
+   * default `envelope()` factory already produces v4 (since the v3→v4
+   * bump in this PR), so v4Envelope() is a thin alias that exists
+   * mostly to make the back-compat shape contrast obvious.
+   */
+  function v4Envelope() {
+    return envelope();
+  }
+
+  /**
+   * Build a v3-shaped envelope (no clusterId on stories). Emulates
+   * what's still resident in Redis under the 7-day brief TTL at the
+   * moment the v4 renderer deploys — the renderer must keep accepting
+   * the v3 shape for the full back-compat window before
+   * SUPPORTED_ENVELOPE_VERSIONS can shrink. Mirrors the v1 back-compat
+   * pattern below.
+   */
+  function v3Envelope() {
+    const v4 = v4Envelope();
+    const stories = v4.data.stories.map(({ clusterId: _ignore, ...rest }) => rest);
+    return /** @type {any} */ ({ ...v4, version: 3, data: { ...v4.data, stories } });
+  }
+
+  it('accepts a v4 envelope where every story carries a non-empty clusterId', () => {
+    const env = v4Envelope();
+    const html = renderBriefMagazine(env);
+    assert.ok(typeof html === 'string' && html.length > 0);
+  });
+
+  it('rejects a v4 envelope when ANY story is missing clusterId', () => {
+    const env = v4Envelope();
+    /** @type {any} */ (env.data.stories[0]).clusterId = undefined;
+    assert.throws(
+      () => renderBriefMagazine(env),
+      /envelope\.data\.stories\[0\]\.clusterId must be a non-empty string on v4 envelopes/,
+    );
+  });
+
+  it('rejects a v4 envelope when clusterId is the empty string', () => {
+    const env = v4Envelope();
+    /** @type {any} */ (env.data.stories[1]).clusterId = '';
+    assert.throws(
+      () => renderBriefMagazine(env),
+      /envelope\.data\.stories\[1\]\.clusterId must be a non-empty string on v4 envelopes/,
+    );
+  });
+
+  it('rejects a v4 envelope when clusterId is null', () => {
+    const env = v4Envelope();
+    /** @type {any} */ (env.data.stories[0]).clusterId = null;
+    assert.throws(
+      () => renderBriefMagazine(env),
+      /envelope\.data\.stories\[0\]\.clusterId must be a non-empty string on v4 envelopes/,
+    );
+  });
+
+  it('rejects a v4 envelope when clusterId is a non-string type', () => {
+    const env = v4Envelope();
+    /** @type {any} */ (env.data.stories[0]).clusterId = 12345;
+    assert.throws(
+      () => renderBriefMagazine(env),
+      /envelope\.data\.stories\[0\]\.clusterId must be a non-empty string on v4 envelopes/,
+    );
+  });
+
+  // Characterization snapshot: v3 envelopes still in the 7-day TTL
+  // window MUST keep rendering after the v4 bump — this is the
+  // back-compat regression guard. If a future change tightens
+  // assertBriefEnvelope to refuse the absence of clusterId on v3,
+  // this test fails loudly. The 7d brief TTL covers every downstream
+  // TTL (story:track:v1 7d, digest:accumulator:v1 shorter, panel
+  // circuit-breaker shorter), so we don't need a longer window here.
+  it('accepts a v3 envelope WITHOUT clusterId on any story (7d TTL back-compat)', () => {
+    const env = v3Envelope();
+    const html = renderBriefMagazine(env);
+    assert.ok(typeof html === 'string' && html.length > 0);
+    // Sanity: the rendered HTML still emits a source line per story.
+    const labelCount = (html.match(/<div class="source">/g) ?? []).length;
+    assert.equal(labelCount, env.data.stories.length);
+  });
+
+  it('rejects a v3 envelope where a story carries an empty-string clusterId (defence-in-depth)', () => {
+    // A v3 envelope shouldn't carry clusterId at all; if a composer
+    // bug somehow stamps an empty string, surface it loudly rather
+    // than poisoning the dedup key in U4.
+    const env = v3Envelope();
+    /** @type {any} */ (env.data.stories[0]).clusterId = '';
+    assert.throws(
+      () => renderBriefMagazine(env),
+      /envelope\.data\.stories\[0\]\.clusterId, when present on v3, must be a non-empty string/,
+    );
+  });
+
+  it('rejects a v5 envelope (forward-incompatible — not in SUPPORTED_ENVELOPE_VERSIONS)', () => {
+    // The v3 → v4 bump expanded the supported set to {1, 2, 3, 4}.
+    // A v5 envelope is composer drift (or a future bump that hasn't
+    // shipped a matching renderer) and must be rejected at the version
+    // gate before any per-story validation runs.
+    const env = /** @type {any} */ (v4Envelope());
+    env.version = 5;
+    assert.throws(
+      () => renderBriefMagazine(env),
+      /is not in supported set/,
+    );
+  });
+});
+
 describe('renderBriefMagazine — v1 envelopes (back-compat window)', () => {
   /**
    * Build a v1-shaped envelope: version=1 and stories carry no
    * sourceUrl. Emulates what's still resident in Redis under the 7-day
    * TTL at the moment the v2 renderer deploys — the renderer must
    * degrade gracefully instead of 404ing the still-live link.
+   *
+   * v1 envelopes also don't carry clusterId (a v4 field) — strip it
+   * here so the fixture matches the historical Redis shape exactly.
+   * The validator's "absent OR non-empty string" rule for clusterId
+   * on v1-v3 envelopes is exercised by the v4 back-compat block above.
    */
   function v1Envelope() {
-    const v2 = envelope();
-    const stories = v2.data.stories.map(({ sourceUrl: _ignore, ...rest }) => rest);
-    return /** @type {any} */ ({ ...v2, version: 1, data: { ...v2.data, stories } });
+    const v4 = envelope();
+    const stories = v4.data.stories.map(({ sourceUrl: _ignoreUrl, clusterId: _ignoreCluster, ...rest }) => rest);
+    return /** @type {any} */ ({ ...v4, version: 1, data: { ...v4.data, stories } });
   }
 
   it('accepts version=1 without sourceUrl and renders plain source line (no anchor)', () => {

--- a/tests/brief-magazine-render.test.mjs
+++ b/tests/brief-magazine-render.test.mjs
@@ -569,6 +569,47 @@ describe('renderBriefMagazine — v4 clusterId field (Sprint 1 canonical contrac
     );
   });
 
+  // Codex PR #3614 P2 regression — sourceUrl is required on v2+, not
+  // just on the latest version. Pre-fix (`env.version === BRIEF_ENVELOPE_VERSION`)
+  // exempted v2 + v3 envelopes from the required-sourceUrl check after
+  // the v4 bump, contradicting the v2+ contract. Tests below lock in
+  // the corrected `env.version >= 2` semantic.
+  it('rejects a v3 envelope where a story is missing sourceUrl (Codex PR #3614 P2)', () => {
+    const env = v3Envelope();
+    /** @type {any} */ (env.data.stories[0]).sourceUrl = undefined;
+    assert.throws(
+      () => renderBriefMagazine(env),
+      /envelope\.data\.stories\[0\]\.sourceUrl/,
+    );
+  });
+
+  it('rejects a v2-shaped envelope where a story is missing sourceUrl (Codex PR #3614 P2)', () => {
+    // v2 envelopes don't carry publicLead/publicSignals/publicThreads
+    // (that's v3) and don't carry clusterId (that's v4). Build the v2
+    // shape from v3Envelope by stripping v3-only public-share fields.
+    const v3 = v3Envelope();
+    const v2Stories = v3.data.stories.map(({ ...rest }) => rest);
+    const v2 = /** @type {any} */ ({
+      ...v3,
+      version: 2,
+      data: { ...v3.data, stories: v2Stories },
+    });
+    delete v2.data.publicLead;
+    delete v2.data.publicSignals;
+    delete v2.data.publicThreads;
+    /** @type {any} */ (v2.data.stories[0]).sourceUrl = undefined;
+    assert.throws(
+      () => renderBriefMagazine(v2),
+      /envelope\.data\.stories\[0\]\.sourceUrl/,
+    );
+  });
+
+  it('accepts a v3 envelope where every story has a valid sourceUrl (positive control)', () => {
+    const env = v3Envelope();
+    const html = renderBriefMagazine(env);
+    assert.ok(typeof html === 'string' && html.length > 0);
+  });
+
   it('rejects a v5 envelope (forward-incompatible — not in SUPPORTED_ENVELOPE_VERSIONS)', () => {
     // The v3 → v4 bump expanded the supported set to {1, 2, 3, 4}.
     // A v5 envelope is composer drift (or a future bump that hasn't

--- a/tests/digest-orchestration-helpers.test.mjs
+++ b/tests/digest-orchestration-helpers.test.mjs
@@ -20,6 +20,7 @@ import {
   pickWinningCandidateWithPool,
   readTimeAgeCutoffMs,
   runSynthesisWithFallback,
+  selectCanonicalSendRule,
   shouldDropTrackByAge,
   subjectForBrief,
 } from '../scripts/lib/digest-orchestration-helpers.mjs';
@@ -567,5 +568,118 @@ describe('shouldDropTrackByAge — predicate matrix', () => {
       true,
       'Months-old residue with a real publishedAt must be dropped',
     );
+  });
+});
+
+// ── selectCanonicalSendRule — Sprint 1 U2 (option (a)) ─────────────────────
+//
+// Under option (a) canonicalisation, the per-user "winning rule" picked by
+// the compose phase drives BOTH the email body and the magazine URL. The
+// send loop must therefore filter the rule list down to ONE rule per user
+// per slot (the winner) before the isDue / channel-fetch / synthesis cascade
+// runs. This helper is that filter — pure, no I/O, exhaustively tested
+// here so the cron's main() loop can rely on its contract without a
+// full-mock integration harness.
+//
+// Why this matters: pre-U2, the send loop ran a separate synthesis per
+// enabled rule and dispatched one email per rule. A multi-rule user
+// received an email body keyed to one rule's pool while the magazine URL
+// pointed at a DIFFERENT rule's envelope (the compose-phase winner). U2
+// collapses the divergence — every channel body now reads from the same
+// canonical winning rule.
+
+describe('selectCanonicalSendRule — option (a) canonical mapping', () => {
+  function makeBrief(overrides = {}) {
+    return {
+      envelope: { v: 4, data: {} },
+      magazineUrl: 'https://example/brief/u/2026-05-06-0800',
+      chosenVariant: 'full',
+      synthesisLevel: 1,
+      ...overrides,
+    };
+  }
+  function makeRule(overrides = {}) {
+    return {
+      userId: 'user_abc',
+      variant: 'full',
+      enabled: true,
+      digestMode: 'daily',
+      sensitivity: 'high',
+      aiDigestEnabled: true,
+      digestTimezone: 'UTC',
+      updatedAt: 1_700_000_000_000,
+      ...overrides,
+    };
+  }
+
+  it('returns the winner rule when it exists in the candidate list', () => {
+    const winner = makeRule({ variant: 'full' });
+    const sibling = makeRule({ variant: 'finance' });
+    const out = selectCanonicalSendRule(makeBrief({ chosenVariant: 'full' }), [sibling, winner]);
+    assert.equal(out, winner);
+  });
+
+  it('multi-rule user: only the winner rule is selected; non-winner siblings are dropped', () => {
+    // The defining U2 invariant. A user with full + finance + tech rules
+    // and a compose-phase winner of "tech" must see the send loop fire
+    // for the tech rule ONLY — full and finance do not get their own
+    // separate emails any more.
+    const full = makeRule({ variant: 'full' });
+    const finance = makeRule({ variant: 'finance' });
+    const tech = makeRule({ variant: 'tech' });
+    const userRules = [full, finance, tech];
+    const out = selectCanonicalSendRule(makeBrief({ chosenVariant: 'tech' }), userRules);
+    assert.equal(out, tech, 'winner=tech must be selected');
+    assert.notEqual(out, full);
+    assert.notEqual(out, finance);
+  });
+
+  it('returns null when the brief has no chosenVariant (compose did not identify a winner)', () => {
+    const userRules = [makeRule()];
+    const out = selectCanonicalSendRule(makeBrief({ chosenVariant: undefined }), userRules);
+    assert.equal(out, null);
+  });
+
+  it('returns null when brief is undefined / null (compose phase produced nothing for this user)', () => {
+    const userRules = [makeRule()];
+    assert.equal(selectCanonicalSendRule(undefined, userRules), null);
+    assert.equal(selectCanonicalSendRule(null, userRules), null);
+  });
+
+  it('returns null when the winner variant no longer exists in the rule list (rule deleted between compose and send)', () => {
+    // Defensive: rather than misrouting to a sibling rule when the
+    // winner has been deleted, skip the send entirely. The next cron
+    // tick will recompose with the remaining rules.
+    const out = selectCanonicalSendRule(
+      makeBrief({ chosenVariant: 'tech' }),
+      [makeRule({ variant: 'full' }), makeRule({ variant: 'finance' })],
+    );
+    assert.equal(out, null);
+  });
+
+  it('returns null on empty userRules list (defensive)', () => {
+    assert.equal(selectCanonicalSendRule(makeBrief(), []), null);
+  });
+
+  it('returns null when chosenVariant is the empty string (defensive — treat as missing)', () => {
+    const out = selectCanonicalSendRule(makeBrief({ chosenVariant: '' }), [makeRule()]);
+    assert.equal(out, null);
+  });
+
+  it('single-rule user with matching winner: no behavior change vs pre-U2', () => {
+    // Regression guard for the happy-path single-rule case.
+    const r = makeRule({ variant: 'full' });
+    const out = selectCanonicalSendRule(makeBrief({ chosenVariant: 'full' }), [r]);
+    assert.equal(out, r);
+  });
+
+  it('skips entries with non-string variant defensively (does not crash on malformed input)', () => {
+    const winner = makeRule({ variant: 'full' });
+    const malformed = { userId: 'user_abc', variant: undefined };
+    const out = selectCanonicalSendRule(
+      makeBrief({ chosenVariant: 'full' }),
+      [/** @type {any} */ (malformed), winner],
+    );
+    assert.equal(out, winner);
   });
 });


### PR DESCRIPTION
## Summary

Sprint 1 Phase 1 of the digest/brief overhaul scoped in `docs/internal/digest-brief-improvements.md`. Establishes the canonical contract:

- **U1 (`579a1d64f`)** — Bumps `BRIEF_ENVELOPE_VERSION` from 3 to 4 with a 7-day backward-read window. Adds `BriefStory.clusterId` — REQUIRED on v4 writes, OPTIONAL on v1-3 reads (back-compat). Empty-string rejected on every version (would silently collapse delivered-log keys across clusters). Producer audit confirms `assembleStubbedBriefEnvelope` is the single live writer.

- **U2 (`f59fa7483`)** — Multi-rule canonicalization (option a). Adds pure helper `selectCanonicalSendRule` and drops non-winner rules at the top of the send loop. Email body and magazine URL now both come from the same per-user winning rule, eliminating the divergence documented at `seed-digest-notifications.mjs:1713-1732`. **Subscriber-visible behavior change for multi-rule users** — they will see the winning rule's content in both email body and magazine URL (vs prior per-rule body + winner-rule URL). Confirmed during planning. Parity log alarm semantics flipped: `winner_match=false` is now a hard alarm (canonical-rule filter bypass / compose↔send drift), not the prior "expected divergence."

- **U3 (`934356285`)** — Wires the stable `clusterId` value: `mergedHashes[0]` from `materializeCluster` threads through `digestStoryToUpstreamTopStory` → `filterTopStories` → `BriefStory.clusterId`. Multi-story clusters collapse to ONE shared clusterId; singletons unchanged. **Discovered + fixed real determinism gap:** `materializeCluster` rep selection relied on TimSort stability + caller iteration order — fully-tied score+mentionCount items resolved non-deterministically across input orderings. Tightened with hash-ASC tiebreak (3rd sort key) so the result is independent of input order.

- **U7 (`a6c9745ca`)** — CI invariant test `digest.cards ⊆ brief.cards`. Locks in the structural-subset enforcement that U1+U2+U3 enable. ~50-line canonical invariant rationale in the test file header (single source of truth per `feedback_doc_drift_after_behavior_fix_needs_grep_sweep`). Pre-push hook auto-picks-up via `tests/<name>.test.mjs` glob.

## Phase 0 prerequisite (already done)

`DIGEST_DEDUP_REPLAY_LOG=1` activated on `digest-notifications` Railway service on 2026-05-06. The 14-day replay window earliest-runnable date is 2026-05-20 — the U6 replay harness (Sprint 1 Phase 3, future PR) will refuse to run with insufficient coverage.

## Production finding flagged for U4 (next session)

The live `formatDigest(stories, ...)` call at `scripts/seed-digest-notifications.mjs:1789` passes the raw post-buildDigest stories pool (capped at `DIGEST_MAX_ITEMS=30`) — not `env.data.stories` (post-compose, capped at `MAX_STORIES_PER_USER=12`). When pool > 12, the digest emits cards beyond the brief envelope. The U7 test fixtures intentionally stay under the cap to test the structural-subset shape; **U4 will plumb `env.data.stories` into the formatter call site so the U7 invariant holds in production unconditionally**, per the strategic doc's "brief-as-canonical" direction.

## What ships under option (a)

Multi-rule users (a small minority of subscribers) will see the winning rule's content in both their email body and magazine URL going forward. Single-rule users see no behavior change. The `digest:last-sent:v1:${userId}:${variant}` isDue gate continues to work — only the winner-variant key is ever read/written for affected user-slots. Pre-cutover non-winner-variant keys are orphan but harmless (8d TTL, no consumer reads them).

## Test plan

- [x] `npm run typecheck` (4.7s)
- [x] `npm run typecheck:api` (1.9s)
- [x] CJS syntax check on `scripts/*.cjs`
- [x] `npm run lint` (Biome) exit 0; no errors in changed files
- [x] `npm run test:data` — 7922/7922 pass (29.6s, +12 new tests across 4 test files)
- [x] Edge function bundle check — all `api/*.js` bundle cleanly
- [x] `node --test tests/edge-functions.test.mjs` — 181/181 pass
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — 2.8.0 sync OK
- [ ] Post-merge: monitor `[digest] PARITY ` log lines for the new `winner_match=false` hard-alarm shape (option (a) makes this universally `true`; any false occurrence indicates canonical-rule filter bypass or compose↔send drift)
- [ ] Post-merge: verify `seed-meta:digest:*` health rows continue to update on the next cron tick
- [ ] Post-merge: spot-check a multi-rule user's brief in production matches the email body content

## Related

- Plan: `docs/plans/2026-05-06-001-feat-digest-brief-canonical-contract-sprint-1-plan.md` (gitignored, local-only)
- Origin / strategic doc: `docs/internal/digest-brief-improvements.md` (gitignored, local-only)
- Codex round-2 APPROVED at strategic-plan level
- Sprint 1 Phase 2/3 (U4 + U5 + U6 + U8) ship in subsequent PRs on this branch or a sibling