### PR TITLE
fix(brief): make magazine pages internally scrollable when content exceeds 100vh

### DIFF
--- a/server/_shared/brief-render.js
+++ b/server/_shared/brief-render.js
@@ -759,7 +759,22 @@ const STYLE_BLOCK = `<style>
   .page {
     flex: 0 0 100vw; width: 100vw; height: 100vh;
     padding: 6vh 6vw 10vh;
-    position: relative; overflow: hidden;
+    /* overflow-y: auto so pages whose content exceeds 100vh become
+       internally scrollable instead of silently clipping (user-reported
+       on desktop where vw-scaled body copy can be ~10-20% taller than
+       viewport; iPhone Pro Max responsive mode "worked" because narrow
+       viewport scaled the vw text down until it fit). overflow-x stays
+       hidden so the deck-level horizontal carousel isn't fought by a
+       per-page horizontal scrollbar. Pair with the wheel handler in
+       NAV_SCRIPT which now defers to native scroll when the current
+       page has remaining scroll in the wheel direction. */
+    position: relative; overflow-x: hidden; overflow-y: auto;
+    /* Smooth out the deck-level transform vs in-page scroll interaction
+       on touch + trackpad: contain scroll within the page so a fast
+       trackpad flick doesn't bubble to the body (body has overflow:hidden
+       anyway, but overscroll-behavior also disables the iOS rubber-band
+       effect that visually fights the deck transform). */
+    overscroll-behavior: contain;
     display: flex; flex-direction: column;
   }
   .mono {
@@ -1189,15 +1204,50 @@ const NAV_SCRIPT = `<script>
   function next() { go(current + 1); }
   function prev() { go(current - 1); }
   window.addEventListener('keydown', function(e) {
-    if (e.key === 'ArrowRight' || e.key === 'PageDown' || e.key === ' ') { e.preventDefault(); next(); }
-    else if (e.key === 'ArrowLeft' || e.key === 'PageUp') { e.preventDefault(); prev(); }
+    // ArrowRight/Left are the deck axis — always paginate, no scroll
+    // conflict. PageDown/PageUp/Space conventionally scroll a long page
+    // in normal browsers; defer to native page scroll when the current
+    // page has remaining scroll in that direction, paginate only at the
+    // scroll edge. Matches the wheel-handler behaviour so keyboard and
+    // mouse users see the same model.
+    if (e.key === 'ArrowRight') { e.preventDefault(); next(); }
+    else if (e.key === 'ArrowLeft') { e.preventDefault(); prev(); }
+    else if (e.key === 'PageDown' || e.key === ' ') {
+      if (pageCanScrollVertical(pages[current], 1)) return;
+      e.preventDefault(); next();
+    } else if (e.key === 'PageUp') {
+      if (pageCanScrollVertical(pages[current], -1)) return;
+      e.preventDefault(); prev();
+    }
     else if (e.key === 'Home') { e.preventDefault(); go(0); }
     else if (e.key === 'End') { e.preventDefault(); go(total - 1); }
   });
+  // Wheel handler defers to per-page native scroll first. The page CSS
+  // is overflow-y: auto, so content longer than 100vh scrolls inside the
+  // page. Only advance/retreat the deck when the user is wheeling
+  // PAST the scroll edge in that direction — otherwise a long page is
+  // unreachable past 100vh because every wheel tick paginates instead
+  // of scrolling (user-reported: "if I try to scroll down to read it,
+  // it just goes to the next page instead"). Vertical wheel falls
+  // through to the page; horizontal wheel still paginates immediately
+  // (the deck axis IS horizontal, no scroll conflict to resolve).
+  function pageCanScrollVertical(page, deltaY) {
+    if (!page) return false;
+    var maxScroll = page.scrollHeight - page.clientHeight;
+    if (maxScroll <= 0) return false;   // page content fits — paginate
+    if (deltaY > 0) return page.scrollTop < maxScroll - 1;   // room to scroll down
+    if (deltaY < 0) return page.scrollTop > 1;               // room to scroll up
+    return false;
+  }
   window.addEventListener('wheel', function(e) {
     if (wheelLock) return;
-    var delta = Math.abs(e.deltaY) > Math.abs(e.deltaX) ? e.deltaY : e.deltaX;
+    var isVertical = Math.abs(e.deltaY) > Math.abs(e.deltaX);
+    var delta = isVertical ? e.deltaY : e.deltaX;
     if (Math.abs(delta) < 12) return;
+    if (isVertical && pageCanScrollVertical(pages[current], e.deltaY)) {
+      // Let the native scroll on .page take this wheel event.
+      return;
+    }
     wheelLock = true;
     if (delta > 0) next(); else prev();
     setTimeout(function() { wheelLock = false; }, 620);

--- a/tests/brief-magazine-render.test.mjs
+++ b/tests/brief-magazine-render.test.mjs
@@ -1143,3 +1143,96 @@ describe('cover greeting ↔ digest.greeting parity', () => {
     assert.ok(cover.includes('&lt;script&gt;'));
   });
 });
+
+
+describe('renderBriefMagazine — page-overflow / scroll-vs-paginate contract', () => {
+  // User-reported on a Pro subscription (2026-05-19): "the text is outside
+  // of the window and I have to zoom the page out to read it ... if I try
+  // to scroll down to read it, it just goes to the next page instead. The
+  // only way I found that works is to enable Responsive Design Mode and
+  // change the preset to iPhone Pro Max." Three compounding bugs in the
+  // pre-fix renderer:
+  //   1. .page CSS was `overflow: hidden` with `height: 100vh` — long
+  //      content was silently clipped.
+  //   2. Fonts size via vw units, so wide desktop viewports scale text UP
+  //      and trigger overflow more often than narrow ones (iPhone Pro Max
+  //      responsive mode "worked" by shrinking everything proportionally).
+  //   3. The global wheel handler paginated on every wheel tick, regardless
+  //      of whether the current page could still scroll — so a long page
+  //      was unreachable past the first 100vh.
+  // These tests pin the fix shape so a future "simplification" can't
+  // silently reintroduce any of the three.
+
+  // Extract the top-level `.page { ... }` rule body and strip CSS
+  // `/* ... */` comments. Necessary because the production CSS carries a
+  // multi-line comment explaining WHY overflow changed shape — a naive
+  // regex against the raw HTML matches the comment text (e.g. "body has
+  // overflow:hidden anyway") and fires false-positives. The body is what
+  // the browser actually applies, so that's what we assert against.
+  function getPageRuleBlock(html) {
+    const m = html.match(/\.page\s*\{((?:[^{}]|\{[^}]*\})*?)\}/);
+    assert.ok(m, '.page rule block not found in rendered CSS');
+    return m[1].replace(/\/\*[\s\S]*?\*\//g, '');
+  }
+
+  it('.page CSS allows internal vertical scroll (overflow-y: auto)', () => {
+    const env = envelope();
+    const body = getPageRuleBlock(renderBriefMagazine(env));
+    assert.match(
+      body,
+      /\boverflow-y\s*:\s*auto\b/,
+      '.page must set overflow-y: auto so long content is reachable instead of clipped',
+    );
+    // The killer regression: shorthand `overflow: hidden` would re-clip
+    // everything. Require declaration form (terminated by `;` or end of
+    // block) so the assertion can't be defeated by a property name like
+    // `overflow-x`.
+    assert.doesNotMatch(
+      body,
+      /\boverflow\s*:\s*hidden\s*[;}]/,
+      '.page must NOT use the shorthand `overflow: hidden` — that re-enables the clipping bug',
+    );
+  });
+
+  it('.page keeps overflow-x: hidden so the horizontal deck carousel is not fought by per-page scrollbars', () => {
+    const env = envelope();
+    const body = getPageRuleBlock(renderBriefMagazine(env));
+    assert.match(body, /\boverflow-x\s*:\s*hidden\b/);
+  });
+
+  it('NAV_SCRIPT wheel handler defers to native page scroll when the page can still scroll in that direction', () => {
+    const env = envelope();
+    const html = renderBriefMagazine(env);
+    // The function name itself is the contract — if a future refactor
+    // renames or removes it, this test fails with a clear message.
+    assert.match(
+      html,
+      /function\s+pageCanScrollVertical\s*\(/,
+      'NAV_SCRIPT must expose a pageCanScrollVertical predicate the wheel handler can call to defer to native scroll',
+    );
+    // Wheel handler must consult the predicate before paginating.
+    assert.match(
+      html,
+      /pageCanScrollVertical\s*\(\s*pages\s*\[\s*current\s*\]/,
+      'wheel handler must check pageCanScrollVertical on the current page before paginating, or long pages stay unreachable',
+    );
+  });
+
+  it('NAV_SCRIPT keyboard handler routes PageDown/PageUp/Space through the scroll-then-paginate predicate', () => {
+    const env = envelope();
+    const html = renderBriefMagazine(env);
+    // Spec match: the predicate must appear inside the keydown branches
+    // for PageDown and PageUp (Space is included in the PageDown branch).
+    // Looser regex than a structural parse, but tight enough that the
+    // predicate-less original code would fail.
+    const pageDownBranch = /PageDown[^}]+pageCanScrollVertical/;
+    const pageUpBranch = /PageUp[^}]+pageCanScrollVertical/;
+    assert.match(html, pageDownBranch, 'PageDown/Space must defer to native scroll before paginating');
+    assert.match(html, pageUpBranch, 'PageUp must defer to native scroll before paginating');
+    // ArrowRight/Left are the deck axis (no scroll conflict) and should
+    // still paginate immediately — guard against a future "fix" that
+    // routes them through the predicate too and breaks deck navigation.
+    assert.doesNotMatch(html, /ArrowRight[^}]+pageCanScrollVertical/);
+    assert.doesNotMatch(html, /ArrowLeft[^}]+pageCanScrollVertical/);
+  });
+});


### PR DESCRIPTION
## User report (Pro subscriber, desktop, both Safari and Chrome)

> "I have the pro subscription, and for some reason when I go to open my daily briefing, the text is outside of the window and I have to zoom the page out to read it, and if there's a significant amount of text, I can't even zoom out enough to read it all. If I try to scroll down to read it, it just goes to the next page instead. I tried resetting window size to 100%, still the same issue. I've also tried on Google Chrome with the same issue. The only way I found that works ... is to enable Responsive Design Mode in Safari and change the preset to iPhone Pro Max."

## Root cause — three compounding bugs in `server/_shared/brief-render.js`

1. **`.page` is fixed-height with clipped overflow** (lines 760-763):
   \`\`\`css
   .page { flex: 0 0 100vw; width: 100vw; height: 100vh; overflow: hidden; ... }
   \`\`\`
   Content longer than the viewport is silently clipped with no in-page scrollbar.

2. **Fonts size in `vw` units.** Body copy is `max(18px, 1.7vw)` desktop, `4.6vw` in the mobile @media block. On a wide desktop monitor, `1.7vw` is bigger than on a narrow viewport, so wider monitors hit overflow MORE OFTEN, not less. iPhone Pro Max responsive mode \"worked\" because shrinking the viewport scaled the vw text down until content fit.

3. **A global wheel handler paginates instead of scrolling** (lines 1197-1204):
   \`\`\`js
   window.addEventListener('wheel', function(e) {
     if (wheelLock) return;
     var delta = …;
     if (Math.abs(delta) < 12) return;
     wheelLock = true;
     if (delta > 0) next(); else prev();
     setTimeout(…, 620);
   });
   \`\`\`
   No check for whether the current page can still scroll. Any long page is unreachable past the first 100vh: every wheel tick paginates instead of scrolling.

## Fix

**CSS** — `.page` now allows internal vertical scroll:
\`\`\`css
.page {
  flex: 0 0 100vw; width: 100vw; height: 100vh;
  padding: 6vh 6vw 10vh;
  position: relative;
  overflow-x: hidden; overflow-y: auto;   /* was: overflow: hidden */
  overscroll-behavior: contain;            /* don't bubble flicks to body */
  display: flex; flex-direction: column;
}
\`\`\`
Horizontal stays hidden so the deck-level carousel isn't fought by per-page horizontal scrollbars. `overscroll-behavior: contain` keeps a trackpad flick from bubbling to the body (which is `overflow: hidden`) or triggering iOS rubber-band against the deck transform.

**Wheel handler** — new `pageCanScrollVertical(page, deltaY)` predicate returns true when the current page has remaining scroll in the wheel direction (top-of-page going up, bottom-of-page going down). Handler defers to native scroll when the predicate is true; only paginates at the scroll edge. Horizontal wheel still paginates immediately (deck IS horizontal — no scroll conflict).

**Keyboard handler** — `PageDown`/`PageUp`/`Space` route through the same predicate so keyboard and mouse users see the same model. `ArrowRight`/`ArrowLeft` stay as immediate paginate (deck axis, no conflict).

## Test plan

- [x] 4 new regression tests in `tests/brief-magazine-render.test.mjs`:
  - `.page` CSS has `overflow-y: auto` and does NOT use the `overflow: hidden` shorthand
  - `.page` keeps `overflow-x: hidden`
  - `NAV_SCRIPT` exposes `pageCanScrollVertical` and the wheel handler calls it
  - Keyboard handler routes `PageDown`/`PageUp`/`Space` through the predicate but NOT `ArrowRight`/`ArrowLeft`
- [x] All 90 tests pass (`npx tsx --test tests/brief-magazine-render.test.mjs`)
- [x] `npm run typecheck` clean
- [x] `biome lint` clean on changed files
- [ ] After deploy: verify on a desktop browser at 1080p+ that a long brief is fully readable without zooming and that mouse-wheel scrolls page content before paginating to the next page

## Notes on what's NOT in this PR

- The font-size-in-vw choice is preserved — capping `vw` sizes with `min(...)` would reduce overflow frequency on ultra-wide monitors but isn't the structural fix. Could land as a polish follow-up if reports persist after this.
- Initial scrollTop is NOT reset when pages change. Browsers preserve scroll position on elements as the deck transforms past them; revisiting a page resumes where you left off (matches typical SPA scroll behavior).