### PR TITLE
fix(brief): date-ground the LLM system prompts (plan F6 / PR D)

### DIFF
--- a/api/internal/brief-why-matters.ts
+++ b/api/internal/brief-why-matters.ts
@@ -376,22 +376,27 @@ export default async function handler(req: Request, ctx?: EdgeContext): Promise<
 
   // Cache identity.
   const hash = await hashBriefStory(story);
-  // v7: RSS-description grounding (2026-04-24). story:track:v1 now carries
+  // v8 (2026-05-14): bumped from v7 alongside the F6 date-grounding
+  // line appended to both whyMatters system prompts (analyst v2 and
+  // the gemini fallback). Every v7 row was produced from a prompt
+  // with no notion of "today" and may state a fabricated year — the
+  // exact bug F6 fixes. Serving v7 on a cache hit would keep shipping
+  // that fabrication for the 6h TTL, so v7 must not survive the
+  // deploy.
+  //
+  // v7: RSS-description grounding (2026-04-24). story:track:v1 carries
   // a cleaned RSS description that rides through buildWhyMattersUserPrompt
   // as the `description` field. Every v6 row was produced either without a
   // description or with the cleaned-headline placeholder; with real article
   // bodies arriving, the editorial voice and named-actor accuracy shift
-  // enough that v6 prose must be invalidated. hashBriefStory includes
-  // description in its hash material so identity naturally drifts too —
-  // this prefix bump is belt-and-braces for a clean cold-start on first
-  // tick after deploy.
+  // enough that v6 prose had to be invalidated.
   //
   // v6 history (kept for reference): category-gated context + prompt-level
-  // RELEVANCE RULE (2026-04-22) — those changes remain in v7.
-  const cacheKey = `brief:llm:whymatters:v7:${hash}`;
-  // Shadow v4→v5 for the same reason — a mid-rollout shadow record
-  // comparing v6 pre-grounding vs gemini is not useful once v7 is live.
-  const shadowKey = `brief:llm:whymatters:shadow:v5:${hash}`;
+  // RELEVANCE RULE (2026-04-22) — those changes remain in v8.
+  const cacheKey = `brief:llm:whymatters:v8:${hash}`;
+  // Shadow v5→v6 for the same reason — a mid-rollout shadow record
+  // comparing v7 pre-date-grounding vs gemini is not useful once v8 is live.
+  const shadowKey = `brief:llm:whymatters:shadow:v6:${hash}`;
 
   // Cache read. Any infrastructure failure → treat as miss (logged).
   let cached: WhyMattersEnvelope | null = null;

--- a/scripts/lib/brief-llm.mjs
+++ b/scripts/lib/brief-llm.mjs
@@ -38,6 +38,7 @@ import { createHash } from 'node:crypto';
 
 import {
   WHY_MATTERS_SYSTEM,
+  briefDateLine,
   buildWhyMattersUserPrompt,
   hashBriefStory,
   parseWhyMatters,
@@ -387,6 +388,7 @@ export function greetingBucket(greeting) {
  * @property {string|null} [profile]   formatted user profile lines, or null for non-personalised
  * @property {string|null} [greeting]  e.g. "Good morning", or null for non-personalised
  * @property {boolean}     [isPublic]  true = strip personalisation, build a generic lead
+ * @property {string}      [todayIso]  ISO date for the date-grounding line; defaults to today (UTC)
  */
 
 /**
@@ -435,7 +437,13 @@ export function buildDigestPrompt(stories, sensitivity, ctx = {}) {
   }
   userParts.push('', "Today's surfaced stories (ranked):", ...lines);
 
-  return { system: DIGEST_PROSE_SYSTEM_BASE, user: userParts.join('\n') };
+  // F6: the static system prompt has no notion of "now" — without an
+  // explicit date the model fabricates years (a May 2026 brief shipped
+  // a "deploy ... in 2024" line). briefDateLine pins the current date.
+  return {
+    system: `${DIGEST_PROSE_SYSTEM_BASE}\n${briefDateLine(ctx?.todayIso)}`,
+    user: userParts.join('\n'),
+  };
 }
 
 // Back-compat alias for tests that import the old constant name.

--- a/scripts/lib/brief-llm.mjs
+++ b/scripts/lib/brief-llm.mjs
@@ -15,12 +15,12 @@
 //     through to the original stub — the brief must always ship.
 //
 // Cache semantics:
-//   - brief:llm:whymatters:v3:{storyHash}:{leadHash} — 24h, shared
-//     across users for the same (story, lead) pair. v3 includes
-//     SHA-256 of the resolved digest lead so per-story rationales
-//     re-generate when the lead changes (rationales must align with
-//     the headline frame). v2 rows were lead-blind and could drift.
-//   - brief:llm:digest:v5:{userId|public}:{sensitivity}:{poolHash}
+//   - brief:llm:whymatters:v4:{storyHash} — 24h, shared across users
+//     for the same story. v4 bumped from v3 alongside the F6
+//     date-grounding line: every v3 row was produced from a prompt
+//     with no notion of "today" and may state a fabricated year, so
+//     v3 rows must not survive the deploy. v2 rows were lead-blind.
+//   - brief:llm:digest:v6:{userId|public}:{sensitivity}:{poolHash}
 //     — 4h. The canonical synthesis is now ALWAYS produced through
 //     this path (formerly split with `generateAISummary` in the
 //     digest cron). Material includes profile-SHA, greeting bucket,
@@ -29,10 +29,10 @@
 //     When isPublic=true, the userId slot in the key is the literal
 //     string 'public' so all public-share readers of the same
 //     (date, sensitivity, story-pool) hit the same row — no PII in
-//     the public cache key. v4 rows ignored on rollout (eviction
-//     paid once after the v5 grounding-validator landed in response
-//     to the May 12 hallucination incident — see generateDigestProse
-//     header comment).
+//     the public cache key. v6 bumped from v5 for the F6
+//     date-grounding line (same reason as whymatters v4); v5 landed
+//     the grounding validator after the May 12 hallucination — see
+//     generateDigestProse header comment.
 
 import { createHash } from 'node:crypto';
 
@@ -108,8 +108,8 @@ const BRIEF_LLM_SKIP_PROVIDERS = ['ollama', 'groq'];
  *
  * Three-layer graceful degradation:
  *   1. `deps.callAnalystWhyMatters(story)` — the analyst-context edge
- *      endpoint (brief:llm:whymatters:v3 cache lives there). Preferred.
- *   2. Legacy direct-Gemini chain: cacheGet (v2) → callLLM → cacheSet.
+ *      endpoint (brief:llm:whymatters:v8 cache lives there). Preferred.
+ *   2. Legacy direct-Gemini chain: cacheGet (v4) → callLLM → cacheSet.
  *      Runs whenever the analyst call is missing, returns null, or throws.
  *   3. Caller (enrichBriefEnvelopeWithLLM) uses the baseline stub if
  *      this function returns null.
@@ -153,13 +153,16 @@ export async function generateWhyMatters(story, deps) {
     }
   }
 
-  // Fallback path: legacy direct-Gemini chain with the v3 cache.
-  // Bumped v2→v3 on 2026-04-24 alongside the RSS-description fix: rows
-  // keyed on the prior v2 prefix were produced from headline-only prompts
-  // and may reference hallucinated named actors. The prefix bump forces
-  // a clean cold-start on first tick after deploy; entries expire in
-  // ≤24h so the prior prefix ages out naturally without a DEL sweep.
-  const key = `brief:llm:whymatters:v3:${await hashBriefStory(story)}`;
+  // Fallback path: legacy direct-Gemini chain with the v4 cache.
+  // Bumped v3→v4 on 2026-05-14 alongside the F6 date-grounding line:
+  // every v3 row was produced from a buildWhyMattersPrompt prompt with
+  // no notion of "today", so a v3 row may state a fabricated year
+  // (the bug F6 fixes). Serving v3 on a cache hit would keep shipping
+  // that fabrication for the 24h TTL — the prefix bump forces a clean
+  // cold-start through the date-grounded prompt on first tick after
+  // deploy. (v2→v3 was the 2026-04-24 RSS-description fix.) Entries
+  // expire in ≤24h so the prior prefix ages out without a DEL sweep.
+  const key = `brief:llm:whymatters:v4:${await hashBriefStory(story)}`;
   try {
     const hit = await deps.cacheGet(key);
     if (typeof hit === 'string' && hit.length > 0) return hit;
@@ -860,12 +863,22 @@ function hashDigestInput(userId, stories, sensitivity, ctx = {}) {
  * @param {DigestPromptCtx} [ctx]
  */
 export async function generateDigestProse(userId, stories, sensitivity, deps, ctx = {}) {
-  // v5 key (2026-05-12): bumped from v4 alongside the grounding
-  // gate in validateDigestProseShape. v4 rows may have been written
-  // for shape-valid but content-fabricated leads (May 12 incident:
-  // a Trump-era geopolitics pool shipped a "President Biden crypto
+  // v6 key (2026-05-14): bumped from v5 alongside the F6 date-grounding
+  // line appended to DIGEST_PROSE_SYSTEM_BASE by buildDigestPrompt.
+  // Every v5 row was produced from a prompt with no notion of "today"
+  // and may state a fabricated year in the lead/threads/signals — the
+  // exact bug F6 fixes. validateDigestProseShape revalidates cache
+  // hits, but its grounding gate is proper-noun based and does NOT
+  // catch date/numeric fabrication, so a v5 row would re-pass and
+  // ship for the 4h TTL. Evicting v5 forces regeneration through the
+  // date-grounded prompt.
+  //
+  // v5 (2026-05-12): bumped from v4 alongside the grounding gate in
+  // validateDigestProseShape. v4 rows may have been written for
+  // shape-valid but content-fabricated leads (May 12 incident: a
+  // Trump-era geopolitics pool shipped a "President Biden crypto
   // executive order" fabricated lead that passed the shape-only
-  // validator). Evicting v4 forces regeneration through the new
+  // validator). Evicting v4 forced regeneration through the new
   // grounded gate; ungrounded re-rolls fall through to L2/L3.
   //
   // v4 (2026-04-25 evening): bumped from v3 when the prompt gained
@@ -874,7 +887,7 @@ export async function generateDigestProse(userId, stories, sensitivity, deps, ct
   // shipped vapid editorial filler ("the global stage is buzzing",
   // "navigating the evolving landscape"). v3 cache rows still in
   // TTL would otherwise serve stale vapid leads for 4h post-deploy.
-  const key = `brief:llm:digest:v5:${hashDigestInput(userId, stories, sensitivity, ctx)}`;
+  const key = `brief:llm:digest:v6:${hashDigestInput(userId, stories, sensitivity, ctx)}`;
   try {
     const hit = await deps.cacheGet(key);
     // CRITICAL: re-run the shape+grounding validator on cache hits.

--- a/scripts/shared/brief-llm-core.d.ts
+++ b/scripts/shared/brief-llm-core.d.ts
@@ -19,7 +19,12 @@ export interface BriefStoryPromptInput {
 
 export const WHY_MATTERS_SYSTEM: string;
 
-export function buildWhyMattersUserPrompt(story: BriefStoryPromptInput): {
+export function briefDateLine(todayIso?: string): string;
+
+export function buildWhyMattersUserPrompt(
+  story: BriefStoryPromptInput,
+  todayIso?: string,
+): {
   system: string;
   user: string;
 };

--- a/scripts/shared/brief-llm-core.js
+++ b/scripts/shared/brief-llm-core.js
@@ -26,6 +26,36 @@ export const WHY_MATTERS_SYSTEM =
   'no quotes. One sentence only.';
 
 /**
+ * Date-grounding line appended to every brief LLM system prompt.
+ *
+ * The brief's source stories are dated, but the system prompts are
+ * static — without an explicit "today" the model fills date/year
+ * gaps from its training-data priors. A May 2026 brief shipped a
+ * whyMatters claiming a deploy "in 2024" (plan F6). The proper-noun
+ * grounding gate does not catch numeric/date fabrication, so one
+ * line stating the current date and forbidding contradictory years
+ * is the cheap structural guard.
+ *
+ * `todayIso` is injectable so prompt-builder tests stay deterministic;
+ * production call sites pass nothing and get the current UTC date.
+ * A malformed override falls back to today rather than interpolating
+ * garbage into the prompt.
+ *
+ * @param {string} [todayIso] ISO date `YYYY-MM-DD`. Defaults to today (UTC).
+ * @returns {string}
+ */
+export function briefDateLine(todayIso) {
+  const iso = typeof todayIso === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(todayIso)
+    ? todayIso
+    : new Date().toISOString().slice(0, 10);
+  return (
+    `Today is ${iso}. Do not state any year or date that contradicts ` +
+    'the dates in the stories below; when a date is not given, omit it ' +
+    'rather than guess.'
+  );
+}
+
+/**
  * @param {{
  *   headline: string;
  *   source: string;
@@ -33,9 +63,10 @@ export const WHY_MATTERS_SYSTEM =
  *   category: string;
  *   country: string;
  * }} story
+ * @param {string} [todayIso] ISO date for the date-grounding line; defaults to today.
  * @returns {{ system: string; user: string }}
  */
-export function buildWhyMattersUserPrompt(story) {
+export function buildWhyMattersUserPrompt(story, todayIso) {
   const user = [
     `Headline: ${story.headline}`,
     `Source: ${story.source}`,
@@ -45,7 +76,7 @@ export function buildWhyMattersUserPrompt(story) {
     '',
     'One editorial sentence on why this matters:',
   ].join('\n');
-  return { system: WHY_MATTERS_SYSTEM, user };
+  return { system: `${WHY_MATTERS_SYSTEM}\n${briefDateLine(todayIso)}`, user };
 }
 
 /**

--- a/server/worldmonitor/intelligence/v1/brief-why-matters-prompt.ts
+++ b/server/worldmonitor/intelligence/v1/brief-why-matters-prompt.ts
@@ -12,7 +12,7 @@
  * LLM latency predictable.
  */
 
-import { WHY_MATTERS_ANALYST_SYSTEM_V2 } from '../../../../shared/brief-llm-core.js';
+import { WHY_MATTERS_ANALYST_SYSTEM_V2, briefDateLine } from '../../../../shared/brief-llm-core.js';
 import { sanitizeForPrompt } from '../../../_shared/llm-sanitize.js';
 import type { BriefStoryContext } from './brief-story-context';
 
@@ -221,6 +221,7 @@ export function buildContextBlock(
 export function buildAnalystWhyMattersPrompt(
   story: StoryForPrompt,
   context: BriefStoryContext,
+  todayIso?: string,
 ): { system: string; user: string; policyLabel: string } {
   const safe = sanitizeStoryFields(story);
   const { sections: allowedSections, policyLabel } = sectionsForCategory(safe.category);
@@ -266,8 +267,12 @@ export function buildAnalystWhyMattersPrompt(
       "into a story where it does not belong. Plain prose, no section labels in the output:",
   );
 
+  // F6: append the current date so the analyst does not fabricate
+  // years from training-data priors (a May 2026 brief shipped a
+  // "deploy ... in 2024" whyMatters). `todayIso` is injectable for
+  // deterministic tests; production callers pass nothing.
   return {
-    system: WHY_MATTERS_ANALYST_SYSTEM_V2,
+    system: `${WHY_MATTERS_ANALYST_SYSTEM_V2}\n${briefDateLine(todayIso)}`,
     user: parts.join('\n\n'),
     policyLabel,
   };

--- a/shared/brief-llm-core.d.ts
+++ b/shared/brief-llm-core.d.ts
@@ -19,7 +19,12 @@ export interface BriefStoryPromptInput {
 
 export const WHY_MATTERS_SYSTEM: string;
 
-export function buildWhyMattersUserPrompt(story: BriefStoryPromptInput): {
+export function briefDateLine(todayIso?: string): string;
+
+export function buildWhyMattersUserPrompt(
+  story: BriefStoryPromptInput,
+  todayIso?: string,
+): {
   system: string;
   user: string;
 };

--- a/shared/brief-llm-core.js
+++ b/shared/brief-llm-core.js
@@ -26,6 +26,36 @@ export const WHY_MATTERS_SYSTEM =
   'no quotes. One sentence only.';
 
 /**
+ * Date-grounding line appended to every brief LLM system prompt.
+ *
+ * The brief's source stories are dated, but the system prompts are
+ * static — without an explicit "today" the model fills date/year
+ * gaps from its training-data priors. A May 2026 brief shipped a
+ * whyMatters claiming a deploy "in 2024" (plan F6). The proper-noun
+ * grounding gate does not catch numeric/date fabrication, so one
+ * line stating the current date and forbidding contradictory years
+ * is the cheap structural guard.
+ *
+ * `todayIso` is injectable so prompt-builder tests stay deterministic;
+ * production call sites pass nothing and get the current UTC date.
+ * A malformed override falls back to today rather than interpolating
+ * garbage into the prompt.
+ *
+ * @param {string} [todayIso] ISO date `YYYY-MM-DD`. Defaults to today (UTC).
+ * @returns {string}
+ */
+export function briefDateLine(todayIso) {
+  const iso = typeof todayIso === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(todayIso)
+    ? todayIso
+    : new Date().toISOString().slice(0, 10);
+  return (
+    `Today is ${iso}. Do not state any year or date that contradicts ` +
+    'the dates in the stories below; when a date is not given, omit it ' +
+    'rather than guess.'
+  );
+}
+
+/**
  * @param {{
  *   headline: string;
  *   source: string;
@@ -33,9 +63,10 @@ export const WHY_MATTERS_SYSTEM =
  *   category: string;
  *   country: string;
  * }} story
+ * @param {string} [todayIso] ISO date for the date-grounding line; defaults to today.
  * @returns {{ system: string; user: string }}
  */
-export function buildWhyMattersUserPrompt(story) {
+export function buildWhyMattersUserPrompt(story, todayIso) {
   const user = [
     `Headline: ${story.headline}`,
     `Source: ${story.source}`,
@@ -45,7 +76,7 @@ export function buildWhyMattersUserPrompt(story) {
     '',
     'One editorial sentence on why this matters:',
   ].join('\n');
-  return { system: WHY_MATTERS_SYSTEM, user };
+  return { system: `${WHY_MATTERS_SYSTEM}\n${briefDateLine(todayIso)}`, user };
 }
 
 /**

--- a/tests/brief-llm-core.test.mjs
+++ b/tests/brief-llm-core.test.mjs
@@ -126,12 +126,18 @@ describe('briefDateLine — date-grounding instruction (plan F6)', () => {
   });
 
   it('falls back to the current UTC date for missing / malformed input', () => {
-    const today = new Date().toISOString().slice(0, 10);
     for (const bad of [undefined, null, '', 'not-a-date', '2026/05/14', 14]) {
-      assert.match(
-        briefDateLine(bad),
-        new RegExp(`^Today is ${today}\\.`),
-        `malformed input ${JSON.stringify(bad)} must fall back to today`,
+      // `before`/`after` bracket each call so a UTC-midnight rollover
+      // mid-test still matches one of the two valid dates — the date is
+      // read inside briefDateLine, not captured once up front.
+      const before = new Date().toISOString().slice(0, 10);
+      const line = briefDateLine(bad);
+      const after = new Date().toISOString().slice(0, 10);
+      const m = line.match(/^Today is (\d{4}-\d{2}-\d{2})\./);
+      assert.ok(m, `malformed input ${JSON.stringify(bad)} must still produce a dated line`);
+      assert.ok(
+        m[1] === before || m[1] === after,
+        `malformed input ${JSON.stringify(bad)} must fall back to the current UTC date (got ${m[1]}, expected ${before} or ${after})`,
       );
     }
   });

--- a/tests/brief-llm-core.test.mjs
+++ b/tests/brief-llm-core.test.mjs
@@ -18,6 +18,7 @@ import { createHash } from 'node:crypto';
 
 import {
   WHY_MATTERS_SYSTEM,
+  briefDateLine,
   buildWhyMattersUserPrompt,
   hashBriefStory,
   parseWhyMatters,
@@ -117,10 +118,31 @@ describe('WHY_MATTERS_SYSTEM — pinned editorial voice', () => {
   });
 });
 
+describe('briefDateLine — date-grounding instruction (plan F6)', () => {
+  it('uses the injected ISO date verbatim', () => {
+    const line = briefDateLine('2026-05-14');
+    assert.match(line, /^Today is 2026-05-14\./);
+    assert.match(line, /Do not state any year or date that contradicts/);
+  });
+
+  it('falls back to the current UTC date for missing / malformed input', () => {
+    const today = new Date().toISOString().slice(0, 10);
+    for (const bad of [undefined, null, '', 'not-a-date', '2026/05/14', 14]) {
+      assert.match(
+        briefDateLine(bad),
+        new RegExp(`^Today is ${today}\\.`),
+        `malformed input ${JSON.stringify(bad)} must fall back to today`,
+      );
+    }
+  });
+});
+
 describe('buildWhyMattersUserPrompt — shape', () => {
   it('emits the exact 5-line format pinned by the cache-identity contract', () => {
-    const { system, user } = buildWhyMattersUserPrompt(FIXTURE);
-    assert.equal(system, WHY_MATTERS_SYSTEM);
+    // todayIso is injected so the system-prompt assertion is deterministic;
+    // the USER prompt (the cache-identity contract) is unchanged by F6.
+    const { system, user } = buildWhyMattersUserPrompt(FIXTURE, '2026-05-14');
+    assert.equal(system, `${WHY_MATTERS_SYSTEM}\n${briefDateLine('2026-05-14')}`);
     assert.equal(
       user,
       [

--- a/tests/brief-llm.test.mjs
+++ b/tests/brief-llm.test.mjs
@@ -176,8 +176,8 @@ describe('generateWhyMatters', () => {
     const real = makeLLM('Closure would freeze a fifth of seaborne crude within days.');
     const first = await generateWhyMatters(story(), { ...cache, callLLM: real.callLLM });
     assert.ok(first);
-    const cachedKey = [...cache.store.keys()].find((k) => k.startsWith('brief:llm:whymatters:v3:'));
-    assert.ok(cachedKey, 'expected a whymatters cache entry under the v3 key (bumped 2026-04-24 for RSS-description grounding)');
+    const cachedKey = [...cache.store.keys()].find((k) => k.startsWith('brief:llm:whymatters:v4:'));
+    assert.ok(cachedKey, 'expected a whymatters cache entry under the v4 key (bumped 2026-05-14 for the F6 date-grounding line)');
 
     // Second call: responder throws — cache must prevent the call
     llm.calls.length = 0;
@@ -503,7 +503,7 @@ describe('generateDigestProse', () => {
     const llm1 = makeLLM(validJson);
     await generateDigestProse('user_a', stories, 'all', { ...cache, callLLM: llm1.callLLM });
 
-    const badKey = [...cache.store.keys()].find((k) => k.startsWith('brief:llm:digest:v5:'));
+    const badKey = [...cache.store.keys()].find((k) => k.startsWith('brief:llm:digest:v6:'));
     assert.ok(badKey, 'expected a digest prose cache entry');
     // Overwrite with a payload whose content has zero proper-noun
     // overlap with `stories` (Iran Hormuz / Gaza). Shape is impeccable.
@@ -529,11 +529,11 @@ describe('generateDigestProse', () => {
     // `threads`, which the renderer's assertBriefEnvelope requires.
     const llm1 = makeLLM(validJson);
     await generateDigestProse('user_a', stories, 'all', { ...cache, callLLM: llm1.callLLM });
-    // Corrupt the stored row in place. Cache key prefix bumped to v5
-    // (2026-05-12) when validateDigestProseShape gained the
-    // grounding gate. v3 rows ignored at v4 rollout; v4 rows ignored
-    // at v5 rollout — see generateDigestProse header comment.
-    const badKey = [...cache.store.keys()].find((k) => k.startsWith('brief:llm:digest:v5:'));
+    // Corrupt the stored row in place. Cache key prefix bumped to v6
+    // (2026-05-14) when buildDigestPrompt gained the F6 date-grounding
+    // line. v4 rows ignored at v5 rollout; v5 rows ignored at v6
+    // rollout — see generateDigestProse header comment.
+    const badKey = [...cache.store.keys()].find((k) => k.startsWith('brief:llm:digest:v6:'));
     assert.ok(badKey, 'expected a digest prose cache entry');
     cache.store.set(badKey, { lead: 'short', /* missing threads + signals */ });
     const llm2 = makeLLM(validJson);
@@ -1105,12 +1105,13 @@ describe('generateDigestProsePublic — public cache shared across users', () =>
     assert.equal(llm2.calls.length, 1, 'profile change re-keys the cache');
   });
 
-  it('writes to cache under brief:llm:digest:v5 prefix (v4/v3/v2 evicted)', async () => {
+  it('writes to cache under brief:llm:digest:v6 prefix (v5/v4/v3/v2 evicted)', async () => {
     const cache = makeCache();
     const llm = makeLLM(validJson);
     await generateDigestProse('user_a', stories, 'all', { ...cache, callLLM: llm.callLLM });
     const keys = [...cache.store.keys()];
-    assert.ok(keys.some((k) => k.startsWith('brief:llm:digest:v5:')), 'v5 prefix used');
+    assert.ok(keys.some((k) => k.startsWith('brief:llm:digest:v6:')), 'v6 prefix used');
+    assert.ok(!keys.some((k) => k.startsWith('brief:llm:digest:v5:')), 'no v5 writes');
     assert.ok(!keys.some((k) => k.startsWith('brief:llm:digest:v4:')), 'no v4 writes');
     assert.ok(!keys.some((k) => k.startsWith('brief:llm:digest:v3:')), 'no v3 writes');
     assert.ok(!keys.some((k) => k.startsWith('brief:llm:digest:v2:')), 'no v2 writes');

--- a/tests/brief-llm.test.mjs
+++ b/tests/brief-llm.test.mjs
@@ -30,6 +30,7 @@ import {
 } from '../scripts/lib/brief-llm.mjs';
 import { assertBriefEnvelope } from '../server/_shared/brief-render.js';
 import { composeBriefFromDigestStories, digestStoryToSynthesisShape } from '../scripts/lib/brief-compose.mjs';
+import { briefDateLine } from '../shared/brief-llm-core.js';
 
 // ── Fixtures ───────────────────────────────────────────────────────────────
 
@@ -314,8 +315,7 @@ describe('buildDigestPrompt', () => {
     assert.match(system, /rankedStoryHashes/);
   });
 
-  it('appends the date-grounding line to the system prompt (F6)', async () => {
-    const { briefDateLine } = await import('../shared/brief-llm-core.js');
+  it('appends the date-grounding line to the system prompt (F6)', () => {
     // Injected todayIso → deterministic assertion.
     const injected = buildDigestPrompt([story()], 'critical', { todayIso: '2026-05-14' });
     assert.ok(
@@ -327,9 +327,17 @@ describe('buildDigestPrompt', () => {
     assert.match(injected.system, /chief editor of WorldMonitor Brief/);
 
     // No ctx.todayIso → falls back to the current UTC date, never absent.
+    // `before`/`after` bracket the call so a UTC-midnight rollover
+    // mid-test still matches one of the two valid dates.
+    const before = new Date().toISOString().slice(0, 10);
     const fallback = buildDigestPrompt([story()], 'critical');
-    const today = new Date().toISOString().slice(0, 10);
-    assert.match(fallback.system, new RegExp(`\\nToday is ${today}\\.`));
+    const after = new Date().toISOString().slice(0, 10);
+    const m = fallback.system.match(/\nToday is (\d{4}-\d{2}-\d{2})\./);
+    assert.ok(m, 'fallback system prompt must carry a dated grounding line');
+    assert.ok(
+      m[1] === before || m[1] === after,
+      `fallback date must be the current UTC date (got ${m[1]}, expected ${before} or ${after})`,
+    );
   });
 });
 

--- a/tests/brief-llm.test.mjs
+++ b/tests/brief-llm.test.mjs
@@ -313,6 +313,24 @@ describe('buildDigestPrompt', () => {
     const { system } = buildDigestPrompt([story()], 'critical');
     assert.match(system, /rankedStoryHashes/);
   });
+
+  it('appends the date-grounding line to the system prompt (F6)', async () => {
+    const { briefDateLine } = await import('../shared/brief-llm-core.js');
+    // Injected todayIso → deterministic assertion.
+    const injected = buildDigestPrompt([story()], 'critical', { todayIso: '2026-05-14' });
+    assert.ok(
+      injected.system.endsWith(`\n${briefDateLine('2026-05-14')}`),
+      'system prompt must end with the injected date-grounding line',
+    );
+    assert.match(injected.system, /Today is 2026-05-14\. Do not state any year or date that contradicts/);
+    // The base editorial contract is still intact ahead of the date line.
+    assert.match(injected.system, /chief editor of WorldMonitor Brief/);
+
+    // No ctx.todayIso → falls back to the current UTC date, never absent.
+    const fallback = buildDigestPrompt([story()], 'critical');
+    const today = new Date().toISOString().slice(0, 10);
+    assert.match(fallback.system, new RegExp(`\\nToday is ${today}\\.`));
+  });
 });
 
 // ── parseDigestProse ───────────────────────────────────────────────────────

--- a/tests/brief-why-matters-analyst.test.mjs
+++ b/tests/brief-why-matters-analyst.test.mjs
@@ -492,21 +492,27 @@ describe('buildAnalystWhyMattersPrompt — shape and budget', () => {
     assert.ok(typeof builder === 'function');
   });
 
-  it('uses the analyst v2 system prompt (multi-sentence, grounded)', async () => {
-    const { WHY_MATTERS_ANALYST_SYSTEM_V2 } = await import('../shared/brief-llm-core.js');
-    const { system } = builder(story(), {
-      worldBrief: 'X',
-      countryBrief: '',
-      riskScores: '',
-      forecasts: '',
-      marketData: '',
-      macroSignals: '',
-      degraded: false,
-    });
-    assert.equal(system, WHY_MATTERS_ANALYST_SYSTEM_V2);
+  it('uses the analyst v2 system prompt (multi-sentence, grounded) + date-grounding line', async () => {
+    const { WHY_MATTERS_ANALYST_SYSTEM_V2, briefDateLine } = await import('../shared/brief-llm-core.js');
+    const { system } = builder(
+      story(),
+      {
+        worldBrief: 'X',
+        countryBrief: '',
+        riskScores: '',
+        forecasts: '',
+        marketData: '',
+        macroSignals: '',
+        degraded: false,
+      },
+      '2026-05-14',
+    );
+    // F6: system prompt is the static v2 const + an injected date line.
+    assert.equal(system, `${WHY_MATTERS_ANALYST_SYSTEM_V2}\n${briefDateLine('2026-05-14')}`);
     // Contract must still mention the 40–70 word target + grounding rule.
     assert.match(system, /40–70 words/);
     assert.match(system, /named person \/ country \/ organization \/ number \/ percentage \/ date \/ city/);
+    assert.match(system, /^Today is 2026-05-14\./m);
   });
 
   it('includes story fields with the multi-sentence footer', () => {


### PR DESCRIPTION
## Summary

**PR D** of the brief-pipeline plan (`docs/plans/2026-05-14-001-…`), Phase 5 / Finding F6 — date-grounds the brief's LLM system prompts. Independent of PRs A/B/C; branched from `main`.

Every brief LLM system prompt — digest synthesis, the whyMatters analyst path, and the whyMatters legacy/fallback path — is a **static string with no notion of "now"**. With no date anchor the model fills date/year gaps from training-data priors: a May 2026 brief shipped a `whyMatters` claiming a deploy "in 2024". The proper-noun grounding gate (#3667) is anchor-based and does not catch numeric/date fabrication.

## Changes

- **New shared helper** `briefDateLine(todayIso?)` in `shared/brief-llm-core.js` — returns `Today is YYYY-MM-DD. Do not state any year or date that contradicts the dates in the stories below; when a date is not given, omit it rather than guess.`
- Appended to the system prompt by all three prompt builders:
  - `buildDigestPrompt` (`DIGEST_PROSE_SYSTEM_BASE`)
  - `buildWhyMattersUserPrompt` (`WHY_MATTERS_SYSTEM` — legacy / cron + edge fallback)
  - `buildAnalystWhyMattersPrompt` (`WHY_MATTERS_ANALYST_SYSTEM_V2` — live analyst path)
- `todayIso` is **injectable for deterministic tests**; production callers pass nothing and get the current UTC date — fully backward compatible, **no production call-site changes**. A malformed override falls back to today rather than interpolating garbage.
- Mirrored byte-for-byte into `scripts/shared/brief-llm-core.{js,d.ts}` per the file's edge-mirror contract.

## Deliberately out of scope

**Cache keys are not touched.** The date line guards against *contradictory* years — it does not emit a literal date into the prose — so a cache hit across midnight is still correctly grounded. The per-run story-pool hash already rotates cache keys; adding the date would only force a daily all-rows miss (extra LLM spend) for no correctness gain.

## Test plan

- [x] `briefDateLine` unit tests — injected date verbatim + malformed-input fallback to today
- [x] Updated the 2 `assert.equal(system, …)` assertions broken by the appended line; added date-line presence assertions for all 3 builders
- [x] 404 brief/digest tests pass under `tsx --test` (incl. `brief-edge-route-smoke`, `brief-magazine-render`, `digest-orchestration-helpers`, `digest-cache-key-sensitivity`)
- [x] `typecheck:api` clean, `biome lint` clean
- [x] `shared/` ↔ `scripts/shared/` mirror byte-identical