### PR TITLE
fix(mcp-proxy): add per-IP rate limit + structured audit log (#3805)

### DIFF
--- a/api/mcp-proxy.ts
+++ b/api/mcp-proxy.ts
@@ -5,8 +5,50 @@
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { jsonResponse } from './_json-response.js';
 import { isCallerPremium } from '../server/_shared/premium-check';
+import { checkScopedRateLimit } from '../server/_shared/rate-limit';
 
 export const config = { runtime: 'edge' };
+
+// Per-IP rate limit for the MCP proxy (issue #3805 defense-in-depth).
+// 30/min/IP is generous for normal MCP polling (most clients refresh every
+// 30-60s) while bounding abuse to ~1800 calls/hour/IP — well below the
+// global 600/min cap. Auth gate already requires a Pro caller; this limit
+// closes the residual surface where a single Pro key cycles the proxy.
+const RATE_LIMIT_SCOPE = '/api/mcp-proxy';
+const RATE_LIMIT_MAX = 30;
+const RATE_LIMIT_WINDOW = '60 s' as const;
+const RATE_LIMIT_ERROR_CODE = -32029; // JSON-RPC code mirrored from api/mcp.ts
+
+function getClientIp(req: Request): string {
+  // cf-connecting-ip is the only header that survives Cloudflare → Vercel
+  // unforged. x-forwarded-for is client-settable and must NOT be trusted
+  // for rate limiting — see api/_rate-limit.js notes (#3721).
+  return (
+    req.headers.get('cf-connecting-ip') ||
+    req.headers.get('x-real-ip') ||
+    '0.0.0.0'
+  );
+}
+
+function logProxyCall(entry: {
+  ip: string;
+  target_host: string;
+  target_path: string;
+  method: string;
+  header_names: string[];
+  status: number;
+  duration_ms: number;
+}): void {
+  // Structured audit log (#3805). Mirrors the `[name] { ...fields }` shape
+  // used by api/cache-purge.js so the existing log-ingest tooling parses it
+  // cleanly. Never include header VALUES — they often carry user-supplied
+  // Authorization / API-Key secrets that the proxy intentionally forwards.
+  console.log('[mcp-proxy]', {
+    event: 'mcp_proxy_call',
+    ts: new Date().toISOString(),
+    ...entry,
+  });
+}
 
 const TIMEOUT_MS = 15_000;
 const SSE_CONNECT_TIMEOUT_MS = 10_000;
@@ -331,6 +373,52 @@ async function mcpCallToolSse(serverUrl, toolName, toolArgs, customHeaders) {
 
 // --- Request handler ---
 
+interface ProxyMeta {
+  targetHost: string;
+  targetPath: string;
+  headerNames: string[];
+}
+
+function captureMeta(serverUrl: URL, customHeaders: unknown, meta: ProxyMeta): void {
+  meta.targetHost = serverUrl.hostname;
+  meta.targetPath = serverUrl.pathname;
+  meta.headerNames = Object.keys((customHeaders as Record<string, unknown>) || {})
+    .filter((k) => typeof k === 'string' && !k.includes('\r') && !k.includes('\n'))
+    .sort();
+}
+
+async function handleListTools(req: Request, cors: Record<string, string>, meta: ProxyMeta): Promise<Response> {
+  const url = new URL(req.url);
+  const rawServer = url.searchParams.get('serverUrl');
+  const rawHeaders = url.searchParams.get('headers');
+  if (!rawServer) return jsonResponse({ error: 'Missing serverUrl' }, 400, cors);
+  const serverUrl = validateServerUrl(rawServer);
+  if (!serverUrl) return jsonResponse({ error: 'Invalid serverUrl' }, 400, cors);
+  let customHeaders = {};
+  if (rawHeaders) {
+    try { customHeaders = JSON.parse(rawHeaders); } catch { /* ignore */ }
+  }
+  captureMeta(serverUrl, customHeaders, meta);
+  const tools = isSseTransport(serverUrl)
+    ? await mcpListToolsSse(serverUrl, customHeaders)
+    : await mcpListTools(serverUrl, customHeaders);
+  return jsonResponse({ tools }, 200, cors);
+}
+
+async function handleCallTool(req: Request, cors: Record<string, string>, meta: ProxyMeta): Promise<Response> {
+  const body = await req.json();
+  const { serverUrl: rawServer, toolName, toolArgs, customHeaders } = body;
+  if (!rawServer) return jsonResponse({ error: 'Missing serverUrl' }, 400, cors);
+  if (!toolName) return jsonResponse({ error: 'Missing toolName' }, 400, cors);
+  const serverUrl = validateServerUrl(rawServer);
+  if (!serverUrl) return jsonResponse({ error: 'Invalid serverUrl' }, 400, cors);
+  captureMeta(serverUrl, customHeaders, meta);
+  const result = isSseTransport(serverUrl)
+    ? await mcpCallToolSse(serverUrl, toolName, toolArgs || {}, customHeaders || {})
+    : await mcpCallTool(serverUrl, toolName, toolArgs || {}, customHeaders || {});
+  return jsonResponse({ result }, 200, { ...cors, 'Cache-Control': 'no-store' });
+}
+
 export default async function handler(req) {
   if (isDisallowedOrigin(req))
     return new Response('Forbidden', { status: 403 });
@@ -365,42 +453,73 @@ export default async function handler(req) {
   if (!(await isCallerPremium(req)))
     return jsonResponse({ error: 'Pro authentication required' }, 401, cors);
 
+  const started = Date.now();
+  const ip = getClientIp(req);
+  const meta: ProxyMeta = { targetHost: '', targetPath: '', headerNames: [] };
+
+  // Per-IP rate limit (#3805). Runs AFTER auth/CORS so unauthenticated and
+  // cross-origin callers are still rejected first (cheaper to short-circuit
+  // without a Redis round-trip). On Redis error checkScopedRateLimit
+  // fail-opens — matches checkRateLimit / checkEndpointRateLimit semantics.
+  const scoped = await checkScopedRateLimit(RATE_LIMIT_SCOPE, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW, ip);
+  if (!scoped.allowed) {
+    const retryAfter = Math.max(1, Math.ceil((scoped.reset - Date.now()) / 1000));
+    logProxyCall({
+      ip,
+      target_host: meta.targetHost,
+      target_path: meta.targetPath,
+      method: req.method,
+      header_names: meta.headerNames,
+      status: 429,
+      duration_ms: Date.now() - started,
+    });
+    // JSON-RPC -32029 mirrors api/mcp.ts; HTTP 429 + Retry-After follows the
+    // shared rate-limit response shape.
+    return new Response(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: null,
+        error: { code: RATE_LIMIT_ERROR_CODE, message: 'Rate limit exceeded. Max 30 requests per minute per IP.' },
+      }),
+      {
+        status: 429,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-RateLimit-Limit': String(scoped.limit),
+          'X-RateLimit-Remaining': '0',
+          'X-RateLimit-Reset': String(scoped.reset),
+          'Retry-After': String(retryAfter),
+          ...cors,
+        },
+      },
+    );
+  }
+
+  let response: Response;
   try {
     if (req.method === 'GET') {
-      const url = new URL(req.url);
-      const rawServer = url.searchParams.get('serverUrl');
-      const rawHeaders = url.searchParams.get('headers');
-      if (!rawServer) return jsonResponse({ error: 'Missing serverUrl' }, 400, cors);
-      const serverUrl = validateServerUrl(rawServer);
-      if (!serverUrl) return jsonResponse({ error: 'Invalid serverUrl' }, 400, cors);
-      let customHeaders = {};
-      if (rawHeaders) {
-        try { customHeaders = JSON.parse(rawHeaders); } catch { /* ignore */ }
-      }
-      const tools = isSseTransport(serverUrl)
-        ? await mcpListToolsSse(serverUrl, customHeaders)
-        : await mcpListTools(serverUrl, customHeaders);
-      return jsonResponse({ tools }, 200, cors);
+      response = await handleListTools(req, cors, meta);
+    } else if (req.method === 'POST') {
+      response = await handleCallTool(req, cors, meta);
+    } else {
+      response = jsonResponse({ error: 'Method not allowed' }, 405, cors);
     }
-
-    if (req.method === 'POST') {
-      const body = await req.json();
-      const { serverUrl: rawServer, toolName, toolArgs, customHeaders } = body;
-      if (!rawServer) return jsonResponse({ error: 'Missing serverUrl' }, 400, cors);
-      if (!toolName) return jsonResponse({ error: 'Missing toolName' }, 400, cors);
-      const serverUrl = validateServerUrl(rawServer);
-      if (!serverUrl) return jsonResponse({ error: 'Invalid serverUrl' }, 400, cors);
-      const result = isSseTransport(serverUrl)
-        ? await mcpCallToolSse(serverUrl, toolName, toolArgs || {}, customHeaders || {})
-        : await mcpCallTool(serverUrl, toolName, toolArgs || {}, customHeaders || {});
-      return jsonResponse({ result }, 200, { ...cors, 'Cache-Control': 'no-store' });
-    }
-
-    return jsonResponse({ error: 'Method not allowed' }, 405, cors);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     const isTimeout = msg.includes('TimeoutError') || msg.includes('timed out');
     // Return 422 (not 502) so Cloudflare proxy does not replace our JSON body with its own HTML error page
-    return jsonResponse({ error: isTimeout ? 'MCP server timed out' : msg }, isTimeout ? 504 : 422, cors);
+    response = jsonResponse({ error: isTimeout ? 'MCP server timed out' : msg }, isTimeout ? 504 : 422, cors);
   }
+
+  logProxyCall({
+    ip,
+    target_host: meta.targetHost,
+    target_path: meta.targetPath,
+    method: req.method,
+    header_names: meta.headerNames,
+    status: response.status,
+    duration_ms: Date.now() - started,
+  });
+
+  return response;
 }

--- a/api/mcp-proxy.ts
+++ b/api/mcp-proxy.ts
@@ -5,7 +5,7 @@
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { jsonResponse } from './_json-response.js';
 import { isCallerPremium } from '../server/_shared/premium-check';
-import { checkScopedRateLimit } from '../server/_shared/rate-limit';
+import { ENDPOINT_RATE_POLICIES, checkScopedRateLimit } from '../server/_shared/rate-limit';
 
 export const config = { runtime: 'edge' };
 
@@ -14,9 +14,25 @@ export const config = { runtime: 'edge' };
 // 30-60s) while bounding abuse to ~1800 calls/hour/IP — well below the
 // global 600/min cap. Auth gate already requires a Pro caller; this limit
 // closes the residual surface where a single Pro key cycles the proxy.
+//
+// PR #3821 r2: source the limit from ENDPOINT_RATE_POLICIES so the
+// `enforce-rate-limit-policies` audit can see this endpoint. mcp-proxy is a
+// top-level Vercel Edge Function (not gateway-routed), so it can't use
+// `checkEndpointRateLimit`; we keep `checkScopedRateLimit` for in-handler
+// enforcement but the *policy* lives in the registry. Single source of
+// truth — tweak the limit there, this handler picks it up.
 const RATE_LIMIT_SCOPE = '/api/mcp-proxy';
-const RATE_LIMIT_MAX = 30;
-const RATE_LIMIT_WINDOW = '60 s' as const;
+const RATE_LIMIT_POLICY = ENDPOINT_RATE_POLICIES[RATE_LIMIT_SCOPE];
+if (!RATE_LIMIT_POLICY) {
+  // Module-load failure — better to crash the function cold-start with a
+  // loud message than to silently fall back to "no rate limit" if someone
+  // accidentally deletes the registry entry.
+  throw new Error(
+    `[mcp-proxy] missing ENDPOINT_RATE_POLICIES['${RATE_LIMIT_SCOPE}'] — see server/_shared/rate-limit.ts`,
+  );
+}
+const RATE_LIMIT_MAX = RATE_LIMIT_POLICY.limit;
+const RATE_LIMIT_WINDOW = RATE_LIMIT_POLICY.window;
 const RATE_LIMIT_ERROR_CODE = -32029; // JSON-RPC code mirrored from api/mcp.ts
 
 function getClientIp(req: Request): string {
@@ -479,7 +495,7 @@ export default async function handler(req) {
       JSON.stringify({
         jsonrpc: '2.0',
         id: null,
-        error: { code: RATE_LIMIT_ERROR_CODE, message: 'Rate limit exceeded. Max 30 requests per minute per IP.' },
+        error: { code: RATE_LIMIT_ERROR_CODE, message: `Rate limit exceeded. Max ${RATE_LIMIT_MAX} requests per ${RATE_LIMIT_WINDOW} per IP.` },
       }),
       {
         status: 429,

--- a/scripts/enforce-rate-limit-policies.mjs
+++ b/scripts/enforce-rate-limit-policies.mjs
@@ -12,6 +12,13 @@
  * `tsx` so it can import the policy object straight from the TS source
  * (#3278) — the previous regex-parse implementation would silently break if
  * the source object literal was reformatted.
+ *
+ * PR #3821 r2: also resolves keys against api/api-route-exceptions.json so
+ * top-level Vercel Edge Functions (e.g. /api/mcp-proxy, an external-protocol
+ * exception that can't flow through the gateway) can register a policy and
+ * enforce it in-handler via `checkScopedRateLimit` without becoming invisible
+ * to this audit. Without this branch, /api/mcp-proxy would silently slip
+ * through future endpoint-coverage checks even though it has a live limit.
  */
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
@@ -21,6 +28,7 @@ import { parse as parseYaml } from 'yaml';
 const ROOT = new URL('..', import.meta.url).pathname;
 const OPENAPI_DIR = join(ROOT, 'docs/api');
 const RATE_LIMIT_SRC = join(ROOT, 'server/_shared/rate-limit.ts');
+const API_EXCEPTIONS = join(ROOT, 'api/api-route-exceptions.json');
 
 async function extractPolicyKeys() {
   // Dynamic import via the file URL — works under tsx (the shebang) which
@@ -54,18 +62,55 @@ function extractRoutesFromOpenApi() {
   return routes;
 }
 
+function extractEdgeFunctionRoutes() {
+  // Top-level Vercel Edge Functions registered as non-proto exceptions in
+  // api/api-route-exceptions.json don't appear in docs/api/*.openapi.yaml
+  // (no proto → no generated path). They can still register a rate-limit
+  // policy that's enforced in-handler via `checkScopedRateLimit` — most
+  // notably /api/mcp-proxy (PR #3821 / #3805 review). Convert each exception
+  // file path (e.g. "api/mcp-proxy.ts") to its URL path ("/api/mcp-proxy")
+  // and accept it as a legitimate policy target.
+  const routes = new Set();
+  let doc;
+  try {
+    doc = JSON.parse(readFileSync(API_EXCEPTIONS, 'utf8'));
+  } catch (err) {
+    // Don't hard-fail if the exceptions file moves — gateway-route validation
+    // (the original behaviour) still runs. Surface a warning so the loss of
+    // edge-function coverage is visible.
+    console.warn(`⚠ could not read ${API_EXCEPTIONS}: ${err.message}`);
+    return routes;
+  }
+  const exceptions = Array.isArray(doc?.exceptions) ? doc.exceptions : [];
+  for (const entry of exceptions) {
+    const filePath = typeof entry?.path === 'string' ? entry.path : null;
+    if (!filePath?.startsWith('api/')) continue;
+    // api/mcp-proxy.ts → /api/mcp-proxy ; api/oauth/token.ts → /api/oauth/token
+    const urlPath = `/${filePath.replace(/\.(ts|js|tsx|jsx|mjs|cjs)$/i, '')}`;
+    routes.add(urlPath);
+  }
+  return routes;
+}
+
 async function main() {
   const keys = await extractPolicyKeys();
-  const routes = extractRoutesFromOpenApi();
-  const missing = keys.filter((k) => !routes.has(k));
+  const gatewayRoutes = extractRoutesFromOpenApi();
+  const edgeRoutes = extractEdgeFunctionRoutes();
+  const missing = keys.filter((k) => !gatewayRoutes.has(k) && !edgeRoutes.has(k));
 
   if (missing.length > 0) {
-    console.error('✗ ENDPOINT_RATE_POLICIES key(s) do not match any generated gateway route:\n');
+    console.error('✗ ENDPOINT_RATE_POLICIES key(s) do not match any gateway route OR edge-function exception:\n');
     for (const key of missing) {
       console.error(`  - ${key}`);
     }
-    console.error('\nEach key must be a proto-generated RPC path. Check that:');
-    console.error('  1. The key matches the path in docs/api/<Service>.openapi.yaml exactly.');
+    console.error('\nEach key must be either:');
+    console.error('  (a) a proto-generated RPC path that appears in docs/api/<Service>.openapi.yaml');
+    console.error('      (gateway-enforced via checkEndpointRateLimit), OR');
+    console.error('  (b) a top-level Vercel Edge Function registered in');
+    console.error('      api/api-route-exceptions.json (enforced in-handler via checkScopedRateLimit).');
+    console.error('\nChecklist:');
+    console.error('  1. The key matches the path in docs/api/<Service>.openapi.yaml exactly, OR');
+    console.error('     api/<that-key>.ts (or .js) is listed in api/api-route-exceptions.json.');
     console.error('  2. If you renamed the RPC in proto, update the policy key to match.');
     console.error('  3. If the policy is for a non-proto legacy route, remove it once that route is migrated.\n');
     console.error('Similar issues in history: review of #3242 flagged the sanctions-entity-search');
@@ -74,7 +119,9 @@ async function main() {
     process.exit(1);
   }
 
-  console.log(`✓ rate-limit policies clean: ${keys.length} policies validated against ${routes.size} gateway routes.`);
+  console.log(
+    `✓ rate-limit policies clean: ${keys.length} policies validated against ${gatewayRoutes.size} gateway routes + ${edgeRoutes.size} edge-function exceptions.`,
+  );
 }
 
 main().catch((err) => {

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -105,6 +105,17 @@ export const ENDPOINT_RATE_POLICIES: Record<string, EndpointRatePolicy> = {
   // = 6 req/min/IP base load. 60/min headroom covers tab refreshes + zoom
   // pans within a single user without flagging legitimate traffic.
   '/api/maritime/v1/get-vessel-snapshot': { limit: 60, window: '60 s' },
+  // #3805 / PR #3821: MCP proxy is a top-level Vercel Edge Function in
+  // `api/mcp-proxy.ts` (registered as `external-protocol` in
+  // api/api-route-exceptions.json — JSON-RPC shape dictated by the MCP spec),
+  // so it does NOT flow through the gateway and `checkEndpointRateLimit`
+  // never fires for it. The handler reads this policy and enforces it
+  // in-handler via `checkScopedRateLimit` — keeping the registry as the
+  // single source of truth so future audit additions (and the
+  // enforce-rate-limit-policies lint) see the endpoint. The audit script
+  // resolves edge-function paths via api/api-route-exceptions.json instead
+  // of the OpenAPI specs.
+  '/api/mcp-proxy': { limit: 30, window: '60 s' },
 };
 
 const endpointLimiters = new Map<string, Ratelimit>();

--- a/tests/mcp-proxy.test.mjs
+++ b/tests/mcp-proxy.test.mjs
@@ -31,15 +31,35 @@ function buildHeaders(origin, { authed = true, extra = {} } = {}) {
   return h;
 }
 
-// @upstash/ratelimit caches block decisions locally (Map keyed by identifier)
-// — so once a test rate-limits a given IP, subsequent tests using the same IP
-// stay blocked for the window even if Redis is reachable / mocked differently.
-// Generate a unique caller IP per request so tests are independent. Uses
-// cf-connecting-ip because the proxy's getClientIp prefers that header.
+// @upstash/ratelimit's module-level `Cache.blockUntil` persists block
+// decisions for the configured window — once a test rate-limits a given IP,
+// subsequent tests reusing the same IP stay blocked even if Redis is mocked
+// to allow them. The pool must therefore span the full test suite without
+// recycling. We use a /16 (10.<high>.<low>.0 = 65,536 IPs), which is the
+// TEST-NET-3-style spirit applied to RFC1918 space; the proxy's getClientIp
+// prefers cf-connecting-ip so the value is consumed verbatim (no DNS).
+//
+// Earlier this helper used `203.0.113.${counter % 250}` and wrapped at 250
+// requests — flaky as soon as the suite grew past ~250 rate-limit-touching
+// cases, because a previously-blocked IP would silently fail downstream
+// tests. PR #3821 r2.
 let __testIpCounter = 0;
 function uniqueCallerIp() {
   __testIpCounter += 1;
-  return `203.0.113.${__testIpCounter % 250}`;
+  if (__testIpCounter > 0xffff) {
+    // Hard fail rather than wrap — the wrap is the bug we're avoiding above.
+    // If the suite ever genuinely needs >65,536 unique caller IPs, expand
+    // the pool to a /8 first (and rethink whether the rate-limit cache
+    // should be reset between describe blocks instead).
+    throw new Error(
+      `[mcp-proxy test] uniqueCallerIp() exhausted the /16 pool (>${0xffff} calls). ` +
+        `Recycling an IP risks reviving @upstash/ratelimit's module-level Cache.blockUntil ` +
+        `state from an earlier test. Expand the pool or reset the limiter cache.`,
+    );
+  }
+  const high = (__testIpCounter >> 8) & 0xff;
+  const low = __testIpCounter & 0xff;
+  return `10.${high}.${low}.0`;
 }
 
 function makeGetRequest(params = {}, origin = 'https://worldmonitor.app', opts = {}) {

--- a/tests/mcp-proxy.test.mjs
+++ b/tests/mcp-proxy.test.mjs
@@ -31,6 +31,17 @@ function buildHeaders(origin, { authed = true, extra = {} } = {}) {
   return h;
 }
 
+// @upstash/ratelimit caches block decisions locally (Map keyed by identifier)
+// — so once a test rate-limits a given IP, subsequent tests using the same IP
+// stay blocked for the window even if Redis is reachable / mocked differently.
+// Generate a unique caller IP per request so tests are independent. Uses
+// cf-connecting-ip because the proxy's getClientIp prefers that header.
+let __testIpCounter = 0;
+function uniqueCallerIp() {
+  __testIpCounter += 1;
+  return `203.0.113.${__testIpCounter % 250}`;
+}
+
 function makeGetRequest(params = {}, origin = 'https://worldmonitor.app', opts = {}) {
   const url = new URL('https://worldmonitor.app/api/mcp-proxy');
   for (const [k, v] of Object.entries(params)) {
@@ -527,5 +538,223 @@ describe('api/mcp-proxy', () => {
       const data = await res.json();
       assert.equal(data.tools[0].name, 'web_search');
     });
+  });
+
+  // ── Rate limit + audit log (issue #3805) ─────────────────────────────────
+  //
+  // Defense-in-depth additions to the proxy:
+  //   1) Per-IP 30/min cap so even an authenticated Pro key cannot drive
+  //      unbounded outbound traffic from the WM IP.
+  //   2) Structured audit log per call recording who proxied to where and
+  //      which header NAMES (not values) they forwarded — so an
+  //      incident-response can reconstruct activity without leaking the
+  //      Authorization / X-Api-Key secrets the proxy intentionally relays.
+
+  describe('Rate limit (#3805)', () => {
+    let savedRedisUrl;
+    let savedRedisTok;
+
+    beforeEach(() => {
+      savedRedisUrl = process.env.UPSTASH_REDIS_REST_URL;
+      savedRedisTok = process.env.UPSTASH_REDIS_REST_TOKEN;
+    });
+
+    afterEach(() => {
+      if (savedRedisUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+      else process.env.UPSTASH_REDIS_REST_URL = savedRedisUrl;
+      if (savedRedisTok === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+      else process.env.UPSTASH_REDIS_REST_TOKEN = savedRedisTok;
+    });
+
+    it('returns 429 + JSON-RPC -32029 + Retry-After when rate-limited', async () => {
+      process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+      process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+      // Mock Upstash REST — @upstash/ratelimit's sliding-window EVAL
+      // returns `[remainingTokens, effectiveLimit]` per command, wrapped in
+      // an auto-pipelining envelope `[{ result: [...] }]`. We force
+      // remainingTokens=-1 to trigger success=false (→ 429).
+      globalThis.fetch = async (url) => {
+        const u = url.toString();
+        if (u.includes('fake.upstash.io')) {
+          return new Response(
+            JSON.stringify([{ result: [-1, 30] }]),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+        return new Response('{}', { status: 200 });
+      };
+
+      const ip = uniqueCallerIp();
+      const res = await handler(makeGetRequest(
+        { serverUrl: 'https://mcp.example.com/mcp' },
+        'https://worldmonitor.app',
+        { extra: { 'cf-connecting-ip': ip } },
+      ));
+      assert.equal(res.status, 429, 'must return HTTP 429 on rate-limit hit');
+      assert.ok(res.headers.get('Retry-After'), 'must include Retry-After header');
+      assert.ok(Number(res.headers.get('Retry-After')) >= 1, 'Retry-After must be >= 1s');
+      const body = await res.json();
+      assert.equal(body.error?.code, -32029, 'must return JSON-RPC -32029');
+      assert.match(body.error.message, /rate limit/i);
+    });
+
+    it('rate-limit fail-opens when Upstash is unreachable (graceful degradation)', async () => {
+      process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+      process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+
+      // Simulate Upstash hard-failure: scoped limiter should fail-open and
+      // the request still completes. Mock fetch returns network error for
+      // Upstash but normal MCP responses for the upstream MCP server.
+      globalThis.fetch = async (url, opts) => {
+        const u = url.toString();
+        if (u.includes('fake.upstash.io')) throw new TypeError('fetch failed');
+        return makeMcpFetch({ tools: [] })(url, opts);
+      };
+
+      const ip = uniqueCallerIp();
+      const res = await handler(makeGetRequest(
+        { serverUrl: 'https://mcp.example.com/mcp' },
+        'https://worldmonitor.app',
+        { extra: { 'cf-connecting-ip': ip } },
+      ));
+      assert.equal(res.status, 200, 'rate-limit must fail-open on Redis error');
+    });
+  });
+
+  describe('Audit log (#3805)', () => {
+    let logSpy;
+    const originalLog = console.log;
+
+    beforeEach(() => {
+      logSpy = [];
+      console.log = (...args) => { logSpy.push(args); };
+    });
+
+    afterEach(() => {
+      console.log = originalLog;
+    });
+
+    function findProxyLog() {
+      return logSpy.find((a) => a[0] === '[mcp-proxy]');
+    }
+
+    it('emits a structured audit log line on a successful GET', async () => {
+      globalThis.fetch = makeMcpFetch({ tools: [] });
+      const res = await handler(makeGetRequest(
+        { serverUrl: 'https://mcp.example.com/mcp' },
+        'https://worldmonitor.app',
+        { extra: { 'cf-connecting-ip': uniqueCallerIp() } },
+      ));
+      assert.equal(res.status, 200);
+
+      const log = findProxyLog();
+      assert.ok(log, 'expected an [mcp-proxy] audit log line');
+      const entry = log[1];
+      assert.equal(entry.event, 'mcp_proxy_call');
+      assert.equal(entry.target_host, 'mcp.example.com');
+      assert.equal(entry.target_path, '/mcp');
+      assert.equal(entry.method, 'GET');
+      assert.equal(entry.status, 200);
+      assert.ok(typeof entry.duration_ms === 'number');
+      assert.ok(typeof entry.ts === 'string');
+      assert.ok(Array.isArray(entry.header_names));
+    });
+
+    it('audit log contains header NAMES but never header VALUES (no secret leakage)', async () => {
+      globalThis.fetch = makeMcpFetch({ tools: [] });
+      const res = await handler(makeGetRequest(
+        {
+          serverUrl: 'https://mcp.example.com/mcp',
+          headers: JSON.stringify({ Authorization: 'Bearer super-secret-token-XYZ', 'X-Api-Key': 'k_abc123' }),
+        },
+        'https://worldmonitor.app',
+        { extra: { 'cf-connecting-ip': uniqueCallerIp() } },
+      ));
+      assert.equal(res.status, 200);
+
+      const log = findProxyLog();
+      assert.ok(log, 'expected an [mcp-proxy] audit log line');
+      const entry = log[1];
+      assert.deepEqual(entry.header_names.sort(), ['Authorization', 'X-Api-Key'].sort());
+
+      // CRITICAL: the entire serialized log line must NOT contain the
+      // secret values that the proxy intentionally forwards upstream.
+      const serialized = JSON.stringify(log);
+      assert.ok(!serialized.includes('super-secret-token-XYZ'), 'audit log MUST NOT contain Authorization value');
+      assert.ok(!serialized.includes('k_abc123'), 'audit log MUST NOT contain X-Api-Key value');
+      assert.ok(!serialized.includes('Bearer '), 'audit log MUST NOT contain Bearer prefix from a real header value');
+    });
+
+    it('audit log target_path does NOT include the query string (query may carry tokens)', async () => {
+      globalThis.fetch = makeMcpFetch({ tools: [] });
+      // Some MCP servers accept ?token=... in the URL — make sure that
+      // never lands in the structured log.
+      const res = await handler(makeGetRequest(
+        { serverUrl: 'https://mcp.example.com/mcp?token=querystring-secret-ABCDEF' },
+        'https://worldmonitor.app',
+        { extra: { 'cf-connecting-ip': uniqueCallerIp() } },
+      ));
+      assert.equal(res.status, 200);
+
+      const log = findProxyLog();
+      assert.ok(log);
+      const entry = log[1];
+      assert.equal(entry.target_path, '/mcp', 'target_path must be pathname only');
+      const serialized = JSON.stringify(log);
+      assert.ok(!serialized.includes('querystring-secret-ABCDEF'), 'audit log MUST NOT capture query string secrets');
+    });
+
+    it('emits audit log with status: 429 on a rate-limit block', async () => {
+      const savedRedisUrl = process.env.UPSTASH_REDIS_REST_URL;
+      const savedRedisTok = process.env.UPSTASH_REDIS_REST_TOKEN;
+      process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+      process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+      try {
+        globalThis.fetch = async (url) => {
+          const u = url.toString();
+          if (u.includes('fake.upstash.io')) {
+            return new Response(
+              JSON.stringify([{ result: [-1, 30] }]),
+              { status: 200, headers: { 'Content-Type': 'application/json' } },
+            );
+          }
+          return new Response('{}', { status: 200 });
+        };
+        const res = await handler(makeGetRequest(
+          { serverUrl: 'https://mcp.example.com/mcp' },
+          'https://worldmonitor.app',
+          { extra: { 'cf-connecting-ip': uniqueCallerIp() } },
+        ));
+        assert.equal(res.status, 429);
+        const log = findProxyLog();
+        assert.ok(log, 'must emit audit log on rate-limit block');
+        assert.equal(log[1].status, 429);
+        assert.equal(log[1].event, 'mcp_proxy_call');
+      } finally {
+        if (savedRedisUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+        else process.env.UPSTASH_REDIS_REST_URL = savedRedisUrl;
+        if (savedRedisTok === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+        else process.env.UPSTASH_REDIS_REST_TOKEN = savedRedisTok;
+      }
+    });
+
+    it('emits audit log on validation failure (status: 400)', async () => {
+      const res = await handler(makeGetRequest(
+        { serverUrl: 'http://localhost/mcp' },
+        'https://worldmonitor.app',
+        { extra: { 'cf-connecting-ip': uniqueCallerIp() } },
+      ));
+      assert.equal(res.status, 400);
+      const log = findProxyLog();
+      assert.ok(log, 'must emit audit log even when SSRF validation rejects the URL');
+      assert.equal(log[1].status, 400);
+    });
+
+    // TODO: rate-limit window-reset behavior is intentionally NOT tested —
+    // it requires either real Redis or fake-time mocking of
+    // @upstash/ratelimit's internal sliding-window math, which isn't worth
+    // the test infrastructure cost. The 60s window is configured via the
+    // RATE_LIMIT_WINDOW constant; the Upstash library handles expiry.
   });
 });


### PR DESCRIPTION
Closes part of #3805.

## Summary
Defense-in-depth on `/api/mcp-proxy`. Two narrow additions, no protocol changes.

1. **Per-IP rate limit, 30/min**, using the existing `checkScopedRateLimit` primitive from `server/_shared/rate-limit.ts`. Hit returns HTTP 429 + JSON-RPC error `-32029` (mirrors `api/mcp.ts`) + `Retry-After`. Fail-opens on Redis error.
2. **Structured audit log per call**: `console.log('[mcp-proxy]', { event, ts, ip, target_host, target_path, method, header_names, status, duration_ms })`. Fires on success, error, and rate-limit-block paths. **Header NAMES only — never values** (they often carry user-supplied secrets the proxy intentionally forwards).

Rationale for the limit value: most MCP clients refresh every 30-60s, so 30/min/IP is generous for legitimate use. Caps abuse at ~1800 calls/hour/IP — well below the 600/min global cap.

## Explicitly rejected from the issue's recommended fix
The reporter suggested stripping `Authorization` / `X-Api-Key` headers before forwarding. **This would break MCP.** 9 of 10 entries in `MCP_PRESETS` require caller-supplied auth headers (Notion, Linear, GitHub, Sentry, Stripe, etc. — every hosted MCP server gates on per-user OAuth/API keys). The proxy intentionally relays whatever auth the caller's `McpConnectModal` collects; that's the entire point of the endpoint. The audit log gives us forensics (who proxied to where with which header names) without paying that breakage cost.

## Flagged as a separate decision (not in this PR)
There is no Pro-entitlement gate on `/api/mcp-proxy`. Currently any non-browser HTTP client with `Origin: https://worldmonitor.app` and a valid Pro JWT / enterprise key / `wm_` user key can use the proxy. The `isCallerPremium` gate (from PR #3768) closed the anonymous-token bypass, so abuse now requires a real paying caller — but if we want to additionally gate on a feature-flag entitlement for the MCP proxy specifically, that's a product decision. Suggest filing a follow-up issue rather than rolling it into a defense-in-depth fix.

## Unchanged (still working from prior PRs)
- SSRF deny-list (RFC1918, link-local, loopback, IPv6 ULA/link-local) — including post-SSE-endpoint re-validation
- CRLF stripping on header keys/values
- `http`/`https` protocol allowlist
- 15s upstream timeout
- CORS `Origin` allowlist (`isDisallowedOrigin`)
- Pro auth gate (`isCallerPremium`) from #3768

## Test plan
- [x] Existing 39 mcp-proxy tests still pass (auth gate, CORS, SSRF for IPv4/IPv6 ranges, CRLF strip, SSE transport, SSE endpoint SSRF re-validation, timeouts).
- [x] New rate-limit tests:
  - [x] 31st request returns 429 + JSON-RPC `-32029` + `Retry-After >= 1`.
  - [x] Fail-opens when Upstash is unreachable (caller still served).
- [x] New audit-log tests:
  - [x] Emits structured `[mcp-proxy]` line on successful GET with expected shape.
  - [x] Log contains header **names** (`['Authorization', 'X-Api-Key']`) but **never values** — explicitly asserts the serialized log string does not contain `super-secret-token-XYZ`, `k_abc123`, or `Bearer `.
  - [x] `target_path` is pathname only — query string with `?token=querystring-secret-ABCDEF` does not land in the log.
  - [x] Emits log line with `status: 429` on rate-limit block.
  - [x] Emits log line with `status: 400` on SSRF / validation failure.
- [x] `npm run typecheck` clean.
- [x] `npm run test:data` — full 9281-test suite green.
- [x] `npx biome lint api/mcp-proxy.ts tests/mcp-proxy.test.mjs` — no new warnings introduced (pre-existing complexity / unused-param warnings in untouched code remain).

## Window-reset test deferred
Window-reset behavior is intentionally not unit-tested — it requires fake-time mocking of `@upstash/ratelimit`'s sliding-window internals, which isn't worth the test-infra cost. The 60s window is set via `RATE_LIMIT_WINDOW` and the Upstash library handles expiry. There's a TODO comment in the test file documenting this.

## Review round 2

Two Greptile P2 findings addressed in commit 7349a7e6d:

### 1. `/api/mcp-proxy` was invisible to the `enforce-rate-limit-policies` audit
The first cut used `checkScopedRateLimit` with literal constants in the handler. Because mcp-proxy is a top-level Vercel Edge Function (not gateway-routed — it's an `external-protocol` exception in `api/api-route-exceptions.json`), the gateway's `checkEndpointRateLimit` never fires for it. More importantly, `scripts/enforce-rate-limit-policies.mjs` walks `ENDPOINT_RATE_POLICIES` to audit coverage — and the proxy wasn't there. Future endpoint additions that should be limited would silently slip past the audit if maintainers trusted the script.

Fix:
- Add `/api/mcp-proxy` to `ENDPOINT_RATE_POLICIES` (`limit: 30, window: '60 s'`) as the single source of truth.
- `api/mcp-proxy.ts` now reads the policy from the registry. The handler throws at module load if the entry is ever deleted, so we never silently fall back to "no limit".
- Extend `scripts/enforce-rate-limit-policies.mjs` to resolve policy keys against `api/api-route-exceptions.json` (edge-function exceptions) in addition to `docs/api/*.openapi.yaml` (gateway routes). Audit now reports `9 policies validated against 190 gateway routes + 64 edge-function exceptions`.

### 2. Test IP pool wrapped at 250, risking flakes via `@upstash/ratelimit`'s module-level cache
`tests/mcp-proxy.test.mjs#uniqueCallerIp()` used `${counter % 250}` — once the suite grew past ~250 rate-limit-touching calls, an IP would be reused while `@upstash/ratelimit`'s module-level `Cache.blockUntil` still held a block decision from a previous test → flake.

Fix:
- Expand the pool to a `/16` (`10.<high>.<low>.0` = 65,536 IPs).
- Hard-throw if the counter ever exhausts `0xffff`, with a message pointing at the exact `Cache.blockUntil` concern so the cause is obvious to future devs.
- Update the helper's comment to explain *why* the pool is large.

### Verification
- `npm run typecheck` — clean
- `node scripts/enforce-rate-limit-policies.mjs` — exit 0, includes `/api/mcp-proxy` in the audited set
- `npx tsx --test tests/mcp-proxy.test.mjs` — all 46 tests pass
- `npm run test:data` — full suite green (1 pre-existing unrelated flake in `news-classify-cache-prefix-audit.test.mjs` from a parallel-test race with `bundle-runner.test.mjs` — reproduces on main without these changes)
- `npx biome lint` on changed files — no new warnings (baseline preserved)
