### PR TITLE
fix(risk-scores): stop fabricating 'Updated now' for absent or stale data (#3800)

### DIFF
--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -2204,7 +2204,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     }
     if (top) {
       const updatedEl = top.querySelector('.cdp-updated');
-      if (updatedEl) updatedEl.textContent = `Updated ${this.shortDate(score?.lastUpdated ?? new Date())}`;
+      if (updatedEl) updatedEl.textContent = `Updated ${score?.lastUpdated ? this.shortDate(score.lastUpdated) : '—'}`;
     }
     if (score) {
       const band = this.ciiBand(score.score);
@@ -2386,7 +2386,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     this.scoreCard = scoreCard;
     const top = this.el('div', 'cdp-score-top');
     const label = this.el('span', 'cdp-score-label', t('countryBrief.instabilityIndex'));
-    const updated = this.el('span', 'cdp-updated', `Updated ${this.shortDate(score?.lastUpdated ?? new Date())}`);
+    const updated = this.el('span', 'cdp-updated', `Updated ${score?.lastUpdated ? this.shortDate(score.lastUpdated) : '—'}`);
     top.append(label, updated);
     scoreCard.append(top);
 

--- a/src/services/cached-risk-scores.ts
+++ b/src/services/cached-risk-scores.ts
@@ -24,14 +24,16 @@ export interface CachedCIIScore {
   trend: 'rising' | 'stable' | 'falling';
   change24h: number;
   components: ComponentScores;
-  lastUpdated: string;
+  // Null when upstream proto provided no computedAt — adapter MUST NOT fabricate `now`.
+  lastUpdated: string | null;
 }
 
 export interface CachedStrategicRisk {
   score: number;
   level: string;
   trend: string;
-  lastUpdated: string;
+  // Derived from max CII computedAt; null when no CII carries a real timestamp.
+  lastUpdated: string | null;
   contributors: Array<{
     country: string;
     code: string;
@@ -44,7 +46,8 @@ export interface CachedRiskScores {
   cii: CachedCIIScore[];
   strategicRisk: CachedStrategicRisk;
   protestCount: number;
-  computedAt: string;
+  // Derived from max CII computedAt; null when no CII carries a real timestamp.
+  computedAt: string | null;
   cached: boolean;
 }
 
@@ -92,18 +95,34 @@ function toCachedCII(proto: CiiScore): CachedCIIScore {
       security: proto.components?.militaryActivity ?? 0,
       information: proto.components?.newsActivity ?? 0,
     },
-    lastUpdated: proto.computedAt ? new Date(proto.computedAt).toISOString() : new Date().toISOString(),
+    // Preserve upstream computedAt verbatim; surface null when absent so the UI does not lie.
+    lastUpdated: proto.computedAt ? new Date(proto.computedAt).toISOString() : null,
   };
 }
 
-function toCachedStrategicRisk(risks: StrategicRisk[], ciiScores: CiiScore[]): CachedStrategicRisk {
+// Strategic-risk and aggregate timestamps are derived from the freshest CII computedAt the
+// adapter saw. The proto carries no dedicated timestamp on StrategicRisk or
+// GetRiskScoresResponse (see #3800 — server-side end-to-end timestamps are a follow-up).
+function deriveMaxCiiTimestamp(ciiScores: CiiScore[]): string | null {
+  let max: number | null = null;
+  for (const s of ciiScores) {
+    if (s.computedAt && (max === null || s.computedAt > max)) max = s.computedAt;
+  }
+  return max === null ? null : new Date(max).toISOString();
+}
+
+function toCachedStrategicRisk(
+  risks: StrategicRisk[],
+  ciiScores: CiiScore[],
+  derivedTimestamp: string | null,
+): CachedStrategicRisk {
   const global = risks[0];
   const ciiMap = new Map(ciiScores.map((s) => [s.region, s]));
   return {
     score: global?.score ?? 0,
     level: SEVERITY_REVERSE[global?.level ?? ''] || 'low',
     trend: TREND_REVERSE[global?.trend ?? ''] || 'stable',
-    lastUpdated: new Date().toISOString(),
+    lastUpdated: derivedTimestamp,
     contributors: (global?.factors ?? []).map((code) => {
       const cii = ciiMap.get(code);
       return {
@@ -117,11 +136,12 @@ function toCachedStrategicRisk(risks: StrategicRisk[], ciiScores: CiiScore[]): C
 }
 
 export function toRiskScores(resp: GetRiskScoresResponse): CachedRiskScores {
+  const derivedTimestamp = deriveMaxCiiTimestamp(resp.ciiScores);
   return {
     cii: resp.ciiScores.map(toCachedCII),
-    strategicRisk: toCachedStrategicRisk(resp.strategicRisks, resp.ciiScores),
+    strategicRisk: toCachedStrategicRisk(resp.strategicRisks, resp.ciiScores, derivedTimestamp),
     protestCount: 0,
-    computedAt: new Date().toISOString(),
+    computedAt: derivedTimestamp,
     cached: true,
   };
 }
@@ -185,11 +205,12 @@ if (stored && stored.cii.length > 0) {
 }
 
 function emptyFallback(): CachedRiskScores {
+  // No data → no timestamp. The UI must render "—" / "Unavailable", not "Updated now".
   return {
     cii: [],
-    strategicRisk: { score: 0, level: 'low', trend: 'stable', lastUpdated: new Date().toISOString(), contributors: [] },
+    strategicRisk: { score: 0, level: 'low', trend: 'stable', lastUpdated: null, contributors: [] },
     protestCount: 0,
-    computedAt: new Date().toISOString(),
+    computedAt: null,
     cached: true,
   };
 }
@@ -276,6 +297,6 @@ export function toCountryScore(cached: CachedCIIScore): CountryScore {
     trend: cached.trend,
     change24h: cached.change24h,
     components: cached.components,
-    lastUpdated: new Date(cached.lastUpdated),
+    lastUpdated: cached.lastUpdated ? new Date(cached.lastUpdated) : null,
   };
 }

--- a/src/services/country-instability.ts
+++ b/src/services/country-instability.ts
@@ -22,7 +22,8 @@ export interface CountryScore {
   trend: 'rising' | 'stable' | 'falling';
   change24h: number;
   components: ComponentScores;
-  lastUpdated: Date;
+  // Null when the underlying source (cached proto) provided no timestamp. See #3800.
+  lastUpdated: Date | null;
 }
 
 export interface ComponentScores {

--- a/tests/cached-risk-scores.test.mts
+++ b/tests/cached-risk-scores.test.mts
@@ -1,0 +1,300 @@
+/**
+ * Regression tests for koala73/worldmonitor#3800.
+ *
+ * Root cause: src/services/cached-risk-scores.ts fabricated `lastUpdated` /
+ * `computedAt` as `new Date().toISOString()` in four places, making cached or
+ * undated risk data look freshly computed in the UI ("Updated today" for
+ * stale or absent intelligence).
+ *
+ * Fix: the adapter MUST
+ *   1. preserve proto.computedAt verbatim on CII entries,
+ *   2. surface `null` when no upstream timestamp exists,
+ *   3. derive strategic-risk + aggregate timestamps from the freshest CII
+ *      computedAt (since the proto carries no dedicated timestamp on
+ *      StrategicRisk or GetRiskScoresResponse), and
+ *   4. return `null` timestamps on emptyFallback (no data → no "now").
+ *
+ * The test loads the adapter module with esbuild after stubbing out side-
+ * effecting imports (RPC client, bootstrap hydration, circuit breaker,
+ * country-instability) so we can exercise the pure transform `toRiskScores`
+ * and the exported `toCountryScore` without standing up the full app.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { transformSync } from 'esbuild';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const sourcePath = resolve(root, 'src/services/cached-risk-scores.ts');
+const source = readFileSync(sourcePath, 'utf-8');
+
+// ============================================================
+// 1. Static analysis: source guarantees no fabrication
+// ============================================================
+
+describe('cached-risk-scores — no fabricated timestamps in source', () => {
+  it('CII adapter does not fall back to new Date() for missing computedAt', () => {
+    // Hard guarantee: no `new Date().toISOString()` literal anywhere in source.
+    // (If a future edit reintroduces fabrication, this test catches it.)
+    assert.doesNotMatch(
+      source,
+      /new\s+Date\(\)\.toISOString\(\)/,
+      'cached-risk-scores.ts must NOT contain `new Date().toISOString()` — adapter must surface null when upstream has no timestamp (see #3800)',
+    );
+  });
+
+  it('CachedCIIScore.lastUpdated is typed as string | null', () => {
+    assert.match(
+      source,
+      /interface\s+CachedCIIScore\b[\s\S]*?lastUpdated:\s*string\s*\|\s*null/,
+      'CachedCIIScore.lastUpdated must be `string | null`',
+    );
+  });
+
+  it('CachedStrategicRisk.lastUpdated is typed as string | null', () => {
+    assert.match(
+      source,
+      /interface\s+CachedStrategicRisk\b[\s\S]*?lastUpdated:\s*string\s*\|\s*null/,
+      'CachedStrategicRisk.lastUpdated must be `string | null`',
+    );
+  });
+
+  it('CachedRiskScores.computedAt is typed as string | null', () => {
+    assert.match(
+      source,
+      /interface\s+CachedRiskScores\b[\s\S]*?computedAt:\s*string\s*\|\s*null/,
+      'CachedRiskScores.computedAt must be `string | null`',
+    );
+  });
+});
+
+// ============================================================
+// 2. Functional: exercise toRiskScores with stubbed imports
+// ============================================================
+
+async function loadAdapter() {
+  // Replace side-effecting imports with inert stubs so the module evaluates
+  // without an RPC client, bootstrap, or circuit breaker.
+  const patched = source
+    .replace(
+      "import { getRpcBaseUrl } from '@/services/rpc-client';",
+      'const getRpcBaseUrl = () => "stub://";',
+    )
+    .replace(
+      "import { setHasCachedScores } from './country-instability';",
+      'const setHasCachedScores = (_: boolean) => {};',
+    )
+    .replace(
+      /import\s*\{[^}]*IntelligenceServiceClient[^}]*\}\s*from\s*'@\/generated\/client\/worldmonitor\/intelligence\/v1\/service_client';/,
+      'class IntelligenceServiceClient { constructor(..._args: any[]) {} async getRiskScores(_: any) { return { ciiScores: [], strategicRisks: [] }; } }',
+    )
+    .replace(
+      "import { createCircuitBreaker } from '@/utils';",
+      'const createCircuitBreaker = <T,>(_opts: any) => ({ getCached: () => null as T | null, recordSuccess: (_: T) => {}, execute: async (fn: () => Promise<T>, _fb: T, _o: any) => fn() });',
+    )
+    .replace(
+      "import { getHydratedData } from '@/services/bootstrap';",
+      'const getHydratedData = (_: string): any => undefined;',
+    )
+    .replace(
+      "import type { CountryScore, ComponentScores } from './country-instability';",
+      'type ComponentScores = { unrest: number; conflict: number; security: number; information: number }; type CountryScore = any;',
+    );
+
+  // Stub localStorage so module-level loadFromStorage() doesn't throw under Node.
+  (globalThis as unknown as { localStorage: Storage }).localStorage = {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+    clear: () => {},
+    key: () => null,
+    length: 0,
+  };
+
+  const transformed = transformSync(patched, {
+    loader: 'ts',
+    format: 'esm',
+    target: 'es2022',
+  });
+
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(transformed.code).toString('base64')}`;
+  return (await import(dataUrl)) as {
+    toRiskScores: (resp: {
+      ciiScores: Array<{
+        region: string;
+        staticBaseline: number;
+        dynamicScore: number;
+        combinedScore: number;
+        trend: string;
+        components?: { newsActivity: number; ciiContribution: number; geoConvergence: number; militaryActivity: number };
+        computedAt: number;
+        methodologyVersion: string;
+        eventMultiplier: number;
+      }>;
+      strategicRisks: Array<{ region: string; level: string; score: number; factors: string[]; trend: string }>;
+    }) => {
+      cii: Array<{ code: string; lastUpdated: string | null }>;
+      strategicRisk: { lastUpdated: string | null };
+      computedAt: string | null;
+    };
+    toCountryScore: (cached: { lastUpdated: string | null; [k: string]: unknown }) => {
+      lastUpdated: Date | null;
+      [k: string]: unknown;
+    };
+  };
+}
+
+function makeCii(region: string, computedAt: number): {
+  region: string;
+  staticBaseline: number;
+  dynamicScore: number;
+  combinedScore: number;
+  trend: string;
+  components: { newsActivity: number; ciiContribution: number; geoConvergence: number; militaryActivity: number };
+  computedAt: number;
+  methodologyVersion: string;
+  eventMultiplier: number;
+} {
+  return {
+    region,
+    staticBaseline: 10,
+    dynamicScore: 5,
+    combinedScore: 30,
+    trend: 'TREND_DIRECTION_STABLE',
+    components: { newsActivity: 1, ciiContribution: 2, geoConvergence: 3, militaryActivity: 4 },
+    computedAt,
+    methodologyVersion: 'v1',
+    eventMultiplier: 1,
+  };
+}
+
+describe('cached-risk-scores — functional adapter behavior', () => {
+  it('preserves proto.computedAt verbatim on CII entries', async () => {
+    const { toRiskScores } = await loadAdapter();
+    const ts = 1_700_000_000_000;
+    const out = toRiskScores({
+      ciiScores: [makeCii('US', ts)],
+      strategicRisks: [],
+    });
+    assert.equal(out.cii[0]!.lastUpdated, new Date(ts).toISOString());
+  });
+
+  it('surfaces null on CII when proto.computedAt is missing (no more fabricated "now")', async () => {
+    const { toRiskScores } = await loadAdapter();
+    const out = toRiskScores({
+      ciiScores: [makeCii('US', 0)], // 0 == falsy == "no upstream timestamp"
+      strategicRisks: [],
+    });
+    assert.equal(out.cii[0]!.lastUpdated, null);
+  });
+
+  it('strategicRisk.lastUpdated derives from the MAX CII computedAt', async () => {
+    const { toRiskScores } = await loadAdapter();
+    const t1 = 1_700_000_000_000;
+    const t2 = 1_700_000_000_000 + 60_000;
+    const t3 = 1_700_000_000_000 + 30_000;
+    const out = toRiskScores({
+      ciiScores: [makeCii('US', t1), makeCii('CN', t2), makeCii('RU', t3)],
+      strategicRisks: [{ region: 'GLOBAL', level: 'SEVERITY_LEVEL_LOW', score: 12, factors: [], trend: 'TREND_DIRECTION_STABLE' }],
+    });
+    assert.equal(out.strategicRisk.lastUpdated, new Date(t2).toISOString());
+  });
+
+  it('aggregate computedAt derives from the MAX CII computedAt', async () => {
+    const { toRiskScores } = await loadAdapter();
+    const t1 = 1_700_000_000_000;
+    const t2 = 1_700_000_000_000 + 60_000;
+    const out = toRiskScores({
+      ciiScores: [makeCii('US', t1), makeCii('CN', t2)],
+      strategicRisks: [],
+    });
+    assert.equal(out.computedAt, new Date(t2).toISOString());
+  });
+
+  it('strategicRisk.lastUpdated and aggregate.computedAt are null when no CII carries a timestamp', async () => {
+    const { toRiskScores } = await loadAdapter();
+    const out = toRiskScores({
+      ciiScores: [makeCii('US', 0), makeCii('CN', 0)],
+      strategicRisks: [{ region: 'GLOBAL', level: 'SEVERITY_LEVEL_LOW', score: 12, factors: [], trend: 'TREND_DIRECTION_STABLE' }],
+    });
+    assert.equal(out.strategicRisk.lastUpdated, null);
+    assert.equal(out.computedAt, null);
+  });
+
+  it('toCountryScore returns Date for non-null cached lastUpdated', async () => {
+    const { toCountryScore } = await loadAdapter();
+    const iso = new Date(1_700_000_000_000).toISOString();
+    const out = toCountryScore({
+      code: 'US',
+      name: 'United States',
+      score: 30,
+      level: 'normal',
+      trend: 'stable',
+      change24h: 0,
+      components: { unrest: 0, conflict: 0, security: 0, information: 0 },
+      lastUpdated: iso,
+    });
+    assert.ok(out.lastUpdated instanceof Date);
+    assert.equal((out.lastUpdated as Date).toISOString(), iso);
+  });
+
+  it('toCountryScore returns null when cached lastUpdated is null (no more fabricated Date)', async () => {
+    const { toCountryScore } = await loadAdapter();
+    const out = toCountryScore({
+      code: 'US',
+      name: 'United States',
+      score: 30,
+      level: 'normal',
+      trend: 'stable',
+      change24h: 0,
+      components: { unrest: 0, conflict: 0, security: 0, information: 0 },
+      lastUpdated: null,
+    });
+    assert.equal(out.lastUpdated, null);
+  });
+});
+
+// ============================================================
+// 3. Source-level guarantee: emptyFallback uses null, not now
+// ============================================================
+
+describe('cached-risk-scores — emptyFallback surfaces null timestamps', () => {
+  it('emptyFallback function body assigns lastUpdated and computedAt to null', () => {
+    const fnStart = source.indexOf('function emptyFallback');
+    assert.ok(fnStart > 0, 'emptyFallback function must exist');
+    // Read until the next top-level function declaration or end of file.
+    const tail = source.slice(fnStart);
+    const fnEnd = tail.search(/\n(function|export\s+function|export\s+async\s+function|const\s+breaker)/);
+    const body = fnEnd > 0 ? tail.slice(0, fnEnd) : tail;
+    assert.match(body, /lastUpdated:\s*null/, 'emptyFallback strategicRisk.lastUpdated must be null');
+    assert.match(body, /computedAt:\s*null/, 'emptyFallback aggregate computedAt must be null');
+    assert.doesNotMatch(body, /new\s+Date\(/, 'emptyFallback must not construct any Date');
+  });
+});
+
+// ============================================================
+// 4. UI guarantee: CountryDeepDivePanel does not fabricate Date on null
+// ============================================================
+
+describe('CountryDeepDivePanel — handles null lastUpdated without fabricating', () => {
+  const panelSrc = readFileSync(resolve(root, 'src/components/CountryDeepDivePanel.ts'), 'utf-8');
+
+  it('no `?? new Date()` fallback on score.lastUpdated render sites', () => {
+    assert.doesNotMatch(
+      panelSrc,
+      /score\?\.lastUpdated\s*\?\?\s*new\s+Date\(\)/,
+      'panel must not fall back to `new Date()` when score.lastUpdated is null — render "—" instead (see #3800)',
+    );
+  });
+
+  it('renders "—" placeholder when score.lastUpdated is null', () => {
+    // Two render sites at L2207 and L2389. Both should use the null-aware ternary.
+    const matches = panelSrc.match(/score\?\.lastUpdated\s*\?\s*this\.shortDate\(score\.lastUpdated\)\s*:\s*'—'/g);
+    assert.ok(matches, 'expected null-aware render pattern with "—" placeholder');
+    assert.ok(matches.length >= 2, `expected ≥2 null-aware render sites, found ${matches.length}`);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #3800.

The `cached-risk-scores` adapter fabricated `lastUpdated` / `computedAt` as `new Date().toISOString()` in four places, making cached or undated risk intelligence render as "Updated today" in the CountryDeepDive panel — misleading users about data freshness for stale or absent data.

## What was broken

`src/services/cached-risk-scores.ts` set timestamps to `now` in 4 places:

| Line | Site | Bug |
|------|------|-----|
| 97 | CII mapper | Fell back to `new Date()` when `proto.computedAt` missing |
| 107 | Strategic-risk | Unconditional `new Date()`, regardless of upstream age |
| 123 | Aggregate | Stamped at adapter time, not preserved from upstream |
| 189 | `emptyFallback` | Even the "no data" path claimed to be fresh |

UI consumer `CountryDeepDivePanel.ts` at L2207 and L2389 then rendered ``Updated ${this.shortDate(score?.lastUpdated ?? new Date())}`` — the `?? new Date()` fallback compounded the lie.

## What's fixed (client-only)

**Adapter (`src/services/cached-risk-scores.ts`):**
- `CachedCIIScore.lastUpdated`, `CachedStrategicRisk.lastUpdated`, and `CachedRiskScores.computedAt` are now `string | null`.
- CII mapper preserves `proto.computedAt` verbatim or surfaces `null` (no more fabrication).
- Strategic-risk + aggregate timestamps derive from the freshest CII `computedAt` via a new `deriveMaxCiiTimestamp` helper. When no CII carries a real timestamp, they're `null`.
- `emptyFallback` returns `null` for both timestamps.
- `toCountryScore` returns `lastUpdated: null` when the source is null.

**Type propagation (`src/services/country-instability.ts`):**
- `CountryScore.lastUpdated` is now `Date | null` so the truth flows through to the UI.

**UI (`src/components/CountryDeepDivePanel.ts`):**
- Both render sites (L2207, L2389) now render `Updated —` when `score.lastUpdated` is null instead of the fabricated `new Date()`.

## Why narrow

The proto only carries `computed_at` on `CiiScore` (`proto/worldmonitor/intelligence/v1/intelligence.proto:33`). `StrategicRisk` and `GetRiskScoresResponse` have no timestamp fields. A full server-side end-to-end fix — adding `StrategicRisk.computed_at` + `GetRiskScoresResponse.computed_at` to the proto, plumbing `cachedFetchJsonWithMeta`, etc. — is a follow-up. This PR closes the user-visible misinformation today.

## Test plan

- [x] New: `tests/cached-risk-scores.test.mts` — 14 tests covering preservation, null surfacing, max-CII derivation, emptyFallback null guarantee, panel render-site guarantees. All pass.
- [x] Existing: `tests/cii-scoring.test.mts` — all 36 tests still pass.
- [x] Full: `npm run test:data` — all 9304 tests pass.
- [x] `npm run typecheck` — clean (the `string | null` change surfaced no other consumers; nothing else broke).
- [x] `npx biome lint` on touched files — no new findings (3 pre-existing complexity/`let`→`const` warnings on unrelated lines in `CountryDeepDivePanel.ts` left untouched).

## Files touched

- `src/services/cached-risk-scores.ts` (+29 / -10)
- `src/services/country-instability.ts` (+2 / -1)
- `src/components/CountryDeepDivePanel.ts` (+2 / -2)
- `tests/cached-risk-scores.test.mts` (new, +260)