### PR TITLE
fix(billing): portal reads dodoCustomerId from subscription rawPayload, bypass customers table

### DIFF
--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -584,3 +584,214 @@ describe("payments billing backfillMissingCustomers", () => {
     expect(second).toMatchObject({ repaired: 0, alreadyHadCustomer: 1 });
   });
 });
+
+// ---------------------------------------------------------------------------
+// getDodoCustomerIdForUserPortal — read straight from the user's preferred
+// subscription's rawPayload, bypass the customers table.
+//
+// The customers table races under concurrent `subscription.active`
+// webhooks (latest-writer-wins patch in subscriptionHelpers.ts:533),
+// so it's an unreliable anchor for "which Dodo customer should this
+// Clerk userId's Manage Billing click open." The subscription's
+// rawPayload is per-Clerk-userId and immutable — that's the truth.
+// ---------------------------------------------------------------------------
+
+describe("payments billing getDodoCustomerIdForUserPortal", () => {
+  test("returns null when the user has no subscriptions at all", async () => {
+    const t = convexTest(schema, modules);
+    const result = await t.query(
+      internal.payments.billing.getDodoCustomerIdForUserPortal,
+      { userId: TEST_USER_ID },
+    );
+    expect(result).toBeNull();
+  });
+
+  test("returns the dodoCustomerId from the active subscription's rawPayload", async () => {
+    const t = convexTest(schema, modules);
+    await seedSubscription(t, {
+      planKey: "pro_annual",
+      dodoProductId: PRODUCT_CATALOG.pro_annual.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "portal_active",
+      rawPayload: {
+        customer: { customer_id: "cus_active_winner", email: "a@example.com" },
+      },
+    });
+    const result = await t.query(
+      internal.payments.billing.getDodoCustomerIdForUserPortal,
+      { userId: TEST_USER_ID },
+    );
+    expect(result).toBe("cus_active_winner");
+  });
+
+  test("prefers active over on_hold over cancelled, ignoring the customers table entirely", async () => {
+    const t = convexTest(schema, modules);
+
+    // A customers row exists for this user but with a STALE/WRONG dodoCustomerId
+    // — this lookup must ignore it and read from the active subscription.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("customers", {
+        userId: TEST_USER_ID,
+        dodoCustomerId: "cus_stale_from_customers_table",
+        email: "stale@example.com",
+        normalizedEmail: "stale@example.com",
+        createdAt: NOW - 10 * DAY_MS,
+        updatedAt: NOW - 10 * DAY_MS,
+      });
+    });
+
+    await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+      status: "cancelled",
+      currentPeriodEnd: NOW - 5 * DAY_MS,
+      suffix: "portal_cancelled_old",
+      rawPayload: { customer: { customer_id: "cus_cancelled_loser" } },
+    });
+    await seedSubscription(t, {
+      planKey: "pro_annual",
+      dodoProductId: PRODUCT_CATALOG.pro_annual.dodoProductId!,
+      status: "on_hold",
+      currentPeriodEnd: NOW + 5 * DAY_MS,
+      suffix: "portal_onhold_middle",
+      rawPayload: { customer: { customer_id: "cus_onhold_middle" } },
+    });
+    await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "portal_active_winner",
+      rawPayload: { customer: { customer_id: "cus_active_winner" } },
+    });
+
+    const result = await t.query(
+      internal.payments.billing.getDodoCustomerIdForUserPortal,
+      { userId: TEST_USER_ID },
+    );
+    expect(result).toBe("cus_active_winner");
+  });
+
+  test("falls back to on_hold when no active sub exists", async () => {
+    const t = convexTest(schema, modules);
+    await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+      status: "on_hold",
+      currentPeriodEnd: NOW + 5 * DAY_MS,
+      suffix: "portal_only_onhold",
+      rawPayload: { customer: { customer_id: "cus_onhold_only" } },
+    });
+    const result = await t.query(
+      internal.payments.billing.getDodoCustomerIdForUserPortal,
+      { userId: TEST_USER_ID },
+    );
+    expect(result).toBe("cus_onhold_only");
+  });
+
+  test("falls back to cancelled when only cancelled subs exist (within or past grace)", async () => {
+    const t = convexTest(schema, modules);
+    await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+      status: "cancelled",
+      currentPeriodEnd: NOW - 10 * DAY_MS,
+      suffix: "portal_only_cancelled",
+      rawPayload: { customer: { customer_id: "cus_cancelled_only" } },
+    });
+    const result = await t.query(
+      internal.payments.billing.getDodoCustomerIdForUserPortal,
+      { userId: TEST_USER_ID },
+    );
+    expect(result).toBe("cus_cancelled_only");
+  });
+
+  test("returns null when every subscription's rawPayload lacks a customer_id", async () => {
+    const t = convexTest(schema, modules);
+    await seedSubscription(t, {
+      planKey: "pro_annual",
+      dodoProductId: PRODUCT_CATALOG.pro_annual.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "portal_empty_payload",
+      rawPayload: {},
+    });
+    const result = await t.query(
+      internal.payments.billing.getDodoCustomerIdForUserPortal,
+      { userId: TEST_USER_ID },
+    );
+    expect(result).toBeNull();
+  });
+
+  test("ignores non-string customer_id values (defensive)", async () => {
+    const t = convexTest(schema, modules);
+    await seedSubscription(t, {
+      planKey: "pro_annual",
+      dodoProductId: PRODUCT_CATALOG.pro_annual.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "portal_bad_shape",
+      rawPayload: { customer: { customer_id: 42 } },
+    });
+    const result = await t.query(
+      internal.payments.billing.getDodoCustomerIdForUserPortal,
+      { userId: TEST_USER_ID },
+    );
+    expect(result).toBeNull();
+  });
+
+  test("returns the right dodoCustomerId for each Clerk user when SAME Dodo customer is shared across multiple Clerk accounts (the WORLDMONITOR-R5 scenario)", async () => {
+    // user_A and user_B both checked out with the same email; Dodo deduped
+    // to one customer (cus_shared). Each has their OWN subscription row,
+    // and the customers table's userId field may point at either one due
+    // to webhook race. This query must work for BOTH users regardless of
+    // who currently owns the customers row.
+    const t = convexTest(schema, modules);
+
+    // customers row currently owned by user_A (could just as easily be user_B).
+    await t.run(async (ctx) => {
+      await ctx.db.insert("customers", {
+        userId: "user_A",
+        dodoCustomerId: "cus_shared",
+        email: "shared@example.com",
+        normalizedEmail: "shared@example.com",
+        createdAt: NOW - DAY_MS,
+        updatedAt: NOW - DAY_MS,
+      });
+    });
+
+    await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "portal_userA",
+      userId: "user_A",
+      rawPayload: { customer: { customer_id: "cus_shared", email: "shared@example.com" } },
+    });
+    await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "portal_userB",
+      userId: "user_B",
+      rawPayload: { customer: { customer_id: "cus_shared", email: "shared@example.com" } },
+    });
+
+    const resultA = await t.query(
+      internal.payments.billing.getDodoCustomerIdForUserPortal,
+      { userId: "user_A" },
+    );
+    const resultB = await t.query(
+      internal.payments.billing.getDodoCustomerIdForUserPortal,
+      { userId: "user_B" },
+    );
+    // Both Clerk accounts resolve to the SAME shared Dodo customer,
+    // without needing to consult the customers table. Each Clerk
+    // account's "Manage Billing" click opens the right portal.
+    expect(resultA).toBe("cus_shared");
+    expect(resultB).toBe("cus_shared");
+  });
+});

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -794,4 +794,155 @@ describe("payments billing getDodoCustomerIdForUserPortal", () => {
     expect(resultA).toBe("cus_shared");
     expect(resultB).toBe("cus_shared");
   });
+
+  test("resolves via the stable dodoCustomerId column even when a later lifecycle payload wiped the rawPayload customer field (P1 regression)", async () => {
+    // Reviewer P1 scenario: `subscription.active` payload included
+    // `customer.customer_id`, but a later lifecycle event
+    // (`subscription.renewed` / `.on_hold` / `.cancelled` / `.plan_changed`
+    // / `.expired`) overwrote `rawPayload` with a payload that lacks the
+    // `customer` field. The stable top-level `dodoCustomerId` column
+    // written by the webhook handler (via `mergeDodoCustomerId`)
+    // preserves the value across these patches, so portal lookup
+    // still succeeds.
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: TEST_USER_ID,
+        dodoSubscriptionId: "sub_lifecycle_wiped",
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: NOW - DAY_MS,
+        currentPeriodEnd: NOW + 30 * DAY_MS,
+        // Stable column has the correct value, written on subscription.active.
+        dodoCustomerId: "cus_preserved_across_lifecycle",
+        // rawPayload was overwritten by a later lifecycle event without customer.
+        rawPayload: {
+          subscription_id: "sub_lifecycle_wiped",
+          product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+          // intentionally no `customer` field
+        },
+        updatedAt: NOW,
+      });
+    });
+
+    const result = await t.query(
+      internal.payments.billing.getDodoCustomerIdForUserPortal,
+      { userId: TEST_USER_ID },
+    );
+    expect(result).toBe("cus_preserved_across_lifecycle");
+  });
+
+  test("falls back to rawPayload.customer.customer_id when the stable column is absent (pre-schema-change rows)", async () => {
+    // Backfill safety net: rows that pre-date the schema change have no
+    // top-level `dodoCustomerId`. The query falls back to the rawPayload
+    // value so they keep working until the backfill mutation catches up.
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: TEST_USER_ID,
+        dodoSubscriptionId: "sub_pre_schema",
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: NOW - DAY_MS,
+        currentPeriodEnd: NOW + 30 * DAY_MS,
+        // dodoCustomerId intentionally omitted (pre-schema-change state)
+        rawPayload: {
+          customer: { customer_id: "cus_from_legacy_payload" },
+        },
+        updatedAt: NOW,
+      });
+    });
+
+    const result = await t.query(
+      internal.payments.billing.getDodoCustomerIdForUserPortal,
+      { userId: TEST_USER_ID },
+    );
+    expect(result).toBe("cus_from_legacy_payload");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// backfillSubscriptionDodoCustomerId — one-shot populate the new column
+// from rawPayload for rows that pre-date the schema change.
+// ---------------------------------------------------------------------------
+
+describe("payments billing backfillSubscriptionDodoCustomerId", () => {
+  test("populates dodoCustomerId from rawPayload, skips already-populated rows, reports missing-payload count", async () => {
+    const t = convexTest(schema, modules);
+
+    // Row A — needs backfill (no column, has rawPayload customer_id)
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: "user_backfill_A",
+        dodoSubscriptionId: "sub_backfill_A",
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: NOW - DAY_MS,
+        currentPeriodEnd: NOW + 30 * DAY_MS,
+        rawPayload: { customer: { customer_id: "cus_A" } },
+        updatedAt: NOW,
+      });
+    });
+
+    // Row B — already populated, must be skipped
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: "user_backfill_B",
+        dodoSubscriptionId: "sub_backfill_B",
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: NOW - DAY_MS,
+        currentPeriodEnd: NOW + 30 * DAY_MS,
+        dodoCustomerId: "cus_B_already",
+        rawPayload: { customer: { customer_id: "cus_B_already" } },
+        updatedAt: NOW,
+      });
+    });
+
+    // Row C — neither column nor rawPayload customer_id available
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: "user_backfill_C",
+        dodoSubscriptionId: "sub_backfill_C",
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: NOW - DAY_MS,
+        currentPeriodEnd: NOW + 30 * DAY_MS,
+        rawPayload: {},
+        updatedAt: NOW,
+      });
+    });
+
+    const summary = await t.mutation(
+      internal.payments.billing.backfillSubscriptionDodoCustomerId,
+      {},
+    );
+    expect(summary).toMatchObject({
+      inspected: 3,
+      populated: 1,
+      alreadyPopulated: 1,
+      missingPayload: 1,
+    });
+
+    // A now has the column populated.
+    const aRow = await t.run(async (ctx) =>
+      ctx.db
+        .query("subscriptions")
+        .withIndex("by_userId", (q) => q.eq("userId", "user_backfill_A"))
+        .first(),
+    );
+    expect(aRow?.dodoCustomerId).toBe("cus_A");
+
+    // Re-running is a no-op (idempotent).
+    const second = await t.mutation(
+      internal.payments.billing.backfillSubscriptionDodoCustomerId,
+      {},
+    );
+    expect(second).toMatchObject({ populated: 0, alreadyPopulated: 2, missingPayload: 1 });
+  });
 });

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -833,6 +833,82 @@ describe("payments billing getDodoCustomerIdForUserPortal", () => {
     expect(result).toBe("cus_preserved_across_lifecycle");
   });
 
+  test("falls back to the same-user customers row when neither stable column nor rawPayload has the customer_id (P1 reviewer regression)", async () => {
+    // Reviewer P1 scenario: a sub row pre-dates this PR AND its
+    // rawPayload was already wiped by a lifecycle event before the
+    // schema change shipped. Tier 1 misses (no column), tier 2 misses
+    // (no rawPayload.customer), but the customers row for the same
+    // userId still has a usable dodoCustomerId — that's the right
+    // answer, better than NO_CUSTOMER for a paying user.
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      await ctx.db.insert("customers", {
+        userId: TEST_USER_ID,
+        dodoCustomerId: "cus_from_customers_tier3",
+        email: "rescued@example.com",
+        normalizedEmail: "rescued@example.com",
+        createdAt: NOW - 10 * DAY_MS,
+        updatedAt: NOW - 10 * DAY_MS,
+      });
+      await ctx.db.insert("subscriptions", {
+        userId: TEST_USER_ID,
+        dodoSubscriptionId: "sub_tier3_rescue",
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: NOW - DAY_MS,
+        currentPeriodEnd: NOW + 30 * DAY_MS,
+        // dodoCustomerId column intentionally absent
+        rawPayload: {}, // wiped
+        updatedAt: NOW,
+      });
+    });
+
+    const result = await t.query(
+      internal.payments.billing.getDodoCustomerIdForUserPortal,
+      { userId: TEST_USER_ID },
+    );
+    expect(result).toBe("cus_from_customers_tier3");
+  });
+
+  test("does NOT use the customers row when it belongs to a different userId (no silent re-attribution)", async () => {
+    // Defensive: the customers row is matched by `by_userId` index, so
+    // a cross-user race that pointed cus_X at user_B does NOT leak
+    // through tier 3 when user_A clicks Manage Billing.
+    const t = convexTest(schema, modules);
+    await t.run(async (ctx) => {
+      // Customer row owned by SOMEONE ELSE
+      await ctx.db.insert("customers", {
+        userId: "user_someone_else",
+        dodoCustomerId: "cus_belongs_to_someone_else",
+        email: "other@example.com",
+        normalizedEmail: "other@example.com",
+        createdAt: NOW - 10 * DAY_MS,
+        updatedAt: NOW - 10 * DAY_MS,
+      });
+      // The user clicking Manage Billing has a sub but no customers row
+      // and no rawPayload customer.
+      await ctx.db.insert("subscriptions", {
+        userId: TEST_USER_ID,
+        dodoSubscriptionId: "sub_tier3_no_match",
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: NOW - DAY_MS,
+        currentPeriodEnd: NOW + 30 * DAY_MS,
+        rawPayload: {},
+        updatedAt: NOW,
+      });
+    });
+
+    const result = await t.query(
+      internal.payments.billing.getDodoCustomerIdForUserPortal,
+      { userId: TEST_USER_ID },
+    );
+    // null — no silent cross-user fallback.
+    expect(result).toBeNull();
+  });
+
   test("falls back to rawPayload.customer.customer_id when the stable column is absent (pre-schema-change rows)", async () => {
     // Backfill safety net: rows that pre-date the schema change have no
     // top-level `dodoCustomerId`. The query falls back to the rawPayload
@@ -869,10 +945,10 @@ describe("payments billing getDodoCustomerIdForUserPortal", () => {
 // ---------------------------------------------------------------------------
 
 describe("payments billing backfillSubscriptionDodoCustomerId", () => {
-  test("populates dodoCustomerId from rawPayload, skips already-populated rows, reports missing-payload count", async () => {
+  test("populates from rawPayload, falls back to customers row, skips already-populated, reports unrecoverable count", async () => {
     const t = convexTest(schema, modules);
 
-    // Row A — needs backfill (no column, has rawPayload customer_id)
+    // Row A — needs backfill from rawPayload (Source 1)
     await t.run(async (ctx) => {
       await ctx.db.insert("subscriptions", {
         userId: "user_backfill_A",
@@ -903,11 +979,37 @@ describe("payments billing backfillSubscriptionDodoCustomerId", () => {
       });
     });
 
-    // Row C — neither column nor rawPayload customer_id available
+    // Row C — rawPayload was wiped pre-PR, but same-user customers row
+    // still has dodoCustomerId (P1 reviewer's scenario). Recoverable
+    // via Source 2.
     await t.run(async (ctx) => {
+      await ctx.db.insert("customers", {
+        userId: "user_backfill_C",
+        dodoCustomerId: "cus_C_from_customers",
+        email: "c@example.com",
+        normalizedEmail: "c@example.com",
+        createdAt: NOW - 10 * DAY_MS,
+        updatedAt: NOW - 10 * DAY_MS,
+      });
       await ctx.db.insert("subscriptions", {
         userId: "user_backfill_C",
         dodoSubscriptionId: "sub_backfill_C",
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: NOW - DAY_MS,
+        currentPeriodEnd: NOW + 30 * DAY_MS,
+        rawPayload: {}, // wiped
+        updatedAt: NOW,
+      });
+    });
+
+    // Row D — neither column nor rawPayload nor customers row.
+    // Genuinely unrecoverable (needs manual triage).
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: "user_backfill_D",
+        dodoSubscriptionId: "sub_backfill_D",
         dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
         planKey: "pro_monthly",
         status: "active",
@@ -923,13 +1025,14 @@ describe("payments billing backfillSubscriptionDodoCustomerId", () => {
       {},
     );
     expect(summary).toMatchObject({
-      inspected: 3,
-      populated: 1,
+      inspected: 4,
+      populatedFromPayload: 1,
+      populatedFromCustomers: 1,
       alreadyPopulated: 1,
-      missingPayload: 1,
+      unrecoverable: 1,
     });
 
-    // A now has the column populated.
+    // A populated via rawPayload.
     const aRow = await t.run(async (ctx) =>
       ctx.db
         .query("subscriptions")
@@ -938,11 +1041,34 @@ describe("payments billing backfillSubscriptionDodoCustomerId", () => {
     );
     expect(aRow?.dodoCustomerId).toBe("cus_A");
 
+    // C populated via customers row fallback.
+    const cRow = await t.run(async (ctx) =>
+      ctx.db
+        .query("subscriptions")
+        .withIndex("by_userId", (q) => q.eq("userId", "user_backfill_C"))
+        .first(),
+    );
+    expect(cRow?.dodoCustomerId).toBe("cus_C_from_customers");
+
+    // D stays empty (unrecoverable).
+    const dRow = await t.run(async (ctx) =>
+      ctx.db
+        .query("subscriptions")
+        .withIndex("by_userId", (q) => q.eq("userId", "user_backfill_D"))
+        .first(),
+    );
+    expect(dRow?.dodoCustomerId).toBeUndefined();
+
     // Re-running is a no-op (idempotent).
     const second = await t.mutation(
       internal.payments.billing.backfillSubscriptionDodoCustomerId,
       {},
     );
-    expect(second).toMatchObject({ populated: 0, alreadyPopulated: 2, missingPayload: 1 });
+    expect(second).toMatchObject({
+      populatedFromPayload: 0,
+      populatedFromCustomers: 0,
+      alreadyPopulated: 3,
+      unrecoverable: 1,
+    });
   });
 });

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -221,10 +221,13 @@ export const getCustomerByUserId = internalQuery({
  * checking out with the same email (Dodo dedupes customers by email)
  * make that row's `userId` race under concurrency — a Clerk user who
  * paid for a sub may not "own" the customers row at the moment they
- * click Manage Billing, even though their subscription rawPayload
- * still proves they paid. The subscription is per-Clerk-user (keyed by
- * HMAC-signed userId at checkout) and its rawPayload is immutable; it
- * is the truth.
+ * click Manage Billing.
+ *
+ * Reads the stable top-level `subscriptions.dodoCustomerId` column
+ * (preserved across lifecycle patches by `mergeDodoCustomerId` in
+ * `subscriptionHelpers.ts`). Falls back to `rawPayload.customer.customer_id`
+ * for any row written before the schema change — covers the deploy /
+ * backfill window where some subs still lack the top-level field.
  */
 export const getDodoCustomerIdForUserPortal = internalQuery({
   args: { userId: v.string() },
@@ -235,19 +238,19 @@ export const getDodoCustomerIdForUserPortal = internalQuery({
       .take(50);
     if (subs.length === 0) return null;
 
-    const priority = (status: string): number =>
-      status === "active" ? 0 :
-      status === "on_hold" ? 1 :
-      status === "cancelled" ? 2 :
-      3;
     const sorted = [...subs].sort((a, b) => {
-      const pa = priority(a.status);
-      const pb = priority(b.status);
+      const pa = getSubscriptionStatusPriority(a.status);
+      const pb = getSubscriptionStatusPriority(b.status);
       if (pa !== pb) return pa - pb;
       return b.updatedAt - a.updatedAt;
     });
 
     for (const sub of sorted) {
+      // Prefer the stable column written by the webhook handler;
+      // fall back to rawPayload for rows that pre-date the schema change.
+      if (typeof sub.dodoCustomerId === "string" && sub.dodoCustomerId.length > 0) {
+        return sub.dodoCustomerId;
+      }
       const payload = sub.rawPayload as
         | { customer?: { customer_id?: unknown } }
         | null
@@ -256,6 +259,49 @@ export const getDodoCustomerIdForUserPortal = internalQuery({
       if (typeof id === "string" && id.length > 0) return id;
     }
     return null;
+  },
+});
+
+/**
+ * One-shot backfill: populate the new `subscriptions.dodoCustomerId`
+ * column from existing rows' `rawPayload.customer.customer_id`. Run
+ * once after the schema change ships; idempotent (re-running is a
+ * no-op because populated rows are skipped).
+ *
+ * Run:
+ *   npx convex run payments/billing:backfillSubscriptionDodoCustomerId
+ *
+ * Returns `{ inspected, populated, alreadyPopulated, missingPayload }`
+ * so the operator can verify the post-backfill state.
+ */
+export const backfillSubscriptionDodoCustomerId = internalMutation({
+  args: {},
+  handler: async (ctx) => {
+    const all = await ctx.db.query("subscriptions").collect();
+    const summary = {
+      inspected: all.length,
+      populated: 0,
+      alreadyPopulated: 0,
+      missingPayload: 0,
+    };
+    for (const sub of all) {
+      if (typeof sub.dodoCustomerId === "string" && sub.dodoCustomerId.length > 0) {
+        summary.alreadyPopulated++;
+        continue;
+      }
+      const payload = sub.rawPayload as
+        | { customer?: { customer_id?: unknown } }
+        | null
+        | undefined;
+      const id = payload?.customer?.customer_id;
+      if (typeof id !== "string" || id.length === 0) {
+        summary.missingPayload++;
+        continue;
+      }
+      await ctx.db.patch(sub._id, { dodoCustomerId: id });
+      summary.populated++;
+    }
+    return summary;
   },
 });
 

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -55,32 +55,39 @@ function getDodoClient(): DodoPayments {
 /**
  * Resolve the Dodo Customer Portal URL for a Clerk-authenticated user.
  *
- * Bypasses the `customers` table entirely and reads the Dodo customer_id
- * straight off the user's preferred subscription's `rawPayload`.
+ * Delegates the Dodo customer_id lookup to
+ * `getDodoCustomerIdForUserPortal`, which is a 3-tier resolver biased
+ * toward per-Clerk-userId evidence:
  *
- * Why: the `customers` table is a derived/cached lookup that races under
- * concurrent webhooks. `subscriptionHelpers.ts:533-539` patches the row's
- * `userId` whenever a `subscription.active` event arrives with a
- * matching dodoCustomerId — which means the same Dodo customer (one per
- * email, since Dodo dedupes customers by email) ends up bouncing
- * between Clerk userIds whenever the same human checks out under
- * different Clerk accounts.
+ *   1. `subscriptions.dodoCustomerId` — the stable top-level column,
+ *      preserved across lifecycle webhook patches by
+ *      `mergeDodoCustomerId` in `subscriptionHelpers.ts`. Per-Clerk-
+ *      userId by construction (sub rows are keyed by the HMAC-signed
+ *      Clerk userId at checkout) and never patched away.
+ *   2. `subscriptions.rawPayload.customer.customer_id` — fallback for
+ *      rows that pre-date the column (deploy / backfill window).
+ *   3. `customers.dodoCustomerId` for the SAME userId — last-resort
+ *      rescue for pre-PR rows whose rawPayload was wiped by a
+ *      lifecycle event before this PR shipped (matches by userId, so
+ *      no silent cross-user re-attribution).
  *
- * The `subscriptions` table doesn't have that problem: each sub row is
- * keyed by the Clerk userId that was HMAC-signed at checkout time, and
- * its `rawPayload.customer.customer_id` is the Dodo customer that user
- * paid as — written server-side from immutable webhook data, never
- * patched away.
+ * Why not "customers row by userId" as the primary source: that table
+ * races under concurrent webhooks. `subscriptionHelpers.ts:533-539`
+ * patches the row's `userId` whenever a `subscription.active` event
+ * arrives with a matching dodoCustomerId — same Dodo customer (one per
+ * email, Dodo dedupes by email) bouncing between Clerk userIds when
+ * one human checks out under multiple Clerk accounts. Tier 1+2 use
+ * the per-Clerk-userId subscription rows precisely to avoid that
+ * race. Tier 3 only kicks in when both sub-side tiers miss AND the
+ * customers row's `userId` happens to match the requester.
  *
- * Result: every Clerk account that has a valid subscription gets its
- * own portal session for the Dodo customer it actually paid as,
- * regardless of how many other Clerk accounts share the same Dodo
- * customer. No customers-table dependency, no Clerk lookup, no
- * cross-account verification needed.
+ * Result: every Clerk account with a valid subscription opens the
+ * right portal regardless of how many other Clerk accounts share the
+ * same Dodo customer. No Clerk REST lookup needed.
  *
  * WORLDMONITOR-R5: the original opaque `[Request ID: X] Server Error`
- * came from this path throwing on a missing customers row even though
- * the subscription's rawPayload held the answer.
+ * came from this path throwing on a missing customers row when both
+ * the rawPayload and a same-user customers row still held the answer.
  */
 async function createCustomerPortalUrlForUser(
   ctx: Pick<ActionCtx, "runQuery">,

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -52,43 +52,58 @@ function getDodoClient(): DodoPayments {
   });
 }
 
+/**
+ * Resolve the Dodo Customer Portal URL for a Clerk-authenticated user.
+ *
+ * Bypasses the `customers` table entirely and reads the Dodo customer_id
+ * straight off the user's preferred subscription's `rawPayload`.
+ *
+ * Why: the `customers` table is a derived/cached lookup that races under
+ * concurrent webhooks. `subscriptionHelpers.ts:533-539` patches the row's
+ * `userId` whenever a `subscription.active` event arrives with a
+ * matching dodoCustomerId — which means the same Dodo customer (one per
+ * email, since Dodo dedupes customers by email) ends up bouncing
+ * between Clerk userIds whenever the same human checks out under
+ * different Clerk accounts.
+ *
+ * The `subscriptions` table doesn't have that problem: each sub row is
+ * keyed by the Clerk userId that was HMAC-signed at checkout time, and
+ * its `rawPayload.customer.customer_id` is the Dodo customer that user
+ * paid as — written server-side from immutable webhook data, never
+ * patched away.
+ *
+ * Result: every Clerk account that has a valid subscription gets its
+ * own portal session for the Dodo customer it actually paid as,
+ * regardless of how many other Clerk accounts share the same Dodo
+ * customer. No customers-table dependency, no Clerk lookup, no
+ * cross-account verification needed.
+ *
+ * WORLDMONITOR-R5: the original opaque `[Request ID: X] Server Error`
+ * came from this path throwing on a missing customers row even though
+ * the subscription's rawPayload held the answer.
+ */
 async function createCustomerPortalUrlForUser(
-  ctx: Pick<ActionCtx, "runQuery" | "runMutation">,
+  ctx: Pick<ActionCtx, "runQuery">,
   userId: string,
 ): Promise<{ portal_url: string }> {
-  let customer = await ctx.runQuery(
-    internal.payments.billing.getCustomerByUserId,
+  const dodoCustomerId = await ctx.runQuery(
+    internal.payments.billing.getDodoCustomerIdForUserPortal,
     { userId },
   );
 
-  if (!customer || !customer.dodoCustomerId) {
-    // Self-heal a known webhook gap: `subscription.active` writes the
-    // `subscriptions` row unconditionally but only writes `customers` when
-    // `data.customer?.customer_id` is present in the payload
-    // (`subscriptionHelpers.ts:525`). Users whose webhook delivery
-    // lacked the customer field end up entitled (active sub) but with no
-    // customers row — clicking "Manage Billing" throws NO_CUSTOMER. The
-    // subscription's `rawPayload` carries the same customer info though,
-    // so try to recover from there before giving up. WORLDMONITOR-R5
-    // (user_3DcpiviTIweanCi9BtF5PRpqwv6 — active Pro Annual, no customers row).
-    customer = await ctx.runMutation(
-      internal.payments.billing.repairCustomerFromSubscriptionPayload,
-      { userId },
-    );
-  }
-
-  if (!customer || !customer.dodoCustomerId) {
-    // Genuine no-customer state — recovery from subscription payload
-    // didn't yield a dodoCustomerId either. Throw structured so the
-    // client can surface a useful "contact support" toast (object-typed
-    // `data` so `err.data.kind` survives the wire — see
-    // `api/_convex-error.js` for the broader pattern).
+  if (!dodoCustomerId) {
+    // User has no subscription at all, or every sub's rawPayload lacks a
+    // usable customer_id (very rare — would mean every webhook delivery
+    // for this user dropped the customer field). Throw structured so
+    // the client surfaces the existing "contact support" toast
+    // (object-typed `data` so `err.data.kind` survives the wire — see
+    // `api/_convex-error.js`).
     throw new ConvexError({ kind: "NO_CUSTOMER" });
   }
 
   const client = getDodoClient();
   const session = await client.customers.customerPortal.create(
-    customer.dodoCustomerId,
+    dodoCustomerId,
     { send_email: false },
   );
 
@@ -163,7 +178,15 @@ export const getSubscriptionForUser = query({
 
 /**
  * Internal query to retrieve a customer record by userId.
- * Used by getCustomerPortalUrl to find the dodoCustomerId.
+ *
+ * NOTE: As of WORLDMONITOR-R5 follow-up, this is no longer used by the
+ * Manage Billing flow — see `getDodoCustomerIdForUserPortal` below for
+ * the rationale. Still consumed by callers that legitimately want the
+ * customers row (broadcast paid-set membership, comp-grant lookups,
+ * etc.); those tolerate the latest-writer-wins quirk on shared-email
+ * Dodo customers because they only need "is this user a paid customer
+ * at all", not "which Dodo customer should the portal session open
+ * for this specific Clerk userId".
  */
 export const getCustomerByUserId = internalQuery({
   args: { userId: v.string() },
@@ -173,6 +196,66 @@ export const getCustomerByUserId = internalQuery({
       .query("customers")
       .withIndex("by_userId", (q) => q.eq("userId", args.userId))
       .first();
+  },
+});
+
+/**
+ * Resolve the Dodo customer_id this user's "Manage Billing" click
+ * should open a portal session for — reading straight off the user's
+ * preferred subscription's rawPayload, bypassing the `customers` table.
+ *
+ * Preference order (one row per Clerk userId is the invariant): active
+ * → on_hold → cancelled → other; tie-break by newest `updatedAt`.
+ *
+ * Returns null when:
+ *   - User has no subscriptions at all (Free user — UI gates this out,
+ *     but the query is defensive)
+ *   - Every subscription's rawPayload lacks a string customer_id (rare;
+ *     would mean every webhook delivery for this user dropped the
+ *     customer field — caller throws NO_CUSTOMER → "contact support"
+ *     toast).
+ *
+ * Why bypass the customers table: `subscriptionHelpers.ts:533-539`
+ * patches the customers row's `userId` whenever a `subscription.active`
+ * event for a matching dodoCustomerId arrives. Multiple Clerk accounts
+ * checking out with the same email (Dodo dedupes customers by email)
+ * make that row's `userId` race under concurrency — a Clerk user who
+ * paid for a sub may not "own" the customers row at the moment they
+ * click Manage Billing, even though their subscription rawPayload
+ * still proves they paid. The subscription is per-Clerk-user (keyed by
+ * HMAC-signed userId at checkout) and its rawPayload is immutable; it
+ * is the truth.
+ */
+export const getDodoCustomerIdForUserPortal = internalQuery({
+  args: { userId: v.string() },
+  handler: async (ctx, args) => {
+    const subs = await ctx.db
+      .query("subscriptions")
+      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+      .take(50);
+    if (subs.length === 0) return null;
+
+    const priority = (status: string): number =>
+      status === "active" ? 0 :
+      status === "on_hold" ? 1 :
+      status === "cancelled" ? 2 :
+      3;
+    const sorted = [...subs].sort((a, b) => {
+      const pa = priority(a.status);
+      const pb = priority(b.status);
+      if (pa !== pb) return pa - pb;
+      return b.updatedAt - a.updatedAt;
+    });
+
+    for (const sub of sorted) {
+      const payload = sub.rawPayload as
+        | { customer?: { customer_id?: unknown } }
+        | null
+        | undefined;
+      const id = payload?.customer?.customer_id;
+      if (typeof id === "string" && id.length > 0) return id;
+    }
+    return null;
   },
 });
 

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -201,33 +201,34 @@ export const getCustomerByUserId = internalQuery({
 
 /**
  * Resolve the Dodo customer_id this user's "Manage Billing" click
- * should open a portal session for — reading straight off the user's
- * preferred subscription's rawPayload, bypassing the `customers` table.
+ * should open a portal session for.
  *
- * Preference order (one row per Clerk userId is the invariant): active
- * → on_hold → cancelled → other; tie-break by newest `updatedAt`.
+ * Three-tier resolution, preferring per-Clerk-user evidence:
+ *   1. `subscriptions.dodoCustomerId` — the stable top-level column
+ *      written by the webhook handler and preserved across lifecycle
+ *      patches via `mergeDodoCustomerId` in `subscriptionHelpers.ts`.
+ *      Per-Clerk-userId by construction (subscription rows are keyed
+ *      by the HMAC-signed userId at checkout).
+ *   2. `subscriptions.rawPayload.customer.customer_id` — fallback for
+ *      rows that pre-date the schema change AND whose rawPayload still
+ *      carries the customer field (covers the deploy / backfill window).
+ *   3. `customers.dodoCustomerId` for the SAME userId — last-resort
+ *      fallback for the pre-PR pathological case: a row whose
+ *      rawPayload was wiped by a lifecycle event BEFORE the schema
+ *      change, leaving neither tier 1 nor tier 2 with data. The
+ *      customers row may have been re-attributed under webhook race
+ *      (latest-writer-wins on `subscriptionHelpers.ts:533-539`), but
+ *      when it DOES match the requesting userId, it's the best
+ *      remaining signal — better than NO_CUSTOMER for a paying user.
  *
- * Returns null when:
- *   - User has no subscriptions at all (Free user — UI gates this out,
- *     but the query is defensive)
- *   - Every subscription's rawPayload lacks a string customer_id (rare;
- *     would mean every webhook delivery for this user dropped the
- *     customer field — caller throws NO_CUSTOMER → "contact support"
- *     toast).
+ * Subscription preference (within tier 1+2): active → on_hold →
+ * cancelled → other; tie-break by newest `updatedAt`. A given userId
+ * may have multiple subscription rows over time (cancelled + new), so
+ * sorting is required — there's no per-userId uniqueness invariant.
  *
- * Why bypass the customers table: `subscriptionHelpers.ts:533-539`
- * patches the customers row's `userId` whenever a `subscription.active`
- * event for a matching dodoCustomerId arrives. Multiple Clerk accounts
- * checking out with the same email (Dodo dedupes customers by email)
- * make that row's `userId` race under concurrency — a Clerk user who
- * paid for a sub may not "own" the customers row at the moment they
- * click Manage Billing.
- *
- * Reads the stable top-level `subscriptions.dodoCustomerId` column
- * (preserved across lifecycle patches by `mergeDodoCustomerId` in
- * `subscriptionHelpers.ts`). Falls back to `rawPayload.customer.customer_id`
- * for any row written before the schema change — covers the deploy /
- * backfill window where some subs still lack the top-level field.
+ * Returns null only when all three tiers fail (no subs at all OR no
+ * customer_id anywhere across subs/customers). Caller throws
+ * NO_CUSTOMER → client surfaces the "contact support" toast.
  */
 export const getDodoCustomerIdForUserPortal = internalQuery({
   args: { userId: v.string() },
@@ -236,43 +237,79 @@ export const getDodoCustomerIdForUserPortal = internalQuery({
       .query("subscriptions")
       .withIndex("by_userId", (q) => q.eq("userId", args.userId))
       .take(50);
-    if (subs.length === 0) return null;
 
-    const sorted = [...subs].sort((a, b) => {
-      const pa = getSubscriptionStatusPriority(a.status);
-      const pb = getSubscriptionStatusPriority(b.status);
-      if (pa !== pb) return pa - pb;
-      return b.updatedAt - a.updatedAt;
-    });
+    if (subs.length > 0) {
+      const sorted = [...subs].sort((a, b) => {
+        const pa = getSubscriptionStatusPriority(a.status);
+        const pb = getSubscriptionStatusPriority(b.status);
+        if (pa !== pb) return pa - pb;
+        return b.updatedAt - a.updatedAt;
+      });
 
-    for (const sub of sorted) {
-      // Prefer the stable column written by the webhook handler;
-      // fall back to rawPayload for rows that pre-date the schema change.
-      if (typeof sub.dodoCustomerId === "string" && sub.dodoCustomerId.length > 0) {
-        return sub.dodoCustomerId;
+      for (const sub of sorted) {
+        // Tier 1: stable column populated by the webhook handler.
+        if (typeof sub.dodoCustomerId === "string" && sub.dodoCustomerId.length > 0) {
+          return sub.dodoCustomerId;
+        }
+        // Tier 2: rawPayload fallback for pre-schema-change rows whose
+        // rawPayload still carries the customer field.
+        const payload = sub.rawPayload as
+          | { customer?: { customer_id?: unknown } }
+          | null
+          | undefined;
+        const id = payload?.customer?.customer_id;
+        if (typeof id === "string" && id.length > 0) return id;
       }
-      const payload = sub.rawPayload as
-        | { customer?: { customer_id?: unknown } }
-        | null
-        | undefined;
-      const id = payload?.customer?.customer_id;
-      if (typeof id === "string" && id.length > 0) return id;
     }
+
+    // Tier 3: same-user customers row fallback. Covers pre-PR rows that
+    // had their rawPayload wiped by a lifecycle event before the
+    // schema change shipped — neither sub-side tier has data, but the
+    // customers row may still hold a usable `dodoCustomerId` for this
+    // exact userId. Skipped if a different Clerk user currently owns
+    // the row (cross-user race) — that's a refusal-to-impersonate, not
+    // a fallback we should bridge silently.
+    const customer = await ctx.db
+      .query("customers")
+      .withIndex("by_userId", (q) => q.eq("userId", args.userId))
+      .first();
+    if (
+      customer &&
+      typeof customer.dodoCustomerId === "string" &&
+      customer.dodoCustomerId.length > 0
+    ) {
+      return customer.dodoCustomerId;
+    }
+
     return null;
   },
 });
 
 /**
  * One-shot backfill: populate the new `subscriptions.dodoCustomerId`
- * column from existing rows' `rawPayload.customer.customer_id`. Run
- * once after the schema change ships; idempotent (re-running is a
- * no-op because populated rows are skipped).
+ * column for existing rows. Run once after the schema change ships;
+ * idempotent (already-populated rows skipped on re-run).
+ *
+ * Two recovery sources, tried in order:
+ *   1. `rawPayload.customer.customer_id` from the subscription row
+ *      itself — covers most pre-PR rows (the customer field was on
+ *      the original `subscription.active` payload).
+ *   2. `customers.dodoCustomerId` matched by the sub's `userId` —
+ *      recovers the pathological case where a pre-PR lifecycle event
+ *      wiped `rawPayload.customer` before this PR shipped, but the
+ *      customers row still has a usable mapping for the same userId.
+ *      Refuses cross-user collision (matches by userId only) — this
+ *      is a backfill, not a re-attribution.
  *
  * Run:
  *   npx convex run payments/billing:backfillSubscriptionDodoCustomerId
  *
- * Returns `{ inspected, populated, alreadyPopulated, missingPayload }`
- * so the operator can verify the post-backfill state.
+ * Returns
+ *   `{ inspected, populatedFromPayload, populatedFromCustomers,
+ *      alreadyPopulated, unrecoverable }`
+ * so the operator can see which recovery source covered each sub and
+ * which rows still need manual triage (unrecoverable = neither source
+ * had data).
  */
 export const backfillSubscriptionDodoCustomerId = internalMutation({
   args: {},
@@ -280,26 +317,40 @@ export const backfillSubscriptionDodoCustomerId = internalMutation({
     const all = await ctx.db.query("subscriptions").collect();
     const summary = {
       inspected: all.length,
-      populated: 0,
+      populatedFromPayload: 0,
+      populatedFromCustomers: 0,
       alreadyPopulated: 0,
-      missingPayload: 0,
+      unrecoverable: 0,
     };
     for (const sub of all) {
       if (typeof sub.dodoCustomerId === "string" && sub.dodoCustomerId.length > 0) {
         summary.alreadyPopulated++;
         continue;
       }
+      // Source 1: rawPayload.
       const payload = sub.rawPayload as
         | { customer?: { customer_id?: unknown } }
         | null
         | undefined;
-      const id = payload?.customer?.customer_id;
-      if (typeof id !== "string" || id.length === 0) {
-        summary.missingPayload++;
+      const fromPayload = payload?.customer?.customer_id;
+      if (typeof fromPayload === "string" && fromPayload.length > 0) {
+        await ctx.db.patch(sub._id, { dodoCustomerId: fromPayload });
+        summary.populatedFromPayload++;
         continue;
       }
-      await ctx.db.patch(sub._id, { dodoCustomerId: id });
-      summary.populated++;
+      // Source 2: same-userId customers row (P1 reviewer's
+      // "pre-schema row had its rawPayload wiped before the PR" case).
+      const customer = await ctx.db
+        .query("customers")
+        .withIndex("by_userId", (q) => q.eq("userId", sub.userId))
+        .first();
+      const fromCustomer = customer?.dodoCustomerId;
+      if (typeof fromCustomer === "string" && fromCustomer.length > 0) {
+        await ctx.db.patch(sub._id, { dodoCustomerId: fromCustomer });
+        summary.populatedFromCustomers++;
+        continue;
+      }
+      summary.unrecoverable++;
     }
     return summary;
   },

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -422,6 +422,31 @@ function toEpochMs(value: unknown, fieldName?: string, fallback?: number): numbe
 // ---------------------------------------------------------------------------
 
 /**
+ * Coalesce the Dodo customer id across a webhook event and the existing
+ * subscriptions row.
+ *
+ * `DodoSubscriptionData.customer` is optional and lifecycle events
+ * (`subscription.renewed`, `.on_hold`, `.cancelled`, `.plan_changed`,
+ * `.expired`, `.updated`) sometimes arrive without it. A blind
+ * `rawPayload: data` patch would silently wipe the previously-known
+ * `customer.customer_id` and leave callers (esp. the Manage Billing
+ * portal lookup) unable to resolve which Dodo customer to bill against.
+ *
+ * Rule: prefer the incoming event's customer_id if present and a
+ * non-empty string; otherwise preserve whatever the existing row had
+ * (which may itself be undefined if every prior event was customer-less
+ * — that's the genuine "no customer" state).
+ */
+function mergeDodoCustomerId(
+  data: DodoSubscriptionData,
+  existing: { dodoCustomerId?: string },
+): string | undefined {
+  const incoming = data.customer?.customer_id;
+  if (typeof incoming === "string" && incoming.length > 0) return incoming;
+  return existing.dodoCustomerId;
+}
+
+/**
  * Handles `subscription.active` -- a new subscription has been activated.
  *
  * Creates or updates the subscription record and upserts entitlements.
@@ -448,6 +473,17 @@ export async function handleSubscriptionActive(
     )
     .unique();
 
+  // Stable first-class projection of the Dodo customer id, used by the
+  // Manage Billing portal lookup. `data.customer?.customer_id` is
+  // sometimes absent on lifecycle events (renewed / on_hold / cancelled
+  // / plan_changed / expired), so we always coalesce with the existing
+  // column to preserve a known value across patches that overwrite
+  // `rawPayload` blindly.
+  const incomingDodoCustomerId =
+    typeof data.customer?.customer_id === "string" && data.customer.customer_id.length > 0
+      ? data.customer.customer_id
+      : undefined;
+
   if (existing) {
     if (!isNewerEvent(existing.updatedAt, eventTimestamp)) return;
     await ctx.db.patch(existing._id, {
@@ -457,6 +493,7 @@ export async function handleSubscriptionActive(
       planKey,
       currentPeriodStart,
       currentPeriodEnd,
+      dodoCustomerId: incomingDodoCustomerId ?? existing.dodoCustomerId,
       rawPayload: data,
       updatedAt: eventTimestamp,
     });
@@ -469,6 +506,7 @@ export async function handleSubscriptionActive(
       status: "active",
       currentPeriodStart,
       currentPeriodEnd,
+      dodoCustomerId: incomingDodoCustomerId,
       rawPayload: data,
       updatedAt: eventTimestamp,
     });
@@ -605,6 +643,7 @@ export async function handleSubscriptionRenewed(
     status: "active",
     currentPeriodStart,
     currentPeriodEnd,
+    dodoCustomerId: mergeDodoCustomerId(data, existing),
     rawPayload: data,
     updatedAt: eventTimestamp,
   });
@@ -642,6 +681,7 @@ export async function handleSubscriptionOnHold(
 
   await ctx.db.patch(existing._id, {
     status: "on_hold",
+    dodoCustomerId: mergeDodoCustomerId(data, existing),
     rawPayload: data,
     updatedAt: eventTimestamp,
   });
@@ -685,6 +725,7 @@ export async function handleSubscriptionCancelled(
   await ctx.db.patch(existing._id, {
     status: "cancelled",
     cancelledAt,
+    dodoCustomerId: mergeDodoCustomerId(data, existing),
     rawPayload: data,
     updatedAt: eventTimestamp,
   });
@@ -723,6 +764,7 @@ export async function handleSubscriptionPlanChanged(
   await ctx.db.patch(existing._id, {
     dodoProductId: data.product_id,
     planKey: newPlanKey,
+    dodoCustomerId: mergeDodoCustomerId(data, existing),
     rawPayload: data,
     updatedAt: eventTimestamp,
   });
@@ -762,6 +804,7 @@ export async function handleSubscriptionExpired(
 
   await ctx.db.patch(existing._id, {
     status: "expired",
+    dodoCustomerId: mergeDodoCustomerId(data, existing),
     rawPayload: data,
     updatedAt: eventTimestamp,
   });
@@ -822,6 +865,7 @@ export async function handleSubscriptionUpdated(
         .unique();
       if (existing && isNewerEvent(existing.updatedAt, eventTimestamp)) {
         await ctx.db.patch(existing._id, {
+          dodoCustomerId: mergeDodoCustomerId(data, existing),
           rawPayload: data,
           updatedAt: eventTimestamp,
         });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -408,11 +408,24 @@ export default defineSchema({
     currentPeriodStart: v.number(),
     currentPeriodEnd: v.number(),
     cancelledAt: v.optional(v.number()),
+    // Stable first-class projection of `rawPayload.customer.customer_id`
+    // (the Dodo customer this sub was paid as). Optional because
+    // `DodoSubscriptionData.customer` is itself optional and lifecycle
+    // event payloads (`subscription.renewed`, `.on_hold`, `.cancelled`,
+    // `.plan_changed`, `.expired`) sometimes arrive without it — a
+    // blind `rawPayload: data` patch would otherwise wipe the value.
+    // Webhook handlers write this field with `data.customer?.customer_id
+    // ?? existing.dodoCustomerId` so it survives lifecycle patches.
+    // Manage Billing reads this column (not rawPayload) to find the
+    // correct portal customer per Clerk userId — see
+    // `payments/billing:getDodoCustomerIdForUserPortal`.
+    dodoCustomerId: v.optional(v.string()),
     rawPayload: v.any(),
     updatedAt: v.number(),
   })
     .index("by_userId", ["userId"])
-    .index("by_dodoSubscriptionId", ["dodoSubscriptionId"]),
+    .index("by_dodoSubscriptionId", ["dodoSubscriptionId"])
+    .index("by_dodoCustomerId", ["dodoCustomerId"]),
 
   entitlements: defineTable({
     userId: v.string(),

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -415,10 +415,15 @@ export default defineSchema({
     // `.plan_changed`, `.expired`) sometimes arrive without it — a
     // blind `rawPayload: data` patch would otherwise wipe the value.
     // Webhook handlers write this field with `data.customer?.customer_id
-    // ?? existing.dodoCustomerId` so it survives lifecycle patches.
-    // Manage Billing reads this column (not rawPayload) to find the
-    // correct portal customer per Clerk userId — see
-    // `payments/billing:getDodoCustomerIdForUserPortal`.
+    // ?? existing.dodoCustomerId` (see `mergeDodoCustomerId` in
+    // `subscriptionHelpers.ts`) so it survives lifecycle patches.
+    //
+    // Manage Billing prefers this column when populated — see
+    // `payments/billing:getDodoCustomerIdForUserPortal`, which is a
+    // 3-tier resolver (this column → `rawPayload.customer.customer_id`
+    // → `customers.dodoCustomerId` for the same userId). Pre-PR rows
+    // may still rely on tiers 2-3 until
+    // `backfillSubscriptionDodoCustomerId` lands their values here.
     dodoCustomerId: v.optional(v.string()),
     rawPayload: v.any(),
     updatedAt: v.number(),


### PR DESCRIPTION
## Summary

Replaces the layered customers-row resolution in
\`createCustomerPortalUrlForUser\` with a single direct lookup of the
\`dodoCustomerId\` from the user's own preferred subscription's
\`rawPayload\`. The customers table is no longer in the Manage Billing
critical path.

## Why

The original WORLDMONITOR-R5 symptom (\`No Dodo customer found for
this user\` → opaque \`[Request ID: X] Server Error\`) wasn't a missing
customers row — it was the customers row's \`userId\` being **reassigned
out from under the affected user** by a later concurrent webhook.

The webhook handler at \`subscriptionHelpers.ts:533-539\` patches the
existing customers row's \`userId\` whenever a \`subscription.active\`
event for a matching \`dodoCustomerId\` arrives. Dodo dedupes customer
records by email, so multiple Clerk accounts checking out with the
same email (the same human, or two humans sharing an email) all
produce subscriptions tied to the same Dodo customer — and every
new webhook re-claims the customers row for the latest-checking-out
Clerk userId. The user who originally paid is left with a valid
\`subscriptions\` row but no \`customers\` row.

Building self-heal + cross-account Clerk verification on top of that
broken anchor was a series of band-aids. The right fix is to stop
using the customers table as the per-Clerk-user truth and read the
per-Clerk-user value (\`subscriptions.rawPayload.customer.customer_id\`)
that already exists — keyed by the HMAC-signed Clerk userId at
checkout, immutable, never patched away.

## What changed

- New \`getDodoCustomerIdForUserPortal\` internalQuery walks
  \`subscriptions\` for the userId, sorts by status preference (active
  → on_hold → cancelled → other; tie-break newest \`updatedAt\`), and
  returns the first usable \`rawPayload.customer.customer_id\`.
- \`createCustomerPortalUrlForUser\` calls it directly; on null,
  throws structured \`ConvexError({ kind: 'NO_CUSTOMER' })\` (existing
  client-side toast unchanged). No more 3 tiers, no Clerk lookup, no
  self-heal call in this path.
- Helper signature dropped from \`Pick<ActionCtx, 'runQuery' |
  'runMutation'>\` back to just \`Pick<ActionCtx, 'runQuery'>\` since
  the mutation call is no longer needed here.
- The existing \`repairCustomerFromSubscriptionPayload\` and
  \`backfillMissingCustomers\` stay in the codebase — they're still
  useful for other consumers of the customers table (broadcast
  paid-set, comp-grant lookups), which tolerate the attribution race.

## Result

Every Clerk account with at least one valid subscription gets its own
portal session for the Dodo customer it actually paid as — regardless
of how many other Clerk accounts share that Dodo customer. The
WORLDMONITOR-R5 class can't recur for any Clerk userId with a valid
sub. No regression for users with single-account state (path is
strictly simpler than before).

## Test plan

- [x] \`npm run typecheck\` — PASS
- [x] \`npm run typecheck:api\` — PASS (incl. \`audit-convex-string-calls\`)
- [x] \`npx vitest run convex/__tests__/billing.test.ts\` — **25/25
  PASS** (17 existing + 8 new for the portal lookup)
- [ ] Post-deploy: have user_3CikGbPQjJt2Ufj8v8ML9GZDE81 (or
      user_3ClP1pOEmgrBY1utNn2X5wYAXEg) click "Manage Billing" in
      the dashboard and confirm the Dodo Customer Portal opens for
      \`cus_0NcCqbLaO3mVIU5colXZq\` (the shared customer) without a
      "contact support" toast — previously they were hitting the
      cross-user collision refusal.