### PR TITLE
fix(gateway): fail closed when CORS header generation throws (#3705)

### DIFF
--- a/server/_shared/usage.ts
+++ b/server/_shared/usage.ts
@@ -70,7 +70,8 @@ export type RequestReason =
   // from auth failures.
   | 'malformed_request'
   | 'unknown_route'
-  | 'method_not_allowed';
+  | 'method_not_allowed'
+  | 'cors_error';
 
 export interface RequestEvent {
   _time: string;

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -13,6 +13,8 @@ import { createRouter, type RouteDescriptor } from './router';
 import { getCorsHeaders, isDisallowedOrigin, isAllowedOrigin } from './cors';
 // @ts-expect-error — JS module, no declaration file
 import { validateApiKey } from '../api/_api-key.js';
+// @ts-expect-error — JS module, no declaration file
+import { captureSilentError } from '../api/_sentry-edge.js';
 import { mapErrorToResponse } from './error-mapper';
 import { checkRateLimit, checkEndpointRateLimit, hasEndpointRatePolicy } from './_shared/rate-limit';
 import { drainResponseHeaders } from './_shared/response-headers';
@@ -423,11 +425,24 @@ export function createDomainGateway(
       });
     }
 
+    // Fail closed on CORS-header generation errors. Previous behaviour fell
+    // back to `Access-Control-Allow-Origin: *`, which converted the
+    // allowlist into wildcard CORS on the error path. Now we omit CORS
+    // headers and surface a 500 so the browser blocks any cross-origin
+    // read. See issue #3705.
     let corsHeaders: Record<string, string>;
     try {
       corsHeaders = getCorsHeaders(request);
-    } catch {
-      corsHeaders = { 'Access-Control-Allow-Origin': '*' };
+    } catch (err) {
+      captureSilentError(err, {
+        tags: { route: 'gateway', step: 'cors_headers' },
+        ctx,
+      });
+      emitRequest(500, 'cors_error', null);
+      return new Response(JSON.stringify({ error: 'Internal server error' }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
     }
 
     // OPTIONS preflight

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -426,22 +426,31 @@ export function createDomainGateway(
     }
 
     // Fail closed on CORS-header generation errors. Previous behaviour fell
-    // back to `Access-Control-Allow-Origin: *`, which converted the
-    // allowlist into wildcard CORS on the error path. Now we omit CORS
-    // headers and surface a 500 so the browser blocks any cross-origin
-    // read. See issue #3705.
+    // back to a wildcard ACAO, which converted the allowlist into wildcard
+    // CORS on the error path. Now we omit CORS headers and surface a 500
+    // so the browser blocks any cross-origin read. See issue #3705.
     let corsHeaders: Record<string, string>;
     try {
       corsHeaders = getCorsHeaders(request);
     } catch (err) {
-      captureSilentError(err, {
+      // Pass the Sentry delivery promise through ctx.waitUntil so the
+      // Vercel Edge isolate survives long enough to actually flush the
+      // event. (captureSilentError uses keepalive:true as a transport
+      // fallback when ctx is absent, but the explicit waitUntil is the
+      // documented best practice.)
+      const captured = captureSilentError(err, {
         tags: { route: 'gateway', step: 'cors_headers' },
-        ctx,
       });
+      ctx?.waitUntil(captured);
       emitRequest(500, 'cors_error', null);
       return new Response(JSON.stringify({ error: 'Internal server error' }), {
         status: 500,
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          // Prevent CDN/edge from caching the 500 — a transient CORS
+          // failure must not be pinned for downstream callers.
+          'Cache-Control': 'no-store',
+        },
       });
     }
 

--- a/tests/cors-fail-closed.test.mts
+++ b/tests/cors-fail-closed.test.mts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+
+import { getCorsHeaders } from '../server/cors.ts';
+
+// Regression coverage for issue #3705: CORS-header generation errors must
+// fail closed rather than fall back to `Access-Control-Allow-Origin: *`.
+
+describe('cors helper', () => {
+  it('returns headers for a well-formed request', () => {
+    const req = new Request('https://worldmonitor.app/x', {
+      headers: { Origin: 'https://worldmonitor.app' },
+    });
+    const headers = getCorsHeaders(req);
+    assert.equal(headers['Access-Control-Allow-Origin'], 'https://worldmonitor.app');
+  });
+
+  it('propagates exceptions (caller must wrap in fail-closed try/catch)', () => {
+    const throwingReq = {
+      headers: {
+        get(): string {
+          throw new Error('simulated header failure');
+        },
+      },
+    } as unknown as Request;
+    assert.throws(() => getCorsHeaders(throwingReq), /simulated header failure/);
+  });
+});
+
+describe('gateway CORS error path (issue #3705)', () => {
+  it('does not contain a wildcard ACAO fallback in source', async () => {
+    const source = await readFile(
+      new URL('../server/gateway.ts', import.meta.url),
+      'utf8',
+    );
+    // No literal that pairs Access-Control-Allow-Origin with `*` should
+    // appear in gateway.ts. The pre-#3705 fallback was:
+    //   corsHeaders = { 'Access-Control-Allow-Origin': '*' };
+    const widening = /Access-Control-Allow-Origin['"]?\s*:\s*['"]\*['"]/i;
+    assert.ok(
+      !widening.test(source),
+      'gateway.ts must not emit wildcard ACAO — see issue #3705',
+    );
+  });
+
+  it('routes CORS exceptions through captureSilentError + 500 (no wildcard)', async () => {
+    const source = await readFile(
+      new URL('../server/gateway.ts', import.meta.url),
+      'utf8',
+    );
+    // The fail-closed branch must log the original error to Sentry AND
+    // return a 5xx instead of a permissive CORS response.
+    assert.ok(
+      /catch \(err\)[\s\S]{0,200}captureSilentError\(err/.test(source),
+      'gateway.ts cors catch must pass the original error to captureSilentError',
+    );
+    assert.ok(
+      /step:\s*['"]cors_headers['"]/.test(source),
+      'gateway.ts cors catch must tag Sentry events with step="cors_headers"',
+    );
+  });
+});

--- a/tests/cors-fail-closed.test.mts
+++ b/tests/cors-fail-closed.test.mts
@@ -5,7 +5,22 @@ import { describe, it } from 'node:test';
 import { getCorsHeaders } from '../server/cors.ts';
 
 // Regression coverage for issue #3705: CORS-header generation errors must
-// fail closed rather than fall back to `Access-Control-Allow-Origin: *`.
+// fail closed rather than fall back to a wildcard ACAO.
+
+// Named for self-documenting failure messages and so a future companion
+// guard elsewhere can re-use the same shape.
+const WILDCARD_ACAO_LITERAL = /Access-Control-Allow-Origin['"]?\s*:\s*['"]\*['"]/i;
+
+// Strip JS line and block comments so the wildcard-literal guard only
+// fires on real code, not on a comment that documents the anti-pattern
+// (e.g. a future PR description quoted in JSDoc above the fail-closed
+// branch). This keeps the test honest if someone documents the original
+// bug verbatim while keeping the fix intact.
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+}
 
 describe('cors helper', () => {
   it('returns headers for a well-formed request', () => {
@@ -29,18 +44,18 @@ describe('cors helper', () => {
 });
 
 describe('gateway CORS error path (issue #3705)', () => {
-  it('does not contain a wildcard ACAO fallback in source', async () => {
+  it('does not contain a wildcard ACAO fallback in source (comments stripped)', async () => {
     const source = await readFile(
       new URL('../server/gateway.ts', import.meta.url),
       'utf8',
     );
-    // No literal that pairs Access-Control-Allow-Origin with `*` should
-    // appear in gateway.ts. The pre-#3705 fallback was:
+    // The pre-#3705 fallback was:
     //   corsHeaders = { 'Access-Control-Allow-Origin': '*' };
-    const widening = /Access-Control-Allow-Origin['"]?\s*:\s*['"]\*['"]/i;
+    // After stripping comments, no such literal should remain — that
+    // would mean the wildcard widening regressed back into real code.
     assert.ok(
-      !widening.test(source),
-      'gateway.ts must not emit wildcard ACAO — see issue #3705',
+      !WILDCARD_ACAO_LITERAL.test(stripComments(source)),
+      'gateway.ts must not emit wildcard ACAO in code — see issue #3705',
     );
   });
 
@@ -50,14 +65,32 @@ describe('gateway CORS error path (issue #3705)', () => {
       'utf8',
     );
     // The fail-closed branch must log the original error to Sentry AND
-    // return a 5xx instead of a permissive CORS response.
+    // return a 5xx instead of a permissive CORS response. The gap is
+    // bounded so we can tolerate minor refactoring inside the catch
+    // (additional tags, intermediate variable names) without losing
+    // the structural assertion.
     assert.ok(
-      /catch \(err\)[\s\S]{0,200}captureSilentError\(err/.test(source),
+      /catch \(err\)[\s\S]{0,500}captureSilentError\(err/.test(source),
       'gateway.ts cors catch must pass the original error to captureSilentError',
     );
     assert.ok(
       /step:\s*['"]cors_headers['"]/.test(source),
       'gateway.ts cors catch must tag Sentry events with step="cors_headers"',
+    );
+  });
+
+  it('returns a non-cacheable 500 on CORS error so CDNs cannot pin it', async () => {
+    const source = await readFile(
+      new URL('../server/gateway.ts', import.meta.url),
+      'utf8',
+    );
+    // Find the catch block for cors_headers and assert Cache-Control:
+    // no-store appears inside the response headers within it.
+    const catchBlock = source.match(/catch \(err\)[\s\S]{0,1500}?\n\s{4}\}/);
+    assert.ok(catchBlock, 'expected to find the cors catch block in gateway.ts');
+    assert.ok(
+      /['"]Cache-Control['"]:\s*['"]no-store['"]/.test(catchBlock![0]),
+      'cors fail-closed 500 must set Cache-Control: no-store',
     );
   });
 });


### PR DESCRIPTION
## Summary

The gateway previously caught any exception from `getCorsHeaders()` and fell back to `Access-Control-Allow-Origin: *`, converting the allowlist into permissive wildcard CORS on the error path. Per issue #3705, a regression in origin handling could therefore silently broaden cross-origin readability for premium / user / intelligence-adjacent endpoints.

## Change

- Replace the wildcard fallback with a fail-closed branch: log the original exception via \`captureSilentError\` (Vercel Edge runtime) and return a 500 with no Access-Control-Allow-Origin header, so the browser blocks any cross-origin read.
- Add \`cors_error\` to \`RequestReason\` so telemetry distinguishes CORS-generation failures from auth/origin/route rejections.
- Preserves the original error cause in the Sentry event (not a synthetic marker), so the actual bug is debuggable.

## Test plan

- [x] \`npx tsx --test tests/cors-fail-closed.test.mts\` — new regression coverage
- [x] \`npx tsx --test tests/gateway-cdn-origin-policy.test.mts\` — 7/7 pass
- [x] \`npx tsx --test tests/premium-stock-gateway.test.mts tests/gateway-internal-mcp.test.mjs\` — 40/40 pass
- [x] \`npm run typecheck\` — clean

The new test file asserts (a) the gateway source contains no wildcard ACAO literal anywhere, and (b) the cors catch block routes the original error into \`captureSilentError\` with a \`step: 'cors_headers'\` tag. Together this guards against future regressions to either property.

Closes #3705