### PR TITLE
fix(daily-market-brief): cap LLM summarizer + total build budget so the panel can't hang forever

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -1712,7 +1712,18 @@ export class DataLoaderManager implements AppModule {
     } catch (error) {
       console.warn('[DailyBrief] Failed to build daily market brief:', error);
       const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
-      const cached = await getCachedDailyMarketBrief(timezone).catch(() => null);
+      // Same 3s cap as the upfront cache read above — covers the
+      // "build hung AND IndexedDB also degraded" double-failure mode
+      // (Greptile #3718 P2): without this guard the recovery path can
+      // itself hang, leaving the panel stuck on whatever the previous
+      // state was. .catch(() => null) absorbs both the TimeoutError and
+      // any persistent-cache read failure into the same null-result
+      // branch that the existing showError fallback already handles.
+      const cached = await withTimeout(
+        getCachedDailyMarketBrief(timezone),
+        3_000,
+        'daily-brief-cache-read-recovery',
+      ).catch(() => null);
       if (cached?.available) {
         this.callPanel('daily-market-brief', 'renderBrief', cached, 'cached');
         return;

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -17,6 +17,7 @@ import {
 import { resolveNewsCategories, enabledNewsCategoryKeys } from '@/config/feed-resolution';
 import { INTEL_HOTSPOTS, CONFLICT_ZONES } from '@/config/geo';
 import { tokenizeForMatch, matchKeyword } from '@/utils/keyword-match';
+import { withTimeout } from '@/utils/with-timeout';
 import {
   fetchCategoryFeeds,
   getFeedFailures,
@@ -1641,7 +1642,14 @@ export class DataLoaderManager implements AppModule {
     this.ctx.inFlight.add('dailyMarketBrief');
     try {
       const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
-      const cached = await getCachedDailyMarketBrief(timezone);
+      // Bound the IndexedDB cache read so a hung persistent-cache layer
+      // can't keep the panel on its default Loading state forever — fall
+      // through to "build from scratch" instead.
+      const cached = await withTimeout(
+        getCachedDailyMarketBrief(timezone),
+        3_000,
+        'daily-brief-cache-read',
+      ).catch(() => null);
 
       if (cached?.available) {
         this.callPanel('daily-market-brief', 'renderBrief', cached, 'cached');
@@ -1664,20 +1672,31 @@ export class DataLoaderManager implements AppModule {
       const yieldCurveContext = r1.status === 'fulfilled' ? r1.value : undefined;
       const sectorContext = r2.status === 'fulfilled' ? r2.value : undefined;
 
-      const brief = await buildDailyMarketBrief({
-        markets: this.ctx.latestMarkets,
-        newsByCategory: this.ctx.newsByCategory,
-        timezone,
-        regimeContext,
-        yieldCurveContext,
-        sectorContext,
-        frameworkAppend: getActiveFrameworkForPanel('daily-market-brief')?.systemPromptAppend,
-        newsCategories: SITE_VARIANT === 'commodity'
-          ? ['commodity-news', 'gold-silver', 'mining-news', 'energy', 'critical-minerals']
-          : SITE_VARIANT === 'energy'
-            ? ['live-news', 'energy', 'supply-chain']
-            : undefined,
-      });
+      // Wall-clock budget on the whole build. The inner summarizer has its
+      // own 45s cap (SUMMARIZER_TIMEOUT_MS in daily-market-brief.ts) and
+      // falls back to rules-based output, so this outer 60s budget only
+      // fires if the rules-based path itself hangs (shouldn't, but defensive
+      // — covers e.g. a getDefaultSummarizer() dynamic-import that never
+      // resolves). On timeout the existing catch below serves the cached
+      // version or shows an error, never letting the panel stay stuck.
+      const brief = await withTimeout(
+        buildDailyMarketBrief({
+          markets: this.ctx.latestMarkets,
+          newsByCategory: this.ctx.newsByCategory,
+          timezone,
+          regimeContext,
+          yieldCurveContext,
+          sectorContext,
+          frameworkAppend: getActiveFrameworkForPanel('daily-market-brief')?.systemPromptAppend,
+          newsCategories: SITE_VARIANT === 'commodity'
+            ? ['commodity-news', 'gold-silver', 'mining-news', 'energy', 'critical-minerals']
+            : SITE_VARIANT === 'energy'
+              ? ['live-news', 'energy', 'supply-chain']
+              : undefined,
+        }),
+        60_000,
+        'daily-brief-total-build',
+      );
 
       if (this.dailyBriefGeneration !== gen) return;
 

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -1663,9 +1663,20 @@ export class DataLoaderManager implements AppModule {
         this.callPanel('daily-market-brief', 'showLoading', 'Building daily market brief...');
       }
 
+      // Each context collector calls a generated RPC client without its
+      // own timeout (`getFearGreedIndex`, `getFredSeriesBatch`); the
+      // `try { ... } catch` inside each collector only handles rejections
+      // — a hung RPC sits forever and `Promise.allSettled` waits with it.
+      // That's the same hang-class this PR was opened to fix; an earlier
+      // commit missed these three call sites because they were two layers
+      // up from the `summaryProvider` await I was hunting. 8s per
+      // collector is generous for an RPC and leaves >36s of the outer
+      // 60s budget for the actual LLM call.
+      // `_collectSectorContext` is sync (reads only hydrated data) so it
+      // needs no wrapping; allSettled accepts non-promises directly.
       const [r0, r1, r2] = await Promise.allSettled([
-        this._collectRegimeContext(),
-        this._collectYieldCurveContext(),
+        withTimeout(this._collectRegimeContext(), 8_000, 'daily-brief-regime-context'),
+        withTimeout(this._collectYieldCurveContext(), 8_000, 'daily-brief-yield-context'),
         this._collectSectorContext(),
       ]);
       const regimeContext = r0.status === 'fulfilled' ? r0.value : undefined;
@@ -1707,8 +1718,22 @@ export class DataLoaderManager implements AppModule {
         return;
       }
 
-      await cacheDailyMarketBrief(brief);
+      // Render first, persist after. The previous order `await
+      // cacheDailyMarketBrief(brief); render(brief)` meant a hung
+      // IndexedDB / Tauri-Store write blocked the panel from ever
+      // displaying the finished brief — the build budget proved nothing
+      // by itself. Now: user sees the brief immediately; the cache write
+      // runs fire-and-forget with its own 5s budget so a hung backend
+      // becomes "no warmup for tomorrow's load" instead of "panel stuck
+      // on Building forever."
       this.callPanel('daily-market-brief', 'renderBrief', brief, 'live');
+      void withTimeout(
+        cacheDailyMarketBrief(brief),
+        5_000,
+        'daily-brief-cache-write',
+      ).catch((err) => {
+        console.warn('[DailyBrief] cache write failed or timed out:', (err as Error).message);
+      });
     } catch (error) {
       console.warn('[DailyBrief] Failed to build daily market brief:', error);
       const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';

--- a/src/services/daily-market-brief.ts
+++ b/src/services/daily-market-brief.ts
@@ -2,6 +2,18 @@ import type { MarketData, NewsItem } from '@/types';
 import type { MarketWatchlistEntry } from './market-watchlist';
 import { getMarketWatchlistEntries } from './market-watchlist';
 import type { SummarizationResult } from './summarization';
+import { withTimeout } from '@/utils/with-timeout';
+
+/**
+ * Upper bound on the LLM summarization step. The full chain
+ * (newsClient.summarizeArticle → Vercel function → OpenRouter/Groq) has
+ * no per-call timeout of its own; without this cap a hung upstream
+ * leaves the panel stuck on "Building daily market brief..." and the
+ * try/catch below is useless against a pending-forever promise. On
+ * timeout we fall through to the rules-based summary (already
+ * pre-computed by `buildRuleSummary` at the top of this branch).
+ */
+const SUMMARIZER_TIMEOUT_MS = 45_000;
 
 export interface DailyMarketBriefItem {
   symbol: string;
@@ -71,6 +83,11 @@ export interface BuildDailyMarketBriefOptions {
   sectorContext?: SectorBriefContext;
   frameworkAppend?: string;
   newsCategories?: string[];
+  /** Override the per-call summarizer budget. Defaults to
+   *  `SUMMARIZER_TIMEOUT_MS` (45s). Tests pass a small value to assert the
+   *  rules-based fallback fires when the LLM hangs without having to wait
+   *  the full prod budget. */
+  summarizerTimeoutMs?: number;
   summarize?: (
     headlines: string[],
     onProgress?: undefined,
@@ -429,11 +446,10 @@ export async function buildDailyMarketBrief(options: BuildDailyMarketBriefOption
   if (summaryHeadlines.length >= 1) {
     try {
       const summaryProvider = options.summarize || await getDefaultSummarizer();
-      const generated = await summaryProvider(
-        summaryHeadlines,
-        undefined,
-        extendedContext,
-        'en',
+      const generated = await withTimeout(
+        summaryProvider(summaryHeadlines, undefined, extendedContext, 'en'),
+        options.summarizerTimeoutMs ?? SUMMARIZER_TIMEOUT_MS,
+        'daily-brief-summary',
       );
       if (generated?.summary) {
         summary = generated.summary.trim();

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -177,6 +177,7 @@ export function shuffle<T>(arr: T[]): T[] {
 export { proxyUrl, fetchWithProxy, rssProxyUrl } from './proxy';
 export { exportToJSON, exportToCSV, ExportPanel } from './export';
 export { buildMapUrl, parseMapUrlState } from './urlState';
+export { withTimeout, TimeoutError } from './with-timeout';
 export type { ParsedMapUrlState } from './urlState';
 export { CircuitBreaker, createCircuitBreaker, getCircuitBreakerStatus, getCircuitBreakerCooldownInfo } from './circuit-breaker';
 export type { CircuitBreakerOptions } from './circuit-breaker';

--- a/src/utils/with-timeout.ts
+++ b/src/utils/with-timeout.ts
@@ -1,0 +1,56 @@
+/**
+ * Race a promise against a deadline.
+ *
+ * If `promise` resolves or rejects within `ms`, the original outcome is
+ * returned. If not, the returned promise rejects with a `TimeoutError`
+ * whose `.label` matches the `label` argument so callers can identify
+ * which budget tripped without parsing the message string.
+ *
+ * Why this exists: a try/catch only handles REJECTIONS — a promise that
+ * never resolves never reaches catch. UI panels and seeders that `await`
+ * an unbounded network/LLM call without a per-call timeout can sit on a
+ * loading state forever when the upstream hangs (Vercel default function
+ * limits + TCP keepalive can keep a fetch pending indefinitely from the
+ * client's perspective). Wrap such awaits in `withTimeout`.
+ *
+ * The pending source promise is NOT cancelled — JS has no general way to
+ * cancel a Promise. If you need true cancellation (release the socket,
+ * stop the LLM cost meter), wire an `AbortController` and pass its
+ * `signal` to the underlying fetch — `withTimeout` is the budget,
+ * `AbortSignal` is the cancellation.
+ */
+
+export class TimeoutError extends Error {
+  public readonly label: string;
+  public readonly timeoutMs: number;
+  constructor(label: string, timeoutMs: number) {
+    super(`[${label}] timed out after ${timeoutMs}ms`);
+    this.name = 'TimeoutError';
+    this.label = label;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string,
+  onTimeout?: () => void,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      if (onTimeout) {
+        try {
+          onTimeout();
+        } catch {
+          // Don't let an onTimeout callback hijack the reject path.
+        }
+      }
+      reject(new TimeoutError(label, ms));
+    }, ms);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer);
+  });
+}

--- a/tests/daily-market-brief.test.mts
+++ b/tests/daily-market-brief.test.mts
@@ -148,4 +148,39 @@ describe('buildDailyMarketBrief', () => {
     assert.equal(brief.items.length, 4, 'should top up to DEFAULT_TARGET_COUNT, not collapse to 1');
     assert.equal(brief.items[0]?.display, 'NVDA', 'the user pick leads');
   });
+
+  it('REGRESSION: a hanging summarizer must not stall the brief — falls back to rules within the timeout', async () => {
+    // Repro the actual prod symptom: the LLM provider call (newsClient
+    // .summarizeArticle → Vercel function → OpenRouter/Groq) hangs without
+    // ever rejecting, and the panel sits on "Building daily market brief..."
+    // forever because the try/catch around summarizeProvider only handles
+    // rejections — not pending-forever promises. The fix (PR
+    // fix/daily-market-brief-timeouts) wraps the summarizer call in
+    // withTimeout; on timeout the catch fires and falls back to the
+    // pre-computed rules-based summary. Use a tight summarizerTimeoutMs so
+    // the test runs in ~30ms instead of waiting the prod 45s budget.
+    const start = Date.now();
+    const brief = await buildDailyMarketBrief({
+      markets,
+      newsByCategory: {
+        markets: [makeNewsItem('NVIDIA holds gains as chip demand remains firm')],
+      },
+      timezone: 'UTC',
+      now: new Date('2026-03-08T10:30:00.000Z'),
+      targets: [{ symbol: 'NVDA', name: 'NVIDIA', display: 'NVDA' }],
+      // Pending-forever — what a hung LLM upstream looks like from the
+      // client side.
+      summarize: () => new Promise(() => {}),
+      summarizerTimeoutMs: 30,
+    });
+    const elapsed = Date.now() - start;
+
+    assert.equal(brief.available, true, 'must return a usable brief, not throw or hang');
+    assert.equal(brief.provider, 'rules', 'must mark the fallback provider so UI can show it');
+    assert.equal(brief.fallback, true);
+    assert.match(brief.summary, /watchlist|breadth|headline flow/i);
+    // Budget is 30ms; tolerate generous CI variance but assert we didn't
+    // wait the prod 45s (proving the timeout actually fired).
+    assert.ok(elapsed < 5_000, `elapsed ${elapsed}ms — withTimeout did not fire`);
+  });
 });

--- a/tests/with-timeout.test.mjs
+++ b/tests/with-timeout.test.mjs
@@ -1,0 +1,79 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { withTimeout, TimeoutError } from '../src/utils/with-timeout.ts';
+
+describe('withTimeout', () => {
+  it('resolves with the source value when the source resolves first', async () => {
+    const v = await withTimeout(Promise.resolve(42), 50, 'unit');
+    assert.equal(v, 42);
+  });
+
+  it('rejects with the source error when the source rejects first', async () => {
+    const err = new Error('boom');
+    await assert.rejects(
+      () => withTimeout(Promise.reject(err), 50, 'unit'),
+      (e) => e === err,
+    );
+  });
+
+  it('rejects with a TimeoutError after the budget when the source hangs forever', async () => {
+    const pendingForever = new Promise(() => {}); // intentional: never settles
+    const start = Date.now();
+    await assert.rejects(
+      () => withTimeout(pendingForever, 25, 'hang-test'),
+      (e) => {
+        assert.ok(e instanceof TimeoutError, `expected TimeoutError, got ${e}`);
+        assert.equal(e.label, 'hang-test');
+        assert.equal(e.timeoutMs, 25);
+        return true;
+      },
+    );
+    const elapsed = Date.now() - start;
+    assert.ok(elapsed >= 20 && elapsed < 200, `elapsed ${elapsed}ms outside [20,200)`);
+  });
+
+  it('clears the timer when the source resolves, so a longer test exits without dangling work', async () => {
+    // Tracks whether the timer-finalizer ran. If we don't clearTimeout, the
+    // reject path still fires and is swallowed by a finished Promise.race —
+    // but the node:test runner would keep the event loop alive until the
+    // budget elapses, which would balloon a 5ms test into a 5000ms one.
+    const start = Date.now();
+    const v = await withTimeout(
+      new Promise((res) => setTimeout(() => res('done'), 5)),
+      5_000, // big budget; if not cleared, test loop stays alive ~5s
+      'cleanup-check',
+    );
+    const elapsed = Date.now() - start;
+    assert.equal(v, 'done');
+    // A clean clearTimeout means we return as soon as the source resolves
+    // (~5ms), not after the 5_000ms budget.
+    assert.ok(elapsed < 500, `elapsed ${elapsed}ms — clearTimeout likely not firing`);
+  });
+
+  it('invokes onTimeout exactly once when the budget fires', async () => {
+    let calls = 0;
+    await assert.rejects(
+      () => withTimeout(new Promise(() => {}), 15, 'onTimeout-check', () => { calls++; }),
+      TimeoutError,
+    );
+    assert.equal(calls, 1);
+  });
+
+  it('does not invoke onTimeout when the source resolves first', async () => {
+    let calls = 0;
+    const v = await withTimeout(Promise.resolve('ok'), 50, 'no-timeout', () => { calls++; });
+    assert.equal(v, 'ok');
+    // Give any rogue timer a beat to fire (it shouldn't, but prove it).
+    await new Promise((res) => setTimeout(res, 30));
+    assert.equal(calls, 0);
+  });
+
+  it('swallows onTimeout errors and still rejects with the TimeoutError', async () => {
+    await assert.rejects(
+      () => withTimeout(new Promise(() => {}), 15, 'throwing-cb', () => {
+        throw new Error('callback should not hijack the reject path');
+      }),
+      TimeoutError,
+    );
+  });
+});

--- a/tests/with-timeout.test.mts
+++ b/tests/with-timeout.test.mts
@@ -76,4 +76,25 @@ describe('withTimeout', () => {
       TimeoutError,
     );
   });
+
+  it('does not invoke onTimeout when the source rejects before the budget', async () => {
+    // Coverage gap surfaced by Greptile on PR #3718: a source that rejects
+    // FAST should NOT trigger the onTimeout side-effect (the previous
+    // "does not invoke onTimeout when the source resolves first" test only
+    // covered the resolve path). Without the .finally(clearTimeout) the
+    // timer would fire after Promise.race already settled with the
+    // rejection — and onTimeout would run AFTER the rejection had already
+    // propagated to the caller. That's the worst kind of side-effect:
+    // visible to telemetry, but the caller already moved on.
+    let calls = 0;
+    const fastRejection = Promise.reject(new Error('immediate'));
+    await assert.rejects(
+      () => withTimeout(fastRejection, 50, 'reject-first', () => { calls++; }),
+      (err) => (err as Error).message === 'immediate',
+    );
+    // Wait past the budget to prove the timer was cleared (callback would
+    // have fired by now if clearTimeout hadn't run).
+    await new Promise((res) => setTimeout(res, 80));
+    assert.equal(calls, 0);
+  });
 });


### PR DESCRIPTION
## Symptom

PRO users were reporting the Daily Market Brief panel stuck on "Building daily market brief..." indefinitely after a cache miss. The try/catch around the summarizer was decorative — it only handles **rejections**, and a hung upstream (LLM provider slow, Vercel cold-start + slow network, transient TCP keepalive holding the socket open) leaves the awaited promise pending forever, never reaching catch.

I called myself out earlier in the session for claiming "it's a timeout issue" without proof. This PR has the evidence.

## Verified root cause

Traced the await chain top-to-bottom looking for ANY enforced timeout:

| Layer | File / line | Has a timeout? |
|---|---|---|
| `loadDailyMarketBrief` (panel entry) | `data-loader.ts:1635` | no |
| `buildDailyMarketBrief` | `daily-market-brief.ts:381` | no |
| `summaryProvider(...)` await | `daily-market-brief.ts:432` | **no** ← hang site |
| `generateSummary` | `summarization.ts:197` | no |
| `summaryResultBreaker.execute` | `summarization.ts:214` | no — `CircuitBreakerOptions` has no `timeoutMs` field (see `circuit-breaker.ts:20`) |
| `tryApiProvider` → `summaryBreaker.execute` | `summarization.ts:86` | no — same breaker, no timeout |
| `newsClient.summarizeArticle(...)` | generated client `service_client.ts:148` | accepts `options.signal` but **no caller passes one** |
| `vercel.json` | repo root | no `maxDuration` override |

The client awaits TCP keepalive — from the browser's perspective the fetch can be effectively forever.

## Fix

**`src/utils/with-timeout.ts`** — new utility. Races a promise with a deadline; rejects with a `TimeoutError` whose `.label` matches the caller's label. Source promise is not cancelled (JS has no general cancel), but the await unblocks and the caller's existing fallback path can fire. If true cancellation is needed (release the socket, stop the LLM cost meter), pair with an `AbortController` — \`withTimeout\` is the budget, \`AbortSignal\` is the cancellation.

**`src/services/daily-market-brief.ts:432`** — wrap `summaryProvider(...)` in \`withTimeout(..., 45_000, 'daily-brief-summary')\`. On timeout the **existing** catch (line 444) falls back to the rules-based summary (\`buildRuleSummary\`), which is already pre-computed at the top of the function — costs nothing extra. Added \`summarizerTimeoutMs?\` to \`BuildDailyMarketBriefOptions\` so tests can exercise the fallback in ~30ms without waiting 45s.

**\`src/app/data-loader.ts:1644\`** — wrap \`getCachedDailyMarketBrief(...)\` in a 3s \`withTimeout\` + \`.catch(() => null)\`. A hung persistent-cache layer can't keep the panel on its default Loading state — fall through to "build from scratch" instead.

**\`src/app/data-loader.ts:1667\`** — wrap \`buildDailyMarketBrief(...)\` in a 60s outer \`withTimeout\`. The inner summarizer has its own 45s cap; this outer budget catches exotic hangs the inner one wouldn't (dynamic import \`getDefaultSummarizer()\` hanging on a slow chunk fetch, etc.). The existing catch (line 1693) serves the cached version or shows an error.

## Test plan

\`tests/with-timeout.test.mjs\` — 7 unit tests:
- resolve-first / reject-first / hang→TimeoutError
- timer cleanup (the smoking-gun: a 5s-budget test that exits at 5ms not 5s)
- onTimeout called exactly once
- onTimeout not called when source resolves
- onTimeout-throw doesn't hijack the reject path

\`tests/daily-market-brief.test.mts\` — new regression test:

> \`a hanging summarizer must not stall the brief — falls back to rules within the timeout\`

Reproduces the actual prod shape with an injected \`() => new Promise(() => {})\` (pending forever) and asserts:
- \`brief.available === true\`
- \`brief.provider === 'rules'\`
- \`brief.fallback === true\`
- Elapsed under 5s (proves the 30ms test budget actually fired)

Local gate: typecheck PASS, biome on touched files PASS (4 pre-existing complexity warnings on \`data-loader.ts\` unrelated to this diff; present on bare main too), \`lint:api-contract\` PASS.