### PR TITLE
feat(mcp): Tier-1+2 coverage — 6 new tools + parity guard (38 total)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -930,4 +930,9 @@ export const __testing__ = {
   readSeedMeta,
   classifyKey,
   STATUS_COUNTS,
+  // U7 (Tier 3 parity test): exposed for tests/mcp-bootstrap-parity.test.mjs
+  // to walk the canonical seeded-data inventory. Both consts are unexported
+  // at module scope by design — this is the test-only escape hatch.
+  BOOTSTRAP_KEYS,
+  STANDALONE_KEYS,
 };

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -465,6 +465,52 @@ const TOOL_REGISTRY: ToolDef[] = [
     ],
   },
   {
+    name: 'get_chokepoint_status',
+    description: 'Live maritime chokepoint status: per-chokepoint vessel transit counts (10-min cadence), rolling transit summaries, per-port activity, plus static reference data (chokepoint geometry, canonical 13-chokepoint registry) and flow aggregates. Covers Suez, Hormuz, Malacca, Bab-el-Mandeb, Panama, etc.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    // Maritime chokepoint bundle distinct from get_supply_chain_data (which keeps
+    // shipping-stress + customs + comtrade). Cadences span 10-minute relay
+    // (transit-summaries, chokepoint_transits) to ~400-day static registries
+    // (chokepoint-baselines), so per-key _freshnessChecks pulled from
+    // api/health.js::SEED_META — a fast transit outage isn't masked by the
+    // slow chokepoint-baselines budget, and the long-cadence portwatch keys
+    // don't drag aggregate stale flagging.
+    //
+    // Payload measurement (PR pre-merge, fun-toad-55127.upstash.io 2026-05-11):
+    //   transit-summaries:v1                        — 6.8 KB
+    //   chokepoint_transits:v1                      — 1.1 KB
+    //   portwatch-ports:v1:_countries               — 0.9 KB
+    //   energy:chokepoint-baselines:v1              — 0.6 KB
+    //   portwatch:chokepoints:ref:v1                — 7.9 KB
+    //   energy:chokepoint-flows:v1                  — 1.2 KB
+    //   ────────────────────────────────────────────────────
+    //   Total: 18.5 KB (well under the 200KB/single-key and 500KB/aggregate
+    //   thresholds that historically tripped handler timeouts —
+    //   see tests/transit-summaries.test.mjs:539-545).
+    //
+    // EXCLUDED on purpose: supply_chain:corridorrisk:v1 is an intermediate
+    // key whose data flows through supply_chain:transit-summaries:v1
+    // (api/health.js:461). U7 will add corridorrisk to EXCLUDED_FROM_MCP.
+    _cacheKeys: [
+      'supply_chain:transit-summaries:v1',          // STANDALONE_KEYS::transitSummaries
+      'supply_chain:chokepoint_transits:v1',        // STANDALONE_KEYS::chokepointTransits
+      'supply_chain:portwatch-ports:v1:_countries', // STANDALONE_KEYS::portwatchPortActivity
+      'energy:chokepoint-baselines:v1',             // STANDALONE_KEYS::chokepointBaselines
+      'portwatch:chokepoints:ref:v1',               // STANDALONE_KEYS::portwatchChokepointsRef
+      'energy:chokepoint-flows:v1',                 // STANDALONE_KEYS::chokepointFlows
+    ],
+    _seedMetaKey: 'seed-meta:supply_chain:transit-summaries',
+    _maxStaleMin: 30, // transit-summaries 10-min relay baseline; per-key budgets via _freshnessChecks below
+    _freshnessChecks: [
+      { key: 'seed-meta:supply_chain:transit-summaries',   maxStaleMin: 30 },             // 10-min relay; 30min = 3× interval
+      { key: 'seed-meta:supply_chain:chokepoint_transits', maxStaleMin: 30 },             // 10-min relay; 30min = 3× interval
+      { key: 'seed-meta:supply_chain:portwatch-ports',     maxStaleMin: 2160 },           // 12h cron; 36h = 3× interval
+      { key: 'seed-meta:energy:chokepoint-baselines',      maxStaleMin: 60 * 24 * 400 },  // ~400d static registry
+      { key: 'seed-meta:portwatch:chokepoints-ref',        maxStaleMin: 60 * 24 * 14 },   // weekly cron; 14d = 2× interval
+      { key: 'seed-meta:energy:chokepoint-flows',          maxStaleMin: 720 },            // 6h cron; 12h = 2× interval
+    ],
+  },
+  {
     name: 'get_positive_events',
     description: 'Positive geopolitical events: diplomatic agreements, humanitarian aid, development milestones, and peace initiatives worldwide.',
     inputSchema: { type: 'object', properties: {}, required: [] },

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -441,6 +441,30 @@ const TOOL_REGISTRY: ToolDef[] = [
     _maxStaleMin: 2880,
   },
   {
+    name: 'get_tariff_trends',
+    description: 'Global trade and pricing indicators: US tariff trends (HTS-coded), BigMac index, FAO Food Price Index, and per-country national debt levels.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    // 4-key bundle spanning trade + economic domains. Cadences span hourly-ish
+    // (tariffs co-pinned to 8h TARIFF_TTL) to monthly (FAO / national debt).
+    // Per-key _freshnessChecks pulled from api/health.js::SEED_META so a slow
+    // monthly key doesn't drag the aggregate stale flag and a fast tariff
+    // outage isn't masked by a long FAO budget.
+    _cacheKeys: [
+      'trade:tariffs:v1:840:all:10',   // STANDALONE_KEYS::tariffTrendsUs
+      'economic:bigmac:v1',            // BOOTSTRAP_KEYS::bigmac
+      'economic:fao-ffpi:v1',          // BOOTSTRAP_KEYS::faoFoodPriceIndex
+      'economic:national-debt:v1',     // BOOTSTRAP_KEYS::nationalDebt
+    ],
+    _seedMetaKey: 'seed-meta:trade:tariffs:v1:840:all:10',
+    _maxStaleMin: 540, // tariff cron baseline; per-key budgets via _freshnessChecks below
+    _freshnessChecks: [
+      { key: 'seed-meta:trade:tariffs:v1:840:all:10', maxStaleMin: 540 },   // TARIFF_TTL 8h + 60min grace
+      { key: 'seed-meta:economic:bigmac',             maxStaleMin: 10080 }, // weekly seed; 7d
+      { key: 'seed-meta:economic:fao-ffpi',           maxStaleMin: 86400 }, // monthly seed; 60d (2× interval)
+      { key: 'seed-meta:economic:national-debt',      maxStaleMin: 86400 }, // monthly seed; 60d (2× interval)
+    ],
+  },
+  {
     name: 'get_positive_events',
     description: 'Positive geopolitical events: diplomatic agreements, humanitarian aid, development milestones, and peace initiatives worldwide.',
     inputSchema: { type: 'object', properties: {}, required: [] },

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -327,6 +327,20 @@ const TOOL_REGISTRY: ToolDef[] = [
     _maxStaleMin: 1440,
   },
   {
+    name: 'get_displacement_data',
+    description: 'Refugee and IDP counts by country (UNHCR annual data).',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    // Dynamic-year key resolved once at module evaluation — mirrors the
+    // STANDALONE_KEYS pattern in api/health.js:147. The UNHCR seeder publishes
+    // a single current-year key; the prior year exists at the same prefix but
+    // is intentionally excluded — the executeTool label-walk would strip the
+    // year segment from both keys and collide on the same `summary` label,
+    // causing the second result to overwrite the first.
+    _cacheKeys: [`displacement:summary:v1:${new Date().getUTCFullYear()}`],
+    _seedMetaKey: 'seed-meta:displacement:summary',
+    _maxStaleMin: 3600,
+  },
+  {
     name: 'get_climate_data',
     description: 'Climate intelligence: temperature/precipitation anomalies (vs 30-year WMO normals), climate-relevant disaster alerts (ReliefWeb/GDACS/FIRMS), atmospheric CO2 trend (NOAA Mauna Loa), air quality (OpenAQ/WAQI PM2.5 stations), Arctic sea ice extent and ocean heat indicators (NSIDC/NOAA), weather alerts, and climate news.',
     inputSchema: { type: 'object', properties: {}, required: [] },

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -720,7 +720,13 @@ const TOOL_REGISTRY: ToolDef[] = [
       if (!params.country_code || typeof params.country_code !== 'string') {
         return { error: 'country_code is required' };
       }
-      const code = params.country_code.toLowerCase().slice(0, 2);
+      const code = params.country_code.toLowerCase();
+      // Strict ISO 3166-1 alpha-2 shape: exactly two lowercase letters.
+      // Without this, .slice(0,2) would silently truncate inputs like
+      // "aexxx" or "AE-DXB" to "ae" and serve AE data — masking client bugs.
+      if (!/^[a-z]{2}$/.test(code)) {
+        return { error: 'country_code must be a two-letter ISO code (e.g. "ae")' };
+      }
       if (!SUPPORTED_CONSUMER_PRICES_COUNTRIES.has(code)) {
         return { error: 'Country not yet supported. Available: ae' };
       }
@@ -752,6 +758,16 @@ const TOOL_REGISTRY: ToolDef[] = [
         Promise.all(dataKeys.map((k) => readJsonFromUpstash(k))),
         Promise.all(freshnessChecks.map((c) => readJsonFromUpstash(c.key))),
       ]);
+
+      // F6 contract parity with the cache-tool path (executeTool, ~line 1139):
+      // if every data read is null/undefined, this is a degenerate-empty
+      // response (Redis transient / stampede / pre-seed). Throw so
+      // dispatchToolsCall's catch fires proRollback — without this, the Pro
+      // user's daily MCP counter increments by 1 for a useless result while
+      // every other cache-tool refunds via the same code path.
+      if (dataResults.every((v: unknown) => v === null || v === undefined)) {
+        throw new Error('cache_all_null');
+      }
 
       const { cached_at, stale } = evaluateFreshness(freshnessChecks, metaResults);
 

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -341,6 +341,23 @@ const TOOL_REGISTRY: ToolDef[] = [
     _maxStaleMin: 3600,
   },
   {
+    name: 'get_health_signals',
+    description: 'Active disease outbreaks (WHO/ECDC etc.) and global air-quality station readings (OpenAQ/WAQI PM2.5). For health-risk screening.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    // Uses the health-domain canonical key health:air-quality:v1 (NOT the
+    // climate-domain mirror climate:air-quality:v1, which stays exclusively
+    // in get_climate_data). Both are written by the same seeder
+    // (scripts/seed-health-air-quality.mjs exports HEALTH_AIR_QUALITY_KEY +
+    // CLIMATE_AIR_QUALITY_KEY) so no duplicate seed work.
+    _cacheKeys: ['health:disease-outbreaks:v1', 'health:air-quality:v1'],
+    _seedMetaKey: 'seed-meta:health:disease-outbreaks',
+    _maxStaleMin: 2880,
+    _freshnessChecks: [
+      { key: 'seed-meta:health:disease-outbreaks', maxStaleMin: 2880 }, // daily cron; 48h budget
+      { key: 'seed-meta:health:air-quality', maxStaleMin: 180 },        // hourly cron; 3h budget
+    ],
+  },
+  {
     name: 'get_climate_data',
     description: 'Climate intelligence: temperature/precipitation anomalies (vs 30-year WMO normals), climate-relevant disaster alerts (ReliefWeb/GDACS/FIRMS), atmospheric CO2 trend (NOAA Mauna Loa), air quality (OpenAQ/WAQI PM2.5 stations), Arctic sea ice extent and ocean heat indicators (NSIDC/NOAA), weather alerts, and climate news.',
     inputSchema: { type: 'object', properties: {}, required: [] },

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -1600,3 +1600,15 @@ export default async function handler(
 ): Promise<Response> {
   return mcpHandler(req, PRODUCTION_DEPS, ctx);
 }
+
+// ---------------------------------------------------------------------------
+// Test-only escape hatch. Exposes the TOOL_REGISTRY for the U7 Tier 3 parity
+// test (tests/mcp-bootstrap-parity.test.mjs), which asserts that every
+// canonical seeded cache key from api/health.js (BOOTSTRAP_KEYS ∪
+// STANDALONE_KEYS) is either covered by some tool's `_cacheKeys` (cache-tool)
+// or `_coverageKeys` (RpcToolDef hybrid), or explicitly excluded via the
+// test's EXCLUDED_FROM_MCP map with a documented reason.
+// ---------------------------------------------------------------------------
+export const __testing__ = {
+  TOOL_REGISTRY,
+};

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -34,6 +34,12 @@ const MCP_PROTOCOL_VERSION = '2025-03-26';
 const SERVER_NAME = 'worldmonitor';
 const SERVER_VERSION = '1.0';
 
+// Country-code whitelist for get_consumer_prices. The consumer-prices seeder
+// currently only produces data for AE (UAE); future markets will be added
+// here as they're seeded. Kept near COUNTRY_BBOXES (the other ISO-3166 alpha-2
+// lookup table used by tools) so adding a market is a single-file change.
+const SUPPORTED_CONSUMER_PRICES_COUNTRIES = new Set(['ae']);
+
 // ---------------------------------------------------------------------------
 // Rate limiters
 // ---------------------------------------------------------------------------
@@ -148,12 +154,18 @@ interface CacheToolDef extends BaseToolDef {
 }
 
 // AI inference tool: calls an internal RPC endpoint and returns the raw response.
+// Hybrid variant: when an _execute tool also reads cache keys directly
+// (e.g. parameterised by country_code), it MAY declare `_coverageKeys` so the
+// U7 Tier 3 parity test can verify that every BOOTSTRAP_KEYS/STANDALONE_KEYS
+// entry it owns is covered by some tool — cache-tool's `_cacheKeys` and
+// hybrid _execute's `_coverageKeys` are equivalent for that audit.
 interface RpcToolDef extends BaseToolDef {
   _cacheKeys?: never;
   _seedMetaKey?: never;
   _maxStaleMin?: never;
   _freshnessChecks?: never;
   _execute: (params: Record<string, unknown>, base: string, context: McpAuthContext) => Promise<unknown>;
+  _coverageKeys?: string[];
 }
 
 type ToolDef = CacheToolDef | RpcToolDef;
@@ -604,6 +616,87 @@ const TOOL_REGISTRY: ToolDef[] = [
       });
       if (!res.ok) throw new Error(`get-country-risk HTTP ${res.status}`);
       return res.json();
+    },
+  },
+  {
+    name: 'get_consumer_prices',
+    description: "Per-country consumer-prices intelligence: 30-day overview, category-level inflation, retailer spread (essentials basket), top movers, and source freshness. Requires country_code (currently only 'ae' is seeded).",
+    inputSchema: {
+      type: 'object',
+      properties: {
+        country_code: {
+          type: 'string',
+          description: 'ISO 3166-1 alpha-2 country code. Currently supported: AE (case-insensitive).',
+        },
+      },
+      required: ['country_code'],
+    },
+    // Hybrid _execute (not a pure cache tool) because the cache keys are
+    // parameterised by country. Mirrors api/health.js::BOOTSTRAP_KEYS:55-59
+    // exactly so the U7 Tier-3 parity test treats every key as covered.
+    _coverageKeys: [
+      'consumer-prices:overview:ae',
+      'consumer-prices:categories:ae:30d',
+      'consumer-prices:movers:ae:30d',
+      'consumer-prices:retailer-spread:ae:essentials-ae',
+      'consumer-prices:freshness:ae',
+    ],
+    _execute: async (params) => {
+      // Result-level errors (NOT throws) for user-input issues — the dispatcher
+      // maps thrown errors to JSON-RPC -32603 "Internal error", which is
+      // misleading for a clearly-user-side fault like a missing/unknown
+      // country_code. Returning {error: ...} surfaces a usable message via
+      // the normal tools/call result envelope.
+      if (!params.country_code || typeof params.country_code !== 'string') {
+        return { error: 'country_code is required' };
+      }
+      const code = params.country_code.toLowerCase().slice(0, 2);
+      if (!SUPPORTED_CONSUMER_PRICES_COUNTRIES.has(code)) {
+        return { error: 'Country not yet supported. Available: ae' };
+      }
+
+      const dataKeys = [
+        `consumer-prices:overview:${code}`,
+        `consumer-prices:categories:${code}:30d`,
+        `consumer-prices:movers:${code}:30d`,
+        `consumer-prices:retailer-spread:${code}:essentials-${code}`,
+        `consumer-prices:freshness:${code}`,
+      ];
+
+      // Freshness checks use the producer's actual meta keys. Note the spread
+      // entry: scripts/seed-consumer-prices.mjs:151 writes
+      // `seed-meta:consumer-prices:spread:<code>` (NO `retailer-` prefix,
+      // NO `:essentials-<code>` suffix). api/health.js:337 has the documented
+      // drift bug (expects `retailer-spread:<code>:essentials-<code>` which
+      // never exists) and so would always report stale; we deliberately
+      // diverge from health.js here to match the actual producer.
+      const freshnessChecks: FreshnessCheck[] = [
+        { key: `seed-meta:consumer-prices:overview:${code}`,      maxStaleMin: 1500 }, // 25h = 24h cron + 1h grace
+        { key: `seed-meta:consumer-prices:categories:${code}:30d`, maxStaleMin: 1500 },
+        { key: `seed-meta:consumer-prices:movers:${code}:30d`,     maxStaleMin: 1500 },
+        { key: `seed-meta:consumer-prices:spread:${code}`,         maxStaleMin: 1500 }, // producer's actual key shape
+        { key: `seed-meta:consumer-prices:freshness:${code}`,      maxStaleMin: 1500 },
+      ];
+
+      const [dataResults, metaResults] = await Promise.all([
+        Promise.all(dataKeys.map((k) => readJsonFromUpstash(k))),
+        Promise.all(freshnessChecks.map((c) => readJsonFromUpstash(c.key))),
+      ]);
+
+      const { cached_at, stale } = evaluateFreshness(freshnessChecks, metaResults);
+
+      return {
+        cached_at,
+        stale,
+        country_code: code,
+        data: {
+          overview: dataResults[0],
+          categories: dataResults[1],
+          movers: dataResults[2],
+          retailerSpread: dataResults[3],
+          freshness: dataResults[4],
+        },
+      };
     },
   },
   {

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -358,6 +358,40 @@ const TOOL_REGISTRY: ToolDef[] = [
     ],
   },
   {
+    name: 'get_energy_intelligence',
+    description: 'Energy supply, prices, storage, disruptions, and policy: EIA petroleum stocks, electricity prices (Ember), gas storage (GIE), fuel shortages, fossil & renewable shares, active energy disruptions, government crisis policies.',
+    inputSchema: { type: 'object', properties: {}, required: [] },
+    // Broad 9-key energy bundle mirroring get_economic_data. Cadences span
+    // hourly (electricity prices) to annual (World Bank renewable share); use
+    // _freshnessChecks with per-key maxStaleMin pulled from
+    // api/health.js::SEED_META so a slow-cadence key doesn't drag the
+    // aggregate stale flag unnecessarily.
+    _cacheKeys: [
+      'energy:eia-petroleum:v1',                  // STANDALONE_KEYS::eiaPetroleum
+      'energy:electricity:v1:index',              // BOOTSTRAP_KEYS::electricityPrices
+      'energy:ember:v1:_all',                     // STANDALONE_KEYS::emberElectricity
+      'energy:gas-storage:v1:_countries',         // BOOTSTRAP_KEYS::gasStorageCountries
+      'energy:fuel-shortages:v1',                 // STANDALONE_KEYS::fuelShortages
+      'energy:disruptions:v1',                    // STANDALONE_KEYS::energyDisruptions
+      'energy:crisis-policies:v1',                // STANDALONE_KEYS::energyCrisisPolicies
+      'resilience:fossil-electricity-share:v1',   // STANDALONE_KEYS::fossilElectricityShare
+      'economic:worldbank-renewable:v1',          // BOOTSTRAP_KEYS::renewableEnergy
+    ],
+    _seedMetaKey: 'seed-meta:energy:eia-petroleum',
+    _maxStaleMin: 4320, // EIA petroleum daily-bundle baseline; per-key budgets via _freshnessChecks below
+    _freshnessChecks: [
+      { key: 'seed-meta:energy:eia-petroleum',                  maxStaleMin: 4320 },   // daily bundle; 72h = 3× interval
+      { key: 'seed-meta:energy:electricity-prices',             maxStaleMin: 2880 },   // daily cron (14:00 UTC); 48h = 2× interval
+      { key: 'seed-meta:energy:ember',                          maxStaleMin: 2880 },   // daily cron (08:00 UTC); 48h = 2× interval
+      { key: 'seed-meta:energy:gas-storage-countries',          maxStaleMin: 2880 },   // daily cron at 10:30 UTC; 48h = 2× interval
+      { key: 'seed-meta:energy:fuel-shortages',                 maxStaleMin: 2880 },   // 2d — daily cron × 2 headroom
+      { key: 'seed-meta:energy:disruptions',                    maxStaleMin: 20160 },  // 14d — weekly cron × 2 headroom
+      { key: 'seed-meta:energy:crisis-policies',                maxStaleMin: 60 * 24 * 400 }, // ~400d static registry
+      { key: 'seed-meta:resilience:fossil-electricity-share',   maxStaleMin: 11520 },  // ~8d (annual WB-style cadence)
+      { key: 'seed-meta:economic:worldbank-renewable:v1',       maxStaleMin: 10080 },  // 7d WB weekly-cron annual data
+    ],
+  },
+  {
     name: 'get_climate_data',
     description: 'Climate intelligence: temperature/precipitation anomalies (vs 30-year WMO normals), climate-relevant disaster alerts (ReliefWeb/GDACS/FIRMS), atmospheric CO2 trend (NOAA Mauna Loa), air quality (OpenAQ/WAQI PM2.5 stations), Arctic sea ice extent and ocean heat indicators (NSIDC/NOAA), weather alerts, and climate news.',
     inputSchema: { type: 'object', properties: {}, required: [] },

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -9,7 +9,7 @@ WorldMonitor exposes its intelligence stack as a [Model Context Protocol](https:
 **Pro and API tiers can both connect via OAuth — no API key required.** Pro subscribers click _"Sign in with WorldMonitor Pro"_ on the consent page; API Starter / Business / Enterprise users may sign in the same way OR paste a `wm_…` key. Free-tier users see a 401 at the OAuth step.
 </Info>
 
-All paid tiers share the same MCP server, the same 32 tools, and the same OAuth flow — they differ only in **daily quotas**. Pro starts at **50 tool calls/day**; API Starter and API Business have generous daily allowances; Enterprise is uncapped. See the [Plans & limits](#plans--limits) table below.
+All paid tiers share the same MCP server, the same 38 tools, and the same OAuth flow — they differ only in **daily quotas**. Pro starts at **50 tool calls/day**; API Starter and API Business have generous daily allowances; Enterprise is uncapped. See the [Plans & limits](#plans--limits) table below.
 
 Pro subscribers can connect Claude Desktop / Cursor / claude.ai without ever pasting an API key — see [Pro sign-in flow](#pro-sign-in-flow) below. API Starter+ holders may continue to paste a `wm_…` key on the consent page (the original flow), or use the same OAuth path as Pro.
 
@@ -161,7 +161,7 @@ npx @modelcontextprotocol/inspector https://worldmonitor.app/mcp
 
 ## Tool catalog
 
-The server exposes 32 tools. Most are cache-reads over pre-seeded Redis keys (sub-second). Six (`get_world_brief`, `get_country_brief`, `analyze_situation`, `generate_forecasts`, `search_flights`, `search_flight_prices_by_date`) call live LLMs or external APIs and are slower.
+The server exposes 38 tools. Most are cache-reads over pre-seeded Redis keys (sub-second). Six (`get_world_brief`, `get_country_brief`, `analyze_situation`, `generate_forecasts`, `search_flights`, `search_flight_prices_by_date`) call live LLMs or external APIs and are slower.
 
 ### Markets & economy
 
@@ -175,7 +175,16 @@ The server exposes 32 tools. Most are cache-reads over pre-seeded Redis keys (su
 | `get_eu_industrial_production` | Eurostat monthly industrial production index, 12-month sparkline. |
 | `get_prediction_markets` | Active Polymarket event contracts with live probabilities. |
 | `get_supply_chain_data` | Dry bulk shipping stress index, customs flows, COMTRADE bilateral trade. |
+| `get_tariff_trends` | Global trade and pricing indicators: US tariff trends (HTS-coded), BigMac index, FAO Food Price Index, and per-country national debt levels. |
+| `get_chokepoint_status` | Live maritime chokepoint status: per-chokepoint vessel transit counts (10-min cadence), rolling transit summaries, per-port activity, plus static reference data and flow aggregates. Covers Suez, Hormuz, Malacca, Bab-el-Mandeb, Panama, etc. |
+| `get_consumer_prices` | Per-country consumer-prices intelligence: 30-day overview, category-level inflation, retailer spread (essentials basket), top movers, and source freshness. Requires `country_code` (currently only `ae` is seeded). |
 | `get_commodity_geo` | 71 major mining sites worldwide (gold, silver, copper, lithium, uranium, coal). |
+
+### Energy
+
+| Tool | Description |
+|------|-------------|
+| `get_energy_intelligence` | Energy supply, prices, storage, disruptions, and policy: EIA petroleum stocks, electricity prices (Ember), gas storage (GIE), fuel shortages, fossil & renewable shares, active energy disruptions, government crisis policies. |
 
 ### Geopolitical & security
 
@@ -209,6 +218,18 @@ The server exposes 32 tools. Most are cache-reads over pre-seeded Redis keys (su
 | `get_climate_data` | Temp/precip anomalies vs WMO normals, GDACS/FIRMS alerts, Mauna Loa CO2, OpenAQ PM2.5, sea ice, ocean heat. |
 | `get_radiation_data` | Global radiation monitoring station readings + anomaly flags. |
 | `get_research_signals` | Emerging technology events from curated research feeds. |
+
+### Health
+
+| Tool | Description |
+|------|-------------|
+| `get_health_signals` | Active disease outbreaks (WHO/ECDC etc.) and global air-quality station readings (OpenAQ/WAQI PM2.5). For health-risk screening. |
+
+### Humanitarian & displacement
+
+| Tool | Description |
+|------|-------------|
+| `get_displacement_data` | Refugee and IDP counts by country (UNHCR annual data). |
 
 ### AI intelligence (live LLM)
 

--- a/tests/mcp-bootstrap-parity.test.mjs
+++ b/tests/mcp-bootstrap-parity.test.mjs
@@ -289,20 +289,26 @@ const EXCLUDED_FROM_MCP = new Map([
     'operational: relay loop heartbeat — covered by /api/health, not a user-facing data slice for MCP.'],
 ]);
 
-// Resolve dynamic STANDALONE_KEYS entries (displacement embeds UTC year).
-function getSeededKeys() {
+// -----------------------------------------------------------------------------
+// Pure predicate helpers (no module-state coupling) — used by both the
+// live-state assertions below and the meta-tests at the bottom of the file
+// that verify these predicates actually fire on synthetic invalid inputs.
+//
+// Each helper takes inputs explicitly and returns the array of offending keys.
+// An empty array means "nothing wrong"; a non-empty array means "fail the test
+// and list these keys".
+// -----------------------------------------------------------------------------
+
+export function collectSeededKeys(bootstrapKeys, standaloneKeys) {
   return new Set([
-    ...Object.values(BOOTSTRAP_KEYS),
-    ...Object.values(STANDALONE_KEYS),
+    ...Object.values(bootstrapKeys),
+    ...Object.values(standaloneKeys),
   ]);
 }
 
-// Flatten all covered keys across the TOOL_REGISTRY:
-//   - CacheToolDef → entry._cacheKeys
-//   - RpcToolDef hybrid → entry._coverageKeys (optional)
-function getCoveredKeys() {
+export function collectCoveredKeys(toolRegistry) {
   const covered = new Set();
-  for (const tool of TOOL_REGISTRY) {
+  for (const tool of toolRegistry) {
     if (Array.isArray(tool._cacheKeys)) {
       for (const k of tool._cacheKeys) covered.add(k);
     }
@@ -313,17 +319,49 @@ function getCoveredKeys() {
   return covered;
 }
 
+/** Seeded keys that are neither covered nor excluded. */
+export function findUncoveredKeys({ seededKeys, coveredKeys, excludedMap }) {
+  const uncovered = [];
+  for (const key of seededKeys) {
+    if (coveredKeys.has(key)) continue;
+    if (excludedMap.has(key)) continue;
+    uncovered.push(key);
+  }
+  return uncovered;
+}
+
+/** Excluded entries whose reason is missing / empty / non-string. */
+export function findEmptyReasonExclusions(excludedMap) {
+  const offenders = [];
+  for (const [key, reason] of excludedMap) {
+    if (typeof reason !== 'string' || reason.trim().length === 0) offenders.push(key);
+  }
+  return offenders;
+}
+
+/** Excluded keys that are not actually in the seeded-key inventory. */
+export function findDeadExclusions({ excludedMap, seededKeys }) {
+  const dead = [];
+  for (const key of excludedMap.keys()) {
+    if (!seededKeys.has(key)) dead.push(key);
+  }
+  return dead;
+}
+
+/** Excluded keys that ARE covered by a tool (mutually-exclusive contract). */
+export function findRedundantExclusions({ excludedMap, coveredKeys }) {
+  const redundant = [];
+  for (const key of excludedMap.keys()) {
+    if (coveredKeys.has(key)) redundant.push(key);
+  }
+  return redundant;
+}
+
 describe('U7 — TOOL_REGISTRY ↔ BOOTSTRAP_KEYS+STANDALONE_KEYS parity', () => {
   it('every seeded cache key is covered by a tool or explicitly excluded', () => {
-    const seededKeys = getSeededKeys();
-    const coveredKeys = getCoveredKeys();
-
-    const uncovered = [];
-    for (const key of seededKeys) {
-      if (coveredKeys.has(key)) continue;
-      if (EXCLUDED_FROM_MCP.has(key)) continue;
-      uncovered.push(key);
-    }
+    const seededKeys = collectSeededKeys(BOOTSTRAP_KEYS, STANDALONE_KEYS);
+    const coveredKeys = collectCoveredKeys(TOOL_REGISTRY);
+    const uncovered = findUncoveredKeys({ seededKeys, coveredKeys, excludedMap: EXCLUDED_FROM_MCP });
 
     if (uncovered.length > 0) {
       const list = uncovered.map((k) => `  - ${k}`).join('\n');
@@ -338,31 +376,91 @@ describe('U7 — TOOL_REGISTRY ↔ BOOTSTRAP_KEYS+STANDALONE_KEYS parity', () =>
   });
 
   it('every EXCLUDED_FROM_MCP entry has a non-empty reason', () => {
-    for (const [key, reason] of EXCLUDED_FROM_MCP) {
-      assert.ok(
-        typeof reason === 'string' && reason.trim().length > 0,
-        `EXCLUDED_FROM_MCP entry "${key}" has an empty or non-string reason — every exclusion must be documented.`,
-      );
-    }
+    const offenders = findEmptyReasonExclusions(EXCLUDED_FROM_MCP);
+    assert.deepEqual(offenders, [], `EXCLUDED_FROM_MCP entries with empty/missing reason: ${offenders.join(', ')}`);
   });
 
   it('every EXCLUDED_FROM_MCP entry is present in BOOTSTRAP_KEYS or STANDALONE_KEYS (no dead exclusions)', () => {
-    const seededKeys = getSeededKeys();
-    for (const key of EXCLUDED_FROM_MCP.keys()) {
-      assert.ok(
-        seededKeys.has(key),
-        `EXCLUDED_FROM_MCP entry "${key}" is not in BOOTSTRAP_KEYS or STANDALONE_KEYS — dead exclusion, remove it.`,
-      );
-    }
+    const seededKeys = collectSeededKeys(BOOTSTRAP_KEYS, STANDALONE_KEYS);
+    const dead = findDeadExclusions({ excludedMap: EXCLUDED_FROM_MCP, seededKeys });
+    assert.deepEqual(dead, [], `Dead EXCLUDED_FROM_MCP entries (not in BOOTSTRAP_KEYS/STANDALONE_KEYS): ${dead.join(', ')}`);
   });
 
   it('EXCLUDED_FROM_MCP keys are not also covered by a tool (no redundant exclusions)', () => {
-    const coveredKeys = getCoveredKeys();
-    for (const key of EXCLUDED_FROM_MCP.keys()) {
-      assert.ok(
-        !coveredKeys.has(key),
-        `EXCLUDED_FROM_MCP entry "${key}" is also covered by a tool — exclusion is redundant, remove it from EXCLUDED_FROM_MCP.`,
-      );
-    }
+    const coveredKeys = collectCoveredKeys(TOOL_REGISTRY);
+    const redundant = findRedundantExclusions({ excludedMap: EXCLUDED_FROM_MCP, coveredKeys });
+    assert.deepEqual(redundant, [], `Redundant EXCLUDED_FROM_MCP entries (also covered by a tool): ${redundant.join(', ')}`);
+  });
+});
+
+// -----------------------------------------------------------------------------
+// Meta-tests — verify the predicate helpers above actually fire on synthetic
+// invalid fixtures. Without these, a regression that makes a predicate a no-op
+// (e.g. early return, predicate inversion, off-by-one filter) would ship
+// undetected because the live-state assertions only fail when the real
+// codebase is broken.
+// -----------------------------------------------------------------------------
+
+describe('U7 meta-tests — parity predicates fire on synthetic invalid inputs', () => {
+  it('findUncoveredKeys returns the synthetic seeded key that is neither covered nor excluded', () => {
+    const seededKeys = new Set(['ghost:key:v1', 'covered:key:v1', 'excluded:key:v1']);
+    const coveredKeys = new Set(['covered:key:v1']);
+    const excludedMap = new Map([['excluded:key:v1', 'documented reason']]);
+    const uncovered = findUncoveredKeys({ seededKeys, coveredKeys, excludedMap });
+    assert.deepEqual(uncovered, ['ghost:key:v1'], 'ghost:key:v1 must surface as uncovered');
+  });
+
+  it('findUncoveredKeys returns empty when every seeded key is covered or excluded', () => {
+    const seededKeys = new Set(['a:v1', 'b:v1']);
+    const coveredKeys = new Set(['a:v1']);
+    const excludedMap = new Map([['b:v1', 'because']]);
+    assert.deepEqual(findUncoveredKeys({ seededKeys, coveredKeys, excludedMap }), []);
+  });
+
+  it('findEmptyReasonExclusions catches empty-string and whitespace-only reasons', () => {
+    const excludedMap = new Map([
+      ['good:v1', 'documented reason'],
+      ['empty:v1', ''],
+      ['whitespace:v1', '   '],
+      ['nullish:v1', null],
+    ]);
+    const offenders = findEmptyReasonExclusions(excludedMap);
+    assert.deepEqual(offenders.sort(), ['empty:v1', 'nullish:v1', 'whitespace:v1']);
+  });
+
+  it('findDeadExclusions catches excluded keys absent from the seeded-key set', () => {
+    const excludedMap = new Map([
+      ['live:v1', 'reason'],
+      ['ghost:v1', 'reason'],
+    ]);
+    const seededKeys = new Set(['live:v1']);
+    assert.deepEqual(findDeadExclusions({ excludedMap, seededKeys }), ['ghost:v1']);
+  });
+
+  it('findRedundantExclusions catches keys that are both excluded AND covered by a tool', () => {
+    const excludedMap = new Map([
+      ['both:v1', 'reason'],
+      ['only-excluded:v1', 'reason'],
+    ]);
+    const coveredKeys = new Set(['both:v1']);
+    assert.deepEqual(findRedundantExclusions({ excludedMap, coveredKeys }), ['both:v1']);
+  });
+
+  it('collectCoveredKeys aggregates _cacheKeys + _coverageKeys across the registry', () => {
+    const registry = [
+      { name: 'cache_tool_a', _cacheKeys: ['a:v1', 'b:v1'] },
+      { name: 'cache_tool_b', _cacheKeys: ['c:v1'] },
+      { name: 'hybrid_tool', _coverageKeys: ['d:v1'], _execute: () => {} },
+      { name: 'rpc_tool_no_cache', _execute: () => {} }, // no _cacheKeys, no _coverageKeys
+    ];
+    const covered = collectCoveredKeys(registry);
+    assert.deepEqual([...covered].sort(), ['a:v1', 'b:v1', 'c:v1', 'd:v1']);
+  });
+
+  it('collectSeededKeys merges BOOTSTRAP and STANDALONE without duplicates', () => {
+    const bootstrap = { alpha: 'a:v1', beta: 'b:v1' };
+    const standalone = { gamma: 'c:v1', alphaAgain: 'a:v1' };
+    const seeded = collectSeededKeys(bootstrap, standalone);
+    assert.deepEqual([...seeded].sort(), ['a:v1', 'b:v1', 'c:v1']);
   });
 });

--- a/tests/mcp-bootstrap-parity.test.mjs
+++ b/tests/mcp-bootstrap-parity.test.mjs
@@ -1,0 +1,368 @@
+// U7 (Tier 3) — MCP parity test. Asserts that every canonical seeded cache key
+// in `api/health.js::BOOTSTRAP_KEYS` ∪ `STANDALONE_KEYS` is either:
+//   (a) covered by some `TOOL_REGISTRY[i]._cacheKeys` array (CacheToolDef), OR
+//   (b) covered by some `TOOL_REGISTRY[i]._coverageKeys` array (RpcToolDef hybrid), OR
+//   (c) listed in `EXCLUDED_FROM_MCP` below with a non-empty documented reason.
+//
+// Fail-hard: a new seed shipping its cache key into BOOTSTRAP_KEYS/STANDALONE_KEYS
+// without a corresponding MCP tool will fail CI until the contributor adds a tool
+// or adds an EXCLUDED_FROM_MCP entry with a reason. This is the structural fix
+// preventing future drift between the canonical seeded-data inventory and the
+// MCP tool registry.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { __testing__ as healthTesting } from '../api/health.js';
+import { __testing__ as mcpTesting } from '../api/mcp.ts';
+
+const { BOOTSTRAP_KEYS, STANDALONE_KEYS } = healthTesting;
+const { TOOL_REGISTRY } = mcpTesting;
+
+// -----------------------------------------------------------------------------
+// EXCLUDED_FROM_MCP — documented intentional omissions.
+//
+// Each entry: cache-key (verbatim from BOOTSTRAP_KEYS/STANDALONE_KEYS) → reason.
+// - Empty reasons are rejected.
+// - Dead exclusions (keys not in either inventory) are rejected.
+// - Redundant exclusions (keys ALSO covered by a tool) are rejected.
+//
+// Categories represented below (annotated inline):
+//   - intermediate:        low-level pipeline key whose data surfaces via a sibling tool.
+//   - on-demand:           populated lazily by RPC handlers; not seeded by cron.
+//   - cascade-mirror:      live/stale/backup fallback variant — covered by the canonical sibling.
+//   - shared-token-panel:  written by the shared token-panels seed run; covered by other panels.
+//   - deferred:            recognised gap; named follow-up tool/expansion not in this plan's scope.
+//   - dashboard-internal:  feeds a UI panel, not a queryable MCP slice.
+//   - operational:         relay heartbeats and similar — visible via /api/health, not MCP.
+// -----------------------------------------------------------------------------
+const EXCLUDED_FROM_MCP = new Map([
+
+  // ===========================================================================
+  // Intermediate / pipeline keys (data surfaces through a sibling tool)
+  // ===========================================================================
+  ['supply_chain:corridorrisk:v1',
+    'intermediate: data flows through transit-summaries:v1 (matches api/health.js:461 ON_DEMAND_KEYS rationale; explicitly NOT bundled into get_chokepoint_status to avoid duplicate exposure).'],
+  ['military:forecast-inputs:stale:v1',
+    'intermediate: seed-to-seed pipeline key, only populated after seed-military-flights runs (matches api/health.js:463 ON_DEMAND_KEYS rationale).'],
+
+  // ===========================================================================
+  // Cascade-mirror fallbacks (live/stale/backup of a sibling already exposed)
+  // ===========================================================================
+  ['theater-posture:sebuf:v1',
+    'cascade-mirror: live counterpart of theater_posture:sebuf:stale:v1 (covered by get_military_posture). CASCADE_GROUPS theaterPosture entry.'],
+  ['theater-posture:sebuf:backup:v1',
+    'cascade-mirror: backup counterpart of theater_posture:sebuf:stale:v1 (covered by get_military_posture). CASCADE_GROUPS theaterPosture entry.'],
+  ['risk:scores:sebuf:v1',
+    'cascade-mirror: live counterpart of risk:scores:sebuf:stale:v1 (covered by get_conflict_events).'],
+  ['military:flights:v1',
+    'cascade-mirror: live counterpart of military:flights:stale:v1 — deferred to a future expanded military tool (no current tool exposes either variant).'],
+  ['military:flights:stale:v1',
+    'cascade-mirror: stale fallback of military:flights:v1 — deferred to a future expanded military tool. CASCADE_GROUPS militaryFlights entry.'],
+  ['usni-fleet:sebuf:v1',
+    'cascade-mirror: live USNI fleet — deferred to a future military-fleet tool (no current tool exposes either variant).'],
+  ['usni-fleet:sebuf:stale:v1',
+    'cascade-mirror: stale USNI fleet — deferred to a future military-fleet tool.'],
+  ['displacement:summary:v1:' + (new Date().getUTCFullYear() - 1),
+    'cascade-mirror: previous-year displacement snapshot used by the dashboard year-over-year diff. Current-year key is exposed via get_displacement_data; the executeTool label-walk would collide on both years (matches api/health.js:482 + api/mcp.ts:346-350 rationale).'],
+  ['positive-events:geo:v1',
+    'cascade-mirror: live counterpart of positive_events:geo-bootstrap:v1 (covered by get_positive_events).'],
+  ['aviation:delays:faa:v1',
+    'cascade-mirror: RPC variant of aviation:delays-bootstrap:v1 (covered by get_aviation_status). Same seed-meta key (seed-meta:aviation:faa).'],
+  ['cyber:threats:v2',
+    'cascade-mirror: RPC variant of cyber:threats-bootstrap:v2 (covered by get_cyber_threats). Same seed-meta key (seed-meta:cyber:threats).'],
+  ['aviation:delays:intl:v3',
+    'cascade-mirror: international delays sibling of aviation:delays-bootstrap:v1 (covered by get_aviation_status) — deferred to a future expanded aviation tool that exposes the intl variant directly.'],
+  ['aviation:notam:closures:v2',
+    'cascade-mirror: NOTAM closures sibling of aviation:delays-bootstrap:v1 (covered by get_aviation_status) — deferred to a future expanded aviation tool that exposes NOTAMs directly.'],
+  ['supply_chain:portwatch:v1',
+    'cascade-mirror: PortWatch aggregate; per-port detail (supply_chain:portwatch-ports:v1:_countries) is the canonical key already exposed via get_chokepoint_status.'],
+
+  // ===========================================================================
+  // On-demand / RPC-populated keys (no dedicated seed cron)
+  // ===========================================================================
+  ['infra:service-statuses:v1',
+    'on-demand: RPC-populated, seed-meta written on fresh fetch only, goes stale between visits (matches api/health.js:462 ON_DEMAND_KEYS rationale).'],
+  ['economic:macro-signals:v1',
+    'on-demand: RPC cache for derived macro-signals panel; underlying inputs already exposed via get_economic_data.'],
+  ['economic:bis:policy:v1',
+    'on-demand: RPC cache for BIS policy-rates extras (matches api/health.js:456 ON_DEMAND_KEYS rationale).'],
+  ['economic:bis:eer:v1',
+    'on-demand: RPC cache for BIS effective exchange rates (matches api/health.js:456 ON_DEMAND_KEYS rationale).'],
+  ['economic:bis:credit:v1',
+    'on-demand: RPC cache for BIS credit-to-GDP (matches api/health.js:456 ON_DEMAND_KEYS rationale).'],
+  ['supply_chain:shipping:v2',
+    'on-demand: cache populated on first user query; shipping-stress index (supply_chain:shipping_stress:v1) is the canonical seeded key already exposed via get_supply_chain_data.'],
+  ['supply_chain:chokepoints:v4',
+    'on-demand: superseded by the transit-summaries + chokepoint-flows + portwatch-ports bundle exposed via get_chokepoint_status.'],
+  ['supply_chain:minerals:v2',
+    'on-demand: RPC cache populated only after first user query — deferred to a future minerals/strategic-materials tool.'],
+  ['giving:summary:v1',
+    'on-demand: RPC cache for philanthropy summary; not in v1 brainstorm inventory. Deferred to a future humanitarian/aid tool.'],
+  ['military:bases:active',
+    'on-demand: RPC cache for military bases — deferred to a future expanded military tool.'],
+  ['temporal:anomalies:v1',
+    'on-demand: RPC cache populated only after first user query — deferred to a future temporal-analysis tool.'],
+  ['news:threat:summary:v1',
+    'on-demand: relay-classify-only, written only when classify produces country matches (matches api/health.js:468 ON_DEMAND_KEYS rationale). Underlying news inputs already exposed via get_news_intelligence.'],
+  ['resilience:ranking:v18',
+    'on-demand: RPC cache populated after Pro ranking requests (matches api/health.js:469 ON_DEMAND_KEYS rationale). Deferred to a future resilience tool.'],
+  ['forecast:simulation-package:latest',
+    'on-demand: written by writeSimulationPackage after deep forecast runs (matches api/health.js:466 ON_DEMAND_KEYS rationale). Internal pipeline artifact, not a queryable slice.'],
+  ['forecast:simulation-outcome:latest',
+    'on-demand: written by writeSimulationOutcome after simulation runs (matches api/health.js:467 ON_DEMAND_KEYS rationale). Internal pipeline artifact, not a queryable slice.'],
+
+  // ===========================================================================
+  // Recovery pillar (stub seeders, not yet deployed) — per api/health.js:470-471
+  // ===========================================================================
+  ['resilience:recovery:fiscal-space:v1',
+    'deferred: recovery pillar stub seeder, not yet deployed (api/health.js:470-471 ON_DEMAND_KEYS). Future resilience tool will expose recovery dimensions.'],
+  ['resilience:recovery:reserve-adequacy:v1',
+    'deferred: recovery pillar stub seeder, not yet deployed (api/health.js:470-471).'],
+  ['resilience:recovery:external-debt:v1',
+    'deferred: recovery pillar stub seeder, not yet deployed (api/health.js:470-471).'],
+  ['resilience:recovery:import-hhi:v1',
+    'deferred: recovery pillar stub seeder, not yet deployed (api/health.js:470-471).'],
+  ['resilience:recovery:fuel-stocks:v1',
+    'deferred: recovery pillar stub seeder, not yet deployed (api/health.js:470-471).'],
+  ['resilience:recovery:reexport-share:v1',
+    'deferred: recovery pillar stub seeder, not yet deployed.'],
+  ['resilience:recovery:sovereign-wealth:v1',
+    'deferred: recovery pillar stub seeder, not yet deployed.'],
+
+  // ===========================================================================
+  // Deferred follow-up tools (explicit gaps named in the plan or related domain)
+  // ===========================================================================
+  ['intelligence:gpsjam:v2',
+    'deferred to a future intelligence tool (per plan U7 expected exclusions).'],
+  ['bls:series:v1',
+    'deferred to a future labor-statistics tool (per plan U7 expected exclusions). BLS economic series already partially surfaced via FRED bundles in get_economic_data.'],
+  ['economic:fx:yoy:v1',
+    'deferred: derived FX year-over-year cache; underlying ECB FX rates already exposed via get_economic_data (economic:ecb-fx-rates:v1).'],
+  ['intelligence:satellites:tle:v1',
+    'deferred to a future space-domain tool. Not in v1 brainstorm inventory.'],
+  ['intelligence:pizzint:seed:v1',
+    'deferred to a future expanded intelligence tool. Not in v1 brainstorm inventory.'],
+  ['intelligence:wsb-tickers:v1',
+    'deferred: companion to get_social_velocity (Reddit r/wallstreetbets sentiment). Future expanded social-sentiment tool would bundle this with reddit feed.'],
+  ['intelligence:telegram-feed:v1',
+    'deferred to a future OSINT tool. Not in v1 brainstorm inventory.'],
+  ['intelligence:regional-snapshots:summary:v1',
+    'deferred to a future region-aware intelligence tool.'],
+  ['intelligence:regional-briefs:summary:v1',
+    'deferred to a future region-aware intelligence tool.'],
+  ['intelligence:market-implications:v1',
+    'deferred: LLM-generated narrative composite; underlying inputs already exposed via existing data tools. A future LLM-narrative tool would bundle this.'],
+  ['supply_chain:hormuz_tracker:v1',
+    'deferred: specialized Strait-of-Hormuz tracker; broader chokepoint coverage via get_chokepoint_status. Hormuz-specific tool deferred.'],
+  ['thermal:escalation:v1',
+    'deferred to a future conflict-escalation tool.'],
+  ['resilience:static:index:v1',
+    'deferred to a future resilience tool (paired with resilience:ranking:v18).'],
+  ['resilience:static:fao',
+    'deferred to a future resilience tool (FAO Phase 3+ aggregate, paired with resilience:static:index:v1).'],
+  ['resilience:intervals:v2:US',
+    'deferred to a future resilience tool (uncertainty intervals on top of resilience:ranking:v18).'],
+  ['resilience:low-carbon-generation:v1',
+    'deferred to a future resilience tool. Companion data to fossil-electricity-share (already exposed via get_energy_intelligence).'],
+  ['resilience:power-losses:v1',
+    'deferred to a future resilience tool. Companion data to the resilience v2 energy bundle.'],
+  ['product-catalog:v2',
+    'deferred to a future product-catalog tool. Used by the dashboard to render product metadata, not a queryable data slice.'],
+  ['climate:zone-normals:v1',
+    'deferred to a future climate-baseline tool. Reference data (30-year WMO normals) used as a denominator for climate:anomalies:v2 (already exposed via get_climate_data).'],
+  ['regulatory:actions:v1',
+    'deferred to a future regulatory/compliance tool. Not in v1 brainstorm inventory.'],
+  ['economic:grocery-basket:v1',
+    'deferred: per-country grocery basket index; complements consumer-prices (already exposed via get_consumer_prices). Future expanded consumer-prices tool would include this.'],
+  ['economic:bis-lbs:v1',
+    'deferred to a future expanded BIS tool. BIS DSR + property prices already exposed via get_economic_data; LBS (locational banking statistics) is a more specialised series.'],
+  ['economic:fatf-listing:v1',
+    'deferred to a future compliance/AML tool. FATF grey/black-listing is policy data, complement to sanctions (already exposed via get_sanctions_data).'],
+  ['economic:wb-external-debt:v1',
+    'deferred to a future World-Bank-detail tool. Annual external debt (WB IDS) companion to current account already in get_country_macro.'],
+  ['economic:worldbank-techreadiness:v1',
+    'deferred to a future World-Bank-detail tool. Tech-readiness composite — not in v1 brainstorm inventory.'],
+  ['economic:worldbank-progress:v1',
+    'deferred to a future World-Bank-detail tool. Development-progress composite — not in v1 brainstorm inventory.'],
+  ['economic:eurostat-country-data:v1',
+    'deferred: Eurostat aggregate panel; the three discrete Eurostat series (house prices, gov-debt-q, industrial production) are already individually exposed via dedicated tools. The aggregate is redundant for MCP consumers.'],
+  ['economic:fsi-eu:v1',
+    'deferred: EU Financial Stress Index composite — not in v1 brainstorm inventory.'],
+  ['economic:eu-gas-storage:v1',
+    'deferred: per-country EU gas storage aggregate; energy:gas-storage:v1:_countries (canonical per-country breakdown) is already exposed via get_energy_intelligence.'],
+  ['economic:crude-inventories:v1',
+    'deferred to a future expanded energy tool. EIA weekly crude inventories sibling of energy:eia-petroleum:v1 (already exposed via get_energy_intelligence as the petroleum-stocks aggregate).'],
+  ['economic:nat-gas-storage:v1',
+    'deferred to a future expanded energy tool. EIA weekly natural-gas storage; complement to energy:gas-storage:v1:_countries (GIE) already exposed via get_energy_intelligence.'],
+  ['economic:refinery-inputs:v1',
+    'deferred to a future expanded energy tool. EIA weekly refinery inputs — petroleum domain, complement to energy:eia-petroleum:v1.'],
+  ['economic:spr:v1',
+    'deferred to a future expanded energy tool. EIA SPR weekly volumes — companion to energy:spr-policies:v1 (also deferred).'],
+  ['economic:stress-index:v1',
+    'deferred: derived economic stress composite; underlying inputs already exposed via get_economic_data. A future composite-narrative tool would bundle this.'],
+  ['economic:fred:v1:GSCPI:0',
+    'deferred: NY Fed Global Supply Chain Pressure Index (single FRED series); supply-chain pressure already broadly covered via get_supply_chain_data + get_chokepoint_status. Future composite supply-chain tool could expose this.'],
+  ['economic:fred:v1:ESTR:0',
+    'deferred: ECB €STR short-rate (single FRED series). Future expanded rates tool. Fed Funds (economic:fred:v1:FEDFUNDS:0) already exposed via get_economic_data.'],
+  ['economic:fred:v1:EURIBOR3M:0',
+    'deferred: EURIBOR 3-month rate (single FRED series). Future expanded rates tool.'],
+  ['economic:fred:v1:EURIBOR6M:0',
+    'deferred: EURIBOR 6-month rate (single FRED series). Future expanded rates tool.'],
+  ['economic:fred:v1:EURIBOR1Y:0',
+    'deferred: EURIBOR 1-year rate (single FRED series). Future expanded rates tool.'],
+  ['health:vpd-tracker:realtime:v1',
+    'deferred: vaccine-preventable disease tracker (realtime); covered partially by disease-outbreaks already in get_health_signals. Future expanded health tool would bundle the VPD-specific series.'],
+  ['health:vpd-tracker:historical:v1',
+    'deferred: vaccine-preventable disease tracker (historical); pair with health:vpd-tracker:realtime:v1.'],
+  ['market:hyperliquid:flow:v1',
+    'deferred to a future expanded crypto/DEX tool. Hyperliquid flow is a single-venue signal; broader crypto coverage via market:crypto:v1 (in get_market_data).'],
+  ['market:stablecoins:v1',
+    'deferred to a future expanded crypto tool. Stablecoin issuance is a specialised slice on top of market:crypto:v1 (already exposed via get_market_data).'],
+  ['market:defi-tokens:v1',
+    'deferred to a future expanded crypto tool. Shared seed-meta (seed-meta:market:token-panels) with ai-tokens + other-tokens.'],
+  ['market:ai-tokens:v1',
+    'deferred to a future expanded crypto tool. Shared seed-meta (seed-meta:market:token-panels) with defi-tokens + other-tokens.'],
+  ['market:other-tokens:v1',
+    'deferred to a future expanded crypto tool. Shared seed-meta (seed-meta:market:token-panels) with defi-tokens + ai-tokens.'],
+  ['market:gold-extended:v1',
+    'deferred to a future expanded commodities tool. Headline gold futures (GC=F) already exposed via get_market_data (market:commodities-bootstrap:v1).'],
+  ['market:gold-etf-flows:v1',
+    'deferred to a future expanded commodities tool. SPDR GLD flows; complement to market:gold-extended:v1.'],
+  ['market:gold-cb-reserves:v1',
+    'deferred to a future expanded commodities tool. IMF IFS monthly central-bank gold reserves.'],
+  ['market:breadth-history:v1',
+    'deferred to a future expanded markets tool. Equity breadth history is a specialised slice on top of market:sectors:v2 (already exposed via get_market_data).'],
+  ['market:aaii-sentiment:v1',
+    'deferred to a future expanded markets tool. AAII sentiment survey is a specialised weekly signal.'],
+  ['market:crypto-sectors:v1',
+    'deferred to a future expanded crypto tool. Sector-level crypto signal on top of market:crypto:v1.'],
+  ['cf:radar:ddos:v1',
+    'deferred to a future internet-health/cyber tool. Cloudflare Radar DDoS data — complement to infra:outages:v1 (already exposed via get_infrastructure_status).'],
+  ['cf:radar:traffic-anomalies:v1',
+    'deferred to a future internet-health/cyber tool. Cloudflare Radar traffic-anomaly data — complement to infra:outages:v1.'],
+  ['correlation:cards-bootstrap:v1',
+    'deferred: derived market-correlation card deck used by the dashboard; underlying inputs (market:sectors:v2 etc.) already exposed via get_market_data. A future correlation-analysis tool would expose this.'],
+  ['energy:iea-oil-stocks:v1:index',
+    'deferred to a future expanded energy tool. IEA OECD oil-stocks index — companion to energy:eia-petroleum:v1 (US weekly petroleum stocks already exposed via get_energy_intelligence). Monthly IEA cadence vs weekly EIA — distinct release.'],
+  ['energy:intelligence:feed:v1',
+    'deferred: derived energy-intelligence narrative feed (LLM-generated); underlying energy inputs already exposed via get_energy_intelligence. A future LLM-narrative tool would expose this.'],
+  ['cable-health-v1',
+    'deferred to a future maritime-infrastructure tool. Subsea cable disruption tracker — not in v1 brainstorm inventory.'],
+
+  // ---- Energy supplementary keys not bundled into get_energy_intelligence ----
+  // get_energy_intelligence covers the 9 headline keys (EIA petroleum,
+  // electricity prices, Ember, gas storage, fuel shortages, disruptions,
+  // crisis policies, fossil/renewable shares). The keys below are
+  // specialised/per-country/infrastructure-registry slices on top of those —
+  // deferred to a future expanded energy tool, not legitimate exclusions
+  // (could be a follow-up tool).
+  ['energy:spine:v1:_countries',
+    'deferred: per-country energy spine index; covered indirectly via get_energy_intelligence headline aggregates. Future expanded per-country energy tool would expose this.'],
+  ['energy:exposure:v1:index',
+    'deferred: OWID energy-mix exposure index; get_energy_intelligence covers the headline energy bundle. Future detailed energy-mix tool would expose this.'],
+  ['energy:mix:v1:_all',
+    'deferred: OWID energy-mix full panel; future detailed energy-mix tool would expose this.'],
+  ['energy:oil-stocks-analysis:v1',
+    'deferred: LLM-generated narrative on top of energy:iea-oil-stocks:v1:index; future LLM-narrative tool would expose this.'],
+  ['energy:jodi-gas:v1:_countries',
+    'deferred: JODI per-country gas breakdown; future per-country energy tool.'],
+  ['energy:lng-vulnerability:v1',
+    'deferred: LNG vulnerability composite; future LNG-specific tool.'],
+  ['energy:jodi-oil:v1:_countries',
+    'deferred: JODI per-country oil breakdown; future per-country energy tool.'],
+  ['energy:spr-policies:v1',
+    'deferred: SPR policy registry; future SPR/policy tool. Distinct from energy volumes in get_energy_intelligence.'],
+  ['energy:pipelines:gas:v1',
+    'deferred: gas pipeline registry; future infrastructure-focused energy tool.'],
+  ['energy:pipelines:oil:v1',
+    'deferred: oil pipeline registry; future infrastructure-focused energy tool.'],
+  ['energy:storage-facilities:v1',
+    'deferred: energy storage-facility registry; future infrastructure-focused energy tool.'],
+
+  // ===========================================================================
+  // Operational (visible via /api/health, not user-facing data)
+  // ===========================================================================
+  ['relay:heartbeat:chokepoint-flows',
+    'operational: relay loop heartbeat — covered by /api/health, not a user-facing data slice for MCP.'],
+  ['relay:heartbeat:climate-news',
+    'operational: relay loop heartbeat — covered by /api/health, not a user-facing data slice for MCP.'],
+]);
+
+// Resolve dynamic STANDALONE_KEYS entries (displacement embeds UTC year).
+function getSeededKeys() {
+  return new Set([
+    ...Object.values(BOOTSTRAP_KEYS),
+    ...Object.values(STANDALONE_KEYS),
+  ]);
+}
+
+// Flatten all covered keys across the TOOL_REGISTRY:
+//   - CacheToolDef → entry._cacheKeys
+//   - RpcToolDef hybrid → entry._coverageKeys (optional)
+function getCoveredKeys() {
+  const covered = new Set();
+  for (const tool of TOOL_REGISTRY) {
+    if (Array.isArray(tool._cacheKeys)) {
+      for (const k of tool._cacheKeys) covered.add(k);
+    }
+    if (Array.isArray(tool._coverageKeys)) {
+      for (const k of tool._coverageKeys) covered.add(k);
+    }
+  }
+  return covered;
+}
+
+describe('U7 — TOOL_REGISTRY ↔ BOOTSTRAP_KEYS+STANDALONE_KEYS parity', () => {
+  it('every seeded cache key is covered by a tool or explicitly excluded', () => {
+    const seededKeys = getSeededKeys();
+    const coveredKeys = getCoveredKeys();
+
+    const uncovered = [];
+    for (const key of seededKeys) {
+      if (coveredKeys.has(key)) continue;
+      if (EXCLUDED_FROM_MCP.has(key)) continue;
+      uncovered.push(key);
+    }
+
+    if (uncovered.length > 0) {
+      const list = uncovered.map((k) => `  - ${k}`).join('\n');
+      throw new Error(
+        `${uncovered.length} seeded cache key(s) are not covered by any MCP tool and not in EXCLUDED_FROM_MCP:\n` +
+        `${list}\n\n` +
+        `Add the key(s) to a TOOL_REGISTRY entry (\`_cacheKeys\` for cache-tools, \`_coverageKeys\` ` +
+        `for \`_execute\` hybrids) OR add to EXCLUDED_FROM_MCP in tests/mcp-bootstrap-parity.test.mjs ` +
+        `with a documented reason.`
+      );
+    }
+  });
+
+  it('every EXCLUDED_FROM_MCP entry has a non-empty reason', () => {
+    for (const [key, reason] of EXCLUDED_FROM_MCP) {
+      assert.ok(
+        typeof reason === 'string' && reason.trim().length > 0,
+        `EXCLUDED_FROM_MCP entry "${key}" has an empty or non-string reason — every exclusion must be documented.`,
+      );
+    }
+  });
+
+  it('every EXCLUDED_FROM_MCP entry is present in BOOTSTRAP_KEYS or STANDALONE_KEYS (no dead exclusions)', () => {
+    const seededKeys = getSeededKeys();
+    for (const key of EXCLUDED_FROM_MCP.keys()) {
+      assert.ok(
+        seededKeys.has(key),
+        `EXCLUDED_FROM_MCP entry "${key}" is not in BOOTSTRAP_KEYS or STANDALONE_KEYS — dead exclusion, remove it.`,
+      );
+    }
+  });
+
+  it('EXCLUDED_FROM_MCP keys are not also covered by a tool (no redundant exclusions)', () => {
+    const coveredKeys = getCoveredKeys();
+    for (const key of EXCLUDED_FROM_MCP.keys()) {
+      assert.ok(
+        !coveredKeys.has(key),
+        `EXCLUDED_FROM_MCP entry "${key}" is also covered by a tool — exclusion is redundant, remove it from EXCLUDED_FROM_MCP.`,
+      );
+    }
+  });
+});

--- a/tests/mcp-bootstrap-parity.test.mjs
+++ b/tests/mcp-bootstrap-parity.test.mjs
@@ -299,14 +299,14 @@ const EXCLUDED_FROM_MCP = new Map([
 // and list these keys".
 // -----------------------------------------------------------------------------
 
-export function collectSeededKeys(bootstrapKeys, standaloneKeys) {
+function collectSeededKeys(bootstrapKeys, standaloneKeys) {
   return new Set([
     ...Object.values(bootstrapKeys),
     ...Object.values(standaloneKeys),
   ]);
 }
 
-export function collectCoveredKeys(toolRegistry) {
+function collectCoveredKeys(toolRegistry) {
   const covered = new Set();
   for (const tool of toolRegistry) {
     if (Array.isArray(tool._cacheKeys)) {
@@ -320,7 +320,7 @@ export function collectCoveredKeys(toolRegistry) {
 }
 
 /** Seeded keys that are neither covered nor excluded. */
-export function findUncoveredKeys({ seededKeys, coveredKeys, excludedMap }) {
+function findUncoveredKeys({ seededKeys, coveredKeys, excludedMap }) {
   const uncovered = [];
   for (const key of seededKeys) {
     if (coveredKeys.has(key)) continue;
@@ -331,7 +331,7 @@ export function findUncoveredKeys({ seededKeys, coveredKeys, excludedMap }) {
 }
 
 /** Excluded entries whose reason is missing / empty / non-string. */
-export function findEmptyReasonExclusions(excludedMap) {
+function findEmptyReasonExclusions(excludedMap) {
   const offenders = [];
   for (const [key, reason] of excludedMap) {
     if (typeof reason !== 'string' || reason.trim().length === 0) offenders.push(key);
@@ -340,7 +340,7 @@ export function findEmptyReasonExclusions(excludedMap) {
 }
 
 /** Excluded keys that are not actually in the seeded-key inventory. */
-export function findDeadExclusions({ excludedMap, seededKeys }) {
+function findDeadExclusions({ excludedMap, seededKeys }) {
   const dead = [];
   for (const key of excludedMap.keys()) {
     if (!seededKeys.has(key)) dead.push(key);
@@ -349,7 +349,7 @@ export function findDeadExclusions({ excludedMap, seededKeys }) {
 }
 
 /** Excluded keys that ARE covered by a tool (mutually-exclusive contract). */
-export function findRedundantExclusions({ excludedMap, coveredKeys }) {
+function findRedundantExclusions({ excludedMap, coveredKeys }) {
   const redundant = [];
   for (const key of excludedMap.keys()) {
     if (coveredKeys.has(key)) redundant.push(key);

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -135,6 +135,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     const toolNames = body.result.tools.map((t) => t.name);
     assert.ok(toolNames.includes('get_displacement_data'), 'get_displacement_data must be registered (U1 Tier 1 regression)');
     assert.ok(toolNames.includes('get_health_signals'), 'get_health_signals must be registered (U2)');
+    assert.ok(toolNames.includes('get_energy_intelligence'), 'get_energy_intelligence must be registered (U3)');
     assert.ok(toolNames.includes('get_consumer_prices'), 'get_consumer_prices must be registered (U4)');
     assert.ok(toolNames.includes('get_tariff_trends'), 'get_tariff_trends must be registered (U5)');
     assert.ok(toolNames.includes('get_chokepoint_status'), 'get_chokepoint_status must be registered (U6)');
@@ -614,14 +615,15 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(payload.error, 'country_code is required');
   });
 
-  it('get_consumer_prices: 5 null keys yields stale=true + cached_at=null (does NOT throw)', async () => {
+  it('get_consumer_prices throws cache_all_null (→ -32603) when every 5 cache reads return null', async () => {
     process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
     process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
 
-    // Every GET returns {} (no `result`) — readJsonFromUpstash → null for both
-    // data keys and seed-meta keys. The hybrid _execute does NOT run the
-    // cache_all_null guard (that's a CacheToolDef-only path inside executeTool),
-    // so the response surfaces 5 nulls with stale=true and cached_at=null.
+    // F6 contract parity with the cache-tool path: hybrid _execute mirrors the
+    // executeTool cache_all_null guard so the Pro quota counter is rolled back
+    // on degenerate-empty responses (Redis transient / pre-seed). Without this
+    // guard, every other cache-tool throws on all-null while this one would
+    // return success and silently burn a quota tick.
     globalThis.fetch = async () => new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
 
     const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
@@ -633,15 +635,28 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     }));
     assert.equal(res.status, 200);
     const body = await res.json();
-    assert.ok(body.result?.content, 'empty cache must surface a result (not -32603) for hybrid _execute');
-    const payload = JSON.parse(body.result.content[0].text);
-    assert.equal(payload.stale, true, 'no valid meta → stale=true');
-    assert.equal(payload.cached_at, null, 'no valid meta → cached_at=null');
-    assert.equal(payload.data.overview, null);
-    assert.equal(payload.data.categories, null);
-    assert.equal(payload.data.movers, null);
-    assert.equal(payload.data.retailerSpread, null);
-    assert.equal(payload.data.freshness, null);
+    assert.equal(body.error?.code, -32603, 'all-5-null reads must surface as -32603 cache_all_null');
+  });
+
+  it('get_consumer_prices rejects oversized/non-alpha country_code (e.g. "aexxx", "AE-DXB") with result-level error', async () => {
+    // Without strict /^[a-z]{2}$/ validation, `.slice(0,2)` would silently
+    // truncate "aexxx" → "ae" and serve AE data — masking client-side bugs.
+    for (const bad of ['aexxx', 'AE-DXB', 'a', 'A1', '1AE', 'ae-']) {
+      const res = await handler(makeReq('POST', {
+        jsonrpc: '2.0', id: 305, method: 'tools/call',
+        params: { name: 'get_consumer_prices', arguments: { country_code: bad } },
+      }));
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.ok(body.result?.content, `bad country_code ${JSON.stringify(bad)} must return a result, not -32603`);
+      assert.equal(body.error, undefined);
+      const payload = JSON.parse(body.result.content[0].text);
+      assert.equal(
+        payload.error,
+        'country_code must be a two-letter ISO code (e.g. "ae")',
+        `${JSON.stringify(bad)} must be rejected by the strict-shape guard`,
+      );
+    }
   });
 
   // --- get_tariff_trends (U5: trade + economic indicator bundle) ---
@@ -1045,6 +1060,142 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(payload.data['chokepoint-flows'], null, 'missing chokepoint-flows slice surfaces as null');
     assert.equal(payload.stale, true, 'missing meta forces stale=true (hasAllValidMeta=false)');
     assert.equal(payload.cached_at, null, 'mixed-validity meta yields cached_at=null per evaluateFreshness contract');
+  });
+
+  // --- get_energy_intelligence (U3: 9-key energy bundle) ---
+
+  it('get_energy_intelligence returns 9-slice data on cache hit when every per-key meta is within budget', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    const eiaPayload = { weeklySeries: [{ week: '2026-W18', stocks: 832.1 }] };
+    const electricityPayload = { countries: [{ iso: 'DE', priceEurMwh: 88 }] };
+    const emberPayload = { regions: [{ id: 'EU', cleanShare: 0.62 }] };
+    const gasStoragePayload = { countries: [{ iso: 'DE', fillPct: 71 }] };
+    const fuelShortagesPayload = { countries: [{ iso: 'CU', severity: 'high' }] };
+    const disruptionsPayload = { events: [{ id: 'pipe-2026-04-21', region: 'Levant' }] };
+    const crisisPolicyPayload = { policies: [{ country: 'DE', kind: 'price-cap' }] };
+    const fossilSharePayload = { countries: [{ iso: 'PL', fossilSharePct: 73 }] };
+    const renewablePayload = { countries: [{ iso: 'IS', renewablePct: 84 }] };
+
+    // Budgets: eiaPetroleum=4320min, electricity-prices=2880, ember=2880, gas-storage=2880,
+    // fuel-shortages=2880, disruptions=20160, crisis-policies=~400d, fossil-share=11520, renewable=10080.
+    // All fetchedAts within their per-key budgets; oldest = crisisPolicy (30d old, within 400d budget)
+    // anchors cached_at — exercises the wide budget-asymmetry property.
+    const eiaFetchedAt           = Date.now() - 60 * 60_000;
+    const electricityFetchedAt   = Date.now() - 30 * 60_000;
+    const emberFetchedAt         = Date.now() - 24 * 60 * 60_000;
+    const gasStorageFetchedAt    = Date.now() - 12 * 60 * 60_000;
+    const fuelShortagesFetchedAt = Date.now() - 12 * 60 * 60_000;
+    const disruptionsFetchedAt   = Date.now() - 5 * 24 * 60 * 60_000;
+    const crisisPolicyFetchedAt  = Date.now() - 30 * 24 * 60 * 60_000;  // OLDEST valid → anchors cached_at (within ~400d budget)
+    const fossilShareFetchedAt   = Date.now() - 7 * 24 * 60 * 60_000;
+    const renewableFetchedAt     = Date.now() - 6 * 24 * 60 * 60_000;
+
+    const JSON_HDR = { 'Content-Type': 'application/json' };
+    globalThis.fetch = async (url) => {
+      const u = url.toString();
+      // Data keys
+      if (u.includes(`/get/${encodeURIComponent('energy:eia-petroleum:v1')}`)) return new Response(JSON.stringify({ result: JSON.stringify(eiaPayload) }), { status: 200, headers: JSON_HDR });
+      if (u.includes(`/get/${encodeURIComponent('energy:electricity:v1:index')}`)) return new Response(JSON.stringify({ result: JSON.stringify(electricityPayload) }), { status: 200, headers: JSON_HDR });
+      if (u.includes(`/get/${encodeURIComponent('energy:ember:v1:_all')}`)) return new Response(JSON.stringify({ result: JSON.stringify(emberPayload) }), { status: 200, headers: JSON_HDR });
+      if (u.includes(`/get/${encodeURIComponent('energy:gas-storage:v1:_countries')}`)) return new Response(JSON.stringify({ result: JSON.stringify(gasStoragePayload) }), { status: 200, headers: JSON_HDR });
+      if (u.includes(`/get/${encodeURIComponent('energy:fuel-shortages:v1')}`)) return new Response(JSON.stringify({ result: JSON.stringify(fuelShortagesPayload) }), { status: 200, headers: JSON_HDR });
+      if (u.includes(`/get/${encodeURIComponent('energy:disruptions:v1')}`)) return new Response(JSON.stringify({ result: JSON.stringify(disruptionsPayload) }), { status: 200, headers: JSON_HDR });
+      if (u.includes(`/get/${encodeURIComponent('energy:crisis-policies:v1')}`)) return new Response(JSON.stringify({ result: JSON.stringify(crisisPolicyPayload) }), { status: 200, headers: JSON_HDR });
+      if (u.includes(`/get/${encodeURIComponent('resilience:fossil-electricity-share:v1')}`)) return new Response(JSON.stringify({ result: JSON.stringify(fossilSharePayload) }), { status: 200, headers: JSON_HDR });
+      if (u.includes(`/get/${encodeURIComponent('economic:worldbank-renewable:v1')}`)) return new Response(JSON.stringify({ result: JSON.stringify(renewablePayload) }), { status: 200, headers: JSON_HDR });
+      // Meta keys (note: shape differs from cache-key shape — match seed-meta keys per producer)
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:energy:eia-petroleum')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: eiaFetchedAt, recordCount: 1 }) }), { status: 200, headers: JSON_HDR });
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:energy:electricity-prices')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: electricityFetchedAt, recordCount: 1 }) }), { status: 200, headers: JSON_HDR });
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:energy:ember')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: emberFetchedAt, recordCount: 1 }) }), { status: 200, headers: JSON_HDR });
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:energy:gas-storage-countries')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: gasStorageFetchedAt, recordCount: 1 }) }), { status: 200, headers: JSON_HDR });
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:energy:fuel-shortages')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: fuelShortagesFetchedAt, recordCount: 1 }) }), { status: 200, headers: JSON_HDR });
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:energy:disruptions')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: disruptionsFetchedAt, recordCount: 1 }) }), { status: 200, headers: JSON_HDR });
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:energy:crisis-policies')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: crisisPolicyFetchedAt, recordCount: 1 }) }), { status: 200, headers: JSON_HDR });
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:resilience:fossil-electricity-share')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: fossilShareFetchedAt, recordCount: 1 }) }), { status: 200, headers: JSON_HDR });
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:economic:worldbank-renewable:v1')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: renewableFetchedAt, recordCount: 1 }) }), { status: 200, headers: JSON_HDR });
+      return new Response(JSON.stringify({}), { status: 200, headers: JSON_HDR });
+    };
+
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const freshHandler = freshMod.default;
+
+    const res = await freshHandler(makeReq('POST', {
+      jsonrpc: '2.0', id: 300, method: 'tools/call',
+      params: { name: 'get_energy_intelligence', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.result?.content, 'result.content must be present');
+    const payload = JSON.parse(body.result.content[0].text);
+    assert.equal(payload.stale, false, 'all 9 metas within their per-key budgets must yield stale=false');
+    assert.equal(payload.cached_at, new Date(crisisPolicyFetchedAt).toISOString(), 'cached_at reflects oldest valid fetchedAt (crisis-policies, 30d old, within ~400d budget)');
+    // Label-walk slice names per NON_LABEL=/^(v\d+|\d+|stale|sebuf)$/:
+    assert.deepEqual(payload.data['eia-petroleum'], eiaPayload);
+    assert.deepEqual(payload.data['index'], electricityPayload, 'energy:electricity:v1:index → "index"');
+    assert.deepEqual(payload.data['_all'], emberPayload, 'energy:ember:v1:_all → "_all"');
+    assert.deepEqual(payload.data['_countries'], gasStoragePayload, 'energy:gas-storage:v1:_countries → "_countries"');
+    assert.deepEqual(payload.data['fuel-shortages'], fuelShortagesPayload);
+    assert.deepEqual(payload.data['disruptions'], disruptionsPayload);
+    assert.deepEqual(payload.data['crisis-policies'], crisisPolicyPayload);
+    assert.deepEqual(payload.data['fossil-electricity-share'], fossilSharePayload);
+    assert.deepEqual(payload.data['worldbank-renewable'], renewablePayload);
+  });
+
+  it('get_energy_intelligence marks aggregate stale when one slow-cadence key is past budget while fast keys are fresh', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    // Per-key budget asymmetry exercise: electricity has 48h budget (fast cron),
+    // disruptions has 14d budget (weekly cron × 2). Set disruptions=15d old → past
+    // its own budget, but electricity stays fresh. Aggregate stale must flip true.
+    const electricityFetchedAt = Date.now() - 30 * 60_000;
+    const disruptionsFetchedAt = Date.now() - 15 * 24 * 60 * 60_000; // past 14d budget
+
+    globalThis.fetch = async (url) => {
+      const u = url.toString();
+      // Provide only electricity + disruptions data; rest absent (null).
+      if (u.includes(`/get/${encodeURIComponent('energy:electricity:v1:index')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ countries: [{ iso: 'DE' }] }) }), { status: 200 });
+      if (u.includes(`/get/${encodeURIComponent('energy:disruptions:v1')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ events: [{ id: 'old-event' }] }) }), { status: 200 });
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:energy:electricity-prices')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: electricityFetchedAt, recordCount: 1 }) }), { status: 200 });
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:energy:disruptions')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: disruptionsFetchedAt, recordCount: 1 }) }), { status: 200 });
+      return new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    };
+
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const freshHandler = freshMod.default;
+
+    const res = await freshHandler(makeReq('POST', {
+      jsonrpc: '2.0', id: 301, method: 'tools/call',
+      params: { name: 'get_energy_intelligence', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.result?.content, 'result.content must be present (cache_all_null guard does NOT fire: 2 keys populated)');
+    const payload = JSON.parse(body.result.content[0].text);
+    assert.equal(payload.stale, true, 'one over-budget key (disruptions @ 15d > 14d budget) flips aggregate stale=true');
+    assert.equal(payload.cached_at, null, 'mixed-validity meta yields cached_at=null per evaluateFreshness contract');
+  });
+
+  it('get_energy_intelligence throws cache_all_null (→ -32603) when every 9 cache reads return null', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    // F6 contract: degenerate-empty result must surface as -32603 so
+    // dispatchToolsCall's catch fires the proRollback DECR (Pro path).
+    globalThis.fetch = async () => new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const freshHandler = freshMod.default;
+
+    const res = await freshHandler(makeReq('POST', {
+      jsonrpc: '2.0', id: 302, method: 'tools/call',
+      params: { name: 'get_energy_intelligence', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.error?.code, -32603, 'all-9-null reads must surface as -32603 cache_all_null');
   });
 
   it('get_supply_chain_data still returns its 3 slices unchanged (regression — U6 must not touch get_supply_chain_data._cacheKeys)', async () => {

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -118,22 +118,24 @@ describe('api/mcp.ts — PRO MCP Server', () => {
 
   // --- tools/list ---
 
-  it('tools/list returns 35 tools with name, description, inputSchema', async () => {
+  it('tools/list returns 36 tools with name, description, inputSchema', async () => {
     const res = await handler(makeReq('POST', { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }));
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.ok(Array.isArray(body.result?.tools), 'result.tools must be an array');
-    assert.equal(body.result.tools.length, 35, `Expected 35 tools, got ${body.result.tools.length}`);
+    assert.equal(body.result.tools.length, 36, `Expected 36 tools, got ${body.result.tools.length}`);
     for (const tool of body.result.tools) {
       assert.ok(tool.name, 'tool.name must be present');
       assert.ok(tool.description, 'tool.description must be present');
       assert.ok(tool.inputSchema, 'tool.inputSchema must be present');
       assert.ok(!('_cacheKeys' in tool), 'Internal _cacheKeys must not be exposed in tools/list');
       assert.ok(!('_execute' in tool), 'Internal _execute must not be exposed in tools/list');
+      assert.ok(!('_coverageKeys' in tool), 'Internal _coverageKeys must not be exposed in tools/list');
     }
     const toolNames = body.result.tools.map((t) => t.name);
     assert.ok(toolNames.includes('get_displacement_data'), 'get_displacement_data must be registered (U1 Tier 1 regression)');
     assert.ok(toolNames.includes('get_health_signals'), 'get_health_signals must be registered (U2)');
+    assert.ok(toolNames.includes('get_consumer_prices'), 'get_consumer_prices must be registered (U4)');
   });
 
   // --- tools/call ---
@@ -474,6 +476,170 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.deepEqual(payload.data['air-quality'], airQualityPayload, 'populated slice still present');
     assert.equal(payload.stale, true, 'missing meta forces stale=true (hasAllValidMeta=false in evaluateFreshness)');
     assert.equal(payload.cached_at, null, 'mixed-validity meta yields cached_at=null per evaluateFreshness contract');
+  });
+
+  // --- get_consumer_prices (U4: hybrid _execute, country_code-parameterised) ---
+
+  it('get_consumer_prices returns 5-slice data on cache hit for country_code: "ae"', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    const overviewPayload   = { headlineCpiPct: 3.1, asOf: '2026-05-01' };
+    const categoriesPayload = { categories: [{ name: 'Groceries', changePct: 2.4 }] };
+    const moversPayload     = { items: [{ sku: 'milk-1L', changePct: 8.2 }] };
+    const spreadPayload     = { retailers: [{ slug: 'carrefour_ae', basketUsd: 38.9 }, { slug: 'lulu_ae', basketUsd: 41.2 }] };
+    const freshnessPayload  = { retailers: [{ slug: 'carrefour_ae', minsSinceScan: 18 }] };
+    // All within the shared 1500-min budget — use 60min old.
+    const fetchedAt = Date.now() - 60 * 60_000;
+
+    globalThis.fetch = async (url) => {
+      const u = url.toString();
+      // Data keys
+      if (u.includes(`/get/${encodeURIComponent('consumer-prices:overview:ae')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(overviewPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('consumer-prices:categories:ae:30d')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(categoriesPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('consumer-prices:movers:ae:30d')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(moversPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('consumer-prices:retailer-spread:ae:essentials-ae')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(spreadPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('consumer-prices:freshness:ae')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(freshnessPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      // Freshness/seed-meta keys — note `spread:ae` (NOT `retailer-spread:ae:essentials-ae`)
+      // matches the producer's actual key shape (see scripts/seed-consumer-prices.mjs:151).
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:consumer-prices:overview:ae')}`)
+        || u.includes(`/get/${encodeURIComponent('seed-meta:consumer-prices:categories:ae:30d')}`)
+        || u.includes(`/get/${encodeURIComponent('seed-meta:consumer-prices:movers:ae:30d')}`)
+        || u.includes(`/get/${encodeURIComponent('seed-meta:consumer-prices:spread:ae')}`)
+        || u.includes(`/get/${encodeURIComponent('seed-meta:consumer-prices:freshness:ae')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt, recordCount: 1 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return originalFetch(url);
+    };
+
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const freshHandler = freshMod.default;
+
+    const res = await freshHandler(makeReq('POST', {
+      jsonrpc: '2.0', id: 300, method: 'tools/call',
+      params: { name: 'get_consumer_prices', arguments: { country_code: 'ae' } },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.result?.content, 'result.content must be present');
+    const payload = JSON.parse(body.result.content[0].text);
+    assert.equal(payload.country_code, 'ae', 'echoes normalised country_code');
+    assert.equal(payload.stale, false, 'all 5 freshness checks within 1500-min budget → stale=false');
+    assert.equal(payload.cached_at, new Date(fetchedAt).toISOString(), 'cached_at is the oldest valid fetchedAt');
+    assert.deepEqual(payload.data.overview, overviewPayload);
+    assert.deepEqual(payload.data.categories, categoriesPayload);
+    assert.deepEqual(payload.data.movers, moversPayload);
+    assert.deepEqual(payload.data.retailerSpread, spreadPayload);
+    assert.deepEqual(payload.data.freshness, freshnessPayload);
+  });
+
+  it('get_consumer_prices normalises uppercase "AE" to lowercase and succeeds', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    const overviewPayload = { headlineCpiPct: 3.1 };
+    const fetchedAt = Date.now() - 60 * 60_000;
+
+    globalThis.fetch = async (url) => {
+      const u = url.toString();
+      if (u.includes(`/get/${encodeURIComponent('consumer-prices:overview:ae')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(overviewPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes('/get/consumer-prices') || u.includes('/get/seed-meta%3Aconsumer-prices')) {
+        // Default: return populated meta so freshness evaluation is clean
+        if (u.includes('seed-meta')) {
+          return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt, recordCount: 1 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+        }
+        return new Response(JSON.stringify({ result: JSON.stringify({}) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return originalFetch(url);
+    };
+
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const freshHandler = freshMod.default;
+
+    const res = await freshHandler(makeReq('POST', {
+      jsonrpc: '2.0', id: 301, method: 'tools/call',
+      params: { name: 'get_consumer_prices', arguments: { country_code: 'AE' } },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.result?.content, 'result.content must be present');
+    const payload = JSON.parse(body.result.content[0].text);
+    assert.equal(payload.country_code, 'ae', 'uppercase AE is lowercased before whitelist check + key build');
+    assert.deepEqual(payload.data.overview, overviewPayload);
+    // No `error` field — request succeeded
+    assert.ok(!('error' in payload), 'success path must not surface an error field');
+  });
+
+  it('get_consumer_prices returns result-level error (NOT -32603) for unsupported country_code: "us"', async () => {
+    // No fetch mock needed — the whitelist guard rejects before any Redis read.
+    const res = await handler(makeReq('POST', {
+      jsonrpc: '2.0', id: 302, method: 'tools/call',
+      params: { name: 'get_consumer_prices', arguments: { country_code: 'us' } },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    // Critical: NOT a JSON-RPC error envelope (-32603). The user-input fault
+    // surfaces inside result.content as `{error: "..."}` so callers see a
+    // usable message instead of "Internal error: data fetch failed".
+    assert.ok(body.result?.content, 'unsupported country must return a result, not -32603');
+    assert.equal(body.error, undefined, 'result-level error must not set the JSON-RPC error envelope');
+    const payload = JSON.parse(body.result.content[0].text);
+    assert.equal(payload.error, 'Country not yet supported. Available: ae');
+  });
+
+  it('get_consumer_prices returns result-level error when country_code is missing', async () => {
+    const res = await handler(makeReq('POST', {
+      jsonrpc: '2.0', id: 303, method: 'tools/call',
+      params: { name: 'get_consumer_prices', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.result?.content, 'missing country_code must return a result, not -32603');
+    assert.equal(body.error, undefined);
+    const payload = JSON.parse(body.result.content[0].text);
+    assert.equal(payload.error, 'country_code is required');
+  });
+
+  it('get_consumer_prices: 5 null keys yields stale=true + cached_at=null (does NOT throw)', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    // Every GET returns {} (no `result`) — readJsonFromUpstash → null for both
+    // data keys and seed-meta keys. The hybrid _execute does NOT run the
+    // cache_all_null guard (that's a CacheToolDef-only path inside executeTool),
+    // so the response surfaces 5 nulls with stale=true and cached_at=null.
+    globalThis.fetch = async () => new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const freshHandler = freshMod.default;
+
+    const res = await freshHandler(makeReq('POST', {
+      jsonrpc: '2.0', id: 304, method: 'tools/call',
+      params: { name: 'get_consumer_prices', arguments: { country_code: 'ae' } },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.result?.content, 'empty cache must surface a result (not -32603) for hybrid _execute');
+    const payload = JSON.parse(body.result.content[0].text);
+    assert.equal(payload.stale, true, 'no valid meta → stale=true');
+    assert.equal(payload.cached_at, null, 'no valid meta → cached_at=null');
+    assert.equal(payload.data.overview, null);
+    assert.equal(payload.data.categories, null);
+    assert.equal(payload.data.movers, null);
+    assert.equal(payload.data.retailerSpread, null);
+    assert.equal(payload.data.freshness, null);
   });
 
   it('get_climate_data still includes air-quality slice (regression — U2 must not touch get_climate_data._cacheKeys)', async () => {

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -1093,28 +1093,36 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     const renewableFetchedAt     = Date.now() - 6 * 24 * 60 * 60_000;
 
     const JSON_HDR = { 'Content-Type': 'application/json' };
+    const meta = (fetchedAt) => ({ fetchedAt, recordCount: 1 });
+    // Single Map of cache-key → payload covers both data + seed-meta lookups.
+    // Replaces an 18-branch if-chain that biome flagged as too complex.
+    const FIXTURES = new Map([
+      ['energy:eia-petroleum:v1', eiaPayload],
+      ['energy:electricity:v1:index', electricityPayload],
+      ['energy:ember:v1:_all', emberPayload],
+      ['energy:gas-storage:v1:_countries', gasStoragePayload],
+      ['energy:fuel-shortages:v1', fuelShortagesPayload],
+      ['energy:disruptions:v1', disruptionsPayload],
+      ['energy:crisis-policies:v1', crisisPolicyPayload],
+      ['resilience:fossil-electricity-share:v1', fossilSharePayload],
+      ['economic:worldbank-renewable:v1', renewablePayload],
+      ['seed-meta:energy:eia-petroleum', meta(eiaFetchedAt)],
+      ['seed-meta:energy:electricity-prices', meta(electricityFetchedAt)],
+      ['seed-meta:energy:ember', meta(emberFetchedAt)],
+      ['seed-meta:energy:gas-storage-countries', meta(gasStorageFetchedAt)],
+      ['seed-meta:energy:fuel-shortages', meta(fuelShortagesFetchedAt)],
+      ['seed-meta:energy:disruptions', meta(disruptionsFetchedAt)],
+      ['seed-meta:energy:crisis-policies', meta(crisisPolicyFetchedAt)],
+      ['seed-meta:resilience:fossil-electricity-share', meta(fossilShareFetchedAt)],
+      ['seed-meta:economic:worldbank-renewable:v1', meta(renewableFetchedAt)],
+    ]);
     globalThis.fetch = async (url) => {
       const u = url.toString();
-      // Data keys
-      if (u.includes(`/get/${encodeURIComponent('energy:eia-petroleum:v1')}`)) return new Response(JSON.stringify({ result: JSON.stringify(eiaPayload) }), { status: 200, headers: JSON_HDR });
-      if (u.includes(`/get/${encodeURIComponent('energy:electricity:v1:index')}`)) return new Response(JSON.stringify({ result: JSON.stringify(electricityPayload) }), { status: 200, headers: JSON_HDR });
-      if (u.includes(`/get/${encodeURIComponent('energy:ember:v1:_all')}`)) return new Response(JSON.stringify({ result: JSON.stringify(emberPayload) }), { status: 200, headers: JSON_HDR });
-      if (u.includes(`/get/${encodeURIComponent('energy:gas-storage:v1:_countries')}`)) return new Response(JSON.stringify({ result: JSON.stringify(gasStoragePayload) }), { status: 200, headers: JSON_HDR });
-      if (u.includes(`/get/${encodeURIComponent('energy:fuel-shortages:v1')}`)) return new Response(JSON.stringify({ result: JSON.stringify(fuelShortagesPayload) }), { status: 200, headers: JSON_HDR });
-      if (u.includes(`/get/${encodeURIComponent('energy:disruptions:v1')}`)) return new Response(JSON.stringify({ result: JSON.stringify(disruptionsPayload) }), { status: 200, headers: JSON_HDR });
-      if (u.includes(`/get/${encodeURIComponent('energy:crisis-policies:v1')}`)) return new Response(JSON.stringify({ result: JSON.stringify(crisisPolicyPayload) }), { status: 200, headers: JSON_HDR });
-      if (u.includes(`/get/${encodeURIComponent('resilience:fossil-electricity-share:v1')}`)) return new Response(JSON.stringify({ result: JSON.stringify(fossilSharePayload) }), { status: 200, headers: JSON_HDR });
-      if (u.includes(`/get/${encodeURIComponent('economic:worldbank-renewable:v1')}`)) return new Response(JSON.stringify({ result: JSON.stringify(renewablePayload) }), { status: 200, headers: JSON_HDR });
-      // Meta keys (note: shape differs from cache-key shape — match seed-meta keys per producer)
-      if (u.includes(`/get/${encodeURIComponent('seed-meta:energy:eia-petroleum')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: eiaFetchedAt, recordCount: 1 }) }), { status: 200, headers: JSON_HDR });
-      if (u.includes(`/get/${encodeURIComponent('seed-meta:energy:electricity-prices')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: electricityFetchedAt, recordCount: 1 }) }), { status: 200, headers: JSON_HDR });
-      if (u.includes(`/get/${encodeURIComponent('seed-meta:energy:ember')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: emberFetchedAt, recordCount: 1 }) }), { status: 200, headers: JSON_HDR });
-      if (u.includes(`/get/${encodeURIComponent('seed-meta:energy:gas-storage-countries')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: gasStorageFetchedAt, recordCount: 1 }) }), { status: 200, headers: JSON_HDR });
-      if (u.includes(`/get/${encodeURIComponent('seed-meta:energy:fuel-shortages')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: fuelShortagesFetchedAt, recordCount: 1 }) }), { status: 200, headers: JSON_HDR });
-      if (u.includes(`/get/${encodeURIComponent('seed-meta:energy:disruptions')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: disruptionsFetchedAt, recordCount: 1 }) }), { status: 200, headers: JSON_HDR });
-      if (u.includes(`/get/${encodeURIComponent('seed-meta:energy:crisis-policies')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: crisisPolicyFetchedAt, recordCount: 1 }) }), { status: 200, headers: JSON_HDR });
-      if (u.includes(`/get/${encodeURIComponent('seed-meta:resilience:fossil-electricity-share')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: fossilShareFetchedAt, recordCount: 1 }) }), { status: 200, headers: JSON_HDR });
-      if (u.includes(`/get/${encodeURIComponent('seed-meta:economic:worldbank-renewable:v1')}`)) return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: renewableFetchedAt, recordCount: 1 }) }), { status: 200, headers: JSON_HDR });
+      for (const [key, payload] of FIXTURES) {
+        if (u.includes(`/get/${encodeURIComponent(key)}`)) {
+          return new Response(JSON.stringify({ result: JSON.stringify(payload) }), { status: 200, headers: JSON_HDR });
+        }
+      }
       return new Response(JSON.stringify({}), { status: 200, headers: JSON_HDR });
     };
 

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -118,12 +118,12 @@ describe('api/mcp.ts — PRO MCP Server', () => {
 
   // --- tools/list ---
 
-  it('tools/list returns 32 tools with name, description, inputSchema', async () => {
+  it('tools/list returns 33 tools with name, description, inputSchema', async () => {
     const res = await handler(makeReq('POST', { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }));
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.ok(Array.isArray(body.result?.tools), 'result.tools must be an array');
-    assert.equal(body.result.tools.length, 32, `Expected 32 tools, got ${body.result.tools.length}`);
+    assert.equal(body.result.tools.length, 33, `Expected 33 tools, got ${body.result.tools.length}`);
     for (const tool of body.result.tools) {
       assert.ok(tool.name, 'tool.name must be present');
       assert.ok(tool.description, 'tool.description must be present');
@@ -131,6 +131,8 @@ describe('api/mcp.ts — PRO MCP Server', () => {
       assert.ok(!('_cacheKeys' in tool), 'Internal _cacheKeys must not be exposed in tools/list');
       assert.ok(!('_execute' in tool), 'Internal _execute must not be exposed in tools/list');
     }
+    const toolNames = body.result.tools.map((t) => t.name);
+    assert.ok(toolNames.includes('get_displacement_data'), 'get_displacement_data must be registered (U1 Tier 1 regression)');
   });
 
   // --- tools/call ---
@@ -251,6 +253,76 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(res.status, 200, 'Must return HTTP 200, not 500');
     const body = await res.json();
     assert.equal(body.error?.code, -32603, 'Must return JSON-RPC -32603, not throw');
+  });
+
+  // --- get_displacement_data (U1: Tier 1 regression) ---
+
+  it('get_displacement_data returns {cached_at, stale, data.summary} on cache hit', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    const currentYear = new Date().getUTCFullYear();
+    const expectedDataKey = `displacement:summary:v1:${currentYear}`;
+    const summaryPayload = {
+      year: currentYear,
+      countries: [
+        { iso3: 'SYR', refugees: 6_700_000, idps: 6_900_000 },
+        { iso3: 'UKR', refugees: 5_900_000, idps: 3_700_000 },
+      ],
+    };
+    const seedFetchedAt = Date.now() - 60 * 60_000; // 1h old — well inside 3600 min budget
+
+    globalThis.fetch = async (url) => {
+      const u = url.toString();
+      if (u.includes(`/get/${encodeURIComponent(expectedDataKey)}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(summaryPayload) }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (u.includes('/get/seed-meta%3Adisplacement%3Asummary')) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: seedFetchedAt, recordCount: 2 }) }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return originalFetch(url);
+    };
+
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const freshHandler = freshMod.default;
+
+    const res = await freshHandler(makeReq('POST', {
+      jsonrpc: '2.0', id: 100, method: 'tools/call',
+      params: { name: 'get_displacement_data', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.result?.content, 'result.content must be present');
+    const payload = JSON.parse(body.result.content[0].text);
+    assert.equal(payload.stale, false, 'fresh meta within budget must yield stale=false');
+    assert.equal(payload.cached_at, new Date(seedFetchedAt).toISOString(), 'cached_at must reflect seed-meta fetchedAt');
+    assert.deepEqual(payload.data.summary, summaryPayload, 'label-walk strips year+v1, exposes payload under data.summary');
+  });
+
+  it('get_displacement_data returns -32603 when cache is empty (cache_all_null)', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    // Upstash returns {} (no result) for every GET — simulates fresh deploy
+    // or evicted cache. executeTool's cache_all_null guard must throw → -32603.
+    globalThis.fetch = async () => new Response(JSON.stringify({}), {
+      status: 200, headers: { 'Content-Type': 'application/json' },
+    });
+
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const freshHandler = freshMod.default;
+
+    const res = await freshHandler(makeReq('POST', {
+      jsonrpc: '2.0', id: 101, method: 'tools/call',
+      params: { name: 'get_displacement_data', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.error?.code, -32603, 'empty cache must surface as -32603 (cache_all_null)');
   });
 
   // --- get_airspace ---

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -118,12 +118,12 @@ describe('api/mcp.ts — PRO MCP Server', () => {
 
   // --- tools/list ---
 
-  it('tools/list returns 34 tools with name, description, inputSchema', async () => {
+  it('tools/list returns 35 tools with name, description, inputSchema', async () => {
     const res = await handler(makeReq('POST', { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }));
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.ok(Array.isArray(body.result?.tools), 'result.tools must be an array');
-    assert.equal(body.result.tools.length, 34, `Expected 34 tools, got ${body.result.tools.length}`);
+    assert.equal(body.result.tools.length, 35, `Expected 35 tools, got ${body.result.tools.length}`);
     for (const tool of body.result.tools) {
       assert.ok(tool.name, 'tool.name must be present');
       assert.ok(tool.description, 'tool.description must be present');

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -118,12 +118,12 @@ describe('api/mcp.ts — PRO MCP Server', () => {
 
   // --- tools/list ---
 
-  it('tools/list returns 37 tools with name, description, inputSchema', async () => {
+  it('tools/list returns 38 tools with name, description, inputSchema', async () => {
     const res = await handler(makeReq('POST', { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }));
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.ok(Array.isArray(body.result?.tools), 'result.tools must be an array');
-    assert.equal(body.result.tools.length, 37, `Expected 37 tools, got ${body.result.tools.length}`);
+    assert.equal(body.result.tools.length, 38, `Expected 38 tools, got ${body.result.tools.length}`);
     for (const tool of body.result.tools) {
       assert.ok(tool.name, 'tool.name must be present');
       assert.ok(tool.description, 'tool.description must be present');
@@ -137,6 +137,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.ok(toolNames.includes('get_health_signals'), 'get_health_signals must be registered (U2)');
     assert.ok(toolNames.includes('get_consumer_prices'), 'get_consumer_prices must be registered (U4)');
     assert.ok(toolNames.includes('get_tariff_trends'), 'get_tariff_trends must be registered (U5)');
+    assert.ok(toolNames.includes('get_chokepoint_status'), 'get_chokepoint_status must be registered (U6)');
   });
 
   // --- tools/call ---
@@ -860,6 +861,249 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     const payload = JSON.parse(body.result.content[0].text);
     // climate:air-quality:v1 → label-walk strips :v1, exposes under data['air-quality']
     assert.deepEqual(payload.data['air-quality'], climateAirQualityPayload, 'get_climate_data._cacheKeys must still include climate:air-quality:v1');
+  });
+
+  // --- get_chokepoint_status (U6: maritime chokepoint bundle, payload-verified) ---
+
+  it('get_chokepoint_status returns 6-slice data on cache hit when every per-key meta is within budget', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    const transitSummariesPayload = { chokepoints: { suez: { vesselsPast24h: 87 } } };
+    const chokepointTransitsPayload = { transits: [{ chokepoint: 'hormuz', count: 142 }] };
+    const portwatchPortsPayload = { countries: { US: { ports: 23 } } };
+    const chokepointBaselinesPayload = { suez: { lat: 30.0, lon: 32.5 } };
+    const portwatchChokepointsRefPayload = { count: 13, ids: ['suez', 'hormuz', 'malacca'] };
+    const chokepointFlowsPayload = { suez: { dailyBarrels: 9_200_000 } };
+
+    // transit-summaries budget=30min → 5min old (fresh)
+    const transitSummariesFetchedAt = Date.now() - 5 * 60_000;
+    // chokepoint_transits budget=30min → 8min old (fresh)
+    const chokepointTransitsFetchedAt = Date.now() - 8 * 60_000;
+    // portwatch-ports budget=2160min (36h) → 12h old (fresh)
+    const portwatchPortsFetchedAt = Date.now() - 12 * 60 * 60_000;
+    // chokepoint-baselines budget=576000min (400d) → 60d old (fresh; SECOND-OLDEST)
+    const chokepointBaselinesFetchedAt = Date.now() - 60 * 24 * 60 * 60_000;
+    // portwatch:chokepoints-ref budget=20160min (14d) → 7d old (fresh)
+    const portwatchChokepointsRefFetchedAt = Date.now() - 7 * 24 * 60 * 60_000;
+    // chokepoint-flows budget=720min (12h) → 5h old (fresh)
+    const chokepointFlowsFetchedAt = Date.now() - 5 * 60 * 60_000;
+
+    globalThis.fetch = async (url) => {
+      const u = url.toString();
+      if (u.includes(`/get/${encodeURIComponent('supply_chain:transit-summaries:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(transitSummariesPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('supply_chain:chokepoint_transits:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(chokepointTransitsPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('supply_chain:portwatch-ports:v1:_countries')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(portwatchPortsPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('energy:chokepoint-baselines:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(chokepointBaselinesPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('portwatch:chokepoints:ref:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(portwatchChokepointsRefPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('energy:chokepoint-flows:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(chokepointFlowsPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:supply_chain:transit-summaries')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: transitSummariesFetchedAt, recordCount: 13 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:supply_chain:chokepoint_transits')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: chokepointTransitsFetchedAt, recordCount: 13 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:supply_chain:portwatch-ports')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: portwatchPortsFetchedAt, recordCount: 200 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:energy:chokepoint-baselines')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: chokepointBaselinesFetchedAt, recordCount: 13 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:portwatch:chokepoints-ref')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: portwatchChokepointsRefFetchedAt, recordCount: 13 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:energy:chokepoint-flows')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: chokepointFlowsFetchedAt, recordCount: 13 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return originalFetch(url);
+    };
+
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const freshHandler = freshMod.default;
+
+    const res = await freshHandler(makeReq('POST', {
+      jsonrpc: '2.0', id: 500, method: 'tools/call',
+      params: { name: 'get_chokepoint_status', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.result?.content, 'result.content must be present');
+    const payload = JSON.parse(body.result.content[0].text);
+    assert.equal(payload.stale, false, 'all 6 metas within their per-key budgets must yield stale=false');
+    // chokepoint-baselines is the oldest valid fetchedAt (60d) → anchors cached_at
+    assert.equal(payload.cached_at, new Date(chokepointBaselinesFetchedAt).toISOString(), 'cached_at reflects oldest valid fetchedAt (chokepoint-baselines)');
+    // Label-walk: trailing non-(v\d+|\d+|stale|sebuf) segment.
+    // supply_chain:transit-summaries:v1 → "transit-summaries"
+    // supply_chain:chokepoint_transits:v1 → "chokepoint_transits"
+    // supply_chain:portwatch-ports:v1:_countries → "_countries" (NOT in NON_LABEL list)
+    // energy:chokepoint-baselines:v1 → "chokepoint-baselines"
+    // portwatch:chokepoints:ref:v1 → "ref"
+    // energy:chokepoint-flows:v1 → "chokepoint-flows"
+    assert.deepEqual(payload.data['transit-summaries'], transitSummariesPayload, 'transit-summaries slice labelled from cache-key suffix');
+    assert.deepEqual(payload.data['chokepoint_transits'], chokepointTransitsPayload, 'chokepoint_transits slice labelled from cache-key suffix');
+    assert.deepEqual(payload.data['_countries'], portwatchPortsPayload, 'portwatch-ports slice labelled from trailing _countries segment');
+    assert.deepEqual(payload.data['chokepoint-baselines'], chokepointBaselinesPayload, 'chokepoint-baselines slice labelled from cache-key suffix');
+    assert.deepEqual(payload.data['ref'], portwatchChokepointsRefPayload, 'portwatch:chokepoints:ref slice labelled from trailing ref segment');
+    assert.deepEqual(payload.data['chokepoint-flows'], chokepointFlowsPayload, 'chokepoint-flows slice labelled from cache-key suffix');
+  });
+
+  it('get_chokepoint_status: fast transit-summaries fresh but slow portwatch-ports past budget flips aggregate stale', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    const transitSummariesPayload = { chokepoints: { suez: { vesselsPast24h: 87 } } };
+    const portwatchPortsPayload = { countries: {} };
+
+    // transit-summaries budget=30min → 5min old (fresh)
+    const transitSummariesFetchedAt = Date.now() - 5 * 60_000;
+    // portwatch-ports budget=2160min (36h) → 100h old (clearly STALE)
+    const portwatchPortsFetchedAt = Date.now() - 100 * 60 * 60_000;
+
+    globalThis.fetch = async (url) => {
+      const u = url.toString();
+      if (u.includes(`/get/${encodeURIComponent('supply_chain:transit-summaries:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(transitSummariesPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('supply_chain:portwatch-ports:v1:_countries')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(portwatchPortsPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:supply_chain:transit-summaries')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: transitSummariesFetchedAt, recordCount: 13 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:supply_chain:portwatch-ports')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: portwatchPortsFetchedAt, recordCount: 200 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      // Everything else absent → mixed shape; at least 2 keys populated so cache_all_null doesn't trip.
+      return new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    };
+
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const freshHandler = freshMod.default;
+
+    const res = await freshHandler(makeReq('POST', {
+      jsonrpc: '2.0', id: 501, method: 'tools/call',
+      params: { name: 'get_chokepoint_status', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    const payload = JSON.parse(body.result.content[0].text);
+    // One over-budget key (portwatch-ports 100h vs 36h budget) flips aggregate stale=true
+    // even though transit-summaries is fresh.
+    assert.equal(payload.stale, true, 'one over-budget key (portwatch-ports) flips aggregate stale=true');
+    assert.deepEqual(payload.data['transit-summaries'], transitSummariesPayload, 'fresh transit-summaries slice still surfaces');
+    assert.deepEqual(payload.data['_countries'], portwatchPortsPayload, 'stale portwatch-ports payload still returned alongside stale=true');
+  });
+
+  it('get_chokepoint_status returns mixed shape without throwing when only one key is populated', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    const transitSummariesPayload = { chokepoints: { suez: { vesselsPast24h: 87 } } };
+    const transitSummariesFetchedAt = Date.now() - 5 * 60_000;
+
+    globalThis.fetch = async (url) => {
+      const u = url.toString();
+      if (u.includes(`/get/${encodeURIComponent('supply_chain:transit-summaries:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(transitSummariesPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:supply_chain:transit-summaries')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: transitSummariesFetchedAt, recordCount: 13 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      // Every other key absent → readJsonFromUpstash → null
+      return new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    };
+
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const freshHandler = freshMod.default;
+
+    const res = await freshHandler(makeReq('POST', {
+      jsonrpc: '2.0', id: 502, method: 'tools/call',
+      params: { name: 'get_chokepoint_status', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    // Must NOT throw -32603: at least one cache slot is populated → cache_all_null guard doesn't fire.
+    assert.ok(body.result?.content, 'partial-population must return a result, not -32603');
+    const payload = JSON.parse(body.result.content[0].text);
+    assert.deepEqual(payload.data['transit-summaries'], transitSummariesPayload, 'populated transit-summaries slice still present');
+    assert.equal(payload.data['chokepoint_transits'], null, 'missing chokepoint_transits slice surfaces as null');
+    assert.equal(payload.data['_countries'], null, 'missing portwatch-ports slice surfaces as null');
+    assert.equal(payload.data['chokepoint-baselines'], null, 'missing chokepoint-baselines slice surfaces as null');
+    assert.equal(payload.data['ref'], null, 'missing portwatch chokepoints-ref slice surfaces as null');
+    assert.equal(payload.data['chokepoint-flows'], null, 'missing chokepoint-flows slice surfaces as null');
+    assert.equal(payload.stale, true, 'missing meta forces stale=true (hasAllValidMeta=false)');
+    assert.equal(payload.cached_at, null, 'mixed-validity meta yields cached_at=null per evaluateFreshness contract');
+  });
+
+  it('get_supply_chain_data still returns its 3 slices unchanged (regression — U6 must not touch get_supply_chain_data._cacheKeys)', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    const shippingStressPayload = { index: 1.42 };
+    const customsRevenuePayload = { receipts: [{ country: 'US', revenue: 1.2e9 }] };
+    const comtradeFlowsPayload = { pairs: [{ a: 'US', b: 'CN', total: 9.1e11 }] };
+    const customsFetchedAt = Date.now() - 6 * 60 * 60_000;
+
+    globalThis.fetch = async (url) => {
+      const u = url.toString();
+      // U6 chokepoint keys MUST NOT be queried by get_supply_chain_data — if they are,
+      // the supply-chain tool was modified, violating the CRITICAL constraint.
+      if (
+        u.includes(`/get/${encodeURIComponent('supply_chain:transit-summaries:v1')}`) ||
+        u.includes(`/get/${encodeURIComponent('supply_chain:chokepoint_transits:v1')}`) ||
+        u.includes(`/get/${encodeURIComponent('supply_chain:portwatch-ports:v1:_countries')}`) ||
+        u.includes(`/get/${encodeURIComponent('energy:chokepoint-baselines:v1')}`) ||
+        u.includes(`/get/${encodeURIComponent('portwatch:chokepoints:ref:v1')}`) ||
+        u.includes(`/get/${encodeURIComponent('energy:chokepoint-flows:v1')}`)
+      ) {
+        throw new Error('get_supply_chain_data must not read chokepoint-bundle keys (U6 regression)');
+      }
+      if (u.includes(`/get/${encodeURIComponent('supply_chain:shipping_stress:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(shippingStressPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('trade:customs-revenue:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(customsRevenuePayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('comtrade:flows:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(comtradeFlowsPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:trade:customs-revenue')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: customsFetchedAt, recordCount: 1 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    };
+
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const freshHandler = freshMod.default;
+
+    const res = await freshHandler(makeReq('POST', {
+      jsonrpc: '2.0', id: 503, method: 'tools/call',
+      params: { name: 'get_supply_chain_data', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.result?.content, 'get_supply_chain_data must still return a result');
+    const payload = JSON.parse(body.result.content[0].text);
+    // Label-walk: supply_chain:shipping_stress:v1 → "shipping_stress",
+    //             trade:customs-revenue:v1       → "customs-revenue",
+    //             comtrade:flows:v1              → "flows"
+    assert.deepEqual(payload.data['shipping_stress'], shippingStressPayload, 'get_supply_chain_data._cacheKeys must still include supply_chain:shipping_stress:v1');
+    assert.deepEqual(payload.data['customs-revenue'], customsRevenuePayload, 'get_supply_chain_data._cacheKeys must still include trade:customs-revenue:v1');
+    assert.deepEqual(payload.data['flows'], comtradeFlowsPayload, 'get_supply_chain_data._cacheKeys must still include comtrade:flows:v1');
+    // Exactly 3 slices — no chokepoint keys leaked in.
+    assert.equal(Object.keys(payload.data).length, 3, 'get_supply_chain_data must return exactly 3 slices (U6 must not add to it)');
   });
 
   // --- get_airspace ---

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -118,12 +118,12 @@ describe('api/mcp.ts — PRO MCP Server', () => {
 
   // --- tools/list ---
 
-  it('tools/list returns 36 tools with name, description, inputSchema', async () => {
+  it('tools/list returns 37 tools with name, description, inputSchema', async () => {
     const res = await handler(makeReq('POST', { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }));
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.ok(Array.isArray(body.result?.tools), 'result.tools must be an array');
-    assert.equal(body.result.tools.length, 36, `Expected 36 tools, got ${body.result.tools.length}`);
+    assert.equal(body.result.tools.length, 37, `Expected 37 tools, got ${body.result.tools.length}`);
     for (const tool of body.result.tools) {
       assert.ok(tool.name, 'tool.name must be present');
       assert.ok(tool.description, 'tool.description must be present');
@@ -136,6 +136,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.ok(toolNames.includes('get_displacement_data'), 'get_displacement_data must be registered (U1 Tier 1 regression)');
     assert.ok(toolNames.includes('get_health_signals'), 'get_health_signals must be registered (U2)');
     assert.ok(toolNames.includes('get_consumer_prices'), 'get_consumer_prices must be registered (U4)');
+    assert.ok(toolNames.includes('get_tariff_trends'), 'get_tariff_trends must be registered (U5)');
   });
 
   // --- tools/call ---
@@ -640,6 +641,179 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(payload.data.movers, null);
     assert.equal(payload.data.retailerSpread, null);
     assert.equal(payload.data.freshness, null);
+  });
+
+  // --- get_tariff_trends (U5: trade + economic indicator bundle) ---
+
+  it('get_tariff_trends returns 4-slice data on cache hit when every per-key meta is within budget', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    const tariffsPayload = { items: [{ hts: '8501.10.40', ratePct: 25 }] };
+    const bigmacPayload = { countries: [{ iso: 'CHE', priceUsd: 7.04 }] };
+    const faoPayload = { months: [{ month: '2026-04', index: 119.2 }] };
+    const debtPayload = { countries: [{ iso: 'JPN', debtPctGdp: 263.1 }] };
+
+    // tariffs budget=540min — set 60min old (fresh)
+    const tariffsFetchedAt = Date.now() - 60 * 60_000;
+    // bigmac budget=10080min — set 12h old (fresh)
+    const bigmacFetchedAt = Date.now() - 12 * 60 * 60_000;
+    // fao budget=86400min — set 7d old (fresh)
+    const faoFetchedAt = Date.now() - 7 * 24 * 60 * 60_000;
+    // national-debt budget=86400min — set 10d old (fresh; OLDEST → anchors cached_at)
+    const debtFetchedAt = Date.now() - 10 * 24 * 60 * 60_000;
+
+    globalThis.fetch = async (url) => {
+      const u = url.toString();
+      if (u.includes(`/get/${encodeURIComponent('trade:tariffs:v1:840:all:10')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(tariffsPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('economic:bigmac:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(bigmacPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('economic:fao-ffpi:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(faoPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('economic:national-debt:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(debtPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:trade:tariffs:v1:840:all:10')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: tariffsFetchedAt, recordCount: 1 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:economic:bigmac')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: bigmacFetchedAt, recordCount: 1 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:economic:fao-ffpi')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: faoFetchedAt, recordCount: 1 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:economic:national-debt')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: debtFetchedAt, recordCount: 1 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return originalFetch(url);
+    };
+
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const freshHandler = freshMod.default;
+
+    const res = await freshHandler(makeReq('POST', {
+      jsonrpc: '2.0', id: 400, method: 'tools/call',
+      params: { name: 'get_tariff_trends', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.result?.content, 'result.content must be present');
+    const payload = JSON.parse(body.result.content[0].text);
+    assert.equal(payload.stale, false, 'all 4 metas within their per-key budgets must yield stale=false');
+    assert.equal(payload.cached_at, new Date(debtFetchedAt).toISOString(), 'cached_at reflects oldest valid fetchedAt (national-debt)');
+    // Label-walk derives slice names from the trailing non-(v\d+|\d+) segment.
+    // trade:tariffs:v1:840:all:10 → trailing "10" + "all" are skipped/kept;
+    // "10" is bare-numeric → skipped, "all" stays → label="all".
+    assert.deepEqual(payload.data['all'], tariffsPayload, 'tariffs slice labelled "all" from cache-key label-walk');
+    assert.deepEqual(payload.data['bigmac'], bigmacPayload, 'bigmac slice labelled from cache-key suffix');
+    assert.deepEqual(payload.data['fao-ffpi'], faoPayload, 'fao-ffpi slice labelled from cache-key suffix');
+    assert.deepEqual(payload.data['national-debt'], debtPayload, 'national-debt slice labelled from cache-key suffix');
+  });
+
+  it('get_tariff_trends marks aggregate stale when FAO meta is past its monthly budget while tariffs are fresh', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    const tariffsPayload = { items: [{ hts: '8501.10.40' }] };
+    const bigmacPayload = { countries: [{ iso: 'CHE' }] };
+    const faoPayload = { months: [{ month: '2025-12' }] };
+    const debtPayload = { countries: [{ iso: 'JPN' }] };
+
+    // tariffs budget=540min → 60min old (fresh)
+    const tariffsFetchedAt = Date.now() - 60 * 60_000;
+    // bigmac budget=10080min → 12h old (fresh)
+    const bigmacFetchedAt = Date.now() - 12 * 60 * 60_000;
+    // FAO budget=86400min (60d) → put 100d old (clearly stale)
+    const faoFetchedAt = Date.now() - 100 * 24 * 60 * 60_000;
+    // national-debt budget=86400min → 5d old (fresh)
+    const debtFetchedAt = Date.now() - 5 * 24 * 60 * 60_000;
+
+    globalThis.fetch = async (url) => {
+      const u = url.toString();
+      if (u.includes(`/get/${encodeURIComponent('trade:tariffs:v1:840:all:10')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(tariffsPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('economic:bigmac:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(bigmacPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('economic:fao-ffpi:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(faoPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('economic:national-debt:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(debtPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:trade:tariffs:v1:840:all:10')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: tariffsFetchedAt, recordCount: 1 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:economic:bigmac')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: bigmacFetchedAt, recordCount: 1 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:economic:fao-ffpi')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: faoFetchedAt, recordCount: 1 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:economic:national-debt')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: debtFetchedAt, recordCount: 1 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return originalFetch(url);
+    };
+
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const freshHandler = freshMod.default;
+
+    const res = await freshHandler(makeReq('POST', {
+      jsonrpc: '2.0', id: 401, method: 'tools/call',
+      params: { name: 'get_tariff_trends', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    const payload = JSON.parse(body.result.content[0].text);
+    assert.equal(payload.stale, true, 'one over-budget key (FAO) flips aggregate stale=true');
+    assert.equal(payload.cached_at, new Date(faoFetchedAt).toISOString(), 'cached_at is the oldest valid fetchedAt across all 4 metas (FAO)');
+    assert.deepEqual(payload.data['all'], tariffsPayload, 'fresh tariffs slice still surfaces');
+    assert.deepEqual(payload.data['fao-ffpi'], faoPayload, 'stale FAO payload still returned alongside stale=true');
+  });
+
+  it('get_tariff_trends returns mixed shape (3 slices null, 1 populated) without throwing when only one key is populated', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    const tariffsPayload = { items: [{ hts: '8501.10.40' }] };
+    const tariffsFetchedAt = Date.now() - 60 * 60_000;
+
+    globalThis.fetch = async (url) => {
+      const u = url.toString();
+      if (u.includes(`/get/${encodeURIComponent('trade:tariffs:v1:840:all:10')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(tariffsPayload) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:trade:tariffs:v1:840:all:10')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: tariffsFetchedAt, recordCount: 1 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      // Everything else absent → readJsonFromUpstash → null
+      return new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    };
+
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const freshHandler = freshMod.default;
+
+    const res = await freshHandler(makeReq('POST', {
+      jsonrpc: '2.0', id: 402, method: 'tools/call',
+      params: { name: 'get_tariff_trends', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    // Must NOT throw -32603: at least one cache slot is populated → cache_all_null guard doesn't fire.
+    assert.ok(body.result?.content, 'partial-population must return a result, not -32603');
+    const payload = JSON.parse(body.result.content[0].text);
+    assert.deepEqual(payload.data['all'], tariffsPayload, 'populated tariffs slice still present');
+    assert.equal(payload.data['bigmac'], null, 'missing bigmac slice surfaces as null');
+    assert.equal(payload.data['fao-ffpi'], null, 'missing fao-ffpi slice surfaces as null');
+    assert.equal(payload.data['national-debt'], null, 'missing national-debt slice surfaces as null');
+    assert.equal(payload.stale, true, 'missing meta forces stale=true (hasAllValidMeta=false)');
+    assert.equal(payload.cached_at, null, 'mixed-validity meta yields cached_at=null per evaluateFreshness contract');
   });
 
   it('get_climate_data still includes air-quality slice (regression — U2 must not touch get_climate_data._cacheKeys)', async () => {

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -118,12 +118,12 @@ describe('api/mcp.ts — PRO MCP Server', () => {
 
   // --- tools/list ---
 
-  it('tools/list returns 33 tools with name, description, inputSchema', async () => {
+  it('tools/list returns 34 tools with name, description, inputSchema', async () => {
     const res = await handler(makeReq('POST', { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }));
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.ok(Array.isArray(body.result?.tools), 'result.tools must be an array');
-    assert.equal(body.result.tools.length, 33, `Expected 33 tools, got ${body.result.tools.length}`);
+    assert.equal(body.result.tools.length, 34, `Expected 34 tools, got ${body.result.tools.length}`);
     for (const tool of body.result.tools) {
       assert.ok(tool.name, 'tool.name must be present');
       assert.ok(tool.description, 'tool.description must be present');
@@ -133,6 +133,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     }
     const toolNames = body.result.tools.map((t) => t.name);
     assert.ok(toolNames.includes('get_displacement_data'), 'get_displacement_data must be registered (U1 Tier 1 regression)');
+    assert.ok(toolNames.includes('get_health_signals'), 'get_health_signals must be registered (U2)');
   });
 
   // --- tools/call ---
@@ -323,6 +324,202 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.equal(body.error?.code, -32603, 'empty cache must surface as -32603 (cache_all_null)');
+  });
+
+  // --- get_health_signals (U2) ---
+
+  it('get_health_signals returns both disease-outbreaks and air-quality slices on cache hit', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    const outbreaksPayload = { outbreaks: [{ id: 'who-1', disease: 'Marburg', country: 'TZA' }] };
+    const airQualityPayload = { stations: [{ id: 'aqi-1', city: 'Delhi', pm25: 187 }] };
+    const outbreaksFetchedAt = Date.now() - 60 * 60_000;   // 1h old; within 2880-min budget
+    const airQualityFetchedAt = Date.now() - 30 * 60_000;  // 30m old; within 180-min budget
+
+    globalThis.fetch = async (url) => {
+      const u = url.toString();
+      if (u.includes(`/get/${encodeURIComponent('health:disease-outbreaks:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(outbreaksPayload) }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (u.includes(`/get/${encodeURIComponent('health:air-quality:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(airQualityPayload) }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:health:disease-outbreaks')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: outbreaksFetchedAt, recordCount: 1 }) }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:health:air-quality')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: airQualityFetchedAt, recordCount: 1 }) }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return originalFetch(url);
+    };
+
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const freshHandler = freshMod.default;
+
+    const res = await freshHandler(makeReq('POST', {
+      jsonrpc: '2.0', id: 200, method: 'tools/call',
+      params: { name: 'get_health_signals', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.result?.content, 'result.content must be present');
+    const payload = JSON.parse(body.result.content[0].text);
+    assert.equal(payload.stale, false, 'both metas within their per-key budgets must yield stale=false');
+    assert.equal(payload.cached_at, new Date(outbreaksFetchedAt).toISOString(), 'cached_at reflects oldest valid fetchedAt across freshness checks');
+    assert.deepEqual(payload.data['disease-outbreaks'], outbreaksPayload, 'disease-outbreaks slice labelled from cache-key suffix');
+    assert.deepEqual(payload.data['air-quality'], airQualityPayload, 'air-quality slice labelled from cache-key suffix');
+  });
+
+  it('get_health_signals marks aggregate stale when disease-outbreaks meta is past budget but air-quality is fresh', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    const outbreaksPayload = { outbreaks: [{ id: 'who-1' }] };
+    const airQualityPayload = { stations: [{ id: 'aqi-1' }] };
+    // disease-outbreaks budget is 2880 min — put it at 4000 min old (clearly stale)
+    const outbreaksFetchedAt = Date.now() - 4000 * 60_000;
+    // air-quality budget is 180 min — put it at 30 min old (fresh)
+    const airQualityFetchedAt = Date.now() - 30 * 60_000;
+
+    globalThis.fetch = async (url) => {
+      const u = url.toString();
+      if (u.includes(`/get/${encodeURIComponent('health:disease-outbreaks:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(outbreaksPayload) }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (u.includes(`/get/${encodeURIComponent('health:air-quality:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(airQualityPayload) }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:health:disease-outbreaks')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: outbreaksFetchedAt, recordCount: 1 }) }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:health:air-quality')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: airQualityFetchedAt, recordCount: 1 }) }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return originalFetch(url);
+    };
+
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const freshHandler = freshMod.default;
+
+    const res = await freshHandler(makeReq('POST', {
+      jsonrpc: '2.0', id: 201, method: 'tools/call',
+      params: { name: 'get_health_signals', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    const payload = JSON.parse(body.result.content[0].text);
+    assert.equal(payload.stale, true, 'one over-budget key flips aggregate stale=true');
+    assert.equal(payload.cached_at, new Date(outbreaksFetchedAt).toISOString(), 'cached_at is the oldest valid fetchedAt (disease-outbreaks)');
+  });
+
+  it('get_health_signals returns mixed shape (one slice null) without throwing when only one key is populated', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    const airQualityPayload = { stations: [{ id: 'aqi-1' }] };
+    const airQualityFetchedAt = Date.now() - 30 * 60_000;
+
+    globalThis.fetch = async (url) => {
+      const u = url.toString();
+      if (u.includes(`/get/${encodeURIComponent('health:disease-outbreaks:v1')}`)) {
+        // Upstash returns {} (no `result`) when the key is absent — readJsonFromUpstash → null
+        return new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('health:air-quality:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(airQualityPayload) }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:health:disease-outbreaks')}`)) {
+        return new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:health:air-quality')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: airQualityFetchedAt, recordCount: 1 }) }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return originalFetch(url);
+    };
+
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const freshHandler = freshMod.default;
+
+    const res = await freshHandler(makeReq('POST', {
+      jsonrpc: '2.0', id: 202, method: 'tools/call',
+      params: { name: 'get_health_signals', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    // Must NOT throw: at least one cache slot is populated, so cache_all_null guard does not fire.
+    assert.ok(body.result?.content, 'partial-population must return a result, not -32603');
+    const payload = JSON.parse(body.result.content[0].text);
+    assert.equal(payload.data['disease-outbreaks'], null, 'missing slice surfaces as null');
+    assert.deepEqual(payload.data['air-quality'], airQualityPayload, 'populated slice still present');
+    assert.equal(payload.stale, true, 'missing meta forces stale=true (hasAllValidMeta=false in evaluateFreshness)');
+    assert.equal(payload.cached_at, null, 'mixed-validity meta yields cached_at=null per evaluateFreshness contract');
+  });
+
+  it('get_climate_data still includes air-quality slice (regression — U2 must not touch get_climate_data._cacheKeys)', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+    const climateAirQualityPayload = { stations: [{ id: 'climate-aqi-1', city: 'Lagos', pm25: 92 }] };
+    const climateFetchedAt = Date.now() - 30 * 60_000;
+
+    globalThis.fetch = async (url) => {
+      const u = url.toString();
+      // Return populated climate:air-quality blob; everything else null (cache_all_null
+      // guard does NOT trip because at least one key is populated).
+      if (u.includes(`/get/${encodeURIComponent('climate:air-quality:v1')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify(climateAirQualityPayload) }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      // Health-domain key MUST NOT be queried by get_climate_data — if it is, the
+      // climate tool was modified, which violates U2's CRITICAL constraint.
+      if (u.includes(`/get/${encodeURIComponent('health:disease-outbreaks:v1')}`)) {
+        throw new Error('get_climate_data must not read health-domain keys (U2 regression)');
+      }
+      // Provide a fresh climate:air-quality meta so the freshness check has at
+      // least one valid fetchedAt to anchor cached_at off (rest stale → aggregate stale=true).
+      if (u.includes(`/get/${encodeURIComponent('seed-meta:health:air-quality')}`)) {
+        return new Response(JSON.stringify({ result: JSON.stringify({ fetchedAt: climateFetchedAt, recordCount: 1 }) }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return new Response(JSON.stringify({}), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    };
+
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const freshHandler = freshMod.default;
+
+    const res = await freshHandler(makeReq('POST', {
+      jsonrpc: '2.0', id: 203, method: 'tools/call',
+      params: { name: 'get_climate_data', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.result?.content, 'get_climate_data must still return a result');
+    const payload = JSON.parse(body.result.content[0].text);
+    // climate:air-quality:v1 → label-walk strips :v1, exposes under data['air-quality']
+    assert.deepEqual(payload.data['air-quality'], climateAirQualityPayload, 'get_climate_data._cacheKeys must still include climate:air-quality:v1');
   });
 
   // --- get_airspace ---


### PR DESCRIPTION
## Summary

Closes the BOOTSTRAP_KEYS → TOOL_REGISTRY coverage gap audited 2026-05-10 after a disease-outbreaks lookup failed via MCP despite the data being seeded. Adds 6 new tools (32 → 38) covering brainstorm-promised + high-value missing domains, plus a Tier-3 parity test that prevents this drift from happening again.

**Plan:** `docs/plans/2026-05-11-001-feat-mcp-coverage-tier1-tier2-plan.md` — Codex-approved over 6 review rounds.

## Tools added

| Unit | Tool | Pattern | Cache keys | Notes |
|------|------|---------|-----------:|-------|
| U1 | \`get_displacement_data\` | CacheToolDef | 1 | Tier-1 regression — present in 2026-03-27 brainstorm inventory but missing from registry. Dynamic UTC-year cache key resolved at module load. |
| U2 | \`get_health_signals\` | CacheToolDef | 2 | Disease outbreaks (the trigger case) + air-quality. Air-quality stays in \`get_climate_data\` too (regression-tested). |
| U3 | \`get_energy_intelligence\` | CacheToolDef | 9 | Broadest bundle — EIA petroleum, electricity (Ember + prices), gas storage, fuel shortages, disruptions, crisis policies, fossil/renewable shares. Per-key freshness budgets spanning hourly to ~400d. |
| U4 | \`get_consumer_prices\` | Hybrid \`_execute\` | 5 (per country) | Required \`country_code\` param (only \`ae\` seeded today). Result-level error (NOT \`-32603\`) on missing/unsupported/malformed input. Spread freshness reads producer's actual \`seed-meta:consumer-prices:spread:<code>\` key (NOT \`api/health.js\`'s drifted shape). |
| U5 | \`get_tariff_trends\` | CacheToolDef | 4 | US tariff trends + BigMac index + FAO FFPI + national debt. |
| U6 | \`get_chokepoint_status\` | CacheToolDef | 6 | Maritime chokepoints — transit summaries, transits, port activity, baselines, ref, flows. Payload-verified live (combined ~18.5KB, well under thresholds). |

## Tier-3 parity test (U7)

\`tests/mcp-bootstrap-parity.test.mjs\` — every key in BOOTSTRAP_KEYS ∪ STANDALONE_KEYS must be either (a) in some tool's \`_cacheKeys\`/\`_coverageKeys\` OR (b) in \`EXCLUDED_FROM_MCP\` with a non-empty documented reason.

- 109 \`EXCLUDED_FROM_MCP\` entries with reasons across 7 categories (intermediate, cascade-mirror, on-demand, deferred follow-up tools, recovery-pillar stubs, shared-token-panels, operational)
- 4 live structural assertions + **7 fixture-based meta-tests** verifying the predicate logic itself fires on synthetic invalid inputs (added in residual review pass)
- New \`_coverageKeys?: string[]\` field on \`RpcToolDef\` so hybrid \`_execute\` tools (U4) declare what they cover
- Added \`BOOTSTRAP_KEYS\` + \`STANDALONE_KEYS\` to \`api/health.js::__testing__\` export

## Docs (U8)

- \`docs/mcp-server.mdx\` — count bumps 32 → 38 at two anchor points, 6 new catalog rows across Markets & economy / Energy / Health / Humanitarian sections

## Tier-2 code review fixes (residual commit)

Three specialist reviewers (code-reviewer + correctness-reviewer + testing-reviewer) ran against the 8-commit feature diff. Findings applied in the final commit:

1. **U3 zero behavioral tests** — broadest 9-key bundle was missing from both the registration-name assertion AND had no \`tools/call\` test. Added 3: 9-fresh happy path with label-walked slice assertions, one-key-stale → aggregate stale=true, all-9-null → -32603.
2. **U7 parity test had no meta-tests** — the test that prevents future drift had no test of its own predicate logic. Refactored 4 inline checks into 6 pure exported helpers; added 7 fixture-based meta-tests asserting each fires on synthetic invalid inputs.
3. **U4 hybrid skipped \`cache_all_null\` guard** — every CacheToolDef throws when all reads return null so \`dispatchToolsCall\`'s catch fires \`proRollback\` (DECR). Hybrid silently returned success → Pro user's daily counter incremented on a useless 5-null result. Added the symmetric guard.
4. **U4 \`country_code\` loose validation** — \`.slice(0,2)\` silently coerced \`'aexxx'\` / \`'AE-DXB'\` / \`'1AE'\` to \`'ae'\`. Tightened to \`/^[a-z]{2}$/\` after lowercase.

### Findings explicitly accepted (not patched)
- Tariffs \`data['all']\` label (plan-asserted by the test)
- U1 year-boundary module-load pinning (plan-documented design choice; Vercel cold-start cadence bounds it)
- \`_countries\`/\`ref\` label brittleness (no collision today, speculative)
- Tool count 38 not cross-locked to docs (drift not present)
- Producer-side key parity for \`:v1\` shapes (out of scope; mock-vs-real is a separate hardening track)

## Tests

- \`tests/mcp.test.mjs\` — 77 tests (was 73): +3 U3 behavioral + 1 new U4 strict-shape + 6 existing-but-modified U4 cases + the count-assertion bump
- \`tests/mcp-bootstrap-parity.test.mjs\` — 11 tests (was 4): 4 live structural + 7 meta-tests of the predicate helpers
- **84/84 pass.** TypeScript clean on both \`tsconfig.json\` and \`tsconfig.api.json\`.

## Deploy notes

- **No env-var changes.** Pure additive cache exposure.
- **No migrations.** No new tables / Convex shape changes / Redis writes.
- **No new Pro quota cost.** Tools count as 1 \`tools/call\` each; existing 50/day Pro cap unchanged.
- **No breaking changes to existing tools.** \`get_climate_data\` keeps air-quality (regression-tested); \`get_supply_chain_data\` keeps its 3 slices (regression-tested).

## Future Tier-4 follow-up candidates

\`EXCLUDED_FROM_MCP\` flags ~40 entries as \"deferred to a future expanded X tool\" — VPD tracker (health), EIA weekly series (energy supplementary), gold metals (markets), resilience ranking, token panels (crypto), Cloudflare Radar (cyber/internet-health), per-country JODI (energy), EU gas storage, intelligence/OSINT feeds. Worth one more pass once a target audience surfaces.

## Test plan

- [ ] CI green (typecheck + tests on both \`tsconfig.json\` and \`tsconfig.api.json\`)
- [ ] Verify \`tools/list\` returns 38 tools with all 6 new names registered
- [ ] Smoke-test one new tool via authenticated MCP session (\`get_displacement_data\` is lowest-risk single-key)
- [ ] Verify \`/docs/mcp-server\` renders the new catalog rows correctly post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)