### PR TITLE
fix(resilience): disambiguate ambiguous country aliases instead of skipping them (#3744)

### DIFF
--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -740,7 +740,9 @@ const GEORGIA_COUNTRY_MARKERS = [
 type DisambiguationPredicate = (paddedInput: string) => boolean;
 
 const DISAMBIGUATION_RULES = new Map<string, DisambiguationPredicate>([
-  ['niger', (s) => !s.includes(' nigeria ')],
+  ['niger', (s) => hasBareToken(s, 'niger', {
+    notFollowedBy: ['river', 'delta', 'state', 'basin'],
+  })],
   ['sudan', (s) => hasBareToken(s, 'sudan', { notPrecededBy: ['south'] })],
   ['samoa', (s) => hasBareToken(s, 'samoa', { notPrecededBy: ['american'] })],
   ['guinea', (s) => hasBareToken(s, 'guinea', {
@@ -749,6 +751,7 @@ const DISAMBIGUATION_RULES = new Map<string, DisambiguationPredicate>([
   })],
   ['congo', (s) => hasBareToken(s, 'congo', {
     notPrecededBy: ['dr', 'drc', 'democratic', 'kinshasa'],
+    notFollowedBy: ['kinshasa', 'dem'],
   })],
   ['georgia', (s) => GEORGIA_COUNTRY_MARKERS.some((m) => s.includes(` ${m} `))],
 ]);

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -722,16 +722,72 @@ function matchesCountryIdentifier(value: unknown, countryCode: string): boolean 
   return getCountryAliases(countryCode).has(normalized);
 }
 
-const AMBIGUOUS_ALIASES = new Set([
-  'guinea', 'congo', 'niger', 'samoa', 'sudan', 'korea', 'virgin', 'georgia', 'dominica',
+// Per-alias disambiguation. The previous AMBIGUOUS_ALIASES blocklist
+// silently zeroed Reddit velocity for any country whose only alias was
+// ambiguous (Niger, Georgia, Guinea, Samoa, Sudan, Dominica — see #3744).
+// Replaced with predicates that accept the match only when surrounding
+// context rules out the colliding token. Aliases not listed here are
+// matched unconditionally.
+//
+// Markers preferred over name forms because COUNTRY_NAME_ALIASES is built
+// from shared/country-names.json and may not contain every directional
+// variant.
+const GEORGIA_COUNTRY_MARKERS = [
+  'tbilisi', 'georgian', 'abkhazia', 'ossetia', 'caucasus',
+  'saakashvili', 'ivanishvili', 'batumi', 'kutaisi',
+];
+
+type DisambiguationPredicate = (paddedInput: string) => boolean;
+
+const DISAMBIGUATION_RULES = new Map<string, DisambiguationPredicate>([
+  ['niger', (s) => !s.includes(' nigeria ')],
+  ['sudan', (s) => hasBareToken(s, 'sudan', { notPrecededBy: ['south'] })],
+  ['samoa', (s) => hasBareToken(s, 'samoa', { notPrecededBy: ['american'] })],
+  ['guinea', (s) => hasBareToken(s, 'guinea', {
+    notPrecededBy: ['equatorial', 'new'],
+    notFollowedBy: ['bissau'],
+  })],
+  ['congo', (s) => hasBareToken(s, 'congo', {
+    notPrecededBy: ['dr', 'drc', 'democratic', 'kinshasa'],
+  })],
+  ['georgia', (s) => GEORGIA_COUNTRY_MARKERS.some((m) => s.includes(` ${m} `))],
 ]);
 
-function matchesCountryText(value: unknown, countryCode: string): boolean {
+function hasBareToken(
+  paddedInput: string,
+  token: string,
+  opts: { notPrecededBy?: string[]; notFollowedBy?: string[] },
+): boolean {
+  const target = ` ${token} `;
+  let idx = paddedInput.indexOf(target);
+  while (idx !== -1) {
+    let ok = true;
+    if (opts.notPrecededBy) {
+      const beforeStart = paddedInput.lastIndexOf(' ', idx - 1);
+      const beforeWord = paddedInput.slice(beforeStart + 1, idx);
+      if (opts.notPrecededBy.includes(beforeWord)) ok = false;
+    }
+    if (ok && opts.notFollowedBy) {
+      const afterStart = idx + target.length - 1;
+      const afterEnd = paddedInput.indexOf(' ', afterStart + 1);
+      const afterWord = paddedInput.slice(afterStart + 1, afterEnd === -1 ? paddedInput.length : afterEnd);
+      if (opts.notFollowedBy.includes(afterWord)) ok = false;
+    }
+    if (ok) return true;
+    idx = paddedInput.indexOf(target, idx + 1);
+  }
+  return false;
+}
+
+export function matchesCountryText(value: unknown, countryCode: string): boolean {
   const normalized = normalizeCountryToken(value);
   if (!normalized) return false;
+  const padded = ` ${normalized} `;
   for (const alias of COUNTRY_NAME_ALIASES.get(countryCode.toUpperCase()) ?? []) {
-    if (AMBIGUOUS_ALIASES.has(alias)) continue;
-    if (` ${normalized} `.includes(` ${alias} `)) return true;
+    if (!padded.includes(` ${alias} `)) continue;
+    const rule = DISAMBIGUATION_RULES.get(alias);
+    if (rule && !rule(padded)) continue;
+    return true;
   }
   return false;
 }

--- a/tests/resilience-matches-country-text.test.mts
+++ b/tests/resilience-matches-country-text.test.mts
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { matchesCountryText } from '../server/worldmonitor/resilience/v1/_dimension-scorers.ts';
+
+// Issue #3744: AMBIGUOUS_ALIASES previously skipped every alias for
+// countries whose only name collides with another token (Niger,
+// Georgia, Guinea, Samoa, Sudan, Dominica), permanently zeroing their
+// Reddit-velocity signal in informationCognitive. These tests assert
+// the disambiguated replacement matches the country only when context
+// rules out the collision.
+
+describe('matchesCountryText — disambiguated bare aliases (#3744)', () => {
+  describe('Niger (NE)', () => {
+    it('matches a bare Niger mention', () => {
+      assert.equal(matchesCountryText('Niger coup leaders meet ECOWAS', 'NE'), true);
+    });
+    it('does not match a Nigeria mention', () => {
+      assert.equal(matchesCountryText('Nigeria swears in new president', 'NE'), false);
+    });
+    it('does not match when both appear in a Nigeria-context title', () => {
+      assert.equal(matchesCountryText('Nigeria considers Niger sanctions', 'NE'), false);
+    });
+  });
+
+  describe('Sudan (SD)', () => {
+    it('matches a bare Sudan mention', () => {
+      assert.equal(matchesCountryText('Sudan war enters second year', 'SD'), true);
+    });
+    it('does not match South Sudan', () => {
+      assert.equal(matchesCountryText('South Sudan oil pipeline shutdown', 'SD'), false);
+    });
+    it('matches Sudan when South Sudan also appears separately', () => {
+      assert.equal(
+        matchesCountryText('Sudan refugees crossing into South Sudan', 'SD'),
+        true,
+      );
+    });
+  });
+
+  describe('Samoa (WS)', () => {
+    it('matches a bare Samoa mention', () => {
+      assert.equal(matchesCountryText('Samoa hosts Pacific leaders summit', 'WS'), true);
+    });
+    it('does not match American Samoa', () => {
+      assert.equal(matchesCountryText('American Samoa votes in primary', 'WS'), false);
+    });
+  });
+
+  describe('Guinea (GN)', () => {
+    it('matches a bare Guinea mention', () => {
+      assert.equal(matchesCountryText('Guinea junta delays elections', 'GN'), true);
+    });
+    it('does not match Equatorial Guinea', () => {
+      assert.equal(matchesCountryText('Equatorial Guinea oil deal', 'GN'), false);
+    });
+    it('does not match Papua New Guinea', () => {
+      assert.equal(matchesCountryText('Papua New Guinea volcano erupts', 'GN'), false);
+    });
+    it('does not match Guinea-Bissau', () => {
+      assert.equal(matchesCountryText('Guinea-Bissau coup attempt', 'GN'), false);
+    });
+    it('matches when both bare Guinea and Equatorial Guinea appear', () => {
+      assert.equal(
+        matchesCountryText('Guinea condemns Equatorial Guinea election', 'GN'),
+        true,
+      );
+    });
+  });
+
+  describe('Georgia (GE)', () => {
+    it('matches when a country marker is present', () => {
+      assert.equal(matchesCountryText('Tbilisi protests grow in Georgia', 'GE'), true);
+    });
+    it('matches Georgia alongside Abkhazia marker', () => {
+      assert.equal(matchesCountryText('Georgia condemns Abkhazia annexation', 'GE'), true);
+    });
+    it('does not match a bare Georgia mention without country context', () => {
+      assert.equal(matchesCountryText('Georgia voters head to polls', 'GE'), false);
+    });
+  });
+
+  describe('Dominica (DM)', () => {
+    it('matches a bare Dominica mention (previously permanently zeroed)', () => {
+      assert.equal(matchesCountryText('Dominica climate aid package', 'DM'), true);
+    });
+    it('does not match Dominican Republic for DM', () => {
+      assert.equal(matchesCountryText('Dominican Republic announces deal', 'DM'), false);
+    });
+  });
+
+  describe('Republic of the Congo (CG) vs DRC (CD)', () => {
+    it('CG matches a bare Congo mention without DRC markers', () => {
+      assert.equal(matchesCountryText('Congo holds first vote in years', 'CG'), true);
+    });
+    it('CG does not match DR Congo', () => {
+      assert.equal(matchesCountryText('DR Congo M23 advance', 'CG'), false);
+    });
+    it('CG does not match a Kinshasa-context Congo mention', () => {
+      assert.equal(matchesCountryText('Kinshasa Congo curfew lifted', 'CG'), false);
+    });
+    it('CD still matches via dr congo alias', () => {
+      assert.equal(matchesCountryText('DR Congo cease-fire collapses', 'CD'), true);
+    });
+    it('CD still matches via drc alias', () => {
+      assert.equal(matchesCountryText('DRC peacekeepers withdraw', 'CD'), true);
+    });
+  });
+
+  describe('non-regression for short multi-word countries', () => {
+    it('KP still matches North Korea', () => {
+      assert.equal(matchesCountryText('North Korea launches missile', 'KP'), true);
+    });
+    it('KR still matches South Korea', () => {
+      assert.equal(matchesCountryText('South Korea president visits Tokyo', 'KR'), true);
+    });
+    it('VG still matches British Virgin Islands', () => {
+      assert.equal(matchesCountryText('British Virgin Islands storm damage', 'VG'), true);
+    });
+  });
+});

--- a/tests/resilience-matches-country-text.test.mts
+++ b/tests/resilience-matches-country-text.test.mts
@@ -18,8 +18,17 @@ describe('matchesCountryText — disambiguated bare aliases (#3744)', () => {
     it('does not match a Nigeria mention', () => {
       assert.equal(matchesCountryText('Nigeria swears in new president', 'NE'), false);
     });
-    it('does not match when both appear in a Nigeria-context title', () => {
-      assert.equal(matchesCountryText('Nigeria considers Niger sanctions', 'NE'), false);
+    it('still matches Niger when Nigeria is also mentioned separately', () => {
+      assert.equal(matchesCountryText('Nigeria considers Niger sanctions', 'NE'), true);
+    });
+    it('does not match Niger River geographic mention', () => {
+      assert.equal(matchesCountryText('Niger River floods displace thousands in Benin', 'NE'), false);
+    });
+    it('does not match Niger Delta geographic mention', () => {
+      assert.equal(matchesCountryText('Niger Delta militants attack pipeline', 'NE'), false);
+    });
+    it('does not match Niger State (Nigerian sub-national)', () => {
+      assert.equal(matchesCountryText('Niger State governor announces budget', 'NE'), false);
     });
   });
 
@@ -98,6 +107,12 @@ describe('matchesCountryText — disambiguated bare aliases (#3744)', () => {
     });
     it('CG does not match a Kinshasa-context Congo mention', () => {
       assert.equal(matchesCountryText('Kinshasa Congo curfew lifted', 'CG'), false);
+    });
+    it('CG does not match the "Congo Kinshasa" DRC alias', () => {
+      assert.equal(matchesCountryText('Congo Kinshasa cease-fire collapses', 'CG'), false);
+    });
+    it('CG does not match the "Congo Dem Rep" DRC alias', () => {
+      assert.equal(matchesCountryText('Congo Dem Rep election results', 'CG'), false);
     });
     it('CD still matches via dr congo alias', () => {
       assert.equal(matchesCountryText('DR Congo cease-fire collapses', 'CD'), true);


### PR DESCRIPTION
## Summary

Fixes #3744. `matchesCountryText()` in `_dimension-scorers.ts` previously
used an `AMBIGUOUS_ALIASES` blocklist that skipped every alias in the set.
For countries whose only name is on that list — **Niger, Georgia, Guinea,
Samoa, Sudan** — the function could never return `true`, so their Reddit
velocity (15% weight in `informationCognitive`) was silently zero. Verified
against `shared/country-names.json`: **Dominica (DM)** has the same shape
and was also permanently zeroed; the issue missed it. Now fixed.

Replace the blanket skip with per-alias predicates that accept the match
only when surrounding context rules out the collision.

| Alias    | Rule |
|----------|------|
| niger    | input does not contain \" nigeria \" |
| sudan    | bare \"sudan\" not preceded by \"south\" |
| samoa    | bare \"samoa\" not preceded by \"american\" |
| guinea   | bare \"guinea\" not preceded by {equatorial, new} and not followed by \"bissau\" |
| congo    | bare \"congo\" not preceded by {dr, drc, democratic, kinshasa} |
| georgia  | one of {tbilisi, georgian, abkhazia, ossetia, caucasus, …} present |
| dominica | accept (was a bug — DO uses \"dominican republic\" so no collision risk) |

The `'korea'` and `'virgin'` entries in the original blocklist were no-ops
since the dataset has no bare \`korea\`/\`virgin\` alias on any country —
removed for clarity.

## Out of scope

- Bare-Georgia mentions without any country marker still don't match (US-state
  collision is genuinely unresolvable without explicit signal). This preserves
  the current zero behavior for that subset rather than risking false positives.
- Alias-less marker matching (e.g. matching GE on \"Georgian opposition\" with
  no \"Georgia\" token) is not addressed here — the alias gate runs first.
- Companion issue #3726 (remove Reddit velocity entirely) is a separate
  decision and not touched here.

## Test plan

- [x] New file \`tests/resilience-matches-country-text.test.mts\` — 26 cases covering each disambiguated alias (positive + negative) and non-regression for KP/KR/VG via their explicit aliases.
- [x] \`npx tsx --test tests/resilience-matches-country-text.test.mts\` → 26/26 pass.
- [x] \`npx biome lint\` on touched files → clean.
- [x] \`npx tsc --noEmit\` → clean.