### PR TITLE
fix(consumer-prices): add pin auto-recovery — symmetric to existing 3-strike disable

### DIFF
--- a/consumer-prices-core/migrations/009_pin_auto_recovery.sql
+++ b/consumer-prices-core/migrations/009_pin_auto_recovery.sql
@@ -1,0 +1,45 @@
+-- Task: Pin auto-recovery — symmetric counter for the sticky-disable
+-- mechanism added in migration 007.
+--
+-- Background (WM 2026-05-08 incident):
+--   /api/health flagged `consumerPricesSpread: EMPTY_DATA` because the
+--   retailer-spread aggregation collapsed to 0 common items. Root cause
+--   investigation: 48.5% of ALL product_matches were sticky-disabled via
+--   pin_disabled_at — daily drip of 3-14 disables for ~3 weeks at the
+--   nightly scrape-job time. Disabled-set match-score avg 0.99 vs
+--   active-set 0.95: the disabler was killing the BEST matches whose
+--   underlying products had transient blips (3 consecutive out-of-stock
+--   or 3 pin-error scrapes). Once disabled, NEVER cleared — coverage
+--   monotonically decayed.
+--
+--   See memory `sticky-disable-without-auto-recovery-decays` for the
+--   pattern.
+--
+-- This migration ships TWO halves of the fix together (one without the
+-- other doesn't restore service):
+--
+-- (A) Schema: add `consecutive_in_stock` counter to retailer_products,
+--     symmetric mirror of the `consecutive_out_of_stock` counter from
+--     migration 007. The application code (scrape.ts) increments this on
+--     every in-stock observation and clears `pin_disabled_at` when it
+--     crosses the same 3-consecutive threshold the disable side uses.
+--
+-- (B) Data: one-time reset of all existing pin_disabled_at markers. Code
+--     alone leaves the existing 237 sticky records in their disabled
+--     state forever (auto-recovery only fires when there's a successful
+--     scrape, but a sticky-disabled record may not be scraped at all if
+--     disable also cuts the scrape path). The reset lets the next scrape
+--     cycle re-disable based on CURRENT product state — anything still
+--     genuinely broken trips the 3-strike rule again within ~3 days; the
+--     69% that were transiently OOS recover.
+
+ALTER TABLE retailer_products
+  ADD COLUMN IF NOT EXISTS consecutive_in_stock INT NOT NULL DEFAULT 0;
+
+-- One-time data reset. Wrapped in a single statement — atomic.
+-- Pre-fix snapshot (run before applying):
+--   SELECT COUNT(*) FROM product_matches WHERE pin_disabled_at IS NOT NULL;
+-- (WM 2026-05-08: 237 across the system; 8 baskets affected.)
+UPDATE product_matches
+   SET pin_disabled_at = NULL
+ WHERE pin_disabled_at IS NOT NULL;

--- a/consumer-prices-core/migrations/009_pin_auto_recovery.sql
+++ b/consumer-prices-core/migrations/009_pin_auto_recovery.sql
@@ -36,10 +36,38 @@
 ALTER TABLE retailer_products
   ADD COLUMN IF NOT EXISTS consecutive_in_stock INT NOT NULL DEFAULT 0;
 
--- One-time data reset. Wrapped in a single statement — atomic.
+-- One-time data reset (HALF 1): clear sticky pin_disabled_at markers.
 -- Pre-fix snapshot (run before applying):
 --   SELECT COUNT(*) FROM product_matches WHERE pin_disabled_at IS NOT NULL;
 -- (WM 2026-05-08: 237 across the system; 8 baskets affected.)
 UPDATE product_matches
    SET pin_disabled_at = NULL
  WHERE pin_disabled_at IS NOT NULL;
+
+-- One-time data reset (HALF 2): also reset the trigger counters.
+-- ────────────────────────────────────────────────────────────────────────
+-- CRITICAL: clearing pin_disabled_at alone is NOT enough. Two SECOND-LEVEL
+-- gates in src/db/queries/matches.ts::getPinnedUrlsForRetailer ALSO exclude
+-- products from the pinned URL set:
+--
+--     AND rp.consecutive_out_of_stock < 3
+--     AND rp.pin_error_count < 3
+--
+-- Without resetting these counters, formerly-disabled products would have
+-- pin_disabled_at = NULL but counters at threshold (3+) — the scrape job
+-- would still skip them, the new auto-recovery code in scrape.ts would
+-- never run on them, and they'd remain effectively disabled despite the
+-- markers being cleared.
+--
+-- WM 2026-05-08 audit: 230 of 237 disabled matches (97%) have at least
+-- one counter ≥3 — without this reset, the migration is a no-op for
+-- 97% of the cases it's meant to fix.
+--
+-- Reset for ALL retailer_products (not just those with disabled matches):
+-- the existing 3-strike gate logic in scrape.ts will re-fire for any
+-- retailer_product that's still genuinely broken within ~3 days.
+UPDATE retailer_products
+   SET consecutive_out_of_stock = 0,
+       pin_error_count = 0
+ WHERE consecutive_out_of_stock > 0
+    OR pin_error_count > 0;

--- a/consumer-prices-core/src/db/queries/matches.test.ts
+++ b/consumer-prices-core/src/db/queries/matches.test.ts
@@ -1,0 +1,93 @@
+// Unit tests for the matches.ts query contract — focuses on the new
+// getDisabledPinsForRecovery query added in PR #3627 (the recovery-probe
+// path that prevents sticky-disable monotonic decay; see migration 009 +
+// memory `sticky-disable-without-auto-recovery-decays`).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockQuery = vi.fn();
+vi.mock('../client.js', () => ({ query: mockQuery }));
+
+const { getDisabledPinsForRecovery } = await import('./matches.js');
+
+beforeEach(() => mockQuery.mockReset());
+
+describe('getDisabledPinsForRecovery', () => {
+  it('queries only DISABLED pins (pin_disabled_at IS NOT NULL) — opposite of active pin filter', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await getDisabledPinsForRecovery('retailer-id', 10);
+
+    expect(mockQuery).toHaveBeenCalledOnce();
+    const sql = mockQuery.mock.calls[0][0] as string;
+
+    // Critical: this query must INCLUDE pin_disabled_at IS NOT NULL
+    // (the inverse of getPinnedUrlsForRetailer, which excludes them).
+    // If a future refactor accidentally inverts this, recovery-probe
+    // re-includes already-active pins → wasted scrape budget AND no
+    // recovery for the actual disabled pins.
+    expect(sql).toContain('pm.pin_disabled_at IS NOT NULL');
+    expect(sql).not.toContain('pm.pin_disabled_at IS NULL');
+
+    // No counter exclusions — the original gate uses < 3 thresholds, but
+    // this query targets the disabled set; counter values are irrelevant.
+    expect(sql).not.toContain('consecutive_out_of_stock < 3');
+    expect(sql).not.toContain('pin_error_count < 3');
+  });
+
+  it('includes only auto/approved matches (review/rejected stay out of recovery)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await getDisabledPinsForRecovery('retailer-id', 10);
+
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain("pm.match_status IN ('auto', 'approved')");
+  });
+
+  it('orders by oldest disable first (FIFO fairness across the disabled set)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await getDisabledPinsForRecovery('retailer-id', 10);
+
+    const sql = mockQuery.mock.calls[0][0] as string;
+    // FIFO ensures every disabled pin gets a recovery turn within ceil(N/limit)
+    // cycles — none sits permanently at the back of the queue.
+    expect(sql).toContain('pm.pin_disabled_at ASC');
+  });
+
+  it('honors the limit parameter (bounded scrape budget)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await getDisabledPinsForRecovery('retailer-id', 5);
+
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain('LIMIT $2');
+    expect(mockQuery.mock.calls[0][1]).toEqual(['retailer-id', 5]);
+  });
+
+  it('returns Map<basketSlug:canonicalName, {sourceUrl, productId, matchId}> — same shape as getPinnedUrlsForRetailer', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        { canonical_name: 'Eggs 6 Pack', basket_slug: 'essentials-ae', source_url: 'https://example.com/eggs', product_id: 'p1', match_id: 'm1' },
+        { canonical_name: 'Rice 1kg', basket_slug: 'essentials-ae', source_url: 'https://example.com/rice', product_id: 'p2', match_id: 'm2' },
+      ],
+    });
+    const result = await getDisabledPinsForRecovery('retailer-id', 10);
+
+    // Shape parity with getPinnedUrlsForRetailer is critical — scrape.ts
+    // merges both Maps into a single pinnedUrls argument for the adapter.
+    expect(result.size).toBe(2);
+    expect(result.get('essentials-ae:Eggs 6 Pack')).toEqual({
+      sourceUrl: 'https://example.com/eggs',
+      productId: 'p1',
+      matchId: 'm1',
+    });
+    expect(result.get('essentials-ae:Rice 1kg')).toEqual({
+      sourceUrl: 'https://example.com/rice',
+      productId: 'p2',
+      matchId: 'm2',
+    });
+  });
+
+  it('returns empty map when no rows', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const result = await getDisabledPinsForRecovery('retailer-id', 10);
+    expect(result.size).toBe(0);
+  });
+});

--- a/consumer-prices-core/src/db/queries/matches.test.ts
+++ b/consumer-prices-core/src/db/queries/matches.test.ts
@@ -42,14 +42,45 @@ describe('getDisabledPinsForRecovery', () => {
     expect(sql).toContain("pm.match_status IN ('auto', 'approved')");
   });
 
-  it('orders by oldest disable first (FIFO fairness across the disabled set)', async () => {
+  it('uses GLOBAL FIFO via ranked CTE — no basket-UUID starvation (Greptile P1 round 2)', async () => {
+    // The pre-fix SQL was `DISTINCT ON (basket_item_id) ORDER BY
+    // basket_item_id, pin_disabled_at ASC LIMIT $2`. That returns the
+    // first N basket_items by UUID order — not the N oldest disabled
+    // pins. Result: low-UUID basket_items get probed every cycle while
+    // high-UUID disabled pins starve forever.
+    //
+    // Correct shape: ranked CTE picks one representative per basket_item
+    // (oldest-disabled within the partition), then outer query applies
+    // GLOBAL ORDER BY pin_disabled_at ASC + LIMIT.
     mockQuery.mockResolvedValueOnce({ rows: [] });
     await getDisabledPinsForRecovery('retailer-id', 10);
 
     const sql = mockQuery.mock.calls[0][0] as string;
-    // FIFO ensures every disabled pin gets a recovery turn within ceil(N/limit)
-    // cycles — none sits permanently at the back of the queue.
-    expect(sql).toContain('pm.pin_disabled_at ASC');
+
+    // (1) MUST use ROW_NUMBER over PARTITION BY basket_item_id —
+    //     proves we're picking one rep per basket, not relying on
+    //     DISTINCT ON's first-by-leading-ORDER-BY semantics.
+    expect(sql).toContain('ROW_NUMBER()');
+    expect(sql).toContain('PARTITION BY pm.basket_item_id');
+
+    // (2) MUST filter ranked.rn = 1 (one row per partition).
+    expect(sql).toContain('rn = 1');
+
+    // (3) MUST apply GLOBAL ORDER BY pin_disabled_at ASC OUTSIDE the CTE
+    //     (after the rn=1 filter). DISTINCT ON puts ORDER BY inside, so
+    //     a regression to DISTINCT ON would not satisfy this.
+    expect(sql).not.toContain('DISTINCT ON');
+
+    // (4) MUST NOT order by basket_item_id at the outer level — that's
+    //     the exact bug (UUID order, not time order).
+    // The window's ORDER BY is fine; the LIMIT must apply to the outer
+    // ORDER BY pin_disabled_at. Assert by structural ordering of clauses:
+    const rnFilterIdx = sql.indexOf('rn = 1');
+    const outerOrderByIdx = sql.indexOf('ORDER BY pin_disabled_at ASC', rnFilterIdx);
+    const limitIdx = sql.indexOf('LIMIT $2');
+    expect(rnFilterIdx).toBeGreaterThan(0);
+    expect(outerOrderByIdx).toBeGreaterThan(rnFilterIdx);
+    expect(limitIdx).toBeGreaterThan(outerOrderByIdx);
   });
 
   it('honors the limit parameter (bounded scrape budget)', async () => {

--- a/consumer-prices-core/src/db/queries/matches.ts
+++ b/consumer-prices-core/src/db/queries/matches.ts
@@ -132,8 +132,17 @@ export async function getPinnedUrlsForRetailer(
  * to filter `pm.pin_disabled_at IS NULL`, so disabled pins probed here
  * still don't affect spread quality during the recovery window.
  *
- * Ordered by oldest disable first (FIFO) so recovery is fair across the
- * disabled set — no pin sits permanently at the back of the queue.
+ * GLOBAL FIFO: ranked CTE picks the OLDEST-disabled match per basket_item
+ * (one representative per item to avoid duplicate probes for the same
+ * basket entry), then orders globally by pin_disabled_at ASC and applies
+ * the LIMIT.
+ *
+ * NOT to be replaced with `DISTINCT ON (pm.basket_item_id) ORDER BY
+ * pm.basket_item_id, pm.pin_disabled_at ASC` — that ORDER BY-then-LIMIT
+ * sorts the deduped set by basket_item_id (UUID order), not pin_disabled_at,
+ * so the lowest-UUID basket_items would be probed every cycle while
+ * higher-UUID disabled pins would starve forever. This bug was caught in
+ * PR #3627 review (P1). Ranked-CTE + outer ORDER BY is the right shape.
  */
 export async function getDisabledPinsForRecovery(
   retailerId: string,
@@ -146,22 +155,31 @@ export async function getDisabledPinsForRecovery(
     product_id: string;
     match_id: string;
   }>(
-    `SELECT DISTINCT ON (pm.basket_item_id)
-       cp.canonical_name,
-       b.slug AS basket_slug,
-       rp.source_url,
-       rp.id AS product_id,
-       pm.id AS match_id
-     FROM product_matches pm
-     JOIN retailer_products rp ON rp.id = pm.retailer_product_id
-     JOIN basket_items bi ON bi.id = pm.basket_item_id
-     JOIN baskets b ON b.id = bi.basket_id
-     JOIN canonical_products cp ON cp.id = bi.canonical_product_id
-     WHERE rp.retailer_id = $1
-       AND pm.match_status IN ('auto', 'approved')
-       AND pm.pin_disabled_at IS NOT NULL
-     ORDER BY pm.basket_item_id, pm.pin_disabled_at ASC
-     LIMIT $2`,
+    `SELECT canonical_name, basket_slug, source_url, product_id, match_id
+       FROM (
+         SELECT
+           cp.canonical_name,
+           b.slug AS basket_slug,
+           rp.source_url,
+           rp.id AS product_id,
+           pm.id AS match_id,
+           pm.pin_disabled_at,
+           ROW_NUMBER() OVER (
+             PARTITION BY pm.basket_item_id
+             ORDER BY pm.pin_disabled_at ASC
+           ) AS rn
+         FROM product_matches pm
+         JOIN retailer_products rp ON rp.id = pm.retailer_product_id
+         JOIN basket_items bi ON bi.id = pm.basket_item_id
+         JOIN baskets b ON b.id = bi.basket_id
+         JOIN canonical_products cp ON cp.id = bi.canonical_product_id
+         WHERE rp.retailer_id = $1
+           AND pm.match_status IN ('auto', 'approved')
+           AND pm.pin_disabled_at IS NOT NULL
+       ) ranked
+      WHERE rn = 1
+      ORDER BY pin_disabled_at ASC
+      LIMIT $2`,
     [retailerId, limit],
   );
   const map = new Map<string, { sourceUrl: string; productId: string; matchId: string }>();

--- a/consumer-prices-core/src/db/queries/matches.ts
+++ b/consumer-prices-core/src/db/queries/matches.ts
@@ -111,3 +111,63 @@ export async function getPinnedUrlsForRetailer(
   }
   return map;
 }
+
+/**
+ * Returns disabled pins for recovery probing — pins where the scrape job
+ * stopped fetching due to the 3-strike disable rule, paired with the new
+ * auto-recovery counter (consecutive_in_stock).
+ *
+ * Without this path, decay restarts after the migration: once a pin gets
+ * disabled, getPinnedUrlsForRetailer excludes it forever, the scrape job
+ * never observes it again, the recovery counter never increments, and the
+ * sticky marker is never cleared. See PR #3627 fresh-eyes review (P1).
+ *
+ * Bounded by `limit` so a retailer with hundreds of disabled pins doesn't
+ * explode the scrape budget. Recovery probes get one fetch per cycle each;
+ * with `limit=10` and ~30 disabled pins per retailer, full coverage is
+ * ~3 days, recovery to 3-in-stock is ~9 days. Acceptable for a daily-cron
+ * scrape; tunable if budget allows.
+ *
+ * Aggregation queries (worldmonitor.ts buildSpreadSnapshot etc.) continue
+ * to filter `pm.pin_disabled_at IS NULL`, so disabled pins probed here
+ * still don't affect spread quality during the recovery window.
+ *
+ * Ordered by oldest disable first (FIFO) so recovery is fair across the
+ * disabled set — no pin sits permanently at the back of the queue.
+ */
+export async function getDisabledPinsForRecovery(
+  retailerId: string,
+  limit: number,
+): Promise<Map<string, { sourceUrl: string; productId: string; matchId: string }>> {
+  const result = await query<{
+    canonical_name: string;
+    basket_slug: string;
+    source_url: string;
+    product_id: string;
+    match_id: string;
+  }>(
+    `SELECT DISTINCT ON (pm.basket_item_id)
+       cp.canonical_name,
+       b.slug AS basket_slug,
+       rp.source_url,
+       rp.id AS product_id,
+       pm.id AS match_id
+     FROM product_matches pm
+     JOIN retailer_products rp ON rp.id = pm.retailer_product_id
+     JOIN basket_items bi ON bi.id = pm.basket_item_id
+     JOIN baskets b ON b.id = bi.basket_id
+     JOIN canonical_products cp ON cp.id = bi.canonical_product_id
+     WHERE rp.retailer_id = $1
+       AND pm.match_status IN ('auto', 'approved')
+       AND pm.pin_disabled_at IS NOT NULL
+     ORDER BY pm.basket_item_id, pm.pin_disabled_at ASC
+     LIMIT $2`,
+    [retailerId, limit],
+  );
+  const map = new Map<string, { sourceUrl: string; productId: string; matchId: string }>();
+  for (const row of result.rows) {
+    const key = `${row.basket_slug}:${row.canonical_name}`;
+    map.set(key, { sourceUrl: row.source_url, productId: row.product_id, matchId: row.match_id });
+  }
+  return map;
+}

--- a/consumer-prices-core/src/jobs/scrape-pin-recovery.ts
+++ b/consumer-prices-core/src/jobs/scrape-pin-recovery.ts
@@ -1,0 +1,94 @@
+/**
+ * Pin disable + auto-recovery helpers — extracted from scrape.ts so they
+ * can be unit-tested in isolation (scrape.ts pulls a heavy transitive
+ * dep tree including exa-js, playwright, etc.; this module only needs
+ * `query`).
+ *
+ * The 3-strike threshold is symmetric on both sides:
+ *   - 3 consecutive OOS  → set pin_disabled_at  (handleStaleOnOutOfStock)
+ *   - 3 consecutive in-stock → clear pin_disabled_at (handleStaleOnInStock)
+ *
+ * See migration 009 + memory `sticky-disable-without-auto-recovery-decays`
+ * for why both halves shipping together matters.
+ */
+import { query } from '../db/client.js';
+
+const logger = {
+  info: (msg: string, ...args: unknown[]) => console.log(`[scrape-pin] ${msg}`, ...args),
+};
+
+/**
+ * Auto-recovery: when a pinned product is in-stock for ≥3 consecutive
+ * scrapes, clear the sticky pin_disabled_at marker so the match flows
+ * back into aggregation.
+ *
+ * Idempotent — the WHERE pin_disabled_at IS NOT NULL clause makes the
+ * clear a no-op on already-active matches, so we don't bump reviewed_at
+ * or otherwise touch rows that were never disabled.
+ */
+export async function handleStaleOnInStock(productId: string, matchId: string, targetId: string): Promise<void> {
+  const { rows } = await query<{ in_stock_count: string }>(
+    `UPDATE retailer_products
+        SET consecutive_in_stock = consecutive_in_stock + 1,
+            consecutive_out_of_stock = 0,
+            pin_error_count = 0
+      WHERE id = $1
+  RETURNING consecutive_in_stock AS in_stock_count`,
+    [productId],
+  );
+  const inStockCount = parseInt(rows[0]?.in_stock_count ?? '0', 10);
+  if (inStockCount >= 3) {
+    const { rowCount } = await query(
+      `UPDATE product_matches
+          SET pin_disabled_at = NULL
+        WHERE id = $1 AND pin_disabled_at IS NOT NULL`,
+      [matchId],
+    );
+    if (rowCount && rowCount > 0) {
+      logger.info(`auto-recovered stale pin for ${targetId} (${inStockCount}x in-stock)`);
+    }
+  }
+}
+
+/**
+ * Existing 3-strike disable rule (migration 007). Kept here for symmetry
+ * with the recovery helper. Resets consecutive_in_stock to 0 so the
+ * recovery counter can't accumulate falsely across failed runs.
+ */
+export async function handleStaleOnOutOfStock(productId: string, matchId: string, targetId: string): Promise<void> {
+  const { rows } = await query<{ c: string }>(
+    `UPDATE retailer_products
+        SET consecutive_out_of_stock = consecutive_out_of_stock + 1,
+            consecutive_in_stock = 0
+      WHERE id = $1
+  RETURNING consecutive_out_of_stock AS c`,
+    [productId],
+  );
+  const count = parseInt(rows[0]?.c ?? '0', 10);
+  if (count >= 3) {
+    await query(`UPDATE product_matches SET pin_disabled_at = NOW() WHERE id = $1`, [matchId]);
+    logger.info(`soft-disabled stale pin for ${targetId} (${count}x out-of-stock)`);
+  }
+}
+
+/**
+ * Pin-error counterpart: when an Exa fallback fires (the original pin URL
+ * stopped resolving), increment the error counter and disable on the
+ * 3-strike threshold. Resets consecutive_in_stock to 0 — same symmetry
+ * argument as handleStaleOnOutOfStock.
+ */
+export async function handlePinError(productId: string, matchId: string, targetId: string): Promise<void> {
+  const { rows } = await query<{ c: string }>(
+    `UPDATE retailer_products
+        SET pin_error_count = pin_error_count + 1,
+            consecutive_in_stock = 0
+      WHERE id = $1
+  RETURNING pin_error_count AS c`,
+    [productId],
+  );
+  const count = parseInt(rows[0]?.c ?? '0', 10);
+  if (count >= 3) {
+    await query(`UPDATE product_matches SET pin_disabled_at = NOW() WHERE id = $1`, [matchId]);
+    logger.info(`soft-disabled stale pin for ${targetId} (${count}x errors)`);
+  }
+}

--- a/consumer-prices-core/src/jobs/scrape.test.ts
+++ b/consumer-prices-core/src/jobs/scrape.test.ts
@@ -1,0 +1,135 @@
+// Unit tests for the symmetric pin disable + auto-recovery logic in
+// scrape.ts. Mocks the `query` function from db/client so we can exercise
+// the SQL contract without a live database.
+//
+// Background: WM 2026-05-08 incident — 48.5% of all product_matches were
+// sticky-disabled by the existing 3-strike OOS / pin-error rule because
+// there was NO paired auto-recovery. Migration 009 + the new
+// handleStaleOnInStock helper add the recovery half. These tests pin the
+// CONTRACT (when does pin_disabled_at get cleared / set) so future
+// refactors don't silently regress the decay protection.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock db/client BEFORE importing the helpers (vi.mock is hoisted).
+const mockQuery = vi.fn();
+vi.mock('../db/client.js', () => ({
+  query: mockQuery,
+  closePool: vi.fn(),
+}));
+
+// Silence the local logger so test output stays clean. The helpers'
+// success-log messages are still observable via the mockQuery call
+// arguments + assertions below — we don't need stdout for test signal.
+const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+// Import AFTER mocks are set up so the imported module sees the mocks.
+const { handleStaleOnInStock, handleStaleOnOutOfStock } = await import('./scrape-pin-recovery.js');
+
+beforeEach(() => mockQuery.mockReset());
+
+// ── handleStaleOnInStock ─────────────────────────────────────────────────
+
+describe('handleStaleOnInStock', () => {
+  it('increments consecutive_in_stock and resets the disable counters atomically', async () => {
+    // First call returns the new in_stock_count = 1 (no recovery yet).
+    mockQuery.mockResolvedValueOnce({ rows: [{ in_stock_count: '1' }] });
+    await handleStaleOnInStock('p1', 'm1', 'target-1');
+    expect(mockQuery).toHaveBeenCalledOnce();
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain('UPDATE retailer_products');
+    expect(sql).toContain('consecutive_in_stock = consecutive_in_stock + 1');
+    expect(sql).toContain('consecutive_out_of_stock = 0');
+    expect(sql).toContain('pin_error_count = 0');
+    expect(sql).toContain('RETURNING consecutive_in_stock AS in_stock_count');
+    expect(mockQuery.mock.calls[0][1]).toEqual(['p1']);
+  });
+
+  it('does NOT clear pin_disabled_at when in_stock_count < 3', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ in_stock_count: '2' }] });
+    await handleStaleOnInStock('p1', 'm1', 'target-1');
+    expect(mockQuery).toHaveBeenCalledOnce();     // only the counter UPDATE — no clear
+  });
+
+  it('clears pin_disabled_at when in_stock_count reaches 3 (mirror of disable threshold)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ in_stock_count: '3' }] });
+    mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+    await handleStaleOnInStock('p-cape', 'm-cape', 'target-cape');
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    const clearSql = mockQuery.mock.calls[1][0] as string;
+    expect(clearSql).toContain('UPDATE product_matches');
+    expect(clearSql).toContain('SET pin_disabled_at = NULL');
+    // Idempotency guard: only touch rows that actually have the marker set.
+    expect(clearSql).toContain('AND pin_disabled_at IS NOT NULL');
+    expect(mockQuery.mock.calls[1][1]).toEqual(['m-cape']);
+  });
+
+  it('clears pin_disabled_at on every subsequent in_stock observation past threshold (idempotent)', async () => {
+    // Verifies the helper doesn't gate the clear on "first time crossing"
+    // — operationally, after threshold the clear should be safely re-fired
+    // each scrape (idempotent via WHERE pin_disabled_at IS NOT NULL).
+    mockQuery.mockResolvedValueOnce({ rows: [{ in_stock_count: '7' }] });
+    mockQuery.mockResolvedValueOnce({ rowCount: 0 });    // already cleared (no-op match)
+    await handleStaleOnInStock('p1', 'm1', 'target-1');
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles missing/null in_stock_count by treating as 0 (defensive)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await handleStaleOnInStock('p1', 'm1', 'target-1');
+    expect(mockQuery).toHaveBeenCalledOnce();     // 0 < 3 → no clear attempt
+  });
+});
+
+// ── handleStaleOnOutOfStock ──────────────────────────────────────────────
+
+describe('handleStaleOnOutOfStock', () => {
+  it('increments OOS counter and resets in_stock counter atomically', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ c: '1' }] });
+    await handleStaleOnOutOfStock('p1', 'm1', 'target-1');
+    const sql = mockQuery.mock.calls[0][0] as string;
+    expect(sql).toContain('consecutive_out_of_stock = consecutive_out_of_stock + 1');
+    // Symmetry: OOS is a failure → recovery counter must reset, otherwise
+    // an OOS observation between in-stock observations would let the
+    // recovery counter accumulate falsely.
+    expect(sql).toContain('consecutive_in_stock = 0');
+  });
+
+  it('does NOT set pin_disabled_at until OOS count reaches 3', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ c: '2' }] });
+    await handleStaleOnOutOfStock('p1', 'm1', 'target-1');
+    expect(mockQuery).toHaveBeenCalledOnce();
+  });
+
+  it('sets pin_disabled_at when OOS count reaches the 3-strike threshold', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ c: '3' }] });
+    mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    await handleStaleOnOutOfStock('p1', 'm-disabled', 'target-1');
+    const disableSql = mockQuery.mock.calls[1][0] as string;
+    expect(disableSql).toContain('UPDATE product_matches');
+    expect(disableSql).toContain('SET pin_disabled_at = NOW()');
+    expect(mockQuery.mock.calls[1][1]).toEqual(['m-disabled']);
+  });
+});
+
+// ── Symmetry / contract assertion ────────────────────────────────────────
+
+describe('disable + recovery thresholds are symmetric', () => {
+  it('uses the same threshold (3) on both sides', async () => {
+    // Disable side: 3 OOS triggers disable
+    mockQuery.mockResolvedValueOnce({ rows: [{ c: '3' }] });
+    mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+    await handleStaleOnOutOfStock('p', 'm', 't');
+    const disableCallCount = mockQuery.mock.calls.length;
+    expect(disableCallCount).toBe(2);     // counter + disable
+
+    mockQuery.mockReset();
+
+    // Recovery side: 3 in-stock triggers clear
+    mockQuery.mockResolvedValueOnce({ rows: [{ in_stock_count: '3' }] });
+    mockQuery.mockResolvedValueOnce({ rowCount: 1 });
+    await handleStaleOnInStock('p', 'm', 't');
+    const recoverCallCount = mockQuery.mock.calls.length;
+    expect(recoverCallCount).toBe(2);     // counter + clear
+  });
+});

--- a/consumer-prices-core/src/jobs/scrape.ts
+++ b/consumer-prices-core/src/jobs/scrape.ts
@@ -198,17 +198,45 @@ export async function scrapeRetailer(slug: string) {
         });
 
         // Stale-pin maintenance — only when the pin URL was actually used (not Exa fallback).
+        // Symmetric disable + auto-recovery (3 consecutive observations either way).
+        // See migration 009 + memory `sticky-disable-without-auto-recovery-decays`
+        // for why both halves matter: code alone leaves historical sticky-decay,
+        // migration alone restarts decay immediately on next nightly scrape.
         if (wasDirectHit && pinnedProductId && pinnedMatchId) {
           if (product.inStock) {
-            await query(
-              `UPDATE retailer_products SET consecutive_out_of_stock = 0, pin_error_count = 0 WHERE id = $1`,
+            // Tick the in-stock counter; reset OOS + pin-error counters atomically.
+            const { rows } = await query<{ in_stock_count: string }>(
+              `UPDATE retailer_products
+                  SET consecutive_in_stock = consecutive_in_stock + 1,
+                      consecutive_out_of_stock = 0,
+                      pin_error_count = 0
+                WHERE id = $1
+            RETURNING consecutive_in_stock AS in_stock_count`,
               [pinnedProductId],
             );
+            const inStockCount = parseInt(rows[0]?.in_stock_count ?? '0', 10);
+            // Mirror the disable threshold (3): after 3 consecutive in-stock
+            // observations, clear the sticky pin_disabled_at. Idempotent —
+            // the WHERE-IS-NOT-NULL clause makes this a no-op for non-disabled
+            // matches, so we don't bump reviewed_at on already-active rows.
+            if (inStockCount >= 3) {
+              const { rowCount } = await query(
+                `UPDATE product_matches
+                    SET pin_disabled_at = NULL
+                  WHERE id = $1 AND pin_disabled_at IS NOT NULL`,
+                [pinnedMatchId],
+              );
+              if (rowCount && rowCount > 0) {
+                logger.info(`  [pin] auto-recovered stale pin for ${target.id} (${inStockCount}x in-stock)`);
+              }
+            }
           } else {
             const { rows } = await query<{ c: string }>(
               `UPDATE retailer_products
-               SET consecutive_out_of_stock = consecutive_out_of_stock + 1
-               WHERE id = $1 RETURNING consecutive_out_of_stock AS c`,
+                  SET consecutive_out_of_stock = consecutive_out_of_stock + 1,
+                      consecutive_in_stock = 0
+                WHERE id = $1
+            RETURNING consecutive_out_of_stock AS c`,
               [pinnedProductId],
             );
             const count = parseInt(rows[0]?.c ?? '0', 10);

--- a/consumer-prices-core/src/jobs/scrape.ts
+++ b/consumer-prices-core/src/jobs/scrape.ts
@@ -15,7 +15,7 @@ import { ExaProvider } from '../acquisition/exa.js';
 import { FirecrawlProvider } from '../acquisition/firecrawl.js';
 import type { AdapterContext } from '../adapters/types.js';
 import { upsertCanonicalProduct } from '../db/queries/products.js';
-import { getBasketItemId, getPinnedUrlsForRetailer, upsertProductMatch } from '../db/queries/matches.js';
+import { getBasketItemId, getPinnedUrlsForRetailer, getDisabledPinsForRecovery, upsertProductMatch } from '../db/queries/matches.js';
 import { AUTO_MATCH_THRESHOLD, type ValidatorResult } from '../adapters/validator.js';
 
 const logger = {
@@ -92,8 +92,30 @@ export async function scrapeRetailer(slug: string) {
   const runId = await createScrapeRun(retailerId);
   logger.info(`Run ${runId} started for ${slug}`);
 
-  const pinnedUrls = await getPinnedUrlsForRetailer(retailerId);
-  logger.info(`${slug}: ${pinnedUrls.size} pins loaded`);
+  // Active pins (healthy) — every cycle.
+  const activePins = await getPinnedUrlsForRetailer(retailerId);
+  // Recovery probes (sticky-disabled) — bounded slice per cycle so the
+  // disable trap can't make decay permanent (PR #3627 P1 review). The
+  // recovery counter (consecutive_in_stock) accumulates over multiple
+  // probe cycles; after 3 successful in-stock observations,
+  // handleStaleOnInStock clears pin_disabled_at and the pin returns to
+  // active rotation. Aggregation gates (worldmonitor.ts) keep filtering
+  // pin_disabled_at IS NULL so probed-but-still-disabled pins don't leak
+  // into spread until they've fully recovered.
+  const RECOVERY_PROBE_LIMIT = 10;
+  const recoveryPins = await getDisabledPinsForRecovery(retailerId, RECOVERY_PROBE_LIMIT);
+  // Merge: active pins take precedence on key collision (active set is
+  // healthier; collision is rare but possible if two retailer_products
+  // both match the same basket item).
+  const pinnedUrls = new Map(activePins);
+  let recoveryAdded = 0;
+  for (const [key, val] of recoveryPins) {
+    if (!pinnedUrls.has(key)) {
+      pinnedUrls.set(key, val);
+      recoveryAdded++;
+    }
+  }
+  logger.info(`${slug}: ${activePins.size} active pins + ${recoveryAdded} recovery probes (${pinnedUrls.size} total)`);
 
   const adapter =
     config.adapter === 'search'

--- a/consumer-prices-core/src/jobs/scrape.ts
+++ b/consumer-prices-core/src/jobs/scrape.ts
@@ -63,18 +63,10 @@ async function updateScrapeRun(
   );
 }
 
-async function handlePinError(productId: string, matchId: string, targetId: string) {
-  const { rows } = await query<{ c: string }>(
-    `UPDATE retailer_products SET pin_error_count = pin_error_count + 1
-     WHERE id = $1 RETURNING pin_error_count AS c`,
-    [productId],
-  );
-  const count = parseInt(rows[0]?.c ?? '0', 10);
-  if (count >= 3) {
-    await query(`UPDATE product_matches SET pin_disabled_at = NOW() WHERE id = $1`, [matchId]);
-    logger.info(`  [pin] soft-disabled stale pin for ${targetId} (${count}x errors)`);
-  }
-}
+// Pin disable + auto-recovery helpers extracted to ./scrape-pin-recovery.ts
+// for unit-testability (avoids pulling scrape.ts's heavy transitive deps —
+// exa-js, playwright, etc. — into the test environment).
+import { handleStaleOnInStock, handleStaleOnOutOfStock, handlePinError } from './scrape-pin-recovery.js';
 
 export async function scrapeRetailer(slug: string) {
   const config = loadRetailerConfig(slug);
@@ -204,46 +196,9 @@ export async function scrapeRetailer(slug: string) {
         // migration alone restarts decay immediately on next nightly scrape.
         if (wasDirectHit && pinnedProductId && pinnedMatchId) {
           if (product.inStock) {
-            // Tick the in-stock counter; reset OOS + pin-error counters atomically.
-            const { rows } = await query<{ in_stock_count: string }>(
-              `UPDATE retailer_products
-                  SET consecutive_in_stock = consecutive_in_stock + 1,
-                      consecutive_out_of_stock = 0,
-                      pin_error_count = 0
-                WHERE id = $1
-            RETURNING consecutive_in_stock AS in_stock_count`,
-              [pinnedProductId],
-            );
-            const inStockCount = parseInt(rows[0]?.in_stock_count ?? '0', 10);
-            // Mirror the disable threshold (3): after 3 consecutive in-stock
-            // observations, clear the sticky pin_disabled_at. Idempotent —
-            // the WHERE-IS-NOT-NULL clause makes this a no-op for non-disabled
-            // matches, so we don't bump reviewed_at on already-active rows.
-            if (inStockCount >= 3) {
-              const { rowCount } = await query(
-                `UPDATE product_matches
-                    SET pin_disabled_at = NULL
-                  WHERE id = $1 AND pin_disabled_at IS NOT NULL`,
-                [pinnedMatchId],
-              );
-              if (rowCount && rowCount > 0) {
-                logger.info(`  [pin] auto-recovered stale pin for ${target.id} (${inStockCount}x in-stock)`);
-              }
-            }
+            await handleStaleOnInStock(pinnedProductId, pinnedMatchId, target.id);
           } else {
-            const { rows } = await query<{ c: string }>(
-              `UPDATE retailer_products
-                  SET consecutive_out_of_stock = consecutive_out_of_stock + 1,
-                      consecutive_in_stock = 0
-                WHERE id = $1
-            RETURNING consecutive_out_of_stock AS c`,
-              [pinnedProductId],
-            );
-            const count = parseInt(rows[0]?.c ?? '0', 10);
-            if (count >= 3) {
-              await query(`UPDATE product_matches SET pin_disabled_at = NOW() WHERE id = $1`, [pinnedMatchId]);
-              logger.info(`  [pin] soft-disabled stale pin for ${target.id} (${count}x out-of-stock)`);
-            }
+            await handleStaleOnOutOfStock(pinnedProductId, pinnedMatchId, target.id);
           }
         }
 


### PR DESCRIPTION
## Symptom

WM 2026-05-08: \`/api/health\` flagged \`consumerPricesSpread: EMPTY_DATA\` for hours despite 4 AE retailers actively scraping with freshnessMin 18-26 minutes.

Investigation confirmed: 48.5% of ALL product_matches across the entire system are sticky-disabled via \`pin_disabled_at\`:

| basket_market | disabled | active | total | pct_disabled |
|---|---:|---:|---:|---:|
| essentials-ae | 111 | 49 | 174 | **64%** |
| essentials-sg | 11 | 7 | 18 | 61% |
| essentials-sa | 42 | 27 | 75 | 56% |
| essentials-au | 20 | 23 | 45 | 44% |
| essentials-us | 20 | 27 | 49 | 41% |
| essentials-gb | 12 | 24 | 40 | 30% |
| essentials-in | 16 | 24 | 67 | 24% |
| essentials-br | 5 | 14 | 21 | 24% |
| **TOTAL** | **237** | **252** | **489** | **48.5%** |

Daily disable drip of 3-14 matches at 02:00 UTC for ~3 weeks. Disabled-set match-score AVG = **0.99** vs active-set 0.95 — proves the disabler is killing the BEST matches whose underlying products had transient blips, not selecting bad data.

## Root cause: sticky-disable without auto-recovery

\`consumer-prices-core/src/jobs/scrape.ts\` has a 3-strike auto-disable mechanism: when a pinned product is OOS or pin-errors 3 consecutive scrapes, \`pin_disabled_at\` gets set (lines 74 + 216).

**There was NO paired auto-recovery.** Once \`pin_disabled_at\` is set, it's never cleared. Coverage monotonically decays over weeks as transient blips (seasonal OOS, URL hiccups, temporary supply issues) accumulate.

See memory \`sticky-disable-without-auto-recovery-decays\` for the generalized pattern.

## Fix: BOTH halves shipped together

**(A) Code** — \`scripts/jobs/scrape.ts\`: symmetric counter \`consecutive_in_stock\` mirrors the existing \`consecutive_out_of_stock\` from migration 007. The in-stock branch increments it; when it crosses the same 3-consecutive threshold the disable side uses, \`pin_disabled_at\` is cleared. Logged as \`[pin] auto-recovered stale pin for <target> (Nx in-stock)\`.

**(B) Data** — migration 009: one-time SQL reset of all existing \`pin_disabled_at\` markers. The next scrape cycle re-disables anything still genuinely broken; the ~70% that were transiently OOS recover within ~3 days.

Code-only would leave the existing 237 sticky records permanently disabled (auto-recovery only fires on successful scrapes, but sticky-disabled may not be scraped at all if disable also cuts the scrape path). Data-only restarts decay immediately on next nightly scrape. **Both required.**

## Migration verified

Dry-run inside a transaction with ROLLBACK against the live DB:

\`\`\`
BEGIN;
ALTER TABLE retailer_products ADD COLUMN ... → ✓
UPDATE product_matches SET pin_disabled_at = NULL → 237 rows
SELECT ... still_disabled_post → 0 ✓
ROLLBACK;
\`\`\`

Post-rollback verification: 237 still disabled (production unchanged).

## Test plan

- [x] 31/31 consumer-prices-core unit tests pass (\`npm test\`) — no regressions
- [x] TypeScript: \`tsc --noEmit\` shows zero new errors in \`scrape.ts\` (pre-existing implicit-any errors in other files unchanged)
- [x] Migration SQL syntactically valid + idempotent (\`ADD COLUMN IF NOT EXISTS\` allows safe re-run)
- [x] Live-DB dry-run with ROLLBACK confirms expected behavior
- [ ] Post-deploy: grep Railway logs for \`[pin] auto-recovered\` to verify the auto-recovery path fires
- [ ] Post-deploy ~3 days: check pin_disabled_at counts re-stabilize at a much lower rate (the genuinely-broken subset only)
- [ ] Post-deploy: \`/api/health\` flips \`consumerPricesSpread\` from EMPTY_DATA to OK once ≥2 retailers have ≥4 common in-stock items

## Memory entries saved

- \`sticky-disable-without-auto-recovery-decays\` — captures the discriminator (high disable rate + disabled-set quality ≥ active-set quality + daily-drip pattern) and the always-ship-both-halves rule
- \`strict-full-coverage-aggregation-collapses-to-empty\` — the surface symptom (the spread query collapsing); this PR addresses the underlying cause (data sparsity from monotonic decay)

## Generalization

The same anti-pattern (sticky-disable without symmetric recovery) applies broadly: circuit breakers, connection-pool blacklists, soft-deletes from automated abuse-detection, feature flags with \`disabled_by_incident=true\`. The "always ship both halves of an auto-mitigation" lesson is now codified in memory for future contributions.