### PR TITLE
fix(payments): static-import LEGACY_PRODUCT_ALIASES (Convex isolate rejects dynamic import)

### DIFF
--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -9,7 +9,7 @@
 import { MutationCtx } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { getFeaturesForPlan } from "../lib/entitlements";
-import { PLAN_PRECEDENCE } from "../config/productCatalog";
+import { PLAN_PRECEDENCE, LEGACY_PRODUCT_ALIASES } from "../config/productCatalog";
 import { verifyUserId } from "../lib/identitySigning";
 import { DEV_USER_ID, isDev } from "../lib/auth";
 
@@ -274,8 +274,11 @@ async function resolvePlanKey(
     .unique();
   if (mapping) return mapping.planKey;
 
-  // Fallback: check legacy aliases for old/rotated product IDs
-  const { LEGACY_PRODUCT_ALIASES } = await import("../config/productCatalog");
+  // Fallback: check legacy aliases for old/rotated product IDs.
+  // NOTE: must use the static import — Convex's V8 isolate throws
+  // `TypeError: dynamic module import unsupported` on `await import(...)`,
+  // which would silently break the legacy-alias path on every webhook
+  // for users on rotated product IDs (WORLDMONITOR-QM, 13 events / 1 user).
   const aliasedPlan = LEGACY_PRODUCT_ALIASES[dodoProductId];
   if (aliasedPlan) {
     console.warn(


### PR DESCRIPTION
## Summary

WORLDMONITOR-QM — Dodo Payments webhook fails 500 on every retry for any user on a rotated/legacy product ID. 13 Sentry events from 1 affected user; Convex Insights shows the same webhook event retried 4× over ~2 minutes before timing out.

```
Webhook processing failed: [Error: Uncaught TypeError:
dynamic module import unsupported
  at resolvePlanKey (subscriptionHelpers.ts:279)
  at handleSubscriptionActive (subscriptionHelpers.ts:385)
  at handler (webhookMutations.ts:103)]
```

`resolvePlanKey` used `await import("../config/productCatalog")` to lazy-load `LEGACY_PRODUCT_ALIASES` only on the legacy-alias fallback (when the productPlans index lookup misses). Convex's V8 isolate rejects first-party `await import(...)` with the exact phrase above — Convex requires static imports.

The same module is already imported statically at line 12 for `PLAN_PRECEDENCE`. Merged `LEGACY_PRODUCT_ALIASES` into that import. Comment on the removed line documents the Convex isolate restriction so a future reader doesn't reintroduce dynamic import.

## User impact (until deploy)

- Users on **current** product IDs: unaffected.
- Users on **rotated/legacy** product IDs: every Dodo webhook 500s, Dodo retries with backoff and eventually gives up, entitlement never updates after a plan change → silent paid-but-not-provisioned drift.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — exit 0
- [x] CJS check — clean
- [x] Repo-wide `grep "await import(" convex/` — only the rephrased comment matches; no other dynamic imports to fix
- Auto-deploy via `.github/workflows/convex-deploy.yml` should ship this on merge

## Sentry status

WORLDMONITOR-QM resolved with `inNextRelease: true`. The affected user's pending webhook retries should succeed on the next Dodo attempt after deploy.