### PR TITLE
docs(brief): document synthesis-prompt vs display category-case divergence (#3752)

### DIFF
--- a/scripts/lib/brief-compose.mjs
+++ b/scripts/lib/brief-compose.mjs
@@ -544,10 +544,29 @@ export function stripHeadlinePrefix(title) {
  * field; `digestStoryToUpstreamTopStory` + `filterTopStories` defaults
  * fill it). `category` IS carried on story:track:v1 (persisted by
  * buildStoryTrackHsetFields, defensive empty-string on missing), passed
- * through buildDigest's stories.push, and word-wise Title-Cased once in
- * shared/brief-filter.js at envelope build. On pre-PR residue rows
- * where category is absent, filterTopStories' `|| 'General'` fallback
- * fires and the value reaches here as 'General'.
+ * through buildDigest's stories.push, and reaches this function as the
+ * canonical lowercase EventCategory enum value (`'conflict'`, `'health'`,
+ * `'diplomatic'`, …). Pre-stamp residue rows where category is absent
+ * gracefully degrade to `'General'` via filterTopStories' `|| 'General'`
+ * fallback elsewhere.
+ *
+ * Intentional case divergence between synthesis and display paths
+ * (issue #3752):
+ *   - **This function** feeds the LLM synthesis prompt
+ *     (`buildDigestPrompt` in scripts/lib/brief-llm.mjs). The prompt
+ *     uses the canonical lowercase enum value as a semantic anchor for
+ *     LLM pattern-matching — the model's training distribution sees
+ *     category labels as bare nouns more often than Title-Cased
+ *     headings, so feeding `'conflict'` is the cleaner signal than
+ *     feeding `'Conflict'`.
+ *   - **The envelope/display path** goes through filterTopStories'
+ *     `out.push` (`shared/brief-filter.js`) where `titleCase` runs
+ *     once to produce `'Conflict'` for the threads card,
+ *     magazine story-page, and public-thread fallback stub. Display
+ *     surfaces want human readability.
+ * Both paths read from the same upstream `s.category` (lowercase); the
+ * divergence is downstream and load-bearing for each consumer's needs.
+ * If you change one site, audit the other.
  *
  * @param {object} s — digest-shaped story from buildDigest()
  * @returns {{ headline: string; threatLevel: string; source: string; category: string; country: string; hash: string }}
@@ -577,6 +596,10 @@ export function digestStoryToSynthesisShape(s) {
     headline: sanitizeHeadline(cleanTitle),
     threatLevel: typeof s?.severity === 'string' ? s.severity : '',
     source: sanitizeForPrompt(primarySource),
+    // `s.category` is the canonical lowercase EventCategory enum value
+    // here (synthesis-prompt path uses lowercase as semantic anchor;
+    // display path Title-Cases at the envelope-build site). See the
+    // function doc above for the case-divergence rationale (#3752).
     category: sanitizeForPrompt(typeof s?.category === 'string' ? s.category : 'General'),
     country: sanitizeForPrompt(typeof s?.countryCode === 'string' ? s.countryCode : 'Global'),
     hash: typeof s?.hash === 'string' ? s.hash : '',

--- a/scripts/lib/brief-compose.mjs
+++ b/scripts/lib/brief-compose.mjs
@@ -546,9 +546,23 @@ export function stripHeadlinePrefix(title) {
  * buildStoryTrackHsetFields, defensive empty-string on missing), passed
  * through buildDigest's stories.push, and reaches this function as the
  * canonical lowercase EventCategory enum value (`'conflict'`, `'health'`,
- * `'diplomatic'`, …). Pre-stamp residue rows where category is absent
- * gracefully degrade to `'General'` via filterTopStories' `|| 'General'`
- * fallback elsewhere.
+ * `'diplomatic'`, …).
+ *
+ * Two fallback layers for pre-stamp residue rows where category is
+ * absent — note that THIS function does NOT go through filterTopStories,
+ * so its local guard is load-bearing, not redundant:
+ *   1. **Local guard at the `category:` field write below**
+ *      (`typeof s?.category === 'string' ? s.category : 'General'`).
+ *      Fires for the synthesis-prompt path — the LLM prompt always
+ *      receives a non-empty string even when the upstream `s` has no
+ *      category field (rare in steady state; possible during the
+ *      48h-accumulator post-deploy residue window per PR #3751).
+ *   2. **filterTopStories' `asTrimmedString(raw.category) || 'General'`
+ *      at `shared/brief-filter.js:384`.** Fires for the envelope/display
+ *      path, which is a separate consumer that reads from the same
+ *      upstream story shape but takes a different code route.
+ * Removing either guard leaves the corresponding path exposed to
+ * residue rows on deploy.
  *
  * Intentional case divergence between synthesis and display paths
  * (issue #3752):

--- a/shared/brief-filter.js
+++ b/shared/brief-filter.js
@@ -451,8 +451,19 @@ export function filterTopStories({ stories, sensitivity, maxStories = 12, maxPer
     // site so all downstream consumers (threads card, magazine
     // story-page, public-thread fallback) see the same normalized
     // form. The cap-key above (`pairKey`) intentionally keeps the
-    // canonical raw `category` value so per-(source, category) capping
-    // groups correctly regardless of input case.
+    // canonical raw `category` value (case-folded via .toLowerCase())
+    // so per-(source, category) capping groups correctly regardless of
+    // input case.
+    //
+    // Intentional case divergence vs synthesis path (issue #3752):
+    // `digestStoryToSynthesisShape` in scripts/lib/brief-compose.mjs
+    // feeds the LLM synthesis prompt with the canonical lowercase enum
+    // value (`'conflict'`, `'health'`, …) — bare-noun form is the
+    // cleaner semantic anchor for LLM pattern-matching. The display
+    // path here Title-Cases for human readability. Both paths read
+    // from the same upstream `s.category`; the divergence is downstream
+    // and load-bearing for each consumer's needs. If you change the
+    // case behavior at one site, audit the other.
     const displayCategory = titleCase(category);
     out.push({
       category: displayCategory,


### PR DESCRIPTION
## Summary

Closes #3752 with option (3) — documentation-only, no behavior change.

`digestStoryToSynthesisShape` in `scripts/lib/brief-compose.mjs` feeds the LLM synthesis prompt with the canonical lowercase EventCategory enum value (`'conflict'`, `'health'`, `'diplomatic'`, …), while the envelope path goes through `filterTopStories`' `out.push` which Title-Cases for display. Both paths read from the same upstream `s.category`; the divergence is downstream and intentional but was previously undocumented.

## Rationale (option 3 from #3752)

- **Synthesis prompts** benefit from the canonical lowercase enum as a semantic anchor — the LLM training distribution sees category labels as bare nouns more often than Title-Cased headings, so feeding `'conflict'` is the cleaner signal than feeding `'Conflict'`.
- **Display surfaces** (threads card, magazine story-page, public-thread fallback) benefit from human-readable Title-Case via the envelope path.

Options (1) and (2) — apply `titleCase` at the synthesis path or upstream at buildDigest — would have:
- Changed LLM prompt content for every digest, every user (non-deterministic prompt drift)
- Required a `brief:llm:digest:v7→v8` cache-prefix bump one day after the `v6→v7` bump that PR #3751's review-driven fixes already shipped (operationally noisy)

Doc-only resolves the audit-trail concern without operational noise.

## Annotation sites

Two annotations added, cross-referencing each other so a future refactor that consolidates the two paths is deliberate rather than accidental:

1. **`scripts/lib/brief-compose.mjs`** — `digestStoryToSynthesisShape` JSDoc explains the divergence + inline comment at the `category:` field write
2. **`shared/brief-filter.js`** — comment at `filterTopStories` `out.push` block notes the cross-reference

Both annotations end with "if you change the case behavior at one site, audit the other."

## Test plan

- [x] 269 tests pass on the touched-surfaces sweep (brief-filter + brief-from-digest-stories + brief-llm)
- [x] biome clean on touched files (pre-existing complexity warning on `filterTopStories` unchanged — doc-only change)
- [x] No code path changed — comments only

## Context

- Issue: #3752
- Surfaced by `/ce-code-review` on PR #3751
- Adversarial finding A-004: `.context/compound-engineering/ce-code-review/20260517-183801-744b2d26/adversarial.json` finding #4
- Original PR that introduced the divergence: #3751 (merged as `5d43e76d`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)