### PR TITLE
docs(mcp-server): user-facing API coverage table

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -32,7 +32,13 @@ export const config = { runtime: 'edge' };
 
 const MCP_PROTOCOL_VERSION = '2025-03-26';
 const SERVER_NAME = 'worldmonitor';
-const SERVER_VERSION = '1.0';
+// Bumped 1.0 → 1.1.0 (2026-05-11) reflecting:
+//   - PR #3658 Tier-1+2 expansion (6 new tools added: displacement, health,
+//     energy, consumer-prices, tariffs, chokepoint)
+//   - PR #3662 Tier-4 parity (_apiPaths metadata + CI-enforced parity test)
+// Keep aligned with public/.well-known/mcp/server-card.json::serverInfo.version
+// — discovery scanners cross-check both values.
+const SERVER_VERSION = '1.1.0';
 
 // Country-code whitelist for get_consumer_prices. The consumer-prices seeder
 // currently only produces data for AE (UAE); future markets will be added

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -181,6 +181,7 @@
             "pages": [
               "agent-discovery",
               "mcp-server",
+              "mcp-tools-reference",
               "api-oauth",
               "api-notifications"
             ]

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -247,7 +247,7 @@ For per-tool parameters, freshness budgets, timeouts, and concrete `curl` exampl
 
 ## API coverage
 
-Every MCP tool wraps one or more REST/RPC endpoints from the [API Reference](/api-reference). The table below maps each tool to the API paths it serves — useful when you know the API endpoint you want and need to find the corresponding MCP tool, or vice versa.
+Most MCP tools wrap one or more REST/RPC endpoints from the [API Reference](/api-reference). The table below maps each covered tool to the API paths it serves — useful when you know the API endpoint you want and need to find the corresponding MCP tool, or vice versa. A handful of tools read bootstrap-aggregate caches without a 1:1 API endpoint and don't appear in this table; see the [MCP Tools Reference](/mcp-tools-reference) for the complete 38-tool set.
 
 | MCP tool | API endpoints served |
 |----------|---------------------|

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -247,7 +247,7 @@ For per-tool parameters, freshness budgets, timeouts, and concrete `curl` exampl
 
 ## API coverage
 
-Most MCP tools wrap one or more REST/RPC endpoints from the [API Reference](/api-reference). The table below maps each covered tool to the API paths it serves — useful when you know the API endpoint you want and need to find the corresponding MCP tool, or vice versa. A handful of tools read bootstrap-aggregate caches without a 1:1 API endpoint and don't appear in this table; see the [MCP Tools Reference](/mcp-tools-reference) for the complete 38-tool set.
+Most MCP tools wrap one or more REST/RPC endpoints from the [API Reference](/api-reference). The table below maps each covered tool to the API paths it serves — useful when you know the API endpoint you want and need to find the corresponding MCP tool, or vice versa. A handful of tools don't appear in this table because they don't expose a 1:1 public OpenAPI operation — see the trailing note below the table for the categories, and the [MCP Tools Reference](/mcp-tools-reference) for the complete 38-tool set.
 
 | MCP tool | API endpoints served |
 |----------|---------------------|
@@ -282,7 +282,13 @@ Most MCP tools wrap one or more REST/RPC endpoints from the [API Reference](/api
 | `search_flights` | `GET /api/aviation/v1/search-google-flights` |
 | `search_flight_prices_by_date` | `GET /api/aviation/v1/search-google-dates` |
 
-A handful of cache-backed tools wrap data that's seeded directly into Redis without a 1:1 API endpoint — these tools have no entry above but still return live data via `tools/call`. See the [Tool catalog](#tool-catalog) above for the complete list of 38 tools.
+A handful of tools have no entry above because they don't map 1:1 to a public OpenAPI operation. They still return live data via `tools/call`; they fall into three categories:
+
+- **Cache-backed bootstrap aggregates** — read Redis keys seeded directly by Railway crons (e.g. `get_aviation_status`, `get_cyber_threats`, `get_country_macro`, the three EU Eurostat tools).
+- **Static in-memory registries** — filter a constant bundled with the MCP server's edge binary, no upstream call at all (e.g. `get_commodity_geo`).
+- **Live tools without a public OpenAPI row** — runtime proxies an HTTP call whose method drifts from the public spec, where a sibling tool already covers the spec-declared method (e.g. `generate_forecasts` POSTs `/api/forecast/v1/get-forecasts` while `get_forecast_predictions` owns the GET).
+
+See the [Tool catalog](#tool-catalog) above for the complete list of 38 tools, or the [MCP Tools Reference](/mcp-tools-reference) for per-tool details.
 
 <Tip>
 **Reverse lookup** — if you know the API path you want, search this table with Cmd/Ctrl+F. The same data is also queryable via the running server's `tools/list` response, where each tool description names its domain.

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -241,14 +241,48 @@ The server exposes 38 tools. Most are cache-reads over pre-seeded Redis keys (su
 | `generate_forecasts` | Fresh probability estimates (bypasses cache). | LLM |
 | `get_forecast_predictions` | Pre-computed cached forecasts. Fast. | Cache |
 
-## Coverage invariants
+## API coverage
 
-WorldMonitor's MCP server is held to two CI-enforced coverage invariants so the tool list stays aligned with the rest of the platform:
+Every MCP tool wraps one or more REST/RPC endpoints from the [API Reference](/api-reference). The table below maps each tool to the API paths it serves — useful when you know the API endpoint you want and need to find the corresponding MCP tool, or vice versa.
 
-- **Cache-key parity** (`tests/mcp-bootstrap-parity.test.mjs`) — every seeded cache key in `api/health.js::BOOTSTRAP_KEYS` ∪ `STANDALONE_KEYS` is either covered by some tool's `_cacheKeys`/`_coverageKeys` or listed in `EXCLUDED_FROM_MCP` with a documented reason. A new seed shipping a cache key without MCP exposure fails CI.
-- **API parity** (`tests/mcp-api-parity.test.mjs`) — every public OpenAPI operation in `docs/api/*.openapi.json` is either declared in some tool's `_apiPaths` array or listed in `EXCLUDED_FROM_MCP_PARITY` with a category-prefixed reason. A new API endpoint without MCP coverage AND without a documented exclusion fails CI.
+| MCP tool | API endpoints served |
+|----------|---------------------|
+| `get_market_data` | `GET /api/market/v1/get-fear-greed-index`<br/>`GET /api/market/v1/get-sector-summary`<br/>`GET /api/market/v1/list-commodity-quotes`<br/>`GET /api/market/v1/list-crypto-quotes`<br/>`GET /api/market/v1/list-etf-flows`<br/>`GET /api/market/v1/list-gulf-quotes`<br/>`GET /api/market/v1/list-market-quotes` |
+| `get_economic_data` | `GET /api/economic/v1/get-ecb-fx-rates`<br/>`GET /api/economic/v1/get-economic-calendar`<br/>`GET /api/economic/v1/get-eu-yield-curve`<br/>`GET /api/economic/v1/list-fuel-prices`<br/>`GET /api/market/v1/get-cot-positioning`<br/>`GET /api/market/v1/list-earnings-calendar` |
+| `get_tariff_trends` | `GET /api/economic/v1/get-fao-food-price-index`<br/>`GET /api/economic/v1/get-national-debt`<br/>`GET /api/economic/v1/list-bigmac-prices` |
+| `get_energy_intelligence` | `GET /api/economic/v1/get-energy-crisis-policies`<br/>`GET /api/supply-chain/v1/get-fuel-shortage-detail`<br/>`GET /api/supply-chain/v1/list-energy-disruptions`<br/>`GET /api/supply-chain/v1/list-fuel-shortages` |
+| `get_consumer_prices` | `GET /api/consumer-prices/v1/get-consumer-price-freshness`<br/>`GET /api/consumer-prices/v1/get-consumer-price-overview`<br/>`GET /api/consumer-prices/v1/list-consumer-price-categories`<br/>`GET /api/consumer-prices/v1/list-consumer-price-movers`<br/>`GET /api/consumer-prices/v1/list-retailer-price-spreads` |
+| `get_supply_chain_data` | `GET /api/supply-chain/v1/get-shipping-stress`<br/>`GET /api/trade/v1/get-customs-revenue` |
+| `get_chokepoint_status` | `GET /api/intelligence/v1/get-country-port-activity`<br/>`GET /api/supply-chain/v1/get-chokepoint-status` |
+| `get_climate_data` | `GET /api/climate/v1/get-co2-monitoring`<br/>`GET /api/climate/v1/get-ocean-ice-data`<br/>`GET /api/climate/v1/list-air-quality-data`<br/>`GET /api/climate/v1/list-climate-anomalies`<br/>`GET /api/climate/v1/list-climate-disasters`<br/>`GET /api/climate/v1/list-climate-news` |
+| `get_health_signals` | `GET /api/health/v1/list-air-quality-alerts`<br/>`GET /api/health/v1/list-disease-outbreaks` |
+| `get_conflict_events` | `GET /api/conflict/v1/list-iran-events`<br/>`GET /api/conflict/v1/list-ucdp-events`<br/>`GET /api/unrest/v1/list-unrest-events` |
+| `get_news_intelligence` | `GET /api/intelligence/v1/list-cross-source-signals`<br/>`GET /api/intelligence/v1/search-gdelt-documents` |
+| `get_country_risk` | `GET /api/intelligence/v1/get-country-risk` |
+| `get_country_brief` | `GET /api/intelligence/v1/get-country-intel-brief` |
+| `get_social_velocity` | `GET /api/intelligence/v1/get-social-velocity` |
+| `get_natural_disasters` | `GET /api/natural/v1/list-natural-events`<br/>`GET /api/seismology/v1/list-earthquakes`<br/>`GET /api/wildfire/v1/list-fire-detections` |
+| `get_radiation_data` | `GET /api/radiation/v1/list-radiation-observations` |
+| `get_infrastructure_status` | `GET /api/infrastructure/v1/list-internet-outages` |
+| `get_airspace` | `GET /api/aviation/v1/track-aircraft`<br/>`GET /api/military/v1/list-military-flights` |
+| `get_maritime_activity` | `GET /api/maritime/v1/get-vessel-snapshot` |
+| `get_military_posture` | `GET /api/military/v1/get-theater-posture` |
+| `get_displacement_data` | `GET /api/displacement/v1/get-displacement-summary` |
+| `get_positive_events` | `GET /api/positive-events/v1/list-positive-geo-events` |
+| `get_sanctions_data` | `GET /api/sanctions/v1/list-sanctions-pressure`<br/>`GET /api/sanctions/v1/lookup-sanction-entity` |
+| `get_research_signals` | `GET /api/research/v1/list-tech-events` |
+| `get_prediction_markets` | `GET /api/prediction/v1/list-prediction-markets` |
+| `get_forecast_predictions` | `GET /api/forecast/v1/get-forecasts` |
+| `get_world_brief` | `GET /api/news/v1/list-feed-digest`<br/>`POST /api/news/v1/summarize-article` |
+| `analyze_situation` | `POST /api/intelligence/v1/deduct-situation` |
+| `search_flights` | `GET /api/aviation/v1/search-google-flights` |
+| `search_flight_prices_by_date` | `GET /api/aviation/v1/search-google-dates` |
 
-When adding a new MCP tool, the `_apiPaths: string[]` field is **required** on every `TOOL_REGISTRY` entry (TypeScript-enforced) and declares the canonical `"METHOD path"` strings the tool covers — e.g., `['GET /api/economic/v1/get-bis-credit', 'GET /api/market/v1/list-defi-tokens']`. When adding a new OpenAPI operation that isn't meant to be MCP-callable (mutating, LLM passthrough, admin-only, etc.), add an entry to `EXCLUDED_FROM_MCP_PARITY` with one of six category prefixes: `mutating:`, `llm-passthrough:`, `fetch-on-miss:` (with a closed-allowlist secondary signal), `admin:`, `manual-mapping:`, or `deferred-to-future-tool:`.
+A handful of cache-backed tools wrap data that's seeded directly into Redis without a 1:1 API endpoint — these tools have no entry above but still return live data via `tools/call`. See the [Tool catalog](#tool-catalog) above for the complete list of 38 tools.
+
+<Tip>
+**Reverse lookup** — if you know the API path you want, search this table with Cmd/Ctrl+F. The same data is also queryable via the running server's `tools/list` response, where each tool description names its domain.
+</Tip>
 
 ## JSON-RPC example
 

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -207,8 +207,8 @@ For per-tool parameters, freshness budgets, timeouts, and concrete `curl` exampl
 
 | Tool | Description |
 |------|-------------|
-| `get_airspace` | Live ADS-B over a country. Params: `iso2` (2-letter code), `filter` (`all`/`civilian`/`military`). |
-| `get_maritime_activity` | AIS density zones, dark-ship events, chokepoint congestion per country. Params: `iso2`. |
+| `get_airspace` | Live ADS-B over a country. Params: `country_code` (2-letter code), `type` (`all`/`civilian`/`military`). |
+| `get_maritime_activity` | AIS density zones, dark-ship events, chokepoint congestion per country. Params: `country_code`. |
 | `get_aviation_status` | FAA airport delays, NOTAM closures, tracked military aircraft. |
 | `get_infrastructure_status` | Cloudflare Radar outages, major cloud/internet service status. |
 | `search_flights` | Google Flights real-time search between IATA airport codes on a specific date. |
@@ -308,7 +308,7 @@ curl -s https://worldmonitor.app/mcp \
   -d '{
     "jsonrpc":"2.0","id":2,
     "method":"tools/call",
-    "params":{"name":"get_country_risk","arguments":{"iso2":"IR"}}
+    "params":{"name":"get_country_risk","arguments":{"country_code":"IR"}}
   }'
 ```
 
@@ -331,7 +331,7 @@ Tool responses use the standard MCP content block format:
 }
 ```
 
-For cache tools, the JSON payload includes `_meta` with `fetchedAt` and `staleness` so the model can reason about freshness.
+For cache tools, the JSON payload includes `cached_at` (ISO timestamp of the oldest contributing data point) and `stale` (boolean — `true` when any contributing seed exceeded its per-key freshness budget) so the model can reason about freshness.
 
 ## Data freshness
 

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -163,6 +163,10 @@ npx @modelcontextprotocol/inspector https://worldmonitor.app/mcp
 
 The server exposes 38 tools. Most are cache-reads over pre-seeded Redis keys (sub-second). Six (`get_world_brief`, `get_country_brief`, `analyze_situation`, `generate_forecasts`, `search_flights`, `search_flight_prices_by_date`) call live LLMs or external APIs and are slower.
 
+<Tip>
+For per-tool parameters, freshness budgets, timeouts, and concrete `curl` examples, see the [MCP Tools Reference](/mcp-tools-reference).
+</Tip>
+
 ### Markets & economy
 
 | Tool | Description |

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -24,7 +24,7 @@ Pro subscribers can connect Claude Desktop / Cursor / claude.ai without ever pas
 | `https://api.worldmonitor.app/.well-known/oauth-authorization-server` | AS metadata (RFC 8414) |
 | `https://worldmonitor.app/.well-known/oauth-protected-resource` | Resource server metadata (RFC 9728) |
 
-Protocol version: `2025-03-26`. Server identifier: `worldmonitor` v1.0.
+Protocol version: `2025-03-26`. Server identifier: `worldmonitor` v1.1.0.
 
 ## Authentication
 

--- a/docs/mcp-tools-reference.mdx
+++ b/docs/mcp-tools-reference.mdx
@@ -242,8 +242,8 @@ Global mining sites with coordinates, operator, mineral type, and production sta
 | `mineral` | string | no | Filter by mineral type (e.g. "Gold", "Copper", "Lithium") |
 | `country` | string | no | Filter by country name (e.g. "Australia", "Chile") |
 
-- **API endpoints:** none directly — reads from a bootstrap-aggregate cache key (no 1:1 REST endpoint).
-- **Kind:** live RPC — proxies a fetch to the WorldMonitor API on each call.
+- **API endpoints:** none — this tool reads no cache and makes no HTTP fetch.
+- **Kind:** static registry — filters the bundled `MINING_SITES_RAW` constant (in-memory, ships with the MCP server's edge bundle). Sub-millisecond, no upstream call. The dataset updates only when the MCP server is redeployed with a refreshed registry.
 
 <CodeGroup>
 
@@ -1003,7 +1003,7 @@ Generate live AI geopolitical and economic forecasts. Unlike get_forecast_predic
 | `domain` | string | no | Forecast domain: "geopolitical", "economic", "military", "climate", or empty for all domains |
 | `region` | string | no | Geographic region filter, e.g. "Middle East", "Europe", "Asia Pacific", or empty for global |
 
-- **API endpoints:** none directly — reads from a bootstrap-aggregate cache key (no 1:1 REST endpoint).
+- **API endpoints:** no public OpenAPI row; runtime proxies `POST /api/forecast/v1/get-forecasts` (the OpenAPI spec only declares `GET` on that path, which is covered by `get_forecast_predictions` — this tool's POST variant runs a fresh forecast).
 - **Kind:** live RPC — proxies a fetch to the WorldMonitor API on each call. Edge-runtime timeout: **25.0s**.
 
 <CodeGroup>

--- a/docs/mcp-tools-reference.mdx
+++ b/docs/mcp-tools-reference.mdx
@@ -216,7 +216,7 @@ curl -s https://worldmonitor.app/mcp \
   -d '{
     "jsonrpc":"2.0","id":1,
     "method":"tools/call",
-    "params":{"name":"get_consumer_prices","arguments":{"country_code":"US"}}
+    "params":{"name":"get_consumer_prices","arguments":{"country_code":"AE"}}
   }'
 ```
 
@@ -370,7 +370,7 @@ AI-generated per-country intelligence brief. Produces an LLM-analyzed geopolitic
 | `framework` | string | no | Optional analytical framework instructions to shape the analysis lens (e.g. Ray Dalio debt cycle, PMESII-PT) |
 
 - **API endpoints:** `GET /api/intelligence/v1/get-country-intel-brief`
-- **Kind:** live RPC — proxies a fetch to the WorldMonitor API on each call. Edge-runtime timeout: **2.0s**.
+- **Kind:** live RPC — proxies a fetch to the WorldMonitor API on each call. Worst-case total budget **~24s** (2s context-digest fetch + 22s brief generation, sequential).
 
 <CodeGroup>
 
@@ -936,7 +936,7 @@ AI-generated world intelligence brief. Fetches the latest geopolitical headlines
 | `geo_context` | string | no | Optional focus context (e.g. "Middle East tensions", "US-China trade war") |
 
 - **API endpoints:** `GET /api/news/v1/list-feed-digest`, `POST /api/news/v1/summarize-article`
-- **Kind:** live RPC — proxies a fetch to the WorldMonitor API on each call. Edge-runtime timeout: **6.0s**.
+- **Kind:** live RPC — proxies a fetch to the WorldMonitor API on each call. Worst-case total budget **~24s** (6s digest fetch + 18s LLM summarization, sequential).
 
 <CodeGroup>
 

--- a/docs/mcp-tools-reference.mdx
+++ b/docs/mcp-tools-reference.mdx
@@ -13,6 +13,14 @@ Every tool returns the standard MCP content-block format:
 
 Cache-backed tools (the majority) include `cached_at` (ISO timestamp) and `stale: boolean` in their JSON payload so you can reason about freshness.
 
+The `curl` examples below all assume you've exported your API key:
+
+```bash
+export WM_KEY="wm_live_..."  # or use the OAuth bearer token instead — see /mcp-server#authentication
+```
+
+If you've completed the OAuth flow instead, replace `-H "X-WorldMonitor-Key: $WM_KEY"` with `-H "Authorization: Bearer $TOKEN"` in each example.
+
 <Tip>
 **Recently added** (May 2026): `get_displacement_data`, `get_health_signals`, `get_energy_intelligence`, `get_consumer_prices`, `get_tariff_trends`, `get_chokepoint_status` — six new bundled tools that exposed previously-cached domains via MCP.
 </Tip>
@@ -206,6 +214,7 @@ Per-country consumer-prices intelligence: 30-day overview, category-level inflat
 
 - **API endpoints:** `GET /api/consumer-prices/v1/get-consumer-price-freshness`, `GET /api/consumer-prices/v1/get-consumer-price-overview`, `GET /api/consumer-prices/v1/list-consumer-price-categories`, `GET /api/consumer-prices/v1/list-consumer-price-movers`, `GET /api/consumer-prices/v1/list-retailer-price-spreads`
 - **Kind:** hybrid — reads cache keys directly (sub-second) but requires an input parameter to select the slice.
+- **Freshness budget:** up to **25 h** per slice (24 h cron + 1 h grace) before `stale: true` is flagged.
 
 <CodeGroup>
 
@@ -520,7 +529,7 @@ Live maritime chokepoint status: per-chokepoint vessel transit counts (10-min ca
 
 - **API endpoints:** `GET /api/intelligence/v1/get-country-port-activity`, `GET /api/supply-chain/v1/get-chokepoint-status`
 - **Kind:** cache read — sub-second response from Redis bootstrap cache.
-- **Freshness budget:** up to **30 min** before `stale: true` is flagged (set by the seeder cron's expected interval).
+- **Freshness budget (per slice):** `stale: true` flags when ANY contributing slice exceeds its individual budget — **30 min** for live transit summaries (relay), **36 h** for PortWatch port activity, **14 d** for chokepoint flows, and up to **~400 d** for the static chokepoint registry / geographic baselines. The bundle's `cached_at` reflects the oldest contributing seed; `stale: true` doesn't mean ALL the data is old.
 
 <CodeGroup>
 
@@ -532,6 +541,31 @@ curl -s https://worldmonitor.app/mcp \
     "jsonrpc":"2.0","id":1,
     "method":"tools/call",
     "params":{"name":"get_chokepoint_status","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_positive_events`
+
+Positive geopolitical events: diplomatic agreements, humanitarian aid, development milestones, and peace initiatives worldwide.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/positive-events/v1/list-positive-geo-events`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **1 h** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_positive_events","arguments":{}}
   }'
 ```
 
@@ -893,31 +927,6 @@ curl -s https://worldmonitor.app/mcp \
     "jsonrpc":"2.0","id":1,
     "method":"tools/call",
     "params":{"name":"get_displacement_data","arguments":{}}
-  }'
-```
-
-</CodeGroup>
-
-### `get_positive_events`
-
-Positive geopolitical events: diplomatic agreements, humanitarian aid, development milestones, and peace initiatives worldwide.
-
-**Parameters:** none
-
-- **API endpoints:** `GET /api/positive-events/v1/list-positive-geo-events`
-- **Kind:** cache read — sub-second response from Redis bootstrap cache.
-- **Freshness budget:** up to **1 h** before `stale: true` is flagged (set by the seeder cron's expected interval).
-
-<CodeGroup>
-
-```bash curl
-curl -s https://worldmonitor.app/mcp \
-  -H "X-WorldMonitor-Key: $WM_KEY" \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "jsonrpc":"2.0","id":1,
-    "method":"tools/call",
-    "params":{"name":"get_positive_events","arguments":{}}
   }'
 ```
 

--- a/docs/mcp-tools-reference.mdx
+++ b/docs/mcp-tools-reference.mdx
@@ -1,0 +1,1038 @@
+---
+title: "MCP Tools Reference"
+description: "Per-tool reference for every MCP tool exposed by WorldMonitor — parameters, freshness, API endpoints, and example calls."
+---
+
+Complete reference for every MCP tool. Use this alongside the [MCP Server overview](/mcp-server) (connection, auth, plans, errors).
+
+Every tool returns the standard MCP content-block format:
+
+```json
+{ "jsonrpc": "2.0", "id": 1, "result": { "content": [{ "type": "text", "text": "{...json payload...}" }], "isError": false } }
+```
+
+Cache-backed tools (the majority) include `cached_at` (ISO timestamp) and `stale: boolean` in their JSON payload so you can reason about freshness.
+
+<Tip>
+**Recently added** (May 2026): `get_displacement_data`, `get_health_signals`, `get_energy_intelligence`, `get_consumer_prices`, `get_tariff_trends`, `get_chokepoint_status` — six new bundled tools that exposed previously-cached domains via MCP.
+</Tip>
+
+## Markets & economy
+
+### `get_market_data`
+
+Real-time equity quotes, commodity prices (including gold futures GC=F), crypto prices, forex FX rates (USD/EUR, USD/JPY etc.), sector performance, ETF flows, and Gulf market quotes from WorldMonitor's curated bootstrap cache.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/market/v1/get-fear-greed-index`, `GET /api/market/v1/get-sector-summary`, `GET /api/market/v1/list-commodity-quotes`, `GET /api/market/v1/list-crypto-quotes`, `GET /api/market/v1/list-etf-flows`, `GET /api/market/v1/list-gulf-quotes`, `GET /api/market/v1/list-market-quotes`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **30 min** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_market_data","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_economic_data`
+
+Macro economic indicators: Fed Funds rate (FRED), economic calendar events, fuel prices, ECB FX rates, EU yield curve, earnings calendar, COT positioning, energy storage data, BIS household debt service ratio (DSR, quarterly, leading indicator of household financial stress across ~40 advanced economies), and BIS residential + commercial property price indices (real, quarterly).
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/economic/v1/get-ecb-fx-rates`, `GET /api/economic/v1/get-economic-calendar`, `GET /api/economic/v1/get-eu-yield-curve`, `GET /api/economic/v1/list-fuel-prices`, `GET /api/market/v1/get-cot-positioning`, `GET /api/market/v1/list-earnings-calendar`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **1 d** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_economic_data","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_country_macro`
+
+Per-country macroeconomic indicators from IMF WEO (~210 countries, monthly cadence). Bundles fiscal/external balance (inflation, current account, gov revenue/expenditure/primary balance, CPI), growth & per-capita (real GDP growth, GDP/capita USD & PPP, savings & investment rates, savings-investment gap), labor & demographics (unemployment, population), and external trade (current account USD, import/export volume % changes). Latest available year per series. Use for country-level economic screening, peer benchmarking, and stagflation/imbalance flags. NOTE: export/import LEVELS in USD (exportsUsd, importsUsd, tradeBalanceUsd) are returned as null — WEO retracted broad coverage for BX/BM indicators in 2026-04; use currentAccountUsd or volume changes (import/exportVolumePctChg) instead.
+
+**Parameters:** none
+
+- **API endpoints:** none directly — reads from a bootstrap-aggregate cache key (no 1:1 REST endpoint).
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **70 d** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_country_macro","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_eu_housing_cycle`
+
+Eurostat annual house price index (prc_hpi_a, base 2015=100) for all 27 EU members plus EA20 and EU27_2020 aggregates. Each country entry includes the latest value, prior value, date, unit, and a 10-year sparkline series. Complements BIS WS_SPP with broader EU coverage for the Housing cycle tile.
+
+**Parameters:** none
+
+- **API endpoints:** none directly — reads from a bootstrap-aggregate cache key (no 1:1 REST endpoint).
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **50 d** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_eu_housing_cycle","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_eu_quarterly_gov_debt`
+
+Eurostat quarterly general government gross debt (gov_10q_ggdebt, %GDP) for all 27 EU members plus EA20 and EU27_2020 aggregates. Each country entry includes latest value, prior value, quarter label, and an 8-quarter sparkline series. Provides fresher debt-trajectory signal than annual IMF GGXWDG_NGDP for EU panels.
+
+**Parameters:** none
+
+- **API endpoints:** none directly — reads from a bootstrap-aggregate cache key (no 1:1 REST endpoint).
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **14 d** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_eu_quarterly_gov_debt","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_eu_industrial_production`
+
+Eurostat monthly industrial production index (sts_inpr_m, NACE B-D industry excl. construction, SCA, base 2021=100) for all 27 EU members plus EA20 and EU27_2020 aggregates. Each country entry includes latest value, prior value, month label, and a 12-month sparkline series. Leading indicator of real-economy activity used by the "Real economy pulse" sparkline.
+
+**Parameters:** none
+
+- **API endpoints:** none directly — reads from a bootstrap-aggregate cache key (no 1:1 REST endpoint).
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **5 d** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_eu_industrial_production","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_tariff_trends`
+
+Global trade and pricing indicators: US tariff trends (HTS-coded), BigMac index, FAO Food Price Index, and per-country national debt levels.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/economic/v1/get-fao-food-price-index`, `GET /api/economic/v1/get-national-debt`, `GET /api/economic/v1/list-bigmac-prices`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **9 h** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_tariff_trends","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_consumer_prices`
+
+Per-country consumer-prices intelligence: 30-day overview, category-level inflation, retailer spread (essentials basket), top movers, and source freshness. Requires country_code (currently only 'ae' is seeded).
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|---------:|-------------|
+| `country_code` | string | **yes** | ISO 3166-1 alpha-2 country code. Currently supported: AE (case-insensitive). |
+
+- **API endpoints:** `GET /api/consumer-prices/v1/get-consumer-price-freshness`, `GET /api/consumer-prices/v1/get-consumer-price-overview`, `GET /api/consumer-prices/v1/list-consumer-price-categories`, `GET /api/consumer-prices/v1/list-consumer-price-movers`, `GET /api/consumer-prices/v1/list-retailer-price-spreads`
+- **Kind:** hybrid — reads cache keys directly (sub-second) but requires an input parameter to select the slice.
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_consumer_prices","arguments":{"country_code":"US"}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_commodity_geo`
+
+Global mining sites with coordinates, operator, mineral type, and production status. Covers 71 major mines spanning gold, silver, copper, lithium, uranium, coal, and other minerals worldwide.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|---------:|-------------|
+| `mineral` | string | no | Filter by mineral type (e.g. "Gold", "Copper", "Lithium") |
+| `country` | string | no | Filter by country name (e.g. "Australia", "Chile") |
+
+- **API endpoints:** none directly — reads from a bootstrap-aggregate cache key (no 1:1 REST endpoint).
+- **Kind:** live RPC — proxies a fetch to the WorldMonitor API on each call.
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_commodity_geo","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_prediction_markets`
+
+Active Polymarket event contracts with current probabilities. Covers geopolitical, economic, and election prediction markets.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/prediction/v1/list-prediction-markets`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **1.5 h** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_prediction_markets","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+## Energy
+
+### `get_energy_intelligence`
+
+Energy supply, prices, storage, disruptions, and policy: EIA petroleum stocks, electricity prices (Ember), gas storage (GIE), fuel shortages, fossil & renewable shares, active energy disruptions, government crisis policies.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/economic/v1/get-energy-crisis-policies`, `GET /api/supply-chain/v1/get-fuel-shortage-detail`, `GET /api/supply-chain/v1/list-energy-disruptions`, `GET /api/supply-chain/v1/list-fuel-shortages`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **3 d** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_energy_intelligence","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+## Geopolitical & security
+
+### `get_conflict_events`
+
+Active armed conflict events (UCDP, Iran), unrest events with geo-coordinates, and country risk scores. Covers ongoing conflicts, protests, and instability indices worldwide.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/conflict/v1/list-iran-events`, `GET /api/conflict/v1/list-ucdp-events`, `GET /api/unrest/v1/list-unrest-events`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **30 min** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_conflict_events","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_country_risk`
+
+Structured risk intelligence for a specific country: Composite Instability Index (CII) score 0-100, component breakdown (unrest/conflict/security/news), travel advisory level, and OFAC sanctions exposure. Fast Redis read — no LLM. Use for quantitative risk screening or to answer "how risky is X right now?"
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|---------:|-------------|
+| `country_code` | string | **yes** | ISO 3166-1 alpha-2 country code, e.g. "RU", "IR", "CN", "UA" |
+
+- **API endpoints:** `GET /api/intelligence/v1/get-country-risk`
+- **Kind:** live RPC — proxies a fetch to the WorldMonitor API on each call. Edge-runtime timeout: **8.0s**.
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_country_risk","arguments":{"country_code":"US"}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_country_brief`
+
+AI-generated per-country intelligence brief. Produces an LLM-analyzed geopolitical and economic assessment for the given country. Supports analytical frameworks for structured lenses.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|---------:|-------------|
+| `country_code` | string | **yes** | ISO 3166-1 alpha-2 country code, e.g. "US", "DE", "CN", "IR" |
+| `framework` | string | no | Optional analytical framework instructions to shape the analysis lens (e.g. Ray Dalio debt cycle, PMESII-PT) |
+
+- **API endpoints:** `GET /api/intelligence/v1/get-country-intel-brief`
+- **Kind:** live RPC — proxies a fetch to the WorldMonitor API on each call. Edge-runtime timeout: **2.0s**.
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_country_brief","arguments":{"country_code":"US"}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_news_intelligence`
+
+AI-classified geopolitical threat news summaries, GDELT intelligence signals, cross-source signals, and security advisories from WorldMonitor's intelligence layer.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/intelligence/v1/list-cross-source-signals`, `GET /api/intelligence/v1/search-gdelt-documents`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **30 min** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_news_intelligence","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_cyber_threats`
+
+Active cyber threat intelligence: malware IOCs (URLhaus, Feodotracker), CISA known exploited vulnerabilities, and active command-and-control infrastructure.
+
+**Parameters:** none
+
+- **API endpoints:** none directly — reads from a bootstrap-aggregate cache key (no 1:1 REST endpoint).
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **4 h** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_cyber_threats","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_sanctions_data`
+
+OFAC SDN sanctioned entities list and sanctions pressure scores by country. Useful for compliance screening and geopolitical pressure analysis.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/sanctions/v1/list-sanctions-pressure`, `GET /api/sanctions/v1/lookup-sanction-entity`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **1 d** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_sanctions_data","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_social_velocity`
+
+Reddit geopolitical social velocity: top posts from worldnews, geopolitics, and related subreddits with engagement scores and trend signals.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/intelligence/v1/get-social-velocity`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **30 min** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_social_velocity","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_military_posture`
+
+Theater posture assessment and military risk scores. Reflects aggregated military positioning and escalation signals across global theaters.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/military/v1/get-theater-posture`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **2 h** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_military_posture","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_chokepoint_status`
+
+Live maritime chokepoint status: per-chokepoint vessel transit counts (10-min cadence), rolling transit summaries, per-port activity, plus static reference data (chokepoint geometry, canonical 13-chokepoint registry) and flow aggregates. Covers Suez, Hormuz, Malacca, Bab-el-Mandeb, Panama, etc.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/intelligence/v1/get-country-port-activity`, `GET /api/supply-chain/v1/get-chokepoint-status`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **30 min** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_chokepoint_status","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+## Movement & infrastructure
+
+### `get_aviation_status`
+
+Airport delays, NOTAM airspace closures, and tracked military aircraft. Covers FAA delay data and active airspace restrictions.
+
+**Parameters:** none
+
+- **API endpoints:** none directly — reads from a bootstrap-aggregate cache key (no 1:1 REST endpoint).
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **1.5 h** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_aviation_status","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_airspace`
+
+Live ADS-B aircraft over a country. Returns civilian flights (OpenSky) and identified military aircraft with callsigns, positions, altitudes, and headings. Answers questions like "how many planes are over the UAE right now?" or "are there military aircraft over Taiwan?"
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|---------:|-------------|
+| `country_code` | string | **yes** | ISO 3166-1 alpha-2 country code (e.g. "AE", "US", "GB", "JP") |
+| `type` | string (all / civilian / military) | no | Filter: all flights (default), civilian only, or military only |
+
+- **API endpoints:** `GET /api/aviation/v1/track-aircraft`, `GET /api/military/v1/list-military-flights`
+- **Kind:** live RPC — proxies a fetch to the WorldMonitor API on each call. Edge-runtime timeout: **8.0s**.
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_airspace","arguments":{"country_code":"US"}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_maritime_activity`
+
+Live vessel traffic and maritime disruptions for a country's waters. Returns AIS density zones (ships-per-day, intensity score), dark ship events, and chokepoint congestion from AIS tracking.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|---------:|-------------|
+| `country_code` | string | **yes** | ISO 3166-1 alpha-2 country code (e.g. "AE", "SA", "JP", "EG") |
+
+- **API endpoints:** `GET /api/maritime/v1/get-vessel-snapshot`
+- **Kind:** live RPC — proxies a fetch to the WorldMonitor API on each call. Edge-runtime timeout: **8.0s**.
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_maritime_activity","arguments":{"country_code":"US"}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_supply_chain_data`
+
+Dry bulk shipping stress index, customs revenue flows, and COMTRADE bilateral trade data. Tracks global supply chain pressure and trade disruptions.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/supply-chain/v1/get-shipping-stress`, `GET /api/trade/v1/get-customs-revenue`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **2 d** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_supply_chain_data","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_infrastructure_status`
+
+Internet infrastructure health: Cloudflare Radar outages and service status for major cloud providers and internet services.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/infrastructure/v1/list-internet-outages`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **30 min** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_infrastructure_status","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `search_flights`
+
+Search Google Flights for real-time flight options between two airports on a specific date. Returns available flights with prices, stops, airline, and segment details. Use IATA airport codes (e.g. "JFK", "LHR", "DXB").
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|---------:|-------------|
+| `origin` | string | **yes** | IATA code for the departure airport, e.g. "JFK" |
+| `destination` | string | **yes** | IATA code for the arrival airport, e.g. "LHR" |
+| `departure_date` | string | **yes** | Departure date in YYYY-MM-DD format |
+| `return_date` | string | no | Return date in YYYY-MM-DD format for round trips (optional) |
+| `cabin_class` | string | no | Cabin class: "economy", "premium_economy", "business", or "first" (optional, default economy) |
+| `max_stops` | string | no | Max stops: "0" or "non_stop" for nonstop, "1" or "one_stop" for max one stop, or omit for any (optional) |
+| `passengers` | number | no | Number of passengers (1-9, default 1) |
+| `sort_by` | string | no | Sort order: "price" (cheapest), "duration", "departure", or "arrival" (optional) |
+
+- **API endpoints:** `GET /api/aviation/v1/search-google-flights`
+- **Kind:** live RPC — proxies a fetch to the WorldMonitor API on each call. Edge-runtime timeout: **25.0s**.
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"search_flights","arguments":{"origin":"JFK","destination":"LHR","departure_date":"2026-08-15"}}
+  }'
+```
+
+</CodeGroup>
+
+### `search_flight_prices_by_date`
+
+Search Google Flights date-grid pricing across a date range. Returns cheapest prices for each departure date between two airports. Useful for finding the cheapest day to fly. Use IATA airport codes.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|---------:|-------------|
+| `origin` | string | **yes** | IATA code for the departure airport, e.g. "JFK" |
+| `destination` | string | **yes** | IATA code for the arrival airport, e.g. "LHR" |
+| `start_date` | string | **yes** | Start of the date range in YYYY-MM-DD format |
+| `end_date` | string | **yes** | End of the date range in YYYY-MM-DD format |
+| `is_round_trip` | boolean | no | Whether to search round-trip prices (default false). Requires trip_duration when true. |
+| `trip_duration` | number | no | Trip duration in days — required when is_round_trip is true (e.g. 7 for a one-week trip) |
+| `cabin_class` | string | no | Cabin class: "economy", "premium_economy", "business", or "first" (optional) |
+| `passengers` | number | no | Number of passengers (1-9, default 1) |
+| `sort_by_price` | boolean | no | Sort results by price ascending (default false, sorts by date) |
+
+- **API endpoints:** `GET /api/aviation/v1/search-google-dates`
+- **Kind:** live RPC — proxies a fetch to the WorldMonitor API on each call. Edge-runtime timeout: **25.0s**.
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"search_flight_prices_by_date","arguments":{"origin":"JFK","destination":"LHR","start_date":"2026-08-01","end_date":"2026-08-31"}}
+  }'
+```
+
+</CodeGroup>
+
+## Environment & science
+
+### `get_climate_data`
+
+Climate intelligence: temperature/precipitation anomalies (vs 30-year WMO normals), climate-relevant disaster alerts (ReliefWeb/GDACS/FIRMS), atmospheric CO2 trend (NOAA Mauna Loa), air quality (OpenAQ/WAQI PM2.5 stations), Arctic sea ice extent and ocean heat indicators (NSIDC/NOAA), weather alerts, and climate news.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/climate/v1/get-co2-monitoring`, `GET /api/climate/v1/get-ocean-ice-data`, `GET /api/climate/v1/list-air-quality-data`, `GET /api/climate/v1/list-climate-anomalies`, `GET /api/climate/v1/list-climate-disasters`, `GET /api/climate/v1/list-climate-news`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **2 d** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_climate_data","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_natural_disasters`
+
+Recent earthquakes (USGS), active wildfires (NASA FIRMS), and natural hazard events. Includes magnitude, location, and threat severity.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/natural/v1/list-natural-events`, `GET /api/seismology/v1/list-earthquakes`, `GET /api/wildfire/v1/list-fire-detections`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **30 min** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_natural_disasters","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_radiation_data`
+
+Radiation observation levels from global monitoring stations. Flags anomalous readings that may indicate nuclear incidents.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/radiation/v1/list-radiation-observations`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **30 min** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_radiation_data","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_research_signals`
+
+Tech and research event signals: emerging technology events bootstrap data from curated research feeds.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/research/v1/list-tech-events`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **8 h** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_research_signals","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+## Health
+
+### `get_health_signals`
+
+Active disease outbreaks (WHO/ECDC etc.) and global air-quality station readings (OpenAQ/WAQI PM2.5). For health-risk screening.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/health/v1/list-air-quality-alerts`, `GET /api/health/v1/list-disease-outbreaks`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **2 d** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_health_signals","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+## Humanitarian & displacement
+
+### `get_displacement_data`
+
+Refugee and IDP counts by country (UNHCR annual data).
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/displacement/v1/get-displacement-summary`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **2.5 d** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_displacement_data","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_positive_events`
+
+Positive geopolitical events: diplomatic agreements, humanitarian aid, development milestones, and peace initiatives worldwide.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/positive-events/v1/list-positive-geo-events`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **1 h** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_positive_events","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+## AI intelligence (live LLM)
+
+### `get_world_brief`
+
+AI-generated world intelligence brief. Fetches the latest geopolitical headlines along with their RSS article bodies and produces a grounded LLM-summarized brief. Supply an optional geo_context to focus on a region or topic.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|---------:|-------------|
+| `geo_context` | string | no | Optional focus context (e.g. "Middle East tensions", "US-China trade war") |
+
+- **API endpoints:** `GET /api/news/v1/list-feed-digest`, `POST /api/news/v1/summarize-article`
+- **Kind:** live RPC — proxies a fetch to the WorldMonitor API on each call. Edge-runtime timeout: **6.0s**.
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_world_brief","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `analyze_situation`
+
+AI geopolitical situation analysis (DeductionPanel). Provide a query and optional geo-political context; returns an LLM-powered analytical deduction with confidence and supporting signals.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|---------:|-------------|
+| `query` | string | **yes** | The question or situation to analyze, e.g. "What are the implications of the Taiwan strait escalation for semiconductor supply chains?" |
+| `context` | string | no | Optional additional geo-political context to include in the analysis |
+| `framework` | string | no | Optional analytical framework instructions to shape the analysis lens (e.g. Ray Dalio debt cycle, PMESII-PT, Porter's Five Forces) |
+
+- **API endpoints:** `POST /api/intelligence/v1/deduct-situation`
+- **Kind:** live RPC — proxies a fetch to the WorldMonitor API on each call. Edge-runtime timeout: **25.0s**.
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"analyze_situation","arguments":{"query":"What are the implications of the Taiwan strait escalation for semiconductor supply chains?"}}
+  }'
+```
+
+</CodeGroup>
+
+### `generate_forecasts`
+
+Generate live AI geopolitical and economic forecasts. Unlike get_forecast_predictions (pre-computed cache), this calls the forecasting model directly for fresh probability estimates. Note: slower than cache tools.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|---------:|-------------|
+| `domain` | string | no | Forecast domain: "geopolitical", "economic", "military", "climate", or empty for all domains |
+| `region` | string | no | Geographic region filter, e.g. "Middle East", "Europe", "Asia Pacific", or empty for global |
+
+- **API endpoints:** none directly — reads from a bootstrap-aggregate cache key (no 1:1 REST endpoint).
+- **Kind:** live RPC — proxies a fetch to the WorldMonitor API on each call. Edge-runtime timeout: **25.0s**.
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"generate_forecasts","arguments":{}}
+  }'
+```
+
+</CodeGroup>
+
+### `get_forecast_predictions`
+
+AI-generated geopolitical and economic forecasts from WorldMonitor's predictive models. Covers upcoming risk events and probability assessments.
+
+**Parameters:** none
+
+- **API endpoints:** `GET /api/forecast/v1/get-forecasts`
+- **Kind:** cache read — sub-second response from Redis bootstrap cache.
+- **Freshness budget:** up to **1.5 h** before `stale: true` is flagged (set by the seeder cron's expected interval).
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"get_forecast_predictions","arguments":{}}
+  }'
+```
+
+</CodeGroup>

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -56,7 +56,7 @@
       "apiBusiness": 10000,
       "enterprise": null
     },
-    "notes": "tools/list and initialize are NEVER counted against per-day quota — only tools/call. Per-minute is per-user (Pro) or per-key (API tiers)."
+    "notes": "Per-day quota (dailyByPlan) counts only tools/call — initialize, tools/list, ping, and notifications/initialized are exempt. Per-minute (60/min, per-user on Pro, per-key on API tiers) counts ALL methods, so a tight discovery probe loop on tools/list will still trip the throttle."
   },
   "tags": [
     "geopolitical-intelligence",

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -1,8 +1,12 @@
 {
   "serverInfo": {
     "name": "worldmonitor",
-    "version": "1.0"
+    "version": "1.1.0",
+    "description": "WorldMonitor's live global-intelligence stack as an MCP server: real-time markets, conflict events, aviation, maritime, energy, climate, health, displacement, supply chain, and AI-generated regional briefs.",
+    "vendor": "WorldMonitor",
+    "homepage": "https://www.worldmonitor.app"
   },
+  "protocolVersion": "2025-03-26",
   "transport": {
     "type": "streamableHttp",
     "endpoint": "https://worldmonitor.app/mcp"
@@ -12,10 +16,63 @@
     "resources": false,
     "prompts": false
   },
+  "tools": {
+    "count": 38,
+    "categories": [
+      "markets-economy",
+      "energy",
+      "geopolitical-security",
+      "movement-infrastructure",
+      "environment-science",
+      "health",
+      "humanitarian-displacement",
+      "ai-intelligence"
+    ]
+  },
   "authentication": {
     "type": "oauth2",
     "authorization_servers": ["https://api.worldmonitor.app"],
     "resource": "https://worldmonitor.app",
-    "scopes": ["mcp"]
+    "scopes": ["mcp"],
+    "alternative_methods": [
+      {
+        "type": "api_key",
+        "header": "X-WorldMonitor-Key",
+        "description": "API-tier subscribers may pass a wm_live_... key directly instead of completing the OAuth flow."
+      }
+    ]
+  },
+  "documentation": {
+    "overview": "https://www.worldmonitor.app/docs/mcp-server",
+    "toolReference": "https://www.worldmonitor.app/docs/mcp-tools-reference",
+    "apiReference": "https://www.worldmonitor.app/docs/api-reference",
+    "support": "https://www.worldmonitor.app/docs/getting-started"
+  },
+  "rateLimits": {
+    "perMinute": 60,
+    "dailyByPlan": {
+      "pro": 50,
+      "apiStarter": 1000,
+      "apiBusiness": 10000,
+      "enterprise": null
+    },
+    "notes": "tools/list and initialize are NEVER counted against per-day quota — only tools/call. Per-minute is per-user (Pro) or per-key (API tiers)."
+  },
+  "tags": [
+    "geopolitical-intelligence",
+    "live-data",
+    "global",
+    "macroeconomic",
+    "real-time",
+    "markets",
+    "conflict",
+    "energy",
+    "climate",
+    "supply-chain"
+  ],
+  "metadata": {
+    "supportsToolAnnotations": true,
+    "supportsStreamingResponses": false,
+    "toolListNote": "Issue a `tools/list` JSON-RPC call against the transport endpoint for the current authoritative tool inventory with input schemas and descriptions."
   }
 }


### PR DESCRIPTION
## Summary

Replaces the contributor-facing **Coverage invariants** subsection in `docs/mcp-server.mdx` (added on PR #3662 U6, covered parity-test internals + `_apiPaths` field mechanics + 6 exclusion category prefixes) with a user-facing **API coverage** reference table mapping every MCP tool to the REST/RPC endpoints it serves.

## Why

The old subsection was contributor-internal. A developer picking an MCP tool to call doesn't need parity-test mechanics — they need to know which tool delivers which data.

## What the new section gives users

Direct mapping for 30 of 38 tools, by tool name → list of \`METHOD path\` API endpoints served. Two use cases:

- **Forward lookup:** "I want X data via MCP → which tool delivers it?"
- **Reverse lookup:** "I know \`/api/economic/v1/get-bis-credit\` — Cmd/Ctrl+F the table to find the MCP equivalent."

Plus a trailing note that the remaining 8 of 38 tools are bootstrap-aggregate cache tools (e.g. \`get_aviation_status\` reads \`aviation:delays-bootstrap:v1\`) that return live data via \`tools/call\` but don't 1:1 map to a single API endpoint — pointer back at the Tool catalog.

## Scope discipline

No mention of:
- \`deferred-to-future-tool\` gaps
- Internal parity-test mechanics
- The \`EXCLUDED_FROM_MCP_PARITY\` exclusion map
- Contributor playbook for adding new tools

Those are contributor-only concerns and remain documented in \`tests/mcp-api-parity.test.mjs\` comments and the audit script header.

## Test plan

- [ ] Mintlify Deployment CI job passes (validates MDX shape)
- [ ] Preview renders the table cleanly (no broken HTML \`<br/>\` escapes inside table cells)
- [ ] Tool catalog and API coverage cross-link sensibly

🤖 Generated with [Claude Code](https://claude.com/claude-code)