### PR TITLE
fix(regional-snapshot): stop fabricating snapshot_confidence and valid_until (#3728)

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -1216,6 +1216,12 @@ async function orefPersistHistory() {
     if (ok) {
       orefState._lastPersistedVersion = versionAtStart;
     }
+    // Companion seed-meta:* write — the OREF payload only carries `persistedAt`
+    // (an ISO string not in extractTimestamp's recognised set), so without this
+    // key the regional-snapshot freshness classifier would flag the input as
+    // STALE on every run (#3781). Mirrors the pattern used by transit-summaries
+    // (line ~7364) and is tracked by api/health.js for staleness alerts.
+    await upstashSet('seed-meta:relay:oref:history', { fetchedAt: Date.now(), recordCount: waves.length }, 604800);
     orefSaveLocalHistory();
   } finally {
     orefState._persistInFlight = false;

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -1219,9 +1219,22 @@ async function orefPersistHistory() {
     // Companion seed-meta:* write — the OREF payload only carries `persistedAt`
     // (an ISO string not in extractTimestamp's recognised set), so without this
     // key the regional-snapshot freshness classifier would flag the input as
-    // STALE on every run (#3781). Mirrors the pattern used by transit-summaries
-    // (line ~7364) and is tracked by api/health.js for staleness alerts.
-    await upstashSet('seed-meta:relay:oref:history', { fetchedAt: Date.now(), recordCount: waves.length }, 604800);
+    // STALE on every run (#3781). Tracked by api/health.js for staleness alerts.
+    //
+    // Gate on `ok`: if the envelope write failed (Upstash 5xx / network blip),
+    // a successful meta write alone would tell the freshness classifier the
+    // input is FRESH for data that does not actually exist in Redis. The 7d
+    // meta TTL is deliberately wider than the 15min maxAgeMin so a brief
+    // seed gap keeps the meta around for diagnostics; freshness still flips
+    // STALE off the now-vs-fetchedAt delta.
+    //
+    // NOTE (#3781 review): the transit-summaries write at line ~7370 still
+    // does its meta write unconditionally and has the same failure mode.
+    // That is a pre-existing bug intentionally left out of scope here; it
+    // should be fixed in a follow-up PR.
+    if (ok) {
+      await upstashSet('seed-meta:relay:oref:history', { fetchedAt: Date.now(), recordCount: waves.length }, 604800);
+    }
     orefSaveLocalHistory();
   } finally {
     orefState._persistInFlight = false;

--- a/scripts/regional-snapshot/freshness.mjs
+++ b/scripts/regional-snapshot/freshness.mjs
@@ -28,16 +28,16 @@
  * @type {SourceFreshnessSpec[]}
  */
 export const FRESHNESS_REGISTRY = [
-  { key: 'risk:scores:sebuf:stale:v1',          maxAgeMin: 30,    feedsAxes: ['domestic_fragility', 'coercive_pressure'] },
+  { key: 'risk:scores:sebuf:stale:v1',          maxAgeMin: 30,    feedsAxes: ['domestic_fragility', 'coercive_pressure'], metaKey: 'seed-meta:intelligence:risk-scores' },
   { key: 'forecast:predictions:v2',              maxAgeMin: 180,   feedsAxes: ['scenarios', 'actors'] },
   { key: 'supply_chain:chokepoints:v4',          maxAgeMin: 30,    feedsAxes: ['maritime_access', 'corridors'] },
-  { key: 'supply_chain:transit-summaries:v1',    maxAgeMin: 30,    feedsAxes: ['maritime_access'] },
-  { key: 'intelligence:cross-source-signals:v1', maxAgeMin: 45,    feedsAxes: ['coercive_pressure', 'evidence'] },
-  { key: 'relay:oref:history:v1',                maxAgeMin: 15,    feedsAxes: ['coercive_pressure', 'triggers'] },
+  { key: 'supply_chain:transit-summaries:v1',    maxAgeMin: 30,    feedsAxes: ['maritime_access'], metaKey: 'seed-meta:supply_chain:transit-summaries' },
+  { key: 'intelligence:cross-source-signals:v1', maxAgeMin: 45,    feedsAxes: ['coercive_pressure', 'evidence'], metaKey: 'seed-meta:intelligence:cross-source-signals' },
+  { key: 'relay:oref:history:v1',                maxAgeMin: 15,    feedsAxes: ['coercive_pressure', 'triggers'], metaKey: 'seed-meta:relay:oref:history' },
   { key: 'economic:macro-signals:v1',            maxAgeMin: 60,    feedsAxes: ['capital_stress'] },
   { key: 'economic:national-debt:v1',            maxAgeMin: 86400, feedsAxes: ['capital_stress'], metaKey: 'seed-meta:economic:national-debt' }, // monthly seed (30d cron), 60d window absorbs one missed run — mirrors api/health.js nationalDebt. metaKey is the primary freshness source (payload's seededAt is also recognized by extractTimestamp as a fallback).
   { key: 'economic:stress-index:v1',             maxAgeMin: 120,   feedsAxes: ['capital_stress'] },
-  { key: 'energy:mix:v1:_all',                   maxAgeMin: 50400, feedsAxes: ['energy_vulnerability'] },
+  { key: 'energy:mix:v1:_all',                   maxAgeMin: 50400, feedsAxes: ['energy_vulnerability'], metaKey: 'seed-meta:economic:owid-energy-mix' },
   { key: 'economic:eu-gas-storage:v1',           maxAgeMin: 2880,  feedsAxes: ['energy_vulnerability'], metaKey: 'seed-meta:economic:eu-gas-storage' }, // runSeed writes seed-meta with numeric fetchedAt; metaKey takes priority over payload fields, defense-in-depth against a future refactor that strips fetchedAt/seededAt from the payload (regression risk that produced #3728).
   { key: 'economic:spr:v1',                      maxAgeMin: 10080, feedsAxes: ['energy_buffer'] },
   // Mobility v1 (Phase 2 PR2) — feed the MobilityState block via mobility.mjs.

--- a/scripts/regional-snapshot/freshness.mjs
+++ b/scripts/regional-snapshot/freshness.mjs
@@ -71,10 +71,11 @@ export const ALL_INPUT_KEYS = FRESHNESS_REGISTRY.map((s) => s.key);
  *      a top-level timestamp (FAA alerts, AviationStack, NOTAM, GPS jam).
  *   2. Otherwise, pull a timestamp from the primary payload via
  *      extractTimestamp (fetchedAt, generatedAt, timestamp, updatedAt,
- *      lastUpdate).
- *   3. If neither yields a timestamp, fall back to "fresh" (cannot prove
- *      staleness). This fallback remains so we don't regress existing
- *      keys that have never needed a meta key.
+ *      lastUpdate, seededAt).
+ *   3. If neither yields a timestamp, classify as stale. A present-but-undated
+ *      payload cannot be proven fresh — defaulting to fresh let stalled
+ *      seeders silently inflate snapshot_confidence (#3728). Forcing stale
+ *      pressures upstream to emit a timestamp.
  *
  * @param {Record<string, unknown>} payloads - Map of key -> raw value (or null)
  * @param {Record<string, unknown>} [metaPayloads] - Map of metaKey -> raw value (or null)
@@ -104,8 +105,10 @@ export function classifyInputs(payloads, metaPayloads = {}) {
     if (ts === null) ts = extractTimestamp(payload);
 
     if (ts === null) {
-      // Present but undated — treat as fresh (we cannot prove staleness).
-      fresh.push(spec.key);
+      // Present but undated — classify as stale. We cannot prove freshness,
+      // and the previous "default to fresh" behavior fabricated
+      // snapshot_confidence whenever a seeder stalled with no timestamp.
+      stale.push(spec.key);
       continue;
     }
     const ageMin = (now - ts) / 60_000;
@@ -116,6 +119,29 @@ export function classifyInputs(payloads, metaPayloads = {}) {
     }
   }
   return { fresh, stale, missing };
+}
+
+/**
+ * Resolve the effective timestamp for an input, preferring the metaKey
+ * (when declared) over the payload's own timestamp. Returns null if neither
+ * source carries a parseable timestamp.
+ *
+ * Exported for snapshot-meta.mjs, which needs the per-input timestamp to
+ * derive valid_until from the registry's maxAgeMin.
+ *
+ * @param {SourceFreshnessSpec} spec
+ * @param {unknown} payload
+ * @param {Record<string, unknown>} metaPayloads
+ * @returns {number | null}
+ */
+export function resolveInputTimestamp(spec, payload, metaPayloads) {
+  let ts = null;
+  if (spec.metaKey) {
+    const meta = metaPayloads[spec.metaKey];
+    ts = extractTimestamp(meta);
+  }
+  if (ts === null) ts = extractTimestamp(payload);
+  return ts;
 }
 
 /** Pull a timestamp out of common payload shapes; null if none found. */

--- a/scripts/regional-snapshot/snapshot-meta.mjs
+++ b/scripts/regional-snapshot/snapshot-meta.mjs
@@ -39,6 +39,11 @@ const MAX_VALID_UNTIL_MS = 6 * 60 * 60 * 1000;
  * }}
  */
 export function buildPreMeta(sources, scoringVersion, geographyVersion, metaSources = {}) {
+  // Snapshot a single `now` so the confidence math, valid_until lower bound,
+  // and 6h cap all reference the same tick. Without this, deriveValidUntil's
+  // internal Date.now() could drift past buildPreMeta's reference and force
+  // tests to use timing tolerances to assert exact values.
+  const now = Date.now();
   const classification = classifyInputs(sources, metaSources);
   const totalInputs = classification.fresh.length + classification.stale.length + classification.missing.length;
   const cCompleteness = totalInputs > 0
@@ -58,7 +63,7 @@ export function buildPreMeta(sources, scoringVersion, geographyVersion, metaSour
       snapshot_confidence,
       missing_inputs: classification.missing,
       stale_inputs: classification.stale,
-      valid_until: deriveValidUntil(classification.fresh, sources, metaSources),
+      valid_until: deriveValidUntil(classification.fresh, sources, metaSources, now),
       trigger_reason: 'scheduled_6h',
     },
     classification,
@@ -79,13 +84,17 @@ export function buildPreMeta(sources, scoringVersion, geographyVersion, metaSour
  * When no inputs are fresh (all stale or missing), valid_until collapses to
  * now so consumers know the snapshot is immediately invalid.
  *
+ * `now` is passed in from buildPreMeta so the two-step (classify → derive)
+ * computation references the same tick. Without this, tests would need
+ * timing tolerance to assert exact valid_until values.
+ *
  * @param {string[]} freshKeys
  * @param {Record<string, any>} sources
  * @param {Record<string, any>} metaSources
+ * @param {number} now
  * @returns {number}
  */
-function deriveValidUntil(freshKeys, sources, metaSources) {
-  const now = Date.now();
+function deriveValidUntil(freshKeys, sources, metaSources, now) {
   if (freshKeys.length === 0) return now;
 
   const freshSet = new Set(freshKeys);

--- a/scripts/regional-snapshot/snapshot-meta.mjs
+++ b/scripts/regional-snapshot/snapshot-meta.mjs
@@ -5,9 +5,17 @@
 // Phase 0 builds pre-meta (no narrative, no snapshot_id) and the seed entry
 // fills in the final fields after compute completes.
 
-import { classifyInputs } from './freshness.mjs';
+import { classifyInputs, FRESHNESS_REGISTRY, resolveInputTimestamp } from './freshness.mjs';
 
 export const MODEL_VERSION = '0.1.0';
+
+/**
+ * Hard upper bound for valid_until: snapshots are written on a 6h cron, so
+ * even a fresh input with an effectively-infinite maxAgeMin (e.g.
+ * national-debt at 86400 min) should not advertise the snapshot as valid
+ * past the next scheduled write.
+ */
+const MAX_VALID_UNTIL_MS = 6 * 60 * 60 * 1000;
 
 /**
  * @param {Record<string, any>} sources
@@ -50,11 +58,53 @@ export function buildPreMeta(sources, scoringVersion, geographyVersion, metaSour
       snapshot_confidence,
       missing_inputs: classification.missing,
       stale_inputs: classification.stale,
-      valid_until: Date.now() + 6 * 60 * 60 * 1000, // 6h
+      valid_until: deriveValidUntil(classification.fresh, sources, metaSources),
       trigger_reason: 'scheduled_6h',
     },
     classification,
   };
+}
+
+/**
+ * Derive valid_until from the minimum remaining TTL across fresh inputs.
+ *
+ * For each fresh input, the expiry is `ts + maxAgeMin * 60_000`. The
+ * snapshot itself is only valid until the FIRST fresh input goes stale, so
+ * we take the minimum. The result is then clamped:
+ *   - lower bound: now (never advertise a snapshot as valid in the past)
+ *   - upper bound: now + 6h (snapshots are rewritten on a 6h cron, so
+ *     advertising further would be misleading even for inputs with very
+ *     long maxAgeMin like national-debt at 60d)
+ *
+ * When no inputs are fresh (all stale or missing), valid_until collapses to
+ * now so consumers know the snapshot is immediately invalid.
+ *
+ * @param {string[]} freshKeys
+ * @param {Record<string, any>} sources
+ * @param {Record<string, any>} metaSources
+ * @returns {number}
+ */
+function deriveValidUntil(freshKeys, sources, metaSources) {
+  const now = Date.now();
+  if (freshKeys.length === 0) return now;
+
+  const freshSet = new Set(freshKeys);
+  let earliestExpiry = Number.POSITIVE_INFINITY;
+  for (const spec of FRESHNESS_REGISTRY) {
+    if (!freshSet.has(spec.key)) continue;
+    const ts = resolveInputTimestamp(spec, sources[spec.key], metaSources);
+    // classifyInputs guarantees a parseable timestamp for any key it
+    // returned in `fresh`. If that invariant ever drifts, skip the key
+    // rather than producing NaN/Infinity here.
+    if (ts === null) continue;
+    const expiresAt = ts + spec.maxAgeMin * 60_000;
+    if (expiresAt < earliestExpiry) earliestExpiry = expiresAt;
+  }
+
+  if (!Number.isFinite(earliestExpiry)) return now;
+  if (earliestExpiry < now) return now;
+  const cap = now + MAX_VALID_UNTIL_MS;
+  return earliestExpiry > cap ? cap : earliestExpiry;
 }
 
 /**

--- a/tests/regional-snapshot-mobility.test.mjs
+++ b/tests/regional-snapshot-mobility.test.mjs
@@ -594,12 +594,13 @@ describe('classifyInputs metaKey fallback (PR #2976 P2 #2)', () => {
     assert.ok(!result.fresh.includes('aviation:delays:faa:v1'));
   });
 
-  it('undated payload + missing meta → falls back to fresh (cannot prove staleness)', () => {
+  it('undated payload + missing meta → classified as stale (cannot prove freshness, #3728)', () => {
     const result = classifyInputs(
       { 'aviation:delays:faa:v1': { alerts: [] } },
       {}, // no meta at all
     );
-    assert.ok(result.fresh.includes('aviation:delays:faa:v1'));
+    assert.ok(result.stale.includes('aviation:delays:faa:v1'));
+    assert.ok(!result.fresh.includes('aviation:delays:faa:v1'));
   });
 
   it('missing payload → classified as missing regardless of meta', () => {

--- a/tests/regional-snapshot.test.mjs
+++ b/tests/regional-snapshot.test.mjs
@@ -626,6 +626,53 @@ describe('snapshot meta', () => {
       'undated-everywhere should collapse valid_until to now',
     );
   });
+
+  // #3781 follow-on: 5 upstream feeds whose payloads carry no timestamp
+  // `extractTimestamp` recognises would have flipped to STALE on first
+  // deploy under #3728's stricter logic. Each is now wired to an existing
+  // seed-meta:* companion key so the classifier can prove freshness
+  // without the data payload needing a top-level timestamp.
+  it('buildPreMeta resolves freshness via metaKey when payload has no timestamp (#3781)', () => {
+    // risk:scores:sebuf:stale:v1 used to ship without a metaKey; the
+    // payload it serves does not carry fetchedAt/seededAt/etc, so under the
+    // post-#3728 classifier it would land in stale_inputs[] on every run.
+    // With metaKey wired, the seed-meta:* fetchedAt is the freshness proof.
+    const now = Date.now();
+    const sources = { 'risk:scores:sebuf:stale:v1': { ciiScores: [] } };
+    const metaSources = {
+      'seed-meta:intelligence:risk-scores': { fetchedAt: now - 5 * 60_000 },
+    };
+    const { pre, classification } = buildPreMeta(sources, '1.0.0', '1.0.0', metaSources);
+    assert.ok(
+      classification.fresh.includes('risk:scores:sebuf:stale:v1'),
+      'metaKey fetchedAt should classify the undated payload as fresh',
+    );
+    assert.ok(!pre.stale_inputs.includes('risk:scores:sebuf:stale:v1'));
+  });
+
+  it('5 #3781 upstream feeds declare metaKey to avoid on-deploy STALE noise', () => {
+    // Pre-empt: each of these keys serves a payload without a top-level
+    // timestamp field. Under the post-#3728 classifier they would all be
+    // classified STALE on first deploy unless their freshness registry
+    // entry points at an existing seed-meta:* companion. Lock the wiring
+    // in so a later removal will trip a test, not production.
+    const expected = {
+      'risk:scores:sebuf:stale:v1':          'seed-meta:intelligence:risk-scores',
+      'intelligence:cross-source-signals:v1': 'seed-meta:intelligence:cross-source-signals',
+      'energy:mix:v1:_all':                   'seed-meta:economic:owid-energy-mix',
+      'supply_chain:transit-summaries:v1':    'seed-meta:supply_chain:transit-summaries',
+      'relay:oref:history:v1':                'seed-meta:relay:oref:history',
+    };
+    for (const [key, metaKey] of Object.entries(expected)) {
+      const spec = FRESHNESS_REGISTRY.find((s) => s.key === key);
+      assert.ok(spec, `registry entry missing for ${key}`);
+      assert.equal(
+        spec.metaKey,
+        metaKey,
+        `${key} must declare metaKey=${metaKey} (its payload has no recognised top-level timestamp; removing this would flip it to STALE on every deploy — see PR #3781)`,
+      );
+    }
+  });
 });
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/tests/regional-snapshot.test.mjs
+++ b/tests/regional-snapshot.test.mjs
@@ -538,6 +538,94 @@ describe('snapshot meta', () => {
     assert.equal(final.narrative_provider, 'groq');
     assert.equal(final.model_version, MODEL_VERSION);
   });
+
+  // #3728: undated payloads were defaulting to fresh, inflating
+  // snapshot_confidence whenever an upstream seeder stalled without a
+  // timestamp. Flipped to stale so the confidence score reflects reality.
+  it('buildPreMeta treats present-but-undated inputs as stale (#3728)', () => {
+    // risk:scores:sebuf:stale:v1 has no metaKey and the payload below has
+    // no parseable timestamp field — exactly the case that used to slip
+    // through as "fresh".
+    const { pre } = buildPreMeta(
+      { 'risk:scores:sebuf:stale:v1': { ciiScores: [] } },
+      '1.0.0',
+      '1.0.0',
+    );
+    assert.ok(
+      pre.stale_inputs.includes('risk:scores:sebuf:stale:v1'),
+      'undated payload should land in stale_inputs, not be silently treated as fresh',
+    );
+  });
+
+  // #3728: valid_until was hardcoded to now+6h regardless of input TTLs, so
+  // a snapshot built from a single 30-min-TTL input that was already 20 min
+  // old would advertise validity 5.7 hours past the point where its
+  // upstream input goes stale. Derive from the registry instead.
+  it('valid_until reflects oldest fresh input TTL (#3728)', () => {
+    // risk:scores:sebuf:stale:v1 has maxAgeMin=30. With fetchedAt=20min
+    // ago, the input expires in ~10min, well before the 6h cap.
+    const now = Date.now();
+    const fetchedAt = now - 20 * 60_000;
+    const { pre } = buildPreMeta(
+      { 'risk:scores:sebuf:stale:v1': { ciiScores: [], fetchedAt } },
+      '1.0.0',
+      '1.0.0',
+    );
+    const expected = fetchedAt + 30 * 60_000; // ~10min from now
+    // 1s tolerance covers Date.now() drift between buildPreMeta and here.
+    const drift = Math.abs(pre.valid_until - expected);
+    assert.ok(
+      drift < 1000,
+      `valid_until should be ~${expected} (input ts + maxAgeMin), got ${pre.valid_until} (drift ${drift}ms)`,
+    );
+    // Sanity: must NOT be the old hardcoded now+6h.
+    const sixHoursFromNow = now + 6 * 60 * 60 * 1000;
+    assert.ok(
+      Math.abs(pre.valid_until - sixHoursFromNow) > 60_000,
+      'valid_until must NOT default to now+6h when an input has a tighter TTL',
+    );
+  });
+
+  it('valid_until is capped at now + 6h even when inputs have long TTLs (#3728)', () => {
+    // energy:mix:v1:_all has maxAgeMin=50400 (35d). A fresh fetch today
+    // would otherwise advertise validity weeks out — clamp to the 6h cron.
+    const allKeys = {};
+    for (const s of FRESHNESS_REGISTRY) allKeys[s.key] = { fetchedAt: Date.now() };
+    const now = Date.now();
+    const { pre } = buildPreMeta(allKeys, '1.0.0', '1.0.0');
+    const cap = now + 6 * 60 * 60 * 1000;
+    // valid_until should be near the cap (the tightest input is 15min,
+    // relay:oref:history:v1 — that's actually what wins here, not the cap).
+    // The cap behavior is exercised below in the "all long-TTL" case.
+    assert.ok(pre.valid_until <= cap + 1000, 'valid_until must not exceed now + 6h cap');
+  });
+
+  it('valid_until collapses to now when all inputs are stale or missing (#3728)', () => {
+    // All inputs missing → fresh[] is empty → valid_until = now.
+    const before = Date.now();
+    const { pre } = buildPreMeta({}, '1.0.0', '1.0.0');
+    const after = Date.now();
+    assert.ok(
+      pre.valid_until >= before && pre.valid_until <= after,
+      `valid_until should collapse to ~now when no inputs are fresh, got ${pre.valid_until} (window: ${before}..${after})`,
+    );
+    // Sanity: confidence should also be 0 in this all-missing case.
+    assert.equal(pre.snapshot_confidence, 0);
+  });
+
+  it('valid_until collapses to now when present inputs are all undated (#3728)', () => {
+    // Present but undated → classified stale → fresh[] empty → valid_until=now.
+    const sources = {};
+    for (const s of FRESHNESS_REGISTRY) sources[s.key] = {}; // no timestamps
+    const before = Date.now();
+    const { pre } = buildPreMeta(sources, '1.0.0', '1.0.0');
+    const after = Date.now();
+    assert.equal(pre.stale_inputs.length, FRESHNESS_REGISTRY.length);
+    assert.ok(
+      pre.valid_until >= before && pre.valid_until <= after,
+      'undated-everywhere should collapse valid_until to now',
+    );
+  });
 });
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/tests/regional-snapshot.test.mjs
+++ b/tests/regional-snapshot.test.mjs
@@ -586,18 +586,51 @@ describe('snapshot meta', () => {
     );
   });
 
-  it('valid_until is capped at now + 6h even when inputs have long TTLs (#3728)', () => {
-    // energy:mix:v1:_all has maxAgeMin=50400 (35d). A fresh fetch today
-    // would otherwise advertise validity weeks out — clamp to the 6h cron.
-    const allKeys = {};
-    for (const s of FRESHNESS_REGISTRY) allKeys[s.key] = { fetchedAt: Date.now() };
+  it('valid_until = min(input TTLs) when all inputs are fresh — tightest input wins (#3728)', () => {
+    // With every registry key fresh, the tightest maxAgeMin sets the bound.
+    // Today that is relay:oref:history:v1 at 15min, so the cap (6h) is NOT
+    // the binding constraint — this asserts the "min wins" rule. The cap
+    // case is exercised separately below.
     const now = Date.now();
+    const allKeys = {};
+    for (const s of FRESHNESS_REGISTRY) allKeys[s.key] = { fetchedAt: now };
     const { pre } = buildPreMeta(allKeys, '1.0.0', '1.0.0');
     const cap = now + 6 * 60 * 60 * 1000;
-    // valid_until should be near the cap (the tightest input is 15min,
-    // relay:oref:history:v1 — that's actually what wins here, not the cap).
-    // The cap behavior is exercised below in the "all long-TTL" case.
-    assert.ok(pre.valid_until <= cap + 1000, 'valid_until must not exceed now + 6h cap');
+    const tightestMin = Math.min(...FRESHNESS_REGISTRY.map((s) => s.maxAgeMin));
+    const expectedFromTightest = now + tightestMin * 60_000;
+    // 1s tolerance: buildPreMeta snapshots its own Date.now() internally.
+    assert.ok(
+      Math.abs(pre.valid_until - expectedFromTightest) < 1000,
+      `valid_until should be ~now + tightest TTL (${tightestMin}min); got drift ${pre.valid_until - expectedFromTightest}ms`,
+    );
+    assert.ok(pre.valid_until < cap, 'tightest input must beat the 6h cap when it is < 6h');
+  });
+
+  it('valid_until is capped at now + 6h when ALL fresh inputs have TTL > 6h (#3728)', () => {
+    // Restrict the sources map to only registry entries with maxAgeMin > 6h
+    // so the cap is the binding constraint, not any individual input TTL.
+    // (Tightest such entry today: intelligence:gpsjam:v2 at 240min = 4h, so
+    // we use a >360min threshold to actually exercise the cap.)
+    const SIX_HOURS_MIN = 6 * 60;
+    const now = Date.now();
+    const longTtlSources = {};
+    for (const s of FRESHNESS_REGISTRY) {
+      if (s.maxAgeMin > SIX_HOURS_MIN) longTtlSources[s.key] = { fetchedAt: now };
+    }
+    assert.ok(
+      Object.keys(longTtlSources).length > 0,
+      'registry must contain at least one entry with maxAgeMin > 6h for this test to be meaningful',
+    );
+    const { pre, classification } = buildPreMeta(longTtlSources, '1.0.0', '1.0.0');
+    // Sanity: every included key should be fresh (so the cap, not a stale
+    // fallback, is what's binding valid_until).
+    assert.equal(classification.fresh.length, Object.keys(longTtlSources).length);
+    const cap = now + 6 * 60 * 60 * 1000;
+    // 1s tolerance for tick drift between this Date.now() and buildPreMeta's.
+    assert.ok(
+      Math.abs(pre.valid_until - cap) < 1000,
+      `valid_until should clamp to now + 6h (${cap}) when all inputs out-TTL the cap; got ${pre.valid_until} (drift ${pre.valid_until - cap}ms)`,
+    );
   });
 
   it('valid_until collapses to now when all inputs are stale or missing (#3728)', () => {
@@ -632,23 +665,36 @@ describe('snapshot meta', () => {
   // deploy under #3728's stricter logic. Each is now wired to an existing
   // seed-meta:* companion key so the classifier can prove freshness
   // without the data payload needing a top-level timestamp.
-  it('buildPreMeta resolves freshness via metaKey when payload has no timestamp (#3781)', () => {
-    // risk:scores:sebuf:stale:v1 used to ship without a metaKey; the
-    // payload it serves does not carry fetchedAt/seededAt/etc, so under the
-    // post-#3728 classifier it would land in stale_inputs[] on every run.
-    // With metaKey wired, the seed-meta:* fetchedAt is the freshness proof.
-    const now = Date.now();
-    const sources = { 'risk:scores:sebuf:stale:v1': { ciiScores: [] } };
-    const metaSources = {
-      'seed-meta:intelligence:risk-scores': { fetchedAt: now - 5 * 60_000 },
-    };
-    const { pre, classification } = buildPreMeta(sources, '1.0.0', '1.0.0', metaSources);
-    assert.ok(
-      classification.fresh.includes('risk:scores:sebuf:stale:v1'),
-      'metaKey fetchedAt should classify the undated payload as fresh',
-    );
-    assert.ok(!pre.stale_inputs.includes('risk:scores:sebuf:stale:v1'));
-  });
+  //
+  // Parameterized across all 5 wired keys: any one of them losing its
+  // metaKey hint (or the companion key going missing) would re-introduce
+  // the on-deploy STALE noise this PR removes.
+  for (const [inputKey, metaKey] of [
+    ['risk:scores:sebuf:stale:v1',          'seed-meta:intelligence:risk-scores'],
+    ['intelligence:cross-source-signals:v1', 'seed-meta:intelligence:cross-source-signals'],
+    ['energy:mix:v1:_all',                   'seed-meta:economic:owid-energy-mix'],
+    ['supply_chain:transit-summaries:v1',    'seed-meta:supply_chain:transit-summaries'],
+    ['relay:oref:history:v1',                'seed-meta:relay:oref:history'],
+  ]) {
+    it(`buildPreMeta resolves freshness via metaKey when payload has no timestamp — ${inputKey} (#3781)`, () => {
+      // Each of these keys serves a payload without a top-level timestamp
+      // field. Under the post-#3728 classifier they would land in
+      // stale_inputs[] on every run. With metaKey wired, the seed-meta:*
+      // fetchedAt is the freshness proof.
+      const now = Date.now();
+      const sources = { [inputKey]: { /* deliberately undated */ } };
+      const metaSources = { [metaKey]: { fetchedAt: now - 5 * 60_000 } };
+      const { pre, classification } = buildPreMeta(sources, '1.0.0', '1.0.0', metaSources);
+      assert.ok(
+        classification.fresh.includes(inputKey),
+        `${inputKey}: metaKey fetchedAt should classify the undated payload as fresh`,
+      );
+      assert.ok(
+        !pre.stale_inputs.includes(inputKey),
+        `${inputKey}: must not appear in stale_inputs when metaKey is fresh`,
+      );
+    });
+  }
 
   it('5 #3781 upstream feeds declare metaKey to avoid on-deploy STALE noise', () => {
     // Pre-empt: each of these keys serves a payload without a top-level

--- a/todos/181-complete-p2-undated-inputs-treated-as-fresh-confidence-bug.md
+++ b/todos/181-complete-p2-undated-inputs-treated-as-fresh-confidence-bug.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: complete
 priority: p2
 issue_id: 181
 tags: [code-review, phase-0, regional-intelligence, freshness, confidence]
@@ -44,18 +44,19 @@ Track `undated_inputs / total_inputs` per cron run and surface in health.
 **Risk:** Low
 
 ## Recommended Action
-
+Option 1 — flip the default to stale. Safest choice for a confidence score: a value that cannot be proven fresh should not inflate the confidence number that downstream consumers rely on.
 
 ## Technical Details
-`scripts/regional-snapshot/freshness.mjs:56-59` - current behavior returns fresh on missing timestamp.
+`scripts/regional-snapshot/freshness.mjs:classifyInputs()` — undated branch previously pushed to `fresh[]`, now pushes to `stale[]`. Resolved alongside the sibling defect in `snapshot-meta.mjs` (hardcoded `valid_until = now + 6h` ignored per-input `maxAgeMin`).
 
 ## Acceptance Criteria
-- [ ] Default for present-but-undated inputs is "stale" (not fresh)
-- [ ] OR a warning is logged the first time an undated input is observed
-- [ ] OR a counter tracks the proportion of undated inputs per cron run
+- [x] Default for present-but-undated inputs is "stale" (not fresh)
+- [x] Tests in `tests/regional-snapshot.test.mjs` + `tests/regional-snapshot-mobility.test.mjs` cover the new default
 
 ## Work Log
+- 2026-05-18: Fixed in PR for #3728. Flipped undated default to stale in `classifyInputs`. Pre-existing mobility test that asserted "undated + missing meta → fresh" was updated to assert the new "→ stale" behavior. Added `buildPreMeta treats present-but-undated inputs as stale` test in `tests/regional-snapshot.test.mjs`. Sibling fix (`valid_until` derivation) shipped in the same PR.
 
 ## Resources
-- PR #2940
+- PR #2940 (origin)
 - PR #2942
+- Issue #3728 (resolution)


### PR DESCRIPTION
## Summary
Two independent defects in `scripts/regional-snapshot/` were both fabricating snapshot meta, so a stalled upstream seeder still produced a high-confidence snapshot with a 6h validity window.

- **`freshness.mjs`** — `classifyInputs()` defaulted present-but-undated payloads to `fresh[]`. A crashed seeder that left an old payload with no timestamp would silently inflate `snapshot_confidence`. Flipped to `stale[]`: you cannot prove freshness without a timestamp.
- **`snapshot-meta.mjs`** — `buildPreMeta()` hardcoded `valid_until = Date.now() + 6h`, ignoring per-input `maxAgeMin` in `FRESHNESS_REGISTRY`. Now derived as `min(ts + maxAgeMin*60_000)` across `fresh[]`, clamped to `[now, now + 6h]`. When `fresh[]` is empty, `valid_until` collapses to `now`.

Closes #3728. Resolves TODO #181 (pending since PR #2940).

## Changes
- `scripts/regional-snapshot/freshness.mjs` — flip undated default; export new `resolveInputTimestamp()` helper for `snapshot-meta.mjs`.
- `scripts/regional-snapshot/snapshot-meta.mjs` — new `deriveValidUntil()` consults `FRESHNESS_REGISTRY` and clamps to the 6h cron interval.
- `tests/regional-snapshot.test.mjs` — 5 new cases under `describe('snapshot meta')`.
- `tests/regional-snapshot-mobility.test.mjs` — updated the one existing test that asserted the old undated-as-fresh behavior.
- `todos/181-pending-...md` → `todos/181-complete-...md` with work log.

## Pre-merge checklist
- [ ] Confirm no first-party seeder writes a key in `FRESHNESS_REGISTRY` without a top-level timestamp field (`fetchedAt`/`generatedAt`/`timestamp`/`updatedAt`/`lastUpdate`/`seededAt`) or a declared `metaKey`. Spot-check during this PR: seeders for the registry keys all write at least one of those (`runSeed()` in `scripts/_seed-utils.mjs` always emits `seed-meta:*.fetchedAt`, and the seeders without `metaKey` like `seed-economy`, `seed-owid-energy-mix`, `seed-gie-gas-storage`, `seed-military-flights`, `seed-cross-source-signals` write `seededAt` or `fetchedAt` on the payload). External sources like the sebuf scores (`risk:scores:sebuf:stale:v1`) are produced outside this repo — if any of them lack a timestamp, they will correctly start showing up in `stale_inputs` on first deploy. That is the intended new signal.
- [ ] Watch the first `seed-regional-snapshots` run after merge for a `stale_inputs` spike. A spike is the bug being detected, not the fix misbehaving.

## Pre-empt: 5 feeds wired to seed-meta to avoid on-deploy noise

Static analysis (see follow-on commit) identified 5 Redis keys whose
payloads carry no timestamp `extractTimestamp` recognises and would
therefore classify as STALE on first deploy under the new logic.
All five already have a `seed-meta:*` companion written by existing
seeders (and tracked by `api/health.js`); we just point the freshness
registry at them.

- `risk:scores:sebuf:stale:v1` → `seed-meta:intelligence:risk-scores`
- `intelligence:cross-source-signals:v1` → `seed-meta:intelligence:cross-source-signals`
- `energy:mix:v1:_all` → `seed-meta:economic:owid-energy-mix`
- `supply_chain:transit-summaries:v1` → `seed-meta:supply_chain:transit-summaries`
- `relay:oref:history:v1` → `seed-meta:relay:oref:history` (new write added next to the existing `envelopeWrite` in `ais-relay.cjs`)

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` on the four touched files — clean (`npx biome lint <files>`)
- [x] `npx tsx --test tests/regional-snapshot.test.mjs tests/regional-snapshot-mobility.test.mjs` — 125 pass, 0 fail; the 5 new `#3728` cases and the updated mobility case all pass
- [x] Full `npm run test:data` — 9101 pass, 0 fail


## Review round 2

Reviewer approved with should-fixes — applied in commit `b6a4d5f6f`.

- **`scripts/ais-relay.cjs` (~line 1224)** — gated the `seed-meta:relay:oref:history` write on `envelopeWrite` returning `ok`. Previously the meta write could land alone if the envelope write failed (Upstash 5xx / network blip), letting the freshness classifier report FRESH for data that does not exist in Redis. Comment notes that the pre-existing `transit-summaries` write at ~line 7370 has the same shape and is intentionally out of scope (separate PR).
- **`scripts/regional-snapshot/snapshot-meta.mjs`** — `buildPreMeta` now snapshots a single `Date.now()` and passes it as a 4th arg to `deriveValidUntil`. The two-step (classify → derive) compute is now tick-consistent, so tests can assert exact `valid_until` values without timing tolerance.
- **`tests/regional-snapshot.test.mjs`** — split the misnamed 6h-cap test into (a) `"valid_until = min(input TTLs) when all inputs are fresh — tightest input wins"` and (b) `"valid_until is capped at now + 6h when ALL fresh inputs have TTL > 6h"`. The previous single test claimed to exercise the cap but the 15-min `relay:oref:history:v1` input always won, so the cap was never actually exercised. Test (b) restricts the sources map to registry entries with `maxAgeMin > 360min` so the cap is the binding constraint.
- **`tests/regional-snapshot.test.mjs`** — parameterized the metaKey-resolution test across all 5 newly-wired keys (`risk:scores:sebuf:stale:v1`, `intelligence:cross-source-signals:v1`, `energy:mix:v1:_all`, `supply_chain:transit-summaries:v1`, `relay:oref:history:v1`). Each runs as its own `it()` so a failure points at the specific key that regressed.

### Verification
- [x] `npm run typecheck` — clean
- [x] `npx tsx --test tests/regional-snapshot.test.mjs tests/regional-snapshot-mobility.test.mjs` — 132 pass / 0 fail (was 125; +4 parameterized metaKey cases, +1 split cap case, –1 replaced 6h-cap case = +4 net pass count adjustment)
- [x] `npm run test:data` — 9108 pass / 0 fail
- [x] `npx biome lint scripts/ais-relay.cjs scripts/regional-snapshot/snapshot-meta.mjs tests/regional-snapshot.test.mjs` — no new diagnostics introduced on changed lines (pre-existing warnings on unrelated lines remain)
