### PR TITLE
feat: surface IMF fiscal indicators on country Economic Indicators card

### DIFF
--- a/src/services/imf-country-data.ts
+++ b/src/services/imf-country-data.ts
@@ -156,6 +156,25 @@ export function buildImfEconomicIndicators(bundle: ImfCountryBundle): {
     });
   }
 
+  // Primary balance %GDP (IMF GGXONLB_NGDP). Directional: a surplus is
+  // unambiguously good, sustained deficit drains fiscal space. Thresholds
+  // tuned around the IMF DSA noise floor — anything within ±1pp of zero is
+  // structural noise; meaningful signal is >+1 surplus or <-3 deficit.
+  // Ordered with the other directional macro rows (growth / inflation /
+  // unemployment) so it survives the caller's 6-row slice (country-intel.ts)
+  // even when stock + score + macro rows compete for surface area. The flat
+  // context rows below are emitted last because losing them is the right
+  // tradeoff when the card is full.
+  const primaryBalance = bundle.macro?.primaryBalancePct;
+  if (primaryBalance != null && Number.isFinite(primaryBalance)) {
+    out.push({
+      label: 'Primary Balance',
+      value: `${primaryBalance >= 0 ? '+' : ''}${primaryBalance.toFixed(1)}% GDP`,
+      trend: primaryBalance > 1 ? 'up' : primaryBalance < -3 ? 'down' : 'flat',
+      source: 'IMF WEO',
+    });
+  }
+
   const gdpPc = bundle.growth?.gdpPerCapitaUsd;
   if (gdpPc != null && Number.isFinite(gdpPc)) {
     const formatted = gdpPc >= 1000
@@ -189,20 +208,6 @@ export function buildImfEconomicIndicators(bundle: ImfCountryBundle): {
       label: 'Gov Revenue',
       value: `${govRev.toFixed(1)}% GDP`,
       trend: 'flat',
-      source: 'IMF WEO',
-    });
-  }
-
-  // Primary balance %GDP (IMF GGXONLB_NGDP). Directional: a surplus is
-  // unambiguously good, sustained deficit drains fiscal space. Thresholds
-  // tuned around the IMF DSA noise floor — anything within ±1pp of zero is
-  // structural noise; meaningful signal is >+1 surplus or <-3 deficit.
-  const primaryBalance = bundle.macro?.primaryBalancePct;
-  if (primaryBalance != null && Number.isFinite(primaryBalance)) {
-    out.push({
-      label: 'Primary Balance',
-      value: `${primaryBalance >= 0 ? '+' : ''}${primaryBalance.toFixed(1)}% GDP`,
-      trend: primaryBalance > 1 ? 'up' : primaryBalance < -3 ? 'down' : 'flat',
       source: 'IMF WEO',
     });
   }

--- a/src/services/imf-country-data.ts
+++ b/src/services/imf-country-data.ts
@@ -169,5 +169,43 @@ export function buildImfEconomicIndicators(bundle: ImfCountryBundle): {
     });
   }
 
+  // Public spending as % of GDP (IMF GGX_NGDP). Level is descriptive context,
+  // not directional — Nordics sit at 50%+ with strong stability scores while
+  // some low-spending states are fragile. Trend stays flat to avoid baking
+  // a "high = bad" signal into the indicator card.
+  const govExp = bundle.macro?.govExpenditurePct;
+  if (govExp != null && Number.isFinite(govExp)) {
+    out.push({
+      label: 'Public Spending',
+      value: `${govExp.toFixed(1)}% GDP`,
+      trend: 'flat',
+      source: 'IMF WEO',
+    });
+  }
+
+  const govRev = bundle.macro?.govRevenuePct;
+  if (govRev != null && Number.isFinite(govRev)) {
+    out.push({
+      label: 'Gov Revenue',
+      value: `${govRev.toFixed(1)}% GDP`,
+      trend: 'flat',
+      source: 'IMF WEO',
+    });
+  }
+
+  // Primary balance %GDP (IMF GGXONLB_NGDP). Directional: a surplus is
+  // unambiguously good, sustained deficit drains fiscal space. Thresholds
+  // tuned around the IMF DSA noise floor — anything within ±1pp of zero is
+  // structural noise; meaningful signal is >+1 surplus or <-3 deficit.
+  const primaryBalance = bundle.macro?.primaryBalancePct;
+  if (primaryBalance != null && Number.isFinite(primaryBalance)) {
+    out.push({
+      label: 'Primary Balance',
+      value: `${primaryBalance >= 0 ? '+' : ''}${primaryBalance.toFixed(1)}% GDP`,
+      trend: primaryBalance > 1 ? 'up' : primaryBalance < -3 ? 'down' : 'flat',
+      source: 'IMF WEO',
+    });
+  }
+
   return out;
 }

--- a/src/services/imf-country-data.ts
+++ b/src/services/imf-country-data.ts
@@ -161,10 +161,12 @@ export function buildImfEconomicIndicators(bundle: ImfCountryBundle): {
   // tuned around the IMF DSA noise floor — anything within ±1pp of zero is
   // structural noise; meaningful signal is >+1 surplus or <-3 deficit.
   // Ordered with the other directional macro rows (growth / inflation /
-  // unemployment) so it survives the caller's 6-row slice (country-intel.ts)
-  // even when stock + score + macro rows compete for surface area. The flat
-  // context rows below are emitted last because losing them is the right
-  // tradeoff when the card is full.
+  // unemployment) so it survives the caller's 6-row slice. Two slice sites
+  // gate visibility — keep both in mind when changing row count or order:
+  //   - src/app/country-intel.ts:1288 (combined producer → consumer cap)
+  //   - src/components/CountryDeepDivePanel.ts:2240 (post-stock-prepend cap)
+  // The flat context rows below are emitted last because losing them is the
+  // right tradeoff when the card is full.
   const primaryBalance = bundle.macro?.primaryBalancePct;
   if (primaryBalance != null && Number.isFinite(primaryBalance)) {
     out.push({

--- a/tests/imf-country-data.test.mts
+++ b/tests/imf-country-data.test.mts
@@ -158,6 +158,40 @@ describe('buildImfEconomicIndicators (panel rendering)', () => {
     assert.equal(pb.trend, 'flat');
   });
 
+  it('orders directional rows before flat context rows so Primary Balance survives the caller\'s 6-row slice', () => {
+    // When all 7 IMF rows fire, the consumer (CountryDeepDivePanel via
+    // country-intel.ts:1288) caps the indicators array at 6. If Primary
+    // Balance — the most informative directional fiscal signal — were
+    // emitted last, it would be the first row sliced off. Order asserts
+    // the priority: directional macro rows first (growth / inflation /
+    // unemployment / primary balance), then flat context rows
+    // (gdp-per-capita / public spending / gov revenue).
+    const rows = buildImfEconomicIndicators(bundle({
+      macro: {
+        inflationPct: 3.4, currentAccountPct: -2.1, govRevenuePct: 30,
+        cpiIndex: null, cpiEopPct: null, govExpenditurePct: 57.2, primaryBalancePct: -2.5,
+        year: 2024,
+      },
+      growth: {
+        realGdpGrowthPct: 0.7, gdpPerCapitaUsd: 47800, realGdp: null,
+        gdpPerCapitaPpp: null, gdpPpp: null, investmentPct: null, savingsPct: null,
+        savingsInvestmentGap: null, year: 2024,
+      },
+      labor: {
+        unemploymentPct: 7.4, populationMillions: 65.5, year: 2024,
+      },
+    }));
+    assert.deepEqual(rows.map(r => r.label), [
+      'Real GDP Growth',
+      'CPI Inflation',
+      'Unemployment',
+      'Primary Balance',
+      'GDP / Capita',
+      'Public Spending',
+      'Gov Revenue',
+    ]);
+  });
+
   it('marks severe primary deficit (<-3) with a downward trend', () => {
     const rows = buildImfEconomicIndicators(bundle({
       macro: {

--- a/tests/imf-country-data.test.mts
+++ b/tests/imf-country-data.test.mts
@@ -205,11 +205,65 @@ describe('buildImfEconomicIndicators (panel rendering)', () => {
     assert.equal(pb.trend, 'down');
   });
 
-  it('skips rows whose values are null or non-finite', () => {
+  it('keeps primary balance flat at the exact upper boundary (+1.0)', () => {
+    // Pins the inclusivity of `> 1` so a future refactor to `>= 1`
+    // would be caught (greptile P2: PR #3668).
     const rows = buildImfEconomicIndicators(bundle({
       macro: {
-        inflationPct: NaN, currentAccountPct: null, govRevenuePct: null,
-        cpiIndex: null, cpiEopPct: null, govExpenditurePct: null, primaryBalancePct: null,
+        inflationPct: null, currentAccountPct: null, govRevenuePct: null,
+        cpiIndex: null, cpiEopPct: null, govExpenditurePct: null, primaryBalancePct: 1.0,
+        year: 2024,
+      },
+    }));
+    const pb = rows.find(r => r.label === 'Primary Balance')!;
+    assert.equal(pb.value, '+1.0% GDP');
+    assert.equal(pb.trend, 'flat');
+  });
+
+  it('keeps primary balance flat at the exact lower boundary (-3.0)', () => {
+    // Pins the inclusivity of `< -3` so a future refactor to `<= -3`
+    // would be caught (greptile P2: PR #3668).
+    const rows = buildImfEconomicIndicators(bundle({
+      macro: {
+        inflationPct: null, currentAccountPct: null, govRevenuePct: null,
+        cpiIndex: null, cpiEopPct: null, govExpenditurePct: null, primaryBalancePct: -3.0,
+        year: 2024,
+      },
+    }));
+    const pb = rows.find(r => r.label === 'Primary Balance')!;
+    assert.equal(pb.value, '-3.0% GDP');
+    assert.equal(pb.trend, 'flat');
+  });
+
+  it('skips rows whose values are null or non-finite (covers all 7 IMF fields)', () => {
+    // Covers Number.isFinite guards across every IMF field — not just
+    // inflation. Catches a future regression where the guard is dropped
+    // on one of the new fiscal fields (greptile P2: PR #3668).
+    const rows = buildImfEconomicIndicators(bundle({
+      macro: {
+        inflationPct: NaN,
+        currentAccountPct: null,
+        govRevenuePct: Infinity,
+        cpiIndex: null,
+        cpiEopPct: null,
+        govExpenditurePct: NaN,
+        primaryBalancePct: -Infinity,
+        year: 2025,
+      },
+      growth: {
+        realGdpGrowthPct: NaN,
+        gdpPerCapitaUsd: Infinity,
+        realGdp: null,
+        gdpPerCapitaPpp: null,
+        gdpPpp: null,
+        investmentPct: null,
+        savingsPct: null,
+        savingsInvestmentGap: null,
+        year: 2025,
+      },
+      labor: {
+        unemploymentPct: NaN,
+        populationMillions: null,
         year: 2025,
       },
     }));

--- a/tests/imf-country-data.test.mts
+++ b/tests/imf-country-data.test.mts
@@ -19,7 +19,7 @@ describe('buildImfEconomicIndicators (panel rendering)', () => {
     assert.deepEqual(buildImfEconomicIndicators(bundle()), []);
   });
 
-  it('renders real GDP growth + inflation + unemployment + GDP/capita rows', () => {
+  it('renders real GDP growth + inflation + unemployment + GDP/capita + revenue rows', () => {
     const rows = buildImfEconomicIndicators(bundle({
       macro: {
         inflationPct: 3.4, currentAccountPct: -2.1, govRevenuePct: 30,
@@ -36,7 +36,7 @@ describe('buildImfEconomicIndicators (panel rendering)', () => {
       },
     }));
     assert.deepEqual(rows.map(r => r.label), [
-      'Real GDP Growth', 'CPI Inflation', 'Unemployment', 'GDP / Capita',
+      'Real GDP Growth', 'CPI Inflation', 'Unemployment', 'GDP / Capita', 'Gov Revenue',
     ]);
     assert.equal(rows[0].value, '+2.7%');
     assert.equal(rows[0].trend, 'up');
@@ -88,6 +88,87 @@ describe('buildImfEconomicIndicators (panel rendering)', () => {
     }));
     const gdp = rows.find(r => r.label === 'GDP / Capita')!;
     assert.equal(gdp.value, '$850');
+  });
+
+  it('renders public spending %GDP with a flat trend (level is descriptive, not directional)', () => {
+    const rows = buildImfEconomicIndicators(bundle({
+      macro: {
+        inflationPct: null, currentAccountPct: null, govRevenuePct: null,
+        cpiIndex: null, cpiEopPct: null, govExpenditurePct: 57.2, primaryBalancePct: null,
+        year: 2024,
+      },
+    }));
+    const spend = rows.find(r => r.label === 'Public Spending')!;
+    assert.equal(spend.value, '57.2% GDP');
+    assert.equal(spend.trend, 'flat');
+    assert.equal(spend.source, 'IMF WEO');
+  });
+
+  it('renders gov revenue %GDP with a flat trend', () => {
+    const rows = buildImfEconomicIndicators(bundle({
+      macro: {
+        inflationPct: null, currentAccountPct: null, govRevenuePct: 32.5,
+        cpiIndex: null, cpiEopPct: null, govExpenditurePct: null, primaryBalancePct: null,
+        year: 2024,
+      },
+    }));
+    const rev = rows.find(r => r.label === 'Gov Revenue')!;
+    assert.equal(rev.value, '32.5% GDP');
+    assert.equal(rev.trend, 'flat');
+    assert.equal(rev.source, 'IMF WEO');
+  });
+
+  it('marks meaningful primary surplus (>+1) with an upward trend and signed value', () => {
+    const rows = buildImfEconomicIndicators(bundle({
+      macro: {
+        inflationPct: null, currentAccountPct: null, govRevenuePct: null,
+        cpiIndex: null, cpiEopPct: null, govExpenditurePct: null, primaryBalancePct: 2.1,
+        year: 2024,
+      },
+    }));
+    const pb = rows.find(r => r.label === 'Primary Balance')!;
+    assert.equal(pb.value, '+2.1% GDP');
+    assert.equal(pb.trend, 'up');
+    assert.equal(pb.source, 'IMF WEO');
+  });
+
+  it('keeps primary balance flat for small surplus (between 0 and +1)', () => {
+    const rows = buildImfEconomicIndicators(bundle({
+      macro: {
+        inflationPct: null, currentAccountPct: null, govRevenuePct: null,
+        cpiIndex: null, cpiEopPct: null, govExpenditurePct: null, primaryBalancePct: 0.5,
+        year: 2024,
+      },
+    }));
+    const pb = rows.find(r => r.label === 'Primary Balance')!;
+    assert.equal(pb.value, '+0.5% GDP');
+    assert.equal(pb.trend, 'flat');
+  });
+
+  it('keeps primary balance flat for mild deficit (between -3 and 0)', () => {
+    const rows = buildImfEconomicIndicators(bundle({
+      macro: {
+        inflationPct: null, currentAccountPct: null, govRevenuePct: null,
+        cpiIndex: null, cpiEopPct: null, govExpenditurePct: null, primaryBalancePct: -1.0,
+        year: 2024,
+      },
+    }));
+    const pb = rows.find(r => r.label === 'Primary Balance')!;
+    assert.equal(pb.value, '-1.0% GDP');
+    assert.equal(pb.trend, 'flat');
+  });
+
+  it('marks severe primary deficit (<-3) with a downward trend', () => {
+    const rows = buildImfEconomicIndicators(bundle({
+      macro: {
+        inflationPct: null, currentAccountPct: null, govRevenuePct: null,
+        cpiIndex: null, cpiEopPct: null, govExpenditurePct: null, primaryBalancePct: -4.0,
+        year: 2024,
+      },
+    }));
+    const pb = rows.find(r => r.label === 'Primary Balance')!;
+    assert.equal(pb.value, '-4.0% GDP');
+    assert.equal(pb.trend, 'down');
   });
 
   it('skips rows whose values are null or non-finite', () => {


### PR DESCRIPTION
## Summary
- Adds Public Spending / Gov Revenue / Primary Balance rows to the Economic Indicators card on `CountryDeepDivePanel`
- Sourced from already-seeded IMF GGX_NGDP / GGR_NGDP / GGXONLB_NGDP fields in `economic:imf:macro:v2` — no new ingestion
- Pure UI additive change; zero impact on resilience scoring or any data pipeline

## Why

These series are pulled monthly by `seed-imf-macro.mjs` but no UI surface consumed them — they were orphan data in Redis. Plan #1 of a two-part fiscal-resilience initiative; Plan #2 (`debtSustainabilityGap` resilience indicator) is drafted in `plans/add-debt-sustainability-gap-indicator.md` and will ship as a separate PR.

## Trend semantics

- **Public Spending / Gov Revenue**: flat trend — level is descriptive context, not directional. Nordics sit at 50%+ public spending and score top-tier on stability; a "high = bad" arrow would be misleading.
- **Primary Balance**: directional with IMF DSA noise-floor thresholds — `> +1%` → up, `< -3%` → down, else flat. A 0.3% surplus showing a green arrow would be noise.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `node --import tsx --test tests/imf-country-data.test.mts` → 12/12 pass (was 7; added 5 new tests + updated 1 label-list assertion to expect Gov Revenue row)
- [x] `npx biome lint src/services/imf-country-data.ts tests/imf-country-data.test.mts` clean
- [ ] Manual: render `CountryDeepDivePanel` for France in the dev app, confirm three new rows appear with correctly formatted values (`57.2% GDP`, `XX.X% GDP`, `±X.X% GDP`) alongside the existing GDP Growth / CPI Inflation / Unemployment / GDP-per-Capita rows

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. Purely additive rows on the existing Economic Indicators card; reads existing seeded `economic:imf:macro:v2` fields with null-skip guards. No new network calls, no new error paths, no new failure modes, no resilience-score impact.

**Rollback**: revert the PR — Economic Indicators card returns to its previous 4 rows; no data cleanup, no cache invalidation needed.

**Observable behavior**: yes — three new rows visible on `CountryDeepDivePanel`'s Economic Indicators card for countries with IMF WEO coverage (≈190 countries). Demo evidence skipped for this PR; rows are testable locally with any IMF-WEO-covered country.