### PR TITLE
fix(feeds): round 2 — Blockworks via Google News, plus 2 newly-surfaced dead feeds

### DIFF
--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -29,9 +29,6 @@ const RELAY_ONLY_DOMAINS = new Set([
   'feeds.capi24.com',
   'islandtimes.org',
   'www.atlanticcouncil.org',
-  // blockworks.co/feed returns 200 to direct curl but 403 to Vercel edge IPs
-  // (Cloudflare bot challenge). Railway egress has different ASN; relay works.
-  'blockworks.co',
 ]);
 
 const DIRECT_FETCH_HEADERS = Object.freeze({

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -696,7 +696,12 @@ const FINANCE_FEEDS: Record<string, Feed[]> = {
     { name: 'Crypto News', url: rss('https://news.google.com/rss/search?q=(bitcoin+OR+ethereum+OR+crypto+OR+"digital+assets")+when:1d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'DeFi News', url: rss('https://news.google.com/rss/search?q=(DeFi+OR+"decentralized+finance"+OR+DEX+OR+"yield+farming")+when:3d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'Decrypt', url: rss('https://decrypt.co/feed') },
-    { name: 'Blockworks', url: rss('https://blockworks.co/feed') },
+    // Blockworks /feed returns 200 to direct curl but Cloudflare blocks both
+    // Vercel edge AND Railway egress (PR #3712 tried RELAY_ONLY_DOMAINS first;
+    // proxy still 403'd because Railway ASN is also blocked). Fall back to
+    // site-scoped Google News, matching the Kitco/Mining Weekly/FX Empire
+    // pattern from the same PR.
+    { name: 'Blockworks', url: rss('https://news.google.com/rss/search?q=site:blockworks.co+(crypto+OR+DeFi+OR+bitcoin+OR+stablecoin)+when:1d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'The Defiant', url: rss('https://thedefiant.io/feed') },
     { name: 'Bitcoin Magazine', url: rss('https://bitcoinmagazine.com/feed') },
     { name: 'DL News', url: rss('https://news.google.com/rss/search?q=site:dlnews.com+when:3d&hl=en-US&gl=US&ceid=US:en') },
@@ -816,7 +821,9 @@ const COMMODITY_FEEDS: Record<string, Feed[]> = {
     { name: 'Bloomberg Commodities', url: rss('https://news.google.com/rss/search?q=site:bloomberg.com+commodities+OR+metals+OR+mining+when:1d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'Reuters Commodities', url: rss('https://news.google.com/rss/search?q=site:reuters.com+commodities+OR+metals+OR+mining+when:1d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'S&P Global Commodity', url: rss('https://news.google.com/rss/search?q=site:spglobal.com+commodities+metals+when:3d&hl=en-US&gl=US&ceid=US:en') },
-    { name: 'Commodity Trade Mantra', url: rss('https://www.commoditytrademantra.com/feed/') },
+    // commoditytrademantra.com 403s direct curl wholesale (not Vercel-specific) —
+    // same automated-traffic block as Mining Weekly. Google News fallback.
+    { name: 'Commodity Trade Mantra', url: rss('https://news.google.com/rss/search?q=site:commoditytrademantra.com+when:2d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'CNBC Commodities', url: rss('https://news.google.com/rss/search?q=site:cnbc.com+(commodities+OR+metals+OR+gold+OR+copper)+when:1d&hl=en-US&gl=US&ceid=US:en') },
   ],
   'gold-silver': [
@@ -848,7 +855,10 @@ const COMMODITY_FEEDS: Record<string, Feed[]> = {
     { name: 'Reuters Energy', url: rss('https://news.google.com/rss/search?q=site:reuters.com+(oil+OR+gas+OR+energy)+when:1d&hl=en-US&gl=US&ceid=US:en') },
   ],
   'mining-news': [
-    { name: 'Mining Journal', url: rss('https://www.mining-journal.com/feed/') },
+    // mining-journal.com migrated to Kreatio CMS; /feed/ now returns
+    // text/html (the homepage SPA), not RSS — produces "Parse error for
+    // Mining Journal" in the client. Google News fallback.
+    { name: 'Mining Journal', url: rss('https://news.google.com/rss/search?q=site:mining-journal.com+when:2d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'Northern Miner', url: rss('https://www.northernminer.com/feed/') },
     // www.miningweekly.com domain-wide 403s every IP-based fetch (homepage
     // included), not just Vercel edge — Railway relay likely wouldn't help.


### PR DESCRIPTION
## Why

Production console still showed errors after #3712 (merged). Diagnostic output the operator pasted exposed three things:

1. **My #3712 Blockworks fix didn't actually work.** Added `blockworks.co` to `RELAY_ONLY_DOMAINS`, but curling the production proxy still returns 403. Cloudflare on blockworks.co blocks BOTH Vercel edge AND Railway egress (their block tier is stricter than scmp.com / iaea.org / cnn.com, which is what I extrapolated the relay fix from).
2. **`commoditytrademantra.com/feed/`** — 503 via proxy because direct curl returns 403 wholesale. Fresh failure.
3. **`mining-journal.com/feed/`** — 200 BUT returns `text/html` (Kreatio CMS homepage), not RSS. Produced the "Parse error for Mining Journal" line in the client.

## Fix

| Feed | What's wrong | This PR |
|---|---|---|
| **Blockworks** | Cloudflare blocks both Vercel + Railway | Google News: `site:blockworks.co+(crypto+OR+DeFi+OR+bitcoin+OR+stablecoin)+when:1d` |
| **Commodity Trade Mantra** | Wholesale 403 (not Vercel-specific) | Google News: `site:commoditytrademantra.com+when:2d` |
| **Mining Journal** | Publisher migrated to Kreatio CMS, killed RSS | Google News: `site:mining-journal.com+when:2d` |

Also removed `blockworks.co` from `RELAY_ONLY_DOMAINS` in `api/rss-proxy.js` — no longer reached since we're using Google News instead.

All three Google News URLs verified to return `application/xml`.

## Honest note on #3712

Adding `blockworks.co` to `RELAY_ONLY_DOMAINS` in #3712 was a guess based on the pattern for scmp.com / iaea.org / etc. I should have probed Railway's actual response through the production proxy before claiming the fix would work. The operator's diagnostic caught it.

## Verification

- `npm run typecheck` ✓
- `npm run lint:api-contract` ✓
- biome on changed files ✓
- esbuild bundle check on `api/rss-proxy.js` ✓
- `npm run test:data` — 8853/8853 ✓
- Each Google News URL `curl`-verified to return real RSS (`application/xml`)

## Open from earlier diagnosis (not in this PR)

Daily Market Brief stuck on "Loading…" — still unconfirmed root cause; awaiting Network-tab data on `/api/news/v1/summarize-article` from a stuck panel to target precisely vs. doing a defensive shotgun fix.