### PR TITLE
chore(ci): defense-in-depth on contributor-trust workflow (#3813)

### DIFF
--- a/.github/workflows/contributor-trust.yml
+++ b/.github/workflows/contributor-trust.yml
@@ -16,11 +16,13 @@
 #    separate `pull_request`-triggered workflow that runs with read-only
 #    permissions.
 #
-# 2. The job has `pull-requests: write`, scoped to the label-applying
-#    step only via job-level permissions. Workflow-level permissions
-#    default-deny so any future step inherits no privileges by default.
-#    If you add a step that needs additional permissions, add a
-#    step-level `permissions:` block — don't widen the job default.
+# 2. The job has `pull-requests: write`, granted at the job level.
+#    Workflow-level permissions default-deny so any future *job*
+#    inherits no privileges by default. GitHub Actions does NOT
+#    support step-level `permissions:` blocks — `permissions:` is
+#    only valid at workflow or job scope. If you need to add a step
+#    that requires different permissions, put it in a NEW JOB with
+#    its own `permissions:` block. Do NOT widen this job's grant.
 #
 # 3. External dependency: `api.brin.sh/contributor/<github-username>`.
 #    No SLA, no response signature, no fallback service. The workflow's
@@ -59,10 +61,12 @@ jobs:
       github.event.pull_request.author_association == 'CONTRIBUTOR' ||
       github.event.pull_request.author_association == 'NONE'
     runs-on: ubuntu-latest
-    # Job-level grant. The curl step needs no permissions; the
-    # label-applying step inherits this default. If steps later get more
-    # granular permission needs, use step-level `permissions:` blocks
-    # instead of widening this default.
+    # Job-level grant applies to every step in this job. The curl step
+    # uses no GITHUB_TOKEN; the label-applying step uses
+    # `pull-requests: write`. GitHub Actions has no step-level
+    # `permissions:` syntax — if a future step needs different
+    # permissions, put it in a NEW JOB with its own `permissions:`
+    # block instead of widening this one. (See workflow-header note 2.)
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/contributor-trust.yml
+++ b/.github/workflows/contributor-trust.yml
@@ -1,8 +1,54 @@
+# Contributor Trust — labels fresh-contributor PRs with a `trust:<verdict>`
+# label sourced from an external scoring service (api.brin.sh).
+#
+# ⚠ SECURITY NOTES — read before editing this workflow ⚠
+#
+# 1. `pull_request_target` is the trigger because we need write access to
+#    add labels on PRs from forks. This is the GitHub-recommended pattern
+#    for "comment/label fork PRs without running their code."
+#    See: https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+#
+#    DO NOT add `actions/checkout` to this workflow with the PR's head ref
+#    (e.g. `ref: ${{ github.event.pull_request.head.sha }}`). That would
+#    run unreviewed fork code with this workflow's elevated permissions
+#    and access to the GITHUB_TOKEN — a textbook GitHub Actions "pwn
+#    requests" CVE pattern. If you need to inspect PR code, do it in a
+#    separate `pull_request`-triggered workflow that runs with read-only
+#    permissions.
+#
+# 2. The job has `pull-requests: write`, scoped to the label-applying
+#    step only via job-level permissions. Workflow-level permissions
+#    default-deny so any future step inherits no privileges by default.
+#    If you add a step that needs additional permissions, add a
+#    step-level `permissions:` block — don't widen the job default.
+#
+# 3. External dependency: `api.brin.sh/contributor/<github-username>`.
+#    No SLA, no response signature, no fallback service. The workflow's
+#    declared fallback policy is: if the call fails, times out, returns
+#    malformed JSON, or returns an unrecognised verdict, the verdict is
+#    `unavailable` and NO label is applied (the second job's `if:` only
+#    matches the four allowlisted verdicts). This is safe because the
+#    label is purely informational — no downstream workflow gates on it
+#    (verified 2026-05-18: `grep -rn "trust:" .github/` returns only
+#    this file). If you wire any merge/auth/permission decision to a
+#    `trust:*` label, this dependency becomes load-bearing and the
+#    threat model must be re-reviewed (see #3813 review notes).
+#
+# 4. AUTHOR is interpolated into the URL path. GitHub usernames are
+#    constrained to `[A-Za-z0-9-]` so URL injection is structurally
+#    impossible; the curl call uses `-sf` and a 10s timeout to fail
+#    closed on any HTTP error.
+
 name: Contributor Trust
 
 on:
   pull_request_target:
     types: [opened, reopened]
+
+# Workflow-level default-deny — every job must explicitly grant any
+# permission it needs. Defense-in-depth against a future job inheriting
+# unintended privileges.
+permissions: {}
 
 jobs:
   check:
@@ -13,6 +59,10 @@ jobs:
       github.event.pull_request.author_association == 'CONTRIBUTOR' ||
       github.event.pull_request.author_association == 'NONE'
     runs-on: ubuntu-latest
+    # Job-level grant. The curl step needs no permissions; the
+    # label-applying step inherits this default. If steps later get more
+    # granular permission needs, use step-level `permissions:` blocks
+    # instead of widening this default.
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
## Summary

Per issue #3813, \`.github/workflows/contributor-trust.yml\` uses \`pull_request_target\` with \`pull-requests: write\` and an unvalidated outbound call to \`api.brin.sh\`. After verifying against the actual workflow:

- The workflow does NOT run \`actions/checkout\` — fork code never executes in the privileged context. The reporter acknowledged this is a **latent** (not active) risk.
- The label is purely informational. \`grep -rn "trust:" .github/\` confirms no other workflow gates on \`trust:*\` labels, so a malicious verdict from \`api.brin.sh\` cannot "fast-track" anything today.
- \`pull_request_target\` is the **correct GitHub-recommended trigger** for "label/comment fork PRs without running their code." Switching to \`pull_request\` (the reporter's recommendation #1) would break the feature entirely — \`GITHUB_TOKEN\` is read-only from fork PRs under \`pull_request\`. We **decline** that change.

## Change

This PR addresses the legitimate residual concerns without breaking the feature:

1. **\`permissions: {}\` at workflow level** — every job must explicitly grant what it needs. Defense-in-depth against a future job inheriting unintended privileges.

2. **Load-bearing comment block at the top of the file** warning future maintainers NEVER to add \`actions/checkout\` with the PR head ref — the textbook pwn-requests CVE pattern the reporter's "future workflow extension" scenario describes. Links to GitHub's own security advisory.

3. **Documents \`api.brin.sh\` as an external dependency** with the declared fallback policy (call fails / malformed JSON / unrecognised verdict → \`unavailable\` → NO label applied — already what the code does, just not previously documented). Includes the load-bearing-ness guard: if anyone wires merge gating to \`trust:*\` labels, the threat model must be re-reviewed.

4. **URL injection acknowledged but bounded** — GitHub usernames are \`[A-Za-z0-9-]\`, so path injection is structurally impossible. Documented in-line.

No code-path behaviour change; semantically identical to the original workflow except for the workflow-level permissions tightening. The real value is in making the invariants future maintainers must preserve impossible to miss.

## Test plan

- [x] YAML parses (\`python3 -c "import yaml; yaml.safe_load(open(...))\"\`) — valid
- [x] Workflow definition unchanged behaviour-wise (same triggers, same job conditional, same step ordering, same action ref, same script body)
- [x] Verified no other workflow consumes \`trust:*\` labels (\`grep -rn "trust:" .github/\` returns only this file)

Addresses #3813.