### PR TITLE
fix(seed-vpd-tracker): support reverted plain-JS bundle format

### DIFF
--- a/scripts/seed-vpd-tracker.mjs
+++ b/scripts/seed-vpd-tracker.mjs
@@ -173,6 +173,129 @@ function* iterateEvalResArrays(bundle) {
 }
 
 /**
+ * Brace-walk a plain-JS array literal starting at `arrayOpen` (the `[` byte)
+ * and return the index of the matching `]`, or -1 on truncation.
+ *
+ * This is a separate scanner from findArrayCloseInEscapedForm: that one
+ * operates over JS-string-escaped JSON (the eval-wrapped format added in
+ * the April 2026 webpack rewrite). This scanner operates over plain JS
+ * source where strings use `"..."` with `\"` for embedded quotes and
+ * brackets inside strings must NOT shift depth.
+ *
+ * Bundle 2026-05 reverted to this format (or shipped a third variant).
+ * Verified against the 4MB index_bundle.js on 2026-05-09 — `var a=[{Alert_ID:"...",...},...]`
+ * with unquoted keys and direct double-quoted values, no eval wrapper.
+ */
+function findArrayCloseInPlainJS(bundle, arrayOpen) {
+  let depth = 0;
+  let stringQuote = null; // null | '"' | "'"
+  let i = arrayOpen;
+  while (i < bundle.length) {
+    const ch = bundle[i];
+    if (stringQuote !== null) {
+      if (ch === '\\') { i += 2; continue; } // skip escape sequence
+      if (ch === stringQuote) stringQuote = null;
+    } else {
+      if (ch === '"' || ch === "'") stringQuote = ch;
+      else if (ch === '[') depth++;
+      else if (ch === ']') {
+        depth--;
+        if (depth === 0) return i;
+      }
+    }
+    i++;
+  }
+  return -1;
+}
+
+/**
+ * Convert a JS array literal that mixes single-quoted and double-quoted
+ * string values into pure JSON. Walks character-by-character so embedded
+ * quote characters inside strings (e.g. `summary:'... "alt wellness" ...'`)
+ * stay correctly escaped in the resulting JSON.
+ *
+ * Does NOT touch unquoted keys — the caller's existing regex pass handles
+ * `{key:` → `{"key":` after this normalization.
+ */
+function normalizeJSStringQuotesToJSON(literal) {
+  let out = '';
+  let i = 0;
+  while (i < literal.length) {
+    const c = literal[i];
+    if (c === "'" || c === '"') {
+      const quote = c;
+      out += '"';
+      i++;
+      while (i < literal.length) {
+        const ch = literal[i];
+        if (ch === '\\') {
+          // Pass escape sequence through unchanged. JSON accepts the same
+          // single-char escapes (\\, \", \/, \n, \t, \r, \b, \f, \uXXXX)
+          // that JS uses, except `\'` which JSON does not allow — convert
+          // that to a bare `'` (no JSON escape needed for a single quote
+          // inside a JSON string).
+          if (literal[i + 1] === "'") { out += "'"; i += 2; continue; }
+          out += ch + (literal[i + 1] ?? '');
+          i += 2;
+          continue;
+        }
+        if (ch === quote) { out += '"'; i++; break; }
+        // If we entered via `'`, any literal `"` in the body must be escaped
+        // for JSON output. (Conversely, a `'` in a `"`-quoted source is fine
+        // both in JS and JSON, no transform needed.)
+        if (quote === "'" && ch === '"') { out += '\\"'; i++; continue; }
+        out += ch;
+        i++;
+      }
+    } else {
+      out += c;
+      i++;
+    }
+  }
+  return out;
+}
+
+/**
+ * Enumerate every `var <name>=[{<key>:...},...]` plain-JS array in the bundle.
+ * Sibling of iterateEvalResArrays for the pre-2026-04 / post-2026-05-revert
+ * bundle format (plain JS object literals with unquoted keys, no eval
+ * wrapper). Tries to JSON-ify each candidate by quoting unquoted keys, then
+ * JSON.parse; silently skips candidates that don't parse.
+ */
+function* iteratePlainJSArrays(bundle) {
+  // Anchor: word boundary + `var ` + identifier + `=[{` + key-like identifier + `:`
+  // The trailing `<id>:` is what excludes unrelated `var x=[1,2,3]` arrays —
+  // we only want object-of-objects arrays which is what VPD ships.
+  const re = /\bvar\s+[A-Za-z_$][A-Za-z0-9_$]*\s*=\s*(\[)\s*\{\s*[A-Za-z_][A-Za-z0-9_]*\s*:/g;
+  let m;
+  while ((m = re.exec(bundle)) !== null) {
+    const arrayOpen = m.index + m[0].lastIndexOf('[');
+    const arrayClose = findArrayCloseInPlainJS(bundle, arrayOpen);
+    if (arrayClose === -1) continue;
+    const literal = bundle.slice(arrayOpen, arrayClose + 1);
+    // Pass 1: normalize JS string quoting → JSON string quoting. Bundle uses
+    // `'...'` for any value containing literal `"` (e.g. summary fields with
+    // embedded quoted phrases) — JSON only allows `"..."`, so we walk strings
+    // character-by-character and re-emit with JSON-compatible escaping.
+    const stringNormalized = normalizeJSStringQuotesToJSON(literal);
+    // Pass 2: quote unquoted keys. `{Foo_Bar:` or `,Foo_Bar:` → `{"Foo_Bar":` /
+    // `,"Foo_Bar":`. The `{|,` boundary excludes mid-value false positives —
+    // any `:` inside a string literal is now safely inside double quotes from
+    // pass 1 and the boundary won't fire there.
+    const quoted = stringNormalized.replace(/([{,])\s*([A-Za-z_][A-Za-z0-9_]*)\s*:/g, '$1"$2":');
+    try {
+      const array = JSON.parse(quoted);
+      if (Array.isArray(array)) yield { array };
+    } catch {
+      // Bundle drift (e.g. an unquoted JS value like `undefined`/`NaN` or a
+      // trailing comma) — skip and keep searching. The schema-fingerprint
+      // matcher in findArrayBySchema will surface a clear error if no other
+      // candidate matches.
+    }
+  }
+}
+
+/**
  * Find the first eval-block array whose records contain ALL of the named
  * fields. Schema-based identification — independent of key order within
  * objects, eval-block order in the bundle, and minor bundler shuffles.
@@ -183,21 +306,28 @@ function* iterateEvalResArrays(bundle) {
  */
 function findArrayBySchema(bundle, requiredFields) {
   const needed = new Set(requiredFields);
-  for (const { array } of iterateEvalResArrays(bundle)) {
-    if (array.length === 0) continue;
-    // Sample up to 5 records to tolerate sparse fields on any single row.
-    const sampleSize = Math.min(5, array.length);
-    const seen = new Set();
-    for (let i = 0; i < sampleSize; i++) {
-      const r = array[i];
-      if (!r || typeof r !== 'object') continue;
-      for (const k of Object.keys(r)) seen.add(k);
+  // Try both bundle formats. The eval-wrapped form was added in the April
+  // 2026 webpack rewrite; the plain-JS form is the pre-rewrite (and
+  // post-2026-05-revert) shape. Either may be present in any given bundle
+  // build, so we iterate both and accept the first schema match.
+  const iterators = [iterateEvalResArrays(bundle), iteratePlainJSArrays(bundle)];
+  for (const iterator of iterators) {
+    for (const { array } of iterator) {
+      if (array.length === 0) continue;
+      // Sample up to 5 records to tolerate sparse fields on any single row.
+      const sampleSize = Math.min(5, array.length);
+      const seen = new Set();
+      for (let i = 0; i < sampleSize; i++) {
+        const r = array[i];
+        if (!r || typeof r !== 'object') continue;
+        for (const k of Object.keys(r)) seen.add(k);
+      }
+      let allPresent = true;
+      for (const f of needed) {
+        if (!seen.has(f)) { allPresent = false; break; }
+      }
+      if (allPresent) return array;
     }
-    let allPresent = true;
-    for (const f of needed) {
-      if (!seen.has(f)) { allPresent = false; break; }
-    }
-    if (allPresent) return array;
   }
   return null;
 }

--- a/scripts/seed-vpd-tracker.mjs
+++ b/scripts/seed-vpd-tracker.mjs
@@ -193,7 +193,14 @@ function findArrayCloseInPlainJS(bundle, arrayOpen) {
   while (i < bundle.length) {
     const ch = bundle[i];
     if (stringQuote !== null) {
-      if (ch === '\\') { i += 2; continue; } // skip escape sequence
+      if (ch === '\\') {
+        // Bundle-truncation guard: if `\` is the last byte, don't overshoot
+        // EOF on the +2 advance — break and let the outer "no close found"
+        // path return -1.
+        if (i + 1 >= bundle.length) break;
+        i += 2;
+        continue;
+      }
       if (ch === stringQuote) stringQuote = null;
     } else {
       if (ch === '"' || ch === "'") stringQuote = ch;
@@ -209,19 +216,35 @@ function findArrayCloseInPlainJS(bundle, arrayOpen) {
 }
 
 /**
- * Convert a JS array literal that mixes single-quoted and double-quoted
- * string values into pure JSON. Walks character-by-character so embedded
- * quote characters inside strings (e.g. `summary:'... "alt wellness" ...'`)
- * stay correctly escaped in the resulting JSON.
+ * Convert a plain-JS array literal into pure JSON in a single pass:
+ *   1. `'...'` string values   → `"..."` JSON strings (with proper re-escaping
+ *      of any literal `"` that appeared inside the single-quoted body).
+ *   2. Unquoted keys after `{` or `,` → `"key":`
  *
- * Does NOT touch unquoted keys — the caller's existing regex pass handles
- * `{key:` → `{"key":` after this normalization.
+ * Both transforms in one walker so the key-quoting step CANNOT misfire on
+ * `, identifier:` sequences embedded inside string values (e.g. a summary
+ * field containing "Cases linked, date: 2026-05-01"). The walker tracks
+ * `inString` and only inserts key quotes when out-of-string.
+ *
+ * Pre-PR-3636 these were two separate passes (a regex over the post-string-
+ * normalized output). Codex review round 1 P2 flagged that the regex pass
+ * had no string-state awareness and could corrupt summary fields that
+ * happened to contain `,<word>:` sequences. This single-pass walker
+ * eliminates the class of bug.
  */
-function normalizeJSStringQuotesToJSON(literal) {
+function jsLiteralToJSON(literal) {
   let out = '';
   let i = 0;
+  // Tracks the last non-whitespace char emitted at top level (out-of-string).
+  // Only `{` and `,` are valid contexts where an unquoted key may follow;
+  // any other prior char (e.g. `:` after a value, `[` opening a nested
+  // array) means an identifier here is NOT a key — leave it alone.
+  let lastTopChar = '';
+
   while (i < literal.length) {
     const c = literal[i];
+
+    // ---- String value handling ----
     if (c === "'" || c === '"') {
       const quote = c;
       out += '"';
@@ -229,28 +252,59 @@ function normalizeJSStringQuotesToJSON(literal) {
       while (i < literal.length) {
         const ch = literal[i];
         if (ch === '\\') {
-          // Pass escape sequence through unchanged. JSON accepts the same
-          // single-char escapes (\\, \", \/, \n, \t, \r, \b, \f, \uXXXX)
-          // that JS uses, except `\'` which JSON does not allow — convert
-          // that to a bare `'` (no JSON escape needed for a single quote
-          // inside a JSON string).
+          // JSON accepts `\\`, `\"`, `\/`, `\n`, `\t`, `\r`, `\b`, `\f`,
+          // `\uXXXX` — pass through. `\'` is invalid in JSON: convert to
+          // bare `'`. Bundle-truncation guard: don't overshoot EOF.
+          if (i + 1 >= literal.length) { i += 1; break; }
           if (literal[i + 1] === "'") { out += "'"; i += 2; continue; }
-          out += ch + (literal[i + 1] ?? '');
+          out += ch + literal[i + 1];
           i += 2;
           continue;
         }
         if (ch === quote) { out += '"'; i++; break; }
-        // If we entered via `'`, any literal `"` in the body must be escaped
-        // for JSON output. (Conversely, a `'` in a `"`-quoted source is fine
-        // both in JS and JSON, no transform needed.)
+        // Single-quoted source body containing a literal `"` must be escaped
+        // for JSON. Double-quoted source bodies don't need this — `'` is
+        // valid in both JS and JSON strings.
         if (quote === "'" && ch === '"') { out += '\\"'; i++; continue; }
         out += ch;
         i++;
       }
-    } else {
-      out += c;
-      i++;
+      lastTopChar = '"'; // string just closed
+      continue;
     }
+
+    // ---- Out-of-string: maybe an unquoted key starts here ----
+    // Trigger conditions:
+    //   - lastTopChar is `{` or `,` (we just opened an object or finished
+    //     a previous key/value pair)
+    //   - current char starts an identifier
+    if ((lastTopChar === '{' || lastTopChar === ',')
+        && /[A-Za-z_]/.test(c)) {
+      // Read the identifier
+      let j = i;
+      while (j < literal.length && /[A-Za-z0-9_]/.test(literal[j])) j++;
+      // Skip whitespace, expect `:`
+      let k = j;
+      while (k < literal.length && /\s/.test(literal[k])) k++;
+      if (literal[k] === ':') {
+        out += '"' + literal.slice(i, j) + '"' + literal.slice(j, k + 1);
+        i = k + 1;
+        lastTopChar = ':';
+        continue;
+      }
+      // Identifier without trailing `:` → not a key (probably a literal
+      // value like `null`, `true`, `false`, or unquoted JS that JSON.parse
+      // will reject downstream). Pass through as-is.
+      out += literal.slice(i, j);
+      i = j;
+      lastTopChar = literal[j - 1];
+      continue;
+    }
+
+    // ---- Default pass-through ----
+    out += c;
+    if (!/\s/.test(c)) lastTopChar = c;
+    i++;
   }
   return out;
 }
@@ -273,18 +327,15 @@ function* iteratePlainJSArrays(bundle) {
     const arrayClose = findArrayCloseInPlainJS(bundle, arrayOpen);
     if (arrayClose === -1) continue;
     const literal = bundle.slice(arrayOpen, arrayClose + 1);
-    // Pass 1: normalize JS string quoting → JSON string quoting. Bundle uses
-    // `'...'` for any value containing literal `"` (e.g. summary fields with
-    // embedded quoted phrases) — JSON only allows `"..."`, so we walk strings
-    // character-by-character and re-emit with JSON-compatible escaping.
-    const stringNormalized = normalizeJSStringQuotesToJSON(literal);
-    // Pass 2: quote unquoted keys. `{Foo_Bar:` or `,Foo_Bar:` → `{"Foo_Bar":` /
-    // `,"Foo_Bar":`. The `{|,` boundary excludes mid-value false positives —
-    // any `:` inside a string literal is now safely inside double quotes from
-    // pass 1 and the boundary won't fire there.
-    const quoted = stringNormalized.replace(/([{,])\s*([A-Za-z_][A-Za-z0-9_]*)\s*:/g, '$1"$2":');
+    // Single-pass walker: converts JS string quoting → JSON string quoting
+    // AND quotes unquoted keys after `{` or `,`. The walker tracks string
+    // state, so the key-quoting step cannot misfire on a `,<ident>:` that
+    // happens to live inside a string value (e.g. summary fields like
+    // "Cases linked, date: 2026-05-01"). Pre-fix this was two passes and
+    // codex round 4 P2 flagged the string-corruption hazard.
+    const jsonForm = jsLiteralToJSON(literal);
     try {
-      const array = JSON.parse(quoted);
+      const array = JSON.parse(jsonForm);
       if (Array.isArray(array)) yield { array };
     } catch {
       // Bundle drift (e.g. an unquoted JS value like `undefined`/`NaN` or a
@@ -338,7 +389,7 @@ export function parseRealtimeAlerts(bundle) {
   // records) is fine; only a real schema change (renamed field) breaks us.
   const rows = findArrayBySchema(bundle, ['Alert_ID', 'lat', 'lng', 'diseases']);
   if (!rows) {
-    throw new Error('[VPD] no eval block matches realtime schema (Alert_ID, lat, lng, diseases) — upstream format drift?');
+    throw new Error('[VPD] no matching array block for realtime schema (Alert_ID, lat, lng, diseases) — tried both eval-wrapped + plain-JS formats; upstream format drift?');
   }
   return rows
     .filter((r) => r.lat && r.lng)
@@ -362,7 +413,7 @@ export function parseHistoricalData(bundle) {
   // schema fingerprint — the iso/disease/year combo is unique to historical.
   const rows = findArrayBySchema(bundle, ['country', 'iso', 'disease', 'year', 'cases']);
   if (!rows) {
-    throw new Error('[VPD] no eval block matches historical schema (country, iso, disease, year, cases) — upstream format drift?');
+    throw new Error('[VPD] no matching array block for historical schema (country, iso, disease, year, cases) — tried both eval-wrapped + plain-JS formats; upstream format drift?');
   }
   return rows.map((r) => ({
     country: r.country,

--- a/tests/vpd-tracker-parser.test.mjs
+++ b/tests/vpd-tracker-parser.test.mjs
@@ -273,24 +273,66 @@ describe('seed-vpd-tracker: REGRESSION — JSON-escaped quotes inside string val
   });
 });
 
-describe('seed-vpd-tracker: REGRESSION — pre-2026-04 bundle shape now throws clearly', () => {
-  // The OLD format: `var a=[{Alert_ID:"...",...}]; a.columns=["Alert_ID",...]`
-  // and `[{country:"Afghanistan",...}]`. The pre-fix parser anchored on these.
-  // Post-fix, the same input throws a clear "anchor not found" message instead
-  // of attempting to parse and producing a confusing downstream error.
-  it('rejects the pre-2026-04 var-a format with a clear message', () => {
-    const oldShape = [
-      'var a=[{Alert_ID:"8731706",lat:"56.85",lng:"24.92",diseases:"Measles"}];',
-      'a.columns=["Alert_ID","lat","lng","diseases"];',
-      '[{country:"Afghanistan",iso:"AF",disease:"Diphtheria",year:"2024",cases:"207"}]',
-    ].join('\n');
-    assert.throws(
-      () => parseRealtimeAlerts(oldShape),
-      /no eval block matches realtime schema/,
+describe('seed-vpd-tracker: plain-JS var-a format (pre-2026-04 / 2026-05-revert)', () => {
+  // The bundle on 2026-05-09 reverted to plain JS object literals (or shipped
+  // a third variant after the April webpack rebuild): unquoted keys, mixed
+  // `"..."`/`'...'` string values, no eval wrapper. The parser now supports
+  // BOTH this format AND the eval+escaped-JSON format from the April
+  // rewrite — both iterate via findArrayBySchema. WM 2026-05-09 detected
+  // via /api/health: vpdTrackerRealtime stale 72h while bundle siblings
+  // (Disease-Outbreaks, Displacement) ran fine in the same bundle.
+  it('parses unquoted-keys realtime alerts (var a=[{Alert_ID:...}])', () => {
+    const bundle = [
+      'function(e,s){var a=[{Alert_ID:"8731706",lat:"56.85",lng:"24.92",',
+      'diseases:"Measles",place_name:"Riga, Latvia",country:"Latvia",',
+      'date:"5/2/2026",cases:"3",link:"https://example.com/x",',
+      'summary:"Three measles cases reported."},',
+      '{Alert_ID:"8731707",lat:"40.1",lng:"-74.2",diseases:"Mumps",',
+      'place_name:"Trenton, NJ",country:"United States",date:"5/3/2026",',
+      'cases:"7",link:"https://example.com/y",summary:"Mumps cluster."}]}',
+    ].join('');
+    const out = parseRealtimeAlerts(bundle);
+    assert.strictEqual(out.length, 2);
+    assert.strictEqual(out[0].alertId, '8731706');
+    assert.strictEqual(out[0].disease, 'Measles');
+    assert.strictEqual(out[0].cases, 3);
+    assert.strictEqual(out[1].country, 'United States');
+  });
+
+  it('parses single-quoted JS values (used when value contains literal ")', () => {
+    // Bundle uses `'...'` for any value with embedded double quotes, e.g.
+    // summaries that quote source phrases. JSON requires `"..."` so the
+    // normalizer rewrites quote style and re-escapes embedded `"`.
+    const bundle = [
+      'function(e,s){var a=[{Alert_ID:"X1",lat:"40",lng:"-74",',
+      'diseases:"Measles",place_name:"Riga",country:"Latvia",',
+      'date:"5/2/2026",cases:"3",link:"https://e.com",',
+      'summary:\'A measles exposure linked to an "alternative wellness" seminar.\'}]}',
+    ].join('');
+    const out = parseRealtimeAlerts(bundle);
+    assert.strictEqual(out.length, 1);
+    assert.strictEqual(
+      out[0].summary,
+      'A measles exposure linked to an "alternative wellness" seminar.',
     );
-    assert.throws(
-      () => parseHistoricalData(oldShape),
-      /no eval block matches historical schema/,
-    );
+  });
+
+  it('parses unquoted-keys historical (var a=[{country:...}])', () => {
+    const bundle = [
+      'function(e,s){var a=[{country:"Afghanistan",iso:"AF",',
+      'disease:"Diphtheria",year:"2024",cases:"207"},',
+      '{country:"Albania",iso:"AL",disease:"Measles",year:"2024",cases:"0"}]}',
+    ].join('');
+    const out = parseHistoricalData(bundle);
+    assert.strictEqual(out.length, 2);
+    assert.strictEqual(out[0].country, 'Afghanistan');
+    assert.strictEqual(out[0].cases, 207);
+  });
+
+  it('still throws clearly when no block matches either format', () => {
+    // No eval wrapper, no var-array with the matching schema fingerprint.
+    const garbage = 'function(e,s){var x = "irrelevant"; var n=[1,2,3]}';
+    assert.throws(() => parseRealtimeAlerts(garbage), /no eval block matches realtime schema/);
+    assert.throws(() => parseHistoricalData(garbage), /no eval block matches historical schema/);
   });
 });

--- a/tests/vpd-tracker-parser.test.mjs
+++ b/tests/vpd-tracker-parser.test.mjs
@@ -58,11 +58,11 @@ describe('seed-vpd-tracker: parseRealtimeAlerts (post-2026-04 bundle format)', (
     assert.equal(madrid.cases, 1234, 'comma-separated "1,234" must parse to 1234');
   });
 
-  it('throws a clear error when no eval block matches realtime schema (upstream format drift)', () => {
+  it('throws a clear error when no matching array block for realtime schema (upstream format drift)', () => {
     const bundle = '/* bundle with no eval var-res blocks */';
     assert.throws(
       () => parseRealtimeAlerts(bundle),
-      /no eval block matches realtime schema \(Alert_ID, lat, lng, diseases\)/,
+      /no matching array block for realtime schema \(Alert_ID, lat, lng, diseases\)/,
     );
   });
 
@@ -74,7 +74,7 @@ describe('seed-vpd-tracker: parseRealtimeAlerts (post-2026-04 bundle format)', (
     const bundle = `eval("${escaped}")`;
     assert.throws(
       () => parseRealtimeAlerts(bundle),
-      /no eval block matches realtime schema/,
+      /no matching array block for realtime schema/,
     );
   });
 });
@@ -102,7 +102,7 @@ describe('seed-vpd-tracker: parseHistoricalData (post-2026-04 bundle format)', (
     assert.equal(aus.cases, 9);
   });
 
-  it('throws a clear error when no eval block matches historical schema', () => {
+  it('throws a clear error when no matching array block for historical schema', () => {
     // Bundle has an Alert_ID block, but no historical-shaped block.
     const realtime = [{ Alert_ID: '1', lat: '0', lng: '0', diseases: 'Measles', place_name: '', country: '', date: '', cases: '', link: '', Type: '', summary: '' }];
     const inner = `var res = ${JSON.stringify(realtime)}`;
@@ -110,7 +110,7 @@ describe('seed-vpd-tracker: parseHistoricalData (post-2026-04 bundle format)', (
     const bundle = `eval("${escaped}")`;
     assert.throws(
       () => parseHistoricalData(bundle),
-      /no eval block matches historical schema/,
+      /no matching array block for historical schema/,
     );
   });
 });
@@ -332,7 +332,40 @@ describe('seed-vpd-tracker: plain-JS var-a format (pre-2026-04 / 2026-05-revert)
   it('still throws clearly when no block matches either format', () => {
     // No eval wrapper, no var-array with the matching schema fingerprint.
     const garbage = 'function(e,s){var x = "irrelevant"; var n=[1,2,3]}';
-    assert.throws(() => parseRealtimeAlerts(garbage), /no eval block matches realtime schema/);
-    assert.throws(() => parseHistoricalData(garbage), /no eval block matches historical schema/);
+    assert.throws(() => parseRealtimeAlerts(garbage), /no matching array block for realtime schema/);
+    assert.throws(() => parseHistoricalData(garbage), /no matching array block for historical schema/);
+  });
+
+  // Regression test for codex round 4 P2: the prior two-pass implementation
+  // (string-quote-normalize, then a regex `s/([{,])\s*(<ident>):/$1"\$2":/g`)
+  // would corrupt summary fields whose body contained a `,<word>:` sequence
+  // because the regex had no string-state awareness. The single-pass
+  // jsLiteralToJSON walker now tracks inString and only quotes keys when
+  // out-of-string, so this case parses cleanly.
+  it('does NOT misquote `,ident:` sequences inside string values (round-4 P2)', () => {
+    const bundle = [
+      'function(e,s){var a=[{Alert_ID:"X1",lat:"40",lng:"-74",',
+      'diseases:"Measles",place_name:"NYC",country:"USA",',
+      'date:"5/2/2026",cases:"3",link:"https://e.com",',
+      // The summary contains a literal `, date:` sequence — exactly the
+      // pattern the old regex would have falsely quoted. The single-pass
+      // walker is in `inString=true` here so it must NOT touch this.
+      'summary:"Cases linked to event, date: 2026-05-01, source confirmed."}]}',
+    ].join('');
+    const out = parseRealtimeAlerts(bundle);
+    assert.strictEqual(out.length, 1);
+    assert.strictEqual(
+      out[0].summary,
+      'Cases linked to event, date: 2026-05-01, source confirmed.',
+    );
+  });
+
+  it('handles bundle truncation at a backslash without overshooting EOF (round-4 P3)', () => {
+    // If the bundle is truncated mid-escape-sequence, the brace walker
+    // must not advance past the end of the string when it hits `\` as the
+    // last byte. Result: walker returns -1 cleanly, candidate is skipped,
+    // findArrayBySchema falls through to the throw.
+    const truncated = 'function(e,s){var a=[{Alert_ID:"foo",lat:"1",lng:"2",diseases:"X\\';
+    assert.throws(() => parseRealtimeAlerts(truncated), /no matching array block/);
   });
 });


### PR DESCRIPTION
## Summary

The Think Global Health VPD tracker bundle (`https://thinkglobalhealth.github.io/disease_tracker/index_bundle.js`, ~4MB) reverted to the pre-April-2026 format on/before 2026-05-09: plain JS object literals with unquoted keys (`var a=[{Alert_ID:"...",...}]`), no `eval()` wrapper, mixed `"..."` and `'...'` string values.

The seeder's parser was rewritten in April to anchor on the new `eval("var res = [{\"Alert_ID\"...]")` shape and ONLY that shape. Every nightly seed since the revert failed with `[VPD] no eval block matches realtime schema` and the tracker keys went stale.

## Detection

Surfaced via `/api/health`:
```
vpdTrackerRealtime    STALE_SEED  records=1949  seedAge=4346min (72.4h, 3.0d)
vpdTrackerHistorical  STALE_SEED  records=1949  seedAge=4346min (72.4h, 3.0d)
```
Sibling scripts in the same Railway bundle (`seed-bundle-health`) ran fine: Air-Quality 27min ago, Disease-Outbreaks 87min, Displacement 0min. Bundle siblings healthy + this one broken = **local parser issue, not infra/cron**.

Direct upstream check confirmed format change:
```
$ curl -s https://thinkglobalhealth.github.io/disease_tracker/index_bundle.js | grep -c 'eval("var res = \[{\\"Alert_ID\\"'
0    ← post-April anchor: ZERO matches in current bundle
$ grep -c 'var a=\[{Alert_ID:' /tmp/bundle.js
1    ← reverted format present
```

## Changes

1. **`iteratePlainJSArrays()`** — walks `var <id>=[{<key>:...},...]` literals with a JS-aware brace-walker that tracks both `"..."` and `'...'` strings (so brackets inside string values don't shift depth).
2. **`normalizeJSStringQuotesToJSON()`** — converts JS string-literal quoting → JSON quoting, including round-tripping single-quoted values that contain literal `"` (21 of 1969 alerts in today's bundle, e.g. `summary:'... "alternative wellness" seminar.'`).
3. **`findArrayBySchema()`** wires both iterators (eval-wrapped + plain-JS), so the parser tries both formats. Schema-fingerprint matching is unchanged.

## Verification

End-to-end against the live bundle:
```
$ node test-parse.mjs
Realtime alerts: 1969
Historical:      25961

First single-quoted alert summary:
"A measles exposure has been confirmed in Latvia, with the source suspected to be an \"alternative wellness\" seminar held in Riga. "
```

Bundle has 4MB total, 2 var-array blocks matching the schema fingerprints (alerts + historical) plus 1 unrelated `var n=[{x:o,y:t/2,...}]` block at position 3961640 that gets correctly rejected by the schema-fingerprint check.

## Test plan

- [x] `node --test tests/vpd-tracker-parser.test.mjs` — 20/20 pass (replaced 1 obsolete "must throw on old format" test with 4 new positive assertions covering unquoted-keys realtime + historical, single-quoted values with embedded `"`, and a schema-mismatch negative)
- [ ] Post-merge: next `seed-bundle-health` cron run produces non-zero VPD records; `/api/health` flips `vpdTrackerRealtime` and `vpdTrackerHistorical` to `OK`

## Why this happened

The April 2026 webpack rewrite dropped a `babel-loader` config option (or upgraded webpack), which changed how `data.js` files inline arrays. Then the May rebuild reverted that change. Both formats are valid JS but require different parsers. Future-proofing: parser now tolerates both; if a third format ships, the fingerprint-based dispatch keeps schema mismatches surfaceable.