### PR TITLE
fix(brief): parse URL pathname in opinion-classifier (backport from PR #3748)

### DIFF
--- a/server/_shared/opinion-classifier.js
+++ b/server/_shared/opinion-classifier.js
@@ -78,6 +78,24 @@ function isWholeHeadlineQuoted(title) {
 }
 
 /**
+ * Parse the URL pathname defensively. Malformed URL → empty string
+ * (skip URL signal entirely; do not throw). Closes the tracking-param
+ * injection vector — aggregator tracking params (?utm=/opinion/promo)
+ * and URL fragments (#/opinion/footer) live OUTSIDE the pathname and
+ * must not trigger STRONG (or CORROBORATING) via raw-string includes()
+ * matching on the full link. Backport of the same helper added in
+ * feelgood-classifier.js (PR #3748 / adv-002).
+ */
+function safePathname(link) {
+  if (typeof link !== 'string' || link.length === 0) return '';
+  try {
+    return new URL(link).pathname.toLowerCase();
+  } catch {
+    return '';
+  }
+}
+
+/**
  * Classify a story as opinion/analysis vs hard news.
  *
  * @param {{ title?: unknown; link?: unknown; description?: unknown }} story
@@ -88,9 +106,14 @@ export function classifyOpinion(story) {
   const link = typeof story?.link === 'string' ? story.link : '';
   const description = typeof story?.description === 'string' ? story.description : '';
 
-  // STRONG #1 — URL section. Lowercased; matches a path segment.
-  const lowerLink = link.toLowerCase();
-  if (STRONG_URL_SEGMENTS.some((seg) => lowerLink.includes(seg))) return true;
+  // Parse pathname once; reused by STRONG #1 and CORROBORATING URL check.
+  const pathname = safePathname(link);
+
+  // STRONG #1 — URL section. Matches a path segment on the parsed
+  // pathname (NOT raw link), so tracking params / fragments can't
+  // spoof a section match. Every STRONG_URL_SEGMENTS entry is
+  // slash-delimited on both sides.
+  if (pathname && STRONG_URL_SEGMENTS.some((seg) => pathname.includes(seg))) return true;
 
   // STRONG #2 — explicit headline prefix.
   if (STRONG_HEADLINE_PREFIX_RE.test(title.trim())) return true;
@@ -99,8 +122,9 @@ export function classifyOpinion(story) {
   let corroborating = 0;
   if (isWholeHeadlineQuoted(title)) corroborating += 1;
   if (CORROBORATING_DESCRIPTION_RE.test(description)) corroborating += 1;
-  // `/analysis/` in the URL is corroborating, not strong.
-  if (lowerLink.includes('/analysis/') || lowerLink.includes('/analyses/')) corroborating += 1;
+  // `/analysis/` in the URL is corroborating, not strong. Parsed
+  // pathname only (same injection-vector reasoning as STRONG #1).
+  if (pathname && (pathname.includes('/analysis/') || pathname.includes('/analyses/'))) corroborating += 1;
 
   return corroborating >= 2;
 }

--- a/tests/opinion-classifier.test.mjs
+++ b/tests/opinion-classifier.test.mjs
@@ -157,6 +157,82 @@ describe('classifyOpinion — does NOT false-positive on hard news', () => {
   });
 });
 
+describe('classifyOpinion — URL match uses parsed pathname, not raw .includes() (backport from PR #3748 / adv-002)', () => {
+  // Pre-backport: lowerLink.includes('/opinion/') returned true for any
+  // URL whose query string OR fragment contained "/opinion/" — including
+  // legitimate aggregator tracking params like ?utm_campaign=/opinion/promo.
+  // The same bug existed in feelgood-classifier.js until PR #3748 closed
+  // it; this PR brings the opinion-classifier to parity by parsing the
+  // URL and matching against pathname.toLowerCase() inside a try/catch.
+  it('tracking param containing /opinion/ does NOT trigger STRONG', () => {
+    assert.equal(
+      classifyOpinion({
+        title: 'Hard news headline',
+        link: 'https://example.com/world/news?utm_campaign=/opinion/promo',
+      }),
+      false,
+    );
+  });
+
+  it('URL fragment containing /commentary/ does NOT trigger STRONG', () => {
+    assert.equal(
+      classifyOpinion({
+        title: 'Hard news headline',
+        link: 'https://example.com/world/news#/commentary/footer',
+      }),
+      false,
+    );
+  });
+
+  it('tracking param containing /analysis/ does NOT trigger CORROBORATING', () => {
+    // Single CORROBORATING signal would not classify on its own, but
+    // combined with a quoted-statement headline (which is the legit
+    // hard-news case the previous code FP'd on), the .includes() bug
+    // would have pushed total to 2. Verify the pathname parse prevents this.
+    assert.equal(
+      classifyOpinion({
+        title: "'We will respond decisively'",
+        link: 'https://example.com/world/iran-statement?utm_campaign=/analysis/section',
+        description: 'The foreign ministry issued a statement.',
+      }),
+      false,
+    );
+  });
+
+  it('malformed URL handled defensively (no throw)', () => {
+    assert.doesNotThrow(() =>
+      classifyOpinion({ title: 'Hard news', link: 'not a valid URL' }),
+    );
+    assert.equal(
+      classifyOpinion({ title: 'Hard news', link: 'not a valid URL' }),
+      false,
+    );
+  });
+
+  it('REGRESSION: a genuine /opinion/ pathname still classifies (the fix does not over-correct)', () => {
+    assert.equal(
+      classifyOpinion({
+        title: 'The election is closer than it looks',
+        link: 'https://example.com/opinion/election-closer-than-it-looks?utm_source=newsletter',
+      }),
+      true,
+    );
+  });
+
+  it('REGRESSION: a genuine /analysis/ pathname still contributes CORROBORATING', () => {
+    // Two corroborating: quote-wrapped headline + /analysis/ pathname
+    // (with a tracking param to verify the pathname parse strips the query).
+    assert.equal(
+      classifyOpinion({
+        title: "'The west has misjudged this moment'",
+        link: 'https://example.com/analysis/2026/foo?ref=twitter',
+        description: 'A straightforward report with no framing words.',
+      }),
+      true,
+    );
+  });
+});
+
 describe('classifyOpinion — input safety', () => {
   it('handles missing / non-string fields without throwing', () => {
     assert.equal(classifyOpinion({}), false);


### PR DESCRIPTION
## Summary

Sibling backport of PR #3748's pathname-parsing fix to `server/_shared/opinion-classifier.js`. The original PR closed the tracking-param injection vector in `feelgood-classifier.js` and explicitly flagged the same latent gap in `opinion-classifier.js:93` as a follow-up. Greptile's review of #3748 also called it out.

## Mechanism (identical to adv-002 closed in #3748)

**Before:**
\`\`\`js
const lowerLink = link.toLowerCase();
if (STRONG_URL_SEGMENTS.some((seg) => lowerLink.includes(seg))) return true;
\`\`\`
Raw `lowerLink.includes('/opinion/')` returns true for any URL whose query string OR fragment contains `/opinion/` — e.g. `?utm_campaign=/opinion/promo`, news.google.com style redirects whose `?url=…` carries an `/opinion/` section, etc. A hard-news article with that tracking shape silently classifies as opinion and drops from the brief.

**After:**
\`\`\`js
const pathname = safePathname(link);
if (pathname && STRONG_URL_SEGMENTS.some((seg) => pathname.includes(seg))) return true;
\`\`\`
`safePathname()` runs `new URL(link).pathname.toLowerCase()` inside `try/catch` and returns `''` on malformed URLs. Match runs against the parsed pathname only — query strings and fragments cannot spoof a section match. Helper mirrors `feelgood-classifier.js` byte-for-byte.

## Two sites fixed

`classifyOpinion` had the bug at:
1. **STRONG #1 URL match** (`server/_shared/opinion-classifier.js:93`) — `STRONG_URL_SEGMENTS.some(...)`
2. **CORROBORATING URL match** (`:103`) — `lowerLink.includes('/analysis/') || lowerLink.includes('/analyses/')`

Both now go through the same parsed-pathname check.

## Test plan

- [x] 6 new regression tests in `tests/opinion-classifier.test.mjs`:
  - Tracking param containing `/opinion/` → not STRONG
  - URL fragment containing `/commentary/` → not STRONG
  - Tracking param containing `/analysis/` → no CORROBORATING contribution
  - Malformed URL → no throw, returns `false`
  - Regression: genuine `/opinion/` pathname WITH `?utm_source=newsletter` → still STRONG (fix does not over-correct)
  - Regression: genuine `/analysis/` pathname WITH `?ref=twitter` → still contributes CORROBORATING
- [x] All 12 original tests still pass (18 total).
- [x] biome clean.
- [x] Broader sweep: 315 tests across opinion + feelgood + ingest + persistence + buildDigest + brief-from-digest-stories + brief-llm — no regressions.

## Out of scope

Same scope as PR #3748 — purely the pathname-parse hardening. No signal-list changes, no threshold changes, no telemetry changes. The opinion classifier's behavior on legitimate URLs is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)