### PR TITLE
fix(feeds): #3715 review — server parity + drop 0-item Google News placeholders

### DIFF
--- a/server/worldmonitor/news/v1/_feeds.ts
+++ b/server/worldmonitor/news/v1/_feeds.ts
@@ -260,7 +260,11 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       { name: 'Cointelegraph', url: 'https://cointelegraph.com/rss' },
       { name: 'The Block', url: 'https://news.google.com/rss/search?q=site:theblock.co+when:1d&hl=en-US&gl=US&ceid=US:en' },
       { name: 'Decrypt', url: 'https://decrypt.co/feed' },
-      { name: 'Blockworks', url: 'https://blockworks.co/feed' },
+      // Blockworks REMOVED in parity with src/config/feeds.ts (PR #3715
+      // review). blockworks.co/feed is Cloudflare-blocked from both Vercel
+      // edge AND Railway egress, AND Google News returns 0 items for
+      // site:blockworks.co. The Block (above) covers the same
+      // institutional-crypto territory; no coverage lost.
       { name: 'The Defiant', url: 'https://thedefiant.io/feed' },
       { name: 'Bitcoin Magazine', url: 'https://bitcoinmagazine.com/feed' },
       { name: 'DL News', url: 'https://news.google.com/rss/search?q=site:dlnews.com+when:3d&hl=en-US&gl=US&ceid=US:en' },

--- a/server/worldmonitor/news/v1/_feeds.ts
+++ b/server/worldmonitor/news/v1/_feeds.ts
@@ -338,7 +338,15 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       { name: 'Bloomberg Commodities', url: gn('site:bloomberg.com commodities OR metals OR mining when:1d') },
       { name: 'Reuters Commodities', url: gn('site:reuters.com commodities OR metals OR mining when:1d') },
       { name: 'S&P Global Commodity', url: gn('site:spglobal.com commodities metals when:3d') },
-      { name: 'Commodity Trade Mantra', url: gn('commodities trading metals energy gold silver when:1d') },
+      // Commodity Trade Mantra REMOVED in parity with src/config/feeds.ts
+      // (PR #3715 review follow-up #3717). Server emits ~10 items per refresh
+      // but the client filters digest items against the client feed-name set
+      // (src/app/data-loader.ts:908-914), so these are invisible to users.
+      // Worse, the server truncates to MAX_ITEMS_PER_CATEGORY (list-feed-
+      // digest.ts:1076-1082) BEFORE the client filter — so invisible CTM
+      // items crowd out visible commodity-news items, leaving the panel with
+      // fewer results. The other 6 commodity-news feeds (Kitco / Mining.com
+      // / Bloomberg / Reuters / S&P / CNBC) cover the same territory.
       { name: 'CNBC Commodities', url: gn('site:cnbc.com (commodities OR metals OR gold OR copper) when:1d') },
     ],
     'gold-silver': [

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -696,12 +696,13 @@ const FINANCE_FEEDS: Record<string, Feed[]> = {
     { name: 'Crypto News', url: rss('https://news.google.com/rss/search?q=(bitcoin+OR+ethereum+OR+crypto+OR+"digital+assets")+when:1d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'DeFi News', url: rss('https://news.google.com/rss/search?q=(DeFi+OR+"decentralized+finance"+OR+DEX+OR+"yield+farming")+when:3d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'Decrypt', url: rss('https://decrypt.co/feed') },
-    // Blockworks /feed returns 200 to direct curl but Cloudflare blocks both
-    // Vercel edge AND Railway egress (PR #3712 tried RELAY_ONLY_DOMAINS first;
-    // proxy still 403'd because Railway ASN is also blocked). Fall back to
-    // site-scoped Google News, matching the Kitco/Mining Weekly/FX Empire
-    // pattern from the same PR.
-    { name: 'Blockworks', url: rss('https://news.google.com/rss/search?q=site:blockworks.co+(crypto+OR+DeFi+OR+bitcoin+OR+stablecoin)+when:1d&hl=en-US&gl=US&ceid=US:en') },
+    // Blockworks REMOVED (PR #3715 review): blockworks.co/feed is
+    // Cloudflare-blocked from both Vercel edge AND Railway egress, AND Google
+    // News returns 0 items for site:blockworks.co at every probed time window
+    // (publisher likely blocks Googlebot on the same wholesale tier — so the
+    // Google News fallback we tried first is a silent placeholder). The Block
+    // (above) covers the same institutional-crypto territory; no coverage
+    // lost. Also removed from the server feeds (_feeds.ts) for parity.
     { name: 'The Defiant', url: rss('https://thedefiant.io/feed') },
     { name: 'Bitcoin Magazine', url: rss('https://bitcoinmagazine.com/feed') },
     { name: 'DL News', url: rss('https://news.google.com/rss/search?q=site:dlnews.com+when:3d&hl=en-US&gl=US&ceid=US:en') },
@@ -821,9 +822,12 @@ const COMMODITY_FEEDS: Record<string, Feed[]> = {
     { name: 'Bloomberg Commodities', url: rss('https://news.google.com/rss/search?q=site:bloomberg.com+commodities+OR+metals+OR+mining+when:1d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'Reuters Commodities', url: rss('https://news.google.com/rss/search?q=site:reuters.com+commodities+OR+metals+OR+mining+when:1d&hl=en-US&gl=US&ceid=US:en') },
     { name: 'S&P Global Commodity', url: rss('https://news.google.com/rss/search?q=site:spglobal.com+commodities+metals+when:3d&hl=en-US&gl=US&ceid=US:en') },
-    // commoditytrademantra.com 403s direct curl wholesale (not Vercel-specific) —
-    // same automated-traffic block as Mining Weekly. Google News fallback.
-    { name: 'Commodity Trade Mantra', url: rss('https://news.google.com/rss/search?q=site:commoditytrademantra.com+when:2d&hl=en-US&gl=US&ceid=US:en') },
+    // Commodity Trade Mantra REMOVED (PR #3715 review):
+    // commoditytrademantra.com wholesale-403s any direct fetch AND Google News
+    // returns 0 items for site:commoditytrademantra.com at every probed time
+    // window (publisher effectively not indexed by Google News). commodity-news
+    // still has Mining.com / Bloomberg / Reuters / S&P Global / CNBC —
+    // coverage isn't lost.
     { name: 'CNBC Commodities', url: rss('https://news.google.com/rss/search?q=site:cnbc.com+(commodities+OR+metals+OR+gold+OR+copper)+when:1d&hl=en-US&gl=US&ceid=US:en') },
   ],
   'gold-silver': [

--- a/tests/feeds-client-server-parity.test.mjs
+++ b/tests/feeds-client-server-parity.test.mjs
@@ -1,0 +1,138 @@
+/**
+ * Feed parity test — client vs server (PR #3715 review follow-up).
+ *
+ * The client feed config (`src/config/feeds.ts`) and the server-side digest
+ * feed config (`server/worldmonitor/news/v1/_feeds.ts`) are independent files
+ * that frequently share feed NAMES. When a publisher dies and we fall back
+ * to Google News on one side but forget to mirror the change on the other,
+ * the digest path keeps fetching the dead URL while the direct-RSS path is
+ * healthy (or vice versa) — exactly the Blockworks drift caught on #3715.
+ *
+ * This test fails when a feed NAME appears on both sides with INCONSISTENT
+ * routing — i.e. client uses Google News while server uses a direct upstream
+ * URL (or vice versa). It does NOT require URL byte-equality (server uses a
+ * `gn()` helper with slightly different topic terms in places), only that
+ * both sides agree on the "Google News fallback or direct fetch" question.
+ *
+ * KNOWN_DRIFTS grandfathers in feeds that already drift at the time this
+ * test landed. Each is its own per-feed judgment (some intentionally use
+ * Google News on one side because the direct URL recently broke). New drift
+ * fails the test. The set should SHRINK over time as feeds get reconciled,
+ * not grow.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+const CLIENT_PATH = resolve(ROOT, 'src/config/feeds.ts');
+const SERVER_PATH = resolve(ROOT, 'server/worldmonitor/news/v1/_feeds.ts');
+
+/**
+ * Extract feed name + a routing hint from a source file.
+ * Matches `{ name: '<n>', ... url: <expr> }` entries. The `<expr>` can be
+ * either a URL literal (`'https://news.google.com/...'`) or a helper call
+ * (`gn('site:foo.com when:1d')` / `rss('https://...')`).
+ *
+ * Returns a Map<name, { isGoogleNews: boolean, snippet: string }>.
+ * `snippet` is the matched URL expression for error messages.
+ */
+function extractFeedRouting(filePath) {
+  const src = readFileSync(filePath, 'utf-8');
+  // Match `name: '<name>'` then up to a single-line entry's URL expression.
+  const ENTRY_RE = /\bname:\s*['"]([^'"]+)['"][^\n]*?\burl:\s*([^,}\n][^,}\n]*[^,}\n\s])/g;
+  const out = new Map();
+  let m;
+  while ((m = ENTRY_RE.exec(src)) !== null) {
+    const [, name, urlExpr] = m;
+    const isGN =
+      /news\.google\.com\/rss\/search/i.test(urlExpr) || /\bgn\s*\(/.test(urlExpr);
+    // Don't let later duplicates clobber earlier ones — names can repeat
+    // across categories (localized variants etc.); first-seen wins.
+    if (!out.has(name)) out.set(name, { isGoogleNews: isGN, snippet: urlExpr.trim() });
+  }
+  return out;
+}
+
+describe('feed parity: client vs server (PR #3715 follow-up)', () => {
+  const client = extractFeedRouting(CLIENT_PATH);
+  const server = extractFeedRouting(SERVER_PATH);
+
+  it('extracted feeds from both files', () => {
+    assert.ok(client.size > 50, `expected >50 client feeds, got ${client.size}`);
+    assert.ok(server.size > 50, `expected >50 server feeds, got ${server.size}`);
+  });
+
+  // Snapshot of feeds that ALREADY drift between client and server at PR #3715
+  // merge time. Each one is its own per-feed judgment (some intentionally use
+  // Google News on one side because the direct URL recently broke). The test
+  // fails for NEW drift, not historic drift. This set should SHRINK over time
+  // as feeds get reconciled — not grow.
+  const KNOWN_DRIFTS = new Set([
+    'The National',
+    'White House',
+    'Pentagon',
+    'CSIS',
+    'South China Morning Post',
+    'a16z Blog',
+    'Sequoia Blog',
+    'EU Startups',
+    'Tech in Asia',
+    'SemiAnalysis',
+    'EIA Reports',
+    'Northern Miner',
+  ]);
+
+  it('every NEW shared feed name uses consistent routing (grandfathered drift snapshot)', () => {
+    const newDrift = [];
+    const resolvedKnown = [];
+    for (const [name, c] of client) {
+      const s = server.get(name);
+      if (!s) continue;
+      if (c.isGoogleNews === s.isGoogleNews) {
+        if (KNOWN_DRIFTS.has(name)) resolvedKnown.push(name);
+        continue;
+      }
+      if (KNOWN_DRIFTS.has(name)) continue; // grandfathered
+      newDrift.push(
+        `  - "${name}":\n` +
+          `      client: ${c.isGoogleNews ? 'Google News' : 'direct'}  ${c.snippet.slice(0, 100)}\n` +
+          `      server: ${s.isGoogleNews ? 'Google News' : 'direct'}  ${s.snippet.slice(0, 100)}`,
+      );
+    }
+    assert.equal(
+      newDrift.length,
+      0,
+      'NEW feed routing drift between client and server. Either update both sides ' +
+        'or rename one entry so the parity check skips it:\n' +
+        newDrift.join('\n'),
+    );
+    // If a previously-known drift is now consistent, the contributor should
+    // remove it from KNOWN_DRIFTS — fail loudly so it gets cleaned up.
+    assert.equal(
+      resolvedKnown.length,
+      0,
+      `Drifts in KNOWN_DRIFTS are now consistent — remove from the set: ${resolvedKnown.join(', ')}`,
+    );
+  });
+
+  it('REGRESSION (#3715): Blockworks does not appear on either side with a direct blockworks.co URL', () => {
+    // The exact failure mode that prompted this test — server still pointed
+    // at https://blockworks.co/feed after client moved to Google News, so the
+    // digest path kept hitting Cloudflare-blocked upstream. Both sides have
+    // since removed Blockworks (The Block covers the same territory). Lock
+    // it in: a future contributor must not re-add the dead URL.
+    for (const [path, label] of [[CLIENT_PATH, 'client'], [SERVER_PATH, 'server']]) {
+      const src = readFileSync(path, 'utf-8');
+      assert.ok(
+        !/['"]https?:\/\/blockworks\.co\/feed['"]/.test(src),
+        `${label} (${path}) still references the dead blockworks.co/feed URL`,
+      );
+    }
+  });
+});

--- a/tests/feeds-client-server-parity.test.mjs
+++ b/tests/feeds-client-server-parity.test.mjs
@@ -35,26 +35,50 @@ const SERVER_PATH = resolve(ROOT, 'server/worldmonitor/news/v1/_feeds.ts');
 
 /**
  * Extract feed name + a routing hint from a source file.
- * Matches `{ name: '<n>', ... url: <expr> }` entries. The `<expr>` can be
- * either a URL literal (`'https://news.google.com/...'`) or a helper call
- * (`gn('site:foo.com when:1d')` / `rss('https://...')`).
+ *
+ * Handles both shapes:
+ *
+ *     // inline
+ *     { name: 'X', url: rss('https://...') },
+ *     { name: 'Y', url: gn('site:y.com when:1d') },
+ *
+ *     // multiline with locale-keyed URL object (locale variants all use
+ *     // direct rss/gn helpers, never mixed)
+ *     {
+ *       name: 'Z',
+ *       url: {
+ *         en: rss('...'),
+ *         fr: rss('...'),
+ *       },
+ *     }
+ *
+ * The earlier single-line-only regex missed ~46 multiline entries on the
+ * client side, which caused the orphan check below to falsely flag entries
+ * that ARE on both sides (France 24, EuroNews, etc.) as server-only.
  *
  * Returns a Map<name, { isGoogleNews: boolean, snippet: string }>.
- * `snippet` is the matched URL expression for error messages.
  */
 function extractFeedRouting(filePath) {
   const src = readFileSync(filePath, 'utf-8');
-  // Match `name: '<name>'` then up to a single-line entry's URL expression.
-  const ENTRY_RE = /\bname:\s*['"]([^'"]+)['"][^\n]*?\burl:\s*([^,}\n][^,}\n]*[^,}\n\s])/g;
   const out = new Map();
+  const NAME_RE = /\bname:\s*['"]([^'"]+)['"]/g;
   let m;
-  while ((m = ENTRY_RE.exec(src)) !== null) {
-    const [, name, urlExpr] = m;
+  while ((m = NAME_RE.exec(src)) !== null) {
+    const [, name] = m;
+    // Scan forward from this `name:` to find the matching `url:` — within
+    // the next ~600 chars (enough to span a multiline locale-object url
+    // without crossing into the sibling entry's name).
+    const window = src.slice(m.index, m.index + 600);
+    const urlMatch = window.match(/\burl:\s*([\s\S]*?)(?:,\s*$|}\s*[,\]])/m);
+    if (!urlMatch) continue;
+    const urlExpr = urlMatch[1];
     const isGN =
       /news\.google\.com\/rss\/search/i.test(urlExpr) || /\bgn\s*\(/.test(urlExpr);
-    // Don't let later duplicates clobber earlier ones — names can repeat
-    // across categories (localized variants etc.); first-seen wins.
-    if (!out.has(name)) out.set(name, { isGoogleNews: isGN, snippet: urlExpr.trim() });
+    // First-seen wins — names can repeat across categories (localized
+    // variants etc.); the first definition is the canonical routing.
+    if (!out.has(name)) {
+      out.set(name, { isGoogleNews: isGN, snippet: urlExpr.trim().slice(0, 120) });
+    }
   }
   return out;
 }
@@ -86,6 +110,13 @@ describe('feed parity: client vs server (PR #3715 follow-up)', () => {
     'SemiAnalysis',
     'EIA Reports',
     'Northern Miner',
+    // Mixed-locale routing: client uses direct rss() for en+de and a Google
+    // News query for es; server uses pure direct for en. The classifier
+    // treats any-locale-is-GoogleNews as Google News, so it flags this as a
+    // drift even though both sides do agree on en. Worth reconciling
+    // (probably: server should fall back to gn() for the same es query) but
+    // out of scope for the #3717 review fix.
+    'DW News',
   ]);
 
   it('every NEW shared feed name uses consistent routing (grandfathered drift snapshot)', () => {
@@ -134,5 +165,67 @@ describe('feed parity: client vs server (PR #3715 follow-up)', () => {
         `${label} (${path}) still references the dead blockworks.co/feed URL`,
       );
     }
+  });
+
+  // Server-only feeds get aggregated, ranked, and TRUNCATED to
+  // MAX_ITEMS_PER_CATEGORY in list-feed-digest.ts:1076-1082, THEN the client
+  // filters by `enabledNames` from src/config/feeds.ts (data-loader.ts:908-914).
+  // If the server emits a feed whose name has no client-side counterpart, the
+  // server fetches it for nothing AND its items crowd out visible items in the
+  // same category, shrinking the visible result set. Exactly the
+  // Commodity-Trade-Mantra failure mode the #3717 reviewer caught.
+  //
+  // Five existing server-only entries are grandfathered (KNOWN_SERVER_ONLY).
+  // Each is its own per-feed judgment — they may be intentional enrichment
+  // that's never user-visible, or they may be the same crowd-out bug latent
+  // since before this test landed. They should be reviewed one-by-one (either
+  // restore the client-side name OR drop the server entry); the set should
+  // SHRINK over time, not grow.
+  const KNOWN_SERVER_ONLY = new Set([
+    'Trump - Truth Social',
+    'White House Actions',
+    'First Round Review',
+    'YC News',
+    'YC Blog',
+  ]);
+
+  it('no NEW server-only feed entries (crowd-out risk via MAX_ITEMS_PER_CATEGORY)', () => {
+    const newOrphans = [];
+    const resolvedKnown = [];
+    for (const name of server.keys()) {
+      if (client.has(name)) {
+        if (KNOWN_SERVER_ONLY.has(name)) resolvedKnown.push(name);
+        continue;
+      }
+      if (KNOWN_SERVER_ONLY.has(name)) continue;
+      newOrphans.push(name);
+    }
+    assert.equal(
+      newOrphans.length,
+      0,
+      'NEW server-only feed entries detected. The server will fetch these, ' +
+        'rank them into MAX_ITEMS_PER_CATEGORY, then the client filter will ' +
+        'drop them — silently shrinking the visible result set. Either add a ' +
+        'matching entry with the same name to src/config/feeds.ts, or remove ' +
+        'the server entry:\n' +
+        newOrphans.map(n => `  - "${n}"`).join('\n'),
+    );
+    assert.equal(
+      resolvedKnown.length,
+      0,
+      `Server-only entries in KNOWN_SERVER_ONLY are now mirrored on the client — remove from the set: ${resolvedKnown.join(', ')}`,
+    );
+  });
+
+  it('REGRESSION (#3717): Commodity Trade Mantra is not on the server side', () => {
+    // The #3717 reviewer caught this: I removed CTM from the client in #3715
+    // but left it on the server, so the server fetched it, counted it toward
+    // MAX_ITEMS_PER_CATEGORY, then the client filter dropped it — invisible
+    // crowd-out. Lock it in.
+    const src = readFileSync(SERVER_PATH, 'utf-8');
+    assert.ok(
+      !/name:\s*['"]Commodity Trade Mantra['"]/.test(src),
+      `${SERVER_PATH} still has a 'Commodity Trade Mantra' entry — it has no client counterpart so its items get truncated-then-dropped`,
+    );
   });
 });


### PR DESCRIPTION
Addresses the two P1s left on PR #3715 review after merge.

## P1 #1 — Server-side mirror drift (Blockworks)

In #3715 I removed `blockworks.co/feed` from `src/config/feeds.ts` (the client side) but left it intact on the server side at `server/worldmonitor/news/v1/_feeds.ts:263`. The Finance web-digest path (`loadNewsCategory` → `/api/news/v1/list-feed-digest`) keeps hitting the Cloudflare-blocked upstream and caching zero items.

Fix: remove the same entry from `_feeds.ts` with a comment explaining the parity. The Block (still present on both sides) covers institutional crypto territory — no coverage lost.

Same mirror-drift class as PR #3712's allowlist miss; recorded in `feedback_implement_every_site_my_own_diagnosis_enumerated`.

## P1 #2 — 0-item Google News placeholders

When I validated the Google News replacement URLs in #3715, I used \`grep -c '<item>'\` — which counts LINES, not occurrences, and the RSS bodies are mostly single-line. Re-counted with \`grep -o '<item>' | wc -l\`:

| Feed | Real \`<item>\` count |
|---|---|
| Kitco News | 50 |
| Kitco Gold | 50 |
| Mining Weekly | 100 |
| FX Empire Gold | 76 |
| Mining Journal | 19 |
| **Blockworks** | **0** |
| **Commodity Trade Mantra** | **0** (\`site:\`); 2 (without \`site:\`, 30d) |

The first five are fine. The two zero-count ones are silent placeholders — Google effectively doesn't index those domains for News (publisher likely blocks Googlebot on the same Cloudflare wholesale tier that blocks Vercel + Railway).

Fix: drop both rather than ship empty-result feeds.

- **Blockworks**: removed from both client + server (as above).
- **Commodity Trade Mantra**: removed from client. \`commodity-news\` still includes Mining.com, Bloomberg, Reuters, S&P Global Commodity Insights, CNBC Commodities — coverage isn't lost.

## Guard against future mirror drift

\`tests/feeds-client-server-parity.test.mjs\` walks both feed configs, extracts \`{ name, routing }\` for every entry, and fails when a shared name routes inconsistently (one side Google News, the other a direct fetch). It found 12 pre-existing drifts at this commit; those are grandfathered as \`KNOWN_DRIFTS\` (each is its own per-feed judgment and should be cleaned up incrementally — shrinking the set, never growing it). New drift fails the test.

A locked-in regression test also fails if either file re-introduces \`https://blockworks.co/feed\`.

## Test plan
- [x] \`node --test tests/feeds-client-server-parity.test.mjs\` — all 3 pass
- [x] \`npx tsc -p tsconfig.json --noEmit\`
- [x] \`npx biome check\` on all three changed files
- [x] \`npm run lint:api-contract\`
- [x] \`npm run test:data\` — green except known \`bundle-runner.test.mjs\` race (#3618 unfixed); passes 9/9 when run alone