### PR TITLE
fix(seed-portwatch): lower temp gate 25→20 so cap-mode rotation accumulates

### DIFF
--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -23,16 +23,24 @@ const LOCK_DOMAIN = 'supply_chain:portwatch-ports';
 // 60 min — covers the widest realistic run of this standalone service.
 const LOCK_TTL_MS = 60 * 60 * 1000;
 const TTL = 259_200; // 3 days — 6× the 12h cron interval
-// Coverage gate. TEMPORARILY lowered from 50 → 25 on 2026-05-14 to let
-// seed-meta refresh while ArcGIS is in a degraded rate-limit state.
-// Background: post-#3681 the proxy retry IS firing, but both direct AND
-// proxy paths are throttled — successful per-country fetches dropped from
-// 24 → 5 between successive runs as Decodo hit its own rate-limit. With
-// gate=50 the seed-meta stayed frozen at 2026-05-12 00:03 UTC for 60+ hours.
-// Lowering to 25 lets a partial-success run advance the meta and clears
-// the operator-facing WARNING while ArcGIS recovers. Revert to 50 once
-// successive runs reliably exceed 50 again (target: 2026-05-20 review).
-const MIN_VALID_COUNTRIES = 25;
+// Coverage gate. TEMPORARILY lowered to 20 on 2026-05-16 (was 50 → 25 on
+// 2026-05-14) to let cap-mode recovery runs actually publish.
+//
+// Background: PR #3711's budget rebalance (15s direct + 70s proxy) now
+// produces consistent partial-success runs in the ~22/30 success range
+// per cold-fetch batch. With gate=25, a 22-success run still fails the
+// COVERAGE GATE and extendExistingTtl-only — meaning the run's 22 fresh
+// successes are NOT written to Redis, so the cap-mode rotation never
+// accumulates (each run restarts from 0 cache-fresh). Lowering to 20
+// lets a 22-success run actually persist, so subsequent runs benefit
+// from the cache-fresh fast path and accumulate toward full coverage
+// across ~8 runs (~4 days at 12h cadence).
+//
+// Revert path: bump to 30 when single-run success rate reliably exceeds
+// 90% (≥27/30 cold-fetched), and back to 50 once upstream is stable
+// enough that we'd see consistent ≥45-country runs (no cap-mode kicking
+// in). Target review: 2026-05-22.
+const MIN_VALID_COUNTRIES = 20;
 
 const EP3_BASE =
   'https://services9.arcgis.com/weJ1QsnbMYJlCHdG/arcgis/rest/services/Daily_Ports_Data/FeatureServer/0/query';

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -278,16 +278,18 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /setTimeout\(resolve,\s*BATCH_BACKOFF_MS\)/);
   });
 
-  it('MIN_VALID_COUNTRIES is temporarily lowered to 25 (ArcGIS degraded)', () => {
-    // Pre-2026-05-14 value: 50. Lowered to 25 to let seed-meta refresh
-    // during the ArcGIS rate-limit degradation. The comment must call
-    // out the temporary nature + review date so this doesn't get
-    // forgotten as the new permanent floor.
-    assert.match(src, /const MIN_VALID_COUNTRIES\s*=\s*25/);
+  it('MIN_VALID_COUNTRIES is temporarily lowered to 20 (ArcGIS degraded)', () => {
+    // 2026-05-16: lowered 25 → 20 because post-#3711 budget-rebalance
+    // runs are landing ~22/30 successes — with gate=25 the 22-success
+    // runs would fail validation and extendExistingTtl-only, so the
+    // cache-fresh rotation could never accumulate. Pre-2026-05-14
+    // value: 50. The comment must call out the temporary nature +
+    // review date so this doesn't get forgotten as the new permanent floor.
+    assert.match(src, /const MIN_VALID_COUNTRIES\s*=\s*20/);
     // Require the comment to flag temporariness (so a future reviewer
     // doesn't normalise the lower value silently).
-    assert.match(src, /TEMPORARILY lowered from 50/);
-    assert.match(src, /Revert to 50/);
+    assert.match(src, /TEMPORARILY lowered/);
+    assert.match(src, /Revert path/);
   });
 
   // Greptile PR #3694 round 3 P1: with the temp gate lowered to 25 but the

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -290,6 +290,11 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     // doesn't normalise the lower value silently).
     assert.match(src, /TEMPORARILY lowered/);
     assert.match(src, /Revert path/);
+    // Greptile PR #3714 P2: keep an anchor to the original permanent
+    // baseline (50) in the comment so the temporary nature has a concrete
+    // reference point — otherwise a vague "TEMPORARILY lowered for now"
+    // edit could silently pass CI and lose the canary property.
+    assert.match(src, /was 50/);
   });
 
   // Greptile PR #3694 round 3 P1: with the temp gate lowered to 25 but the


### PR DESCRIPTION
## Summary

First post-PR-#3711 run produced **22 fresh-fetched countries** (~73% success rate from the 30-country cold-fetch batch) — the real recovery starting to land. But the temp coverage gate at 25 fired one short:

```
batch 5/5: 22 countries published, 8 errors (370.4s)
COVERAGE GATE FAILED: only 22 countries, need >=25
Extended TTL on 176 key(s) (259200s)
```

Net effect: the 22 fresh successes were NOT persisted to Redis. `extendExistingTtl` preserved prior payloads (graceful), but **cap-mode rotation can't accumulate** — each run restarts from 0 cache-fresh and we re-attempt the same population, never converging.

## Fix

Lower `MIN_VALID_COUNTRIES` 25 → 20.

This matches the observed reality: PR #3711's budget rebalance produces a stable ~22/30 success rate. A 22-success run now persists, those 22 countries become cache-fresh (cacheHits next run), cap-mode picks a different 30 from the remaining 152, and we accumulate toward full coverage.

**Projected convergence at 12h cadence, ~22 fresh per run:**

| Run | Cumulative cache-fresh | Cap-mode still kicks in? |
|---|---|---|
| 1 (post-merge) | 22 | yes (152 still need fetch) |
| 2 | 44 | yes |
| 4 | ~88 | yes |
| 8 | ~174 | no — full coverage |

≈ 4 days to full refresh, assuming upstream maxDate stays stable. If upstream advances mid-rotation, the cache invalidates and rotation restarts — that's an upstream-cadence problem, not something this PR fixes.

## Why this is safe

The 80% degradation guard still protects against silent data loss (PR #3694): if cap-mode is triggered but `freshFetched + cacheHits < MIN_FRESH_FETCH_FOR_CAP_BYPASS=5`, the bypass is refused and the 80% guard fires anyway. So a true upstream-collapse run (0 fresh) still won't publish stale-only data.

## Revert path

- **First step:** bump to 30 when single-run success rate exceeds 90% (≥27/30 cold-fetched)
- **Final step:** back to 50 once upstream is stable enough that we'd see consistent ≥45-country runs (no cap-mode kicking in)
- **Target review:** 2026-05-22

## Test plan

- [x] 99/99 portwatch-port-activity-seed tests pass
- [x] 8853/8853 \`npm run test:data\` pass
- [x] typecheck pass
- [ ] **Post-merge observation**: next Railway run should land batch summary `XX countries published`, then `Fetched XX countries`, then **PARTIAL PUBLISH (cap-mode)** OR `Done` WITHOUT the COVERAGE GATE FAILED line; Redis should accept the writes; subsequent run should show `Cache: ~22 hits, ~152 misses` (not `0 hits`)
- [ ] **3-day watch**: cumulative cache-fresh should rise (22 → 44 → 66 → 88 → ~110); if it stays flat at 22 between runs, the rotation isn't accumulating and we need to investigate