### PR TITLE
fix(stock-analysis): additive tier-aware watchlist for PRO users

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -88,6 +88,7 @@ import {
   fetchStoredStockBacktests,
   getMissingOrStaleStoredStockBacktests,
   hasFreshStoredStockBacktests,
+  type StockBacktestResult,
 } from '@/services/stock-backtest';
 import {
   fetchStockAnalysisHistory,
@@ -1344,7 +1345,22 @@ export class DataLoaderManager implements AppModule {
         }
         return;
       }
-      panel.renderBacktests(results);
+      // Build a combined view so a partial refetch does not shrink the panel:
+      // keep still-fresh cached backtests for symbols we did NOT refetch, swap
+      // in live results for the ones we did. Watchlist order is preserved.
+      const resultBySymbol = new Map(results.map((r) => [r.symbol, r]));
+      const storedBySymbol = new Map(stored.map((s) => [s.symbol, s]));
+      const combined: StockBacktestResult[] = [];
+      for (const target of targets) {
+        const live = resultBySymbol.get(target.symbol);
+        if (live) {
+          combined.push(live);
+          continue;
+        }
+        const cached = storedBySymbol.get(target.symbol);
+        if (cached) combined.push(cached);
+      }
+      panel.renderBacktests(combined.length > 0 ? combined : results);
     } catch (error) {
       console.error('[StockBacktest] failed:', error);
       const stored = await fetchStoredStockBacktests().catch(() => []);

--- a/src/components/DailyMarketBriefPanel.ts
+++ b/src/components/DailyMarketBriefPanel.ts
@@ -6,6 +6,7 @@ import type { DailyMarketBrief } from '@/services/daily-market-brief';
 import { describeFreshness } from '@/services/persistent-cache';
 import { escapeHtml } from '@/utils/sanitize';
 import { getChangeClass } from '@/utils';
+import { createWatchlistButton } from './watchlist-modal';
 
 type BriefSource = 'live' | 'cached';
 
@@ -47,6 +48,7 @@ export class DailyMarketBriefPanel extends Panel {
     super({ id: 'daily-market-brief', title: 'Daily Market Brief', infoTooltip: t('components.dailyMarketBrief.infoTooltip'), premium: 'locked' });
     this.fwSelector = new FrameworkSelector({ panelId: 'daily-market-brief', isPremium: hasPremiumAccess(), panel: this, note: 'Applies to client-generated analysis only' });
     this.header.appendChild(this.fwSelector.el);
+    this.header.appendChild(createWatchlistButton('Edit Watchlist'));
   }
 
   public override destroy(): void {

--- a/src/components/MarketPanel.ts
+++ b/src/components/MarketPanel.ts
@@ -5,105 +5,12 @@ import { formatPrice, formatChange, getChangeClass, getHeatmapClass } from '@/ut
 import { escapeHtml } from '@/utils/sanitize';
 import { miniSparkline } from '@/utils/sparkline';
 import { SITE_VARIANT } from '@/config';
-import {
-  getMarketWatchlistEntries,
-  parseMarketWatchlistInput,
-  resetMarketWatchlist,
-  setMarketWatchlistEntries,
-} from '@/services/market-watchlist';
+import { createWatchlistButton } from './watchlist-modal';
 
 export class MarketPanel extends Panel {
-  private settingsBtn: HTMLButtonElement | null = null;
-  private overlay: HTMLElement | null = null;
-
   constructor() {
     super({ id: 'markets', title: t('panels.markets'), infoTooltip: t('components.markets.infoTooltip') });
-    this.createSettingsButton();
-  }
-
-  private createSettingsButton(): void {
-    this.settingsBtn = document.createElement('button');
-    this.settingsBtn.className = 'live-news-settings-btn';
-    this.settingsBtn.title = 'Customize market watchlist';
-    this.settingsBtn.textContent = 'Watchlist';
-    this.settingsBtn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      this.openWatchlistModal();
-    });
-    this.header.appendChild(this.settingsBtn);
-  }
-
-  private openWatchlistModal(): void {
-    if (this.overlay) return;
-
-    const current = getMarketWatchlistEntries();
-    const currentText = current.length
-      ? current.map((e) => (e.name ? `${e.symbol}|${e.name}` : e.symbol)).join('\n')
-      : '';
-
-    const overlay = document.createElement('div');
-    overlay.className = 'modal-overlay active';
-    overlay.id = 'marketWatchlistModal';
-    overlay.addEventListener('click', (e) => {
-      if (e.target === overlay) this.closeWatchlistModal();
-    });
-
-    const modal = document.createElement('div');
-    modal.className = 'modal unified-settings-modal';
-    modal.style.maxWidth = '680px';
-
-    modal.innerHTML = `
-      <div class="modal-header">
-        <span class="modal-title">Market watchlist</span>
-        <button class="modal-close" aria-label="Close">×</button>
-      </div>
-      <div style="padding:14px 16px 16px 16px">
-        <div style="color:var(--text-dim);font-size:12px;line-height:1.4;margin-bottom:10px">
-          Add extra tickers (comma or newline separated). Friendly labels supported: SYMBOL|Label.
-          Example: TSLA|Tesla, AAPL|Apple, ^GSPC|S&P 500
-          <br/>
-          Tip: keep it under ~30 unless you enjoy scrolling.
-        </div>
-        <textarea id="wmMarketWatchlistInput"
-          style="width:100%;min-height:120px;resize:vertical;background:rgba(255,255,255,0.04);border:1px solid var(--border);color:var(--text);border-radius:10px;padding:10px;font-family:inherit;font-size:12px;outline:none"
-          spellcheck="false"></textarea>
-        <div style="display:flex;gap:8px;justify-content:flex-end;margin-top:12px">
-          <button type="button" class="panels-reset-layout" id="wmMarketResetBtn">Reset</button>
-          <button type="button" class="panels-reset-layout" id="wmMarketCancelBtn">Cancel</button>
-          <button type="button" class="panels-reset-layout" id="wmMarketSaveBtn" style="border-color:var(--text-dim);color:var(--text)">Save</button>
-        </div>
-      </div>
-    `;
-
-    const closeBtn = modal.querySelector('.modal-close') as HTMLButtonElement | null;
-    closeBtn?.addEventListener('click', () => this.closeWatchlistModal());
-
-    overlay.appendChild(modal);
-    document.body.appendChild(overlay);
-    this.overlay = overlay;
-
-    const input = modal.querySelector<HTMLTextAreaElement>('#wmMarketWatchlistInput');
-    if (input) input.value = currentText;
-
-    modal.querySelector<HTMLButtonElement>('#wmMarketCancelBtn')?.addEventListener('click', () => this.closeWatchlistModal());
-    modal.querySelector<HTMLButtonElement>('#wmMarketResetBtn')?.addEventListener('click', () => {
-      resetMarketWatchlist();
-      if (input) input.value = ''; // defaults are always included automatically
-      this.closeWatchlistModal();
-    });
-    modal.querySelector<HTMLButtonElement>('#wmMarketSaveBtn')?.addEventListener('click', () => {
-      const raw = input?.value || '';
-      const parsed = parseMarketWatchlistInput(raw);
-      if (parsed.length === 0) resetMarketWatchlist();
-      else setMarketWatchlistEntries(parsed);
-      this.closeWatchlistModal();
-    });
-  }
-
-  private closeWatchlistModal(): void {
-    if (!this.overlay) return;
-    this.overlay.remove();
-    this.overlay = null;
+    this.header.appendChild(createWatchlistButton());
   }
 
   public renderMarkets(data: MarketData[], rateLimited?: boolean): void {

--- a/src/components/StockAnalysisPanel.ts
+++ b/src/components/StockAnalysisPanel.ts
@@ -1,11 +1,14 @@
 import { Panel } from './Panel';
 import { t } from '@/services/i18n';
 import type { StockAnalysisResult } from '@/services/stock-analysis';
+import { isAnalyzableSymbol } from '@/services/stock-analysis';
+import { getMarketWatchlistEntries } from '@/services/market-watchlist';
 import type { AnalystConsensus, PriceTarget, UpgradeDowngrade } from '@/generated/client/worldmonitor/market/v1/service_client';
 import type { InsiderTransactionsResult } from '@/services/insider-transactions';
 import { escapeHtml, sanitizeUrl } from '@/utils/sanitize';
 import type { StockAnalysisHistory } from '@/services/stock-analysis-history';
 import { sparkline } from '@/utils/sparkline';
+import { createWatchlistButton } from './watchlist-modal';
 
 function formatChange(change: number): string {
   const rounded = Number.isFinite(change) ? change.toFixed(2) : '0.00';
@@ -52,6 +55,7 @@ export class StockAnalysisPanel extends Panel {
 
   constructor() {
     super({ id: 'stock-analysis', title: 'Premium Stock Analysis', infoTooltip: t('components.stockAnalysis.infoTooltip'), premium: 'locked' });
+    this.header.appendChild(createWatchlistButton('Edit Watchlist'));
   }
 
   public setInsiderData(symbol: string, data: InsiderTransactionsResult): void {
@@ -67,10 +71,17 @@ export class StockAnalysisPanel extends Panel {
 
     this.setDataBadge(source, `${items.length} symbols`);
 
+    const skippedCount = getMarketWatchlistEntries()
+      .filter((entry) => !isAnalyzableSymbol(entry.symbol)).length;
+    const tickerWord = items.length === 1 ? 'ticker' : 'tickers';
+    const skippedNote = skippedCount > 0
+      ? ` <span style="color:var(--text-dim)">${skippedCount} watchlist ${skippedCount === 1 ? 'symbol is an index/FX rate' : 'symbols are indices/FX rates'} and don't get an equity report.</span>`
+      : '';
+
     const html = `
       <div style="display:flex;flex-direction:column;gap:12px">
         <div style="font-size:12px;color:var(--text-dim);line-height:1.5">
-          Analyst-grade equity reports powered by the shared market watchlist. The panel tracks the first ${items.length} eligible tickers.
+          Analyst-grade equity reports for the ${items.length} ${tickerWord} in your watchlist — your picks lead, popular names fill the rest. Use <strong>Edit Watchlist</strong> to add your own.${skippedNote}
         </div>
         ${items.map((item) => this.renderCard(item, historyBySymbol[item.symbol] || [])).join('')}
       </div>

--- a/src/components/StockBacktestPanel.ts
+++ b/src/components/StockBacktestPanel.ts
@@ -2,6 +2,7 @@ import { Panel } from './Panel';
 import { t } from '@/services/i18n';
 import type { StockBacktestResult } from '@/services/stock-backtest';
 import { escapeHtml } from '@/utils/sanitize';
+import { createWatchlistButton } from './watchlist-modal';
 
 function tone(value: number): string {
   if (value > 0) return '#8df0b2';
@@ -17,6 +18,7 @@ function fmtPct(value: number): string {
 export class StockBacktestPanel extends Panel {
   constructor() {
     super({ id: 'stock-backtest', title: 'Premium Backtesting', infoTooltip: t('components.stockBacktest.infoTooltip'), premium: 'locked' });
+    this.header.appendChild(createWatchlistButton('Edit Watchlist'));
   }
 
   public renderBacktests(items: StockBacktestResult[], source: 'live' | 'cached' = 'live'): void {

--- a/src/components/watchlist-modal.ts
+++ b/src/components/watchlist-modal.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared market-watchlist editor modal.
+ *
+ * The watchlist drives the Markets panel (additive to the defaults) and the
+ * PRO panels — Premium Stock Analysis, Backtesting, and the Daily Market Brief
+ * — so the editor is reachable from every panel that consumes it rather than
+ * living only on the Markets header.
+ */
+
+import {
+  getMarketWatchlistEntries,
+  parseMarketWatchlistInput,
+  resetMarketWatchlist,
+  setMarketWatchlistEntries,
+} from '@/services/market-watchlist';
+
+let activeOverlay: HTMLElement | null = null;
+
+export function openWatchlistModal(): void {
+  if (activeOverlay) return;
+
+  const current = getMarketWatchlistEntries();
+  const currentText = current.length
+    ? current.map((e) => (e.name ? `${e.symbol}|${e.name}` : e.symbol)).join('\n')
+    : '';
+
+  const overlay = document.createElement('div');
+  overlay.className = 'modal-overlay active';
+  overlay.id = 'marketWatchlistModal';
+
+  const close = () => {
+    overlay.remove();
+    if (activeOverlay === overlay) activeOverlay = null;
+  };
+
+  overlay.addEventListener('click', (e) => {
+    if (e.target === overlay) close();
+  });
+
+  const modal = document.createElement('div');
+  modal.className = 'modal unified-settings-modal';
+  modal.style.maxWidth = '680px';
+
+  modal.innerHTML = `
+    <div class="modal-header">
+      <span class="modal-title">Market watchlist</span>
+      <button class="modal-close" aria-label="Close">×</button>
+    </div>
+    <div style="padding:14px 16px 16px 16px">
+      <div style="color:var(--text-dim);font-size:12px;line-height:1.5;margin-bottom:10px">
+        Add tickers (comma or newline separated). Friendly labels supported: SYMBOL|Label.
+        Example: TSLA|Tesla, AAPL|Apple, ^GSPC|S&amp;P 500
+        <br/>
+        Your picks are <strong>added</strong> to the Markets panel and lead the
+        Premium Stock Analysis, Backtesting and Daily Market Brief panels.
+        PRO members get every analysable ticker in the list reported (up to 50);
+        indices and FX (^GSPC, EURUSD=X) still appear in Markets but get no equity report.
+      </div>
+      <textarea id="wmMarketWatchlistInput"
+        style="width:100%;min-height:120px;resize:vertical;background:rgba(255,255,255,0.04);border:1px solid var(--border);color:var(--text);border-radius:10px;padding:10px;font-family:inherit;font-size:12px;outline:none"
+        spellcheck="false"></textarea>
+      <div style="display:flex;gap:8px;justify-content:flex-end;margin-top:12px">
+        <button type="button" class="panels-reset-layout" id="wmMarketResetBtn">Reset</button>
+        <button type="button" class="panels-reset-layout" id="wmMarketCancelBtn">Cancel</button>
+        <button type="button" class="panels-reset-layout" id="wmMarketSaveBtn" style="border-color:var(--text-dim);color:var(--text)">Save</button>
+      </div>
+    </div>
+  `;
+
+  modal.querySelector('.modal-close')?.addEventListener('click', close);
+
+  overlay.appendChild(modal);
+  document.body.appendChild(overlay);
+  activeOverlay = overlay;
+
+  const input = modal.querySelector<HTMLTextAreaElement>('#wmMarketWatchlistInput');
+  if (input) input.value = currentText;
+
+  modal.querySelector<HTMLButtonElement>('#wmMarketCancelBtn')?.addEventListener('click', close);
+  modal.querySelector<HTMLButtonElement>('#wmMarketResetBtn')?.addEventListener('click', () => {
+    resetMarketWatchlist();
+    if (input) input.value = ''; // defaults are always included automatically
+    close();
+  });
+  modal.querySelector<HTMLButtonElement>('#wmMarketSaveBtn')?.addEventListener('click', () => {
+    const raw = input?.value || '';
+    const parsed = parseMarketWatchlistInput(raw);
+    if (parsed.length === 0) resetMarketWatchlist();
+    else setMarketWatchlistEntries(parsed);
+    close();
+  });
+}
+
+/**
+ * Build a header button wired to {@link openWatchlistModal}. Reuses the
+ * existing `live-news-settings-btn` styling so it matches the other panel
+ * header affordances.
+ */
+export function createWatchlistButton(label = 'Watchlist'): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.className = 'live-news-settings-btn';
+  btn.title = 'Customize market watchlist';
+  btn.textContent = label;
+  btn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    openWatchlistModal();
+  });
+  return btn;
+}

--- a/src/services/daily-market-brief.ts
+++ b/src/services/daily-market-brief.ts
@@ -200,6 +200,7 @@ function resolveTargets(markets: MarketData[], explicitTargets?: MarketWatchlist
   const resolved: MarketData[] = [];
   const seen = new Set<string>();
 
+  // User/explicit picks lead — they care about those most.
   for (const entry of targetEntries) {
     const match = bySymbol.get(entry.symbol);
     if (!match || seen.has(match.symbol)) continue;
@@ -208,13 +209,15 @@ function resolveTargets(markets: MarketData[], explicitTargets?: MarketWatchlist
     if (resolved.length >= DEFAULT_TARGET_COUNT) return resolved;
   }
 
-  if (!explicitEntries && !(watchlistEntries && watchlistEntries.length > 0)) {
-    for (const market of markets) {
-      if (seen.has(market.symbol)) continue;
-      seen.add(market.symbol);
-      resolved.push(market);
-      if (resolved.length >= DEFAULT_TARGET_COUNT) break;
-    }
+  // ...then top up with default markets. The watchlist is additive: a
+  // one-entry watchlist must still produce a full brief, not collapse to a
+  // single item (matches the additive behaviour of the Markets panel and
+  // getStockAnalysisTargets).
+  for (const market of markets) {
+    if (seen.has(market.symbol)) continue;
+    seen.add(market.symbol);
+    resolved.push(market);
+    if (resolved.length >= DEFAULT_TARGET_COUNT) break;
   }
 
   return resolved;

--- a/src/services/stock-analysis-history.ts
+++ b/src/services/stock-analysis-history.ts
@@ -10,14 +10,13 @@ export type StockAnalysisHistory = Record<string, StockAnalysisSnapshot[]>;
 
 const client = new MarketServiceClient(getRpcBaseUrl(), { fetch: premiumFetch });
 
-const DEFAULT_LIMIT = 4;
 const DEFAULT_LIMIT_PER_SYMBOL = 4;
 const MAX_SNAPSHOTS_PER_SYMBOL = 32;
 export const STOCK_ANALYSIS_FRESH_MS = 15 * 60 * 1000;
 
-async function getTargetSymbols(limit: number): Promise<string[]> {
+async function getTargetSymbols(limitOverride?: number): Promise<string[]> {
   const { getStockAnalysisTargets } = await import('./stock-analysis');
-  return getStockAnalysisTargets(limit).map((target) => target.symbol);
+  return getStockAnalysisTargets(limitOverride).map((target) => target.symbol);
 }
 
 function compareSnapshots(a: StockAnalysisSnapshot, b: StockAnalysisSnapshot): number {
@@ -55,12 +54,12 @@ export function mergeStockAnalysisHistory(
   return next;
 }
 
-export function getLatestStockAnalysisSnapshots(history: StockAnalysisHistory, limit = DEFAULT_LIMIT): StockAnalysisSnapshot[] {
-  return Object.values(history)
+export function getLatestStockAnalysisSnapshots(history: StockAnalysisHistory, limit?: number): StockAnalysisSnapshot[] {
+  const snapshots = Object.values(history)
     .map((items) => items[0])
     .filter((item): item is StockAnalysisSnapshot => !!item?.available)
-    .sort(compareSnapshots)
-    .slice(0, limit);
+    .sort(compareSnapshots);
+  return limit != null ? snapshots.slice(0, limit) : snapshots;
 }
 
 // Snapshots written before the analyst-revisions rollout have neither
@@ -104,10 +103,10 @@ export function getMissingOrStaleStockAnalysisSymbols(
 }
 
 export async function fetchStockAnalysisHistory(
-  limit = DEFAULT_LIMIT,
+  limitOverride?: number,
   limitPerSymbol = DEFAULT_LIMIT_PER_SYMBOL,
 ): Promise<StockAnalysisHistory> {
-  const symbols = await getTargetSymbols(limit);
+  const symbols = await getTargetSymbols(limitOverride);
   const response = await client.getStockAnalysisHistory({
     symbols,
     limitPerSymbol,

--- a/src/services/stock-analysis-targets.ts
+++ b/src/services/stock-analysis-targets.ts
@@ -1,0 +1,84 @@
+/**
+ * Pure target-selection for the Premium Stock Analysis / Backtesting / Daily
+ * Market Brief panels. No runtime imports — kept side-effect free so it can be
+ * unit-tested without a DOM, localStorage, or RPC client.
+ */
+
+import type { MarketWatchlistEntry } from '@/services/market-watchlist';
+
+export interface StockAnalysisTarget {
+  symbol: string;
+  name: string;
+  display: string;
+}
+
+/**
+ * Free tier (and the empty-watchlist baseline for every tier) analyses this
+ * many tickers. PRO users get their full watchlist analysed, up to
+ * STOCK_ANALYSIS_PRO_LIMIT — which mirrors the 50-entry storage cap enforced
+ * in market-watchlist.ts.
+ */
+export const STOCK_ANALYSIS_FREE_LIMIT = 4;
+export const STOCK_ANALYSIS_PRO_LIMIT = 50;
+
+/** Indices (^GSPC) and FX/futures (EURUSD=X, GC=F) have no equity report. */
+export function isAnalyzableSymbol(symbol: string): boolean {
+  return !symbol.startsWith('^') && !symbol.includes('=');
+}
+
+/**
+ * Resolve the ordered list of tickers to analyse.
+ *
+ * The user's watchlist picks come first (they care about those most), then the
+ * panel is topped up with default symbols — so a watchlist with a single entry
+ * never collapses the panel to one card (the original "tracking only one
+ * ticker" bug).
+ *
+ * - Free tier: capped at STOCK_ANALYSIS_FREE_LIMIT.
+ * - PRO tier: sized to the user's own analysable picks, floored at the free
+ *   limit (an empty/tiny watchlist is never emptier than free) and capped at
+ *   STOCK_ANALYSIS_PRO_LIMIT.
+ *
+ * `limitOverride`, when provided, can only *shrink* the resolved cap — callers
+ * pass it to keep dependent fetches (history, backtests) aligned with an
+ * already-resolved target list, never to grant more than the tier allows.
+ */
+export function selectStockAnalysisTargets(
+  watchlistEntries: readonly MarketWatchlistEntry[],
+  defaultSymbols: readonly { symbol: string; name: string; display: string }[],
+  opts: { isPro: boolean; limitOverride?: number },
+): StockAnalysisTarget[] {
+  const userPicks: StockAnalysisTarget[] = watchlistEntries
+    .filter((entry) => isAnalyzableSymbol(entry.symbol))
+    .map((entry) => ({
+      symbol: entry.symbol,
+      name: entry.name || entry.symbol,
+      display: entry.display || entry.symbol,
+    }));
+
+  const cap = opts.isPro
+    ? Math.max(STOCK_ANALYSIS_FREE_LIMIT, Math.min(STOCK_ANALYSIS_PRO_LIMIT, userPicks.length))
+    : STOCK_ANALYSIS_FREE_LIMIT;
+  const limit = opts.limitOverride != null
+    ? Math.max(0, Math.min(opts.limitOverride, cap))
+    : cap;
+
+  const seen = new Set<string>();
+  const targets: StockAnalysisTarget[] = [];
+
+  for (const entry of userPicks) {
+    if (targets.length >= limit) break;
+    if (seen.has(entry.symbol)) continue;
+    seen.add(entry.symbol);
+    targets.push(entry);
+  }
+
+  for (const entry of defaultSymbols) {
+    if (targets.length >= limit) break;
+    if (!isAnalyzableSymbol(entry.symbol) || seen.has(entry.symbol)) continue;
+    seen.add(entry.symbol);
+    targets.push({ symbol: entry.symbol, name: entry.name, display: entry.display });
+  }
+
+  return targets;
+}

--- a/src/services/stock-analysis.ts
+++ b/src/services/stock-analysis.ts
@@ -7,42 +7,35 @@ import {
 import { getMarketWatchlistEntries } from '@/services/market-watchlist';
 import { runThrottledTargetRequests } from '@/services/throttled-target-requests';
 import { premiumFetch } from '@/services/premium-fetch';
+import { isProUser } from '@/services/widget-store';
+import {
+  selectStockAnalysisTargets,
+  type StockAnalysisTarget,
+} from '@/services/stock-analysis-targets';
 
 const client = new MarketServiceClient(getRpcBaseUrl(), { fetch: premiumFetch });
 
 export type StockAnalysisResult = AnalyzeStockResponse;
 
-export interface StockAnalysisTarget {
-  symbol: string;
-  name: string;
-  display: string;
-}
+export {
+  isAnalyzableSymbol,
+  selectStockAnalysisTargets,
+  STOCK_ANALYSIS_FREE_LIMIT,
+  STOCK_ANALYSIS_PRO_LIMIT,
+} from '@/services/stock-analysis-targets';
+export type { StockAnalysisTarget } from '@/services/stock-analysis-targets';
 
-const DEFAULT_LIMIT = 4;
-
-function isAnalyzableSymbol(symbol: string): boolean {
-  return !symbol.startsWith('^') && !symbol.includes('=');
-}
-
-export function getStockAnalysisTargets(limit = DEFAULT_LIMIT): StockAnalysisTarget[] {
-  const customEntries = getMarketWatchlistEntries().filter((entry) => isAnalyzableSymbol(entry.symbol));
-  const baseEntries = customEntries.length > 0
-    ? customEntries.map((entry) => ({
-        symbol: entry.symbol,
-        name: entry.name || entry.symbol,
-        display: entry.display || entry.symbol,
-      }))
-    : MARKET_SYMBOLS.filter((entry) => isAnalyzableSymbol(entry.symbol));
-
-  const seen = new Set<string>();
-  const targets: StockAnalysisTarget[] = [];
-  for (const entry of baseEntries) {
-    if (seen.has(entry.symbol)) continue;
-    seen.add(entry.symbol);
-    targets.push({ symbol: entry.symbol, name: entry.name, display: entry.display });
-    if (targets.length >= limit) break;
-  }
-  return targets;
+/**
+ * Tier-aware watchlist resolution: the user's analysable picks lead, then the
+ * panel is topped up with default symbols. `limitOverride` only shrinks the
+ * resolved cap — callers pass it to keep dependent fetches aligned with an
+ * already-resolved target list. See selectStockAnalysisTargets for the rules.
+ */
+export function getStockAnalysisTargets(limitOverride?: number): StockAnalysisTarget[] {
+  return selectStockAnalysisTargets(getMarketWatchlistEntries(), MARKET_SYMBOLS, {
+    isPro: isProUser(),
+    limitOverride,
+  });
 }
 
 export async function fetchStockAnalysesForTargets(targets: StockAnalysisTarget[]): Promise<StockAnalysisResult[]> {
@@ -55,6 +48,6 @@ export async function fetchStockAnalysesForTargets(targets: StockAnalysisTarget[
   });
 }
 
-export async function fetchStockAnalyses(limit = DEFAULT_LIMIT): Promise<StockAnalysisResult[]> {
-  return fetchStockAnalysesForTargets(getStockAnalysisTargets(limit));
+export async function fetchStockAnalyses(limitOverride?: number): Promise<StockAnalysisResult[]> {
+  return fetchStockAnalysesForTargets(getStockAnalysisTargets(limitOverride));
 }

--- a/src/services/stock-backtest.ts
+++ b/src/services/stock-backtest.ts
@@ -10,13 +10,12 @@ const client = new MarketServiceClient(getRpcBaseUrl(), { fetch: premiumFetch })
 
 export type StockBacktestResult = BacktestStockResponse;
 
-const DEFAULT_LIMIT = 4;
 const DEFAULT_EVAL_WINDOW_DAYS = 10;
 export const STOCK_BACKTEST_FRESH_MS = 24 * 60 * 60 * 1000;
 
-async function getTargets(limit: number) {
+async function getTargets(limitOverride?: number) {
   const { getStockAnalysisTargets } = await import('./stock-analysis');
-  return getStockAnalysisTargets(limit);
+  return getStockAnalysisTargets(limitOverride);
 }
 
 export async function fetchStockBacktestsForTargets(
@@ -33,17 +32,17 @@ export async function fetchStockBacktestsForTargets(
 }
 
 export async function fetchStockBacktests(
-  limit = DEFAULT_LIMIT,
+  limitOverride?: number,
   evalWindowDays = DEFAULT_EVAL_WINDOW_DAYS,
 ): Promise<StockBacktestResult[]> {
-  return fetchStockBacktestsForTargets(await getTargets(limit), evalWindowDays);
+  return fetchStockBacktestsForTargets(await getTargets(limitOverride), evalWindowDays);
 }
 
 export async function fetchStoredStockBacktests(
-  limit = DEFAULT_LIMIT,
+  limitOverride?: number,
   evalWindowDays = DEFAULT_EVAL_WINDOW_DAYS,
 ): Promise<StockBacktestResult[]> {
-  const targets = await getTargets(limit);
+  const targets = await getTargets(limitOverride);
   const symbols = targets.map((target) => target.symbol);
   const response = await client.listStoredStockBacktests({
     symbols,

--- a/tests/daily-market-brief.test.mts
+++ b/tests/daily-market-brief.test.mts
@@ -23,6 +23,12 @@ const markets: MarketData[] = [
   { symbol: 'NVDA', name: 'NVIDIA', display: 'NVDA', price: 913.77, change: 0.42 },
 ];
 
+const widerMarkets: MarketData[] = [
+  ...markets,
+  { symbol: 'GOOGL', name: 'Alphabet', display: 'GOOGL', price: 178.3, change: 0.91 },
+  { symbol: 'AMZN', name: 'Amazon', display: 'AMZN', price: 201.6, change: -0.55 },
+];
+
 describe('daily market brief schedule logic', () => {
   it('does not refresh before the local schedule if a prior brief exists', () => {
     const shouldRefresh = shouldRefreshDailyBrief({
@@ -93,7 +99,10 @@ describe('buildDailyMarketBrief', () => {
     });
 
     assert.equal(brief.available, true);
-    assert.equal(brief.items.length, 2);
+    // Targets are additive: the 2 explicit picks lead, then the brief tops up
+    // from `markets` (NVDA) toward DEFAULT_TARGET_COUNT.
+    assert.equal(brief.items.length, 3);
+    assert.deepEqual(brief.items.map((i) => i.display), ['AAPL', 'MSFT', 'NVDA']);
     assert.equal(brief.provider, 'openrouter');
     assert.equal(brief.fallback, false);
     assert.match(brief.title, /Daily Market Brief/);
@@ -119,5 +128,24 @@ describe('buildDailyMarketBrief', () => {
     assert.equal(brief.provider, 'rules');
     assert.equal(brief.fallback, true);
     assert.match(brief.summary, /watchlist|breadth|headline flow/i);
+  });
+
+  it('REGRESSION: a single watchlist target never collapses the brief to one item', async () => {
+    // Mirrors the additive watchlist fix — one pick must lead, then the brief
+    // tops up from the wider market list toward DEFAULT_TARGET_COUNT (4).
+    const brief = await buildDailyMarketBrief({
+      markets: widerMarkets,
+      newsByCategory: {
+        markets: [makeNewsItem('NVIDIA holds gains as chip demand remains firm')],
+      },
+      timezone: 'UTC',
+      now: new Date('2026-03-08T10:30:00.000Z'),
+      targets: [{ symbol: 'NVDA', name: 'NVIDIA', display: 'NVDA' }],
+      summarize: async () => null,
+    });
+
+    assert.equal(brief.available, true);
+    assert.equal(brief.items.length, 4, 'should top up to DEFAULT_TARGET_COUNT, not collapse to 1');
+    assert.equal(brief.items[0]?.display, 'NVDA', 'the user pick leads');
   });
 });

--- a/tests/stock-analysis-targets.test.mts
+++ b/tests/stock-analysis-targets.test.mts
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  selectStockAnalysisTargets,
+  isAnalyzableSymbol,
+  STOCK_ANALYSIS_FREE_LIMIT,
+  STOCK_ANALYSIS_PRO_LIMIT,
+} from '../src/services/stock-analysis-targets.ts';
+
+const DEFAULTS = [
+  { symbol: 'AAPL', name: 'Apple', display: 'AAPL' },
+  { symbol: 'MSFT', name: 'Microsoft', display: 'MSFT' },
+  { symbol: 'NVDA', name: 'NVIDIA', display: 'NVDA' },
+  { symbol: 'GOOGL', name: 'Alphabet', display: 'GOOGL' },
+  { symbol: 'AMZN', name: 'Amazon', display: 'AMZN' },
+  { symbol: '^GSPC', name: 'S&P 500', display: 'SPX' },
+  { symbol: 'GC=F', name: 'Gold', display: 'GOLD' },
+];
+
+const symbolsOf = (targets: Array<{ symbol: string }>) => targets.map((t) => t.symbol);
+
+describe('isAnalyzableSymbol', () => {
+  it('rejects indices and FX/futures, accepts ordinary equities', () => {
+    assert.equal(isAnalyzableSymbol('^GSPC'), false);
+    assert.equal(isAnalyzableSymbol('EURUSD=X'), false);
+    assert.equal(isAnalyzableSymbol('GC=F'), false);
+    assert.equal(isAnalyzableSymbol('AAPL'), true);
+    assert.equal(isAnalyzableSymbol('BRK-B'), true);
+    assert.equal(isAnalyzableSymbol('RELIANCE.NS'), true);
+  });
+});
+
+describe('selectStockAnalysisTargets', () => {
+  it('free tier with empty watchlist falls back to the first 4 analysable defaults', () => {
+    const targets = selectStockAnalysisTargets([], DEFAULTS, { isPro: false });
+    assert.deepEqual(symbolsOf(targets), ['AAPL', 'MSFT', 'NVDA', 'GOOGL']);
+  });
+
+  it('free tier is capped at STOCK_ANALYSIS_FREE_LIMIT even with a long watchlist', () => {
+    const watchlist = ['T1', 'T2', 'T3', 'T4', 'T5', 'T6'].map((symbol) => ({ symbol }));
+    const targets = selectStockAnalysisTargets(watchlist, DEFAULTS, { isPro: false });
+    assert.equal(targets.length, STOCK_ANALYSIS_FREE_LIMIT);
+    assert.deepEqual(symbolsOf(targets), ['T1', 'T2', 'T3', 'T4']);
+  });
+
+  it('PRO with empty watchlist still gets the 4 default tickers (floored at free limit)', () => {
+    const targets = selectStockAnalysisTargets([], DEFAULTS, { isPro: true });
+    assert.deepEqual(symbolsOf(targets), ['AAPL', 'MSFT', 'NVDA', 'GOOGL']);
+  });
+
+  it('REGRESSION: a single watchlist entry never collapses the panel to one ticker', () => {
+    // This is the original "tracking only one ticker" bug: adding one ticker
+    // used to REPLACE the defaults. It must now be ADDITIVE.
+    const targets = selectStockAnalysisTargets([{ symbol: 'TSLA' }], DEFAULTS, { isPro: true });
+    assert.equal(targets.length, 4, 'should top up to the free-limit floor, not collapse to 1');
+    assert.equal(targets[0]?.symbol, 'TSLA', 'the user pick leads');
+    assert.deepEqual(symbolsOf(targets), ['TSLA', 'AAPL', 'MSFT', 'NVDA']);
+  });
+
+  it('PRO watchlist is sized to the user list — picks lead, no default top-up beyond it', () => {
+    const watchlist = ['T1', 'T2', 'T3', 'T4', 'T5', 'T6', 'T7', 'T8', 'T9', 'T10']
+      .map((symbol) => ({ symbol }));
+    const targets = selectStockAnalysisTargets(watchlist, DEFAULTS, { isPro: true });
+    assert.equal(targets.length, 10);
+    assert.deepEqual(symbolsOf(targets), watchlist.map((e) => e.symbol));
+  });
+
+  it('PRO watchlist is capped at STOCK_ANALYSIS_PRO_LIMIT', () => {
+    const watchlist = Array.from({ length: 60 }, (_, i) => ({ symbol: `SYM${i}` }));
+    const targets = selectStockAnalysisTargets(watchlist, DEFAULTS, { isPro: true });
+    assert.equal(targets.length, STOCK_ANALYSIS_PRO_LIMIT);
+    assert.equal(targets[0]?.symbol, 'SYM0');
+    assert.equal(targets[STOCK_ANALYSIS_PRO_LIMIT - 1]?.symbol, `SYM${STOCK_ANALYSIS_PRO_LIMIT - 1}`);
+  });
+
+  it('drops non-analysable watchlist entries but still tops up — an index-only watchlist never breaks the panel', () => {
+    const targets = selectStockAnalysisTargets(
+      [{ symbol: '^GSPC' }, { symbol: 'EURUSD=X' }],
+      DEFAULTS,
+      { isPro: true },
+    );
+    assert.deepEqual(symbolsOf(targets), ['AAPL', 'MSFT', 'NVDA', 'GOOGL']);
+  });
+
+  it('mixes analysable picks with the top-up and de-dupes against the defaults', () => {
+    // NVDA appears in both the watchlist and DEFAULTS — it must appear once,
+    // in the user-pick position.
+    const targets = selectStockAnalysisTargets(
+      [{ symbol: 'TSLA' }, { symbol: '^GSPC' }, { symbol: 'NVDA' }],
+      DEFAULTS,
+      { isPro: true },
+    );
+    assert.deepEqual(symbolsOf(targets), ['TSLA', 'NVDA', 'AAPL', 'MSFT']);
+  });
+
+  it('falls back to the symbol for missing name/display', () => {
+    const [target] = selectStockAnalysisTargets([{ symbol: 'TSLA' }], [], { isPro: true });
+    assert.deepEqual(target, { symbol: 'TSLA', name: 'TSLA', display: 'TSLA' });
+  });
+
+  it('preserves friendly name/display labels from the watchlist entry', () => {
+    const [target] = selectStockAnalysisTargets(
+      [{ symbol: 'TSLA', name: 'Tesla', display: 'TSLA' }],
+      [],
+      { isPro: true },
+    );
+    assert.deepEqual(target, { symbol: 'TSLA', name: 'Tesla', display: 'TSLA' });
+  });
+
+  it('limitOverride can shrink the resolved cap (keeps dependent fetches aligned)', () => {
+    const watchlist = Array.from({ length: 10 }, (_, i) => ({ symbol: `SYM${i}` }));
+    const targets = selectStockAnalysisTargets(watchlist, DEFAULTS, { isPro: true, limitOverride: 3 });
+    assert.equal(targets.length, 3);
+  });
+
+  it('limitOverride cannot grow past the tier cap', () => {
+    const targets = selectStockAnalysisTargets([], DEFAULTS, { isPro: false, limitOverride: 20 });
+    assert.equal(targets.length, STOCK_ANALYSIS_FREE_LIMIT);
+  });
+});


### PR DESCRIPTION
## Summary

Premium Stock Analysis was **tracking only one ticker** for any PRO user who added a single watchlist entry. Root cause: `getStockAnalysisTargets()` treated the watchlist as a *replacement* for the defaults (`customEntries.length > 0 ? customEntries : MARKET_SYMBOLS`) — even though `market-watchlist.ts` documents itself as "additive" and `loadMarkets()` honors that. Adding one ticker collapsed the panel from 4 cards to 1.

Compounded by:
- A hard `DEFAULT_LIMIT = 4` cap copy-pasted across three files — a PRO user with a 15-name watchlist saw only 4.
- The watchlist editor reachable only from the **Markets** panel header — invisible on the PRO panels that promise "stocks in your watchlist", which is plausibly what the customer's "can't access the stock watch list" report actually meant.

### Changes

- **New `selectStockAnalysisTargets()`** (side-effect-free, unit-testable): user picks lead, then the panel is **topped up** with defaults so a one-entry watchlist never collapses. Free cap = 4; PRO sized to the user's analysable picks, floored at 4 (empty watchlist never emptier than free), capped at 50 (mirrors the storage cap). Indices/FX (`^GSPC`, `EURUSD=X`) are skipped gracefully instead of breaking the panel.
- **Single source of truth** for the limits — deleted all three `DEFAULT_LIMIT = 4` constants. `limit` params are now optional *shrink-only* overrides.
- **Shared watchlist modal** — extracted into `watchlist-modal.ts`; surfaced an `Edit Watchlist` button on the Premium Stock Analysis, Backtesting, and Daily Market Brief panel headers. Modal + panel copy explain the additive + tier behaviour.
- **13 new unit tests**, including the explicit regression: one watchlist entry must never collapse the panel to a single ticker.

## Test plan

- [x] `npm run typecheck` + `npm run typecheck:api` — PASS
- [x] `npm run lint` (biome) — PASS (0 errors)
- [x] `npm run test:data` — PASS, 8713/8713
- [x] `node --test tests/edge-functions.test.mjs` — PASS, 184/184
- [x] edge function esbuild bundle check — PASS
- [x] `npm run lint:md` — PASS, 0 errors
- [x] `npm run version:check` — PASS
- [x] New `tests/stock-analysis-targets.test.mjs` — 13/13, incl. single-ticker regression
- [ ] Manual: PRO user adds 1 ticker → panel shows that ticker + 3 defaults (not 1)
- [ ] Manual: `Edit Watchlist` button visible + functional on all 4 panels