### PR TITLE
fix(seed-portwatch): rate-limit recovery — concurrency 12→6 + batch backoff + temp gate

### DIFF
--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -23,7 +23,16 @@ const LOCK_DOMAIN = 'supply_chain:portwatch-ports';
 // 60 min — covers the widest realistic run of this standalone service.
 const LOCK_TTL_MS = 60 * 60 * 1000;
 const TTL = 259_200; // 3 days — 6× the 12h cron interval
-const MIN_VALID_COUNTRIES = 50;
+// Coverage gate. TEMPORARILY lowered from 50 → 25 on 2026-05-14 to let
+// seed-meta refresh while ArcGIS is in a degraded rate-limit state.
+// Background: post-#3681 the proxy retry IS firing, but both direct AND
+// proxy paths are throttled — successful per-country fetches dropped from
+// 24 → 5 between successive runs as Decodo hit its own rate-limit. With
+// gate=50 the seed-meta stayed frozen at 2026-05-12 00:03 UTC for 60+ hours.
+// Lowering to 25 lets a partial-success run advance the meta and clears
+// the operator-facing WARNING while ArcGIS recovers. Revert to 50 once
+// successive runs reliably exceed 50 again (target: 2026-05-20 review).
+const MIN_VALID_COUNTRIES = 25;
 
 const EP3_BASE =
   'https://services9.arcgis.com/weJ1QsnbMYJlCHdG/arcgis/rest/services/Daily_Ports_Data/FeatureServer/0/query';
@@ -59,7 +68,19 @@ const MAX_PORTS_PER_COUNTRY = 50;
 // similar) can push 60-90s when the server is under load. Promise.allSettled would
 // otherwise wait for the slowest, stalling the whole batch.
 const PER_COUNTRY_TIMEOUT_MS = 90_000;
-const CONCURRENCY = 12;
+// Concurrency for the per-country activity fetch. Halved from 12 → 6 on
+// 2026-05-14 to ease pressure on both ArcGIS direct AND Decodo proxy paths,
+// which were each hitting their own rate-limits in the post-3676/3681 runs
+// (24/30 successes on run #1, 5/30 on run #2 as Decodo throttled us).
+// Math at concurrency 6 + cold-fetch cap 30:
+//   5 batches × ~60s realistic (90s worst-case per country) + 4×5s backoff
+//   ≈ 320s realistic, 470s worst case — fits the 570s bundle budget.
+const CONCURRENCY = 6;
+// Cooldown between activity-fetch batches. Spaces out per-batch bursts so
+// neither ArcGIS-direct nor Decodo-proxy hits its rate-limit window from
+// our run alone. 5s × 4 inter-batch gaps = 20s total added to a 30-country
+// run — negligible against the 570s bundle budget.
+const BATCH_BACKOFF_MS = 5_000;
 const BATCH_LOG_EVERY = 5;
 // Cache hygiene: force a full refetch if the cached payload is older than 7 days
 // even when upstream maxDate is unchanged. Protects against window-shift drift
@@ -785,6 +806,17 @@ export async function fetchAll(progress, { signal } = {}) {
         );
         break;
       }
+    }
+
+    // Inter-batch backoff. Spaces out per-batch bursts so neither
+    // ArcGIS-direct nor Decodo-proxy hits its rate-limit window from our
+    // run alone (post-#3681 run #2 showed Decodo throttling us after run
+    // #1 hammered it back-to-back: 24/30 → 5/30 success rate degradation).
+    // Skip on the final batch — no point waiting before exiting the loop.
+    // Also short-circuit if the caller signal has aborted so SIGTERM
+    // doesn't pay an extra 5s before propagating.
+    if (batchIdx < batches && !signal?.aborted) {
+      await new Promise((r) => setTimeout(r, BATCH_BACKOFF_MS));
     }
   }
 

--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -679,7 +679,19 @@ export async function fetchAll(progress, { signal } = {}) {
   // stale → 174 cold-fetches → bundle SIGTERM" failure mode that produced
   // 37h of stale data after a single upstream-advance event. A full
   // rotation completes in ~ceil(174/30) = 6 runs ≈ 3 days at 12h cadence.
+  // Cap-mode signaling. Surfaces to the caller so main() can bypass the 80%
+  // degradation guard for an intentionally-partial publish. Greptile PR #3694
+  // round 3 P1: pre-fix, cap-mode + temp-gate=25 would clear the coverage gate
+  // (countryData.size ≥ 25) but still fail the degradation guard
+  // (countryData.size < prevCount × 0.8 ≈ 139), so seed-meta would not advance
+  // and the WARNING would persist — defeating the PR's main recovery claim.
+  let capTriggered = false;
+  let servedStaleCount = 0;
+  let droppedTooOldCount = 0;
+  let droppedNoCacheCount = 0;
+
   if (needsFetch.length > MAX_COLD_FETCH_PER_RUN) {
+    capTriggered = true;
     // Deterministic-ish shuffle: Fisher-Yates with Math.random — fine here
     // because we just need "different subset each run", not crypto strength.
     const shuffled = [...needsFetch];
@@ -722,6 +734,11 @@ export async function fetchAll(progress, { signal } = {}) {
     // slice, so the two are numerically equal here, but using the constant
     // keeps the intent unambiguous if this log block is ever reordered.
     const originalMisses = MAX_COLD_FETCH_PER_RUN + servedStale + droppedTooOld + droppedNoCache;
+    // Surface the bucket counts to the outer-scope fields so main()'s
+    // degradation-guard bypass can include them in the partial-publish log.
+    servedStaleCount = servedStale;
+    droppedTooOldCount = droppedTooOld;
+    droppedNoCacheCount = droppedNoCache;
     console.warn(
       `  [port-activity] Cold-fetch capped at ${MAX_COLD_FETCH_PER_RUN}/run — ` +
       `refreshing ${MAX_COLD_FETCH_PER_RUN} now, serving ${servedStale} on stale cache (asof behind), ` +
@@ -830,7 +847,18 @@ export async function fetchAll(progress, { signal } = {}) {
   }
 
   if (countryData.size === 0) throw new Error('No country port data returned from ArcGIS');
-  return { countries: [...countryData.keys()], countryData, fetchedAt: new Date().toISOString() };
+  return {
+    countries: [...countryData.keys()],
+    countryData,
+    fetchedAt: new Date().toISOString(),
+    // Cap-mode signaling — see capTriggered declaration. main() reads these
+    // to bypass the 80% degradation guard for an intentionally-partial
+    // publish AND to emit a "PARTIAL PUBLISH" log noting the fresh/stale split.
+    capTriggered,
+    servedStaleCount,
+    droppedTooOldCount,
+    droppedNoCacheCount,
+  };
 }
 
 export function validateFn(data) {
@@ -892,7 +920,14 @@ async function main() {
     prevCount = Array.isArray(prevIso2List) ? prevIso2List.length : 0;
 
     console.log(`  Fetching port activity data (60d: last30 + prev30 windows)...`);
-    const { countries, countryData } = await fetchAll(progress, { signal: shutdownController.signal });
+    const {
+      countries,
+      countryData,
+      capTriggered,
+      servedStaleCount,
+      droppedTooOldCount,
+      droppedNoCacheCount,
+    } = await fetchAll(progress, { signal: shutdownController.signal });
 
     console.log(`  Fetched ${countryData.size} countries`);
 
@@ -902,7 +937,27 @@ async function main() {
       return;
     }
 
-    if (prevCount > 0 && countryData.size < prevCount * 0.8) {
+    // Degradation guard — bypass when capTriggered (Greptile PR #3694 round 3 P1).
+    //
+    // The 80%-of-prev guard exists to catch SILENT data loss: an ArcGIS
+    // regression that drops 100 → 50 countries with no other signal. In
+    // cap-mode the partial coverage is LOUD, INTENTIONAL, and ROTATIONAL
+    // (refresh 30 per run, serve rest from cache up to 7d age) — the
+    // coverage gate (countryData.size ≥ MIN_VALID_COUNTRIES) is the right
+    // floor here, not the 80%-of-prev comparison.
+    //
+    // Without this bypass, the cap-mode path would always trip the guard
+    // (cap=30 + ~24 stale-served = ~54 << 0.8 × 174 = 139), seed-meta
+    // would never advance, and the operator-facing WARNING would persist
+    // — defeating the entire recovery design from #3676 onwards.
+    if (capTriggered) {
+      console.warn(
+        `  PARTIAL PUBLISH (cap-mode): ${countryData.size}/${prevCount} countries — ` +
+        `${servedStaleCount} stale-served, ${droppedTooOldCount} dropped (cache > 7d), ` +
+        `${droppedNoCacheCount} dropped (no prior payload). ` +
+        `Degradation guard bypassed; seed-meta will advance.`,
+      );
+    } else if (prevCount > 0 && countryData.size < prevCount * 0.8) {
       console.error(`  DEGRADATION GUARD: ${countryData.size} countries vs ${prevCount} previous — refusing to overwrite (need ≥${Math.ceil(prevCount * 0.8)})`);
       await extendExistingTtl([CANONICAL_KEY, META_KEY, ...prevCountryKeys], TTL).catch(() => {});
       return;

--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -813,9 +813,14 @@ export async function fetchAll(progress, { signal } = {}) {
     // run alone (post-#3681 run #2 showed Decodo throttling us after run
     // #1 hammered it back-to-back: 24/30 → 5/30 success rate degradation).
     // Skip on the final batch — no point waiting before exiting the loop.
-    // Also short-circuit if the caller signal has aborted so SIGTERM
-    // doesn't pay an extra 5s before propagating.
-    if (batchIdx < batches && !signal?.aborted) {
+    //
+    // On caller-signal abort: skip the sleep AND break the loop.
+    // Greptile PR #3694 P2: pre-fix this was "skip the sleep only" which
+    // still started the next batch's 6 concurrent fetches before the
+    // onSigterm → process.exit(1) backstop fired. Now the loop exits
+    // immediately so SIGTERM doesn't start additional in-flight work.
+    if (signal?.aborted) break;
+    if (batchIdx < batches) {
       await new Promise((r) => setTimeout(r, BATCH_BACKOFF_MS));
     }
   }

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -129,7 +129,7 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
   });
 
   it('CONCURRENCY is 6 and PER_COUNTRY_TIMEOUT_MS is 90s', () => {
-    // Halved from 12 → 6 on 2026-05-14 (PR #3683) to ease pressure on both
+    // Halved from 12 → 6 on 2026-05-14 (PR #3694) to ease pressure on both
     // ArcGIS-direct AND Decodo-proxy rate-limits during the ongoing
     // ArcGIS degradation. Math at concurrency 6 + cold-fetch cap 30:
     //   5 batches × ~60s realistic (90s worst case) + 4×5s backoff
@@ -139,15 +139,18 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /PER_COUNTRY_TIMEOUT_MS\s*=\s*90_000/);
   });
 
-  it('BATCH_BACKOFF_MS spaces out per-batch bursts (rate-limit gentleness)', () => {
+  it('BATCH_BACKOFF_MS spaces out per-batch bursts + signal-aborts break the loop', () => {
     // Inter-batch sleep prevents back-to-back rate-limit hits on Decodo +
     // ArcGIS. Post-#3681 run #2 showed Decodo throttling us after run #1
     // hammered it (24/30 → 5/30 success degradation). 5s × 4 = 20s total
     // added; negligible against the 570s bundle budget.
     assert.match(src, /const BATCH_BACKOFF_MS\s*=\s*5_000/);
-    // The sleep must be in the batch loop, gated on not-last-batch +
-    // not-aborted (so SIGTERM doesn't pay an extra 5s).
-    assert.match(src, /batchIdx\s*<\s*batches\s*&&\s*!signal\?\.aborted/);
+    // The sleep itself is gated on not-last-batch. Pre-Greptile P2 it was
+    // also gated on !signal.aborted but the loop kept iterating after the
+    // skipped sleep — defeating the SIGTERM-responsiveness intent. Now an
+    // aborted signal `break`s the loop entirely (Greptile PR #3694 P2).
+    assert.match(src, /if\s*\(\s*signal\?\.aborted\s*\)\s*break/);
+    assert.match(src, /if\s*\(\s*batchIdx\s*<\s*batches\s*\)/);
     assert.match(src, /setTimeout\(r,\s*BATCH_BACKOFF_MS\)/);
   });
 

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -166,6 +166,59 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /Revert to 50/);
   });
 
+  // Greptile PR #3694 round 3 P1: with the temp gate lowered to 25 but the
+  // 80% degradation guard unchanged, a cap-mode partial-success run that
+  // CLEARS the coverage gate (countryData.size ≥ 25) would STILL fail the
+  // degradation guard (countryData.size < prevCount × 0.8 ≈ 139). The fix
+  // is to bypass the degradation guard when capTriggered.
+  it('degradation guard is bypassed when capTriggered (cap-mode partial publish)', () => {
+    // fetchAll must surface capTriggered + counter fields to main()
+    assert.match(src, /capTriggered,\s*\n\s*servedStaleCount,/);
+    assert.match(src, /droppedTooOldCount,/);
+    assert.match(src, /droppedNoCacheCount,/);
+    // main() must read those fields off the fetchAll result
+    assert.match(src, /capTriggered,\s*\n\s*servedStaleCount,\s*\n\s*droppedTooOldCount,\s*\n\s*droppedNoCacheCount,\s*\n\s*\}\s*=\s*await fetchAll/);
+    // The guard branch must be wrapped in `if (capTriggered) {} else if (...)`
+    // so cap-mode runs SKIP the guard entirely (not just log a warning and
+    // then still fall through to the guard).
+    assert.match(src, /if\s*\(\s*capTriggered\s*\)\s*\{[\s\S]+?PARTIAL PUBLISH \(cap-mode\)[\s\S]+?\}\s*else if\s*\(\s*prevCount\s*>\s*0\s*&&\s*countryData\.size\s*<\s*prevCount\s*\*\s*0\.8\s*\)/);
+  });
+
+  it('cap-mode partial publish logs operator-visible bucket counts', () => {
+    // Without this log, operators see seed-meta advance but have no signal
+    // that the publish was partial. The log must include servedStale,
+    // droppedTooOld, droppedNoCache counts so /api/health WARNING ↔ HEALTHY
+    // transitions are explainable from the seed log alone.
+    assert.match(src, /PARTIAL PUBLISH \(cap-mode\)/);
+    assert.match(src, /\$\{servedStaleCount\}\s*stale-served/);
+    assert.match(src, /\$\{droppedTooOldCount\}\s*dropped/);
+    assert.match(src, /\$\{droppedNoCacheCount\}\s*dropped/);
+    assert.match(src, /Degradation guard bypassed/);
+  });
+
+  it('non-cap-mode runs still enforce the 80% degradation guard (silent-loss protection)', () => {
+    // The bypass MUST only fire when capTriggered. A run where
+    // needsFetch.length ≤ MAX_COLD_FETCH_PER_RUN (normal happy path) must
+    // still apply the 80% guard so an ArcGIS schema regression that
+    // silently drops 100 → 50 countries can't sneak through as a publish.
+    //
+    // Assert by structure: the else-if branch contains the prevCount × 0.8
+    // comparison and a DEGRADATION GUARD error+return, AND the comparison
+    // is INSIDE the else-if condition (not in a separate unconditional
+    // check before it that would bypass the else-if scoping).
+    assert.match(src, /else if\s*\([\s\S]{0,200}prevCount\s*\*\s*0\.8[\s\S]{0,200}\)\s*\{[\s\S]{0,400}DEGRADATION GUARD/);
+    // Ensure the 0.8 threshold appears exactly twice (once in the
+    // condition, once in the error message's `Math.ceil(prevCount * 0.8)`
+    // suggestion) — both inside the else-if scope. A third occurrence
+    // would suggest a duplicated check leaked outside the bypass.
+    const matches = src.match(/prevCount\s*\*\s*0\.8/g) ?? [];
+    assert.equal(
+      matches.length,
+      2,
+      `expected exactly 2 prevCount × 0.8 references (condition + error-msg suggestion), found ${matches.length}`,
+    );
+  });
+
   it('batch loop wires eager .catch for mid-batch SIGTERM diagnostics', () => {
     assert.match(src, /p\.catch\(err\s*=>\s*errors\.push/);
   });

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -128,9 +128,39 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.ok(matches.length >= 2, `expected retry wrapper used by both paginators, found ${matches.length}`);
   });
 
-  it('CONCURRENCY is 12 and PER_COUNTRY_TIMEOUT_MS is 90s', () => {
-    assert.match(src, /CONCURRENCY\s*=\s*12/);
+  it('CONCURRENCY is 6 and PER_COUNTRY_TIMEOUT_MS is 90s', () => {
+    // Halved from 12 → 6 on 2026-05-14 (PR #3683) to ease pressure on both
+    // ArcGIS-direct AND Decodo-proxy rate-limits during the ongoing
+    // ArcGIS degradation. Math at concurrency 6 + cold-fetch cap 30:
+    //   5 batches × ~60s realistic (90s worst case) + 4×5s backoff
+    //   ≈ 320s realistic, 470s worst case — still fits the 570s
+    //   bundle budget.
+    assert.match(src, /const CONCURRENCY\s*=\s*6/);
     assert.match(src, /PER_COUNTRY_TIMEOUT_MS\s*=\s*90_000/);
+  });
+
+  it('BATCH_BACKOFF_MS spaces out per-batch bursts (rate-limit gentleness)', () => {
+    // Inter-batch sleep prevents back-to-back rate-limit hits on Decodo +
+    // ArcGIS. Post-#3681 run #2 showed Decodo throttling us after run #1
+    // hammered it (24/30 → 5/30 success degradation). 5s × 4 = 20s total
+    // added; negligible against the 570s bundle budget.
+    assert.match(src, /const BATCH_BACKOFF_MS\s*=\s*5_000/);
+    // The sleep must be in the batch loop, gated on not-last-batch +
+    // not-aborted (so SIGTERM doesn't pay an extra 5s).
+    assert.match(src, /batchIdx\s*<\s*batches\s*&&\s*!signal\?\.aborted/);
+    assert.match(src, /setTimeout\(r,\s*BATCH_BACKOFF_MS\)/);
+  });
+
+  it('MIN_VALID_COUNTRIES is temporarily lowered to 25 (ArcGIS degraded)', () => {
+    // Pre-2026-05-14 value: 50. Lowered to 25 to let seed-meta refresh
+    // during the ArcGIS rate-limit degradation. The comment must call
+    // out the temporary nature + review date so this doesn't get
+    // forgotten as the new permanent floor.
+    assert.match(src, /const MIN_VALID_COUNTRIES\s*=\s*25/);
+    // Require the comment to flag temporariness (so a future reviewer
+    // doesn't normalise the lower value silently).
+    assert.match(src, /TEMPORARILY lowered from 50/);
+    assert.match(src, /Revert to 50/);
   });
 
   it('batch loop wires eager .catch for mid-batch SIGTERM diagnostics', () => {


### PR DESCRIPTION
## Summary

Option E from the 2026-05-14 incident triage: combined response to the ongoing ArcGIS degradation where **both** direct AND Decodo-proxy paths are now throttled. Three small, coordinated changes in one file.

## Why all three together

Post-#3676 (cold-fetch cap) + post-#3681 (proxy fallback on timeout), the proxy retry IS firing but **Decodo itself is now rate-limited** by our usage:

```
Run #1 (19:55 UTC May 13):  Activity queue 30  →  24 proxy successes  →  gate fails 24<50
Run #2 (00:03 UTC May 14):  Activity queue 30  →   5 proxy successes  →  gate fails  5<50
```

Run-over-run degradation (24 → 5) means we're depleting Decodo's bucket faster than it refills. Three orthogonal mitigations needed:

| Change | Effect |
|---|---|
| **B**: CONCURRENCY 12 → 6 | Halve in-flight pressure on both upstreams |
| **C**: BATCH_BACKOFF_MS = 5_000 (new) | Inter-batch sleep gives both buckets time to refill |
| **gate**: MIN_VALID_COUNTRIES 50 → 25 (temporary) | Partial-success runs advance seed-meta and clear alert |

## Math fits the budget

With CONCURRENCY=6 and cold-fetch cap 30:

- 5 batches × ~60s realistic + 4 × 5s backoff = **~320s realistic**
- 5 batches × ~90s worst-case + 4 × 5s backoff = **~470s worst-case**
- Bundle budget: **570s**
- Headroom: 100s minimum

## Why the temporary gate is OK

Pre-fix the seed-meta was frozen at 2026-05-12 00:03 UTC for 60+ hours, even though SOME successful fetches were landing each run. The gate-of-50 was sized for "normal ArcGIS"; with ArcGIS in this degraded state, no run can clear 50.

Lowering to 25 means a 5-success run STILL FAILS (correctly flags a real outage), but a 25+ partial-success run advances meta and clears the operator-facing WARNING. The remaining countries serve from cache (≤7d old per `MAX_CACHE_AGE_MS`).

I marked the change `TEMPORARILY lowered from 50 → 25 … Revert to 50 once successive runs reliably exceed 50 again (target: 2026-05-20 review)`. Test asserts the comment shape so a future reviewer can't silently normalise 25 as the new permanent floor.

## SIGTERM responsiveness preserved

The 5s backoff is gated on `!signal?.aborted` — if SIGTERM fires during a backoff sleep, the loop exits immediately without paying the full 5s.

## Test plan

- [x] `node --test tests/portwatch-port-activity-seed.test.mjs` — **87/87 pass** (was 85, +2 for new invariants, 1 modified for CONCURRENCY)
  - CONCURRENCY now pins at 6 (was 12)
  - BATCH_BACKOFF_MS pins at 5000 + gated on `batchIdx < batches && !signal?.aborted`
  - MIN_VALID_COUNTRIES pins at 25 + comment includes "TEMPORARILY lowered from 50" + "Revert to 50"
- [x] `node --check scripts/seed-portwatch-port-activity.mjs` — syntax OK
- [ ] Post-merge: next cron run should produce 20-30 successful fetches (proxy + reduced concurrency), gate passes at 25, seed-meta advances, `/api/health` flips HEALTHY (or stays WARNING only if <25 succeed → real outage signal)

## This week's portwatch series — three layers of resilience

| PR | Layer | What it fixes |
|---|---|---|
| #3676 (merged) | Bundle budget | Cap cold-fetch at 30/run to prevent SIGTERM cliff |
| #3681 (merged) | Network routing | Retry timeouts via Decodo (not just 429s) |
| **This PR** | Rate-limit gentleness | Halve concurrency + space out batches + temporary partial-coverage acceptance |

If after this PR + 1-2 runs the seeder reliably hits 25+ successes, we ride out the ArcGIS degradation gracefully. If it still can't hit 25, that's an even deeper upstream problem and we'd need to investigate ArcGIS-side directly (different access pattern, different proxy region, support ticket to IMF).

## Followups (not in this PR)

1. **Revert MIN_VALID_COUNTRIES 25 → 50** when ArcGIS recovers. Tracking via the inline comment + the test-shape assertion.
2. **Investigate ArcGIS upstream** — try a different proxy egress, check Decodo plan tier, contact IMF if needed.
3. **Telemetry on stale-served vs fresh-fetched** in seed-meta so operators can distinguish "X countries fresh, Y on cache" from "Z countries fresh" — currently the seed-meta only counts total, not the freshness split.