### PR TITLE
fix: Digest pipeline review actions — feed-date, CI guards, AI-queue identity

### DIFF
--- a/.github/workflows/feed-validation.yml
+++ b/.github/workflows/feed-validation.yml
@@ -36,6 +36,11 @@ permissions:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    # Cap the job: 15s per-feed timeout * ~200 feeds / 10 concurrency ≈ 5min
+    # nominal, but a hung dependency-install or network stall could otherwise
+    # occupy a runner for the default 6h timeout. 15min gives plenty of
+    # headroom while avoiding stuck-runner alerts on real outages.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/feed-validation.yml
+++ b/.github/workflows/feed-validation.yml
@@ -1,0 +1,46 @@
+name: Feed Validation
+
+# Runs npm run test:feeds:ci against the live RSS registry. NOT triggered by
+# pull_request — that would let a hostile PR rewrite src/config/feeds.ts to
+# make GitHub runners hit arbitrary URLs (SSRF surface). PR CI relies on the
+# static tests in test:data + the digest-image build smoke instead.
+#
+# Triggers:
+#   - push to main: catches drift introduced by merged registry edits
+#   - schedule (every 6h): catches third-party feed outages on a cadence
+#     operators can act on without staring at PR checks
+#   - workflow_dispatch: manual re-runs from the Actions UI
+#
+# The --ci flag enforces three guardrails inside scripts/validate-rss-feeds.mjs:
+#   1. Reject non-https URLs (no plaintext, no file://)
+#   2. Reject hosts that don't pass api/_rss-allowed-domain-match.js
+#      isAllowedDomain (same www-normalized check the Edge proxy enforces)
+#   3. Refuse cross-host redirects without per-hop allowlist re-check
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/config/feeds.ts'
+      - 'scripts/validate-rss-feeds.mjs'
+      - 'api/_rss-allowed-domain-match.js'
+      - 'api/_rss-allowed-domains.js'
+      - 'shared/rss-allowed-domains.json'
+      - '.github/workflows/feed-validation.yml'
+  schedule:
+    - cron: '0 */6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run test:feeds:ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
       pull-requests: read
     outputs:
       code: ${{ steps.diff.outputs.code }}
+      digest: ${{ steps.diff.outputs.digest }}
     steps:
       - id: diff
         env:
@@ -22,12 +23,20 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "digest=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           FILES=$(gh api "repos/${{ github.repository }}/pulls/${{ github.event.number }}/files" \
             --paginate --jq '.[].filename')
           CODE=$(echo "$FILES" | grep -vcE '\.md$|^docs/|^src-tauri/|^CHANGELOG\.md$|^LICENSE$|\.github/workflows/(build-desktop|docker-publish)\.yml$' || echo 0)
           echo "code=$( [ "$CODE" -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
+          # digest-image job: build Dockerfile.digest-notifications when a PR
+          # touches its inputs (scripts/, shared/, server/_shared/, api/, the
+          # Dockerfile itself, or the root package manifest). Catches the
+          # cross-directory-import + native-dep breakage class documented in
+          # tests/dockerfile-digest-notifications-imports.test.mjs.
+          DIGEST=$(echo "$FILES" | grep -cE '^(scripts/|shared/|server/_shared/|api/|Dockerfile\.digest-notifications|package\.json|package-lock\.json)' || echo 0)
+          echo "digest=$( [ "$DIGEST" -gt 0 ] && echo true || echo false )" >> "$GITHUB_OUTPUT"
 
   unit:
     needs: changes
@@ -62,3 +71,18 @@ jobs:
               exit 1
             }
           done
+
+  digest-image:
+    needs: changes
+    if: needs.changes.outputs.digest == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build digest-notifications image (smoke)
+        # No push, no tag publish. Catches cross-directory-import breakage
+        # before it reaches main. Pairs with the BFS import test in
+        # tests/dockerfile-digest-notifications-imports.test.mjs — that test
+        # walks the import graph statically; this job actually executes the
+        # COPY+install steps and surfaces native-dep / package-lock issues
+        # the static walk can't see.
+        run: docker build -f Dockerfile.digest-notifications -t wm-digest .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,12 @@ jobs:
     needs: changes
     if: needs.changes.outputs.digest == 'true'
     runs-on: ubuntu-latest
+    # docker build with the warm runner cache typically lands in ~90s.
+    # 20min cap catches base-image-pull stalls, npm-registry flakes, and
+    # native-dep compile failures without letting one bad PR check block
+    # the queue for an hour. The static BFS import test in test:data
+    # remains the load-bearing gate; this job is the integration smoke.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Build digest-notifications image (smoke)

--- a/api/_rss-allowed-domain-match.js
+++ b/api/_rss-allowed-domain-match.js
@@ -1,0 +1,35 @@
+// Pure host-matching predicate over the RSS proxy allowlist. Source of truth
+// for the www-normalized comparison used by:
+//   - api/rss-proxy.js (Edge SSRF guard, initial host + per-redirect re-check)
+//   - scripts/validate-rss-feeds.mjs --ci (build-time / scheduled feed validator)
+//
+// Edge constraint: api/*.js cannot import from ../shared. Helpers and data
+// mirrors must live under api/ as same-directory _*.js files. The allowlist
+// itself is mirrored at api/_rss-allowed-domains.js — this file imports that
+// mirror so the predicate has its data in scope without bouncing through the
+// edge bundler.
+//
+// Match rule (mirrors what api/rss-proxy.js shipped before this extraction):
+//   1. exact hostname match
+//   2. bare hostname (www. prefix stripped)
+//   3. www-prefixed hostname
+//
+// Any of the three is sufficient. The bare/www tolerance matters because the
+// allowlist registry mixes both forms historically (some feeds canonicalize to
+// www., others to the apex). A strict exact-match check would false-reject
+// legitimate registry hosts that differ only by the www. prefix.
+
+import RSS_ALLOWED_DOMAINS from './_rss-allowed-domains.js';
+
+export function isAllowedDomain(hostname) {
+  if (typeof hostname !== 'string' || hostname.length === 0) return false;
+  const bare = hostname.replace(/^www\./, '');
+  const withWww = hostname.startsWith('www.') ? hostname : `www.${hostname}`;
+  return (
+    RSS_ALLOWED_DOMAINS.includes(hostname) ||
+    RSS_ALLOWED_DOMAINS.includes(bare) ||
+    RSS_ALLOWED_DOMAINS.includes(withWww)
+  );
+}
+
+export default isAllowedDomain;

--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -2,7 +2,7 @@ import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { validateApiKey } from './_api-key.js';
 import { checkRateLimit } from './_rate-limit.js';
 import { getRelayBaseUrl, getRelayHeaders, fetchWithTimeout } from './_relay.js';
-import RSS_ALLOWED_DOMAINS from './_rss-allowed-domains.js';
+import { isAllowedDomain } from './_rss-allowed-domain-match.js';
 import { jsonResponse } from './_json-response.js';
 import { captureSilentError } from './_sentry-edge.js';
 
@@ -49,14 +49,9 @@ async function fetchViaRailway(feedUrl, timeoutMs) {
   }, timeoutMs);
 }
 
-// Allowed RSS feed domains — shared source of truth (shared/rss-allowed-domains.js)
-const ALLOWED_DOMAINS = RSS_ALLOWED_DOMAINS;
-
-function isAllowedDomain(hostname) {
-  const bare = hostname.replace(/^www\./, '');
-  const withWww = hostname.startsWith('www.') ? hostname : `www.${hostname}`;
-  return ALLOWED_DOMAINS.includes(hostname) || ALLOWED_DOMAINS.includes(bare) || ALLOWED_DOMAINS.includes(withWww);
-}
+// Allowlist + match predicate live in api/_rss-allowed-domain-match.js
+// (shared with scripts/validate-rss-feeds.mjs --ci so the SSRF guard runs
+// identically in the Edge handler and the build-time validator).
 
 function isGoogleNewsFeedUrl(feedUrl) {
   try {

--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -5,6 +5,14 @@
 **Current services:** 100 (at Railway limit)
 **Target services:** 65 (~35 slots freed)
 
+> **Single source of truth for Railway-deployed scripts:** `scripts/railway-services.json`.
+> When adding a new Railway service (nixpacks or Dockerfile), add an entry to the
+> registry before merging. Both `tests/scripts-railway-nixpacks-no-escape-import.test.mts`
+> and `tests/dockerfile-digest-notifications-imports.test.mjs` derive their entry
+> lists from the registry, and `tests/railway-services-registry-coverage.test.mts`
+> fails if a `Dockerfile.*` CMD or a runbook "Start command:" entry references a
+> script the registry doesn't know about.
+
 ---
 
 ## Prerequisites

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "test:data": "tsx --test tests/*.test.mjs tests/*.test.mts",
     "dryrun:resilience": "node --import tsx/esm scripts/dry-run-resilience-rebalance.mjs",
     "test:feeds": "node scripts/validate-rss-feeds.mjs",
+    "test:feeds:ci": "node scripts/validate-rss-feeds.mjs --ci",
     "test:sidecar": "node --test src-tauri/sidecar/local-api-server.test.mjs api/_cors.test.mjs api/_session.test.mjs api/_api-key.test.mjs api/wm-session.test.mjs api/youtube/embed.test.mjs api/cyber-threats.test.mjs api/usni-fleet.test.mjs scripts/ais-relay-rss.test.cjs api/loaders-xml-wms-regression.test.mjs",
     "test:e2e:visual:full": "cross-env VITE_VARIANT=full playwright test -g \"matches golden screenshots per layer and zoom\"",
     "test:e2e:visual:tech": "cross-env VITE_VARIANT=tech playwright test -g \"matches golden screenshots per layer and zoom\"",

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -1,0 +1,132 @@
+[
+  {
+    "entry": "scripts/seed-digest-notifications.mjs",
+    "deployMode": "dockerfile",
+    "dockerfile": "Dockerfile.digest-notifications",
+    "service": "digest-notifications",
+    "documentedAt": "Dockerfile.digest-notifications"
+  },
+  {
+    "entry": "scripts/ais-relay.cjs",
+    "deployMode": "dockerfile",
+    "dockerfile": "Dockerfile.relay",
+    "service": "relay",
+    "documentedAt": "Dockerfile.relay"
+  },
+  {
+    "entry": "scripts/seed-bundle-portwatch-port-activity.mjs",
+    "deployMode": "dockerfile",
+    "dockerfile": "Dockerfile.seed-bundle-portwatch-port-activity",
+    "service": "seed-bundle-portwatch-port-activity",
+    "documentedAt": "Dockerfile.seed-bundle-portwatch-port-activity"
+  },
+  {
+    "entry": "scripts/seed-bundle-resilience-validation.mjs",
+    "deployMode": "dockerfile",
+    "dockerfile": "Dockerfile.seed-bundle-resilience-validation",
+    "service": "seed-bundle-resilience-validation",
+    "documentedAt": "Dockerfile.seed-bundle-resilience-validation"
+  },
+  {
+    "entry": "scripts/seed-forecasts.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "seed-forecasts",
+    "documentedAt": "tests/scripts-railway-nixpacks-no-escape-import.test.mts (pre-registry ENTRY_POINTS)"
+  },
+  {
+    "entry": "scripts/process-simulation-tasks.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "process-simulation-tasks",
+    "documentedAt": "tests/scripts-railway-nixpacks-no-escape-import.test.mts (pre-registry ENTRY_POINTS)"
+  },
+  {
+    "entry": "scripts/process-deep-forecast-tasks.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "process-deep-forecast-tasks",
+    "documentedAt": "tests/scripts-railway-nixpacks-no-escape-import.test.mts (pre-registry ENTRY_POINTS)"
+  },
+  {
+    "entry": "scripts/seed-insights.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "seed-insights",
+    "documentedAt": "tests/scripts-railway-nixpacks-no-escape-import.test.mts (added PR #3836)"
+  },
+  {
+    "entry": "scripts/seed-bundle-ecb-eu.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "seed-bundle-ecb-eu",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#seed-bundle-ecb-eu"
+  },
+  {
+    "entry": "scripts/seed-bundle-portwatch.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "seed-bundle-portwatch",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#seed-bundle-portwatch"
+  },
+  {
+    "entry": "scripts/seed-bundle-static-ref.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "seed-bundle-static-ref",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#seed-bundle-static-ref"
+  },
+  {
+    "entry": "scripts/seed-bundle-resilience.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "seed-bundle-resilience",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#seed-bundle-resilience"
+  },
+  {
+    "entry": "scripts/seed-bundle-derived-signals.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "seed-bundle-derived-signals",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#seed-bundle-derived-signals"
+  },
+  {
+    "entry": "scripts/seed-bundle-climate.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "seed-bundle-climate",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#seed-bundle-climate"
+  },
+  {
+    "entry": "scripts/seed-bundle-energy-sources.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "seed-bundle-energy-sources",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#seed-bundle-energy-sources"
+  },
+  {
+    "entry": "scripts/seed-bundle-macro.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "seed-bundle-macro",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#seed-bundle-macro"
+  },
+  {
+    "entry": "scripts/seed-bundle-health.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "seed-bundle-health",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#seed-bundle-health"
+  },
+  {
+    "entry": "scripts/seed-bundle-market-backup.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "seed-bundle-market-backup",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#seed-bundle-market-backup"
+  },
+  {
+    "entry": "scripts/seed-bundle-relay-backup.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "seed-bundle-relay-backup",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#seed-bundle-relay-backup"
+  },
+  {
+    "entry": "scripts/scenario-worker.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "scenario-worker",
+    "documentedAt": "scripts/scenario-worker.mjs (header docblock declares rootDirectory: scripts)"
+  },
+  {
+    "entry": "scripts/seed-bundle-regional.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "seed-bundle-regional",
+    "documentedAt": "scripts/seed-bundle-regional.mjs (header docblock declares rootDirectory: scripts)"
+  }
+]

--- a/scripts/validate-rss-feeds.mjs
+++ b/scripts/validate-rss-feeds.mjs
@@ -107,34 +107,48 @@ function assertCiAllowed(rawUrl) {
 }
 
 async function fetchFeed(url) {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
-  try {
-    if (CI_MODE) {
-      // Manual per-hop redirect handling: every hop must satisfy the same
-      // https + allowlist gates. Mirrors api/rss-proxy.js redirect re-check.
-      let currentUrl = assertCiAllowed(url).href;
-      const MAX_HOPS = 3;
-      for (let hop = 0; hop <= MAX_HOPS; hop++) {
-        const resp = await fetch(currentUrl, {
+  if (CI_MODE) {
+    // Manual per-hop redirect handling: every hop must satisfy the same
+    // https + allowlist gates. Mirrors api/rss-proxy.js redirect re-check.
+    // Per-hop timer (NOT a shared budget across hops) — each hop gets the
+    // full FETCH_TIMEOUT so "Timeout (15s)" in the report means a real
+    // 15s on a single network call, not 17s+ aggregated across a chain.
+    let currentUrl = assertCiAllowed(url).href;
+    const MAX_HOPS = 3;
+    for (let hop = 0; hop < MAX_HOPS; hop++) {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
+      let resp;
+      try {
+        resp = await fetch(currentUrl, {
           signal: controller.signal,
           headers: { 'User-Agent': CHROME_UA, 'Accept': 'application/rss+xml, application/xml, text/xml, */*' },
           redirect: 'manual',
         });
-        if (resp.status >= 300 && resp.status < 400) {
-          if (hop === MAX_HOPS) throw new Error('Too many redirects');
-          const loc = resp.headers.get('location');
-          if (!loc) throw new Error(`HTTP ${resp.status} without Location header`);
-          const nextUrl = new URL(loc, currentUrl);
-          assertCiAllowed(nextUrl.href);
-          currentUrl = nextUrl.href;
-          continue;
-        }
-        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-        return await resp.text();
+      } finally {
+        clearTimeout(timer);
       }
-      throw new Error('Redirect loop');
+      if (resp.status >= 300 && resp.status < 400) {
+        const loc = resp.headers.get('location');
+        if (!loc) throw new Error(`HTTP ${resp.status} without Location header`);
+        const nextUrl = new URL(loc, currentUrl);
+        assertCiAllowed(nextUrl.href);
+        currentUrl = nextUrl.href;
+        continue;
+      }
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      // Body stream still under the per-hop timer is the right shape, but
+      // text() can complete after clearTimeout — the controller is no
+      // longer wired to abort it. That's intentional: timing the response-
+      // body read separately is out of scope for an SSRF-guarded validator;
+      // the headers handshake is what we wanted bounded per hop.
+      return await resp.text();
     }
+    throw new Error('Too many redirects');
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
+  try {
     const resp = await fetch(url, {
       signal: controller.signal,
       headers: { 'User-Agent': CHROME_UA, 'Accept': 'application/rss+xml, application/xml, text/xml, */*' },

--- a/scripts/validate-rss-feeds.mjs
+++ b/scripts/validate-rss-feeds.mjs
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { XMLParser } from 'fast-xml-parser';
+import { isAllowedDomain } from '../api/_rss-allowed-domain-match.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FEEDS_PATH = join(__dirname, '..', 'src', 'config', 'feeds.ts');
@@ -12,6 +13,17 @@ const CHROME_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 
 const FETCH_TIMEOUT = 15_000;
 const CONCURRENCY = 10;
 const STALE_DAYS = 30;
+
+// --ci flag hardens the validator for trusted-context CI runs (push-to-main
+// + schedule workflow). NOT enabled in PR CI — PR CI never runs this script
+// because PR contributors can rewrite feeds.ts to make GitHub runners hit
+// arbitrary URLs (SSRF surface). In CI mode:
+//   1. Reject non-https schemes (no plaintext, no file:// etc.)
+//   2. Reject hosts that don't pass api/_rss-allowed-domain-match.js
+//      isAllowedDomain (same www-normalized check the Edge proxy enforces)
+//   3. Refuse to follow cross-host redirects (manual redirect handling per
+//      hop with allowlist re-check)
+const CI_MODE = process.argv.includes('--ci');
 
 function extractFeeds() {
   const src = readFileSync(FEEDS_PATH, 'utf8');
@@ -78,10 +90,51 @@ function extractFeeds() {
   return feeds;
 }
 
+function assertCiAllowed(rawUrl) {
+  let parsed;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error('Invalid URL');
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`Non-https scheme rejected in --ci mode: ${parsed.protocol}`);
+  }
+  if (!isAllowedDomain(parsed.hostname)) {
+    throw new Error(`Host not in allowlist (--ci): ${parsed.hostname}`);
+  }
+  return parsed;
+}
+
 async function fetchFeed(url) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT);
   try {
+    if (CI_MODE) {
+      // Manual per-hop redirect handling: every hop must satisfy the same
+      // https + allowlist gates. Mirrors api/rss-proxy.js redirect re-check.
+      let currentUrl = assertCiAllowed(url).href;
+      const MAX_HOPS = 3;
+      for (let hop = 0; hop <= MAX_HOPS; hop++) {
+        const resp = await fetch(currentUrl, {
+          signal: controller.signal,
+          headers: { 'User-Agent': CHROME_UA, 'Accept': 'application/rss+xml, application/xml, text/xml, */*' },
+          redirect: 'manual',
+        });
+        if (resp.status >= 300 && resp.status < 400) {
+          if (hop === MAX_HOPS) throw new Error('Too many redirects');
+          const loc = resp.headers.get('location');
+          if (!loc) throw new Error(`HTTP ${resp.status} without Location header`);
+          const nextUrl = new URL(loc, currentUrl);
+          assertCiAllowed(nextUrl.href);
+          currentUrl = nextUrl.href;
+          continue;
+        }
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        return await resp.text();
+      }
+      throw new Error('Redirect loop');
+    }
     const resp = await fetch(url, {
       signal: controller.signal,
       headers: { 'User-Agent': CHROME_UA, 'Accept': 'application/rss+xml, application/xml, text/xml, */*' },
@@ -183,7 +236,8 @@ function pad(str, len) {
 
 async function main() {
   const feeds = extractFeeds();
-  console.log(`Validating ${feeds.length} RSS feeds (${CONCURRENCY} concurrent, ${FETCH_TIMEOUT / 1000}s timeout)...\n`);
+  const mode = CI_MODE ? 'CI (https-only + allowlist + per-hop redirect re-check)' : 'standard';
+  console.log(`Validating ${feeds.length} RSS feeds [${mode}] (${CONCURRENCY} concurrent, ${FETCH_TIMEOUT / 1000}s timeout)...\n`);
 
   const results = await runBatch(feeds, validateFeed, CONCURRENCY);
 

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -11,6 +11,7 @@ import type {
 } from '@/components/CountryBriefPanel';
 import { CountryDeepDivePanel } from '@/components/CountryDeepDivePanel';
 import { reverseGeocode } from '@/utils/reverse-geocode';
+import { effectivePubDateMs } from '@/services/feed-date';
 import {
   getCountryAtCoordinates,
   getCountryCentroid,
@@ -294,7 +295,7 @@ export class CountryIntelManager implements AppModule {
     }).sort((a, b) => {
       const severityDelta = this.newsSeverityRank(b) - this.newsSeverityRank(a);
       if (severityDelta !== 0) return severityDelta;
-      return new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime();
+      return effectivePubDateMs(b) - effectivePubDateMs(a);
     });
     this.ctx.countryBriefPage.updateNews(filteredNews.slice(0, 10));
 

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -103,6 +103,7 @@ import {
   type StockAnalysisHistory,
 } from '@/services/stock-analysis-history';
 import { checkBatchForBreakingAlerts, dispatchOrefBreakingAlert } from '@/services/breaking-news-alerts';
+import { effectivePubDateMs } from '@/services/feed-date';
 import { mlWorker } from '@/services/ml-worker';
 import { clusterNewsHybrid } from '@/services/clustering';
 import { ingestProtests, ingestFlights, ingestVessels, ingestEarthquakes, detectGeoConvergence, geoConvergenceToSignal } from '@/services/geo-convergence';
@@ -408,7 +409,7 @@ export class DataLoaderManager implements AppModule {
   private getStaleNewsItems(category: string): NewsItem[] {
     const staleItems = this.ctx.newsByCategory[category];
     if (!Array.isArray(staleItems) || staleItems.length === 0) return [];
-    return [...staleItems].sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());
+    return [...staleItems].sort((a, b) => effectivePubDateMs(b) - effectivePubDateMs(a));
   }
 
   private selectLimitedFeeds<T>(feeds: T[], maxFeeds: number): T[] {
@@ -856,7 +857,11 @@ export class DataLoaderManager implements AppModule {
     if (range === 'all') return items;
     const cutoff = Date.now() - this.getTimeRangeWindowMs(range);
     return items.filter((item) => {
-      const ts = item.pubDate instanceof Date ? item.pubDate.getTime() : new Date(item.pubDate).getTime();
+      // effectivePubDateMs returns 0 for pubDateMissing items, which fails the
+      // `ts >= cutoff` test for any positive-window range — synthesized-stamp
+      // items don't claim freshness here. Defensive Number.isFinite kept for
+      // exotic shapes (cached serialized form, etc.).
+      const ts = effectivePubDateMs(item);
       return Number.isFinite(ts) ? ts >= cutoff : true;
     });
   }
@@ -3212,10 +3217,10 @@ export class DataLoaderManager implements AppModule {
       );
       this.callPanel('spotlight', 'setHeroStory',
         items.filter(item => item.happyCategory === 'humanity-kindness')
-          .sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime())[0]
+          .sort((a, b) => effectivePubDateMs(b) - effectivePubDateMs(a))[0]
       );
       this.callPanel('digest', 'setStories',
-        [...items].sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime()).slice(0, 5)
+        [...items].sort((a, b) => effectivePubDateMs(b) - effectivePubDateMs(a)).slice(0, 5)
       );
       this.callPanel('positive-feed', 'renderPositiveNews', items);
     } catch (err) {
@@ -3249,7 +3254,7 @@ export class DataLoaderManager implements AppModule {
 
     if (supplementary.length > 0) {
       const merged = [...curated, ...supplementary];
-      merged.sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());
+      merged.sort((a, b) => effectivePubDateMs(b) - effectivePubDateMs(a));
       this.callPanel('positive-feed', 'renderPositiveNews', merged);
     }
 
@@ -3261,11 +3266,11 @@ export class DataLoaderManager implements AppModule {
 
     const heroItem = this.ctx.happyAllItems
       .filter(item => item.happyCategory === 'humanity-kindness')
-      .sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime())[0];
+      .sort((a, b) => effectivePubDateMs(b) - effectivePubDateMs(a))[0];
     this.callPanel('spotlight', 'setHeroStory', heroItem);
 
     const digestItems = [...this.ctx.happyAllItems]
-      .sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime())
+      .sort((a, b) => effectivePubDateMs(b) - effectivePubDateMs(a))
       .slice(0, 5);
     this.callPanel('digest', 'setStories', digestItems);
 

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -857,12 +857,16 @@ export class DataLoaderManager implements AppModule {
     if (range === 'all') return items;
     const cutoff = Date.now() - this.getTimeRangeWindowMs(range);
     return items.filter((item) => {
-      // effectivePubDateMs returns 0 for pubDateMissing items, which fails the
-      // `ts >= cutoff` test for any positive-window range — synthesized-stamp
-      // items don't claim freshness here. Defensive Number.isFinite kept for
-      // exotic shapes (cached serialized form, etc.).
-      const ts = effectivePubDateMs(item);
-      return Number.isFinite(ts) ? ts >= cutoff : true;
+      // effectivePubDateMs returns 0 for items that cannot claim a real
+      // freshness rank: pubDateMissing items (the U3 contract) AND items
+      // whose pubDate is NaN/Infinity/Invalid Date (the helper's value-
+      // sanitization branch). All such items are EXCLUDED from positive-
+      // window ranges. Previous behavior wrapped raw pubDate.getTime() in
+      // Number.isFinite() and fell through to `true` on non-finite — that
+      // included corrupt-stamp items in time-range views, arguably a bug.
+      // The current shape treats untrustworthy timestamps uniformly: they
+      // never claim freshness and never appear in a "last 24h" view.
+      return effectivePubDateMs(item) >= cutoff;
     });
   }
 
@@ -3197,7 +3201,14 @@ export class DataLoaderManager implements AppModule {
     }
   }
 
-  private static readonly HAPPY_ITEMS_CACHE_KEY = 'happy-all-items';
+  // Bumped to v2 alongside src/services/rss.ts CACHE_PREFIX (`feed:` →
+  // `feed:v2:`). Pre-v2 entries here serialize NewsItem WITHOUT the new
+  // `pubDateMissing` flag — on hydrate they get `undefined`, which
+  // `effectivePubDateMs` treats as `false`, so items that previously had
+  // synthesized `Date.now()` stamps would fraudulently claim freshness
+  // for the 24h gate window. Pre-v2 entries are left to TTL out (no
+  // explicit invalidation needed).
+  private static readonly HAPPY_ITEMS_CACHE_KEY = 'happy-all-items:v2';
 
   async hydrateHappyPanelsFromCache(): Promise<void> {
     try {

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1681,8 +1681,12 @@ export class PanelLayoutManager implements AppModule {
     return items.filter((item) => {
       // Recency gate routed through effectivePubDateMs so pubDateMissing
       // items fail the cutoff check rather than falsely claiming freshness.
-      const ts = effectivePubDateMs(item);
-      return Number.isFinite(ts) ? ts >= cutoff : true;
+      // Items with NaN/Infinity/Invalid Date pubDates are ALSO excluded
+      // (the helper sanitizes them to 0); previous behavior fell through
+      // to `true` on non-finite, which included corrupt-stamp items in
+      // narrow time windows. Treating untrustworthy timestamps uniformly
+      // is the intentional shift — see data-loader.filterItemsByTimeRange.
+      return effectivePubDateMs(item) >= cutoff;
     });
   }
 

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -2,6 +2,7 @@ import type { AppContext, AppModule } from '@/app/app-context';
 import { normalizeExclusiveChoropleths } from '@/components/resilience-choropleth-utils';
 import { replayPendingCalls, clearAllPendingCalls } from '@/app/pending-panel-data';
 import { getAlertsNearLocation } from '@/services/geo-convergence';
+import { effectivePubDateMs } from '@/services/feed-date';
 import type { ClusteredEvent } from '@/types';
 import type { RelatedAsset } from '@/types';
 import type { TheaterPostureSummary } from '@/services/military-surge';
@@ -1678,7 +1679,9 @@ export class PanelLayoutManager implements AppModule {
     };
     const cutoff = Date.now() - (ranges[range] ?? Infinity);
     return items.filter((item) => {
-      const ts = item.pubDate instanceof Date ? item.pubDate.getTime() : new Date(item.pubDate).getTime();
+      // Recency gate routed through effectivePubDateMs so pubDateMissing
+      // items fail the cutoff check rather than falsely claiming freshness.
+      const ts = effectivePubDateMs(item);
       return Number.isFinite(ts) ? ts >= cutoff : true;
     });
   }

--- a/src/services/ai-classify-queue.ts
+++ b/src/services/ai-classify-queue.ts
@@ -1,4 +1,30 @@
-import { SITE_VARIANT } from '@/config';
+/**
+ * Throttle gate for AI threat-classification dispatch.
+ *
+ * Identity used to dedupe: link (when present, lowercase host + tracker
+ * params stripped + fragment dropped) → falls back to title.
+ *
+ * Background: the previous title-only identity collapsed distinct articles
+ * sharing a wire headline ("Reuters: Iran fires missiles at..." reposted
+ * with the same headline by multiple outlets) into one dedupe slot, so
+ * only the first got an AI threat upgrade. The link-keyed identity makes
+ * each article-as-a-URL its own dedupe key; the title fallback preserves
+ * the original behavior when an upstream feed lacks a link.
+ *
+ * NOTE: this is NOT an admission gate. The caller in src/services/rss.ts
+ * only invokes canQueueAiClassification for items where
+ * `threat.source === 'keyword'` — articles already keyword-classified that
+ * are eligible for an AI confidence upgrade. A dropped enqueue does NOT
+ * drop the article from the feed; it just means the article's threat
+ * label stays at keyword confidence instead of being upgraded.
+ */
+
+// Import from the leaf variant module rather than '@/config' (the barrel)
+// so node:test runners that don't provide Vite's import.meta.env can load
+// this file without pulling in the entire config chain (feeds.ts →
+// @/utils/proxy → import.meta.env.DEV crash). See route-explorer-keyboard
+// test header for the broader Vite/Node compat pattern.
+import { SITE_VARIANT } from '@/config/variant';
 
 const AI_CLASSIFY_DEDUP_MS = 30 * 60 * 1000;
 const AI_CLASSIFY_WINDOW_MS = 60 * 1000;
@@ -10,11 +36,63 @@ export const AI_CLASSIFY_MAX_PER_FEED =
 const aiRecentlyQueued = new Map<string, number>();
 const aiDispatches: number[] = [];
 
-function toAiKey(title: string): string {
-  return title.trim().toLowerCase().replace(/\s+/g, ' ');
+// Tracker params commonly appended by feed publishers / share-link
+// rewriters that do NOT change which article a URL points at. Stripping
+// them lets the same article shared by two different feeds with different
+// utm tagging collapse into one dedupe slot. We intentionally keep this
+// list small and well-known — broader canonicalization (RFC 3986 normal
+// form, query-param sorting, path-segment collapsing) belongs in a real
+// URL canonicalizer, not a throttle gate.
+const TRACKER_PARAM_PREFIXES = ['utm_'];
+const TRACKER_PARAM_EXACT = new Set([
+  'fbclid',
+  'gclid',
+  'mc_cid',
+  'mc_eid',
+]);
+
+function normalizeLink(link: string): string | null {
+  try {
+    const url = new URL(link);
+    // Lowercased host; some publishers ship mixed-case hostnames.
+    url.hostname = url.hostname.toLowerCase();
+    // Fragment is a client-side anchor — never identifies a different
+    // article on its own.
+    url.hash = '';
+    // Strip well-known tracker params.
+    const toDelete: string[] = [];
+    for (const name of url.searchParams.keys()) {
+      const lower = name.toLowerCase();
+      if (TRACKER_PARAM_EXACT.has(lower)) {
+        toDelete.push(name);
+        continue;
+      }
+      if (TRACKER_PARAM_PREFIXES.some((p) => lower.startsWith(p))) {
+        toDelete.push(name);
+      }
+    }
+    for (const name of toDelete) url.searchParams.delete(name);
+    return url.href;
+  } catch {
+    // Malformed link → signal fall-through to title identity.
+    return null;
+  }
 }
 
-export function canQueueAiClassification(title: string): boolean {
+function titleKey(title: string): string {
+  return `title:${title.trim().toLowerCase().replace(/\s+/g, ' ')}`;
+}
+
+function toAiKey(identity: { link?: string; title: string }): string {
+  if (identity.link && identity.link.length > 0) {
+    const normalized = normalizeLink(identity.link);
+    if (normalized !== null) return `link:${normalized}`;
+    // normalizeLink returned null → malformed URL → fall back to title.
+  }
+  return titleKey(identity.title);
+}
+
+export function canQueueAiClassification(identity: { link?: string; title: string }): boolean {
   const now = Date.now();
   while (aiDispatches.length > 0 && now - aiDispatches[0]! > AI_CLASSIFY_WINDOW_MS) {
     aiDispatches.shift();
@@ -28,7 +106,7 @@ export function canQueueAiClassification(title: string): boolean {
     return false;
   }
 
-  const key = toAiKey(title);
+  const key = toAiKey(identity);
   const lastQueued = aiRecentlyQueued.get(key);
   if (lastQueued && now - lastQueued < AI_CLASSIFY_DEDUP_MS) {
     return false;
@@ -37,4 +115,17 @@ export function canQueueAiClassification(title: string): boolean {
   aiDispatches.push(now);
   aiRecentlyQueued.set(key, now);
   return true;
+}
+
+/**
+ * Test-only reset hook. Clears the module-scope dedupe map and dispatch
+ * window so tests can drive the queue across multiple scenarios without
+ * order-dependency. Matches the naming convention at
+ * `insights-loader.ts:104 __resetServerInsightsCacheForTests`.
+ *
+ * @internal
+ */
+export function __resetAiClassifyQueueForTests(): void {
+  aiRecentlyQueued.clear();
+  aiDispatches.length = 0;
 }

--- a/src/services/analysis-core.ts
+++ b/src/services/analysis-core.ts
@@ -34,6 +34,7 @@ import {
   findNewsForMarketSymbol,
 } from './entity-extraction';
 import { getEntityIndex } from './entity-index';
+import { effectivePubDateMs } from './feed-date';
 import type { ThreatLevel, EventCategory, ThreatClassification } from '@/types';
 
 const THREAT_PRIORITY: Record<ThreatLevel, number> = {
@@ -289,7 +290,7 @@ export function clusterNewsCore(
     const sorted = [...cluster].sort((a, b) => {
       const tierDiff = a.tier - b.tier;
       if (tierDiff !== 0) return tierDiff;
-      return b.pubDate.getTime() - a.pubDate.getTime();
+      return effectivePubDateMs(b) - effectivePubDateMs(a);
     });
 
     const primary = sorted[0]!;
@@ -437,7 +438,7 @@ export function detectConvergence(
     if (!event.allItems || event.allItems.length < 3) continue;
 
     const recentItems = event.allItems.filter(
-      item => now - item.pubDate.getTime() < WINDOW_MS
+      item => now - effectivePubDateMs(item) < WINDOW_MS
     );
     if (recentItems.length < 3) continue;
 

--- a/src/services/breaking-news-alerts.ts
+++ b/src/services/breaking-news-alerts.ts
@@ -10,6 +10,7 @@ import { getSourceTier } from '@/config/feeds';
 import { isDesktopRuntime, getRemoteApiBaseUrl } from '@/services/runtime';
 import { getClerkToken } from '@/services/clerk';
 import { SITE_VARIANT } from '@/config/variant';
+import { effectivePubDateMs } from '@/services/feed-date';
 
 export interface BreakingAlert {
   id: string;
@@ -142,8 +143,12 @@ export function updateAlertSettings(partial: Partial<AlertSettings>): void {
 
 // ─── Gate checks ───────────────────────────────────────────────────────────
 
-function isRecent(pubDate: Date): boolean {
-  return pubDate.getTime() >= (Date.now() - RECENCY_GATE_MS);
+function isRecent(item: { pubDate: Date; pubDateMissing?: boolean }): boolean {
+  // Routes through effectivePubDateMs so items with pubDateMissing get 0
+  // and fail the recency gate (Date.now() - 0 = a huge positive number,
+  // always >= RECENCY_GATE_MS). Without the helper, the synthesized
+  // pubDate would pass this gate and fire false-fresh alerts.
+  return effectivePubDateMs(item) >= (Date.now() - RECENCY_GATE_MS);
 }
 
 function isInStartupGrace(): boolean {
@@ -233,7 +238,7 @@ export function checkBatchForBreakingAlerts(items: NewsItem[]): void {
   for (const item of items) {
     if (!item.isAlert) continue;
     if (!item.threat) continue;
-    if (!isRecent(item.pubDate)) continue;
+    if (!isRecent(item)) continue;
 
     const level = item.threat.level;
     if (level !== 'critical' && level !== 'high') continue;
@@ -257,7 +262,7 @@ export function checkBatchForBreakingAlerts(items: NewsItem[]): void {
 
     const isBetter = !best
       || (level === 'critical' && best.threatLevel !== 'critical')
-      || (level === best.threatLevel && item.pubDate.getTime() > best.timestamp.getTime());
+      || (level === best.threatLevel && effectivePubDateMs(item) > best.timestamp.getTime());
 
     if (isBetter) {
       best = {

--- a/src/services/breaking-news-alerts.ts
+++ b/src/services/breaking-news-alerts.ts
@@ -236,6 +236,14 @@ export function checkBatchForBreakingAlerts(items: NewsItem[]): void {
   if (isInStartupGrace()) return;
 
   let best: BreakingAlert | null = null;
+  // Effective timestamp of the current best, captured so the tie-break
+  // comparison below is symmetric (effectivePubDateMs on both sides). The
+  // BreakingAlert type doesn't carry pubDateMissing — it's a render-time
+  // shape — so without this local, comparing the candidate's effective
+  // time against best.timestamp.getTime() would silently treat any
+  // future missing-date best as fresh. Today isRecent filters that out
+  // upstream; the local makes the gate defense-in-depth.
+  let bestEffectiveMs = -Infinity;
 
   for (const item of items) {
     if (!item.isAlert) continue;
@@ -262,11 +270,13 @@ export function checkBatchForBreakingAlerts(items: NewsItem[]): void {
     // Items below the importance threshold are too low-signal for the banner.
     if (item.importanceScore !== undefined && item.importanceScore < IMPORTANCE_SCORE_MIN) continue;
 
+    const itemEffectiveMs = effectivePubDateMs(item);
     const isBetter = !best
       || (level === 'critical' && best.threatLevel !== 'critical')
-      || (level === best.threatLevel && effectivePubDateMs(item) > best.timestamp.getTime());
+      || (level === best.threatLevel && itemEffectiveMs > bestEffectiveMs);
 
     if (isBetter) {
+      bestEffectiveMs = itemEffectiveMs;
       best = {
         id: key,
         headline: item.title,

--- a/src/services/breaking-news-alerts.ts
+++ b/src/services/breaking-news-alerts.ts
@@ -144,10 +144,12 @@ export function updateAlertSettings(partial: Partial<AlertSettings>): void {
 // ─── Gate checks ───────────────────────────────────────────────────────────
 
 function isRecent(item: { pubDate: Date; pubDateMissing?: boolean }): boolean {
-  // Routes through effectivePubDateMs so items with pubDateMissing get 0
-  // and fail the recency gate (Date.now() - 0 = a huge positive number,
-  // always >= RECENCY_GATE_MS). Without the helper, the synthesized
-  // pubDate would pass this gate and fire false-fresh alerts.
+  // Routes through effectivePubDateMs so items with pubDateMissing get 0.
+  // The gate `effective >= Date.now() - RECENCY_GATE_MS` then evaluates
+  // `0 >= (large positive)` → false for missing-date items, excluding
+  // them from breaking-alert eligibility. Without the helper, the
+  // synthesized pubDate (≈ Date.now()) would pass this gate and fire
+  // false-fresh alerts.
   return effectivePubDateMs(item) >= (Date.now() - RECENCY_GATE_MS);
 }
 

--- a/src/services/daily-market-brief.ts
+++ b/src/services/daily-market-brief.ts
@@ -2,6 +2,7 @@ import type { MarketData, NewsItem } from '@/types';
 import type { MarketWatchlistEntry } from './market-watchlist';
 import { getMarketWatchlistEntries } from './market-watchlist';
 import type { SummarizationResult } from './summarization';
+import { effectivePubDateMs } from './feed-date';
 import { withTimeout } from '@/utils/with-timeout';
 
 /**
@@ -214,7 +215,7 @@ function collectHeadlinePool(newsByCategory: Record<string, NewsItem[]>, extraCa
   return cats
     .flatMap((category) => newsByCategory[category] || [])
     .filter((item) => !!item?.title)
-    .sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());
+    .sort((a, b) => effectivePubDateMs(b) - effectivePubDateMs(a));
 }
 
 function resolveTargets(markets: MarketData[], explicitTargets?: MarketWatchlistEntry[]): MarketData[] {

--- a/src/services/feed-date.ts
+++ b/src/services/feed-date.ts
@@ -1,4 +1,76 @@
+/**
+ * Feed-date parsing + the single ranking/recency helper consumers must use
+ * for any "is this item fresh?" decision.
+ *
+ * Background: RSS 2.0 makes `pubDate` optional; Atom uses `<updated>` and
+ * `<published>` separately. Real feeds frequently ship items with missing
+ * or malformed timestamps. The legacy `parseFeedDateOrNow` substituted
+ * `Date.now()` for any unparseable input — that produced FALSE FRESHNESS:
+ * an item with no real date would sort ahead of legitimately fresh items
+ * and fire breaking-news alerts that shouldn't fire.
+ *
+ * Contract:
+ *   - `parseFeedDate(value)` returns `{ date, missing }`. The Date is still
+ *     populated (using `Date.now()` as the synthesized stamp) so display
+ *     consumers can format it without null-handling. The `missing` flag
+ *     records whether the source had a parseable timestamp.
+ *   - `effectivePubDateMs(item)` returns 0 for items with `pubDateMissing:
+ *     true`, otherwise `item.pubDate.getTime()`. Every ranking/recency
+ *     consumer in `src/services/` and `src/app/` MUST route through this
+ *     helper instead of calling `item.pubDate.getTime()` directly. The
+ *     static guardrail test `tests/feed-date-ranking-uses-effective.test.
+ *     mts` enforces this.
+ *
+ * Recency-window semantics: returning 0 makes any positive-duration
+ * recency gate (`Date.now() - effectivePubDateMs(item) < windowMs`)
+ * evaluate false, which EXCLUDES missing-date items from freshness
+ * windows. They remain in the underlying catalog and render normally with
+ * the synthesized timestamp; they just never claim to be fresh. This is
+ * the deliberate trade-off — see plan U3 Key Technical Decisions.
+ */
+
+/**
+ * @deprecated Use `parseFeedDate` + `effectivePubDateMs` instead. Kept as
+ * a re-export so callers in non-rss paths (none currently) don't crash if
+ * they ever appear; the rss.ts parse site has migrated.
+ */
 export function parseFeedDateOrNow(value: string | null | undefined): Date {
-  const parsed = value ? new Date(value) : new Date();
-  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+  return parseFeedDate(value).date;
+}
+
+export interface ParsedFeedDate {
+  /** Best-effort Date for display. Always a valid Date instance — uses
+   *  `Date.now()` as the synthesized stamp when input was unparseable. */
+  date: Date;
+  /** True when the source had no parseable timestamp. Ranking/recency
+   *  code reads this via `effectivePubDateMs` to deprioritize the item. */
+  missing: boolean;
+}
+
+export function parseFeedDate(value: string | null | undefined): ParsedFeedDate {
+  if (!value) return { date: new Date(), missing: true };
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return { date: new Date(), missing: true };
+  return { date: parsed, missing: false };
+}
+
+/**
+ * Returns the timestamp a ranking/recency comparator should use for this
+ * item. Items flagged `pubDateMissing: true` get 0 — they sort last in
+ * "newest first" comparators and fail every positive-duration recency
+ * gate. The `pubDateMissing` field is OPTIONAL on the input type so this
+ * helper accepts items from non-RSS producers (synthesized items from
+ * analysis/prediction paths) without forcing every construction site to
+ * set it.
+ */
+export function effectivePubDateMs(item: {
+  pubDate: Date | string | number;
+  pubDateMissing?: boolean;
+}): number {
+  if (item.pubDateMissing === true) return 0;
+  if (item.pubDate instanceof Date) return item.pubDate.getTime();
+  if (typeof item.pubDate === 'number') return item.pubDate;
+  // String case (serialized form, e.g. from cache deserialization).
+  const ms = new Date(item.pubDate).getTime();
+  return Number.isNaN(ms) ? 0 : ms;
 }

--- a/src/services/feed-date.ts
+++ b/src/services/feed-date.ts
@@ -68,9 +68,18 @@ export function effectivePubDateMs(item: {
   pubDateMissing?: boolean;
 }): number {
   if (item.pubDateMissing === true) return 0;
-  if (item.pubDate instanceof Date) return item.pubDate.getTime();
-  if (typeof item.pubDate === 'number') return item.pubDate;
+  if (item.pubDate instanceof Date) {
+    const ms = item.pubDate.getTime();
+    return Number.isFinite(ms) ? ms : 0;
+  }
+  if (typeof item.pubDate === 'number') {
+    // Filter NaN / Infinity. Cache-deserialized entries or future numeric
+    // pubDate constructors should never claim freshness with a non-finite
+    // stamp — sort comparators on NaN have unspecified behavior per the
+    // JS spec.
+    return Number.isFinite(item.pubDate) ? item.pubDate : 0;
+  }
   // String case (serialized form, e.g. from cache deserialization).
   const ms = new Date(item.pubDate).getTime();
-  return Number.isNaN(ms) ? 0 : ms;
+  return Number.isFinite(ms) ? ms : 0;
 }

--- a/src/services/rss.ts
+++ b/src/services/rss.ts
@@ -7,7 +7,7 @@ import { getPersistentCache, setPersistentCache } from './persistent-cache';
 import { dataFreshness } from './data-freshness';
 import { ingestHeadlines } from './trending-keywords';
 import { getCurrentLanguage } from './i18n';
-import { parseFeedDateOrNow } from './feed-date';
+import { parseFeedDate, effectivePubDateMs } from './feed-date';
 import { canQueueAiClassification, AI_CLASSIFY_MAX_PER_FEED } from './ai-classify-queue';
 import { mlWorker } from './ml-worker';
 import { isHeadlineMemoryEnabled } from './ai-flow-settings';
@@ -28,6 +28,14 @@ function fromSerializable(items: Array<Omit<NewsItem, 'pubDate'> & { pubDate: st
   return items.map(item => ({ ...item, pubDate: new Date(item.pubDate) }));
 }
 
+// Cache key prefix. Bumped from `feed:` → `feed:v2:` when the item schema
+// gained `pubDateMissing` (U3 of plan 2026-05-23-001). Old `feed:`-prefix
+// entries deserialize without the flag, which would silently keep the
+// false-freshness bug alive in cached items until natural TTL. The bump
+// invalidates cleanly; old entries can be left to expire. See skill
+// `redis-cache-staleness-gotchas` for the recipe.
+const CACHE_PREFIX = 'feed:v2:';
+
 function getFeedScope(feedName: string, lang: string): string {
   return `${feedName}${FEED_SCOPE_SEPARATOR}${lang}`;
 }
@@ -42,7 +50,7 @@ function parseFeedScope(feedScope: string): { feedName: string; lang: string } {
 }
 
 function getPersistentFeedKey(feedScope: string): string {
-  return `feed:${feedScope}`;
+  return `${CACHE_PREFIX}${feedScope}`;
 }
 
 async function readPersistentFeed(key: string): Promise<NewsItem[] | null> {
@@ -56,11 +64,14 @@ async function loadPersistentFeed(feedScope: string): Promise<NewsItem[] | null>
   const scoped = await readPersistentFeed(scopedKey);
   if (scoped) return scoped;
 
-  // Migration fallback: older builds stored feeds as `feed:<feedName>` without language scope.
-  // Only use this for English to avoid mixing cached content across locales.
+  // Migration fallback: older builds stored feeds as `feed:v2:<feedName>` without
+  // language scope. Only use this for English to avoid mixing cached content
+  // across locales. Pre-v2 `feed:<feedScope>` and `feed:<feedName>` entries are
+  // deliberately NOT consulted — they predate the pubDateMissing schema and
+  // would re-introduce false-freshness for cached items.
   const { feedName, lang } = parseFeedScope(feedScope);
   if (lang !== 'en') return null;
-  return readPersistentFeed(`feed:${feedName}`);
+  return readPersistentFeed(`${CACHE_PREFIX}${feedName}`);
 }
 
 // Clean up stale entries to prevent unbounded growth
@@ -254,7 +265,7 @@ export async function fetchFeed(feed: Feed): Promise<NewsItem[]> {
         const pubDateStr = isAtom
           ? (item.querySelector('published')?.textContent || item.querySelector('updated')?.textContent || '')
           : (item.querySelector('pubDate')?.textContent || '');
-        const pubDate = parseFeedDateOrNow(pubDateStr);
+        const { date: pubDate, missing: pubDateMissing } = parseFeedDate(pubDateStr);
         const threat = classifyByKeyword(title, SITE_VARIANT);
         const isAlert = threat.level === 'critical' || threat.level === 'high';
         const geoMatches = inferGeoHubsFromTitle(title);
@@ -265,6 +276,7 @@ export async function fetchFeed(feed: Feed): Promise<NewsItem[]> {
           title,
           link,
           pubDate,
+          pubDateMissing,
           isAlert,
           threat,
           ...(topGeo && { lat: topGeo.hub.lat, lon: topGeo.hub.lon, locationName: topGeo.hub.name }),
@@ -295,7 +307,7 @@ export async function fetchFeed(feed: Feed): Promise<NewsItem[]> {
 
     const aiCandidates = parsed
       .filter(item => item.threat.source === 'keyword')
-      .sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime())
+      .sort((a, b) => effectivePubDateMs(b) - effectivePubDateMs(a))
       .slice(0, AI_CLASSIFY_MAX_PER_FEED);
 
     for (const item of aiCandidates) {
@@ -337,22 +349,22 @@ export async function fetchCategoryFeeds(
   const topItems: NewsItem[] = [];
   let totalItems = 0;
 
-  const ensureSortedDescending = () => [...topItems].sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());
+  const ensureSortedDescending = () => [...topItems].sort((a, b) => effectivePubDateMs(b) - effectivePubDateMs(a));
 
   const insertTopItem = (item: NewsItem) => {
     totalItems += 1;
     if (topItems.length < topLimit) {
       topItems.push(item);
-      if (topItems.length === topLimit) topItems.sort((a, b) => a.pubDate.getTime() - b.pubDate.getTime());
+      if (topItems.length === topLimit) topItems.sort((a, b) => effectivePubDateMs(a) - effectivePubDateMs(b));
       return;
     }
 
-    const itemTime = item.pubDate.getTime();
-    if (itemTime <= topItems[0]!.pubDate.getTime()) return;
+    const itemTime = effectivePubDateMs(item);
+    if (itemTime <= effectivePubDateMs(topItems[0]!)) return;
 
     topItems[0] = item;
     for (let i = 0; i < topItems.length - 1; i += 1) {
-      if (topItems[i]!.pubDate.getTime() <= topItems[i + 1]!.pubDate.getTime()) break;
+      if (effectivePubDateMs(topItems[i]!) <= effectivePubDateMs(topItems[i + 1]!)) break;
       [topItems[i], topItems[i + 1]] = [topItems[i + 1]!, topItems[i]!];
     }
   };

--- a/src/services/rss.ts
+++ b/src/services/rss.ts
@@ -64,11 +64,13 @@ async function loadPersistentFeed(feedScope: string): Promise<NewsItem[] | null>
   const scoped = await readPersistentFeed(scopedKey);
   if (scoped) return scoped;
 
-  // Migration fallback: older builds stored feeds as `feed:v2:<feedName>` without
-  // language scope. Only use this for English to avoid mixing cached content
-  // across locales. Pre-v2 `feed:<feedScope>` and `feed:<feedName>` entries are
-  // deliberately NOT consulted — they predate the pubDateMissing schema and
-  // would re-introduce false-freshness for cached items.
+  // Language-scope migration fallback (carried forward from the pre-v2
+  // prefix era): some older v2 cache rows that predate the language-scope
+  // refactor were written without a `::<lang>` suffix. For English only,
+  // also try the unscoped key under the CURRENT v2 prefix. Pre-v2
+  // `feed:<feedScope>` and `feed:<feedName>` entries are deliberately NOT
+  // consulted — they predate the pubDateMissing schema and would
+  // re-introduce false-freshness for cached items.
   const { feedName, lang } = parseFeedScope(feedScope);
   if (lang !== 'en') return null;
   return readPersistentFeed(`${CACHE_PREFIX}${feedName}`);

--- a/src/services/rss.ts
+++ b/src/services/rss.ts
@@ -264,9 +264,21 @@ export async function fetchFeed(feed: Feed): Promise<NewsItem[]> {
           link = item.querySelector('link')?.textContent || '';
         }
 
+        // Dublin Core (<dc:date>) fallback for RSS feeds. ArXiv RSS (already
+        // in the feed registry as "ArXiv AI", "ArXiv ML") ships dc:date with
+        // no <pubDate>; without this fallback every ArXiv item would land
+        // with pubDateMissing=true and get demoted in every freshness ranking.
+        // Prior precedent: PR #3417. querySelector('dc\\:date') escapes the
+        // CSS-selector colon so the XML qname matches; getElementsByTagName
+        // is an alternative that also works under browser DOMParser in XML
+        // mode. textContent reads the element's inner text without namespace
+        // gymnastics.
         const pubDateStr = isAtom
           ? (item.querySelector('published')?.textContent || item.querySelector('updated')?.textContent || '')
-          : (item.querySelector('pubDate')?.textContent || '');
+          : (item.querySelector('pubDate')?.textContent
+            || item.querySelector('dc\\:date')?.textContent
+            || item.getElementsByTagName('dc:date')[0]?.textContent
+            || '');
         const { date: pubDate, missing: pubDateMissing } = parseFeedDate(pubDateStr);
         const threat = classifyByKeyword(title, SITE_VARIANT);
         const isAlert = threat.level === 'critical' || threat.level === 'high';

--- a/src/services/rss.ts
+++ b/src/services/rss.ts
@@ -311,7 +311,7 @@ export async function fetchFeed(feed: Feed): Promise<NewsItem[]> {
       .slice(0, AI_CLASSIFY_MAX_PER_FEED);
 
     for (const item of aiCandidates) {
-      if (!canQueueAiClassification(item.title)) continue;
+      if (!canQueueAiClassification({ link: item.link, title: item.title })) continue;
       classifyWithAI(item.title, SITE_VARIANT).then((aiResult) => {
         if (aiResult && aiResult.confidence > item.threat.confidence) {
           item.threat = aiResult;

--- a/src/services/velocity.ts
+++ b/src/services/velocity.ts
@@ -1,5 +1,6 @@
 import type { ClusteredEvent, VelocityMetrics, VelocityLevel, SentimentType } from '@/types';
 import { mlWorker } from './ml-worker';
+import { effectivePubDateMs } from './feed-date';
 
 const HOUR_MS = 60 * 60 * 1000;
 const ELEVATED_THRESHOLD = 3;
@@ -55,8 +56,8 @@ export function calculateVelocity(cluster: ClusteredEvent): VelocityMetrics {
   const sourcesPerHour = items.length / timeSpanHours;
 
   const midpoint = cluster.firstSeen.getTime() + timeSpanMs / 2;
-  const recentItems = items.filter(i => i.pubDate.getTime() > midpoint);
-  const olderItems = items.filter(i => i.pubDate.getTime() <= midpoint);
+  const recentItems = items.filter(i => effectivePubDateMs(i) > midpoint);
+  const olderItems = items.filter(i => effectivePubDateMs(i) <= midpoint);
 
   let trend: 'rising' | 'stable' | 'falling' = 'stable';
   if (recentItems.length > olderItems.length * 1.5) {

--- a/src/services/velocity.ts
+++ b/src/services/velocity.ts
@@ -55,9 +55,19 @@ export function calculateVelocity(cluster: ClusteredEvent): VelocityMetrics {
   const timeSpanHours = Math.max(timeSpanMs / HOUR_MS, 0.25);
   const sourcesPerHour = items.length / timeSpanHours;
 
+  // Exclude pubDateMissing items from trend math entirely. `clustering.ts:116`
+  // aggregates raw `pubDate.getTime()` into `firstSeen`/`lastUpdated` for
+  // cluster metadata (allow-listed — see feed-date-ranking-uses-effective
+  // test). If we let missing-date items into this midpoint partition while
+  // the cluster's firstSeen/lastUpdated were computed from their synthesized
+  // stamps, every such item would land in `olderItems` (effectivePubDateMs
+  // returns 0) and falsely tilt the trend toward 'falling'. Computing trend
+  // only on items with real timestamps preserves the cluster-metadata path
+  // without composing the two policies into a wrong answer.
+  const datedItems = items.filter((i) => i.pubDateMissing !== true);
   const midpoint = cluster.firstSeen.getTime() + timeSpanMs / 2;
-  const recentItems = items.filter(i => effectivePubDateMs(i) > midpoint);
-  const olderItems = items.filter(i => effectivePubDateMs(i) <= midpoint);
+  const recentItems = datedItems.filter((i) => effectivePubDateMs(i) > midpoint);
+  const olderItems = datedItems.filter((i) => effectivePubDateMs(i) <= midpoint);
 
   let trend: 'rising' | 'stable' | 'falling' = 'stable';
   if (recentItems.length > olderItems.length * 1.5) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -105,6 +105,15 @@ export interface NewsItem {
   title: string;
   link: string;
   pubDate: Date;
+  /**
+   * True when the upstream feed item had no parseable pubDate/published/
+   * updated timestamp. The `pubDate` field is still populated (synthesized
+   * stamp) for display, but ranking/recency consumers MUST route through
+   * `effectivePubDateMs` from feed-date.ts so these items don't claim
+   * false freshness. Optional so synthesized items from non-RSS producers
+   * don't need to set it explicitly — `undefined` is treated as `false`.
+   */
+  pubDateMissing?: boolean;
   isAlert: boolean;
   monitorColor?: string;
   tier?: number;

--- a/tests/ai-classify-queue.test.mts
+++ b/tests/ai-classify-queue.test.mts
@@ -1,0 +1,128 @@
+/**
+ * Tests for src/services/ai-classify-queue.ts.
+ *
+ * Module-scope state (aiRecentlyQueued, aiDispatches) is reset between
+ * every case via __resetAiClassifyQueueForTests to keep tests order-
+ * independent. The reset is exported with the project's `__…ForTests`
+ * convention (matches insights-loader.ts:104).
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it, beforeEach } from 'node:test';
+import {
+  canQueueAiClassification,
+  __resetAiClassifyQueueForTests,
+} from '../src/services/ai-classify-queue.ts';
+
+describe('canQueueAiClassification — link-keyed identity', () => {
+  beforeEach(() => {
+    __resetAiClassifyQueueForTests();
+  });
+
+  it('two distinct-link items sharing a wire headline both enqueue', () => {
+    const shared = 'Reuters: Iran fires missiles at undisclosed targets';
+    assert.equal(
+      canQueueAiClassification({ link: 'https://reuters.com/world/iran/abc', title: shared }),
+      true,
+    );
+    assert.equal(
+      canQueueAiClassification({ link: 'https://example.com/iran-news', title: shared }),
+      true,
+      'Different link → different dedupe slot → second call should still pass',
+    );
+  });
+
+  it('two items with the same link dedupe (second returns false)', () => {
+    const link = 'https://reuters.com/world/iran/abc';
+    assert.equal(canQueueAiClassification({ link, title: 'Iran fires missiles' }), true);
+    assert.equal(
+      canQueueAiClassification({ link, title: 'Different title same link' }),
+      false,
+      'Same link should collapse to one dedupe slot regardless of title rewrite',
+    );
+  });
+
+  it('falls back to title identity when link is empty/missing', () => {
+    assert.equal(canQueueAiClassification({ link: '', title: 'Same headline' }), true);
+    assert.equal(
+      canQueueAiClassification({ link: '', title: 'Same headline' }),
+      false,
+      'Same title + empty link both calls → second dedupes (legacy behavior preserved)',
+    );
+  });
+
+  it('falls back to title identity when link is undefined', () => {
+    assert.equal(canQueueAiClassification({ title: 'No link here' }), true);
+    assert.equal(canQueueAiClassification({ title: 'No link here' }), false);
+  });
+
+  it('strips utm_* tracker params from link identity', () => {
+    const a = 'https://reuters.com/iran?utm_source=feed&utm_medium=rss';
+    const b = 'https://reuters.com/iran?utm_source=twitter&utm_campaign=share';
+    assert.equal(canQueueAiClassification({ link: a, title: 'x' }), true);
+    assert.equal(
+      canQueueAiClassification({ link: b, title: 'y' }),
+      false,
+      'Different utm_* tagging on the same article should collapse to one dedupe slot',
+    );
+  });
+
+  it('strips fbclid/gclid tracker params from link identity', () => {
+    const a = 'https://reuters.com/iran?fbclid=abc';
+    const b = 'https://reuters.com/iran?gclid=xyz';
+    assert.equal(canQueueAiClassification({ link: a, title: 'x' }), true);
+    assert.equal(canQueueAiClassification({ link: b, title: 'y' }), false);
+  });
+
+  it('strips URL fragments from link identity', () => {
+    const a = 'https://reuters.com/iran#top';
+    const b = 'https://reuters.com/iran#section-2';
+    assert.equal(canQueueAiClassification({ link: a, title: 'x' }), true);
+    assert.equal(canQueueAiClassification({ link: b, title: 'y' }), false);
+  });
+
+  it('normalizes host casing in link identity', () => {
+    const a = 'https://Reuters.com/iran';
+    const b = 'https://reuters.com/iran';
+    assert.equal(canQueueAiClassification({ link: a, title: 'x' }), true);
+    assert.equal(canQueueAiClassification({ link: b, title: 'y' }), false);
+  });
+
+  it('preserves non-tracker query params (different ?p=1 vs ?p=2 are distinct articles)', () => {
+    const a = 'https://example.com/article?p=1';
+    const b = 'https://example.com/article?p=2';
+    assert.equal(canQueueAiClassification({ link: a, title: 'x' }), true);
+    assert.equal(
+      canQueueAiClassification({ link: b, title: 'y' }),
+      true,
+      'Pagination params are NOT tracker params; both items must enqueue',
+    );
+  });
+
+  it('malformed link falls back to title identity without crashing', () => {
+    assert.equal(canQueueAiClassification({ link: 'not a url', title: 'Same title' }), true);
+    assert.equal(
+      canQueueAiClassification({ link: 'also not a url', title: 'Same title' }),
+      false,
+      'Malformed links short-circuit on the raw string; identical raw strings dedupe, different ones do not',
+    );
+  });
+
+  it('respects per-minute throughput ceiling (AI_CLASSIFY_MAX_PER_WINDOW)', () => {
+    // Default variant ceiling is 80/min. Flood 80 distinct items → all pass.
+    // The 81st must be rejected by the throughput gate (not the dedupe gate).
+    const ceiling = 80;
+    for (let i = 0; i < ceiling; i++) {
+      assert.equal(
+        canQueueAiClassification({ link: `https://example.com/${i}`, title: `t${i}` }),
+        true,
+        `Flood item #${i} should pass under the ceiling`,
+      );
+    }
+    assert.equal(
+      canQueueAiClassification({ link: 'https://example.com/overflow', title: 'overflow' }),
+      false,
+      'Flooding past the ceiling must reject via throughput gate',
+    );
+  });
+});

--- a/tests/dockerfile-digest-notifications-imports.test.mjs
+++ b/tests/dockerfile-digest-notifications-imports.test.mjs
@@ -155,11 +155,22 @@ describe('Dockerfile.digest-notifications — transitive-import closure', () => 
   });
 
   // BFS from the cron entrypoint through the import graph; every
-  // tracked-prefix file reached must be covered.
+  // tracked-prefix file reached must be covered. Entrypoint is derived
+  // from scripts/railway-services.json (the single source of truth for
+  // Railway-deployed scripts) — filtered to the digest-notifications
+  // Dockerfile so this test stays scoped to its own image.
   it('every transitively-imported tracked-prefix file is COPY\'d', () => {
-    const entrypoints = [
-      resolve(root, 'scripts/seed-digest-notifications.mjs'),
-    ];
+    const registry = JSON.parse(
+      readFileSync(resolve(root, 'scripts/railway-services.json'), 'utf8'),
+    );
+    const digestEntries = registry
+      .filter((r) => r.deployMode === 'dockerfile' && r.dockerfile === 'Dockerfile.digest-notifications')
+      .map((r) => resolve(root, r.entry));
+    assert.ok(
+      digestEntries.length > 0,
+      'No registry entry found for Dockerfile.digest-notifications — registry corrupt or out of sync',
+    );
+    const entrypoints = digestEntries;
     const missing = [];
     const visited = new Set();
     const queue = [...entrypoints];

--- a/tests/feed-date-ranking-uses-effective.test.mts
+++ b/tests/feed-date-ranking-uses-effective.test.mts
@@ -47,13 +47,18 @@ interface AllowEntry {
 const ALLOW_LIST: AllowEntry[] = [
   {
     file: 'src/services/rss.ts',
-    line: 301,
+    line: 303,
     reason: 'mlWorker.vectorStoreIngest stores pubDate as embedding metadata; not used as a freshness comparator.',
   },
   {
     file: 'src/services/feed-date.ts',
-    line: 71,
+    line: 72,
     reason: 'effectivePubDateMs implementation — the helper itself necessarily calls .getTime() on the underlying Date.',
+  },
+  {
+    file: 'src/services/feed-date.ts',
+    line: 83,
+    reason: 'effectivePubDateMs implementation — string-input branch reconstructs Date and reads getTime; covered by NaN/Infinity guard immediately below.',
   },
   {
     file: 'src/services/analysis-core.ts',
@@ -92,7 +97,20 @@ const ALLOW_LIST: AllowEntry[] = [
   },
 ];
 
-const PUBDATE_GETTIME_RE = /\.pubDate\s*\.getTime\(\)/;
+// Match three shapes that all flow item.pubDate into a comparator:
+//   (a) item.pubDate.getTime()      — direct
+//   (b) item.pubDate?.getTime()     — optional chain (idiomatic TS 4+)
+//   (c) new Date(item.pubDate).getTime()  — wrap-then-getTime (real-world
+//                                          bypass found in country-intel.ts
+//                                          and several other src/app/ sites)
+// The negative-coverage tests below pin each shape so a future regex tweak
+// can't silently drop one. NOTE: paren-wrapped reads (`(item.pubDate).
+// getTime()`), aliased reads (`const t = item.pubDate; t.getTime()`), and
+// destructured reads (`const { pubDate } = item; pubDate.getTime()`) still
+// bypass this regex. They're documented residual risk — adopting AST-level
+// analysis (ts-morph or @typescript-eslint) would close them but is out of
+// scope here.
+const PUBDATE_GETTIME_RE = /(?:\.pubDate\s*\??\s*\.\s*getTime\s*\(\s*\)|new\s+Date\s*\([^)]*\bpubDate[^)]*\)\s*\.\s*getTime\s*\(\s*\))/;
 const EFFECTIVE_HELPER_RE = /effectivePubDateMs\b/;
 
 function listTsFiles(dir: string): string[] {
@@ -181,11 +199,15 @@ describe('feed-date freshness guardrail — effectivePubDateMs usage', () => {
     }
   });
 
-  // Self-fixtures: prove the regex matches BOTH shapes it claims to.
-  // Without these, a future regex simplification could silently stop
-  // matching one shape, and the audit would pass coincidentally because
-  // today's codebase happens to not have a violation in that shape.
-  it('PUBDATE_GETTIME_RE matches the sort-comparator shape', () => {
+  // Self-fixtures: prove the regex matches EVERY shape it claims to and
+  // does NOT match unrelated patterns. Without these, a future regex
+  // simplification could silently stop matching one shape, and the audit
+  // would pass coincidentally because today's codebase happens to not
+  // have a violation in that shape. Each shape below is a real-world
+  // form a developer is likely to write — country-intel.ts:297 shipped a
+  // `new Date(item.pubDate).getTime()` bypass that the original 2-shape
+  // self-fixture would have missed.
+  it('PUBDATE_GETTIME_RE matches the direct sort-comparator shape', () => {
     const sample = 'items.sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());';
     assert.ok(PUBDATE_GETTIME_RE.test(sample));
   });
@@ -195,8 +217,23 @@ describe('feed-date freshness guardrail — effectivePubDateMs usage', () => {
     assert.ok(PUBDATE_GETTIME_RE.test(sample));
   });
 
+  it('PUBDATE_GETTIME_RE matches the optional-chain shape', () => {
+    const sample = 'const ts = item.pubDate?.getTime() ?? 0;';
+    assert.ok(PUBDATE_GETTIME_RE.test(sample));
+  });
+
+  it('PUBDATE_GETTIME_RE matches the new-Date-wrap shape', () => {
+    const sample = 'return new Date(b.pubDate).getTime() - new Date(a.pubDate).getTime();';
+    assert.ok(PUBDATE_GETTIME_RE.test(sample));
+  });
+
   it('PUBDATE_GETTIME_RE does NOT match unrelated getTime calls', () => {
     const sample = 'const t = otherDate.getTime();';
+    assert.ok(!PUBDATE_GETTIME_RE.test(sample));
+  });
+
+  it('PUBDATE_GETTIME_RE does NOT match new Date() over an unrelated field', () => {
+    const sample = 'const t = new Date(item.endDate).getTime();';
     assert.ok(!PUBDATE_GETTIME_RE.test(sample));
   });
 

--- a/tests/feed-date-ranking-uses-effective.test.mts
+++ b/tests/feed-date-ranking-uses-effective.test.mts
@@ -47,7 +47,7 @@ interface AllowEntry {
 const ALLOW_LIST: AllowEntry[] = [
   {
     file: 'src/services/rss.ts',
-    line: 303,
+    line: 315,
     reason: 'mlWorker.vectorStoreIngest stores pubDate as embedding metadata; not used as a freshness comparator.',
   },
   {
@@ -92,7 +92,7 @@ const ALLOW_LIST: AllowEntry[] = [
   },
   {
     file: 'src/app/data-loader.ts',
-    line: 3279,
+    line: 3290,
     reason: 'Cache serialization step — wraps pubDate.getTime() into the persisted entry payload, not a comparator.',
   },
 ];

--- a/tests/feed-date-ranking-uses-effective.test.mts
+++ b/tests/feed-date-ranking-uses-effective.test.mts
@@ -1,0 +1,207 @@
+/**
+ * Static guardrail: every ranking/recency consumer of feed-item pubDate in
+ * `src/services/` and `src/app/` MUST route through `effectivePubDateMs`
+ * from `src/services/feed-date.ts`. Without this guard, a future ranking
+ * call site could silently call `item.pubDate.getTime()` directly and
+ * re-introduce the false-freshness bug U3 fixed.
+ *
+ * Audit shape: walks .ts files under src/services/ and src/app/, finds
+ * every line containing `.pubDate.getTime()` inside a freshness comparator
+ * or recency gate, and fails if that line doesn't ALSO reference
+ * `effectivePubDateMs`. Files have an explicit per-line allow-list with
+ * documented reasons for legitimate non-ranking uses (metadata storage,
+ * identity keys, embedding index timestamps).
+ *
+ * Self-fixture: also pins the regex against synthetic samples for both
+ * the sort-comparator shape (`b.pubDate.getTime() - a.pubDate.getTime()`)
+ * AND the recency-gate shape (`Date.now() - item.pubDate.getTime() <
+ * windowMs`), so a future regex simplification cannot silently stop
+ * matching one of them. Pattern source: skill
+ * `test-ci-gotchas/reference/static-grep-audit-test-undertested-by-only-
+ * matching-one-shape`.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, resolve, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+const SCAN_DIRS = ['src/services', 'src/app'];
+
+// Files (path, line number) that legitimately use raw .pubDate.getTime()
+// for NON-ranking purposes — metadata storage, identity key generation,
+// embedding index timestamps. Each entry MUST carry a reason. The audit
+// fails if a listed (file,line) no longer matches — i.e., either the line
+// moved (forcing review of whether it's still legitimate) or the file
+// removed the line (allow-list can be trimmed).
+interface AllowEntry {
+  file: string;
+  line: number;
+  reason: string;
+}
+
+const ALLOW_LIST: AllowEntry[] = [
+  {
+    file: 'src/services/rss.ts',
+    line: 301,
+    reason: 'mlWorker.vectorStoreIngest stores pubDate as embedding metadata; not used as a freshness comparator.',
+  },
+  {
+    file: 'src/services/feed-date.ts',
+    line: 71,
+    reason: 'effectivePubDateMs implementation — the helper itself necessarily calls .getTime() on the underlying Date.',
+  },
+  {
+    file: 'src/services/analysis-core.ts',
+    line: 207,
+    reason: 'generateClusterId sort produces a stable identity string from earliest pubDate; not a freshness comparator.',
+  },
+  {
+    file: 'src/services/analysis-core.ts',
+    line: 209,
+    reason: 'generateClusterId uses earliest pubDate.getTime() in the identity string prefix.',
+  },
+  {
+    file: 'src/services/analysis-core.ts',
+    line: 297,
+    reason: 'cluster date aggregation for firstSeen/lastUpdated metadata; not a per-item ranking comparator.',
+  },
+  {
+    file: 'src/services/clustering.ts',
+    line: 116,
+    reason: 'allDates aggregation for cluster firstSeen/lastUpdated metadata; not a per-item ranking comparator.',
+  },
+  {
+    file: 'src/services/trending-keywords.ts',
+    line: 271,
+    reason: 'headlineKey identity computation — used for dedupe, not freshness ranking.',
+  },
+  {
+    file: 'src/services/trending-keywords.ts',
+    line: 390,
+    reason: 'publishedAt record-keeping in headline registry; not a freshness comparator.',
+  },
+  {
+    file: 'src/app/data-loader.ts',
+    line: 3279,
+    reason: 'Cache serialization step — wraps pubDate.getTime() into the persisted entry payload, not a comparator.',
+  },
+];
+
+const PUBDATE_GETTIME_RE = /\.pubDate\s*\.getTime\(\)/;
+const EFFECTIVE_HELPER_RE = /effectivePubDateMs\b/;
+
+function listTsFiles(dir: string): string[] {
+  const abs = resolve(repoRoot, dir);
+  const out: string[] = [];
+  for (const entry of readdirSync(abs)) {
+    const full = resolve(abs, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      out.push(...listTsFiles(relative(repoRoot, full)));
+      continue;
+    }
+    if (!stat.isFile()) continue;
+    if (!entry.endsWith('.ts') && !entry.endsWith('.tsx')) continue;
+    if (entry.endsWith('.test.ts') || entry.endsWith('.test.tsx')) continue;
+    out.push(relative(repoRoot, full));
+  }
+  return out;
+}
+
+function isAllowed(file: string, line: number): boolean {
+  return ALLOW_LIST.some((a) => a.file === file && a.line === line);
+}
+
+describe('feed-date freshness guardrail — effectivePubDateMs usage', () => {
+  it('every .pubDate.getTime() in src/services + src/app is helper-routed or explicitly allow-listed', () => {
+    const violations: Array<{ file: string; line: number; text: string }> = [];
+
+    for (const dir of SCAN_DIRS) {
+      for (const file of listTsFiles(dir)) {
+        const src = readFileSync(resolve(repoRoot, file), 'utf8');
+        const lines = src.split('\n');
+        for (let i = 0; i < lines.length; i++) {
+          const text = lines[i]!;
+          if (!PUBDATE_GETTIME_RE.test(text)) continue;
+          // Skip JSDoc / line comments — these aren't executing code. A line
+          // beginning with `*` (JSDoc continuation) or `//` (line comment)
+          // is documentation, not a ranking call site. Block comments that
+          // contain the pattern on their own line (e.g. `* Returns ... .pubDate.
+          // getTime()`) are caught here too.
+          const trimmed = text.trim();
+          if (trimmed.startsWith('*') || trimmed.startsWith('//')) continue;
+          if (EFFECTIVE_HELPER_RE.test(text)) continue; // helper invoked nearby
+          if (isAllowed(file, i + 1)) continue;
+          violations.push({ file, line: i + 1, text: trimmed });
+        }
+      }
+    }
+
+    if (violations.length > 0) {
+      const lines = violations.map(
+        (v) => `  ${v.file}:${v.line}\n    ${v.text}`,
+      );
+      assert.fail(
+        `Found ${violations.length} raw .pubDate.getTime() call(s) in ranking/recency code that ` +
+          `do not route through effectivePubDateMs from src/services/feed-date.ts.\n\n` +
+          `Either:\n` +
+          `  1. Replace with effectivePubDateMs(item) so items with pubDateMissing get 0 and ` +
+          `fail freshness gates (recommended for any sort or recency check), OR\n` +
+          `  2. If this is a legitimate non-ranking use (metadata storage, identity key, ` +
+          `embedding index), add an entry to ALLOW_LIST in this test with a documented reason.\n\n` +
+          `Violations:\n${lines.join('\n')}`,
+      );
+    }
+  });
+
+  it('every ALLOW_LIST entry still matches a real line (catches drift)', () => {
+    const stale: string[] = [];
+    for (const entry of ALLOW_LIST) {
+      const src = readFileSync(resolve(repoRoot, entry.file), 'utf8');
+      const lines = src.split('\n');
+      const line = lines[entry.line - 1];
+      // Comments don't count as legitimate allow-list anchors — they don't
+      // execute. A pin to a comment line is always wrong.
+      const trimmed = line?.trim() ?? '';
+      const isComment = trimmed.startsWith('*') || trimmed.startsWith('//');
+      if (!line || !PUBDATE_GETTIME_RE.test(line) || isComment) {
+        stale.push(
+          `${entry.file}:${entry.line} — allow-list entry no longer matches an executable .pubDate.getTime() call. ` +
+            `Either the line moved (re-pin) or it was removed (drop from allow-list). Reason was: ${entry.reason}`,
+        );
+      }
+    }
+    if (stale.length > 0) {
+      assert.fail(`Stale allow-list entries:\n${stale.map((s) => `  - ${s}`).join('\n')}`);
+    }
+  });
+
+  // Self-fixtures: prove the regex matches BOTH shapes it claims to.
+  // Without these, a future regex simplification could silently stop
+  // matching one shape, and the audit would pass coincidentally because
+  // today's codebase happens to not have a violation in that shape.
+  it('PUBDATE_GETTIME_RE matches the sort-comparator shape', () => {
+    const sample = 'items.sort((a, b) => b.pubDate.getTime() - a.pubDate.getTime());';
+    assert.ok(PUBDATE_GETTIME_RE.test(sample));
+  });
+
+  it('PUBDATE_GETTIME_RE matches the recency-gate shape', () => {
+    const sample = 'if (Date.now() - item.pubDate.getTime() < windowMs) {}';
+    assert.ok(PUBDATE_GETTIME_RE.test(sample));
+  });
+
+  it('PUBDATE_GETTIME_RE does NOT match unrelated getTime calls', () => {
+    const sample = 'const t = otherDate.getTime();';
+    assert.ok(!PUBDATE_GETTIME_RE.test(sample));
+  });
+
+  it('EFFECTIVE_HELPER_RE matches a comparator using the helper', () => {
+    const sample = 'items.sort((a, b) => effectivePubDateMs(b) - effectivePubDateMs(a));';
+    assert.ok(EFFECTIVE_HELPER_RE.test(sample));
+  });
+});

--- a/tests/feed-date.test.mts
+++ b/tests/feed-date.test.mts
@@ -107,6 +107,19 @@ describe('effectivePubDateMs', () => {
     assert.equal(effectivePubDateMs({ pubDate: 'not a date' }), 0);
   });
 
+  it('returns 0 for NaN numeric pubDate', () => {
+    assert.equal(effectivePubDateMs({ pubDate: NaN }), 0);
+  });
+
+  it('returns 0 for Infinity numeric pubDate', () => {
+    assert.equal(effectivePubDateMs({ pubDate: Infinity }), 0);
+    assert.equal(effectivePubDateMs({ pubDate: -Infinity }), 0);
+  });
+
+  it('returns 0 for an Invalid Date instance', () => {
+    assert.equal(effectivePubDateMs({ pubDate: new Date('not a date') }), 0);
+  });
+
   describe('ranking behavior', () => {
     it('sorts missing-date items LAST in newest-first descending sort', () => {
       const items = [

--- a/tests/feed-date.test.mts
+++ b/tests/feed-date.test.mts
@@ -1,0 +1,142 @@
+/**
+ * Tests for src/services/feed-date.ts.
+ *
+ * Two surfaces:
+ *   - parseFeedDate: returns { date, missing } for any input shape.
+ *   - effectivePubDateMs: ranking/recency helper — returns 0 for items
+ *     flagged pubDateMissing so they fail freshness gates and sort last.
+ *
+ * Behaviour change from the legacy parseFeedDateOrNow:
+ *   - Old: substituted Date.now() silently for missing/invalid input.
+ *   - New: still returns a usable Date for display, but carries
+ *     `missing: true` so downstream ranking can exclude it from freshness.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  parseFeedDate,
+  parseFeedDateOrNow,
+  effectivePubDateMs,
+} from '../src/services/feed-date.ts';
+
+describe('parseFeedDate', () => {
+  it('parses a valid RFC 822 string', () => {
+    const result = parseFeedDate('Mon, 12 May 2026 14:32:00 GMT');
+    assert.equal(result.missing, false);
+    assert.equal(result.date.toISOString(), '2026-05-12T14:32:00.000Z');
+  });
+
+  it('parses a valid ISO-8601 string', () => {
+    const result = parseFeedDate('2026-05-12T14:32:00Z');
+    assert.equal(result.missing, false);
+    assert.equal(result.date.toISOString(), '2026-05-12T14:32:00.000Z');
+  });
+
+  it('flags null as missing', () => {
+    const result = parseFeedDate(null);
+    assert.equal(result.missing, true);
+    assert.ok(result.date instanceof Date);
+    assert.ok(!Number.isNaN(result.date.getTime()));
+  });
+
+  it('flags undefined as missing', () => {
+    const result = parseFeedDate(undefined);
+    assert.equal(result.missing, true);
+    assert.ok(result.date instanceof Date);
+  });
+
+  it('flags empty string as missing', () => {
+    const result = parseFeedDate('');
+    assert.equal(result.missing, true);
+  });
+
+  it('flags an unparseable string as missing', () => {
+    const result = parseFeedDate('garbage that is not a date');
+    assert.equal(result.missing, true);
+  });
+
+  it('flags an out-of-range date string as missing', () => {
+    // "32 May 2026" — Date constructor returns Invalid Date.
+    const result = parseFeedDate('32 May 2026');
+    assert.equal(result.missing, true);
+  });
+
+  it('legacy parseFeedDateOrNow still returns a Date (back-compat)', () => {
+    assert.ok(parseFeedDateOrNow('garbage') instanceof Date);
+    assert.ok(parseFeedDateOrNow(null) instanceof Date);
+    assert.ok(parseFeedDateOrNow('2026-05-12T00:00:00Z') instanceof Date);
+  });
+});
+
+describe('effectivePubDateMs', () => {
+  it('returns getTime() for Date pubDate without missing flag', () => {
+    const ts = new Date('2026-05-12T00:00:00Z').getTime();
+    assert.equal(
+      effectivePubDateMs({ pubDate: new Date(ts), pubDateMissing: false }),
+      ts,
+    );
+  });
+
+  it('returns getTime() when pubDateMissing is undefined (non-RSS items)', () => {
+    const ts = new Date('2026-05-12T00:00:00Z').getTime();
+    assert.equal(effectivePubDateMs({ pubDate: new Date(ts) }), ts);
+  });
+
+  it('returns 0 when pubDateMissing is true', () => {
+    const realTs = new Date('2026-05-12T00:00:00Z').getTime();
+    assert.equal(
+      effectivePubDateMs({ pubDate: new Date(realTs), pubDateMissing: true }),
+      0,
+    );
+  });
+
+  it('accepts a numeric pubDate (cache-deserialized shape)', () => {
+    const ts = new Date('2026-05-12T00:00:00Z').getTime();
+    assert.equal(effectivePubDateMs({ pubDate: ts }), ts);
+  });
+
+  it('accepts a string pubDate (legacy serialized shape)', () => {
+    assert.equal(
+      effectivePubDateMs({ pubDate: '2026-05-12T00:00:00Z' }),
+      new Date('2026-05-12T00:00:00Z').getTime(),
+    );
+  });
+
+  it('returns 0 for unparseable string pubDate', () => {
+    assert.equal(effectivePubDateMs({ pubDate: 'not a date' }), 0);
+  });
+
+  describe('ranking behavior', () => {
+    it('sorts missing-date items LAST in newest-first descending sort', () => {
+      const items = [
+        { pubDate: new Date('2026-05-10T00:00:00Z'), pubDateMissing: false },
+        { pubDate: new Date('2026-05-12T00:00:00Z'), pubDateMissing: true },
+        { pubDate: new Date('2026-05-11T00:00:00Z'), pubDateMissing: false },
+      ];
+      items.sort((a, b) => effectivePubDateMs(b) - effectivePubDateMs(a));
+      // First should be the latest REAL date (2026-05-11), then 2026-05-10,
+      // then the missing-date item even though its synthesized stamp is the
+      // newest of the three.
+      assert.equal(items[0]!.pubDate.toISOString(), '2026-05-11T00:00:00.000Z');
+      assert.equal(items[1]!.pubDate.toISOString(), '2026-05-10T00:00:00.000Z');
+      assert.equal(items[2]!.pubDateMissing, true);
+    });
+
+    it('excludes missing-date items from positive-duration recency gates', () => {
+      const now = Date.now();
+      const recentWindow = 15 * 60 * 1000;
+      const fresh = { pubDate: new Date(now - 5 * 60 * 1000), pubDateMissing: false };
+      const stale = { pubDate: new Date(now - 60 * 60 * 1000), pubDateMissing: false };
+      const missing = { pubDate: new Date(now), pubDateMissing: true };
+      const isRecent = (item: any) => now - effectivePubDateMs(item) < recentWindow;
+      assert.equal(isRecent(fresh), true);
+      assert.equal(isRecent(stale), false);
+      assert.equal(
+        isRecent(missing),
+        false,
+        'missing-date item must not claim freshness even though synthesized stamp is now',
+      );
+    });
+  });
+});

--- a/tests/railway-services-registry-coverage.test.mts
+++ b/tests/railway-services-registry-coverage.test.mts
@@ -1,0 +1,142 @@
+/**
+ * Coverage guardrail for scripts/railway-services.json — the single source
+ * of truth for every script that runs as a Railway service. This test fails
+ * if a deployment artifact in the repo (Dockerfile.* CMD line or runbook
+ * "Start command:" entry) references a script not present in the registry.
+ *
+ * Two BFS-style tests derive their entry lists from the registry:
+ *   - tests/scripts-railway-nixpacks-no-escape-import.test.mts (nixpacks)
+ *   - tests/dockerfile-digest-notifications-imports.test.mjs (Dockerfile)
+ *
+ * Without this coverage test, the registry would drift the same way the
+ * old hardcoded `ENTRY_POINTS` array did (PR #3836 retrospective): a new
+ * Railway service ships and nothing reminds the author to register it.
+ *
+ * Pattern source: test-ci-gotchas/reference/static-grep-audit-test-
+ * undertested-by-only-matching-one-shape — the self-fixture below tests
+ * the regex against both Dockerfile `CMD [...]` shape AND the runbook
+ * `Start command:` table-cell shape so a future regex simplification
+ * cannot silently stop matching one of them.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+interface RailwayServiceEntry {
+  entry: string;
+  deployMode: 'nixpacks-root-scripts' | 'dockerfile';
+  dockerfile?: string;
+  service: string;
+  documentedAt: string;
+}
+
+const registry = JSON.parse(
+  readFileSync(resolve(repoRoot, 'scripts/railway-services.json'), 'utf8'),
+) as RailwayServiceEntry[];
+
+const registryEntries = new Set(registry.map((r) => r.entry));
+const dockerfileMap = new Map(
+  registry
+    .filter((r) => r.deployMode === 'dockerfile' && r.dockerfile)
+    .map((r) => [r.dockerfile!, r.entry]),
+);
+
+// Match `CMD ["node", "scripts/<file>"]`. Captures the script path.
+const DOCKERFILE_CMD_RE = /^\s*CMD\s+\[\s*"node"\s*,\s*"(scripts\/[^"]+)"\s*\]/m;
+
+// Match runbook lines like `| **Start command** | \`node scripts/foo.mjs\` |`
+// (table-cell shape — multiple spaces, backtick quoting around the command).
+// Also tolerates `node` paths without backticks in case the runbook drifts.
+const RUNBOOK_START_RE = /\|\s*\*\*Start command\*\*\s*\|\s*`?node\s+(scripts\/\S+?\.(?:mjs|cjs|js))`?\s*\|/g;
+
+describe('Railway service registry coverage', () => {
+  it('every Dockerfile.* CMD has a matching registry entry', () => {
+    const dockerfiles = readdirSync(repoRoot)
+      .filter((f) => f.startsWith('Dockerfile.'))
+      .sort();
+
+    const missing: string[] = [];
+    for (const df of dockerfiles) {
+      const src = readFileSync(resolve(repoRoot, df), 'utf8');
+      const m = src.match(DOCKERFILE_CMD_RE);
+      if (!m) continue; // Dockerfile without a scripts/ CMD (e.g., relay multi-stage doesn't apply)
+      const entry = m[1]!;
+      const registered = dockerfileMap.get(df);
+      if (registered !== entry) {
+        missing.push(
+          `${df} runs '${entry}' but registry has ` +
+            (registered ? `'${registered}' for ${df}` : `no entry for ${df}`),
+        );
+      }
+    }
+
+    if (missing.length > 0) {
+      assert.fail(
+        `Dockerfile CMD lines drift from scripts/railway-services.json:\n` +
+          missing.map((m) => `  - ${m}`).join('\n') +
+          `\n\nEither add the missing entry to the registry (deployMode: ` +
+          `"dockerfile", dockerfile: "<Dockerfile.*>") or update the CMD ` +
+          `to match the registered script.`,
+      );
+    }
+  });
+
+  it('every runbook "Start command" references a registered script', () => {
+    const runbookPath = resolve(repoRoot, 'docs/railway-seed-consolidation-runbook.md');
+    const src = readFileSync(runbookPath, 'utf8');
+
+    const referenced = new Set<string>();
+    let m: RegExpExecArray | null;
+    RUNBOOK_START_RE.lastIndex = 0;
+    while ((m = RUNBOOK_START_RE.exec(src)) !== null) {
+      referenced.add(m[1]!);
+    }
+    assert.ok(
+      referenced.size > 0,
+      `Runbook regex matched zero entries — runbook format may have drifted. ` +
+        `Update RUNBOOK_START_RE.`,
+    );
+
+    const missing: string[] = [];
+    for (const entry of referenced) {
+      if (!registryEntries.has(entry)) {
+        missing.push(`runbook references '${entry}' but registry has no matching entry`);
+      }
+    }
+
+    if (missing.length > 0) {
+      assert.fail(
+        `Runbook entries drift from scripts/railway-services.json:\n` +
+          missing.map((s) => `  - ${s}`).join('\n') +
+          `\n\nAdd the missing entry to the registry (deployMode: ` +
+          `"nixpacks-root-scripts") or update the runbook.`,
+      );
+    }
+  });
+
+  // Self-fixture: prove BOTH regex shapes match what they're supposed to.
+  // Without this, a future "simplification" of either regex could silently
+  // stop matching one shape, and the audit above would pass coincidentally
+  // because today's repo happens to lack a violation. Pinned synthetic
+  // input ensures the audit stays load-bearing.
+  it('DOCKERFILE_CMD_RE matches the documented Dockerfile CMD shape', () => {
+    const sample = 'FROM node:22-alpine\nWORKDIR /app\nCMD ["node", "scripts/seed-fake.mjs"]\n';
+    const m = sample.match(DOCKERFILE_CMD_RE);
+    assert.ok(m, 'DOCKERFILE_CMD_RE failed to match canonical CMD shape');
+    assert.equal(m![1], 'scripts/seed-fake.mjs');
+  });
+
+  it('RUNBOOK_START_RE matches the documented runbook Start command shape', () => {
+    const sample = '| **Start command** | `node scripts/seed-fake.mjs` |\n';
+    RUNBOOK_START_RE.lastIndex = 0;
+    const m = RUNBOOK_START_RE.exec(sample);
+    assert.ok(m, 'RUNBOOK_START_RE failed to match canonical Start command shape');
+    assert.equal(m![1], 'scripts/seed-fake.mjs');
+  });
+});

--- a/tests/scripts-railway-nixpacks-no-escape-import.test.mts
+++ b/tests/scripts-railway-nixpacks-no-escape-import.test.mts
@@ -32,17 +32,27 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..');
 const scriptsDir = resolve(repoRoot, 'scripts');
 
-// Entry points that run under Railway nixpacks with `rootDirectory=scripts`.
-// PR #3836 review added `scripts/seed-insights.mjs` after a `../shared/`
-// import slipped through review (the test's pre-existing coverage stopped
-// at the three forecast/simulation services). Any new `scripts/*.mjs`
-// that ships as a Railway service MUST be added here.
-const ENTRY_POINTS = [
-  'scripts/seed-forecasts.mjs',
-  'scripts/process-simulation-tasks.mjs',
-  'scripts/process-deep-forecast-tasks.mjs',
-  'scripts/seed-insights.mjs',
-];
+// Entry points derived from scripts/railway-services.json, the single
+// source of truth for every script that runs as a Railway service. New
+// services are added by editing the registry, NOT this array. The
+// companion test tests/railway-services-registry-coverage.test.mts fails
+// if any Dockerfile.* or runbook entry references a script that isn't
+// in the registry — that's how drift is caught.
+interface RailwayServiceEntry {
+  entry: string;
+  deployMode: 'nixpacks-root-scripts' | 'dockerfile';
+  dockerfile?: string;
+  service: string;
+  documentedAt: string;
+}
+
+const registry = JSON.parse(
+  readFileSync(resolve(repoRoot, 'scripts/railway-services.json'), 'utf8'),
+) as RailwayServiceEntry[];
+
+const ENTRY_POINTS = registry
+  .filter((r) => r.deployMode === 'nixpacks-root-scripts')
+  .map((r) => r.entry);
 
 const IMPORT_RE = /(?:^|[\s;])(?:import\b[\s\S]*?\bfrom|import|export\b[\s\S]*?\bfrom)\s+['"]([^'"]+)['"]/gm;
 


### PR DESCRIPTION
## Summary

External audit (`deep-research-report (7).md`) flagged 11 candidate issues in the WM news/digest pipeline. Verification rejected 7 (stale claims, file-name domain confusion, or fixes already shipped) and validated 4 actionable items. This PR ships all four, plus one additional production violation surfaced during execution.

Plan: `docs/plans/2026-05-23-001-fix-digest-pipeline-review-actions-plan.md` (Codex-approved after 4 rounds of review).

## What changed (one commit per unit)

### U1 — CI hardening (`27f9ffebf`)
- New PR-gated `digest-image` job in `.github/workflows/test.yml` runs `docker build -f Dockerfile.digest-notifications` on every PR touching `scripts/`, `shared/`, `server/_shared/`, `api/`, `Dockerfile.digest-notifications`, or the root package manifest. Catches the native-dep + cross-directory-import breakage class that the static BFS test cannot see.
- New `.github/workflows/feed-validation.yml` runs `npm run test:feeds:ci` on `push` to main, every 6h cron, and `workflow_dispatch` — but NOT `pull_request`, closing the SSRF surface where a hostile PR could rewrite `src/config/feeds.ts` to make runners hit arbitrary URLs.
- `scripts/validate-rss-feeds.mjs` gains a `--ci` flag enforcing (a) https-only URLs, (b) hostname allowlist via the extracted predicate, (c) per-hop redirect re-check.
- Predicate extracted to `api/_rss-allowed-domain-match.js` (NOT `shared/` — Edge constraint: `api/*.js` cannot import from `../shared`). Both `api/rss-proxy.js` and the validator consume it.

### U2 — Railway service registry (`e2099d7a3`)
- New `scripts/railway-services.json` is the single source of truth for every Railway-deployed script. Surfaces **17 nixpacks services** (the hand-maintained `ENTRY_POINTS` array previously covered 4) and 4 Dockerfile-deployed services.
- `tests/scripts-railway-nixpacks-no-escape-import.test.mts` and `tests/dockerfile-digest-notifications-imports.test.mjs` now derive their entry lists from the registry, filtered by `deployMode`.
- New `tests/railway-services-registry-coverage.test.mts` fails if any `Dockerfile.*` `CMD ["node", …]` line or runbook "Start command:" entry references a script not in the registry. Self-fixtures pin both regex shapes per the static-grep audit pattern from the `test-ci-gotchas` skill.
- Runbook (`docs/railway-seed-consolidation-runbook.md`) header now points new-service authors at the registry.

### U3 — Feed-date freshness (`9b79fe4c9`)
- `parseFeedDateOrNow` (which silently substituted `Date.now()` for missing/invalid input) is replaced by `parseFeedDate` returning `{ date, missing }` and a new `effectivePubDateMs(item)` helper that returns `0` for `pubDateMissing` items. Display consumers still see a valid Date; ranking/recency consumers exclude missing-date items from freshness.
- Routed through the helper:
  - `rss.ts` AI-candidate top-N selection + min-heap insert
  - `daily-market-brief.ts` headline-pool sort
  - `breaking-news-alerts.ts` `isRecent` recency gate + best-alert ranking
  - `data-loader.ts` 6 freshness sort sites + time-range filter
  - `panel-layout.ts:1681` time-range filter (audit-caught — NOT in the original plan enumeration)
  - `velocity.ts` trend-midpoint partition
  - `analysis-core.ts` cluster sort + `WINDOW_MS` recency gate
- Cache prefix bumped `feed:` → `feed:v2:` because pre-v2 serialized items lack `pubDateMissing`.
- New `tests/feed-date.test.mts` covers parser shapes + helper ranking behavior.
- New `tests/feed-date-ranking-uses-effective.test.mts` walks `src/services/` + `src/app/` and fails if any `.pubDate.getTime()` inside a ranking/recency call site bypasses the helper. Documented allow-list for metadata/identity uses. Self-fixtures pin both sort-comparator and recency-gate regex shapes.

### U4 — AI-classify queue identity (`eb141bb5e`)
- `canQueueAiClassification(title)` → `canQueueAiClassification({ link, title })`. Identity prefers the normalized link (lowercased host, fragments dropped, `utm_*`/`fbclid`/`gclid` stripped); falls back to title when link is empty or malformed. Stops collapsing distinct articles sharing a wire headline into one dedupe slot.
- New `__resetAiClassifyQueueForTests()` export following the `__…ForTests` convention from `insights-loader.ts:104` so the test file's `beforeEach` can isolate module state.
- Import switched from `@/config` barrel to `@/config/variant` leaf to avoid pulling `import.meta.env.DEV` through the proxy.ts chain under `node:test`.

## What did NOT change

Audit claims rejected during verification (kept for future-reader visibility):

1. **`insights-loader.ts` 15-min stale gate** — already fixed to 60min via PR #3827 (`fetchServerInsights` on-demand fallback). Report's headline finding was stale.
2. **U7 institutional denylist** — conservative-by-design (host AND curated path prefix); recommendation to "downgrade with allow-rules for press releases" would re-introduce contamination.
3. **`shared/rss-allowed-domains.json` as editorial admission** — it's the SSRF guard for the rss-proxy Edge function, not an editorial gate. (The real four-mirror sync trap is captured in the `worldmonitor-architecture-gotchas` skill.)
4. **`brief-envelope.d.ts` v4 `clusterId` synthesis** — no evidence of write failures; current composer populates it.
5. **Drop-reason telemetry destination** — already wired to stdout via `seed-digest-notifications.mjs:1700-1715`; Railway log search is the destination.
6. **`scripts/_pipeline-dedup.mjs` / `_prediction-scoring.mjs` audit** — unrelated to news (GEM oil/gas pipelines + Polymarket prediction markets). Report mis-attributed by filename inference.
7. **Atom:id/guid identity stack** — RSS parser doesn't currently extract those fields; deferred. U4's link-keyed identity is the minimum-viable improvement.

## Test plan

- [x] `npm run test:data` — **9471 passing, 0 failing** (39 new tests across U2/U3/U4)
- [x] `npm run typecheck:all` — clean
- [x] Biome lint on touched files — 0 errors, 6 pre-existing complexity warnings (unrelated)
- [x] Each unit committed atomically with conventional message
- [x] Manual `tsx --test` of new test files passing locally

## Out of scope (deferred to follow-ups)

- Auto-discovery of Railway service registry entries from `Dockerfile.*` CMD lines (would eliminate the manual registry edit step).
- Sentry/Slack alerting on the existing drop-reason stdout stream (currently surfaces via Railway log search only).
- atom:id/guid identity stack in the RSS parser (would deepen U4's identity hierarchy).