### PR TITLE
feat(news): add Trump Truth Social to politics feed

### DIFF
--- a/server/worldmonitor/news/v1/_feeds.ts
+++ b/server/worldmonitor/news/v1/_feeds.ts
@@ -15,6 +15,7 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       { name: 'AP News', url: gn('site:apnews.com when:1d') },
       { name: 'Reuters World', url: gn('site:reuters.com world when:1d') },
       { name: 'CNN World', url: gn('site:cnn.com world news when:1d') },
+      { name: 'Trump - Truth Social', url: 'https://trumpstruth.org/feed' },
     ],
     us: [
       { name: 'Reuters US', url: gn('site:reuters.com US when:1d') },


### PR DESCRIPTION
## Summary
- Adds `trumpstruth.org/feed` (3rd-party RSS archive of @realDonaldTrump on Truth Social) to `full.politics` in `server/worldmonitor/news/v1/_feeds.ts`.
- One-line config change — no new code. Standard RSS 2.0; existing parser, dedup, and classification pipeline handle it.

## Why this source (not truthsocial.com directly)
- `truthsocial.com/@realDonaldTrump.rss` and `/users/realDonaldTrump.rss` 200 but return the SPA HTML shell — Mastodon RSS is disabled.
- The Mastodon API (`/api/v1/accounts/lookup`, `/api/v2/search`) is behind a Cloudflare challenge and requires auth; ToS prohibits scraping.
- `trumpstruth.org/feed` is a long-running archive (RSS 2.0, ~15–30 min lag, full post text, used by news orgs).

## Tradeoff
- Single-point-of-failure on a 3rd-party archive. If trumpstruth.org goes down, this entry silently drops out — same blast radius as any other feed in the array. No special handling beyond the existing pipeline.

## Test plan
- [x] `npm run typecheck` — PASS
- [x] `npm run typecheck:api` — PASS
- [x] `npm run lint` — PASS (0 errors)
- [x] `npm run test:data` — PASS (8659/0)
- [x] `node --test tests/edge-functions.test.mjs` — PASS (184/0)
- [x] `npm run lint:md` — PASS (0 errors)
- [x] `npm run version:check` — PASS
- [x] Edge function bundle check — PASS
- [x] Verified `trumpstruth.org/feed` returns valid RSS 2.0 with fresh items at probe time
- [ ] Post-merge: verify Trump posts appear in the `full` digest under the politics category within one ingest cycle