### PR TITLE
docs(deckgl): correct misleading 'dead code' comment on createPipelinesLayer

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -1548,9 +1548,12 @@ export class DeckGLMap {
 
     // Pipelines layer — Redis-backed evidence registry (seed-pipelines-{gas,oil}.mjs),
     // colored by derived publicBadge. Available on every variant that toggles
-    // `pipelines: true`. The legacy static `PIPELINES` fallback was retired in
-    // the gap #3B rollout (plan §R/#3 decision B); createPipelinesLayer is kept
-    // in this file as a dead-code reference until the next cleanup pass.
+    // `pipelines: true`. createEnergyPipelinesLayer falls back to the legacy
+    // static `PIPELINES` layer (createPipelinesLayer below) when the bootstrap
+    // hasn't hydrated yet, so the static layer is a real fallback — not dead
+    // code despite an earlier comment claiming it was retired in the gap #3B
+    // rollout. Removing createPipelinesLayer would leave the map blank on
+    // cold loads / variant switches before the first hydrate.
     if (mapLayers.pipelines) {
       layers.push(this.createEnergyPipelinesLayer());
     } else {


### PR DESCRIPTION
## Summary
Comment-only fix. The pipelines-layer comment at \`src/components/DeckGLMap.ts:1549\` claimed the legacy static \`PIPELINES\` fallback was retired and \`createPipelinesLayer\` was kept only as a dead-code reference. It is not dead — \`createEnergyPipelinesLayer\` at line 2073 calls it as a real cold-load fallback when the gas/oil bootstrap hasn't hydrated yet (variant switch, first paint, etc.). Without it, toggling the pipelines layer would render blank on cold loads.

## Why this matters
A future cleanup pass following the existing comment would delete \`createPipelinesLayer\`, leaving an obvious user-visible regression on every variant that ships with \`pipelines: true\`.

## Test plan
- [x] No code change. Comment text only.