### PR TITLE
fix(seed-portwatch): retry via Decodo proxy on TIMEOUT (not just HTTP 429)

### DIFF
--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -41,6 +41,12 @@ const EP4_BASE =
 
 const PAGE_SIZE = 2000;
 const FETCH_TIMEOUT = 45_000;
+// Tighter timeout for the proxy-retry leg. Direct + proxy must total under
+// PER_COUNTRY_TIMEOUT_MS (90s) with slack for Decodo's TCP handshake +
+// CONNECT setup (~3-5s). 45s direct + 35s proxy = 80s, leaving ~10s for
+// setup overhead and the surrounding pagination accounting. Greptile PR
+// #3681 review P2 flagged the prior 45+45=90s arrangement as racey.
+const PROXY_FETCH_TIMEOUT = 35_000;
 // Two aggregation windows, hardcoded in fetchCountryAccum:
 //   last30 = days  0-30 → tankerCalls30d, avg30d, import/export sums
 //   prev30 = days 30-60 → trendDelta baseline
@@ -90,13 +96,24 @@ function epochToTimestamp(epochMs) {
 // path when the direct request returns 429 OR silently times out — both
 // are signals that ArcGIS is rate-limiting our seed-server IP. Returns the
 // parsed JSON body or throws.
+//
+// Uses PROXY_FETCH_TIMEOUT (35s, shorter than the 45s direct FETCH_TIMEOUT)
+// so the combined direct + proxy budget stays under PER_COUNTRY_TIMEOUT_MS
+// (90s) with slack for Decodo's TCP handshake and CONNECT setup. Greptile
+// PR #3681 review P2.
 async function arcgisProxyRetry(url, reason, { signal } = {}) {
   const proxyAuth = resolveProxyForConnect();
   if (!proxyAuth) throw new Error(`ArcGIS direct ${reason} + no proxy configured for ${url.slice(0, 80)}`);
   console.warn(`  [portwatch] ${reason} — retrying via proxy: ${url.slice(0, 80)}`);
-  const { buffer } = await httpsProxyFetchRaw(url, proxyAuth, { accept: 'application/json', timeoutMs: FETCH_TIMEOUT, signal });
+  const { buffer } = await httpsProxyFetchRaw(url, proxyAuth, { accept: 'application/json', timeoutMs: PROXY_FETCH_TIMEOUT, signal });
   const proxied = JSON.parse(buffer.toString('utf8'));
-  if (proxied.error) throw new Error(`ArcGIS error (via proxy after ${reason}): ${proxied.error.message}`);
+  if (proxied.error) {
+    // Greptile PR #3681 review P2: ArcGIS can return `{"error":{"code":400}}`
+    // with no message field. Fall back to code, then JSON.stringify so the
+    // thrown error message stays informative on unexpected error shapes.
+    const errInfo = proxied.error.message ?? proxied.error.code ?? JSON.stringify(proxied.error);
+    throw new Error(`ArcGIS error (via proxy after ${reason}): ${errInfo}`);
+  }
   return proxied;
 }
 

--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -86,24 +86,57 @@ function epochToTimestamp(epochMs) {
   return `timestamp '${d.getUTCFullYear()}-${p(d.getUTCMonth() + 1)}-${p(d.getUTCDate())} ${p(d.getUTCHours())}:${p(d.getUTCMinutes())}:${p(d.getUTCSeconds())}'`;
 }
 
+// Retry an ArcGIS request through the Decodo proxy. Used as the fallback
+// path when the direct request returns 429 OR silently times out — both
+// are signals that ArcGIS is rate-limiting our seed-server IP. Returns the
+// parsed JSON body or throws.
+async function arcgisProxyRetry(url, reason, { signal } = {}) {
+  const proxyAuth = resolveProxyForConnect();
+  if (!proxyAuth) throw new Error(`ArcGIS direct ${reason} + no proxy configured for ${url.slice(0, 80)}`);
+  console.warn(`  [portwatch] ${reason} — retrying via proxy: ${url.slice(0, 80)}`);
+  const { buffer } = await httpsProxyFetchRaw(url, proxyAuth, { accept: 'application/json', timeoutMs: FETCH_TIMEOUT, signal });
+  const proxied = JSON.parse(buffer.toString('utf8'));
+  if (proxied.error) throw new Error(`ArcGIS error (via proxy after ${reason}): ${proxied.error.message}`);
+  return proxied;
+}
+
 async function fetchWithTimeout(url, { signal } = {}) {
   // Combine the per-call FETCH_TIMEOUT with the upstream caller signal so an
   // abort propagates into the in-flight fetch AND future pagination iterations.
   const combined = signal
     ? AbortSignal.any([signal, AbortSignal.timeout(FETCH_TIMEOUT)])
     : AbortSignal.timeout(FETCH_TIMEOUT);
-  const resp = await fetch(url, {
-    headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
-    signal: combined,
-  });
+  let resp;
+  try {
+    resp = await fetch(url, {
+      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+      signal: combined,
+    });
+  } catch (err) {
+    // If the CALLER signal aborted (real cancellation request from SIGTERM
+    // / per-country timeout), propagate as-is. Only the internal 45s
+    // FETCH_TIMEOUT or transient network errors fall through to the proxy
+    // retry below.
+    if (signal?.aborted) throw err;
+    // WM 2026-05-13 incident: ArcGIS rate-limited our seed-server by
+    // silently stalling responses instead of returning HTTP 429. Every
+    // direct per-country fetch hit the 45s FETCH_TIMEOUT, none reached
+    // the existing 429 retry branch. Result: 30/30 timeouts on the
+    // cold-fetch path, coverage gate failed at 27/50.
+    //
+    // Detect timeout / transient network errors and fall through to the
+    // same proxy retry that 429 uses. The proxy path has its own
+    // FETCH_TIMEOUT so one stalled call can't accumulate indefinitely.
+    const errName = err?.name || '';
+    const errMsg = err?.message || '';
+    const isTimeoutLike = errName === 'TimeoutError'
+      || errName === 'AbortError'
+      || /timeout|aborted|fetch failed|ECONNRESET|UND_ERR_/i.test(errMsg);
+    if (!isTimeoutLike) throw err;
+    return await arcgisProxyRetry(url, `direct ${errName || 'timeout'}`, { signal });
+  }
   if (resp.status === 429) {
-    const proxyAuth = resolveProxyForConnect();
-    if (!proxyAuth) throw new Error(`ArcGIS HTTP 429 (rate limited) for ${url.slice(0, 80)}`);
-    console.warn(`  [portwatch] 429 rate-limited — retrying via proxy: ${url.slice(0, 80)}`);
-    const { buffer } = await httpsProxyFetchRaw(url, proxyAuth, { accept: 'application/json', timeoutMs: FETCH_TIMEOUT, signal });
-    const proxied = JSON.parse(buffer.toString('utf8'));
-    if (proxied.error) throw new Error(`ArcGIS error (via proxy): ${proxied.error.message}`);
-    return proxied;
+    return await arcgisProxyRetry(url, 'HTTP 429 rate-limited', { signal });
   }
   if (!resp.ok) throw new Error(`ArcGIS HTTP ${resp.status} for ${url.slice(0, 80)}`);
   const body = await resp.json();

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -356,6 +356,47 @@ describe('ArcGIS 429 proxy fallback', () => {
     assert.match(src, /direct \$\{errName \|\| 'timeout'\}/);
     assert.match(src, /'HTTP 429 rate-limited'/);
   });
+
+  // Greptile PR #3681 review round 2 P2: combined direct + proxy budget must
+  // stay under PER_COUNTRY_TIMEOUT_MS with slack for proxy setup overhead.
+  it('proxy timeout is tighter than direct timeout to leave PER_COUNTRY budget slack', () => {
+    // FETCH_TIMEOUT (45s) + PROXY_FETCH_TIMEOUT (35s) = 80s, under
+    // PER_COUNTRY_TIMEOUT_MS (90s) with 10s slack for Decodo TCP handshake
+    // + CONNECT setup. Pre-fix used FETCH_TIMEOUT on both sides (90s exact,
+    // racey with the per-country signal abort).
+    assert.match(src, /const PROXY_FETCH_TIMEOUT\s*=\s*35_000/);
+    // The proxy retry MUST pass PROXY_FETCH_TIMEOUT, not FETCH_TIMEOUT:
+    assert.match(src, /timeoutMs:\s*PROXY_FETCH_TIMEOUT/);
+    // And the budget invariant: direct + proxy < per-country.
+    const fetchTimeout = src.match(/const FETCH_TIMEOUT\s*=\s*(\d+_?\d*)/)?.[1];
+    const proxyTimeout = src.match(/const PROXY_FETCH_TIMEOUT\s*=\s*(\d+_?\d*)/)?.[1];
+    const perCountry = src.match(/const PER_COUNTRY_TIMEOUT_MS\s*=\s*(\d+_?\d*)/)?.[1];
+    const parseMs = (s) => parseInt((s ?? '0').replace(/_/g, ''), 10);
+    const total = parseMs(fetchTimeout) + parseMs(proxyTimeout);
+    const perCountryMs = parseMs(perCountry);
+    assert.ok(
+      total < perCountryMs,
+      `direct(${fetchTimeout}) + proxy(${proxyTimeout}) = ${total}ms must be < PER_COUNTRY_TIMEOUT_MS(${perCountryMs}); ` +
+      `pre-fix 45+45=90 exactly equalled per-country, no slack for proxy setup.`,
+    );
+    // Specifically require ≥5s slack for the TCP handshake and CONNECT setup
+    // to Decodo, which can run ~3-5s on cold connections.
+    assert.ok(
+      perCountryMs - total >= 5000,
+      `proxy setup needs ≥5s slack; got ${perCountryMs - total}ms`,
+    );
+  });
+
+  // Greptile PR #3681 review round 2 P2: ArcGIS can return error objects
+  // without a `message` field (observed `{"error":{"code":400}}`). The thrown
+  // message must stay informative on unexpected shapes.
+  it('proxy error message falls back through message → code → JSON.stringify', () => {
+    assert.match(
+      src,
+      /proxied\.error\.message\s*\?\?\s*proxied\.error\.code\s*\?\?\s*JSON\.stringify\(proxied\.error\)/,
+      'proxy error path must fall back through message → code → JSON.stringify so `undefined` never reaches the thrown message',
+    );
+  });
 });
 
 // ── standalone bundle + Dockerfile assertions ────────────────────────────────

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -305,6 +305,57 @@ describe('ArcGIS 429 proxy fallback', () => {
   it('429 proxy fallback threads caller signal', () => {
     assert.match(src, /httpsProxyFetchRaw\(url,\s*proxyAuth,\s*\{[^}]*signal\s*\}/s);
   });
+
+  // WM 2026-05-13 incident: ArcGIS silently stalled instead of returning
+  // 429, so all 30 cold-fetches timed out at 45s without ever entering
+  // the 429 retry branch. Fix: also fall through to proxy on timeout /
+  // transient network errors.
+  it('proxy fallback also fires on timeout (not just HTTP 429)', () => {
+    // The fetchWithTimeout body must wrap `await fetch(...)` in try/catch
+    // so a thrown AbortError (timeout) can be inspected and re-dispatched
+    // to the proxy path. Pre-fix the fetch was bare-awaited, so any
+    // throw exited the function before the 429 branch.
+    assert.match(src, /try\s*\{[\s\S]*?resp\s*=\s*await fetch\(url/);
+    // The catch block must detect timeout-class errors before deciding to
+    // re-throw vs retry-via-proxy.
+    assert.match(src, /errName\s*===\s*'TimeoutError'/);
+    assert.match(src, /isTimeoutLike/);
+  });
+
+  it('proxy retry helper is shared between 429 and timeout paths', () => {
+    // Centralized in arcgisProxyRetry so both branches behave identically
+    // (same Decodo creds resolution, same proxy-side timeout budget, same
+    // error message format). Pre-fix the 429 branch had inline proxy
+    // logic; the timeout path would have duplicated it. Refactored to
+    // share the helper.
+    assert.match(src, /async function arcgisProxyRetry/);
+    // Both branches must dispatch through the helper:
+    const callSites = src.match(/arcgisProxyRetry\(url,/g) ?? [];
+    assert.ok(
+      callSites.length >= 2,
+      `arcgisProxyRetry must be called from both 429 and timeout paths, found ${callSites.length}`,
+    );
+  });
+
+  it('caller signal-abort propagates without proxy retry (real cancellation)', () => {
+    // If the OUTER signal aborts (SIGTERM, per-country 90s timeout), we
+    // must NOT silently retry via proxy — the caller is asking us to
+    // stop. The check is `if (signal?.aborted) throw err`. Without this,
+    // a SIGTERM-triggered abort would still fire a proxy attempt and
+    // potentially miss the shutdown window.
+    assert.match(src, /if\s*\(\s*signal\?\.aborted\s*\)\s*throw err/);
+  });
+
+  it('proxy fallback distinguishes timeout error sources for operator visibility', () => {
+    // Pre-fix the 429 warn log said only "429 rate-limited — retrying via
+    // proxy". Post-fix the same helper is reused with a reason string,
+    // so operator logs distinguish "HTTP 429 rate-limited" from "direct
+    // TimeoutError" from "direct AbortError". Critical for diagnosing
+    // whether ArcGIS is explicitly rate-limiting (429) or silently
+    // stalling (timeout) — different mitigation paths.
+    assert.match(src, /direct \$\{errName \|\| 'timeout'\}/);
+    assert.match(src, /'HTTP 429 rate-limited'/);
+  });
 });
 
 // ── standalone bundle + Dockerfile assertions ────────────────────────────────


### PR DESCRIPTION
## Summary

Companion to **#3676** (merged earlier today — cold-fetch cap). #3676 prevented the 174-country SIGTERM cliff but my manual re-run revealed a deeper upstream issue: even with only 30 attempted cold-fetches, **30/30 timed out** at the 45s `FETCH_TIMEOUT`. Coverage gate failed at 27/50, `/api/health` stayed WARNING.

Root cause: the existing proxy fallback only fires on **HTTP 429**. ArcGIS was silently *stalling* our seed-server IP instead of returning 429 — every fetch hit the AbortSignal timeout, exited via thrown AbortError, and the 429-only retry branch never engaged.

## Evidence

From the manual re-run log (`logs.1778697563750.log`):

```
Activity queue: 30 countries (skipped 0 via cache, 6 unmapped, concurrency 12, per-country cap 90s)
Cold-fetch capped at 30/run — refreshing 30 now, serving 27 on stale cache, 117 dropped (cache > 7d old), 0 dropped (no prior payload)
batch 1/3: 27 countries published, 12 errors (45.0s)
batch 3/3: 27 countries published, 30 errors (135.1s)
30 country errors: VIR: timeout; GHA: timeout; MNE: timeout; WSM: timeout; PRT: timeout ...
COVERAGE GATE FAILED: only 27 countries, need >=50
```

100% of cold-fetches timed out — including tiny countries (VIR, MNE, WSM) that should respond in <2s. Classic IP-level rate-limit-by-stall.

## Fix

Wrap `await fetch(...)` in `try/catch` and route timeout-class errors to the same proxy retry that 429 uses. Refactor the proxy retry into `arcgisProxyRetry(url, reason, opts)` so both branches share identical Decodo creds resolution, proxy-side `FETCH_TIMEOUT`, and error message format.

```diff
+ async function arcgisProxyRetry(url, reason, { signal } = {}) {
+   const proxyAuth = resolveProxyForConnect();
+   if (!proxyAuth) throw new Error(`ArcGIS direct ${reason} + no proxy configured for ${url.slice(0, 80)}`);
+   console.warn(`  [portwatch] ${reason} — retrying via proxy: ${url.slice(0, 80)}`);
+   const { buffer } = await httpsProxyFetchRaw(url, proxyAuth, { accept: 'application/json', timeoutMs: FETCH_TIMEOUT, signal });
+   const proxied = JSON.parse(buffer.toString('utf8'));
+   if (proxied.error) throw new Error(`ArcGIS error (via proxy after ${reason}): ${proxied.error.message}`);
+   return proxied;
+ }

  async function fetchWithTimeout(url, { signal } = {}) {
    const combined = signal ? AbortSignal.any([signal, AbortSignal.timeout(FETCH_TIMEOUT)]) : AbortSignal.timeout(FETCH_TIMEOUT);
+   let resp;
+   try {
-   const resp = await fetch(url, { headers: ..., signal: combined });
+     resp = await fetch(url, { headers: ..., signal: combined });
+   } catch (err) {
+     if (signal?.aborted) throw err;                            // real cancellation → propagate
+     const isTimeoutLike = /TimeoutError|AbortError|timeout|aborted|fetch failed|ECONNRESET|UND_ERR_/i.test(...);
+     if (!isTimeoutLike) throw err;
+     return await arcgisProxyRetry(url, `direct ${errName || 'timeout'}`, { signal });
+   }
    if (resp.status === 429) {
-     // ...inline 429 retry logic...
+     return await arcgisProxyRetry(url, 'HTTP 429 rate-limited', { signal });
    }
    ...
  }
```

## Caller-signal-abort still propagates correctly

If the OUTER caller signal aborts (SIGTERM, per-country 90s timeout, bundle shutdown), the `if (signal?.aborted) throw err` guard at the top of the catch block propagates the abort as-is. Without this, a SIGTERM could be silently extended into an extra proxy attempt.

## Timeout-class detection

Covers all common transient-network error shapes:
- `DOMException [TimeoutError]` — from `AbortSignal.timeout(FETCH_TIMEOUT)`
- `AbortError` — from network-level aborts
- `UND_ERR_*` — undici-layer transient errors
- `ECONNRESET` — mid-response disconnect
- `fetch failed` / `aborted` / `timeout` in error message

## Operator visibility

The shared `arcgisProxyRetry` helper takes a `reason` string so logs distinguish:
- `HTTP 429 rate-limited — retrying via proxy` (explicit upstream signal)
- `direct TimeoutError — retrying via proxy` (silent stall)
- `direct AbortError — retrying via proxy` (network-level disconnect)

Different operator mitigations apply for each.

## Test plan

- [x] `node --test tests/portwatch-port-activity-seed.test.mjs` — **83/83 pass** (was 79 in #3676, +4 for this PR)
  - try/catch wraps the direct fetch
  - `errName === 'TimeoutError'` + `isTimeoutLike` detected
  - `arcgisProxyRetry` helper exists and is called from BOTH 429 and timeout paths (≥2 call sites asserted)
  - `signal?.aborted` propagation guard present
  - Both error sources surface distinct log reasons
- [x] `node --check scripts/seed-portwatch-port-activity.mjs` — syntax OK
- [ ] Post-merge: re-run the seeder manually. Expectation: where the 2026-05-13 manual run had 30 direct-timeout errors and 0 successful fetches, the proxy retry should produce ≥25 successful fetches and clear the coverage gate (≥50). `/api/health` flips back to HEALTHY.

## This week's portwatch series

| PR | Layer | Fix |
|---|---|---|
| #3676 (merged) | Structural — bundle budget | Cap cold-fetch at 30/run; serve deferred from cache |
| **This PR** | **Network — proxy fallback** | **Route timeouts to Decodo proxy, not just 429s** |

Both required — #3676 alone couldn't help because every direct fetch silently timed out. This PR plus #3676 = the seeder recovers gracefully from both the bundle-budget-cliff AND the silent-rate-limit failure modes.