### PR TITLE
fix(sentry): downgrade carousel render timeout to warning level

### DIFF
--- a/api/brief/carousel/[userId]/[issueDate]/[page].ts
+++ b/api/brief/carousel/[userId]/[issueDate]/[page].ts
@@ -142,13 +142,25 @@ export default async function handler(
     }
     return response;
   } catch (err) {
-    console.error(
+    // AbortSignal.timeout / AbortController.abort firing somewhere inside
+    // `renderCarouselImageResponse` (remote image fetch, font load, OG
+    // generation) surfaces as `DOMException` / `TimeoutError` / `AbortError`.
+    // The handler already returns 503 to the client; downgrade the Sentry
+    // capture to `warning` so single transient timeouts don't drown real
+    // render-pipeline regressions (font missing, image source broken, layout
+    // bug). Non-timeout errors stay at default `error` level. Pattern mirrors
+    // PR #3660's MCP dispatcher gate. WORLDMONITOR-QJ.
+    const errName = err instanceof Error ? err.name : '';
+    const isTransientTimeout = errName === 'AbortError' || errName === 'TimeoutError';
+    const log = isTransientTimeout ? console.warn : console.error;
+    log(
       `[api/brief/carousel] render failed for ${userId}/${issueDate}/${page}:`,
       (err as Error).message,
     );
     captureSilentError(err, {
       tags: { route: 'api/brief/carousel', step: 'render', page: String(page) },
       ctx,
+      ...(isTransientTimeout ? { level: 'warning' as const } : {}),
     });
     return jsonError('render_failed', 503, cors, { noStore: true });
   }


### PR DESCRIPTION
## Summary

**WORLDMONITOR-QJ** was a 3-event / 3-user `DOMException: The operation
was aborted due to timeout` from the `api/brief/carousel/...` render
path. The handler already returns a clean 503 + `Cache-Control:
no-store`, and the digest cron treats carousel failure as best-effort
(falls back to text-only message), so transient @vercel/og timeouts /
remote image fetch aborts are expected-but-trackable — not error-grade.

Same shape and fix as PR #3660's MCP dispatcher gate: inspect
`err.name` for `AbortError` / `TimeoutError` and pass
`level: 'warning'` to \`captureSilentError\` when matched.
Non-timeout throws (font missing, image source broken, render
pipeline bugs) stay at default error level so real regressions still
page.

Log-drain severity routed in parallel (\`console.warn\` for transient,
\`console.error\` otherwise) so Vercel/Datadog see the same severity
as Sentry — same alignment Greptile flagged on PR #3660.

## Test plan

- [x] \`npm run typecheck\` — PASS
- [x] \`npm run typecheck:api\` — PASS (incl. \`audit-convex-string-calls\`)
- [x] \`npm run lint\` — PASS (warnings only, pre-existing)
- [x] \`node --test tests/edge-functions.test.mjs\` — PASS
- [x] Edge bundle check — PASS
- [ ] Verify next QJ recurrence lands at \`warning\` level instead of \`error\`

\`test:data\` skipped here — it just passed (8678/8678) on the sibling
PR #3679 branch which contained a strict superset of changes; this PR
is a single isolated edit to one edge handler with no shared code
paths.