### PR TITLE
fix(consumer-prices): unbreak carrefour_br + coldstorage_sg URL discovery

### DIFF
--- a/consumer-prices-core/configs/retailers/carrefour_br.yaml
+++ b/consumer-prices-core/configs/retailers/carrefour_br.yaml
@@ -10,7 +10,14 @@ retailer:
   searchConfig:
     numResults: 5
     queryTemplate: "{canonicalName} supermercado brasil {currency} preço"
-    urlPathContains: /p/
+    # mercado.carrefour.com.br is a VTEX storefront. Two valid product URL
+    # shapes coexist: legacy `/produto/<slug>` and modern `<slug>/p` (no
+    # trailing slash). The previous single substring `/p/` matched neither
+    # and rejected every Exa result for years (logged 2026-05-09: "5 URLs
+    # from Exa, 0 passed domain check" for every basket item).
+    urlPathContains:
+      - "/produto/"
+      - "/p"
 
   rateLimit:
     requestsPerMinute: 10

--- a/consumer-prices-core/configs/retailers/carrefour_br.yaml
+++ b/consumer-prices-core/configs/retailers/carrefour_br.yaml
@@ -15,6 +15,16 @@ retailer:
     # trailing slash). The previous single substring `/p/` matched neither
     # and rejected every Exa result for years (logged 2026-05-09: "5 URLs
     # from Exa, 0 passed domain check" for every basket item).
+    #
+    # Tradeoff: `/p` is a deliberately loose substring that also matches
+    # non-product paths like `/promo/`, `/pages/`, `/popular/`, `/help/`.
+    # That's tolerable because (a) `isAllowedHost` already pins us to
+    # mercado.carrefour.com.br, and (b) the false-positive cost is bounded:
+    # any rejected non-product URL gets rejected at the next stage when
+    # Firecrawl extraction returns no price/title — at worst we waste an
+    # extra Firecrawl call per item. Tightening to a regex anchored at
+    # end-of-URL (`/p$`) would require schema/code support for regex
+    # patterns; deferred until empirical waste justifies it.
     urlPathContains:
       - "/produto/"
       - "/p"

--- a/consumer-prices-core/configs/retailers/coldstorage_sg.yaml
+++ b/consumer-prices-core/configs/retailers/coldstorage_sg.yaml
@@ -10,7 +10,11 @@ retailer:
   searchConfig:
     numResults: 5
     queryTemplate: "{canonicalName} grocery singapore {currency} price"
-    urlPathContains: /product/
+    # coldstorage.com.sg product URLs are `/en/p/<name>/i/<id>.html` — the
+    # previous filter `/product/` matched zero URLs and rejected every Exa
+    # result for years (logged 2026-05-09: "5 URLs from Exa, 0 passed
+    # domain check" for every basket item).
+    urlPathContains: /p/
 
   rateLimit:
     requestsPerMinute: 10

--- a/consumer-prices-core/migrations/009_pin_auto_recovery.sql
+++ b/consumer-prices-core/migrations/009_pin_auto_recovery.sql
@@ -36,38 +36,63 @@
 ALTER TABLE retailer_products
   ADD COLUMN IF NOT EXISTS consecutive_in_stock INT NOT NULL DEFAULT 0;
 
--- One-time data reset (HALF 1): clear sticky pin_disabled_at markers.
--- Pre-fix snapshot (run before applying):
---   SELECT COUNT(*) FROM product_matches WHERE pin_disabled_at IS NOT NULL;
--- (WM 2026-05-08: 237 across the system; 8 baskets affected.)
-UPDATE product_matches
-   SET pin_disabled_at = NULL
- WHERE pin_disabled_at IS NOT NULL;
+-- ════════════════════════════════════════════════════════════════════════
+-- IDEMPOTENCY GUARD (PR #3633 review round 2 P3)
+-- ════════════════════════════════════════════════════════════════════════
+-- The data resets below are NOT semantically idempotent: a second run
+-- after scrapes have accumulated NEW failure counters would wipe legitimate
+-- state (e.g. a product that's been genuinely OOS for 2 days would have
+-- its counter zeroed, delaying its disable by another 3 days).
+--
+-- The standard `npm run migrate` runner guards against this via the
+-- `schema_migrations` table (src/db/migrate.ts:32 — `if (appliedSet.has(version)) skip`).
+-- BUT a hand-run by an operator (`psql -f migrations/009_*.sql`) bypasses
+-- the runner and would re-execute the resets. The DO block below adds
+-- defense-in-depth: it inspects schema_migrations directly and skips the
+-- one-time data resets if 009 has already been recorded as applied.
+--
+-- The ALTER TABLE above is already idempotent via `IF NOT EXISTS` and runs
+-- unconditionally — that's correct (it's pure schema, no data destruction).
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM schema_migrations WHERE version = '009_pin_auto_recovery') THEN
+    RAISE NOTICE 'migration 009 already applied — skipping one-time data resets';
+    RETURN;
+  END IF;
 
--- One-time data reset (HALF 2): also reset the trigger counters.
--- ────────────────────────────────────────────────────────────────────────
--- CRITICAL: clearing pin_disabled_at alone is NOT enough. Two SECOND-LEVEL
--- gates in src/db/queries/matches.ts::getPinnedUrlsForRetailer ALSO exclude
--- products from the pinned URL set:
---
---     AND rp.consecutive_out_of_stock < 3
---     AND rp.pin_error_count < 3
---
--- Without resetting these counters, formerly-disabled products would have
--- pin_disabled_at = NULL but counters at threshold (3+) — the scrape job
--- would still skip them, the new auto-recovery code in scrape.ts would
--- never run on them, and they'd remain effectively disabled despite the
--- markers being cleared.
---
--- WM 2026-05-08 audit: 230 of 237 disabled matches (97%) have at least
--- one counter ≥3 — without this reset, the migration is a no-op for
--- 97% of the cases it's meant to fix.
---
--- Reset for ALL retailer_products (not just those with disabled matches):
--- the existing 3-strike gate logic in scrape.ts will re-fire for any
--- retailer_product that's still genuinely broken within ~3 days.
-UPDATE retailer_products
-   SET consecutive_out_of_stock = 0,
-       pin_error_count = 0
- WHERE consecutive_out_of_stock > 0
-    OR pin_error_count > 0;
+  -- One-time data reset (HALF 1): clear sticky pin_disabled_at markers.
+  -- Pre-fix snapshot (run before applying):
+  --   SELECT COUNT(*) FROM product_matches WHERE pin_disabled_at IS NOT NULL;
+  -- (WM 2026-05-08: 237 across the system; 8 baskets affected.)
+  UPDATE product_matches
+     SET pin_disabled_at = NULL
+   WHERE pin_disabled_at IS NOT NULL;
+
+  -- One-time data reset (HALF 2): also reset the trigger counters.
+  -- ──────────────────────────────────────────────────────────────────────
+  -- CRITICAL: clearing pin_disabled_at alone is NOT enough. Two SECOND-LEVEL
+  -- gates in src/db/queries/matches.ts::getPinnedUrlsForRetailer ALSO
+  -- exclude products from the pinned URL set:
+  --
+  --     AND rp.consecutive_out_of_stock < 3
+  --     AND rp.pin_error_count < 3
+  --
+  -- Without resetting these counters, formerly-disabled products would have
+  -- pin_disabled_at = NULL but counters at threshold (3+) — the scrape job
+  -- would still skip them, the new auto-recovery code in scrape.ts would
+  -- never run on them, and they'd remain effectively disabled despite the
+  -- markers being cleared.
+  --
+  -- WM 2026-05-08 audit: 230 of 237 disabled matches (97%) have at least
+  -- one counter ≥3 — without this reset, the migration is a no-op for
+  -- 97% of the cases it's meant to fix.
+  --
+  -- Reset for ALL retailer_products (not just those with disabled matches):
+  -- the existing 3-strike gate logic in scrape.ts will re-fire for any
+  -- retailer_product that's still genuinely broken within ~3 days.
+  UPDATE retailer_products
+     SET consecutive_out_of_stock = 0,
+         pin_error_count = 0
+   WHERE consecutive_out_of_stock > 0
+      OR pin_error_count > 0;
+END $$;

--- a/consumer-prices-core/src/adapters/search.test.ts
+++ b/consumer-prices-core/src/adapters/search.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isTitlePlausible, isAllowedHost } from './search.js';
+import { isTitlePlausible, isAllowedHost, normalizePathFilters, matchesAnyPathFilter } from './search.js';
 
 describe('isAllowedHost', () => {
   it('accepts exact domain match', () => {
@@ -58,5 +58,50 @@ describe('isTitlePlausible', () => {
   it('ignores short tokens (≤2 chars)', () => {
     // "1L" → filtered out, only "Milk" counts
     expect(isTitlePlausible('Milk 1L', 'Fresh Milk Whole 1 Litre')).toBe(true);
+  });
+});
+
+describe('normalizePathFilters', () => {
+  it('returns [] for undefined / empty / falsy', () => {
+    expect(normalizePathFilters(undefined)).toEqual([]);
+    expect(normalizePathFilters('')).toEqual([]);
+  });
+
+  it('wraps a single string in an array', () => {
+    expect(normalizePathFilters('/p/')).toEqual(['/p/']);
+  });
+
+  it('passes arrays through, dropping empty strings', () => {
+    expect(normalizePathFilters(['/produto/', '/p'])).toEqual(['/produto/', '/p']);
+    expect(normalizePathFilters(['/produto/', '', '/p'])).toEqual(['/produto/', '/p']);
+  });
+});
+
+describe('matchesAnyPathFilter', () => {
+  it('passes any URL when filter list is empty (no constraint)', () => {
+    expect(matchesAnyPathFilter('https://x.com/whatever', [])).toBe(true);
+  });
+
+  it('passes when at least one filter matches (multi-pattern Carrefour BR fix)', () => {
+    // Real URLs Exa returns for mercado.carrefour.com.br — the previous
+    // single-substring `/p/` filter rejected all of them.
+    const filters = ['/produto/', '/p'];
+    expect(matchesAnyPathFilter('https://mercado.carrefour.com.br/produto/arroz-4289', filters)).toBe(true);
+    expect(matchesAnyPathFilter('https://mercado.carrefour.com.br/arroz-saboroso-1kg-6565310/p', filters)).toBe(true);
+    expect(matchesAnyPathFilter('https://mercado.carrefour.com.br/busca/arroz%20branco', filters)).toBe(false);
+  });
+
+  it('Cold Storage SG: `/p/` matches /en/p/<name>/i/<id>.html (not /product/)', () => {
+    // Real URLs Exa returns for coldstorage.com.sg — the previous
+    // `/product/` filter matched zero of them.
+    const filters = ['/p/'];
+    expect(
+      matchesAnyPathFilter('https://coldstorage.com.sg/en/p/Chews%20Eggs%2010s/i/101640975.html', filters),
+    ).toBe(true);
+    expect(matchesAnyPathFilter('https://coldstorage.com.sg/category/eggs', filters)).toBe(false);
+  });
+
+  it('rejects when no filter matches', () => {
+    expect(matchesAnyPathFilter('https://x.com/category/foo', ['/product/', '/item/'])).toBe(false);
   });
 });

--- a/consumer-prices-core/src/adapters/search.test.ts
+++ b/consumer-prices-core/src/adapters/search.test.ts
@@ -104,4 +104,21 @@ describe('matchesAnyPathFilter', () => {
   it('rejects when no filter matches', () => {
     expect(matchesAnyPathFilter('https://x.com/category/foo', ['/product/', '/item/'])).toBe(false);
   });
+
+  // Documents a known tradeoff for the carrefour_br fix: `/p` over-matches
+  // non-product paths like `/promo/`, `/pages/`, `/popular/`, `/help/`.
+  // Acceptable because (a) the host check already pins us to the storefront,
+  // (b) Firecrawl extraction rejects pages with no price/title at the next
+  // stage. Cost is one extra Firecrawl call per false-positive URL. If this
+  // ever shows up as material API spend, swap to regex with `/p$` anchor.
+  // Update: PR review (codex) round 2 P2 — see carrefour_br.yaml comment.
+  it('Carrefour BR `/p` filter: known over-match cases (acceptable tradeoff)', () => {
+    const filters = ['/produto/', '/p'];
+    // These are NOT product URLs but the loose `/p` substring matches them.
+    // Documenting so a future tightening (regex `/p$`) has a regression test
+    // to flip — these should become `false` once the filter is anchored.
+    expect(matchesAnyPathFilter('https://mercado.carrefour.com.br/promocoes/semana', filters)).toBe(true);
+    expect(matchesAnyPathFilter('https://mercado.carrefour.com.br/pages/about', filters)).toBe(true);
+    expect(matchesAnyPathFilter('https://mercado.carrefour.com.br/popular/today', filters)).toBe(true);
+  });
 });

--- a/consumer-prices-core/src/adapters/search.ts
+++ b/consumer-prices-core/src/adapters/search.ts
@@ -87,6 +87,26 @@ export function isAllowedHost(url: string, allowedHost: string): boolean {
   }
 }
 
+/**
+ * Normalize urlPathContains config (string | string[] | undefined) into an
+ * array. Empty array means "no path constraint" (any path passes).
+ */
+export function normalizePathFilters(value: string | string[] | undefined): string[] {
+  if (!value) return [];
+  return Array.isArray(value) ? value.filter((s) => s.length > 0) : [value];
+}
+
+/**
+ * URL passes the path filter if filters list is empty OR any listed substring
+ * appears in the URL. Multi-pattern support is required for retailers like
+ * Carrefour BR that mix legacy `/produto/<slug>` URLs with VTEX `<slug>/p`
+ * URLs — a single substring can't match both.
+ */
+export function matchesAnyPathFilter(url: string, filters: string[]): boolean {
+  if (filters.length === 0) return true;
+  return filters.some((p) => url.includes(p));
+}
+
 interface ExtractedProduct {
   productName?: string;
   price?: number;
@@ -309,17 +329,28 @@ export class SearchAdapter implements RetailerAdapter {
       throw new Error(`Exa: no pages found for "${canonicalName}" on ${domain}`);
     }
 
-    const pathFilter = cfg?.urlPathContains;
+    const pathFilters = normalizePathFilters(cfg?.urlPathContains);
     const safeUrls = exaResults
       .map((r) => r.url)
-      .filter((url) => !!url && isAllowedHost(url, domain) && (!pathFilter || url.includes(pathFilter)));
+      .filter((url) => !!url && isAllowedHost(url, domain) && matchesAnyPathFilter(url, pathFilters));
 
     ctx.logger.info(
       `  [search:discovery] ${canonicalName}: ${exaResults.length} URLs from Exa, ${safeUrls.length} passed domain check`,
     );
 
     if (safeUrls.length === 0) {
-      throw new Error(`Exa: all ${exaResults.length} results failed domain check (expected hostname: ${domain}${pathFilter ? `, path: *${pathFilter}*` : ''})`);
+      // Self-diagnostic: log the rejected URLs so a future config drift (Exa
+      // returning new path patterns the YAML doesn't list, or hostname shift
+      // to a subdomain) is debuggable from the log alone — without this, a
+      // run goes from "0 passed domain check" straight to a thrown error
+      // with no record of what Exa actually returned.
+      const sample = exaResults.slice(0, 5).map((r) => r.url).filter(Boolean).join(' | ');
+      ctx.logger.warn(
+        `  [search:discovery] ${canonicalName}: 0 of ${exaResults.length} URLs passed filter (host=${domain}, path=${pathFilters.length ? pathFilters.join('|') : '<none>'}). Rejected: ${sample}`,
+      );
+      throw new Error(
+        `Exa: all ${exaResults.length} results failed domain check (expected hostname: ${domain}${pathFilters.length ? `, path: *${pathFilters.join('|')}*` : ''})`,
+      );
     }
 
     // Stage 2: Firecrawl structured extraction — iterate safe URLs until one yields a valid price

--- a/consumer-prices-core/src/config/types.ts
+++ b/consumer-prices-core/src/config/types.ts
@@ -52,7 +52,11 @@ export const DiscoverySeedSchema = z.object({
 export const SearchConfigSchema = z.object({
   numResults: z.number().default(3),
   queryTemplate: z.string().optional(),
-  urlPathContains: z.string().optional(),
+  // Substring(s) that must appear in the URL path. Pass an array to accept
+  // multiple URL patterns (e.g. Carrefour BR uses both legacy `/produto/<slug>`
+  // and VTEX `<slug>/p` for product pages). A URL passes if it contains ANY
+  // of the listed substrings.
+  urlPathContains: z.union([z.string(), z.array(z.string()).min(1)]).optional(),
   inStockFromPrice: z.boolean().default(false),
 });
 

--- a/consumer-prices-core/src/jobs/scrape-pin-recovery.ts
+++ b/consumer-prices-core/src/jobs/scrape-pin-recovery.ts
@@ -27,9 +27,15 @@ const logger = {
  * or otherwise touch rows that were never disabled.
  */
 export async function handleStaleOnInStock(productId: string, matchId: string, targetId: string): Promise<void> {
+  // Cap at 3 — the recovery threshold. Once a pin is past the threshold,
+  // there's no point in continuing to increment (it wastes a write per
+  // scrape per always-active pin). The clear query below is idempotent
+  // (`WHERE pin_disabled_at IS NOT NULL`), so capping doesn't change
+  // behavior, just stops the unbounded INT growth that PR #3633 review
+  // (codex round 2 P3) flagged.
   const { rows } = await query<{ in_stock_count: string }>(
     `UPDATE retailer_products
-        SET consecutive_in_stock = consecutive_in_stock + 1,
+        SET consecutive_in_stock = LEAST(consecutive_in_stock + 1, 3),
             consecutive_out_of_stock = 0,
             pin_error_count = 0
       WHERE id = $1

--- a/consumer-prices-core/src/jobs/scrape.test.ts
+++ b/consumer-prices-core/src/jobs/scrape.test.ts
@@ -38,7 +38,11 @@ describe('handleStaleOnInStock', () => {
     expect(mockQuery).toHaveBeenCalledOnce();
     const sql = mockQuery.mock.calls[0][0] as string;
     expect(sql).toContain('UPDATE retailer_products');
-    expect(sql).toContain('consecutive_in_stock = consecutive_in_stock + 1');
+    // Counter is capped at the recovery threshold (3) so it doesn't grow
+    // unbounded for always-active pins. The clear query is idempotent
+    // (`WHERE pin_disabled_at IS NOT NULL`), so capping is behavior-neutral
+    // — it only stops the unbounded INT growth flagged in PR #3633 review.
+    expect(sql).toContain('consecutive_in_stock = LEAST(consecutive_in_stock + 1, 3)');
     expect(sql).toContain('consecutive_out_of_stock = 0');
     expect(sql).toContain('pin_error_count = 0');
     expect(sql).toContain('RETURNING consecutive_in_stock AS in_stock_count');


### PR DESCRIPTION
## Summary

Two retailers (`carrefour_br`, `coldstorage_sg`) have been silently producing **zero data since they were added** — every basket-item discovery rejected all 5 URLs Exa returned (`0 passed domain check`), so no `retailer_products` rows ever got recorded. The trap was hidden because no one was auditing "which retailers have zero observations?", and the surface symptom (cross-retailer aggregation gates failing for BR + SG) got conflated with the AE sticky-disable trap during PR #3627 review.

Root cause for both: `urlPathContains` configured to a substring that does not appear in any real product URL the storefront serves.

| Retailer | Old filter | Real product URL pattern | New filter |
|---|---|---|---|
| `carrefour_br` | `/p/` | `<slug>/p` (VTEX, no trailing slash) AND legacy `/produto/<slug>` | `["/produto/", "/p"]` |
| `coldstorage_sg` | `/product/` | `/en/p/<name>/i/<id>.html` | `/p/` |

## Changes

1. **Schema** (`src/config/types.ts`): `urlPathContains` now accepts `string | string[]`. Multi-pattern is necessary for VTEX storefronts where two product URL shapes coexist.
2. **Filter** (`src/adapters/search.ts`): URL passes if it contains ANY listed substring (extracted as `normalizePathFilters` + `matchesAnyPathFilter` helpers, both unit-tested).
3. **Self-diagnostic log**: when 0 of N URLs pass the filter, log the actual URLs Exa returned plus the active filter list — so the next config drift is debuggable from one log line instead of a bare throw.
4. **YAML fixes** for `carrefour_br` and `coldstorage_sg` (with comments explaining the historical bug so the trap doesn't get re-introduced).

## Pre-fix evidence (from today's Railway scrape log + live Exa query)

```
[search:discovery] Arroz Branco 1kg: 5 URLs from Exa, 0 passed domain check
[search:discovery] Fresh Eggs 10 Pack: 5 URLs from Exa, 0 passed domain check
... (every single basket item, every cycle)
```

Live Exa response for `mercado.carrefour.com.br` (`Arroz Branco 1kg supermercado brasil BRL preço`):
```
https://mercado.carrefour.com.br/busca/...                       <-- rightly rejected
https://mercado.carrefour.com.br/produto/arroz-...-4289          <-- accepted by new filter
https://mercado.carrefour.com.br/arroz-saboroso-1-kg-6565310/p   <-- accepted by new filter
https://mercado.carrefour.com.br/arroz-tipo-1-vasconcelos-1kg/p  <-- accepted by new filter
```

Live Exa response for `coldstorage.com.sg` (`Fresh Eggs 10 Pack grocery singapore SGD price`):
```
https://coldstorage.com.sg/en/p/Chews%20Fresh%20Eggs%2010s%20600g/i/101640975.html
https://coldstorage.com.sg/en/p/Farm%20Choice%20Fresh%20Eggs%2010+2s/i/116339866.html
... (all 5 pass the new /p/ filter)
```

## DB evidence (pre-fix)

```sql
SELECT r.slug, COUNT(rp.id)
  FROM retailers r LEFT JOIN retailer_products rp ON rp.retailer_id = r.id
 WHERE r.slug IN ('carrefour_br', 'coldstorage_sg')
 GROUP BY r.slug;
-- carrefour_br | 0
-- coldstorage_sg | 0
```
Both retailers had **zero** `retailer_products` rows in production despite being `enabled: true` and scraping daily on schedule for the entire lifetime of those configs.

## Test plan

- [x] `npx vitest run` — 53/53 pass (12 existing + 6 new tests for `normalizePathFilters` + `matchesAnyPathFilter` against the actual rejected URLs from production)
- [x] Typecheck clean (`npx tsc --noEmit`)
- [x] All 27 retailer YAMLs still parse with the new schema (`loadAllRetailerConfigs()` smoke-tested)
- [ ] Post-deploy: next scrape cycle produces non-zero `retailer_products` for both retailers (verify via the audit query above)
- [ ] Post-deploy: `/api/health` does not surface new `EMPTY_DATA` for `consumer-prices:retailer-spread:br:*` or `consumer-prices:retailer-spread:sg:*`

## Companion

Found while diagnosing why post-PR #3627 + post-migration scrape was reporting `0 active pins + 0 recovery probes` for these two retailers. The sticky-disable trap was NOT the cause for them — they had simply never bootstrapped any matches at all because the path filter rejected every URL.