### PR TITLE
chore(mcp): bump protocol floor to 2025-06-18 behind env-var gate

### DIFF
--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -37,27 +37,54 @@ import { hashKeySync } from '../server/_shared/usage-identity';
 
 export const config = { runtime: 'edge' };
 
-// Protocol version advertised in the `initialize` response. Bumping this is a
-// wire-visible default-behavior change, so the bumped floor ships behind an
-// env-var gate (`MCP_PROTOCOL_FLOOR_2025_06_18`) per the operational rollout
-// cadence: off default → staging `on` ≥24h → prod `on` ≥48h → follow-up
-// commit flips the default → remove the env var the version after. The
-// published server-card (public/.well-known/mcp/server-card.json) advertises
-// the bumped floor unconditionally — the card is a static capability
-// declaration; this constant is what the live initialize handler negotiates.
+// MCP protocol versions this server can speak on the initialize handshake.
+// Bumping the supported set is a wire-visible default-behavior change, so the
+// bumped floor ships behind an env-var gate (`MCP_PROTOCOL_FLOOR_2025_06_18`)
+// per the operational rollout cadence: off default → staging `on` ≥24h →
+// prod `on` ≥48h → follow-up commit flips the default → remove the env var
+// the version after. The published server-card
+// (public/.well-known/mcp/server-card.json) advertises the bumped floor
+// unconditionally — the card is a static capability declaration; the live
+// initialize handler is what actually negotiates with each client.
+//
+// Negotiation rule (per MCP lifecycle spec): if the client's requested
+// `protocolVersion` is in MCP_SUPPORTED_PROTOCOL_VERSIONS, the server MUST
+// respond with that same version; otherwise the server MUST respond with
+// another version it supports — by convention the latest. The server keeps
+// both versions in the set while the floor is being bumped so callers pinned
+// to the older version continue to work unchanged across the env-var flip.
 //
 // Version history (protocol floor — distinct from SERVER_VERSION below):
 //   - 2025-03-26 — initial floor; streamable HTTP transport.
 //   - 2025-06-18 (declared 2026-05-23, env-var gated, default off) — unlocks
-//     spec-native `outputSchema` per tool in a follow-up. Pre-floor clients
-//     negotiate down per MCP lifecycle spec (server returns the highest
-//     version it supports ≤ the client's request), so callers pinned to
-//     2025-03-26 continue to work unchanged.
+//     spec-native `outputSchema` per tool in a follow-up. When the env var
+//     is on, the server supports BOTH 2025-03-26 and 2025-06-18 so old and
+//     new clients are both served correctly during the rollout window.
 const MCP_PROTOCOL_FLOOR_2025_06_18_ENABLED =
   process.env.MCP_PROTOCOL_FLOOR_2025_06_18 === 'on';
-export const MCP_PROTOCOL_VERSION = MCP_PROTOCOL_FLOOR_2025_06_18_ENABLED
+export const MCP_SUPPORTED_PROTOCOL_VERSIONS: readonly string[] =
+  MCP_PROTOCOL_FLOOR_2025_06_18_ENABLED
+    ? ['2025-03-26', '2025-06-18']
+    : ['2025-03-26'];
+// Latest supported version — used as the fallback when the client requests
+// a version this server does not support. Always the last entry of
+// MCP_SUPPORTED_PROTOCOL_VERSIONS above (invariant asserted in tests). Kept
+// as a top-level export for downstream code that needs the canonical
+// "what would the server prefer" value.
+export const MCP_PROTOCOL_VERSION: string = MCP_PROTOCOL_FLOOR_2025_06_18_ENABLED
   ? '2025-06-18'
   : '2025-03-26';
+
+// Negotiate the protocol version returned in the initialize response.
+// Lenient on missing/non-string input (some test fixtures + older clients
+// omit the field): fall back to the server's latest supported version,
+// matching the spec's "respond with what you support" stance.
+export function negotiateProtocolVersion(requested: unknown): string {
+  return typeof requested === 'string'
+    && MCP_SUPPORTED_PROTOCOL_VERSIONS.includes(requested)
+    ? requested
+    : MCP_PROTOCOL_VERSION;
+}
 
 // Hand-curated minimum-version matrix for MCP clients validated against
 // MCP_PROTOCOL_VERSION's current floor. Comment-grade documentation; no
@@ -3511,6 +3538,8 @@ export async function mcpHandler(
   switch (method) {
     case 'initialize': {
       const sessionId = crypto.randomUUID();
+      const clientRequestedVersion = (body.params as { protocolVersion?: unknown } | null | undefined)?.protocolVersion;
+      const negotiatedVersion = negotiateProtocolVersion(clientRequestedVersion);
       // `tools_array_bytes` is the bare TOOL_LIST_RESPONSE stringify, not the
       // full JSON-RPC envelope (jsonrpc/id/protocolVersion/capabilities add
       // fixed overhead). UA is sliced to 256 chars: a pathological 32 KB
@@ -3523,7 +3552,7 @@ export async function mcpHandler(
         client_user_agent: (req.headers.get('User-Agent') ?? '').slice(0, 256),
       });
       return rpcOk(id, {
-        protocolVersion: MCP_PROTOCOL_VERSION,
+        protocolVersion: negotiatedVersion,
         capabilities: { tools: {}, logging: {} },
         serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
         instructions: SERVER_INSTRUCTIONS,

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -37,7 +37,46 @@ import { hashKeySync } from '../server/_shared/usage-identity';
 
 export const config = { runtime: 'edge' };
 
-const MCP_PROTOCOL_VERSION = '2025-03-26';
+// Protocol version advertised in the `initialize` response. Bumping this is a
+// wire-visible default-behavior change, so the bumped floor ships behind an
+// env-var gate (`MCP_PROTOCOL_FLOOR_2025_06_18`) per the operational rollout
+// cadence: off default → staging `on` ≥24h → prod `on` ≥48h → follow-up
+// commit flips the default → remove the env var the version after. The
+// published server-card (public/.well-known/mcp/server-card.json) advertises
+// the bumped floor unconditionally — the card is a static capability
+// declaration; this constant is what the live initialize handler negotiates.
+//
+// Version history (protocol floor — distinct from SERVER_VERSION below):
+//   - 2025-03-26 — initial floor; streamable HTTP transport.
+//   - 2025-06-18 (declared 2026-05-23, env-var gated, default off) — unlocks
+//     spec-native `outputSchema` per tool in a follow-up. Pre-floor clients
+//     negotiate down per MCP lifecycle spec (server returns the highest
+//     version it supports ≤ the client's request), so callers pinned to
+//     2025-03-26 continue to work unchanged.
+const MCP_PROTOCOL_FLOOR_2025_06_18_ENABLED =
+  process.env.MCP_PROTOCOL_FLOOR_2025_06_18 === 'on';
+export const MCP_PROTOCOL_VERSION = MCP_PROTOCOL_FLOOR_2025_06_18_ENABLED
+  ? '2025-06-18'
+  : '2025-03-26';
+
+// Hand-curated minimum-version matrix for MCP clients validated against
+// MCP_PROTOCOL_VERSION's current floor. Comment-grade documentation; no
+// handler reads it. Update entries (or add new clients) when bumping the
+// floor — reviewers should sanity-check that real-world clients have caught
+// up before flipping the env-var default.
+export const MCP_SUPPORTED_CLIENT_MATRIX: Record<string, string> = {
+  // source: Claude Desktop release notes — first version shipping MCP support
+  'Claude Desktop': '0.7.0',
+  // source: Claude Code CLI ships current MCP support without a pinned floor
+  'Claude Code': 'any current',
+  // source: MCP Inspector release notes
+  'MCP Inspector': '0.6.0',
+  // source: https://docs.cursor.com/ MCP integration — exact minimum not
+  // confirmed against the live docs at write time; treat as approximate and
+  // re-verify before flipping the env-var default on prod
+  'Cursor': '0.40.0',
+};
+
 const SERVER_NAME = 'worldmonitor';
 // Bumped 1.0 → 1.1.0 (2026-05-11) reflecting:
 //   - PR #3658 Tier-1+2 expansion (6 new tools added: displacement, health,

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -6,7 +6,7 @@
     "vendor": "WorldMonitor",
     "homepage": "https://www.worldmonitor.app"
   },
-  "protocolVersion": "2025-03-26",
+  "protocolVersion": "2025-06-18",
   "transport": {
     "type": "streamableHttp",
     "endpoint": "https://worldmonitor.app/mcp"

--- a/tests/mcp-protocol-version.test.mjs
+++ b/tests/mcp-protocol-version.test.mjs
@@ -1,9 +1,19 @@
-// Protocol-version-floor contract: the live initialize handler advertises
-// 2025-03-26 by default and 2025-06-18 when MCP_PROTOCOL_FLOOR_2025_06_18=on,
-// while the published server-card advertises the bumped floor unconditionally
-// (the card is a static capability declaration; the env var gates only the
-// runtime negotiation). The client-version matrix is a structural sanity
-// check so a future floor bump can't silently drop a tracked client.
+// Protocol-version-floor + negotiation contract:
+//
+//   - With MCP_PROTOCOL_FLOOR_2025_06_18 unset, the server supports only
+//     [2025-03-26] — the safe default.
+//   - With MCP_PROTOCOL_FLOOR_2025_06_18=on, the server supports both
+//     [2025-03-26, 2025-06-18] so old + new clients are both served
+//     correctly during the rollout window.
+//   - On `initialize`, the server returns the client's requested version
+//     verbatim if it is in the supported set; otherwise the server returns
+//     the latest supported version (its own preferred). This matches the
+//     MCP lifecycle spec's "respond with what you support" rule.
+//   - The published server-card advertises the bumped floor unconditionally
+//     (the card is a static capability declaration; negotiation happens at
+//     the live initialize handler).
+//   - The client-version matrix is a structural sanity check so a future
+//     floor bump can't silently drop a tracked client.
 import { describe, it, before, after } from 'node:test';
 import { strict as assert } from 'node:assert';
 import { readFileSync } from 'node:fs';
@@ -49,30 +59,77 @@ describe('api/mcp.ts — protocol-version floor', () => {
     Object.assign(process.env, originalEnv);
   });
 
-  it('with MCP_PROTOCOL_FLOOR_2025_06_18=on, initialize advertises the live MCP_PROTOCOL_VERSION constant', async () => {
+  it('env on + client requests 2025-06-18 → server returns 2025-06-18 (latest supported)', async () => {
     process.env.MCP_PROTOCOL_FLOOR_2025_06_18 = 'on';
     try {
-      const mod = await import(`../api/mcp.ts?t=${Date.now()}_on`);
+      const mod = await import(`../api/mcp.ts?t=${Date.now()}_on_new`);
       const res = await mod.default(makeInitReq('2025-06-18'));
       assert.equal(res.status, 200);
       const body = await res.json();
       // Assert against the live exported constant so this test can't drift
-      // if the bumped-floor string ever changes in a future spec revision.
+      // if the latest-supported string ever changes in a future spec revision.
       assert.equal(body.result?.protocolVersion, mod.MCP_PROTOCOL_VERSION);
     } finally {
       delete process.env.MCP_PROTOCOL_FLOOR_2025_06_18;
     }
   });
 
-  it('with MCP_PROTOCOL_FLOOR_2025_06_18 unset, initialize advertises 2025-03-26 (safe default)', async () => {
+  it('env on + client requests 2025-03-26 → server negotiates down to 2025-03-26 (the rollout-safety guarantee)', async () => {
+    process.env.MCP_PROTOCOL_FLOOR_2025_06_18 = 'on';
+    try {
+      const mod = await import(`../api/mcp.ts?t=${Date.now()}_on_down`);
+      const res = await mod.default(makeInitReq('2025-03-26'));
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      // Hardcoded: this is the load-bearing assertion for the env-var flip.
+      // If the server stops returning 2025-03-26 to clients pinned there,
+      // the rollout safety net is gone and pre-floor clients will disconnect.
+      assert.equal(body.result?.protocolVersion, '2025-03-26');
+    } finally {
+      delete process.env.MCP_PROTOCOL_FLOOR_2025_06_18;
+    }
+  });
+
+  it('env on + client requests an unsupported version → server returns the latest supported (fallback)', async () => {
+    process.env.MCP_PROTOCOL_FLOOR_2025_06_18 = 'on';
+    try {
+      const mod = await import(`../api/mcp.ts?t=${Date.now()}_on_unknown`);
+      const res = await mod.default(makeInitReq('1999-01-01'));
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.equal(body.result?.protocolVersion, mod.MCP_PROTOCOL_VERSION);
+    } finally {
+      delete process.env.MCP_PROTOCOL_FLOOR_2025_06_18;
+    }
+  });
+
+  it('env unset + client requests 2025-06-18 → server returns 2025-03-26 (safe default; unsupported request)', async () => {
     delete process.env.MCP_PROTOCOL_FLOOR_2025_06_18;
     const mod = await import(`../api/mcp.ts?t=${Date.now()}_off`);
     const res = await mod.default(makeInitReq('2025-06-18'));
     assert.equal(res.status, 200);
     const body = await res.json();
-    // Hardcoded value is deliberate: this test locks in the OFF-default
-    // contract so an accidental flip to default-on shows up here.
+    // Hardcoded: locks in the OFF-default contract — an accidental flip to
+    // default-on shows up here.
     assert.equal(body.result?.protocolVersion, '2025-03-26');
+  });
+
+  it('MCP_SUPPORTED_PROTOCOL_VERSIONS is gated by the env var', async () => {
+    process.env.MCP_PROTOCOL_FLOOR_2025_06_18 = 'on';
+    try {
+      const modOn = await import(`../api/mcp.ts?t=${Date.now()}_supported_on`);
+      assert.deepEqual([...modOn.MCP_SUPPORTED_PROTOCOL_VERSIONS], ['2025-03-26', '2025-06-18']);
+      // Latest-supported convention: MCP_PROTOCOL_VERSION is the last entry.
+      assert.equal(
+        modOn.MCP_PROTOCOL_VERSION,
+        modOn.MCP_SUPPORTED_PROTOCOL_VERSIONS[modOn.MCP_SUPPORTED_PROTOCOL_VERSIONS.length - 1],
+      );
+    } finally {
+      delete process.env.MCP_PROTOCOL_FLOOR_2025_06_18;
+    }
+    const modOff = await import(`../api/mcp.ts?t=${Date.now()}_supported_off`);
+    assert.deepEqual([...modOff.MCP_SUPPORTED_PROTOCOL_VERSIONS], ['2025-03-26']);
+    assert.equal(modOff.MCP_PROTOCOL_VERSION, '2025-03-26');
   });
 
   it('server-card.json advertises protocolVersion 2025-06-18 unconditionally', () => {

--- a/tests/mcp-protocol-version.test.mjs
+++ b/tests/mcp-protocol-version.test.mjs
@@ -1,0 +1,98 @@
+// Protocol-version-floor contract: the live initialize handler advertises
+// 2025-03-26 by default and 2025-06-18 when MCP_PROTOCOL_FLOOR_2025_06_18=on,
+// while the published server-card advertises the bumped floor unconditionally
+// (the card is a static capability declaration; the env var gates only the
+// runtime negotiation). The client-version matrix is a structural sanity
+// check so a future floor bump can't silently drop a tracked client.
+import { describe, it, before, after } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+
+const VALID_KEY = 'wm_test_key_123';
+const BASE_URL = 'https://worldmonitor.app/mcp';
+
+const originalEnv = { ...process.env };
+
+function makeInitReq(protocolVersion) {
+  return new Request(BASE_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-WorldMonitor-Key': VALID_KEY,
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion,
+        capabilities: {},
+        clientInfo: { name: 'test', version: '1.0' },
+      },
+    }),
+  });
+}
+
+describe('api/mcp.ts — protocol-version floor', () => {
+  before(() => {
+    process.env.WORLDMONITOR_VALID_KEYS = VALID_KEY;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    process.env.MCP_TELEMETRY = 'false';
+  });
+
+  after(() => {
+    delete process.env.MCP_PROTOCOL_FLOOR_2025_06_18;
+    Object.keys(process.env).forEach((k) => {
+      if (!(k in originalEnv)) delete process.env[k];
+    });
+    Object.assign(process.env, originalEnv);
+  });
+
+  it('with MCP_PROTOCOL_FLOOR_2025_06_18=on, initialize advertises the live MCP_PROTOCOL_VERSION constant', async () => {
+    process.env.MCP_PROTOCOL_FLOOR_2025_06_18 = 'on';
+    try {
+      const mod = await import(`../api/mcp.ts?t=${Date.now()}_on`);
+      const res = await mod.default(makeInitReq('2025-06-18'));
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      // Assert against the live exported constant so this test can't drift
+      // if the bumped-floor string ever changes in a future spec revision.
+      assert.equal(body.result?.protocolVersion, mod.MCP_PROTOCOL_VERSION);
+    } finally {
+      delete process.env.MCP_PROTOCOL_FLOOR_2025_06_18;
+    }
+  });
+
+  it('with MCP_PROTOCOL_FLOOR_2025_06_18 unset, initialize advertises 2025-03-26 (safe default)', async () => {
+    delete process.env.MCP_PROTOCOL_FLOOR_2025_06_18;
+    const mod = await import(`../api/mcp.ts?t=${Date.now()}_off`);
+    const res = await mod.default(makeInitReq('2025-06-18'));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    // Hardcoded value is deliberate: this test locks in the OFF-default
+    // contract so an accidental flip to default-on shows up here.
+    assert.equal(body.result?.protocolVersion, '2025-03-26');
+  });
+
+  it('server-card.json advertises protocolVersion 2025-06-18 unconditionally', () => {
+    const card = JSON.parse(
+      readFileSync(
+        new URL('../public/.well-known/mcp/server-card.json', import.meta.url),
+        'utf8',
+      ),
+    );
+    assert.equal(card.protocolVersion, '2025-06-18');
+  });
+
+  it('MCP_SUPPORTED_CLIENT_MATRIX lists each canonical client with a non-empty minimum', async () => {
+    const mod = await import(`../api/mcp.ts?t=${Date.now()}_matrix`);
+    const matrix = mod.MCP_SUPPORTED_CLIENT_MATRIX;
+    assert.ok(matrix && typeof matrix === 'object', 'MCP_SUPPORTED_CLIENT_MATRIX must be exported');
+    for (const client of ['Claude Desktop', 'Claude Code', 'MCP Inspector', 'Cursor']) {
+      const value = matrix[client];
+      assert.equal(typeof value, 'string', `matrix entry for ${client} must be a string`);
+      assert.ok(value.length > 0, `matrix entry for ${client} must be non-empty`);
+    }
+  });
+});


### PR DESCRIPTION
## What changes

- `api/mcp.ts`: introduces a `MCP_SUPPORTED_PROTOCOL_VERSIONS` set (env-gated: `['2025-03-26']` by default, `['2025-03-26', '2025-06-18']` when `MCP_PROTOCOL_FLOOR_2025_06_18=on`) and a `negotiateProtocolVersion(requested)` helper. The `initialize` handler reads `body.params.protocolVersion` and returns the client's requested version verbatim when supported, else falls back to the latest supported (`MCP_PROTOCOL_VERSION`). Adds an `MCP_SUPPORTED_CLIENT_MATRIX` constant alongside as comment-grade documentation of validated client minimums. Extends the version-history comment block with the new floor and rationale.
- `public/.well-known/mcp/server-card.json`: bumps `protocolVersion` to `2025-06-18` unconditionally. The card is a static capability declaration; the env var only gates the live initialize handler's supported set.
- `tests/mcp-protocol-version.test.mjs` (new): seven assertions — env on + client requests `2025-06-18` returns `2025-06-18`, env on + client requests `2025-03-26` returns `2025-03-26` (the rollout-safety guarantee), env on + unsupported request falls back to latest, env unset + client requests `2025-06-18` returns `2025-03-26` (locks the safe default), supported-versions set is env-gated and the latest-supported invariant holds, server-card unconditional, matrix has the four canonical clients with non-empty minimums.

## Why now

Unblocks spec-native `outputSchema` per tool in the follow-up — that field is only valid from `2025-06-18` onward.

## How negotiation works

Per the MCP lifecycle spec: if the client's requested `protocolVersion` is in the server's supported set, the server MUST respond with that same version; otherwise the server MUST respond with another version it supports — by convention the latest. With the env var on, both `2025-03-26` and `2025-06-18` are simultaneously supported, so old + new clients are both served correctly during the rollout window. With the env var off, only `2025-03-26` is supported.

| env var | client requests | server returns |
|---------|-----------------|----------------|
| off     | `2025-03-26`    | `2025-03-26`   |
| off     | `2025-06-18`    | `2025-03-26` (fallback) |
| on      | `2025-03-26`    | `2025-03-26` (down-negotiation) |
| on      | `2025-06-18`    | `2025-06-18`   |
| on      | anything else   | `2025-06-18` (fallback) |

## Supported-client matrix

| Client          | Minimum       | Source                                                            |
|-----------------|---------------|-------------------------------------------------------------------|
| Claude Desktop  | 0.7.0         | Claude Desktop release notes — first version shipping MCP support |
| Claude Code     | any current   | Claude Code CLI ships current MCP support without a pinned floor  |
| MCP Inspector   | 0.6.0         | MCP Inspector release notes                                       |
| Cursor          | 0.40.0        | https://docs.cursor.com/ — approximate; re-verify before prod flip |

## Operational rollout cadence

- Env var: `MCP_PROTOCOL_FLOOR_2025_06_18`, default **off** (supported set = `['2025-03-26']`).
- Stage 1 — staging: set env var to `on`, observe telemetry ≥24h for client-compatibility regressions.
- Stage 2 — prod: set env var to `on`, observe ≥48h.
- Stage 3 — follow-up commit: flip the in-code default to `on`, mark the env var deprecated.
- Stage 4 — the version after: remove the env var entirely.

## Test plan

- [x] `npm run typecheck:api`
- [x] `npm run test:data` (full suite 9453 pass / 0 fail; new `tests/mcp-protocol-version.test.mjs` passes 7/7 in isolation)
- [ ] Manual curl with env var ON + client `protocolVersion: '2025-06-18'` returns `protocolVersion: '2025-06-18'`
- [ ] Manual curl with env var ON + client `protocolVersion: '2025-03-26'` returns `protocolVersion: '2025-03-26'` (down-negotiation)
- [ ] Manual curl with env var unset + client `protocolVersion: '2025-06-18'` returns `protocolVersion: '2025-03-26'` (safe-default fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
