### PR TITLE
fix(user-prefs): downgrade convex auth-drift Sentry capture to warning

### DIFF
--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -88,11 +88,20 @@ export default async function handler(
       // caught earlier (the `validateBearerToken` 401 above) and never reach
       // this catch. Capture before returning 401 so the drift surfaces under
       // a stable Sentry bucket instead of silently 401'ing every request.
+      //
+      // `level: 'warning'` because the observed pattern is one transient
+      // event per user (5ev/5u over a week — WORLDMONITOR-QK), which a
+      // client retry recovers cleanly. Keeping the capture at error
+      // drowned real bugs in the dashboard while delivering no operational
+      // signal beyond "drift happened" (already evident from the warning
+      // bucket). A genuine systemic drift incident would still surface
+      // because volume would escalate and reopen the archived issue.
       if (kind === 'UNAUTHENTICATED') {
-        console.error('[user-prefs] GET convex auth drift:', err);
+        console.warn('[user-prefs] GET convex auth drift:', err);
         captureSilentError(err, buildSentryContext(err, msg, {
           method: 'GET', convexFn: 'userPreferences:getPreferences',
           userId: session.userId, variant, ctx,
+          level: 'warning',
         }));
         return jsonResponse({ error: 'UNAUTHENTICATED' }, 401, cors);
       }
@@ -190,14 +199,17 @@ export default async function handler(
     if (kind === 'UNAUTHENTICATED') {
       // See GET branch above — UNAUTHENTICATED here means Clerk-vs-Convex
       // auth drift (token already passed validateBearerToken). Capture
-      // before returning 401 so the drift is visible.
-      console.error('[user-prefs] POST convex auth drift:', err);
+      // at `warning` for visibility without paging — the observed pattern
+      // is transient single-event-per-user that recovers on client retry
+      // (WORLDMONITOR-QK).
+      console.warn('[user-prefs] POST convex auth drift:', err);
       captureSilentError(err, buildSentryContext(err, msg, {
         method: 'POST', convexFn: 'userPreferences:setPreferences',
         userId: session.userId, variant: body.variant, ctx,
         schemaVersion: typeof body.schemaVersion === 'number' ? body.schemaVersion : null,
         expectedSyncVersion: body.expectedSyncVersion,
         blobSize: body.data !== undefined ? JSON.stringify(body.data).length : 0,
+        level: 'warning',
       }));
       return jsonResponse({ error: 'UNAUTHENTICATED' }, 401, cors);
     }


### PR DESCRIPTION
## Summary

WORLDMONITOR-QK was the Convex \`UNAUTHENTICATED\` auth-drift signal from \`api/user-prefs.ts\`: the user's Clerk token passed our edge's \`validateBearerToken\` but Convex's OIDC verify rejected it. The intent comment on both UNAUTHENTICATED branches already framed the capture as "for visibility, not user-bug" — but default \`error\` level paged on baseline noise.

Observed pattern: **one transient event per user** (5 events across 5 distinct users over a week), with the client retry recovering cleanly. This matches the same disposition as \`convex_service_unavailable\` / \`transport_timeout\` / \`transport_network\` / mcp 4xx transients already shipped in prior PRs.

## Change

Both UNAUTHENTICATED branches (GET line 91-99 and POST line 199-211) now:
- pass \`level: 'warning'\` to \`captureSilentError\` via \`buildSentryContext({ ..., level: 'warning' })\`
- use \`console.warn\` instead of \`console.error\` so Vercel / Datadog log severity stays aligned with Sentry (same alignment Greptile flagged on PR #3660)
- carry an updated rationale comment

A genuine systemic drift incident (\`CLERK_JWT_ISSUER_DOMAIN\` regression, JWKS rotation mismatch, audience misconfig) would still escalate via volume — the archived Sentry issue auto-reopens on the next \`ignoreUntilEscalating\` threshold breach.

QK has been archived in Sentry with \`ignoreUntilEscalating\`.

## Test plan

- [x] \`npm run typecheck\` — PASS
- [x] \`npm run typecheck:api\` — PASS (incl. \`audit-convex-string-calls\`)
- [x] \`npm run lint\` — PASS (warnings only, pre-existing)
- [x] \`npx tsx --test tests/user-prefs-sentry-context.test.mts tests/user-prefs-convex-error.test.mjs\` — PASS (46/46) — \`buildSentryContext\` shape unchanged; existing tests still cover the contract
- [x] \`node --test tests/edge-functions.test.mjs\` — PASS (184/184)
- [x] \`npm run lint:md\` — PASS
- [x] \`npm run version:check\` — PASS
- [x] Edge bundle check — PASS
- [ ] Post-deploy: confirm new UNAUTHENTICATED events arrive at \`warning\` level in Sentry (queryable as \`error_shape:convex_auth_drift\`) instead of \`error\`