### PR TITLE
fix(widget): gate sandbox HTML delivery by nonce

### DIFF
--- a/public/wm-widget-sandbox.html
+++ b/public/wm-widget-sandbox.html
@@ -1,21 +1,51 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head><meta charset="utf-8"></head>
 <body>
 <script>
-(function () {
+(() => {
+  var params = new URLSearchParams(window.location.hash.slice(1));
+  var id = params.get('id') || '';
+  var token = params.get('token') || '';
   var handled = false;
-  window.addEventListener('message', function (e) {
+
+  function isAllowedParentOrigin(origin) {
+    return (
+      /^https:\/\/([a-z0-9-]+\.)?worldmonitor\.app$/i.test(origin) ||
+      /^https?:\/\/localhost(:\d+)?$/i.test(origin) ||
+      /^https?:\/\/127\.0\.0\.1(:\d+)?$/i.test(origin)
+    );
+  }
+
+  function getParentOrigin() {
+    try {
+      return new URL(document.referrer).origin;
+    } catch (_err) {
+      return '';
+    }
+  }
+
+  window.addEventListener('message', (e) => {
     if (handled) return;
     if (!e.data || e.data.type !== 'wm-html') return;
+    if (e.source !== window.parent) return;
+    if (e.data.id !== id || e.data.token !== token) return;
+    if (typeof e.data.html !== 'string') return;
+
     var origin = e.origin || '';
-    if (!origin.endsWith('worldmonitor.app') && !/^https?:\/\/localhost/.test(origin)) return;
+    if (!isAllowedParentOrigin(origin)) return;
+
     handled = true;
     document.open();
     document.write(e.data.html);
     document.close();
   });
-}());
+
+  var parentOrigin = getParentOrigin();
+  if (id && token && parentOrigin && isAllowedParentOrigin(parentOrigin)) {
+    window.parent.postMessage({ type: 'wm-widget-ready', id: id, token: token }, parentOrigin);
+  }
+})();
 </script>
 </body>
 </html>

--- a/public/wm-widget-sandbox.html
+++ b/public/wm-widget-sandbox.html
@@ -44,6 +44,8 @@
   var parentOrigin = getParentOrigin();
   if (id && token && parentOrigin && isAllowedParentOrigin(parentOrigin)) {
     window.parent.postMessage({ type: 'wm-widget-ready', id: id, token: token }, parentOrigin);
+  } else {
+    console.warn('[WorldMonitor] PRO widget sandbox handshake blocked: missing or disallowed parent origin.');
   }
 })();
 </script>

--- a/src/utils/widget-sanitizer.ts
+++ b/src/utils/widget-sanitizer.ts
@@ -157,6 +157,8 @@ function mountProWidget(iframe: HTMLIFrameElement): void {
   widgetBodyStore.delete(id);
   widgetTokenStore.delete(id);
   const html = buildWidgetDoc(body);
+  // Keep the mounted entry while the iframe remains connected so sandbox
+  // reloads after DOM moves can request the same document again.
   mountedWidgetDocs.set(id, { iframe, html, token });
   ensureWidgetMessageListener();
 

--- a/src/utils/widget-sanitizer.ts
+++ b/src/utils/widget-sanitizer.ts
@@ -49,14 +49,24 @@ export function wrapWidgetHtml(html: string, extraClass = ''): string {
 }
 
 const widgetBodyStore = new Map<string, string>();
+const widgetTokenStore = new Map<string, string>();
 
-// Keyed by iframe element — persists HTML across DOM moves so the load listener
-// can re-post whenever the browser re-navigates the iframe after a drag.
-const iframeHtmlStore = new WeakMap<HTMLIFrameElement, string>();
+const mountedWidgetDocs = new Map<string, {
+  iframe: HTMLIFrameElement;
+  html: string;
+  token: string;
+}>();
+let widgetMessageListenerStarted = false;
+
+function createWidgetToken(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
 
 function buildWidgetDoc(bodyContent: string): string {
   return `<!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'unsafe-inline'; img-src data:; connect-src https://cdn.jsdelivr.net;">
@@ -87,26 +97,49 @@ td{padding:5px 8px;border-bottom:1px solid var(--border-subtle);color:var(--text
 </html>`;
 }
 
+function handleWidgetSandboxReady(event: MessageEvent): void {
+  const data = event.data as { type?: unknown; id?: unknown; token?: unknown } | null;
+  if (!data || data.type !== 'wm-widget-ready' || typeof data.id !== 'string' || typeof data.token !== 'string') {
+    return;
+  }
+
+  const mounted = mountedWidgetDocs.get(data.id);
+  if (!mounted || data.token !== mounted.token || event.source !== mounted.iframe.contentWindow) {
+    return;
+  }
+
+  // The sandbox deliberately omits allow-same-origin, so the child document has
+  // an opaque origin and cannot be targeted with location.origin. The per-widget
+  // token and source check above are the trust boundary before sending HTML.
+  mounted.iframe.contentWindow?.postMessage(
+    { type: 'wm-html', id: data.id, token: mounted.token, html: mounted.html },
+    '*',
+  );
+}
+
+function ensureWidgetMessageListener(): void {
+  if (widgetMessageListenerStarted || typeof window === 'undefined') return;
+  window.addEventListener('message', handleWidgetSandboxReady);
+  widgetMessageListenerStarted = true;
+}
+
 function mountProWidget(iframe: HTMLIFrameElement): void {
   const id = iframe.dataset.wmId;
   if (!id) return;
 
-  // Already wired up — the persistent load listener will re-post on every
-  // navigation (including after the panel is dragged to a new position).
-  if (iframeHtmlStore.has(iframe)) return;
+  if (mountedWidgetDocs.has(id)) return;
 
   const body = widgetBodyStore.get(id);
-  if (!body) return;
+  const token = widgetTokenStore.get(id);
+  if (!body || !token) return;
   widgetBodyStore.delete(id);
+  widgetTokenStore.delete(id);
   const html = buildWidgetDoc(body);
-  iframeHtmlStore.set(iframe, html);
+  mountedWidgetDocs.set(id, { iframe, html, token });
+  ensureWidgetMessageListener();
 
-  // Persistent (no { once }) — fires on initial load AND whenever the browser
-  // re-navigates the iframe after its DOM position changes (drag/drop).
-  iframe.addEventListener('load', () => {
-    const storedHtml = iframeHtmlStore.get(iframe);
-    if (storedHtml) iframe.contentWindow?.postMessage({ type: 'wm-html', html: storedHtml }, '*');
-  });
+  const fragment = new URLSearchParams({ id, token }).toString();
+  iframe.src = `/wm-widget-sandbox.html#${fragment}`;
 }
 
 if (typeof document !== 'undefined') {
@@ -134,6 +167,8 @@ if (typeof document !== 'undefined') {
 
 export function wrapProWidgetHtml(bodyContent: string): string {
   const id = `wm-${Math.random().toString(36).slice(2)}`;
+  const token = createWidgetToken();
   widgetBodyStore.set(id, stripLeadingPanelHeader(bodyContent));
-  return `<div class="wm-widget-shell wm-widget-pro"><iframe src="/wm-widget-sandbox.html" data-wm-id="${id}" sandbox="allow-scripts" style="width:100%;height:400px;border:none;display:block;" title="Interactive widget"></iframe></div>`;
+  widgetTokenStore.set(id, token);
+  return `<div class="wm-widget-shell wm-widget-pro"><iframe data-wm-id="${id}" sandbox="allow-scripts" style="width:100%;height:400px;border:none;display:block;" title="Interactive widget"></iframe></div>`;
 }

--- a/src/utils/widget-sanitizer.ts
+++ b/src/utils/widget-sanitizer.ts
@@ -56,7 +56,9 @@ const mountedWidgetDocs = new Map<string, {
   html: string;
   token: string;
 }>();
+const pendingRemovedWidgetIframes = new Set<HTMLIFrameElement>();
 let widgetMessageListenerStarted = false;
+let removedWidgetCleanupScheduled = false;
 
 function createWidgetToken(): string {
   const bytes = new Uint8Array(16);
@@ -123,6 +125,26 @@ function ensureWidgetMessageListener(): void {
   widgetMessageListenerStarted = true;
 }
 
+function cleanupRemovedProWidgets(): void {
+  removedWidgetCleanupScheduled = false;
+  for (const iframe of pendingRemovedWidgetIframes) {
+    const id = iframe.dataset.wmId;
+    if (!id) continue;
+    const mounted = mountedWidgetDocs.get(id);
+    if (mounted?.iframe === iframe && !iframe.isConnected) {
+      mountedWidgetDocs.delete(id);
+    }
+  }
+  pendingRemovedWidgetIframes.clear();
+}
+
+function scheduleRemovedProWidgetCleanup(iframe: HTMLIFrameElement): void {
+  pendingRemovedWidgetIframes.add(iframe);
+  if (removedWidgetCleanupScheduled) return;
+  removedWidgetCleanupScheduled = true;
+  queueMicrotask(cleanupRemovedProWidgets);
+}
+
 function mountProWidget(iframe: HTMLIFrameElement): void {
   const id = iframe.dataset.wmId;
   if (!id) return;
@@ -142,9 +164,21 @@ function mountProWidget(iframe: HTMLIFrameElement): void {
   iframe.src = `/wm-widget-sandbox.html#${fragment}`;
 }
 
+function scheduleRemovedProWidgets(node: Node): void {
+  if (!(node instanceof Element)) return;
+  if (node instanceof HTMLIFrameElement && node.dataset.wmId) {
+    scheduleRemovedProWidgetCleanup(node);
+  } else {
+    node.querySelectorAll<HTMLIFrameElement>('iframe[data-wm-id]').forEach(scheduleRemovedProWidgetCleanup);
+  }
+}
+
 if (typeof document !== 'undefined') {
   const observer = new MutationObserver((mutations) => {
     for (const mut of mutations) {
+      for (const node of mut.removedNodes) {
+        scheduleRemovedProWidgets(node);
+      }
       for (const node of mut.addedNodes) {
         if (!(node instanceof Element)) continue;
         if (node instanceof HTMLIFrameElement && node.dataset.wmId) {

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -1156,6 +1156,29 @@ describe('PRO widget — store and sanitizer', () => {
     );
   });
 
+  it('PRO iframe registry prunes disconnected sandbox iframes', () => {
+    assert.ok(
+      san.includes('pendingRemovedWidgetIframes'),
+      'removed PRO iframe elements must be tracked for cleanup',
+    );
+    assert.ok(
+      san.includes('queueMicrotask(cleanupRemovedProWidgets)'),
+      'cleanup must run after the mutation batch so DOM moves can reconnect',
+    );
+    assert.ok(
+      san.includes('!iframe.isConnected'),
+      'cleanup must only delete iframes that stayed disconnected',
+    );
+    assert.ok(
+      san.includes('mounted?.iframe === iframe'),
+      'cleanup must only remove the registry entry for the exact iframe instance',
+    );
+    assert.ok(
+      san.includes('mountedWidgetDocs.delete(id)'),
+      'stale mounted widget entries must be removed to avoid retaining iframe HTML',
+    );
+  });
+
   it('sandbox page verifies origin and nonce before writing widget HTML', () => {
     assert.ok(
       sandbox.includes("e.data.type !== 'wm-html'"),

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -1009,6 +1009,7 @@ describe('PRO widget — relay auth and configuration', () => {
 describe('PRO widget — store and sanitizer', () => {
   const store = src('src/services/widget-store.ts');
   const san = src('src/utils/widget-sanitizer.ts');
+  const sandbox = src('public/wm-widget-sandbox.html');
 
   it('MAX_HTML_CHARS_PRO is 80000', () => {
     const match = store.match(/MAX_HTML_CHARS_PRO\s*=\s*([\d_]+)/);
@@ -1123,16 +1124,58 @@ describe('PRO widget — store and sanitizer', () => {
     );
   });
 
-  it('wrapProWidgetHtml uses sandbox page src (not srcdoc) for CSP isolation', () => {
+  it('wrapProWidgetHtml keeps sandbox page transport and avoids srcdoc CSP inheritance', () => {
     const fnIdx = san.indexOf('wrapProWidgetHtml');
     const fnBody = san.slice(fnIdx, fnIdx + 500);
     assert.ok(
-      fnBody.includes('wm-widget-sandbox.html'),
-      'wrapProWidgetHtml must load the dedicated sandbox page (not srcdoc) to get its own CSP',
+      san.includes('wm-widget-sandbox.html'),
+      'PRO widget mount must load the dedicated sandbox page to get its own CSP',
     );
     assert.ok(
       !fnBody.includes('srcdoc'),
       'wrapProWidgetHtml must NOT use srcdoc — srcdoc inherits parent CSP',
+    );
+  });
+
+  it('PRO iframe HTML delivery is gated by sandbox nonce handshake', () => {
+    assert.ok(
+      san.includes('createWidgetToken'),
+      'PRO widgets must generate a per-widget token before loading the sandbox',
+    );
+    assert.ok(
+      san.includes("data.type !== 'wm-widget-ready'"),
+      'parent must wait for an explicit sandbox-ready message',
+    );
+    assert.ok(
+      san.includes('event.source !== mounted.iframe.contentWindow'),
+      'parent must verify the ready message came from the mounted iframe window',
+    );
+    assert.ok(
+      san.includes('data.token !== mounted.token'),
+      'parent must verify the per-widget token before sending HTML',
+    );
+  });
+
+  it('sandbox page verifies origin and nonce before writing widget HTML', () => {
+    assert.ok(
+      sandbox.includes("e.data.type !== 'wm-html'"),
+      'sandbox must only accept wm-html messages',
+    );
+    assert.ok(
+      sandbox.includes('e.data.id !== id || e.data.token !== token'),
+      'sandbox must verify id and token before document.write',
+    );
+    assert.ok(
+      sandbox.includes('e.source !== window.parent'),
+      'sandbox must only accept widget HTML from the embedding parent window',
+    );
+    assert.ok(
+      sandbox.includes("typeof e.data.html !== 'string'"),
+      'sandbox must reject malformed wm-html payloads before document.write',
+    );
+    assert.ok(
+      sandbox.includes('isAllowedParentOrigin(origin)'),
+      'sandbox must verify the parent origin before processing HTML',
     );
   });
 

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -1200,6 +1200,10 @@ describe('PRO widget — store and sanitizer', () => {
       sandbox.includes('isAllowedParentOrigin(origin)'),
       'sandbox must verify the parent origin before processing HTML',
     );
+    assert.ok(
+      sandbox.includes('console.warn'),
+      'sandbox must surface handshake failures instead of rendering blank silently',
+    );
   });
 
   it('widget document builder injects panel CSS classes for design-system alignment', () => {


### PR DESCRIPTION
## Summary

Closes #3544 by replacing the unconditional PRO widget iframe load-time HTML post with a nonce-gated sandbox handshake. The iframe remains isolated with `sandbox="allow-scripts"` and no `allow-same-origin`.

## Root cause

`mountProWidget()` sent the generated widget document to `iframe.contentWindow` with `targetOrigin: '*'` whenever the iframe load event fired. If the iframe navigated before that load path completed, the parent could send widget HTML to an unexpected document.

## Changes

- Generate a per-widget nonce before loading `/wm-widget-sandbox.html`.
- Pass `id` and nonce through the iframe URL fragment so they are not sent in HTTP referrers.
- Have the sandbox send `wm-widget-ready` only to the parent origin derived from `document.referrer`.
- Verify `event.source` and nonce in the parent before sending HTML.
- Verify parent source, nonce, payload shape, and allowed origin in the sandbox before `document.write()`.
- Warn when the sandbox handshake is blocked by missing or disallowed parent origin, avoiding silent blank widgets during development and smoke testing.
- Prune disconnected iframe entries from the mounted widget registry after mutation batches, so closed/replaced widgets do not retain full HTML documents.
- Add regression coverage for the parent handshake, sandbox checks, and registry cleanup.

## Notes

The final parent-to-sandbox `postMessage` still uses `'*'` because the sandbox intentionally has an opaque origin without `allow-same-origin`. Adding `allow-same-origin` would weaken the isolation. The trust boundary is now the source-checked, per-widget nonce handshake before any HTML is delivered.

## Validation

- `node --test tests/widget-builder.test.mjs`
- `npx biome check src/utils/widget-sanitizer.ts tests/widget-builder.test.mjs public/wm-widget-sandbox.html`
- `npm run typecheck`
- `npm run lint:unicode`
- `git diff --check -- src/utils/widget-sanitizer.ts public/wm-widget-sandbox.html tests/widget-builder.test.mjs`
- Browser smoke test with a temporary local server verifying the sandbox handshake completes in Chrome

## Risk

Medium-low. This is isolated to PRO widget iframe mounting. The main compatibility risk is PRO widget rendering if a browser blocks the handshake; the sandbox now warns for the known referrer-policy failure path, and the local browser smoke test covers the expected opaque-sandbox flow. Registry cleanup is deferred to the microtask after DOM mutations so same-cycle DOM moves keep their mounted entry.
