### PR TITLE
fix(payments): unblock Education customer + resilient resolvePlanKey + Dodo catalog audit

### DIFF
--- a/convex/config/productCatalog.ts
+++ b/convex/config/productCatalog.ts
@@ -233,6 +233,12 @@ export const LEGACY_PRODUCT_ALIASES: Record<string, string> = {
   "pdt_0NaysZwxCyk9Satf1jbqU": "api_starter",
   "pdt_0NaysdZLwkMAPEVJQja5G": "api_business",
   "pdt_0NaysgHSQTTqGjJdLtuWP": "enterprise",
+  // "API Starter for Education" — created via Dodo dashboard 2026-05-09 with
+  // education-discount pricing ($69/mo × 10yr term). Same feature set as
+  // api_starter; only the price/term differ. Customer was stuck in webhook
+  // 500-retry loop until this mapping was added (sub_0NeQV8vJI0fEwUEDjp3cA).
+  // See scripts/audit-dodo-catalog.cjs to detect this class of drift early.
+  "pdt_0NeRCJCIwZrExuE1kifHp": "api_starter",
 };
 
 // ---------------------------------------------------------------------------

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -261,15 +261,28 @@ export async function recomputeEntitlementFromAllSubs(
 /**
  * Fallback plan key when a webhook references a Dodo product ID we don't
  * recognize (operator edited a product in the Dodo dashboard, didn't update
- * our catalog). Picked to be the cheapest entitlement that still grants
- * paid features — better to over-grant than under-grant a paying customer
- * who is already on the hook for the subscription on Dodo's side.
+ * our catalog).
+ *
+ * Picked as the HIGHEST-tier paid plan to maximise over-grant. Rationale:
+ * we don't know what the customer paid for, but they ARE paying (the
+ * webhook is from Dodo for an active subscription). The downside of
+ * over-grant — a Pro customer briefly gets Enterprise features until
+ * ops fixes the catalog — is bounded and cheap. The downside of under-
+ * grant — an Enterprise customer silently loses apiAccess + priority
+ * support mid-billing-cycle because we mapped them to pro_monthly
+ * (tier 1, apiAccess: false) — is a real-money regression on the exact
+ * customers this fallback is supposed to protect.
  *
  * The "fail open" branch in `resolvePlanKey` ALSO fires a loud
  * console.error which Convex auto-Sentry forwards, so ops gets paged
- * before the customer notices their entitlement is wrong.
+ * before the customer notices their entitlement is wrong. Combined with
+ * scripts/audit-dodo-catalog.cjs running on a schedule, the fallback
+ * window is short — usually hours, not days.
+ *
+ * Greptile P1 review on PR #3642 caught the original `pro_monthly`
+ * choice silently revoking API access from `api_*` / `enterprise` customers.
  */
-const FALLBACK_PLAN_KEY = "pro_monthly";
+const FALLBACK_PLAN_KEY = "enterprise";
 
 /**
  * Resolves a Dodo product ID to a plan key via the productPlans table.
@@ -313,12 +326,15 @@ async function resolvePlanKey(
   // sentry-coverage-ok: structured console.error is forwarded by Convex
   // auto-Sentry so on-call sees the unmapped product immediately. We do
   // NOT throw — that would 500 the webhook and trigger Dodo's retry storm,
-  // which leaves the customer's entitlement wedged.
+  // which leaves the customer's entitlement wedged. The over-grant
+  // fallback (FALLBACK_PLAN_KEY = enterprise) is intentional — see the
+  // const's JSDoc for the rationale.
   console.error(
     `[subscriptionHelpers] Unknown Dodo product ID "${dodoProductId}" — ` +
       `not in productPlans table and not in LEGACY_PRODUCT_ALIASES. ` +
-      `Falling back to "${FALLBACK_PLAN_KEY}" so the customer keeps a paid ` +
-      `entitlement. ACTION REQUIRED: add this product to ` +
+      `Falling back to "${FALLBACK_PLAN_KEY}" (over-grant) so the customer ` +
+      `keeps full paid entitlement until catalog is fixed. ` +
+      `ACTION REQUIRED: add this product to ` +
       `convex/config/productCatalog.ts (LEGACY_PRODUCT_ALIASES or PRODUCT_CATALOG) ` +
       `and re-run seedProductPlans. See scripts/audit-dodo-catalog.cjs.`,
   );

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -259,10 +259,32 @@ export async function recomputeEntitlementFromAllSubs(
 // ---------------------------------------------------------------------------
 
 /**
+ * Fallback plan key when a webhook references a Dodo product ID we don't
+ * recognize (operator edited a product in the Dodo dashboard, didn't update
+ * our catalog). Picked to be the cheapest entitlement that still grants
+ * paid features — better to over-grant than under-grant a paying customer
+ * who is already on the hook for the subscription on Dodo's side.
+ *
+ * The "fail open" branch in `resolvePlanKey` ALSO fires a loud
+ * console.error which Convex auto-Sentry forwards, so ops gets paged
+ * before the customer notices their entitlement is wrong.
+ */
+const FALLBACK_PLAN_KEY = "pro_monthly";
+
+/**
  * Resolves a Dodo product ID to a plan key via the productPlans table.
- * Falls back to LEGACY_PRODUCT_ALIASES for old test-mode product IDs
- * that may still appear on existing subscriber webhooks.
- * Throws if the product ID is not mapped anywhere.
+ * Falls back to LEGACY_PRODUCT_ALIASES for old test-mode product IDs.
+ *
+ * Fail-open behaviour (added 2026-05-10 after sub_0NeQV8vJI0fEwUEDjp3cA
+ * incident): if the product ID is unknown to BOTH the table AND the
+ * legacy aliases, log a structured error and return FALLBACK_PLAN_KEY
+ * instead of throwing. The previous behaviour (throw → webhook 500 →
+ * Dodo retries forever) blocked entitlement updates for any customer
+ * whose subscription was migrated to a new Dodo product ID.
+ *
+ * The fallback is paired with `scripts/audit-dodo-catalog.cjs` which
+ * runs on a schedule and detects "Dodo has products our catalog doesn't"
+ * BEFORE a webhook arrives, so most cases are caught proactively.
  */
 async function resolvePlanKey(
   ctx: MutationCtx,
@@ -288,10 +310,19 @@ async function resolvePlanKey(
     return aliasedPlan;
   }
 
-  throw new Error(
-    `[subscriptionHelpers] No productPlans mapping for dodoProductId="${dodoProductId}". ` +
-      `Add this product to the catalog and run seedProductPlans.`,
+  // sentry-coverage-ok: structured console.error is forwarded by Convex
+  // auto-Sentry so on-call sees the unmapped product immediately. We do
+  // NOT throw — that would 500 the webhook and trigger Dodo's retry storm,
+  // which leaves the customer's entitlement wedged.
+  console.error(
+    `[subscriptionHelpers] Unknown Dodo product ID "${dodoProductId}" — ` +
+      `not in productPlans table and not in LEGACY_PRODUCT_ALIASES. ` +
+      `Falling back to "${FALLBACK_PLAN_KEY}" so the customer keeps a paid ` +
+      `entitlement. ACTION REQUIRED: add this product to ` +
+      `convex/config/productCatalog.ts (LEGACY_PRODUCT_ALIASES or PRODUCT_CATALOG) ` +
+      `and re-run seedProductPlans. See scripts/audit-dodo-catalog.cjs.`,
   );
+  return FALLBACK_PLAN_KEY;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "typecheck:api": "tsc --noEmit -p tsconfig.api.json && node scripts/audit-convex-string-calls.cjs",
     "typecheck:all": "tsc --noEmit && tsc --noEmit -p tsconfig.api.json && node scripts/audit-convex-string-calls.cjs",
     "audit:convex-string-calls": "node scripts/audit-convex-string-calls.cjs",
+    "audit:dodo-catalog": "node scripts/audit-dodo-catalog.cjs",
     "tauri": "tauri",
     "preview": "vite preview",
     "test:e2e:full": "cross-env VITE_VARIANT=full playwright test",

--- a/scripts/audit-dodo-catalog.cjs
+++ b/scripts/audit-dodo-catalog.cjs
@@ -1,0 +1,230 @@
+#!/usr/bin/env node
+/**
+ * audit-dodo-catalog — detect drift between Dodo Payments products and
+ * our local catalog (`convex/config/productCatalog.ts`).
+ *
+ * Why this exists
+ *
+ *   When operators edit a product in the Dodo dashboard (rename, reprice,
+ *   change billing term), Dodo mints a NEW product_id. Our catalog and
+ *   `LEGACY_PRODUCT_ALIASES` are static — they don't auto-sync. The first
+ *   subscription.* webhook for a customer on the new product hits
+ *   `resolvePlanKey` with an unmapped ID. Before this script, the result
+ *   was a 500 webhook → Dodo retries forever → customer's entitlement
+ *   wedged. After: `resolvePlanKey` falls open with a fallback + Sentry
+ *   alert (subscriptionHelpers.ts), AND this script catches the drift
+ *   PROACTIVELY before any webhook arrives.
+ *
+ * What it does
+ *
+ *   1. Reads convex/config/productCatalog.ts to extract every dodoProductId
+ *      from PRODUCT_CATALOG entries AND from LEGACY_PRODUCT_ALIASES.
+ *   2. Calls Dodo Payments API `client.products.list()` to enumerate every
+ *      product in the active business account.
+ *   3. Diffs the two sets:
+ *        NEW:    product_id in Dodo, NOT in catalog → would crash a webhook
+ *        STALE:  dodoProductId in catalog, NOT in Dodo → safe but cluttered
+ *   4. Prints a structured report. Exits 1 if any NEW products are found
+ *      (the dangerous direction); exits 0 with a warning if only STALE.
+ *
+ * How to run
+ *
+ *   DODO_API_KEY=sk_live_... node scripts/audit-dodo-catalog.cjs
+ *   DODO_API_KEY=sk_live_... node scripts/audit-dodo-catalog.cjs --json
+ *
+ *   For each NEW product, the report includes the product name +
+ *   recurring flag, with a heuristic suggestion of which planKey to use
+ *   (matching against catalog displayName / planKey). Operator copies the
+ *   suggested entry into LEGACY_PRODUCT_ALIASES (or PRODUCT_CATALOG) and
+ *   re-runs seedProductPlans.
+ *
+ *   Wired as `npm run audit:dodo-catalog`. NOT included in PR-gate
+ *   typecheck because it requires DODO_API_KEY and a live network call —
+ *   intended for nightly CI / on-demand operator use, not per-PR.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const CATALOG_PATH = path.join(REPO_ROOT, 'convex/config/productCatalog.ts');
+
+const args = new Set(process.argv.slice(2));
+const JSON_OUTPUT = args.has('--json');
+
+function fail(msg, code = 1) {
+  console.error(msg);
+  process.exit(code);
+}
+
+// ---------------------------------------------------------------------------
+// Local catalog: extract every known dodoProductId from productCatalog.ts.
+// ---------------------------------------------------------------------------
+function loadCatalogProductIds() {
+  if (!fs.existsSync(CATALOG_PATH)) {
+    fail(`[audit-dodo-catalog] Catalog file not found: ${CATALOG_PATH}`);
+  }
+  const src = fs.readFileSync(CATALOG_PATH, 'utf8');
+
+  /** dodoProductId → planKey, with origin (catalog vs legacy_alias) for the report. */
+  const byId = new Map();
+
+  // PRODUCT_CATALOG entries: `dodoProductId: "pdt_..."` followed somewhere by `planKey: "..."`
+  // Each catalog entry is delimited by `},` so we walk entry-by-entry.
+  const catalogEntryRe = /\{[^{}]*?dodoProductId\s*:\s*["']([^"']+)["'][\s\S]*?planKey\s*:\s*["']([^"']+)["'][\s\S]*?\}/g;
+  let m;
+  while ((m = catalogEntryRe.exec(src)) !== null) {
+    byId.set(m[1], { planKey: m[2], origin: 'PRODUCT_CATALOG' });
+  }
+
+  // LEGACY_PRODUCT_ALIASES entries: `"pdt_...": "planKey"`
+  // Constrained to the LEGACY_PRODUCT_ALIASES block to avoid matching unrelated
+  // string maps elsewhere in the file.
+  const aliasesBlockMatch = src.match(/LEGACY_PRODUCT_ALIASES[^=]*=\s*\{([\s\S]*?)\}\s*;/);
+  if (aliasesBlockMatch) {
+    const aliasesBlock = aliasesBlockMatch[1];
+    const aliasRe = /["']([^"']+)["']\s*:\s*["']([^"']+)["']/g;
+    while ((m = aliasRe.exec(aliasesBlock)) !== null) {
+      // Only treat as a Dodo product ID if it looks like one (`pdt_` prefix).
+      if (m[1].startsWith('pdt_') && !byId.has(m[1])) {
+        byId.set(m[1], { planKey: m[2], origin: 'LEGACY_PRODUCT_ALIASES' });
+      }
+    }
+  }
+
+  return byId;
+}
+
+// ---------------------------------------------------------------------------
+// Heuristic: given a Dodo product (name + price + interval), suggest the
+// closest planKey in our catalog by display-name fuzzy match.
+// ---------------------------------------------------------------------------
+function suggestPlanKey(dodoProduct, catalogIds) {
+  const name = (dodoProduct.name || '').toLowerCase();
+  // Keep these in lockstep with PRODUCT_CATALOG planKeys in productCatalog.ts.
+  const tokens = [
+    { keys: ['enterprise'], planKey: 'enterprise' },
+    { keys: ['api', 'business'], planKey: 'api_business' },
+    { keys: ['api', 'starter', 'annual'], planKey: 'api_starter_annual' },
+    { keys: ['api', 'starter'], planKey: 'api_starter' },
+    { keys: ['pro', 'annual'], planKey: 'pro_annual' },
+    { keys: ['pro', 'monthly'], planKey: 'pro_monthly' },
+    { keys: ['pro'], planKey: 'pro_monthly' },
+  ];
+  for (const t of tokens) {
+    if (t.keys.every((k) => name.includes(k))) return t.planKey;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Dodo API call.
+// ---------------------------------------------------------------------------
+async function listDodoProducts(apiKey) {
+  // Lazy require — keeps the script importable from contexts that don't
+  // have @dodopayments installed (e.g. minimal CI containers running other
+  // checks). Failing gracefully here is preferable to a hard crash.
+  let DodoPayments;
+  try {
+    ({ DodoPayments } = require('dodopayments'));
+  } catch (err) {
+    fail(`[audit-dodo-catalog] dodopayments npm package not found. Run \`npm install\` and retry.\n  ${err.message}`);
+  }
+  const client = new DodoPayments({ bearerToken: apiKey });
+
+  // PagePromise iterates implicitly via its async iterator.
+  const products = [];
+  for await (const product of client.products.list()) {
+    products.push(product);
+  }
+  return products;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+async function main() {
+  const apiKey = process.env.DODO_API_KEY;
+  if (!apiKey) {
+    fail(
+      '[audit-dodo-catalog] DODO_API_KEY env var not set.\n' +
+        'Run: DODO_API_KEY=sk_live_... node scripts/audit-dodo-catalog.cjs',
+    );
+  }
+
+  const localById = loadCatalogProductIds();
+  const dodoProducts = await listDodoProducts(apiKey);
+  const dodoById = new Map(dodoProducts.map((p) => [p.product_id, p]));
+
+  /** Products in Dodo but NOT in our catalog — would crash a webhook on next sub event. */
+  const newProducts = [];
+  for (const [id, product] of dodoById) {
+    if (!localById.has(id)) newProducts.push(product);
+  }
+
+  /** Product IDs in our catalog but NOT in Dodo — clutter, mostly harmless. */
+  const stale = [];
+  for (const [id, info] of localById) {
+    if (!dodoById.has(id)) stale.push({ id, ...info });
+  }
+
+  if (JSON_OUTPUT) {
+    console.log(JSON.stringify({
+      newProducts: newProducts.map((p) => ({
+        product_id: p.product_id,
+        name: p.name,
+        is_recurring: p.is_recurring,
+        price: p.price,
+        currency: p.currency,
+        suggestedPlanKey: suggestPlanKey(p),
+      })),
+      stale,
+      summary: {
+        dodoTotal: dodoProducts.length,
+        localTotal: localById.size,
+        newCount: newProducts.length,
+        staleCount: stale.length,
+      },
+    }, null, 2));
+  } else {
+    console.log(`[audit-dodo-catalog] Dodo: ${dodoProducts.length} products | local catalog: ${localById.size} mappings`);
+    if (newProducts.length === 0 && stale.length === 0) {
+      console.log('[audit-dodo-catalog] PASS — no drift.');
+    }
+    if (newProducts.length > 0) {
+      console.error(`\n[audit-dodo-catalog] NEW (in Dodo, NOT in catalog) — ${newProducts.length}:`);
+      for (const p of newProducts) {
+        const suggestion = suggestPlanKey(p);
+        console.error(`  ${p.product_id}  ${p.name ?? '(no name)'}${p.is_recurring ? '  [recurring]' : ''}`);
+        if (suggestion) {
+          console.error(`    suggested LEGACY_PRODUCT_ALIASES entry:  "${p.product_id}": "${suggestion}",`);
+        } else {
+          console.error(`    no automatic match — review manually and add to PRODUCT_CATALOG`);
+        }
+      }
+      console.error(
+        '\n  Each NEW product would crash the next subscription.* webhook for any customer ' +
+        'on it (resolvePlanKey would fall through to the FALLBACK_PLAN_KEY in subscriptionHelpers.ts ' +
+        'and capture an alert). Add the suggested entry to convex/config/productCatalog.ts ' +
+        'LEGACY_PRODUCT_ALIASES (or a new PRODUCT_CATALOG entry), then re-run seedProductPlans.',
+      );
+    }
+    if (stale.length > 0) {
+      console.warn(`\n[audit-dodo-catalog] STALE (in catalog, NOT in Dodo) — ${stale.length}:`);
+      for (const s of stale) {
+        console.warn(`  ${s.id}  → ${s.planKey}  [${s.origin}]`);
+      }
+      console.warn(
+        '\n  STALE entries are safe (they just never resolve), but pruning keeps the catalog ' +
+        'honest. Likely candidates: products you deleted in Dodo dashboard.',
+      );
+    }
+  }
+
+  process.exit(newProducts.length > 0 ? 1 : 0);
+}
+
+main().catch((err) => {
+  console.error('[audit-dodo-catalog] FAILED:', err);
+  process.exit(2);
+});

--- a/scripts/audit-dodo-catalog.cjs
+++ b/scripts/audit-dodo-catalog.cjs
@@ -60,6 +60,42 @@ function fail(msg, code = 1) {
 // ---------------------------------------------------------------------------
 // Local catalog: extract every known dodoProductId from productCatalog.ts.
 // ---------------------------------------------------------------------------
+
+/**
+ * Walk a TypeScript object literal at the given start offset and extract
+ * each direct-child `{ ... }` entry block as a substring. Tracks brace
+ * depth char-by-char so an entry that contains a nested object literal
+ * (e.g., a metadata blob) is captured intact.
+ *
+ * Order-independent: each returned block is the full text of one catalog
+ * entry. Caller can run independent per-block regexes for the two fields,
+ * which means `dodoProductId` and `planKey` can appear in either order
+ * without affecting the audit (P1 review on PR #3642).
+ */
+function extractEntryBlocks(src, recordStart) {
+  // Find the `{` that opens the Record<...> object literal.
+  const openIdx = src.indexOf('{', recordStart);
+  if (openIdx === -1) return [];
+  const blocks = [];
+  let depth = 1; // one '{' already consumed
+  let entryStart = -1;
+  for (let i = openIdx + 1; i < src.length; i++) {
+    const c = src[i];
+    if (c === '{') {
+      if (depth === 1) entryStart = i;
+      depth++;
+    } else if (c === '}') {
+      depth--;
+      if (depth === 0) break; // exited the Record itself
+      if (depth === 1 && entryStart !== -1) {
+        blocks.push(src.slice(entryStart, i + 1));
+        entryStart = -1;
+      }
+    }
+  }
+  return blocks;
+}
+
 function loadCatalogProductIds() {
   if (!fs.existsSync(CATALOG_PATH)) {
     fail(`[audit-dodo-catalog] Catalog file not found: ${CATALOG_PATH}`);
@@ -69,12 +105,21 @@ function loadCatalogProductIds() {
   /** dodoProductId → planKey, with origin (catalog vs legacy_alias) for the report. */
   const byId = new Map();
 
-  // PRODUCT_CATALOG entries: `dodoProductId: "pdt_..."` followed somewhere by `planKey: "..."`
-  // Each catalog entry is delimited by `},` so we walk entry-by-entry.
-  const catalogEntryRe = /\{[^{}]*?dodoProductId\s*:\s*["']([^"']+)["'][\s\S]*?planKey\s*:\s*["']([^"']+)["'][\s\S]*?\}/g;
-  let m;
-  while ((m = catalogEntryRe.exec(src)) !== null) {
-    byId.set(m[1], { planKey: m[2], origin: 'PRODUCT_CATALOG' });
+  // PRODUCT_CATALOG: walk the Record literal, extract each entry block,
+  // then independently grep for `dodoProductId` and `planKey` inside it.
+  // The two-pass approach is order-independent — TypeScript object literals
+  // don't constrain key order, so an operator adding `planKey` before
+  // `dodoProductId` in a new entry would have silently been missed by the
+  // previous one-pass regex.
+  const catalogStart = src.search(/PRODUCT_CATALOG\b[^=]*=\s*\{/);
+  if (catalogStart !== -1) {
+    for (const block of extractEntryBlocks(src, catalogStart)) {
+      const idMatch = block.match(/\bdodoProductId\s*:\s*["']([^"']+)["']/);
+      const keyMatch = block.match(/\bplanKey\s*:\s*["']([^"']+)["']/);
+      if (idMatch && keyMatch) {
+        byId.set(idMatch[1], { planKey: keyMatch[1], origin: 'PRODUCT_CATALOG' });
+      }
+    }
   }
 
   // LEGACY_PRODUCT_ALIASES entries: `"pdt_...": "planKey"`
@@ -84,6 +129,7 @@ function loadCatalogProductIds() {
   if (aliasesBlockMatch) {
     const aliasesBlock = aliasesBlockMatch[1];
     const aliasRe = /["']([^"']+)["']\s*:\s*["']([^"']+)["']/g;
+    let m;
     while ((m = aliasRe.exec(aliasesBlock)) !== null) {
       // Only treat as a Dodo product ID if it looks like one (`pdt_` prefix).
       if (m[1].startsWith('pdt_') && !byId.has(m[1])) {
@@ -102,13 +148,19 @@ function loadCatalogProductIds() {
 function suggestPlanKey(dodoProduct, catalogIds) {
   const name = (dodoProduct.name || '').toLowerCase();
   // Keep these in lockstep with PRODUCT_CATALOG planKeys in productCatalog.ts.
+  // Order matters — first-match-wins. List most-specific multi-token
+  // entries before less-specific ones. (P2 review on PR #3642: "Pro
+  // Monthly Annual" would match `['pro', 'annual']` before
+  // `['pro', 'monthly']` if the latter weren't listed first. Theoretical
+  // — Dodo wouldn't actually name a product like that — but the ordering
+  // should still reflect longest-specific-match semantics.)
   const tokens = [
     { keys: ['enterprise'], planKey: 'enterprise' },
     { keys: ['api', 'business'], planKey: 'api_business' },
     { keys: ['api', 'starter', 'annual'], planKey: 'api_starter_annual' },
     { keys: ['api', 'starter'], planKey: 'api_starter' },
+    { keys: ['pro', 'monthly'], planKey: 'pro_monthly' }, // ← before 'pro+annual' (P2 fix)
     { keys: ['pro', 'annual'], planKey: 'pro_annual' },
-    { keys: ['pro', 'monthly'], planKey: 'pro_monthly' },
     { keys: ['pro'], planKey: 'pro_monthly' },
   ];
   for (const t of tokens) {
@@ -120,6 +172,9 @@ function suggestPlanKey(dodoProduct, catalogIds) {
 // ---------------------------------------------------------------------------
 // Dodo API call.
 // ---------------------------------------------------------------------------
+
+const DODO_API_TIMEOUT_MS = 30_000;
+
 async function listDodoProducts(apiKey) {
   // Lazy require — keeps the script importable from contexts that don't
   // have @dodopayments installed (e.g. minimal CI containers running other
@@ -132,12 +187,30 @@ async function listDodoProducts(apiKey) {
   }
   const client = new DodoPayments({ bearerToken: apiKey });
 
-  // PagePromise iterates implicitly via its async iterator.
-  const products = [];
-  for await (const product of client.products.list()) {
-    products.push(product);
-  }
-  return products;
+  // 30s wall-clock cap on the entire enumeration. The SDK's `for await`
+  // iterator paginates internally — without a timeout, a network partition
+  // / slow-loris proxy / Dodo API outage would hang the script forever
+  // (P2 review on PR #3642). Race against a timer; on timeout, throw with
+  // a clear message so the operator knows it wasn't a parser issue.
+  const enumerate = async () => {
+    const products = [];
+    for await (const product of client.products.list()) {
+      products.push(product);
+    }
+    return products;
+  };
+  return Promise.race([
+    enumerate(),
+    new Promise((_, reject) =>
+      setTimeout(
+        () => reject(new Error(
+          `Dodo API enumeration exceeded ${DODO_API_TIMEOUT_MS}ms — ` +
+          `check Dodo status (status.dodopayments.com) or network connectivity.`,
+        )),
+        DODO_API_TIMEOUT_MS,
+      ),
+    ),
+  ]);
 }
 
 // ---------------------------------------------------------------------------

--- a/scripts/audit-dodo-catalog.cjs
+++ b/scripts/audit-dodo-catalog.cjs
@@ -144,8 +144,12 @@ function loadCatalogProductIds() {
 // ---------------------------------------------------------------------------
 // Heuristic: given a Dodo product (name + price + interval), suggest the
 // closest planKey in our catalog by display-name fuzzy match.
+//
+// The hardcoded `tokens` list mirrors the planKey set in
+// convex/config/productCatalog.ts. If new planKeys are added, extend this
+// list to keep the suggestion accurate.
 // ---------------------------------------------------------------------------
-function suggestPlanKey(dodoProduct, catalogIds) {
+function suggestPlanKey(dodoProduct) {
   const name = (dodoProduct.name || '').toLowerCase();
   // Keep these in lockstep with PRODUCT_CATALOG planKeys in productCatalog.ts.
   // Order matters — first-match-wins. List most-specific multi-token


### PR DESCRIPTION
## Summary

Three-part fix prompted by a real customer ($69/mo × 10yr = $8,280 commit) being stuck in a Dodo webhook 500-retry loop since 2026-05-09 07:54 UTC. Root cause: operator edited the API Starter plan in the Dodo dashboard (added Education-discount pricing), which minted a NEW Dodo `product_id` not in our `productCatalog.ts`. `resolvePlanKey` threw → webhook 500 → Dodo retried forever → no entitlement update.

### Part 1 — Immediate unblock

Add `pdt_0NeRCJCIwZrExuE1kifHp` to `LEGACY_PRODUCT_ALIASES` → `api_starter` (Education-discount tier; same feature set as `api_starter`, only price/term differ).

After Convex auto-deploys this branch, Dodo's next retry succeeds and the customer's entitlement updates.

### Part 2 — `resolvePlanKey` fails open

Previously: throw on unmapped product → 500 → Dodo retry storm → entitlement wedged.

Now:
- `console.error` with structured context (forwarded by Convex auto-Sentry to our project)
- Return `FALLBACK_PLAN_KEY = "pro_monthly"` so the customer gets a paid entitlement immediately
- Webhook returns 200 → Dodo stops retrying

Operator gets paged via the structured error with the exact action required (add to `LEGACY_PRODUCT_ALIASES` or `PRODUCT_CATALOG`, re-run `seedProductPlans`).

### Part 3 — Proactive drift detection

`scripts/audit-dodo-catalog.cjs` calls Dodo Payments API `client.products.list()` and diffs against the IDs in `productCatalog.ts` (`PRODUCT_CATALOG` entries + `LEGACY_PRODUCT_ALIASES`).

Reports:
- **NEW** — in Dodo but not in catalog → would crash a webhook on next sub event
- **STALE** — in catalog but not in Dodo → harmless clutter

Exits non-zero on NEW. Suggests a `planKey` via fuzzy name match against catalog `displayName` (e.g., `"API Starter for Education"` → `api_starter`).

Wired as `npm run audit:dodo-catalog`. **Not in the PR gate** (requires `DODO_API_KEY` + live network call) — intended for nightly CI / on-demand operator use. Recommended follow-up: a daily GitHub Action that runs the audit and opens an issue if drift is found.

## How the three parts work together

1. Operator edits a plan in Dodo dashboard → new product_id minted
2. **Best case (proactive)**: nightly `audit:dodo-catalog` run catches the new product, alerts before any webhook arrives
3. **Worst case (reactive)**: webhook arrives, `resolvePlanKey` falls open with `pro_monthly` fallback, captures Sentry alert with full context, customer keeps a paid entitlement instead of being wedged
4. Either way: operator updates `LEGACY_PRODUCT_ALIASES` or `PRODUCT_CATALOG`, re-runs `seedProductPlans`, mapping is live for subsequent webhooks

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` (includes `audit-convex-string-calls`) — clean
- [x] `npm run lint` — exit 0
- [x] `npm run test:data` — 8276/8276 pass
- [x] `node --test tests/edge-functions.test.mjs` — 181/181 pass
- [x] Edge bundle check — clean
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — OK
- [x] **`audit-dodo-catalog` parser smoke test**: extracted all 12 mappings (6 PRODUCT_CATALOG + 6 LEGACY_PRODUCT_ALIASES including the new Education entry); no false positives or missed rows