### PR TITLE
fix(sentry): classify Cloudflare 520-527 edge errors as transient transport

### DIFF
--- a/api/_convex-error.js
+++ b/api/_convex-error.js
@@ -61,6 +61,16 @@ export function extractConvexErrorKind(err, msg) {
   // Sentry's classifier tags these as `transport_network` so they're queryable
   // separately from genuine Convex 503s.
   if (/Network connection lost/i.test(msg)) return 'SERVICE_UNAVAILABLE';
+  // Cloudflare edge errors (520-527) fronting the Convex deployment: a
+  // transient origin/connection failure where Cloudflare returns a text/HTML
+  // body containing `error code: 52x` instead of a JSON Convex response. The
+  // HTTP client surfaces this as `Error('error code: 520...')` — `.data` is
+  // undefined (the request never reached Convex's runtime). Same transient
+  // retry-with-back-off remediation as the platform 503. WORLDMONITOR-PG: was
+  // falling through to the 'unknown' error_shape bucket at error level instead
+  // of 503 + Retry-After. Sentry's classifier tags these `transport_cloudflare`
+  // so they stay queryable apart from genuine Convex platform 5xx.
+  if (/error code:\s*52[0-7]\b/i.test(msg)) return 'SERVICE_UNAVAILABLE';
   // Convex platform-level 401: when Clerk's OIDC token fails Convex's own
   // verification (token expired between our edge's `validateBearerToken`
   // and Convex's check, or Clerk JWKS rotated), the SDK surfaces a JSON

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -381,6 +381,11 @@ export function buildSentryContext(
       : /"code":"InternalServerError"/.test(msg) ? 'convex_internal_error'
       : /\[Request ID:\s*[a-f0-9]+\]\s*Server Error/i.test(msg) ? 'convex_server_error'
       : /timeout|timed out|aborted/i.test(msg) ? 'transport_timeout'
+      // Cloudflare edge error (520-527) fronting the Convex deployment — see
+      // _convex-error.js. Mapped to SERVICE_UNAVAILABLE (503 + Retry-After)
+      // there; kept as its own Sentry bucket so on-call can tell CDN-layer
+      // transients apart from genuine Convex platform 5xx (WORLDMONITOR-PG).
+      : /error code:\s*52[0-7]\b/i.test(msg) ? 'transport_cloudflare'
       : /fetch failed|network|ECONN|ENOTFOUND|getaddrinfo/i.test(msg) ? 'transport_network'
       : 'unknown');
 

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -380,12 +380,17 @@ export function buildSentryContext(
       // (WORLDMONITOR-PG/PH).
       : /"code":"InternalServerError"/.test(msg) ? 'convex_internal_error'
       : /\[Request ID:\s*[a-f0-9]+\]\s*Server Error/i.test(msg) ? 'convex_server_error'
-      : /timeout|timed out|aborted/i.test(msg) ? 'transport_timeout'
       // Cloudflare edge error (520-527) fronting the Convex deployment — see
       // _convex-error.js. Mapped to SERVICE_UNAVAILABLE (503 + Retry-After)
       // there; kept as its own Sentry bucket so on-call can tell CDN-layer
       // transients apart from genuine Convex platform 5xx (WORLDMONITOR-PG).
+      // Checked BEFORE the /timeout/ branch: Cloudflare 524's error page body
+      // is literally "A timeout occurred", so a 524 whose message carries the
+      // CF body text would otherwise be mis-bucketed as transport_timeout.
+      // A genuine client AbortSignal.timeout never carries an `error code: 52x`
+      // substring, so this ordering steals no real-timeout events.
       : /error code:\s*52[0-7]\b/i.test(msg) ? 'transport_cloudflare'
+      : /timeout|timed out|aborted/i.test(msg) ? 'transport_timeout'
       : /fetch failed|network|ECONN|ENOTFOUND|getaddrinfo/i.test(msg) ? 'transport_network'
       : 'unknown');
 

--- a/src/services/premium-fetch.ts
+++ b/src/services/premium-fetch.ts
@@ -56,9 +56,15 @@ function reportServerError(res: Response, input: RequestInfo | URL): void {
   try {
     const href = input instanceof Request ? input.url : String(input);
     const path = new URL(href, globalThis.location?.href ?? 'https://worldmonitor.app').pathname;
+    // Cloudflare edge errors (520-527) are CDN<->origin transport failures, not
+    // origin application errors — a single one is a transient blip. Capture at
+    // `warning` so a sustained outage still escalates by volume without a lone
+    // transient drowning genuine origin 5xx in the error dashboard
+    // (WORLDMONITOR-RG). Genuine origin 5xx (500-511) stay at `error`.
+    const isCloudflareEdgeError = res.status >= 520 && res.status <= 527;
     Sentry.captureMessage(`API ${res.status}: ${path}`, {
-      level: 'error',
-      tags: { kind: 'api_5xx' },
+      level: isCloudflareEdgeError ? 'warning' : 'error',
+      tags: { kind: isCloudflareEdgeError ? 'api_cf_5xx' : 'api_5xx' },
       extra: { path, status: res.status },
     });
   } catch { /* ignore URL parse errors */ }

--- a/tests/user-prefs-convex-error.test.mjs
+++ b/tests/user-prefs-convex-error.test.mjs
@@ -162,6 +162,46 @@ describe('extractConvexErrorKind — Convex client error → kind', () => {
     });
   });
 
+  describe('Cloudflare edge error 520-527 fronting Convex (WORLDMONITOR-PG)', () => {
+    it('detects SERVICE_UNAVAILABLE from the "error code: 520" Cloudflare body', () => {
+      // Cloudflare returns a text/HTML body containing `error code: 52x` when
+      // the origin misbehaves; the Convex HTTP client surfaces it as
+      // `Error('error code: 520...')` with `.data === undefined`. Without this
+      // match it fell to the 'unknown' bucket at error level instead of
+      // 503 + Retry-After (WORLDMONITOR-PG: 10 events / 8 users).
+      const err = new Error('error code: 520');
+      assert.equal(extractConvexErrorKind(err, err.message), 'SERVICE_UNAVAILABLE');
+    });
+
+    it('matches the whole 520-527 Cloudflare range', () => {
+      for (const code of [520, 521, 522, 523, 524, 525, 526, 527]) {
+        const err = new Error(`<html><body>error code: ${code}</body></html>`);
+        assert.equal(
+          extractConvexErrorKind(err, err.message), 'SERVICE_UNAVAILABLE',
+          `expected SERVICE_UNAVAILABLE for Cloudflare ${code}`,
+        );
+      }
+    });
+
+    it('does NOT match non-Cloudflare codes (519/528/error code: 500)', () => {
+      // Defensive: only the real Cloudflare 520-527 range is transient-transport.
+      for (const code of [500, 503, 519, 528, 530]) {
+        const err = new Error(`error code: ${code}`);
+        assert.equal(
+          extractConvexErrorKind(err, err.message), null,
+          `expected null (no Cloudflare match) for code ${code}`,
+        );
+      }
+    });
+
+    it('structured-data path still wins over "error code: 52x" substring (forward-compat)', () => {
+      const err = Object.assign(new Error('error code: 522'), {
+        data: { kind: 'CONFLICT', actualSyncVersion: 3 },
+      });
+      assert.equal(extractConvexErrorKind(err, err.message), 'CONFLICT');
+    });
+  });
+
   describe('legacy substring-match fallback (string-data ConvexError that arrived without errorData)', () => {
     it('matches CONFLICT in the message', () => {
       const err = new Error('CONFLICT');

--- a/tests/user-prefs-sentry-context.test.mts
+++ b/tests/user-prefs-sentry-context.test.mts
@@ -153,6 +153,28 @@ describe('buildSentryContext — backwards-compat for non-CONFLICT callers', () 
     assert.equal(ctx.tags.error_shape, 'convex_auth_drift');
   });
 
+  it('Cloudflare edge body "error code: 52x" classifies as transport_cloudflare', () => {
+    // WORLDMONITOR-PG: a Cloudflare 520-527 fronting the Convex deployment
+    // produced a body `error code: 520`. No classifier matched it, so it fell
+    // to `error_shape: 'unknown'` at error level (10 events / 8 users). Now
+    // _convex-error.js maps it to SERVICE_UNAVAILABLE (503 + Retry-After,
+    // warning) and this bucket keeps it queryable apart from genuine Convex
+    // platform 5xx.
+    for (const code of [520, 522, 524, 527]) {
+      const err = new Error(`error code: ${code}`);
+      const ctx = buildSentryContext(err, err.message, baseOpts);
+      assert.equal(ctx.tags.error_shape, 'transport_cloudflare', `code ${code}`);
+    }
+  });
+
+  it('non-Cloudflare 5xx (error code: 500/503) does NOT classify as transport_cloudflare', () => {
+    // Defensive: only the real Cloudflare 520-527 range is the CDN-transport
+    // bucket. A bare "error code: 500" with no other signal stays 'unknown'.
+    const err = new Error('error code: 500');
+    const ctx = buildSentryContext(err, err.message, baseOpts);
+    assert.equal(ctx.tags.error_shape, 'unknown');
+  });
+
   it('messageHead still in extra (non-indexed payload, not promoted)', () => {
     const err = new Error('quite a long error message that should land in extra');
     const ctx = buildSentryContext(err, err.message, baseOpts);

--- a/tests/user-prefs-sentry-context.test.mts
+++ b/tests/user-prefs-sentry-context.test.mts
@@ -175,6 +175,25 @@ describe('buildSentryContext — backwards-compat for non-CONFLICT callers', () 
     assert.equal(ctx.tags.error_shape, 'unknown');
   });
 
+  it('Cloudflare 524 wins transport_cloudflare even when body contains "A timeout occurred"', () => {
+    // greptile review on #3854: Cloudflare 524's error page body is literally
+    // "A timeout occurred". If the Convex client carries that body text in the
+    // error message, the /timeout/ branch would fire first and mis-bucket the
+    // 524 as transport_timeout. The `error code: 52x` branch is ordered BEFORE
+    // /timeout/ specifically to prevent this.
+    const err = new Error('<html><title>524: A timeout occurred</title><body>A timeout occurred. error code: 524</body></html>');
+    const ctx = buildSentryContext(err, err.message, baseOpts);
+    assert.equal(ctx.tags.error_shape, 'transport_cloudflare');
+  });
+
+  it('a genuine client AbortSignal timeout (no CF code) still classifies as transport_timeout', () => {
+    // Ordering guard the other way: moving error-code-52x above /timeout/ must
+    // NOT steal real client-timeout events — they carry no `error code: 52x`.
+    const err = new Error('The operation was aborted due to timeout');
+    const ctx = buildSentryContext(err, err.message, baseOpts);
+    assert.equal(ctx.tags.error_shape, 'transport_timeout');
+  });
+
   it('messageHead still in extra (non-indexed payload, not promoted)', () => {
     const err = new Error('quite a long error message that should land in extra');
     const ctx = buildSentryContext(err, err.message, baseOpts);


### PR DESCRIPTION
## Summary

Two Sentry issues, one root cause: a **Cloudflare edge error (520-527)** fronting an upstream was bucketed as a hard error instead of a transient transport blip.

- **WORLDMONITOR-PG** (10 events / 8 users) — `api/user-prefs` edge → Convex hit a Cloudflare `520`. The body `error code: 520` matched no pattern in `extractConvexErrorKind`, so the catch fell through to the default **error**-level capture + **500** response. Added a classifier branch mapping `error code: 52[0-7]` → `SERVICE_UNAVAILABLE`, so it now returns **503 + Retry-After** at **warning** level — same remediation as the existing platform-503 path. `buildSentryContext` gets a distinct `transport_cloudflare` `error_shape` so it stays queryable apart from genuine Convex platform 5xx.
- **WORLDMONITOR-RG** (1 event) — `reportServerError` captured every client-observed `status >= 500` at **error** level. Cloudflare 520-527 are CDN↔origin transport failures, not origin application errors — now captured at **warning** (tag `api_cf_5xx`) so a sustained outage still escalates by volume without a lone transient drowning genuine origin 5xx. Origin 5xx (500-511) unchanged.

Also triaged in the same Sentry pass (no code change in this PR):
- **WORLDMONITOR-R2** `aborted due to timeout` — already correctly handled (`transport_timeout`, warning, 503+Retry-After). Resolved as working-as-intended.
- **WORLDMONITOR-RJ** `API 500: /api/mcp-proxy` — left open; `mcp-proxy` handler never returns 500 itself (a `500` = Vercel function crash), insufficient signal to pinpoint, and suppressing 500 would hide real outages.
- **WORLDMONITOR-RH** `SyntaxError` from the Dodo Payments SDK on an iOS in-app browser — left open as a legitimate (low-volume) conversion-bug signal; filtering would hide it. Product follow-up: detect in-app browser → use redirect checkout mode.

## Test plan

- [x] `npm run typecheck` + `typecheck:api` — PASS
- [x] `npm run lint` (biome) — PASS
- [x] `npm run lint:md` — PASS
- [x] `npm run version:check` — PASS
- [x] CJS syntax check — PASS
- [x] `api/*.js` esbuild bundle check — PASS
- [x] `tests/edge-functions.test.mjs` — PASS
- [x] `npm run test:data` — PASS (9424 tests)
- [x] 6 new cases: full 520-527 range, negative non-Cloudflare codes (500/503/519/528/530), structured-data-precedence guard
- [ ] After deploy: WORLDMONITOR-PG / RG do not auto-reopen; new Cloudflare-transport events land in the `transport_cloudflare` / `api_cf_5xx` buckets at warning level