### PR TITLE
fix(brief-dedup): cap replay-log lists to prevent Upstash 500MB record limit

### DIFF
--- a/scripts/lib/brief-dedup-replay-log.mjs
+++ b/scripts/lib/brief-dedup-replay-log.mjs
@@ -29,6 +29,27 @@ const KEY_PREFIX = 'digest:replay-log:v1';
 const TTL_SECONDS = 30 * 24 * 60 * 60; // 30 days
 
 /**
+ * Per-day list cap. Each record is ~1.0-1.7KB JSON; Upstash enforces a
+ * 500MB max-record-size on the Fixed plan. Without a cap, busy days
+ * (~420K entries observed in production on 2026-05-07) hit the limit
+ * and back-pressure adjacent Redis writes — see WM 2026-05-10 incident
+ * where seed-forecasts publish timed out coincident with Max Record Size
+ * alerts.
+ *
+ * 100,000 entries × 1.5KB ≈ 150MB → ~3× safety margin under 500MB.
+ * For the calibration use-case (replay/sweep tooling consumes the
+ * NEWEST entries to evaluate dedup quality), tail-keep semantics are
+ * correct: LTRIM `-N..-1` keeps the most recent N records.
+ *
+ * Tradeoff: very busy days lose the OLDEST entries beyond 100K. The
+ * U6 14-day replay harness aggregates ACROSS days and uses repHash
+ * stability for cluster identity, so within-day eviction of older
+ * entries is acceptable — operators get a representative sample of
+ * each day's traffic, not exhaustive coverage.
+ */
+export const REPLAY_LOG_MAX_ENTRIES_PER_DAY = 100_000;
+
+/**
  * Env-read at call time so Railway can flip the flag without a redeploy.
  * Anything other than literal '1' (including unset, '0', 'yes', 'true',
  * mis-cased 'True') is treated as OFF — fail-closed so a typo can't
@@ -316,13 +337,17 @@ export async function writeReplayLog(args) {
       return { wrote: 0, key: null, skipped: 'empty' };
     }
     const key = buildReplayLogKey(tickContext?.ruleId, tickContext?.tsMs ?? Date.now());
-    // Single RPUSH with variadic values (one per story) + EXPIRE. Keep
-    // to two commands so Upstash's pipeline stays cheap even on large
-    // ticks. Stringify each record individually so downstream readers
-    // can consume with LRANGE + JSON.parse.
+    // RPUSH + LTRIM + EXPIRE in one pipeline. LTRIM `-N..-1` keeps the
+    // last N entries (most recent), evicting the oldest beyond the cap.
+    // This bounds each per-day key under ~150MB at observed entry sizes,
+    // well under Upstash's 500MB max-record-size that production hit on
+    // 2026-05-10 (busy days reached 420K entries ≈ 630MB without a cap).
+    // Stringify each record individually so downstream readers can
+    // consume with LRANGE + JSON.parse.
     const rpushCmd = ['RPUSH', key, ...records.map((r) => JSON.stringify(r))];
+    const ltrimCmd = ['LTRIM', key, `-${REPLAY_LOG_MAX_ENTRIES_PER_DAY}`, '-1'];
     const expireCmd = ['EXPIRE', key, String(TTL_SECONDS)];
-    const result = await pipelineImpl([rpushCmd, expireCmd]);
+    const result = await pipelineImpl([rpushCmd, ltrimCmd, expireCmd]);
     if (result == null) {
       warn(`[digest] replay-log: pipeline returned null (creds missing or upstream down) key=${key}`);
       return { wrote: 0, key, skipped: null };

--- a/tests/brief-dedup-replay-log.test.mjs
+++ b/tests/brief-dedup-replay-log.test.mjs
@@ -386,7 +386,7 @@ describe('writeReplayLog — behaviour', () => {
     assert.equal(pipe.calls.length, 0);
   });
 
-  it('flag ON + stories → RPUSH + EXPIRE 30d on correct key', async () => {
+  it('flag ON + stories → RPUSH + LTRIM cap + EXPIRE 30d on correct key', async () => {
     const pipe = mockPipeline();
     const warn = mockWarn();
     const res = await writeReplayLog({
@@ -398,11 +398,22 @@ describe('writeReplayLog — behaviour', () => {
     assert.equal(res.skipped, null);
     assert.equal(pipe.calls.length, 1);
     const [commands] = pipe.calls;
-    assert.equal(commands.length, 2, 'two commands: RPUSH + EXPIRE');
-    const [rpushCmd, expireCmd] = commands;
+    // RPUSH appends → LTRIM caps the per-day list at the most recent N
+    // entries → EXPIRE refreshes the 30d TTL. The cap was added on
+    // 2026-05-10 after busy days (~420K entries) hit Upstash's 500MB
+    // max-record-size and back-pressured adjacent writes.
+    assert.equal(commands.length, 3, 'three commands: RPUSH + LTRIM + EXPIRE');
+    const [rpushCmd, ltrimCmd, expireCmd] = commands;
     assert.equal(rpushCmd[0], 'RPUSH');
     assert.equal(rpushCmd[1], 'digest:replay-log:v1:full:en:high:2026-04-23');
     assert.equal(rpushCmd.length, 4, 'RPUSH + key + 2 story records');
+    assert.equal(ltrimCmd[0], 'LTRIM');
+    assert.equal(ltrimCmd[1], 'digest:replay-log:v1:full:en:high:2026-04-23');
+    // `-N..-1` keeps the most recent N entries (tail-keep). The cap
+    // value is sourced from REPLAY_LOG_MAX_ENTRIES_PER_DAY in the
+    // module so a future bump only needs one location change.
+    assert.match(ltrimCmd[2], /^-\d+$/, 'start index is negative (tail offset)');
+    assert.equal(ltrimCmd[3], '-1', 'end index is -1 (last element)');
     assert.equal(expireCmd[0], 'EXPIRE');
     assert.equal(expireCmd[1], 'digest:replay-log:v1:full:en:high:2026-04-23');
     assert.equal(expireCmd[2], String(30 * 24 * 60 * 60));
@@ -416,6 +427,24 @@ describe('writeReplayLog — behaviour', () => {
     assert.equal(rec1.isRep, false);
     assert.equal(rec1.clusterId, 0, 'h2 is in the same cluster as h1');
     assert.equal(warn.lines.length, 0);
+  });
+
+  it('LTRIM uses the exported cap constant (REPLAY_LOG_MAX_ENTRIES_PER_DAY)', async () => {
+    // Don't hard-code 100000 here — read from the module so a future
+    // bump propagates without a brittle dual-update. This regression
+    // guard fails loudly if the writer drifts away from the constant.
+    const { REPLAY_LOG_MAX_ENTRIES_PER_DAY } = await import('../scripts/lib/brief-dedup-replay-log.mjs');
+    const pipe = mockPipeline();
+    await writeReplayLog({
+      ...baseArgs(),
+      deps: { env: { DIGEST_DEDUP_REPLAY_LOG: '1' }, redisPipeline: pipe.impl, warn: () => {} },
+    });
+    const ltrimCmd = pipe.calls[0][1];
+    assert.equal(ltrimCmd[2], `-${REPLAY_LOG_MAX_ENTRIES_PER_DAY}`);
+    // Sanity — keep the constant inside a band that's reasonable for
+    // the 500MB Upstash limit at observed entry sizes (~1.5KB).
+    assert.ok(REPLAY_LOG_MAX_ENTRIES_PER_DAY >= 10_000, 'cap must allow useful sample');
+    assert.ok(REPLAY_LOG_MAX_ENTRIES_PER_DAY <= 200_000, 'cap must stay under the 500MB record limit at observed entry sizes');
   });
 
   it('pipeline returns null → warn + skipped=null + wrote=0', async () => {


### PR DESCRIPTION
## Summary

Found the source of today's Upstash "Max Record Size 500MB hit 6× in 5 minutes" alerts. The `digest:replay-log:v1:full:en:all:<date>` lists have been growing unbounded within each day — the largest at 421,716 entries × ~1.5KB each = **~630MB per key**, well over the 500MB Fixed-plan record-size limit.

## Likely connected to today's seed-forecasts crash

The seed-forecasts cron failed at 13:00 UTC with a Redis SET timeout on a 0.17MB payload (well under any limit). When Upstash's backend struggles with a 630MB-record write, it back-pressures adjacent operations. Trimming the oversized lists should reduce that pressure.

## Evidence

Sweep of all replay-log keys:
```
421716 entries  digest:replay-log:v1:full:en:all:2026-05-07
419782 entries  digest:replay-log:v1:full:en:all:2026-05-08
419473 entries  digest:replay-log:v1:full:en:all:2026-05-06
411401 entries  digest:replay-log:v1:full:en:all:2026-05-05
397556 entries  digest:replay-log:v1:full:en:all:2026-04-30
... 10 more daily logs at 100K-360K each
```

## Root cause

`scripts/lib/brief-dedup-replay-log.mjs:323` issued only `RPUSH + EXPIRE`, no `LTRIM`. The 30d TTL bounded cross-day rotation, but within a single busy day the list grew without limit:

```js
const rpushCmd = ['RPUSH', key, ...records.map((r) => JSON.stringify(r))];
const expireCmd = ['EXPIRE', key, String(TTL_SECONDS)];
const result = await pipelineImpl([rpushCmd, expireCmd]);
//                                       ↑ no LTRIM
```

## Fix

Insert `LTRIM key -100000 -1` between RPUSH and EXPIRE — tail-keep the most recent 100,000 entries:

```js
const rpushCmd = ['RPUSH', key, ...records.map((r) => JSON.stringify(r))];
const ltrimCmd = ['LTRIM', key, `-${REPLAY_LOG_MAX_ENTRIES_PER_DAY}`, '-1'];
const expireCmd = ['EXPIRE', key, String(TTL_SECONDS)];
```

Cap chosen: 100,000 × ~1.5KB ≈ 150MB → 3× safety margin under 500MB. Cap exported as `REPLAY_LOG_MAX_ENTRIES_PER_DAY` so a future bump only needs one location change.

## Why tail-keep is safe for the use-case

The U6 14-day replay harness aggregates ACROSS days using stable repHash cluster identity (per the existing comments in `replay-digest-cooldown.mjs`). Within-day older-entry eviction is acceptable for calibration analysis — operators get a representative sample of each day's traffic, not exhaustive coverage. The newest 100K still vastly exceeds any realistic sweep sample size.

## Test plan

- [x] `node --test tests/brief-dedup-replay-log.test.mjs` — 31/31 pass
  - Updated existing pipeline-shape assertion (2 commands → 3, with LTRIM in the middle)
  - Added regression guard reading the cap from the exported `REPLAY_LOG_MAX_ENTRIES_PER_DAY` constant (no brittle dual-update)
  - Sanity assertion that the cap stays in the 10K-200K band (so future bumps stay safely under 500MB at observed entry sizes)
- [ ] Post-merge: monitor Upstash for "Max Record Size" alerts → expectation: zero new alerts on `digest:replay-log:*` after the next writer cycle
- [ ] Post-merge: monitor seed-forecasts cron success rate → expectation: improved publish reliability

## One-time cleanup of EXISTING oversized keys

The new code only caps NEW writes. Existing keys are already at 200K-420K entries. They'll naturally trim when the next writer pass adds even one entry (the LTRIM applies to the whole list, not just new entries). But to immediately reclaim the ~6GB of overage, run this after merge:

```bash
TOKEN=$UPSTASH_REDIS_REST_TOKEN
URL=$UPSTASH_REDIS_REST_URL
for d in 04-25 04-26 04-27 04-28 04-29 04-30 05-01 05-02 05-03 05-04 05-05 05-06 05-07 05-08 05-09 05-10; do
  for variant in full finance markets safety conflict;  do
    k="digest:replay-log:v1:${variant}:en:all:2026-${d}"
    curl -s "$URL/ltrim/$k/-100000/-1" -H "Authorization: Bearer $TOKEN"
    echo "  trimmed $k"
  done
done
```

(Or wait for next writer cycle — same end state, just slower.)

## Companion to today's other resilience work

- #3640 (correlationCards budget) — reduces alert flap noise
- #3641 (history endpoint) — makes diagnosis self-service
- **This PR** — fixes the 500MB record-limit overruns that are likely back-pressuring other writes
- Upcoming: retry-on-transient for `atomicPublish` in `_seed-utils.mjs` so a single Upstash hiccup doesn't kill a 3-minute LLM-heavy seed run (separate PR — different surface area, separate review focus)