### PR TITLE
test(mcp): per-tool byte-budget regression suite

### DIFF
--- a/scripts/mcp-budget-check.mjs
+++ b/scripts/mcp-budget-check.mjs
@@ -15,46 +15,33 @@
  * This is the same chain `dispatchToolsCall` measures against
  * `_outputBudgetBytes` at runtime (api/mcp.ts — search `textBytes > budget`),
  * restricted to the default-args identity path (no JMESPath projection, no
- * `summary: true`). Matching the byte count is the property the regression
- * test asserts (`tests/mcp-output-budget.test.mjs`).
+ * `summary: true`).
+ *
+ * The fixture mapping, `KNOWN_OVER_BUDGET` exclusion list, and measurement
+ * function are shared with `tests/mcp-output-budget.test.mjs` via
+ * `tests/helpers/mcp-output-budget.mjs`, so the script and test cannot drift.
+ *
+ * Exit code: non-zero on any of the three failure modes the test gates on —
+ *   - `over`   tool exceeds budget AND is not in KNOWN_OVER_BUDGET
+ *   - `stale`  tool listed in KNOWN_OVER_BUDGET is now under budget
+ *              (the exclusion entry must be deleted)
+ *   - dead    KNOWN_OVER_BUDGET names a tool with no fixture in this suite
+ *   - `missing-tool` / `missing-file` (lookup failures)
+ * Same gating semantics as the test, so the script doubles as a standalone
+ * CI check.
  *
  * Direct-invocation strategy: identical to `measure-jmespath-savings.mjs`.
  * Reads the fixture, runs the filter in-process. No `mcpHandler`, no cache
  * round-trip, no fetch mocking. Deterministic: same fixtures → byte-identical
  * numbers every run.
  *
- * Exit code: non-zero if any tool exceeds its declared `_outputBudgetBytes`
- * AND is NOT listed in KNOWN_OVER_BUDGET. Mirrors the gating semantics of
- * the test so the script doubles as a standalone CI check.
- *
  * Usage:
  *   npx tsx scripts/mcp-budget-check.mjs
  */
-import { readFileSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { __testing__, utf8ByteLength } from '../api/mcp.ts';
-
-const HERE = dirname(fileURLToPath(import.meta.url));
-const ROOT = resolve(HERE, '..');
-const FIXTURES_DIR = resolve(ROOT, 'tests/fixtures/jmespath-samples');
-
-// Fixture → tool mapping. Kept in lockstep with the same const in
-// `tests/mcp-output-schema-coverage.test.mjs` and
-// `tests/mcp-output-budget.test.mjs`.
-const FIXTURES = [
-  { file: 'fat-get-market-data.response.json', tool: 'get_market_data' },
-  { file: 'medium-get-conflict-events.response.json', tool: 'get_conflict_events' },
-  { file: 'thin-get-chokepoint-status.response.json', tool: 'get_chokepoint_status' },
-];
-
-// Tools whose default-args envelope is currently over its declared
-// `_outputBudgetBytes` and which the runtime gate is therefore already
-// rejecting in production with the `_budget_exceeded` envelope.
-// Keep in sync with the same const in `tests/mcp-output-budget.test.mjs`.
-const KNOWN_OVER_BUDGET = new Set([
-  'get_market_data',
-]);
+import {
+  KNOWN_OVER_BUDGET,
+  runBudgetChecks,
+} from '../tests/helpers/mcp-output-budget.mjs';
 
 function fmtBytes(n) {
   if (typeof n !== 'number' || !Number.isFinite(n)) return String(n);
@@ -62,47 +49,54 @@ function fmtBytes(n) {
   return `${(n / 1024).toFixed(1)} KB`;
 }
 
-function measure(tool, fixture) {
-  const filtered = tool._postFilter
-    ? tool._postFilter(structuredClone(fixture.data), {})
-    : fixture.data;
-  const envelope = { cached_at: fixture.cached_at, stale: fixture.stale, data: filtered };
-  return utf8ByteLength(JSON.stringify(envelope));
-}
+const { rows, deadEntries } = runBudgetChecks();
 
-const rows = [];
-let unexpectedOver = false;
-for (const { file, tool: toolName } of FIXTURES) {
-  const tool = __testing__.TOOL_REGISTRY.find((t) => t.name === toolName);
-  if (!tool) {
-    rows.push({ tool: toolName, budget: '—', observed: 'tool not in registry', headroom: '—', status: 'ERR' });
-    unexpectedOver = true;
-    continue;
+let anyFailure = false;
+const tableRows = [];
+for (const r of rows) {
+  let budgetCell = typeof r.budget === 'number' ? fmtBytes(r.budget) : '—';
+  let observedCell;
+  let headroomCell = '—';
+  let statusCell;
+  switch (r.status) {
+    case 'ok':
+      observedCell = fmtBytes(r.observed);
+      headroomCell = `${(((r.budget - r.observed) / r.budget) * 100).toFixed(1)}%`;
+      statusCell = 'OK';
+      break;
+    case 'known-over':
+      observedCell = fmtBytes(r.observed);
+      headroomCell = `${(((r.budget - r.observed) / r.budget) * 100).toFixed(1)}%`;
+      statusCell = `OVER by ${r.observed - r.budget} B (known)`;
+      break;
+    case 'over':
+      observedCell = fmtBytes(r.observed);
+      headroomCell = `${(((r.budget - r.observed) / r.budget) * 100).toFixed(1)}%`;
+      statusCell = `OVER by ${r.observed - r.budget} B`;
+      anyFailure = true;
+      break;
+    case 'stale':
+      observedCell = fmtBytes(r.observed);
+      headroomCell = `${(((r.budget - r.observed) / r.budget) * 100).toFixed(1)}%`;
+      statusCell = `STALE — delete KNOWN_OVER_BUDGET entry (UNDER by ${r.budget - r.observed} B)`;
+      anyFailure = true;
+      break;
+    case 'missing-tool':
+      observedCell = 'tool not in registry';
+      statusCell = 'ERR';
+      anyFailure = true;
+      break;
+    case 'missing-file':
+      observedCell = `fixture missing: ${r.error}`;
+      statusCell = 'ERR';
+      anyFailure = true;
+      break;
+    default:
+      observedCell = '?';
+      statusCell = `unknown status: ${r.status}`;
+      anyFailure = true;
   }
-  let fixture;
-  try {
-    fixture = JSON.parse(readFileSync(resolve(FIXTURES_DIR, file), 'utf8'));
-  } catch (e) {
-    const note = e.code === 'ENOENT' ? 'fixture missing' : e.message;
-    rows.push({ tool: toolName, budget: tool._outputBudgetBytes, observed: note, headroom: '—', status: 'ERR' });
-    unexpectedOver = true;
-    continue;
-  }
-  const observed = measure(tool, fixture);
-  const budget = tool._outputBudgetBytes;
-  const headroomPct = budget > 0 ? ((budget - observed) / budget) * 100 : 0;
-  let status;
-  if (observed > budget) {
-    if (KNOWN_OVER_BUDGET.has(toolName)) {
-      status = `OVER by ${observed - budget} B (known)`;
-    } else {
-      status = `OVER by ${observed - budget} B`;
-      unexpectedOver = true;
-    }
-  } else {
-    status = 'OK';
-  }
-  rows.push({ tool: toolName, budget, observed, headroom: headroomPct, status });
+  tableRows.push(`| \`${r.tool}\` | ${budgetCell} | ${observedCell} | ${headroomCell} | ${statusCell} |`);
 }
 
 const lines = [
@@ -112,17 +106,28 @@ const lines = [
   '',
   '| Tool | Budget | Observed | Headroom | Status |',
   '|---|---:|---:|---:|---|',
-];
-for (const r of rows) {
-  const budget = typeof r.budget === 'number' ? fmtBytes(r.budget) : r.budget;
-  const observed = typeof r.observed === 'number' ? fmtBytes(r.observed) : r.observed;
-  const headroom = typeof r.headroom === 'number' ? `${r.headroom.toFixed(1)}%` : r.headroom;
-  lines.push(`| \`${r.tool}\` | ${budget} | ${observed} | ${headroom} | ${r.status} |`);
-}
-lines.push(
+  ...tableRows,
   '',
   'Measurement: `utf8ByteLength(JSON.stringify({cached_at, stale, data: _postFilter(data, {})}))` — the same chain the runtime budget gate measures (default-args identity path; no JMESPath, no summary).',
-);
+];
 process.stdout.write(lines.join('\n') + '\n');
 
-process.exit(unexpectedOver ? 1 : 0);
+if (deadEntries.length > 0) {
+  process.stderr.write(
+    `\nERR: KNOWN_OVER_BUDGET entries reference tools with no fixture in this suite: ${deadEntries.join(', ')}\n  -> remove the dead entries from tests/helpers/mcp-output-budget.mjs.\n`,
+  );
+  anyFailure = true;
+}
+
+// Surface the documented reason for any known-over rows on stderr so a dev
+// running the script locally sees the issue context without polluting the
+// stdout markdown table (which is meant to be pasteable into PR bodies).
+for (const r of rows) {
+  if (r.status === 'known-over') {
+    process.stderr.write(
+      `\nKNOWN over-budget: ${r.tool} observed=${r.observed} budget=${r.budget} delta=+${r.observed - r.budget}B\n  -> ${KNOWN_OVER_BUDGET.get(r.tool)}\n`,
+    );
+  }
+}
+
+process.exit(anyFailure ? 1 : 0);

--- a/scripts/mcp-budget-check.mjs
+++ b/scripts/mcp-budget-check.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * Reproducible per-tool output byte-budget measurement.
+ *
+ * Reads checked-in tool-response fixtures from
+ * `tests/fixtures/jmespath-samples/` and replays the runtime byte-accounting
+ * pipeline against each:
+ *
+ *   fixture.data
+ *     → tool._postFilter(structuredClone(fixture.data), {})   // skipped if no _postFilter
+ *     → { cached_at, stale, data: filtered }                  // reassembled envelope
+ *     → JSON.stringify(envelope)
+ *     → utf8ByteLength(...)
+ *
+ * This is the same chain `dispatchToolsCall` measures against
+ * `_outputBudgetBytes` at runtime (api/mcp.ts — search `textBytes > budget`),
+ * restricted to the default-args identity path (no JMESPath projection, no
+ * `summary: true`). Matching the byte count is the property the regression
+ * test asserts (`tests/mcp-output-budget.test.mjs`).
+ *
+ * Direct-invocation strategy: identical to `measure-jmespath-savings.mjs`.
+ * Reads the fixture, runs the filter in-process. No `mcpHandler`, no cache
+ * round-trip, no fetch mocking. Deterministic: same fixtures → byte-identical
+ * numbers every run.
+ *
+ * Exit code: non-zero if any tool exceeds its declared `_outputBudgetBytes`
+ * AND is NOT listed in KNOWN_OVER_BUDGET. Mirrors the gating semantics of
+ * the test so the script doubles as a standalone CI check.
+ *
+ * Usage:
+ *   npx tsx scripts/mcp-budget-check.mjs
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { __testing__, utf8ByteLength } from '../api/mcp.ts';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '..');
+const FIXTURES_DIR = resolve(ROOT, 'tests/fixtures/jmespath-samples');
+
+// Fixture → tool mapping. Kept in lockstep with the same const in
+// `tests/mcp-output-schema-coverage.test.mjs` and
+// `tests/mcp-output-budget.test.mjs`.
+const FIXTURES = [
+  { file: 'fat-get-market-data.response.json', tool: 'get_market_data' },
+  { file: 'medium-get-conflict-events.response.json', tool: 'get_conflict_events' },
+  { file: 'thin-get-chokepoint-status.response.json', tool: 'get_chokepoint_status' },
+];
+
+// Tools whose default-args envelope is currently over its declared
+// `_outputBudgetBytes` and which the runtime gate is therefore already
+// rejecting in production with the `_budget_exceeded` envelope.
+// Keep in sync with the same const in `tests/mcp-output-budget.test.mjs`.
+const KNOWN_OVER_BUDGET = new Set([
+  'get_market_data',
+]);
+
+function fmtBytes(n) {
+  if (typeof n !== 'number' || !Number.isFinite(n)) return String(n);
+  if (n < 1024) return `${n} B`;
+  return `${(n / 1024).toFixed(1)} KB`;
+}
+
+function measure(tool, fixture) {
+  const filtered = tool._postFilter
+    ? tool._postFilter(structuredClone(fixture.data), {})
+    : fixture.data;
+  const envelope = { cached_at: fixture.cached_at, stale: fixture.stale, data: filtered };
+  return utf8ByteLength(JSON.stringify(envelope));
+}
+
+const rows = [];
+let unexpectedOver = false;
+for (const { file, tool: toolName } of FIXTURES) {
+  const tool = __testing__.TOOL_REGISTRY.find((t) => t.name === toolName);
+  if (!tool) {
+    rows.push({ tool: toolName, budget: '—', observed: 'tool not in registry', headroom: '—', status: 'ERR' });
+    unexpectedOver = true;
+    continue;
+  }
+  let fixture;
+  try {
+    fixture = JSON.parse(readFileSync(resolve(FIXTURES_DIR, file), 'utf8'));
+  } catch (e) {
+    const note = e.code === 'ENOENT' ? 'fixture missing' : e.message;
+    rows.push({ tool: toolName, budget: tool._outputBudgetBytes, observed: note, headroom: '—', status: 'ERR' });
+    unexpectedOver = true;
+    continue;
+  }
+  const observed = measure(tool, fixture);
+  const budget = tool._outputBudgetBytes;
+  const headroomPct = budget > 0 ? ((budget - observed) / budget) * 100 : 0;
+  let status;
+  if (observed > budget) {
+    if (KNOWN_OVER_BUDGET.has(toolName)) {
+      status = `OVER by ${observed - budget} B (known)`;
+    } else {
+      status = `OVER by ${observed - budget} B`;
+      unexpectedOver = true;
+    }
+  } else {
+    status = 'OK';
+  }
+  rows.push({ tool: toolName, budget, observed, headroom: headroomPct, status });
+}
+
+const lines = [
+  '## Per-tool output budget — observed vs declared',
+  '',
+  '_Reproducible. Same fixtures → byte-identical numbers every run._',
+  '',
+  '| Tool | Budget | Observed | Headroom | Status |',
+  '|---|---:|---:|---:|---|',
+];
+for (const r of rows) {
+  const budget = typeof r.budget === 'number' ? fmtBytes(r.budget) : r.budget;
+  const observed = typeof r.observed === 'number' ? fmtBytes(r.observed) : r.observed;
+  const headroom = typeof r.headroom === 'number' ? `${r.headroom.toFixed(1)}%` : r.headroom;
+  lines.push(`| \`${r.tool}\` | ${budget} | ${observed} | ${headroom} | ${r.status} |`);
+}
+lines.push(
+  '',
+  'Measurement: `utf8ByteLength(JSON.stringify({cached_at, stale, data: _postFilter(data, {})}))` — the same chain the runtime budget gate measures (default-args identity path; no JMESPath, no summary).',
+);
+process.stdout.write(lines.join('\n') + '\n');
+
+process.exit(unexpectedOver ? 1 : 0);

--- a/tests/helpers/mcp-output-budget.mjs
+++ b/tests/helpers/mcp-output-budget.mjs
@@ -1,0 +1,108 @@
+// Shared single-source-of-truth for `tests/mcp-output-budget.test.mjs` and
+// `scripts/mcp-budget-check.mjs`. Holds the fixture→tool mapping, the
+// `KNOWN_OVER_BUDGET` exclusion map, the measurement function, and the
+// composite check used by both consumers so they cannot drift.
+//
+// Why one module: when the same gate was inlined in both files, the
+// `Map` / `Set` shapes drifted, the script's exit code skipped the
+// stale-entry + dead-entry guards the test enforces, and the
+// "Keep in sync" comments were a manual contract no one would catch
+// breaking. Single source eliminates all three.
+
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { __testing__, utf8ByteLength } from '../../api/mcp.ts';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+export const FIXTURES_DIR = path.resolve(HERE, '..', 'fixtures', 'jmespath-samples');
+
+// (fixture file, tool name). Add a row when capturing a new fixture under
+// `tests/fixtures/jmespath-samples/`. Each entry is automatically picked up
+// by both the test (one node-test case per entry) and the script (one row
+// in the markdown table).
+export const FIXTURES = [
+  { file: 'fat-get-market-data.response.json', tool: 'get_market_data' },
+  { file: 'medium-get-conflict-events.response.json', tool: 'get_conflict_events' },
+  { file: 'thin-get-chokepoint-status.response.json', tool: 'get_chokepoint_status' },
+];
+
+// Tools whose default-args envelope is currently over their declared
+// `_outputBudgetBytes`. Each entry: tool name → reason + deletion criterion.
+// The bidirectional guards in `runBudgetChecks` (below) ensure entries can't
+// go stale: a tool that drops back under budget while still listed here
+// fails the check; a tool listed here without a fixture in `FIXTURES` also
+// fails. Remove an entry once the underlying tool is brought back under
+// budget.
+export const KNOWN_OVER_BUDGET = new Map([
+  ['get_market_data',
+    'commodities-bootstrap ships 30 quotes per the universal default `limit` — that single key alone is ~133 KB, more than the entire 128 KB budget. Default-args calls currently return the runtime `_budget_exceeded` envelope. Delete this entry once the per-key default cap is tightened (or the per-tool budget raised with justification) so the envelope fits under budget.'],
+]);
+
+export function readFixture(file) {
+  return JSON.parse(readFileSync(path.join(FIXTURES_DIR, file), 'utf8'));
+}
+
+// Replays the runtime byte-accounting pipeline (`dispatchToolsCall`,
+// default-args identity path: no JMESPath, no `summary: true`) against a
+// captured fixture envelope and returns the byte count the runtime gate
+// would compare against `tool._outputBudgetBytes`.
+export function measure(tool, fixture) {
+  const filtered = tool._postFilter
+    ? tool._postFilter(structuredClone(fixture.data), {})
+    : fixture.data;
+  const envelope = { cached_at: fixture.cached_at, stale: fixture.stale, data: filtered };
+  return utf8ByteLength(JSON.stringify(envelope));
+}
+
+// Per-fixture outcome categories. The two consumers (test + script) map
+// each row to their own surface (assertion vs printed status), but the
+// classification logic lives here so both agree on what counts as a
+// failure.
+//
+//   ok            — observed ≤ budget, tool not in KNOWN_OVER_BUDGET
+//   over          — observed > budget, tool not in KNOWN_OVER_BUDGET (FAIL)
+//   known-over    — observed > budget, tool in KNOWN_OVER_BUDGET (allowed)
+//   stale         — observed ≤ budget, tool in KNOWN_OVER_BUDGET (FAIL —
+//                   delete the entry)
+//   missing-tool  — tool name not found in TOOL_REGISTRY (FAIL)
+//   missing-file  — fixture file not present on disk (FAIL)
+export function classify(observed, budget, toolName, knownOverBudget = KNOWN_OVER_BUDGET) {
+  const isKnown = knownOverBudget.has(toolName);
+  const over = observed > budget;
+  if (over && isKnown) return 'known-over';
+  if (over) return 'over';
+  if (!over && isKnown) return 'stale';
+  return 'ok';
+}
+
+// Run all (fixture, tool) measurements PLUS the dead-entry guard. Returns a
+// list of row records the consumers render however they want. The test
+// turns each row into an assertion; the script turns each row into a
+// markdown row + an exit code.
+export function runBudgetChecks() {
+  const rows = [];
+  for (const { file, tool: toolName } of FIXTURES) {
+    const tool = __testing__.TOOL_REGISTRY.find((t) => t.name === toolName);
+    if (!tool) {
+      rows.push({ file, tool: toolName, status: 'missing-tool', budget: null, observed: null });
+      continue;
+    }
+    let fixture;
+    try {
+      fixture = readFixture(file);
+    } catch (e) {
+      rows.push({ file, tool: toolName, status: 'missing-file', budget: tool._outputBudgetBytes, observed: null, error: e.message });
+      continue;
+    }
+    const observed = measure(tool, fixture);
+    const budget = tool._outputBudgetBytes;
+    rows.push({ file, tool: toolName, status: classify(observed, budget, toolName), budget, observed });
+  }
+  // Dead-entry guard: every KNOWN_OVER_BUDGET name must reference a tool
+  // with a fixture in this file (unfalsifiable exclusions = silent risk).
+  const fixtureTools = new Set(FIXTURES.map((f) => f.tool));
+  const dead = [...KNOWN_OVER_BUDGET.keys()].filter((name) => !fixtureTools.has(name));
+  return { rows, deadEntries: dead };
+}

--- a/tests/mcp-output-budget.test.mjs
+++ b/tests/mcp-output-budget.test.mjs
@@ -24,95 +24,71 @@
 // picked up by this test the next CI run. Mocked-response contract coverage
 // for the other tools is a separate follow-up.
 //
-// `KNOWN_OVER_BUDGET` documents tools that currently exceed their declared
-// budget on default args. Each entry is a known-issue exception with a
-// recorded reason and a deletion criterion. The exclusion is itself
-// regression-signal: a NEW over-budget tool (not in the map) fails the test;
-// an exclusion that becomes obsolete (tool now under budget) ALSO fails so
-// the entry can't go stale and mask a future regression.
+// `KNOWN_OVER_BUDGET` (in `tests/helpers/mcp-output-budget.mjs`) documents
+// tools that currently exceed their declared budget on default args. The
+// `tests/helpers/mcp-output-budget.mjs` module is the single source of truth
+// — `scripts/mcp-budget-check.mjs` shares the same map and applies the same
+// gating semantics, so the two cannot drift.
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
-import { __testing__, utf8ByteLength } from '../api/mcp.ts';
-
-const FIXTURES_DIR = path.join(
-  path.dirname(fileURLToPath(import.meta.url)),
-  'fixtures',
-  'jmespath-samples',
-);
-
-// Kept in lockstep with `tests/mcp-output-schema-coverage.test.mjs` and
-// `scripts/mcp-budget-check.mjs`. Three rows — duplicating is cheaper than
-// threading a shared module just for this.
-const FIXTURES = [
-  { file: 'fat-get-market-data.response.json', tool: 'get_market_data' },
-  { file: 'medium-get-conflict-events.response.json', tool: 'get_conflict_events' },
-  { file: 'thin-get-chokepoint-status.response.json', tool: 'get_chokepoint_status' },
-];
-
-// Tools whose default-args envelope is currently over its declared
-// `_outputBudgetBytes` and which the runtime gate is therefore already
-// rejecting in production with the `_budget_exceeded` envelope. Each entry
-// MUST be deleted once the underlying tool is brought back under budget,
-// otherwise the exclusion masks future regressions (the test guards both
-// directions — see `KNOWN_OVER_BUDGET entry is now stale` below).
-//
-// Keep in sync with the same const in `scripts/mcp-budget-check.mjs`.
-const KNOWN_OVER_BUDGET = new Map([
-  ['get_market_data',
-    'commodities-bootstrap ships 30 quotes per the universal default `limit` — that single key alone is ~133 KB, more than the entire 128 KB budget. Default-args calls currently return the runtime `_budget_exceeded` envelope. Delete this entry once the per-key default cap is tightened (or the per-tool budget raised with justification) so the envelope fits under budget.'],
-]);
+import {
+  FIXTURES,
+  KNOWN_OVER_BUDGET,
+  runBudgetChecks,
+} from './helpers/mcp-output-budget.mjs';
 
 describe('api/mcp.ts — per-tool output byte-budget regression (v1.7.0)', () => {
+  const { rows, deadEntries } = runBudgetChecks();
+  const rowByTool = new Map(rows.map((r) => [r.tool, r]));
+
   // Dead-entry guard: a KNOWN_OVER_BUDGET name that doesn't appear in
-  // FIXTURES can't be measured, so the exclusion is unfalsifiable and must
-  // be removed. (When a new fixture is added in the future and exposes a
-  // genuine over-budget tool, the dev will add both the fixture AND a
-  // KNOWN_OVER_BUDGET entry — this guard prevents adding the entry alone.)
-  it('every KNOWN_OVER_BUDGET entry names a tool with a fixture in this file', () => {
-    const fixtureTools = new Set(FIXTURES.map((f) => f.tool));
-    const dead = [...KNOWN_OVER_BUDGET.keys()].filter((name) => !fixtureTools.has(name));
-    assert.deepEqual(dead, [], `KNOWN_OVER_BUDGET names tools without a fixture: ${dead.join(', ')}`);
+  // FIXTURES is unfalsifiable and must be removed. (Future fixture additions
+  // will include a paired KNOWN_OVER_BUDGET entry if needed — this prevents
+  // adding the exclusion alone.)
+  it('every KNOWN_OVER_BUDGET entry names a tool with a fixture in this suite', () => {
+    assert.deepEqual(
+      deadEntries,
+      [],
+      `KNOWN_OVER_BUDGET names tools without a fixture: ${deadEntries.join(', ')}`,
+    );
   });
 
   for (const { file, tool: toolName } of FIXTURES) {
     it(`${toolName}: default-args response stays under _outputBudgetBytes (${file})`, () => {
-      const tool = __testing__.TOOL_REGISTRY.find((t) => t.name === toolName);
-      assert.ok(tool, `tool ${toolName} not found in TOOL_REGISTRY`);
+      const row = rowByTool.get(toolName);
+      assert.ok(row, `no row produced for ${toolName}`);
 
-      const fixture = JSON.parse(readFileSync(path.join(FIXTURES_DIR, file), 'utf8'));
-      const filtered = tool._postFilter
-        ? tool._postFilter(structuredClone(fixture.data), {})
-        : fixture.data;
-      const envelope = { cached_at: fixture.cached_at, stale: fixture.stale, data: filtered };
-      const observed = utf8ByteLength(JSON.stringify(envelope));
-      const budget = tool._outputBudgetBytes;
-      const delta = observed - budget;
-
-      if (KNOWN_OVER_BUDGET.has(toolName)) {
-        // Expected over-budget. If the observation is now under budget, the
-        // entry is stale and must be removed — otherwise the exclusion
-        // would silently absorb a future regression.
-        assert.ok(
-          delta > 0,
-          `${toolName}: observed=${observed} bytes, budget=${budget} bytes (UNDER by ${-delta}). KNOWN_OVER_BUDGET entry is now stale — delete it from this file so the standard over-budget assertion gates this tool again.`,
-        );
-        // Still over, as expected. Surface the known-issue context so a dev
-        // running the suite locally sees why it's allowed.
-        process.stderr.write(
-          `[mcp-output-budget] KNOWN over-budget: ${toolName} observed=${observed} budget=${budget} delta=+${delta}B — ${KNOWN_OVER_BUDGET.get(toolName)}\n`,
-        );
-        return;
+      switch (row.status) {
+        case 'ok':
+          return;
+        case 'missing-tool':
+          assert.fail(`tool ${toolName} not found in TOOL_REGISTRY`);
+          break;
+        case 'missing-file':
+          assert.fail(`fixture ${file} missing: ${row.error}`);
+          break;
+        case 'over':
+          assert.fail(
+            `${toolName}: observed=${row.observed} bytes, budget=${row.budget} bytes, over by ${row.observed - row.budget} bytes (fixture: ${file})`,
+          );
+          break;
+        case 'known-over':
+          // Allowed — surface the documented reason so a dev running the
+          // suite locally sees the known-issue context.
+          process.stderr.write(
+            `[mcp-output-budget] KNOWN over-budget: ${toolName} observed=${row.observed} budget=${row.budget} delta=+${row.observed - row.budget}B — ${KNOWN_OVER_BUDGET.get(toolName)}\n`,
+          );
+          return;
+        case 'stale':
+          assert.fail(
+            `${toolName}: observed=${row.observed} bytes, budget=${row.budget} bytes (UNDER by ${row.budget - row.observed}). KNOWN_OVER_BUDGET entry is now stale — delete it from tests/helpers/mcp-output-budget.mjs so the standard over-budget assertion gates this tool again.`,
+          );
+          break;
+        default:
+          assert.fail(`unknown status: ${row.status}`);
       }
-
-      assert.ok(
-        delta <= 0,
-        `${toolName}: observed=${observed} bytes, budget=${budget} bytes, over by ${delta} bytes (fixture: ${file})`,
-      );
     });
   }
 });

--- a/tests/mcp-output-budget.test.mjs
+++ b/tests/mcp-output-budget.test.mjs
@@ -1,0 +1,118 @@
+// Per-tool output byte-budget regression test (v1.7.0).
+//
+// Mirrors the runtime byte-accounting gate in `dispatchToolsCall`
+// (`api/mcp.ts` — search `textBytes > budget`):
+//
+//   fixture.data
+//     → tool._postFilter(structuredClone(fixture.data), {})   // skipped if no _postFilter
+//     → { cached_at, stale, data: filtered }                  // reassembled envelope
+//     → JSON.stringify(envelope)
+//     → utf8ByteLength(...)
+//
+// One test case per fixture-tool pair, so a failure names the offending tool
+// directly. Assertion: `observed <= tool._outputBudgetBytes`. The failure
+// message includes tool name, observed bytes, budget bytes, and the delta so
+// the dev sees immediately how far over they are.
+//
+// Default-args identity path only: no JMESPath projection, no `summary: true`.
+// This is the upper-bound path the per-tool budgets are sized for — a JMESPath
+// or summary call shrinks the response further, so testing the unprojected
+// path is the bound the runtime gate cares about.
+//
+// Coverage caveat: only 3/39 tools have captured fixtures today
+// (`tests/fixtures/jmespath-samples/`). Each new fixture added there will be
+// picked up by this test the next CI run. Mocked-response contract coverage
+// for the other tools is a separate follow-up.
+//
+// `KNOWN_OVER_BUDGET` documents tools that currently exceed their declared
+// budget on default args. Each entry is a known-issue exception with a
+// recorded reason and a deletion criterion. The exclusion is itself
+// regression-signal: a NEW over-budget tool (not in the map) fails the test;
+// an exclusion that becomes obsolete (tool now under budget) ALSO fails so
+// the entry can't go stale and mask a future regression.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { __testing__, utf8ByteLength } from '../api/mcp.ts';
+
+const FIXTURES_DIR = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'jmespath-samples',
+);
+
+// Kept in lockstep with `tests/mcp-output-schema-coverage.test.mjs` and
+// `scripts/mcp-budget-check.mjs`. Three rows — duplicating is cheaper than
+// threading a shared module just for this.
+const FIXTURES = [
+  { file: 'fat-get-market-data.response.json', tool: 'get_market_data' },
+  { file: 'medium-get-conflict-events.response.json', tool: 'get_conflict_events' },
+  { file: 'thin-get-chokepoint-status.response.json', tool: 'get_chokepoint_status' },
+];
+
+// Tools whose default-args envelope is currently over its declared
+// `_outputBudgetBytes` and which the runtime gate is therefore already
+// rejecting in production with the `_budget_exceeded` envelope. Each entry
+// MUST be deleted once the underlying tool is brought back under budget,
+// otherwise the exclusion masks future regressions (the test guards both
+// directions — see `KNOWN_OVER_BUDGET entry is now stale` below).
+//
+// Keep in sync with the same const in `scripts/mcp-budget-check.mjs`.
+const KNOWN_OVER_BUDGET = new Map([
+  ['get_market_data',
+    'commodities-bootstrap ships 30 quotes per the universal default `limit` — that single key alone is ~133 KB, more than the entire 128 KB budget. Default-args calls currently return the runtime `_budget_exceeded` envelope. Delete this entry once the per-key default cap is tightened (or the per-tool budget raised with justification) so the envelope fits under budget.'],
+]);
+
+describe('api/mcp.ts — per-tool output byte-budget regression (v1.7.0)', () => {
+  // Dead-entry guard: a KNOWN_OVER_BUDGET name that doesn't appear in
+  // FIXTURES can't be measured, so the exclusion is unfalsifiable and must
+  // be removed. (When a new fixture is added in the future and exposes a
+  // genuine over-budget tool, the dev will add both the fixture AND a
+  // KNOWN_OVER_BUDGET entry — this guard prevents adding the entry alone.)
+  it('every KNOWN_OVER_BUDGET entry names a tool with a fixture in this file', () => {
+    const fixtureTools = new Set(FIXTURES.map((f) => f.tool));
+    const dead = [...KNOWN_OVER_BUDGET.keys()].filter((name) => !fixtureTools.has(name));
+    assert.deepEqual(dead, [], `KNOWN_OVER_BUDGET names tools without a fixture: ${dead.join(', ')}`);
+  });
+
+  for (const { file, tool: toolName } of FIXTURES) {
+    it(`${toolName}: default-args response stays under _outputBudgetBytes (${file})`, () => {
+      const tool = __testing__.TOOL_REGISTRY.find((t) => t.name === toolName);
+      assert.ok(tool, `tool ${toolName} not found in TOOL_REGISTRY`);
+
+      const fixture = JSON.parse(readFileSync(path.join(FIXTURES_DIR, file), 'utf8'));
+      const filtered = tool._postFilter
+        ? tool._postFilter(structuredClone(fixture.data), {})
+        : fixture.data;
+      const envelope = { cached_at: fixture.cached_at, stale: fixture.stale, data: filtered };
+      const observed = utf8ByteLength(JSON.stringify(envelope));
+      const budget = tool._outputBudgetBytes;
+      const delta = observed - budget;
+
+      if (KNOWN_OVER_BUDGET.has(toolName)) {
+        // Expected over-budget. If the observation is now under budget, the
+        // entry is stale and must be removed — otherwise the exclusion
+        // would silently absorb a future regression.
+        assert.ok(
+          delta > 0,
+          `${toolName}: observed=${observed} bytes, budget=${budget} bytes (UNDER by ${-delta}). KNOWN_OVER_BUDGET entry is now stale — delete it from this file so the standard over-budget assertion gates this tool again.`,
+        );
+        // Still over, as expected. Surface the known-issue context so a dev
+        // running the suite locally sees why it's allowed.
+        process.stderr.write(
+          `[mcp-output-budget] KNOWN over-budget: ${toolName} observed=${observed} budget=${budget} delta=+${delta}B — ${KNOWN_OVER_BUDGET.get(toolName)}\n`,
+        );
+        return;
+      }
+
+      assert.ok(
+        delta <= 0,
+        `${toolName}: observed=${observed} bytes, budget=${budget} bytes, over by ${delta} bytes (fixture: ${file})`,
+      );
+    });
+  }
+});


### PR DESCRIPTION
## What changes

Adds a fixture-driven regression test that mirrors the runtime `_outputBudgetBytes` gate in `dispatchToolsCall`, plus a standalone measurement script that emits the same observations as a markdown table.

- `tests/mcp-output-budget.test.mjs` — one `node:test` case per (fixture, tool) pair under `tests/fixtures/jmespath-samples/`. Asserts `observed <= tool._outputBudgetBytes`. Failures name the tool with observed / budget / delta in the message.
- `scripts/mcp-budget-check.mjs` — measures the same numbers, prints a markdown table to stdout, exits non-zero if any unexpected over-budget. Reproducible: same fixtures → byte-identical numbers every run. Mirrors the direct-invocation pattern of `scripts/measure-jmespath-savings.mjs`.

No production code changes. No `SERVER_VERSION` bump. Test-only PR.

## Decisions documented

**Which response shape gets measured?** The fixture envelope after `tool._postFilter(structuredClone(data), {})` is re-applied and the envelope `{cached_at, stale, data: filtered}` is reassembled and `JSON.stringify`'d. This is the chain `dispatchToolsCall` measures at runtime (search `textBytes > budget` in `api/mcp.ts`), restricted to the default-args identity path — no JMESPath projection, no `summary: true`. That's the upper-bound path the per-tool budgets are sized for; both downstream transforms shrink the response further.

**Which tools are in scope?** The 3 fixtures currently captured under `tests/fixtures/jmespath-samples/` — `get_market_data`, `get_conflict_events`, `get_chokepoint_status` — all cache tools with `required: []` so default args (`{}`) are valid. RPC tools (those with `_execute`) and required-arg tools aren't covered here; mock-driven coverage is a separate follow-up (see *Out of scope*).

## Measurement (reproducible — run `npx tsx scripts/mcp-budget-check.mjs`)

| Tool | Budget | Observed | Headroom | Status |
|---|---:|---:|---:|---|
| `get_market_data` | 128.0 KB | 213.6 KB | -66.8% | OVER by 87617 B (known) |
| `get_conflict_events` | 128.0 KB | 56.9 KB | 55.6% | OK |
| `get_chokepoint_status` | 128.0 KB | 17.4 KB | 86.4% | OK |

`get_market_data` is currently over its declared 128 KB budget on default args — `commodities-bootstrap` ships 30 quotes per the universal default `limit` cap, and that single key alone is ~133 KB. The live runtime gate is therefore returning the `_budget_exceeded` envelope for default-args `get_market_data` calls today. This PR documents the breach in `KNOWN_OVER_BUDGET` (with reason + deletion criterion) so the test can ship green for the other two fixtures while making the known issue surfaceable.

The exclusion is itself a regression signal:
- A NEW over-budget tool (not in `KNOWN_OVER_BUDGET`) fails the test by name.
- An exclusion that becomes obsolete (tool now under budget) ALSO fails — `KNOWN_OVER_BUDGET entry is now stale — delete it from this file …` — so the entry can't go stale and silently absorb a future regression.
- A dead exclusion (entry names a tool with no fixture) fails the dead-entry guard.

## Sabotage-check evidence

**1. Tighten a healthy tool's budget.** Temporarily set `get_conflict_events._outputBudgetBytes = 100` and rerun:

```
✖ get_conflict_events: default-args response stays under _outputBudgetBytes (medium-get-conflict-events.response.json)
  AssertionError: get_conflict_events: observed=58232 bytes, budget=100 bytes,
  over by 58132 bytes (fixture: medium-get-conflict-events.response.json)
```

Failure names the tool, shows observed/budget/delta, and identifies the fixture.

**2. Make a `KNOWN_OVER_BUDGET` entry stale.** Temporarily raise `get_market_data._outputBudgetBytes` to 524288 (so observed=218689 is comfortably under) and rerun:

```
✖ get_market_data: default-args response stays under _outputBudgetBytes (fat-get-market-data.response.json)
  AssertionError: get_market_data: observed=218689 bytes, budget=524288 bytes
  (UNDER by 305599). KNOWN_OVER_BUDGET entry is now stale — delete it from this
  file so the standard over-budget assertion gates this tool again.
```

Both sabotage scenarios were reverted before this commit; `git diff api/mcp.ts` is empty on this branch.

## Coverage caveat

3 of 39 tools have captured fixtures today. This test catches drift on those 3 — the genuine scope. Each new fixture added to `tests/fixtures/jmespath-samples/` is picked up by the next CI run with no other changes (add the row to the `FIXTURES` const in the script + test).

## Out of scope (follow-ups)

- **Mocked-response contract test** — for tools without a captured fixture, contract coverage requires a mocked `_execute` / cache response asserting each tool's response shape and budget. Separate follow-up because it needs a different harness (mock injection, not fixture replay) and a different signal (shape stability, not just byte count).
- **Protocol-conformance lifecycle test** — full `initialize` → `tools/list` → `tools/call` × N → quota exhaustion walk. Separate follow-up; orthogonal to per-tool budget.
- **Tightening `get_market_data` default behavior** so the `KNOWN_OVER_BUDGET` entry can be removed (likely a per-key default cap rather than a global `DEFAULT_LIST_LIMIT` change, since `commodities-bootstrap` is the load-bearing key here). Tracked by the `KNOWN_OVER_BUDGET` entry itself.

## Test plan

- [x] `npm run typecheck:api` green
- [x] `npx tsx --test tests/mcp-output-budget.test.mjs` — 4/4 pass
- [x] Sabotage 1 (tighten healthy budget) → fails by name with observed/budget/delta
- [x] Sabotage 2 (make exclusion stale) → fails by name with stale-entry message
- [x] `npx tsx scripts/mcp-budget-check.mjs` exits 0 with markdown table