### PR TITLE
feat(mcp): expose 6 MCP prompts + JMESPath schema parity

### DIFF
--- a/api/api-route-exceptions.json
+++ b/api/api-route-exceptions.json
@@ -115,6 +115,13 @@
       "removal_issue": null
     },
     {
+      "path": "api/mcp/prompts/index.ts",
+      "category": "external-protocol",
+      "reason": "MCP PROMPT_REGISTRY + buildPromptResponse + prompts/list public-shape projection. Workflow templates surfaced via prompts/list + prompts/get JSON-RPC methods, shape dictated by the MCP spec.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
       "path": "api/mcp-proxy.ts",
       "category": "external-protocol",
       "reason": "Proxy for the MCP transport — same shape constraint as api/mcp.ts. Renamed .js → .ts in PR #3768 to unlock the isCallerPremium import from server/.",

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -64,10 +64,17 @@ export type {
 } from './mcp/types';
 export { compressDescription, utf8ByteLength } from './mcp/utils';
 
+export { buildPromptResponse, PROMPT_LIST_RESPONSE, PROMPT_REGISTRY } from './mcp/prompts/index';
+
 // Test-only escape hatch. Exposes the TOOL_REGISTRY by REFERENCE so mutations
 // inside `tests/mcp-tool-output-contracts.test.mjs` (which monkey-patches
 // `_execute` on individual RPC tools) propagate through the live binding.
+// PROMPT_REGISTRY follows the same live-binding contract so a test that
+// monkey-patches a prompt (e.g. the sabotage cases in mcp-prompts.test.mjs)
+// observes the same array the handler dispatches against.
+import { PROMPT_REGISTRY as __PROMPT_REGISTRY } from './mcp/prompts/index';
 import { TOOL_REGISTRY as __TOOL_REGISTRY } from './mcp/registry/index';
 export const __testing__ = {
   TOOL_REGISTRY: __TOOL_REGISTRY,
+  PROMPT_REGISTRY: __PROMPT_REGISTRY,
 };

--- a/api/mcp/constants.ts
+++ b/api/mcp/constants.ts
@@ -125,6 +125,23 @@ export const SERVER_NAME = 'worldmonitor';
 //     unknown fields, and discovery on 2025-03-26 sessions should still benefit.
 //   - Purely additive on the wire — no input contract change. Bundle delta is
 //     documented in the v1.6.0 PR body.
+// Bumped 1.7.0 → 1.8.0 (2026-05-24) reflecting:
+//   - MCP `prompts` capability turned on. Six workflow templates exposed via
+//     prompts/list + prompts/get (country-briefing, energy-shock-watch,
+//     market-open-prep, conflict-pulse, route-risk-check, freshness-audit).
+//     Each template pre-bakes a literal JMESPath projection per step so the
+//     LLM doesn't have to discover the response shape on first execution.
+//   - Wire-visible additive capability — clients that ignore the new methods
+//     keep working; capable clients (Claude Desktop slash menu, MCP Inspector)
+//     surface the workflows in a discovery affordance.
+//   - prompts/list and prompts/get are quota-exempt (per-minute limit only)
+//     to mirror the describe_tool metadata posture — counting template
+//     fetches against the 50/day Pro cap would discourage exploration.
+//   - capabilities.prompts.listChanged = false advertised, because the
+//     stateless edge transport can't push notifications/prompts/list_changed
+//     today.
+//   - Server-card prompts capability flag flipped false → true in the same
+//     commit so external scanners see the wire and the card agree.
 // Bumped 1.6.0 → 1.7.0 (2026-05-23) reflecting:
 //   - De-blanket the `Tool.annotations` object. Previously buildPublicTool
 //     hard-coded `{ readOnlyHint: true, openWorldHint: true }` for every
@@ -144,7 +161,7 @@ export const SERVER_NAME = 'worldmonitor';
 //     hints keep working; new four-hint clients get a richer signal.
 // Keep aligned with public/.well-known/mcp/server-card.json::serverInfo.version
 // — discovery scanners cross-check both values.
-export const SERVER_VERSION = '1.7.0';
+export const SERVER_VERSION = '1.8.0';
 
 // MCP logging capability — valid severity levels per the 2025-03-26 spec
 // (RFC 5424 subset). Stateless HTTP transport: we ACK the level but do not
@@ -193,6 +210,8 @@ export const SERVER_INSTRUCTIONS = [
   `Limits: expression ≤ ${JMESPATH_MAX_EXPR_BYTES} bytes; projected payload ≤ ${JMESPATH_MAX_OUTPUT_BYTES} bytes. Failures return {_jmespath_error, original_keys} inside the normal result envelope. Bad expressions DO consume one daily quota unit on retry — original_keys is echoed so you can self-correct in one extra call.`,
   '',
   `tools/list returns COMPRESSED tool descriptions (first sentence, ≤${TOOL_DESCRIPTION_MAX_BYTES}B per tool). Call describe_tool({tool_name}) to get the full uncompressed definition for any tool you're considering — especially useful when the compressed entry is ambiguous about behaviour or argument semantics. describe_tool is metadata-only and is EXEMPT from the Pro daily quota (still counts toward the 60/min rate limit), so use it freely while exploring. describe_tool({tool_name: 'nonexistent'}) returns {error: 'unknown_tool', available: [...]} so you can self-correct.`,
+  '',
+  'Issue prompts/list to discover pre-built workflow templates (country-briefing, energy-shock-watch, market-open-prep, conflict-pulse, route-risk-check, freshness-audit). Each prompt pre-bakes a JMESPath projection per step so the first execution lands on the right shape. prompts/list + prompts/get are quota-exempt (per-minute limit only).',
 ].join('\n');
 
 // Country-code whitelist for get_consumer_prices. The consumer-prices seeder

--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -14,6 +14,7 @@ import {
   SERVER_VERSION,
 } from './constants';
 import { dispatchToolsCall } from './dispatch';
+import { buildPromptResponse, PROMPT_LIST_RESPONSE } from './prompts/index';
 import { TOOL_LIST_BYTES, TOOL_LIST_RESPONSE } from './registry/index';
 import { rpcError, rpcOk } from './rpc';
 import { emitTelemetry, principalIdForLog } from './telemetry';
@@ -94,7 +95,11 @@ export async function mcpHandler(
       });
       return rpcOk(id, {
         protocolVersion: negotiatedVersion,
-        capabilities: { tools: {}, logging: {} },
+        // `prompts.listChanged: false` is the spec-correct value for our
+        // transport — the stateless edge route cannot push
+        // `notifications/prompts/list_changed`, so advertising `true` would
+        // be a lie. Same posture applies if/when `resources` lands later.
+        capabilities: { tools: {}, logging: {}, prompts: { listChanged: false } },
         serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
         instructions: SERVER_INSTRUCTIONS,
       }, { 'Mcp-Session-Id': sessionId, ...corsHeaders });
@@ -107,6 +112,22 @@ export async function mcpHandler(
       return rpcOk(id, { tools: TOOL_LIST_RESPONSE }, corsHeaders);
     case 'tools/call':
       return dispatchToolsCall(req, context, deps, body, corsHeaders, ctx);
+    // Prompts are metadata-class — they ship a workflow template, not data.
+    // Symmetric posture with `describe_tool`: quota-exempt (counting template
+    // fetches against the 50/day cap would discourage exploration, which
+    // defeats the prompt-discovery point), but the per-minute rate limit
+    // applied above still gates abusive loops.
+    case 'prompts/list':
+      return rpcOk(id, { prompts: PROMPT_LIST_RESPONSE }, corsHeaders);
+    case 'prompts/get': {
+      const params = body.params as { name?: unknown; arguments?: Record<string, unknown> } | null;
+      if (!params || typeof params.name !== 'string') {
+        return rpcError(id, -32602, 'Invalid params: missing prompt name');
+      }
+      const built = buildPromptResponse(params.name, params.arguments);
+      if (!built.ok) return rpcError(id, built.code, built.message);
+      return rpcOk(id, { description: built.description, messages: built.messages }, corsHeaders);
+    }
     case 'logging/setLevel': {
       const level = (body.params as { level?: string } | null)?.level;
       if (typeof level !== 'string' || !MCP_LOG_LEVELS.has(level)) {

--- a/api/mcp/prompts/index.ts
+++ b/api/mcp/prompts/index.ts
@@ -322,7 +322,17 @@ export function buildPromptResponse(
 
   const lines: string[] = [renderedIntro, ''];
   prompt.steps.forEach((step, i) => {
-    const renderedArgs = substituteValue(step.args, values);
+    const rawArgs = substituteValue(step.args, values) as Record<string, unknown>;
+    // Strip top-level keys that resolved to '' (an omitted optional arg —
+    // required-arg absence already returned -32602 above). Passing `""` to a
+    // tool is ambiguous: postFilters today truthy-check (safe), but a future
+    // tool that guards with `!== undefined` would try to filter by empty
+    // string and serve incorrect/empty results instead of the global view.
+    // Render the no-filter call literally as `{}` so the LLM sees the
+    // intended shape.
+    const renderedArgs = Object.fromEntries(
+      Object.entries(rawArgs).filter(([, v]) => v !== ''),
+    );
     lines.push(`Step ${i + 1} — ${step.tool}`);
     lines.push(`  purpose: ${substituteString(step.purpose, values)}`);
     lines.push(`  arguments: ${JSON.stringify(renderedArgs)}`);

--- a/api/mcp/prompts/index.ts
+++ b/api/mcp/prompts/index.ts
@@ -1,0 +1,427 @@
+// MCP prompts registry. Each entry is a workflow template: it declares the
+// arguments the caller passes via `prompts/get`, the sequence of `tools/call`
+// invocations the model should execute (with literal JMESPath projections
+// pre-baked from the corresponding tool's outputSchema), and the rendered
+// user-facing instructions that explain the workflow.
+//
+// Why a structured `steps` shape (vs. an inline jmespath: marker in a freeform
+// template string): a structured shape lets the schema-parity test
+// (tests/mcp-prompts.test.mjs) walk every {tool, jmespath} pair directly
+// without fragile regex extraction from the rendered text. Same content ends
+// up in the rendered message, but the source of truth stays machine-readable.
+//
+// Load-time validator (validatePromptRegistry, run at module init) guards
+// against three classes of authoring mistake:
+//   1. A ${token} in any template string that isn't declared in the prompt's
+//      arguments[].name — would render as the literal "${unknown}" and
+//      silently break the workflow.
+//   2. A duplicate prompt name — would shadow the earlier entry in
+//      prompts/list and break the prompts/get lookup.
+//   3. A duplicate argument name within a single prompt — would let two
+//      arguments[] entries collide on substitution.
+// Tool-name parity (every step.tool exists in TOOL_REGISTRY) is enforced by
+// the test suite at test time, not at module load, to keep this module free
+// of an import cycle with the registry.
+
+import type { McpPromptArgument, McpPromptDef } from '../types';
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+// JMESPath authoring rule: only reference fields that exist in the targeted
+// tool's outputSchema. The Phase-1 schema-parity test (see
+// tests/mcp-prompts.test.mjs) compiles every expression below and asserts
+// that every field identifier resolves to some property in the matching
+// outputSchema. A rename in a future PR (either side) fails this test by
+// name with both the prompt and the broken path.
+//
+// Cache-tool envelopes are wrapped as `{cached_at, stale, data: {...labels}}`
+// (see cacheEnvelope in filters.ts). Projections into cache-tool responses
+// therefore start at `data.<label>`. RPC tools return the raw payload — no
+// `data.` prefix needed.
+export const PROMPT_REGISTRY: McpPromptDef[] = [
+  {
+    name: 'country-briefing',
+    description:
+      'Multi-tool country brief: quantitative risk score + LLM-synthesised intelligence brief + macro indicators for a single ISO 3166-1 alpha-2 country.',
+    arguments: [
+      {
+        name: 'iso2',
+        description: 'ISO 3166-1 alpha-2 country code (e.g. "DE", "US", "CN", "IR"). Case-sensitive — pass uppercase.',
+        required: true,
+      },
+    ],
+    steps: [
+      {
+        tool: 'get_country_risk',
+        args: { country_code: '${iso2}' },
+        jmespath: '{cii: cii, components: components, travelAdvisory: travelAdvisory, sanctionsExposure: sanctionsExposure}',
+        purpose: 'Quantitative Composite Instability Index (CII) + component breakdown + travel advisory + OFAC sanctions exposure.',
+      },
+      {
+        tool: 'get_country_brief',
+        args: { country_code: '${iso2}' },
+        jmespath: '{country_code: country_code, brief: brief}',
+        purpose: 'LLM-synthesised geopolitical + economic narrative grounded on the latest headlines.',
+      },
+      {
+        tool: 'get_country_macro',
+        args: { countries: ['${iso2}'] },
+        jmespath: '{macro: data.macro.countries, growth: data.growth.countries, labor: data.labor.countries}',
+        purpose: 'IMF WEO macro/growth/labor indicators (one-country slice; external excluded — broad WEO retraction 2026-04).',
+      },
+    ],
+    intro:
+      'Build a country briefing for ${iso2}. Execute the three steps below in order; combine the results into a single concise brief (CII score and components, travel/sanctions posture, the LLM brief, then the key macro indicators).',
+  },
+  {
+    name: 'energy-shock-watch',
+    description:
+      'Active energy supply disruptions, fuel shortages, and government crisis policies. Optional country filter narrows the country-keyed slices; omit for a global view.',
+    arguments: [
+      {
+        name: 'country',
+        description: 'Optional ISO 3166-1 alpha-2 country code to focus on (e.g. "DE", "IN"). Omit for the global energy bundle.',
+        required: false,
+      },
+    ],
+    steps: [
+      {
+        tool: 'get_energy_intelligence',
+        args: { country: '${country}' },
+        jmespath: '{disruptions: data.disruptions.events, fuel_shortages: data."fuel-shortages".shortages, crisis_policies: data."crisis-policies".policies}',
+        purpose: 'Active disruptions + per-country fuel shortages + government crisis policies. Three slices of the energy bundle most relevant to a near-term shock.',
+      },
+    ],
+    intro:
+      'Surface active energy disruptions, fuel shortages, and the government crisis-policy posture${country_suffix}. Call the step below, then summarise: are there active disruptions right now, and which countries / policies are in scope?',
+    intro_substitutions: {
+      country_suffix: { when_present: ' for ${country}', when_absent: ' (global view)' },
+    },
+  },
+  {
+    name: 'market-open-prep',
+    description:
+      'Pre-market briefing: equity, commodity, and crypto quotes with per-symbol percent changes. Designed to be cheap to read — only changePercent + symbol are projected per asset class.',
+    arguments: [],
+    steps: [
+      {
+        tool: 'get_market_data',
+        args: { asset_class: ['equity', 'commodity', 'crypto'] },
+        jmespath: '{equity: data."stocks-bootstrap".quotes[*].{symbol: symbol, changePercent: changePercent}, commodity: data."commodities-bootstrap".quotes[*].{symbol: symbol, changePercent: changePercent}, crypto: data.crypto.quotes[*].{symbol: symbol, changePercent: changePercent}}',
+        purpose: 'Per-asset-class quote pairs (symbol + changePercent only). Skip ETF flows / sectors / Gulf / fear-greed — they belong in a deeper drill-down, not a session-opening read.',
+      },
+    ],
+    intro:
+      'Prepare a market-open briefing. Call the step below to fetch equity, commodity, and crypto movers, then highlight the largest gainers and losers per asset class along with anything anomalous (e.g. correlated moves, single-name outliers).',
+  },
+  {
+    name: 'conflict-pulse',
+    description:
+      'Active conflict events (UCDP) + alert-flagged top news stories. Optional country filter narrows both feeds; omit for a global pulse.',
+    arguments: [
+      {
+        name: 'country',
+        description: 'Optional country filter. UCDP event names use full country names ("United States"); news intelligence uses ISO 3166-1 alpha-2. Pass the most specific form that matches both — the postFilters are case-insensitive on substring/code respectively.',
+        required: false,
+      },
+    ],
+    steps: [
+      {
+        tool: 'get_conflict_events',
+        args: { country: '${country}', min_fatalities: 1 },
+        jmespath: 'data."ucdp-events".events',
+        purpose: 'UCDP armed-conflict events (≥1 fatality) — the canonical low-noise feed for hot conflicts.',
+      },
+      {
+        tool: 'get_news_intelligence',
+        args: { country: '${country}', alerts_only: true },
+        jmespath: 'data.insights.topStories',
+        purpose: 'Alert-flagged top stories only — high signal-to-noise filter on the news layer.',
+      },
+    ],
+    intro:
+      'Read the current conflict pulse${country_suffix}. Run both steps below and synthesise: where are the active conflict events, and what alert-flagged stories cluster with them? Be specific about geographies and sides.',
+    intro_substitutions: {
+      country_suffix: { when_present: ' for ${country}', when_absent: ' (global view)' },
+    },
+  },
+  {
+    name: 'route-risk-check',
+    description:
+      'Maritime chokepoint transit summary + risk posture for a single chokepoint (e.g. "hormuz", "suez", "malacca", "bab-el-mandeb", "panama"). The filter is case-insensitive substring against the chokepoint identifiers used by each dataset.',
+    arguments: [
+      {
+        name: 'chokepoint',
+        description: 'Substring match against chokepoint identifiers — e.g. "hormuz" matches both "hormuz_strait" and "Strait of Hormuz". Use the most specific name you have.',
+        required: true,
+      },
+    ],
+    steps: [
+      {
+        tool: 'get_chokepoint_status',
+        args: { chokepoint: '${chokepoint}' },
+        jmespath: 'data."transit-summaries".summaries',
+        purpose: 'Per-chokepoint transit summary: today total / tanker / cargo, week-over-week change, risk level, incident count, disruption percentage, and a risk narrative.',
+      },
+    ],
+    intro:
+      'Assess the current route risk for the ${chokepoint} chokepoint. Call the step below and surface: today\'s transit volume, week-over-week change, risk level + narrative, and any incidents in the trailing 7 days. Flag explicitly if the dataAvailable field is false.',
+  },
+  {
+    name: 'freshness-audit',
+    description:
+      'Quick audit of cache freshness across three high-cadence cache tools. Reads each envelope\'s cached_at + stale flag (no full data payload) so the operator can see at a glance whether the bootstrap pipeline is up to date.',
+    arguments: [],
+    steps: [
+      {
+        tool: 'get_market_data',
+        args: { summary: true },
+        jmespath: '{cached_at: cached_at, stale: stale}',
+        purpose: 'Market-data envelope freshness (10-min cadence on equity quotes; stale if any contributing key is older than its per-key budget).',
+      },
+      {
+        tool: 'get_energy_intelligence',
+        args: { summary: true },
+        jmespath: '{cached_at: cached_at, stale: stale}',
+        purpose: 'Energy bundle envelope freshness (multi-cadence — EIA daily, Ember daily, gas-storage daily, World Bank annual).',
+      },
+      {
+        tool: 'get_chokepoint_status',
+        args: { summary: true },
+        jmespath: '{cached_at: cached_at, stale: stale}',
+        purpose: 'Chokepoint transit-summary envelope freshness (10-min relay cadence on the live transit feeds).',
+      },
+    ],
+    intro:
+      'Audit the bootstrap pipeline freshness across markets, energy, and maritime chokepoints. For each step below, project ONLY the envelope (cached_at + stale) — the summary: true flag collapses the payload so this stays cheap. Then report a one-line freshness verdict per tool.',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Substitution + rendering
+// ---------------------------------------------------------------------------
+
+// Recognised token grammar: ${name} where name is one of the prompt's
+// declared arguments. Non-matching `${...}` content is treated as a token
+// (so a typo'd token surfaces as a load-time error, not a silent passthrough).
+const TOKEN_RE = /\$\{([^}]*)\}/g;
+
+function collectTokens(s: string): string[] {
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
+  TOKEN_RE.lastIndex = 0;
+  while ((m = TOKEN_RE.exec(s)) !== null) out.push(m[1] ?? '');
+  return out;
+}
+
+// Recursive token walk over the args_template object — covers strings nested
+// in arrays/objects (e.g. `{countries: ["${iso2}"]}`). Non-string leaves
+// (numbers, booleans, null) are skipped.
+function collectTokensFromValue(v: unknown, sink: string[]): void {
+  if (typeof v === 'string') {
+    for (const t of collectTokens(v)) sink.push(t);
+    return;
+  }
+  if (Array.isArray(v)) {
+    for (const x of v) collectTokensFromValue(x, sink);
+    return;
+  }
+  if (v !== null && typeof v === 'object') {
+    for (const x of Object.values(v as Record<string, unknown>)) collectTokensFromValue(x, sink);
+  }
+}
+
+function substituteString(s: string, values: Record<string, string>): string {
+  return s.replace(TOKEN_RE, (_, name) => values[name] ?? '');
+}
+
+function substituteValue(v: unknown, values: Record<string, string>): unknown {
+  if (typeof v === 'string') return substituteString(v, values);
+  if (Array.isArray(v)) return v.map((x) => substituteValue(x, values));
+  if (v !== null && typeof v === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+      out[k] = substituteValue(val, values);
+    }
+    return out;
+  }
+  return v;
+}
+
+// Render `intro_substitutions` conditional segments BEFORE the standard
+// ${arg} pass so the intro template can express "with a country filter" vs.
+// "global view" branches without per-prompt code. Each substitution name
+// (e.g. country_suffix) maps to one of two literal substrings keyed by
+// whether the controlling arg was provided.
+function applyIntroSubstitutions(
+  intro: string,
+  intro_substitutions: McpPromptDef['intro_substitutions'] | undefined,
+  values: Record<string, string>,
+): string {
+  if (!intro_substitutions) return intro;
+  let out = intro;
+  for (const [tokenName, spec] of Object.entries(intro_substitutions)) {
+    // The controlling arg name is implied by the values inside the spec —
+    // each spec template references one arg via ${name}. Determine presence
+    // by inspecting the spec's own token grammar: if the referenced arg has a
+    // non-empty value, render when_present; otherwise when_absent.
+    const argsReferenced = [
+      ...collectTokens(spec.when_present),
+      ...collectTokens(spec.when_absent),
+    ];
+    const isPresent = argsReferenced.some((arg) => (values[arg] ?? '').length > 0);
+    const replacement = isPresent ? spec.when_present : spec.when_absent;
+    out = out.split('${' + tokenName + '}').join(replacement);
+  }
+  return out;
+}
+
+export interface BuildPromptResponseError {
+  ok: false;
+  code: number;
+  message: string;
+}
+export interface BuildPromptResponseOk {
+  ok: true;
+  description: string;
+  messages: Array<{ role: 'user'; content: { type: 'text'; text: string } }>;
+}
+
+// Resolve a prompts/get call: look up the prompt by name, validate the
+// provided arguments against the declaration, substitute, and render the
+// user-facing workflow message. Returns a discriminated union so the dispatch
+// layer can map ok=false to the right JSON-RPC error code (-32602 for both
+// unknown-name and missing-required-arg, mirroring tools/call).
+export function buildPromptResponse(
+  promptName: string,
+  providedArgs: Record<string, unknown> | undefined,
+): BuildPromptResponseOk | BuildPromptResponseError {
+  const prompt = PROMPT_REGISTRY.find((p) => p.name === promptName);
+  if (!prompt) {
+    return { ok: false, code: -32602, message: `Unknown prompt: ${promptName}` };
+  }
+
+  const values: Record<string, string> = {};
+  for (const arg of prompt.arguments) {
+    const raw = providedArgs?.[arg.name];
+    if (raw == null || raw === '') {
+      if (arg.required) {
+        return { ok: false, code: -32602, message: `Missing required argument "${arg.name}" for prompt "${promptName}"` };
+      }
+      values[arg.name] = '';
+      continue;
+    }
+    values[arg.name] = String(raw);
+  }
+
+  const renderedIntro = substituteString(
+    applyIntroSubstitutions(prompt.intro, prompt.intro_substitutions, values),
+    values,
+  );
+
+  const lines: string[] = [renderedIntro, ''];
+  prompt.steps.forEach((step, i) => {
+    const renderedArgs = substituteValue(step.args, values);
+    lines.push(`Step ${i + 1} — ${step.tool}`);
+    lines.push(`  purpose: ${substituteString(step.purpose, values)}`);
+    lines.push(`  arguments: ${JSON.stringify(renderedArgs)}`);
+    lines.push(`  jmespath: ${step.jmespath}`);
+    lines.push('');
+  });
+
+  return {
+    ok: true,
+    description: prompt.description,
+    messages: [
+      { role: 'user', content: { type: 'text', text: lines.join('\n').trimEnd() } },
+    ],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Load-time validator
+// ---------------------------------------------------------------------------
+// Throws on any structural authoring mistake. Runs once at module-init so a
+// malformed PROMPT_REGISTRY takes down the handler at deploy time rather
+// than producing silently broken renders on first prompts/get. Same
+// discipline as the TOOL_REGISTRY collision-guard in registry/index.ts.
+function validatePromptRegistry(): void {
+  const namesSeen = new Set<string>();
+  for (const prompt of PROMPT_REGISTRY) {
+    if (namesSeen.has(prompt.name)) {
+      throw new Error(`api/mcp/prompts/index.ts: duplicate prompt name "${prompt.name}".`);
+    }
+    namesSeen.add(prompt.name);
+
+    const argNames = new Set<string>();
+    for (const arg of prompt.arguments) {
+      if (argNames.has(arg.name)) {
+        throw new Error(`api/mcp/prompts/index.ts: prompt "${prompt.name}" declares duplicate argument "${arg.name}".`);
+      }
+      argNames.add(arg.name);
+    }
+
+    // Allow intro_substitutions[tokenName] as an additional declared token in
+    // the intro string (it's a synthetic name expanded BEFORE the ${arg}
+    // pass). The token names declared in intro_substitutions stand in for
+    // their conditional segments and don't need to appear in arguments[].
+    const introTokens = new Set<string>(prompt.intro_substitutions ? Object.keys(prompt.intro_substitutions) : []);
+
+    const validateTokensIn = (where: string, s: string): void => {
+      for (const tok of collectTokens(s)) {
+        if (!argNames.has(tok) && !introTokens.has(tok)) {
+          throw new Error(`api/mcp/prompts/index.ts: prompt "${prompt.name}" ${where} references unknown token "\${${tok}}". Declared args: [${[...argNames].join(', ')}]${introTokens.size ? `; intro substitutions: [${[...introTokens].join(', ')}]` : ''}.`);
+        }
+      }
+    };
+
+    validateTokensIn('intro', prompt.intro);
+    if (prompt.intro_substitutions) {
+      for (const [name, spec] of Object.entries(prompt.intro_substitutions)) {
+        // Inside intro_substitutions specs, only real argument names are
+        // permitted — synthetic names cannot reference each other.
+        for (const tok of collectTokens(spec.when_present)) {
+          if (!argNames.has(tok)) {
+            throw new Error(`api/mcp/prompts/index.ts: prompt "${prompt.name}" intro_substitutions.${name}.when_present references unknown token "\${${tok}}".`);
+          }
+        }
+        for (const tok of collectTokens(spec.when_absent)) {
+          if (!argNames.has(tok)) {
+            throw new Error(`api/mcp/prompts/index.ts: prompt "${prompt.name}" intro_substitutions.${name}.when_absent references unknown token "\${${tok}}".`);
+          }
+        }
+      }
+    }
+    for (const [i, step] of prompt.steps.entries()) {
+      const sink: string[] = [];
+      collectTokensFromValue(step.args, sink);
+      for (const tok of sink) {
+        if (!argNames.has(tok)) {
+          throw new Error(`api/mcp/prompts/index.ts: prompt "${prompt.name}" step ${i + 1} (${step.tool}) args reference unknown token "\${${tok}}".`);
+        }
+      }
+      validateTokensIn(`step ${i + 1} (${step.tool}) purpose`, step.purpose);
+    }
+  }
+}
+
+validatePromptRegistry();
+
+// ---------------------------------------------------------------------------
+// prompts/list public shape
+// ---------------------------------------------------------------------------
+// Per MCP spec, prompts/list returns `{prompts: [{name, description,
+// arguments}]}` — no `steps` / `intro`. Internal authoring fields stay
+// internal; the wire shape is the spec's.
+export interface PublicPromptShape {
+  name: string;
+  description: string;
+  arguments: McpPromptArgument[];
+}
+
+export const PROMPT_LIST_RESPONSE: PublicPromptShape[] = PROMPT_REGISTRY.map((p) => ({
+  name: p.name,
+  description: p.description,
+  arguments: p.arguments.map((a) => ({ ...a })),
+}));

--- a/api/mcp/types.ts
+++ b/api/mcp/types.ts
@@ -225,3 +225,43 @@ export interface AuthResolutionRejected {
   ok: false;
   response: Response;
 }
+
+// ---------------------------------------------------------------------------
+// Prompts registry types (MCP 2025-03-26 prompts capability)
+// ---------------------------------------------------------------------------
+export interface McpPromptArgument {
+  name: string;
+  description: string;
+  required: boolean;
+}
+
+// One tool-call step inside a prompt workflow. `args` is a JSON-shaped value
+// where string leaves may carry `${argname}` tokens; the prompt renderer
+// substitutes them against the call-time provided arguments. `jmespath` is
+// a literal expression (no substitution) validated against the targeted
+// tool's outputSchema by tests/mcp-prompts.test.mjs.
+export interface McpPromptStep {
+  tool: string;
+  args: Record<string, unknown>;
+  jmespath: string;
+  purpose: string;
+}
+
+// Optional intro conditional-substitution map. The key is a synthetic token
+// name (e.g. `country_suffix`); its presence in the intro string toggles
+// between `when_present` (any controlling arg has a non-empty value) and
+// `when_absent`. Lets the same prompt express both "filtered" and "global"
+// renders without a per-prompt code branch.
+export interface McpPromptIntroSubstitution {
+  when_present: string;
+  when_absent: string;
+}
+
+export interface McpPromptDef {
+  name: string;
+  description: string;
+  arguments: McpPromptArgument[];
+  steps: McpPromptStep[];
+  intro: string;
+  intro_substitutions?: Record<string, McpPromptIntroSubstitution>;
+}

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -1,7 +1,7 @@
 {
   "serverInfo": {
     "name": "worldmonitor",
-    "version": "1.7.0",
+    "version": "1.8.0",
     "description": "WorldMonitor's live global-intelligence stack as an MCP server: real-time markets, conflict events, aviation, maritime, energy, climate, health, displacement, supply chain, and AI-generated regional briefs.",
     "vendor": "WorldMonitor",
     "homepage": "https://www.worldmonitor.app"
@@ -15,7 +15,7 @@
     "tools": true,
     "logging": true,
     "resources": false,
-    "prompts": false
+    "prompts": true
   },
   "tools": {
     "count": 39,

--- a/tests/mcp-jmespath.test.mjs
+++ b/tests/mcp-jmespath.test.mjs
@@ -300,12 +300,12 @@ describe('api/mcp.ts — JMESPath projection (v1.7.0)', () => {
   // Initialize handshake — version + instructions
   // ============================================================
   describe('initialize handshake', () => {
-    it('serverInfo.version === "1.7.0"', async () => {
+    it('serverInfo.version === "1.8.0"', async () => {
       // Tracks current SERVER_VERSION. Each minor bump needs to update
       // this assertion + the cross-check at line 327 below.
       const res = await mod.default(makeReq(initBody(1)));
       const body = await res.json();
-      assert.equal(body.result?.serverInfo?.version, '1.7.0');
+      assert.equal(body.result?.serverInfo?.version, '1.8.0');
     });
 
     it('result.instructions is present and mentions jmespath', async () => {
@@ -326,12 +326,12 @@ describe('api/mcp.ts — JMESPath projection (v1.7.0)', () => {
       assert.ok(/daily quota/i.test(inst), 'missing quota note');
     });
 
-    it('server-card.json version matches SERVER_VERSION (currently 1.7.0)', () => {
+    it('server-card.json version matches SERVER_VERSION (currently 1.8.0)', () => {
       // Cross-check the comment at api/mcp.ts:~56 — discovery scanners
       // verify both values; a future bump that misses one would break
       // discovery. This is the test that prevents that drift.
       const card = JSON.parse(readFileSync(new URL('../public/.well-known/mcp/server-card.json', import.meta.url), 'utf8'));
-      assert.equal(card.serverInfo.version, '1.7.0');
+      assert.equal(card.serverInfo.version, '1.8.0');
       assert.equal(card.features?.responseProjection, 'jmespath');
     });
 
@@ -339,7 +339,7 @@ describe('api/mcp.ts — JMESPath projection (v1.7.0)', () => {
       const res = await mod.default(makeReq(initBody(4)));
       const body = await res.json();
       assert.equal(body.result?.protocolVersion, '2025-03-26');
-      assert.deepEqual(body.result?.capabilities, { tools: {}, logging: {} });
+      assert.deepEqual(body.result?.capabilities, { tools: {}, logging: {}, prompts: { listChanged: false } });
       assert.equal(body.result?.serverInfo?.name, 'worldmonitor');
     });
   });

--- a/tests/mcp-prompts.test.mjs
+++ b/tests/mcp-prompts.test.mjs
@@ -180,6 +180,28 @@ describe('api/mcp.ts — prompts capability + JMESPath-vs-schema parity', () => 
     assert.ok(text.includes('for DE'), `optional-arg-present branch must include "for DE" — got: ${text.slice(0, 200)}…`);
   });
 
+  it('prompts/get strips empty-string optional args from the rendered tool-arguments block', async () => {
+    // Regression guard: when an optional arg is omitted, the renderer must
+    // emit `arguments: {}` (no-filter) — NOT `{"country":""}`. Passing "" to
+    // a future tool that guards with `!== undefined` would filter by empty
+    // string instead of returning the global view.
+    const res = await handler(makeReq('POST', {
+      jsonrpc: '2.0', id: 9, method: 'prompts/get',
+      params: { name: 'energy-shock-watch', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    const text = body.result?.messages?.[0]?.content?.text ?? '';
+    assert.ok(
+      text.includes('arguments: {}'),
+      `omitted optional arg must render as {} — got: ${text.slice(0, 400)}…`,
+    );
+    assert.ok(
+      !text.includes('"country":""'),
+      `omitted optional arg must NOT render as {"country":""} — got: ${text.slice(0, 400)}…`,
+    );
+  });
+
   // -------------------------------------------------------------------------
   // prompts/get error paths
   // -------------------------------------------------------------------------

--- a/tests/mcp-prompts.test.mjs
+++ b/tests/mcp-prompts.test.mjs
@@ -1,0 +1,338 @@
+// MCP prompts wire-contract + JMESPath-vs-schema parity.
+//
+// Three concerns:
+//   1. prompts/list returns the documented six entries with the spec-shaped
+//      {name, description, arguments} fields. Detects accidental registry
+//      truncation or schema-shape drift.
+//   2. prompts/get interpolates ${arg} tokens, surfaces -32602 for unknown
+//      names and missing required args. Detects the substitution-grammar
+//      regressions that the load-time validator can't see (it only checks
+//      authoring; this exercises runtime).
+//   3. JMESPath-vs-schema parity (the load-bearing assertion). For every
+//      prompt, for every step:
+//        a. the step's `tool` exists in TOOL_REGISTRY,
+//        b. the step's `jmespath` compiles via the same parser the handler
+//           uses at runtime,
+//        c. every field identifier the expression references exists as a
+//           property NAME somewhere in the referenced tool's outputSchema.
+//      A typo'd field path in a prompt OR a renamed field in a tool's schema
+//      fails this test by name, citing the prompt and the offending path.
+//
+// Phase-1 scope: presence-level parity, not full path-level (a Field name
+// must appear in the schema somewhere, not necessarily at the exact
+// dot-path). This is strong enough to catch both sabotage cases documented
+// in the executing-agent notes: a typo'd field name disappears from the
+// schema; a renamed schema field disappears from prompts' Field set. Phase 2
+// (full path-level eval against fixtures) is a follow-up issue.
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import jmespath from 'jmespath';
+
+import {
+  BASE_URL,
+} from './helpers/mcp-pro-deps.mjs';
+
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+
+const VALID_KEY = 'wm_test_key_prompts';
+
+function makeReq(method = 'POST', body = null, headers = {}) {
+  return new Request(BASE_URL, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      'X-WorldMonitor-Key': VALID_KEY,
+      ...headers,
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+let handler;
+let PROMPT_REGISTRY;
+let TOOL_REGISTRY;
+
+describe('api/mcp.ts — prompts capability + JMESPath-vs-schema parity', () => {
+  beforeEach(async () => {
+    process.env.WORLDMONITOR_VALID_KEYS = VALID_KEY;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    process.env.MCP_TELEMETRY = 'false';
+
+    const mod = await import(`../api/mcp.ts?t=${Date.now()}-prompts`);
+    handler = mod.default;
+    PROMPT_REGISTRY = mod.__testing__.PROMPT_REGISTRY;
+    TOOL_REGISTRY = mod.__testing__.TOOL_REGISTRY;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    Object.keys(process.env).forEach((k) => {
+      if (!(k in originalEnv)) delete process.env[k];
+    });
+    Object.assign(process.env, originalEnv);
+  });
+
+  // -------------------------------------------------------------------------
+  // initialize advertises the new capability
+  // -------------------------------------------------------------------------
+  it('initialize advertises capabilities.prompts.listChanged = false', async () => {
+    const res = await handler(makeReq('POST', {
+      jsonrpc: '2.0', id: 1, method: 'initialize',
+      params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'test', version: '1.0' } },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.result?.capabilities?.prompts, 'capabilities.prompts must be present');
+    assert.equal(
+      body.result.capabilities.prompts.listChanged, false,
+      'capabilities.prompts.listChanged must be false (stateless transport can\'t push notifications/prompts/list_changed)',
+    );
+    // Sibling capabilities must NOT be regressed by the additive change.
+    assert.ok(body.result.capabilities.tools, 'capabilities.tools must still be present');
+    assert.ok(body.result.capabilities.logging, 'capabilities.logging must still be present');
+  });
+
+  // -------------------------------------------------------------------------
+  // prompts/list shape
+  // -------------------------------------------------------------------------
+  it('prompts/list returns the six documented entries with name/description/arguments', async () => {
+    const res = await handler(makeReq('POST', { jsonrpc: '2.0', id: 2, method: 'prompts/list', params: {} }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(Array.isArray(body.result?.prompts), 'result.prompts must be an array');
+    assert.equal(body.result.prompts.length, 6, `Expected 6 prompts, got ${body.result.prompts.length}`);
+
+    const expectedNames = [
+      'country-briefing', 'energy-shock-watch', 'market-open-prep',
+      'conflict-pulse', 'route-risk-check', 'freshness-audit',
+    ];
+    const actualNames = body.result.prompts.map((p) => p.name);
+    assert.deepEqual(actualNames, expectedNames, 'prompt names and order must match the documented set');
+
+    for (const prompt of body.result.prompts) {
+      assert.equal(typeof prompt.name, 'string', `prompt ${prompt.name}: name must be a string`);
+      assert.ok(prompt.name.length > 0, `prompt ${prompt.name}: name must be non-empty`);
+      assert.equal(typeof prompt.description, 'string', `prompt ${prompt.name}: description must be a string`);
+      assert.ok(prompt.description.length > 0, `prompt ${prompt.name}: description must be non-empty`);
+      assert.ok(Array.isArray(prompt.arguments), `prompt ${prompt.name}: arguments must be an array`);
+      for (const arg of prompt.arguments) {
+        assert.equal(typeof arg.name, 'string', `prompt ${prompt.name}: argument name must be a string`);
+        assert.equal(typeof arg.description, 'string', `prompt ${prompt.name}: argument description must be a string`);
+        assert.equal(typeof arg.required, 'boolean', `prompt ${prompt.name}: argument required must be a boolean`);
+      }
+      // Internal authoring fields must NOT leak via prompts/list.
+      assert.equal(prompt.steps, undefined, `prompt ${prompt.name}: internal "steps" must not leak via prompts/list`);
+      assert.equal(prompt.intro, undefined, `prompt ${prompt.name}: internal "intro" must not leak via prompts/list`);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // prompts/get success
+  // -------------------------------------------------------------------------
+  it('prompts/get(country-briefing, {iso2: "DE"}) renders the iso2 into the message text', async () => {
+    const res = await handler(makeReq('POST', {
+      jsonrpc: '2.0', id: 3, method: 'prompts/get',
+      params: { name: 'country-briefing', arguments: { iso2: 'DE' } },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.result?.description, 'result.description must be present');
+    assert.ok(Array.isArray(body.result?.messages), 'result.messages must be an array');
+    assert.ok(body.result.messages.length >= 1, 'result.messages must contain at least one message');
+
+    const msg = body.result.messages[0];
+    assert.equal(msg.role, 'user', 'rendered message role must be "user"');
+    assert.equal(msg.content?.type, 'text', 'rendered message content.type must be "text"');
+    assert.ok(typeof msg.content?.text === 'string', 'rendered message content.text must be a string');
+    assert.ok(msg.content.text.includes('DE'), `rendered message must contain the interpolated iso2 "DE" — got: ${msg.content.text.slice(0, 200)}…`);
+    // Every step's tool name should appear in the rendered text (so the LLM
+    // sees the call plan, not an opaque "do something" instruction).
+    for (const expectedTool of ['get_country_risk', 'get_country_brief', 'get_country_macro']) {
+      assert.ok(
+        msg.content.text.includes(expectedTool),
+        `rendered message must reference step tool "${expectedTool}" — got: ${msg.content.text.slice(0, 200)}…`,
+      );
+    }
+  });
+
+  it('prompts/get(energy-shock-watch, {}) renders the "global view" branch when the optional arg is omitted', async () => {
+    const res = await handler(makeReq('POST', {
+      jsonrpc: '2.0', id: 4, method: 'prompts/get',
+      params: { name: 'energy-shock-watch', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    const text = body.result?.messages?.[0]?.content?.text ?? '';
+    assert.ok(text.includes('global view'), `optional-arg-absent branch must include "global view" — got: ${text.slice(0, 200)}…`);
+  });
+
+  it('prompts/get(energy-shock-watch, {country: "DE"}) renders the country-filter branch', async () => {
+    const res = await handler(makeReq('POST', {
+      jsonrpc: '2.0', id: 5, method: 'prompts/get',
+      params: { name: 'energy-shock-watch', arguments: { country: 'DE' } },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    const text = body.result?.messages?.[0]?.content?.text ?? '';
+    assert.ok(text.includes('for DE'), `optional-arg-present branch must include "for DE" — got: ${text.slice(0, 200)}…`);
+  });
+
+  // -------------------------------------------------------------------------
+  // prompts/get error paths
+  // -------------------------------------------------------------------------
+  it('prompts/get with an unknown name returns -32602', async () => {
+    const res = await handler(makeReq('POST', {
+      jsonrpc: '2.0', id: 6, method: 'prompts/get',
+      params: { name: 'no-such-prompt', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.error?.code, -32602, `unknown prompt name must be -32602, got ${body.error?.code}`);
+    assert.ok(/Unknown prompt/i.test(body.error?.message ?? ''), 'error message should explain the unknown-prompt condition');
+  });
+
+  it('prompts/get with a missing required argument returns -32602', async () => {
+    const res = await handler(makeReq('POST', {
+      jsonrpc: '2.0', id: 7, method: 'prompts/get',
+      params: { name: 'country-briefing', arguments: {} },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.error?.code, -32602, `missing required arg must be -32602, got ${body.error?.code}`);
+    assert.ok(/iso2/.test(body.error?.message ?? ''), 'error message should name the missing required argument');
+  });
+
+  it('prompts/get with missing params returns -32602', async () => {
+    const res = await handler(makeReq('POST', {
+      jsonrpc: '2.0', id: 8, method: 'prompts/get',
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.error?.code, -32602, 'missing params must be -32602');
+  });
+
+  // -------------------------------------------------------------------------
+  // Tool-name parity (every step.tool exists in TOOL_REGISTRY)
+  // -------------------------------------------------------------------------
+  it('every prompt step references a tool that exists in TOOL_REGISTRY', () => {
+    const toolNames = new Set(TOOL_REGISTRY.map((t) => t.name));
+    for (const prompt of PROMPT_REGISTRY) {
+      for (const [i, step] of prompt.steps.entries()) {
+        assert.ok(
+          toolNames.has(step.tool),
+          `prompt "${prompt.name}" step ${i + 1} references unknown tool "${step.tool}". Known tools: [${[...toolNames].sort().join(', ')}]`,
+        );
+      }
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // JMESPath-vs-schema parity (load-bearing)
+  // -------------------------------------------------------------------------
+  it('every prompt step JMESPath compiles and references only fields declared in the tool\'s outputSchema', () => {
+    const toolByName = new Map(TOOL_REGISTRY.map((t) => [t.name, t]));
+
+    for (const prompt of PROMPT_REGISTRY) {
+      for (const [i, step] of prompt.steps.entries()) {
+        const tool = toolByName.get(step.tool);
+        assert.ok(tool, `prompt "${prompt.name}" step ${i + 1}: unknown tool "${step.tool}" (covered by sibling test, but guard here too)`);
+
+        // (a) Compiles.
+        let ast;
+        try {
+          ast = jmespath.compile(step.jmespath);
+        } catch (err) {
+          assert.fail(`prompt "${prompt.name}" step ${i + 1} (${step.tool}): JMESPath failed to compile: ${step.jmespath} — ${(err && err.message) || err}`);
+        }
+        assert.ok(ast, `prompt "${prompt.name}" step ${i + 1} (${step.tool}): jmespath.compile returned no AST for ${step.jmespath}`);
+
+        // (b) Every Field identifier appears in the tool's outputSchema.
+        const referencedFields = collectFieldNames(ast);
+        const declaredProps = collectSchemaPropertyNames(tool.outputSchema);
+        for (const field of referencedFields) {
+          assert.ok(
+            declaredProps.has(field),
+            `prompt "${prompt.name}" step ${i + 1} (${step.tool}): JMESPath "${step.jmespath}" references field "${field}" which is NOT declared in the tool's outputSchema. Declared (sample): [${[...declaredProps].slice(0, 30).sort().join(', ')}${declaredProps.size > 30 ? ', …' : ''}]`,
+          );
+        }
+      }
+    }
+  });
+});
+
+// -----------------------------------------------------------------------------
+// JMESPath AST walker — collect Field identifier names.
+//
+// Field nodes carry `name` (the source-data identifier). KeyValuePair nodes
+// (inside MultiSelectHash) carry `name` too but it's the OUTPUT key, not a
+// source field — recurse into `value` only. Same posture for MultiSelectList
+// (recurse into each child).
+// -----------------------------------------------------------------------------
+function collectFieldNames(node) {
+  const out = new Set();
+  walk(node, out);
+  return out;
+}
+function walk(node, sink) {
+  if (!node || typeof node !== 'object') return;
+  if (node.type === 'Field' && typeof node.name === 'string') {
+    sink.add(node.name);
+    return;
+  }
+  if (node.type === 'KeyValuePair') {
+    // skip node.name (output key), recurse into value
+    walk(node.value, sink);
+    return;
+  }
+  if (Array.isArray(node.children)) {
+    for (const child of node.children) walk(child, sink);
+  }
+  // KeyValuePair handled above; some node types use `.value` for the inner
+  // expression (e.g. FilterProjection condition uses `children[2]`; safe
+  // because we walk every child of `children`).
+  if (node.value && typeof node.value === 'object' && node.value.type) {
+    walk(node.value, sink);
+  }
+}
+
+// -----------------------------------------------------------------------------
+// JSON-Schema walker — collect every property NAME at any nesting level.
+//
+// Presence-level check (Phase 1). Walks:
+//   - properties: { foo: <schema> } → adds "foo", recurses into <schema>
+//   - additionalProperties: <schema> → recurses (does NOT add a key)
+//   - items: <schema> | <schema[]>   → recurses
+//   - allOf/oneOf/anyOf: <schema[]>  → recurses each
+// Bounded by the schema's own structural depth, which our outputSchemas are
+// shallow (≤6 levels). Phase 2 (path-level parity vs. captured fixtures) is
+// a follow-up issue.
+// -----------------------------------------------------------------------------
+function collectSchemaPropertyNames(schema) {
+  const out = new Set();
+  walkSchema(schema, out);
+  return out;
+}
+function walkSchema(s, sink) {
+  if (!s || typeof s !== 'object') return;
+  if (s.properties && typeof s.properties === 'object') {
+    for (const [name, sub] of Object.entries(s.properties)) {
+      sink.add(name);
+      walkSchema(sub, sink);
+    }
+  }
+  if (s.additionalProperties && typeof s.additionalProperties === 'object') {
+    walkSchema(s.additionalProperties, sink);
+  }
+  if (s.items) {
+    if (Array.isArray(s.items)) for (const sub of s.items) walkSchema(sub, sink);
+    else walkSchema(s.items, sink);
+  }
+  for (const combinator of ['allOf', 'oneOf', 'anyOf']) {
+    if (Array.isArray(s[combinator])) {
+      for (const sub of s[combinator]) walkSchema(sub, sink);
+    }
+  }
+}

--- a/tests/mcp-tools-list-compression.test.mjs
+++ b/tests/mcp-tools-list-compression.test.mjs
@@ -359,14 +359,14 @@ describe('api/mcp.ts — tools/list description compression (v1.7.0)', () => {
     // ============================================================
     // U4: Version bump + SERVER_INSTRUCTIONS + server-card sync
     // ============================================================
-    it('serverInfo.version === "1.7.0"', async () => {
+    it('serverInfo.version === "1.8.0"', async () => {
       const res = await mod.default(new Request('https://worldmonitor.app/mcp', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-WorldMonitor-Key': VALID_KEY },
         body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 't', version: '1' } } }),
       }));
       const body = await res.json();
-      assert.equal(body.result?.serverInfo?.version, '1.7.0');
+      assert.equal(body.result?.serverInfo?.version, '1.8.0');
     });
 
     it('initialize.result.instructions mentions describe_tool AND the TOOL_DESCRIPTION_MAX_BYTES cap value', async () => {
@@ -383,9 +383,9 @@ describe('api/mcp.ts — tools/list description compression (v1.7.0)', () => {
         'instructions should mention the TOOL_DESCRIPTION_MAX_BYTES cap');
     });
 
-    it('server-card.json version matches SERVER_VERSION (1.7.0) AND tools.count matches (39)', () => {
+    it('server-card.json version matches SERVER_VERSION (1.8.0) AND tools.count matches (39)', () => {
       const card = JSON.parse(readFileSync(new URL('../public/.well-known/mcp/server-card.json', import.meta.url), 'utf8'));
-      assert.equal(card.serverInfo.version, '1.7.0');
+      assert.equal(card.serverInfo.version, '1.8.0');
       assert.equal(card.tools.count, 39);
       assert.equal(card.features?.toolDescriptionCompression, true);
       assert.equal(card.features?.responseProjection, 'jmespath',


### PR DESCRIPTION
## Summary

Turns on the MCP `prompts` capability with six concrete workflow templates exposed via `prompts/list` + `prompts/get` JSON-RPC. Each step pre-bakes a literal JMESPath projection so the first execution lands on the right shape without a discover-then-retry round-trip.

The load-bearing addition is the parity test (`tests/mcp-prompts.test.mjs`): for every prompt step, it compiles the embedded JMESPath via the same parser the handler uses at runtime and asserts every field identifier resolves to a property in the referenced tool's declared `outputSchema`. A typo'd field path in a prompt OR a renamed field in a tool's schema fails the test by name with both the prompt and the broken path.

## Prompts shipped (tool-call mapping)

| Prompt | Arg(s) | Tool calls (with literal JMESPath projection) |
|---|---|---|
| `country-briefing` | `iso2` (required) | `get_country_risk`, `get_country_brief`, `get_country_macro` |
| `energy-shock-watch` | `country` (optional) | `get_energy_intelligence` |
| `market-open-prep` | — | `get_market_data` |
| `conflict-pulse` | `country` (optional) | `get_conflict_events`, `get_news_intelligence` |
| `route-risk-check` | `chokepoint` (required) | `get_chokepoint_status` |
| `freshness-audit` | — | `get_market_data`, `get_energy_intelligence`, `get_chokepoint_status` (each with `summary: true`, projecting only `cached_at` + `stale`) |

## Decisions documented

- **Module location:** `api/mcp/prompts/index.ts` (a new sibling to `api/mcp/registry/`), not inside `registry/`. Prompts are a distinct capability surface (own JSON-RPC methods, own list/get pair) and should not muddy the boundary that the recent structural split established.
- **Template format:** Structured `steps: [{tool, args, jmespath, purpose}]` per prompt — not freeform text with inline `jmespath:` markers. The structured shape lets the parity test walk every `{tool, jmespath}` pair directly without fragile regex extraction. Same content reaches the rendered message.
- **Substitution grammar:** `${argname}` over a strict whitelist of declared arg names. Unknown tokens are a load-time validation failure (collision-guard-style — matches `TOOL_REGISTRY`'s posture in `registry/index.ts`). String values inside nested arrays/objects in `args` are walked recursively. An `intro_substitutions` map lets a single prompt express both "filtered" and "global" intro branches without per-prompt code (used by `energy-shock-watch` and `conflict-pulse`).
- **Auth + quota:** `prompts/list` and `prompts/get` flow through the same auth-resolve + per-minute-limit gates as everything else, but are quota-exempt (no daily-quota reservation). Symmetric posture with `describe_tool` — template fetches against the 50/day cap would discourage exploration, which defeats the prompt-discovery point. The per-minute limiter still applies as the abuse guard.
- **JMESPath path extraction:** AST walk via `jmespath.compile`. Collects every `Field` node's `name` while recursing into `KeyValuePair.value` only (the `name` on a `KeyValuePair` is the output key in a multi-select hash, not a source field). Phase-1 parity is presence-level (every Field name must appear somewhere in the schema) rather than full path-level — strong enough to catch both sabotage cases and avoids the false-negative-prone path walk through `additionalProperties`-style schemas. Full path-level eval against fixtures is filed as a Phase-2 follow-up.

## Sabotage evidence

Both sabotages run against the parity test (`npx tsx --test tests/mcp-prompts.test.mjs`) before commit. Both fail with the prompt name AND the offending path in the message. Both reverted.

1. **Typo'd field path in a JMESPath.** Edited `energy-shock-watch`'s projection from `data."crisis-policies".policies` → `data."crisis-policies".policiez`. Test failed with: `prompt "energy-shock-watch" step 1 (get_energy_intelligence): JMESPath "..." references field "policiez" which is NOT declared in the tool's outputSchema.`
2. **Renamed field in a tool's outputSchema.** Edited `get_energy_intelligence` to rename `policies` → `policies_renamed_sabotage`. Test failed with: `prompt "energy-shock-watch" step 1 (get_energy_intelligence): JMESPath "..." references field "policies" which is NOT declared in the tool's outputSchema. Declared (sample): [..., policies_renamed_sabotage, ...]`

## Wire changes

- `initialize.result.capabilities` now includes `prompts: { listChanged: false }`. `listChanged: false` is the spec-correct value for our stateless edge transport — we can't push `notifications/prompts/list_changed` today.
- `SERVER_VERSION` 1.7.0 → 1.8.0 (additive wire-visible capability).
- `public/.well-known/mcp/server-card.json` flipped `prompts: false → true` in the same commit so external scanners see the wire and the card agree.
- `SERVER_INSTRUCTIONS` gains one sentence pointing the LLM at `prompts/list` as a discoverable affordance.

## Pre-existing tests touched

- `tests/mcp-jmespath.test.mjs` — version + capabilities assertion (1.7.0 → 1.8.0; capabilities deepEqual extended to include `prompts: { listChanged: false }`).
- `tests/mcp-tools-list-compression.test.mjs` — version assertion (1.7.0 → 1.8.0; server-card cross-check).

Neither test was a regression — they were tracking version + advertised-capability strings that this PR legitimately moves.

## Test plan

- [x] `npm run typecheck:api` green.
- [x] `npm run lint:api-contract` green (new module manifest entry added).
- [x] `npx tsx --test tests/mcp-prompts.test.mjs` — 10/10 green.
- [x] `npm run test:data` green.
- [x] Sabotage 1 (typo'd field path): test fails by prompt + path; reverted.
- [x] Sabotage 2 (renamed schema field): test fails by prompt + path; reverted.
- [ ] Manual curl smoke against Vercel preview: `prompts/list` returns 6, `prompts/get(country-briefing, {iso2: DE})` renders "DE" into the message text.
- [ ] Claude Desktop slash menu shows `/world-monitor:country-briefing` (smoke; if access available).

## Note for reviewer

Given the wire-visible capability change, please run `/ultrareview` before merge — a new MCP surface is exactly where a second cloud opinion catches the spec-compliance-vs-convenience trade-offs (the `listChanged: false` choice, the auth-symmetry decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)