### PR TITLE
test(security): drop vacuous runtime smoke test from secret guard (#3786 follow-up)

### DIFF
--- a/tests/browser-bundle-secret-guard.test.mts
+++ b/tests/browser-bundle-secret-guard.test.mts
@@ -145,22 +145,23 @@ describe('browser bundle secret guard (#3704)', () => {
     }
   });
 
-  it('runtime-config snapshot does not contain a platform-only secret at module load', async () => {
-    // Dynamic import so the module loads in this Node test runner. The
-    // Vite-injected `import.meta.env` is absent in node:test, so any
-    // platform secret that ends up in the snapshot here is provably
-    // coming from a non-Vite path (e.g. someone hard-coding the value
-    // in seedSecretsFromEnvironment or a default initializer).
-    const mod = await import('../src/services/runtime-config.ts');
-    const snapshot = mod.getRuntimeConfigSnapshot();
-    for (const secret of PLATFORM_ONLY_SECRETS) {
-      assert.equal(
-        (snapshot.secrets as Record<string, unknown>)[secret],
-        undefined,
-        `${secret} was seeded into runtimeConfig.secrets at module load time. ` +
-          `Platform secrets must never appear in the browser runtime snapshot. ` +
-          `See issue #3704.`,
-      );
-    }
-  });
+  // ─────────────────────────────────────────────────────────────────
+  // NOTE: a prior draft of this file included a 4th test that imported
+  // `runtime-config.ts` and asserted `getRuntimeConfigSnapshot().secrets`
+  // contained no platform-only secret at module load. Greptile flagged
+  // it (PR #3786 review) as vacuous: in node:test, `import.meta.env` is
+  // undefined, so `readEnvSecret()` returns `''` for every key
+  // regardless of what's in `process.env` or what's listed in
+  // `requiredSecrets`. The snapshot is always empty and the assertion
+  // always passes — even if `WORLDMONITOR_API_KEY` were added to a
+  // `requiredSecrets` array (the exact regression test #1 above catches).
+  //
+  // The HONEST runtime check is a bundle-content grep after `npm run build`:
+  //
+  //   npm run build
+  //   grep -r "WORLDMONITOR_API_KEY" dist/  # must return zero hits
+  //
+  // That's done at deploy time, not unit-test time. Tests #1–#3 above
+  // are the load-bearing CI guards.
+  // ─────────────────────────────────────────────────────────────────
 });


### PR DESCRIPTION
Follow-up to #3786 (merged at 16:43Z) addressing the P2 review comment from Greptile that I caught after the merge window closed.

## Summary

The 4th test in the secret-guard suite was passing vacuously:

\`\`\`ts
it('runtime-config snapshot does not contain a platform-only secret at module load', async () => {
  const mod = await import('../src/services/runtime-config.ts');
  const snapshot = mod.getRuntimeConfigSnapshot();
  for (const secret of PLATFORM_ONLY_SECRETS) {
    assert.equal(snapshot.secrets[secret], undefined, '…');
  }
});
\`\`\`

In \`node:test\`, \`import.meta.env\` is undefined → \`readEnvSecret()\` returns \`''\` for every key regardless of \`process.env\` or \`requiredSecrets\` contents → the snapshot is **always empty** → the assertion **always passes**, even if a contributor adds \`WORLDMONITOR_API_KEY\` to a \`requiredSecrets\` array (the exact regression test #1 catches via source-grep).

This provided **false confidence**, not real defense-in-depth.

## Change

Drop the test. Replace with an inline note explaining (a) why it was removed and (b) where the honest runtime check belongs:

\`\`\`bash
npm run build
grep -r \"WORLDMONITOR_API_KEY\" dist/  # must return zero hits
\`\`\`

That's a deploy-time / manual check, not a unit-test guard. Tests #1–#3 (requiredSecrets scan, define-block scan, envPrefix array-form scan) remain as the load-bearing CI guards.

## Test plan

- [x] 3/3 remaining tests pass (\`npx tsx --test tests/browser-bundle-secret-guard.test.mts\`)
- [x] \`npm run typecheck\` — clean
- [x] Self-check verified: deliberately adding WORLDMONITOR_API_KEY to a \`requiredSecrets\` array now causes test #1 to fail (as intended); previously test #4 would also fail vacuously \"for free\" but test #1 was already catching it.

The dropped-test pattern is now documented in \`~/.claude/skills/test-ci-gotchas/reference/vacuous-test-when-runtime-injected-context-absent.md\` (extracted this session) so the same trap doesn't get re-introduced.

Background: this commit was originally part of the #3786 review-response work but missed the merge window when you merged #3786 before my push completed. Greptile's P2 comment lives on the merged PR; replies posted there acknowledging this PR.