### PR TITLE
fix(brief): single canonical synthesis — kill the compose/enrich/send parity regression

### DIFF
--- a/scripts/lib/brief-llm.mjs
+++ b/scripts/lib/brief-llm.mjs
@@ -991,11 +991,24 @@ async function mapLimit(items, limit, fn) {
  * BriefEnvelope (structure unchanged; only string/array field
  * contents are substituted).
  *
+ * `opts.skipDigestProse` — when true, the per-user digest-prose call
+ * is SKIPPED entirely and `envelope.data.digest` is passed through
+ * untouched; only per-story `whyMatters` / `description` are
+ * enriched. The compose path passes this because it has ALREADY
+ * produced the canonical synthesis (via `runSynthesisWithFallback`)
+ * and spliced it into the envelope. Without the skip, this function
+ * re-synthesises here — a SECOND, ctx-free `generateDigestProse`
+ * call that overwrites the compose-pass synthesis and breaks the
+ * compose↔send parity contract. See plan
+ * docs/plans/2026-05-14-001-fix-brief-pipeline-parity-grounding-opinion-plan.md
+ * (F1, "call site 2") + Codex review R2.
+ *
  * @param {object} envelope
  * @param {{ userId: string; sensitivity?: string }} rule
  * @param {{ callLLM: Function; cacheGet: Function; cacheSet: Function }} deps
+ * @param {{ skipDigestProse?: boolean }} [opts]
  */
-export async function enrichBriefEnvelopeWithLLM(envelope, rule, deps) {
+export async function enrichBriefEnvelopeWithLLM(envelope, rule, deps, opts = {}) {
   if (!envelope?.data || !Array.isArray(envelope.data.stories)) return envelope;
   const stories = envelope.data.stories;
   // Default to 'high' (NOT 'all') so the digest prompt and cache key
@@ -1023,16 +1036,22 @@ export async function enrichBriefEnvelopeWithLLM(envelope, rule, deps) {
     };
   });
 
-  // Per-user digest prose — one call.
-  const prose = await generateDigestProse(rule.userId, stories, sensitivity, deps);
-  const digest = prose
-    ? {
+  // Per-user digest prose — one call, UNLESS the caller already
+  // supplied the canonical synthesis (skipDigestProse). See the
+  // function-header note: re-synthesising here is the "call site 2"
+  // parity regression.
+  let digest = envelope.data.digest;
+  if (opts?.skipDigestProse !== true) {
+    const prose = await generateDigestProse(rule.userId, stories, sensitivity, deps);
+    if (prose) {
+      digest = {
         ...envelope.data.digest,
         lead: prose.lead,
         threads: prose.threads,
         signals: prose.signals,
-      }
-    : envelope.data.digest;
+      };
+    }
+  }
 
   return {
     ...envelope,

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -2447,7 +2447,30 @@ async function main() {
       // Both alarms warn on the same console.warn channel so Sentry's
       // console-breadcrumb hook surfaces them without explicit
       // captureMessage calls.
-      if (AI_DIGEST_ENABLED && rule.aiDigestEnabled !== false) {
+      if (AI_DIGEST_ENABLED && rule.aiDigestEnabled !== false && !brief) {
+        // Compose-miss path: `briefByUser` had no entry for this user,
+        // so the canonical-rule filter was skipped and this rule fell
+        // through to the legacy per-rule send (see the compose-miss
+        // branch above). There is NO canonical envelope to compare
+        // against — `brief` is undefined — so winner_match and
+        // channels_equal are both n/a. winnerVariant would be '' here,
+        // which would make winner_match=false and trip a FALSE
+        // PARITY REGRESSION every compose-miss tick. The compose-miss
+        // itself is already logged separately (`[digest] compose-miss
+        // user=…`), so emit an informational parity line and skip both
+        // alarms. Plan 2026-05-14-001 F1, Phase 1 step 5.
+        console.log(
+          `[digest] brief lead parity user=${rule.userId} ` +
+            `rule=${rule.variant ?? 'full'}:${rule.sensitivity ?? 'high'}:${rule.lang ?? 'en'} ` +
+            `winner_match=n/a ` +
+            `synthesis_level=${synthesisLevel} ` +
+            `exec_len=${(briefLead ?? '').length} ` +
+            `brief_lead_len=0 ` +
+            `channels_equal=n/a ` +
+            `public_lead_len=0 ` +
+            `reason=compose-miss`,
+        );
+      } else if (AI_DIGEST_ENABLED && rule.aiDigestEnabled !== false) {
         const envLead = brief?.envelope?.data?.digest?.lead ?? '';
         const winnerVariant = brief?.chosenVariant ?? '';
         const winnerMatch = winnerVariant === (rule.variant ?? 'full');
@@ -2475,12 +2498,15 @@ async function main() {
             `public_lead_len=${publicLead.length}`,
         );
         if (!winnerMatch) {
-          // Under option (a) this is unreachable in practice — the
-          // canonical-rule filter at the top of the loop drops every
-          // non-winner rule before this point. If we ever see it in
-          // production, the canonical-rule filter has been bypassed
-          // OR briefByUser/chosenVariant drifted between compose and
-          // send. Hard alarm.
+          // This branch is reached ONLY when `brief` exists (the
+          // compose-miss case is handled in the `!brief` branch
+          // above with winner_match=n/a). Under option (a) it is
+          // unreachable in practice — the canonical-rule filter at
+          // the top of the loop drops every non-winner rule before
+          // this point. If we ever see it in production with a
+          // present `brief`, the canonical-rule filter has been
+          // bypassed OR briefByUser/chosenVariant drifted between
+          // compose and send. Hard alarm.
           console.warn(
             `[digest] PARITY REGRESSION user=${rule.userId} — winner_match=false under option (a). ` +
               `Expected: winner_variant=${winnerVariant || '<missing>'} === rule_variant=${rule.variant ?? 'full'}. ` +

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -1621,14 +1621,20 @@ async function composeAndStoreBriefForUser(userId, annotated, insightsNumbers, d
 
   if (!envelope) return null;
 
-  // Per-story whyMatters enrichment. The synthesis is already in the
-  // envelope; this pass only fills per-story rationales. Failures
-  // fall through cleanly — the stub `whyMatters` from the composer
-  // is acceptable.
+  // Per-story whyMatters enrichment. The canonical synthesis is
+  // already spliced into the envelope above; `skipDigestProse: true`
+  // makes this pass fill ONLY per-story rationales and leave
+  // `envelope.data.digest` untouched. Without the flag,
+  // enrichBriefEnvelopeWithLLM re-synthesises the digest prose here
+  // (a second, ctx-free generateDigestProse call) and overwrites the
+  // compose-pass synthesis — the "call site 2" parity regression.
+  // See docs/plans/2026-05-14-001-fix-brief-pipeline-parity-grounding-opinion-plan.md.
+  // Failures fall through cleanly — the stub `whyMatters` from the
+  // composer is acceptable.
   let finalEnvelope = envelope;
   if (BRIEF_LLM_ENABLED) {
     try {
-      const enriched = await enrichBriefEnvelopeWithLLM(envelope, winner.rule, briefLlmDeps);
+      const enriched = await enrichBriefEnvelopeWithLLM(envelope, winner.rule, briefLlmDeps, { skipDigestProse: true });
       // Defence in depth: re-validate the enriched envelope against
       // the renderer's strict contract before we SETEX it. If
       // enrichment produced a structurally broken shape (bad cache
@@ -1688,6 +1694,13 @@ async function composeAndStoreBriefForUser(userId, annotated, insightsNumbers, d
     // assertNoExtraKeys would reject it). Read by the send loop for
     // the email subject-line ternary and the parity log.
     synthesisLevel,
+    // Canonical synthesis ({lead, threads, signals, rankedStoryHashes}
+    // or null for L3 stub / BRIEF_LLM_ENABLED=false). The send pass
+    // reads this DIRECTLY instead of re-synthesising — a second
+    // synthesis call diverges from the compose pass and breaks the
+    // parity contract (the "call site 3" regression). See plan
+    // docs/plans/2026-05-14-001-fix-brief-pipeline-parity-grounding-opinion-plan.md.
+    synthesis,
   };
 }
 
@@ -1918,45 +1931,43 @@ async function main() {
     // We are guaranteed to be on the WINNING rule for this user-slot
     // (the canonical-rule filter above dropped every non-winner). So:
     //
-    //   - The synthesis we run here against `stories` is the canonical
-    //     synthesis that backs the magazine envelope. generateDigestProse
-    //     hits the same cache row the compose phase wrote (same
-    //     userId/sensitivity/pool/ctx), so this is a cache read, not a
-    //     second LLM call.
+    //   - The send pass reads the canonical synthesis the COMPOSE pass
+    //     already produced (carried on the briefByUser entry as
+    //     `synthesis`). It does NOT re-synthesise. A second
+    //     runSynthesisWithFallback call here would diverge from the
+    //     compose pass — different `stories` pool, different ctx,
+    //     temperature 0.4 — and break the compose↔send parity contract
+    //     (the "call site 3" parity regression). See plan
+    //     docs/plans/2026-05-14-001-fix-brief-pipeline-parity-grounding-opinion-plan.md
+    //     (F1) + Codex review.
     //   - Every channel body — email HTML + plain text + Telegram +
     //     Slack + Discord + webhook — reads from this single synthesis
     //     output. There is no per-rule fan-out, no winner-vs-non-winner
     //     channel divergence, and no separate per-rule magazine URL.
     //   - The magazine URL (briefByUser[userId].magazineUrl) points at
     //     the SAME rule's envelope this synthesis was derived from, so
-    //     subscribers experience full email-body ↔ magazine consistency
-    //     for the first time.
-    //
-    // Pre-U2 (PR <U2-pr> reference), this block ran a fresh synthesis
-    // per enabled rule and accepted "channel-body lead vs magazine lead
-    // may differ for non-winner rules" as a trade-off. Option (a) closes
-    // the divergence at the cost of multi-rule users seeing only the
-    // winner rule's content per slot — confirmed during planning as the
-    // intended subscriber-visible behaviour change.
+    //     subscribers experience full email-body ↔ magazine consistency.
     //
     // Reuse briefForUser fetched above (Codex PR #3614 P2 — was a
-    // duplicate Map.get on the same key).
+    // duplicate Map.get on the same key). In the compose-miss
+    // fallback path `brief` is undefined → no synthesis to read → no
+    // editorial block this tick (the story list still ships); the
+    // path is rare and self-healing on the next compose.
     const brief = briefForUser;
     let briefSynthesis = null;  // full {lead, threads, signals} when synthesis succeeded
     let briefLead = null;       // string projection for non-email channels + parity log
-    let synthesisLevel = 3;
-    if (AI_DIGEST_ENABLED && rule.aiDigestEnabled !== false) {
-      const ruleCtx = await buildSynthesisCtx(rule, nowMs);
-      const ruleResult = await runSynthesisWithFallback(
-        rule.userId,
-        stories,
-        rule.sensitivity ?? 'high',
-        ruleCtx,
-        briefLlmDeps,
-      );
-      briefSynthesis = ruleResult.synthesis;
-      briefLead = ruleResult.synthesis?.lead ?? null;
-      synthesisLevel = ruleResult.level;
+    // synthesisLevel is sourced from the compose pass — not recomputed.
+    const synthesisLevel = brief?.synthesisLevel ?? 3;
+    // Gate: AI_DIGEST_ENABLED + per-rule opt-out + synthesisLevel ∈
+    // {1,2}. For L3 (stub) or opt-out, briefSynthesis/briefLead stay
+    // null and the channel bodies render no editorial block — exactly
+    // today's behaviour. The persisted envelope always carries a
+    // `digest.lead` (even the L3 stub), so reading the synthesis from
+    // the briefByUser entry (NOT the envelope) is what keeps L3 /
+    // opt-out users from getting a fake "Executive Summary".
+    if (AI_DIGEST_ENABLED && rule.aiDigestEnabled !== false && synthesisLevel !== 3) {
+      briefSynthesis = brief?.synthesis ?? null;
+      briefLead = briefSynthesis?.lead ?? null;
     }
 
     // Sprint 1 / U7 production-gap fix.
@@ -2440,7 +2451,18 @@ async function main() {
         const envLead = brief?.envelope?.data?.digest?.lead ?? '';
         const winnerVariant = brief?.chosenVariant ?? '';
         const winnerMatch = winnerVariant === (rule.variant ?? 'full');
-        const channelsEqual = briefLead === envLead;
+        // channels_equal is `n/a` when there is no channel synthesis
+        // (L3 stub, aiDigest opt-out, or — defensively — compose-miss):
+        // briefLead is intentionally null and there is nothing to
+        // compare. The persisted envelope ALWAYS carries a
+        // `digest.lead` (the L3 stub included), so comparing null
+        // against it would emit a misleading `channels_equal=false`
+        // and, pre-fix, a false PARITY REGRESSION every tick for
+        // every L3 / opt-out user. See plan
+        // docs/plans/2026-05-14-001-fix-brief-pipeline-parity-grounding-opinion-plan.md
+        // (F1, Phase 1 step 5).
+        const hasChannelSynthesis = briefLead != null;
+        const channelsEqual = hasChannelSynthesis ? (briefLead === envLead) : 'n/a';
         const publicLead = brief?.envelope?.data?.digest?.publicLead ?? '';
         console.log(
           `[digest] brief lead parity user=${rule.userId} ` +
@@ -2464,13 +2486,19 @@ async function main() {
               `Expected: winner_variant=${winnerVariant || '<missing>'} === rule_variant=${rule.variant ?? 'full'}. ` +
               `Investigate: canonical-rule filter bypass OR compose↔send chosenVariant drift.`,
           );
-        } else if (!channelsEqual && briefLead && envLead) {
-          // Canonical-synthesis cache row drifted between compose and
-          // send passes — a real contract break. Same semantics as
-          // pre-U2 PARITY REGRESSION.
+        } else if (hasChannelSynthesis && channelsEqual === false) {
+          // Channel lead != envelope lead while a channel synthesis
+          // exists — a real contract break. After the Phase-1 parity
+          // fix the send pass reads the SAME synthesis object the
+          // compose pass spliced into the envelope, so for L1/L2 this
+          // is now unreachable UNLESS envelope.data.digest.lead was
+          // mutated after compose (e.g. a stray enrichment path
+          // re-running digest prose). If this fires, that invariant
+          // broke — investigate post-compose envelope mutation.
           console.warn(
             `[digest] PARITY REGRESSION user=${rule.userId} — winner-rule channel lead != envelope lead. ` +
-              `Investigate: cache drift between compose pass and send pass?`,
+              `Post-Phase-1 the send pass reads the compose-pass synthesis directly; ` +
+              `a mismatch means envelope.data.digest.lead was mutated after compose.`,
           );
         }
       }

--- a/tests/brief-llm.test.mjs
+++ b/tests/brief-llm.test.mjs
@@ -1203,6 +1203,54 @@ describe('enrichBriefEnvelopeWithLLM', () => {
     assert.equal(out.data.stories.length, env.data.stories.length);
   });
 
+  it('skipDigestProse: true — does NOT call generateDigestProse, leaves digest untouched, still enriches whyMatters', async () => {
+    // PR-A / plan 2026-05-14-001 F1, "call site 2": the compose path
+    // already produced the canonical synthesis and spliced it into
+    // the envelope. With skipDigestProse:true this pass must do ONLY
+    // per-story enrichment — re-synthesising here would overwrite the
+    // compose-pass synthesis with a ctx-free re-roll and break parity.
+    const cache = makeCache();
+    const llm = makeLLM((_sys, user) => {
+      if (user.includes('Reader sensitivity level')) return goodProse;
+      return goodWhy;
+    });
+    const env = envelope();
+    const out = await enrichBriefEnvelopeWithLLM(
+      env,
+      { userId: 'user_a', sensitivity: 'all' },
+      { ...cache, callLLM: llm.callLLM },
+      { skipDigestProse: true },
+    );
+    // No digest-prose LLM call was made (the digest-prose prompt is
+    // the only one carrying the "Reader sensitivity level" marker).
+    const proseCalls = llm.calls.filter((c) => c.user.includes('Reader sensitivity level'));
+    assert.equal(proseCalls.length, 0, 'skipDigestProse must suppress the generateDigestProse call');
+    // digest is the input envelope's digest, untouched (same reference)
+    assert.equal(out.data.digest, env.data.digest, 'digest passed through by reference — not rebuilt');
+    assert.equal(out.data.digest.lead, env.data.digest.lead);
+    assert.deepEqual(out.data.digest.threads, env.data.digest.threads);
+    assert.deepEqual(out.data.digest.signals, env.data.digest.signals);
+    // per-story whyMatters STILL enriched
+    for (const s of out.data.stories) {
+      assert.equal(s.whyMatters, goodWhy, 'per-story enrichment still runs under skipDigestProse');
+    }
+  });
+
+  it('skipDigestProse omitted (default) — still runs generateDigestProse (back-compat)', async () => {
+    const cache = makeCache();
+    const llm = makeLLM((_sys, user) => {
+      if (user.includes('Reader sensitivity level')) return goodProse;
+      return goodWhy;
+    });
+    const env = envelope();
+    const out = await enrichBriefEnvelopeWithLLM(env, { userId: 'user_a', sensitivity: 'all' }, {
+      ...cache, callLLM: llm.callLLM,
+    });
+    const proseCalls = llm.calls.filter((c) => c.user.includes('Reader sensitivity level'));
+    assert.equal(proseCalls.length, 1, 'default (no opts) behaviour: digest prose is still synthesised');
+    assert.match(out.data.digest.lead, /Strait of Hormuz/);
+  });
+
   it('LLM down everywhere: envelope returns unchanged stubs', async () => {
     const cache = makeCache();
     const llm = makeLLM(() => { throw new Error('provider down'); });


### PR DESCRIPTION
## Summary

PR A of the brief-pipeline plan (`docs/plans/2026-05-14-001-fix-brief-pipeline-parity-grounding-opinion-plan.md`, Codex-approved after 3 rounds). Phase 1 + Phase 1.5.

The May 14 0802 brief tripped `PARITY REGRESSION` for a real user — the email channel lead (403 chars) and the magazine envelope lead (373 chars) were **different syntheses**. PR #3396's canonical-brain promise had regressed because there were **three** synthesis call sites, not one:

1. **Compose pass** — `runSynthesisWithFallback` (ctx-aware), spliced into the envelope. Its output never survived.
2. **`enrichBriefEnvelopeWithLLM`** — a 4-arg, **NO-ctx** `generateDigestProse` call that **overwrote** `envelope.data.digest`. The comment claimed it "only fills per-story rationales" — it lied.
3. **Send pass** — `runSynthesisWithFallback` against a different `stories` pool, for the channel bodies.

Compose built a ctx-aware synthesis, enrich threw it away and re-rolled context-free, send rolled a third time. At temperature 0.4 the three rolls diverge.

## Fix — collapse to ONE synthesis, produced by the compose pass

- **`enrichBriefEnvelopeWithLLM` gains `opts.skipDigestProse`.** When set, it does ONLY per-story `whyMatters`/`description` enrichment and leaves `envelope.data.digest` untouched. The compose path passes `skipDigestProse: true`. **Call site 2 gone.**
- **`composeAndStoreBriefForUser` returns the `synthesis` object** on its `briefByUser` entry (alongside the existing `synthesisLevel`).
- **The send pass no longer calls `runSynthesisWithFallback`.** It reads `briefSynthesis` / `briefLead` / `synthesisLevel` from the compose-pass result. **Call site 3 gone.**
- **L3 / opt-out gate preserved** — `briefSynthesis`/`briefLead` only set when `AI_DIGEST_ENABLED && rule.aiDigestEnabled !== false && synthesisLevel !== 3`. The persisted envelope always carries a `digest.lead` (the L3 stub included), so reading from the `briefByUser` entry — **not** the envelope — is what keeps L3/opt-out users from a fake "Executive Summary".
- **Parity log: `channels_equal` is now `n/a`** (not a misleading `false`) when there is no channel synthesis (L3 / opt-out / compose-miss). Stops those users tripping a false `PARITY REGRESSION` every tick. The remaining `PARITY REGRESSION` branch fires only on a genuine post-compose envelope mutation.

**Legitimate non-violations preserved:** `generateDigestProsePublic` stays (separate public/share synthesis); the L1→L2 fallback inside `runSynthesisWithFallback` may still call `generateDigestProse` twice within one canonical attempt.

## Phase 1.5 — F5 root-cause finding (investigation, no code)

A harness fed the verbatim May 14 severity walk (`CCHHHHCCCCHH`) through `orderBriefCandidates` under four topic-assignment scenarios. **None reproduce the shipped interleave** — `bestSeverityRank` is the comparator's primary block-sort key, so a high-only block can never precede a critical block. **H2 (comparator bug) is ruled out; H1 confirmed.** The comparator is untouched. F5 gets a post-PR-A verification step (re-fetch a freshly-composed brief; if still interleaved, probe the `threatLevel` field as seen by `filterTopStories`). Full finding recorded in the plan's Phase 1.5 section.

## Test plan

- [x] 2 new `enrichBriefEnvelopeWithLLM` tests: `skipDigestProse: true` suppresses the `generateDigestProse` call + leaves `digest` untouched (same reference) + still enriches `whyMatters`; default (no opts) still synthesises (back-compat)
- [x] `node --test tests/brief-llm.test.mjs` → 93/93 pass
- [x] `tsx --test tests/*.test.mjs tests/*.test.mts` → 8702/8702 pass
- [x] `npx tsc --noEmit` clean
- [x] `biome check` — 2 pre-existing complexity warnings on `buildDigest`/`main` (4-5x over limit on origin/main already; this change neither introduced nor worsened them)
- [ ] **After deploy** — verify on a freshly-composed brief: zero `PARITY REGRESSION` in the cron log; `channels_equal=true` for L1/L2 users, `channels_equal=n/a` for L3/opt-out; email lead == magazine lead byte-identical
- [ ] **After deploy** — F5 verification: re-fetch a brief, confirm severity walk is `orderBriefCandidates`-clean (criticals-first within topic blocks)

## Not in this PR

PR B (grounding gate + prompt sanitization) and PR C (opinion exclusion + lead/card coherence) — both depend on PR A and are tracked in the plan. F5's post-deploy verification and any residual probe ride on the plan, not this PR.