### PR TITLE
fix(insights): on-demand bootstrap-key refetch so mobile recovers from hydration miss

### DIFF
--- a/src/components/InsightsPanel.ts
+++ b/src/components/InsightsPanel.ts
@@ -18,7 +18,7 @@ import { getAiFlowSettings, isAnyAiProviderEnabled, subscribeAiFlowChange } from
 import { getActiveFrameworkForPanel, subscribeFrameworkChange } from '@/services/analysis-framework-store';
 import { hasPremiumAccess } from '@/services/panel-gating';
 import { FrameworkSelector } from './FrameworkSelector';
-import { getServerInsights, type ServerInsights, type ServerInsightStory } from '@/services/insights-loader';
+import { fetchServerInsights, getServerInsights, type ServerInsights, type ServerInsightStory } from '@/services/insights-loader';
 import { computeISQ, type SignalQuality, type SignalQualityInput } from '@/utils/signal-quality';
 import { extractEntitiesFromTitle } from '@/services/entity-extraction';
 import { getEntityIndex } from '@/services/entity-index';
@@ -185,7 +185,18 @@ export class InsightsPanel extends Panel {
     const thisGeneration = this.updateGeneration;
 
     // Try server-side pre-computed insights first (instant, works even without clusters)
-    const serverInsights = getServerInsights();
+    let serverInsights = getServerInsights();
+    if (!serverInsights) {
+      // Bootstrap hydration miss (mobile fast-tier abort on 4G, stale cache,
+      // or single-shot getHydratedData already consumed). On-demand refetch
+      // via the bootstrap key-filter endpoint covers all three cases —
+      // critical for mobile where the client-side LLM fallback is gated off,
+      // and a free win for desktop (no client LLM cost when server data is
+      // recoverable). Mirrors the AAIISentimentPanel pattern.
+      if (this.updateGeneration !== thisGeneration) return;
+      serverInsights = await fetchServerInsights();
+      if (this.updateGeneration !== thisGeneration) return;
+    }
     if (serverInsights) {
       await this.updateFromServer(serverInsights, clusters, thisGeneration);
       return;

--- a/src/services/insights-loader.ts
+++ b/src/services/insights-loader.ts
@@ -1,4 +1,5 @@
 import { getHydratedData } from '@/services/bootstrap';
+import { toApiUrl } from '@/services/runtime';
 
 export interface ServerInsightStory {
   primaryTitle: string;
@@ -41,23 +42,65 @@ function isFresh(data: ServerInsights): boolean {
   return age < MAX_AGE_MS;
 }
 
+function validateInsights(raw: unknown): ServerInsights | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const data = raw as ServerInsights;
+  if (!Array.isArray(data.topStories) || data.topStories.length === 0) return null;
+  if (typeof data.generatedAt !== 'string') return null;
+  if (!isFresh(data)) return null;
+  return data;
+}
+
 export function getServerInsights(): ServerInsights | null {
   if (cached && isFresh(cached)) {
     return cached;
   }
   cached = null;
 
-  const raw = getHydratedData('insights');
-  if (!raw || typeof raw !== 'object') return null;
-  const data = raw as ServerInsights;
-  if (!Array.isArray(data.topStories) || data.topStories.length === 0) return null;
-  if (typeof data.generatedAt !== 'string') return null;
-  if (!isFresh(data)) return null;
-
-  cached = data;
+  const data = validateInsights(getHydratedData('insights'));
+  if (data) cached = data;
   return data;
+}
+
+/**
+ * On-demand refetch of the server-insights snapshot via the bootstrap
+ * key-filter endpoint. Used by InsightsPanel when getServerInsights() returns
+ * null because the bootstrap hydration cache is empty — typically:
+ *   - mobile fast-tier abort on 4G (bootstrap.ts:179 — 1.2 s budget),
+ *   - cached value went stale (>MAX_AGE_MS) with no second bootstrap fetch,
+ *   - getHydratedData() was already consumed by an earlier failed validation
+ *     (it deletes on read; insights-loader.ts validation drained the slot
+ *     without caching, leaving subsequent reads with nothing).
+ *
+ * The bootstrap API supports `?keys=insights` filtering (api/bootstrap.js:250)
+ * and is CDN-cached (s-maxage=600 for fast tier), so polling is cheap.
+ * Mirrors the AAIISentimentPanel fallback shape (AAIISentimentPanel.ts:147).
+ *
+ * Returns the validated insights on success, null on any failure (network,
+ * timeout, validation). Caches the value module-locally on success so
+ * subsequent getServerInsights() calls return it without re-fetching.
+ */
+export async function fetchServerInsights(timeoutMs = 5_000): Promise<ServerInsights | null> {
+  if (cached && isFresh(cached)) return cached;
+  try {
+    const resp = await fetch(toApiUrl('/api/bootstrap?keys=insights'), {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!resp.ok) return null;
+    const payload = (await resp.json()) as { data?: { insights?: unknown } };
+    const data = validateInsights(payload.data?.insights);
+    if (data) cached = data;
+    return data;
+  } catch {
+    return null;
+  }
 }
 
 export function setServerInsights(data: ServerInsights): void {
   cached = data;
+}
+
+/** Test-only: reset module-local cache so suites can exercise the drain-once behavior. */
+export function __resetServerInsightsCacheForTests(): void {
+  cached = null;
 }

--- a/tests/insights-loader.test.mjs
+++ b/tests/insights-loader.test.mjs
@@ -1,7 +1,12 @@
-import { describe, it, beforeEach } from 'node:test';
+import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { MAX_AGE_MS } from '../src/services/insights-loader';
+import {
+  MAX_AGE_MS,
+  fetchServerInsights,
+  getServerInsights,
+  __resetServerInsightsCacheForTests,
+} from '../src/services/insights-loader';
 
 describe('insights-loader', () => {
   describe('MAX_AGE_MS — server-cadence-aligned freshness window', () => {
@@ -74,6 +79,107 @@ describe('insights-loader', () => {
     it('rejects empty topStories', () => {
       const empty = { topStories: [] };
       assert.equal(empty.topStories.length >= 1, false);
+    });
+  });
+
+  describe('fetchServerInsights — bootstrap-key on-demand refetch', () => {
+    let originalFetch;
+
+    function makeValidInsights() {
+      return {
+        worldBrief: 'Test brief',
+        briefProvider: 'groq',
+        status: 'ok',
+        topStories: [{
+          primaryTitle: 'Test', primarySource: 's', primaryLink: 'l', pubDate: '',
+          sourceCount: 2, importanceScore: 1, velocity: { level: 'low', sourcesPerHour: 1 },
+          isAlert: false, category: 'general', threatLevel: 'low', countryCode: null,
+        }],
+        generatedAt: new Date().toISOString(),
+        clusterCount: 10,
+        multiSourceCount: 5,
+        fastMovingCount: 3,
+      };
+    }
+
+    beforeEach(() => {
+      __resetServerInsightsCacheForTests();
+      originalFetch = globalThis.fetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('REGRESSION: recovers when getServerInsights() returns null because bootstrap hydration is missing', async () => {
+      // Repros the mobile "AI INSIGHTS · UNAVAILABLE · Waiting for news data..."
+      // bug: on 4G the fast-tier bootstrap aborts at 1.2 s, `insights` never
+      // lands in the hydration cache, `getServerInsights()` returns null,
+      // and InsightsPanel dead-ends on the mobile branch with no retry. The
+      // on-demand fetcher must hit /api/bootstrap?keys=insights and return
+      // validated data so the panel can recover without a page reload.
+      const valid = makeValidInsights();
+      let calledUrl = '';
+      globalThis.fetch = async (url) => {
+        calledUrl = String(url);
+        return new Response(JSON.stringify({ data: { insights: valid } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      };
+
+      assert.equal(getServerInsights(), null, 'precondition: no hydrated data');
+      const fetched = await fetchServerInsights();
+      assert.ok(fetched, 'fetch fallback returned data');
+      assert.equal(fetched?.worldBrief, 'Test brief');
+      assert.match(calledUrl, /\/api\/bootstrap\?keys=insights\b/, 'used the bootstrap key-filter endpoint, not a separate route');
+    });
+
+    it('caches the fetched value so subsequent getServerInsights() is synchronous', async () => {
+      const valid = makeValidInsights();
+      let fetchCount = 0;
+      globalThis.fetch = async () => {
+        fetchCount++;
+        return new Response(JSON.stringify({ data: { insights: valid } }), { status: 200 });
+      };
+
+      await fetchServerInsights();
+      const sync = getServerInsights();
+      assert.ok(sync, 'cached value visible to sync reader');
+      assert.equal(sync?.worldBrief, 'Test brief');
+      assert.equal(fetchCount, 1, 'no extra network round trip');
+    });
+
+    it('returns null without throwing when /api/bootstrap times out', async () => {
+      globalThis.fetch = async () => {
+        const err = new Error('aborted');
+        err.name = 'TimeoutError';
+        throw err;
+      };
+      const result = await fetchServerInsights(50);
+      assert.equal(result, null);
+    });
+
+    it('returns null without throwing on a non-2xx response', async () => {
+      globalThis.fetch = async () => new Response('upstream down', { status: 503 });
+      const result = await fetchServerInsights();
+      assert.equal(result, null);
+    });
+
+    it('returns null when payload validation fails (empty topStories)', async () => {
+      const invalid = { ...makeValidInsights(), topStories: [] };
+      globalThis.fetch = async () =>
+        new Response(JSON.stringify({ data: { insights: invalid } }), { status: 200 });
+      const result = await fetchServerInsights();
+      assert.equal(result, null);
+    });
+
+    it('returns null when payload validation fails (stale generatedAt)', async () => {
+      const stale = { ...makeValidInsights(), generatedAt: new Date(Date.now() - MAX_AGE_MS - 60_000).toISOString() };
+      globalThis.fetch = async () =>
+        new Response(JSON.stringify({ data: { insights: stale } }), { status: 200 });
+      const result = await fetchServerInsights();
+      assert.equal(result, null);
     });
   });
 });


### PR DESCRIPTION
## Symptom

Mobile users on 4G see \`AI INSIGHTS · UNAVAILABLE · Waiting for news data...\` with no recovery short of a page reload. Desktop is fine — same Redis data, same bootstrap endpoint, same panel code.

## Root cause — 3-way trap

1. **Mobile dead-end:** \`InsightsPanel.ts:200-205\` explicitly skips the client-side LLM fallback that desktop uses:
   \`\`\`ts
   if (isMobileDevice()) {
     this.setDataBadge('unavailable');
     this.setContent(\`<div class="insights-empty">\${...}</div>\`);
     return;   // ← mobile dead-ends here
   }
   await this.updateFromClient(clusters, thisGeneration);   // ← desktop only
   \`\`\`
   So mobile is 100% dependent on \`getServerInsights()\` returning truthy.

2. **Single-shot hydration consume:** \`bootstrap.ts:32-36\` — \`getHydratedData(key)\` *deletes* on first read. On mobile, the fast-tier bootstrap budget is **1.2 s** (\`bootstrap.ts:179\`) vs **5 s** desktop; on 4G it routinely aborts → \`insights\` never lands in the hydration cache. Even after the abort, on a stale or empty-topStories validation miss, the slot is drained without caching → subsequent reads find nothing.

3. **No retry path:** \`updateInsights()\` runs exactly once per news-load cycle (\`data-loader.ts:1213\`), never re-runs purely because insights data later arrives.

## Fix

Add \`fetchServerInsights()\` to \`insights-loader.ts\` — fetches \`/api/bootstrap?keys=insights\` on demand, validates with the same shape checks, caches module-locally. \`InsightsPanel.updateInsights()\` now tries it before bailing.

Mirrors the \`AAIISentimentPanel.ts:147\` pattern (the only other panel using bootstrap-key refetch as a fallback). Uses the existing \`?keys=\` filter (\`api/bootstrap.js:250\`) — no new endpoint. The \`wm-session\` fetch interceptor adds \`X-WorldMonitor-Key\` automatically, so the bare \`fetch\` authenticates in production the same way every other bare-fetch panel call does.

Applies to **both** mobile (the broken-by-design branch) and desktop (saves a client-LLM call when the server snapshot is just temporarily missing from hydration).

## Audit results

User asked whether other panels have the same shape. **They don't:**

| Pattern | Sites | Has fallback? |
|---|---|---|
| \`isMobileDevice()\` data cutoff → UNAVAILABLE | **1** (\`InsightsPanel.ts:201\`) | **No — broken** |
| \`isMobileDevice()\` for layout/UX only | 5 (SearchModal, MobileWarningModal, LiveWebcamsPanel, MapPopup, MapContainer) | N/A |
| \`getHydratedData('X')\` with RPC fallback | 7 sampled (Stablecoin, ETFFlows, MacroSignals, FuelPrices, MarketBreadth, FAO, Positioning) | ✓ |
| \`getHydratedData('X')\` with bootstrap-key fallback | AAIISentimentPanel | ✓ — pattern copied here |
| \`getHydratedData('X')\` with no fallback | **InsightsPanel only** | **No — fixed** |

## Test plan

- [x] 6 new regression tests in \`tests/insights-loader.test.mjs\` stubbing \`globalThis.fetch\`:
  - hydration-miss recovery (the bug repro)
  - cache memoization (subsequent \`getServerInsights()\` returns cached without re-fetch)
  - timeout: returns null without throwing
  - non-2xx: returns null without throwing
  - validation failure: empty \`topStories\` → null
  - validation failure: stale \`generatedAt\` → null
- [x] All 15 tests pass (\`npx tsx --test tests/insights-loader.test.mjs\`)
- [x] \`npm run typecheck\` clean
- [x] \`biome lint\` clean on changed files
- [ ] After deploy: verify on mobile 4G that AI INSIGHTS recovers within one news-load tick when hydration misses, instead of dead-ending on UNAVAILABLE