### PR TITLE
fix(seed-fire-detections): exit non-zero when NASA_FIRMS_API_KEY missing (#3766)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -161,6 +161,7 @@ CLOUDFLARE_R2_TRACE_PREFIX=seed-data/forecast-traces
 
 # NASA FIRMS (Fire Information for Resource Management System)
 # Register at: https://firms.modaps.eosdis.nasa.gov/
+# REQUIRED for scripts/seed-fire-detections.mjs — the seed exits non-zero if unset.
 NASA_FIRMS_API_KEY=
 
 # ------ Climate Disasters Seed (Railway cron) ------

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -49,7 +49,7 @@ services:
       ACLED_ACCESS_TOKEN: ""      # https://acleddata.com (free for researchers)
 
       # 🛰️ Earth Observation
-      NASA_FIRMS_API_KEY: ""      # https://firms.modaps.eosdis.nasa.gov (free)
+      NASA_FIRMS_API_KEY: ""      # REQUIRED for seed-fire-detections.mjs — https://firms.modaps.eosdis.nasa.gov (free)
 
       # ✈️ Aviation
       AVIATIONSTACK_API: ""       # https://aviationstack.com (free tier)

--- a/scripts/seed-fire-detections.mjs
+++ b/scripts/seed-fire-detections.mjs
@@ -123,8 +123,8 @@ export function declareRecords(data) {
 async function main() {
   const apiKey = process.env.NASA_FIRMS_API_KEY || process.env.FIRMS_API_KEY || '';
   if (!apiKey) {
-    console.log('NASA_FIRMS_API_KEY not set — skipping fire detections seed');
-    process.exit(0);
+    console.error('[seed-fire-detections] NASA_FIRMS_API_KEY (or FIRMS_API_KEY) is required but not set. Refusing to run.');
+    process.exit(1);
   }
 
   console.log('  FIRMS key configured');


### PR DESCRIPTION
## Summary

Closes #3766.

Proposed fix — please review before merging.

### Root cause
`scripts/seed-fire-detections.mjs` previously did this when the API key was unset:

```js
const apiKey = process.env.NASA_FIRMS_API_KEY || process.env.FIRMS_API_KEY || '';
if (!apiKey) {
  console.log('NASA_FIRMS_API_KEY not set — skipping fire detections seed');
  process.exit(0);
}
```

`exit 0` plus stdout means cron, Docker healthchecks, and CI all see the run as a success, so a missing API key silently drains the wildfire panel without any alarm firing.

### Fix
- `process.exit(0)` -> `process.exit(1)` so any orchestrator (cron, Docker `HEALTHCHECK`, CI) registers the failure.
- `console.log(...)` -> `console.error(...)` so the message goes to stderr.
- Message is now explicit and namespaced: `[seed-fire-detections] NASA_FIRMS_API_KEY (or FIRMS_API_KEY) is required but not set. Refusing to run.`
- `.env.example` annotates `NASA_FIRMS_API_KEY` as REQUIRED for this seed.
- `SELF_HOSTING.md` (docker-compose example) marks the var REQUIRED for the seeder.

### Manual verification

```
$ env -i PATH="$PATH" HOME=/tmp/nohome node scripts/seed-fire-detections.mjs 2>/tmp/err 1>/tmp/out; echo exit=$?
exit=1
$ cat /tmp/err
[seed-fire-detections] NASA_FIRMS_API_KEY (or FIRMS_API_KEY) is required but not set. Refusing to run.
$ cat /tmp/out
(empty)
```

### Not done in this PR (intentional)
- **Healthcheck wiring.** `api/health.js` has a `SEED_META` map but no existing per-seed `requiredEnv` pattern. Adding one cleanly would require a new abstraction; per repo convention I left it as a follow-up rather than invent a pattern. The non-zero exit alone already covers cron/Docker/CI signal — startup healthcheck for env presence is the belt-and-braces extra.
- **Other seed scripts with the same pattern.** A quick `grep` shows several others log-and-`exit 0` (or just `return`) when their API keys are missing — e.g. `seed-webcams.mjs` (WINDY_API_KEY), `seed-internet-outages.mjs` (CLOUDFLARE_API_TOKEN), `seed-earnings-calendar.mjs` (FINNHUB_API_KEY), `seed-electricity-prices.mjs` (ENTSO_E_TOKEN / EIA_API_KEY), `seed-climate-news.mjs` (RELIEFWEB_APPNAME). Each needs its own judgment call on whether the key is truly required or genuinely optional — out of scope for #3766.

## Test plan
- [x] Manual: run with no env, confirm `exit=1` and message on stderr.
- [ ] CI / cron run with key absent should now fail loudly (left for reviewer to confirm in the deployed pipeline).