### PR TITLE
fix(panels): resolve feeds for cross-variant customized panels

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -14,7 +14,7 @@ import {
   SITE_VARIANT,
   LAYER_TO_SOURCE,
 } from '@/config';
-import { resolveNewsCategories } from '@/config/feed-resolution';
+import { resolveNewsCategories, enabledNewsCategoryKeys } from '@/config/feed-resolution';
 import { INTEL_HOTSPOTS, CONFLICT_ZONES } from '@/config/geo';
 import { tokenizeForMatch, matchKeyword } from '@/utils/keyword-match';
 import {
@@ -1086,7 +1086,7 @@ export class DataLoaderManager implements AppModule {
     const categories = resolveNewsCategories(
       FEEDS,
       CANONICAL_FEEDS,
-      Object.keys(this.ctx.newsPanels),
+      enabledNewsCategoryKeys(this.ctx.newsPanels, this.ctx.panels, this.ctx.panelSettings),
     );
 
     const digest = await digestPromise;

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -6,6 +6,7 @@ import type { MarketData } from '@/types';
 import type { TimeRange } from '@/components';
 import {
   FEEDS,
+  CANONICAL_FEEDS,
   INTEL_SOURCES,
   SECTORS,
   COMMODITIES,
@@ -13,6 +14,7 @@ import {
   SITE_VARIANT,
   LAYER_TO_SOURCE,
 } from '@/config';
+import { resolveNewsCategories } from '@/config/feed-resolution';
 import { INTEL_HOTSPOTS, CONFLICT_ZONES } from '@/config/geo';
 import { tokenizeForMatch, matchKeyword } from '@/utils/keyword-match';
 import {
@@ -884,7 +886,11 @@ export class DataLoaderManager implements AppModule {
     this.applyTimeRangeFilterToNewsPanelsDebounced();
   }
 
-  private async loadNewsCategory(category: string, feeds: typeof FEEDS.politics, digest?: ListFeedDigestResponse | null): Promise<NewsItem[]> {
+  // `isCustom` marks a category from a user-added panel that isn't in the
+  // active variant's preset. The per-variant server digest never carries it,
+  // so it skips the digest-availability gate and fetches its full feed set
+  // directly client-side (the cost is borne only by users who customize).
+  private async loadNewsCategory(category: string, feeds: typeof FEEDS.politics, digest?: ListFeedDigestResponse | null, isCustom = false): Promise<NewsItem[]> {
     try {
       const panel = this.ctx.newsPanels[category];
 
@@ -978,7 +984,11 @@ export class DataLoaderManager implements AppModule {
         return staleItems;
       }
 
-      if (!this.isPerFeedFallbackEnabled()) {
+      // The per-feed-fallback flag throttles the digest-down thundering herd
+      // (every preset category fetching at once). It does NOT apply to custom
+      // categories: those are NEVER in the digest by design — direct fetch is
+      // their only path, and there are only a handful of them per user.
+      if (!isCustom && !this.isPerFeedFallbackEnabled()) {
         console.warn(`[News] Digest missing for "${category}", limited per-feed fallback disabled`);
         this.renderNewsForCategory(category, []);
         this.ctx.statusPanel?.updateFeed(category.charAt(0).toUpperCase() + category.slice(1), {
@@ -988,8 +998,14 @@ export class DataLoaderManager implements AppModule {
         return [];
       }
 
-      const fallbackFeeds = this.selectLimitedFeeds(enabledFeeds, this.perFeedFallbackCategoryFeedLimit);
-      if (fallbackFeeds.length < enabledFeeds.length) {
+      // Custom categories fetch their full feed set (no thundering-herd risk);
+      // preset categories stay capped by perFeedFallbackCategoryFeedLimit.
+      const fallbackFeeds = isCustom
+        ? enabledFeeds
+        : this.selectLimitedFeeds(enabledFeeds, this.perFeedFallbackCategoryFeedLimit);
+      if (isCustom) {
+        console.warn(`[News] Custom category "${category}" (not in variant preset), fetching ${fallbackFeeds.length} feeds directly`);
+      } else if (fallbackFeeds.length < enabledFeeds.length) {
         console.warn(`[News] Digest missing for "${category}", using limited per-feed fallback (${fallbackFeeds.length}/${enabledFeeds.length} feeds)`);
       } else {
         console.warn(`[News] Digest missing for "${category}", using per-feed fallback (${fallbackFeeds.length} feeds)`);
@@ -1055,9 +1071,16 @@ export class DataLoaderManager implements AppModule {
     // Fire digest fetch early (non-blocking) — await before category loop
     const digestPromise = this.tryFetchDigest();
 
-    const categories = Object.entries(FEEDS)
-      .filter((entry): entry is [string, typeof FEEDS[keyof typeof FEEDS]] => Array.isArray(entry[1]) && entry[1].length > 0)
-      .map(([key, feeds]) => ({ key, feeds }));
+    // Panel-driven, not variant-driven: load the active variant's preset
+    // categories PLUS any extra categories required by enabled news panels the
+    // user added beyond the preset (e.g. Tech panels customized into `full`).
+    // Custom categories aren't in the per-variant server digest, so they're
+    // flagged `isCustom` and fetched directly client-side in loadNewsCategory().
+    const categories = resolveNewsCategories(
+      FEEDS,
+      CANONICAL_FEEDS,
+      Object.keys(this.ctx.newsPanels),
+    );
 
     const digest = await digestPromise;
 
@@ -1067,7 +1090,7 @@ export class DataLoaderManager implements AppModule {
     for (let i = 0; i < categories.length; i += categoryConcurrency) {
       const chunk = categories.slice(i, i + categoryConcurrency);
       const chunkResults = await Promise.allSettled(
-        chunk.map(({ key, feeds }) => this.loadNewsCategory(key, feeds, digest))
+        chunk.map(({ key, feeds, isCustom }) => this.loadNewsCategory(key, feeds, digest, isCustom))
       );
       categoryResults.push(...chunkResults);
     }

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -973,8 +973,15 @@ export class DataLoaderManager implements AppModule {
         }
       };
 
+      // Preset categories: serve last-known-good while the digest is briefly
+      // unavailable. Custom categories are NEVER in the digest, so this branch
+      // would fire on every refresh after the first load — getStaleNewsItems
+      // reads ctx.newsByCategory, which the prior cycle's direct fetch already
+      // populated — and freeze the panel on stale headlines. Skip it for them
+      // and fall through to the direct fetch; the panel keeps showing its
+      // current batch until fresh data lands (no blank flash).
       const staleItems = this.getStaleNewsItems(category).filter(i => enabledNames.has(i.source));
-      if (staleItems.length > 0) {
+      if (!isCustom && staleItems.length > 0) {
         console.warn(`[News] Digest missing for "${category}", serving stale headlines (${staleItems.length})`);
         this.renderNewsForCategory(category, staleItems);
         this.ctx.statusPanel?.updateFeed(category.charAt(0).toUpperCase() + category.slice(1), {

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -34,8 +34,10 @@ import {
   SITE_VARIANT,
   LAYER_TO_SOURCE,
   FEEDS,
+  CANONICAL_FEEDS,
   INTEL_SOURCES,
 } from '@/config';
+import { resolveNewsCategories } from '@/config/feed-resolution';
 import { VARIANT_META } from '@/config/variant-meta';
 import { isDesktopRuntime } from '@/services/runtime';
 import {
@@ -1542,9 +1544,10 @@ export class EventHandlerManager implements AppModule {
 
   getAllSourceNames(): string[] {
     const sources = new Set<string>();
-    Object.values(FEEDS).forEach(feeds => {
-      if (feeds) feeds.forEach(f => sources.add(f.name));
-    });
+    // Preset feeds + sources from any custom news panels the user added, so
+    // the source manager stays in sync with what loadNews() actually fetches.
+    const categories = resolveNewsCategories(FEEDS, CANONICAL_FEEDS, Object.keys(this.ctx.newsPanels));
+    categories.forEach(({ feeds }) => feeds.forEach(f => sources.add(f.name)));
     INTEL_SOURCES.forEach(f => sources.add(f.name));
     return Array.from(sources).sort((a, b) => a.localeCompare(b));
   }

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -37,7 +37,7 @@ import {
   CANONICAL_FEEDS,
   INTEL_SOURCES,
 } from '@/config';
-import { resolveNewsCategories } from '@/config/feed-resolution';
+import { resolveNewsCategories, enabledNewsCategoryKeys } from '@/config/feed-resolution';
 import { VARIANT_META } from '@/config/variant-meta';
 import { isDesktopRuntime } from '@/services/runtime';
 import {
@@ -1546,7 +1546,7 @@ export class EventHandlerManager implements AppModule {
     const sources = new Set<string>();
     // Preset feeds + sources from any custom news panels the user added, so
     // the source manager stays in sync with what loadNews() actually fetches.
-    const categories = resolveNewsCategories(FEEDS, CANONICAL_FEEDS, Object.keys(this.ctx.newsPanels));
+    const categories = resolveNewsCategories(FEEDS, CANONICAL_FEEDS, enabledNewsCategoryKeys(this.ctx.newsPanels, this.ctx.panels, this.ctx.panelSettings));
     categories.forEach(({ feeds }) => feeds.forEach(f => sources.add(f.name)));
     INTEL_SOURCES.forEach(f => sources.add(f.name));
     return Array.from(sources).sort((a, b) => a.localeCompare(b));

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1024,9 +1024,9 @@ export class PanelLayoutManager implements AppModule {
       // in the full variant), that data panel's own settings entry must NOT
       // spawn a phantom news panel: the remapped key has to be explicitly
       // enabled. When there's no collision, panelKey === key so this is unchanged.
-      if (!this.ctx.panelSettings[panelKey]) continue;
-      const panelConfig = this.ctx.panelSettings[panelKey] ?? ALL_PANELS[panelKey] ?? ALL_PANELS[key];
-      const label = panelConfig?.name ?? key.charAt(0).toUpperCase() + key.slice(1);
+      const panelConfig = this.ctx.panelSettings[panelKey];
+      if (!panelConfig) continue;
+      const label = panelConfig.name ?? key.charAt(0).toUpperCase() + key.slice(1);
       const tooltip = PanelLayoutManager.NEWS_PANEL_TOOLTIPS[panelKey] ?? PanelLayoutManager.NEWS_PANEL_TOOLTIPS[key];
       const panel = new NewsPanel(panelKey, label, tooltip);
       this.attachRelatedAssetHandlers(panel);

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -91,12 +91,14 @@ import { debounce, saveToStorage, loadFromStorage } from '@/utils';
 import { escapeHtml } from '@/utils/sanitize';
 import {
   FEEDS,
+  CANONICAL_FEEDS,
   INTEL_SOURCES,
   STORAGE_KEYS,
   SITE_VARIANT,
   ALL_PANELS,
   VARIANT_DEFAULTS,
 } from '@/config';
+import { resolveNewsCategories } from '@/config/feed-resolution';
 import { BETA_MODE } from '@/config/beta';
 import { t } from '@/services/i18n';
 import { getCurrentTheme } from '@/utils';
@@ -1007,9 +1009,14 @@ export class PanelLayoutManager implements AppModule {
     this.createNewsPanel('asia', 'panels.asia');
     this.createNewsPanel('energy', 'panels.energy');
 
-    for (const key of Object.keys(FEEDS)) {
+    // Iterate CANONICAL_FEEDS (union of all variants), not just the active
+    // variant's FEEDS preset — so a news panel the user customized in from
+    // another variant (e.g. Finance `forex` added to a `full` session) still
+    // gets a NewsPanel created. The panelSettings gate below ensures only
+    // panels the user actually enabled are instantiated.
+    for (const key of Object.keys(CANONICAL_FEEDS)) {
       if (this.ctx.newsPanels[key]) continue;
-      if (!Array.isArray((FEEDS as Record<string, unknown>)[key])) continue;
+      if (!Array.isArray((CANONICAL_FEEDS as Record<string, unknown>)[key])) continue;
       const panelKey = this.ctx.panels[key] && !this.ctx.newsPanels[key] ? `${key}-news` : key;
       if (this.ctx.panels[panelKey]) continue;
       if (!this.ctx.panelSettings[panelKey] && !this.ctx.panelSettings[key]) continue;
@@ -2362,9 +2369,10 @@ export class PanelLayoutManager implements AppModule {
 
   getAllSourceNames(): string[] {
     const sources = new Set<string>();
-    Object.values(FEEDS).forEach(feeds => {
-      if (feeds) feeds.forEach(f => sources.add(f.name));
-    });
+    // Preset feeds + sources from any custom news panels the user added, so
+    // the source manager stays in sync with what loadNews() actually fetches.
+    const categories = resolveNewsCategories(FEEDS, CANONICAL_FEEDS, Object.keys(this.ctx.newsPanels));
+    categories.forEach(({ feeds }) => feeds.forEach(f => sources.add(f.name)));
     INTEL_SOURCES.forEach(f => sources.add(f.name));
     return Array.from(sources).sort((a, b) => a.localeCompare(b));
   }

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1019,8 +1019,13 @@ export class PanelLayoutManager implements AppModule {
       if (!Array.isArray((CANONICAL_FEEDS as Record<string, unknown>)[key])) continue;
       const panelKey = this.ctx.panels[key] && !this.ctx.newsPanels[key] ? `${key}-news` : key;
       if (this.ctx.panels[panelKey]) continue;
-      if (!this.ctx.panelSettings[panelKey] && !this.ctx.panelSettings[key]) continue;
-      const panelConfig = this.ctx.panelSettings[panelKey] ?? this.ctx.panelSettings[key] ?? ALL_PANELS[panelKey] ?? ALL_PANELS[key];
+      // Gate on panelKey, NOT key. When `key` collided with a non-news data
+      // panel (panelKey became `${key}-news` — e.g. `markets`/`crypto`/`economic`
+      // in the full variant), that data panel's own settings entry must NOT
+      // spawn a phantom news panel: the remapped key has to be explicitly
+      // enabled. When there's no collision, panelKey === key so this is unchanged.
+      if (!this.ctx.panelSettings[panelKey]) continue;
+      const panelConfig = this.ctx.panelSettings[panelKey] ?? ALL_PANELS[panelKey] ?? ALL_PANELS[key];
       const label = panelConfig?.name ?? key.charAt(0).toUpperCase() + key.slice(1);
       const tooltip = PanelLayoutManager.NEWS_PANEL_TOOLTIPS[panelKey] ?? PanelLayoutManager.NEWS_PANEL_TOOLTIPS[key];
       const panel = new NewsPanel(panelKey, label, tooltip);

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -98,7 +98,7 @@ import {
   ALL_PANELS,
   VARIANT_DEFAULTS,
 } from '@/config';
-import { resolveNewsCategories } from '@/config/feed-resolution';
+import { resolveNewsCategories, enabledNewsCategoryKeys } from '@/config/feed-resolution';
 import { BETA_MODE } from '@/config/beta';
 import { t } from '@/services/i18n';
 import { getCurrentTheme } from '@/utils';
@@ -2376,7 +2376,7 @@ export class PanelLayoutManager implements AppModule {
     const sources = new Set<string>();
     // Preset feeds + sources from any custom news panels the user added, so
     // the source manager stays in sync with what loadNews() actually fetches.
-    const categories = resolveNewsCategories(FEEDS, CANONICAL_FEEDS, Object.keys(this.ctx.newsPanels));
+    const categories = resolveNewsCategories(FEEDS, CANONICAL_FEEDS, enabledNewsCategoryKeys(this.ctx.newsPanels, this.ctx.panels, this.ctx.panelSettings));
     categories.forEach(({ feeds }) => feeds.forEach(f => sources.add(f.name)));
     INTEL_SOURCES.forEach(f => sources.add(f.name));
     return Array.from(sources).sort((a, b) => a.localeCompare(b));

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -1,5 +1,5 @@
 import '@/styles/settings-window.css';
-import { FEEDS, INTEL_SOURCES, SOURCE_REGION_MAP } from '@/config/feeds';
+import { CANONICAL_FEEDS, INTEL_SOURCES, SOURCE_REGION_MAP } from '@/config/feeds';
 import { PANEL_CATEGORY_MAP, ALL_PANELS, VARIANT_DEFAULTS, getEffectivePanelConfig, isPanelEntitled, FREE_MAX_PANELS } from '@/config/panels';
 import { isProUser } from '@/services/widget-store';
 import { SITE_VARIANT } from '@/config/variant';
@@ -823,7 +823,10 @@ export class UnifiedSettings {
   }
 
   private getAvailableRegions(): Array<{ key: string; label: string }> {
-    const feedKeys = new Set(Object.keys(FEEDS));
+    // A region pill shows when at least one of its sources is actually being
+    // loaded — getAllSourceNames() covers the active preset PLUS any cross-
+    // variant panels the user enabled, so customized-in regions appear too.
+    const allowed = new Set(this.config.getAllSourceNames());
     const regions: Array<{ key: string; label: string }> = [
       { key: 'all', label: t('header.sourceRegionAll') }
     ];
@@ -835,7 +838,8 @@ export class UnifiedSettings {
         }
         continue;
       }
-      const hasFeeds = regionDef.feedKeys.some(fk => feedKeys.has(fk));
+      const hasFeeds = regionDef.feedKeys.some(fk =>
+        (CANONICAL_FEEDS[fk] ?? []).some(f => allowed.has(f.name)));
       if (hasFeeds) {
         regions.push({ key: regionKey, label: t(regionDef.labelKey) });
       }
@@ -846,7 +850,12 @@ export class UnifiedSettings {
 
   private getSourcesByRegion(): Map<string, string[]> {
     const map = new Map<string, string[]>();
-    const feedKeys = new Set(Object.keys(FEEDS));
+    // Resolve region membership from CANONICAL_FEEDS (the all-variant union),
+    // then intersect with the sources actually loaded — getAllSourceNames()
+    // already covers the active preset + any custom panels the user enabled —
+    // so a customized-in panel's sources show under their proper region pill,
+    // not just the 'all' view.
+    const allowed = new Set(this.config.getAllSourceNames());
 
     for (const [regionKey, regionDef] of Object.entries(SOURCE_REGION_MAP)) {
       const sources: string[] = [];
@@ -854,8 +863,8 @@ export class UnifiedSettings {
         INTEL_SOURCES.forEach(f => sources.push(f.name));
       } else {
         for (const fk of regionDef.feedKeys) {
-          if (feedKeys.has(fk)) {
-            FEEDS[fk]!.forEach(f => sources.push(f.name));
+          for (const f of CANONICAL_FEEDS[fk] ?? []) {
+            if (allowed.has(f.name)) sources.push(f.name);
           }
         }
       }

--- a/src/config/feed-resolution.ts
+++ b/src/config/feed-resolution.ts
@@ -67,8 +67,11 @@ export interface ResolvedCategory {
  *
  * @param presetFeeds      the active variant's `FEEDS` map
  * @param canonicalFeeds   merged map covering every category across all variants
- * @param enabledPanelKeys keys of the news panels the user actually has enabled
- *                         (i.e. `Object.keys(ctx.newsPanels)`)
+ * @param enabledPanelKeys feed-category keys of the news panels the user has
+ *                         ENABLED. Pass `enabledNewsCategoryKeys(...)` — NOT
+ *                         `Object.keys(ctx.newsPanels)`, which includes disabled
+ *                         cross-variant panels and would fan out RSS fetches
+ *                         for every user.
  */
 export function resolveNewsCategories(
   presetFeeds: Record<string, Feed[]>,

--- a/src/config/feed-resolution.ts
+++ b/src/config/feed-resolution.ts
@@ -97,3 +97,35 @@ export function resolveNewsCategories(
 
   return resolved;
 }
+
+/**
+ * The feed-category keys whose news panel the user actually has ENABLED.
+ *
+ * `ctx.newsPanels` holds an instantiated panel for EVERY news category, not
+ * just enabled ones: App.ts seeds `panelSettings` with every `ALL_PANELS` key
+ * (cross-variant ones `enabled: false`) and panel creation keys on presence,
+ * not `.enabled`. Passing the raw `Object.keys(ctx.newsPanels)` to
+ * `resolveNewsCategories` would treat every disabled cross-variant panel as a
+ * custom category and fan out RSS fetches for every user — exactly the
+ * blast-radius this design is meant to avoid.
+ *
+ * A news panel registers under `key`, or under the remapped `${key}-news`
+ * when `key` collided with a non-news data panel already occupying
+ * `ctx.panels[key]` (e.g. `markets`/`crypto`/`economic` in the full variant).
+ * We detect the collision by reference identity — `ctx.panels[key]` is a
+ * *different* object than the news panel — rather than by re-deriving naming
+ * conventions, so this stays correct regardless of which keys exist.
+ */
+export function enabledNewsCategoryKeys(
+  newsPanels: Record<string, unknown>,
+  panels: Record<string, unknown>,
+  panelSettings: Record<string, { enabled?: boolean } | undefined>,
+): string[] {
+  const result: string[] = [];
+  for (const [key, newsPanel] of Object.entries(newsPanels)) {
+    const collided = panels[key] !== undefined && panels[key] !== newsPanel;
+    const panelKey = collided ? `${key}-news` : key;
+    if (panelSettings[panelKey]?.enabled === true) result.push(key);
+  }
+  return result;
+}

--- a/src/config/feed-resolution.ts
+++ b/src/config/feed-resolution.ts
@@ -1,0 +1,99 @@
+import type { Feed } from '@/types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Panel-driven (not variant-driven) feed resolution.
+//
+// A "variant" (full / tech / finance / commodity / energy / happy) is only a
+// PRESET — the default set of enabled panels. Users freely customize: a `full`
+// user can add the Tech `startups` panel, a `tech` user can add `middleeast`,
+// etc. The data layer must follow the user's ENABLED PANELS, not the variant.
+//
+// Before this module, `loadNews()` iterated the active variant's `FEEDS` map,
+// so any enabled news panel whose category wasn't in that one variant's preset
+// never had its feeds fetched and the panel sat on "Loading..." forever.
+//
+// `mergeCanonicalFeeds` builds the union of every variant's feed map;
+// `resolveNewsCategories` then loads the active preset PLUS whatever extra
+// categories the user's enabled panels require.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Stable dedup key for a feed — handles both single-URL and multi-URL feeds. */
+function feedKey(feed: Feed): string {
+  return typeof feed.url === 'string' ? feed.url : JSON.stringify(feed.url);
+}
+
+/**
+ * Merge multiple variant feed maps into one canonical category→feeds map.
+ * For category keys present in more than one variant, feeds are unioned and
+ * deduped by URL (first occurrence wins, so earlier maps in the list take
+ * precedence for shared keys).
+ */
+export function mergeCanonicalFeeds(
+  variantMaps: Array<Record<string, Feed[]>>,
+): Record<string, Feed[]> {
+  const merged: Record<string, Feed[]> = {};
+  for (const map of variantMaps) {
+    for (const [category, feeds] of Object.entries(map)) {
+      if (!Array.isArray(feeds)) continue;
+      const bucket = merged[category] ?? (merged[category] = []);
+      const seen = new Set(bucket.map(feedKey));
+      for (const feed of feeds) {
+        const key = feedKey(feed);
+        if (!seen.has(key)) {
+          bucket.push(feed);
+          seen.add(key);
+        }
+      }
+    }
+  }
+  return merged;
+}
+
+export interface ResolvedCategory {
+  key: string;
+  feeds: Feed[];
+  /**
+   * `true` when the category is NOT part of the active variant's preset — it
+   * comes from a user-customized panel. The server digest is built per-variant
+   * and won't carry it, so it must be loaded via direct client-side fetch.
+   */
+  isCustom: boolean;
+}
+
+/**
+ * Resolve every news category that should be loaded for the current session:
+ * the active variant's preset categories, PLUS any extra categories required
+ * by enabled news panels the preset doesn't cover (user customization).
+ *
+ * @param presetFeeds      the active variant's `FEEDS` map
+ * @param canonicalFeeds   merged map covering every category across all variants
+ * @param enabledPanelKeys keys of the news panels the user actually has enabled
+ *                         (i.e. `Object.keys(ctx.newsPanels)`)
+ */
+export function resolveNewsCategories(
+  presetFeeds: Record<string, Feed[]>,
+  canonicalFeeds: Record<string, Feed[]>,
+  enabledPanelKeys: Iterable<string>,
+): ResolvedCategory[] {
+  const resolved: ResolvedCategory[] = [];
+  const presetKeys = new Set<string>();
+
+  for (const [key, feeds] of Object.entries(presetFeeds)) {
+    if (Array.isArray(feeds) && feeds.length > 0) {
+      resolved.push({ key, feeds, isCustom: false });
+      presetKeys.add(key);
+    }
+  }
+
+  const seenCustom = new Set<string>();
+  for (const key of enabledPanelKeys) {
+    if (presetKeys.has(key) || seenCustom.has(key)) continue;
+    const feeds = canonicalFeeds[key];
+    if (Array.isArray(feeds) && feeds.length > 0) {
+      resolved.push({ key, feeds, isCustom: true });
+      seenCustom.add(key);
+    }
+  }
+
+  return resolved;
+}

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -162,6 +162,12 @@ let _sourcePanelMap: Map<string, string> | null = null;
 export function getSourcePanelId(sourceName: string): string {
   if (!_sourcePanelMap) {
     _sourcePanelMap = new Map();
+    // Seed with CANONICAL_FEEDS first so a source belonging to a cross-variant
+    // custom panel still resolves to its real panel. The active-variant FEEDS
+    // pass below then overwrites, so the active preset wins any collision.
+    for (const [category, feeds] of Object.entries(CANONICAL_FEEDS)) {
+      for (const feed of feeds) _sourcePanelMap.set(feed.name, category);
+    }
     for (const [category, feeds] of Object.entries(FEEDS)) {
       for (const feed of feeds) _sourcePanelMap.set(feed.name, category);
     }

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -1,6 +1,7 @@
 import type { Feed } from '@/types';
 import { SITE_VARIANT } from './variant';
 import { rssProxyUrl } from '@/utils';
+import { mergeCanonicalFeeds } from './feed-resolution';
 
 const rss = rssProxyUrl;
 const railwayRss = rssProxyUrl;
@@ -935,6 +936,22 @@ export const FEEDS = SITE_VARIANT === 'tech'
         : SITE_VARIANT === 'energy'
           ? ENERGY_FEEDS
           : FULL_FEEDS;
+
+// Canonical category→feeds map: the union of every variant's feed set.
+// `FEEDS` (above) is just the active variant's PRESET; users freely customize
+// their panel set, so any enabled news panel must be able to resolve its feeds
+// regardless of which variant it "belongs" to. Consumers:
+//  • data-loader `loadNews()` — loads preset categories + custom enabled panels
+//  • panel-layout — creates a NewsPanel for any enabled category, not just preset
+// See src/config/feed-resolution.ts for the merge + resolution helpers.
+export const CANONICAL_FEEDS: Record<string, Feed[]> = mergeCanonicalFeeds([
+  FULL_FEEDS,
+  TECH_FEEDS,
+  FINANCE_FEEDS,
+  COMMODITY_FEEDS,
+  ENERGY_FEEDS,
+  HAPPY_FEEDS,
+]);
 
 export const SOURCE_REGION_MAP: Record<string, { labelKey: string; feedKeys: string[] }> = {
   // Full (geopolitical) variant regions

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -60,9 +60,14 @@ export {
 // These are large data files that should be tree-shaken in tech builds
 export {
   FEEDS,
-  CANONICAL_FEEDS,
   INTEL_SOURCES,
 } from './feeds';
+
+// CANONICAL_FEEDS is the union of every variant's feed map — by design it
+// references all *_FEEDS consts, so unlike FEEDS it is NOT tree-shaken per
+// variant (~10KB gz). Required so a panel customized in from another variant
+// can resolve its feeds. See src/config/feed-resolution.ts.
+export { CANONICAL_FEEDS } from './feeds';
 
 export {
   INTEL_HOTSPOTS,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -60,6 +60,7 @@ export {
 // These are large data files that should be tree-shaken in tech builds
 export {
   FEEDS,
+  CANONICAL_FEEDS,
   INTEL_SOURCES,
 } from './feeds';
 

--- a/tests/feed-resolution.test.mts
+++ b/tests/feed-resolution.test.mts
@@ -1,0 +1,133 @@
+// Unit tests for panel-driven feed resolution (src/config/feed-resolution.ts).
+//
+// Regression motivation — the concrete bug this fixes:
+//
+// A user customized the `full` (geopolitical) variant by enabling Tech panels
+// (Startups & VC, Unicorn Tracker, GitHub Trending, Cybersecurity, …). The
+// panels rendered but sat on "Loading..." forever. Root cause: `loadNews()`
+// built its work-list from `Object.entries(FEEDS)` — the ACTIVE VARIANT'S
+// PRESET — so any enabled news panel whose category wasn't in that one
+// variant's feed map never had its feeds fetched.
+//
+// `resolveNewsCategories` makes the data layer panel-driven instead of
+// variant-driven: it loads the preset PLUS any extra categories required by
+// the user's enabled panels, flagging the extras `isCustom` (they aren't in
+// the per-variant server digest and must be fetched directly client-side).
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  mergeCanonicalFeeds,
+  resolveNewsCategories,
+} from '../src/config/feed-resolution.ts';
+import type { Feed } from '../src/types/index.ts';
+
+const f = (name: string, url: string): Feed => ({ name, url });
+
+describe('mergeCanonicalFeeds', () => {
+  test('unions categories across variant maps', () => {
+    const merged = mergeCanonicalFeeds([
+      { politics: [f('BBC', 'bbc')] },
+      { startups: [f('TechCrunch', 'tc')] },
+    ]);
+    assert.deepStrictEqual(Object.keys(merged).sort(), ['politics', 'startups']);
+    assert.strictEqual(merged.politics?.length, 1);
+    assert.strictEqual(merged.startups?.length, 1);
+  });
+
+  test('merges + dedupes feeds for a category present in multiple variants', () => {
+    const merged = mergeCanonicalFeeds([
+      { tech: [f('The Verge', 'verge'), f('Hacker News', 'hn')] },
+      { tech: [f('Hacker News', 'hn'), f('Ars Technica', 'ars')] },
+    ]);
+    const urls = merged.tech?.map(x => x.url);
+    assert.deepStrictEqual(urls, ['verge', 'hn', 'ars'], 'duplicate URL collapsed, order preserved (first wins)');
+  });
+
+  test('dedupes multi-URL (Record) feeds by stringified url', () => {
+    const multi: Feed = { name: 'Multi', url: { a: 'x', b: 'y' } };
+    const merged = mergeCanonicalFeeds([
+      { region: [multi] },
+      { region: [{ name: 'Multi', url: { a: 'x', b: 'y' } }] },
+    ]);
+    assert.strictEqual(merged.region?.length, 1, 'identical Record url deduped');
+  });
+
+  test('ignores non-array values defensively', () => {
+    const merged = mergeCanonicalFeeds([
+      { good: [f('A', 'a')], bad: undefined as unknown as Feed[] },
+    ]);
+    assert.deepStrictEqual(Object.keys(merged), ['good']);
+  });
+});
+
+describe('resolveNewsCategories', () => {
+  const FULL_PRESET = {
+    politics: [f('BBC', 'bbc')],
+    tech: [f('Verge', 'verge')],
+  };
+  const CANONICAL = {
+    politics: [f('BBC', 'bbc')],
+    tech: [f('Verge', 'verge')],
+    startups: [f('TechCrunch', 'tc')],
+    github: [f('GitHub Blog', 'gh')],
+    forex: [f('Forex News', 'fx')],
+  };
+
+  test('preset categories resolve with isCustom=false', () => {
+    const resolved = resolveNewsCategories(FULL_PRESET, CANONICAL, []);
+    assert.deepStrictEqual(
+      resolved.map(c => ({ key: c.key, isCustom: c.isCustom })),
+      [
+        { key: 'politics', isCustom: false },
+        { key: 'tech', isCustom: false },
+      ],
+    );
+  });
+
+  // THE BUG REPRO: a Tech panel enabled in the `full` variant.
+  // Against the old `Object.entries(FEEDS)` logic, `startups` would never
+  // appear in the work-list. resolveNewsCategories must surface it as custom.
+  test('enabled panel NOT in the preset resolves as a custom category', () => {
+    const resolved = resolveNewsCategories(FULL_PRESET, CANONICAL, [
+      'politics', // preset panel — already covered, must not duplicate
+      'startups', // customized in from the Tech variant
+      'github',   // customized in from the Tech variant
+    ]);
+    const byKey = new Map(resolved.map(c => [c.key, c]));
+    assert.strictEqual(byKey.get('startups')?.isCustom, true);
+    assert.strictEqual(byKey.get('github')?.isCustom, true);
+    assert.deepStrictEqual(byKey.get('startups')?.feeds, CANONICAL.startups);
+    // preset panel passed in enabledPanelKeys must not produce a 2nd entry
+    assert.strictEqual(resolved.filter(c => c.key === 'politics').length, 1);
+    assert.strictEqual(byKey.get('politics')?.isCustom, false);
+  });
+
+  test('symmetric across variants — a full-variant panel customized into tech', () => {
+    const TECH_PRESET = { startups: [f('TechCrunch', 'tc')] };
+    const resolved = resolveNewsCategories(TECH_PRESET, CANONICAL, ['startups', 'forex']);
+    const byKey = new Map(resolved.map(c => [c.key, c]));
+    assert.strictEqual(byKey.get('startups')?.isCustom, false);
+    assert.strictEqual(byKey.get('forex')?.isCustom, true);
+  });
+
+  test('enabled panel with no feeds anywhere is skipped (no phantom entry)', () => {
+    const resolved = resolveNewsCategories(FULL_PRESET, CANONICAL, ['intel']);
+    assert.strictEqual(resolved.find(c => c.key === 'intel'), undefined);
+  });
+
+  test('preset categories with empty feed arrays are excluded', () => {
+    const resolved = resolveNewsCategories(
+      { politics: [f('BBC', 'bbc')], empty: [] },
+      CANONICAL,
+      [],
+    );
+    assert.deepStrictEqual(resolved.map(c => c.key), ['politics']);
+  });
+
+  test('duplicate enabled panel keys do not produce duplicate custom entries', () => {
+    const resolved = resolveNewsCategories(FULL_PRESET, CANONICAL, ['startups', 'startups']);
+    assert.strictEqual(resolved.filter(c => c.key === 'startups').length, 1);
+  });
+});

--- a/tests/feed-resolution.test.mts
+++ b/tests/feed-resolution.test.mts
@@ -20,6 +20,7 @@ import assert from 'node:assert/strict';
 import {
   mergeCanonicalFeeds,
   resolveNewsCategories,
+  enabledNewsCategoryKeys,
 } from '../src/config/feed-resolution.ts';
 import type { Feed } from '../src/types/index.ts';
 
@@ -129,5 +130,61 @@ describe('resolveNewsCategories', () => {
   test('duplicate enabled panel keys do not produce duplicate custom entries', () => {
     const resolved = resolveNewsCategories(FULL_PRESET, CANONICAL, ['startups', 'startups']);
     assert.strictEqual(resolved.filter(c => c.key === 'startups').length, 1);
+  });
+});
+
+describe('enabledNewsCategoryKeys', () => {
+  // App.ts seeds panelSettings with EVERY ALL_PANELS key (cross-variant ones
+  // enabled:false) and panel creation keys on presence — so ctx.newsPanels
+  // holds disabled panels too. Only enabled ones may become custom categories.
+  test('includes enabled panels, excludes disabled ones', () => {
+    const politics = {};
+    const startups = {};
+    const newsPanels = { politics, startups };
+    const panels = { politics, startups };
+    const panelSettings = {
+      politics: { enabled: true },
+      startups: { enabled: false }, // cross-variant panel, disabled in this variant
+    };
+    assert.deepStrictEqual(
+      enabledNewsCategoryKeys(newsPanels, panels, panelSettings),
+      ['politics'],
+    );
+  });
+
+  test('excludes a panel with no settings entry', () => {
+    const orphan = {};
+    assert.deepStrictEqual(
+      enabledNewsCategoryKeys({ orphan }, { orphan }, {}),
+      [],
+    );
+  });
+
+  // Collision case: `markets` key is occupied by a non-news DATA panel, so the
+  // news panel registered under `markets-news`. Enablement must be read from
+  // panelSettings['markets-news'] — NOT panelSettings['markets'] (the data panel).
+  test('collision: reads the remapped ${key}-news settings entry, not the data panel', () => {
+    const marketsNews = {};
+    const marketsData = {};
+    const newsPanels = { markets: marketsNews };
+    const panels = { markets: marketsData, 'markets-news': marketsNews };
+
+    // data panel enabled, news panel enabled → included
+    assert.deepStrictEqual(
+      enabledNewsCategoryKeys(newsPanels, panels, {
+        markets: { enabled: true },
+        'markets-news': { enabled: true },
+      }),
+      ['markets'],
+    );
+
+    // data panel enabled, news panel DISABLED → excluded (data state must not leak)
+    assert.deepStrictEqual(
+      enabledNewsCategoryKeys(newsPanels, panels, {
+        markets: { enabled: true },
+        'markets-news': { enabled: false },
+      }),
+      [],
+    );
   });
 });

--- a/tests/news-feed-key-parity.test.mts
+++ b/tests/news-feed-key-parity.test.mts
@@ -208,3 +208,73 @@ describe('news feed key parity (client FEEDS ⇔ server VARIANT_FEEDS)', () => {
     });
   }
 });
+
+// Static guard: every news panel the UI can create MUST have a feed
+// definition somewhere in feeds.ts — otherwise enabling it (in its own
+// variant OR customized into another variant) leaves it stuck on
+// "Loading..." forever, because loadNews()/panel-layout resolve feeds from
+// CANONICAL_FEEDS (the union of every variant's *_FEEDS map).
+//
+// Regression motivated this: 14 Tech news panels (startups, github, …) were
+// reachable via the settings picker in the `full` variant but had no
+// FULL_FEEDS category, so they never loaded. The fix made the data layer
+// panel-driven; this guard locks the invariant.
+describe('news panel ↔ feed coverage (panel-layout createNewsPanel ⇔ feeds.ts)', () => {
+  const PANEL_LAYOUT_PATH = resolve(__dirname, '../src/app/panel-layout.ts');
+
+  // News panels intentionally NOT backed by a *_FEEDS category — they have a
+  // dedicated loader path in data-loader.ts instead. Keep this list tight.
+  const SPECIAL_CASED = new Set<string>([
+    'intel', // INTEL_SOURCES + bespoke branch in DataLoader.loadNews()
+  ]);
+
+  // Every client-side variant feed map. CANONICAL_FEEDS is their union.
+  const ALL_FEED_CONSTS = [
+    'FULL_FEEDS',
+    'TECH_FEEDS',
+    'FINANCE_FEEDS',
+    'COMMODITY_FEEDS',
+    'ENERGY_FEEDS',
+    'HAPPY_FEEDS',
+  ];
+
+  test('every createNewsPanel(...) key resolves to feeds in CANONICAL_FEEDS', () => {
+    const clientSrc = readFileSync(CLIENT_FEEDS_PATH, 'utf-8');
+    // NB: do NOT run stripComments() on panel-layout.ts — unlike the pure-data
+    // feed maps, it contains regex literals (e.g. /-([a-z])/g) that the naive
+    // block-comment regex would mangle. The createNewsPanel('X') call shape is
+    // distinctive enough to match safely on raw source.
+    const panelLayoutSrc = readFileSync(PANEL_LAYOUT_PATH, 'utf-8');
+
+    const canonicalKeys = new Set<string>();
+    for (const constName of ALL_FEED_CONSTS) {
+      const body = extractConstObjectBody(clientSrc, constName);
+      assert.ok(body, `failed to locate const ${constName} in feeds.ts`);
+      for (const k of extractCategoryKeys(body)) canonicalKeys.add(k);
+    }
+    assert.ok(canonicalKeys.size > 0, 'parsed 0 canonical feed keys');
+
+    const createNewsPanelKeys = new Set<string>();
+    const re = /createNewsPanel\(\s*'([^']+)'/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(panelLayoutSrc)) !== null) {
+      if (m[1]) createNewsPanelKeys.add(m[1]);
+    }
+    assert.ok(createNewsPanelKeys.size > 0, 'parsed 0 createNewsPanel keys from panel-layout.ts');
+
+    const orphans = [...createNewsPanelKeys]
+      .filter(k => !canonicalKeys.has(k) && !SPECIAL_CASED.has(k))
+      .sort();
+    assert.deepStrictEqual(
+      orphans,
+      [],
+      `News panels created by panel-layout.ts with NO feed definition in any ` +
+      `*_FEEDS map:\n\n  ${orphans.join(', ')}\n\n` +
+      `These panels can be enabled via the settings picker but will sit on ` +
+      `"Loading..." forever — loadNews() resolves feeds from CANONICAL_FEEDS ` +
+      `(the union of all *_FEEDS maps) and finds nothing.\n\n` +
+      `Fix: add the category to the relevant *_FEEDS map in src/config/feeds.ts, ` +
+      `or add it to SPECIAL_CASED in this test if it has a dedicated loader.`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Variant feed maps are **presets, not capability boundaries** — users freely customize panel sets across variants. But the data layer was keyed on the *active variant*, so a news panel enabled outside its native variant (e.g. Tech **Startups & VC / GitHub Trending / Cybersecurity** added to the `full` variant) rendered but sat on **"Loading..." forever**:

- `loadNews()` iterated `Object.entries(FEEDS)` — the active variant's preset only
- the panel-creation loop iterated `Object.keys(FEEDS)` — same
- so `loadNewsCategory()` was never called for cross-variant panels — no error, because the per-variant `FEEDS` ternary silently falls through to `: FULL_FEEDS`

### Fix — make the data layer panel-driven, not variant-driven

- **`src/config/feed-resolution.ts`** (new) — `mergeCanonicalFeeds` + `resolveNewsCategories` pure helpers
- **`CANONICAL_FEEDS`** — the union of every variant's feed map
- **`loadNews()`** resolves categories from *enabled panels*; non-preset ("custom") categories fetch their full feed set directly client-side, since the per-variant server digest can't carry them — cost borne only by users who customize, zero blast radius otherwise
- panel-creation loop + `getAllSourceNames()` iterate the canonical set
- **static guard test** — every `createNewsPanel(...)` key must have feeds in some `*_FEEDS` map, so no news panel can ever ship dataless again

### Tradeoff

`CANONICAL_FEEDS` statically references all 6 variant feed maps → each variant build ships ~10 KB gzipped of other variants' feed definitions that were previously tree-shaken. Unavoidable: cross-variant panels need cross-variant data at runtime.

## Test plan

- [x] `npm run typecheck` / `typecheck:api` — clean
- [x] `npm run lint` (biome) / `lint:md` — clean
- [x] `npm run test:data` — new `feed-resolution.test.mts` (10 tests incl. exact bug repro), `news panel ↔ feed coverage` static guard, `news feed key parity` all pass
- [x] esbuild edge bundle + `edge-functions` tests — pass
- [ ] Manual: load `full` variant, enable Tech panels via `/settings`, confirm they load instead of spinning