### PR TITLE
feat(mcp): logging capability + logging/setLevel handler

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -88,6 +88,14 @@ const SERVER_NAME = 'worldmonitor';
 // — discovery scanners cross-check both values.
 const SERVER_VERSION = '1.5.0';
 
+// MCP logging capability — valid severity levels per the 2025-03-26 spec
+// (RFC 5424 subset). Stateless HTTP transport: we ACK the level but do not
+// push async `notifications/message` log events.
+const MCP_LOG_LEVELS: ReadonlySet<string> = new Set([
+  'debug', 'info', 'notice', 'warning',
+  'error', 'critical', 'alert', 'emergency',
+]);
+
 // Universal JMESPath projection caps (v1.4.0) — applied at the dispatch
 // boundary AFTER `_postFilter` and `summary`, before serialization. Two
 // gates protect the edge function: an input gate against pathological-parse
@@ -3374,7 +3382,7 @@ export async function mcpHandler(
       });
       return rpcOk(id, {
         protocolVersion: MCP_PROTOCOL_VERSION,
-        capabilities: { tools: {} },
+        capabilities: { tools: {}, logging: {} },
         serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
         instructions: SERVER_INSTRUCTIONS,
       }, { 'Mcp-Session-Id': sessionId, ...corsHeaders });
@@ -3387,6 +3395,15 @@ export async function mcpHandler(
       return rpcOk(id, { tools: TOOL_LIST_RESPONSE }, corsHeaders);
     case 'tools/call':
       return dispatchToolsCall(req, context, deps, body, corsHeaders, ctx);
+    case 'logging/setLevel': {
+      const level = (body.params as { level?: string } | null)?.level;
+      if (typeof level !== 'string' || !MCP_LOG_LEVELS.has(level)) {
+        return rpcError(id, -32602,
+          `Invalid params: level must be one of ${[...MCP_LOG_LEVELS].join(', ')}`,
+        );
+      }
+      return rpcOk(id, {}, corsHeaders);
+    }
     default:
       return rpcError(id, -32601, `Method not found: ${method}`);
   }

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -13,6 +13,7 @@
   },
   "capabilities": {
     "tools": true,
+    "logging": true,
     "resources": false,
     "prompts": false
   },

--- a/tests/mcp-jmespath.test.mjs
+++ b/tests/mcp-jmespath.test.mjs
@@ -339,7 +339,7 @@ describe('api/mcp.ts — JMESPath projection (v1.4.0)', () => {
       const res = await mod.default(makeReq(initBody(4)));
       const body = await res.json();
       assert.equal(body.result?.protocolVersion, '2025-03-26');
-      assert.deepEqual(body.result?.capabilities, { tools: {} });
+      assert.deepEqual(body.result?.capabilities, { tools: {}, logging: {} });
       assert.equal(body.result?.serverInfo?.name, 'worldmonitor');
     });
   });

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -124,6 +124,40 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(body.error?.code, -32600);
   });
 
+  // --- logging/setLevel ---
+
+  it('logging/setLevel with valid level returns success', async () => {
+    for (const level of ['debug', 'info', 'notice', 'warning', 'error', 'critical', 'alert', 'emergency']) {
+      const res = await handler(makeReq('POST', {
+        jsonrpc: '2.0', id: 10, method: 'logging/setLevel',
+        params: { level },
+      }));
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.deepStrictEqual(body.result, {}, `level "${level}" must return empty success result`);
+      assert.equal(body.error, undefined, `level "${level}" must not return an error`);
+    }
+  });
+
+  it('logging/setLevel with invalid level returns JSON-RPC -32602', async () => {
+    for (const bad of ['trace', 'warn', 'CRITICAL', 'Info', '', 42, null, undefined]) {
+      const res = await handler(makeReq('POST', {
+        jsonrpc: '2.0', id: 11, method: 'logging/setLevel',
+        params: { level: bad },
+      }));
+      const body = await res.json();
+      assert.equal(body.error?.code, -32602, `level ${JSON.stringify(bad)} must be rejected with -32602`);
+    }
+  });
+
+  it('initialize response advertises logging capability', async () => {
+    const res = await handler(makeReq('POST', initBody(12)));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.result?.capabilities?.logging, 'capabilities.logging must be present');
+    assert.deepStrictEqual(body.result.capabilities.logging, {}, 'capabilities.logging must be an empty object');
+  });
+
   // --- tools/list ---
 
   it('tools/list returns 39 tools with name, description, inputSchema', async () => {


### PR DESCRIPTION
## Summary
- Advertise `logging: {}` in MCP `initialize` capabilities and `server-card.json`
- Add `logging/setLevel` handler that validates against the 8 RFC 5424 severity levels (`debug` through `emergency`) and returns `rpcOk(id, {})`
- Stateless HTTP transport acknowledges the level but does not push async `notifications/message` events (spec-compliant — servers MAY send, not MUST)
- 3 new tests + 1 existing test updated for the new capability shape

## Test plan
- [x] `logging/setLevel` with all 8 valid levels returns `{}`
- [x] `logging/setLevel` with invalid levels (`trace`, `warn`, `CRITICAL`, `''`, `42`, `null`, `undefined`) returns `-32602`
- [x] `initialize` response includes `logging: {}` in capabilities
- [x] Full test suite passes (9421 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)