### PR TITLE
Fixed stale FSI-EU values

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -372,7 +372,7 @@ const SEED_META = {
   eurostatIndProd:     { key: 'seed-meta:economic:eurostat-industrial-production', maxStaleMin: 60 * 24 * 5 }, // daily cron, monthly data; 5d threshold matches TTL
   euGasStorage:      { key: 'seed-meta:economic:eu-gas-storage',      maxStaleMin: 2880 }, // daily seed (T+1); 2880min = 48h = 2x interval
   euYieldCurve:      { key: 'seed-meta:economic:yield-curve-eu',      maxStaleMin: 4320 }, // daily seed (weekdays only); 4320min = 72h = covers Fri→Mon gap
-  euFsi:             { key: 'seed-meta:economic:fsi-eu',               maxStaleMin: 20160 }, // weekly seed (Saturday); 20160min = 14d = 2x interval
+  euFsi:             { key: 'seed-meta:economic:fsi-eu',               maxStaleMin: 5760 }, // daily seed (weekdays + holidays); 5760min = 96h = covers Wed→Mon Easter gap
   newsThreatSummary: { key: 'seed-meta:news:threat-summary',          maxStaleMin: 60 }, // relay classify every ~20min; 60min = 3x interval
   shippingStress:    { key: 'seed-meta:supply_chain:shipping_stress',  maxStaleMin: 45 }, // relay loop every 15min; 45 = 3x interval (was 30 = 2×, too tight on relay hiccup)
   diseaseOutbreaks:  { key: 'seed-meta:health:disease-outbreaks',      maxStaleMin: 2880 }, // daily seed; 2880 = 48h = 2x interval

--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -163,7 +163,7 @@ All new services share these settings:
 | **Watch paths** | `scripts/**`, `shared/**` |
 | **Replaces** | 4 services (ecb-fx-rates, ecb-short-rates, yield-curve-eu, fsi-eu) |
 | **Net savings** | 3 slots |
-| **Members** | ECB FX Rates (daily), ECB Short Rates (daily), Yield Curve EU (daily), FSI EU (weekly, skips 6/7 runs) |
+| **Members** | ECB FX Rates (daily), ECB Short Rates (daily), Yield Curve EU (daily), FSI EU (daily) |
 
 ### Bundle 2: seed-bundle-portwatch
 

--- a/scripts/seed-bundle-ecb-eu.mjs
+++ b/scripts/seed-bundle-ecb-eu.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-import { runBundle, DAY, WEEK } from './_bundle-runner.mjs';
+import { runBundle, DAY } from './_bundle-runner.mjs';
 
 await runBundle('ecb-eu', [
   { label: 'ECB-FX-Rates', script: 'seed-ecb-fx-rates.mjs', seedMetaKey: 'economic:ecb-fx-rates', canonicalKey: 'economic:ecb-fx-rates:v1', intervalMs: DAY, timeoutMs: 120_000 },
   { label: 'ECB-Short-Rates', script: 'seed-ecb-short-rates.mjs', seedMetaKey: 'economic:ecb-short-rates', intervalMs: DAY, timeoutMs: 120_000 },
   { label: 'Yield-Curve-EU', script: 'seed-yield-curve-eu.mjs', seedMetaKey: 'economic:yield-curve-eu', canonicalKey: 'economic:yield-curve-eu:v1', intervalMs: DAY, timeoutMs: 120_000 },
-  { label: 'FSI-EU', script: 'seed-fsi-eu.mjs', seedMetaKey: 'economic:fsi-eu', canonicalKey: 'economic:fsi-eu:v1', intervalMs: WEEK, timeoutMs: 120_000 },
+  { label: 'FSI-EU', script: 'seed-fsi-eu.mjs', seedMetaKey: 'economic:fsi-eu', canonicalKey: 'economic:fsi-eu:v1', intervalMs: DAY, timeoutMs: 120_000 },
 ]);

--- a/scripts/seed-fsi-eu.mjs
+++ b/scripts/seed-fsi-eu.mjs
@@ -4,15 +4,21 @@ import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
 loadEnvFile(import.meta.url);
 
 // ECB SDMX REST API — free, no auth required.
-// CISS: Composite Indicator of Systemic Stress (0–1 range, higher = more systemic stress).
-// Weekly frequency, Euro area aggregate; ECB publishes each Friday (SDMX series key uses 'D' but only Friday observations are present).
-const ECB_CISS_URL =
-  'https://data-api.ecb.europa.eu/service/data/CISS/D.U2.Z0Z.4F.EC.SS_CI.IDX?format=jsondata&lastNObservations=52';
+// CISS (NEW): Composite Indicator of Systemic Stress (0–1 range, higher = more systemic stress).
+// Daily frequency, Euro area aggregate. The legacy SS_CI series stopped updating in May 2025;
+// SS_CIN is the actively-published successor ("NEW CISS" per ECB metadata title).
+// Window: trailing 1 year via startPeriod (~260 daily observations).
+function buildCissUrl() {
+  const oneYearAgo = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+  return `https://data-api.ecb.europa.eu/service/data/CISS/D.U2.Z0Z.4F.EC.SS_CIN.IDX?format=jsondata&startPeriod=${oneYearAgo}`;
+}
 
 const FSI_EU_KEY = 'economic:fsi-eu:v1';
-// Weekly cron (Saturday) — 864000s (10 days) matches other weekly seeds (bigmac, groceryBasket,
-// fuelPrices) and provides a 3-day buffer against cron-drift or missed runs.
-const FSI_EU_TTL = 864000;
+// Daily cron — 259200s (3 days) TTL provides a generous 3× safety margin against
+// cron-drift or missed runs.
+const FSI_EU_TTL = 259200;
 
 function classifyLabel(value) {
   if (value < 0.2) return 'Low';
@@ -22,7 +28,8 @@ function classifyLabel(value) {
 }
 
 async function fetchEcbCiss() {
-  const resp = await fetch(ECB_CISS_URL, {
+  const url = buildCissUrl();
+  const resp = await fetch(url, {
     headers: { 'User-Agent': CHROME_UA, Accept: 'application/json' },
     signal: AbortSignal.timeout(15_000),
   });
@@ -80,7 +87,7 @@ async function fetchEcbCiss() {
 
 // Contract opt-in: canonical record count for envelope + health.
 // FSI-EU payload is `{latestValue, latestDate, label, history[], ...}`.
-// Records = weekly CISS observations in the history array.
+// Records = daily CISS observations in the history array (~260 for a 1y window).
 export function declareRecords(data) {
   return Array.isArray(data?.history) ? data.history.length : 0;
 }
@@ -106,7 +113,7 @@ if (isMain) {
     sourceVersion: 'ecb-ciss-sdmx-v1',
     declareRecords,
     schemaVersion: 1,
-    maxStaleMin: 20160, // 14 days — matches api/health.js SEED_META threshold
+    maxStaleMin: 5760, // 4 days — matches api/health.js SEED_META threshold
   }).catch((err) => {
     console.error('FATAL:', err.message || err);
     process.exit(1);

--- a/tests/seeder-canonical-ttl-vs-cron.test.mjs
+++ b/tests/seeder-canonical-ttl-vs-cron.test.mjs
@@ -68,7 +68,6 @@ const KNOWN_VIOLATIONS = {
   // ── Climate ──
   'CO2-Monitoring:seed-co2-monitoring.mjs': '72h TTL vs 72h cron (1×) — needs bump to ≥216h',
   'Cross-Source-Signals:seed-cross-source-signals.mjs': '30min TTL vs 15min cron (2×) — borderline',
-  'FSI-EU:seed-fsi-eu.mjs': '240h TTL vs 168h cron (1.43×)',
   'IEA-Oil-Stocks:seed-iea-oil-stocks.mjs': '40d TTL vs 40d cron (1×) — needs bump to ≥120d',
 
   // ── Macro / IMF / WB cohort ──


### PR DESCRIPTION
## Summary

<!-- Brief description of what this PR does -->

Fixes https://github.com/koala73/worldmonitor/issues/3845

The legacy ECB CISS series `D.U2.Z0Z.4F.EC.SS_CI.IDX` (weekly, Friday-only observations) stopped updating in May 2025, so `economic:fsi-eu:v1` had been serving stale `latestValue`/`latestDate` for ~12 months. ECB published `SS_CIN` ("NEW CISS") as a daily successor on the same flow — this PR migrates to it and rescales TTL/cron/health-staleness to the new cadence.

- Series: `SS_CI` (weekly, frozen) → `SS_CIN` (daily, live). URL builder now passes `startPeriod` for a trailing-1y window (~260 obs) instead of `lastNObservations=52`.
- Cron: `seed-bundle-ecb-eu` member `intervalMs` `WEEK` → `DAY` — bundle-runner no longer skips 6/7 invocations; FSI now runs every daily bundle tick. Dropped now-unused `WEEK` import.
- TTL: canonical-key `ttlSeconds` 864000 (10d) → 259200 (3d). New ratio is 72h TTL vs 24h cron = 3×, hitting the `seeder-canonical-ttl-vs-cron` SAFETY_FACTOR exactly — so removed from `KNOWN_VIOLATIONS`.
- Health staleness: `SEED_META.euFsi.maxStaleMin` 20160 (14d, weekly×2) → 5760 (96h = TTL + 1d buffer, matching `ecbFxRates` daily-weekday convention).
- Records semantic: `declareRecords` doc-comment now reflects daily history length (~260) instead of "weekly observations".

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [ ] API endpoints (`/api/*`)
- [ ] Config / Settings
- [x] Other: Financial Stress Indicator Panel

## Checklist

- [x] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [x] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [x] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)

## Screenshots


