### PR TITLE
fix(sentry-noise): suppress img-src CSP on own host + Safari module-loader EOF

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -541,6 +541,18 @@ Sentry.init({
         // handled above by `isHostScopedFetchFailure` which does its own
         // first-party-host allowlist (WORLDMONITOR-KM).
         || /^(?:TypeError: )?Failed to fetch$/.test(msg)
+        // Safari module-loader abort / streaming-fetch interruption: iOS
+        // Safari emits `SyntaxError: Unexpected EOF` with zero captured
+        // frames via `onunhandledrejection` when a dynamic `import()` or
+        // service-worker-mediated fetch is truncated mid-stream (PWA
+        // lifecycle transitions, background-tab termination, network blip
+        // during app boot). Our own `JSON.parse` calls produce
+        // engine-specific phrasings — V8: `Unexpected end of JSON input`;
+        // Safari: `JSON Parse error: Unexpected EOF` (with prefix) — so
+        // bare `Unexpected EOF` is engine-emitted only. Same `!hasFirstParty`
+        // safety as the `Failed to fetch` / `signal timed out` blocks above
+        // (WORLDMONITOR-RF).
+        || /^(?:SyntaxError: )?Unexpected EOF$/.test(msg)
       )
     ) return null;
     if (hasAnyStack && !hasFirstParty && (
@@ -601,6 +613,21 @@ function shouldSuppressCspViolation(
   if (directive === 'connect-src' && firstPartyConvexHost) {
     try {
       if (new URL(blockedURI).hostname === firstPartyConvexHost) return true;
+    } catch { /* scheme-only values fall through */ }
+  }
+  // First-party img-src block on OUR registrable domain: same pattern as the Convex
+  // connect-src case above. Corporate proxies / privacy extensions (Zscaler, Symantec
+  // CloudSOC, school content-filters) can strip both `'self'` and `https:` from img-src
+  // in the user's effective policy, causing our own favicon and panel icons to be
+  // CSP-blocked even though our policy (`img-src 'self' data: blob: https:`) allows
+  // them. Scope to `worldmonitor.app` and its subdomains — img-src blocks to foreign
+  // hosts (a third-party CDN we never load, attacker-controlled host) still surface
+  // (WORLDMONITOR-JP). Suffix check uses a leading `.` so lookalikes like
+  // `worldmonitor.app.evil.com` do NOT match.
+  if (directive === 'img-src') {
+    try {
+      const host = new URL(blockedURI).hostname;
+      if (host === 'worldmonitor.app' || host.endsWith('.worldmonitor.app')) return true;
     } catch { /* scheme-only values fall through */ }
   }
   // YouTube IFrame API loader: explicitly allowed by our script-src

--- a/src/main.ts
+++ b/src/main.ts
@@ -624,10 +624,17 @@ function shouldSuppressCspViolation(
   // hosts (a third-party CDN we never load, attacker-controlled host) still surface
   // (WORLDMONITOR-JP). Suffix check uses a leading `.` so lookalikes like
   // `worldmonitor.app.evil.com` do NOT match.
+  //
+  // REQUIRE https: protocol — our CSP only allows https: for img-src, so a real
+  // mixed-content regression (`<img src="http://worldmonitor.app/...">`) would be
+  // blocked by the browser. Suppressing http: blocks on first-party hosts would mask
+  // that regression in Sentry. The `cspConnectSrcAllowsHttps` block above uses the
+  // same protocol gate for connect-src.
   if (directive === 'img-src') {
     try {
-      const host = new URL(blockedURI).hostname;
-      if (host === 'worldmonitor.app' || host.endsWith('.worldmonitor.app')) return true;
+      const url = new URL(blockedURI);
+      if (url.protocol === 'https:'
+          && (url.hostname === 'worldmonitor.app' || url.hostname.endsWith('.worldmonitor.app'))) return true;
     } catch { /* scheme-only values fall through */ }
   }
   // YouTube IFrame API loader: explicitly allowed by our script-src

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -254,6 +254,54 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
     it('does NOT suppress connect-src to Zscaler (only frame-src is the injection)', () => {
       assert.ok(!suppress('enforce', 'connect-src', 'https://gateway.zscloud.net/api', '', false, FIRST_PARTY_CONVEX));
     });
+
+    // First-party img-src suppression — same pattern as connect-src+Convex above.
+    // Corporate proxies / privacy extensions / school content-filters can strip
+    // both `'self'` and `https:` from img-src in the user's effective policy,
+    // causing browsers to block our own favicon and panel icons even though our
+    // policy (`img-src 'self' data: blob: https:`) allows them (WORLDMONITOR-JP).
+    it('suppresses img-src to apex worldmonitor.app (favicon)', () => {
+      assert.ok(suppress('enforce', 'img-src', 'https://worldmonitor.app/favico/favicon-32x32.png', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('suppresses img-src to www.worldmonitor.app (production favicon, WORLDMONITOR-JP)', () => {
+      assert.ok(suppress('enforce', 'img-src', 'https://www.worldmonitor.app/favico/favicon-32x32.png', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('suppresses img-src to finance.worldmonitor.app subdomain', () => {
+      assert.ok(suppress('enforce', 'img-src', 'https://finance.worldmonitor.app/favico/finance/apple-touch-icon.png', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('suppresses img-src to tech.worldmonitor.app subdomain', () => {
+      assert.ok(suppress('enforce', 'img-src', 'https://tech.worldmonitor.app/favico/tech/favicon-32x32.png', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('does NOT suppress img-src to a foreign host', () => {
+      // Real third-party CDN image blocks should still surface.
+      assert.ok(!suppress('enforce', 'img-src', 'https://malicious.example.com/tracker.gif', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('does NOT suppress img-src to suffix-spoof lookalike `worldmonitor.app.evil.com`', () => {
+      // Endswith check uses a leading `.` so attacker-controlled lookalikes
+      // (`worldmonitor.app.evil.com`, `not-worldmonitor.app`) are not whitelisted.
+      assert.ok(!suppress('enforce', 'img-src', 'https://worldmonitor.app.evil.com/pixel.gif', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('does NOT suppress img-src to prefix-spoof `not-worldmonitor.app`', () => {
+      assert.ok(!suppress('enforce', 'img-src', 'https://not-worldmonitor.app/pixel.gif', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('does NOT suppress connect-src to worldmonitor.app (rule is scoped to img-src)', () => {
+      // First-party img-src rule must not bleed into other directives.
+      // A real connect-src regression to our own host must still surface.
+      assert.ok(!suppress('enforce', 'connect-src', 'https://api.worldmonitor.app/api/health', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('does NOT suppress script-src to worldmonitor.app (rule is scoped to img-src)', () => {
+      // A script-src block on our own host indicates a real CSP regression
+      // we want to see — must not be swallowed by the img-src rule.
+      assert.ok(!suppress('enforce', 'script-src', 'https://www.worldmonitor.app/assets/main-abc.js', '', false, FIRST_PARTY_CONVEX));
+    });
   });
 
   describe('real violations pass through', () => {

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -302,6 +302,24 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       // we want to see — must not be swallowed by the img-src rule.
       assert.ok(!suppress('enforce', 'script-src', 'https://www.worldmonitor.app/assets/main-abc.js', '', false, FIRST_PARTY_CONVEX));
     });
+
+    // Mixed-content / wrong-scheme regression guard. Our CSP only allows `https:`
+    // for img-src, so a future `<img src="http://...">` regression on a
+    // first-party host would be blocked by the browser. The first-party host
+    // suppression MUST NOT hide that signal — it requires `https:` explicitly.
+    it('does NOT suppress http:// img-src to our own apex (mixed-content regression must surface)', () => {
+      assert.ok(!suppress('enforce', 'img-src', 'http://worldmonitor.app/favico/favicon-32x32.png', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('does NOT suppress http:// img-src to a worldmonitor.app subdomain', () => {
+      assert.ok(!suppress('enforce', 'img-src', 'http://www.worldmonitor.app/favico/favicon-32x32.png', '', false, FIRST_PARTY_CONVEX));
+    });
+
+    it('does NOT suppress ws:// img-src to a worldmonitor.app subdomain (only https: is whitelisted)', () => {
+      // ws:// is not a valid img source but a malformed reference could trigger
+      // a violation; protocol gate must reject anything other than https:.
+      assert.ok(!suppress('enforce', 'img-src', 'ws://www.worldmonitor.app/socket', '', false, FIRST_PARTY_CONVEX));
+    });
   });
 
   describe('real violations pass through', () => {

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -267,6 +267,16 @@ describe('zero-frame async-rejection patterns (timeout / DOMException / OOM / DO
     // through this gate.
     ['Failed to fetch', 'TypeError'],
     ['TypeError: Failed to fetch', 'TypeError'],
+    // Safari module-loader abort / streaming-fetch interruption
+    // (WORLDMONITOR-RF). iOS Safari fires `SyntaxError: Unexpected EOF`
+    // via `onunhandledrejection` with no captured frames when a dynamic
+    // `import()` or service-worker-mediated fetch is truncated mid-stream
+    // during PWA lifecycle transitions. Our own `JSON.parse` produces
+    // engine-prefixed phrasings (V8: `Unexpected end of JSON input`;
+    // Safari: `JSON Parse error: Unexpected EOF`) — bare `Unexpected EOF`
+    // is engine-emitted only.
+    ['Unexpected EOF', 'SyntaxError'],
+    ['SyntaxError: Unexpected EOF', 'SyntaxError'],
   ];
 
   for (const [msg, type] of zeroFrameErrors) {


### PR DESCRIPTION
## Summary

Two zero-signal Sentry issues from this triage pass — both noise from third-party / browser-engine infrastructure interfering with our own resources.

### WORLDMONITOR-JP — `CSP: img-src blocked https://www.worldmonitor.app/favico/favicon-32x32.png` (13 events / 5 users)

Our CSP allows `img-src 'self' data: blob: https:`. The only way our own favicon's CSP-blocked on its own origin is a corporate proxy or privacy extension (Zscaler, Symantec CloudSOC, school content-filters) stripping both `'self'` AND `https:` from img-src in the user's effective policy. **Same pattern as the existing first-party Convex `connect-src` suppression (WORLDMONITOR-HN).**

Fix: extend `shouldSuppressCspViolation` with an img-src-scoped first-party host rule, gated to the `worldmonitor.app` registrable domain. Apex equality + leading-dot suffix (`'.worldmonitor.app'`) rejects lookalikes (`worldmonitor.app.evil.com`, `not-worldmonitor.app`) and foreign hosts; directive-scoped to `img-src` only so connect-src / script-src regressions on our own host still surface.

### WORLDMONITOR-RF — `SyntaxError: Unexpected EOF` (1 event / 1 user, Mobile Safari 26.0.1)

Fired via `onunhandledrejection` with **zero captured frames**. iOS Safari emits this when a dynamic `import()` or service-worker-mediated fetch is truncated mid-stream during PWA lifecycle transitions (background-tab termination, network blip during boot). Engine-emitted only — our own JSON.parse calls produce engine-prefixed phrasings (V8: `Unexpected end of JSON input`; Safari: `JSON Parse error: Unexpected EOF`), never bare `Unexpected EOF`.

Fix: add to the existing zero-frame `!hasFirstParty` block in `beforeSend` — same gate as `Failed to fetch` / `signal timed out` / `out of memory`.

## Safety analysis

- **CSP img-src rule** — directive-scoped + apex+suffix host match. 9 dedicated tests cover apex, www, subdomains (finance/tech), foreign hosts, suffix-spoof, prefix-spoof, and directive-scoping (rule must not bleed into connect-src/script-src). Real CSP regressions on our own host's `script-src`/`connect-src` still surface; tests assert this.
- **`Unexpected EOF` rule** — anchored regex with optional `SyntaxError:` prefix, gated by `!hasFirstParty`. Any genuine first-party JSON.parse error with a source-mapped frame on the awaiting site still surfaces. Three auto-generated test assertions per message (empty stack → suppressed, third-party stack → suppressed, first-party stack → NOT suppressed).

Both Sentry issues marked resolved server-side with `inNextRelease: true` — auto-reopen if recurrence after deploy.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean (Convex audit PASS)
- [x] CJS syntax check — all `scripts/*.cjs` valid
- [x] `npm run lint` — exit 0
- [x] `npm run test:data` — 9330/9335 (5 flake-timeouts in `tests/brief-carousel.test.mjs` confirmed network-flake by isolated re-run: 19/19 PASS in 776 ms)
- [x] All API edge functions bundle clean via esbuild
- [x] `node --test tests/edge-functions.test.mjs` — 183/183
- [x] `npm run lint:md` — 0 errors
- [x] `npm run version:check` — synced (2.8.0)
- [x] Targeted: `node --test tests/csp-filter.test.mjs tests/sentry-beforesend.test.mjs` — 207/207 PASS