### PR TITLE
fix(chat-analyst): override unlockPanel to rebuild chat surface after lock→unlock

### DIFF
--- a/src/components/ChatAnalystPanel.ts
+++ b/src/components/ChatAnalystPanel.ts
@@ -70,6 +70,7 @@ export class ChatAnalystPanel extends Panel {
   private isStreaming = false;
   private messagesEl!: HTMLElement;
   private inputEl: HTMLTextAreaElement | null = null;
+  private contentDelegationAttached = false;
 
   constructor() {
     super({
@@ -138,6 +139,13 @@ export class ChatAnalystPanel extends Panel {
   }
 
   private attachListeners(): void {
+    // Click + keydown are both delegated on this.content (the persistent
+    // panel content div), so attaching exactly once survives every buildUI()
+    // re-render — including the FREE→PRO unlock rebuild path. Re-attaching
+    // would duplicate handlers and fire send() N times per Enter.
+    if (this.contentDelegationAttached) return;
+    this.contentDelegationAttached = true;
+
     this.content.addEventListener('click', (e) => {
       const target = e.target as HTMLElement;
 
@@ -163,14 +171,14 @@ export class ChatAnalystPanel extends Panel {
       }
     });
 
-    if (this.inputEl) {
-      this.inputEl.addEventListener('keydown', (e) => {
-        if (e.key === 'Enter' && !e.shiftKey) {
-          e.preventDefault();
-          this.sendFromInput();
-        }
-      });
-    }
+    this.content.addEventListener('keydown', (e) => {
+      const target = e.target as HTMLElement | null;
+      if (!target || target !== this.inputEl) return;
+      if (e.key === 'Enter' && !e.shiftKey) {
+        e.preventDefault();
+        this.sendFromInput();
+      }
+    });
   }
 
   private setDomain(domain: string): void {
@@ -445,6 +453,20 @@ export class ChatAnalystPanel extends Panel {
     a.download = `wm-analyst-session-${Date.now()}.md`;
     a.click();
     URL.revokeObjectURL(url);
+  }
+
+  // Panel.unlockPanel() does `replaceChildren(this.content)` (empties it)
+  // when a previously-locked panel transitions to unlocked. The chat surface
+  // (chips, messages, quick actions, input row) lives entirely in buildUI()
+  // and is only constructed once in the ctor — without a rebuild here, the
+  // body would stay empty after the FREE→PRO unlock fired by
+  // panel-layout.ts:updatePanelGating(). Re-detect via querySelector so we
+  // only pay the cost when the wipe actually happened.
+  override unlockPanel(): void {
+    super.unlockPanel();
+    if (!this.content.querySelector('.chat-analyst-wrapper')) {
+      this.buildUI();
+    }
   }
 
   override destroy(): void {

--- a/tests/chat-analyst-panel-unlock.test.mts
+++ b/tests/chat-analyst-panel-unlock.test.mts
@@ -1,0 +1,110 @@
+import assert from 'node:assert/strict';
+import { after, describe, it } from 'node:test';
+
+import { createChatAnalystPanelHarness } from './helpers/chat-analyst-panel-harness.mjs';
+
+const harness = await createChatAnalystPanelHarness();
+
+after(() => {
+  harness.cleanup();
+});
+
+// Regression: src/components/ChatAnalystPanel.ts (override unlockPanel).
+//
+// Bug shape: Panel.unlockPanel() wipes this.content via replaceChildren()
+// when a previously-locked panel transitions to unlocked. ChatAnalystPanel
+// builds all of its chrome (chips, messages, quick actions, INPUT row) in
+// buildUI() during the constructor only, so without an override the body
+// stays empty after the FREE→PRO unlock fired by
+// panel-layout.ts:updatePanelGating(). Symptom: header + PRO badge render
+// but the entire content body is blank — the "field is hidden" report.
+
+describe('ChatAnalystPanel — unlockPanel restores chat surface', () => {
+  it('initial mount renders chips, messages, quick actions, and input row', () => {
+    const panel = harness.createPanel();
+    const root = panel.getElement();
+
+    assert.ok(root.querySelector('.chat-analyst-wrapper'), 'wrapper present after ctor');
+    assert.ok(root.querySelector('.chat-analyst-chips'), 'chip bar present');
+    assert.ok(root.querySelector('.chat-analyst-messages'), 'messages container present');
+    assert.ok(root.querySelector('.chat-analyst-quick'), 'quick actions present');
+    assert.ok(root.querySelector('.chat-analyst-input'), 'input textarea present');
+    assert.ok(root.querySelector('.chat-analyst-send'), 'send button present');
+  });
+
+  it('FREE→PRO unlock path (showGatedCta → unlockPanel) restores the input row', () => {
+    const panel = harness.createPanel();
+    const root = panel.getElement();
+
+    assert.ok(root.querySelector('.chat-analyst-input'), 'input present before gating');
+
+    // Simulate updatePanelGating() seeing FREE/anon — content is replaced
+    // with the locked CTA and Panel._locked flips to true.
+    panel.showGatedCta('free_tier', () => {});
+
+    assert.equal(
+      root.querySelector('.chat-analyst-input'),
+      null,
+      'input row is wiped while panel is locked',
+    );
+    assert.ok(root.querySelector('.panel-locked-state'), 'locked CTA rendered');
+
+    // Simulate updatePanelGating() seeing PRO on the next auth snapshot.
+    // Pre-fix this leaves this.content empty (the user-visible bug); the
+    // ChatAnalystPanel.unlockPanel override re-runs buildUI() to repaint.
+    panel.unlockPanel();
+
+    assert.ok(
+      root.querySelector('.chat-analyst-wrapper'),
+      'wrapper must come back after unlock',
+    );
+    assert.ok(
+      root.querySelector('.chat-analyst-input'),
+      'input row must be restored after FREE→PRO unlock — the "field is hidden" bug',
+    );
+    assert.ok(root.querySelector('.chat-analyst-chips'), 'chip bar restored');
+    assert.ok(root.querySelector('.chat-analyst-messages'), 'messages container restored');
+    assert.ok(root.querySelector('.chat-analyst-send'), 'send button restored');
+    assert.equal(
+      root.querySelector('.panel-locked-state'),
+      null,
+      'locked CTA cleared after unlock',
+    );
+  });
+
+  it('repeated showGatedCta → unlockPanel cycles continue to restore the surface', () => {
+    const panel = harness.createPanel();
+    const root = panel.getElement();
+
+    for (let i = 0; i < 3; i++) {
+      panel.showGatedCta('free_tier', () => {});
+      panel.unlockPanel();
+
+      assert.ok(
+        root.querySelector('.chat-analyst-input'),
+        `input row must survive lock/unlock cycle ${i + 1}`,
+      );
+    }
+  });
+
+  it('unlockPanel on an already-unlocked panel does not replace the existing wrapper', () => {
+    const panel = harness.createPanel();
+    const root = panel.getElement();
+
+    const wrapperBefore = root.querySelector('.chat-analyst-wrapper');
+    assert.ok(wrapperBefore, 'wrapper present before idempotent unlock');
+
+    // Panel.unlockPanel() early-returns when not locked. The override must
+    // not attempt a rebuild in that case (would briefly thrash the DOM and
+    // lose any in-progress conversation state).
+    panel.unlockPanel();
+
+    const wrappers = root.querySelectorAll('.chat-analyst-wrapper');
+    assert.equal(wrappers.length, 1, 'exactly one wrapper after no-op unlock');
+    assert.equal(
+      wrappers[0],
+      wrapperBefore,
+      'no-op unlock must NOT replace the existing wrapper instance',
+    );
+  });
+});

--- a/tests/helpers/chat-analyst-panel-harness.mjs
+++ b/tests/helpers/chat-analyst-panel-harness.mjs
@@ -1,0 +1,215 @@
+import { build } from 'esbuild';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createBrowserEnvironment } from './runtime-config-panel-harness.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..', '..');
+const entry = resolve(root, 'src/components/ChatAnalystPanel.ts');
+
+function snapshotGlobal(name) {
+  return {
+    exists: Object.prototype.hasOwnProperty.call(globalThis, name),
+    value: globalThis[name],
+  };
+}
+
+function restoreGlobal(name, snapshot) {
+  if (snapshot.exists) {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value: snapshot.value,
+    });
+    return;
+  }
+  delete globalThis[name];
+}
+
+function defineGlobal(name, value) {
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+async function loadChatAnalystPanel() {
+  const tempDir = mkdtempSync(join(tmpdir(), 'wm-chat-analyst-panel-'));
+  const outfile = join(tempDir, 'ChatAnalystPanel.bundle.mjs');
+
+  const stubModules = new Map([
+    ['i18n-stub', `
+      // Empty string for every key — skips Panel's infoTooltip safeHtml() path
+      // (gated by \`if (options.infoTooltip)\`) which would otherwise crash the
+      // MiniDocument template-element shim.
+      export function t() { return ''; }
+    `],
+    ['runtime-stub', `
+      export function isDesktopRuntime() { return false; }
+    `],
+    ['tauri-bridge-stub', `
+      export function invokeTauri() { return Promise.reject(new Error('not wired in test')); }
+    `],
+    ['analytics-stub', `
+      export function trackPanelResized() {}
+    `],
+    ['ai-flow-settings-stub', `
+      export function getAiFlowSettings() { return { badgeAnimation: false }; }
+    `],
+    ['runtime-config-stub', `
+      export function getSecretState() { return { present: true }; }
+    `],
+    ['panel-gating-stub', `
+      export const PanelGateReason = Object.freeze({
+        NONE: 'none',
+        ANONYMOUS: 'anonymous',
+        FREE_TIER: 'free_tier',
+      });
+    `],
+    ['premium-fetch-stub', `
+      export function premiumFetch() { return Promise.reject(new Error('not wired in test')); }
+    `],
+    ['analyst-markdown-stub', `
+      export function postProcessAnalystHtml(html) { return html; }
+    `],
+    ['marked-stub', `
+      export const marked = { parse: (s) => s };
+    `],
+    ['dompurify-stub', `
+      export default { sanitize: (s) => s };
+    `],
+    ['checkout-stub', `
+      export function startCheckout() {}
+    `],
+    ['products-stub', `
+      export const DEFAULT_UPGRADE_PRODUCT = 'pro';
+    `],
+  ]);
+
+  const aliasMap = new Map([
+    ['@/services/i18n', 'i18n-stub'],
+    ['../services/i18n', 'i18n-stub'],
+    ['@/services/runtime', 'runtime-stub'],
+    ['../services/runtime', 'runtime-stub'],
+    ['@/services/tauri-bridge', 'tauri-bridge-stub'],
+    ['../services/tauri-bridge', 'tauri-bridge-stub'],
+    ['@/services/analytics', 'analytics-stub'],
+    ['@/services/ai-flow-settings', 'ai-flow-settings-stub'],
+    ['@/services/runtime-config', 'runtime-config-stub'],
+    ['@/services/panel-gating', 'panel-gating-stub'],
+    ['@/services/premium-fetch', 'premium-fetch-stub'],
+    ['@/utils/analyst-markdown', 'analyst-markdown-stub'],
+    ['@/services/checkout', 'checkout-stub'],
+    ['@/config/products', 'products-stub'],
+    ['marked', 'marked-stub'],
+    ['dompurify', 'dompurify-stub'],
+  ]);
+
+  const plugin = {
+    name: 'chat-analyst-panel-test-stubs',
+    setup(buildApi) {
+      buildApi.onResolve({ filter: /.*/ }, (args) => {
+        const target = aliasMap.get(args.path);
+        return target ? { path: target, namespace: 'stub' } : null;
+      });
+
+      buildApi.onLoad({ filter: /.*/, namespace: 'stub' }, (args) => ({
+        contents: stubModules.get(args.path),
+        loader: 'js',
+      }));
+    },
+  };
+
+  const result = await build({
+    entryPoints: [entry],
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    target: 'es2020',
+    write: false,
+    plugins: [plugin],
+  });
+
+  writeFileSync(outfile, result.outputFiles[0].text, 'utf8');
+
+  const mod = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`);
+  return {
+    ChatAnalystPanel: mod.ChatAnalystPanel,
+    cleanupBundle() {
+      rmSync(tempDir, { recursive: true, force: true });
+    },
+  };
+}
+
+export async function createChatAnalystPanelHarness() {
+  const originalGlobals = {
+    document: snapshotGlobal('document'),
+    window: snapshotGlobal('window'),
+    localStorage: snapshotGlobal('localStorage'),
+    requestAnimationFrame: snapshotGlobal('requestAnimationFrame'),
+    cancelAnimationFrame: snapshotGlobal('cancelAnimationFrame'),
+    navigator: snapshotGlobal('navigator'),
+    HTMLElement: snapshotGlobal('HTMLElement'),
+    HTMLButtonElement: snapshotGlobal('HTMLButtonElement'),
+    Node: snapshotGlobal('Node'),
+  };
+  const browserEnvironment = createBrowserEnvironment();
+
+  // dom-utils.h() and appendChildren() branch on `instanceof Node`. The
+  // browser harness models nodes via MiniNode (extends EventTarget), so we
+  // hoist the MiniNode constructor to globalThis.Node so the instanceof
+  // checks match. Walk up the prototype chain from MiniElement to find it.
+  const MiniNode = Object.getPrototypeOf(browserEnvironment.HTMLElement.prototype).constructor;
+
+  defineGlobal('document', browserEnvironment.document);
+  defineGlobal('window', browserEnvironment.window);
+  defineGlobal('localStorage', browserEnvironment.localStorage);
+  defineGlobal('requestAnimationFrame', browserEnvironment.requestAnimationFrame);
+  defineGlobal('cancelAnimationFrame', browserEnvironment.cancelAnimationFrame);
+  defineGlobal('navigator', browserEnvironment.window.navigator);
+  defineGlobal('HTMLElement', browserEnvironment.HTMLElement);
+  defineGlobal('HTMLButtonElement', browserEnvironment.HTMLButtonElement);
+  defineGlobal('Node', MiniNode);
+
+  let ChatAnalystPanel;
+  let cleanupBundle;
+  try {
+    ({ ChatAnalystPanel, cleanupBundle } = await loadChatAnalystPanel());
+  } catch (error) {
+    restoreGlobal('document', originalGlobals.document);
+    restoreGlobal('window', originalGlobals.window);
+    restoreGlobal('localStorage', originalGlobals.localStorage);
+    restoreGlobal('requestAnimationFrame', originalGlobals.requestAnimationFrame);
+    restoreGlobal('cancelAnimationFrame', originalGlobals.cancelAnimationFrame);
+    restoreGlobal('navigator', originalGlobals.navigator);
+    restoreGlobal('HTMLElement', originalGlobals.HTMLElement);
+    restoreGlobal('HTMLButtonElement', originalGlobals.HTMLButtonElement);
+    throw error;
+  }
+
+  function createPanel() {
+    return new ChatAnalystPanel();
+  }
+
+  function cleanup() {
+    cleanupBundle();
+    restoreGlobal('document', originalGlobals.document);
+    restoreGlobal('window', originalGlobals.window);
+    restoreGlobal('localStorage', originalGlobals.localStorage);
+    restoreGlobal('requestAnimationFrame', originalGlobals.requestAnimationFrame);
+    restoreGlobal('cancelAnimationFrame', originalGlobals.cancelAnimationFrame);
+    restoreGlobal('navigator', originalGlobals.navigator);
+    restoreGlobal('HTMLElement', originalGlobals.HTMLElement);
+    restoreGlobal('HTMLButtonElement', originalGlobals.HTMLButtonElement);
+    restoreGlobal('Node', originalGlobals.Node);
+  }
+
+  return {
+    document: browserEnvironment.document,
+    createPanel,
+    cleanup,
+  };
+}


### PR DESCRIPTION
## Summary

- **Symptom**: WM Analyst panel renders header + PRO badge with a vast empty body on mobile. User report: "WM analyst can't be used on mobile, the field is just hidden."
- **Root cause**: `Panel.unlockPanel()` (src/components/Panel.ts:908-918) does `replaceChildren(this.content)` without any hook for subclasses to rebuild. `ChatAnalystPanel`'s entire UI (chips, messages, quick actions, input row) is built **only** in the constructor via `buildUI()`, so the body stays permanently empty after a FREE→PRO unlock fired by `panel-layout.ts:updatePanelGating()`.
- **Why mobile makes it routine**: warm desktop sessions resolve auth once and stay there. On mobile, Clerk WS suspend/resume + network switches force extra `anon → pro` cycles via `subscribeAuthState`, and each cycle hits `unlockPanel()` → wipe.

## Fix

- `ChatAnalystPanel.unlockPanel()` override: call `super`, then `querySelector('.chat-analyst-wrapper')`-detect whether the wipe happened, re-run `buildUI()` if so. Self-healing: works for any future code path that empties the content.
- `attachListeners()` refactored to use **content-level delegation for both click and keydown** (textarea keydown previously bound to the per-rebuild textarea instance), gated on a `contentDelegationAttached` one-shot flag. Without this, the `buildUI()` re-run on unlock would double-bind handlers and fire `send()` N times per Enter.

## Test plan

- [x] New `tests/chat-analyst-panel-unlock.test.mts` (4 cases) covers:
  - Initial mount renders chips / messages / quick actions / **input row**.
  - **FREE→PRO unlock (showGatedCta → unlockPanel) restores the input row** — the user-visible regression.
  - Repeated lock/unlock cycles continue to restore.
  - Idempotent no-op unlock does NOT replace the existing wrapper instance.
- [x] Reverting the override → tests #2 and #3 fail with `actual: null` on the input lookup → confirms the assertions bite the right behavior.
- [x] Sibling DOM-harness suite (`tests/runtime-config-panel-visibility.test.mjs`) and existing `tests/chat-analyst.test.mts` still pass.
- [x] `npx tsc --noEmit` clean.

## Test harness notes (for reviewers)

`tests/helpers/chat-analyst-panel-harness.mjs` bundles `ChatAnalystPanel` via esbuild with stubs for i18n / runtime / analytics / panel-gating / marked / DOMPurify / etc., and runs against the existing `MiniDocument` browser shim from `runtime-config-panel-harness.mjs`. Two non-obvious bits:

- Hoists `globalThis.Node = MiniNode` (walked up the prototype chain from `HTMLElement`) so `dom-utils.h()`'s `instanceof Node` matches the shim's node instances.
- Uses class selectors (`.chat-analyst-input`, `.chat-analyst-wrapper`) instead of `[data-action="send"]` because `MiniElement`'s `dataset` property assignment doesn't bridge to its `attributes` Map — attribute selectors would silently miss buttons created via `h('button', { dataset: { action: 'send' } }, ...)`.

## Follow-up (out of scope)

Other premium `Panel` subclasses with constructor-only static chrome are likely vulnerable to the same wipe. Worth a sweep: `grep "extends Panel"` for subclasses whose `buildUI()`-equivalent is only called from the constructor. Long-term fix is a `Panel.onUnlock()` hook in the base class so subclasses don't have to detect the wipe themselves.