### PR TITLE
fix(panel-layout): guard dynamic-import destructure for Safari ESM-cache edge (WORLDMONITOR-R4)

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1039,6 +1039,7 @@ export class PanelLayoutManager implements AppModule {
     this.createPanel('gdelt-intel', () => new GdeltIntelPanel());
 
     import('@/components/DeductionPanel').then(({ DeductionPanel }) => {
+      if (typeof DeductionPanel !== 'function') return;
       const deductionPanel = new DeductionPanel(() => this.ctx.allNews);
       this.ctx.panels['deduction'] = deductionPanel;
       const el = deductionPanel.getElement();
@@ -1054,9 +1055,13 @@ export class PanelLayoutManager implements AppModule {
       }
       this.applyPanelSettings();
       this.updatePanelGating(getAuthState());
-    });
+    }).catch(() => { /* dynamic import failure: stale-chunk handler in main.ts beforeSend already suppresses, swallow second unhandledrejection */ });
 
+    // Guard against named-export resolving to undefined (Safari ESM cache / proxy truncation
+    // edge case, WORLDMONITOR-R4): `new undefined` surfaced as
+    // `TypeError: undefined is not a constructor (evaluating 'new m')` from this exact line.
     import('@/components/RegionalIntelligenceBoard').then(({ RegionalIntelligenceBoard }) => {
+      if (typeof RegionalIntelligenceBoard !== 'function') return;
       const regionalBoard = new RegionalIntelligenceBoard();
       this.ctx.panels['regional-intelligence'] = regionalBoard;
       const el = regionalBoard.getElement();
@@ -1072,7 +1077,7 @@ export class PanelLayoutManager implements AppModule {
       }
       this.applyPanelSettings();
       this.updatePanelGating(getAuthState());
-    });
+    }).catch(() => { /* dynamic import failure: stale-chunk handler in main.ts beforeSend already suppresses, swallow second unhandledrejection */ });
 
     if (this.shouldCreatePanel('cii')) {
       const ciiPanel = new CIIPanel();

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1038,6 +1038,10 @@ export class PanelLayoutManager implements AppModule {
 
     this.createPanel('gdelt-intel', () => new GdeltIntelPanel());
 
+    // Two-arg `.then(onFulfilled, onRejected)` so the rejection handler ONLY catches
+    // the dynamic-import promise itself (already suppressed in main.ts beforeSend) and
+    // does NOT swallow synchronous throws from the callback body (panel construction,
+    // makeDraggable, etc.) — those must continue to surface in Sentry as real bugs.
     import('@/components/DeductionPanel').then(({ DeductionPanel }) => {
       if (typeof DeductionPanel !== 'function') return;
       const deductionPanel = new DeductionPanel(() => this.ctx.allNews);
@@ -1055,7 +1059,7 @@ export class PanelLayoutManager implements AppModule {
       }
       this.applyPanelSettings();
       this.updatePanelGating(getAuthState());
-    }).catch(() => { /* dynamic import failure: stale-chunk handler in main.ts beforeSend already suppresses, swallow second unhandledrejection */ });
+    }, () => undefined);
 
     // Guard against named-export resolving to undefined (Safari ESM cache / proxy truncation
     // edge case, WORLDMONITOR-R4): `new undefined` surfaced as
@@ -1077,7 +1081,7 @@ export class PanelLayoutManager implements AppModule {
       }
       this.applyPanelSettings();
       this.updatePanelGating(getAuthState());
-    }).catch(() => { /* dynamic import failure: stale-chunk handler in main.ts beforeSend already suppresses, swallow second unhandledrejection */ });
+    }, () => undefined);
 
     if (this.shouldCreatePanel('cii')) {
       const ciiPanel = new CIIPanel();

--- a/tests/panel-layout-dynamic-import-guard.test.mts
+++ b/tests/panel-layout-dynamic-import-guard.test.mts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { describe, it } from 'node:test';
+
+// Regression coverage for WORLDMONITOR-R4: dynamic `import(...).then(({ Foo }) => new Foo(...))`
+// must guard against the destructured named export resolving to `undefined`, and must attach
+// a `.catch()` to avoid an unhandled-rejection event when the browser's module loader returns
+// an incomplete module (Safari ESM cache, proxy truncation, etc.).
+//
+// The two call sites at src/app/panel-layout.ts:1041 (DeductionPanel) and :1059
+// (RegionalIntelligenceBoard) are the only ones in the file that use the destructure-and-
+// construct pattern; any sibling that adopts the same shape should add the same guards.
+
+// Note: we deliberately do NOT strip comments before grepping — panel-layout.ts contains
+// regex literals like `/\/\*.../` that would defeat a naive block-comment stripper. The
+// patterns we assert below (literal `import('@/components/Foo').then(...)` with a typeof
+// guard inside the callback) won't false-match inside a comment in practice.
+
+// Walk forward from the start of a `.then(arg => { ... })` callback, tracking brace depth,
+// and return [openIdx, closeIdx] for the callback body. Lets us assert on the body in
+// isolation even when it contains nested `if (...) { ... }` blocks that would defeat a
+// lazy `[\s\S]*?` regex.
+function findCallbackBody(source: string, callbackHeader: RegExp): { body: string; afterIdx: number } | null {
+  const headerMatch = callbackHeader.exec(source);
+  if (!headerMatch) return null;
+  const openIdx = source.indexOf('{', headerMatch.index + headerMatch[0].length - 1);
+  if (openIdx < 0) return null;
+  let depth = 1;
+  for (let i = openIdx + 1; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return { body: source.slice(openIdx + 1, i), afterIdx: i + 1 };
+    }
+  }
+  return null;
+}
+
+function assertGuardedDynamicImport(source: string, modulePath: string, exportName: string) {
+  const callbackHeader = new RegExp(
+    `import\\(['"]${modulePath.replace(/[.*+?^${}()|[\\\]\\\\]/g, '\\$&')}['"]\\)\\.then\\(\\(\\{\\s*${exportName}\\s*\\}\\)\\s*=>\\s*\\{`,
+  );
+  const callback = findCallbackBody(source, callbackHeader);
+  assert.ok(callback, `${exportName} dynamic import not found at expected call site`);
+  assert.match(
+    callback.body,
+    new RegExp(`typeof\\s+${exportName}\\s*!==?\\s*['"]function['"]\\s*\\)\\s*return`),
+    `${exportName} .then() must early-return if the destructured class is not a function`,
+  );
+  // After the closing `}` of the .then callback, `.catch(` must appear before any
+  // newline-then-non-whitespace (i.e. before the next statement in the function body).
+  const tail = source.slice(callback.afterIdx, callback.afterIdx + 200);
+  assert.match(
+    tail,
+    /^\s*\)\s*\.catch\(/,
+    `${exportName} dynamic import must chain .catch(...) onto its .then(...) callback`,
+  );
+}
+
+describe('panel-layout dynamic-import guard (WORLDMONITOR-R4)', () => {
+  const filePath = new URL('../src/app/panel-layout.ts', import.meta.url);
+
+  it('RegionalIntelligenceBoard import has typeof guard + .catch', async () => {
+    const source = await readFile(filePath, 'utf8');
+    assertGuardedDynamicImport(source, '@/components/RegionalIntelligenceBoard', 'RegionalIntelligenceBoard');
+  });
+
+  it('DeductionPanel import has typeof guard + .catch', async () => {
+    const source = await readFile(filePath, 'utf8');
+    assertGuardedDynamicImport(source, '@/components/DeductionPanel', 'DeductionPanel');
+  });
+});

--- a/tests/panel-layout-dynamic-import-guard.test.mts
+++ b/tests/panel-layout-dynamic-import-guard.test.mts
@@ -3,36 +3,87 @@ import { readFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
 
 // Regression coverage for WORLDMONITOR-R4: dynamic `import(...).then(({ Foo }) => new Foo(...))`
-// must guard against the destructured named export resolving to `undefined`, and must attach
-// a `.catch()` to avoid an unhandled-rejection event when the browser's module loader returns
-// an incomplete module (Safari ESM cache, proxy truncation, etc.).
+// must guard against the destructured named export resolving to `undefined`, AND must pass an
+// onRejected handler as the SECOND argument to `.then(...)` so the import-promise rejection is
+// suppressed without swallowing synchronous throws from inside the .then() callback body
+// (panel construction, getElement, makeDraggable, etc.) — those must keep surfacing in Sentry.
 //
 // The two call sites at src/app/panel-layout.ts:1041 (DeductionPanel) and :1059
 // (RegionalIntelligenceBoard) are the only ones in the file that use the destructure-and-
 // construct pattern; any sibling that adopts the same shape should add the same guards.
 
-// Note: we deliberately do NOT strip comments before grepping — panel-layout.ts contains
-// regex literals like `/\/\*.../` that would defeat a naive block-comment stripper. The
-// patterns we assert below (literal `import('@/components/Foo').then(...)` with a typeof
-// guard inside the callback) won't false-match inside a comment in practice.
+// Note: we deliberately do NOT strip comments via a naive regex before grepping —
+// panel-layout.ts contains regex literals like `/\/\*.../` that would defeat a naive
+// block-comment stripper. Instead, the brace walker below is token-aware: it skips over
+// strings, template literals, line comments, and block comments so `{` / `}` characters
+// inside those tokens don't confuse the depth tracker (greptile P2 robustness ask).
 
-// Walk forward from the start of a `.then(arg => { ... })` callback, tracking brace depth,
-// and return [openIdx, closeIdx] for the callback body. Lets us assert on the body in
-// isolation even when it contains nested `if (...) { ... }` blocks that would defeat a
-// lazy `[\s\S]*?` regex.
+// Walk forward from the first `{` after a `.then(arg => ` header, tracking brace depth
+// while skipping JS tokens that can contain `{` or `}` characters (strings, template
+// literals, comments). Returns the callback body slice and the index immediately after
+// the closing `}` so callers can assert on what follows the callback.
 function findCallbackBody(source: string, callbackHeader: RegExp): { body: string; afterIdx: number } | null {
   const headerMatch = callbackHeader.exec(source);
   if (!headerMatch) return null;
   const openIdx = source.indexOf('{', headerMatch.index + headerMatch[0].length - 1);
   if (openIdx < 0) return null;
   let depth = 1;
-  for (let i = openIdx + 1; i < source.length; i++) {
+  let i = openIdx + 1;
+  while (i < source.length) {
     const ch = source[i];
-    if (ch === '{') depth++;
-    else if (ch === '}') {
+    // Line comment: skip to end of line
+    if (ch === '/' && source[i + 1] === '/') {
+      const nl = source.indexOf('\n', i + 2);
+      i = nl < 0 ? source.length : nl + 1;
+      continue;
+    }
+    // Block comment: skip to closing */
+    if (ch === '/' && source[i + 1] === '*') {
+      const end = source.indexOf('*/', i + 2);
+      i = end < 0 ? source.length : end + 2;
+      continue;
+    }
+    // Single or double-quoted string: skip with escape awareness
+    if (ch === '"' || ch === "'") {
+      const quote = ch;
+      i++;
+      while (i < source.length) {
+        const sc = source[i];
+        if (sc === '\\') { i += 2; continue; }
+        if (sc === quote) { i++; break; }
+        i++;
+      }
+      continue;
+    }
+    // Template literal: skip with escape awareness; nested `${...}` braces must still count
+    // toward the OUTER block depth because they're real expression-position braces.
+    // The simpler and sufficient choice here is to NOT count `{`/`}` inside the raw template
+    // text, but DO count them inside `${...}` interpolations (treat the interpolation as
+    // normal code). To keep the walker compact, we track interpolation depth separately.
+    if (ch === '`') {
+      i++;
+      let interp = 0;
+      while (i < source.length) {
+        const tc = source[i];
+        if (tc === '\\') { i += 2; continue; }
+        if (interp === 0 && tc === '`') { i++; break; }
+        if (interp === 0 && tc === '$' && source[i + 1] === '{') { interp = 1; i += 2; continue; }
+        if (interp > 0) {
+          if (tc === '{') interp++;
+          else if (tc === '}') { interp--; if (interp === 0) { i++; continue; } }
+        }
+        i++;
+      }
+      continue;
+    }
+    if (ch === '{') { depth++; i++; continue; }
+    if (ch === '}') {
       depth--;
       if (depth === 0) return { body: source.slice(openIdx + 1, i), afterIdx: i + 1 };
+      i++;
+      continue;
     }
+    i++;
   }
   return null;
 }
@@ -48,26 +99,72 @@ function assertGuardedDynamicImport(source: string, modulePath: string, exportNa
     new RegExp(`typeof\\s+${exportName}\\s*!==?\\s*['"]function['"]\\s*\\)\\s*return`),
     `${exportName} .then() must early-return if the destructured class is not a function`,
   );
-  // After the closing `}` of the .then callback, `.catch(` must appear before any
-  // newline-then-non-whitespace (i.e. before the next statement in the function body).
+  // After the callback's closing `}`, the next non-whitespace must be `, <onRejected>)`
+  // — the two-arg `.then(onFulfilled, onRejected)` form. Specifically forbid the
+  // `.then(...).catch(...)` shape because that swallows synchronous throws from
+  // inside the callback body, masking real panel-construction bugs from Sentry.
   const tail = source.slice(callback.afterIdx, callback.afterIdx + 200);
   assert.match(
     tail,
+    /^\s*,\s*\([^)]*\)\s*=>/,
+    `${exportName} dynamic import must use the two-arg .then(onFulfilled, onRejected) form (not .then(...).catch(...) — that would swallow callback throws)`,
+  );
+  // Belt-and-braces: explicitly forbid a `.catch(` chained directly after the .then's
+  // closing `)`. If someone re-introduces the bad pattern they get a clear failure.
+  assert.doesNotMatch(
+    tail,
     /^\s*\)\s*\.catch\(/,
-    `${exportName} dynamic import must chain .catch(...) onto its .then(...) callback`,
+    `${exportName} dynamic import MUST NOT use .then(...).catch(...) — use the two-arg .then(onFulfilled, onRejected) form so callback throws still surface in Sentry`,
   );
 }
 
 describe('panel-layout dynamic-import guard (WORLDMONITOR-R4)', () => {
   const filePath = new URL('../src/app/panel-layout.ts', import.meta.url);
 
-  it('RegionalIntelligenceBoard import has typeof guard + .catch', async () => {
+  it('RegionalIntelligenceBoard import has typeof guard + onRejected arg', async () => {
     const source = await readFile(filePath, 'utf8');
     assertGuardedDynamicImport(source, '@/components/RegionalIntelligenceBoard', 'RegionalIntelligenceBoard');
   });
 
-  it('DeductionPanel import has typeof guard + .catch', async () => {
+  it('DeductionPanel import has typeof guard + onRejected arg', async () => {
     const source = await readFile(filePath, 'utf8');
     assertGuardedDynamicImport(source, '@/components/DeductionPanel', 'DeductionPanel');
+  });
+
+  it('token-aware brace walker skips strings/templates/comments', () => {
+    // Synthetic fixture: braces inside strings, templates, line comments, block comments,
+    // and ${...} interpolations MUST NOT confuse the depth tracker.
+    const fixture = `import('@/components/Foo').then(({ Foo }) => {
+      const s = "}{}{";
+      const t = \`outer \${ {a: 1} } inner\`;
+      // }}}
+      /* { { { } } } */
+      if (typeof Foo !== 'function') return;
+      const r = new Foo();
+    }, () => undefined);`;
+    assertGuardedDynamicImport(fixture, '@/components/Foo', 'Foo');
+  });
+
+  it('synthetic mutation: missing typeof guard fails the assert', async () => {
+    // If a future PR drops the typeof guard, the test must fail loudly (not silently pass).
+    const fixture = `import('@/components/Foo').then(({ Foo }) => {
+      const r = new Foo();
+    }, () => undefined);`;
+    assert.throws(
+      () => assertGuardedDynamicImport(fixture, '@/components/Foo', 'Foo'),
+      /must early-return if the destructured class is not a function/,
+    );
+  });
+
+  it('synthetic mutation: .then(...).catch(...) form fails the assert', async () => {
+    // The pre-greptile pattern. Must be rejected: it swallows callback throws.
+    const fixture = `import('@/components/Foo').then(({ Foo }) => {
+      if (typeof Foo !== 'function') return;
+      const r = new Foo();
+    }).catch(() => undefined);`;
+    assert.throws(
+      () => assertGuardedDynamicImport(fixture, '@/components/Foo', 'Foo'),
+      /two-arg \.then\(onFulfilled, onRejected\) form/,
+    );
   });
 });


### PR DESCRIPTION
## Summary

- **Sentry WORLDMONITOR-R4** fired 4 events / 3 users / 6 days on Safari 26.3–26.4 (Mac) as `TypeError: undefined is not a constructor (evaluating 'new m')` from `src/app/panel-layout.ts:1059`. Frame `context` from Sentry's REST API revealed the minified destructure `({RegionalIntelligenceBoard:m})=>{...new m...}` — the named export came back **undefined even though the chunk loaded** (curl on the live CDN showed both the main bundle and `RegionalIntelligenceBoard-Cu9_Y8xY.js` returning HTTP 200 with `export{ne as RegionalIntelligenceBoard}` intact). Most likely a Safari ESM-cache edge case, proxy mid-stream truncation, or extension interception. The existing beforeSend gate `Failed to fetch dynamically imported module` doesn't match this shape because the chunk **did** load.
- Added `typeof X !== 'function'` early-return + `.catch()` to both sister sites: the failing `RegionalIntelligenceBoard` import at line 1059 **and** the identical-shape `DeductionPanel` import two lines above at 1041 (same risk profile, same fix).
- Added `tests/panel-layout-dynamic-import-guard.test.mts` — a brace-aware source walker (lazy `[\s\S]*?` can't span nested `if (grid) { ... }`) that asserts the guard + `.catch()` are present at both call sites; removing either fails the test with a specific message naming the missing pattern.
- Marked the Sentry issue resolved with `inNextRelease: true` so it auto-reopens if it recurs after this release ships.

## Test plan

- [x] `npm run typecheck` — PASS
- [x] `npm run typecheck:api` — PASS
- [x] `npm run lint` (biome) — PASS
- [x] `npm run test:data` — PASS (9354 tests)
- [x] `npm run lint:md` — PASS
- [x] `npm run version:check` — PASS
- [x] api/*.js esbuild bundle check — PASS
- [x] `node --test tests/edge-functions.test.mjs` — PASS (183 tests)
- [x] New `tests/panel-layout-dynamic-import-guard.test.mts` — PASS (2/2)
- [ ] After deploy: Sentry WORLDMONITOR-R4 event count stays at 0 / does not auto-reopen