### PR TITLE
feat: digest delivered-log shadow + cooldown decision + replay harness — Sprint 1 Phase 2/3 (U4+U5+U6+U8)

### DIFF
--- a/Dockerfile.digest-notifications
+++ b/Dockerfile.digest-notifications
@@ -49,6 +49,15 @@ RUN npm ci --prefix scripts --omit=dev
 COPY scripts/seed-digest-notifications.mjs ./scripts/
 COPY scripts/_digest-markdown.mjs ./scripts/
 COPY scripts/lib/ ./scripts/lib/
+# Sprint 1 / U4 operator one-shot — `clearDeliveredEntry` primitive
+# pairs with the delivered-log writer in scripts/lib/digest-delivered-
+# log.mjs (per skill_new_blocking_state_without_matching_clear_primitive).
+# Shipped here so an operator can `railway run node scripts/clear-
+# delivered-entry.mjs --user X --slot Y --cluster Z --reason "..."`
+# directly on the digest-notifications service container without
+# spinning up a separate one-off image. Read-only path: requires the
+# same UPSTASH_REDIS_REST_{URL,TOKEN} env this cron already has.
+COPY scripts/clear-delivered-entry.mjs ./scripts/
 
 # Brief envelope contract + filter + renderer assertion. These live
 # under shared/ and server/_shared/ in the repo and are imported from

--- a/scripts/clear-delivered-entry.mjs
+++ b/scripts/clear-delivered-entry.mjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+/**
+ * Operator one-shot: clear one or more `digest:sent:v1:*` rows.
+ *
+ * Pairs with the writer at `scripts/lib/digest-delivered-log.mjs` per
+ * the coding-convention rule from `skill_new_blocking_state_without_
+ * matching_clear_primitive`: every halt-able state needs an audited
+ * unhalt path. Without this primitive, an operator who needs to
+ * un-suppress a story (cooldown evaluator falsely flagged a real
+ * follow-up event as a re-air, classifier mis-tagged something as
+ * Analysis with a 7d floor, etc.) would have to either wait out the
+ * 30d TTL or hand-curl Upstash — neither is auditable.
+ *
+ * USAGE
+ *
+ *   node scripts/clear-delivered-entry.mjs \
+ *     --user user_abc \
+ *     --slot 2026-05-06-0800 \
+ *     --cluster sha256-deadbeef \
+ *     [--channel email] \
+ *     [--rule full:en:high] \
+ *     --reason "false-suppress: classifier mis-tagged USNI op-ed as Analysis"
+ *
+ * Required: --user, --slot, --cluster, --reason. Refuses to run on
+ * missing reason — there's NO unsafe shortcut. The slot is consumed
+ * for log-line context only (it's not part of the key); operators
+ * carry it from the parity log line they were investigating.
+ *
+ * Without --channel and --rule the script SCANs for every row matching
+ * `digest:sent:v1:${user}:*:*:${cluster}` and deletes each. With both,
+ * it targets one specific row. With one but not the other → error.
+ *
+ * RETURN CODES
+ *
+ *   0  — operation completed (deletions or no-op both green; the
+ *        no-op case is logged with the matched-zero counter).
+ *   1  — argument validation failure (missing required flag, mis-paired
+ *        --channel/--rule, no UPSTASH creds in env).
+ *   2  — Upstash transport failure (SCAN/DEL HTTP non-2xx, fetch
+ *        threw). Signals operator to retry, not "nothing matched".
+ *
+ * AUDIT TRAIL
+ *
+ *   Every deletion logs a single line:
+ *     [clear-delivered-entry] DELETED key=<key> reason="<reason>" at=<ISO>
+ *   The Railway log retention covers the audit window. No separate
+ *   audit file: stdout-only keeps the script self-contained.
+ */
+
+import { defaultRedisPipeline } from './lib/_upstash-pipeline.mjs';
+import { ALLOWED_CHANNELS } from './lib/digest-delivered-log.mjs';
+
+const KEY_PREFIX = 'digest:sent:v1';
+
+/** Tagged exit codes — kept terse so an exit-trap operator script can
+ * map them without parsing stderr. */
+const EXIT_OK = 0;
+const EXIT_ARG = 1;
+const EXIT_TRANSPORT = 2;
+
+/**
+ * Hand-rolled flag parser. We avoid commander/yargs to keep this script
+ * importable from `Dockerfile.digest-notifications` without adding a
+ * runtime dep. Pattern: `--flag value` only — no `--flag=value`, no
+ * shorthands, no positional args. Anything unrecognised is rejected
+ * loudly so a typo can't silently fall through to "no --reason".
+ *
+ * @param {string[]} argv — process.argv.slice(2)
+ * @returns {{ kind: 'ok', args: Record<string,string> } | { kind: 'err', message: string }}
+ */
+export function parseArgs(argv) {
+  const allowedFlags = new Set(['--user', '--slot', '--cluster', '--channel', '--rule', '--reason']);
+  const args = {};
+  for (let i = 0; i < argv.length; i++) {
+    const flag = argv[i];
+    if (!allowedFlags.has(flag)) {
+      return { kind: 'err', message: `unknown flag: ${JSON.stringify(flag)} (allowed: ${[...allowedFlags].join(' ')})` };
+    }
+    const value = argv[i + 1];
+    if (typeof value !== 'string' || value.length === 0 || value.startsWith('--')) {
+      return { kind: 'err', message: `flag ${flag} requires a non-empty value` };
+    }
+    args[flag.slice(2)] = value;
+    i++;
+  }
+
+  // Required arg gate. The reason check is a hard contract — see module
+  // docblock + skill_new_blocking_state_without_matching_clear_primitive.
+  for (const required of ['user', 'slot', 'cluster', 'reason']) {
+    if (!args[required]) {
+      return { kind: 'err', message: `missing required flag: --${required}` };
+    }
+  }
+  // Channel + rule must be paired (both or neither). One alone is
+  // ambiguous: it would either skip the SCAN (not what the operator
+  // wanted if they only specified --channel) or produce a malformed key.
+  const hasChannel = typeof args.channel === 'string';
+  const hasRule = typeof args.rule === 'string';
+  if (hasChannel !== hasRule) {
+    return { kind: 'err', message: `--channel and --rule must be specified together (or neither — sweep all rows for {user,cluster})` };
+  }
+  if (hasChannel && !ALLOWED_CHANNELS.has(args.channel)) {
+    return { kind: 'err', message: `--channel must be one of ${[...ALLOWED_CHANNELS].join(',')}; got ${JSON.stringify(args.channel)}` };
+  }
+  return { kind: 'ok', args };
+}
+
+/**
+ * Build the SCAN match pattern for the sweep mode (no --channel/--rule).
+ *
+ * Result: `digest:sent:v1:${user}:*:*:${cluster}` — narrow to ONE user
+ * + ONE cluster with channel/rule wildcards. We don't sweep across
+ * users or clusters from this primitive — that'd be too easy to
+ * accidentally invoke.
+ */
+export function buildScanPattern(userId, clusterId) {
+  return `${KEY_PREFIX}:${userId}:*:*:${clusterId}`;
+}
+
+/**
+ * Single-key shape (paired --channel + --rule).
+ */
+export function buildSingleKey(userId, channel, ruleId, clusterId) {
+  return `${KEY_PREFIX}:${userId}:${channel}:${ruleId}:${clusterId}`;
+}
+
+/**
+ * Walk Upstash SCAN cursor. Returns every key that matches `pattern`.
+ * Bounded by `maxKeys` as a defensive cap — a single user-cluster
+ * shouldn't have more than 5 channel rows, but if a future schema bug
+ * leaks bad keys we don't want one operator command to delete 100k
+ * unrelated rows.
+ *
+ * @param {string} pattern
+ * @param {{ url: string, token: string }} creds
+ * @param {number} [maxKeys=200]
+ * @returns {Promise<{ kind: 'ok', keys: string[] } | { kind: 'transport-error', message: string }>}
+ */
+async function scanKeys(pattern, creds, maxKeys = 200) {
+  const keys = new Set();
+  let cursor = '0';
+  let iterations = 0;
+  do {
+    let resp;
+    try {
+      resp = await fetch(`${creds.url}/scan/${encodeURIComponent(cursor)}/match/${encodeURIComponent(pattern)}/count/100`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${creds.token}`,
+          'User-Agent': 'worldmonitor-clear-delivered/1.0',
+        },
+        signal: AbortSignal.timeout(10_000),
+      });
+    } catch (err) {
+      return { kind: 'transport-error', message: `SCAN fetch threw: ${err?.message ?? err}` };
+    }
+    if (!resp.ok) {
+      return { kind: 'transport-error', message: `SCAN HTTP ${resp.status}` };
+    }
+    const json = await resp.json();
+    const result = Array.isArray(json?.result) ? json.result : [];
+    cursor = String(result[0] ?? '0');
+    const batch = Array.isArray(result[1]) ? result[1] : [];
+    for (const k of batch) {
+      if (typeof k === 'string') keys.add(k);
+      if (keys.size >= maxKeys) {
+        return { kind: 'ok', keys: [...keys] };
+      }
+    }
+    iterations++;
+    if (iterations > 50) {
+      // Defensive — Upstash SCAN cursor on a 200-key cap should never
+      // need 50+ iterations. Bail loudly so a buggy cursor loop
+      // doesn't hang the operator.
+      return { kind: 'transport-error', message: 'SCAN exceeded 50 iterations' };
+    }
+  } while (cursor !== '0');
+  return { kind: 'ok', keys: [...keys] };
+}
+
+/**
+ * Pure orchestration entrypoint — separated from `main` so the test
+ * suite can drive it without process.exit. Returns a result code +
+ * structured counts.
+ *
+ * @param {object} args
+ * @param {{ user: string, slot: string, cluster: string, channel?: string, rule?: string, reason: string }} args.parsed
+ * @param {object} args.deps
+ * @param {(pattern: string) => Promise<{ kind: 'ok', keys: string[] } | { kind: 'transport-error', message: string }>} args.deps.scan
+ * @param {typeof defaultRedisPipeline} args.deps.redisPipeline
+ * @param {(line: string) => void} [args.deps.log=console.log]
+ * @param {(line: string) => void} [args.deps.warn=console.warn]
+ * @returns {Promise<{ code: number, deleted: number, ineligible: string[] }>}
+ */
+export async function runClear({ parsed, deps }) {
+  const log = deps?.log ?? ((line) => console.log(line));
+  const warn = deps?.warn ?? ((line) => console.warn(line));
+  const pipeline = deps?.redisPipeline ?? defaultRedisPipeline;
+
+  const { user, slot, cluster, channel, rule, reason } = parsed;
+
+  // Resolve the target key set.
+  let targetKeys;
+  if (channel && rule) {
+    targetKeys = [buildSingleKey(user, channel, rule, cluster)];
+  } else {
+    const scanResult = await deps.scan(buildScanPattern(user, cluster));
+    if (scanResult.kind === 'transport-error') {
+      warn(`[clear-delivered-entry] SCAN failed: ${scanResult.message}`);
+      return { code: EXIT_TRANSPORT, deleted: 0, ineligible: [] };
+    }
+    targetKeys = scanResult.keys;
+  }
+
+  if (targetKeys.length === 0) {
+    log(`[clear-delivered-entry] no matching keys for user=${user} cluster=${cluster} (slot=${slot}) — nothing to do`);
+    return { code: EXIT_OK, deleted: 0, ineligible: [] };
+  }
+
+  // DEL each key individually so we can report per-key success/no-op.
+  // DEL returns 1 for "key existed and was deleted", 0 for "key missing
+  // already" (TTL expired, prior DEL by another operator, key never
+  // existed). 0 isn't an error — it's "ineligible", reported separately.
+  const cmds = targetKeys.map((key) => ['DEL', key]);
+  const result = await pipeline(cmds);
+  if (result == null || !Array.isArray(result)) {
+    warn(`[clear-delivered-entry] DEL pipeline returned null — Upstash transport failure`);
+    return { code: EXIT_TRANSPORT, deleted: 0, ineligible: [] };
+  }
+
+  const at = new Date().toISOString();
+  const ineligible = [];
+  let deleted = 0;
+  for (let i = 0; i < targetKeys.length; i++) {
+    const key = targetKeys[i];
+    const cell = result[i];
+    if (cell && typeof cell === 'object' && 'error' in cell) {
+      warn(`[clear-delivered-entry] DEL key=${key} → upstream error: ${cell.error}`);
+      continue;
+    }
+    const n = Number(cell?.result ?? 0);
+    if (n >= 1) {
+      log(`[clear-delivered-entry] DELETED key=${key} reason=${JSON.stringify(reason)} at=${at}`);
+      deleted++;
+    } else {
+      ineligible.push(key);
+    }
+  }
+  if (ineligible.length > 0) {
+    log(`[clear-delivered-entry] ineligible_keys=${ineligible.length} (already expired or never present): ${ineligible.join(', ')}`);
+  }
+  log(`[clear-delivered-entry] summary user=${user} cluster=${cluster} slot=${slot} deleted=${deleted} ineligible=${ineligible.length} reason=${JSON.stringify(reason)}`);
+  return { code: EXIT_OK, deleted, ineligible };
+}
+
+// ── Main ──────────────────────────────────────────────────────────────
+
+async function main() {
+  const parseResult = parseArgs(process.argv.slice(2));
+  if (parseResult.kind === 'err') {
+    console.error(`[clear-delivered-entry] ARG ERROR: ${parseResult.message}`);
+    console.error(`Usage: node scripts/clear-delivered-entry.mjs --user <id> --slot <YYYY-MM-DD-HHMM> --cluster <clusterId> [--channel <name> --rule <ruleId>] --reason "<string>"`);
+    process.exit(EXIT_ARG);
+  }
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) {
+    console.error(`[clear-delivered-entry] UPSTASH_REDIS_REST_URL / UPSTASH_REDIS_REST_TOKEN must be set in env`);
+    process.exit(EXIT_ARG);
+  }
+  const result = await runClear({
+    parsed: parseResult.args,
+    deps: {
+      scan: (pattern) => scanKeys(pattern, { url, token }),
+      redisPipeline: defaultRedisPipeline,
+    },
+  });
+  process.exit(result.code);
+}
+
+// Only run main when invoked directly — keeps the export surface
+// importable from tests without triggering a process.exit.
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error('[clear-delivered-entry] FATAL:', err);
+    process.exit(EXIT_TRANSPORT);
+  });
+}

--- a/scripts/clear-delivered-entry.mjs
+++ b/scripts/clear-delivered-entry.mjs
@@ -70,21 +70,28 @@ const EXIT_TRANSPORT = 2;
  */
 // Codex PR #3617 P1 — Redis SCAN glob-injection guard.
 //
-// The scan pattern at buildScanPattern is `digest:sent:v1:${user}:*:*:${cluster}`.
-// If user OR cluster contains Redis glob metacharacters (* ? [ ] \), the
-// pattern broadens beyond the intended single-user-single-cluster scope.
-// `--cluster '*'` would match every key in the prefix; `--user 'foo*'`
-// would match every cluster for every user starting with `foo`. The
-// followup DEL loop would then wipe far more rows than the operator
-// intended.
+// The sweep-mode scan pattern at buildScanPattern is
+// `digest:sent:v1:${user}:*:*:${cluster}`. If user OR cluster contains
+// Redis glob metacharacters (* ? [ ] \), the pattern broadens beyond
+// the intended single-user-single-cluster scope. `--cluster '*'` would
+// match every key in the prefix; `--user 'foo*'` would match every
+// cluster for every user starting with `foo`. The followup DEL loop
+// would then wipe far more rows than the operator intended.
 //
-// Reject these characters at parse time. The legitimate value space for
-// userId / clusterId / channel / ruleId is alphanumerics + a small
-// punctuation set (`:` for ruleId composites, `-` for hash IDs); none
-// of the Redis metacharacters belong here. Reason strings are free-form
-// (audit log) and don't reach the SCAN pattern, so they're exempt.
+// Codex PR #3617 P2 follow-up — the guard is SWEEP-MODE-ONLY. In
+// exact-DEL mode (both --channel AND --rule supplied), the DEL is
+// against a single literal key — Redis treats DEL arguments as exact
+// strings, not patterns. Legitimate clusterIds can be the level-3
+// fallback `url:${sourceUrl}` from `shared/brief-filter.js:300` and
+// real URLs commonly contain `?` (query strings). Rejecting glob chars
+// in exact-DEL mode would make those rows unrecoverable via this
+// primitive.
+//
+// Implementation: sweep-mode guard runs in validateScanFlags() AFTER
+// args are gathered (we know mode at that point). parseArgs only
+// rejects the universally-illegal cases (empty, missing required).
 const REDIS_GLOB_CHARS = /[*?[\]\\]/;
-const SCAN_KEY_FLAGS = new Set(['user', 'slot', 'cluster', 'channel', 'rule']);
+const SCAN_KEY_FLAGS = new Set(['user', 'cluster']);
 
 export function parseArgs(argv) {
   const allowedFlags = new Set(['--user', '--slot', '--cluster', '--channel', '--rule', '--reason']);
@@ -98,19 +105,7 @@ export function parseArgs(argv) {
     if (typeof value !== 'string' || value.length === 0 || value.startsWith('--')) {
       return { kind: 'err', message: `flag ${flag} requires a non-empty value` };
     }
-    const flagName = flag.slice(2);
-    // Codex PR #3617 P1 — block Redis glob metacharacters in any flag
-    // whose value reaches the SCAN/DEL pattern. The reason flag is
-    // free-form (audit log) and does not reach Redis, so it's exempt.
-    if (SCAN_KEY_FLAGS.has(flagName) && REDIS_GLOB_CHARS.test(value)) {
-      return {
-        kind: 'err',
-        message: `--${flagName} value contains Redis glob metacharacter (*, ?, [, ], or \\). ` +
-          `These would broaden the SCAN pattern beyond a single user-cluster scope and ` +
-          `delete unrelated keys. Got: ${JSON.stringify(value)}`,
-      };
-    }
-    args[flagName] = value;
+    args[flag.slice(2)] = value;
     i++;
   }
 
@@ -131,6 +126,27 @@ export function parseArgs(argv) {
   }
   if (hasChannel && !ALLOWED_CHANNELS.has(args.channel)) {
     return { kind: 'err', message: `--channel must be one of ${[...ALLOWED_CHANNELS].join(',')}; got ${JSON.stringify(args.channel)}` };
+  }
+  // Codex PR #3617 P2 — glob-char guard is sweep-mode-only.
+  // Sweep mode = no --channel + no --rule (we'll SCAN with a wildcard
+  // pattern). Exact-DEL mode = both supplied (we DEL a literal key, so
+  // Redis treats glob chars as plain bytes). The guard catches the
+  // sweep case where injection would broaden the SCAN pattern.
+  const isSweepMode = !hasChannel && !hasRule;
+  if (isSweepMode) {
+    for (const flagName of SCAN_KEY_FLAGS) {
+      const value = args[flagName];
+      if (typeof value === 'string' && REDIS_GLOB_CHARS.test(value)) {
+        return {
+          kind: 'err',
+          message: `--${flagName} value contains a Redis glob metacharacter (*, ?, [, ], or \\) ` +
+            `in sweep mode (no --channel/--rule). These would broaden the SCAN pattern beyond ` +
+            `a single user-cluster scope and delete unrelated keys. Got: ${JSON.stringify(value)}. ` +
+            `If the cluster ID legitimately contains glob chars (e.g. a url:* fallback), use ` +
+            `exact-DEL mode by also passing --channel and --rule.`,
+        };
+      }
+    }
   }
   return { kind: 'ok', args };
 }

--- a/scripts/clear-delivered-entry.mjs
+++ b/scripts/clear-delivered-entry.mjs
@@ -68,6 +68,24 @@ const EXIT_TRANSPORT = 2;
  * @param {string[]} argv — process.argv.slice(2)
  * @returns {{ kind: 'ok', args: Record<string,string> } | { kind: 'err', message: string }}
  */
+// Codex PR #3617 P1 — Redis SCAN glob-injection guard.
+//
+// The scan pattern at buildScanPattern is `digest:sent:v1:${user}:*:*:${cluster}`.
+// If user OR cluster contains Redis glob metacharacters (* ? [ ] \), the
+// pattern broadens beyond the intended single-user-single-cluster scope.
+// `--cluster '*'` would match every key in the prefix; `--user 'foo*'`
+// would match every cluster for every user starting with `foo`. The
+// followup DEL loop would then wipe far more rows than the operator
+// intended.
+//
+// Reject these characters at parse time. The legitimate value space for
+// userId / clusterId / channel / ruleId is alphanumerics + a small
+// punctuation set (`:` for ruleId composites, `-` for hash IDs); none
+// of the Redis metacharacters belong here. Reason strings are free-form
+// (audit log) and don't reach the SCAN pattern, so they're exempt.
+const REDIS_GLOB_CHARS = /[*?[\]\\]/;
+const SCAN_KEY_FLAGS = new Set(['user', 'slot', 'cluster', 'channel', 'rule']);
+
 export function parseArgs(argv) {
   const allowedFlags = new Set(['--user', '--slot', '--cluster', '--channel', '--rule', '--reason']);
   const args = {};
@@ -80,7 +98,19 @@ export function parseArgs(argv) {
     if (typeof value !== 'string' || value.length === 0 || value.startsWith('--')) {
       return { kind: 'err', message: `flag ${flag} requires a non-empty value` };
     }
-    args[flag.slice(2)] = value;
+    const flagName = flag.slice(2);
+    // Codex PR #3617 P1 — block Redis glob metacharacters in any flag
+    // whose value reaches the SCAN/DEL pattern. The reason flag is
+    // free-form (audit log) and does not reach Redis, so it's exempt.
+    if (SCAN_KEY_FLAGS.has(flagName) && REDIS_GLOB_CHARS.test(value)) {
+      return {
+        kind: 'err',
+        message: `--${flagName} value contains Redis glob metacharacter (*, ?, [, ], or \\). ` +
+          `These would broaden the SCAN pattern beyond a single user-cluster scope and ` +
+          `delete unrelated keys. Got: ${JSON.stringify(value)}`,
+      };
+    }
+    args[flagName] = value;
     i++;
   }
 

--- a/scripts/lib/brief-dedup-replay-log.mjs
+++ b/scripts/lib/brief-dedup-replay-log.mjs
@@ -117,6 +117,43 @@ export function buildReplayRecords(stories, reps, embeddingByHash, cfg, tickCont
     }
   }
 
+  // Codex PR #3617 P1 — Sprint 1 / U6 cluster identity contract.
+  //
+  // Map storyHash → rep.hash so every record can carry the canonical
+  // stable cluster identity (the rep's own hash, which equals
+  // mergedHashes[0] by U3's contract from Sprint 1). The pre-fix
+  // writer only emitted a per-tick numeric clusterId and the rep's
+  // mergedHashes was unreachable from non-rep records; U6's harness
+  // had to guess at cluster identity by re-deriving from individual
+  // storyHashes, splitting clusters whenever a non-rep story got
+  // sampled.
+  //
+  // Now: every record carries `repHash` (stable across ticks). U6
+  // collapses by repHash to get one timeline per (ruleId, cluster)
+  // regardless of which member story happened to be in the dedup
+  // input that tick.
+  //
+  // We also retain a separate Map of rep.hash → mergedHashes so the
+  // record builder can stamp mergedHashes ONLY onto rep records (the
+  // mergedHashes set lives on the rep object, not on individual input
+  // stories — readers asking "which storyHashes are in this cluster?"
+  // need to consult the rep, not the member).
+  const repHashByStoryHash = new Map();
+  const mergedHashesByRepHash = new Map();
+  if (Array.isArray(reps)) {
+    for (const rep of reps) {
+      const hashes = Array.isArray(rep?.mergedHashes) ? rep.mergedHashes : [rep?.hash];
+      for (const h of hashes) {
+        if (typeof h === 'string' && typeof rep?.hash === 'string' && !repHashByStoryHash.has(h)) {
+          repHashByStoryHash.set(h, rep.hash);
+        }
+      }
+      if (typeof rep?.hash === 'string' && Array.isArray(rep?.mergedHashes)) {
+        mergedHashesByRepHash.set(rep.hash, rep.mergedHashes);
+      }
+    }
+  }
+
   const tickConfig = {
     mode: cfg?.mode ?? null,
     clustering: cfg?.clustering ?? null,
@@ -141,20 +178,43 @@ export function buildReplayRecords(stories, reps, embeddingByHash, cfg, tickCont
     // "embed path completed" from "embed path fell back to Jaccard".
     const hasEmbedding =
       embeddingByHash instanceof Map && embeddingByHash.has(story?.hash);
+    // Codex PR #3617 P1 — Sprint 1 / U6 fields. headline + sourceUrl
+    // are the canonical names U5's classifier expects (matches the
+    // BriefStory schema and the digest-cooldown-decision input shape).
+    // We keep `title` and `link` as legacy aliases for any older
+    // consumer that pinned to the v1 shape.
+    const link = typeof story?.link === 'string' ? story.link : null;
+    const sourceUrl = link;
+    const isRep = repHashes.has(story?.hash);
     records.push({
-      v: 1,
+      v: 2, // Codex PR #3617 P1 — bump to v2 for repHash + headline + sourceUrl additions
       briefTickId: tickContext.briefTickId,
       ruleId: tickContext.ruleId,
       tsMs: tickContext.tsMs,
       storyHash: story?.hash ?? null,
       originalIndex,
-      isRep: repHashes.has(story?.hash),
+      isRep,
       clusterId: clusterByHash.has(story?.hash)
         ? clusterByHash.get(story?.hash)
         : null,
+      // Codex PR #3617 P1 — stable cluster identity (rep's own hash)
+      // for every record, including non-rep cluster members. U6
+      // collapses timelines by this field.
+      repHash: repHashByStoryHash.has(story?.hash)
+        ? repHashByStoryHash.get(story?.hash)
+        : null,
+      // Only reps carry the full mergedHashes set. Non-reps get null
+      // (their cluster membership is preserved via repHash). The set
+      // lives on the rep object (looked up via mergedHashesByRepHash);
+      // input stories don't carry mergedHashes themselves.
+      mergedHashes: isRep && typeof story?.hash === 'string' && mergedHashesByRepHash.has(story.hash)
+        ? mergedHashesByRepHash.get(story.hash)
+        : null,
       title: rawTitle,
+      headline: rawTitle, // U5/U6 prefer this name; matches BriefStory.headline
       normalizedTitle,
-      link: typeof story?.link === 'string' ? story.link : null,
+      link,
+      sourceUrl, // U5/U6 prefer this name; matches BriefStory.sourceUrl
       severity: story?.severity ?? null,
       currentScore: Number(story?.currentScore ?? 0),
       mentionCount: Number(story?.mentionCount ?? 1),

--- a/scripts/lib/brief-dedup-replay-log.mjs
+++ b/scripts/lib/brief-dedup-replay-log.mjs
@@ -140,6 +140,16 @@ export function buildReplayRecords(stories, reps, embeddingByHash, cfg, tickCont
   // need to consult the rep, not the member).
   const repHashByStoryHash = new Map();
   const mergedHashesByRepHash = new Map();
+  // Codex PR #3617 round-3 P1 — sources live on REP objects (post
+  // pre-hydration in seed-digest-notifications), NOT on the original
+  // pre-dedup `stories` array. materializeCluster() in brief-dedup-jaccard
+  // copies the rep into a new object, so mutations to dedupedAll[i].sources
+  // never reach the input `stories[i]` references the writer iterates
+  // below. Build a sourcesByRepHash Map here so EVERY record (rep AND
+  // non-rep cluster member) gets the rep's hydrated source set —
+  // non-reps share the rep's source identity by definition (the rep
+  // is the cluster's canonical view).
+  const sourcesByRepHash = new Map();
   if (Array.isArray(reps)) {
     for (const rep of reps) {
       const hashes = Array.isArray(rep?.mergedHashes) ? rep.mergedHashes : [rep?.hash];
@@ -150,6 +160,9 @@ export function buildReplayRecords(stories, reps, embeddingByHash, cfg, tickCont
       }
       if (typeof rep?.hash === 'string' && Array.isArray(rep?.mergedHashes)) {
         mergedHashesByRepHash.set(rep.hash, rep.mergedHashes);
+      }
+      if (typeof rep?.hash === 'string' && Array.isArray(rep?.sources)) {
+        sourcesByRepHash.set(rep.hash, rep.sources);
       }
     }
   }
@@ -186,6 +199,17 @@ export function buildReplayRecords(stories, reps, embeddingByHash, cfg, tickCont
     const link = typeof story?.link === 'string' ? story.link : null;
     const sourceUrl = link;
     const isRep = repHashes.has(story?.hash);
+    // Codex PR #3617 round-3 P1 — read sources from the rep's hydrated
+    // set (sourcesByRepHash) keyed by repHash, NOT from the input
+    // story's `sources` field. The latter is empty at writeReplayLog
+    // call time because materializeCluster returned copied rep objects
+    // and pre-hydration mutates dedupedAll, not the input `stories`.
+    const repHashForStory = repHashByStoryHash.has(story?.hash)
+      ? repHashByStoryHash.get(story?.hash)
+      : null;
+    const repSources = repHashForStory && sourcesByRepHash.has(repHashForStory)
+      ? sourcesByRepHash.get(repHashForStory)
+      : null;
     records.push({
       v: 2, // Codex PR #3617 P1 — bump to v2 for repHash + headline + sourceUrl additions
       briefTickId: tickContext.briefTickId,
@@ -200,9 +224,7 @@ export function buildReplayRecords(stories, reps, embeddingByHash, cfg, tickCont
       // Codex PR #3617 P1 — stable cluster identity (rep's own hash)
       // for every record, including non-rep cluster members. U6
       // collapses timelines by this field.
-      repHash: repHashByStoryHash.has(story?.hash)
-        ? repHashByStoryHash.get(story?.hash)
-        : null,
+      repHash: repHashForStory,
       // Only reps carry the full mergedHashes set. Non-reps get null
       // (their cluster membership is preserved via repHash). The set
       // lives on the rep object (looked up via mergedHashesByRepHash);
@@ -219,7 +241,16 @@ export function buildReplayRecords(stories, reps, embeddingByHash, cfg, tickCont
       currentScore: Number(story?.currentScore ?? 0),
       mentionCount: Number(story?.mentionCount ?? 1),
       phase: story?.phase ?? null,
-      sources: Array.isArray(story?.sources) ? story.sources : [],
+      // Codex PR #3617 round-3 P1 — sources from the rep's hydrated
+      // set, not the input story's (empty by construction at this point).
+      // Non-rep records inherit the rep's set so cluster source-count
+      // identity is uniform across all member records. Falls back to
+      // the input story's sources when the rep map has no entry (e.g.
+      // a synthetic test fixture passing pre-hydrated input stories
+      // and bypass-rep-build paths) so existing tests don't break.
+      sources: Array.isArray(repSources)
+        ? repSources
+        : (Array.isArray(story?.sources) ? story.sources : []),
       embeddingCacheKey: cacheKey,
       hasEmbedding,
       // Per-record shallow copy so an in-memory consumer (future

--- a/scripts/lib/digest-cooldown-config.mjs
+++ b/scripts/lib/digest-cooldown-config.mjs
@@ -1,0 +1,84 @@
+/**
+ * Sprint 1 / U5 — kill-switch parser for the cooldown decision module.
+ *
+ * Mode contract:
+ *   `DIGEST_COOLDOWN_MODE` ∈ {'shadow', 'off'}.
+ *   Default (unset / empty)         → 'shadow'
+ *   Exact 'off'                     → 'off'
+ *   Anything else (typo, garbage,
+ *     'true', '1', or even 'enforce'
+ *     which Sprint 2 will introduce) → 'shadow' + invalidRaw warn.
+ *
+ * Why 'enforce' is intentionally invalid in Sprint 1: Sprint 2 introduces
+ * the third value once the 14-day replay (U6) validates the cooldown
+ * table. Treating an early 'enforce' set as fail-closed-to-shadow
+ * prevents an operator from accidentally flipping enforcement on before
+ * Sprint 2 ships the wiring — the env flag would otherwise produce a
+ * silent partial-enforce state where the U5 decision is computed but
+ * the send-loop integration that gates on it doesn't exist yet.
+ *
+ * Pattern modelled on `scripts/lib/brief-dedup.mjs::readOrchestratorConfig`
+ * — see that file's header for the canonical fail-closed-on-typo
+ * rationale (`feedback_kill_switch_default_on_typo`).
+ *
+ * The parser is pure: no I/O, no side effects, deterministic output for a
+ * given env. Callers that want the warn-on-typo loud-log pass `cfg.invalidRaw`
+ * to their console.warn at startup; this module only reports it.
+ */
+
+const VALID_MODES = Object.freeze(new Set(['shadow', 'off']));
+
+/**
+ * @typedef {'shadow' | 'off'} CooldownMode
+ *
+ * @typedef {object} CooldownConfig
+ * @property {CooldownMode} mode
+ * @property {string | null} invalidRaw
+ *   Non-null when the env var was set to something the parser rejected.
+ *   Operators surface this as a startup warn so a typo can't hide.
+ */
+
+/**
+ * Parse the cooldown mode from the given env (or process.env). Empty /
+ * unset → 'shadow' (the safe default). Exact 'off' → 'off'. Anything
+ * else → 'shadow' with `invalidRaw` populated for the caller to warn.
+ *
+ * Case-folded to lowercase so `Shadow`, `OFF`, `Off` all behave as
+ * expected (Railway env values frequently come from operators typing
+ * mixed case during incident response). Empty string after .trim() is
+ * also treated as unset — Railway sometimes round-trips through a
+ * dashboard widget that surfaces empty strings instead of unset values.
+ *
+ * @param {Record<string, string | undefined>} [env]
+ * @returns {CooldownConfig}
+ */
+export function readCooldownConfig(env = process.env) {
+  const raw = env?.DIGEST_COOLDOWN_MODE;
+  // Treat unset, undefined, and empty-after-trim identically — these are
+  // all "no operator opinion" cases that should fall to the safe default.
+  const trimmed = typeof raw === 'string' ? raw.trim().toLowerCase() : '';
+  if (trimmed === '') {
+    return { mode: 'shadow', invalidRaw: null };
+  }
+  if (VALID_MODES.has(trimmed)) {
+    return { mode: /** @type {CooldownMode} */ (trimmed), invalidRaw: null };
+  }
+  // Anything else fails closed to 'shadow'. Surface the raw (post-trim,
+  // post-lowercase) value so operators can spot typos. We deliberately
+  // don't pass the original case-sensitive string here — operators
+  // chasing a typo care about which value the parser saw, not the exact
+  // capitalisation they typed.
+  return { mode: 'shadow', invalidRaw: trimmed };
+}
+
+/**
+ * Convenience accessor — returns just the mode. Use this when you don't
+ * need the invalidRaw warn surface (e.g., inside the decision module's
+ * `decision === null` short-circuit when mode is 'off').
+ *
+ * @param {Record<string, string | undefined>} [env]
+ * @returns {CooldownMode}
+ */
+export function readCooldownMode(env = process.env) {
+  return readCooldownConfig(env).mode;
+}

--- a/scripts/lib/digest-cooldown-decision.mjs
+++ b/scripts/lib/digest-cooldown-decision.mjs
@@ -1,0 +1,402 @@
+/**
+ * Sprint 1 / U5 — pure cooldown decision module.
+ *
+ * Computes a "would-have-suppressed" decision for a given (user, slot,
+ * cluster, channel, rule) candidate against the U4 delivered-log's
+ * `lastDelivered*` state. Sprint 1 ships this in SHADOW MODE — the
+ * decision is logged but never gates a send. Sprint 2 (post-replay
+ * validation) flips the connection to enforcement.
+ *
+ * Pure function: no I/O, no side effects. Caller resolves the
+ * `lastDeliveredAt` / `lastDeliveredSourceCount` / `lastDeliveredTier`
+ * inputs from a single Upstash GET on the U4 key
+ *   `digest:sent:v1:{userId}:{channel}:{ruleId}:{clusterId}`
+ * (value JSON shape `{sentAt, sourceCount, severity}` per
+ * `scripts/lib/digest-delivered-log.mjs:148-170`).
+ *
+ * ── Cooldown table (initial; tunable post-replay in U6) ──────────────
+ *
+ *   | Type                              | Floor | Re-allow trigger                       |
+ *   |-----------------------------------|-------|----------------------------------------|
+ *   | CRITICAL · developing kinetic     | 4h    | +5 sources OR new fact OR severity     |
+ *   | CRITICAL · sustained narrative    | 24h ✱ | new fact only                          |
+ *   | HIGH · event                      | 18h   | +5 sources OR new fact                 |
+ *   | HIGH · earnings/single-corporate  | 48h ✱ | real follow-up event (escalation)      |
+ *   | Analysis (doctrine, research)     | 7d ✱  | never within window (hard floor)       |
+ *   | MED                               | 36h   | any update                             |
+ *
+ *   ✱ = "hard" floor (no source-count evolution bypass; only listed
+ *       trigger). The non-hard floors honour the +5-sources / new-fact
+ *       evolution bypasses on top of the floor check.
+ *
+ * Severity-tier change is a universal allow trigger across all classes
+ * EXCEPT the hard-floor ones (Analysis 7d, single-corp 48h) — a follow-up
+ * regulatory event on a corporate-earnings cluster is the encoded "real
+ * follow-up event" trigger, captured by the caller setting `currentTier`
+ * on the corp-earnings re-air to a higher tier than `lastDeliveredTier`.
+ *
+ * ── Type classifier (Sprint 1 stub; Sprint 3 ships final taxonomy) ───
+ *
+ *   1. Source domain `usni.org|csis.org|brookings.edu|*.edu|nature.com|
+ *      sciencemag.org` → 'analysis'
+ *   2. Source domain `*.gov` AND headline matches
+ *      `/LICENSE NO\.|Final Rule|Notice of/` → 'sanctions-regulatory'
+ *   3. Headline matches `/(beat|miss|tops|exceeds) (forecast|estimate|
+ *      profit)/i` → 'high-single-corporate'
+ *   4. Severity from existing scoring → 'critical-developing' (when
+ *      severity='critical' AND we have no sustained marker), else
+ *      'critical-sustained' for repeat critical airings (3+ priors),
+ *      'high-event' for severity='high', 'med' for severity='medium'.
+ *   5. Missing classification → fallback 'high-event' (18h floor) +
+ *      `classificationMissing: true` flag for telemetry.
+ *
+ * ── Decision input / output shapes ───────────────────────────────────
+ *
+ * Input fields used by this module:
+ *   userId, slot, clusterId, channel, ruleId   — opaque pass-through;
+ *                                                 only used in logs.
+ *   type            — pre-classified label OR null to invoke classifier
+ *   severity        — current-airing severity tier ('critical' | 'high' |
+ *                     'medium' | 'low')
+ *   currentSourceCount, currentTier   — current-airing observables
+ *   lastDeliveredAt — epoch ms; null/undefined means "no prior delivery"
+ *   lastDeliveredSourceCount, lastDeliveredTier  — read from U4 row
+ *   classifierInputs (optional) — { sourceDomain, headline } when caller
+ *                                  wants the stub classifier to run.
+ *   nowMs (optional) — epoch ms for tests; defaults to Date.now().
+ *
+ * Output:
+ *   { decision: 'allow' | 'suppress',
+ *     reason: string,            — see REASON_* constants
+ *     cooldownHours: number,     — applicable floor for this type
+ *     evolutionDelta: object,    — { sourceCountDelta, tierChanged } when relevant
+ *     classifiedType: string,    — final type used for the decision
+ *     classificationMissing: boolean, — true when stub fell back to
+ *                                       'high-event' default
+ *   }
+ *
+ * Output reasons (string consts; downstream observers may switch on
+ * these). Stable contract — adding a reason is fine; renaming requires
+ * a coordinated change in `scripts/lib/digest-cooldown-shadow-log.mjs`
+ * + the U6 replay harness.
+ */
+
+// ── Cooldown floors (hours) ──────────────────────────────────────────
+
+/**
+ * @typedef {'critical-developing' | 'critical-sustained' | 'high-event' |
+ *           'high-single-corporate' | 'analysis' | 'sanctions-regulatory' |
+ *           'med'} CooldownType
+ */
+
+/**
+ * @type {Record<CooldownType, { hours: number, hard: boolean,
+ *   allowSourceCountEvolution: boolean, allowNewFact: boolean,
+ *   allowTierChange: boolean }>}
+ */
+const COOLDOWN_TABLE = Object.freeze({
+  'critical-developing':       { hours: 4,        hard: false, allowSourceCountEvolution: true,  allowNewFact: true, allowTierChange: true },
+  'critical-sustained':        { hours: 24,       hard: true,  allowSourceCountEvolution: false, allowNewFact: true, allowTierChange: false },
+  'high-event':                { hours: 18,       hard: false, allowSourceCountEvolution: true,  allowNewFact: true, allowTierChange: true },
+  'high-single-corporate':     { hours: 48,       hard: true,  allowSourceCountEvolution: false, allowNewFact: false, allowTierChange: true /* tier escalation = "real follow-up" trigger */ },
+  // Sanctions/regulatory are treated like high-event by default — they
+  // get a floor + evolution bypasses. Sprint 3's classifier may split
+  // this further (e.g., immediate-effect vs scheduled).
+  'sanctions-regulatory':      { hours: 18,       hard: false, allowSourceCountEvolution: true,  allowNewFact: true, allowTierChange: true },
+  'analysis':                  { hours: 7 * 24,   hard: true,  allowSourceCountEvolution: false, allowNewFact: false, allowTierChange: false },
+  'med':                       { hours: 36,       hard: false, allowSourceCountEvolution: true,  allowNewFact: true, allowTierChange: true },
+});
+
+const SOURCE_COUNT_EVOLUTION_DELTA = 5;
+
+// Severity tier ordering for "tier change" detection. Higher number =
+// higher severity. When `currentTier > lastTier` the cluster has
+// escalated — usually allow. When `currentTier < lastTier` it has
+// de-escalated — also allow under the spirit of "tier changed", because
+// the user may want to know a previously-critical event has cooled.
+const SEVERITY_RANK = Object.freeze({
+  critical: 4,
+  high: 3,
+  medium: 2,
+  low: 1,
+  unknown: 0,
+});
+
+// ── Reason constants (stable wire contract) ──────────────────────────
+
+export const REASON = Object.freeze({
+  NO_PRIOR_DELIVERY: 'no_prior_delivery',
+  COOLDOWN_FLOOR: 'cooldown_floor',
+  COOLDOWN_DISABLED: 'cooldown_disabled',
+  EVOLUTION_SOURCE_COUNT: 'evolution_source_count',
+  EVOLUTION_NEW_FACT: 'evolution_new_fact',
+  SEVERITY_TIER_CHANGE: 'severity_tier_change',
+  ANALYSIS_7D_HARD: 'analysis_7d_hard',
+  SINGLE_CORP_48H_HARD: 'single_corp_48h_hard',
+  CLASSIFICATION_MISSING_DEFAULT_HIGH: 'classification_missing_default_high',
+});
+
+// Stub classifier domains. `*.edu` etc. are matched as a suffix.
+const ANALYSIS_DOMAINS = Object.freeze([
+  'usni.org', 'csis.org', 'brookings.edu', 'nature.com', 'sciencemag.org',
+]);
+const ANALYSIS_DOMAIN_SUFFIXES = Object.freeze(['.edu']);
+const GOV_DOMAIN_SUFFIXES = Object.freeze(['.gov', '.gov.uk', '.gov.us']);
+const REGULATORY_HEADLINE_REGEX = /LICENSE NO\.|Final Rule|Notice of/;
+// Single-corporate earnings: deliberately restrictive — matches the
+// editorial-slot pattern (verb + forecast/estimate/profit). Avoids
+// false positives like "company beat its own internal goal" via the
+// noun-anchor.
+const SINGLE_CORP_HEADLINE_REGEX = /\b(beat|miss|tops|exceeds)\s+(forecast|estimate|profit)/i;
+
+// ── Stub classifier ──────────────────────────────────────────────────
+
+/**
+ * Stub type classifier (Sprint 1).
+ *
+ * Returns `{ type, classificationMissing }`. `classificationMissing` is
+ * only true when no rule matched and the caller is forced to the
+ * conservative 'high-event' fallback. Telemetry surface for U6 replay.
+ *
+ * @param {object} args
+ * @param {string} [args.sourceDomain] — host of the canonical source URL
+ * @param {string} [args.headline]
+ * @param {string} [args.severity]
+ * @returns {{ type: CooldownType, classificationMissing: boolean }}
+ */
+export function classifyStub(args = {}) {
+  const sourceDomain = typeof args.sourceDomain === 'string' ? args.sourceDomain.toLowerCase() : '';
+  const headline = typeof args.headline === 'string' ? args.headline : '';
+  const severity = typeof args.severity === 'string' ? args.severity.toLowerCase() : '';
+
+  // Rule 1 — Analysis domains (highest priority; a `.edu` domain
+  // publishing a "beat forecast" headline is still an analysis essay,
+  // not a corporate earnings update).
+  if (sourceDomain && (
+    ANALYSIS_DOMAINS.includes(sourceDomain) ||
+    ANALYSIS_DOMAIN_SUFFIXES.some((suffix) => sourceDomain.endsWith(suffix))
+  )) {
+    return { type: 'analysis', classificationMissing: false };
+  }
+
+  // Rule 2 — Government regulatory event (must be `.gov` AND headline
+  // looks like a regulatory notice).
+  if (sourceDomain && GOV_DOMAIN_SUFFIXES.some((suffix) => sourceDomain.endsWith(suffix))
+      && REGULATORY_HEADLINE_REGEX.test(headline)) {
+    return { type: 'sanctions-regulatory', classificationMissing: false };
+  }
+
+  // Rule 3 — Single-corporate earnings (regardless of domain — earnings
+  // headlines run on Reuters/Bloomberg/etc., not just IR pages).
+  if (SINGLE_CORP_HEADLINE_REGEX.test(headline)) {
+    return { type: 'high-single-corporate', classificationMissing: false };
+  }
+
+  // Rule 4 — Severity-derived fallback, tier-by-tier. We don't have a
+  // "developing vs sustained" signal in the BriefStory schema, so every
+  // critical airing is treated as 'critical-developing' (the more
+  // permissive 4h floor). Sprint 3's classifier will split this on a
+  // per-cluster repeat-airing count.
+  if (severity === 'critical') {
+    return { type: 'critical-developing', classificationMissing: false };
+  }
+  if (severity === 'high') {
+    return { type: 'high-event', classificationMissing: false };
+  }
+  if (severity === 'medium') {
+    return { type: 'med', classificationMissing: false };
+  }
+
+  // Rule 5 — fall back to the conservative 'high-event' default and
+  // surface the gap so U6 replay catches it. We pick 'high-event' (not
+  // 'med') because mis-suppressing a high-severity item is worse than
+  // mis-suppressing a medium one.
+  return { type: 'high-event', classificationMissing: true };
+}
+
+// ── Decision function ────────────────────────────────────────────────
+
+/**
+ * Pure decision: returns `null` if cooldown is disabled (mode === 'off')
+ * — the caller treats `null` as "no decision artifact, send through".
+ * Otherwise returns a `{decision, reason, ...}` object.
+ *
+ * Returning `null` (not an "allow with reason=cooldown_disabled" object)
+ * is the load-bearing contract per
+ * `feedback_gate_on_ground_truth_not_configured_state`: downstream
+ * observers gate on `cooldownDecision !== null`, NOT on the configured
+ * env. This way a future "shadow per-user" subset can short-circuit by
+ * returning null for users not in the subset, and the parity log line
+ * naturally omits the `cooldown_decision` field for them.
+ *
+ * @param {object} input
+ * @param {string} input.userId
+ * @param {string} input.slot
+ * @param {string} input.clusterId
+ * @param {string} input.channel
+ * @param {string} input.ruleId
+ * @param {CooldownType | null} [input.type] — pre-classified, OR null to
+ *   invoke the stub classifier on `classifierInputs`.
+ * @param {string} input.severity — current-airing severity
+ *   ('critical' | 'high' | 'medium' | 'low')
+ * @param {number} input.currentSourceCount
+ * @param {string} input.currentTier — same vocabulary as severity; for
+ *   most callers `currentTier === severity`. Decoupled in case future
+ *   classifiers want to express "severity downgraded but type
+ *   unchanged".
+ * @param {number | null | undefined} input.lastDeliveredAt — epoch ms
+ * @param {number | null | undefined} input.lastDeliveredSourceCount
+ * @param {string | null | undefined} input.lastDeliveredTier
+ * @param {{ sourceDomain?: string, headline?: string }} [input.classifierInputs]
+ * @param {{ mode?: 'shadow' | 'off', nowMs?: number }} [input.options]
+ * @returns {(null | {
+ *   decision: 'allow' | 'suppress',
+ *   reason: string,
+ *   cooldownHours: number,
+ *   evolutionDelta: { sourceCountDelta: number, tierChanged: boolean,
+ *                     hoursSinceLastDelivery: number | null },
+ *   classifiedType: CooldownType,
+ *   classificationMissing: boolean,
+ * })}
+ */
+export function evaluateCooldown(input) {
+  const opts = input?.options ?? {};
+  const mode = opts.mode ?? 'shadow';
+  // `mode === 'off'` is the explicit "do not produce an artifact" path.
+  // The downstream observer reads `cooldownDecision === null` as
+  // "cooldown was not consulted for this candidate" — see header.
+  if (mode === 'off') return null;
+
+  const nowMs = Number.isFinite(opts.nowMs) ? opts.nowMs : Date.now();
+
+  // Resolve classification: caller-supplied beats stub.
+  let classifiedType;
+  let classificationMissing = false;
+  if (input?.type && COOLDOWN_TABLE[input.type]) {
+    classifiedType = input.type;
+  } else {
+    const stub = classifyStub({
+      sourceDomain: input?.classifierInputs?.sourceDomain,
+      headline: input?.classifierInputs?.headline,
+      severity: input?.severity,
+    });
+    classifiedType = stub.type;
+    classificationMissing = stub.classificationMissing;
+  }
+
+  const cell = COOLDOWN_TABLE[classifiedType];
+  // Defensive: if a future caller passes an invalid pre-classified type
+  // we fall back to the same default the stub uses (high-event), so the
+  // decision pipeline never throws mid-cron. Telemetry flag fires.
+  const tableEntry = cell ?? COOLDOWN_TABLE['high-event'];
+  if (!cell) classificationMissing = true;
+
+  const cooldownHours = tableEntry.hours;
+  const lastDeliveredAt = Number.isFinite(input?.lastDeliveredAt) ? input.lastDeliveredAt : null;
+
+  // No prior delivery → always allow. This is the "first-send" path —
+  // the U4 writer hasn't recorded a row for this (channel, rule,
+  // cluster) tuple yet.
+  if (lastDeliveredAt === null) {
+    return {
+      decision: 'allow',
+      reason: classificationMissing
+        ? REASON.CLASSIFICATION_MISSING_DEFAULT_HIGH
+        : REASON.NO_PRIOR_DELIVERY,
+      cooldownHours,
+      evolutionDelta: {
+        sourceCountDelta: 0,
+        tierChanged: false,
+        hoursSinceLastDelivery: null,
+      },
+      classifiedType,
+      classificationMissing,
+    };
+  }
+
+  const elapsedMs = nowMs - lastDeliveredAt;
+  const elapsedHours = elapsedMs / (60 * 60 * 1000);
+  const floorMs = cooldownHours * 60 * 60 * 1000;
+  const withinFloor = elapsedMs < floorMs;
+
+  const lastSourceCount = Number.isFinite(input?.lastDeliveredSourceCount)
+    ? input.lastDeliveredSourceCount
+    : 0;
+  const currentSourceCount = Number.isFinite(input?.currentSourceCount)
+    ? input.currentSourceCount
+    : 0;
+  const sourceCountDelta = currentSourceCount - lastSourceCount;
+
+  const lastTierRank = SEVERITY_RANK[String(input?.lastDeliveredTier ?? '').toLowerCase()] ?? 0;
+  const currentTierRank = SEVERITY_RANK[String(input?.currentTier ?? '').toLowerCase()] ?? 0;
+  const tierChanged = lastTierRank !== currentTierRank && lastTierRank > 0 && currentTierRank > 0;
+
+  const evolutionDelta = {
+    sourceCountDelta,
+    tierChanged,
+    hoursSinceLastDelivery: Number(elapsedHours.toFixed(3)),
+  };
+
+  // Beyond the floor → always allow. Cooldown is satisfied.
+  if (!withinFloor) {
+    return {
+      decision: 'allow',
+      reason: REASON.COOLDOWN_FLOOR,
+      cooldownHours,
+      evolutionDelta,
+      classifiedType,
+      classificationMissing,
+    };
+  }
+
+  // Within the floor — check evolution bypasses (if the type permits).
+  // Order of precedence: tier change → source count → suppress.
+  // Tier-change has highest precedence because it's the strongest
+  // editorial signal: a critical-→-high de-escalation deserves a fresh
+  // edition even if no new sources came in. Single-corp's
+  // allowTierChange is on (real follow-up event = tier escalation),
+  // analysis's is off (the 7d hard floor really is the contract).
+  if (tableEntry.allowTierChange && tierChanged) {
+    return {
+      decision: 'allow',
+      reason: REASON.SEVERITY_TIER_CHANGE,
+      cooldownHours,
+      evolutionDelta,
+      classifiedType,
+      classificationMissing,
+    };
+  }
+
+  if (tableEntry.allowSourceCountEvolution && sourceCountDelta >= SOURCE_COUNT_EVOLUTION_DELTA) {
+    return {
+      decision: 'allow',
+      reason: REASON.EVOLUTION_SOURCE_COUNT,
+      cooldownHours,
+      evolutionDelta,
+      classifiedType,
+      classificationMissing,
+    };
+  }
+
+  // No bypass triggered — within-floor suppression. Return the
+  // type-specific "hard" reason for the two hard-floor classes so the
+  // shadow log is greppable per-class without a separate filter.
+  let reason = REASON.COOLDOWN_FLOOR;
+  if (classifiedType === 'analysis') reason = REASON.ANALYSIS_7D_HARD;
+  if (classifiedType === 'high-single-corporate') reason = REASON.SINGLE_CORP_48H_HARD;
+
+  return {
+    decision: 'suppress',
+    reason,
+    cooldownHours,
+    evolutionDelta,
+    classifiedType,
+    classificationMissing,
+  };
+}
+
+// Re-export the table for tests that want to assert specific cells
+// without re-encoding the contract. Keep the export read-only to
+// prevent a test from mutating it and corrupting other tests.
+export const __COOLDOWN_TABLE = COOLDOWN_TABLE;
+export const __SOURCE_COUNT_EVOLUTION_DELTA = SOURCE_COUNT_EVOLUTION_DELTA;

--- a/scripts/lib/digest-cooldown-decision.mjs
+++ b/scripts/lib/digest-cooldown-decision.mjs
@@ -282,6 +282,12 @@ export function classifyStub(args = {}) {
  * @param {number | null | undefined} input.lastDeliveredAt — epoch ms
  * @param {number | null | undefined} input.lastDeliveredSourceCount
  * @param {string | null | undefined} input.lastDeliveredTier
+ * @param {string | null | undefined} input.lastDeliveredHeadline
+ *   Greptile PR #3617 P2 — last-delivered headline (read from the U4
+ *   row's optional `headline` field). When present, drives the
+ *   EVOLUTION_NEW_FACT bypass via string-equality compare against the
+ *   current-airing headline. Sprint 1 stub; Sprint 3's full classifier
+ *   replaces with LLM-driven fact-diff.
  * @param {{ sourceDomain?: string, headline?: string }} [input.classifierInputs]
  * @param {{ mode?: 'shadow' | 'off', nowMs?: number }} [input.options]
  * @returns {(null | {
@@ -412,6 +418,49 @@ export function evaluateCooldown(input) {
       classifiedType,
       classificationMissing,
     };
+  }
+
+  // Greptile PR #3617 P2 — EVOLUTION_NEW_FACT bypass.
+  //
+  // The reason constant + per-class allowNewFact flag have been part
+  // of the wire contract since U5 shipped, but no code path produced
+  // the reason — exporting an unused contract surface is worse than
+  // not exporting it (downstream consumers couldn't rely on the
+  // reason ever firing). Sprint 1 stub: detect via string-equality
+  // compare on the canonical headline. The U4 writer now persists
+  // `headline` alongside {sentAt, sourceCount, severity} so the
+  // evaluator can read the prior airing's headline.
+  //
+  // Why string-equality (not LLM-diff): Sprint 3's full classifier
+  // ships an LLM-driven fact-diff that replaces this. For Sprint 1
+  // string-equality is the conservative stub — it only fires the
+  // bypass when the upstream feed produced a genuinely different
+  // headline (rephrased news, not just a wire-rewording duplicate).
+  // False negatives (rewordings that should fire) keep the
+  // suppression conservative — preferable to false positives
+  // (typo-edits firing the bypass and over-shipping).
+  //
+  // Compare semantic: case-insensitive, whitespace-trimmed equality.
+  // Both sides must be non-empty for the bypass to fire — when
+  // lastDeliveredHeadline is null (older v4 row without the field, or
+  // first send) we skip cleanly, leaving the source-count bypass and
+  // the suppress branch as the only paths.
+  if (tableEntry.allowNewFact && typeof input?.lastDeliveredHeadline === 'string'
+    && input.lastDeliveredHeadline.length > 0
+    && typeof input?.classifierInputs?.headline === 'string'
+    && input.classifierInputs.headline.length > 0) {
+    const currentHeadlineNorm = input.classifierInputs.headline.trim().toLowerCase();
+    const lastHeadlineNorm = input.lastDeliveredHeadline.trim().toLowerCase();
+    if (currentHeadlineNorm !== lastHeadlineNorm) {
+      return {
+        decision: 'allow',
+        reason: REASON.EVOLUTION_NEW_FACT,
+        cooldownHours,
+        evolutionDelta,
+        classifiedType,
+        classificationMissing,
+      };
+    }
   }
 
   if (tableEntry.allowSourceCountEvolution && sourceCountDelta >= SOURCE_COUNT_EVOLUTION_DELTA) {

--- a/scripts/lib/digest-cooldown-decision.mjs
+++ b/scripts/lib/digest-cooldown-decision.mjs
@@ -98,7 +98,14 @@ const COOLDOWN_TABLE = Object.freeze({
   'critical-developing':       { hours: 4,        hard: false, allowSourceCountEvolution: true,  allowNewFact: true, allowTierChange: true },
   'critical-sustained':        { hours: 24,       hard: true,  allowSourceCountEvolution: false, allowNewFact: true, allowTierChange: false },
   'high-event':                { hours: 18,       hard: false, allowSourceCountEvolution: true,  allowNewFact: true, allowTierChange: true },
-  'high-single-corporate':     { hours: 48,       hard: true,  allowSourceCountEvolution: false, allowNewFact: false, allowTierChange: true /* tier escalation = "real follow-up" trigger */ },
+  // Codex PR #3617 P2 — `tierChangeMode: 'escalation-only'` is the
+  // load-bearing signal. The table comment above ("real follow-up event
+  // = tier escalation") was the documented contract, but the pre-fix
+  // `allowTierChange: true` permitted ANY tier change including
+  // de-escalations, so a HIGH→MEDIUM earnings repeat inside 48h
+  // returned allow / severity_tier_change. Downgrade is editorial noise,
+  // not a follow-up signal.
+  'high-single-corporate':     { hours: 48,       hard: true,  allowSourceCountEvolution: false, allowNewFact: false, allowTierChange: true, tierChangeMode: 'escalation-only' },
   // Sanctions/regulatory are treated like high-event by default — they
   // get a floor + evolution bypasses. Sprint 3's classifier may split
   // this further (e.g., immediate-effect vs scheduled).
@@ -384,7 +391,19 @@ export function evaluateCooldown(input) {
   // edition even if no new sources came in. Single-corp's
   // allowTierChange is on (real follow-up event = tier escalation),
   // analysis's is off (the 7d hard floor really is the contract).
-  if (tableEntry.allowTierChange && tierChanged) {
+  //
+  // Codex PR #3617 P2 — `tierChangeMode: 'escalation-only'` opts a
+  // class out of the de-escalation bypass. high-single-corporate uses
+  // it: a HIGH→MEDIUM earnings repeat inside 48h is editorial noise
+  // (the original release was already shipped; the downgrade isn't a
+  // new event), not a "real follow-up". Other classes still honour
+  // the symmetric tier-change rule (a critical→high de-escalation IS
+  // editorial signal: "the situation cooled" is news).
+  const tierChangeMode = tableEntry.tierChangeMode ?? 'any';
+  const tierChangeAllowed = tableEntry.allowTierChange && tierChanged && (
+    tierChangeMode === 'any' || (tierChangeMode === 'escalation-only' && currentTierRank > lastTierRank)
+  );
+  if (tierChangeAllowed) {
     return {
       decision: 'allow',
       reason: REASON.SEVERITY_TIER_CHANGE,

--- a/scripts/lib/digest-cooldown-decision.mjs
+++ b/scripts/lib/digest-cooldown-decision.mjs
@@ -136,12 +136,32 @@ export const REASON = Object.freeze({
   CLASSIFICATION_MISSING_DEFAULT_HIGH: 'classification_missing_default_high',
 });
 
-// Stub classifier domains. `*.edu` etc. are matched as a suffix.
+// Stub classifier domains. Each registered domain matches three host shapes:
+//   1. exact: `usni.org`
+//   2. www-prefixed: `www.usni.org`  (strip leading `www.` before exact match)
+//   3. subdomain: `editorial.usni.org`, `media.nature.com`  (suffix match)
+// Codex PR #3617 P2 — pre-fix only handled exact matches, so common
+// real-world hosts like `www.usni.org` and `www.nature.com` fell through
+// to the severity-derived fallback (high-event 18h floor) instead of
+// the analysis 7d hard floor. That broke shadow telemetry for the
+// dominant publication-host shape.
 const ANALYSIS_DOMAINS = Object.freeze([
   'usni.org', 'csis.org', 'brookings.edu', 'nature.com', 'sciencemag.org',
 ]);
 const ANALYSIS_DOMAIN_SUFFIXES = Object.freeze(['.edu']);
 const GOV_DOMAIN_SUFFIXES = Object.freeze(['.gov', '.gov.uk', '.gov.us']);
+
+/**
+ * Normalise a host for the analysis-domain checks: lowercase + strip a
+ * single leading `www.`. Other subdomain prefixes (editorial.usni.org,
+ * www2.csis.org) are caught by the suffix-match branch in classifyStub.
+ *
+ * @param {string} sourceDomain
+ * @returns {string}
+ */
+function stripWwwPrefix(sourceDomain) {
+  return sourceDomain.startsWith('www.') ? sourceDomain.slice(4) : sourceDomain;
+}
 const REGULATORY_HEADLINE_REGEX = /LICENSE NO\.|Final Rule|Notice of/;
 // Single-corporate earnings: deliberately restrictive — matches the
 // editorial-slot pattern (verb + forecast/estimate/profit). Avoids
@@ -172,11 +192,19 @@ export function classifyStub(args = {}) {
   // Rule 1 — Analysis domains (highest priority; a `.edu` domain
   // publishing a "beat forecast" headline is still an analysis essay,
   // not a corporate earnings update).
-  if (sourceDomain && (
-    ANALYSIS_DOMAINS.includes(sourceDomain) ||
-    ANALYSIS_DOMAIN_SUFFIXES.some((suffix) => sourceDomain.endsWith(suffix))
-  )) {
-    return { type: 'analysis', classificationMissing: false };
+  //
+  // Codex PR #3617 P2 — match three host shapes:
+  //   1. exact: `usni.org` → analysis
+  //   2. www-prefixed: `www.usni.org` → strip + exact match → analysis
+  //   3. subdomain: `editorial.usni.org`, `media.nature.com` → analysis
+  // The suffix match is `.${domain}` so `notmyusni.org` stays a miss.
+  if (sourceDomain) {
+    const stripped = stripWwwPrefix(sourceDomain);
+    const matchesAnalysisDomain = ANALYSIS_DOMAINS.some((d) => stripped === d || sourceDomain.endsWith(`.${d}`));
+    const matchesAnalysisSuffix = ANALYSIS_DOMAIN_SUFFIXES.some((suffix) => sourceDomain.endsWith(suffix));
+    if (matchesAnalysisDomain || matchesAnalysisSuffix) {
+      return { type: 'analysis', classificationMissing: false };
+    }
   }
 
   // Rule 2 — Government regulatory event (must be `.gov` AND headline

--- a/scripts/lib/digest-cooldown-shadow-log.mjs
+++ b/scripts/lib/digest-cooldown-shadow-log.mjs
@@ -1,0 +1,171 @@
+/**
+ * Sprint 1 / U5 — shadow-mode decision logger.
+ *
+ * Aggregates per-cluster cooldown decisions for one (user, rule) send
+ * and emits ONE summary line per send (not one per cluster). Format
+ * matches the existing parity log at `scripts/seed-digest-notifications
+ * .mjs:~2122-2131` so Sentry's console-breadcrumb hook can group both
+ * logs under the same fingerprint family.
+ *
+ * Why per-(user, rule), not per-(user, rule, channel): the cooldown
+ * decision is per-channel under the U4 key shape, but the operator
+ * surface that matters is "did this user-rule send have any would-have-
+ * been-suppressed clusters?". Per-channel granularity stays available
+ * via the `byChannel` aggregate in the line, but the line is one per
+ * send so a busy cron doesn't flood Sentry.
+ *
+ * `console.log` is the default level. `console.warn` is reserved for
+ * decisions where ANY cluster had `classificationMissing: true` — that
+ * is real telemetry signal worth surfacing in Sentry (the stub
+ * classifier hit the conservative-default fallback, which means U6
+ * replay needs to spot the gap before Sprint 3's final taxonomy lands).
+ *
+ * The module is pure — accepts a `consoleLike` dep so tests can record
+ * lines without touching real console. Returns the formatted line so
+ * tests can assert on shape without parsing console output.
+ */
+
+import { REASON } from './digest-cooldown-decision.mjs';
+
+/**
+ * Aggregate a flat list of per-cluster decisions into the summary
+ * counters used in the log line.
+ *
+ * Every decision is a `{decision, reason, classifiedType,
+ * classificationMissing, ...}` object as produced by `evaluateCooldown`.
+ * Decisions that came back `null` from the evaluator (mode='off') MUST
+ * be filtered by the caller BEFORE invoking this function — the logger
+ * intentionally has no opinion on the kill-switch state, only on
+ * decisions that were actually computed.
+ *
+ * @param {Array<{ decision: 'allow' | 'suppress', reason: string,
+ *   classifiedType: string, classificationMissing: boolean }>} decisions
+ * @returns {{
+ *   total: number,
+ *   allow: number,
+ *   suppress: number,
+ *   classificationMissing: number,
+ *   byReason: Record<string, number>,
+ *   byType: Record<string, number>,
+ * }}
+ */
+export function aggregateCooldownDecisions(decisions) {
+  /** @type {Record<string, number>} */
+  const byReason = {};
+  /** @type {Record<string, number>} */
+  const byType = {};
+  let allow = 0;
+  let suppress = 0;
+  let classificationMissing = 0;
+  if (!Array.isArray(decisions)) {
+    return { total: 0, allow: 0, suppress: 0, classificationMissing: 0, byReason, byType };
+  }
+  for (const d of decisions) {
+    if (!d || typeof d !== 'object') continue;
+    if (d.decision === 'allow') allow++;
+    else if (d.decision === 'suppress') suppress++;
+    if (d.classificationMissing) classificationMissing++;
+    const reason = typeof d.reason === 'string' ? d.reason : 'unknown';
+    byReason[reason] = (byReason[reason] ?? 0) + 1;
+    const type = typeof d.classifiedType === 'string' ? d.classifiedType : 'unknown';
+    byType[type] = (byType[type] ?? 0) + 1;
+  }
+  return {
+    total: allow + suppress,
+    allow,
+    suppress,
+    classificationMissing,
+    byReason,
+    byType,
+  };
+}
+
+/**
+ * Render the by-reason / by-type maps as a stable, parseable inline
+ * string for the Sentry-friendly log line: `k1=v1,k2=v2` sorted by key.
+ *
+ * Sorting is load-bearing — without it two ticks with the same counter
+ * distribution but different insertion order would produce different
+ * log lines, which breaks Sentry fingerprint grouping (the breadcrumb
+ * hook hashes the line text). Empty input renders as `none` so the
+ * field is always non-empty (avoids `bytype= ` parsing ambiguity).
+ *
+ * @param {Record<string, number>} map
+ * @returns {string}
+ */
+function renderSortedKv(map) {
+  const keys = Object.keys(map).sort();
+  if (keys.length === 0) return 'none';
+  return keys.map((k) => `${k}=${map[k]}`).join(',');
+}
+
+/**
+ * Emit one shadow-mode summary line per (user, rule) send. Caller
+ * collects per-cluster per-channel decisions during the send loop and
+ * passes them as a flat array.
+ *
+ * @param {object} args
+ * @param {string} args.userId
+ * @param {string} args.ruleId — same composite shape used by the U4
+ *   delivered-log writer (`${variant}:${lang}:${sensitivity}`).
+ * @param {string} args.slot — issueSlot string (used by the U6 replay
+ *   harness to bucket per-day; included in the line so an operator can
+ *   grep one slot's worth of decisions).
+ * @param {Array<object>} args.decisions — per-cluster decisions; null
+ *   entries (mode='off' short-circuits) MUST be filtered by the caller
+ *   before the line is emitted, OR set
+ *   `args.skipEmptyAggregate=true` to no-op when zero decisions remain.
+ * @param {boolean} [args.skipEmptyAggregate=true] — when true and the
+ *   filtered decisions list is empty, the function returns null without
+ *   emitting (avoids a `cooldown_decision total=0` line on every cron
+ *   tick when mode='off').
+ * @param {{ log?: (line: string) => void, warn?: (line: string) => void }} [args.consoleLike]
+ * @returns {string | null} — the line that was emitted, or null if
+ *   skipped. Useful for tests that want to assert on shape.
+ */
+export function emitCooldownShadowLog(args) {
+  const userId = typeof args?.userId === 'string' ? args.userId : 'unknown';
+  const ruleId = typeof args?.ruleId === 'string' ? args.ruleId : 'unknown';
+  const slot = typeof args?.slot === 'string' ? args.slot : 'unknown';
+  const decisions = Array.isArray(args?.decisions) ? args.decisions.filter(Boolean) : [];
+  const skipEmpty = args?.skipEmptyAggregate !== false;
+  const log = args?.consoleLike?.log ?? ((line) => console.log(line));
+  const warn = args?.consoleLike?.warn ?? ((line) => console.warn(line));
+
+  if (decisions.length === 0) {
+    if (skipEmpty) return null;
+    // Non-skip path: still emit so operators can see "decision pipeline
+    // ran with zero candidates" for one user-rule. Useful when testing
+    // the wiring on a low-traffic dev account.
+  }
+
+  const agg = aggregateCooldownDecisions(decisions);
+
+  // The line shape mirrors the existing parity log:
+  //   `[digest] brief lead parity user=X rule=Y winner_match=true ...`
+  // We use `[digest] cooldown_decision` as the prefix so a single
+  // `grep -E "cooldown_decision"` filters the whole stream.
+  const line =
+    `[digest] cooldown_decision user=${userId} ` +
+    `rule=${ruleId} ` +
+    `slot=${slot} ` +
+    `total=${agg.total} ` +
+    `allow=${agg.allow} ` +
+    `suppress=${agg.suppress} ` +
+    `would_have_dropped=${agg.suppress} ` + // alias: U6 replay names the metric this
+    `classification_missing=${agg.classificationMissing} ` +
+    `by_reason=${renderSortedKv(agg.byReason)} ` +
+    `by_type=${renderSortedKv(agg.byType)}`;
+
+  // Promote to warn ONLY when the stub classifier fell back to the
+  // conservative default for at least one cluster. That's a signal the
+  // Sprint 3 taxonomy needs to learn a new pattern, and it's the kind
+  // of thing Sentry should surface — the rest of the cooldown stream is
+  // observability noise that only matters in aggregate.
+  if (agg.classificationMissing > 0) {
+    warn(line);
+  } else {
+    log(line);
+  }
+  return line;
+}

--- a/scripts/lib/digest-delivered-log.mjs
+++ b/scripts/lib/digest-delivered-log.mjs
@@ -1,0 +1,257 @@
+/**
+ * Sprint 1 / U4 — per-channel, per-cluster delivered-log writer.
+ *
+ * Records "channel X delivered story-cluster Y for rule R to user U at
+ * time T" as an idempotent Redis row. Sprint 1 ships this in shadow:
+ * the U5 cooldown evaluator (next unit) will read these rows to decide
+ * "would-have-suppressed" without changing send behaviour. Sprint 2
+ * flips the read into enforcement.
+ *
+ * Key shape:
+ *   digest:sent:v1:${userId}:${channel}:${ruleId}:${clusterId}
+ *
+ * Every discriminator is explicit (no `${ruleId || slot}` boolean-OR
+ * fallback collapse — see `skill_cache_key_or_fallback_collapses_input
+ * _shapes`). Even though U2's option (a) collapses multi-rule users to
+ * one canonical winning rule per slot, `ruleId` stays in the key for
+ * audit traceability + so a future per-rule policy can target rows
+ * without a key migration.
+ *
+ * Value shape (minimal):
+ *   { sentAt: <epochMs>, sourceCount: <int>, severity: <tier> }
+ *
+ * U5's cooldown evaluator reads sentAt for the floor check and
+ * (sourceCount, severity) for the evolution-bypass decisions. Adding
+ * fields here is a contract change (U5 must read them); avoid bloat.
+ *
+ * TTL: 30 days base + per-key uniform random jitter 0-3 days. The
+ * jitter prevents synchronized expiry of every key 30 days after first
+ * deploy — without it, Sprint 2's enforce-mode would face a cliff
+ * where the cooldown filter sees no history one day after writing
+ * stopped working. See `per-item-cache-cliff-masks-upstream-regression`
+ * for the canonical incident pattern (different feed; same mechanism).
+ *
+ * Idempotency:
+ *   We use SET NX EX in JSON-body pipeline form (`feedback_upstash_rest
+ *   _set_ex_path_not_query`). The boolean response distinguishes
+ *   "wrote new key" (`'OK'`) from "key already existed, NX prevented
+ *   overwrite" (`null`). We trust the response and never write-then-
+ *   reread (`feedback_upstash_write_reread_race_in_handler`).
+ *
+ * Tri-state writer return: `{ written, conflicts, errors }` per
+ * `skill_caller_narrows_partial_result_type_drops_failure_counters`.
+ * The send-loop caller MUST early-return on `errors > 0` BEFORE any
+ * subsequent stamp/log — letting the story re-air to that channel on
+ * the next tick is preferable to false-suppressing it. `conflicts > 0`
+ * is benign idempotent re-write; log INFO not WARN.
+ *
+ * Failure-mode trade-off (operator-facing): if Resend returns 200 but
+ * THIS writer fails afterwards, the story re-airs to that channel on
+ * the next cron tick. We accept that trade-off: an extra email beats
+ * a silent suppression that hides a real delivery failure. The inverse
+ * (suppress on failure) would mask the delivery problem itself by
+ * pretending we'd already sent the story.
+ *
+ * Operator-side: paired primitive `clearDeliveredEntry` lives at
+ * `scripts/clear-delivered-entry.mjs`. Required `--reason` argument
+ * matches `skill_new_blocking_state_without_matching_clear_primitive`
+ * — every halt-able state needs an audited unhalt path.
+ */
+
+import { defaultRedisPipeline } from './_upstash-pipeline.mjs';
+
+const KEY_PREFIX = 'digest:sent:v1';
+const TTL_BASE_SECONDS = 30 * 24 * 60 * 60;     // 30d
+const TTL_JITTER_SECONDS = 3 * 24 * 60 * 60;    // 3d uniform random spread
+
+// Keep in lockstep with the cron's deliverable-channels filter in
+// scripts/seed-digest-notifications.mjs (the channel.channelType check).
+// Adding a new channel type → also add it here AND in api/health.js's
+// seed-meta SEED_META configuration if that channel needs separate
+// monitoring.
+export const ALLOWED_CHANNELS = Object.freeze(
+  new Set(['email', 'telegram', 'slack', 'discord', 'webhook']),
+);
+
+/**
+ * Build the canonical Redis key for a delivered-log entry. Every
+ * component must be a non-empty string of `[A-Za-z0-9_:-]` to keep the
+ * key namespace traversable by `redis-cli SCAN` / Upstash dashboard.
+ * Throws on any violation BEFORE the network call so malformed keys
+ * never reach Upstash.
+ *
+ * @param {{ userId: string; channel: string; ruleId: string; clusterId: string }} parts
+ * @returns {string}
+ */
+export function buildDeliveredLogKey(parts) {
+  const { userId, channel, ruleId, clusterId } = parts ?? {};
+  assertNonEmptyString(userId, 'userId');
+  assertChannel(channel);
+  assertNonEmptyString(ruleId, 'ruleId');
+  assertNonEmptyString(clusterId, 'clusterId');
+  // No explicit safety regex here — we trust the cron's userId/ruleId/
+  // clusterId producers (Convex IDs, our own variant strings, sha256
+  // hashes). If a future producer ever introduces a colon-bearing
+  // segment that could ambiguate the key, the `assertNonEmptyString`
+  // gate is the place to tighten.
+  return `${KEY_PREFIX}:${userId}:${channel}:${ruleId}:${clusterId}`;
+}
+
+/**
+ * Pure helper: per-write TTL with uniform jitter.
+ *
+ * Returns 30d * 86400 + Math.floor(rand * 3d * 86400). With the default
+ * `Math.random` the spread is uniform in `[2_592_000, 2_851_200)`.
+ *
+ * Tests inject a deterministic `randomFn` to assert distribution shape
+ * + bounds without relying on `Math.random` luck.
+ *
+ * @param {() => number} [randomFn=Math.random]
+ * @returns {number}
+ */
+export function computeTtlSecondsWithJitter(randomFn = Math.random) {
+  const r = randomFn();
+  // Clamp the random sample to [0, 1) so a buggy injection (returns
+  // negative, returns >=1) cannot push the TTL below the base or above
+  // base+jitter. Without this guard a `randomFn = () => 1` injection
+  // would yield TTL = base + jitter exactly, off-by-one above the
+  // documented bound.
+  const clamped = Number.isFinite(r) ? Math.max(0, Math.min(0.9999999, r)) : 0;
+  return TTL_BASE_SECONDS + Math.floor(clamped * TTL_JITTER_SECONDS);
+}
+
+/**
+ * Write one delivered-log entry. Idempotent via SET NX EX.
+ *
+ * Returns tri-state counts. Caller MUST inspect `errors > 0` and skip
+ * any subsequent "delivered" stamp / log when set — allowing the story
+ * to re-air on the next tick. See module docblock for the full failure-
+ * mode rationale.
+ *
+ * @param {object} args
+ * @param {string} args.userId
+ * @param {string} args.channel — one of ALLOWED_CHANNELS
+ * @param {string} args.ruleId
+ * @param {string} args.clusterId — BriefStory.clusterId (rep hash)
+ * @param {number} args.sentAt — epoch ms (Date.now()) at write time
+ * @param {number} args.sourceCount — BriefStory.sources?.length ?? 1
+ * @param {string} args.severity — BriefStory.threatLevel tier
+ * @param {object} [args.deps]
+ * @param {typeof defaultRedisPipeline} [args.deps.redisPipeline]
+ * @param {() => number} [args.deps.randomFn]
+ * @returns {Promise<{ written: number, conflicts: number, errors: number, key: string }>}
+ *   `key` is the canonical key shape — useful to logs and tests; never
+ *   used as a side-channel for the tri-state contract.
+ * @throws if any key component is empty or `channel` is unknown. Thrown
+ *   BEFORE the Upstash call — malformed keys never reach the wire.
+ */
+export async function writeDeliveredEntry(args) {
+  const {
+    userId,
+    channel,
+    ruleId,
+    clusterId,
+    sentAt,
+    sourceCount,
+    severity,
+    deps = {},
+  } = args ?? {};
+
+  // Throws on bad input — caller's responsibility to pre-validate.
+  // Throwing here (vs returning {errors: 1}) is intentional: a bad
+  // userId/clusterId is a programmer error, not a transient upstream
+  // failure, and we want the cron's existing try/catch to surface the
+  // stack trace. Network/Upstash failures DO return `errors: 1` — see
+  // the catch arm below.
+  const key = buildDeliveredLogKey({ userId, channel, ruleId, clusterId });
+  if (!Number.isFinite(sentAt) || sentAt <= 0) {
+    throw new Error(
+      `writeDeliveredEntry: sentAt must be a positive epoch-ms number; got ${JSON.stringify(sentAt)}`,
+    );
+  }
+  // sourceCount + severity are persisted but not key components — bad
+  // values degrade U5's cooldown decision, they don't break the key.
+  // Coerce defensively rather than throw so a single weird story can't
+  // poison an entire cron tick.
+  const safeSourceCount = Number.isFinite(sourceCount) && sourceCount >= 0
+    ? Math.floor(sourceCount)
+    : 0;
+  const safeSeverity = typeof severity === 'string' && severity.length > 0
+    ? severity
+    : 'unknown';
+
+  const value = JSON.stringify({
+    sentAt,
+    sourceCount: safeSourceCount,
+    severity: safeSeverity,
+  });
+  const ttl = computeTtlSecondsWithJitter(deps.randomFn);
+  const pipeline = deps.redisPipeline ?? defaultRedisPipeline;
+
+  let result;
+  try {
+    result = await pipeline([['SET', key, value, 'NX', 'EX', String(ttl)]]);
+  } catch (err) {
+    // defaultRedisPipeline catches its own throws and returns null. If
+    // a custom-injected pipeline DOES throw (test mock, future helper),
+    // surface as `errors: 1` so the caller's gate still fires. The
+    // failure mode is identical to a 5xx — story re-airs next tick.
+    return { written: 0, conflicts: 0, errors: 1, key };
+  }
+
+  // pipeline returned null = creds missing OR HTTP non-2xx OR fetch
+  // threw. Treat as error: caller short-circuits stamp/log.
+  if (result == null || !Array.isArray(result) || result.length === 0) {
+    return { written: 0, conflicts: 0, errors: 1, key };
+  }
+  const cell = result[0];
+  if (cell && typeof cell === 'object' && 'error' in cell) {
+    return { written: 0, conflicts: 0, errors: 1, key };
+  }
+  // Upstash pipeline cells: { result: 'OK' } on new write, { result: null }
+  // when NX prevented overwrite. Anything else is an upstream surprise —
+  // count as error so the cron does not silently mark the story stamped.
+  const cellResult = cell?.result;
+  if (cellResult === 'OK') return { written: 1, conflicts: 0, errors: 0, key };
+  if (cellResult === null) return { written: 0, conflicts: 1, errors: 0, key };
+  return { written: 0, conflicts: 0, errors: 1, key };
+}
+
+/**
+ * Convenience aggregator — sum tri-state counters across multiple
+ * writes (e.g. one cron tick across all channels for one user). Pure;
+ * no I/O. Useful for the seed-meta `keyCount`/`errorRate` sample +
+ * for tests that batch writes.
+ *
+ * @param {Array<{written?: number, conflicts?: number, errors?: number}>} results
+ * @returns {{ written: number, conflicts: number, errors: number }}
+ */
+export function aggregateResults(results) {
+  let written = 0, conflicts = 0, errors = 0;
+  if (!Array.isArray(results)) return { written, conflicts, errors };
+  for (const r of results) {
+    written += Number(r?.written ?? 0);
+    conflicts += Number(r?.conflicts ?? 0);
+    errors += Number(r?.errors ?? 0);
+  }
+  return { written, conflicts, errors };
+}
+
+// ── Internal validators ──────────────────────────────────────────────
+
+function assertNonEmptyString(value, label) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(
+      `digest-delivered-log: ${label} must be a non-empty string; got ${JSON.stringify(value)}`,
+    );
+  }
+}
+
+function assertChannel(channel) {
+  assertNonEmptyString(channel, 'channel');
+  if (!ALLOWED_CHANNELS.has(channel)) {
+    throw new Error(
+      `digest-delivered-log: channel must be one of ${[...ALLOWED_CHANNELS].join(',')}; got ${JSON.stringify(channel)}`,
+    );
+  }
+}

--- a/scripts/lib/digest-delivered-log.mjs
+++ b/scripts/lib/digest-delivered-log.mjs
@@ -190,7 +190,26 @@ export async function writeDeliveredEntry(args) {
 
   let result;
   try {
-    result = await pipeline([['SET', key, value, 'NX', 'EX', String(ttl)]]);
+    // Codex PR #3617 round-4 P1 — SET (overwrite) semantics, NOT SET NX.
+    //
+    // Pre-fix used NX so the row "stuck" to its first value forever
+    // (within the 30d±jitter TTL). After a high-event re-air was
+    // ALLOWED at 19h post-floor, the Redis row still pointed to T0 —
+    // so the next re-air at 20h read lastDeliveredAt=T0 and saw "20h
+    // beyond 18h floor → allow", instead of "1h since last delivery
+    // → suppress". Production shadow telemetry diverged from U6
+    // replay (which correctly updates synthetic state on allow), and
+    // Sprint 2 enforce-mode would have inherited the divergence as
+    // under-suppression of high-rate clusters.
+    //
+    // Refresh semantics: every successful send overwrites the row
+    // with the new {sentAt, sourceCount, severity}. The same-tick
+    // double-write idempotency that NX provided was a non-concern
+    // (the second write has the same value structurally), so SET is
+    // strictly correct + simpler. The TTL is re-applied on each
+    // write (per-key jitter recomputed) so a cluster that re-airs
+    // every few days never permanently expires.
+    result = await pipeline([['SET', key, value, 'EX', String(ttl)]]);
   } catch (err) {
     // defaultRedisPipeline catches its own throws and returns null. If
     // a custom-injected pipeline DOES throw (test mock, future helper),
@@ -208,12 +227,15 @@ export async function writeDeliveredEntry(args) {
   if (cell && typeof cell === 'object' && 'error' in cell) {
     return { written: 0, conflicts: 0, errors: 1, key };
   }
-  // Upstash pipeline cells: { result: 'OK' } on new write, { result: null }
-  // when NX prevented overwrite. Anything else is an upstream surprise —
+  // Upstash pipeline cells: { result: 'OK' } on every successful SET
+  // (whether new or overwrite). Anything else is an upstream surprise —
   // count as error so the cron does not silently mark the story stamped.
+  // The `conflicts` counter is preserved at 0 in the return shape for
+  // back-compat with the U4 aggregator and existing call sites; under
+  // SET semantics it can never increment (every successful write IS a
+  // write, never an idempotent no-op).
   const cellResult = cell?.result;
   if (cellResult === 'OK') return { written: 1, conflicts: 0, errors: 0, key };
-  if (cellResult === null) return { written: 0, conflicts: 1, errors: 0, key };
   return { written: 0, conflicts: 0, errors: 1, key };
 }
 

--- a/scripts/lib/digest-delivered-log.mjs
+++ b/scripts/lib/digest-delivered-log.mjs
@@ -154,6 +154,14 @@ export async function writeDeliveredEntry(args) {
     sentAt,
     sourceCount,
     severity,
+    // Greptile PR #3617 P2 — `headline` (optional) lets U5's cooldown
+    // evaluator drive the EVOLUTION_NEW_FACT bypass via simple string
+    // comparison against the prior delivery. Sprint 1 ships this as
+    // a stub (string-equality on the canonical headline); Sprint 3's
+    // full classifier replaces with an LLM-driven fact-diff. Storing
+    // headline here is forward-compatible — older readers ignore the
+    // field; the contract surface is the JSON shape, not the schema.
+    headline,
     deps = {},
   } = args ?? {};
 
@@ -179,12 +187,23 @@ export async function writeDeliveredEntry(args) {
   const safeSeverity = typeof severity === 'string' && severity.length > 0
     ? severity
     : 'unknown';
+  // Headline is optional — only set when caller provides a non-empty
+  // string. Allows existing call sites without a headline arg to keep
+  // working (their stored row simply omits the field, and the U5
+  // evaluator treats `lastDeliveredHeadline = null` as "can't compare,
+  // skip the new-fact bypass").
+  const safeHeadline = typeof headline === 'string' && headline.length > 0
+    ? headline
+    : null;
 
-  const value = JSON.stringify({
+  /** @type {Record<string, unknown>} */
+  const valueShape = {
     sentAt,
     sourceCount: safeSourceCount,
     severity: safeSeverity,
-  });
+  };
+  if (safeHeadline !== null) valueShape.headline = safeHeadline;
+  const value = JSON.stringify(valueShape);
   const ttl = computeTtlSecondsWithJitter(deps.randomFn);
   const pipeline = deps.redisPipeline ?? defaultRedisPipeline;
 

--- a/scripts/replay-digest-cooldown.mjs
+++ b/scripts/replay-digest-cooldown.mjs
@@ -274,7 +274,7 @@ export function aggregateReplayDecisions(records, options = {}) {
 
       if (i === 0) {
         // First occurrence — seed the synthesized delivered-log row.
-        lastDelivered = { sentAt: r.tsMs, sourceCount, severity };
+        lastDelivered = { sentAt: r.tsMs, sourceCount, severity, headline: recordHeadline(r) };
         continue;
       }
 
@@ -305,6 +305,11 @@ export function aggregateReplayDecisions(records, options = {}) {
         lastDeliveredAt: lastDelivered.sentAt,
         lastDeliveredSourceCount: lastDelivered.sourceCount,
         lastDeliveredTier: lastDelivered.severity,
+        // Greptile PR #3617 P2 — drives EVOLUTION_NEW_FACT bypass.
+        // Synthetic state tracks last delivered headline alongside
+        // sentAt/sourceCount/severity so replay matches the live
+        // evaluator's behavior under the new-fact bypass path.
+        lastDeliveredHeadline: lastDelivered.headline ?? null,
         options: { mode: 'shadow', nowMs: r.tsMs },
       });
 
@@ -314,7 +319,7 @@ export function aggregateReplayDecisions(records, options = {}) {
         allowDecisions += 1;
         timelineAllow += 1;
         // Allowed → simulated U4 write updates the synthesized state.
-        lastDelivered = { sentAt: r.tsMs, sourceCount, severity };
+        lastDelivered = { sentAt: r.tsMs, sourceCount, severity, headline: recordHeadline(r) };
       } else {
         suppressDecisions += 1;
         timelineSuppress += 1;

--- a/scripts/replay-digest-cooldown.mjs
+++ b/scripts/replay-digest-cooldown.mjs
@@ -83,15 +83,30 @@ const SCAN_PAGE_SIZE = 200;
  */
 
 /**
- * Build a stable cluster identity from a replay-log record. Uses
- * `mergedHashes[0]` when present (rep's own hash by U3's contract),
- * else falls back to the record's `storyHash` (singletons cluster
- * to themselves).
+ * Build a stable cluster identity from a replay-log record. Source
+ * preference (top wins; matches the writer's emit order):
+ *
+ *   1. `repHash` (v2+) — every record carries the rep's stable hash;
+ *      non-reps inherit it via repHashByStoryHash. This is the
+ *      canonical post-fix path: collapses cluster timelines uniformly
+ *      regardless of which member was sampled in the dedup input.
+ *   2. `mergedHashes[0]` (v2+ on reps) — equivalent to repHash for
+ *      reps but absent on non-reps.
+ *   3. `storyHash` (v1 fallback) — for records still in the 30-day TTL
+ *      window that pre-date the v2 writer bump. These will silently
+ *      split clusters by story (the original Codex PR #3617 P1 issue),
+ *      but rejecting them entirely would cost the harness 1+ days of
+ *      data right after the v2 cutover. Accept and degrade gracefully.
  *
  * @param {ReplayRecord} record
  * @returns {string}
  */
 export function clusterIdFromRecord(record) {
+  // Codex PR #3617 P1 — v2 records carry repHash on every record
+  // (rep AND non-rep), so this is the canonical cluster identity.
+  if (typeof record?.repHash === 'string' && record.repHash.length > 0) {
+    return record.repHash;
+  }
   if (Array.isArray(record?.mergedHashes) && record.mergedHashes.length > 0
     && typeof record.mergedHashes[0] === 'string' && record.mergedHashes[0].length > 0) {
     return record.mergedHashes[0];
@@ -99,6 +114,28 @@ export function clusterIdFromRecord(record) {
   if (typeof record?.storyHash === 'string' && record.storyHash.length > 0) {
     return record.storyHash;
   }
+  return '';
+}
+
+/**
+ * Read the headline from a replay-log record. v2 emits `headline`
+ * (matching BriefStory + the U5 classifier's input shape); v1 emits
+ * `title`. Accept either.
+ */
+function recordHeadline(record) {
+  if (typeof record?.headline === 'string' && record.headline.length > 0) return record.headline;
+  if (typeof record?.title === 'string' && record.title.length > 0) return record.title;
+  return '';
+}
+
+/**
+ * Read the source URL from a replay-log record. v2 emits `sourceUrl`
+ * (matching BriefStory + the U5 classifier's input shape); v1 emits
+ * `link`. Accept either.
+ */
+function recordSourceUrl(record) {
+  if (typeof record?.sourceUrl === 'string' && record.sourceUrl.length > 0) return record.sourceUrl;
+  if (typeof record?.link === 'string' && record.link.length > 0) return record.link;
   return '';
 }
 
@@ -203,10 +240,13 @@ export function aggregateReplayDecisions(records, options = {}) {
       }
 
       // Derive sourceDomain from sourceUrl host for the stub classifier.
+      // Codex PR #3617 P1 — read via recordSourceUrl/recordHeadline so
+      // both the v2 writer shape and v1 legacy records work correctly.
+      const sourceUrlForRecord = recordSourceUrl(r);
       let sourceDomain = '';
-      if (typeof r.sourceUrl === 'string' && r.sourceUrl.length > 0) {
+      if (sourceUrlForRecord) {
         try {
-          sourceDomain = new URL(r.sourceUrl).host.toLowerCase();
+          sourceDomain = new URL(sourceUrlForRecord).host.toLowerCase();
         } catch {
           sourceDomain = '';
         }
@@ -219,7 +259,7 @@ export function aggregateReplayDecisions(records, options = {}) {
         channel,
         ruleId: timeline.ruleId,
         // Let classifyStub run — replay records carry headline + sourceUrl
-        classifierInputs: { sourceDomain, headline: r.headline ?? '' },
+        classifierInputs: { sourceDomain, headline: recordHeadline(r) },
         severity,
         currentSourceCount: sourceCount,
         currentTier: severity,

--- a/scripts/replay-digest-cooldown.mjs
+++ b/scripts/replay-digest-cooldown.mjs
@@ -192,9 +192,41 @@ export function aggregateReplayDecisions(records, options = {}) {
     );
   }
 
+  // Codex PR #3617 round-3 P1 — collapse multi-record-per-tick to ONE
+  // observation per (ruleId, repHash, tsMs). The replay-log writer
+  // emits one record per INPUT story (rep + each non-rep cluster
+  // member), so a 2-story cluster in one tick yields 2 records at the
+  // same tsMs. Pre-fix the timeline aggregator treated each record as
+  // a separate occurrence — the second record (same tsMs) read the
+  // first as `lastDeliveredAt` and produced a false "0-hour repeat"
+  // suppression. Result: every multi-member cluster doubled its
+  // suppression count in the report.
+  //
+  // Collapse: keep one record per (ruleId, repHash, tsMs). Prefer the
+  // rep record (isRep=true) so the headline/sourceUrl come from the
+  // canonical rep's view of the cluster. Falls back to the first-seen
+  // record when no rep is present (e.g. v1 records without isRep).
+  /** @type {Map<string, ReplayRecord>} */
+  const collapsed = new Map();
+  for (const record of sorted) {
+    const clusterId = clusterIdFromRecord(record);
+    if (!clusterId) continue;
+    const tickKey = `${record.ruleId}::${clusterId}::${record.tsMs}`;
+    const existing = collapsed.get(tickKey);
+    if (!existing) {
+      collapsed.set(tickKey, record);
+      continue;
+    }
+    // Replace if the new record is the rep and the existing isn't
+    // (the rep carries the canonical headline + sourceUrl + sources).
+    if (record?.isRep === true && existing?.isRep !== true) {
+      collapsed.set(tickKey, record);
+    }
+  }
+
   /** @type {Map<string, {records: ReplayRecord[], ruleId: string, clusterId: string}>} */
   const timelines = new Map();
-  for (const record of sorted) {
+  for (const record of collapsed.values()) {
     const clusterId = clusterIdFromRecord(record);
     if (!clusterId) continue;
     const key = `${record.ruleId}::${clusterId}`;
@@ -204,6 +236,13 @@ export function aggregateReplayDecisions(records, options = {}) {
       timelines.set(key, timeline);
     }
     timeline.records.push(record);
+  }
+  // Re-sort each timeline's records by tsMs after collapse — the
+  // collapse Map iteration order matches insertion order (which was
+  // already sorted), but defensive sort guards against future
+  // refactors that change Map iteration semantics.
+  for (const timeline of timelines.values()) {
+    timeline.records.sort((a, b) => a.tsMs - b.tsMs);
   }
 
   let allowDecisions = 0;

--- a/scripts/replay-digest-cooldown.mjs
+++ b/scripts/replay-digest-cooldown.mjs
@@ -1,0 +1,511 @@
+#!/usr/bin/env node
+/**
+ * Sprint 1 / U6 — 14-day replay harness against `digest:replay-log:v1:*`.
+ *
+ * Validates the U5 cooldown decision table BEFORE Sprint 2 enables
+ * enforce mode. For each (ruleId, storyHash) timeline observed across
+ * the last 14 days of replay-log records, simulates what U4's
+ * delivered-log would have looked like, then runs U5's evaluateCooldown
+ * against each subsequent occurrence. Aggregates would-have-suppressed
+ * counts by classification × severity × channel.
+ *
+ * Phase 0 prerequisite: `DIGEST_DEDUP_REPLAY_LOG=1` must have been on
+ * for ≥14 days before this script can produce a meaningful report. The
+ * activation date for this deployment is 2026-05-06; earliest-runnable
+ * is 2026-05-20. The harness refuses to run if coverage spans <14 days.
+ *
+ * Live run: `node scripts/replay-digest-cooldown.mjs [--days 14] [--rule <ruleId>]`
+ *   Reads from Upstash via SCAN + per-key range fetch. Outputs a JSON
+ *   report to stdout + a markdown summary block (printable for paste
+ *   into docs/internal/digest-brief-improvements.md Sprint 1 outcomes).
+ *
+ * Test path: `aggregateReplayDecisions(records, options)` is the pure
+ * aggregation function. Tests load fixture records and assert
+ * histogram counts without any Upstash IO.
+ *
+ * Replay-log key shape (from scripts/lib/brief-dedup-replay-log.mjs):
+ *   `digest:replay-log:v1:{ruleId}:{YYYY-MM-DD}`
+ * Each value is a Redis list of JSON records. Each record carries:
+ *   { storyHash, isRep, mergedHashes?, currentScore, mentionCount, phase,
+ *     sources, severity, headline, sourceUrl, briefTickId, ruleId, tsMs, ... }
+ *
+ * Per-tick numeric `clusterId` from the replay-log is NOT stable across
+ * ticks (per scripts/lib/brief-dedup-replay-log.mjs:96-109). We use the
+ * REP's storyHash (= rep.hash, where mergedHashes[0] = rep.hash by
+ * U3's contract) as the canonical cluster identity. For non-rep
+ * stories we follow `mergedHashes[0]` to find the rep.
+ *
+ * The harness assumes cooldown channel = 'email' for the simulated
+ * U4 lookup. Real production has per-channel cooldown rows; the
+ * replay-log only records the dedup pass (channel-agnostic), so the
+ * simulation conservatively models "would we have suppressed on
+ * email?". Multi-channel granularity is a Sprint 3 follow-on.
+ */
+
+import process from 'node:process';
+import { evaluateCooldown } from './lib/digest-cooldown-decision.mjs';
+
+const DEFAULT_REPLAY_DAYS = 14;
+const REPLAY_KEY_PREFIX = 'digest:replay-log:v1';
+const SCAN_PAGE_SIZE = 200;
+
+// ── Pure aggregation (test-exercised) ───────────────────────────────
+
+/**
+ * @typedef {object} ReplayRecord
+ * @property {string} storyHash
+ * @property {boolean} [isRep]
+ * @property {string[]} [mergedHashes]
+ * @property {number} [currentScore]
+ * @property {number} [mentionCount]
+ * @property {string[]} [sources]
+ * @property {string} [severity]   — 'critical' | 'high' | 'medium' | 'low'
+ * @property {string} [headline]
+ * @property {string} [sourceUrl]
+ * @property {string} [phase]
+ * @property {string} ruleId
+ * @property {number} tsMs         — record timestamp; U6 timeline uses this
+ *
+ * @typedef {object} ReplayAggregate
+ * @property {number} totalRecords
+ * @property {number} totalTimelines      — distinct (ruleId, clusterId) pairs
+ * @property {number} totalDecisions      — decisions evaluated (excludes first occurrence per timeline)
+ * @property {number} allowDecisions
+ * @property {number} suppressDecisions
+ * @property {number} dropRatePct         — suppressDecisions / totalDecisions × 100
+ * @property {Record<string, number>} reasonHistogram      — keyed by REASON value
+ * @property {Record<string, number>} typeHistogram        — keyed by classifiedType
+ * @property {Record<string, number>} severityHistogram    — keyed by severity
+ * @property {Array<{clusterId: string, ruleId: string, suppressCount: number,
+ *                   allowCount: number, reasons: Record<string, number>}>} topSuppressed
+ * @property {{startDate: string, endDate: string, daysCovered: number,
+ *             distinctRuleIds: number}} coverage
+ */
+
+/**
+ * Build a stable cluster identity from a replay-log record. Uses
+ * `mergedHashes[0]` when present (rep's own hash by U3's contract),
+ * else falls back to the record's `storyHash` (singletons cluster
+ * to themselves).
+ *
+ * @param {ReplayRecord} record
+ * @returns {string}
+ */
+export function clusterIdFromRecord(record) {
+  if (Array.isArray(record?.mergedHashes) && record.mergedHashes.length > 0
+    && typeof record.mergedHashes[0] === 'string' && record.mergedHashes[0].length > 0) {
+    return record.mergedHashes[0];
+  }
+  if (typeof record?.storyHash === 'string' && record.storyHash.length > 0) {
+    return record.storyHash;
+  }
+  return '';
+}
+
+/**
+ * Pure aggregation: simulate cooldown decisions across all (ruleId,
+ * clusterId) timelines in the input records. The first occurrence of
+ * a timeline seeds the synthesized U4 delivered-log; each subsequent
+ * occurrence within the timeline runs evaluateCooldown against that
+ * synthesized state and records the decision.
+ *
+ * @param {ReplayRecord[]} records
+ * @param {object} [options]
+ * @param {string} [options.channel='email']  — assumed channel for the simulation
+ * @param {number} [options.minDaysCovered=14] — abort if coverage is below this
+ * @param {boolean} [options.allowShortCoverage=false] — test-only escape hatch
+ * @returns {ReplayAggregate}
+ */
+export function aggregateReplayDecisions(records, options = {}) {
+  const channel = options.channel ?? 'email';
+  const minDaysCovered = Number.isFinite(options.minDaysCovered)
+    ? options.minDaysCovered
+    : DEFAULT_REPLAY_DAYS;
+  const allowShortCoverage = options.allowShortCoverage === true;
+
+  if (!Array.isArray(records) || records.length === 0) {
+    throw new Error(
+      'aggregateReplayDecisions: empty input — DIGEST_DEDUP_REPLAY_LOG may be off, OR no ticks ' +
+        `recorded in the requested window. The flag must have been on for ≥${minDaysCovered} days.`,
+    );
+  }
+
+  // Sort by tsMs so timeline simulation reads ticks in chronological order.
+  // Defensive copy — never mutate caller input.
+  const sorted = [...records]
+    .filter((r) => Number.isFinite(r?.tsMs) && typeof r?.ruleId === 'string')
+    .sort((a, b) => a.tsMs - b.tsMs);
+
+  if (sorted.length === 0) {
+    throw new Error(
+      'aggregateReplayDecisions: no records have valid {tsMs, ruleId} — ' +
+        'check replay-log writer (scripts/lib/brief-dedup-replay-log.mjs) is producing the expected shape.',
+    );
+  }
+
+  // Coverage gate — refuse to run on insufficient data.
+  const startMs = sorted[0].tsMs;
+  const endMs = sorted[sorted.length - 1].tsMs;
+  const daysCovered = Math.max(0, (endMs - startMs) / (24 * 60 * 60 * 1000));
+  if (daysCovered < minDaysCovered && !allowShortCoverage) {
+    throw new Error(
+      `aggregateReplayDecisions: coverage ${daysCovered.toFixed(2)} days < required ${minDaysCovered}. ` +
+        `First record: ${new Date(startMs).toISOString()}. Last record: ${new Date(endMs).toISOString()}. ` +
+        'Wait for the 14-day window OR pass {allowShortCoverage: true} for a partial-window probe.',
+    );
+  }
+
+  /** @type {Map<string, {records: ReplayRecord[], ruleId: string, clusterId: string}>} */
+  const timelines = new Map();
+  for (const record of sorted) {
+    const clusterId = clusterIdFromRecord(record);
+    if (!clusterId) continue;
+    const key = `${record.ruleId}::${clusterId}`;
+    let timeline = timelines.get(key);
+    if (!timeline) {
+      timeline = { records: [], ruleId: record.ruleId, clusterId };
+      timelines.set(key, timeline);
+    }
+    timeline.records.push(record);
+  }
+
+  let allowDecisions = 0;
+  let suppressDecisions = 0;
+  /** @type {Record<string, number>} */
+  const reasonHistogram = {};
+  /** @type {Record<string, number>} */
+  const typeHistogram = {};
+  /** @type {Record<string, number>} */
+  const severityHistogram = {};
+  /** @type {Array<{clusterId: string, ruleId: string, suppressCount: number, allowCount: number, reasons: Record<string, number>}>} */
+  const perTimeline = [];
+
+  for (const timeline of timelines.values()) {
+    const tlRecords = timeline.records;
+    if (tlRecords.length < 2) continue; // single-occurrence timelines have no cooldown decision to simulate
+    let lastDelivered = null; // synthesized U4 row state
+    let timelineSuppress = 0;
+    let timelineAllow = 0;
+    /** @type {Record<string, number>} */
+    const timelineReasons = {};
+
+    for (let i = 0; i < tlRecords.length; i += 1) {
+      const r = tlRecords[i];
+      const sources = Array.isArray(r.sources) ? r.sources : [];
+      const sourceCount = sources.length;
+      const severity = typeof r.severity === 'string' ? r.severity.toLowerCase() : 'unknown';
+      severityHistogram[severity] = (severityHistogram[severity] ?? 0) + 1;
+
+      if (i === 0) {
+        // First occurrence — seed the synthesized delivered-log row.
+        lastDelivered = { sentAt: r.tsMs, sourceCount, severity };
+        continue;
+      }
+
+      // Derive sourceDomain from sourceUrl host for the stub classifier.
+      let sourceDomain = '';
+      if (typeof r.sourceUrl === 'string' && r.sourceUrl.length > 0) {
+        try {
+          sourceDomain = new URL(r.sourceUrl).host.toLowerCase();
+        } catch {
+          sourceDomain = '';
+        }
+      }
+
+      const decision = evaluateCooldown({
+        userId: 'replay-harness', // synthetic — only used in logs the harness drops
+        slot: 'replay',
+        clusterId: timeline.clusterId,
+        channel,
+        ruleId: timeline.ruleId,
+        // Let classifyStub run — replay records carry headline + sourceUrl
+        classifierInputs: { sourceDomain, headline: r.headline ?? '' },
+        severity,
+        currentSourceCount: sourceCount,
+        currentTier: severity,
+        lastDeliveredAt: lastDelivered.sentAt,
+        lastDeliveredSourceCount: lastDelivered.sourceCount,
+        lastDeliveredTier: lastDelivered.severity,
+        options: { mode: 'shadow', nowMs: r.tsMs },
+      });
+
+      if (decision === null) continue;
+
+      if (decision.decision === 'allow') {
+        allowDecisions += 1;
+        timelineAllow += 1;
+        // Allowed → simulated U4 write updates the synthesized state.
+        lastDelivered = { sentAt: r.tsMs, sourceCount, severity };
+      } else {
+        suppressDecisions += 1;
+        timelineSuppress += 1;
+      }
+
+      reasonHistogram[decision.reason] = (reasonHistogram[decision.reason] ?? 0) + 1;
+      typeHistogram[decision.classifiedType] = (typeHistogram[decision.classifiedType] ?? 0) + 1;
+      timelineReasons[decision.reason] = (timelineReasons[decision.reason] ?? 0) + 1;
+    }
+
+    perTimeline.push({
+      clusterId: timeline.clusterId,
+      ruleId: timeline.ruleId,
+      suppressCount: timelineSuppress,
+      allowCount: timelineAllow,
+      reasons: timelineReasons,
+    });
+  }
+
+  const totalDecisions = allowDecisions + suppressDecisions;
+  const dropRatePct = totalDecisions === 0 ? 0 : (suppressDecisions / totalDecisions) * 100;
+
+  // Top-10 most-suppressed timelines for manual review.
+  const topSuppressed = perTimeline
+    .filter((t) => t.suppressCount > 0)
+    .sort((a, b) => b.suppressCount - a.suppressCount)
+    .slice(0, 10);
+
+  /** @type {Set<string>} */
+  const distinctRuleIds = new Set();
+  for (const r of sorted) distinctRuleIds.add(r.ruleId);
+
+  return {
+    totalRecords: sorted.length,
+    totalTimelines: timelines.size,
+    totalDecisions,
+    allowDecisions,
+    suppressDecisions,
+    dropRatePct: Number(dropRatePct.toFixed(2)),
+    reasonHistogram,
+    typeHistogram,
+    severityHistogram,
+    topSuppressed,
+    coverage: {
+      startDate: new Date(startMs).toISOString().slice(0, 10),
+      endDate: new Date(endMs).toISOString().slice(0, 10),
+      daysCovered: Number(daysCovered.toFixed(2)),
+      distinctRuleIds: distinctRuleIds.size,
+    },
+  };
+}
+
+/**
+ * Render a markdown summary block suitable for pasting into the strategic
+ * doc's Sprint 1 outcomes section.
+ *
+ * @param {ReplayAggregate} agg
+ * @returns {string}
+ */
+export function renderMarkdownSummary(agg) {
+  const lines = [
+    `## Sprint 1 / U6 replay results — ${agg.coverage.startDate} → ${agg.coverage.endDate}`,
+    '',
+    `- Coverage: ${agg.coverage.daysCovered} days, ${agg.coverage.distinctRuleIds} distinct ruleId(s)`,
+    `- Records: ${agg.totalRecords}; timelines (rule × cluster): ${agg.totalTimelines}; decisions: ${agg.totalDecisions}`,
+    `- **Drop-rate: ${agg.dropRatePct}%** (${agg.suppressDecisions} suppress / ${agg.allowDecisions} allow)`,
+    '',
+    '### Reason histogram',
+    ...Object.entries(agg.reasonHistogram)
+      .sort(([, a], [, b]) => b - a)
+      .map(([reason, count]) => `- \`${reason}\`: ${count}`),
+    '',
+    '### Type histogram',
+    ...Object.entries(agg.typeHistogram)
+      .sort(([, a], [, b]) => b - a)
+      .map(([type, count]) => `- \`${type}\`: ${count}`),
+    '',
+    '### Top-10 most-suppressed timelines',
+    ...(agg.topSuppressed.length === 0
+      ? ['_No timelines triggered suppression in this window._']
+      : agg.topSuppressed.map((t, i) => {
+          const reasons = Object.entries(t.reasons).map(([r, c]) => `${r}=${c}`).join(', ');
+          return `${i + 1}. \`${t.clusterId.slice(0, 16)}…\` (rule \`${t.ruleId}\`): ${t.suppressCount} suppress, ${t.allowCount} allow — ${reasons}`;
+        })),
+  ];
+  return lines.join('\n');
+}
+
+// ── CLI / live-Redis IO (not test-exercised) ─────────────────────────
+
+/**
+ * Parse CLI args. Returns { days, rule, allowShortCoverage, help }.
+ */
+export function parseArgs(argv) {
+  const args = { days: DEFAULT_REPLAY_DAYS, rule: null, allowShortCoverage: false, help: false };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') args.help = true;
+    else if (arg === '--days') {
+      const next = argv[i + 1];
+      const parsed = Number.parseInt(next, 10);
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        throw new Error(`--days must be a positive integer, got: ${next}`);
+      }
+      args.days = parsed;
+      i += 1;
+    } else if (arg === '--rule') {
+      const next = argv[i + 1];
+      if (!next || next.startsWith('--')) {
+        throw new Error('--rule requires a value');
+      }
+      args.rule = next;
+      i += 1;
+    } else if (arg === '--allow-short-coverage') {
+      args.allowShortCoverage = true;
+    } else {
+      throw new Error(`Unknown argument: ${arg}. Run with --help for usage.`);
+    }
+  }
+  return args;
+}
+
+const HELP_TEXT = `
+Usage: node scripts/replay-digest-cooldown.mjs [options]
+
+Replay the last N days of digest:replay-log:v1:* records through the
+Sprint 1 / U5 cooldown decision module and report a drop-rate
+distribution. Used to validate the cooldown table BEFORE Sprint 2
+enables enforce mode.
+
+Options:
+  --days <N>              Days of history to replay (default: 14, the
+                          minimum required to validate Sprint 2 enforcement).
+  --rule <ruleId>         Limit replay to one ruleId (e.g. "full:en:high").
+                          Default: all rules in the window.
+  --allow-short-coverage  Run with <14d coverage. ONLY for partial-window
+                          probes during development. Sprint 2 cannot use
+                          short-coverage results to gate enforcement.
+  --help, -h              Show this message.
+
+Required env:
+  UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN
+
+Output:
+  - Markdown summary block printed to stdout — paste into
+    docs/internal/digest-brief-improvements.md Sprint 1 outcomes section.
+  - Full JSON aggregate written to /tmp/replay-digest-cooldown-<date>.json
+    for downstream tooling.
+`.trim();
+
+/**
+ * Live-Redis fetch path. SCANs all replay-log keys, ranges each list,
+ * deserialises records, returns the flat record array. Bounded by
+ * --days; defaults to 14.
+ *
+ * @param {object} args  — output of parseArgs
+ * @returns {Promise<ReplayRecord[]>}
+ */
+async function fetchRecords(args) {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) {
+    throw new Error('UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN must be set');
+  }
+
+  const cutoffMs = Date.now() - args.days * 24 * 60 * 60 * 1000;
+  const matchPattern = args.rule
+    ? `${REPLAY_KEY_PREFIX}:${args.rule}:*`
+    : `${REPLAY_KEY_PREFIX}:*`;
+
+  /** @type {string[]} */
+  const allKeys = [];
+  let cursor = '0';
+  do {
+    const scanRes = await fetch(`${url}/scan/${cursor}/match/${encodeURIComponent(matchPattern)}/count/${SCAN_PAGE_SIZE}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!scanRes.ok) {
+      throw new Error(`SCAN failed: ${scanRes.status} ${scanRes.statusText}`);
+    }
+    const body = await scanRes.json();
+    const result = Array.isArray(body?.result) ? body.result : null;
+    if (!result || result.length < 2) break;
+    cursor = String(result[0]);
+    const keys = Array.isArray(result[1]) ? result[1] : [];
+    for (const k of keys) {
+      if (typeof k === 'string') allKeys.push(k);
+    }
+  } while (cursor !== '0');
+
+  // Filter keys by date suffix to honour --days. Key shape:
+  //   digest:replay-log:v1:{ruleId}:{YYYY-MM-DD}
+  const cutoffDate = new Date(cutoffMs).toISOString().slice(0, 10);
+  const eligibleKeys = allKeys.filter((k) => {
+    const dateSuffix = k.slice(-10);
+    return /^\d{4}-\d{2}-\d{2}$/.test(dateSuffix) && dateSuffix >= cutoffDate;
+  });
+
+  if (eligibleKeys.length === 0) {
+    return [];
+  }
+
+  /** @type {ReplayRecord[]} */
+  const records = [];
+  for (const key of eligibleKeys) {
+    const rangeRes = await fetch(`${url}/lrange/${encodeURIComponent(key)}/0/-1`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!rangeRes.ok) {
+      console.warn(`[replay] LRANGE failed for ${key}: ${rangeRes.status}; continuing`);
+      continue;
+    }
+    const body = await rangeRes.json();
+    const list = Array.isArray(body?.result) ? body.result : [];
+    for (const item of list) {
+      try {
+        const parsed = JSON.parse(item);
+        records.push(parsed);
+      } catch (err) {
+        console.warn(`[replay] failed to parse record in ${key}: ${err?.message ?? err}`);
+      }
+    }
+  }
+  return records;
+}
+
+async function mainCli() {
+  let args;
+  try {
+    args = parseArgs(process.argv);
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
+    process.exit(1);
+  }
+  if (args.help) {
+    console.log(HELP_TEXT);
+    process.exit(0);
+  }
+
+  console.log(`[replay] fetching last ${args.days} days of replay-log records${args.rule ? ` for rule=${args.rule}` : ''}…`);
+  const records = await fetchRecords(args);
+  if (records.length === 0) {
+    console.error('[replay] no records returned. Verify DIGEST_DEDUP_REPLAY_LOG=1 has been on for the requested window.');
+    process.exit(2);
+  }
+
+  const aggregate = aggregateReplayDecisions(records, {
+    minDaysCovered: args.days,
+    allowShortCoverage: args.allowShortCoverage,
+  });
+
+  const md = renderMarkdownSummary(aggregate);
+  console.log('\n' + md + '\n');
+
+  const fs = await import('node:fs/promises');
+  const outPath = `/tmp/replay-digest-cooldown-${new Date().toISOString().slice(0, 10)}.json`;
+  await fs.writeFile(outPath, JSON.stringify(aggregate, null, 2), 'utf8');
+  console.log(`[replay] full JSON aggregate written to ${outPath}`);
+  process.exit(0);
+}
+
+// Only run the CLI when invoked directly. Tests import the pure helpers.
+const isMainModule = typeof process !== 'undefined'
+  && Array.isArray(process.argv)
+  && process.argv[1]
+  && import.meta.url === `file://${process.argv[1]}`;
+
+if (isMainModule) {
+  mainCli().catch((err) => {
+    console.error('[replay] fatal:', err?.stack ?? err);
+    process.exit(3);
+  });
+}

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -70,6 +70,9 @@ import {
   aggregateResults as aggregateDeliveredResults,
   writeDeliveredEntry,
 } from './lib/digest-delivered-log.mjs';
+import { readCooldownConfig } from './lib/digest-cooldown-config.mjs';
+import { evaluateCooldown } from './lib/digest-cooldown-decision.mjs';
+import { emitCooldownShadowLog } from './lib/digest-cooldown-shadow-log.mjs';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -1757,6 +1760,27 @@ async function main() {
   // one per rule iteration. See the briefForUser-missing branch below.
   const composeMissUsers = new Set();
 
+  // Sprint 1 / U5 — cooldown mode resolved ONCE per cron tick. Operator
+  // surface is `DIGEST_COOLDOWN_MODE` ∈ {shadow, off}; default 'shadow'.
+  // Anything else (typo, garbage, even 'enforce' which Sprint 2 will
+  // introduce) fails closed to 'shadow' with `invalidRaw` populated for
+  // a startup warn — see `feedback_kill_switch_default_on_typo`.
+  //
+  // Resolved at the top of the run (not per rule) because the env value
+  // can't change mid-tick, and we want the typo-warn to fire ONCE per
+  // cron run, not once per user. The decision evaluator below is invoked
+  // with `mode` as a per-call option so a future per-user shadow-subset
+  // gate can short-circuit by passing `mode: 'off'` for excluded users
+  // (decision artifact becomes null → shadow logger silently skips them
+  // per `feedback_gate_on_ground_truth_not_configured_state`).
+  const cooldownConfig = readCooldownConfig(process.env);
+  if (cooldownConfig.invalidRaw !== null) {
+    console.warn(
+      `[digest] cooldown unrecognised DIGEST_COOLDOWN_MODE=${JSON.stringify(cooldownConfig.invalidRaw)} — ` +
+        `falling back to 'shadow' (safe default; Sprint 1 has no enforce mode). Valid: shadow | off.`,
+    );
+  }
+
   for (const rule of rules) {
     if (!rule.userId || !rule.variant) continue;
 
@@ -1948,6 +1972,121 @@ async function main() {
     const shortDate = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric' }).format(new Date(nowMs));
     const subject = subjectForBrief({ briefLead, synthesisLevel, shortDate });
 
+    // Sprint 1 / U5 — cooldown shadow-mode evaluation (per-cluster,
+    // per-channel, BEFORE the channel send). The decision is computed
+    // and accumulated; the send loop below is unchanged. Sprint 2 will
+    // wire the decision into the send-loop guard. Until then, the
+    // accumulator's only consumer is the shadow log line emitted after
+    // the send loop completes for this user-rule.
+    //
+    // Why before the send (not after): the U4 delivered-log writes
+    // happen AFTER each channel's send returns true, and we want the
+    // cooldown evaluator to see the previous tick's row, not the row
+    // we're about to write. Moving the GET to "after send" would race
+    // with the writer and turn every re-send into a `conflicts: 1`
+    // observation — masking the real cooldown signal we're trying to
+    // measure.
+    //
+    // The evaluator is short-circuited by `mode === 'off'` (decision
+    // === null). When that happens we skip the per-cluster GET pipeline
+    // entirely — no Upstash traffic, no log line. This makes the
+    // operator-side kill switch instant: flip Railway env to 'off',
+    // next tick spends zero on cooldown.
+    const cooldownDecisions = [];
+    const ruleIdComposite = `${rule.variant ?? 'full'}:${rule.lang ?? 'en'}:${rule.sensitivity ?? 'high'}`;
+    // Slot string mirrors the brief composer: `issueSlotInTz(nowMs, tz)`.
+    // We use the same tz the composer used (rule.digestTimezone, default
+    // 'UTC') so the slot naming aligns 1:1 with the brief envelope's
+    // magazine URL slot. Operators grepping the shadow log by slot get
+    // the same slot string they'd see in `brief:${userId}:${issueSlot}`.
+    const cooldownSlot = issueSlotInTz(nowMs, rule.digestTimezone ?? 'UTC');
+    if (
+      cooldownConfig.mode === 'shadow'
+      && Array.isArray(briefEnvelopeStories)
+      && briefEnvelopeStories.length > 0
+    ) {
+      // Outer loop: one decision per (channel, cluster) tuple. Same
+      // shape as the U4 writer's iteration so the shadow log's
+      // `total` aligns with the writer's eventual write count under
+      // healthy paths. Sequential awaits — same rationale as the U4
+      // writer (≤12 clusters × ≤5 channels per user = ≤60 GETs;
+      // bursty parallelism would compete with the rest of the cron's
+      // Upstash traffic for no measurable latency win).
+      for (const ch of deliverableChannels) {
+        for (const briefStory of briefEnvelopeStories) {
+          const clusterId = typeof briefStory?.clusterId === 'string' ? briefStory.clusterId : '';
+          if (!clusterId) {
+            // Same defensive branch as the U4 writer below — a v4
+            // envelope MUST carry clusterId. Skip the GET here so we
+            // don't construct a malformed key; the U4-side warn will
+            // fire on the same iteration when the writer runs.
+            continue;
+          }
+          const key = `digest:sent:v1:${rule.userId}:${ch.channelType}:${ruleIdComposite}:${clusterId}`;
+          let lastDeliveredAt = null;
+          let lastDeliveredSourceCount = null;
+          let lastDeliveredTier = null;
+          try {
+            const raw = await upstashRest('GET', key);
+            if (typeof raw === 'string' && raw.length > 0) {
+              const parsed = JSON.parse(raw);
+              if (parsed && typeof parsed === 'object') {
+                if (Number.isFinite(parsed.sentAt)) lastDeliveredAt = parsed.sentAt;
+                if (Number.isFinite(parsed.sourceCount)) lastDeliveredSourceCount = parsed.sourceCount;
+                if (typeof parsed.severity === 'string') lastDeliveredTier = parsed.severity;
+              }
+            }
+          } catch (err) {
+            // GET failed (transient Upstash, JSON parse error). Treat
+            // as "no prior delivery" — the safe default in shadow mode
+            // is `decision='allow'`, which never affects subsequent
+            // sends. A real enforcement path (Sprint 2) will need to
+            // decide whether to fail-open or fail-closed here; shadow
+            // mode is fail-open by definition.
+            console.warn(
+              `[digest] U5 cooldown: GET failed for key=${key}: ${err?.message ?? err} — treating as no prior delivery`,
+            );
+          }
+          const sourceDomain = (() => {
+            const url = typeof briefStory?.sourceUrl === 'string' ? briefStory.sourceUrl : '';
+            if (!url) return '';
+            try {
+              return new URL(url).hostname.toLowerCase();
+            } catch {
+              return '';
+            }
+          })();
+          const severity = typeof briefStory?.threatLevel === 'string' ? briefStory.threatLevel : 'unknown';
+          const currentSourceCount = typeof briefStory?.source === 'string' && briefStory.source.length > 0 ? 1 : 0;
+          const decision = evaluateCooldown({
+            userId: rule.userId,
+            slot: cooldownSlot,
+            clusterId,
+            channel: ch.channelType,
+            ruleId: ruleIdComposite,
+            type: null, // invoke stub classifier
+            severity,
+            currentSourceCount,
+            currentTier: severity,
+            lastDeliveredAt,
+            lastDeliveredSourceCount,
+            lastDeliveredTier,
+            classifierInputs: {
+              sourceDomain,
+              headline: typeof briefStory?.headline === 'string' ? briefStory.headline : '',
+            },
+            options: { mode: cooldownConfig.mode, nowMs },
+          });
+          // `decision === null` is unreachable here (we guarded on
+          // `mode === 'shadow'` at the loop entry) but defensive —
+          // protects the shadow logger from a future code path that
+          // calls evaluateCooldown with mode='off' inside the shadow
+          // branch.
+          if (decision !== null) cooldownDecisions.push(decision);
+        }
+      }
+    }
+
     let anyDelivered = false;
     // Sprint 1 / U4 — per-channel/per-cluster delivered-log accumulator.
     // We aggregate tri-state counts across every (channel, cluster)
@@ -2076,6 +2215,25 @@ async function main() {
           `total=${deliveredLogResults.length}`,
       );
     }
+
+    // Sprint 1 / U5 — shadow-mode cooldown summary line. ONE line per
+    // user-rule send (not per cluster, not per channel) so a busy cron
+    // doesn't flood Sentry. Skipped entirely when no decisions were
+    // accumulated (mode='off' OR no brief envelope OR all clusters
+    // missing clusterId). The logger promotes to console.warn when
+    // any decision had `classificationMissing: true` — that's real
+    // signal for Sprint 3's classifier work.
+    //
+    // The line is independent of `anyDelivered` — we want the would-
+    // have-suppressed counter even on no-channel-success ticks (those
+    // are the operator-visible cases where shadow telemetry matters
+    // most: "we'd have suppressed even MORE if the send had succeeded").
+    emitCooldownShadowLog({
+      userId: rule.userId,
+      ruleId: ruleIdComposite,
+      slot: cooldownSlot,
+      decisions: cooldownDecisions,
+    });
 
     if (anyDelivered) {
       await upstashRest(

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -66,6 +66,10 @@ import {
 import { stripSourceSuffix } from './lib/brief-dedup-jaccard.mjs';
 import { writeReplayLog } from './lib/brief-dedup-replay-log.mjs';
 import { readStoryTracksChunked } from './lib/story-track-batch-reader.mjs';
+import {
+  aggregateResults as aggregateDeliveredResults,
+  writeDeliveredEntry,
+} from './lib/digest-delivered-log.mjs';
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -805,6 +809,75 @@ function formatDigestHtml(stories, nowMs) {
     </div>
   </div>
 </div>`;
+}
+
+// ── Sprint 1 / U7 production-gap shim: BriefStory → formatter shape ──
+//
+// The U7 invariant `digest.cards ⊆ brief.cards` only holds in
+// production if `formatDigest`/`formatDigestHtml` consume the brief
+// envelope's filtered slice (capped at MAX_STORIES_PER_USER=12, post-
+// compose, post-filter), NOT the raw `stories` pool from `buildDigest`
+// (capped at DIGEST_MAX_ITEMS=30).
+//
+// The two formatters above were written when there was no envelope —
+// they expect raw-shape stories with `{title, severity, sources, link,
+// description, phase}`. The brief envelope's `BriefStory` carries a
+// different field set: `{headline, threatLevel, source, sourceUrl,
+// description, clusterId, ...}`. This shim maps the envelope shape to
+// the formatter shape without touching the formatters themselves,
+// keeping the U7 invariant holdable on the live send path with the
+// minimum surgical change.
+//
+// Compatibility decisions:
+//   - `headline` → `title`. Direct rename.
+//   - `threatLevel` → `severity`. The values overlap (`critical`,
+//     `high`, `medium`); a `BriefStory` `low` falls into the formatter's
+//     `high` bucket fallback (line ~651 / ~692). That's a benign
+//     mis-bucket — the brief composer's filter already drops `low` from
+//     the pool today, so the production occurrence is zero.
+//   - `source` (single string) → `sources` (array). Wrap into a
+//     1-element array; empty when missing. Multi-source fan-out for the
+//     formatter's "+N" suffix is lost here — acceptable trade-off
+//     because the BriefStory schema only carries the primary source by
+//     design (per shared/brief-envelope.d.ts:112).
+//   - `sourceUrl` → `link`. Direct rename. Empty string when absent
+//     (the formatter renders unlinked text in that case).
+//   - `description` → `description`. Direct passthrough.
+//   - `clusterId` → `hash`. THIS IS THE U7-LOAD-BEARING MAPPING. The
+//     formatter doesn't consume `hash` for rendering, but the U7
+//     invariant projection (`projectDigestEmitClusterId` in the
+//     companion test) reads it as the per-card identity. Setting
+//     `hash = clusterId` makes the runtime emit set provably equal to
+//     the brief envelope's clusterId set.
+//   - `phase` is not on `BriefStory`. Default to `'sustained'` — a
+//     valid phase value with a dedicated PHASE_COLOR entry, no
+//     filtering effect (the only phase that filters is `'fading'`,
+//     and that filter lives in `buildDigest`, not the formatters).
+//
+// Why an inline shim and not a shared helper: this transformation is
+// load-bearing only for the cron's send loop. Any other consumer that
+// wants the formatter shape would convert via this function would couple
+// itself to the BriefStory→raw mapping that is not load-bearing
+// anywhere else. Keep it local until a second consumer appears.
+function briefStoriesToFormatterShape(briefStories) {
+  if (!Array.isArray(briefStories)) return [];
+  return briefStories.map((s) => {
+    const sources = typeof s?.source === 'string' && s.source.length > 0 ? [s.source] : [];
+    return {
+      title: typeof s?.headline === 'string' ? s.headline : '',
+      severity: typeof s?.threatLevel === 'string' ? s.threatLevel : 'high',
+      sources,
+      link: typeof s?.sourceUrl === 'string' ? s.sourceUrl : '',
+      description: typeof s?.description === 'string' ? s.description : '',
+      // 'sustained' has a defined PHASE_COLOR entry in the formatter
+      // and is NOT 'fading' (the only phase value that drops in
+      // buildDigest). The formatter only uses phase for cosmetic
+      // colour/label, never for filtering.
+      phase: 'sustained',
+      // Load-bearing for the U7 invariant — see header above.
+      hash: typeof s?.clusterId === 'string' ? s.clusterId : '',
+    };
+  });
 }
 
 // ── (Removed) standalone generateAISummary ───────────────────────────────────
@@ -1822,9 +1895,39 @@ async function main() {
       synthesisLevel = ruleResult.level;
     }
 
-    const storyListPlain = formatDigest(stories, nowMs);
+    // Sprint 1 / U7 production-gap fix.
+    //
+    // Pre-fix the formatters consumed the raw `stories` pool (capped
+    // at DIGEST_MAX_ITEMS=30 by buildDigest). Post-fix they consume
+    // the brief envelope's `data.stories` (capped at MAX_STORIES_PER_USER
+    // =12 by filterTopStories). This is what makes the U7 invariant
+    // `digest.cards ⊆ brief.cards` HOLD ON THE LIVE SEND PATH — without
+    // this swap the email body could surface clusterIds the brief
+    // envelope omitted (the 18-30 stories the cap dropped), which
+    // would orphan their delivered-log keys from the magazine side.
+    //
+    // briefForUser is guaranteed non-null in this branch (the
+    // canonical-rule filter at the top of the loop returned only when
+    // briefForUser was present). The compose-miss fallback path
+    // (briefForUser === undefined) does NOT reach here — that branch
+    // either skips the user or falls through with magazineUrl=null;
+    // the formatters in that fallback continue to consume the raw
+    // stories pool, accepting U7-invariant degradation as the cost of
+    // delivering SOMETHING for that one tick.
+    //
+    // Compatibility shim: briefStoriesToFormatterShape maps the
+    // BriefStory schema to the formatter's expected raw-shape fields.
+    // See the function header for field-by-field rationale + the
+    // load-bearing `clusterId → hash` mapping that makes the U7
+    // invariant projection work at runtime.
+    const briefEnvelopeStories = brief?.envelope?.data?.stories;
+    const formatterStories = Array.isArray(briefEnvelopeStories) && briefEnvelopeStories.length > 0
+      ? briefStoriesToFormatterShape(briefEnvelopeStories)
+      : stories; // fallback: brief envelope absent (compose-miss branch above)
+
+    const storyListPlain = formatDigest(formatterStories, nowMs);
     if (!storyListPlain) continue;
-    const htmlRaw = formatDigestHtml(stories, nowMs);
+    const htmlRaw = formatDigestHtml(formatterStories, nowMs);
 
     const magazineUrl = brief?.magazineUrl ?? null;
     const { text, telegramText, slackText, discordText } = buildChannelBodies(
@@ -1846,6 +1949,17 @@ async function main() {
     const subject = subjectForBrief({ briefLead, synthesisLevel, shortDate });
 
     let anyDelivered = false;
+    // Sprint 1 / U4 — per-channel/per-cluster delivered-log accumulator.
+    // We aggregate tri-state counts across every (channel, cluster)
+    // write for THIS user-rule send so the post-loop log line can
+    // report a single summary instead of one line per cluster (with
+    // ~12 clusters × ~5 channels that's 60 lines per user otherwise).
+    // This sits ALONGSIDE the existing `anyDelivered` write below — the
+    // delivered-log keys feed U5's cooldown evaluator (per-cluster
+    // grain), the `digest:last-sent:v1:{user}:{variant}` write feeds
+    // the cron's isDue gate (per-rule grain). Two separate concerns;
+    // both writes happen on success.
+    const deliveredLogResults = [];
 
     for (const ch of deliverableChannels) {
       let ok = false;
@@ -1855,7 +1969,7 @@ async function main() {
         // the long-form story list goes in the text message below so
         // it remains forwardable / quotable on its own.
         if (magazineUrl) {
-          const caption = `<b>WorldMonitor Brief — ${shortDate}</b>\n${stories.length} ${stories.length === 1 ? 'thread' : 'threads'} on the desk today.`;
+          const caption = `<b>WorldMonitor Brief — ${shortDate}</b>\n${formatterStories.length} ${formatterStories.length === 1 ? 'thread' : 'threads'} on the desk today.`;
           await sendTelegramBriefCarousel(rule.userId, ch.chatId, caption, magazineUrl);
         }
         ok = await sendTelegram(rule.userId, ch.chatId, telegramText);
@@ -1872,7 +1986,95 @@ async function main() {
         // parity).
         ok = await sendWebhook(rule.userId, ch.webhookEnvelope, stories, briefLead);
       }
-      if (ok) anyDelivered = true;
+      if (ok) {
+        anyDelivered = true;
+        // Sprint 1 / U4 — record one delivered-log entry per cluster
+        // surfaced in this channel's body. The brief envelope's stories
+        // are the canonical source set (post-cap, post-filter, ⊆ U7
+        // invariant); the formatter shim above maps them into the
+        // raw-shape used by formatDigest, which means the SAME stories
+        // were surfaced to the user.
+        //
+        // Order of operations: send first, write second. If the writer
+        // fails AFTER the channel succeeded, the story is eligible to
+        // re-air on the next tick. We accept that trade-off (extra
+        // edition beats silent suppression of a real delivery
+        // problem) — see digest-delivered-log.mjs's "Failure-mode
+        // trade-off" docblock for the canonical rationale.
+        //
+        // Per-cluster writer is awaited sequentially: under option (a)
+        // we ship ≤12 clusters × ≤5 channels per user, so the
+        // sequential cost is ~bounded at 60 SET commands per user.
+        // Parallelising via Promise.all would add bursty load to the
+        // same Upstash account that's serving the rest of the cron;
+        // sequential is simpler and the latency budget already
+        // tolerates it.
+        if (Array.isArray(briefEnvelopeStories) && briefEnvelopeStories.length > 0) {
+          for (const briefStory of briefEnvelopeStories) {
+            const clusterId = typeof briefStory?.clusterId === 'string'
+              ? briefStory.clusterId
+              : '';
+            if (!clusterId) {
+              // Defensive: a v4 envelope MUST carry clusterId per
+              // assertBriefEnvelope. If we ever land here it's a real
+              // invariant break — log loudly so the parity log catches
+              // it, but skip the write (malformed key would throw).
+              console.warn(
+                `[digest] U4 delivered-log: brief story missing clusterId — ` +
+                  `user=${rule.userId} channel=${ch.channelType} headline=${JSON.stringify(briefStory?.headline ?? '<missing>')}. ` +
+                  `Skipping log write for this cluster.`,
+              );
+              continue;
+            }
+            try {
+              const writeResult = await writeDeliveredEntry({
+                userId: rule.userId,
+                channel: ch.channelType,
+                ruleId: `${rule.variant ?? 'full'}:${rule.lang ?? 'en'}:${rule.sensitivity ?? 'high'}`,
+                clusterId,
+                sentAt: nowMs,
+                sourceCount: typeof briefStory?.source === 'string' && briefStory.source.length > 0 ? 1 : 0,
+                severity: typeof briefStory?.threatLevel === 'string' ? briefStory.threatLevel : 'unknown',
+              });
+              deliveredLogResults.push(writeResult);
+            } catch (err) {
+              // writeDeliveredEntry only throws on programmer error
+              // (empty key components). Network/Upstash failures map
+              // to {errors: 1} in the tri-state result. A throw here
+              // means a v4 envelope leaked through with bad fields;
+              // record as error in the aggregate so it surfaces in
+              // the summary line below.
+              console.warn(
+                `[digest] U4 delivered-log: writeDeliveredEntry threw for ` +
+                  `user=${rule.userId} channel=${ch.channelType} clusterId=${clusterId}: ${err?.message ?? err}`,
+              );
+              deliveredLogResults.push({ written: 0, conflicts: 0, errors: 1 });
+            }
+          }
+        }
+      }
+    }
+    // Sprint 1 / U4 summary — one line per user-rule send, not per
+    // (channel, cluster) write. Operators can tail this as a single
+    // line per user. Tri-state counters distinguish:
+    //   - written  = first-time delivered-log entries (cooldown table starts here)
+    //   - conflicts = NX-collide on existing keys (idempotent re-write,
+    //                 happens when the same (channel, rule, cluster)
+    //                 ships twice within the 30d±jitter TTL window —
+    //                 expected for sustained-narrative re-airs)
+    //   - errors   = Upstash transport failure or invariant break —
+    //                next tick re-airs the story to the affected
+    //                channel (see digest-delivered-log.mjs failure-mode
+    //                docblock).
+    if (deliveredLogResults.length > 0) {
+      const aggregate = aggregateDeliveredResults(deliveredLogResults);
+      const logFn = aggregate.errors > 0 ? console.warn : console.log;
+      logFn(
+        `[digest] U4 delivered-log user=${rule.userId} ` +
+          `rule=${rule.variant ?? 'full'}:${rule.lang ?? 'en'}:${rule.sensitivity ?? 'high'} ` +
+          `written=${aggregate.written} conflicts=${aggregate.conflicts} errors=${aggregate.errors} ` +
+          `total=${deliveredLogResults.length}`,
+      );
     }
 
     if (anyDelivered) {
@@ -1880,8 +2082,13 @@ async function main() {
         'SET', lastSentKey, JSON.stringify({ sentAt: nowMs }), 'EX', '691200', // 8 days
       );
       sentCount++;
+      // Story count reports the formatter-shape length (post-cap,
+      // post-filter slice) — what the user actually received in their
+      // digest. Pre-U7-fix this read `stories.length` (raw 30 from
+      // buildDigest), which over-counted by up to ~18 vs the cards
+      // the user saw.
       console.log(
-        `[digest] Sent ${stories.length} stories to ${rule.userId} (${rule.variant}, ${rule.digestMode})`,
+        `[digest] Sent ${formatterStories.length} stories to ${rule.userId} (${rule.variant}, ${rule.digestMode})`,
       );
       // Parity observability. Gated on AI_DIGEST_ENABLED + per-rule
       // aiDigestEnabled — without this guard, opt-out users (briefLead

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -2147,6 +2147,11 @@ async function main() {
           let lastDeliveredAt = null;
           let lastDeliveredSourceCount = null;
           let lastDeliveredTier = null;
+          // Greptile PR #3617 P2 — read prior headline for the
+          // EVOLUTION_NEW_FACT bypass. Older v4 rows written before
+          // this fix won't carry the field; null is the safe default
+          // (the evaluator skips the bypass when either side is null).
+          let lastDeliveredHeadline = null;
           try {
             const raw = await upstashRest('GET', key);
             if (typeof raw === 'string' && raw.length > 0) {
@@ -2155,6 +2160,9 @@ async function main() {
                 if (Number.isFinite(parsed.sentAt)) lastDeliveredAt = parsed.sentAt;
                 if (Number.isFinite(parsed.sourceCount)) lastDeliveredSourceCount = parsed.sourceCount;
                 if (typeof parsed.severity === 'string') lastDeliveredTier = parsed.severity;
+                if (typeof parsed.headline === 'string' && parsed.headline.length > 0) {
+                  lastDeliveredHeadline = parsed.headline;
+                }
               }
             }
           } catch (err) {
@@ -2197,6 +2205,8 @@ async function main() {
             lastDeliveredAt,
             lastDeliveredSourceCount,
             lastDeliveredTier,
+            // Greptile PR #3617 P2 — drives EVOLUTION_NEW_FACT bypass.
+            lastDeliveredHeadline,
             classifierInputs: {
               sourceDomain,
               headline: typeof briefStory?.headline === 'string' ? briefStory.headline : '',
@@ -2320,6 +2330,14 @@ async function main() {
                 // U5 cooldown loop for the full rationale.
                 sourceCount: sourceCountByClusterId.get(clusterId) ?? 0,
                 severity: typeof briefStory?.threatLevel === 'string' ? briefStory.threatLevel : 'unknown',
+                // Greptile PR #3617 P2 — persist headline so the next
+                // tick's cooldown evaluator can drive the
+                // EVOLUTION_NEW_FACT bypass via string-equality
+                // compare. cooldownIterableStories carries the
+                // canonical headline in both branches (BriefStory
+                // shape under brief-success; synthesized from raw
+                // story.title under compose-miss).
+                headline: typeof briefStory?.headline === 'string' ? briefStory.headline : '',
               });
               deliveredLogResults.push(writeResult);
             } catch (err) {

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -1994,6 +1994,42 @@ async function main() {
     // next tick spends zero on cooldown.
     const cooldownDecisions = [];
     const ruleIdComposite = `${rule.variant ?? 'full'}:${rule.lang ?? 'en'}:${rule.sensitivity ?? 'high'}`;
+    // Codex PR #3617 P1 — real per-cluster source count for U4 writes
+    // and U5 cooldown evaluation.
+    //
+    // The brief envelope's BriefStory schema only carries a single
+    // `source` string (the primary wire) — the original cluster's full
+    // sources[] array is not preserved. Reading 0/1 off briefStory.source
+    // collapses real source counts (5, 10, 37+) and breaks U5's "+5
+    // sources within floor" evolution bypass: the delta from N to 0/1
+    // is always 0 or 1, never ≥5. Without this, today's shadow rows
+    // seed bad history that Sprint 2's enforce mode would inherit.
+    //
+    // Fix: derive sourceCount from the raw clustered `stories` pool
+    // (post-buildDigest, pre-filterTopStories) where the original
+    // sources[] is still attached. Match by cluster identity:
+    // mergedHashes[0] when present (rep's own hash by U3's contract),
+    // else the story's own hash (singletons). One Map build per send,
+    // O(1) lookup per cluster iteration.
+    const sourceCountByClusterId = new Map();
+    if (Array.isArray(stories)) {
+      for (const rawStory of stories) {
+        const repHash = Array.isArray(rawStory?.mergedHashes)
+          && rawStory.mergedHashes.length > 0
+          && typeof rawStory.mergedHashes[0] === 'string'
+          ? rawStory.mergedHashes[0]
+          : (typeof rawStory?.hash === 'string' ? rawStory.hash : '');
+        if (!repHash) continue;
+        const sources = Array.isArray(rawStory?.sources) ? rawStory.sources : [];
+        // Existing entry wins (first-rep-by-iteration order). Raw
+        // stories shouldn't duplicate clusterIds post-dedup, but the
+        // defensive first-write semantics protect against a future
+        // dedup bug double-counting sources.
+        if (!sourceCountByClusterId.has(repHash)) {
+          sourceCountByClusterId.set(repHash, sources.length);
+        }
+      }
+    }
     // Slot string mirrors the brief composer: `issueSlotInTz(nowMs, tz)`.
     // We use the same tz the composer used (rule.digestTimezone, default
     // 'UTC') so the slot naming aligns 1:1 with the brief envelope's
@@ -2057,7 +2093,12 @@ async function main() {
             }
           })();
           const severity = typeof briefStory?.threatLevel === 'string' ? briefStory.threatLevel : 'unknown';
-          const currentSourceCount = typeof briefStory?.source === 'string' && briefStory.source.length > 0 ? 1 : 0;
+          // Codex PR #3617 P1 — real source count from the raw clustered
+          // story (sources[].length), not the BriefStory.source 0/1 collapse.
+          // Falls back to 0 when the cluster doesn't appear in the raw
+          // stories Map (defensive — shouldn't happen on the option-(a)
+          // canonical-rule path, but a future bug shouldn't crash the cron).
+          const currentSourceCount = sourceCountByClusterId.get(clusterId) ?? 0;
           const decision = evaluateCooldown({
             userId: rule.userId,
             slot: cooldownSlot,
@@ -2172,7 +2213,11 @@ async function main() {
                 ruleId: `${rule.variant ?? 'full'}:${rule.lang ?? 'en'}:${rule.sensitivity ?? 'high'}`,
                 clusterId,
                 sentAt: nowMs,
-                sourceCount: typeof briefStory?.source === 'string' && briefStory.source.length > 0 ? 1 : 0,
+                // Codex PR #3617 P1 — real source count, not the
+                // 0/1 collapse from BriefStory.source. See the
+                // sourceCountByClusterId Map construction above the
+                // U5 cooldown loop for the full rationale.
+                sourceCount: sourceCountByClusterId.get(clusterId) ?? 0,
                 severity: typeof briefStory?.threatLevel === 'string' ? briefStory.threatLevel : 'unknown',
               });
               deliveredLogResults.push(writeResult);

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -548,6 +548,55 @@ async function buildDigest(rule, windowStartMs) {
   // catch + early return when the flag is off, so awaiting is free on
   // the disabled path and bounded by the 10s Upstash pipeline timeout
   // on the enabled path.
+  // Codex PR #3617 P1 — hydrate sources on `dedupedAll` BEFORE
+  // writeReplayLog so the replay records carry the canonical source
+  // count Sprint 1 / U6 needs to evaluate +5-evolution bypasses. The
+  // pre-fix order wrote replay records with `sources: []` (hydration
+  // happened later, only on the post-cap `top` slice), which made U6
+  // structurally unable to detect source-count evolution.
+  //
+  // Implementation: run SMEMBERS for every rep's mergedHashes BEFORE
+  // the replay-log write. `top` (built later as a slice of dedupedAll)
+  // shares object references with the reps we're hydrating here, so the
+  // later "hydrate top.sources" block becomes a no-op and is removed
+  // below. Cost: one Upstash pipeline with ~30 SMEMBERS commands per
+  // tick — bounded by the dedup output size (typically 20-30 reps).
+  {
+    const preCmds = [];
+    const preIdx = [];
+    for (let i = 0; i < dedupedAll.length; i++) {
+      dedupedAll[i].sources = [];
+      const hashes = Array.isArray(dedupedAll[i].mergedHashes)
+        ? dedupedAll[i].mergedHashes
+        : [dedupedAll[i].hash];
+      for (const h of hashes) {
+        if (typeof h === 'string' && h.length > 0) {
+          preCmds.push(['SMEMBERS', `story:sources:v1:${h}`]);
+          preIdx.push(i);
+        }
+      }
+    }
+    if (preCmds.length > 0) {
+      try {
+        const preResults = await upstashPipeline(preCmds);
+        for (let j = 0; j < preResults.length; j++) {
+          const arr = preResults[j]?.result ?? [];
+          const target = dedupedAll[preIdx[j]];
+          for (const src of arr) {
+            if (!target.sources.includes(src)) target.sources.push(src);
+          }
+        }
+      } catch (err) {
+        // Best-effort: if the source pipeline fails, replay-log carries
+        // empty source arrays (the pre-fix shape). Cooldown evolution
+        // bypass goes blind for that tick — preferable to crashing the
+        // cron over a non-load-bearing diagnostic write.
+        console.warn(
+          `[digest] U6 pre-hydrate sources failed: ${err?.message ?? err} — replay records will carry empty sources for this tick`,
+        );
+      }
+    }
+  }
   const ruleKey = `${variant}:${lang}:${rule.sensitivity ?? 'high'}`;
   await writeReplayLog({
     stories,
@@ -624,23 +673,13 @@ async function buildDigest(rule, windowStartMs) {
     console.log(finalLog);
   }
 
-  const allSourceCmds = [];
-  const cmdIndex = [];
-  for (let i = 0; i < top.length; i++) {
-    const hashes = top[i].mergedHashes ?? [top[i].hash];
-    for (const h of hashes) {
-      allSourceCmds.push(['SMEMBERS', `story:sources:v1:${h}`]);
-      cmdIndex.push(i);
-    }
-  }
-  const sourceResults = await upstashPipeline(allSourceCmds);
-  for (let i = 0; i < top.length; i++) top[i].sources = [];
-  for (let j = 0; j < sourceResults.length; j++) {
-    const arr = sourceResults[j]?.result ?? [];
-    for (const src of arr) {
-      if (!top[cmdIndex[j]].sources.includes(src)) top[cmdIndex[j]].sources.push(src);
-    }
-  }
+  // Codex PR #3617 P1 — sources are already hydrated on `dedupedAll`
+  // BEFORE the writeReplayLog call above (so U6 replay records carry
+  // canonical source counts). `top` items are references to the same
+  // objects, so they already have `sources` populated. The redundant
+  // hydration block that lived here pre-fix has been removed; it would
+  // have RESET (top[i].sources = []) and re-fetched, doubling the
+  // SMEMBERS pipeline cost per tick for no functional benefit.
 
   return top;
 }

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -2249,7 +2249,19 @@ async function main() {
         // briefLead — same string the email exec block + magazine
         // pull-quote use. Codex Round-1 Medium #6 (channel-scope
         // parity).
-        ok = await sendWebhook(rule.userId, ch.webhookEnvelope, stories, briefLead);
+        //
+        // Codex PR #3617 round-5 P1 — pass formatterStories (NOT raw
+        // stories). Pre-fix the webhook serialised the full raw pool
+        // (up to DIGEST_MAX_ITEMS=30) while every other channel
+        // consumed formatterStories (post-cap, post-filter — what
+        // U4/U5 also iterate via cooldownIterableStories). Webhook
+        // users were therefore receiving cards that were never
+        // shadow-evaluated and never seeded delivered-log rows for
+        // future cooldown enforcement. Aligning to formatterStories
+        // closes the channel-coverage gap so the webhook payload
+        // exactly matches what U4 stamped + U5 evaluated for that
+        // (user, rule, tick).
+        ok = await sendWebhook(rule.userId, ch.webhookEnvelope, formatterStories, briefLead);
       }
       if (ok) {
         anyDelivered = true;

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -1988,6 +1988,47 @@ async function main() {
       ? briefStoriesToFormatterShape(briefEnvelopeStories)
       : stories; // fallback: brief envelope absent (compose-miss branch above)
 
+    // Codex PR #3617 round-4 P2 — unified iterable for U4/U5 coverage in
+    // both branches.
+    //
+    // Pre-fix the cooldown loop (U5) and delivered-log writer (U4) were
+    // both gated on `briefEnvelopeStories.length > 0`, so under
+    // compose-miss (brief absent) the digest cards were SENT to the
+    // user but the U4/U5 substrate skipped them entirely. Multi-tick
+    // compose outages (e.g. signing secret unset for 6h) accumulated
+    // un-tracked deliveries; when compose recovered, the cooldown
+    // saw "no prior delivery" and re-aired everything the user had
+    // received during the outage.
+    //
+    // Fix: build a unified `cooldownIterableStories` array that both
+    // branches feed. Under brief-success it's the v4 BriefStory shape
+    // directly (already has clusterId, threatLevel, source, sourceUrl,
+    // headline). Under compose-miss it's a normalized projection of
+    // the raw `stories` pool — fields mapped by hand from the
+    // post-buildDigest shape (severity → threatLevel, link → sourceUrl,
+    // title → headline, mergedHashes[0] || hash → clusterId).
+    //
+    // Same downstream iteration in both U4 and U5 loops; same
+    // sourceCountByClusterId Map (already keyed on repHash, which
+    // matches both branches' clusterId semantics).
+    const cooldownIterableStories = Array.isArray(briefEnvelopeStories) && briefEnvelopeStories.length > 0
+      ? briefEnvelopeStories
+      : (Array.isArray(stories) ? stories.map((rawStory) => {
+          const repHash = Array.isArray(rawStory?.mergedHashes)
+            && rawStory.mergedHashes.length > 0
+            && typeof rawStory.mergedHashes[0] === 'string'
+            ? rawStory.mergedHashes[0]
+            : (typeof rawStory?.hash === 'string' ? rawStory.hash : '');
+          const sources = Array.isArray(rawStory?.sources) ? rawStory.sources : [];
+          return {
+            clusterId: repHash,
+            threatLevel: typeof rawStory?.severity === 'string' ? rawStory.severity : 'unknown',
+            source: typeof sources[0] === 'string' ? sources[0] : '',
+            sourceUrl: typeof rawStory?.link === 'string' ? rawStory.link : '',
+            headline: typeof rawStory?.title === 'string' ? rawStory.title : '',
+          };
+        }) : []);
+
     const storyListPlain = formatDigest(formatterStories, nowMs);
     if (!storyListPlain) continue;
     const htmlRaw = formatDigestHtml(formatterStories, nowMs);
@@ -2077,8 +2118,8 @@ async function main() {
     const cooldownSlot = issueSlotInTz(nowMs, rule.digestTimezone ?? 'UTC');
     if (
       cooldownConfig.mode === 'shadow'
-      && Array.isArray(briefEnvelopeStories)
-      && briefEnvelopeStories.length > 0
+      && Array.isArray(cooldownIterableStories)
+      && cooldownIterableStories.length > 0
     ) {
       // Outer loop: one decision per (channel, cluster) tuple. Same
       // shape as the U4 writer's iteration so the shadow log's
@@ -2087,8 +2128,13 @@ async function main() {
       // writer (≤12 clusters × ≤5 channels per user = ≤60 GETs;
       // bursty parallelism would compete with the rest of the cron's
       // Upstash traffic for no measurable latency win).
+      //
+      // Codex PR #3617 round-4 P2 — iterate cooldownIterableStories
+      // (NOT briefEnvelopeStories) so the compose-miss fallback path
+      // also gets U5 coverage. See the cooldownIterableStories
+      // construction above for the unified-shape rationale.
       for (const ch of deliverableChannels) {
-        for (const briefStory of briefEnvelopeStories) {
+        for (const briefStory of cooldownIterableStories) {
           const clusterId = typeof briefStory?.clusterId === 'string' ? briefStory.clusterId : '';
           if (!clusterId) {
             // Same defensive branch as the U4 writer below — a v4
@@ -2228,16 +2274,20 @@ async function main() {
         // same Upstash account that's serving the rest of the cron;
         // sequential is simpler and the latency budget already
         // tolerates it.
-        if (Array.isArray(briefEnvelopeStories) && briefEnvelopeStories.length > 0) {
-          for (const briefStory of briefEnvelopeStories) {
+        // Codex PR #3617 round-4 P2 — iterate cooldownIterableStories
+        // (unified across brief-success + compose-miss). See the
+        // cooldownIterableStories construction above for rationale.
+        if (Array.isArray(cooldownIterableStories) && cooldownIterableStories.length > 0) {
+          for (const briefStory of cooldownIterableStories) {
             const clusterId = typeof briefStory?.clusterId === 'string'
               ? briefStory.clusterId
               : '';
             if (!clusterId) {
               // Defensive: a v4 envelope MUST carry clusterId per
-              // assertBriefEnvelope. If we ever land here it's a real
-              // invariant break — log loudly so the parity log catches
-              // it, but skip the write (malformed key would throw).
+              // assertBriefEnvelope. Under compose-miss, clusterId is
+              // derived from raw mergedHashes[0]/hash — always present
+              // for valid raw stories. Skip the write on missing
+              // clusterId either way (malformed key would throw).
               console.warn(
                 `[digest] U4 delivered-log: brief story missing clusterId — ` +
                   `user=${rule.userId} channel=${ch.channelType} headline=${JSON.stringify(briefStory?.headline ?? '<missing>')}. ` +

--- a/tests/brief-dedup-replay-log.test.mjs
+++ b/tests/brief-dedup-replay-log.test.mjs
@@ -168,6 +168,42 @@ describe('buildReplayRecords — record shape', () => {
     assert.equal(byHash.get('h3').isRep, true);
   });
 
+  // Codex PR #3617 P1 — Sprint 1 / U6 v2 shape: every record carries
+  // `repHash` (canonical stable cluster identity), reps additionally
+  // carry `mergedHashes`, and `headline`/`sourceUrl` aliases for the
+  // U5 classifier shape.
+  it('repHash is the rep\'s own hash, set on EVERY record (rep AND non-rep) — Codex PR #3617 P1', () => {
+    const records = buildReplayRecords(stories, reps, new Map(), cfg, tickContext);
+    const byHash = new Map(records.map((r) => [r.storyHash, r]));
+    assert.equal(byHash.get('h1').repHash, 'h1', 'rep h1 → repHash=h1');
+    assert.equal(byHash.get('h2').repHash, 'h1', 'non-rep h2 in cluster {h1,h2} → repHash=h1');
+    assert.equal(byHash.get('h3').repHash, 'h3', 'singleton h3 → repHash=h3');
+  });
+
+  it('mergedHashes is set on rep records, null on non-rep records', () => {
+    const records = buildReplayRecords(stories, reps, new Map(), cfg, tickContext);
+    const byHash = new Map(records.map((r) => [r.storyHash, r]));
+    assert.deepEqual(byHash.get('h1').mergedHashes, ['h1', 'h2']);
+    assert.equal(byHash.get('h2').mergedHashes, null, 'non-rep gets null mergedHashes');
+    assert.deepEqual(byHash.get('h3').mergedHashes, ['h3']);
+  });
+
+  it('headline aliases title; sourceUrl aliases link (U5 classifier-shape compat)', () => {
+    const sWithLink = { ...s1, link: 'https://example.com/n1' };
+    const repsWithLink = [rep('h1', ['h1'], { currentScore: 10 })];
+    const records = buildReplayRecords([sWithLink], repsWithLink, new Map(), cfg, tickContext);
+    assert.equal(records[0].headline, sWithLink.title);
+    assert.equal(records[0].sourceUrl, 'https://example.com/n1');
+    // Legacy fields preserved for back-compat.
+    assert.equal(records[0].title, sWithLink.title);
+    assert.equal(records[0].link, 'https://example.com/n1');
+  });
+
+  it('writer emits v=2 (Codex PR #3617 P1 bump)', () => {
+    const records = buildReplayRecords(stories, reps, new Map(), cfg, tickContext);
+    for (const r of records) assert.equal(r.v, 2, `record v should be 2; got ${r.v}`);
+  });
+
   it('clusterId derives from rep.mergedHashes (s1+s2 → 0, s3 → 1)', () => {
     const records = buildReplayRecords(stories, reps, new Map(), cfg, tickContext);
     const byHash = new Map(records.map((r) => [r.storyHash, r]));
@@ -242,7 +278,10 @@ describe('buildReplayRecords — record shape', () => {
       assert.equal(r.briefTickId, 'tick-1');
       assert.equal(r.ruleId, 'full:en:high');
       assert.equal(r.tsMs, 1000);
-      assert.equal(r.v, 1);
+      // Codex PR #3617 P1 — bumped to v2 (added repHash + mergedHashes
+      // + headline + sourceUrl). v1 envelopes still in 30d TTL are
+      // accepted on read by the U6 harness via legacy-field fallbacks.
+      assert.equal(r.v, 2);
     }
   });
 

--- a/tests/brief-dedup-replay-log.test.mjs
+++ b/tests/brief-dedup-replay-log.test.mjs
@@ -204,6 +204,44 @@ describe('buildReplayRecords — record shape', () => {
     for (const r of records) assert.equal(r.v, 2, `record v should be 2; got ${r.v}`);
   });
 
+  // Codex PR #3617 round-3 P1 — sources come from the REP's hydrated
+  // set, not from individual input stories. Pre-fix mutating
+  // dedupedAll[i].sources didn't reach the writer because it iterated
+  // input `stories` (which materializeCluster() never wrote back to).
+  it('sources are sourced from the rep object (not input story.sources)', () => {
+    // Rep with hydrated sources, input story with EMPTY sources.
+    // Pre-fix the writer would have emitted sources: [] (reading from
+    // the input story). Post-fix it reads from the rep.
+    const repWithSources = rep('h1', ['h1', 'h2'], { currentScore: 10, sources: ['Reuters', 'AP', 'BBC'] });
+    const recs = buildReplayRecords(
+      [story('a', { hash: 'h1', sources: [] }), story('b', { hash: 'h2', sources: [] })],
+      [repWithSources],
+      new Map(),
+      cfg,
+      tickContext,
+    );
+    const byHash = new Map(recs.map((r) => [r.storyHash, r]));
+    assert.deepEqual(byHash.get('h1').sources, ['Reuters', 'AP', 'BBC']);
+    // Non-rep gets the SAME hydrated sources (cluster source-count
+    // identity is uniform across members — the rep is the canonical view).
+    assert.deepEqual(byHash.get('h2').sources, ['Reuters', 'AP', 'BBC']);
+  });
+
+  it('falls back to story.sources when rep has none (defensive — fixture compatibility)', () => {
+    // Some test fixtures pass pre-populated input story.sources and
+    // omit them on the rep. The writer should still emit those rather
+    // than dropping them silently.
+    const repNoSources = { hash: 'h1', mergedHashes: ['h1'], currentScore: 5, mentionCount: 1 };
+    const recs = buildReplayRecords(
+      [story('a', { hash: 'h1', sources: ['fixture-source'] })],
+      [repNoSources],
+      new Map(),
+      cfg,
+      tickContext,
+    );
+    assert.deepEqual(recs[0].sources, ['fixture-source']);
+  });
+
   it('clusterId derives from rep.mergedHashes (s1+s2 → 0, s3 → 1)', () => {
     const records = buildReplayRecords(stories, reps, new Map(), cfg, tickContext);
     const byHash = new Map(records.map((r) => [r.storyHash, r]));

--- a/tests/brief-from-digest-stories.test.mjs
+++ b/tests/brief-from-digest-stories.test.mjs
@@ -1273,4 +1273,40 @@ describe('Sprint 1 U7 production-gap source-text guard — formatter call site',
       '(optional-chained for the compose-miss fallback path).',
     );
   });
+
+  // Codex PR #3617 P1 — real source count regression guard.
+  it('U4 writer + U5 evaluator both consume sourceCountByClusterId (not BriefStory.source 0/1 collapse)', async () => {
+    const path = fileURLToPath(new URL('../scripts/seed-digest-notifications.mjs', import.meta.url));
+    const src = await readFile(path, 'utf8');
+
+    // The Map must be built once before the cluster iteration loop, from
+    // the raw clustered `stories` pool (where sources[] is still attached).
+    assert.match(
+      src,
+      /const\s+sourceCountByClusterId\s*=\s*new\s+Map\(\s*\)/,
+      'sourceCountByClusterId Map must be built (per-send) for U4 writer + U5 evaluator',
+    );
+    assert.match(
+      src,
+      /sourceCountByClusterId\.set\(/,
+      'sourceCountByClusterId Map must be populated from raw stories',
+    );
+
+    // Both consumer sites must use the Map, NOT the BriefStory.source 0/1 collapse.
+    const collapsedPattern = /briefStory\?\.source\s*===\s*'string'\s*&&\s*briefStory\.source\.length\s*>\s*0\s*\?\s*1\s*:\s*0/;
+    assert.doesNotMatch(
+      src,
+      collapsedPattern,
+      'cron must NOT collapse source count to 0/1 from BriefStory.source — that breaks U5\'s +5-sources evolution bypass. ' +
+      'Use sourceCountByClusterId.get(clusterId) ?? 0 instead.',
+    );
+
+    // Both sites must read from the Map.
+    const getMatches = src.match(/sourceCountByClusterId\.get\(\s*clusterId\s*\)/g) ?? [];
+    assert.ok(
+      getMatches.length >= 2,
+      `expected ≥2 sourceCountByClusterId.get(clusterId) reads (U4 writer + U5 evaluator); ` +
+      `found ${getMatches.length}. If you removed one of them, the cooldown evolution bypass will break silently.`,
+    );
+  });
 });

--- a/tests/brief-from-digest-stories.test.mjs
+++ b/tests/brief-from-digest-stories.test.mjs
@@ -1274,6 +1274,66 @@ describe('Sprint 1 U7 production-gap source-text guard — formatter call site',
     );
   });
 
+  // Codex PR #3617 round-4 P2 — compose-miss fallback must run U4/U5.
+  it('cooldownIterableStories unifies brief-success + compose-miss for U4/U5 coverage', async () => {
+    const path = fileURLToPath(new URL('../scripts/seed-digest-notifications.mjs', import.meta.url));
+    const src = await readFile(path, 'utf8');
+
+    // The unified iterable is constructed from briefEnvelopeStories OR
+    // a normalized projection of raw `stories`. Pre-fix the U5/U4 loops
+    // gated on `briefEnvelopeStories.length > 0`, so compose-miss
+    // delivered cards without seeding cooldown rows or shadow decisions.
+    assert.match(
+      src,
+      /const\s+cooldownIterableStories\s*=/,
+      'cron must declare cooldownIterableStories — the unified U4/U5 iterable across both branches',
+    );
+
+    // Both U5 and U4 loops must iterate cooldownIterableStories, NOT
+    // briefEnvelopeStories. Pre-fix used briefEnvelopeStories which
+    // skipped the entire compose-miss path. Capture every
+    // `for (const briefStory of <name>)` and assert all instances
+    // iterate cooldownIterableStories — there should be exactly 2
+    // (U5 cooldown loop + U4 writer loop) but the contract is "NEVER
+    // iterate the brief-only briefEnvelopeStories".
+    const briefStoryLoops = [...src.matchAll(/for\s*\(\s*const\s+briefStory\s+of\s+(\w+)\s*\)/g)];
+    assert.ok(briefStoryLoops.length >= 2, `expected ≥2 briefStory loops (U5 + U4); found ${briefStoryLoops.length}`);
+    for (const m of briefStoryLoops) {
+      assert.equal(
+        m[1],
+        'cooldownIterableStories',
+        `every briefStory loop must iterate cooldownIterableStories (compose-miss coverage); got "${m[1]}"`,
+      );
+    }
+    // The U5 mode-gate must also use cooldownIterableStories for the
+    // length check (NOT briefEnvelopeStories).
+    assert.match(
+      src,
+      /cooldownConfig\.mode\s*===\s*'shadow'[\s\S]{0,800}?cooldownIterableStories\.length\s*>\s*0/,
+      'U5 mode-gate must check cooldownIterableStories.length, not briefEnvelopeStories',
+    );
+  });
+
+  // Codex PR #3617 round-4 P1 — writer uses SET not SET NX.
+  it('U4 writer issues SET (NOT SET NX) so cooldown reads see refreshed lastDeliveredAt', async () => {
+    const writerPath = fileURLToPath(new URL('../scripts/lib/digest-delivered-log.mjs', import.meta.url));
+    const src = await readFile(writerPath, 'utf8');
+
+    // Look for the pipeline command construction. Must have SET ... EX
+    // (no NX between them). A regex hit on `'NX'` as a literal
+    // command argument is the bug signature; we forbid it.
+    assert.doesNotMatch(
+      src,
+      /pipeline\s*\(\s*\[\s*\[\s*'SET'[\s\S]{0,200}?,\s*'NX'/,
+      'writer must NOT use SET NX — that locks the row to its first value forever and breaks refresh-on-allow',
+    );
+    assert.match(
+      src,
+      /pipeline\s*\(\s*\[\s*\[\s*'SET'/,
+      'writer must use SET pipeline command',
+    );
+  });
+
   // Codex PR #3617 P1 — real source count regression guard.
   it('U4 writer + U5 evaluator both consume sourceCountByClusterId (not BriefStory.source 0/1 collapse)', async () => {
     const path = fileURLToPath(new URL('../scripts/seed-digest-notifications.mjs', import.meta.url));

--- a/tests/brief-from-digest-stories.test.mjs
+++ b/tests/brief-from-digest-stories.test.mjs
@@ -1314,6 +1314,31 @@ describe('Sprint 1 U7 production-gap source-text guard — formatter call site',
     );
   });
 
+  // Codex PR #3617 round-5 P1 — webhook channel must consume
+  // formatterStories so its payload matches the U4/U5-covered set.
+  it('sendWebhook is called with formatterStories (NOT raw stories) — channel-coverage parity', async () => {
+    const path = fileURLToPath(new URL('../scripts/seed-digest-notifications.mjs', import.meta.url));
+    const src = await readFile(path, 'utf8');
+
+    // Pre-fix: `sendWebhook(rule.userId, ch.webhookEnvelope, stories, briefLead)`
+    // Post-fix: `sendWebhook(rule.userId, ch.webhookEnvelope, formatterStories, briefLead)`
+    // The pre-fix shape would have webhook users receiving up to
+    // DIGEST_MAX_ITEMS=30 raw cards while U4/U5 only saw the
+    // post-cap subset (≤12 under brief-success).
+    assert.match(
+      src,
+      /sendWebhook\([^)]*?,\s*formatterStories\s*,\s*briefLead\s*\)/,
+      'webhook channel must consume formatterStories so its payload matches U4/U5-covered set',
+    );
+    // Forbidden-pattern guard: if a future refactor reverts to passing
+    // raw `stories`, this fails loudly.
+    assert.doesNotMatch(
+      src,
+      /sendWebhook\([^)]*?,\s*stories\s*,\s*briefLead\s*\)/,
+      'webhook must NOT pass raw stories — that bypasses U4/U5 coverage for webhook users',
+    );
+  });
+
   // Codex PR #3617 round-4 P1 — writer uses SET not SET NX.
   it('U4 writer issues SET (NOT SET NX) so cooldown reads see refreshed lastDeliveredAt', async () => {
     const writerPath = fileURLToPath(new URL('../scripts/lib/digest-delivered-log.mjs', import.meta.url));

--- a/tests/brief-from-digest-stories.test.mjs
+++ b/tests/brief-from-digest-stories.test.mjs
@@ -12,6 +12,8 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 import { composeBriefFromDigestStories, stripHeadlineSuffix } from '../scripts/lib/brief-compose.mjs';
 import { materializeCluster } from '../scripts/lib/brief-dedup-jaccard.mjs';
 
@@ -1191,6 +1193,84 @@ describe('Sprint 1 U7 — digest projection invariant: digest.cards ⊆ brief.ca
     assertDigestSubsetOfBrief(
       projectDigestEmitClusterIds(digestStories),
       envelopeClusterIds(env),
+    );
+  });
+});
+
+// ── Sprint 1 / U7 production-gap fix: source-text guard ────────────────────
+//
+// The U7 invariant proven above (via composeBriefFromDigestStories +
+// projectDigestEmitClusterIds) holds STRUCTURALLY. But the RUNTIME guarantee
+// that the live cron emits a digest body whose clusterIds are a subset of the
+// brief envelope's clusterIds depends on a separate fact:
+//
+//   `formatDigest` and `formatDigestHtml` in scripts/seed-digest-notifications
+//   .mjs MUST consume the brief envelope's `data.stories` slice (post-cap,
+//   post-filter, ≤ MAX_STORIES_PER_USER=12), NOT the raw `stories` pool from
+//   buildDigest (capped at DIGEST_MAX_ITEMS=30).
+//
+// Pre-fix, the formatters were called with `stories` (raw 30); the user could
+// see clusters that were never in the brief envelope. The U7 invariant
+// projection helper above models the brief side correctly, but didn't catch
+// the production-side regression — those formatters never produced a v4
+// envelope at all, so a structural test against the envelope can't see them.
+//
+// This source-text guard mirrors the U2 precedent at
+// tests/brief-composer-rule-dedup.test.mjs (`describe('Sprint 1 U2 source-
+// text guard', ...)`): assert the source code at the load-bearing call site
+// matches a regex. It can't be bypassed by Vitest mocks; it can't drift
+// silently if a future refactor "innocently" reverts the wiring. If the
+// regex stops matching, the test fails with a message that names the file
+// and lists the candidate lines for an operator to repair.
+//
+// Why source-text not behaviour: the cron's send loop pulls together
+// Upstash, Convex relay, Resend, Telegram, and DNS resolution. There's no
+// existing test harness that mocks all five together (documented in the
+// U7 header above). A behaviour test for THIS specific wiring would need
+// that whole harness; a source-text guard captures the same invariant in
+// 5 lines, with the trade-off that a future refactor that uses the brief
+// envelope via a DIFFERENT spelling (e.g. local variable rename) needs to
+// touch this regex too. That's a fair trade — the alternative is no test
+// at all, and an "everything works in unit tests, fails in production"
+// shape, which is exactly what this guard exists to prevent.
+
+describe('Sprint 1 U7 production-gap source-text guard — formatter call site', () => {
+  it('formatDigest + formatDigestHtml consume the brief-envelope-derived slice (NOT raw stories)', async () => {
+    const path = fileURLToPath(new URL('../scripts/seed-digest-notifications.mjs', import.meta.url));
+    const src = await readFile(path, 'utf8');
+
+    // We expect both call sites to consume `formatterStories` — the local
+    // variable populated from `briefStoriesToFormatterShape(brief.envelope.
+    // data.stories)`. Anything else (raw `stories`, a renamed local) would
+    // break the U7 invariant on the live send path.
+    assert.match(
+      src,
+      /formatDigest\(\s*formatterStories\s*,\s*nowMs\s*\)/,
+      'formatDigest call site must consume `formatterStories` (the brief-envelope-derived slice). ' +
+      'Pre-fix this read `stories` (raw pool); see U7 source-text guard rationale in this test header.',
+    );
+    assert.match(
+      src,
+      /formatDigestHtml\(\s*formatterStories\s*,\s*nowMs\s*\)/,
+      'formatDigestHtml call site must consume `formatterStories` (the brief-envelope-derived slice). ' +
+      'Pre-fix this read `stories` (raw pool); see U7 source-text guard rationale in this test header.',
+    );
+
+    // The shim itself must be wired against `brief.envelope.data.stories`.
+    // If a future refactor renames/relocates this access, this assertion
+    // must move with it — fail loudly so the operator notices and updates
+    // both the wiring AND this guard in lockstep.
+    assert.match(
+      src,
+      /briefStoriesToFormatterShape\(\s*briefEnvelopeStories\s*\)/,
+      'formatter shim must be applied to the brief envelope-derived stories ' +
+      '(local var `briefEnvelopeStories`, populated from `brief.envelope.data.stories`).',
+    );
+    assert.match(
+      src,
+      /brief\?\.envelope\?\.data\?\.stories/,
+      'the brief-envelope-derived slice must be read from `brief.envelope.data.stories` ' +
+      '(optional-chained for the compose-miss fallback path).',
     );
   });
 });

--- a/tests/digest-cooldown-config.test.mjs
+++ b/tests/digest-cooldown-config.test.mjs
@@ -1,0 +1,154 @@
+// Sprint 1 / U5 — kill-switch parser tests for the cooldown decision
+// module. The parser is the gate between operator intent
+// (`DIGEST_COOLDOWN_MODE` env) and the runtime "should we evaluate
+// cooldown for this send?" decision. Every code path must fail closed
+// to 'shadow' on anything we don't recognise — per
+// feedback_kill_switch_default_on_typo, a typo that produces an
+// unintended-enforce shape is worse than no signal at all.
+//
+// Sprint 1 deliberately rejects 'enforce' (Sprint 2 introduces it),
+// so the parser MUST treat 'enforce' as a typo-class invalid value
+// and fall back to 'shadow' with the invalidRaw warn surface.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  readCooldownConfig,
+  readCooldownMode,
+} from '../scripts/lib/digest-cooldown-config.mjs';
+
+describe('readCooldownConfig — default + valid modes', () => {
+  it('empty env → mode=shadow (the safe default), invalidRaw=null', () => {
+    const cfg = readCooldownConfig({});
+    assert.equal(cfg.mode, 'shadow');
+    assert.equal(cfg.invalidRaw, null);
+  });
+
+  it('undefined value → mode=shadow, invalidRaw=null', () => {
+    const cfg = readCooldownConfig({ DIGEST_COOLDOWN_MODE: undefined });
+    assert.equal(cfg.mode, 'shadow');
+    assert.equal(cfg.invalidRaw, null);
+  });
+
+  it('empty string → mode=shadow (Railway dashboard widget produces empty for "no operator opinion")', () => {
+    const cfg = readCooldownConfig({ DIGEST_COOLDOWN_MODE: '' });
+    assert.equal(cfg.mode, 'shadow');
+    assert.equal(cfg.invalidRaw, null);
+  });
+
+  it('whitespace-only string → mode=shadow (treated as unset after trim)', () => {
+    const cfg = readCooldownConfig({ DIGEST_COOLDOWN_MODE: '   \t  ' });
+    assert.equal(cfg.mode, 'shadow');
+    assert.equal(cfg.invalidRaw, null);
+  });
+
+  it('exact "shadow" → mode=shadow, invalidRaw=null', () => {
+    const cfg = readCooldownConfig({ DIGEST_COOLDOWN_MODE: 'shadow' });
+    assert.equal(cfg.mode, 'shadow');
+    assert.equal(cfg.invalidRaw, null);
+  });
+
+  it('exact "off" → mode=off, invalidRaw=null', () => {
+    const cfg = readCooldownConfig({ DIGEST_COOLDOWN_MODE: 'off' });
+    assert.equal(cfg.mode, 'off');
+    assert.equal(cfg.invalidRaw, null);
+  });
+});
+
+describe('readCooldownConfig — case-folding (operator typing)', () => {
+  it('"Shadow" → mode=shadow (operators paste mixed-case during incidents)', () => {
+    const cfg = readCooldownConfig({ DIGEST_COOLDOWN_MODE: 'Shadow' });
+    assert.equal(cfg.mode, 'shadow');
+    assert.equal(cfg.invalidRaw, null);
+  });
+
+  it('"OFF" → mode=off (uppercase is a common Railway dashboard pattern)', () => {
+    const cfg = readCooldownConfig({ DIGEST_COOLDOWN_MODE: 'OFF' });
+    assert.equal(cfg.mode, 'off');
+    assert.equal(cfg.invalidRaw, null);
+  });
+
+  it('"Off" → mode=off (mixed case still resolves)', () => {
+    const cfg = readCooldownConfig({ DIGEST_COOLDOWN_MODE: 'Off' });
+    assert.equal(cfg.mode, 'off');
+    assert.equal(cfg.invalidRaw, null);
+  });
+
+  it('leading/trailing whitespace is trimmed before classification', () => {
+    const cfg = readCooldownConfig({ DIGEST_COOLDOWN_MODE: '  shadow  ' });
+    assert.equal(cfg.mode, 'shadow');
+    assert.equal(cfg.invalidRaw, null);
+  });
+});
+
+describe('readCooldownConfig — fail-closed-to-shadow on typo / invalid', () => {
+  it('"enforce" → mode=shadow + invalidRaw="enforce" (intentionally invalid in Sprint 1)', () => {
+    // The point: an operator who flips DIGEST_COOLDOWN_MODE=enforce
+    // before Sprint 2 ships gets fail-closed-to-shadow + a loud warn
+    // surface, NOT a silent partial-enforce state.
+    const cfg = readCooldownConfig({ DIGEST_COOLDOWN_MODE: 'enforce' });
+    assert.equal(cfg.mode, 'shadow');
+    assert.equal(cfg.invalidRaw, 'enforce');
+  });
+
+  it('"true" → mode=shadow + invalidRaw="true" (boolean-coercion mistake)', () => {
+    const cfg = readCooldownConfig({ DIGEST_COOLDOWN_MODE: 'true' });
+    assert.equal(cfg.mode, 'shadow');
+    assert.equal(cfg.invalidRaw, 'true');
+  });
+
+  it('"1" → mode=shadow + invalidRaw="1" (numeric-coercion mistake)', () => {
+    const cfg = readCooldownConfig({ DIGEST_COOLDOWN_MODE: '1' });
+    assert.equal(cfg.mode, 'shadow');
+    assert.equal(cfg.invalidRaw, '1');
+  });
+
+  it('"garbage" → mode=shadow + invalidRaw="garbage" (generic typo)', () => {
+    const cfg = readCooldownConfig({ DIGEST_COOLDOWN_MODE: 'garbage' });
+    assert.equal(cfg.mode, 'shadow');
+    assert.equal(cfg.invalidRaw, 'garbage');
+  });
+
+  it('case-folded typo: "ENFORCE" → mode=shadow + invalidRaw="enforce" (post-fold)', () => {
+    // The invalidRaw is post-fold lowercase — operators chasing a typo
+    // care about which value the parser saw, not the exact capitalisation.
+    const cfg = readCooldownConfig({ DIGEST_COOLDOWN_MODE: 'ENFORCE' });
+    assert.equal(cfg.mode, 'shadow');
+    assert.equal(cfg.invalidRaw, 'enforce');
+  });
+});
+
+describe('readCooldownMode — convenience accessor', () => {
+  it('returns just the mode (no invalidRaw)', () => {
+    assert.equal(readCooldownMode({}), 'shadow');
+    assert.equal(readCooldownMode({ DIGEST_COOLDOWN_MODE: 'off' }), 'off');
+    assert.equal(readCooldownMode({ DIGEST_COOLDOWN_MODE: 'enforce' }), 'shadow');
+  });
+
+  it('defaults env to process.env when unspecified', () => {
+    // Snapshot + restore so we don't pollute the rest of the suite.
+    const original = process.env.DIGEST_COOLDOWN_MODE;
+    try {
+      process.env.DIGEST_COOLDOWN_MODE = 'off';
+      assert.equal(readCooldownMode(), 'off');
+    } finally {
+      if (original === undefined) delete process.env.DIGEST_COOLDOWN_MODE;
+      else process.env.DIGEST_COOLDOWN_MODE = original;
+    }
+  });
+});
+
+describe('readCooldownConfig — purity contract', () => {
+  it('does not mutate the input env', () => {
+    const env = Object.freeze({ DIGEST_COOLDOWN_MODE: 'enforce' });
+    // assert.doesNotThrow because Object.freeze would throw on any
+    // mutation attempt — proving the parser is read-only.
+    assert.doesNotThrow(() => readCooldownConfig(env));
+  });
+
+  it('returns the same shape for the same input (deterministic)', () => {
+    const a = readCooldownConfig({ DIGEST_COOLDOWN_MODE: 'enforce' });
+    const b = readCooldownConfig({ DIGEST_COOLDOWN_MODE: 'enforce' });
+    assert.deepEqual(a, b);
+  });
+});

--- a/tests/digest-cooldown-decision.test.mjs
+++ b/tests/digest-cooldown-decision.test.mjs
@@ -21,6 +21,7 @@ import {
 } from '../scripts/lib/digest-cooldown-decision.mjs';
 
 const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
 const NOW = 1_777_000_000_000; // 2026-04-23-ish, deterministic
 
 describe('classifyStub — Rule 1: Analysis domains', () => {
@@ -467,6 +468,118 @@ describe('evaluateCooldown — hard floors (no evolution bypass)', () => {
       type: 'high-single-corporate', severity: 'critical', currentSourceCount: 4, currentTier: 'critical',
       lastDeliveredAt: NOW - 47 * HOUR_MS,
       lastDeliveredSourceCount: 2, lastDeliveredTier: 'high',
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'allow');
+    assert.equal(r.reason, REASON.SEVERITY_TIER_CHANGE);
+  });
+});
+
+// Greptile PR #3617 P2 — EVOLUTION_NEW_FACT bypass.
+//
+// Pre-fix: REASON.EVOLUTION_NEW_FACT was exported and allowNewFact
+// flags were set on COOLDOWN_TABLE cells, but no code path returned
+// the reason. Wire contract surface that nothing produced.
+//
+// Post-fix: when allowNewFact is true AND lastDeliveredHeadline is
+// present AND the current headline differs (case-insensitive,
+// whitespace-trimmed equality), the bypass fires.
+describe('evaluateCooldown — EVOLUTION_NEW_FACT bypass (Greptile PR #3617 P2)', () => {
+  it('high-event re-air at 6h (within 18h floor) WITH new headline → allow / evolution_new_fact', () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'high-event', severity: 'high', currentSourceCount: 3, currentTier: 'high',
+      lastDeliveredAt: NOW - 6 * HOUR_MS,
+      lastDeliveredSourceCount: 3, lastDeliveredTier: 'high',
+      lastDeliveredHeadline: 'Iran threatens to close Strait of Hormuz',
+      classifierInputs: {
+        sourceDomain: 'reuters.com',
+        headline: 'Iran fires missiles into Strait of Hormuz', // genuinely different fact
+      },
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'allow');
+    assert.equal(r.reason, REASON.EVOLUTION_NEW_FACT);
+  });
+
+  it('same headline (case-insensitive, whitespace-trimmed) → suppress (no bypass)', () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'high-event', severity: 'high', currentSourceCount: 3, currentTier: 'high',
+      lastDeliveredAt: NOW - 6 * HOUR_MS,
+      lastDeliveredSourceCount: 3, lastDeliveredTier: 'high',
+      lastDeliveredHeadline: '  Iran threatens to close Strait of Hormuz  ',
+      classifierInputs: {
+        sourceDomain: 'reuters.com',
+        headline: 'IRAN threatens to close Strait of Hormuz',
+      },
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'suppress');
+    assert.equal(r.reason, REASON.COOLDOWN_FLOOR);
+  });
+
+  it('lastDeliveredHeadline=null (older v4 row without the field) → no bypass, suppress as cooldown_floor', () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'high-event', severity: 'high', currentSourceCount: 3, currentTier: 'high',
+      lastDeliveredAt: NOW - 6 * HOUR_MS,
+      lastDeliveredSourceCount: 3, lastDeliveredTier: 'high',
+      lastDeliveredHeadline: null,
+      classifierInputs: { sourceDomain: 'reuters.com', headline: 'Some new headline' },
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'suppress');
+    assert.equal(r.reason, REASON.COOLDOWN_FLOOR);
+  });
+
+  it('analysis (allowNewFact=false) at 6d with NEW headline → still suppress (7d hard floor wins)', () => {
+    // The hard-floor classes have allowNewFact=false. New-fact bypass
+    // must NOT fire even when headlines differ.
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'analysis', severity: 'high', currentSourceCount: 1, currentTier: 'high',
+      lastDeliveredAt: NOW - 6 * DAY_MS,
+      lastDeliveredSourceCount: 1, lastDeliveredTier: 'high',
+      lastDeliveredHeadline: 'Original doctrine essay',
+      classifierInputs: {
+        sourceDomain: 'usni.org',
+        headline: 'Completely different doctrine essay headline',
+      },
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'suppress');
+    assert.equal(r.reason, REASON.ANALYSIS_7D_HARD);
+  });
+
+  it('high-single-corporate (allowNewFact=false) inside 48h with NEW headline → still suppress', () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'high-single-corporate', severity: 'high', currentSourceCount: 4, currentTier: 'high',
+      lastDeliveredAt: NOW - 24 * HOUR_MS,
+      lastDeliveredSourceCount: 2, lastDeliveredTier: 'high',
+      lastDeliveredHeadline: 'Hugo Boss tops profit forecasts',
+      classifierInputs: {
+        sourceDomain: 'reuters.com',
+        headline: 'Hugo Boss reports record Q3 results',
+      },
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'suppress');
+    assert.equal(r.reason, REASON.SINGLE_CORP_48H_HARD);
+  });
+
+  it('tier-change still wins precedence over new-fact bypass', () => {
+    // Order of bypass precedence: tier change → new fact → source count.
+    // A tier change AND a new headline both fire — tier change should
+    // win the reason since it's the strongest editorial signal.
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'high-event', severity: 'high', currentSourceCount: 3, currentTier: 'high',
+      lastDeliveredAt: NOW - 6 * HOUR_MS,
+      lastDeliveredSourceCount: 3, lastDeliveredTier: 'critical', // tier downgraded
+      lastDeliveredHeadline: 'Old headline',
+      classifierInputs: { sourceDomain: 'reuters.com', headline: 'New headline' },
       options: { mode: 'shadow', nowMs: NOW },
     });
     assert.equal(r.decision, 'allow');

--- a/tests/digest-cooldown-decision.test.mjs
+++ b/tests/digest-cooldown-decision.test.mjs
@@ -427,6 +427,37 @@ describe('evaluateCooldown — hard floors (no evolution bypass)', () => {
     assert.equal(r.reason, REASON.SINGLE_CORP_48H_HARD);
   });
 
+  // Codex PR #3617 P2 regression — high-single-corporate downgrade
+  // (HIGH→MEDIUM) inside 48h must NOT bypass the hard floor. Pre-fix
+  // the bypass triggered on any tier change; post-fix it requires
+  // strict escalation (currentTierRank > lastTierRank).
+  it('high-single-corporate at 47h WITH tier DOWNGRADE (high→medium) → suppress (Codex PR #3617 P2)', () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'high-single-corporate', severity: 'medium', currentSourceCount: 4, currentTier: 'medium',
+      lastDeliveredAt: NOW - 47 * HOUR_MS,
+      lastDeliveredSourceCount: 2, lastDeliveredTier: 'high',
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'suppress');
+    assert.equal(r.reason, REASON.SINGLE_CORP_48H_HARD);
+  });
+
+  it('high-event tier downgrade (critical→high) inside floor → STILL allow (symmetric tier change for non-corp classes)', () => {
+    // Non-single-corp classes retain the symmetric tier-change rule:
+    // a critical→high de-escalation IS editorial signal ("the situation
+    // cooled" is news worth re-airing).
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'high-event', severity: 'high', currentSourceCount: 3, currentTier: 'high',
+      lastDeliveredAt: NOW - 6 * HOUR_MS,
+      lastDeliveredSourceCount: 3, lastDeliveredTier: 'critical',
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'allow');
+    assert.equal(r.reason, REASON.SEVERITY_TIER_CHANGE);
+  });
+
   it('high-single-corporate at 47h WITH tier escalation (high→critical) → allow / severity_tier_change', () => {
     // The encoded "real follow-up event" trigger: a corporate-earnings
     // cluster that escalates to a higher tier (e.g. regulatory action

--- a/tests/digest-cooldown-decision.test.mjs
+++ b/tests/digest-cooldown-decision.test.mjs
@@ -59,6 +59,36 @@ describe('classifyStub — Rule 1: Analysis domains', () => {
   });
 });
 
+describe('classifyStub — Rule 1 host-shape coverage (Codex PR #3617 P2)', () => {
+  it('www-prefixed analysis domain: www.usni.org → analysis', () => {
+    assert.equal(classifyStub({ sourceDomain: 'www.usni.org', severity: 'high' }).type, 'analysis');
+  });
+
+  it('www-prefixed: www.nature.com → analysis', () => {
+    assert.equal(classifyStub({ sourceDomain: 'www.nature.com', severity: 'high' }).type, 'analysis');
+  });
+
+  it('subdomain: editorial.usni.org → analysis', () => {
+    assert.equal(classifyStub({ sourceDomain: 'editorial.usni.org', severity: 'high' }).type, 'analysis');
+  });
+
+  it('subdomain: media.brookings.edu → analysis (also covered by .edu suffix)', () => {
+    assert.equal(classifyStub({ sourceDomain: 'media.brookings.edu', severity: 'high' }).type, 'analysis');
+  });
+
+  it('false-positive guard: notmyusni.org does NOT match (suffix is `.${domain}`, not bare suffix)', () => {
+    // The fix uses .endsWith(`.${d}`) for subdomain matching, so a
+    // host that ends with the bare domain name without a dot
+    // separator (notmyusni.org) is correctly rejected.
+    const r = classifyStub({ sourceDomain: 'notmyusni.org', severity: 'high' });
+    assert.notEqual(r.type, 'analysis');
+  });
+
+  it('case-folded www-prefixed: WWW.USNI.ORG → analysis', () => {
+    assert.equal(classifyStub({ sourceDomain: 'WWW.USNI.ORG', severity: 'high' }).type, 'analysis');
+  });
+});
+
 describe('classifyStub — Rule 2: Government regulatory', () => {
   it('*.gov + LICENSE NO. → sanctions-regulatory', () => {
     const r = classifyStub({

--- a/tests/digest-cooldown-decision.test.mjs
+++ b/tests/digest-cooldown-decision.test.mjs
@@ -1,0 +1,474 @@
+// Sprint 1 / U5 — pure cooldown decision tests. The decision function
+// drives Sprint 2's enforce-mode behavior; these tests lock in the
+// table cells, the evolution-bypass triggers, and the
+// fail-closed-on-missing-classification telemetry shape that U6 replay
+// will read.
+//
+// Test layout:
+//   1. classifyStub — every rule path with its discriminating input
+//   2. evaluateCooldown — happy/edge/error matrix per the plan U5 list
+//   3. Mode='off' contract (decision === null per
+//      feedback_gate_on_ground_truth_not_configured_state)
+//   4. Cooldown table sanity (the cells the implementation depends on)
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  classifyStub,
+  evaluateCooldown,
+  REASON,
+  __COOLDOWN_TABLE,
+} from '../scripts/lib/digest-cooldown-decision.mjs';
+
+const HOUR_MS = 60 * 60 * 1000;
+const NOW = 1_777_000_000_000; // 2026-04-23-ish, deterministic
+
+describe('classifyStub — Rule 1: Analysis domains', () => {
+  it('exact match: usni.org → analysis', () => {
+    const r = classifyStub({ sourceDomain: 'usni.org', headline: 'Doctrine essay', severity: 'high' });
+    assert.equal(r.type, 'analysis');
+    assert.equal(r.classificationMissing, false);
+  });
+
+  it('exact match: csis.org, brookings.edu, nature.com, sciencemag.org → analysis', () => {
+    for (const d of ['csis.org', 'brookings.edu', 'nature.com', 'sciencemag.org']) {
+      const r = classifyStub({ sourceDomain: d, severity: 'high' });
+      assert.equal(r.type, 'analysis', `${d} should classify as analysis`);
+    }
+  });
+
+  it('suffix match: any *.edu → analysis', () => {
+    for (const d of ['mit.edu', 'stanford.edu', 'foo.bar.edu']) {
+      assert.equal(classifyStub({ sourceDomain: d, severity: 'high' }).type, 'analysis');
+    }
+  });
+
+  it('case-insensitive on domain', () => {
+    assert.equal(classifyStub({ sourceDomain: 'USNI.ORG', severity: 'high' }).type, 'analysis');
+  });
+
+  it('analysis domain wins even when headline matches single-corp regex', () => {
+    // A .edu publishing a "beat forecast" headline is still analysis,
+    // not corporate earnings. Order-of-precedence test.
+    const r = classifyStub({
+      sourceDomain: 'mit.edu',
+      headline: 'Q3 results: SuperCorp beats forecast on AI demand',
+      severity: 'high',
+    });
+    assert.equal(r.type, 'analysis');
+  });
+});
+
+describe('classifyStub — Rule 2: Government regulatory', () => {
+  it('*.gov + LICENSE NO. → sanctions-regulatory', () => {
+    const r = classifyStub({
+      sourceDomain: 'treasury.gov',
+      headline: 'OFAC GENERAL LICENSE NO. 58 Authorizing Certain Services',
+      severity: 'high',
+    });
+    assert.equal(r.type, 'sanctions-regulatory');
+    assert.equal(r.classificationMissing, false);
+  });
+
+  it('*.gov + Final Rule → sanctions-regulatory', () => {
+    const r = classifyStub({
+      sourceDomain: 'sec.gov',
+      headline: 'Final Rule on Climate Disclosure',
+      severity: 'high',
+    });
+    assert.equal(r.type, 'sanctions-regulatory');
+  });
+
+  it('*.gov + Notice of → sanctions-regulatory', () => {
+    const r = classifyStub({
+      sourceDomain: 'commerce.gov',
+      headline: 'Notice of Inquiry on AI Diffusion',
+      severity: 'high',
+    });
+    assert.equal(r.type, 'sanctions-regulatory');
+  });
+
+  it('*.gov.uk + LICENSE NO. → sanctions-regulatory', () => {
+    const r = classifyStub({
+      sourceDomain: 'foreign.gov.uk',
+      headline: 'GENERAL LICENSE NO. 12 — UK sanctions',
+      severity: 'high',
+    });
+    assert.equal(r.type, 'sanctions-regulatory');
+  });
+
+  it('*.gov + non-regulatory headline → falls through (NOT sanctions-regulatory)', () => {
+    const r = classifyStub({
+      sourceDomain: 'whitehouse.gov',
+      headline: 'President addresses the nation',
+      severity: 'high',
+    });
+    assert.notEqual(r.type, 'sanctions-regulatory');
+  });
+});
+
+describe('classifyStub — Rule 3: Single-corporate earnings', () => {
+  it('"X tops forecast" → high-single-corporate (regardless of domain)', () => {
+    const r = classifyStub({
+      sourceDomain: 'reuters.com',
+      headline: 'Hugo Boss tops profit forecasts',
+      severity: 'high',
+    });
+    assert.equal(r.type, 'high-single-corporate');
+  });
+
+  it('"X beat estimate" → high-single-corporate (regex anchors on bare verb form)', () => {
+    // The regex is /\b(beat|miss|tops|exceeds)\s+(forecast|estimate|profit)/i —
+    // matches the verb directly adjacent to the noun, no intervening words.
+    // Conservative on purpose: a future Sprint-3 classifier broadens this.
+    assert.equal(classifyStub({
+      sourceDomain: 'bloomberg.com',
+      headline: 'NVIDIA beat estimate handily on AI demand',
+      severity: 'high',
+    }).type, 'high-single-corporate');
+  });
+
+  it('"X exceeds forecast" → high-single-corporate', () => {
+    assert.equal(classifyStub({
+      sourceDomain: 'ft.com',
+      headline: 'Apple exceeds forecast on services growth',
+      severity: 'high',
+    }).type, 'high-single-corporate');
+  });
+
+  it('"X miss profit" → high-single-corporate', () => {
+    assert.equal(classifyStub({
+      sourceDomain: 'wsj.com',
+      headline: 'Tesla miss profit guidance',
+      severity: 'high',
+    }).type, 'high-single-corporate');
+  });
+
+  it('case-insensitive on headline', () => {
+    assert.equal(classifyStub({
+      sourceDomain: 'reuters.com',
+      headline: 'HUGO BOSS BEAT FORECAST',
+      severity: 'high',
+    }).type, 'high-single-corporate');
+  });
+
+  it('"beats" (3rd person) does NOT match — known regex limitation flagged for Sprint 3', () => {
+    // The current regex matches the bare verb form ('beat' not 'beats').
+    // Real-world Reuters/Bloomberg headlines use 'beats'/'misses'/etc more
+    // often, so this is a known false-negative for Sprint 1's stub.
+    // Sprint 3's full classifier ships a broader regex; for now we lock
+    // the current contract so a future change to extend coverage flips
+    // this test naturally.
+    const r = classifyStub({
+      sourceDomain: 'reuters.com',
+      headline: 'Hugo Boss beats forecast',
+      severity: 'high',
+    });
+    // Falls through to severity-derived 'high-event' (severity='high').
+    assert.equal(r.type, 'high-event');
+    assert.equal(r.classificationMissing, false);
+  });
+
+  it('false-positive guard: "company beat its own internal goal" → does NOT classify single-corp', () => {
+    // The regex is anchored to the verb-noun pair (beat|miss|tops|exceeds + forecast|estimate|profit).
+    // An internal-goal headline doesn't match.
+    const r = classifyStub({
+      sourceDomain: 'reuters.com',
+      headline: 'Hugo Boss beat its own internal sales goal',
+      severity: 'high',
+    });
+    assert.notEqual(r.type, 'high-single-corporate');
+  });
+});
+
+describe('classifyStub — Rule 4: Severity-derived fallback', () => {
+  it('severity=critical → critical-developing', () => {
+    const r = classifyStub({ sourceDomain: 'reuters.com', headline: 'Iran strikes Hormuz', severity: 'critical' });
+    assert.equal(r.type, 'critical-developing');
+    assert.equal(r.classificationMissing, false);
+  });
+
+  it('severity=high → high-event', () => {
+    assert.equal(classifyStub({
+      sourceDomain: 'reuters.com',
+      headline: 'Cabinet shuffle in Berlin',
+      severity: 'high',
+    }).type, 'high-event');
+  });
+
+  it('severity=medium → med', () => {
+    assert.equal(classifyStub({
+      sourceDomain: 'reuters.com',
+      headline: 'Trade talks resume',
+      severity: 'medium',
+    }).type, 'med');
+  });
+});
+
+describe('classifyStub — Rule 5: Missing classification fallback', () => {
+  it('no domain, no headline, no severity → high-event default + classificationMissing=true', () => {
+    const r = classifyStub({});
+    assert.equal(r.type, 'high-event');
+    assert.equal(r.classificationMissing, true);
+  });
+
+  it('unknown severity ("low") with no other rule match → high-event + classificationMissing=true', () => {
+    const r = classifyStub({ sourceDomain: 'example.com', headline: 'Unknown topic', severity: 'low' });
+    assert.equal(r.type, 'high-event');
+    assert.equal(r.classificationMissing, true);
+  });
+});
+
+describe('evaluateCooldown — mode contract', () => {
+  it("mode='off' → null (no decision artifact, observers see 'cooldown not consulted')", () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: '2026-05-06-2001', clusterId: 'c1', channel: 'email', ruleId: 'full:en:high',
+      type: 'high-event',
+      severity: 'high', currentSourceCount: 5, currentTier: 'high',
+      lastDeliveredAt: null, lastDeliveredSourceCount: null, lastDeliveredTier: null,
+      options: { mode: 'off', nowMs: NOW },
+    });
+    assert.equal(r, null);
+  });
+
+  it("mode='shadow' (default) → produces a decision artifact", () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'high-event', severity: 'high', currentSourceCount: 5, currentTier: 'high',
+      lastDeliveredAt: null,
+      options: { nowMs: NOW },
+    });
+    assert.notEqual(r, null);
+    assert.equal(r.decision, 'allow');
+  });
+});
+
+describe('evaluateCooldown — no prior delivery (first send)', () => {
+  it('lastDeliveredAt=null → allow, reason=no_prior_delivery', () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'high-event', severity: 'high', currentSourceCount: 5, currentTier: 'high',
+      lastDeliveredAt: null,
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'allow');
+    assert.equal(r.reason, REASON.NO_PRIOR_DELIVERY);
+    assert.equal(r.evolutionDelta.hoursSinceLastDelivery, null);
+  });
+
+  it('lastDeliveredAt=undefined → also treated as no prior delivery', () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'high-event', severity: 'high', currentSourceCount: 5, currentTier: 'high',
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'allow');
+    assert.equal(r.reason, REASON.NO_PRIOR_DELIVERY);
+  });
+});
+
+describe('evaluateCooldown — within-floor suppression (no evolution)', () => {
+  it('high-event re-air at 6h post-delivery → suppress (18h floor, no evolution)', () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'high-event', severity: 'high', currentSourceCount: 3, currentTier: 'high',
+      lastDeliveredAt: NOW - 6 * HOUR_MS,
+      lastDeliveredSourceCount: 3, lastDeliveredTier: 'high',
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'suppress');
+    assert.equal(r.reason, REASON.COOLDOWN_FLOOR);
+    assert.equal(r.cooldownHours, 18);
+  });
+
+  it('med re-air at 12h post-delivery → suppress (36h floor)', () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'med', severity: 'medium', currentSourceCount: 2, currentTier: 'medium',
+      lastDeliveredAt: NOW - 12 * HOUR_MS,
+      lastDeliveredSourceCount: 2, lastDeliveredTier: 'medium',
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'suppress');
+    assert.equal(r.reason, REASON.COOLDOWN_FLOOR);
+    assert.equal(r.cooldownHours, 36);
+  });
+
+  it('beyond floor → allow (cooldown_floor as the elapsed reason)', () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'high-event', severity: 'high', currentSourceCount: 3, currentTier: 'high',
+      lastDeliveredAt: NOW - 19 * HOUR_MS, // > 18h floor
+      lastDeliveredSourceCount: 3, lastDeliveredTier: 'high',
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'allow');
+    assert.equal(r.reason, REASON.COOLDOWN_FLOOR);
+  });
+});
+
+describe('evaluateCooldown — evolution bypasses (within floor)', () => {
+  it('+5 sources within floor on a soft-floor type → allow / evolution_source_count', () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'high-event', severity: 'high', currentSourceCount: 8, currentTier: 'high',
+      lastDeliveredAt: NOW - 6 * HOUR_MS, // within 18h floor
+      lastDeliveredSourceCount: 3, lastDeliveredTier: 'high',
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'allow');
+    assert.equal(r.reason, REASON.EVOLUTION_SOURCE_COUNT);
+    assert.equal(r.evolutionDelta.sourceCountDelta, 5);
+  });
+
+  it('+4 sources within floor → still suppressed (delta < threshold of 5)', () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'high-event', severity: 'high', currentSourceCount: 7, currentTier: 'high',
+      lastDeliveredAt: NOW - 6 * HOUR_MS,
+      lastDeliveredSourceCount: 3, lastDeliveredTier: 'high',
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'suppress');
+    assert.equal(r.reason, REASON.COOLDOWN_FLOOR);
+  });
+
+  it('severity tier change (CRITICAL→HIGH) within floor → allow / severity_tier_change', () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'critical-developing', severity: 'high', currentSourceCount: 3, currentTier: 'high',
+      lastDeliveredAt: NOW - 2 * HOUR_MS, // within 4h floor
+      lastDeliveredSourceCount: 3, lastDeliveredTier: 'critical',
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'allow');
+    assert.equal(r.reason, REASON.SEVERITY_TIER_CHANGE);
+    assert.equal(r.evolutionDelta.tierChanged, true);
+  });
+
+  it('tier change has higher precedence than source count (both true)', () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'high-event', severity: 'high', currentSourceCount: 8, currentTier: 'critical',
+      lastDeliveredAt: NOW - 2 * HOUR_MS,
+      lastDeliveredSourceCount: 3, lastDeliveredTier: 'high',
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'allow');
+    assert.equal(r.reason, REASON.SEVERITY_TIER_CHANGE);
+  });
+});
+
+describe('evaluateCooldown — hard floors (no evolution bypass)', () => {
+  it('Analysis re-air at 6d → suppress (7d hard, never bypass)', () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'analysis', severity: 'high', currentSourceCount: 50, currentTier: 'critical', // huge evolution attempt
+      lastDeliveredAt: NOW - 6 * 24 * HOUR_MS,
+      lastDeliveredSourceCount: 1, lastDeliveredTier: 'high',
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'suppress');
+    assert.equal(r.reason, REASON.ANALYSIS_7D_HARD);
+    assert.equal(r.cooldownHours, 168); // 7 * 24
+  });
+
+  it('Analysis re-air at 7.1d → allow (beyond hard floor)', () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'analysis', severity: 'high', currentSourceCount: 1, currentTier: 'high',
+      lastDeliveredAt: NOW - 7.1 * 24 * HOUR_MS,
+      lastDeliveredSourceCount: 1, lastDeliveredTier: 'high',
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'allow');
+    assert.equal(r.reason, REASON.COOLDOWN_FLOOR);
+  });
+
+  it('high-single-corporate re-air at 47h with +10 sources → suppress (48h hard, no source-count bypass)', () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'high-single-corporate', severity: 'high', currentSourceCount: 12, currentTier: 'high',
+      lastDeliveredAt: NOW - 47 * HOUR_MS,
+      lastDeliveredSourceCount: 2, lastDeliveredTier: 'high',
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'suppress');
+    assert.equal(r.reason, REASON.SINGLE_CORP_48H_HARD);
+  });
+
+  it('high-single-corporate at 47h WITH tier escalation (high→critical) → allow / severity_tier_change', () => {
+    // The encoded "real follow-up event" trigger: a corporate-earnings
+    // cluster that escalates to a higher tier (e.g. regulatory action
+    // following the earnings beat).
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'high-single-corporate', severity: 'critical', currentSourceCount: 4, currentTier: 'critical',
+      lastDeliveredAt: NOW - 47 * HOUR_MS,
+      lastDeliveredSourceCount: 2, lastDeliveredTier: 'high',
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'allow');
+    assert.equal(r.reason, REASON.SEVERITY_TIER_CHANGE);
+  });
+});
+
+describe('evaluateCooldown — classification-missing telemetry', () => {
+  it('missing classification → falls back to high-event (18h) with classificationMissing flag', () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      // no `type` and no `classifierInputs.severity` → stub returns
+      // classificationMissing=true
+      severity: undefined, currentSourceCount: 3, currentTier: 'high',
+      lastDeliveredAt: null,
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.decision, 'allow');
+    assert.equal(r.reason, REASON.CLASSIFICATION_MISSING_DEFAULT_HIGH);
+    assert.equal(r.classifiedType, 'high-event');
+    assert.equal(r.classificationMissing, true);
+    assert.equal(r.cooldownHours, 18);
+  });
+
+  it('classifier-supplied type bypasses the stub', () => {
+    const r = evaluateCooldown({
+      userId: 'u', slot: 's', clusterId: 'c', channel: 'email', ruleId: 'r',
+      type: 'analysis', // explicit type wins over classifierInputs
+      classifierInputs: { sourceDomain: 'reuters.com', headline: 'X tops forecast' },
+      severity: 'high', currentSourceCount: 3, currentTier: 'high',
+      lastDeliveredAt: null,
+      options: { mode: 'shadow', nowMs: NOW },
+    });
+    assert.equal(r.classifiedType, 'analysis');
+    assert.equal(r.classificationMissing, false);
+  });
+});
+
+describe('cooldown table sanity — implementation invariants', () => {
+  it('every type has a valid cell with hours, hard, and the three allow* flags', () => {
+    for (const [type, cell] of Object.entries(__COOLDOWN_TABLE)) {
+      assert.equal(typeof cell.hours, 'number', `${type}: hours must be a number`);
+      assert.ok(cell.hours > 0, `${type}: hours must be positive`);
+      assert.equal(typeof cell.hard, 'boolean', `${type}: hard must be a boolean`);
+      assert.equal(typeof cell.allowSourceCountEvolution, 'boolean', `${type}: allowSourceCountEvolution must be a boolean`);
+      assert.equal(typeof cell.allowNewFact, 'boolean', `${type}: allowNewFact must be a boolean`);
+      assert.equal(typeof cell.allowTierChange, 'boolean', `${type}: allowTierChange must be a boolean`);
+    }
+  });
+
+  it('hard-floor types disable source-count evolution (the hard contract)', () => {
+    assert.equal(__COOLDOWN_TABLE['analysis'].hard, true);
+    assert.equal(__COOLDOWN_TABLE['analysis'].allowSourceCountEvolution, false);
+    assert.equal(__COOLDOWN_TABLE['high-single-corporate'].hard, true);
+    assert.equal(__COOLDOWN_TABLE['high-single-corporate'].allowSourceCountEvolution, false);
+  });
+
+  it('floor values match the plan table (snapshot guard)', () => {
+    assert.equal(__COOLDOWN_TABLE['critical-developing'].hours, 4);
+    assert.equal(__COOLDOWN_TABLE['critical-sustained'].hours, 24);
+    assert.equal(__COOLDOWN_TABLE['high-event'].hours, 18);
+    assert.equal(__COOLDOWN_TABLE['high-single-corporate'].hours, 48);
+    assert.equal(__COOLDOWN_TABLE['analysis'].hours, 7 * 24);
+    assert.equal(__COOLDOWN_TABLE['med'].hours, 36);
+  });
+});

--- a/tests/digest-delivered-log.test.mjs
+++ b/tests/digest-delivered-log.test.mjs
@@ -526,6 +526,83 @@ describe('clear-delivered-entry — argument parsing', () => {
     assert.equal(r1.kind, 'err');
     assert.match(r1.message, /requires a non-empty value/);
   });
+
+  // Codex PR #3617 P1 — Redis SCAN glob-injection guard.
+  // The sweep-mode pattern is `digest:sent:v1:${user}:*:*:${cluster}`.
+  // If user OR cluster contains glob metacharacters (* ? [ ] \), the
+  // pattern broadens and the followup DEL loop wipes far more rows
+  // than the operator intended. Guard at parse time.
+  it('rejects --cluster value containing * (Redis glob char)', () => {
+    const r = parseArgs(['--user', 'u', '--slot', 's', '--cluster', '*', '--reason', 'oops']);
+    assert.equal(r.kind, 'err');
+    assert.match(r.message, /glob metacharacter/);
+    assert.match(r.message, /--cluster/);
+  });
+
+  it('rejects --cluster value containing prefix wildcard (foo*)', () => {
+    const r = parseArgs(['--user', 'u', '--slot', 's', '--cluster', 'foo*', '--reason', 'oops']);
+    assert.equal(r.kind, 'err');
+    assert.match(r.message, /glob metacharacter/);
+  });
+
+  it('rejects --user value containing * (would broaden across users)', () => {
+    const r = parseArgs(['--user', 'u*', '--slot', 's', '--cluster', 'c', '--reason', 'oops']);
+    assert.equal(r.kind, 'err');
+    assert.match(r.message, /--user/);
+    assert.match(r.message, /glob metacharacter/);
+  });
+
+  it('rejects --cluster value containing ? (single-char wildcard)', () => {
+    const r = parseArgs(['--user', 'u', '--slot', 's', '--cluster', 'c?', '--reason', 'oops']);
+    assert.equal(r.kind, 'err');
+    assert.match(r.message, /glob metacharacter/);
+  });
+
+  it('rejects --cluster value containing [ (character class)', () => {
+    const r = parseArgs(['--user', 'u', '--slot', 's', '--cluster', 'c[ab]', '--reason', 'oops']);
+    assert.equal(r.kind, 'err');
+    assert.match(r.message, /glob metacharacter/);
+  });
+
+  it('rejects --cluster value containing \\ (escape char)', () => {
+    const r = parseArgs(['--user', 'u', '--slot', 's', '--cluster', 'c\\x', '--reason', 'oops']);
+    assert.equal(r.kind, 'err');
+    assert.match(r.message, /glob metacharacter/);
+  });
+
+  it('rejects --channel containing glob char (even though channel is from a fixed set, defence-in-depth)', () => {
+    const r = parseArgs(['--user', 'u', '--slot', 's', '--cluster', 'c', '--channel', 'em*', '--rule', 'r', '--reason', 'oops']);
+    assert.equal(r.kind, 'err');
+    assert.match(r.message, /glob metacharacter|--channel must be one of/);
+  });
+
+  it('rejects --rule containing glob char', () => {
+    const r = parseArgs(['--user', 'u', '--slot', 's', '--cluster', 'c', '--channel', 'email', '--rule', 'full:*:high', '--reason', 'oops']);
+    assert.equal(r.kind, 'err');
+    assert.match(r.message, /glob metacharacter/);
+  });
+
+  it('--reason is exempt (audit log, never reaches Redis pattern)', () => {
+    // Operators may legitimately put glob chars in a reason string
+    // (e.g. "duplicate * in test fixture"). The reason is logged but
+    // never substituted into the SCAN pattern, so it's safe.
+    const r = parseArgs(['--user', 'u', '--slot', 's', '--cluster', 'c', '--reason', 'wildcard * cleanup']);
+    assert.equal(r.kind, 'ok');
+  });
+
+  it('legitimate values with `:` and `-` still parse cleanly (regression guard)', () => {
+    // The glob-char regex is /[*?[\]\\]/ — must not over-match into
+    // the legitimate ruleId-composite separator `:` or hash-id `-`.
+    const r = parseArgs([
+      '--user', 'user-abc-123',
+      '--slot', '2026-05-06-2001',
+      '--cluster', 'cluster-rep-hash-deadbeef',
+      '--channel', 'email',
+      '--rule', 'full:en:high',
+      '--reason', 'cleanup',
+    ]);
+    assert.equal(r.kind, 'ok');
+  });
 });
 
 describe('clear-delivered-entry — key shape helpers', () => {

--- a/tests/digest-delivered-log.test.mjs
+++ b/tests/digest-delivered-log.test.mjs
@@ -213,6 +213,46 @@ describe('writeDeliveredEntry — happy path', () => {
     assert.deepEqual(JSON.parse(sentValue), { sentAt: 42, sourceCount: 7, severity: 'critical' });
   });
 
+  // Greptile PR #3617 P2 — headline persistence for EVOLUTION_NEW_FACT.
+  it('persists headline when caller provides it (drives U5 new-fact bypass next tick)', async () => {
+    const pipeline = mockPipeline();
+    await writeDeliveredEntry({
+      userId: 'u', channel: 'email', ruleId: 'r', clusterId: 'c',
+      sentAt: 42, sourceCount: 7, severity: 'critical',
+      headline: 'Iran threatens to close Strait of Hormuz',
+      deps: { redisPipeline: pipeline.impl, randomFn: () => 0 },
+    });
+    const parsed = JSON.parse(pipeline.calls[0][0][2]);
+    assert.equal(parsed.headline, 'Iran threatens to close Strait of Hormuz');
+  });
+
+  it('omits headline field when caller passes empty string (forward-compat: no field at all)', async () => {
+    // Older readers must not see an unexpected empty-string headline
+    // and trip a "headline must be non-empty" check later. Cleanest
+    // forward-compat: omit the field entirely when absent on write.
+    const pipeline = mockPipeline();
+    await writeDeliveredEntry({
+      userId: 'u', channel: 'email', ruleId: 'r', clusterId: 'c',
+      sentAt: 42, sourceCount: 7, severity: 'critical',
+      headline: '',
+      deps: { redisPipeline: pipeline.impl, randomFn: () => 0 },
+    });
+    const parsed = JSON.parse(pipeline.calls[0][0][2]);
+    assert.equal(parsed.headline, undefined, 'empty-string headline must not be persisted');
+  });
+
+  it('omits headline field when caller does not pass headline at all (call-site back-compat)', async () => {
+    const pipeline = mockPipeline();
+    await writeDeliveredEntry({
+      userId: 'u', channel: 'email', ruleId: 'r', clusterId: 'c',
+      sentAt: 42, sourceCount: 7, severity: 'critical',
+      // no `headline` arg
+      deps: { redisPipeline: pipeline.impl, randomFn: () => 0 },
+    });
+    const parsed = JSON.parse(pipeline.calls[0][0][2]);
+    assert.equal(parsed.headline, undefined);
+  });
+
   it('writes to every channel in ALLOWED_CHANNELS', async () => {
     for (const ch of ALLOWED_CHANNELS) {
       const pipeline = mockPipeline();

--- a/tests/digest-delivered-log.test.mjs
+++ b/tests/digest-delivered-log.test.mjs
@@ -576,10 +576,15 @@ describe('clear-delivered-entry — argument parsing', () => {
     assert.match(r.message, /glob metacharacter|--channel must be one of/);
   });
 
-  it('rejects --rule containing glob char', () => {
+  // Codex PR #3617 P2 update — exact-DEL mode (both --channel + --rule)
+  // accepts glob chars in --rule because the resulting key is DEL'd
+  // literally (Redis treats DEL args as exact strings, not patterns).
+  // The pre-fix test rejected this case; the post-fix contract allows
+  // it for legitimate ruleId composites that may contain `?` etc.
+  it('exact-DEL mode (--channel + --rule) accepts --rule with glob char (post-Codex-P2)', () => {
     const r = parseArgs(['--user', 'u', '--slot', 's', '--cluster', 'c', '--channel', 'email', '--rule', 'full:*:high', '--reason', 'oops']);
-    assert.equal(r.kind, 'err');
-    assert.match(r.message, /glob metacharacter/);
+    assert.equal(r.kind, 'ok');
+    assert.equal(r.args.rule, 'full:*:high');
   });
 
   it('--reason is exempt (audit log, never reaches Redis pattern)', () => {
@@ -588,6 +593,56 @@ describe('clear-delivered-entry — argument parsing', () => {
     // never substituted into the SCAN pattern, so it's safe.
     const r = parseArgs(['--user', 'u', '--slot', 's', '--cluster', 'c', '--reason', 'wildcard * cleanup']);
     assert.equal(r.kind, 'ok');
+  });
+
+  // Codex PR #3617 P2 — exact-DEL mode must accept glob chars.
+  // Legitimate clusterIds can be the level-3 fallback `url:${sourceUrl}`
+  // (shared/brief-filter.js:300) and real URLs commonly contain `?` for
+  // query strings. Rejecting these in exact-DEL mode would make those
+  // delivered-log rows unrecoverable via this primitive. The guard is
+  // sweep-mode-only (no --channel + no --rule).
+  it('exact-DEL mode (--channel + --rule) accepts cluster with ? (URL-fallback clusterIds)', () => {
+    const r = parseArgs([
+      '--user', 'u',
+      '--slot', 's',
+      '--cluster', 'url:https://example.com/article?ref=rss',
+      '--channel', 'email',
+      '--rule', 'full:en:high',
+      '--reason', 'cleanup-of-rss-fallback',
+    ]);
+    assert.equal(r.kind, 'ok', `expected exact-DEL with ? in clusterId to parse OK, got: ${JSON.stringify(r)}`);
+    assert.equal(r.args.cluster, 'url:https://example.com/article?ref=rss');
+  });
+
+  it('exact-DEL mode accepts cluster with bracket chars (deep URL paths)', () => {
+    const r = parseArgs([
+      '--user', 'u',
+      '--slot', 's',
+      '--cluster', 'url:https://example.com/[breaking]/article',
+      '--channel', 'email',
+      '--rule', 'full:en:high',
+      '--reason', 'cleanup-of-bracketed-url',
+    ]);
+    assert.equal(r.kind, 'ok');
+  });
+
+  it('sweep mode (no --channel/--rule) STILL rejects glob chars in cluster (regression guard for the original Codex P1)', () => {
+    const r = parseArgs([
+      '--user', 'u',
+      '--slot', 's',
+      '--cluster', 'url:https://example.com/article?ref=rss',
+      '--reason', 'cleanup',
+    ]);
+    assert.equal(r.kind, 'err');
+    assert.match(r.message, /sweep mode/);
+    assert.match(r.message, /exact-DEL mode by also passing/);
+  });
+
+  it('sweep mode rejects --user with * (still guarded)', () => {
+    const r = parseArgs(['--user', 'u*', '--slot', 's', '--cluster', 'c', '--reason', 'oops']);
+    assert.equal(r.kind, 'err');
+    assert.match(r.message, /--user/);
+    assert.match(r.message, /sweep mode/);
   });
 
   it('legitimate values with `:` and `-` still parse cleanly (regression guard)', () => {

--- a/tests/digest-delivered-log.test.mjs
+++ b/tests/digest-delivered-log.test.mjs
@@ -194,7 +194,9 @@ describe('writeDeliveredEntry — happy path', () => {
       'SET',
       'digest:sent:v1:user_abc:email:full:en:high:cluster-1',
       JSON.stringify({ sentAt: 1_700_000_000_000, sourceCount: 4, severity: 'high' }),
-      'NX',
+      // Codex PR #3617 round-4 P1 — SET (overwrite) semantics, NOT
+      // SET NX. Every successful send refreshes the row so subsequent
+      // cooldown reads see the most recent delivery.
       'EX',
       String(2_592_000 + Math.floor(0.5 * 259_200)),
     ]]);
@@ -226,27 +228,18 @@ describe('writeDeliveredEntry — happy path', () => {
   });
 });
 
-// ── writeDeliveredEntry — idempotency / conflict ───────────────────────────────
+// ── writeDeliveredEntry — refresh semantics (Codex PR #3617 round-4 P1) ────────
 
-describe('writeDeliveredEntry — idempotency via SET NX EX', () => {
-  it('second write of same key → { written: 0, conflicts: 1, errors: 0 } (NX rejected)', async () => {
-    const pipeline = mockPipeline({ responses: [{ result: null }] });
-    const result = await writeDeliveredEntry({
-      userId: 'u', channel: 'email', ruleId: 'r', clusterId: 'c',
-      sentAt: 1, sourceCount: 1, severity: 'high',
-      deps: { redisPipeline: pipeline.impl },
-    });
-    assert.deepEqual(result, {
-      written: 0,
-      conflicts: 1,
-      errors: 0,
-      key: 'digest:sent:v1:u:email:r:c',
-    });
-  });
+describe('writeDeliveredEntry — refresh-on-write semantics (post-Codex round-4 P1)', () => {
+  // Pre-fix used SET NX so the row stuck to its first value forever.
+  // After a high-event re-air was ALLOWED at 19h, the Redis row still
+  // pointed to T0 — so the next re-air at 20h saw "20h beyond 18h
+  // floor → allow" instead of "1h since last delivery → suppress".
+  // Post-fix: every successful send overwrites the row.
 
-  it('back-to-back writes: first OK then NX-collide → counters land at written=1, conflicts=1', async () => {
-    let call = 0;
-    const impl = async () => (call++ === 0 ? [{ result: 'OK' }] : [{ result: null }]);
+  it('back-to-back writes both succeed → counters land at written=2, conflicts=0', async () => {
+    // Both writes return OK under SET semantics (overwrite is fine).
+    const impl = async () => [{ result: 'OK' }];
     const r1 = await writeDeliveredEntry({
       userId: 'u', channel: 'email', ruleId: 'r', clusterId: 'c',
       sentAt: 1, sourceCount: 1, severity: 'high',
@@ -258,7 +251,49 @@ describe('writeDeliveredEntry — idempotency via SET NX EX', () => {
       deps: { redisPipeline: impl },
     });
     const agg = aggregateResults([r1, r2]);
-    assert.deepEqual(agg, { written: 1, conflicts: 1, errors: 0 });
+    // Post-fix: both writes succeed, conflicts always 0 under SET.
+    assert.deepEqual(agg, { written: 2, conflicts: 0, errors: 0 });
+  });
+
+  it('writer issues SET (NOT SET NX) — NX would lock the row to first value forever', async () => {
+    const pipeline = mockPipeline();
+    await writeDeliveredEntry({
+      userId: 'u', channel: 'email', ruleId: 'r', clusterId: 'c',
+      sentAt: 1, sourceCount: 1, severity: 'high',
+      deps: { redisPipeline: pipeline.impl, randomFn: () => 0 },
+    });
+    const cmd = pipeline.calls[0][0];
+    // Verify the literal command shape — must NOT include 'NX'.
+    assert.equal(cmd[0], 'SET');
+    assert.equal(cmd[3], 'EX', `expected SET ... EX (not SET ... NX). Got: ${JSON.stringify(cmd)}`);
+    assert.notEqual(cmd[3], 'NX', 'NX would lock the row; refresh requires plain SET');
+  });
+
+  it('refreshing the row updates {sentAt, sourceCount, severity} on each write', async () => {
+    // Two writes for the same key with different values. Pre-fix the
+    // second write was a no-op (NX). Post-fix the second value is what
+    // a downstream cooldown read would see.
+    const pipeline = mockPipeline();
+    await writeDeliveredEntry({
+      userId: 'u', channel: 'email', ruleId: 'r', clusterId: 'c',
+      sentAt: 1_700_000_000_000, sourceCount: 3, severity: 'high',
+      deps: { redisPipeline: pipeline.impl },
+    });
+    await writeDeliveredEntry({
+      userId: 'u', channel: 'email', ruleId: 'r', clusterId: 'c',
+      sentAt: 1_700_000_069_000, // 19h later
+      sourceCount: 8, // +5 sources evolution
+      severity: 'critical',
+      deps: { redisPipeline: pipeline.impl },
+    });
+    // Both writes were issued (refresh, not skip).
+    assert.equal(pipeline.calls.length, 2);
+    // Second write carries the updated value — this is what makes the
+    // subsequent cooldown read see lastDeliveredAt = 1700000069000.
+    const secondValue = JSON.parse(pipeline.calls[1][0][2]);
+    assert.equal(secondValue.sentAt, 1_700_000_069_000);
+    assert.equal(secondValue.sourceCount, 8);
+    assert.equal(secondValue.severity, 'critical');
   });
 });
 

--- a/tests/digest-delivered-log.test.mjs
+++ b/tests/digest-delivered-log.test.mjs
@@ -1,0 +1,660 @@
+/**
+ * Sprint 1 / U4 — tests for the per-channel/per-cluster delivered-log writer.
+ *
+ * Contract being verified (full rationale lives in the writer's module
+ * docblock at scripts/lib/digest-delivered-log.mjs — JSDoc and code
+ * comments here reference back to that header rather than re-stating it):
+ *
+ *   1. Key shape is `digest:sent:v1:${userId}:${channel}:${ruleId}:${clusterId}`
+ *      with EVERY discriminator explicit. No fallback collapse.
+ *   2. Value is `JSON.stringify({ sentAt, sourceCount, severity })` —
+ *      U5's cooldown evaluator's read contract.
+ *   3. TTL = 30d base + uniform random jitter [0, 3d) — prevents
+ *      synchronized cliff expiry of every key 30d after first deploy.
+ *   4. SET NX EX in JSON-body pipeline form — idempotent without
+ *      write-then-reread. Caller trusts the boolean response.
+ *   5. Tri-state result `{written, conflicts, errors}`. Caller MUST
+ *      early-return on errors > 0 BEFORE any subsequent stamp/log.
+ *   6. Empty / invalid key components throw BEFORE the network call —
+ *      malformed keys never reach Upstash.
+ *
+ * Run: node --test tests/digest-delivered-log.test.mjs
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  ALLOWED_CHANNELS,
+  aggregateResults,
+  buildDeliveredLogKey,
+  computeTtlSecondsWithJitter,
+  writeDeliveredEntry,
+} from '../scripts/lib/digest-delivered-log.mjs';
+import {
+  buildScanPattern,
+  buildSingleKey,
+  parseArgs,
+  runClear,
+} from '../scripts/clear-delivered-entry.mjs';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Programmable Upstash pipeline mock. Records every commands payload
+ * (pipeline takes Array<unknown[]>) and returns a fixed cell sequence.
+ *
+ * Default cell = { result: 'OK' } (success / new write). Override per
+ * test via `responses` to drive conflict / error branches.
+ *
+ * Set `throwOnce: true` to simulate a transient fetch reject — the
+ * writer should map this to errors=1 and not surface the throw.
+ */
+function mockPipeline({ responses = [{ result: 'OK' }], throwOnce = false } = {}) {
+  const calls = [];
+  let didThrow = false;
+  const impl = async (commands) => {
+    calls.push(commands);
+    if (throwOnce && !didThrow) {
+      didThrow = true;
+      throw new Error('mock pipeline transient throw');
+    }
+    return responses;
+  };
+  return { impl, calls };
+}
+
+/** Deterministic random source for jitter tests. */
+function seqRandom(values) {
+  let i = 0;
+  return () => {
+    const v = values[i % values.length];
+    i++;
+    return v;
+  };
+}
+
+// ── buildDeliveredLogKey ───────────────────────────────────────────────────────
+
+describe('buildDeliveredLogKey — key shape + validation', () => {
+  it('produces digest:sent:v1:{userId}:{channel}:{ruleId}:{clusterId}', () => {
+    const k = buildDeliveredLogKey({
+      userId: 'user_abc',
+      channel: 'email',
+      ruleId: 'full:en:high',
+      clusterId: 'sha256-deadbeef',
+    });
+    assert.equal(k, 'digest:sent:v1:user_abc:email:full:en:high:sha256-deadbeef');
+  });
+
+  it('throws on empty userId / channel / ruleId / clusterId', () => {
+    const valid = { userId: 'u', channel: 'email', ruleId: 'r', clusterId: 'c' };
+    for (const field of ['userId', 'ruleId', 'clusterId']) {
+      assert.throws(
+        () => buildDeliveredLogKey({ ...valid, [field]: '' }),
+        new RegExp(`${field} must be a non-empty string`),
+      );
+      assert.throws(
+        () => buildDeliveredLogKey({ ...valid, [field]: null }),
+        new RegExp(`${field} must be a non-empty string`),
+      );
+    }
+    assert.throws(
+      () => buildDeliveredLogKey({ ...valid, channel: '' }),
+      /channel must be a non-empty string/,
+    );
+  });
+
+  it('rejects unknown channel — only ALLOWED_CHANNELS', () => {
+    for (const ch of [...ALLOWED_CHANNELS]) {
+      assert.doesNotThrow(() =>
+        buildDeliveredLogKey({ userId: 'u', channel: ch, ruleId: 'r', clusterId: 'c' }),
+      );
+    }
+    assert.throws(
+      () => buildDeliveredLogKey({ userId: 'u', channel: 'sms', ruleId: 'r', clusterId: 'c' }),
+      /channel must be one of/,
+    );
+  });
+});
+
+// ── computeTtlSecondsWithJitter ────────────────────────────────────────────────
+
+describe('computeTtlSecondsWithJitter — distribution', () => {
+  const BASE = 30 * 24 * 60 * 60;            // 2_592_000
+  const MAX = BASE + 3 * 24 * 60 * 60;       // 2_851_200
+
+  it('default Math.random: 100 samples land in [BASE, BASE+3d)', () => {
+    for (let i = 0; i < 100; i++) {
+      const ttl = computeTtlSecondsWithJitter();
+      assert.ok(ttl >= BASE, `ttl=${ttl} below base=${BASE}`);
+      assert.ok(ttl < MAX, `ttl=${ttl} >= max=${MAX}`);
+    }
+  });
+
+  it('deterministic: random=0 → exactly BASE, random=0.9999999 → BASE+3d-1', () => {
+    assert.equal(computeTtlSecondsWithJitter(() => 0), BASE);
+    // The clamp at 0.9999999 ensures random=1 still produces a value
+    // strictly less than BASE+jitter — protects callers from off-by-one
+    // bound assertions.
+    const ttl = computeTtlSecondsWithJitter(() => 1);
+    assert.ok(ttl < MAX, `ttl=${ttl} should be < ${MAX} when random=1 (clamped)`);
+    assert.ok(ttl >= MAX - 1);
+  });
+
+  it('jitter spreads — 200 samples cover at least 50% of the [BASE, BASE+3d) range', () => {
+    // Loose distribution check: with 200 uniform samples we expect the
+    // observed range (max - min) to span well over half the jitter
+    // window. Tighter-than-50% would invite flakes; the goal here is
+    // "no clustering at exact BASE", not statistical purity.
+    const samples = [];
+    for (let i = 0; i < 200; i++) samples.push(computeTtlSecondsWithJitter());
+    const min = Math.min(...samples);
+    const max = Math.max(...samples);
+    const span = max - min;
+    const jitterWindow = MAX - BASE;
+    assert.ok(
+      span > jitterWindow * 0.5,
+      `expected span > ${jitterWindow * 0.5}; got ${span} (min=${min}, max=${max})`,
+    );
+  });
+
+  it('handles invalid random (NaN, negative, >1) defensively', () => {
+    assert.equal(computeTtlSecondsWithJitter(() => Number.NaN), BASE);
+    assert.equal(computeTtlSecondsWithJitter(() => -5), BASE);
+    const ttl = computeTtlSecondsWithJitter(() => 5);
+    assert.ok(ttl < MAX);
+  });
+});
+
+// ── writeDeliveredEntry — happy path ───────────────────────────────────────────
+
+describe('writeDeliveredEntry — happy path', () => {
+  it('first write → { written: 1, conflicts: 0, errors: 0 }; key + value + TTL on the wire', async () => {
+    const pipeline = mockPipeline();
+    const result = await writeDeliveredEntry({
+      userId: 'user_abc',
+      channel: 'email',
+      ruleId: 'full:en:high',
+      clusterId: 'cluster-1',
+      sentAt: 1_700_000_000_000,
+      sourceCount: 4,
+      severity: 'high',
+      deps: { redisPipeline: pipeline.impl, randomFn: () => 0.5 },
+    });
+    assert.deepEqual(result, {
+      written: 1,
+      conflicts: 0,
+      errors: 0,
+      key: 'digest:sent:v1:user_abc:email:full:en:high:cluster-1',
+    });
+    // Pipeline received exactly one command in JSON-body form.
+    assert.equal(pipeline.calls.length, 1);
+    assert.deepEqual(pipeline.calls[0], [[
+      'SET',
+      'digest:sent:v1:user_abc:email:full:en:high:cluster-1',
+      JSON.stringify({ sentAt: 1_700_000_000_000, sourceCount: 4, severity: 'high' }),
+      'NX',
+      'EX',
+      String(2_592_000 + Math.floor(0.5 * 259_200)),
+    ]]);
+  });
+
+  it('value JSON parses back into { sentAt, sourceCount, severity }', async () => {
+    const pipeline = mockPipeline();
+    await writeDeliveredEntry({
+      userId: 'u', channel: 'telegram', ruleId: 'r', clusterId: 'c',
+      sentAt: 42, sourceCount: 7, severity: 'critical',
+      deps: { redisPipeline: pipeline.impl, randomFn: () => 0 },
+    });
+    const sentValue = pipeline.calls[0][0][2];
+    assert.deepEqual(JSON.parse(sentValue), { sentAt: 42, sourceCount: 7, severity: 'critical' });
+  });
+
+  it('writes to every channel in ALLOWED_CHANNELS', async () => {
+    for (const ch of ALLOWED_CHANNELS) {
+      const pipeline = mockPipeline();
+      const r = await writeDeliveredEntry({
+        userId: 'u', channel: ch, ruleId: 'r', clusterId: 'c',
+        sentAt: 1, sourceCount: 1, severity: 'medium',
+        deps: { redisPipeline: pipeline.impl },
+      });
+      assert.equal(r.written, 1, `channel=${ch} expected written=1`);
+      assert.equal(r.errors, 0);
+      assert.match(r.key, new RegExp(`:${ch}:`));
+    }
+  });
+});
+
+// ── writeDeliveredEntry — idempotency / conflict ───────────────────────────────
+
+describe('writeDeliveredEntry — idempotency via SET NX EX', () => {
+  it('second write of same key → { written: 0, conflicts: 1, errors: 0 } (NX rejected)', async () => {
+    const pipeline = mockPipeline({ responses: [{ result: null }] });
+    const result = await writeDeliveredEntry({
+      userId: 'u', channel: 'email', ruleId: 'r', clusterId: 'c',
+      sentAt: 1, sourceCount: 1, severity: 'high',
+      deps: { redisPipeline: pipeline.impl },
+    });
+    assert.deepEqual(result, {
+      written: 0,
+      conflicts: 1,
+      errors: 0,
+      key: 'digest:sent:v1:u:email:r:c',
+    });
+  });
+
+  it('back-to-back writes: first OK then NX-collide → counters land at written=1, conflicts=1', async () => {
+    let call = 0;
+    const impl = async () => (call++ === 0 ? [{ result: 'OK' }] : [{ result: null }]);
+    const r1 = await writeDeliveredEntry({
+      userId: 'u', channel: 'email', ruleId: 'r', clusterId: 'c',
+      sentAt: 1, sourceCount: 1, severity: 'high',
+      deps: { redisPipeline: impl },
+    });
+    const r2 = await writeDeliveredEntry({
+      userId: 'u', channel: 'email', ruleId: 'r', clusterId: 'c',
+      sentAt: 2, sourceCount: 2, severity: 'high',
+      deps: { redisPipeline: impl },
+    });
+    const agg = aggregateResults([r1, r2]);
+    assert.deepEqual(agg, { written: 1, conflicts: 1, errors: 0 });
+  });
+});
+
+// ── writeDeliveredEntry — error paths ──────────────────────────────────────────
+
+describe('writeDeliveredEntry — error mapping', () => {
+  it('pipeline returns null (creds missing / 5xx / fetch threw inside helper) → errors=1, NO write', async () => {
+    const impl = async () => null;
+    const r = await writeDeliveredEntry({
+      userId: 'u', channel: 'email', ruleId: 'r', clusterId: 'c',
+      sentAt: 1, sourceCount: 1, severity: 'high',
+      deps: { redisPipeline: impl },
+    });
+    assert.deepEqual(r, {
+      written: 0,
+      conflicts: 0,
+      errors: 1,
+      key: 'digest:sent:v1:u:email:r:c',
+    });
+  });
+
+  it('pipeline cell has { error } → errors=1', async () => {
+    const impl = async () => [{ error: 'WRONGTYPE Operation against a key holding the wrong kind of value' }];
+    const r = await writeDeliveredEntry({
+      userId: 'u', channel: 'email', ruleId: 'r', clusterId: 'c',
+      sentAt: 1, sourceCount: 1, severity: 'high',
+      deps: { redisPipeline: impl },
+    });
+    assert.equal(r.errors, 1);
+    assert.equal(r.written, 0);
+  });
+
+  it('pipeline throws → errors=1 (mapped, not propagated)', async () => {
+    const pipeline = mockPipeline({ throwOnce: true });
+    const r = await writeDeliveredEntry({
+      userId: 'u', channel: 'email', ruleId: 'r', clusterId: 'c',
+      sentAt: 1, sourceCount: 1, severity: 'high',
+      deps: { redisPipeline: pipeline.impl },
+    });
+    assert.equal(r.errors, 1);
+    assert.equal(r.written, 0);
+  });
+
+  it('unknown response shape (e.g. {result: 1}) → errors=1 (defensive)', async () => {
+    const impl = async () => [{ result: 1 }];
+    const r = await writeDeliveredEntry({
+      userId: 'u', channel: 'email', ruleId: 'r', clusterId: 'c',
+      sentAt: 1, sourceCount: 1, severity: 'high',
+      deps: { redisPipeline: impl },
+    });
+    assert.equal(r.errors, 1);
+  });
+});
+
+// ── writeDeliveredEntry — input validation throws (no Upstash call) ────────────
+
+describe('writeDeliveredEntry — input validation', () => {
+  it('clusterId === "" throws BEFORE any pipeline call', async () => {
+    let pipelineCalled = false;
+    const impl = async () => { pipelineCalled = true; return [{ result: 'OK' }]; };
+    await assert.rejects(
+      writeDeliveredEntry({
+        userId: 'u', channel: 'email', ruleId: 'r', clusterId: '',
+        sentAt: 1, sourceCount: 1, severity: 'high',
+        deps: { redisPipeline: impl },
+      }),
+      /clusterId must be a non-empty string/,
+    );
+    assert.equal(pipelineCalled, false, 'pipeline must NOT be called for malformed keys');
+  });
+
+  it('non-positive sentAt throws BEFORE any pipeline call', async () => {
+    let pipelineCalled = false;
+    const impl = async () => { pipelineCalled = true; return [{ result: 'OK' }]; };
+    for (const bad of [0, -1, Number.NaN, 'now', null, undefined]) {
+      await assert.rejects(
+        writeDeliveredEntry({
+          userId: 'u', channel: 'email', ruleId: 'r', clusterId: 'c',
+          sentAt: bad, sourceCount: 1, severity: 'high',
+          deps: { redisPipeline: impl },
+        }),
+        /sentAt must be a positive epoch-ms number/,
+      );
+    }
+    assert.equal(pipelineCalled, false);
+  });
+
+  it('weird sourceCount / severity coerce defensively (no throw)', async () => {
+    const pipeline = mockPipeline();
+    const r = await writeDeliveredEntry({
+      userId: 'u', channel: 'email', ruleId: 'r', clusterId: 'c',
+      sentAt: 1, sourceCount: -5, severity: '',
+      deps: { redisPipeline: pipeline.impl },
+    });
+    assert.equal(r.errors, 0);
+    const sentValue = JSON.parse(pipeline.calls[0][0][2]);
+    assert.equal(sentValue.sourceCount, 0, 'negative coerces to 0');
+    assert.equal(sentValue.severity, 'unknown', 'empty severity coerces to "unknown"');
+  });
+});
+
+// ── aggregateResults ───────────────────────────────────────────────────────────
+
+describe('aggregateResults', () => {
+  it('sums tri-state counters across multiple writes', () => {
+    const agg = aggregateResults([
+      { written: 1, conflicts: 0, errors: 0 },
+      { written: 0, conflicts: 1, errors: 0 },
+      { written: 1, conflicts: 0, errors: 0 },
+      { written: 0, conflicts: 0, errors: 1 },
+    ]);
+    assert.deepEqual(agg, { written: 2, conflicts: 1, errors: 1 });
+  });
+
+  it('handles empty / non-array input safely', () => {
+    assert.deepEqual(aggregateResults([]), { written: 0, conflicts: 0, errors: 0 });
+    assert.deepEqual(aggregateResults(null), { written: 0, conflicts: 0, errors: 0 });
+    assert.deepEqual(aggregateResults(undefined), { written: 0, conflicts: 0, errors: 0 });
+  });
+
+  it('tolerates partial cells (missing keys default to 0)', () => {
+    const agg = aggregateResults([
+      { written: 3 },
+      { conflicts: 2 },
+      { errors: 1 },
+      {},
+    ]);
+    assert.deepEqual(agg, { written: 3, conflicts: 2, errors: 1 });
+  });
+});
+
+// ── Integration-shape sanity (no live Upstash) ─────────────────────────────────
+
+describe('writeDeliveredEntry — integration shape (single-user, multi-channel)', () => {
+  it('full digest send across email + Telegram → exactly 2 entries with same {userId,ruleId,clusterId}, differing channel', async () => {
+    const calls = [];
+    const impl = async (commands) => {
+      calls.push(commands);
+      return [{ result: 'OK' }];
+    };
+    const common = {
+      userId: 'user_xyz',
+      ruleId: 'full:en:high',
+      clusterId: 'sha256-cluster-A',
+      sentAt: 1_700_000_000_000,
+      sourceCount: 3,
+      severity: 'critical',
+      deps: { redisPipeline: impl },
+    };
+    const r1 = await writeDeliveredEntry({ ...common, channel: 'email' });
+    const r2 = await writeDeliveredEntry({ ...common, channel: 'telegram' });
+    assert.equal(r1.written, 1);
+    assert.equal(r2.written, 1);
+    assert.notEqual(r1.key, r2.key, 'channel discriminator must produce distinct keys');
+    assert.match(r1.key, /:email:/);
+    assert.match(r2.key, /:telegram:/);
+    assert.equal(calls.length, 2);
+  });
+
+  it('failing channel (mock telegram pipeline returns error) → email entry exists, telegram does NOT', async () => {
+    const writes = [];
+    const emailPipeline = async (commands) => {
+      writes.push({ channel: 'email', commands });
+      return [{ result: 'OK' }];
+    };
+    const telegramPipeline = async (commands) => {
+      writes.push({ channel: 'telegram', commands });
+      return null; // simulate Upstash 5xx during the telegram entry write
+    };
+    const common = {
+      userId: 'u', ruleId: 'r', clusterId: 'c',
+      sentAt: 1, sourceCount: 1, severity: 'high',
+    };
+    const rEmail = await writeDeliveredEntry({
+      ...common, channel: 'email',
+      deps: { redisPipeline: emailPipeline },
+    });
+    const rTel = await writeDeliveredEntry({
+      ...common, channel: 'telegram',
+      deps: { redisPipeline: telegramPipeline },
+    });
+    assert.equal(rEmail.written, 1);
+    assert.equal(rEmail.errors, 0);
+    assert.equal(rTel.written, 0);
+    assert.equal(rTel.errors, 1);
+    // Cron caller's contract: rTel.errors > 0 → DO NOT mark stamp.
+    // Story is eligible to re-air to telegram next tick. Verified by
+    // the call-site behaviour in tests/digest-delivered-log-source-
+    // guard.test.mjs (source-text guard for the integration site).
+  });
+});
+
+// ── clearDeliveredEntry — operator one-shot ────────────────────────────────────
+//
+// The script lives at scripts/clear-delivered-entry.mjs; tests live here
+// (not in a sibling file) so the .husky/pre-push glob picks them up
+// alongside the writer's tests under the same `digest-delivered-log` name.
+// Pattern matches the U2 + U3 unit-vs-integration colocation.
+
+describe('clear-delivered-entry — argument parsing', () => {
+  it('rejects invocation without --reason (the dedicated audit-trail flag)', () => {
+    const r = parseArgs(['--user', 'u', '--slot', 's', '--cluster', 'c']);
+    assert.equal(r.kind, 'err');
+    assert.match(r.message, /missing required flag: --reason/);
+  });
+
+  it('rejects invocation without --user / --slot / --cluster', () => {
+    for (const missing of ['user', 'slot', 'cluster']) {
+      const argv = ['--user', 'u', '--slot', 's', '--cluster', 'c', '--reason', 'r']
+        .filter((_, i, a) => !(a[i - 1] === `--${missing}` || a[i] === `--${missing}`));
+      const r = parseArgs(argv);
+      assert.equal(r.kind, 'err', `missing --${missing} should error`);
+      assert.match(r.message, new RegExp(`missing required flag: --${missing}`));
+    }
+  });
+
+  it('accepts the minimum-args invocation (sweep mode)', () => {
+    const r = parseArgs(['--user', 'u', '--slot', '2026-05-06-0800', '--cluster', 'c', '--reason', 'audit-recovery']);
+    assert.equal(r.kind, 'ok');
+    assert.deepEqual(r.args, {
+      user: 'u',
+      slot: '2026-05-06-0800',
+      cluster: 'c',
+      reason: 'audit-recovery',
+    });
+  });
+
+  it('accepts the full-args invocation (single-key mode)', () => {
+    const r = parseArgs([
+      '--user', 'u', '--slot', '2026-05-06-0800', '--cluster', 'c',
+      '--channel', 'email', '--rule', 'full:en:high',
+      '--reason', 'classifier-misfire',
+    ]);
+    assert.equal(r.kind, 'ok');
+    assert.equal(r.args.channel, 'email');
+    assert.equal(r.args.rule, 'full:en:high');
+  });
+
+  it('rejects --channel without --rule (and vice versa) — must be paired', () => {
+    const r1 = parseArgs(['--user', 'u', '--slot', 's', '--cluster', 'c', '--channel', 'email', '--reason', 'r']);
+    assert.equal(r1.kind, 'err');
+    assert.match(r1.message, /must be specified together/);
+    const r2 = parseArgs(['--user', 'u', '--slot', 's', '--cluster', 'c', '--rule', 'r1', '--reason', 'r']);
+    assert.equal(r2.kind, 'err');
+    assert.match(r2.message, /must be specified together/);
+  });
+
+  it('rejects unknown channel values', () => {
+    const r = parseArgs([
+      '--user', 'u', '--slot', 's', '--cluster', 'c',
+      '--channel', 'sms', '--rule', 'r', '--reason', 'r',
+    ]);
+    assert.equal(r.kind, 'err');
+    assert.match(r.message, /channel must be one of/);
+  });
+
+  it('rejects unknown flags loudly (typo guard)', () => {
+    const r = parseArgs(['--user', 'u', '--slott', '2026-05-06', '--cluster', 'c', '--reason', 'r']);
+    assert.equal(r.kind, 'err');
+    assert.match(r.message, /unknown flag/);
+  });
+
+  it('rejects flag with no value (or value that looks like another flag)', () => {
+    const r1 = parseArgs(['--user', '--slot', 's', '--cluster', 'c', '--reason', 'r']);
+    assert.equal(r1.kind, 'err');
+    assert.match(r1.message, /requires a non-empty value/);
+  });
+});
+
+describe('clear-delivered-entry — key shape helpers', () => {
+  it('buildSingleKey matches the writer-side shape', () => {
+    assert.equal(
+      buildSingleKey('u', 'email', 'full:en:high', 'cluster-1'),
+      'digest:sent:v1:u:email:full:en:high:cluster-1',
+    );
+  });
+
+  it('buildScanPattern wildcards channel + rule, pins user + cluster', () => {
+    assert.equal(
+      buildScanPattern('user_abc', 'sha256-cluster-1'),
+      'digest:sent:v1:user_abc:*:*:sha256-cluster-1',
+    );
+  });
+});
+
+describe('clear-delivered-entry — runClear (single-key mode)', () => {
+  function captureLogs() {
+    const lines = [];
+    return { log: (l) => lines.push(['log', l]), warn: (l) => lines.push(['warn', l]), lines };
+  }
+
+  it('--channel email --rule X targets ONE key, leaves others untouched', async () => {
+    const calls = [];
+    const pipeline = async (cmds) => {
+      calls.push(cmds);
+      // Upstash returns one cell per command. DEL returns 1 on success.
+      return cmds.map(() => ({ result: 1 }));
+    };
+    const cap = captureLogs();
+    const r = await runClear({
+      parsed: { user: 'u', slot: '2026-05-06-0800', cluster: 'c', channel: 'email', rule: 'r1', reason: 'audit' },
+      deps: { scan: async () => { throw new Error('SCAN must NOT be called in single-key mode'); }, redisPipeline: pipeline, log: cap.log, warn: cap.warn },
+    });
+    assert.equal(r.code, 0);
+    assert.equal(r.deleted, 1);
+    assert.equal(r.ineligible.length, 0);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0], [['DEL', 'digest:sent:v1:u:email:r1:c']]);
+    // Audit line emitted with reason.
+    assert.ok(cap.lines.some(([level, line]) => level === 'log' && /DELETED key=digest:sent:v1:u:email:r1:c/.test(line) && /reason="audit"/.test(line)));
+  });
+
+  it('DEL returns 0 (key already absent) → 0 deleted, 1 ineligible, exit 0', async () => {
+    const pipeline = async (cmds) => cmds.map(() => ({ result: 0 }));
+    const cap = captureLogs();
+    const r = await runClear({
+      parsed: { user: 'u', slot: 's', cluster: 'c', channel: 'email', rule: 'r1', reason: 'audit' },
+      deps: { scan: async () => ({ kind: 'ok', keys: [] }), redisPipeline: pipeline, log: cap.log, warn: cap.warn },
+    });
+    assert.equal(r.code, 0);
+    assert.equal(r.deleted, 0);
+    assert.equal(r.ineligible.length, 1);
+  });
+});
+
+describe('clear-delivered-entry — runClear (sweep mode, no channel/rule)', () => {
+  it('SCAN finds 3 keys → DELETE pipeline issues 3 commands → 3 deleted', async () => {
+    const scanned = [];
+    const scan = async (pattern) => {
+      scanned.push(pattern);
+      return {
+        kind: 'ok',
+        keys: [
+          'digest:sent:v1:u:email:r1:c',
+          'digest:sent:v1:u:telegram:r1:c',
+          'digest:sent:v1:u:slack:r1:c',
+        ],
+      };
+    };
+    const calls = [];
+    const pipeline = async (cmds) => {
+      calls.push(cmds);
+      return cmds.map(() => ({ result: 1 }));
+    };
+    const r = await runClear({
+      parsed: { user: 'u', slot: 's', cluster: 'c', reason: 'sweep-test' },
+      deps: { scan, redisPipeline: pipeline, log: () => {}, warn: () => {} },
+    });
+    assert.equal(r.code, 0);
+    assert.equal(r.deleted, 3);
+    assert.equal(scanned[0], 'digest:sent:v1:u:*:*:c');
+    assert.equal(calls[0].length, 3);
+  });
+
+  it('SCAN returns empty → 0 deleted, exit 0, no DEL pipeline call', async () => {
+    let pipelineCalled = false;
+    const r = await runClear({
+      parsed: { user: 'u', slot: 's', cluster: 'c', reason: 'r' },
+      deps: {
+        scan: async () => ({ kind: 'ok', keys: [] }),
+        redisPipeline: async () => { pipelineCalled = true; return []; },
+        log: () => {}, warn: () => {},
+      },
+    });
+    assert.equal(r.code, 0);
+    assert.equal(r.deleted, 0);
+    assert.equal(pipelineCalled, false);
+  });
+
+  it('SCAN transport error → exit code 2 (operator retries)', async () => {
+    const cap = (() => {
+      const lines = [];
+      return { log: () => {}, warn: (l) => lines.push(l), lines };
+    })();
+    const r = await runClear({
+      parsed: { user: 'u', slot: 's', cluster: 'c', reason: 'r' },
+      deps: {
+        scan: async () => ({ kind: 'transport-error', message: 'SCAN HTTP 503' }),
+        redisPipeline: async () => { throw new Error('pipeline must NOT be called when SCAN failed'); },
+        log: cap.log, warn: cap.warn,
+      },
+    });
+    assert.equal(r.code, 2);
+    assert.equal(r.deleted, 0);
+    assert.ok(cap.lines.some((l) => /SCAN HTTP 503/.test(l)));
+  });
+
+  it('DEL pipeline returns null → exit code 2 (transport failure)', async () => {
+    const r = await runClear({
+      parsed: { user: 'u', slot: 's', cluster: 'c', channel: 'email', rule: 'r1', reason: 'r' },
+      deps: {
+        scan: async () => ({ kind: 'ok', keys: [] }),
+        redisPipeline: async () => null,
+        log: () => {}, warn: () => {},
+      },
+    });
+    assert.equal(r.code, 2);
+  });
+});

--- a/tests/dockerfile-digest-notifications-imports.test.mjs
+++ b/tests/dockerfile-digest-notifications-imports.test.mjs
@@ -1,0 +1,193 @@
+// Sprint 1 / U8 — static guard for Dockerfile.digest-notifications.
+//
+// Mirrors tests/dockerfile-relay-imports.test.mjs but extends coverage
+// to ALL cross-dir imports (scripts/, shared/, server/_shared/, api/),
+// since the digest cron's import graph spans all four. A missing
+// transitive import looks like a silent Railway cron crash —
+// ERR_MODULE_NOT_FOUND on the child process, sometimes hours before
+// anyone notices the digest stopped sending.
+//
+// The relay Dockerfile guard only catches missing scripts/ COPYs; this
+// guard also catches missing shared/, server/_shared/, and api/ COPYs.
+// Both directly and recursively (e.g., `COPY scripts/lib/ ./scripts/lib/`
+// covers the entire subdirectory).
+//
+// Historical context (per Dockerfile.relay test header): the
+// 2026-04-14→16 chokepoint-flows 32h outage was caused by a missing
+// COPY line for an _seed-utils.mjs transitive import. Sprint 1 / U4
+// added scripts/lib/digest-delivered-log.mjs and scripts/clear-delivered-entry.mjs
+// to the digest cron's import graph; Sprint 1 / U5 added three more
+// scripts/lib/digest-cooldown-* modules. Without this guard, a future
+// shared-helper extraction could land at the same risk class.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+// Scopes the guard checks. Imports OUTSIDE these prefixes are out of
+// scope (e.g., node_modules, node:built-ins, top-level package.json
+// references resolved by the runtime).
+const TRACKED_PREFIXES = ['scripts/', 'shared/', 'server/_shared/', 'api/'];
+
+/**
+ * Read the COPY directives from the Dockerfile and split them into
+ * file-level and directory-level (recursive) coverage.
+ *
+ * Matches:
+ *   COPY <src> [<src> ...] ./<dest>
+ *
+ * A trailing slash on a tracked-prefix source means recursive directory
+ * coverage (e.g. `scripts/lib/` covers every file under scripts/lib/
+ * recursively). Otherwise it's a single-file COPY.
+ *
+ * @param {string} dockerfilePath
+ * @returns {{ files: Set<string>, directories: Set<string> }}
+ */
+function readCoverage(dockerfilePath) {
+  const src = readFileSync(dockerfilePath, 'utf-8');
+  const files = new Set();
+  const directories = new Set();
+
+  // Split each COPY line, take all source args (everything but the
+  // trailing destination), and bucket into file/directory coverage.
+  const lineRe = /^COPY\s+(.+?)\s+\.\/[^\n]*$/gm;
+  for (const m of src.matchAll(lineRe)) {
+    const args = m[1].split(/\s+/);
+    for (const arg of args) {
+      // Skip non-tracked prefixes (e.g. package.json, node_modules
+      // would never appear here but defensive).
+      if (!TRACKED_PREFIXES.some((p) => arg.startsWith(p))) continue;
+      if (arg.endsWith('/')) {
+        directories.add(arg.replace(/\/$/, ''));
+      } else {
+        files.add(arg);
+      }
+    }
+  }
+  return { files, directories };
+}
+
+/**
+ * Check whether a tracked-prefix file path is covered by either a
+ * file-level COPY (exact match) or a directory-level COPY (prefix match).
+ */
+function isCovered(coverage, relPath) {
+  if (coverage.files.has(relPath)) return true;
+  for (const dir of coverage.directories) {
+    if (relPath === dir) return true;
+    if (relPath.startsWith(dir + '/')) return true;
+  }
+  return false;
+}
+
+/**
+ * Collect relative imports from a JS/TS source file. Same scanner the
+ * relay test uses (covers ESM import/export-from + CJS require + CJS
+ * createRequire).
+ */
+function collectRelativeImports(filePath) {
+  const src = readFileSync(filePath, 'utf-8');
+  const imports = new Set();
+  const esmRe = /(?:^|\s|;)(?:import|export)\s+(?:[\s\S]*?\s+from\s+)?['"](\.[^'"]+)['"]/g;
+  for (const m of src.matchAll(esmRe)) imports.add(m[1]);
+  const cjsRe = /(?:^|[^a-zA-Z0-9_$])require\s*\(\s*['"](\.[^'"]+)['"]/g;
+  for (const m of src.matchAll(cjsRe)) imports.add(m[1]);
+  const createRequireRe = /createRequire\s*\([^)]*\)\s*\(\s*['"](\.[^'"]+)['"]/g;
+  for (const m of src.matchAll(createRequireRe)) imports.add(m[1]);
+  return imports;
+}
+
+function resolveImport(fromFile, relImport) {
+  const abs = resolve(dirname(fromFile), relImport);
+  if (existsSync(abs) && !statSync(abs).isDirectory()) return abs;
+  for (const ext of ['.mjs', '.cjs', '.js', '.ts']) {
+    if (existsSync(abs + ext)) return abs + ext;
+  }
+  return null;
+}
+
+describe('Dockerfile.digest-notifications — transitive-import closure', () => {
+  const dockerfile = resolve(root, 'Dockerfile.digest-notifications');
+  const coverage = readCoverage(dockerfile);
+
+  it('Dockerfile exists at the repo root', () => {
+    assert.ok(existsSync(dockerfile), 'Dockerfile.digest-notifications missing');
+  });
+
+  it('coverage parser picks up all four tracked prefixes', () => {
+    // Sanity check on the parser: confirm it found at least one COPY
+    // per tracked prefix. If the Dockerfile changes shape (e.g., scripts
+    // is dropped because everything moved into scripts/lib/), this test
+    // surfaces the change explicitly so the operator updates the test.
+    const allCovered = [...coverage.files, ...coverage.directories];
+    for (const prefix of TRACKED_PREFIXES) {
+      const hit = allCovered.some((p) => p.startsWith(prefix));
+      assert.ok(hit, `no COPY line found for ${prefix} prefix — Dockerfile.digest-notifications shape changed?`);
+    }
+  });
+
+  it('seed-digest-notifications.mjs is COPY\'d as the entrypoint', () => {
+    assert.ok(
+      isCovered(coverage, 'scripts/seed-digest-notifications.mjs'),
+      'cron entrypoint not in COPY list',
+    );
+  });
+
+  it('U4 + U5 modules are covered (scripts/lib/ recursive OR explicit)', () => {
+    const u4u5Files = [
+      'scripts/lib/digest-delivered-log.mjs',
+      'scripts/lib/digest-cooldown-config.mjs',
+      'scripts/lib/digest-cooldown-decision.mjs',
+      'scripts/lib/digest-cooldown-shadow-log.mjs',
+      'scripts/clear-delivered-entry.mjs',
+    ];
+    for (const f of u4u5Files) {
+      assert.ok(
+        isCovered(coverage, f),
+        `${f} (Sprint 1 / U4 or U5) not covered by any COPY directive`,
+      );
+    }
+  });
+
+  // BFS from the cron entrypoint through the import graph; every
+  // tracked-prefix file reached must be covered.
+  it('every transitively-imported tracked-prefix file is COPY\'d', () => {
+    const entrypoints = [
+      resolve(root, 'scripts/seed-digest-notifications.mjs'),
+    ];
+    const missing = [];
+    const visited = new Set();
+    const queue = [...entrypoints];
+    while (queue.length) {
+      const file = queue.shift();
+      if (visited.has(file)) continue;
+      visited.add(file);
+      if (!existsSync(file)) continue;
+      for (const rel of collectRelativeImports(file)) {
+        const resolved = resolveImport(file, rel);
+        if (!resolved) continue;
+        const relToRoot = resolved.startsWith(root + '/')
+          ? resolved.slice(root.length + 1)
+          : null;
+        if (!relToRoot) continue;
+        const tracked = TRACKED_PREFIXES.some((p) => relToRoot.startsWith(p));
+        if (!tracked) continue;
+        if (!isCovered(coverage, relToRoot)) {
+          missing.push(`${relToRoot} (imported by ${file.slice(root.length + 1)})`);
+        }
+        queue.push(resolved);
+      }
+    }
+    assert.deepEqual(
+      missing,
+      [],
+      `Dockerfile.digest-notifications is missing COPY lines for:\n  ${missing.join('\n  ')}\n` +
+      `Add a 'COPY <path> ./<path>' line per missing file (or extend a recursive directory COPY).`,
+    );
+  });
+});

--- a/tests/replay-digest-cooldown-harness.test.mjs
+++ b/tests/replay-digest-cooldown-harness.test.mjs
@@ -244,6 +244,91 @@ describe('aggregateReplayDecisions — coverage report shape', () => {
   });
 });
 
+describe('aggregateReplayDecisions — Codex PR #3617 round-3 P1 collapse', () => {
+  // The replay-log writer emits ONE record per input story (rep + each
+  // non-rep member), so a 2-story cluster in one tick yields 2 records
+  // at the same tsMs. Pre-fix the harness treated each as a separate
+  // occurrence — the second record (same tsMs) saw the first as
+  // `lastDeliveredAt` and produced a false 0-hour repeat suppression.
+  // Post-fix the harness collapses to one observation per
+  // (ruleId, repHash, tsMs).
+  it('multi-member cluster in one tick → ONE observation, NOT a 0-hour repeat (suppress)', () => {
+    const records = [
+      // Tick 1 — cluster {h-rep, h-mem1, h-mem2}, all at the same tsMs.
+      { storyHash: 'h-rep', repHash: 'h-rep', mergedHashes: ['h-rep', 'h-mem1', 'h-mem2'], isRep: true,
+        severity: 'high', sources: ['A','B','C'], ruleId: 'full:en:high', tsMs: T0 },
+      { storyHash: 'h-mem1', repHash: 'h-rep', isRep: false,
+        severity: 'high', sources: ['A','B','C'], ruleId: 'full:en:high', tsMs: T0 },
+      { storyHash: 'h-mem2', repHash: 'h-rep', isRep: false,
+        severity: 'high', sources: ['A','B','C'], ruleId: 'full:en:high', tsMs: T0 },
+      // Padding for coverage gate.
+      { storyHash: 'h-pad', repHash: 'h-pad', isRep: true, severity: 'high',
+        sources: [], ruleId: 'full:en:high', tsMs: T0 + 14 * DAY_MS },
+    ];
+    const agg = aggregateReplayDecisions(records, { minDaysCovered: 14 });
+    // Pre-fix: 3 records at T0 → 1 timeline with 3 records → 2
+    // synthetic suppress decisions (cooldown_floor at 0h elapsed).
+    // Post-fix: collapses to 1 record at T0 → 1 timeline with 1 record
+    // → no decision (single-occurrence timelines are skipped).
+    assert.equal(agg.totalDecisions, 0, 'multi-member in one tick must not produce false repeat decisions');
+    assert.equal(agg.suppressDecisions, 0);
+    assert.equal(agg.dropRatePct, 0);
+  });
+
+  it('genuine multi-tick cluster timeline still simulates correctly after collapse', () => {
+    const records = [
+      // Tick 1: 2-member cluster.
+      { storyHash: 'h-rep', repHash: 'h-rep', mergedHashes: ['h-rep', 'h-mem'], isRep: true,
+        severity: 'high', sources: ['A','B'], ruleId: 'full:en:high', tsMs: T0 },
+      { storyHash: 'h-mem', repHash: 'h-rep', isRep: false,
+        severity: 'high', sources: ['A','B'], ruleId: 'full:en:high', tsMs: T0 },
+      // Tick 2: same cluster re-airs 6h later (within 18h floor, no evolution).
+      { storyHash: 'h-rep', repHash: 'h-rep', mergedHashes: ['h-rep', 'h-mem'], isRep: true,
+        severity: 'high', sources: ['A','B'], ruleId: 'full:en:high', tsMs: T0 + 6 * HOUR_MS },
+      { storyHash: 'h-mem', repHash: 'h-rep', isRep: false,
+        severity: 'high', sources: ['A','B'], ruleId: 'full:en:high', tsMs: T0 + 6 * HOUR_MS },
+      // Padding.
+      { storyHash: 'h-pad', repHash: 'h-pad', isRep: true, severity: 'high',
+        sources: [], ruleId: 'full:en:high', tsMs: T0 + 14 * DAY_MS },
+    ];
+    const agg = aggregateReplayDecisions(records, { minDaysCovered: 14 });
+    // After collapse: tick-1 (1 record) + tick-2 (1 record) = 1
+    // legitimate within-floor re-air = 1 suppress decision (high-event
+    // 18h floor).
+    assert.equal(agg.totalDecisions, 1);
+    assert.equal(agg.suppressDecisions, 1);
+    assert.equal(agg.allowDecisions, 0);
+  });
+
+  it('rep record wins over non-rep when collapsing — uses canonical headline/sourceUrl', () => {
+    // Two records at the same (ruleId, repHash, tsMs). Verify the rep
+    // is the one preserved (it carries the canonical view; non-reps
+    // may have nulled-out fields).
+    const records = [
+      { storyHash: 'h-mem', repHash: 'h-rep', isRep: false, sourceUrl: 'https://reuters.com/x',
+        severity: 'high', sources: ['A','B'], ruleId: 'full:en:high', tsMs: T0 },
+      { storyHash: 'h-rep', repHash: 'h-rep', mergedHashes: ['h-rep', 'h-mem'], isRep: true,
+        sourceUrl: 'https://www.usni.org/article', // analysis domain
+        severity: 'high', sources: ['A','B'], ruleId: 'full:en:high', tsMs: T0 },
+      // Re-air 6 days later (within 7d analysis hard floor).
+      { storyHash: 'h-rep', repHash: 'h-rep', mergedHashes: ['h-rep'], isRep: true,
+        sourceUrl: 'https://www.usni.org/article',
+        severity: 'high', sources: ['A','B'], ruleId: 'full:en:high', tsMs: T0 + 6 * DAY_MS },
+      { storyHash: 'h-pad', repHash: 'h-pad', isRep: true, severity: 'high',
+        sources: [], ruleId: 'full:en:high', tsMs: T0 + 14 * DAY_MS },
+    ];
+    const agg = aggregateReplayDecisions(records, { minDaysCovered: 14 });
+    // The collapsed first-tick record must carry the rep's USNI URL
+    // (analysis domain) so the classifier routes correctly to the 7d
+    // hard floor. If the non-rep record won the collapse, the
+    // sourceUrl would be reuters.com and the classifier would route to
+    // high-event (18h soft floor) — the 6d re-air would then be allow
+    // (beyond floor) instead of suppress (within hard floor).
+    assert.equal(agg.suppressDecisions, 1);
+    assert.equal(agg.reasonHistogram['analysis_7d_hard'], 1);
+  });
+});
+
 describe('aggregateReplayDecisions — top-suppressed timelines', () => {
   it('reports top-10 timelines sorted by suppress count', () => {
     // Build 3 timelines with different suppress counts (3, 2, 1).

--- a/tests/replay-digest-cooldown-harness.test.mjs
+++ b/tests/replay-digest-cooldown-harness.test.mjs
@@ -42,20 +42,68 @@ function rec(overrides = {}) {
 }
 
 describe('clusterIdFromRecord', () => {
-  it('uses mergedHashes[0] when present (multi-story cluster identity)', () => {
+  // Codex PR #3617 P1 — v2 records carry repHash on every record;
+  // collapse non-rep records by repHash so the U6 timeline aggregation
+  // doesn't split a multi-story cluster across its members.
+  it('v2: uses repHash when present (canonical cluster identity)', () => {
+    assert.equal(
+      clusterIdFromRecord({ storyHash: 'h-x', repHash: 'rep-a', mergedHashes: null }),
+      'rep-a',
+      'non-rep record should resolve to its rep via repHash',
+    );
+  });
+
+  it('v2: rep record with repHash + mergedHashes resolves to repHash', () => {
+    assert.equal(
+      clusterIdFromRecord({ storyHash: 'rep-a', repHash: 'rep-a', mergedHashes: ['rep-a', 'h-x'] }),
+      'rep-a',
+    );
+  });
+
+  it('v1 fallback: uses mergedHashes[0] when present (legacy v1 records still in 30d TTL)', () => {
     assert.equal(clusterIdFromRecord(rec({ storyHash: 'h-x', mergedHashes: ['rep-a', 'h-x'] })), 'rep-a');
   });
 
-  it('falls back to storyHash when mergedHashes is empty (singleton)', () => {
+  it('v1 fallback: falls back to storyHash when both repHash and mergedHashes are absent', () => {
     assert.equal(clusterIdFromRecord(rec({ storyHash: 'h-singleton', mergedHashes: [] })), 'h-singleton');
   });
 
-  it('falls back to storyHash when mergedHashes is absent', () => {
-    assert.equal(clusterIdFromRecord(rec({ storyHash: 'h-foo', mergedHashes: undefined })), 'h-foo');
+  it('returns empty string when all three identity sources are missing (caller filters)', () => {
+    assert.equal(clusterIdFromRecord({ tsMs: T0, ruleId: 'r' }), '');
+  });
+});
+
+describe('headline / sourceUrl reader (Codex PR #3617 P1 v2 alias compat)', () => {
+  it('v2 record with sourceUrl: classifier sees the URL via recordSourceUrl path', () => {
+    // Indirect test via the aggregator — pass a v2-shaped record where
+    // sourceUrl is set but link is absent; expect classifyStub to see
+    // the host and route it correctly.
+    const records = [
+      rec({ storyHash: 'h-1', mergedHashes: ['h-1'], repHash: 'h-1', sourceUrl: 'https://www.usni.org/2026/foo', link: undefined, severity: 'high', tsMs: T0 }),
+      rec({ storyHash: 'h-1', mergedHashes: ['h-1'], repHash: 'h-1', sourceUrl: 'https://www.usni.org/2026/foo', link: undefined, severity: 'high', tsMs: T0 + 6 * DAY_MS }),
+      rec({ storyHash: 'h-pad', mergedHashes: ['h-pad'], repHash: 'h-pad', tsMs: T0 + 14 * DAY_MS }),
+    ];
+    const agg = aggregateReplayDecisions(records, { minDaysCovered: 14 });
+    // www.usni.org should classify as analysis (Codex PR #3617 P2 fix)
+    // and the 6-day re-air sits inside the 7-day hard floor → suppress.
+    assert.equal(agg.suppressDecisions, 1);
+    assert.equal(agg.reasonHistogram['analysis_7d_hard'], 1);
   });
 
-  it('returns empty string when both are missing (caller filters)', () => {
-    assert.equal(clusterIdFromRecord({ tsMs: T0, ruleId: 'r' }), '');
+  it('v1 record with link: harness still reads it via legacy fallback', () => {
+    // Pre-Codex-P1 records carry `link` not `sourceUrl`. The harness
+    // must still consume them so the 30-day TTL window doesn't get
+    // truncated when v2 ships.
+    const records = [
+      // No `repHash` (v1), no `sourceUrl` (v1) — only legacy fields.
+      { storyHash: 'h-x', mergedHashes: ['h-x'], link: 'https://www.usni.org/2026/foo', severity: 'high', ruleId: 'full:en:high', tsMs: T0 },
+      { storyHash: 'h-x', mergedHashes: ['h-x'], link: 'https://www.usni.org/2026/foo', severity: 'high', ruleId: 'full:en:high', tsMs: T0 + 6 * DAY_MS },
+      { storyHash: 'h-pad', mergedHashes: ['h-pad'], ruleId: 'full:en:high', tsMs: T0 + 14 * DAY_MS },
+    ];
+    const agg = aggregateReplayDecisions(records, { minDaysCovered: 14 });
+    // v1 fallback path still produces the same analysis-domain
+    // classification via the link → sourceUrl alias.
+    assert.equal(agg.reasonHistogram['analysis_7d_hard'], 1);
   });
 });
 

--- a/tests/replay-digest-cooldown-harness.test.mjs
+++ b/tests/replay-digest-cooldown-harness.test.mjs
@@ -1,0 +1,320 @@
+// Sprint 1 / U6 — replay harness tests. Exercises the pure aggregator
+// against synthetic fixture timelines; the live-Redis IO path is
+// intentionally out of scope (the CLI wrapper requires the real Upstash
+// REST endpoint and 14 days of accumulated replay-log records, which
+// the test env doesn't have).
+//
+// The aggregator's contract: simulate cooldown decisions across all
+// (ruleId, clusterId) timelines, return histogram counts that match
+// the U5 decision module's behavior. If U5 changes the cooldown table
+// or reasons, these tests catch the drift via the histogram keys.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  aggregateReplayDecisions,
+  clusterIdFromRecord,
+  parseArgs,
+  renderMarkdownSummary,
+} from '../scripts/replay-digest-cooldown.mjs';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
+const T0 = 1_777_000_000_000; // start of synthetic 14-day window
+
+/** Helper: build a replay-log record with sane defaults. */
+function rec(overrides = {}) {
+  return {
+    storyHash: 'h-default',
+    isRep: true,
+    mergedHashes: ['h-default'],
+    currentScore: 50,
+    mentionCount: 1,
+    sources: ['Reuters'],
+    severity: 'high',
+    headline: 'Generic headline',
+    sourceUrl: 'https://example.com/x',
+    phase: 'sustained',
+    ruleId: 'full:en:high',
+    tsMs: T0,
+    ...overrides,
+  };
+}
+
+describe('clusterIdFromRecord', () => {
+  it('uses mergedHashes[0] when present (multi-story cluster identity)', () => {
+    assert.equal(clusterIdFromRecord(rec({ storyHash: 'h-x', mergedHashes: ['rep-a', 'h-x'] })), 'rep-a');
+  });
+
+  it('falls back to storyHash when mergedHashes is empty (singleton)', () => {
+    assert.equal(clusterIdFromRecord(rec({ storyHash: 'h-singleton', mergedHashes: [] })), 'h-singleton');
+  });
+
+  it('falls back to storyHash when mergedHashes is absent', () => {
+    assert.equal(clusterIdFromRecord(rec({ storyHash: 'h-foo', mergedHashes: undefined })), 'h-foo');
+  });
+
+  it('returns empty string when both are missing (caller filters)', () => {
+    assert.equal(clusterIdFromRecord({ tsMs: T0, ruleId: 'r' }), '');
+  });
+});
+
+describe('aggregateReplayDecisions — coverage gate', () => {
+  it('throws on empty input (flag may be off)', () => {
+    assert.throws(
+      () => aggregateReplayDecisions([], { minDaysCovered: 14 }),
+      /DIGEST_DEDUP_REPLAY_LOG may be off/,
+    );
+  });
+
+  it('throws when coverage < minDaysCovered (default 14d)', () => {
+    const records = [
+      rec({ tsMs: T0 }),
+      rec({ tsMs: T0 + 5 * DAY_MS }), // only 5 days of coverage
+    ];
+    assert.throws(
+      () => aggregateReplayDecisions(records, { minDaysCovered: 14 }),
+      /coverage 5\.\d+ days < required 14/,
+    );
+  });
+
+  it('passes the coverage gate when allowShortCoverage=true (test escape hatch)', () => {
+    const records = [
+      rec({ tsMs: T0 }),
+      rec({ tsMs: T0 + 5 * DAY_MS, storyHash: 'h-2', mergedHashes: ['h-2'] }),
+    ];
+    const agg = aggregateReplayDecisions(records, {
+      minDaysCovered: 14,
+      allowShortCoverage: true,
+    });
+    assert.equal(agg.totalRecords, 2);
+  });
+
+  it('passes when coverage meets minDaysCovered', () => {
+    const records = [
+      rec({ tsMs: T0 }),
+      rec({ tsMs: T0 + 14 * DAY_MS, storyHash: 'h-2', mergedHashes: ['h-2'] }),
+    ];
+    const agg = aggregateReplayDecisions(records, { minDaysCovered: 14 });
+    assert.ok(agg.coverage.daysCovered >= 14);
+  });
+});
+
+describe('aggregateReplayDecisions — single-occurrence timelines (no decision)', () => {
+  it('skips timelines with only one occurrence (no cooldown to evaluate)', () => {
+    const records = [
+      rec({ storyHash: 'h-1', mergedHashes: ['h-1'], tsMs: T0 }),
+      rec({ storyHash: 'h-2', mergedHashes: ['h-2'], tsMs: T0 + 14 * DAY_MS }),
+    ];
+    const agg = aggregateReplayDecisions(records, { minDaysCovered: 14 });
+    assert.equal(agg.totalTimelines, 2);
+    assert.equal(agg.totalDecisions, 0);
+    assert.equal(agg.dropRatePct, 0);
+  });
+});
+
+describe('aggregateReplayDecisions — multi-occurrence timelines simulate cooldown', () => {
+  it('within-floor re-occurrence on a soft type → suppress decision recorded', () => {
+    // Two occurrences of the same cluster within the high-event 18h floor,
+    // no source-count evolution. Expect: 1 decision, suppress.
+    const records = [
+      rec({ storyHash: 'h-x', mergedHashes: ['h-x'], severity: 'high', tsMs: T0 }),
+      rec({ storyHash: 'h-x', mergedHashes: ['h-x'], severity: 'high', tsMs: T0 + 6 * HOUR_MS }),
+      // Second cluster present so the coverage gate passes (2 records over 14d wouldn't satisfy).
+      rec({ storyHash: 'h-y', mergedHashes: ['h-y'], severity: 'high', tsMs: T0 + 14 * DAY_MS }),
+    ];
+    const agg = aggregateReplayDecisions(records, { minDaysCovered: 14 });
+    assert.equal(agg.totalDecisions, 1);
+    assert.equal(agg.suppressDecisions, 1);
+    assert.equal(agg.allowDecisions, 0);
+    assert.equal(agg.dropRatePct, 100);
+    assert.ok(agg.reasonHistogram['cooldown_floor'] >= 1);
+  });
+
+  it('beyond-floor re-occurrence → allow decision recorded', () => {
+    const records = [
+      rec({ storyHash: 'h-x', mergedHashes: ['h-x'], severity: 'high', tsMs: T0 }),
+      rec({ storyHash: 'h-x', mergedHashes: ['h-x'], severity: 'high', tsMs: T0 + 24 * HOUR_MS }), // > 18h floor
+      rec({ storyHash: 'h-y', mergedHashes: ['h-y'], severity: 'high', tsMs: T0 + 14 * DAY_MS }),
+    ];
+    const agg = aggregateReplayDecisions(records, { minDaysCovered: 14 });
+    assert.equal(agg.allowDecisions, 1);
+    assert.equal(agg.suppressDecisions, 0);
+  });
+
+  it('+5 sources within floor → allow / evolution_source_count', () => {
+    const records = [
+      rec({ storyHash: 'h-x', mergedHashes: ['h-x'], severity: 'high', sources: ['Reuters', 'AP'], tsMs: T0 }), // 2 sources
+      rec({ storyHash: 'h-x', mergedHashes: ['h-x'], severity: 'high', sources: ['Reuters', 'AP', 'BBC', 'CNN', 'NPR', 'France 24', 'Al Jazeera'], tsMs: T0 + 6 * HOUR_MS }), // 7 sources, +5
+      rec({ storyHash: 'h-y', mergedHashes: ['h-y'], severity: 'high', tsMs: T0 + 14 * DAY_MS }),
+    ];
+    const agg = aggregateReplayDecisions(records, { minDaysCovered: 14 });
+    assert.equal(agg.allowDecisions, 1);
+    assert.equal(agg.reasonHistogram['evolution_source_count'], 1);
+  });
+
+  it('Analysis domain hard floor: 6d re-air → suppress / analysis_7d_hard', () => {
+    const records = [
+      rec({ storyHash: 'h-a', mergedHashes: ['h-a'], severity: 'high', sourceUrl: 'https://usni.org/article-x', tsMs: T0 }),
+      rec({ storyHash: 'h-a', mergedHashes: ['h-a'], severity: 'high', sourceUrl: 'https://usni.org/article-x', tsMs: T0 + 6 * DAY_MS }),
+      rec({ storyHash: 'h-y', mergedHashes: ['h-y'], severity: 'high', tsMs: T0 + 14 * DAY_MS }),
+    ];
+    const agg = aggregateReplayDecisions(records, { minDaysCovered: 14 });
+    assert.equal(agg.suppressDecisions, 1);
+    assert.equal(agg.reasonHistogram['analysis_7d_hard'], 1);
+    assert.ok(agg.typeHistogram['analysis'] >= 1);
+  });
+
+  it('aggregates across multiple distinct timelines independently', () => {
+    const records = [
+      // Timeline 1: cluster A, 2 occurrences within floor → 1 suppress
+      rec({ storyHash: 'h-a', mergedHashes: ['h-a'], severity: 'high', tsMs: T0 }),
+      rec({ storyHash: 'h-a', mergedHashes: ['h-a'], severity: 'high', tsMs: T0 + 4 * HOUR_MS }),
+      // Timeline 2: cluster B, 2 occurrences beyond floor → 1 allow
+      rec({ storyHash: 'h-b', mergedHashes: ['h-b'], severity: 'high', tsMs: T0 + 1 * DAY_MS }),
+      rec({ storyHash: 'h-b', mergedHashes: ['h-b'], severity: 'high', tsMs: T0 + 14 * DAY_MS }),
+    ];
+    const agg = aggregateReplayDecisions(records, { minDaysCovered: 14 });
+    assert.equal(agg.totalDecisions, 2);
+    assert.equal(agg.suppressDecisions, 1);
+    assert.equal(agg.allowDecisions, 1);
+    assert.equal(agg.dropRatePct, 50);
+  });
+});
+
+describe('aggregateReplayDecisions — coverage report shape', () => {
+  it('reports startDate, endDate, daysCovered, distinctRuleIds', () => {
+    const records = [
+      rec({ ruleId: 'full:en:high', tsMs: T0 }),
+      rec({ ruleId: 'finance:en:high', storyHash: 'h-2', mergedHashes: ['h-2'], tsMs: T0 + 14 * DAY_MS }),
+    ];
+    const agg = aggregateReplayDecisions(records, { minDaysCovered: 14 });
+    assert.equal(agg.coverage.startDate, new Date(T0).toISOString().slice(0, 10));
+    assert.equal(agg.coverage.endDate, new Date(T0 + 14 * DAY_MS).toISOString().slice(0, 10));
+    assert.ok(agg.coverage.daysCovered >= 14);
+    assert.equal(agg.coverage.distinctRuleIds, 2);
+  });
+});
+
+describe('aggregateReplayDecisions — top-suppressed timelines', () => {
+  it('reports top-10 timelines sorted by suppress count', () => {
+    // Build 3 timelines with different suppress counts (3, 2, 1).
+    const records = [];
+    for (let i = 0; i < 4; i += 1) { // timeline A: 1 first + 3 suppresses
+      records.push(rec({ storyHash: 'h-a', mergedHashes: ['h-a'], tsMs: T0 + i * HOUR_MS }));
+    }
+    for (let i = 0; i < 3; i += 1) { // timeline B: 1 first + 2 suppresses
+      records.push(rec({ storyHash: 'h-b', mergedHashes: ['h-b'], tsMs: T0 + i * HOUR_MS }));
+    }
+    for (let i = 0; i < 2; i += 1) { // timeline C: 1 first + 1 suppress
+      records.push(rec({ storyHash: 'h-c', mergedHashes: ['h-c'], tsMs: T0 + i * HOUR_MS }));
+    }
+    // Coverage padding
+    records.push(rec({ storyHash: 'h-pad', mergedHashes: ['h-pad'], tsMs: T0 + 14 * DAY_MS }));
+
+    const agg = aggregateReplayDecisions(records, { minDaysCovered: 14 });
+    assert.equal(agg.topSuppressed.length, 3);
+    assert.equal(agg.topSuppressed[0].clusterId, 'h-a');
+    assert.equal(agg.topSuppressed[0].suppressCount, 3);
+    assert.equal(agg.topSuppressed[1].clusterId, 'h-b');
+    assert.equal(agg.topSuppressed[2].clusterId, 'h-c');
+  });
+
+  it('omits never-suppressed timelines from the top list', () => {
+    const records = [
+      rec({ storyHash: 'h-allow', mergedHashes: ['h-allow'], severity: 'high', tsMs: T0 }),
+      rec({ storyHash: 'h-allow', mergedHashes: ['h-allow'], severity: 'high', tsMs: T0 + 24 * HOUR_MS }), // beyond 18h floor → allow
+      rec({ storyHash: 'h-pad', mergedHashes: ['h-pad'], tsMs: T0 + 14 * DAY_MS }),
+    ];
+    const agg = aggregateReplayDecisions(records, { minDaysCovered: 14 });
+    assert.equal(agg.topSuppressed.length, 0);
+  });
+});
+
+describe('renderMarkdownSummary', () => {
+  it('produces a paste-ready markdown block with all key sections', () => {
+    const agg = {
+      totalRecords: 100,
+      totalTimelines: 30,
+      totalDecisions: 25,
+      allowDecisions: 17,
+      suppressDecisions: 8,
+      dropRatePct: 32,
+      reasonHistogram: { cooldown_floor: 6, evolution_source_count: 2 },
+      typeHistogram: { 'high-event': 20, 'critical-developing': 5 },
+      severityHistogram: { high: 80, critical: 20 },
+      topSuppressed: [
+        { clusterId: 'cluster-abc-123-def-456', ruleId: 'full:en:high', suppressCount: 3, allowCount: 0, reasons: { cooldown_floor: 3 } },
+      ],
+      coverage: { startDate: '2026-05-06', endDate: '2026-05-20', daysCovered: 14, distinctRuleIds: 1 },
+    };
+    const md = renderMarkdownSummary(agg);
+    assert.match(md, /Sprint 1 \/ U6 replay results/);
+    assert.match(md, /Drop-rate.*32%/);
+    assert.match(md, /Reason histogram/);
+    assert.match(md, /Type histogram/);
+    assert.match(md, /Top-10 most-suppressed/);
+    assert.match(md, /full:en:high/);
+  });
+
+  it('reports "no suppression" when topSuppressed is empty', () => {
+    const agg = {
+      totalRecords: 10,
+      totalTimelines: 5,
+      totalDecisions: 5,
+      allowDecisions: 5,
+      suppressDecisions: 0,
+      dropRatePct: 0,
+      reasonHistogram: { cooldown_floor: 5 },
+      typeHistogram: { 'high-event': 5 },
+      severityHistogram: { high: 10 },
+      topSuppressed: [],
+      coverage: { startDate: '2026-05-06', endDate: '2026-05-20', daysCovered: 14, distinctRuleIds: 1 },
+    };
+    const md = renderMarkdownSummary(agg);
+    assert.match(md, /No timelines triggered suppression in this window/);
+  });
+});
+
+describe('parseArgs', () => {
+  it('defaults to 14 days, no rule filter', () => {
+    const args = parseArgs(['node', 'replay-digest-cooldown.mjs']);
+    assert.equal(args.days, 14);
+    assert.equal(args.rule, null);
+    assert.equal(args.allowShortCoverage, false);
+    assert.equal(args.help, false);
+  });
+
+  it('parses --days N', () => {
+    const args = parseArgs(['node', 'r.mjs', '--days', '30']);
+    assert.equal(args.days, 30);
+  });
+
+  it('parses --rule <ruleId>', () => {
+    const args = parseArgs(['node', 'r.mjs', '--rule', 'full:en:high']);
+    assert.equal(args.rule, 'full:en:high');
+  });
+
+  it('parses --allow-short-coverage', () => {
+    const args = parseArgs(['node', 'r.mjs', '--allow-short-coverage']);
+    assert.equal(args.allowShortCoverage, true);
+  });
+
+  it('parses --help / -h', () => {
+    assert.equal(parseArgs(['node', 'r.mjs', '--help']).help, true);
+    assert.equal(parseArgs(['node', 'r.mjs', '-h']).help, true);
+  });
+
+  it('throws on unknown flag', () => {
+    assert.throws(() => parseArgs(['node', 'r.mjs', '--bogus']), /Unknown argument/);
+  });
+
+  it('throws when --days has a non-integer value', () => {
+    assert.throws(() => parseArgs(['node', 'r.mjs', '--days', 'forever']), /must be a positive integer/);
+  });
+
+  it('throws when --rule is missing its value', () => {
+    assert.throws(() => parseArgs(['node', 'r.mjs', '--rule']), /requires a value/);
+    assert.throws(() => parseArgs(['node', 'r.mjs', '--rule', '--days']), /requires a value/);
+  });
+});


### PR DESCRIPTION
**Stacked on PR #3614** (Phase 1 canonical contract). Merge order: #3614 first, then this PR rebases onto main automatically.

## Summary

Sprint 1 Phase 2/3 of the digest/brief overhaul scoped in `docs/internal/digest-brief-improvements.md`. Builds the per-channel/per-cluster delivered-log substrate, the cooldown decision module in shadow mode, and the 14-day replay harness that gates Sprint 2's enforce-mode rollout.

**Subscriber-visible: nothing changes in this PR.** All cooldown decisions are computed and logged but never gate a send. Sprint 2 (cooldown enforce + since-last-edition diff) flips that connection AFTER U6 replay validates the cooldown table against production data on 2026-05-20.

- **U4 (`f5d7d6bb4`)** — Per-channel/per-cluster delivered-log writer + `clearDeliveredEntry` operator primitive. Key shape `digest:sent:v1:${userId}:${channel}:${ruleId}:${clusterId}` written via SET NX EX (JSON-body pipeline form per `feedback_upstash_rest_set_ex_path_not_query`), 30d ± 0-3d jitter TTL (per `per-item-cache-cliff-masks-upstream-regression`). Tri-state `{written, conflicts, errors}` writer return per `skill_caller_narrows_partial_result_type_drops_failure_counters`. Trust SET NX boolean — no write-then-reread per `feedback_upstash_write_reread_race_in_handler`. ALSO: fixes the U7 production gap from PR #3614 by routing `formatDigest`/`formatDigestHtml` to `brief.envelope.data.stories` (post-cap, post-filter, ⊆ U7 invariant) via a `briefStoriesToFormatterShape` compatibility shim. clearDeliveredEntry CLI requires `--reason`; supports targeted (channel, rule) or sweep modes; per-deletion audit log.

- **U5 (`4c67fd194`)** — Cooldown decision module + shadow logger. Three new modules: `digest-cooldown-config.mjs` (kill-switch parser, fail-closed-to-shadow on typo per `feedback_kill_switch_default_on_typo`; `'enforce'` is intentionally invalid in Sprint 1), `digest-cooldown-decision.mjs` (pure decision function + 5-rule stub classifier per the plan; cooldown table covers CRITICAL kinetic 4h, sustained 24h hard, HIGH event 18h, HIGH single-corp 48h hard, Analysis 7d hard, MED 36h), `digest-cooldown-shadow-log.mjs` (one summary line per user-rule send). Decision artifact (NOT config env) gates downstream observability per `feedback_gate_on_ground_truth_not_configured_state`. Cron integration calls evaluator BEFORE channel send, logs decision, never gates the send.

- **U6 (`c83455efb`)** — 14-day replay harness against `digest:replay-log:v1:*`. Pure `aggregateReplayDecisions` (test-exercised) + thin Upstash-REST CLI wrapper. Builds (ruleId, clusterId) timelines, simulates U4 delivered-log state from the first occurrence, runs U5 evaluateCooldown on each subsequent occurrence. Reports drop-rate distribution by classification × severity × channel + top-10 most-suppressed timelines. Refuses to run on <14d coverage. **Live run earliest: 2026-05-20** (Phase 0 prereq `DIGEST_DEDUP_REPLAY_LOG=1` activated 2026-05-06). Fixture-tested only until then.

- **U8 (`5aff38518`)** — Dockerfile.digest-notifications import-closure static guard. Mirrors `tests/dockerfile-relay-imports.test.mjs` but extends coverage to ALL cross-dir imports (scripts/, shared/, server/_shared/, api/). BFS from cron entrypoint through the full import graph; every tracked-prefix file must be covered by either a file-level COPY or a directory-recursive COPY. Catches the same class of silent Railway crashes as the relay guard (the 2026-04-14→16 chokepoint-flows 32h outage). Strategic doc `docs/internal/digest-brief-improvements.md` also updated with Sprint 1 outcomes section (file is gitignored — local-only operator artifact).

## What this enables

After Phase 2/3 ships:
- `digest:sent:v1:*` keys begin populating in production with every cron tick (per-channel, per-cluster)
- Cooldown decisions are logged via the U5 shadow logger; operators see "would have suppressed N stories for user X" telemetry
- The U7 invariant `digest.cards ⊆ brief.cards` holds in production (was already CI-enforced in PR #3614; now also runtime-correct via the formatter call-site swap)
- 2026-05-20 onwards: U6 replay harness produces the drop-rate report that gates Sprint 2's enforce-mode rollout

## Review-iteration notes from PR #3614 (pre-applied here)

This branch incorporates the Codex P1+P2 and Greptile P2 fixes from PR #3614 (`a6de2c748` and `ab36acde0`) since it stacks on top of those commits. No re-review needed for those concerns.

## Subagent timeouts (transparency)

Two subagent stream-idle timeouts during U4 and U5; orchestrator inspected partial state, finished the work inline (U5's cooldown integration + tests; U4 was complete just untested). All work verified by full test suite + typecheck before commit. Pattern documented in commit messages.

## Test plan

- [x] `npm run typecheck` PASS
- [x] `npm run typecheck:api` PASS
- [x] CJS syntax check on `scripts/*.cjs`
- [x] `npm run lint` (Biome) exit 0; warnings are pre-existing, none in changed files
- [x] `npm run test:data` — 8064/8064 pass (54.4s, +134 net new tests for U4-U8)
- [x] Edge function bundle check — all `api/*.js` bundle cleanly
- [x] `node --test tests/edge-functions.test.mjs` — 181/181 pass
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — 2.8.0 sync OK
- [ ] Post-merge: monitor `[digest] U4 delivered-log` and `[digest] U5 cooldown` log lines for the first 24h; confirm written/conflicts/errors counters are within expected bands
- [ ] Post-merge: sample-curl one `digest:sent:v1:*` key from Upstash; verify TTL is between 2592000 and 2851200 seconds (30d to 30d+3d jitter)
- [ ] Post-merge: confirm `seed-meta:digest-delivered-log:v1:lastWriteAt` updates each cron tick (/api/health visibility)
- [ ] 2026-05-20: run `node scripts/replay-digest-cooldown.mjs` against production Upstash; record drop-rate distribution + classification mix in `docs/internal/digest-brief-improvements.md` Sprint 1 outcomes section
- [ ] After replay: open Sprint 2 PR (cooldown enforce-mode + since-last-edition diff)

## Related

- Plan: `docs/plans/2026-05-06-001-feat-digest-brief-canonical-contract-sprint-1-plan.md` (gitignored, local-only)
- Origin / strategic doc: `docs/internal/digest-brief-improvements.md` (gitignored, local-only)
- Stacked on: #3614 (Phase 1)
- Phase 0 prereq activated 2026-05-06; replay earliest-runnable 2026-05-20