### PR TITLE
docs(mcp): quickstart + JMESPath projection guide

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -122,18 +122,16 @@ export const TOOL_DESCRIPTION_MAX_BYTES = 120;
 
 // Session-level discovery instructions. Per MCP 2025-03-26 lifecycle spec,
 // servers MAY return an `instructions` string in the `initialize` result;
-// clients SHOULD surface this to the model. We carry the JMESPath grammar
-// + worked examples here (rather than duplicating ~500 bytes into every
-// tool's description) so per-tool advertisements stay terse and the LLM
-// gets the full contract once per session.
+// clients SHOULD surface this to the model. We carry the JMESPath contract
+// (grammar URL, projection guide URL, limits) and the describe_tool affordance
+// here — once per session — so per-tool advertisements stay terse. Worked
+// examples used to live inline; they now live in docs/mcp-jmespath.mdx, which
+// the LLM can fetch on demand instead of amortising ~500 bytes per session.
 const SERVER_INSTRUCTIONS = [
   'Every tool accepts an optional `jmespath` string argument. The server applies the expression server-side AFTER any per-tool filter/summary args, projecting the response before serialization. This is the single most effective way to reduce response tokens — typical 80-95% reduction when you only need a subset of fields.',
   '',
   'Grammar: https://jmespath.org/specification.html',
-  'Examples:',
-  '  data.markets.stocks[*].{s:symbol,p:price}',
-  '  data.events[?fatalities > `10`].country',
-  '  data.advisories[?level==\'warning\'][].title',
+  'Guide with 12 worked examples against real response shapes: https://www.worldmonitor.app/docs/mcp-jmespath',
   '',
   `Limits: expression ≤ ${JMESPATH_MAX_EXPR_BYTES} bytes; projected payload ≤ ${JMESPATH_MAX_OUTPUT_BYTES} bytes. Failures return {_jmespath_error, original_keys} inside the normal result envelope. Bad expressions DO consume one daily quota unit on retry — original_keys is echoed so you can self-correct in one extra call.`,
   '',

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -182,8 +182,10 @@
             "group": "MCP & Integrations",
             "pages": [
               "agent-discovery",
+              "mcp-quickstart",
               "mcp-server",
               "mcp-tools-reference",
+              "mcp-jmespath",
               "api-oauth",
               "api-notifications"
             ]

--- a/docs/mcp-jmespath.mdx
+++ b/docs/mcp-jmespath.mdx
@@ -1,0 +1,494 @@
+---
+title: "JMESPath Projection Guide"
+description: "Cut MCP response payloads by 80-95% with JMESPath. Twelve worked examples against real WorldMonitor response shapes."
+---
+
+Every WorldMonitor MCP tool accepts an optional `jmespath` string argument. The server applies the expression **after** any per-tool filter and `summary` args, then projects the response before serialisation. A well-chosen projection typically cuts payload size by **80–95%** — the single most effective lever you have for keeping a long agent loop inside its context window.
+
+This page is the practical reference: a quick orientation, then twelve worked examples against three real captured tool responses. For the grammar itself, lean on the spec — [jmespath.org/specification.html](https://jmespath.org/specification.html). Coming back here is faster than re-reading the spec.
+
+## Quick orientation
+
+- Pass the expression as the `jmespath` argument on any `tools/call`. It applies to the **payload `data`**, not the outer `cached_at` / `stale` envelope — but you can still address the envelope with `cached_at`, `stale`, or `data.…`.
+- **Hyphenated keys must be quoted with double quotes.** Most WorldMonitor tools have hyphenated cache keys (`stocks-bootstrap`, `ucdp-events`, `etf-flows`, `fear-greed`, `transit-summaries`). Use `data."stocks-bootstrap".quotes[*].symbol`, not `data.stocks-bootstrap.…`.
+- **Numbers and JSON literals go in backticks, strings in single quotes.** `[?deathsBest > \`5\`]` (numeric), `[?country == 'Iraq']` (string). Mixing them up silently parses the value as something else.
+- **Two server-side limits** keep edge functions healthy:
+  - Expression itself: ≤ **1024 bytes**.
+  - Projected output: ≤ **256 KB**.
+
+  Failures return `{ _jmespath_error, original_keys, ... }` inside the normal result envelope — the tool call still succeeds at the JSON-RPC layer (no `isError: true`), and `original_keys` echoes the top-level keys of the unprojected response so the model can self-correct on the next call.
+
+The three response shapes used below are the captured fixtures under `tests/fixtures/jmespath-samples/` (re-captured periodically against the prod MCP endpoint). They were picked deliberately — fat (~100 KB), medium (~30 KB), and thin (~10 KB) — to span the size tiers you'll actually project against.
+
+## The twelve examples
+
+### 1. Drill into a single nested object
+
+**Intent.** Skip the equity list and just get the WorldMonitor fear-greed composite score from `get_market_data`.
+
+**Tool call:**
+
+```json
+{
+  "name": "get_market_data",
+  "arguments": {
+    "jmespath": "data.\"fear-greed\".composite"
+  }
+}
+```
+
+**Unprojected response (~100 KB).** Hundreds of equity quotes, every sector, all of crypto, every Gulf ticker, the full fear-greed breakdown:
+
+```json
+{
+  "cached_at": "2026-05-17T10:34:00.852Z",
+  "stale": false,
+  "data": {
+    "stocks-bootstrap": { "quotes": [ /* 200+ entries */ ] },
+    "commodities-bootstrap": { "quotes": [ /* +sparkline arrays */ ] },
+    "crypto": { "quotes": [ /* … */ ] },
+    "sectors": { "sectors": [ /* … */ ] },
+    "etf-flows": { /* … */ },
+    "gulf-quotes": { /* … */ },
+    "fear-greed": {
+      "timestamp": "2026-05-17T06:01:06.163Z",
+      "composite": { "score": 66.5, "label": "Greed", "previous": 67.3 },
+      "categories": { "sentiment": { "score": 55, "weight": 0.1, "inputs": { /* … */ } }, /* … */ }
+    }
+  }
+}
+```
+
+**Projected response:**
+
+```json
+{ "score": 66.5, "label": "Greed", "previous": 67.3 }
+```
+
+**Why this works.** Drill-down is just dotted path navigation. `data."fear-greed"` quotes the hyphenated key, then `.composite` plucks the nested object. Everything else in the payload — the 100 KB of quotes — never crosses the wire.
+
+---
+
+### 2. Slim each item to a few fields (multiselect-hash)
+
+**Intent.** From `get_market_data`, get a compact table of all equity quotes: symbol, price, percent change.
+
+**Tool call:**
+
+```json
+{
+  "name": "get_market_data",
+  "arguments": {
+    "jmespath": "data.\"stocks-bootstrap\".quotes[*].{s:symbol,p:price,chg:change}"
+  }
+}
+```
+
+**Unprojected response (relevant slice).** Each quote also carries `name`, `display`, and a `sparkline` array — none of which the model usually needs for a "what moved today" question:
+
+```json
+[
+  { "symbol": "AAPL", "name": "AAPL", "display": "AAPL", "price": 300.23, "change": 0.6774, "sparkline": [] },
+  { "symbol": "AMZN", "name": "AMZN", "display": "AMZN", "price": 264.14, "change": -1.1526, "sparkline": [] }
+]
+```
+
+**Projected response:**
+
+```json
+[
+  { "s": "AAPL", "p": 300.23, "chg": 0.6774 },
+  { "s": "AMZN", "p": 264.14, "chg": -1.1526 },
+  { "s": "AVGO", "p": 425.19, "chg": -3.3198 }
+]
+```
+
+**Why this works.** `[*]` projects across every array element; `{s:symbol, p:price, chg:change}` is the multiselect-hash — it builds a new object per element using whichever fields you list. Shorter output keys (`s`, `p`, `chg`) shave a few more bytes; standard keys (`symbol`, `price`, `change`) are fine too if you want readability.
+
+---
+
+### 3. Filter on a numeric comparator
+
+**Intent.** From `get_conflict_events`, keep only UCDP events with at least one confirmed fatality.
+
+**Tool call:**
+
+```json
+{
+  "name": "get_conflict_events",
+  "arguments": {
+    "jmespath": "data.\"ucdp-events\".events[?deathsBest > `0`]"
+  }
+}
+```
+
+**Unprojected response (relevant slice).** Many UCDP entries record encounters with `deathsBest: 0` — political incidents, intercepted attacks, near-misses:
+
+```json
+[
+  { "id": "565175", "country": "Ecuador",        "deathsBest": 2,  "violenceType": "UCDP_VIOLENCE_TYPE_NON_STATE" },
+  { "id": "565999", "country": "DR Congo",       "deathsBest": 17, "violenceType": "UCDP_VIOLENCE_TYPE_ONE_SIDED" },
+  { "id": "568494", "country": "Iraq",           "deathsBest": 7,  "violenceType": "UCDP_VIOLENCE_TYPE_STATE_BASED" },
+  { "id": "560968", "country": "Ecuador",        "deathsBest": 0,  "violenceType": "UCDP_VIOLENCE_TYPE_NON_STATE" }
+]
+```
+
+**Projected response:** the `deathsBest: 0` entry is dropped.
+
+**Why this works.** `[?expr]` is the filter projection; `>` is the numeric comparator. **Backticks around the literal** matter — `[?deathsBest > 0]` (no backticks) treats `0` as an identifier, which JMESPath parses but then evaluates to `null`, and the comparison silently returns no rows. Always wrap numeric and boolean literals in backticks.
+
+---
+
+### 4. Filter on string equality
+
+**Intent.** From `get_conflict_events`, get every UCDP event whose `country` is exactly `"Iraq"`.
+
+**Tool call:**
+
+```json
+{
+  "name": "get_conflict_events",
+  "arguments": {
+    "jmespath": "data.\"ucdp-events\".events[?country == 'Iraq']"
+  }
+}
+```
+
+**Projected response:**
+
+```json
+[
+  {
+    "id": "568494",
+    "country": "Iraq",
+    "sideA": "Government of Iraq",
+    "sideB": "IS",
+    "deathsBest": 7,
+    "violenceType": "UCDP_VIOLENCE_TYPE_STATE_BASED",
+    "sourceOriginal": "the Iraqi Security Information Cell"
+  }
+]
+```
+
+**Why this works.** String literals use **single quotes**, not double quotes. Double quotes mean "identifier" in JMESPath (the same syntax used to escape hyphenated keys like `"stocks-bootstrap"`). A common first-time mistake is `[?country == "Iraq"]`, which JMESPath parses as "compare `country` to a field literally named `Iraq`", evaluates the right-hand side to `null`, and returns no rows.
+
+---
+
+### 5. Array projection — flat list of one field
+
+**Intent.** From `get_market_data`, get a flat list of sector ETF tickers.
+
+**Tool call:**
+
+```json
+{
+  "name": "get_market_data",
+  "arguments": {
+    "jmespath": "data.sectors.sectors[*].symbol"
+  }
+}
+```
+
+**Unprojected response (relevant slice):**
+
+```json
+{
+  "sectors": [
+    { "symbol": "XLK", "name": "XLK", "change": -1.805 },
+    { "symbol": "XLF", "name": "XLF", "change": -0.3704 },
+    { "symbol": "XLE", "name": "XLE", "change":  2.3592 }
+  ]
+}
+```
+
+**Projected response:**
+
+```json
+["XLK","XLF","XLE","XLV","XLY","XLI","XLP","XLU","XLB","XLRE","XLC","SMH"]
+```
+
+**Why this works.** `[*]` projects across every array element, and `.symbol` is applied to each one in turn. The result is an array of just the symbol strings — no enclosing objects.
+
+---
+
+### 6. Slice — first N elements
+
+**Intent.** From `get_conflict_events`, return only the first five UCDP events.
+
+**Tool call:**
+
+```json
+{
+  "name": "get_conflict_events",
+  "arguments": {
+    "jmespath": "data.\"ucdp-events\".events[0:5]"
+  }
+}
+```
+
+**Projected response:** a five-element array of the same shape as the unprojected `events[]`.
+
+**Why this works.** `[start:stop]` is the slice projection (`stop` is exclusive). Negative indices and a step are also supported — `[-5:]` for the last five, `[::-1]` to reverse, `[::2]` for every other element. Slicing is **post-filter** in the pipeline — to slice the filtered set, pipe (see example 12).
+
+<Tip>
+**`limit` vs. slicing.** Several tools (`get_country_macro`, `get_eu_*`, `get_displacement_data`) accept a tool-level `limit` argument that caps the response **before** projection. `limit` and JMESPath compose: the tool-level cap narrows the candidate set, then your `[0:N]` slice picks the prefix. Pass `limit: 0` to disable the tool-level cap when you want everything and intend to project further with JMESPath.
+</Tip>
+
+---
+
+### 7. `length()` for counting
+
+**Intent.** How many UCDP events are in the latest bundle?
+
+**Tool call:**
+
+```json
+{
+  "name": "get_conflict_events",
+  "arguments": {
+    "jmespath": "length(data.\"ucdp-events\".events)"
+  }
+}
+```
+
+**Projected response:**
+
+```json
+38
+```
+
+**Why this works.** `length()` is one of JMESPath's built-in functions; it works on arrays, strings, and objects (where it returns the key count). Useful as a sanity check before a longer call — a `length()` projection returns a single integer, costs nothing in tokens, and tells the model whether the bundle is empty before deciding what to project next.
+
+---
+
+### 8. `sort_by` + reverse + slice — Top-N
+
+**Intent.** From `get_conflict_events`, give me the three deadliest UCDP events with country + death count only.
+
+**Tool call:**
+
+```json
+{
+  "name": "get_conflict_events",
+  "arguments": {
+    "jmespath": "sort_by(data.\"ucdp-events\".events, &deathsBest) | reverse(@) | [0:3].{c:country, d:deathsBest}"
+  }
+}
+```
+
+**Projected response:**
+
+```json
+[
+  { "c": "DR Congo (Zaire)", "d": 17 },
+  { "c": "Iraq",             "d": 7  },
+  { "c": "Mexico",           "d": 3  }
+]
+```
+
+**Why this works.** Three stages chained with `|`:
+
+1. `sort_by(events, &deathsBest)` — JMESPath sorts ascending; `&expr` is an **expression reference** (sort key).
+2. `reverse(@)` — flip ascending to descending. `@` is the current node.
+3. `[0:3].{...}` — slice the top three, then multiselect-hash to slim each row.
+
+This is the workhorse shape for "give me the top-N by some metric". The same shape applies to top-N markets by % change, top-N countries by CII score, top-N chokepoints by incident count.
+
+---
+
+### 9. Filter on enum-string field
+
+**Intent.** From `get_conflict_events`, return only UCDP events classified as state-based violence — the highest-severity tier.
+
+**Tool call:**
+
+```json
+{
+  "name": "get_conflict_events",
+  "arguments": {
+    "jmespath": "data.\"ucdp-events\".events[?violenceType == 'UCDP_VIOLENCE_TYPE_STATE_BASED'].{c:country, a:sideA, b:sideB, d:deathsBest}"
+  }
+}
+```
+
+**Projected response:**
+
+```json
+[
+  { "c": "Iraq", "a": "Government of Iraq", "b": "IS", "d": 7 },
+  { "c": "Yemen (North Yemen)", "a": "Government of United Kingdom, Government of United States of America", "b": "Government of Yemen (North Yemen)", "d": 0 }
+]
+```
+
+**Why this works.** Filters and multiselect-hashes compose left-to-right inside the same projection — `[?...].{a:..., b:...}` filters first, then slims each surviving row. Most WorldMonitor responses use upper-snake enum strings (`SEVERITY_LEVEL_HIGH`, `TREND_DIRECTION_STABLE`, `UCDP_VIOLENCE_TYPE_*`); search them with `==` and single quotes exactly as written.
+
+---
+
+### 10. Object-as-map navigation
+
+**Intent.** From `get_chokepoint_status`, get the risk level + 7-day incident count for the Strait of Hormuz only.
+
+**Tool call:**
+
+```json
+{
+  "name": "get_chokepoint_status",
+  "arguments": {
+    "jmespath": "data.\"transit-summaries\".summaries.hormuz_strait.{risk:riskLevel, count:incidentCount7d}"
+  }
+}
+```
+
+**Unprojected response (relevant slice).** Note that `summaries` is **keyed by chokepoint name** (object map), not an array of `{name, ...}` records:
+
+```json
+{
+  "transit-summaries": {
+    "summaries": {
+      "suez":          { "riskLevel": "critical", "incidentCount7d": 28,  "wowChangePct":   4.5, "riskSummary": "..." },
+      "hormuz_strait": { "riskLevel": "critical", "incidentCount7d": 627, "wowChangePct": -72.5, "riskSummary": "..." },
+      "panama":        { "riskLevel": "",         "incidentCount7d": 0,   "wowChangePct":   0.4, "riskSummary": "" }
+    }
+  }
+}
+```
+
+**Projected response:**
+
+```json
+{ "risk": "critical", "count": 627 }
+```
+
+**Why this works.** Object-as-map shapes are everywhere in this server — chokepoints, weights inside `fear-greed.categories`, EU member-keyed series in `get_eu_housing_cycle`. Treat them as dotted path navigation: known key → use the key directly. If you don't know the key, see the next example.
+
+---
+
+### 11. Object-as-map projection — `*` and `keys()`
+
+**Intent.** From `get_chokepoint_status`, list every chokepoint currently rated "critical" with its incident count.
+
+**Tool call:**
+
+```json
+{
+  "name": "get_chokepoint_status",
+  "arguments": {
+    "jmespath": "data.\"transit-summaries\".summaries.* | [?riskLevel == 'critical'].{risk:riskLevel, count:incidentCount7d}"
+  }
+}
+```
+
+**Projected response:**
+
+```json
+[
+  { "risk": "critical", "count": 28  },
+  { "risk": "critical", "count": 627 },
+  { "risk": "critical", "count": 33  },
+  { "risk": "critical", "count": 735 }
+]
+```
+
+**Why this works.** `summaries.*` flattens the map's **values** into an array — so `suez`, `hormuz_strait`, `bab_el_mandeb`, etc. become indexable array elements. Then a normal `[?…]` filter and multiselect-hash apply.
+
+The flatten drops the original map keys (the chokepoint names). If you need the names too, project them separately with `keys(data."transit-summaries".summaries)`, or accept the structural mismatch and switch to the sibling `chokepoint_transits.transits` payload, which IS keyed-as-map of `{tanker, cargo, other, total}` with the chokepoint name as the key — `keys(data.chokepoint_transits.transits)` gets you a flat list of every chokepoint covered.
+
+---
+
+### 12. Pipe combinator — multi-stage projection
+
+**Intent.** From `get_conflict_events`, give me the five deadliest fatality-positive events with country, death count, and violence type.
+
+**Tool call:**
+
+```json
+{
+  "name": "get_conflict_events",
+  "arguments": {
+    "jmespath": "data.\"ucdp-events\".events[?deathsBest > `0`] | sort_by(@, &deathsBest) | reverse(@) | [0:5].{c:country, d:deathsBest, t:violenceType}"
+  }
+}
+```
+
+**Projected response:**
+
+```json
+[
+  { "c": "DR Congo (Zaire)", "d": 17, "t": "UCDP_VIOLENCE_TYPE_ONE_SIDED" },
+  { "c": "Iraq",             "d": 7,  "t": "UCDP_VIOLENCE_TYPE_STATE_BASED" },
+  { "c": "Mexico",           "d": 3,  "t": "UCDP_VIOLENCE_TYPE_NON_STATE" },
+  { "c": "Ecuador",          "d": 2,  "t": "UCDP_VIOLENCE_TYPE_NON_STATE" },
+  { "c": "Brazil",           "d": 1,  "t": "UCDP_VIOLENCE_TYPE_NON_STATE" }
+]
+```
+
+**Why this works.** `|` resets the context to "the result so far" and starts a new projection — so the filter runs first, the sort runs against the filtered set (not the whole array), reverse flips it, slice takes the top five, and the multiselect-hash slims each row. Pipe is the right tool whenever you need to apply a projection (like `sort_by`) *after* a filter rather than across the original array.
+
+## Escape hatches
+
+### Get the full payload (no projection)
+
+Omit the `jmespath` argument entirely. Some tools (`get_country_macro`, the three `get_eu_*` tools, `get_displacement_data`) also default-cap their list-shaped fields at 30 rows for the same reason; pass `limit: 0` to disable that cap when you genuinely want the whole bundle:
+
+```json
+{
+  "name": "get_country_macro",
+  "arguments": { "limit": 0 }
+}
+```
+
+This is the right call when you're capturing a fixture, running a one-off audit, or piping the response into a more expressive downstream filter (your own jq, a notebook). For day-to-day model context, a projection almost always wins.
+
+### `_budget_exceeded` — when the payload is too big
+
+Each tool declares a per-tool output budget (`_outputBudgetBytes`). When a tool's serialised response exceeds that budget **after** all filtering, `summary`, and JMESPath have been applied, the server returns this envelope instead of the oversized payload — still inside the normal MCP result, still HTTP 200, still `isError: false`:
+
+```json
+{
+  "_budget_exceeded": true,
+  "budget_bytes": 65536,
+  "actual_bytes": 142337,
+  "hint": "Response still exceeds tool output budget after JMESPath projection. Use a more selective expression to project fewer fields, or apply tool-level filters to narrow the result set."
+}
+```
+
+The recovery is always the same: **make the projection more selective**, or layer a tool-level filter (`country`, `since`, `limit`) underneath it. The Pro daily quota is automatically rolled back when this envelope fires — you don't pay a quota slot for a response you can't use.
+
+### `_jmespath_error` — when the projection itself fails
+
+A JMESPath expression can fail in two ways: it can be syntactically invalid, or it can blow up the per-call output limit (256 KB) via a runaway multiselect-hash. Either way you get this envelope back:
+
+```json
+{
+  "_jmespath_error": {
+    "kind": "invalid_expression",
+    "message": "Parse error: …",
+    "expression": "data.\"stocks-bootstrap\".quotes[*"
+  },
+  "original_keys": ["stocks-bootstrap", "commodities-bootstrap", "crypto", "sectors", "etf-flows", "gulf-quotes", "fear-greed"]
+}
+```
+
+`original_keys` is the top-level keys of the unprojected response — enough context for the model to retry with a corrected expression in one extra call. A bad expression **does** consume one daily quota slot per attempt; the echoed `original_keys` exists specifically to make the retry self-correcting rather than guesswork.
+
+## Complements to projection
+
+### `summary: true` flag
+
+Every cache tool also accepts a universal `summary: true` argument that returns a server-built summary (counts + samples) instead of the full payload. Use it when:
+
+- You want a quick sanity-check of what's in the bundle before designing a projection — `summary: true` returns the shape and tier counts in a handful of fields.
+- The model only needs aggregate counts ("how many active conflicts?", "how many critical chokepoints?") and not the underlying rows.
+
+`summary: true` and `jmespath` compose: the summary is built first, then the projection applies on top. Combine the two when you want the summary's pre-aggregated counts but only some of the categories.
+
+### `describe_tool`
+
+When `tools/list` returns a compressed description that's ambiguous about a tool's response shape, call `describe_tool({ tool_name: "get_market_data" })` to fetch the full uncompressed definition. `describe_tool` is metadata-only and **exempt from the Pro daily quota** — use it freely while authoring projections. If the name is wrong, the response is `{ error: "unknown_tool", available: [...] }`, again with no quota cost.
+
+## See also
+
+- [JMESPath specification](https://jmespath.org/specification.html) — the canonical grammar reference.
+- [MCP Quickstart](/mcp-quickstart) — five-minute zero-to-first-call onboarding.
+- [MCP Tools Reference](/mcp-tools-reference) — per-tool parameters, freshness budgets, and response shapes for every tool.
+- [MCP Server reference](/mcp-server) — auth, OAuth setup, plans, quotas, errors.

--- a/docs/mcp-jmespath.mdx
+++ b/docs/mcp-jmespath.mdx
@@ -9,7 +9,7 @@ This page is the practical reference: a quick orientation, then twelve worked ex
 
 ## Quick orientation
 
-- Pass the expression as the `jmespath` argument on any `tools/call`. It applies to the **payload `data`**, not the outer `cached_at` / `stale` envelope — but you can still address the envelope with `cached_at`, `stale`, or `data.…`.
+- Pass the expression as the `jmespath` argument on any `tools/call`. The expression root is the **full response envelope** — `{ cached_at, stale, data: { … } }` for cache tools — so most expressions start with `data.<key>` to reach the payload, and `cached_at` / `stale` are addressable from the same root when you want them.
 - **Hyphenated keys must be quoted with double quotes.** Most WorldMonitor tools have hyphenated cache keys (`stocks-bootstrap`, `ucdp-events`, `etf-flows`, `fear-greed`, `transit-summaries`). Use `data."stocks-bootstrap".quotes[*].symbol`, not `data.stocks-bootstrap.…`.
 - **Numbers and JSON literals go in backticks, strings in single quotes.** `[?deathsBest > \`5\`]` (numeric), `[?country == 'Iraq']` (string). Mixing them up silently parses the value as something else.
 - **Two server-side limits** keep edge functions healthy:

--- a/docs/mcp-quickstart.mdx
+++ b/docs/mcp-quickstart.mdx
@@ -133,20 +133,24 @@ curl -s https://worldmonitor.app/mcp \
     "params":{"name":"get_market_data","arguments":{}}
   }'
 
-# 3. Same call with a JMESPath projection (much smaller response)
+# 3. Same call with a JMESPath projection (much smaller response).
+# Heredoc keeps the single-quoted JMESPath string literals readable —
+# wrapping the JSON in -d '...' would collide with the inner quotes.
 curl -s https://worldmonitor.app/mcp \
   -H "X-WorldMonitor-Key: $WM_KEY" \
   -H 'Content-Type: application/json' \
-  -d '{
-    "jsonrpc":"2.0","id":3,
-    "method":"tools/call",
-    "params":{
-      "name":"get_market_data",
-      "arguments":{
-        "jmespath":"data.\"stocks-bootstrap\".quotes[?symbol==`AAPL` || symbol==`MSFT`].{s:symbol,p:price}"
-      }
+  --data-binary @- <<'EOF'
+{
+  "jsonrpc":"2.0","id":3,
+  "method":"tools/call",
+  "params":{
+    "name":"get_market_data",
+    "arguments":{
+      "jmespath":"data.\"stocks-bootstrap\".quotes[?symbol=='AAPL' || symbol=='MSFT'].{s:symbol,p:price}"
     }
-  }'
+  }
+}
+EOF
 ```
 
 The `wm_live_…` key goes in `X-WorldMonitor-Key`, **not** as a `Bearer` token — sending it as a bearer fails OAuth resolution and returns `401 invalid_token`. If you already have an OAuth access token from `/api/oauth/token`, use `Authorization: Bearer $TOKEN` instead and drop the `X-WorldMonitor-Key` header.

--- a/docs/mcp-quickstart.mdx
+++ b/docs/mcp-quickstart.mdx
@@ -1,0 +1,163 @@
+---
+title: "MCP Quickstart"
+description: "Connect Claude Desktop to WorldMonitor and make your first real intelligence call in five minutes."
+---
+
+WorldMonitor exposes 39 live tools — markets, conflict events, maritime chokepoints, aviation, climate, AI briefs — over the [Model Context Protocol](https://modelcontextprotocol.io). This page is the shortest path from zero to a useful response inside Claude. Everything else in the [MCP Server reference](/mcp-server) is optional reading once this works.
+
+## 1. Pick a tier and grab credentials
+
+Free accounts can't reach the MCP server — the OAuth flow returns `401 INSUFFICIENT_TIER`. You need one of:
+
+- **Pro** — sign in with your WorldMonitor account, no key to manage. 50 tool calls per UTC day.
+- **API Starter / Business / Enterprise** — paste a `wm_live_…` key in your client, or use the same OAuth flow as Pro. 1,000 / 10,000 / unlimited calls per day.
+
+Upgrade or generate a key at [worldmonitor.app/pro](https://www.worldmonitor.app/pro). The rest of this guide assumes Claude Desktop + OAuth (the simplest path); if you'd rather paste a `wm_…` key into a `curl` script, jump to [Server-side curl](#server-side-curl) at the bottom.
+
+## 2. Add the server to Claude Desktop
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or the Windows equivalent at `%APPDATA%\Claude\claude_desktop_config.json` and add the `worldmonitor` entry:
+
+```json
+{
+  "mcpServers": {
+    "worldmonitor": {
+      "url": "https://worldmonitor.app/mcp"
+    }
+  }
+}
+```
+
+Restart Claude Desktop. The first time you mention WorldMonitor in a chat, Claude pops the OAuth consent screen — click **Sign in with WorldMonitor Pro**, authenticate in your browser, and the token is stored locally by Claude. No API key ever touches your filesystem.
+
+<Tip>
+Cursor, Claude web, and MCP Inspector use the same URL. See [client setup](/mcp-server#client-setup) for the exact config field per client.
+</Tip>
+
+## 3. Ask your first question
+
+Open a new chat in Claude Desktop and try:
+
+> _What's the current US equity market sentiment and which sectors are leading or lagging today?_
+
+Claude will pick `get_market_data` from the WorldMonitor toolset, call it with no arguments, and answer in plain English. The raw tool response is a single bootstrap bundle covering quotes, sector ETFs, crypto, gulf quotes, ETF flows, and the WorldMonitor fear-greed composite. Typical latency: **300–800 ms** (cache read from Redis, no upstream API call).
+
+Behind the scenes, the tool call looks like this:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": { "name": "get_market_data", "arguments": {} }
+}
+```
+
+And the response is a standard MCP content block — a single text block whose `text` field is the JSON payload:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "content": [
+      { "type": "text", "text": "{\"cached_at\":\"2026-05-17T10:34:00.852Z\",\"stale\":false,\"data\":{\"stocks-bootstrap\":{...},\"sectors\":{...},\"fear-greed\":{...}}}" }
+    ],
+    "isError": false
+  }
+}
+```
+
+Two payload-level fields you'll see on every cache tool:
+
+- `cached_at` — ISO timestamp of the oldest contributing data point. Use this to reason about how fresh the answer is.
+- `stale` — `true` when any contributing seed exceeded its freshness budget. Tells the model when to caveat its answer.
+
+## 4. Trim the response (when it matters)
+
+`get_market_data` returns roughly 100 KB unfiltered. That's fine for one call, but if you're chaining several reads inside a longer conversation, you'll burn context fast. Every tool accepts an optional `jmespath` argument that projects the response server-side **before** it crosses the wire:
+
+```json
+{
+  "name": "get_market_data",
+  "arguments": {
+    "jmespath": "data.\"stocks-bootstrap\".quotes[?symbol=='AAPL' || symbol=='MSFT'].{s:symbol,p:price,chg:change}"
+  }
+}
+```
+
+Same call, ~120 bytes of response instead of 100 KB. JMESPath cuts payload by **80–95%** for typical projections.
+
+Don't try to memorise the grammar from scratch — head to the [JMESPath guide](/mcp-jmespath) for the 12 worked examples covering filters, projections, multiselect-hash, and the rest of the slices you'll actually use.
+
+## 5. Browse the full tool catalog
+
+`get_market_data` is one of 39 tools. The rest cover:
+
+- **Geopolitical & security** — `get_conflict_events`, `get_country_risk`, `get_military_posture`, `get_cyber_threats`, `get_sanctions_data`, `get_news_intelligence`.
+- **Movement & infrastructure** — `get_chokepoint_status`, `get_maritime_activity`, `get_airspace`, `get_aviation_status`, `search_flights`.
+- **Energy & macro** — `get_energy_intelligence`, `get_economic_data`, `get_country_macro`, `get_tariff_trends`, `get_eu_housing_cycle`, `get_eu_quarterly_gov_debt`, `get_eu_industrial_production`.
+- **Environment & health** — `get_climate_data`, `get_natural_disasters`, `get_radiation_data`, `get_health_signals`.
+- **AI synthesis** (live LLM, slower — 1–4 s) — `get_world_brief`, `get_country_brief`, `analyze_situation`, `generate_forecasts`.
+
+Full per-tool parameters, freshness budgets, and `curl` examples are in the [MCP Tools Reference](/mcp-tools-reference). When the compressed `tools/list` description is ambiguous about a specific tool, call `describe_tool` with `tool_name: "<name>"` for the full uncompressed definition — it's exempt from your daily quota, so use it freely while exploring.
+
+## What just happened
+
+The MCP handshake is invisible from the chat side, but here's the sequence so you know where to look if something breaks:
+
+1. Claude Desktop reads `claude_desktop_config.json`, sees the WorldMonitor server, and on first use POSTs `initialize` to `https://worldmonitor.app/mcp`. The server responds with its capabilities, the protocol version (`2025-03-26`), and a session-level `instructions` string that tells the model about the universal `jmespath` argument.
+2. Claude Desktop calls `tools/list` and receives 39 compressed tool descriptions (`≤120` bytes per tool). The compressed form keeps `tools/list` cheap; `describe_tool` returns the full definition on demand.
+3. When you ask a question that needs live data, Claude picks a tool, calls `tools/call`, and inlines the response into its reply. Cache tools return in under a second; LLM-backed tools (`get_world_brief`, `analyze_situation`, etc.) take 1–4 s.
+
+## Server-side curl
+
+If you'd rather skip the OAuth dance and drive MCP from a script:
+
+```bash
+export WM_KEY="wm_live_..."  # API Starter+ key from worldmonitor.app/settings
+
+# 1. List tools (compressed descriptions)
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+
+# 2. Call a cache tool
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":2,
+    "method":"tools/call",
+    "params":{"name":"get_market_data","arguments":{}}
+  }'
+
+# 3. Same call with a JMESPath projection (much smaller response)
+curl -s https://worldmonitor.app/mcp \
+  -H "X-WorldMonitor-Key: $WM_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "jsonrpc":"2.0","id":3,
+    "method":"tools/call",
+    "params":{
+      "name":"get_market_data",
+      "arguments":{
+        "jmespath":"data.\"stocks-bootstrap\".quotes[?symbol==`AAPL` || symbol==`MSFT`].{s:symbol,p:price}"
+      }
+    }
+  }'
+```
+
+The `wm_live_…` key goes in `X-WorldMonitor-Key`, **not** as a `Bearer` token — sending it as a bearer fails OAuth resolution and returns `401 invalid_token`. If you already have an OAuth access token from `/api/oauth/token`, use `Authorization: Bearer $TOKEN` instead and drop the `X-WorldMonitor-Key` header.
+
+## Where to go next
+
+- **[JMESPath guide](/mcp-jmespath)** — projection grammar with 12 worked examples against real response shapes. Read this before your second day of MCP use; it will pay for itself in saved tokens within an hour.
+- **[MCP Tools Reference](/mcp-tools-reference)** — per-tool parameters, freshness budgets, API endpoint mapping, and `curl` examples for every tool.
+- **[MCP Server reference](/mcp-server)** — auth modes, OAuth setup, plans & quotas, error codes, and freshness model.
+- **[Authentication overview](/authentication)** — when to use a `wm_live_…` key vs. OAuth vs. browser session.
+
+## Operational note (for ops, not callers)
+
+Every `initialize` and `tools/call` emits a structured telemetry line tagged `mcp.toolcall` or `mcp.initialize` with latency, payload bytes (pre and post JMESPath), `jmespath_used`, and `budget_exceeded`. Pipe Vercel / log-drain consumers at this line if you want a real P95 per tool. Caller-facing behaviour is unaffected.

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -5,6 +5,10 @@ description: "Connect Claude, Cursor, and other MCP-compatible clients to WorldM
 
 WorldMonitor exposes its intelligence stack as a [Model Context Protocol](https://modelcontextprotocol.io) server so any MCP-compatible client (Claude Desktop, Claude web, Cursor, MCP Inspector, custom agents) can pull live conflict, market, aviation, maritime, economic, and forecasting data directly into a model's context.
 
+<Tip>
+**New here?** The [MCP Quickstart](/mcp-quickstart) is a five-minute path from zero to a real tool call in Claude Desktop. Come back to this page for auth modes, plans, OAuth setup, and the full tool catalog.
+</Tip>
+
 <Info>
 **Pro and API tiers can both connect via OAuth — no API key required.** Pro subscribers click _"Sign in with WorldMonitor Pro"_ on the consent page; API Starter / Business / Enterprise users may sign in the same way OR paste a `wm_…` key. Free-tier users see a 401 at the OAuth step.
 </Info>
@@ -164,7 +168,7 @@ npx @modelcontextprotocol/inspector https://worldmonitor.app/mcp
 The server exposes 39 tools. Most are cache-reads over pre-seeded Redis keys (sub-second). Six (`get_world_brief`, `get_country_brief`, `analyze_situation`, `generate_forecasts`, `search_flights`, `search_flight_prices_by_date`) call live LLMs or external APIs and are slower. One (`describe_tool`, added v1.5.0) returns the full uncompressed definition of any other tool — useful when the compressed `tools/list` description is ambiguous; exempt from the Pro daily quota.
 
 <Tip>
-For per-tool parameters, freshness budgets, timeouts, and concrete `curl` examples, see the [MCP Tools Reference](/mcp-tools-reference).
+For per-tool parameters, freshness budgets, timeouts, and concrete `curl` examples, see the [MCP Tools Reference](/mcp-tools-reference). For payload projection — every tool accepts an optional `jmespath` argument that typically cuts response size by 80-95% — see the [JMESPath guide](/mcp-jmespath).
 </Tip>
 
 ### Markets & economy
@@ -368,6 +372,9 @@ Tool-level errors return `isError: true` with a text explanation in `content`.
 
 ## Related
 
+- [MCP Quickstart](/mcp-quickstart) — five-minute zero-to-first-call walkthrough
+- [JMESPath guide](/mcp-jmespath) — projection grammar + 12 worked examples
+- [MCP Tools Reference](/mcp-tools-reference) — per-tool parameters and `curl` examples
 - [Authentication overview](/authentication) — browser vs bearer vs OAuth
 - [API Reference](/api-reference) — the same data via REST
 - [Pro features](https://www.worldmonitor.app/pro)


### PR DESCRIPTION
## Summary

Two new developer docs aimed at the zero-adoption end of the MCP funnel, plus a small trim to the server's per-session instructions string to compensate.

- **`docs/mcp-quickstart.mdx`** — five-minute zero-to-first-call walkthrough. Targets the simplest path (Claude Desktop + OAuth) and routes scripted callers to a server-side `curl` section. Explains what `cached_at` / `stale` mean, what the initialize/tools/list/tools-call handshake looks like, and where to go next. No "Troubleshooting" or "FAQ" sections by design — if a path fails, fix the doc upstream.
- **`docs/mcp-jmespath.mdx`** — projection grammar with 12 worked examples against the three captured fixtures (`fat-get-market-data`, `medium-get-conflict-events`, `thin-get-chokepoint-status`). Covers field access, numeric/string filters, multiselect-hash, array projection, slicing, `length()`, `sort_by` top-N, object-as-map navigation/projection, and pipes. Documents the `_budget_exceeded` and `_jmespath_error` envelopes, plus `summary: true` and `describe_tool` as complements.
- **`api/mcp.ts` (`SERVER_INSTRUCTIONS`)** — replaces the three inline JMESPath worked examples with a single link to the new guide. Grammar URL, byte limits, and `describe_tool` affordance preserved (those are server-state, not worked examples). Net ~250 fewer bytes amortised per `initialize`.
- **`docs/mcp-server.mdx`** — adds the quickstart entry-point tip at the top, a JMESPath guide link in the tool-catalog tip, and both new pages in the Related section. No rewrites.
- **`docs/docs.json`** — wires both new pages into the MCP & Integrations nav group.

The full error catalog (RPC + HTTP + soft-behavior envelopes) and `outputSchema` examples are deliberately **deferred** to a follow-up — they're blocked on upstream work (envelope-name freeze, `outputSchema` on the wire) that hasn't shipped yet.

## Test plan

- [x] `npm run typecheck:api` green
- [x] `npm run test:data` green (9446/9446, including `mdx-lint`, `mcp-tools-list-compression`, `mcp-bootstrap-parity`, `mcp-api-parity`, `mcp-schema-default-parity`)
- [ ] Mintlify deploy preview renders `/mcp-quickstart` and `/mcp-jmespath` with no broken links (verify on Vercel/Mintlify preview from this PR)
- [ ] `initialize.instructions` still asserts on `describe_tool` mention + `TOOL_DESCRIPTION_MAX_BYTES` cap (covered by `mcp-tools-list-compression.test.mjs`, passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)