### PR TITLE
fix(seed-imf): auth-optional Ocp-Apim-Subscription-Key + 4xx-non-retryable guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,13 @@ EIA_API_KEY=
 # Register at: https://fred.stlouisfed.org/docs/api/api_key.html
 FRED_API_KEY=
 
+# IMF SDMX API (WEO, IRFCL gold reserves, national debt)
+# Currently OPTIONAL but recommended — IMF allows unauthenticated requests
+# today, but has flipped to hard 401 enforcement intermittently. Setting this
+# is forward-compatible. Azure APIM key sent as `Ocp-Apim-Subscription-Key`.
+# Register at: https://portal.api.imf.org/ → Products → IMF Data SDMX API → Subscribe
+IMF_API_KEY=
+
 
 # ------ Air Quality Intelligence (Railway seed) ------
 

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -351,6 +351,10 @@ export async function withRetry(fn, maxRetries = 3, delayMs = 1000) {
       return await fn();
     } catch (err) {
       lastErr = err;
+      // Permanent failures (4xx auth/permission, missing config) burn the
+      // bundle timeoutMs if retried. Callers tag with `nonRetryable: true`
+      // so the loop fails in ~10ms instead of waiting through every backoff.
+      if (err?.nonRetryable) throw err;
       if (attempt < maxRetries) {
         const wait = delayMs * 2 ** attempt;
         const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
@@ -576,9 +580,31 @@ export async function imfFetchJson(url, proxyAuth) {
 }
 
 // ---------------------------------------------------------------------------
-// IMF SDMX 3.0 API (api.imf.org) — replaces blocked DataMapper API
+// IMF SDMX 3.0 API (api.imf.org) — replaces blocked DataMapper API.
+//
+// Auth status (2026-05): currently allows unauthenticated requests, but the
+// gateway has been observed flipping to hard 401 enforcement intermittently
+// (one ~hours-long window on 2026-05-09 SIGTERM'd seed-bundle-market-backup
+// in production). Set IMF_API_KEY to send `Ocp-Apim-Subscription-Key` for
+// forward-compatibility — get a key at https://portal.api.imf.org/ (Sign in
+// → Products → IMF Data SDMX API → Subscribe → Profile → Subscriptions →
+// Primary key). One subscription unlocks both SDMX 2.1 and 3.0. The gateway
+// returns a misleading `WWW-Authenticate: Bearer` 401; the actual scheme is
+// APIM subscription key, NOT Bearer.
 // ---------------------------------------------------------------------------
 const IMF_SDMX_BASE = 'https://api.imf.org/external/sdmx/3.0';
+
+// Build auth headers for api.imf.org. Returns {} when IMF_API_KEY is unset —
+// IMF currently allows unauthenticated requests through, but flipped to hard
+// 401 enforcement for ~hours on 2026-05-09 (captured in seed-bundle-market-
+// backup logs). Sending the key when we have it is forward-compatible with
+// permanent enforcement; the omit-on-empty path preserves today's working
+// state. The `nonRetryable` 4xx guard in the fetcher (paired with this
+// helper) prevents a 180s SIGTERM the next time enforcement lands.
+export function imfAuthHeaders() {
+  const key = process.env.IMF_API_KEY;
+  return key ? { 'Ocp-Apim-Subscription-Key': key } : {};
+}
 
 /**
  * Normalize an SDMX 3.0 monthly period from `YYYY-MMM` (the on-the-wire
@@ -626,10 +652,14 @@ export async function imfSdmxFetchIndicator(indicator, { database = 'WEO', years
 
   const json = await withRetry(async () => {
     const r = await fetch(url, {
-      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json', ...imfAuthHeaders() },
       signal: AbortSignal.timeout(60_000),
     });
-    if (!r.ok) throw new Error(`IMF SDMX ${indicator}: HTTP ${r.status}`);
+    if (!r.ok) {
+      const err = new Error(`IMF SDMX ${indicator}: HTTP ${r.status}`);
+      if (r.status >= 400 && r.status < 500) err.nonRetryable = true;
+      throw err;
+    }
     return r.json();
   }, 2, 2000);
 

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -344,6 +344,41 @@ export async function readCanonicalEnvelopeMeta(canonicalKey) {
   }
 }
 
+// HTTP statuses where retrying CAN'T succeed because the failure is in the
+// caller's request shape, not server load:
+//   400 malformed query   401 bad auth      403 forbidden
+//   404 missing path      410 permanently gone
+//   422 semantic error    451 legal block
+// 408 Request Timeout and 429 Too Many Requests are deliberately excluded —
+// both are explicit "back off and retry" signals, often paired with a
+// Retry-After header. Tagging them nonRetryable would convert transient
+// rate-limits into immediate seed failures (especially under parallel
+// fetches like seed-imf-* WEO bundles).
+export const PERMANENT_4XX_STATUSES = new Set([400, 401, 403, 404, 410, 422, 451]);
+
+// Cap upstream Retry-After hints so a stuck/abusive header can't park the
+// bundle past its section timeoutMs. Mirrors _yahoo-fetch.mjs convention.
+const MAX_RETRY_AFTER_MS = 60_000;
+
+/**
+ * Parse `Retry-After` header value (seconds OR HTTP-date). Returns null
+ * when missing/unparseable so callers can fall back to default backoff.
+ * Duplicates exist in _yahoo-fetch / _gdelt-fetch / _open-meteo-archive —
+ * those predate this helper; consolidating them is a separate refactor.
+ */
+export function parseRetryAfterMs(value) {
+  if (!value) return null;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds > 0) {
+    return Math.min(seconds * 1000, MAX_RETRY_AFTER_MS);
+  }
+  const retryAt = Date.parse(value);
+  if (Number.isFinite(retryAt)) {
+    return Math.min(Math.max(retryAt - Date.now(), 1000), MAX_RETRY_AFTER_MS);
+  }
+  return null;
+}
+
 export async function withRetry(fn, maxRetries = 3, delayMs = 1000) {
   let lastErr;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -356,7 +391,12 @@ export async function withRetry(fn, maxRetries = 3, delayMs = 1000) {
       // so the loop fails in ~10ms instead of waiting through every backoff.
       if (err?.nonRetryable) throw err;
       if (attempt < maxRetries) {
-        const wait = delayMs * 2 ** attempt;
+        // Honor upstream `Retry-After` hint when caller attached it
+        // (typically 429 / 503). Take whichever is longer — the upstream
+        // hint OR the exponential backoff — so a generous server hint
+        // isn't undercut, and a missing/short hint still gets back-off.
+        const baseWait = delayMs * 2 ** attempt;
+        const wait = err?.retryAfterMs ? Math.max(baseWait, err.retryAfterMs) : baseWait;
         const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
         console.warn(`  Retry ${attempt + 1}/${maxRetries} in ${wait}ms: ${err.message || err}${cause}`);
         await new Promise(r => setTimeout(r, wait));
@@ -657,7 +697,12 @@ export async function imfSdmxFetchIndicator(indicator, { database = 'WEO', years
     });
     if (!r.ok) {
       const err = new Error(`IMF SDMX ${indicator}: HTTP ${r.status}`);
-      if (r.status >= 400 && r.status < 500) err.nonRetryable = true;
+      if (PERMANENT_4XX_STATUSES.has(r.status)) err.nonRetryable = true;
+      // 429 (rate limit) and 503 (overloaded) typically carry Retry-After;
+      // attach so withRetry can honor the upstream hint.
+      if (r.status === 429 || r.status === 503) {
+        err.retryAfterMs = parseRetryAfterMs(r.headers.get('retry-after'));
+      }
       throw err;
     }
     return r.json();

--- a/scripts/seed-gold-cb-reserves.mjs
+++ b/scripts/seed-gold-cb-reserves.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, withRetry, normalizeSdmxPeriod, imfAuthHeaders } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, withRetry, normalizeSdmxPeriod, imfAuthHeaders, PERMANENT_4XX_STATUSES, parseRetryAfterMs } from './_seed-utils.mjs';
 loadEnvFile(import.meta.url);
 
 // Re-exported for the test suite. The shared normalizer lives in _seed-utils
@@ -72,7 +72,11 @@ async function fetchIrfclMonthlySeries(indicator) {
     });
     if (!r.ok) {
       const err = new Error(`IMF IRFCL ${indicator}: HTTP ${r.status}`);
-      if (r.status >= 400 && r.status < 500) err.nonRetryable = true;
+      if (PERMANENT_4XX_STATUSES.has(r.status)) err.nonRetryable = true;
+      // 429 (rate limit) and 503 (overloaded) typically carry Retry-After.
+      if (r.status === 429 || r.status === 503) {
+        err.retryAfterMs = parseRetryAfterMs(r.headers.get('retry-after'));
+      }
       throw err;
     }
     return r.json();

--- a/scripts/seed-gold-cb-reserves.mjs
+++ b/scripts/seed-gold-cb-reserves.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, runSeed, withRetry, normalizeSdmxPeriod } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, runSeed, withRetry, normalizeSdmxPeriod, imfAuthHeaders } from './_seed-utils.mjs';
 loadEnvFile(import.meta.url);
 
 // Re-exported for the test suite. The shared normalizer lives in _seed-utils
@@ -11,9 +11,11 @@ const CB_KEY = 'market:gold-cb-reserves:v1';
 const CB_TTL = 2_592_000; // 30 days — data is monthly, TTL long to survive missed runs
 
 // IMF IRFCL (International Reserves and Foreign Currency Liquidity) dataflow
-// via SDMX 3.0 — public, no auth. The original PR (#3038) targeted
-// IMF.STA/IFS which returns HTTP 404 — IFS isn't an exposed dataflow on
-// api.imf.org; gold-reserves data lives under IMF.STA/IRFCL.
+// via SDMX 3.0. Set IMF_API_KEY for forward-compatibility — see
+// imfAuthHeaders in _seed-utils.mjs for the auth-status backstory. The
+// original PR (#3038) targeted IMF.STA/IFS which returns HTTP 404 — IFS
+// isn't an exposed dataflow on api.imf.org; gold-reserves data lives under
+// IMF.STA/IRFCL.
 //
 // Dimensions: COUNTRY.INDICATOR.SECTOR.FREQUENCY (4, not 3). Key pattern
 // requires explicit wildcards `*.<indicator>.*.M`; empty segments return
@@ -65,10 +67,14 @@ async function fetchIrfclMonthlySeries(indicator) {
 
   const json = await withRetry(async () => {
     const r = await fetch(url, {
-      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json', ...imfAuthHeaders() },
       signal: AbortSignal.timeout(90_000),
     });
-    if (!r.ok) throw new Error(`IMF IRFCL ${indicator}: HTTP ${r.status}`);
+    if (!r.ok) {
+      const err = new Error(`IMF IRFCL ${indicator}: HTTP ${r.status}`);
+      if (r.status >= 400 && r.status < 500) err.nonRetryable = true;
+      throw err;
+    }
     return r.json();
   }, 2, 3000);
 

--- a/tests/seed-utils-with-retry.test.mjs
+++ b/tests/seed-utils-with-retry.test.mjs
@@ -1,0 +1,120 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  withRetry,
+  parseRetryAfterMs,
+  PERMANENT_4XX_STATUSES,
+} from '../scripts/_seed-utils.mjs';
+
+describe('PERMANENT_4XX_STATUSES classification', () => {
+  it('includes the request-shape errors that retrying cannot fix', () => {
+    for (const code of [400, 401, 403, 404, 410, 422, 451]) {
+      assert.equal(PERMANENT_4XX_STATUSES.has(code), true, `expected ${code} permanent`);
+    }
+  });
+
+  it('EXCLUDES 408 and 429 (transient back-off signals) — regression guard for PR #3635 review', () => {
+    // 408 Request Timeout and 429 Too Many Requests are explicit "try again
+    // later" signals from the server. If we tagged them nonRetryable, a
+    // single rate-limited indicator fetch under parallel WEO load would
+    // crash the entire seeder instead of riding out the back-off window.
+    assert.equal(PERMANENT_4XX_STATUSES.has(408), false);
+    assert.equal(PERMANENT_4XX_STATUSES.has(429), false);
+  });
+
+  it('EXCLUDES 5xx (server-side, retry-friendly by definition)', () => {
+    for (const code of [500, 502, 503, 504]) {
+      assert.equal(PERMANENT_4XX_STATUSES.has(code), false, `${code} must stay retryable`);
+    }
+  });
+});
+
+describe('parseRetryAfterMs', () => {
+  it('parses seconds form', () => {
+    assert.equal(parseRetryAfterMs('5'), 5000);
+    assert.equal(parseRetryAfterMs('30'), 30_000);
+  });
+
+  it('parses HTTP-date form to a positive ms delta', () => {
+    const future = new Date(Date.now() + 7000).toUTCString();
+    const ms = parseRetryAfterMs(future);
+    assert.ok(ms !== null && ms >= 1000 && ms <= 60_000, `expected 1-60s, got ${ms}`);
+  });
+
+  it('returns null for missing or genuinely unparseable values', () => {
+    assert.equal(parseRetryAfterMs(null), null);
+    assert.equal(parseRetryAfterMs(undefined), null);
+    assert.equal(parseRetryAfterMs(''), null);
+    assert.equal(parseRetryAfterMs('not-a-number-or-date'), null);
+  });
+
+  it('clamps "0" / negative / past-date hints to a 1000ms floor (matches yahoo/gdelt helpers)', () => {
+    // Date.parse("0") yields year-2000-Jan-01 (a past date); retryAt-Date.now()
+    // is hugely negative, clamped to 1000ms by Math.max. This is intentional —
+    // a 0/past-time hint means "retry now" but we still want a tiny floor so
+    // we don't tight-loop. Same behavior as _yahoo-fetch.mjs::parseRetryAfterMs.
+    assert.equal(parseRetryAfterMs('0'), 1000);
+    assert.equal(parseRetryAfterMs('-5'), 1000);
+  });
+
+  it('caps absurdly large hints at 60s so a stuck header cannot park the bundle', () => {
+    assert.equal(parseRetryAfterMs('3600'), 60_000);
+    const farFuture = new Date(Date.now() + 24 * 60 * 60 * 1000).toUTCString();
+    assert.equal(parseRetryAfterMs(farFuture), 60_000);
+  });
+});
+
+describe('withRetry', () => {
+  it('short-circuits on err.nonRetryable instead of burning the retry budget', async () => {
+    let attempts = 0;
+    const t0 = Date.now();
+    await assert.rejects(
+      withRetry(async () => {
+        attempts++;
+        const err = new Error('permanent');
+        err.nonRetryable = true;
+        throw err;
+      }, 5, 100),
+      /permanent/,
+    );
+    assert.equal(attempts, 1, 'must NOT retry a nonRetryable error');
+    assert.ok(Date.now() - t0 < 50, 'must fail in <50ms (no backoff sleeps)');
+  });
+
+  it('retries plain errors up to maxRetries with exponential backoff', async () => {
+    let attempts = 0;
+    await assert.rejects(
+      withRetry(async () => { attempts++; throw new Error('transient'); }, 2, 1),
+      /transient/,
+    );
+    assert.equal(attempts, 3, 'initial + 2 retries = 3 attempts');
+  });
+
+  it('returns success on first attempt when fn succeeds', async () => {
+    let attempts = 0;
+    const result = await withRetry(async () => { attempts++; return 'ok'; }, 3, 1);
+    assert.equal(result, 'ok');
+    assert.equal(attempts, 1);
+  });
+
+  it('honors err.retryAfterMs when caller attaches it (e.g. from 429 Retry-After header)', async () => {
+    // Trip-wire: if the caller attaches retryAfterMs=200 and the default
+    // exponential backoff would have been ~1ms, we MUST sleep ≥200ms so the
+    // upstream rate-limit hint is respected.
+    let attempts = 0;
+    const t0 = Date.now();
+    await assert.rejects(
+      withRetry(async () => {
+        attempts++;
+        const err = new Error('rate limited');
+        if (attempts === 1) err.retryAfterMs = 200;  // hint only on first failure
+        throw err;
+      }, 1, 1),  // baseWait would otherwise be 1ms
+      /rate limited/,
+    );
+    const elapsed = Date.now() - t0;
+    assert.ok(elapsed >= 200, `expected ≥200ms (Retry-After hint), got ${elapsed}ms`);
+    assert.ok(elapsed < 1000, `expected <1000ms (cap respected), got ${elapsed}ms`);
+  });
+});


### PR DESCRIPTION
## Summary

`seed-bundle-market-backup` SIGTERM'd at 180s on 2026-05-09 because every IMF IRFCL request 401'd and `withRetry`'s exponential backoff burned the whole bundle budget. Investigation revealed two compounding issues — fixing both:

- **IMF migrated `api.imf.org` onto Azure APIM** (~2025-Q1) and is rolling out hard 401 enforcement intermittently. We captured a multi-hour enforcement window today (verified across three IPs incl. production), then verified the rollback within ~3 hours. Code needs to survive both states.
- **`withRetry` had no concept of permanent failures** — every 4xx (auth, permission, missing config) burned the full retry budget exactly like a transient 5xx. Without a `nonRetryable` short-circuit, the next enforcement window will SIGTERM the bundle again even with a valid key.

The gateway's `WWW-Authenticate: Bearer` 401 is a misdirection — actual auth scheme is `Ocp-Apim-Subscription-Key` (verified: Bearer → 401, APIM key → 200, query param `?subscription-key=` also → 200). One subscription unlocks both SDMX 2.1 and 3.0.

## Changes

- **`scripts/_seed-utils.mjs`**
  - New `imfAuthHeaders()` — returns `{}` when `IMF_API_KEY` unset (preserves today's anonymous-pass-through), `{Ocp-Apim-Subscription-Key: …}` when set (forward-compat with permanent enforcement).
  - `withRetry` short-circuits on `err.nonRetryable === true` before sleeping. Generalises across all seeders.
  - `imfSdmxFetchIndicator` sends auth header + tags 4xx as `nonRetryable`. Covers 6 WEO seeders (growth, macro, labor, external, national-debt, recovery-fiscal-space).

- **`scripts/seed-gold-cb-reserves.mjs`**
  - `fetchIrfclMonthlySeries` sends auth header + tags 4xx. Covers the seeder whose SIGTERM surfaced this incident.
  - Outdated `// public, no auth` header comment fixed.

- **`.env.example`** — `IMF_API_KEY` (optional, recommended) with portal URL.

## Why auth-optional rather than required

IMF currently allows anonymous requests. Hard-throwing on missing `IMF_API_KEY` would instantly break every IMF seeder right now (they're working). Sending the header opportunistically when the env is set is forward-compatible without regressing today's state. The `nonRetryable` 4xx guard is the safety net for whenever IMF flips enforcement on permanently.

## Operator action required (separate from merge)

Set `IMF_API_KEY` on every Railway service that runs an IMF-touching bundle:

- `seed-bundle-market-backup` (gold-cb-reserves)
- whichever services run WEO bundles (`seed-bundle-macro` and siblings — `seed-imf-{growth,macro,labor,external}`, `seed-national-debt`, `seed-recovery-fiscal-space`)

Get the key at https://portal.api.imf.org/ → Sign in → Products → IMF Data SDMX API → Subscribe → Profile → Subscriptions → Primary key. Free tier, 5 min, no IMF approval queue.

## Test plan

- [x] 37/37 affected unit tests pass (`gold-cb-reserves`, `seed-imf-extended`, `seed-utils-sigterm-cleanup`)
- [x] Full data test suite: 8256/8256 pass (`npm run test:data`)
- [x] Live fetch w/o env → 200, 111 IRFCL series in 1.9s (today's anonymous-pass-through state)
- [x] Live fetch w/ env  → 200, 208 WEO countries in 1.5s (forward-compat path)
- [x] Missing-env path returns `{}` (no `nonRetryable` throw — correct relaxed behavior)
- [x] Forced 401 (bogus key) → tagged `nonRetryable`, fails in <1s instead of burning the retry budget
- [x] `npm run typecheck`, `typecheck:api`, `lint`, `lint:md`, `version:check`, edge bundle, edge-functions test — all pass
- [x] Pre-push hook clean (boundary, sentry coverage, rate-limit, premium-fetch, seed tests)
- [ ] After merge: set `IMF_API_KEY` on Railway services listed above, then watch one cycle of `seed-bundle-market-backup` to confirm the section completes in <10s instead of the prior 180s SIGTERM