### PR TITLE
fix(seed-portwatch-port-activity): cap cold-fetch at 30/run to prevent 174-country cliff

### DIFF
--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -61,6 +61,20 @@ const BATCH_LOG_EVERY = 5;
 // from today's last30/prev30 cutoffs) and serves as a belt-and-braces refresh
 // if the maxDate check ever silently short-circuits.
 const MAX_CACHE_AGE_MS = 7 * 86_400_000;
+// Cap how many countries can be cold-fetched in a single run. When upstream
+// advances its data (asof mismatch on a sync'd cache), all 174 countries
+// become "cache miss" at once. Cold-fetching 174 against ArcGIS exceeds the
+// 570s bundle budget (observed 2026-05-13: preflight alone took 360s, batch 1
+// of 15 hit 12 errors in 45s before container died at the budget cap).
+//
+// With this cap, a "everything stale" run refreshes a random subset and
+// serves the remainder from prior cache (marked staleAsof=true so downstream
+// can see they're a window behind). A full rotation completes in ~6 runs
+// = ~3 days at the 12h cron cadence, well within the 7-day MAX_CACHE_AGE_MS.
+//
+// 30 is sized so the cold-fetch path (30 × ~3-5s/country with concurrency
+// 12 ≈ 12-15s) easily fits the 570s budget even when ArcGIS is slow.
+const MAX_COLD_FETCH_PER_RUN = 30;
 // Concurrency for the cheap per-country maxDate preflight. These are tiny
 // outStatistics queries (returns 1 row), so we can push harder than the
 // expensive fetch concurrency without tripping ArcGIS 429s in practice.
@@ -562,8 +576,11 @@ export async function fetchAll(progress, { signal } = {}) {
   console.log(`  [port-activity] Preflight maxDate for ${eligibleIso3.length} countries (${((Date.now() - preflightT0) / 1000).toFixed(1)}s)`);
 
   // Partition: cache hits (reusable) vs misses (need expensive fetch).
+  // For misses, capture `prevPayload` (may be null) so that if we end up
+  // deferring this country to a later run we can still serve its previous
+  // (slightly-stale) data — better than dropping it entirely.
   const countryData = new Map();
-  const needsFetch = [];
+  let needsFetch = [];
   let cacheHits = 0;
   const now = Date.now();
   for (let i = 0; i < eligibleIso3.length; i++) {
@@ -580,10 +597,47 @@ export async function fetchAll(progress, { signal } = {}) {
       countryData.set(iso2, prev);
       cacheHits++;
     } else {
-      needsFetch.push({ iso3, iso2, upstreamMaxDate });
+      needsFetch.push({ iso3, iso2, upstreamMaxDate, prevPayload: prev });
     }
   }
   console.log(`  [port-activity] Cache: ${cacheHits} hits, ${needsFetch.length} misses`);
+
+  // Cold-fetch cap (WM 2026-05-13 incident): when needsFetch exceeds the
+  // per-run cap, refresh a random subset and serve the rest from prior
+  // cache marked staleAsof=true. Prevents the catastrophic "everything
+  // stale → 174 cold-fetches → bundle SIGTERM" failure mode that produced
+  // 37h of stale data after a single upstream-advance event. A full
+  // rotation completes in ~ceil(174/30) = 6 runs ≈ 3 days at 12h cadence.
+  if (needsFetch.length > MAX_COLD_FETCH_PER_RUN) {
+    // Deterministic-ish shuffle: Fisher-Yates with Math.random — fine here
+    // because we just need "different subset each run", not crypto strength.
+    const shuffled = [...needsFetch];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    const deferred = shuffled.slice(MAX_COLD_FETCH_PER_RUN);
+    let servedStale = 0;
+    let droppedNoCache = 0;
+    for (const item of deferred) {
+      if (item.prevPayload && typeof item.prevPayload === 'object') {
+        // Mark as stale-asof so downstream consumers know this country is one
+        // window behind. The canonical payload structure is unchanged.
+        countryData.set(item.iso2, { ...item.prevPayload, staleAsof: true });
+        servedStale++;
+      } else {
+        // No prior payload (new country, first-ever miss). Drop — same as
+        // pre-fix behavior for hard misses.
+        droppedNoCache++;
+      }
+    }
+    needsFetch = shuffled.slice(0, MAX_COLD_FETCH_PER_RUN);
+    console.warn(
+      `  [port-activity] Cold-fetch capped at ${MAX_COLD_FETCH_PER_RUN}/run — ` +
+      `refreshing ${needsFetch.length} now, serving ${servedStale} on stale cache (asof behind), ` +
+      `${droppedNoCache} dropped (no prior payload). Rotation: ~${Math.ceil((needsFetch.length + servedStale + droppedNoCache) / MAX_COLD_FETCH_PER_RUN)} runs to fully refresh.`,
+    );
+  }
 
   // ─────────────────────────────────────────────────────────────────────────
   // Expensive path: paginated fetch for cache misses only.

--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -618,24 +618,44 @@ export async function fetchAll(progress, { signal } = {}) {
     }
     const deferred = shuffled.slice(MAX_COLD_FETCH_PER_RUN);
     let servedStale = 0;
+    let droppedTooOld = 0;
     let droppedNoCache = 0;
     for (const item of deferred) {
-      if (item.prevPayload && typeof item.prevPayload === 'object') {
-        // Mark as stale-asof so downstream consumers know this country is one
-        // window behind. The canonical payload structure is unchanged.
-        countryData.set(item.iso2, { ...item.prevPayload, staleAsof: true });
-        servedStale++;
-      } else {
+      const prev = item.prevPayload;
+      if (!prev || typeof prev !== 'object') {
         // No prior payload (new country, first-ever miss). Drop — same as
         // pre-fix behavior for hard misses.
         droppedNoCache++;
+        continue;
       }
+      // MAX_CACHE_AGE_MS hard-drop boundary (Greptile PR #3676 review P1):
+      // the deferred-stale path MUST respect the same age gate the
+      // cacheFresh check enforces, otherwise a country deferred across
+      // enough runs while upstream was frozen ≥4 days could publish data
+      // older than the intended 7d hard-drop threshold. Without this,
+      // window-drift accumulates past MAX_CACHE_AGE_MS and the PR's claim
+      // that hard-drop behavior is unchanged would be false.
+      const cacheWrittenAt = prev.cacheWrittenAt;
+      if (typeof cacheWrittenAt !== 'number' || (now - cacheWrittenAt) >= MAX_CACHE_AGE_MS) {
+        droppedTooOld++;
+        continue;
+      }
+      // Mark as stale-asof so downstream consumers know this country is one
+      // window behind. The canonical payload structure is unchanged.
+      countryData.set(item.iso2, { ...prev, staleAsof: true });
+      servedStale++;
     }
     needsFetch = shuffled.slice(0, MAX_COLD_FETCH_PER_RUN);
+    // Rotation arithmetic uses MAX_COLD_FETCH_PER_RUN directly rather than
+    // needsFetch.length — needsFetch was just reassigned to the cap-sized
+    // slice, so the two are numerically equal here, but using the constant
+    // keeps the intent unambiguous if this log block is ever reordered.
+    const originalMisses = MAX_COLD_FETCH_PER_RUN + servedStale + droppedTooOld + droppedNoCache;
     console.warn(
       `  [port-activity] Cold-fetch capped at ${MAX_COLD_FETCH_PER_RUN}/run — ` +
-      `refreshing ${needsFetch.length} now, serving ${servedStale} on stale cache (asof behind), ` +
-      `${droppedNoCache} dropped (no prior payload). Rotation: ~${Math.ceil((needsFetch.length + servedStale + droppedNoCache) / MAX_COLD_FETCH_PER_RUN)} runs to fully refresh.`,
+      `refreshing ${MAX_COLD_FETCH_PER_RUN} now, serving ${servedStale} on stale cache (asof behind), ` +
+      `${droppedTooOld} dropped (cache > ${MAX_CACHE_AGE_MS / 86_400_000}d old), ${droppedNoCache} dropped (no prior payload). ` +
+      `Rotation: ~${Math.ceil(originalMisses / MAX_COLD_FETCH_PER_RUN)} runs to fully refresh.`,
     );
   }
 

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -722,7 +722,31 @@ describe('cold-fetch cap prevents 174-country cliff (WM 2026-05-13)', () => {
     // output — that's the same as a hard-fail for the consumer. Marking
     // staleAsof preserves the country's data shape but signals "one window
     // behind" so downstream can render or warn accordingly.
-    assert.match(src, /prevPayload[\s\S]{0,200}staleAsof:\s*true/);
+    assert.match(src, /\.\.\.prev,\s*staleAsof:\s*true/);
+  });
+
+  it('deferred-stale path respects MAX_CACHE_AGE_MS hard-drop (Greptile P1)', () => {
+    // The cacheFresh check enforces a 7-day age gate via `(now - cacheWrittenAt)
+    // < MAX_CACHE_AGE_MS`. The deferred-stale fallback MUST enforce the same
+    // gate, otherwise a country repeatedly deferred across enough runs while
+    // upstream was frozen >4 days could publish data older than the intended
+    // hard-drop threshold (window-drift). Greptile review P1 on PR #3676.
+    //
+    // Assert the age comparison appears inside the cap block (between the
+    // shuffle and the needsFetch reassignment) — using a multi-line regex
+    // that requires shuffle → cacheWrittenAt → MAX_CACHE_AGE_MS in order.
+    const capBlock = src.match(
+      /needsFetch\.length\s*>\s*MAX_COLD_FETCH_PER_RUN[\s\S]+?needsFetch\s*=\s*shuffled\.slice/,
+    );
+    assert.ok(capBlock, 'cap block found');
+    assert.match(
+      capBlock[0],
+      /cacheWrittenAt[\s\S]{0,200}MAX_CACHE_AGE_MS/,
+      'deferred-stale path must compare prev.cacheWrittenAt against MAX_CACHE_AGE_MS',
+    );
+    // And the failure-bucket counter exists so operators can see how many
+    // countries dropped via the age gate (vs no-cache).
+    assert.match(src, /droppedTooOld/);
   });
 
   it('partition path captures prevPayload alongside iso3/iso2/upstreamMaxDate', () => {
@@ -736,11 +760,36 @@ describe('cold-fetch cap prevents 174-country cliff (WM 2026-05-13)', () => {
   it('cap logs refresh count + defer count for operator visibility', () => {
     // When the cap fires, an operator hitting `/api/health?history=1` and
     // pulling the Railway log needs to see "X refreshing, Y deferred on
-    // stale cache, Z dropped" — without that, "everything looked fine"
-    // (174 records published) masks that 144 of them are a window behind.
+    // stale cache, Z dropped (cache too old), W dropped (no prior payload)"
+    // — without per-bucket counts, "everything looked fine" (174 records
+    // published) would mask that some are a window behind and some are
+    // beyond the hard-drop threshold.
     assert.match(src, /Cold-fetch capped/);
     assert.match(src, /refreshing/);
     assert.match(src, /\$\{servedStale\}/);
+    assert.match(src, /\$\{droppedTooOld\}/);
+    assert.match(src, /\$\{droppedNoCache\}/);
+  });
+
+  it('rotation arithmetic uses MAX_COLD_FETCH_PER_RUN directly, not needsFetch.length (Greptile P2)', () => {
+    // After `needsFetch = shuffled.slice(0, MAX_COLD_FETCH_PER_RUN)`,
+    // `needsFetch.length` numerically equals MAX_COLD_FETCH_PER_RUN — so the
+    // pre-fix arithmetic was coincidentally correct. But if the log block
+    // is ever reordered above the reassignment (or the cap value changes
+    // dynamically), `needsFetch.length` would silently break. Using the
+    // constant directly makes the intent unambiguous. Greptile review P2
+    // on PR #3676.
+    const capBlock = src.match(
+      /needsFetch\.length\s*>\s*MAX_COLD_FETCH_PER_RUN[\s\S]+?Rotation:/,
+    );
+    assert.ok(capBlock, 'cap block found');
+    // The rotation expression must reference MAX_COLD_FETCH_PER_RUN, not
+    // needsFetch.length, in its numerator/denominator.
+    assert.match(
+      capBlock[0],
+      /originalMisses\s*=\s*MAX_COLD_FETCH_PER_RUN/,
+      'rotation total must be expressed as cap + stale + dropped, using the constant',
+    );
   });
 
   it('needsFetch is declared with let (mutable) — cap path reassigns it', () => {

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -691,3 +691,78 @@ describe('resolveArcgisDateField (runtime, schema-flap defence)', () => {
     } finally { restoreFetch(); }
   });
 });
+
+// WM 2026-05-13 incident: when upstream advanced ArcGIS data after two days of
+// "frozen" runs, every cached country's `asof` mismatched, producing a
+// 174-country cold-fetch. The 570s bundle budget couldn't cover it (preflight
+// alone took 360s; batch 1 of 15 hit 12 errors at 45s before SIGTERM).
+// Result: 37 hours of stale data + UptimeRobot WARNING.
+//
+// Fix: cap cold-fetches per run; serve the deferred countries from prior
+// (slightly-stale) cache rather than dropping them. Full rotation across
+// ~ceil(N / cap) runs.
+describe('cold-fetch cap prevents 174-country cliff (WM 2026-05-13)', () => {
+  it('MAX_COLD_FETCH_PER_RUN constant is declared with a sane value', () => {
+    // The cap value must allow the cold-fetch loop to fit comfortably inside
+    // the 570s bundle budget at the observed ~3-5s/country with concurrency
+    // 12. 30 × 5s / 12 ≈ 13s — well under budget, with plenty of room for
+    // preflight + write phases.
+    assert.match(src, /const MAX_COLD_FETCH_PER_RUN\s*=\s*30/);
+  });
+
+  it('cap triggers when needsFetch exceeds the cap (not a no-op)', () => {
+    // The guard must be a > comparison so a needsFetch of EXACTLY the cap
+    // doesn't trigger the partition path (which would create an unnecessary
+    // shuffle/log line for the happy case where everything fits).
+    assert.match(src, /if\s*\(\s*needsFetch\.length\s*>\s*MAX_COLD_FETCH_PER_RUN\s*\)/);
+  });
+
+  it('deferred countries are served from prior payload with staleAsof=true', () => {
+    // Without this fallback, a deferred country DROPS from the canonical
+    // output — that's the same as a hard-fail for the consumer. Marking
+    // staleAsof preserves the country's data shape but signals "one window
+    // behind" so downstream can render or warn accordingly.
+    assert.match(src, /prevPayload[\s\S]{0,200}staleAsof:\s*true/);
+  });
+
+  it('partition path captures prevPayload alongside iso3/iso2/upstreamMaxDate', () => {
+    // The needsFetch entries gained a 4th field (prevPayload) so the cap
+    // logic can fall back to cached data per-country. Pre-fix the entries
+    // were {iso3, iso2, upstreamMaxDate} — adding prevPayload is the
+    // critical contract change for the deferred-serving path.
+    assert.match(src, /needsFetch\.push\(\{\s*iso3,\s*iso2,\s*upstreamMaxDate,\s*prevPayload:\s*prev\s*\}\)/);
+  });
+
+  it('cap logs refresh count + defer count for operator visibility', () => {
+    // When the cap fires, an operator hitting `/api/health?history=1` and
+    // pulling the Railway log needs to see "X refreshing, Y deferred on
+    // stale cache, Z dropped" — without that, "everything looked fine"
+    // (174 records published) masks that 144 of them are a window behind.
+    assert.match(src, /Cold-fetch capped/);
+    assert.match(src, /refreshing/);
+    assert.match(src, /\$\{servedStale\}/);
+  });
+
+  it('needsFetch is declared with let (mutable) — cap path reassigns it', () => {
+    // The cap path slices needsFetch to keep only the refresh-now subset.
+    // Pre-fix needsFetch was const. This regression-guards a future cleanup
+    // that switches it back without realizing the cap path mutates it.
+    assert.match(src, /let needsFetch\s*=\s*\[\]/);
+    // And the reassignment in the cap path:
+    assert.match(src, /needsFetch\s*=\s*shuffled\.slice\(0,\s*MAX_COLD_FETCH_PER_RUN\)/);
+  });
+
+  it('full rotation is computable: ~ceil(174 / 30) = 6 runs ≈ 3 days at 12h cadence', () => {
+    // Documentation-grade test: encodes the rotation math so a future
+    // bump to the cap (or a different country count) surfaces the
+    // implication via failure rather than silent drift.
+    const cap = 30;
+    const countries = 174;
+    const cronIntervalHours = 12;
+    const runs = Math.ceil(countries / cap);
+    const fullRotationHours = runs * cronIntervalHours;
+    assert.equal(runs, 6);
+    assert.equal(fullRotationHours, 72, 'full rotation must stay under MAX_CACHE_AGE_MS (7d = 168h)');
+    assert.ok(fullRotationHours < 168, 'rotation must complete before MAX_CACHE_AGE_MS forces hard drops');
+  });
+});


### PR DESCRIPTION
## Summary

Resolves WM 2026-05-13 incident where `portwatchPortActivity` went `STALE_SEED` for 37 hours after a single upstream-advance event triggered a 174-country cold-fetch that couldn't complete inside the 570s bundle budget.

## Evidence

Three consecutive cron runs from the Railway log (`portwatch-port-activity-seed`):

```
2026-05-11 00:05 UTC ✓ Cache: 174 hits, 0 misses, Done in 11.2s
2026-05-12 00:03 UTC ✓ Cache: 174 hits, 0 misses, Done in 10.3s   ← upstream frozen, TTLs all sync'd
2026-05-13 00:04 UTC ✗ Cache: 0 hits, 174 misses
                        Preflight maxDate for 174 countries (360.3s)
                        Activity queue: 174 countries (skipped 0 via cache, ...)
                        batch 1/15: 0 countries published, 12 errors (45.0s)
                        [log truncates — bundle SIGKILL at 570s cap]
```

The "all-cache-hits" runs **re-wrote** all 174 country keys with the same 3d TTL, keeping their expirations synchronized. When ArcGIS finally advanced its data on May 13, every cached country's `asof` field mismatched the new `upstreamMaxDate` — flipping all 174 from HIT to MISS simultaneously. The cold-fetch couldn't complete in 570s.

This is exactly the pattern documented in the existing memory `per-item-cache-cliff-masks-upstream-regression` (2026-05-06), applied to a different cache-invalidation axis: TTL was fine here, but asof-sync produced the same effective cliff.

## Fix

Introduce `MAX_COLD_FETCH_PER_RUN = 30`. When `needsFetch.length > cap`:

1. Random-shuffle the misses (Fisher-Yates)
2. Refresh the first `cap` countries via the normal expensive path
3. Serve the rest from prior cache marked `staleAsof: true`
4. Log: "refreshing N, serving M on stale cache, X dropped"

`needsFetch` entries gain a `prevPayload` field so per-country fallback works.

```js
const MAX_COLD_FETCH_PER_RUN = 30;
// ...
if (needsFetch.length > MAX_COLD_FETCH_PER_RUN) {
  const shuffled = fisherYates([...needsFetch]);
  const deferred = shuffled.slice(MAX_COLD_FETCH_PER_RUN);
  for (const item of deferred) {
    if (item.prevPayload && typeof item.prevPayload === 'object') {
      countryData.set(item.iso2, { ...item.prevPayload, staleAsof: true });
    }
  }
  needsFetch = shuffled.slice(0, MAX_COLD_FETCH_PER_RUN);
  console.warn(`Cold-fetch capped at ${MAX_COLD_FETCH_PER_RUN}/run — refreshing ${needsFetch.length}, serving ${servedStale} stale, ${droppedNoCache} dropped`);
}
```

## Math

| Metric | Value |
|---|---|
| Cold-fetch budget consumed | 30 × ~5s × 1/concurrency=12 ≈ **13s** (well under 570s) |
| Countries per rotation | 30 |
| Total countries | 174 |
| Runs to full rotation | ceil(174 / 30) = **6** |
| Time to full rotation @ 12h cadence | 72h ≈ 3 days |
| MAX_CACHE_AGE_MS (hard drop threshold) | 7d (168h) |
| Safety margin | 72h vs 168h = **2.3× headroom** before any country ages out |

## Why not just bump the bundle budget?

I considered raising 570s → 900s, but:
- ArcGIS preflight alone took 360s in the incident — the slowness compounds with concurrency
- A worst-case cold-fetch (174 × 90s per-country cap / 12 concurrency) = 1305s, even at the new larger budget
- The cap is the actual structural fix; budget bumps are bandaid

The bundle budget stays at 570s.

## What this DOES NOT change

- `MAX_CACHE_AGE_MS` (7d) — countries past this still drop hard (same pre-fix behavior)
- Cache freshness criteria — same `asof === upstreamMaxDate` + age check
- Validate gate (`MIN_VALID_COUNTRIES = 50`) — same coverage requirement
- Degradation guard (>80% prev count) — same overwrite protection
- Lock, SIGTERM handler, circuit-breaker — all unchanged
- Per-country error logging (already streams to `errors[]` via eager `.catch`) — unchanged

## Test plan

- [x] `node --test tests/portwatch-port-activity-seed.test.mjs` — **77/77 pass** (was 70, +7 for the cap behavior)
  - Constant value pin (`MAX_COLD_FETCH_PER_RUN = 30`)
  - Trigger condition (`> cap`, not `>=`)
  - `staleAsof: true` marker on deferred countries
  - `prevPayload` field on needsFetch entries
  - Operator-visibility log line shape
  - `let needsFetch` (mutable) regression guard
  - Rotation math: 6 runs × 12h < 168h MAX_CACHE_AGE_MS
- [x] `node --check scripts/seed-portwatch-port-activity.mjs` — syntax OK
- [ ] Post-merge: monitor `/api/health?history=1` for the next 7 days. Expectation: no more 37h gaps. Brief flips OK only if MORE than 30 countries miss in the same single run cadence.

## Operator action AFTER merge

The current Redis state still has the 174 country keys cached. Once the seeder ships and Railway redeploys, the next 00:0X UTC run will:
1. See the post-incident cache (whatever survived)
2. Compare against current `upstreamMaxDate`
3. Apply the cap if too many are stale

If you want to force a clean cold-fetch right now (before merge lands), running `node scripts/seed-portwatch-port-activity.mjs` locally with prod env vars and no bundle budget will populate the cache cleanly (likely 1-2 min runtime without the 570s ceiling).

## Companion

Sixth PR in this week's resilience series. The previous five fixed budget knobs sized at the safety floor; this one fixes a structural failure mode that no budget knob can solve.

| PR | Surface | Fix shape |
|---|---|---|
| #3640 | correlationCards + hyperliquidFlow | budget 3× → 6× |
| #3641 | `/api/health?history=1` | diagnostic surface |
| #3649 | digest:replay-log LTRIM cap | unbounded-list guard |
| #3650 | atomicPublish retry-on-transient | absorb 48s timeout |
| #3652 | resilienceIntervals/Ranking | budget 2× → 2.33× |
| #3671 | gdeltIntel | budget 1.16× → 2× |
| **This PR** | **portwatch-port-activity** | **per-run cold-fetch cap** |