### PR TITLE
fix(billing): swallow deleteEntitlementCache failures (no user impact)

### DIFF
--- a/convex/payments/cacheActions.ts
+++ b/convex/payments/cacheActions.ts
@@ -111,7 +111,11 @@ export const syncEntitlementCache = internalAction({
  * Deletes a user's entitlement cache entry from Redis.
  *
  * Used by claimSubscription to clear the stale anonymous ID cache entry
- * after reassigning records to the real authenticated user.
+ * after reassigning records to the real authenticated user. The deleted
+ * key is unreachable post-claim (read path uses the real userId) and
+ * self-expires at ENTITLEMENT_CACHE_TTL_SECONDS, so a failed DEL has no
+ * user impact — warn and swallow rather than surfacing transient
+ * Upstash latency blips to Convex auto-Sentry.
  */
 export const deleteEntitlementCache = internalAction({
   args: { userId: v.string() },
@@ -136,18 +140,19 @@ export const deleteEntitlementCache = internalAction({
       );
 
       if (!resp.ok) {
-        // Same rationale as the SET path — surface persistent failures
-        // via Convex auto-Sentry. DEL is idempotent so retry is safe.
-        throw new Error(
+        console.warn(
           `[cacheActions] Redis DEL failed: HTTP ${resp.status} for key ${key}`,
         );
       }
     } catch (err) {
+      // sentry-coverage-ok — DEL failure has no user impact (key is
+      // unreachable post-claim, self-expires at 15-min TTL); a 5s
+      // AbortError from a transient Upstash latency blip should not
+      // page via Convex auto-Sentry.
       console.warn(
         "[cacheActions] Redis cache delete failed:",
         err instanceof Error ? err.message : String(err),
       );
-      throw err;
     } finally {
       clearTimeout(timeout);
     }


### PR DESCRIPTION
## Summary

- `cacheActions:deleteEntitlementCache` was throwing on Upstash DEL failure, surfacing every transient 5s `AbortError` to Convex auto-Sentry. Observed on the Convex dashboard (May 10, 23:14:33 UTC) as a `failure 5.0s — Uncaught Error: AbortError`.
- The DEL has **zero user impact**: it clears the stale anon-ID entitlement key after `claimSubscription` promotes anon → real user, but the read path (`server/_shared/entitlement-check.ts:129`) keys off the **real** authenticated `userId`. The anon key is unreachable post-claim and self-expires at the 15-min `ENTITLEMENT_CACHE_TTL_SECONDS`.
- Demote the DEL throws (HTTP-non-2xx branch + catch block) to `console.warn`. Add `// sentry-coverage-ok` override marker in the catch with rationale so the pre-push Sentry-coverage gate accepts the deliberate swallow.
- `syncEntitlementCache` left untouched — that one **does** have user impact (Pro features dark for 15 min if SET fails), so its throw + auto-Sentry surfacing remains correct.

## Why not just bump the 5s timeout?

Bumping the timeout treats the symptom. The right shape for a best-effort cleanup of an unreachable key with a TTL safety net is "warn and swallow", not "page on transient latency blips". The 5s budget itself is fine.

## Why keep the action at all?

Considered deleting it outright (the 15-min TTL would handle cleanup), but the action does provide value when Upstash is healthy: the anon key clears immediately rather than lingering for up to 15 min. Just don't page on the rare slow-Upstash path.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run typecheck:api` — passes
- [x] `npm run lint` — passes (235 warnings, 0 errors; all pre-existing)
- [x] `npm run test:data` — 8526/8526 pass
- [x] `node --test tests/edge-functions.test.mjs` — 184/184 pass
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — passes
- [x] `node scripts/check-sentry-coverage.mjs --all` — clean (184 files; override marker accepted)
- [x] Pre-push hooks all green