### PR TITLE
fix(docker): require explicit REDIS_PASSWORD + REDIS_TOKEN, drop wm-local-token default (#3804)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,21 @@ UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 
 
+# ------ Self-hosted Redis (Docker Compose only) ------
+
+# REQUIRED when running via docker-compose.yml. Both containers fail to start
+# if either variable is unset (no shipped defaults — see #3804).
+# Generate fresh values:  openssl rand -hex 32
+#
+# REDIS_PASSWORD    → Redis AUTH password (--requirepass)
+# REDIS_TOKEN       → Upstash-compatible REST proxy bearer token (SRH_TOKEN)
+#
+# Not used on Vercel — the Upstash hosted instance uses the UPSTASH_*
+# variables above instead.
+REDIS_PASSWORD=
+REDIS_TOKEN=
+
+
 # ------ Market Data (Vercel) ------
 
 # Finnhub (primary stock quotes — free tier available)

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -122,6 +122,11 @@ To automate, add a cron job:
 If you prefer to run seeders individually:
 
 ```bash
+# Source .env so REDIS_TOKEN (and any API keys it holds) become available.
+# Quick-start puts REDIS_TOKEN in .env, not in your shell — without this,
+# the next line fails-loud with "REDIS_TOKEN: parameter null or not set".
+set -a; . ./.env; set +a
+
 export UPSTASH_REDIS_REST_URL=http://localhost:8079
 export UPSTASH_REDIS_REST_TOKEN="${REDIS_TOKEN:?set REDIS_TOKEN in .env first}"
 node scripts/seed-earthquakes.mjs

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -16,9 +16,11 @@ git clone https://github.com/koala73/worldmonitor.git
 cd worldmonitor
 npm install
 
-# 2. Set the REQUIRED secret used to authenticate the AIS relay (see below).
-#    Without this the ais-relay container will exit at startup.
+# 2. Generate the REQUIRED secrets. Without these the stack will not start
+#    (see the "Required Environment Variables" table below).
 echo "RELAY_SHARED_SECRET=$(openssl rand -hex 32)" >> .env
+echo "REDIS_PASSWORD=$(openssl rand -hex 32)"      >> .env
+echo "REDIS_TOKEN=$(openssl rand -hex 32)"         >> .env
 
 # 3. Start the stack
 docker compose up -d        # or: uvx podman-compose up -d
@@ -34,11 +36,15 @@ The dashboard works out of the box with public data sources (earthquakes, weathe
 
 ## 🔐 Required Environment Variables
 
-These must be set before `docker compose up -d`, or the relay container will exit on boot.
+These must be set before `docker compose up -d`, or one of the containers will exit on boot.
 
 | Variable | Purpose | How to generate |
 | --- | --- | --- |
 | `RELAY_SHARED_SECRET` | Authenticates every non-public request the dashboard makes to the AIS relay. The relay refuses to start without it. | `openssl rand -hex 32` |
+| `REDIS_PASSWORD` | Redis AUTH password (`--requirepass`). The Redis container refuses to start without it; the REST proxy uses it in its upstream connection string. | `openssl rand -hex 32` |
+| `REDIS_TOKEN` | Bearer token the REST proxy (`redis-rest`) requires on every request, and the value the app sends as `UPSTASH_REDIS_REST_TOKEN`. The proxy and app containers refuse to start without it. | `openssl rand -hex 32` |
+
+> Earlier releases shipped `wm-local-token` as a default for the REST token. That default has been removed (#3804) — the proxy was only reachable from `127.0.0.1:8079` so external exposure required a hostile `docker-compose.override.yml`, but any user who flipped that binding to `0.0.0.0` was instantly authenticated by a publicly documented string. Fresh installs and existing clones both need to set `REDIS_TOKEN` and `REDIS_PASSWORD` in `.env` from this release onward.
 
 > Need to bring the relay up without auth for local debugging? Set `I_UNDERSTAND_THIS_DISABLES_AUTH=true` (the deprecated `ALLOW_UNAUTHENTICATED_RELAY=true` is still accepted). The relay will log a loud `[SECURITY]` warning at boot and every 5 minutes, and every non-public route will be reachable by anyone who can hit the port — **never use this on an internet-reachable host.**
 
@@ -117,11 +123,13 @@ If you prefer to run seeders individually:
 
 ```bash
 export UPSTASH_REDIS_REST_URL=http://localhost:8079
-export UPSTASH_REDIS_REST_TOKEN=wm-local-token
+export UPSTASH_REDIS_REST_TOKEN="${REDIS_TOKEN:?set REDIS_TOKEN in .env first}"
 node scripts/seed-earthquakes.mjs
 node scripts/seed-military-flights.mjs
 # ... etc
 ```
+
+`./scripts/run-seeders.sh` auto-sources `REDIS_TOKEN` from `.env`, so the wrapper is the simpler path. Use the manual form only when iterating on a single seeder.
 
 ## 🏗️ Architecture
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
       - "${WM_PORT:-3000}:8080"
     environment:
       UPSTASH_REDIS_REST_URL: "http://redis-rest:80"
-      UPSTASH_REDIS_REST_TOKEN: "${REDIS_TOKEN:-wm-local-token}"
+      UPSTASH_REDIS_REST_TOKEN: "${REDIS_TOKEN:?REDIS_TOKEN required — generate with: openssl rand -hex 32}"
       LOCAL_API_PORT: "46123"
       LOCAL_API_MODE: "docker"
       LOCAL_API_CLOUD_FALLBACK: "false"
@@ -72,7 +72,14 @@ services:
   redis:
     image: docker.io/redis:7-alpine
     container_name: worldmonitor-redis
-    command: redis-server --maxmemory 256mb --maxmemory-policy allkeys-lru
+    # --requirepass closes off the network so any future sidecar / compromised
+    # dependency added to the worldmonitor network can't read or write cache
+    # entries without the password. Defense-in-depth alongside the REST token.
+    command: >
+      redis-server
+      --requirepass "${REDIS_PASSWORD:?REDIS_PASSWORD required — generate with: openssl rand -hex 32}"
+      --maxmemory 256mb
+      --maxmemory-policy allkeys-lru
     volumes:
       - redis-data:/data
     restart: unless-stopped
@@ -86,8 +93,8 @@ services:
     ports:
       - "127.0.0.1:8079:80"
     environment:
-      SRH_TOKEN: "${REDIS_TOKEN:-wm-local-token}"
-      SRH_CONNECTION_STRING: "redis://redis:6379"
+      SRH_TOKEN: "${REDIS_TOKEN:?REDIS_TOKEN required — generate with: openssl rand -hex 32}"
+      SRH_CONNECTION_STRING: "redis://:${REDIS_PASSWORD}@redis:6379"
     depends_on:
       - redis
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,11 @@ services:
       - "127.0.0.1:8079:80"
     environment:
       SRH_TOKEN: "${REDIS_TOKEN:?REDIS_TOKEN required — generate with: openssl rand -hex 32}"
-      SRH_CONNECTION_STRING: "redis://:${REDIS_PASSWORD}@redis:6379"
+      # Defense-in-depth: the redis service's --requirepass already fails
+      # compose validation if REDIS_PASSWORD is unset, but the explicit
+      # :? here protects against a future PR removing --requirepass or
+      # copying this connection string into a new service.
+      SRH_CONNECTION_STRING: "redis://:${REDIS_PASSWORD:?REDIS_PASSWORD required — generate with: openssl rand -hex 32}@redis:6379"
     depends_on:
       - redis
     restart: unless-stopped

--- a/scripts/run-seeders.sh
+++ b/scripts/run-seeders.sh
@@ -5,12 +5,31 @@
 # Requires the worldmonitor stack to be running (uvx podman-compose up -d).
 # The Redis REST proxy listens on localhost:8079 by default.
 
-UPSTASH_REDIS_REST_URL="${UPSTASH_REDIS_REST_URL:-http://localhost:8079}"
-UPSTASH_REDIS_REST_TOKEN="${UPSTASH_REDIS_REST_TOKEN:-wm-local-token}"
-export UPSTASH_REDIS_REST_URL UPSTASH_REDIS_REST_TOKEN
-
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Load REDIS_TOKEN (and any seeder API keys present) from .env so the
+# host-side seeders can talk to the REST proxy with the same bearer the
+# compose stack is using. Defaults removed in #3804 — the seeders fail-loud
+# if REDIS_TOKEN is not in the environment or .env.
+if [ -f "$PROJECT_DIR/.env" ]; then
+  set -a
+  # shellcheck disable=SC1091
+  . "$PROJECT_DIR/.env"
+  set +a
+fi
+
+UPSTASH_REDIS_REST_URL="${UPSTASH_REDIS_REST_URL:-http://localhost:8079}"
+if [ -z "${UPSTASH_REDIS_REST_TOKEN:-}" ] && [ -n "${REDIS_TOKEN:-}" ]; then
+  UPSTASH_REDIS_REST_TOKEN="$REDIS_TOKEN"
+fi
+if [ -z "${UPSTASH_REDIS_REST_TOKEN:-}" ]; then
+  echo "ERROR: REDIS_TOKEN (or UPSTASH_REDIS_REST_TOKEN) is required." >&2
+  echo "       Generate with: openssl rand -hex 32, then add to .env" >&2
+  echo "       See SELF_HOSTING.md → Required Environment Variables." >&2
+  exit 1
+fi
+export UPSTASH_REDIS_REST_URL UPSTASH_REDIS_REST_TOKEN
 
 # Source API keys from docker-compose.override.yml if present.
 # These keys are configured for the container but seeders run on the host.

--- a/scripts/run-seeders.sh
+++ b/scripts/run-seeders.sh
@@ -20,7 +20,13 @@ if [ -f "$PROJECT_DIR/.env" ]; then
 fi
 
 UPSTASH_REDIS_REST_URL="${UPSTASH_REDIS_REST_URL:-http://localhost:8079}"
-if [ -z "${UPSTASH_REDIS_REST_TOKEN:-}" ] && [ -n "${REDIS_TOKEN:-}" ]; then
+# This script targets the LOCAL Docker REST proxy, so REDIS_TOKEN always
+# wins if set — even when UPSTASH_REDIS_REST_TOKEN also appears in .env
+# (e.g. a contributor who also works on the Vercel/Upstash side and keeps
+# the production token in the same file). Otherwise we'd silently send a
+# Vercel-Upstash bearer to localhost:8079 and the proxy would 401 the
+# request with no hint about why. Reviewer caught this on PR #3829.
+if [ -n "${REDIS_TOKEN:-}" ]; then
   UPSTASH_REDIS_REST_TOKEN="$REDIS_TOKEN"
 fi
 if [ -z "${UPSTASH_REDIS_REST_TOKEN:-}" ]; then

--- a/tests/docker-compose-no-default-secrets.test.mts
+++ b/tests/docker-compose-no-default-secrets.test.mts
@@ -1,0 +1,145 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+
+// Regression coverage for issue #3804: the self-hosted Docker stack must
+// not ship default Redis credentials. Earlier releases defaulted SRH_TOKEN
+// and UPSTASH_REDIS_REST_TOKEN to the publicly documented literal
+// "wm-local-token"; flipping the redis-rest binding from 127.0.0.1 to
+// 0.0.0.0 instantly exposed an authenticated interface with a known token.
+//
+// These tests grep the relevant repo files for forbidden patterns rather
+// than starting containers, because:
+//   - the dangerous shape is a literal default in YAML / shell, which a
+//     literal-absence regex catches deterministically without any harness;
+//   - any future contributor who reintroduces the default in any of the
+//     three files (compose, manual seeder docs, or the wrapper script) is
+//     blocked at CI time, not at deploy time.
+
+const REPO_ROOT = new URL('..', import.meta.url);
+
+async function read(rel: string): Promise<string> {
+  return readFile(new URL(rel, REPO_ROOT), 'utf8');
+}
+
+// Allow a documentation note that EXPLAINS the historical default while
+// scanning for live shipped defaults. The note has the literal in prose
+// (e.g. "shipped `wm-local-token` as a default") rather than as a YAML
+// scalar or shell assignment.
+const WM_LOCAL_TOKEN = /wm-local-token/;
+
+// A shipped default has the literal on the right-hand side of an env
+// assignment, a YAML mapping, or a parameter-expansion default — NOT in
+// a Markdown code-comment, prose paragraph, or backtick-quoted reference.
+const SHIPPED_DEFAULT_PATTERNS: RegExp[] = [
+  // YAML:     SRH_TOKEN: "${REDIS_TOKEN:-wm-local-token}"
+  /:-\s*wm-local-token/,
+  // Shell:    UPSTASH_REDIS_REST_TOKEN="${UPSTASH_REDIS_REST_TOKEN:-wm-local-token}"
+  /=\s*"?\$\{[^}]*:-wm-local-token/,
+  // Bare assignment: UPSTASH_REDIS_REST_TOKEN=wm-local-token (export line)
+  /UPSTASH_REDIS_REST_TOKEN\s*=\s*wm-local-token\b/,
+  // YAML literal value (no parameter expansion): TOKEN: wm-local-token
+  /^\s*(SRH_TOKEN|UPSTASH_REDIS_REST_TOKEN|REDIS_TOKEN)\s*:\s*["']?wm-local-token/m,
+];
+
+describe('docker self-hosting — no default credentials (#3804)', () => {
+  it('docker-compose.yml does not default REDIS_TOKEN or UPSTASH_REDIS_REST_TOKEN to a literal', async () => {
+    const compose = await read('docker-compose.yml');
+    assert.ok(
+      !WM_LOCAL_TOKEN.test(compose),
+      'docker-compose.yml must not contain the literal wm-local-token — see #3804',
+    );
+    // Belt-and-braces: any future "default" of any shape on either token name fails the test.
+    assert.ok(
+      !/\$\{REDIS_TOKEN:-/.test(compose),
+      'docker-compose.yml must not provide a default for ${REDIS_TOKEN}; require fail-closed via ${REDIS_TOKEN:?...}',
+    );
+    assert.ok(
+      !/\$\{REDIS_PASSWORD:-/.test(compose),
+      'docker-compose.yml must not provide a default for ${REDIS_PASSWORD}; require fail-closed via ${REDIS_PASSWORD:?...}',
+    );
+    // The fail-closed assertion: both vars must use the ${VAR:?...} form somewhere in the file.
+    assert.ok(
+      /\$\{REDIS_TOKEN:\?/.test(compose),
+      'docker-compose.yml must require REDIS_TOKEN via ${REDIS_TOKEN:?...} fail-closed syntax',
+    );
+    assert.ok(
+      /\$\{REDIS_PASSWORD:\?/.test(compose),
+      'docker-compose.yml must require REDIS_PASSWORD via ${REDIS_PASSWORD:?...} fail-closed syntax',
+    );
+    // Redis itself must be authenticated.
+    assert.ok(
+      /--requirepass\s+"\$\{REDIS_PASSWORD/.test(compose),
+      'docker-compose.yml redis service must pass --requirepass using REDIS_PASSWORD',
+    );
+  });
+
+  it('SELF_HOSTING.md instructions reference $REDIS_TOKEN, not the literal wm-local-token', async () => {
+    const md = await read('SELF_HOSTING.md');
+    for (const pat of SHIPPED_DEFAULT_PATTERNS) {
+      assert.ok(
+        !pat.test(md),
+        `SELF_HOSTING.md must not show wm-local-token as a default or assigned value (matched ${pat}) — see #3804`,
+      );
+    }
+    // Either both new env vars are explicitly required, or the doc was
+    // restructured to point at .env.example. Accept either, fail closed
+    // on both being absent.
+    const documentsTokens = /REDIS_TOKEN/.test(md) && /REDIS_PASSWORD/.test(md);
+    assert.ok(
+      documentsTokens,
+      'SELF_HOSTING.md must document REDIS_TOKEN and REDIS_PASSWORD as required env vars',
+    );
+  });
+
+  it('scripts/run-seeders.sh does not silently fall back to wm-local-token', async () => {
+    const sh = await read('scripts/run-seeders.sh');
+    for (const pat of SHIPPED_DEFAULT_PATTERNS) {
+      assert.ok(
+        !pat.test(sh),
+        `scripts/run-seeders.sh must not default UPSTASH_REDIS_REST_TOKEN to wm-local-token (matched ${pat}) — see #3804`,
+      );
+    }
+    assert.ok(
+      /REDIS_TOKEN/.test(sh),
+      'scripts/run-seeders.sh must reference REDIS_TOKEN so it picks up the value from .env',
+    );
+  });
+
+  it('.env.example documents REDIS_PASSWORD and REDIS_TOKEN as self-hosted Docker vars', async () => {
+    const env = await read('.env.example');
+    assert.ok(
+      /^REDIS_PASSWORD=/m.test(env),
+      '.env.example must include a REDIS_PASSWORD= line for Docker self-hosting',
+    );
+    assert.ok(
+      /^REDIS_TOKEN=/m.test(env),
+      '.env.example must include a REDIS_TOKEN= line for Docker self-hosting',
+    );
+    assert.ok(
+      !/REDIS_PASSWORD=wm-local-token/.test(env) && !/REDIS_TOKEN=wm-local-token/.test(env),
+      '.env.example must not pre-fill the credentials with a literal value',
+    );
+  });
+
+  it('meta — the SHIPPED_DEFAULT_PATTERNS regexes match the historical bad shapes', () => {
+    const cases: Array<[string, boolean]> = [
+      ['SRH_TOKEN: "${REDIS_TOKEN:-wm-local-token}"', true],
+      ['UPSTASH_REDIS_REST_TOKEN="${UPSTASH_REDIS_REST_TOKEN:-wm-local-token}"', true],
+      ['export UPSTASH_REDIS_REST_TOKEN=wm-local-token', true],
+      ['  SRH_TOKEN: wm-local-token', true],
+      // Negative cases — prose mentions of the literal should NOT match.
+      ['Earlier releases shipped `wm-local-token` as a default.', false],
+      ['// the literal wm-local-token was the dangerous default — see #3804', false],
+      ['SRH_TOKEN: "${REDIS_TOKEN:?REDIS_TOKEN required}"', false],
+    ];
+    for (const [sample, shouldMatch] of cases) {
+      const matched = SHIPPED_DEFAULT_PATTERNS.some((p) => p.test(sample));
+      assert.equal(
+        matched,
+        shouldMatch,
+        `pattern coverage broke for input: ${JSON.stringify(sample)} (expected match=${shouldMatch}, got ${matched})`,
+      );
+    }
+  });
+});

--- a/tests/docker-compose-no-default-secrets.test.mts
+++ b/tests/docker-compose-no-default-secrets.test.mts
@@ -58,7 +58,24 @@ describe('docker self-hosting — no default credentials (#3804)', () => {
       !/\$\{REDIS_PASSWORD:-/.test(compose),
       'docker-compose.yml must not provide a default for ${REDIS_PASSWORD}; require fail-closed via ${REDIS_PASSWORD:?...}',
     );
-    // The fail-closed assertion: both vars must use the ${VAR:?...} form somewhere in the file.
+    // The fail-closed assertion: EVERY expansion of either var must use
+    // the ${VAR:?...} form. A bare ${VAR} silently expands to empty if
+    // the upstream guard ever moves or gets deleted (PR #3829 reviewer
+    // P2 — SRH_CONNECTION_STRING used a bare ${REDIS_PASSWORD} before fix).
+    const bareTokenExpansions = compose.match(/\$\{REDIS_TOKEN(?![:?])/g) ?? [];
+    assert.equal(
+      bareTokenExpansions.length,
+      0,
+      `docker-compose.yml must use \${REDIS_TOKEN:?...} at every expansion (found ${bareTokenExpansions.length} bare \${REDIS_TOKEN})`,
+    );
+    const barePasswordExpansions = compose.match(/\$\{REDIS_PASSWORD(?![:?])/g) ?? [];
+    assert.equal(
+      barePasswordExpansions.length,
+      0,
+      `docker-compose.yml must use \${REDIS_PASSWORD:?...} at every expansion (found ${barePasswordExpansions.length} bare \${REDIS_PASSWORD})`,
+    );
+    // Both vars must appear in at least one fail-closed expansion (i.e. the
+    // file actually requires them somewhere, not just by total absence).
     assert.ok(
       /\$\{REDIS_TOKEN:\?/.test(compose),
       'docker-compose.yml must require REDIS_TOKEN via ${REDIS_TOKEN:?...} fail-closed syntax',
@@ -103,6 +120,20 @@ describe('docker self-hosting — no default credentials (#3804)', () => {
     assert.ok(
       /REDIS_TOKEN/.test(sh),
       'scripts/run-seeders.sh must reference REDIS_TOKEN so it picks up the value from .env',
+    );
+    // Precedence guard for PR #3829 reviewer P1: a developer with BOTH
+    // tokens in .env (Vercel/Upstash token + local Docker proxy token)
+    // would otherwise have UPSTASH_REDIS_REST_TOKEN populated from .env
+    // and the script would silently pass the Vercel bearer to
+    // localhost:8079 → 401 with no hint. Inversion: REDIS_TOKEN wins
+    // unconditionally if set, then fall back to UPSTASH_REDIS_REST_TOKEN.
+    assert.ok(
+      !/if \[ -z "\$\{UPSTASH_REDIS_REST_TOKEN[^}]*}" \] && \[ -n "\$\{REDIS_TOKEN/.test(sh),
+      'scripts/run-seeders.sh must not gate REDIS_TOKEN copy on UPSTASH_REDIS_REST_TOKEN being absent (PR #3829 P1)',
+    );
+    assert.ok(
+      /if \[ -n "\$\{REDIS_TOKEN[^}]*}" \]/.test(sh),
+      'scripts/run-seeders.sh must unconditionally prefer REDIS_TOKEN when set (PR #3829 P1)',
     );
   });
 


### PR DESCRIPTION
## Summary

Closes #3804.

Self-hosted Docker stack shipped two interlocking security defaults that made the deployment one hostile `docker-compose.override.yml` away from "publicly authenticated by a known string":

1. **Redis ran without `--requirepass`** — any container added to the `worldmonitor` docker network could read/write all cache entries (session tokens, rate-limit counters, AIS snapshots) without credentials. The `redis-rest` REST proxy held the only credential gate.
2. **`SRH_TOKEN` and `UPSTASH_REDIS_REST_TOKEN` both defaulted to `wm-local-token`** — `${REDIS_TOKEN:-wm-local-token}`. `SELF_HOSTING.md:120` and `scripts/run-seeders.sh:9` *reinforced* the default with copy-pasteable snippets. A fresh clone that flipped the `redis-rest` binding from `127.0.0.1:8079:80` to `0.0.0.0:8079:80` (one-line override) instantly exposed an authenticated REST interface authenticated by a token anyone reading the docs already knew.

Today's `127.0.0.1` binding contains external exposure, but the threat model is brittle — and the docs were actively encouraging the brittle path.

## Changes

- **`docker-compose.yml`** — `${VAR:?...}` fail-closed expansion for `REDIS_PASSWORD` and `REDIS_TOKEN` on every service that touches them. Affected containers refuse to start with a helpful error pointing at `openssl rand -hex 32`. Redis gains `--requirepass "${REDIS_PASSWORD:?...}"`; `redis-rest` plumbs the password into `SRH_CONNECTION_STRING` (`redis://:${REDIS_PASSWORD}@redis:6379`) so it still reaches Redis.
- **`.env.example`** — new "Self-hosted Redis (Docker Compose only)" section documenting both vars + how to generate, distinguishing them from the Vercel-Upstash hosted block above.
- **`SELF_HOSTING.md`** — quick-start now generates all three secrets in step 2; required-env table covers all three with a migration note for existing clones; manual-seeder snippet uses `${REDIS_TOKEN:?...}` instead of the literal.
- **`scripts/run-seeders.sh`** — auto-sources `REDIS_TOKEN` from `.env`, fail-loud if neither `REDIS_TOKEN` nor `UPSTASH_REDIS_REST_TOKEN` is set instead of silently using `wm-local-token`.

## Regression test

`tests/docker-compose-no-default-secrets.test.mts` — literal-absence + structural-presence source-greps over all four files, following the static-grep recipe from PR #3778 (CORS fail-closed). The `SHIPPED_DEFAULT_PATTERNS` regex set is paired with a meta-test exercising 7 representative inputs (4 historical bad shapes + 3 acceptable shapes including prose mentions of the literal in a deprecation note) so a future "simplification" of the pattern can't silently drop coverage.

**Reverse-check performed:** temporarily reintroducing the bad default in `docker-compose.yml` fails the matching test with the `#3804` reference; restoring the fix turns it green again.

## Test plan

- [x] `npx tsx --test tests/docker-compose-no-default-secrets.test.mts` → 5/5 pass locally
- [x] Reverse-test confirms each assertion fires when its bad default is reintroduced
- [x] Pre-push hook (full test suite + version:check) passed
- [ ] Existing self-hosters need a one-time `.env` update — release notes should call this out

## Out of scope

- Doesn't touch the Vercel Upstash credential path (`UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN` sourced from Upstash itself, unaffected by this change)
- Docker secrets (`secrets:` block) remains the documented escalation path for production deployments that don't want creds in `docker inspect`