### PR TITLE
fix(billing): structured NO_CUSTOMER + self-heal customers row gap

### DIFF
--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -18,18 +18,20 @@ async function seedSubscription(
     status: "active" | "on_hold" | "cancelled" | "expired";
     currentPeriodEnd: number;
     suffix: string;
+    rawPayload?: unknown;
+    userId?: string;
   },
 ) {
   await t.run(async (ctx) => {
     await ctx.db.insert("subscriptions", {
-      userId: TEST_USER_ID,
+      userId: opts.userId ?? TEST_USER_ID,
       dodoSubscriptionId: `sub_billing_${opts.suffix}`,
       dodoProductId: opts.dodoProductId,
       planKey: opts.planKey,
       status: opts.status,
       currentPeriodStart: NOW - DAY_MS,
       currentPeriodEnd: opts.currentPeriodEnd,
-      rawPayload: {},
+      rawPayload: opts.rawPayload ?? {},
       updatedAt: NOW,
     });
   });
@@ -168,5 +170,295 @@ describe("payments billing duplicate-checkout guard", () => {
     );
 
     expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// repairCustomerFromSubscriptionPayload — self-heal data-integrity gap
+//
+// Webhook handler at `subscriptionHelpers.ts:520-549` writes the
+// `customers` row only when `data.customer?.customer_id` is present in the
+// webhook payload. Users whose `subscription.active` delivery omitted that
+// field end up entitled (active sub written) but with no portal-resolvable
+// customer row. WORLDMONITOR-R5 surfaced this for an active Pro Annual
+// user — clicking "Manage Billing" threw `NO_CUSTOMER`. This repair runs
+// at portal-open time and recovers the dodoCustomerId from the
+// subscription's `rawPayload`.
+// ---------------------------------------------------------------------------
+
+describe("payments billing repairCustomerFromSubscriptionPayload", () => {
+  test("inserts a customers row from rawPayload.customer.customer_id and returns it", async () => {
+    const t = convexTest(schema, modules);
+    await seedSubscription(t, {
+      planKey: "pro_annual",
+      dodoProductId: PRODUCT_CATALOG.pro_annual.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "repair_happy",
+      rawPayload: {
+        customer: { customer_id: "cus_recovered_001", email: "Repair@Example.com" },
+      },
+    });
+
+    const result = await t.mutation(
+      internal.payments.billing.repairCustomerFromSubscriptionPayload,
+      { userId: TEST_USER_ID },
+    );
+
+    expect(result).toMatchObject({
+      userId: TEST_USER_ID,
+      dodoCustomerId: "cus_recovered_001",
+      email: "Repair@Example.com",
+      // normalizedEmail mirrors `email.trim().toLowerCase()` — required for
+      // O(1) email joins against `registrations`/`emailSuppressions`.
+      normalizedEmail: "repair@example.com",
+    });
+
+    // Confirm the row landed in the table — a second call should idempotently
+    // return the same row rather than insert a duplicate.
+    const second = await t.mutation(
+      internal.payments.billing.repairCustomerFromSubscriptionPayload,
+      { userId: TEST_USER_ID },
+    );
+    expect(second?.dodoCustomerId).toBe("cus_recovered_001");
+    expect(second?._id).toBe(result?._id);
+  });
+
+  test("returns null when no subscription payload carries a customer_id", async () => {
+    const t = convexTest(schema, modules);
+    await seedSubscription(t, {
+      planKey: "pro_annual",
+      dodoProductId: PRODUCT_CATALOG.pro_annual.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "repair_no_payload",
+      // Empty payload — exactly the symptomatic case behind WORLDMONITOR-R5.
+      rawPayload: {},
+    });
+
+    const result = await t.mutation(
+      internal.payments.billing.repairCustomerFromSubscriptionPayload,
+      { userId: TEST_USER_ID },
+    );
+    expect(result).toBeNull();
+  });
+
+  test("returns null when the user has no subscriptions at all", async () => {
+    const t = convexTest(schema, modules);
+    const result = await t.mutation(
+      internal.payments.billing.repairCustomerFromSubscriptionPayload,
+      { userId: TEST_USER_ID },
+    );
+    expect(result).toBeNull();
+  });
+
+  test("prefers active subscription's payload over cancelled when both exist", async () => {
+    const t = convexTest(schema, modules);
+    await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+      status: "cancelled",
+      currentPeriodEnd: NOW - 7 * DAY_MS,
+      suffix: "repair_old_cancelled",
+      rawPayload: { customer: { customer_id: "cus_stale_old", email: "old@example.com" } },
+    });
+    await seedSubscription(t, {
+      planKey: "pro_annual",
+      dodoProductId: PRODUCT_CATALOG.pro_annual.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "repair_active",
+      rawPayload: { customer: { customer_id: "cus_active_winner", email: "new@example.com" } },
+    });
+
+    const result = await t.mutation(
+      internal.payments.billing.repairCustomerFromSubscriptionPayload,
+      { userId: TEST_USER_ID },
+    );
+    expect(result?.dodoCustomerId).toBe("cus_active_winner");
+  });
+
+  test("refuses to remap when the dodoCustomerId already belongs to a different userId", async () => {
+    const t = convexTest(schema, modules);
+
+    // A pre-existing customers row already maps cus_collision_001 to another user.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("customers", {
+        userId: "user_other_owner",
+        dodoCustomerId: "cus_collision_001",
+        email: "other@example.com",
+        normalizedEmail: "other@example.com",
+        createdAt: NOW - DAY_MS,
+        updatedAt: NOW - DAY_MS,
+      });
+    });
+
+    // TEST_USER_ID's subscription rawPayload happens to carry the same dodoCustomerId
+    // — cross-user collision. The repair must refuse rather than silently remap.
+    await seedSubscription(t, {
+      planKey: "pro_annual",
+      dodoProductId: PRODUCT_CATALOG.pro_annual.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "repair_collision",
+      rawPayload: { customer: { customer_id: "cus_collision_001", email: "x@x.com" } },
+    });
+
+    const result = await t.mutation(
+      internal.payments.billing.repairCustomerFromSubscriptionPayload,
+      { userId: TEST_USER_ID },
+    );
+    expect(result).toBeNull();
+
+    // Defensive: confirm the original mapping was NOT clobbered.
+    const stillOriginal = await t.run(async (ctx) =>
+      ctx.db
+        .query("customers")
+        .withIndex("by_dodoCustomerId", (q) => q.eq("dodoCustomerId", "cus_collision_001"))
+        .first(),
+    );
+    expect(stillOriginal?.userId).toBe("user_other_owner");
+  });
+
+  test("ignores non-string customer_id values (defensive)", async () => {
+    const t = convexTest(schema, modules);
+    await seedSubscription(t, {
+      planKey: "pro_annual",
+      dodoProductId: PRODUCT_CATALOG.pro_annual.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "repair_bad_shape",
+      // customer_id present but typed wrong (number) — guard rejects, walk continues.
+      rawPayload: { customer: { customer_id: 42, email: "n@example.com" } },
+    });
+
+    const result = await t.mutation(
+      internal.payments.billing.repairCustomerFromSubscriptionPayload,
+      { userId: TEST_USER_ID },
+    );
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// backfillMissingCustomers — proactive one-shot sweep for the same gap.
+//
+// The portal-open repair fixes affected users on their NEXT click, but the
+// gap is silent until they click. The backfill closes that exposure by
+// scanning every user with a subscription and repairing missing customers
+// rows in one transaction. Idempotent: a second pass is a no-op.
+// ---------------------------------------------------------------------------
+
+describe("payments billing backfillMissingCustomers", () => {
+  test("repairs users with subscriptions but no customers row, leaves healthy users alone", async () => {
+    const t = convexTest(schema, modules);
+
+    // User A — needs repair (active sub, payload has customer_id, no row yet)
+    await seedSubscription(t, {
+      planKey: "pro_annual",
+      dodoProductId: PRODUCT_CATALOG.pro_annual.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "backfill_user_a",
+      userId: "user_backfill_a",
+      rawPayload: { customer: { customer_id: "cus_a", email: "a@example.com" } },
+    });
+
+    // User B — already healthy (customers row exists, should be skipped)
+    await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "backfill_user_b",
+      userId: "user_backfill_b",
+      rawPayload: { customer: { customer_id: "cus_b", email: "b@example.com" } },
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("customers", {
+        userId: "user_backfill_b",
+        dodoCustomerId: "cus_b",
+        email: "b@example.com",
+        normalizedEmail: "b@example.com",
+        createdAt: NOW - DAY_MS,
+        updatedAt: NOW - DAY_MS,
+      });
+    });
+
+    // User C — unresolvable (sub exists but rawPayload has no customer_id)
+    await seedSubscription(t, {
+      planKey: "pro_annual",
+      dodoProductId: PRODUCT_CATALOG.pro_annual.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "backfill_user_c",
+      userId: "user_backfill_c",
+      rawPayload: {},
+    });
+
+    const summary = await t.mutation(
+      internal.payments.billing.backfillMissingCustomers,
+      {},
+    );
+
+    expect(summary).toMatchObject({
+      usersInspected: 3,
+      alreadyHadCustomer: 1,
+      repaired: 1,
+      couldNotRepair: 1,
+      unresolved: ["user_backfill_c"],
+    });
+
+    // Confirm A now has a customers row with the right dodoCustomerId.
+    const aCustomer = await t.run(async (ctx) =>
+      ctx.db
+        .query("customers")
+        .withIndex("by_userId", (q) => q.eq("userId", "user_backfill_a"))
+        .first(),
+    );
+    expect(aCustomer?.dodoCustomerId).toBe("cus_a");
+
+    // Confirm B was not duplicated.
+    const bCustomers = await t.run(async (ctx) =>
+      ctx.db
+        .query("customers")
+        .withIndex("by_userId", (q) => q.eq("userId", "user_backfill_b"))
+        .collect(),
+    );
+    expect(bCustomers.length).toBe(1);
+
+    // Confirm C has no customers row.
+    const cCustomer = await t.run(async (ctx) =>
+      ctx.db
+        .query("customers")
+        .withIndex("by_userId", (q) => q.eq("userId", "user_backfill_c"))
+        .first(),
+    );
+    expect(cCustomer).toBeNull();
+  });
+
+  test("is idempotent — second pass reports zero new repairs", async () => {
+    const t = convexTest(schema, modules);
+    await seedSubscription(t, {
+      planKey: "pro_annual",
+      dodoProductId: PRODUCT_CATALOG.pro_annual.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "backfill_idempotent",
+      userId: "user_idem_001",
+      rawPayload: { customer: { customer_id: "cus_idem", email: "i@example.com" } },
+    });
+
+    const first = await t.mutation(
+      internal.payments.billing.backfillMissingCustomers,
+      {},
+    );
+    expect(first).toMatchObject({ repaired: 1, alreadyHadCustomer: 0 });
+
+    const second = await t.mutation(
+      internal.payments.billing.backfillMissingCustomers,
+      {},
+    );
+    expect(second).toMatchObject({ repaired: 0, alreadyHadCustomer: 1 });
   });
 });

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -320,6 +320,83 @@ describe("payments billing repairCustomerFromSubscriptionPayload", () => {
     expect(stillOriginal?.userId).toBe("user_other_owner");
   });
 
+  test("patches existing customers row that lacks dodoCustomerId instead of inserting a duplicate", async () => {
+    // Greptile P1 — a customers row can exist for this userId without a
+    // dodoCustomerId (the field is v.optional). Repair must update the
+    // existing row, NOT insert a second one that getCustomerByUserId's
+    // .first() would silently shadow.
+    const t = convexTest(schema, modules);
+
+    const existingId = await t.run(async (ctx) =>
+      ctx.db.insert("customers", {
+        userId: TEST_USER_ID,
+        // dodoCustomerId intentionally omitted (v.optional schema state)
+        email: "old@example.com",
+        normalizedEmail: "old@example.com",
+        createdAt: NOW - DAY_MS,
+        updatedAt: NOW - DAY_MS,
+      }),
+    );
+
+    await seedSubscription(t, {
+      planKey: "pro_annual",
+      dodoProductId: PRODUCT_CATALOG.pro_annual.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "repair_patches_existing",
+      rawPayload: {
+        customer: { customer_id: "cus_patched_001", email: "fresh@example.com" },
+      },
+    });
+
+    const result = await t.mutation(
+      internal.payments.billing.repairCustomerFromSubscriptionPayload,
+      { userId: TEST_USER_ID },
+    );
+
+    expect(result?._id).toBe(existingId);
+    expect(result?.dodoCustomerId).toBe("cus_patched_001");
+    expect(result?.email).toBe("fresh@example.com");
+
+    // Exactly ONE customers row for this user — duplicate-avoidance verified.
+    const rowsForUser = await t.run(async (ctx) =>
+      ctx.db
+        .query("customers")
+        .withIndex("by_userId", (q) => q.eq("userId", TEST_USER_ID))
+        .collect(),
+    );
+    expect(rowsForUser.length).toBe(1);
+  });
+
+  test("does NOT blank out a pre-existing email when payload email is missing", async () => {
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) =>
+      ctx.db.insert("customers", {
+        userId: TEST_USER_ID,
+        email: "keep@example.com",
+        normalizedEmail: "keep@example.com",
+        createdAt: NOW - DAY_MS,
+        updatedAt: NOW - DAY_MS,
+      }),
+    );
+    await seedSubscription(t, {
+      planKey: "pro_annual",
+      dodoProductId: PRODUCT_CATALOG.pro_annual.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "repair_preserves_email",
+      rawPayload: { customer: { customer_id: "cus_emailless" } },
+    });
+
+    const result = await t.mutation(
+      internal.payments.billing.repairCustomerFromSubscriptionPayload,
+      { userId: TEST_USER_ID },
+    );
+    expect(result?.dodoCustomerId).toBe("cus_emailless");
+    expect(result?.email).toBe("keep@example.com");
+    expect(result?.normalizedEmail).toBe("keep@example.com");
+  });
+
   test("ignores non-string customer_id values (defensive)", async () => {
     const t = convexTest(schema, modules);
     await seedSubscription(t, {
@@ -435,6 +512,51 @@ describe("payments billing backfillMissingCustomers", () => {
         .first(),
     );
     expect(cCustomer).toBeNull();
+  });
+
+  test("patches an existing customers row that lacks dodoCustomerId instead of inserting a duplicate", async () => {
+    // Greptile P1 (backfill path): same duplicate-avoidance contract as
+    // the portal-open repair — when the outer `existing` lookup finds a
+    // row without dodoCustomerId, patch it rather than inserting.
+    const t = convexTest(schema, modules);
+
+    const existingId = await t.run(async (ctx) =>
+      ctx.db.insert("customers", {
+        userId: "user_backfill_patch",
+        // dodoCustomerId intentionally omitted
+        email: "stale@example.com",
+        normalizedEmail: "stale@example.com",
+        createdAt: NOW - DAY_MS,
+        updatedAt: NOW - DAY_MS,
+      }),
+    );
+
+    await seedSubscription(t, {
+      planKey: "pro_annual",
+      dodoProductId: PRODUCT_CATALOG.pro_annual.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "backfill_patch",
+      userId: "user_backfill_patch",
+      rawPayload: { customer: { customer_id: "cus_backfill_patch", email: "n@example.com" } },
+    });
+
+    const summary = await t.mutation(
+      internal.payments.billing.backfillMissingCustomers,
+      {},
+    );
+    expect(summary).toMatchObject({ repaired: 1, alreadyHadCustomer: 0 });
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db
+        .query("customers")
+        .withIndex("by_userId", (q) => q.eq("userId", "user_backfill_patch"))
+        .collect(),
+    );
+    expect(rows.length).toBe(1);
+    expect(rows[0]?._id).toBe(existingId);
+    expect(rows[0]?.dodoCustomerId).toBe("cus_backfill_patch");
+    expect(rows[0]?.email).toBe("n@example.com");
   });
 
   test("is idempotent — second pass reports zero new repairs", async () => {

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -9,7 +9,7 @@
  * - claimSubscription: mutation to migrate entitlements from anon ID to authed user
  */
 
-import { v } from "convex/values";
+import { ConvexError, v } from "convex/values";
 import { action, mutation, query, internalAction, internalMutation, internalQuery, type ActionCtx } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { DodoPayments } from "dodopayments";
@@ -39,7 +39,11 @@ const ANON_ID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[
 function getDodoClient(): DodoPayments {
   const apiKey = process.env.DODO_API_KEY;
   if (!apiKey) {
-    throw new Error("[billing] DODO_API_KEY not set — cannot call Dodo API");
+    // Structured throw (object-typed `data`) so the client receives
+    // `err.data.kind` instead of an opaque `[Request ID: X] Server Error`
+    // (Convex's HTTP runtime drops `errorData` for string-data throws).
+    // Surfaces a config drift bug at error level so on-call sees the real cause.
+    throw new ConvexError({ kind: "DODO_API_KEY_MISSING" });
   }
   const isLive = process.env.DODO_PAYMENTS_ENVIRONMENT === "live_mode";
   return new DodoPayments({
@@ -49,16 +53,37 @@ function getDodoClient(): DodoPayments {
 }
 
 async function createCustomerPortalUrlForUser(
-  ctx: Pick<ActionCtx, "runQuery">,
+  ctx: Pick<ActionCtx, "runQuery" | "runMutation">,
   userId: string,
 ): Promise<{ portal_url: string }> {
-  const customer = await ctx.runQuery(
+  let customer = await ctx.runQuery(
     internal.payments.billing.getCustomerByUserId,
     { userId },
   );
 
   if (!customer || !customer.dodoCustomerId) {
-    throw new Error("No Dodo customer found for this user");
+    // Self-heal a known webhook gap: `subscription.active` writes the
+    // `subscriptions` row unconditionally but only writes `customers` when
+    // `data.customer?.customer_id` is present in the payload
+    // (`subscriptionHelpers.ts:525`). Users whose webhook delivery
+    // lacked the customer field end up entitled (active sub) but with no
+    // customers row — clicking "Manage Billing" throws NO_CUSTOMER. The
+    // subscription's `rawPayload` carries the same customer info though,
+    // so try to recover from there before giving up. WORLDMONITOR-R5
+    // (user_3DcpiviTIweanCi9BtF5PRpqwv6 — active Pro Annual, no customers row).
+    customer = await ctx.runMutation(
+      internal.payments.billing.repairCustomerFromSubscriptionPayload,
+      { userId },
+    );
+  }
+
+  if (!customer || !customer.dodoCustomerId) {
+    // Genuine no-customer state — recovery from subscription payload
+    // didn't yield a dodoCustomerId either. Throw structured so the
+    // client can surface a useful "contact support" toast (object-typed
+    // `data` so `err.data.kind` survives the wire — see
+    // `api/_convex-error.js` for the broader pattern).
+    throw new ConvexError({ kind: "NO_CUSTOMER" });
   }
 
   const client = getDodoClient();
@@ -152,9 +177,232 @@ export const getCustomerByUserId = internalQuery({
 });
 
 /**
+ * Last-resort repair when an entitled user has no `customers` row.
+ *
+ * The Dodo `subscription.active` handler writes the `subscriptions` row
+ * unconditionally but only writes `customers` when `data.customer?.customer_id`
+ * is present in the webhook payload (`subscriptionHelpers.ts:525`). Webhook
+ * deliveries that omitted the customer field leave the user entitled but with
+ * no portal-resolvable record — clicking "Manage Billing" then throws
+ * `NO_CUSTOMER`.
+ *
+ * The subscription row carries the full webhook payload in `rawPayload`, so
+ * the dodoCustomerId is recoverable from there. Walk the user's
+ * subscriptions newest-first (preferring `active`, then `on_hold` or
+ * `cancelled`), find the first one whose `rawPayload.customer.customer_id`
+ * is a string, and upsert a customers row from it. Logs at warning level so
+ * a sustained repair rate is queryable in Convex logs — that's the signal
+ * to harden the webhook handler.
+ *
+ * Returns the resulting `customers` document, or null if no payload yielded
+ * a usable dodoCustomerId (or the dodoCustomerId already maps to a
+ * different userId, which is a distinct cross-user integrity issue we
+ * deliberately don't auto-overwrite).
+ */
+export const repairCustomerFromSubscriptionPayload = internalMutation({
+  args: { userId: v.string() },
+  handler: async (ctx, args) => {
+    const subs = await ctx.db
+      .query("subscriptions")
+      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+      .take(50);
+
+    // Prefer active → on_hold → cancelled, then newest updatedAt within tier.
+    const priority = (status: string): number =>
+      status === "active" ? 0 :
+      status === "on_hold" ? 1 :
+      status === "cancelled" ? 2 :
+      3;
+    subs.sort((a, b) => {
+      const pa = priority(a.status);
+      const pb = priority(b.status);
+      if (pa !== pb) return pa - pb;
+      return b.updatedAt - a.updatedAt;
+    });
+
+    for (const sub of subs) {
+      const payload = sub.rawPayload as
+        | { customer?: { customer_id?: unknown; email?: unknown } }
+        | null
+        | undefined;
+      const rawId = payload?.customer?.customer_id;
+      const dodoCustomerId = typeof rawId === "string" && rawId.length > 0 ? rawId : null;
+      if (!dodoCustomerId) continue;
+
+      const rawEmail = payload?.customer?.email;
+      const email = typeof rawEmail === "string" ? rawEmail : "";
+      const normalizedEmail = email.trim().toLowerCase();
+      const now = Date.now();
+
+      // If a customers row with this dodoCustomerId already exists for a
+      // DIFFERENT userId, don't auto-overwrite — that's a cross-user
+      // integrity issue (one Dodo customer mapped to two Clerk users)
+      // that deserves manual triage, not silent repair.
+      const existing = await ctx.db
+        .query("customers")
+        .withIndex("by_dodoCustomerId", (q) => q.eq("dodoCustomerId", dodoCustomerId))
+        .first();
+      if (existing) {
+        if (existing.userId !== args.userId) {
+          console.warn(
+            `[billing/repair] customers.dodoCustomerId=${dodoCustomerId} already mapped to userId=${existing.userId}; refusing to remap to userId=${args.userId}.`,
+          );
+          return null;
+        }
+        return existing;
+      }
+
+      console.warn(
+        `[billing/repair] Repairing missing customers row for userId=${args.userId} from subscription rawPayload (dodoSubscriptionId=${sub.dodoSubscriptionId}). Webhook gap — investigate subscriptionHelpers.ts:520-549.`,
+      );
+      const insertedId = await ctx.db.insert("customers", {
+        userId: args.userId,
+        dodoCustomerId,
+        email,
+        normalizedEmail,
+        createdAt: now,
+        updatedAt: now,
+      });
+      return await ctx.db.get(insertedId);
+    }
+
+    // No subscription payload carried a usable customer_id. Caller throws
+    // NO_CUSTOMER and the client shows a "contact support" toast.
+    return null;
+  },
+});
+
+/**
  * Internal query to retrieve the active subscription for a user.
  * Returns null if no subscription or if the subscription is cancelled/expired.
  */
+/**
+ * Operator-run backfill: proactively heal users affected by the
+ * `subscription.active → customers` webhook gap before they hit
+ * "Manage Billing" themselves.
+ *
+ * Walks every subscription, groups by `userId`, and for each user with at
+ * least one subscription but no `customers` row, invokes
+ * `repairCustomerFromSubscriptionPayload`. Returns a structured summary so
+ * the operator can verify how many users were repaired vs. how many
+ * couldn't be (e.g. rawPayload also lacked `customer_id`, which means
+ * support needs to manually re-link the user via Dodo's dashboard).
+ *
+ * Run:
+ *   npx convex run payments/billing:backfillMissingCustomers
+ *
+ * Idempotent — re-running after a successful pass is a no-op because every
+ * affected user now has a customers row.
+ *
+ * WORLDMONITOR-R5 surfaced this gap for one user; the backfill is the
+ * "find everyone else" sweep.
+ */
+export const backfillMissingCustomers = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    // Walk all subscriptions, dedupe to one userId per pass. .collect() is
+    // bounded by Convex's per-mutation read limit (~16k rows) which is
+    // fine for the current subscription volume; if this ever overflows
+    // we'd switch to paginate() — left as a follow-up because today's
+    // user base is well under the limit.
+    const allSubs = await ctx.db.query("subscriptions").collect();
+    const userIds = new Set<string>();
+    for (const sub of allSubs) userIds.add(sub.userId);
+
+    const summary = {
+      usersInspected: userIds.size,
+      alreadyHadCustomer: 0,
+      repaired: 0,
+      couldNotRepair: 0,
+      // userIds that need manual support touch — rawPayload didn't carry
+      // a usable customer_id and we refuse to silently fabricate one.
+      unresolved: [] as string[],
+    };
+
+    for (const userId of userIds) {
+      const existing = await ctx.db
+        .query("customers")
+        .withIndex("by_userId", (q) => q.eq("userId", userId))
+        .first();
+      if (existing?.dodoCustomerId) {
+        summary.alreadyHadCustomer++;
+        continue;
+      }
+      // Inline the repair logic rather than calling
+      // `repairCustomerFromSubscriptionPayload` so we stay inside a single
+      // mutation transaction (Convex doesn't allow mutations to invoke
+      // other mutations via runMutation — that's an action-only API).
+      const subs = await ctx.db
+        .query("subscriptions")
+        .withIndex("by_userId", (q) => q.eq("userId", userId))
+        .take(50);
+      const priority = (status: string): number =>
+        status === "active" ? 0 :
+        status === "on_hold" ? 1 :
+        status === "cancelled" ? 2 :
+        3;
+      subs.sort((a, b) => {
+        const pa = priority(a.status);
+        const pb = priority(b.status);
+        if (pa !== pb) return pa - pb;
+        return b.updatedAt - a.updatedAt;
+      });
+
+      let repairedThisUser = false;
+      for (const sub of subs) {
+        const payload = sub.rawPayload as
+          | { customer?: { customer_id?: unknown; email?: unknown } }
+          | null
+          | undefined;
+        const rawId = payload?.customer?.customer_id;
+        const dodoCustomerId = typeof rawId === "string" && rawId.length > 0 ? rawId : null;
+        if (!dodoCustomerId) continue;
+        const rawEmail = payload?.customer?.email;
+        const email = typeof rawEmail === "string" ? rawEmail : "";
+        const normalizedEmail = email.trim().toLowerCase();
+        const now = Date.now();
+        const collision = await ctx.db
+          .query("customers")
+          .withIndex("by_dodoCustomerId", (q) => q.eq("dodoCustomerId", dodoCustomerId))
+          .first();
+        if (collision) {
+          if (collision.userId !== userId) {
+            // Cross-user collision — refuse to remap. Logged for triage.
+            console.warn(
+              `[billing/backfill] cross-user collision: dodoCustomerId=${dodoCustomerId} already maps to userId=${collision.userId}; skipping userId=${userId}.`,
+            );
+            break;
+          }
+          repairedThisUser = true;
+          break;
+        }
+        await ctx.db.insert("customers", {
+          userId,
+          dodoCustomerId,
+          email,
+          normalizedEmail,
+          createdAt: now,
+          updatedAt: now,
+        });
+        console.warn(
+          `[billing/backfill] Inserted customers row for userId=${userId} from subscription dodoSubscriptionId=${sub.dodoSubscriptionId}.`,
+        );
+        repairedThisUser = true;
+        break;
+      }
+
+      if (repairedThisUser) {
+        summary.repaired++;
+      } else {
+        summary.couldNotRepair++;
+        summary.unresolved.push(userId);
+      }
+    }
+
+    return summary;
+  },
+});
+
 export const getActiveSubscription = internalQuery({
   args: { userId: v.string() },
   handler: async (ctx, args) => {
@@ -251,7 +499,7 @@ export const internalGetCustomerPortalUrl = internalAction({
   args: { userId: v.string() },
   handler: async (ctx, args) => {
     if (!args.userId) {
-      throw new Error("userId is required");
+      throw new ConvexError({ kind: "USER_ID_REQUIRED" });
     }
     return createCustomerPortalUrlForUser(ctx, args.userId);
   },

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -234,26 +234,47 @@ export const repairCustomerFromSubscriptionPayload = internalMutation({
       const normalizedEmail = email.trim().toLowerCase();
       const now = Date.now();
 
-      // If a customers row with this dodoCustomerId already exists for a
-      // DIFFERENT userId, don't auto-overwrite — that's a cross-user
-      // integrity issue (one Dodo customer mapped to two Clerk users)
-      // that deserves manual triage, not silent repair.
-      const existing = await ctx.db
+      // Cross-user collision check: if a customers row with this
+      // dodoCustomerId already exists for a DIFFERENT userId, don't
+      // auto-overwrite — that's a cross-user integrity issue (one Dodo
+      // customer mapped to two Clerk users) that deserves manual triage.
+      const collidingByDodo = await ctx.db
         .query("customers")
         .withIndex("by_dodoCustomerId", (q) => q.eq("dodoCustomerId", dodoCustomerId))
         .first();
-      if (existing) {
-        if (existing.userId !== args.userId) {
-          console.warn(
-            `[billing/repair] customers.dodoCustomerId=${dodoCustomerId} already mapped to userId=${existing.userId}; refusing to remap to userId=${args.userId}.`,
-          );
-          return null;
-        }
-        return existing;
+      if (collidingByDodo && collidingByDodo.userId !== args.userId) {
+        console.warn(
+          `[billing/repair] customers.dodoCustomerId=${dodoCustomerId} already mapped to userId=${collidingByDodo.userId}; refusing to remap to userId=${args.userId}.`,
+        );
+        return null;
+      }
+
+      // by_userId precedence: a row may already exist for this user
+      // WITHOUT a dodoCustomerId (the field is `v.optional(v.string())`
+      // so a null/missing value is a valid pre-existing schema state).
+      // In that case, PATCH the existing row instead of inserting a
+      // second one — `getCustomerByUserId` uses `.first()` defensively,
+      // so a duplicate row would be a silent orphan. Greptile P1 review.
+      const existingByUser = await ctx.db
+        .query("customers")
+        .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+        .first();
+      if (existingByUser) {
+        console.warn(
+          `[billing/repair] Patching dodoCustomerId=${dodoCustomerId} into existing customers row for userId=${args.userId} (dodoSubscriptionId=${sub.dodoSubscriptionId}). Webhook gap — investigate subscriptionHelpers.ts:520-549.`,
+        );
+        await ctx.db.patch(existingByUser._id, {
+          dodoCustomerId,
+          // Only refresh email/normalizedEmail when payload supplied one;
+          // never blank out a previously-populated value.
+          ...(email ? { email, normalizedEmail } : {}),
+          updatedAt: now,
+        });
+        return await ctx.db.get(existingByUser._id);
       }
 
       console.warn(
-        `[billing/repair] Repairing missing customers row for userId=${args.userId} from subscription rawPayload (dodoSubscriptionId=${sub.dodoSubscriptionId}). Webhook gap — investigate subscriptionHelpers.ts:520-549.`,
+        `[billing/repair] Inserting customers row for userId=${args.userId} from subscription rawPayload (dodoSubscriptionId=${sub.dodoSubscriptionId}). Webhook gap — investigate subscriptionHelpers.ts:520-549.`,
       );
       const insertedId = await ctx.db.insert("customers", {
         userId: args.userId,
@@ -373,20 +394,38 @@ export const backfillMissingCustomers = internalMutation({
             );
             break;
           }
+          // by_dodoCustomerId match for the SAME user already covers
+          // the by_userId case for the dominant path. Count as repaired.
           repairedThisUser = true;
           break;
         }
-        await ctx.db.insert("customers", {
-          userId,
-          dodoCustomerId,
-          email,
-          normalizedEmail,
-          createdAt: now,
-          updatedAt: now,
-        });
-        console.warn(
-          `[billing/backfill] Inserted customers row for userId=${userId} from subscription dodoSubscriptionId=${sub.dodoSubscriptionId}.`,
-        );
+        // by_userId precedence: when `existing` row lacks `dodoCustomerId`
+        // (valid schema state since the field is `v.optional`), PATCH that
+        // row rather than inserting a second customers doc for the same
+        // user. `getCustomerByUserId` uses `.first()` defensively, so a
+        // duplicate would be a silent orphan. Greptile P1 review.
+        if (existing) {
+          console.warn(
+            `[billing/backfill] Patching dodoCustomerId=${dodoCustomerId} into existing customers row for userId=${userId} (dodoSubscriptionId=${sub.dodoSubscriptionId}).`,
+          );
+          await ctx.db.patch(existing._id, {
+            dodoCustomerId,
+            ...(email ? { email, normalizedEmail } : {}),
+            updatedAt: now,
+          });
+        } else {
+          await ctx.db.insert("customers", {
+            userId,
+            dodoCustomerId,
+            email,
+            normalizedEmail,
+            createdAt: now,
+            updatedAt: now,
+          });
+          console.warn(
+            `[billing/backfill] Inserted customers row for userId=${userId} from subscription dodoSubscriptionId=${sub.dodoSubscriptionId}.`,
+          );
+        }
         repairedThisUser = true;
         break;
       }

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -119,7 +119,17 @@ export class UnifiedSettings {
         // window.open inside openBillingPortal (which runs after an
         // await of the Convex action).
         const reservedWin = prereserveBillingPortalTab();
-        void openBillingPortal(reservedWin);
+        void openBillingPortal(reservedWin).then((result) => {
+          // NO_CUSTOMER: user is entitled but has no Dodo customer row
+          // (comp grant, restore race, or post-purge cancellation). Send
+          // them somewhere actionable instead of leaving them in a
+          // generic Dodo portal that won't recognise them.
+          if (result.outcome === 'no-customer') {
+            showToast(
+              'Subscription is managed outside Dodo. Email support@worldmonitor.app for help.',
+            );
+          }
+        });
         return;
       }
 
@@ -641,7 +651,13 @@ export class UnifiedSettings {
     if (isEntitled()) {
       this.close();
       const reservedWin = prereserveBillingPortalTab();
-      void openBillingPortal(reservedWin);
+      void openBillingPortal(reservedWin).then((result) => {
+        if (result.outcome === 'no-customer') {
+          showToast(
+            'Subscription is managed outside Dodo. Email support@worldmonitor.app for help.',
+          );
+        }
+      });
       return;
     }
     this.close();

--- a/src/services/_billing-error.ts
+++ b/src/services/_billing-error.ts
@@ -1,0 +1,38 @@
+/**
+ * Structured-error introspection for `payments/billing:getCustomerPortalUrl`.
+ *
+ * Mirrors the edge-runtime `extractConvexErrorKind` helper in
+ * `api/_convex-error.js`, scoped to the data shapes this Convex action
+ * produces: `{ kind: 'NO_CUSTOMER' | 'DODO_API_KEY_MISSING' |
+ * 'USER_ID_REQUIRED' }`.
+ *
+ * Zero deps so it can be unit-tested from `node --test` without pulling
+ * the rest of `src/services/billing.ts`' browser-only import graph
+ * (Sentry SDK, Convex client) into the test runner.
+ */
+
+/**
+ * Extract the structured `kind` field from a thrown Convex object-data
+ * ConvexError, falling back to a legacy substring match on the message
+ * during the deploy-ordering window where the browser bundle and the
+ * Convex action may briefly disagree on the throw shape.
+ *
+ * Returns null when neither path matches — letting the caller default
+ * unknown shapes to error-level Sentry capture.
+ */
+export function extractBillingErrorKind(err: unknown): string | null {
+  const data = (err as { data?: unknown } | null | undefined)?.data;
+  if (data && typeof data === 'object' && 'kind' in data) {
+    const kind = (data as Record<string, unknown>).kind;
+    if (typeof kind === 'string') return kind;
+  }
+  // Legacy substring fallback for the deploy-ordering window where the
+  // browser bundle ships ahead of the Convex action update (or vice-versa).
+  // Pre-fix, the action threw `new Error('No Dodo customer found for this
+  // user')`; if a stale Convex deployment is still serving that text we
+  // can still classify the event correctly. Removable once both layers
+  // have soaked on the structured-throw rollout.
+  const msg = err instanceof Error ? err.message : '';
+  if (/No Dodo customer found for this user/.test(msg)) return 'NO_CUSTOMER';
+  return null;
+}

--- a/src/services/billing.ts
+++ b/src/services/billing.ts
@@ -11,6 +11,7 @@
 
 import * as Sentry from '@sentry/browser';
 import { getConvexClient, getConvexApi } from './convex-client';
+import { extractBillingErrorKind } from './_billing-error';
 
 export interface SubscriptionInfo {
   planKey: string;
@@ -154,16 +155,37 @@ export function prereserveBillingPortalTab(): Window | null {
   return window.open('', '_blank', 'noopener,noreferrer');
 }
 
-export async function openBillingPortal(preopened?: Window | null): Promise<string | null> {
+export type OpenBillingPortalOutcome =
+  | { outcome: 'opened'; url: string }
+  | { outcome: 'no-customer' }
+  | { outcome: 'error' };
+
+export async function openBillingPortal(
+  preopened?: Window | null,
+): Promise<OpenBillingPortalOutcome> {
   const reservedWin = preopened ?? null;
-  const navigate = (url: string): string => {
+  const navigate = (url: string): { outcome: 'opened'; url: string } => {
     if (reservedWin && !reservedWin.closed) {
       reservedWin.location.href = url;
     } else {
       const fresh = window.open(url, '_blank', 'noopener,noreferrer');
       if (!fresh) window.location.assign(url);
     }
-    return url;
+    return { outcome: 'opened', url };
+  };
+
+  // NO_CUSTOMER means the user is entitled (comp grant, recently-restored
+  // sub, or sub state where Dodo already purged the customer row) but no
+  // Dodo customer record exists to open a portal session for. Navigating
+  // them to the generic Dodo portal (`customer.dodopayments.com`) is
+  // actively misleading — that portal won't recognise them. Close the
+  // pre-reserved tab and return a typed outcome so callers with an
+  // in-app toast surface (UnifiedSettings) can tell the user what
+  // happened. Callers that don't handle the outcome silently drop the
+  // pre-reserved tab — still better UX than landing in a stranger's
+  // portal. WORLDMONITOR-R5.
+  const closeReserved = (): void => {
+    if (reservedWin && !reservedWin.closed) reservedWin.close();
   };
 
   try {
@@ -181,11 +203,35 @@ export async function openBillingPortal(preopened?: Window | null): Promise<stri
     const url = (result?.portal_url as string | undefined) ?? DODO_PORTAL_FALLBACK_URL;
     return navigate(url);
   } catch (err) {
-    console.warn('[billing] Failed to get customer portal URL, falling back:', err);
+    // Convex object-data ConvexError surfaces `err.data.kind` reliably on the
+    // wire; string-data and plain-Error throws arrive as
+    // `[Request ID: X] Server Error` with `err.data === undefined`. Read kind
+    // and split severity: NO_CUSTOMER is EXPECTED for entitled users who
+    // have no Dodo customer row, so it shouldn't drown real config/SDK bugs
+    // in error-level alerts. Anything else (DODO_API_KEY_MISSING, Dodo SDK
+    // throw, network failure, unknown shape) stays at the default `error`
+    // level. WORLDMONITOR-R5.
+    const kind = extractBillingErrorKind(err);
+    const isNoCustomer = kind === 'NO_CUSTOMER';
+    const level: 'warning' | 'error' = isNoCustomer ? 'warning' : 'error';
+    const log = level === 'warning' ? console.warn : console.error;
+    log('[billing] Failed to get customer portal URL:', err);
     Sentry.captureException(
       normalizeCaughtError('openBillingPortal', err),
-      { tags: { component: 'dodo-billing', action: 'openBillingPortal' } },
+      {
+        tags: {
+          component: 'dodo-billing',
+          action: 'openBillingPortal',
+          ...(kind ? { billing_error_kind: kind } : {}),
+        },
+        level,
+      },
     );
+    if (isNoCustomer) {
+      closeReserved();
+      return { outcome: 'no-customer' };
+    }
     return navigate(DODO_PORTAL_FALLBACK_URL);
   }
 }
+

--- a/src/services/billing.ts
+++ b/src/services/billing.ts
@@ -157,8 +157,7 @@ export function prereserveBillingPortalTab(): Window | null {
 
 export type OpenBillingPortalOutcome =
   | { outcome: 'opened'; url: string }
-  | { outcome: 'no-customer' }
-  | { outcome: 'error' };
+  | { outcome: 'no-customer' };
 
 export async function openBillingPortal(
   preopened?: Window | null,

--- a/tests/billing-convex-error.test.mts
+++ b/tests/billing-convex-error.test.mts
@@ -1,0 +1,92 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractBillingErrorKind } from '../src/services/_billing-error.ts';
+
+// ---------------------------------------------------------------------------
+// extractBillingErrorKind — structured-error introspection for the
+// Convex action `payments/billing:getCustomerPortalUrl`.
+//
+// WORLDMONITOR-R5 surfaced as `ConvexError: [Request ID: X] Server Error`
+// because the action threw plain `Error("No Dodo customer found for this
+// user")`. Convex's HTTP runtime only forwards `errorData` for object-typed
+// throws, so the client received an opaque message with `err.data ===
+// undefined` and reported the event at error level even though the action
+// was just signalling an expected "free user with no Dodo customer row" state.
+//
+// Fix: throw `new ConvexError({ kind: 'NO_CUSTOMER' })` on the server,
+// read `err.data.kind` on the client to downgrade the Sentry capture.
+// ---------------------------------------------------------------------------
+
+describe('extractBillingErrorKind — structured-data path', () => {
+  it('reads NO_CUSTOMER from err.data.kind', () => {
+    const err = Object.assign(new Error('any message'), {
+      data: { kind: 'NO_CUSTOMER' },
+    });
+    assert.equal(extractBillingErrorKind(err), 'NO_CUSTOMER');
+  });
+
+  it('reads DODO_API_KEY_MISSING from err.data.kind', () => {
+    const err = Object.assign(new Error('any message'), {
+      data: { kind: 'DODO_API_KEY_MISSING' },
+    });
+    assert.equal(extractBillingErrorKind(err), 'DODO_API_KEY_MISSING');
+  });
+
+  it('reads USER_ID_REQUIRED from err.data.kind', () => {
+    const err = Object.assign(new Error(''), {
+      data: { kind: 'USER_ID_REQUIRED' },
+    });
+    assert.equal(extractBillingErrorKind(err), 'USER_ID_REQUIRED');
+  });
+
+  it('returns null when err.data.kind is non-string', () => {
+    const err = Object.assign(new Error(''), { data: { kind: 42 } });
+    assert.equal(extractBillingErrorKind(err), null);
+  });
+
+  it('returns null when err.data lacks a kind field', () => {
+    const err = Object.assign(new Error(''), { data: { other: 'x' } });
+    assert.equal(extractBillingErrorKind(err), null);
+  });
+});
+
+describe('extractBillingErrorKind — legacy substring fallback', () => {
+  it('classifies the pre-fix "No Dodo customer found" message as NO_CUSTOMER', () => {
+    // Deploy-ordering window: if the browser is updated but the Convex
+    // action still ships the plain-Error throw, the catch path should
+    // still bucket the event correctly.
+    const err = new Error('No Dodo customer found for this user');
+    assert.equal(extractBillingErrorKind(err), 'NO_CUSTOMER');
+  });
+
+  it('does NOT classify a generic "[Request ID: X] Server Error" (the pre-fix bug)', () => {
+    // This is the EXACT symptom the structured-throw fix exists to address:
+    // Convex's `[Request ID: X] Server Error` wrapper used to bypass any
+    // substring-classification path. Confirm null so the caller defaults
+    // to error-level Sentry capture for unknown shapes.
+    const err = new Error('[Request ID: 6d59ef5d8b4c46cc] Server Error');
+    assert.equal(extractBillingErrorKind(err), null);
+  });
+
+  it('structured-data path wins when both data.kind and matching message exist (forward-compat)', () => {
+    // If a future ConvexError both sets a structured kind AND its message
+    // happens to contain the legacy substring, structured wins.
+    const err = Object.assign(new Error('No Dodo customer found for this user'), {
+      data: { kind: 'DODO_API_KEY_MISSING' },
+    });
+    assert.equal(extractBillingErrorKind(err), 'DODO_API_KEY_MISSING');
+  });
+});
+
+describe('extractBillingErrorKind — null returns for shapes we never produce', () => {
+  it('returns null for a plain non-Error value', () => {
+    assert.equal(extractBillingErrorKind('plain string'), null);
+    assert.equal(extractBillingErrorKind(undefined), null);
+    assert.equal(extractBillingErrorKind(null), null);
+    assert.equal(extractBillingErrorKind(42), null);
+  });
+
+  it('returns null for an Error without data and unrelated message', () => {
+    assert.equal(extractBillingErrorKind(new Error('network timeout')), null);
+  });
+});


### PR DESCRIPTION
## Summary

**WORLDMONITOR-R5** traced to a real data-integrity gap, not just a
Sentry-noise issue. The `subscription.active` webhook handler at
`convex/payments/subscriptionHelpers.ts:520-549` writes the
`subscriptions` row unconditionally but only writes the `customers`
row when `data.customer?.customer_id` is present in the webhook
payload. A paying Pro Annual user whose webhook delivery omitted that
field ended up entitled but with no portal-resolvable customers row.

Clicking "Manage Billing" threw `Error("No Dodo customer found for
this user")`, which Convex's HTTP runtime collapsed to an opaque
`[Request ID: X] Server Error` on the wire (the
`string-data ConvexError → wire loses errorData` pattern documented
in `api/_convex-error.js`). The client silently fell back to
`customer.dodopayments.com` — a generic Dodo portal that doesn't
recognise the user.

## What this PR does

Three layers of defence:

**1. Structured throws (`convex/payments/billing.ts`)** — all three
plain `Error()` sites converted to
`new ConvexError({ kind: 'NO_CUSTOMER' | 'DODO_API_KEY_MISSING' |
'USER_ID_REQUIRED' })`. Object-typed `data` propagates `err.data.kind`
faithfully so the next event is diagnosable without log-spelunking.

**2. Self-heal (`repairCustomerFromSubscriptionPayload`)** — when the
customers lookup fails, walk the user's subscriptions
active → on_hold → cancelled, read `rawPayload.customer.customer_id`,
and upsert the customers row. Refuses cross-user remap if the
dodoCustomerId already belongs to a different userId. Affected users
get fixed on their next "Manage Billing" click.

**3. Proactive backfill (`backfillMissingCustomers`)** — operator
sweeps all affected users immediately post-deploy:
\`\`\`bash
npx convex run payments/billing:backfillMissingCustomers
# → { usersInspected, alreadyHadCustomer, repaired, couldNotRepair,
#     unresolved: [userIds needing manual support touch] }
\`\`\`
Idempotent — second pass reports zero new repairs.

**Client-side (`src/services/billing.ts`)** — discriminated
\`OpenBillingPortalOutcome\` return type splits Sentry severity
(NO_CUSTOMER → warning; everything else → error) and closes the
pre-reserved tab instead of dumping the user at a stranger's portal.
UI callers in \`UnifiedSettings.ts\` surface a "contact support"
toast on no-customer so the user knows what to do next.

## Test plan

- [x] \`npm run typecheck\` — PASS
- [x] \`npm run typecheck:api\` — PASS (incl. \`audit-convex-string-calls\`)
- [x] \`npm run lint\` — PASS (warnings only, pre-existing)
- [x] \`npm run test:data\` — PASS (8678/8678)
- [x] \`node --test tests/edge-functions.test.mjs\` — PASS (184/184)
- [x] \`npx vitest run convex/__tests__/billing.test.ts\` — PASS (14/14, incl. 8 new repair + backfill cases)
- [x] \`node --test tests/billing-convex-error.test.mts\` — PASS (10/10 client-side extractor cases)
- [x] \`npm run lint:md\` — PASS
- [x] \`npm run version:check\` — PASS
- [x] Edge bundle check — PASS
- [ ] **Post-deploy**: run \`npx convex run payments/billing:backfillMissingCustomers\` and review the \`unresolved\` list for any user IDs needing manual support touch
- [ ] **Post-deploy**: verify a future occurrence of the bug surfaces with \`err.data.kind\` (queryable as \`billing_error_kind\` tag in Sentry) instead of opaque Server Error