### PR TITLE
feat(mcp): expose 4 stable resource URIs (auth-symmetric, freshness-explicit)

### DIFF
--- a/api/api-route-exceptions.json
+++ b/api/api-route-exceptions.json
@@ -122,6 +122,20 @@
       "removal_issue": null
     },
     {
+      "path": "api/mcp/resources/index.ts",
+      "category": "external-protocol",
+      "reason": "MCP RESOURCE_REGISTRY + buildResourceResponse + resources/list public-shape projection. Read-only addressable URIs surfaced via resources/list + resources/read JSON-RPC methods, shape dictated by the MCP spec. Routes resources/read through dispatchToolsCall for auth-symmetric Pro daily-quota deduction.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
+      "path": "api/mcp/resources/slugs.ts",
+      "category": "external-protocol",
+      "reason": "Hand-curated kebab-case slug → matcher table for the worldmonitor://chokepoints/{slug}/status MCP resource URI. The stability contract: bookmarked URIs survive cache refreshes / upstream renames. Same external-protocol constraint as the resources index it backs.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
       "path": "api/mcp-proxy.ts",
       "category": "external-protocol",
       "reason": "Proxy for the MCP transport — same shape constraint as api/mcp.ts. Renamed .js → .ts in PR #3768 to unlock the isCallerPremium import from server/.",

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -65,16 +65,20 @@ export type {
 export { compressDescription, utf8ByteLength } from './mcp/utils';
 
 export { buildPromptResponse, PROMPT_LIST_RESPONSE, PROMPT_REGISTRY } from './mcp/prompts/index';
+export { buildResourceResponse, RESOURCE_LIST_RESPONSE, RESOURCE_REGISTRY } from './mcp/resources/index';
+export { CHOKEPOINT_SLUGS } from './mcp/resources/slugs';
 
 // Test-only escape hatch. Exposes the TOOL_REGISTRY by REFERENCE so mutations
 // inside `tests/mcp-tool-output-contracts.test.mjs` (which monkey-patches
 // `_execute` on individual RPC tools) propagate through the live binding.
-// PROMPT_REGISTRY follows the same live-binding contract so a test that
-// monkey-patches a prompt (e.g. the sabotage cases in mcp-prompts.test.mjs)
-// observes the same array the handler dispatches against.
+// PROMPT_REGISTRY + RESOURCE_REGISTRY follow the same live-binding contract
+// so tests that monkey-patch one (e.g. sabotage cases) observe the same
+// array the handler dispatches against.
 import { PROMPT_REGISTRY as __PROMPT_REGISTRY } from './mcp/prompts/index';
+import { RESOURCE_REGISTRY as __RESOURCE_REGISTRY } from './mcp/resources/index';
 import { TOOL_REGISTRY as __TOOL_REGISTRY } from './mcp/registry/index';
 export const __testing__ = {
   TOOL_REGISTRY: __TOOL_REGISTRY,
   PROMPT_REGISTRY: __PROMPT_REGISTRY,
+  RESOURCE_REGISTRY: __RESOURCE_REGISTRY,
 };

--- a/api/mcp/constants.ts
+++ b/api/mcp/constants.ts
@@ -142,6 +142,31 @@ export const SERVER_NAME = 'worldmonitor';
 //     today.
 //   - Server-card prompts capability flag flipped false → true in the same
 //     commit so external scanners see the wire and the card agree.
+// Bumped 1.8.0 → 1.9.0 (2026-05-25) reflecting:
+//   - MCP `resources` capability turned on. Four read-only addressable URIs
+//     exposed via resources/list + resources/read:
+//       worldmonitor://countries/{iso2}/risk
+//       worldmonitor://chokepoints/{slug}/status
+//       worldmonitor://seed-meta/freshness
+//       worldmonitor://markets/{symbol}/quote
+//     Chokepoint slugs are pinned in a hand-curated kebab-case table
+//     (api/mcp/resources/slugs.ts) so a cache refresh / upstream rename
+//     never breaks a bookmarked URI.
+//   - Auth-symmetric: resources/read routes through dispatchToolsCall and
+//     inherits the Pro daily-quota reservation identical to the equivalent
+//     tools/call — UNLIKE prompts (metadata-class, quota-exempt). Asymmetric
+//     auth between resources and the equivalent tools/call is a known MCP
+//     data-leak vector; the symmetry is structural rather than
+//     replicated and is proven by tests/mcp-resources.test.mjs.
+//   - Freshness envelope on every resources/read response: cache-tool-backed
+//     resources inherit cached_at + stale from the cacheEnvelope; RPC-tool-
+//     backed resources (country risk) wrap explicitly via evaluateFreshness
+//     against the underlying seed-meta key.
+//   - capabilities.resources.{subscribe: false, listChanged: false}
+//     advertised. subscribe is unimplemented; listChanged is false for the
+//     same stateless-edge-transport reason as prompts.
+//   - Server-card resources capability flag flipped false → true in the
+//     same commit so external scanners see the wire and the card agree.
 // Bumped 1.6.0 → 1.7.0 (2026-05-23) reflecting:
 //   - De-blanket the `Tool.annotations` object. Previously buildPublicTool
 //     hard-coded `{ readOnlyHint: true, openWorldHint: true }` for every
@@ -161,7 +186,7 @@ export const SERVER_NAME = 'worldmonitor';
 //     hints keep working; new four-hint clients get a richer signal.
 // Keep aligned with public/.well-known/mcp/server-card.json::serverInfo.version
 // — discovery scanners cross-check both values.
-export const SERVER_VERSION = '1.8.0';
+export const SERVER_VERSION = '1.9.0';
 
 // MCP logging capability — valid severity levels per the 2025-03-26 spec
 // (RFC 5424 subset). Stateless HTTP transport: we ACK the level but do not
@@ -212,6 +237,8 @@ export const SERVER_INSTRUCTIONS = [
   `tools/list returns COMPRESSED tool descriptions (first sentence, ≤${TOOL_DESCRIPTION_MAX_BYTES}B per tool). Call describe_tool({tool_name}) to get the full uncompressed definition for any tool you're considering — especially useful when the compressed entry is ambiguous about behaviour or argument semantics. describe_tool is metadata-only and is EXEMPT from the Pro daily quota (still counts toward the 60/min rate limit), so use it freely while exploring. describe_tool({tool_name: 'nonexistent'}) returns {error: 'unknown_tool', available: [...]} so you can self-correct.`,
   '',
   'Issue prompts/list to discover pre-built workflow templates (country-briefing, energy-shock-watch, market-open-prep, conflict-pulse, route-risk-check, freshness-audit). Each prompt pre-bakes a JMESPath projection per step so the first execution lands on the right shape. prompts/list + prompts/get are quota-exempt (per-minute limit only).',
+  '',
+  'Issue resources/list to discover four read-only addressable resource URIs (country risk, chokepoint status, seed-meta freshness, market quote). resources/read consumes the Pro daily quota IDENTICALLY to the equivalent tools/call — there is no free path around the cap via resources.',
 ].join('\n');
 
 // Country-code whitelist for get_consumer_prices. The consumer-prices seeder

--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -16,6 +16,7 @@ import {
 import { dispatchToolsCall } from './dispatch';
 import { buildPromptResponse, PROMPT_LIST_RESPONSE } from './prompts/index';
 import { TOOL_LIST_BYTES, TOOL_LIST_RESPONSE } from './registry/index';
+import { buildResourceResponse, RESOURCE_LIST_RESPONSE } from './resources/index';
 import { rpcError, rpcOk } from './rpc';
 import { emitTelemetry, principalIdForLog } from './telemetry';
 import type { McpHandlerDeps } from './types';
@@ -95,11 +96,18 @@ export async function mcpHandler(
       });
       return rpcOk(id, {
         protocolVersion: negotiatedVersion,
-        // `prompts.listChanged: false` is the spec-correct value for our
-        // transport — the stateless edge route cannot push
-        // `notifications/prompts/list_changed`, so advertising `true` would
-        // be a lie. Same posture applies if/when `resources` lands later.
-        capabilities: { tools: {}, logging: {}, prompts: { listChanged: false } },
+        // `prompts.listChanged: false` and `resources.listChanged: false`
+        // are the spec-correct values for our transport — the stateless
+        // edge route cannot push `notifications/prompts/list_changed` or
+        // `notifications/resources/list_changed`, so advertising `true`
+        // would be a wire lie. `resources.subscribe: false` because
+        // resources/subscribe is not implemented.
+        capabilities: {
+          tools: {},
+          logging: {},
+          prompts: { listChanged: false },
+          resources: { subscribe: false, listChanged: false },
+        },
         serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
         instructions: SERVER_INSTRUCTIONS,
       }, { 'Mcp-Session-Id': sessionId, ...corsHeaders });
@@ -128,6 +136,20 @@ export async function mcpHandler(
       if (!built.ok) return rpcError(id, built.code, built.message);
       return rpcOk(id, { description: built.description, messages: built.messages }, corsHeaders);
     }
+    // Resources surface DATA — unlike prompts (metadata-class, quota-exempt)
+    // and describe_tool (metadata-class, quota-exempt), resources/read MUST
+    // consume the Pro daily quota IDENTICALLY to a tools/call to the
+    // equivalent tool. Asymmetric auth here is a known MCP data-leak
+    // vector (a Pro user at the daily cap could otherwise keep reading
+    // data via resources for free). The symmetry is structural:
+    // buildResourceResponse synthesizes a tools/call body and routes
+    // through dispatchToolsCall, inheriting the reservation + telemetry
+    // path. resources/list is metadata-class — quota-exempt like
+    // prompts/list, gated only by the per-minute rate limiter above.
+    case 'resources/list':
+      return rpcOk(id, { resources: RESOURCE_LIST_RESPONSE }, corsHeaders);
+    case 'resources/read':
+      return buildResourceResponse(req, context, deps, body, corsHeaders, ctx);
     case 'logging/setLevel': {
       const level = (body.params as { level?: string } | null)?.level;
       if (typeof level !== 'string' || !MCP_LOG_LEVELS.has(level)) {

--- a/api/mcp/resources/index.ts
+++ b/api/mcp/resources/index.ts
@@ -1,0 +1,305 @@
+// MCP resources registry — four read-only addressable URIs surfaced via
+// resources/list + resources/read. Each entry routes through the SAME
+// dispatchToolsCall path the tools/call method uses, so auth, Pro daily
+// quota, telemetry, and per-tool budget gating are inherited unchanged —
+// asymmetric auth between resources and the equivalent tools/call is a
+// known MCP data-leak vector (a Pro user at the daily cap could otherwise
+// keep reading data through resources for free), so the symmetry is
+// load-bearing and proven by tests/mcp-resources.test.mjs.
+//
+// Stability contract:
+//   - URIs use canonical kebab-case slugs (CHOKEPOINT_SLUGS in ./slugs.ts)
+//     and ISO 3166-1 alpha-2 / uppercase tickers. Slugs are pinned in a
+//     hand-curated table so a cache refresh / upstream rename never breaks
+//     a bookmarked URI.
+//   - Every resources/read response carries `cached_at` + `stale` in the
+//     content payload. Cache-tool-backed resources already have this from
+//     the cacheEnvelope shape; RPC-tool-backed resources (just country
+//     risk in v1) get the envelope explicitly wrapped here.
+//
+// Spec-shape note: resources/list returns the four template-shaped URIs
+// (e.g. `worldmonitor://countries/{iso2}/risk`) verbatim. Strict 2025-06-18
+// reading would route templates through resources/templates/list, but
+// surfacing them via resources/list is the pragmatic posture (Claude
+// Desktop / MCP Inspector both render the literal URI; the user / model
+// substitutes the placeholder before issuing resources/read). If a future
+// client complains, splitting out a templates/list method is a
+// non-breaking additive change.
+//
+// resources/read response shape (per MCP spec):
+//   { contents: [{ uri, mimeType, text }] }
+// where `text` is the JSON-stringified payload INCLUDING `cached_at` and
+// `stale`. mimeType is `application/json` for every resource here.
+
+import type { McpAuthContext, McpHandlerDeps, McpResourceDef } from '../types';
+import { dispatchToolsCall } from '../dispatch';
+import { evaluateFreshness } from '../freshness';
+import { rpcError, rpcOk } from '../rpc';
+// @ts-expect-error — JS module, no declaration file
+import { readJsonFromUpstash } from '../../_upstash-json.js';
+import { CHOKEPOINT_SLUGS } from './slugs';
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+// URI parsing is hand-rolled: four resources don't justify a URI-template
+// library. Each paramExtractor returns null when the URI doesn't even start
+// with the right prefix (cheap reject), an {ok: false, reason} when the
+// shape matches but a component is invalid, or an {ok: true, args} when
+// the URI resolves cleanly to synthetic tools/call arguments.
+export const RESOURCE_REGISTRY: McpResourceDef[] = [
+  {
+    uri: 'worldmonitor://countries/{iso2}/risk',
+    name: 'Country Risk',
+    description: 'Composite Instability Index (CII) score 0–100 with unrest/conflict/security/news components, travel-advisory level, and OFAC sanctions exposure for a single ISO 3166-1 alpha-2 country. URI param {iso2} is lowercase alpha-2 (e.g. "de", "us", "ir").',
+    mimeType: 'application/json',
+    tool: 'get_country_risk',
+    // RPC tool — wrap freshness against the regional-snapshot-canonical
+    // risk-scores seed-meta key (30min budget matches the upstream cadence).
+    freshnessWrap: { seedMetaKey: 'seed-meta:intelligence:risk-scores', maxStaleMin: 30 },
+    paramExtractor: (uri: string) => {
+      if (!uri.startsWith('worldmonitor://countries/')) return null;
+      const m = /^worldmonitor:\/\/countries\/([a-z]{2})\/risk$/.exec(uri);
+      const iso2 = m?.[1];
+      if (!iso2) {
+        return {
+          ok: false,
+          reason: 'Expected worldmonitor://countries/{iso2}/risk where {iso2} is lowercase ISO 3166-1 alpha-2.',
+        };
+      }
+      return { ok: true, args: { country_code: iso2.toUpperCase() } };
+    },
+  },
+  {
+    uri: 'worldmonitor://chokepoints/{slug}/status',
+    name: 'Chokepoint Status',
+    description: 'Maritime chokepoint transit summary: today total / tanker / cargo counts, week-over-week change, risk level, incident count, disruption percentage, and risk narrative. URI param {slug} is one of the hand-curated kebab-case identifiers (suez, strait-of-malacca, strait-of-hormuz, bab-el-mandeb, panama-canal, taiwan-strait, cape-of-good-hope, strait-of-gibraltar, bosphorus, korea-strait, dover-strait, kerch-strait, lombok-strait).',
+    mimeType: 'application/json',
+    tool: 'get_chokepoint_status',
+    paramExtractor: (uri: string) => {
+      if (!uri.startsWith('worldmonitor://chokepoints/')) return null;
+      const m = /^worldmonitor:\/\/chokepoints\/([a-z][a-z0-9-]*)\/status$/.exec(uri);
+      const slug = m?.[1];
+      if (!slug) {
+        return {
+          ok: false,
+          reason: 'Expected worldmonitor://chokepoints/{slug}/status where {slug} is a hand-curated kebab-case identifier.',
+        };
+      }
+      const matcher = CHOKEPOINT_SLUGS[slug];
+      if (!matcher) {
+        const known = Object.keys(CHOKEPOINT_SLUGS).join(', ');
+        return { ok: false, reason: `Unknown chokepoint slug "${slug}". Known slugs: [${known}].` };
+      }
+      // Project envelope-only via a fixed jmespath argument is NOT applied
+      // here — chokepoint status callers want the transit-summaries data
+      // body, not just the freshness envelope. The cacheEnvelope from
+      // get_chokepoint_status already includes {cached_at, stale}.
+      return { ok: true, args: { chokepoint: matcher } };
+    },
+  },
+  {
+    uri: 'worldmonitor://seed-meta/freshness',
+    name: 'Seed-Meta Freshness',
+    description: 'Cache-freshness audit for the high-cadence market-data bootstrap pipeline. Returns only the envelope (cached_at + stale) — no quote payload. Use this as a cheap probe to detect a stuck seeder. v1 covers market freshness only; an aggregate freshness resource spanning energy + maritime + risk feeds is a follow-up if customers ask.',
+    mimeType: 'application/json',
+    tool: 'get_market_data',
+    paramExtractor: (uri: string) => {
+      if (uri !== 'worldmonitor://seed-meta/freshness') {
+        if (uri.startsWith('worldmonitor://seed-meta/')) {
+          return { ok: false, reason: 'Expected worldmonitor://seed-meta/freshness (no further path segments).' };
+        }
+        return null;
+      }
+      // summary: true collapses the payload to counts + samples (cheap
+      // wire shape); the jmespath projection then strips data entirely and
+      // emits only the envelope. The dispatcher's per-budget gate runs
+      // against the projected size — well under 1 KB.
+      return { ok: true, args: { summary: true, jmespath: '{cached_at: cached_at, stale: stale}' } };
+    },
+  },
+  {
+    uri: 'worldmonitor://markets/{symbol}/quote',
+    name: 'Market Quote',
+    description: 'Single-symbol quote slice from the market-data bootstrap cache. URI param {symbol} is the uppercase ticker (e.g. "AAPL", "GC=F", "BTC-USD"). Matches equity / commodity / crypto / Gulf / sector / ETF-flow tickers — same case-insensitive matcher as get_market_data({symbols: [...]}).',
+    mimeType: 'application/json',
+    tool: 'get_market_data',
+    paramExtractor: (uri: string) => {
+      if (!uri.startsWith('worldmonitor://markets/')) return null;
+      // Symbol grammar: leading uppercase letter, then up to 15 more
+      // uppercase letters / digits / dash / equals / dot. Covers AAPL,
+      // BTC-USD, GC=F, BRK.B. Lowercase tickers are explicitly invalid —
+      // canonical wire shape from the bootstrap cache is uppercase.
+      const m = /^worldmonitor:\/\/markets\/([A-Z][A-Z0-9.=-]{0,15})\/quote$/.exec(uri);
+      const symbol = m?.[1];
+      if (!symbol) {
+        return {
+          ok: false,
+          reason: 'Expected worldmonitor://markets/{symbol}/quote where {symbol} is an uppercase ticker (e.g. "AAPL", "GC=F", "BTC-USD").',
+        };
+      }
+      return { ok: true, args: { symbols: [symbol], asset_class: ['equity', 'commodity', 'crypto', 'gulf', 'etf', 'sectors'] } };
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// resources/list public shape
+// ---------------------------------------------------------------------------
+// Per MCP spec, resources/list entries carry {uri, name, description,
+// mimeType}. Internal authoring fields (tool, paramExtractor,
+// freshnessWrap) stay internal.
+export interface PublicResourceShape {
+  uri: string;
+  name: string;
+  description: string;
+  mimeType: string;
+}
+
+export const RESOURCE_LIST_RESPONSE: PublicResourceShape[] = RESOURCE_REGISTRY.map((r) => ({
+  uri: r.uri,
+  name: r.name,
+  description: r.description,
+  mimeType: r.mimeType,
+}));
+
+// ---------------------------------------------------------------------------
+// resources/read dispatcher
+// ---------------------------------------------------------------------------
+// Resolves a URI to its content by synthesizing a tools/call body and
+// invoking dispatchToolsCall — that path runs the same Pro daily-quota
+// reservation, telemetry emission, and per-tool budget gate the tools/call
+// surface does, so auth + quota symmetry is structural rather than
+// duplicated. Resource-shape wrapping happens AFTER dispatch returns:
+//   1. Match the URI; -32602 on no-match or malformed component.
+//   2. Synthesize a tools/call JSON-RPC body with the matched tool +
+//      extracted args.
+//   3. Await dispatchToolsCall — Response back is the standard JSON-RPC
+//      envelope. Bubble up error envelopes (auth, quota cap exceeded,
+//      tool errors, budget exceeded) by re-emitting them under the
+//      OUTER id.
+//   4. On success: extract the dispatcher's content[0].text. For cache-
+//      tool-backed resources this already contains the cacheEnvelope
+//      `{cached_at, stale, data}`. For RPC-tool-backed resources (just
+//      country risk), read the configured seed-meta key and wrap with
+//      `{cached_at, stale, ...rawPayload}` so the freshness contract
+//      holds uniformly across all four resources.
+//   5. Re-emit as resources/read shape: `{contents: [{uri, mimeType, text}]}`
+//      under the outer id, preserving the standard rpcOk envelope.
+export async function buildResourceResponse(
+  req: Request,
+  context: McpAuthContext,
+  deps: McpHandlerDeps,
+  body: { id?: unknown; params?: unknown },
+  corsHeaders: Record<string, string>,
+  ctx?: { waitUntil: (p: Promise<unknown>) => void },
+): Promise<Response> {
+  const outerId = body.id ?? null;
+  const params = body.params as { uri?: unknown } | null;
+  if (!params || typeof params.uri !== 'string') {
+    return rpcError(outerId, -32602, 'Invalid params: missing resource uri');
+  }
+  const uri = params.uri;
+
+  // Find the first registry entry whose paramExtractor returns non-null.
+  // null = prefix mismatch (try next entry). ok:false = prefix matched but
+  // component invalid (terminate with -32602). ok:true = resolved.
+  let matched: { def: McpResourceDef; args: Record<string, unknown> } | null = null;
+  let lastReason: string | null = null;
+  for (const def of RESOURCE_REGISTRY) {
+    const r = def.paramExtractor(uri);
+    if (r === null) continue;
+    if (!r.ok) {
+      lastReason = r.reason;
+      // Don't try further entries — the prefix matched, so this entry is
+      // the one the caller meant. The reason explains the malformed
+      // component (unknown slug, bad iso2 case, etc.).
+      break;
+    }
+    matched = { def, args: r.args };
+    break;
+  }
+  if (!matched) {
+    const msg = lastReason
+      ?? `Unknown resource uri "${uri}". Issue resources/list to discover the four supported URI shapes.`;
+    return rpcError(outerId, -32602, msg);
+  }
+
+  // Synthesize a tools/call body. The inner id is internal — never reaches
+  // the wire — but dispatchToolsCall threads it through, so use a stable
+  // sentinel for debuggability if a telemetry line leaks it.
+  const innerBody = {
+    id: '__resources_read__',
+    params: { name: matched.def.tool, arguments: matched.args },
+  };
+
+  // dispatchToolsCall handles auth-symmetric quota reservation + rollback
+  // + per-tool budget gate + telemetry emission. Returns a Response with
+  // the standard JSON-RPC envelope. We parse, repackage, and re-emit
+  // under the OUTER id.
+  const dispatched = await dispatchToolsCall(req, context, deps, innerBody, corsHeaders, ctx);
+
+  // Parse the dispatched body. dispatched.json() is safe — the dispatcher
+  // always emits JSON-RPC, never streams or returns null bodies for these
+  // success/error cases.
+  const innerBodyParsed: {
+    error?: { code: number; message: string };
+    result?: { content?: Array<{ type?: string; text?: string }> };
+  } = await dispatched.json();
+
+  if (innerBodyParsed.error) {
+    // Preserve the inner code (quota -32029, budget-exceeded comes back as
+    // a 200 with _budget_exceeded inside content[0].text — handled below
+    // as a success-shape envelope, not an error — see PR 4 design).
+    return new Response(
+      JSON.stringify({ jsonrpc: '2.0', id: outerId, error: innerBodyParsed.error }),
+      { status: dispatched.status, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+    );
+  }
+
+  const innerText = innerBodyParsed.result?.content?.[0]?.text;
+  if (typeof innerText !== 'string') {
+    return rpcError(outerId, -32603, 'Internal error: resource dispatcher returned no text payload');
+  }
+
+  // Freshness wrap. Cache-tool-backed resources already carry
+  // `{cached_at, stale, data}` from the cacheEnvelope; pass through
+  // unchanged. RPC-tool-backed resources (just country risk) need an
+  // explicit wrap against the configured seed-meta key.
+  let wrappedText: string;
+  if (matched.def.freshnessWrap) {
+    let rawPayload: unknown;
+    try {
+      rawPayload = JSON.parse(innerText);
+    } catch {
+      // _budget_exceeded / _jmespath_error envelopes are JSON too; if the
+      // dispatcher emitted one of those, parse will still succeed. A
+      // genuine parse failure here means the underlying RPC returned
+      // non-JSON, which should already have been a -32603 inside the
+      // dispatcher — defensive fallback: surface as -32603.
+      return rpcError(outerId, -32603, 'Internal error: resource payload was not valid JSON');
+    }
+    const { seedMetaKey, maxStaleMin } = matched.def.freshnessWrap;
+    const meta = await readJsonFromUpstash(seedMetaKey).catch(() => null);
+    const { cached_at, stale } = evaluateFreshness(
+      [{ key: seedMetaKey, maxStaleMin }],
+      [meta],
+    );
+    // Merge envelope ahead of payload fields so the standard shape is
+    // visible first when humans inspect the response.
+    const merged = (rawPayload !== null && typeof rawPayload === 'object' && !Array.isArray(rawPayload))
+      ? { cached_at, stale, ...(rawPayload as Record<string, unknown>) }
+      : { cached_at, stale, data: rawPayload };
+    wrappedText = JSON.stringify(merged);
+  } else {
+    wrappedText = innerText;
+  }
+
+  return rpcOk(
+    outerId,
+    {
+      contents: [{ uri, mimeType: matched.def.mimeType, text: wrappedText }],
+    },
+    corsHeaders,
+  );
+}

--- a/api/mcp/resources/index.ts
+++ b/api/mcp/resources/index.ts
@@ -251,9 +251,19 @@ export async function buildResourceResponse(
     // Preserve the inner code (quota -32029, budget-exceeded comes back as
     // a 200 with _budget_exceeded inside content[0].text — handled below
     // as a success-shape envelope, not an error — see PR 4 design).
+    //
+    // Forward Retry-After from the inner response so quota-exhaustion
+    // (429 with seconds-until-UTC-midnight) and reservation-failure (503
+    // with 5s) honour the same client back-off contract tools/call does.
+    // Without this, a correctly-implemented client back-off would retry
+    // immediately on resources/read while waiting correctly on tools/call
+    // — directly contradicting the auth-symmetry contract.
+    const errorHeaders: Record<string, string> = { 'Content-Type': 'application/json', ...corsHeaders };
+    const retryAfter = dispatched.headers.get('Retry-After');
+    if (retryAfter !== null) errorHeaders['Retry-After'] = retryAfter;
     return new Response(
       JSON.stringify({ jsonrpc: '2.0', id: outerId, error: innerBodyParsed.error }),
-      { status: dispatched.status, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      { status: dispatched.status, headers: errorHeaders },
     );
   }
 
@@ -272,25 +282,40 @@ export async function buildResourceResponse(
     try {
       rawPayload = JSON.parse(innerText);
     } catch {
-      // _budget_exceeded / _jmespath_error envelopes are JSON too; if the
-      // dispatcher emitted one of those, parse will still succeed. A
-      // genuine parse failure here means the underlying RPC returned
-      // non-JSON, which should already have been a -32603 inside the
-      // dispatcher — defensive fallback: surface as -32603.
+      // A parse failure means the underlying RPC returned non-JSON,
+      // which should already have been a -32603 inside the dispatcher —
+      // defensive fallback: surface as -32603.
       return rpcError(outerId, -32603, 'Internal error: resource payload was not valid JSON');
     }
-    const { seedMetaKey, maxStaleMin } = matched.def.freshnessWrap;
-    const meta = await readJsonFromUpstash(seedMetaKey).catch(() => null);
-    const { cached_at, stale } = evaluateFreshness(
-      [{ key: seedMetaKey, maxStaleMin }],
-      [meta],
-    );
-    // Merge envelope ahead of payload fields so the standard shape is
-    // visible first when humans inspect the response.
-    const merged = (rawPayload !== null && typeof rawPayload === 'object' && !Array.isArray(rawPayload))
-      ? { cached_at, stale, ...(rawPayload as Record<string, unknown>) }
-      : { cached_at, stale, data: rawPayload };
-    wrappedText = JSON.stringify(merged);
+    // Soft-error envelopes (PR 4 _budget_exceeded, PR 1.4 _jmespath_error)
+    // come back as 200 with the sentinel inside content[0].text — NOT as
+    // a JSON-RPC error. Pass these through unwrapped so the structured
+    // sentinel survives. Merging with {cached_at, stale} would otherwise
+    // produce a hybrid shape where the soft-error sentinel sits alongside
+    // freshness fields, and clients that detect via top-level key
+    // presence would see "valid-looking" content with the error buried
+    // as an inner field.
+    if (
+      rawPayload !== null
+      && typeof rawPayload === 'object'
+      && !Array.isArray(rawPayload)
+      && (('_budget_exceeded' in rawPayload) || ('_jmespath_error' in rawPayload))
+    ) {
+      wrappedText = innerText;
+    } else {
+      const { seedMetaKey, maxStaleMin } = matched.def.freshnessWrap;
+      const meta = await readJsonFromUpstash(seedMetaKey).catch(() => null);
+      const { cached_at, stale } = evaluateFreshness(
+        [{ key: seedMetaKey, maxStaleMin }],
+        [meta],
+      );
+      // Merge envelope ahead of payload fields so the standard shape is
+      // visible first when humans inspect the response.
+      const merged = (rawPayload !== null && typeof rawPayload === 'object' && !Array.isArray(rawPayload))
+        ? { cached_at, stale, ...(rawPayload as Record<string, unknown>) }
+        : { cached_at, stale, data: rawPayload };
+      wrappedText = JSON.stringify(merged);
+    }
   } else {
     wrappedText = innerText;
   }

--- a/api/mcp/resources/slugs.ts
+++ b/api/mcp/resources/slugs.ts
@@ -1,0 +1,37 @@
+// Hand-curated canonical-slug table for the
+// `worldmonitor://chokepoints/{slug}/status` resource URI. The slug → matcher
+// map is the STABILITY CONTRACT: callers can bookmark a slug and trust the URI
+// resolves to the same chokepoint across cache refreshes / upstream renames.
+// A new chokepoint requires an explicit edit here AND an update to the
+// stability snapshot in tests/mcp-resources.test.mjs — that test reads this
+// file's byte-for-byte contents, so a casual rename in one place will fail
+// the snapshot and force the author to acknowledge the contract change.
+//
+// The matcher value is the case-insensitive substring passed to
+// get_chokepoint_status({chokepoint: <matcher>}). Each matcher is picked to
+// uniquely identify exactly ONE chokepoint within the 13-entry canonical
+// registry (scripts/seed-portwatch.mjs::CHOKEPOINTS that feeds
+// supply_chain:transit-summaries:v1, mirrored in
+// scripts/seed-hs2-chokepoint-exposure.mjs::CHOKEPOINT_REGISTRY). Picking a
+// shorter-than-id matcher is intentional: the postFilter's `ciIncludes` runs
+// against the differing identifier shapes used by each sub-dataset
+// (`hormuz_strait` in transit-summaries, `Strait of Hormuz` in
+// chokepoint-baselines.name), so the matcher must be a substring of BOTH.
+//
+// Slugs are kebab-case. Underscores would conflict with the canonical-id
+// convention used inside the response payload.
+export const CHOKEPOINT_SLUGS: Readonly<Record<string, string>> = Object.freeze({
+  'suez': 'suez',
+  'strait-of-malacca': 'malacca',
+  'strait-of-hormuz': 'hormuz',
+  'bab-el-mandeb': 'bab',
+  'panama-canal': 'panama',
+  'taiwan-strait': 'taiwan',
+  'cape-of-good-hope': 'cape',
+  'strait-of-gibraltar': 'gibraltar',
+  'bosphorus': 'bosphorus',
+  'korea-strait': 'korea',
+  'dover-strait': 'dover',
+  'kerch-strait': 'kerch',
+  'lombok-strait': 'lombok',
+});

--- a/api/mcp/types.ts
+++ b/api/mcp/types.ts
@@ -265,3 +265,35 @@ export interface McpPromptDef {
   intro: string;
   intro_substitutions?: Record<string, McpPromptIntroSubstitution>;
 }
+
+// ---------------------------------------------------------------------------
+// Resources registry types (MCP 2025-03-26 resources capability)
+// ---------------------------------------------------------------------------
+// Per-resource `paramExtractor` parses a concrete URI back into the
+// synthetic tools/call arguments. Discriminated return: null = prefix
+// mismatch (try the next registry entry); {ok: false, reason} = prefix
+// matched but a component is malformed (terminate with -32602);
+// {ok: true, args} = resolved cleanly. Lives in types.ts so both the
+// resources module and the test harness can reference the type without
+// importing the runtime registry.
+export type McpResourceExtractResult =
+  | { ok: true; args: Record<string, unknown> }
+  | { ok: false; reason: string };
+
+export interface McpResourceDef {
+  uri: string;
+  name: string;
+  description: string;
+  mimeType: string;
+  // Backing tool whose tools/call execution path the resources/read
+  // dispatcher routes through. Validated against TOOL_REGISTRY at test
+  // time (the resources module itself avoids the import cycle that the
+  // prompts module also avoids).
+  tool: string;
+  paramExtractor: (uri: string) => McpResourceExtractResult | null;
+  // Only set for RPC-tool-backed resources whose underlying response
+  // doesn't already carry a `{cached_at, stale}` cacheEnvelope. The
+  // dispatcher reads the named seed-meta key and prepends the envelope
+  // before re-emitting; cache-tool-backed resources omit this field.
+  freshnessWrap?: { seedMetaKey: string; maxStaleMin: number };
+}

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -1,7 +1,7 @@
 {
   "serverInfo": {
     "name": "worldmonitor",
-    "version": "1.8.0",
+    "version": "1.9.0",
     "description": "WorldMonitor's live global-intelligence stack as an MCP server: real-time markets, conflict events, aviation, maritime, energy, climate, health, displacement, supply chain, and AI-generated regional briefs.",
     "vendor": "WorldMonitor",
     "homepage": "https://www.worldmonitor.app"
@@ -14,7 +14,7 @@
   "capabilities": {
     "tools": true,
     "logging": true,
-    "resources": false,
+    "resources": true,
     "prompts": true
   },
   "tools": {
@@ -57,7 +57,7 @@
       "apiBusiness": 10000,
       "enterprise": null
     },
-    "notes": "Per-day quota (dailyByPlan) counts only tools/call — initialize, tools/list, ping, and notifications/initialized are exempt. The `describe_tool` tools/call is also exempt (v1.5.0 metadata escape hatch — SERVER_INSTRUCTIONS encourages calling it freely while exploring; otherwise a Pro user at the 50/day cap could not fetch tool definitions). Per-minute (60/min, per-user on Pro, per-key on API tiers) counts ALL methods, so a tight discovery probe loop on tools/list will still trip the throttle."
+    "notes": "Per-day quota (dailyByPlan) counts tools/call AND resources/read — initialize, tools/list, ping, notifications/initialized, prompts/list, prompts/get, and resources/list are exempt. The `describe_tool` tools/call is also exempt (v1.5.0 metadata escape hatch — SERVER_INSTRUCTIONS encourages calling it freely while exploring; otherwise a Pro user at the 50/day cap could not fetch tool definitions). resources/read intentionally counts toward the cap symmetrically with the equivalent tools/call — asymmetric auth is a known MCP data-leak vector. Per-minute (60/min, per-user on Pro, per-key on API tiers) counts ALL methods, so a tight discovery probe loop on tools/list will still trip the throttle."
   },
   "tags": [
     "geopolitical-intelligence",

--- a/tests/mcp-jmespath.test.mjs
+++ b/tests/mcp-jmespath.test.mjs
@@ -300,12 +300,12 @@ describe('api/mcp.ts — JMESPath projection (v1.7.0)', () => {
   // Initialize handshake — version + instructions
   // ============================================================
   describe('initialize handshake', () => {
-    it('serverInfo.version === "1.8.0"', async () => {
+    it('serverInfo.version === "1.9.0"', async () => {
       // Tracks current SERVER_VERSION. Each minor bump needs to update
       // this assertion + the cross-check at line 327 below.
       const res = await mod.default(makeReq(initBody(1)));
       const body = await res.json();
-      assert.equal(body.result?.serverInfo?.version, '1.8.0');
+      assert.equal(body.result?.serverInfo?.version, '1.9.0');
     });
 
     it('result.instructions is present and mentions jmespath', async () => {
@@ -326,12 +326,12 @@ describe('api/mcp.ts — JMESPath projection (v1.7.0)', () => {
       assert.ok(/daily quota/i.test(inst), 'missing quota note');
     });
 
-    it('server-card.json version matches SERVER_VERSION (currently 1.8.0)', () => {
+    it('server-card.json version matches SERVER_VERSION (currently 1.9.0)', () => {
       // Cross-check the comment at api/mcp.ts:~56 — discovery scanners
       // verify both values; a future bump that misses one would break
       // discovery. This is the test that prevents that drift.
       const card = JSON.parse(readFileSync(new URL('../public/.well-known/mcp/server-card.json', import.meta.url), 'utf8'));
-      assert.equal(card.serverInfo.version, '1.8.0');
+      assert.equal(card.serverInfo.version, '1.9.0');
       assert.equal(card.features?.responseProjection, 'jmespath');
     });
 
@@ -339,7 +339,12 @@ describe('api/mcp.ts — JMESPath projection (v1.7.0)', () => {
       const res = await mod.default(makeReq(initBody(4)));
       const body = await res.json();
       assert.equal(body.result?.protocolVersion, '2025-03-26');
-      assert.deepEqual(body.result?.capabilities, { tools: {}, logging: {}, prompts: { listChanged: false } });
+      assert.deepEqual(body.result?.capabilities, {
+        tools: {},
+        logging: {},
+        prompts: { listChanged: false },
+        resources: { subscribe: false, listChanged: false },
+      });
       assert.equal(body.result?.serverInfo?.name, 'worldmonitor');
     });
   });

--- a/tests/mcp-resources.test.mjs
+++ b/tests/mcp-resources.test.mjs
@@ -1,0 +1,501 @@
+// MCP resources wire-contract + stability + auth-symmetry.
+//
+// Three load-bearing concerns:
+//   1. **Stability** — the chokepoint slug table is a publicly-bookmarkable
+//      contract. The byte-for-byte snapshot test fails on ANY slug-table
+//      change so a casual rename forces a deliberate snapshot update.
+//   2. **Auth symmetry** — resources/read MUST consume Pro daily quota
+//      IDENTICALLY to a tools/call against the equivalent tool. This is
+//      the test that catches a "resources are quota-exempt" regression:
+//      the dispatcher counter increment is asserted equal between
+//      resources/read and tools/call against the same backing tool, with
+//      identical pre-seeded counter state. Asymmetric auth is a known MCP
+//      data-leak vector — a Pro user at the daily cap could otherwise
+//      keep reading data through resources for free.
+//   3. **Freshness envelope** — every successful resources/read response
+//      carries `cached_at` and `stale` in the content payload. Cache-tool-
+//      backed resources inherit the envelope from cacheEnvelope; RPC-tool-
+//      backed resources (just country risk in v1) wrap explicitly via
+//      evaluateFreshness against the underlying seed-meta key.
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import {
+  BASE_URL,
+  HMAC_SECRET,
+  callBody,
+  makeProDeps,
+  proReq,
+} from './helpers/mcp-pro-deps.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+const VALID_KEY = 'wm_test_key_resources';
+
+function envKeyReq(body, headers = {}) {
+  return new Request(BASE_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-WorldMonitor-Key': VALID_KEY,
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+// resources/read JSON-RPC body factory.
+function readBody(uri, id = 100) {
+  return { jsonrpc: '2.0', id, method: 'resources/read', params: { uri } };
+}
+
+// Mock fetch covering every read path the four resources can touch:
+//   - Upstash REST cache reads (`GET /get/<key>`) → return Redis JSON.
+//   - get_country_risk RPC (sibling fetch to /api/intelligence/v1/get-country-risk).
+//   - Upstash REST sliding-window ratelimit (pipeline / EVALSHA against the
+//     same host) → return null shape so the @upstash/ratelimit limiter
+//     degrades gracefully and doesn't add latency to every test.
+function installMockFetch({ riskPayload = null } = {}) {
+  const NOW = Date.now();
+  const META = { fetchedAt: NOW, recordCount: 1 };
+
+  // Default payloads for the cache keys the four resources touch. Empty
+  // arrays / objects keep the schema valid; the F6 cache_all_null guard
+  // requires at least ONE key to come back non-null per tool.
+  const stocks = { quotes: [{ symbol: 'AAPL', price: 100, changePercent: 1.2 }, { symbol: 'MSFT', price: 200, changePercent: -0.3 }] };
+  const commodities = { quotes: [{ symbol: 'GC=F', price: 2500, changePercent: 0.5 }] };
+  const crypto = { quotes: [{ symbol: 'BTC-USD', price: 100000, changePercent: 0.0 }] };
+  const transit = { summaries: { suez: { todayTotal: 100, todayTanker: 30, todayCargo: 50, riskLevel: 'normal', riskSummary: 'Normal flow.', dataAvailable: true } } };
+  const chokeRef = { hormuz: { name: 'Strait of Hormuz' } };
+
+  const keyMap = {
+    // get_market_data cache
+    'market:stocks-bootstrap:v1': stocks,
+    'market:commodities-bootstrap:v1': commodities,
+    'market:crypto:v1': crypto,
+    'market:sectors:v2': null,
+    'market:etf-flows:v1': null,
+    'market:gulf-quotes:v1': null,
+    'market:fear-greed:v1': null,
+    'seed-meta:market:stocks': META,
+    // get_chokepoint_status cache
+    'supply_chain:transit-summaries:v1': transit,
+    'supply_chain:chokepoint_transits:v1': null,
+    'supply_chain:portwatch-ports:v1:_countries': null,
+    'energy:chokepoint-baselines:v1': null,
+    'portwatch:chokepoints:ref:v1': chokeRef,
+    'energy:chokepoint-flows:v1': null,
+    'seed-meta:supply_chain:transit-summaries': META,
+    'seed-meta:supply_chain:chokepoint_transits': META,
+    'seed-meta:supply_chain:portwatch-ports': META,
+    'seed-meta:energy:chokepoint-baselines': META,
+    'seed-meta:portwatch:chokepoints-ref': META,
+    'seed-meta:energy:chokepoint-flows': META,
+    // get_country_risk freshness wrap (resource-layer read, distinct from
+    // the RPC's own fetch path)
+    'seed-meta:intelligence:risk-scores': META,
+  };
+
+  globalThis.fetch = async (url, init) => {
+    const u = url.toString();
+
+    // get_country_risk RPC — the sibling fetch dispatch._execute does.
+    if (u.includes('/api/intelligence/v1/get-country-risk')) {
+      const body = riskPayload ?? {
+        country_code: 'DE',
+        cii: 28,
+        components: { unrest: 12, conflict: 8, security: 5, news: 3 },
+        travelAdvisory: { level: 1 },
+        sanctionsExposure: [],
+      };
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // Upstash REST cache reads — `GET /get/<urlencoded-key>` → `{result}`.
+    for (const [k, v] of Object.entries(keyMap)) {
+      if (u.includes(`/get/${encodeURIComponent(k)}`)) {
+        return new Response(JSON.stringify({ result: v === null ? null : JSON.stringify(v) }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      }
+    }
+
+    // Default upstash bucket — unrecognised key returns null. Also catches
+    // the @upstash/ratelimit sliding-window EVALSHA / pipeline shape so
+    // the limiter degrades gracefully (~5ms instead of timing out).
+    if (u.includes('fake.upstash') || u.includes('stub.upstash') || u.includes('upstash.io')) {
+      return new Response(JSON.stringify({ result: null }), {
+        status: 200, headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    return originalFetch(url, init);
+  };
+}
+
+let handler;
+let mcpHandler;
+let RESOURCE_REGISTRY;
+let TOOL_REGISTRY;
+let CHOKEPOINT_SLUGS;
+
+describe('api/mcp.ts — resources capability + stability + auth-symmetry', () => {
+  beforeEach(async () => {
+    process.env.WORLDMONITOR_VALID_KEYS = VALID_KEY;
+    process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'fake_token';
+    process.env.MCP_INTERNAL_HMAC_SECRET = HMAC_SECRET;
+    process.env.MCP_TELEMETRY = 'false';
+
+    installMockFetch();
+
+    const mod = await import(`../api/mcp.ts?t=${Date.now()}-resources`);
+    handler = mod.default;
+    mcpHandler = mod.mcpHandler;
+    RESOURCE_REGISTRY = mod.__testing__.RESOURCE_REGISTRY;
+    TOOL_REGISTRY = mod.__testing__.TOOL_REGISTRY;
+    CHOKEPOINT_SLUGS = mod.CHOKEPOINT_SLUGS;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    Object.keys(process.env).forEach((k) => {
+      if (!(k in originalEnv)) delete process.env[k];
+    });
+    Object.assign(process.env, originalEnv);
+  });
+
+  // -------------------------------------------------------------------------
+  // initialize advertises the new capability
+  // -------------------------------------------------------------------------
+  it('initialize advertises capabilities.resources.{subscribe: false, listChanged: false}', async () => {
+    const res = await handler(envKeyReq({
+      jsonrpc: '2.0', id: 1, method: 'initialize',
+      params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'test', version: '1.0' } },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.deepEqual(
+      body.result?.capabilities?.resources,
+      { subscribe: false, listChanged: false },
+      'capabilities.resources must declare both flags explicitly false (stateless transport)',
+    );
+    // Sibling capabilities must NOT be regressed.
+    assert.ok(body.result.capabilities.tools, 'capabilities.tools must still be present');
+    assert.ok(body.result.capabilities.prompts, 'capabilities.prompts must still be present');
+    assert.ok(body.result.capabilities.logging, 'capabilities.logging must still be present');
+  });
+
+  // -------------------------------------------------------------------------
+  // resources/list shape
+  // -------------------------------------------------------------------------
+  it('resources/list returns exactly four entries with the documented URIs', async () => {
+    const res = await handler(envKeyReq({ jsonrpc: '2.0', id: 2, method: 'resources/list', params: {} }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(Array.isArray(body.result?.resources), 'result.resources must be an array');
+    assert.equal(body.result.resources.length, 4, `Expected 4 resources, got ${body.result.resources.length}`);
+
+    const expectedUris = [
+      'worldmonitor://countries/{iso2}/risk',
+      'worldmonitor://chokepoints/{slug}/status',
+      'worldmonitor://seed-meta/freshness',
+      'worldmonitor://markets/{symbol}/quote',
+    ];
+    const actualUris = body.result.resources.map((r) => r.uri);
+    assert.deepEqual(actualUris, expectedUris, 'resource URIs and order must match the documented set');
+
+    for (const r of body.result.resources) {
+      assert.equal(typeof r.uri, 'string', `resource ${r.uri}: uri must be a string`);
+      assert.ok(r.uri.length > 0, `resource ${r.uri}: uri must be non-empty`);
+      assert.equal(typeof r.name, 'string', `resource ${r.uri}: name must be a string`);
+      assert.equal(typeof r.description, 'string', `resource ${r.uri}: description must be a string`);
+      assert.equal(r.mimeType, 'application/json', `resource ${r.uri}: mimeType must be application/json`);
+      // Internal authoring fields must NOT leak via resources/list.
+      assert.equal(r.tool, undefined, `resource ${r.uri}: internal "tool" must not leak via resources/list`);
+      assert.equal(r.paramExtractor, undefined, `resource ${r.uri}: internal "paramExtractor" must not leak via resources/list`);
+      assert.equal(r.freshnessWrap, undefined, `resource ${r.uri}: internal "freshnessWrap" must not leak via resources/list`);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // resources/read — each URI resolves (env-key auth path)
+  // -------------------------------------------------------------------------
+  it('resources/read worldmonitor://countries/de/risk returns country-risk content with cached_at + stale', async () => {
+    const res = await handler(envKeyReq(readBody('worldmonitor://countries/de/risk')));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.error, undefined, `unexpected error: ${JSON.stringify(body.error)}`);
+    assert.ok(Array.isArray(body.result?.contents), 'result.contents must be an array');
+    assert.equal(body.result.contents.length, 1, 'must return exactly one content entry');
+    const c = body.result.contents[0];
+    assert.equal(c.uri, 'worldmonitor://countries/de/risk', 'echo the requested uri verbatim');
+    assert.equal(c.mimeType, 'application/json');
+    const payload = JSON.parse(c.text);
+    assert.equal(typeof payload.cached_at === 'string' || payload.cached_at === null, true,
+      'cached_at must be string-or-null');
+    assert.equal(typeof payload.stale, 'boolean', 'stale must be a boolean');
+    // The RPC-backed payload merges through — assert the country-risk
+    // shape survived the freshness wrap.
+    assert.equal(payload.country_code, 'DE', 'country_code must round-trip through the freshness wrap');
+    assert.equal(payload.cii, 28);
+  });
+
+  it('resources/read worldmonitor://chokepoints/suez/status returns the transit-summary envelope with cached_at + stale', async () => {
+    const res = await handler(envKeyReq(readBody('worldmonitor://chokepoints/suez/status')));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.error, undefined, `unexpected error: ${JSON.stringify(body.error)}`);
+    const payload = JSON.parse(body.result.contents[0].text);
+    assert.equal(typeof payload.cached_at === 'string' || payload.cached_at === null, true);
+    assert.equal(typeof payload.stale, 'boolean');
+    // Cache-tool envelope — data is keyed by the last-segment label.
+    assert.ok(payload.data, 'cache-tool envelope must carry a data field');
+  });
+
+  it('resources/read worldmonitor://seed-meta/freshness returns envelope-only (no data field)', async () => {
+    const res = await handler(envKeyReq(readBody('worldmonitor://seed-meta/freshness')));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.error, undefined, `unexpected error: ${JSON.stringify(body.error)}`);
+    const payload = JSON.parse(body.result.contents[0].text);
+    // The jmespath projection in the resource definition collapses to
+    // ONLY {cached_at, stale} — no data field, no nested payload.
+    assert.equal(typeof payload.cached_at === 'string' || payload.cached_at === null, true);
+    assert.equal(typeof payload.stale, 'boolean');
+    assert.equal(Object.keys(payload).sort().join(','), 'cached_at,stale',
+      'envelope-only projection must contain exactly cached_at + stale');
+  });
+
+  it('resources/read worldmonitor://markets/AAPL/quote returns the matched single-symbol slice with cached_at + stale', async () => {
+    const res = await handler(envKeyReq(readBody('worldmonitor://markets/AAPL/quote')));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.error, undefined, `unexpected error: ${JSON.stringify(body.error)}`);
+    const payload = JSON.parse(body.result.contents[0].text);
+    assert.equal(typeof payload.cached_at === 'string' || payload.cached_at === null, true);
+    assert.equal(typeof payload.stale, 'boolean');
+    assert.ok(payload.data, 'cache-tool envelope must carry a data field');
+  });
+
+  // -------------------------------------------------------------------------
+  // resources/read error paths
+  // -------------------------------------------------------------------------
+  it('resources/read with an unknown URI prefix returns -32602', async () => {
+    const res = await handler(envKeyReq(readBody('worldmonitor://nope/asdf')));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.error?.code, -32602, `unknown uri prefix must be -32602, got ${body.error?.code}`);
+  });
+
+  it('resources/read with a malformed iso2 (3 letters) returns -32602 with a specific message', async () => {
+    const res = await handler(envKeyReq(readBody('worldmonitor://countries/deu/risk')));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.error?.code, -32602);
+    assert.ok(/iso2|alpha-2/i.test(body.error?.message ?? ''),
+      `error must explain the iso2 constraint — got: ${body.error?.message}`);
+  });
+
+  it('resources/read with an uppercase iso2 returns -32602 (lowercase canonical)', async () => {
+    // Stability contract: the URI is case-sensitive. "DE" is invalid;
+    // "de" is canonical. Documented inline in the resource description.
+    const res = await handler(envKeyReq(readBody('worldmonitor://countries/DE/risk')));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.error?.code, -32602);
+  });
+
+  it('resources/read with an unknown chokepoint slug returns -32602 listing the known slugs', async () => {
+    const res = await handler(envKeyReq(readBody('worldmonitor://chokepoints/no-such-slug/status')));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.error?.code, -32602);
+    assert.ok(/no-such-slug/.test(body.error?.message ?? ''),
+      'error message must echo the unknown slug for debuggability');
+    assert.ok(/suez/.test(body.error?.message ?? ''),
+      'error message must list at least one known slug');
+  });
+
+  it('resources/read with a lowercase ticker returns -32602', async () => {
+    const res = await handler(envKeyReq(readBody('worldmonitor://markets/aapl/quote')));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.error?.code, -32602);
+  });
+
+  it('resources/read with no uri param returns -32602', async () => {
+    const res = await handler(envKeyReq({ jsonrpc: '2.0', id: 50, method: 'resources/read', params: {} }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.error?.code, -32602);
+  });
+
+  // -------------------------------------------------------------------------
+  // Stability — CHOKEPOINT_SLUGS table is a publicly bookmarkable contract.
+  // -------------------------------------------------------------------------
+  it('CHOKEPOINT_SLUGS exposes a frozen 13-entry kebab-case slug table', () => {
+    const entries = Object.entries(CHOKEPOINT_SLUGS);
+    assert.equal(entries.length, 13, `Expected 13 chokepoint slugs, got ${entries.length}`);
+    for (const [slug, matcher] of entries) {
+      assert.match(slug, /^[a-z][a-z0-9-]*$/, `slug "${slug}" must be lowercase kebab-case`);
+      assert.equal(typeof matcher, 'string', `slug "${slug}" matcher must be a string`);
+      assert.ok(matcher.length > 0, `slug "${slug}" matcher must be non-empty`);
+    }
+  });
+
+  it('CHOKEPOINT_SLUGS exact byte-snapshot matches the canonical 13-entry registry', () => {
+    // Stability snapshot. Any slug-table edit must update this expected
+    // map deliberately — a casual rename / re-ordering fails here and
+    // forces the author to acknowledge the public contract change.
+    // Source-of-truth slugs map (alphabetical by slug) — the test failure
+    // when this drifts reports both expected and actual.
+    const expected = {
+      'bab-el-mandeb': 'bab',
+      'bosphorus': 'bosphorus',
+      'cape-of-good-hope': 'cape',
+      'dover-strait': 'dover',
+      'kerch-strait': 'kerch',
+      'korea-strait': 'korea',
+      'lombok-strait': 'lombok',
+      'panama-canal': 'panama',
+      'strait-of-gibraltar': 'gibraltar',
+      'strait-of-hormuz': 'hormuz',
+      'strait-of-malacca': 'malacca',
+      'suez': 'suez',
+      'taiwan-strait': 'taiwan',
+    };
+    // Order doesn't matter (Object.freeze preserves declaration order; we
+    // compare as sorted entries to avoid coupling to authoring order).
+    const actualSorted = Object.fromEntries(
+      Object.entries(CHOKEPOINT_SLUGS).sort(([a], [b]) => a.localeCompare(b)),
+    );
+    assert.deepEqual(actualSorted, expected, 'CHOKEPOINT_SLUGS contents must match the snapshot byte-for-byte');
+  });
+
+  it('api/mcp/resources/slugs.ts file-on-disk parses to the same CHOKEPOINT_SLUGS export', () => {
+    // Defense-in-depth: the snapshot test above runs against the
+    // already-loaded module; this one re-reads the source file from disk
+    // so a sabotage that edits ONLY the in-memory const (test bypass)
+    // would still fail here.
+    const src = readFileSync(resolve(__dirname, '..', 'api', 'mcp', 'resources', 'slugs.ts'), 'utf8');
+    for (const slug of Object.keys(CHOKEPOINT_SLUGS)) {
+      assert.ok(src.includes(`'${slug}'`),
+        `slugs.ts must contain a literal entry for slug "${slug}"`);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Auth symmetry — the load-bearing assertion.
+  // -------------------------------------------------------------------------
+  it('LOAD-BEARING: Pro resources/read on countries/de/risk decrements the daily-quota counter by exactly 1 (identical to tools/call(get_country_risk))', async () => {
+    const { deps: depsR, pipe: pipeR } = makeProDeps({ pipelineOpts: { initialCount: 0 } });
+    const resR = await mcpHandler(
+      proReq('POST', readBody('worldmonitor://countries/de/risk')),
+      depsR,
+    );
+    const bodyR = await resR.json();
+    assert.equal(bodyR.error, undefined, `resources/read should succeed, got error: ${JSON.stringify(bodyR.error)}`);
+    assert.equal(pipeR.count, 1,
+      `Pro resources/read MUST increment quota counter by EXACTLY 1 (got ${pipeR.count}). If resources are quota-exempt, this is the data-leak vector the test exists to catch.`);
+
+    // PARITY — tools/call against the same backing tool from an identical
+    // initial state must produce the SAME counter delta. The two paths
+    // share the dispatcher, so divergence here means resources/read
+    // skipped the dispatcher.
+    const { deps: depsT, pipe: pipeT } = makeProDeps({ pipelineOpts: { initialCount: 0 } });
+    const resT = await mcpHandler(
+      proReq('POST', callBody('get_country_risk', { country_code: 'DE' })),
+      depsT,
+    );
+    const bodyT = await resT.json();
+    assert.equal(bodyT.error, undefined, `tools/call should succeed, got error: ${JSON.stringify(bodyT.error)}`);
+    assert.equal(pipeT.count, pipeR.count,
+      `auth symmetry: tools/call counter delta (${pipeT.count}) must equal resources/read counter delta (${pipeR.count})`);
+  });
+
+  it('Pro resources/read on cache-tool-backed URIs (markets, chokepoints, seed-meta) also increments counter by 1 each', async () => {
+    const uris = [
+      'worldmonitor://markets/AAPL/quote',
+      'worldmonitor://chokepoints/suez/status',
+      'worldmonitor://seed-meta/freshness',
+    ];
+    for (const uri of uris) {
+      const { deps, pipe } = makeProDeps({ pipelineOpts: { initialCount: 0 } });
+      const res = await mcpHandler(proReq('POST', readBody(uri)), deps);
+      const body = await res.json();
+      assert.equal(body.error, undefined,
+        `resources/read ${uri} should succeed, got error: ${JSON.stringify(body.error)}`);
+      assert.equal(pipe.count, 1,
+        `${uri} MUST increment Pro counter by exactly 1, got ${pipe.count}`);
+    }
+  });
+
+  it('env-key resources/read on countries/de/risk does NOT touch the Pro quota path (env-key tier is its own quota)', async () => {
+    // env-key auth path uses X-WorldMonitor-Key. The dispatcher's INCR
+    // reservation only fires for context.kind === 'pro'. This test asserts
+    // the response succeeds AND no Pro pipeline activity was attempted.
+    const { deps, pipe } = makeProDeps({ pipelineOpts: { initialCount: 0 } });
+    const res = await mcpHandler(envKeyReq(readBody('worldmonitor://countries/de/risk')), deps);
+    const body = await res.json();
+    assert.equal(body.error, undefined, `env-key resources/read should succeed, got error: ${JSON.stringify(body.error)}`);
+    assert.equal(pipe.count, 0, 'env-key auth must NOT touch the Pro daily-quota counter');
+  });
+
+  it('resources/list does NOT increment the Pro quota counter (metadata-class, mirrors prompts/list)', async () => {
+    const { deps, pipe } = makeProDeps({ pipelineOpts: { initialCount: 0 } });
+    const res = await mcpHandler(
+      proReq('POST', { jsonrpc: '2.0', id: 1, method: 'resources/list', params: {} }),
+      deps,
+    );
+    const body = await res.json();
+    assert.equal(body.error, undefined);
+    assert.equal(pipe.count, 0, 'resources/list is metadata-class — must NOT count toward daily quota');
+  });
+
+  it('Pro resources/read returns -32029 when the daily quota is exhausted (identical to tools/call)', async () => {
+    // Pre-seed the counter at the cap so the next INCR rejects.
+    const { deps, pipe } = makeProDeps({ pipelineOpts: { initialCount: 50 } });
+    const res = await mcpHandler(
+      proReq('POST', readBody('worldmonitor://countries/de/risk')),
+      deps,
+    );
+    assert.equal(res.status, 429, 'cap-exceeded must surface as HTTP 429');
+    const body = await res.json();
+    assert.equal(body.error?.code, -32029, 'cap-exceeded must use the -32029 quota code');
+    assert.equal(pipe.count, 50,
+      'counter must return to the cap after the rejected reservation rolls back (initialCount=50, no net change)');
+  });
+
+  // -------------------------------------------------------------------------
+  // Tool-existence parity (every resource.tool exists in TOOL_REGISTRY)
+  // -------------------------------------------------------------------------
+  it('every RESOURCE_REGISTRY entry references a tool that exists in TOOL_REGISTRY', () => {
+    const toolNames = new Set(TOOL_REGISTRY.map((t) => t.name));
+    for (const r of RESOURCE_REGISTRY) {
+      assert.ok(
+        toolNames.has(r.tool),
+        `resource "${r.uri}" references unknown tool "${r.tool}". Known: [${[...toolNames].sort().join(', ')}]`,
+      );
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // server-card.json drift (mirrors the prompts test posture)
+  // -------------------------------------------------------------------------
+  it('server-card.json advertises resources: true (matches the wire capability)', () => {
+    const card = JSON.parse(
+      readFileSync(resolve(__dirname, '..', 'public', '.well-known', 'mcp', 'server-card.json'), 'utf8'),
+    );
+    assert.equal(card.capabilities?.resources, true,
+      'server-card.json::capabilities.resources must be true (wire-card parity)');
+  });
+});

--- a/tests/mcp-resources.test.mjs
+++ b/tests/mcp-resources.test.mjs
@@ -475,6 +475,63 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
       'counter must return to the cap after the rejected reservation rolls back (initialCount=50, no net change)');
   });
 
+  it('cap-exhausted resources/read forwards Retry-After header (parity with tools/call)', async () => {
+    // Greptile P1 regression guard. A correctly-implemented MCP client
+    // backing off on 429 will retry immediately if Retry-After is absent.
+    // tools/call attaches Retry-After (seconds until UTC midnight on quota
+    // cap, "5" on reservation failure); resources/read must forward it
+    // verbatim or the auth-symmetry contract is broken on the error path.
+    const { deps: depsR } = makeProDeps({ pipelineOpts: { initialCount: 50 } });
+    const resR = await mcpHandler(
+      proReq('POST', readBody('worldmonitor://countries/de/risk')),
+      depsR,
+    );
+    assert.equal(resR.status, 429);
+    const retryAfterR = resR.headers.get('Retry-After');
+    assert.ok(retryAfterR, 'resources/read 429 MUST attach a Retry-After header (Greptile P1)');
+    // Cross-check: tools/call against the same backing tool from the same
+    // pre-seeded state must attach the SAME header. Drift in the resources
+    // re-emission would surface here as a string mismatch.
+    const { deps: depsT } = makeProDeps({ pipelineOpts: { initialCount: 50 } });
+    const resT = await mcpHandler(
+      proReq('POST', callBody('get_country_risk', { country_code: 'DE' })),
+      depsT,
+    );
+    assert.equal(resT.status, 429);
+    const retryAfterT = resT.headers.get('Retry-After');
+    assert.equal(retryAfterR, retryAfterT,
+      `Retry-After symmetry: resources/read="${retryAfterR}" must match tools/call="${retryAfterT}"`);
+  });
+
+  it('_budget_exceeded soft envelope from country-risk RPC passes through unchanged (no freshness merge)', async () => {
+    // Greptile P2 regression guard. When the RPC return exceeds the
+    // 256 KB budget, dispatchToolsCall emits a 200 with
+    // `{_budget_exceeded, budget_bytes, actual_bytes, hint}` inside
+    // content[0].text. The freshness-wrap branch must detect this and
+    // pass through unchanged — merging the sentinel with `{cached_at,
+    // stale, ...}` would produce a hybrid shape where clients detecting
+    // soft errors by top-level key see "valid-looking" content with the
+    // error sentinel buried as an inner field.
+    //
+    // Trigger: mock get_country_risk to return a payload >256 KB.
+    const huge = { padding: 'x'.repeat(300_000) }; // > 262_144 budget
+    installMockFetch({ riskPayload: huge });
+
+    const res = await handler(envKeyReq(readBody('worldmonitor://countries/de/risk')));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.error, undefined, 'budget-exceeded surfaces as success-shape, not JSON-RPC error');
+    const payload = JSON.parse(body.result.contents[0].text);
+    assert.equal(payload._budget_exceeded, true, '_budget_exceeded sentinel must survive at top level');
+    assert.equal(typeof payload.budget_bytes, 'number');
+    assert.equal(typeof payload.actual_bytes, 'number');
+    // Critically — no freshness fields silently merged onto the soft-error.
+    assert.equal(payload.cached_at, undefined,
+      'cached_at must NOT be merged onto a soft-error envelope (Greptile P2)');
+    assert.equal(payload.stale, undefined,
+      'stale must NOT be merged onto a soft-error envelope (Greptile P2)');
+  });
+
   // -------------------------------------------------------------------------
   // Tool-existence parity (every resource.tool exists in TOOL_REGISTRY)
   // -------------------------------------------------------------------------

--- a/tests/mcp-tools-list-compression.test.mjs
+++ b/tests/mcp-tools-list-compression.test.mjs
@@ -359,14 +359,14 @@ describe('api/mcp.ts — tools/list description compression (v1.7.0)', () => {
     // ============================================================
     // U4: Version bump + SERVER_INSTRUCTIONS + server-card sync
     // ============================================================
-    it('serverInfo.version === "1.8.0"', async () => {
+    it('serverInfo.version === "1.9.0"', async () => {
       const res = await mod.default(new Request('https://worldmonitor.app/mcp', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-WorldMonitor-Key': VALID_KEY },
         body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 't', version: '1' } } }),
       }));
       const body = await res.json();
-      assert.equal(body.result?.serverInfo?.version, '1.8.0');
+      assert.equal(body.result?.serverInfo?.version, '1.9.0');
     });
 
     it('initialize.result.instructions mentions describe_tool AND the TOOL_DESCRIPTION_MAX_BYTES cap value', async () => {
@@ -383,9 +383,9 @@ describe('api/mcp.ts — tools/list description compression (v1.7.0)', () => {
         'instructions should mention the TOOL_DESCRIPTION_MAX_BYTES cap');
     });
 
-    it('server-card.json version matches SERVER_VERSION (1.8.0) AND tools.count matches (39)', () => {
+    it('server-card.json version matches SERVER_VERSION (1.9.0) AND tools.count matches (39)', () => {
       const card = JSON.parse(readFileSync(new URL('../public/.well-known/mcp/server-card.json', import.meta.url), 'utf8'));
-      assert.equal(card.serverInfo.version, '1.8.0');
+      assert.equal(card.serverInfo.version, '1.9.0');
       assert.equal(card.tools.count, 39);
       assert.equal(card.features?.toolDescriptionCompression, true);
       assert.equal(card.features?.responseProjection, 'jmespath',


### PR DESCRIPTION
## Summary

Turns on the MCP `resources` capability with four read-only addressable URIs:

- `worldmonitor://countries/{iso2}/risk`
- `worldmonitor://chokepoints/{slug}/status`
- `worldmonitor://seed-meta/freshness`
- `worldmonitor://markets/{symbol}/quote`

Three properties are load-bearing and proven by tests:

1. **Stability** — chokepoint slugs are pinned in a hand-curated kebab-case table (`api/mcp/resources/slugs.ts`). The 13-entry table is byte-snapshot-asserted; any edit fails the snapshot and forces a deliberate update.
2. **Auth symmetry** — `resources/read` consumes Pro daily quota IDENTICALLY to a `tools/call` against the equivalent tool. The dispatcher is the single source of truth: `buildResourceResponse` synthesizes a `tools/call` body and routes through `dispatchToolsCall`, inheriting INCR-first reservation + rollback + telemetry. **Unlike** prompts and `describe_tool` (metadata-class, quota-exempt), resources serve DATA — asymmetric auth is a known MCP data-leak vector. A parity test asserts the counter delta on `resources/read` equals the counter delta on the equivalent `tools/call`.
3. **Freshness envelope** — every `resources/read` response carries `cached_at` and `stale`. Cache-tool-backed resources inherit it from `cacheEnvelope`; the RPC-tool-backed country-risk resource wraps explicitly via `evaluateFreshness` against `seed-meta:intelligence:risk-scores` (30 min budget).

`resources/list` is metadata-class (quota-exempt, per-minute limit only), mirroring `prompts/list`. `capabilities.resources` advertises `{subscribe: false, listChanged: false}` — the stateless edge transport can't push `notifications/resources/list_changed` and `resources/subscribe` isn't implemented.

`SERVER_VERSION` 1.8.0 → 1.9.0; server-card `resources` flag flipped in lockstep. `SERVER_INSTRUCTIONS` mentions `resources/list` and explicitly notes that `resources/read` is NOT a free path around the daily cap.

## Decision outcomes

1. **Module location** — new `api/mcp/resources/index.ts` sibling to `registry/` and `prompts/`. Own JSON-RPC method pair + capability surface; same boundary as the PR-9.5 / PR-10 splits. Manifest entry uses `external-protocol`.
2. **Registry shape** — `{uri, name, description, mimeType, tool, paramExtractor, freshnessWrap?}`. `paramExtractor` returns a discriminated `{ok: true, args} | {ok: false, reason} | null` so the dispatcher can distinguish "wrong prefix, try next entry" from "right prefix, malformed component". `tool` is the backing tools/call name; routing through `dispatchToolsCall` inherits auth + quota + telemetry + budget for free.
3. **seed-meta/freshness backing** — `get_market_data({summary: true})` with a fixed `jmespath: '{cached_at: cached_at, stale: stale}'` projection. Cheap, single tool, envelope-only on the wire. Documented inline that v1 covers market freshness only; an aggregate freshness resource is a follow-up if customers ask.
4. **CHOKEPOINT_SLUGS table** — hand-curated 13-entry kebab-case map in `api/mcp/resources/slugs.ts`. The brief described the source as "13 canonical chokepoints from `portwatch:chokepoints:ref:v1`"; that key is actually 28 PortWatch *ports* (different dataset). The actual 13 entries come from `scripts/seed-portwatch.mjs::CHOKEPOINTS` (which feeds `supply_chain:transit-summaries:v1`) and `scripts/seed-hs2-chokepoint-exposure.mjs::CHOKEPOINT_REGISTRY`. Matchers are uniquely-identifying substrings within that 13-entry set, chosen for substring-match parity across the differing identifier shapes used by each sub-dataset (`hormuz_strait` in transit-summaries, `Strait of Hormuz` in chokepoint-baselines.name).
5. **Auth + quota** — load-bearing, NOT exempt. `buildResourceResponse` routes through `dispatchToolsCall`, so a Pro `resources/read` hits the same INCR reservation path as a `tools/call`. Symmetry asserted at both the success path (counter delta == 1, identical to `tools/call(get_country_risk)`) and the cap-exhausted path (`-32029` at `initialCount=50`).
6. **Freshness envelope shape** — cache-tool responses pass through unchanged (the `cacheEnvelope` already wraps as `{cached_at, stale, data}`). `get_country_risk` (RPC) is the only resource needing an explicit wrap; the resource layer does the `seed-meta:intelligence:risk-scores` read and prepends `{cached_at, stale, ...rawPayload}`.
7. **URI parsing** — hand-rolled regex per entry, no URI-template library. Lowercase ISO 3166-1 alpha-2 for `{iso2}`, hand-curated slug table for `{slug}`, uppercase ticker (`[A-Z][A-Z0-9.=-]{0,15}`) for `{symbol}`. Invalid components → `-32602` with a specific message.

## Sabotage evidence

**Sabotage 1 — auth-symmetry skip.** Patched `dispatchToolsCall` to skip the Pro INCR reservation when called with the resources-synthetic body id (`__resources_read__`). Three load-bearing assertions failed citing the symptom:

```
✖ LOAD-BEARING: Pro resources/read on countries/de/risk decrements ... by exactly 1
  AssertionError: Pro resources/read MUST increment quota counter by EXACTLY 1 (got 0).
  If resources are quota-exempt, this is the data-leak vector the test exists to catch.

✖ Pro resources/read on cache-tool-backed URIs (markets, chokepoints, seed-meta) also increments counter by 1 each
  AssertionError: worldmonitor://markets/AAPL/quote MUST increment Pro counter by exactly 1, got 0

✖ Pro resources/read returns -32029 when the daily quota is exhausted
  AssertionError: cap-exceeded must surface as HTTP 429
```

Reverted.

**Sabotage 2 — slug-table rename.** Edited `'strait-of-hormuz'` → `'strait-of-hormuz-sabotage'` in `CHOKEPOINT_SLUGS`. Byte-snapshot test failed by name:

```
✖ CHOKEPOINT_SLUGS exact byte-snapshot matches the canonical 13-entry registry
  AssertionError: CHOKEPOINT_SLUGS contents must match the snapshot byte-for-byte
```

Reverted.

## Test plan

- [x] `npm run typecheck:api` green.
- [x] `npm run lint:api-contract` green (new manifest entries added).
- [x] `npx tsx --test tests/mcp-resources.test.mjs` → 22/22 green.
- [x] `npm run test:data` green (9655 tests, 0 fail — baseline + 22 new).
- [x] Sabotage 1 (auth-symmetry skip) reproduced + reverted.
- [x] Sabotage 2 (slug-table rename) reproduced + reverted.
- [ ] **Suggested:** run `/ultrareview` before requesting merge. This is a new wire-visible capability AND introduces an auth-symmetry surface that the brief flagged as a known data-leak vector — a second cloud opinion is the right posture for that blast radius.
- [ ] Vercel preview: `curl /api/mcp -d '{"jsonrpc":"2.0","id":1,"method":"resources/list"}'` returns 4 resources.
- [ ] Vercel preview: `curl /api/mcp -d '{"jsonrpc":"2.0","id":1,"method":"resources/read","params":{"uri":"worldmonitor://countries/de/risk"}}'` returns country risk content with `cached_at` and `stale`.
- [ ] Vercel preview: `curl /.well-known/mcp/server-card.json` shows `capabilities.resources: true` and `serverInfo.version: "1.9.0"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)