### PR TITLE
fix(sentry): suppress maplibre texture-undefined + stay-userscript noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -301,7 +301,7 @@ Sentry.init({
     const hasFirstParty = nonInfraFrames.some(f => firstPartyFile(f.filename ?? ''));
     const hasAnyStack = nonInfraFrames.length > 0;
     // Suppress maplibre internal null-access crashes (light, placement) only when stack is in map chunk
-    if (/this\.style\._layers|reading '_layers'|this\.(light|sky) is null|can't access property "(id|type|setFilter)"[,] ?\w+ is (null|undefined)|can't access property "(id|type)" of null|Cannot read properties of null \(reading '(id|type|setFilter|_layers)'\)|null is not an object \(evaluating '\w{1,3}\.(id|style)|^\w{1,2} is null$/.test(msg)) {
+    if (/this\.style\._layers|reading '_layers'|this\.(light|sky) is null|can't access property "(id|type|setFilter|bind)"[,] ?[\w.]+ is (null|undefined)|can't access property "(id|type)" of null|Cannot read properties of null \(reading '(id|type|setFilter|_layers)'\)|null is not an object \(evaluating '\w{1,3}\.(id|style)|^\w{1,2} is null$/.test(msg)) {
       if (frames.some(f => /\/(map|maplibre|deck-stack)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
     }
     // Suppress any TypeError / RangeError that happens entirely within maplibre or deck.gl internals.
@@ -426,8 +426,8 @@ Sentry.init({
     if (excType === 'SyntaxError' && /is not valid JSON/.test(msg) && !hasFirstParty && frames.some(f => /onmessage/.test(f.function ?? ''))) return null;
     // Suppress errors originating from UV proxy (Ultraviolet service worker)
     if (frames.some(f => /\/uv\/service\//.test(f.filename ?? '') || /uv\.handler/.test(f.filename ?? ''))) return null;
-    // Suppress Greasemonkey/Tampermonkey userscript errors (x-plugin-script)
-    if (frames.length > 0 && frames.every(f => !f.filename || /\/x-plugin-script\//.test(f.filename))) return null;
+    // Suppress Greasemonkey/Tampermonkey userscript errors (x-plugin-script, stay-userscript.html)
+    if (frames.length > 0 && frames.every(f => !f.filename || /\/x-plugin-script\/|stay-userscript\.html$/.test(f.filename))) return null;
     // Suppress YouTube IFrame widget API internal errors
     if (frames.some(f => /www-widgetapi\.js/.test(f.filename ?? ''))) return null;
     // Suppress Sentry beacon XHR transport errors (readyState on aborted XHR — not our code)

--- a/src/main.ts
+++ b/src/main.ts
@@ -427,7 +427,7 @@ Sentry.init({
     // Suppress errors originating from UV proxy (Ultraviolet service worker)
     if (frames.some(f => /\/uv\/service\//.test(f.filename ?? '') || /uv\.handler/.test(f.filename ?? ''))) return null;
     // Suppress Greasemonkey/Tampermonkey userscript errors (x-plugin-script, stay-userscript.html)
-    if (frames.length > 0 && frames.every(f => !f.filename || /\/x-plugin-script\/|stay-userscript\.html$/.test(f.filename))) return null;
+    if (frames.length > 0 && frames.every(f => !f.filename || /\/x-plugin-script\/|\/stay-userscript\.html$/.test(f.filename))) return null;
     // Suppress YouTube IFrame widget API internal errors
     if (frames.some(f => /www-widgetapi\.js/.test(f.filename ?? ''))) return null;
     // Suppress Sentry beacon XHR transport errors (readyState on aborted XHR — not our code)


### PR DESCRIPTION
## Summary

Triage of 3 new Sentry issues from the 2026-05-11 sweep. Two filter
extensions in `src/main.ts`; one issue resolved without code (transient
Convex platform 503 at level=warning, auto-reopens on recurrence).

- **WORLDMONITOR-QZ** (3 events / 1 user) — `TypeError: can't access
  property "bind", ne.texture is undefined` thrown inside maplibre's
  GL bindings (Firefox). The existing maplibre internal-crash regex at
  `src/main.ts:304` only covered `id`/`type`/`setFilter` property
  names and a bare `\w+` for the variable, missing both the `bind`
  property name and the dotted `ne.texture` form. Widened the
  property allowlist to include `bind` and changed `\w+` →
  `[\w.]+`. Still stack-gated to `map`/`maplibre`/`deck-stack`
  chunks, so a first-party regression with the same message shape
  remains visible.

- **WORLDMONITOR-R0** (2 events / 1 user) — `TypeError: Illegal
  invocation` from a `./stay-userscript.html` host (another
  userscript runner alongside Tampermonkey/Greasemonkey). Extended the
  every-frame userscript filter at `src/main.ts:430` with
  `stay-userscript\.html$`. Frame-scoped: only fires when **every**
  frame is userscript-owned, so app code intermixed with a userscript
  stack still reports.

- **WORLDMONITOR-Q7** (21 events / 9 users, level=warning) — Convex
  platform 503 transient (`DOMException: The operation was aborted
  due to timeout`) already filtered to `warning` upstream via the PR
  #3479 typed-503 plumbing. No code change; resolved with
  `inNextRelease: true` so any recurrence auto-reopens.

All three resolved in Sentry via API.

## Test plan

- [x] `npm run typecheck` — PASS
- [x] `npm run typecheck:api` — PASS (includes
      `audit-convex-string-calls`)
- [x] `npm run lint` — PASS (warnings only, all pre-existing)
- [x] `npm run test:data` — PASS (8559 tests)
- [x] `node --test tests/edge-functions.test.mjs` — PASS (184 tests)
- [x] `npm run lint:md` — PASS
- [x] `npm run version:check` — PASS
- [x] Edge bundle check — PASS
- [ ] Verify WORLDMONITOR-QZ/R0 do not reopen after next release