### PR TITLE
fix(progress-panel): disclose fallback when hardcoded series rendered (#3758)

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -3306,8 +3306,8 @@ export class DataLoaderManager implements AppModule {
   }
 
   private async loadProgressData(): Promise<void> {
-    const datasets = await fetchProgressData();
-    this.callPanel('progress', 'setData', datasets);
+    const result = await fetchProgressData();
+    this.callPanel('progress', 'setData', result);
   }
 
   private async loadSpeciesData(): Promise<void> {

--- a/src/components/ProgressChartsPanel.ts
+++ b/src/components/ProgressChartsPanel.ts
@@ -89,7 +89,7 @@ export class ProgressChartsPanel extends Panel {
       fontSize: '11px',
       color: 'var(--text-dim)',
       background: 'var(--bg-subtle, rgba(255,255,255,0.04))',
-      border: '1px solid var(--border-subtle)',
+      border: '1px solid var(--border-subtle, rgba(255,255,255,0.12))',
       borderRadius: '4px',
     });
     banner.textContent = t('components.progressCharts.fallbackBadge');

--- a/src/components/ProgressChartsPanel.ts
+++ b/src/components/ProgressChartsPanel.ts
@@ -9,7 +9,12 @@
 
 import { Panel } from './Panel';
 import * as d3 from 'd3';
-import { type ProgressDataSet, type ProgressDataPoint } from '@/services/progress-data';
+import {
+  type ProgressDataSet,
+  type ProgressDataPoint,
+  type ProgressDataResult,
+  type ProgressDataSource,
+} from '@/services/progress-data';
 import { getCSSColor } from '@/utils';
 import { replaceChildren } from '@/utils/dom-utils';
 import { escapeHtml } from '@/utils/sanitize';
@@ -21,6 +26,7 @@ const RESIZE_DEBOUNCE_MS = 200;
 
 export class ProgressChartsPanel extends Panel {
   private datasets: ProgressDataSet[] = [];
+  private source: ProgressDataSource = 'hydrated';
   private resizeObserver: ResizeObserver | null = null;
   private resizeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
   private tooltip: HTMLDivElement | null = null;
@@ -31,10 +37,17 @@ export class ProgressChartsPanel extends Panel {
   }
 
   /**
-   * Set chart data and render all 4 area charts.
+   * Set chart data and render all 4 area charts. Accepts either a
+   * `ProgressDataResult` (preferred — carries a source tag so the panel
+   * can disclose fallback state per #3758) or a raw `ProgressDataSet[]`
+   * for backward compatibility with callers that haven't been updated.
    */
-  public setData(datasets: ProgressDataSet[]): void {
+  public setData(input: ProgressDataResult | ProgressDataSet[]): void {
+    const { datasets, source } = Array.isArray(input)
+      ? { datasets: input, source: 'hydrated' as ProgressDataSource }
+      : input;
     this.datasets = datasets;
+    this.source = source;
 
     // Clear existing content
     replaceChildren(this.content);
@@ -46,6 +59,12 @@ export class ProgressChartsPanel extends Panel {
       return;
     }
 
+    // Disclose hardcoded-fallback state before the charts so the user
+    // does not mistake a degraded panel for live data (#3758).
+    if (source === 'fallback') {
+      this.renderFallbackBanner();
+    }
+
     // Create tooltip once (shared by all charts)
     this.createTooltip();
 
@@ -53,6 +72,28 @@ export class ProgressChartsPanel extends Panel {
     for (const dataset of valid) {
       this.renderChart(dataset);
     }
+  }
+
+  private renderFallbackBanner(): void {
+    const banner = document.createElement('div');
+    banner.className = 'progress-charts-fallback-banner';
+    banner.setAttribute('role', 'status');
+    banner.setAttribute('data-source', 'fallback');
+    banner.title = t('components.progressCharts.fallbackTooltip');
+    Object.assign(banner.style, {
+      display: 'flex',
+      alignItems: 'center',
+      gap: '6px',
+      margin: '0 0 8px 0',
+      padding: '6px 8px',
+      fontSize: '11px',
+      color: 'var(--text-dim)',
+      background: 'var(--bg-subtle, rgba(255,255,255,0.04))',
+      border: '1px solid var(--border-subtle)',
+      borderRadius: '4px',
+    });
+    banner.textContent = t('components.progressCharts.fallbackBadge');
+    this.content.appendChild(banner);
   }
 
   /**
@@ -333,7 +374,7 @@ export class ProgressChartsPanel extends Panel {
         clearTimeout(this.resizeDebounceTimer);
       }
       this.resizeDebounceTimer = setTimeout(() => {
-        this.setData(this.datasets);
+        this.setData({ datasets: this.datasets, source: this.source });
       }, RESIZE_DEBOUNCE_MS);
     });
     this.resizeObserver.observe(this.content);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -847,7 +847,9 @@
       "summarizing": "Summarizing…"
     },
     "progressCharts": {
-      "noData": "No progress data available"
+      "noData": "No progress data available",
+      "fallbackBadge": "Showing static fallback data — live series unavailable",
+      "fallbackTooltip": "The live World Bank seed could not be reached. These charts are rendered from a hardcoded snapshot last verified Feb 2026."
     },
     "monitor": {
       "placeholder": "Keywords (comma separated)",

--- a/src/services/progress-data.ts
+++ b/src/services/progress-data.ts
@@ -6,7 +6,7 @@
  * from bootstrap/Redis. Never calls WB API from the frontend.
  */
 
-import { createCircuitBreaker } from '@/utils';
+import { createCircuitBreaker } from '@/utils/circuit-breaker';
 import { getHydratedData } from '@/services/bootstrap';
 import { toApiUrl } from '@/services/runtime';
 
@@ -33,6 +33,21 @@ export interface ProgressDataSet {
   latestValue: number;
   oldestValue: number;
   changePercent: number; // Positive = improvement (accounts for invertTrend)
+}
+
+/**
+ * Where the rendered series came from. The UI surfaces a disclosure
+ * badge when `source === 'fallback'` so a degraded panel does not look
+ * like live truth (see issue #3758).
+ *   hydrated  -- bootstrap hydration cache (first page load)
+ *   bootstrap -- live fetch from /api/bootstrap
+ *   fallback  -- hardcoded FALLBACK_DATA (no fresh data available)
+ */
+export type ProgressDataSource = 'hydrated' | 'bootstrap' | 'fallback';
+
+export interface ProgressDataResult {
+  datasets: ProgressDataSet[];
+  source: ProgressDataSource;
 }
 
 // ---- Indicator Definitions ----
@@ -87,11 +102,18 @@ export const PROGRESS_INDICATORS: ProgressIndicator[] = [
 
 // ---- Circuit Breaker (persistent cache for instant reload) ----
 
-const breaker = createCircuitBreaker<ProgressDataSet[]>({
+const breaker = createCircuitBreaker<ProgressDataResult>({
   name: 'Progress Data',
   cacheTtlMs: 60 * 60 * 1000, // 1h — World Bank data changes yearly
   persistCache: true,
 });
+
+function fallbackResult(): ProgressDataResult {
+  return {
+    datasets: PROGRESS_INDICATORS.map(fallbackDataSet),
+    source: 'fallback',
+  };
+}
 
 // ---- Seed data shape (from seed-wb-indicators.mjs) ----
 
@@ -137,10 +159,12 @@ function resolveFromSeeds(seedMap: Map<string, SeedProgressIndicator>): Progress
   });
 }
 
-async function fetchProgressDataFresh(): Promise<ProgressDataSet[]> {
+export async function fetchProgressDataFresh(): Promise<ProgressDataResult> {
   // 1. Try bootstrap hydration cache (first page load)
   const hydrated = getHydratedData('progressData') as SeedProgressIndicator[] | undefined;
-  if (hydrated?.length) return resolveFromSeeds(buildSeedMap(hydrated));
+  if (hydrated?.length) {
+    return { datasets: resolveFromSeeds(buildSeedMap(hydrated)), source: 'hydrated' };
+  }
 
   // 2. Fallback: fetch from bootstrap endpoint directly
   try {
@@ -149,22 +173,24 @@ async function fetchProgressDataFresh(): Promise<ProgressDataSet[]> {
     });
     if (resp.ok) {
       const { data } = (await resp.json()) as { data: { progressData?: SeedProgressIndicator[] } };
-      if (data.progressData?.length) return resolveFromSeeds(buildSeedMap(data.progressData));
+      if (data.progressData?.length) {
+        return { datasets: resolveFromSeeds(buildSeedMap(data.progressData)), source: 'bootstrap' };
+      }
     }
   } catch { /* fall through to fallback */ }
 
-  // 3. Static fallback
-  return PROGRESS_INDICATORS.map(fallbackDataSet);
+  // 3. Static fallback — UI must show a disclosure badge (#3758)
+  return fallbackResult();
 }
 
 /**
  * Fetch progress data with persistent caching.
  * Returns instantly from IndexedDB cache on subsequent loads.
  */
-export async function fetchProgressData(): Promise<ProgressDataSet[]> {
+export async function fetchProgressData(): Promise<ProgressDataResult> {
   return breaker.execute(
     () => fetchProgressDataFresh(),
-    PROGRESS_INDICATORS.map(fallbackDataSet),
+    fallbackResult(),
   );
 }
 

--- a/src/services/progress-data.ts
+++ b/src/services/progress-data.ts
@@ -191,6 +191,11 @@ export async function fetchProgressData(): Promise<ProgressDataResult> {
   return breaker.execute(
     () => fetchProgressDataFresh(),
     fallbackResult(),
+    // Never persist the static fallback — fetchProgressDataFresh swallows
+    // errors and returns a fallback result, which the breaker would otherwise
+    // cache to IndexedDB for the 1h TTL and keep showing the disclosure
+    // banner long after the network recovers.
+    { shouldCache: (result) => result.source !== 'fallback' },
   );
 }
 

--- a/tests/progress-data-fallback-disclosure.test.mts
+++ b/tests/progress-data-fallback-disclosure.test.mts
@@ -1,0 +1,105 @@
+/**
+ * Regression for #3758: Human Progress panel silently fell back to
+ * hardcoded World Bank series with no signal to the UI. The fix is for
+ * the service to tag every result with a `source` so the panel can
+ * disclose degraded state. These tests exercise the two non-hydrated
+ * code paths -- successful bootstrap fetch and total fetch failure --
+ * and assert that the tag is correct.
+ *
+ * The hydrated path is not covered here because the hydration cache is
+ * a module-level Map populated only by `fetchBootstrapData()` (which
+ * hits the network); manual / e2e verification covers it.
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  fetchProgressDataFresh,
+  PROGRESS_INDICATORS,
+} from '../src/services/progress-data.ts';
+
+type FetchFn = typeof fetch;
+const originalFetch: FetchFn | undefined = globalThis.fetch;
+
+function buildSeedPayload() {
+  // Matches the shape produced by seed-wb-indicators.mjs: id + code +
+  // ordered ProgressDataPoint[] + invertTrend.
+  return PROGRESS_INDICATORS.map(ind => ({
+    id: ind.id,
+    code: ind.code,
+    invertTrend: ind.invertTrend,
+    data: [
+      { year: 2000, value: 10 },
+      { year: 2010, value: 20 },
+      { year: 2020, value: 30 },
+    ],
+  }));
+}
+
+describe('fetchProgressDataFresh — fallback disclosure (#3758)', () => {
+  beforeEach(() => {
+    // Reset to a known state before each scenario; individual tests
+    // install their own stub.
+    if (originalFetch) globalThis.fetch = originalFetch;
+  });
+
+  afterEach(() => {
+    if (originalFetch) globalThis.fetch = originalFetch;
+  });
+
+  it('tags result as "bootstrap" when /api/bootstrap returns seed data', async () => {
+    const stub: FetchFn = async () =>
+      new Response(JSON.stringify({ data: { progressData: buildSeedPayload() } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    globalThis.fetch = stub;
+
+    const result = await fetchProgressDataFresh();
+    assert.equal(result.source, 'bootstrap', 'source must reflect live bootstrap fetch');
+    assert.equal(result.datasets.length, PROGRESS_INDICATORS.length);
+    // Sanity: data came from the stub (value 30 in 2020), NOT from the
+    // hardcoded FALLBACK_DATA (which has 73.3 for life expectancy 2023).
+    const life = result.datasets.find(d => d.indicator.id === 'lifeExpectancy');
+    assert.ok(life, 'lifeExpectancy dataset missing');
+    assert.equal(life!.latestValue, 30, 'latestValue must come from stubbed seed');
+  });
+
+  it('tags result as "fallback" when bootstrap fetch throws (network down)', async () => {
+    const stub: FetchFn = async () => {
+      throw new Error('simulated network failure');
+    };
+    globalThis.fetch = stub;
+
+    const result = await fetchProgressDataFresh();
+    assert.equal(result.source, 'fallback', 'source must be fallback when fetch throws');
+    assert.equal(result.datasets.length, PROGRESS_INDICATORS.length);
+    // Sanity: data is the hardcoded FALLBACK_DATA snapshot — life
+    // expectancy ends at 73.3 (Feb 2026 verified value).
+    const life = result.datasets.find(d => d.indicator.id === 'lifeExpectancy');
+    assert.ok(life, 'lifeExpectancy dataset missing');
+    assert.equal(life!.latestValue, 73.3, 'latestValue must come from FALLBACK_DATA snapshot');
+  });
+
+  it('tags result as "fallback" when bootstrap returns non-OK status', async () => {
+    const stub: FetchFn = async () =>
+      new Response('upstream error', { status: 503 });
+    globalThis.fetch = stub;
+
+    const result = await fetchProgressDataFresh();
+    assert.equal(result.source, 'fallback');
+  });
+
+  it('tags result as "fallback" when bootstrap returns OK but empty payload', async () => {
+    const stub: FetchFn = async () =>
+      new Response(JSON.stringify({ data: { progressData: [] } }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    globalThis.fetch = stub;
+
+    const result = await fetchProgressDataFresh();
+    assert.equal(result.source, 'fallback', 'empty seed must trigger fallback');
+  });
+});


### PR DESCRIPTION
**Proposed fix — needs human review.** Per the issue body's explicit instruction, I am not claiming this is "fixed" until a human eyeballs the disclosure behaviour in the running app.

Closes #3758

## Root cause

`fetchProgressData()` had three return paths -- hydrated bootstrap cache, live `/api/bootstrap` fetch, hardcoded `FALLBACK_DATA` -- and all three handed the panel an identically-shaped `ProgressDataSet[]`. The fallback path (hit on bootstrap miss + fetch failure, and again as the circuit-breaker open-state default) was indistinguishable from live data at the call site, so `ProgressChartsPanel` rendered a Feb-2026 snapshot looking exactly like fresh truth. No source tag, no freshness signal, no banner.

## Fix

Smallest change that satisfies the acceptance criteria:

1. **`src/services/progress-data.ts`** -- new `ProgressDataResult = { datasets, source }` where `source: 'hydrated' | 'bootstrap' | 'fallback'`. Each branch (hydration cache hit, live fetch success, fetch-throw / non-OK / empty-payload, breaker-open default) returns the appropriate tag. Also exports `fetchProgressDataFresh` so the un-cached logic is unit-testable.
2. **`src/app/data-loader.ts`** -- passes the whole result object to the panel (one-line change).
3. **`src/components/ProgressChartsPanel.ts`** -- `setData` now accepts `ProgressDataResult` (still accepts a bare array for back-compat with any stragglers). When `source === 'fallback'`, a small banner is rendered above the charts: *"Showing static fallback data -- live series unavailable"* with a tooltip explaining the Feb-2026 snapshot. Resize re-renders preserve the source tag.
4. **`src/locales/en.json`** -- two new keys under `components.progressCharts` (`fallbackBadge`, `fallbackTooltip`). Other 19 locales intentionally untouched; the translation pipeline handles those.

## What is NOT in this PR (deliberate)

- No redesign of the panel or the seeding pipeline.
- No change to the `FALLBACK_DATA` snapshot itself.
- No new freshness telemetry for the `hydrated` / `bootstrap` paths -- the issue's containment was specifically about the silent fallback, and over-broadening the disclosure would clutter the panel in the happy path.
- Hydrated-path was not given a unit test because the hydration cache is a module-level `Map` populated only by `fetchBootstrapData()` (which hits the network). Manual / e2e verification covers it.

## Tests

New file: `tests/progress-data-fallback-disclosure.test.mts` (4 cases, all passing).

```
fetchProgressDataFresh -- fallback disclosure (#3758)
  PASS tags result as "bootstrap" when /api/bootstrap returns seed data
  PASS tags result as "fallback" when bootstrap fetch throws (network down)
  PASS tags result as "fallback" when bootstrap returns non-OK status
  PASS tags result as "fallback" when bootstrap returns OK but empty payload
```

`tsc --noEmit` clean. Smoke-ran adjacent suites (`bootstrap.test.mjs`, `checkout-banner-initial-state.test.mts`) -- still green.

## Human review checklist

- [ ] Load the Human Progress panel against a backend with the WB seed missing -- confirm the banner appears.
- [ ] Reload with WB seed present -- confirm no banner, charts unchanged.
- [ ] Confirm the banner copy reads acceptably and the muted-text/subtle-border styling matches the panel's visual language (it uses `var(--bg-subtle)` / `var(--border-subtle)`).
- [ ] Decide whether the `hydrated` vs `bootstrap` distinction is worth surfacing in the UI too, or whether silent-on-happy-path is the right call.