### PR TITLE
fix(prediction-markets): rank by conviction, not maximum uncertainty (#3735)

### DIFF
--- a/scripts/_prediction-scoring.mjs
+++ b/scripts/_prediction-scoring.mjs
@@ -54,10 +54,19 @@ export function shouldInclude(m, relaxed = false) {
   return true;
 }
 
+// Rank markets by crowd CONVICTION (distance from 50/50), not maximum
+// uncertainty. The analyst LLM should see the markets where collective
+// betting has converged on a directional answer, with volume as a tiebreaker.
+//
+// The previous formula inverted this — it weighted 50/50 markets highest,
+// burying high-signal contested markets (e.g. "Iran strike: 88% YES") below
+// coin-flip ones. See #3735 + #3726. Lopsided markets are not a concern here
+// because shouldInclude() already clips yesPrice to [10, 90] (relaxed [5, 95]),
+// so 99% locks-in never reach the ranker.
 export function scoreMarket(m) {
-  const uncertainty = 1 - (2 * Math.abs(m.yesPrice - 50) / 100);
+  const conviction = (2 * Math.abs(m.yesPrice - 50)) / 100;
   const vol = Math.log10(Math.max(m.volume, 1)) / Math.log10(10_000_000);
-  return (uncertainty * 0.6) + (Math.min(vol, 1) * 0.4);
+  return (conviction * 0.5) + (Math.min(vol, 1) * 0.5);
 }
 
 export function isExpired(endDate) {

--- a/tests/prediction-scoring.test.mjs
+++ b/tests/prediction-scoring.test.mjs
@@ -184,42 +184,55 @@ describe('shouldInclude', () => {
   });
 });
 
-describe('scoreMarket', () => {
-  it('50% price gets maximum uncertainty (0.6)', () => {
+describe('scoreMarket (conviction-weighted, post-#3735)', () => {
+  it('50% price gets minimum conviction — only volume contributes', () => {
+    // p=50 → conviction=0; score collapses to vol_term * 0.5.
     const score = scoreMarket(market('Test', 50, 1));
-    assert.ok(score >= 0.59, `50% market should have uncertainty ~0.6, got ${score}`);
+    assert.ok(score < 0.1, `coin-flip market at $1 volume should score near 0, got ${score}`);
   });
 
-  it('1% price gets near-zero uncertainty', () => {
-    const lowScore = scoreMarket(market('Test', 1, 10000));
-    const midScore = scoreMarket(market('Test', 50, 10000));
-    assert.ok(midScore > lowScore, `50% score (${midScore}) should beat 1% score (${lowScore})`);
+  it('high-conviction market outranks coin-flip at equal volume (#3735)', () => {
+    // The motivating example from the audit: "Iran strike: 88% YES" should
+    // surface above "Fed rate cut: 51%" when volumes are comparable.
+    const highConviction = scoreMarket(market('Iran military action', 88, 100000));
+    const coinFlip = scoreMarket(market('Fed rate cut', 51, 100000));
+    assert.ok(highConviction > coinFlip,
+      `88%/$100K (${highConviction}) should outrank 51%/$100K (${coinFlip})`);
   });
 
-  it('higher volume increases score', () => {
-    const lowVol = scoreMarket(market('Test', 50, 1000));
-    const highVol = scoreMarket(market('Test', 50, 1000000));
+  it('higher volume increases score at equal conviction', () => {
+    const lowVol = scoreMarket(market('Test', 70, 1000));
+    const highVol = scoreMarket(market('Test', 70, 1000000));
     assert.ok(highVol > lowVol, `$1M vol (${highVol}) should beat $1K vol (${lowVol})`);
   });
 
-  it('uncertainty dominates: 50%/$10K beats 10%/$10M', () => {
-    const uncertain = scoreMarket(market('Test', 50, 10000));
-    const certain = scoreMarket(market('Test', 10, 10000000));
-    assert.ok(uncertain > certain,
-      `50%/$10K (${uncertain}) should beat 10%/$10M (${certain}) — uncertainty weight 60%`);
+  it('within-band conviction beats coin-flip even on lower volume', () => {
+    // The previous formula buried this case (1% < 50% by uncertainty).
+    // After flip: 85% conviction at $10K beats 50% coin-flip at $10M as long
+    // as conviction's contribution exceeds the volume gap.
+    const convicted = scoreMarket(market('Convicted', 85, 100000));
+    const coinFlip = scoreMarket(market('Coin flip', 50, 10000000));
+    assert.ok(convicted > coinFlip,
+      `85%/$100K (${convicted}) should outrank 50%/$10M (${coinFlip}) — conviction signal beats volume`);
   });
 
   it('score bounded between 0 and 1', () => {
-    const s1 = scoreMarket(market('Test', 50, 10000000));
-    const s2 = scoreMarket(market('Test', 1, 1));
+    const s1 = scoreMarket(market('Test', 90, 10000000));
+    const s2 = scoreMarket(market('Test', 50, 1));
     assert.ok(s1 >= 0 && s1 <= 1, `score should be 0-1, got ${s1}`);
     assert.ok(s2 >= 0 && s2 <= 1, `score should be 0-1, got ${s2}`);
   });
 
-  it('symmetric: 40% and 60% get same uncertainty', () => {
+  it('symmetric around 50%: 40% and 60% get the same score', () => {
     const s40 = scoreMarket(market('Test', 40, 10000));
     const s60 = scoreMarket(market('Test', 60, 10000));
     assert.ok(Math.abs(s40 - s60) < 0.001, `40% (${s40}) and 60% (${s60}) should have same score`);
+  });
+
+  it('symmetric around 50%: 20% and 80% get the same score', () => {
+    const s20 = scoreMarket(market('Test', 20, 10000));
+    const s80 = scoreMarket(market('Test', 80, 10000));
+    assert.ok(Math.abs(s20 - s80) < 0.001, `20% (${s20}) and 80% (${s80}) should have same score`);
   });
 });
 
@@ -274,14 +287,17 @@ describe('filterAndScore', () => {
     assert.equal(result[0].title, 'AI regulation');
   });
 
-  it('sorts by composite score (most uncertain first)', () => {
+  it('sorts by composite score (highest conviction first, post-#3735)', () => {
+    // Conviction ordering at equal volume: 85% (Δ35) > 65% (Δ15) > 48% (Δ2)
     const candidates = [
-      market('Market A (certain)', 85, 100000, { endDate: '2099-01-01' }),
-      market('Market B (uncertain)', 48, 100000, { endDate: '2099-01-01' }),
+      market('Market A (high conviction)', 85, 100000, { endDate: '2099-01-01' }),
+      market('Market B (coin flip)', 48, 100000, { endDate: '2099-01-01' }),
       market('Market C (mid)', 65, 100000, { endDate: '2099-01-01' }),
     ];
     const result = filterAndScore(candidates, null);
-    assert.equal(result[0].title, 'Market B (uncertain)');
+    assert.equal(result[0].title, 'Market A (high conviction)');
+    assert.equal(result[1].title, 'Market C (mid)');
+    assert.equal(result[2].title, 'Market B (coin flip)');
   });
 
   it('respects limit parameter', () => {
@@ -325,10 +341,17 @@ describe('regression: meme market surfacing', () => {
     assert.ok(isMemeCandidate(m.title, m.yesPrice), 'should be flagged as meme');
   });
 
-  it('LeBron market scores lower than genuine uncertain market', () => {
-    const meme = scoreMarket(market('Will LeBron James win?', 1, 500000));
-    const real = scoreMarket(market('Will the Fed cut rates?', 48, 50000));
-    assert.ok(real > meme, `Real market (${real}) should score higher than meme (${meme})`);
+  it('LeBron meme market is dropped by filterAndScore, never reaches the analyst', () => {
+    // Direct scoreMarket comparison is meaningless after #3735 — a 1% meme
+    // would score high on conviction. The real guarantee is that shouldInclude
+    // + isMemeCandidate prune it before it ever reaches the ranker.
+    const meme = market('Will LeBron James win?', 1, 500000, { endDate: '2099-01-01' });
+    const real = market('Will the Fed cut rates?', 48, 50000, { endDate: '2099-01-01' });
+    const result = filterAndScore([meme, real], null);
+    assert.ok(!result.some(m => m.title.includes('LeBron')),
+      `LeBron meme must not reach the analyst output: ${result.map(m => m.title).join(', ')}`);
+    assert.ok(result.some(m => m.title.includes('Fed')),
+      'Genuine market should be present');
   });
 
   it('high-volume 99% market excluded by shouldInclude', () => {

--- a/tests/prediction-scoring.test.mjs
+++ b/tests/prediction-scoring.test.mjs
@@ -354,6 +354,31 @@ describe('regression: meme market surfacing', () => {
       'Genuine market should be present');
   });
 
+  // Companion to the filterAndScore drop-through test above. Adversarial review
+  // of #3785 noted that the filterAndScore test passes because the price floor
+  // (yesPrice < 10 strict / < 5 relaxed) catches the LeBron market BEFORE the
+  // meme regex ever runs — so loosening the price floor would silently neuter
+  // the meme-detection guarantee. This isolated test pins the meme detector
+  // itself: at the maximum price where isMemeCandidate's short-circuit still
+  // allows the regex to fire (yesPrice=14, one below the `>= 15` cutoff), the
+  // meme is correctly flagged. If someone moves or removes the short-circuit
+  // or drops the regex patterns, this test fails — independent of the price
+  // floor in shouldInclude.
+  it('isMemeCandidate detects LeBron meme up to its yesPrice<15 short-circuit boundary', () => {
+    assert.ok(
+      isMemeCandidate('Will LeBron James become president?', 14),
+      'meme regex must still fire at yesPrice=14 (one below the >=15 short-circuit)',
+    );
+    // Documented behavior, NOT a bug we are asserting away: at yesPrice >= 15
+    // the meme detector deliberately short-circuits to false (assumption:
+    // genuine market activity will not push an obvious meme above 15%). If
+    // this short-circuit is ever revisited, see #3735 follow-up.
+    assert.ok(
+      !isMemeCandidate('Will LeBron James become president?', 15),
+      'isMemeCandidate intentionally short-circuits at yesPrice >= 15',
+    );
+  });
+
   it('high-volume 99% market excluded by shouldInclude', () => {
     const m = market('Will the sun rise tomorrow?', 99, 10000000);
     assert.ok(!shouldInclude(m), '99% market excluded regardless of volume');


### PR DESCRIPTION
## Summary

Closes #3735 (from the external audit, #3726).

The prediction-market ranker that feeds the analyst LLM via `scripts/seed-prediction-markets.mjs` was scoring **50/50 coin-flip markets highest** and burying high-conviction signals like \"Iran strike: 88% YES\" below random contested markets at the same volume. That is the inverse of what an intelligence product wants.

## Root cause

`scripts/_prediction-scoring.mjs:57-60`:

\`\`\`js
const uncertainty = 1 - (2 * Math.abs(m.yesPrice - 50) / 100);  // max at p=50, drops to 0 at edges
return (uncertainty * 0.6) + (Math.min(vol, 1) * 0.4);
\`\`\`

## Fix

Replace \`uncertainty\` with its inverse, \`conviction\`, and rebalance the volume weight:

\`\`\`js
const conviction = (2 * Math.abs(m.yesPrice - 50)) / 100;  // max at edges, 0 at p=50
return (conviction * 0.5) + (Math.min(vol, 1) * 0.5);
\`\`\`

The conviction framing is safe here because the upstream filter `shouldInclude()` already clips `yesPrice` to `[10, 90]` (relaxed: `[5, 95]`) and `isMemeCandidate()` strips deep-OTM trash — so 99%-locks (\"Will the sun rise?\" / \"Trump won 2024 retro\") never reach the ranker. The naive failure mode of a high-conviction ranker (every 99% market dominates) doesn't apply.

## Numeric sanity check

Realistic input set, ranked by the new formula (descending):

| Score | Market | yesPrice | Volume | Note |
|---|---|---|---|---|
| 0.809 | Iran strike | 88% | \$1M | **Was buried before** |
| 0.686 | Low-vol high-conviction | 85% | \$50K | Conviction beats volume here |
| 0.628 | High-vol contested | 65% | \$5M | |
| 0.500 | Coin-flip big | 50% | \$10M | **Was top-ranked before** |
| 0.439 | Fed cut Q3 | 51% | \$1M | |

## Test updates

The existing tests in `tests/prediction-scoring.test.mjs` **codified the broken behavior**, so rewriting them is part of the fix:

- 6 tests in `describe('scoreMarket')` rewritten + 1 added (asymmetry around 20%/80%)
- `filterAndScore` \"sorts by composite score\" — now asserts the full ordering (high conviction → mid → coin flip), not just \`result[0]\`
- LeBron meme regression — old test directly compared \`scoreMarket()\` on a meme market that \`filterAndScore\` would already prune (meaningless after the flip). Rewrote to assert the real invariant: \`filterAndScore([meme, real])\` must drop the meme entirely.
- Added the issue's motivating example as a named regression: \"Iran 88% beats Fed 51% at equal volume\"

\`node --test tests/prediction-scoring.test.mjs\` → **55/55 pass**

## Test plan

- [x] All existing prediction-scoring tests updated and passing
- [x] New regression test for the issue's motivating example passes
- [x] Numeric sanity check on realistic inputs reproduces the expected ordering
- [ ] Reviewer to validate whether 0.5/0.5 conviction-vs-volume split is the right calibration (vs. 0.6/0.4 or 0.7/0.3)
- [ ] Optional: spot-check next analyst-LLM output to confirm contested high-conviction markets now surface

## Out of scope

- Recency weighting (markets that *moved* recently are highest-signal of all). Would require an upstream change to capture and propagate \`lastTradePrice\` deltas; tracked as a future enhancement.
- Tuning the [10, 90] bounds in `shouldInclude` — those are the right gate for the new ranker too.