### PR TITLE
docs(readme): publish support status for site variants + desktop binaries (#3703)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ For the full feature list, architecture, data sources, and algorithms, see the *
 
 ---
 
+## Support Status
+
+All site variants and desktop binaries are built from a single codebase and ship from the same release process. The table below clarifies maintenance status so you know which surfaces are safe to depend on.
+
+| Surface | Status | Notes |
+|---------|--------|-------|
+| `worldmonitor.app`, `tech.`, `finance.`, `commodity.`, `happy.` | Stable | Public deployments built from this repo, actively maintained |
+| `energy.worldmonitor.app` | Experimental | Scaffolded but not advertised in the header badges; expect rough edges |
+| Desktop binaries (Windows / macOS Apple Silicon / macOS Intel / Linux AppImage) | Stable | One Tauri binary that switches variants in-app; current CI release targets are `full` and `tech` |
+
+Issues filed against any of the above are triaged from the same backlog — see the [issues board](https://github.com/koala73/worldmonitor/issues) for currently-open work.
+
+---
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## Summary

Per issue #3703, the README advertises five public site variants and four desktop download targets but never says which surfaces are stable, experimental, or unbuilt. Adds a tight Support Status table so users can tell what is safe to depend on.

## Findings (verified against the codebase)

- Five web variants in the badge row are all maintained (\`worldmonitor.app\`, \`tech.\`, \`finance.\`, \`commodity.\`, \`happy.\`).
- A sixth variant — \`energy.worldmonitor.app\` — exists in code (\`src/config/variant.ts\` handles its hostname and variant store) but is not in the header badges. Marking it experimental in the table lets users know rough edges are expected.
- Desktop binaries: the four download badges all point at \`worldmonitor.app/api/download\`, which serves a single Tauri binary that switches variants in-app via \`localStorage\`. CI release targets in \`.github/workflows/build-desktop.yml\` are \`full\` and \`tech\` only — \`tauri.finance.conf.json\` exists but is not in the dispatch list. The table explains both points.

## Test plan

- [x] \`npx markdownlint-cli2 README.md\` — 0 errors
- [x] Visual review — section fits cleanly between the feature list and Quick Start

Closes #3703