### PR TITLE
feat(mcp): per-tool outputBudgetBytes gate

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -114,6 +114,13 @@ export const JMESPATH_MAX_EXPR_BYTES = 1024;
 export const JMESPATH_MAX_OUTPUT_BYTES = 256 * 1024;
 export type JmespathFailKind = 'expression_too_long' | 'projection_too_large' | 'invalid_expression';
 
+// Per-tool output budget (PR-B). When serialised tool output exceeds the
+// tool's budget AFTER _postFilter + summary + JMESPath, the server returns
+// a `_budget_exceeded` envelope instead of the oversized payload.
+export const DEFAULT_OUTPUT_BUDGET_BYTES = 256 * 1024;
+const CACHE_OUTPUT_BUDGET_BYTES = 128 * 1024;
+const LLM_OUTPUT_BUDGET_BYTES = 64 * 1024;
+
 // tools/list tool-description compression cap (v1.5.0). Defined here
 // rather than near `compressDescription` so SERVER_INSTRUCTIONS can
 // quote it without a temporal-dead-zone error. The compressDescription
@@ -250,6 +257,7 @@ interface BaseToolDef {
   name: string;
   description: string;
   inputSchema: { type: string; properties: Record<string, unknown>; required: string[] };
+  _outputBudgetBytes?: number;
 }
 
 interface FreshnessCheck {
@@ -2553,6 +2561,18 @@ const TOOL_REGISTRY: ToolDef[] = [
   },
 ];
 
+// Per-category output budgets (PR-B). Applied post-hoc to keep the registry
+// literal clean — repeating the constant inline 32× adds noise without value.
+// dispatchToolsCall reads `tool._outputBudgetBytes ?? DEFAULT_OUTPUT_BUDGET_BYTES`.
+for (const t of TOOL_REGISTRY) {
+  if (t._cacheKeys) t._outputBudgetBytes = CACHE_OUTPUT_BUDGET_BYTES;
+}
+for (const name of ['analyze_situation', 'generate_forecasts', 'get_world_brief', 'get_country_brief']) {
+  const t = TOOL_REGISTRY.find((r) => r.name === name);
+  if (t) t._outputBudgetBytes = LLM_OUTPUT_BUDGET_BYTES;
+}
+{ const dt = TOOL_REGISTRY.find((t) => t.name === 'describe_tool'); if (dt) dt._outputBudgetBytes = 8 * 1024; }
+
 // Public shape for tools/list — strips internal _-prefixed fields, adds MCP
 // annotations, and injects the universal `summary` flag (issue #3678) into
 // every cache tool's advertised schema. Cache tools are uniformly summarisable;
@@ -2724,6 +2744,7 @@ export const MCP_TOOLCALL_TELEMETRY_KEYS = Object.freeze([
   'jmespath_failed',
   'ok',
   'error_kind',
+  'budget_exceeded',
 ] as const);
 
 export const MCP_TOOLS_LIST_TELEMETRY_KEYS = Object.freeze([
@@ -3232,13 +3253,13 @@ async function dispatchToolsCall(
     // size.
     const { text, failed } = applyJmespath(result, jmespathArg);
     const latencyMs = Date.now() - tStart;
-    // Outer `telemetryEnabled()` here is a perf gate: it skips the
-    // utf8ByteLength + (when JMESPath is active) JSON.stringify(result) walk
-    // when telemetry is off. `emitTelemetry` re-checks internally as the
-    // single safety gate for the initialize + error call sites, which don't
-    // have outer gating because their byte fields are zero or precomputed.
+    // Budget gate: always compute byte length for the budget check. This
+    // replaces the previous telemetry-only perf gate for the post-JMESPath
+    // measurement — budget enforcement requires the walk unconditionally.
+    const textBytes = utf8ByteLength(text);
+    const budget = tool._outputBudgetBytes ?? DEFAULT_OUTPUT_BUDGET_BYTES;
+    const budgetExceeded = textBytes > budget;
     if (telemetryEnabled()) {
-      const bytesPost = utf8ByteLength(text);
       let bytesPre: number;
       if (jmespathUsed) {
         // Telemetry stringify must never escape into the outer catch — a
@@ -3253,7 +3274,7 @@ async function dispatchToolsCall(
           bytesPre = -1;
         }
       } else {
-        bytesPre = bytesPost;
+        bytesPre = textBytes;
       }
       emitTelemetry('mcp.toolcall', {
         tool: tool.name,
@@ -3261,11 +3282,20 @@ async function dispatchToolsCall(
         user_id: principalIdForLog(context),
         latency_ms: latencyMs,
         bytes_pre_jmespath: bytesPre,
-        bytes_post_jmespath: bytesPost,
+        bytes_post_jmespath: textBytes,
         jmespath_used: jmespathUsed,
         jmespath_failed: failed ?? null,
         ok: true,
+        budget_exceeded: budgetExceeded,
       });
+    }
+    if (budgetExceeded) {
+      return rpcOk(id, { content: [{ type: 'text', text: JSON.stringify({
+        _budget_exceeded: true,
+        budget_bytes: budget,
+        actual_bytes: textBytes,
+        hint: 'Response exceeds tool output budget. Use the jmespath argument to project only the fields you need, or apply filters to narrow the result set.',
+      }) }] }, corsHeaders);
     }
     return rpcOk(id, { content: [{ type: 'text', text }] }, corsHeaders);
   } catch (err: unknown) {
@@ -3304,6 +3334,7 @@ async function dispatchToolsCall(
       jmespath_failed: null,
       ok: false,
       error_kind: isClient4xx ? 'client_4xx' : 'server_error',
+      budget_exceeded: false,
     });
     return rpcError(id, -32603, 'Internal error: data fetch failed');
   }

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -2569,9 +2569,10 @@ for (const t of TOOL_REGISTRY) {
 }
 for (const name of ['analyze_situation', 'generate_forecasts', 'get_world_brief', 'get_country_brief']) {
   const t = TOOL_REGISTRY.find((r) => r.name === name);
-  if (t) t._outputBudgetBytes = LLM_OUTPUT_BUDGET_BYTES;
+  if (!t) throw new Error(`[mcp] budget-assignment: tool '${name}' not found in TOOL_REGISTRY`);
+  t._outputBudgetBytes = LLM_OUTPUT_BUDGET_BYTES;
 }
-{ const dt = TOOL_REGISTRY.find((t) => t.name === 'describe_tool'); if (dt) dt._outputBudgetBytes = 8 * 1024; }
+{ const dt = TOOL_REGISTRY.find((t) => t.name === 'describe_tool'); if (!dt) throw new Error("[mcp] budget-assignment: 'describe_tool' not found in TOOL_REGISTRY"); dt._outputBudgetBytes = 8 * 1024; }
 
 // Public shape for tools/list — strips internal _-prefixed fields, adds MCP
 // annotations, and injects the universal `summary` flag (issue #3678) into
@@ -3290,6 +3291,9 @@ async function dispatchToolsCall(
       });
     }
     if (budgetExceeded) {
+      // Rollback Pro quota — the user received no usable data, so the
+      // daily slot should not be consumed (mirrors the catch-block rollback).
+      if (proRollback) await proRollback();
       return rpcOk(id, { content: [{ type: 'text', text: JSON.stringify({
         _budget_exceeded: true,
         budget_bytes: budget,

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -3294,11 +3294,14 @@ async function dispatchToolsCall(
       // Rollback Pro quota — the user received no usable data, so the
       // daily slot should not be consumed (mirrors the catch-block rollback).
       if (proRollback) await proRollback();
+      const hint = jmespathUsed
+        ? 'Response still exceeds tool output budget after JMESPath projection. Use a more selective expression to project fewer fields, or apply tool-level filters to narrow the result set.'
+        : 'Response exceeds tool output budget. Use the jmespath argument to project only the fields you need, or apply filters to narrow the result set.';
       return rpcOk(id, { content: [{ type: 'text', text: JSON.stringify({
         _budget_exceeded: true,
         budget_bytes: budget,
         actual_bytes: textBytes,
-        hint: 'Response exceeds tool output budget. Use the jmespath argument to project only the fields you need, or apply filters to narrow the result set.',
+        hint,
       }) }] }, corsHeaders);
     }
     return rpcOk(id, { content: [{ type: 'text', text }] }, corsHeaders);

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -175,6 +175,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
       assert.ok(!('_coverageKeys' in tool), 'Internal _coverageKeys must not be exposed in tools/list');
       assert.ok(!('_apiPaths' in tool), 'Internal _apiPaths must not be exposed in tools/list (Tier-4 parity)');
       assert.ok(!('_postFilter' in tool), 'Internal _postFilter must not be exposed in tools/list (issue #3677)');
+      assert.ok(!('_outputBudgetBytes' in tool), 'Internal _outputBudgetBytes must not be exposed in tools/list (PR-B)');
     }
     const toolNames = body.result.tools.map((t) => t.name);
     assert.ok(toolNames.includes('get_displacement_data'), 'get_displacement_data must be registered (U1 Tier 1 regression)');
@@ -565,6 +566,66 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(ev.jmespath_failed, null);
     assert.equal(ev.bytes_pre_jmespath, -1, 'circular result must surface bytes_pre_jmespath: -1 sentinel');
     assert.ok(ev.bytes_post_jmespath > 0, 'bytes_post_jmespath must reflect the projected size (> 0)');
+  });
+
+  // --- Budget (PR-B: outputBudgetBytes) ---
+
+  it('budget: tools/call within budget returns normal response', async () => {
+    // Small payload well within the 128 KB cache-tool budget
+    const stocks = { quotes: [{ symbol: 'AAPL', price: 100 }] };
+    mockCacheKeys(
+      { 'market:stocks-bootstrap:v1': stocks, 'market:crypto:v1': { quotes: [] } },
+      { 'seed-meta:market:stocks': { fetchedAt: Date.now() - 60_000, recordCount: 1 } },
+    );
+    const out = await callTool('get_market_data', {});
+    assert.ok(out.data, 'normal response must contain data');
+    assert.equal(out._budget_exceeded, undefined, 'within-budget response must not contain _budget_exceeded');
+  });
+
+  it('budget: tools/call exceeding budget returns _budget_exceeded envelope', async () => {
+    // Generate a payload that exceeds the 128 KB cache-tool budget.
+    // Each quote entry is ~80 bytes; 3000 entries ≈ 240 KB in the stocks
+    // slice alone, comfortably above 128 KB after JSON serialisation.
+    // Pass limit: 0 to bypass the DEFAULT_LIST_LIMIT (30) cap.
+    const hugeQuotes = Array.from({ length: 3000 }, (_, i) => ({
+      symbol: `SYM${String(i).padStart(4, '0')}`,
+      price: i + 1,
+      change: 0.01 * i,
+      volume: 1000000 + i,
+    }));
+    mockCacheKeys(
+      { 'market:stocks-bootstrap:v1': { quotes: hugeQuotes }, 'market:crypto:v1': { quotes: [] } },
+      { 'seed-meta:market:stocks': { fetchedAt: Date.now() - 60_000, recordCount: hugeQuotes.length } },
+    );
+    const out = await callTool('get_market_data', { limit: 0 });
+    assert.equal(out._budget_exceeded, true, 'oversized response must return _budget_exceeded envelope');
+    assert.equal(typeof out.budget_bytes, 'number', 'envelope must include budget_bytes');
+    assert.equal(typeof out.actual_bytes, 'number', 'envelope must include actual_bytes');
+    assert.ok(out.actual_bytes > out.budget_bytes, 'actual_bytes must exceed budget_bytes');
+    assert.equal(typeof out.hint, 'string', 'envelope must include a hint string');
+  });
+
+  it('budget: telemetry includes budget_exceeded field', async () => {
+    process.env.MCP_TELEMETRY = 'true';
+    const captured = [];
+    const origLog = console.log;
+    console.log = (line) => captured.push(line);
+
+    // Small payload — within budget
+    mockCacheKeys(
+      { 'market:stocks-bootstrap:v1': { quotes: [{ symbol: 'AAPL', price: 100 }] }, 'market:crypto:v1': { quotes: [] } },
+      { 'seed-meta:market:stocks': { fetchedAt: Date.now() - 60_000, recordCount: 1 } },
+    );
+    const res = await handler(makeReq('POST', {
+      jsonrpc: '2.0', id: 800, method: 'tools/call',
+      params: { name: 'get_market_data', arguments: {} },
+    }));
+    console.log = origLog;
+    assert.equal(res.status, 200);
+
+    const tc = captured.filter((l) => l && typeof l === 'object' && !Array.isArray(l) && l.tag === 'mcp.toolcall');
+    assert.equal(tc.length, 1, `expected exactly one mcp.toolcall line, got ${tc.length}`);
+    assert.equal(tc[0].budget_exceeded, false, 'within-budget call must emit budget_exceeded: false');
   });
 
   it('get_market_data: symbols filter narrows quote arrays across asset slices', async () => {

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -628,6 +628,42 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(tc[0].budget_exceeded, false, 'within-budget call must emit budget_exceeded: false');
   });
 
+  it('budget: telemetry emits budget_exceeded=true when budget is exceeded', async () => {
+    process.env.MCP_TELEMETRY = 'true';
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+    const captured = [];
+    const origLog = console.log;
+    console.log = (line) => captured.push(line);
+
+    // Large payload that exceeds the 128 KB cache-tool budget
+    const hugeQuotes = Array.from({ length: 3000 }, (_, i) => ({
+      symbol: `SYM${String(i).padStart(4, '0')}`,
+      price: i + 1,
+      change: 0.01 * i,
+      volume: 1000000 + i,
+    }));
+    mockCacheKeys(
+      { 'market:stocks-bootstrap:v1': { quotes: hugeQuotes }, 'market:crypto:v1': { quotes: [] } },
+      { 'seed-meta:market:stocks': { fetchedAt: Date.now() - 60_000, recordCount: hugeQuotes.length } },
+    );
+    const freshMod = await import(`../api/mcp.ts?t=${Date.now()}`);
+    const res = await freshMod.default(makeReq('POST', {
+      jsonrpc: '2.0', id: 801, method: 'tools/call',
+      params: { name: 'get_market_data', arguments: { limit: 0 } },
+    }));
+    console.log = origLog;
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    const out = JSON.parse(body.result.content[0].text);
+    assert.equal(out._budget_exceeded, true, 'sanity: response is the budget-exceeded envelope');
+
+    const tc = captured.filter((l) => l && typeof l === 'object' && !Array.isArray(l) && l.tag === 'mcp.toolcall');
+    assert.equal(tc.length, 1, `expected exactly one mcp.toolcall line, got ${tc.length}`);
+    assert.equal(tc[0].budget_exceeded, true, 'over-budget call must emit budget_exceeded: true');
+    assert.equal(tc[0].ok, true, 'budget-exceeded is a successful dispatch, not an error');
+  });
+
   it('get_market_data: symbols filter narrows quote arrays across asset slices', async () => {
     const stocks = { quotes: [{ symbol: 'AAPL', price: 100 }, { symbol: 'MSFT', price: 200 }] };
     const crypto = { quotes: [{ symbol: 'BTC', price: 50000 }] };


### PR DESCRIPTION
## Summary
- Adds a byte-level output budget per tool, enforced AFTER `_postFilter` + summary + JMESPath — returns a `_budget_exceeded` envelope instead of oversized payloads
- Budget tiers: cache tools 128 KB, LLM tools 64 KB, `describe_tool` 8 KB, default 256 KB
- Adds `budget_exceeded: boolean` to `mcp.toolcall` telemetry (both success and error paths)

## Test plan
- [x] `budget: tools/call within budget returns normal response`
- [x] `budget: tools/call exceeding budget returns _budget_exceeded envelope`
- [x] `budget: telemetry includes budget_exceeded field`
- [x] `_outputBudgetBytes` not leaked in `tools/list`
- [x] Existing telemetry schema tests pass with new `budget_exceeded` key
- [x] `npm run typecheck:api` clean
- [x] Full test suite (110 tests) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)