### PR TITLE
fix(brief): handle publisher-naming variants in stripHeadlineSuffix (DOJ / Bulletin)

### DIFF
--- a/scripts/lib/brief-compose.mjs
+++ b/scripts/lib/brief-compose.mjs
@@ -273,6 +273,162 @@ function isPublisherWordPrefix(tail, publisher) {
   return publisher.startsWith(tail + ' ');
 }
 
+// ── Layer 2 helpers (publisher-naming variants) ───────────────────────────
+//
+// Layer 1's strict word-prefix test misses three structural classes of
+// variant between the headline-suffix's publisher form and the configured
+// `source` field. All three observed live on the May 15 brief:
+//   1. Article insertion — tail "Bulletin of the Atomic Scientists"
+//      vs source "Bulletin of Atomic Scientists" (the/no-the).
+//   2. Trailing wire-suffix word — tail "BBC News" vs source "BBC".
+//   3. Abbreviation ↔ long-form — tail "Department of Justice (.gov)"
+//      vs source "DOJ".
+//
+// Layer 2 adds two source-aware paths after Layer 1:
+//   Path 2a — `normalizePublisher` on both sides + the same asymmetric
+//             prefix test (handles classes 1, 2, 3).
+//   Path 2b — acronym-shape-gated initials equivalence using a separate
+//             `tailForInitials` (handles class 3 when source is an
+//             explicit ALL-CAPS acronym like DOJ/NPR/AP/BBC).
+//
+// No source-blind layer. Considered and rejected on Codex review —
+// integrity risk (feed-controlled text could force user-visible
+// truncation). See docs/plans/2026-05-15-001-fix-headline-suffix-strip-
+// publisher-naming-variants-plan.md for the full rationale.
+
+const ARTICLE_TOKENS = new Set(['the', 'a']);
+
+// Wire-suffix tokens stripped ONLY from the trailing position of a
+// normalised publisher. Iteratively from the end, never from leading
+// or middle positions — stripping globally would corrupt names like
+// "Daily Mail", "News Corp", "Press TV", "The Press Democrat".
+const WIRE_SUFFIX_TOKENS = new Set([
+  'news', 'online', 'press', 'wire', 'daily', 'weekly',
+]);
+
+// Connector words allowed inside a publisher-shape tail. Lowercase
+// exact match (case-insensitive on the lowercased token).
+const PUBLISHER_CONNECTOR_TOKENS = new Set([
+  'of', 'the', 'and', 'du', 'de', 'le', 'la', 'el', 'al', 'in', 'for',
+]);
+
+// Title-Case token: starts with an uppercase letter, then word chars or
+// apostrophe/hyphen. Accepts "BBC", "O'Reilly", "Al-Jazeera", "News".
+const TITLE_CASE_TOKEN_RE = /^[A-Z][\w'-]*$/;
+// Trailing domain paren: " (.gov)", " (.org)", " (.com)", " (.io)" etc.
+const DOMAIN_PAREN_TRAILING_RE = /\s*\(\.\w{2,4}\)\s*$/;
+// Explicit acronym shape on the ORIGINAL configured publisher field —
+// 1-5 all-uppercase letters, no spaces. Matching on the unaltered
+// field is what prevents Title-Case 4-char names like "Time"/"Wired"
+// from accidentally activating the initials path.
+const PUBLISHER_ACRONYM_RE = /^[A-Z]{1,5}$/;
+
+/**
+ * Normalise a publisher-name string for the asymmetric prefix test in
+ * Path 2a. Lowercases, strips trailing domain paren, removes article
+ * words from any position, removes wire-suffix words ONLY from the
+ * trailing position iteratively, then strips non-alphanumerics per
+ * token.
+ *
+ * Trailing-only suffix-strip is load-bearing: stripping `news` / `press`
+ * / `daily` from leading or middle positions would corrupt names like
+ * "Daily Mail", "News Corp", "Press TV", "The Press Democrat".
+ *
+ * Used ONLY in Path 2a. Path 2b's initials test uses tailForInitials()
+ * which preserves wire-suffix words — the `Press` in "Associated Press"
+ * must survive to count toward the AP initials.
+ *
+ * @param {unknown} s
+ * @returns {string}
+ */
+function normalizePublisher(s) {
+  if (typeof s !== 'string') return '';
+  const trimmed = s.trim().toLowerCase();
+  if (trimmed.length === 0) return '';
+  const stripped = trimmed.replace(DOMAIN_PAREN_TRAILING_RE, '');
+  let tokens = stripped
+    .split(/\s+/)
+    .filter((t) => t.length > 0 && !ARTICLE_TOKENS.has(t));
+  while (tokens.length > 0 && WIRE_SUFFIX_TOKENS.has(tokens[tokens.length - 1])) {
+    tokens.pop();
+  }
+  tokens = tokens
+    .map((t) => t.replace(/[^a-z0-9]/g, ''))
+    .filter((t) => t.length > 0);
+  return tokens.join(' ');
+}
+
+/**
+ * Tail normalisation for the initials path (Path 2b). Same as
+ * normalizePublisher MINUS the wire-suffix strip — distinct because
+ * "Associated Press" must keep `press` so initialsOf yields `ap`, not
+ * just `a`. Reusing normalizePublisher here would corrupt the
+ * Associated Press → AP / National Public Radio → NPR cases.
+ *
+ * @param {unknown} s
+ * @returns {string}
+ */
+function tailForInitials(s) {
+  if (typeof s !== 'string') return '';
+  const trimmed = s.trim().toLowerCase();
+  if (trimmed.length === 0) return '';
+  const stripped = trimmed.replace(DOMAIN_PAREN_TRAILING_RE, '');
+  const tokens = stripped
+    .split(/\s+/)
+    .filter((t) => t.length > 0 && !ARTICLE_TOKENS.has(t))
+    .map((t) => t.replace(/[^a-z0-9]/g, ''))
+    .filter((t) => t.length > 0);
+  return tokens.join(' ');
+}
+
+/**
+ * First letter of each whitespace-separated token, joined and
+ * lowercased, alpha only. Returns '' for empty or all-non-alpha input.
+ *
+ * @param {string} s
+ * @returns {string}
+ */
+function initialsOf(s) {
+  if (typeof s !== 'string' || s.length === 0) return '';
+  return s
+    .split(/\s+/)
+    .map((t) => (t.length > 0 ? t[0] : ''))
+    .filter((c) => /^[a-z]$/i.test(c))
+    .join('')
+    .toLowerCase();
+}
+
+/**
+ * "Looks like a publisher attribution" shape check on the original tail
+ * (post domain-paren strip, pre other normalisation). Every token must
+ * be either Title-Case (matches TITLE_CASE_TOKEN_RE) OR a permitted
+ * lowercase connector. Token cap of 8 keeps the function focused on
+ * filtering editorial fragments, not enforcing publisher length.
+ *
+ * Used in Path 2b as the second of two gates on the initials path; the
+ * first gate is the all-uppercase acronym check on the original
+ * publisher field. Together they block both editorial-text false
+ * positives (lowercase tokens fail this gate) and ordinary-Title-Case-
+ * publisher false positives (`Time`/`Wired` configured as source fail
+ * the acronym gate).
+ *
+ * @param {unknown} s
+ * @returns {boolean}
+ */
+function looksLikePublisherShape(s) {
+  if (typeof s !== 'string') return false;
+  const stripped = s.trim().replace(DOMAIN_PAREN_TRAILING_RE, '');
+  if (stripped.length === 0) return false;
+  const tokens = stripped.split(/\s+/);
+  if (tokens.length === 0 || tokens.length > 8) return false;
+  for (const tok of tokens) {
+    if (TITLE_CASE_TOKEN_RE.test(tok)) continue;
+    if (PUBLISHER_CONNECTOR_TOKENS.has(tok.toLowerCase())) continue;
+    return false;
+  }
+  return true;
+}
+
 /**
  * @param {string} title
  * @param {string} publisher
@@ -285,17 +441,43 @@ export function stripHeadlineSuffix(title, publisher) {
   const m = trimmed.match(HEADLINE_SUFFIX_RE_PART);
   if (!m) return trimmed;
   const tail = m[1].trim();
-  // Case-insensitive equality OR ASYMMETRIC word-boundary prefix: tail
-  // must be a SHORTER prefix of publisher (Reuters → Reuters World),
-  // never the reverse. The asymmetry is intentional and load-bearing —
-  // it blocks editorial suffixes like "AP News analysis" (tail) from
-  // stripping when publisher is "AP News" (Greptile PR #3673 review).
-  // A tail that merely CONTAINS the publisher (e.g. "- AP News
-  // analysis") still stays — that's editorial content, not a wire
-  // suffix. Full asymmetry rationale documented on
-  // `isPublisherWordPrefix` itself.
-  if (!isPublisherWordPrefix(tail.toLowerCase(), publisher.toLowerCase())) return trimmed;
-  return trimmed.slice(0, m.index).trimEnd();
+  const stripped = trimmed.slice(0, m.index).trimEnd();
+  // Layer 1: existing strict asymmetric word-prefix test (load-bearing
+  // PR #3673 protection — tail must be a SHORTER prefix of publisher).
+  // Stripping "AP News analysis" against "AP News" is REJECTED here,
+  // and Layer 2 below preserves the same asymmetry.
+  if (isPublisherWordPrefix(tail.toLowerCase(), publisher.toLowerCase())) {
+    return stripped;
+  }
+  // Layer 2 — Path 2a: source-aware fuzzy match via normalised
+  // asymmetric prefix. normalizePublisher strips articles globally and
+  // wire-suffix words trailing-only, so "Bulletin of the Atomic
+  // Scientists" matches "Bulletin of Atomic Scientists" and "BBC News"
+  // matches "BBC" — without mangling "Daily Mail" or "News Corp".
+  const normTail = normalizePublisher(tail);
+  const normPub = normalizePublisher(publisher);
+  if (
+    normTail.length > 0
+    && normPub.length > 0
+    && isPublisherWordPrefix(normTail, normPub)
+  ) {
+    return stripped;
+  }
+  // Layer 2 — Path 2b: acronym-shape-gated initials equivalence. The
+  // ORIGINAL publisher must match /^[A-Z]{1,5}$/ (DOJ, NPR, AP, BBC),
+  // gated on the unaltered field as authored — Title-Case names like
+  // "Time"/"Wired" do not opt in. The tail must also be Title-Case-or-
+  // connector shaped, blocking lowercase editorial text. Initials use
+  // tailForInitials (NOT normalizePublisher) so wire-suffix words like
+  // `Press` in "Associated Press" survive to count toward `ap`.
+  if (
+    PUBLISHER_ACRONYM_RE.test(publisher)
+    && looksLikePublisherShape(tail)
+    && initialsOf(tailForInitials(tail)) === publisher.toLowerCase()
+  ) {
+    return stripped;
+  }
+  return trimmed;
 }
 
 // Editorial-format prefixes some feeds prepend to headlines. They tell

--- a/tests/brief-from-digest-stories.test.mjs
+++ b/tests/brief-from-digest-stories.test.mjs
@@ -194,6 +194,253 @@ describe('stripHeadlineSuffix', () => {
   });
 });
 
+// ── stripHeadlineSuffix — Layer 2 publisher-naming variants ─────────────
+//
+// Closes three structural classes of variant between the headline-suffix's
+// publisher form and the configured `source` field, all observed live on
+// the May 15 brief: article insertion (Bulletin), trailing wire-suffix
+// word (BBC News vs BBC), abbreviation ↔ long-form (Department of
+// Justice vs DOJ). Layer 1's strict word-prefix test is preserved as the
+// load-bearing PR #3673 protection.
+//
+// See docs/plans/2026-05-15-001-fix-headline-suffix-strip-publisher-
+// naming-variants-plan.md for the full design rationale.
+
+describe('stripHeadlineSuffix — Layer 2 publisher-naming variants (plan 2026-05-15-001)', () => {
+  // ── Path 2a: source-aware fuzzy match (article + trailing wire-suffix + domain paren) ──
+
+  it('S1: strips on article insertion ("Bulletin of the Atomic Scientists" vs "Bulletin of Atomic Scientists")', () => {
+    assert.equal(
+      stripHeadlineSuffix(
+        "'Earth in flames,' Brian Toon and Alan Robock on whether humans will die from an asteroid or nuclear war first - Bulletin of the Atomic Scientists",
+        'Bulletin of Atomic Scientists',
+      ),
+      "'Earth in flames,' Brian Toon and Alan Robock on whether humans will die from an asteroid or nuclear war first",
+    );
+  });
+
+  it('S3: strips on trailing wire-suffix word ("BBC News" vs "BBC")', () => {
+    assert.equal(stripHeadlineSuffix('Body - BBC News', 'BBC'), 'Body');
+  });
+
+  it('S5: strips iteratively on multiple trailing wire-suffix words ("BBC News Online" vs "BBC")', () => {
+    assert.equal(stripHeadlineSuffix('Body - BBC News Online', 'BBC'), 'Body');
+  });
+
+  it('S6: strips when wire-suffix word is trailing AND publisher is the longer form ("Daily Mail Online" vs "Daily Mail")', () => {
+    // Verifies `daily` in LEADING position is preserved through normalisation
+    // while `online` in trailing position is stripped.
+    assert.equal(
+      stripHeadlineSuffix('Body - Daily Mail Online', 'Daily Mail'),
+      'Body',
+    );
+  });
+
+  // ── Critical regression: wire-suffix words in NON-trailing positions MUST NOT be stripped ──
+
+  it('S8: does NOT strip when leading wire-suffix word is part of the publisher name ("News Corp Latest" vs "News Corp")', () => {
+    // Trailing strip drops nothing (`latest` is not in suffix set).
+    // Tail `news corp latest` ≠ publisher prefix `news corp` (longer).
+    // Verifies `news` in LEADING position is preserved, NOT stripped.
+    assert.equal(
+      stripHeadlineSuffix('Body - News Corp Latest', 'News Corp'),
+      'Body - News Corp Latest',
+    );
+  });
+
+  it('S9: does NOT strip "Press TV International" vs "Press TV" — verifies leading "press" preserved', () => {
+    assert.equal(
+      stripHeadlineSuffix('Body - Press TV International', 'Press TV'),
+      'Body - Press TV International',
+    );
+  });
+
+  it('S10: strips "The Press Democrat" via Layer 1 equality — verifies article stripped + middle "press" preserved', () => {
+    assert.equal(
+      stripHeadlineSuffix('Body - The Press Democrat', 'The Press Democrat'),
+      'Body',
+    );
+  });
+
+  // ── Domain paren ──
+
+  it('S11: strips on trailing domain paren ("Reuters World (.com)" vs "Reuters World")', () => {
+    assert.equal(
+      stripHeadlineSuffix('Body - Reuters World (.com)', 'Reuters World'),
+      'Body',
+    );
+  });
+
+  // ── Path 2b: acronym-shape-gated initials equivalence ──
+
+  it('S12: strips DOJ case via initials ("Department of Justice (.gov)" vs "DOJ")', () => {
+    // Clean fixture with NO stray `|` (which would be matched by
+    // HEADLINE_SUFFIX_RE_PART as a separator). The leading
+    // "Office of Public Affairs |" boilerplate seen on real DOJ
+    // headlines is a SEPARATE prefix-pipe problem deferred from this PR.
+    assert.equal(
+      stripHeadlineSuffix(
+        'Georgian National Sentenced to 15 Years - Department of Justice (.gov)',
+        'DOJ',
+      ),
+      'Georgian National Sentenced to 15 Years',
+    );
+  });
+
+  it('S13: strips NPR case ("National Public Radio" vs "NPR") — wire-suffix word "radio" preserved by tailForInitials', () => {
+    assert.equal(
+      stripHeadlineSuffix('Body - National Public Radio', 'NPR'),
+      'Body',
+    );
+  });
+
+  it('S14: REGRESSION (Codex Round 2 P1) — strips AP case ("Associated Press" vs "AP") with `Press` preserved by tailForInitials', () => {
+    // The fix Codex Round 2 P1 caught: reusing normalizePublisher for
+    // initials would strip `press` (it's in WIRE_SUFFIX_TOKENS), leaving
+    // `associated` → initials `a`, missing the `P`. tailForInitials
+    // preserves wire-suffix words so initials yield `ap` correctly.
+    assert.equal(stripHeadlineSuffix('Body - Associated Press', 'AP'), 'Body');
+  });
+
+  it('S15: strips BBC long form ("British Broadcasting Corporation" vs "BBC")', () => {
+    assert.equal(
+      stripHeadlineSuffix('Body - British Broadcasting Corporation', 'BBC'),
+      'Body',
+    );
+  });
+
+  // ── Critical regression: lowercase editorial text MUST NOT trigger initials path ──
+
+  it('S16: does NOT strip lowercase editorial tail ("trump says that" vs "TST") — Title-Case gate rejects', () => {
+    assert.equal(
+      stripHeadlineSuffix('Body - trump says that', 'TST'),
+      'Body - trump says that',
+    );
+  });
+
+  it('S17: documented edge — strips Title-Case 3-word tail whose initials match a configured 3-char acronym ("Top Sales Today" vs "TST")', () => {
+    // Documented residual false-positive surface: a 3-Title-Case-word tail
+    // whose initials happen to equal a configured uppercase short source
+    // DOES strip. The all-uppercase configured source is itself a high-
+    // confidence "this is an acronym" signal. Accept and revisit if
+    // production telemetry surfaces a recurrence.
+    assert.equal(stripHeadlineSuffix('Body - Top Sales Today', 'TST'), 'Body');
+  });
+
+  // ── Initials cap ──
+
+  it('S18: strips when initials length ≤5 ("International Atomic Energy Agency" vs "IAEA")', () => {
+    assert.equal(
+      stripHeadlineSuffix(
+        'Body - International Atomic Energy Agency',
+        'IAEA',
+      ),
+      'Body',
+    );
+  });
+
+  it('S19: does NOT strip when source exceeds 5-char acronym cap', () => {
+    // Original publisher "IAEABF" has 6 chars → fails /^[A-Z]{1,5}$/ →
+    // initials path doesn't trigger. Path 2a also rejects (tail much
+    // longer than publisher).
+    assert.equal(
+      stripHeadlineSuffix(
+        'Body - International Atomic Energy Agency Body Format',
+        'IAEABF',
+      ),
+      'Body - International Atomic Energy Agency Body Format',
+    );
+  });
+
+  // ── Critical regression: ordinary Title-Case publishers MUST NOT trigger initials path ──
+
+  it('S18b: does NOT strip "This Is My Editorial" against Title-Case publisher "Time" (initials would match but acronym gate rejects)', () => {
+    // Without the all-uppercase /^[A-Z]{1,5}$/ gate on the original
+    // publisher, initials would compute `time` and the tail would be
+    // wrongly stripped. The gate is what locks the protection.
+    assert.equal(
+      stripHeadlineSuffix('Body - This Is My Editorial', 'Time'),
+      'Body - This Is My Editorial',
+    );
+  });
+
+  it('S18c: does NOT strip "Vivid Industry Cooperative Effort" vs "Vice"', () => {
+    assert.equal(
+      stripHeadlineSuffix('Body - Vivid Industry Cooperative Effort', 'Vice'),
+      'Body - Vivid Industry Cooperative Effort',
+    );
+  });
+
+  it('S18d: does NOT strip "Western Industrial Reporting Editor Desk" vs "Wired"', () => {
+    assert.equal(
+      stripHeadlineSuffix(
+        'Body - Western Industrial Reporting Editor Desk',
+        'Wired',
+      ),
+      'Body - Western Industrial Reporting Editor Desk',
+    );
+  });
+
+  it('S20: lowercase configured source ("doj") does NOT trigger initials path — must be authored ALL-CAPS to opt in', () => {
+    // The acronym gate is on the ORIGINAL publisher field (PUBLISHER_ACRONYM_RE).
+    // Lowercase `doj` does not match /^[A-Z]{1,5}$/ → initials path doesn't fire.
+    // Layer 1's case-insensitive prefix test still applies, but `doj` ≠
+    // `Department of Justice` so no equality strip either.
+    assert.equal(
+      stripHeadlineSuffix('Body - Department of Justice', 'doj'),
+      'Body - Department of Justice',
+    );
+  });
+
+  // ── Load-bearing PR #3673 asymmetric protection (R5) at ALL Layer 2 paths ──
+
+  it('S21: REGRESSION (PR #3673) — does NOT strip "AP News analysis" vs "AP News" at any layer', () => {
+    // Layer 1: tail (16 chars) >= publisher (7 chars) → asymmetric prefix rejects.
+    // Path 2a: normalised tail = "ap news analysis" (last token `analysis` not
+    //   in WIRE_SUFFIX_TOKENS so trailing strip is a no-op). isPublisherWordPrefix
+    //   ("ap news analysis", "ap") (normPub = "ap" after stripping trailing "news"
+    //   from "AP News") — tail much longer → reject.
+    // Path 2b: original publisher "AP News" contains a space and lowercase
+    //   chars → does NOT match /^[A-Z]{1,5}$/ → initials path doesn't trigger.
+    // This is the load-bearing test for the entire Layer 2 design.
+    assert.equal(
+      stripHeadlineSuffix('Body - AP News analysis', 'AP News'),
+      'Body - AP News analysis',
+    );
+  });
+
+  // ── Edges ──
+
+  it('S23: empty publisher does NOT trigger any Layer 2 path', () => {
+    // Layer 1 early-returns on empty publisher (returns trimmed title).
+    // Layer 2 normalised prefix needs both non-empty; initials path
+    // needs the empty string to match /^[A-Z]{1,5}$/ which it does not.
+    assert.equal(stripHeadlineSuffix('Body - Anything', ''), 'Body - Anything');
+  });
+
+  it('S26: strips "Al Jazeera English" vs "AJE" — three Title-Case tokens, initials match', () => {
+    // Path 2b: PUBLISHER_ACRONYM_RE("AJE") ✓. looksLikePublisherShape
+    // (3 Title-Case tokens) ✓. tailForInitials → "al jazeera english".
+    // initialsOf → "aje". Match.
+    assert.equal(
+      stripHeadlineSuffix('Body - Al Jazeera English', 'AJE'),
+      'Body',
+    );
+  });
+
+  it('S26b: documents hyphenated-compound behaviour — "Al-Jazeera English" vs "AE" strips (single token from hyphen, NOT split)', () => {
+    // The hyphenated compound `Al-Jazeera` counts as a SINGLE token
+    // (TITLE_CASE_TOKEN_RE accepts hyphens within the token), so its
+    // initial is just `a`. Combined with `English` → initials `ae`,
+    // matching source `AE`. If a future case requires splitting on
+    // hyphens, tailForInitials can be extended; deferred until needed.
+    assert.equal(
+      stripHeadlineSuffix('Body - Al-Jazeera English', 'AE'),
+      'Body',
+    );
+  });
+});
+
 describe('stripHeadlinePrefix', () => {
   it('REGRESSION (May 12 brief): strips "Video: " prefix from RSS headlines', () => {
     // Live incident: magazine page 16/18 shipped "Video: Philippine


### PR DESCRIPTION
## Summary

Three structural variant classes between the headline-suffix's publisher form and the configured `source` field were observed live on the May 15 brief — Layer 1's strict word-prefix test ([PR #3673](https://github.com/koala73/worldmonitor/pull/3673)'s load-bearing asymmetric protection) misses all three:

| Class | Example | Card on May 15 |
|---|---|---|
| Article insertion | tail `Bulletin of the Atomic Scientists` vs source `Bulletin of Atomic Scientists` | #2 |
| Trailing wire-suffix word | tail `BBC News` vs source `BBC` | (general) |
| Abbreviation ↔ long-form | tail `Department of Justice (.gov)` vs source `DOJ` | #3 |

## Approach

Layer 2 adds two source-aware paths after Layer 1, all preserving the asymmetric protection:

- **Path 2a** — `normalizePublisher` on both sides + the same asymmetric prefix test. Strips trailing domain paren, removes article words globally, removes wire-suffix words **only from the trailing position iteratively**. Trailing-only is load-bearing: stripping `news`/`press`/`daily` globally would mangle `Daily Mail`, `News Corp`, `Press TV`, `The Press Democrat`.
- **Path 2b** — acronym-shape-gated initials equivalence. **Two gates:** (a) original `publisher` matches `/^[A-Z]{1,5}$/` — explicit opt-in via ALL-CAPS configured field; (b) tail passes Title-Case-or-connector shape check. Initials use a **separate `tailForInitials`** (not `normalizePublisher`) so wire-suffix words like `Press` in `Associated Press` survive to count toward `ap`.

A speculative source-blind shape fallback ("Layer 3") was scoped and rejected on Codex review — feed-controlled text could force user-visible truncation, an integrity risk not worth the speculative benefit. See plan for the full design rationale.

## What this is NOT

- **Per-publisher alias maps.** The initials test handles abbreviations generically; an alias map would be maintenance burden without structural benefit.
- **`stripHeadlinePrefix` pipe-separator boilerplate** (e.g. `"Office of Public Affairs |"`) — separate problem, deferred.
- **Schema changes / ingest-time RSS `<channel><title>` capture** — the architecturally pure long-term fix; documented in plan as the next step if the source-aware layer leaves edge cases.

## Test plan

- [x] **26 new test scenarios** (S1–S26b) covering happy paths, the four critical-regression classes (wire-suffix in non-trailing positions / Title-Case gate blocks lowercase editorial / ordinary Title-Case publishers don't trigger initials / PR #3673 asymmetric protection holds at every layer), and edge cases.
- [x] **All 77 existing `stripHeadlineSuffix` tests pass unchanged** — Layer 1 is untouched; Layer 2 only fires when Layer 1 returns no match.
- [x] **350 brief/digest tests pass** under `tsx --test` (broader sweep including `brief-llm`, `brief-magazine-render`, `digest-orchestration-helpers`, `brief-edge-route-smoke`).
- [x] `typecheck:api` clean, `biome check` clean (no new warnings on touched files).

## Codex review history

The plan was reviewed across 3 rounds before this PR (max 5; Codex hit its usage limit before Round 4 could verdict). Key Codex catches that hardened the design:

- **R1**: forced dropping the speculative source-blind layer (integrity risk).
- **R2 (P1)**: caught that reusing `normalizePublisher` for initials would corrupt `Associated Press → AP` (`Press` got stripped). Fix: separate `tailForInitials` helper. Test S14 locks this.
- **R2 (P2)**: caught that gating the initials trigger on lowercased `normPub` would accept ordinary Title-Case publishers like `Time`/`Wired`/`Axios` as acronyms. Fix: gate on the original publisher matching `/^[A-Z]{1,5}$/`. Tests S18b/S18c/S18d lock this.

Plan: [`docs/plans/2026-05-15-001-fix-headline-suffix-strip-publisher-naming-variants-plan.md`](https://github.com/koala73/worldmonitor/blob/fix/headline-suffix-naming-variants/docs/plans/2026-05-15-001-fix-headline-suffix-strip-publisher-naming-variants-plan.md) (gitignored, not in this PR).