### PR TITLE
fix(brief): forbid weak temporal stitching in digest lead

### DIFF
--- a/scripts/lib/brief-llm.mjs
+++ b/scripts/lib/brief-llm.mjs
@@ -20,7 +20,7 @@
 //     date-grounding line: every v3 row was produced from a prompt
 //     with no notion of "today" and may state a fabricated year, so
 //     v3 rows must not survive the deploy. v2 rows were lead-blind.
-//   - brief:llm:digest:v7:{userId|public}:{sensitivity}:{poolHash}
+//   - brief:llm:digest:v8:{userId|public}:{sensitivity}:{poolHash}
 //     — 4h. The canonical synthesis is now ALWAYS produced through
 //     this path (formerly split with `generateAISummary` in the
 //     digest cron). Material includes profile-SHA, greeting bucket,
@@ -344,8 +344,16 @@ const DIGEST_PROSE_SYSTEM_BASE =
   "impactful development by its specific actor and event (e.g. \"Pentagon " +
   "chief Hegseth declared the US blockade on Iran is going global\"), NOT " +
   'an editorial framing about "geopolitical tensions" or "shifting ' +
-  'landscapes". Subsequent sentences may give brief context. Reference at ' +
-  'most 1–2 threads. No vapid hedging.>",\n' +
+  'landscapes". Subsequent sentences may give brief context about THE SAME ' +
+  'story (causes, stakes, prior developments). Reference a SECOND story ONLY ' +
+  'when there is a substantive link to the primary one (shared actor, causal ' +
+  'connection, direct policy consequence, same geographic theatre). NEVER ' +
+  'staple unrelated stories together using weak temporal connectives like ' +
+  '"This comes as", "Meanwhile", "At the same time", "In other news", or ' +
+  '"Elsewhere" — those produce editorially incoherent leads that mention two ' +
+  'unrelated events in one sentence without explaining why they belong ' +
+  'together. If two top stories are unrelated, just lead with the most ' +
+  'impactful one and let the threads list cover the rest. No vapid hedging.>",\n' +
   '  "threads": [\n' +
   '    { "tag": "<one-word editorial category e.g. Energy, Diplomacy, Climate>", ' +
   '"teaser": "<one sentence naming a SPECIFIC event or actor — e.g. ' +
@@ -363,6 +371,14 @@ const DIGEST_PROSE_SYSTEM_BASE =
   '"buzzing with developments", "intricate shifts", "evolving landscape", ' +
   '"navigating", "discerning reader", "continues to simmer", "shape the ' +
   'coming months", "strategic importance".\n' +
+  'BANNED stitching phrases (do NOT use any of these to staple two stories ' +
+  'together in the lead — they signal unrelated content awkwardly joined): ' +
+  '"this comes as", "this declaration comes as", "this announcement comes as", ' +
+  '"meanwhile", "at the same time", "in other news", "elsewhere", "across the ' +
+  'world", "on another front", "in a separate development". If two stories ' +
+  'are not substantively linked (no shared actor, no causal connection, no ' +
+  'direct policy consequence, no same geographic theatre), do NOT stitch them ' +
+  'into one sentence — lead with the more impactful one alone.\n' +
   'Threads: 3–6 items reflecting actual clusters in the stories. ' +
   'Signals: 2–4 items, forward-looking. ' +
   'rankedStoryHashes: at least the top 3 stories by editorial importance, ' +
@@ -943,7 +959,18 @@ export async function generateDigestProse(userId, stories, sensitivity, deps, ct
   // for the full 4h TTL. Sibling bumps applied to whymatters (v4→v5)
   // and description (v2→v3) — all three caches depend on the same
   // story.category field via hashBriefStory / hashDigestInput.
-  const key = `brief:llm:digest:v7:${hashDigestInput(userId, stories, sensitivity, ctx)}`;
+  //
+  // v8 (2026-05-18): bumped from v7 when DIGEST_PROSE_SYSTEM_BASE gained
+  // anti-stitching instructions (May 17 brief shipped a lead that stapled
+  // Ebola + Israel-Lebanon with "This declaration comes as…" — two
+  // unrelated top stories awkwardly joined). The prompt now explicitly
+  // forbids weak temporal connectives ("This comes as", "Meanwhile",
+  // "At the same time", "In other news", "Elsewhere", "Across the world",
+  // "On another front", "In a separate development") and instructs the
+  // model to lead with ONE primary story when two top stories aren't
+  // substantively linked. v7 cache rows would otherwise serve stitched
+  // leads for the full 4h TTL. Prompt content change → cache invalidation.
+  const key = `brief:llm:digest:v8:${hashDigestInput(userId, stories, sensitivity, ctx)}`;
   try {
     const hit = await deps.cacheGet(key);
     // CRITICAL: re-run the shape+grounding validator on cache hits.

--- a/tests/brief-llm.test.mjs
+++ b/tests/brief-llm.test.mjs
@@ -331,17 +331,38 @@ describe('buildDigestPrompt', () => {
       'lead instruction must call out weak temporal stitching',
     );
 
-    // 2. The dedicated BANNED stitching section must exist and enumerate
-    //    the most common offenders.
-    assert.match(system, /BANNED stitching phrases/, 'banned-stitching section present');
+    // 2. The dedicated BANNED stitching section must exist. Extract just
+    //    that section so the per-phrase assertions cannot pass on
+    //    duplicate mentions in the lead-field instruction text. The
+    //    section runs from `BANNED stitching phrases` up to the next
+    //    instruction bullet (`Threads:`), matching the prompt layout.
+    const stitchingSectionMatch = system.match(
+      /BANNED stitching phrases[\s\S]*?(?=\nThreads:)/,
+    );
+    assert.ok(
+      stitchingSectionMatch,
+      'banned-stitching section must be present and bounded by the next instruction bullet (Threads:)',
+    );
+    const stitchingSection = stitchingSectionMatch[0].toLowerCase();
+
+    // All 10 banned phrases must appear in the dedicated section, not just
+    // in the lead-field instruction prose. If a phrase is removed from the
+    // banned section (or only ever lived in the lead-instruction list),
+    // the model loses the explicit BANNED signal and this assertion fires.
     for (const phrase of [
       'this comes as',
+      'this declaration comes as',
+      'this announcement comes as',
       'meanwhile',
+      'at the same time',
       'in other news',
       'elsewhere',
+      'across the world',
+      'on another front',
+      'in a separate development',
     ]) {
       assert.ok(
-        system.toLowerCase().includes(`"${phrase}"`),
+        stitchingSection.includes(`"${phrase}"`),
         `banned-stitching section must list "${phrase}"`,
       );
     }

--- a/tests/brief-llm.test.mjs
+++ b/tests/brief-llm.test.mjs
@@ -316,6 +316,45 @@ describe('buildDigestPrompt', () => {
     assert.match(system, /rankedStoryHashes/);
   });
 
+  it('forbids weak stitching connectives in the lead (anti-conflation, v8)', () => {
+    // Regression guard for the May 17 brief that shipped a lead stapling
+    // unrelated Ebola + Israel-Lebanon stories with "This declaration comes
+    // as…". The prompt must explicitly call out the banned phrases AND
+    // instruct the model to lead with one primary story when two top
+    // stories aren't substantively linked.
+    const { system } = buildDigestPrompt([story()], 'critical');
+
+    // 1. The lead instruction must mention the anti-stitching guidance.
+    assert.match(
+      system,
+      /staple unrelated stories together using weak temporal connectives/i,
+      'lead instruction must call out weak temporal stitching',
+    );
+
+    // 2. The dedicated BANNED stitching section must exist and enumerate
+    //    the most common offenders.
+    assert.match(system, /BANNED stitching phrases/, 'banned-stitching section present');
+    for (const phrase of [
+      'this comes as',
+      'meanwhile',
+      'in other news',
+      'elsewhere',
+    ]) {
+      assert.ok(
+        system.toLowerCase().includes(`"${phrase}"`),
+        `banned-stitching section must list "${phrase}"`,
+      );
+    }
+
+    // 3. The substantive-link allowlist must explain when a second story
+    //    can be referenced, so the model can tell linkage from stitching.
+    assert.match(
+      system,
+      /shared actor|causal connection|same geographic theatre/i,
+      'lead instruction must define what counts as a substantive link',
+    );
+  });
+
   it('appends the date-grounding line to the system prompt (F6)', () => {
     // Injected todayIso → deterministic assertion.
     const injected = buildDigestPrompt([story()], 'critical', { todayIso: '2026-05-14' });
@@ -512,7 +551,7 @@ describe('generateDigestProse', () => {
     const llm1 = makeLLM(validJson);
     await generateDigestProse('user_a', stories, 'all', { ...cache, callLLM: llm1.callLLM });
 
-    const badKey = [...cache.store.keys()].find((k) => k.startsWith('brief:llm:digest:v7:'));
+    const badKey = [...cache.store.keys()].find((k) => k.startsWith('brief:llm:digest:v8:'));
     assert.ok(badKey, 'expected a digest prose cache entry');
     // Overwrite with a payload whose content has zero proper-noun
     // overlap with `stories` (Iran Hormuz / Gaza). Shape is impeccable.
@@ -542,7 +581,7 @@ describe('generateDigestProse', () => {
     // (2026-05-14) when buildDigestPrompt gained the F6 date-grounding
     // line. v4 rows ignored at v5 rollout; v5 rows ignored at v6
     // rollout — see generateDigestProse header comment.
-    const badKey = [...cache.store.keys()].find((k) => k.startsWith('brief:llm:digest:v7:'));
+    const badKey = [...cache.store.keys()].find((k) => k.startsWith('brief:llm:digest:v8:'));
     assert.ok(badKey, 'expected a digest prose cache entry');
     cache.store.set(badKey, { lead: 'short', /* missing threads + signals */ });
     const llm2 = makeLLM(validJson);
@@ -1174,12 +1213,13 @@ describe('generateDigestProsePublic — public cache shared across users', () =>
     assert.equal(llm2.calls.length, 1, 'profile change re-keys the cache');
   });
 
-  it('writes to cache under brief:llm:digest:v7 prefix (v6/v5/v4/v3/v2 evicted)', async () => {
+  it('writes to cache under brief:llm:digest:v8 prefix (v7/v6/v5/v4/v3/v2 evicted)', async () => {
     const cache = makeCache();
     const llm = makeLLM(validJson);
     await generateDigestProse('user_a', stories, 'all', { ...cache, callLLM: llm.callLLM });
     const keys = [...cache.store.keys()];
-    assert.ok(keys.some((k) => k.startsWith('brief:llm:digest:v7:')), 'v7 prefix used');
+    assert.ok(keys.some((k) => k.startsWith('brief:llm:digest:v8:')), 'v8 prefix used');
+    assert.ok(!keys.some((k) => k.startsWith('brief:llm:digest:v7:')), 'no v7 writes (bumped for anti-stitching prompt — May 2026)');
     assert.ok(!keys.some((k) => k.startsWith('brief:llm:digest:v6:')), 'no v6 writes (bumped for category persistence — PR #3751)');
     assert.ok(!keys.some((k) => k.startsWith('brief:llm:digest:v5:')), 'no v5 writes');
     assert.ok(!keys.some((k) => k.startsWith('brief:llm:digest:v4:')), 'no v4 writes');


### PR DESCRIPTION
## Summary

- May 17 brief shipped a lead that stapled the WHO Ebola declaration and the Israel/Hezbollah escalation into one sentence with "This declaration comes as…" — two unrelated top stories joined by an editorial connective. This was triage item **#5 (lead conflates stories)** from the May 17 brief sweep.
- `DIGEST_PROSE_SYSTEM_BASE` now explicitly forbids weak temporal connectives ("This comes as", "Meanwhile", "At the same time", "In other news", "Elsewhere", "Across the world", "On another front", "In a separate development") and tells the model to lead with **one** primary story when two top stories aren't substantively linked (shared actor / causal connection / direct policy consequence / same geographic theatre).
- Cache prefix bumped **v7 → v8** at the two sites in `scripts/lib/brief-llm.mjs` so stale v7 rows generated against the stitching-tolerant prompt do not serve for the 4h TTL after deploy.

## Why prompt-only (not a synthesis-step rewrite)

The conflation was a stylistic failure of the existing instructions, not a missing pipeline stage. Adding a focused "no-stitching" instruction + cache bump is the cheapest fix that addresses the regression without growing prompt surface area or adding a second LLM round-trip. Pattern reference: PR #3751 followed the same prompt-change → cache-prefix-bump → assertion-update shape when category persistence landed (v6 → v7).

## Files changed

- `scripts/lib/brief-llm.mjs` — `DIGEST_PROSE_SYSTEM_BASE` updated lead instruction + new BANNED stitching section; cache key v7 → v8 (line 962) + matching comment (line 23) + v8 rationale in the version-history block.
- `tests/brief-llm.test.mjs` — new `forbids weak stitching connectives in the lead (anti-conflation, v8)` test asserting the prompt contains the instruction text, the BANNED section, the enumerated phrases, and the substantive-link allowlist; cache-prefix assertion bumped v7 → v8 with an added negative assertion that no v7 rows are written.

## Test plan

- [x] `node --test tests/brief-llm.test.mjs` — 102/102 pass, including the new anti-stitching assertion and the v8 prefix-bump assertion.
- [x] Broader `tests/brief-*.test.mjs` sweep — 664/670 pass; the 6 failures are pre-existing `api/brief/*.ts` ESM module-resolution issues unrelated to this change.
- [ ] After deploy: spot-check the next 2–3 brief leads for the anchor failure mode (two unrelated top stories joined by a temporal connective).