### PR TITLE
fix(analytics): mute Umami on tech/finance/commodity while upstream #4183 is open

### DIFF
--- a/index.html
+++ b/index.html
@@ -117,8 +117,17 @@
     }
     </script>
 
-    <!-- Umami Analytics — async (not defer): defer blocks DOMContentLoaded if abacus is slow/down (15s observed when origin 502s). -->
-    <script async src="https://abacus.worldmonitor.app/script.js" data-website-id="e8800335-c853-46a8-8497-c993ed2f58bc" data-domains="worldmonitor.app,tech.worldmonitor.app,finance.worldmonitor.app,commodity.worldmonitor.app,happy.worldmonitor.app"></script>
+    <!--
+      Umami Analytics — async (not defer): defer blocks DOMContentLoaded if abacus is slow/down (15s observed when origin 502s).
+      data-domains is temporarily reduced to worldmonitor.app + happy.worldmonitor.app while upstream Umami issue #4183
+      (https://github.com/umami-software/umami/issues/4183) is open — v3.1.0 has a race in
+      prisma.sessionData.updateMany() that returns HTTP 500 from /api/send for 4-8% of requests
+      across all listed hosts. Self-hosted Umami has no fix tag yet (master since 2026-04-17 has
+      22 commits but none touch sessionData). Tracker self-disables when current hostname isn't in
+      data-domains — same mechanism that keeps energy.worldmonitor.app silent. Restore tech, finance,
+      and commodity once #4183 ships in a tagged release.
+    -->
+    <script async src="https://abacus.worldmonitor.app/script.js" data-website-id="e8800335-c853-46a8-8497-c993ed2f58bc" data-domains="worldmonitor.app,happy.worldmonitor.app"></script>
 
     <!-- Favicons -->
     <link rel="icon" type="image/x-icon" href="/favico/favicon.ico" />


### PR DESCRIPTION
## Why

`POST https://abacus.worldmonitor.app/api/send` returns 500 for ~4-8% of requests on `tech`, `finance`, and `commodity` variants. Grafana shows the error rate climbing steadily; p99 response time spikes to 25s during the storm.

Root cause is **upstream**, not us: [`umami-software/umami#4183`](https://github.com/umami-software/umami/issues/4183) — a race in `prisma.sessionData.updateMany()` returns `Unique constraint failed on the fields: (session_data_id)` for concurrent same-session events. Logs from our Railway-hosted Umami confirm the exact stack trace + Prisma client version (`7.6.0`) called out in the upstream report.

Maintainer Maxime-J acknowledged the bug on 2026-04-22 with a proposed fix (composite unique on `(sessionId, dataKey)` + switch to `upsert`), but **no commit has landed on master**. 22 commits since 3.1.0 — all dependency bumps + a chart canvas fix; none touch `sessionData`. There is no upgrade target.

## What this PR does

Reduces `data-domains` in `index.html:121` from 5 hosts to 2. Umami's tracker self-disables when the current hostname isn't in `data-domains` — same mechanism that's been keeping `energy.worldmonitor.app` quiet (it was never enrolled).

Dropped:
- `tech.worldmonitor.app`
- `finance.worldmonitor.app`
- `commodity.worldmonitor.app`

Kept:
- `worldmonitor.app` (main, residual analytics signal)
- `happy.worldmonitor.app` (low traffic, near-zero 500 volume)

## Companion change (already shipped, not in this diff)

Railway service `umami` had `source.image = umamisoftware/umami:2.13.2` in config but was actually running `umamisoftware/umami:postgresql-latest` (resolved digest = `latest` = `3` = `3.1` = **`3.1.0`**, from a manual redeploy on 2026-05-01). The rolling tag was free to drift back to a broken digest on the next redeploy. I pinned source to `umamisoftware/umami:3.1.0` via `serviceInstanceUpdate` — no redeploy triggered since the digest is identical to what's already running.

## Tradeoff

`worldmonitor.app` + `happy.worldmonitor.app` will still produce a small 500 stream — same root cause, just lower volume. Drop them too if you want the metric flat at 0%; I kept them so the analytics product isn't fully blacked out for the days-to-weeks window before upstream ships a tagged fix.

## Test plan

- [ ] Deploy preview → load `https://tech.worldmonitor.app/` (or whichever variant the preview maps to) → DevTools Network → confirm `POST .../api/send` is absent (tracker silenced itself)
- [ ] Load `https://worldmonitor.app/` → confirm `POST .../api/send` still fires (kept active)
- [ ] Grafana `Request Error Rate` on the Umami service should drop materially within minutes of the deploy reaching production

## To restore

Add the three subdomains back to `data-domains` once `umami-software/umami` ships a tagged release containing the #4183 fix. Subscribe to the issue to be notified.