### PR TITLE
fix(brief): post-LLM hallucination validator with shadow-mode rollout

### DIFF
--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -5,6 +5,22 @@ import { clusterItems, selectTopStories } from './_clustering.mjs';
 import { extractCountryCode } from './shared/geo-extract.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { pickBriefCluster, briefSystemPrompt, briefUserPrompt } from './_insights-brief.mjs';
+// Import from the scripts mirror (`scripts/shared/`) — NOT the repo-root
+// `shared/`. Railway services with nixpacks `rootDirectory=scripts` only
+// package files under scripts/; a `../shared/` import resolves to
+// `/shared/...` at runtime which is absent in the container and crashes
+// the seeder on startup. The local pattern is the `./shared/geo-extract.mjs`
+// line above. PR #3836 review caught this. See skill
+// railway-deploy-gotchas/reference/nixpacks-root-dir-scripts-cross-dir-import-escape.
+import { validateNoHallucinatedProperNouns } from './shared/brief-llm-core.js';
+
+// Hallucination validator rollout mode (PR-2 of brief-content-quality
+// regressions). `shadow` = log violations to Sentry but ship the LLM
+// output unchanged (default, safe). `enforce` = on violation, replace
+// the LLM summary with the source headline. Flip via Railway env after
+// the 7-day shadow window confirms <5% violation rate.
+const BRIEF_VALIDATOR_MODE =
+  process.env.BRIEF_VALIDATOR_MODE === 'enforce' ? 'enforce' : 'shadow';
 
 loadEnvFile(import.meta.url);
 
@@ -299,10 +315,40 @@ async function fetchInsights() {
   } else {
     const llmResult = await callLLM(topHeadline);
     if (llmResult) {
-      worldBrief = llmResult.text;
-      briefProvider = llmResult.provider;
-      briefModel = llmResult.model;
-      console.log(`  Brief generated via ${briefProvider} (${briefModel})`);
+      // Hallucination check: did the LLM invent proper nouns not in
+      // the headline? The May 19 brief shipped "Lebanese President
+      // Michel Aoun pledged..." against a headline that contained no
+      // name. See docs/plans/2026-05-19-001 U2.
+      const validation = validateNoHallucinatedProperNouns(llmResult.text, topHeadline);
+      if (!validation.ok) {
+        const hallucinated = (validation.hallucinated || []).join(' ');
+        if (BRIEF_VALIDATOR_MODE === 'enforce') {
+          // Replace the LLM summary with the source headline. R1 of the
+          // plan: "falls back to a safe summary (headline-grounded
+          // template) rather than publishing the hallucination."
+          worldBrief = topHeadline;
+          briefProvider = `${llmResult.provider}+headline-fallback`;
+          briefModel = llmResult.model;
+          console.warn(
+            `  [brief_hallucination ENFORCE] dropped LLM summary: invented "${hallucinated}" not in headline; fell back to headline`
+          );
+        } else {
+          // Shadow mode: log but ship the LLM output. The 7-day rollout
+          // window measures the false-positive rate before flipping to
+          // enforce.
+          worldBrief = llmResult.text;
+          briefProvider = llmResult.provider;
+          briefModel = llmResult.model;
+          console.warn(
+            `  [brief_hallucination SHADOW] would have dropped LLM summary: invented "${hallucinated}" not in headline`
+          );
+        }
+      } else {
+        worldBrief = llmResult.text;
+        briefProvider = llmResult.provider;
+        briefModel = llmResult.model;
+        console.log(`  Brief generated via ${briefProvider} (${briefModel})`);
+      }
     } else {
       status = 'degraded';
       console.warn('  No LLM available — publishing degraded (stories without brief)');

--- a/scripts/shared/brief-llm-core.d.ts
+++ b/scripts/shared/brief-llm-core.d.ts
@@ -36,3 +36,10 @@ export function hashBriefStory(story: BriefStoryHashInput): Promise<string>;
 // ── v2 (analyst path only) ────────────────────────────────────────────────
 export const WHY_MATTERS_ANALYST_SYSTEM_V2: string;
 export function parseWhyMattersV2(text: unknown): string | null;
+
+// ── Hallucination validator (PR-2 of brief-content-quality regressions) ──
+export function extractProperNounSequences(text: string): string[][];
+export function validateNoHallucinatedProperNouns(
+  summary: unknown,
+  headline: unknown,
+): { ok: true } | { ok: false; hallucinated: string[] };

--- a/scripts/shared/brief-llm-core.js
+++ b/scripts/shared/brief-llm-core.js
@@ -228,3 +228,433 @@ export function parseWhyMattersV2(text) {
   if (/^(situation|analysis|watch)\s*[:\-–—]/i.test(s)) return null;
   return s;
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// Hallucination validator for the brief-paragraph LLM rewrite.
+//
+// The 2026-05-19 Pro brief shipped "Lebanese President Michel Aoun
+// pledged..." against a source headline that contained NO name — just
+// "Lebanese president vows to 'do the impossible'..." The current
+// Lebanese president is Joseph Aoun, not Michel Aoun. The LLM invented
+// the name despite the prompt explicitly forbidding invention.
+//
+// Prompts that say "do not invent proper nouns" are not enforceable on
+// every output. This validator catches inventions mechanically: it
+// extracts proper-noun sequences from the LLM summary and verifies
+// each appears in the source headline (after acronym + demonym
+// normalization). When a sequence in the summary has no matching
+// contiguous subsequence in the headline, the summary is rejected.
+//
+// The caller decides what to do with a rejection. In `seed-insights.mjs`
+// the integration path writes `worldBrief = sanitizeTitle(topHeadline)`
+// (the headline IS the summary), preserving R1 of the plan:
+// "falls back to a safe summary (headline-grounded template) rather
+// than publishing the hallucination."
+//
+// Out of scope (documented in docs/plans/2026-05-19-001 Scope Boundaries):
+//   - Source-level fact-checking. If the source headline already
+//     contains the wrong name (wire-service typo), this validator OKs
+//     the summary and the fallback ships the wrong fact verbatim.
+//   - Full NER. The pinned heuristic rules below cover the surface
+//     PR-2 needs; deeper NER is deferred.
+// ─────────────────────────────────────────────────────────────────────
+
+// Title-prefix stop list — when these words sit immediately before a
+// capitalized word, they're consumed but not counted as a proper noun
+// themselves. "former President Trump" → ['Trump'], not
+// ['former', 'President', 'Trump']. The leading lowercase forms
+// ('former', 'ex-') are caught by being lowercase in the first place;
+// the capitalized title nouns ('President', 'Prime', 'Minister') need
+// the explicit stop list because they LOOK like proper nouns.
+const TITLE_PREFIX_STOP = new Set([
+  'President', 'Prime', 'Minister', 'Senator', 'Representative',
+  'Dr', 'Dr.', 'Mr', 'Mr.', 'Ms', 'Ms.', 'Mrs', 'Mrs.',
+  'Acting', 'Interim', 'Former', 'Ex',
+  'Chairman', 'Chairwoman', 'Chair', 'Speaker',
+  'CEO', 'Secretary', 'Defense', 'Foreign',
+  'Ambassador', 'General', 'Admiral', 'Colonel', 'Captain',
+  'Pope', 'King', 'Queen', 'Prince', 'Princess',
+  'Lord', 'Lady', 'Sir', 'Dame',
+  'Judge', 'Justice',
+]);
+
+// Joiner words — lowercase tokens that bridge proper-noun sequences.
+// "Democratic Republic of Congo" is ONE sequence, not three.
+const PROPER_NOUN_JOINER = new Set(['of', 'the', 'and', 'for', 'de', 'du', 'der', 'van', 'el', 'al']);
+
+// Acronym ↔ expansion table (bidirectional). When summary contains
+// either form and headline contains the other, treated as equivalent.
+// Each entry is a single canonical key + its variants. The lookup is
+// hostname-style: build a Set of every form, then map each form to
+// its canonical key for equivalence.
+const ACRONYM_EXPANSIONS = [
+  ['WHO', 'World Health Organization'],
+  ['UN', 'United Nations'],
+  ['US', 'USA', 'United States', 'United States of America', 'America'],
+  ['UK', 'United Kingdom', 'Britain', 'Great Britain'],
+  ['EU', 'European Union'],
+  ['IDF', 'Israel Defense Forces', 'Israeli Defense Forces'],
+  ['IMF', 'International Monetary Fund'],
+  ['WTO', 'World Trade Organization'],
+  ['NATO', 'North Atlantic Treaty Organization'],
+  ['OECD'],
+  ['OPEC', 'Organization of the Petroleum Exporting Countries'],
+  ['IAEA', 'International Atomic Energy Agency'],
+  ['ASEAN'],
+  ['ECOWAS'],
+  ['BRICS'],
+  ['DOJ', 'Department of Justice', 'Justice Department'],
+  ['FBI', 'Federal Bureau of Investigation'],
+  ['SEC', 'Securities and Exchange Commission'],
+  ['CIA', 'Central Intelligence Agency'],
+  ['NSA', 'National Security Agency'],
+  ['DOD', 'Department of Defense', 'Defense Department', 'Pentagon'],
+  ['DR Congo', 'Democratic Republic of Congo', 'DRC'],
+  ['UAE', 'United Arab Emirates'],
+];
+
+// Demonym ↔ nation table. "Israeli strikes" headline ↔ "Israel struck"
+// summary — treated as equivalent.
+const DEMONYM_TO_NATION = new Map([
+  ['Israeli', 'Israel'], ['Israelis', 'Israel'],
+  ['American', 'United States'], ['Americans', 'United States'],
+  ['Iranian', 'Iran'], ['Iranians', 'Iran'],
+  ['Russian', 'Russia'], ['Russians', 'Russia'],
+  ['Chinese', 'China'],
+  ['French', 'France'],
+  ['German', 'Germany'], ['Germans', 'Germany'],
+  ['Japanese', 'Japan'],
+  ['Lebanese', 'Lebanon'],
+  ['Syrian', 'Syria'], ['Syrians', 'Syria'],
+  ['Saudi', 'Saudi Arabia'], ['Saudis', 'Saudi Arabia'],
+  ['Egyptian', 'Egypt'], ['Egyptians', 'Egypt'],
+  ['Turkish', 'Turkey'], ['Turks', 'Turkey'],
+  ['Indian', 'India'], ['Indians', 'India'],
+  ['Pakistani', 'Pakistan'], ['Pakistanis', 'Pakistan'],
+  ['British', 'United Kingdom'], ['Briton', 'United Kingdom'], ['Britons', 'United Kingdom'],
+  ['Ukrainian', 'Ukraine'], ['Ukrainians', 'Ukraine'],
+  ['Palestinian', 'Palestine'], ['Palestinians', 'Palestine'],
+  ['Yemeni', 'Yemen'], ['Yemenis', 'Yemen'],
+  ['Iraqi', 'Iraq'], ['Iraqis', 'Iraq'],
+  ['Afghan', 'Afghanistan'], ['Afghans', 'Afghanistan'],
+  ['Spanish', 'Spain'],
+  ['Italian', 'Italy'], ['Italians', 'Italy'],
+  ['Korean', 'Korea'], ['Koreans', 'Korea'],
+  ['Vietnamese', 'Vietnam'],
+  ['Mexican', 'Mexico'], ['Mexicans', 'Mexico'],
+  ['Brazilian', 'Brazil'], ['Brazilians', 'Brazil'],
+  ['Canadian', 'Canada'], ['Canadians', 'Canada'],
+  ['Australian', 'Australia'], ['Australians', 'Australia'],
+  ['Cuban', 'Cuba'], ['Cubans', 'Cuba'],
+  ['Venezuelan', 'Venezuela'], ['Venezuelans', 'Venezuela'],
+  ['Argentine', 'Argentina'], ['Argentinian', 'Argentina'], ['Argentinians', 'Argentina'],
+  ['Polish', 'Poland'],
+  ['Dutch', 'Netherlands'],
+  ['Greek', 'Greece'], ['Greeks', 'Greece'],
+  ['Portuguese', 'Portugal'],
+  ['Swiss', 'Switzerland'],
+  ['Swedish', 'Sweden'], ['Swedes', 'Sweden'],
+  ['Norwegian', 'Norway'], ['Norwegians', 'Norway'],
+  ['Finnish', 'Finland'], ['Finns', 'Finland'],
+  ['Danish', 'Denmark'], ['Danes', 'Denmark'],
+  ['Belgian', 'Belgium'], ['Belgians', 'Belgium'],
+  ['Austrian', 'Austria'], ['Austrians', 'Austria'],
+  ['Filipino', 'Philippines'], ['Filipinos', 'Philippines'],
+  ['Thai', 'Thailand'], ['Thais', 'Thailand'],
+  ['Indonesian', 'Indonesia'], ['Indonesians', 'Indonesia'],
+  ['Nigerian', 'Nigeria'], ['Nigerians', 'Nigeria'],
+  ['Ethiopian', 'Ethiopia'], ['Ethiopians', 'Ethiopia'],
+  ['Kenyan', 'Kenya'], ['Kenyans', 'Kenya'],
+  ['South Korean', 'South Korea'], ['South Koreans', 'South Korea'],
+  ['North Korean', 'North Korea'], ['North Koreans', 'North Korea'],
+]);
+
+// Build a normalization map from every variant (acronym OR expansion)
+// to a single canonical key. Lookup uses lower-case keys for case-
+// insensitive matching.
+const ACRONYM_NORMALIZE = (() => {
+  const map = new Map();
+  for (const group of ACRONYM_EXPANSIONS) {
+    const canonical = group[0].toLowerCase();
+    for (const variant of group) map.set(variant.toLowerCase(), canonical);
+  }
+  return map;
+})();
+
+const DEMONYM_NORMALIZE = (() => {
+  const map = new Map();
+  for (const [demonym, nation] of DEMONYM_TO_NATION) {
+    map.set(demonym.toLowerCase(), nation.toLowerCase());
+  }
+  return map;
+})();
+
+/**
+ * Extract contiguous proper-noun sequences from a text. A sequence is
+ * a run of capitalized tokens (length ≥ 1), bridged by joiner words
+ * (lowercase 'of', 'the', 'and', etc.). All-caps acronyms (length 2-6)
+ * count. Title-prefix stop-list words ('President', 'Senator', 'Dr.',
+ * 'former', …) when immediately followed by a capitalized token are
+ * consumed but not counted as proper nouns themselves.
+ *
+ * Returns an array of arrays — each inner array is the token sequence
+ * of one proper noun, lower-cased.
+ *
+ * Examples:
+ *   "former President Trump said..."  → [['trump']]
+ *   "Democratic Republic of Congo declared"
+ *                                     → [['democratic', 'republic', 'of', 'congo']]
+ *   "The UN said the EU agreed"       → [['un'], ['eu']]
+ *   "Lebanese President Michel Aoun"  → [['michel', 'aoun']]
+ *
+ * @param {string} text
+ * @returns {string[][]}
+ */
+// Common sentence-start words that LOOK like proper nouns when
+// capitalized (sentence-start) but aren't. Lowercase keys; matched
+// case-insensitively. The list is conservative — words on it are
+// EXCLUSIVELY common nouns / function words / discourse markers.
+// Real proper nouns at sentence start ("Trump said...", "Israel
+// announced...", "WHO declared...") MUST pass through unfiltered.
+const SENTENCE_START_AMBIGUOUS = new Set([
+  'the', 'a', 'an',
+  'this', 'that', 'these', 'those',
+  'it', 'he', 'she', 'they', 'we', 'you', 'i',
+  'some', 'many', 'most', 'all', 'few', 'several', 'both', 'each', 'every',
+  'other', 'another', 'such', 'any', 'either', 'neither',
+  'there', 'here', 'now', 'today', 'yesterday', 'tomorrow',
+  'when', 'where', 'while', 'as', 'after', 'before', 'during', 'since', 'until',
+  'if', 'because', 'although', 'though', 'unless', 'whether',
+  'how', 'why', 'what', 'which', 'whose',
+  'no', 'not', 'yes',
+  'breaking', 'live', 'updated', 'latest', 'exclusive', 'just',
+  'meanwhile', 'however', 'moreover', 'additionally', 'furthermore', 'still',
+  'with', 'without', 'on', 'in', 'at', 'by', 'for', 'over', 'under', 'about',
+]);
+
+/**
+ * Collapse dotted acronyms (`U.S.`, `U.S.A.`, `D.O.J.`) into bare form
+ * (`US`, `USA`, `DOJ`) so the tokenizer doesn't split them into single-
+ * char tokens that fail the 2-6-char acronym rule. PR #3836 review:
+ * a valid summary using common dotted style ("the U.S. announced...")
+ * against an expanded headline ("United States imposed...") tokenized
+ * to `['U', 'S']` vs `['us']` (canonical) and never matched —
+ * false-flagging as hallucination.
+ *
+ * Match: a capital letter followed by a dot, then at least one more
+ * capital-letter-then-optional-dot pair. The second pair commitment
+ * prevents a sentence-final initial ("...J.") from false-positiving.
+ *
+ * Examples:
+ *   "the U.S. announced"             → "the US announced"
+ *   "U.S.A. delegation"              → "USA delegation"
+ *   "FBI raided J.D. Vance's office" → "FBI raided JD Vance's office"
+ *   "i.e., these things"             → "i.e., these things"  (lowercase, no match)
+ *   "end of sentence."               → "end of sentence."    (single dot, no run)
+ */
+function normalizeDottedAcronyms(text) {
+  return text.replace(/(\b[A-Z]\.(?:[A-Z]\.?)+)/g, (match) => match.replace(/\./g, ''));
+}
+
+export function extractProperNounSequences(text) {
+  if (typeof text !== 'string' || text.length === 0) return [];
+
+  // Normalize dotted acronyms BEFORE sentence-splitting so "U.S." isn't
+  // misread as a sentence boundary or split into ['U', 'S'].
+  const preprocessed = normalizeDottedAcronyms(text);
+
+  // Split into sentences so sentence-start handling can run per-sentence.
+  const sentences = preprocessed.split(/[.!?]+\s+|\n+/);
+
+  const sequences = [];
+  for (const rawSentence of sentences) {
+    const sentence = rawSentence.trim();
+    if (!sentence) continue;
+
+    // Tokenize: keep alphanumeric runs + apostrophes + hyphens
+    // (preserves "Mar-a-Lago", "O'Brien").
+    const tokens = sentence.split(/[^\p{L}\p{N}'’-]+/u).filter(Boolean);
+    if (tokens.length === 0) continue;
+
+    let current = [];
+    let bridgeBuffer = []; // joiners pending — kept only if another proper noun follows
+    let firstToken = true;
+
+    for (const token of tokens) {
+      // Strip trailing punctuation and possessive 's / ’s so
+      // "Beirut's" → "beirut" and "U.S." → "U.S" (handled below).
+      let stripped = token.replace(/[.,;:'’]+$/g, '');
+      stripped = stripped.replace(/['’]s$/i, '');
+      const tokenForLookup = stripped || token;
+      const isTitlePrefix = TITLE_PREFIX_STOP.has(stripped);
+      const isJoiner = PROPER_NOUN_JOINER.has(token.toLowerCase());
+      // Capitalized: at least 2 chars long. Single-letter capitalized
+      // tokens are sentence-final initials ("...J.D. Vance was met by Smith
+      // and J."), middle initials in names, or "I" (the pronoun, already
+      // handled by SENTENCE_START_AMBIGUOUS). None should register as
+      // a standalone proper noun.
+      const isCapitalized = token.length >= 2 && /^[A-Z]/.test(token);
+      const isAllCapsAcronym = /^[A-Z]{2,6}$/.test(token);
+      const isAmbiguousSentenceStart = firstToken
+        && !isAllCapsAcronym
+        && SENTENCE_START_AMBIGUOUS.has(token.toLowerCase());
+
+      // Title-prefix consume — even at sentence start, "Former" /
+      // "President" / "Dr." consume without registering.
+      if (isTitlePrefix && current.length === 0) {
+        firstToken = false;
+        continue;
+      }
+
+      // Skip ambiguous sentence-starters ("The", "It", "Breaking", …)
+      // that LOOK like proper nouns but are common-word capitalization.
+      if (isAmbiguousSentenceStart) {
+        firstToken = false;
+        continue;
+      }
+      firstToken = false;
+
+      if (isJoiner) {
+        if (current.length > 0) bridgeBuffer.push(token.toLowerCase());
+        continue;
+      }
+
+      if (isCapitalized || isAllCapsAcronym) {
+        // Flush pending bridge buffer into current sequence.
+        if (current.length > 0 && bridgeBuffer.length > 0) {
+          current.push(...bridgeBuffer);
+        }
+        bridgeBuffer = [];
+        // Use the punctuation/possessive-stripped form so "Beirut's"
+        // lands as "beirut", matching the headline's "Beirut".
+        current.push(tokenForLookup.toLowerCase());
+      } else {
+        // Lowercase non-joiner — ends current sequence.
+        if (current.length > 0) {
+          sequences.push(current);
+          current = [];
+        }
+        bridgeBuffer = [];
+      }
+    }
+    if (current.length > 0) sequences.push(current);
+  }
+
+  return sequences;
+}
+
+/**
+ * Normalize a token: if it's a known acronym variant, return the
+ * canonical key; otherwise return it unchanged (lower-cased).
+ */
+function normalizeToken(token) {
+  const lower = token.toLowerCase();
+  if (ACRONYM_NORMALIZE.has(lower)) return ACRONYM_NORMALIZE.get(lower);
+  if (DEMONYM_NORMALIZE.has(lower)) return DEMONYM_NORMALIZE.get(lower);
+  return lower;
+}
+
+/**
+ * Apply the same normalization to a token SEQUENCE: greedy match
+ * multi-word acronym expansions ("Democratic Republic of Congo" → 'dr
+ * congo' canonical) before single-token normalization. Returns a new
+ * sequence (array of canonical tokens).
+ */
+function normalizeSequence(sequence) {
+  const out = [];
+  let i = 0;
+  while (i < sequence.length) {
+    // Try multi-word matches first, longest first (5 → 4 → 3 → 2 tokens).
+    let matched = false;
+    for (let span = Math.min(5, sequence.length - i); span >= 2; span--) {
+      const candidate = sequence.slice(i, i + span).join(' ').toLowerCase();
+      if (ACRONYM_NORMALIZE.has(candidate)) {
+        out.push(ACRONYM_NORMALIZE.get(candidate));
+        i += span;
+        matched = true;
+        break;
+      }
+    }
+    if (matched) continue;
+    // Fall through to single-token normalization.
+    out.push(normalizeToken(sequence[i]));
+    i += 1;
+  }
+  return out;
+}
+
+/**
+ * Validate that every proper noun in `summary` has a matching
+ * contiguous subsequence in `headline` (after acronym + demonym
+ * normalization). The validator catches LLM-introduced invention.
+ *
+ * Returns `{ ok: true }` when every summary proper-noun sequence is
+ * grounded in the headline, OR when either input is malformed (defensive
+ * default — ship the LLM output rather than fall back on confusion).
+ *
+ * Returns `{ ok: false, hallucinated: [...] }` when at least one
+ * summary sequence has no matching contiguous subsequence in the
+ * headline. The first such sequence is returned; iterating to find
+ * all of them is not necessary for the fallback decision.
+ *
+ * @param {string} summary - the LLM-rewritten brief paragraph
+ * @param {string} headline - the source headline the LLM was given
+ * @returns {{ ok: boolean, hallucinated?: string[] }}
+ */
+export function validateNoHallucinatedProperNouns(summary, headline) {
+  // Defensive: malformed inputs return ok (ship the LLM output rather
+  // than fall back on confusion). Catches null, undefined, empty
+  // string, non-string, and weird unicode.
+  if (typeof summary !== 'string' || summary.length === 0) return { ok: true };
+  if (typeof headline !== 'string' || headline.length === 0) return { ok: true };
+
+  let summarySequences, headlineSequences;
+  try {
+    summarySequences = extractProperNounSequences(summary).map(normalizeSequence);
+    headlineSequences = extractProperNounSequences(headline).map(normalizeSequence);
+  } catch {
+    return { ok: true };
+  }
+
+  if (summarySequences.length === 0) return { ok: true };
+
+  // For each summary sequence, check whether at least one contiguous
+  // subsequence of it appears in some headline sequence.
+  for (const summarySeq of summarySequences) {
+    let found = false;
+    for (const headlineSeq of headlineSequences) {
+      if (containsSubsequence(headlineSeq, summarySeq)) {
+        found = true;
+        break;
+      }
+      // Also check the reverse: a single-token summary sequence
+      // (e.g., ['us']) matches if it appears anywhere in a longer
+      // headline sequence.
+      if (summarySeq.length === 1 && headlineSeq.includes(summarySeq[0])) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      return { ok: false, hallucinated: summarySeq };
+    }
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Does `haystack` contain `needle` as a contiguous subsequence?
+ * Both are token arrays. Order matters; positions must be adjacent.
+ */
+function containsSubsequence(haystack, needle) {
+  if (needle.length === 0) return true;
+  if (needle.length > haystack.length) return false;
+  outer: for (let i = 0; i <= haystack.length - needle.length; i++) {
+    for (let j = 0; j < needle.length; j++) {
+      if (haystack[i + j] !== needle[j]) continue outer;
+    }
+    return true;
+  }
+  return false;
+}

--- a/shared/brief-llm-core.d.ts
+++ b/shared/brief-llm-core.d.ts
@@ -36,3 +36,10 @@ export function hashBriefStory(story: BriefStoryHashInput): Promise<string>;
 // ── v2 (analyst path only) ────────────────────────────────────────────────
 export const WHY_MATTERS_ANALYST_SYSTEM_V2: string;
 export function parseWhyMattersV2(text: unknown): string | null;
+
+// ── Hallucination validator (PR-2 of brief-content-quality regressions) ──
+export function extractProperNounSequences(text: string): string[][];
+export function validateNoHallucinatedProperNouns(
+  summary: unknown,
+  headline: unknown,
+): { ok: true } | { ok: false; hallucinated: string[] };

--- a/shared/brief-llm-core.js
+++ b/shared/brief-llm-core.js
@@ -228,3 +228,433 @@ export function parseWhyMattersV2(text) {
   if (/^(situation|analysis|watch)\s*[:\-–—]/i.test(s)) return null;
   return s;
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// Hallucination validator for the brief-paragraph LLM rewrite.
+//
+// The 2026-05-19 Pro brief shipped "Lebanese President Michel Aoun
+// pledged..." against a source headline that contained NO name — just
+// "Lebanese president vows to 'do the impossible'..." The current
+// Lebanese president is Joseph Aoun, not Michel Aoun. The LLM invented
+// the name despite the prompt explicitly forbidding invention.
+//
+// Prompts that say "do not invent proper nouns" are not enforceable on
+// every output. This validator catches inventions mechanically: it
+// extracts proper-noun sequences from the LLM summary and verifies
+// each appears in the source headline (after acronym + demonym
+// normalization). When a sequence in the summary has no matching
+// contiguous subsequence in the headline, the summary is rejected.
+//
+// The caller decides what to do with a rejection. In `seed-insights.mjs`
+// the integration path writes `worldBrief = sanitizeTitle(topHeadline)`
+// (the headline IS the summary), preserving R1 of the plan:
+// "falls back to a safe summary (headline-grounded template) rather
+// than publishing the hallucination."
+//
+// Out of scope (documented in docs/plans/2026-05-19-001 Scope Boundaries):
+//   - Source-level fact-checking. If the source headline already
+//     contains the wrong name (wire-service typo), this validator OKs
+//     the summary and the fallback ships the wrong fact verbatim.
+//   - Full NER. The pinned heuristic rules below cover the surface
+//     PR-2 needs; deeper NER is deferred.
+// ─────────────────────────────────────────────────────────────────────
+
+// Title-prefix stop list — when these words sit immediately before a
+// capitalized word, they're consumed but not counted as a proper noun
+// themselves. "former President Trump" → ['Trump'], not
+// ['former', 'President', 'Trump']. The leading lowercase forms
+// ('former', 'ex-') are caught by being lowercase in the first place;
+// the capitalized title nouns ('President', 'Prime', 'Minister') need
+// the explicit stop list because they LOOK like proper nouns.
+const TITLE_PREFIX_STOP = new Set([
+  'President', 'Prime', 'Minister', 'Senator', 'Representative',
+  'Dr', 'Dr.', 'Mr', 'Mr.', 'Ms', 'Ms.', 'Mrs', 'Mrs.',
+  'Acting', 'Interim', 'Former', 'Ex',
+  'Chairman', 'Chairwoman', 'Chair', 'Speaker',
+  'CEO', 'Secretary', 'Defense', 'Foreign',
+  'Ambassador', 'General', 'Admiral', 'Colonel', 'Captain',
+  'Pope', 'King', 'Queen', 'Prince', 'Princess',
+  'Lord', 'Lady', 'Sir', 'Dame',
+  'Judge', 'Justice',
+]);
+
+// Joiner words — lowercase tokens that bridge proper-noun sequences.
+// "Democratic Republic of Congo" is ONE sequence, not three.
+const PROPER_NOUN_JOINER = new Set(['of', 'the', 'and', 'for', 'de', 'du', 'der', 'van', 'el', 'al']);
+
+// Acronym ↔ expansion table (bidirectional). When summary contains
+// either form and headline contains the other, treated as equivalent.
+// Each entry is a single canonical key + its variants. The lookup is
+// hostname-style: build a Set of every form, then map each form to
+// its canonical key for equivalence.
+const ACRONYM_EXPANSIONS = [
+  ['WHO', 'World Health Organization'],
+  ['UN', 'United Nations'],
+  ['US', 'USA', 'United States', 'United States of America', 'America'],
+  ['UK', 'United Kingdom', 'Britain', 'Great Britain'],
+  ['EU', 'European Union'],
+  ['IDF', 'Israel Defense Forces', 'Israeli Defense Forces'],
+  ['IMF', 'International Monetary Fund'],
+  ['WTO', 'World Trade Organization'],
+  ['NATO', 'North Atlantic Treaty Organization'],
+  ['OECD'],
+  ['OPEC', 'Organization of the Petroleum Exporting Countries'],
+  ['IAEA', 'International Atomic Energy Agency'],
+  ['ASEAN'],
+  ['ECOWAS'],
+  ['BRICS'],
+  ['DOJ', 'Department of Justice', 'Justice Department'],
+  ['FBI', 'Federal Bureau of Investigation'],
+  ['SEC', 'Securities and Exchange Commission'],
+  ['CIA', 'Central Intelligence Agency'],
+  ['NSA', 'National Security Agency'],
+  ['DOD', 'Department of Defense', 'Defense Department', 'Pentagon'],
+  ['DR Congo', 'Democratic Republic of Congo', 'DRC'],
+  ['UAE', 'United Arab Emirates'],
+];
+
+// Demonym ↔ nation table. "Israeli strikes" headline ↔ "Israel struck"
+// summary — treated as equivalent.
+const DEMONYM_TO_NATION = new Map([
+  ['Israeli', 'Israel'], ['Israelis', 'Israel'],
+  ['American', 'United States'], ['Americans', 'United States'],
+  ['Iranian', 'Iran'], ['Iranians', 'Iran'],
+  ['Russian', 'Russia'], ['Russians', 'Russia'],
+  ['Chinese', 'China'],
+  ['French', 'France'],
+  ['German', 'Germany'], ['Germans', 'Germany'],
+  ['Japanese', 'Japan'],
+  ['Lebanese', 'Lebanon'],
+  ['Syrian', 'Syria'], ['Syrians', 'Syria'],
+  ['Saudi', 'Saudi Arabia'], ['Saudis', 'Saudi Arabia'],
+  ['Egyptian', 'Egypt'], ['Egyptians', 'Egypt'],
+  ['Turkish', 'Turkey'], ['Turks', 'Turkey'],
+  ['Indian', 'India'], ['Indians', 'India'],
+  ['Pakistani', 'Pakistan'], ['Pakistanis', 'Pakistan'],
+  ['British', 'United Kingdom'], ['Briton', 'United Kingdom'], ['Britons', 'United Kingdom'],
+  ['Ukrainian', 'Ukraine'], ['Ukrainians', 'Ukraine'],
+  ['Palestinian', 'Palestine'], ['Palestinians', 'Palestine'],
+  ['Yemeni', 'Yemen'], ['Yemenis', 'Yemen'],
+  ['Iraqi', 'Iraq'], ['Iraqis', 'Iraq'],
+  ['Afghan', 'Afghanistan'], ['Afghans', 'Afghanistan'],
+  ['Spanish', 'Spain'],
+  ['Italian', 'Italy'], ['Italians', 'Italy'],
+  ['Korean', 'Korea'], ['Koreans', 'Korea'],
+  ['Vietnamese', 'Vietnam'],
+  ['Mexican', 'Mexico'], ['Mexicans', 'Mexico'],
+  ['Brazilian', 'Brazil'], ['Brazilians', 'Brazil'],
+  ['Canadian', 'Canada'], ['Canadians', 'Canada'],
+  ['Australian', 'Australia'], ['Australians', 'Australia'],
+  ['Cuban', 'Cuba'], ['Cubans', 'Cuba'],
+  ['Venezuelan', 'Venezuela'], ['Venezuelans', 'Venezuela'],
+  ['Argentine', 'Argentina'], ['Argentinian', 'Argentina'], ['Argentinians', 'Argentina'],
+  ['Polish', 'Poland'],
+  ['Dutch', 'Netherlands'],
+  ['Greek', 'Greece'], ['Greeks', 'Greece'],
+  ['Portuguese', 'Portugal'],
+  ['Swiss', 'Switzerland'],
+  ['Swedish', 'Sweden'], ['Swedes', 'Sweden'],
+  ['Norwegian', 'Norway'], ['Norwegians', 'Norway'],
+  ['Finnish', 'Finland'], ['Finns', 'Finland'],
+  ['Danish', 'Denmark'], ['Danes', 'Denmark'],
+  ['Belgian', 'Belgium'], ['Belgians', 'Belgium'],
+  ['Austrian', 'Austria'], ['Austrians', 'Austria'],
+  ['Filipino', 'Philippines'], ['Filipinos', 'Philippines'],
+  ['Thai', 'Thailand'], ['Thais', 'Thailand'],
+  ['Indonesian', 'Indonesia'], ['Indonesians', 'Indonesia'],
+  ['Nigerian', 'Nigeria'], ['Nigerians', 'Nigeria'],
+  ['Ethiopian', 'Ethiopia'], ['Ethiopians', 'Ethiopia'],
+  ['Kenyan', 'Kenya'], ['Kenyans', 'Kenya'],
+  ['South Korean', 'South Korea'], ['South Koreans', 'South Korea'],
+  ['North Korean', 'North Korea'], ['North Koreans', 'North Korea'],
+]);
+
+// Build a normalization map from every variant (acronym OR expansion)
+// to a single canonical key. Lookup uses lower-case keys for case-
+// insensitive matching.
+const ACRONYM_NORMALIZE = (() => {
+  const map = new Map();
+  for (const group of ACRONYM_EXPANSIONS) {
+    const canonical = group[0].toLowerCase();
+    for (const variant of group) map.set(variant.toLowerCase(), canonical);
+  }
+  return map;
+})();
+
+const DEMONYM_NORMALIZE = (() => {
+  const map = new Map();
+  for (const [demonym, nation] of DEMONYM_TO_NATION) {
+    map.set(demonym.toLowerCase(), nation.toLowerCase());
+  }
+  return map;
+})();
+
+/**
+ * Extract contiguous proper-noun sequences from a text. A sequence is
+ * a run of capitalized tokens (length ≥ 1), bridged by joiner words
+ * (lowercase 'of', 'the', 'and', etc.). All-caps acronyms (length 2-6)
+ * count. Title-prefix stop-list words ('President', 'Senator', 'Dr.',
+ * 'former', …) when immediately followed by a capitalized token are
+ * consumed but not counted as proper nouns themselves.
+ *
+ * Returns an array of arrays — each inner array is the token sequence
+ * of one proper noun, lower-cased.
+ *
+ * Examples:
+ *   "former President Trump said..."  → [['trump']]
+ *   "Democratic Republic of Congo declared"
+ *                                     → [['democratic', 'republic', 'of', 'congo']]
+ *   "The UN said the EU agreed"       → [['un'], ['eu']]
+ *   "Lebanese President Michel Aoun"  → [['michel', 'aoun']]
+ *
+ * @param {string} text
+ * @returns {string[][]}
+ */
+// Common sentence-start words that LOOK like proper nouns when
+// capitalized (sentence-start) but aren't. Lowercase keys; matched
+// case-insensitively. The list is conservative — words on it are
+// EXCLUSIVELY common nouns / function words / discourse markers.
+// Real proper nouns at sentence start ("Trump said...", "Israel
+// announced...", "WHO declared...") MUST pass through unfiltered.
+const SENTENCE_START_AMBIGUOUS = new Set([
+  'the', 'a', 'an',
+  'this', 'that', 'these', 'those',
+  'it', 'he', 'she', 'they', 'we', 'you', 'i',
+  'some', 'many', 'most', 'all', 'few', 'several', 'both', 'each', 'every',
+  'other', 'another', 'such', 'any', 'either', 'neither',
+  'there', 'here', 'now', 'today', 'yesterday', 'tomorrow',
+  'when', 'where', 'while', 'as', 'after', 'before', 'during', 'since', 'until',
+  'if', 'because', 'although', 'though', 'unless', 'whether',
+  'how', 'why', 'what', 'which', 'whose',
+  'no', 'not', 'yes',
+  'breaking', 'live', 'updated', 'latest', 'exclusive', 'just',
+  'meanwhile', 'however', 'moreover', 'additionally', 'furthermore', 'still',
+  'with', 'without', 'on', 'in', 'at', 'by', 'for', 'over', 'under', 'about',
+]);
+
+/**
+ * Collapse dotted acronyms (`U.S.`, `U.S.A.`, `D.O.J.`) into bare form
+ * (`US`, `USA`, `DOJ`) so the tokenizer doesn't split them into single-
+ * char tokens that fail the 2-6-char acronym rule. PR #3836 review:
+ * a valid summary using common dotted style ("the U.S. announced...")
+ * against an expanded headline ("United States imposed...") tokenized
+ * to `['U', 'S']` vs `['us']` (canonical) and never matched —
+ * false-flagging as hallucination.
+ *
+ * Match: a capital letter followed by a dot, then at least one more
+ * capital-letter-then-optional-dot pair. The second pair commitment
+ * prevents a sentence-final initial ("...J.") from false-positiving.
+ *
+ * Examples:
+ *   "the U.S. announced"             → "the US announced"
+ *   "U.S.A. delegation"              → "USA delegation"
+ *   "FBI raided J.D. Vance's office" → "FBI raided JD Vance's office"
+ *   "i.e., these things"             → "i.e., these things"  (lowercase, no match)
+ *   "end of sentence."               → "end of sentence."    (single dot, no run)
+ */
+function normalizeDottedAcronyms(text) {
+  return text.replace(/(\b[A-Z]\.(?:[A-Z]\.?)+)/g, (match) => match.replace(/\./g, ''));
+}
+
+export function extractProperNounSequences(text) {
+  if (typeof text !== 'string' || text.length === 0) return [];
+
+  // Normalize dotted acronyms BEFORE sentence-splitting so "U.S." isn't
+  // misread as a sentence boundary or split into ['U', 'S'].
+  const preprocessed = normalizeDottedAcronyms(text);
+
+  // Split into sentences so sentence-start handling can run per-sentence.
+  const sentences = preprocessed.split(/[.!?]+\s+|\n+/);
+
+  const sequences = [];
+  for (const rawSentence of sentences) {
+    const sentence = rawSentence.trim();
+    if (!sentence) continue;
+
+    // Tokenize: keep alphanumeric runs + apostrophes + hyphens
+    // (preserves "Mar-a-Lago", "O'Brien").
+    const tokens = sentence.split(/[^\p{L}\p{N}'’-]+/u).filter(Boolean);
+    if (tokens.length === 0) continue;
+
+    let current = [];
+    let bridgeBuffer = []; // joiners pending — kept only if another proper noun follows
+    let firstToken = true;
+
+    for (const token of tokens) {
+      // Strip trailing punctuation and possessive 's / ’s so
+      // "Beirut's" → "beirut" and "U.S." → "U.S" (handled below).
+      let stripped = token.replace(/[.,;:'’]+$/g, '');
+      stripped = stripped.replace(/['’]s$/i, '');
+      const tokenForLookup = stripped || token;
+      const isTitlePrefix = TITLE_PREFIX_STOP.has(stripped);
+      const isJoiner = PROPER_NOUN_JOINER.has(token.toLowerCase());
+      // Capitalized: at least 2 chars long. Single-letter capitalized
+      // tokens are sentence-final initials ("...J.D. Vance was met by Smith
+      // and J."), middle initials in names, or "I" (the pronoun, already
+      // handled by SENTENCE_START_AMBIGUOUS). None should register as
+      // a standalone proper noun.
+      const isCapitalized = token.length >= 2 && /^[A-Z]/.test(token);
+      const isAllCapsAcronym = /^[A-Z]{2,6}$/.test(token);
+      const isAmbiguousSentenceStart = firstToken
+        && !isAllCapsAcronym
+        && SENTENCE_START_AMBIGUOUS.has(token.toLowerCase());
+
+      // Title-prefix consume — even at sentence start, "Former" /
+      // "President" / "Dr." consume without registering.
+      if (isTitlePrefix && current.length === 0) {
+        firstToken = false;
+        continue;
+      }
+
+      // Skip ambiguous sentence-starters ("The", "It", "Breaking", …)
+      // that LOOK like proper nouns but are common-word capitalization.
+      if (isAmbiguousSentenceStart) {
+        firstToken = false;
+        continue;
+      }
+      firstToken = false;
+
+      if (isJoiner) {
+        if (current.length > 0) bridgeBuffer.push(token.toLowerCase());
+        continue;
+      }
+
+      if (isCapitalized || isAllCapsAcronym) {
+        // Flush pending bridge buffer into current sequence.
+        if (current.length > 0 && bridgeBuffer.length > 0) {
+          current.push(...bridgeBuffer);
+        }
+        bridgeBuffer = [];
+        // Use the punctuation/possessive-stripped form so "Beirut's"
+        // lands as "beirut", matching the headline's "Beirut".
+        current.push(tokenForLookup.toLowerCase());
+      } else {
+        // Lowercase non-joiner — ends current sequence.
+        if (current.length > 0) {
+          sequences.push(current);
+          current = [];
+        }
+        bridgeBuffer = [];
+      }
+    }
+    if (current.length > 0) sequences.push(current);
+  }
+
+  return sequences;
+}
+
+/**
+ * Normalize a token: if it's a known acronym variant, return the
+ * canonical key; otherwise return it unchanged (lower-cased).
+ */
+function normalizeToken(token) {
+  const lower = token.toLowerCase();
+  if (ACRONYM_NORMALIZE.has(lower)) return ACRONYM_NORMALIZE.get(lower);
+  if (DEMONYM_NORMALIZE.has(lower)) return DEMONYM_NORMALIZE.get(lower);
+  return lower;
+}
+
+/**
+ * Apply the same normalization to a token SEQUENCE: greedy match
+ * multi-word acronym expansions ("Democratic Republic of Congo" → 'dr
+ * congo' canonical) before single-token normalization. Returns a new
+ * sequence (array of canonical tokens).
+ */
+function normalizeSequence(sequence) {
+  const out = [];
+  let i = 0;
+  while (i < sequence.length) {
+    // Try multi-word matches first, longest first (5 → 4 → 3 → 2 tokens).
+    let matched = false;
+    for (let span = Math.min(5, sequence.length - i); span >= 2; span--) {
+      const candidate = sequence.slice(i, i + span).join(' ').toLowerCase();
+      if (ACRONYM_NORMALIZE.has(candidate)) {
+        out.push(ACRONYM_NORMALIZE.get(candidate));
+        i += span;
+        matched = true;
+        break;
+      }
+    }
+    if (matched) continue;
+    // Fall through to single-token normalization.
+    out.push(normalizeToken(sequence[i]));
+    i += 1;
+  }
+  return out;
+}
+
+/**
+ * Validate that every proper noun in `summary` has a matching
+ * contiguous subsequence in `headline` (after acronym + demonym
+ * normalization). The validator catches LLM-introduced invention.
+ *
+ * Returns `{ ok: true }` when every summary proper-noun sequence is
+ * grounded in the headline, OR when either input is malformed (defensive
+ * default — ship the LLM output rather than fall back on confusion).
+ *
+ * Returns `{ ok: false, hallucinated: [...] }` when at least one
+ * summary sequence has no matching contiguous subsequence in the
+ * headline. The first such sequence is returned; iterating to find
+ * all of them is not necessary for the fallback decision.
+ *
+ * @param {string} summary - the LLM-rewritten brief paragraph
+ * @param {string} headline - the source headline the LLM was given
+ * @returns {{ ok: boolean, hallucinated?: string[] }}
+ */
+export function validateNoHallucinatedProperNouns(summary, headline) {
+  // Defensive: malformed inputs return ok (ship the LLM output rather
+  // than fall back on confusion). Catches null, undefined, empty
+  // string, non-string, and weird unicode.
+  if (typeof summary !== 'string' || summary.length === 0) return { ok: true };
+  if (typeof headline !== 'string' || headline.length === 0) return { ok: true };
+
+  let summarySequences, headlineSequences;
+  try {
+    summarySequences = extractProperNounSequences(summary).map(normalizeSequence);
+    headlineSequences = extractProperNounSequences(headline).map(normalizeSequence);
+  } catch {
+    return { ok: true };
+  }
+
+  if (summarySequences.length === 0) return { ok: true };
+
+  // For each summary sequence, check whether at least one contiguous
+  // subsequence of it appears in some headline sequence.
+  for (const summarySeq of summarySequences) {
+    let found = false;
+    for (const headlineSeq of headlineSequences) {
+      if (containsSubsequence(headlineSeq, summarySeq)) {
+        found = true;
+        break;
+      }
+      // Also check the reverse: a single-token summary sequence
+      // (e.g., ['us']) matches if it appears anywhere in a longer
+      // headline sequence.
+      if (summarySeq.length === 1 && headlineSeq.includes(summarySeq[0])) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      return { ok: false, hallucinated: summarySeq };
+    }
+  }
+
+  return { ok: true };
+}
+
+/**
+ * Does `haystack` contain `needle` as a contiguous subsequence?
+ * Both are token arrays. Order matters; positions must be adjacent.
+ */
+function containsSubsequence(haystack, needle) {
+  if (needle.length === 0) return true;
+  if (needle.length > haystack.length) return false;
+  outer: for (let i = 0; i <= haystack.length - needle.length; i++) {
+    for (let j = 0; j < needle.length; j++) {
+      if (haystack[i + j] !== needle[j]) continue outer;
+    }
+    return true;
+  }
+  return false;
+}

--- a/tests/brief-llm-core.test.mjs
+++ b/tests/brief-llm-core.test.mjs
@@ -12,7 +12,7 @@
  * alongside.
  */
 
-import { describe, it } from 'node:test';
+import { describe, it, before } from 'node:test';
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
 
@@ -267,5 +267,204 @@ describe('parseWhyMattersV2 — multi-sentence, analyst-path only', () => {
     const out = parseWhyMattersV2(raw);
     assert.ok(out && !out.startsWith('\u201C'));
     assert.ok(out && !out.endsWith('\u201D'));
+  });
+});
+
+describe('validateNoHallucinatedProperNouns — May 19 regression + class', () => {
+  let validateNoHallucinatedProperNouns;
+  let extractProperNounSequences;
+  before(async () => {
+    ({ validateNoHallucinatedProperNouns, extractProperNounSequences } = await import('../shared/brief-llm-core.js'));
+  });
+
+  // Captured fixture: the actual 2026-05-19 LLM hallucination.
+  const MAY_19_LEBANON_HEADLINE =
+    "Lebanese president vows to 'do the impossible' to end war with Israel as strikes continue despite ceasefire";
+  const MAY_19_LEBANON_CAPTURED_SUMMARY =
+    "Lebanese President Michel Aoun pledged to pursue all avenues to end the ongoing conflict with Israel, even as Israeli strikes continued despite a declared ceasefire.";
+
+  it('REGRESSION (captured): "Michel Aoun" not in headline → flagged', () => {
+    const r = validateNoHallucinatedProperNouns(MAY_19_LEBANON_CAPTURED_SUMMARY, MAY_19_LEBANON_HEADLINE);
+    assert.equal(r.ok, false);
+    assert.ok(r.hallucinated.includes('michel') || r.hallucinated.includes('aoun'),
+      `expected hallucinated to include 'michel' or 'aoun'; got ${JSON.stringify(r.hallucinated)}`);
+  });
+
+  it('CLASS (synthesized variant 1): "President Michel Aoun reportedly stated..." → flagged', () => {
+    const summary = "President Michel Aoun reportedly stated he would pursue all paths to end the war.";
+    const r = validateNoHallucinatedProperNouns(summary, MAY_19_LEBANON_HEADLINE);
+    assert.equal(r.ok, false, 'LLM non-determinism must not let a different phrasing slip through');
+  });
+
+  it('CLASS (synthesized variant 2): "Lebanese leader Aoun..." → flagged', () => {
+    const summary = "Lebanese leader Aoun, who reportedly pledged action, faces ongoing strikes.";
+    const r = validateNoHallucinatedProperNouns(summary, MAY_19_LEBANON_HEADLINE);
+    assert.equal(r.ok, false);
+  });
+
+  it('CLASS (synthesized variant 3): "Aoun, the Lebanese president, said..." → flagged', () => {
+    const summary = "Aoun, the Lebanese president, said the war with Israel must end.";
+    const r = validateNoHallucinatedProperNouns(summary, MAY_19_LEBANON_HEADLINE);
+    assert.equal(r.ok, false);
+  });
+
+  it('happy path: every summary proper noun grounded in headline', () => {
+    // Note: the original draft of this test summary said "the planned US
+    // strike against Iran" — "US" is NOT in the headline, so the
+    // validator correctly flags that. Rewrite the summary to introduce
+    // only proper nouns the headline contains. This is exactly the
+    // contract: an LLM rewrite that ADDS a new entity ("US") gets
+    // flagged; one that paraphrases without introducing entities passes.
+    const headline = "Trump says Iran attack postponed at request of Gulf allies";
+    const summary = "Trump revealed that the planned attack against Iran was postponed at the request of Gulf allies.";
+    const r = validateNoHallucinatedProperNouns(summary, headline);
+    assert.equal(r.ok, true, `unexpectedly flagged: ${JSON.stringify(r)}`);
+  });
+
+  it('hallucination by addition: summary adds entity not in headline → flagged', () => {
+    // The "US" case from the failed draft test above — codified as its
+    // own regression. A real test of the hallucination class.
+    const headline = "Trump says Iran attack postponed at request of Gulf allies";
+    const summary = "Trump revealed that the planned US strike against Iran was postponed.";
+    const r = validateNoHallucinatedProperNouns(summary, headline);
+    assert.equal(r.ok, false, 'summary introduced "US" not in headline — must flag');
+  });
+
+  it('title-prefix stop list: "former President Trump" passes when headline has "Trump"', () => {
+    const headline = "Trump signs trade bill into law";
+    const summary = "Former President Trump approved the legislation today.";
+    const r = validateNoHallucinatedProperNouns(summary, headline);
+    assert.equal(r.ok, true);
+  });
+
+  it('demonym rule: "Israeli" headline ↔ "Israel" summary equivalent', () => {
+    const headline = "Israeli strikes hit Beirut suburbs";
+    const summary = "Israel struck Beirut's southern suburbs in pre-dawn raids.";
+    const r = validateNoHallucinatedProperNouns(summary, headline);
+    assert.equal(r.ok, true);
+  });
+
+  it('demonym rule: "Iranian" headline ↔ "Iran" summary equivalent', () => {
+    const headline = "Iranian officials confirm uranium enrichment progress";
+    const summary = "Iran confirmed reaching weapons-grade enrichment thresholds today.";
+    const r = validateNoHallucinatedProperNouns(summary, headline);
+    assert.equal(r.ok, true);
+  });
+
+  it('acronym↔expansion: WHO headline ↔ "World Health Organization" summary', () => {
+    const headline = "WHO declares Ebola emergency in DR Congo";
+    const summary = "World Health Organization declared the Ebola outbreak in Democratic Republic of Congo a public health emergency.";
+    const r = validateNoHallucinatedProperNouns(summary, headline);
+    assert.equal(r.ok, true);
+  });
+
+  it('acronym↔expansion: reverse direction (expansion headline ↔ acronym summary)', () => {
+    const headline = "United States imposes new sanctions on Cuba";
+    const summary = "The US announced new sanctions targeting Cuban leadership today.";
+    const r = validateNoHallucinatedProperNouns(summary, headline);
+    assert.equal(r.ok, true);
+  });
+
+  it('multi-word with joiner: "Democratic Republic of Congo" → preserved as one sequence', () => {
+    const seqs = extractProperNounSequences("The Democratic Republic of Congo declared an emergency.");
+    // Should be one sequence containing all 4 tokens, not 2 separate sequences.
+    const longest = seqs.reduce((max, s) => (s.length > max.length ? s : max), []);
+    assert.ok(longest.includes('democratic') && longest.includes('republic') && longest.includes('congo'),
+      `expected DRC tokens in one sequence; got ${JSON.stringify(seqs)}`);
+  });
+
+  it('sentence-start "The" not registered as a proper noun', () => {
+    const seqs = extractProperNounSequences("The UN said the EU agreed.");
+    // 'The' should not appear as a sequence; UN and EU should.
+    const flat = seqs.flat();
+    assert.ok(!flat.includes('the'));
+    assert.ok(flat.includes('un'));
+    assert.ok(flat.includes('eu'));
+  });
+
+  it('no proper nouns either side → ok', () => {
+    const r = validateNoHallucinatedProperNouns("the situation continues to evolve", "no proper nouns here");
+    assert.equal(r.ok, true);
+  });
+
+  it('out-of-scope: headline already contains a wrong name → validator does NOT fact-check', () => {
+    // Source-level errors are explicitly out of scope (see plan Scope Boundaries).
+    // The validator catches LLM invention only — if the headline ships the
+    // wrong name from a wire-service typo, the summary using that name OKs.
+    const headline = "Lebanese President Michel Aoun vows to end war"; // typo'd headline
+    const summary = "Michel Aoun pledged action today.";
+    const r = validateNoHallucinatedProperNouns(summary, headline);
+    assert.equal(r.ok, true);
+  });
+
+  it('headline has "Trump", summary adds "Mar-a-Lago" not in headline → flagged', () => {
+    const headline = "FBI raids Trump residence in Florida";
+    const summary = "FBI agents conducted a raid on Mar-a-Lago today.";
+    const r = validateNoHallucinatedProperNouns(summary, headline);
+    assert.equal(r.ok, false);
+  });
+
+  it('REGRESSION (PR #3836 review): dotted-acronym summary against bare headline → ok', () => {
+    // "U.S." tokenized as ['U', 'S'] — single-char tokens fail the
+    // 2–6-char acronym rule. Preprocessing pass `normalizeDottedAcronyms`
+    // collapses `U.S.` to `US` before tokenization so the existing
+    // acronym↔expansion normalization can do its job.
+    const headline = "US announces new sanctions on Iran";
+    const summary = "The U.S. announced new sanctions against Iran today.";
+    const r = validateNoHallucinatedProperNouns(summary, headline);
+    assert.equal(r.ok, true, `dotted-acronym summary should match bare headline; got ${JSON.stringify(r)}`);
+  });
+
+  it('REGRESSION (PR #3836 review): dotted-acronym summary against expanded headline → ok', () => {
+    const headline = "United States announces new sanctions on Iran";
+    const summary = "The U.S. announced new sanctions against Iran today.";
+    const r = validateNoHallucinatedProperNouns(summary, headline);
+    assert.equal(r.ok, true, `"U.S." summary should match "United States" headline; got ${JSON.stringify(r)}`);
+  });
+
+  it('REGRESSION (PR #3836 review): three-letter dotted acronym U.S.A.', () => {
+    const headline = "United States delegation arrives";
+    const summary = "The U.S.A. delegation arrived today.";
+    const r = validateNoHallucinatedProperNouns(summary, headline);
+    assert.equal(r.ok, true);
+  });
+
+  it('dotted-acronym extractor: "U.S." extracts as ["us"] sequence', () => {
+    const seqs = extractProperNounSequences("The U.S. announced sanctions.");
+    const flat = seqs.flat();
+    assert.ok(flat.includes('us'), `expected 'us' in extracted sequences; got ${JSON.stringify(seqs)}`);
+  });
+
+  it('dotted-acronym extractor does not false-positive on lowercase "i.e."', () => {
+    // Lowercase dotted patterns (i.e., e.g., p.m., a.m.) must NOT collapse.
+    const seqs = extractProperNounSequences("The result was, i.e., a postponement.");
+    const flat = seqs.flat();
+    // No proper noun expected from "i.e."; should not become "ie" and register.
+    assert.ok(!flat.includes('ie'));
+  });
+
+  it('dotted-acronym single sentence-final initial does not over-collapse', () => {
+    // "I had a meeting with J." — single capital-then-dot at sentence end
+    // should NOT collapse (needs at least 2 letter-dot pairs to trigger).
+    const seqs = extractProperNounSequences("I had a meeting with J.");
+    const flat = seqs.flat();
+    // 'j' alone shouldn't appear (single-char, not all-caps acronym ≥ 2).
+    assert.ok(!flat.includes('j'));
+  });
+
+  it('defensive: malformed inputs return ok (do not throw)', () => {
+    assert.doesNotThrow(() => validateNoHallucinatedProperNouns(undefined, "x"));
+    assert.equal(validateNoHallucinatedProperNouns(undefined, "x").ok, true);
+    assert.equal(validateNoHallucinatedProperNouns(null, "x").ok, true);
+    assert.equal(validateNoHallucinatedProperNouns("", "x").ok, true);
+    assert.equal(validateNoHallucinatedProperNouns("x", "").ok, true);
+    assert.equal(validateNoHallucinatedProperNouns(42, "x").ok, true);
+    assert.equal(validateNoHallucinatedProperNouns("<script>alert(1)</script>", "x").ok, true);
+  });
+
+  it('defensive: 10x-longer summaries do not crash extractor', () => {
+    const headline = "Trump signs bill";
+    const summary = "Trump ".repeat(2000) + "approved the legislation.";
+    assert.doesNotThrow(() => validateNoHallucinatedProperNouns(summary, headline));
   });
 });

--- a/tests/scripts-railway-nixpacks-no-escape-import.test.mts
+++ b/tests/scripts-railway-nixpacks-no-escape-import.test.mts
@@ -32,10 +32,16 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
 const scriptsDir = resolve(repoRoot, 'scripts');
 
+// Entry points that run under Railway nixpacks with `rootDirectory=scripts`.
+// PR #3836 review added `scripts/seed-insights.mjs` after a `../shared/`
+// import slipped through review (the test's pre-existing coverage stopped
+// at the three forecast/simulation services). Any new `scripts/*.mjs`
+// that ships as a Railway service MUST be added here.
 const ENTRY_POINTS = [
   'scripts/seed-forecasts.mjs',
   'scripts/process-simulation-tasks.mjs',
   'scripts/process-deep-forecast-tasks.mjs',
+  'scripts/seed-insights.mjs',
 ];
 
 const IMPORT_RE = /(?:^|[\s;])(?:import\b[\s\S]*?\bfrom|import|export\b[\s\S]*?\bfrom)\s+['"]([^'"]+)['"]/gm;


### PR DESCRIPTION
## Symptom

The 2026-05-19 0801 Pro brief shipped \"Lebanese President Michel Aoun pledged...\" against a source headline that contained no name (\"Lebanese president vows to 'do the impossible' to end war with Israel...\"). Current Lebanese president is Joseph Aoun; Michel Aoun left office in 2022. The LLM invented \"Michel Aoun\" despite the prompt explicitly forbidding invention. One of 5 distinct content-quality defects on the same brief; this PR addresses defect #1.

## Root cause

`scripts/_insights-brief.mjs:30-39` `briefSystemPrompt` instructs the LLM \"Do not invent proper nouns (people, organizations, countries) that are not in the headline.\" The instruction was correct. The LLM violated it anyway. Prompts that say \"do not invent\" aren't mechanically enforceable on every output.

## Fix

Add `validateNoHallucinatedProperNouns(summary, headline)` to `shared/brief-llm-core.js`. Extract proper-noun sequences from both texts, normalize via acronym + demonym tables, and verify each summary sequence has a matching contiguous subsequence in the headline. When a summary sequence has no headline match, the summary is rejected.

**Extractor rules pinned** (per the plan, after `/ce-doc-review` flagged these as load-bearing — see [origin plan U2 \"Approach (H2 fix)\"](https://github.com/koala73/worldmonitor/blob/main/docs/plans/2026-05-19-001-fix-brief-content-quality-regressions-plan.md)):

- `TITLE_PREFIX_STOP` — \"former President Trump\" extracts as `['trump']` (consume the title-prefix, don't register it).
- `PROPER_NOUN_JOINER` — \"Democratic Republic of Congo\" stays one sequence, bridged by lowercase joiners (`of`, `the`, `and`, `for`, …).
- All-caps acronym rule — 2–6-char ALL CAPS tokens (WHO, UN, NATO, IDF, …) register as proper nouns even at sentence start.
- `SENTENCE_START_AMBIGUOUS` — explicit stop list of common sentence-starters (\"The\", \"It\", \"Breaking\", \"Meanwhile\", …) that LOOK proper-noun-like but aren't. Real proper nouns at sentence start (\"Trump said...\", \"Israel announced...\") pass through.
- Possessive `'s` stripped (\"Beirut's\" → \"beirut\").
- `ACRONYM_NORMALIZE` — 24 acronym↔expansion groups, bidirectional (`WHO ↔ World Health Organization`, `US ↔ United States`, `EU ↔ European Union`, …).
- `DEMONYM_NORMALIZE` — 50+ demonym↔nation mappings (`Israeli ↔ Israel`, `Iranian ↔ Iran`, `Cuban ↔ Cuba`, …).

**Shadow-mode rollout** (env-flag controlled):
- `BRIEF_VALIDATOR_MODE=shadow` (DEFAULT): violations logged to console as `[brief_hallucination SHADOW]` but the LLM output ships unchanged. Lets us measure false-positive rate in production without breaking anything.
- `BRIEF_VALIDATOR_MODE=enforce`: violations replace the LLM summary with the source headline (R1 of the plan: \"falls back to a safe summary (headline-grounded template)\"). Flip via Railway env after the 7-day shadow window confirms <5% false-positive rate.

**Defensive against malformed inputs** (undefined, null, empty string, non-string, HTML-encoded, 10KB long): all return `{ ok: true }` without throwing. The validator can never crash brief generation.

## Test plan

- [x] 17 new test cases covering:
  - REGRESSION (captured May 19 hallucination): \"Michel Aoun\" not in headline → flagged ✓
  - CLASS (3 synthesized hallucination variants): LLM non-determinism guard ✓
  - Happy path: every summary proper noun grounded in headline ✓
  - Hallucination by addition (\"US\" introduced from nowhere) → flagged ✓
  - Title-prefix stop list: \"former President Trump\" passes ✓
  - Demonym rules (Israeli↔Israel, Iranian↔Iran) ✓
  - Acronym↔expansion (both directions): `WHO ↔ World Health Organization`, `US ↔ United States` ✓
  - Multi-word with joiner: \"Democratic Republic of Congo\" preserved as one sequence ✓
  - Sentence-start `The` not registered ✓
  - Out-of-scope: headline already contains wrong name → validator does NOT fact-check (documented limit) ✓
  - Defensive: malformed inputs return ok without throwing ✓
  - Defensive: 10x-longer summaries don't crash ✓
- [x] All 41 tests pass (`npx tsx --test tests/brief-llm-core.test.mjs`)
- [x] Mirror parity test passes (`tests/scripts-shared-mirror.test.mjs`) — `shared/brief-llm-core.js` and `scripts/shared/brief-llm-core.js` are byte-for-byte equal
- [x] `npm run typecheck` clean
- [x] `biome lint` clean on changed files
- [ ] **After deploy: monitor the `[brief_hallucination SHADOW]` log frequency for 7 days. False-positive rate ≥5% → expand acronym/demonym lists before flipping enforce. ≤5% → flip `BRIEF_VALIDATOR_MODE=enforce`.**

## Origin

PR-2 of the 4-PR Phase 1 wave from [`docs/plans/2026-05-19-001-fix-brief-content-quality-regressions-plan.md`](https://github.com/koala73/worldmonitor/blob/main/docs/plans/2026-05-19-001-fix-brief-content-quality-regressions-plan.md).

## Out of scope (documented in plan Scope Boundaries)

- **Source-level fact-checking.** Validator catches LLM invention only. If a wire-service typo ships the wrong name in the headline, validator OKs the summary using that name. Brief pipeline isn't fact-checking source data; that's separate.
- **Full NER.** Heuristic rules cover the surface PR-2 needs. Deeper NER is deferred unless shadow-mode data surfaces a class the heuristics miss.
- **LLM provider/model change.** Validator is provider-agnostic — operates on output text, not metadata. Any provider that produces the same hallucination class triggers the same fallback.