### PR TITLE
fix(cloud-prefs): merge local edits on 409 conflict instead of discarding them

### DIFF
--- a/src/utils/cloud-prefs-migrations.ts
+++ b/src/utils/cloud-prefs-migrations.ts
@@ -70,6 +70,39 @@ export function mergeCloudWithLocalDirty(
 }
 
 /**
+ * After a successful upload, decide which dirty keys are now durably synced
+ * and can be cleared — NOT the whole set.
+ *
+ * A user can mutate another pref *while the POST is in flight*: the setItem
+ * patch marks it dirty, but it was never in `postedBlob`. Blanket-clearing
+ * the dirty set would drop that tracking, so a subsequent 409 would see an
+ * empty dirty set and mergeCloudWithLocalDirty would let the cloud blob
+ * clobber the just-made edit — reintroducing the exact data-loss bug the
+ * dirty set exists to prevent.
+ *
+ * A key is "settled" iff the value the server accepted (`postedBlob`) still
+ * equals the current local value (`localBlob`). Absence counts as null on
+ * both sides, so a synced *removal* settles too. A key changed mid-flight,
+ * or dirtied mid-flight and absent from `postedBlob`, fails the equality
+ * check and is NOT returned — it stays dirty for the next upload.
+ *
+ * Pure function — no I/O. Returns the subset of `dirtyKeys` safe to clear.
+ */
+export function settledDirtyKeys(
+  postedBlob: Record<string, string>,
+  localBlob: Record<string, string>,
+  dirtyKeys: Iterable<string>,
+): string[] {
+  const settled: string[] = [];
+  for (const key of dirtyKeys) {
+    const posted = Object.prototype.hasOwnProperty.call(postedBlob, key) ? postedBlob[key]! : null;
+    const local = Object.prototype.hasOwnProperty.call(localBlob, key) ? localBlob[key]! : null;
+    if (posted === local) settled.push(key);
+  }
+  return settled;
+}
+
+/**
  * Schema-2 migrations map. Used both inline by cloud-prefs-sync.ts (against
  * the variant-aware FEEDS) and by tests (against fixture FEEDS).
  */

--- a/src/utils/cloud-prefs-migrations.ts
+++ b/src/utils/cloud-prefs-migrations.ts
@@ -1,8 +1,8 @@
 /**
- * Cloud-prefs schema migrations, isolated from cloud-prefs-sync.ts so they
- * stay testable without importing the full sync runtime (which transitively
- * pulls in `import.meta.env.DEV` via `@/services/clerk` → proxy.ts and
- * fails outside a Vite build).
+ * Cloud-prefs schema migrations and conflict-merge, isolated from
+ * cloud-prefs-sync.ts so they stay testable without importing the full sync
+ * runtime (which transitively pulls in `import.meta.env.DEV` via
+ * `@/services/clerk` → proxy.ts and fails outside a Vite build).
  *
  * Each migration is a pure function from blob → blob. The map is keyed by
  * the TARGET schema version (so MIGRATIONS[N] runs when going from N-1 → N).
@@ -27,6 +27,46 @@ export function applyMigrationChain(
     result = migrations[v]?.(result) ?? result;
   }
   return result;
+}
+
+/**
+ * Conflict-resolution merge for cloud-prefs sync.
+ *
+ * When a POST to /api/user-prefs hits a 409 (the cloud row advanced under
+ * us), the local edits the user JUST made must not be discarded. The old
+ * behaviour fetched the fresh cloud row and overwrote localStorage with it
+ * wholesale — silently destroying, e.g., a watchlist the user typed seconds
+ * earlier. This merge resolves the conflict without data loss:
+ *
+ *   - Start from the fresh cloud blob (so a concurrent change from another
+ *     device survives).
+ *   - Overlay the keys the user changed locally since the last clean upload
+ *     (`dirtyKeys`): a dirty key present in `localBlob` → the local value
+ *     wins; a dirty key ABSENT from `localBlob` → the user removed it
+ *     locally → drop it from the merge so the removal sticks.
+ *
+ * Pure function — no I/O. `cloudData` is the migrated cloud blob, `localBlob`
+ * is the current localStorage snapshot, `dirtyKeys` is the set of sync keys
+ * mutated locally since the last clean upload. Extracted here (not in
+ * cloud-prefs-sync.ts) so it stays unit-testable without the sync runtime.
+ */
+export function mergeCloudWithLocalDirty(
+  cloudData: Record<string, unknown>,
+  localBlob: Record<string, string>,
+  dirtyKeys: Iterable<string>,
+): Record<string, string> {
+  const merged: Record<string, string> = {};
+  for (const [key, val] of Object.entries(cloudData)) {
+    if (typeof val === 'string') merged[key] = val;
+  }
+  for (const key of dirtyKeys) {
+    if (Object.prototype.hasOwnProperty.call(localBlob, key)) {
+      merged[key] = localBlob[key]!;
+    } else {
+      delete merged[key];
+    }
+  }
+  return merged;
 }
 
 /**

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -16,7 +16,12 @@ import { CLOUD_SYNC_KEYS, type CloudSyncKey } from './sync-keys';
 import { isDesktopRuntime } from '@/services/runtime';
 import { getClerkToken } from '@/services/clerk';
 import { FEEDS } from '@/config/feeds';
-import { applyMigrationChain, buildMigrations, mergeCloudWithLocalDirty } from './cloud-prefs-migrations';
+import {
+  applyMigrationChain,
+  buildMigrations,
+  mergeCloudWithLocalDirty,
+  settledDirtyKeys,
+} from './cloud-prefs-migrations';
 
 const ENABLED = import.meta.env.VITE_CLOUD_PREFS_ENABLED === 'true';
 
@@ -70,8 +75,27 @@ let _cachedToken: string | null = null; // synchronous token cache for flush()
 // 409 CONFLICT we must NOT overwrite these with the cloud blob — they are
 // the edits the user just made (e.g. a watchlist typed seconds ago). The
 // install() setItem/removeItem patch records them; a clean upload clears the
-// set. See resolveConflictWithMerge + mergeCloudWithLocalDirty.
+// SETTLED ones. See resolveConflictWithMerge + mergeCloudWithLocalDirty.
 const _dirtyKeys = new Set<CloudSyncKey>();
+
+/**
+ * Clear dirty keys that a just-succeeded upload actually durably synced —
+ * NOT the whole set. A user can mutate another pref *while postCloudPrefs is
+ * in flight*: the setItem patch marks it dirty, but it was never in the
+ * posted blob. Blanket-clearing would drop that tracking, so a subsequent
+ * 409 would see an empty dirty set and mergeCloudWithLocalDirty would let
+ * applyCloudBlob clobber the just-made edit — the very bug this set exists
+ * to prevent.
+ *
+ * The "settled" decision is the pure `settledDirtyKeys` (testable without
+ * the sync runtime): a key is settled iff the posted value still equals the
+ * current local value.
+ */
+function clearSettledDirtyKeys(postedBlob: Record<string, string>): void {
+  for (const key of settledDirtyKeys(postedBlob, buildCloudBlob(), _dirtyKeys)) {
+    _dirtyKeys.delete(key as CloudSyncKey);
+  }
+}
 
 // ── 503 retry tracking ───────────────────────────────────────────────────────
 //
@@ -356,7 +380,7 @@ async function resolveConflictWithMerge(token: string, variant: string): Promise
     return false;
   }
   setSyncVersion(retry.syncVersion);
-  _dirtyKeys.clear();
+  clearSettledDirtyKeys(merged);
   Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
   setState('synced');
   return true;
@@ -430,7 +454,7 @@ export async function onSignIn(userId: string, variant: string): Promise<void> {
         await resolveConflictWithMerge(token, variant);
       } else {
         setSyncVersion(result.syncVersion);
-        _dirtyKeys.clear();
+        clearSettledDirtyKeys(blob);
         Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
         setState('synced');
       }
@@ -519,7 +543,8 @@ async function uploadNow(variant: string): Promise<void> {
   setState('syncing');
 
   try {
-    const result = await postCloudPrefs(token, variant, migrateLocalBlobIfNeeded(), getSyncVersion());
+    const postedBlob = migrateLocalBlobIfNeeded();
+    const result = await postCloudPrefs(token, variant, postedBlob, getSyncVersion());
 
     if ('conflict' in result) {
       setState('conflict');
@@ -530,7 +555,7 @@ async function uploadNow(variant: string): Promise<void> {
       await resolveConflictWithMerge(token, variant);
     } else {
       setSyncVersion(result.syncVersion);
-      _dirtyKeys.clear();
+      clearSettledDirtyKeys(postedBlob);
       Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
       setState('synced');
     }

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -16,7 +16,7 @@ import { CLOUD_SYNC_KEYS, type CloudSyncKey } from './sync-keys';
 import { isDesktopRuntime } from '@/services/runtime';
 import { getClerkToken } from '@/services/clerk';
 import { FEEDS } from '@/config/feeds';
-import { applyMigrationChain, buildMigrations } from './cloud-prefs-migrations';
+import { applyMigrationChain, buildMigrations, mergeCloudWithLocalDirty } from './cloud-prefs-migrations';
 
 const ENABLED = import.meta.env.VITE_CLOUD_PREFS_ENABLED === 'true';
 
@@ -65,6 +65,13 @@ let _currentVariant = 'full';
 let _installed = false;
 let _suppressPatch = false; // prevents applyCloudBlob from re-triggering upload
 let _cachedToken: string | null = null; // synchronous token cache for flush()
+
+// Sync keys the user has mutated locally since the last clean upload. On a
+// 409 CONFLICT we must NOT overwrite these with the cloud blob — they are
+// the edits the user just made (e.g. a watchlist typed seconds ago). The
+// install() setItem/removeItem patch records them; a clean upload clears the
+// set. See resolveConflictWithMerge + mergeCloudWithLocalDirty.
+const _dirtyKeys = new Set<CloudSyncKey>();
 
 // ── 503 retry tracking ───────────────────────────────────────────────────────
 //
@@ -320,6 +327,41 @@ async function postCloudPrefs(
 
 // ── Core logic ────────────────────────────────────────────────────────────────
 
+/**
+ * Resolve a 409 CONFLICT without losing local edits. Fetch the fresh cloud
+ * row, merge the user's locally-dirty keys over it (mergeCloudWithLocalDirty),
+ * apply the merge to localStorage, and re-post. On success the dirty set is
+ * cleared and state goes 'synced'; on a second conflict or a failed fetch the
+ * dirty set is preserved so the next pref change / sign-in retries.
+ *
+ * Replaces the previous "fetch cloud → applyCloudBlob → re-post buildCloudBlob"
+ * path, which overwrote localStorage with the cloud blob *before* rebuilding
+ * the post body — silently discarding the edit the user had just made (e.g. a
+ * watchlist typed seconds earlier, then lost on the debounced upload's 409).
+ */
+async function resolveConflictWithMerge(token: string, variant: string): Promise<boolean> {
+  const fresh = await fetchCloudPrefs(token, variant);
+  if (!fresh) {
+    setState('error');
+    return false;
+  }
+  const migratedCloud = applyMigrations(fresh.data, fresh.schemaVersion ?? 1);
+  const merged = mergeCloudWithLocalDirty(migratedCloud, buildCloudBlob(), _dirtyKeys);
+  applyCloudBlob(merged);
+  setSyncVersion(fresh.syncVersion);
+  setLocalSchemaVersion(CURRENT_PREFS_SCHEMA_VERSION);
+  const retry = await postCloudPrefs(token, variant, merged, fresh.syncVersion);
+  if ('conflict' in retry) {
+    setState('conflict');
+    return false;
+  }
+  setSyncVersion(retry.syncVersion);
+  _dirtyKeys.clear();
+  Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
+  setState('synced');
+  return true;
+}
+
 export async function onSignIn(userId: string, variant: string): Promise<void> {
   if (!isEnabled()) return;
 
@@ -347,18 +389,23 @@ export async function onSignIn(userId: string, variant: string): Promise<void> {
 
       const migrated = applyMigrations(cloud.data, cloud.schemaVersion ?? 1);
       const migrationChanged = (cloud.schemaVersion ?? 1) < CURRENT_PREFS_SCHEMA_VERSION;
-      applyCloudBlob(migrated);
+      // Cloud is ahead, but the user may have un-uploaded local edits — e.g.
+      // onSignIn re-fired by a 503 retry after the user changed a pref. Merge
+      // those dirty keys over the cloud blob instead of clobbering them.
+      const hasDirty = _dirtyKeys.size > 0;
+      const toApply = hasDirty
+        ? mergeCloudWithLocalDirty(migrated, buildCloudBlob(), _dirtyKeys)
+        : migrated;
+      applyCloudBlob(toApply);
       setSyncVersion(cloud.syncVersion);
       // After applyCloudBlob, local data IS at CURRENT schema (applyMigrations
       // ran every step from cloud.schemaVersion to CURRENT). Mark it so the
       // post paths don't redundantly re-run migrations on already-clean data.
       setLocalSchemaVersion(CURRENT_PREFS_SCHEMA_VERSION);
-      // If applyMigrations advanced the schema, force an upload so the cloud
-      // row's schemaVersion catches up. Without this, the cloud blob stays at
-      // the old schemaVersion and the migration re-runs on every load until
-      // any user pref change happens to fire schedulePrefUpload organically.
-      // Idempotent migrations make that harmless but wasteful and noisy.
-      if (migrationChanged) schedulePrefUpload(variant);
+      // Force an upload when the cloud row's schemaVersion is behind (so it
+      // catches up — otherwise the migration re-runs every load) OR when we
+      // merged in local dirty keys the cloud row doesn't have yet.
+      if (migrationChanged || hasDirty) schedulePrefUpload(variant);
       Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
 
       if (isFirstEverSync && prevBlobJson && Object.keys(cloud.data).length > 0) {
@@ -377,19 +424,13 @@ export async function onSignIn(userId: string, variant: string): Promise<void> {
       const result = await postCloudPrefs(token, variant, blob, getSyncVersion());
 
       if ('conflict' in result) {
-        setState('conflict');
-        const fresh = await fetchCloudPrefs(token, variant);
-        if (fresh) {
-          const migrated = applyMigrations(fresh.data, fresh.schemaVersion ?? 1);
-          applyCloudBlob(migrated);
-          setSyncVersion(fresh.syncVersion);
-          setLocalSchemaVersion(CURRENT_PREFS_SCHEMA_VERSION);
-          setState('synced');
-        } else {
-          setState('error');
-        }
+        // Merge instead of clobber — see resolveConflictWithMerge. The old
+        // path here applied the cloud blob over localStorage and stopped,
+        // discarding the local edits this branch was trying to upload.
+        await resolveConflictWithMerge(token, variant);
       } else {
         setSyncVersion(result.syncVersion);
+        _dirtyKeys.clear();
         Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
         setState('synced');
       }
@@ -452,6 +493,9 @@ export function onSignOut(): void {
   clearRetryTimer();
   _authGeneration += 1;
   _cachedToken = null;
+  // Dirty-key tracking is per-user session state — drop it so edits made by
+  // the next signed-in user don't merge against the prior user's pending set.
+  _dirtyKeys.clear();
 
   // Preserve prefs; only clear sync metadata
   localStorage.removeItem(KEY_SYNC_VERSION);
@@ -479,26 +523,14 @@ async function uploadNow(variant: string): Promise<void> {
 
     if ('conflict' in result) {
       setState('conflict');
-      const fresh = await fetchCloudPrefs(token, variant);
-      if (fresh) {
-        const migrated = applyMigrations(fresh.data, fresh.schemaVersion ?? 1);
-        applyCloudBlob(migrated);
-        setSyncVersion(fresh.syncVersion);
-        // applyCloudBlob just put migrated data into local at CURRENT schema.
-        setLocalSchemaVersion(CURRENT_PREFS_SCHEMA_VERSION);
-        const retryResult = await postCloudPrefs(token, variant, buildCloudBlob(), fresh.syncVersion);
-        if (!('conflict' in retryResult)) {
-          setSyncVersion(retryResult.syncVersion);
-          Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
-          setState('synced');
-        } else {
-          setState('conflict');
-        }
-      } else {
-        setState('error');
-      }
+      // Merge the user's locally-dirty keys over the fresh cloud row instead
+      // of overwriting localStorage with cloud (the old path did
+      // applyCloudBlob(cloud) then re-posted buildCloudBlob() — which by then
+      // WAS the cloud blob, so the user's just-made edit was silently lost).
+      await resolveConflictWithMerge(token, variant);
     } else {
       setSyncVersion(result.syncVersion);
+      _dirtyKeys.clear();
       Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
       setState('synced');
     }
@@ -573,6 +605,7 @@ export function install(variant: string): void {
   Storage.prototype.setItem = function setItem(key: string, value: string) {
     originalSetItem.call(this, key, value);
     if (this === localStorage && !_suppressPatch && CLOUD_SYNC_KEYS.includes(key as CloudSyncKey)) {
+      _dirtyKeys.add(key as CloudSyncKey);
       schedulePrefUpload(_currentVariant);
     }
   };
@@ -581,6 +614,7 @@ export function install(variant: string): void {
   Storage.prototype.removeItem = function removeItem(key: string) {
     originalRemoveItem.call(this, key);
     if (this === localStorage && !_suppressPatch && CLOUD_SYNC_KEYS.includes(key as CloudSyncKey)) {
+      _dirtyKeys.add(key as CloudSyncKey);
       schedulePrefUpload(_currentVariant);
     }
   };

--- a/tests/cloud-prefs-conflict-merge.test.mts
+++ b/tests/cloud-prefs-conflict-merge.test.mts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { mergeCloudWithLocalDirty } from '../src/utils/cloud-prefs-migrations.ts';
+import { mergeCloudWithLocalDirty, settledDirtyKeys } from '../src/utils/cloud-prefs-migrations.ts';
 
 describe('mergeCloudWithLocalDirty', () => {
   it('with no dirty keys, returns the cloud blob verbatim (string values only)', () => {
@@ -73,5 +73,50 @@ describe('mergeCloudWithLocalDirty', () => {
     mergeCloudWithLocalDirty(cloud, local, ['worldmonitor-theme']);
     assert.deepEqual(cloud, cloudCopy);
     assert.deepEqual(local, localCopy);
+  });
+});
+
+describe('settledDirtyKeys', () => {
+  it('a dirty key whose posted value still matches local is settled', () => {
+    const posted = { 'wm-market-watchlist-v1': '["GLW"]' };
+    const local = { 'wm-market-watchlist-v1': '["GLW"]' };
+    assert.deepEqual(settledDirtyKeys(posted, local, ['wm-market-watchlist-v1']), ['wm-market-watchlist-v1']);
+  });
+
+  it('a dirty key changed mid-flight (posted != current local) stays dirty', () => {
+    const posted = { 'wm-market-watchlist-v1': '["GLW"]' };
+    const local = { 'wm-market-watchlist-v1': '["GLW","LLY"]' }; // user typed more during the POST
+    assert.deepEqual(settledDirtyKeys(posted, local, ['wm-market-watchlist-v1']), []);
+  });
+
+  it('REGRESSION: a key dirtied mid-flight and absent from the posted blob stays dirty', () => {
+    // The race the reviewer flagged: postCloudPrefs({watchlist}) is in flight,
+    // the user changes the theme. A blanket _dirtyKeys.clear() would drop
+    // 'worldmonitor-theme' even though it was never posted — then a later 409
+    // would clobber it. settledDirtyKeys must keep it.
+    const posted = { 'wm-market-watchlist-v1': '["GLW","LLY","ENTG"]' };
+    const local = { 'wm-market-watchlist-v1': '["GLW","LLY","ENTG"]', 'worldmonitor-theme': 'light' };
+    const settled = settledDirtyKeys(posted, local, ['wm-market-watchlist-v1', 'worldmonitor-theme']);
+    assert.deepEqual(settled, ['wm-market-watchlist-v1']); // theme NOT settled
+  });
+
+  it('a synced removal settles (posted absent + local absent)', () => {
+    const posted = { 'worldmonitor-theme': 'dark' }; // watchlist removed → not in posted blob
+    const local = { 'worldmonitor-theme': 'dark' };  // still absent locally
+    assert.deepEqual(settledDirtyKeys(posted, local, ['wm-market-watchlist-v1']), ['wm-market-watchlist-v1']);
+  });
+
+  it('a key removed-then-re-added mid-flight stays dirty', () => {
+    const posted = { 'worldmonitor-theme': 'dark' }; // posted as removed
+    const local = { 'worldmonitor-theme': 'dark', 'wm-market-watchlist-v1': '["TSLA"]' }; // re-added during POST
+    assert.deepEqual(settledDirtyKeys(posted, local, ['wm-market-watchlist-v1']), []);
+  });
+
+  it('only considers keys in the dirty set', () => {
+    // A non-dirty key that happens to differ between posted and local must
+    // never be returned — we only ever clear keys we were tracking.
+    const posted = { 'worldmonitor-theme': 'dark' };
+    const local = { 'worldmonitor-theme': 'light' };
+    assert.deepEqual(settledDirtyKeys(posted, local, []), []);
   });
 });

--- a/tests/cloud-prefs-conflict-merge.test.mts
+++ b/tests/cloud-prefs-conflict-merge.test.mts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { mergeCloudWithLocalDirty } from '../src/utils/cloud-prefs-migrations.ts';
+
+describe('mergeCloudWithLocalDirty', () => {
+  it('with no dirty keys, returns the cloud blob verbatim (string values only)', () => {
+    const cloud = { 'worldmonitor-theme': 'dark', 'wm-market-watchlist-v1': '["AAPL"]' };
+    const local = { 'worldmonitor-theme': 'light', 'wm-market-watchlist-v1': '["TSLA"]' };
+    assert.deepEqual(mergeCloudWithLocalDirty(cloud, local, []), cloud);
+  });
+
+  it('a dirty key present locally wins over the cloud value', () => {
+    const cloud = { 'wm-market-watchlist-v1': '["AAPL"]', 'worldmonitor-theme': 'dark' };
+    const local = { 'wm-market-watchlist-v1': '["GLW","LLY","ENTG"]', 'worldmonitor-theme': 'dark' };
+    const merged = mergeCloudWithLocalDirty(cloud, local, ['wm-market-watchlist-v1']);
+    assert.equal(merged['wm-market-watchlist-v1'], '["GLW","LLY","ENTG"]');
+    // non-dirty key still takes the cloud value
+    assert.equal(merged['worldmonitor-theme'], 'dark');
+  });
+
+  it('REGRESSION: the just-typed local watchlist survives a 409 conflict', () => {
+    // The reported bug: user types 7 tickers, the debounced upload 409s, and
+    // the old conflict path overwrote localStorage with the cloud blob —
+    // losing all 7. The merge must keep them.
+    const cloudData = { 'wm-market-watchlist-v1': '[]' }; // stale cloud row
+    const localBlob = { 'wm-market-watchlist-v1': '["GLW","LLY","ENTG","FLNC","KULR","ONDS","QCOM"]' };
+    const merged = mergeCloudWithLocalDirty(cloudData, localBlob, ['wm-market-watchlist-v1']);
+    assert.equal(
+      merged['wm-market-watchlist-v1'],
+      '["GLW","LLY","ENTG","FLNC","KULR","ONDS","QCOM"]',
+    );
+  });
+
+  it('a dirty key removed locally is dropped from the merge', () => {
+    // User reset the watchlist (removeItem) — the key is dirty but absent
+    // from localBlob. The merge must NOT resurrect the cloud value.
+    const cloud = { 'wm-market-watchlist-v1': '["AAPL"]', 'worldmonitor-theme': 'dark' };
+    const local = { 'worldmonitor-theme': 'dark' }; // watchlist removed locally
+    const merged = mergeCloudWithLocalDirty(cloud, local, ['wm-market-watchlist-v1']);
+    assert.equal('wm-market-watchlist-v1' in merged, false);
+    assert.equal(merged['worldmonitor-theme'], 'dark');
+  });
+
+  it('a concurrent change on a non-dirty key survives (cloud wins for keys we did not touch)', () => {
+    // Cloud advanced because another device changed the theme; locally we
+    // only touched the watchlist. Both changes must survive the merge.
+    const cloud = { 'worldmonitor-theme': 'light', 'wm-market-watchlist-v1': '["AAPL"]' };
+    const local = { 'worldmonitor-theme': 'dark', 'wm-market-watchlist-v1': '["TSLA"]' };
+    const merged = mergeCloudWithLocalDirty(cloud, local, ['wm-market-watchlist-v1']);
+    assert.equal(merged['worldmonitor-theme'], 'light'); // other device's change kept
+    assert.equal(merged['wm-market-watchlist-v1'], '["TSLA"]'); // our change kept
+  });
+
+  it('a dirty key that exists only locally is included', () => {
+    const cloud = { 'worldmonitor-theme': 'dark' };
+    const local = { 'worldmonitor-theme': 'dark', 'wm-market-watchlist-v1': '["TSLA"]' };
+    const merged = mergeCloudWithLocalDirty(cloud, local, ['wm-market-watchlist-v1']);
+    assert.equal(merged['wm-market-watchlist-v1'], '["TSLA"]');
+  });
+
+  it('drops non-string cloud values', () => {
+    const cloud = { 'worldmonitor-theme': 'dark', 'wm-bogus': 42, 'wm-nullish': null } as Record<string, unknown>;
+    const merged = mergeCloudWithLocalDirty(cloud, {}, []);
+    assert.deepEqual(merged, { 'worldmonitor-theme': 'dark' });
+  });
+
+  it('does not mutate its inputs', () => {
+    const cloud = { 'worldmonitor-theme': 'dark' };
+    const local = { 'worldmonitor-theme': 'light' };
+    const cloudCopy = { ...cloud };
+    const localCopy = { ...local };
+    mergeCloudWithLocalDirty(cloud, local, ['worldmonitor-theme']);
+    assert.deepEqual(cloud, cloudCopy);
+    assert.deepEqual(local, localCopy);
+  });
+});


### PR DESCRIPTION
## Summary

A PRO user adding watchlist tickers (surfaced testing #3686, which made the watchlist load-bearing for PRO) reported the edit **silently vanishing** — and a *worse*, stale state after refresh — with repeated `409` responses from `/api/user-prefs` in the console.

**Root cause:** the client's 409 conflict resolution in `cloud-prefs-sync.ts` was "cloud wins, local discarded":

```
postCloudPrefs → 409 → fetchCloudPrefs → applyCloudBlob(cloud)   ← clobbers localStorage
              → re-post buildCloudBlob()  ← which is now the cloud blob
```

The edit the user made seconds earlier is destroyed at `applyCloudBlob`. On the next page load `onSignIn` pulls that same stale cloud row and writes it back over localStorage — the "refreshing shows worse" symptom. The 409 itself is **normal** optimistic-concurrency (multi-tab/device, or a debounced upload racing a sign-in version bump) — the server is fine; the bug is that the client's resolution threw away local data.

## Fix — merge, don't clobber

- **Track dirty keys.** `_dirtyKeys` records sync keys mutated locally since the last clean upload, populated by the existing `install()` `setItem`/`removeItem` patch. Cleared on every clean upload and on sign-out.
- **`mergeCloudWithLocalDirty(cloud, local, dirtyKeys)`** — new pure function in the testable `cloud-prefs-migrations` module: start from the fresh cloud blob (so a concurrent change from *another device* survives), overlay the keys the user changed locally (local wins; a dirty key removed locally is dropped, not resurrected).
- **`resolveConflictWithMerge()`** routes both the `uploadNow` and `onSignIn` conflict paths through the merge + a re-post. `onSignIn`'s cloud-ahead branch also merges dirty keys rather than clobbering them (covers `onSignIn` re-firing via a 503 retry mid-edit).

## Test plan

- [x] `npm run typecheck` — PASS
- [x] `npm run lint` (biome) — PASS on changed files
- [x] `npm run test:data` — PASS, 8757/8757
- [x] New `tests/cloud-prefs-conflict-merge.test.mjs` — 8 tests, incl. regression: a just-typed 7-ticker watchlist must survive a 409 against a stale/empty cloud row; concurrent non-dirty key from another device survives; locally-removed dirty key is not resurrected.
- [ ] Manual: PRO user adds watchlist tickers → edit persists through the debounced upload and across a page refresh; no data loss on `409`.