### PR TITLE
fix(watchlist): address #3698 review — UA header, server cache, clear() invalidation

### DIFF
--- a/api/symbol-search.ts
+++ b/api/symbol-search.ts
@@ -21,6 +21,8 @@ import { checkRateLimit } from './_rate-limit.js';
 import { jsonResponse } from './_json-response.js';
 // @ts-expect-error — JS module, no declaration file
 import { captureSilentError } from './_sentry-edge.js';
+// @ts-expect-error — JS module, no declaration file
+import { readRawJsonFromUpstash, setCachedData } from './_upstash-json.js';
 
 interface FinnhubSearchResult {
   symbol?: string;
@@ -37,6 +39,20 @@ export interface SymbolSearchResult {
 
 const MAX_RESULTS = 12;
 const UPSTREAM_TIMEOUT_MS = 8_000;
+// Shared cache for the symbol-search results. The Finnhub free-tier quota
+// (60/min) is per-key, NOT per-user — client-side debounce only protects
+// each tab. Without a server cache, two concurrent users typing the same
+// query (or one user typing across two tabs) can race to exhaust the
+// shared quota. Symbol→company mappings are stable; a 10-minute TTL is
+// a comfortable margin. Empty results are cached too, so a typo query
+// can't repeatedly hammer Finnhub.
+const CACHE_KEY_PREFIX = 'symsearch:v1:';
+const CACHE_TTL_SECONDS = 600;
+// Honest UA identifying ourselves to Finnhub. The AGENTS.md Critical
+// Conventions section requires UA on server-side fetches; matches the
+// `worldmonitor-edge/1.0` convention used by api/notify.ts and
+// api/notification-channels.ts.
+const FETCH_USER_AGENT = 'worldmonitor-edge/1.0';
 
 // Finnhub `type` values worth offering in the watchlist editor. Finnhub also
 // returns crypto, FX, bonds, warrants, etc. — excluding those keeps the
@@ -105,10 +121,26 @@ export default async function handler(
     return jsonResponse({ error: 'SYMBOL_SEARCH_UNAVAILABLE' }, 503, cors);
   }
 
+  // Normalize query for the cache key — case-insensitive, whitespace-folded.
+  // The Finnhub upstream is case-insensitive, so 'NVDA', 'nvda', '  nvda '
+  // all yield the same result set; share one cache entry.
+  const cacheKey = CACHE_KEY_PREFIX + q.toLowerCase().replace(/\s+/g, ' ');
+
+  // Cache-first. A miss / Upstash hiccup / decode failure all fall through
+  // to Finnhub — the cache is best-effort, never load-bearing.
+  try {
+    const cached = await readRawJsonFromUpstash(cacheKey);
+    if (cached && typeof cached === 'object' && Array.isArray((cached as { results?: unknown }).results)) {
+      return jsonResponse(cached, 200, cors);
+    }
+  } catch {
+    // Treat Upstash unavailability as a cache miss; do not 5xx the user.
+  }
+
   try {
     const url = `https://finnhub.io/api/v1/search?q=${encodeURIComponent(q)}&token=${encodeURIComponent(apiKey)}`;
     const resp = await fetch(url, {
-      headers: { Accept: 'application/json' },
+      headers: { Accept: 'application/json', 'User-Agent': FETCH_USER_AGENT },
       signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
     });
     if (!resp.ok) {
@@ -126,7 +158,17 @@ export default async function handler(
     }
     const data = (await resp.json()) as { result?: FinnhubSearchResult[] };
     const results = mapFinnhubResults(Array.isArray(data.result) ? data.result : []);
-    return jsonResponse({ results }, 200, cors);
+    const payload = { results };
+
+    // Fire-and-forget write — never block the response on the cache fill.
+    // Use ctx.waitUntil when Vercel provides it (keeps the function alive
+    // until the SET completes); fall back to bare `void` for environments
+    // (tests, local invokes) that don't pass ctx.
+    const writePromise = setCachedData(cacheKey, payload, CACHE_TTL_SECONDS).catch(() => false);
+    if (ctx) ctx.waitUntil(writePromise);
+    else void writePromise;
+
+    return jsonResponse(payload, 200, cors);
   } catch (err) {
     console.error('[symbol-search] error:', err);
     captureSilentError(err, {

--- a/api/symbol-search.ts
+++ b/api/symbol-search.ts
@@ -3,10 +3,13 @@
  *
  * GET /api/symbol-search?q=<query>  → { results: [{ symbol, name, display }] }
  *
- * Thin passthrough to Finnhub's symbol-search endpoint. Used by every user
- * (the market watchlist is not a PRO feature), so there is no entitlement
- * gate — just CORS + rate limiting. The client debounces keystrokes, so
- * Finnhub's free-tier quota (60 req/min) is not a concern in practice.
+ * Thin Finnhub-search wrapper with a short Upstash cache. Used by every user
+ * (the market watchlist is not a PRO feature), so there's no entitlement
+ * gate — just CORS + rate limiting + a 10-minute cache on the normalized
+ * query. The cache is the real quota guard: Finnhub's free-tier 60/min is
+ * per-key (shared across all users), not per-user, so client-side debounce
+ * alone wouldn't protect it. The cache is best-effort — any Upstash hiccup
+ * falls through to a direct Finnhub call.
  */
 
 export const config = { runtime: 'edge' };

--- a/src/components/WatchlistEditor.ts
+++ b/src/components/WatchlistEditor.ts
@@ -108,9 +108,15 @@ export class WatchlistEditor {
 
   /** Reset to an empty watchlist (the modal's Reset button). */
   public clear(): void {
+    // Invalidate any in-flight search before wiping state — otherwise a
+    // debounce timer that has already fired (but whose searchSymbols
+    // response is still pending) can repopulate the dropdown after clear.
+    // Bumping searchSeq makes the runSearch completion path drop the result.
+    this.cancelPendingSearch();
     this.entries = [];
     this.input.value = '';
     this.results = [];
+    this.highlight = -1;
     this.hideDropdown();
     this.renderChips();
   }
@@ -120,8 +126,18 @@ export class WatchlistEditor {
   }
 
   public destroy(): void {
+    this.cancelPendingSearch();
+  }
+
+  /** Cancels both the debounced timer AND any in-flight runSearch via the
+   * sequence guard, then clears the loading flag. Used by clear() and
+   * destroy() so a search that was kicked off seconds before reset/teardown
+   * cannot render results into a stale editor. */
+  private cancelPendingSearch(): void {
     if (this.debounceTimer) clearTimeout(this.debounceTimer);
     this.debounceTimer = null;
+    this.searchSeq++;
+    this.loading = false;
   }
 
   // ── search ──────────────────────────────────────────────────────────────

--- a/tests/symbol-search.test.mts
+++ b/tests/symbol-search.test.mts
@@ -15,6 +15,8 @@ process.env.WORLDMONITOR_VALID_KEYS = TEST_KEY;
 afterEach(() => {
   globalThis.fetch = originalFetch;
   delete process.env.FINNHUB_API_KEY;
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
 });
 
 function makeReq(q?: string, method = 'GET'): Request {
@@ -74,11 +76,14 @@ describe('mapFinnhubResults', () => {
 });
 
 describe('symbol-search handler', () => {
-  it('returns mapped Finnhub results for a query', async () => {
+  it('returns mapped Finnhub results for a query, with our User-Agent', async () => {
     process.env.FINNHUB_API_KEY = 'test-key';
     let requestedUrl = '';
-    globalThis.fetch = (async (input: RequestInfo | URL) => {
+    let requestedUA: string | null = null;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       requestedUrl = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const h = new Headers(init?.headers ?? {});
+      requestedUA = h.get('User-Agent');
       return new Response(
         JSON.stringify({ count: 1, result: [{ symbol: 'NVDA', displaySymbol: 'NVDA', description: 'NVIDIA CORP', type: 'Common Stock' }] }),
         { status: 200 },
@@ -88,6 +93,9 @@ describe('symbol-search handler', () => {
     const res = await handler(makeReq('nvidia'));
     assert.equal(res.status, 200);
     assert.match(requestedUrl, /finnhub\.io\/api\/v1\/search\?q=nvidia&token=test-key/);
+    // AGENTS.md Critical Conventions: "Always include User-Agent header in
+    // server-side fetch calls". Reviewer P1 on PR #3698.
+    assert.equal(requestedUA, 'worldmonitor-edge/1.0');
     const body = await res.json() as { results: unknown };
     assert.deepEqual(body.results, [{ symbol: 'NVDA', name: 'NVIDIA CORP', display: 'NVDA' }]);
   });
@@ -125,5 +133,103 @@ describe('symbol-search handler', () => {
   it('rejects non-GET methods', async () => {
     const res = await handler(makeReq('x', 'POST'));
     assert.equal(res.status, 405);
+  });
+
+  // ── shared Upstash cache (reviewer P2) ─────────────────────────────────
+  //
+  // Per-client debounce only protects each tab — the Finnhub 60/min quota
+  // is shared across all users. The handler reads a short Upstash cache
+  // before calling Finnhub, and writes successful results back. Both paths
+  // are tested here against a URL-routed fetch mock.
+
+  // `checkRateLimit` shares the same UPSTASH_* env vars as our cache, so
+  // enabling Upstash for these tests also activates the rate limiter. The
+  // catch-all branch below returns a permissive shape for ANY Upstash URL
+  // we didn't specifically route (the rate-limiter scripts / eval paths),
+  // so it always says "allow".
+  function permissiveUpstashCatchAll(): Response {
+    return new Response(
+      JSON.stringify({ result: [1, 600, 599, Date.now() + 60_000] }),
+      { status: 200 },
+    );
+  }
+
+  it('serves a cache hit from Upstash without calling Finnhub', async () => {
+    process.env.FINNHUB_API_KEY = 'test-key';
+    process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.test';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'upstash-tok';
+
+    const cachedPayload = { results: [{ symbol: 'GLW', name: 'Corning Inc', display: 'GLW' }] };
+    let finnhubCalls = 0;
+
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.startsWith('https://upstash.test/get/symsearch')) {
+        // Upstash returns the JSON-stringified value under `.result`.
+        return new Response(JSON.stringify({ result: JSON.stringify(cachedPayload) }), { status: 200 });
+      }
+      if (url.includes('finnhub.io')) {
+        finnhubCalls++;
+        return new Response('should not be called', { status: 500 });
+      }
+      if (url.startsWith('https://upstash.test')) return permissiveUpstashCatchAll();
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    const res = await handler(makeReq('glw'));
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), cachedPayload);
+    assert.equal(finnhubCalls, 0, 'cache hit must not hit Finnhub');
+  });
+
+  it('on cache miss, calls Finnhub and writes the result back to Upstash', async () => {
+    process.env.FINNHUB_API_KEY = 'test-key';
+    process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.test';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'upstash-tok';
+
+    let finnhubCalls = 0;
+    let setCalls = 0;
+    let setBody: string | null = null;
+    let getKey: string | null = null;
+
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      if (url.startsWith('https://upstash.test/get/symsearch')) {
+        getKey = decodeURIComponent(url.slice('https://upstash.test/get/'.length));
+        return new Response(JSON.stringify({ result: null }), { status: 200 }); // miss
+      }
+      // setCachedData posts a SET-bearing pipeline; identify it by body
+      // shape so we don't conflate with rate-limiter pipeline calls.
+      if (url === 'https://upstash.test/pipeline' && typeof init?.body === 'string' && init.body.includes('symsearch:v1:')) {
+        setCalls++;
+        setBody = init.body;
+        return new Response(JSON.stringify([{ result: 'OK' }]), { status: 200 });
+      }
+      if (url.includes('finnhub.io')) {
+        finnhubCalls++;
+        return new Response(
+          JSON.stringify({ count: 1, result: [{ symbol: 'GLW', displaySymbol: 'GLW', description: 'Corning Inc', type: 'Common Stock' }] }),
+          { status: 200 },
+        );
+      }
+      if (url.startsWith('https://upstash.test')) return permissiveUpstashCatchAll();
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as typeof fetch;
+
+    // Pass a stub ctx so the cache-write runs synchronously enough to assert.
+    const writePromises: Array<Promise<unknown>> = [];
+    const res = await handler(makeReq('glw'), { waitUntil: (p) => writePromises.push(p) });
+    await Promise.all(writePromises);
+
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { results: [{ symbol: 'GLW', name: 'Corning Inc', display: 'GLW' }] });
+    assert.equal(finnhubCalls, 1, 'cache miss must hit Finnhub once');
+    assert.equal(setCalls, 1, 'successful Finnhub result must be written to Upstash');
+    // The cache key is normalized (lowercase, whitespace-folded) so 'GLW',
+    // 'glw', and '  GLW ' all share one entry.
+    assert.equal(getKey, 'symsearch:v1:glw');
+    // Sanity-check the SET command shape.
+    assert.match(setBody ?? '', /"SET","symsearch:v1:glw"/);
+    assert.match(setBody ?? '', /"EX","600"/);
   });
 });


### PR DESCRIPTION
## What

Three findings from the review on PR #3698 at commit dfcb9dc7. All three are real; this PR addresses them.

### P1 — `api/symbol-search.ts`: missing User-Agent

Finnhub fetch was sending only `Accept`, no `User-Agent`. `AGENTS.md` Critical Conventions explicitly require UA on server-side fetches. Now sends `worldmonitor-edge/1.0` (matches `api/notify.ts` and `api/notification-channels.ts`). The happy-path test asserts the header.

### P2 — `api/symbol-search.ts`: no server cache, shared Finnhub quota at risk

Every keystroke (post-debounce) hit Finnhub directly. The 60/min free-tier quota is **per-key (shared)**, not per-user — concurrent users could exhaust it and trigger 503 / empty results for everyone. Per-client debounce only protects each tab.

Added a short Upstash cache via the existing `_upstash-json` helpers:

- **Key:** `symsearch:v1:<normalized-lowercase-query>` (whitespace-folded, so `NVDA`, `nvda`, `  NVDA ` share one entry).
- **TTL:** 10 minutes — symbol→company mappings are stable.
- **Writes** are fire-and-forget via `ctx.waitUntil` when Vercel provides it; bare `void` otherwise. The cache is best-effort, never load-bearing — any Upstash hiccup falls through to Finnhub.
- **Coalescing/gating** skipped per the "ideally" qualifier in the review; can land as a follow-up if Sentry shows quota pressure.

### P3 — `WatchlistEditor.ts`: `clear()` / `destroy()` didn't invalidate in-flight searches

A debounced search that had already fired (but whose `searchSymbols` response was still pending) could repopulate the dropdown *after* Reset / unmount. Extracted `cancelPendingSearch()` that clears the debounce timer, bumps `searchSeq` (so `runSearch`'s sequence guard drops the late result), and clears `loading`. Both `clear()` and `destroy()` now call it.

## Test plan

- [x] `npm run typecheck` + `typecheck:api` — PASS
- [x] `npm run lint:api-contract` — PASS (98 api/ files, 64 manifest entries clean)
- [x] esbuild bundle check on the updated edge fn — PASS
- [x] `npm run test:data` — PASS, 8802/8802
- [x] New: UA assertion on the happy-path Finnhub test
- [x] New: cache-hit short-circuit test (Upstash GET returns cached payload → handler returns 200 without hitting Finnhub)
- [x] New: cache-miss + write-through test (Upstash GET null → Finnhub called → SET pipeline observed with `symsearch:v1:` prefix + `EX 600`)
- [ ] Manual on preview: open Edit Watchlist, type a query, confirm it works; click Reset mid-search and confirm dropdown doesn't repopulate.

## Notes

Branched fresh off `main` (which now contains the merged #3698) — these are pure follow-up fixes, no other scope creep.