### PR TITLE
feat(watchlist): search-and-add editor with real symbol validation

### DIFF
--- a/api/api-route-exceptions.json
+++ b/api/api-route-exceptions.json
@@ -259,6 +259,13 @@
       "removal_issue": null
     },
     {
+      "path": "api/symbol-search.ts",
+      "category": "internal-helper",
+      "reason": "Stock-symbol typeahead used only by the watchlist editor — thin wrapper over Finnhub's /api/v1/search. Light filter (equity-type instruments) + field rename (symbol/description/displaySymbol -> symbol/name/display); shape tracks Finnhub, not a versioned product contract. Same constraint as api/reverse-geocode.js (UI-only helper wrapping an upstream provider). Could fold into MarketService as a SearchSymbol RPC — flagged for reviewer; kept as a helper so the watchlist-editor PR stays self-contained rather than coupling it to a proto regen.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
       "path": "api/internal/brief-why-matters.ts",
       "category": "internal-helper",
       "reason": "LLM-enrichment helper for the brief pipeline. Cron-triggered from Railway under RELAY_SHARED_SECRET bearer auth — never reached by dashboards, desktop, or partners. Request/response shape is an implementation detail of the brief renderer; modeling it as a generated service would publish internal cron plumbing as user-facing API surface. Same shape constraint as api/notify.ts (also cron-only).",

--- a/api/symbol-search.ts
+++ b/api/symbol-search.ts
@@ -1,0 +1,139 @@
+/**
+ * Stock symbol search — backs the watchlist editor's typeahead.
+ *
+ * GET /api/symbol-search?q=<query>  → { results: [{ symbol, name, display }] }
+ *
+ * Thin passthrough to Finnhub's symbol-search endpoint. Used by every user
+ * (the market watchlist is not a PRO feature), so there is no entitlement
+ * gate — just CORS + rate limiting. The client debounces keystrokes, so
+ * Finnhub's free-tier quota (60 req/min) is not a concern in practice.
+ */
+
+export const config = { runtime: 'edge' };
+
+// @ts-expect-error — JS module, no declaration file
+import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+// @ts-expect-error — JS module, no declaration file
+import { validateApiKey } from './_api-key.js';
+// @ts-expect-error — JS module, no declaration file
+import { checkRateLimit } from './_rate-limit.js';
+// @ts-expect-error — JS module, no declaration file
+import { jsonResponse } from './_json-response.js';
+// @ts-expect-error — JS module, no declaration file
+import { captureSilentError } from './_sentry-edge.js';
+
+interface FinnhubSearchResult {
+  symbol?: string;
+  displaySymbol?: string;
+  description?: string;
+  type?: string;
+}
+
+export interface SymbolSearchResult {
+  symbol: string;
+  name: string;
+  display: string;
+}
+
+const MAX_RESULTS = 12;
+const UPSTREAM_TIMEOUT_MS = 8_000;
+
+// Finnhub `type` values worth offering in the watchlist editor. Finnhub also
+// returns crypto, FX, bonds, warrants, etc. — excluding those keeps the
+// editor to instruments the stock-analysis pipeline can actually report on.
+// An empty/missing type is allowed through (Finnhub omits it for some plain
+// US listings) rather than silently dropped.
+const ALLOWED_TYPES = new Set([
+  'Common Stock', 'ADR', 'GDR', 'ETP', 'ETF', 'REIT', 'Unit', 'Equity', '',
+]);
+
+/**
+ * Map + filter raw Finnhub results to our shape. Exported for unit tests —
+ * the Vercel edge runtime ignores non-default exports, so this has no
+ * production-side effect.
+ */
+export function mapFinnhubResults(raw: FinnhubSearchResult[]): SymbolSearchResult[] {
+  const seen = new Set<string>();
+  const out: SymbolSearchResult[] = [];
+  for (const r of raw) {
+    const symbol = (r.symbol || '').trim();
+    if (!symbol || seen.has(symbol)) continue;
+    if (r.type !== undefined && !ALLOWED_TYPES.has(r.type)) continue;
+    seen.add(symbol);
+    out.push({
+      symbol,
+      name: (r.description || symbol).trim(),
+      display: (r.displaySymbol || symbol).trim(),
+    });
+    if (out.length >= MAX_RESULTS) break;
+  }
+  return out;
+}
+
+export default async function handler(
+  req: Request,
+  ctx?: { waitUntil: (p: Promise<unknown>) => void },
+): Promise<Response> {
+  if (isDisallowedOrigin(req)) {
+    return jsonResponse({ error: 'Origin not allowed' }, 403);
+  }
+
+  const cors = getCorsHeaders(req, 'GET, OPTIONS');
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: cors });
+  }
+  if (req.method !== 'GET') {
+    return jsonResponse({ error: 'Method not allowed' }, 405, cors);
+  }
+
+  const keyCheck = await validateApiKey(req);
+  if (keyCheck.required && !keyCheck.valid) {
+    return jsonResponse({ error: keyCheck.error }, 401, cors);
+  }
+
+  const rateLimitResponse = await checkRateLimit(req, cors);
+  if (rateLimitResponse) return rateLimitResponse;
+
+  const q = (new URL(req.url).searchParams.get('q') ?? '').trim();
+  if (!q) {
+    return jsonResponse({ results: [] }, 200, cors);
+  }
+
+  const apiKey = process.env.FINNHUB_API_KEY;
+  if (!apiKey) {
+    return jsonResponse({ error: 'SYMBOL_SEARCH_UNAVAILABLE' }, 503, cors);
+  }
+
+  try {
+    const url = `https://finnhub.io/api/v1/search?q=${encodeURIComponent(q)}&token=${encodeURIComponent(apiKey)}`;
+    const resp = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    });
+    if (!resp.ok) {
+      // 429 from Finnhub = quota exhausted; surface as 503 so the client
+      // backs off rather than treating it as a permanent failure.
+      const status = resp.status === 429 ? 503 : 502;
+      console.warn(`[symbol-search] Finnhub HTTP ${resp.status} for q="${q}"`);
+      captureSilentError(new Error(`Finnhub search HTTP ${resp.status}`), {
+        tags: { route: 'api/symbol-search', step: 'finnhub_fetch' },
+        extra: { q, finnhubStatus: resp.status },
+        level: 'warning',
+        ctx,
+      });
+      return jsonResponse({ error: 'SYMBOL_SEARCH_UNAVAILABLE' }, status, cors);
+    }
+    const data = (await resp.json()) as { result?: FinnhubSearchResult[] };
+    const results = mapFinnhubResults(Array.isArray(data.result) ? data.result : []);
+    return jsonResponse({ results }, 200, cors);
+  } catch (err) {
+    console.error('[symbol-search] error:', err);
+    captureSilentError(err, {
+      tags: { route: 'api/symbol-search', step: 'handler' },
+      extra: { q },
+      ctx,
+    });
+    return jsonResponse({ error: 'SYMBOL_SEARCH_FAILED' }, 500, cors);
+  }
+}

--- a/src/components/WatchlistEditor.ts
+++ b/src/components/WatchlistEditor.ts
@@ -1,0 +1,314 @@
+/**
+ * Search-first market watchlist editor.
+ *
+ * Replaces the old free-text textarea: the user types a ticker or company
+ * name, picks from a keyboard-navigable dropdown of REAL symbols (Finnhub-
+ * backed via /api/symbol-search), and the pick becomes a chip. Invalid input
+ * is structurally impossible — every entry comes from a resolved search
+ * result, so the watchlist only ever contains tickers the data pipeline can
+ * actually track.
+ *
+ * Keyboard: ↑/↓ move the dropdown highlight, Enter adds the highlighted
+ * result, Backspace on an empty input removes the last chip, Esc closes the
+ * dropdown.
+ */
+
+import { escapeHtml } from '@/utils/sanitize';
+import { searchSymbols, toWatchlistEntry, type SymbolSearchResult } from '@/services/symbol-search';
+import type { MarketWatchlistEntry } from '@/services/market-watchlist';
+
+const SEARCH_DEBOUNCE_MS = 280;
+const MAX_ENTRIES = 50;
+
+export interface WatchlistEditorOptions {
+  /** The user's current watchlist — seeds the chips. */
+  initial: MarketWatchlistEntry[];
+}
+
+function dedupeEntries(list: MarketWatchlistEntry[]): MarketWatchlistEntry[] {
+  const seen = new Set<string>();
+  const out: MarketWatchlistEntry[] = [];
+  for (const e of list || []) {
+    const symbol = (e?.symbol || '').trim();
+    if (!symbol || seen.has(symbol)) continue;
+    seen.add(symbol);
+    out.push({
+      symbol,
+      ...(e.name ? { name: e.name } : {}),
+      ...(e.display ? { display: e.display } : {}),
+    });
+    if (out.length >= MAX_ENTRIES) break;
+  }
+  return out;
+}
+
+export class WatchlistEditor {
+  public readonly element: HTMLDivElement;
+  private input: HTMLInputElement;
+  private dropdown: HTMLUListElement;
+  private chipsEl: HTMLDivElement;
+  private statusEl: HTMLDivElement;
+  private entries: MarketWatchlistEntry[];
+  private results: SymbolSearchResult[] = [];
+  private highlight = -1;
+  private loading = false;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private searchSeq = 0;
+
+  constructor(opts: WatchlistEditorOptions) {
+    this.entries = dedupeEntries(opts.initial);
+
+    this.element = document.createElement('div');
+    this.element.style.cssText = 'display:flex;flex-direction:column;gap:10px';
+
+    const searchWrap = document.createElement('div');
+    searchWrap.style.cssText = 'position:relative';
+
+    this.input = document.createElement('input');
+    this.input.type = 'text';
+    this.input.autocomplete = 'off';
+    this.input.spellcheck = false;
+    this.input.placeholder = 'Search ticker or company — e.g. NVDA or Nvidia';
+    this.input.setAttribute('aria-label', 'Search ticker or company');
+    this.input.style.cssText =
+      'width:100%;box-sizing:border-box;background:rgba(255,255,255,0.04);border:1px solid var(--border);' +
+      'color:var(--text);border-radius:10px;padding:10px 12px;font-family:inherit;font-size:13px;outline:none';
+
+    this.dropdown = document.createElement('ul');
+    this.dropdown.setAttribute('role', 'listbox');
+    this.dropdown.style.cssText =
+      'position:absolute;left:0;right:0;top:calc(100% + 4px);z-index:5;margin:0;padding:4px;list-style:none;' +
+      'max-height:240px;overflow-y:auto;background:var(--bg,#0b0b0b);border:1px solid var(--border);' +
+      'border-radius:10px;box-shadow:0 8px 24px rgba(0,0,0,0.5);display:none';
+
+    searchWrap.append(this.input, this.dropdown);
+
+    this.chipsEl = document.createElement('div');
+    this.chipsEl.style.cssText = 'display:flex;flex-wrap:wrap;gap:6px;min-height:8px';
+
+    this.statusEl = document.createElement('div');
+    this.statusEl.style.cssText = 'font-size:11px;color:var(--text-dim)';
+
+    this.element.append(searchWrap, this.chipsEl, this.statusEl);
+
+    this.input.addEventListener('input', this.onInput);
+    this.input.addEventListener('focus', this.onFocus);
+    this.input.addEventListener('blur', () => setTimeout(() => this.hideDropdown(), 150));
+    this.input.addEventListener('keydown', this.onKeydown);
+    this.dropdown.addEventListener('mousedown', this.onDropdownMouseDown);
+    this.chipsEl.addEventListener('click', this.onChipsClick);
+
+    this.renderChips();
+  }
+
+  /** Working entries — the modal persists these on Save. */
+  public getEntries(): MarketWatchlistEntry[] {
+    return this.entries.slice();
+  }
+
+  /** Reset to an empty watchlist (the modal's Reset button). */
+  public clear(): void {
+    this.entries = [];
+    this.input.value = '';
+    this.results = [];
+    this.hideDropdown();
+    this.renderChips();
+  }
+
+  public focus(): void {
+    this.input.focus();
+  }
+
+  public destroy(): void {
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = null;
+  }
+
+  // ── search ──────────────────────────────────────────────────────────────
+
+  private onFocus = (): void => {
+    if (this.results.length > 0 || this.input.value.trim()) this.showDropdown();
+  };
+
+  private onInput = (): void => {
+    const q = this.input.value.trim();
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    if (!q) {
+      this.results = [];
+      this.loading = false;
+      this.hideDropdown();
+      return;
+    }
+    this.loading = true;
+    this.showDropdown();
+    this.renderDropdown();
+    this.debounceTimer = setTimeout(() => { void this.runSearch(q); }, SEARCH_DEBOUNCE_MS);
+  };
+
+  private async runSearch(q: string): Promise<void> {
+    const seq = ++this.searchSeq;
+    const results = await searchSymbols(q);
+    // A newer keystroke superseded this search — drop the stale response.
+    if (seq !== this.searchSeq) return;
+    this.results = results;
+    this.loading = false;
+    this.highlight = results.length > 0 ? 0 : -1;
+    this.renderDropdown();
+  }
+
+  // ── entries ─────────────────────────────────────────────────────────────
+
+  private hasEntry(symbol: string): boolean {
+    return this.entries.some((e) => e.symbol === symbol);
+  }
+
+  private addResult(result: SymbolSearchResult): void {
+    if (this.hasEntry(result.symbol)) {
+      this.input.value = '';
+      this.results = [];
+      this.hideDropdown();
+      this.input.focus();
+      return;
+    }
+    if (this.entries.length >= MAX_ENTRIES) {
+      this.renderChips();
+      return;
+    }
+    this.entries.push(toWatchlistEntry(result));
+    this.input.value = '';
+    this.results = [];
+    this.highlight = -1;
+    this.hideDropdown();
+    this.renderChips();
+    this.input.focus();
+  }
+
+  private removeEntry(symbol: string): void {
+    this.entries = this.entries.filter((e) => e.symbol !== symbol);
+    this.renderChips();
+  }
+
+  // ── rendering ───────────────────────────────────────────────────────────
+
+  private showDropdown(): void { this.dropdown.style.display = 'block'; }
+  private hideDropdown(): void { this.dropdown.style.display = 'none'; }
+
+  private renderDropdown(): void {
+    this.dropdown.innerHTML = '';
+
+    if (this.loading) {
+      this.dropdown.append(this.messageRow('Searching…'));
+      return;
+    }
+    if (this.results.length === 0) {
+      this.dropdown.append(this.messageRow('No matching stocks'));
+      return;
+    }
+
+    this.results.forEach((r, idx) => {
+      const li = document.createElement('li');
+      li.setAttribute('role', 'option');
+      li.dataset.idx = String(idx);
+      const added = this.hasEntry(r.symbol);
+      const active = idx === this.highlight;
+      li.style.cssText =
+        'display:flex;align-items:baseline;gap:8px;padding:7px 9px;border-radius:7px;cursor:pointer;' +
+        `font-size:12px;${active ? 'background:rgba(255,255,255,0.08);' : ''}` +
+        (added ? 'opacity:0.5;' : '');
+      if (active) li.setAttribute('aria-selected', 'true');
+      li.innerHTML =
+        `<span style="font-family:var(--font-mono);font-weight:600;min-width:64px">${escapeHtml(r.display || r.symbol)}</span>` +
+        `<span style="color:var(--text-dim);overflow:hidden;text-overflow:ellipsis;white-space:nowrap">${escapeHtml(r.name)}</span>` +
+        (added ? `<span style="margin-left:auto;color:var(--semantic-normal);font-size:11px">added</span>` : '');
+      this.dropdown.append(li);
+    });
+  }
+
+  private messageRow(text: string): HTMLLIElement {
+    const li = document.createElement('li');
+    li.style.cssText = 'padding:8px 9px;font-size:12px;color:var(--text-dim)';
+    li.textContent = text;
+    return li;
+  }
+
+  private renderChips(): void {
+    this.chipsEl.innerHTML = '';
+    for (const e of this.entries) {
+      const chip = document.createElement('span');
+      chip.style.cssText =
+        'display:inline-flex;align-items:center;gap:6px;padding:4px 6px 4px 9px;border:1px solid var(--border);' +
+        'border-radius:999px;font-size:11px;background:rgba(255,255,255,0.03)';
+      const label = e.name && e.name !== e.symbol ? `${e.display || e.symbol} · ${e.name}` : (e.display || e.symbol);
+      chip.innerHTML =
+        `<span><span style="font-family:var(--font-mono);font-weight:600">${escapeHtml(e.display || e.symbol)}</span>` +
+        `${e.name && e.name !== e.symbol ? `<span style="color:var(--text-dim)"> · ${escapeHtml(e.name)}</span>` : ''}</span>` +
+        `<button type="button" data-remove="${escapeHtml(e.symbol)}" aria-label="Remove ${escapeHtml(label)}" ` +
+        `style="background:none;border:none;color:var(--text-dim);cursor:pointer;font-size:13px;line-height:1;padding:0 2px">×</button>`;
+      this.chipsEl.append(chip);
+    }
+    this.renderStatus();
+  }
+
+  private renderStatus(): void {
+    const n = this.entries.length;
+    if (n === 0) {
+      this.statusEl.textContent = 'No tickers yet — search above to add. Defaults are shown until you add your own.';
+    } else if (n >= MAX_ENTRIES) {
+      this.statusEl.textContent = `${n} tickers tracked — that's the maximum.`;
+    } else {
+      this.statusEl.textContent = `${n} ticker${n === 1 ? '' : 's'} tracked (up to ${MAX_ENTRIES}).`;
+    }
+  }
+
+  // ── events ──────────────────────────────────────────────────────────────
+
+  private onKeydown = (e: KeyboardEvent): void => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (this.results.length === 0) return;
+      this.highlight = Math.min(this.highlight + 1, this.results.length - 1);
+      this.renderDropdown();
+      return;
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (this.results.length === 0) return;
+      this.highlight = Math.max(this.highlight - 1, 0);
+      this.renderDropdown();
+      return;
+    }
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const picked = this.results[this.highlight];
+      if (picked) this.addResult(picked);
+      return;
+    }
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      this.hideDropdown();
+      return;
+    }
+    if (e.key === 'Backspace' && this.input.value === '' && this.entries.length > 0) {
+      // Empty input + Backspace removes the last chip — standard token-input UX.
+      e.preventDefault();
+      this.removeEntry(this.entries[this.entries.length - 1]!.symbol);
+    }
+  };
+
+  // mousedown (not click) so it fires before the input's blur hides the list.
+  private onDropdownMouseDown = (e: MouseEvent): void => {
+    const item = (e.target as HTMLElement).closest('[data-idx]') as HTMLElement | null;
+    if (!item) return;
+    e.preventDefault();
+    const idx = Number.parseInt(item.dataset.idx ?? '', 10);
+    const picked = this.results[idx];
+    if (picked) this.addResult(picked);
+  };
+
+  private onChipsClick = (e: MouseEvent): void => {
+    const btn = (e.target as HTMLElement).closest('[data-remove]') as HTMLElement | null;
+    if (!btn) return;
+    const symbol = btn.dataset.remove;
+    if (symbol) this.removeEntry(symbol);
+  };
+}

--- a/src/components/watchlist-modal.ts
+++ b/src/components/watchlist-modal.ts
@@ -9,26 +9,24 @@
 
 import {
   getMarketWatchlistEntries,
-  parseMarketWatchlistInput,
   resetMarketWatchlist,
   setMarketWatchlistEntries,
 } from '@/services/market-watchlist';
+import { WatchlistEditor } from './WatchlistEditor';
 
 let activeOverlay: HTMLElement | null = null;
 
 export function openWatchlistModal(): void {
   if (activeOverlay) return;
 
-  const current = getMarketWatchlistEntries();
-  const currentText = current.length
-    ? current.map((e) => (e.name ? `${e.symbol}|${e.name}` : e.symbol)).join('\n')
-    : '';
-
   const overlay = document.createElement('div');
   overlay.className = 'modal-overlay active';
   overlay.id = 'marketWatchlistModal';
 
+  const editor = new WatchlistEditor({ initial: getMarketWatchlistEntries() });
+
   const close = () => {
+    editor.destroy();
     overlay.remove();
     if (activeOverlay === overlay) activeOverlay = null;
   };
@@ -47,19 +45,14 @@ export function openWatchlistModal(): void {
       <button class="modal-close" aria-label="Close">×</button>
     </div>
     <div style="padding:14px 16px 16px 16px">
-      <div style="color:var(--text-dim);font-size:12px;line-height:1.5;margin-bottom:10px">
-        Add tickers (comma or newline separated). Friendly labels supported: SYMBOL|Label.
-        Example: TSLA|Tesla, AAPL|Apple, ^GSPC|S&amp;P 500
-        <br/>
-        Your picks are <strong>added</strong> to the Markets panel and lead the
-        Premium Stock Analysis, Backtesting and Daily Market Brief panels.
-        PRO members get every analysable ticker in the list reported (up to 50);
-        indices and FX (^GSPC, EURUSD=X) still appear in Markets but get no equity report.
+      <div style="color:var(--text-dim);font-size:12px;line-height:1.5;margin-bottom:12px">
+        Search a ticker or company name and pick from the list — every entry is a
+        real, tracked symbol. Your picks are <strong>added</strong> to the Markets
+        panel and lead the Premium Stock Analysis, Backtesting and Daily Market
+        Brief panels. PRO members get every ticker in the list reported (up to 50).
       </div>
-      <textarea id="wmMarketWatchlistInput"
-        style="width:100%;min-height:120px;resize:vertical;background:rgba(255,255,255,0.04);border:1px solid var(--border);color:var(--text);border-radius:10px;padding:10px;font-family:inherit;font-size:12px;outline:none"
-        spellcheck="false"></textarea>
-      <div style="display:flex;gap:8px;justify-content:flex-end;margin-top:12px">
+      <div id="wmWatchlistEditorMount"></div>
+      <div style="display:flex;gap:8px;justify-content:flex-end;margin-top:16px">
         <button type="button" class="panels-reset-layout" id="wmMarketResetBtn">Reset</button>
         <button type="button" class="panels-reset-layout" id="wmMarketCancelBtn">Cancel</button>
         <button type="button" class="panels-reset-layout" id="wmMarketSaveBtn" style="border-color:var(--text-dim);color:var(--text)">Save</button>
@@ -68,25 +61,24 @@ export function openWatchlistModal(): void {
   `;
 
   modal.querySelector('.modal-close')?.addEventListener('click', close);
+  modal.querySelector<HTMLDivElement>('#wmWatchlistEditorMount')?.append(editor.element);
 
   overlay.appendChild(modal);
   document.body.appendChild(overlay);
   activeOverlay = overlay;
-
-  const input = modal.querySelector<HTMLTextAreaElement>('#wmMarketWatchlistInput');
-  if (input) input.value = currentText;
+  editor.focus();
 
   modal.querySelector<HTMLButtonElement>('#wmMarketCancelBtn')?.addEventListener('click', close);
   modal.querySelector<HTMLButtonElement>('#wmMarketResetBtn')?.addEventListener('click', () => {
-    resetMarketWatchlist();
-    if (input) input.value = ''; // defaults are always included automatically
-    close();
+    // Clear in place — the user still confirms with Save (or backs out with
+    // Cancel). The old modal reset-and-closed in one click, which committed
+    // a destructive change with no confirmation step.
+    editor.clear();
   });
   modal.querySelector<HTMLButtonElement>('#wmMarketSaveBtn')?.addEventListener('click', () => {
-    const raw = input?.value || '';
-    const parsed = parseMarketWatchlistInput(raw);
-    if (parsed.length === 0) resetMarketWatchlist();
-    else setMarketWatchlistEntries(parsed);
+    const entries = editor.getEntries();
+    if (entries.length === 0) resetMarketWatchlist();
+    else setMarketWatchlistEntries(entries);
     close();
   });
 }

--- a/src/services/market-watchlist.ts
+++ b/src/services/market-watchlist.ts
@@ -114,24 +114,3 @@ export function subscribeMarketWatchlistChange(cb: (entries: MarketWatchlistEntr
   window.addEventListener(MARKET_WATCHLIST_EVENT, handler);
   return () => window.removeEventListener(MARKET_WATCHLIST_EVENT, handler);
 }
-
-export function parseMarketWatchlistInput(text: string): MarketWatchlistEntry[] {
-  // Accept comma or newline-separated entries.
-  // Friendly label format: SYMBOL|Label (ex: TSLA|Tesla)
-  const rawItems = text
-    .split(/[\n,]+/g)
-    .map((s) => s.trim())
-    .filter(Boolean);
-
-  const entries: MarketWatchlistEntry[] = [];
-
-  for (const item of rawItems) {
-    const [left, ...rest] = item.split('|');
-    const symbol = normalizeSymbol(left || '');
-    if (!symbol) continue;
-    const name = normalizeName(rest.join('|'));
-    entries.push({ symbol, ...(name ? { name } : {}) });
-  }
-
-  return entries;
-}

--- a/src/services/symbol-search.ts
+++ b/src/services/symbol-search.ts
@@ -1,0 +1,52 @@
+/**
+ * Client for /api/symbol-search — the watchlist editor's typeahead source.
+ *
+ * Cancels the in-flight request when a newer query supersedes it, so the
+ * dropdown never flashes a stale result set after the user keeps typing.
+ */
+
+import type { MarketWatchlistEntry } from '@/services/market-watchlist';
+
+export interface SymbolSearchResult {
+  symbol: string;
+  name: string;
+  display: string;
+}
+
+let _inflight: AbortController | null = null;
+
+/**
+ * Search stocks by ticker or company name. Returns [] for an empty query, a
+ * superseded (aborted) request, or any failure — the caller treats "no
+ * results" and "search unavailable" the same way (an empty dropdown).
+ */
+export async function searchSymbols(query: string): Promise<SymbolSearchResult[]> {
+  const q = query.trim();
+  if (!q) return [];
+
+  // Supersede any in-flight search — the user has typed more since.
+  _inflight?.abort();
+  const controller = new AbortController();
+  _inflight = controller;
+
+  try {
+    const res = await fetch(`/api/symbol-search?q=${encodeURIComponent(q)}`, {
+      signal: controller.signal,
+    });
+    if (!res.ok) return [];
+    const data = (await res.json()) as { results?: SymbolSearchResult[] };
+    return Array.isArray(data.results) ? data.results : [];
+  } catch (err) {
+    // AbortError = superseded by a newer query; everything else = transient
+    // failure. Either way the dropdown just shows nothing.
+    void err;
+    return [];
+  } finally {
+    if (_inflight === controller) _inflight = null;
+  }
+}
+
+/** A resolved search result is directly usable as a watchlist entry. */
+export function toWatchlistEntry(r: SymbolSearchResult): MarketWatchlistEntry {
+  return { symbol: r.symbol, name: r.name, display: r.display };
+}

--- a/tests/symbol-search.test.mts
+++ b/tests/symbol-search.test.mts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+import handler, { mapFinnhubResults } from '../api/symbol-search.ts';
+
+const originalFetch = globalThis.fetch;
+
+// validateApiKey() rejects credential-less requests (production browsers send
+// an anonymous session token via the wm-session fetch wrapper). The enterprise
+// key path is the simplest to satisfy in-test — an env allowlist + a matching
+// header, no HMAC. Set for the whole file.
+const TEST_KEY = 'wm-test-enterprise-key';
+process.env.WORLDMONITOR_VALID_KEYS = TEST_KEY;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  delete process.env.FINNHUB_API_KEY;
+});
+
+function makeReq(q?: string, method = 'GET'): Request {
+  const url = q === undefined
+    ? 'https://worldmonitor.app/api/symbol-search'
+    : `https://worldmonitor.app/api/symbol-search?q=${encodeURIComponent(q)}`;
+  return new Request(url, { method, headers: { 'X-WorldMonitor-Key': TEST_KEY } });
+}
+
+describe('mapFinnhubResults', () => {
+  it('maps symbol/description/displaySymbol and keeps equity-type instruments', () => {
+    const out = mapFinnhubResults([
+      { symbol: 'NVDA', displaySymbol: 'NVDA', description: 'NVIDIA CORP', type: 'Common Stock' },
+      { symbol: 'NVDL', displaySymbol: 'NVDL', description: 'GraniteShares 2x NVDA ETF', type: 'ETP' },
+    ]);
+    assert.deepEqual(out, [
+      { symbol: 'NVDA', name: 'NVIDIA CORP', display: 'NVDA' },
+      { symbol: 'NVDL', name: 'GraniteShares 2x NVDA ETF', display: 'NVDL' },
+    ]);
+  });
+
+  it('drops non-equity instrument types (crypto, FX, bonds, warrants)', () => {
+    const out = mapFinnhubResults([
+      { symbol: 'BINANCE:BTCUSDT', description: 'Bitcoin', type: 'Crypto' },
+      { symbol: 'OANDA:EUR_USD', description: 'EUR/USD', type: 'Forex' },
+      { symbol: 'AAPL', displaySymbol: 'AAPL', description: 'APPLE INC', type: 'Common Stock' },
+    ]);
+    assert.deepEqual(out, [{ symbol: 'AAPL', name: 'APPLE INC', display: 'AAPL' }]);
+  });
+
+  it('allows results with a missing/empty type and falls back name→symbol', () => {
+    const out = mapFinnhubResults([
+      { symbol: 'GLW', displaySymbol: 'GLW' },           // no type, no description
+      { symbol: 'KULR', description: 'KULR TECH', type: '' },
+    ]);
+    assert.deepEqual(out, [
+      { symbol: 'GLW', name: 'GLW', display: 'GLW' },
+      { symbol: 'KULR', name: 'KULR TECH', display: 'KULR' },
+    ]);
+  });
+
+  it('skips empty symbols and de-dupes', () => {
+    const out = mapFinnhubResults([
+      { symbol: '', description: 'nothing', type: 'Common Stock' },
+      { symbol: 'TSLA', description: 'TESLA INC', type: 'Common Stock' },
+      { symbol: 'TSLA', description: 'TESLA INC DUP', type: 'Common Stock' },
+    ]);
+    assert.deepEqual(out, [{ symbol: 'TSLA', name: 'TESLA INC', display: 'TSLA' }]);
+  });
+
+  it('caps the result list at 12', () => {
+    const raw = Array.from({ length: 30 }, (_, i) => ({
+      symbol: `SYM${i}`, description: `Company ${i}`, type: 'Common Stock',
+    }));
+    assert.equal(mapFinnhubResults(raw).length, 12);
+  });
+});
+
+describe('symbol-search handler', () => {
+  it('returns mapped Finnhub results for a query', async () => {
+    process.env.FINNHUB_API_KEY = 'test-key';
+    let requestedUrl = '';
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      requestedUrl = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      return new Response(
+        JSON.stringify({ count: 1, result: [{ symbol: 'NVDA', displaySymbol: 'NVDA', description: 'NVIDIA CORP', type: 'Common Stock' }] }),
+        { status: 200 },
+      );
+    }) as typeof fetch;
+
+    const res = await handler(makeReq('nvidia'));
+    assert.equal(res.status, 200);
+    assert.match(requestedUrl, /finnhub\.io\/api\/v1\/search\?q=nvidia&token=test-key/);
+    const body = await res.json() as { results: unknown };
+    assert.deepEqual(body.results, [{ symbol: 'NVDA', name: 'NVIDIA CORP', display: 'NVDA' }]);
+  });
+
+  it('returns empty results for a blank query without calling Finnhub', async () => {
+    process.env.FINNHUB_API_KEY = 'test-key';
+    let called = false;
+    globalThis.fetch = (async () => { called = true; return new Response('{}'); }) as typeof fetch;
+
+    const res = await handler(makeReq('   '));
+    assert.equal(res.status, 200);
+    assert.deepEqual((await res.json() as { results: unknown }).results, []);
+    assert.equal(called, false, 'a blank query must not hit Finnhub');
+  });
+
+  it('returns 503 when FINNHUB_API_KEY is not configured', async () => {
+    const res = await handler(makeReq('nvidia'));
+    assert.equal(res.status, 503);
+  });
+
+  it('maps a Finnhub 429 to 503 so the client backs off instead of failing hard', async () => {
+    process.env.FINNHUB_API_KEY = 'test-key';
+    globalThis.fetch = (async () => new Response('rate limited', { status: 429 })) as typeof fetch;
+    const res = await handler(makeReq('nvidia'));
+    assert.equal(res.status, 503);
+  });
+
+  it('returns 500 when the upstream fetch throws', async () => {
+    process.env.FINNHUB_API_KEY = 'test-key';
+    globalThis.fetch = (async () => { throw new Error('network down'); }) as typeof fetch;
+    const res = await handler(makeReq('nvidia'));
+    assert.equal(res.status, 500);
+  });
+
+  it('rejects non-GET methods', async () => {
+    const res = await handler(makeReq('x', 'POST'));
+    assert.equal(res.status, 405);
+  });
+});


### PR DESCRIPTION
## Why

The watchlist editor was a free-text textarea with **zero validation**. Type `Nvidia` instead of `NVDA`, or a typo, and it was stored verbatim — then **dropped silently** downstream (Yahoo returns nothing → `available:false` → the card just never renders). The user had no way to know what resolved, what didn't, or why. This blocked the whole watchlist feature in practice.

## What

A search-first editor — invalid input is now structurally impossible because every entry comes from a resolved real symbol.

- **`api/symbol-search.ts`** — new edge function. `GET ?q=` → Finnhub `/search`, filtered to equity-type instruments, returns `{symbol, name, display}[]`. CORS + `validateApiKey` + rate-limit (mirrors `rss-proxy`); a Finnhub `429` is mapped to `503` so the client backs off.
- **`src/services/symbol-search.ts`** — typed client; aborts the in-flight request when a newer keystroke supersedes it.
- **`src/components/WatchlistEditor.ts`** — debounced search input + keyboard-nav dropdown of real matches + removable chips, reusing the existing `CountryPicker` pattern. Dedupes, caps at 50, Backspace-removes-last-chip.
- **`watchlist-modal.ts`** — swaps the textarea for the editor; `Reset` now clears **in place** (the old Reset committed a destructive change with no confirmation step). Copy rewritten.
- Removed the now-dead `parseMarketWatchlistInput`.

Existing `localStorage` watchlists — including any legacy bad entries a user typed under the old editor — render as chips, so they're visible and removable.

## Test plan

- [x] `npm run typecheck` + `typecheck:api` — PASS
- [x] `npm run lint` (biome) — PASS on changed files
- [x] esbuild bundle check on the new `.ts` edge function — PASS
- [x] `npm run test:data` — PASS, 8800/8800
- [x] New `tests/symbol-search.test.mjs` — 11 tests: `mapFinnhubResults` equity-type filtering / dedupe / cap / name fallback, and the handler (query passthrough, empty-query short-circuit, `429`→`503`, `500`-on-throw, `405`, missing-`FINNHUB_API_KEY`→`503`).
- [ ] Manual on preview: open any panel's "Edit Watchlist" → search `nvidia` → pick `NVDA` from the dropdown → chip appears → Save → panel tracks it. Confirm a nonsense query shows "No matching stocks", not a silent accept.

## Notes

- Requires `FINNHUB_API_KEY` in the environment (already used elsewhere for quotes). If unset, the endpoint returns `503` and the dropdown shows nothing — no crash.
- Stacks conceptually on #3686 (additive watchlist) and #3695 (sync data-loss fix); independent diff, branches off `main`.