### PR TITLE
fix(brief): exclude opinion/analysis from the pool + lead↔card-#1 coherence telemetry

### DIFF
--- a/Dockerfile.digest-notifications
+++ b/Dockerfile.digest-notifications
@@ -82,6 +82,11 @@ COPY server/_shared/brief-render.js server/_shared/brief-render.d.ts ./server/_s
 # the cherry-pick pattern keeps biting when new cross-dir imports land.
 COPY server/_shared/llm-sanitize.js server/_shared/llm-sanitize.d.ts ./server/_shared/
 
+# opinion-classifier is imported directly by scripts/seed-digest-notifications.mjs
+# (buildDigest's read-time opinion filter — F3). Without this COPY the cron
+# crashes at import with ERR_MODULE_NOT_FOUND on startup.
+COPY server/_shared/opinion-classifier.js server/_shared/opinion-classifier.d.ts ./server/_shared/
+
 # Upstash REST helper (brief compose uses redisPipeline + readRawJson).
 COPY api/_upstash-json.js ./api/
 COPY api/_seed-envelope.js ./api/

--- a/scripts/lib/brief-llm.mjs
+++ b/scripts/lib/brief-llm.mjs
@@ -674,6 +674,41 @@ export function checkLeadGrounding(synthesis, stories) {
 }
 
 /**
+ * Lead ↔ single-story coherence check (F4). Returns true iff `lead`
+ * shares ≥1 proper-noun anchor with `headline`. Reuses the same
+ * anchor machinery as `checkLeadGrounding` (capitalised, length ≥4,
+ * stopword-filtered headline anchors; token-set membership against
+ * the lead) but with a FIXED threshold of 1 — coherence asks only
+ * "is the lead about the same story?", not "how well-grounded is it?".
+ *
+ * `checkLeadGrounding` itself is the wrong fit here: scoped to one
+ * story, a single headline can carry ≥4 anchor tokens, which trips
+ * its `size >= 4 ? 2 : 1` threshold up to 2 — too strict for
+ * coherence, where a lead legitimately about card #1 may name only
+ * one of its entities.
+ *
+ * Used by the cron's lead/card-#1 coherence telemetry
+ * (`composeAndStoreBriefForUser`) — see plan
+ * docs/plans/2026-05-14-001-…-plan.md (F4, Phase 4).
+ *
+ * @param {string} lead — the canonical synthesis lead
+ * @param {string} headline — the rendered first card's headline
+ * @returns {boolean} true = coherent (or check-skipped); false = the
+ *   lead names none of the headline's proper-noun anchors
+ */
+export function leadGroundsAgainstStory(lead, headline) {
+  const anchors = new Set(extractAnchorTokens(typeof headline === 'string' ? headline : ''));
+  // No proper-noun anchors in the headline → cannot judge coherence,
+  // skip (same "degenerate corpus → accept" stance as checkLeadGrounding).
+  if (anchors.size === 0) return true;
+  const leadTokens = groundingTokenSet(typeof lead === 'string' ? lead : '');
+  for (const tok of anchors) {
+    if (leadTokens.has(tok)) return true;
+  }
+  return false;
+}
+
+/**
  * Strict shape check for a parsed digest-prose object. Used by BOTH
  * parseDigestProse (fresh LLM output) AND generateDigestProse's
  * cache-hit path, so a bad row written under an older/buggy version

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -30,6 +30,7 @@ const { fetchUserPreferences, extractUserContext, formatUserProfile } = require(
 const { Resend } = require('resend');
 const { normalizeResendSender } = require('./lib/resend-from.cjs');
 import { readRawJsonFromUpstash, redisPipeline } from '../api/_upstash-json.js';
+import { classifyOpinion } from '../server/_shared/opinion-classifier.js';
 import {
   composeBriefFromDigestStories,
   compareRules,
@@ -55,6 +56,7 @@ import {
   generateDigestProse,
   generateDigestProsePublic,
   greetingBucket,
+  leadGroundsAgainstStory,
 } from './lib/brief-llm.mjs';
 import { parseDigestOnlyUser } from './lib/digest-only-user.mjs';
 import { assertBriefEnvelope } from '../server/_shared/brief-render.js';
@@ -482,6 +484,7 @@ async function buildDigest(rule, windowStartMs) {
 
   const stories = [];
   let droppedStaleAtRead = 0;
+  let droppedOpinion = 0;
   for (let i = 0; i < hashes.length; i++) {
     const raw = trackResults[i]?.result;
     if (!Array.isArray(raw) || raw.length === 0) continue;
@@ -490,6 +493,28 @@ async function buildDigest(rule, windowStartMs) {
 
     if (shouldDropTrackByAge(track, ageCutoffMs)) {
       droppedStaleAtRead++;
+      continue;
+    }
+
+    // Opinion / analysis exclusion (F3). The brief is event-driven
+    // intelligence — an op-ed column is not an event. Ingest stamps
+    // `isOpinion` on the story:track:v1 row; trust that stamp when
+    // present ('1' | '0'). Pre-stamp residue rows (ingested before the
+    // ingest-side stamp shipped) have NO `isOpinion` field at all — for
+    // those, re-classify from the persisted title/link/description so
+    // residue is still excluded for the row's TTL window. See
+    // docs/plans/2026-05-14-001-…-plan.md (F3, Phase 3).
+    const stampedOpinion = track.isOpinion === '1';
+    const stampMissing = typeof track.isOpinion !== 'string' || track.isOpinion.length === 0;
+    if (
+      stampedOpinion ||
+      (stampMissing && classifyOpinion({
+        title: track.title,
+        link: track.link ?? '',
+        description: typeof track.description === 'string' ? track.description : '',
+      }))
+    ) {
+      droppedOpinion++;
       continue;
     }
 
@@ -518,6 +543,14 @@ async function buildDigest(rule, windowStartMs) {
     console.warn(
       `[digest] buildDigest read-time freshness floor dropped ${droppedStaleAtRead} ` +
         `stale items (window cutoff: ${cutoffH}h ago) — likely pre-deploy residue`,
+    );
+  }
+
+  if (droppedOpinion > 0) {
+    console.log(
+      `[digest] buildDigest opinion filter dropped ${droppedOpinion} ` +
+        `op-ed/analysis item(s) from the pool (variant=${rule.variant ?? 'full'} ` +
+        `lang=${rule.lang ?? 'en'} sensitivity=${rule.sensitivity ?? 'high'})`,
     );
   }
 
@@ -1634,6 +1667,49 @@ async function composeAndStoreBriefForUser(userId, annotated, insightsNumbers, d
   );
 
   if (!envelope) return null;
+
+  // ── Lead ↔ final-card-#1 coherence (F4) ─────────────────────────────
+  //
+  // The synthesis emits `lead` and `rankedStoryHashes` as independent
+  // fields with no constraint that the lead is ABOUT the story that
+  // renders first. And `rankedStoryHashes[0]` is NOT
+  // `data.stories[0]` — `orderBriefCandidates` re-sorts by severity /
+  // topic-block / score with the LLM rank only as a tie-breaker. So
+  // the coherence check must run AFTER `filterTopStories` has produced
+  // the final order, against `envelope.data.stories[0]` — never
+  // `rankedStoryHashes[0]`. It runs here in the orchestration layer
+  // (not inside the pure `composeBriefFromDigestStories`) so the
+  // composer stays I/O-free; `data.stories` is identical before and
+  // after `enrichBriefEnvelopeWithLLM` (skipDigestProse → per-story
+  // only), so checking now is equivalent to checking post-enrich.
+  //
+  // Measure-first (plan F4, option b): emit a telemetry line every
+  // brief and a warn on mismatch — ship the brief as-is. Once the
+  // mismatch RATE is known in production, decide between regenerating
+  // the lead bound to stories[0] or having the LLM emit a separate
+  // leadStoryHash. See docs/plans/2026-05-14-001-…-plan.md (F4).
+  if (synthesis?.lead && Array.isArray(envelope?.data?.stories) && envelope.data.stories.length > 0) {
+    const card1 = envelope.data.stories[0];
+    const card1Headline = typeof card1?.headline === 'string' ? card1.headline : '';
+    // leadGroundsAgainstStory: true iff the lead shares ≥1 proper-noun
+    // anchor with card #1's headline (fixed threshold of 1 — coherence
+    // asks "same story?", not "how grounded?"). checkLeadGrounding is
+    // the wrong fit here: a single headline can carry ≥4 anchors,
+    // tripping its size-based threshold up to 2.
+    const coherent = leadGroundsAgainstStory(synthesis.lead, card1Headline);
+    console.log(
+      `[digest] lead card1 coherence user=${userId} ` +
+        `coherent=${coherent} synthesis_level=${synthesisLevel} ` +
+        `card1_clusterId=${card1?.clusterId ?? '?'}`,
+    );
+    if (!coherent) {
+      console.warn(
+        `[digest] LEAD/CARD-#1 INCOHERENCE user=${userId} — digest.lead does not ` +
+          `reference the rendered first story. ` +
+          `lead="${synthesis.lead.slice(0, 90)}" card1="${card1Headline.slice(0, 90)}"`,
+      );
+    }
+  }
 
   // Per-story whyMatters enrichment. The canonical synthesis is
   // already spliced into the envelope above; `skipDigestProse: true`

--- a/server/_shared/opinion-classifier.d.ts
+++ b/server/_shared/opinion-classifier.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Classify a story as opinion/analysis vs hard news. Single classifier
+ * shared by the ingest path (list-feed-digest.ts — stamps `isOpinion`
+ * on the story:track:v1 row) and the read path (buildDigest —
+ * re-classifies residue). Uses title, link (URL), and description.
+ * See docs/plans/2026-05-14-001-…-plan.md (F3, Phase 3).
+ *
+ * @param story - { title, link, description } — any may be missing.
+ * @returns true = opinion/analysis (exclude from the brief).
+ */
+export function classifyOpinion(story: {
+  title?: unknown;
+  link?: unknown;
+  description?: unknown;
+}): boolean;

--- a/server/_shared/opinion-classifier.js
+++ b/server/_shared/opinion-classifier.js
@@ -25,13 +25,16 @@
 
 // ── STRONG: URL path / feed-section segments ─────────────────────────
 // A dedicated opinion/commentary section in the URL is an unambiguous
-// publisher signal. `/analysis/` is deliberately NOT here — many
+// publisher signal. Every entry is SLASH-DELIMITED on both sides — a
+// real path segment, not a substring. An unbounded `/opinion-` prefix
+// was rejected on review: it false-positives on hard-news article
+// slugs like `/world/opinion-polls-tighten-election` (PR #3690
+// review). `/analysis/` is deliberately NOT here either — many
 // outlets file hard-news explainers under /analysis/ (it is a
 // CORROBORATING signal below).
 const STRONG_URL_SEGMENTS = [
   '/opinion/',
   '/opinions/',
-  '/opinion-',
   '/views/',
   '/commentary/',
   '/editorial/',

--- a/server/_shared/opinion-classifier.js
+++ b/server/_shared/opinion-classifier.js
@@ -1,0 +1,103 @@
+// Opinion / analysis classifier for the WorldMonitor brief pipeline.
+//
+// The brief is event-driven intelligence — an op-ed column is not an
+// event. On 2026-05-14 a Le Monde opinion column ("'Russia's invasion
+// of Ukraine could have warned Trump…'", by columnist Gilles Paris)
+// shipped as story #1, tagged Critical, ahead of a nuclear ICBM test.
+// See plan docs/plans/2026-05-14-001-fix-brief-pipeline-parity-grounding-opinion-plan.md
+// (F3, Phase 3).
+//
+// This module is the SINGLE classifier, imported by BOTH the ingest
+// path (server/worldmonitor/news/v1/list-feed-digest.ts — stamps
+// `isOpinion` onto the story:track:v1 row) AND the read path
+// (scripts/seed-digest-notifications.mjs buildDigest — re-classifies
+// to catch residue rows ingested before the ingest stamp shipped).
+//
+// Available signals at BOTH layers are the same: title, link (URL),
+// description. story:track:v1 does not persist byline or feed-section
+// metadata, and the parsed RSS item does not carry them either — so
+// there is no richer ingest-time signal to exploit.
+//
+// Tiering (conservative — a false negative ships one opinion piece;
+// a false positive silently drops a real event):
+//   STRONG       — sufficient alone to classify as opinion
+//   CORROBORATING — needs a STRONG signal OR two CORROBORATING signals
+
+// ── STRONG: URL path / feed-section segments ─────────────────────────
+// A dedicated opinion/commentary section in the URL is an unambiguous
+// publisher signal. `/analysis/` is deliberately NOT here — many
+// outlets file hard-news explainers under /analysis/ (it is a
+// CORROBORATING signal below).
+const STRONG_URL_SEGMENTS = [
+  '/opinion/',
+  '/opinions/',
+  '/opinion-',
+  '/views/',
+  '/commentary/',
+  '/editorial/',
+  '/editorials/',
+  '/op-ed/',
+  '/op-eds/',
+  '/columnists/',
+  '/columnist/',
+  '/columns/',
+];
+
+// ── STRONG: explicit headline prefix ─────────────────────────────────
+// "Opinion: …", "Analysis: …", "Commentary: …", "Op-Ed: …" — an
+// explicit editorial label the publisher chose. Mirrors the prefix
+// set stripHeadlinePrefix removes for display, but here it CLASSIFIES
+// rather than strips. Trailing colon required so a bare-noun headline
+// ("Opinion polls tighten…") is not caught.
+const STRONG_HEADLINE_PREFIX_RE = /^(?:opinion|analysis|commentary|op-?ed|editorial|perspective|viewpoint)\s*:/i;
+
+// ── CORROBORATING: description framing ───────────────────────────────
+// Columnist/argument framing in the body. Alone these false-positive
+// on quoted-statement hard news ("the minister argues that…"), so they
+// only count toward a 2-signal threshold.
+const CORROBORATING_DESCRIPTION_RE = /\b(?:columnist|op-?ed|opinion piece|our columnist|argues that|posits that|makes the case|the case for|guest essay|editorial board)\b/i;
+
+// ── CORROBORATING: whole-headline quote wrap ─────────────────────────
+// An entire headline wrapped in quotation marks is the classic op-ed
+// headline format (the May 14 Le Monde column). But a hard-news
+// headline can also lead with a quoted phrase, so this is corroborating
+// only. Requires the FULL headline to be quote-wrapped — a headline
+// that merely CONTAINS a quoted phrase does not count.
+function isWholeHeadlineQuoted(title) {
+  if (typeof title !== 'string') return false;
+  const t = title.trim();
+  if (t.length < 2) return false;
+  const first = t[0];
+  const last = t[t.length - 1];
+  const opensQuote = first === '"' || first === '“' || first === "'" || first === '‘';
+  const closesQuote = last === '"' || last === '”' || last === "'" || last === '’';
+  return opensQuote && closesQuote;
+}
+
+/**
+ * Classify a story as opinion/analysis vs hard news.
+ *
+ * @param {{ title?: unknown; link?: unknown; description?: unknown }} story
+ * @returns {boolean} true = opinion/analysis (exclude from the brief)
+ */
+export function classifyOpinion(story) {
+  const title = typeof story?.title === 'string' ? story.title : '';
+  const link = typeof story?.link === 'string' ? story.link : '';
+  const description = typeof story?.description === 'string' ? story.description : '';
+
+  // STRONG #1 — URL section. Lowercased; matches a path segment.
+  const lowerLink = link.toLowerCase();
+  if (STRONG_URL_SEGMENTS.some((seg) => lowerLink.includes(seg))) return true;
+
+  // STRONG #2 — explicit headline prefix.
+  if (STRONG_HEADLINE_PREFIX_RE.test(title.trim())) return true;
+
+  // CORROBORATING — need at least TWO.
+  let corroborating = 0;
+  if (isWholeHeadlineQuoted(title)) corroborating += 1;
+  if (CORROBORATING_DESCRIPTION_RE.test(description)) corroborating += 1;
+  // `/analysis/` in the URL is corroborating, not strong.
+  if (lowerLink.includes('/analysis/') || lowerLink.includes('/analyses/')) corroborating += 1;
+
+  return corroborating >= 2;
+}

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -14,6 +14,7 @@ import { sha256Hex } from '../../../_shared/hash';
 import { CHROME_UA } from '../../../_shared/constants';
 import { VARIANT_FEEDS, INTEL_SOURCES, type ServerFeed } from './_feeds';
 import { classifyByKeyword, hasHistoricalMarker, type ThreatLevel } from './_classifier';
+import { classifyOpinion } from '../../../_shared/opinion-classifier.js';
 import { buildClassifyCacheKey } from '../../intelligence/v1/_shared';
 import { getSourceTier } from '../../../_shared/source-tiers';
 import {
@@ -152,6 +153,14 @@ interface ParsedItem {
   // absent, too short, or indistinguishable from the headline. Grounding input
   // for brief / whyMatters / SummarizeArticle LLMs.
   description: string;
+  // Opinion / analysis classification (classifyOpinion over title + link +
+  // description). Persisted on the story:track:v1 row as `isOpinion` so the
+  // brief's read path (buildDigest) can exclude op-ed/column content — the
+  // brief is event-driven intelligence, a column is not an event. See
+  // docs/plans/2026-05-14-001-…-plan.md (F3). story:track rows feed more
+  // than the brief, so this STAMPS rather than drops — only buildDigest
+  // filters on it.
+  isOpinion: boolean;
 }
 
 const MAX_DESCRIPTION_LEN = 400;
@@ -466,6 +475,7 @@ function parseRssXml(xml: string, feed: ServerFeed, variant: string): ParseResul
       corroborationCount: 1,
       lang: feed.lang ?? 'en',
       description,
+      isOpinion: classifyOpinion({ title, link, description }),
     });
   }
 
@@ -890,6 +900,15 @@ function buildStoryTrackHsetFields(
     // (treats as legacy row) instead of being mis-classified as a stale
     // row with a bogus timestamp.
     'publishedAt', Number.isFinite(item.publishedAt) ? String(item.publishedAt) : '',
+    // Opinion/analysis flag (classifyOpinion). '1' = op-ed/column,
+    // '0' = hard news. buildDigest's read-path filter excludes '1' rows
+    // from the brief pool. Written unconditionally for the same
+    // shared-row reason as `description` above: story:track rows are
+    // collapsed by normalised-title hash, so a stale '1' from an earlier
+    // mention must be overwritten by the current mention's verdict.
+    // Pre-stamp rows (ingested before this shipped) have no field at
+    // all; buildDigest re-classifies those from title/link/description.
+    'isOpinion', item.isOpinion ? '1' : '0',
   ];
 }
 

--- a/tests/brief-llm.test.mjs
+++ b/tests/brief-llm.test.mjs
@@ -20,6 +20,7 @@ import {
   parseDigestProse,
   validateDigestProseShape,
   checkLeadGrounding,
+  leadGroundsAgainstStory,
   generateDigestProse,
   generateDigestProsePublic,
   enrichBriefEnvelopeWithLLM,
@@ -893,6 +894,66 @@ describe('checkLeadGrounding', () => {
     assert.ok(parseDigestProse(json), 'no stories → shape only');
     assert.equal(parseDigestProse(json, may12Stories), null,
       'stories supplied → grounding gate trips on hallucinated lead');
+  });
+
+  // ── Lead ↔ final-card-#1 coherence: leadGroundsAgainstStory (F4) ───
+  //
+  // The orchestration layer (composeAndStoreBriefForUser) runs
+  // `leadGroundsAgainstStory(synthesis.lead, data.stories[0].headline)`
+  // — true iff the lead shares ≥1 proper-noun anchor with the rendered
+  // first card's headline (fixed threshold of 1; checkLeadGrounding is
+  // the wrong fit because one headline can carry ≥4 anchors → its
+  // size-based threshold trips to 2).
+
+  it('leadGroundsAgainstStory: lead that references card-#1 → coherent (true)', () => {
+    assert.equal(
+      leadGroundsAgainstStory(
+        'Ukraine struck Russian energy infrastructure after the ceasefire collapsed.',
+        'Ukraine hits Russian energy targets after US-brokered ceasefire ends',
+      ),
+      true,
+    );
+    // Single shared anchor is enough — coherence asks "same story?",
+    // not "how grounded?". Card #1 here has ≥4 anchors; the lead names
+    // only one (Putin) and that is still coherent.
+    assert.equal(
+      leadGroundsAgainstStory(
+        'Putin escalated the standoff with a new weapons announcement.',
+        'Putin tests nuclear-capable Sarmat missile from Plesetsk Cosmodrome',
+      ),
+      true,
+    );
+  });
+
+  it('REGRESSION (May 14 F4): lead about a different story than card-#1 → incoherent (false)', () => {
+    // The verbatim May 14 envelope: digest.lead was about the
+    // Ukraine-energy story; data.stories[0] was the Le Monde opinion
+    // column. A lead about an unrelated story shares no anchor with
+    // card #1's headline → flagged incoherent.
+    const card1Headline = "'Russia's invasion of Ukraine could have warned Trump from the pitfalls he now faces in Iran'";
+    assert.equal(
+      leadGroundsAgainstStory(
+        'Netanyahu made a secret visit to the UAE during the US-Israel war.',
+        card1Headline,
+      ),
+      false,
+      'a lead about Netanyahu/UAE shares no anchor with the Le Monde card-#1 headline',
+    );
+    // A lead that genuinely matches card #1 is still coherent.
+    assert.equal(
+      leadGroundsAgainstStory(
+        'Russia and Ukraine remain locked in the conflict that Trump now echoes over Iran.',
+        card1Headline,
+      ),
+      true,
+    );
+  });
+
+  it('leadGroundsAgainstStory: headline with no proper-noun anchors → skipped (true)', () => {
+    // Degenerate corpus — same "cannot judge → accept" stance as
+    // checkLeadGrounding's empty-storyTokens branch.
+    assert.equal(leadGroundsAgainstStory('Anything at all here.', 'the market dipped today'), true);
+    assert.equal(leadGroundsAgainstStory('', ''), true);
   });
 });
 

--- a/tests/news-rss-description-extract.test.mts
+++ b/tests/news-rss-description-extract.test.mts
@@ -195,6 +195,29 @@ describe('parseRssXml — integration with description', () => {
     assert.strictEqual(items[1]!.description, '', 'second item falls back to empty string');
   });
 
+  it('every ParsedItem carries an isOpinion flag — hard news false, op-ed true (F3)', () => {
+    const xml = wrapRss(`
+      <item>
+        <title>Putin tests nuclear-capable Sarmat missile</title>
+        <link>https://news.example.com/world/sarmat-test</link>
+        <pubDate>Thu, 24 Apr 2026 08:01:00 GMT</pubDate>
+        <description><![CDATA[<p>Russia test-fired the intercontinental ballistic missile from Plesetsk on Thursday morning.</p>]]></description>
+      </item>
+      <item>
+        <title>Opinion: The west has misjudged this moment</title>
+        <link>https://news.example.com/opinion/west-misjudged</link>
+        <pubDate>Thu, 24 Apr 2026 08:02:00 GMT</pubDate>
+        <description><![CDATA[<p>Our columnist argues that the strategic picture has shifted decisively.</p>]]></description>
+      </item>
+    `);
+    const result = parseRssXml(xml, FEED, 'full');
+    assert.ok(result);
+    const items = result!.items;
+    assert.strictEqual(items.length, 2);
+    assert.strictEqual(items[0]!.isOpinion, false, 'hard-news item is not opinion');
+    assert.strictEqual(items[1]!.isOpinion, true, 'Opinion:-prefixed item under /opinion/ is opinion');
+  });
+
   it('Atom feed ParsedItems carry a description field from <summary>/<content>', () => {
     const xml = wrapAtom(`
       <entry>

--- a/tests/news-story-track-description-persistence.test.mts
+++ b/tests/news-story-track-description-persistence.test.mts
@@ -30,6 +30,7 @@ function baseItem(overrides: Record<string, unknown> = {}) {
     corroborationCount: 1,
     lang: 'en',
     description: '',
+    isOpinion: false,
     ...overrides,
   };
 }
@@ -54,6 +55,25 @@ describe('buildStoryTrackHsetFields — story:track:v1 HSET contract', () => {
     assert.ok(m.has('link'));
     assert.ok(m.has('severity'));
     assert.ok(m.has('lang'));
+  });
+
+  it('writes isOpinion as "1" / "0" — stamps the opinion verdict on the row (F3)', () => {
+    // The brief's read path (buildDigest) excludes isOpinion="1" rows.
+    // Written unconditionally for the same shared-row reason as
+    // `description`: a stale "1" from an earlier mention must be
+    // overwritten by the current mention's verdict.
+    const opinionItem = baseItem({ isOpinion: true });
+    assert.strictEqual(fieldsToMap(buildStoryTrackHsetFields(opinionItem, '1745000000000', 42)).get('isOpinion'), '1');
+    const newsItem = baseItem({ isOpinion: false });
+    assert.strictEqual(fieldsToMap(buildStoryTrackHsetFields(newsItem, '1745000000000', 42)).get('isOpinion'), '0');
+    // Missing field (old cached ParsedItem rows pre-dating the parser
+    // change) → falsy → "0", never the literal "undefined".
+    const legacyItem = baseItem();
+    delete (legacyItem as Record<string, unknown>).isOpinion;
+    assert.strictEqual(
+      fieldsToMap(buildStoryTrackHsetFields(legacyItem as Parameters<typeof buildStoryTrackHsetFields>[0], '1745000000000', 42)).get('isOpinion'),
+      '0',
+    );
   });
 
   it('writes an empty-string description when the current mention has no body — overwrites any prior mention body', () => {

--- a/tests/opinion-classifier.test.mjs
+++ b/tests/opinion-classifier.test.mjs
@@ -121,6 +121,30 @@ describe('classifyOpinion — does NOT false-positive on hard news', () => {
     );
   });
 
+  it('REGRESSION (PR #3690 review): a hard-news slug containing "opinion-" is NOT a strong URL match', () => {
+    // STRONG_URL_SEGMENTS entries are slash-delimited path segments,
+    // not substrings. `/world/opinion-polls-tighten-election` is a
+    // hard-news ARTICLE SLUG that merely starts with "opinion-" — it
+    // must NOT classify as opinion. An unbounded `/opinion-` prefix
+    // was removed from STRONG_URL_SEGMENTS for exactly this.
+    assert.equal(
+      classifyOpinion({
+        title: 'Opinion polls tighten ahead of the election',
+        link: 'https://example.com/world/opinion-polls-tighten-election',
+        description: 'A new survey shows the race narrowing in three swing states.',
+      }),
+      false,
+    );
+    // A genuine /opinion/ SECTION (slash-delimited) is still caught.
+    assert.equal(
+      classifyOpinion({
+        title: 'The election is closer than it looks',
+        link: 'https://example.com/opinion/election-closer-than-it-looks',
+      }),
+      true,
+    );
+  });
+
   it('a plain hard-news event → NOT opinion', () => {
     assert.equal(
       classifyOpinion({

--- a/tests/opinion-classifier.test.mjs
+++ b/tests/opinion-classifier.test.mjs
@@ -1,0 +1,145 @@
+// Unit tests for the opinion/analysis classifier (F3, Phase 3).
+//
+// classifyOpinion is the single shared classifier — imported by the
+// ingest path (list-feed-digest.ts, stamps `isOpinion` on the
+// story:track:v1 row) and the read path (buildDigest, re-classifies
+// residue). The brief is event-driven intelligence; an op-ed column
+// is not an event. See docs/plans/2026-05-14-001-…-plan.md.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyOpinion } from '../server/_shared/opinion-classifier.js';
+
+describe('classifyOpinion — STRONG signals (sufficient alone)', () => {
+  it('URL path /opinion/ → opinion', () => {
+    assert.equal(
+      classifyOpinion({ title: 'A perfectly normal hard-news headline', link: 'https://example.com/opinion/2026/05/14/foo' }),
+      true,
+    );
+  });
+
+  it('URL path variants /views/ /commentary/ /editorial/ /op-ed/ /columnists/ → opinion', () => {
+    for (const seg of ['/views/', '/commentary/', '/editorial/', '/op-ed/', '/columnists/', '/columns/']) {
+      assert.equal(
+        classifyOpinion({ title: 'Normal headline', link: `https://example.com${seg}article` }),
+        true,
+        `${seg} should classify as opinion`,
+      );
+    }
+  });
+
+  it('explicit "Opinion:" / "Analysis:" / "Commentary:" / "Op-Ed:" headline prefix → opinion', () => {
+    for (const prefix of ['Opinion:', 'Analysis:', 'Commentary:', 'Op-Ed:', 'Op-ed:', 'Editorial:', 'Viewpoint:']) {
+      assert.equal(
+        classifyOpinion({ title: `${prefix} The case for sanctions`, link: 'https://example.com/world/article' }),
+        true,
+        `"${prefix}" prefix should classify as opinion`,
+      );
+    }
+  });
+});
+
+describe('classifyOpinion — CORROBORATING signals (need a STRONG signal OR two CORROBORATING)', () => {
+  it('REGRESSION (May 14): the Le Monde Gilles Paris column → opinion', () => {
+    // The verbatim May 14 story: a fully quote-wrapped headline (1
+    // corroborating) + "posits that" framing in the description (1
+    // corroborating) = 2 → opinion. This shipped as story #1, tagged
+    // Critical, ahead of a nuclear ICBM test.
+    assert.equal(
+      classifyOpinion({
+        title: "'Russia's invasion of Ukraine could have warned Trump from the pitfalls he now faces in Iran'",
+        link: 'https://www.lemonde.fr/en/international/article/2026/05/14/foo_123_4.html',
+        description: "Le Monde's Gilles Paris posits that Trump's miscalculation regarding Iran mirrors Putin's Ukraine invasion, offering a cautionary tale for Xi Jinping's Taiwan ambitions.",
+      }),
+      true,
+    );
+  });
+
+  it('two corroborating (quote-wrapped headline + /analysis/ URL) → opinion', () => {
+    assert.equal(
+      classifyOpinion({
+        title: "'The west has misjudged this moment'",
+        link: 'https://example.com/analysis/2026/foo',
+        description: 'A straightforward report with no framing words.',
+      }),
+      true,
+    );
+  });
+
+  it('ONE corroborating signal alone → NOT opinion (false-negative is safer than false-positive)', () => {
+    // /analysis/ URL alone — many outlets file hard-news explainers there.
+    assert.equal(
+      classifyOpinion({ title: 'Sudan airstrike kills 100 at market', link: 'https://example.com/analysis/sudan-airstrike' }),
+      false,
+    );
+    // A quote-wrapped headline alone — could be a quoted-statement lead.
+    assert.equal(
+      classifyOpinion({ title: "'We will respond decisively'", link: 'https://example.com/world/iran-statement', description: 'The foreign ministry issued a statement.' }),
+      false,
+    );
+    // Description framing alone.
+    assert.equal(
+      classifyOpinion({ title: 'Minister addresses parliament', link: 'https://example.com/world/x', description: 'The minister argues that the budget must pass.' }),
+      false,
+    );
+  });
+});
+
+describe('classifyOpinion — does NOT false-positive on hard news', () => {
+  it('REGRESSION (A3): a hard-news story under /analysis/ with no other signal is NOT dropped', () => {
+    assert.equal(
+      classifyOpinion({
+        title: 'What we know about the Strait of Hormuz closure',
+        link: 'https://example.com/analysis/hormuz-closure-explainer',
+        description: 'Shipping data shows a 40% drop in transits since Tuesday.',
+      }),
+      false,
+    );
+  });
+
+  it('REGRESSION (A3): a hard-news headline that QUOTES a phrase (not whole-wrapped) is NOT dropped', () => {
+    // "'on life support'" is a quoted phrase inside the headline — the
+    // headline as a whole is not quote-wrapped.
+    assert.equal(
+      classifyOpinion({
+        title: "Trump says Iran ceasefire is 'on life support' after he rejects Tehran's response",
+        link: 'https://example.com/world/trump-iran-ceasefire',
+        description: 'Former President Trump rejected the latest proposal.',
+      }),
+      false,
+    );
+  });
+
+  it('a bare-noun headline starting with "Opinion" / "Analysis" (no colon) is NOT caught', () => {
+    assert.equal(
+      classifyOpinion({ title: 'Opinion polls tighten ahead of the election', link: 'https://example.com/world/polls' }),
+      false,
+    );
+    assert.equal(
+      classifyOpinion({ title: 'Analysis firm downgrades the bank', link: 'https://example.com/business/downgrade' }),
+      false,
+    );
+  });
+
+  it('a plain hard-news event → NOT opinion', () => {
+    assert.equal(
+      classifyOpinion({
+        title: 'Putin tests nuclear-capable Sarmat missile',
+        link: 'https://example.com/world/russia-sarmat-test',
+        description: 'Russia test-fired the intercontinental ballistic missile from Plesetsk.',
+      }),
+      false,
+    );
+  });
+});
+
+describe('classifyOpinion — input safety', () => {
+  it('handles missing / non-string fields without throwing', () => {
+    assert.equal(classifyOpinion({}), false);
+    assert.equal(classifyOpinion({ title: 42, link: null, description: undefined }), false);
+    // @ts-expect-error testing unexpected input
+    assert.doesNotThrow(() => classifyOpinion(null));
+    // @ts-expect-error testing unexpected input
+    assert.equal(classifyOpinion(undefined), false);
+  });
+});


### PR DESCRIPTION
## Summary

PR C of the brief-pipeline plan (`docs/plans/2026-05-14-001-…`, Phase 3 F3 + Phase 4 F4). **Stacked on PR B (#3688)** → base `fix/brief-grounding-gate-adapter`; auto-retargets up the chain as A→B merge.

### F3 — opinion/analysis exclusion

The May 14 brief ranked a **Le Monde opinion column** ("'Russia's invasion of Ukraine could have warned Trump…'", by columnist Gilles Paris) as story #1, tagged Critical, ahead of a nuclear ICBM test. The brief is event-driven intelligence — an op-ed column is not an event.

- **`server/_shared/opinion-classifier.js`** — single shared classifier `classifyOpinion({ title, link, description })`. **Tiered**: STRONG signals (URL `/opinion/`,`/views/`,`/commentary/`,`/editorial/`,`/op-ed/`,`/columnists/` segments; explicit `Opinion:`/`Analysis:`/`Commentary:`/`Op-Ed:` headline prefix) classify alone; CORROBORATING signals (whole-headline quote-wrap, description framing words, `/analysis/` URL) need a STRONG signal OR two corroborating. Conservative — a false negative ships one op-ed; a false positive silently drops a real event.
  - *Plan correction*: the plan expected ingest-time byline/section metadata, but the parsed RSS item and the `story:track:v1` row carry neither — only `title`, `link`, `description`. Both layers classify from the same three signals.
- **Two-layer filter**:
  - **Ingest** (`list-feed-digest.ts`) — `ParsedItem` gains `isOpinion`, set by `classifyOpinion` in `parseRssXml`; `buildStoryTrackHsetFields` stamps `isOpinion` (`'1'`/`'0'`) on the `story:track:v1` row.
  - **Read-time** (`buildDigest`) — drops `isOpinion === '1'` rows; for residue rows ingested *before* the stamp shipped (no `isOpinion` field), re-classifies from the persisted title/link/description. Emits `[digest] buildDigest opinion filter dropped N` telemetry.
  - Stamps rather than drops at ingest — `story:track` rows feed more than the brief; only `buildDigest` (the brief's read path) filters.

### F4 — lead ↔ final-card-#1 coherence

The synthesis emits `lead` and `rankedStoryHashes` independently, with no constraint that the lead is *about* the rendered first story. And `rankedStoryHashes[0]` ≠ `data.stories[0]` — `orderBriefCandidates` re-sorts by severity/topic/score after the LLM rank. On May 14 the lead was about the Ukraine-energy story while `data.stories[0]` was the Le Monde column.

- **`leadGroundsAgainstStory(lead, headline)`** in `brief-llm.mjs` — reuses the `checkLeadGrounding` anchor machinery but with a **fixed threshold of 1**. `checkLeadGrounding` is the wrong fit: scoped to one story, a single headline can carry ≥4 anchors, tripping its size-based threshold up to 2 — too strict for a coherence question ("same story?", not "how grounded?").
- `composeAndStoreBriefForUser` runs the check **after** `composeBriefFromDigestStories`, against `envelope.data.stories[0]` (the final ordered first card) — **never** `rankedStoryHashes[0]`. It runs in the orchestration layer, not the pure composer, so `composeBriefFromDigestStories` stays I/O-free. **Measure-first** (plan F4 option b): emits `[digest] lead card1 coherence` every brief + a `LEAD/CARD-#1 INCOHERENCE` warn on mismatch; ships the brief as-is. Once the mismatch rate is known, decide between regenerating the lead bound to `stories[0]` or a separate `leadStoryHash`.

## Test coverage

- 11 `classifyOpinion` unit tests — STRONG-alone, two-corroborating, one-corroborating-not-enough, the verbatim May 14 Le Monde column → opinion, `/analysis/` hard-news NOT dropped, quoted-*phrase* (not whole-wrap) hard-news NOT dropped, bare-noun "Opinion polls…" NOT caught, input safety
- `parseRssXml` carries `isOpinion` (hard-news false / op-ed true)
- `buildStoryTrackHsetFields` stamps `isOpinion` `'1'`/`'0'` + legacy missing-field → `'0'`
- 3 `leadGroundsAgainstStory` tests incl. the May 14 F4 regression (lead about Netanyahu vs Le Monde card-#1 → incoherent) and degenerate no-anchor → skip
- `Dockerfile.digest-notifications` COPYs the new `opinion-classifier.js` — the transitive-import-closure test caught the missing COPY

## Test plan

- [x] `node --test tests/opinion-classifier.test.mjs` → 11/11
- [x] `node --test tests/brief-llm.test.mjs` → 100/100
- [x] `tsx --test tests/news-rss-description-extract.test.mts tests/news-story-track-description-persistence.test.mts` → 26/26
- [x] `tsx --test tests/*.test.mjs tests/*.test.mts` → 8728/8728
- [x] `npx tsc --noEmit` + `tsc --noEmit -p tsconfig.api.json` clean
- [x] `biome check` — 3 pre-existing warnings (buildDigest/main complexity already 5x over limit; one useOptionalChain on untouched list-feed-digest code), none introduced here
- [ ] **After deploy** — cron log shows `buildDigest opinion filter dropped N`; no op-ed/column in the rendered brief
- [ ] **After deploy** — cron log shows `lead card1 coherence` lines; measure the `coherent=false` rate to decide F4 follow-up

## Notes

No cache-prefix bump — F3 changes digest **pool membership** (fewer stories), not the synthesis cache material; F4 is pure telemetry.

Depends on PR A (#3685) and PR B (#3688). This is the last code PR in the plan; PR D (date drift) and PR E (threads consistency) remain as deferred low-urgency follow-ups.