### PR TITLE
fix(resilience): relabel borderSecurity to 'Conflict & Displacement' (#3737)

### DIFF
--- a/docs/methodology/country-resilience-index.mdx
+++ b/docs/methodology/country-resilience-index.mdx
@@ -60,7 +60,7 @@ The index is organized into 6 domains. Each domain weight reflects its relative 
 | Economic | `economic` | 0.17 | Macro-Fiscal, Currency & External, Trade Policy, Financial System Exposure |
 | Infrastructure | `infrastructure` | 0.15 | Cyber & Digital, Logistics & Supply, Infrastructure |
 | Energy | `energy` | 0.11 | Energy |
-| Social & Governance | `social-governance` | 0.19 | Governance, Social Cohesion, Border Security, Information |
+| Social & Governance | `social-governance` | 0.19 | Governance, Social Cohesion, Conflict & Displacement, Information |
 | Health & Food | `health-food` | 0.13 | Health & Public Service, Food & Water |
 | Recovery | `recovery` | 0.25 | Fiscal Space, Reserve Adequacy, External Debt Coverage, Import Concentration, State Continuity, Fuel Stock Days |
 
@@ -252,7 +252,13 @@ still observed. Seed-outage paths (raw payload absent) continue to
 drop the weight rather than imputing — the outage-vs-absence
 distinction is preserved.
 
-#### Border Security
+#### Conflict & Displacement
+
+This dimension measures **armed-conflict event intensity and refugee
+displacement**. It does **not** measure border-control infrastructure,
+customs throughput, or cross-border-crime enforcement. The internal
+identifier is `borderSecurity` for proto / cache-key stability; the
+relabeling is tracked in #3737.
 
 | Indicator | Description | Direction | Goalposts (worst-best) | Weight | Source | Cadence |
 |---|---|---|---|---|---|---|

--- a/docs/methodology/known-limitations.md
+++ b/docs/methodology/known-limitations.md
@@ -13,8 +13,10 @@ NOT being fixed.
 ## Displacement field-mapping (scoreSocialCohesion / scoreBorderSecurity / scoreStateContinuity)
 
 **Dimensions.** `socialCohesion` (weight 0.25 of the blend),
-`borderSecurity` (weight 0.35 of the blend), `stateContinuity`
-(weight 0.20 of the blend).
+`borderSecurity` / "Conflict & Displacement" (weight 0.35 of the
+blend; see #3737 — internal id is `borderSecurity` but the dimension
+measures armed conflict + displacement, not border infrastructure),
+`stateContinuity` (weight 0.20 of the blend).
 
 **Source.** UNHCR Population API
 (`https://api.unhcr.org/population/v1/population/`), written via
@@ -72,9 +74,9 @@ effectively dead code.** The scorer reads
 `_dimension-scorers.ts`. Intent (from the surrounding comments):
 
 - Primary (`hostTotal`): how many UNHCR-registered people this
-  country hosts → direct border-security signal.
+  country hosts → host-inflow displacement signal.
 - Fallback (`totalDisplaced`): how many of this country's people
-  are displaced → indirect border-security signal for
+  are displaced → origin-outflow displacement signal for
   origin-dominated countries.
 
 **Discovered during this audit**: the fallback **does not fire in
@@ -100,12 +102,16 @@ dim). The actual signal is never picked up. Turkey-pattern
 
 **Why not fixing this today.** A one-line change (`||` instead of
 `??`, or `hostTotal > 0 ? hostTotal : totalDisplaced`) would
-flip the borderSecurity score for ~6 high-outflow origin
-countries by a material amount — a methodology change, not a
-pure bug-fix. That belongs in a construct-decision PR with a
+flip the dimension score for ~6 high-outflow origin countries
+by a material amount — a methodology change, not a pure
+bug-fix. That belongs in a construct-decision PR with a
 cohort-audit snapshot before/after, not bundled into an audit
-doc PR. Opening a follow-up to decide: should borderSecurity
-reflect origin-outflow pressure, host-inflow pressure, or both?
+doc PR. Opening a follow-up to decide: should the dimension
+reflect origin-outflow displacement, host-inflow displacement,
+or both? (Separately, the dimension was relabeled to
+"Conflict & Displacement" in #3737 because it doesn't measure
+border infrastructure regardless of which displacement source
+fires.)
 
 **Test pin.** `tests/resilience-displacement-field-mapping.test.mts`
 pins the CURRENT behavior (Syria-pattern scores 100 on this

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -1915,6 +1915,20 @@ export async function scoreSocialCohesion(
   return weightedBlend([gpiRow, displacementRow, unrestRow]);
 }
 
+// #3737 — despite the legacy `scoreBorderSecurity` / `borderSecurity` name,
+// this scorer measures UCDP armed-conflict event intensity and UNHCR
+// refugee displacement. It does NOT measure border-control infrastructure,
+// customs throughput, or cross-border-crime enforcement.
+//
+// The user-facing label is "Conflict" / "Conflict & Displacement" in the
+// widget and methodology docs respectively. The internal identifier is
+// retained as `borderSecurity` because the proto enum, Redis cache prefixes,
+// snapshot fixtures, and dozens of downstream tests are keyed on it — a
+// rename would cascade through ~100 files for a string the user never sees.
+//
+// If/when this dimension is replaced with genuine border-control indicators
+// (UNODC cross-border crime, FRONTEX/WCO data, CBP seizure stats), introduce
+// the new dimension under a fresh id and migrate cleanly.
 export async function scoreBorderSecurity(
   countryCode: string,
   reader: ResilienceSeedReader = defaultSeedReader,

--- a/server/worldmonitor/resilience/v1/_indicator-registry.ts
+++ b/server/worldmonitor/resilience/v1/_indicator-registry.ts
@@ -809,7 +809,11 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     comprehensive: false,
   },
 
-  // ── borderSecurity (2 sub-metrics) ────────────────────────────────────────
+  // ── borderSecurity / "Conflict & Displacement" (2 sub-metrics) ───────────
+  // #3737 — internal id stays `borderSecurity` for proto / cache stability,
+  // but the dimension measures armed-conflict event intensity + refugee
+  // displacement, not border-control infrastructure. User-facing label is
+  // "Conflict" (widget) / "Conflict & Displacement" (methodology doc).
   {
     id: 'ucdpConflict',
     dimension: 'borderSecurity',

--- a/src/components/resilience-widget-utils.ts
+++ b/src/components/resilience-widget-utils.ts
@@ -301,7 +301,10 @@ const DIMENSION_LABELS: Record<string, string> = {
   energy: 'Energy',
   governanceInstitutional: 'Gov',
   socialCohesion: 'Social',
-  borderSecurity: 'Border',
+  // #3737 — internal id is `borderSecurity` for proto/cache stability,
+  // but the dimension measures UCDP armed conflict events + UNHCR
+  // displacement, not border infrastructure. Surface the truthful label.
+  borderSecurity: 'Conflict',
   informationCognitive: 'Info',
   healthPublicService: 'Health',
   foodWater: 'Food',

--- a/tests/resilience-methodology-lint.test.mts
+++ b/tests/resilience-methodology-lint.test.mts
@@ -43,7 +43,10 @@ const HEADING_TO_DIMENSION: Readonly<Record<string, ResilienceDimensionId>> = {
   'Energy': 'energy',
   'Governance': 'governanceInstitutional',
   'Social Cohesion': 'socialCohesion',
-  'Border Security': 'borderSecurity',
+  // #3737 — methodology doc heading relabeled from 'Border Security' to match
+  // what the scorer actually measures. Internal id `borderSecurity` retained
+  // for proto / cache-key stability.
+  'Conflict & Displacement': 'borderSecurity',
   'Information & Cognitive': 'informationCognitive',
   'Health & Public Service': 'healthPublicService',
   'Food & Water': 'foodWater',

--- a/tests/resilience-widget.test.mts
+++ b/tests/resilience-widget.test.mts
@@ -230,7 +230,10 @@ test('getResilienceDimensionLabel returns short stable labels for all 22 dimensi
   assert.equal(getResilienceDimensionLabel('energy'), 'Energy');
   assert.equal(getResilienceDimensionLabel('governanceInstitutional'), 'Gov');
   assert.equal(getResilienceDimensionLabel('socialCohesion'), 'Social');
-  assert.equal(getResilienceDimensionLabel('borderSecurity'), 'Border');
+  // #3737 — relabeled from 'Border' so the displayed dimension name matches
+  // what it actually measures (UCDP conflict + UNHCR displacement, not border
+  // control infrastructure). Internal id stays `borderSecurity` for stability.
+  assert.equal(getResilienceDimensionLabel('borderSecurity'), 'Conflict');
   assert.equal(getResilienceDimensionLabel('informationCognitive'), 'Info');
   assert.equal(getResilienceDimensionLabel('healthPublicService'), 'Health');
   assert.equal(getResilienceDimensionLabel('foodWater'), 'Food');


### PR DESCRIPTION
## Summary

Closes #3737 (from the external audit, #3726).

The \`borderSecurity\` resilience dimension does **not** measure border security. It measures:
- **65% UCDP armed conflict events** (battles, explosions, violence against civilians)
- **35% UNHCR refugee + IDP displacement**

The audit's mislabeling examples hold up against the current implementation:
- **Jordan** hosts ~780k UNHCR-registered refugees behind tight, internationally-monitored borders. Under the current scorer it lands poorly on \"Border Security\" because of the displacement figure.
- **Iceland** has near-zero conflict and negligible displacement. Schengen-open borders, essentially no border-control infrastructure. Scores near-perfect on \"Border Security.\"

When the analyst LLM is told a country \"scores poorly on Border Security,\" it is being told the country has high armed-conflict activity — and any downstream reasoning about border management, customs, or migration proceeds from a mislabeled input.

## Scoped fix

**Relabel every user-facing surface; keep the internal \`borderSecurity\` key.** Renaming the internal identifier would cascade through the proto enum, Redis cache prefixes, snapshot fixtures, and ~100 downstream files for a string the user never sees. The audit's primary harm is at the label layer; the internal id is a separate refactor.

| File | Change |
|---|---|
| \`src/components/resilience-widget-utils.ts\` | Widget compact label \`'Border'\` → \`'Conflict'\` |
| \`docs/methodology/country-resilience-index.mdx\` | Section heading + table row \`Border Security\` → \`Conflict & Displacement\`; added a paragraph explicitly noting what the dimension does NOT measure + the deferred-rename rationale |
| \`server/worldmonitor/resilience/v1/_dimension-scorers.ts\` | 11-line comment header on \`scoreBorderSecurity\` explaining the legacy id, the user-facing label, and the path for genuine border-control indicators if/when they're added |
| \`server/worldmonitor/resilience/v1/_indicator-registry.ts\` | Matching clarification on the registry header for the dimension |
| \`tests/resilience-widget.test.mts\` | Assertion now expects \`'Conflict'\`; comment cites #3737 |
| \`tests/resilience-methodology-lint.test.mts\` | \`HEADING_TO_DIMENSION\` map entry updated so the methodology-vs-scorer parity test stays green |

## Test plan

- [x] Widget label test: passes with new \`'Conflict'\` expected value
- [x] Methodology-lint parity test: passes (doc heading + map entry both reference \`Conflict & Displacement\`)
- [x] Dimension-scorer tests (no behavior change, only comment): pass
- [x] Full resilience suite: 130/130 affected tests pass, 709/709 across the broader suite remains green
- [ ] Reviewer: confirm \"Conflict\" is the right widget label vs alternatives like \"Conflict & Displacement\" (would overflow at 19-cell width), \"Conflict Events\", or just \"Conflict\". The methodology doc uses the full \"Conflict & Displacement\" where space allows.

## Out of scope (tracked as follow-ups)

1. **Internal-id rename** (\`borderSecurity\` → e.g. \`conflictAndDisplacement\`). Documented in the scorer header comment; deferred because of proto + cache-prefix cascade. Worth picking up the next time the resilience proto is touched.
2. **Replacement with actual border-control data** (UNODC cross-border crime, FRONTEX, WCO customs compliance, CBP seizure stats). This was the audit's second alternative; it's a workstream rather than a single PR — requires new seeders, schemas, and a fresh dimension id.

## Risk

Pure relabel; no scoring values shift. Users with cached widget data will see the dimension label change from \"Border\" to \"Conflict\" on next render. The methodology doc reflects the new framing immediately.