### PR TITLE
feat(panels): table-with-expand view for Stock Analysis + Backtesting (50-symbol scale)

### DIFF
--- a/src/components/StockAnalysisPanel.ts
+++ b/src/components/StockAnalysisPanel.ts
@@ -9,6 +9,7 @@ import { escapeHtml, sanitizeUrl } from '@/utils/sanitize';
 import type { StockAnalysisHistory } from '@/services/stock-analysis-history';
 import { sparkline } from '@/utils/sparkline';
 import { createWatchlistButton } from './watchlist-modal';
+import { WatchlistTableView } from './WatchlistTableView';
 
 function formatChange(change: number): string {
   const rounded = Number.isFinite(change) ? change.toFixed(2) : '0.00';
@@ -52,6 +53,14 @@ function txCodeLabel(code: string): string {
 
 export class StockAnalysisPanel extends Panel {
   private insiderBySymbol: Record<string, InsiderTransactionsResult> = {};
+  // Lazily initialised. WatchlistTableView holds the sort/filter/search
+  // state across data refreshes within the session — without it, every
+  // refresh resets the user's chosen sort or filter pill.
+  private tableView?: WatchlistTableView<StockAnalysisResult>;
+  // Cached so re-renders triggered by user interaction (filter/sort
+  // change) can rebuild HTML without a fresh fetch.
+  private lastItems: StockAnalysisResult[] = [];
+  private lastHistory: StockAnalysisHistory = {};
 
   constructor() {
     super({ id: 'stock-analysis', title: 'Premium Stock Analysis', infoTooltip: t('components.stockAnalysis.infoTooltip'), premium: 'locked' });
@@ -71,23 +80,82 @@ export class StockAnalysisPanel extends Panel {
 
     this.setDataBadge(source, `${items.length} symbols`);
 
+    this.lastItems = items;
+    this.lastHistory = historyBySymbol;
+
+    if (!this.tableView) {
+      this.tableView = new WatchlistTableView<StockAnalysisResult>({
+        intro: this.buildIntro(items.length),
+        columns: [
+          {
+            key: 'symbol', label: 'Symbol', sortable: true, sortOptionKey: 'symbol-asc',
+            cell: (i) => `<strong>${escapeHtml(i.display || i.symbol)}</strong>`,
+          },
+          {
+            key: 'price', label: 'Price', align: 'right',
+            cell: (i) => escapeHtml(formatPrice(i.currentPrice, i.currency)),
+          },
+          {
+            key: 'signal', label: 'Signal',
+            cell: (i) => `<span class="signal-badge ${stockSignalClass(i.signal)}">${escapeHtml(i.signal)}</span>`,
+          },
+          {
+            key: 'score', label: 'Score', align: 'right', sortable: true, sortOptionKey: 'score-desc',
+            cell: (i) => escapeHtml(String(i.signalScore)),
+          },
+          {
+            key: 'change', label: '1d %', align: 'right', sortable: true, sortOptionKey: 'change-desc',
+            cell: (i) => `<span style="color:${i.changePercent >= 0 ? 'var(--semantic-normal)' : 'var(--semantic-critical)'}">${escapeHtml(formatChange(i.changePercent))}</span>`,
+          },
+        ],
+        filters: [
+          { key: 'all', label: 'All', match: () => true },
+          { key: 'strong-buy', label: 'Strong Buy', match: (i) => i.signal.toLowerCase().includes('strong buy') },
+          { key: 'buy', label: 'Buy+', match: (i) => i.signal.toLowerCase().includes('buy') },
+          { key: 'hold', label: 'Hold', match: (i) => i.signal.toLowerCase().includes('hold') || i.signal.toLowerCase().includes('watch') },
+          { key: 'sell', label: 'Sell', match: (i) => i.signal.toLowerCase().includes('sell') },
+        ],
+        sortOptions: [
+          { key: 'score-desc', label: 'Score ↓', cmp: (a, b) => b.signalScore - a.signalScore },
+          { key: 'change-desc', label: '1d % ↓', cmp: (a, b) => b.changePercent - a.changePercent },
+          { key: 'symbol-asc', label: 'Symbol A-Z', cmp: (a, b) => (a.display || a.symbol).localeCompare(b.display || b.symbol) },
+        ],
+        defaultSort: 'score-desc',
+        defaultFilter: 'all',
+        getKey: (i) => i.symbol,
+        getSearchText: (i) => `${i.symbol} ${i.display || ''} ${i.name || ''}`,
+        renderDetail: (i) => this.renderCard(i, this.lastHistory[i.symbol] || []),
+        searchPlaceholder: 'Search ticker or name...',
+      });
+    } else {
+      // Refresh closures that capture the latest data each render —
+      // history and intro both depend on current items.
+      this.tableView.updateRenderDetail((i) => this.renderCard(i, this.lastHistory[i.symbol] || []));
+    }
+
+    this.tableView.setItems(items);
+    this.rerender();
+  }
+
+  // Mounts the table view's HTML and (re)binds its event handlers so
+  // sort/filter/search/expand survive across refreshes.
+  private rerender(): void {
+    if (!this.tableView) return;
+    // Keep the intro in sync with current item count + skipped-symbol
+    // note even as the table view persists across refreshes.
+    this.tableView.updateIntro(this.buildIntro(this.lastItems.length));
+    this.setContent(this.tableView.render());
+    this.tableView.bind(this.content, () => this.rerender());
+  }
+
+  private buildIntro(itemCount: number): string {
     const skippedCount = getMarketWatchlistEntries()
       .filter((entry) => !isAnalyzableSymbol(entry.symbol)).length;
-    const tickerWord = items.length === 1 ? 'ticker' : 'tickers';
+    const tickerWord = itemCount === 1 ? 'ticker' : 'tickers';
     const skippedNote = skippedCount > 0
       ? ` <span style="color:var(--text-dim)">${skippedCount} watchlist ${skippedCount === 1 ? 'symbol is an index/FX rate' : 'symbols are indices/FX rates'} and don't get an equity report.</span>`
       : '';
-
-    const html = `
-      <div style="display:flex;flex-direction:column;gap:12px">
-        <div style="font-size:12px;color:var(--text-dim);line-height:1.5">
-          Analyst-grade equity reports for the ${items.length} ${tickerWord} in your watchlist — your picks lead, popular names fill the rest. Use <strong>Edit Watchlist</strong> to add your own.${skippedNote}
-        </div>
-        ${items.map((item) => this.renderCard(item, historyBySymbol[item.symbol] || [])).join('')}
-      </div>
-    `;
-
-    this.setContent(html);
+    return `Analyst-grade equity reports for the ${itemCount} ${tickerWord} in your watchlist — your picks lead, popular names fill the rest. Use <strong>Edit Watchlist</strong> to add your own.${skippedNote}`;
   }
 
   private formatDividendRate(rate: number, currency: string): string {

--- a/src/components/StockBacktestPanel.ts
+++ b/src/components/StockBacktestPanel.ts
@@ -3,6 +3,7 @@ import { t } from '@/services/i18n';
 import type { StockBacktestResult } from '@/services/stock-backtest';
 import { escapeHtml } from '@/utils/sanitize';
 import { createWatchlistButton } from './watchlist-modal';
+import { WatchlistTableView } from './WatchlistTableView';
 
 function tone(value: number): string {
   if (value > 0) return '#8df0b2';
@@ -15,7 +16,21 @@ function fmtPct(value: number): string {
   return `${sign}${value.toFixed(1)}%`;
 }
 
+function backtestSignalClass(winRate: number): string {
+  if (winRate >= 55) return 'badge-bullish';
+  if (winRate >= 45) return 'badge-neutral';
+  return 'badge-bearish';
+}
+
+function backtestSignalLabel(winRate: number): string {
+  if (winRate >= 55) return 'Profitable';
+  if (winRate >= 45) return 'Mixed';
+  return 'Losing';
+}
+
 export class StockBacktestPanel extends Panel {
+  private tableView?: WatchlistTableView<StockBacktestResult>;
+
   constructor() {
     super({ id: 'stock-backtest', title: 'Premium Backtesting', infoTooltip: t('components.stockBacktest.infoTooltip'), premium: 'locked' });
     this.header.appendChild(createWatchlistButton('Edit Watchlist'));
@@ -30,46 +45,99 @@ export class StockBacktestPanel extends Panel {
 
     this.setDataBadge(source, `${items.length} symbols`);
 
-    const html = `
-      <div style="display:flex;flex-direction:column;gap:12px">
-        <div style="font-size:12px;color:var(--text-dim);line-height:1.5">
-          Historical replay of the premium stock-analysis signal engine over recent daily bars.
-        </div>
-        ${items.map((item) => `
-          <section style="border:1px solid var(--border);background:rgba(255,255,255,0.03);padding:14px;display:flex;flex-direction:column;gap:10px">
-            <div style="display:flex;justify-content:space-between;gap:12px;align-items:flex-start">
-              <div>
-                <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
-                  <strong style="font-size:16px;letter-spacing:-0.02em">${escapeHtml(item.name || item.symbol)}</strong>
-                  <span style="font-size:11px;color:var(--text-dim);font-family:var(--font-mono);text-transform:uppercase">${escapeHtml(item.display || item.symbol)}</span>
-                </div>
-                <div style="margin-top:6px;font-size:12px;color:var(--text-dim);line-height:1.5">${escapeHtml(item.summary)}</div>
-              </div>
-              <div style="text-align:right;min-width:110px">
-                <div style="font-size:18px;font-weight:700;color:${tone(item.avgSimulatedReturnPct)}">${escapeHtml(fmtPct(item.avgSimulatedReturnPct))}</div>
-                <div style="font-size:11px;color:var(--text-dim)">Avg simulated return</div>
-              </div>
-            </div>
-            <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:8px;font-size:11px">
-              <div style="border:1px solid var(--border);padding:8px"><div style="color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Win Rate</div><div style="margin-top:4px">${escapeHtml(fmtPct(item.winRate))}</div></div>
-              <div style="border:1px solid var(--border);padding:8px"><div style="color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Direction Accuracy</div><div style="margin-top:4px">${escapeHtml(fmtPct(item.directionAccuracy))}</div></div>
-              <div style="border:1px solid var(--border);padding:8px"><div style="color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Cumulative</div><div style="margin-top:4px;color:${tone(item.cumulativeSimulatedReturnPct)}">${escapeHtml(fmtPct(item.cumulativeSimulatedReturnPct))}</div></div>
-              <div style="border:1px solid var(--border);padding:8px"><div style="color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Signals</div><div style="margin-top:4px">${escapeHtml(String(item.actionableEvaluations))}</div></div>
-            </div>
-            <div style="display:grid;gap:6px">
-              <div style="font-size:11px;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-dim)">Recent Evaluations</div>
-              ${item.evaluations.map((evaluation) => `
-                <div style="display:flex;justify-content:space-between;gap:12px;padding:8px 10px;border:1px solid var(--border);background:rgba(255,255,255,0.02);font-size:11px">
-                  <span>${escapeHtml(evaluation.signal)} · ${escapeHtml(evaluation.outcome)} · ${escapeHtml(fmtPct(evaluation.simulatedReturnPct))}</span>
-                  <span style="color:var(--text-dim)">${escapeHtml(new Date(Number(evaluation.analysisAt)).toLocaleDateString())}</span>
-                </div>
-              `).join('')}
-            </div>
-          </section>
-        `).join('')}
-      </div>
-    `;
+    if (!this.tableView) {
+      this.tableView = new WatchlistTableView<StockBacktestResult>({
+        intro: 'Historical replay of the premium stock-analysis signal engine over recent daily bars.',
+        columns: [
+          {
+            key: 'symbol', label: 'Symbol', sortable: true, sortOptionKey: 'symbol-asc',
+            cell: (i) => `<strong>${escapeHtml(i.display || i.symbol)}</strong>`,
+          },
+          {
+            key: 'winrate', label: 'Win Rate', align: 'right', sortable: true, sortOptionKey: 'winrate-desc',
+            cell: (i) => escapeHtml(fmtPct(i.winRate)),
+          },
+          {
+            key: 'direction', label: 'Direction', align: 'right', sortable: true, sortOptionKey: 'direction-desc',
+            cell: (i) => escapeHtml(fmtPct(i.directionAccuracy)),
+          },
+          {
+            key: 'avgreturn', label: 'Avg Return', align: 'right', sortable: true, sortOptionKey: 'avgreturn-desc',
+            cell: (i) => `<span style="color:${tone(i.avgSimulatedReturnPct)}">${escapeHtml(fmtPct(i.avgSimulatedReturnPct))}</span>`,
+          },
+          {
+            key: 'signals', label: 'Signals', align: 'right', sortable: true, sortOptionKey: 'signals-desc',
+            cell: (i) => escapeHtml(String(i.actionableEvaluations)),
+          },
+        ],
+        filters: [
+          { key: 'all', label: 'All', match: () => true },
+          // The Win Rate ≥ 55% / ≥ 45% / < 45% bands mirror the
+          // Profitable / Mixed / Losing badge classifier in
+          // backtestSignalLabel so the pill semantics match the row badge.
+          { key: 'profitable', label: 'Profitable', match: (i) => i.winRate >= 55 },
+          { key: 'mixed', label: 'Mixed', match: (i) => i.winRate >= 45 && i.winRate < 55 },
+          { key: 'losing', label: 'Losing', match: (i) => i.winRate < 45 },
+        ],
+        sortOptions: [
+          { key: 'winrate-desc', label: 'Win Rate ↓', cmp: (a, b) => b.winRate - a.winRate },
+          { key: 'direction-desc', label: 'Direction ↓', cmp: (a, b) => b.directionAccuracy - a.directionAccuracy },
+          { key: 'avgreturn-desc', label: 'Avg Return ↓', cmp: (a, b) => b.avgSimulatedReturnPct - a.avgSimulatedReturnPct },
+          { key: 'signals-desc', label: 'Signals ↓', cmp: (a, b) => b.actionableEvaluations - a.actionableEvaluations },
+          { key: 'symbol-asc', label: 'Symbol A-Z', cmp: (a, b) => (a.display || a.symbol).localeCompare(b.display || b.symbol) },
+        ],
+        defaultSort: 'winrate-desc',
+        defaultFilter: 'all',
+        getKey: (i) => i.symbol,
+        getSearchText: (i) => `${i.symbol} ${i.display || ''} ${i.name || ''}`,
+        renderDetail: (i) => this.renderDetail(i),
+        searchPlaceholder: 'Search ticker or name...',
+      });
+    }
 
-    this.setContent(html);
+    this.tableView.setItems(items);
+    this.rerender();
+  }
+
+  private rerender(): void {
+    if (!this.tableView) return;
+    this.setContent(this.tableView.render());
+    this.tableView.bind(this.content, () => this.rerender());
+  }
+
+  private renderDetail(item: StockBacktestResult): string {
+    return `
+      <section style="padding:14px;display:flex;flex-direction:column;gap:10px">
+        <div style="display:flex;justify-content:space-between;gap:12px;align-items:flex-start">
+          <div>
+            <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+              <strong style="font-size:16px;letter-spacing:-0.02em">${escapeHtml(item.name || item.symbol)}</strong>
+              <span style="font-size:11px;color:var(--text-dim);font-family:var(--font-mono);text-transform:uppercase">${escapeHtml(item.display || item.symbol)}</span>
+              <span class="signal-badge ${backtestSignalClass(item.winRate)}">${escapeHtml(backtestSignalLabel(item.winRate))}</span>
+            </div>
+            <div style="margin-top:6px;font-size:12px;color:var(--text-dim);line-height:1.5">${escapeHtml(item.summary)}</div>
+          </div>
+          <div style="text-align:right;min-width:110px">
+            <div style="font-size:18px;font-weight:700;color:${tone(item.avgSimulatedReturnPct)}">${escapeHtml(fmtPct(item.avgSimulatedReturnPct))}</div>
+            <div style="font-size:11px;color:var(--text-dim)">Avg simulated return</div>
+          </div>
+        </div>
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(120px,1fr));gap:8px;font-size:11px">
+          <div style="border:1px solid var(--border);padding:8px"><div style="color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Win Rate</div><div style="margin-top:4px">${escapeHtml(fmtPct(item.winRate))}</div></div>
+          <div style="border:1px solid var(--border);padding:8px"><div style="color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Direction Accuracy</div><div style="margin-top:4px">${escapeHtml(fmtPct(item.directionAccuracy))}</div></div>
+          <div style="border:1px solid var(--border);padding:8px"><div style="color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Cumulative</div><div style="margin-top:4px;color:${tone(item.cumulativeSimulatedReturnPct)}">${escapeHtml(fmtPct(item.cumulativeSimulatedReturnPct))}</div></div>
+          <div style="border:1px solid var(--border);padding:8px"><div style="color:var(--text-dim);text-transform:uppercase;letter-spacing:0.08em">Signals</div><div style="margin-top:4px">${escapeHtml(String(item.actionableEvaluations))}</div></div>
+        </div>
+        <div style="display:grid;gap:6px">
+          <div style="font-size:11px;text-transform:uppercase;letter-spacing:0.08em;color:var(--text-dim)">Recent Evaluations</div>
+          ${item.evaluations.map((evaluation) => `
+            <div style="display:flex;justify-content:space-between;gap:12px;padding:8px 10px;border:1px solid var(--border);background:rgba(255,255,255,0.02);font-size:11px">
+              <span>${escapeHtml(evaluation.signal)} · ${escapeHtml(evaluation.outcome)} · ${escapeHtml(fmtPct(evaluation.simulatedReturnPct))}</span>
+              <span style="color:var(--text-dim)">${escapeHtml(new Date(Number(evaluation.analysisAt)).toLocaleDateString())}</span>
+            </div>
+          `).join('')}
+        </div>
+      </section>
+    `;
   }
 }

--- a/src/components/WatchlistTableView.ts
+++ b/src/components/WatchlistTableView.ts
@@ -1,0 +1,269 @@
+// Reusable table-with-expand view for watchlist-style panels (50+ symbols).
+// Renders a search/filter/sort control bar + sortable table where each row
+// expands inline to show full detail. Used by StockAnalysisPanel and
+// StockBacktestPanel; the long-scroll one-card-per-symbol layout doesn't
+// scale past ~10 symbols. Layout is option B from the watchlist panel
+// playground (watchlist-panel-playground.html).
+//
+// Lifecycle (called from owning panel):
+//   1. const view = new WatchlistTableView<T>({...config});
+//   2. view.setItems(items);
+//   3. panel.setContent(view.render());
+//   4. view.bind(panel.content, () => { panel.setContent(view.render()); view.bind(...); });
+//
+// State is held internally so sort/filter/search/expanded persist across
+// data refreshes within a session. Reset on full page reload (no
+// localStorage — keeps the surface narrow).
+
+import { escapeHtml } from '@/utils/sanitize';
+
+export interface WatchlistColumn<T> {
+  // Stable HTML-attribute-safe key. Used in data-sortkey attributes.
+  key: string;
+  // Header label (already humanized; no further transform applied).
+  label: string;
+  // When true, clicking the header column toggles/applies the matching
+  // sort option (looked up by sortOptionKey or falling back to key).
+  sortable?: boolean;
+  // The sort option to apply when this header is clicked.
+  sortOptionKey?: string;
+  // 'right' aligns the column content + header (numeric columns).
+  align?: 'left' | 'right';
+  // Returns HTML for the cell. Caller is responsible for escaping.
+  cell: (item: T) => string;
+}
+
+export interface WatchlistFilter<T> {
+  key: string;
+  label: string;
+  // Returns true to include the item.
+  match: (item: T) => boolean;
+}
+
+export interface WatchlistSortOption<T> {
+  key: string;
+  label: string;
+  cmp: (a: T, b: T) => number;
+}
+
+export interface WatchlistConfig<T> {
+  columns: WatchlistColumn<T>[];
+  filters: WatchlistFilter<T>[];
+  sortOptions: WatchlistSortOption<T>[];
+  defaultSort: string;
+  defaultFilter: string;
+  // Stable per-item key — drives expanded-row identity across rerenders.
+  getKey: (item: T) => string;
+  // Lower-cased haystack for the search-input filter.
+  getSearchText: (item: T) => string;
+  // The full detail card rendered when a row is expanded. Reuses the
+  // existing per-symbol renderer from the owning panel.
+  renderDetail: (item: T) => string;
+  // Optional intro text rendered above the controls (e.g. "Analyst-grade
+  // equity reports for the N tickers in your watchlist...").
+  intro?: string;
+  // Shown when no items match the current filter/search.
+  emptyMessage?: string;
+  searchPlaceholder?: string;
+}
+
+export class WatchlistTableView<T> {
+  private items: T[] = [];
+  private state: {
+    sort: string;
+    filter: string;
+    search: string;
+    expandedKey: string | null;
+  };
+
+  constructor(private config: WatchlistConfig<T>) {
+    this.state = {
+      sort: config.defaultSort,
+      filter: config.defaultFilter,
+      search: '',
+      expandedKey: null,
+    };
+  }
+
+  public setItems(items: T[]): void {
+    this.items = items;
+    // Drop the expanded row if the symbol is no longer in the dataset
+    // (e.g. watchlist editor removed it between refreshes).
+    if (this.state.expandedKey) {
+      const stillPresent = items.some((item) => this.config.getKey(item) === this.state.expandedKey);
+      if (!stillPresent) this.state.expandedKey = null;
+    }
+  }
+
+  // Replace the renderDetail closure (called on each data refresh to bind
+  // the latest history/insider/etc. captured in the panel's lexical scope).
+  public updateRenderDetail(fn: (item: T) => string): void {
+    this.config = { ...this.config, renderDetail: fn };
+  }
+
+  // Replace the intro string (called per render so the item count or
+  // skipped-symbol note stays in sync with the latest items).
+  public updateIntro(intro: string): void {
+    this.config = { ...this.config, intro };
+  }
+
+  public render(): string {
+    const list = this.getFilteredSorted();
+    const intro = this.config.intro
+      ? `<div class="watchlist-intro">${this.config.intro}</div>`
+      : '';
+    const controls = this.renderControls();
+    const tableBody = list.length === 0
+      ? `<tr><td colspan="${this.config.columns.length}" class="watchlist-empty">${escapeHtml(this.config.emptyMessage || 'No symbols match the current filter.')}</td></tr>`
+      : list.map((item) => this.renderRow(item)).join('');
+    const headers = this.config.columns.map((col) => {
+      const sortKey = col.sortable ? (col.sortOptionKey || col.key) : '';
+      const sortable = sortKey ? `data-sortkey="${escapeHtml(sortKey)}" class="watchlist-th-sortable"` : '';
+      const alignClass = col.align === 'right' ? ' watchlist-th-right' : '';
+      const activeSortIndicator = sortKey && sortKey === this.state.sort ? ' ↓' : '';
+      return `<th${alignClass ? ` class="${alignClass.trim()}"` : ''} ${sortable}>${escapeHtml(col.label)}${activeSortIndicator}</th>`;
+    }).join('');
+    return `
+      <div class="watchlist-table-view">
+        ${intro}
+        ${controls}
+        <table class="watchlist-table">
+          <thead><tr>${headers}</tr></thead>
+          <tbody>${tableBody}</tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  private renderControls(): string {
+    const placeholder = this.config.searchPlaceholder || 'Search symbol or name...';
+    const pills = this.config.filters.map((f) => {
+      const active = f.key === this.state.filter ? ' watchlist-pill-active' : '';
+      return `<button class="watchlist-pill${active}" data-filterkey="${escapeHtml(f.key)}" type="button">${escapeHtml(f.label)}</button>`;
+    }).join('');
+    const sortOpts = this.config.sortOptions.map((opt) => {
+      const selected = opt.key === this.state.sort ? ' selected' : '';
+      return `<option value="${escapeHtml(opt.key)}"${selected}>${escapeHtml(opt.label)}</option>`;
+    }).join('');
+    return `
+      <div class="watchlist-controls">
+        <input
+          class="watchlist-search"
+          type="text"
+          placeholder="${escapeHtml(placeholder)}"
+          value="${escapeHtml(this.state.search)}"
+          data-watchlist-search="1">
+        <div class="watchlist-control-row">
+          <div class="watchlist-pills">${pills}</div>
+          <select class="watchlist-sort" data-watchlist-sort="1">${sortOpts}</select>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderRow(item: T): string {
+    const key = this.config.getKey(item);
+    const isExpanded = key === this.state.expandedKey;
+    const cells = this.config.columns.map((col) => {
+      const alignClass = col.align === 'right' ? ' class="watchlist-td-right"' : '';
+      return `<td${alignClass}>${col.cell(item)}</td>`;
+    }).join('');
+    const row = `<tr class="watchlist-row${isExpanded ? ' watchlist-row-expanded' : ''}" data-rowkey="${escapeHtml(key)}">${cells}</tr>`;
+    if (!isExpanded) return row;
+    const detail = this.config.renderDetail(item);
+    return `${row}<tr class="watchlist-detail-row"><td colspan="${this.config.columns.length}">${detail}</td></tr>`;
+  }
+
+  private getFilteredSorted(): T[] {
+    let list = this.items.slice();
+    const filter = this.config.filters.find((f) => f.key === this.state.filter);
+    if (filter) list = list.filter((item) => filter.match(item));
+    if (this.state.search.trim()) {
+      const q = this.state.search.trim().toLowerCase();
+      list = list.filter((item) => this.config.getSearchText(item).toLowerCase().includes(q));
+    }
+    const sortOption = this.config.sortOptions.find((s) => s.key === this.state.sort);
+    if (sortOption) list.sort(sortOption.cmp);
+    return list;
+  }
+
+  public bind(root: HTMLElement, onRerender: () => void): void {
+    const rootEl = root.querySelector('.watchlist-table-view') as HTMLElement | null;
+    if (!rootEl) return;
+
+    // Row click → toggle expanded (one-at-a-time semantics: clicking a
+    // different row collapses the previous one).
+    rootEl.querySelectorAll<HTMLElement>('.watchlist-row').forEach((rowEl) => {
+      rowEl.addEventListener('click', () => {
+        const key = rowEl.dataset.rowkey || '';
+        this.state.expandedKey = this.state.expandedKey === key ? null : key;
+        onRerender();
+      });
+    });
+
+    // Sortable header click → set sort option, rerender.
+    rootEl.querySelectorAll<HTMLElement>('.watchlist-th-sortable').forEach((thEl) => {
+      thEl.addEventListener('click', () => {
+        const key = thEl.dataset.sortkey || '';
+        if (!key) return;
+        // Only switch sort if the option exists (defensive guard against
+        // a column wired to a sortOptionKey that's not in sortOptions).
+        if (this.config.sortOptions.some((o) => o.key === key)) {
+          this.state.sort = key;
+          onRerender();
+        }
+      });
+    });
+
+    // Filter pill click.
+    rootEl.querySelectorAll<HTMLElement>('.watchlist-pill').forEach((pillEl) => {
+      pillEl.addEventListener('click', () => {
+        const key = pillEl.dataset.filterkey || '';
+        if (key && key !== this.state.filter) {
+          this.state.filter = key;
+          onRerender();
+        }
+      });
+    });
+
+    // Sort dropdown change.
+    const sortSelect = rootEl.querySelector('[data-watchlist-sort="1"]') as HTMLSelectElement | null;
+    if (sortSelect) {
+      sortSelect.addEventListener('change', () => {
+        this.state.sort = sortSelect.value;
+        onRerender();
+      });
+    }
+
+    // Search input — focus restored after rerender (setContent destroys
+    // the DOM, so we keep the cursor position by reading selection state
+    // before each keystroke triggers the rerender).
+    const searchInput = rootEl.querySelector('[data-watchlist-search="1"]') as HTMLInputElement | null;
+    if (searchInput) {
+      // Restore focus on rerender — focus IS lost when setContent rebuilds
+      // innerHTML, so we re-apply it whenever the input was the active
+      // element before rerender. Detection: state.search is non-empty AND
+      // the input has the placeholder/value mismatch handled by setting
+      // selectionStart from the current value length.
+      if (this.searchWasFocused) {
+        searchInput.focus();
+        const pos = this.state.search.length;
+        try { searchInput.setSelectionRange(pos, pos); } catch { /* ignore */ }
+        this.searchWasFocused = false;
+      }
+      searchInput.addEventListener('input', () => {
+        this.state.search = searchInput.value;
+        this.searchWasFocused = true;
+        onRerender();
+      });
+      searchInput.addEventListener('focus', () => { this.searchWasFocused = true; });
+      searchInput.addEventListener('blur', () => { this.searchWasFocused = false; });
+    }
+  }
+
+  // Tracks whether the search input was focused immediately before the
+  // last rerender. Necessary because Panel.setContent rebuilds the
+  // content innerHTML, destroying focus state. Without this, typing in
+  // the search box loses focus on every keystroke.
+  private searchWasFocused = false;
+}

--- a/src/components/WatchlistTableView.ts
+++ b/src/components/WatchlistTableView.ts
@@ -118,10 +118,18 @@ export class WatchlistTableView<T> {
       : list.map((item) => this.renderRow(item)).join('');
     const headers = this.config.columns.map((col) => {
       const sortKey = col.sortable ? (col.sortOptionKey || col.key) : '';
-      const sortable = sortKey ? `data-sortkey="${escapeHtml(sortKey)}" class="watchlist-th-sortable"` : '';
-      const alignClass = col.align === 'right' ? ' watchlist-th-right' : '';
+      // Build a SINGLE class string — pre-fix this code emitted two
+      // `class` attributes (one for sortable, one for right-align) when
+      // a column was both, and browsers silently drop the second one,
+      // breaking click-to-sort on every right-aligned numeric column.
+      // Greptile PR #3719 P2.
+      const classes: string[] = [];
+      if (sortKey) classes.push('watchlist-th-sortable');
+      if (col.align === 'right') classes.push('watchlist-th-right');
+      const classAttr = classes.length ? ` class="${classes.join(' ')}"` : '';
+      const sortAttr = sortKey ? ` data-sortkey="${escapeHtml(sortKey)}"` : '';
       const activeSortIndicator = sortKey && sortKey === this.state.sort ? ' ↓' : '';
-      return `<th${alignClass ? ` class="${alignClass.trim()}"` : ''} ${sortable}>${escapeHtml(col.label)}${activeSortIndicator}</th>`;
+      return `<th${classAttr}${sortAttr}>${escapeHtml(col.label)}${activeSortIndicator}</th>`;
     }).join('');
     return `
       <div class="watchlist-table-view">

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -3004,3 +3004,145 @@ a.hub-top-story {
   color: var(--text-muted, #888);
   font-size: 12px;
 }
+
+/* ----------------------------------------------------------
+   Watchlist Table View (StockAnalysisPanel, StockBacktestPanel)
+   Option B from watchlist-panel-playground.html — replaces the
+   one-long-card-per-symbol scroll with a sortable summary table
+   that expands inline on row click. Scales to 50+ symbols.
+   ---------------------------------------------------------- */
+.watchlist-table-view {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.watchlist-intro {
+  font-size: 12px;
+  color: var(--text-dim);
+  line-height: 1.5;
+  padding: 4px 0;
+}
+
+.watchlist-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 6px 0 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.watchlist-search {
+  width: 100%;
+  background: var(--input-bg, #1a1a1a);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 5px 8px;
+  font-family: inherit;
+  font-size: 11px;
+  border-radius: 3px;
+}
+.watchlist-search:focus {
+  outline: none;
+  border-color: var(--border-strong);
+}
+
+.watchlist-control-row {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.watchlist-pills {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.watchlist-pill {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  padding: 3px 8px;
+  font-family: inherit;
+  font-size: 10px;
+  cursor: pointer;
+  border-radius: 10px;
+  transition: color 0.1s ease, border-color 0.1s ease, background 0.1s ease;
+}
+.watchlist-pill:hover {
+  color: var(--text);
+  border-color: var(--border-strong);
+}
+.watchlist-pill-active {
+  color: var(--accent);
+  background: var(--overlay-medium);
+  border-color: var(--border-strong);
+}
+
+.watchlist-sort {
+  margin-left: auto;
+  background: var(--input-bg, #1a1a1a);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 3px 6px;
+  font-family: inherit;
+  font-size: 11px;
+  border-radius: 3px;
+}
+
+.watchlist-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+}
+.watchlist-table thead th {
+  text-align: left;
+  color: var(--text-dim);
+  font-weight: 500;
+  text-transform: uppercase;
+  font-size: 9px;
+  letter-spacing: 0.4px;
+  padding: 6px 4px;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+.watchlist-table thead th.watchlist-th-right {
+  text-align: right;
+}
+.watchlist-table thead th.watchlist-th-sortable {
+  cursor: pointer;
+  user-select: none;
+}
+.watchlist-table thead th.watchlist-th-sortable:hover {
+  color: var(--text);
+}
+.watchlist-table tbody tr.watchlist-row {
+  cursor: pointer;
+  border-bottom: 1px solid var(--border-subtle);
+  transition: background 0.1s ease;
+}
+.watchlist-table tbody tr.watchlist-row:hover {
+  background: var(--overlay-subtle);
+}
+.watchlist-table tbody tr.watchlist-row-expanded {
+  background: var(--overlay-light);
+}
+.watchlist-table tbody td {
+  padding: 6px 4px;
+}
+.watchlist-table tbody td.watchlist-td-right {
+  text-align: right;
+}
+.watchlist-table tbody tr.watchlist-detail-row > td {
+  padding: 0;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+}
+.watchlist-empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--text-dim);
+  font-size: 11px;
+}


### PR DESCRIPTION
## Summary

The one-card-per-symbol vertical-scroll layout in Premium Stock Analysis and Premium Backtesting doesn't survive the watchlist growing past ~10 symbols. At the planned 50 you can't compare, sort, or find a specific ticker — every interaction means scrolling through the whole stack.

Replaces both panels with **Option B** from the watchlist-panel-playground.html design exploration: sortable summary table at the top, row click expands inline to the existing full-detail card.

```
┌─────────────────────────────────────┐
│ [ search ticker or name ]           │
│ [All] [Strong Buy] [Buy+] [Hold]    │
│                       [Score ↓ ▼]   │
├─────────────────────────────────────┤
│ SYMBOL  PRICE  SIGNAL    SCORE  1d %│
│ AAPL    $230   STRONG BUY 87   +1.2 │
│  └─ [inline expand: full detail]   │
│ MSFT    $410   STRONG BUY 84   +0.6 │
│ ...                                 │
└─────────────────────────────────────┘
```

Sort / filter / search state persists across data refreshes within a session (in-memory; resets on full page reload — no localStorage, keeps the surface narrow).

## What ships

- **`src/components/WatchlistTableView.ts`** — new generic typed helper (269 lines). Holds the sort/filter/search/expandedKey state, renders the table + controls, binds event handlers. Reused by both panels via a small config object.
- **`StockAnalysisPanel`** — 5 columns (Symbol, Price, Signal, Score, 1d %); filter pills All / Strong Buy / Buy+ / Hold / Sell; default sort Score ↓. The existing `renderCard()` is reused verbatim as the inline-expand detail, so no regressions in the full-detail card content.
- **`StockBacktestPanel`** — 5 columns (Symbol, Win Rate, Direction, Avg Return, Signals); filter pills All / Profitable (≥55%) / Mixed (45-55%) / Losing (<45%); default sort Win Rate ↓.
- **CSS in `src/styles/panels.css`** (`.watchlist-*` namespace) — uses existing theme tokens (`--bg`, `--surface`, `--border`, `--text-dim`, `--semantic-normal`/`critical`). Sortable headers, expandable row, inline detail-row.

## Validation (Playwright via mcp__playwright)

Validated against a 30-symbol mock dataset injected directly into the WatchlistTableView module (panel itself is premium-locked so couldn't be hydrated end-to-end from a logged-out browser session):

- 30-symbol render: 30 rows, 5 headers, 4 pills, 3 sort options ✓
- Row click expands inline ✓
- Click different row → previous collapses (one-at-a-time semantics) ✓
- Filter pill "Strong Buy" → 8 rows (30/4 distribution) ✓
- Sort header click (Symbol A-Z) → AAPL first ✓
- Search "NVDA" → 1 row, value AND focus retained after rerender ✓
- Empty search "ZZZZZ" → empty-state message rendered ✓

The **search-focus retention** was the trickiest part. `Panel.setContent` rebuilds `innerHTML` on each rerender, which destroys focus. The view tracks `searchWasFocused` on input/focus/blur events and refocuses + restores cursor position after each rebind so typing in the search box doesn't lose focus per keystroke.

## Test plan

- [x] `npm run typecheck` + `npm run typecheck:api` pass
- [x] `npm run test:data` — 8867/8867 pass (was 8853 before — no regressions)
- [x] biome clean on all 3 affected source files
- [x] Playwright interactions all pass (above)
- [ ] **Post-merge**: a Pro user with ≥10 symbols should see the table view instead of the long card stack. Filter pills should narrow, sort header clicks should reorder, row click should expand the existing detail card inline, one row open at a time.
- [ ] **Watch for**: search-focus loss on slow networks (the rerender-on-keystroke pattern depends on the rebind happening fast enough that focus restoration is invisible). If users report typing feeling laggy, consider debouncing search.

## Design artifact

The design exploration that led to this implementation lives at `watchlist-panel-playground.html` in the worktree root (untracked, intentionally — it's a one-off design artifact). Open it in a browser to compare Option A (tabs) / Option B (table+expand, what shipped) / Option C (card grid+modal) with toggles for 7/12/25/50 mock symbol counts. Was the reference used to decide on B.