### PR TITLE
feat(cii): unify the Country Instability Index (Phases 0-3b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to World Monitor are documented here.
 
 ### Changed
 
-- **CII formula `v2`** — the Composite Instability Index `Security` component now scores military flights, military vessels and aviation disruptions in addition to GPS jamming (previously GPS-jamming-only — issue #3738). The composite blend gains `newsUrgencyBoost`, `earthquakeBoost`, `sanctionsBoost`, an AIS-disruption boost and a temporal-anomaly boost; `cyberBoost`/`fireBoost` are now severity-weighted. Public `combinedScore` values shift accordingly and `methodology_version` is bumped `v1` → `v2` — clients pinned on it should re-baseline. See `docs/methodology/cii-risk-scores.mdx` (#3864).
+- **CII formula `v2`** — the Composite Instability Index `Security` component now scores military flights, military vessels and aviation disruptions in addition to GPS jamming (previously GPS-jamming-only — issue #3738). The composite blend gains `newsUrgencyBoost`, `earthquakeBoost`, `sanctionsBoost` and an AIS-disruption boost; `cyberBoost`/`fireBoost` are now severity-weighted. Public `combinedScore` values shift accordingly and `methodology_version` is bumped `v1` → `v2` — clients pinned on it should re-baseline. See `docs/methodology/cii-risk-scores.mdx` (#3864).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to World Monitor are documented here.
 
 ## [Unreleased]
 
+### Changed
+
+- **CII formula `v2`** — the Composite Instability Index `Security` component now scores military flights, military vessels and aviation disruptions in addition to GPS jamming (previously GPS-jamming-only — issue #3738). The composite blend gains `newsUrgencyBoost`, `earthquakeBoost`, `sanctionsBoost`, an AIS-disruption boost and a temporal-anomaly boost; `cyberBoost`/`fireBoost` are now severity-weighted. Public `combinedScore` values shift accordingly and `methodology_version` is bumped `v1` → `v2` — clients pinned on it should re-baseline. See `docs/methodology/cii-risk-scores.mdx` (#3864).
+
 ### Added
 
 - **Unified OpenAPI bundle** — `docs/api/worldmonitor.openapi.yaml` is now emitted alongside per-service specs, merging every WorldMonitor RPC into a single OpenAPI 3.1 document (190 operations). Powered by sebuf v0.11.1's origin-level bundle support ([SebastienMelki/sebuf#158](https://github.com/SebastienMelki/sebuf/issues/158)). Bumps `SEBUF_VERSION` in the Makefile from v0.7.0 to v0.11.1 — rerun `make install-plugins` after pulling.

--- a/api/health.js
+++ b/api/health.js
@@ -300,6 +300,7 @@ const SEED_META = {
   iranEvents:       { key: 'seed-meta:conflict:iran-events',      maxStaleMin: 20160 }, // manual seed from LiveUAMap; 20160 = 14d = 2× weekly cadence
   ucdpEvents:       { key: 'seed-meta:conflict:ucdp-events',      maxStaleMin: 420 },
   militaryFlights:  { key: 'seed-meta:military:flights',           maxStaleMin: 30 }, // cron ~10min (LIVE_TTL=600s); 30min = 3x interval,
+  militaryCii:      { key: 'seed-meta:intelligence:military-cii',  maxStaleMin: 45 }, // seed-military-cii cron ~10min; 45 = generous grace (relay-dependent; preserve-last-good runs still refresh meta)
   satellites:       { key: 'seed-meta:intelligence:satellites',    maxStaleMin: 240 }, // CelesTrak every 120min; 240min = absorbs one missed cycle
   weatherAlerts:    { key: 'seed-meta:weather:alerts',             maxStaleMin: 45 }, // relay loop every 15min; 45 = 3× interval (was 30 = 2×, too tight on relay hiccup)
   spending:         { key: 'seed-meta:economic:spending',          maxStaleMin: 120 },

--- a/api/health.js
+++ b/api/health.js
@@ -143,6 +143,7 @@ const STANDALONE_KEYS = {
   militaryBases:         'military:bases:active',
   militaryFlights:       'military:flights:v1',
   militaryFlightsStale:  'military:flights:stale:v1',
+  militaryCii:           'intelligence:military-cii:v1',
   temporalAnomalies:     'temporal:anomalies:v1',
   displacement:          `displacement:summary:v1:${new Date().getUTCFullYear()}`,
   displacementPrev:      `displacement:summary:v1:${new Date().getUTCFullYear() - 1}`,

--- a/api/health.js
+++ b/api/health.js
@@ -143,6 +143,10 @@ const STANDALONE_KEYS = {
   militaryBases:         'military:bases:active',
   militaryFlights:       'military:flights:v1',
   militaryFlightsStale:  'military:flights:stale:v1',
+  // STANDALONE (not BOOTSTRAP) by design — value is a single keyed payload
+  // (asOf + per-country aggregate), no per-record gating needed; health just
+  // verifies existence + freshness via the matching SEED_META entry. Same
+  // shape as militaryFlights above.
   militaryCii:           'intelligence:military-cii:v1',
   temporalAnomalies:     'temporal:anomalies:v1',
   displacement:          `displacement:summary:v1:${new Date().getUTCFullYear()}`,

--- a/docs/methodology/cii-risk-scores.mdx
+++ b/docs/methodology/cii-risk-scores.mdx
@@ -26,10 +26,10 @@ The current version is **v2**.
 > **v2 (2026-05-22).** The `Security` component is no longer GPS-jamming-only
 > — it now scores military flights, military vessels and aviation disruptions
 > alongside GPS jamming (issue #3738). The composite blend gains
-> `newsUrgencyBoost`, `earthquakeBoost`, `sanctionsBoost`, an AIS-disruption
-> boost and a temporal-anomaly boost, and `cyberBoost`/`fireBoost` are now
-> severity-weighted rather than raw counts. `combinedScore` values shift
-> accordingly — clients pinned on `methodology_version` should re-baseline.
+> `newsUrgencyBoost`, `earthquakeBoost`, `sanctionsBoost` and an AIS-disruption
+> boost, and `cyberBoost`/`fireBoost` are now severity-weighted rather than raw
+> counts. `combinedScore` values shift accordingly — clients pinned on
+> `methodology_version` should re-baseline.
 
 > **Heads up — coefficient changes.** Any edit to the per-country baselines,
 > event multipliers, or the strategic-risk roll-up coefficients MUST come
@@ -70,7 +70,6 @@ composite = baseline * 0.4
           + earthquakeBoost   (≤ 25)
           + sanctionsBoost    (≤ 14)
           + aisBoost          (≤ 10, AIS disruptions)
-          + temporalBoost     (≤  6, temporal anomalies)
 ```
 
 `composite` is then clamped to `[floor, 100]` where `floor` is the larger of:

--- a/docs/methodology/cii-risk-scores.mdx
+++ b/docs/methodology/cii-risk-scores.mdx
@@ -1,6 +1,6 @@
 ---
 title: "CII Risk Scoring Methodology"
-description: "Editorial methodology behind the Composite Instability Index (CII) and Strategic Risk roll-up. Documents per-country baselineRisk, eventMultiplier, the four-component score (Unrest, Conflict, Security, Information), strategic-risk band derivation, and the v1 formula version stamped on every CiiScore."
+description: "Editorial methodology behind the Composite Instability Index (CII) and Strategic Risk roll-up. Documents per-country baselineRisk, eventMultiplier, the four-component score (Unrest, Conflict, Security, Information), strategic-risk band derivation, and the v2 formula version stamped on every CiiScore."
 ---
 
 <Warning>
@@ -21,7 +21,15 @@ agree.
 
 The on-the-wire `methodology_version` field on every `CiiScore` reflects
 which revision of this document was active when the score was computed.
-The current version is **v1**.
+The current version is **v2**.
+
+> **v2 (2026-05-22).** The `Security` component is no longer GPS-jamming-only
+> — it now scores military flights, military vessels and aviation disruptions
+> alongside GPS jamming (issue #3738). The composite blend gains
+> `newsUrgencyBoost`, `earthquakeBoost`, `sanctionsBoost`, an AIS-disruption
+> boost and a temporal-anomaly boost, and `cyberBoost`/`fireBoost` are now
+> severity-weighted rather than raw counts. `combinedScore` values shift
+> accordingly — clients pinned on `methodology_version` should re-baseline.
 
 > **Heads up — coefficient changes.** Any edit to the per-country baselines,
 > event multipliers, or the strategic-risk roll-up coefficients MUST come
@@ -42,7 +50,7 @@ exposed on the wire as `CiiComponents`:
 |---|---|
 | `cii_contribution` (**U**nrest) | Civil disorder pressure: ACLED protests + riots, fatalities from those events, and confirmed internet/power outages. Reflects pre-violent friction. |
 | `geo_convergence` (**C**onflict) | Kinetic activity: ACLED battles, explosions/remote violence, and violence-against-civilians events, plus Iran-region strike intensity. Square-root fatality scaling prevents single-event saturation. |
-| `military_activity` (**S**ecurity) | Hard-security tempo near the country: GPS-jamming hex density (high vs medium severity) over the country bounding box. |
+| `military_activity` (**S**ecurity) | Hard-security tempo near the country: military flight activity, military vessel activity, aviation disruptions (closures/delays), and GPS-jamming hex density. Foreign military presence is weighted ×2. |
 | `news_activity` (**I**nformation) | Information-environment pressure: weighted count of classified critical/high/medium news headlines geo-attributed to the country. |
 
 The four components are weighted into the headline `combinedScore`:
@@ -52,12 +60,17 @@ eventScore = U * 0.25 + C * 0.30 + S * 0.20 + I * 0.25
 
 composite = baseline * 0.4
           + eventScore * 0.6
-          + climateBoost     (≤ 15)
-          + cyberBoost       (≤ 10)
-          + fireBoost        (≤  8)
-          + advisoryBoost    (≤ 15)
-          + orefBlendBoost   (IL only, ≤ 25)
+          + climateBoost      (≤ 15)
+          + cyberBoost        (≤ 12, severity-weighted)
+          + fireBoost         (≤  8, high-fire weighted)
+          + advisoryBoost     (≤ 15)
+          + orefBlendBoost    (IL only, ≤ 25)
           + displacementBoost (≤ 20)
+          + newsUrgencyBoost  (≤  5)
+          + earthquakeBoost   (≤ 25)
+          + sanctionsBoost    (≤ 14)
+          + aisBoost          (≤ 10, AIS disruptions)
+          + temporalBoost     (≤  6, temporal anomalies)
 ```
 
 `composite` is then clamped to `[floor, 100]` where `floor` is the larger of:

--- a/plans/cii-phase3a-decisions.md
+++ b/plans/cii-phase3a-decisions.md
@@ -7,12 +7,20 @@ Every row is a real divergence between the two engines, verified line-by-line:
 - **Engine A — frontend**: `src/services/country-instability.ts`
 - **Engine B — server**: `server/worldmonitor/intelligence/v1/get-risk-scores.ts`
 
-Each row has a **Recommendation** (pre-filled, with rationale) and a **Decision** column
-for you. Default rule from the plan: *frontend wins, except where the server intentionally
-diverged.* Fill the Decision column (`A` / `B` / `new`) — blank means "accept recommendation."
+Default rule from the plan: *frontend wins, except where the server intentionally diverged.*
 
-Caps the score anyway: the composite is `Math.min(100, Math.max(floor, blend))` in both
-engines, so individual boost caps are about *shape*, not overflow.
+## Decisions — signed off 2026-05-22
+
+**All recommendations accepted** as the canonical decision (Decision column filled per row
+below). Two items carried forward:
+
+- **N3 (cold-cache fallback)** — stays **OPEN**. No engineering recommendation exists; it is
+  a product/UX call. Does not block Phase 3b — it gates Phase 4.
+- **V1 (keep vs drop military vessels)** — **BLOCKED** on deployment data. The vessel
+  signal's weight in the blend cannot be measured until `seed-military-cii.mjs` runs on
+  Railway. Default until then: keep vessels (already built).
+
+With those two exceptions Phase 3a is settled — **Phase 3b may proceed against this table.**
 
 ---
 
@@ -20,13 +28,13 @@ engines, so individual boost caps are about *shape*, not overflow.
 
 | # | Component | Engine A (frontend) | Engine B (server) | Recommendation | Decision |
 |---|---|---|---|---|---|
-| C1 | **Unrest** | adds `severityBoost = min(20, highSeverity·10·mult)`; counts `protests.length` | no `severityBoost`; counts `protests + riots` | **A** — port `severityBoost`; keep server's `protests+riots` (riots belong in unrest). Hybrid: A's formula + riots included. | |
-| C2 | **Conflict** | has `hapiFallback` + `newsFloor` when ACLED empty; generic 7-day `recentStrikes` | no fallbacks; `iranStrikes + highSeverityStrikes` only | **A** — the fallbacks matter: without them the server scores 0 conflict whenever ACLED is empty. Port `hapiFallback` + `newsFloor`. | |
-| C3 | **Security** | `flightScore + vesselScore + aviationScore + gpsJammingScore` (4 inputs) | `gpsJammingScore` only | **A** — the 4-input formula. Server now has all inputs after Phases 1–2. This is the mechanical half of the #3738 fix. | |
-| C4 | **Information** | velocity-aware score from local `newsEvents` clustering | `newsScore + threatSummaryScore` (pre-computed, additive) | **B** — the server **cannot** run A's formula (no local `newsEvents`), and the server's cap was a deliberate #3739 improvement. Server wins; bring the frontend renderer to consume it. | |
+| C1 | **Unrest** | adds `severityBoost = min(20, highSeverity·10·mult)`; counts `protests.length` | no `severityBoost`; counts `protests + riots` | **A** — port `severityBoost`; keep server's `protests+riots` (riots belong in unrest). Hybrid: A's formula + riots included. | ✓ **HYBRID** |
+| C2 | **Conflict** | has `hapiFallback` + `newsFloor` when ACLED empty; generic 7-day `recentStrikes` | no fallbacks; `iranStrikes + highSeverityStrikes` only | **A** — the fallbacks matter: without them the server scores 0 conflict whenever ACLED is empty. Port `hapiFallback` + `newsFloor`. | ✓ **A** |
+| C3 | **Security** | `flightScore + vesselScore + aviationScore + gpsJammingScore` (4 inputs) | `gpsJammingScore` only | **A** — the 4-input formula. Server now has all inputs after Phases 1–2. This is the mechanical half of the #3738 fix. | ✓ **A** |
+| C4 | **Information** | velocity-aware score from local `newsEvents` clustering | `newsScore + threatSummaryScore` (pre-computed, additive) | **B** — the server **cannot** run A's formula (no local `newsEvents`), and the server's cap was a deliberate #3739 improvement. Server wins; bring the frontend renderer to consume it. | ✓ **B** |
 
-C4 is the one genuine "server wins" — flagged in the plan. C1's hybrid (A's formula but
-keep `riots`) is the only row that isn't a clean A-or-B; confirm it explicitly.
+C4 is the one genuine "server wins". C1's hybrid (A's formula but keep `riots`) is the only
+row that isn't a clean A-or-B — confirmed as the accepted hybrid.
 
 ## 2. eventScore weights — no decision
 
@@ -40,25 +48,25 @@ Engine B: `baseline·0.4 + eventScore·0.6 + climate + cyber + fire + advisory +
 
 | # | Item | Recommendation | Decision |
 |---|---|---|---|
-| B1 | Canonical blend shape | **A's `calculateCII` blend** (the fuller one). Server adds the missing terms. Note: A's `cyber`/`fire` live *inside* `supplementalSignalBoost` — adopting A means the server's standalone `cyberBoost`/`fireBoost` terms are removed (folded into supplemental), no double-count. | |
-| B2 | Frontend's own split: `calculateCII` includes `earthquake`+`sanctions`, `getCountryScore` omits them | **`calculateCII` is canonical.** `getCountryScore` is deleted in Phase 4; its consumers (map tint, etc.) silently gain earthquake+sanctions — intended. | |
+| B1 | Canonical blend shape | **A's `calculateCII` blend** (the fuller one). Server adds the missing terms. Note: A's `cyber`/`fire` live *inside* `supplementalSignalBoost` — adopting A means the server's standalone `cyberBoost`/`fireBoost` terms are removed (folded into supplemental), no double-count. | ✓ **A** |
+| B2 | Frontend's own split: `calculateCII` includes `earthquake`+`sanctions`, `getCountryScore` omits them | **`calculateCII` is canonical.** `getCountryScore` is deleted in Phase 4; its consumers (map tint, etc.) silently gain earthquake+sanctions — intended. | ✓ **calculateCII** |
 
 ## 4. Boost helpers
 
 | # | Boost | Engine A | Engine B | Recommendation | Decision |
 |---|---|---|---|---|---|
-| D1 | hotspotBoost | `min(10, activity·1.5)` | absent | **DROP** — `hotspotActivityMap` is a frontend-only subsystem fed by `ingest*` calls; not reproducible from server signals without porting the whole hotspot tracker. Document the gap. | |
-| D2 | newsUrgencyBoost | `info≥70→5, ≥50→3` | absent | **A (port)** — pure function of the `information` component the server already has. Trivial. | |
-| D3 | focalBoost | `focalPointDetector` urgency `critical→8, elevated→4` | absent | **DROP** — verified frontend-only (`focalPointDetector` has zero server-side references); not reproducible server-side. Document the gap. | |
-| D4 | supplementalSignalBoost | AIS + fire + cyber + temporal (severity-weighted) | partial — see D7/D8 | **A (port)** — server has all 4 inputs after Phases 1–2. Replaces server's standalone cyber/fire terms. | |
-| D5 | earthquakeBoost | `min(25, severe·10 + major·5 + significant·2)` | absent | **A (port)** — server has earthquake counts after Phase 1. | |
-| D6 | sanctionsBoost | tiered by `entryCount` + `newEntry` bonus | absent | **A (port)** — server has sanctions counts after Phase 1. | |
-| D7 | cyber (within supplemental) | severity-weighted (`crit·3 + high·1.8 + med·0.9`) | `floor(cyberCount/5)` count-discount | **A** — severity-weighting beats a raw-count discount. Folds into D4. | |
-| D8 | fire (within supplemental) | brightness-weighted | `floor(fireCount/10)` count-discount | **A** — same reasoning. Folds into D4. | |
-| D9 | displacementBoost | step: `1M→8, 100K→4` (cap 8) | log: `(log10(n)−5)·8+4` (cap 20) | **B** — the log curve is more granular and spans real crisis sizes (1M→12, 10M→20); the step function flat-lines at 8. Server wins. | |
-| D10 | climateBoost | `climateStress` uncapped | `min(15, severity·3)` | **B** — an uncapped term is a latent bug; the cap is correct. Server wins. | |
-| D11 | advisoryBoost | level + source-count bonus (`≥3→+5, ≥2→+3`) | level only | **A** — source-count corroboration is a real signal; server must start tracking advisory source count. | |
-| D12 | orefBlendBoost | IL-only blend | identical | no decision — **identical**. | |
+| D1 | hotspotBoost | `min(10, activity·1.5)` | absent | **DROP** — `hotspotActivityMap` is a frontend-only subsystem fed by `ingest*` calls; not reproducible from server signals without porting the whole hotspot tracker. Document the gap. | ✓ **DROP** |
+| D2 | newsUrgencyBoost | `info≥70→5, ≥50→3` | absent | **A (port)** — pure function of the `information` component the server already has. Trivial. | ✓ **A** |
+| D3 | focalBoost | `focalPointDetector` urgency `critical→8, elevated→4` | absent | **DROP** — verified frontend-only (`focalPointDetector` has zero server-side references); not reproducible server-side. Document the gap. | ✓ **DROP** |
+| D4 | supplementalSignalBoost | AIS + fire + cyber + temporal (severity-weighted) | partial — see D7/D8 | **A (port)** — server has all 4 inputs after Phases 1–2. Replaces server's standalone cyber/fire terms. | ✓ **A** |
+| D5 | earthquakeBoost | `min(25, severe·10 + major·5 + significant·2)` | absent | **A (port)** — server has earthquake counts after Phase 1. | ✓ **A** |
+| D6 | sanctionsBoost | tiered by `entryCount` + `newEntry` bonus | absent | **A (port)** — server has sanctions counts after Phase 1. | ✓ **A** |
+| D7 | cyber (within supplemental) | severity-weighted (`crit·3 + high·1.8 + med·0.9`) | `floor(cyberCount/5)` count-discount | **A** — severity-weighting beats a raw-count discount. Folds into D4. | ✓ **A** |
+| D8 | fire (within supplemental) | brightness-weighted | `floor(fireCount/10)` count-discount | **A** — same reasoning. Folds into D4. | ✓ **A** |
+| D9 | displacementBoost | step: `1M→8, 100K→4` (cap 8) | log: `(log10(n)−5)·8+4` (cap 20) | **B** — the log curve is more granular and spans real crisis sizes (1M→12, 10M→20); the step function flat-lines at 8. Server wins. | ✓ **B** |
+| D10 | climateBoost | `climateStress` uncapped | `min(15, severity·3)` | **B** — an uncapped term is a latent bug; the cap is correct. Server wins. | ✓ **B** |
+| D11 | advisoryBoost | level + source-count bonus (`≥3→+5, ≥2→+3`) | level only | **A** — source-count corroboration is a real signal; server must start tracking advisory source count. | ✓ **A** |
+| D12 | orefBlendBoost | IL-only blend | identical | no decision — **identical**. | — identical |
 
 ## 5. Floors — no decision
 
@@ -68,7 +76,7 @@ Engine B: `baseline·0.4 + eventScore·0.6 + climate + cyber + fire + advisory +
 
 | # | Item | Engine A `getLevel` | Engine B adapter `getScoreLevel` | Recommendation | Decision |
 |---|---|---|---|---|---|
-| L1 | critical / high / elevated / normal cutoffs | ≥81 / ≥66 / ≥51 / ≥31 | ≥70 / ≥55 / ≥40 / ≥25 | **A** — the frontend table is what the UI has always shown; changing it shifts every country's badge. Reconcile `cached-risk-scores.ts getScoreLevel` to A's cutoffs. (Override only if you want a deliberate re-banding.) | |
+| L1 | critical / high / elevated / normal cutoffs | ≥81 / ≥66 / ≥51 / ≥31 | ≥70 / ≥55 / ≥40 / ≥25 | **A** — the frontend table is what the UI has always shown; changing it shifts every country's badge. Reconcile `cached-risk-scores.ts getScoreLevel` to A's cutoffs. | ✓ **A** |
 
 ## 7. Scalar tables — `BASELINE_RISK` / `EVENT_MULTIPLIER`
 
@@ -87,27 +95,49 @@ the frontend simply lacks curation.
 
 | # | Item | Recommendation | Decision |
 |---|---|---|---|
-| S1 | Scalar-table source of truth | **B (server)** for all rows above — the server file already declares itself authoritative for these. Update `CURATED_COUNTRIES` to match, then both read one table. | |
+| S1 | Scalar-table source of truth | **B (server)** for all rows above — the server file already declares itself authoritative for these. Update `CURATED_COUNTRIES` to match, then both read one table. | ✓ **B** |
 
 ## 8. Non-formula Phase 3a decisions
 
 | # | Item | Recommendation | Decision |
 |---|---|---|---|
-| N1 | Country set — expand server set vs accept curated-only | **Accept curated-only (31).** Both engines already iterate the same 31; the frontend's dynamic extras were thin (baseline-only). No expansion. | |
-| N2 | Proto field naming — keep positional aliases vs rename to `unrest/conflict/security/information` | **Rename.** The cache-key bump (`v2→v3`) is mandatory regardless; do the rename in the same bump so the proto stops lying. | |
-| N3 | Cold-cache fallback (Risk 3 / Open Question) | **Open** — keep a thin client fallback for the empty-result case, or accept degraded baseline-only CII on cold start. Still needs your call; see the plan's Deferred section. | |
-| N4 | Signal→component mapping for the Phase 1/2 signals | **aviation → Security (C3); military flights+vessels → Security (C3); AIS disruptions + temporal anomalies → supplemental (D4); earthquakes → earthquakeBoost (D5); sanctions → sanctionsBoost (D6).** Confirm. | |
-| N5 | `ingest*ForCII` side-effect decomposition (which non-CII side effects survive Phase 4 deletion) | Enumerate before Phase 4: `trackHotspotActivity → hotspotActivityMap` is the known one. Produce the full list as part of this table. | |
+| N1 | Country set — expand server set vs accept curated-only | **Accept curated-only (31).** Both engines already iterate the same 31; the frontend's dynamic extras were thin (baseline-only). No expansion. | ✓ **curated-only** |
+| N2 | Proto field naming — keep positional aliases vs rename to `unrest/conflict/security/information` | **Rename.** The cache-key bump (`v2→v3`) is mandatory regardless; do the rename in the same bump so the proto stops lying. | ✓ **rename** |
+| N3 | Cold-cache fallback (Risk 3 / Open Question) | **Open** — keep a thin client fallback for the empty-result case, or accept degraded baseline-only CII on cold start. A product/UX call; gates Phase 4, not Phase 3b. | **OPEN — you decide** |
+| N4 | Signal→component mapping for the Phase 1/2 signals | **aviation → Security (C3); military flights+vessels → Security (C3); AIS disruptions + temporal anomalies → supplemental (D4); earthquakes → earthquakeBoost (D5); sanctions → sanctionsBoost (D6).** | ✓ **accepted** |
+| N5 | `ingest*ForCII` side-effect decomposition (which non-CII side effects survive Phase 4 deletion) | **RESOLVED — see N5 audit below.** | ✓ **resolved** |
+| V1 | Keep military vessels vs drop (Phase 2 vessel classifier) | Check the vessel signal's weight in the blend before committing; if marginal, "drop + document the gap" is valid. | **BLOCKED — needs deploy data** |
+
+### N5 audit — `ingest*ForCII` side effects (resolved 2026-05-22)
+
+Audited all 20 `ingest*ForCII` functions in `country-instability.ts` for state writes
+beyond CII scoring (`countryDataMap`). Finding:
+
+- The **only** non-CII side effect is `trackHotspotActivity` → `hotspotActivityMap`, called
+  by exactly three ingest functions: `ingestProtestsForCII` (line 258),
+  `ingestConflictsForCII` (270), `ingestMilitaryForCII` (424, 444).
+- `hotspotActivityMap` is consumed by **`getHotspotBoost` only** — a non-exported function
+  that feeds **only** `calculateCII`'s blend. Grep confirms **zero** consumers of
+  `getHotspotBoost` / `hotspotActivityMap` outside `country-instability.ts`.
+- `focalPointDetector` is read by `calculateCII` / `getCountryScore` but is **not fed by any
+  `ingest*ForCII`** — it is an independent detector, out of scope here.
+
+**Conclusion: no `ingest*ForCII` side effect needs preserving.** Because D1 drops
+`hotspotBoost` and Phase 4 deletes the CII engine, the entire hotspot subsystem
+(`hotspotActivityMap`, `trackHotspotActivity`, `getHotspotBoost`, `resetHotspotActivity`)
+is dead and deletes with it. Phase 4 deletes the `ingest*ForCII` functions **wholesale**,
+not surgically — this simplifies Phase 4 vs the plan's earlier "surgical decomposition"
+assumption.
 
 ## Summary
 
-- **15 formula/threshold rows + 5 non-formula rows.** Of the formula rows, the default
-  (frontend wins) holds for all **except**: C4 information (server — #3739), D9 displacement
-  (server — better curve), D10 climate (server — has the cap), and S1 scalar tables (server
-  — frontend is uncurated).
-- **D1 hotspot and D3 focal** are recommended **drops** — both are frontend-only
-  subsystems with no server-reproducible inputs.
-- **N3 cold-cache** is the one row that genuinely cannot be pre-recommended — it's a
-  product/UX call.
-- Once the Decision column is filled, Phase 3b is mechanical: implement each winner, bump
-  `RISK_CACHE_KEY`, land the Guardrails equality/level tests.
+- **15 formula/threshold rows + 5 non-formula rows + V1.** All recommendations accepted
+  (signed off above). Frontend wins by default; server wins only on C4 (#3739), D9
+  (log curve), D10 (the cap), S1 (frontend uncurated).
+- **D1 hotspot and D3 focal** — accepted **drops**; both frontend-only with no
+  server-reproducible inputs. N5 confirms the hotspot subsystem deletes cleanly.
+- **N3 cold-cache** — the one open decision; product/UX call; gates Phase 4.
+- **V1 military vessels** — blocked on deployment data.
+- Phase 3b is now unblocked and mechanical: implement each accepted winner, bump
+  `RISK_CACHE_KEY` (`v2→v3`) with the N2 proto rename, land the Guardrails
+  equality/level tests.

--- a/plans/cii-phase3a-decisions.md
+++ b/plans/cii-phase3a-decisions.md
@@ -138,6 +138,42 @@ assumption.
   server-reproducible inputs. N5 confirms the hotspot subsystem deletes cleanly.
 - **N3 cold-cache** — the one open decision; product/UX call; gates Phase 4.
 - **V1 military vessels** — blocked on deployment data.
-- Phase 3b is now unblocked and mechanical: implement each accepted winner, bump
-  `RISK_CACHE_KEY` (`v2→v3`) with the N2 proto rename, land the Guardrails
-  equality/level tests.
+- Phase 3b implementation status is recorded below.
+
+## Phase 3b — implementation status (2026-05-22)
+
+Commits `94b7afa54` (C3) and `42e739f33` (blend + L1). 91 tests pass; typecheck clean.
+
+**Implemented & verified:**
+- **C3** — server `security` component is the full 4-input formula (flights + vessels +
+  aviation + GPS). The substantive #3738 fix.
+- **D2 / D5 / D6** — newsUrgency / earthquake / sanctions boosts ported verbatim into the blend.
+- **D4** — supplemental: AIS + temporal ported exactly.
+- **L1** — `getScoreLevel` cutoffs reconciled (81 / 66 / 51 / 31).
+- **C4 / D9 / D10 / N1** — no code change; the server already matched the decision.
+
+**Deferred — the accepted decision needs a server signal that does not exist yet:**
+- **C1 `severityBoost`** — the server has no high-severity-protest signal distinct from
+  fatalities; `unrestFatalityBoost` (driven by `protestFatalities`) already captures protest
+  severity. Server unrest already equals the C1 hybrid *minus* `severityBoost`.
+- **C2 `hapiFallback` + `newsFloor`** — hapiFallback needs the per-ISO3
+  `conflict:humanitarian:v1` keys plumbed; newsFloor needs per-event threat-category +
+  source-tier data `threatSummaryByCountry` does not carry. Conflict already matches A's
+  primary ACLED path — the fallbacks are a robustness follow-up.
+- **D7 / D8** — cyber + fire stay total-based; A's severity-weighted versions need
+  severity-split cyber/fire ingestion (a Phase-1-style plumbing follow-up).
+- **D11** — advisory source-count bonus; `intelligence:advisories:v1` carries only the
+  level. Server `advisoryBoost` is A's formula minus the source-count bonus.
+
+**Deferred — Phase 4:**
+- **S1** — `CURATED_COUNTRIES` AF/LB/EG/JP/QA/KR. The server is already authoritative for
+  the API. Those fields are read only by the frontend engine, which Phase 4 deletes — the
+  reconciliation happens by deletion, not by editing the table now.
+- **N2** proto rename — the Phase 3b formula changes do not alter the `CiiScore` proto
+  *shape*, so no `RISK_CACHE_KEY` bump is required. The rename is cosmetic; it rides a
+  future bump.
+
+**Net:** the substantive reconciliation is done — the server CII now scores security,
+earthquakes, sanctions, temporal anomalies, and AIS, with reconciled level banding. Every
+deferral is a "needs a new server signal" follow-up, documented above; none block the
+unified engine from being correct on the signals it already has.

--- a/plans/cii-phase3a-decisions.md
+++ b/plans/cii-phase3a-decisions.md
@@ -152,9 +152,13 @@ Commits `94b7afa54` (C3) and `42e739f33` (blend + L1). 91 tests pass; typecheck 
 - **C1 `severityBoost`** — implemented. The server counts `highSeverityUnrest` in the ACLED
   loop and applies `min(20, count·10·mult)`.
 - **D2 / D5 / D6** — newsUrgency / earthquake / sanctions boosts ported verbatim into the blend.
-- **D4 / D7 / D8** — supplemental fully ported: AIS + temporal as their own blend terms,
-  cyber + fire severity-weighted (`cyberBoost` = crit·3+high·1.8+med·0.9; `fireBoost`
-  = highFire·1.5 + min(20,total)·0.25). Not a partial port.
+- **D4 / D7 / D8** — supplemental ported: AIS as its own blend term, cyber + fire
+  severity-weighted (`cyberBoost` = crit·3+high·1.8+med·0.9; `fireBoost`
+  = highFire·1.5 + min(20,total)·0.25). The frontend's temporal sub-boost is **not
+  wired** — the `temporal:anomalies:v1` producer emits `region:'global'` so anomalies
+  cannot be country-attributed (the frontend's temporal sub-boost is dormant for the same
+  reason). `temporalAnomaly*Count` stay gathered-not-scored; re-wire if the producer
+  emits country-scoped anomalies.
 - **L1** — `getScoreLevel` cutoffs reconciled (81 / 66 / 51 / 31).
 
 > **Correction.** C1, D7 and D8 were initially listed as deferred "missing server signal"

--- a/plans/cii-phase3a-decisions.md
+++ b/plans/cii-phase3a-decisions.md
@@ -1,0 +1,113 @@
+# CII Phase 3a — reconciliation decision table
+
+Companion to `plans/unify-cii-single-source.md`. Phase 3b implements whatever this table
+decides; per the plan, Phase 3b makes **no** decisions of its own.
+
+Every row is a real divergence between the two engines, verified line-by-line:
+- **Engine A — frontend**: `src/services/country-instability.ts`
+- **Engine B — server**: `server/worldmonitor/intelligence/v1/get-risk-scores.ts`
+
+Each row has a **Recommendation** (pre-filled, with rationale) and a **Decision** column
+for you. Default rule from the plan: *frontend wins, except where the server intentionally
+diverged.* Fill the Decision column (`A` / `B` / `new`) — blank means "accept recommendation."
+
+Caps the score anyway: the composite is `Math.min(100, Math.max(floor, blend))` in both
+engines, so individual boost caps are about *shape*, not overflow.
+
+---
+
+## 1. Component formulas
+
+| # | Component | Engine A (frontend) | Engine B (server) | Recommendation | Decision |
+|---|---|---|---|---|---|
+| C1 | **Unrest** | adds `severityBoost = min(20, highSeverity·10·mult)`; counts `protests.length` | no `severityBoost`; counts `protests + riots` | **A** — port `severityBoost`; keep server's `protests+riots` (riots belong in unrest). Hybrid: A's formula + riots included. | |
+| C2 | **Conflict** | has `hapiFallback` + `newsFloor` when ACLED empty; generic 7-day `recentStrikes` | no fallbacks; `iranStrikes + highSeverityStrikes` only | **A** — the fallbacks matter: without them the server scores 0 conflict whenever ACLED is empty. Port `hapiFallback` + `newsFloor`. | |
+| C3 | **Security** | `flightScore + vesselScore + aviationScore + gpsJammingScore` (4 inputs) | `gpsJammingScore` only | **A** — the 4-input formula. Server now has all inputs after Phases 1–2. This is the mechanical half of the #3738 fix. | |
+| C4 | **Information** | velocity-aware score from local `newsEvents` clustering | `newsScore + threatSummaryScore` (pre-computed, additive) | **B** — the server **cannot** run A's formula (no local `newsEvents`), and the server's cap was a deliberate #3739 improvement. Server wins; bring the frontend renderer to consume it. | |
+
+C4 is the one genuine "server wins" — flagged in the plan. C1's hybrid (A's formula but
+keep `riots`) is the only row that isn't a clean A-or-B; confirm it explicitly.
+
+## 2. eventScore weights — no decision
+
+Both engines: `unrest·0.25 + conflict·0.30 + security·0.20 + information·0.25`. **Identical.**
+
+## 3. Composite blend
+
+The canonical blend. Engine A's `calculateCII`:
+`baseline·0.4 + eventScore·0.6 + hotspot + newsUrgency + focal + displacement + climate + oref + advisory + supplemental + earthquake + sanctions`.
+Engine B: `baseline·0.4 + eventScore·0.6 + climate + cyber + fire + advisory + oref + displacement`.
+
+| # | Item | Recommendation | Decision |
+|---|---|---|---|
+| B1 | Canonical blend shape | **A's `calculateCII` blend** (the fuller one). Server adds the missing terms. Note: A's `cyber`/`fire` live *inside* `supplementalSignalBoost` — adopting A means the server's standalone `cyberBoost`/`fireBoost` terms are removed (folded into supplemental), no double-count. | |
+| B2 | Frontend's own split: `calculateCII` includes `earthquake`+`sanctions`, `getCountryScore` omits them | **`calculateCII` is canonical.** `getCountryScore` is deleted in Phase 4; its consumers (map tint, etc.) silently gain earthquake+sanctions — intended. | |
+
+## 4. Boost helpers
+
+| # | Boost | Engine A | Engine B | Recommendation | Decision |
+|---|---|---|---|---|---|
+| D1 | hotspotBoost | `min(10, activity·1.5)` | absent | **DROP** — `hotspotActivityMap` is a frontend-only subsystem fed by `ingest*` calls; not reproducible from server signals without porting the whole hotspot tracker. Document the gap. | |
+| D2 | newsUrgencyBoost | `info≥70→5, ≥50→3` | absent | **A (port)** — pure function of the `information` component the server already has. Trivial. | |
+| D3 | focalBoost | `focalPointDetector` urgency `critical→8, elevated→4` | absent | **DROP** — verified frontend-only (`focalPointDetector` has zero server-side references); not reproducible server-side. Document the gap. | |
+| D4 | supplementalSignalBoost | AIS + fire + cyber + temporal (severity-weighted) | partial — see D7/D8 | **A (port)** — server has all 4 inputs after Phases 1–2. Replaces server's standalone cyber/fire terms. | |
+| D5 | earthquakeBoost | `min(25, severe·10 + major·5 + significant·2)` | absent | **A (port)** — server has earthquake counts after Phase 1. | |
+| D6 | sanctionsBoost | tiered by `entryCount` + `newEntry` bonus | absent | **A (port)** — server has sanctions counts after Phase 1. | |
+| D7 | cyber (within supplemental) | severity-weighted (`crit·3 + high·1.8 + med·0.9`) | `floor(cyberCount/5)` count-discount | **A** — severity-weighting beats a raw-count discount. Folds into D4. | |
+| D8 | fire (within supplemental) | brightness-weighted | `floor(fireCount/10)` count-discount | **A** — same reasoning. Folds into D4. | |
+| D9 | displacementBoost | step: `1M→8, 100K→4` (cap 8) | log: `(log10(n)−5)·8+4` (cap 20) | **B** — the log curve is more granular and spans real crisis sizes (1M→12, 10M→20); the step function flat-lines at 8. Server wins. | |
+| D10 | climateBoost | `climateStress` uncapped | `min(15, severity·3)` | **B** — an uncapped term is a latent bug; the cap is correct. Server wins. | |
+| D11 | advisoryBoost | level + source-count bonus (`≥3→+5, ≥2→+3`) | level only | **A** — source-count corroboration is a real signal; server must start tracking advisory source count. | |
+| D12 | orefBlendBoost | IL-only blend | identical | no decision — **identical**. | |
+
+## 5. Floors — no decision
+
+`ucdpFloor` (70/50/0) and `advisoryFloor` (60/50/0) are **identical** in both engines.
+
+## 6. Level thresholds
+
+| # | Item | Engine A `getLevel` | Engine B adapter `getScoreLevel` | Recommendation | Decision |
+|---|---|---|---|---|---|
+| L1 | critical / high / elevated / normal cutoffs | ≥81 / ≥66 / ≥51 / ≥31 | ≥70 / ≥55 / ≥40 / ≥25 | **A** — the frontend table is what the UI has always shown; changing it shifts every country's badge. Reconcile `cached-risk-scores.ts getScoreLevel` to A's cutoffs. (Override only if you want a deliberate re-banding.) | |
+
+## 7. Scalar tables — `BASELINE_RISK` / `EVENT_MULTIPLIER`
+
+The frontend `CURATED_COUNTRIES` left **AF, LB, EG, JP, QA** at the default `15 / 1.0` — they
+were never curated. The server has real values for all 31. This is not a judgment call —
+the frontend simply lacks curation.
+
+| Country | Frontend (uncurated default) | Server | Recommendation |
+|---|---|---|---|
+| AF | baseline 15, mult 1.0 | 45 / 0.8 | **B** |
+| LB | 15 / 1.0 | 40 / 1.5 | **B** |
+| EG | 15 / 1.0 | 20 / 1.0 | **B** |
+| JP | 15 / 1.0 | 5 / 0.5 | **B** |
+| QA | 15 / 1.0 | 10 / 0.8 | **B** |
+| KR | mult 1.0 | mult 0.8 | **B** |
+
+| # | Item | Recommendation | Decision |
+|---|---|---|---|
+| S1 | Scalar-table source of truth | **B (server)** for all rows above — the server file already declares itself authoritative for these. Update `CURATED_COUNTRIES` to match, then both read one table. | |
+
+## 8. Non-formula Phase 3a decisions
+
+| # | Item | Recommendation | Decision |
+|---|---|---|---|
+| N1 | Country set — expand server set vs accept curated-only | **Accept curated-only (31).** Both engines already iterate the same 31; the frontend's dynamic extras were thin (baseline-only). No expansion. | |
+| N2 | Proto field naming — keep positional aliases vs rename to `unrest/conflict/security/information` | **Rename.** The cache-key bump (`v2→v3`) is mandatory regardless; do the rename in the same bump so the proto stops lying. | |
+| N3 | Cold-cache fallback (Risk 3 / Open Question) | **Open** — keep a thin client fallback for the empty-result case, or accept degraded baseline-only CII on cold start. Still needs your call; see the plan's Deferred section. | |
+| N4 | Signal→component mapping for the Phase 1/2 signals | **aviation → Security (C3); military flights+vessels → Security (C3); AIS disruptions + temporal anomalies → supplemental (D4); earthquakes → earthquakeBoost (D5); sanctions → sanctionsBoost (D6).** Confirm. | |
+| N5 | `ingest*ForCII` side-effect decomposition (which non-CII side effects survive Phase 4 deletion) | Enumerate before Phase 4: `trackHotspotActivity → hotspotActivityMap` is the known one. Produce the full list as part of this table. | |
+
+## Summary
+
+- **15 formula/threshold rows + 5 non-formula rows.** Of the formula rows, the default
+  (frontend wins) holds for all **except**: C4 information (server — #3739), D9 displacement
+  (server — better curve), D10 climate (server — has the cap), and S1 scalar tables (server
+  — frontend is uncurated).
+- **D1 hotspot and D3 focal** are recommended **drops** — both are frontend-only
+  subsystems with no server-reproducible inputs.
+- **N3 cold-cache** is the one row that genuinely cannot be pre-recommended — it's a
+  product/UX call.
+- Once the Decision column is filled, Phase 3b is mechanical: implement each winner, bump
+  `RISK_CACHE_KEY`, land the Guardrails equality/level tests.

--- a/plans/cii-phase3a-decisions.md
+++ b/plans/cii-phase3a-decisions.md
@@ -147,23 +147,33 @@ Commits `94b7afa54` (C3) and `42e739f33` (blend + L1). 91 tests pass; typecheck 
 **Implemented & verified:**
 - **C3** — server `security` component is the full 4-input formula (flights + vessels +
   aviation + GPS). The substantive #3738 fix.
+- **C1 `severityBoost`** — implemented. The server counts `highSeverityUnrest` in the ACLED
+  loop and applies `min(20, count·10·mult)`.
 - **D2 / D5 / D6** — newsUrgency / earthquake / sanctions boosts ported verbatim into the blend.
-- **D4** — supplemental: AIS + temporal ported exactly.
+- **D4 / D7 / D8** — supplemental fully ported: AIS + temporal as their own blend terms,
+  cyber + fire severity-weighted (`cyberBoost` = crit·3+high·1.8+med·0.9; `fireBoost`
+  = highFire·1.5 + min(20,total)·0.25). Not a partial port.
 - **L1** — `getScoreLevel` cutoffs reconciled (81 / 66 / 51 / 31).
+
+> **Correction.** C1, D7 and D8 were initially listed as deferred "missing server signal"
+> items. That was wrong — and worth recording. Protest *severity*, cyber *severity*, and
+> fire *brightness* are not feed signals; they are fields the cached objects already carry
+> (`classifySeverity` derives protest severity from fatalities+type; cyber threats carry
+> `severity`; fire detections carry `brightness`/`frp`). The server's CII *ingestion* was
+> simply discarding those fields (`cyberCount++`, `fireCount++`). The lesson: check what
+> the cached data carries, not what the current ingestion code reads. All three are now
+> implemented.
 - **C4 / D9 / D10 / N1** — no code change; the server already matched the decision.
 
 **Deferred — the accepted decision needs a server signal that does not exist yet:**
-- **C1 `severityBoost`** — the server has no high-severity-protest signal distinct from
-  fatalities; `unrestFatalityBoost` (driven by `protestFatalities`) already captures protest
-  severity. Server unrest already equals the C1 hybrid *minus* `severityBoost`.
 - **C2 `hapiFallback` + `newsFloor`** — hapiFallback needs the per-ISO3
   `conflict:humanitarian:v1` keys plumbed; newsFloor needs per-event threat-category +
   source-tier data `threatSummaryByCountry` does not carry. Conflict already matches A's
   primary ACLED path — the fallbacks are a robustness follow-up.
-- **D7 / D8** — cyber + fire stay total-based; A's severity-weighted versions need
-  severity-split cyber/fire ingestion (a Phase-1-style plumbing follow-up).
-- **D11** — advisory source-count bonus; `intelligence:advisories:v1` carries only the
-  level. Server `advisoryBoost` is A's formula minus the source-count bonus.
+- **D11** — advisory source-count bonus. Verified genuine: `intelligence:advisories:v1`
+  exposes only `byCountry: {code → level}` — the individual advisories and their sources
+  are collapsed away in the cache. The bonus needs the advisory seed extended to emit
+  per-country source counts. Server `advisoryBoost` is A's formula minus that bonus.
 
 **Deferred — Phase 4:**
 - **S1** — `CURATED_COUNTRIES` AF/LB/EG/JP/QA/KR. The server is already authoritative for

--- a/plans/cii-phase3a-decisions.md
+++ b/plans/cii-phase3a-decisions.md
@@ -4,6 +4,7 @@ Companion to `plans/unify-cii-single-source.md`. Phase 3b implements whatever th
 decides; per the plan, Phase 3b makes **no** decisions of its own.
 
 Every row is a real divergence between the two engines, verified line-by-line:
+
 - **Engine A — frontend**: `src/services/country-instability.ts`
 - **Engine B — server**: `server/worldmonitor/intelligence/v1/get-risk-scores.ts`
 
@@ -145,6 +146,7 @@ assumption.
 Commits `94b7afa54` (C3) and `42e739f33` (blend + L1). 91 tests pass; typecheck clean.
 
 **Implemented & verified:**
+
 - **C3** — server `security` component is the full 4-input formula (flights + vessels +
   aviation + GPS). The substantive #3738 fix.
 - **C1 `severityBoost`** — implemented. The server counts `highSeverityUnrest` in the ACLED
@@ -163,9 +165,11 @@ Commits `94b7afa54` (C3) and `42e739f33` (blend + L1). 91 tests pass; typecheck 
 > simply discarding those fields (`cyberCount++`, `fireCount++`). The lesson: check what
 > the cached data carries, not what the current ingestion code reads. All three are now
 > implemented.
+
 - **C4 / D9 / D10 / N1** — no code change; the server already matched the decision.
 
 **Deferred — the accepted decision needs a server signal that does not exist yet:**
+
 - **C2 `hapiFallback` + `newsFloor`** — hapiFallback needs the per-ISO3
   `conflict:humanitarian:v1` keys plumbed; newsFloor needs per-event threat-category +
   source-tier data `threatSummaryByCountry` does not carry. Conflict already matches A's
@@ -176,6 +180,7 @@ Commits `94b7afa54` (C3) and `42e739f33` (blend + L1). 91 tests pass; typecheck 
   per-country source counts. Server `advisoryBoost` is A's formula minus that bonus.
 
 **Deferred — Phase 4:**
+
 - **S1** — `CURATED_COUNTRIES` AF/LB/EG/JP/QA/KR. The server is already authoritative for
   the API. Those fields are read only by the frontend engine, which Phase 4 deletes — the
   reconciliation happens by deletion, not by editing the table now.

--- a/plans/unify-cii-single-source.md
+++ b/plans/unify-cii-single-source.md
@@ -95,7 +95,7 @@ The 8 families the server CII does not currently *score*, and what each needs:
 | Signal | Frontend ingest | Server source today | Work |
 |---|---|---|---|
 | Aviation disruptions | `ingestAviationForCII` | `aviation:delays:intl:v3` (Redis) ✅ | Plumb into `AuxiliarySources` |
-| AIS disruptions | `ingestAisDisruptionsForCII` | `get-vessel-snapshot.ts` emits `AisDisruption` (live relay HTTP, **not** a Redis key) ⚠️ | Plumb + **geo→country** (`AisDisruption` has `{lat,lon}`+free-text `region`, no `countryCode`) |
+| AIS disruptions | `ingestAisDisruptionsForCII` | `get-vessel-snapshot.ts` emits `AisDisruption` (live relay HTTP, **not** a Redis key) ⚠️ | **Phase 2** — cached to a Redis key by Phase 2's scheduled relay job, then plumbed + **geo→country** |
 | Earthquakes | `ingestEarthquakesForCII` | `seismology:earthquakes:v1` (Redis) ✅ | Plumb + geo→country |
 | Sanctions | `ingestSanctionsForCII` | `sanctions/v1/list-sanctions-pressure.ts` (per-country) ✅ | Plumb |
 | Temporal anomalies | `ingestTemporalAnomaliesForCII` | server-detected (`TemporalAnomalyProto`, `temporal-baseline.ts consumeServerAnomalies()`) ✅ | Plumb |
@@ -142,15 +142,21 @@ each test ships inside an earlier phase's PR (noted per test).
 - No engine change. Safe given the Scope-boundary commitment above.
 
 ### Phase 1 — Server acquires the cheap signals
-- `AuxiliarySources` + `fetchAuxiliarySources()`: add aviation, AIS disruptions (with
-  geo→country), earthquakes (with geo→country), sanctions, temporal anomalies.
-- `CountrySignals` + `emptySignals()`: add the count fields, mirroring `CountryData`
-  (`aisDisruptionHighCount`, `earthquakeSignificantCount`, `sanctionsEntryCount`,
-  `temporalAnomalyCount`, …).
+- `AuxiliarySources` + `fetchAuxiliarySources()`: add aviation (`aviation:delays:intl:v3`),
+  earthquakes (`seismology:earthquakes:v1`, with geo→country), sanctions
+  (`sanctions:pressure:v1`), temporal anomalies (`temporal:anomalies:v1`). All four are
+  backed by an existing Redis key.
+- `CountrySignals` + `emptySignals()`: add the count fields
+  (`aviation{Closure,Severe,Major,Moderate}Count`, `earthquake{Significant,Major,Severe}Count`,
+  `sanctions{Entry,NewEntry}Count`, `temporalAnomaly{,Critical}Count`).
 - Wire each into the per-country accumulation loop. **No scoring change** — signals
   gathered but unused. Additive and safe.
+- **AIS disruptions moved to Phase 2.** Unlike the four above, AIS disruptions have no Redis
+  key — `get-vessel-snapshot.ts` fetches them from the Railway relay per request. Adding a
+  live relay HTTP call into the 600 s scoring path is the anti-pattern the feasibility
+  review flagged; instead AIS rides on the scheduled relay job Phase 2 already stands up.
 
-### Phase 2 — Server military flights + vessels
+### Phase 2 — Server military flights, vessels + AIS disruptions
 - Per-country aggregation of `military:flights:v1` (already operator-classified) — add
   location-code attribution for foreign presence.
 - New server-side military **vessel** classifier: port `MILITARY_VESSEL_PATTERNS` /
@@ -167,6 +173,12 @@ each test ships inside an earlier phase's PR (noted per test).
 - **Decision:** aggregation runs as a scheduled server job writing the Redis key (not a
   relay extension) — keeps `get-risk-scores.ts` reading Redis uniformly, matches the 600 s
   cadence, and avoids coupling scoring to relay request latency.
+- **AIS disruptions (moved from Phase 1).** AIS disruptions have no Redis key —
+  `get-vessel-snapshot.ts` fetches them from the relay per request. The same scheduled job
+  caches them to a Redis key with geo→country attribution (`AisDisruption` carries
+  `{lat,lon}` + a free-text `region`, no `countryCode`), so `fetchAuxiliarySources()` reads
+  them uniformly like the Phase 1 signals — no live relay call in the scoring path. Add
+  `aisDisruption{High,Elevated,Low}Count` to `CountrySignals`.
 - **Attribution caveat:** the server's `geoToCountry` (`get-risk-scores.ts:154`) is a
   bounding-box scan; the frontend uses polygon containment. For straits/borders (Hormuz,
   Taiwan Strait, Black Sea — the high-signal cases) bbox will mis-attribute. Either port

--- a/plans/unify-cii-single-source.md
+++ b/plans/unify-cii-single-source.md
@@ -94,7 +94,7 @@ The 8 families the server CII does not currently *score*, and what each needs:
 
 | Signal | Frontend ingest | Server source today | Work |
 |---|---|---|---|
-| Aviation disruptions | `ingestAviationForCII` | `aviation:delays:intl:v3` (Redis) ✅ | Plumb into `AuxiliarySources` |
+| Aviation disruptions | `ingestAviationForCII` | `aviation:delays-bootstrap:v2` (Redis — pre-merged FAA + intl + NOTAM by seed-aviation.mjs) ✅ | Plumb into `AuxiliarySources` |
 | AIS disruptions | `ingestAisDisruptionsForCII` | `get-vessel-snapshot.ts` emits `AisDisruption` (live relay HTTP, **not** a Redis key) ⚠️ | **Phase 2** — cached to a Redis key by Phase 2's scheduled relay job, then plumbed + **geo→country** |
 | Earthquakes | `ingestEarthquakesForCII` | `seismology:earthquakes:v1` (Redis) ✅ | Plumb + geo→country |
 | Sanctions | `ingestSanctionsForCII` | `sanctions/v1/list-sanctions-pressure.ts` (per-country) ✅ | Plumb |
@@ -144,7 +144,7 @@ each test ships inside an earlier phase's PR (noted per test).
 
 ### Phase 1 — Server acquires the cheap signals
 
-- `AuxiliarySources` + `fetchAuxiliarySources()`: add aviation (`aviation:delays:intl:v3`),
+- `AuxiliarySources` + `fetchAuxiliarySources()`: add aviation (`aviation:delays-bootstrap:v2` — the pre-merged FAA + intl + NOTAM source),
   earthquakes (`seismology:earthquakes:v1`, with geo→country), sanctions
   (`sanctions:pressure:v1`), temporal anomalies (`temporal:anomalies:v1`). All four are
   backed by an existing Redis key.

--- a/plans/unify-cii-single-source.md
+++ b/plans/unify-cii-single-source.md
@@ -132,6 +132,7 @@ design-note decision table, not a PR. The Guardrails section below is **not** a 
 each test ships inside an earlier phase's PR (noted per test).
 
 ### Phase 0 — Label stopgap (ships immediately, independent)
+
 - Rename the CII component label `"Security"` → `"Mil. Activity"` in **all three**
   component blocks of `src/locales/en.json` (lines 101, 745, 3170) and the **20 non-English
   locale files** in `src/locales/*.json` (regenerate any `.d.ts` companions).
@@ -142,6 +143,7 @@ each test ships inside an earlier phase's PR (noted per test).
 - No engine change. Safe given the Scope-boundary commitment above.
 
 ### Phase 1 — Server acquires the cheap signals
+
 - `AuxiliarySources` + `fetchAuxiliarySources()`: add aviation (`aviation:delays:intl:v3`),
   earthquakes (`seismology:earthquakes:v1`, with geo→country), sanctions
   (`sanctions:pressure:v1`), temporal anomalies (`temporal:anomalies:v1`). All four are
@@ -157,6 +159,7 @@ each test ships inside an earlier phase's PR (noted per test).
   review flagged; instead AIS rides on the scheduled relay job Phase 2 already stands up.
 
 ### Phase 2 — Server military flights, vessels + AIS disruptions
+
 - Per-country aggregation of `military:flights:v1` (already operator-classified) — add
   location-code attribution for foreign presence.
 - New server-side military **vessel** classifier: port `MILITARY_VESSEL_PATTERNS` /
@@ -185,10 +188,12 @@ each test ships inside an earlier phase's PR (noted per test).
   polygon containment server-side or accept and document the precision loss.
 
 ### Phase 3a — Reconciliation decisions (design note, no code)
+
 "Port verbatim" is **not** sufficient — the formulas diverge structurally and at least one
 divergence is intentional. Before the behavior-changing PR opens, settle every decision
 below and record it in a signed-off table. Phase 3b executes this table; it does not make
 decisions inside the PR.
+
 - For **each** of the 4 component formulas and **each** blend boost
   (`hotspotBoost`, `newsUrgencyBoost`, `focalBoost`, `supplementalSignalBoost`,
   `earthquakeBoost`, `sanctionsBoost`, `displacementBoost`), a **canonical decision**: which
@@ -214,12 +219,14 @@ decisions inside the PR.
   which feature consumes each. Phase 4's irreversible deletion is gated on this table.
 
 ### Phase 3b — Server computes the full CII (implementation)
+
 This is the behavior-changing PR. It **executes** the Phase 3a decision table — it makes no
 decisions. Implement each canonical formula choice, the scalar tables, the `getScoreLevel`
 thresholds, and the proto change. Pair with the Guardrails equality/level/attribution tests
 below; the PR is not done until the equality test is green.
 
 ### Phase 3-proto — `CiiComponents` field naming
+
 Folded into the Phase 3b PR (same cache-key bump); the keep-vs-rename choice is made in
 Phase 3a. Decide: keep abusing the positional
 aliases (`militaryActivity`≡`security`, …), or rename the `.proto` fields to
@@ -230,6 +237,7 @@ aliases (`militaryActivity`≡`security`, …), or rename the `.proto` fields to
 `RISK_CACHE_KEY` (`v2`→`v3`) propagated to every reader listed at `get-risk-scores.ts:626-631`.
 
 ### Phase 4 — Frontend becomes a renderer
+
 - Repoint every CII consumer to `cached-risk-scores.ts` — both `calculateCII()` and
   `getCountryScore()` consumers. The `rg 'calculateCII|getCountryScore' src/` sweep is
   authoritative and must be run before starting; the known sites are:
@@ -249,6 +257,7 @@ aliases (`militaryActivity`≡`security`, …), or rename the `.proto` fields to
 ## Guardrails (not a standalone phase — each test ships in the phase noted)
 
 These are not an independently shippable phase; each test lands inside an earlier phase's PR.
+
 - **Equality test (lands with Phase 3b):** feed identical fixture *component-input* signals
   to the server formulas and the frontend `calc*Score` functions; assert byte-identical
   component scores. This is *formula parity* only — a green equality test is necessary but
@@ -322,6 +331,7 @@ which side is canonical before the equality test can pass.
 ## Deferred / Open Questions
 
 ### From 2026-05-22 review
+
 - **Cold-cache fallback decision (Risk 3).** Phase 4 deletes the frontend engine that today
   masks the cold-cache failure mode — on cold Redis + upstream failure the server returns
   31 baseline-only scores (`get-risk-scores.ts:694-700`). Decide before Phase 4: keep a

--- a/plans/unify-cii-single-source.md
+++ b/plans/unify-cii-single-source.md
@@ -1,0 +1,319 @@
+# Unify the CII — one engine, server-canonical
+
+Origin: Issue #3738 ("Security dimension is 100% GPS jamming"). Investigation showed the
+mislabel is a symptom, not the bug. The bug: **WorldMonitor runs two CII engines that
+diverge in formula, inputs, and output shape.** This plan unifies them.
+
+> Reviewed 2026-05-22 by three parallel reviewers (feasibility / adversarial / coherence).
+> Their verified findings are folded in. Corrections to the first draft are marked `[rev]`.
+
+## Problem
+
+| | Frontend engine | Server engine |
+|---|---|---|
+| File | `src/services/country-instability.ts` | `server/worldmonitor/intelligence/v1/get-risk-scores.ts` |
+| Scoring fns | `calcUnrestScore`, `calcConflictScore`, `calcSecurityScore`, `calcInformationScore`, `calcNewsConflictFloor` | 4 inline component blocks in `computeCIIScores` |
+| Inputs | ~20 `ingest*ForCII` functions | ~12 `AuxiliarySources` (post-Phase-1: ~17) |
+| Output consumers | `calculateCII()` / `getCountryScore()` | RPC `getRiskScores` → MCP `get_country_risk`, API, panels |
+| Cadence | recomputed live as browser streams tick | cached `risk:scores:sebuf:v2`, TTL 600 s |
+
+Three independent divergences, not one:
+
+1. **Input divergence.** The server's `computeCIIScores` does not *score* 8 signal families
+   the frontend scores (military flights, military vessels, aviation disruptions, AIS
+   disruptions, earthquakes, sanctions, temporal anomalies, HAPI). `[rev]` "Does not score"
+   ≠ "cannot see" — 6 of the 8 already have a usable server source (audit table ✅), AIS
+   disruptions has a relay source needing only geo-attribution, and only military vessels
+   need a genuinely new classifier. See the audit table.
+2. **Formula divergence.** Beyond inputs, the *blend* formulas differ structurally. Server
+   `get-risk-scores.ts:549-556`: `baseline·0.4 + eventScore·0.6 + climateBoost + cyberBoost
+   + fireBoost + advisoryBoost + orefBlendBoost + displacementBoost`. Frontend
+   `country-instability.ts:~1014`: adds `hotspotBoost`, `newsUrgencyBoost`, `focalBoost`,
+   `supplementalSignalBoost`, `getEarthquakeBoost`, `getSanctionsBoost`, and uses a
+   *different* `displacementBoost` shape (server = `log10` ramp cap 20; frontend = step
+   function cap 8). The component sub-formulas (`security` GPS-only vs 4-input) also differ.
+   And the *frontend itself* carries two divergent blends: `calculateCII`
+   (defined `country-instability.ts:975`, blend at `:1014`) includes the
+   earthquake/sanctions/supplemental boosts; `getCountryScore` (`:1042`) omits all three. Phase 3a's canonical-decision list must pick
+   one blend — Phase 4 then silently changes scores for `getCountryScore` consumers (an
+   expected, intended change).
+3. **Output-shape divergence.** The `CiiComponents` proto fields are
+   `newsActivity / ciiContribution / geoConvergence / militaryActivity` — *positionally
+   aliased* to `information / unrest / conflict / security` by `cached-risk-scores.ts:92-97`
+   and `get-risk-scores.ts:572-577`. There is no `security` proto field.
+
+Because both engines are user-facing (MCP/API serve the server score; the UI's
+`calculateCII()` / `getCountryScore()` serve the frontend score), the MCP tool and the
+on-screen CII can disagree for the same country.
+
+## Scope boundary — "unify" is not "correct"
+
+This plan makes the two engines produce **one** score. It does **not** fix whether that
+score is *right*. Specifically: `calcSecurityScore` (flights + vessels + aviation + GPS) is
+*military activity*, not "security" in the terrorism sense (issue #3738's actual complaint).
+Unifying on it freezes that model. Correcting the security model is **out of scope** here,
+but must not be silently dropped: filing the follow-up issue — a real security/terrorism
+signal, with a named owner — is a **Phase 0 deliverable**, and #3738 is closed against that
+follow-up, not against this plan's rename. Phase 0's label rename (`"Security"` → `"Mil. Activity"`) is the
+honest stopgap that makes the frozen model's name accurate; it is a deliberate, lasting
+decision, not a placeholder. `[rev]` This is why Phase 0 is safe to ship early: the plan
+commits to "the dimension stays military-activity-only," so the label will not need
+re-reverting later.
+
+## Target architecture
+
+**The server `get-risk-scores.ts` is the single CII engine. The browser renders its output.**
+
+- Delete `calculateCII()`, `getCountryScore()`, `calc*Score`, `calcNewsConflictFloor`, and
+  the CII-scoring state from `country-instability.ts`.
+- All frontend CII consumers read the server `RiskScores` proto via the **already-built**
+  `src/services/cached-risk-scores.ts` adapter (`getCachedScores`, `toCountryScore`,
+  `fetchCachedRiskScores`, circuit breaker, localStorage persistence). `[rev]` This module
+  already exists and several call sites already dual-path through it — Phase 4 is "remove
+  the frontend-engine arm," not "build a consumption layer."
+- Accepted tradeoff: the CII *number* freshness becomes the server cadence (~10 min), not
+  live. Map layers stay live; only the index number follows server cadence. For a
+  `baseline·0.4 + eventScore·0.6` slow index this is acceptable — but the acceptance is
+  **per-consumer, not blanket**. Live-CII-dependent surfaces and their verdict:
+  - `checkCIIChanges` instability alerts (`cross-module-integration.ts:561`) — delta
+    detection moves from live ticks to 10-min snapshots; **needs retuning** (see Risk 4).
+  - `getCountryScore` map tint (`DeckGLMap.ts` / `Map.ts` via `setCIIGetter`) — 10-min
+    staleness acceptable for a country-level choropleth.
+  - `story-data.ts`, `military-surge.ts` — consume CII for context, not real time; 10-min
+    acceptable.
+  Phase 4 confirms each consumer owner signs off; the alerts surface is the one with a real
+  behavior change, not a pure latency change.
+
+A shared-formula module ("one formula, two engines") is **rejected** — the user's decision
+is one engine. Note: a shared module would eliminate *formula* divergence but not *input*
+or *country-set* divergence, so it does not by itself deliver one CII.
+
+## Per-signal source audit
+
+The 8 families the server CII does not currently *score*, and what each needs:
+
+| Signal | Frontend ingest | Server source today | Work |
+|---|---|---|---|
+| Aviation disruptions | `ingestAviationForCII` | `aviation:delays:intl:v3` (Redis) ✅ | Plumb into `AuxiliarySources` |
+| AIS disruptions | `ingestAisDisruptionsForCII` | `get-vessel-snapshot.ts` emits `AisDisruption` (live relay HTTP, **not** a Redis key) ⚠️ | Plumb + **geo→country** (`AisDisruption` has `{lat,lon}`+free-text `region`, no `countryCode`) |
+| Earthquakes | `ingestEarthquakesForCII` | `seismology:earthquakes:v1` (Redis) ✅ | Plumb + geo→country |
+| Sanctions | `ingestSanctionsForCII` | `sanctions/v1/list-sanctions-pressure.ts` (per-country) ✅ | Plumb |
+| Temporal anomalies | `ingestTemporalAnomaliesForCII` | server-detected (`TemporalAnomalyProto`, `temporal-baseline.ts consumeServerAnomalies()`) ✅ | Plumb |
+| Military flights | `ingestMilitaryForCII` | `military:flights:v1` (Redis) — **already operator-classified** by `scripts/seed-military-flights.mjs` ✅ | Per-country count + location/foreign-presence attribution |
+| Military vessels | `ingestMilitaryForCII` | relay `get-vessel-snapshot.ts` has raw vessels; **no military classification/attribution** ⚠️ | Port classifier (`MILITARY_VESSEL_PATTERNS`, `KNOWN_NAVAL_VESSELS` in `src/config/military.ts`) + attribution |
+| HAPI conflict | `ingestHapiForCII` | `conflict/v1/get-humanitarian-summary-batch.ts` → `conflict:humanitarian:v1:{ISO3}` ✅ | Phase 1 plumb — or take the drop decision in Phase 3a (frontend uses it only as ACLED-empty fallback) |
+
+`[rev]` Corrections from the first draft: only **military vessels** need genuinely new
+*classification* work — military flights are already classified in `military:flights:v1`;
+the relay is a process (`scripts/ais-relay.cjs`) reached by per-request HTTP, not a Redis
+key; AIS disruptions and earthquakes both need a geo→country step. No new persistent-
+WebSocket worker is needed (the relay process already holds the streams), but "plumbing"
+for AIS still means a live relay HTTP call with a timeout, not a cheap cache read.
+
+Additional frontend-only **inputs** (feed `calculateCII` but not in the 8 families):
+`focalPointDetector.getCountryUrgencyMap()` (`country-instability.ts:977`), hotspot boost
+(`getHotspotBoost`), learning-mode gating (`isInLearningMode`). Decide per Phase 3a.
+
+## Country-set divergence `[rev]`
+
+Server `computeCIIScores` iterates `Object.keys(TIER1_COUNTRIES)` — **31 countries**
+(`_shared.ts:35`, includes KR/IQ/AF/LB/EG/JP/QA). Frontend `calculateCII()` iterates
+`new Set([...countryDataMap.keys(), ...Object.keys(CURATED_COUNTRIES)])` — the same 31
+curated **plus any country that received ingested data** (dynamic). So after Phase 4,
+non-curated countries with events lose their CII. This is a smaller gap than a reviewer
+first claimed (it is *not* 31→24), but it is real: decide in Phase 3a whether to expand the
+server set or accept that CII is curated-countries-only (those dynamic scores were thin —
+baseline 20 + events — anyway).
+
+## Phases
+
+Phases 0, 1, 2, 3b, and 4 are each an independently shippable PR; Phase 3a is a
+design-note decision table, not a PR. The Guardrails section below is **not** a phase —
+each test ships inside an earlier phase's PR (noted per test).
+
+### Phase 0 — Label stopgap (ships immediately, independent)
+- Rename the CII component label `"Security"` → `"Mil. Activity"` in **all three**
+  component blocks of `src/locales/en.json` (lines 101, 745, 3170) and the **20 non-English
+  locale files** in `src/locales/*.json` (regenerate any `.d.ts` companions).
+- Internal dimension key stays `security`; only the display string changes.
+- File the security-model follow-up issue (#3738's actual complaint — a real
+  security/terrorism signal) and link #3738 to it. **Owner: TBD — assign before Phase 0
+  ships;** Phase 0 is not complete with only the rename.
+- No engine change. Safe given the Scope-boundary commitment above.
+
+### Phase 1 — Server acquires the cheap signals
+- `AuxiliarySources` + `fetchAuxiliarySources()`: add aviation, AIS disruptions (with
+  geo→country), earthquakes (with geo→country), sanctions, temporal anomalies.
+- `CountrySignals` + `emptySignals()`: add the count fields, mirroring `CountryData`
+  (`aisDisruptionHighCount`, `earthquakeSignificantCount`, `sanctionsEntryCount`,
+  `temporalAnomalyCount`, …).
+- Wire each into the per-country accumulation loop. **No scoring change** — signals
+  gathered but unused. Additive and safe.
+
+### Phase 2 — Server military flights + vessels
+- Per-country aggregation of `military:flights:v1` (already operator-classified) — add
+  location-code attribution for foreign presence.
+- New server-side military **vessel** classifier: port `MILITARY_VESSEL_PATTERNS` /
+  `KNOWN_NAVAL_VESSELS` and apply to the relay vessel snapshot. This is the single largest
+  new-build item in the plan — before committing, Phase 3a must check the vessel signal's
+  weight in the CII blend; if it is marginal, **drop military vessels and document the
+  accepted input gap** is a valid Phase 3a decision (mirroring HAPI's "or drop").
+- Port the *intent* of `ingestMilitaryForCII`'s foreign-presence weighting — **not the
+  representation hack**. The frontend fakes the ×2 weight by pushing synthetic `{}` objects
+  so `array.length` inflates (`country-instability.ts:447-456`); the server must store
+  honest counts and apply the ×2 in the formula, or any future reader of the new key gets a
+  ~3× inflated aircraft count.
+- Write per-country counts to a Redis key (e.g. `intelligence:military-cii:v1`).
+- **Decision:** aggregation runs as a scheduled server job writing the Redis key (not a
+  relay extension) — keeps `get-risk-scores.ts` reading Redis uniformly, matches the 600 s
+  cadence, and avoids coupling scoring to relay request latency.
+- **Attribution caveat:** the server's `geoToCountry` (`get-risk-scores.ts:154`) is a
+  bounding-box scan; the frontend uses polygon containment. For straits/borders (Hormuz,
+  Taiwan Strait, Black Sea — the high-signal cases) bbox will mis-attribute. Either port
+  polygon containment server-side or accept and document the precision loss.
+
+### Phase 3a — Reconciliation decisions (design note, no code)
+"Port verbatim" is **not** sufficient — the formulas diverge structurally and at least one
+divergence is intentional. Before the behavior-changing PR opens, settle every decision
+below and record it in a signed-off table. Phase 3b executes this table; it does not make
+decisions inside the PR.
+- For **each** of the 4 component formulas and **each** blend boost
+  (`hotspotBoost`, `newsUrgencyBoost`, `focalBoost`, `supplementalSignalBoost`,
+  `earthquakeBoost`, `sanctionsBoost`, `displacementBoost`), a **canonical decision**: which
+  engine's formula wins. Default = frontend, **except** where the server intentionally
+  diverged — e.g. the `information` cap was deliberately raised 20→100 in issue #3739
+  (`get-risk-scores.ts:518-521`); the server version wins there.
+- The `BASELINE_RISK` / `EVENT_MULTIPLIER` scalar-table reconciliation.
+- The `getScoreLevel` threshold reconciliation — frontend `getLevel` (≥81 / ≥66 / ≥51 /
+  ≥31) vs server adapter `cached-risk-scores.ts getScoreLevel` (≥70 / ≥55 / ≥40 / ≥25).
+  Even identical scores render different `level` badges until this is unified.
+- focal-urgency / hotspot-boost / learning-mode: **port if reproducible from
+  server-available signals, drop otherwise**.
+- The country-set question (Risk 6: expand server set, or accept curated-only).
+- The Phase 3-proto field-naming choice (below).
+- The Risk 3 cold-cache decision.
+- Signal→component mapping: for each newly-plumbed signal (Phase 1 — aviation, AIS
+  disruptions, earthquakes, sanctions, temporal anomalies; Phase 2 — military
+  flights/vessels), which component it scores into and with what sub-formula. The boost
+  list above does not cover signal→component mapping; an unmapped signal gets silently
+  dropped or invented inside Phase 3b.
+- The `ingest*ForCII` side-effect decomposition for Phase 4: enumerate which non-CII side
+  effects (e.g. `trackHotspotActivity` → `hotspotActivityMap`) survive the deletion and
+  which feature consumes each. Phase 4's irreversible deletion is gated on this table.
+
+### Phase 3b — Server computes the full CII (implementation)
+This is the behavior-changing PR. It **executes** the Phase 3a decision table — it makes no
+decisions. Implement each canonical formula choice, the scalar tables, the `getScoreLevel`
+thresholds, and the proto change. Pair with the Guardrails equality/level/attribution tests
+below; the PR is not done until the equality test is green.
+
+### Phase 3-proto — `CiiComponents` field naming
+Folded into the Phase 3b PR (same cache-key bump); the keep-vs-rename choice is made in
+Phase 3a. Decide: keep abusing the positional
+aliases (`militaryActivity`≡`security`, …), or rename the `.proto` fields to
+`unrest/conflict/security/information` and regenerate
+`src/generated/server/worldmonitor/intelligence/v1/service_server.ts` +
+`src/generated/client/worldmonitor/intelligence/v1/service_client.ts`. Either way the
+`CiiScore` shape changes → **mandatory** bump of
+`RISK_CACHE_KEY` (`v2`→`v3`) propagated to every reader listed at `get-risk-scores.ts:626-631`.
+
+### Phase 4 — Frontend becomes a renderer
+- Repoint every CII consumer to `cached-risk-scores.ts` — both `calculateCII()` and
+  `getCountryScore()` consumers. The `rg 'calculateCII|getCountryScore' src/` sweep is
+  authoritative and must be run before starting; the known sites are:
+  `country-intel.ts:218,740`, `data-loader.ts:348`, `search-manager.ts:710`,
+  `CIIPanel.ts:134`, `story-data.ts:65`, `src/services/cross-module-integration.ts:561,630`,
+  the internal `country-instability.ts:1038` (`getTopUnstableCountries`), and the
+  `getCountryScore` path: `DeckGLMap.ts` / `Map.ts` (via `setCIIGetter`), `InsightsPanel.ts`,
+  `military-surge.ts`.
+- `search-manager.ts:710` (`panelScores.length > 0 ? panelScores : calculateCII()`): the
+  fallback arm is **removed**, the line keeps the `panelScores` arm. It is not "converted
+  to a proto consumer" — `panelScores` already is one.
+- Delete `calculateCII`, `getCountryScore`, `calc*Score`, `calcNewsConflictFloor`.
+- **Surgical:** the `ingest*ForCII` functions have non-CII side effects (see Risk 1) — keep
+  the ingestion, delete only the CII scoring state. Use the side-effect decomposition table
+  produced in Phase 3a; do not leave it to per-engineer judgment.
+
+## Guardrails (not a standalone phase — each test ships in the phase noted)
+
+These are not an independently shippable phase; each test lands inside an earlier phase's PR.
+- **Equality test (lands with Phase 3b):** feed identical fixture *component-input* signals
+  to the server formulas and the frontend `calc*Score` functions; assert byte-identical
+  component scores. This is *formula parity* only — a green equality test is necessary but
+  **not sufficient** for UI parity (see Principle).
+- **Level-parity test (lands with Phase 3b):** assert the rendered `level` badge matches
+  across engines for the same score, gated on the Phase 3a `getScoreLevel` reconciliation.
+  Identical component scores still render different badges until thresholds are unified —
+  the equality test does not catch this.
+- **Attribution-parity test (lands with Phase 3b, one-shot while both engines coexist):**
+  feed real coordinates (straits, borders) through both the server bbox and frontend
+  polygon attribution; assert the country assignment matches, or document the accepted
+  deltas. The equality test alone is blind to this (Risk 2). The frontend attribution is
+  deleted in Phase 4, so this is a transition check, not an ongoing guardrail.
+- **Standing attribution regression test (permanent — survives Phase 4):** a fixed
+  coordinate-set → expected-country fixture for the server's `geoToCountry`, independent of
+  the frontend. The one-shot attribution-parity test validates the port; this guards
+  against future bbox drift once the frontend polygon attribution is deleted.
+- **Source-grep test (lands with Phase 4):** fails if `calculateCII` / `getCountryScore` /
+  `calc*Score` reappear in `src/`.
+
+## Principle
+
+The server CII and the frontend CII are **one metric** — after Phase 4 only the server
+engine exists, so equality is structural. *During* the transition (Phases 1–3) "equal"
+means **formula parity given identical inputs**, verified by the Guardrails equality test.
+Full production equality additionally requires input parity and attribution parity, which
+the Guardrails attribution-parity test covers. Note: byte-equality cannot be asserted against the
+*current* server `information` block — it intentionally diverged (#3739); Phase 3a resolves
+which side is canonical before the equality test can pass.
+
+## Risks / gotchas
+
+1. **`ingest*ForCII` have non-CII side effects.** `ingestMilitaryForCII`,
+   `ingestProtestsForCII`, `ingestConflictsForCII` call `trackHotspotActivity`
+   (`country-instability.ts:258,270,424,444`), feeding `hotspotActivityMap` consumed by
+   `getHotspotBoost`. Phase 4 deletes scoring, not ingestion — decompose each function.
+2. **Formula parity needs input + attribution parity.** Porting `calcSecurityScore`
+   byte-for-byte while feeding differently-attributed arrays still drifts. The Guardrails
+   attribution-parity test guards this; the equality test alone does not.
+3. **Cold-cache failure mode.** On a cold Redis cache + upstream failure, the server
+   returns 31 countries scored on **baseline only** (`get-risk-scores.ts:694-700`:
+   `computeCIIScores([], emptyAux)`). Today the frontend fallback masks this by recomputing
+   from live in-browser streams. Phase 4 removes that mask. **Decision required before
+   Phase 4:** either keep a thin client-side fallback for the empty-result case, or accept
+   a degraded baseline-only CII on cold start. Do not delete the fallback silently.
+4. **`cross-module-integration.ts` is stateful.** `checkCIIChanges()` (line 561) keeps
+   alert history in a module-level `previousCIIScores` Map and gates on `isInLearningMode()`
+   (frontend-only state). Moving to a 600 s server cadence changes delta-detection
+   semantics (two snapshots 10 min apart, not live ticks). This is a behavior change, not
+   just an availability concern — re-validate against the learning-mode decision in Phase 3a.
+5. **Cache key bump is mandatory, not conditional** — see Phase 3-proto.
+6. **Country-set shrink** — see "Country-set divergence"; decide in Phase 3a.
+
+## Sequencing notes
+
+- Phase 0 ships today; safe given the Scope-boundary commitment.
+- Phases 1–2 are additive (signals gathered, not scored) — safe, provided no proto change
+  ships with them (it ships with Phase 3b).
+- Phase 3a is a design note (decision table), not code; it is authored **after Phases 1–2
+  land** so the vessel-weight check has real data, and its cited formula line numbers are
+  re-verified against current source at the start of Phase 3b. Phase 3b (executing that
+  table, + Phase 3-proto + the Guardrails equality/level/attribution tests) is one PR — the
+  behavior-changing one. It is not done until the equality test is green and every
+  per-component canonical decision from 3a is recorded.
+- Phase 4 is the deletion PR — largest blast radius. Gate it on the Risk 3 (cold-cache),
+  Risk 4 (alert retuning), and Risk 6 (country-set) items being resolved and signed off.
+- Revertability: Phases 0–3 revert cleanly. Phase 4 deletes code — reverting it means
+  restoring the deleted engine *and* the `ingest*ForCII` decomposition. Treat Phase 4 as
+  the point of no return.
+
+## Deferred / Open Questions
+
+### From 2026-05-22 review
+- **Cold-cache fallback decision (Risk 3).** Phase 4 deletes the frontend engine that today
+  masks the cold-cache failure mode — on cold Redis + upstream failure the server returns
+  31 baseline-only scores (`get-risk-scores.ts:694-700`). Decide before Phase 4: keep a
+  thin client-side fallback for the empty-result case only, or accept a degraded
+  baseline-only CII on cold start (and decide whether a degraded score needs a UI staleness
+  indicator). This is an architecture/UX call that depends on tolerance for a cold-start
+  baseline-only CII — it cannot be auto-resolved. Blocks Phase 4. (adversarial, product-lens)

--- a/scripts/seed-military-cii.mjs
+++ b/scripts/seed-military-cii.mjs
@@ -374,11 +374,20 @@ function aggregate(flights, candidateReports, disruptions) {
 
   // Flights — operator country owns it; a flight located in a different country counts
   // as foreign presence there (the dual-attribution intent of ingestMilitaryForCII).
+  // When the operator is unknown (seed-military-flights emits the literal
+  // operatorCountry: 'Unknown' for `other`-class matches without source metadata, and
+  // non-TIER1 / coalition strings like 'NATO' also fall through normalizeCountryName)
+  // we count once as local presence — same logic as the vessel branch — because we
+  // cannot assert foreignness without a resolved operator, and foreignFlights is
+  // x2-weighted in the C3 security formula.
   for (const f of flights) {
     const op = normalizeCountryName(f.operatorCountry);
     const loc = geoToCountry(num(f.lat), num(f.lon));
     if (op && byCountry[op]) byCountry[op].ownFlights++;
-    if (loc && byCountry[loc] && loc !== op) byCountry[loc].foreignFlights++;
+    if (loc && byCountry[loc]) {
+      if (op && loc !== op) byCountry[loc].foreignFlights++;
+      else if (!op) byCountry[loc].ownFlights++;
+    }
   }
 
   // Vessels — classify each candidate AIS report, then attribute.

--- a/scripts/seed-military-cii.mjs
+++ b/scripts/seed-military-cii.mjs
@@ -25,7 +25,7 @@
 // Railway nixpacks packaging.
 
 import { pathToFileURL } from 'node:url';
-import { loadEnvFile, CHROME_UA, getRedisCredentials, acquireLockSafely, releaseLock, withRetry } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, getRedisCredentials, acquireLockSafely, releaseLock, withRetry, writeFreshnessMetadata } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -381,7 +381,7 @@ function aggregate(flights, candidateReports, disruptions) {
     if (loc && byCountry[loc] && loc !== op) byCountry[loc].foreignFlights++;
   }
 
-  // Vessels — classify each candidate AIS report, then attribute like flights.
+  // Vessels — classify each candidate AIS report, then attribute.
   let militaryVesselCount = 0;
   for (const c of candidateReports) {
     const cls = classifyVessel(c);
@@ -390,7 +390,13 @@ function aggregate(flights, candidateReports, disruptions) {
     const op = cls.operatorIso2;
     const loc = geoToCountry(num(c.lat), num(c.lon));
     if (op && byCountry[op]) byCountry[op].ownVessels++;
-    if (loc && byCountry[loc] && loc !== op) byCountry[loc].foreignVessels++;
+    if (loc && byCountry[loc]) {
+      if (op && loc !== op) byCountry[loc].foreignVessels++;
+      // Operator unknown (e.g. classified by AIS ship-type alone): count once as local
+      // presence, NOT as foreign — foreignVessels is ×2-weighted in the CII security
+      // formula, and we cannot assert a vessel is foreign without knowing its operator.
+      else if (!op) byCountry[loc].ownVessels++;
+    }
   }
 
   // AIS disruptions — attributed by location.
@@ -444,6 +450,8 @@ async function main() {
       const existing = await redisGetJson(url, token, LIVE_KEY).catch(() => null);
       if (existing && existing.byCountry) {
         await withRetry(() => redisSetJson(url, token, LIVE_KEY, existing, LIVE_TTL), 2, 1000);
+        // The cron ran successfully (data preserved) — freshness reflects "job alive".
+        await writeFreshnessMetadata('intelligence', 'military-cii', Object.keys(existing.byCountry).length, 'seed-military-cii', LIVE_TTL);
         console.warn(`  relay unavailable — preserved last-good ${LIVE_KEY} (vessels/AIS not overwritten)`);
         return;
       }
@@ -476,6 +484,8 @@ async function main() {
     };
 
     await withRetry(() => redisSetJson(url, token, LIVE_KEY, payload, LIVE_TTL), 2, 1000);
+    // Freshness record for health/seed monitoring — seed-meta:intelligence:military-cii.
+    await writeFreshnessMetadata('intelligence', 'military-cii', Object.keys(byCountry).length, 'seed-military-cii', LIVE_TTL);
     console.log(`  wrote ${LIVE_KEY}: own ${totals.ownFlights}f/${totals.ownVessels}v, foreign ${totals.foreignFlights}f/${totals.foreignVessels}v across ${Object.keys(byCountry).length} countries`);
   } finally {
     await releaseLock('intelligence:military-cii', runId);

--- a/scripts/seed-military-cii.mjs
+++ b/scripts/seed-military-cii.mjs
@@ -241,7 +241,10 @@ const COUNTRY_NAME_TO_ISO2 = {
 function analyzeMmsi(mmsi) {
   // Reject short or non-numeric IDs before the heuristics — a letter-padded MMSI
   // (corrupt / hostile relay data) must not slip through the suffix check.
-  if (!mmsi || mmsi.length < 9 || !/^\d+$/.test(mmsi)) return { isPotentialMilitary: false };
+  // Shape-consistent with the other three returns below — `country` is always
+  // present (possibly undefined) so call sites can rely on `result.country`
+  // without a null-check on the result object itself.
+  if (!mmsi || mmsi.length < 9 || !/^\d+$/.test(mmsi)) return { isPotentialMilitary: false, country: undefined };
   const mid = mmsi.substring(0, 3);
   const country = MILITARY_MIDS[mid];
   for (const pattern of MILITARY_VESSEL_PATTERNS) {

--- a/scripts/seed-military-cii.mjs
+++ b/scripts/seed-military-cii.mjs
@@ -1,0 +1,439 @@
+#!/usr/bin/env node
+//
+// seed-military-cii.mjs — Phase 2 of the CII unification (plans/unify-cii-single-source.md).
+//
+// Aggregates military activity per country into a single Redis key the CII engine
+// (server/worldmonitor/intelligence/v1/get-risk-scores.ts) reads as one auxiliary source:
+//
+//   - military FLIGHTS  — read from `military:flights:v1` (already operator-classified
+//                         by seed-military-flights.mjs)
+//   - military VESSELS  — classified here from the relay `/ais/snapshot` candidate feed
+//   - AIS DISRUPTIONS   — taken from the same relay snapshot
+//
+// Output key: `intelligence:military-cii:v1`
+//   { assessedAt, byCountry: { ISO2: { ownFlights, foreignFlights, ownVessels,
+//     foreignVessels, aisDisruptionHigh, aisDisruptionElevated, aisDisruptionLow } }, stats }
+//
+// "Honest counts": own vs foreign presence are stored as SEPARATE integers — the consumer
+// applies any foreign-presence weighting at scoring time. This deliberately does NOT mirror
+// the frontend's synthetic-`{}`-push ×2 hack (see the plan's Phase 2 notes).
+//
+// SCHEDULING: like every other scripts/seed-*.mjs, this is a self-contained job run on a
+// schedule by Railway (the cron/job config lives in the Railway dashboard, not the repo).
+// Run cadence ~10 min; the output key TTL (3600s) tolerates a few skipped runs.
+// Self-contained by necessity — scripts/ cannot import from server/ or src/ under the
+// Railway nixpacks packaging.
+
+import { pathToFileURL } from 'node:url';
+import { loadEnvFile, CHROME_UA, getRedisCredentials, acquireLockSafely, releaseLock } from './_seed-utils.mjs';
+
+loadEnvFile(import.meta.url);
+
+const LIVE_KEY = 'intelligence:military-cii:v1';
+const LIVE_TTL = 3600;
+const RELAY_TIMEOUT_MS = 15_000;
+
+// ── Country reference tables (mirror server/.../get-risk-scores.ts + _shared.ts) ──────
+
+const TIER1_COUNTRIES = {
+  US: 'United States', RU: 'Russia', CN: 'China', UA: 'Ukraine', IR: 'Iran',
+  IL: 'Israel', TW: 'Taiwan', KP: 'North Korea', SA: 'Saudi Arabia', TR: 'Turkey',
+  PL: 'Poland', DE: 'Germany', FR: 'France', GB: 'United Kingdom', IN: 'India',
+  PK: 'Pakistan', SY: 'Syria', YE: 'Yemen', MM: 'Myanmar', VE: 'Venezuela',
+  CU: 'Cuba', MX: 'Mexico', BR: 'Brazil', AE: 'United Arab Emirates',
+  KR: 'South Korea', IQ: 'Iraq', AF: 'Afghanistan', LB: 'Lebanon',
+  EG: 'Egypt', JP: 'Japan', QA: 'Qatar',
+};
+
+const COUNTRY_KEYWORDS = {
+  US: ['united states', 'usa', 'america', 'washington'],
+  RU: ['russia', 'moscow', 'kremlin'],
+  CN: ['china', 'beijing', 'prc'],
+  UA: ['ukraine', 'kyiv'],
+  IR: ['iran', 'tehran'],
+  IL: ['israel', 'tel aviv'],
+  TW: ['taiwan', 'taipei'],
+  KP: ['north korea', 'pyongyang'],
+  SA: ['saudi arabia', 'riyadh'],
+  TR: ['turkey', 'ankara', 'turkiye'],
+  PL: ['poland', 'warsaw'],
+  DE: ['germany', 'berlin'],
+  FR: ['france', 'paris'],
+  GB: ['britain', 'uk', 'united kingdom', 'london', 'england'],
+  IN: ['india', 'delhi'],
+  PK: ['pakistan', 'islamabad'],
+  SY: ['syria', 'damascus'],
+  YE: ['yemen', 'sanaa'],
+  MM: ['myanmar', 'burma'],
+  VE: ['venezuela', 'caracas'],
+  CU: ['cuba', 'havana'],
+  MX: ['mexico', 'mexican'],
+  BR: ['brazil', 'brasilia'],
+  AE: ['uae', 'emirates', 'united arab emirates'],
+  KR: ['south korea', 'korean peninsula', 'seoul'],
+  IQ: ['iraq', 'iraqi', 'baghdad'],
+  AF: ['afghanistan', 'afghan', 'kabul'],
+  LB: ['lebanon', 'lebanese', 'beirut'],
+  EG: ['egypt', 'egyptian', 'cairo'],
+  JP: ['japan', 'japanese', 'tokyo'],
+  QA: ['qatar', 'qatari', 'doha'],
+};
+
+const COUNTRY_BBOX = {
+  US: { minLat: 24.5, maxLat: 49.4, minLon: -125.0, maxLon: -66.9 },
+  RU: { minLat: 41.2, maxLat: 81.9, minLon: 19.6, maxLon: 180.0 },
+  CN: { minLat: 18.2, maxLat: 53.6, minLon: 73.5, maxLon: 135.1 },
+  UA: { minLat: 44.4, maxLat: 52.4, minLon: 22.1, maxLon: 40.2 },
+  IR: { minLat: 25.1, maxLat: 39.8, minLon: 44.0, maxLon: 63.3 },
+  IL: { minLat: 29.5, maxLat: 33.3, minLon: 34.3, maxLon: 35.9 },
+  TW: { minLat: 21.9, maxLat: 25.3, minLon: 120.0, maxLon: 122.0 },
+  KP: { minLat: 37.7, maxLat: 43.0, minLon: 124.3, maxLon: 130.7 },
+  SA: { minLat: 16.4, maxLat: 32.2, minLon: 34.6, maxLon: 55.7 },
+  TR: { minLat: 36.0, maxLat: 42.1, minLon: 26.0, maxLon: 44.8 },
+  PL: { minLat: 49.0, maxLat: 54.8, minLon: 14.1, maxLon: 24.2 },
+  DE: { minLat: 47.3, maxLat: 55.1, minLon: 5.9, maxLon: 15.0 },
+  FR: { minLat: 41.4, maxLat: 51.1, minLon: -5.1, maxLon: 9.6 },
+  GB: { minLat: 49.9, maxLat: 60.9, minLon: -8.2, maxLon: 1.8 },
+  IN: { minLat: 6.7, maxLat: 35.5, minLon: 68.1, maxLon: 97.4 },
+  PK: { minLat: 23.7, maxLat: 37.1, minLon: 60.9, maxLon: 77.8 },
+  SY: { minLat: 32.3, maxLat: 37.3, minLon: 35.7, maxLon: 42.4 },
+  YE: { minLat: 12.1, maxLat: 19.0, minLon: 42.5, maxLon: 54.5 },
+  MM: { minLat: 9.8, maxLat: 28.5, minLon: 92.2, maxLon: 101.2 },
+  VE: { minLat: 0.6, maxLat: 12.2, minLon: -73.4, maxLon: -59.8 },
+  CU: { minLat: 19.8, maxLat: 23.3, minLon: -85.0, maxLon: -74.1 },
+  MX: { minLat: 14.5, maxLat: 32.7, minLon: -118.4, maxLon: -86.7 },
+  BR: { minLat: -33.7, maxLat: 5.3, minLon: -73.9, maxLon: -34.8 },
+  AE: { minLat: 22.6, maxLat: 26.1, minLon: 51.6, maxLon: 56.4 },
+  KR: { minLat: 33.1, maxLat: 38.6, minLon: 125.1, maxLon: 131.9 },
+  IQ: { minLat: 29.1, maxLat: 37.4, minLon: 38.8, maxLon: 48.6 },
+  AF: { minLat: 29.4, maxLat: 38.5, minLon: 60.5, maxLon: 75.0 },
+  LB: { minLat: 33.1, maxLat: 34.7, minLon: 35.1, maxLon: 36.6 },
+  EG: { minLat: 22.0, maxLat: 31.7, minLon: 24.7, maxLon: 36.9 },
+  JP: { minLat: 24.4, maxLat: 45.5, minLon: 122.9, maxLon: 153.0 },
+  QA: { minLat: 24.5, maxLat: 26.2, minLon: 50.7, maxLon: 51.7 },
+};
+
+// Smallest-area-first so a point inside several boxes resolves to the tightest fit.
+const BBOX_BY_AREA = Object.entries(COUNTRY_BBOX)
+  .map(([code, b]) => ({ code, ...b, area: (b.maxLat - b.minLat) * (b.maxLon - b.minLon) }))
+  .sort((a, b) => a.area - b.area);
+
+function num(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function normalizeCountryName(text) {
+  const lower = String(text || '').toLowerCase();
+  if (!lower) return null;
+  for (const [code, keywords] of Object.entries(COUNTRY_KEYWORDS)) {
+    if (keywords.some((kw) => lower.includes(kw))) return code;
+  }
+  return null;
+}
+
+function geoToCountry(lat, lon) {
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+  for (const b of BBOX_BY_AREA) {
+    if (lat >= b.minLat && lat <= b.maxLat && lon >= b.minLon && lon <= b.maxLon) return b.code;
+  }
+  return null;
+}
+
+// ── Military vessel classifier (mirror src/config/military.ts + military-vessels.ts) ──
+
+const MILITARY_VESSEL_PATTERNS = [
+  { mmsiPrefix: '3699', country: 'USA' },
+  { mmsiPrefix: '369970', country: 'USA' },
+  { mmsiPrefix: '232', country: 'UK' },
+  { mmsiPrefix: '2320', country: 'UK' },
+];
+
+const KNOWN_NAVAL_VESSELS = [
+  { name: 'USS Gerald R. Ford', hullNumber: 'CVN-78', country: 'USA' },
+  { name: 'USS George H.W. Bush', hullNumber: 'CVN-77', country: 'USA' },
+  { name: 'USS Ronald Reagan', hullNumber: 'CVN-76', country: 'USA' },
+  { name: 'USS Harry S. Truman', hullNumber: 'CVN-75', country: 'USA' },
+  { name: 'USS John C. Stennis', hullNumber: 'CVN-74', country: 'USA' },
+  { name: 'USS George Washington', hullNumber: 'CVN-73', country: 'USA' },
+  { name: 'USS Abraham Lincoln', hullNumber: 'CVN-72', country: 'USA' },
+  { name: 'USS Theodore Roosevelt', hullNumber: 'CVN-71', country: 'USA' },
+  { name: 'USS Carl Vinson', hullNumber: 'CVN-70', country: 'USA' },
+  { name: 'USS Dwight D. Eisenhower', hullNumber: 'CVN-69', country: 'USA' },
+  { name: 'USS Nimitz', hullNumber: 'CVN-68', country: 'USA' },
+  { name: 'HMS Queen Elizabeth', hullNumber: 'R08', country: 'UK' },
+  { name: 'HMS Prince of Wales', hullNumber: 'R09', country: 'UK' },
+  { name: 'Liaoning', hullNumber: '16', country: 'China' },
+  { name: 'Shandong', hullNumber: '17', country: 'China' },
+  { name: 'Fujian', hullNumber: '18', country: 'China' },
+  { name: 'Admiral Kuznetsov', country: 'Russia' },
+  { name: 'USS Zumwalt', hullNumber: 'DDG-1000', country: 'USA' },
+  { name: 'HMS Defender', hullNumber: 'D36', country: 'UK' },
+  { name: 'HMS Duncan', hullNumber: 'D37', country: 'UK' },
+  { name: 'USNS Victorious', hullNumber: 'T-AGOS-19', country: 'USA' },
+  { name: 'USNS Impeccable', hullNumber: 'T-AGOS-23', country: 'USA' },
+  { name: 'Yuan Wang', country: 'China' },
+];
+
+// Maritime Identification Digits → country name (first 3 digits of an MMSI).
+const MILITARY_MIDS = {
+  '201': 'Albania', '202': 'Andorra', '203': 'Austria', '211': 'Germany', '212': 'Cyprus',
+  '213': 'Georgia', '214': 'Moldova', '215': 'Malta', '216': 'Armenia', '218': 'Germany',
+  '219': 'Denmark', '220': 'Denmark', '224': 'Spain', '225': 'Spain', '226': 'France',
+  '227': 'France', '228': 'France', '229': 'Malta', '230': 'Finland', '231': 'Faroe',
+  '232': 'UK', '233': 'UK', '234': 'UK', '235': 'UK', '236': 'Gibraltar', '237': 'Greece',
+  '238': 'Croatia', '239': 'Greece', '240': 'Greece', '241': 'Greece', '242': 'Morocco',
+  '243': 'Hungary', '244': 'Netherlands', '245': 'Netherlands', '246': 'Netherlands',
+  '247': 'Italy', '248': 'Malta', '249': 'Malta', '250': 'Ireland', '255': 'Portugal',
+  '256': 'Malta', '257': 'Norway', '258': 'Norway', '259': 'Norway', '261': 'Poland',
+  '263': 'Portugal', '264': 'Romania', '265': 'Sweden', '266': 'Sweden', '267': 'Slovakia',
+  '268': 'San Marino', '269': 'Switzerland', '270': 'Czechia', '271': 'Turkey',
+  '272': 'Ukraine', '273': 'Russia', '274': 'North Macedonia', '275': 'Latvia',
+  '276': 'Estonia', '277': 'Lithuania', '278': 'Slovenia', '279': 'Serbia',
+  '316': 'Canada', '323': 'Cuba', '338': 'USA', '345': 'Mexico', '366': 'USA',
+  '367': 'USA', '368': 'USA', '369': 'USA',
+  '401': 'Afghanistan', '403': 'Saudi Arabia', '405': 'Bangladesh', '408': 'Bahrain',
+  '412': 'China', '413': 'China', '414': 'China', '416': 'Taiwan', '417': 'Sri Lanka',
+  '419': 'India', '422': 'Iran', '423': 'Azerbaijan', '425': 'Iraq', '428': 'Israel',
+  '431': 'Japan', '432': 'Japan', '434': 'Turkmenistan', '436': 'Kazakhstan',
+  '437': 'Uzbekistan', '438': 'Jordan', '440': 'South Korea', '441': 'South Korea',
+  '443': 'Palestine', '445': 'North Korea', '447': 'Kuwait', '450': 'Lebanon',
+  '451': 'Kyrgyzstan', '453': 'Macau', '455': 'Maldives', '457': 'Mongolia',
+  '459': 'Nepal', '461': 'Oman', '463': 'Pakistan', '466': 'Qatar', '468': 'Syria',
+  '470': 'UAE', '472': 'Tajikistan', '473': 'Yemen', '475': 'Yemen', '477': 'Hong Kong',
+  '503': 'Australia', '506': 'Myanmar', '508': 'Brunei', '512': 'New Zealand',
+  '525': 'Indonesia', '533': 'Malaysia', '548': 'Philippines', '563': 'Singapore',
+  '564': 'Singapore', '565': 'Singapore', '566': 'Singapore', '567': 'Thailand',
+  '574': 'Vietnam',
+};
+
+function analyzeMmsi(mmsi) {
+  if (!mmsi || mmsi.length < 9) return { isPotentialMilitary: false };
+  const mid = mmsi.substring(0, 3);
+  const country = MILITARY_MIDS[mid];
+  for (const pattern of MILITARY_VESSEL_PATTERNS) {
+    if (pattern.mmsiPrefix && mmsi.startsWith(pattern.mmsiPrefix)) {
+      return { isPotentialMilitary: true, country: pattern.country };
+    }
+  }
+  const suffix = mmsi.substring(3);
+  if (suffix.startsWith('00') || suffix.startsWith('99')) {
+    return { isPotentialMilitary: true, country };
+  }
+  return { isPotentialMilitary: false, country };
+}
+
+function matchKnownVessel(name) {
+  if (!name) return undefined;
+  const normalized = name.toUpperCase().trim();
+  for (const vessel of KNOWN_NAVAL_VESSELS) {
+    if (normalized.includes(vessel.name.toUpperCase())
+      || (vessel.hullNumber && normalized.includes(vessel.hullNumber))) {
+      return vessel;
+    }
+  }
+  return undefined;
+}
+
+// AIS ship-type code → military marker. 35 = military ops, 50-59 = special craft.
+function isMilitaryShipType(shipType) {
+  return shipType === 35 || (shipType >= 50 && shipType <= 59);
+}
+
+// Returns { operatorCountry } if the candidate classifies as military, else null.
+function classifyVessel(candidate) {
+  const mmsi = String(candidate.mmsi || '');
+  const name = String(candidate.name || '');
+  const known = matchKnownVessel(name);
+  const mmsiAnalysis = analyzeMmsi(mmsi);
+  const aisMilitary = isMilitaryShipType(num(candidate.shipType));
+  if (!known && !mmsiAnalysis.isPotentialMilitary && !aisMilitary) return null;
+  return { operatorCountry: known?.country || mmsiAnalysis.country || null };
+}
+
+// ── Redis (Upstash REST) ──────────────────────────────────────────────────────────────
+
+async function redisCommand(url, token, command) {
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(command),
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!resp.ok) throw new Error(`Redis ${command[0]} ${command[1]} failed: HTTP ${resp.status}`);
+  return (await resp.json()).result;
+}
+
+async function redisGetJson(url, token, key) {
+  const raw = await redisCommand(url, token, ['GET', key]);
+  if (!raw || typeof raw !== 'string') return null;
+  try {
+    const parsed = JSON.parse(raw);
+    // get-risk-scores reads via getCachedJson(key, true) → unwrapEnvelope(...).data;
+    // tolerate both the bare shape and a { data: ... } envelope.
+    return parsed && typeof parsed === 'object' && 'data' in parsed ? parsed.data : parsed;
+  } catch {
+    return null;
+  }
+}
+
+async function redisSetJson(url, token, key, value, ttl) {
+  await redisCommand(url, token, ['SET', key, JSON.stringify(value), 'EX', ttl]);
+}
+
+// ── Relay ────────────────────────────────────────────────────────────────────────────
+
+function getRelayBaseUrl() {
+  const relayUrl = process.env.WS_RELAY_URL;
+  if (!relayUrl) return null;
+  return relayUrl.replace(/^ws(s?):\/\//, 'http$1://').replace(/\/$/, '');
+}
+
+function getRelayHeaders() {
+  const headers = { Accept: 'application/json', 'User-Agent': CHROME_UA };
+  const relaySecret = process.env.RELAY_SHARED_SECRET;
+  if (relaySecret) {
+    const relayHeader = (process.env.RELAY_AUTH_HEADER || 'x-relay-key').toLowerCase();
+    headers[relayHeader] = relaySecret;
+    if (relayHeader !== 'authorization') headers.Authorization = `Bearer ${relaySecret}`;
+  }
+  return headers;
+}
+
+// Returns { candidateReports, disruptions } — empty arrays if the relay is unreachable.
+async function fetchRelaySnapshot() {
+  const base = getRelayBaseUrl();
+  if (!base) {
+    console.warn('  WS_RELAY_URL not set — vessels + AIS disruptions skipped');
+    return { candidateReports: [], disruptions: [] };
+  }
+  try {
+    const resp = await fetch(`${base}/ais/snapshot?candidates=true`, {
+      headers: getRelayHeaders(),
+      signal: AbortSignal.timeout(RELAY_TIMEOUT_MS),
+    });
+    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+    const data = await resp.json();
+    return {
+      candidateReports: Array.isArray(data.candidateReports) ? data.candidateReports : [],
+      disruptions: Array.isArray(data.disruptions) ? data.disruptions : [],
+    };
+  } catch (err) {
+    console.warn(`  relay /ais/snapshot failed (${err.message || err}) — vessels + AIS skipped`);
+    return { candidateReports: [], disruptions: [] };
+  }
+}
+
+// ── Aggregation ──────────────────────────────────────────────────────────────────────
+
+function emptyCountryRecord() {
+  return {
+    ownFlights: 0, foreignFlights: 0, ownVessels: 0, foreignVessels: 0,
+    aisDisruptionHigh: 0, aisDisruptionElevated: 0, aisDisruptionLow: 0,
+  };
+}
+
+function aggregate(flights, candidateReports, disruptions) {
+  const byCountry = {};
+  for (const code of Object.keys(TIER1_COUNTRIES)) byCountry[code] = emptyCountryRecord();
+
+  // Flights — operator country owns it; a flight located in a different country counts
+  // as foreign presence there (the dual-attribution intent of ingestMilitaryForCII).
+  for (const f of flights) {
+    const op = normalizeCountryName(f.operatorCountry);
+    const loc = geoToCountry(num(f.lat), num(f.lon));
+    if (op && byCountry[op]) byCountry[op].ownFlights++;
+    if (loc && byCountry[loc] && loc !== op) byCountry[loc].foreignFlights++;
+  }
+
+  // Vessels — classify each candidate AIS report, then attribute like flights.
+  let militaryVesselCount = 0;
+  for (const c of candidateReports) {
+    const cls = classifyVessel(c);
+    if (!cls) continue;
+    militaryVesselCount++;
+    const op = cls.operatorCountry ? normalizeCountryName(cls.operatorCountry) : null;
+    const loc = geoToCountry(num(c.lat), num(c.lon));
+    if (op && byCountry[op]) byCountry[op].ownVessels++;
+    if (loc && byCountry[loc] && loc !== op) byCountry[loc].foreignVessels++;
+  }
+
+  // AIS disruptions — attributed by location.
+  for (const d of disruptions) {
+    const code = geoToCountry(num(d.lat), num(d.lon));
+    if (!code || !byCountry[code]) continue;
+    const sev = String(d.severity || '').toLowerCase();
+    if (sev === 'high') byCountry[code].aisDisruptionHigh++;
+    else if (sev === 'elevated') byCountry[code].aisDisruptionElevated++;
+    else byCountry[code].aisDisruptionLow++;
+  }
+
+  return { byCountry, militaryVesselCount };
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const startMs = Date.now();
+  const runId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const { url, token } = getRedisCredentials();
+
+  console.log('=== intelligence:military-cii Seed ===');
+
+  const lockResult = await acquireLockSafely('intelligence:military-cii', runId, 120_000, { label: 'military-cii' });
+  if (lockResult.skipped || !lockResult.locked) {
+    console.log('  SKIPPED: another seed run in progress');
+    process.exit(0);
+  }
+
+  try {
+    // Military flights — already classified upstream by seed-military-flights.mjs.
+    let flights = [];
+    try {
+      const flightsData = await redisGetJson(url, token, 'military:flights:v1');
+      flights = Array.isArray(flightsData?.flights) ? flightsData.flights : [];
+    } catch (err) {
+      console.warn(`  military:flights:v1 read failed (${err.message || err}) — flights skipped`);
+    }
+
+    const { candidateReports, disruptions } = await fetchRelaySnapshot();
+    console.log(`  inputs: ${flights.length} flights, ${candidateReports.length} vessel candidates, ${disruptions.length} AIS disruptions`);
+
+    const { byCountry, militaryVesselCount } = aggregate(flights, candidateReports, disruptions);
+
+    const totals = Object.values(byCountry).reduce((acc, r) => {
+      acc.ownFlights += r.ownFlights; acc.foreignFlights += r.foreignFlights;
+      acc.ownVessels += r.ownVessels; acc.foreignVessels += r.foreignVessels;
+      return acc;
+    }, { ownFlights: 0, foreignFlights: 0, ownVessels: 0, foreignVessels: 0 });
+
+    const payload = {
+      assessedAt: Date.now(),
+      byCountry,
+      stats: {
+        flightsInput: flights.length,
+        vesselCandidatesInput: candidateReports.length,
+        militaryVesselsClassified: militaryVesselCount,
+        disruptionsInput: disruptions.length,
+        ...totals,
+      },
+    };
+
+    await redisSetJson(url, token, LIVE_KEY, payload, LIVE_TTL);
+    console.log(`  wrote ${LIVE_KEY}: own ${totals.ownFlights}f/${totals.ownVessels}v, foreign ${totals.foreignFlights}f/${totals.foreignVessels}v across ${Object.keys(byCountry).length} countries`);
+  } finally {
+    await releaseLock('intelligence:military-cii', runId);
+  }
+
+  console.log(`=== Done (${Math.round(Date.now() - startMs)}ms) ===`);
+}
+
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isDirectRun) {
+  main().catch((err) => {
+    console.error(`FATAL: ${err?.stack || err}`);
+    process.exit(1);
+  });
+}
+
+export { aggregate, classifyVessel, analyzeMmsi, geoToCountry, normalizeCountryName };

--- a/scripts/seed-military-cii.mjs
+++ b/scripts/seed-military-cii.mjs
@@ -25,7 +25,7 @@
 // Railway nixpacks packaging.
 
 import { pathToFileURL } from 'node:url';
-import { loadEnvFile, CHROME_UA, getRedisCredentials, acquireLockSafely, releaseLock } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, getRedisCredentials, acquireLockSafely, releaseLock, withRetry } from './_seed-utils.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -207,8 +207,33 @@ const MILITARY_MIDS = {
   '574': 'Vietnam',
 };
 
+// Country NAME → ISO2. The classifier tables (MILITARY_MIDS, KNOWN_NAVAL_VESSELS) carry
+// names; aggregation needs ISO2. Covers every name those tables can emit so a non-TIER1
+// operator resolves to a real code instead of silently becoming null.
+const COUNTRY_NAME_TO_ISO2 = {
+  Albania: 'AL', Andorra: 'AD', Austria: 'AT', Germany: 'DE', Cyprus: 'CY', Georgia: 'GE',
+  Moldova: 'MD', Malta: 'MT', Armenia: 'AM', Denmark: 'DK', Spain: 'ES', France: 'FR',
+  Finland: 'FI', Faroe: 'FO', UK: 'GB', Gibraltar: 'GI', Greece: 'GR', Croatia: 'HR',
+  Morocco: 'MA', Hungary: 'HU', Netherlands: 'NL', Italy: 'IT', Ireland: 'IE',
+  Portugal: 'PT', Norway: 'NO', Poland: 'PL', Romania: 'RO', Sweden: 'SE', Slovakia: 'SK',
+  'San Marino': 'SM', Switzerland: 'CH', Czechia: 'CZ', Turkey: 'TR', Ukraine: 'UA',
+  'North Macedonia': 'MK', Latvia: 'LV', Estonia: 'EE', Lithuania: 'LT', Slovenia: 'SI',
+  Serbia: 'RS', Canada: 'CA', Cuba: 'CU', USA: 'US', Mexico: 'MX', Afghanistan: 'AF',
+  'Saudi Arabia': 'SA', Bangladesh: 'BD', Bahrain: 'BH', China: 'CN', Taiwan: 'TW',
+  'Sri Lanka': 'LK', India: 'IN', Iran: 'IR', Azerbaijan: 'AZ', Iraq: 'IQ', Israel: 'IL',
+  Japan: 'JP', Turkmenistan: 'TM', Kazakhstan: 'KZ', Uzbekistan: 'UZ', Jordan: 'JO',
+  'South Korea': 'KR', Palestine: 'PS', 'North Korea': 'KP', Kuwait: 'KW', Lebanon: 'LB',
+  Kyrgyzstan: 'KG', Macau: 'MO', Maldives: 'MV', Mongolia: 'MN', Nepal: 'NP', Oman: 'OM',
+  Pakistan: 'PK', Qatar: 'QA', Syria: 'SY', UAE: 'AE', Tajikistan: 'TJ', Yemen: 'YE',
+  'Hong Kong': 'HK', Australia: 'AU', Myanmar: 'MM', Brunei: 'BN', 'New Zealand': 'NZ',
+  Indonesia: 'ID', Malaysia: 'MY', Philippines: 'PH', Singapore: 'SG', Thailand: 'TH',
+  Vietnam: 'VN', Russia: 'RU',
+};
+
 function analyzeMmsi(mmsi) {
-  if (!mmsi || mmsi.length < 9) return { isPotentialMilitary: false };
+  // Reject short or non-numeric IDs before the heuristics — a letter-padded MMSI
+  // (corrupt / hostile relay data) must not slip through the suffix check.
+  if (!mmsi || mmsi.length < 9 || !/^\d+$/.test(mmsi)) return { isPotentialMilitary: false };
   const mid = mmsi.substring(0, 3);
   const country = MILITARY_MIDS[mid];
   for (const pattern of MILITARY_VESSEL_PATTERNS) {
@@ -216,8 +241,10 @@ function analyzeMmsi(mmsi) {
       return { isPotentialMilitary: true, country: pattern.country };
     }
   }
+  // The 00/99-suffix heuristic is noisy on civilian MMSIs; only trust it when the MID
+  // resolves to a known country — drops the unknown-MID civilian false positives.
   const suffix = mmsi.substring(3);
-  if (suffix.startsWith('00') || suffix.startsWith('99')) {
+  if (country && (suffix.startsWith('00') || suffix.startsWith('99'))) {
     return { isPotentialMilitary: true, country };
   }
   return { isPotentialMilitary: false, country };
@@ -227,8 +254,11 @@ function matchKnownVessel(name) {
   if (!name) return undefined;
   const normalized = name.toUpperCase().trim();
   for (const vessel of KNOWN_NAVAL_VESSELS) {
+    // Hull-number substring match only for hull numbers >=3 chars — short numeric hulls
+    // ('16','17','18') match civilian names by coincidence; those carriers still match
+    // by their distinctive name above.
     if (normalized.includes(vessel.name.toUpperCase())
-      || (vessel.hullNumber && normalized.includes(vessel.hullNumber))) {
+      || (vessel.hullNumber && vessel.hullNumber.length >= 3 && normalized.includes(vessel.hullNumber))) {
       return vessel;
     }
   }
@@ -240,7 +270,8 @@ function isMilitaryShipType(shipType) {
   return shipType === 35 || (shipType >= 50 && shipType <= 59);
 }
 
-// Returns { operatorCountry } if the candidate classifies as military, else null.
+// Returns { operatorIso2 } if the candidate classifies as military, else null.
+// operatorIso2 is null when the vessel is military by ship-type alone (no operator known).
 function classifyVessel(candidate) {
   const mmsi = String(candidate.mmsi || '');
   const name = String(candidate.name || '');
@@ -248,7 +279,8 @@ function classifyVessel(candidate) {
   const mmsiAnalysis = analyzeMmsi(mmsi);
   const aisMilitary = isMilitaryShipType(num(candidate.shipType));
   if (!known && !mmsiAnalysis.isPotentialMilitary && !aisMilitary) return null;
-  return { operatorCountry: known?.country || mmsiAnalysis.country || null };
+  const operatorName = known?.country || mmsiAnalysis.country || null;
+  return { operatorIso2: operatorName ? (COUNTRY_NAME_TO_ISO2[operatorName] || null) : null };
 }
 
 // ── Redis (Upstash REST) ──────────────────────────────────────────────────────────────
@@ -308,16 +340,18 @@ async function fetchRelaySnapshot() {
     return { candidateReports: [], disruptions: [] };
   }
   try {
-    const resp = await fetch(`${base}/ais/snapshot?candidates=true`, {
-      headers: getRelayHeaders(),
-      signal: AbortSignal.timeout(RELAY_TIMEOUT_MS),
-    });
-    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-    const data = await resp.json();
-    return {
-      candidateReports: Array.isArray(data.candidateReports) ? data.candidateReports : [],
-      disruptions: Array.isArray(data.disruptions) ? data.disruptions : [],
-    };
+    const data = await withRetry(async () => {
+      const resp = await fetch(`${base}/ais/snapshot?candidates=true`, {
+        headers: getRelayHeaders(),
+        signal: AbortSignal.timeout(RELAY_TIMEOUT_MS),
+      });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      return resp.json();
+    }, 2, 1000);
+    // Cap to bound classification work — a hostile/buggy relay must not OOM the job
+    // or overrun the lock TTL. Consumers in get-risk-scores cap reads at maxLen=10000.
+    const cap = (a) => (Array.isArray(a) ? a.slice(0, 20_000) : []);
+    return { candidateReports: cap(data.candidateReports), disruptions: cap(data.disruptions) };
   } catch (err) {
     console.warn(`  relay /ais/snapshot failed (${err.message || err}) — vessels + AIS skipped`);
     return { candidateReports: [], disruptions: [] };
@@ -352,7 +386,7 @@ function aggregate(flights, candidateReports, disruptions) {
     const cls = classifyVessel(c);
     if (!cls) continue;
     militaryVesselCount++;
-    const op = cls.operatorCountry ? normalizeCountryName(cls.operatorCountry) : null;
+    const op = cls.operatorIso2;
     const loc = geoToCountry(num(c.lat), num(c.lon));
     if (op && byCountry[op]) byCountry[op].ownVessels++;
     if (loc && byCountry[loc] && loc !== op) byCountry[loc].foreignVessels++;
@@ -380,7 +414,9 @@ async function main() {
 
   console.log('=== intelligence:military-cii Seed ===');
 
-  const lockResult = await acquireLockSafely('intelligence:military-cii', runId, 120_000, { label: 'military-cii' });
+  // 180s TTL leaves headroom above worst-case runtime (flights read + relay fetch, each
+  // with up to 2 retries) so a slow run cannot expire the lock and let a second run race.
+  const lockResult = await acquireLockSafely('intelligence:military-cii', runId, 180_000, { label: 'military-cii' });
   if (lockResult.skipped || !lockResult.locked) {
     console.log('  SKIPPED: another seed run in progress');
     process.exit(0);
@@ -419,7 +455,7 @@ async function main() {
       },
     };
 
-    await redisSetJson(url, token, LIVE_KEY, payload, LIVE_TTL);
+    await withRetry(() => redisSetJson(url, token, LIVE_KEY, payload, LIVE_TTL), 2, 1000);
     console.log(`  wrote ${LIVE_KEY}: own ${totals.ownFlights}f/${totals.ownVessels}v, foreign ${totals.foreignFlights}f/${totals.foreignVessels}v across ${Object.keys(byCountry).length} countries`);
   } finally {
     await releaseLock('intelligence:military-cii', runId);
@@ -436,4 +472,4 @@ if (isDirectRun) {
   });
 }
 
-export { aggregate, classifyVessel, analyzeMmsi, geoToCountry, normalizeCountryName };
+export { aggregate, classifyVessel, analyzeMmsi, geoToCountry, normalizeCountryName, TIER1_COUNTRIES, COUNTRY_BBOX };

--- a/scripts/seed-military-cii.mjs
+++ b/scripts/seed-military-cii.mjs
@@ -332,12 +332,13 @@ function getRelayHeaders() {
   return headers;
 }
 
-// Returns { candidateReports, disruptions } — empty arrays if the relay is unreachable.
+// Returns { ok, candidateReports, disruptions }. ok=false when the relay is missing or
+// unreachable (after retries) — the caller must NOT publish the empty arrays as fresh data.
 async function fetchRelaySnapshot() {
   const base = getRelayBaseUrl();
   if (!base) {
     console.warn('  WS_RELAY_URL not set — vessels + AIS disruptions skipped');
-    return { candidateReports: [], disruptions: [] };
+    return { ok: false, candidateReports: [], disruptions: [] };
   }
   try {
     const data = await withRetry(async () => {
@@ -351,10 +352,10 @@ async function fetchRelaySnapshot() {
     // Cap to bound classification work — a hostile/buggy relay must not OOM the job
     // or overrun the lock TTL. Consumers in get-risk-scores cap reads at maxLen=10000.
     const cap = (a) => (Array.isArray(a) ? a.slice(0, 20_000) : []);
-    return { candidateReports: cap(data.candidateReports), disruptions: cap(data.disruptions) };
+    return { ok: true, candidateReports: cap(data.candidateReports), disruptions: cap(data.disruptions) };
   } catch (err) {
     console.warn(`  relay /ais/snapshot failed (${err.message || err}) — vessels + AIS skipped`);
-    return { candidateReports: [], disruptions: [] };
+    return { ok: false, candidateReports: [], disruptions: [] };
   }
 }
 
@@ -432,10 +433,28 @@ async function main() {
       console.warn(`  military:flights:v1 read failed (${err.message || err}) — flights skipped`);
     }
 
-    const { candidateReports, disruptions } = await fetchRelaySnapshot();
-    console.log(`  inputs: ${flights.length} flights, ${candidateReports.length} vessel candidates, ${disruptions.length} AIS disruptions`);
+    const relay = await fetchRelaySnapshot();
+    console.log(`  inputs: ${flights.length} flights, ${relay.candidateReports.length} vessel candidates, ${relay.disruptions.length} AIS disruptions`);
 
-    const { byCountry, militaryVesselCount } = aggregate(flights, candidateReports, disruptions);
+    // Relay unavailable: do NOT overwrite last-good vessel/AIS data with zeros. Re-publish
+    // the existing key (refreshing its TTL) so the CII engine keeps the last-good military
+    // signal until the relay recovers; fall through to a flights-only publish only when
+    // there is no prior key (cold start).
+    if (!relay.ok) {
+      const existing = await redisGetJson(url, token, LIVE_KEY).catch(() => null);
+      if (existing && existing.byCountry) {
+        await withRetry(() => redisSetJson(url, token, LIVE_KEY, existing, LIVE_TTL), 2, 1000);
+        console.warn(`  relay unavailable — preserved last-good ${LIVE_KEY} (vessels/AIS not overwritten)`);
+        return;
+      }
+      console.warn(`  relay unavailable, no prior ${LIVE_KEY} — publishing flights-only`);
+    }
+
+    const { byCountry, militaryVesselCount } = aggregate(
+      flights,
+      relay.ok ? relay.candidateReports : [],
+      relay.ok ? relay.disruptions : [],
+    );
 
     const totals = Object.values(byCountry).reduce((acc, r) => {
       acc.ownFlights += r.ownFlights; acc.foreignFlights += r.foreignFlights;
@@ -447,10 +466,11 @@ async function main() {
       assessedAt: Date.now(),
       byCountry,
       stats: {
+        relayOk: relay.ok,
         flightsInput: flights.length,
-        vesselCandidatesInput: candidateReports.length,
+        vesselCandidatesInput: relay.ok ? relay.candidateReports.length : 0,
         militaryVesselsClassified: militaryVesselCount,
-        disruptionsInput: disruptions.length,
+        disruptionsInput: relay.ok ? relay.disruptions.length : 0,
         ...totals,
       },
     };

--- a/scripts/seed-military-cii.mjs
+++ b/scripts/seed-military-cii.mjs
@@ -45,6 +45,13 @@ const TIER1_COUNTRIES = {
   EG: 'Egypt', JP: 'Japan', QA: 'Qatar',
 };
 
+// Intentionally narrower than server's normalizeCountryName: this table only
+// has to resolve the operatorCountry strings emitted by seed-military-flights
+// (full country names + 'USA' / 'UK' / 'UAE'). News-title tokens like
+// 'biden' / 'trump' / 'pentagon' that normalizeCountryName carries for the
+// news-classification path don't apply here — flight operator labels are
+// constrained vocabulary. Producer-vocabulary coverage is locked down in
+// tests/seed-military-cii.test.mts ("producer operatorCountry vocabulary").
 const COUNTRY_KEYWORDS = {
   US: ['united states', 'usa', 'america', 'washington'],
   RU: ['russia', 'moscow', 'kremlin'],
@@ -118,7 +125,8 @@ const BBOX_BY_AREA = Object.entries(COUNTRY_BBOX)
   .map(([code, b]) => ({ code, ...b, area: (b.maxLat - b.minLat) * (b.maxLon - b.minLon) }))
   .sort((a, b) => a.area - b.area);
 
-function num(v) {
+// Mirrors safeNum() in server/.../get-risk-scores.ts — keep the names aligned.
+function safeNum(v) {
   const n = Number(v);
   return Number.isFinite(n) ? n : 0;
 }
@@ -277,7 +285,7 @@ function classifyVessel(candidate) {
   const name = String(candidate.name || '');
   const known = matchKnownVessel(name);
   const mmsiAnalysis = analyzeMmsi(mmsi);
-  const aisMilitary = isMilitaryShipType(num(candidate.shipType));
+  const aisMilitary = isMilitaryShipType(safeNum(candidate.shipType));
   if (!known && !mmsiAnalysis.isPotentialMilitary && !aisMilitary) return null;
   const operatorName = known?.country || mmsiAnalysis.country || null;
   return { operatorIso2: operatorName ? (COUNTRY_NAME_TO_ISO2[operatorName] || null) : null };
@@ -382,7 +390,7 @@ function aggregate(flights, candidateReports, disruptions) {
   // x2-weighted in the C3 security formula.
   for (const f of flights) {
     const op = normalizeCountryName(f.operatorCountry);
-    const loc = geoToCountry(num(f.lat), num(f.lon));
+    const loc = geoToCountry(safeNum(f.lat), safeNum(f.lon));
     if (op && byCountry[op]) byCountry[op].ownFlights++;
     if (loc && byCountry[loc]) {
       if (op && loc !== op) byCountry[loc].foreignFlights++;
@@ -397,7 +405,7 @@ function aggregate(flights, candidateReports, disruptions) {
     if (!cls) continue;
     militaryVesselCount++;
     const op = cls.operatorIso2;
-    const loc = geoToCountry(num(c.lat), num(c.lon));
+    const loc = geoToCountry(safeNum(c.lat), safeNum(c.lon));
     if (op && byCountry[op]) byCountry[op].ownVessels++;
     if (loc && byCountry[loc]) {
       if (op && loc !== op) byCountry[loc].foreignVessels++;
@@ -410,7 +418,7 @@ function aggregate(flights, candidateReports, disruptions) {
 
   // AIS disruptions — attributed by location.
   for (const d of disruptions) {
-    const code = geoToCountry(num(d.lat), num(d.lon));
+    const code = geoToCountry(safeNum(d.lat), safeNum(d.lon));
     if (!code || !byCountry[code]) continue;
     const sev = String(d.severity || '').toLowerCase();
     if (sev === 'high') byCountry[code].aisDisruptionHigh++;

--- a/server/worldmonitor/intelligence/v1/_risk-config.ts
+++ b/server/worldmonitor/intelligence/v1/_risk-config.ts
@@ -24,7 +24,7 @@
  * Formula version emitted on every CiiScore as `methodology_version`.
  * Bump on any coefficient change so API clients can detect score drift.
  */
-export const CII_FORMULA_VERSION = 'v1';
+export const CII_FORMULA_VERSION = 'v2';
 
 /**
  * Strategic-risk top-N positional decay step. Weight for position `i` (0-based)

--- a/server/worldmonitor/intelligence/v1/_risk-config.ts
+++ b/server/worldmonitor/intelligence/v1/_risk-config.ts
@@ -17,7 +17,7 @@
 //      downstream users of the proto API see why combinedScore values may
 //      shift between deploys.
 //
-// Last reviewed: 2026-05-18 (issue #3725 — methodology disclosure).
+// Last reviewed: 2026-05-23 (PR #3864 — Phase 3a CII unification, v1→v2).
 // ============================================================================
 
 /**

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -205,6 +205,14 @@ interface CountrySignals {
   sanctionsNewEntryCount: number;
   temporalAnomalyCount: number;
   temporalAnomalyCriticalCount: number;
+  // Phase 2 (CII unification) — military activity, gathered, not yet scored.
+  militaryOwnFlights: number;
+  militaryForeignFlights: number;
+  militaryOwnVessels: number;
+  militaryForeignVessels: number;
+  aisDisruptionHighCount: number;
+  aisDisruptionElevatedCount: number;
+  aisDisruptionLowCount: number;
 }
 
 function emptySignals(): CountrySignals {
@@ -225,6 +233,9 @@ function emptySignals(): CountrySignals {
     earthquakeSignificantCount: 0, earthquakeMajorCount: 0, earthquakeSevereCount: 0,
     sanctionsEntryCount: 0, sanctionsNewEntryCount: 0,
     temporalAnomalyCount: 0, temporalAnomalyCriticalCount: 0,
+    militaryOwnFlights: 0, militaryForeignFlights: 0,
+    militaryOwnVessels: 0, militaryForeignVessels: 0,
+    aisDisruptionHighCount: 0, aisDisruptionElevatedCount: 0, aisDisruptionLowCount: 0,
   };
 }
 
@@ -277,11 +288,14 @@ interface AuxiliarySources {
   earthquakes: any[];
   sanctionsCountries: any[];
   temporalAnomalies: any[];
+  // Phase 2 (CII unification) — per-country military activity from intelligence:military-cii:v1
+  // (written by scripts/seed-military-cii.mjs). Keyed by ISO2.
+  militaryCii: Record<string, any> | null;
 }
 
 async function fetchAuxiliarySources(): Promise<AuxiliarySources> {
   const currentYear = new Date().getFullYear();
-  const [ucdpRaw, outagesRaw, climateRaw, cyberRaw, firesRaw, gpsRaw, iranRaw, orefRaw, advisoriesRaw, displacementRaw, insightsRaw, threatSummaryRaw, aviationRaw, earthquakesRaw, sanctionsRaw, temporalRaw] = await Promise.all([
+  const [ucdpRaw, outagesRaw, climateRaw, cyberRaw, firesRaw, gpsRaw, iranRaw, orefRaw, advisoriesRaw, displacementRaw, insightsRaw, threatSummaryRaw, aviationRaw, earthquakesRaw, sanctionsRaw, temporalRaw, militaryCiiRaw] = await Promise.all([
     getCachedJson('conflict:ucdp-events:v1', true).catch(() => null),
     getCachedJson('infra:outages:v1', true).catch(() => null),
     getCachedJson(CLIMATE_ANOMALIES_KEY, true).catch(() => null),
@@ -301,6 +315,7 @@ async function fetchAuxiliarySources(): Promise<AuxiliarySources> {
     getCachedJson('seismology:earthquakes:v1', true).catch(() => null),
     getCachedJson('sanctions:pressure:v1', true).catch(() => null),
     getCachedJson('temporal:anomalies:v1', true).catch(() => null),
+    getCachedJson('intelligence:military-cii:v1', true).catch(() => null),
   ]);
   const arr = (v: any, field?: string, maxLen = 10000) => {
     let a: any[];
@@ -364,6 +379,9 @@ async function fetchAuxiliarySources(): Promise<AuxiliarySources> {
     earthquakes: arr(earthquakesRaw, 'earthquakes'),
     sanctionsCountries: arr(sanctionsRaw, 'countries'),
     temporalAnomalies: arr(temporalRaw, 'anomalies'),
+    militaryCii: militaryCiiRaw && typeof militaryCiiRaw === 'object' && (militaryCiiRaw as any).byCountry
+      ? (militaryCiiRaw as any).byCountry
+      : null,
   };
 }
 
@@ -510,6 +528,19 @@ export function computeCIIScores(
     if (!code || !data[code]) continue;
     data[code].temporalAnomalyCount++;
     if (String(an.severity || '').toLowerCase() === 'critical') data[code].temporalAnomalyCriticalCount++;
+  }
+
+  // --- Military activity (Phase 2) — per-country aggregate from intelligence:military-cii:v1 ---
+  for (const [code, m] of Object.entries(aux.militaryCii ?? {})) {
+    const d = data[code];
+    if (!d || !m || typeof m !== 'object') continue;
+    d.militaryOwnFlights = safeNum((m as any).ownFlights);
+    d.militaryForeignFlights = safeNum((m as any).foreignFlights);
+    d.militaryOwnVessels = safeNum((m as any).ownVessels);
+    d.militaryForeignVessels = safeNum((m as any).foreignVessels);
+    d.aisDisruptionHighCount = safeNum((m as any).aisDisruptionHigh);
+    d.aisDisruptionElevatedCount = safeNum((m as any).aisDisruptionElevated);
+    d.aisDisruptionLowCount = safeNum((m as any).aisDisruptionLow);
   }
 
   // --- Iran strikes with severity ---

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -322,7 +322,10 @@ async function fetchAuxiliarySources(): Promise<AuxiliarySources> {
       .then(d => d ?? getCachedJson(`displacement:summary:v1:${currentYear - 1}`, true).catch(() => null)),
     getCachedJson('news:insights:v1', true).catch(() => null),
     getCachedJson('news:threat:summary:v1', true).catch(() => null),
-    getCachedJson('aviation:delays:intl:v3', true).catch(() => null),
+    // Pre-merged bootstrap (seed-aviation.mjs writes it after merging FAA + intl +
+    // NOTAM-synthesized closures). Reading the intl-only key here silently dropped US
+    // FAA delays and NOTAM closures from aviationScore.
+    getCachedJson('aviation:delays-bootstrap:v2', true).catch(() => null),
     getCachedJson('seismology:earthquakes:v1', true).catch(() => null),
     getCachedJson('sanctions:pressure:v1', true).catch(() => null),
     getCachedJson('temporal:anomalies:v1', true).catch(() => null),

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -620,9 +620,22 @@ export function computeCIIScores(
       : 0;
     const conflict = Math.min(100, acledScore + fatalityScore + civilianBoost + strikeBoost + orefBoost);
 
-    // --- Security score (ported from frontend calcSecurityScore) ---
+    // --- Security score (Phase 3b / decision C3 — full 4-input calcSecurityScore) ---
+    // Was GPS-only (issue #3738). Now flights + vessels + aviation + GPS, matching the
+    // frontend. Military counts reconstruct the frontend's array length: foreign presence
+    // is weighted ×2 (the intent of ingestMilitaryForCII's synthetic-{} push), applied
+    // here in the formula instead of as a representation hack.
+    const milFlights = d.militaryOwnFlights + d.militaryForeignFlights * 2;
+    const milVessels = d.militaryOwnVessels + d.militaryForeignVessels * 2;
+    const flightScore = Math.min(50, milFlights * 3);
+    const vesselScore = Math.min(30, milVessels * 5);
+    const aviationScore = Math.min(
+      40,
+      d.aviationClosureCount * 20 + d.aviationSevereCount * 15
+        + d.aviationMajorCount * 10 + d.aviationModerateCount * 5,
+    );
     const gpsJammingScore = Math.min(35, d.gpsHighCount * 5 + d.gpsMediumCount * 2);
-    const security = Math.min(100, Math.round(gpsJammingScore));
+    const security = Math.min(100, Math.round(flightScore + vesselScore + aviationScore + gpsJammingScore));
 
     // information cap raised 20 → 100 to match unrest/conflict/security ranges.
     // Previous cap silently limited information's max contribution to 5 points

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -153,7 +153,10 @@ const BBOX_BY_AREA = Object.entries(COUNTRY_BBOX)
   .map(([code, b]) => ({ code, ...b, area: (b.maxLat - b.minLat) * (b.maxLon - b.minLon) }))
   .sort((a, b) => a.area - b.area);
 
-function geoToCountry(lat: number, lon: number): string | null {
+// Exported so scripts/seed-military-cii.mjs's re-embedded copy can be cross-checked
+// for parity in tests/seed-military-cii-table-drift.test.mts. The seed cannot import
+// from server/ under Railway nixpacks packaging.
+export function geoToCountry(lat: number, lon: number): string | null {
   if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
   for (const b of BBOX_BY_AREA) {
     if (lat >= b.minLat && lat <= b.maxLat && lon >= b.minLon && lon <= b.maxLon) return b.code;

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -874,7 +874,7 @@ export async function getRiskScores(
 
   const stale = (await getCachedJson(RISK_STALE_CACHE_KEY)) as GetRiskScoresResponse | null;
   if (stale) return stale;
-  const emptyAux: AuxiliarySources = { ucdpEvents: [], outages: [], climate: [], cyber: [], fires: [], gpsHexes: [], iranEvents: [], orefData: null, advisories: null, displacedByIso3: {}, newsTopStories: [], threatSummaryByCountry: null };
+  const emptyAux: AuxiliarySources = { ucdpEvents: [], outages: [], climate: [], cyber: [], fires: [], gpsHexes: [], iranEvents: [], orefData: null, advisories: null, displacedByIso3: {}, newsTopStories: [], threatSummaryByCountry: null, aviationAlerts: [], earthquakes: [], sanctionsCountries: [], temporalAnomalies: [], militaryCii: null };
   const ciiScores = computeCIIScores([], emptyAux);
   return { ciiScores, strategicRisks: computeStrategicRisks(ciiScores) };
 }

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -88,7 +88,9 @@ const COUNTRY_KEYWORDS: Record<string, string[]> = {
   QA: ['qatar', 'qatari', 'doha', 'al jazeera'],
 };
 
-const COUNTRY_BBOX: Record<string, { minLat: number; maxLat: number; minLon: number; maxLon: number }> = {
+// Exported so the seed-military-cii.mjs drift-guard test can assert its re-embedded copy
+// stays in sync (scripts/ cannot import from server/ at runtime, but tests can).
+export const COUNTRY_BBOX: Record<string, { minLat: number; maxLat: number; minLon: number; maxLon: number }> = {
   US: { minLat: 24.5, maxLat: 49.4, minLon: -125.0, maxLon: -66.9 },
   RU: { minLat: 41.2, maxLat: 81.9, minLon: 19.6, maxLon: 180.0 },
   CN: { minLat: 18.2, maxLat: 53.6, minLon: 73.5, maxLon: 135.1 },
@@ -516,8 +518,10 @@ export function computeCIIScores(
   for (const c of aux.sanctionsCountries ?? []) {
     const code = String(c.countryCode || '').toUpperCase();
     if (!data[code]) continue;
-    data[code].sanctionsEntryCount = safeNum(c.entryCount);
-    data[code].sanctionsNewEntryCount = safeNum(c.newEntryCount);
+    // Accumulate (not assign): the producer keys per-country rows by `code:name`, so one
+    // ISO2 can appear in multiple rows when the source spells the name differently.
+    data[code].sanctionsEntryCount += safeNum(c.entryCount);
+    data[code].sanctionsNewEntryCount += safeNum(c.newEntryCount);
   }
 
   // --- Temporal anomalies (Phase 1) — region is ISO2 or country name; skip 'global' ---

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -668,6 +668,32 @@ export function computeCIIScores(
       ? Math.min(20, Math.max(0, Math.round((Math.log10(d.totalDisplaced) - 5) * 8 + 4)))
       : 0;
 
+    // --- Phase 3b blend reconciliation (decisions D2/D4/D5/D6) ---
+    // newsUrgencyBoost (D2): pure function of the information component.
+    const newsUrgencyBoost = information >= 70 ? 5 : information >= 50 ? 3 : 0;
+    // earthquakeBoost (D5): ported verbatim from the frontend getEarthquakeBoost.
+    const earthquakeBoost = Math.min(
+      25,
+      d.earthquakeSevereCount * 10 + d.earthquakeMajorCount * 5 + d.earthquakeSignificantCount * 2,
+    );
+    // sanctionsBoost (D6): ported verbatim from the frontend getSanctionsBoost.
+    let sanctionsBoost = 0;
+    if (d.sanctionsEntryCount > 0) {
+      sanctionsBoost = d.sanctionsEntryCount >= 2000 ? 12
+        : d.sanctionsEntryCount >= 501 ? 8
+        : d.sanctionsEntryCount >= 101 ? 5 : 3;
+      if (d.sanctionsNewEntryCount > 0) sanctionsBoost += 2;
+    }
+    // supplementalSignalBoost (D4): AIS + temporal ported exactly. The frontend also
+    // folds cyber + fire into this helper with severity-weighting; the server has only
+    // total cyber/fire counts, so cyberBoost/fireBoost above stay total-based — a
+    // documented partial port (severity-split cyber/fire ingestion is a follow-up).
+    const aisBoost = Math.min(
+      10,
+      d.aisDisruptionHighCount * 2.5 + d.aisDisruptionElevatedCount * 1.5 + d.aisDisruptionLowCount * 0.5,
+    );
+    const temporalBoost = Math.min(6, d.temporalAnomalyCriticalCount * 2 + d.temporalAnomalyCount * 0.75);
+
     const blended = baseline * 0.4
       + eventScore * 0.6
       + climateBoost
@@ -675,7 +701,12 @@ export function computeCIIScores(
       + fireBoost
       + advisoryBoost
       + orefBlendBoost
-      + displacementBoost;
+      + displacementBoost
+      + newsUrgencyBoost
+      + earthquakeBoost
+      + sanctionsBoost
+      + aisBoost
+      + temporalBoost;
 
     // --- Floors ---
     const ucdpFloor = d.ucdpWar ? 70 : (d.ucdpMinor ? 50 : 0);

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -711,14 +711,16 @@ export function computeCIIScores(
       if (d.sanctionsNewEntryCount > 0) sanctionsBoost += 2;
     }
     // supplementalSignalBoost (D4): the frontend's helper sums AIS + fire + cyber +
-    // temporal. Here AIS + temporal are their own blend terms below; cyber + fire are the
-    // severity-weighted terms above. All four are now faithful ports of the frontend's
-    // sub-formulas — D4 is complete, not partial.
+    // temporal. AIS is its own blend term below; cyber + fire are the severity-weighted
+    // terms above. The temporal sub-boost is NOT wired — the temporal:anomalies:v1
+    // producer (list-temporal-anomalies.ts) emits every anomaly with region:'global', so
+    // they cannot be country-attributed. `temporalAnomaly*Count` stay gathered-not-scored
+    // (Phase 1 intent); re-wire a temporalBoost only if the producer emits country-scoped
+    // anomalies. The frontend's temporal sub-boost has the same dormancy for the same reason.
     const aisBoost = Math.min(
       10,
       d.aisDisruptionHighCount * 2.5 + d.aisDisruptionElevatedCount * 1.5 + d.aisDisruptionLowCount * 0.5,
     );
-    const temporalBoost = Math.min(6, d.temporalAnomalyCriticalCount * 2 + d.temporalAnomalyCount * 0.75);
 
     const blended = baseline * 0.4
       + eventScore * 0.6
@@ -731,8 +733,7 @@ export function computeCIIScores(
       + newsUrgencyBoost
       + earthquakeBoost
       + sanctionsBoost
-      + aisBoost
-      + temporalBoost;
+      + aisBoost;
 
     // --- Floors ---
     const ucdpFloor = d.ucdpWar ? 70 : (d.ucdpMinor ? 50 : 0);

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -183,8 +183,11 @@ interface CountrySignals {
   outageMajorCount: number;
   outagePartialCount: number;
   climateSeverity: number;
-  cyberCount: number;
+  cyberCriticalCount: number;
+  cyberHighCount: number;
+  cyberMediumCount: number;
   fireCount: number;
+  fireHighCount: number;
   gpsHighCount: number;
   gpsMediumCount: number;
   iranStrikes: number;
@@ -195,6 +198,9 @@ interface CountrySignals {
   totalDisplaced: number;
   newsScore: number;
   threatSummaryScore: number;
+  // High-severity unrest event count (Phase 3b / C1) — a "high-severity" unrest event is
+  // one that killed someone OR is a riot, matching seed-unrest-events.mjs classifySeverity.
+  highSeverityUnrest: number;
   // Phase 1 (CII unification, plans/unify-cii-single-source.md) — gathered, not yet scored.
   aviationClosureCount: number;
   aviationSevereCount: number;
@@ -223,7 +229,9 @@ function emptySignals(): CountrySignals {
     fatalities: 0, protestFatalities: 0, conflictFatalities: 0,
     ucdpWar: false, ucdpMinor: false,
     outageTotalCount: 0, outageMajorCount: 0, outagePartialCount: 0,
-    climateSeverity: 0, cyberCount: 0, fireCount: 0,
+    climateSeverity: 0,
+    cyberCriticalCount: 0, cyberHighCount: 0, cyberMediumCount: 0,
+    fireCount: 0, fireHighCount: 0,
     gpsHighCount: 0, gpsMediumCount: 0,
     iranStrikes: 0, highSeverityStrikes: 0,
     orefAlertCount: 0, orefHistoryCount24h: 0,
@@ -231,6 +239,7 @@ function emptySignals(): CountrySignals {
     totalDisplaced: 0,
     newsScore: 0,
     threatSummaryScore: 0,
+    highSeverityUnrest: 0,
     aviationClosureCount: 0, aviationSevereCount: 0, aviationMajorCount: 0, aviationModerateCount: 0,
     earthquakeSignificantCount: 0, earthquakeMajorCount: 0, earthquakeSevereCount: 0,
     sanctionsEntryCount: 0, sanctionsNewEntryCount: 0,
@@ -418,9 +427,13 @@ export function computeCIIScores(
     if (type.includes('protest')) {
       data[code].protests += weight;
       data[code].protestFatalities += fat;
+      // High-severity = the event killed someone (classifySeverity rule).
+      if (safeNum(ev.fatalities) > 0) data[code].highSeverityUnrest += weight;
     } else if (type.includes('riot')) {
       data[code].riots += weight;
       data[code].protestFatalities += fat;
+      // A riot is always high-severity (classifySeverity rule).
+      data[code].highSeverityUnrest += weight;
     } else if (type.includes('battle')) {
       data[code].battles += weight;
       data[code].conflictFatalities += fat;
@@ -466,7 +479,12 @@ export function computeCIIScores(
   // --- Cyber ---
   for (const t of aux.cyber) {
     const code = (t.country || '').toUpperCase();
-    if (data[code]) data[code].cyberCount++;
+    if (!data[code]) continue;
+    // Split by the severity the cached cyber threat already carries (Phase 3b / D7).
+    const sev = String(t.severity || '').toLowerCase();
+    if (sev === 'critical') data[code].cyberCriticalCount++;
+    else if (sev === 'high') data[code].cyberHighCount++;
+    else if (sev === 'medium') data[code].cyberMediumCount++;
   }
 
   // --- Fires ---
@@ -474,7 +492,10 @@ export function computeCIIScores(
     const lat = safeNum(f.lat || f.latitude || f.location?.latitude);
     const lon = safeNum(f.lon || f.longitude || f.location?.longitude);
     const code = geoToCountry(lat, lon);
-    if (code && data[code]) data[code].fireCount++;
+    if (!code || !data[code]) continue;
+    data[code].fireCount++;
+    // "High" fire — bright or high radiative power (Phase 3b / D8, matches the frontend).
+    if (safeNum(f.brightness) >= 360 || safeNum(f.frp) >= 50) data[code].fireHighCount++;
   }
 
   // --- GPS hex severity split ---
@@ -607,8 +628,10 @@ export function computeCIIScores(
       : unrestCount * multiplier;
     const unrestBase = Math.min(50, adjustedCount * 8);
     const unrestFatalityBoost = Math.min(30, d.protestFatalities * 5 * multiplier);
+    // severityBoost (Phase 3b / C1) — ported from the frontend calcUnrestScore.
+    const unrestSeverityBoost = Math.min(20, d.highSeverityUnrest * 10 * multiplier);
     const outageBoost = Math.min(50, d.outageTotalCount * 30 + d.outageMajorCount * 15 + d.outagePartialCount * 5);
-    const unrest = Math.min(100, Math.round(unrestBase + unrestFatalityBoost + outageBoost));
+    const unrest = Math.min(100, Math.round(unrestBase + unrestFatalityBoost + unrestSeverityBoost + outageBoost));
 
     // --- Conflict score (ported from frontend calcConflictScore) ---
     const acledScore = Math.min(50, Math.round((d.battles * 3 + d.explosions * 4 + d.civilianViolence * 5) * multiplier));
@@ -646,8 +669,11 @@ export function computeCIIScores(
     const eventScore = unrest * 0.25 + conflict * 0.30 + security * 0.20 + information * 0.25;
 
     const climateBoost = Math.min(15, d.climateSeverity * 3);
-    const cyberBoost = Math.min(10, Math.floor(d.cyberCount / 5));
-    const fireBoost = Math.min(8, Math.floor(d.fireCount / 10));
+    // cyber + fire (Phase 3b / D7, D8) — severity-weighted, ported from the frontend
+    // getSupplementalSignalBoost. Was total-count based; the cached cyber/fire feeds
+    // already carry severity / brightness, so this is a faithful port, not a partial one.
+    const cyberBoost = Math.min(12, d.cyberCriticalCount * 3 + d.cyberHighCount * 1.8 + d.cyberMediumCount * 0.9);
+    const fireBoost = Math.min(8, d.fireHighCount * 1.5 + Math.min(20, d.fireCount) * 0.25);
 
     // --- Advisory boost ---
     const advisoryBoost = d.advisoryLevel === 'do-not-travel' ? 15
@@ -684,10 +710,10 @@ export function computeCIIScores(
         : d.sanctionsEntryCount >= 101 ? 5 : 3;
       if (d.sanctionsNewEntryCount > 0) sanctionsBoost += 2;
     }
-    // supplementalSignalBoost (D4): AIS + temporal ported exactly. The frontend also
-    // folds cyber + fire into this helper with severity-weighting; the server has only
-    // total cyber/fire counts, so cyberBoost/fireBoost above stay total-based — a
-    // documented partial port (severity-split cyber/fire ingestion is a follow-up).
+    // supplementalSignalBoost (D4): the frontend's helper sums AIS + fire + cyber +
+    // temporal. Here AIS + temporal are their own blend terms below; cyber + fire are the
+    // severity-weighted terms above. All four are now faithful ports of the frontend's
+    // sub-formulas — D4 is complete, not partial.
     const aisBoost = Math.min(
       10,
       d.aisDisruptionHighCount * 2.5 + d.aisDisruptionElevatedCount * 1.5 + d.aisDisruptionLowCount * 0.5,

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -489,6 +489,12 @@ export function computeCIIScores(
     // Split by the severity the cached cyber threat already carries (Phase 3b / D7).
     // seed-cyber-threats.mjs emits the proto enum form ('CRITICALITY_LEVEL_CRITICAL' etc.)
     // — strip the prefix so bare lowercase fixtures and the production enum both bucket.
+    // NOTE: 'low' / 'info' / unknown severities are intentionally dropped. Pre-unification
+    // the server used a flat `cyberCount++` for every threat regardless of severity, but
+    // the only consumer (cyberBoost in the blend below) reads critical/high/medium with
+    // weights 3 / 1.8 / 0.9 — matching the frontend formula at
+    // src/services/country-instability.ts:609. A 'low' would have no coefficient to land
+    // on, so counting it would be a no-op anyway; the drop just makes the contract explicit.
     const sev = String(t.severity || '').toLowerCase().replace(/^criticality_level_/, '');
     if (sev === 'critical') data[code].cyberCriticalCount++;
     else if (sev === 'high') data[code].cyberHighCount++;

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -193,6 +193,18 @@ interface CountrySignals {
   totalDisplaced: number;
   newsScore: number;
   threatSummaryScore: number;
+  // Phase 1 (CII unification, plans/unify-cii-single-source.md) — gathered, not yet scored.
+  aviationClosureCount: number;
+  aviationSevereCount: number;
+  aviationMajorCount: number;
+  aviationModerateCount: number;
+  earthquakeSignificantCount: number;
+  earthquakeMajorCount: number;
+  earthquakeSevereCount: number;
+  sanctionsEntryCount: number;
+  sanctionsNewEntryCount: number;
+  temporalAnomalyCount: number;
+  temporalAnomalyCriticalCount: number;
 }
 
 function emptySignals(): CountrySignals {
@@ -209,6 +221,10 @@ function emptySignals(): CountrySignals {
     totalDisplaced: 0,
     newsScore: 0,
     threatSummaryScore: 0,
+    aviationClosureCount: 0, aviationSevereCount: 0, aviationMajorCount: 0, aviationModerateCount: 0,
+    earthquakeSignificantCount: 0, earthquakeMajorCount: 0, earthquakeSevereCount: 0,
+    sanctionsEntryCount: 0, sanctionsNewEntryCount: 0,
+    temporalAnomalyCount: 0, temporalAnomalyCriticalCount: 0,
   };
 }
 
@@ -256,11 +272,16 @@ interface AuxiliarySources {
   newsTopStories: Array<{ countryCode: string | null; threatLevel: string; primaryTitle: string }>;
   // Per-country classified headline counts from relay seedClassify() — written to news:threat:summary:v1
   threatSummaryByCountry: Record<string, { critical: number; high: number; medium: number; low: number; info: number }> | null;
+  // Phase 1 (CII unification) — additive signal sources, all backed by an existing Redis key.
+  aviationAlerts: any[];
+  earthquakes: any[];
+  sanctionsCountries: any[];
+  temporalAnomalies: any[];
 }
 
 async function fetchAuxiliarySources(): Promise<AuxiliarySources> {
   const currentYear = new Date().getFullYear();
-  const [ucdpRaw, outagesRaw, climateRaw, cyberRaw, firesRaw, gpsRaw, iranRaw, orefRaw, advisoriesRaw, displacementRaw, insightsRaw, threatSummaryRaw] = await Promise.all([
+  const [ucdpRaw, outagesRaw, climateRaw, cyberRaw, firesRaw, gpsRaw, iranRaw, orefRaw, advisoriesRaw, displacementRaw, insightsRaw, threatSummaryRaw, aviationRaw, earthquakesRaw, sanctionsRaw, temporalRaw] = await Promise.all([
     getCachedJson('conflict:ucdp-events:v1', true).catch(() => null),
     getCachedJson('infra:outages:v1', true).catch(() => null),
     getCachedJson(CLIMATE_ANOMALIES_KEY, true).catch(() => null),
@@ -276,6 +297,10 @@ async function fetchAuxiliarySources(): Promise<AuxiliarySources> {
       .then(d => d ?? getCachedJson(`displacement:summary:v1:${currentYear - 1}`, true).catch(() => null)),
     getCachedJson('news:insights:v1', true).catch(() => null),
     getCachedJson('news:threat:summary:v1', true).catch(() => null),
+    getCachedJson('aviation:delays:intl:v3', true).catch(() => null),
+    getCachedJson('seismology:earthquakes:v1', true).catch(() => null),
+    getCachedJson('sanctions:pressure:v1', true).catch(() => null),
+    getCachedJson('temporal:anomalies:v1', true).catch(() => null),
   ]);
   const arr = (v: any, field?: string, maxLen = 10000) => {
     let a: any[];
@@ -335,6 +360,10 @@ async function fetchAuxiliarySources(): Promise<AuxiliarySources> {
     displacedByIso3,
     newsTopStories,
     threatSummaryByCountry,
+    aviationAlerts: arr(aviationRaw, 'alerts'),
+    earthquakes: arr(earthquakesRaw, 'earthquakes'),
+    sanctionsCountries: arr(sanctionsRaw, 'countries'),
+    temporalAnomalies: arr(temporalRaw, 'anomalies'),
   };
 }
 
@@ -436,6 +465,51 @@ export function computeCIIScores(
     if (!code || !data[code]) continue;
     if (h.level === 'high') data[code].gpsHighCount++;
     else data[code].gpsMediumCount++;
+  }
+
+  // --- Aviation disruptions (Phase 1 — gathered, not yet scored) ---
+  // country is a name; delayType/severity may be lowercase or proto-enum form
+  // (FLIGHT_DELAY_TYPE_CLOSURE / FLIGHT_DELAY_SEVERITY_SEVERE) — substring match handles both.
+  for (const a of aux.aviationAlerts ?? []) {
+    const code = normalizeCountryName(String(a.country || ''));
+    if (!code || !data[code]) continue;
+    const dt = String(a.delayType || '').toLowerCase();
+    const sev = String(a.severity || '').toLowerCase();
+    if (dt.includes('closure')) data[code].aviationClosureCount++;
+    else if (sev.includes('severe')) data[code].aviationSevereCount++;
+    else if (sev.includes('major')) data[code].aviationMajorCount++;
+    else if (sev.includes('moderate')) data[code].aviationModerateCount++;
+  }
+
+  // --- Earthquakes (Phase 1) — magnitude >= 5.5, within 7-day lookback ---
+  const eqCutoff = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  for (const eq of aux.earthquakes ?? []) {
+    const mag = safeNum(eq.magnitude);
+    if (mag < 5.5) continue;
+    if (safeNum(eq.occurredAt) < eqCutoff) continue;
+    const code = geoToCountry(safeNum(eq.location?.latitude), safeNum(eq.location?.longitude));
+    if (!code || !data[code]) continue;
+    if (mag >= 7.5) data[code].earthquakeSevereCount++;
+    else if (mag >= 6.5) data[code].earthquakeMajorCount++;
+    else data[code].earthquakeSignificantCount++;
+  }
+
+  // --- Sanctions pressure (Phase 1) — direct ISO2 attribution ---
+  for (const c of aux.sanctionsCountries ?? []) {
+    const code = String(c.countryCode || '').toUpperCase();
+    if (!data[code]) continue;
+    data[code].sanctionsEntryCount = safeNum(c.entryCount);
+    data[code].sanctionsNewEntryCount = safeNum(c.newEntryCount);
+  }
+
+  // --- Temporal anomalies (Phase 1) — region is ISO2 or country name; skip 'global' ---
+  for (const an of aux.temporalAnomalies ?? []) {
+    const region = String(an.region || '').trim();
+    if (!region || region.toLowerCase() === 'global') continue;
+    const code = data[region.toUpperCase()] ? region.toUpperCase() : normalizeCountryName(region);
+    if (!code || !data[code]) continue;
+    data[code].temporalAnomalyCount++;
+    if (String(an.severity || '').toLowerCase() === 'critical') data[code].temporalAnomalyCriticalCount++;
   }
 
   // --- Iran strikes with severity ---

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -481,7 +481,9 @@ export function computeCIIScores(
     const code = (t.country || '').toUpperCase();
     if (!data[code]) continue;
     // Split by the severity the cached cyber threat already carries (Phase 3b / D7).
-    const sev = String(t.severity || '').toLowerCase();
+    // seed-cyber-threats.mjs emits the proto enum form ('CRITICALITY_LEVEL_CRITICAL' etc.)
+    // — strip the prefix so bare lowercase fixtures and the production enum both bucket.
+    const sev = String(t.severity || '').toLowerCase().replace(/^criticality_level_/, '');
     if (sev === 'critical') data[code].cyberCriticalCount++;
     else if (sev === 'high') data[code].cyberHighCount++;
     else if (sev === 'medium') data[code].cyberMediumCount++;

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -28,7 +28,7 @@
     "components": {
       "unrest": "اضطرابات",
       "conflict": "نزاع",
-      "security": "أمن",
+      "security": "نشاط عسكري",
       "information": "معلومات"
     },
     "signals": {
@@ -674,7 +674,7 @@
       "components": {
         "unrest": "اضطرابات",
         "conflict": "نزاع",
-        "security": "أمن",
+        "security": "نشاط عسكري",
         "information": "معلومات"
       },
       "signals": {
@@ -3096,7 +3096,7 @@
     "selectNone": "إلغاء التحديد",
     "unrest": "اضطرابات",
     "conflict": "نزاع",
-    "security": "أمن",
+    "security": "نشاط عسكري",
     "information": "معلومات",
     "shareStory": "مشاركة القصة",
     "exportImage": "تصدير صورة",

--- a/src/locales/bg.json
+++ b/src/locales/bg.json
@@ -28,7 +28,7 @@
     "components": {
       "unrest": "Неразбира",
       "conflict": "Конфликт",
-      "security": "Сигурност",
+      "security": "Военна активност",
       "information": "Информация"
     },
     "signals": {
@@ -674,7 +674,7 @@
       "components": {
         "unrest": "Неразбира",
         "conflict": "Конфликт",
-        "security": "Сигурност",
+        "security": "Военна активност",
         "information": "Информация"
       },
       "signals": {
@@ -3098,7 +3098,7 @@
     "selectNone": "Не избирайте",
     "unrest": "Неразбира",
     "conflict": "Конфликт",
-    "security": "Сигурност",
+    "security": "Военна активност",
     "information": "Информация",
     "shareStory": "Дели история",
     "exportImage": "Експортирай изображение",

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -28,7 +28,7 @@
     "components": {
       "unrest": "Nepokoje",
       "conflict": "Konflikt",
-      "security": "Bezpečnost",
+      "security": "Vojenská aktivita",
       "information": "Informace"
     },
     "signals": {
@@ -674,7 +674,7 @@
       "components": {
         "unrest": "Nepokoje",
         "conflict": "Konflikt",
-        "security": "Bezpečnost",
+        "security": "Vojenská aktivita",
         "information": "Informace"
       },
       "signals": {
@@ -3098,7 +3098,7 @@
     "selectNone": "Nevybrat nic",
     "unrest": "Nepokoje",
     "conflict": "Konflikt",
-    "security": "Bezpečnost",
+    "security": "Vojenská aktivita",
     "information": "Informace",
     "shareStory": "Sdílet příběh",
     "exportImage": "Exportovat obrázek",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -28,7 +28,7 @@
     "components": {
       "unrest": "Unruhen",
       "conflict": "Konflikt",
-      "security": "Sicherheit",
+      "security": "Militäraktivität",
       "information": "Information"
     },
     "signals": {
@@ -602,7 +602,7 @@
       "components": {
         "unrest": "Unruhe",
         "conflict": "Konflikt",
-        "security": "Sicherheit",
+        "security": "Militäraktivität",
         "information": "Information"
       },
       "signals": {
@@ -3098,7 +3098,7 @@
     "exportPdf": "PDF exportieren",
     "unrest": "Unruhen",
     "conflict": "Konflikt",
-    "security": "Sicherheit",
+    "security": "Militäraktivität",
     "information": "Information",
     "shareStory": "Geschichte teilen",
     "selectAll": "Wählen Sie „Alle“ aus",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -28,7 +28,7 @@
     "components": {
       "unrest": "Αναταραχή",
       "conflict": "Σύγκρουση",
-      "security": "Ασφάλεια",
+      "security": "Στρατιωτική δραστηριότητα",
       "information": "Πληροφορίες"
     },
     "signals": {
@@ -674,7 +674,7 @@
       "components": {
         "unrest": "Αναταραχή",
         "conflict": "Σύγκρουση",
-        "security": "Ασφάλεια",
+        "security": "Στρατιωτική δραστηριότητα",
         "information": "Πληροφορίες"
       },
       "signals": {
@@ -3098,7 +3098,7 @@
     "selectNone": "Αποεπιλογή Όλων",
     "unrest": "Αναταραχή",
     "conflict": "Σύγκρουση",
-    "security": "Ασφάλεια",
+    "security": "Στρατιωτική δραστηριότητα",
     "information": "Πληροφορίες",
     "shareStory": "Κοινοποίηση ιστορίας",
     "exportImage": "Εξαγωγή Εικόνας",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -98,7 +98,7 @@
     "components": {
       "unrest": "Unrest",
       "conflict": "Conflict",
-      "security": "Security",
+      "security": "Mil. Activity",
       "information": "Information"
     },
     "signals": {
@@ -742,7 +742,7 @@
       "components": {
         "unrest": "Unrest",
         "conflict": "Conflict",
-        "security": "Security",
+        "security": "Mil. Activity",
         "information": "Information"
       },
       "signals": {
@@ -3167,7 +3167,7 @@
     "selectNone": "Select None",
     "unrest": "Unrest",
     "conflict": "Conflict",
-    "security": "Security",
+    "security": "Mil. Activity",
     "information": "Information",
     "shareStory": "Share story",
     "exportImage": "Export Image",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -28,7 +28,7 @@
     "components": {
       "unrest": "Disturbios",
       "conflict": "Conflicto",
-      "security": "Seguridad",
+      "security": "Actividad militar",
       "information": "Información"
     },
     "signals": {
@@ -602,7 +602,7 @@
       "components": {
         "unrest": "Disturbios",
         "conflict": "Conflicto",
-        "security": "Seguridad",
+        "security": "Actividad militar",
         "information": "Información"
       },
       "signals": {
@@ -3098,7 +3098,7 @@
     "exportPdf": "Exportar PDF",
     "unrest": "Disturbios",
     "conflict": "Conflicto",
-    "security": "Seguridad",
+    "security": "Actividad militar",
     "information": "Información",
     "shareStory": "Compartir historia",
     "selectAll": "Seleccionar todo",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -28,7 +28,7 @@
     "components": {
       "unrest": "Troubles",
       "conflict": "Conflit",
-      "security": "Sécurité",
+      "security": "Activité militaire",
       "information": "Information"
     },
     "signals": {
@@ -656,7 +656,7 @@
       "components": {
         "unrest": "Troubles",
         "conflict": "Conflit",
-        "security": "Sécurité",
+        "security": "Activité militaire",
         "information": "Information"
       },
       "signals": {
@@ -3093,7 +3093,7 @@
     "exportData": "Exporter les données",
     "unrest": "Troubles",
     "conflict": "Conflit",
-    "security": "Sécurité",
+    "security": "Activité militaire",
     "information": "Information",
     "shareStory": "Partager le sujet",
     "exportImage": "Exporter l'image",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -28,7 +28,7 @@
     "components": {
       "unrest": "Disordini",
       "conflict": "Conflitto",
-      "security": "Sicurezza",
+      "security": "Attività militare",
       "information": "Informazioni"
     },
     "signals": {
@@ -602,7 +602,7 @@
       "components": {
         "unrest": "Disordini",
         "conflict": "Conflitto",
-        "security": "Sicurezza",
+        "security": "Attività militare",
         "information": "Informazioni"
       },
       "signals": {
@@ -3098,7 +3098,7 @@
     "exportPdf": "Esporta PDF",
     "unrest": "Disordini",
     "conflict": "Conflitto",
-    "security": "Sicurezza",
+    "security": "Attività militare",
     "information": "Informazione",
     "shareStory": "Condividi storia",
     "selectAll": "Seleziona tutto",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -28,7 +28,7 @@
     "components": {
       "unrest": "騒乱",
       "conflict": "紛争",
-      "security": "安全保障",
+      "security": "軍事活動",
       "information": "情報"
     },
     "signals": {
@@ -674,7 +674,7 @@
       "components": {
         "unrest": "騒乱",
         "conflict": "紛争",
-        "security": "安全保障",
+        "security": "軍事活動",
         "information": "情報"
       },
       "signals": {
@@ -3098,7 +3098,7 @@
     "selectNone": "全解除",
     "unrest": "騒乱",
     "conflict": "紛争",
-    "security": "安全保障",
+    "security": "軍事活動",
     "information": "情報",
     "shareStory": "ストーリーを共有",
     "exportImage": "画像をエクスポート",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -28,7 +28,7 @@
     "components": {
       "unrest": "소요",
       "conflict": "분쟁",
-      "security": "안보",
+      "security": "군사 활동",
       "information": "정보"
     },
     "signals": {
@@ -674,7 +674,7 @@
       "components": {
         "unrest": "소요",
         "conflict": "분쟁",
-        "security": "안보",
+        "security": "군사 활동",
         "information": "정보"
       },
       "signals": {
@@ -3098,7 +3098,7 @@
     "selectNone": "선택 해제",
     "unrest": "소요",
     "conflict": "분쟁",
-    "security": "안보",
+    "security": "군사 활동",
     "information": "정보",
     "shareStory": "기사 공유",
     "exportImage": "이미지 내보내기",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -373,7 +373,7 @@
       "components": {
         "unrest": "Onrust",
         "conflict": "Conflict",
-        "security": "Beveiliging",
+        "security": "Militaire activiteit",
         "information": "Informatie"
       },
       "signals": {
@@ -2881,7 +2881,7 @@
     "exportPdf": "PDF exporteren",
     "unrest": "Onrust",
     "conflict": "Conflict",
-    "security": "Veiligheid",
+    "security": "Militaire activiteit",
     "information": "Informatie",
     "shareStory": "Verhaal delen",
     "selectAll": "Selecteer Alles",
@@ -3010,7 +3010,7 @@
     "components": {
       "unrest": "Onrust",
       "conflict": "Conflict",
-      "security": "Beveiliging",
+      "security": "Militaire activiteit",
       "information": "Informatie"
     },
     "signals": {

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -28,7 +28,7 @@
     "components": {
       "unrest": "Niepokoje",
       "conflict": "Konflikt",
-      "security": "Bezpieczeństwo",
+      "security": "Aktywność wojskowa",
       "information": "Informacja"
     },
     "signals": {
@@ -602,7 +602,7 @@
       "components": {
         "unrest": "Niepokój",
         "conflict": "Konflikt",
-        "security": "Bezpieczeństwo",
+        "security": "Aktywność wojskowa",
         "information": "Informacja"
       },
       "signals": {
@@ -3096,7 +3096,7 @@
     "exportPdf": "Eksportuj PDF",
     "unrest": "Niepokoje",
     "conflict": "Konflikt",
-    "security": "Bezpieczeństwo",
+    "security": "Aktywność wojskowa",
     "information": "Informacja",
     "shareStory": "Udostępnij historię",
     "selectAll": "Wybierz wszystko",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -373,7 +373,7 @@
       "components": {
         "unrest": "Agitação",
         "conflict": "Conflito",
-        "security": "Segurança",
+        "security": "Atividade militar",
         "information": "Informação"
       },
       "signals": {
@@ -2881,7 +2881,7 @@
     "exportPdf": "Exportar PDF",
     "unrest": "Agitação",
     "conflict": "Conflito",
-    "security": "Segurança",
+    "security": "Atividade militar",
     "information": "Informação",
     "shareStory": "Compartilhar história",
     "selectAll": "Selecionar tudo",
@@ -3010,7 +3010,7 @@
     "components": {
       "unrest": "Agitação",
       "conflict": "Conflito",
-      "security": "Segurança",
+      "security": "Atividade militar",
       "information": "Informação"
     },
     "signals": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -28,7 +28,7 @@
     "components": {
       "unrest": "Revolte",
       "conflict": "Conflict",
-      "security": "Securitate",
+      "security": "Activitate militară",
       "information": "Informații"
     },
     "signals": {
@@ -674,7 +674,7 @@
       "components": {
         "unrest": "Neliniște",
         "conflict": "Conflict",
-        "security": "Securitate",
+        "security": "Activitate militară",
         "information": "Informații"
       },
       "signals": {
@@ -3098,7 +3098,7 @@
     "selectNone": "Selectați Niciunul",
     "unrest": "Neliniște",
     "conflict": "Conflict",
-    "security": "Securitate",
+    "security": "Activitate militară",
     "information": "Informații",
     "shareStory": "Distribuie povestea",
     "exportImage": "Exportați imaginea",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -28,7 +28,7 @@
     "components": {
       "unrest": "Беспорядки",
       "conflict": "Конфликт",
-      "security": "Безопасность",
+      "security": "Военная активность",
       "information": "Информация"
     },
     "signals": {
@@ -674,7 +674,7 @@
       "components": {
         "unrest": "Беспорядки",
         "conflict": "Конфликт",
-        "security": "Безопасность",
+        "security": "Военная активность",
         "information": "Информация"
       },
       "signals": {
@@ -3098,7 +3098,7 @@
     "selectNone": "Снять выбор",
     "unrest": "Беспорядки",
     "conflict": "Конфликт",
-    "security": "Безопасность",
+    "security": "Военная активность",
     "information": "Информация",
     "shareStory": "Поделиться сюжетом",
     "exportImage": "Экспорт изображения",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -373,7 +373,7 @@
       "components": {
         "unrest": "Oro",
         "conflict": "Konflikt",
-        "security": "Säkerhet",
+        "security": "Militär aktivitet",
         "information": "Information"
       },
       "signals": {
@@ -2881,7 +2881,7 @@
     "exportPdf": "Exportera PDF",
     "unrest": "Oroligheter",
     "conflict": "Konflikt",
-    "security": "Säkerhet",
+    "security": "Militär aktivitet",
     "information": "Information",
     "shareStory": "Dela historia",
     "selectAll": "Välj Alla",
@@ -3010,7 +3010,7 @@
     "components": {
       "unrest": "Oro",
       "conflict": "Konflikt",
-      "security": "Säkerhet",
+      "security": "Militär aktivitet",
       "information": "Information"
     },
     "signals": {

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -28,7 +28,7 @@
     "components": {
       "unrest": "ความไม่สงบ",
       "conflict": "ความขัดแย้ง",
-      "security": "ความมั่นคง",
+      "security": "กิจกรรมทางทหาร",
       "information": "ข้อมูลข่าวสาร"
     },
     "signals": {
@@ -674,7 +674,7 @@
       "components": {
         "unrest": "ความไม่สงบ",
         "conflict": "ความขัดแย้ง",
-        "security": "ความมั่นคง",
+        "security": "กิจกรรมทางทหาร",
         "information": "ข้อมูลข่าวสาร"
       },
       "signals": {
@@ -3098,7 +3098,7 @@
     "selectNone": "ไม่เลือก",
     "unrest": "ความไม่สงบ",
     "conflict": "ความขัดแย้ง",
-    "security": "ความมั่นคง",
+    "security": "กิจกรรมทางทหาร",
     "information": "ข้อมูล",
     "shareStory": "แชร์เรื่องราว",
     "exportImage": "ส่งออกรูปภาพ",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -28,7 +28,7 @@
     "components": {
       "unrest": "Huzursuzluk",
       "conflict": "Catisma",
-      "security": "Guvenlik",
+      "security": "Askeri faaliyet",
       "information": "Bilgi"
     },
     "signals": {
@@ -674,7 +674,7 @@
       "components": {
         "unrest": "Huzursuzluk",
         "conflict": "Catisma",
-        "security": "Guvenlik",
+        "security": "Askeri faaliyet",
         "information": "Bilgi"
       },
       "signals": {
@@ -3098,7 +3098,7 @@
     "selectNone": "Hicbirini Secme",
     "unrest": "Huzursuzluk",
     "conflict": "Catisma",
-    "security": "Guvenlik",
+    "security": "Askeri faaliyet",
     "information": "Bilgi",
     "shareStory": "Hikayeyi paylas",
     "exportImage": "Gorsel Disari Aktar",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -28,7 +28,7 @@
     "components": {
       "unrest": "Bất ổn",
       "conflict": "Xung đột",
-      "security": "An ninh",
+      "security": "Hoạt động quân sự",
       "information": "Thông tin"
     },
     "signals": {
@@ -674,7 +674,7 @@
       "components": {
         "unrest": "Bất ổn",
         "conflict": "Xung đột",
-        "security": "An ninh",
+        "security": "Hoạt động quân sự",
         "information": "Thông tin"
       },
       "signals": {
@@ -3098,7 +3098,7 @@
     "selectNone": "Bỏ chọn Tất cả",
     "unrest": "Bất ổn",
     "conflict": "Xung đột",
-    "security": "An ninh",
+    "security": "Hoạt động quân sự",
     "information": "Thông tin",
     "shareStory": "Chia sẻ bài viết",
     "exportImage": "Xuất Hình ảnh",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -28,7 +28,7 @@
     "components": {
       "unrest": "动荡",
       "conflict": "冲突",
-      "security": "安全",
+      "security": "军事活动",
       "information": "信息"
     },
     "signals": {
@@ -674,7 +674,7 @@
       "components": {
         "unrest": "动荡",
         "conflict": "冲突",
-        "security": "安全",
+        "security": "军事活动",
         "information": "信息"
       },
       "signals": {
@@ -3098,7 +3098,7 @@
     "selectNone": "全不选",
     "unrest": "动荡",
     "conflict": "冲突",
-    "security": "安全",
+    "security": "军事活动",
     "information": "信息",
     "shareStory": "分享报道",
     "exportImage": "导出图片",

--- a/src/services/cached-risk-scores.ts
+++ b/src/services/cached-risk-scores.ts
@@ -74,10 +74,12 @@ const SEVERITY_REVERSE: Record<string, string> = {
 };
 
 function getScoreLevel(score: number): 'low' | 'normal' | 'elevated' | 'high' | 'critical' {
-  if (score >= 70) return 'critical';
-  if (score >= 55) return 'high';
-  if (score >= 40) return 'elevated';
-  if (score >= 25) return 'normal';
+  // Phase 3b / decision L1 — reconciled to the frontend getLevel cutoffs
+  // (was 70 / 55 / 40 / 25). The frontend table is the canonical badge banding.
+  if (score >= 81) return 'critical';
+  if (score >= 66) return 'high';
+  if (score >= 51) return 'elevated';
+  if (score >= 31) return 'normal';
   return 'low';
 }
 

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -50,8 +50,7 @@ function scoreFor(scores: ReturnType<typeof computeCIIScores>, code: string) {
 }
 
 describe('CII signal wiring', () => {
-  it('earthquake / sanctions / temporal signals are still gathered without scoring (pre-Phase-3b)', () => {
-    // These three are not yet read by any formula (D4/D5/D6 land later in Phase 3b).
+  it('Phase 3b D5/D6/D4: earthquake / sanctions / temporal signals raise the score', () => {
     const acled = [acledEvent('US', 'protest', 0)];
     const base = scoreFor(computeCIIScores(acled, emptyAux()), 'US');
     const aux = emptyAux();
@@ -63,8 +62,22 @@ describe('CII signal wiring', () => {
     aux.temporalAnomalies = [{ region: 'US', severity: 'critical' }];
     const withAux = scoreFor(computeCIIScores(acled, aux), 'US');
     assert.ok(withAux, 'computeCIIScores handles the aux sources without throwing');
-    assert.equal(withAux!.combinedScore, base!.combinedScore,
-      'earthquake/sanctions/temporal are gathered but not yet scored');
+    assert.ok(withAux!.combinedScore > base!.combinedScore,
+      'earthquake / sanctions / temporal now feed earthquakeBoost / sanctionsBoost / temporalBoost');
+  });
+
+  it('Phase 3b D6: sanctions duplicate-ISO2 rows accumulate across the tier boundary', () => {
+    const aux = emptyAux();
+    aux.sanctionsCountries = [
+      { countryCode: 'US', entryCount: 60, newEntryCount: 1 },
+      { countryCode: 'US', entryCount: 60, newEntryCount: 0 },
+    ];
+    const us = scoreFor(computeCIIScores([], aux), 'US');
+    const none = scoreFor(computeCIIScores([], emptyAux()), 'US');
+    // 60+60 = 120 entries → tier ≥101 → boost 5, +2 newEntry = 7. Had the loop overwritten
+    // instead of accumulated, 60 alone → tier <101 → boost 3+2 = 5. The gap proves accumulation.
+    assert.ok(us!.combinedScore - none!.combinedScore >= 7,
+      'duplicate-ISO2 sanctions rows accumulate (120 entries crosses the ≥101 tier)');
   });
 
   it('C3: security component scores military flights/vessels/aviation, not just GPS', () => {

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -50,7 +50,9 @@ function scoreFor(scores: ReturnType<typeof computeCIIScores>, code: string) {
 }
 
 describe('CII signal wiring', () => {
-  it('Phase 3b D5/D6/D4: earthquake / sanctions / temporal signals raise the score', () => {
+  it('Phase 3b D5/D6: earthquake / sanctions signals raise the score', () => {
+    // Temporal anomalies are deliberately NOT scored — the temporal:anomalies:v1
+    // producer emits region:'global', so they cannot be country-attributed.
     const acled = [acledEvent('US', 'protest', 0)];
     const base = scoreFor(computeCIIScores(acled, emptyAux()), 'US');
     const aux = emptyAux();
@@ -59,7 +61,6 @@ describe('CII signal wiring', () => {
       { countryCode: 'US', entryCount: 10, newEntryCount: 1 },
       { countryCode: 'US', entryCount: 5, newEntryCount: 0 }, // duplicate ISO2 — must accumulate, not overwrite
     ];
-    aux.temporalAnomalies = [{ region: 'US', severity: 'critical' }];
     const withAux = scoreFor(computeCIIScores(acled, aux), 'US');
     assert.ok(withAux, 'computeCIIScores handles the aux sources without throwing');
     assert.ok(withAux!.combinedScore > base!.combinedScore,

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -77,6 +77,22 @@ describe('CII signal wiring', () => {
       'critical/high cyber feed the severity-weighted cyberBoost; a bright fire feeds fireBoost');
   });
 
+  it('Phase 3b D7: cyber severity accepts the production proto enum form (CRITICALITY_LEVEL_*)', () => {
+    // The cyber seed (seed-cyber-threats.mjs lines 52-55) emits the proto enum strings,
+    // not bare lowercase — the ingestion must bucket both. Without the prefix-strip,
+    // these would all fall through and cyberBoost would be 0 in production.
+    const baseAux = emptyAux();
+    const protoAux = emptyAux();
+    protoAux.cyber = [
+      { country: 'US', severity: 'CRITICALITY_LEVEL_CRITICAL' },
+      { country: 'US', severity: 'CRITICALITY_LEVEL_HIGH' },
+    ];
+    const protoScore = scoreFor(computeCIIScores([], protoAux), 'US');
+    const baseScore = scoreFor(computeCIIScores([], baseAux), 'US');
+    assert.ok(protoScore!.combinedScore > baseScore!.combinedScore,
+      'production CRITICALITY_LEVEL_* enums must feed cyberBoost');
+  });
+
   it('Phase 3b D6: sanctions duplicate-ISO2 rows accumulate across the tier boundary', () => {
     const aux = emptyAux();
     aux.sanctionsCountries = [

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -49,25 +49,47 @@ function scoreFor(scores: ReturnType<typeof computeCIIScores>, code: string) {
   return scores.find((s) => s.region === code);
 }
 
-describe('Phase 1/2 auxiliary signals', () => {
-  it('are gathered without changing the score (additive)', () => {
+describe('CII signal wiring', () => {
+  it('earthquake / sanctions / temporal signals are still gathered without scoring (pre-Phase-3b)', () => {
+    // These three are not yet read by any formula (D4/D5/D6 land later in Phase 3b).
     const acled = [acledEvent('US', 'protest', 0)];
     const base = scoreFor(computeCIIScores(acled, emptyAux()), 'US');
     const aux = emptyAux();
-    aux.aviationAlerts = [{ country: 'United States', delayType: 'closure', severity: 'severe' }];
     aux.earthquakes = [{ magnitude: 7.0, occurredAt: Date.now(), location: { latitude: 39, longitude: -98 } }];
     aux.sanctionsCountries = [
       { countryCode: 'US', entryCount: 10, newEntryCount: 1 },
       { countryCode: 'US', entryCount: 5, newEntryCount: 0 }, // duplicate ISO2 — must accumulate, not overwrite
     ];
     aux.temporalAnomalies = [{ region: 'US', severity: 'critical' }];
-    aux.militaryCii = {
-      US: { ownFlights: 3, foreignFlights: 1, ownVessels: 2, foreignVessels: 0, aisDisruptionHigh: 1, aisDisruptionElevated: 0, aisDisruptionLow: 0 },
-    };
     const withAux = scoreFor(computeCIIScores(acled, aux), 'US');
-    assert.ok(withAux, 'computeCIIScores handles the new Phase 1/2 aux sources without throwing');
+    assert.ok(withAux, 'computeCIIScores handles the aux sources without throwing');
     assert.equal(withAux!.combinedScore, base!.combinedScore,
-      'Phase 1/2 signals are gathered into CountrySignals but no scoring formula reads them yet');
+      'earthquake/sanctions/temporal are gathered but not yet scored');
+  });
+
+  it('C3: security component scores military flights/vessels/aviation, not just GPS', () => {
+    // No GPS hexes — pre-Phase-3b this would score security 0; the 4-input formula
+    // must now pick up military activity and aviation.
+    const aux = emptyAux();
+    aux.militaryCii = {
+      US: { ownFlights: 5, foreignFlights: 0, ownVessels: 0, foreignVessels: 0, aisDisruptionHigh: 0, aisDisruptionElevated: 0, aisDisruptionLow: 0 },
+    };
+    aux.aviationAlerts = [{ country: 'United States', delayType: 'closure' }];
+    const us = scoreFor(computeCIIScores([], aux), 'US');
+    assert.ok(us, 'US scored');
+    // flightScore = min(50, 5·3=15) = 15; aviationScore (one closure) = 20; vessels/GPS = 0
+    assert.equal(us!.components!.militaryActivity, 35,
+      'security = flightScore(15) + aviationScore(20), no GPS');
+  });
+
+  it('C3: foreign military presence is weighted x2', () => {
+    const aux = emptyAux();
+    // 0 own + 5 foreign flights → reconstructed count 0 + 5·2 = 10 → flightScore min(50, 30) = 30
+    aux.militaryCii = {
+      US: { ownFlights: 0, foreignFlights: 5, ownVessels: 0, foreignVessels: 0, aisDisruptionHigh: 0, aisDisruptionElevated: 0, aisDisruptionLow: 0 },
+    };
+    const us = scoreFor(computeCIIScores([], aux), 'US');
+    assert.equal(us!.components!.militaryActivity, 30, 'foreign flights weighted x2: 5·2·3 = 30');
   });
 });
 

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -33,6 +33,11 @@ function emptyAux() {
     displacedByIso3: {} as Record<string, number>,
     newsTopStories: [] as Array<{ countryCode: string | null; threatLevel: string; primaryTitle: string }>,
     threatSummaryByCountry: null as Record<string, { critical: number; high: number; medium: number; low: number; info: number }> | null,
+    aviationAlerts: [] as any[],
+    earthquakes: [] as any[],
+    sanctionsCountries: [] as any[],
+    temporalAnomalies: [] as any[],
+    militaryCii: null as Record<string, any> | null,
   };
 }
 
@@ -43,6 +48,28 @@ function acledEvent(country: string, type: string, fatalities = 0) {
 function scoreFor(scores: ReturnType<typeof computeCIIScores>, code: string) {
   return scores.find((s) => s.region === code);
 }
+
+describe('Phase 1/2 auxiliary signals', () => {
+  it('are gathered without changing the score (additive)', () => {
+    const acled = [acledEvent('US', 'protest', 0)];
+    const base = scoreFor(computeCIIScores(acled, emptyAux()), 'US');
+    const aux = emptyAux();
+    aux.aviationAlerts = [{ country: 'United States', delayType: 'closure', severity: 'severe' }];
+    aux.earthquakes = [{ magnitude: 7.0, occurredAt: Date.now(), location: { latitude: 39, longitude: -98 } }];
+    aux.sanctionsCountries = [
+      { countryCode: 'US', entryCount: 10, newEntryCount: 1 },
+      { countryCode: 'US', entryCount: 5, newEntryCount: 0 }, // duplicate ISO2 — must accumulate, not overwrite
+    ];
+    aux.temporalAnomalies = [{ region: 'US', severity: 'critical' }];
+    aux.militaryCii = {
+      US: { ownFlights: 3, foreignFlights: 1, ownVessels: 2, foreignVessels: 0, aisDisruptionHigh: 1, aisDisruptionElevated: 0, aisDisruptionLow: 0 },
+    };
+    const withAux = scoreFor(computeCIIScores(acled, aux), 'US');
+    assert.ok(withAux, 'computeCIIScores handles the new Phase 1/2 aux sources without throwing');
+    assert.equal(withAux!.combinedScore, base!.combinedScore,
+      'Phase 1/2 signals are gathered into CountrySignals but no scoring formula reads them yet');
+  });
+});
 
 describe('CII scoring', () => {
   it('returns scores for all 31 tier-1 countries including MX, BR, AE, LB, IQ, AF', () => {

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -66,6 +66,16 @@ describe('CII signal wiring', () => {
       'earthquake / sanctions / temporal now feed earthquakeBoost / sanctionsBoost / temporalBoost');
   });
 
+  it('Phase 3b D7/D8: cyber severity + high-brightness fires raise the score', () => {
+    const base = scoreFor(computeCIIScores([], emptyAux()), 'US');
+    const aux = emptyAux();
+    aux.cyber = [{ country: 'US', severity: 'critical' }, { country: 'US', severity: 'high' }];
+    aux.fires = [{ lat: 39, lon: -98, brightness: 400, frp: 60 }];
+    const us = scoreFor(computeCIIScores([], aux), 'US');
+    assert.ok(us!.combinedScore > base!.combinedScore,
+      'critical/high cyber feed the severity-weighted cyberBoost; a bright fire feeds fireBoost');
+  });
+
   it('Phase 3b D6: sanctions duplicate-ISO2 rows accumulate across the tier boundary', () => {
     const aux = emptyAux();
     aux.sanctionsCountries = [
@@ -93,6 +103,15 @@ describe('CII signal wiring', () => {
     // flightScore = min(50, 5·3=15) = 15; aviationScore (one closure) = 20; vessels/GPS = 0
     assert.equal(us!.components!.militaryActivity, 35,
       'security = flightScore(15) + aviationScore(20), no GPS');
+  });
+
+  it('Phase 3b C1: a riot adds severityBoost vs a plain protest', () => {
+    // Same unrest count (1 event), 0 fatalities, 0 outages in both — the only difference
+    // is the riot classifies as high-severity → severityBoost. Isolates C1.
+    const protest = scoreFor(computeCIIScores([acledEvent('Russia', 'Protests', 0)], emptyAux()), 'RU');
+    const riot = scoreFor(computeCIIScores([acledEvent('Russia', 'Riots', 0)], emptyAux()), 'RU');
+    assert.ok(riot!.components!.ciiContribution > protest!.components!.ciiContribution,
+      'a riot is high-severity unrest and adds severityBoost; a plain protest does not');
   });
 
   it('C3: foreign military presence is weighted x2', () => {

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -52,7 +52,8 @@ function scoreFor(scores: ReturnType<typeof computeCIIScores>, code: string) {
 describe('CII signal wiring', () => {
   it('Phase 3b D5/D6: earthquake / sanctions signals raise the score', () => {
     // Temporal anomalies are deliberately NOT scored — the temporal:anomalies:v1
-    // producer emits region:'global', so they cannot be country-attributed.
+    // producer emits region:'global' so they cannot be country-attributed. The
+    // score rise asserted below comes entirely from earthquakeBoost + sanctionsBoost.
     const acled = [acledEvent('US', 'protest', 0)];
     const base = scoreFor(computeCIIScores(acled, emptyAux()), 'US');
     const aux = emptyAux();
@@ -64,7 +65,7 @@ describe('CII signal wiring', () => {
     const withAux = scoreFor(computeCIIScores(acled, aux), 'US');
     assert.ok(withAux, 'computeCIIScores handles the aux sources without throwing');
     assert.ok(withAux!.combinedScore > base!.combinedScore,
-      'earthquake / sanctions / temporal now feed earthquakeBoost / sanctionsBoost / temporalBoost');
+      'earthquake + sanctions feed earthquakeBoost + sanctionsBoost in the blend');
   });
 
   it('Phase 3b D7/D8: cyber severity + high-brightness fires raise the score', () => {

--- a/tests/mcp-bootstrap-parity.test.mjs
+++ b/tests/mcp-bootstrap-parity.test.mjs
@@ -45,6 +45,8 @@ const EXCLUDED_FROM_MCP = new Map([
     'intermediate: data flows through transit-summaries:v1 (matches api/health.js:461 ON_DEMAND_KEYS rationale; explicitly NOT bundled into get_chokepoint_status to avoid duplicate exposure).'],
   ['military:forecast-inputs:stale:v1',
     'intermediate: seed-to-seed pipeline key, only populated after seed-military-flights runs (matches api/health.js:463 ON_DEMAND_KEYS rationale).'],
+  ['intelligence:military-cii:v1',
+    'intermediate: per-country military-presence aggregate (own/foreign flights+vessels, AIS disruption buckets) read by server/worldmonitor/intelligence/v1/get-risk-scores.ts to feed the CII Security component; surfaces transitively via the country-risk score returned by get_country_risk. Not a queryable MCP slice on its own.'],
 
   // ===========================================================================
   // Cascade-mirror fallbacks (live/stale/backup of a sibling already exposed)

--- a/tests/seed-military-cii-table-drift.test.mts
+++ b/tests/seed-military-cii-table-drift.test.mts
@@ -12,9 +12,16 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { TIER1_COUNTRIES as SEED_TIER1, COUNTRY_BBOX as SEED_BBOX } from '../scripts/seed-military-cii.mjs';
+import {
+  TIER1_COUNTRIES as SEED_TIER1,
+  COUNTRY_BBOX as SEED_BBOX,
+  geoToCountry as seedGeoToCountry,
+} from '../scripts/seed-military-cii.mjs';
 import { TIER1_COUNTRIES as SERVER_TIER1 } from '../server/worldmonitor/intelligence/v1/_shared.ts';
-import { COUNTRY_BBOX as SERVER_BBOX } from '../server/worldmonitor/intelligence/v1/get-risk-scores.ts';
+import {
+  COUNTRY_BBOX as SERVER_BBOX,
+  geoToCountry as serverGeoToCountry,
+} from '../server/worldmonitor/intelligence/v1/get-risk-scores.ts';
 
 test('seed TIER1_COUNTRIES matches the server source of truth exactly', () => {
   assert.deepEqual(
@@ -32,4 +39,42 @@ test('seed COUNTRY_BBOX matches the server source of truth exactly', () => {
     'scripts/seed-military-cii.mjs COUNTRY_BBOX has drifted from get-risk-scores.ts — '
       + 'the seed would attribute flights/vessels to stale country boundaries',
   );
+});
+
+test('seed geoToCountry agrees with server geoToCountry across overlap + non-overlap probes', () => {
+  // The drift tests above lock down BBOX entries by value, but the
+  // smallest-area-first sort heuristic decides who wins for points inside
+  // multiple bboxes — a future change to that heuristic on the server
+  // (e.g., centroid-distance) would silently diverge. These probes hit
+  // four real TIER1 overlap zones where the area-sort is the discriminator:
+  //   - LB inside IL bbox (LB area ~2.4 < IL area ~6.1)
+  //   - AE inside SA bbox (AE area ~14.7 < SA area ~331)
+  //   - AF inside IR bbox (AF area ~132 < IR area ~284)
+  //   - KP inside CN bbox (KP area ~41 < CN area ~2178)
+  // Plus four unambiguous interior points so a degenerate seed implementation
+  // (e.g., always returning null or always returning the first match) can't pass.
+  const PROBES: Array<[number, number, string]> = [
+    [33.2, 35.5, 'LB'],   // overlap: IL∩LB → LB smaller wins
+    [24.0, 53.0, 'AE'],   // overlap: SA∩AE → AE smaller wins
+    [33.0, 62.0, 'AF'],   // overlap: IR∩AF → AF smaller wins
+    [40.0, 126.0, 'KP'],  // overlap: CN∩KP → KP smaller wins
+    [39.0, -98.0, 'US'],  // unambiguous central US
+    [55.7, 37.6, 'RU'],   // Moscow
+    [31.5, 35.0, 'IL'],   // unambiguous interior IL (south of LB overlap zone)
+    [0.0, -150.0, null as unknown as string], // open Pacific — neither resolves
+  ];
+  for (const [lat, lon, expected] of PROBES) {
+    const seedResult = seedGeoToCountry(lat, lon);
+    const serverResult = serverGeoToCountry(lat, lon);
+    assert.equal(
+      seedResult,
+      serverResult,
+      `seed/server geoToCountry disagree at (${lat}, ${lon}): seed=${seedResult} server=${serverResult}`,
+    );
+    assert.equal(
+      seedResult,
+      expected,
+      `probe (${lat}, ${lon}) — expected ${expected}, both returned ${seedResult}`,
+    );
+  }
 });

--- a/tests/seed-military-cii-table-drift.test.mts
+++ b/tests/seed-military-cii-table-drift.test.mts
@@ -1,0 +1,35 @@
+// Drift guard for scripts/seed-military-cii.mjs.
+//
+// The seed job is self-contained by necessity — scripts/ cannot import from server/ or
+// src/ under the Railway nixpacks packaging — so it re-embeds country reference tables
+// with the server modules as the implicit source of truth. Nothing at runtime detects
+// when the two copies diverge. Tests CAN cross the boundary, so this asserts parity.
+//
+// Covers the two exact-match tables (TIER1 country set, country bounding boxes). The
+// seed's COUNTRY_KEYWORDS and MMSI MID tables are intentionally trimmed subsets and are
+// not asserted here — behavioural tests in seed-military-cii.test.mts cover those.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { TIER1_COUNTRIES as SEED_TIER1, COUNTRY_BBOX as SEED_BBOX } from '../scripts/seed-military-cii.mjs';
+import { TIER1_COUNTRIES as SERVER_TIER1 } from '../server/worldmonitor/intelligence/v1/_shared.ts';
+import { COUNTRY_BBOX as SERVER_BBOX } from '../server/worldmonitor/intelligence/v1/get-risk-scores.ts';
+
+test('seed TIER1_COUNTRIES matches the server source of truth exactly', () => {
+  assert.deepEqual(
+    SEED_TIER1,
+    SERVER_TIER1,
+    'scripts/seed-military-cii.mjs TIER1_COUNTRIES has drifted from server/.../_shared.ts — '
+      + 'the seed would score a different country set than the CII engine',
+  );
+});
+
+test('seed COUNTRY_BBOX matches the server source of truth exactly', () => {
+  assert.deepEqual(
+    SEED_BBOX,
+    SERVER_BBOX,
+    'scripts/seed-military-cii.mjs COUNTRY_BBOX has drifted from get-risk-scores.ts — '
+      + 'the seed would attribute flights/vessels to stale country boundaries',
+  );
+});

--- a/tests/seed-military-cii.test.mts
+++ b/tests/seed-military-cii.test.mts
@@ -81,6 +81,13 @@ test('aggregate: a domestic flight is own-only, never double-counted as foreign'
   assert.equal(agg.byCountry.US.foreignFlights, 0); // loc === op → the `loc !== op` guard holds
 });
 
+test('aggregate: an unknown-operator military vessel is local presence, not x2 foreign', () => {
+  // shipType 35 (military ops) but an MMSI resolving no country → classifyVessel operatorIso2 null.
+  const agg = aggregate([], [{ mmsi: '111111111', name: '', lat: 39, lon: -98, shipType: 35 }], []);
+  assert.equal(agg.byCountry.US.ownVessels, 1, 'counted once as local military presence');
+  assert.equal(agg.byCountry.US.foreignVessels, 0, 'not x2 foreign — the operator is unknown');
+});
+
 test('aggregate: AIS disruption with unknown/missing severity falls into the low bucket', () => {
   const agg = aggregate([], [], [
     { lat: 39, lon: -98, severity: 'minor' },

--- a/tests/seed-military-cii.test.mts
+++ b/tests/seed-military-cii.test.mts
@@ -35,10 +35,11 @@ test('analyzeMmsi flags military by pattern, suffix, and MID', () => {
   assert.deepEqual(analyzeMmsi('999009999'), { isPotentialMilitary: false, country: undefined });
   // plain civilian MMSI under a known MID — not flagged, but country still resolved
   assert.deepEqual(analyzeMmsi('338123456'), { isPotentialMilitary: false, country: 'USA' });
-  // non-numeric / letter-padded MMSI is rejected outright
-  assert.deepEqual(analyzeMmsi('ABC009999'), { isPotentialMilitary: false });
+  // non-numeric / letter-padded MMSI is rejected outright — shape-consistent
+  // with the other branches (always carries a `country` key, undefined here)
+  assert.deepEqual(analyzeMmsi('ABC009999'), { isPotentialMilitary: false, country: undefined });
   // too short
-  assert.deepEqual(analyzeMmsi('123'), { isPotentialMilitary: false });
+  assert.deepEqual(analyzeMmsi('123'), { isPotentialMilitary: false, country: undefined });
 });
 
 test('classifyVessel: military by pattern / known name / ship type, civilian rejected', () => {

--- a/tests/seed-military-cii.test.mts
+++ b/tests/seed-military-cii.test.mts
@@ -115,3 +115,26 @@ test('aggregate emits a record for every TIER1 country, zeroed by default', () =
       + rec.foreignVessels + rec.aisDisruptionHigh, 0);
   }
 });
+
+test('producer operatorCountry vocabulary: every TIER1-mapped string resolves to its ISO2', () => {
+  // Locks down the seed COUNTRY_KEYWORDS table against drift from the producer
+  // (scripts/seed-military-flights.mjs). If that script adds a new operatorCountry
+  // string that maps to a TIER1 country, the seed must resolve it — otherwise the
+  // flight silently buckets to "unknown operator" (local presence, not x2 foreign).
+  // Non-TIER1 operator strings (Australia/Canada/Kuwait/NATO) are intentionally not
+  // covered — they have nowhere to land in the TIER1-only score and should fall
+  // through to the unknown-operator branch.
+  const PRODUCER_TIER1_OPERATORS: Array<[string, string]> = [
+    ['USA', 'US'], ['UK', 'GB'], ['China', 'CN'], ['France', 'FR'], ['Germany', 'DE'],
+    ['Israel', 'IL'], ['Japan', 'JP'], ['Pakistan', 'PK'], ['Qatar', 'QA'],
+    ['Russia', 'RU'], ['Saudi Arabia', 'SA'], ['South Korea', 'KR'],
+    ['Turkey', 'TR'], ['UAE', 'AE'], ['Egypt', 'EG'],
+  ];
+  for (const [operatorString, expectedIso2] of PRODUCER_TIER1_OPERATORS) {
+    assert.equal(
+      normalizeCountryName(operatorString),
+      expectedIso2,
+      `producer emits operatorCountry='${operatorString}' but seed COUNTRY_KEYWORDS no longer resolves it to ${expectedIso2}`,
+    );
+  }
+});

--- a/tests/seed-military-cii.test.mts
+++ b/tests/seed-military-cii.test.mts
@@ -88,6 +88,15 @@ test('aggregate: an unknown-operator military vessel is local presence, not x2 f
   assert.equal(agg.byCountry.US.foreignVessels, 0, 'not x2 foreign — the operator is unknown');
 });
 
+test('aggregate: an unknown-operator military flight is local presence, not x2 foreign', () => {
+  // seed-military-flights emits operatorCountry: 'Unknown' for low-confidence matches
+  // (and 'NATO' / non-TIER1 names also fall through normalizeCountryName) — they must
+  // not inflate the location country's foreignFlights x2 weight.
+  const agg = aggregate([{ operatorCountry: 'Unknown', lat: 39, lon: -98 }], [], []);
+  assert.equal(agg.byCountry.US.ownFlights, 1, 'counted once as local military presence');
+  assert.equal(agg.byCountry.US.foreignFlights, 0, 'not x2 foreign — the operator is unknown');
+});
+
 test('aggregate: AIS disruption with unknown/missing severity falls into the low bucket', () => {
   const agg = aggregate([], [], [
     { lat: 39, lon: -98, severity: 'minor' },

--- a/tests/seed-military-cii.test.mts
+++ b/tests/seed-military-cii.test.mts
@@ -1,0 +1,78 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  aggregate,
+  classifyVessel,
+  analyzeMmsi,
+  geoToCountry,
+  normalizeCountryName,
+} from '../scripts/seed-military-cii.mjs';
+
+test('geoToCountry resolves points inside a TIER1 bbox', () => {
+  assert.equal(geoToCountry(39, -98), 'US');
+  assert.equal(geoToCountry(31.5, 35), 'IL');
+  assert.equal(geoToCountry(55.7, 37.6), 'RU'); // Moscow
+  assert.equal(geoToCountry(0, -150), null); // open Pacific
+  assert.equal(geoToCountry(NaN, 35), null);
+});
+
+test('normalizeCountryName maps names/abbreviations to ISO2', () => {
+  assert.equal(normalizeCountryName('USA'), 'US');
+  assert.equal(normalizeCountryName('China'), 'CN');
+  assert.equal(normalizeCountryName('UK'), 'GB');
+  assert.equal(normalizeCountryName('Russia'), 'RU');
+  assert.equal(normalizeCountryName('Narnia'), null);
+  assert.equal(normalizeCountryName(''), null);
+});
+
+test('analyzeMmsi flags military by pattern, suffix, and MID', () => {
+  // explicit US Navy MMSI prefix pattern
+  assert.deepEqual(analyzeMmsi('369970123'), { isPotentialMilitary: true, country: 'USA' });
+  // 00/99 suffix heuristic + MID country (273 = Russia)
+  assert.deepEqual(analyzeMmsi('273009999'), { isPotentialMilitary: true, country: 'Russia' });
+  // plain civilian MMSI under a known MID — not flagged, but country still resolved
+  assert.deepEqual(analyzeMmsi('338123456'), { isPotentialMilitary: false, country: 'USA' });
+  // too short
+  assert.deepEqual(analyzeMmsi('123'), { isPotentialMilitary: false });
+});
+
+test('classifyVessel: military by pattern / known name / ship type, civilian rejected', () => {
+  assert.deepEqual(classifyVessel({ mmsi: '369970123', name: '', shipType: 0 }), { operatorCountry: 'USA' });
+  assert.deepEqual(classifyVessel({ mmsi: '', name: 'USS Nimitz underway', shipType: 0 }), { operatorCountry: 'USA' });
+  // AIS ship type 35 = military ops; no MID country → operatorCountry null
+  assert.deepEqual(classifyVessel({ mmsi: '111111111', name: 'X', shipType: 35 }), { operatorCountry: null });
+  // ordinary cargo vessel — not military
+  assert.equal(classifyVessel({ mmsi: '111111111', name: 'Cargo', shipType: 70 }), null);
+});
+
+test('aggregate splits own vs foreign presence and buckets AIS disruptions', () => {
+  const agg = aggregate(
+    // a US-operated flight physically over Israel
+    [{ operatorCountry: 'USA', lat: 31.5, lon: 35 }],
+    // a US Navy vessel in US waters
+    [{ mmsi: '369970123', name: '', lat: 39, lon: -98, shipType: 0 }],
+    [
+      { lat: 31.5, lon: 35, severity: 'high' },
+      { lat: 39, lon: -98, severity: 'elevated' },
+      { lat: 39, lon: -98, severity: 'low' },
+    ],
+  );
+  assert.equal(agg.byCountry.US.ownFlights, 1);
+  assert.equal(agg.byCountry.US.foreignFlights, 0);
+  assert.equal(agg.byCountry.IL.foreignFlights, 1); // US flight counts as foreign presence in IL
+  assert.equal(agg.byCountry.US.ownVessels, 1);
+  assert.equal(agg.byCountry.IL.aisDisruptionHigh, 1);
+  assert.equal(agg.byCountry.US.aisDisruptionElevated, 1);
+  assert.equal(agg.byCountry.US.aisDisruptionLow, 1);
+  assert.equal(agg.militaryVesselCount, 1);
+});
+
+test('aggregate emits a record for every TIER1 country, zeroed by default', () => {
+  const agg = aggregate([], [], []);
+  assert.equal(Object.keys(agg.byCountry).length, 31);
+  for (const rec of Object.values(agg.byCountry) as Array<Record<string, number>>) {
+    assert.equal(rec.ownFlights + rec.foreignFlights + rec.ownVessels
+      + rec.foreignVessels + rec.aisDisruptionHigh, 0);
+  }
+});

--- a/tests/seed-military-cii.test.mts
+++ b/tests/seed-military-cii.test.mts
@@ -29,19 +29,26 @@ test('normalizeCountryName maps names/abbreviations to ISO2', () => {
 test('analyzeMmsi flags military by pattern, suffix, and MID', () => {
   // explicit US Navy MMSI prefix pattern
   assert.deepEqual(analyzeMmsi('369970123'), { isPotentialMilitary: true, country: 'USA' });
-  // 00/99 suffix heuristic + MID country (273 = Russia)
+  // 00-suffix heuristic fires only when the MID resolves to a known country (273 = Russia)
   assert.deepEqual(analyzeMmsi('273009999'), { isPotentialMilitary: true, country: 'Russia' });
+  // 00-suffix under an UNKNOWN MID is NOT trusted — civilian false-positive guard
+  assert.deepEqual(analyzeMmsi('999009999'), { isPotentialMilitary: false, country: undefined });
   // plain civilian MMSI under a known MID — not flagged, but country still resolved
   assert.deepEqual(analyzeMmsi('338123456'), { isPotentialMilitary: false, country: 'USA' });
+  // non-numeric / letter-padded MMSI is rejected outright
+  assert.deepEqual(analyzeMmsi('ABC009999'), { isPotentialMilitary: false });
   // too short
   assert.deepEqual(analyzeMmsi('123'), { isPotentialMilitary: false });
 });
 
 test('classifyVessel: military by pattern / known name / ship type, civilian rejected', () => {
-  assert.deepEqual(classifyVessel({ mmsi: '369970123', name: '', shipType: 0 }), { operatorCountry: 'USA' });
-  assert.deepEqual(classifyVessel({ mmsi: '', name: 'USS Nimitz underway', shipType: 0 }), { operatorCountry: 'USA' });
-  // AIS ship type 35 = military ops; no MID country → operatorCountry null
-  assert.deepEqual(classifyVessel({ mmsi: '111111111', name: 'X', shipType: 35 }), { operatorCountry: null });
+  // classifyVessel resolves the operator straight to ISO2
+  assert.deepEqual(classifyVessel({ mmsi: '369970123', name: '', shipType: 0 }), { operatorIso2: 'US' });
+  assert.deepEqual(classifyVessel({ mmsi: '', name: 'USS Nimitz underway', shipType: 0 }), { operatorIso2: 'US' });
+  // AIS ship type 35 = military ops; no operator known → operatorIso2 null
+  assert.deepEqual(classifyVessel({ mmsi: '111111111', name: 'X', shipType: 35 }), { operatorIso2: null });
+  // hull number '16' alone must NOT classify a civilian vessel as the carrier Liaoning
+  assert.equal(classifyVessel({ mmsi: '111111111', name: 'CONTAINER 16', shipType: 70 }), null);
   // ordinary cargo vessel — not military
   assert.equal(classifyVessel({ mmsi: '111111111', name: 'Cargo', shipType: 70 }), null);
 });
@@ -66,6 +73,22 @@ test('aggregate splits own vs foreign presence and buckets AIS disruptions', () 
   assert.equal(agg.byCountry.US.aisDisruptionElevated, 1);
   assert.equal(agg.byCountry.US.aisDisruptionLow, 1);
   assert.equal(agg.militaryVesselCount, 1);
+});
+
+test('aggregate: a domestic flight is own-only, never double-counted as foreign', () => {
+  const agg = aggregate([{ operatorCountry: 'USA', lat: 39, lon: -98 }], [], []);
+  assert.equal(agg.byCountry.US.ownFlights, 1);
+  assert.equal(agg.byCountry.US.foreignFlights, 0); // loc === op → the `loc !== op` guard holds
+});
+
+test('aggregate: AIS disruption with unknown/missing severity falls into the low bucket', () => {
+  const agg = aggregate([], [], [
+    { lat: 39, lon: -98, severity: 'minor' },
+    { lat: 39, lon: -98 },
+  ]);
+  assert.equal(agg.byCountry.US.aisDisruptionLow, 2);
+  assert.equal(agg.byCountry.US.aisDisruptionHigh, 0);
+  assert.equal(agg.byCountry.US.aisDisruptionElevated, 0);
 });
 
 test('aggregate emits a record for every TIER1 country, zeroed by default', () => {


### PR DESCRIPTION
## Summary

Origin: **issue #3738** — the CII "Security" dimension was 100% GPS jamming. Root cause: WorldMonitor ran **two divergent CII engines** (an in-browser engine and the server `get-risk-scores.ts` engine) that disagreed in formula, inputs, and output. This PR unifies them onto the server engine.

- **Phase 0** — relabel the CII `Security` component → `Mil. Activity` across all 21 locales (internal key unchanged; display string only).
- **Phase 1** — the server CII engine gathers 4 signal families it ignored: aviation disruptions, earthquakes, sanctions pressure, temporal anomalies (all from existing Redis keys).
- **Phase 2** — new self-contained seed job `scripts/seed-military-cii.mjs` aggregates military flights + vessels + AIS disruptions per country into `intelligence:military-cii:v1`; the server plumbs it.
- **Phase 3a** — full reconciliation decision table comparing the two engines line-by-line (`plans/cii-phase3a-decisions.md`), signed off.
- **Phase 3b** — server formula reconciliation: `Security` is now the **4-input formula** (flights + vessels + aviation + GPS — the substantive #3738 fix); blend boosts reconciled (newsUrgency, earthquake, sanctions, AIS, temporal, severity-weighted cyber/fire); level-badge thresholds reconciled.

Plans: `plans/unify-cii-single-source.md` (the plan), `plans/cii-phase3a-decisions.md` (decisions).

### Notable / follow-ups

- **`seed-military-cii.mjs` needs a Railway schedule** wired up — the cron config lives in the Railway dashboard, not the repo. Until then `intelligence:military-cii:v1` is absent and the server CII no-ops on military signals (guarded).
- **2 decisions deferred** (documented in the decision doc): C2 conflict fallbacks and D11 advisory source-count — each needs a new server signal; neither is a bug.
- **Phase 4 (delete the in-browser engine) is NOT in this PR** — it is gated on the N3 cold-cache decision (a product call).
- `computeCIIScores` carries a pre-existing Biome complexity warning that grew with the added formulas; refactoring into per-component helpers is a sensible follow-up.

## Test plan

- [x] `typecheck` + `typecheck:api` — pass
- [x] `test:data` — 9437/9437 pass (incl. cii-scoring 42, seed-military-cii 8, table-drift 2)
- [x] edge-functions tests — 183/183
- [x] Biome lint exit 0, `lint:md` 0 errors, `version:check` pass
- [x] CJS syntax + edge bundle checks — pass