### PR TITLE
fix(symbol-search): treat Finnhub 422 as client BAD_QUERY, skip Sentry capture

### DIFF
--- a/api/symbol-search.ts
+++ b/api/symbol-search.ts
@@ -158,6 +158,17 @@ export default async function handler(
       // than Sentry.
       if (resp.status === 422) {
         console.warn(`[symbol-search] Finnhub 422 (bad query) for q="${q}"`);
+        // Cache as empty results so repeated identical bad queries (e.g.
+        // `$`, scanner probes) don't each reach Finnhub and drain the
+        // shared 60/min quota. Same protection the success-path empty-
+        // result cache provides for typos (top-level file comment).
+        // Subsequent identical requests short-circuit at the cache-read
+        // above and return 200 + `{ results: [] }` — semantically
+        // equivalent to "no matches for that query" for the user, but
+        // quota-cheap for us. Greptile P2 on PR #3745.
+        const writePromise = setCachedData(cacheKey, { results: [] }, CACHE_TTL_SECONDS).catch(() => false);
+        if (ctx) ctx.waitUntil(writePromise);
+        else void writePromise;
         return jsonResponse({ error: 'BAD_QUERY' }, 400, cors);
       }
       // 429 from Finnhub = quota exhausted; surface as 503 so the client

--- a/api/symbol-search.ts
+++ b/api/symbol-search.ts
@@ -147,6 +147,19 @@ export default async function handler(
       signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
     });
     if (!resp.ok) {
+      // 422 from Finnhub = malformed query string (special characters,
+      // junk symbols, scanner probes). This is USER-INPUT noise, not
+      // upstream failure — return 400 to the client and SKIP the Sentry
+      // capture entirely. Capturing 422 was paging at warning level
+      // (WORLDMONITOR-RE) on real users typing things like "$" or "< "
+      // in the symbol search box, which we can't act on. A spike in
+      // 422s would suggest tightening our client-side input validation,
+      // but the signal for that lives better in front-end analytics
+      // than Sentry.
+      if (resp.status === 422) {
+        console.warn(`[symbol-search] Finnhub 422 (bad query) for q="${q}"`);
+        return jsonResponse({ error: 'BAD_QUERY' }, 400, cors);
+      }
       // 429 from Finnhub = quota exhausted; surface as 503 so the client
       // backs off rather than treating it as a permanent failure.
       const status = resp.status === 429 ? 503 : 502;


### PR DESCRIPTION
## Summary

**WORLDMONITOR-RE** was paging on \`Finnhub search HTTP 422\` at warning level — 3 events / 2 users typing things like \`$\` or \`< \` or scanner-probe junk into the symbol search box. Finnhub returns 422 specifically when its query-string validator rejects the input shape, which is **user-input noise, not upstream failure**.

Before this PR every Finnhub non-OK was funnelled through one branch that returned 502 + captured at warning. That conflated three semantics:

- 429 = quota exhausted (transient, already mapped to 503)
- **422 = OUR input was bad** (return 400, don't capture)
- 4xx/5xx other = upstream actually broken (return 502, capture)

Split 422 into its own early branch:
- Returns \`400 { error: 'BAD_QUERY' }\` to the client — bad gateway is misleading when the upstream is fine and the query was wrong
- Skips Sentry capture entirely — can't act on a user typing junk. A spike-detection signal for tightening client-side validation lives better in front-end analytics than Sentry

Other Finnhub non-OK behavior unchanged.

## Test plan

- [x] \`npm run typecheck\` — PASS
- [x] \`npm run typecheck:api\` — PASS
- [x] Edge bundle check — PASS
- [x] \`node --test tests/edge-functions.test.mjs\` — PASS
- [ ] Post-deploy: RE doesn't reopen on the next user typing junk into the symbol search box