### PR TITLE
fix(mcp): return HTTP 401 + WWW-Authenticate on invalid env-key (closes todos/076)

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -2999,7 +2999,13 @@ async function resolveAuthContext(
   }
   const validKeys = (process.env.WORLDMONITOR_VALID_KEYS || '').split(',').filter(Boolean);
   if (!await timingSafeIncludes(candidateKey, validKeys)) {
-    return { ok: false, response: rpcError(null, -32001, 'Invalid API key') };
+    return {
+      ok: false,
+      response: new Response(
+        JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'Invalid API key' } }),
+        { status: 401, headers: { 'Content-Type': 'application/json', 'WWW-Authenticate': wwwAuthHeader(resourceMetadataUrl, 'invalid_token'), ...corsHeaders } },
+      ),
+    };
   }
   return { ok: true, context: { kind: 'env_key', apiKey: candidateKey } };
 }

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -70,10 +70,13 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(body.error?.code, -32001);
   });
 
-  it('returns JSON-RPC -32001 when invalid API key provided', async () => {
+  it('returns HTTP 401 + WWW-Authenticate when invalid API key provided', async () => {
     const req = makeReq('POST', initBody(), { 'X-WorldMonitor-Key': 'wrong_key' });
     const res = await handler(req);
-    assert.equal(res.status, 200);
+    assert.equal(res.status, 401);
+    const wwwAuth = res.headers.get('www-authenticate') ?? '';
+    assert.ok(wwwAuth.includes('Bearer realm="worldmonitor"'), 'must include WWW-Authenticate Bearer realm');
+    assert.ok(wwwAuth.includes('error="invalid_token"'), 'must include error="invalid_token" per RFC 6750');
     const body = await res.json();
     assert.equal(body.error?.code, -32001);
   });

--- a/todos/076-complete-p1-mcp-auth-failure-must-return-http-401.md
+++ b/todos/076-complete-p1-mcp-auth-failure-must-return-http-401.md
@@ -91,11 +91,12 @@ Use **Option 2**. Distinguishing "Bearer present but invalid" from "no auth" is 
 
 ## Acceptance Criteria
 
-- [ ] `POST /mcp` with expired/unknown Bearer token returns HTTP 401 (not 200)
-- [ ] HTTP 401 response includes `WWW-Authenticate: Bearer realm="worldmonitor", error="invalid_token"`
-- [ ] `POST /mcp` with no credentials returns HTTP 200 with JSON-RPC `-32001` error (existing behavior for non-OAuth clients)
-- [ ] `POST /mcp` with valid Bearer token works normally
-- [ ] curl test confirms: `curl -si -X POST /mcp -H "Authorization: Bearer invalid" | head -5` shows `HTTP/1.1 401`
+- [x] `POST /mcp` with expired/unknown Bearer token returns HTTP 401 (not 200)
+- [x] HTTP 401 response includes `WWW-Authenticate: Bearer realm="worldmonitor", error="invalid_token"`
+- [x] `POST /mcp` with no credentials returns HTTP 401 + `WWW-Authenticate` (upgraded from the original ACG, which permitted 200; full RFC 6750 compliance now applies on every auth-failure branch)
+- [x] `POST /mcp` with valid Bearer token works normally
+- [x] curl test confirms: `curl -si -X POST /mcp -H "Authorization: Bearer invalid" | head -5` shows `HTTP/1.1 401`
+- [x] `POST /mcp` with invalid `X-WorldMonitor-Key` returns HTTP 401 + `WWW-Authenticate: Bearer realm="worldmonitor", error="invalid_token"`
 
 ## Work Log
 
@@ -122,3 +123,13 @@ Use **Option 2**. Distinguishing "Bearer present but invalid" from "no auth" is 
 ```
 
 **Still pending:** The "no credentials at all" path and "invalid direct key" path still return HTTP 200 via `rpcError`. For claude.ai OAuth clients specifically this is acceptable (they always send a Bearer header), but it is a RFC 6750 non-compliance for any client that calls the endpoint without any auth. Full fix requires either: (a) special-casing -32001 in `rpcError` to return 401, or (b) manually constructing the 401 response for the "no candidateKey" and "invalid candidateKey" branches.
+
+### 2026-05-20 — Residual closed (invalid env-key returns 401)
+
+**By:** Claude Code
+
+**Actions:**
+
+- Replaced the `rpcError(null, -32001, 'Invalid API key')` call in `resolveAuthContext` (formerly `api/mcp.ts:439-443`, now at the env-key validation branch) with a manual `Response` mirroring the no-credentials and invalid-Bearer branches: `status: 401` + `WWW-Authenticate: Bearer realm="worldmonitor", error="invalid_token", resource_metadata="..."` via the shared `wwwAuthHeader` helper.
+- Updated `tests/mcp.test.mjs` to assert 401 + the `WWW-Authenticate` header on `X-WorldMonitor-Key: wrong_key` (previously asserted 200).
+- The "no credentials" branch had already been upgraded to HTTP 401 in a prior commit, so all three auth-failure exit paths (no creds, invalid env-key, invalid Bearer) are now RFC 6750-compliant.


### PR DESCRIPTION
## Summary

The env-key validation branch in `resolveAuthContext` returned the JSON-RPC `-32001` error via the shared `rpcError` helper, which hardcodes HTTP 200. That violates RFC 6750 §3.1 and prevents OAuth-aware clients (e.g. claude.ai) from triggering re-authentication when the supplied `X-WorldMonitor-Key` is wrong. The no-credentials and invalid-Bearer branches were already upgraded to HTTP 401 in a prior commit; the invalid-env-key branch was the last residual 200-on-auth-failure exit, closing the residual portion of todos/076.

The fix replaces the `rpcError` call with the same manual `Response` construction used by the other two branches: status 401 + `Content-Type` + `WWW-Authenticate` via the shared `wwwAuthHeader` helper, classified as `error="invalid_token"` (matching the OAuth-bearer-invalid branch).

## Test plan

- [x] `npx tsx --test tests/mcp.test.mjs` — all 97 tests green, including the updated assertion that `X-WorldMonitor-Key: wrong_key` returns HTTP 401 with `WWW-Authenticate: Bearer realm="worldmonitor", error="invalid_token"`
- [x] `npx tsx --test tests/mcp-api-parity.test.mjs tests/mcp-bootstrap-parity.test.mjs tests/mcp-schema-default-parity.test.mjs` — load-bearing parity tests stay green (39/39)
- [x] `npm run typecheck:api` — clean
- [x] `npm run test:data` — full suite green (9397/9397)