### PR TITLE
fix(seed-iea-oil-stocks): bump STALE_CONTENT budget 90d → 120d

### DIFF
--- a/scripts/_iea-oil-stocks-helpers.mjs
+++ b/scripts/_iea-oil-stocks-helpers.mjs
@@ -64,7 +64,7 @@ export function ieaOilStocksContentMeta(data, nowMs = Date.now()) {
 }
 
 /**
- * Sprint 3b pilot threshold (90 days).
+ * Threshold for STALE_CONTENT alerting (120 days).
  *
  * IEA monthly oil stocks publish on an M+2 cadence — August data
  * (`dataMonth = "2024-08"`, end-of-month = Aug 31) ships in late Oct
@@ -72,13 +72,24 @@ export function ieaOilStocksContentMeta(data, nowMs = Date.now()) {
  * That means at fresh-arrival the helper's `newestItemAt` is already
  * 60d old, before any real staleness has accrued.
  *
- * The budget therefore needs ~60d to cover the natural M+2 lag PLUS
- * ~30d slack for one missed publication = 90d total. STALE_CONTENT
- * trips when a month is missed entirely (e.g. cache stuck at
- * "2024-08" past mid-Jan when "2024-10" should have landed).
+ * Budget breakdown: ~60d for the natural M+2 lag + ~60d slack for
+ * up-to-two missed publications = 120d total. STALE_CONTENT trips
+ * when more than two months are missed (e.g. cache stuck at
+ * "2024-08" past mid-Feb when "2024-11" should have landed).
  *
- * (Sprint 3b initial PR shipped 45d, which would have fired
- * STALE_CONTENT on every fresh seed because 45d < natural lag.
- * Greptile P1 caught it; #3599 review.)
+ * Iteration history:
+ *   - Sprint 3b initial PR (#3599) shipped 45d, which would have
+ *     fired STALE_CONTENT on every fresh seed because 45d < natural
+ *     lag. Greptile P1 caught it.
+ *   - Sprint 3b shipped at 90d (60d M+2 lag + 30d slack for one
+ *     missed publication).
+ *   - 2026-05-09: bumped to 120d after IEA delayed Feb 2026 data by
+ *     >24 days past expected mid-April publish window. Direct probe
+ *     of `https://api.iea.org/netimports/monthly/?year=2026&month=02`
+ *     returned `[]` (no data on the upstream itself), confirming this
+ *     was a real publication delay, not a parser/network bug. The 90d
+ *     budget was sized for "one missed publication"; IEA's recent
+ *     pattern of 1-2 month delays makes 120d a better fit. Real
+ *     "IEA went silent" incidents (>2 month gaps) still surface.
  */
-export const IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN = 90 * 24 * 60;
+export const IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN = 120 * 24 * 60;

--- a/tests/iea-oil-stocks-content-age.test.mjs
+++ b/tests/iea-oil-stocks-content-age.test.mjs
@@ -15,12 +15,15 @@ import {
 
 const FIXED_NOW = 1700000000000;     // 2023-11-14T22:13:20.000Z — stable test "now"
 
-test('IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN is 90 days', () => {
-  // 90d = ~60d natural M+2 lag + ~30d missed-publication slack. See helper
-  // module's JSDoc on the threshold. Initial PR shipped 45d, which was
-  // wrong: every fresh seed run would have tripped STALE_CONTENT because
-  // 45d < the natural lag. Greptile P1 caught it on PR #3599.
-  assert.equal(IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN, 90 * 24 * 60);
+test('IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN is 120 days', () => {
+  // 120d = ~60d natural M+2 lag + ~60d slack for up-to-two missed
+  // publications. See helper module's JSDoc for the iteration history
+  // (45d → 90d → 120d). The 2026-05-09 bump from 90d → 120d followed an
+  // IEA Feb 2026 publication delay confirmed via direct upstream probe:
+  // `https://api.iea.org/netimports/monthly/?year=2026&month=02` returned
+  // `[]`, so the staleness was a real upstream delay rather than a
+  // parser/network bug.
+  assert.equal(IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN, 120 * 24 * 60);
 });
 
 // ── dataMonthToEndOfMonthMs ──────────────────────────────────────────────
@@ -134,11 +137,14 @@ test('pilot threshold: dataMonth ~14 days old is within 90-day budget (no false 
   );
 });
 
-test('pilot threshold: dataMonth ~120d old (multiple missed publications) trips STALE_CONTENT', () => {
-  // FIXED_NOW = 2023-11-14T22:13:20Z. "2023-07" → end-of-Jul = ~106d ago,
-  // past the 90d budget. Simulates "Aug AND Sept data both missed" or "Aug
-  // arrived very late" scenarios where on-call should be paged.
-  const cm = ieaOilStocksContentMeta({ dataMonth: '2023-07' }, FIXED_NOW);
+test('threshold: dataMonth ~168d old (multiple missed publications) trips STALE_CONTENT', () => {
+  // FIXED_NOW = 2023-11-14T22:13:20Z. "2023-05" → end-of-May = ~168d ago,
+  // past the 120d budget. Simulates "Jun, Jul AND Aug data all missed" or
+  // "Jun arrived very late" — at least three monthly publications late, on-call
+  // should be paged. Pre-bump this test used "2023-07" (~106d) which was past
+  // the old 90d budget but well WITHIN the new 120d budget; pushed back two
+  // months so the trip remains decisive.
+  const cm = ieaOilStocksContentMeta({ dataMonth: '2023-05' }, FIXED_NOW);
   const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
   assert.ok(
     ageMin > IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN,
@@ -146,16 +152,18 @@ test('pilot threshold: dataMonth ~120d old (multiple missed publications) trips 
   );
 });
 
-test('pilot threshold: M+2 lag scenario — Sept data still in cache by Feb 1 (5 months later) trips STALE_CONTENT', () => {
-  // Realistic incident pattern: cache holds dataMonth="2023-09" (Sept data,
-  // M+2 publication = late Nov 2023). By Feb 1 2024 — three months past
-  // expected publication of Oct AND Nov data — staleness is unambiguous.
-  // 154d > 90d budget: clearly trips.
+test('threshold: M+2 lag scenario — Aug data still in cache by Feb 1 (5+ months later) trips STALE_CONTENT', () => {
+  // Realistic incident pattern: cache holds dataMonth="2023-08" (Aug data,
+  // M+2 publication = late Oct 2023). By Feb 1 2024 — three full months past
+  // expected publication of Sep AND Oct data — staleness is unambiguous.
+  // ~154d > 120d budget: clearly trips. Pre-bump this used dataMonth="2023-09"
+  // (~122d), which was only 2d past the new 120d budget — too close to the
+  // boundary to be a useful regression guard. Pushed back one month.
   const FIXED_FUTURE = Date.UTC(2024, 1, 1);     // Feb 1 2024 UTC
-  const cm = ieaOilStocksContentMeta({ dataMonth: '2023-09' }, FIXED_FUTURE);
+  const cm = ieaOilStocksContentMeta({ dataMonth: '2023-08' }, FIXED_FUTURE);
   const ageMin = (FIXED_FUTURE - cm.newestItemAt) / 60000;
   assert.ok(
     ageMin > IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN,
-    `Sept 2023 data on Feb 1 2024: ${Math.round(ageMin / 60 / 24)}d > ${IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN / 60 / 24}d budget — STALE_CONTENT trips`,
+    `Aug 2023 data on Feb 1 2024: ${Math.round(ageMin / 60 / 24)}d > ${IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN / 60 / 24}d budget — STALE_CONTENT trips`,
   );
 });


### PR DESCRIPTION
## Summary

Tunable threshold bump — no code-path change. IEA delayed Feb 2026 oil stocks publication by >24 days past the historical mid-April M+2 cadence, pushing our content age past the 90d budget. Bumping to 120d so `/api/health` doesn't show DEGRADED for the duration of this delay (and gives slack for similar 1-2 month delays in future).

## Evidence — IEA upstream itself is genuinely stuck on Jan 2026

Verified via direct probes (2026-05-09, anyone can reproduce — public, no auth):

```
GET https://api.iea.org/netimports/latest                        → {"year":"2026","month":"01"}
GET https://api.iea.org/netimports/monthly/?year=2026&month=02   → []          ← 2 bytes, 0 records
GET https://api.iea.org/netimports/monthly/?year=2026&month=01   → [37 records]
GET https://api.iea.org/netimports/monthly/?year=2025&month=12   → [37 records]
GET https://api.iea.org/netimports/monthly/?year=2025&month=11   → [37 records]
GET https://api.iea.org/netimports/monthly/?year=2026&month=03   → []
GET https://api.iea.org/netimports/monthly/?year=2026&month=04   → []
```

**Proof by absence**: every other month returns 37 records; Feb/Mar 2026 return empty arrays. The data isn't sitting somewhere ours can't reach — IEA hasn't generated it yet. Our seeder is healthy (`seedAge=9h`, runs daily) and faithfully fetches what `/latest` reports.

## Math

```
Today                    = 2026-05-09
Latest IEA dataMonth     = 2026-01     (per /latest endpoint)
End-of-Jan-2026 → today  = ~98 days  (matches /api/health contentAgeMin=140681)
Old budget               = 90d  (60d M+2 + 30d slack for 1 missed publication)
                         → STALE_CONTENT fires when delay > 30d (we are at ~24d delay + still climbing)
New budget               = 120d (60d M+2 + 60d slack for 2 missed publications)
                         → STALE_CONTENT fires when delay > 60d
```

A real "IEA went silent" incident (gap > 2 months) still surfaces.

## Changes

1. `IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN`: `90 * 24 * 60` → `120 * 24 * 60` (`scripts/_iea-oil-stocks-helpers.mjs:84`).
2. Updated docstring with iteration history (45d → 90d → 120d) and the Feb 2026 incident notes including the verification URLs above.
3. Updated value-pin assertion in test (`90 * 24 * 60` → `120 * 24 * 60`).
4. Pushed two budget-overshoot test cases further past the new boundary so they remain decisive guards (not boundary-hugging):
   - `2023-07` (~106d, was 16d past old budget) → `2023-05` (~168d, 48d past new budget)
   - `2023-09 on Feb 1 2024` (~122d, 2d past new budget — fragile) → `2023-08 on Feb 1 2024` (~154d, 34d past new budget)

## Test plan

- [x] `node --test tests/iea-oil-stocks-content-age.test.mjs` — 16/16 pass
- [ ] Post-merge: `/api/health?compact=1` no longer shows `ieaOilStocks: STALE_CONTENT` (warning clears once Vercel redeploys)
- [ ] When IEA eventually publishes Feb 2026 data: next daily seed picks it up, content-age resets to ~70d, well within the new 120d budget

## Companion

Surfaced during the multi-issue health-endpoint audit (PR #3633 + #3636). The other issues — VPD parser revert (#3636), consumer-prices migration apply (#3627), Carrefour BR / Cold Storage SG path filter (#3633) — were all our bugs. This one is upstream-only; the bump is the only operator-visible action.