### PR TITLE
fix(daily-brief): refresh intraday when cached brief is older than 60 min

### DIFF
--- a/src/services/daily-market-brief.ts
+++ b/src/services/daily-market-brief.ts
@@ -112,6 +112,13 @@ async function getPersistentCacheApi(): Promise<{
 const CACHE_PREFIX = 'premium:daily-market-brief:v1';
 const DEFAULT_SCHEDULE_HOUR = 8;
 const DEFAULT_TARGET_COUNT = 4;
+// Intraday refresh ceiling. Without this, shouldRefreshDailyBrief returns
+// false for every tick after the first build of the day (same `dateKey`),
+// which silently disables the 60-min scheduler in App.ts and leaves the
+// panel showing a 9 AM snapshot of prices+news+regime+yield+sector for the
+// rest of the day. 60 min matches the scheduler interval so each tick that
+// finds a stale-enough brief triggers a rebuild.
+const DEFAULT_MAX_INTRADAY_AGE_MS = 60 * 60 * 1000;
 const BRIEF_NEWS_CATEGORIES = ['markets', 'economic', 'crypto', 'finance'];
 const COMMON_NAME_TOKENS = new Set(['inc', 'corp', 'group', 'holdings', 'company', 'companies', 'class', 'common', 'plc', 'limited', 'ltd', 'adr']);
 
@@ -375,11 +382,20 @@ export function shouldRefreshDailyBrief(
   timezone = 'UTC',
   now = new Date(),
   scheduleHour = DEFAULT_SCHEDULE_HOUR,
+  maxIntradayAgeMs = DEFAULT_MAX_INTRADAY_AGE_MS,
 ): boolean {
   if (!brief?.available) return true;
   const resolvedTimezone = resolveTimeZone(timezone || brief.timezone);
   const dateKey = getDateKey(now, resolvedTimezone);
-  if (brief.dateKey === dateKey) return false;
+  if (brief.dateKey === dateKey) {
+    // Same calendar day: refresh once the cached brief is older than the
+    // intraday ceiling. Without this gate the 60-min scheduler in App.ts is
+    // dead code after the first build of the day — the panel is stuck on
+    // the morning snapshot until tomorrow's schedule hour.
+    const generatedMs = new Date(brief.generatedAt).getTime();
+    if (!Number.isFinite(generatedMs)) return false;
+    return now.getTime() - generatedMs >= maxIntradayAgeMs;
+  }
   return getLocalHour(now, resolvedTimezone) >= scheduleHour;
 }
 

--- a/src/services/daily-market-brief.ts
+++ b/src/services/daily-market-brief.ts
@@ -116,9 +116,11 @@ const DEFAULT_TARGET_COUNT = 4;
 // false for every tick after the first build of the day (same `dateKey`),
 // which silently disables the 60-min scheduler in App.ts and leaves the
 // panel showing a 9 AM snapshot of prices+news+regime+yield+sector for the
-// rest of the day. 60 min matches the scheduler interval so each tick that
-// finds a stale-enough brief triggers a rebuild.
-const DEFAULT_MAX_INTRADAY_AGE_MS = 60 * 60 * 1000;
+// rest of the day. Deliberately set 5 min UNDER the 60-min scheduler interval
+// so a slightly-early tick (browser timer jitter, wake-from-throttled-tab)
+// still satisfies `age >= ceiling` and rebuilds — a ceiling equal to the
+// interval rounds the effective cadence up to 2× when the timer drifts early.
+const DEFAULT_MAX_INTRADAY_AGE_MS = 55 * 60 * 1000;
 const BRIEF_NEWS_CATEGORIES = ['markets', 'economic', 'crypto', 'finance'];
 const COMMON_NAME_TOKENS = new Set(['inc', 'corp', 'group', 'holdings', 'company', 'companies', 'class', 'common', 'plc', 'limited', 'ltd', 'adr']);
 

--- a/tests/daily-market-brief.test.mts
+++ b/tests/daily-market-brief.test.mts
@@ -74,8 +74,8 @@ describe('daily market brief schedule logic', () => {
     // Repro the reported "CACHED · 8h ago" symptom: a brief built at 09:20
     // local stays cached until the next day's schedule hour because the
     // same-day branch unconditionally returned `false`. With the intraday
-    // ceiling (default 60 min) the 60-min scheduler in App.ts can actually
-    // rebuild — same dateKey, but generatedAt is older than the ceiling.
+    // ceiling in place the 60-min scheduler in App.ts can actually rebuild
+    // — same dateKey, but generatedAt is older than the ceiling.
     const shouldRefresh = shouldRefreshDailyBrief({
       available: true,
       title: 'Brief',
@@ -98,7 +98,7 @@ describe('daily market brief schedule logic', () => {
   it('does NOT refresh during the same day when the cached brief is fresher than the intraday ceiling', () => {
     // Guard against the opposite over-correction: every scheduler tick must
     // not trigger an LLM rebuild. 20 minutes after the build should still
-    // serve cached under the default 60-min ceiling.
+    // serve cached under the default 55-min ceiling.
     const shouldRefresh = shouldRefreshDailyBrief({
       available: true,
       title: 'Brief',
@@ -118,8 +118,35 @@ describe('daily market brief schedule logic', () => {
     assert.equal(shouldRefresh, false);
   });
 
+  it('REGRESSION: default ceiling is below the scheduler interval so an early tick still rebuilds', () => {
+    // Greptile review on PR #3822: if the default ceiling equals the
+    // scheduler interval (both 60 min) and the browser fires the scheduler
+    // tick a hair early — wake-from-throttled-tab, accumulated drift —
+    // age=58m < ceiling=60m skips the rebuild and the next eligible fire
+    // is at t+118m, doubling the effective cadence. Default ceiling MUST
+    // stay below 60 min so a 58-min-old brief refreshes on the early tick.
+    // If you change this, also update DEFAULT_MAX_INTRADAY_AGE_MS comment.
+    const shouldRefresh = shouldRefreshDailyBrief({
+      available: true,
+      title: 'Brief',
+      dateKey: '2026-03-08',
+      timezone: 'UTC',
+      summary: '',
+      actionPlan: '',
+      riskWatch: '',
+      items: [],
+      provider: 'rules',
+      model: '',
+      fallback: true,
+      generatedAt: '2026-03-08T09:20:00.000Z',
+      headlineCount: 0,
+    }, 'UTC', new Date('2026-03-08T10:18:00.000Z'));
+
+    assert.equal(shouldRefresh, true);
+  });
+
   it('honours an explicit maxIntradayAgeMs override (cost-tuning hook)', () => {
-    // Callers that want a coarser/finer cadence than the default 60 min
+    // Callers that want a coarser/finer cadence than the default 55 min
     // can pass it through. 30-min-old brief with a 2h ceiling → no refresh.
     const shouldRefresh = shouldRefreshDailyBrief(
       {

--- a/tests/daily-market-brief.test.mts
+++ b/tests/daily-market-brief.test.mts
@@ -69,6 +69,82 @@ describe('daily market brief schedule logic', () => {
 
     assert.equal(shouldRefresh, true);
   });
+
+  it('REGRESSION: refreshes during the same day when the cached brief is older than the intraday ceiling', () => {
+    // Repro the reported "CACHED · 8h ago" symptom: a brief built at 09:20
+    // local stays cached until the next day's schedule hour because the
+    // same-day branch unconditionally returned `false`. With the intraday
+    // ceiling (default 60 min) the 60-min scheduler in App.ts can actually
+    // rebuild — same dateKey, but generatedAt is older than the ceiling.
+    const shouldRefresh = shouldRefreshDailyBrief({
+      available: true,
+      title: 'Brief',
+      dateKey: '2026-03-08',
+      timezone: 'UTC',
+      summary: '',
+      actionPlan: '',
+      riskWatch: '',
+      items: [],
+      provider: 'rules',
+      model: '',
+      fallback: true,
+      generatedAt: '2026-03-08T09:20:00.000Z',
+      headlineCount: 0,
+    }, 'UTC', new Date('2026-03-08T17:00:00.000Z'));
+
+    assert.equal(shouldRefresh, true);
+  });
+
+  it('does NOT refresh during the same day when the cached brief is fresher than the intraday ceiling', () => {
+    // Guard against the opposite over-correction: every scheduler tick must
+    // not trigger an LLM rebuild. 20 minutes after the build should still
+    // serve cached under the default 60-min ceiling.
+    const shouldRefresh = shouldRefreshDailyBrief({
+      available: true,
+      title: 'Brief',
+      dateKey: '2026-03-08',
+      timezone: 'UTC',
+      summary: '',
+      actionPlan: '',
+      riskWatch: '',
+      items: [],
+      provider: 'rules',
+      model: '',
+      fallback: true,
+      generatedAt: '2026-03-08T09:20:00.000Z',
+      headlineCount: 0,
+    }, 'UTC', new Date('2026-03-08T09:40:00.000Z'));
+
+    assert.equal(shouldRefresh, false);
+  });
+
+  it('honours an explicit maxIntradayAgeMs override (cost-tuning hook)', () => {
+    // Callers that want a coarser/finer cadence than the default 60 min
+    // can pass it through. 30-min-old brief with a 2h ceiling → no refresh.
+    const shouldRefresh = shouldRefreshDailyBrief(
+      {
+        available: true,
+        title: 'Brief',
+        dateKey: '2026-03-08',
+        timezone: 'UTC',
+        summary: '',
+        actionPlan: '',
+        riskWatch: '',
+        items: [],
+        provider: 'rules',
+        model: '',
+        fallback: true,
+        generatedAt: '2026-03-08T09:20:00.000Z',
+        headlineCount: 0,
+      },
+      'UTC',
+      new Date('2026-03-08T09:50:00.000Z'),
+      undefined,
+      2 * 60 * 60 * 1000,
+    );
+
+    assert.equal(shouldRefresh, false);
+  });
 });
 
 describe('buildDailyMarketBrief', () => {


### PR DESCRIPTION
## Symptom

Daily Market Brief panel header shows `CACHED · 8h ago` for the rest of the day after the morning build. Reported with screenshot at 6:27 PM showing a brief generated at 9:20 AM.

## Root cause

`shouldRefreshDailyBrief` in `src/services/daily-market-brief.ts` returned `false` whenever `brief.dateKey === today`:

```ts
if (brief.dateKey === dateKey) return false;
return getLocalHour(now, resolvedTimezone) >= scheduleHour;
```

So after today's morning build, every subsequent tick of the 60-min `dailyMarketBrief` scheduler in `App.ts:1502-1507` short-circuited at `data-loader.ts:1658` and the panel kept rendering the 9 AM snapshot until tomorrow's `scheduleHour` (08:00). The scheduler was effectively dead code on day 2+ of any session.

The brief mixes live intraday inputs — prices, news, regime/yield/sector context — all of which evolve during the day, so the snapshot is genuinely stale by the afternoon.

## Fix

Add `maxIntradayAgeMs` (default 60 min, matches the scheduler interval). Same-day branch now returns `true` once the cached brief exceeds the ceiling, so the scheduler's hourly tick actually rebuilds.

Cross-day behaviour (don't refresh before local schedule hour) is unchanged. The default 60 min is configurable per-call for cost tuning; callers in `data-loader.ts` use the default.

## Test plan

- [x] `tests/daily-market-brief.test.mts` — 3 new cases:
  - same-day stale (>60 min) → refresh
  - same-day fresh (<60 min) → no refresh (guards against per-tick LLM spend)
  - explicit `maxIntradayAgeMs=2h` override → respected
- [x] All 9 tests pass (`npx tsx --test tests/daily-market-brief.test.mts`)
- [x] `npm run typecheck` clean
- [x] `biome lint` clean on changed files
- [ ] Verify in browser after deploy: panel header should refresh every ~hour while open instead of sticking on the morning snapshot