### PR TITLE
fix(mcp-tokens): listProMcpTokens returns [] on unauth (kills RD auth-race noise)

### DIFF
--- a/convex/__tests__/mcpProTokens.test.ts
+++ b/convex/__tests__/mcpProTokens.test.ts
@@ -326,6 +326,27 @@ describe("listProMcpTokens", () => {
     const rows = await t.withIdentity(OTHER_USER).query(api.mcpProTokens.listProMcpTokens, {});
     expect(rows).toEqual([]);
   });
+
+  test("returns empty array when called without auth identity (does not throw AUTH_REQUIRED)", async () => {
+    // WORLDMONITOR-RD regression: this query is reactive (subscribed by
+    // the settings UI), so it fires during transient unauth windows —
+    // sign-out, initial page load before Clerk resolves, token-rotation
+    // races. Throwing AUTH_REQUIRED from those races was paging via
+    // Convex's server-side Sentry integration despite the
+    // requireUserId() comment explicitly aiming to suppress N3-class
+    // noise. Returning [] is observationally identical to "no tokens
+    // yet" and removes the throw entirely.
+    const t = convexTest(schema, modules);
+
+    // Seed a token under a real user so we can prove the no-auth caller
+    // gets empty (not the other user's row, not a throw).
+    await seedProEntitlement(t, "user-pro");
+    await t.mutation(internal.mcpProTokens.issueProMcpToken, { userId: "user-pro" });
+
+    // No .withIdentity(...) — simulates the unauth race.
+    const rows = await t.query(api.mcpProTokens.listProMcpTokens, {});
+    expect(rows).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/convex/mcpProTokens.ts
+++ b/convex/mcpProTokens.ts
@@ -1,6 +1,6 @@
 import { ConvexError, v } from "convex/values";
 import { internalMutation, internalQuery, mutation, query } from "./_generated/server";
-import { requireUserId } from "./lib/auth";
+import { requireUserId, resolveUserId } from "./lib/auth";
 import { getFeaturesForPlan } from "./lib/entitlements";
 
 /**
@@ -186,11 +186,25 @@ export const touchProMcpTokenLastUsed = internalMutation({
  *
  * Returns ALL rows — including revoked — for transparency. The settings UI
  * surfaces revoked rows greyed-out so the user has a record of past grants.
+ *
+ * Uses `resolveUserId` (not `requireUserId`) and returns an empty array
+ * when unauthenticated, because this is a REACTIVE query: the client
+ * WebSocket subscription fires it on every state change including the
+ * brief unauth windows during sign-out, initial page load before Clerk
+ * resolves, and token-rotation races. Throwing `AUTH_REQUIRED` from a
+ * reactive query path causes Convex's server-side Sentry integration
+ * to page on those transient races (WORLDMONITOR-RD, sibling of N3),
+ * even though the `requireUserId` ConvexError throw was explicitly
+ * designed not to. Returning `[]` is observationally identical to
+ * "user has no tokens yet" — the only legitimate caller is the
+ * settings UI, which already gates this query behind a signed-in
+ * shell.
  */
 export const listProMcpTokens = query({
   args: {},
   handler: async (ctx) => {
-    const userId = await requireUserId(ctx);
+    const userId = await resolveUserId(ctx);
+    if (!userId) return [];
     const rows = await ctx.db
       .query("mcpProTokens")
       .withIndex("by_userId", (q) => q.eq("userId", userId))


### PR DESCRIPTION
## Summary

**WORLDMONITOR-RD**: \`Uncaught ConvexError: AUTH_REQUIRED\` from the reactive \`listProMcpTokens\` query, paged at error level by Convex's server-side Sentry integration despite the explicit anti-N3 comment on \`requireUserId\` saying it should be treated as expected business noise.

Reactive Convex queries fire even during transient unauth windows (sign-out, initial page load before Clerk resolves, token rotation). \`requireUserId\` throws \`AUTH_REQUIRED\` whenever those races land — most clearly visible here because the query is only ever subscribed from the settings UI shell (already gated on signed-in state) but the WebSocket subscription fires across the unauth gap either side.

## Change

- Switch \`listProMcpTokens\` to \`resolveUserId\` (the null-returning sibling) + return \`[]\` on null. Observationally identical to "user has no tokens yet" for the only caller (settings UI).
- Mutation site (\`revokeProMcpToken\`) is user-click-initiated, auth IS required — kept as \`requireUserId\`.
- New regression test: \`t.query(api.mcpProTokens.listProMcpTokens, {})\` without \`.withIdentity(...)\` returns \`[]\` instead of throwing.

## Test plan

- [x] \`npm run typecheck\` — PASS
- [x] \`npm run typecheck:api\` — PASS
- [x] \`npx vitest run convex/__tests__/mcpProTokens.test.ts\` — **30/30 PASS** (was 29; +1 new unauth-race regression)
- [ ] Post-deploy: RD doesn't reopen on the next sign-out / sign-in cycle