### PR TITLE
feat(mcp): telemetry user_id + log payload as structured object

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -33,6 +33,7 @@ import {
   signInternalMcpRequest,
   buildInternalMcpHeaders,
 } from '../server/_shared/mcp-internal-hmac';
+import { hashKeySync } from '../server/_shared/usage-identity';
 
 export const config = { runtime: 'edge' };
 
@@ -2662,12 +2663,18 @@ function rpcError(id: unknown, code: number, message: string): Response {
 // ---------------------------------------------------------------------------
 // Telemetry
 // ---------------------------------------------------------------------------
-// One structured single-line JSON log per `tools/call` (tag `mcp.toolcall`)
-// and one per `initialize` (tag `mcp.tools_list_emitted`). Vercel log drain
-// → analytics consumer reads these as production data on payload sizes,
-// JMESPath adoption %, latency P95, and tool usage histogram. Gated behind
+// One structured log per `tools/call` (tag `mcp.toolcall`) and one per
+// `initialize` (tag `mcp.tools_list_emitted`). Vercel log drain → analytics
+// consumer reads these as production data on payload sizes, JMESPath
+// adoption %, latency P95, and tool usage histogram. Gated behind
 // `MCP_TELEMETRY` so tests that snapshot stdout can suppress noise; default
 // ON in every other environment.
+//
+// Payload is passed to `console.log` as an object (not a pre-stringified
+// blob) so Vercel's logs UI renders it as a collapsible structured tree
+// instead of one long horizontal line. The Edge runtime serializes objects
+// to JSON when forwarding to log drains, so downstream parsers still see
+// valid JSON.
 function telemetryEnabled(): boolean {
   const v = process.env.MCP_TELEMETRY;
   return v !== 'false' && v !== '0';
@@ -2675,11 +2682,21 @@ function telemetryEnabled(): boolean {
 function emitTelemetry(event: string, payload: Record<string, unknown>): void {
   if (!telemetryEnabled()) return;
   try {
-    console.log(JSON.stringify({ tag: event, ts: new Date().toISOString(), ...payload }));
+    console.log({ tag: event, ts: new Date().toISOString(), ...payload });
   } catch {
-    // Never throw out of telemetry — a stringify failure on an
-    // unexpected circular value must not break the request path.
+    // Never throw out of telemetry — a serializer failure on an unexpected
+    // payload value must not break the request path.
   }
+}
+
+// Log-safe principal id derived from the resolved auth context:
+//   - Pro:     raw Clerk `userId` (internal ID, not a secret; matches the
+//              REST gateway's `customer_id` convention).
+//   - env_key: FNV-64 hash of the API key (secret — never log raw key
+//              material; mirrors `principal_id` in
+//              server/_shared/usage-identity.ts).
+function principalIdForLog(context: McpAuthContext): string {
+  return context.kind === 'pro' ? context.userId : hashKeySync(context.apiKey);
 }
 
 export function evaluateFreshness(checks: FreshnessCheck[], metas: unknown[], now = Date.now()): { cached_at: string | null; stale: boolean } {
@@ -3194,6 +3211,7 @@ async function dispatchToolsCall(
       emitTelemetry('mcp.toolcall', {
         tool: tool.name,
         auth_kind: context.kind,
+        user_id: principalIdForLog(context),
         latency_ms: latencyMs,
         bytes_pre_jmespath: bytesPre,
         bytes_post_jmespath: bytesPost,
@@ -3231,6 +3249,7 @@ async function dispatchToolsCall(
     emitTelemetry('mcp.toolcall', {
       tool: tool.name,
       auth_kind: context.kind,
+      user_id: principalIdForLog(context),
       latency_ms: latencyMs,
       bytes_pre_jmespath: 0,
       bytes_post_jmespath: 0,

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -3327,6 +3327,8 @@ export async function mcpHandler(
       // fixed overhead). UA is sliced to 256 chars: a pathological 32 KB
       // custom UA would otherwise inflate every emitted line for that session.
       emitTelemetry('mcp.tools_list_emitted', {
+        auth_kind: context.kind,
+        user_id: principalIdForLog(context),
         tools_array_bytes: TOOL_LIST_BYTES,
         tool_count: TOOL_LIST_RESPONSE.length,
         client_user_agent: (req.headers.get('User-Agent') ?? '').slice(0, 256),

--- a/server/_shared/usage-identity.ts
+++ b/server/_shared/usage-identity.ts
@@ -92,7 +92,7 @@ export function buildUsageIdentity(input: UsageIdentityInput): UsageIdentity {
 // want a sync helper for the hot path. Two rounds with different seeds give
 // ~64 bits of state, dropping birthday-collision risk well below the
 // widget-key population horizon (32-bit collides ~65k keys).
-function hashKeySync(key: string): string {
+export function hashKeySync(key: string): string {
   let h1 = 2166136261;
   let h2 = 0x811c9dc5 ^ 0xa3b2c1d4;
   for (let i = 0; i < key.length; i++) {

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -356,10 +356,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     } finally {
       console.log = origLog;
     }
-    const tc = captured
-      .filter((l) => typeof l === 'string')
-      .map((l) => { try { return JSON.parse(l); } catch { return null; } })
-      .filter((j) => j && j.tag === 'mcp.toolcall');
+    const tc = captured.filter((l) => l && typeof l === 'object' && !Array.isArray(l) && l.tag === 'mcp.toolcall');
     assert.equal(tc.length, 1, `expected exactly one mcp.toolcall line, got ${tc.length}`);
     const ev = tc[0];
     assert.equal(ev.tool, 'get_market_data');
@@ -372,6 +369,9 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(typeof ev.bytes_post_jmespath, 'number');
     assert.ok(ev.bytes_post_jmespath > 0, 'bytes_post_jmespath must be > 0 on a successful response');
     assert.equal(typeof ev.ts, 'string');
+    assert.equal(typeof ev.user_id, 'string');
+    assert.ok(ev.user_id.length > 0, 'user_id must be a non-empty string');
+    assert.notEqual(ev.user_id, VALID_KEY, 'env_key user_id MUST be hashed — never log the raw API key');
   });
 
   it('telemetry: tool-execution throw emits one mcp.toolcall line with ok:false + error_kind:server_error', async () => {
@@ -400,10 +400,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
       console.log = origLog;
       console.error = origErr;
     }
-    const tc = captured
-      .filter((l) => typeof l === 'string')
-      .map((l) => { try { return JSON.parse(l); } catch { return null; } })
-      .filter((j) => j && j.tag === 'mcp.toolcall');
+    const tc = captured.filter((l) => l && typeof l === 'object' && !Array.isArray(l) && l.tag === 'mcp.toolcall');
     assert.equal(tc.length, 1, `expected exactly one mcp.toolcall line, got ${tc.length}`);
     const ev = tc[0];
     assert.equal(ev.ok, false);
@@ -411,6 +408,8 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(ev.tool, 'get_market_data');
     assert.equal(typeof ev.latency_ms, 'number');
     assert.ok(Number.isFinite(ev.latency_ms), 'latency_ms must be finite (captured before rollback)');
+    assert.equal(typeof ev.user_id, 'string');
+    assert.ok(ev.user_id.length > 0, 'user_id must be present on the error path too');
   });
 
   it('telemetry: invalid jmespath expression emits ok:true with jmespath_failed=invalid_expression', async () => {
@@ -436,10 +435,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     } finally {
       console.log = origLog;
     }
-    const tc = captured
-      .filter((l) => typeof l === 'string')
-      .map((l) => { try { return JSON.parse(l); } catch { return null; } })
-      .filter((j) => j && j.tag === 'mcp.toolcall');
+    const tc = captured.filter((l) => l && typeof l === 'object' && !Array.isArray(l) && l.tag === 'mcp.toolcall');
     assert.equal(tc.length, 1, `expected exactly one mcp.toolcall line, got ${tc.length}`);
     const ev = tc[0];
     assert.equal(ev.ok, true, 'jmespath failure is a *user* error, not a system error');
@@ -459,10 +455,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     } finally {
       console.log = origLog;
     }
-    const ev = captured
-      .filter((l) => typeof l === 'string')
-      .map((l) => { try { return JSON.parse(l); } catch { return null; } })
-      .filter((j) => j && j.tag === 'mcp.tools_list_emitted');
+    const ev = captured.filter((l) => l && typeof l === 'object' && !Array.isArray(l) && l.tag === 'mcp.tools_list_emitted');
     assert.equal(ev.length, 1, `expected exactly one mcp.tools_list_emitted line, got ${ev.length}`);
     assert.equal(typeof ev[0].tools_array_bytes, 'number');
     assert.ok(ev[0].tools_array_bytes > 0, 'tools_array_bytes must be > 0');
@@ -482,10 +475,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     } finally {
       console.log = origLog;
     }
-    const ev = captured
-      .filter((l) => typeof l === 'string')
-      .map((l) => { try { return JSON.parse(l); } catch { return null; } })
-      .filter((j) => j && j.tag === 'mcp.tools_list_emitted');
+    const ev = captured.filter((l) => l && typeof l === 'object' && !Array.isArray(l) && l.tag === 'mcp.tools_list_emitted');
     assert.equal(ev[0].client_user_agent.length, 256, 'pathological UA must be sliced to 256 chars');
   });
 
@@ -527,10 +517,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(resStatus, 200, 'circular result + clean JMESPath projection must still return HTTP 200');
     assert.ok(body.result?.content, 'must return a successful JSON-RPC result (no -32603)');
     assert.equal(body.result.content[0].text, '1', 'JMESPath `total` must extract the clean subtree');
-    const tc = captured
-      .filter((l) => typeof l === 'string')
-      .map((l) => { try { return JSON.parse(l); } catch { return null; } })
-      .filter((j) => j && j.tag === 'mcp.toolcall');
+    const tc = captured.filter((l) => l && typeof l === 'object' && !Array.isArray(l) && l.tag === 'mcp.toolcall');
     assert.equal(tc.length, 1, `expected exactly one mcp.toolcall line, got ${tc.length}`);
     const ev = tc[0];
     assert.equal(ev.ok, true, 'telemetry stringify failure must not flip ok to false');

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -410,6 +410,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.ok(Number.isFinite(ev.latency_ms), 'latency_ms must be finite (captured before rollback)');
     assert.equal(typeof ev.user_id, 'string');
     assert.ok(ev.user_id.length > 0, 'user_id must be present on the error path too');
+    assert.notEqual(ev.user_id, VALID_KEY, 'error-path env_key user_id MUST be hashed — the key-never-logged contract holds on the ok:false branch too');
   });
 
   it('telemetry: invalid jmespath expression emits ok:true with jmespath_failed=invalid_expression', async () => {
@@ -461,6 +462,10 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.ok(ev[0].tools_array_bytes > 0, 'tools_array_bytes must be > 0');
     assert.equal(ev[0].tool_count, expectedToolCount, 'tool_count must equal current registry size');
     assert.equal(ev[0].client_user_agent, 'wm-test/1.0');
+    assert.equal(ev[0].auth_kind, 'env_key');
+    assert.equal(typeof ev[0].user_id, 'string');
+    assert.ok(ev[0].user_id.length > 0, 'user_id must be present on initialize too');
+    assert.notEqual(ev[0].user_id, VALID_KEY, 'initialize user_id MUST be hashed for env_key — raw key never logged');
   });
 
   it('telemetry: 32 KB User-Agent is capped at 256 chars in client_user_agent', async () => {
@@ -2294,6 +2299,41 @@ describe('api/mcp.ts — U7 Pro-path', () => {
     const res = await mcpHandler(proReq('POST', callBody('describe_tool', { tool_name: 'get_market_data' })), deps);
     assert.equal(res.status, 200);
     assert.equal(pipe.count, 0, 'describe_tool MUST NOT increment the Pro daily quota');
+  });
+
+  it('telemetry: Pro-path tools/call AND initialize emit raw user_id === PRO_USER_ID (un-hashed)', async () => {
+    // Pro context carries a real Clerk userId — it is an internal ID, not
+    // secret material, so the log-safe principal is the raw userId itself
+    // (matches the REST gateway's customer_id convention). This locks in
+    // the Pro branch of principalIdForLog against future regressions to
+    // hashing/redacting/aliasing.
+    process.env.MCP_TELEMETRY = 'true';
+    process.env.UPSTASH_REDIS_REST_URL = 'https://stub.upstash';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'stub';
+    const { deps } = makeProDeps();
+    globalThis.fetch = async () => new Response(JSON.stringify({ result: JSON.stringify({ ok: 1 }) }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+
+    const captured = [];
+    const origLog = console.log;
+    console.log = (line) => captured.push(line);
+    try {
+      const initRes = await mcpHandler(proReq('POST', initBody(700)), deps);
+      assert.equal(initRes.status, 200, 'initialize must succeed for Pro');
+      const callRes = await mcpHandler(proReq('POST', callBody('get_market_data', {}, 701)), deps);
+      assert.equal(callRes.status, 200, 'tools/call must succeed for Pro');
+    } finally {
+      console.log = origLog;
+    }
+
+    const init = captured.filter((l) => l && typeof l === 'object' && !Array.isArray(l) && l.tag === 'mcp.tools_list_emitted');
+    assert.equal(init.length, 1, `expected exactly one mcp.tools_list_emitted line, got ${init.length}`);
+    assert.equal(init[0].auth_kind, 'pro');
+    assert.equal(init[0].user_id, PRO_USER_ID, 'initialize user_id MUST be the raw Clerk userId on the Pro path');
+
+    const tc = captured.filter((l) => l && typeof l === 'object' && !Array.isArray(l) && l.tag === 'mcp.toolcall');
+    assert.equal(tc.length, 1, `expected exactly one mcp.toolcall line, got ${tc.length}`);
+    assert.equal(tc[0].auth_kind, 'pro');
+    assert.equal(tc[0].user_id, PRO_USER_ID, 'tools/call user_id MUST be the raw Clerk userId on the Pro path');
   });
 
   it('integration: signed header for /api/news/v1/list-feed-digest cannot be replayed against /api/intelligence/v1/deduct-situation', async () => {


### PR DESCRIPTION
## Summary

Two related fixes to the per-call MCP telemetry shipped previously, both surfaced while looking at live `mcp.toolcall` lines in the Vercel logs UI.

1. **Log shape — pass an object, not a stringified blob.** `emitTelemetry()` previously called `console.log(JSON.stringify({...}))`, which Vercel's logs UI displays as one long horizontal text line because there's nothing to expand. Switching to `console.log({...})` makes Vercel render it as a collapsible structured tree. The Edge runtime still serializes objects to JSON when forwarding to log drains, so downstream parsers (Axiom / Datadog / custom drain) keep receiving valid JSON — only the in-dashboard display changes.

2. **Add `user_id` to every `mcp.toolcall` line.** Without it, the stream supports global aggregates only — no per-customer attribution, no targeted debugging, no abuse detection. Derived per auth kind:
   - **Pro:** raw Clerk `userId` (internal ID, not a secret; matches the REST gateway's `customer_id`/`principal_id` convention).
   - **env_key:** FNV-64 hash of the API key — secret material is never logged raw, mirroring how `enterprise_api_key` / `widget_key` are hashed in `server/_shared/usage-identity.ts`.

The `hashKeySync` helper from `server/_shared/usage-identity.ts` is exported so both telemetry pipelines (REST gateway + MCP) share a single redaction implementation instead of forking a copy.

Tests updated to read the object form from the `console.log` spy (replacing the previous `typeof === 'string'` + `JSON.parse` pattern). New assertion on the env-key happy path locks in that `user_id !== VALID_KEY` — guarantees the raw API key never leaks into the log line.

## Test plan

- [x] `npx tsx --test tests/mcp.test.mjs` — 97/97
- [x] `npx tsx --test tests/mcp-api-parity.test.mjs tests/mcp-bootstrap-parity.test.mjs tests/mcp-schema-default-parity.test.mjs` — 39/39
- [x] `npm run typecheck:api` clean
- [x] `npm run test:data` — full suite 9397/9397