### PR TITLE
fix(panel): restore pre-lock content on unlockPanel — fixes ALL constructor-only premium panels

### DIFF
--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -878,16 +878,6 @@ export class Panel {
   }
 
   public showGatedCta(reason: PanelGateReason, onAction: () => void): void {
-    this._locked = true;
-    this.clearRetryCountdown();
-    this._snapshotContentForRestore();
-
-    // Hide elements between header and content (same as showLocked)
-    for (let child = this.header.nextElementSibling; child && child !== this.content; child = child.nextElementSibling) {
-      (child as HTMLElement).style.display = 'none';
-    }
-    this.element.classList.add('panel-is-locked');
-
     const config: Record<string, { icon: string; desc: string; cta: string }> = {
       [PanelGateReason.ANONYMOUS]: {
         icon: lockSvg,
@@ -903,6 +893,20 @@ export class Panel {
 
     const entry = config[reason];
     if (!entry) return; // PanelGateReason.NONE should never reach here
+
+    // Bail-out done — now commit to the locked state. Doing this AFTER the
+    // guard avoids a half-locked DOM (header siblings hidden, panel-is-locked
+    // class set, _savedContent populated) on the acknowledged-impossible
+    // NONE-reason path. PR #3814 review (Greptile P2).
+    this._locked = true;
+    this.clearRetryCountdown();
+    this._snapshotContentForRestore();
+
+    // Hide elements between header and content (same as showLocked)
+    for (let child = this.header.nextElementSibling; child && child !== this.content; child = child.nextElementSibling) {
+      (child as HTMLElement).style.display = 'none';
+    }
+    this.element.classList.add('panel-is-locked');
 
     const iconEl = h('div', { className: 'panel-locked-icon' });
     iconEl.innerHTML = entry.icon;
@@ -1172,6 +1176,10 @@ export class Panel {
       this.contentDebounceTimer = null;
     }
     this.pendingContentHtml = null;
+    // Drop the snapshot of pre-lock children so a panel destroyed while
+    // still in the locked state doesn't retain the detached DOM subtree
+    // for the lifetime of the Panel instance. PR #3814 review (Greptile P2).
+    this._savedContent = null;
 
     if (this.tooltipCloseHandler) {
       document.removeEventListener('click', this.tooltipCloseHandler);

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -238,6 +238,14 @@ export class Panel {
   private retryAttempt = 0;
   private _fetching = false;
   private _locked = false;
+  // Snapshot of this.content's children at the moment showLocked /
+  // showGatedCta replaces them with a lock CTA. unlockPanel re-attaches
+  // these nodes so subclasses whose UI is constructed once (typically in
+  // the ctor — chips, input rows, static chrome) don't end up with a
+  // permanently empty body after a FREE→PRO auth-state cycle. The cache
+  // holds the actual DOM nodes; reattaching preserves any listeners and
+  // any subclass references like `this.inputEl`.
+  private _savedContent: ChildNode[] | null = null;
   private _collapsed = false;
   private _collapseBtn: HTMLButtonElement | null = null;
 
@@ -831,6 +839,7 @@ export class Panel {
   public showLocked(features: string[] = []): void {
     this._locked = true;
     this.clearRetryCountdown();
+    this._snapshotContentForRestore();
 
     for (let child = this.header.nextElementSibling; child && child !== this.content; child = child.nextElementSibling) {
       (child as HTMLElement).style.display = 'none';
@@ -871,6 +880,7 @@ export class Panel {
   public showGatedCta(reason: PanelGateReason, onAction: () => void): void {
     this._locked = true;
     this.clearRetryCountdown();
+    this._snapshotContentForRestore();
 
     // Hide elements between header and content (same as showLocked)
     for (let child = this.header.nextElementSibling; child && child !== this.content; child = child.nextElementSibling) {
@@ -913,8 +923,27 @@ export class Panel {
     for (let child = this.header.nextElementSibling; child && child !== this.content; child = child.nextElementSibling) {
       (child as HTMLElement).style.display = '';
     }
-    // Clear the locked state content
-    replaceChildren(this.content);
+    // Restore the pre-lock content if we have it. The saved nodes are the
+    // ORIGINAL DOM nodes the subclass built — reattaching preserves event
+    // listeners and any references the subclass holds (this.inputEl etc.),
+    // and fixes constructor-only subclasses (DeductionPanel,
+    // ChatAnalystPanel, …) that would otherwise end up with an empty body.
+    // Fall back to the legacy empty-content behaviour if nothing was saved.
+    if (this._savedContent !== null) {
+      replaceChildren(this.content, ...this._savedContent);
+      this._savedContent = null;
+    } else {
+      replaceChildren(this.content);
+    }
+  }
+
+  // Capture this.content's current child nodes so unlockPanel can put them
+  // back. Only snapshots on the FIRST transition into a lock state — a
+  // re-entrant showLocked / showGatedCta must not overwrite the cache with
+  // the locked-state CTA. The cache is cleared by unlockPanel on restore.
+  private _snapshotContentForRestore(): void {
+    if (this._savedContent !== null) return;
+    this._savedContent = Array.from(this.content.childNodes);
   }
 
   public showRetrying(message?: string, countdownSeconds?: number): void {

--- a/tests/helpers/minimal-panel-harness.mjs
+++ b/tests/helpers/minimal-panel-harness.mjs
@@ -1,0 +1,223 @@
+// Bundles a tiny `extends Panel` subclass with no constructor-only-UI
+// override, so tests can prove the BASE-CLASS unlock-restore behavior
+// without depending on any specific premium panel's implementation.
+//
+// Mirrors the structure of chat-analyst-panel-harness.mjs (same stubs,
+// same browser-environment shim) but the esbuild entry is a virtual
+// in-memory file rather than a real source file.
+
+import { build } from 'esbuild';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { createBrowserEnvironment } from './runtime-config-panel-harness.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..', '..');
+
+function snapshotGlobal(name) {
+  return {
+    exists: Object.prototype.hasOwnProperty.call(globalThis, name),
+    value: globalThis[name],
+  };
+}
+
+function restoreGlobal(name, snapshot) {
+  if (snapshot.exists) {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value: snapshot.value,
+    });
+    return;
+  }
+  delete globalThis[name];
+}
+
+function defineGlobal(name, value) {
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+async function loadMinimalPanel() {
+  const tempDir = mkdtempSync(join(tmpdir(), 'wm-minimal-panel-'));
+  const outfile = join(tempDir, 'MinimalPanel.bundle.mjs');
+
+  // Virtual entry source — defines a minimal `extends Panel` subclass that
+  // builds its UI ONCE in the constructor (the exact shape that triggers
+  // the unlock-wipe bug). Imports the REAL Panel base class so the test
+  // exercises the actual unlock/restore code path.
+  const panelImportPath = resolve(root, 'src/components/Panel.ts').replace(/\\/g, '/');
+  const domUtilsPath = resolve(root, 'src/utils/dom-utils.ts').replace(/\\/g, '/');
+  const virtualEntrySource = `
+    import { Panel } from '${panelImportPath}';
+    import { h, replaceChildren } from '${domUtilsPath}';
+
+    // Module-level counter so a test can prove the ctor (and thus the
+    // initial DOM build) runs ONLY ONCE per panel instance — the whole
+    // point of base-class restore is to avoid rebuilding.
+    export let constructorRunCount = 0;
+    export function resetConstructorRunCount() { constructorRunCount = 0; }
+
+    export class MinimalConstructorOnlyPanel extends Panel {
+      static MARKER_CLASS = 'minimal-test-wrapper';
+      static INPUT_CLASS = 'minimal-test-input';
+
+      constructor() {
+        super({ id: 'minimal-test', title: 'Minimal Test' });
+        constructorRunCount += 1;
+        // Build UI ONCE — no buildUI() method, no override of unlockPanel.
+        // This mirrors DeductionPanel's shape (src/components/DeductionPanel.ts:30-77).
+        const input = h('textarea', { className: MinimalConstructorOnlyPanel.INPUT_CLASS });
+        const wrapper = h('div', { className: MinimalConstructorOnlyPanel.MARKER_CLASS }, input);
+        replaceChildren(this.content, wrapper);
+      }
+    }
+  `;
+
+  const stubModules = new Map([
+    ['i18n-stub', `export function t() { return ''; }`],
+    ['runtime-stub', `export function isDesktopRuntime() { return false; }`],
+    ['tauri-bridge-stub', `export function invokeTauri() { return Promise.reject(new Error('not wired in test')); }`],
+    ['analytics-stub', `export function trackPanelResized() {}`],
+    ['ai-flow-settings-stub', `export function getAiFlowSettings() { return { badgeAnimation: false }; }`],
+    ['runtime-config-stub', `export function getSecretState() { return { present: true }; }`],
+    ['panel-gating-stub', `
+      export const PanelGateReason = Object.freeze({
+        NONE: 'none',
+        ANONYMOUS: 'anonymous',
+        FREE_TIER: 'free_tier',
+      });
+    `],
+    ['checkout-stub', `export function startCheckout() {}`],
+    ['products-stub', `export const DEFAULT_UPGRADE_PRODUCT = 'pro';`],
+    ['virtual-entry', virtualEntrySource],
+  ]);
+
+  const aliasMap = new Map([
+    ['@/services/i18n', 'i18n-stub'],
+    ['../services/i18n', 'i18n-stub'],
+    ['@/services/runtime', 'runtime-stub'],
+    ['../services/runtime', 'runtime-stub'],
+    ['@/services/tauri-bridge', 'tauri-bridge-stub'],
+    ['../services/tauri-bridge', 'tauri-bridge-stub'],
+    ['@/services/analytics', 'analytics-stub'],
+    ['@/services/ai-flow-settings', 'ai-flow-settings-stub'],
+    ['@/services/runtime-config', 'runtime-config-stub'],
+    ['@/services/panel-gating', 'panel-gating-stub'],
+    ['@/services/checkout', 'checkout-stub'],
+    ['@/config/products', 'products-stub'],
+    ['virtual:minimal-entry', 'virtual-entry'],
+  ]);
+
+  const plugin = {
+    name: 'minimal-panel-test-stubs',
+    setup(buildApi) {
+      buildApi.onResolve({ filter: /.*/ }, (args) => {
+        const target = aliasMap.get(args.path);
+        return target ? { path: target, namespace: 'stub' } : null;
+      });
+
+      buildApi.onLoad({ filter: /.*/, namespace: 'stub' }, (args) => ({
+        contents: stubModules.get(args.path),
+        loader: 'ts',
+        resolveDir: root,
+      }));
+    },
+  };
+
+  const result = await build({
+    entryPoints: [{ in: 'virtual:minimal-entry', out: 'MinimalPanel.bundle' }],
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    target: 'es2020',
+    write: false,
+    plugins: [plugin],
+  });
+
+  writeFileSync(outfile, result.outputFiles[0].text, 'utf8');
+
+  const mod = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`);
+  return {
+    MinimalConstructorOnlyPanel: mod.MinimalConstructorOnlyPanel,
+    getConstructorRunCount: () => mod.constructorRunCount,
+    resetConstructorRunCount: mod.resetConstructorRunCount,
+    cleanupBundle() {
+      rmSync(tempDir, { recursive: true, force: true });
+    },
+  };
+}
+
+export async function createMinimalPanelHarness() {
+  const originalGlobals = {
+    document: snapshotGlobal('document'),
+    window: snapshotGlobal('window'),
+    localStorage: snapshotGlobal('localStorage'),
+    requestAnimationFrame: snapshotGlobal('requestAnimationFrame'),
+    cancelAnimationFrame: snapshotGlobal('cancelAnimationFrame'),
+    navigator: snapshotGlobal('navigator'),
+    HTMLElement: snapshotGlobal('HTMLElement'),
+    HTMLButtonElement: snapshotGlobal('HTMLButtonElement'),
+    Node: snapshotGlobal('Node'),
+  };
+  const browserEnvironment = createBrowserEnvironment();
+  const MiniNode = Object.getPrototypeOf(browserEnvironment.HTMLElement.prototype).constructor;
+
+  defineGlobal('document', browserEnvironment.document);
+  defineGlobal('window', browserEnvironment.window);
+  defineGlobal('localStorage', browserEnvironment.localStorage);
+  defineGlobal('requestAnimationFrame', browserEnvironment.requestAnimationFrame);
+  defineGlobal('cancelAnimationFrame', browserEnvironment.cancelAnimationFrame);
+  defineGlobal('navigator', browserEnvironment.window.navigator);
+  defineGlobal('HTMLElement', browserEnvironment.HTMLElement);
+  defineGlobal('HTMLButtonElement', browserEnvironment.HTMLButtonElement);
+  defineGlobal('Node', MiniNode);
+
+  let MinimalConstructorOnlyPanel;
+  let getConstructorRunCount;
+  let resetConstructorRunCount;
+  let cleanupBundle;
+  try {
+    ({
+      MinimalConstructorOnlyPanel,
+      getConstructorRunCount,
+      resetConstructorRunCount,
+      cleanupBundle,
+    } = await loadMinimalPanel());
+  } catch (error) {
+    restoreGlobal('document', originalGlobals.document);
+    restoreGlobal('window', originalGlobals.window);
+    restoreGlobal('localStorage', originalGlobals.localStorage);
+    restoreGlobal('requestAnimationFrame', originalGlobals.requestAnimationFrame);
+    restoreGlobal('cancelAnimationFrame', originalGlobals.cancelAnimationFrame);
+    restoreGlobal('navigator', originalGlobals.navigator);
+    restoreGlobal('HTMLElement', originalGlobals.HTMLElement);
+    restoreGlobal('HTMLButtonElement', originalGlobals.HTMLButtonElement);
+    restoreGlobal('Node', originalGlobals.Node);
+    throw error;
+  }
+
+  return {
+    document: browserEnvironment.document,
+    createPanel: () => new MinimalConstructorOnlyPanel(),
+    getConstructorRunCount,
+    resetConstructorRunCount,
+    cleanup() {
+      cleanupBundle();
+      restoreGlobal('document', originalGlobals.document);
+      restoreGlobal('window', originalGlobals.window);
+      restoreGlobal('localStorage', originalGlobals.localStorage);
+      restoreGlobal('requestAnimationFrame', originalGlobals.requestAnimationFrame);
+      restoreGlobal('cancelAnimationFrame', originalGlobals.cancelAnimationFrame);
+      restoreGlobal('navigator', originalGlobals.navigator);
+      restoreGlobal('HTMLElement', originalGlobals.HTMLElement);
+      restoreGlobal('HTMLButtonElement', originalGlobals.HTMLButtonElement);
+      restoreGlobal('Node', originalGlobals.Node);
+    },
+  };
+}

--- a/tests/panel-unlock-restore.test.mts
+++ b/tests/panel-unlock-restore.test.mts
@@ -152,6 +152,54 @@ describe('Panel base class — unlockPanel restores pre-lock content', () => {
     );
   });
 
+  it('showGatedCta with an unknown reason is a clean no-op (no half-locked state)', () => {
+    // PR #3814 review (Greptile P2): the early-return for PanelGateReason.NONE
+    // must run BEFORE any side-effect. If snapshotting / _locked / class-add
+    // happened first, the panel would end up visually half-locked (header
+    // siblings hidden, panel-is-locked class set, snapshot populated) with
+    // no CTA rendered, and an unrelated subsequent unlock would unwind into
+    // a confused state.
+    harness.resetConstructorRunCount();
+    const panel = harness.createPanel();
+    const root = panel.getElement();
+    const wrapperBefore = root.querySelector('.minimal-test-wrapper');
+    const inputBefore = root.querySelector('.minimal-test-input');
+
+    // PanelGateReason.NONE — acknowledged impossible path in the
+    // updatePanelGating flow, but the guard must still bail cleanly.
+    panel.showGatedCta('none', () => {});
+
+    assert.equal(
+      root.querySelector('.minimal-test-wrapper'),
+      wrapperBefore,
+      'wrapper untouched on unknown-reason showGatedCta',
+    );
+    assert.equal(
+      root.querySelector('.minimal-test-input'),
+      inputBefore,
+      'input untouched on unknown-reason showGatedCta',
+    );
+    assert.equal(
+      root.querySelector('.panel-locked-state'),
+      null,
+      'no locked CTA rendered on unknown-reason path',
+    );
+    assert.equal(
+      panel.getElement().classList.contains('panel-is-locked'),
+      false,
+      'panel-is-locked class must NOT be applied on the early-return path',
+    );
+
+    // Sanity: a subsequent real unlock should also be a no-op (since the
+    // panel never actually entered the locked state in the first place).
+    panel.unlockPanel();
+    assert.equal(
+      root.querySelector('.minimal-test-input'),
+      inputBefore,
+      'after unlockPanel, input still the same instance — proves no snapshot was taken',
+    );
+  });
+
   it('unlockPanel on a never-locked panel is a no-op (legacy behavior preserved)', () => {
     harness.resetConstructorRunCount();
     const panel = harness.createPanel();

--- a/tests/panel-unlock-restore.test.mts
+++ b/tests/panel-unlock-restore.test.mts
@@ -1,0 +1,170 @@
+import assert from 'node:assert/strict';
+import { after, describe, it } from 'node:test';
+
+import { createMinimalPanelHarness } from './helpers/minimal-panel-harness.mjs';
+
+const harness = await createMinimalPanelHarness();
+
+after(() => {
+  harness.cleanup();
+});
+
+// Regression: src/components/Panel.ts (showLocked / showGatedCta /
+// unlockPanel).
+//
+// Before the fix, Panel.unlockPanel() called replaceChildren(this.content)
+// to clear the lock-state CTA but never restored the subclass UI. Any
+// premium-gated subclass whose UI lives only in the constructor (no
+// data-driven re-render path) ended up with a permanently empty body
+// after the first FREE/anon → PRO auth-state cycle fired by
+// panel-layout.ts:updatePanelGating(). Confirmed casualties: ChatAnalystPanel
+// (fixed surgically in PR #3797), DeductionPanel (reported as the same
+// symptom — header-only, empty body, no input field).
+//
+// Fix shape: Panel snapshots this.content's child nodes at the moment
+// showLocked / showGatedCta replaces them, and unlockPanel re-attaches
+// those same node instances. Constructor-only subclasses are repaired
+// transparently — no per-subclass override required.
+
+describe('Panel base class — unlockPanel restores pre-lock content', () => {
+  it('initial mount renders the constructor-built UI', () => {
+    harness.resetConstructorRunCount();
+    const panel = harness.createPanel();
+    const root = panel.getElement();
+
+    assert.equal(harness.getConstructorRunCount(), 1, 'constructor ran exactly once at mount');
+    assert.ok(root.querySelector('.minimal-test-wrapper'), 'wrapper present');
+    assert.ok(root.querySelector('.minimal-test-input'), 'input element present');
+  });
+
+  it('showGatedCta → unlockPanel restores the original DOM nodes by identity', () => {
+    harness.resetConstructorRunCount();
+    const panel = harness.createPanel();
+    const root = panel.getElement();
+
+    const wrapperBefore = root.querySelector('.minimal-test-wrapper');
+    const inputBefore = root.querySelector('.minimal-test-input');
+    assert.ok(wrapperBefore, 'wrapper present at mount');
+    assert.ok(inputBefore, 'input present at mount');
+
+    // Simulate updatePanelGating() seeing FREE/anon — content is replaced
+    // with the locked CTA and Panel._locked flips to true.
+    panel.showGatedCta('free_tier', () => {});
+
+    assert.equal(
+      root.querySelector('.minimal-test-input'),
+      null,
+      'input is removed from DOM while locked',
+    );
+    assert.ok(root.querySelector('.panel-locked-state'), 'locked CTA rendered');
+
+    // Simulate updatePanelGating() seeing PRO on the next auth snapshot.
+    panel.unlockPanel();
+
+    const wrapperAfter = root.querySelector('.minimal-test-wrapper');
+    const inputAfter = root.querySelector('.minimal-test-input');
+    assert.ok(wrapperAfter, 'wrapper restored after unlock');
+    assert.ok(inputAfter, 'input restored after unlock');
+    assert.equal(
+      wrapperAfter,
+      wrapperBefore,
+      'restored wrapper must be the SAME DOM node instance (identity preserved)',
+    );
+    assert.equal(
+      inputAfter,
+      inputBefore,
+      'restored input must be the SAME DOM node instance — listeners and ' +
+      'subclass references like this.inputEl point at this node',
+    );
+    assert.equal(
+      root.querySelector('.panel-locked-state'),
+      null,
+      'locked CTA cleared after unlock',
+    );
+    assert.equal(
+      harness.getConstructorRunCount(),
+      1,
+      'constructor must NOT have re-run — base-class restore reuses original nodes',
+    );
+  });
+
+  it('showLocked → unlockPanel also restores via the snapshot', () => {
+    harness.resetConstructorRunCount();
+    const panel = harness.createPanel();
+    const root = panel.getElement();
+
+    const inputBefore = root.querySelector('.minimal-test-input');
+    assert.ok(inputBefore, 'input present at mount');
+
+    panel.showLocked(['Feature A', 'Feature B']);
+
+    assert.equal(root.querySelector('.minimal-test-input'), null, 'input wiped while locked');
+    assert.ok(root.querySelector('.panel-locked-state'), 'lock state rendered');
+
+    panel.unlockPanel();
+
+    const inputAfter = root.querySelector('.minimal-test-input');
+    assert.equal(inputAfter, inputBefore, 'input restored by identity from showLocked path too');
+  });
+
+  it('repeated lock / unlock cycles continue to restore the same node', () => {
+    harness.resetConstructorRunCount();
+    const panel = harness.createPanel();
+    const root = panel.getElement();
+    const inputAtMount = root.querySelector('.minimal-test-input');
+    assert.ok(inputAtMount, 'input present at mount');
+
+    for (let i = 0; i < 3; i++) {
+      panel.showGatedCta('free_tier', () => {});
+      panel.unlockPanel();
+      const inputAfter = root.querySelector('.minimal-test-input');
+      assert.equal(
+        inputAfter,
+        inputAtMount,
+        `cycle ${i + 1}: input is the same node instance from mount`,
+      );
+    }
+
+    assert.equal(
+      harness.getConstructorRunCount(),
+      1,
+      'constructor stays at 1 across 3 lock/unlock cycles',
+    );
+  });
+
+  it('a second showLocked WHILE already locked does not corrupt the snapshot', () => {
+    harness.resetConstructorRunCount();
+    const panel = harness.createPanel();
+    const root = panel.getElement();
+    const inputBefore = root.querySelector('.minimal-test-input');
+
+    panel.showGatedCta('free_tier', () => {});
+    // Re-entrant lock call — should NOT overwrite the cache with the
+    // locked-state CTA, otherwise unlockPanel would "restore" the lock CTA.
+    panel.showGatedCta('anonymous', () => {});
+    panel.unlockPanel();
+
+    const inputAfter = root.querySelector('.minimal-test-input');
+    assert.equal(
+      inputAfter,
+      inputBefore,
+      'snapshot was the pre-lock state, not the first locked CTA',
+    );
+  });
+
+  it('unlockPanel on a never-locked panel is a no-op (legacy behavior preserved)', () => {
+    harness.resetConstructorRunCount();
+    const panel = harness.createPanel();
+    const root = panel.getElement();
+    const wrapperBefore = root.querySelector('.minimal-test-wrapper');
+
+    panel.unlockPanel();
+
+    const wrapperAfter = root.querySelector('.minimal-test-wrapper');
+    assert.equal(
+      wrapperAfter,
+      wrapperBefore,
+      'never-locked unlock must leave existing content untouched',
+    );
+  });
+});


### PR DESCRIPTION
## Symptom

DeductionPanel (reported today) shows header-only with a vast empty body — input field, geo input, submit button all missing. Identical shape to the WM Analyst regression fixed in PR #3797. Two of the 10 panels in `WEB_PREMIUM_PANELS` are now confirmed broken; the rest are likely vulnerable too.

## Root cause

`Panel.unlockPanel()` previously did:

```ts
public unlockPanel(): void {
  if (!this._locked) return;
  this._locked = false;
  this.element.classList.remove('panel-is-locked');
  // re-show hidden header siblings...
  replaceChildren(this.content);   // ← wipes; subclass never told to rebuild
}
```

Any subclass whose UI is built ONCE in the constructor (no `refresh()`-driven re-render path) ends up permanently empty after the first FREE/anon → PRO auth cycle fired by `panel-layout.ts:updatePanelGating()`.

## Fix

Snapshot `this.content`'s child nodes at the moment `showLocked` / `showGatedCta` replaces them, and re-attach the same nodes on `unlockPanel`. The cache holds the **actual DOM node instances**, so reattaching preserves:

- event listeners bound directly to wrapper / textarea / button nodes
- subclass references like `this.inputEl`, `this.submitBtn` (still point at the live node)
- any in-flight UI state (half-typed query, partial stream bubble, scroll position)

Constructor-only subclasses (DeductionPanel + the other 8 premium panels) are repaired transparently with **zero per-subclass changes**. ChatAnalystPanel's surgical override from PR #3797 becomes redundant belt-and-braces but harmless — its `querySelector` check finds the restored wrapper and short-circuits the rebuild.

### Re-entrancy safety

Snapshot is taken only on the FIRST transition into lock state. A subsequent `showLocked` / `showGatedCta` while already locked does NOT overwrite the cache with the lock-state CTA. Covered by a dedicated regression test.

## Diff shape

```
src/components/Panel.ts                          +31 / −2
tests/panel-unlock-restore.test.mts              (new)
tests/helpers/minimal-panel-harness.mjs          (new)
```

The harness pattern mirrors `tests/helpers/chat-analyst-panel-harness.mjs` from PR #3797, but the esbuild entry is a **virtual in-memory source string** that defines a minimal `extends Panel` subclass — so the test exercises the REAL Panel base-class restore path without depending on any specific premium panel's full module graph.

## Test plan

6 new cases against the minimal subclass with no override:

- [x] Initial mount renders constructor-built UI
- [x] `showGatedCta → unlockPanel` restores nodes by **identity** (`===`), not just by selector
- [x] `showLocked → unlockPanel` also restores via the same snapshot
- [x] 3 lock/unlock cycles all restore the same node instance
- [x] Re-entrant `showLocked` while already locked does NOT corrupt the snapshot
- [x] Constructor counter stays at 1 across all cycles — proves zero rebuilds

Regression coverage:

- [x] Existing `tests/chat-analyst-panel-unlock.test.mts` still 4/4 green — surgical override now finds the restored wrapper and short-circuits cleanly
- [x] Existing `tests/premium-paths-guard.test.mts` still 7/7 green
- [x] `npx tsc --noEmit` clean

**Anti-regression check**: reverting the new restore block in `unlockPanel` breaks exactly the 4 cases that exercise the restore path; the 2 cases that don't (initial mount, never-locked unlock) stay green. Confirms the test bites the right regression.

- [ ] Manual verify in preview: sign in as a Pro user, open WM Analyst and Deduct Situation → both should show their input fields. Lock/unlock via auth-state churn (e.g. toggle network) → fields should reappear.

## Why a base-class fix instead of overriding DeductionPanel

PR #3797 explicitly called this out as the long-term direction. Two confirmed instances of the same bug shape and 8 more potential candidates is the threshold where surgical per-subclass overrides stop being the right scope. The base-class restore is:

- **Transparent** — no subclass code to touch
- **Identity-preserving** — re-attaches same DOM nodes rather than rebuilding (so listeners + in-flight state survive)
- **Forward-compatible** — every future premium panel is covered automatically
- **Backward-compatible** — the never-locked path is unchanged (line-for-line identical behavior when `_savedContent === null`)