### PR TITLE
fix(brief): severity/topic-cluster ordering + Video:/Reuters headline cleanup

### DIFF
--- a/scripts/lib/brief-compose.mjs
+++ b/scripts/lib/brief-compose.mjs
@@ -362,6 +362,7 @@ function digestStoryToUpstreamTopStory(s) {
     primarySource,
     primaryLink: typeof s?.link === 'string' ? s.link : undefined,
     threatLevel: s?.severity,
+    importanceScore: Number.isFinite(Number(s?.currentScore)) ? Number(s.currentScore) : undefined,
     // story:track:v1 carries neither field, so the brief falls back
     // to 'General' / 'Global' via filterTopStories defaults.
     category: typeof s?.category === 'string' ? s.category : undefined,
@@ -391,6 +392,14 @@ function digestStoryToUpstreamTopStory(s) {
       && typeof s.mergedHashes[0] === 'string' && s.mergedHashes[0].length > 0
       ? s.mergedHashes[0]
       : (typeof s?.hash === 'string' && s.hash.length > 0 ? s.hash : undefined),
+    // Transient topic-ordering metadata from groupTopicsPostDedup.
+    // filterTopStories consumes these before writing BriefStory; they
+    // are not part of the persisted envelope schema.
+    briefTopicId: typeof s?.briefTopicId === 'string' && s.briefTopicId.length > 0
+      ? s.briefTopicId
+      : undefined,
+    briefTopicSize: Number.isFinite(Number(s?.briefTopicSize)) ? Number(s.briefTopicSize) : undefined,
+    briefTopicMaxScore: Number.isFinite(Number(s?.briefTopicMaxScore)) ? Number(s.briefTopicMaxScore) : undefined,
   };
 }
 
@@ -429,8 +438,9 @@ function digestStoryToUpstreamTopStory(s) {
  *   how they are reported.
  *   `synthesis` (when provided) substitutes envelope.digest.lead /
  *   threads / signals / publicLead with the canonical synthesis from
- *   the orchestration layer, and re-orders the candidate pool by
- *   `synthesis.rankedStoryHashes` before applying the cap.
+ *   the orchestration layer. `synthesis.rankedStoryHashes` is passed to
+ *   the filter as a tie-breaker after severity/topic-cluster ordering,
+ *   before applying the cap.
  */
 export function composeBriefFromDigestStories(rule, digestStories, insightsNumbers, { nowMs = Date.now(), onDrop, synthesis } = {}) {
   if (!Array.isArray(digestStories) || digestStories.length === 0) return null;

--- a/scripts/lib/brief-compose.mjs
+++ b/scripts/lib/brief-compose.mjs
@@ -370,9 +370,9 @@ function digestStoryToUpstreamTopStory(s) {
     // Stable digest story hash. Carried through so:
     //   (a) the canonical synthesis prompt can emit `rankedStoryHashes`
     //       referencing each story by hash (not position, not title),
-    //   (b) `filterTopStories` can re-order the pool by ranking BEFORE
-    //       applying the MAX_STORIES_PER_USER cap, so the model's
-    //       editorial judgment of importance survives the cap.
+    //   (b) `filterTopStories` can use the model's order as the final
+    //       tie-breaker after deterministic severity/topic-block mass
+    //       and score, before applying the MAX_STORIES_PER_USER cap.
     // Falls back to titleHash when the digest path didn't materialise
     // a primary `hash` (rare; shape varies across producer versions).
     hash: typeof s?.hash === 'string' && s.hash.length > 0

--- a/scripts/lib/brief-compose.mjs
+++ b/scripts/lib/brief-compose.mjs
@@ -284,11 +284,15 @@ export function stripHeadlineSuffix(title, publisher) {
   const m = trimmed.match(HEADLINE_SUFFIX_RE_PART);
   if (!m) return trimmed;
   const tail = m[1].trim();
-  // Case-insensitive equality OR word-boundary prefix in either
-  // direction. The prefix relaxation handles wire-name vs feed-name
-  // mismatch (Reuters / Reuters World, AP / AP News). A tail that
-  // merely CONTAINS the publisher (e.g. "- AP News analysis") still
-  // stays — that's editorial content, not a wire suffix.
+  // Case-insensitive equality OR ASYMMETRIC word-boundary prefix: tail
+  // must be a SHORTER prefix of publisher (Reuters → Reuters World),
+  // never the reverse. The asymmetry is intentional and load-bearing —
+  // it blocks editorial suffixes like "AP News analysis" (tail) from
+  // stripping when publisher is "AP News" (Greptile PR #3673 review).
+  // A tail that merely CONTAINS the publisher (e.g. "- AP News
+  // analysis") still stays — that's editorial content, not a wire
+  // suffix. Full asymmetry rationale documented on
+  // `isPublisherWordPrefix` itself.
   if (!isPublisherWordPrefix(tail.toLowerCase(), publisher.toLowerCase())) return trimmed;
   return trimmed.slice(0, m.index).trimEnd();
 }

--- a/scripts/lib/brief-compose.mjs
+++ b/scripts/lib/brief-compose.mjs
@@ -242,6 +242,37 @@ export function composeBriefForRule(rule, insights, { nowMs = Date.now() } = {})
 const HEADLINE_SUFFIX_RE_PART = /\s+[-\u2013\u2014|]\s+([^\s].*)$/;
 
 /**
+ * Wire-name vs feed-name match. Returns true when `tail` is a shorter
+ * (or equal) word-boundary prefix of `publisher` — i.e. when the
+ * headline ended with the wire-service short name (e.g. "Reuters")
+ * but the configured publisher is the longer feed-name expansion
+ * (e.g. "Reuters World" / "Reuters Politics"). Strict equality
+ * (the v1 implementation) missed this case — observed live on the
+ * May 13 brief: "Putin says Russia will deploy new Sarmat nuclear
+ * missile this year - Reuters" had publisher "Reuters World" and the
+ * strict-equality check passed the suffix to the magazine.
+ *
+ * The direction is asymmetric ON PURPOSE: we never accept the inverse
+ * (publisher word-prefix of tail), because that case admits editorial
+ * suffixes like "Story - AP News analysis" — the tail "AP News
+ * analysis" extends the publisher "AP News" with an editorial word,
+ * not a desk-name suffix, and stripping it would lose real content.
+ *
+ * Word-boundary requirement (trailing space) prevents "iran" matching
+ * "iranian" — only space-delimited extensions ("Reuters" / "Reuters
+ * World") succeed.
+ *
+ * @param {string} tail — already lowercased, trimmed
+ * @param {string} publisher — already lowercased, trimmed
+ * @returns {boolean}
+ */
+function isPublisherWordPrefix(tail, publisher) {
+  if (tail === publisher) return true;
+  if (tail.length >= publisher.length) return false;
+  return publisher.startsWith(tail + ' ');
+}
+
+/**
  * @param {string} title
  * @param {string} publisher
  * @returns {string}
@@ -253,11 +284,35 @@ export function stripHeadlineSuffix(title, publisher) {
   const m = trimmed.match(HEADLINE_SUFFIX_RE_PART);
   if (!m) return trimmed;
   const tail = m[1].trim();
-  // Case-insensitive full-string match. We're conservative: only strip
-  // when the tail EQUALS the publisher — a tail that merely contains
-  // it (e.g. "- AP News analysis") is editorial content and stays.
-  if (tail.toLowerCase() !== publisher.toLowerCase()) return trimmed;
+  // Case-insensitive equality OR word-boundary prefix in either
+  // direction. The prefix relaxation handles wire-name vs feed-name
+  // mismatch (Reuters / Reuters World, AP / AP News). A tail that
+  // merely CONTAINS the publisher (e.g. "- AP News analysis") still
+  // stays — that's editorial content, not a wire suffix.
+  if (!isPublisherWordPrefix(tail.toLowerCase(), publisher.toLowerCase())) return trimmed;
   return trimmed.slice(0, m.index).trimEnd();
+}
+
+// Editorial-format prefixes some feeds prepend to headlines. They tell
+// the user nothing the magazine card doesn't already convey (every
+// card has its own source line and body block), so they just dilute
+// the headline. Conservative list — only patterns observed in
+// production briefs (May 12 magazine page 16/18: "Video: Philippine
+// senator flees ICC arrest..."). The trailing colon is REQUIRED so a
+// real headline starting with the bare word "Video game regulator
+// fines..." stays intact.
+const HEADLINE_PREFIX_RE = /^(?:video|watch|live|photos?|gallery|listen|podcast|breaking|exclusive|opinion|analysis|update)\s*:\s*/i;
+
+/**
+ * Strip editorial-format prefixes like "Video: ", "Watch: ", "Live: ",
+ * "Photos: ", "Breaking: " from the start of a headline.
+ *
+ * @param {string} title
+ * @returns {string}
+ */
+export function stripHeadlinePrefix(title) {
+  if (typeof title !== 'string' || title.length === 0) return '';
+  return title.trim().replace(HEADLINE_PREFIX_RE, '').trimStart();
 }
 
 /**
@@ -286,7 +341,12 @@ function digestStoryToUpstreamTopStory(s) {
   const sources = Array.isArray(s?.sources) ? s.sources : [];
   const primarySource = sources.length > 0 ? sources[0] : 'Multiple wires';
   const rawTitle = typeof s?.title === 'string' ? s.title : '';
-  const cleanTitle = stripHeadlineSuffix(rawTitle, primarySource);
+  // Two-stage cleanup: strip editorial-format prefix first ("Video:",
+  // "Watch:", "Breaking:") then publisher suffix (" - Reuters",
+  // "| AP News"). Order matters because some headlines have both:
+  // "Video: Philippine senator flees ICC arrest - Al Jazeera" should
+  // become "Philippine senator flees ICC arrest".
+  const cleanTitle = stripHeadlineSuffix(stripHeadlinePrefix(rawTitle), primarySource);
   const rawDescription = typeof s?.description === 'string' ? s.description.trim() : '';
   return {
     primaryTitle: cleanTitle,

--- a/scripts/lib/brief-dedup.mjs
+++ b/scripts/lib/brief-dedup.mjs
@@ -409,10 +409,19 @@ export function groupTopicsPostDedup(top, cfg, embeddingByHash, deps = {}) {
     });
 
     // Concatenate: for each topic in topicOrder, emit its members in
-    // their intra-topic order.
+    // their intra-topic order. Attach transient topic metadata to the
+    // rep object so the brief composer can preserve topic blocks after
+    // severity bucketing and LLM rank tie-breaking. These fields never
+    // enter the persisted BriefStory envelope.
     const order = [];
     for (const t of topicOrder) {
-      for (const i of membersOf[t]) order.push(i);
+      const topicId = topicTieHash[t] ?? String(t);
+      for (const i of membersOf[t]) {
+        top[i].briefTopicId = topicId;
+        top[i].briefTopicSize = topicSize[t];
+        top[i].briefTopicMaxScore = topicMax[t];
+        order.push(i);
+      }
     }
 
     return {

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -1566,8 +1566,9 @@ async function composeAndStoreBriefForUser(userId, annotated, insightsNumbers, d
   }
 
   // Compose envelope with synthesis pre-baked. The composer applies
-  // rankedStoryHashes-aware ordering BEFORE the cap, so the model's
-  // editorial judgment of importance survives MAX_STORIES_PER_USER.
+  // severity/topic-cluster ordering BEFORE the cap, with
+  // rankedStoryHashes only as a tie-breaker inside similarly severe
+  // blocks, so critical clusters survive MAX_STORIES_PER_USER.
   const dropStats = {
     severity: 0,
     headline: 0,

--- a/shared/brief-filter.d.ts
+++ b/shared/brief-filter.d.ts
@@ -66,18 +66,20 @@ export type DropMetricsFn = (event: {
  * can use it to aggregate per-user drop counters without altering
  * filter behaviour.
  *
- * When `rankedStoryHashes` is provided, stories are re-ordered BEFORE
- * the cap is applied: stories whose `hash` matches a ranking entry
- * (by short-hash prefix, ≥4 chars) come first in ranking order;
- * stories not in the ranking come after in their original relative
- * order. Lets the canonical synthesis brain's editorial judgment of
- * importance survive the `maxStories` cut.
+ * Stories are re-ordered BEFORE the cap using deterministic editorial
+ * signals first: topic block's highest eligible severity, count at that
+ * severity, eligible block size, and score. `rankedStoryHashes` remains
+ * a tie-breaker inside similarly severe/sized blocks, matched by
+ * short-hash prefix (≥4 chars). This keeps critical topic clusters
+ * contiguous instead of letting model ranking pull unrelated singletons
+ * above them.
  *
  * `maxPerSourceTopic` (U5, default 2) caps how many stories sharing
  * the same `(source, category)` pair can survive into a single brief.
- * Pass `Infinity` to disable. The cap runs AFTER `applyRankedOrder`
- * so the highest-ranked sibling of any pair survives. Stories beyond
- * the cap are dropped with `onDrop({ reason: 'source_topic_cap' })`.
+ * Pass `Infinity` to disable. The cap runs AFTER deterministic
+ * severity/topic ordering so the strongest sibling of any pair
+ * survives. Stories beyond the cap are dropped with
+ * `onDrop({ reason: 'source_topic_cap' })`.
  */
 export function filterTopStories(input: {
   stories: UpstreamTopStory[];
@@ -140,6 +142,7 @@ export interface UpstreamTopStory {
   category?: unknown;
   countryCode?: unknown;
   importanceScore?: unknown;
+  currentScore?: unknown;
   /**
    * Stable digest-story hash carried through from the cron's pool
    * (digestStoryToUpstreamTopStory at scripts/lib/brief-compose.mjs).
@@ -148,4 +151,20 @@ export interface UpstreamTopStory {
    * the upstream digest path didn't materialise a primary `hash`.
    */
   hash?: unknown;
+  /**
+   * Canonical dedup cluster rep hash, when available. Used as a
+   * fallback transient grouping key before envelope assembly; not
+   * written to BriefStory.
+   */
+  clusterRepHash?: unknown;
+  /**
+   * Transient topic metadata from groupTopicsPostDedup. Used only for
+   * final ordering before the maxStories cap; these fields are stripped
+   * before BriefStory is written into the envelope.
+   */
+  briefTopicId?: unknown;
+  briefTopicSize?: unknown;
+  briefTopicMaxScore?: unknown;
+  topicGroupId?: unknown;
+  topicId?: unknown;
 }

--- a/shared/brief-filter.d.ts
+++ b/shared/brief-filter.d.ts
@@ -28,9 +28,11 @@ export type AlertSensitivity = 'all' | 'high' | 'critical';
  * failed the sensitivity gate, or when a later gate (headline/url)
  * dropped a story that had already passed the severity check.
  *
- * `cap` fires once per story skipped after `maxStories` has been
- * reached — neither severity nor field metadata is included since
- * the loop short-circuits without parsing the remaining stories.
+ * `cap` fires once per otherwise-renderable story skipped after
+ * `maxStories` has been reached. Invalid/excluded tail items keep
+ * their root-cause reason (`severity`, `headline`, `url`, etc.) so
+ * operator telemetry reconciles without hiding data-quality failures
+ * behind truncation.
  *
  * `source_topic_cap` (U5) fires when a story is dropped because the
  * `(source, category)` pair already has `maxPerSourceTopic` survivors
@@ -68,11 +70,13 @@ export type DropMetricsFn = (event: {
  *
  * Stories are re-ordered BEFORE the cap using deterministic editorial
  * signals first: topic block's highest eligible severity, count at that
- * severity, eligible block size, and score. `rankedStoryHashes` remains
- * a tie-breaker inside similarly severe/sized blocks, matched by
- * short-hash prefix (≥4 chars). This keeps critical topic clusters
- * contiguous instead of letting model ranking pull unrelated singletons
- * above them.
+ * severity, eligible block size, and score. This intentionally favors
+ * concentrated top severity before breadth: a block with two critical
+ * stories sorts ahead of a block with one critical plus many high
+ * stories. `rankedStoryHashes` remains a tie-breaker inside similarly
+ * severe/sized blocks, matched by short-hash prefix (≥4 chars). This
+ * keeps critical topic clusters contiguous instead of letting model
+ * ranking pull unrelated singletons above them.
  *
  * `maxPerSourceTopic` (U5, default 2) caps how many stories sharing
  * the same `(source, category)` pair can survive into a single brief.
@@ -141,7 +145,15 @@ export interface UpstreamTopStory {
   threatLevel?: unknown;
   category?: unknown;
   countryCode?: unknown;
+  /**
+   * Canonical score used by final topic-block ordering. Digest-backed
+   * compose paths write this from story:track:v1.currentScore.
+   */
   importanceScore?: unknown;
+  /**
+   * Legacy upstream score alias retained for callers that still feed
+   * raw news:insights:v1 rows directly into filterTopStories.
+   */
   currentScore?: unknown;
   /**
    * Stable digest-story hash carried through from the cron's pool
@@ -154,7 +166,8 @@ export interface UpstreamTopStory {
   /**
    * Canonical dedup cluster rep hash, when available. Used as a
    * fallback transient grouping key before envelope assembly; not
-   * written to BriefStory.
+   * written to BriefStory. Rows without briefTopicId or clusterRepHash
+   * degrade to per-row singleton blocks rather than risk false grouping.
    */
   clusterRepHash?: unknown;
   /**
@@ -165,6 +178,4 @@ export interface UpstreamTopStory {
   briefTopicId?: unknown;
   briefTopicSize?: unknown;
   briefTopicMaxScore?: unknown;
-  topicGroupId?: unknown;
-  topicId?: unknown;
 }

--- a/shared/brief-filter.js
+++ b/shared/brief-filter.js
@@ -155,15 +155,15 @@ function rankForStory(story, rankedStoryHashes) {
  * @returns {string}
  */
 function topicKeyForStory(story, originalIndex) {
-  const explicit =
-    nonEmptyString(story?.briefTopicId) ??
-    nonEmptyString(story?.topicGroupId) ??
-    nonEmptyString(story?.topicId);
+  const explicit = nonEmptyString(story?.briefTopicId);
   if (explicit) return `topic:${explicit}`;
-  const numericTopic = story?.briefTopicId ?? story?.topicGroupId ?? story?.topicId;
+  const numericTopic = story?.briefTopicId;
   if (typeof numericTopic === 'number' && Number.isFinite(numericTopic)) return `topic:${numericTopic}`;
   const repHash = nonEmptyString(story?.clusterRepHash);
   if (repHash) return `cluster:${repHash}`;
+  // Legacy/raw rows without topic or cluster metadata deliberately
+  // atomise into singleton blocks. That loses adjacency, but avoids
+  // false-grouping unrelated stories under a guessed key.
   return `story:${originalIndex}`;
 }
 
@@ -182,6 +182,11 @@ function topicKeyForStory(story, originalIndex) {
  *
  * This keeps critical clusters together while still letting the model
  * choose between similarly severe/sized candidates.
+ *
+ * Editorial trade-off: concentrated top severity beats broad nearby
+ * context. A block with two critical stories sorts ahead of a block
+ * with one critical plus many high stories; once that count ties,
+ * broader eligible block size decides the next tie.
  *
  * @param {Array<Record<string, unknown>>} stories
  * @param {Set<BriefThreatLevel>} allowed
@@ -216,8 +221,12 @@ function orderBriefCandidates(stories, allowed, rankedStoryHashes) {
         bestSeverityRank: Infinity,
         bestSeverityCount: 0,
         eligibleCount: 0,
+        // Sentinel for all-ineligible blocks. The comparator's !==
+        // guard prevents `-Infinity - -Infinity` from producing NaN.
         maxScore: -Infinity,
-        bestRank: Infinity,
+        // Best (lowest) LLM rank seen across any eligible member in
+        // this block, not the rank of the highest-scoring member.
+        bestLlmRank: Infinity,
       };
       blocks.set(item.topicKey, block);
     }
@@ -226,7 +235,7 @@ function orderBriefCandidates(stories, allowed, rankedStoryHashes) {
     if (item.eligible) {
       block.eligibleCount += 1;
       block.maxScore = Math.max(block.maxScore, item.score);
-      block.bestRank = Math.min(block.bestRank, item.rank);
+      block.bestLlmRank = Math.min(block.bestLlmRank, item.rank);
       if (item.severityRank < block.bestSeverityRank) {
         block.bestSeverityRank = item.severityRank;
         block.bestSeverityCount = 1;
@@ -241,7 +250,7 @@ function orderBriefCandidates(stories, allowed, rankedStoryHashes) {
     if (a.bestSeverityCount !== b.bestSeverityCount) return b.bestSeverityCount - a.bestSeverityCount;
     if (a.eligibleCount !== b.eligibleCount) return b.eligibleCount - a.eligibleCount;
     if (a.maxScore !== b.maxScore) return b.maxScore - a.maxScore;
-    if (a.bestRank !== b.bestRank) return a.bestRank - b.bestRank;
+    if (a.bestLlmRank !== b.bestLlmRank) return a.bestLlmRank - b.bestLlmRank;
     return a.firstIndex - b.firstIndex;
   });
 

--- a/shared/brief-filter.js
+++ b/shared/brief-filter.js
@@ -57,6 +57,24 @@ const MAX_DESCRIPTION_LEN = 400;
 const MAX_SOURCE_LEN = 120;
 const MAX_SOURCE_URL_LEN = 2000;
 
+const SEVERITY_RANK = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+/** @param {unknown} v */
+function finiteNumberOrZero(v) {
+  const n = typeof v === 'number' ? v : Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** @param {unknown} v */
+function nonEmptyString(v) {
+  return typeof v === 'string' && v.trim().length > 0 ? v.trim() : null;
+}
+
 /**
  * Validate + normalise the upstream story link into an outgoing
  * https/http URL. Returns the normalised URL on success, null when the
@@ -99,53 +117,146 @@ function clip(v, cap) {
  */
 
 /**
- * Re-order `stories` so entries whose `hash` matches an entry in
- * `rankedStoryHashes` come first, in ranking order. Entries not in
- * the ranking keep their original relative order and come after.
- * Match is by short-hash prefix: a ranking entry of "abc12345"
- * matches a story whose `hash` starts with "abc12345" (≥4 chars).
- * The canonical synthesis prompt emits 8-char prefixes; stories
- * carry the full hash. Defensive check: when ranking is missing /
- * empty / not an array, returns the original array unchanged.
+ * Return the LLM rank slot for a story, or Infinity when unranked.
+ * Match is by short-hash prefix: a ranking entry of "abc12345" matches
+ * a story whose `hash` starts with "abc12345" (≥4 chars). The canonical
+ * synthesis prompt emits 8-char prefixes; stories carry the full hash.
  *
- * Pure helper — does not mutate the input. Stable for stories that
- * share rank slots (preserves original order within a slot).
- *
- * @param {Array<{ hash?: unknown }>} stories
+ * @param {{ hash?: unknown }} story
  * @param {unknown} rankedStoryHashes
- * @returns {Array<{ hash?: unknown }>}
+ * @returns {number}
  */
-function applyRankedOrder(stories, rankedStoryHashes) {
+function rankForStory(story, rankedStoryHashes) {
   if (!Array.isArray(rankedStoryHashes) || rankedStoryHashes.length === 0) {
-    return stories;
+    return Infinity;
   }
   const ranking = rankedStoryHashes
     .filter((x) => typeof x === 'string' && x.length >= 4)
     .map((x) => x);
-  if (ranking.length === 0) return stories;
+  if (ranking.length === 0) return Infinity;
 
-  // For each story, compute its rank index — the smallest index of a
-  // ranking entry that is a PREFIX of the story's hash. Stories with
-  // no match get Infinity so they sort last while preserving their
-  // original order via the secondary index.
+  const storyHash = typeof story?.hash === 'string' ? story.hash : '';
+  if (storyHash.length === 0) return Infinity;
+  for (let i = 0; i < ranking.length; i++) {
+    if (storyHash.startsWith(ranking[i])) {
+      return i;
+    }
+  }
+  return Infinity;
+}
+
+/**
+ * Topic identity is transient composer metadata. It is deliberately
+ * NOT written into BriefStory because the envelope contract stays
+ * story-focused; ordering is the only consumer.
+ *
+ * @param {Record<string, unknown>} story
+ * @param {number} originalIndex
+ * @returns {string}
+ */
+function topicKeyForStory(story, originalIndex) {
+  const explicit =
+    nonEmptyString(story?.briefTopicId) ??
+    nonEmptyString(story?.topicGroupId) ??
+    nonEmptyString(story?.topicId);
+  if (explicit) return `topic:${explicit}`;
+  const numericTopic = story?.briefTopicId ?? story?.topicGroupId ?? story?.topicId;
+  if (typeof numericTopic === 'number' && Number.isFinite(numericTopic)) return `topic:${numericTopic}`;
+  const repHash = nonEmptyString(story?.clusterRepHash);
+  if (repHash) return `cluster:${repHash}`;
+  return `story:${originalIndex}`;
+}
+
+/**
+ * Final editorial ordering for the rendered brief.
+ *
+ * The build stage already tries to create topic-contiguous blocks, but
+ * the LLM ranking used to run as a dominant global sort and could pull a
+ * lower-severity singleton above a heavier critical cluster. Here the
+ * deterministic signals lead:
+ *   1. topic block's highest eligible severity;
+ *   2. count of stories at that highest severity;
+ *   3. eligible block size;
+ *   4. max score in the block;
+ *   5. LLM rank as a tie-breaker only.
+ *
+ * This keeps critical clusters together while still letting the model
+ * choose between similarly severe/sized candidates.
+ *
+ * @param {Array<Record<string, unknown>>} stories
+ * @param {Set<BriefThreatLevel>} allowed
+ * @param {unknown} rankedStoryHashes
+ * @returns {Array<Record<string, unknown>>}
+ */
+function orderBriefCandidates(stories, allowed, rankedStoryHashes) {
   const annotated = stories.map((story, originalIndex) => {
-    const storyHash = typeof story?.hash === 'string' ? story.hash : '';
-    let rank = Infinity;
-    if (storyHash.length > 0) {
-      for (let i = 0; i < ranking.length; i++) {
-        if (storyHash.startsWith(ranking[i])) {
-          rank = i;
-          break;
-        }
+    const threatLevel = normaliseThreatLevel(story?.threatLevel);
+    const severityRank = threatLevel ? (SEVERITY_RANK[threatLevel] ?? Infinity) : Infinity;
+    return {
+      story,
+      originalIndex,
+      topicKey: topicKeyForStory(story, originalIndex),
+      threatLevel,
+      severityRank,
+      eligible: Boolean(threatLevel && allowed.has(threatLevel)),
+      rank: rankForStory(story, rankedStoryHashes),
+      score: finiteNumberOrZero(story?.importanceScore ?? story?.currentScore),
+    };
+  });
+
+  /** @type {Map<string, any>} */
+  const blocks = new Map();
+  for (const item of annotated) {
+    let block = blocks.get(item.topicKey);
+    if (!block) {
+      block = {
+        key: item.topicKey,
+        items: [],
+        firstIndex: item.originalIndex,
+        bestSeverityRank: Infinity,
+        bestSeverityCount: 0,
+        eligibleCount: 0,
+        maxScore: -Infinity,
+        bestRank: Infinity,
+      };
+      blocks.set(item.topicKey, block);
+    }
+    block.items.push(item);
+    block.firstIndex = Math.min(block.firstIndex, item.originalIndex);
+    if (item.eligible) {
+      block.eligibleCount += 1;
+      block.maxScore = Math.max(block.maxScore, item.score);
+      block.bestRank = Math.min(block.bestRank, item.rank);
+      if (item.severityRank < block.bestSeverityRank) {
+        block.bestSeverityRank = item.severityRank;
+        block.bestSeverityCount = 1;
+      } else if (item.severityRank === block.bestSeverityRank) {
+        block.bestSeverityCount += 1;
       }
     }
-    return { story, originalIndex, rank };
+  }
+
+  const orderedBlocks = [...blocks.values()].sort((a, b) => {
+    if (a.bestSeverityRank !== b.bestSeverityRank) return a.bestSeverityRank - b.bestSeverityRank;
+    if (a.bestSeverityCount !== b.bestSeverityCount) return b.bestSeverityCount - a.bestSeverityCount;
+    if (a.eligibleCount !== b.eligibleCount) return b.eligibleCount - a.eligibleCount;
+    if (a.maxScore !== b.maxScore) return b.maxScore - a.maxScore;
+    if (a.bestRank !== b.bestRank) return a.bestRank - b.bestRank;
+    return a.firstIndex - b.firstIndex;
   });
-  annotated.sort((a, b) => {
-    if (a.rank !== b.rank) return a.rank - b.rank;
-    return a.originalIndex - b.originalIndex;
-  });
-  return annotated.map((a) => a.story);
+
+  const ordered = [];
+  for (const block of orderedBlocks) {
+    block.items.sort((a, b) => {
+      if (a.eligible !== b.eligible) return a.eligible ? -1 : 1;
+      if (a.severityRank !== b.severityRank) return a.severityRank - b.severityRank;
+      if (a.rank !== b.rank) return a.rank - b.rank;
+      if (a.score !== b.score) return b.score - a.score;
+      return a.originalIndex - b.originalIndex;
+    });
+    for (const item of block.items) ordered.push(item.story);
+  }
+  return ordered;
 }
 
 /**
@@ -163,15 +274,11 @@ export function filterTopStories({ stories, sensitivity, maxStories = 12, maxPer
   // and synchronous — any throw is the caller's problem (tested above).
   const emit = typeof onDrop === 'function' ? onDrop : null;
 
-  // Optional editorial ranking — when supplied, stories are sorted by
-  // the position of `story.hash` in `rankedStoryHashes` BEFORE the
-  // cap is applied, so the canonical synthesis brain's judgment of
-  // editorial importance survives the MAX_STORIES_PER_USER cut.
-  // Stories not in the ranking go after, in their original order.
-  // Match is by short-hash prefix (≥4 chars) to tolerate the
-  // ranker's emit format (the prompt uses 8-char prefixes; the
-  // story carries the full hash). Empty/missing array = no-op.
-  const orderedStories = applyRankedOrder(stories, rankedStoryHashes);
+  // Final editorial ordering happens BEFORE the cap. Severity and
+  // topic-block mass dominate so a critical cluster stays contiguous
+  // and reaches the rendered brief ahead of lower-severity singletons;
+  // rankedStoryHashes remains a tie-breaker inside that frame.
+  const orderedStories = orderBriefCandidates(stories, allowed, rankedStoryHashes);
 
   /** @type {BriefStory[]} */
   const out = [];
@@ -189,19 +296,6 @@ export function filterTopStories({ stories, sensitivity, maxStories = 12, maxPer
   const pairCounts = new Map();
   for (let i = 0; i < orderedStories.length; i++) {
     const raw = orderedStories[i];
-    if (out.length >= maxStories) {
-      // Cap-truncation: remaining stories are not evaluated. Emit one
-      // event per skipped story so operators can reconcile in vs out
-      // counts (`in - out - sum(dropped_severity|headline|url|shape)
-      // == dropped_cap`). Without this, cap-truncated stories are
-      // invisible to Sol-0 telemetry and Sol-3's gating signal is
-      // undercounted by up to (DIGEST_MAX_ITEMS - MAX_STORIES_PER_USER)
-      // per user per tick.
-      if (emit) {
-        for (let j = i; j < orderedStories.length; j++) emit({ reason: 'cap' });
-      }
-      break;
-    }
     if (!raw || typeof raw !== 'object') {
       if (emit) emit({ reason: 'shape' });
       continue;
@@ -238,6 +332,16 @@ export function filterTopStories({ stories, sensitivity, maxStories = 12, maxPer
     // ensures the brief surface stays clean even then. R7.
     if (isInstitutionalStaticPage(sourceUrl)) {
       if (emit) emit({ reason: 'institutional_static_page', severity: threatLevel, sourceUrl });
+      continue;
+    }
+
+    if (out.length >= maxStories) {
+      // Cap-truncation after eligibility checks: a story is counted as
+      // `cap` only if it otherwise would have been eligible to render.
+      // Invalid/low-severity tail items keep their root-cause reason,
+      // which keeps operator reconciliation useful after deterministic
+      // severity/topic ordering moves excluded stories later.
+      if (emit) emit({ reason: 'cap' });
       continue;
     }
 

--- a/tests/brief-dedup-embedding.test.mjs
+++ b/tests/brief-dedup-embedding.test.mjs
@@ -820,6 +820,8 @@ describe('groupTopicsPostDedup — size-first total ordering', () => {
       ordered.slice(0, 4).map((r) => r.hash),
       ['a0', 'a1', 'a2', 'a3'],
     );
+    assert.equal(new Set(ordered.slice(0, 4).map((r) => r.briefTopicId)).size, 1);
+    assert.deepEqual(ordered.slice(0, 4).map((r) => r.briefTopicSize), [4, 4, 4, 4]);
     // Topic B next; members in score DESC: 91, 90, 85
     assert.deepEqual(
       ordered.slice(4, 7).map((r) => r.hash),

--- a/tests/brief-filter.test.mjs
+++ b/tests/brief-filter.test.mjs
@@ -168,6 +168,80 @@ describe('filterTopStories', () => {
     assert.equal(out.length, 1);
     assert.equal(out[0].sourceUrl, 'https://example.com/keep');
   });
+
+  it('orders critical stories ahead of lower-severity LLM-ranked stories', () => {
+    const out = filterTopStories({
+      stories: [
+        upstreamStory({
+          primaryTitle: 'High story ranked by the model',
+          threatLevel: 'high',
+          hash: 'high111111111111',
+          primarySource: 'Wire A',
+          category: 'Diplomacy',
+        }),
+        upstreamStory({
+          primaryTitle: 'Critical story not ranked by the model',
+          threatLevel: 'critical',
+          hash: 'crit222222222222',
+          primarySource: 'Wire B',
+          category: 'Security',
+        }),
+      ],
+      sensitivity: 'all',
+      rankedStoryHashes: ['high1111'],
+      maxPerSourceTopic: Infinity,
+    });
+
+    assert.equal(out.length, 2);
+    assert.equal(out[0].headline, 'Critical story not ranked by the model');
+    assert.equal(out[1].headline, 'High story ranked by the model');
+  });
+
+  it('keeps heavier critical topic blocks contiguous ahead of ranked singletons', () => {
+    const out = filterTopStories({
+      stories: [
+        upstreamStory({
+          primaryTitle: 'Ranked singleton critical',
+          threatLevel: 'critical',
+          hash: 'solo111111111111',
+          briefTopicId: 'singleton',
+          importanceScore: 999,
+          primarySource: 'Wire A',
+          category: 'Security',
+        }),
+        upstreamStory({
+          primaryTitle: 'Cluster critical anchor',
+          threatLevel: 'critical',
+          hash: 'clust22222222222',
+          briefTopicId: 'critical-cluster',
+          importanceScore: 120,
+          primarySource: 'Wire B',
+          category: 'Security',
+        }),
+        upstreamStory({
+          primaryTitle: 'Cluster related high follow-up',
+          threatLevel: 'high',
+          hash: 'clust33333333333',
+          briefTopicId: 'critical-cluster',
+          importanceScore: 100,
+          primarySource: 'Wire C',
+          category: 'Diplomacy',
+        }),
+      ],
+      sensitivity: 'all',
+      rankedStoryHashes: ['solo1111'],
+      maxPerSourceTopic: Infinity,
+    });
+
+    assert.deepEqual(
+      out.map((story) => story.headline),
+      [
+        'Cluster critical anchor',
+        'Cluster related high follow-up',
+        'Ranked singleton critical',
+      ],
+    );
+  });
 });
 
 describe('assembleStubbedBriefEnvelope', () => {
@@ -355,10 +429,10 @@ describe('filterTopStories — onDrop metrics', () => {
     for (const ev of calls) assert.equal(ev.reason, 'cap');
   });
 
-  it('cap events do NOT count earlier severity/headline/url drops twice', () => {
-    // The cap-emit loop runs from the break point onward — earlier
-    // valid stories that pushed `out` to maxStories are not re-emitted,
-    // and earlier-dropped stories are accounted under their own reason.
+  it('cap events count only otherwise-renderable stories after maxStories', () => {
+    // After deterministic re-ordering, excluded stories may move after
+    // the cap point. They should keep their root-cause reason instead
+    // of being counted as cap-truncated valid cards.
     const tally = { severity: 0, headline: 0, url: 0, shape: 0, cap: 0 };
     filterTopStories({
       stories: [
@@ -366,15 +440,15 @@ describe('filterTopStories — onDrop metrics', () => {
         upstreamStory({ threatLevel: 'low' }),        // severity (not cap)
         upstreamStory({ primaryTitle: 'B' }),         // kept (out reaches 2)
         upstreamStory({ primaryTitle: 'C' }),         // cap
-        upstreamStory({ primaryLink: 'ftp://bad' }),  // cap (loop short-circuits past url check)
+        upstreamStory({ primaryLink: 'ftp://bad' }),  // url (not cap)
       ],
       sensitivity,
       maxStories: 2,
       onDrop: (ev) => { tally[ev.reason]++; },
     });
     assert.equal(tally.severity, 1);
-    assert.equal(tally.cap, 2);
-    assert.equal(tally.url, 0, 'url drop should NOT fire after cap break');
+    assert.equal(tally.cap, 1);
+    assert.equal(tally.url, 1, 'url drop should keep its root-cause reason after cap is full');
   });
 
   it('reconciliation invariant: in === out + sum(dropped_*) across all reasons', () => {

--- a/tests/brief-filter.test.mjs
+++ b/tests/brief-filter.test.mjs
@@ -197,7 +197,7 @@ describe('filterTopStories', () => {
     assert.equal(out[1].headline, 'High story ranked by the model');
   });
 
-  it('keeps heavier critical topic blocks contiguous ahead of ranked singletons', () => {
+  it('keeps larger critical-anchored topic blocks contiguous ahead of ranked singletons', () => {
     const out = filterTopStories({
       stories: [
         upstreamStory({
@@ -239,6 +239,144 @@ describe('filterTopStories', () => {
         'Cluster critical anchor',
         'Cluster related high follow-up',
         'Ranked singleton critical',
+      ],
+    );
+  });
+
+  it('orders concentrated top-severity blocks before broader lower-tier context', () => {
+    const out = filterTopStories({
+      stories: [
+        upstreamStory({
+          primaryTitle: 'Broad block critical anchor',
+          threatLevel: 'critical',
+          hash: 'broad1111111111',
+          briefTopicId: 'broad',
+          importanceScore: 900,
+          primarySource: 'Wire A',
+          category: 'Security',
+        }),
+        upstreamStory({
+          primaryTitle: 'Broad block high context one',
+          threatLevel: 'high',
+          hash: 'broad2222222222',
+          briefTopicId: 'broad',
+          importanceScore: 800,
+          primarySource: 'Wire B',
+          category: 'Diplomacy',
+        }),
+        upstreamStory({
+          primaryTitle: 'Broad block high context two',
+          threatLevel: 'high',
+          hash: 'broad3333333333',
+          briefTopicId: 'broad',
+          importanceScore: 700,
+          primarySource: 'Wire C',
+          category: 'Economy',
+        }),
+        upstreamStory({
+          primaryTitle: 'Dense block critical one',
+          threatLevel: 'critical',
+          hash: 'dense4444444444',
+          briefTopicId: 'dense',
+          importanceScore: 100,
+          primarySource: 'Wire D',
+          category: 'Military',
+        }),
+        upstreamStory({
+          primaryTitle: 'Dense block critical two',
+          threatLevel: 'critical',
+          hash: 'dense5555555555',
+          briefTopicId: 'dense',
+          importanceScore: 90,
+          primarySource: 'Wire E',
+          category: 'Military',
+        }),
+      ],
+      sensitivity: 'all',
+      rankedStoryHashes: ['broad111'],
+      maxPerSourceTopic: Infinity,
+    });
+
+    assert.deepEqual(
+      out.map((story) => story.headline),
+      [
+        'Dense block critical one',
+        'Dense block critical two',
+        'Broad block critical anchor',
+        'Broad block high context one',
+        'Broad block high context two',
+      ],
+    );
+  });
+
+  it('uses max score before LLM rank when severity mass is tied', () => {
+    const out = filterTopStories({
+      stories: [
+        upstreamStory({
+          primaryTitle: 'Ranked lower-score critical',
+          threatLevel: 'critical',
+          hash: 'rank11111111111',
+          briefTopicId: 'ranked',
+          importanceScore: 100,
+          primarySource: 'Wire A',
+          category: 'Security',
+        }),
+        upstreamStory({
+          primaryTitle: 'Unranked higher-score critical',
+          threatLevel: 'critical',
+          hash: 'score2222222222',
+          briefTopicId: 'scored',
+          importanceScore: 200,
+          primarySource: 'Wire B',
+          category: 'Diplomacy',
+        }),
+      ],
+      sensitivity: 'all',
+      rankedStoryHashes: ['rank111'],
+      maxPerSourceTopic: Infinity,
+    });
+
+    assert.deepEqual(
+      out.map((story) => story.headline),
+      [
+        'Unranked higher-score critical',
+        'Ranked lower-score critical',
+      ],
+    );
+  });
+
+  it('uses best LLM rank only after severity mass and score tie', () => {
+    const out = filterTopStories({
+      stories: [
+        upstreamStory({
+          primaryTitle: 'Unranked equal-score critical',
+          threatLevel: 'critical',
+          hash: 'tie111111111111',
+          briefTopicId: 'tie-a',
+          importanceScore: 100,
+          primarySource: 'Wire A',
+          category: 'Security',
+        }),
+        upstreamStory({
+          primaryTitle: 'Ranked equal-score critical',
+          threatLevel: 'critical',
+          hash: 'tie222222222222',
+          briefTopicId: 'tie-b',
+          importanceScore: 100,
+          primarySource: 'Wire B',
+          category: 'Diplomacy',
+        }),
+      ],
+      sensitivity: 'all',
+      rankedStoryHashes: ['tie222'],
+      maxPerSourceTopic: Infinity,
+    });
+
+    assert.deepEqual(
+      out.map((story) => story.headline),
+      [
+        'Ranked equal-score critical',
+        'Unranked equal-score critical',
       ],
     );
   });

--- a/tests/brief-from-digest-stories.test.mjs
+++ b/tests/brief-from-digest-stories.test.mjs
@@ -14,7 +14,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-import { composeBriefFromDigestStories, stripHeadlineSuffix } from '../scripts/lib/brief-compose.mjs';
+import { composeBriefFromDigestStories, stripHeadlineSuffix, stripHeadlinePrefix } from '../scripts/lib/brief-compose.mjs';
 import { materializeCluster } from '../scripts/lib/brief-dedup-jaccard.mjs';
 
 const NOW = 1_745_000_000_000; // 2026-04-18 ish, deterministic
@@ -135,11 +135,133 @@ describe('stripHeadlineSuffix', () => {
     const title = 'Headline with no suffix';
     assert.equal(stripHeadlineSuffix(title, 'AP News'), title);
   });
+  it('REGRESSION (May 13 brief): strips wire-name suffix when feed-name is the longer form', () => {
+    // Live incident: headline ended " - Reuters" but the story's
+    // primarySource was "Reuters World" (the feed name). The strict-
+    // equality check ('reuters' !== 'reuters world') let the suffix
+    // ship to the magazine. Asymmetric word-boundary prefix-match
+    // (tail SHORTER than publisher only) catches it.
+    assert.equal(
+      stripHeadlineSuffix('Putin says Russia will deploy new Sarmat nuclear missile this year - Reuters', 'Reuters World'),
+      'Putin says Russia will deploy new Sarmat nuclear missile this year',
+    );
+    // AP (tail) shorter than AP News (publisher) → strips.
+    assert.equal(stripHeadlineSuffix('Headline - AP', 'AP News'), 'Headline');
+  });
+
+  it('REJECTS the inverse direction (publisher prefix of tail) — preserves editorial suffixes', () => {
+    // "Story - AP News analysis" with publisher "AP News" must NOT
+    // strip — "analysis" is editorial content that extends the
+    // publisher name, not a desk-name suffix. Asymmetric direction
+    // catches the legitimate Reuters/Reuters World case while
+    // preserving editorial extensions like this one.
+    assert.equal(
+      stripHeadlineSuffix('Story - AP News analysis', 'AP News'),
+      'Story - AP News analysis',
+    );
+    // Same shape with tail "Reuters World" / publisher "Reuters":
+    // tail is LONGER, so we conservatively don't strip. We can't
+    // distinguish "Reuters World" (a desk) from "Reuters World scoop"
+    // (editorial) without a desk-name allowlist, so err on the side
+    // of preserving content.
+    assert.equal(
+      stripHeadlineSuffix('Story body - Reuters World', 'Reuters'),
+      'Story body - Reuters World',
+    );
+  });
+
+  it('does NOT word-boundary-match unrelated names that share a stem', () => {
+    // "reuter" (length 6) is NOT a word-prefix of "Reuters" because
+    // the space delimiter is absent ("Reuters" has no space after
+    // "reuter"). Should not strip.
+    assert.equal(
+      stripHeadlineSuffix('Story body - reuter', 'Reuters'),
+      'Story body - reuter',
+    );
+    // "iran" is a prefix of "iranian" without a space, so a tail of
+    // "iran" must NOT match a publisher "iranian press".
+    assert.equal(
+      stripHeadlineSuffix('Story body - iran', 'iranian press'),
+      'Story body - iran',
+    );
+  });
+
   it('handles missing / empty inputs without throwing', () => {
     assert.equal(stripHeadlineSuffix('', 'AP News'), '');
     assert.equal(stripHeadlineSuffix('Headline', ''), 'Headline');
     // @ts-expect-error testing unexpected input
     assert.equal(stripHeadlineSuffix(undefined, 'AP News'), '');
+  });
+});
+
+describe('stripHeadlinePrefix', () => {
+  it('REGRESSION (May 12 brief): strips "Video: " prefix from RSS headlines', () => {
+    // Live incident: magazine page 16/18 shipped "Video: Philippine
+    // senator flees ICC arrest over role in drug war". The prefix
+    // tells the user nothing the magazine card body doesn't already
+    // convey — every card has its own source line.
+    assert.equal(
+      stripHeadlinePrefix('Video: Philippine senator flees ICC arrest over role in drug war'),
+      'Philippine senator flees ICC arrest over role in drug war',
+    );
+  });
+
+  it('strips Watch / Live / Photos / Photo / Gallery / Listen / Podcast / Breaking / Exclusive / Opinion / Analysis / Update prefixes', () => {
+    assert.equal(stripHeadlinePrefix('Watch: Press conference live'), 'Press conference live');
+    assert.equal(stripHeadlinePrefix('LIVE: Senate hearing'), 'Senate hearing');
+    assert.equal(stripHeadlinePrefix('Photos: Damage from the airstrike'), 'Damage from the airstrike');
+    assert.equal(stripHeadlinePrefix('Photo: Wildfire aftermath'), 'Wildfire aftermath');
+    assert.equal(stripHeadlinePrefix('Gallery: Election day around the world'), 'Election day around the world');
+    assert.equal(stripHeadlinePrefix('Listen: Interview with the foreign minister'), 'Interview with the foreign minister');
+    assert.equal(stripHeadlinePrefix('Podcast: Today in the Middle East'), 'Today in the Middle East');
+    assert.equal(stripHeadlinePrefix('Breaking: Cabinet resignation announced'), 'Cabinet resignation announced');
+    assert.equal(stripHeadlinePrefix('Exclusive: Internal memo reveals plan'), 'Internal memo reveals plan');
+    assert.equal(stripHeadlinePrefix('Opinion: The case for sanctions'), 'The case for sanctions');
+    assert.equal(stripHeadlinePrefix('Analysis: What the deal means'), 'What the deal means');
+    assert.equal(stripHeadlinePrefix('Update: Death toll rises'), 'Death toll rises');
+  });
+
+  it('is case-insensitive on the prefix word', () => {
+    assert.equal(stripHeadlinePrefix('VIDEO: Story'), 'Story');
+    assert.equal(stripHeadlinePrefix('video: Story'), 'Story');
+    assert.equal(stripHeadlinePrefix('Video: Story'), 'Story');
+  });
+
+  it('REQUIRES the trailing colon — bare "Video game regulator..." is preserved', () => {
+    // The colon constraint is what prevents stripping legitimate
+    // headlines that happen to start with one of the prefix words
+    // used as a noun ("Video game...", "Watch list...", "Live broadcast...").
+    assert.equal(
+      stripHeadlinePrefix('Video game regulator fines top studio'),
+      'Video game regulator fines top studio',
+    );
+    assert.equal(
+      stripHeadlinePrefix('Watch list updated by sanctions office'),
+      'Watch list updated by sanctions office',
+    );
+    assert.equal(
+      stripHeadlinePrefix('Live broadcasts paused during emergency'),
+      'Live broadcasts paused during emergency',
+    );
+  });
+
+  it('handles whitespace variants around the colon', () => {
+    assert.equal(stripHeadlinePrefix('Video : Story'), 'Story');
+    assert.equal(stripHeadlinePrefix('Video:Story'), 'Story');
+    assert.equal(stripHeadlinePrefix('Video:    Story'), 'Story');
+  });
+
+  it('handles missing / empty inputs without throwing', () => {
+    assert.equal(stripHeadlinePrefix(''), '');
+    // @ts-expect-error testing unexpected input
+    assert.equal(stripHeadlinePrefix(undefined), '');
+    // @ts-expect-error testing unexpected input
+    assert.equal(stripHeadlinePrefix(null), '');
+  });
+
+  it('leaves headlines without a known prefix alone', () => {
+    const title = 'Russia and Ukraine trade blame for continued fighting';
+    assert.equal(stripHeadlinePrefix(title), title);
   });
 });
 

--- a/tests/brief-from-digest-stories.test.mjs
+++ b/tests/brief-from-digest-stories.test.mjs
@@ -646,6 +646,56 @@ describe('composeBriefFromDigestStories — synthesis splice', () => {
     assert.equal(env.data.stories[1].headline, 'Unranked A');
     assert.equal(env.data.stories[2].headline, 'Unranked C');
   });
+
+  it('severity/topic-cluster order beats rankedStoryHashes for critical clusters', () => {
+    const stories = [
+      digestStory({
+        hash: 'solo111111111111',
+        title: 'Ranked singleton critical',
+        severity: 'critical',
+        currentScore: 999,
+        sources: ['SrcA'],
+        briefTopicId: 'singleton',
+      }),
+      digestStory({
+        hash: 'cluster222222222',
+        title: 'Cluster critical anchor',
+        severity: 'critical',
+        currentScore: 120,
+        sources: ['SrcB'],
+        briefTopicId: 'critical-cluster',
+      }),
+      digestStory({
+        hash: 'cluster333333333',
+        title: 'Cluster related high follow-up',
+        severity: 'high',
+        currentScore: 100,
+        sources: ['SrcC'],
+        briefTopicId: 'critical-cluster',
+      }),
+    ];
+    const env = composeBriefFromDigestStories(
+      rule(),
+      stories,
+      { clusters: 0, multiSource: 0 },
+      {
+        nowMs: NOW,
+        synthesis: {
+          lead: 'Editorial lead at least forty characters long for validator pass-through.',
+          rankedStoryHashes: ['solo1111'],
+        },
+      },
+    );
+    assert.ok(env);
+    assert.deepEqual(
+      env.data.stories.map((story) => story.headline),
+      [
+        'Cluster critical anchor',
+        'Cluster related high follow-up',
+        'Ranked singleton critical',
+      ],
+    );
+  });
 });
 
 // ── Sprint 1 / U3 — stable clusterId wiring (canonical cluster-rep hash) ──


### PR DESCRIPTION
## Summary

This PR fixes three brief-quality issues observed on the May 12 / May 13 sends:

1. **Editorial prefixes shipping to the magazine.** May 12 brief, page 16/18: *"Video: Philippine senator flees ICC arrest…"*. Strip `Video:`, `Watch:`, `Live:`, `Photos:`, `Breaking:`, `Exclusive:`, `Opinion:`, `Analysis:`, `Update:`, and similar editorial-format prefixes (12 variants) at compose time. The trailing colon is REQUIRED so legitimate noun-form headlines (*"Video game regulator…"*, *"Watch list updated…"*, *"Live broadcasts paused…"*) survive intact.

2. **Wire-name suffixes surviving when feed-name is the longer form.** May 13 brief, story 5: *"Putin says Russia will deploy new Sarmat nuclear missile this year - Reuters"*; `primarySource` was `Reuters World`. The old strict-equality check (`"reuters" !== "reuters world"`) shipped the suffix to the magazine. Fix: asymmetric word-boundary prefix match — tail must be a SHORTER prefix of publisher (`Reuters` against `Reuters World` → strip). The inverse direction is rejected ON PURPOSE so *"Story - AP News analysis"* with publisher `AP News` keeps the editorial `analysis` word.

3. **Severity / topic-cluster ordering breaking down to a chaotic interleaved walk.** May 13 brief order was 🔴🟠🟠🟠🔴🔴🔴🔴🔴🟠🟠🟠 with Nigeria stories split by Syria and the Iran arc fragmented across four non-adjacent positions. Root cause: `applyRankedOrder` let LLM `rankedStoryHashes` dominate the global sort, overriding the topic blocks from `groupTopicsPostDedup` and ignoring severity entirely. Replace with `orderBriefCandidates` — a block-based sort keyed by (topic block's highest eligible severity, count at that severity, eligible block size, max score, then LLM rank as tie-breaker). Critical clusters now stay contiguous; LLM still chooses between similarly severe candidates.

## Ordering trade-off

The ordering model intentionally favors **concentrated top severity before breadth**: a block with two critical stories sorts ahead of a block with one critical plus several high stories. Once top-severity count ties, broader eligible block size wins, then max score, then LLM rank. Each tiebreak rung is individually tested so a future contributor reordering the keys will fail a named test, not a vibes check.

Rows without `briefTopicId` or `clusterRepHash` degrade to per-row singleton blocks. That preserves severity ordering but loses topic adjacency for legacy/raw rows — deliberate, to avoid false-grouping unrelated stories under a guessed key.

## Ops note

`dropped_cap` telemetry now counts only **otherwise-renderable stories** skipped after `maxStories`. Invalid or sensitivity-excluded tail items keep their root-cause reason (`severity`, `headline`, `url`, etc.). The reconciliation invariant still holds (`in === out + Σ dropped_*`), but absolute `dropped_cap` values may be lower post-deploy. Worth recalibrating any alerts keyed on the absolute count.

## Test coverage

- REGRESSION (May 13 brief): critical clusters beat lower-severity or ranked singletons
- Tiebreak coverage for top-severity count, eligible block size, max score, and final LLM rank — one test per rung in the chain
- REGRESSION (May 13 brief): Sarmat / Reuters / Reuters World suffix stripping
- REGRESSION (May 12 brief): `Video:` prefix stripping
- Rejects inverse suffix stripping for AP News / AP News analysis
- Word-boundary stem rejection (`reuter` / `Reuters`, `iran` / `iranian press`)
- Topic metadata plumbing from `groupTopicsPostDedup` through compose
- Cap-drop reconciliation and root-cause telemetry behavior

## Test plan

- [x] `node --test tests/brief-filter.test.mjs`
- [x] `node --test tests/brief-from-digest-stories.test.mjs`
- [x] `node --test tests/brief-dedup-embedding.test.mjs`
- [x] `npm run typecheck`
- [x] `biome check` clean (verified locally + on CI)
- [ ] After deploy, verify next production brief shows:
    - critical-cluster-first ordering (May 13 🔴🟠🟠🟠🔴🔴🔴🔴🔴🟠🟠🟠 interleave fixed)
    - topic-adjacent stories within each severity tier (Nigeria adjacency, Iran-arc grouped)
    - no `Video:` / `Watch:` / `Live:` prefixes on magazine cards
    - no `- Reuters` suffix when story source is `Reuters World`

## Notes

Independent of PR #3667 (digest grounding validation). PR #3667 guards synthesis content grounding (catches hallucinated leads); this PR handles headline cleanup and deterministic story ordering before render. Both touch the brief but address orthogonal bug classes.

For the full pipeline context, see `docs/internal/brief130526.md` — the §7 signal-conflict matrix names every offending signal interaction this PR closes.