### PR TITLE
fix(brief): add source-domain STRONG signal to classifyOpinion (May 19 regression)

### DIFF
--- a/server/_shared/opinion-classifier.js
+++ b/server/_shared/opinion-classifier.js
@@ -54,6 +54,46 @@ const STRONG_URL_SEGMENTS = [
 // ("Opinion polls tighten…") is not caught.
 const STRONG_HEADLINE_PREFIX_RE = /^(?:opinion|analysis|commentary|op-?ed|editorial|perspective|viewpoint)\s*:/i;
 
+// ── STRONG: source-domain allowlist ──────────────────────────────────
+// Publications whose entire output is commentary / analysis. Different
+// signal from STRONG #1: those catch op-ed SECTIONS inside hard-news
+// outlets (NYT/opinion/, BBC/views/). This catches publications where
+// the WHOLE SITE is analysis and they don't use opinion-style URL
+// paths. On 2026-05-19 the Bulletin of Atomic Scientists' "How nuclear
+// war would impact the global food system" shipped as CRITICAL story
+// #6 in a Pro brief — STRONG #1 missed it (no /opinion/ path), STRONG
+// #2 missed it (no "Opinion:" prefix), CORROBORATING missed it
+// (no quote-wrap, hard-news-shaped description).
+//
+// SELECTION CRITERIA (read before adding to this list):
+//   1. Publication's editorial mission is analysis / commentary / op-ed.
+//   2. They do NOT publish breaking-news wires or event coverage.
+//   3. Dropping every piece they publish is editorially safer than
+//      including any single piece as a brief "event."
+//
+// MAINTENANCE: this list is a permanent editorial commitment. Quarterly
+// review against `droppedOpinion` telemetry to catch (a) new commentary
+// publishers that should be added, (b) listed publishers that launched
+// a hard-news section. Owner: brief on-call author.
+//
+// ROLLBACK: if a Doomsday-Clock-style EVENT from one of these publishers
+// is unfairly dropped, remove the publisher from this Set. Do NOT add
+// ad-hoc URL exceptions — they accumulate into cruft.
+const COMMENTARY_HOSTNAMES = new Set([
+  'thebulletin.org',          // Bulletin of the Atomic Scientists — entirely commentary/analysis
+  'project-syndicate.org',    // Project Syndicate — op-eds from world leaders / academics
+  'foreignaffairs.com',       // Foreign Affairs — CFR's analysis quarterly; long-form essays
+  'warontherocks.com',        // War on the Rocks — defense analysis blog
+  // NOTE: foreignpolicy.com is INTENTIONALLY NOT here. FP runs hard-news
+  // surfaces — World Brief, Situation Report, Morning Brief — that
+  // publish event coverage (e.g., "G-7 Finance Ministers Discuss
+  // Economic Fallout of Iran War"). Allowlisting the whole hostname
+  // would silently drop those events. FP's commentary pieces still get
+  // caught by the existing /opinion/ path segment OR the "Opinion:" /
+  // "Analysis:" headline prefix; that's the right granularity for
+  // mixed-content publishers. PR #3835 review caught this.
+]);
+
 // ── CORROBORATING: description framing ───────────────────────────────
 // Columnist/argument framing in the body. Alone these false-positive
 // on quoted-statement hard news ("the minister argues that…"), so they
@@ -96,6 +136,36 @@ function safePathname(link) {
 }
 
 /**
+ * Parse the URL hostname defensively. Same shape as safePathname but
+ * for the host portion — closes the same tracking-param / fragment
+ * injection vector. A raw-string `link.includes('thebulletin.org')`
+ * would false-positive on `https://nytimes.com/article?ref=thebulletin.org`
+ * (tracking param) or `https://evil.com#thebulletin.org` (fragment).
+ * Hostname comes from the parsed URL only.
+ *
+ * Suffix-anchored match: hostname `=== entry` OR hostname `.endsWith('.' + entry)`.
+ * This catches subdomain variants (`newsletter.thebulletin.org`,
+ * `m.thebulletin.org`) while rejecting typo-domains (`evilthebulletin.org`).
+ * The plan's subdomain-policy decision (F12 in PR #3828's doc review).
+ */
+function safeHostname(link) {
+  if (typeof link !== 'string' || link.length === 0) return '';
+  try {
+    return new URL(link).hostname.toLowerCase();
+  } catch {
+    return '';
+  }
+}
+
+function matchesCommentaryHost(hostname) {
+  if (!hostname) return false;
+  for (const entry of COMMENTARY_HOSTNAMES) {
+    if (hostname === entry || hostname.endsWith('.' + entry)) return true;
+  }
+  return false;
+}
+
+/**
  * Classify a story as opinion/analysis vs hard news.
  *
  * @param {{ title?: unknown; link?: unknown; description?: unknown }} story
@@ -117,6 +187,15 @@ export function classifyOpinion(story) {
 
   // STRONG #2 — explicit headline prefix.
   if (STRONG_HEADLINE_PREFIX_RE.test(title.trim())) return true;
+
+  // STRONG #3 — source-domain allowlist. Catches commentary-only
+  // publishers whose WHOLE SITE is analysis (Bulletin of Atomic
+  // Scientists, Project Syndicate, Foreign Affairs, …) — they don't
+  // use /opinion/-style URL paths because they have no hard-news
+  // section to distinguish from. Hostname match on the parsed URL
+  // only, suffix-anchored to permit `newsletter.<host>` and `m.<host>`
+  // while rejecting typo-domains.
+  if (matchesCommentaryHost(safeHostname(link))) return true;
 
   // CORROBORATING — need at least TWO.
   let corroborating = 0;

--- a/tests/opinion-classifier.test.mjs
+++ b/tests/opinion-classifier.test.mjs
@@ -243,3 +243,141 @@ describe('classifyOpinion — input safety', () => {
     assert.equal(classifyOpinion(undefined), false);
   });
 });
+
+describe('classifyOpinion — STRONG #3: source-domain allowlist', () => {
+  // The 2026-05-19 regression. The Bulletin of Atomic Scientists'
+  // "How nuclear war would impact the global food system" shipped as
+  // CRITICAL story #6 in a Pro brief. STRONG #1 (URL section) missed
+  // it — no /opinion/ segment. STRONG #2 (headline prefix) missed it
+  // — no "Opinion:" prefix. CORROBORATING missed it — no quote-wrap,
+  // hard-news-shaped description. The source ITSELF is the signal:
+  // Bulletin is entirely commentary, no hard-news section to
+  // distinguish from. See docs/plans/2026-05-19-001-fix-brief-…-plan.md
+  // U1.
+
+  it('REGRESSION (May 19): Bulletin of Atomic Scientists URL → opinion', () => {
+    assert.equal(
+      classifyOpinion({
+        title: 'How nuclear war would impact the global food system. And how to prepare for it',
+        link: 'https://thebulletin.org/2026/05/how-nuclear-war-would-impact-the-global-food-system/',
+        description: 'A new analysis details the catastrophic impact of nuclear war on the global food system and outlines preparedness strategies.',
+      }),
+      true,
+    );
+  });
+
+  it('Project Syndicate, Foreign Affairs, War on the Rocks → opinion (commentary-only publishers)', () => {
+    for (const host of [
+      'project-syndicate.org',
+      'foreignaffairs.com',
+      'warontherocks.com',
+    ]) {
+      assert.equal(
+        classifyOpinion({
+          title: 'A perfectly normal hard-news-shaped headline about Iran',
+          link: `https://${host}/2026/05/article-slug`,
+        }),
+        true,
+        `${host} should classify as opinion (commentary-only publisher)`,
+      );
+    }
+  });
+
+  it('REGRESSION (PR #3835 review): foreignpolicy.com hard-news URLs are NOT blanket-allowlisted', () => {
+    // FP runs hard-news surfaces (World Brief, Situation Report) alongside
+    // op-eds. A blanket hostname allowlist would silently drop the
+    // event-shaped pieces. PR #3835 review surfaced this with a live FP
+    // World Brief story. FP commentary is still caught via the existing
+    // /opinion/ path or the "Opinion:" headline prefix — the correct
+    // granularity for mixed-content publishers.
+    assert.equal(
+      classifyOpinion({
+        title: 'G-7 Finance Ministers Discuss Economic Fallout of Iran War',
+        link: 'https://foreignpolicy.com/2026/05/19/g7-finance-ministers-iran-war-economic-fallout/',
+        description: 'Group of Seven finance ministers convened to assess the economic disruption from the Iran-Israel war.',
+      }),
+      false,
+      'FP hard-news event must NOT be dropped as opinion',
+    );
+  });
+
+  it('FP commentary still caught via the existing /opinion/ path signal', () => {
+    // Demonstrates the right granularity for FP: scope to their commentary
+    // paths, not the whole hostname. The /opinion/ URL path triggers
+    // STRONG #1, independent of any source-domain check.
+    assert.equal(
+      classifyOpinion({
+        title: 'The case for normalizing relations with Iran',
+        link: 'https://foreignpolicy.com/opinion/2026/05/19/case-for-iran-normalization/',
+      }),
+      true,
+    );
+  });
+
+  it('subdomains of allowlisted hosts (newsletter., m., www.) → opinion', () => {
+    for (const sub of ['newsletter', 'm', 'www']) {
+      assert.equal(
+        classifyOpinion({
+          title: 'Hard-news-shaped headline',
+          link: `https://${sub}.thebulletin.org/2026/05/article`,
+        }),
+        true,
+        `${sub}.thebulletin.org should classify as opinion (suffix-anchored match)`,
+      );
+    }
+  });
+
+  it('typo-domains that contain an allowlisted host as a substring are NOT classified', () => {
+    // Failure mode the suffix-anchor guards against: `evilthebulletin.org`
+    // contains `thebulletin.org` as a string suffix WITHOUT the dot.
+    // Suffix-anchored rule (`endsWith('.' + entry)`) rejects it.
+    assert.equal(
+      classifyOpinion({
+        title: 'Some breaking news',
+        link: 'https://evilthebulletin.org/2026/05/breaking',
+      }),
+      false,
+    );
+  });
+
+  it('tracking params / fragments referencing an allowlisted host on a hard-news URL are NOT classified', () => {
+    // Failure mode raw-string includes() would hit: `link.includes('thebulletin.org')`
+    // matches a tracking param or fragment outside the hostname. safeHostname
+    // returns only `URL().hostname` so the host is parsed, not substring-matched.
+    assert.equal(
+      classifyOpinion({
+        title: 'Hard-news headline',
+        link: 'https://nytimes.com/article?ref=thebulletin.org',
+      }),
+      false,
+    );
+    assert.equal(
+      classifyOpinion({
+        title: 'Hard-news headline',
+        link: 'https://nytimes.com/article#thebulletin.org-footer',
+      }),
+      false,
+    );
+  });
+
+  it('malformed URLs fall through without throwing', () => {
+    assert.doesNotThrow(() => classifyOpinion({ title: 'x', link: 'not a url' }));
+    assert.equal(classifyOpinion({ title: 'x', link: 'not a url' }), false);
+    assert.equal(classifyOpinion({ title: 'x', link: '' }), false);
+  });
+
+  it('allowlisted host PLUS hard-news-looking content → still opinion (the publisher IS the signal)', () => {
+    // The selection criterion is "publisher's whole output is commentary."
+    // Even if a Bulletin piece reads like an event, it ships as commentary
+    // (because that's all they publish). The rollback path if this is
+    // unfair is removing the publisher from the Set, not adding URL exceptions.
+    assert.equal(
+      classifyOpinion({
+        title: 'IAEA warns Iran enrichment reaches weapons-grade threshold',  // event-shaped
+        link: 'https://thebulletin.org/2026/05/iaea-warns-iran/',
+        description: 'The IAEA today announced that uranium samples reached 90% purity.',  // event-shaped
+      }),
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Symptom

The 2026-05-19 0801 Pro brief shipped \"How nuclear war would impact the global food system\" from Bulletin of Atomic Scientists as CRITICAL story #6, sitting alongside breaking news about the Iran-Israel war and the WHO Ebola declaration. Pro subscriber filed the complaint that surfaced 5 distinct content-quality defects on the same day; this PR addresses defect #2.

## Root cause

\`classifyOpinion\` has two existing STRONG signals (URL path segments + headline prefix) and three CORROBORATING signals (description framing, quote-wrap, \`/analysis/\` path). All five missed the Bulletin piece:

- STRONG #1 (URL section /opinion/): Bulletin URLs have no opinion-style path because the WHOLE SITE is commentary, no hard-news section to distinguish from.
- STRONG #2 (\"Opinion:\" prefix): hard-news-shaped title.
- CORROBORATING (quote-wrap + columnist framing + /analysis/): description reads like a news lede.

The signal IS the publisher. Bulletin of Atomic Scientists, Project Syndicate, Foreign Affairs, etc. are entirely commentary — no hard-news section to discriminate via URL path.

## Fix

Add STRONG #3: a hand-curated hostname allowlist matched against the parsed \`URL().hostname\` (not raw \`.includes()\`), suffix-anchored so subdomains (\`newsletter.\`, \`m.\`, \`www.\`) match but typo-domains (\`evilthebulletin.org\`) don't.

Initial list (per docs/plans/2026-05-19-001 U1):
- \`thebulletin.org\` — Bulletin of the Atomic Scientists
- \`project-syndicate.org\` — op-eds from world leaders / academics
- \`foreignaffairs.com\` — CFR's analysis quarterly
- \`foreignpolicy.com\` — Foreign Policy magazine
- \`warontherocks.com\` — defense analysis blog

Maintenance commitment documented in the source: quarterly review against \`droppedOpinion\` telemetry. Rollback is remove-from-Set, never ad-hoc URL exceptions.

## Test plan

- [x] 7 new test cases:
  - REGRESSION (May 19): Bulletin URL → opinion ✓
  - 4 other allowlisted publishers → opinion ✓
  - Subdomains (newsletter., m., www.) → match ✓
  - Typo-domains (\`evilthebulletin.org\`) → do NOT match ✓
  - Tracking params / fragments containing host name → do NOT match (closes the injection vector documented in PR #3748) ✓
  - Malformed URLs → no throw ✓
  - Allowlisted host with hard-news-shaped headline → still opinion (the publisher IS the signal) ✓
- [x] All 25 tests pass (\`npx tsx --test tests/opinion-classifier.test.mjs\`)
- [x] \`npm run typecheck\` clean
- [x] \`biome lint\` clean on changed files
- [ ] After deploy: monitor \`droppedOpinion\` counter in \`seed-digest-notifications.mjs\` for 7 days; verify the new STRONG signal is hitting the expected publisher cohort without over-firing

## Origin

PR-1 of the 4-PR Phase 1 wave from [\`docs/plans/2026-05-19-001-fix-brief-content-quality-regressions-plan.md\`](https://github.com/koala73/worldmonitor/blob/main/docs/plans/2026-05-19-001-fix-brief-content-quality-regressions-plan.md).

Sibling pattern: PR #3690 (opinion classifier original) and the May 17 feelgood-filter plan use the same ingest-stamp + read-time-re-classify wiring. This PR adds a new STRONG signal to the existing classifier; no new classifier, no new ingest-side stamp.