### PR TITLE
fix(mcp): downgrade tool-execution HTTP 4xx to warning level

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -1522,7 +1522,18 @@ async function dispatchToolsCall(
   } catch (err: unknown) {
     if (proRollback) await proRollback();
     console.error('[mcp] tool execution error:', err);
-    captureSilentError(err, { tags: { route: 'api/mcp', step: 'tool-execution', tool: tool.name }, ctx });
+    // HTTP 4xx from an internal sibling fetch (e.g. `feed-digest HTTP 401`)
+    // is expected-but-trackable: transient HMAC/auth/quota drift, replay-window
+    // skew, or a single user's expired context. Report at `warning` so single
+    // occurrences don't drown real 5xx bugs in alerts; the pattern still
+    // surfaces if it recurs. Non-HTTP errors and 5xx stay at default `error`.
+    const message = err instanceof Error ? err.message : String(err);
+    const isClient4xx = /HTTP 4\d\d\b/.test(message);
+    captureSilentError(err, {
+      tags: { route: 'api/mcp', step: 'tool-execution', tool: tool.name },
+      ctx,
+      ...(isClient4xx ? { level: 'warning' as const } : {}),
+    });
     return rpcError(id, -32603, 'Internal error: data fetch failed');
   }
 }

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -1521,14 +1521,18 @@ async function dispatchToolsCall(
     return rpcOk(id, { content: [{ type: 'text', text: JSON.stringify(result) }] }, corsHeaders);
   } catch (err: unknown) {
     if (proRollback) await proRollback();
-    console.error('[mcp] tool execution error:', err);
     // HTTP 4xx from an internal sibling fetch (e.g. `feed-digest HTTP 401`)
     // is expected-but-trackable: transient HMAC/auth/quota drift, replay-window
     // skew, or a single user's expired context. Report at `warning` so single
     // occurrences don't drown real 5xx bugs in alerts; the pattern still
     // surfaces if it recurs. Non-HTTP errors and 5xx stay at default `error`.
+    // Log-drain consumers (Vercel, Datadog) read console severity, so route
+    // the `console.*` call to match the Sentry level — otherwise log alerts
+    // fire on 4xx while Sentry does not, defeating the downgrade.
     const message = err instanceof Error ? err.message : String(err);
     const isClient4xx = /HTTP 4\d\d\b/.test(message);
+    const log = isClient4xx ? console.warn : console.error;
+    log('[mcp] tool execution error:', err);
     captureSilentError(err, {
       tags: { route: 'api/mcp', step: 'tool-execution', tool: tool.name },
       ctx,


### PR DESCRIPTION
## Summary

WORLDMONITOR-R1 was a single-event `feed-digest HTTP 401` from
`get_world_brief`'s internal sibling fetch to
`/api/news/v1/list-feed-digest`. The MCP tool-execution dispatcher
captured it at default `error` level via `captureSilentError`, so a
transient HMAC/replay/auth blip on one user surfaced as an error-grade
Sentry issue.

- 4xx-from-internal-fetch is **expected-but-trackable** (transient
  HMAC drift around a deploy, replay-window skew, single-user expired
  context, gateway quota refusal). It should NOT drown real 5xx
  backend regressions in alerting.
- The thrown shape is uniform across every tool in `api/mcp.ts` (each
  `_execute` throws `Error('<endpoint> HTTP ${status}')` on non-OK),
  so the gate at the dispatcher applies to all tools without per-call
  edits.
- `captureSilentError` already supports `level: 'warning'`
  (`api/_sentry-common.js:80`); the dispatcher just wasn't wiring it.

The change inspects the thrown error message for `HTTP 4\d\d\b` and
passes `level: 'warning'` when matched. 5xx, network failures, parse
errors, and any non-HTTP throw stay at the default `error` level so
real bugs still page.

## Test plan

- [x] `npm run typecheck` — PASS
- [x] `npm run typecheck:api` — PASS (incl. `audit-convex-string-calls`)
- [x] `npm run lint` — PASS (warnings only, all pre-existing)
- [x] `npm run test:data` — PASS (8559/8559)
- [x] `node --test tests/edge-functions.test.mjs` — PASS (184/184)
- [x] `npm run lint:md` — PASS
- [x] `npm run version:check` — PASS
- [x] Edge bundle check — PASS
- [ ] After deploy, verify WORLDMONITOR-R1 recurrence (if any) lands at
      `warning` level, not `error`