### PR TITLE
fix(seed-comtrade): freshness gate + monthly cron — backstop UN Comtrade quota

### DIFF
--- a/scripts/seed-comtrade-bilateral-hs4.mjs
+++ b/scripts/seed-comtrade-bilateral-hs4.mjs
@@ -29,8 +29,19 @@ const LOCK_TTL_MS = 30 * 60 * 1000; // 30 min
 // new monthly Railway cron with one tick of slack against missed runs.
 // Belt-and-suspenders against the UN Comtrade Free APIs 500 calls/month
 // quota (~396 calls per run with a single COMTRADE_API_KEYS entry).
-// Override for force-resed scenarios: FORCE_RESEED=true bypasses the gate.
-const FRESHNESS_GATE_MS = 24 * 24 * 60 * 60 * 1000;
+// Override for force-reseed scenarios: FORCE_RESEED=true bypasses the gate.
+export const FRESHNESS_GATE_MS = 24 * 24 * 60 * 60 * 1000;
+
+// seed-meta TTL must outlive the freshness gate by at least one cron tick
+// of slack. Otherwise Redis evicts the key between SEED_META_TTL_SECONDS
+// and FRESHNESS_GATE_MS / 1000, opening a fail-open window where the gate
+// silently lets every cron tick through. Pre-fix (Greptile review on
+// PR #3661): meta TTL was TTL_SECONDS * 3 = 9d while gate = 24d, leaving
+// days 9-24 unprotected — if the cron ever flipped back to daily, those
+// 15 days would burn ~6,000 calls against the 500/mo quota.
+//
+// Formula: gate + 1 day buffer (absorbs clock skew + one missed tick).
+export const SEED_META_TTL_SECONDS = Math.ceil(FRESHNESS_GATE_MS / 1000) + 86_400;
 
 const COMTRADE_KEYS = (process.env.COMTRADE_API_KEYS || '').split(',').map(k => k.trim()).filter(Boolean);
 let keyIndex = 0;
@@ -323,7 +334,9 @@ export async function main() {
 
   const writeMeta = async (count, status = 'ok') => {
     const meta = JSON.stringify({ fetchedAt: Date.now(), recordCount: count, status });
-    await redisPipeline([['SET', META_KEY, meta, 'EX', String(TTL_SECONDS * 3)]])
+    // TTL ≥ FRESHNESS_GATE_MS so the gate's "fresh" answer cannot be silently
+    // invalidated by Redis eviction. See the SEED_META_TTL_SECONDS comment.
+    await redisPipeline([['SET', META_KEY, meta, 'EX', String(SEED_META_TTL_SECONDS)]])
       .catch(e => console.warn('[bilateral-hs4] Failed to write seed-meta:', e.message));
   };
 

--- a/scripts/seed-comtrade-bilateral-hs4.mjs
+++ b/scripts/seed-comtrade-bilateral-hs4.mjs
@@ -22,6 +22,16 @@ const TTL_SECONDS = 259200; // 72h
 const LOCK_DOMAIN = 'comtrade:bilateral-hs4';
 const LOCK_TTL_MS = 30 * 60 * 1000; // 30 min
 
+// Freshness gate: skip the run if seed-meta says we re-seeded recently.
+// Mirrors _bundle-runner.mjs:240's `elapsed < intervalMs * 0.8` pattern so
+// the gate lives in code regardless of the Railway cron cadence or any
+// future Watch-Paths filter changes. Set to 24d (0.8 × 30d) to match the
+// new monthly Railway cron with one tick of slack against missed runs.
+// Belt-and-suspenders against the UN Comtrade Free APIs 500 calls/month
+// quota (~396 calls per run with a single COMTRADE_API_KEYS entry).
+// Override for force-resed scenarios: FORCE_RESEED=true bypasses the gate.
+const FRESHNESS_GATE_MS = 24 * 24 * 60 * 60 * 1000;
+
 const COMTRADE_KEYS = (process.env.COMTRADE_API_KEYS || '').split(',').map(k => k.trim()).filter(Boolean);
 let keyIndex = 0;
 function getNextKey() {
@@ -105,6 +115,32 @@ async function redisPipeline(commands) {
     throw new Error(`Redis pipeline failed: HTTP ${resp.status} — ${text.slice(0, 200)}`);
   }
   return resp.json();
+}
+
+/**
+ * Returns { fresh, ageMs, reason } for the existing seed-meta record.
+ * Fail-open: any read error or parse error reports fresh=false so the
+ * caller can fall through to the regular fetch path. The cron schedule
+ * (monthly) is the primary quota guard; this gate is the secondary one.
+ */
+export async function checkSeedMetaFreshness(now = Date.now()) {
+  try {
+    const result = await redisPipeline([['GET', META_KEY]]);
+    const raw = Array.isArray(result) ? result[0]?.result : null;
+    if (!raw || typeof raw !== 'string') return { fresh: false, ageMs: null, reason: 'no-meta' };
+    const parsed = JSON.parse(raw);
+    const fetchedAt = Number(parsed?.fetchedAt);
+    if (!Number.isFinite(fetchedAt) || fetchedAt <= 0) {
+      return { fresh: false, ageMs: null, reason: 'no-fetchedAt' };
+    }
+    const ageMs = now - fetchedAt;
+    if (ageMs < FRESHNESS_GATE_MS) return { fresh: true, ageMs, reason: 'within-gate' };
+    return { fresh: false, ageMs, reason: 'stale' };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`[bilateral-hs4] seed-meta freshness check failed (fail-open): ${message}`);
+    return { fresh: false, ageMs: null, reason: 'read-error' };
+  }
 }
 
 /**
@@ -253,6 +289,22 @@ function groupByProduct(records) {
 export async function main() {
   const startedAt = Date.now();
   const runId = `${LOCK_DOMAIN}:${startedAt}`;
+
+  // Freshness gate: skip if seed-meta says we re-seeded < 24d ago.
+  // One run = ~396 authenticated UN Comtrade calls; their Free APIs tier is
+  // 500/month, so a stuck-on cron schedule used to put us 24× over quota
+  // before this gate landed. FORCE_RESEED=true bypasses (used by ad-hoc
+  // refresh scripts like post-pr*-force-refresh.mjs).
+  if (!process.env.FORCE_RESEED) {
+    const freshness = await checkSeedMetaFreshness();
+    if (freshness.fresh) {
+      const ageDays = freshness.ageMs != null ? (freshness.ageMs / 86_400_000).toFixed(1) : '?';
+      const gateDays = (FRESHNESS_GATE_MS / 86_400_000).toFixed(0);
+      console.log(`[bilateral-hs4] seed-meta is ${ageDays}d old (gate=${gateDays}d) — skipping (set FORCE_RESEED=true to override)`);
+      return;
+    }
+  }
+
   const lock = await acquireLockSafely(LOCK_DOMAIN, runId, LOCK_TTL_MS, { label: LOCK_DOMAIN });
 
   const countries = Object.entries(COUNTRY_PORT_CLUSTERS)

--- a/tests/seed-comtrade-bilateral-freshness-gate.test.mjs
+++ b/tests/seed-comtrade-bilateral-freshness-gate.test.mjs
@@ -1,0 +1,101 @@
+// Regression test for the seed-comtrade-bilateral-hs4 freshness gate.
+// Backstop against the Comtrade Free APIs 500/month quota being burned by a
+// stuck-on cron. Discovered 2026-05-11: Railway cron was set to daily but
+// only fired once every ~2 weeks via Watch-Paths accident; if the filter
+// ever starts firing reliably, daily × ~396 calls = ~24× over quota. The
+// gate inside the seeder is the belt-and-suspenders defense regardless of
+// cron cadence.
+
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { checkSeedMetaFreshness } from '../scripts/seed-comtrade-bilateral-hs4.mjs';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+const ORIGINAL_REDIS_URL = process.env.UPSTASH_REDIS_REST_URL;
+const ORIGINAL_REDIS_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+function mockRedisGet(value) {
+  // Upstash REST /pipeline returns an array of { result } objects.
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify([{ result: value }]), { status: 200 });
+}
+
+function mockRedisError() {
+  globalThis.fetch = async () =>
+    new Response('boom', { status: 500 });
+}
+
+beforeEach(() => {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://test.upstash.io';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  if (ORIGINAL_REDIS_URL === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = ORIGINAL_REDIS_URL;
+  if (ORIGINAL_REDIS_TOKEN === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = ORIGINAL_REDIS_TOKEN;
+});
+
+test('checkSeedMetaFreshness: fresh seed (1 day old) reports fresh=true', async () => {
+  const now = Date.now();
+  mockRedisGet(JSON.stringify({ fetchedAt: now - 1 * 86_400_000, recordCount: 180, status: 'ok' }));
+  const result = await checkSeedMetaFreshness(now);
+  assert.equal(result.fresh, true);
+  assert.equal(result.reason, 'within-gate');
+});
+
+test('checkSeedMetaFreshness: stale seed (25 days old) reports fresh=false', async () => {
+  const now = Date.now();
+  mockRedisGet(JSON.stringify({ fetchedAt: now - 25 * 86_400_000, recordCount: 180, status: 'ok' }));
+  const result = await checkSeedMetaFreshness(now);
+  assert.equal(result.fresh, false);
+  assert.equal(result.reason, 'stale');
+});
+
+test('checkSeedMetaFreshness: exactly at the 24-day gate boundary is treated as stale', async () => {
+  // The gate is `ageMs < FRESHNESS_GATE_MS` (strict <), so exactly-at-gate
+  // falls through to a re-seed. Pins the boundary so a future refactor that
+  // flips the comparison to `<=` has to update this assertion.
+  const now = Date.now();
+  mockRedisGet(JSON.stringify({ fetchedAt: now - 24 * 86_400_000, recordCount: 180, status: 'ok' }));
+  const result = await checkSeedMetaFreshness(now);
+  assert.equal(result.fresh, false, 'exactly-at-gate falls through to re-seed');
+});
+
+test('checkSeedMetaFreshness: missing seed-meta returns fresh=false (no-meta)', async () => {
+  mockRedisGet(null);
+  const result = await checkSeedMetaFreshness(Date.now());
+  assert.equal(result.fresh, false);
+  assert.equal(result.reason, 'no-meta');
+});
+
+test('checkSeedMetaFreshness: malformed seed-meta returns fresh=false (no-fetchedAt)', async () => {
+  mockRedisGet(JSON.stringify({ recordCount: 5 })); // missing fetchedAt
+  const result = await checkSeedMetaFreshness(Date.now());
+  assert.equal(result.fresh, false);
+  assert.equal(result.reason, 'no-fetchedAt');
+});
+
+test('checkSeedMetaFreshness: invalid JSON in seed-meta returns fresh=false (read-error)', async () => {
+  mockRedisGet('not-valid-json');
+  const result = await checkSeedMetaFreshness(Date.now());
+  assert.equal(result.fresh, false);
+  assert.equal(result.reason, 'read-error');
+});
+
+test('checkSeedMetaFreshness: Redis HTTP 500 fails open (fresh=false, reason=read-error)', async () => {
+  mockRedisError();
+  const result = await checkSeedMetaFreshness(Date.now());
+  assert.equal(result.fresh, false);
+  assert.equal(result.reason, 'read-error');
+});
+
+test('checkSeedMetaFreshness: fetchedAt:0 (legacy bad write) treated as no-fetchedAt', async () => {
+  mockRedisGet(JSON.stringify({ fetchedAt: 0 }));
+  const result = await checkSeedMetaFreshness(Date.now());
+  assert.equal(result.fresh, false);
+  assert.equal(result.reason, 'no-fetchedAt');
+});

--- a/tests/seed-comtrade-bilateral-freshness-gate.test.mjs
+++ b/tests/seed-comtrade-bilateral-freshness-gate.test.mjs
@@ -9,7 +9,11 @@
 import { test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { checkSeedMetaFreshness } from '../scripts/seed-comtrade-bilateral-hs4.mjs';
+import {
+  checkSeedMetaFreshness,
+  FRESHNESS_GATE_MS,
+  SEED_META_TTL_SECONDS,
+} from '../scripts/seed-comtrade-bilateral-hs4.mjs';
 
 const ORIGINAL_FETCH = globalThis.fetch;
 const ORIGINAL_REDIS_URL = process.env.UPSTASH_REDIS_REST_URL;
@@ -98,4 +102,35 @@ test('checkSeedMetaFreshness: fetchedAt:0 (legacy bad write) treated as no-fetch
   const result = await checkSeedMetaFreshness(Date.now());
   assert.equal(result.fresh, false);
   assert.equal(result.reason, 'no-fetchedAt');
+});
+
+test('invariant: SEED_META_TTL_SECONDS strictly outlives FRESHNESS_GATE_MS', () => {
+  // Greptile review on PR #3661 caught the original: meta TTL was 9d while
+  // gate was 24d, leaving a 15-day fail-open window between Redis eviction
+  // and gate expiry. This invariant prevents the bug from regressing.
+  const gateSeconds = FRESHNESS_GATE_MS / 1000;
+  assert.ok(
+    SEED_META_TTL_SECONDS > gateSeconds,
+    `SEED_META_TTL_SECONDS (${SEED_META_TTL_SECONDS}s) must be > FRESHNESS_GATE_MS in seconds (${gateSeconds}s)`,
+  );
+  // Pin the buffer too — without it the relationship is brittle to clock skew.
+  const bufferSeconds = SEED_META_TTL_SECONDS - gateSeconds;
+  assert.ok(
+    bufferSeconds >= 86_400,
+    `seed-meta TTL must outlive the gate by ≥1 day for clock-skew + missed-tick slack (got ${bufferSeconds}s)`,
+  );
+});
+
+test('invariant: seed-meta TTL chosen by writeMeta covers the full gate window (no fail-open hole)', () => {
+  // Property statement: at any t ∈ [0, FRESHNESS_GATE_MS), if a successful run
+  // wrote seed-meta at t=0, the meta key must still exist in Redis. Without
+  // this property, the gate goes from "skip if fresh" to "fail-open and burn
+  // the upstream quota" between TTL-eviction and gate-elapsed.
+  for (const tMs of [0, FRESHNESS_GATE_MS / 4, FRESHNESS_GATE_MS / 2, FRESHNESS_GATE_MS - 1]) {
+    const tSeconds = tMs / 1000;
+    assert.ok(
+      tSeconds < SEED_META_TTL_SECONDS,
+      `at t=${tSeconds}s after write, meta TTL (${SEED_META_TTL_SECONDS}s) must still cover us`,
+    );
+  }
 });


### PR DESCRIPTION
## Summary

The `seed-comtrade-bilateral-hs4` Railway service was set to fire daily (`0 6 * * *`) against the UN Comtrade **Free APIs** tier (500 calls/month). Each run = ~396 authenticated calls; daily firing would put us **24× over quota**. The actual outcome was masked entirely by Railway's Watch Paths filter silently dropping 99 of 100 cron ticks (91 `SKIPPED` + 8 `REMOVED` + 1 `SUCCESS` in the last 100 deployments spanning 12 days). That single accidental `SUCCESS` run consumed 378 of 500 calls in the current monthly window — surfaced via the UN Comtrade "approaching quota limit" email.

Two **independent** defenses landed in this PR:

### 1. Railway cron schedule: `0 6 * * *` → `0 6 1 * *`

Applied via Railway GraphQL API; verified by read-back. Monthly matches the data's annual update cadence — daily refresh was pure waste.

### 2. In-seeder freshness gate (the real fix)

`scripts/seed-comtrade-bilateral-hs4.mjs` now `GET`s `seed-meta:comtrade:bilateral-hs4` before lock acquisition. If `fetchedAt < 24 days ago`, skip the run (mirrors the `_bundle-runner.mjs:240` `elapsed < intervalMs * 0.8` pattern).

- **Fail-open** on Redis read errors, JSON parse errors, missing `fetchedAt`, or `fetchedAt:0` legacy bad writes — the cron schedule is the primary quota guard; this gate is secondary.
- **`FORCE_RESEED=true`** bypasses for ad-hoc `post-pr*-force-refresh.mjs` workflows.
- Skips the lock acquisition entirely on fresh-meta hits → a no-op cron tick costs 1 Redis GET, 0 Comtrade calls.

The two defenses are deliberately independent:
- If Railway "fixes" the Watch Paths filter or someone resets the cron, the in-seeder gate still prevents quota burn.
- If the seed-meta key gets corrupted or unreadable, the monthly cron still prevents daily-fire mode.

## Why not just delete the auth env var?

The seeder already supports `usePublicApi` mode (`seed-comtrade-bilateral-hs4.mjs:34`) when `COMTRADE_API_KEYS` is unset. Keeping the authenticated tier is intentional — 1500ms pacing (auth) vs 3500ms (public) means ~6.6 min vs ~15 min per full run. The freshness gate makes this a non-issue at the current cadence.

## Test plan

- [x] 8 new focused unit tests in `tests/seed-comtrade-bilateral-freshness-gate.test.mjs` cover fresh/stale/exact-boundary, missing meta, malformed JSON, invalid JSON parse exception, Redis HTTP 500 fail-open, and `fetchedAt:0` legacy edge case.
- [x] Existing `tests/seed-comtrade-5xx-retry.test.mjs` regression suite still passes (8526 → 8534 tests, +8).
- [x] `npm run typecheck` — passes
- [x] `npm run typecheck:api` — passes
- [x] `npm run lint` — passes (235 warnings, 0 errors; all pre-existing)
- [x] `npm run test:data` — 8534/8534 pass
- [x] `node --test tests/edge-functions.test.mjs` — 184/184 pass
- [x] `npm run lint:md` — 0 errors
- [x] Edge function bundle check — passes
- [x] Pre-push hooks all green
- [x] Railway cron schedule change verified via GraphQL read-back: `0 6 1 * *`

## Verification post-merge

After this PR merges and the next cron tick fires (1st of June), verify:

```
railway logs --service seed-comtrade-bilateral-hs4 --since 1h
```

Expected log line if seed-meta is still fresh from this month's accidental run:
```
[bilateral-hs4] seed-meta is N.Nd old (gate=24d) — skipping (set FORCE_RESEED=true to override)
```

If you want to force-refresh later: `FORCE_RESEED=true` on the next cron, or run the seeder ad-hoc via `railway run`.