### PR TITLE
fix(convex-error): map "Network connection lost" → SERVICE_UNAVAILABLE

### DIFF
--- a/api/_convex-error.js
+++ b/api/_convex-error.js
@@ -52,6 +52,15 @@ export function extractConvexErrorKind(err, msg) {
   // pattern (`transport_timeout` vs `convex_service_unavailable`).
   const errName = /** @type {{ name?: string } | null | undefined} */ (err)?.name;
   if (errName === 'TimeoutError' || errName === 'AbortError') return 'SERVICE_UNAVAILABLE';
+  // Vercel edge runtime transient: the upstream connection dropped mid-flight
+  // (Cloudflare Workers / Vercel edge surface `TypeError: Network connection
+  // lost.` from the inner `fetch` when the socket is reset during an in-flight
+  // request). Same recovery profile as the platform 503 — transient, retry
+  // with back-off. WORLDMONITOR-QE: was previously falling through to the
+  // 'unknown' error_shape bucket at error level instead of 503 + Retry-After.
+  // Sentry's classifier tags these as `transport_network` so they're queryable
+  // separately from genuine Convex 503s.
+  if (/Network connection lost/i.test(msg)) return 'SERVICE_UNAVAILABLE';
   // Convex platform-level 401: when Clerk's OIDC token fails Convex's own
   // verification (token expired between our edge's `validateBearerToken`
   // and Convex's check, or Clerk JWKS rotated), the SDK surfaces a JSON

--- a/tests/user-prefs-convex-error.test.mjs
+++ b/tests/user-prefs-convex-error.test.mjs
@@ -131,6 +131,37 @@ describe('extractConvexErrorKind — Convex client error → kind', () => {
     });
   });
 
+  describe('Vercel edge transient — "Network connection lost." (WORLDMONITOR-QE)', () => {
+    it('detects SERVICE_UNAVAILABLE from the exact "Network connection lost." shape', () => {
+      // Vercel/Cloudflare edge runtime surface this when the upstream socket
+      // is reset mid-request from inside `ConvexHttpClient`'s inner fetch.
+      // Same retry-with-backoff remediation as ServiceUnavailable — without
+      // this match, the catch falls to the 'unknown' bucket at error level
+      // instead of 503 + Retry-After (WORLDMONITOR-QE: 2 events / 2 users).
+      const err = new Error('Network connection lost.');
+      assert.equal(extractConvexErrorKind(err, err.message), 'SERVICE_UNAVAILABLE');
+    });
+
+    it('is case-insensitive (matches mid-message variants)', () => {
+      const err = new Error('TypeError: network connection LOST during fetch');
+      assert.equal(extractConvexErrorKind(err, err.message), 'SERVICE_UNAVAILABLE');
+    });
+
+    it('does NOT match unrelated "network" mentions', () => {
+      // Defensive: detector keys off the exact phrase, not loose "network"
+      // mentions, so generic transport prose isn't incorrectly bucketed.
+      const err = new Error('Network error: connection refused');
+      assert.equal(extractConvexErrorKind(err, err.message), null);
+    });
+
+    it('structured-data path still wins over "Network connection lost" substring (forward-compat)', () => {
+      const err = Object.assign(new Error('Network connection lost.'), {
+        data: { kind: 'CONFLICT', actualSyncVersion: 7 },
+      });
+      assert.equal(extractConvexErrorKind(err, err.message), 'CONFLICT');
+    });
+  });
+
   describe('legacy substring-match fallback (string-data ConvexError that arrived without errorData)', () => {
     it('matches CONFLICT in the message', () => {
       const err = new Error('CONFLICT');


### PR DESCRIPTION
## Summary

WORLDMONITOR-QE was a 2-event / 2-user `Error: Network connection lost.`
from `api/user-prefs.ts`'s inner `ConvexHttpClient.query` fetch.
`extractConvexErrorKind` didn't recognise the shape, so the catch chain
fell through to the 'unknown' error_shape bucket and returned 500 at
default error level — bypassing the 503 + Retry-After + warning
treatment we already apply to every other Convex platform transient
(`{"code":"ServiceUnavailable"}`, `{"code":"InternalServerError"}`,
`TimeoutError`, `AbortError`).

- Vercel / Cloudflare edge runtime surface `TypeError: Network
  connection lost.` (Cloudflare Workers internals) when the upstream
  socket is reset mid-request from inside the inner `fetch`. Same
  recovery profile as the platform 503 — transient, retry with
  back-off — so reuse SERVICE_UNAVAILABLE.
- The Sentry classifier in `buildSentryContext` still tags these as
  `transport_network` (separate fingerprint from
  `convex_service_unavailable` / `transport_timeout`) so the dashboard
  discriminates the three transient flavours.
- Structured-data precedence is preserved: `err.data.kind` still wins
  over the new substring match.
- Pattern anchored on the specific phrase (`/Network connection lost/i`)
  rather than a loose `/network/i` so unrelated transport prose stays
  in 'unknown'.

Regression suite added (4 cases): positive exact-match, positive
case-insensitive variant, defensive negative for unrelated "network"
mentions, structured-data precedence over the new substring.

## Test plan

- [x] `npm run typecheck` — PASS
- [x] `npm run typecheck:api` — PASS (incl. `audit-convex-string-calls`)
- [x] `npm run lint` — PASS (warnings only, all pre-existing)
- [x] `npm run test:data` — PASS (8597/8597)
- [x] `node --test tests/edge-functions.test.mjs` — PASS
- [x] `node --test tests/user-prefs-convex-error.test.mjs` — PASS (32/32)
- [x] `npm run lint:md` — PASS
- [x] `npm run version:check` — PASS
- [x] Edge bundle check — PASS
- [ ] After deploy, verify WORLDMONITOR-QE recurrence (if any) lands at
      warning level with `error_shape: transport_network`