### PR TITLE
feat(seed-utils): retry transient Upstash failures in atomicPublish

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -145,7 +145,22 @@ async function redisCommand(url, token, command) {
   });
   if (!resp.ok) {
     const text = await resp.text().catch(() => '');
-    throw new Error(`Redis command failed: HTTP ${resp.status} — ${text.slice(0, 200)}`);
+    const err = new Error(`Redis command failed: HTTP ${resp.status} — ${text.slice(0, 200)}`);
+    // Tag errors so callers wrapping in withRetry know whether to back off.
+    // Permanent 4xx (auth, payload-too-large, etc.) won't recover on retry —
+    // mark non-retryable so withRetry exits the loop in ~10ms instead of
+    // wasting backoff on a guaranteed-fail. Only 429 (rate-limited) should
+    // keep retrying among the 4xx set, with the upstream Retry-After hint
+    // honoured. Transient 5xx and timeouts fall through with no flag —
+    // withRetry's default backoff applies.
+    if (PERMANENT_4XX_STATUSES.has(resp.status)) {
+      err.nonRetryable = true;
+    } else if (resp.status === 429) {
+      const retryAfterMs = parseRetryAfterMs(resp.headers.get('retry-after'));
+      if (retryAfterMs != null) err.retryAfterMs = retryAfterMs;
+    }
+    err.httpStatus = resp.status;
+    throw err;
   }
   return resp.json();
 }
@@ -222,8 +237,6 @@ export async function releaseLock(domain, runId) {
 
 export async function atomicPublish(canonicalKey, data, validateFn, ttlSeconds, options = {}) {
   const { url, token } = getRedisCredentials();
-  const runId = String(Date.now());
-  const stagingKey = `${canonicalKey}:staging:${runId}`;
 
   if (validateFn) {
     const valid = validateFn(data);
@@ -246,20 +259,42 @@ export async function atomicPublish(canonicalKey, data, validateFn, ttlSeconds, 
     throw new Error(`Payload too large: ${(payloadBytes / 1024 / 1024).toFixed(1)}MB > 5MB limit`);
   }
 
-  // Write to staging key
-  await redisSet(url, token, stagingKey, payloadValue, 300); // 5 min staging TTL
+  // Retry the entire 3-call publish unit on transient Upstash failures.
+  // Pre-fix: a single timeout on the canonical SET would crash the whole
+  // seeder run and Railway just waited for the next cron tick (1h for
+  // seed-forecasts). On 2026-05-10 this exact failure mode produced a
+  // ~3h gap on forecasts + marketImplications. Wrapping the body means
+  // a transient 5xx/timeout retries automatically with exponential
+  // backoff. Permanent 4xx (auth, payload-too-large) get the
+  // `nonRetryable: true` flag from redisCommand and abort immediately.
+  //
+  // Each attempt re-stages with a fresh runId so a previous attempt's
+  // staging key (if it landed server-side but the response was lost)
+  // doesn't shadow the retry. The 5-min staging TTL cleans up any
+  // orphaned stagings naturally.
+  return await withRetry(
+    async () => {
+      const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const stagingKey = `${canonicalKey}:staging:${runId}`;
 
-  // Overwrite canonical key
-  if (ttlSeconds) {
-    await redisCommand(url, token, ['SET', canonicalKey, payload, 'EX', ttlSeconds]);
-  } else {
-    await redisCommand(url, token, ['SET', canonicalKey, payload]);
-  }
+      // Write to staging key
+      await redisSet(url, token, stagingKey, payloadValue, 300); // 5 min staging TTL
 
-  // Cleanup staging
-  await redisDel(url, token, stagingKey).catch(() => {});
+      // Overwrite canonical key
+      if (ttlSeconds) {
+        await redisCommand(url, token, ['SET', canonicalKey, payload, 'EX', ttlSeconds]);
+      } else {
+        await redisCommand(url, token, ['SET', canonicalKey, payload]);
+      }
 
-  return { payloadBytes, recordCount: Array.isArray(data) ? data.length : null };
+      // Cleanup staging
+      await redisDel(url, token, stagingKey).catch(() => {});
+
+      return { payloadBytes, recordCount: Array.isArray(data) ? data.length : null };
+    },
+    2,    // 2 retries (3 attempts total) — sufficient for transient blips
+    1000, // 1s base delay; exponential → 1s, 2s, 4s = ~7s worst case before re-attempt
+  );
 }
 
 export async function writeFreshnessMetadata(domain, resource, count, source, ttlSeconds, fetchedAtOverride, contentAge) {

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -293,7 +293,9 @@ export async function atomicPublish(canonicalKey, data, validateFn, ttlSeconds, 
       return { payloadBytes, recordCount: Array.isArray(data) ? data.length : null };
     },
     2,    // 2 retries (3 attempts total) — sufficient for transient blips
-    1000, // 1s base delay; exponential → 1s, 2s, 4s = ~7s worst case before re-attempt
+    1000, // 1s base delay; exponential backoff → 1s + 2s = ~3s worst-case
+          // cumulative wait between attempts. Plus per-attempt fetch time
+          // (15s timeout each) means total worst-case before propagating ≈ 48s.
   );
 }
 

--- a/tests/seed-utils-with-retry.test.mjs
+++ b/tests/seed-utils-with-retry.test.mjs
@@ -118,3 +118,164 @@ describe('withRetry', () => {
     assert.ok(elapsed < 1000, `expected <1000ms (cap respected), got ${elapsed}ms`);
   });
 });
+
+// ── atomicPublish: transient-failure retry contract (WM 2026-05-10) ────────
+//
+// Pre-fix: a single Upstash REST timeout on the canonical SET would crash
+// the entire seeder run. Railway just waited an hour for the next cron
+// tick. Fix: wrap the publish body in withRetry so transient timeouts /
+// 5xx / undici network errors retry with exponential backoff. Permanent
+// 4xx (auth, payload-too-large) get tagged nonRetryable in redisCommand
+// and abort immediately.
+//
+// We mock globalThis.fetch + Upstash creds to drive the retry path
+// without hitting a real Redis. atomicPublish's three calls (staging
+// SET, canonical SET, staging DEL) all go through the same fetch.
+
+import { atomicPublish } from '../scripts/_seed-utils.mjs';
+
+function mockFetch(responses) {
+  let i = 0;
+  return async (_url, _init) => {
+    const r = responses[Math.min(i, responses.length - 1)];
+    i += 1;
+    if (typeof r === 'function') return r(_url, _init);
+    if (r instanceof Error) throw r;
+    return new Response(JSON.stringify(r.body ?? { result: 'OK' }), {
+      status: r.status ?? 200,
+      headers: r.headers ?? {},
+    });
+  };
+}
+
+describe('atomicPublish retry-on-transient (WM 2026-05-10 incident fix)', () => {
+  const ORIG_FETCH = globalThis.fetch;
+  const ORIG_URL = process.env.UPSTASH_REDIS_REST_URL;
+  const ORIG_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  function setup(fetchImpl) {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://test.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+    globalThis.fetch = fetchImpl;
+  }
+  function teardown() {
+    globalThis.fetch = ORIG_FETCH;
+    if (ORIG_URL == null) delete process.env.UPSTASH_REDIS_REST_URL;
+    else process.env.UPSTASH_REDIS_REST_URL = ORIG_URL;
+    if (ORIG_TOKEN == null) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    else process.env.UPSTASH_REDIS_REST_TOKEN = ORIG_TOKEN;
+  }
+
+  it('succeeds without retry when all calls return 200 (happy path unchanged)', async () => {
+    let calls = 0;
+    setup(mockFetch([
+      // Each call returns 200 OK; atomicPublish makes 3 calls (staging SET,
+      // canonical SET, staging DEL). With 3 successes in a row, no retry fires.
+      () => { calls += 1; return new Response(JSON.stringify({ result: 'OK' }), { status: 200 }); },
+    ]));
+    try {
+      const result = await atomicPublish('test:key:v1', { hello: 'world' }, null, 60);
+      assert.equal(result.payloadBytes > 0, true);
+      assert.equal(calls, 3, 'staging-SET + canonical-SET + staging-DEL');
+    } finally {
+      teardown();
+    }
+  });
+
+  it('retries on transient 503 then succeeds on 2nd attempt', async () => {
+    // First attempt: staging SET returns 503 → atomicPublish body throws,
+    // withRetry sleeps 1s, re-runs the whole body. Second attempt: all OK.
+    // Total fetch calls = 1 (failed) + 3 (success) = 4.
+    let calls = 0;
+    let firstAttemptFailed = false;
+    setup(async (_url, _init) => {
+      calls += 1;
+      if (!firstAttemptFailed) {
+        firstAttemptFailed = true;
+        return new Response('upstream temporarily unavailable', { status: 503 });
+      }
+      return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+    });
+    try {
+      const t0 = Date.now();
+      const result = await atomicPublish('test:key:v1', { hello: 'world' }, null, 60);
+      const elapsed = Date.now() - t0;
+      assert.equal(result.payloadBytes > 0, true);
+      assert.equal(calls, 4, '1 failed staging-SET + 3 successful calls on retry');
+      assert.ok(elapsed >= 900, `expected ≥1s backoff, got ${elapsed}ms`);
+    } finally {
+      teardown();
+    }
+  });
+
+  it('aborts immediately on permanent 4xx (no useless backoff)', async () => {
+    // 401 Unauthorized would never recover on retry. redisCommand tags it
+    // nonRetryable, withRetry skips backoff and exits the loop ~10ms.
+    let calls = 0;
+    setup(async (_url, _init) => {
+      calls += 1;
+      return new Response('bad token', { status: 401 });
+    });
+    try {
+      const t0 = Date.now();
+      await assert.rejects(
+        atomicPublish('test:key:v1', { hello: 'world' }, null, 60),
+        /HTTP 401/,
+      );
+      const elapsed = Date.now() - t0;
+      assert.equal(calls, 1, 'no retries on permanent 401');
+      assert.ok(elapsed < 500, `expected fast-fail, got ${elapsed}ms`);
+    } finally {
+      teardown();
+    }
+  });
+
+  it('exhausts 3 attempts on persistent transient failure (matches withRetry contract)', async () => {
+    // Keep returning 503 forever. withRetry's default for atomicPublish is
+    // 2 retries (3 attempts total). After exhausting, the last error
+    // propagates to the caller — runSeed treats this as a fatal seed
+    // failure (which, post-fix, is what we want: 3 transient failures in
+    // a row IS something the operator should see).
+    let calls = 0;
+    setup(async () => {
+      calls += 1;
+      return new Response('still down', { status: 503 });
+    });
+    try {
+      await assert.rejects(
+        atomicPublish('test:key:v1', { hello: 'world' }, null, 60),
+        /HTTP 503/,
+      );
+      // 3 attempts × 1 fetch each (fail on staging-SET) = 3 calls.
+      assert.equal(calls, 3, '3 attempts before giving up');
+    } finally {
+      teardown();
+    }
+  });
+
+  it('honors Retry-After hint on 429', async () => {
+    // 429 is transient AND carries a hint. redisCommand tags retryAfterMs;
+    // withRetry waits at least that long before the next attempt.
+    let calls = 0;
+    let firstAttemptDone = false;
+    setup(async (_url, _init) => {
+      calls += 1;
+      if (!firstAttemptDone) {
+        firstAttemptDone = true;
+        return new Response('rate limited', {
+          status: 429,
+          headers: { 'retry-after': '2' },  // 2 seconds
+        });
+      }
+      return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+    });
+    try {
+      const t0 = Date.now();
+      await atomicPublish('test:key:v1', { hello: 'world' }, null, 60);
+      const elapsed = Date.now() - t0;
+      assert.ok(elapsed >= 1900, `expected ≥2s Retry-After honored, got ${elapsed}ms`);
+    } finally {
+      teardown();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Wraps `atomicPublish`'s 3-call publish unit (staging SET → canonical SET → staging DEL) in `withRetry` so a single transient Upstash REST timeout no longer kills a multi-minute seeder run. Also tags redisCommand errors with `nonRetryable: true` for permanent 4xx and `retryAfterMs` for 429 — so the existing `withRetry` helper makes the right backoff decision.

## Why now

WM 2026-05-10 incident: seed-forecasts cron failed with a Redis SET timeout on a **0.17MB payload** (well under any limit) after completing the entire 3-minute run — LLM calls, 42 forecasts filtered, full publish payload built. Stack trace:

```
DOMException [TimeoutError]: The operation was aborted due to timeout
  at async redisCommand (_seed-utils.mjs:140:16)
  at async atomicPublish (_seed-utils.mjs:254:5)
  at async runSeed (_seed-utils.mjs:1236:27)
```

Cron just waited an hour for the next tick. forecasts + marketImplications stayed STALE_SEED for ~3 hours.

R2 timeouts and OpenRouter LLM failures earlier in the same run were caught and degraded gracefully (fallback narratives applied). The ONLY fragility was the publish step itself.

## Companion to PR #3649

PR #3649 caps `digest:replay-log:v1:*` lists at 100K entries to prevent Upstash 500MB overages that were back-pressuring these timeouts. Together:
- **#3649** removes the *source* of the back-pressure
- **This PR** removes the *single point of failure* even when other transients hit

## Changes

### 1. `redisCommand` — error tagging (no retry on its own)

```diff
   if (!resp.ok) {
     const text = await resp.text().catch(() => '');
-    throw new Error(`Redis command failed: HTTP ${resp.status} — ${text.slice(0, 200)}`);
+    const err = new Error(`Redis command failed: HTTP ${resp.status} — ${text.slice(0, 200)}`);
+    if (PERMANENT_4XX_STATUSES.has(resp.status)) {
+      err.nonRetryable = true;
+    } else if (resp.status === 429) {
+      const retryAfterMs = parseRetryAfterMs(resp.headers.get('retry-after'));
+      if (retryAfterMs != null) err.retryAfterMs = retryAfterMs;
+    }
+    err.httpStatus = resp.status;
+    throw err;
   }
```

`redisCommand` itself stays single-attempt — auto-retrying every redisCommand caller (e.g. `acquireLock` with NX semantics) would change behavior subtly. Only callers that opt in via `withRetry` get the retry behavior.

### 2. `atomicPublish` — wrap the body in `withRetry`

```diff
-  const runId = String(Date.now());
-  const stagingKey = `${canonicalKey}:staging:${runId}`;
   ...
-  await redisSet(url, token, stagingKey, payloadValue, 300);
-  if (ttlSeconds) await redisCommand(url, token, ['SET', canonicalKey, payload, 'EX', ttlSeconds]);
-  else await redisCommand(url, token, ['SET', canonicalKey, payload]);
-  await redisDel(url, token, stagingKey).catch(() => {});
-  return { payloadBytes, recordCount: ... };
+  return await withRetry(
+    async () => {
+      const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const stagingKey = `${canonicalKey}:staging:${runId}`;
+      await redisSet(url, token, stagingKey, payloadValue, 300);
+      if (ttlSeconds) await redisCommand(url, token, ['SET', canonicalKey, payload, 'EX', ttlSeconds]);
+      else await redisCommand(url, token, ['SET', canonicalKey, payload]);
+      await redisDel(url, token, stagingKey).catch(() => {});
+      return { payloadBytes, recordCount: ... };
+    },
+    2,    // 2 retries (3 attempts total)
+    1000, // 1s base; exponential → 1s, 2s, 4s ≈ 7s worst case
+  );
```

Each attempt re-stages with a **fresh runId** so a previous attempt's staging key (if the SET landed server-side but the response was lost) doesn't shadow the retry. The 5-min staging TTL cleans up orphans automatically.

## Retry decision matrix

| Failure mode | Tagged | withRetry behavior |
|---|---|---|
| Timeout (DOMException) | (none) | Retries with exponential backoff |
| 5xx (502, 503, 504) | (none) | Retries with exponential backoff |
| Network error (ECONNRESET, fetch failed, undici) | (none, but isTransientRedisError matches) | Retries with exponential backoff |
| 429 (rate limit) | `retryAfterMs` from header | Waits `max(baseWait, retryAfterMs)`, then retries |
| 401, 403, 404, 410, 422, 451 (permanent) | `nonRetryable: true` | Exits loop in ~10ms |
| 400 (bad request) | `nonRetryable: true` | Exits loop |

408 and 429 are NOT in `PERMANENT_4XX_STATUSES` (per PR #3635 review) — they're explicit "try again" signals.

## Test plan

- [x] `node --test tests/seed-utils-with-retry.test.mjs` — 17/17 pass
  - 5 new tests for atomicPublish retry behavior:
    - happy path (no retry, 3 fetch calls)
    - transient 503 → retry → success (4 calls, ≥1s elapsed for 1s backoff)
    - permanent 401 → fast-fail, no retry (1 call, <500ms)
    - persistent 503 → exhausts 3 attempts then throws
    - 429 with Retry-After: 2 → wait ≥2s before retry
  - 12 existing tests for `withRetry`, `parseRetryAfterMs`, `PERMANENT_4XX_STATUSES`, `isTransientRedisError` all unchanged
- [x] `node --test tests/seed-utils*.test.mjs` — 54/54 pass (full seed-utils surface)
- [ ] Post-merge: monitor seed-forecasts (and other long-running seeders) for crashes on Redis timeouts. Expectation: transient timeouts retry silently; only persistent failures (3+ attempts) surface

## What this DOES NOT change

- Permanent failures (auth, payload-too-large) still abort fast — no useless backoff
- The 5MB MAX_PAYLOAD_BYTES check stays at the top of atomicPublish — payload validation runs once, not per attempt
- `acquireLock`'s single-attempt behavior unchanged — wrap at call site (`acquireLockSafely:201`) handles retry semantics specifically for NX
- Other Redis read paths (`redisGet`) unchanged — their callers can opt in via withRetry as needed