### PR TITLE
fix(seed-portwatch): surface degraded ArcGIS 400 body + cap degenerate retries

### DIFF
--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -220,20 +220,32 @@ async function fetchWithTimeout(url, { signal } = {}) {
     // surface its message so the circuit-breaker can fire on the
     // upstream-degradation signal.
     //
-    // Gated: fires ONCE per process. We only need the body shape once
-    // for diagnostics + to flip the circuit-breaker into bail-mode via
-    // INVALID_PARAMS_RETRY_THRESHOLD. Subsequent timeouts go straight
-    // to proxy retry so the 35s proxy budget stays intact and we don't
-    // re-create the budget-tight 45+20+35>90 scenario Greptile P2'd on
-    // PR #3681. Net cost: +20s once per run. Best-effort: any failure
-    // here just falls through to proxy retry as before.
-    if (!_bodyCapturedOnceThisRun) {
-      _bodyCapturedOnceThisRun = true;
+    // Gated: fires until we get a SUCCESSFUL capture or hit the attempt
+    // cap. We only need the body shape ONCE for diagnostics + to flip
+    // the circuit-breaker into bail-mode via INVALID_PARAMS_RETRY_THRESHOLD,
+    // so MAX_BODY_CAPTURE_SUCCESSES=1 — first body wins. But because the
+    // capture itself can ALSO time out during consistent degradation (the
+    // +20s budget isn't long enough when ArcGIS is uniformly slow per
+    // PR #3701 Greptile P2), we bound attempts at MAX_BODY_CAPTURE_ATTEMPTS
+    // (3) to keep retrying when initial captures fail. The 35s proxy budget
+    // and 45+20+35>90 scenario stay protected because per-country wrap
+    // caps the whole thing at 90s. Net cost: ≤3 × 20s wall-clock per run.
+    // Best-effort: any failure falls through to proxy retry as before.
+    if (_bodyCaptureSuccessCount < MAX_BODY_CAPTURE_SUCCESSES
+        && _bodyCaptureAttemptCount < MAX_BODY_CAPTURE_ATTEMPTS) {
+      _bodyCaptureAttemptCount += 1;
       const captured = await _captureErrorBodyAfterTimeout(url, signal);
       if (captured?.error) {
+        _bodyCaptureSuccessCount += 1;
         throw new Error(`ArcGIS error: ${captured.error.message ?? captured.error.code ?? JSON.stringify(captured.error)}`);
       }
-      if (captured?.body) return captured.body;
+      if (captured?.body) {
+        _bodyCaptureSuccessCount += 1;
+        return captured.body;
+      }
+      // captured=null: capture also timed out / errored. Don't count as
+      // success — fall through to proxy retry, leaving attempts budget
+      // for the next timing-out country in case that one settles faster.
     }
     return await arcgisProxyRetry(url, `direct ${errName || 'timeout'}`, { signal });
   }
@@ -246,16 +258,28 @@ async function fetchWithTimeout(url, { signal } = {}) {
   return body;
 }
 
-// Module-local: tracks whether the diagnostic body-capture path has
-// fired this run. Gated to once-per-process so subsequent timeouts go
-// straight to proxy retry without paying the extra capture budget.
-// See _captureErrorBodyAfterTimeout call site in fetchWithTimeout.
-let _bodyCapturedOnceThisRun = false;
+// Module-local: tracks SUCCESSFUL diagnostic body-captures this run.
+// Greptile PR #3701 P2: pre-fix the gate fired on first ATTEMPT, so a
+// failed first capture (capture also timing out at +20s during
+// consistent degradation) locked out every subsequent attempt — the
+// diagnostic value could be lost for an entire run. New behavior: gate
+// on successful captures, bound total ATTEMPTS to
+// MAX_BODY_CAPTURE_ATTEMPTS so we don't pay the +20s on every timing-out
+// country in a fully-degraded run.
+let _bodyCaptureSuccessCount = 0;
+let _bodyCaptureAttemptCount = 0;
+const MAX_BODY_CAPTURE_SUCCESSES = 1;
+// Cap on attempts in case captures keep failing (also-timing-out at +20s).
+// 3 attempts × 20s ÷ concurrency 6 ≈ 10s of extra wall-clock across the
+// run, bounded. Beyond that, the cost-benefit tips and subsequent
+// timeouts go straight to proxy.
+const MAX_BODY_CAPTURE_ATTEMPTS = 3;
 
-// Test-only helper: resets the once-per-run guard so unit tests can
+// Test-only helper: resets the capture counters so unit tests can
 // re-exercise the capture path with different mocked responses.
 export function _resetBodyCapturedFlag() {
-  _bodyCapturedOnceThisRun = false;
+  _bodyCaptureSuccessCount = 0;
+  _bodyCaptureAttemptCount = 0;
 }
 
 // Best-effort body capture when the initial fetch times out at
@@ -319,6 +343,15 @@ async function fetchWithRetryOnInvalidParams(url, { signal } = {}) {
     const msg = err?.message || '';
     if (!/Invalid query parameters/i.test(msg)) throw err;
     _invalidParamsErrorCount += 1;
+    // Greptile PR #3701 P2: if the error came BACK from the proxy
+    // (arcgisProxyRetry wraps with "via proxy after ${reason}"), the
+    // proxy has already confirmed the upstream error — retrying would
+    // just round-trip direct timeout → proxy → same error, burning the
+    // per-country budget for nothing. The proxy response is the
+    // definitive upstream signal here. We still increment the counter
+    // (proxy-confirmed errors are valid degradation signals for the
+    // threshold) but skip the retry.
+    if (/via proxy after/i.test(msg)) throw err;
     if (_invalidParamsErrorCount > INVALID_PARAMS_RETRY_THRESHOLD) {
       // Degradation signal — caller sees a clear "no retry, run will be
       // partial" message instead of doubling time-on-task for nothing.

--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -64,13 +64,21 @@ const PROXY_FETCH_TIMEOUT = 35_000;
 // parameters."}}`) after 30-56s of server processing. Our 45s
 // FETCH_TIMEOUT fires first; the caller sees AbortError; the existing
 // circuit-breaker that looks for `/Invalid query parameters/i` never
-// fires because the message is never read. This extra 20s window lets
-// the body land (most degraded responses settle in <60s total) before
-// falling through to the proxy retry. Hard-capped — withPerCountryTimeout
-// still bounds the overall per-country budget at 90s, and the diagnostic
-// re-fetch only fires on internal-FETCH_TIMEOUT, not caller-signal
-// aborts.
-const ERROR_BODY_CAPTURE_EXTRA_MS = 20_000;
+// fires because the message is never read.
+//
+// PR #3701 P2 round 3: bumped 20s → 40s because the observed degraded
+// response class is 30-56s from request start, and each capture is a
+// FRESH request (the original was already aborted). A 20s budget rarely
+// caught the body. 40s catches most. The per-country wrap
+// (PER_COUNTRY_TIMEOUT_MS=90s) naturally caps this: direct (45s timeout)
+// + capture (40s budget) = 85s, leaving 5s before the wrap fires. Proxy
+// retry effectively dies for timing-out countries in this mode — accepted
+// tradeoff because the proxy itself is degraded during this incident
+// (Decodo throttled per PR #3694 history), so it wasn't helping anyway.
+// Hard-capped — withPerCountryTimeout still bounds the overall per-country
+// budget at 90s, and the diagnostic re-fetch only fires on
+// internal-FETCH_TIMEOUT, not caller-signal aborts.
+const ERROR_BODY_CAPTURE_EXTRA_MS = 40_000;
 // After this many "Invalid query parameters" errors in a single process,
 // stop retrying on them — that's a degradation signal, not a transient
 // flake. The historical comment on fetchWithRetryOnInvalidParams notes
@@ -269,10 +277,16 @@ async function fetchWithTimeout(url, { signal } = {}) {
 let _bodyCaptureSuccessCount = 0;
 let _bodyCaptureAttemptCount = 0;
 const MAX_BODY_CAPTURE_SUCCESSES = 1;
-// Cap on attempts in case captures keep failing (also-timing-out at +20s).
-// 3 attempts × 20s ÷ concurrency 6 ≈ 10s of extra wall-clock across the
-// run, bounded. Beyond that, the cost-benefit tips and subsequent
-// timeouts go straight to proxy.
+// Cap on attempts in case captures keep failing. With
+// ERROR_BODY_CAPTURE_EXTRA_MS bumped to 40s (PR #3701 P2 round 3), 2
+// attempts already total 80s of capture wall-clock per timing-out country
+// (direct 45s + capture 40s = 85s, fits the 90s wrap once). A SECOND
+// attempt for the same country would always be aborted by the wrap. So
+// cap at 1 per-country attempt — but track ATTEMPTS across the run so
+// the first ~3 timing-out countries each get a try, after which we go
+// straight to proxy (the diagnostic value is captured by then). Bounded
+// total: 3 × 40s ≈ 120s WALL-CLOCK across concurrent batches of 6 ≈ 20s
+// extra wall-clock per run, well under the 540s container budget.
 const MAX_BODY_CAPTURE_ATTEMPTS = 3;
 
 // Test-only helper: resets the capture counters so unit tests can
@@ -343,20 +357,27 @@ async function fetchWithRetryOnInvalidParams(url, { signal } = {}) {
     const msg = err?.message || '';
     if (!/Invalid query parameters/i.test(msg)) throw err;
     _invalidParamsErrorCount += 1;
-    // Greptile PR #3701 P2: if the error came BACK from the proxy
-    // (arcgisProxyRetry wraps with "via proxy after ${reason}"), the
-    // proxy has already confirmed the upstream error — retrying would
-    // just round-trip direct timeout → proxy → same error, burning the
-    // per-country budget for nothing. The proxy response is the
-    // definitive upstream signal here. We still increment the counter
-    // (proxy-confirmed errors are valid degradation signals for the
-    // threshold) but skip the retry.
-    if (/via proxy after/i.test(msg)) throw err;
+    // PR #3701 P1 round 3: threshold check MUST come before the
+    // proxy-confirmed short-circuit. Pre-fix the short-circuit ran first,
+    // so a degraded incident where every error arrives via proxy would
+    // never surface the clean "ArcGIS degraded — N errors" message — the
+    // counter incremented forever but the threshold path was unreachable.
+    // Right order: count → threshold (emits the degraded message) → proxy
+    // short-circuit (skip retry only when below threshold).
     if (_invalidParamsErrorCount > INVALID_PARAMS_RETRY_THRESHOLD) {
       // Degradation signal — caller sees a clear "no retry, run will be
       // partial" message instead of doubling time-on-task for nothing.
       throw new Error(`ArcGIS degraded — ${_invalidParamsErrorCount} 'Invalid query parameters' errors in this run, no retry (threshold ${INVALID_PARAMS_RETRY_THRESHOLD})`);
     }
+    // Greptile PR #3701 P2: if the error came BACK from the proxy
+    // (arcgisProxyRetry wraps with "via proxy after ${reason}"), the
+    // proxy has already confirmed the upstream error — retrying would
+    // just round-trip direct timeout → proxy → same error, burning the
+    // per-country budget for nothing. The proxy response is the
+    // definitive upstream signal here. Counter increment + threshold
+    // check above still apply, so proxy-confirmed errors DO contribute
+    // to the degraded-run message.
+    if (/via proxy after/i.test(msg)) throw err;
     await new Promise((r) => setTimeout(r, 500));
     if (signal?.aborted) throw signal.reason ?? err;
     console.warn(`  [port-activity] retrying after "${msg}" (${_invalidParamsErrorCount}/${INVALID_PARAMS_RETRY_THRESHOLD}): ${url.slice(0, 80)}`);

--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -81,6 +81,20 @@ const ERROR_BODY_CAPTURE_EXTRA_MS = 20_000;
 // (30 cold × 2 attempts × 45s = blown 540s container budget). Counter
 // is module-local and resets at process start (next cron tick).
 const INVALID_PARAMS_RETRY_THRESHOLD = 5;
+// Minimum FRESH upstream successes (cache-fresh OR fetched-fresh) required
+// for cap-mode to bypass the 80% degradation guard. Pre-fix the bypass was
+// unconditional, which meant a run with `servedStale=27, freshSuccess=0,
+// dropped=117` could pass `countryData.size >= MIN_VALID_COUNTRIES` (all
+// stale-served entries) AND bypass the degradation guard (capTriggered),
+// shrinking the canonical list from ~174 → 27 stale-only entries and
+// advancing seed-meta — hiding the upstream outage.
+//
+// Floor at 5 fresh successes: meaningful upstream contact this run.
+// Below that, cap-mode is NOT a rotational steady-state — it's an
+// ArcGIS-completely-down scenario, and the 80% guard should fire (which
+// extendExistingTtl-only on prior payloads, preserves canonical list,
+// keeps WARNING visible to the operator).
+const MIN_FRESH_FETCH_FOR_CAP_BYPASS = 5;
 // Two aggregation windows, hardcoded in fetchCountryAccum:
 //   last30 = days  0-30 → tankerCalls30d, avg30d, import/export sums
 //   prev30 = days 30-60 → trendDelta baseline
@@ -802,6 +816,12 @@ export async function fetchAll(progress, { signal } = {}) {
   let servedStaleCount = 0;
   let droppedTooOldCount = 0;
   let droppedNoCacheCount = 0;
+  // Counts fresh upstream successes this run (fetched-fresh path, line ~904).
+  // cacheHits is counted separately and also contributes to "fresh upstream
+  // contact" — both are aggregated into the cap-mode bypass gate in main().
+  // Servet-stale entries do NOT count: they're prior-run data being held
+  // over, no upstream contact this run.
+  let freshFetchedCount = 0;
 
   if (needsFetch.length > MAX_COLD_FETCH_PER_RUN) {
     capTriggered = true;
@@ -911,6 +931,7 @@ export async function fetchAll(progress, { signal } = {}) {
         asof: upstreamMaxDate,
         cacheWrittenAt: Date.now(),
       });
+      freshFetchedCount++;
     }
 
     if (progress) progress.seeded = countryData.size;
@@ -951,7 +972,22 @@ export async function fetchAll(progress, { signal } = {}) {
     // immediately so SIGTERM doesn't start additional in-flight work.
     if (signal?.aborted) break;
     if (batchIdx < batches) {
-      await new Promise((r) => setTimeout(r, BATCH_BACKOFF_MS));
+      // Abort-aware sleep: previously a plain setTimeout(BATCH_BACKOFF_MS)
+      // that ignored the caller signal mid-sleep, so a SIGTERM during the
+      // 5s backoff still made the loop wait the full 5s before observing
+      // the abort. Race the sleep against signal.aborted so the loop exits
+      // immediately on a real cancellation (which then surfaces via the
+      // signal?.aborted check at the top of the next iteration).
+      await new Promise((resolve) => {
+        const timer = setTimeout(resolve, BATCH_BACKOFF_MS);
+        if (!signal) return;
+        const onAbort = () => {
+          clearTimeout(timer);
+          signal.removeEventListener('abort', onAbort);
+          resolve();
+        };
+        signal.addEventListener('abort', onAbort, { once: true });
+      });
     }
   }
 
@@ -971,6 +1007,14 @@ export async function fetchAll(progress, { signal } = {}) {
     servedStaleCount,
     droppedTooOldCount,
     droppedNoCacheCount,
+    // Fresh upstream contact this run. Surfaced so main() can gate the
+    // cap-mode bypass on a minimum-fresh-success floor — see
+    // MIN_FRESH_FETCH_FOR_CAP_BYPASS. Without this, a run with all-stale
+    // served entries (freshFetched=0, cacheHits=0, servedStale≥25) could
+    // bypass the degradation guard and publish a shrunken canonical list
+    // as healthy, hiding the upstream outage.
+    freshFetchedCount,
+    cacheHitCount: cacheHits,
   };
 }
 
@@ -1040,6 +1084,8 @@ async function main() {
       servedStaleCount,
       droppedTooOldCount,
       droppedNoCacheCount,
+      freshFetchedCount,
+      cacheHitCount,
     } = await fetchAll(progress, { signal: shutdownController.signal });
 
     console.log(`  Fetched ${countryData.size} countries`);
@@ -1063,13 +1109,41 @@ async function main() {
     // (cap=30 + ~24 stale-served = ~54 << 0.8 × 174 = 139), seed-meta
     // would never advance, and the operator-facing WARNING would persist
     // — defeating the entire recovery design from #3676 onwards.
-    if (capTriggered) {
+    //
+    // PR #3701 review P1: the bypass MUST also require fresh upstream
+    // contact this run (freshFetchedCount + cacheHitCount). Pre-fix, a
+    // worst-case "ArcGIS completely down" run with freshSuccess=0,
+    // cacheHits=0, servedStale=27 would pass the lowered coverage gate
+    // (countryData.size=27 ≥ 25) and bypass the degradation guard, shrinking
+    // the canonical list from ~174 → 27 stale-only entries and advancing
+    // seed-meta as healthy — hiding the upstream outage. With this gate,
+    // such a run falls through to the 80% guard (which fires and
+    // extendExistingTtl-only), preserving the canonical list and the
+    // operator-facing WARNING.
+    const upstreamContactCount = freshFetchedCount + cacheHitCount;
+    const capBypassEarned = capTriggered && upstreamContactCount >= MIN_FRESH_FETCH_FOR_CAP_BYPASS;
+    if (capBypassEarned) {
       console.warn(
         `  PARTIAL PUBLISH (cap-mode): ${countryData.size}/${prevCount} countries — ` +
-        `${servedStaleCount} stale-served, ${droppedTooOldCount} dropped (cache > 7d), ` +
-        `${droppedNoCacheCount} dropped (no prior payload). ` +
-        `Degradation guard bypassed; seed-meta will advance.`,
+        `${freshFetchedCount} fresh-fetched, ${cacheHitCount} cache-fresh, ${servedStaleCount} stale-served, ` +
+        `${droppedTooOldCount} dropped (cache > 7d), ${droppedNoCacheCount} dropped (no prior payload). ` +
+        `Degradation guard bypassed (≥${MIN_FRESH_FETCH_FOR_CAP_BYPASS} fresh upstream contacts); seed-meta will advance.`,
       );
+    } else if (capTriggered) {
+      // Cap-mode WITHOUT enough fresh upstream contact — fall through to the
+      // 80% guard. If we got here, freshFetched + cacheHits < threshold,
+      // which means this is an upstream-degraded run, not a rotational one.
+      // Log explicitly so the operator sees why the bypass didn't fire.
+      console.error(
+        `  CAP-MODE BYPASS REFUSED: only ${upstreamContactCount} fresh upstream contacts ` +
+        `(${freshFetchedCount} fetched + ${cacheHitCount} cache-fresh, threshold ${MIN_FRESH_FETCH_FOR_CAP_BYPASS}). ` +
+        `Stale-only published would hide the upstream outage. Falling through to 80% degradation guard.`,
+      );
+      if (prevCount > 0 && countryData.size < prevCount * 0.8) {
+        console.error(`  DEGRADATION GUARD: ${countryData.size} countries vs ${prevCount} previous — refusing to overwrite (need ≥${Math.ceil(prevCount * 0.8)})`);
+        await extendExistingTtl([CANONICAL_KEY, META_KEY, ...prevCountryKeys], TTL).catch(() => {});
+        return;
+      }
     } else if (prevCount > 0 && countryData.size < prevCount * 0.8) {
       console.error(`  DEGRADATION GUARD: ${countryData.size} countries vs ${prevCount} previous — refusing to overwrite (need ≥${Math.ceil(prevCount * 0.8)})`);
       await extendExistingTtl([CANONICAL_KEY, META_KEY, ...prevCountryKeys], TTL).catch(() => {});

--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -56,6 +56,31 @@ const FETCH_TIMEOUT = 45_000;
 // setup overhead and the surrounding pagination accounting. Greptile PR
 // #3681 review P2 flagged the prior 45+45=90s arrangement as racey.
 const PROXY_FETCH_TIMEOUT = 35_000;
+// Diagnostic re-fetch budget for capturing the actual error body when the
+// initial direct fetch times out at FETCH_TIMEOUT. WM 2026-05-15
+// investigation found ArcGIS Daily_Ports_Data, during degradation
+// episodes, returns HTTP 200 with a 400 error body
+// (`{"error":{"code":400,"message":"Cannot perform query. Invalid query
+// parameters."}}`) after 30-56s of server processing. Our 45s
+// FETCH_TIMEOUT fires first; the caller sees AbortError; the existing
+// circuit-breaker that looks for `/Invalid query parameters/i` never
+// fires because the message is never read. This extra 20s window lets
+// the body land (most degraded responses settle in <60s total) before
+// falling through to the proxy retry. Hard-capped — withPerCountryTimeout
+// still bounds the overall per-country budget at 90s, and the diagnostic
+// re-fetch only fires on internal-FETCH_TIMEOUT, not caller-signal
+// aborts.
+const ERROR_BODY_CAPTURE_EXTRA_MS = 20_000;
+// After this many "Invalid query parameters" errors in a single process,
+// stop retrying on them — that's a degradation signal, not a transient
+// flake. The historical comment on fetchWithRetryOnInvalidParams notes
+// "a single retry with a short back-off clears it in practice", which
+// was true for the 2026-04-20 BRA/IDN/NGA transient. NOT true during the
+// 2026-05-15 degradation episode where every cold-fetch hit the same
+// 400 and the retry burned another full FETCH_TIMEOUT for nothing
+// (30 cold × 2 attempts × 45s = blown 540s container budget). Counter
+// is module-local and resets at process start (next cron tick).
+const INVALID_PARAMS_RETRY_THRESHOLD = 5;
 // Two aggregation windows, hardcoded in fetchCountryAccum:
 //   last30 = days  0-30 → tankerCalls30d, avg30d, import/export sums
 //   prev30 = days 30-60 → trendDelta baseline
@@ -171,6 +196,31 @@ async function fetchWithTimeout(url, { signal } = {}) {
       || errName === 'AbortError'
       || /timeout|aborted|fetch failed|ECONNRESET|UND_ERR_/i.test(errMsg);
     if (!isTimeoutLike) throw err;
+    // WM 2026-05-15: before routing to proxy, make ONE diagnostic
+    // re-fetch with an extra ERROR_BODY_CAPTURE_EXTRA_MS budget to
+    // capture the actual response body. ArcGIS Daily_Ports_Data in
+    // degradation mode returns HTTP 200 with a 400 error body after
+    // 30-56s; the existing 45s FETCH_TIMEOUT misses it, so the upstream
+    // circuit-breaker (fetchWithRetryOnInvalidParams) never sees the
+    // real message. If THIS re-fetch lands a body with `body.error`,
+    // surface its message so the circuit-breaker can fire on the
+    // upstream-degradation signal.
+    //
+    // Gated: fires ONCE per process. We only need the body shape once
+    // for diagnostics + to flip the circuit-breaker into bail-mode via
+    // INVALID_PARAMS_RETRY_THRESHOLD. Subsequent timeouts go straight
+    // to proxy retry so the 35s proxy budget stays intact and we don't
+    // re-create the budget-tight 45+20+35>90 scenario Greptile P2'd on
+    // PR #3681. Net cost: +20s once per run. Best-effort: any failure
+    // here just falls through to proxy retry as before.
+    if (!_bodyCapturedOnceThisRun) {
+      _bodyCapturedOnceThisRun = true;
+      const captured = await _captureErrorBodyAfterTimeout(url, signal);
+      if (captured?.error) {
+        throw new Error(`ArcGIS error: ${captured.error.message ?? captured.error.code ?? JSON.stringify(captured.error)}`);
+      }
+      if (captured?.body) return captured.body;
+    }
     return await arcgisProxyRetry(url, `direct ${errName || 'timeout'}`, { signal });
   }
   if (resp.status === 429) {
@@ -182,32 +232,95 @@ async function fetchWithTimeout(url, { signal } = {}) {
   return body;
 }
 
+// Module-local: tracks whether the diagnostic body-capture path has
+// fired this run. Gated to once-per-process so subsequent timeouts go
+// straight to proxy retry without paying the extra capture budget.
+// See _captureErrorBodyAfterTimeout call site in fetchWithTimeout.
+let _bodyCapturedOnceThisRun = false;
+
+// Test-only helper: resets the once-per-run guard so unit tests can
+// re-exercise the capture path with different mocked responses.
+export function _resetBodyCapturedFlag() {
+  _bodyCapturedOnceThisRun = false;
+}
+
+// Best-effort body capture when the initial fetch times out at
+// FETCH_TIMEOUT. Used to surface the actual ArcGIS error body during
+// degradation episodes (see ERROR_BODY_CAPTURE_EXTRA_MS comment).
+// Returns `{error}` if the response body contains an ArcGIS error,
+// `{body}` if it contains a normal response, or null if the re-fetch
+// itself failed (caller falls through to proxy retry as before).
+async function _captureErrorBodyAfterTimeout(url, signal) {
+  if (signal?.aborted) return null;
+  const captureSignal = signal
+    ? AbortSignal.any([signal, AbortSignal.timeout(ERROR_BODY_CAPTURE_EXTRA_MS)])
+    : AbortSignal.timeout(ERROR_BODY_CAPTURE_EXTRA_MS);
+  try {
+    const resp = await fetch(url, {
+      headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
+      signal: captureSignal,
+    });
+    if (!resp.ok) return null;
+    const body = await resp.json();
+    if (body?.error) {
+      console.warn(`  [port-activity] degraded ArcGIS response captured: ${JSON.stringify(body.error).slice(0, 160)} (${url.slice(0, 80)})`);
+      return { error: body.error };
+    }
+    return { body };
+  } catch {
+    return null;
+  }
+}
+
 // ArcGIS's Daily_Ports_Data FeatureServer intermittently returns "Cannot
 // perform query. Invalid query parameters." for otherwise-valid queries —
 // observed in prod 2026-04-20 for BRA/IDN/NGA on per-country WHERE, and
 // also for the global WHERE after the PR #3225 rollout. A single retry with
-// a short back-off clears it in practice. No retry loop — one attempt
-// bounded. Does not retry any other error class.
+// a short back-off clears it in practice for transient single-call flakes,
+// but NOT during upstream degradation episodes where every call returns
+// the same 400 (WM 2026-05-15: ArcGIS Daily_Ports_Data flapped, 30 cold
+// fetches all hit the 400, retry burned ~22 minutes of container budget
+// for zero recoveries).
+//
+// Strategy: keep the one-shot retry for transient flakes, but cap total
+// retries-on-this-error per process at INVALID_PARAMS_RETRY_THRESHOLD.
+// Beyond that, bail-don't-retry — caller treats the country as failed
+// for this run, and cap-mode + stale-serve + multi-tick rotation cover
+// the gap until upstream recovers.
 //
 // IMPORTANT: a 100%-batch-rejected version of this error is NOT a flake —
 // it's an upstream schema-rename or policy change. The 2026-04-29 IMF
 // reserved-keyword sweep flapped `date` → `date_` → `date` within ~9h,
 // which would silently break any seeder using a hardcoded literal twice
 // in the same incident. resolveArcgisDateField introspects the schema at
-// run start to survive the flap; the circuit-breaker below still covers
-// other global-regression classes (renamed table, removed field, policy
-// change) so we don't burn 30s of doomed work per cron tick.
+// run start to survive the flap; the threshold below catches other
+// global-regression classes (renamed table, removed field, policy
+// change, server-side degradation) so we don't burn the container
+// budget on doomed retries.
+let _invalidParamsErrorCount = 0;
 async function fetchWithRetryOnInvalidParams(url, { signal } = {}) {
   try {
     return await fetchWithTimeout(url, { signal });
   } catch (err) {
     const msg = err?.message || '';
     if (!/Invalid query parameters/i.test(msg)) throw err;
+    _invalidParamsErrorCount += 1;
+    if (_invalidParamsErrorCount > INVALID_PARAMS_RETRY_THRESHOLD) {
+      // Degradation signal — caller sees a clear "no retry, run will be
+      // partial" message instead of doubling time-on-task for nothing.
+      throw new Error(`ArcGIS degraded — ${_invalidParamsErrorCount} 'Invalid query parameters' errors in this run, no retry (threshold ${INVALID_PARAMS_RETRY_THRESHOLD})`);
+    }
     await new Promise((r) => setTimeout(r, 500));
     if (signal?.aborted) throw signal.reason ?? err;
-    console.warn(`  [port-activity] retrying after "${msg}": ${url.slice(0, 80)}`);
+    console.warn(`  [port-activity] retrying after "${msg}" (${_invalidParamsErrorCount}/${INVALID_PARAMS_RETRY_THRESHOLD}): ${url.slice(0, 80)}`);
     return await fetchWithTimeout(url, { signal });
   }
+}
+
+// Test-only helper: clears the module-level counter so unit tests can
+// re-exercise the threshold path with different inputs.
+export function _resetInvalidParamsErrorCount() {
+  _invalidParamsErrorCount = 0;
 }
 
 // Fetch ALL ports globally in one paginated pass, grouped by ISO3.

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -136,22 +136,39 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /const captured = await _captureErrorBodyAfterTimeout\(url, signal\)/);
     // If the captured body has an ArcGIS error, surface its message so
     // fetchWithRetryOnInvalidParams's pattern matcher can fire.
-    assert.match(src, /if\s*\(captured\?\.error\)\s*{\s*throw new Error\(`ArcGIS error:/);
+    assert.match(src, /if\s*\(captured\?\.error\)\s*{[\s\S]{0,160}throw new Error\(`ArcGIS error:/);
   });
 
-  it('body capture is gated to once-per-run (proxy budget protection)', () => {
-    // Greptile PR #3681 P2 flagged tight direct+proxy budget under
-    // PER_COUNTRY_TIMEOUT_MS=90s. If every timing-out country paid the
-    // +20s capture cost, the 35s proxy budget would get crowded out.
-    // Gate the capture to fire ONCE per process — we only need the body
-    // shape once for diagnostics + to trip the threshold counter.
-    assert.match(src, /let _bodyCapturedOnceThisRun\s*=\s*false/);
-    // Set BEFORE the await so concurrent timing-out fetches don't all
-    // race past the guard (JS is single-threaded between awaits, but
-    // multiple in-flight fetches can each enter the catch).
-    assert.match(src, /if\s*\(!_bodyCapturedOnceThisRun\)\s*{\s*_bodyCapturedOnceThisRun\s*=\s*true/);
+  it('body capture is bounded by success + attempt caps (PR #3701 P2 round 2)', () => {
+    // Greptile PR #3681 P2 flagged tight direct+proxy budget; PR #3701 P2
+    // round 2 flagged that a failed first capture (the capture also timing
+    // out at +20s during consistent degradation) locked out every future
+    // attempt — diagnostic value lost. Fix: gate on SUCCESS count, bound
+    // ATTEMPTS so we keep trying but don't pay 30×20s in a fully-degraded
+    // run.
+    assert.match(src, /MAX_BODY_CAPTURE_SUCCESSES\s*=\s*1/);
+    assert.match(src, /MAX_BODY_CAPTURE_ATTEMPTS\s*=\s*3/);
+    assert.match(src, /let _bodyCaptureSuccessCount\s*=\s*0/);
+    assert.match(src, /let _bodyCaptureAttemptCount\s*=\s*0/);
+    // Gate uses both counters — successes < cap AND attempts < cap.
+    assert.match(src, /_bodyCaptureSuccessCount\s*<\s*MAX_BODY_CAPTURE_SUCCESSES[\s\S]{0,80}_bodyCaptureAttemptCount\s*<\s*MAX_BODY_CAPTURE_ATTEMPTS/);
+    // Attempt counter increments at the start, success counter only when
+    // we get a body (error or normal). null captures consume an attempt
+    // but not a success, so the next timing-out country can retry.
+    assert.match(src, /_bodyCaptureAttemptCount\s*\+=\s*1/);
+    assert.match(src, /_bodyCaptureSuccessCount\s*\+=\s*1/);
     // Test-only reset helper.
     assert.match(src, /export function _resetBodyCapturedFlag/);
+  });
+
+  it('proxy-confirmed Invalid query parameters short-circuits the retry (PR #3701 P2 round 2)', () => {
+    // arcgisProxyRetry wraps proxy errors with `(via proxy after ${reason})`.
+    // If we hit fetchWithRetryOnInvalidParams with that message, the proxy
+    // has already confirmed the upstream error — retrying would round-trip
+    // direct → proxy → same error, burning budget. Counter still increments
+    // (proxy-confirmed errors are valid degradation signals for the
+    // threshold) but the retry is skipped.
+    assert.match(src, /_invalidParamsErrorCount\s*\+=\s*1;\s*\n[\s\S]{0,800}if\s*\(\/via proxy after\/i\.test\(msg\)\)\s*throw err/);
   });
 
   it('cap-mode bypass requires fresh upstream contact (PR #3701 review P1)', () => {

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -129,7 +129,7 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     // never fires. Diagnostic re-fetch with +20s budget surfaces the body so
     // the circuit-breaker can act on the upstream-degraded signal instead
     // of treating every degraded country as a generic timeout.
-    assert.match(src, /ERROR_BODY_CAPTURE_EXTRA_MS\s*=\s*20_000/);
+    assert.match(src, /ERROR_BODY_CAPTURE_EXTRA_MS\s*=\s*40_000/);
     assert.match(src, /async function _captureErrorBodyAfterTimeout/);
     // fetchWithTimeout calls it on the timeout-like-error path, before
     // routing to proxy.
@@ -168,7 +168,28 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     // direct → proxy → same error, burning budget. Counter still increments
     // (proxy-confirmed errors are valid degradation signals for the
     // threshold) but the retry is skipped.
-    assert.match(src, /_invalidParamsErrorCount\s*\+=\s*1;\s*\n[\s\S]{0,800}if\s*\(\/via proxy after\/i\.test\(msg\)\)\s*throw err/);
+    assert.match(src, /_invalidParamsErrorCount\s*\+=\s*1;[\s\S]{0,2400}if\s*\(\/via proxy after\/i\.test\(msg\)\)\s*throw err/);
+  });
+
+  it('threshold check fires BEFORE proxy-confirmed short-circuit (PR #3701 P1 round 3)', () => {
+    // Pre-fix the proxy-confirmed short-circuit ran first, so during an
+    // incident where every error arrives via proxy (likely — that's the
+    // fallback path), the counter incremented forever but the
+    // "ArcGIS degraded — N errors" message was unreachable.
+    // Right order: increment counter → check threshold (emit degraded
+    // message if exceeded) → only then short-circuit on proxy-confirmed
+    // errors below the threshold.
+    //
+    // Assert by source order: the threshold throw must appear BEFORE the
+    // `via proxy after` short-circuit in fetchWithRetryOnInvalidParams.
+    const thresholdIdx = src.search(/_invalidParamsErrorCount\s*>\s*INVALID_PARAMS_RETRY_THRESHOLD/);
+    const proxyShortCircuitIdx = src.search(/if\s*\(\/via proxy after\/i\.test\(msg\)\)\s*throw err/);
+    assert.ok(thresholdIdx > 0, 'threshold check not found in source');
+    assert.ok(proxyShortCircuitIdx > 0, 'proxy short-circuit not found in source');
+    assert.ok(
+      thresholdIdx < proxyShortCircuitIdx,
+      `threshold check (${thresholdIdx}) must appear before proxy short-circuit (${proxyShortCircuitIdx}) so proxy-confirmed errors still trip the degraded message after N occurrences`,
+    );
   });
 
   it('cap-mode bypass requires fresh upstream contact (PR #3701 review P1)', () => {

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -122,6 +122,53 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /if\s*\(!\/Invalid query parameters\/i\.test\(msg\)\)\s*throw\s+err/);
   });
 
+  it('captures the ArcGIS error body after FETCH_TIMEOUT via diagnostic re-fetch (WM 2026-05-15)', () => {
+    // ArcGIS Daily_Ports_Data, during degradation episodes, returns
+    // HTTP 200 with a 400 error body after 30-56s. The 45s FETCH_TIMEOUT
+    // misses it; the upstream circuit-breaker on /Invalid query parameters/i
+    // never fires. Diagnostic re-fetch with +20s budget surfaces the body so
+    // the circuit-breaker can act on the upstream-degraded signal instead
+    // of treating every degraded country as a generic timeout.
+    assert.match(src, /ERROR_BODY_CAPTURE_EXTRA_MS\s*=\s*20_000/);
+    assert.match(src, /async function _captureErrorBodyAfterTimeout/);
+    // fetchWithTimeout calls it on the timeout-like-error path, before
+    // routing to proxy.
+    assert.match(src, /const captured = await _captureErrorBodyAfterTimeout\(url, signal\)/);
+    // If the captured body has an ArcGIS error, surface its message so
+    // fetchWithRetryOnInvalidParams's pattern matcher can fire.
+    assert.match(src, /if\s*\(captured\?\.error\)\s*{\s*throw new Error\(`ArcGIS error:/);
+  });
+
+  it('body capture is gated to once-per-run (proxy budget protection)', () => {
+    // Greptile PR #3681 P2 flagged tight direct+proxy budget under
+    // PER_COUNTRY_TIMEOUT_MS=90s. If every timing-out country paid the
+    // +20s capture cost, the 35s proxy budget would get crowded out.
+    // Gate the capture to fire ONCE per process — we only need the body
+    // shape once for diagnostics + to trip the threshold counter.
+    assert.match(src, /let _bodyCapturedOnceThisRun\s*=\s*false/);
+    // Set BEFORE the await so concurrent timing-out fetches don't all
+    // race past the guard (JS is single-threaded between awaits, but
+    // multiple in-flight fetches can each enter the catch).
+    assert.match(src, /if\s*\(!_bodyCapturedOnceThisRun\)\s*{\s*_bodyCapturedOnceThisRun\s*=\s*true/);
+    // Test-only reset helper.
+    assert.match(src, /export function _resetBodyCapturedFlag/);
+  });
+
+  it('bail-don\'t-retry on >5 Invalid query parameters errors per run (degradation signal)', () => {
+    // WM 2026-05-15 degradation: 30 cold fetches all hit the same 400,
+    // retry burned ~22 minutes of container budget for zero recoveries.
+    // Threshold preserves the legit transient-flake retry while protecting
+    // budget during global degradation.
+    assert.match(src, /INVALID_PARAMS_RETRY_THRESHOLD\s*=\s*5/);
+    assert.match(src, /let _invalidParamsErrorCount\s*=\s*0/);
+    // Counter increments + threshold check + bail-don't-retry path:
+    assert.match(src, /_invalidParamsErrorCount\s*\+=\s*1/);
+    assert.match(src, /if\s*\(_invalidParamsErrorCount\s*>\s*INVALID_PARAMS_RETRY_THRESHOLD\)/);
+    assert.match(src, /ArcGIS degraded — \${_invalidParamsErrorCount} 'Invalid query parameters'/);
+    // Test-only reset helper for re-exercising the threshold in unit tests.
+    assert.match(src, /export function _resetInvalidParamsErrorCount/);
+  });
+
   it('both EP3 + EP4 paginators route through fetchWithRetryOnInvalidParams', () => {
     const matches = src.match(/fetchWithRetryOnInvalidParams\(/g) ?? [];
     // Called in: fetchAllPortRefs (EP4), fetchCountryAccum (EP3). 2+ usages.

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -154,6 +154,40 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /export function _resetBodyCapturedFlag/);
   });
 
+  it('cap-mode bypass requires fresh upstream contact (PR #3701 review P1)', () => {
+    // Pre-fix the cap-mode bypass was unconditional: any countryData.size
+    // ≥ MIN_VALID_COUNTRIES + capTriggered = bypass, even if ALL entries
+    // were stale-served prior-run data. That meant an "ArcGIS completely
+    // down" run with freshFetched=0 + cacheHits=0 + servedStale=27 could
+    // shrink the canonical list from ~174 → 27 stale-only entries and
+    // advance seed-meta as healthy — hiding the outage from operators.
+    // Fix: gate bypass on freshFetched + cacheHits ≥ floor.
+    assert.match(src, /MIN_FRESH_FETCH_FOR_CAP_BYPASS\s*=\s*5/);
+    // Counter is tracked in fetchAll's fetched-fresh path:
+    assert.match(src, /let freshFetchedCount\s*=\s*0/);
+    assert.match(src, /freshFetchedCount\+\+/);
+    // Counts are surfaced out of fetchAll:
+    assert.match(src, /freshFetchedCount,[\s\n]+cacheHitCount: cacheHits/);
+    // main() gates the bypass on the combined fresh upstream contact:
+    assert.match(src, /const upstreamContactCount = freshFetchedCount \+ cacheHitCount/);
+    assert.match(src, /const capBypassEarned = capTriggered && upstreamContactCount >= MIN_FRESH_FETCH_FOR_CAP_BYPASS/);
+    // When cap-mode is triggered but bypass NOT earned, refuse to publish
+    // a stale-only set and fall through to the 80% guard (which will fire
+    // and extendExistingTtl).
+    assert.match(src, /CAP-MODE BYPASS REFUSED/);
+  });
+
+  it('inter-batch sleep is abort-aware (PR #3701 review P2)', () => {
+    // Pre-fix the 5s batch backoff used plain `setTimeout` that ignored
+    // the caller signal mid-sleep, so a SIGTERM during the 5s wait still
+    // forced the full 5s before observing the abort. Fix: race the
+    // setTimeout against signal's abort event so the loop exits
+    // immediately on a real cancellation.
+    assert.match(src, /const timer = setTimeout\(resolve, BATCH_BACKOFF_MS\)/);
+    assert.match(src, /signal\.addEventListener\('abort', onAbort/);
+    assert.match(src, /clearTimeout\(timer\)/);
+  });
+
   it('bail-don\'t-retry on >5 Invalid query parameters errors per run (degradation signal)', () => {
     // WM 2026-05-15 degradation: 30 cold fetches all hit the same 400,
     // retry burned ~22 minutes of container budget for zero recoveries.
@@ -198,7 +232,10 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     // aborted signal `break`s the loop entirely (Greptile PR #3694 P2).
     assert.match(src, /if\s*\(\s*signal\?\.aborted\s*\)\s*break/);
     assert.match(src, /if\s*\(\s*batchIdx\s*<\s*batches\s*\)/);
-    assert.match(src, /setTimeout\(r,\s*BATCH_BACKOFF_MS\)/);
+    // PR #3701 review P2: the sleep itself races against signal.aborted
+    // so a mid-sleep SIGTERM exits the wait immediately instead of
+    // forcing the full BATCH_BACKOFF_MS.
+    assert.match(src, /setTimeout\(resolve,\s*BATCH_BACKOFF_MS\)/);
   });
 
   it('MIN_VALID_COUNTRIES is temporarily lowered to 25 (ArcGIS degraded)', () => {
@@ -223,12 +260,13 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /capTriggered,\s*\n\s*servedStaleCount,/);
     assert.match(src, /droppedTooOldCount,/);
     assert.match(src, /droppedNoCacheCount,/);
-    // main() must read those fields off the fetchAll result
-    assert.match(src, /capTriggered,\s*\n\s*servedStaleCount,\s*\n\s*droppedTooOldCount,\s*\n\s*droppedNoCacheCount,\s*\n\s*\}\s*=\s*await fetchAll/);
-    // The guard branch must be wrapped in `if (capTriggered) {} else if (...)`
-    // so cap-mode runs SKIP the guard entirely (not just log a warning and
-    // then still fall through to the guard).
-    assert.match(src, /if\s*\(\s*capTriggered\s*\)\s*\{[\s\S]+?PARTIAL PUBLISH \(cap-mode\)[\s\S]+?\}\s*else if\s*\(\s*prevCount\s*>\s*0\s*&&\s*countryData\.size\s*<\s*prevCount\s*\*\s*0\.8\s*\)/);
+    // main() must read those fields off the fetchAll result (plus the
+    // PR #3701 review P1 additions: freshFetchedCount + cacheHitCount).
+    assert.match(src, /capTriggered,\s*\n\s*servedStaleCount,\s*\n\s*droppedTooOldCount,\s*\n\s*droppedNoCacheCount,\s*\n\s*freshFetchedCount,\s*\n\s*cacheHitCount,\s*\n\s*\}\s*=\s*await fetchAll/);
+    // The earned-bypass branch (PR #3701 review P1) must lead to the
+    // PARTIAL PUBLISH log; falling through to the 80%-degradation-guard
+    // branch is the silent-loss protection.
+    assert.match(src, /if\s*\(\s*capBypassEarned\s*\)\s*\{[\s\S]+?PARTIAL PUBLISH \(cap-mode\)/);
   });
 
   it('cap-mode partial publish logs operator-visible bucket counts', () => {
@@ -244,25 +282,27 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
   });
 
   it('non-cap-mode runs still enforce the 80% degradation guard (silent-loss protection)', () => {
-    // The bypass MUST only fire when capTriggered. A run where
+    // The bypass MUST only fire when capTriggered AND the cap-mode bypass
+    // has been earned (sufficient fresh upstream contact). A run where
     // needsFetch.length ≤ MAX_COLD_FETCH_PER_RUN (normal happy path) must
     // still apply the 80% guard so an ArcGIS schema regression that
     // silently drops 100 → 50 countries can't sneak through as a publish.
     //
-    // Assert by structure: the else-if branch contains the prevCount × 0.8
-    // comparison and a DEGRADATION GUARD error+return, AND the comparison
-    // is INSIDE the else-if condition (not in a separate unconditional
-    // check before it that would bypass the else-if scoping).
-    assert.match(src, /else if\s*\([\s\S]{0,200}prevCount\s*\*\s*0\.8[\s\S]{0,200}\)\s*\{[\s\S]{0,400}DEGRADATION GUARD/);
-    // Ensure the 0.8 threshold appears exactly twice (once in the
-    // condition, once in the error message's `Math.ceil(prevCount * 0.8)`
-    // suggestion) — both inside the else-if scope. A third occurrence
-    // would suggest a duplicated check leaked outside the bypass.
+    // Assert by structure: a DEGRADATION GUARD error+return follows the
+    // prevCount × 0.8 comparison.
+    assert.match(src, /prevCount\s*\*\s*0\.8[\s\S]{0,400}DEGRADATION GUARD/);
+    // PR #3701 review P1 introduces a SECOND 80%-guard branch inside the
+    // `capTriggered && !capBypassEarned` block (cap-mode without enough
+    // fresh upstream contact also falls back to the 80% guard). So the
+    // threshold now appears in two condition + two Math.ceil sites = 4.
+    // More than 4 would imply a duplicated check leaked outside the
+    // guard scoping.
     const matches = src.match(/prevCount\s*\*\s*0\.8/g) ?? [];
     assert.equal(
       matches.length,
-      2,
-      `expected exactly 2 prevCount × 0.8 references (condition + error-msg suggestion), found ${matches.length}`,
+      4,
+      `expected exactly 4 prevCount × 0.8 references (2 conditions + 2 Math.ceil error-msg suggestions, ` +
+      `one set per guard branch — cap-mode-without-bypass-earned + non-cap-mode), found ${matches.length}`,
     );
   });
 


### PR DESCRIPTION
## Summary

ArcGIS Daily_Ports_Data, during degradation episodes, returns **HTTP 200 with a 400 error body** (`Cannot perform query. Invalid query parameters.`) after 30-56s of server processing. Our 45s `FETCH_TIMEOUT` fires before the body lands → caller sees `AbortError` → the existing circuit-breaker that pattern-matches the error message never fires → we treat every degraded country as a generic timeout → proxy retry against the same degraded upstream → also fails → fetchWithRetryOnInvalidParams burns another full 45s on a doomed direct retry.

Investigation that drove this (WM 2026-05-15): direct `curl` probes against `services9.arcgis.com` revealed (a) HTTP 200 with a 400 error body taking 30-56s to return, (b) non-deterministic results across attempts within minutes — same query, ERR → OK → ERR → 504, (c) WHERE-clause reshaping helps unevenly but never reliably. Right frame: **upstream is degraded, surface it and protect the container budget**, not "we're being rate-limited."

Two surgical fixes:

1. **Diagnostic body-capture on timeout** — when direct fetch hits its FETCH_TIMEOUT (not a caller-signal abort), make ONE extra fetch with +20s budget purely to read the response body. If it contains `body.error`, throw with the real ArcGIS message so the upstream circuit-breaker can act on the upstream-degradation signal. **Gated to fire once per process** — the proxy budget Greptile P2'd on #3681 stays intact for subsequent timeouts.

2. **Bail-don't-retry threshold on "Invalid query parameters"** — preserves the legit one-shot retry for transient single-call flakes (2026-04-20 BRA/IDN/NGA pattern), but caps total retries-on-this-error per process at 5. Beyond that, throws a clear `ArcGIS degraded — N errors` message so the operator sees the regression class instead of N identical retries × 45s burning the 540s container budget.

The existing cap-mode + stale-serve + temp-gate-25 logic (PRs #3676/#3681/#3694) already rides through partial coverage — these changes just make sure we don't waste the container budget while ArcGIS recovers, and that the next diagnostic round has the **real error message** instead of generic AbortError.

## Test plan

- [x] `npm run test:data` — 8803/8803 pass (96/96 in the focused portwatch test file, was 93)
- [x] `npm run typecheck` + `npm run typecheck:api` — pass
- [x] `npm run lint` — no new diagnostics (235 warnings pre-existing on `origin/main`)
- [x] `node --test tests/edge-functions.test.mjs` — 185/185 pass
- [x] `npm run version:check` — pass
- [x] 3 new structural pattern-match tests covering: `ERROR_BODY_CAPTURE_EXTRA_MS=20_000`, `_captureErrorBodyAfterTimeout` helper, once-per-run gating (`_bodyCapturedOnceThisRun`), `INVALID_PARAMS_RETRY_THRESHOLD=5`, counter increment + threshold check + `_resetInvalidParamsErrorCount` / `_resetBodyCapturedFlag` reset helpers
- [ ] Watch UptimeRobot post-merge: should see either (a) the real "Invalid query parameters" message in `seed-portwatch-port-activity` logs once per run (capture fired) AND/OR `ArcGIS degraded — N 'Invalid query parameters' errors in this run` after 5 such errors, instead of the current generic per-country timeout cascade
- [ ] Once ArcGIS recovers, expect the degradation message to disappear; if it persists, that's the signal to investigate further upstream (publisher contact, alternate dataset, etc.)