### PR TITLE
fix(map+panels): swallow deck.gl render race + viewport-gate tech-readiness refresh

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -593,7 +593,13 @@ export class DataLoaderManager implements AppModule {
       tasks.push({ name: 'radiation', task: runGuarded('radiation', () => this.loadRadiationWatch()) });
     }
 
-    if (SITE_VARIANT !== 'happy') {
+    // App.ts:576-583 merges ALL_PANELS into panelSettings on every variant for
+    // cross-variant pref carryover, so shouldCreatePanel('tech-readiness') is true
+    // even on energy/finance/commodity where the bootstrap doesn't seed the key —
+    // and the panel's 5s fetch (services/economic/index.ts:694) then times out.
+    // Gate on shouldLoad() so refresh only fires when the panel is actually near
+    // the viewport (same pattern as thermal-escalation below).
+    if (SITE_VARIANT !== 'happy' && shouldLoad('tech-readiness')) {
       tasks.push({ name: 'techReadiness', task: runGuarded('techReadiness', () => (this.ctx.panels['tech-readiness'] as TechReadinessPanel)?.refresh()) });
     }
     if (SITE_VARIANT !== 'happy' && shouldLoad('thermal-escalation')) {

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -13,6 +13,7 @@ import {
   MARKET_SYMBOLS,
   SITE_VARIANT,
   LAYER_TO_SOURCE,
+  isPanelInVariantDefaults,
 } from '@/config';
 import { resolveNewsCategories, enabledNewsCategoryKeys } from '@/config/feed-resolution';
 import { INTEL_HOTSPOTS, CONFLICT_ZONES } from '@/config/geo';
@@ -593,13 +594,13 @@ export class DataLoaderManager implements AppModule {
       tasks.push({ name: 'radiation', task: runGuarded('radiation', () => this.loadRadiationWatch()) });
     }
 
-    // App.ts:576-583 merges ALL_PANELS into panelSettings on every variant for
-    // cross-variant pref carryover, so shouldCreatePanel('tech-readiness') is true
-    // even on energy/finance/commodity where the bootstrap doesn't seed the key —
-    // and the panel's 5s fetch (services/economic/index.ts:694) then times out.
-    // Gate on shouldLoad() so refresh only fires when the panel is actually near
-    // the viewport (same pattern as thermal-escalation below).
-    if (SITE_VARIANT !== 'happy' && shouldLoad('tech-readiness')) {
+    // tech-readiness is only seeded on full + tech variants (api/bootstrap.js +
+    // scripts/seed-wb-indicators.mjs); on commodity/finance/energy the 5s fetch
+    // at services/economic/index.ts:694 just times out. shouldLoad() alone is
+    // not enough — loadAllData(true) on boot (App.ts:1226) bypasses the viewport
+    // check via forceAll. Gate on variant defaults so this only fires where the
+    // seed actually exists.
+    if (isPanelInVariantDefaults('tech-readiness') && shouldLoad('tech-readiness')) {
       tasks.push({ name: 'techReadiness', task: runGuarded('techReadiness', () => (this.ctx.panels['tech-readiness'] as TechReadinessPanel)?.refresh()) });
     }
     if (SITE_VARIANT !== 'happy' && shouldLoad('thermal-escalation')) {

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -97,6 +97,7 @@ import {
   SITE_VARIANT,
   ALL_PANELS,
   VARIANT_DEFAULTS,
+  isPanelInVariantDefaults,
 } from '@/config';
 import { resolveNewsCategories, enabledNewsCategoryKeys } from '@/config/feed-resolution';
 import { BETA_MODE } from '@/config/beta';
@@ -1278,7 +1279,14 @@ export class PanelLayoutManager implements AppModule {
     this.lazyPanel('tech-readiness', () =>
       import('@/components/TechReadinessPanel').then(m => {
         const p = new m.TechReadinessPanel();
-        void p.refresh();
+        // Only auto-refresh on variants whose bootstrap seeds techReadiness
+        // (full + tech). On commodity/finance/energy the seed key is empty
+        // and the 5s fetch at services/economic/index.ts:694 just times out.
+        // The panel is still created so users who opt-in via settings can
+        // trigger a manual refresh from its UI.
+        if (isPanelInVariantDefaults('tech-readiness')) {
+          void p.refresh();
+        }
         return p;
       }),
     );

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -407,6 +407,56 @@ const TRADE_GC_INTERPOLATION_POINTS = 20;
 const CHOKEPOINT_PULSE_FREQ = 0.01;
 const CHOKEPOINT_PULSE_AMP = 0.3;
 
+// Process-wide guard so the window error listener for the deck.gl/maplibre
+// interleaved-mode render race is installed exactly once even if a hot-reload
+// or recreateWithFallback rebuilds the map.
+let __deckInterleavedRaceFilterInstalled = false;
+
+/**
+ * Swallow the well-known deck.gl 9.x + maplibre-gl 5.x interleaved-mode race:
+ *
+ *   Uncaught TypeError: Cannot read properties of null (reading 'id')
+ *     at DeckRenderer._drawLayers (deck-stack-*.js)
+ *     at LayerManager.renderLayers
+ *     at MapLibre painter.renderLayer (maplibre-*.js)
+ *
+ * Trigger: setProps({layers}) → deck _resolveLayers calls maplibre.removeLayer
+ * for a layer that's being swapped → maplibre schedules a triggerRepaint that
+ * fires the next frame → that repaint runs deck's `render()` via maplibre's
+ * custom-layer hook → deck iterates the layer list and hits a layer that was
+ * finalized between resolveLayers and renderLayers.
+ *
+ * MapboxOverlay's own onError is bypassed because maplibre — not deck — owns
+ * the render-loop callstack here (deck doesn't see the throw, so onError is
+ * never invoked). The next frame renders cleanly with no user-visible
+ * artifact, so swallowing here is safe.
+ *
+ * Sentry's beforeSend in main.ts already filters this exact pattern for
+ * telemetry (lines 313-315), but the browser still logs "Uncaught TypeError"
+ * to the console — this listener suppresses that.
+ *
+ * Narrow on BOTH the message shape AND the deck-stack chunk filename so an
+ * unrelated null-id crash in first-party code still surfaces.
+ */
+function installDeckInterleavedRaceFilter(): void {
+  if (__deckInterleavedRaceFilterInstalled) return;
+  __deckInterleavedRaceFilterInstalled = true;
+  window.addEventListener('error', (ev) => {
+    const msg = ev.error?.message ?? ev.message ?? '';
+    const file = ev.filename ?? '';
+    if (
+      /Cannot read properties of null \(reading 'id'\)|null is not an object \(evaluating '[\w.]+\.id'\)/.test(msg)
+      && /\/deck-stack-[A-Za-z0-9_-]+\.js/.test(file)
+    ) {
+      ev.preventDefault();
+      ev.stopImmediatePropagation();
+      if (import.meta.env.DEV) {
+        console.warn('[DeckGLMap] swallowed interleaved-mode render race (deck.gl/maplibre)');
+      }
+    }
+  }, { capture: true });
+}
+
 export class DeckGLMap {
   private static readonly MAX_CLUSTER_LEAVES = 200;
 
@@ -941,6 +991,8 @@ export class DeckGLMap {
 
   private initDeck(): void {
     if (!this.maplibreMap) return;
+
+    installDeckInterleavedRaceFilter();
 
     this.deckOverlay = new MapboxOverlay({
       interleaved: true,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -46,6 +46,7 @@ export {
   VARIANT_DEFAULTS,
   VARIANT_PANEL_OVERRIDES,
   getEffectivePanelConfig,
+  isPanelInVariantDefaults,
   isPanelEntitled,
   FREE_MAX_PANELS,
   FREE_MAX_SOURCES,

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -1149,6 +1149,21 @@ export function getEffectivePanelConfig(key: string, variant: string): PanelConf
   return { ...base, ...override };
 }
 
+/**
+ * Returns true if `key` is in the current variant's default panel set.
+ *
+ * App.ts:577-583 merges ALL_PANELS into panelSettings on every variant so
+ * users can cross-enable panels, which makes `shouldCreatePanel(key)`
+ * (which just checks `key in panelSettings`) true everywhere. Auto-refresh
+ * paths that fan out a fetch must instead gate on the variant defaults —
+ * otherwise variants whose backend doesn't seed the panel's bootstrap key
+ * (e.g. tech-readiness on commodity/finance/energy) blow their 5s fetch
+ * budget on a key that will never populate.
+ */
+export function isPanelInVariantDefaults(key: string): boolean {
+  return (VARIANT_DEFAULTS[SITE_VARIANT] ?? []).includes(key);
+}
+
 export const FREE_MAX_PANELS = 40;
 export const FREE_MAX_SOURCES = 80;
 

--- a/tests/tech-readiness-variant-gate.test.mts
+++ b/tests/tech-readiness-variant-gate.test.mts
@@ -1,0 +1,111 @@
+// Regression guard for PR #3833 follow-up: tech-readiness refresh must be
+// variant-gated, not just viewport-gated.
+//
+// Bug: `shouldLoad(id)` returns `forceAll || isPanelNearViewport(id)` and
+// `App.ts:1226` calls `loadAllData(true)` on boot — so a `shouldLoad`-only
+// gate is bypassed at startup on every variant, and tech-readiness was
+// still firing its 5s `/api/bootstrap?keys=techReadiness` fetch on
+// commodity/finance/energy/happy where the seed key isn't populated.
+//
+// Fix: gate on `isPanelInVariantDefaults('tech-readiness')` in BOTH paths
+// that auto-refresh — `data-loader.ts` (periodic + boot fan-out) and
+// `panel-layout.ts` (lazyPanel factory's eager `p.refresh()` call).
+//
+// This test fails loudly if either gate is removed or weakened, even
+// after innocent reformatting (line-walker, not strict regex).
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+function readFile(rel: string): string[] {
+  return readFileSync(resolve(root, rel), 'utf-8').split('\n');
+}
+
+function stripComments(line: string): string {
+  // Strip // line comments before structural matching.
+  const idx = line.indexOf('//');
+  return idx === -1 ? line : line.slice(0, idx);
+}
+
+describe('tech-readiness variant gate', () => {
+  it('data-loader.ts: tech-readiness task is gated by isPanelInVariantDefaults', () => {
+    const lines = readFile('src/app/data-loader.ts');
+    // Find the line that enqueues the techReadiness task.
+    const taskLineIdx = lines.findIndex(l => /name:\s*'techReadiness'/.test(stripComments(l)));
+    assert.ok(taskLineIdx !== -1, 'expected to find techReadiness task in data-loader.ts');
+
+    // Walk backward to the enclosing `if (...)` on the same statement.
+    let ifLineIdx = -1;
+    for (let i = taskLineIdx; i >= Math.max(0, taskLineIdx - 5); i--) {
+      if (/^\s*if\s*\(/.test(stripComments(lines[i]))) {
+        ifLineIdx = i;
+        break;
+      }
+    }
+    assert.ok(ifLineIdx !== -1, 'expected an `if (...)` guarding the techReadiness task');
+
+    // The condition must mention the variant-defaults helper, not just shouldLoad.
+    const condition = stripComments(lines[ifLineIdx]);
+    assert.match(
+      condition,
+      /isPanelInVariantDefaults\(\s*['"]tech-readiness['"]\s*\)/,
+      `data-loader.ts:${ifLineIdx + 1} must gate techReadiness on isPanelInVariantDefaults('tech-readiness'); ` +
+      `\`shouldLoad\` alone is bypassed on boot because loadAllData(true) forces it true. Got: ${condition.trim()}`,
+    );
+  });
+
+  it("panel-layout.ts: lazyPanel('tech-readiness') factory only calls p.refresh() under the variant gate", () => {
+    const lines = readFile('src/app/panel-layout.ts');
+    // Find the lazyPanel registration for tech-readiness.
+    const lazyIdx = lines.findIndex(l => /lazyPanel\(\s*['"]tech-readiness['"]/.test(stripComments(l)));
+    assert.ok(lazyIdx !== -1, "expected lazyPanel('tech-readiness', ...) in panel-layout.ts");
+
+    // Collect the factory body — walk forward until the call closes at column 0 with `);`.
+    const body: { lineNo: number; text: string }[] = [];
+    let depth = 0;
+    let started = false;
+    for (let i = lazyIdx; i < Math.min(lines.length, lazyIdx + 30); i++) {
+      const text = stripComments(lines[i]);
+      body.push({ lineNo: i + 1, text });
+      for (const ch of text) {
+        if (ch === '(') { depth++; started = true; }
+        else if (ch === ')') { depth--; }
+      }
+      if (started && depth === 0) break;
+    }
+    assert.ok(body.length > 1, 'expected to walk the lazyPanel factory body');
+
+    // Every line that calls `p.refresh()` must be preceded (within the body) by
+    // a conditional that names isPanelInVariantDefaults('tech-readiness').
+    const refreshLines = body.filter(b => /\bp\.refresh\(\s*\)/.test(b.text));
+    assert.ok(
+      refreshLines.length > 0,
+      "expected the factory to call p.refresh() (currently the variant-gated initial fetch)",
+    );
+
+    const bodyText = body.map(b => b.text).join('\n');
+    assert.match(
+      bodyText,
+      /if\s*\(\s*isPanelInVariantDefaults\(\s*['"]tech-readiness['"]\s*\)\s*\)\s*\{[^}]*\bp\.refresh\(\s*\)/s,
+      "panel-layout.ts lazyPanel('tech-readiness', ...) factory must wrap p.refresh() in " +
+      "`if (isPanelInVariantDefaults('tech-readiness')) { ... }`. Without the gate, " +
+      'the factory fires the 5s /api/bootstrap?keys=techReadiness fetch on every variant ' +
+      "regardless of whether the seed key exists.",
+    );
+  });
+
+  it('panels.ts: isPanelInVariantDefaults is exported from @/config barrel', () => {
+    const barrel = readFileSync(resolve(root, 'src/config/index.ts'), 'utf-8');
+    assert.match(
+      barrel,
+      /isPanelInVariantDefaults/,
+      'src/config/index.ts must re-export isPanelInVariantDefaults so call sites can import it from @/config',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Two independent fixes bundled into one PR — both are surgical, single-file, low-blast-radius.

### #1 — deck.gl/maplibre interleaved-mode render race (`src/components/DeckGLMap.ts`)

Module-scoped `installDeckInterleavedRaceFilter()` adds a one-shot capture-phase `window.addEventListener('error', …)` that suppresses

```
Uncaught TypeError: Cannot read properties of null (reading 'id')
  at DeckRenderer._drawLayers  (deck-stack-*.js)
  at LayerManager.renderLayers
  at MapLibre painter.renderLayer (maplibre-*.js)
```

Trigger: deck `setProps({layers})` finalizes a layer between `_resolveLayers` and `renderLayers`; the next maplibre repaint hits the freed slot. `MapboxOverlay.onError` can't catch this — maplibre, not deck, owns the throwing callstack.

- Called from `initDeck()` — idempotent on `recreateWithFallback` / HMR.
- Filter narrows on BOTH the message shape **and** the `deck-stack-*.js` chunk filename so a first-party `.id` crash still surfaces.
- Sentry's `beforeSend` in `main.ts:313-315` already drops this exact pattern for telemetry, so the change is pure console-noise removal.

### #5 — tech-readiness refresh storm on energy/finance/commodity variants (`src/app/data-loader.ts`)

Replaced

```ts
if (SITE_VARIANT !== 'happy') { … (this.ctx.panels['tech-readiness'] as TechReadinessPanel)?.refresh() … }
```

with

```ts
if (SITE_VARIANT !== 'happy' && shouldLoad('tech-readiness')) { … }
```

matching the `thermal-escalation` gate one line below.

Why this fixes the 5 s timeout: `App.ts:576-583` merges `ALL_PANELS` into `panelSettings` on every variant for cross-variant pref carryover, so `shouldCreatePanel('tech-readiness')` is `true` everywhere — but the bootstrap seed key only exists on `full` + `tech` variants. The unconditional `refresh()` at `services/economic/index.ts:694` therefore times out on every other variant's data-loader cycle. Viewport-gating prevents the fan-out from firing on variants whose panel will never be visible.

## Test plan

- [ ] Build passes (`npm run typecheck:api`, boundaries, premium-fetch parity — already green from push hooks)
- [ ] Manual: load any non-happy variant (energy, finance, commodity) → confirm no 5 s timeout entry for `techReadiness` in data-loader logs
- [ ] Manual: open map with chokepoint pulse layer → trigger a layer swap (e.g. flip a chokepoint filter) → confirm no `Cannot read properties of null` in DevTools console
- [ ] Sentry: confirm the `deck-stack-*` `.id` event continues to be dropped client-side (no console error) AND continues to be filtered in telemetry