### PR TITLE
test(security): defensive guard against client-bundle secret leaks (#3704)

### DIFF
--- a/tests/browser-bundle-secret-guard.test.mts
+++ b/tests/browser-bundle-secret-guard.test.mts
@@ -1,0 +1,120 @@
+/**
+ * Defensive guard for issue #3704.
+ *
+ * The reporter flagged that the browser runtime *appeared* to seed
+ * `WORLDMONITOR_API_KEY` (a server-side platform credential) into
+ * client-readable state. Investigation showed the architecture is
+ * actually safe today because:
+ *
+ *   1. Vite's default `envPrefix: 'VITE_'` blocks any unprefixed env
+ *      var from being inlined into `import.meta.env` in the browser
+ *      bundle. `WORLDMONITOR_API_KEY` has no prefix → invisible to
+ *      `readEnvSecret()` at runtime in web builds.
+ *
+ *   2. No entry in `RUNTIME_FEATURES.requiredSecrets` references
+ *      `WORLDMONITOR_API_KEY`, so `seedSecretsFromEnvironment()` never
+ *      iterates over it — the key isn't even attempted.
+ *
+ *   3. `vite.config.ts` does not pass `WORLDMONITOR_API_KEY` through
+ *      its `define:` block (which would inline the literal value into
+ *      the bundle regardless of `envPrefix`).
+ *
+ * These tests assert all three invariants so a future contributor who
+ * accidentally widens any of them gets a CI failure with a pointer
+ * back to issue #3704.
+ *
+ * To add another platform-only secret to the guard, extend
+ * `PLATFORM_ONLY_SECRETS` below.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+// Server-side secrets that MUST NOT cross into the browser bundle. Each
+// of these grants access to worldmonitor.app infrastructure (enterprise
+// API tier, signing keys, etc.) — distinct from per-user provider
+// credentials (GROQ_API_KEY, OPENROUTER_API_KEY) which users
+// legitimately enter via the desktop settings UI.
+const PLATFORM_ONLY_SECRETS = [
+  'WORLDMONITOR_API_KEY',
+] as const;
+
+async function readRepoFile(relPath: string): Promise<string> {
+  return readFile(new URL(`../${relPath}`, import.meta.url), 'utf8');
+}
+
+describe('browser bundle secret guard (#3704)', () => {
+  it('runtime-config.ts does not list a platform-only secret as a required feature secret', async () => {
+    const source = await readRepoFile('src/services/runtime-config.ts');
+    // `requiredSecrets: [...]` literals are what seedSecretsFromEnvironment iterates.
+    // Any platform-only key appearing inside one of those arrays would be
+    // attempted at runtime, so flag it.
+    const requiredSecretsBlocks = source.match(/requiredSecrets:\s*\[[^\]]*\]/g) ?? [];
+    for (const block of requiredSecretsBlocks) {
+      for (const secret of PLATFORM_ONLY_SECRETS) {
+        assert.ok(
+          !block.includes(`'${secret}'`) && !block.includes(`"${secret}"`),
+          `${secret} appears in a RUNTIME_FEATURES.requiredSecrets array. ` +
+            `Server-side platform secrets must not be seeded into the browser ` +
+            `runtime config. See issue #3704.`,
+        );
+      }
+    }
+  });
+
+  it('vite.config.ts does not inline platform-only secrets via define', async () => {
+    const source = await readRepoFile('vite.config.ts');
+    // `define:` injects literal values into the client bundle regardless
+    // of `envPrefix`. Flag any reference to a platform-only secret name
+    // inside the rough vicinity of a define block.
+    const defineMatch = source.match(/define:\s*\{[\s\S]{0,2000}?\n\s*\},/);
+    assert.ok(defineMatch, 'expected to find a define: block in vite.config.ts');
+    for (const secret of PLATFORM_ONLY_SECRETS) {
+      assert.ok(
+        !defineMatch[0].includes(secret),
+        `${secret} appears inside the vite.config.ts define: block. ` +
+          `That inlines the literal value into the browser bundle. See issue #3704.`,
+      );
+    }
+  });
+
+  it('vite.config.ts does not set a custom envPrefix that would expose unprefixed secrets', async () => {
+    const source = await readRepoFile('vite.config.ts');
+    // Vite's default is `envPrefix: 'VITE_'`. If a future contributor
+    // sets `envPrefix: ''` or includes a non-VITE_ prefix, unprefixed
+    // env vars (including platform secrets) become reachable via
+    // `import.meta.env` in the browser bundle.
+    const envPrefixMatch = source.match(/envPrefix\s*:\s*([^,\n}]+)/);
+    if (envPrefixMatch) {
+      const value = envPrefixMatch[1].trim();
+      assert.ok(
+        value.includes('VITE_') || value.includes('PUBLIC_'),
+        `vite.config.ts sets envPrefix=${value}; this must include the VITE_/PUBLIC_ ` +
+          `convention or unprefixed platform secrets become reachable from the ` +
+          `browser bundle. See issue #3704.`,
+      );
+    }
+    // No envPrefix override = Vite default = safe. No assertion needed.
+  });
+
+  it('readEnvSecret returns empty when import.meta.env lacks the platform secret', async () => {
+    // Dynamic import so the module loads in this Node test runner; the
+    // bundler-time `import.meta.env` shape matches what Vite produces.
+    const mod = await import('../src/services/runtime-config.ts');
+    // The module's exported public surface intentionally does not include
+    // readEnvSecret — assert via getRuntimeConfigSnapshot that no
+    // platform-only secret was seeded at module load time (default
+    // import.meta.env contains no platform secrets in node test env).
+    const snapshot = mod.getRuntimeConfigSnapshot();
+    for (const secret of PLATFORM_ONLY_SECRETS) {
+      assert.equal(
+        (snapshot.secrets as Record<string, unknown>)[secret],
+        undefined,
+        `${secret} was seeded into runtimeConfig.secrets at module load time. ` +
+          `Platform secrets must never appear in the browser runtime snapshot. ` +
+          `See issue #3704.`,
+      );
+    }
+  });
+});

--- a/tests/browser-bundle-secret-guard.test.mts
+++ b/tests/browser-bundle-secret-guard.test.mts
@@ -87,10 +87,12 @@ describe('browser bundle secret guard (#3704)', () => {
   it('vite.config.ts does not inline platform-only secrets via define', async () => {
     const source = await readRepoFile('vite.config.ts');
     // `define:` injects literal values into the client bundle regardless
-    // of `envPrefix`. Flag any reference to a platform-only secret name
-    // inside the rough vicinity of a define block.
+    // of `envPrefix`. We only need to inspect the block when it exists —
+    // a future refactor that removes the block entirely is strictly
+    // safer (nothing to accidentally inline) and must not fail this
+    // guard. Only validate contents when the block is present.
     const defineMatch = source.match(/define:\s*\{[\s\S]{0,2000}?\n\s*\},/);
-    assert.ok(defineMatch, 'expected to find a define: block in vite.config.ts');
+    if (!defineMatch) return;
     for (const secret of PLATFORM_ONLY_SECRETS) {
       assert.ok(
         !defineMatch[0].includes(secret),

--- a/tests/browser-bundle-secret-guard.test.mts
+++ b/tests/browser-bundle-secret-guard.test.mts
@@ -19,12 +19,13 @@
  *      its `define:` block (which would inline the literal value into
  *      the bundle regardless of `envPrefix`).
  *
- * These tests assert all three invariants so a future contributor who
- * accidentally widens any of them gets a CI failure with a pointer
- * back to issue #3704.
+ * These tests assert all three invariants for every entry in
+ * `PLATFORM_ONLY_SECRETS` so a future contributor who accidentally
+ * widens any of them gets a CI failure with a pointer back to issue
+ * #3704.
  *
- * To add another platform-only secret to the guard, extend
- * `PLATFORM_ONLY_SECRETS` below.
+ * To add another platform-only secret to the guard, extend the
+ * `PLATFORM_ONLY_SECRETS` constant below.
  */
 
 import { describe, it } from 'node:test';
@@ -32,13 +33,28 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
 // Server-side secrets that MUST NOT cross into the browser bundle. Each
-// of these grants access to worldmonitor.app infrastructure (enterprise
-// API tier, signing keys, etc.) — distinct from per-user provider
-// credentials (GROQ_API_KEY, OPENROUTER_API_KEY) which users
-// legitimately enter via the desktop settings UI.
+// of these grants access to worldmonitor.app infrastructure. They are
+// distinct from per-user provider credentials (GROQ_API_KEY,
+// OPENROUTER_API_KEY, etc.) which users legitimately enter via the
+// desktop settings UI.
 const PLATFORM_ONLY_SECRETS = [
+  // Enterprise tier key — possession grants enterprise API access (see
+  // api/_api-key.js validation against WORLDMONITOR_VALID_KEYS).
   'WORLDMONITOR_API_KEY',
+  // Allowlist of accepted enterprise keys — leaking it reveals all
+  // accepted keys at once.
+  'WORLDMONITOR_VALID_KEYS',
+  // Signs anonymous browser session tokens (see api/_session.js).
+  // Leakage lets attackers mint valid wms_ tokens.
+  'WM_SESSION_SECRET',
+  // Signs Pro MCP grants (see api/_mcp-grant-hmac.ts). Leakage lets
+  // attackers mint valid Pro MCP grants for arbitrary users.
+  'MCP_PRO_GRANT_HMAC_SECRET',
 ] as const;
+
+// Safe envPrefix entries — anything else exposes unprefixed env vars to
+// the browser bundle. Keep this list narrow.
+const SAFE_ENV_PREFIXES = ['VITE_', 'PUBLIC_'];
 
 async function readRepoFile(relPath: string): Promise<string> {
   return readFile(new URL(`../${relPath}`, import.meta.url), 'utf8');
@@ -50,6 +66,11 @@ describe('browser bundle secret guard (#3704)', () => {
     // `requiredSecrets: [...]` literals are what seedSecretsFromEnvironment iterates.
     // Any platform-only key appearing inside one of those arrays would be
     // attempted at runtime, so flag it.
+    //
+    // The regex assumes requiredSecrets stays a flat string array. If the
+    // shape ever changes (e.g. requiredSecrets: [{ key: 'X', tier: 'A' }]),
+    // the lazy `[^\]]*` will stop at the first inner `]` and miss content.
+    // Update this regex if/when that shape changes.
     const requiredSecretsBlocks = source.match(/requiredSecrets:\s*\[[^\]]*\]/g) ?? [];
     for (const block of requiredSecretsBlocks) {
       for (const secret of PLATFORM_ONLY_SECRETS) {
@@ -82,30 +103,53 @@ describe('browser bundle secret guard (#3704)', () => {
   it('vite.config.ts does not set a custom envPrefix that would expose unprefixed secrets', async () => {
     const source = await readRepoFile('vite.config.ts');
     // Vite's default is `envPrefix: 'VITE_'`. If a future contributor
-    // sets `envPrefix: ''` or includes a non-VITE_ prefix, unprefixed
-    // env vars (including platform secrets) become reachable via
-    // `import.meta.env` in the browser bundle.
-    const envPrefixMatch = source.match(/envPrefix\s*:\s*([^,\n}]+)/);
-    if (envPrefixMatch) {
-      const value = envPrefixMatch[1].trim();
+    // sets `envPrefix: ''`, includes a non-VITE_ prefix in an array form
+    // (`envPrefix: ['VITE_', '']`), or replaces the default with a
+    // narrower string that doesn't include VITE_/PUBLIC_, unprefixed env
+    // vars become reachable via `import.meta.env` in the browser bundle.
+    // Match either a string literal (`envPrefix: 'X'`) or a bracketed
+    // array (`envPrefix: ['A', 'B']`). The 200-char ceiling on array
+    // contents is generous — real values are <50 chars.
+    const envPrefixMatch = source.match(
+      /envPrefix\s*:\s*(\[[^\]]{0,200}\]|'[^']*'|"[^"]*")/,
+    );
+    if (!envPrefixMatch) {
+      // No envPrefix override = Vite default = safe.
+      return;
+    }
+
+    const raw = envPrefixMatch[1].trim();
+    // Parse JS-style string or array literal. We rewrite single quotes
+    // to double quotes so JSON.parse can handle the common case.
+    let value: unknown;
+    try {
+      value = JSON.parse(raw.replace(/'/g, '"'));
+    } catch {
+      assert.fail(
+        `vite.config.ts envPrefix has an unparseable value ${raw}. ` +
+          `Defensive guard for #3704 cannot verify entries.`,
+      );
+    }
+
+    const entries = Array.isArray(value) ? value : [value];
+    for (const entry of entries) {
       assert.ok(
-        value.includes('VITE_') || value.includes('PUBLIC_'),
-        `vite.config.ts sets envPrefix=${value}; this must include the VITE_/PUBLIC_ ` +
-          `convention or unprefixed platform secrets become reachable from the ` +
+        typeof entry === 'string' && SAFE_ENV_PREFIXES.some(safe => entry.startsWith(safe)),
+        `vite.config.ts envPrefix entry ${JSON.stringify(entry)} is not in the safe ` +
+          `prefix allowlist (${SAFE_ENV_PREFIXES.join(', ')}). Empty-string or ` +
+          `non-VITE_/PUBLIC_ entries expose unprefixed platform secrets to the ` +
           `browser bundle. See issue #3704.`,
       );
     }
-    // No envPrefix override = Vite default = safe. No assertion needed.
   });
 
-  it('readEnvSecret returns empty when import.meta.env lacks the platform secret', async () => {
-    // Dynamic import so the module loads in this Node test runner; the
-    // bundler-time `import.meta.env` shape matches what Vite produces.
+  it('runtime-config snapshot does not contain a platform-only secret at module load', async () => {
+    // Dynamic import so the module loads in this Node test runner. The
+    // Vite-injected `import.meta.env` is absent in node:test, so any
+    // platform secret that ends up in the snapshot here is provably
+    // coming from a non-Vite path (e.g. someone hard-coding the value
+    // in seedSecretsFromEnvironment or a default initializer).
     const mod = await import('../src/services/runtime-config.ts');
-    // The module's exported public surface intentionally does not include
-    // readEnvSecret — assert via getRuntimeConfigSnapshot that no
-    // platform-only secret was seeded at module load time (default
-    // import.meta.env contains no platform secrets in node test env).
     const snapshot = mod.getRuntimeConfigSnapshot();
     for (const secret of PLATFORM_ONLY_SECRETS) {
       assert.equal(


### PR DESCRIPTION
## Summary

A security report (#3704) suggested the browser runtime seeded \`WORLDMONITOR_API_KEY\` from \`import.meta.env\` into client-readable state. Investigation confirmed the architecture is **safe today** through two independent layers (full analysis posted on the issue), but \"safe today\" is only as durable as the next contributor's PR. This adds a CI guard that locks the invariants down.

## Three invariants enforced

1. **No platform-only secret listed in any \`RUNTIME_FEATURES.requiredSecrets\` array** — that's what \`seedSecretsFromEnvironment()\` iterates.
2. **No platform-only secret inlined via \`vite.config.ts\`'s \`define:\` block** — define would bypass envPrefix entirely.
3. **\`vite.config.ts\` does not set a custom \`envPrefix\` that drops the \`VITE_\`/\`PUBLIC_\` convention** — the default prefix is what keeps unprefixed env vars out of the browser bundle.

Plus a runtime smoke test that loads \`runtime-config.ts\` and asserts no platform-only secret appears in the snapshot.

Extending the guard to cover new platform-only secrets is one constant edit — add the name to \`PLATFORM_ONLY_SECRETS\` in the test file.

## Test plan

- [x] \`npx tsx --test tests/browser-bundle-secret-guard.test.mts\` — 4/4 pass
- [x] \`npm run typecheck\` — clean

Resolves #3704