### PR TITLE
fix(feeds): restore 7 dead commodity-variant RSS feeds without losing any

### DIFF
--- a/api/_rss-allowed-domains.js
+++ b/api/_rss-allowed-domains.js
@@ -294,6 +294,8 @@ export default [
   "www.australianmining.com.au",
   "news.goldseek.com",
   "news.silverseek.com",
+  "www.goldseek.com",
+  "www.silverseek.com",
   "decrypt.co",
   "blockworks.co",
   "thedefiant.io",

--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -29,6 +29,9 @@ const RELAY_ONLY_DOMAINS = new Set([
   'feeds.capi24.com',
   'islandtimes.org',
   'www.atlanticcouncil.org',
+  // blockworks.co/feed returns 200 to direct curl but 403 to Vercel edge IPs
+  // (Cloudflare bot challenge). Railway egress has different ASN; relay works.
+  'blockworks.co',
 ]);
 
 const DIRECT_FETCH_HEADERS = Object.freeze({

--- a/scripts/shared/rss-allowed-domains.json
+++ b/scripts/shared/rss-allowed-domains.json
@@ -291,6 +291,8 @@
   "www.australianmining.com.au",
   "news.goldseek.com",
   "news.silverseek.com",
+  "www.goldseek.com",
+  "www.silverseek.com",
   "decrypt.co",
   "blockworks.co",
   "thedefiant.io",

--- a/shared/rss-allowed-domains.json
+++ b/shared/rss-allowed-domains.json
@@ -291,6 +291,8 @@
   "www.australianmining.com.au",
   "news.goldseek.com",
   "news.silverseek.com",
+  "www.goldseek.com",
+  "www.silverseek.com",
   "decrypt.co",
   "blockworks.co",
   "thedefiant.io",

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -807,7 +807,11 @@ const HAPPY_FEEDS: Record<string, Feed[]> = {
 // Commodity variant feeds (from commodity.ts)
 const COMMODITY_FEEDS: Record<string, Feed[]> = {
   'commodity-news': [
-    { name: 'Kitco News', url: rss('https://www.kitco.com/rss/KitcoNews.xml') },
+    // Kitco shut down their public RSS feeds in 2025 (every /rss/*, /news/feed,
+    // /news/category/*/feed path now returns an HTML SPA page, not XML). Fall
+    // back to Google News scoped to site:kitco.com, matching the pattern used
+    // by TASS / Kyiv Independent / Telegraaf elsewhere in this file.
+    { name: 'Kitco News', url: rss('https://news.google.com/rss/search?q=site:kitco.com+(gold+OR+silver+OR+metals)+when:1d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'Mining.com', url: rss('https://www.mining.com/feed/') },
     { name: 'Bloomberg Commodities', url: rss('https://news.google.com/rss/search?q=site:bloomberg.com+commodities+OR+metals+OR+mining+when:1d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'Reuters Commodities', url: rss('https://news.google.com/rss/search?q=site:reuters.com+commodities+OR+metals+OR+mining+when:1d&hl=en-US&gl=US&ceid=US:en') },
@@ -816,15 +820,23 @@ const COMMODITY_FEEDS: Record<string, Feed[]> = {
     { name: 'CNBC Commodities', url: rss('https://news.google.com/rss/search?q=site:cnbc.com+(commodities+OR+metals+OR+gold+OR+copper)+when:1d&hl=en-US&gl=US&ceid=US:en') },
   ],
   'gold-silver': [
-    { name: 'Kitco Gold', url: rss('https://www.kitco.com/rss/KitcoGold.xml') },
+    // Kitco RSS shutdown (see Kitco News comment in commodity-news above).
+    // Gold-scoped Google News query targeting site:kitco.com.
+    { name: 'Kitco Gold', url: rss('https://news.google.com/rss/search?q=site:kitco.com+gold+when:1d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'Gold Price News', url: rss('https://news.google.com/rss/search?q=(gold+price+OR+"gold+market"+OR+bullion+OR+LBMA)+when:1d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'Silver Price News', url: rss('https://news.google.com/rss/search?q=(silver+price+OR+"silver+market"+OR+"silver+futures")+when:2d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'Precious Metals', url: rss('https://news.google.com/rss/search?q=("precious+metals"+OR+platinum+OR+palladium+OR+"gold+ETF"+OR+GLD+OR+SLV)+when:2d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'World Gold Council', url: rss('https://news.google.com/rss/search?q="World+Gold+Council"+OR+"central+bank+gold"+OR+"gold+reserves"+when:7d&hl=en-US&gl=US&ceid=US:en') },
-    { name: 'GoldSeek', url: rss('https://news.goldseek.com/GoldSeek/rss.xml') },
-    { name: 'SilverSeek', url: rss('https://news.silverseek.com/SilverSeek/rss.xml') },
+    // GoldSeek + SilverSeek moved their feeds from the `news.*` subdomain to
+    // the apex domain (the old subdomain returns 404; the apex /rss.xml on
+    // both returns application/rss+xml).
+    { name: 'GoldSeek', url: rss('https://www.goldseek.com/rss.xml') },
+    { name: 'SilverSeek', url: rss('https://www.silverseek.com/rss.xml') },
     { name: 'Gold Silver Worlds', url: rss('https://goldsilverworlds.com/feed/') },
-    { name: 'FX Empire Gold', url: rss('https://www.fxempire.com/api/v1/en/markets/commodity/Gold/news/feed') },
+    // The /api/v1/.../feed endpoint FX Empire used to expose was deprecated;
+    // their generic /feed now returns text/html, not RSS. Google News scoped
+    // to site:fxempire.com for gold articles.
+    { name: 'FX Empire Gold', url: rss('https://news.google.com/rss/search?q=site:fxempire.com+gold+when:1d&hl=en-US&gl=US&ceid=US:en') },
   ],
   energy: [
     { name: 'OilPrice.com', url: rss('https://oilprice.com/rss/main') },
@@ -838,7 +850,11 @@ const COMMODITY_FEEDS: Record<string, Feed[]> = {
   'mining-news': [
     { name: 'Mining Journal', url: rss('https://www.mining-journal.com/feed/') },
     { name: 'Northern Miner', url: rss('https://www.northernminer.com/feed/') },
-    { name: 'Mining Weekly', url: rss('https://www.miningweekly.com/rss/') },
+    // www.miningweekly.com domain-wide 403s every IP-based fetch (homepage
+    // included), not just Vercel edge — Railway relay likely wouldn't help.
+    // Google News scoped to site:miningweekly.com is the reliable path and
+    // matches the pattern used for other wholesale-blocked publishers.
+    { name: 'Mining Weekly', url: rss('https://news.google.com/rss/search?q=site:miningweekly.com+when:2d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'Mining Technology', url: rss('https://www.mining-technology.com/feed/') },
     { name: 'Australian Mining', url: rss('https://www.australianmining.com.au/feed/') },
     { name: 'Mine Web (SNL)', url: rss('https://news.google.com/rss/search?q=("mining+company"+OR+"mine+production"+OR+"mining+operations")+when:2d&hl=en-US&gl=US&ceid=US:en') },


### PR DESCRIPTION
## Why

Production console (commodity variant) showed persistent 403 / 404 on 7 RSS feeds via `/api/rss-proxy` — Blockworks, Kitco News, Kitco Gold, GoldSeek, SilverSeek, Mining Weekly, FX Empire Gold. Probed each upstream; every failure is genuinely upstream-dead or upstream-blocking, none transient.

The brief was: **don't lose any feeds.** Each entry now has a working replacement — net zero feeds dropped from the commodity variant.

## Per-feed diagnosis + fix

| Feed | Probe result | Fix |
|---|---|---|
| **Blockworks** | 200 to direct curl, **403 from Vercel edge** (Cloudflare IP block) | Added `'blockworks.co'` to `RELAY_ONLY_DOMAINS` in `api/rss-proxy.js` → routes via Railway (same pattern as `scmp.com`, `iaea.org`, `rss.cnn.com`). |
| **Kitco News** | 404 — Kitco shut down public RSS in 2025. Every `/rss/*`, `/news/feed`, `/news/category/*/feed` path now returns an HTML SPA page (verified by content-type check). | Site-scoped Google News query: `site:kitco.com+(gold+OR+silver+OR+metals)+when:1d`. |
| **Kitco Gold** | Same as Kitco News. | Gold-scoped: `site:kitco.com+gold+when:1d`. |
| **GoldSeek** | 404 at old `news.goldseek.com` subdomain. | Apex `https://www.goldseek.com/rss.xml` — serves real `application/rss+xml`. |
| **SilverSeek** | 404 at old `news.silverseek.com` subdomain. | Apex `https://www.silverseek.com/rss.xml` — serves real `application/rss+xml`. |
| **Mining Weekly** | Domain-wide 403 from every direct fetch including homepage `/` — wholesale automated-traffic block, not Vercel-specific. Railway relay unlikely to help. | Google News: `site:miningweekly.com+when:2d`. |
| **FX Empire Gold** | `/api/v1/.../feed` endpoint deprecated; generic `/feed` returns text/html (no real RSS). | Google News: `site:fxempire.com+gold+when:1d`. |

Three patterns:
- **2 entries** "alive direct, dead from edge" → `RELAY_ONLY_DOMAINS` (Blockworks).
- **2 entries** "moved to apex" → URL swap (GoldSeek, SilverSeek).
- **3 entries** "publisher killed RSS / wholesale block" → site-scoped Google News query (Kitco × 2, Mining Weekly, FX Empire Gold).

The Google News pattern matches what's already used in this file for TASS, Kyiv Independent, De Telegraaf, Kathimerini, Proto Thema, CNN World, AP News, Reuters World, and similar.

## Verification

- All four new Google News URLs verified to return `application/xml` RSS with items.
- Both apex GoldSeek / SilverSeek URLs verified to return `application/rss+xml`.
- `npm run typecheck` + `typecheck:api` ✓
- `npm run lint:api-contract` ✓
- biome on changed files ✓
- esbuild bundle check on `api/rss-proxy.js` ✓
- `npm run test:data` — 8853/8853 ✓

## Manual check on preview

Open the commodity variant on the deploy preview and confirm none of the seven feeds show the 403/404 error in the console.

## Separate concern (not in this PR)

The Daily Market Brief panel sometimes shows a generic "Loading…" indefinitely when the LLM summarization step hangs (`src/services/summarization.ts:generateSummary` doesn't pass an `AbortSignal`). That's a different fix and will land in a follow-up PR.