### PR TITLE
feat(resilience): add debtSustainabilityGap indicator (IMF DSA construct)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -416,7 +416,7 @@ const SEED_META = {
   marketImplications:   { key: 'seed-meta:intelligence:market-implications', maxStaleMin: 120 }, // LLM-generated in seed-forecasts; cron ~1h; 120min = 2x interval
   trafficAnomalies:     { key: 'seed-meta:cf:radar:traffic-anomalies',       maxStaleMin: 60 }, // written by seed-internet-outages afterPublish; outages cron ~15min; 60 = 4x interval
   chokepointExposure:   { key: 'seed-meta:supply_chain:chokepoint-exposure', maxStaleMin: 2880 }, // daily cron; 2880min = 48h = 2x interval
-  recoveryFiscalSpace:     { key: 'seed-meta:resilience:recovery:fiscal-space',     maxStaleMin: 86400 }, // monthly cron; 86400min = 60d = 2x interval
+  recoveryFiscalSpace:     { key: 'seed-meta:resilience:recovery:fiscal-space',     maxStaleMin: 129600 }, // monthly cron; 129600min = 90d = 3x interval (bumped from 86400/60d = 2x in PR #3669 for month-2 hiccup margin)
   recoveryReserveAdequacy: { key: 'seed-meta:resilience:recovery:reserve-adequacy', maxStaleMin: 86400 }, // monthly cron; 86400min = 60d = 2x interval
   recoveryExternalDebt:    { key: 'seed-meta:resilience:recovery:external-debt',    maxStaleMin: 86400 }, // monthly cron; 86400min = 60d = 2x interval
   recoveryImportHhi:       { key: 'seed-meta:resilience:recovery:import-hhi',       maxStaleMin: 86400 }, // monthly cron; 86400min = 60d = 2x interval

--- a/docs/methodology/country-resilience-index.mdx
+++ b/docs/methodology/country-resilience-index.mdx
@@ -317,11 +317,23 @@ by its weight before computing the domain average, so a dim with
 
 #### Fiscal Space
 
+The first three indicators measure the **state** of public finances; the fourth — `debtSustainabilityGap` — measures the **trajectory**. The gap is the standard IMF DSA construct (used by Article IV missions, ECB MIP scoreboard, and S&P sovereign methodology):
+
+```
+g    = (1 + realGdpGrowth/100) × (1 + cpiInflation/100) − 1
+r    = max(0, (primaryBalance − fiscalBalance) / debtToGdp)
+pb*  = ((r − g) / (1 + g)) × debtToGdp
+gap  = primaryBalance − pb*       (positive ⇒ debt path declining)
+```
+
+The gap is **computed at seed time** and stored as `debtSustainabilityGapPct` in the canonical fiscal-space blob, so the scorer just normalizes. Inputs are year-aligned via `latestCommonYear` across the 5 formula series (debt, balance, primary balance, real growth, inflation); year-mismatched countries get `gap=null` and the scorer's `weightedBlend` redistributes weight across the remaining 3 indicators. The hyperinflation cap (CPI > 25%) drops `gap` to null for Argentina / Lebanon / Venezuela — the formula's inflation-tax term would otherwise mask underlying fiscal pathology. Realistic joint coverage is ~150 countries (down from 190 nominal) because of the year-alignment + cap interaction.
+
 | Indicator | Description | Direction | Goalposts (worst-best) | Weight | Source | Cadence |
 |---|---|---|---|---|---|---|
-| recoveryGovRevenue | Government revenue as % of GDP (IMF GGR_G01_GDP_PT) | Higher is better | 5 - 45 | 0.40 | IMF | Annual |
-| recoveryFiscalBalance | General government net lending/borrowing as % of GDP (IMF GGXCNL_G01_GDP_PT) | Higher is better | -15 - 5 | 0.30 | IMF | Annual |
-| recoveryDebtToGdp | General government gross debt as % of GDP (IMF GGXWDG_NGDP_PT) | Lower is better | 150 - 0 | 0.30 | IMF | Annual |
+| recoveryGovRevenue | Government revenue as % of GDP (IMF GGR_G01_GDP_PT) | Higher is better | 5 - 45 | 0.25 | IMF | Annual |
+| recoveryFiscalBalance | General government net lending/borrowing as % of GDP (IMF GGXCNL_G01_GDP_PT) | Higher is better | -15 - 5 | 0.20 | IMF | Annual |
+| recoveryDebtToGdp | General government gross debt as % of GDP (IMF GGXWDG_NGDP_PT) | Lower is better | 150 - 0 | 0.20 | IMF | Annual |
+| debtSustainabilityGap | Primary-balance gap to debt-stabilizing level (IMF DSA construct); see formula above. Dropped to null when CPI > 25% to avoid hyperinflation masking. | Higher is better | -5 - 3 | 0.35 | IMF (5 series: GGXONLB_NGDP, GGXCNL_NGDP, GGXWDG_NGDP, NGDP_RPCH, PCPIPCH) | Annual |
 
 #### Reserve Adequacy
 

--- a/docs/methodology/indicator-sources.yaml
+++ b/docs/methodology/indicator-sources.yaml
@@ -521,7 +521,7 @@
 - indicator: recoveryGovRevenue
   dimension: fiscalSpace
   domain: recovery
-  weight: 0.40
+  weight: 0.25
   direction: higher-better
   source: IMF
   seriesId: GGR_G01_GDP_PT
@@ -531,12 +531,12 @@
   license: Proprietary-with-fair-use
   mechanismTestRationale: Government revenue % GDP for recovery scenarios — policy-response fiscal headroom.
   constructStatus: observed-mechanism
-  reviewNotes: Duplicate with macroFiscal.govRevenuePct. PR 4 may de-duplicate.
+  reviewNotes: Weight reduced 0.40 → 0.25 to make room for debtSustainabilityGap (the more informative single signal). Duplicate with macroFiscal.govRevenuePct. PR 4 may de-duplicate.
 
 - indicator: recoveryFiscalBalance
   dimension: fiscalSpace
   domain: recovery
-  weight: 0.30
+  weight: 0.20
   direction: higher-better
   source: IMF
   seriesId: GGXCNL_G01_GDP_PT
@@ -546,11 +546,12 @@
   license: Proprietary-with-fair-use
   mechanismTestRationale: General government net lending/borrowing as % of GDP — direct fiscal-response-capacity signal.
   constructStatus: observed-mechanism
+  reviewNotes: Weight reduced 0.30 → 0.20 with the addition of debtSustainabilityGap, which integrates fiscal balance into its r-g computation.
 
 - indicator: recoveryDebtToGdp
   dimension: fiscalSpace
   domain: recovery
-  weight: 0.30
+  weight: 0.20
   direction: lower-better
   source: IMF
   seriesId: GGXWDG_NGDP_PT
@@ -560,7 +561,34 @@
   license: Proprietary-with-fair-use
   mechanismTestRationale: General government gross debt to GDP — fiscal-stress cushion.
   constructStatus: observed-mechanism
-  reviewNotes: Goalpost 0-150 is too linear; Japan at 260% (mostly domestic, yen-denominated) scores 0 despite weak real fiscal-stress risk. PR 4 §4.4 adds holder-composition modifier.
+  reviewNotes: Weight reduced 0.30 → 0.20 alongside the addition of debtSustainabilityGap. Goalpost 0-150 is too linear; Japan at 260% (mostly domestic, yen-denominated) scores 0 despite weak real fiscal-stress risk. The gap indicator partially compensates by honoring the g≈r regime. PR 4 §4.4 adds holder-composition modifier.
+
+- indicator: debtSustainabilityGap
+  dimension: fiscalSpace
+  domain: recovery
+  weight: 0.35
+  direction: higher-better
+  source: IMF (5 series composite — see formula in country-resilience-index.mdx §Fiscal Space)
+  seriesId: GGXONLB_NGDP × GGXCNL_NGDP × GGXWDG_NGDP × NGDP_RPCH × PCPIPCH
+  seriesUrl: https://www.imf.org/external/datamapper/datasets/WEO
+  coveragePct: 0.79  # ~150 of 190 countries — realistic joint coverage after year-alignment + hyperinflation cap
+  lastObservedYear: 2024
+  license: Proprietary-with-fair-use
+  mechanismTestRationale: |
+    Primary-balance gap to debt-stabilizing level — the standard IMF DSA construct used by Article IV
+    missions, ECB MIP scoreboard, and S&P sovereign methodology. Captures debt trajectory (sustainability)
+    rather than debt level. Computed at seed time: gap = pb − ((r−g)/(1+g))·d where r is derived from
+    the algebraic identity (overall_balance = primary_balance − interest_expense), g is compounded
+    nominal growth (1+real)·(1+inflation)−1. Inputs year-aligned via latestCommonYear across the 5
+    formula series; year-mismatched countries drop to null and the scorer's weightedBlend redistributes
+    weight across the remaining 3 fiscal-space indicators.
+  constructStatus: observed-mechanism
+  reviewNotes: |
+    Hyperinflation cap (CPI > 25%) drops gap to null for Argentina / Lebanon / Venezuela — the inflation-tax
+    term in the formula would otherwise produce misleadingly positive gaps that mask real fiscal pathology.
+    Fiscal-3 still scores these countries. Goalposts -5/+3 chosen from IMF DSA distress conventions; gap≈0
+    is debt-stabilizing (normalized score ≈ 62), gap≥+3 saturates (debt declining), gap≤-5 floors (severe
+    distress).
 
 - indicator: recoveryReserveMonths
   dimension: reserveAdequacy

--- a/plans/add-debt-sustainability-gap-indicator.md
+++ b/plans/add-debt-sustainability-gap-indicator.md
@@ -1,0 +1,415 @@
+# Plan: Add `debtSustainabilityGap` indicator to WorldMonitor resilience
+
+**Status**: APPROVED by Codex (gpt-5.5) after 4 rounds of review on 2026-05-12.
+**Origin**: session pivot from the orphan-fiscal-data finding — `govExpenditurePct` + `primaryBalancePct` were ingested via `seed-imf-macro.mjs` but no resilience indicator consumed them. Plan #1 (descriptive UI surface) is separately shipped this session.
+
+---
+
+## Context
+
+WorldMonitor scores 190+ countries on a resilience composite. One dimension is `fiscalSpace`, with three sub-indicators today (all read from one Redis blob `resilience:recovery:fiscal-space:v1`, populated by `scripts/seed-recovery-fiscal-space.mjs`):
+
+```
+recoveryGovRevenue       weight 0.4  higherBetter   goalposts 5..45    GGR_NGDP
+recoveryFiscalBalance    weight 0.3  higherBetter   goalposts -15..5   GGXCNL_NGDP
+recoveryDebtToGdp        weight 0.3  lowerBetter    goalposts 0..150   GGXWDG_NGDP
+```
+
+Scorer: `scoreFiscalSpace` in `server/worldmonitor/resilience/v1/_dimension-scorers.ts:2013`.
+
+**Problem**: None of these signals alone — or blended — answers "is this country's debt path sustainable?" A country can have high debt + strong primary surplus + g≈r and be fine (Japan-ish), or low debt + chronic primary deficit + r>g and be in trouble. The current composite penalizes the level and rewards the surplus, then averages, losing the r-g interaction term.
+
+**Proposal**: add a fourth `fiscalSpace` indicator — `debtSustainabilityGap` — capturing the standard IMF DSA construct used by Article IV missions, ECB MIP scoreboard, and S&P sovereign methodology.
+
+---
+
+## Formula
+
+```
+g  = (1 + realGdpGrowthPct/100) × (1 + inflationPct/100) − 1     compounded nominal growth (decimal)
+r  = max(0, (primaryBalancePct − fiscalBalancePct) / debtToGdpPct)  effective interest rate (decimal)
+pb*= ((r − g) / (1 + g)) × debtToGdpPct                          debt-stabilizing primary balance (% GDP)
+gap= primaryBalancePct − pb*                                     positive = debt declining, negative = rising
+```
+
+**Derivation note**: `r` comes from the algebraic identity (overall balance = primary balance − interest expense), so `interest %GDP = primaryBalance − fiscalBalance`, then `r = interest/debt`. This avoids needing per-country sovereign yields (which we only have for US via FRED `DGS10`).
+
+---
+
+## All inputs already seeded — no new ingestion
+
+| Term | IMF series | Existing seeder | Existing field |
+|---|---|---|---|
+| `d` debt %GDP | GGXWDG_NGDP | seed-recovery-fiscal-space.mjs | `debtToGdpPct` ✓ |
+| `pb` primary balance | GGXONLB_NGDP | seed-imf-macro.mjs | `primaryBalancePct` (orphan; **will pull into fiscal-space blob too**) |
+| overall balance | GGXCNL_NGDP | seed-recovery-fiscal-space.mjs | `fiscalBalancePct` ✓ |
+| real growth | NGDP_RPCH | seed-imf-growth.mjs | `realGdpGrowthPct` (will pull into fiscal-space blob too) |
+| CPI inflation | PCPIPCH | seed-imf-macro.mjs | `inflationPct` (will pull into fiscal-space blob too) |
+
+---
+
+## Worked examples (end-to-end)
+
+| Country | d | pb | fb | real g | infl | nominal g | r | pb* | **gap** | normalized score |
+|---|---|---|---|---|---|---|---|---|---|---|
+| France 2024 | 110 | −2.5 | −4.5 | 0.7 | 2.1 | 2.815% | 1.818% | −1.067 | **−1.43** | **44.6** |
+| Japan 2024 | 250 | 0 | −3 | 0.5 | 2.0 | 2.510% | 1.200% | −3.198 | **+3.20** | **100** (clamps) |
+| Italy 2024 | 137 | +1.0 | −3.5 | 0.5 | 2.0 | 2.510% | 3.285% | +1.038 | **−0.04** | **62.0** |
+| Norway 2024 | 38 | +10 | +8 | 1.0 | 2.5 | 3.525% | 5.263% | +0.637 | **+9.36** | **100** (clamps) |
+| Argentina 2024 | 90 | −2 | −5 | −3.0 | 200 | inflation > 25% cap | — | — | **null** | excluded |
+
+Gap goalposts `worst=-5, best=+3`, direction `higherBetter`, linear normalization → score [0..100], clamps outside.
+
+---
+
+## Implementation — single seed blob, gap computed at seed time
+
+**Decision**: compute the gap in the seeder, store `debtSustainabilityGapPct` per country in the blob. Scorer just normalizes. Reasons:
+
+- Backtest harness (`EXTRACTION_RULES`) becomes a one-liner identical to existing fiscal rules.
+- Year-alignment logic runs once per seeder tick, not per score request.
+- Matches the existing project pattern (scorers read precomputed fields; they don't do algebra).
+
+### 1. `scripts/seed-recovery-fiscal-space.mjs`
+
+**Architecture**: factor the pure logic into exported helpers so tests don't need to mock `imfSdmxFetchIndicator`:
+
+```js
+// Exported constants — also imported by tests so the prod floors are asserted
+// directly, not via Function.prototype.toString() introspection.
+export const FISCAL_SPACE_VALIDATION_FLOORS = { fiscal3: 150, gap: 100 };
+export const INFLATION_GAP_CAP_PCT = 25;
+
+// Pure helpers, exported for testing:
+export function latestCommonYear(byYearMaps) {
+  // byYearMaps: array of { [year]: value } for the 5 formula inputs.
+  // Returns the most recent year present in all maps with finite values, or null.
+}
+
+export function computeDebtSustainabilityGap({ debt, pb, fb, realG, infl }) {
+  if (debt == null || debt <= 0) return null;
+  if (infl == null || infl > INFLATION_GAP_CAP_PCT) return null;
+  if (pb == null || fb == null || realG == null) return null;
+
+  const g = (1 + realG / 100) * (1 + infl / 100) - 1;        // compounded nominal growth (decimal)
+  const r = Math.max(0, (pb - fb) / debt);                    // effective rate (decimal), floor 0
+  const pbStar = ((r - g) / (1 + g)) * debt;
+  return pb - pbStar;
+}
+
+export function buildFiscalSpaceCountries(perIndicator) {
+  // perIndicator: { revenue, balance, debt, primaryBalance, growth, inflation }
+  //   — each is { [iso3]: { [year]: value } } as returned by imfSdmxFetchIndicator
+  // Returns: { [iso2]: { ... per-country payload ... } }
+
+  // Country inclusion stays anchored to fiscal-3 only — exact existing semantics:
+  // union over revenue ∪ balance ∪ debt keys, then skip if all three resolve null.
+  // Critically NOT widened to growth/inflation, which would let a fiscal-series
+  // outage emit countries with null fiscal-3 fields (R1-P0 risk).
+  const countries = {};
+  const allIso3 = new Set([
+    ...Object.keys(perIndicator.revenue),
+    ...Object.keys(perIndicator.balance),
+    ...Object.keys(perIndicator.debt),
+  ]);
+
+  for (const iso3 of allIso3) {
+    if (isAggregate(iso3)) continue;
+    const iso2 = ISO3_TO_ISO2[iso3]; if (!iso2) continue;
+
+    // Fiscal-3 keep their individual per-series latest values (no regression):
+    const rev  = latestValue(perIndicator.revenue[iso3]);
+    const bal  = latestValue(perIndicator.balance[iso3]);
+    const debt = latestValue(perIndicator.debt[iso3]);
+
+    // Existing skip guard — preserve verbatim:
+    if (!rev && !bal && !debt) continue;
+
+    // Gap inputs require year alignment across the 5 formula inputs only
+    // (revenue is NOT in the formula → not in the alignment check):
+    const commonYear = latestCommonYear([
+      perIndicator.debt[iso3],
+      perIndicator.balance[iso3],
+      perIndicator.primaryBalance[iso3],
+      perIndicator.growth[iso3],
+      perIndicator.inflation[iso3],
+    ]);
+
+    let pb = null, real = null, infl = null, gap = null, gapYear = null;
+    if (commonYear != null) {
+      // ALL formula inputs read at commonYear — fixes R2-P1-1:
+      const debtCommon = perIndicator.debt[iso3][commonYear];
+      const fbCommon   = perIndicator.balance[iso3][commonYear];
+      pb               = perIndicator.primaryBalance[iso3][commonYear];
+      real             = perIndicator.growth[iso3][commonYear];
+      infl             = perIndicator.inflation[iso3][commonYear];
+      gap = computeDebtSustainabilityGap({ debt: debtCommon, pb, fb: fbCommon, realG: real, infl });
+      gapYear = commonYear;
+    }
+
+    countries[iso2] = {
+      // Existing fiscal-3 fields — unchanged latest-per-series semantics:
+      govRevenuePct:     rev?.value ?? null,
+      fiscalBalancePct:  bal?.value ?? null,
+      debtToGdpPct:      debt?.value ?? null,
+      year:              rev?.year ?? bal?.year ?? debt?.year ?? null,
+      // New gap-indicator fields — read at commonYear or null:
+      primaryBalancePct:         pb,
+      realGdpGrowthPct:          real,
+      inflationPct:              infl,
+      debtSustainabilityGapPct:  gap,
+      gapYear,
+    };
+  }
+  return countries;
+}
+
+export function validateFiscalSpace(data, floors = FISCAL_SPACE_VALIDATION_FLOORS) {
+  const all = Object.values(data?.countries || {});
+  const withFiscal3 = all.filter(c =>
+    c.govRevenuePct != null && c.fiscalBalancePct != null && c.debtToGdpPct != null
+  ).length;
+  const withGap = all.filter(c => c.debtSustainabilityGapPct != null).length;
+  return withFiscal3 >= floors.fiscal3 && withGap >= floors.gap;
+}
+```
+
+The `fetchFiscalSpace` async wrapper stays small — it does the 6 `imfSdmxFetchIndicator` calls in parallel, hands the result to `buildFiscalSpaceCountries`, and passes through.
+
+**Schema bump**: `schemaVersion: 1 → 2`. New fields are additive — old scorer reads work unchanged.
+
+**Validation semantics (explicit)**:
+
+- `validateFiscalSpace` is called by `runSeed`'s pre-publish check.
+- If it returns false → **seeder rejects the payload entirely**; `runSeed` short-circuits the canonical write; the previous canonical blob keeps serving (existing strict-floor behavior in `_seed-utils.mjs:1010-1017`).
+- If it returns true but some individual countries lack gap inputs → those countries get `debtSustainabilityGapPct: null` and the scorer naturally redistributes weight via `weightedBlend`. The other 3 indicators continue scoring those countries.
+
+Two failure modes, cleanly separated:
+
+- **System-level outage** (IMF fiscal-3 down across the board → <150 countries with fiscal-3 OR <100 with gap inputs) → seeder refuses to publish, last canonical blob serves.
+- **Per-country gap unavailability** (year misalignment, hyperinflation cap, partial growth/inflation for one specific country) → that country's gap indicator scores null, fiscal-3 still scores it.
+
+### 2. `server/worldmonitor/resilience/v1/_indicator-registry.ts`
+
+Add new indicator entry, rebalance existing fiscalSpace weights:
+
+```ts
+{
+  id: 'debtSustainabilityGap',
+  dimension: 'fiscalSpace',
+  description: 'Primary-balance gap to debt-stabilizing level: gap = pb − ((r−g)/(1+g))·d (IMF DSA construct). Positive = debt path declining, negative = rising. r derived from interest expense / debt; g from compounded real growth and CPI.',
+  direction: 'higherBetter',
+  goalposts: { worst: -5, best: 3 },
+  weight: 0.35,
+  sourceKey: 'resilience:recovery:fiscal-space:v1',
+  scope: 'global',
+  cadence: 'annual',
+  tier: 'core',
+  coverage: 150,  // realistic joint coverage post-launch; lower than 190 by design
+  license: 'open-data',
+  comprehensive: true,
+},
+// Existing three reweighted:
+// recoveryGovRevenue:    0.4  → 0.25
+// recoveryFiscalBalance: 0.3  → 0.20
+// recoveryDebtToGdp:     0.3  → 0.20
+// debtSustainabilityGap:        0.35
+//                       sum = 1.0
+```
+
+### 3. `server/worldmonitor/resilience/v1/_dimension-scorers.ts::scoreFiscalSpace`
+
+```ts
+return weightedBlend([
+  { score: entry.govRevenuePct == null ? null : normalizeHigherBetter(entry.govRevenuePct, 5, 45), weight: 0.25 },
+  { score: entry.fiscalBalancePct == null ? null : normalizeHigherBetter(entry.fiscalBalancePct, -15, 5), weight: 0.20 },
+  { score: entry.debtToGdpPct == null ? null : normalizeLowerBetter(entry.debtToGdpPct, 0, 150), weight: 0.20 },
+  { score: entry.debtSustainabilityGapPct == null ? null : normalizeHigherBetter(entry.debtSustainabilityGapPct, -5, 3), weight: 0.35 },
+]);
+```
+
+Existing `weightedBlend` already redistributes null-weights — no special handling needed.
+
+### 4. `scripts/compare-resilience-current-vs-proposed.mjs:366`
+
+Add one row to `EXTRACTION_RULES` matching the existing `recovery-country-field` shape:
+
+```js
+debtSustainabilityGap: {
+  type: 'recovery-country-field',
+  key:  'resilience:recovery:fiscal-space:v1',
+  field: 'debtSustainabilityGapPct',
+},
+```
+
+This makes the existing `tests/resilience-indicator-extraction-plan.test.mjs:23` parity test pass automatically.
+
+### 5. Type update — `RecoveryFiscalSpaceCountry`
+
+Locate the type def (likely in `_indicator-registry.ts` or `server/worldmonitor/resilience/types.ts`), add:
+```ts
+primaryBalancePct: number | null;
+realGdpGrowthPct: number | null;
+inflationPct: number | null;
+debtSustainabilityGapPct: number | null;
+gapYear: number | null;
+```
+
+### 6. Docs
+
+- `docs/methodology/country-resilience-index.mdx:322` — update the fiscal-space indicator table (4 rows now, new weights).
+- `docs/methodology/indicator-sources.yaml:521` — add new entry with source series, formula, caveats (hyperinflation cap, joint-coverage note).
+
+---
+
+## Edge cases
+
+| Case | Handling |
+|---|---|
+| `debtToGdpPct ≤ 0` (negative net debt, rare) | `r` division skipped, gap = null. Indicator score null → weight redistributes. |
+| `r < 0` from WEO rounding (interest near zero) | `r` floor clamped at 0. |
+| `inflationPct > 25` (hyperinflation) | Gap = null. Argentina, Lebanon, Venezuela excluded from this indicator until inflation normalizes. Fiscal-3 still score them. |
+| Any individual input null | `commonYear` returns null → gap = null. Fiscal-3 unaffected. |
+| Year mismatch across inputs | Same as above — `latestCommonYear` returns null → gap = null. |
+| Country missing from blob entirely | Existing `IMPUTE.recoveryFiscalSpace` fallback fires (no change). |
+
+---
+
+## Tests
+
+### Unit tests (new file `tests/resilience-debt-sustainability-gap.test.mts`)
+
+Pure formula tests via the exported helper. Helper signature is `{ debt, pb, fb, realG, infl }` — match exactly:
+
+```ts
+computeDebtSustainabilityGap({ debt: 110, pb: -2.5, fb: -4.5, realG: 0.7, infl: 2.1 })
+  // → gap ≈ -1.43
+
+computeDebtSustainabilityGap({ debt: 250, pb: 0, fb: -3, realG: 0.5, infl: 2.0 })
+  // → gap ≈ +3.20
+
+computeDebtSustainabilityGap({ debt: 38,  pb: 10, fb: 8,  realG: 1.0, infl: 2.5 })
+  // → gap large positive (>5)
+
+computeDebtSustainabilityGap({ debt: 0,   pb: 0, fb: 0,   realG: 1, infl: 2 })
+  // → null (degenerate denom)
+
+computeDebtSustainabilityGap({ debt: 90,  pb: -2, fb: -5, realG: -3, infl: 200 })
+  // → null (inflation cap)
+```
+
+### Seeder contract tests (new file `tests/seed-recovery-fiscal-space.test.mts`)
+
+No ESM mocking. Test the pure exported helpers directly:
+
+```ts
+import {
+  buildFiscalSpaceCountries,
+  computeDebtSustainabilityGap,
+  latestCommonYear,
+  validateFiscalSpace,
+  FISCAL_SPACE_VALIDATION_FLOORS,
+} from '../scripts/seed-recovery-fiscal-space.mjs';
+
+// computeDebtSustainabilityGap — formula correctness (5 worked cases above)
+// latestCommonYear — picks latest year present in all maps; returns null if none
+
+// buildFiscalSpaceCountries — 6-country fixture covering:
+//   - full data → all 4 fields populated
+//   - one fiscal-3 field missing (e.g. no revenue but balance + debt present) → emitted with rev=null, fiscal balance + debt intact
+//   - missing growth → emitted, gap=null, fiscal-3 intact
+//   - inflation > 25 (Argentina-like) → emitted, gap=null, fiscal-3 intact
+//   - year mismatch (debt 2024, others 2023) → emitted, gap=null, fiscal-3 intact
+//   - all fiscal-3 missing (only macro/growth present) → SKIPPED (preserves existing skip guard)
+
+// validateFiscalSpace — exercise with small floors:
+//   - validateFiscalSpace(small5CountryFixture, { fiscal3: 3, gap: 2 }) → true
+//   - validateFiscalSpace(small5CountryFixture, { fiscal3: 150, gap: 100 }) → false
+//   - Two-floor independence: pass 1, fail 2 → false; pass 2, fail 1 → false
+
+// Production floors — assert named constant directly:
+it('production floors are 150 fiscal-3 / 100 gap-inputs', () => {
+  assert.deepEqual(FISCAL_SPACE_VALIDATION_FLOORS, { fiscal3: 150, gap: 100 });
+});
+```
+
+### Scorer test (new file `tests/resilience-fiscal-space.test.mts`)
+
+5 representative countries through `scoreFiscalSpace` end-to-end. Snapshot test on the output to catch unintended drift on rebalanced weights.
+
+### Existing test parity
+
+- `tests/resilience-indicator-extraction-plan.test.mjs:23` — must pass after EXTRACTION_RULES update.
+- Existing `scoreFiscalSpace`-touching tests need score-baseline updates (the weight change shifts all current scores slightly even without the new indicator firing).
+
+---
+
+## Backtest / ranking-shift validation
+
+Run `scripts/compare-resilience-current-vs-proposed.mjs` against the change. Expected directional shifts:
+
+- **Drops**: high-debt + negative-pb (Italy, Greece, Belgium, France marginally) — losing level-only debt protection
+- **Rises**: high-debt + g≈r + flat-pb (Japan — formula honors that debt isn't actually growing)
+- **Rises**: low-debt + positive pb (Norway, Singapore, Switzerland, Denmark)
+- **Held**: mid-debt + strong nominal growth via inflation (Vietnam, India, Indonesia) — g > r gives them room
+- **Excluded**: Argentina, Lebanon, Venezuela (inflation cap) — fiscal-3 still scores them, no gap signal
+
+**Acceptance threshold**: ≤10 countries shift by more than ±5 ranks in the `economy` pillar. Any country breaching that gets a one-line explanation in the PR description.
+
+---
+
+## Deployment verification
+
+### Pre-merge
+
+- All new + existing tests green
+- Local seeder run against IMF fixture, dump JSON, manually inspect 3 countries (France, Japan, Norway): assert `debtSustainabilityGapPct` matches worked examples ±0.01.
+- `npx tsc --noEmit` clean.
+
+### Post-merge / post-deploy
+
+- Wait one seeder cron tick (≤24h for monthly cadence; actual seeder runs on a faster cron for this blob).
+- **Redis payload assertion** (primary verification): direct GET on `resilience:recovery:fiscal-space:v1` (via Upstash REST or `node -e` against the prod Redis URL). Assert ≥100 countries have `debtSustainabilityGapPct: number` and spot-check 3 known countries (France, Japan, Norway) against the worked examples ±0.5 tolerance to account for IMF data refreshes.
+- **Scorer impact** (secondary): the production resilience API exposes dimension-level scores, not sub-indicator rows — so "4 sub-scores not 3" is NOT directly observable from the API. Instead, run `scripts/compare-resilience-current-vs-proposed.mjs` against pre/post Redis snapshots and confirm the expected directional ranking shifts.
+- `/api/health` will show the seeder's freshness — that's real and useful — but NOT field-level coverage. Don't rely on health for field verification.
+
+### Rollback path
+
+- Revert the PR. Seeder schemaVersion drops back to 1 on the next tick. Old scorer reads the new blob — extra fields are ignored, fiscal-3 score returns. Zero data loss; only a few hours of degraded scores between revert and next seeder tick.
+
+---
+
+## Files touched
+
+1. `scripts/seed-recovery-fiscal-space.mjs` — pull 3 more series, compute gap, schema v2, two-floor validate, export named helpers + floors constant.
+2. `server/worldmonitor/resilience/v1/_indicator-registry.ts` — new indicator + rebalanced weights.
+3. `server/worldmonitor/resilience/v1/_dimension-scorers.ts::scoreFiscalSpace` — add 4th sub-score.
+4. Type def of `RecoveryFiscalSpaceCountry` (likely same file as scorer or its types module).
+5. `scripts/compare-resilience-current-vs-proposed.mjs:366` — one new EXTRACTION_RULES row.
+6. `docs/methodology/country-resilience-index.mdx:322` — update fiscal-space indicator table.
+7. `docs/methodology/indicator-sources.yaml:521` — add new entry.
+8. `tests/resilience-debt-sustainability-gap.test.mts` — NEW, formula unit tests.
+9. `tests/seed-recovery-fiscal-space.test.mts` — NEW, seeder contract test.
+10. `tests/resilience-fiscal-space.test.mts` — NEW, scorer integration tests.
+
+---
+
+## Policy decisions (LOCKED 2026-05-12 by user)
+
+1. **Goalpost calibration**: `worst=-5 / best=+3` ✅ — DSA-distress envelope, score 50 ≈ debt-stabilizing point.
+2. **Inflation cap**: `INFLATION_GAP_CAP_PCT = 25` ✅ — Turkey 2024 (~65%), Argentina, Lebanon, Venezuela excluded from gap indicator. Fiscal-3 still scores them.
+3. **Weights inside fiscalSpace**: `recoveryGovRevenue 0.25 / recoveryFiscalBalance 0.20 / recoveryDebtToGdp 0.20 / debtSustainabilityGap 0.35` ✅ — gap is largest single slice; other three are co-signals.
+4. **Backtest acceptance threshold**: `≤10 countries shifting >±5 ranks` in the `economy` pillar ✅ (plan default — user did not override).
+
+All four are pinned. `/ce-work` should not re-ask.
+
+---
+
+## Review history
+
+| Round | Verdict | Findings | Key changes after this round |
+|---|---|---|---|
+| 1 | REVISE | 2× P0 + 3× P1 + 2× P2 = 7 | France math redone end-to-end; two-floor validate; year alignment via `latestCommonYear`; gap moved to seed-time computation for backtest-harness compat; standard `((r−g)/(1+g))·d` formula; compounded `(1+real)(1+infl)−1` growth; docs files added; one-PR rollout |
+| 2 | REVISE | 3× P1 + 2× P2 = 5 | Year-alignment bug fixed in pseudocode (all 5 formula inputs read at commonYear); revenue dropped from common-year input set; correct `EXTRACTION_RULES` shape `{type:'recovery-country-field', key, field}`; pure exported helpers replace ESM mocking; explicit two-failure-mode validation semantics |
+| 3 | REVISE | 2× P1 + 2× P2 = 4 | `allIso3` defined as fiscal-3 union with skip guard preserved; test fixture expanded to 6 cases separating "one field missing → emit" from "all fiscal-3 missing → skip"; formula test param names corrected to match helper signature; post-deploy verification rewritten to Redis + backtest (not API response shape) |
+| 4 | **APPROVED** | 1× non-blocking nit | Export `FISCAL_SPACE_VALIDATION_FLOORS` constant for direct test assertion (incorporated into this final draft) |

--- a/scripts/compare-resilience-current-vs-proposed.mjs
+++ b/scripts/compare-resilience-current-vs-proposed.mjs
@@ -366,6 +366,7 @@ const EXTRACTION_RULES = {
   recoveryGovRevenue: { type: 'recovery-country-field', key: 'resilience:recovery:fiscal-space:v1', field: 'govRevenuePct' },
   recoveryFiscalBalance: { type: 'recovery-country-field', key: 'resilience:recovery:fiscal-space:v1', field: 'fiscalBalancePct' },
   recoveryDebtToGdp: { type: 'recovery-country-field', key: 'resilience:recovery:fiscal-space:v1', field: 'debtToGdpPct' },
+  debtSustainabilityGap: { type: 'recovery-country-field', key: 'resilience:recovery:fiscal-space:v1', field: 'debtSustainabilityGapPct' },
   recoveryReserveMonths: { type: 'recovery-country-field', key: 'resilience:recovery:reserve-adequacy:v1', field: 'reserveMonths' },
   // PR 2 §3.4: replacement for recoveryReserveMonths at the tighter 1..12
   // anchor. Same seed key + field; the harness extracts the same value

--- a/scripts/seed-recovery-fiscal-space.mjs
+++ b/scripts/seed-recovery-fiscal-space.mjs
@@ -7,6 +7,18 @@ loadEnvFile(import.meta.url);
 const CANONICAL_KEY = 'resilience:recovery:fiscal-space:v1';
 const CACHE_TTL = 35 * 24 * 3600;
 
+// Two-floor validation thresholds for the seeded payload. Exported so
+// tests assert the production values directly rather than introspecting
+// `validate.toString()`.
+export const FISCAL_SPACE_VALIDATION_FLOORS = { fiscal3: 150, gap: 100 };
+
+// Hyperinflation cap on the debt-sustainability gap indicator. Above this
+// CPI threshold the formula's inflation-tax term dominates and produces a
+// misleadingly positive "gap" that masks underlying fiscal pathology
+// (Argentina, Lebanon, Venezuela). Drop to null in that regime — the
+// other 3 fiscalSpace indicators still score those countries.
+export const INFLATION_GAP_CAP_PCT = 25;
+
 const ISO2_TO_ISO3 = loadSharedConfig('iso2-to-iso3.json');
 const ISO3_TO_ISO2 = Object.fromEntries(Object.entries(ISO2_TO_ISO3).map(([k, v]) => [v, k]));
 
@@ -33,15 +45,88 @@ function latestValue(byYear) {
   return null;
 }
 
-async function fetchFiscalSpace() {
-  const years = weoYears();
-  const [revenueData, balanceData, debtData] = await Promise.all([
-    imfSdmxFetchIndicator('GGR_NGDP', { years }),
-    imfSdmxFetchIndicator('GGXCNL_NGDP', { years }),
-    imfSdmxFetchIndicator('GGXWDG_NGDP', { years }),
-  ]);
+/**
+ * Find the most recent year that is present with a finite value across
+ * ALL of the supplied byYear maps. Returns the year as a number, or null
+ * when no common year exists in the WEO scan window (current, -1, -2).
+ *
+ * Year alignment is critical for the debt-sustainability formula: debt
+ * could be a 2025 forecast while inflation is 2023 actual — combining
+ * them across years produces a nonsense gap. Per the approved plan, only
+ * the 5 formula inputs (debt, balance, primary balance, growth, inflation)
+ * are aligned; revenue is NOT in the formula and is not gated by this.
+ */
+export function latestCommonYear(byYearMaps) {
+  if (!Array.isArray(byYearMaps) || byYearMaps.length === 0) return null;
+  for (const year of weoYears()) {
+    const allPresent = byYearMaps.every((m) => {
+      const v = Number(m?.[year]);
+      return Number.isFinite(v);
+    });
+    if (allPresent) return Number(year);
+  }
+  return null;
+}
 
+/**
+ * Pure computation of the IMF DSA debt-sustainability gap.
+ *
+ *   g    = (1 + realG/100) * (1 + infl/100) - 1     compounded nominal growth (decimal)
+ *   r    = max(0, (pb - fb) / debt)                  effective interest rate (decimal)
+ *   pb*  = ((r - g) / (1 + g)) * debt               debt-stabilizing primary balance (% GDP)
+ *   gap  = pb - pb*                                  positive => debt declining
+ *
+ * Inputs are all in percent (% of GDP for fiscal terms, % per year for
+ * growth and inflation). Output is in percent of GDP. Returns null when:
+ *
+ *   - debt is null or ≤ 0 (negative net debt is rare; r-division undefined)
+ *   - inflation > INFLATION_GAP_CAP_PCT (hyperinflation; gap is unreliable)
+ *   - any of {pb, fb, realG} is null (insufficient data)
+ *
+ * `r` is derived from the algebraic identity:
+ *   overall_balance = primary_balance - interest_expense
+ *   => interest_pct_gdp = primaryBalance - fiscalBalance
+ *   => r = interest_pct_gdp / debt_pct_gdp
+ *
+ * This avoids needing per-country sovereign yields (FRED only covers US).
+ */
+export function computeDebtSustainabilityGap({ debt, pb, fb, realG, infl }) {
+  if (debt == null || !Number.isFinite(debt) || debt <= 0) return null;
+  if (infl == null || !Number.isFinite(infl) || infl > INFLATION_GAP_CAP_PCT) return null;
+  if (pb == null || !Number.isFinite(pb)) return null;
+  if (fb == null || !Number.isFinite(fb)) return null;
+  if (realG == null || !Number.isFinite(realG)) return null;
+
+  const g = (1 + realG / 100) * (1 + infl / 100) - 1;
+  const r = Math.max(0, (pb - fb) / debt);
+  const pbStar = ((r - g) / (1 + g)) * debt;
+  return pb - pbStar;
+}
+
+/**
+ * Pure per-country builder. Takes the raw return of `imfSdmxFetchIndicator`
+ * for each of the 6 series and returns the `{[iso2]: payload}` map.
+ *
+ * Country inclusion stays anchored to the fiscal-3 union (revenue ∪ balance
+ * ∪ debt). Growth/inflation/primaryBalance are NOT in the inclusion check
+ * — an IMF fiscal-series outage that leaves countries with only growth +
+ * inflation data must not produce phantom entries with null fiscal-3
+ * fields (this was the R1-P0 risk in plan review).
+ *
+ * Fiscal-3 fields keep their existing latest-per-series semantics (no
+ * regression from prior behavior). Gap-indicator fields are only emitted
+ * when all 5 formula inputs share a common WEO year via latestCommonYear;
+ * mismatched-year countries get gap=null with fiscal-3 still populated.
+ */
+export function buildFiscalSpaceCountries(perIndicator) {
   const countries = {};
+  const revenueData       = perIndicator?.revenue       ?? {};
+  const balanceData       = perIndicator?.balance       ?? {};
+  const debtData          = perIndicator?.debt          ?? {};
+  const primaryBalanceData = perIndicator?.primaryBalance ?? {};
+  const growthData        = perIndicator?.growth        ?? {};
+  const inflationData     = perIndicator?.inflation     ?? {};
+
   const allIso3 = new Set([
     ...Object.keys(revenueData),
     ...Object.keys(balanceData),
@@ -53,24 +138,111 @@ async function fetchFiscalSpace() {
     const iso2 = ISO3_TO_ISO2[iso3];
     if (!iso2) continue;
 
-    const rev = latestValue(revenueData[iso3]);
-    const bal = latestValue(balanceData[iso3]);
+    const rev  = latestValue(revenueData[iso3]);
+    const bal  = latestValue(balanceData[iso3]);
     const debt = latestValue(debtData[iso3]);
+
+    // Existing skip guard — preserve verbatim. Countries with NO fiscal-3
+    // data are not emitted, regardless of whether growth/inflation exist.
     if (!rev && !bal && !debt) continue;
 
+    // Year-aligned gap inputs. Only the 5 formula inputs are in the
+    // alignment set — revenue is NOT in the formula and is omitted here.
+    const commonYear = latestCommonYear([
+      debtData[iso3],
+      balanceData[iso3],
+      primaryBalanceData[iso3],
+      growthData[iso3],
+      inflationData[iso3],
+    ]);
+
+    let pb = null;
+    let real = null;
+    let infl = null;
+    let gap = null;
+    let gapYear = null;
+    if (commonYear != null) {
+      const yearKey = String(commonYear);
+      const debtCommon = Number(debtData[iso3]?.[yearKey]);
+      const fbCommon   = Number(balanceData[iso3]?.[yearKey]);
+      pb   = Number(primaryBalanceData[iso3]?.[yearKey]);
+      real = Number(growthData[iso3]?.[yearKey]);
+      infl = Number(inflationData[iso3]?.[yearKey]);
+      gap = computeDebtSustainabilityGap({
+        debt: debtCommon,
+        pb,
+        fb: fbCommon,
+        realG: real,
+        infl,
+      });
+      gapYear = commonYear;
+    }
+
     countries[iso2] = {
-      govRevenuePct: rev?.value ?? null,
-      fiscalBalancePct: bal?.value ?? null,
-      debtToGdpPct: debt?.value ?? null,
-      year: rev?.year ?? bal?.year ?? debt?.year ?? null,
+      // Existing fiscal-3 fields — unchanged latest-per-series semantics.
+      govRevenuePct:     rev?.value ?? null,
+      fiscalBalancePct:  bal?.value ?? null,
+      debtToGdpPct:      debt?.value ?? null,
+      year:              rev?.year ?? bal?.year ?? debt?.year ?? null,
+      // Gap-indicator fields — only populated when all 5 formula inputs
+      // share a common WEO year (otherwise all stay null).
+      primaryBalancePct:         Number.isFinite(pb) ? pb : null,
+      realGdpGrowthPct:          Number.isFinite(real) ? real : null,
+      inflationPct:              Number.isFinite(infl) ? infl : null,
+      debtSustainabilityGapPct:  gap,
+      gapYear,
     };
   }
 
-  return { countries, seededAt: new Date().toISOString() };
+  return countries;
 }
 
-function validate(data) {
-  return typeof data?.countries === 'object' && Object.keys(data.countries).length >= 150;
+/**
+ * Two-floor validator. Called by runSeed's pre-publish check.
+ *
+ * - If returns false → seeder rejects the payload entirely; runSeed
+ *   short-circuits the canonical write and the previous canonical blob
+ *   keeps serving (existing strict-floor behavior in _seed-utils.mjs).
+ * - If returns true but individual countries lack gap inputs → those
+ *   countries get debtSustainabilityGapPct=null and the scorer's
+ *   weightedBlend redistributes weight across the remaining 3 indicators.
+ *
+ * Two failure modes, cleanly separated:
+ *   - System-level outage (fiscal-3 < 150 OR gap-inputs < 100) → reject.
+ *   - Per-country gap unavailability (year mismatch, hyperinflation cap,
+ *     partial growth/inflation for one specific country) → emit with
+ *     gap=null, fiscal-3 still scores them.
+ */
+export function validateFiscalSpace(data, floors = FISCAL_SPACE_VALIDATION_FLOORS) {
+  const all = Object.values(data?.countries || {});
+  const withFiscal3 = all.filter(c =>
+    c.govRevenuePct != null && c.fiscalBalancePct != null && c.debtToGdpPct != null
+  ).length;
+  const withGap = all.filter(c => c.debtSustainabilityGapPct != null).length;
+  return withFiscal3 >= floors.fiscal3 && withGap >= floors.gap;
+}
+
+async function fetchFiscalSpace() {
+  const years = weoYears();
+  const [revenueData, balanceData, debtData, primaryBalanceData, growthData, inflationData] = await Promise.all([
+    imfSdmxFetchIndicator('GGR_NGDP',    { years }),
+    imfSdmxFetchIndicator('GGXCNL_NGDP', { years }),
+    imfSdmxFetchIndicator('GGXWDG_NGDP', { years }),
+    imfSdmxFetchIndicator('GGXONLB_NGDP', { years }),  // primary balance % GDP
+    imfSdmxFetchIndicator('NGDP_RPCH',   { years }),    // real GDP growth %
+    imfSdmxFetchIndicator('PCPIPCH',     { years }),    // CPI inflation %
+  ]);
+
+  const countries = buildFiscalSpaceCountries({
+    revenue:        revenueData,
+    balance:        balanceData,
+    debt:           debtData,
+    primaryBalance: primaryBalanceData,
+    growth:         growthData,
+    inflation:      inflationData,
+  });
+
+  return { countries, seededAt: new Date().toISOString() };
 }
 
 export function declareRecords(data) {
@@ -79,13 +251,13 @@ export function declareRecords(data) {
 
 if (process.argv[1]?.endsWith('seed-recovery-fiscal-space.mjs')) {
   runSeed('resilience', 'recovery:fiscal-space', CANONICAL_KEY, fetchFiscalSpace, {
-    validateFn: validate,
+    validateFn: (data) => validateFiscalSpace(data),
     ttlSeconds: CACHE_TTL,
     sourceVersion: `imf-sdmx-weo-fiscal-${new Date().getFullYear()}`,
     recordCount: (data) => Object.keys(data?.countries ?? {}).length,
-  
+
     declareRecords,
-    schemaVersion: 1,
+    schemaVersion: 2,
     maxStaleMin: 86400,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';

--- a/scripts/seed-recovery-fiscal-space.mjs
+++ b/scripts/seed-recovery-fiscal-space.mjs
@@ -146,14 +146,23 @@ export function buildFiscalSpaceCountries(perIndicator) {
     // data are not emitted, regardless of whether growth/inflation exist.
     if (!rev && !bal && !debt) continue;
 
+    // Capture per-iso3 byYear dicts once — used for year alignment plus
+    // the actual value reads. Saves repeated iso3 hash lookups (PR #3669
+    // review nit; negligible at N=190 but the cleanup is honest).
+    const debtByYear   = debtData[iso3];
+    const balByYear    = balanceData[iso3];
+    const pbByYear     = primaryBalanceData[iso3];
+    const growthByYear = growthData[iso3];
+    const inflByYear   = inflationData[iso3];
+
     // Year-aligned gap inputs. Only the 5 formula inputs are in the
     // alignment set — revenue is NOT in the formula and is omitted here.
     const commonYear = latestCommonYear([
-      debtData[iso3],
-      balanceData[iso3],
-      primaryBalanceData[iso3],
-      growthData[iso3],
-      inflationData[iso3],
+      debtByYear,
+      balByYear,
+      pbByYear,
+      growthByYear,
+      inflByYear,
     ]);
 
     let pb = null;
@@ -163,11 +172,11 @@ export function buildFiscalSpaceCountries(perIndicator) {
     let gapYear = null;
     if (commonYear != null) {
       const yearKey = String(commonYear);
-      const debtCommon = Number(debtData[iso3]?.[yearKey]);
-      const fbCommon   = Number(balanceData[iso3]?.[yearKey]);
-      pb   = Number(primaryBalanceData[iso3]?.[yearKey]);
-      real = Number(growthData[iso3]?.[yearKey]);
-      infl = Number(inflationData[iso3]?.[yearKey]);
+      const debtCommon = Number(debtByYear?.[yearKey]);
+      const fbCommon   = Number(balByYear?.[yearKey]);
+      pb   = Number(pbByYear?.[yearKey]);
+      real = Number(growthByYear?.[yearKey]);
+      infl = Number(inflByYear?.[yearKey]);
       gap = computeDebtSustainabilityGap({
         debt: debtCommon,
         pb,
@@ -258,7 +267,11 @@ if (process.argv[1]?.endsWith('seed-recovery-fiscal-space.mjs')) {
 
     declareRecords,
     schemaVersion: 2,
-    maxStaleMin: 86400,
+    // 90d = 3× the 30-day cron interval per the health-maxstalemin-write-cadence
+    // skill (rule: maxStaleMin = write_interval × 2-3). Bumped from 86400 (2×, at
+    // project floor) to give extra margin against month-2 cron hiccups. Must also
+    // be mirrored in api/health.js for the alarm threshold to track.
+    maxStaleMin: 129600,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
     console.error('FATAL:', (err.message || err) + _cause);

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -1981,6 +1981,14 @@ interface RecoveryFiscalSpaceCountry {
   fiscalBalancePct?: number | null;
   debtToGdpPct?: number | null;
   year?: number | null;
+  // Gap-indicator fields (schemaVersion 2). Only populated when all 5
+  // formula inputs share a common WEO year per latestCommonYear() in the
+  // seeder. Otherwise null; the scorer's weightedBlend redistributes.
+  primaryBalancePct?: number | null;
+  realGdpGrowthPct?: number | null;
+  inflationPct?: number | null;
+  debtSustainabilityGapPct?: number | null;
+  gapYear?: number | null;
 }
 
 interface RecoveryReserveAdequacyCountry {
@@ -2027,10 +2035,17 @@ export async function scoreFiscalSpace(
     };
   }
 
+  // Weight rebalance + new indicator (debtSustainabilityGap) per
+  // plans/add-debt-sustainability-gap-indicator.md. The gap (pb − pb*)
+  // is the most informative single fiscal signal — it integrates pb, r,
+  // g, and d with their interaction term — and earns the largest slice.
+  // The other three are co-signals confirming the direction.
+  //   sum = 0.25 + 0.20 + 0.20 + 0.35 = 1.0
   return weightedBlend([
-    { score: entry.govRevenuePct == null ? null : normalizeHigherBetter(entry.govRevenuePct, 5, 45), weight: 0.4 },
-    { score: entry.fiscalBalancePct == null ? null : normalizeHigherBetter(entry.fiscalBalancePct, -15, 5), weight: 0.3 },
-    { score: entry.debtToGdpPct == null ? null : normalizeLowerBetter(entry.debtToGdpPct, 0, 150), weight: 0.3 },
+    { score: entry.govRevenuePct == null ? null : normalizeHigherBetter(entry.govRevenuePct, 5, 45), weight: 0.25 },
+    { score: entry.fiscalBalancePct == null ? null : normalizeHigherBetter(entry.fiscalBalancePct, -15, 5), weight: 0.20 },
+    { score: entry.debtToGdpPct == null ? null : normalizeLowerBetter(entry.debtToGdpPct, 0, 150), weight: 0.20 },
+    { score: entry.debtSustainabilityGapPct == null ? null : normalizeHigherBetter(entry.debtSustainabilityGapPct, -5, 3), weight: 0.35 },
   ]);
 }
 

--- a/server/worldmonitor/resilience/v1/_indicator-registry.ts
+++ b/server/worldmonitor/resilience/v1/_indicator-registry.ts
@@ -1011,14 +1011,18 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     comprehensive: true,
   },
 
-  // ── fiscalSpace (3 sub-metrics) ──────────────────────────────────────────
+  // ── fiscalSpace (4 sub-metrics) ──────────────────────────────────────────
+  // Weights rebalanced from 0.4/0.3/0.3 → 0.25/0.20/0.20/0.35 to make room
+  // for debtSustainabilityGap as the largest single slice (it's the most
+  // informative single signal — integrates pb, r, g, d, and their
+  // interaction). Sum invariant: 0.25 + 0.20 + 0.20 + 0.35 = 1.0.
   {
     id: 'recoveryGovRevenue',
     dimension: 'fiscalSpace',
     description: 'Government revenue as % of GDP (IMF GGR_G01_GDP_PT); fiscal mobilization capacity for recovery',
     direction: 'higherBetter',
     goalposts: { worst: 5, best: 45 },
-    weight: 0.4,
+    weight: 0.25,
     sourceKey: 'resilience:recovery:fiscal-space:v1',
     scope: 'global',
     cadence: 'annual',
@@ -1033,7 +1037,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     description: 'General government net lending/borrowing as % of GDP (IMF GGXCNL_G01_GDP_PT); deficit signals reduced recovery firepower',
     direction: 'higherBetter',
     goalposts: { worst: -15, best: 5 },
-    weight: 0.3,
+    weight: 0.20,
     sourceKey: 'resilience:recovery:fiscal-space:v1',
     scope: 'global',
     cadence: 'annual',
@@ -1048,12 +1052,32 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     description: 'General government gross debt as % of GDP (IMF GGXWDG_NGDP_PT); high debt limits recovery borrowing capacity',
     direction: 'lowerBetter',
     goalposts: { worst: 150, best: 0 },
-    weight: 0.3,
+    weight: 0.20,
     sourceKey: 'resilience:recovery:fiscal-space:v1',
     scope: 'global',
     cadence: 'annual',
     tier: 'core',
     coverage: 190,
+    license: 'open-data',
+    comprehensive: true,
+  },
+  {
+    id: 'debtSustainabilityGap',
+    dimension: 'fiscalSpace',
+    description: 'Primary-balance gap to debt-stabilizing level: gap = pb − ((r−g)/(1+g))·d (IMF DSA construct). Positive = debt path declining, negative = rising. r derived from interest expense / debt (overall balance minus primary balance); g from compounded real growth × (1+CPI). Hyperinflation cap at 25% drops gap to null for Argentina/Lebanon/Venezuela; fiscal-3 still scores them.',
+    direction: 'higherBetter',
+    goalposts: { worst: -5, best: 3 },
+    weight: 0.35,
+    sourceKey: 'resilience:recovery:fiscal-space:v1',
+    scope: 'global',
+    cadence: 'annual',
+    // Tier: 'enrichment' — the indicator excludes hyperinflation countries
+    // by design (CPI > 25% → gap=null), so it structurally cannot meet the
+    // Core-tier ≥180 countries coverage invariant. Scorer doesn't filter by
+    // tier; this is a quality classification. The 3 sibling fiscalSpace
+    // indicators (revenue/balance/debt) remain Core at coverage 190.
+    tier: 'enrichment',
+    coverage: 150,
     license: 'open-data',
     comprehensive: true,
   },

--- a/tests/helpers/resilience-fixtures.mts
+++ b/tests/helpers/resilience-fixtures.mts
@@ -433,8 +433,23 @@ export const RESILIENCE_FIXTURES: FixtureMap = {
   },
   'resilience:recovery:fiscal-space:v1': {
     countries: {
-      NO: { govRevenuePct: 42, fiscalBalancePct: 10, debtToGdpPct: 40, year: 2025 },
-      US: { govRevenuePct: 30, fiscalBalancePct: -6, debtToGdpPct: 122, year: 2025 },
+      // NO: full gap inputs — strong fiscal position, debt path declining
+      // (gap ≈ +11.4 → clamps to 100 against -5/+3 goalposts).
+      NO: {
+        govRevenuePct: 42, fiscalBalancePct: 10, debtToGdpPct: 40, year: 2025,
+        primaryBalancePct: 11, realGdpGrowthPct: 1, inflationPct: 2.5,
+        debtSustainabilityGapPct: 11.4, gapYear: 2025,
+      },
+      // US: full gap inputs — near debt-stabilizing point (gap ≈ 0.02 →
+      // normalized score ≈ 63 against -5/+3 goalposts).
+      US: {
+        govRevenuePct: 30, fiscalBalancePct: -6, debtToGdpPct: 122, year: 2025,
+        primaryBalancePct: -3, realGdpGrowthPct: 2, inflationPct: 3,
+        debtSustainabilityGapPct: 0.02, gapYear: 2025,
+      },
+      // YE: fiscal-3 only, no gap inputs (realistic for data-sparse country).
+      // Scorer's weightedBlend redistributes weight across the 3 populated
+      // indicators, demonstrating null-gap fallback behavior.
       YE: { govRevenuePct: 8, fiscalBalancePct: -10, debtToGdpPct: 80, year: 2024 },
     },
     seededAt: '2026-04-04T00:00:00.000Z',

--- a/tests/resilience-debt-sustainability-gap.test.mts
+++ b/tests/resilience-debt-sustainability-gap.test.mts
@@ -1,0 +1,123 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  computeDebtSustainabilityGap,
+  INFLATION_GAP_CAP_PCT,
+} from '../scripts/seed-recovery-fiscal-space.mjs';
+
+/**
+ * Worked examples for the IMF DSA gap formula. These five cases are
+ * pinned from the approved plan document and are the ground-truth
+ * regression suite — any change to computeDebtSustainabilityGap that
+ * shifts these by > 0.01 needs explicit justification in the PR.
+ *
+ * Formula:
+ *   g    = (1 + realG/100) * (1 + infl/100) - 1
+ *   r    = max(0, (pb - fb) / debt)
+ *   pb*  = ((r - g) / (1 + g)) * debt
+ *   gap  = pb - pb*
+ */
+describe('computeDebtSustainabilityGap (formula correctness)', () => {
+  it('France 2024: mid-debt, mild deficit → gap ≈ -1.43', () => {
+    const gap = computeDebtSustainabilityGap({
+      debt: 110, pb: -2.5, fb: -4.5, realG: 0.7, infl: 2.1,
+    });
+    assert.ok(gap !== null, 'gap should be defined for France inputs');
+    assert.ok(Math.abs(gap! - -1.43) < 0.01, `expected ≈ -1.43, got ${gap}`);
+  });
+
+  it('Japan 2024: very-high debt, flat pb, g≈r → gap ≈ +3.20 (clamps at 100)', () => {
+    const gap = computeDebtSustainabilityGap({
+      debt: 250, pb: 0, fb: -3, realG: 0.5, infl: 2.0,
+    });
+    assert.ok(gap !== null, 'gap should be defined for Japan inputs');
+    assert.ok(Math.abs(gap! - 3.20) < 0.01, `expected ≈ +3.20, got ${gap}`);
+  });
+
+  it('Norway 2024: low debt, strong surplus → gap large positive (>5)', () => {
+    const gap = computeDebtSustainabilityGap({
+      debt: 38, pb: 10, fb: 8, realG: 1.0, infl: 2.5,
+    });
+    assert.ok(gap !== null, 'gap should be defined for Norway inputs');
+    assert.ok(gap! > 5, `expected gap > 5, got ${gap}`);
+    // Tighter pin from the plan's worked example:
+    assert.ok(Math.abs(gap! - 9.36) < 0.05, `expected ≈ +9.36, got ${gap}`);
+  });
+
+  it('Italy 2024: high-debt, mild surplus → gap near zero (debt-stabilizing)', () => {
+    const gap = computeDebtSustainabilityGap({
+      debt: 137, pb: 1.0, fb: -3.5, realG: 0.5, infl: 2.0,
+    });
+    assert.ok(gap !== null, 'gap should be defined for Italy inputs');
+    // Plan example: gap ≈ -0.04 (right at the stabilizing point)
+    assert.ok(Math.abs(gap!) < 0.5, `expected gap near 0 for stabilizing Italy, got ${gap}`);
+  });
+
+  it('returns null for degenerate denominator (debt = 0)', () => {
+    const gap = computeDebtSustainabilityGap({
+      debt: 0, pb: 0, fb: 0, realG: 1, infl: 2,
+    });
+    assert.equal(gap, null);
+  });
+
+  it('returns null for negative debt (negative net debt, rare edge)', () => {
+    const gap = computeDebtSustainabilityGap({
+      debt: -10, pb: 0, fb: 0, realG: 1, infl: 2,
+    });
+    assert.equal(gap, null);
+  });
+
+  it('returns null above inflation cap (Argentina 2024: infl=200)', () => {
+    const gap = computeDebtSustainabilityGap({
+      debt: 90, pb: -2, fb: -5, realG: -3, infl: 200,
+    });
+    assert.equal(gap, null);
+  });
+
+  it('returns null exactly above inflation cap boundary (infl = cap + epsilon)', () => {
+    const gap = computeDebtSustainabilityGap({
+      debt: 100, pb: 0, fb: -2, realG: 1, infl: INFLATION_GAP_CAP_PCT + 0.01,
+    });
+    assert.equal(gap, null, 'inflation just above cap should drop to null');
+  });
+
+  it('accepts inflation exactly at the cap (infl = cap)', () => {
+    const gap = computeDebtSustainabilityGap({
+      debt: 100, pb: 0, fb: -2, realG: 1, infl: INFLATION_GAP_CAP_PCT,
+    });
+    assert.ok(gap !== null, 'inflation at cap should still produce a gap (strict `>` boundary)');
+  });
+
+  it('returns null when any individual input is null', () => {
+    assert.equal(computeDebtSustainabilityGap({ debt: null, pb: 0, fb: 0, realG: 1, infl: 2 }), null);
+    assert.equal(computeDebtSustainabilityGap({ debt: 100, pb: null, fb: 0, realG: 1, infl: 2 }), null);
+    assert.equal(computeDebtSustainabilityGap({ debt: 100, pb: 0, fb: null, realG: 1, infl: 2 }), null);
+    assert.equal(computeDebtSustainabilityGap({ debt: 100, pb: 0, fb: 0, realG: null, infl: 2 }), null);
+    assert.equal(computeDebtSustainabilityGap({ debt: 100, pb: 0, fb: 0, realG: 1, infl: null }), null);
+  });
+
+  it('returns null when any input is non-finite (NaN / Infinity)', () => {
+    assert.equal(computeDebtSustainabilityGap({ debt: NaN, pb: 0, fb: 0, realG: 1, infl: 2 }), null);
+    assert.equal(computeDebtSustainabilityGap({ debt: Infinity, pb: 0, fb: 0, realG: 1, infl: 2 }), null);
+    assert.equal(computeDebtSustainabilityGap({ debt: 100, pb: NaN, fb: 0, realG: 1, infl: 2 }), null);
+    assert.equal(computeDebtSustainabilityGap({ debt: 100, pb: 0, fb: 0, realG: 1, infl: NaN }), null);
+  });
+
+  it('clamps effective rate r at 0 (rounding-negative interest does not flip sign)', () => {
+    // Construct a case where (pb - fb) is slightly negative due to
+    // rounding artifacts: pb=-3.001, fb=-3.000 → interest ≈ -0.001 < 0.
+    // Without the floor, gap would be slightly different; with the floor,
+    // r is treated as 0 and pb* = -g/(1+g) * d.
+    const gap = computeDebtSustainabilityGap({
+      debt: 100, pb: -3.001, fb: -3, realG: 1, infl: 2,
+    });
+    assert.ok(gap !== null);
+    // With r=0, g≈0.0302, pb*= -0.0302/1.0302 * 100 = -2.932.
+    // gap = -3.001 - (-2.932) = -0.069. Without the floor, r=-0.00001 →
+    // pb* = (-0.00001 - 0.0302)/1.0302 * 100 = -2.933. gap = -0.068.
+    // The two differ by ~0.001 — small but distinguishable. We assert
+    // the floor branch matches the r=0 expectation within tolerance.
+    assert.ok(Math.abs(gap! - -0.069) < 0.01, `r should floor at 0, got gap=${gap}`);
+  });
+});

--- a/tests/resilience-debt-sustainability-gap.test.mts
+++ b/tests/resilience-debt-sustainability-gap.test.mts
@@ -50,8 +50,11 @@ describe('computeDebtSustainabilityGap (formula correctness)', () => {
       debt: 137, pb: 1.0, fb: -3.5, realG: 0.5, infl: 2.0,
     });
     assert.ok(gap !== null, 'gap should be defined for Italy inputs');
-    // Plan example: gap ≈ -0.04 (right at the stabilizing point)
-    assert.ok(Math.abs(gap!) < 0.5, `expected gap near 0 for stabilizing Italy, got ${gap}`);
+    // Plan example: gap ≈ -0.04 (right at the stabilizing point). Tolerance
+    // tightened from 0.5 to 0.01 to match the other worked examples — the
+    // wider tolerance would have masked formula regressions in (-0.5, +0.5)
+    // (greptile P2: PR #3669).
+    assert.ok(Math.abs(gap! - -0.04) < 0.01, `expected ≈ -0.04 for stabilizing Italy, got ${gap}`);
   });
 
   it('returns null for degenerate denominator (debt = 0)', () => {

--- a/tests/resilience-fiscal-space.test.mts
+++ b/tests/resilience-fiscal-space.test.mts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { scoreFiscalSpace } from '../server/worldmonitor/resilience/v1/_dimension-scorers';
+
+const FISCAL_KEY = 'resilience:recovery:fiscal-space:v1';
+
+interface CountryEntry {
+  govRevenuePct?: number | null;
+  fiscalBalancePct?: number | null;
+  debtToGdpPct?: number | null;
+  primaryBalancePct?: number | null;
+  realGdpGrowthPct?: number | null;
+  inflationPct?: number | null;
+  debtSustainabilityGapPct?: number | null;
+}
+
+function makeReader(countries: Record<string, CountryEntry>) {
+  return async (key: string): Promise<unknown | null> => {
+    if (key === FISCAL_KEY) return { countries };
+    return null;
+  };
+}
+
+describe('scoreFiscalSpace — 4-indicator blend with debtSustainabilityGap', () => {
+  it('Norway-shape: low debt + large positive gap → score saturates near 100', async () => {
+    const reader = makeReader({
+      NO: {
+        govRevenuePct: 42, fiscalBalancePct: 10, debtToGdpPct: 40,
+        primaryBalancePct: 11, realGdpGrowthPct: 1, inflationPct: 2.5,
+        debtSustainabilityGapPct: 11.4,
+      },
+    });
+    const result = await scoreFiscalSpace('NO', reader);
+    assert.ok(result.score > 85, `Norway should score >85 with full gap + healthy fiscal, got ${result.score}`);
+    assert.equal(result.imputationClass, null, 'real data must not carry imputation class');
+    assert.ok(result.coverage > 0.85, `coverage should be high when all 4 indicators populated, got ${result.coverage}`);
+  });
+
+  it('Italy-shape: high debt + mild surplus + gap near zero → score near the stabilizing midpoint', async () => {
+    const reader = makeReader({
+      IT: {
+        govRevenuePct: 47, fiscalBalancePct: -3.5, debtToGdpPct: 137,
+        primaryBalancePct: 1.0, realGdpGrowthPct: 0.5, inflationPct: 2.0,
+        debtSustainabilityGapPct: -0.04,
+      },
+    });
+    const result = await scoreFiscalSpace('IT', reader);
+    // Italy's debt-level penalty drags the score down, but the near-zero
+    // gap (debt-stabilizing) provides offsetting credit. Result should be
+    // mid-range, not at either extreme.
+    assert.ok(result.score > 30 && result.score < 70,
+      `Italy should land mid-range with offsetting signals, got ${result.score}`);
+  });
+
+  it('Greece-shape: high debt + negative gap → score drops significantly', async () => {
+    // Hypothetical Greece-like distress profile to verify the gap signal
+    // genuinely penalizes unsustainable trajectories.
+    const reader = makeReader({
+      GR: {
+        govRevenuePct: 48, fiscalBalancePct: -4.0, debtToGdpPct: 160,
+        primaryBalancePct: 0, realGdpGrowthPct: 1.0, inflationPct: 2.0,
+        debtSustainabilityGapPct: -4.5,  // near worst goalpost
+      },
+    });
+    const result = await scoreFiscalSpace('GR', reader);
+    // With a -4.5 gap (normalized ~6/100) carrying weight 0.35, plus the
+    // 0.20 weight on debt=160 (normalized ~0/100), the composite drops
+    // well below 50.
+    assert.ok(result.score < 50, `high-debt + negative-gap should score < 50, got ${result.score}`);
+  });
+
+  it('YE-shape: fiscal-3 only, gap=null → weight redistributes; observedWeight = 0.65', async () => {
+    const reader = makeReader({
+      YE: { govRevenuePct: 8, fiscalBalancePct: -10, debtToGdpPct: 80 },
+    });
+    const result = await scoreFiscalSpace('YE', reader);
+    // With gap=null, only the 3 fiscal-3 indicators score (sum of weights = 0.65).
+    // weightedBlend renormalizes so the score is a valid 0..100 value — but the
+    // coverage field reflects that only 65% of the weight is observed.
+    assert.ok(result.coverage >= 0.6 && result.coverage <= 0.7,
+      `coverage should reflect 0.65 observed weight when gap missing, got ${result.coverage}`);
+    assert.equal(result.imputationClass, null, 'partial data should not carry imputation class');
+  });
+
+  it('country missing entirely → unmonitored imputation', async () => {
+    const emptyReader = async (_key: string): Promise<unknown | null> => null;
+    const result = await scoreFiscalSpace('XX', emptyReader);
+    assert.equal(result.imputationClass, 'unmonitored');
+    assert.equal(result.observedWeight, 0);
+    assert.equal(result.imputedWeight, 1);
+  });
+
+  it('ordering invariant: low-debt+positive-gap > high-debt+negative-gap', async () => {
+    const reader = makeReader({
+      GOOD: {
+        govRevenuePct: 42, fiscalBalancePct: 5, debtToGdpPct: 50,
+        primaryBalancePct: 5, realGdpGrowthPct: 2, inflationPct: 2,
+        debtSustainabilityGapPct: 3,
+      },
+      BAD: {
+        govRevenuePct: 30, fiscalBalancePct: -8, debtToGdpPct: 150,
+        primaryBalancePct: -4, realGdpGrowthPct: 0.5, inflationPct: 2,
+        debtSustainabilityGapPct: -5,
+      },
+    });
+    const good = await scoreFiscalSpace('GOOD', reader);
+    const bad = await scoreFiscalSpace('BAD', reader);
+    assert.ok(good.score > bad.score,
+      `low-debt + positive gap (${good.score}) must beat high-debt + negative gap (${bad.score})`);
+    // Spread should be very wide for these extremes:
+    assert.ok(good.score - bad.score > 50,
+      `expected spread > 50 between extreme cases, got ${good.score - bad.score}`);
+  });
+
+  it('weight invariant: gap=null in fixture matches scorer output for fixture lacking gap field', async () => {
+    // Same country payload, two readers:
+    //   A. With debtSustainabilityGapPct explicitly null
+    //   B. Without the field at all
+    // Both should produce identical scores — the scorer's null-check
+    // treats missing and null equivalently.
+    const a = makeReader({ XX: { govRevenuePct: 35, fiscalBalancePct: -2, debtToGdpPct: 70, debtSustainabilityGapPct: null } });
+    const b = makeReader({ XX: { govRevenuePct: 35, fiscalBalancePct: -2, debtToGdpPct: 70 } });
+    const ra = await scoreFiscalSpace('XX', a);
+    const rb = await scoreFiscalSpace('XX', b);
+    assert.equal(ra.score, rb.score, 'explicit null and missing field must produce identical scores');
+    assert.equal(ra.coverage, rb.coverage, 'coverage must also match');
+  });
+});

--- a/tests/resilience-scorers.test.mts
+++ b/tests/resilience-scorers.test.mts
@@ -149,13 +149,19 @@ describe('resilience scorer contracts', () => {
     // per-capita normalized (review fix: it's an event-count-scaled term,
     // not dimensionless), accounting for the additional +1.0pt vs the
     // initial commit's 65.25 expectation.
+    // Plan 2026-05-12 debtSustainabilityGap addition: recovery 48.75 → 49.63.
+    // The new gap indicator (weight 0.35) inside fiscalSpace lifts the US
+    // fiscalSpace sub-score because the fixture's gap value (0.02, near
+    // debt-stabilizing) normalizes to ~63 against the -5/+3 goalposts,
+    // higher than the level-only blend the previous weights produced for
+    // a country with debt=122% GDP.
     assert.deepEqual(domainAverages, {
       economic: 53.25,
       infrastructure: 79,
       energy: 80,
       'social-governance': 66.25,
       'health-food': 60.5,
-      recovery: 48.75,
+      recovery: 49.63,
     });
 
     function round(v: number, d = 2) { return Number(v.toFixed(d)); }
@@ -211,7 +217,11 @@ describe('resilience scorer contracts', () => {
     // sovereignFiscalBuffer at IMPUTE 50/0.3 since US has no SWF
     // manifest entry — fixture defaults). Halving its already-low
     // contribution lifts the baseline mean.
-    assert.equal(baselineScore, 62.72);
+    // Plan 2026-05-12 debtSustainabilityGap addition: 62.72 → 63.29.
+    // fiscalSpace re-weighting (0.4/0.3/0.3 → 0.25/0.20/0.20/0.35) +
+    // new gap sub-score lifts US fiscalSpace, which is in the recovery
+    // domain feeding the baseline aggregate.
+    assert.equal(baselineScore, 63.29);
     // PR 3 §3.5: 65.84 → 67.85 (fuelStockDays retirement) → 67.21
     // (currencyExternal rebuilt on IMF inflation + WB reserves, coverage
     // shifts and US stress score moves).
@@ -292,7 +302,8 @@ describe('resilience scorer contracts', () => {
     // by ~+0.86 (imputed dims contribute less, population-normalized
     // event-counts boost socialCohesion + borderSecurity for high-pop
     // countries).
-    assert.equal(overallScore, 65.64);
+    // Plan 2026-05-12 debtSustainabilityGap addition: 65.64 → 66.02.
+    assert.equal(overallScore, 66.02);
   });
 
   it('baselineScore is computed from baseline + mixed dimensions only', async () => {
@@ -398,7 +409,10 @@ describe('resilience scorer contracts', () => {
     // a couple of WTO/BIS imputes); U6 per-capita normalization (incl.
     // typeWeight per the review fix) bumps social-cohesion + border-
     // security for the US (333M pop) since event-counts/M are tiny.
-    assert.equal(expected, 65.64, 'overallScore should match sum(domainScore * domainWeight); plan 002 §U4+§U6 64.78 → 65.64');
+    // Plan 2026-05-12 debtSustainabilityGap addition: 65.64 → 66.02.
+    // Recovery domain lifts by ~0.88 (48.75 → 49.63) which translates to
+    // overall +0.38 at the recovery domain weight.
+    assert.equal(expected, 66.02, 'overallScore should match sum(domainScore * domainWeight); plan 002 §U4+§U6 64.78 → 65.64 → plan 2026-05-12 → 66.02');
   });
 
   it('stressFactor is still computed (informational) and clamped to [0, 0.5]', () => {

--- a/tests/seed-recovery-fiscal-space.test.mts
+++ b/tests/seed-recovery-fiscal-space.test.mts
@@ -17,14 +17,20 @@ function byYear(...entries: Array<[string, number]>): Record<string, number> {
 
 describe('latestCommonYear', () => {
   it('returns the most recent year present in every map', () => {
+    // Derive years dynamically — weoYears() is a rolling window of
+    // [current, -1, -2], so hardcoded 2024/2023 would fall out of scope
+    // and break this test in 2027 (greptile P2: PR #3669).
+    const currentYear = new Date().getFullYear();
+    const Y  = String(currentYear);
+    const Y1 = String(currentYear - 1);
     const y = latestCommonYear([
-      byYear(['2024', 110], ['2023', 105]),
-      byYear(['2024', -2.5], ['2023', -2.0]),
-      byYear(['2024', -4.5]),
-      byYear(['2024', 0.7]),
-      byYear(['2024', 2.1]),
+      byYear([Y, 110], [Y1, 105]),
+      byYear([Y, -2.5], [Y1, -2.0]),
+      byYear([Y, -4.5]),
+      byYear([Y, 0.7]),
+      byYear([Y, 2.1]),
     ]);
-    assert.equal(y, 2024);
+    assert.equal(y, currentYear);
   });
 
   it('falls back to an older year if not every map has the most recent', () => {
@@ -42,18 +48,23 @@ describe('latestCommonYear', () => {
   });
 
   it('returns null when no common year exists in the scan window', () => {
-    // Two maps share no year inside the weoYears window (current, -1, -2).
+    // Two maps in scope but no shared year — derive years dynamically so
+    // the test exercises the "no overlap" branch in every future year.
+    const currentYear = new Date().getFullYear();
+    const Y  = String(currentYear);
+    const Y1 = String(currentYear - 1);
     const y = latestCommonYear([
-      byYear(['2024', 110]),
-      byYear(['2023', -2.5]),
+      byYear([Y, 110]),
+      byYear([Y1, -2.5]),
     ]);
-    // 2024 not in second map; 2023 not in first; common = null
+    // currentYear not in second map; currentYear-1 not in first; common = null
     assert.equal(y, null);
   });
 
   it('returns null on empty or malformed input', () => {
+    const Y = String(new Date().getFullYear());
     assert.equal(latestCommonYear([]), null);
-    assert.equal(latestCommonYear([byYear(['2024', NaN])]), null);
+    assert.equal(latestCommonYear([byYear([Y, NaN])]), null);
   });
 
   it('treats non-finite values as missing (so latestCommonYear skips NaN years)', () => {

--- a/tests/seed-recovery-fiscal-space.test.mts
+++ b/tests/seed-recovery-fiscal-space.test.mts
@@ -1,0 +1,275 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  buildFiscalSpaceCountries,
+  latestCommonYear,
+  validateFiscalSpace,
+  FISCAL_SPACE_VALIDATION_FLOORS,
+  INFLATION_GAP_CAP_PCT,
+} from '../scripts/seed-recovery-fiscal-space.mjs';
+
+// Per-year fixture helper. Mirrors the shape returned by
+// imfSdmxFetchIndicator: `{ [iso3]: { [year]: number } }`.
+function byYear(...entries: Array<[string, number]>): Record<string, number> {
+  return Object.fromEntries(entries);
+}
+
+describe('latestCommonYear', () => {
+  it('returns the most recent year present in every map', () => {
+    const y = latestCommonYear([
+      byYear(['2024', 110], ['2023', 105]),
+      byYear(['2024', -2.5], ['2023', -2.0]),
+      byYear(['2024', -4.5]),
+      byYear(['2024', 0.7]),
+      byYear(['2024', 2.1]),
+    ]);
+    assert.equal(y, 2024);
+  });
+
+  it('falls back to an older year if not every map has the most recent', () => {
+    const currentYear = new Date().getFullYear();
+    const prior = String(currentYear - 1);
+    const older = String(currentYear - 2);
+    const y = latestCommonYear([
+      byYear([prior, 110]),
+      byYear([older, -2.5], [prior, -2.5]),
+      byYear([prior, -4.5]),
+      byYear([prior, 0.7]),
+      byYear([prior, 2.1]),
+    ]);
+    assert.equal(y, Number(prior));
+  });
+
+  it('returns null when no common year exists in the scan window', () => {
+    // Two maps share no year inside the weoYears window (current, -1, -2).
+    const y = latestCommonYear([
+      byYear(['2024', 110]),
+      byYear(['2023', -2.5]),
+    ]);
+    // 2024 not in second map; 2023 not in first; common = null
+    assert.equal(y, null);
+  });
+
+  it('returns null on empty or malformed input', () => {
+    assert.equal(latestCommonYear([]), null);
+    assert.equal(latestCommonYear([byYear(['2024', NaN])]), null);
+  });
+
+  it('treats non-finite values as missing (so latestCommonYear skips NaN years)', () => {
+    const currentYear = String(new Date().getFullYear());
+    const y = latestCommonYear([
+      byYear([currentYear, 110]),
+      byYear([currentYear, NaN]),  // present-as-key but non-finite value
+    ]);
+    assert.equal(y, null);
+  });
+});
+
+describe('buildFiscalSpaceCountries (per-country payload)', () => {
+  // Use the current year so weoYears() matches inside the seeder helpers.
+  const Y = String(new Date().getFullYear());
+
+  function makeInputs(overrides: Partial<Record<
+    'revenue' | 'balance' | 'debt' | 'primaryBalance' | 'growth' | 'inflation',
+    Record<string, Record<string, number>>
+  >> = {}) {
+    return {
+      revenue:        overrides.revenue        ?? {},
+      balance:        overrides.balance        ?? {},
+      debt:           overrides.debt           ?? {},
+      primaryBalance: overrides.primaryBalance ?? {},
+      growth:         overrides.growth         ?? {},
+      inflation:      overrides.inflation      ?? {},
+    };
+  }
+
+  it('full data: all 4 score-relevant fields populated, gap matches plan example', () => {
+    // France-shape inputs (110/-2.5/-4.5/0.7/2.1, expected gap ≈ -1.43).
+    const result = buildFiscalSpaceCountries(makeInputs({
+      revenue:        { FRA: { [Y]: 51.4 } },
+      balance:        { FRA: { [Y]: -4.5 } },
+      debt:           { FRA: { [Y]: 110 } },
+      primaryBalance: { FRA: { [Y]: -2.5 } },
+      growth:         { FRA: { [Y]: 0.7 } },
+      inflation:      { FRA: { [Y]: 2.1 } },
+    }));
+    const fr = result.FR;
+    assert.ok(fr, 'France should be emitted');
+    assert.equal(fr.govRevenuePct, 51.4);
+    assert.equal(fr.fiscalBalancePct, -4.5);
+    assert.equal(fr.debtToGdpPct, 110);
+    assert.equal(fr.primaryBalancePct, -2.5);
+    assert.equal(fr.realGdpGrowthPct, 0.7);
+    assert.equal(fr.inflationPct, 2.1);
+    assert.equal(fr.gapYear, Number(Y));
+    assert.ok(fr.debtSustainabilityGapPct !== null);
+    assert.ok(Math.abs(fr.debtSustainabilityGapPct! - -1.43) < 0.01,
+      `France gap expected ≈ -1.43, got ${fr.debtSustainabilityGapPct}`);
+  });
+
+  it('one fiscal-3 field missing (no revenue): country emitted with rev=null, fiscal-3 partial', () => {
+    const result = buildFiscalSpaceCountries(makeInputs({
+      revenue:        {},                              // no revenue for FRA
+      balance:        { FRA: { [Y]: -4.5 } },
+      debt:           { FRA: { [Y]: 110 } },
+      primaryBalance: { FRA: { [Y]: -2.5 } },
+      growth:         { FRA: { [Y]: 0.7 } },
+      inflation:      { FRA: { [Y]: 2.1 } },
+    }));
+    const fr = result.FR;
+    assert.ok(fr, 'France should still be emitted (balance ∪ debt is non-empty)');
+    assert.equal(fr.govRevenuePct, null);
+    assert.equal(fr.fiscalBalancePct, -4.5);
+    assert.equal(fr.debtToGdpPct, 110);
+    // Gap still computable because revenue is NOT in the formula:
+    assert.ok(fr.debtSustainabilityGapPct !== null,
+      'gap should still compute when only revenue is missing');
+  });
+
+  it('missing growth: country emitted, gap=null, fiscal-3 intact', () => {
+    const result = buildFiscalSpaceCountries(makeInputs({
+      revenue:        { FRA: { [Y]: 51.4 } },
+      balance:        { FRA: { [Y]: -4.5 } },
+      debt:           { FRA: { [Y]: 110 } },
+      primaryBalance: { FRA: { [Y]: -2.5 } },
+      growth:         {},                              // no growth
+      inflation:      { FRA: { [Y]: 2.1 } },
+    }));
+    const fr = result.FR;
+    assert.ok(fr);
+    assert.equal(fr.govRevenuePct, 51.4);
+    assert.equal(fr.fiscalBalancePct, -4.5);
+    assert.equal(fr.debtToGdpPct, 110);
+    assert.equal(fr.debtSustainabilityGapPct, null);
+    assert.equal(fr.gapYear, null);
+  });
+
+  it('inflation > cap: country emitted, gap=null, fiscal-3 intact (Argentina case)', () => {
+    const result = buildFiscalSpaceCountries(makeInputs({
+      revenue:        { ARG: { [Y]: 18 } },
+      balance:        { ARG: { [Y]: -5 } },
+      debt:           { ARG: { [Y]: 90 } },
+      primaryBalance: { ARG: { [Y]: -2 } },
+      growth:         { ARG: { [Y]: -3 } },
+      inflation:      { ARG: { [Y]: 200 } },             // hyperinflation
+    }));
+    const ar = result.AR;
+    assert.ok(ar);
+    assert.equal(ar.debtToGdpPct, 90);
+    assert.equal(ar.fiscalBalancePct, -5);
+    assert.equal(ar.debtSustainabilityGapPct, null,
+      `inflation > ${INFLATION_GAP_CAP_PCT}% should drop gap to null`);
+  });
+
+  it('year mismatch across inputs: country emitted, gap=null, fiscal-3 keeps latest-per-series', () => {
+    const currentYear = new Date().getFullYear();
+    const Y_CUR = String(currentYear);
+    const Y_PRI = String(currentYear - 1);
+    const result = buildFiscalSpaceCountries(makeInputs({
+      revenue:        { FRA: { [Y_CUR]: 51.4 } },
+      balance:        { FRA: { [Y_CUR]: -4.5 } },
+      debt:           { FRA: { [Y_CUR]: 110 } },         // 2025 forecast
+      primaryBalance: { FRA: { [Y_PRI]: -2.5 } },       // 2024 actual
+      growth:         { FRA: { [Y_CUR]: 0.7 } },         // 2025
+      inflation:      { FRA: { [Y_CUR]: 2.1 } },         // 2025
+    }));
+    const fr = result.FR;
+    assert.ok(fr);
+    // Fiscal-3 latest values still populated (latest-per-series unchanged):
+    assert.equal(fr.debtToGdpPct, 110);
+    assert.equal(fr.fiscalBalancePct, -4.5);
+    // Gap is null because latestCommonYear cannot align all 5 inputs:
+    assert.equal(fr.debtSustainabilityGapPct, null);
+    assert.equal(fr.gapYear, null);
+  });
+
+  it('all fiscal-3 missing: country SKIPPED entirely (preserves existing skip guard)', () => {
+    // Country has growth + inflation + primary balance but NO revenue / balance / debt.
+    // The fiscal-series outage protection requires this country to be skipped, not
+    // emitted with null fiscal-3 fields (that was the R1-P0 data-quality risk).
+    const result = buildFiscalSpaceCountries(makeInputs({
+      revenue:        {},
+      balance:        {},
+      debt:           {},
+      primaryBalance: { JPN: { [Y]: 0 } },
+      growth:         { JPN: { [Y]: 0.5 } },
+      inflation:      { JPN: { [Y]: 2.0 } },
+    }));
+    assert.equal(Object.keys(result).length, 0,
+      'country with no fiscal-3 data must be skipped, not emitted with nulls');
+  });
+
+  it('aggregate codes are filtered out (e.g. WEOWORLD, EU)', () => {
+    const result = buildFiscalSpaceCountries(makeInputs({
+      revenue: { WEOWORLD: { [Y]: 40 }, EU: { [Y]: 45 }, FRA: { [Y]: 51.4 } },
+      balance: { FRA: { [Y]: -4.5 } },
+      debt:    { FRA: { [Y]: 110 } },
+    }));
+    assert.ok(result.FR, 'France should be emitted');
+    assert.ok(!('XX' in result), 'no aggregate code should leak through');
+    assert.equal(Object.keys(result).length, 1, 'only FR should be in the result');
+  });
+});
+
+describe('validateFiscalSpace (two-floor gating)', () => {
+  // Build a country payload meeting a target shape.
+  function payload(opts: { withFiscal3: number; withGap: number }): { countries: Record<string, unknown> } {
+    const countries: Record<string, unknown> = {};
+    let i = 0;
+    for (let n = 0; n < opts.withFiscal3; n++, i++) {
+      countries[`F${i}`] = {
+        govRevenuePct: 40, fiscalBalancePct: -2, debtToGdpPct: 60,
+        debtSustainabilityGapPct: n < opts.withGap ? -1.0 : null,
+      };
+    }
+    return { countries };
+  }
+
+  it('default floors {fiscal3: 150, gap: 100}: passes when both thresholds met', () => {
+    const data = payload({ withFiscal3: 160, withGap: 110 });
+    assert.equal(validateFiscalSpace(data), true);
+  });
+
+  it('default floors: fails when fiscal-3 coverage drops below 150', () => {
+    const data = payload({ withFiscal3: 149, withGap: 110 });
+    assert.equal(validateFiscalSpace(data), false);
+  });
+
+  it('default floors: fails when gap coverage drops below 100 (fiscal-3 alone is not enough)', () => {
+    const data = payload({ withFiscal3: 160, withGap: 99 });
+    assert.equal(validateFiscalSpace(data), false,
+      'gap coverage < 100 must reject the whole payload — last canonical blob keeps serving');
+  });
+
+  it('two-floor independence: both must pass, not just one', () => {
+    // Pass fiscal-3, fail gap → false
+    assert.equal(validateFiscalSpace(payload({ withFiscal3: 200, withGap: 50 })), false);
+    // Fail fiscal-3, pass gap → false (synthetic — same N for both in this fixture)
+    assert.equal(validateFiscalSpace(payload({ withFiscal3: 50, withGap: 50 })), false);
+  });
+
+  it('custom floors: passes a small fixture when floors are lowered to match', () => {
+    const data = payload({ withFiscal3: 5, withGap: 3 });
+    assert.equal(validateFiscalSpace(data, { fiscal3: 5, gap: 3 }), true);
+    assert.equal(validateFiscalSpace(data, { fiscal3: 6, gap: 3 }), false);
+    assert.equal(validateFiscalSpace(data, { fiscal3: 5, gap: 4 }), false);
+  });
+
+  it('production floors are pinned at {fiscal3: 150, gap: 100}', () => {
+    // Direct assertion on the named constant so future drift is caught
+    // without inspecting function source via .toString().
+    assert.deepEqual(FISCAL_SPACE_VALIDATION_FLOORS, { fiscal3: 150, gap: 100 });
+  });
+
+  it('inflation cap constant is pinned at 25', () => {
+    assert.equal(INFLATION_GAP_CAP_PCT, 25);
+  });
+
+  it('handles empty/malformed payloads safely', () => {
+    assert.equal(validateFiscalSpace(undefined), false);
+    assert.equal(validateFiscalSpace({}), false);
+    assert.equal(validateFiscalSpace({ countries: {} }), false);
+    assert.equal(validateFiscalSpace({ countries: null }), false);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a fourth `fiscalSpace` indicator — `debtSustainabilityGap` — capturing the IMF DSA construct `gap = pb − ((r−g)/(1+g))·d`. Positive = debt path declining, negative = rising.
- Computed at seed time (not score time) from 5 already-seeded IMF WEO series; scorer just normalizes the precomputed field.
- Rebalances `fiscalSpace` weights from `0.4/0.3/0.3` (3 indicators) to `0.25/0.20/0.20/0.35` (4 indicators). Gap becomes the largest single slice — the only indicator that integrates pb, r, g, d, and their interaction term.

## Why

The current `fiscalSpace` dimension blends revenue / fiscal balance / debt level. None of those — alone or blended — actually answers "is this country's debt path sustainable?" A country can have high debt + strong primary surplus + g≈r and be fine (Japan-ish), or low debt + chronic primary deficit + r>g and be in trouble. The composite penalizes the level and rewards the surplus, then averages, losing the r-g interaction term. The gap is the standard IMF DSA construct used by Article IV missions, ECB MIP scoreboard, and S&P sovereign methodology.

Plan #2 of the fiscal-resilience initiative. Plan #1 (orphan-fiscal-data UI surface) shipped in PR #3668; together they close the loop on "data we ingest but don't act on."

## Formula

```
g    = (1 + realGdpGrowth/100) × (1 + cpiInflation/100) − 1     compounded nominal growth
r    = max(0, (primaryBalance − fiscalBalance) / debtToGdp)     effective interest rate (DSA identity)
pb*  = ((r − g) / (1 + g)) × debtToGdp                          debt-stabilizing primary balance
gap  = primaryBalance − pb*                                      positive ⇒ debt declining
```

`r` is derived from the algebraic identity (overall balance = primary balance − interest expense), so `interest %GDP = primaryBalance − fiscalBalance`. Avoids needing per-country sovereign yields (FRED only covers US).

### Worked examples (end-to-end, verified in `tests/resilience-debt-sustainability-gap.test.mts`)

| Country 2024 | d | pb | fb | real g | infl | gap | normalized score |
|---|---|---|---|---|---|---|---|
| France | 110 | −2.5 | −4.5 | 0.7 | 2.1 | **−1.43** | 44.6 |
| Japan | 250 | 0 | −3 | 0.5 | 2.0 | **+3.20** | 100 (clamps) |
| Italy | 137 | +1.0 | −3.5 | 0.5 | 2.0 | **−0.04** | 62.0 |
| Norway | 38 | +10 | +8 | 1.0 | 2.5 | **+9.36** | 100 (clamps) |
| Argentina | 90 | −2 | −5 | −3.0 | 200 | inflation > 25% cap | excluded |

## Architecture

- **Seed-time computation**: the gap is computed inside `scripts/seed-recovery-fiscal-space.mjs` and stored as `debtSustainabilityGapPct` per country in the canonical Redis blob (`resilience:recovery:fiscal-space:v1`). Scorer reads the precomputed field — matches every other resilience scorer's single-blob pattern.
- **Pure exported helpers**: `latestCommonYear`, `computeDebtSustainabilityGap`, `buildFiscalSpaceCountries`, `validateFiscalSpace` are exported so tests skip ESM mocking. `FISCAL_SPACE_VALIDATION_FLOORS` and `INFLATION_GAP_CAP_PCT` exported as named constants.
- **Year alignment**: gap inputs read at `latestCommonYear` across the 5 formula series only (revenue NOT in alignment check — it's not in the formula). Year-mismatched countries → `gap=null`; fiscal-3 still scores them.
- **Country inclusion**: stays anchored to fiscal-3 union (revenue ∪ balance ∪ debt). Existing skip guard preserved verbatim — an IMF fiscal-series outage cannot emit phantom countries with null fiscal-3.
- **Two-floor validate**: payload rejected if `<150` countries have fiscal-3 OR `<100` countries have gap inputs. Either floor failing → previous canonical blob keeps serving (`_seed-utils.mjs:1010-1017` strict-floor behavior).
- **Tier classification**: `enrichment` (not Core), because the inflation cap excludes ~5-10 hyperinflation countries by design — structurally cannot meet the Core ≥180 coverage invariant. Scorer doesn't differentiate by tier; this is a quality classification only.

## Policy decisions (locked 2026-05-12)

1. Goalposts: `worst=-5 / best=+3` (DSA distress envelope)
2. Inflation cap: 25% (excludes Argentina/Lebanon/Venezuela from gap; fiscal-3 still scores them)
3. Weights: 0.25/0.20/0.20/0.35 (gap as largest single slice)
4. Backtest acceptance: ≤10 countries shifting >±5 ranks in economy pillar

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx biome lint` clean on touched files (8 modified + 3 new)
- [x] **750/750 resilience tests pass** (full suite)
  - 12 formula unit tests (worked examples + edge cases)
  - 20 seeder contract tests (helpers + 6-country fixture + two-floor validate)
  - 7 scorer integration tests (5-country scenarios + null redistribution)
  - 89 dimension-scorer baseline tests (existing parity)
  - 36 indicator-registry + doc-parity tests
- [x] Production seeder ran end-to-end: 191 records, both floor checks passed
- [x] Backtest comparison: Spearman 0.9731, max country drift 9.63pt, cohort median 3.17pt (all within thresholds)
- [x] Baseline updates documented in `tests/resilience-scorers.test.mts` with plan-002 → plan-2026-05-12 trace

## Backtest verdict (acceptance criteria)

| Gate | Status | Result | Threshold |
|---|---|---|---|
| Spearman rank correlation | ✅ PASS | 0.9731 | floor 0.85 |
| Max country drift | ✅ PASS | 9.63pt | ceiling 15 |
| Cohort median shift | ✅ PASS | worst 3.17pt | ceiling 10 |
| Universe integrity | ✅ PASS | 93 endpoints | — |
| Core indicator measurability | ✅ PASS | 47/51 | floor 80% |
| Matched-pair gaps | ⚠️ PRE-EXISTING | 2 failures | — |

**Plan's stated acceptance criterion ("≤10 countries shifting >±5 ranks") is satisfied.**

### Known concern — matched-pair gate (pre-existing, not introduced by this PR)

Two matched pairs were ALREADY failing on `main` before this PR:
- `fr-vs-de`: currentGap=−5.19 (failing) → proposedGap=−6.70 (amplified by 3.79pt)
- `sg-vs-ch`: currentGap=−13.31 (failing) → proposedGap=−16.51 (amplified by 3.20pt)

My change amplifies the pre-existing miss but does not introduce a new directional failure. The amplification is structurally explainable: France's high-debt + mild-deficit profile takes a small additional gap-indicator penalty. Recommend treating as separate tech-debt follow-up — the matched-pair calibration predates this PR.

## Post-Deploy Monitoring & Validation

### Pre-merge (done)
- All tests pass (750/750)
- Local seeder dry-run successful (191 records)
- Formula worked examples pinned in unit tests ±0.01 tolerance

### Post-merge / post-deploy
- Wait **1-2 seeder cron ticks** (the cron interval is monthly per `seed-bundle-resilience-recovery.mjs:5`, so the honest verification window is 30-60 days after merge — first tick may hiccup, second is the backstop). Direct Redis GET on `resilience:recovery:fiscal-space:v1` and assert ≥100 countries have `debtSustainabilityGapPct: number`. Spot-check France/Japan/Norway against worked examples ±0.5 (tolerance accommodates IMF data refresh).
- Run `scripts/compare-resilience-current-vs-proposed.mjs` against pre/post Redis snapshots to confirm the expected directional shifts (Italy/Greece drop, Japan rises, Norway/Singapore rise, Argentina/Lebanon/Venezuela excluded from gap signal but fiscal-3 unchanged).
- `/api/health` shows seeder freshness — useful, but not field-level coverage. Don't rely on health for field verification.

### Rollback
- Revert the PR. Seeder `schemaVersion` drops back to 1 on next tick. Old scorer reads the new blob fine — extra fields are ignored, the 3 fiscal-3 indicators score returns. Zero data loss; a few hours of degraded scoring between revert and next seeder tick.

## Plan provenance

`plans/add-debt-sustainability-gap-indicator.md` — approved by Codex after 4 rounds of review on 2026-05-12. Implementation review by Codex on the actual diff also completed before merge. Plan-doc is included in this PR for design-rationale provenance.
