### PR TITLE
feat(feeds): add Romanian (ro) locale with mainstream + investigative sources

### DIFF
--- a/api/_rss-allowed-domains.js
+++ b/api/_rss-allowed-domains.js
@@ -311,5 +311,12 @@ export default [
   "hirado.hu",
   "portfolio.hu",
   "www.portfolio.hu",
-  "www.atv.hu"
+  "www.atv.hu",
+  "www.digi24.ro",
+  "www.g4media.ro",
+  "hotnews.ro",
+  "recorder.ro",
+  "www.zf.ro",
+  "www.agerpres.ro",
+  "www.riseproject.ro"
 ];

--- a/scripts/shared/rss-allowed-domains.json
+++ b/scripts/shared/rss-allowed-domains.json
@@ -308,5 +308,12 @@
   "hirado.hu",
   "portfolio.hu",
   "www.portfolio.hu",
-  "www.atv.hu"
+  "www.atv.hu",
+  "www.digi24.ro",
+  "www.g4media.ro",
+  "hotnews.ro",
+  "recorder.ro",
+  "www.zf.ro",
+  "www.agerpres.ro",
+  "www.riseproject.ro"
 ]

--- a/scripts/shared/source-tiers.json
+++ b/scripts/shared/source-tiers.json
@@ -262,5 +262,12 @@
   "ArXiv AI": 4,
   "AI News": 4,
   "Layoffs News": 4,
-  "GloNewswire (Taiwan)": 4
+  "GloNewswire (Taiwan)": 4,
+  "Digi24": 2,
+  "G4Media": 2,
+  "HotNews": 2,
+  "Recorder": 2,
+  "Ziarul Financiar": 2,
+  "Agerpres": 2,
+  "Rise Project": 2
 }

--- a/server/worldmonitor/news/v1/_feeds.ts
+++ b/server/worldmonitor/news/v1/_feeds.ts
@@ -55,6 +55,14 @@ export const VARIANT_FEEDS: Record<string, Record<string, ServerFeed[]>> = {
       { name: 'Híradó', url: gnLocale('site:hirado.hu when:2d', 'hu', 'HU', 'HU:hu'), lang: 'hu' },
       { name: 'Portfolio.hu', url: 'https://portfolio.hu/rss/all.xml', lang: 'hu' },
       { name: 'ATV', url: 'https://www.atv.hu/rss', lang: 'hu' },
+      // Romanian (RO) — mainstream + investigative
+      { name: 'Digi24', url: 'https://www.digi24.ro/rss', lang: 'ro' },
+      { name: 'G4Media', url: 'https://www.g4media.ro/feed', lang: 'ro' },
+      { name: 'HotNews', url: 'https://hotnews.ro/feed', lang: 'ro' },
+      { name: 'Recorder', url: 'https://recorder.ro/feed/', lang: 'ro' },
+      { name: 'Ziarul Financiar', url: 'https://www.zf.ro/rss/', lang: 'ro' },
+      { name: 'Agerpres', url: 'https://www.agerpres.ro/rss/stiri', lang: 'ro' },
+      { name: 'Rise Project', url: 'https://www.riseproject.ro/feed/', lang: 'ro' },
     ],
     middleeast: [
       { name: 'BBC Middle East', url: 'https://feeds.bbci.co.uk/news/world/middle_east/rss.xml' },

--- a/shared/rss-allowed-domains.json
+++ b/shared/rss-allowed-domains.json
@@ -308,5 +308,12 @@
   "hirado.hu",
   "portfolio.hu",
   "www.portfolio.hu",
-  "www.atv.hu"
+  "www.atv.hu",
+  "www.digi24.ro",
+  "www.g4media.ro",
+  "hotnews.ro",
+  "recorder.ro",
+  "www.zf.ro",
+  "www.agerpres.ro",
+  "www.riseproject.ro"
 ]

--- a/shared/source-tiers.json
+++ b/shared/source-tiers.json
@@ -262,5 +262,12 @@
   "ArXiv AI": 4,
   "AI News": 4,
   "Layoffs News": 4,
-  "GloNewswire (Taiwan)": 4
+  "GloNewswire (Taiwan)": 4,
+  "Digi24": 2,
+  "G4Media": 2,
+  "HotNews": 2,
+  "Recorder": 2,
+  "Ziarul Financiar": 2,
+  "Agerpres": 2,
+  "Rise Project": 2
 }

--- a/src/config/feeds.ts
+++ b/src/config/feeds.ts
@@ -55,6 +55,10 @@ export const SOURCE_TYPES: Record<string, SourceType> = {
   'SVT Nyheter': 'mainstream', 'Dagens Nyheter': 'mainstream', 'Svenska Dagbladet': 'mainstream',
   // Brazilian Addition
   'Brasil Paralelo': 'mainstream',
+  // Romanian (RO)
+  'Digi24': 'mainstream', 'G4Media': 'mainstream', 'HotNews': 'mainstream',
+  'Recorder': 'intel', 'Agerpres': 'wire',
+  'Ziarul Financiar': 'market', 'Rise Project': 'intel',
 
   // Market/Finance
   'CNBC': 'market', 'MarketWatch': 'market', 'Yahoo Finance': 'market',
@@ -278,6 +282,14 @@ const FULL_FEEDS: Record<string, Feed[]> = {
     { name: 'in.gr', url: rss('https://www.in.gr/feed/'), lang: 'el' },
     { name: 'iefimerida', url: rss('https://www.iefimerida.gr/rss.xml'), lang: 'el' },
     { name: 'Proto Thema', url: rss('https://news.google.com/rss/search?q=site:protothema.gr+when:2d&hl=el&gl=GR&ceid=GR:el'), lang: 'el' },
+    // Romanian (RO) — mainstream + investigative
+    { name: 'Digi24', url: rss('https://www.digi24.ro/rss'), lang: 'ro' },
+    { name: 'G4Media', url: rss('https://www.g4media.ro/feed'), lang: 'ro' },
+    { name: 'HotNews', url: rss('https://hotnews.ro/feed'), lang: 'ro' },
+    { name: 'Recorder', url: rss('https://recorder.ro/feed/'), lang: 'ro' },
+    { name: 'Ziarul Financiar', url: rss('https://www.zf.ro/rss/'), lang: 'ro' },
+    { name: 'Agerpres', url: rss('https://www.agerpres.ro/rss/stiri'), lang: 'ro' },
+    { name: 'Rise Project', url: rss('https://www.riseproject.ro/feed/'), lang: 'ro' },
     // Russia & Ukraine (independent sources)
     { name: 'BBC Russian', url: rss('https://feeds.bbci.co.uk/russian/rss.xml'), lang: 'ru' },
     { name: 'Meduza', url: rss('https://meduza.io/rss/all'), lang: 'ru' },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -567,6 +567,8 @@ const RSS_PROXY_ALLOWED_DOMAINS = new Set([
   'news.ycombinator.com',
   // Hungarian / Central European feeds
   'telex.hu', 'index.hu', 'hvg.hu', '444.hu', '24.hu', 'hirado.hu', 'portfolio.hu', 'www.portfolio.hu', 'www.atv.hu',
+  // Romanian
+  'www.digi24.ro', 'www.g4media.ro', 'hotnews.ro', 'recorder.ro', 'www.zf.ro', 'www.agerpres.ro', 'www.riseproject.ro',
   // Finance variant
   'www.coindesk.com', 'cointelegraph.com',
   // Happy variant — positive news sources


### PR DESCRIPTION
## Summary

Adds 7 Romanian-language news sources covering public broadcasting, quality journalism, business reporting, and investigative outlets.

### New feeds

| Name | URL | Type |
|---|---|---|
| Digi24 | https://www.digi24.ro/rss | direct RSS |
| G4Media | https://www.g4media.ro/feed | direct RSS |
| HotNews | https://hotnews.ro/feed | direct RSS |
| Recorder | https://recorder.ro/feed/ | direct RSS |
| Ziarul Financiar | https://www.zf.ro/rss/ | direct RSS |
| Agerpres | https://www.agerpres.ro/rss/stiri | direct RSS |
| Rise Project | https://www.riseproject.ro/feed/ | direct RSS |

All feed URLs probed and verified (≥1 item returned).

### Files changed

- `src/config/feeds.ts` — SOURCE_TYPES entries + feed array entries (lang: 'ro')
- `server/worldmonitor/news/v1/_feeds.ts` — server-side mirror (all direct RSS, no gnLocale needed)
- `shared/rss-allowed-domains.json` — 7 new domains
- `scripts/shared/rss-allowed-domains.json` — byte-identical copy
- `api/_rss-allowed-domains.js` — edge-compatible copy
- `vite.config.ts` — proxy allowlist
- `shared/source-tiers.json` — 7 entries at tier 2
- `scripts/shared/source-tiers.json` — byte-identical copy

All 4 allowlist files and both source-tiers files are kept in parity (verified with `diff`).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)