### PR TITLE
feat(health): expose failure-log via /api/health?history=1

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -748,11 +748,11 @@ export default async function handler(req, ctx) {
       const lastFailureRaw = results?.[0]?.result;
       const failureLogRaw = results?.[1]?.result;
       const body = {
-        lastFailure: typeof lastFailureRaw === 'string' ? parseJson(lastFailureRaw) : null,
+        lastFailure: parseJson(lastFailureRaw),
         failureLog: Array.isArray(failureLogRaw)
           ? failureLogRaw.map(parseJson).filter((e) => e !== null)
           : [],
-        checkedAt: new Date(Date.now()).toISOString(),
+        checkedAt: new Date().toISOString(),
       };
       return new Response(JSON.stringify(body, null, 2), { status: 200, headers });
     }

--- a/api/health.js
+++ b/api/health.js
@@ -722,6 +722,42 @@ export default async function handler(req, ctx) {
     return new Response(null, { status: 204, headers });
   }
 
+  // ?history=1 — fast read of the failure-log persisted by previous /api/health
+  // probes. Skips the full freshness check (which is expensive — fetches every
+  // bootstrap key) and returns only the last-failure snapshot + the deduped
+  // incident log. Use to answer "what's been flipping?" without needing
+  // Upstash creds. The classifier writes these keys on every non-OK probe:
+  //   health:last-failure   — single most recent unhealthy snapshot (24h TTL)
+  //   health:failure-log    — last 50 deduped incidents (7-day TTL)
+  // See WM 2026-05-10 — added after a night of UptimeRobot flips that needed
+  // direct Upstash inspection to diagnose.
+  {
+    const earlyUrl = new URL(req.url);
+    if (earlyUrl.searchParams.get('history') === '1') {
+      const results = await redisPipeline(
+        [
+          ['GET', 'health:last-failure'],
+          ['LRANGE', 'health:failure-log', '0', '-1'],
+        ],
+        4_000,
+      );
+      const parseJson = (raw) => {
+        if (typeof raw !== 'string') return null;
+        try { return JSON.parse(raw); } catch { return null; }
+      };
+      const lastFailureRaw = results?.[0]?.result;
+      const failureLogRaw = results?.[1]?.result;
+      const body = {
+        lastFailure: typeof lastFailureRaw === 'string' ? parseJson(lastFailureRaw) : null,
+        failureLog: Array.isArray(failureLogRaw)
+          ? failureLogRaw.map(parseJson).filter((e) => e !== null)
+          : [],
+        checkedAt: new Date(Date.now()).toISOString(),
+      };
+      return new Response(JSON.stringify(body, null, 2), { status: 200, headers });
+    }
+  }
+
   const now = Date.now();
 
   const allDataKeys = [

--- a/tests/health-history-endpoint.test.mjs
+++ b/tests/health-history-endpoint.test.mjs
@@ -1,0 +1,82 @@
+// Sprint follow-up — `/api/health?history=1` early-return path.
+//
+// The /api/health classifier writes `health:last-failure` and
+// `health:failure-log` to Redis on every non-OK probe. Pre-2026-05-10 there
+// was no read endpoint, so diagnosing UptimeRobot flips required direct
+// Upstash credentials. This test exercises the new query-param path that
+// surfaces those keys without re-running the (expensive) full freshness
+// probe.
+//
+// We intentionally don't mock Redis — when UPSTASH_REDIS_REST_URL is unset
+// (test environment), `redisPipeline` returns null and the handler falls
+// through to a `{ lastFailure: null, failureLog: [] }` response. That's
+// the correct contract: the endpoint never throws, even when Redis is
+// unreachable.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+describe('api/health ?history=1', () => {
+  it('returns lastFailure + failureLog shape, never throws', async () => {
+    // Force the no-Redis path so the test is hermetic. The endpoint must
+    // gracefully degrade to empty arrays/null when Upstash is unreachable.
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    const { default: handler } = await import('../api/health.js');
+    const req = new Request('https://api.worldmonitor.app/api/health?history=1');
+    const res = await handler(req);
+
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('Content-Type'), 'application/json');
+
+    const body = await res.json();
+    assert.ok(Object.hasOwn(body, 'lastFailure'), 'body has lastFailure key');
+    assert.ok(Object.hasOwn(body, 'failureLog'), 'body has failureLog key');
+    assert.ok(Object.hasOwn(body, 'checkedAt'), 'body has checkedAt key');
+    assert.equal(body.lastFailure, null, 'lastFailure null when Redis unreachable');
+    assert.deepEqual(body.failureLog, [], 'failureLog empty when Redis unreachable');
+    assert.match(body.checkedAt, /^\d{4}-\d{2}-\d{2}T/, 'checkedAt is ISO 8601');
+  });
+
+  it('does NOT trigger the early-return when ?history is absent or != "1"', async () => {
+    // Without ?history=1 the handler MUST take the full classification
+    // path. The exact non-history shape varies (REDIS_DOWN short-circuit
+    // when Upstash is unconfigured, full {summary, ...} shape when
+    // configured) — what we care about is that the history-specific
+    // fields (lastFailure, failureLog) are absent.
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    const { default: handler } = await import('../api/health.js?second-import');
+    const req = new Request('https://api.worldmonitor.app/api/health?compact=1');
+    const res = await handler(req);
+
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(
+      !Object.hasOwn(body, 'lastFailure'),
+      'non-history path must not include lastFailure key',
+    );
+    assert.ok(
+      !Object.hasOwn(body, 'failureLog'),
+      'non-history path must not include failureLog key',
+    );
+  });
+
+  it('treats history values other than exact "1" as non-matching (no false-trigger)', async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    const { default: handler } = await import('../api/health.js?third-import');
+    for (const v of ['0', 'true', 'yes', '01']) {
+      const req = new Request(`https://api.worldmonitor.app/api/health?history=${v}`);
+      const res = await handler(req);
+      const body = await res.json();
+      assert.ok(
+        !Object.hasOwn(body, 'lastFailure'),
+        `history=${v} should NOT trigger early-return (history-specific keys leaked)`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Surfaces the `health:last-failure` + `health:failure-log` Redis keys via a query-param path on `/api/health`, so diagnosing UptimeRobot flips no longer requires Upstash credentials.

## Why

The /api/health classifier already writes incident snapshots to Redis on every non-OK probe:
- `health:last-failure` — most recent unhealthy snapshot (24h TTL)
- `health:failure-log` — last 50 deduped incidents (7-day TTL)

But there was no read endpoint. WM 2026-05-10 had a night of UptimeRobot DOWN/UP flips on `correlationCards`; the only way to diagnose was hand-pulling `health:failure-log` via curl + Upstash token. This PR adds the missing read surface.

## Behavior

```
GET /api/health?history=1
{
  "lastFailure": { "at": "...", "status": "WARNING", "critCount": 0, "warnCount": 1, "problems": ["correlationCards:STALE_SEED(19min)"] },
  "failureLog": [
    { "at": "2026-05-10T04:04:29Z", "status": "WARNING", "problems": ["correlationCards:STALE_SEED(19min)"] },
    { "at": "2026-05-10T02:21:49Z", "status": "WARNING", "problems": ["correlationCards:STALE_SEED(17min)"] },
    ...
  ],
  "checkedAt": "2026-05-10T04:30:00Z"
}
```

```
GET /api/health             ← unchanged (full classification probe)
GET /api/health?compact=1   ← unchanged (compact problem-list shape)
```

The new path is **early-return**: it reads two Redis keys and returns. Skips the full bootstrap-keys probe (which is expensive). Cheap to call from a browser tab.

## Discriminator

Strict `=== '1'` match on the `history` query param. Any other value (`0`, `true`, `yes`, `01`) falls through to the classification path. Tests cover all three cases.

## Graceful degradation

When Upstash is unreachable (creds missing, network failure, timeout), `redisPipeline` returns null and the handler responds with `{ lastFailure: null, failureLog: [] }`. Never throws, never 5xx.

## Test plan

- [x] `node --test tests/health-history-endpoint.test.mjs` — 3/3 pass
  - Returns history shape on `?history=1`, no exceptions when Redis unconfigured
  - Default `/api/health?compact=1` does NOT include history fields (no leak into the classification response)
  - Non-`1` values for `?history` (`0`, `true`, `yes`, `01`) all fall through to the classification path
- [x] `node --test tests/health-content-age.test.mjs` — 18/18 pass (existing classifier tests unchanged)
- [x] `node --check api/health.js` — syntax OK
- [x] `npx esbuild --bundle --format=esm --platform=browser` — bundles cleanly for the edge runtime
- [ ] Post-merge: `curl https://api.worldmonitor.app/api/health?history=1` returns the live failure log

## Companion

Pairs with #3640 (correlationCards budget bump). Together they (a) reduce false-positive flips and (b) make residual flips easier to diagnose.