### PR TITLE
chore(readme): remove GitHub forks badge from header

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 **Real-time global intelligence dashboard** — AI-powered news aggregation, geopolitical monitoring, and infrastructure tracking in a unified situational awareness interface.
 
 [![GitHub stars](https://img.shields.io/github/stars/koala73/worldmonitor?style=social)](https://github.com/koala73/worldmonitor/stargazers)
-[![GitHub forks](https://img.shields.io/github/forks/koala73/worldmonitor?style=social)](https://github.com/koala73/worldmonitor/network/members)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?style=flat&logo=discord&logoColor=white)](https://discord.gg/re63kWKxaz)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 [![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?style=flat&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)


### PR DESCRIPTION
## Summary

- Remove the `shields.io/github/forks` badge from the README header.
- Keep the stars badge and the rest of the header unchanged.

## Why

Issue #3741 documents a fork-graph pattern (≈99.9% issues-disabled forks, multiple 400–600 forks/day bursts in Feb–Mar 2026) consistent with external engagement-farming activity targeting this repo. Whatever the cause, the fork count is no longer a number worth presenting as a social-proof / adoption signal in our own README.

This change implements the issue's recommendation #3 ("Avoid presenting fork count as a trust or adoption signal until the pattern is understood") with the minimum possible surface area — one badge removed, nothing else touched.

## Test plan

- [x] `markdownlint-cli2 README.md` → 0 errors
- [x] Visually confirm the badge row still renders cleanly (stars · Discord · License · TypeScript · Last commit · Latest release)
- [x] `git diff` is a single-line deletion

Refs: #3741