### PR TITLE
fix(resilience): weight-attenuate langFactor instead of amplifying signal (#3736)

### DIFF
--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -73,6 +73,14 @@ interface WeightedMetric {
   // T1.7 schema pass: populated only when imputed=true so weightedBlend can
   // aggregate a dominant class at the dimension level.
   imputationClass?: ImputationClass;
+  // #3787 follow-up: design-time weight, used as the coverage-computation
+  // denominator share when the runtime `weight` has been attenuated by a
+  // confidence factor (e.g. langFactor in scoreInformationCognitive). Without
+  // this, attenuating `weight` shrinks the coverage denominator alongside the
+  // numerator and the dimension reports a HIGHER coverage for sparse-coverage
+  // countries — the inverse of the intended semantic. Omit when `weight` is
+  // already the nominal design-time value (default = weight).
+  nominalWeight?: number;
 }
 
 // Four-class imputation taxonomy (Phase 1 T1.7 of the country-resilience
@@ -648,12 +656,25 @@ function weightedBlend(metrics: WeightedMetric[]): ResilienceDimensionScore {
 
   const weightedScore = available.reduce((sum, metric) => sum + (metric.score || 0) * metric.weight, 0) / availableWeight;
 
-  // Coverage: weighted average of certainty per metric.
-  // Real data → 1.0; imputed (certaintyCoverage set) → partial; absent (null, no imputation) → 0.
+  // Coverage: weighted average of certainty per metric, computed against the
+  // NOMINAL design-time weight rather than the runtime weight. Real data → 1.0;
+  // imputed (certaintyCoverage set) → partial; absent (null, no imputation) → 0.
+  //
+  // The nominalWeight vs weight split matters whenever a caller attenuates
+  // `weight` by a confidence factor (e.g. scoreInformationCognitive scales
+  // velocity/threat sub-indicator weights by langFactor). If coverage were
+  // computed against the attenuated weights, the denominator would shrink
+  // alongside the numerator and sparse-coverage countries would report a
+  // HIGHER coverage than primary-coverage ones — the inverse of the intended
+  // semantic (#3787). Using nominalWeight keeps coverage as a stable
+  // measurement of "what fraction of designed signal we observed", independent
+  // of the confidence weighting applied to the score.
+  const totalNominalWeight = metrics.reduce((sum, metric) => sum + (metric.nominalWeight ?? metric.weight), 0);
   const weightedCertainty = metrics.reduce((sum, metric) => {
     const certainty = metric.certaintyCoverage ?? (metric.score != null ? 1 : 0);
-    return sum + metric.weight * certainty;
-  }, 0) / totalWeight;
+    const nominalWeight = metric.nominalWeight ?? metric.weight;
+    return sum + nominalWeight * certainty;
+  }, 0) / totalNominalWeight;
 
   // Track provenance: observed (real data) vs imputed weight.
   // Metrics with imputed=true → imputed (synthetic absence-based scores).
@@ -1981,15 +2002,23 @@ export async function scoreInformationCognitive(
   // signal. Apply `langFactor` to the WEIGHT of those sub-indicators, not to
   // the signal value itself. Raw signals flow through unchanged; coverage-poor
   // countries lean more heavily on the static RSF press-freedom indicator
-  // (which IS coverage-independent and the most reliable annual signal). The
-  // overall dimension `coverage` field also drops for sparse-coverage countries,
-  // surfacing the lower confidence to downstream consumers.
+  // (which IS coverage-independent and the most reliable annual signal).
+  //
+  // #3787 follow-up: the velocity/threat sub-indicators also pass `nominalWeight`
+  // so that `weightedBlend` computes the dimension's `coverage` field against
+  // the un-attenuated design-time weights (0.15 + 0.30 + 0.55 = 1.0). Without
+  // this, attenuating `weight` would shrink the coverage denominator alongside
+  // the numerator, and a minimal-coverage country reporting the same data shape
+  // as a primary-coverage country would inadvertently report a HIGHER coverage
+  // value — the inverse of the intended semantic. With nominalWeight, coverage
+  // stays a stable measurement of "what fraction of designed signal we observed"
+  // independent of the confidence-weighting applied to the score.
   const langFactor = getLanguageCoverageFactor(countryCode);
 
   return weightedBlend([
     { score: rsfScore == null ? null : normalizeLowerBetter(rsfScore, 0, 100), weight: 0.55 },
-    { score: velocity > 0 ? normalizeLowerBetter(Math.log10(velocity + 1), 0, 3) : null, weight: 0.15 * langFactor },
-    { score: threatScore == null ? null : normalizeLowerBetter(threatScore, 0, 20), weight: 0.30 * langFactor },
+    { score: velocity > 0 ? normalizeLowerBetter(Math.log10(velocity + 1), 0, 3) : null, weight: 0.15 * langFactor, nominalWeight: 0.15 },
+    { score: threatScore == null ? null : normalizeLowerBetter(threatScore, 0, 20), weight: 0.30 * langFactor, nominalWeight: 0.30 },
   ]);
 }
 

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -1968,14 +1968,28 @@ export async function scoreInformationCognitive(
   const velocity = summarizeSocialVelocity(socialVelocityRaw, countryCode);
   const threatScore = getThreatSummaryScore(threatSummaryRaw, countryCode);
 
+  // Language-coverage adjustment (fixes #3736).
+  //
+  // The previous implementation divided raw velocity + threatScore by
+  // `langFactor` (range 0.2..1.0), which AMPLIFIED signal for countries with
+  // sparse English-language news coverage by up to 5x. Effect: a small uptick
+  // in coverage-poor countries scored worse than a substantial signal in
+  // coverage-rich ones — exactly the inverse of what the data justifies.
+  //
+  // Correct framing: sparse English coverage means LOW CONFIDENCE in the
+  // observable velocity/threat sub-signals, not a higher inferred underlying
+  // signal. Apply `langFactor` to the WEIGHT of those sub-indicators, not to
+  // the signal value itself. Raw signals flow through unchanged; coverage-poor
+  // countries lean more heavily on the static RSF press-freedom indicator
+  // (which IS coverage-independent and the most reliable annual signal). The
+  // overall dimension `coverage` field also drops for sparse-coverage countries,
+  // surfacing the lower confidence to downstream consumers.
   const langFactor = getLanguageCoverageFactor(countryCode);
-  const adjustedVelocity = velocity > 0 ? Math.min(velocity / Math.max(langFactor, 0.1), 1000) : 0;
-  const adjustedThreat = threatScore != null ? Math.min(threatScore / Math.max(langFactor, 0.1), 100) : null;
 
   return weightedBlend([
     { score: rsfScore == null ? null : normalizeLowerBetter(rsfScore, 0, 100), weight: 0.55 },
-    { score: adjustedVelocity > 0 ? normalizeLowerBetter(Math.log10(adjustedVelocity + 1), 0, 3) : null, weight: 0.15 },
-    { score: adjustedThreat == null ? null : normalizeLowerBetter(adjustedThreat, 0, 20), weight: 0.3 },
+    { score: velocity > 0 ? normalizeLowerBetter(Math.log10(velocity + 1), 0, 3) : null, weight: 0.15 * langFactor },
+    { score: threatScore == null ? null : normalizeLowerBetter(threatScore, 0, 20), weight: 0.30 * langFactor },
   ]);
 }
 

--- a/server/worldmonitor/resilience/v1/_indicator-registry.ts
+++ b/server/worldmonitor/resilience/v1/_indicator-registry.ts
@@ -847,10 +847,11 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
   },
 
   // ── informationCognitive (3 sub-metrics) ──────────────────────────────────
-  // Promoted back to Core in T2.9 after language / source-density
-  // normalization landed (getLanguageCoverageFactor in _language-coverage.ts).
-  // Social velocity and news threat scores are now adjusted by the
-  // English-language coverage factor before normalization.
+  // The velocity + news-threat sub-indicators are weight-attenuated by
+  // `getLanguageCoverageFactor` (_language-coverage.ts) so that countries with
+  // sparse English-language news coverage lean more heavily on the static RSF
+  // press-freedom indicator (which is coverage-independent). See #3736 for the
+  // earlier divide-amplification bug this replaced.
   {
     id: 'rsfPressFreedom',
     dimension: 'informationCognitive',
@@ -869,7 +870,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
   {
     id: 'socialVelocity',
     dimension: 'informationCognitive',
-    description: 'Reddit social velocity score (log10(velocity+1)); language-normalized viral narrative stress',
+    description: 'Reddit social velocity score (log10(velocity+1)); sub-indicator weight scales with English-language coverage',
     direction: 'lowerBetter',
     goalposts: { worst: 3, best: 0 },
     weight: 0.15,
@@ -884,7 +885,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
   {
     id: 'newsThreatScore',
     dimension: 'informationCognitive',
-    description: 'AI news threat summary (critical=4x, high=2x, medium=1x, low=0.5x); language-normalized',
+    description: 'AI news threat summary (critical=4x, high=2x, medium=1x, low=0.5x); sub-indicator weight scales with English-language coverage',
     direction: 'lowerBetter',
     goalposts: { worst: 20, best: 0 },
     weight: 0.3,

--- a/tests/resilience-dimension-scorers.test.mts
+++ b/tests/resilience-dimension-scorers.test.mts
@@ -493,37 +493,58 @@ describe('resilience dimension scorers', () => {
     assert.ok(score.score === 20, `RSF only (no threat, no velocity), got ${score.score}`);
   });
 
-  // Regression for #3736 — the old implementation divided raw velocity/threat
-  // by `langFactor`, amplifying signal for minimal-coverage countries by up to
-  // 5x. The fix attenuates the sub-indicator WEIGHTS by langFactor instead;
-  // raw signal values flow through unchanged. Identical signal payloads must
-  // therefore NOT produce a worse score for a minimal-coverage country.
-  it('scoreInformationCognitive: identical signals do not amplify a minimal-coverage country (#3736)', async () => {
-    // Same RSF + same observable threat signal wired for both US (primary,
-    // langFactor=1.0) and BF (unlisted -> minimal, langFactor=0.2).
-    // `byCountry` is keyed on the actual ISO2 each scorer queries with.
+  // Regression for #3736 / #3787 — the old implementation divided raw
+  // velocity/threat by `langFactor`, amplifying signal for minimal-coverage
+  // countries up to 5x. The fix attenuates the sub-indicator WEIGHTS by
+  // langFactor instead; raw signal values flow through unchanged.
+  //
+  // This test pins the EXACT post-fix scores so regressions in either
+  // direction are caught:
+  //   - Re-introducing divide-amplification would saturate BF's threat
+  //     score at the worst goalpost, collapsing BF.score to ~26.
+  //   - Attenuating weights too aggressively (e.g. `weight: 0` instead of
+  //     `weight: 0.30 * langFactor`) would pin BF.score to its RSF-only
+  //     baseline of 40.
+  //   - The correct fix lands BF.score ≈ 41 (RSF dominates but threat still
+  //     contributes a small attenuated weight).
+  //
+  // Threat sub-signal is chosen to be BELOW the worst-goalpost (20) so it
+  // produces a discriminating normalized value (not clamped to 0) under
+  // both the old and new formulas — the bug the v1 of this test missed.
+  it('scoreInformationCognitive: weight-attenuation produces specific scores per langFactor tier (#3736 / #3787)', async () => {
+    // Threat = 0*4 + 2*2 + 4*1 + 2*0.5 = 9 (below worst-goalpost of 20).
+    // RSF = 60 → normalizeLowerBetter(60, 0, 100) = 40.
+    // Threat = 9 → normalizeLowerBetter(9, 0, 20) = 55.
     const makeReader = (iso: string) => async (key: string): Promise<unknown | null> => {
       if (key === `resilience:static:${iso}`) return { rsf: { score: 60, rank: 50, year: 2025 } };
       if (key === 'intelligence:social:reddit:v1') return { posts: [] };
       if (key === 'news:threat:summary:v1') return {
-        byCountry: { [iso]: { critical: 4, high: 6, medium: 8, low: 4 } },
+        byCountry: { [iso]: { critical: 0, high: 2, medium: 4, low: 2 } },
         generatedAt: '2026-04-06T00:00:00.000Z',
       };
       return null;
     };
 
-    const primary = await scoreInformationCognitive('US', makeReader('US'));
-    const minimal = await scoreInformationCognitive('BF', makeReader('BF'));
+    const primary = await scoreInformationCognitive('US', makeReader('US')); // lf=1.0
+    const minimal = await scoreInformationCognitive('BF', makeReader('BF')); // lf=0.2
 
-    // The old divide-amplification bug would have driven minimal STRICTLY
-    // WORSE than primary on identical inputs (the same threat score scaled
-    // up 5x for BF). The weight-attenuation fix means minimal can only equal
-    // or score better here, because its threat sub-indicator contributes
-    // less weight and the (identical) RSF score dominates more.
-    assert.ok(
-      minimal.score >= primary.score,
-      `minimal-coverage country must not score worse than primary on identical signals (regression #3736): primary=${primary.score}, minimal=${minimal.score}`,
-    );
+    // US (lf=1.0): (40*0.55 + 55*0.30) / (0.55+0.30) = 38.5 / 0.85 = 45.29
+    assert.equal(Math.round(primary.score), 45,
+      `US (primary, lf=1.0) should score ~45 on this fixture; got ${primary.score}. Likely a regression in the weight or normalize logic.`);
+
+    // BF (lf=0.2): (40*0.55 + 55*0.06) / (0.55+0.06) = 25.3 / 0.61 = 41.48
+    // Under the old divide-amplification bug, this would have been ~26 (threat
+    // saturates at worst-goalpost). Under "attenuate too hard" (weight=0), this
+    // would be exactly 40 (RSF-only). The 41 value is the correct fix.
+    assert.equal(Math.round(minimal.score), 41,
+      `BF (minimal, lf=0.2) should score ~41 on this fixture; got ${minimal.score}. Likely a regression: divide-amplification re-introduced (~26) or attenuation too aggressive (~40).`);
+
+    // #3787 fix: coverage must NOT invert between sparse and primary countries.
+    // With `nominalWeight` on the attenuated sub-indicators, both countries
+    // observe the same fraction of designed signal (RSF + threat with data,
+    // velocity null) and must report the same coverage value.
+    assert.equal(primary.coverage, minimal.coverage,
+      `coverage must be identical for primary and minimal countries with identical signal availability (#3787 coverage-inversion regression): primary.coverage=${primary.coverage}, minimal.coverage=${minimal.coverage}`);
   });
 
   it('scoreBorderSecurity: zero UCDP events still scores (UCDP is global registry)', async () => {

--- a/tests/resilience-dimension-scorers.test.mts
+++ b/tests/resilience-dimension-scorers.test.mts
@@ -493,6 +493,39 @@ describe('resilience dimension scorers', () => {
     assert.ok(score.score === 20, `RSF only (no threat, no velocity), got ${score.score}`);
   });
 
+  // Regression for #3736 — the old implementation divided raw velocity/threat
+  // by `langFactor`, amplifying signal for minimal-coverage countries by up to
+  // 5x. The fix attenuates the sub-indicator WEIGHTS by langFactor instead;
+  // raw signal values flow through unchanged. Identical signal payloads must
+  // therefore NOT produce a worse score for a minimal-coverage country.
+  it('scoreInformationCognitive: identical signals do not amplify a minimal-coverage country (#3736)', async () => {
+    // Same RSF + same observable threat signal wired for both US (primary,
+    // langFactor=1.0) and BF (unlisted -> minimal, langFactor=0.2).
+    // `byCountry` is keyed on the actual ISO2 each scorer queries with.
+    const makeReader = (iso: string) => async (key: string): Promise<unknown | null> => {
+      if (key === `resilience:static:${iso}`) return { rsf: { score: 60, rank: 50, year: 2025 } };
+      if (key === 'intelligence:social:reddit:v1') return { posts: [] };
+      if (key === 'news:threat:summary:v1') return {
+        byCountry: { [iso]: { critical: 4, high: 6, medium: 8, low: 4 } },
+        generatedAt: '2026-04-06T00:00:00.000Z',
+      };
+      return null;
+    };
+
+    const primary = await scoreInformationCognitive('US', makeReader('US'));
+    const minimal = await scoreInformationCognitive('BF', makeReader('BF'));
+
+    // The old divide-amplification bug would have driven minimal STRICTLY
+    // WORSE than primary on identical inputs (the same threat score scaled
+    // up 5x for BF). The weight-attenuation fix means minimal can only equal
+    // or score better here, because its threat sub-indicator contributes
+    // less weight and the (identical) RSF score dominates more.
+    assert.ok(
+      minimal.score >= primary.score,
+      `minimal-coverage country must not score worse than primary on identical signals (regression #3736): primary=${primary.score}, minimal=${minimal.score}`,
+    );
+  });
+
   it('scoreBorderSecurity: zero UCDP events still scores (UCDP is global registry)', async () => {
     const reader = async (key: string): Promise<unknown | null> => {
       if (key === 'conflict:ucdp-events:v1') return { events: [] };


### PR DESCRIPTION
## Summary

Closes #3736 (from the external audit, #3726).

\`scoreInformationCognitive\` divided raw social-velocity and news-threat signals by \`langFactor\` (range 0.2..1.0) before normalization. The intent was to compensate for English-language news coverage gaps; the actual effect was **5x signal amplification** for countries with minimal English coverage. A small uptick in a coverage-poor country scored worse than a substantial signal in a coverage-rich one — exactly the inverse of what the underlying evidence justifies.

## Root cause

\`server/worldmonitor/resilience/v1/_dimension-scorers.ts:1912-1914\` (pre-fix):

\`\`\`ts
const langFactor = getLanguageCoverageFactor(countryCode);
const adjustedVelocity = velocity > 0 ? Math.min(velocity / Math.max(langFactor, 0.1), 1000) : 0;
const adjustedThreat   = threatScore != null ? Math.min(threatScore / Math.max(langFactor, 0.1), 100) : null;
\`\`\`

Dividing by \`langFactor\` ∈ [0.2, 1.0] is mathematically AMPLIFICATION (×5 at the floor). The audit's reproduction case: Country A (langFactor=1.0, velocity=50, threat=8) and Country B (langFactor=0.2, velocity=5, threat=0.8) produce identical scoring inputs despite A having 10× as much observable evidence.

## Fix

Reframe: low coverage is **low confidence in the sub-indicator**, not "the real signal is higher." Apply \`langFactor\` to the **WEIGHT** of the velocity and threat sub-indicators rather than to their signal values:

\`\`\`ts
return weightedBlend([
  { score: rsfScore, weight: 0.55 },
  { score: velocity > 0 ? normalizeLowerBetter(Math.log10(velocity + 1), 0, 3) : null, weight: 0.15 * langFactor, nominalWeight: 0.15 },
  { score: threatScore, weight: 0.30 * langFactor, nominalWeight: 0.30 },
]);
\`\`\`

- Raw signals flow through unchanged (no fabricated magnitude)
- Coverage-poor countries lean more heavily on the static RSF press-freedom indicator (which IS coverage-independent and the most reliable annual signal)
- Coverage-rich countries' scoring is unchanged (\`langFactor=1.0\`)

### The \`nominalWeight\` field (commit 39eb35b4, from adversarial review)

The first version of this PR attenuated the runtime \`weight\` but the coverage formula in \`weightedBlend\` normalizes against \`totalWeight\`. When weight shrinks, the denominator shrinks alongside the numerator → a minimal-coverage country with the same observed-data shape as a primary-coverage country reported a **HIGHER** coverage value (0.95 vs 0.85), the inverse of the intended semantic. Since the widget surfaces \`coverage\` as the headline confidence number (\`src/components/resilience-widget-utils.ts\`), that was a worse regression than the original bug.

Added an optional \`nominalWeight\` field to \`WeightedMetric\`. When set, \`weightedBlend\` uses it as the coverage-computation denominator share in place of the (possibly attenuated) \`weight\`. Score blending continues to use \`weight\`. The change is fully backward-compatible — all ~17 existing callers of \`weightedBlend\` pass no \`nominalWeight\`, so the formula degenerates to \`metric.weight\` and behavior is unchanged for every other scorer.

## Numeric sanity check (post fix-up)

At rsf=60 + identical threat signal (critical:4, high:6, medium:8, low:4 — clamps to 0 via normalizeLowerBetter) across tiers:

| Country | Tier | langFactor | Score | Coverage |
|---|---|---|---|---|
| US | primary | 1.0 | 26.0 | 0.85 |
| IN | secondary | 0.7 | 29.0 | 0.85 |
| FR | limited | 0.4 | 33.0 | 0.85 |
| BF | minimal (default) | 0.2 | 36.0 | 0.85 |

Lower score = worse on this dimension. **Under the old divide-amplification bug, BF would have scored strictly worse than US on identical inputs**; under the fix, BF trends toward its RSF-only baseline. **Coverage is now identical at 0.85 across tiers** (all countries observe the same data shape), correctly reflecting "what fraction of designed signal we observed" independent of the confidence-weighting applied to the score.

## Test plan

- [x] **New pinned-value regression test** — \`scoreInformationCognitive: weight-attenuation produces specific scores per langFactor tier (#3736 / #3787)\`. Pins US to score 45 and BF to score 41 on a discriminating fixture (threat=9, below the worst-goalpost). The old divide-amplification bug would have collapsed BF to ~26; "attenuate too hard" (weight=0) would pin BF to 40. The 41 value is the correct fix. Also asserts \`primary.coverage === minimal.coverage\` to lock the \`nominalWeight\` fix.
- [x] All 3 existing \`scoreInformationCognitive\` tests pass.
- [x] Country-ordering invariant test (NO ≥ US > YE for informationCognitive) still passes — RSF dominance preserves it.
- [x] Full resilience suite: **741/741 pass** (verified with node_modules linked into the temp worktree).

## Out of scope (audit's secondary ask, tracked as follow-up)

The audit's \"add an \`adjustmentFlag\` to the response when \`langFactor < 0.5\` so callers can treat the score as adjusted rather than observed\" requires a proto + UI change. The immediate amplification bug + the coverage-inversion regression are both closed by this PR; the transparency-flag work is a separate ticket.

Also out of scope: the country→tier table in \`_language-coverage.ts\` itself encodes editorial judgments (e.g., the listing of Nordic countries at \`limited\` rather than \`primary\` is debatable). The audit's broader \"hidden editorial constants\" thesis is addressed by the #3725 / #3722 methodology rework in another session.

## Risk

This DOES change observable dimension scores for the ~150 countries that are not in the \`primary\` tier. Coverage-poor countries will see their \`informationCognitive\` score shift UP (less bad) because their dynamic sub-indicators no longer fabricate magnitude. Documented in the registry comment and CHANGELOG-worthy.