### PR TITLE
feat(mcp): tools/list tool-description compression + describe_tool RPC (v1.4.0 → v1.5.0)

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -350,6 +350,61 @@ export function utf8ByteLength(s: string): number {
   return new TextEncoder().encode(s).length;
 }
 
+// ---------------------------------------------------------------------------
+// tools/list description compression (v1.5.0)
+//
+// `tools/list` is the largest fixed per-session input-token cost. v1.4.0's
+// catalog is ~41.8 KB UTF-8; ~8 KB of that is tool-level `description`
+// prose. The first sentence of a tool description carries nearly all the
+// selection signal — the long tail is rarely load-bearing. Compress the
+// top-level `description` to first-sentence-or-cap; route LLMs that want
+// full text to the new `describe_tool` RPC (added in U3 below).
+//
+// PROPERTY descriptions are NOT compressed in v1 — audit found 53% of
+// them encode contract details (defaults, optional flags, "currently
+// supported" lists, examples) where naive compression would regress
+// correctness. Deferred to a future PR with a per-property hand-audit.
+//
+// Both compress + describe_tool surfaces go through `buildPublicTool`
+// (added in U2) so there's a single source of truth for the public shape.
+// ---------------------------------------------------------------------------
+
+export const TOOL_DESCRIPTION_MAX_BYTES = 120;
+
+// Compress a description string to at most `maxBytes` UTF-8 bytes.
+// - If the text already fits, returns it unchanged (identity).
+// - Otherwise, extracts the first sentence (terminated by `. ! ?` followed
+//   by whitespace or end-of-string) and truncates to the byte cap.
+// - If no sentence boundary exists, falls back to plain byte truncation.
+// - Never cuts inside a UTF-8 codepoint (uses TextEncoder bytewise walk).
+//
+// Pure, no I/O. Pure function; idempotent.
+export function compressDescription(text: string, maxBytes: number): string {
+  if (typeof text !== 'string' || text.length === 0) return text;
+  if (utf8ByteLength(text) <= maxBytes) return text;
+  // First-sentence extraction. The /(?:\s|$)/ tail prevents `e.g.` / `i.e.`
+  // mis-splits when the abbreviation is mid-sentence (followed by ` ` not
+  // `<EOL>`), though it does still split on a leading `e.g. ...` — that
+  // edge case is documented in U1 test scenarios. Tool descriptions in
+  // TOOL_REGISTRY don't start with abbreviations, audited at write-time.
+  const sentenceMatch = text.match(/^[\s\S]+?[.!?](?:\s|$)/);
+  const candidate = sentenceMatch ? sentenceMatch[0].trim() : text;
+  if (utf8ByteLength(candidate) <= maxBytes) return candidate;
+  // Byte-truncate without splitting a codepoint mid-cut. TextEncoder
+  // produces one byte per UTF-8 byte; walk codepoints forward and stop
+  // when adding the next would exceed maxBytes.
+  const encoder = new TextEncoder();
+  let out = '';
+  let used = 0;
+  for (const ch of candidate) {
+    const chBytes = encoder.encode(ch).length;
+    if (used + chBytes > maxBytes) break;
+    out += ch;
+    used += chBytes;
+  }
+  return out;
+}
+
 // Defensive snapshot of the top-level keys / shape of an unprojected value.
 // Echoed inside every `_jmespath_error` envelope so the LLM can self-correct
 // on its next `tools/call` without refetching the (already-paid-for) payload.

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -128,7 +128,7 @@ const SERVER_INSTRUCTIONS = [
   '',
   `Limits: expression ≤ ${JMESPATH_MAX_EXPR_BYTES} bytes; projected payload ≤ ${JMESPATH_MAX_OUTPUT_BYTES} bytes. Failures return {_jmespath_error, original_keys} inside the normal result envelope. Bad expressions DO consume one daily quota unit on retry — original_keys is echoed so you can self-correct in one extra call.`,
   '',
-  `tools/list returns COMPRESSED tool descriptions (first sentence, ≤${TOOL_DESCRIPTION_MAX_BYTES}B per tool). Call describe_tool({tool_name}) to get the full uncompressed definition for any tool you're considering — especially useful when the compressed entry is ambiguous about behaviour or argument semantics. describe_tool({tool_name: 'nonexistent'}) returns {error: 'unknown_tool', available: [...]} so you can self-correct.`,
+  `tools/list returns COMPRESSED tool descriptions (first sentence, ≤${TOOL_DESCRIPTION_MAX_BYTES}B per tool). Call describe_tool({tool_name}) to get the full uncompressed definition for any tool you're considering — especially useful when the compressed entry is ambiguous about behaviour or argument semantics. describe_tool is metadata-only and is EXEMPT from the Pro daily quota (still counts toward the 60/min rate limit), so use it freely while exploring. describe_tool({tool_name: 'nonexistent'}) returns {error: 'unknown_tool', available: [...]} so you can self-correct.`,
 ].join('\n');
 
 // Country-code whitelist for get_consumer_prices. The consumer-prices seeder
@@ -3075,9 +3075,17 @@ async function dispatchToolsCall(
     return rpcError(id, -32602, `Unknown tool: ${p.name}`);
   }
 
-  // Pro-only INCR-first reservation. Both cache-only AND RPC tools count.
+  // Pro-only INCR-first reservation. Both cache-only AND RPC tools count
+  // toward the daily 50/day cap — EXCEPT `describe_tool` (v1.5.0), which
+  // is metadata-only and is actively encouraged by SERVER_INSTRUCTIONS
+  // when the compressed tools/list entry is ambiguous. Charging quota for
+  // schema lookups would (a) discourage the LLM from using it, defeating
+  // the v1.5.0 compression's UX hedge, and (b) lock out Pro users at the
+  // 50/day cap from even seeing tool definitions. Exempt by name; rate-
+  // limiter (60/min) still applies as the abuse guard.
+  const isMetadataTool = p.name === 'describe_tool';
   let proRollback: (() => Promise<void>) | null = null;
-  if (context.kind === 'pro') {
+  if (context.kind === 'pro' && !isMetadataTool) {
     const reservation = await reserveQuota(context.userId, deps.redisPipeline);
     if (!reservation.ok) {
       if (reservation.reason === 'cap-exceeded') {

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -68,9 +68,24 @@ const SERVER_NAME = 'worldmonitor';
 //     ~600 bytes emitted once per session vs ×38 schema-bloat across tools.
 //   - Purely additive — omitting `jmespath` returns the v1.3.0 payload
 //     byte-for-byte. Bundle delta +57.8 KB raw / +9.4 KB gzipped.
+// Bumped 1.4.0 → 1.5.0 (2026-05-18) reflecting:
+//   - tools/list TOOL descriptions are now compressed to ≤120 UTF-8 bytes
+//     (first sentence or byte-truncate). Reduces per-session input-token
+//     cost on session-init. Property descriptions intentionally NOT
+//     compressed in v1 (audit found 53% encode contract details).
+//   - New `describe_tool({tool_name})` RPC returns the full uncompressed
+//     definition on demand. Same public shape as a tools/list entry.
+//   - Both surfaces flow through a single `buildPublicTool` helper —
+//     can never drift. Property schemas + injected SUMMARY_SCHEMA/
+//     JMESPATH_SCHEMA are `structuredClone`'d before injection so the
+//     module-level consts can't be mutated through returned objects.
+//   - Tool count bumped 38 → 39 (describe_tool added).
+//   - Purely additive — omitting all v1.5.0 args returns a compressed
+//     description in tools/list (observable shape change); describe_tool
+//     recovers full text.
 // Keep aligned with public/.well-known/mcp/server-card.json::serverInfo.version
 // — discovery scanners cross-check both values.
-const SERVER_VERSION = '1.4.0';
+const SERVER_VERSION = '1.5.0';
 
 // Universal JMESPath projection caps (v1.4.0) — applied at the dispatch
 // boundary AFTER `_postFilter` and `summary`, before serialization. Two
@@ -90,6 +105,12 @@ export const JMESPATH_MAX_EXPR_BYTES = 1024;
 export const JMESPATH_MAX_OUTPUT_BYTES = 256 * 1024;
 export type JmespathFailKind = 'expression_too_long' | 'projection_too_large' | 'invalid_expression';
 
+// tools/list tool-description compression cap (v1.5.0). Defined here
+// rather than near `compressDescription` so SERVER_INSTRUCTIONS can
+// quote it without a temporal-dead-zone error. The compressDescription
+// helper definition lives later, with the rest of the helpers.
+export const TOOL_DESCRIPTION_MAX_BYTES = 120;
+
 // Session-level discovery instructions. Per MCP 2025-03-26 lifecycle spec,
 // servers MAY return an `instructions` string in the `initialize` result;
 // clients SHOULD surface this to the model. We carry the JMESPath grammar
@@ -106,6 +127,8 @@ const SERVER_INSTRUCTIONS = [
   '  data.advisories[?level==\'warning\'][].title',
   '',
   `Limits: expression ≤ ${JMESPATH_MAX_EXPR_BYTES} bytes; projected payload ≤ ${JMESPATH_MAX_OUTPUT_BYTES} bytes. Failures return {_jmespath_error, original_keys} inside the normal result envelope. Bad expressions DO consume one daily quota unit on retry — original_keys is echoed so you can self-correct in one extra call.`,
+  '',
+  `tools/list returns COMPRESSED tool descriptions (first sentence, ≤${TOOL_DESCRIPTION_MAX_BYTES}B per tool). Call describe_tool({tool_name}) to get the full uncompressed definition for any tool you're considering — especially useful when the compressed entry is ambiguous about behaviour or argument semantics. describe_tool({tool_name: 'nonexistent'}) returns {error: 'unknown_tool', available: [...]} so you can self-correct.`,
 ].join('\n');
 
 // Country-code whitelist for get_consumer_prices. The consumer-prices seeder
@@ -369,7 +392,9 @@ export function utf8ByteLength(s: string): number {
 // (added in U2) so there's a single source of truth for the public shape.
 // ---------------------------------------------------------------------------
 
-export const TOOL_DESCRIPTION_MAX_BYTES = 120;
+// TOOL_DESCRIPTION_MAX_BYTES is declared above with the version-bump caps
+// block so SERVER_INSTRUCTIONS can quote it without a TDZ. Referenced here
+// by compressDescription's default call sites.
 
 // Compress a description string to at most `maxBytes` UTF-8 bytes.
 // - If the text already fits, returns it unchanged (identity).

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -2518,20 +2518,72 @@ for (const tool of TOOL_REGISTRY) {
   }
 }
 
-const TOOL_LIST_RESPONSE = TOOL_REGISTRY.map((tool) => {
+// Shared public-shape builder (v1.5.0). SINGLE source of truth for what
+// `tools/list` and `describe_tool` emit. Both surfaces go through this
+// helper so they can never drift.
+//
+// Always recursively deep-clones property schemas AND the injected
+// SUMMARY_SCHEMA / JMESPATH_SCHEMA consts via `structuredClone`. Without
+// this, mutating any returned property (including nested `enum` / `items.enum`
+// arrays, e.g. `get_market_data.asset_classes.items.enum`) would corrupt
+// the registry or the module-level schema consts. Codex Round 2 explicitly
+// flagged shallow `{ ...prop }` as insufficient for these shapes.
+//
+// `_*`-prefixed internal fields (_apiPaths, _cacheKeys, _seedMetaKey,
+// _maxStaleMin, _freshnessChecks, _coverageKeys, _postFilter, _execute)
+// are NEVER enumerated — the function only constructs a fresh object with
+// the public-shape fields (name, description, inputSchema, annotations).
+//
+// `opts.compressDescriptions` — when true (the tools/list call path),
+// the tool's top-level `description` is run through compressDescription.
+// When false (the describe_tool call path), full text is preserved.
+export interface PublicToolShape {
+  name: string;
+  description: string;
+  inputSchema: { type: string; properties: Record<string, unknown>; required: string[] };
+  annotations: { readOnlyHint: boolean; openWorldHint: boolean };
+}
+
+export function buildPublicTool(
+  tool: ToolDef,
+  opts: { compressDescriptions: boolean },
+): PublicToolShape {
   const isCacheTool = tool._execute === undefined;
-  // `summary` is cache-only (RPC responses are bespoke and don't summarize
-  // uniformly). `jmespath` is universal (projection is shape-agnostic).
-  const properties = isCacheTool
-    ? { ...tool.inputSchema.properties, summary: SUMMARY_SCHEMA, jmespath: JMESPATH_SCHEMA }
-    : { ...tool.inputSchema.properties, jmespath: JMESPATH_SCHEMA };
+
+  // Recursively clone each property schema. Handles direct `enum: [...]`
+  // arrays (e.g. api/mcp.ts:810) and nested `items.enum: [...]` arrays
+  // (e.g. api/mcp.ts:655) — both present in TOOL_REGISTRY. `structuredClone`
+  // is a Web Platform global on Vercel edge + Node 18+ (no polyfill needed).
+  const clonedProperties: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(tool.inputSchema.properties)) {
+    clonedProperties[key] = structuredClone(value);
+  }
+
+  // Inject the universal schemas as CLONES, not bare references, so that
+  // mutating `result.inputSchema.properties.jmespath.description` doesn't
+  // corrupt the module-level JMESPATH_SCHEMA const.
+  if (isCacheTool) {
+    clonedProperties.summary = structuredClone(SUMMARY_SCHEMA);
+  }
+  clonedProperties.jmespath = structuredClone(JMESPATH_SCHEMA);
+
+  const description = opts.compressDescriptions
+    ? compressDescription(tool.description, TOOL_DESCRIPTION_MAX_BYTES)
+    : tool.description;
+
   return {
     name: tool.name,
-    description: tool.description,
-    inputSchema: { ...tool.inputSchema, properties },
+    description,
+    inputSchema: {
+      type: tool.inputSchema.type,
+      properties: clonedProperties,
+      required: [...tool.inputSchema.required],
+    },
     annotations: { readOnlyHint: true, openWorldHint: true },
   };
-});
+}
+
+const TOOL_LIST_RESPONSE = TOOL_REGISTRY.map((tool) => buildPublicTool(tool, { compressDescriptions: true }));
 
 // ---------------------------------------------------------------------------
 // JSON-RPC helpers

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -2483,6 +2483,40 @@ const TOOL_REGISTRY: ToolDef[] = [
     },
     _apiPaths: [],
   },
+  {
+    // describe_tool (v1.5.0) — on-demand escape hatch for the full
+    // uncompressed tool definition. tools/list (default) emits each tool's
+    // description compressed to ≤TOOL_DESCRIPTION_MAX_BYTES (first sentence
+    // or byte-truncated); the LLM calls describe_tool with a tool_name to
+    // get the full v1.4.0-shape tool object — same public shape, just with
+    // long-form text in `description`. Uses the SAME buildPublicTool helper
+    // as tools/list so the two surfaces can never drift.
+    name: 'describe_tool',
+    description: 'Return the full uncompressed definition of one tool by name. Use when the compressed tools/list entry is ambiguous about behaviour or argument semantics.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tool_name: { type: 'string', description: 'Exact tool name from tools/list.' },
+      },
+      required: ['tool_name'],
+    },
+    _execute: async (params: Record<string, unknown>) => {
+      const name = params.tool_name;
+      if (typeof name !== 'string' || name.length === 0) {
+        return { error: 'missing_tool_name', hint: 'Pass tool_name as a non-empty string matching a tool from tools/list.' };
+      }
+      const tool = TOOL_REGISTRY.find((t) => t.name === name);
+      if (!tool) {
+        return {
+          error: 'unknown_tool',
+          requested: name,
+          available: TOOL_REGISTRY.map((t) => t.name).sort(),
+        };
+      }
+      return buildPublicTool(tool, { compressDescriptions: false });
+    },
+    _apiPaths: [],
+  },
 ];
 
 // Public shape for tools/list — strips internal _-prefixed fields, adds MCP

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -9,7 +9,7 @@ WorldMonitor exposes its intelligence stack as a [Model Context Protocol](https:
 **Pro and API tiers can both connect via OAuth — no API key required.** Pro subscribers click _"Sign in with WorldMonitor Pro"_ on the consent page; API Starter / Business / Enterprise users may sign in the same way OR paste a `wm_…` key. Free-tier users see a 401 at the OAuth step.
 </Info>
 
-All paid tiers share the same MCP server, the same 38 tools, and the same OAuth flow — they differ only in **daily quotas**. Pro starts at **50 tool calls/day**; API Starter and API Business have generous daily allowances; Enterprise is uncapped. See the [Plans & limits](#plans--limits) table below.
+All paid tiers share the same MCP server, the same 39 tools, and the same OAuth flow — they differ only in **daily quotas**. Pro starts at **50 tool calls/day**; API Starter and API Business have generous daily allowances; Enterprise is uncapped. See the [Plans & limits](#plans--limits) table below. (`describe_tool`, the v1.5.0 metadata-lookup helper, is exempt from the daily quota.)
 
 Pro subscribers can connect Claude Desktop / Cursor / claude.ai without ever pasting an API key — see [Pro sign-in flow](#pro-sign-in-flow) below. API Starter+ holders may continue to paste a `wm_…` key on the consent page (the original flow), or use the same OAuth path as Pro.
 
@@ -24,7 +24,7 @@ Pro subscribers can connect Claude Desktop / Cursor / claude.ai without ever pas
 | `https://api.worldmonitor.app/.well-known/oauth-authorization-server` | AS metadata (RFC 8414) |
 | `https://worldmonitor.app/.well-known/oauth-protected-resource` | Resource server metadata (RFC 9728) |
 
-Protocol version: `2025-03-26`. Server identifier: `worldmonitor` v1.1.0.
+Protocol version: `2025-03-26`. Server identifier: `worldmonitor` v1.5.0.
 
 ## Authentication
 
@@ -161,7 +161,7 @@ npx @modelcontextprotocol/inspector https://worldmonitor.app/mcp
 
 ## Tool catalog
 
-The server exposes 38 tools. Most are cache-reads over pre-seeded Redis keys (sub-second). Six (`get_world_brief`, `get_country_brief`, `analyze_situation`, `generate_forecasts`, `search_flights`, `search_flight_prices_by_date`) call live LLMs or external APIs and are slower.
+The server exposes 39 tools. Most are cache-reads over pre-seeded Redis keys (sub-second). Six (`get_world_brief`, `get_country_brief`, `analyze_situation`, `generate_forecasts`, `search_flights`, `search_flight_prices_by_date`) call live LLMs or external APIs and are slower. One (`describe_tool`, added v1.5.0) returns the full uncompressed definition of any other tool — useful when the compressed `tools/list` description is ambiguous; exempt from the Pro daily quota.
 
 <Tip>
 For per-tool parameters, freshness budgets, timeouts, and concrete `curl` examples, see the [MCP Tools Reference](/mcp-tools-reference).
@@ -288,7 +288,7 @@ A handful of tools have no entry above because they don't map 1:1 to a public Op
 - **Static in-memory registries** — filter a constant bundled with the MCP server's edge binary, no upstream call at all (e.g. `get_commodity_geo`).
 - **Live tools without a public OpenAPI row** — runtime proxies an HTTP call whose method drifts from the public spec, where a sibling tool already covers the spec-declared method (e.g. `generate_forecasts` POSTs `/api/forecast/v1/get-forecasts` while `get_forecast_predictions` owns the GET).
 
-See the [Tool catalog](#tool-catalog) above for the complete list of 38 tools, or the [MCP Tools Reference](/mcp-tools-reference) for per-tool details.
+See the [Tool catalog](#tool-catalog) above for the complete list of 39 tools, or the [MCP Tools Reference](/mcp-tools-reference) for per-tool details.
 
 <Tip>
 **Reverse lookup** — if you know the API path you want, search this table with Cmd/Ctrl+F. The same data is also queryable via the running server's `tools/list` response, where each tool description names its domain.

--- a/docs/mcp-tools-reference.mdx
+++ b/docs/mcp-tools-reference.mdx
@@ -1045,3 +1045,39 @@ curl -s https://worldmonitor.app/mcp \
 ```
 
 </CodeGroup>
+
+## Meta
+
+### `describe_tool`
+
+Returns the full uncompressed definition of any other tool by name. Use when the compressed `tools/list` entry is ambiguous about behaviour or argument semantics — since v1.5.0, `tools/list` returns each tool's `description` truncated to the first sentence (≤120 UTF-8 bytes); `describe_tool` returns the full long-form text plus the same `inputSchema` (every property's full description).
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `tool_name` | string | **yes** | Exact tool name from `tools/list` (e.g. `"get_market_data"`). |
+
+**Response shape:** identical to a single `tools/list` entry — `{ name, description, inputSchema, annotations }` — with the full uncompressed `description` and the same `inputSchema.properties` (including injected `summary` for cache tools and `jmespath` for every tool).
+
+**Soft errors** (HTTP 200, returned inside the normal `content[0].text` envelope — NOT JSON-RPC errors):
+
+- `{ "error": "missing_tool_name", "hint": "Pass tool_name as a non-empty string matching a tool from tools/list." }` — `tool_name` was omitted, empty, or non-string.
+- `{ "error": "unknown_tool", "requested": "<the bad name>", "available": [...sorted list of all 39 tool names...] }` — `tool_name` didn't match any registered tool. The `available` array lets the LLM self-correct in one extra call.
+
+- **API endpoints:** none — server-local lookup, no upstream call.
+- **Kind:** metadata lookup — sub-millisecond, no Redis, no LLM.
+- **Quota:** **EXEMPT** from the Pro daily quota (50/day). Per-minute rate limit (60/min) still applies.
+
+<CodeGroup>
+
+```bash curl
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":1,
+    "method":"tools/call",
+    "params":{"name":"describe_tool","arguments":{"tool_name":"get_market_data"}}
+  }'
+```
+
+</CodeGroup>

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -1,7 +1,7 @@
 {
   "serverInfo": {
     "name": "worldmonitor",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "description": "WorldMonitor's live global-intelligence stack as an MCP server: real-time markets, conflict events, aviation, maritime, energy, climate, health, displacement, supply chain, and AI-generated regional briefs.",
     "vendor": "WorldMonitor",
     "homepage": "https://www.worldmonitor.app"
@@ -17,7 +17,7 @@
     "prompts": false
   },
   "tools": {
-    "count": 38,
+    "count": 39,
     "categories": [
       "markets-economy",
       "energy",
@@ -76,6 +76,7 @@
     "toolListNote": "Issue a `tools/list` JSON-RPC call against the transport endpoint for the current authoritative tool inventory with input schemas and descriptions."
   },
   "features": {
-    "responseProjection": "jmespath"
+    "responseProjection": "jmespath",
+    "toolDescriptionCompression": true
   }
 }

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -56,7 +56,7 @@
       "apiBusiness": 10000,
       "enterprise": null
     },
-    "notes": "Per-day quota (dailyByPlan) counts only tools/call — initialize, tools/list, ping, and notifications/initialized are exempt. Per-minute (60/min, per-user on Pro, per-key on API tiers) counts ALL methods, so a tight discovery probe loop on tools/list will still trip the throttle."
+    "notes": "Per-day quota (dailyByPlan) counts only tools/call — initialize, tools/list, ping, and notifications/initialized are exempt. The `describe_tool` tools/call is also exempt (v1.5.0 metadata escape hatch — SERVER_INSTRUCTIONS encourages calling it freely while exploring; otherwise a Pro user at the 50/day cap could not fetch tool definitions). Per-minute (60/min, per-user on Pro, per-key on API tiers) counts ALL methods, so a tight discovery probe loop on tools/list will still trip the throttle."
   },
   "tags": [
     "geopolitical-intelligence",

--- a/scripts/measure-tools-list-compression.mjs
+++ b/scripts/measure-tools-list-compression.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Reproducible tools/list byte-reduction measurement (v1.4.0 → v1.5.0).
+ *
+ * Self-contained — no fixture file needed. The script computes BOTH
+ * compressed (v1.5.0 path) and uncompressed (synthetic v1.4.0 shape,
+ * excluding describe_tool) responses in one process by calling the
+ * shared `buildPublicTool` helper with both flag values. Deterministic;
+ * same source → same byte counts every run.
+ *
+ * The synthetic-v1.4.0 path is faithful because v1.4.0's
+ * TOOL_LIST_RESPONSE builder did exactly what `buildPublicTool(t,
+ * { compressDescriptions: false })` does today (minus describe_tool,
+ * which is new in v1.5.0). Excluding describe_tool from the synthetic
+ * baseline gives an apples-to-apples comparison.
+ *
+ * Output: markdown table for the PR description + assertion that the
+ * reduction crosses R1's ≥8% target.
+ *
+ * Usage:
+ *   npx tsx scripts/measure-tools-list-compression.mjs
+ */
+import {
+  TOOL_DESCRIPTION_MAX_BYTES,
+  utf8ByteLength,
+  buildPublicTool,
+} from '../api/mcp.ts';
+
+// Re-import the module to reach TOOL_REGISTRY indirectly via the public
+// tools/list call. We don't export TOOL_REGISTRY; the round-trip through
+// mcpHandler gives us the v1.5.0 compressed catalog. For the v1.4.0
+// baseline we re-run the same registry through buildPublicTool with
+// compressDescriptions=false and filter out describe_tool (the v1.5.0
+// addition).
+process.env.WORLDMONITOR_VALID_KEYS = 'wm_measure_key';
+delete process.env.UPSTASH_REDIS_REST_URL;
+delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+const mcpMod = await import('../api/mcp.ts');
+
+async function fetchToolsList() {
+  const req = new Request('https://worldmonitor.app/mcp', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-WorldMonitor-Key': 'wm_measure_key' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+  });
+  const res = await mcpMod.default(req);
+  const body = await res.json();
+  return body.result.tools;
+}
+
+const v15Tools = await fetchToolsList();
+
+// Reconstruct v1.4.0 baseline: same tools as v1.5.0 EXCEPT exclude
+// describe_tool (new in v1.5.0), AND replace each compressed description
+// with the full text by calling describe_tool({tool_name: t.name}).
+async function callDescribeTool(toolName) {
+  const req = new Request('https://worldmonitor.app/mcp', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'X-WorldMonitor-Key': 'wm_measure_key' },
+    body: JSON.stringify({
+      jsonrpc: '2.0', id: 1, method: 'tools/call',
+      params: { name: 'describe_tool', arguments: { tool_name: toolName } },
+    }),
+  });
+  const res = await mcpMod.default(req);
+  const body = await res.json();
+  return JSON.parse(body.result.content[0].text);
+}
+
+// v1.4.0 baseline: every non-describe_tool tool with FULL description
+const v14Tools = [];
+for (const t of v15Tools) {
+  if (t.name === 'describe_tool') continue; // v1.5.0 addition
+  const full = await callDescribeTool(t.name);
+  v14Tools.push(full);
+}
+
+// The response envelope structure matches what `tools/list` emits:
+// { jsonrpc: '2.0', id: 1, result: { tools: [...] } }
+function envelopeFor(tools) {
+  return { jsonrpc: '2.0', id: 1, result: { tools } };
+}
+
+const v14Bytes = utf8ByteLength(JSON.stringify(envelopeFor(v14Tools)));
+const v15Bytes = utf8ByteLength(JSON.stringify(envelopeFor(v15Tools)));
+const reduction = Math.round(((v14Bytes - v15Bytes) / v14Bytes) * 10000) / 100;
+
+const v14ToolDescBytes = v14Tools.reduce((sum, t) => sum + utf8ByteLength(t.description), 0);
+const v15ToolDescBytes = v15Tools.reduce((sum, t) => sum + utf8ByteLength(t.description), 0);
+
+function fmt(n) { return n < 1024 ? `${n} B` : `${(n / 1024).toFixed(1)} KB`; }
+
+const out = [
+  '## tools/list compression — A/B byte savings (v1.4.0 → v1.5.0)',
+  '',
+  '_Reproducible. Self-contained measurement — no captured fixture. Same source → same byte counts._',
+  '',
+  '| Slice | v1.4.0 (uncompressed) | v1.5.0 (compressed) | Reduction |',
+  '|---|---:|---:|---:|',
+  `| **Total tools/list envelope** | ${fmt(v14Bytes)} | ${fmt(v15Bytes)} | **${reduction}%** |`,
+  `| Tool descriptions (38 / 39) | ${fmt(v14ToolDescBytes)} | ${fmt(v15ToolDescBytes)} | ${Math.round(((v14ToolDescBytes - v15ToolDescBytes) / v14ToolDescBytes) * 100)}% |`,
+  '',
+  `Measurement: \`utf8ByteLength(JSON.stringify(envelope))\` — same helper that gates JMESPath output (api/mcp.ts:utf8ByteLength), so reported numbers match the runtime contract.`,
+  '',
+  `Cap: \`TOOL_DESCRIPTION_MAX_BYTES = ${TOOL_DESCRIPTION_MAX_BYTES}\`. Property descriptions intentionally NOT compressed in v1.5.0 (audit found 53% encode contract details).`,
+];
+process.stdout.write(out.join('\n') + '\n');
+
+// R1: reduction ≥ 8%
+if (reduction < 8) {
+  process.stderr.write(`\nERROR: reduction ${reduction}% is below R1 target of ≥8%.\n`);
+  process.exit(1);
+}

--- a/tests/mcp-jmespath.test.mjs
+++ b/tests/mcp-jmespath.test.mjs
@@ -300,10 +300,12 @@ describe('api/mcp.ts — JMESPath projection (v1.4.0)', () => {
   // Initialize handshake — version + instructions
   // ============================================================
   describe('initialize handshake', () => {
-    it('serverInfo.version === "1.4.0"', async () => {
+    it('serverInfo.version === "1.5.0"', async () => {
+      // Tracks current SERVER_VERSION. Each minor bump needs to update
+      // this assertion + the cross-check at line 327 below.
       const res = await mod.default(makeReq(initBody(1)));
       const body = await res.json();
-      assert.equal(body.result?.serverInfo?.version, '1.4.0');
+      assert.equal(body.result?.serverInfo?.version, '1.5.0');
     });
 
     it('result.instructions is present and mentions jmespath', async () => {
@@ -324,12 +326,12 @@ describe('api/mcp.ts — JMESPath projection (v1.4.0)', () => {
       assert.ok(/daily quota/i.test(inst), 'missing quota note');
     });
 
-    it('server-card.json version matches SERVER_VERSION (1.4.0)', () => {
-      // Cross-check the comment at api/mcp.ts:56 — discovery scanners
+    it('server-card.json version matches SERVER_VERSION (currently 1.5.0)', () => {
+      // Cross-check the comment at api/mcp.ts:~56 — discovery scanners
       // verify both values; a future bump that misses one would break
       // discovery. This is the test that prevents that drift.
       const card = JSON.parse(readFileSync(new URL('../public/.well-known/mcp/server-card.json', import.meta.url), 'utf8'));
-      assert.equal(card.serverInfo.version, '1.4.0');
+      assert.equal(card.serverInfo.version, '1.5.0');
       assert.equal(card.features?.responseProjection, 'jmespath');
     });
 

--- a/tests/mcp-tools-list-compression.test.mjs
+++ b/tests/mcp-tools-list-compression.test.mjs
@@ -1,5 +1,6 @@
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
 
 const originalEnv = { ...process.env };
 
@@ -344,6 +345,42 @@ describe('api/mcp.ts — tools/list description compression (v1.5.0)', () => {
     it('describe_tool({}) returns {error: "missing_tool_name"}', async () => {
       const env = await callDescribeTool(undefined);
       assert.equal(env.error, 'missing_tool_name');
+    });
+
+    // ============================================================
+    // U4: Version bump + SERVER_INSTRUCTIONS + server-card sync
+    // ============================================================
+    it('serverInfo.version === "1.5.0"', async () => {
+      const res = await mod.default(new Request('https://worldmonitor.app/mcp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-WorldMonitor-Key': VALID_KEY },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 't', version: '1' } } }),
+      }));
+      const body = await res.json();
+      assert.equal(body.result?.serverInfo?.version, '1.5.0');
+    });
+
+    it('initialize.result.instructions mentions describe_tool AND the TOOL_DESCRIPTION_MAX_BYTES cap value', async () => {
+      const res = await mod.default(new Request('https://worldmonitor.app/mcp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-WorldMonitor-Key': VALID_KEY },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 't', version: '1' } } }),
+      }));
+      const body = await res.json();
+      const inst = body.result.instructions;
+      assert.ok(typeof inst === 'string' && inst.length > 0);
+      assert.ok(/describe_tool/i.test(inst), 'instructions should mention describe_tool');
+      assert.ok(inst.includes(String(mod.TOOL_DESCRIPTION_MAX_BYTES)),
+        'instructions should mention the TOOL_DESCRIPTION_MAX_BYTES cap');
+    });
+
+    it('server-card.json version matches SERVER_VERSION (1.5.0) AND tools.count matches (39)', () => {
+      const card = JSON.parse(readFileSync(new URL('../public/.well-known/mcp/server-card.json', import.meta.url), 'utf8'));
+      assert.equal(card.serverInfo.version, '1.5.0');
+      assert.equal(card.tools.count, 39);
+      assert.equal(card.features?.toolDescriptionCompression, true);
+      assert.equal(card.features?.responseProjection, 'jmespath',
+        'v1.4.0 feature flag must still be present');
     });
 
     it('round-trip: every tool returned by describe_tool has no _-prefixed key (R9)', async () => {

--- a/tests/mcp-tools-list-compression.test.mjs
+++ b/tests/mcp-tools-list-compression.test.mjs
@@ -255,4 +255,118 @@ describe('api/mcp.ts — tools/list description compression (v1.5.0)', () => {
       }
     });
   });
+
+  // ============================================================
+  // U3: TOOL_LIST_RESPONSE compression + describe_tool RPC
+  // ============================================================
+  describe('tools/list compression + describe_tool RPC', () => {
+    async function getToolsList() {
+      const res = await mod.default(new Request('https://worldmonitor.app/mcp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-WorldMonitor-Key': VALID_KEY },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      }));
+      const body = await res.json();
+      return body.result.tools;
+    }
+
+    async function callDescribeTool(tool_name) {
+      const res = await mod.default(new Request('https://worldmonitor.app/mcp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-WorldMonitor-Key': VALID_KEY },
+        body: JSON.stringify({
+          jsonrpc: '2.0', id: 1, method: 'tools/call',
+          params: { name: 'describe_tool', arguments: tool_name === undefined ? {} : { tool_name } },
+        }),
+      }));
+      const body = await res.json();
+      assert.equal(res.status, 200);
+      assert.equal(body.error, undefined, `describe_tool returned JSON-RPC error: ${JSON.stringify(body.error)}`);
+      return JSON.parse(body.result.content[0].text);
+    }
+
+    it('tools/list contains 39 tools (38 + describe_tool)', async () => {
+      const tools = await getToolsList();
+      assert.equal(tools.length, 39);
+    });
+
+    it('describe_tool itself appears in tools/list', async () => {
+      const tools = await getToolsList();
+      assert.ok(tools.find(t => t.name === 'describe_tool'),
+        'describe_tool must be discoverable via tools/list');
+    });
+
+    it('every tool in tools/list has compressed description ≤ TOOL_DESCRIPTION_MAX_BYTES utf8 bytes', async () => {
+      const tools = await getToolsList();
+      for (const t of tools) {
+        assert.ok(mod.utf8ByteLength(t.description) <= mod.TOOL_DESCRIPTION_MAX_BYTES,
+          `tool "${t.name}" description is ${mod.utf8ByteLength(t.description)} bytes (cap ${mod.TOOL_DESCRIPTION_MAX_BYTES})`);
+      }
+    });
+
+    it('describe_tool({tool_name: "get_market_data"}) returns the FULL uncompressed description', async () => {
+      const tools = await getToolsList();
+      const compressed = tools.find(t => t.name === 'get_market_data');
+      const full = await callDescribeTool('get_market_data');
+      assert.ok(mod.utf8ByteLength(full.description) > mod.utf8ByteLength(compressed.description),
+        `describe_tool should return longer description than tools/list (full=${mod.utf8ByteLength(full.description)}, compressed=${mod.utf8ByteLength(compressed.description)})`);
+      // Full text should NOT have been truncated by compression — verify
+      // the v1.4.0 description is longer than the cap so this test is meaningful.
+      assert.ok(mod.utf8ByteLength(full.description) > mod.TOOL_DESCRIPTION_MAX_BYTES,
+        'test premise: full get_market_data description should exceed the cap');
+    });
+
+    it('describe_tool result has the SAME shape as a tools/list entry (name + description + inputSchema + annotations)', async () => {
+      const tools = await getToolsList();
+      const fromList = tools.find(t => t.name === 'get_market_data');
+      const fromDescribe = await callDescribeTool('get_market_data');
+      assert.deepEqual(Object.keys(fromList).sort(), Object.keys(fromDescribe).sort());
+    });
+
+    it('describe_tool result has inputSchema.properties.jmespath structurally equal to JMESPATH_SCHEMA (R7)', async () => {
+      const JMESPATH_SCHEMA = { type: 'string', description: 'Optional JMESPath projection applied to the response. See initialize.instructions for grammar and examples.' };
+      const full = await callDescribeTool('get_market_data');
+      assert.deepEqual(full.inputSchema.properties.jmespath, JMESPATH_SCHEMA);
+    });
+
+    it('describe_tool({tool_name: "nonexistent"}) returns {error: "unknown_tool", available: [...]} (soft error, HTTP 200, NOT a JSON-RPC error)', async () => {
+      const env = await callDescribeTool('nonexistent_tool');
+      assert.equal(env.error, 'unknown_tool');
+      assert.equal(env.requested, 'nonexistent_tool');
+      assert.ok(Array.isArray(env.available));
+      assert.equal(env.available.length, 39, 'available should list all 39 tools');
+      // Sorted alphabetically
+      const sorted = [...env.available].sort();
+      assert.deepEqual(env.available, sorted);
+      assert.ok(env.available.includes('describe_tool'));
+    });
+
+    it('describe_tool({}) returns {error: "missing_tool_name"}', async () => {
+      const env = await callDescribeTool(undefined);
+      assert.equal(env.error, 'missing_tool_name');
+    });
+
+    it('round-trip: every tool returned by describe_tool has no _-prefixed key (R9)', async () => {
+      const tools = await getToolsList();
+      function scanForUnderscoreKey(value, pathStack) {
+        if (Array.isArray(value)) {
+          for (let i = 0; i < value.length; i++) scanForUnderscoreKey(value[i], [...pathStack, `[${i}]`]);
+        } else if (value && typeof value === 'object') {
+          for (const k of Object.keys(value)) {
+            if (k.startsWith('_')) {
+              throw new Error(`describe_tool leaked internal key "${k}" at ${pathStack.join('.')}`);
+            }
+            scanForUnderscoreKey(value[k], [...pathStack, k]);
+          }
+        }
+      }
+      // Spot-check 3 cache tools + 3 RPC tools + describe_tool itself
+      const sample = ['get_market_data', 'get_conflict_events', 'get_chokepoint_status', 'search_flights', 'analyze_situation', 'get_commodity_geo', 'describe_tool'];
+      for (const name of sample) {
+        if (!tools.find(t => t.name === name)) continue;
+        const full = await callDescribeTool(name);
+        scanForUnderscoreKey(full, [`describe_tool(${name})`]);
+      }
+    });
+  });
 });

--- a/tests/mcp-tools-list-compression.test.mjs
+++ b/tests/mcp-tools-list-compression.test.mjs
@@ -110,4 +110,149 @@ describe('api/mcp.ts — tools/list description compression (v1.5.0)', () => {
       }
     });
   });
+
+  // ============================================================
+  // U2: buildPublicTool shared helper — clone, inject, strip
+  // ============================================================
+  describe('buildPublicTool helper', () => {
+    // Pick a cache tool (has _execute===undefined) and an RPC tool from
+    // the registry. Use module-side TOOL_REGISTRY via the helper's
+    // outputs since we don't export TOOL_REGISTRY directly.
+    async function getRegistry() {
+      // Reach into the module's tools/list response to find tool shapes,
+      // then call buildPublicTool against the public surface via a fresh
+      // import + direct tool lookup.
+      // Easier: use the existing tools/list call to learn the names, then
+      // export TOOL_REGISTRY-like access by calling buildPublicTool indirectly.
+      // We need TOOL_REGISTRY here for tests; export it temporarily via
+      // module internals.
+      const res = await mod.default(new Request('https://worldmonitor.app/mcp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-WorldMonitor-Key': VALID_KEY },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+      }));
+      const body = await res.json();
+      return body.result.tools;
+    }
+
+    it('compressDescriptions=true returns { name, description, inputSchema, annotations } with no other top-level keys', async () => {
+      const tools = await getRegistry();
+      const t = tools.find(t => t.name === 'get_market_data');
+      assert.ok(t, 'get_market_data must be registered');
+      assert.deepEqual(Object.keys(t).sort(), ['annotations', 'description', 'inputSchema', 'name']);
+    });
+
+    it('every cache-tool result has inputSchema.properties.summary STRUCTURALLY equal to SUMMARY_SCHEMA (deepEqual not ===)', async () => {
+      // We need an internal handle on SUMMARY_SCHEMA / JMESPATH_SCHEMA to
+      // assert structural equality.
+      const SUMMARY_SCHEMA = { type: 'boolean', description: 'Return counts + 3-item samples instead of full lists. Useful when you only need shape/size or want to budget context before drilling in.' };
+      const tools = await getRegistry();
+      const cacheTool = tools.find(t => t.name === 'get_market_data');
+      assert.ok(cacheTool.inputSchema.properties.summary);
+      assert.deepEqual(cacheTool.inputSchema.properties.summary, SUMMARY_SCHEMA);
+    });
+
+    it('every tool has inputSchema.properties.jmespath STRUCTURALLY equal to JMESPATH_SCHEMA (deepEqual not ===)', async () => {
+      const JMESPATH_SCHEMA = { type: 'string', description: 'Optional JMESPath projection applied to the response. See initialize.instructions for grammar and examples.' };
+      const tools = await getRegistry();
+      for (const t of tools) {
+        assert.ok(t.inputSchema?.properties?.jmespath, `tool "${t.name}" missing jmespath schema`);
+        assert.deepEqual(t.inputSchema.properties.jmespath, JMESPATH_SCHEMA, `tool "${t.name}" jmespath shape differs`);
+      }
+    });
+
+    it('RPC tool result does NOT have summary in properties', async () => {
+      const tools = await getRegistry();
+      // search_flights is RPC (_execute) — no summary
+      const rpc = tools.find(t => t.name === 'search_flights');
+      assert.ok(rpc);
+      assert.ok(!('summary' in (rpc.inputSchema?.properties ?? {})),
+        'search_flights (RPC) MUST NOT have summary in its properties');
+    });
+
+    it('R5: mutating result.inputSchema.properties.asset_class.items.enum does NOT mutate registry', async () => {
+      // get_market_data.asset_class has items.enum (api/mcp.ts:655).
+      const tools1 = await getRegistry();
+      const a1 = tools1.find(t => t.name === 'get_market_data');
+      assert.ok(Array.isArray(a1.inputSchema.properties.asset_class?.items?.enum),
+        'asset_class.items.enum must exist for this test');
+      const before = [...a1.inputSchema.properties.asset_class.items.enum];
+      // Mutate the returned schema
+      a1.inputSchema.properties.asset_class.items.enum.push('hacked');
+      // Fetch again — should be untouched
+      const tools2 = await getRegistry();
+      const a2 = tools2.find(t => t.name === 'get_market_data');
+      assert.deepEqual(a2.inputSchema.properties.asset_class.items.enum, before,
+        'nested items.enum was mutated through shared reference');
+    });
+
+    it('R5: mutating result.inputSchema.properties.<x>.enum does NOT mutate registry (direct-enum case)', async () => {
+      // get_news_intelligence.topic has direct enum (api/mcp.ts:810).
+      const tools1 = await getRegistry();
+      const a1 = tools1.find(t => t.name === 'get_news_intelligence');
+      assert.ok(Array.isArray(a1.inputSchema.properties.topic?.enum),
+        'topic.enum must exist for this test');
+      const before = [...a1.inputSchema.properties.topic.enum];
+      a1.inputSchema.properties.topic.enum.length = 0; // mutate to empty
+      const tools2 = await getRegistry();
+      const a2 = tools2.find(t => t.name === 'get_news_intelligence');
+      assert.deepEqual(a2.inputSchema.properties.topic.enum, before,
+        'direct enum array was mutated through shared reference');
+    });
+
+    it('R5: mutating result.inputSchema.properties.jmespath.description does NOT mutate JMESPATH_SCHEMA', async () => {
+      const tools1 = await getRegistry();
+      const a1 = tools1.find(t => t.name === 'get_market_data');
+      a1.inputSchema.properties.jmespath.description = 'EVIL';
+      const tools2 = await getRegistry();
+      const a2 = tools2.find(t => t.name === 'get_market_data');
+      assert.notEqual(a2.inputSchema.properties.jmespath.description, 'EVIL',
+        'JMESPATH_SCHEMA was mutated through shared reference — buildPublicTool must clone it');
+      assert.ok(a2.inputSchema.properties.jmespath.description.includes('JMESPath'),
+        `expected the original JMESPATH_SCHEMA description, got "${a2.inputSchema.properties.jmespath.description}"`);
+    });
+
+    it('R5: mutating result.inputSchema.properties.summary.description does NOT mutate SUMMARY_SCHEMA', async () => {
+      const tools1 = await getRegistry();
+      const a1 = tools1.find(t => t.name === 'get_market_data');
+      a1.inputSchema.properties.summary.description = 'EVIL';
+      const tools2 = await getRegistry();
+      const a2 = tools2.find(t => t.name === 'get_market_data');
+      assert.notEqual(a2.inputSchema.properties.summary.description, 'EVIL',
+        'SUMMARY_SCHEMA was mutated through shared reference');
+      assert.ok(a2.inputSchema.properties.summary.description.includes('counts'),
+        `expected the original SUMMARY_SCHEMA description, got "${a2.inputSchema.properties.summary.description}"`);
+    });
+
+    it('two calls produce structurally-equal but reference-distinct property objects', async () => {
+      const tools1 = await getRegistry();
+      const tools2 = await getRegistry();
+      const a1 = tools1.find(t => t.name === 'get_market_data');
+      const a2 = tools2.find(t => t.name === 'get_market_data');
+      assert.deepEqual(a1.inputSchema.properties, a2.inputSchema.properties);
+      assert.notEqual(a1.inputSchema.properties, a2.inputSchema.properties,
+        'expected reference-distinct properties objects between calls');
+      assert.notEqual(a1.inputSchema.properties.jmespath, a2.inputSchema.properties.jmespath,
+        'expected reference-distinct jmespath property objects between calls');
+    });
+
+    it('R9: no key starting with _ appears anywhere in any returned tool object (recursive scan)', async () => {
+      const tools = await getRegistry();
+      function scanForUnderscoreKey(value, pathStack) {
+        if (Array.isArray(value)) {
+          for (let i = 0; i < value.length; i++) scanForUnderscoreKey(value[i], [...pathStack, `[${i}]`]);
+        } else if (value && typeof value === 'object') {
+          for (const k of Object.keys(value)) {
+            if (k.startsWith('_')) {
+              throw new Error(`Internal field leak: tools/list contains key "${k}" at path ${pathStack.join('.')}`);
+            }
+            scanForUnderscoreKey(value[k], [...pathStack, k]);
+          }
+        }
+      }
+      for (const t of tools) {
+        scanForUnderscoreKey(t, [`tools[${t.name}]`]);
+      }
+    });
+  });
 });

--- a/tests/mcp-tools-list-compression.test.mjs
+++ b/tests/mcp-tools-list-compression.test.mjs
@@ -383,6 +383,28 @@ describe('api/mcp.ts — tools/list description compression (v1.5.0)', () => {
         'v1.4.0 feature flag must still be present');
     });
 
+    // ============================================================
+    // U5: Reduction-target regression guard (R1: ≥8%)
+    // ============================================================
+    it('R1: tools/list compression reduces total envelope by ≥8% UTF-8 bytes vs v1.4.0 baseline', async () => {
+      const tools = await getToolsList();
+      // v1.4.0 baseline: same tools EXCEPT describe_tool (v1.5.0 addition),
+      // with full uncompressed descriptions. Use describe_tool to recover
+      // full text for each tool — same self-contained measurement strategy
+      // the U5 script uses.
+      const v14 = [];
+      for (const t of tools) {
+        if (t.name === 'describe_tool') continue;
+        const full = await callDescribeTool(t.name);
+        v14.push(full);
+      }
+      const v14Bytes = mod.utf8ByteLength(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { tools: v14 } }));
+      const v15Bytes = mod.utf8ByteLength(JSON.stringify({ jsonrpc: '2.0', id: 1, result: { tools } }));
+      const reductionPct = ((v14Bytes - v15Bytes) / v14Bytes) * 100;
+      assert.ok(reductionPct >= 8,
+        `reduction ${reductionPct.toFixed(2)}% below R1 target (≥8%). v1.4.0=${v14Bytes}B v1.5.0=${v15Bytes}B`);
+    });
+
     it('round-trip: every tool returned by describe_tool has no _-prefixed key (R9)', async () => {
       const tools = await getToolsList();
       function scanForUnderscoreKey(value, pathStack) {

--- a/tests/mcp-tools-list-compression.test.mjs
+++ b/tests/mcp-tools-list-compression.test.mjs
@@ -1,0 +1,113 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+const originalEnv = { ...process.env };
+
+const VALID_KEY = 'wm_test_key_123';
+
+async function freshMod() {
+  return import(`../api/mcp.ts?t=${Date.now()}-${Math.random()}`);
+}
+
+describe('api/mcp.ts — tools/list description compression (v1.5.0)', () => {
+  let mod;
+
+  beforeEach(async () => {
+    process.env.WORLDMONITOR_VALID_KEYS = VALID_KEY;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    mod = await freshMod();
+  });
+
+  afterEach(() => {
+    Object.keys(process.env).forEach(k => {
+      if (!(k in originalEnv)) delete process.env[k];
+    });
+    Object.assign(process.env, originalEnv);
+  });
+
+  // ============================================================
+  // U1: compressDescription helper + cap constant
+  // ============================================================
+  describe('compressDescription helper', () => {
+    it('TOOL_DESCRIPTION_MAX_BYTES === 120', () => {
+      assert.equal(mod.TOOL_DESCRIPTION_MAX_BYTES, 120);
+    });
+
+    it('short text (≤cap) returns unchanged (identity, same reference)', () => {
+      const t = 'Short description.';
+      const r = mod.compressDescription(t, mod.TOOL_DESCRIPTION_MAX_BYTES);
+      assert.equal(r, t);
+    });
+
+    it('long text with sentence boundary returns first-sentence trimmed', () => {
+      const t = 'First sentence is short. Second sentence is much longer and would otherwise blow past the cap by including a great deal of additional prose that nobody reads.';
+      const r = mod.compressDescription(t, 80);
+      assert.equal(r, 'First sentence is short.');
+      assert.ok(mod.utf8ByteLength(r) <= 80);
+    });
+
+    it('long text without sentence boundary returns truncated-to-cap raw text', () => {
+      const t = 'a'.repeat(200); // no `.`, `!`, or `?`
+      const r = mod.compressDescription(t, 50);
+      assert.equal(mod.utf8ByteLength(r), 50);
+      assert.equal(r, 'a'.repeat(50));
+    });
+
+    it('text exactly at cap returns unchanged', () => {
+      const t = 'x'.repeat(50);
+      const r = mod.compressDescription(t, 50);
+      assert.equal(r, t);
+    });
+
+    it('UTF-8 emoji at the cap boundary: never splits a 4-byte codepoint mid-cut', () => {
+      // 30 emoji = 120 UTF-8 bytes (each emoji is 4 bytes); cap=100.
+      // The byte-truncate path should stop AT a codepoint boundary,
+      // not produce a malformed UTF-8 string. 25 emoji = 100 bytes.
+      const t = '🚀'.repeat(30);
+      assert.equal(mod.utf8ByteLength(t), 120);
+      const r = mod.compressDescription(t, 100);
+      assert.equal(mod.utf8ByteLength(r), 100, `expected exactly 100 bytes, got ${mod.utf8ByteLength(r)}`);
+      // Round-trip through encode/decode to confirm no broken codepoint
+      const decoded = new TextDecoder('utf-8', { fatal: true }).decode(new TextEncoder().encode(r));
+      assert.equal(decoded, r);
+      assert.equal(r, '🚀'.repeat(25));
+    });
+
+    it('CJK content compresses correctly (utf8 byte accounting, not .length)', () => {
+      // Each Chinese char is 3 UTF-8 bytes. 50 chars = 150 bytes, .length=50.
+      const t = '中'.repeat(50);
+      assert.equal(mod.utf8ByteLength(t), 150);
+      assert.equal(t.length, 50);
+      const r = mod.compressDescription(t, 60);
+      // Should fit ~20 chars (60 bytes) — first-sentence regex doesn't match, falls through to byte-truncate
+      assert.ok(mod.utf8ByteLength(r) <= 60);
+      assert.equal(mod.utf8ByteLength(r), 60); // exactly 20 chars
+    });
+
+    it('empty string returns empty string', () => {
+      assert.equal(mod.compressDescription('', 120), '');
+    });
+
+    it('idempotent: compressDescription(compressDescription(t, cap), cap) === compressDescription(t, cap)', () => {
+      const t = 'a long description that exceeds the cap. With multiple sentences. Each one different.';
+      const once = mod.compressDescription(t, 30);
+      const twice = mod.compressDescription(once, 30);
+      assert.equal(twice, once);
+    });
+
+    it('never grows: output bytes ≤ max(input, cap)', () => {
+      const inputs = [
+        'short',
+        'medium length sentence here.',
+        'a'.repeat(300),
+        '🚀'.repeat(50),
+      ];
+      for (const t of inputs) {
+        const r = mod.compressDescription(t, 50);
+        assert.ok(mod.utf8ByteLength(r) <= Math.max(mod.utf8ByteLength(t), 50),
+          `growth detected for input ${JSON.stringify(t.slice(0, 40))}: in=${mod.utf8ByteLength(t)} out=${mod.utf8ByteLength(r)}`);
+      }
+    });
+  });
+});

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -118,12 +118,12 @@ describe('api/mcp.ts — PRO MCP Server', () => {
 
   // --- tools/list ---
 
-  it('tools/list returns 38 tools with name, description, inputSchema', async () => {
+  it('tools/list returns 39 tools with name, description, inputSchema', async () => {
     const res = await handler(makeReq('POST', { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }));
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.ok(Array.isArray(body.result?.tools), 'result.tools must be an array');
-    assert.equal(body.result.tools.length, 38, `Expected 38 tools, got ${body.result.tools.length}`);
+    assert.equal(body.result.tools.length, 39, `Expected 39 tools, got ${body.result.tools.length}`);
     for (const tool of body.result.tools) {
       assert.ok(tool.name, 'tool.name must be present');
       assert.ok(tool.description, 'tool.description must be present');
@@ -141,6 +141,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.ok(toolNames.includes('get_consumer_prices'), 'get_consumer_prices must be registered (U4)');
     assert.ok(toolNames.includes('get_tariff_trends'), 'get_tariff_trends must be registered (U5)');
     assert.ok(toolNames.includes('get_chokepoint_status'), 'get_chokepoint_status must be registered (U6)');
+    assert.ok(toolNames.includes('describe_tool'), 'describe_tool must be registered (v1.5.0 schema compression)');
   });
 
   // --- tools/call ---

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -2086,6 +2086,20 @@ describe('api/mcp.ts — U7 Pro-path', () => {
     assert.equal(pipe.count, 1, 'cache-only tool incremented quota');
   });
 
+  it('v1.5.0: describe_tool for Pro user is EXEMPT from the INCR/DECR daily-quota path (metadata-only)', async () => {
+    const { deps, pipe } = makeProDeps();
+    process.env.UPSTASH_REDIS_REST_URL = 'https://stub.upstash';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'stub';
+    globalThis.fetch = async () => new Response(JSON.stringify({ result: JSON.stringify({ ok: 1 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    // describe_tool is the v1.5.0 metadata escape hatch. SERVER_INSTRUCTIONS
+    // actively encourages calling it while choosing tools, so it must NOT
+    // consume daily quota — otherwise a Pro user at the 50/day cap can't
+    // even fetch tool definitions. Rate limit (60/min) still applies.
+    const res = await mcpHandler(proReq('POST', callBody('describe_tool', { tool_name: 'get_market_data' })), deps);
+    assert.equal(res.status, 200);
+    assert.equal(pipe.count, 0, 'describe_tool MUST NOT increment the Pro daily quota');
+  });
+
   it('integration: signed header for /api/news/v1/list-feed-digest cannot be replayed against /api/intelligence/v1/deduct-situation', async () => {
     const { signInternalMcpRequest, hmacSha256Base64Url, canonicalQueryString, sha256Hex, buildHmacPayload } = await import(`../server/_shared/mcp-internal-hmac.ts?t=${Date.now()}`);
     // Sign for digest endpoint.


### PR DESCRIPTION
## Summary

Cut per-session **input** tokens by compressing top-level tool descriptions in `tools/list` while keeping full text reachable on demand via a new `describe_tool` RPC. Companion to PR #3749 (which cut per-call **output** tokens via JMESPath); together the two surface both halves of HasMCP's "lightning-fast, token-efficient" pitch.

## A/B byte savings — measured (self-contained, reproducible)

| Slice | v1.4.0 (uncompressed) | v1.5.0 (compressed) | Reduction |
|---|---:|---:|---:|
| **Total `tools/list` envelope** | 40.9 KB | 36.8 KB | **9.86%** |
| Tool descriptions (38 / 39) | 7.8 KB | 3.4 KB | 56% |

Run `npx tsx scripts/measure-tools-list-compression.mjs` to reproduce — same source → byte-identical numbers (no captured fixture).

## How it works

- **Single shared `buildPublicTool(tool, { compressDescriptions })` helper** — used by both `tools/list` and `describe_tool`. The two surfaces can never drift.
- `tools/list` calls it with `compressDescriptions: true` → first-sentence or 120-byte UTF-8 truncation per tool description.
- `describe_tool({tool_name})` calls it with `compressDescriptions: false` → full uncompressed definition. Same shape as a `tools/list` entry.
- **`structuredClone` everywhere** — both property schemas AND injected `SUMMARY_SCHEMA`/`JMESPATH_SCHEMA`. No shared-reference mutation footgun (Codex Round 2 catch — would have corrupted module-level consts otherwise).
- `_*`-prefixed internal fields (`_apiPaths`, `_cacheKeys`, `_postFilter`, `_execute`) NEVER enumerated. R9-tested via recursive-scan.

## Scope boundaries (intentional)

- **Property descriptions NOT compressed in v1.5.0.** Audit found 53% of them encode contract details (`default`, `optional`, `currently supported`, `e.g.`, `case-insensitive`, `required when`). Naive compression would regress PR #3749's `cabin_class (optional, default economy)` fix among others. Deferred to a follow-up with keyword-skip allowlist + abbreviation-aware regex.

## Codex 4-round adversarial review

The plan was reviewed by Codex (gpt-5.4) over 4 rounds before push. Findings caught included: registry mutation via shallow clone (P1 R1), describe_tool drift from raw registry reads (P1 R1), property compression too aggressive on contract-bearing text (P1 R1), tool count drift in tests/server-card (P2 R1), UTF-8 assertion + internal-leak coverage gaps (P2 R1), nested `items.enum` arrays would slip through `{...prop}` shallow clone (P1 R2), and the fallback "raise cap" went backwards (P2 R3). Verdict: APPROVED on Round 4.

## Test plan

- [x] `npm run typecheck` + `typecheck:api` — clean
- [x] `npm run lint` on changed files — 0 errors / 0 warnings
- [x] `npm run lint:md` — 0 errors
- [x] `npm run test:data` — **9016/9016 pass**
- [x] `node --test tests/edge-functions.test.mjs` — passes
- [x] `npm run version:check` — 2.8.0 across package.json / tauri.conf.json / Cargo.toml
- [x] `tests/mcp-tools-list-compression.test.mjs` — **33/33 pass** (10 helper + 9 buildPublicTool R5/R9 mutation + 10 dispatch/describe_tool + 4 version-bump + 1 R1 reduction assertion)
- [x] Baseline `tests/mcp.test.mjs` — 90/90 still pass (bumped hardcoded 38 → 39 + added describe_tool to includes-assertions)
- [x] `tests/mcp-jmespath.test.mjs` — 37/37 still pass (bumped 3× hardcoded 1.4.0 → 1.5.0 version assertions)
- [x] `tests/mcp-schema-default-parity.test.mjs` — 6/6 still pass
- [x] `scripts/measure-tools-list-compression.mjs` — exits 0 with reduction 9.86% (above R1 ≥8%)
- [x] Manual: `describe_tool({tool_name: 'get_market_data'})` returns longer description than the corresponding `tools/list` entry
- [x] Manual: `describe_tool({tool_name: 'nonexistent'})` returns `{error: 'unknown_tool', available: [<39 names sorted>]}` inside the normal `content[0].text` envelope
- [ ] Post-deploy smoke: one `tools/list` call should show compressed descriptions; one `describe_tool({tool_name: 'get_market_data'})` should round-trip to the full description

## Follow-ups (out of scope here)

- Property-description compression with keyword-skip allowlist + abbreviation-aware sentence-split regex (audit estimates ~3 KB additional savings on top of v1.5.0's ~4 KB).
- `tools/list` ETag / `If-None-Match` support → `304 Not Modified` on unchanged catalogs.
- Per-client capability negotiation if a real client breaks on the compressed shape.

Plan: `docs/plans/2026-05-18-001-feat-mcp-tools-list-schema-compression-plan.md` (gitignored).