### PR TITLE
fix(relay): fail-closed on missing RELAY_SHARED_SECRET + loud SECURITY warning when auth disabled (#3801, #3812)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -218,16 +218,23 @@ WS_RELAY_URL=
 # Optional client-side URL (wss://) — local/dev fallback only
 VITE_WS_RELAY_URL=
 
-# Shared secret between Vercel and Railway relay.
-# Must be set to the SAME value on both platforms in production.
+# REQUIRED: Shared secret used to authenticate requests to the Railway relay
+# (scripts/ais-relay.cjs). Without it the relay refuses to start. Generate
+# with: openssl rand -hex 32 — then set the SAME value on every host that
+# runs the relay AND on every Vercel/server process that calls it.
 RELAY_SHARED_SECRET=
 
 # Header name used to send the relay secret (must match on both platforms)
 RELAY_AUTH_HEADER=x-relay-key
 
-# Emergency production override to allow unauthenticated relay traffic.
-# Leave unset/false in production.
-ALLOW_UNAUTHENTICATED_RELAY=false
+# Dev-only escape hatch: lets the relay boot WITHOUT a shared secret. When set,
+# every non-public route is reachable by anyone who can hit the relay port and
+# a loud [SECURITY] line is logged at boot and every 5 minutes. Never set this
+# in production or on any internet-reachable host. Keep unset/false otherwise.
+# The legacy name ALLOW_UNAUTHENTICATED_RELAY=true is still accepted for back-
+# compat but is deprecated — prefer the verbose name below.
+I_UNDERSTAND_THIS_DISABLES_AUTH=false
+# ALLOW_UNAUTHENTICATED_RELAY=false  # deprecated alias of the var above
 
 # Rolling window size (seconds) used by relay /metrics endpoint.
 RELAY_METRICS_WINDOW_SECONDS=60

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -16,17 +16,31 @@ git clone https://github.com/koala73/worldmonitor.git
 cd worldmonitor
 npm install
 
-# 2. Start the stack
+# 2. Set the REQUIRED secret used to authenticate the AIS relay (see below).
+#    Without this the ais-relay container will exit at startup.
+echo "RELAY_SHARED_SECRET=$(openssl rand -hex 32)" >> .env
+
+# 3. Start the stack
 docker compose up -d        # or: uvx podman-compose up -d
 
-# 3. Seed data into Redis
+# 4. Seed data into Redis
 ./scripts/run-seeders.sh
 
-# 4. Open the dashboard
+# 5. Open the dashboard
 open http://localhost:3000
 ```
 
 The dashboard works out of the box with public data sources (earthquakes, weather, conflicts, etc.). API keys unlock additional data feeds.
+
+## 🔐 Required Environment Variables
+
+These must be set before `docker compose up -d`, or the relay container will exit on boot.
+
+| Variable | Purpose | How to generate |
+| --- | --- | --- |
+| `RELAY_SHARED_SECRET` | Authenticates every non-public request the dashboard makes to the AIS relay. The relay refuses to start without it. | `openssl rand -hex 32` |
+
+> Need to bring the relay up without auth for local debugging? Set `I_UNDERSTAND_THIS_DISABLES_AUTH=true` (the deprecated `ALLOW_UNAUTHENTICATED_RELAY=true` is still accepted). The relay will log a loud `[SECURITY]` warning at boot and every 5 minutes, and every non-public route will be reachable by anyone who can hit the port — **never use this on an internet-reachable host.**
 
 ## 🔑 API Keys
 

--- a/docs/relay-parameters.mdx
+++ b/docs/relay-parameters.mdx
@@ -44,9 +44,10 @@ Set these before enabling strict relay auth.
 | `PORT` | Railway/local | `3004` | No | HTTP server listen port for relay process. |
 | `WS_RELAY_URL` | Vercel + server handlers | none | Yes (for relay-backed features) | Base URL used by Vercel/server to reach Railway relay. |
 | `VITE_WS_RELAY_URL` | Browser (local dev) | none | No | Localhost fallback path for direct browser calls in development only. |
-| `RELAY_SHARED_SECRET` | Railway + Vercel | empty | Yes in production | Shared secret for non-public relay routes. |
+| `RELAY_SHARED_SECRET` | Railway + Vercel + self-hosted | empty | **Yes (always)** | Shared secret for non-public relay routes. The relay refuses to start without it unless `I_UNDERSTAND_THIS_DISABLES_AUTH=true`. |
 | `RELAY_AUTH_HEADER` | Railway + Vercel | `x-relay-key` | No (but recommended explicit) | Header name carrying relay secret. |
-| `ALLOW_UNAUTHENTICATED_RELAY` | Railway | `false` | No | Emergency override. If `true`, production can start without secret. Keep `false`. |
+| `I_UNDERSTAND_THIS_DISABLES_AUTH` | Railway / self-hosted | `false` | No | Dev-only escape hatch. If `true`, the relay boots WITHOUT a shared secret, logs a loud `[SECURITY]` line at boot and every 5 minutes, and accepts every request on non-public routes. Never set in production. |
+| `ALLOW_UNAUTHENTICATED_RELAY` | Railway / self-hosted | `false` | No | **Deprecated** alias of `I_UNDERSTAND_THIS_DISABLES_AUTH`. Still accepted for back-compat; the relay logs a `[DEPRECATED]` warning when this name is used. |
 | `ALLOW_VERCEL_PREVIEW_ORIGINS` | Railway | `false` | No | If `true`, allows `*.vercel.app` origins in relay CORS checks. |
 
 ## Relay-Adjacent Feature Flags
@@ -110,11 +111,12 @@ These are used only for production detection and are usually injected by platfor
 These are safe starting points for a busy relay:
 
 ```bash
-# Auth + routing
-RELAY_SHARED_SECRET=<strong-random-secret>
+# Auth + routing — RELAY_SHARED_SECRET is REQUIRED (the relay exits at startup
+# without it unless I_UNDERSTAND_THIS_DISABLES_AUTH=true is set).
+RELAY_SHARED_SECRET=<strong-random-secret>   # openssl rand -hex 32
 RELAY_AUTH_HEADER=x-relay-key
 WS_RELAY_URL=https://<your-railway-relay>.up.railway.app
-ALLOW_UNAUTHENTICATED_RELAY=false
+# I_UNDERSTAND_THIS_DISABLES_AUTH=false   # dev-only override; do NOT set in prod
 
 # OpenSky cache/cardinality
 OPENSKY_CACHE_MAX_ENTRIES=256
@@ -162,7 +164,7 @@ curl -sS https://<relay>/metrics \
 
 Expected checks:
 
-- `auth.sharedSecretEnabled` is `true` in `/health`.
+- `auth.enabled` is `true` in `/health` (canonical operator-visible flag — `true` only when a shared secret is configured AND the `I_UNDERSTAND_THIS_DISABLES_AUTH` bypass is NOT engaged). `auth.sharedSecretEnabled` is preserved for back-compat.
 - `/metrics.opensky.hitRatio` is stable and high under load.
 - `/metrics.ais.dropsPerSec` stays at `0` in normal operation.
 - `/metrics.ais.queueMax` is comfortably below `AIS_UPSTREAM_QUEUE_HARD_CAP`.

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -78,7 +78,16 @@ const MEMORY_CLEANUP_THRESHOLD_GB = (() => {
 })();
 const RELAY_SHARED_SECRET = process.env.RELAY_SHARED_SECRET || '';
 const RELAY_AUTH_HEADER = (process.env.RELAY_AUTH_HEADER || 'x-relay-key').toLowerCase();
-const ALLOW_UNAUTHENTICATED_RELAY = process.env.ALLOW_UNAUTHENTICATED_RELAY === 'true';
+// Auth bypass: new canonical name + legacy alias. The new name's verbose
+// wording is intentional — it should be hard to set in production by accident.
+// The legacy `ALLOW_UNAUTHENTICATED_RELAY` is still accepted but emits a
+// deprecation warning so existing self-hosted operators are not broken.
+const _AUTH_BYPASS_NEW = process.env.I_UNDERSTAND_THIS_DISABLES_AUTH === 'true';
+const _AUTH_BYPASS_OLD = process.env.ALLOW_UNAUTHENTICATED_RELAY === 'true';
+const ALLOW_UNAUTHENTICATED_RELAY = _AUTH_BYPASS_NEW || _AUTH_BYPASS_OLD;
+if (_AUTH_BYPASS_OLD && !_AUTH_BYPASS_NEW) {
+  console.warn('[DEPRECATED] ALLOW_UNAUTHENTICATED_RELAY=true is deprecated. Use I_UNDERSTAND_THIS_DISABLES_AUTH=true instead.');
+}
 const IS_PRODUCTION_RELAY = process.env.NODE_ENV === 'production'
   || !!process.env.RAILWAY_ENVIRONMENT
   || !!process.env.RAILWAY_PROJECT_ID
@@ -146,11 +155,30 @@ const OREF_LOCAL_FILE = (() => {
 const RELAY_OREF_RATE_LIMIT_MAX = Number.isFinite(Number(process.env.RELAY_OREF_RATE_LIMIT_MAX))
   ? Number(process.env.RELAY_OREF_RATE_LIMIT_MAX) : 600;
 
-if (IS_PRODUCTION_RELAY && !RELAY_SHARED_SECRET && !ALLOW_UNAUTHENTICATED_RELAY) {
-  console.error('[Relay] Error: RELAY_SHARED_SECRET is required in production');
-  console.error('[Relay] Set RELAY_SHARED_SECRET on Railway and Vercel to secure relay endpoints');
-  console.error('[Relay] To bypass temporarily (not recommended), set ALLOW_UNAUTHENTICATED_RELAY=true');
+// Fail-closed: refuse to boot without a shared secret. This applies in ALL
+// environments (production, dev, self-hosted Docker, etc.) so a self-hosted
+// `docker compose up -d` against the published image cannot accidentally
+// expose every route. Operators who genuinely need an unauthenticated relay
+// must opt in explicitly with the loud `I_UNDERSTAND_THIS_DISABLES_AUTH=true`.
+// (#3801 — closes the IS_PRODUCTION_RELAY-only gate that left self-hosted
+// deployments wide open.)
+if (!RELAY_SHARED_SECRET && !ALLOW_UNAUTHENTICATED_RELAY) {
+  console.error('[Relay] FATAL: RELAY_SHARED_SECRET is not set.');
+  console.error('[Relay] Generate a strong random secret and set it on every host running the relay:');
+  console.error('[Relay]   RELAY_SHARED_SECRET="$(openssl rand -hex 32)"');
+  console.error('[Relay] To explicitly opt out (DEV ONLY — leaves all routes publicly accessible):');
+  console.error('[Relay]   I_UNDERSTAND_THIS_DISABLES_AUTH=true   (formerly ALLOW_UNAUTHENTICATED_RELAY=true)');
   process.exit(1);
+}
+
+// Loud recurring SECURITY warning when auth is effectively disabled. Operators
+// who opt out with the bypass var get a bright reminder both at boot and every
+// 5 minutes in long-running logs so the no-auth state stays visible.
+if (!RELAY_SHARED_SECRET || ALLOW_UNAUTHENTICATED_RELAY) {
+  console.warn('[SECURITY] relay is running WITHOUT auth (RELAY_SHARED_SECRET unset or I_UNDERSTAND_THIS_DISABLES_AUTH=true). All non-public routes are reachable by anyone who can hit this port.');
+  setInterval(() => {
+    console.warn('[SECURITY] relay STILL running without auth — set RELAY_SHARED_SECRET to lock down non-public routes.');
+  }, 5 * 60 * 1000).unref();
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -6287,7 +6315,14 @@ function getRelaySecretFromRequest(req) {
 }
 
 function isAuthorizedRequest(req) {
-  if (!RELAY_SHARED_SECRET) return true;
+  if (!RELAY_SHARED_SECRET) {
+    // Defensive: the startup guard rejects an empty secret unless the
+    // operator explicitly opted out via I_UNDERSTAND_THIS_DISABLES_AUTH
+    // (or the deprecated ALLOW_UNAUTHENTICATED_RELAY). In that bypass case
+    // every request is allowed; otherwise this branch is unreachable. Keeping
+    // the explicit check makes this function safe to call in isolation.
+    return ALLOW_UNAUTHENTICATED_RELAY;
+  }
   const provided = getRelaySecretFromRequest(req);
   if (!provided) return false;
   return safeTokenEquals(provided, RELAY_SHARED_SECRET);
@@ -9086,6 +9121,10 @@ const server = http.createServer(async (req, res) => {
         polymarketInflight: polymarketInflight.size,
       },
       auth: {
+        // `enabled` is the canonical operator-visible field: true only when a
+        // shared secret is configured AND the bypass is NOT engaged. Use this
+        // to detect a no-auth deployment from monitoring without scraping logs.
+        enabled: !!RELAY_SHARED_SECRET && !ALLOW_UNAUTHENTICATED_RELAY,
         sharedSecretEnabled: !!RELAY_SHARED_SECRET,
         authHeader: RELAY_AUTH_HEADER,
         allowVercelPreviewOrigins: ALLOW_VERCEL_PREVIEW_ORIGINS,

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -88,10 +88,6 @@ const ALLOW_UNAUTHENTICATED_RELAY = _AUTH_BYPASS_NEW || _AUTH_BYPASS_OLD;
 if (_AUTH_BYPASS_OLD && !_AUTH_BYPASS_NEW) {
   console.warn('[DEPRECATED] ALLOW_UNAUTHENTICATED_RELAY=true is deprecated. Use I_UNDERSTAND_THIS_DISABLES_AUTH=true instead.');
 }
-const IS_PRODUCTION_RELAY = process.env.NODE_ENV === 'production'
-  || !!process.env.RAILWAY_ENVIRONMENT
-  || !!process.env.RAILWAY_PROJECT_ID
-  || !!process.env.RAILWAY_STATIC_URL;
 const RELAY_RATE_LIMIT_WINDOW_MS = Math.max(1000, Number(process.env.RELAY_RATE_LIMIT_WINDOW_MS || 60000));
 const RELAY_RATE_LIMIT_MAX = Number.isFinite(Number(process.env.RELAY_RATE_LIMIT_MAX))
   ? Number(process.env.RELAY_RATE_LIMIT_MAX) : 1200;
@@ -174,11 +170,25 @@ if (!RELAY_SHARED_SECRET && !ALLOW_UNAUTHENTICATED_RELAY) {
 // Loud recurring SECURITY warning when auth is effectively disabled. Operators
 // who opt out with the bypass var get a bright reminder both at boot and every
 // 5 minutes in long-running logs so the no-auth state stays visible.
-if (!RELAY_SHARED_SECRET || ALLOW_UNAUTHENTICATED_RELAY) {
-  console.warn('[SECURITY] relay is running WITHOUT auth (RELAY_SHARED_SECRET unset or I_UNDERSTAND_THIS_DISABLES_AUTH=true). All non-public routes are reachable by anyone who can hit this port.');
+//
+// Auth is effectively disabled ONLY when there's no secret to check. If a
+// secret IS set, isAuthorizedRequest() enforces it regardless of the bypass
+// flag — the bypass branch only runs when the secret is absent — so we must
+// not warn (or report auth.enabled=false on /health) when the secret is set.
+const AUTH_EFFECTIVELY_DISABLED = !RELAY_SHARED_SECRET;
+if (AUTH_EFFECTIVELY_DISABLED) {
+  console.warn('[SECURITY] relay is running WITHOUT auth — RELAY_SHARED_SECRET unset and I_UNDERSTAND_THIS_DISABLES_AUTH=true. All non-public routes are reachable by anyone who can hit this port.');
   setInterval(() => {
     console.warn('[SECURITY] relay STILL running without auth — set RELAY_SHARED_SECRET to lock down non-public routes.');
   }, 5 * 60 * 1000).unref();
+}
+
+// Separately: if the bypass is set redundantly alongside a real secret, the
+// bypass is silently ignored (isAuthorizedRequest enforces the secret). Emit
+// a single INFO line so operators can clean up their env without wondering
+// why their bypass appears to have no effect.
+if (RELAY_SHARED_SECRET && ALLOW_UNAUTHENTICATED_RELAY) {
+  console.info('[Relay] I_UNDERSTAND_THIS_DISABLES_AUTH=true is ignored — RELAY_SHARED_SECRET is configured and takes precedence. Unset the bypass flag to silence this notice.');
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -9121,10 +9131,11 @@ const server = http.createServer(async (req, res) => {
         polymarketInflight: polymarketInflight.size,
       },
       auth: {
-        // `enabled` is the canonical operator-visible field: true only when a
-        // shared secret is configured AND the bypass is NOT engaged. Use this
-        // to detect a no-auth deployment from monitoring without scraping logs.
-        enabled: !!RELAY_SHARED_SECRET && !ALLOW_UNAUTHENTICATED_RELAY,
+        // `enabled` is the canonical operator-visible field: true when a
+        // shared secret is configured (which is what isAuthorizedRequest()
+        // actually enforces, regardless of any bypass flag). Use this to
+        // detect a no-auth deployment from monitoring without scraping logs.
+        enabled: !AUTH_EFFECTIVELY_DISABLED,
         sharedSecretEnabled: !!RELAY_SHARED_SECRET,
         authHeader: RELAY_AUTH_HEADER,
         allowVercelPreviewOrigins: ALLOW_VERCEL_PREVIEW_ORIGINS,

--- a/tests/relay-auth.test.mjs
+++ b/tests/relay-auth.test.mjs
@@ -38,16 +38,41 @@ const RELAY_SCRIPT = path.resolve(__dirname, '..', 'scripts', 'ais-relay.cjs');
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
-function pickFreePort() {
-  return new Promise((resolve, reject) => {
-    const srv = createServer();
-    srv.unref();
-    srv.on('error', reject);
-    srv.listen(0, '127.0.0.1', () => {
-      const { port } = srv.address();
-      srv.close(() => resolve(port));
+// Pick a free port for a subprocess to bind. There's an inherent TOCTOU race
+// between us closing the probe socket and the child re-binding — another
+// process on the box could grab the port in that window and the test would
+// fail with EADDRINUSE. To shrink the window we re-probe the port after
+// closing the first socket; if the probe succeeds, the port was almost
+// certainly still free when the child bound (the race window is tiny). On
+// EADDRINUSE we just try a different OS-assigned port.
+async function pickFreePort(maxAttempts = 8) {
+  let lastErr;
+  for (let i = 0; i < maxAttempts; i++) {
+    const port = await new Promise((resolve, reject) => {
+      const srv = createServer();
+      srv.unref();
+      srv.on('error', reject);
+      srv.listen(0, '127.0.0.1', () => {
+        const { port: p } = srv.address();
+        srv.close(() => resolve(p));
+      });
     });
-  });
+    try {
+      await new Promise((resolve, reject) => {
+        const probe = createServer();
+        probe.unref();
+        probe.once('error', reject);
+        probe.listen(port, '127.0.0.1', () => {
+          probe.close(() => resolve());
+        });
+      });
+      return port;
+    } catch (err) {
+      lastErr = err;
+      // Another process claimed it between our two listens; loop and retry.
+    }
+  }
+  throw new Error(`pickFreePort: exhausted ${maxAttempts} attempts (last error: ${lastErr?.message})`);
 }
 
 function spawnRelay(envOverrides = {}) {
@@ -228,7 +253,13 @@ describe('relay /health exposes auth.enabled (#3812)', () => {
     }
   });
 
-  it('reports auth.enabled=false when secret set AND bypass also set (bypass wins for visibility)', async () => {
+  it('reports auth.enabled=true when secret set AND bypass also set (bypass is ignored)', async () => {
+    // Greptile #3815 round 2: align /health with isAuthorizedRequest() — the
+    // bypass branch only runs when no secret is configured, so a secret +
+    // bypass combo still enforces the secret. Reporting enabled=false here
+    // would lie about the actual enforcement behavior. Operators who want to
+    // detect a misconfigured bypass should look for the [Relay] info line
+    // (covered by the test below).
     const port = await pickFreePort();
     const r = spawnRelay({
       RELAY_SHARED_SECRET: 'good-secret',
@@ -239,9 +270,41 @@ describe('relay /health exposes auth.enabled (#3812)', () => {
       await r.waitForLog('WebSocket relay on port', 15_000);
       const res = await httpGet(port, '/health');
       const body = JSON.parse(res.body);
-      // bypass takes priority — operators need a single field they can monitor
-      // that flips false the moment ANY bypass is in play.
-      assert.equal(body.auth.enabled, false);
+      assert.equal(body.auth.enabled, true, 'auth.enabled mirrors actual isAuthorizedRequest() behavior: secret wins');
+      assert.equal(body.auth.sharedSecretEnabled, true);
+    } finally {
+      await killRelay(r.child);
+    }
+  });
+});
+
+// ─── 4) Bypass + secret combo emits info log and does NOT emit [SECURITY] ───
+
+describe('relay startup info-log when bypass is set alongside secret (#3815)', () => {
+  it('logs the "bypass ignored" info line and does NOT emit [SECURITY] warning', async () => {
+    const port = await pickFreePort();
+    const r = spawnRelay({
+      RELAY_SHARED_SECRET: 'good-secret',
+      I_UNDERSTAND_THIS_DISABLES_AUTH: 'true',
+      PORT: String(port),
+    });
+    try {
+      await r.waitForLog('WebSocket relay on port', 15_000);
+      // Give a microtask tick so the info log is fully flushed alongside the
+      // listen banner. (Both are synchronous on the same boot path so this is
+      // belt-and-suspenders.)
+      await new Promise((r2) => setImmediate(r2));
+      const combined = r.stdout() + r.stderr();
+      assert.match(
+        combined,
+        /I_UNDERSTAND_THIS_DISABLES_AUTH=true is ignored/,
+        'expected info line explaining the bypass is being ignored',
+      );
+      assert.doesNotMatch(
+        r.stderr(),
+        /\[SECURITY\] relay is running WITHOUT auth/,
+        'must NOT emit the SECURITY warning when a real secret is configured',
+      );
     } finally {
       await killRelay(r.child);
     }

--- a/tests/relay-auth.test.mjs
+++ b/tests/relay-auth.test.mjs
@@ -1,0 +1,325 @@
+/**
+ * Regression tests for the AIS-relay auth layer.
+ *
+ * Covers:
+ *   - #3801 (P1): the startup guard fails closed in ALL environments, not just
+ *     when an IS_PRODUCTION_RELAY signal is present. A self-hosted Docker /
+ *     VPS deployment that forgets RELAY_SHARED_SECRET must NOT boot wide open.
+ *   - #3812 (Low): renaming the bypass to I_UNDERSTAND_THIS_DISABLES_AUTH,
+ *     back-compat for the legacy ALLOW_UNAUTHENTICATED_RELAY, the loud
+ *     [SECURITY] warning that fires whenever auth is effectively disabled,
+ *     and the auth.enabled field on /health.
+ *
+ * Two layers of coverage:
+ *   1. Startup behavior — spawn `node scripts/ais-relay.cjs` as a subprocess
+ *      with controlled env, listen on a random port, and assert exit code +
+ *      stderr / health-endpoint shape.
+ *   2. isAuthorizedRequest() logic — re-export the auth helpers by re-loading
+ *      the relay module in a child VM context is overkill; instead we mirror
+ *      the production helpers in this file and exercise the exact branches we
+ *      changed. The startup-spawn tests guard against drift between the mirror
+ *      and the real implementation.
+ *
+ * Run: tsx --test tests/relay-auth.test.mjs
+ *      (or via `npm run test:data`)
+ */
+
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { createServer } from 'node:net';
+import crypto from 'node:crypto';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const RELAY_SCRIPT = path.resolve(__dirname, '..', 'scripts', 'ais-relay.cjs');
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function pickFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+function spawnRelay(envOverrides = {}) {
+  const child = spawn(process.execPath, [RELAY_SCRIPT], {
+    env: {
+      // Inherit PATH, HOME, etc. but start from a clean slate for any env var
+      // we care about. We DO need a few unrelated vars to be present so the
+      // relay only fails on the auth guard, not the AIS upstream key check.
+      ...process.env,
+      // The AIS upstream key is checked BEFORE the auth guard. Tests that want
+      // to reach the auth guard must provide it.
+      AISSTREAM_API_KEY: 'test-aisstream-key',
+      // Strip every env var the auth guard cares about so tests start from a
+      // known state. Each test then sets only what it needs.
+      RELAY_SHARED_SECRET: '',
+      ALLOW_UNAUTHENTICATED_RELAY: '',
+      I_UNDERSTAND_THIS_DISABLES_AUTH: '',
+      // Avoid pulling in Railway-prod detection noise from the parent env.
+      NODE_ENV: 'test',
+      RAILWAY_ENVIRONMENT: '',
+      RAILWAY_PROJECT_ID: '',
+      RAILWAY_STATIC_URL: '',
+      ...envOverrides,
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', (b) => { stdout += b.toString('utf8'); });
+  child.stderr.on('data', (b) => { stderr += b.toString('utf8'); });
+  return {
+    child,
+    stdout: () => stdout,
+    stderr: () => stderr,
+    waitForExit: () => once(child, 'exit'),
+    waitForLog: (needle, timeoutMs = 10_000) => new Promise((resolve, reject) => {
+      const started = Date.now();
+      const tick = setInterval(() => {
+        if (stdout.includes(needle) || stderr.includes(needle)) {
+          clearInterval(tick);
+          resolve();
+        } else if (Date.now() - started > timeoutMs) {
+          clearInterval(tick);
+          reject(new Error(`timeout waiting for log "${needle}". stdout=${stdout.slice(-500)} stderr=${stderr.slice(-500)}`));
+        }
+      }, 50);
+    }),
+  };
+}
+
+async function killRelay(child) {
+  if (child.exitCode != null || child.signalCode != null) return;
+  child.kill('SIGKILL');
+  try { await once(child, 'exit'); } catch {}
+}
+
+function httpGet(port, pathname, headers = {}) {
+  return new Promise((resolve, reject) => {
+    import('node:http').then(({ default: http }) => {
+      const req = http.request({
+        host: '127.0.0.1',
+        port,
+        method: 'GET',
+        path: pathname,
+        headers,
+      }, (res) => {
+        const chunks = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          resolve({
+            status: res.statusCode,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString('utf8'),
+          });
+        });
+      });
+      req.on('error', reject);
+      req.end();
+    }, reject);
+  });
+}
+
+// ─── 1) Startup behavior (subprocess) ───────────────────────────────────────
+
+describe('relay startup auth guard (#3801)', () => {
+  it('exits non-zero when RELAY_SHARED_SECRET is unset and no bypass is set', async () => {
+    // This is the #3801 regression: prior code only enforced the guard when
+    // IS_PRODUCTION_RELAY (NODE_ENV=production OR any RAILWAY_* var) was true.
+    // The fix requires the secret unconditionally.
+    const r = spawnRelay({});
+    const [code] = await r.waitForExit();
+    assert.equal(code, 1, `expected exit 1, got ${code}. stderr=${r.stderr()}`);
+    assert.match(r.stderr(), /RELAY_SHARED_SECRET/, 'stderr should mention RELAY_SHARED_SECRET');
+    assert.match(r.stderr(), /I_UNDERSTAND_THIS_DISABLES_AUTH/, 'stderr should mention the new bypass var name');
+  });
+
+  it('boots when only the new bypass var is set, and logs [SECURITY] warning', async () => {
+    const port = await pickFreePort();
+    const r = spawnRelay({
+      I_UNDERSTAND_THIS_DISABLES_AUTH: 'true',
+      PORT: String(port),
+    });
+    try {
+      await r.waitForLog('WebSocket relay on port', 15_000);
+      assert.match(r.stderr(), /\[SECURITY\] relay is running WITHOUT auth/, 'expected boot-time SECURITY warning');
+      // Process is alive (no premature exit).
+      assert.equal(r.child.exitCode, null, 'relay should still be running');
+    } finally {
+      await killRelay(r.child);
+    }
+  });
+
+  it('boots with RELAY_SHARED_SECRET set and emits NO [SECURITY] warning', async () => {
+    const port = await pickFreePort();
+    const r = spawnRelay({
+      RELAY_SHARED_SECRET: 'good-secret',
+      PORT: String(port),
+    });
+    try {
+      await r.waitForLog('WebSocket relay on port', 15_000);
+      assert.doesNotMatch(r.stderr(), /\[SECURITY\] relay is running WITHOUT auth/, 'should NOT warn when auth is on');
+    } finally {
+      await killRelay(r.child);
+    }
+  });
+
+  it('accepts the legacy ALLOW_UNAUTHENTICATED_RELAY=true with a deprecation warning', async () => {
+    const port = await pickFreePort();
+    const r = spawnRelay({
+      ALLOW_UNAUTHENTICATED_RELAY: 'true',
+      PORT: String(port),
+    });
+    try {
+      await r.waitForLog('WebSocket relay on port', 15_000);
+      assert.match(r.stderr(), /\[DEPRECATED\] ALLOW_UNAUTHENTICATED_RELAY=true/, 'expected deprecation warning');
+      assert.match(r.stderr(), /\[SECURITY\] relay is running WITHOUT auth/, 'expected SECURITY warning under legacy alias too');
+    } finally {
+      await killRelay(r.child);
+    }
+  });
+});
+
+// ─── 2) /health auth.enabled field ──────────────────────────────────────────
+
+describe('relay /health exposes auth.enabled (#3812)', () => {
+  it('reports auth.enabled=true when secret set and no bypass', async () => {
+    const port = await pickFreePort();
+    const r = spawnRelay({
+      RELAY_SHARED_SECRET: 'good-secret',
+      PORT: String(port),
+    });
+    try {
+      await r.waitForLog('WebSocket relay on port', 15_000);
+      const res = await httpGet(port, '/health');
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.auth.enabled, true, 'auth.enabled should be true');
+      assert.equal(body.auth.sharedSecretEnabled, true, 'back-compat field still true');
+    } finally {
+      await killRelay(r.child);
+    }
+  });
+
+  it('reports auth.enabled=false when bypass is engaged', async () => {
+    const port = await pickFreePort();
+    const r = spawnRelay({
+      I_UNDERSTAND_THIS_DISABLES_AUTH: 'true',
+      PORT: String(port),
+    });
+    try {
+      await r.waitForLog('WebSocket relay on port', 15_000);
+      const res = await httpGet(port, '/health');
+      assert.equal(res.status, 200);
+      const body = JSON.parse(res.body);
+      assert.equal(body.auth.enabled, false, 'auth.enabled should be false when bypass on');
+    } finally {
+      await killRelay(r.child);
+    }
+  });
+
+  it('reports auth.enabled=false when secret set AND bypass also set (bypass wins for visibility)', async () => {
+    const port = await pickFreePort();
+    const r = spawnRelay({
+      RELAY_SHARED_SECRET: 'good-secret',
+      I_UNDERSTAND_THIS_DISABLES_AUTH: 'true',
+      PORT: String(port),
+    });
+    try {
+      await r.waitForLog('WebSocket relay on port', 15_000);
+      const res = await httpGet(port, '/health');
+      const body = JSON.parse(res.body);
+      // bypass takes priority — operators need a single field they can monitor
+      // that flips false the moment ANY bypass is in play.
+      assert.equal(body.auth.enabled, false);
+    } finally {
+      await killRelay(r.child);
+    }
+  });
+});
+
+// ─── 3) isAuthorizedRequest() logic (mirror of production helper) ───────────
+//
+// The auth helpers in scripts/ais-relay.cjs are private to that module and
+// the module starts servers at import time, so we mirror the exact functions
+// here to exercise their branches in isolation. The startup-spawn tests above
+// catch any drift between this mirror and production.
+
+describe('isAuthorizedRequest() — mirrored unit tests', () => {
+  function makeFns({ secret, bypass }) {
+    const RELAY_AUTH_HEADER = 'x-relay-key';
+    function safeTokenEquals(provided, expected) {
+      const a = Buffer.from(provided || '');
+      const b = Buffer.from(expected || '');
+      if (a.length !== b.length) return false;
+      return crypto.timingSafeEqual(a, b);
+    }
+    function getRelaySecretFromRequest(req) {
+      const direct = req.headers[RELAY_AUTH_HEADER];
+      if (typeof direct === 'string' && direct.trim()) return direct.trim();
+      const auth = req.headers.authorization;
+      if (typeof auth === 'string' && auth.toLowerCase().startsWith('bearer ')) {
+        const token = auth.slice(7).trim();
+        if (token) return token;
+      }
+      return '';
+    }
+    function isAuthorizedRequest(req) {
+      if (!secret) {
+        return bypass;
+      }
+      const provided = getRelaySecretFromRequest(req);
+      if (!provided) return false;
+      return safeTokenEquals(provided, secret);
+    }
+    return { isAuthorizedRequest };
+  }
+
+  const req = (headers = {}) => ({ headers });
+
+  it('returns false when secret unset and bypass unset (fail-closed)', () => {
+    const { isAuthorizedRequest } = makeFns({ secret: '', bypass: false });
+    assert.equal(isAuthorizedRequest(req()), false);
+    assert.equal(isAuthorizedRequest(req({ 'x-relay-key': 'anything' })), false);
+    assert.equal(isAuthorizedRequest(req({ authorization: 'Bearer x' })), false);
+  });
+
+  it('returns true when bypass is engaged, regardless of headers', () => {
+    const { isAuthorizedRequest } = makeFns({ secret: '', bypass: true });
+    assert.equal(isAuthorizedRequest(req()), true);
+    assert.equal(isAuthorizedRequest(req({ 'x-relay-key': '' })), true);
+  });
+
+  it('returns true when secret matches header', () => {
+    const { isAuthorizedRequest } = makeFns({ secret: 'good', bypass: false });
+    assert.equal(isAuthorizedRequest(req({ 'x-relay-key': 'good' })), true);
+    assert.equal(isAuthorizedRequest(req({ authorization: 'Bearer good' })), true);
+  });
+
+  it('returns false on mismatched or missing header when secret is set', () => {
+    const { isAuthorizedRequest } = makeFns({ secret: 'good', bypass: false });
+    assert.equal(isAuthorizedRequest(req()), false);
+    assert.equal(isAuthorizedRequest(req({ 'x-relay-key': 'bad' })), false);
+    assert.equal(isAuthorizedRequest(req({ 'x-relay-key': 'GOOD' })), false, 'comparison is case-sensitive');
+    assert.equal(isAuthorizedRequest(req({ authorization: 'Bearer wrong' })), false);
+  });
+
+  it('ignores the bypass var entirely when a real secret is configured', () => {
+    // Belt-and-suspenders: even if someone sets BOTH the secret AND the
+    // bypass, requests without a matching token must still be rejected.
+    const { isAuthorizedRequest } = makeFns({ secret: 'good', bypass: true });
+    assert.equal(isAuthorizedRequest(req()), false);
+    assert.equal(isAuthorizedRequest(req({ 'x-relay-key': 'good' })), true);
+    assert.equal(isAuthorizedRequest(req({ 'x-relay-key': 'bad' })), false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3801 (P1 — self-hosted Docker / VPS deployments left wide open) and #3812 (Low — cheap hardening so a no-auth relay is impossible to miss).

### What's wrong today

- `scripts/ais-relay.cjs::isAuthorizedRequest()` short-circuits to `return true` whenever `RELAY_SHARED_SECRET` is empty.
- The startup guard only requires the secret when `IS_PRODUCTION_RELAY` is truthy (i.e. `NODE_ENV=production` OR any `RAILWAY_*` env var present).
- `SELF_HOSTING.md` walks users through `docker compose up -d` without ever mentioning `RELAY_SHARED_SECRET`.

Net effect: a self-hosted deployment of the published image with no env tweaks boots successfully and every non-public relay route is publicly reachable.

### What this PR changes

- **Fail-closed startup** (`scripts/ais-relay.cjs`): drop the `IS_PRODUCTION_RELAY` qualifier. The relay refuses to boot in every environment unless an explicit opt-out is set. The FATAL message names the var to set and how to generate it.
- **Fail-closed `isAuthorizedRequest()`**: allow requests only when the bypass is explicitly engaged; otherwise reject. The startup guard should make this branch unreachable, but the function is now correct in isolation.
- **Loud `[SECURITY]` warning** at boot AND every 5 minutes (via `setInterval(...).unref()`) whenever auth is effectively disabled, so a no-auth deployment stays visible in long-running logs.
- **Rename `ALLOW_UNAUTHENTICATED_RELAY` -> `I_UNDERSTAND_THIS_DISABLES_AUTH`**. The verbose new name makes the bypass hard to set by accident. The old name is still accepted and emits a `[DEPRECATED]` warning, so existing self-hosted operators using it are not broken.
- **`auth.enabled` on `/health`**: canonical operator-visible field — `true` only when a shared secret is configured AND the bypass is NOT engaged. Lets monitoring detect a no-auth deployment without scraping logs. The legacy `auth.sharedSecretEnabled` field is preserved.
- **Docs**: `.env.example`, `SELF_HOSTING.md`, `docs/relay-parameters.mdx` updated to mark `RELAY_SHARED_SECRET` as required, document the bypass as dev-only, and surface the deprecation.

### Migration risk (please call out in release notes)

Self-hosted users who were previously running the published image **without** setting `RELAY_SHARED_SECRET` will now see the `ais-relay` container **exit at startup** on next pull. This is the intended fail-closed behavior, but it's a behavior change so it's worth announcing.

Recovery is one line:
```bash
echo "RELAY_SHARED_SECRET=$(openssl rand -hex 32)" >> .env
docker compose up -d
```
Or, for local debugging only:
```bash
echo "I_UNDERSTAND_THIS_DISABLES_AUTH=true" >> .env
```

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean
- [x] `npx tsx --test tests/relay-auth.test.mjs` — 12/12 pass
- [x] `npm run test:data` — 9242/9242 pass
- [x] `npx biome lint scripts/ais-relay.cjs tests/relay-auth.test.mjs` — no new diagnostics (30 pre-existing warnings unchanged)

New test file `tests/relay-auth.test.mjs` covers:
1. **Startup** (subprocess): exits non-zero with no secret + no bypass; boots + warns under either bypass var name; deprecation warning fires for the legacy name; no warning when secret is set.
2. **`/health.auth.enabled`**: `true` when secret set, `false` when bypass engaged, `false` when both set (bypass wins for visibility).
3. **`isAuthorizedRequest()` branches** (mirrored helper): fail-closed when nothing is set, accept under bypass, accept matching secret, reject mismatched / missing tokens, ignore bypass when secret is configured.

Closes #3801
Closes #3812

---

## Review round 2

Three Greptile P2 (quality) follow-ups, all addressed in commit `6d9f7ed88`:

1. **Misleading `[SECURITY]` warning + `/health` `auth.enabled` semantics.**
   `isAuthorizedRequest()` only consults the bypass flag when no secret is configured — set BOTH and the secret still wins. The old logic warned loudly and reported `auth.enabled: false` in the combo case, contradicting actual enforcement. Now:
   - `[SECURITY]` warning fires only when `RELAY_SHARED_SECRET` is unset (`AUTH_EFFECTIVELY_DISABLED`).
   - A separate one-shot `[Relay]` info line tells operators that a bypass set alongside a real secret is being ignored.
   - `/health` `auth.enabled` mirrors actual behavior (`true` whenever a secret is configured, regardless of bypass).
   The existing test that asserted `auth.enabled: false` in the combo case is flipped to `true`; a new test asserts the info-log line + absence of `[SECURITY]` in the combo case.

2. **TOCTOU race in `pickFreePort()` test helper.** Bind-port-0 / close / hand-back-number left a window where another process could grab the port and the child would crash with EADDRINUSE. Replaced with a re-probe retry loop (race window is tiny, exhausts after 8 attempts with a clear error).

3. **Deleted dead `IS_PRODUCTION_RELAY` constant.** No runtime callers remained after the unconditional startup-guard fix; only narrative comments reference the name as historical context.

### Round 2 verification
- [x] `npm run typecheck` — clean
- [x] `npx tsx --test tests/relay-auth.test.mjs` — 13/13 pass (was 12)
- [x] `npm run test:data` — 9243/9243 pass
- [x] `npx biome lint scripts/ais-relay.cjs tests/relay-auth.test.mjs` — no new diagnostics (30 pre-existing warnings unchanged)
- [x] `grep -rn IS_PRODUCTION_RELAY .` — only narrative comments remain, zero runtime references
