### PR TITLE
chore(agents): scaffold per-repo config for Matt Pocock's engineering skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -196,3 +196,28 @@ Runs automatically before `git push`:
 - [Health endpoints](docs/health-endpoints.mdx)
 - [Adding endpoints guide](docs/adding-endpoints.mdx)
 - [API reference (OpenAPI)](docs/api/)
+
+## Agent skills
+
+Per-repo configuration for Matt Pocock's engineering skills (`/to-issues`,
+`/to-prd`, `/triage`, `/diagnose`, `/tdd`, `/improve-codebase-architecture`,
+`/zoom-out`).
+
+### Issue tracker
+
+GitHub issues at `koala73/worldmonitor`, accessed via the `gh` CLI.
+See [`docs/agents/issue-tracker.md`](docs/agents/issue-tracker.md).
+
+### Triage labels
+
+Five canonical roles using Matt's defaults: `needs-triage`, `needs-info`,
+`ready-for-agent`, `ready-for-human`, `wontfix`. `wontfix` already exists on
+the repo; the other four get created on first `/triage` run.
+See [`docs/agents/triage-labels.md`](docs/agents/triage-labels.md).
+
+### Domain docs
+
+Single-context — one `CONTEXT.md` + `docs/adr/` at the repo root. Both
+currently absent; skills proceed silently and `/grill-with-docs` creates
+them lazily as terms/decisions get resolved.
+See [`docs/agents/domain.md`](docs/agents/domain.md).

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary

Adds the per-repo bindings that Matt Pocock's engineering skills expect, so `/to-issues`, `/to-prd`, `/triage`, `/diagnose`, `/tdd`, `/improve-codebase-architecture`, and `/zoom-out` know how to operate against *this* repo (which issue tracker, which label vocabulary, where domain docs live).

Skills installed globally via `npx skills@latest add mattpocock/skills`; this PR just wires up the per-repo glue.

## Files

- **`AGENTS.md`** — new `## Agent skills` section linking the three docs below.
- **`docs/agents/issue-tracker.md`** — GitHub via `gh` CLI (`gh issue create / view / list / comment / edit --add-label / close`). Repo: `koala73/worldmonitor`.
- **`docs/agents/triage-labels.md`** — five canonical roles mapped 1:1 to Matt's defaults (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). `wontfix` already exists; the other four get created on first `/triage` run. `question` was *not* mapped to `needs-info` (different semantics: kind vs state).
- **`docs/agents/domain.md`** — single-context layout (one `CONTEXT.md` + `docs/adr/` at the repo root). Both files currently absent; per Matt's spec the skills proceed silently and `/grill-with-docs` creates them lazily as terms/decisions get resolved.

## Test plan

- [x] `npm run lint:md` — PASS, 0 errors
- [x] No code changes — pure docs.
- [ ] Manual: after merge, run `/diagnose` or `/to-issues` to confirm skills pick up the config.

## Notes

This is *configuration*, not Matt's skill code — the skills themselves live in `~/.claude/skills/` globally and are not part of this repo. Editing `docs/agents/*.md` is the supported way to evolve the bindings; re-run `/setup-matt-pocock-skills` only when switching issue trackers or restarting from scratch.