### PR TITLE
chore(diagnostic): MCP_PRO_GRANT_HMAC_SECRET runtime visibility

### DIFF
--- a/api/_mcp-grant-hmac.ts
+++ b/api/_mcp-grant-hmac.ts
@@ -81,6 +81,22 @@ async function importHmacKey(secret: string): Promise<CryptoKey> {
 export function readGrantSecret(env: NodeJS.ProcessEnv = process.env): string {
   const secret = env.MCP_PRO_GRANT_HMAC_SECRET ?? '';
   if (!secret) {
+    // TEMP DIAGNOSTIC (PR #3646): on missing-secret, log the NAMES (not values)
+    // of every process.env key starting with `MCP_` so we can confirm whether
+    // the runtime sees the linked Shared env vars at all. Removed in the next
+    // commit once root cause is confirmed.
+    try {
+      const mcpKeys = Object.keys(env)
+        .filter((k) => k.startsWith('MCP_'))
+        .sort();
+      console.warn(
+        `[mcp-grant-hmac] DIAGNOSTIC missing-secret: process.env MCP_* keys = ${
+          mcpKeys.length === 0 ? '<NONE>' : mcpKeys.join(', ')
+        }`,
+      );
+    } catch {
+      /* never let diagnostic hide the real error */
+    }
     throw new GrantConfigError('MCP_PRO_GRANT_HMAC_SECRET is not set');
   }
   return secret;


### PR DESCRIPTION
## Summary

Temporary diagnostic on top of merged PR #3646. Logs the **names** (not values) of every `process.env` key starting with `MCP_` at the moment `getGrantSecret()` throws `GrantConfigError`.

## Why

After #3646 merged + production deploy, every Pro user authorize click → "MCP authorization is temporarily unavailable" → mint endpoint returning `CONFIGURATION_ERROR` 500 → which fires only when `process.env.MCP_PRO_GRANT_HMAC_SECRET` is empty/unset at the apex function.

Vercel dashboard shows both `MCP_PRO_GRANT_HMAC_SECRET` and `MCP_INTERNAL_HMAC_SECRET` linked under Production+Preview as Sensitive, but `vercel env ls production | grep MCP_` returns no match. Need to confirm whether the running function process actually sees the variable.

## What this commit does

Adds a single `console.warn` at `api/_mcp-grant-hmac.ts:84` when the secret is missing, before the throw:

```
[mcp-grant-hmac] DIAGNOSTIC missing-secret: process.env MCP_* keys = <list>
```

If `<list>` is `<NONE>` → link didn't actually apply.
If only `MCP_INTERNAL_HMAC_SECRET` → wrong key linked / typo.
If includes `MCP_PRO_GRANT_HMAC_SECRET` → linked but empty (separate bug).

## Removal

This is temporary. Removed in the immediately-following commit once root cause is confirmed.

## Test plan

- [ ] Merge + production deploy
- [ ] Trigger one failed Pro authorize click
- [ ] Open Vercel Logs → filter for `[mcp-grant-hmac] DIAGNOSTIC missing-secret`
- [ ] Read the listed keys to determine which of the three branches applies
- [ ] Open follow-up PR to remove the diagnostic