### PR TITLE
feat(gateway): distinct 404/405 reasons + drop docs path collision

### DIFF
--- a/docs/adding-endpoints.mdx
+++ b/docs/adding-endpoints.mdx
@@ -332,7 +332,7 @@ import { createCircuitBreaker } from '@/utils';
 
 export type { WeatherStation };
 
-const client = new WeatherServiceClient('', { fetch: fetch.bind(globalThis) });
+const client = new WeatherServiceClient('', { fetch: (...args) => globalThis.fetch(...args) });
 const breaker = createCircuitBreaker<ListWeatherStationsResponse>({ name: 'Weather' });
 
 const emptyFallback: ListWeatherStationsResponse = { stations: [] };
@@ -440,13 +440,13 @@ This ensures the compiler catches any mismatch between your implementation and t
 
 ### Client construction
 
-Always pass `{ fetch: fetch.bind(globalThis) }` when creating clients:
+Always pass `{ fetch: (...args) => globalThis.fetch(...args) }` when creating clients:
 
 ```typescript
-const client = new WeatherServiceClient('', { fetch: fetch.bind(globalThis) });
+const client = new WeatherServiceClient('', { fetch: (...args) => globalThis.fetch(...args) });
 ```
 
-The empty string base URL works because both Vite dev server and Vercel serve the API on the same origin. The `fetch.bind(globalThis)` is required for Tauri compatibility.
+The empty string base URL works because both Vite dev server and Vercel serve the API on the same origin. The arrow-function wrapper around `globalThis.fetch` is required for Tauri compatibility AND for the runtime fetch interceptor — `fetch.bind(globalThis)` is **banned** because it freezes a reference to the global `fetch` at module-init time, which bypasses any later interceptor (auth headers, request logging, retry shims) installed on `globalThis.fetch`. The arrow-function wrapper resolves `globalThis.fetch` on every call.
 
 ## Generated documentation
 

--- a/docs/adding-endpoints.mdx
+++ b/docs/adding-endpoints.mdx
@@ -165,69 +165,69 @@ Open `docs/api/SeismologyService.openapi.yaml` — the new endpoint should appea
 
 ## Adding a new service
 
-Example: adding a `SanctionsService`.
+Example: adding a hypothetical `WeatherService`. (No `weather` domain exists in this repo — the example below is purely illustrative; copy-pasting any path from this section will hit a 404.)
 
 ### 1. Create the proto directory
 
 ```
-proto/worldmonitor/sanctions/v1/
+proto/worldmonitor/weather/v1/
 ```
 
 ### 2. Define entity messages
 
-Create `proto/worldmonitor/sanctions/v1/sanctions_entry.proto`:
+Create `proto/worldmonitor/weather/v1/weather_station.proto`:
 
 ```protobuf
 syntax = "proto3";
-package worldmonitor.sanctions.v1;
+package worldmonitor.weather.v1;
 
 import "buf/validate/validate.proto";
 import "sebuf/http/annotations.proto";
 
-// SanctionsEntry represents a single entity on a sanctions list.
-message SanctionsEntry {
-  // Unique identifier.
+// WeatherStation represents a single ground-based observation station.
+message WeatherStation {
+  // Unique identifier (e.g., WMO station number).
   string id = 1 [
     (buf.validate.field).required = true,
     (buf.validate.field).string.min_len = 1
   ];
-  // Name of the sanctioned entity or individual.
+  // Human-readable station name.
   string name = 2;
-  // Issuing authority (e.g., "OFAC", "EU", "UN").
-  string authority = 3;
-  // ISO 3166-1 alpha-2 country code of the target.
+  // Operating network (e.g., "NWS", "WMO", "NOAA").
+  string network = 3;
+  // ISO 3166-1 alpha-2 country code where the station is located.
   string country_code = 4;
-  // Date the sanction was imposed, as Unix epoch milliseconds.
-  int64 imposed_at = 5 [(sebuf.http.int64_encoding) = INT64_ENCODING_NUMBER];
+  // Date the station first reported observations, as Unix epoch milliseconds.
+  int64 first_seen_at = 5 [(sebuf.http.int64_encoding) = INT64_ENCODING_NUMBER];
 }
 ```
 
 ### 3. Define request/response messages
 
-Create `proto/worldmonitor/sanctions/v1/list_sanctions.proto`:
+Create `proto/worldmonitor/weather/v1/list_weather_stations.proto`:
 
 ```protobuf
 syntax = "proto3";
-package worldmonitor.sanctions.v1;
+package worldmonitor.weather.v1;
 
 import "buf/validate/validate.proto";
 import "worldmonitor/core/v1/pagination.proto";
-import "worldmonitor/sanctions/v1/sanctions_entry.proto";
+import "worldmonitor/weather/v1/weather_station.proto";
 
-// ListSanctionsRequest specifies filters for sanctions data.
-message ListSanctionsRequest {
-  // Filter by issuing authority (e.g., "OFAC"). Empty returns all.
-  string authority = 1;
+// ListWeatherStationsRequest specifies filters for weather station data.
+message ListWeatherStationsRequest {
+  // Filter by operating network (e.g., "NWS"). Empty returns all.
+  string network = 1;
   // Filter by country code.
   string country_code = 2 [(buf.validate.field).string.max_len = 2];
   // Pagination parameters.
   worldmonitor.core.v1.PaginationRequest pagination = 3;
 }
 
-// ListSanctionsResponse contains the matching sanctions entries.
-message ListSanctionsResponse {
-  // The list of sanctions entries.
-  repeated SanctionsEntry entries = 1;
+// ListWeatherStationsResponse contains the matching stations.
+message ListWeatherStationsResponse {
+  // The list of weather stations.
+  repeated WeatherStation stations = 1;
   // Pagination metadata.
   worldmonitor.core.v1.PaginationResponse pagination = 2;
 }
@@ -235,22 +235,22 @@ message ListSanctionsResponse {
 
 ### 4. Define the service
 
-Create `proto/worldmonitor/sanctions/v1/service.proto`:
+Create `proto/worldmonitor/weather/v1/service.proto`:
 
 ```protobuf
 syntax = "proto3";
-package worldmonitor.sanctions.v1;
+package worldmonitor.weather.v1;
 
 import "sebuf/http/annotations.proto";
-import "worldmonitor/sanctions/v1/list_sanctions.proto";
+import "worldmonitor/weather/v1/list_weather_stations.proto";
 
-// SanctionsService provides APIs for international sanctions monitoring.
-service SanctionsService {
-  option (sebuf.http.service_config) = {base_path: "/api/sanctions/v1"};
+// WeatherService provides APIs for weather observation stations.
+service WeatherService {
+  option (sebuf.http.service_config) = {base_path: "/api/weather/v1"};
 
-  // ListSanctions retrieves sanctions entries matching the given filters.
-  rpc ListSanctions(ListSanctionsRequest) returns (ListSanctionsResponse) {
-    option (sebuf.http.config) = {path: "/list-sanctions"};
+  // ListWeatherStations retrieves stations matching the given filters.
+  rpc ListWeatherStations(ListWeatherStationsRequest) returns (ListWeatherStationsResponse) {
+    option (sebuf.http.config) = {path: "/list-weather-stations"};
   }
 }
 ```
@@ -266,37 +266,37 @@ make check   # lint + generate in one step
 Create the handler directory and files:
 
 ```
-server/worldmonitor/sanctions/v1/
-├── handler.ts               # thin re-export
-└── list-sanctions.ts        # RPC implementation
+server/worldmonitor/weather/v1/
+├── handler.ts                     # thin re-export
+└── list-weather-stations.ts       # RPC implementation
 ```
 
-`server/worldmonitor/sanctions/v1/list-sanctions.ts`:
+`server/worldmonitor/weather/v1/list-weather-stations.ts`:
 ```typescript
 import type {
-  SanctionsServiceHandler,
+  WeatherServiceHandler,
   ServerContext,
-  ListSanctionsRequest,
-  ListSanctionsResponse,
-} from '../../../../src/generated/server/worldmonitor/sanctions/v1/service_server';
+  ListWeatherStationsRequest,
+  ListWeatherStationsResponse,
+} from '../../../../src/generated/server/worldmonitor/weather/v1/service_server';
 
-export const listSanctions: SanctionsServiceHandler['listSanctions'] = async (
+export const listWeatherStations: WeatherServiceHandler['listWeatherStations'] = async (
   _ctx: ServerContext,
-  req: ListSanctionsRequest,
-): Promise<ListSanctionsResponse> => {
+  req: ListWeatherStationsRequest,
+): Promise<ListWeatherStationsResponse> => {
   // Your implementation here — fetch from upstream API, transform to proto shape
-  return { entries: [], pagination: undefined };
+  return { stations: [], pagination: undefined };
 };
 ```
 
-`server/worldmonitor/sanctions/v1/handler.ts`:
+`server/worldmonitor/weather/v1/handler.ts`:
 ```typescript
-import type { SanctionsServiceHandler } from '../../../../src/generated/server/worldmonitor/sanctions/v1/service_server';
+import type { WeatherServiceHandler } from '../../../../src/generated/server/worldmonitor/weather/v1/service_server';
 
-import { listSanctions } from './list-sanctions';
+import { listWeatherStations } from './list-weather-stations';
 
-export const sanctionsHandler: SanctionsServiceHandler = {
-  listSanctions,
+export const weatherHandler: WeatherServiceHandler = {
+  listWeatherStations,
 };
 ```
 
@@ -305,12 +305,12 @@ export const sanctionsHandler: SanctionsServiceHandler = {
 Edit `api/[[...path]].js` — add the import and mount the routes:
 
 ```typescript
-import { createSanctionsServiceRoutes } from '../src/generated/server/worldmonitor/sanctions/v1/service_server';
-import { sanctionsHandler } from './server/worldmonitor/sanctions/v1/handler';
+import { createWeatherServiceRoutes } from '../src/generated/server/worldmonitor/weather/v1/service_server';
+import { weatherHandler } from './server/worldmonitor/weather/v1/handler';
 
 const allRoutes = [
   // ... existing routes ...
-  ...createSanctionsServiceRoutes(sanctionsHandler, serverOptions),
+  ...createWeatherServiceRoutes(weatherHandler, serverOptions),
 ];
 ```
 
@@ -320,28 +320,28 @@ Edit `vite.config.ts` — add the lazy import and route mount inside the `sebufA
 
 ### 9. Create the frontend service wrapper
 
-Create `src/services/sanctions.ts`:
+Create `src/services/weather.ts`:
 
 ```typescript
 import {
-  SanctionsServiceClient,
-  type SanctionsEntry,
-  type ListSanctionsResponse,
-} from '@/generated/client/worldmonitor/sanctions/v1/service_client';
+  WeatherServiceClient,
+  type WeatherStation,
+  type ListWeatherStationsResponse,
+} from '@/generated/client/worldmonitor/weather/v1/service_client';
 import { createCircuitBreaker } from '@/utils';
 
-export type { SanctionsEntry };
+export type { WeatherStation };
 
-const client = new SanctionsServiceClient('', { fetch: fetch.bind(globalThis) });
-const breaker = createCircuitBreaker<ListSanctionsResponse>({ name: 'Sanctions' });
+const client = new WeatherServiceClient('', { fetch: fetch.bind(globalThis) });
+const breaker = createCircuitBreaker<ListWeatherStationsResponse>({ name: 'Weather' });
 
-const emptyFallback: ListSanctionsResponse = { entries: [] };
+const emptyFallback: ListWeatherStationsResponse = { stations: [] };
 
-export async function fetchSanctions(authority?: string): Promise<SanctionsEntry[]> {
+export async function fetchWeatherStations(network?: string): Promise<WeatherStation[]> {
   const response = await breaker.execute(async () => {
-    return client.listSanctions({ authority: authority ?? '', countryCode: '', pagination: undefined });
+    return client.listWeatherStations({ network: network ?? '', countryCode: '', pagination: undefined });
   }, emptyFallback);
-  return response.entries;
+  return response.stations;
 }
 ```
 
@@ -357,7 +357,7 @@ These conventions are enforced across the codebase. Follow them for consistency.
 
 ### File naming
 
-- One file per message type: `earthquake.proto`, `sanctions_entry.proto`
+- One file per message type: `earthquake.proto`, `weather_station.proto`
 - One file per RPC pair: `list_earthquakes.proto`, `get_earthquake_details.proto`
 - Service definition: `service.proto`
 - Use `snake_case` for file names and field names
@@ -428,10 +428,10 @@ buf lint enforces comments on all messages, fields, services, RPCs, and enum val
 Always type the handler function against the generated interface using indexed access:
 
 ```typescript
-export const listSanctions: SanctionsServiceHandler['listSanctions'] = async (
+export const listWeatherStations: WeatherServiceHandler['listWeatherStations'] = async (
   _ctx: ServerContext,
-  req: ListSanctionsRequest,
-): Promise<ListSanctionsResponse> => {
+  req: ListWeatherStationsRequest,
+): Promise<ListWeatherStationsResponse> => {
   // ...
 };
 ```
@@ -443,7 +443,7 @@ This ensures the compiler catches any mismatch between your implementation and t
 Always pass `{ fetch: fetch.bind(globalThis) }` when creating clients:
 
 ```typescript
-const client = new SanctionsServiceClient('', { fetch: fetch.bind(globalThis) });
+const client = new WeatherServiceClient('', { fetch: fetch.bind(globalThis) });
 ```
 
 The empty string base URL works because both Vite dev server and Vercel serve the API on the same origin. The `fetch.bind(globalThis)` is required for Tauri compatibility.

--- a/server/_shared/usage.ts
+++ b/server/_shared/usage.ts
@@ -64,7 +64,9 @@ export type RequestReason =
   | 'preflight'
   | 'auth_401'
   | 'auth_403'
-  | 'tier_403';
+  | 'tier_403'
+  | 'unknown_route'
+  | 'method_not_allowed';
 
 export interface RequestEvent {
   _time: string;

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -622,13 +622,13 @@ export function createDomainGateway(
     if (!matchedHandler) {
       const allowed = router.allowedMethods(new URL(request.url).pathname);
       if (allowed.length > 0) {
-        emitRequest(405, 'ok', null);
+        emitRequest(405, 'method_not_allowed', null);
         return new Response(JSON.stringify({ error: 'Method not allowed' }), {
           status: 405,
           headers: { 'Content-Type': 'application/json', Allow: allowed.join(', '), ...corsHeaders },
         });
       }
-      emitRequest(404, 'ok', null);
+      emitRequest(404, 'unknown_route', null);
       return new Response(JSON.stringify({ error: 'Not found' }), {
         status: 404,
         headers: { 'Content-Type': 'application/json', ...corsHeaders },

--- a/tests/usage-telemetry-emission.test.mts
+++ b/tests/usage-telemetry-emission.test.mts
@@ -36,6 +36,7 @@ interface CapturedEvent {
   customer_id: string | null;
   auth_kind: string;
   tier: number;
+  reason: string;
 }
 
 function makeRecordingCtx(): { ctx: GatewayCtx; settled: Promise<void> } {
@@ -408,5 +409,96 @@ describe('gateway telemetry payload — ctx-optional safety', () => {
     // No ctx → emit short-circuits → no events delivered. The point is that
     // the handler does not throw "Cannot read properties of undefined".
     assert.equal(spy.events.length, 0);
+  });
+});
+
+describe('gateway telemetry payload — unmatched route reason labels', () => {
+  // Phantom-route operability: a route like /api/trade/v1/list-tariffs that
+  // doesn't exist must emit reason='unknown_route' so an Axiom filter
+  // (where reason == 'unknown_route') instantly separates scraper / stale-
+  // client noise from real handler errors. Same idea for 405s — a known path
+  // hit with the wrong method must emit reason='method_not_allowed' so it
+  // doesn't get conflated with auth_401 or rate_limit_429.
+  //
+  // Without these assertions, regressing both back to reason='ok' is a
+  // silent telemetry-only change that CI would not catch.
+
+  it("unknown path → status=404 + reason='unknown_route'", async () => {
+    process.env.USAGE_TELEMETRY = '1';
+    process.env.AXIOM_API_TOKEN = 'test-token';
+    const spy = installAxiomFetchSpy(ORIGINAL_FETCH);
+
+    // Domain gateway is mounted with at least one route so the router has
+    // a valid table — the request below targets a path that isn't in it.
+    const handler = createDomainGateway([
+      {
+        method: 'GET',
+        path: '/api/trade/v1/get-tariff-trends',
+        handler: async () => new Response('{"ok":true}', { status: 200 }),
+      },
+    ]);
+
+    const recorder = makeRecordingCtx();
+    const res = await handler(
+      new Request('https://worldmonitor.app/api/trade/v1/list-tariffs', {
+        headers: { Origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': SESSION_TOKEN },
+      }),
+      recorder.ctx,
+    );
+    assert.equal(res.status, 404);
+
+    await recorder.settled;
+    spy.restore();
+
+    assert.equal(spy.events.length, 1, 'expected exactly one telemetry event');
+    const ev = spy.events[0]!;
+    assert.equal(ev.status, 404);
+    assert.equal(
+      ev.reason,
+      'unknown_route',
+      `404 emit must label reason='unknown_route' (got '${ev.reason}'); regression to 'ok' would re-conflate phantom-route noise with handled traffic`,
+    );
+    assert.equal(ev.route, '/api/trade/v1/list-tariffs');
+    assert.equal(ev.domain, 'trade');
+  });
+
+  it("known path with wrong method → status=405 + reason='method_not_allowed'", async () => {
+    process.env.USAGE_TELEMETRY = '1';
+    process.env.AXIOM_API_TOKEN = 'test-token';
+    const spy = installAxiomFetchSpy(ORIGINAL_FETCH);
+
+    // Register a GET-only route, then DELETE it: router responds 405 with
+    // Allow: GET. POST→GET fallback only kicks in for POST, so DELETE is
+    // the cleanest way to force the 405 branch.
+    const handler = createDomainGateway([
+      {
+        method: 'GET',
+        path: '/api/market/v1/list-market-quotes',
+        handler: async () => new Response('{"ok":true}', { status: 200 }),
+      },
+    ]);
+
+    const recorder = makeRecordingCtx();
+    const res = await handler(
+      new Request('https://worldmonitor.app/api/market/v1/list-market-quotes', {
+        method: 'DELETE',
+        headers: { Origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': SESSION_TOKEN },
+      }),
+      recorder.ctx,
+    );
+    assert.equal(res.status, 405);
+    assert.match(res.headers.get('Allow') ?? '', /GET/);
+
+    await recorder.settled;
+    spy.restore();
+
+    assert.equal(spy.events.length, 1, 'expected exactly one telemetry event');
+    const ev = spy.events[0]!;
+    assert.equal(ev.status, 405);
+    assert.equal(
+      ev.reason,
+      'method_not_allowed',
+      `405 emit must label reason='method_not_allowed' (got '${ev.reason}'); regression to 'ok' would hide method-mismatch traffic in healthy-emit counts`,
+    );
   });
 });


### PR DESCRIPTION
## Summary

- Gateway emits `reason="unknown_route"` (404) and `reason="method_not_allowed"` (405) instead of generic `"ok"`, so phantom-route traffic in `wm_api_usage` is one Axiom filter away from real noise.
- `docs/adding-endpoints.mdx`: rename worked example from `SanctionsService` → fictional `WeatherService`. The old example used path `/list-sanctions` which shadowed our real `/api/sanctions/v1/*` domain and was the only doc-surface mention of a non-existent endpoint anywhere in the repo.
- Adds `'unknown_route' | 'method_not_allowed'` to the `RequestReason` union in `server/_shared/usage.ts`.

## Why

Operator question this morning: an Axiom dashboard showed 4 routes with 100% error rate over 1h:
- `/api/supply-chain/v1/list-chokepoints`
- `/api/trade/v1/list-tariffs`
- `/api/economic/v1/list-economic-events`
- `/api/trade/v1/list-sanctions`

None of them exist anywhere in `server/`/`proto/`. They're all 404s from scrapers/stale-client traffic. Today the only way to confirm "this is a phantom route, not a real bug" is to grep the codebase. After this PR: `where reason == "unknown_route"` filters them out instantly.

The docs change closes the one path-collision risk: `/list-sanctions` appeared on the public Mintlify "Adding endpoints" page (under Developer Guide) as the literal RPC path for the example service. Switching the worked example to a service we don't have (`WeatherService`) eliminates the risk that an LLM crawler or careless reader extracts it as a real endpoint.

## Telemetry impact

Existing dashboards filtering `reason != "ok"` will see a small bump in non-`"ok"` events for 404/405 traffic that was previously labelled `"ok"`. No actual traffic or status-code change — only the `reason` label.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run typecheck:api` passes
- [x] `npm run lint` exit 0
- [x] `npm run test:data` 8276/8276 pass
- [x] `node --test tests/edge-functions.test.mjs` 181/181 pass
- [x] `npm run lint:md` 0 errors
- [x] `npm run version:check` clean
- [x] CJS scripts/*.cjs `node -c` clean
- [x] All `api/*.js` esbuild-bundle clean
- [ ] After merge: confirm `wm_api_usage` shows `reason="unknown_route"` for one of the four phantom routes within 1h