### PR TITLE
fix(audit): close #3733 (Lop Nur 85km drift) + #3740 (deduce-situation typo)

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -9995,7 +9995,7 @@ function isWidgetEndpointAllowed(endpoint) {
   if (!endpoint.startsWith('/api/')) return false;
   const blocked = [
     'analyze-stock', 'backtest-stock', 'summarize-article', 'classify-event',
-    'deduce-situation', 'track-aircraft', 'search-flight-prices', 'get-youtube',
+    'deduct-situation', 'track-aircraft', 'search-flight-prices', 'get-youtube',
     'get-vessel-snapshot', 'lookup-sanction', 'get-ip-geo', 'get-simulation',
   ];
   return !blocked.some(b => endpoint.includes(b));

--- a/scripts/seed-earthquakes.mjs
+++ b/scripts/seed-earthquakes.mjs
@@ -8,9 +8,11 @@ const USGS_FEED_URL = 'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary
 const CANONICAL_KEY = 'seismology:earthquakes:v1';
 const CACHE_TTL = 21600; // 6h — 6x the 1h cron interval (was 2x = survived only 1 missed run)
 
+// Canonical coordinates: src/config/geo.ts NUCLEAR_FACILITIES (type: 'test-site').
+// Keep in sync — drift here mislabels seismic events near nuclear infrastructure.
 const TEST_SITES = [
   { name: 'Punggye-ri',    lat: 41.28, lon: 129.08 },
-  { name: 'Lop Nur',       lat: 41.39, lon: 89.03  },
+  { name: 'Lop Nur',       lat: 41.75, lon: 88.35  },
   { name: 'Novaya Zemlya', lat: 73.37, lon: 54.78  },
   { name: 'Nevada NTS',    lat: 37.07, lon: -116.05 },
   { name: 'Semipalatinsk', lat: 50.07, lon: 78.43  },

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -123,6 +123,20 @@ describe('widget-agent relay — security', () => {
     );
   });
 
+  it('SSRF guard — deduct-situation blocklist entry matches the real method name (#3740)', () => {
+    // Regression: blocklist previously had a one-char typo 'deduce-situation' that
+    // never matched the real /api/intelligence/v1/deduct-situation path, leaving an
+    // expensive LLM endpoint freely callable.
+    assert.ok(
+      relay.includes("'deduct-situation'"),
+      "Blocklist must contain 'deduct-situation' (matches /api/intelligence/v1/deduct-situation)",
+    );
+    assert.ok(
+      !relay.includes("'deduce-situation'"),
+      "Blocklist must not contain the typo 'deduce-situation' — it never matches any real URL",
+    );
+  });
+
   it('injection guard — isWidgetInjectionAttempt function is present', () => {
     assert.ok(relay.includes('isWidgetInjectionAttempt'), 'injection guard function must exist');
     assert.ok(relay.includes('ignore') && relay.includes('previous'), 'must detect override patterns');

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -127,6 +127,17 @@ describe('widget-agent relay — security', () => {
     // Regression: blocklist previously had a one-char typo 'deduce-situation' that
     // never matched the real /api/intelligence/v1/deduct-situation path, leaving an
     // expensive LLM endpoint freely callable.
+    //
+    // A fully behavioral test (calling isWidgetEndpointAllowed() with the real URL)
+    // would catch a wider set of regressions than these structural assertions, but
+    // requires extracting the function from ais-relay.cjs into its own module —
+    // ais-relay.cjs starts an HTTP server unconditionally at module-load time, so
+    // it can't be required from a unit test without that refactor. The structural
+    // checks below catch the failure modes the audit explicitly named: the typo,
+    // the substring leaving the blocked-array, and a refactor away from the
+    // substring-match dispatch that re-opens the gap.
+
+    // 1. The correct entry is present (and the typo is gone).
     assert.ok(
       relay.includes("'deduct-situation'"),
       "Blocklist must contain 'deduct-situation' (matches /api/intelligence/v1/deduct-situation)",
@@ -134,6 +145,26 @@ describe('widget-agent relay — security', () => {
     assert.ok(
       !relay.includes("'deduce-situation'"),
       "Blocklist must not contain the typo 'deduce-situation' — it never matches any real URL",
+    );
+
+    // 2. The entry lives inside the `blocked = [...]` array literal, not in some
+    //    comment that happens to mention the method name. This catches a regression
+    //    where the array is commented out or guarded by a falsy condition but the
+    //    string survives elsewhere in the file.
+    const blockedArrayMatch = relay.match(/const blocked = \[[\s\S]*?\];/);
+    assert.ok(blockedArrayMatch, "isWidgetEndpointAllowed must define `const blocked = [...]`");
+    assert.ok(
+      blockedArrayMatch[0].includes("'deduct-situation'"),
+      "'deduct-situation' must appear inside the blocked array literal, not just somewhere in the file",
+    );
+
+    // 3. The dispatch still uses substring matching (`endpoint.includes(b)`). A
+    //    refactor to exact equality (`endpoint === b`) would silently re-open the
+    //    gap because callers pass the full `/api/intelligence/v1/deduct-situation`
+    //    path, not the bare method name.
+    assert.ok(
+      /blocked\.some\([^)]*=>\s*endpoint\.includes\(/.test(relay),
+      "isWidgetEndpointAllowed must keep substring matching (`endpoint.includes(b)`); switching to `endpoint === b` would re-open the SSRF gap",
     );
   });
 

--- a/todos/065-complete-p2-relay-blocklist-wrong-method-name-deduce-vs-deduct.md
+++ b/todos/065-complete-p2-relay-blocklist-wrong-method-name-deduce-vs-deduct.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: complete
 priority: p2
 issue_id: "065"
 tags: [code-review, agent-native, correctness, analytical-frameworks]
@@ -24,3 +24,4 @@ Change `'deduce-situation'` → `'deduct-situation'` in the blocklist array.
 
 ## Work Log
 - 2026-03-28: Identified by agent-native-reviewer during PR #2386 review
+- 2026-05-18: Fixed in commit on branch worktree-vast-jumping-duckling — single-char correction at `scripts/ais-relay.cjs:9998`. Closes external audit issue #3740.


### PR DESCRIPTION
## Summary

Trivial bundle from the external [AI Slop audit](https://github.com/koala73/worldmonitor/issues/3726) — two issues with one-line fixes, shipped together.

- **#3740** — `scripts/ais-relay.cjs:9998` widget-agent SSRF blocklist had `'deduce-situation'`, a one-char typo of the real method name `'deduct-situation'`. Substring match (`endpoint.includes(b)`) therefore never fired, leaving `/api/intelligence/v1/deduct-situation` (full LLM situation-deduction, expensive) freely callable by widget consumers despite the apparent intent to block it. In-repo TODO `todos/065-pending-...` (flagged by the agent-native-reviewer on PR #2386) is now `065-complete-...`.
- **#3733** — `scripts/seed-earthquakes.mjs:13` had Lop Nur at `41.39, 89.03` while the canonical `src/config/geo.ts:3159 NUCLEAR_FACILITIES` entry (and Wikipedia/NTI) put it at `41.75, 88.35` (~85 km off). The seeder uses a 100 km radius to label seismic events near nuclear test infrastructure, so events in the 85–100 km band around the true site were systematically mis-bucketed.

## Changes

| File | Change |
|---|---|
| `scripts/ais-relay.cjs` | `'deduce-situation'` → `'deduct-situation'` |
| `scripts/seed-earthquakes.mjs` | Lop Nur `41.39, 89.03` → `41.75, 88.35`; added 2-line comment naming `geo.ts` as the source of truth |
| `tests/widget-builder.test.mjs` | New regression assertion — blocklist must contain `'deduct-situation'` AND must not contain `'deduce-situation'` |
| `todos/065-pending-... .md` → `todos/065-complete-... .md` | Frontmatter `status: pending` → `complete`; work-log entry dated today |

## Why two issues in one PR

Both are < 2 LOC, both are linked from #3726, neither requires a backtest, and they have non-overlapping blast radius. Separate PRs would just be ceremony.

## Verification

- `node --test tests/widget-builder.test.mjs` — **205/205 pass**, including the new `#3740` regression test
- `node --check scripts/ais-relay.cjs` and `node --check scripts/seed-earthquakes.mjs` — both parse clean
- Cross-checked the other 4 entries in `TEST_SITES` (Punggye-ri, Novaya Zemlya, Nevada NTS, Semipalatinsk) against `geo.ts` — all already match exactly, only Lop Nur drifted
- Pre-push gates ran (typecheck, sentry coverage, pro-bundle, version sync) — all green

## Out of scope

The #3733 reviewer's long-term suggestion ("import `NUCLEAR_FACILITIES` from `src/config/geo.ts` into the seeder to eliminate the duplicate definition") is left for a follow-up — that requires either a `.ts → .mjs` import path or a generated JSON mirror, neither of which fits a trivial fix.

## Test plan

- [x] Existing widget-builder tests still pass (205/205)
- [x] New regression test for #3740 passes
- [x] Both edited scripts parse with `node --check`
- [x] Sibling test-site coordinates verified against canonical `geo.ts`
- [ ] Reviewer to confirm canonical Lop Nur coords (`41.75, 88.35`) match expectation