### PR TITLE
fix(sentry): ignore "crusoe is not defined" userscript noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -202,6 +202,7 @@ Sentry.init({
     /^NetworkError: Load failed$/,
     /^A network error occurred\.?$/,
     /nmhCrx is not defined/,
+    /\bcrusoe is not defined\b/, // WORLDMONITOR-R3 — injected userscript reference, anonymous-frames-only stack
     /navigationPerformanceLoggerJavascriptInterface/,
     /jQuery is not defined/,
     /illegal UTF-16 sequence/,


### PR DESCRIPTION
## Summary

WORLDMONITOR-R3: \`ReferenceError: crusoe is not defined\` — 2 events
from 1 user, Chrome 142 on Linux, stack is pure \`<anonymous>:1\`
(col 59 and 81, classic eval-injection shape). The identifier
\`crusoe\` appears nowhere in this codebase; it's a named global
referenced by an injected userscript on the user's browser.

Same pattern as the existing \`DarkReader\` / \`frappe\` / \`ucConfig\`
/ \`userScripts is not defined\` / \`nmhCrx is not defined\` entries
already in \`ignoreErrors\` — extension/userscript-injected globals
that can never come from our own bundle.

\`\\b\` anchors guard against accidental substring matches in
hypothetical future messages.

## Test plan

- [x] \`npm run typecheck\` — PASS
- [x] \`npm run typecheck:api\` — PASS (incl. \`audit-convex-string-calls\`)
- [x] \`npm run lint\` — PASS (warnings only, pre-existing)
- [x] \`npm run test:data\` — PASS (8620/8620)
- [x] \`node --test tests/edge-functions.test.mjs\` — PASS
- [x] \`npm run lint:md\` — PASS
- [x] \`npm run version:check\` — PASS
- [x] Edge bundle check — PASS
- [ ] Verify R3 doesn't reopen post-deploy