### PR TITLE
fix(sentry): Convex JSON InternalServerError → 503 + rainviewer allowlist + AbortError noise

### DIFF
--- a/api/_convex-error.js
+++ b/api/_convex-error.js
@@ -62,6 +62,15 @@ export function extractConvexErrorKind(err, msg) {
   // the edge handler maps it to 401 and tags it as `convex_auth_drift`
   // (WORLDMONITOR-PG).
   if (msg.includes('"code":"Unauthenticated"')) return 'UNAUTHENTICATED';
+  // Convex platform-level 500: `{"code":"InternalServerError","message":
+  // "Your request couldn't be completed. Try again later."}` — runtime
+  // signals an internal failure that the SDK can't classify further. Same
+  // remediation profile as the platform 503 (transient, retry with
+  // back-off), so reuse SERVICE_UNAVAILABLE → 503 + Retry-After response.
+  // Sentry `error_shape` discriminates via msg-pattern fallback so the
+  // dashboard can tell internal-500s apart from genuine ServiceUnavailable
+  // 503s (WORLDMONITOR-PG / WORLDMONITOR-PH).
+  if (msg.includes('"code":"InternalServerError"')) return 'SERVICE_UNAVAILABLE';
   if (msg.includes('CONFLICT')) return 'CONFLICT';
   if (msg.includes('BLOB_TOO_LARGE')) return 'BLOB_TOO_LARGE';
   if (msg.includes('UNAUTHENTICATED')) return 'UNAUTHENTICATED';

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -361,6 +361,12 @@ export function buildSentryContext(
     // case-sensitive.
     ?? (/UNAUTHENTICATED|"code":"Unauthenticated"/.test(msg) ? 'convex_auth_drift'
       : /"code":"ServiceUnavailable"/.test(msg) ? 'convex_service_unavailable'
+      // Convex platform 500 — runtime can't recover the request. Same
+      // 503-with-Retry-After remediation as ServiceUnavailable in
+      // _convex-error.js, but kept as its own Sentry bucket so on-call can
+      // tell internal-500s apart from genuine 503s when triaging
+      // (WORLDMONITOR-PG/PH).
+      : /"code":"InternalServerError"/.test(msg) ? 'convex_internal_error'
       : /\[Request ID:\s*[a-f0-9]+\]\s*Server Error/i.test(msg) ? 'convex_server_error'
       : /timeout|timed out|aborted/i.test(msg) ? 'transport_timeout'
       : /fetch failed|network|ECONN|ENOTFOUND|getaddrinfo/i.test(msg) ? 'transport_network'

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ const sentryDsn = import.meta.env.VITE_SENTRY_DSN?.trim();
 // fetches that happen to land on a maplibre-framed stack.
 const MAPLIBRE_THIRD_PARTY_TILE_HOSTS = new Set([
   'tilecache.rainviewer.com',
+  'api.rainviewer.com', // weather radar API used by MapContainer.fetchAndApplyRadar — WORLDMONITOR-QG
   'basemaps.cartocdn.com',
   'tiles.openfreemap.org',
   'protomaps.github.io',
@@ -99,6 +100,11 @@ Sentry.init({
     /setting 'luma'/,
     /ML request .* timed out/,
     /(?:AbortError: )?The operation was aborted\.?\s*$/,
+    // Bare `Uncaught Error: AbortError` (no message body) from Convex
+    // server-side action timeouts auto-captured by Convex's Sentry
+    // integration. Zero-frame, environment 'prod', no actionable context
+    // — the action retries cleanly. WORLDMONITOR-QH.
+    /^Uncaught Error: AbortError$/,
     /Unexpected end of script/,
     /Style is not done loading/,
     /Event `CustomEvent`.*captured as promise rejection/,
@@ -313,7 +319,15 @@ Sentry.init({
     // already logs it as a warning. Allowlist KNOWN third-party tile/style/glyph hosts —
     // leaves first-party fetch failures (self-hosted R2 PMTiles bucket, api.worldmonitor.app)
     // to surface so a real basemap regression is never silently dropped (WORLDMONITOR-NE/NF).
-    if (isMaplibreAjaxFailure && frames.some(f => /\/maplibre-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) {
+    //
+    // The maplibre-frame requirement was dropped (WORLDMONITOR-QG) — first-party
+    // call sites that fetch the same allowlisted hosts directly (e.g.
+    // `MapContainer.fetchAndApplyRadar` hitting `api.rainviewer.com`) get the same
+    // transient-network-failure behavior as the maplibre AJAX path. The
+    // host-allowlist set is the load-bearing safety: only known third-party hosts
+    // get suppressed; `api.worldmonitor.app` is intentionally NOT in the set so
+    // first-party API regressions still surface.
+    if (isMaplibreAjaxFailure) {
       const hostMatch = msg.match(/^Failed to fetch \(([^)]+)\)$/);
       const host = hostMatch?.[1];
       if (host && MAPLIBRE_THIRD_PARTY_TILE_HOSTS.has(host)) return null;

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,10 +9,14 @@ import { installUtmInterceptor } from './utils/utm';
 const sentryDsn = import.meta.env.VITE_SENTRY_DSN?.trim();
 
 // Known third-party hosts fetched by MapLibre (tiles, styles, glyphs, sprites).
-// Used by the beforeSend `Failed to fetch (<host>)` filter to avoid suppressing
-// failures from our self-hosted R2 PMTiles bucket or any api.worldmonitor.app
-// fetches that happen to land on a maplibre-framed stack.
-const MAPLIBRE_THIRD_PARTY_TILE_HOSTS = new Set([
+// Hosts whose `Failed to fetch (<host>)` errors are suppressed in beforeSend.
+// Originally maplibre-only (transient tile/style failures), expanded to cover
+// first-party callers that hit the same hosts directly (e.g.
+// `MapContainer.fetchAndApplyRadar` → `api.rainviewer.com`). The set IS the
+// safety: only known third-party hosts are suppressed; first-party fetches
+// to `api.worldmonitor.app` and the self-hosted R2 PMTiles bucket are NOT
+// in the set, so genuine basemap / API regressions still surface.
+const THIRD_PARTY_FETCH_HOST_ALLOWLIST = new Set([
   'tilecache.rainviewer.com',
   'api.rainviewer.com', // weather radar API used by MapContainer.fetchAndApplyRadar — WORLDMONITOR-QG
   'basemaps.cartocdn.com',
@@ -307,30 +311,32 @@ Sentry.init({
     // so a self-hosted R2 PMTiles / first-party basemap regression isn't silently dropped just
     // because its stack happens to be all-vendor frames (WORLDMONITOR-NE/NF follow-up).
     const excType = event.exception?.values?.[0]?.type ?? '';
-    const isMaplibreAjaxFailure = excType === 'TypeError' && /^Failed to fetch \([^)]+\)$/.test(msg);
-    if (!isMaplibreAjaxFailure
+    // `TypeError: Failed to fetch (<host>)` shape — emitted by maplibre's AJAX
+    // wrapper AND by first-party fetch callers that surface a host-suffixed
+    // network error. The host allowlist below is the load-bearing safety;
+    // this match is just the shape detector.
+    const isHostScopedFetchFailure = excType === 'TypeError' && /^Failed to fetch \([^)]+\)$/.test(msg);
+    if (!isHostScopedFetchFailure
         && (excType === 'TypeError' || excType === 'RangeError' || /^(?:TypeError|RangeError):/.test(msg))
         && frames.length > 0) {
       if (nonInfraFrames.length > 0 && nonInfraFrames.every(f => /\/(map|maplibre|deck-stack)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
     }
-    // Suppress MapLibre AJAXError for third-party tile fetches: maplibre wraps transient
-    // network errors as `Failed to fetch (<hostname>)` and rethrows in a Generator-backed
-    // Promise that leaks to onunhandledrejection even though DeckGLMap's map-error handler
-    // already logs it as a warning. Allowlist KNOWN third-party tile/style/glyph hosts —
-    // leaves first-party fetch failures (self-hosted R2 PMTiles bucket, api.worldmonitor.app)
-    // to surface so a real basemap regression is never silently dropped (WORLDMONITOR-NE/NF).
-    //
-    // The maplibre-frame requirement was dropped (WORLDMONITOR-QG) — first-party
-    // call sites that fetch the same allowlisted hosts directly (e.g.
-    // `MapContainer.fetchAndApplyRadar` hitting `api.rainviewer.com`) get the same
-    // transient-network-failure behavior as the maplibre AJAX path. The
-    // host-allowlist set is the load-bearing safety: only known third-party hosts
-    // get suppressed; `api.worldmonitor.app` is intentionally NOT in the set so
-    // first-party API regressions still surface.
-    if (isMaplibreAjaxFailure) {
+    // Suppress `Failed to fetch (<host>)` for known third-party hosts. Originally
+    // scoped to maplibre's tile/style/glyph fetches (which wrap transient network
+    // errors and rethrow in a Generator-backed Promise that leaks to
+    // onunhandledrejection even though DeckGLMap's map-error handler already
+    // logs the warning). Expanded (WORLDMONITOR-QG) to also cover first-party
+    // call sites that fetch the same allowlisted hosts directly — e.g.
+    // `MapContainer.fetchAndApplyRadar` hitting `api.rainviewer.com`. The
+    // host-allowlist set is the load-bearing safety: only known third-party
+    // hosts get suppressed; first-party fetch failures (self-hosted R2 PMTiles
+    // bucket, `api.worldmonitor.app`) are intentionally NOT in the set so a
+    // real basemap / API regression is never silently dropped
+    // (WORLDMONITOR-NE/NF, WORLDMONITOR-QG).
+    if (isHostScopedFetchFailure) {
       const hostMatch = msg.match(/^Failed to fetch \(([^)]+)\)$/);
       const host = hostMatch?.[1];
-      if (host && MAPLIBRE_THIRD_PARTY_TILE_HOSTS.has(host)) return null;
+      if (host && THIRD_PARTY_FETCH_HOST_ALLOWLIST.has(host)) return null;
     }
     // Suppress Three.js/globe.gl TypeError crashes in main bundle (reading 'type'/'pathType'/'count'/'__globeObjType' on undefined during WebGL traversal/raycast).
     // __globeObjType is exclusively set by three-globe on its own objects and we have no user onClick/onHover handler, so it is always globe.gl internal even when the stack shows the bundled main chunk (WORLDMONITOR-ME).
@@ -523,7 +529,7 @@ Sentry.init({
         // failing in our shipped code surfaces with at least one
         // source-mapped .ts frame on the rejection (the awaiting site).
         // The hostname-suffixed variant `Failed to fetch (<host>)` is
-        // handled above by `isMaplibreAjaxFailure` which does its own
+        // handled above by `isHostScopedFetchFailure` which does its own
         // first-party-host allowlist (WORLDMONITOR-KM).
         || /^(?:TypeError: )?Failed to fetch$/.test(msg)
       )

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -29,10 +29,10 @@ const fnBody = mainSrc.slice(bsStart + 'beforeSend(event) '.length, bsEnd)
   .replace(/as\s+\w+(\[\])?/g, '')        // type assertions
   .replace(/<[A-Z]\w*>/g, '');            // generic type params
 
-// Extract the MAPLIBRE_THIRD_PARTY_TILE_HOSTS Set so the test harness can evaluate
+// Extract the THIRD_PARTY_FETCH_HOST_ALLOWLIST Set so the test harness can evaluate
 // beforeSend with the same allowlist the real module has.
-const tpMatch = mainSrc.match(/const MAPLIBRE_THIRD_PARTY_TILE_HOSTS = new Set\(\[[^\]]*\]\);/);
-assert.ok(tpMatch, 'MAPLIBRE_THIRD_PARTY_TILE_HOSTS must be defined in src/main.ts');
+const tpMatch = mainSrc.match(/const THIRD_PARTY_FETCH_HOST_ALLOWLIST = new Set\(\[[^\]]*\]\);/);
+assert.ok(tpMatch, 'THIRD_PARTY_FETCH_HOST_ALLOWLIST must be defined in src/main.ts');
 
 // Build a callable version. Input: a Sentry-shaped event object. Returns event or null.
 // eslint-disable-next-line no-new-func
@@ -263,7 +263,7 @@ describe('zero-frame async-rejection patterns (timeout / DOMException / OOM / DO
     // fetch failures surface with a source-mapped frame on the awaiting
     // site (WORLDMONITOR-KM 10ev/8u). The host-suffixed variant
     // `Failed to fetch (<host>)` has its own first-party allowlist
-    // earlier in beforeSend (isMaplibreAjaxFailure), so doesn't go
+    // earlier in beforeSend (isHostScopedFetchFailure), so doesn't go
     // through this gate.
     ['Failed to fetch', 'TypeError'],
     ['TypeError: Failed to fetch', 'TypeError'],

--- a/tests/user-prefs-convex-error.test.mjs
+++ b/tests/user-prefs-convex-error.test.mjs
@@ -102,6 +102,35 @@ describe('extractConvexErrorKind — Convex client error → kind', () => {
     });
   });
 
+  describe('Convex platform 500 — InternalServerError JSON body (transient runtime failure)', () => {
+    it('detects SERVICE_UNAVAILABLE from the {"code":"InternalServerError"} JSON shape', () => {
+      // WORLDMONITOR-PG/PH: Convex runtime occasionally surfaces
+      //   `{"code":"InternalServerError","message":"Your request couldn't
+      //     be completed. Try again later."}`
+      // when an action / mutation fails internally. Same retry-with-backoff
+      // remediation as ServiceUnavailable, so we map to SERVICE_UNAVAILABLE
+      // → 503 + Retry-After. Sentry's `error_shape` classifier still
+      // discriminates these two cases via its own msg pattern.
+      const err = new Error('{"code":"InternalServerError","message":"Your request couldn\'t be completed. Try again later."}');
+      assert.equal(extractConvexErrorKind(err, err.message), 'SERVICE_UNAVAILABLE');
+    });
+
+    it('does NOT match the loose phrase "internal server error" without the JSON code field', () => {
+      // Defensive: detector keys off the exact JSON shape, not free-form
+      // prose, so unrelated upstreams that mention the words don't get
+      // bucketed together.
+      const err = new Error('upstream returned an internal server error, retrying');
+      assert.equal(extractConvexErrorKind(err, err.message), null);
+    });
+
+    it('structured-data path still wins over JSON-shape InternalServerError (forward-compat)', () => {
+      const err = Object.assign(new Error('{"code":"InternalServerError","message":"x"}'), {
+        data: { kind: 'CONFLICT' },
+      });
+      assert.equal(extractConvexErrorKind(err, err.message), 'CONFLICT');
+    });
+  });
+
   describe('legacy substring-match fallback (string-data ConvexError that arrived without errorData)', () => {
     it('matches CONFLICT in the message', () => {
       const err = new Error('CONFLICT');

--- a/tests/user-prefs-sentry-context.test.mts
+++ b/tests/user-prefs-sentry-context.test.mts
@@ -130,6 +130,17 @@ describe('buildSentryContext — backwards-compat for non-CONFLICT callers', () 
     assert.equal(ctx.tags.error_shape, 'convex_service_unavailable');
   });
 
+  it('JSON-shape "code":"InternalServerError" classifies as convex_internal_error', () => {
+    // WORLDMONITOR-PG/PH: Convex runtime 500 was previously bucketed as
+    // 'unknown' in the dashboard, conflating a transient platform failure
+    // with genuinely-novel error shapes. Its own bucket + the
+    // SERVICE_UNAVAILABLE mapping in `_convex-error.js` mean on-call sees
+    // these tagged distinctly without a 500 → 503 user-impact regression.
+    const err = new Error('{"code":"InternalServerError","message":"Your request couldn\'t be completed. Try again later."}');
+    const ctx = buildSentryContext(err, err.message, baseOpts);
+    assert.equal(ctx.tags.error_shape, 'convex_internal_error');
+  });
+
   it('JSON-shape "code":"Unauthenticated" classifies as convex_auth_drift (mixed-case OIDC failure)', () => {
     // WORLDMONITOR-PG: Convex platform-level 401 ships a JSON body
     //   `{"code":"Unauthenticated","message":"Could not verify OIDC token claim..."}`


### PR DESCRIPTION
## Summary

Three triage findings bundled because they all touch the same Sentry-classification surfaces.

### A. WORLDMONITOR-PG (9ev/7u) + PH (3ev/3u) — JSON-shape `InternalServerError`

Convex runtime occasionally surfaces `{"code":"InternalServerError","message":"Your request couldn't be completed. Try again later."}` on internal failures. The legacy substring check missed this shape and it bucketed as `error_shape: 'unknown'` → generic 500. Same retry-with-backoff remediation as the already-handled `"code":"ServiceUnavailable"`:

- `api/_convex-error.js`: detect the JSON shape → return `SERVICE_UNAVAILABLE` kind. Edge handler maps to 503 + Retry-After.
- `api/user-prefs.ts`: extend `error_shape` classifier with `convex_internal_error` bucket so on-call sees runtime-500s and platform 503s as separate issues.

### B. WORLDMONITOR-QG (1ev/1u) — `Failed to fetch (api.rainviewer.com)`

The host-allowlist gate at `src/main.ts` required a maplibre frame in the stack. `MapContainer.fetchAndApplyRadar` calls fetch directly (no maplibre frame in trace), so the gate didn't fire for `api.rainviewer.com`. Two changes:
- Added `api.rainviewer.com` to `MAPLIBRE_THIRD_PARTY_TILE_HOSTS`.
- Dropped the maplibre-frame requirement on the gate. The host-set IS the load-bearing safety — `api.worldmonitor.app` is intentionally NOT in the set, so first-party API regressions still surface.

### C. WORLDMONITOR-QH (1ev/1u) — bare `Uncaught Error: AbortError`

Zero-frame, env=prod. Convex auto-Sentry on server-side action timeouts; no actionable context, the action retries cleanly. Anchored `^Uncaught Error: AbortError$` added to `ignoreErrors`.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean
- [x] `npm run lint` — exit 0
- [x] `npm run test:data` — 8118/8118 pass (3 new cases in `user-prefs-convex-error.test.mjs`, 1 in `user-prefs-sentry-context.test.mts`)
- [x] `node --test tests/edge-functions.test.mjs` — 181/181 pass
- [x] Edge bundle check — clean
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — OK

## Sentry status

PG / PH / QG / QH resolved with `inNextRelease: true`. QD (deck.gl pointer-handler `Iie.Fie` crash, 4ev/2u) was also resolved this round but deferred to auto-reopen — the minified symbol is bundled into our own MapContainer chunk, so a generic filter would risk masking real first-party MapContainer.ts bugs.