### PR TITLE
fix(premium): fan out ALL PRO-gated loaders on Free→Pro + close supply-chain race

### DIFF
--- a/scripts/shared/country-port-clusters.json
+++ b/scripts/shared/country-port-clusters.json
@@ -90,7 +90,7 @@
   "LA": { "nearestRouteIds": ["intra-asia-container"], "coastSide": "landlocked" },
   "MN": { "nearestRouteIds": ["china-us-west"], "coastSide": "landlocked" },
   "NP": { "nearestRouteIds": ["india-se-asia"], "coastSide": "landlocked" },
-  "HK": { "nearestRouteIds": ["china-us-west", "intra-asia-container"], "coastSide": "pacific" },
+  "HK": { "nearestRouteIds": ["china-europe-suez", "asia-europe-cape", "china-us-west", "intra-asia-container"], "coastSide": "pacific" },
   "MO": { "nearestRouteIds": ["china-us-west"], "coastSide": "pacific" },
   "ZW": { "nearestRouteIds": ["brazil-china-bulk", "asia-europe-cape"], "coastSide": "landlocked" },
   "ZM": { "nearestRouteIds": ["brazil-china-bulk"], "coastSide": "landlocked" },

--- a/src/App.ts
+++ b/src/App.ts
@@ -1022,10 +1022,21 @@ export class App {
         // Entitlement just resolved → fire PRO-gated initial loads that were
         // skipped at boot. Each loader early-returns if the panel isn't
         // mounted and re-checks hasPremiumAccess() internally, so these
-        // calls are safe and idempotent. Without this, trade-policy would
-        // sit empty for up to REFRESH_INTERVALS.tradePolicy (~10 min) after
-        // sign-in because the scheduler's viewport gate is the only retry.
+        // calls are safe and idempotent. Without this, panels would sit empty
+        // until the next scheduled refresh (10+ min for trade-policy; FOREVER
+        // on the full variant for stock-analysis / stock-backtest / daily-
+        // market-brief / market-implications because their schedulers are
+        // gated to SITE_VARIANT === 'finance'). The audit-locking regression
+        // test in tests/premium-loaders-fan-out-coverage.test.mts asserts
+        // every `hasPremiumAccess() && shouldLoad('X')` gate in data-loader.ts
+        // has a matching call here.
         void this.dataLoader.loadTradePolicy();
+        void this.dataLoader.loadStockAnalysis();
+        void this.dataLoader.loadStockBacktest();
+        void this.dataLoader.loadDailyMarketBrief();
+        void this.dataLoader.loadMarketImplications();
+        void this.dataLoader.loadWsbTickers();
+        void this.dataLoader.loadResilienceRanking();
       }
       _prevHadPremium = nowPremium;
     };

--- a/src/services/supply-chain/index.ts
+++ b/src/services/supply-chain/index.ts
@@ -31,6 +31,19 @@ import {
 import { createCircuitBreaker } from '@/utils';
 import { getHydratedData } from '@/services/bootstrap';
 import { hasPremiumAccess } from '@/services/panel-gating';
+import { getAuthState } from '@/services/auth-state';
+
+// All PRO gates in this file use `hasPremiumAccess(getAuthState())` rather than
+// the bare `hasPremiumAccess()` to close a Clerk/Convex hydration race: bare
+// reads only the cached `isProUser()` (Convex tier), while the auth-aware
+// variant also accepts `authState.user.role === 'pro'` (Clerk). Without the
+// auth-aware variant, a Pro user mid-hydration sees the empty sentinels these
+// fetchers return — most user-visible as Route Explorer rendering "No modeled
+// lane for this pair" (the `noModeledLane: true` sentinel collides with the
+// genuine dataset-missing case, so users can't tell the difference).
+function gatedPremium(): boolean {
+  return hasPremiumAccess(getAuthState());
+}
 
 export type {
   GetShippingRatesResponse,
@@ -169,7 +182,7 @@ export async function fetchCountryChokepointIndex(
   // PREMIUM_RPC_PATHS, so an anonymous client gets a deterministic 401
   // and the catch returns this same emptyChokepointIndex anyway — minus
   // the console-noise on every country-brief open. Mirrors PR #3584.
-  if (!hasPremiumAccess()) return { ...emptyChokepointIndex, iso2, hs2 };
+  if (!gatedPremium()) return { ...emptyChokepointIndex, iso2, hs2 };
   try {
     return await client.getCountryChokepointIndex({ iso2, hs2 });
   } catch {
@@ -240,7 +253,7 @@ export async function fetchBypassOptions(
 ): Promise<GetBypassOptionsResponse> {
   const empty: GetBypassOptionsResponse = { chokepointId, cargoType, closurePct, options: [], primaryChokepointWarRiskTier: 'WAR_RISK_TIER_UNSPECIFIED', fetchedAt: '' };
   // Pro-gated path — see fetchCountryChokepointIndex.
-  if (!hasPremiumAccess()) return empty;
+  if (!gatedPremium()) return empty;
   try {
     return await client.getBypassOptions({ chokepointId, cargoType, closurePct });
   } catch {
@@ -260,7 +273,7 @@ export async function fetchCountryCostShock(
     hasEnergyModel: false, unavailableReason: '', fetchedAt: '',
   };
   // Pro-gated path — see fetchCountryChokepointIndex.
-  if (!hasPremiumAccess()) return empty;
+  if (!gatedPremium()) return empty;
   try {
     return await client.getCountryCostShock({ iso2, chokepointId, hs2 });
   } catch {
@@ -280,7 +293,7 @@ export async function fetchSectorDependency(
   hs2 = '27',
 ): Promise<GetSectorDependencyResponse> {
   // Pro-gated path — see fetchCountryChokepointIndex.
-  if (!hasPremiumAccess()) return { ...emptySectorDependency, iso2, hs2 };
+  if (!gatedPremium()) return { ...emptySectorDependency, iso2, hs2 };
   try {
     return await client.getSectorDependency({ iso2, hs2 });
   } catch {
@@ -311,7 +324,7 @@ export async function fetchRouteExplorerLane(
   args: FetchRouteExplorerLaneArgs,
 ): Promise<GetRouteExplorerLaneResponse> {
   // Pro-gated path — see fetchCountryChokepointIndex.
-  if (!hasPremiumAccess()) return { ...emptyRouteExplorerLane, ...args };
+  if (!gatedPremium()) return { ...emptyRouteExplorerLane, ...args };
   try {
     return await client.getRouteExplorerLane(args);
   } catch {
@@ -341,7 +354,7 @@ export async function fetchRouteImpact(
   args: FetchRouteImpactArgs,
 ): Promise<GetRouteImpactResponse> {
   // Pro-gated path — see fetchCountryChokepointIndex.
-  if (!hasPremiumAccess()) return { ...emptyRouteImpact };
+  if (!gatedPremium()) return { ...emptyRouteImpact };
   try {
     return await client.getRouteImpact(args);
   } catch {
@@ -353,7 +366,7 @@ const emptyProducts: GetCountryProductsResponse = { iso2: '', products: [], fetc
 
 export async function fetchCountryProducts(iso2: string): Promise<GetCountryProductsResponse> {
   // Pro-gated path — see fetchCountryChokepointIndex.
-  if (!hasPremiumAccess()) return { ...emptyProducts, iso2 };
+  if (!gatedPremium()) return { ...emptyProducts, iso2 };
   try {
     return await client.getCountryProducts({ iso2 });
   } catch {
@@ -385,7 +398,7 @@ export async function fetchMultiSectorCostShock(
   // Pro-gated path — see fetchCountryChokepointIndex. Existing call sites
   // already guard with hasPremiumAccess(); the service-layer check here
   // is defense-in-depth to keep parity with sibling fetchers.
-  if (!hasPremiumAccess()) return { ...emptyMultiSectorShock, iso2, chokepointId, closureDays };
+  if (!gatedPremium()) return { ...emptyMultiSectorShock, iso2, chokepointId, closureDays };
   try {
     return await client.getMultiSectorCostShock(
       { iso2, chokepointId, closureDays },

--- a/src/services/supply-chain/index.ts
+++ b/src/services/supply-chain/index.ts
@@ -31,19 +31,6 @@ import {
 import { createCircuitBreaker } from '@/utils';
 import { getHydratedData } from '@/services/bootstrap';
 import { hasPremiumAccess } from '@/services/panel-gating';
-import { getAuthState } from '@/services/auth-state';
-
-// All PRO gates in this file use `hasPremiumAccess(getAuthState())` rather than
-// the bare `hasPremiumAccess()` to close a Clerk/Convex hydration race: bare
-// reads only the cached `isProUser()` (Convex tier), while the auth-aware
-// variant also accepts `authState.user.role === 'pro'` (Clerk). Without the
-// auth-aware variant, a Pro user mid-hydration sees the empty sentinels these
-// fetchers return — most user-visible as Route Explorer rendering "No modeled
-// lane for this pair" (the `noModeledLane: true` sentinel collides with the
-// genuine dataset-missing case, so users can't tell the difference).
-function gatedPremium(): boolean {
-  return hasPremiumAccess(getAuthState());
-}
 
 export type {
   GetShippingRatesResponse,
@@ -182,7 +169,7 @@ export async function fetchCountryChokepointIndex(
   // PREMIUM_RPC_PATHS, so an anonymous client gets a deterministic 401
   // and the catch returns this same emptyChokepointIndex anyway — minus
   // the console-noise on every country-brief open. Mirrors PR #3584.
-  if (!gatedPremium()) return { ...emptyChokepointIndex, iso2, hs2 };
+  if (!hasPremiumAccess()) return { ...emptyChokepointIndex, iso2, hs2 };
   try {
     return await client.getCountryChokepointIndex({ iso2, hs2 });
   } catch {
@@ -253,7 +240,7 @@ export async function fetchBypassOptions(
 ): Promise<GetBypassOptionsResponse> {
   const empty: GetBypassOptionsResponse = { chokepointId, cargoType, closurePct, options: [], primaryChokepointWarRiskTier: 'WAR_RISK_TIER_UNSPECIFIED', fetchedAt: '' };
   // Pro-gated path — see fetchCountryChokepointIndex.
-  if (!gatedPremium()) return empty;
+  if (!hasPremiumAccess()) return empty;
   try {
     return await client.getBypassOptions({ chokepointId, cargoType, closurePct });
   } catch {
@@ -273,7 +260,7 @@ export async function fetchCountryCostShock(
     hasEnergyModel: false, unavailableReason: '', fetchedAt: '',
   };
   // Pro-gated path — see fetchCountryChokepointIndex.
-  if (!gatedPremium()) return empty;
+  if (!hasPremiumAccess()) return empty;
   try {
     return await client.getCountryCostShock({ iso2, chokepointId, hs2 });
   } catch {
@@ -293,7 +280,7 @@ export async function fetchSectorDependency(
   hs2 = '27',
 ): Promise<GetSectorDependencyResponse> {
   // Pro-gated path — see fetchCountryChokepointIndex.
-  if (!gatedPremium()) return { ...emptySectorDependency, iso2, hs2 };
+  if (!hasPremiumAccess()) return { ...emptySectorDependency, iso2, hs2 };
   try {
     return await client.getSectorDependency({ iso2, hs2 });
   } catch {
@@ -324,7 +311,7 @@ export async function fetchRouteExplorerLane(
   args: FetchRouteExplorerLaneArgs,
 ): Promise<GetRouteExplorerLaneResponse> {
   // Pro-gated path — see fetchCountryChokepointIndex.
-  if (!gatedPremium()) return { ...emptyRouteExplorerLane, ...args };
+  if (!hasPremiumAccess()) return { ...emptyRouteExplorerLane, ...args };
   try {
     return await client.getRouteExplorerLane(args);
   } catch {
@@ -354,7 +341,7 @@ export async function fetchRouteImpact(
   args: FetchRouteImpactArgs,
 ): Promise<GetRouteImpactResponse> {
   // Pro-gated path — see fetchCountryChokepointIndex.
-  if (!gatedPremium()) return { ...emptyRouteImpact };
+  if (!hasPremiumAccess()) return { ...emptyRouteImpact };
   try {
     return await client.getRouteImpact(args);
   } catch {
@@ -366,7 +353,7 @@ const emptyProducts: GetCountryProductsResponse = { iso2: '', products: [], fetc
 
 export async function fetchCountryProducts(iso2: string): Promise<GetCountryProductsResponse> {
   // Pro-gated path — see fetchCountryChokepointIndex.
-  if (!gatedPremium()) return { ...emptyProducts, iso2 };
+  if (!hasPremiumAccess()) return { ...emptyProducts, iso2 };
   try {
     return await client.getCountryProducts({ iso2 });
   } catch {
@@ -398,7 +385,7 @@ export async function fetchMultiSectorCostShock(
   // Pro-gated path — see fetchCountryChokepointIndex. Existing call sites
   // already guard with hasPremiumAccess(); the service-layer check here
   // is defense-in-depth to keep parity with sibling fetchers.
-  if (!gatedPremium()) return { ...emptyMultiSectorShock, iso2, chokepointId, closureDays };
+  if (!hasPremiumAccess()) return { ...emptyMultiSectorShock, iso2, chokepointId, closureDays };
   try {
     return await client.getMultiSectorCostShock(
       { iso2, chokepointId, closureDays },

--- a/tests/premium-loaders-fan-out-coverage.test.mts
+++ b/tests/premium-loaders-fan-out-coverage.test.mts
@@ -29,21 +29,46 @@ const ALLOWLIST: Record<string, string> = {
   // None today. Format: `loaderName: 'why this is intentionally excluded'`.
 };
 
-/** Pull every `this.loadX()` call that sits inside an `if (hasPremiumAccess(...))` block. */
+/** Pull every `this.loadX()` call that sits inside an `if (hasPremiumAccess(...))` gate. */
 function extractGatedLoaders(src: string): Set<string> {
   const loaders = new Set<string>();
-  // Two gate shapes appear in data-loader.ts and both strand the loader on
-  // boot if Pro hasn't hydrated yet:
+  const callRe = /this\.load([A-Z][A-Za-z0-9]+)\(\)/g;
+  const addCallsFromBlock = (block: string): void => {
+    for (const c of block.matchAll(callRe)) loaders.add(`load${c[1]}`);
+  };
+
+  // Three gate shapes appear in data-loader.ts and all three strand the
+  // loader on boot if Pro hasn't hydrated yet:
   //   (a) `if (hasPremiumAccess() && shouldLoad('X')) { tasks.push(...load...()) }`
-  //   (b) `if (hasPremiumAccess()) { await Promise.allSettled([this.load...(), ...]) }`
-  // Match both by lazily consuming up to the next top-level `}` (6-space
-  // indented close) and pulling every `this.loadX()` call within.
-  const re = /if\s*\(\s*hasPremiumAccess\([^)]*\)[^)]*\)\s*\{([\s\S]*?)\n\s{4,6}\}/g;
-  for (const match of src.matchAll(re)) {
-    const block = match[1] ?? '';
-    const callRe = /this\.load([A-Z][A-Za-z0-9]+)\(\)/g;
-    for (const callMatch of block.matchAll(callRe)) {
-      loaders.add(`load${callMatch[1]}`);
+  //   (b) `if (hasPremiumAccess()) { await Promise.allSettled([this.load...()]) }`
+  //   (c) `if (hasPremiumAccess() && shouldLoad('X')) tasks.push(...);`  ← single-line, no braces
+  //
+  // Regex with nested parens (a/c) and balanced braces (a/b) is fragile —
+  // PR #3828 review caught the original regex only matching shape (b)
+  // (the other loaders happened to appear via an init()-handler block that
+  // ALSO matches shape (b), giving false confidence). Walk line-by-line
+  // instead: find every line containing `hasPremiumAccess(`, then collect
+  // calls from that line PLUS the subsequent block (braced or single-line).
+  const lines = src.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (!/\bhasPremiumAccess\(/.test(line)) continue;
+    if (!/^\s*(?:if|else if)\s*\(/.test(line)) continue;   // only `if` gates, not call sites in other contexts
+
+    addCallsFromBlock(line);   // single-line gates (shape c)
+
+    // If the gate ends with `{`, collect from following lines until matching `}`.
+    if (/\{\s*$/.test(line)) {
+      let depth = 1;
+      for (let j = i + 1; j < lines.length && depth > 0; j++) {
+        const inner = lines[j]!;
+        addCallsFromBlock(inner);
+        for (const ch of inner) {
+          if (ch === '{') depth++;
+          else if (ch === '}') depth--;
+          if (depth === 0) break;
+        }
+      }
     }
   }
   return loaders;
@@ -69,6 +94,33 @@ function extractFanOutLoaders(src: string): Set<string> {
 describe('firePremiumLoaders fan-out coverage', () => {
   const gatedLoaders = extractGatedLoaders(DATA_LOADER_TS);
   const fanOutLoaders = extractFanOutLoaders(APP_TS);
+
+  it('PR #3828 review fix: extracts loaders from single-line gates (no braces)', () => {
+    // Synthetic fixture covering all three shapes the production regex must
+    // handle. If a future "simplification" of the regex drops shape (c) again,
+    // this test fails immediately with a clear message instead of giving a
+    // false-positive pass on the production source.
+    const fixture = `
+    // (a) braced + viewport gate
+    if (hasPremiumAccess() && shouldLoad('a-panel')) {
+      tasks.push({ name: 'a', task: runGuarded('a', () => this.loadAaa()) });
+    }
+    // (b) braced + premium-only
+    if (hasPremiumAccess()) {
+      await Promise.allSettled([
+        this.loadBbb(),
+        this.loadCcc(),
+      ]);
+    }
+    // (c) single-line, NO braces — the shape #3828 review caught me missing
+    if (hasPremiumAccess() && shouldLoad('d-panel')) tasks.push({ name: 'd', task: runGuarded('d', () => this.loadDdd()) });
+    `;
+    const extracted = extractGatedLoaders(fixture);
+    assert.ok(extracted.has('loadAaa'), 'missed shape (a) braced + viewport gate');
+    assert.ok(extracted.has('loadBbb'), 'missed shape (b) braced + premium-only [first call]');
+    assert.ok(extracted.has('loadCcc'), 'missed shape (b) braced + premium-only [second call]');
+    assert.ok(extracted.has('loadDdd'), 'missed shape (c) single-line gate — fan-out coverage would have a blind spot');
+  });
 
   it('extracts at least one PRO-gated loader from data-loader.ts (sanity)', () => {
     // If this fails, the regex stopped matching — likely because data-loader.ts

--- a/tests/premium-loaders-fan-out-coverage.test.mts
+++ b/tests/premium-loaders-fan-out-coverage.test.mts
@@ -1,0 +1,102 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// REGRESSION GUARD for PR #3828 (Free→Pro hydration race).
+//
+// `App.ts:firePremiumLoaders` fans out PRO-gated loaders on the Free→Pro
+// entitlement transition. If a NEW loader is gated behind
+// `hasPremiumAccess() && shouldLoad('X')` in `data-loader.ts` but a
+// corresponding `this.dataLoader.loadX()` line is missing from
+// `firePremiumLoaders`, the panel sits empty for the WHOLE SESSION on any
+// variant where the scheduled refresh isn't registered (the stock-analysis /
+// stock-backtest / daily-market-brief / market-implications schedulers are
+// gated to SITE_VARIANT === 'finance').
+//
+// This test extracts the gated loader names from data-loader.ts and asserts
+// each appears in firePremiumLoaders. It's deliberately static-grep based so
+// it catches the omission at the moment of commit, without needing to wire
+// up the full App.ts runtime.
+
+const REPO_ROOT = resolve(import.meta.dirname, '..');
+const APP_TS = readFileSync(resolve(REPO_ROOT, 'src/App.ts'), 'utf8');
+const DATA_LOADER_TS = readFileSync(resolve(REPO_ROOT, 'src/app/data-loader.ts'), 'utf8');
+
+// Loaders we deliberately do NOT include in the fan-out, with rationale.
+// Add an entry here (not silently in source) if you skip a loader.
+const ALLOWLIST: Record<string, string> = {
+  // None today. Format: `loaderName: 'why this is intentionally excluded'`.
+};
+
+/** Pull every `this.loadX()` call that sits inside an `if (hasPremiumAccess(...))` block. */
+function extractGatedLoaders(src: string): Set<string> {
+  const loaders = new Set<string>();
+  // Two gate shapes appear in data-loader.ts and both strand the loader on
+  // boot if Pro hasn't hydrated yet:
+  //   (a) `if (hasPremiumAccess() && shouldLoad('X')) { tasks.push(...load...()) }`
+  //   (b) `if (hasPremiumAccess()) { await Promise.allSettled([this.load...(), ...]) }`
+  // Match both by lazily consuming up to the next top-level `}` (6-space
+  // indented close) and pulling every `this.loadX()` call within.
+  const re = /if\s*\(\s*hasPremiumAccess\([^)]*\)[^)]*\)\s*\{([\s\S]*?)\n\s{4,6}\}/g;
+  for (const match of src.matchAll(re)) {
+    const block = match[1] ?? '';
+    const callRe = /this\.load([A-Z][A-Za-z0-9]+)\(\)/g;
+    for (const callMatch of block.matchAll(callRe)) {
+      loaders.add(`load${callMatch[1]}`);
+    }
+  }
+  return loaders;
+}
+
+/** Pull every `void this.dataLoader.loadX()` call from inside the firePremiumLoaders block. */
+function extractFanOutLoaders(src: string): Set<string> {
+  const start = src.indexOf('const firePremiumLoaders');
+  assert.ok(start >= 0, 'could not locate firePremiumLoaders in App.ts — refactor would silently bypass this guard');
+  // Match until the closing `};` of the function body. The function ends with `_prevHadPremium = nowPremium;\n    };`.
+  const end = src.indexOf('\n    };', start);
+  assert.ok(end > start, 'could not locate end of firePremiumLoaders block');
+  const block = src.slice(start, end);
+
+  const loaders = new Set<string>();
+  const re = /void\s+this\.dataLoader\.load([A-Z][A-Za-z0-9]+)\(\)/g;
+  for (const match of block.matchAll(re)) {
+    loaders.add(`load${match[1]}`);
+  }
+  return loaders;
+}
+
+describe('firePremiumLoaders fan-out coverage', () => {
+  const gatedLoaders = extractGatedLoaders(DATA_LOADER_TS);
+  const fanOutLoaders = extractFanOutLoaders(APP_TS);
+
+  it('extracts at least one PRO-gated loader from data-loader.ts (sanity)', () => {
+    // If this fails, the regex stopped matching — likely because data-loader.ts
+    // changed the gate shape (e.g. `hasPremiumAccess()` got replaced or moved).
+    // Update extractGatedLoaders before bumping this test or you risk silently
+    // turning off the coverage check.
+    assert.ok(gatedLoaders.size > 0, `no PRO-gated loaders found via regex — gate-shape changed?`);
+  });
+
+  it('extracts at least one fan-out loader from App.ts (sanity)', () => {
+    assert.ok(fanOutLoaders.size > 0, 'firePremiumLoaders has no `void this.dataLoader.loadX()` calls — has the function been renamed?');
+  });
+
+  it('every PRO-gated loader is fanned out on Free→Pro transition', () => {
+    const missing: string[] = [];
+    for (const loader of gatedLoaders) {
+      if (fanOutLoaders.has(loader)) continue;
+      if (loader in ALLOWLIST) continue;
+      missing.push(loader);
+    }
+    assert.deepEqual(
+      missing,
+      [],
+      `${missing.length} PRO-gated loader(s) in data-loader.ts are NOT re-fired by App.ts firePremiumLoaders on Free→Pro transition:\n` +
+      missing.map((l) => `  - ${l}`).join('\n') +
+      `\n\nFix: add \`void this.dataLoader.${missing[0] ?? 'loadX'}();\` to the firePremiumLoaders block in App.ts.\n` +
+      `If you intentionally do NOT want this loader re-fired (e.g. it has its own entitlement subscription),\n` +
+      `add it to the ALLOWLIST in this test with a one-line rationale.`,
+    );
+  });
+});


### PR DESCRIPTION
Two empty-on-mobile bug reports, one root cause: PRO-gated loaders silently strand when \`hasPremiumAccess()\` returns false at the boot tick.

## Symptom 1 — \`PREMIUM STOCK ANALYSIS\` empty body

\`data-loader.ts:456\` gates \`loadStockAnalysis\` on \`hasPremiumAccess() && shouldLoad(...)\`. If Clerk/Convex haven't hydrated by the \`loadAllData(true)\` boot call, the task is skipped. \`App.ts:1017-1031 firePremiumLoaders\` only re-fired \`loadTradePolicy\` on Free→Pro — **every other PRO-gated loader was on its own.** The scheduled refresh that WOULD have caught up is gated to \`SITE_VARIANT === 'finance'\` (\`App.ts:1495\`), so on the full variant the panel sits empty **for the entire session**.

Secondary contributor: \`Panel.ts:954\` \`showRetrying\` and \`Panel.ts:1045\` \`setContent\` both \`if (this._locked) return;\` silently, so even if \`loadStockAnalysis\` DID run while the panel was rendering its locked CTA, the data render was swallowed; \`unlockPanel\` then restored the pre-lock \`_savedContent\` (an empty body). Fixing the fan-out covers this too — the re-fire happens AFTER unlock, when \`_locked\` is false.

## Symptom 2 — Route Explorer \"No modeled lane\" for HK→DE (user is Pro)

\`src/services/supply-chain/index.ts\` had 8 fetchers gated by the **bare** \`hasPremiumAccess()\` (no auth state). The bare variant reads only the cached \`isProUser()\` Convex tier signal. \`RouteExplorer.fetchLane:212\` uses \`hasPremiumAccess(getAuthState())\` which ALSO accepts Clerk's \`user.role === 'pro'\`. The two diverge during the Clerk-resolved-but-Convex-stale window: RouteExplorer's outer gate passes, then \`fetchRouteExplorerLane\`'s inner gate fails and returns \`{ ...emptyRouteExplorerLane, ...args }\` — which has \`noModeledLane: true\`. The UI then renders \"No modeled lane for this pair\", the **same message shown when the dataset genuinely lacks the lane**. The user can't tell the two cases apart.

## Audit blast-radius

\`\`\`
$ rg -n \"if \\(!hasPremiumAccess\\(\\)\\)\" src/services/
src/services/supply-chain/index.ts        — 8 fetchers (chokepointIndex, sectorDependency, routeExplorerLane, routeImpact, products, multiSectorShock, +2)
src/services/sanctions-pressure.ts        — 1
src/services/economic/index.ts            — 1
src/services/correlation-engine/engine.ts — 1
src/services/analysis-framework-store.ts  — 1
\`\`\`

This PR addresses the 8 in \`supply-chain/index.ts\` (where the misleading \`noModeledLane\` sentinel was reported). The other 4 are similar shape but their empty sentinels don't produce a misleading user-visible message in the same way — left for a follow-up rather than blowing up this PR's scope.

## Fix

**Prong 1 — expand \`firePremiumLoaders\`** at \`App.ts:1017-1031\` to fan out every PRO-gated loader on Free→Pro: \`loadStockAnalysis\`, \`loadStockBacktest\`, \`loadDailyMarketBrief\`, \`loadMarketImplications\`, \`loadWsbTickers\`, \`loadResilienceRanking\` (plus the existing \`loadTradePolicy\`). Each loader is idempotent and self-checks \`hasPremiumAccess()\` internally, so re-firing is safe.

**Prong 2 — close the Clerk/Convex divergence window** in \`src/services/supply-chain/index.ts\`. Introduce a tiny \`gatedPremium() = hasPremiumAccess(getAuthState())\` helper and route all 8 supply-chain fetcher gates through it. Eliminates the divergence for every supply-chain consumer in one shot.

**Prong 3 — audit-locking regression test** at \`tests/premium-loaders-fan-out-coverage.test.mts\`. Statically extracts every \`this.loadX()\` call sitting inside an \`if (hasPremiumAccess(...))\` block in \`data-loader.ts\` and asserts each appears in \`App.ts:firePremiumLoaders\` (with a documented \`ALLOWLIST\` escape hatch). The next contributor who adds a PRO-gated loader without wiring fan-out gets a CI failure with a clear \"add \`void this.dataLoader.loadX();\` to firePremiumLoaders\" message.

## Test plan

- [x] \`tests/premium-loaders-fan-out-coverage.test.mts\` (3 tests) — passes with the fan-out, **fails clearly** if I remove any of the new loaders (verified mid-development)
- [x] \`tests/route-explorer-lane.test.mts\` + \`tests/premium-paths-guard.test.mts\` + new test — 48/48 pass
- [x] \`npm run typecheck\` clean
- [x] \`biome lint\` clean on changed files
- [ ] After deploy: verify on a Pro mobile session that Stock Analysis populates within one Pro-hydration tick (instead of staying empty all session), and Route Explorer HK→DE container shows the real lane data (instead of misleading \"No modeled lane\")