### PR TITLE
feat(feeds): add Czech (cs) locale with mainstream + investigative sources

### DIFF
--- a/api/_rss-allowed-domains.js
+++ b/api/_rss-allowed-domains.js
@@ -311,5 +311,13 @@ export default [
   "hirado.hu",
   "portfolio.hu",
   "www.portfolio.hu",
-  "www.atv.hu"
+  "www.atv.hu",
+  "www.irozhlas.cz",
+  "ct24.ceskatelevize.cz",
+  "denikn.cz",
+  "hn.cz",
+  "www.novinky.cz",
+  "aktualne.cz",
+  "hlidacipes.org",
+  "demagog.cz"
 ];

--- a/scripts/shared/rss-allowed-domains.json
+++ b/scripts/shared/rss-allowed-domains.json
@@ -308,5 +308,13 @@
   "hirado.hu",
   "portfolio.hu",
   "www.portfolio.hu",
-  "www.atv.hu"
+  "www.atv.hu",
+  "www.irozhlas.cz",
+  "ct24.ceskatelevize.cz",
+  "denikn.cz",
+  "hn.cz",
+  "www.novinky.cz",
+  "aktualne.cz",
+  "hlidacipes.org",
+  "demagog.cz"
 ]

--- a/scripts/shared/source-tiers.json
+++ b/scripts/shared/source-tiers.json
@@ -262,5 +262,13 @@
   "ArXiv AI": 4,
   "AI News": 4,
   "Layoffs News": 4,
-  "GloNewswire (Taiwan)": 4
+  "GloNewswire (Taiwan)": 4,
+  "iRozhlas": 2,
+  "CT24": 2,
+  "Deník N": 2,
+  "Hospodářské Noviny": 2,
+  "Novinky.cz": 2,
+  "Aktuálně": 2,
+  "Hlídač Pipsu": 2,
+  "Demagog.cz": 2
 }

--- a/server/worldmonitor/news/v1/_feeds.ts
+++ b/server/worldmonitor/news/v1/_feeds.ts
@@ -55,6 +55,15 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       { name: 'Híradó', url: gnLocale('site:hirado.hu when:2d', 'hu', 'HU', 'HU:hu'), lang: 'hu' },
       { name: 'Portfolio.hu', url: 'https://portfolio.hu/rss/all.xml', lang: 'hu' },
       { name: 'ATV', url: 'https://www.atv.hu/rss', lang: 'hu' },
+      // Czech (CS) — mainstream + investigative
+      { name: 'iRozhlas', url: 'https://www.irozhlas.cz/rss/irozhlas', lang: 'cs' },
+      { name: 'CT24', url: 'https://ct24.ceskatelevize.cz/rss', lang: 'cs' },
+      { name: 'Deník N', url: 'https://denikn.cz/feed/', lang: 'cs' },
+      { name: 'Hospodářské Noviny', url: 'https://hn.cz/rss/cz', lang: 'cs' },
+      { name: 'Novinky.cz', url: 'https://www.novinky.cz/rss2', lang: 'cs' },
+      { name: 'Aktuálně', url: gnLocale('site:aktualne.cz when:2d', 'cs', 'CZ', 'CZ:cs'), lang: 'cs' },
+      { name: 'Hlídač Pipsu', url: 'https://hlidacipes.org/feed/', lang: 'cs' },
+      { name: 'Demagog.cz', url: gnLocale('site:demagog.cz when:14d', 'cs', 'CZ', 'CZ:cs'), lang: 'cs' },
     ],
     middleeast: [
       { name: 'BBC Middle East', url: 'https://feeds.bbci.co.uk/news/world/middle_east/rss.xml' },

--- a/shared/rss-allowed-domains.json
+++ b/shared/rss-allowed-domains.json
@@ -308,5 +308,13 @@
   "hirado.hu",
   "portfolio.hu",
   "www.portfolio.hu",
-  "www.atv.hu"
+  "www.atv.hu",
+  "www.irozhlas.cz",
+  "ct24.ceskatelevize.cz",
+  "denikn.cz",
+  "hn.cz",
+  "www.novinky.cz",
+  "aktualne.cz",
+  "hlidacipes.org",
+  "demagog.cz"
 ]

--- a/shared/source-tiers.json
+++ b/shared/source-tiers.json
@@ -262,5 +262,13 @@
   "ArXiv AI": 4,
   "AI News": 4,
   "Layoffs News": 4,
-  "GloNewswire (Taiwan)": 4
+  "GloNewswire (Taiwan)": 4,
+  "iRozhlas": 2,
+  "CT24": 2,
+  "Deník N": 2,
+  "Hospodářské Noviny": 2,
+  "Novinky.cz": 2,
+  "Aktuálně": 2,
+  "Hlídač Pipsu": 2,
+  "Demagog.cz": 2
 }

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -55,6 +55,10 @@ export const SOURCE_TYPES: Record<string, SourceType> = {
   'SVT Nyheter': 'mainstream', 'Dagens Nyheter': 'mainstream', 'Svenska Dagbladet': 'mainstream',
   // Brazilian Addition
   'Brasil Paralelo': 'mainstream',
+  // Czech (CS)
+  'iRozhlas': 'mainstream', 'CT24': 'mainstream', 'Deník N': 'mainstream',
+  'Hospodářské Noviny': 'market', 'Novinky.cz': 'mainstream', 'Aktuálně': 'mainstream',
+  'Hlídač Pipsu': 'intel', 'Demagog.cz': 'intel',
 
   // Market/Finance
   'CNBC': 'market', 'MarketWatch': 'market', 'Yahoo Finance': 'market',
@@ -278,6 +282,15 @@ const FULL_FEEDS: Record<string, Feed[]> = {
     { name: 'in.gr', url: rss('https://www.in.gr/feed/'), lang: 'el' },
     { name: 'iefimerida', url: rss('https://www.iefimerida.gr/rss.xml'), lang: 'el' },
     { name: 'Proto Thema', url: rss('https://news.google.com/rss/search?q=site:protothema.gr+when:2d&hl=el&gl=GR&ceid=GR:el'), lang: 'el' },
+    // Czech (CS) — mainstream + investigative
+    { name: 'iRozhlas', url: rss('https://www.irozhlas.cz/rss/irozhlas'), lang: 'cs' },
+    { name: 'CT24', url: rss('https://ct24.ceskatelevize.cz/rss'), lang: 'cs' },
+    { name: 'Deník N', url: rss('https://denikn.cz/feed/'), lang: 'cs' },
+    { name: 'Hospodářské Noviny', url: rss('https://hn.cz/rss/cz'), lang: 'cs' },
+    { name: 'Novinky.cz', url: rss('https://www.novinky.cz/rss2'), lang: 'cs' },
+    { name: 'Aktuálně', url: rss('https://news.google.com/rss/search?q=site:aktualne.cz+when:2d&hl=cs&gl=CZ&ceid=CZ:cs'), lang: 'cs' },
+    { name: 'Hlídač Pipsu', url: rss('https://hlidacipes.org/feed/'), lang: 'cs' },
+    { name: 'Demagog.cz', url: rss('https://news.google.com/rss/search?q=site:demagog.cz+when:14d&hl=cs&gl=CZ&ceid=CZ:cs'), lang: 'cs' },
     // Russia & Ukraine (independent sources)
     { name: 'BBC Russian', url: rss('https://feeds.bbci.co.uk/russian/rss.xml'), lang: 'ru' },
     { name: 'Meduza', url: rss('https://meduza.io/rss/all'), lang: 'ru' },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -567,6 +567,8 @@ const RSS_PROXY_ALLOWED_DOMAINS = new Set([
   'news.ycombinator.com',
   // Hungarian / Central European feeds
   'telex.hu', 'index.hu', 'hvg.hu', '444.hu', '24.hu', 'hirado.hu', 'portfolio.hu', 'www.portfolio.hu', 'www.atv.hu',
+  // Czech
+  'www.irozhlas.cz', 'ct24.ceskatelevize.cz', 'denikn.cz', 'hn.cz', 'www.novinky.cz', 'aktualne.cz', 'hlidacipes.org', 'demagog.cz',
   // Finance variant
   'www.coindesk.com', 'cointelegraph.com',
   // Happy variant — positive news sources


### PR DESCRIPTION
## Summary

Adds 8 Czech-language news sources covering public broadcasting, quality journalism, business reporting, and investigative/fact-checking outlets.

### New feeds

| Name | URL | Type |
|---|---|---|
| iRozhlas | https://www.irozhlas.cz/rss/irozhlas | direct RSS |
| CT24 | https://ct24.ceskatelevize.cz/rss | direct RSS |
| Deník N | https://denikn.cz/feed/ | direct RSS |
| Hospodářské Noviny | https://hn.cz/rss/cz | direct RSS |
| Novinky.cz | https://www.novinky.cz/rss2 | direct RSS |
| Aktuálně.cz | Google News (`site:aktualne.cz`) | gnLocale |
| Hlídač Pipsu | https://hlidacipes.org/feed/ | direct RSS |
| Demagog.cz | Google News (`site:demagog.cz`) | gnLocale |

All feed URLs probed and verified (≥1 item returned).

### Files changed

- `src/config/feeds.ts` — SOURCE_TYPES entries + feed array entries (lang: 'cs')
- `server/worldmonitor/news/v1/_feeds.ts` — server-side mirror with `gnLocale()` for Google News feeds
- `shared/rss-allowed-domains.json` — 8 new domains
- `scripts/shared/rss-allowed-domains.json` — byte-identical copy
- `api/_rss-allowed-domains.js` — edge-compatible copy
- `vite.config.ts` — proxy allowlist
- `shared/source-tiers.json` — 8 entries at tier 2
- `scripts/shared/source-tiers.json` — byte-identical copy

All 4 allowlist files and both source-tiers files are kept in parity (verified with `diff`).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)