### PR TITLE
fix(checkout): capture upstream 403 emitter; reclassify 403 as service_unavailable

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -202,6 +202,9 @@ Sentry.init({
     /Qt\([^)]*\) is not a function/,
     /shaderSource must be an instance of WebGLShader/,
     /WebGL2RenderingContext\.shaderSource: Argument 1 is not an object/,
+    // Chrome wording for the same condition (gl.createShader returned null,
+    // typically after WebGL context loss or on degraded GPU drivers). WORLDMONITOR-RM.
+    /Failed to execute 'shaderSource' on 'WebGL2?RenderingContext': parameter 1 is not of type 'WebGLShader'/,
     /Failed to initialize WebGL/,
     /opacityVertexArray\.length/,
     /Length of new data is \d+, which doesn't match current length of/,

--- a/src/services/checkout-errors.ts
+++ b/src/services/checkout-errors.ts
@@ -73,6 +73,12 @@ function extractServerMessage(body: CheckoutErrorBody | undefined): string | und
 function statusToCode(status: number, body: CheckoutErrorBody | undefined): CheckoutErrorCode {
   if (status === 401) return 'unauthorized';
   if (status === 409 && body?.error === ACTIVE_SUBSCRIPTION_EXISTS) return 'duplicate_subscription';
+  // 403 from /api/create-checkout is infrastructure (Vercel firewall / WAF / edge
+  // bot-protection) — neither the edge gateway nor the Convex relay handler
+  // ever emits 403 on this route. Treat as retryable service unavailability so
+  // the user gets accurate copy instead of the misleading "That product isn't
+  // available" they'd see under the generic 4xx → invalid_product branch.
+  if (status === 403) return 'service_unavailable';
   if (status >= 400 && status < 500) return 'invalid_product';
   if (status >= 500 && status < 600) return 'service_unavailable';
   return 'unknown';
@@ -128,4 +134,60 @@ export function classifySyntheticCheckoutError(
     userMessage: pickUserMessage(kind),
     retryable: RETRYABLE[kind],
   };
+}
+
+/**
+ * Snapshot of upstream-emitter identity captured from a failed HTTP
+ * response. Attached to the Sentry payload so a future 403/4xx event
+ * carries enough information to identify whether Cloudflare, Vercel,
+ * or our own app emitted it.
+ *
+ * Originating triage: WORLDMONITOR-RN — a 403 on /api/create-checkout
+ * had no signal beyond status code because the old failure path called
+ * `resp.json().catch(() => ({}))` and discarded both the response body
+ * (Cloudflare 403 pages are HTML and silently became `{}`) AND the
+ * response headers (cf-ray, server, x-vercel-id would have named the
+ * emitter in one glance). This snapshot is the diagnostic recovery.
+ */
+export interface UpstreamSnapshot {
+  /** Cloudflare ray identifier — presence is definitive for CF emission. */
+  cfRay?: string;
+  /** `server` response header — "cloudflare" / "Vercel" / etc. */
+  server?: string;
+  /** Vercel function/edge invocation ID — presence means Vercel saw the request. */
+  vercelId?: string;
+  /** Vercel cache status (HIT/MISS/STALE/BYPASS). */
+  vercelCache?: string;
+  /** First 200 chars of the response body (truncated). HTML 403 pages from
+   *  CF/Vercel are distinctive; our own JSON errors fit comfortably. */
+  bodySnippet?: string;
+}
+
+const BODY_SNIPPET_MAX = 200;
+
+/**
+ * Build an UpstreamSnapshot from a fetch Response (already-read text body
+ * is passed in because Response bodies are single-use; the caller must
+ * read it once for both classifier parsing and snapshot capture).
+ *
+ * All fields are optional — missing headers map to `undefined`, not
+ * empty strings, so Sentry's `extra` view filters cleanly.
+ */
+export function snapshotUpstreamResponse(
+  resp: Pick<Response, 'headers'>,
+  rawBody: string,
+): UpstreamSnapshot {
+  const headers = resp.headers;
+  const snap: UpstreamSnapshot = {
+    cfRay: headers.get('cf-ray') ?? undefined,
+    server: headers.get('server') ?? undefined,
+    vercelId: headers.get('x-vercel-id') ?? undefined,
+    vercelCache: headers.get('x-vercel-cache') ?? undefined,
+  };
+  if (rawBody.length > 0) {
+    snap.bodySnippet = rawBody.length > BODY_SNIPPET_MAX
+      ? rawBody.slice(0, BODY_SNIPPET_MAX)
+      : rawBody;
+  }
+  return snap;
 }

--- a/src/services/checkout-errors.ts
+++ b/src/services/checkout-errors.ts
@@ -166,6 +166,37 @@ export interface UpstreamSnapshot {
 const BODY_SNIPPET_MAX = 200;
 
 /**
+ * Safely parse a response body string into a CheckoutErrorBody.
+ *
+ * Returns `{}` for: invalid JSON, the literal `null`, JSON arrays,
+ * JSON primitives (numbers, strings, booleans). Only a plain-object
+ * parse result is accepted — anything else would be a structural lie
+ * if cast to CheckoutErrorBody (which is a `{ error?, message?, code? }`
+ * shape) and would set traps for future consumers that don't add
+ * defensive optional-chaining.
+ *
+ * Why this matters even though current callers are defensive: the cast
+ * is an implicit contract. A future consumer writing
+ * `body.message.toLowerCase()` against a server that returned `null` or
+ * `[]` would crash. Returning `{}` from this helper makes the contract
+ * "downstream may treat body as a plain CheckoutErrorBody-shaped object"
+ * actually true at runtime. (Greptile P2 review of PR #3894.)
+ */
+export function parseCheckoutErrorBody(rawText: string): CheckoutErrorBody {
+  if (rawText.length === 0) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch {
+    return {};
+  }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {};
+  }
+  return parsed as CheckoutErrorBody;
+}
+
+/**
  * Build an UpstreamSnapshot from a fetch Response (already-read text body
  * is passed in because Response bodies are single-use; the caller must
  * read it once for both classifier parsing and snapshot capture).

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -22,6 +22,7 @@ import {
   classifyHttpCheckoutError,
   classifySyntheticCheckoutError,
   classifyThrownCheckoutError,
+  parseCheckoutErrorBody,
   snapshotUpstreamResponse,
   type CheckoutError,
   type CheckoutErrorBody,
@@ -745,13 +746,12 @@ export async function startCheckout(
       // for our own JSON error envelopes. WORLDMONITOR-RN.
       const rawText = await resp.text().catch(() => '');
       const upstream = snapshotUpstreamResponse(resp, rawText);
-      let body: CheckoutErrorBody = {};
-      try {
-        body = JSON.parse(rawText) as CheckoutErrorBody;
-      } catch {
-        // HTML / empty body — leave classifier with an empty object so
-        // the existing status-code-driven branches behave unchanged.
-      }
+      // parseCheckoutErrorBody returns {} for invalid JSON AND for valid
+      // JSON that isn't a plain object (null / array / primitive), making
+      // the implicit "body is CheckoutErrorBody-shaped" contract true at
+      // runtime — defensive against future consumers that don't add their
+      // own optional chaining. Greptile P2 review of PR #3894.
+      const body = parseCheckoutErrorBody(rawText);
       const error = classifyHttpCheckoutError(resp.status, body);
       reportCheckoutError(error, { productId, action: 'http-error' }, undefined, upstream);
       // 409 duplicate-subscription — confirm with the user BEFORE

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -22,9 +22,11 @@ import {
   classifyHttpCheckoutError,
   classifySyntheticCheckoutError,
   classifyThrownCheckoutError,
+  snapshotUpstreamResponse,
   type CheckoutError,
   type CheckoutErrorBody,
   type CheckoutErrorCode,
+  type UpstreamSnapshot,
 } from './checkout-errors';
 import { showCheckoutErrorToast } from './checkout-error-toast';
 import { decideNoUserPathOutcome } from './checkout-no-user-policy';
@@ -736,9 +738,22 @@ export async function startCheckout(
     });
 
     if (!resp.ok) {
-      const body = (await resp.json().catch(() => ({}))) as CheckoutErrorBody;
+      // Read body as text FIRST so we can both snapshot it for Sentry
+      // (Cloudflare / Vercel deployment-protection 403s are HTML, not
+      // JSON — the old `resp.json().catch(() => ({}))` swallowed the
+      // smoking-gun page) AND still attempt structured-body parsing
+      // for our own JSON error envelopes. WORLDMONITOR-RN.
+      const rawText = await resp.text().catch(() => '');
+      const upstream = snapshotUpstreamResponse(resp, rawText);
+      let body: CheckoutErrorBody = {};
+      try {
+        body = JSON.parse(rawText) as CheckoutErrorBody;
+      } catch {
+        // HTML / empty body — leave classifier with an empty object so
+        // the existing status-code-driven branches behave unchanged.
+      }
       const error = classifyHttpCheckoutError(resp.status, body);
-      reportCheckoutError(error, { productId, action: 'http-error' });
+      reportCheckoutError(error, { productId, action: 'http-error' }, undefined, upstream);
       // 409 duplicate-subscription — confirm with the user BEFORE
       // navigating to the billing portal. Previously the portal opened
       // silently in a new tab, which was disorienting for users who
@@ -773,11 +788,15 @@ export async function startCheckout(
       // inline so the post-auth Clerk listener can auto-resume the
       // exact checkout without manual re-click.
       //
-      // 403 is intentionally NOT routed here: 403 = valid auth but
-      // forbidden action (banned account, plan-tier mismatch, etc.).
-      // Reopening sign-in would not change the outcome and would
-      // confuse the user. 403 falls through to the normal error
-      // surface (toast) below.
+      // 403 is intentionally NOT routed here. Neither api/create-checkout.ts
+      // nor the Convex /relay/create-checkout handler ever emits 403 —
+      // observed 403s on this route originate above our function
+      // (Cloudflare Bot Fight Mode on datacenter IPs, Vercel Deployment
+      // Protection, a client-side proxy/extension, etc.). 403 maps to
+      // service_unavailable + retryable=true in the classifier so the
+      // user sees retry-friendly copy; reopening sign-in wouldn't help.
+      // The `upstream` snapshot captured above identifies which layer
+      // emitted it (WORLDMONITOR-RN).
       if (error.code === 'unauthorized' || error.code === 'session_expired') {
         savePendingCheckoutIntent({
           productId,
@@ -846,6 +865,7 @@ function reportCheckoutError(
   error: CheckoutError,
   context: { productId: string; action: string },
   caught?: unknown,
+  upstream?: UpstreamSnapshot,
 ): void {
   const level: SentryLevel = INFO_LEVEL_CODES.has(error.code) ? 'info' : 'error';
   const payload = {
@@ -854,11 +874,17 @@ function reportCheckoutError(
       component: 'dodo-checkout',
       action: context.action,
       code: error.code,
+      // Promote cf-ray and server to tags so they're filterable in the
+      // Sentry UI without opening the event. cf-ray presence alone is
+      // definitive for Cloudflare emission. WORLDMONITOR-RN.
+      ...(upstream?.cfRay ? { cfRay: upstream.cfRay } : {}),
+      ...(upstream?.server ? { upstreamServer: upstream.server } : {}),
     },
     extra: {
       productId: context.productId,
       httpStatus: error.httpStatus,
       serverMessage: error.serverMessage,
+      ...(upstream ? { upstream } : {}),
     },
   };
   if (!shouldSkipSentryForAction(context.action)) {

--- a/tests/checkout-error-classification.test.mts
+++ b/tests/checkout-error-classification.test.mts
@@ -47,6 +47,18 @@ describe('classifyHttpCheckoutError', () => {
     assert.equal(err.code, 'invalid_product');
   });
 
+  // 403 on the create-checkout edge route never comes from our handler or the
+  // Convex relay — it's Vercel firewall / edge bot-protection. "Temporarily
+  // unavailable" copy is honest and retryable; the generic 4xx copy ("That
+  // product isn't available") is misleading and tells the user to refresh
+  // forever. Originally surfaced as Sentry WORLDMONITOR-RN.
+  it('maps 403 to service_unavailable (infra block, retryable)', () => {
+    const err = classifyHttpCheckoutError(403);
+    assert.equal(err.code, 'service_unavailable');
+    assert.equal(err.retryable, true);
+    assert.equal(err.httpStatus, 403);
+  });
+
   it('maps 500 to service_unavailable', () => {
     const err = classifyHttpCheckoutError(500);
     assert.equal(err.code, 'service_unavailable');

--- a/tests/checkout-upstream-snapshot.test.mts
+++ b/tests/checkout-upstream-snapshot.test.mts
@@ -1,0 +1,90 @@
+/**
+ * Locks the upstream-emitter snapshot used to identify whether a failed
+ * /api/create-checkout response came from Cloudflare, Vercel, our own
+ * function, or a client-side middlebox. Regression scope:
+ * WORLDMONITOR-RN — the old failure path discarded both the response
+ * body (CF 403 pages are HTML, silently became `{}`) and headers
+ * (cf-ray / server / x-vercel-id would have named the emitter).
+ *
+ * The snapshot is what makes the next 403 self-diagnosing in Sentry.
+ * If a future refactor drops one of these fields, the corresponding
+ * test fails and the diagnostic capability silently regresses.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { snapshotUpstreamResponse } from '../src/services/checkout-errors.ts';
+
+function makeResp(headers: Record<string, string>): { headers: Headers } {
+  return { headers: new Headers(headers) };
+}
+
+describe('snapshotUpstreamResponse', () => {
+  it('captures Cloudflare cf-ray and server when present (definitive CF signal)', () => {
+    const snap = snapshotUpstreamResponse(
+      makeResp({ 'cf-ray': 'a00d6f7b7b9bfb0a-FRA', server: 'cloudflare' }),
+      '<!DOCTYPE html><html>Cloudflare blocked you</html>',
+    );
+    assert.equal(snap.cfRay, 'a00d6f7b7b9bfb0a-FRA');
+    assert.equal(snap.server, 'cloudflare');
+    assert.equal(snap.vercelId, undefined);
+    assert.ok(snap.bodySnippet?.includes('Cloudflare'));
+  });
+
+  it('captures Vercel x-vercel-id and x-vercel-cache when present', () => {
+    const snap = snapshotUpstreamResponse(
+      makeResp({
+        'x-vercel-id': 'fra1::abc123',
+        'x-vercel-cache': 'MISS',
+        server: 'Vercel',
+      }),
+      '{"error":"Unauthorized"}',
+    );
+    assert.equal(snap.vercelId, 'fra1::abc123');
+    assert.equal(snap.vercelCache, 'MISS');
+    assert.equal(snap.server, 'Vercel');
+    assert.equal(snap.cfRay, undefined);
+  });
+
+  it('truncates body snippet to 200 chars to stay well under Sentry payload caps', () => {
+    const longBody = 'x'.repeat(5000);
+    const snap = snapshotUpstreamResponse(makeResp({}), longBody);
+    assert.equal(snap.bodySnippet?.length, 200);
+    assert.equal(snap.bodySnippet, 'x'.repeat(200));
+  });
+
+  it('omits bodySnippet when body is empty (signal vs noise — undefined is filterable)', () => {
+    const snap = snapshotUpstreamResponse(makeResp({}), '');
+    assert.equal(snap.bodySnippet, undefined);
+  });
+
+  it('returns all-undefined header fields when no upstream identifiers present (client middlebox case)', () => {
+    // An ad blocker or VPN-side interception layer that synthesizes a
+    // 403 typically strips standard upstream headers. Empty snapshot +
+    // empty body is itself the signal: "neither CF nor Vercel saw this."
+    const snap = snapshotUpstreamResponse(makeResp({}), '');
+    assert.equal(snap.cfRay, undefined);
+    assert.equal(snap.server, undefined);
+    assert.equal(snap.vercelId, undefined);
+    assert.equal(snap.vercelCache, undefined);
+    assert.equal(snap.bodySnippet, undefined);
+  });
+
+  it('preserves the full snippet when body is shorter than the cap', () => {
+    const snap = snapshotUpstreamResponse(makeResp({}), '{"error":"PRO_REQUIRED"}');
+    assert.equal(snap.bodySnippet, '{"error":"PRO_REQUIRED"}');
+  });
+
+  it('header lookups are case-insensitive (Headers normalizes — guard against future regression)', () => {
+    // Browser fetch returns Headers that are case-insensitive on get();
+    // some test doubles aren't. This pin makes a regression on the test
+    // double (or a stricter implementation) fail loudly.
+    const snap = snapshotUpstreamResponse(
+      makeResp({ 'CF-RAY': 'mixed-case-id', Server: 'Cloudflare' }),
+      '',
+    );
+    assert.equal(snap.cfRay, 'mixed-case-id');
+    assert.equal(snap.server, 'Cloudflare');
+  });
+});

--- a/tests/checkout-upstream-snapshot.test.mts
+++ b/tests/checkout-upstream-snapshot.test.mts
@@ -14,7 +14,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { snapshotUpstreamResponse } from '../src/services/checkout-errors.ts';
+import {
+  parseCheckoutErrorBody,
+  snapshotUpstreamResponse,
+} from '../src/services/checkout-errors.ts';
 
 function makeResp(headers: Record<string, string>): { headers: Headers } {
   return { headers: new Headers(headers) };
@@ -86,5 +89,64 @@ describe('snapshotUpstreamResponse', () => {
     );
     assert.equal(snap.cfRay, 'mixed-case-id');
     assert.equal(snap.server, 'Cloudflare');
+  });
+});
+
+// parseCheckoutErrorBody hardens the implicit "body is a CheckoutErrorBody"
+// contract at runtime: only plain-object JSON is accepted. Returning {}
+// for null / arrays / primitives / malformed JSON means a future consumer
+// writing e.g. `body.message.toLowerCase()` can't crash because the server
+// returned `null` or `[]`. Greptile P2 review of PR #3894.
+describe('parseCheckoutErrorBody', () => {
+  it('returns the parsed object for valid object JSON', () => {
+    const body = parseCheckoutErrorBody('{"error":"ACTIVE_SUBSCRIPTION_EXISTS","message":"x"}');
+    assert.deepEqual(body, { error: 'ACTIVE_SUBSCRIPTION_EXISTS', message: 'x' });
+  });
+
+  it('returns {} for empty string (avoids JSON.parse SyntaxError on no-body responses)', () => {
+    assert.deepEqual(parseCheckoutErrorBody(''), {});
+  });
+
+  it('returns {} for HTML body (CF / Vercel 403 page — JSON.parse throws)', () => {
+    assert.deepEqual(parseCheckoutErrorBody('<!DOCTYPE html><html>blocked</html>'), {});
+  });
+
+  it('returns {} for JSON literal null (would otherwise null-poison the cast)', () => {
+    // Critical: JSON.parse("null") returns null, which IS a valid JSON
+    // value but is NOT a plain object. Without the guard, body=null
+    // would crash any consumer not using optional chaining.
+    assert.deepEqual(parseCheckoutErrorBody('null'), {});
+  });
+
+  it('returns {} for JSON array (structurally not a CheckoutErrorBody)', () => {
+    // Arrays are typeof 'object' AND non-null, so the typeof+null check
+    // alone wouldn't reject them. Array.isArray() is the discriminator.
+    assert.deepEqual(parseCheckoutErrorBody('[]'), {});
+    assert.deepEqual(parseCheckoutErrorBody('[{"error":"X"}]'), {});
+  });
+
+  it('returns {} for JSON primitives (numbers, booleans, strings)', () => {
+    assert.deepEqual(parseCheckoutErrorBody('42'), {});
+    assert.deepEqual(parseCheckoutErrorBody('true'), {});
+    assert.deepEqual(parseCheckoutErrorBody('"plain string"'), {});
+  });
+
+  it('returns {} for malformed JSON (incomplete brace, trailing garbage)', () => {
+    assert.deepEqual(parseCheckoutErrorBody('{not valid'), {});
+    assert.deepEqual(parseCheckoutErrorBody('{"error":"x"} trailing'), {});
+  });
+
+  it('preserves nested fields downstream callers use (e.g. duplicate_subscription path)', () => {
+    // The 409 duplicate-subscription branch in checkout.ts reads
+    // body.subscription.planKey via optional chaining. Lock in that a
+    // realistic body shape passes through unchanged.
+    const body = parseCheckoutErrorBody(
+      '{"error":"ACTIVE_SUBSCRIPTION_EXISTS","subscription":{"planKey":"pro_monthly"}}',
+    );
+    assert.equal(body.error, 'ACTIVE_SUBSCRIPTION_EXISTS');
+    assert.equal(
+      (body as { subscription?: { planKey?: string } }).subscription?.planKey,
+      'pro_monthly',
+    );
   });
 });


### PR DESCRIPTION
## Summary

Originated from Sentry triage of **WORLDMONITOR-RN** (`/api/create-checkout` 403). The Sentry event carried no signal beyond status code — the failure path called `resp.json().catch(() => ({}))` and discarded both the response body (Cloudflare / Vercel 403 pages are HTML, silently became `{}`) and the upstream-identifying headers (cf-ray, server, x-vercel-id would have named the emitter in one glance). Three small changes close that gap and one bonus filter closes WORLDMONITOR-RM.

### Changes

- **`src/services/checkout-errors.ts`** — `statusToCode` adds a `403 → service_unavailable` branch above the generic 4xx catch-all. Neither `api/create-checkout.ts` nor the Convex `/relay/create-checkout` handler ever emits 403 on this route; observed 403s are infrastructure (CF Bot Fight Mode on datacenter IPs, Vercel Deployment Protection, client-side middleboxes). Old behaviour mapped this to `invalid_product` with copy "That product isn't available. Please refresh and try again." — users refreshed forever for what is structurally an upstream block. New copy is retry-friendly ("Checkout is temporarily unavailable. Please try again in a moment.") and `retryable=true`.

- **`src/services/checkout-errors.ts`** — new pure helper `snapshotUpstreamResponse(resp, rawBody)` returning an `UpstreamSnapshot` with `cfRay`, `server`, `vercelId`, `vercelCache`, and the first 200 chars of the response body. Pure module, no SDK imports — fully unit-tested.

- **`src/services/checkout.ts`** (failure path at ~736) — reads the response as text first, attempts JSON parse for the classifier, builds the snapshot from the same `rawText`. CF/Vercel HTML 403 pages are no longer silently dropped. `reportCheckoutError` signature widened with `upstream?: UpstreamSnapshot`; `cfRay` and `server` are promoted to Sentry tags so they're filterable in the UI without opening events. Stale 403 comment (claimed "403 = valid auth but forbidden action") updated to reflect actual observed behavior.

- **`src/main.ts`** — filters Chrome's WebGL `shaderSource` DOMException wording (WORLDMONITOR-RM) alongside the existing Firefox variants. The Chrome string "Failed to execute 'shaderSource' on 'WebGL2RenderingContext': parameter 1 is not of type 'WebGLShader'." is engine-emitted via the WebIDL binding template and cannot originate from first-party code.

### What this unlocks

The next 403 in Sentry self-diagnoses via `extra.upstream`:

| `extra.upstream` shape | Verdict |
|---|---|
| `cfRay` set, `server: cloudflare`, snippet has CF HTML | Cloudflare emitted it (Bot Fight Mode / WAF). Fix in CF dashboard. |
| No `cfRay`, `vercelId` set, snippet says "Authentication Required" | Vercel Deployment Protection. |
| No `cfRay`, no `vercelId`, snippet empty | Client-side middlebox (VPN/extension/proxy). Not ours. |
| Snippet is JSON `{error: "…"}` | Our app emitted it — chase the relay. |

### Open follow-up (not in this PR)

Cloudflare WAF Rule #9 "Block API Bots" on `api.worldmonitor.app` fired **10,080 times in 24h** — almost certainly blocking signed-in users on commercial VPN / datacenter IPs at the checkout step. Dashboard fix: add a Skip rule above #9 exempting `POST /api/create-checkout` and `POST /api/customer-portal` when an `Authorization: Bearer …` header is present. The Clerk JWT validation in `api/create-checkout.ts:62` is already sufficient — bots can't forge a valid token, so skipping the bot layer for authenticated POSTs on these paths doesn't widen the attack surface.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean (Convex string-call audit pass)
- [x] `npm run lint` (Biome) — exit 0, no new warnings introduced
- [x] `npm run lint:md` — 0 errors
- [x] `npm run test:data` — 9596/9596 pass
- [x] `node --test tests/edge-functions.test.mjs` — 183/183 pass
- [x] `node --test tests/checkout-error-classification.test.mts tests/checkout-upstream-snapshot.test.mts` — 30/30 pass (7 new tests for the snapshot helper covering CF capture, Vercel capture, 200-char truncation, empty-body omission, all-undefined case, short-body passthrough, case-insensitive header lookup)
- [x] Edge function bundle check — all bundle clean
- [x] `npm run version:check` — 2.8.0 sync confirmed
- [x] CJS syntax check — all `scripts/*.cjs` valid
- [x] Pre-push hook (full suite) ran on push — passed