### PR TITLE
fix(relay): drop attacker-recon fields from public /health (#3802)

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -9089,25 +9089,32 @@ const server = http.createServer(async (req, res) => {
     //
     // /health is in `isPublicRoute` (no auth check). Fields here are
     // returned to ANY caller — uptime monitors, attackers probing the
-    // relay, anyone with the URL. Two field categories were intentionally
-    // REMOVED from this response per issue #3802:
+    // relay, anyone with the URL.
     //
-    //   • `auth: {...}` — `auth.sharedSecretEnabled` was a direct signal
-    //     that the relay was deployed without a configured secret, letting
-    //     an attacker know that follow-up requests would succeed without
-    //     credentials. `auth.authHeader` is technically already exposed
-    //     via the CORS Allow-Headers preflight, but bundling it on /health
-    //     made the attack scenario one-step instead of two.
-    //   • `rateLimit: {...}` — exact windowMs / defaultMax /
-    //     openskyMax / rssMax let an attacker tune scraping cadence to
-    //     stay just under the throttle thresholds.
+    // Per issue #3802, two attacker-aiding fields were REMOVED from the
+    // `auth: {...}` block and the entire `rateLimit: {...}` block was
+    // removed:
     //
-    // Operators inspect auth/rate-limit state via env vars or the Railway
-    // dashboard — they don't need it on /health. If a future legitimate
-    // operator workflow needs them, add an AUTHENTICATED /health/full
-    // route instead of widening the public response. The
-    // `ais-relay-health-no-secret-recon` test source-greps this block to
-    // ensure neither field reappears here.
+    //   • `auth.authHeader` — revealed the non-standard header name
+    //     (`x-relay-key`) attackers should target. (Technically also
+    //     exposed via the CORS Allow-Headers preflight, but bundling it
+    //     on /health made the attack one-step instead of two.)
+    //   • `auth.allowVercelPreviewOrigins` — CORS-policy leak.
+    //   • `rateLimit: {...}` — exact windowMs / defaultMax / openskyMax /
+    //     rssMax let an attacker tune scraping cadence to stay just under
+    //     the throttle thresholds.
+    //
+    // The remaining `auth.enabled` + `auth.sharedSecretEnabled` are
+    // PRESERVED intentionally: PR #3812 / #3815 added them as the
+    // operator-visible "is auth configured?" signal that monitoring
+    // tools depend on (tests in tests/relay-auth.test.mjs codify this
+    // contract). Removing them would lie to ops; the trade-off was
+    // explicitly debated and decided in favour of operability.
+    //
+    // If a future operator workflow needs the removed fields, add an
+    // AUTHENTICATED /health/full route instead of widening this public
+    // response. The `ais-relay-health-no-secret-recon` test asserts the
+    // removed fields don't reappear here.
     sendCompressed(req, res, 200, { 'Content-Type': 'application/json' }, JSON.stringify({
       status: 'ok',
       clients: clients.size,
@@ -9152,6 +9159,13 @@ const server = http.createServer(async (req, res) => {
         polymarket: polymarketCache.size,
         yahooChart: yahooChartCache.size,
         polymarketInflight: polymarketInflight.size,
+      },
+      auth: {
+        // Preserved per PR #3812 / #3815 contract — operators monitor
+        // "is auth configured?" via these two fields. authHeader and
+        // allowVercelPreviewOrigins removed per #3802. See note above.
+        enabled: !AUTH_EFFECTIVELY_DISABLED,
+        sharedSecretEnabled: !!RELAY_SHARED_SECRET,
       },
     }));
   } else if (pathname === '/metrics') {

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -9085,6 +9085,29 @@ const server = http.createServer(async (req, res) => {
 
   if (pathname === '/health' || pathname === '/') {
     const mem = process.memoryUsage();
+    // ⚠ SECURITY — read before adding fields to this response.
+    //
+    // /health is in `isPublicRoute` (no auth check). Fields here are
+    // returned to ANY caller — uptime monitors, attackers probing the
+    // relay, anyone with the URL. Two field categories were intentionally
+    // REMOVED from this response per issue #3802:
+    //
+    //   • `auth: {...}` — `auth.sharedSecretEnabled` was a direct signal
+    //     that the relay was deployed without a configured secret, letting
+    //     an attacker know that follow-up requests would succeed without
+    //     credentials. `auth.authHeader` is technically already exposed
+    //     via the CORS Allow-Headers preflight, but bundling it on /health
+    //     made the attack scenario one-step instead of two.
+    //   • `rateLimit: {...}` — exact windowMs / defaultMax /
+    //     openskyMax / rssMax let an attacker tune scraping cadence to
+    //     stay just under the throttle thresholds.
+    //
+    // Operators inspect auth/rate-limit state via env vars or the Railway
+    // dashboard — they don't need it on /health. If a future legitimate
+    // operator workflow needs them, add an AUTHENTICATED /health/full
+    // route instead of widening the public response. The
+    // `ais-relay-health-no-secret-recon` test source-greps this block to
+    // ensure neither field reappears here.
     sendCompressed(req, res, 200, { 'Content-Type': 'application/json' }, JSON.stringify({
       status: 'ok',
       clients: clients.size,
@@ -9129,22 +9152,6 @@ const server = http.createServer(async (req, res) => {
         polymarket: polymarketCache.size,
         yahooChart: yahooChartCache.size,
         polymarketInflight: polymarketInflight.size,
-      },
-      auth: {
-        // `enabled` is the canonical operator-visible field: true when a
-        // shared secret is configured (which is what isAuthorizedRequest()
-        // actually enforces, regardless of any bypass flag). Use this to
-        // detect a no-auth deployment from monitoring without scraping logs.
-        enabled: !AUTH_EFFECTIVELY_DISABLED,
-        sharedSecretEnabled: !!RELAY_SHARED_SECRET,
-        authHeader: RELAY_AUTH_HEADER,
-        allowVercelPreviewOrigins: ALLOW_VERCEL_PREVIEW_ORIGINS,
-      },
-      rateLimit: {
-        windowMs: RELAY_RATE_LIMIT_WINDOW_MS,
-        defaultMax: RELAY_RATE_LIMIT_MAX,
-        openskyMax: RELAY_OPENSKY_RATE_LIMIT_MAX,
-        rssMax: RELAY_RSS_RATE_LIMIT_MAX,
       },
     }));
   } else if (pathname === '/metrics') {

--- a/tests/ais-relay-health-no-secret-recon.test.mjs
+++ b/tests/ais-relay-health-no-secret-recon.test.mjs
@@ -39,7 +39,7 @@ async function getHealthHandlerBody() {
     new URL('../scripts/ais-relay.cjs', import.meta.url),
     'utf8',
   );
-  // Anchor the /health handler block. ~80-line handler — bound to 4000
+  // Anchor the /health handler block. ~80-line handler — bound to 8000
   // chars to avoid runaway matching if the handler ever grows.
   const handlerMatch = source.match(
     /if \(pathname === '\/health' \|\| pathname === '\/'\) \{[\s\S]{0,8000}?\n\s{2}\}/,

--- a/tests/ais-relay-health-no-secret-recon.test.mjs
+++ b/tests/ais-relay-health-no-secret-recon.test.mjs
@@ -1,95 +1,114 @@
 /**
  * Regression for issue #3802: the relay's /health endpoint was returning
- * `auth: {...}` (sharedSecretEnabled, authHeader, allowVercelPreviewOrigins)
- * and `rateLimit: {...}` (exact thresholds) in its UNauthenticated
- * response. Both gave reconnaissance to attackers probing the relay:
+ * attacker-aiding fields in its UNauthenticated response:
  *
- *   - `auth.sharedSecretEnabled: false` confirmed a no-auth deployment.
- *   - `rateLimit.*` thresholds let an attacker tune scraping cadence to
- *     stay under the throttle.
+ *   - `auth.authHeader` — revealed the non-standard header name
+ *     (`x-relay-key`) attackers should target.
+ *   - `auth.allowVercelPreviewOrigins` — CORS-policy leak.
+ *   - `rateLimit: { windowMs, defaultMax, openskyMax, rssMax }` — exact
+ *     thresholds that let attackers tune scraping cadence to stay under
+ *     the throttle.
  *
  * The /health handler is in `isPublicRoute` and has no auth gate, so
- * this test source-greps the handler body to assert the two field
- * categories don't reappear. Inspired by:
+ * this test source-greps the handler body to assert the three field
+ * categories don't reappear.
+ *
+ * IMPORTANT: `auth.enabled` and `auth.sharedSecretEnabled` are
+ * PRESERVED on purpose. PR #3812 / #3815 added them as the
+ * operator-visible "is auth configured?" signal; their behaviour is
+ * pinned by tests/relay-auth.test.mjs. The contract is "operators get
+ * a coarse boolean; we don't reveal the credential header name or rate
+ * thresholds."
+ *
+ * Inspired by:
  * ~/.claude/skills/test-ci-gotchas/reference/source-grep-regression-test-for-unexercisable-defensive-branch.md
  *
  * (Why source-grep: ais-relay.cjs is a 9600-line single-process daemon
  * that's not easily importable in node:test. Spawning the relay and
- * curl'ing /health is expensive and flaky. The grep catches the exact
- * regression class at near-zero cost.)
+ * curl'ing /health is expensive and flaky for THIS check; the existing
+ * relay-auth.test.mjs already pays that cost for the auth.enabled
+ * contract.)
  */
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
-describe('ais-relay /health does not expose auth/rateLimit recon (#3802)', () => {
-  it('the /health handler block does NOT contain an `auth:` field', async () => {
-    const source = await readFile(
-      new URL('../scripts/ais-relay.cjs', import.meta.url),
-      'utf8',
-    );
-    // Find the /health handler body. The anchor is unique enough.
-    // ~70-line handler body — bound to 4000 chars to avoid runaway matching
-    // if the handler ever grows. Bump if it ever exceeds.
-    const handlerMatch = source.match(
-      /if \(pathname === '\/health' \|\| pathname === '\/'\) \{[\s\S]{0,4000}?\n\s{2}\}/,
-    );
-    assert.ok(handlerMatch, 'expected to find /health handler block in ais-relay.cjs');
-    const handlerBody = handlerMatch[0];
+async function getHealthHandlerBody() {
+  const source = await readFile(
+    new URL('../scripts/ais-relay.cjs', import.meta.url),
+    'utf8',
+  );
+  // Anchor the /health handler block. ~80-line handler — bound to 4000
+  // chars to avoid runaway matching if the handler ever grows.
+  const handlerMatch = source.match(
+    /if \(pathname === '\/health' \|\| pathname === '\/'\) \{[\s\S]{0,8000}?\n\s{2}\}/,
+  );
+  assert.ok(handlerMatch, 'expected to find /health handler block in ais-relay.cjs');
+  // Strip JS comments so the in-line doc comment that NAMES the removed
+  // fields as a defense-in-depth note doesn't false-positive.
+  return handlerMatch[0]
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+}
 
-    // Strip JS comments so the in-line doc comment that NAMES the removed
-    // `auth:` field as a defense-in-depth note doesn't false-positive.
-    const stripped = handlerBody
-      .replace(/\/\*[\s\S]*?\*\//g, '')
-      .replace(/\/\/.*$/gm, '');
-
+describe('ais-relay /health attacker-recon fields removed (#3802)', () => {
+  it('does NOT expose `authHeader` (would reveal the non-standard header name to target)', async () => {
+    const body = await getHealthHandlerBody();
     assert.ok(
-      !/\bauth:\s*\{/.test(stripped),
-      'relay /health must NOT return an `auth: { ... }` block — issue #3802. ' +
-        'Operators can read auth state from env vars / Railway dashboard. ' +
-        'If you need it on a health endpoint, add an AUTHENTICATED /health/full ' +
-        'instead of widening the public response.',
+      !/\bauthHeader\b/.test(body),
+      'relay /health must NOT return `authHeader` — issue #3802. ' +
+        'The CORS Allow-Headers preflight already exposes it; do not bundle ' +
+        'it on /health to make the one-step attack two-step.',
     );
   });
 
-  it('the /health handler block does NOT contain a `rateLimit:` field', async () => {
-    const source = await readFile(
-      new URL('../scripts/ais-relay.cjs', import.meta.url),
-      'utf8',
-    );
-    const handlerMatch = source.match(
-      /if \(pathname === '\/health' \|\| pathname === '\/'\) \{[\s\S]{0,4000}?\n\s{2}\}/,
-    );
-    assert.ok(handlerMatch);
-    const stripped = handlerMatch[0]
-      .replace(/\/\*[\s\S]*?\*\//g, '')
-      .replace(/\/\/.*$/gm, '');
-
+  it('does NOT expose `allowVercelPreviewOrigins` (CORS-policy leak)', async () => {
+    const body = await getHealthHandlerBody();
     assert.ok(
-      !/\brateLimit:\s*\{/.test(stripped),
+      !/\ballowVercelPreviewOrigins\b/.test(body),
+      'relay /health must NOT return `allowVercelPreviewOrigins` — issue #3802. ' +
+        'Operators read CORS policy from env vars, not /health.',
+    );
+  });
+
+  it('does NOT contain a `rateLimit:` block (exact thresholds let attackers tune scraping)', async () => {
+    const body = await getHealthHandlerBody();
+    assert.ok(
+      !/\brateLimit:\s*\{/.test(body),
       'relay /health must NOT return a `rateLimit: { ... }` block — issue #3802. ' +
-        'Exact thresholds let attackers tune scraping cadence to stay under ' +
-        'the throttle. Operators read these from env vars.',
+        'Operators read these from env vars / Railway dashboard.',
+    );
+  });
+});
+
+describe('ais-relay /health operator-monitoring contract preserved (#3812 / #3815)', () => {
+  it('STILL exposes `auth.enabled` (operator-visible "is auth configured?" signal)', async () => {
+    const body = await getHealthHandlerBody();
+    assert.match(
+      body,
+      /\benabled:\s*!AUTH_EFFECTIVELY_DISABLED\b/,
+      'relay /health MUST keep `auth.enabled` — codified by PR #3812 + tests/relay-auth.test.mjs. ' +
+        'Removing it lies to operator monitoring. If you genuinely need to remove it, ' +
+        'coordinate with the contract test owner first.',
     );
   });
 
-  it('the /health handler still returns `status: \"ok\"` and core uptime fields (no over-stripping)', async () => {
-    const source = await readFile(
-      new URL('../scripts/ais-relay.cjs', import.meta.url),
-      'utf8',
+  it('STILL exposes `auth.sharedSecretEnabled` (back-compat field for monitoring tools)', async () => {
+    const body = await getHealthHandlerBody();
+    assert.match(
+      body,
+      /\bsharedSecretEnabled:\s*!!RELAY_SHARED_SECRET\b/,
+      'relay /health MUST keep `auth.sharedSecretEnabled` — back-compat per PR #3815.',
     );
-    const handlerMatch = source.match(
-      /if \(pathname === '\/health' \|\| pathname === '\/'\) \{[\s\S]{0,4000}?\n\s{2}\}/,
-    );
-    assert.ok(handlerMatch);
-    const body = handlerMatch[0];
-    // Pin the legitimate operational fields so a future "strip everything"
-    // refactor doesn't remove the uptime signal that monitoring tools need.
+  });
+
+  it('STILL returns core uptime fields (no over-stripping)', async () => {
+    const body = await getHealthHandlerBody();
     assert.match(body, /status:\s*'ok'/, 'must keep status:"ok"');
     assert.match(body, /\bclients:\s*clients\.size/, 'must keep client count');
     assert.match(body, /\btelegram:\s*\{/, 'must keep telegram diagnostics');
     assert.match(body, /\boref:\s*\{/, 'must keep oref diagnostics');
-    assert.match(body, /\bmemory:\s*\{/, 'must keep memory block (process state, not credential)');
+    assert.match(body, /\bmemory:\s*\{/, 'must keep memory block');
   });
 });

--- a/tests/ais-relay-health-no-secret-recon.test.mjs
+++ b/tests/ais-relay-health-no-secret-recon.test.mjs
@@ -1,0 +1,95 @@
+/**
+ * Regression for issue #3802: the relay's /health endpoint was returning
+ * `auth: {...}` (sharedSecretEnabled, authHeader, allowVercelPreviewOrigins)
+ * and `rateLimit: {...}` (exact thresholds) in its UNauthenticated
+ * response. Both gave reconnaissance to attackers probing the relay:
+ *
+ *   - `auth.sharedSecretEnabled: false` confirmed a no-auth deployment.
+ *   - `rateLimit.*` thresholds let an attacker tune scraping cadence to
+ *     stay under the throttle.
+ *
+ * The /health handler is in `isPublicRoute` and has no auth gate, so
+ * this test source-greps the handler body to assert the two field
+ * categories don't reappear. Inspired by:
+ * ~/.claude/skills/test-ci-gotchas/reference/source-grep-regression-test-for-unexercisable-defensive-branch.md
+ *
+ * (Why source-grep: ais-relay.cjs is a 9600-line single-process daemon
+ * that's not easily importable in node:test. Spawning the relay and
+ * curl'ing /health is expensive and flaky. The grep catches the exact
+ * regression class at near-zero cost.)
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+describe('ais-relay /health does not expose auth/rateLimit recon (#3802)', () => {
+  it('the /health handler block does NOT contain an `auth:` field', async () => {
+    const source = await readFile(
+      new URL('../scripts/ais-relay.cjs', import.meta.url),
+      'utf8',
+    );
+    // Find the /health handler body. The anchor is unique enough.
+    // ~70-line handler body — bound to 4000 chars to avoid runaway matching
+    // if the handler ever grows. Bump if it ever exceeds.
+    const handlerMatch = source.match(
+      /if \(pathname === '\/health' \|\| pathname === '\/'\) \{[\s\S]{0,4000}?\n\s{2}\}/,
+    );
+    assert.ok(handlerMatch, 'expected to find /health handler block in ais-relay.cjs');
+    const handlerBody = handlerMatch[0];
+
+    // Strip JS comments so the in-line doc comment that NAMES the removed
+    // `auth:` field as a defense-in-depth note doesn't false-positive.
+    const stripped = handlerBody
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '');
+
+    assert.ok(
+      !/\bauth:\s*\{/.test(stripped),
+      'relay /health must NOT return an `auth: { ... }` block — issue #3802. ' +
+        'Operators can read auth state from env vars / Railway dashboard. ' +
+        'If you need it on a health endpoint, add an AUTHENTICATED /health/full ' +
+        'instead of widening the public response.',
+    );
+  });
+
+  it('the /health handler block does NOT contain a `rateLimit:` field', async () => {
+    const source = await readFile(
+      new URL('../scripts/ais-relay.cjs', import.meta.url),
+      'utf8',
+    );
+    const handlerMatch = source.match(
+      /if \(pathname === '\/health' \|\| pathname === '\/'\) \{[\s\S]{0,4000}?\n\s{2}\}/,
+    );
+    assert.ok(handlerMatch);
+    const stripped = handlerMatch[0]
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/.*$/gm, '');
+
+    assert.ok(
+      !/\brateLimit:\s*\{/.test(stripped),
+      'relay /health must NOT return a `rateLimit: { ... }` block — issue #3802. ' +
+        'Exact thresholds let attackers tune scraping cadence to stay under ' +
+        'the throttle. Operators read these from env vars.',
+    );
+  });
+
+  it('the /health handler still returns `status: \"ok\"` and core uptime fields (no over-stripping)', async () => {
+    const source = await readFile(
+      new URL('../scripts/ais-relay.cjs', import.meta.url),
+      'utf8',
+    );
+    const handlerMatch = source.match(
+      /if \(pathname === '\/health' \|\| pathname === '\/'\) \{[\s\S]{0,4000}?\n\s{2}\}/,
+    );
+    assert.ok(handlerMatch);
+    const body = handlerMatch[0];
+    // Pin the legitimate operational fields so a future "strip everything"
+    // refactor doesn't remove the uptime signal that monitoring tools need.
+    assert.match(body, /status:\s*'ok'/, 'must keep status:"ok"');
+    assert.match(body, /\bclients:\s*clients\.size/, 'must keep client count');
+    assert.match(body, /\btelegram:\s*\{/, 'must keep telegram diagnostics');
+    assert.match(body, /\boref:\s*\{/, 'must keep oref diagnostics');
+    assert.match(body, /\bmemory:\s*\{/, 'must keep memory block (process state, not credential)');
+  });
+});


### PR DESCRIPTION
## Summary

Per issue #3802, \`scripts/ais-relay.cjs\`'s \`/health\` endpoint returned attacker-aiding fields without authentication. The endpoint is in \`isPublicRoute\` (no auth check), so the response goes to anyone who can reach the relay URL.

## Change

Drop three attacker-recon fields. Keep operator-monitoring contract from PR #3812 / #3815.

| Field | Status | Why |
|-------|--------|-----|
| \`auth.enabled\` | **KEEP** | Operator-monitoring contract added by PR #3812 / #3815; codified by \`tests/relay-auth.test.mjs\`. Removing it lies to ops dashboards. |
| \`auth.sharedSecretEnabled\` | **KEEP** | Back-compat alias for monitoring tools (also pinned by the existing test). |
| \`auth.authHeader\` | **REMOVE** | Reveals the non-standard header name (\`x-relay-key\`) attackers should target. |
| \`auth.allowVercelPreviewOrigins\` | **REMOVE** | CORS-policy leak. |
| \`rateLimit: {...}\` | **REMOVE** | Exact \`windowMs / defaultMax / openskyMax / rssMax\` let attackers tune scraping cadence to stay under the throttle. |

The reporter recommended splitting into public \`/health\` (minimal) + authenticated \`/health/full\` (everything). The narrower scope here preserves the existing monitoring contract while closing the genuinely material reconnaissance vectors. If a future operator workflow needs the removed fields, an authenticated \`/health/full\` route is the right place — not widening this public response. That's documented in the load-bearing security comment block above the handler.

## Trade-off note (security vs. operability)

\`auth.enabled\` IS attacker-visible. The decision to expose it was deliberate (PR #3812) so monitoring can detect a no-auth deployment without scraping logs. This PR doesn't relitigate that — it just stops the additional fields that gave attackers strictly more information (header name, CORS policy, rate-limit thresholds) without any matching operator benefit.

## Test plan

- [x] New regression test \`tests/ais-relay-health-no-secret-recon.test.mjs\`:
  - 3 negative assertions (\`authHeader\` / \`allowVercelPreviewOrigins\` / \`rateLimit\` block must NOT reappear)
  - 2 positive assertions (\`auth.enabled\` + \`auth.sharedSecretEnabled\` MUST remain — pin the #3812 contract)
  - 1 no-over-stripping assertion (core uptime fields stay)
- [x] Pre-existing \`tests/relay-auth.test.mjs\` (13 tests) still passes — original contract preserved.
- [x] \`node -c scripts/ais-relay.cjs\` syntax OK; typecheck clean.

## Session note

First attempt removed the entire \`auth: {...}\` block per the issue's literal recommendation; pre-push test surfaced that PR #3812's tests codify \`auth.enabled\` as a load-bearing operator-visibility contract. Same shape as the \`shared-utility-default-change-breaks-pre-existing-contract-tests\` gotcha from earlier this session — pre-existing tests ARE the contract, re-scoped accordingly.

Closes #3802