### PR TITLE
fix(sentry): ignore IndexedDB-unavailable + Samsung Tizen vc_ noise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -54,6 +54,13 @@ Sentry.init({
     /Unable to load image/,
     /Non-Error promise rejection captured with value:/,
     /Connection to Indexed Database server lost/,
+    // Library-thrown (Convex client / Clerk persistent cache) when the user's
+    // browser has IndexedDB disabled (Safari Private Browsing, hardened
+    // Firefox, some WebView contexts). Our code only initializes the
+    // library; the throw is environmental and unavoidable from our side.
+    // Same disposition as the existing "Connection to Indexed Database
+    // server lost" entry above. WORLDMONITOR-RC.
+    /^IndexedDBUnavailableError|IndexedDB is not available in this environment/,
     /webkit\.messageHandlers/,
     /(?:unsafe-eval.*Content Security Policy|Content Security Policy.*unsafe-eval)/,
     /Fullscreen request denied/,
@@ -203,6 +210,7 @@ Sentry.init({
     /^A network error occurred\.?$/,
     /nmhCrx is not defined/,
     /\bcrusoe is not defined\b/, // WORLDMONITOR-R3 — injected userscript reference, anonymous-frames-only stack
+    /\bvc_request_action is not defined\b/, // WORLDMONITOR-RB — Samsung Internet / Tizen smart-view-cast global injection
     /navigationPerformanceLoggerJavascriptInterface/,
     /jQuery is not defined/,
     /illegal UTF-16 sequence/,


### PR DESCRIPTION
## Summary

Two unresolved Sentry issues, both unambiguous third-party / browser-env noise:

- **WORLDMONITOR-RC** (2ev/1u): \`IndexedDBUnavailableError: IndexedDB is not available in this environment\`. Library-thrown by the Convex client / Clerk persistent cache when the user's browser has IDB disabled (Safari Private Browsing, hardened Firefox, certain WebView contexts). Companion to the existing \`Connection to Indexed Database server lost\` entry.

- **WORLDMONITOR-RB** (1ev/1u): \`vc_request_action is not defined\` on Samsung Internet 8.0 / Tizen 9.0. Smart-view-cast global, anonymous-frame eval injection. Same shape as existing \`nmhCrx\` / \`crusoe\` / \`vc_text_indicators_context\` entries.

Both patterns are bounded so they can't match generic minified-symbol noise from our own bundle:
- RC: anchored on the named error class \`IndexedDBUnavailableError\` OR the full error message
- RB: \`\\b\` word boundaries

Both Sentry issues marked resolved with \`inNextRelease: true\` — auto-reopens if any new event matches from our bundle (which would itself be a real regression signal worth investigating).

## Test plan

- [x] \`npm run typecheck\` — PASS
- [x] \`npm run lint\` — PASS (warnings only, all pre-existing)
- [x] \`npm run lint:md\` — PASS
- [x] \`npm run version:check\` — PASS
- [ ] Post-deploy: verify RC + RB don't reopen