### PR TITLE
fix(seeders): bump canonical TTLs to ≥3× cron interval (marketImplications + iranEvents)

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -15718,7 +15718,14 @@ async function runDeepForecastWorker({ once = false, runId = '' } = {}) {
 // ---------------------------------------------------------------------------
 
 const MARKET_IMPLICATIONS_KEY = 'intelligence:market-implications:v1';
-const MARKET_IMPLICATIONS_TTL = 75 * 60; // 75 minutes
+// 180min = 3× the ~60min cron cadence (api/health.js:416 sets
+// maxStaleMin=120 = 2× cron). Pre-fix at 75min the canonical TTL was only
+// 1.25× cron, so any cron drift or LLM-call slowness left canonical
+// TTL'd-out before the next write — seed-meta survived (rc=3, 78min old)
+// while the canonical was missing, manifesting as `marketImplications:
+// EMPTY records=0`. Same trap shape as BIS PR #3610 + iranEvents below;
+// see memory `seed-meta-populated-canonical-missing-ttl-cron-match`.
+const MARKET_IMPLICATIONS_TTL = 180 * 60;
 
 const ALLOWED_INSTRUMENTS = {
   equities: ['SPY', 'QQQ', 'DIA', 'IWM', 'EEM', 'VWO', 'EFA', 'GLD', 'SLV', 'USO', 'UNG', 'TLT', 'HYG', 'LQD',

--- a/scripts/seed-iran-events.mjs
+++ b/scripts/seed-iran-events.mjs
@@ -246,7 +246,17 @@ export function declareRecords(data) {
 
 runSeed('conflict', 'iran-events', CANONICAL_KEY, fetchIranEvents, {
   validateFn: validate,
-  ttlSeconds: 172800,
+  // 14d canonical TTL == maxStaleMin (20160 min = 14d). This is a MANUALLY
+  // re-seeded source (operator runs the script ~weekly when LiveUAMap has
+  // fresh events); pre-fix the canonical TTL was 2 days while the
+  // health-tolerance was 14 days, so any operator-cadence delay >2d left
+  // the canonical TTL'd-out while seed-meta survived. Health then reported
+  // `iranEvents: EMPTY records=0` while seed-meta still showed last-good
+  // recordCount. Symptom on WM 2026-05-08: last manual seed 2.7d ago
+  // (within tolerance), but canonical missing → CRIT in /api/health.
+  // Bumping canonical TTL to match maxStaleMin keeps the canonical alive
+  // for the full health-tolerance window. Same trap family as BIS PR #3610.
+  ttlSeconds: 1209600,     // 14 days = 14 * 24 * 3600
   sourceVersion: 'liveuamap-manual-v1',
 
   declareRecords,


### PR DESCRIPTION
## Symptom

\`/api/health\` on 2026-05-08 reported:

\`\`\`
marketImplications: EMPTY records=0 seedAge=78min  maxStale=120min
iranEvents:         EMPTY records=0 seedAge=3837min (~64h)  maxStale=20160min (14d)
\`\`\`

Both have fresh \`seed-meta\` entries (rc=3 marketImpl, rc=52 iranEvents from last successful runs) but the canonical keys are **MISSING** from Upstash. Same shape as BIS PR #3610.

## Root cause

Canonical TTL was only ~1× the cadence — zero drift margin. Per the "TTL ≥ 3× cron interval" gold standard codified in \`api/health.js:268-281\` and memory \`seed-meta-populated-canonical-missing-ttl-cron-match\`:

| Seeder | Pre-fix TTL | Cadence | Margin |
|---|---|---|---|
| marketImplications | 75min | ~60min cron | 1.25× — any LLM-call slowness or cron drift kills canonical |
| iranEvents | 2 days | weekly manual seeds | 0.28× — operator went 2.7d (within tolerance per maxStale=14d), canonical TTL'd out at 2d |

\`seed-meta\` has a much longer TTL (7 days for marketImpl; runSeed default for iranEvents) so it survives the gap, showing last-good rc — that's the diagnostic discriminator: rc>0 in seed-meta + canonical missing on direct GET = TTL/cadence mismatch.

## Fix

| Seeder | Pre-fix | Post-fix | Rationale |
|---|---|---|---|
| \`scripts/seed-forecasts.mjs:15721\` \`MARKET_IMPLICATIONS_TTL\` | \`75 * 60\` | \`180 * 60\` | 3× the ~60min cron — survives normal drift |
| \`scripts/seed-iran-events.mjs:249\` \`ttlSeconds\` | \`172800\` (2d) | \`1209600\` (14d) | Match \`maxStaleMin: 20160\` (14d) — canonical alive for the full health-tolerance window |

Both fixes carry extensive comments explaining the WHY so future contributors don't tighten under the plausible-but-wrong "TTL should match cron interval" intuition.

## Verification

- \`node -c\` clean on both files
- \`npm run typecheck:api\` clean
- \`npm run lint\` clean
- No tests required for pure-config TTL bumps. Memory \`seed-meta-populated-canonical-missing-ttl-cron-match\` documents the diagnostic recipe (curl canonical + curl seed-meta from Upstash) for verifying post-deploy.

## Test plan

- [x] Tests pass + lint/typecheck clean
- [ ] Post-merge: \`/api/health\` flips both \`marketImplications\` and \`iranEvents\` from EMPTY → OK after the next respective cron tick / manual seed
- [ ] Post-merge: direct Upstash GET on each canonical confirms it's alive (not nil) for the full health-tolerance window

## Sibling PR

A structural follow-up — a static test that scans all WM seeders + bundle \`intervalMs\` and asserts canonical TTL ≥ 3× cron — being opened concurrently. That would catch this trap class on every contribution rather than after the first production failure.

## Out of scope

\`consumerPricesSpread\` is also EMPTY (also surfaced in /api/health on 2026-05-08) but for a different reason — \`consumer-prices-core/src/jobs/publish.ts\` ran with state=OK_ZERO (0 retailers scraped within the 2h freshness window). Real data-pipeline issue in the \`consumer-prices-core\` service, not a TTL trap. Filing separately.