### PR TITLE
feat(seo): AEO fixes — single H1, internal/external links, schema, variant subdomains

### DIFF
--- a/blog-site/src/content/blog/ai-powered-intelligence-without-the-cloud.md
+++ b/blog-site/src/content/blog/ai-powered-intelligence-without-the-cloud.md
@@ -39,7 +39,7 @@ What runs locally:
 - **Threat classification:** Categorizing news events by threat type and severity
 - **AI Deduction:** Interactive geopolitical forecasting grounded in live data
 
-The desktop app (Tauri) discovers your local Ollama instance automatically. No configuration needed. Just install Ollama, pull a model, and open World Monitor.
+The desktop app ([Tauri](https://tauri.app/)) discovers your local [Ollama](https://ollama.com/) instance automatically. No configuration needed. Just install Ollama, pull a model, and open World Monitor.
 
 ### Tier 2: Groq (Llama 3.1 8B)
 
@@ -61,7 +61,7 @@ Beyond the LLM tiers, World Monitor runs several ML pipelines entirely in your b
 
 ### Named Entity Recognition (NER)
 
-Extracts people, organizations, locations, and dates from news headlines. Runs in a Web Worker using Transformers.js with ONNX models. Never touches a server.
+Extracts people, organizations, locations, and dates from news headlines. Runs in a Web Worker using [Transformers.js](https://huggingface.co/docs/transformers.js) with ONNX models. Never touches a server.
 
 ### Sentiment Analysis
 

--- a/blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md
+++ b/blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md
@@ -45,8 +45,8 @@ World Monitor's API is organized into domain-specific services:
 
 | Domain | What It Covers |
 |--------|---------------|
-| **Conflict** | ACLED events, UCDP data, hotspot scoring |
-| **Military** | Bases, ADS-B flights, AIS vessels, USNI reports |
+| **Conflict** | [ACLED](https://acleddata.com/) events, [UCDP](https://ucdp.uu.se/) data, hotspot scoring |
+| **Military** | Bases, ADS-B flights, AIS vessels, [USNI](https://news.usni.org/) reports |
 | **Market** | Stock quotes, forex, commodities, sector performance |
 | **Crypto** | BTC signals, stablecoin pegs, ETF flows, Fear & Greed |
 | **Aviation** | Airport delays, flight tracking, airspace data |
@@ -56,12 +56,12 @@ World Monitor's API is organized into domain-specific services:
 | **News** | Aggregated RSS feeds, trending keywords |
 | **Intelligence** | CII scores, theater posture, convergence events |
 | **Infrastructure** | Cables, pipelines, nuclear facilities, datacenters |
-| **Prediction** | Polymarket data, forecast probabilities |
+| **Prediction** | [Polymarket](https://polymarket.com/) data, forecast probabilities |
 | **Cyber** | Threat feeds, C2 servers, malware URLs |
 | **Disaster** | Earthquakes, fires, volcanic events |
 | **Displacement** | UNHCR refugee and IDP data |
 | **Travel** | Government advisories, risk levels |
-| **Central Bank** | Policy rates, BIS data, REER |
+| **Central Bank** | Policy rates, [BIS](https://www.bis.org/) data, REER |
 | **Tech** | AI labs, startups, accelerators, tech hubs |
 | **Commodity** | Mining sites, exchange hubs, energy infrastructure |
 | **Regulation** | AI policy tracking, regulatory changes |

--- a/blog-site/src/content/blog/command-palette-search-everything-instantly.md
+++ b/blog-site/src/content/blog/command-palette-search-everything-instantly.md
@@ -56,7 +56,7 @@ The command palette uses **case-insensitive fuzzy matching** with intelligent ra
 
 - Type "taiwan" → Shows Taiwan country brief, Taiwan Strait theater, nearby bases
 - Type "crypto" → Shows crypto panel, stablecoin monitor, BTC signals
-- Type "fire" → Shows NASA FIRMS layer, fire-related news
+- Type "fire" → Shows [NASA FIRMS](https://firms.modaps.eosdis.nasa.gov/) layer, fire-related news
 - Type "base" → Shows military bases layer
 - Type "iran" → Shows Iran country brief, Iran theater, Iran-related panels
 
@@ -123,7 +123,7 @@ The command palette is panel-aware. When you have specific panels open, related 
 
 1. Cmd+K → "finance" preset → Enter
 2. Cmd+K → "macro" → Enter (7-signal radar)
-3. Cmd+K → "prediction" → Enter (Polymarket)
+3. Cmd+K → "prediction" → Enter ([Polymarket](https://polymarket.com/))
 4. Cmd+K → "commodity" → Enter (price panel)
 
 The command palette turns World Monitor from a visual dashboard into a queryable intelligence system. Ask it anything, get there instantly. Explore the [five dashboard variants](/blog/posts/five-dashboards-one-platform-worldmonitor-variants/) to see how the palette adapts to different operational contexts.

--- a/blog-site/src/content/blog/cyber-threat-intelligence-for-security-teams.md
+++ b/blog-site/src/content/blog/cyber-threat-intelligence-for-security-teams.md
@@ -57,7 +57,7 @@ Additional command-and-control intelligence feeds providing broader coverage of 
 
 ## Internet Outage Detection (Cloudflare Radar)
 
-World Monitor integrates **Cloudflare Radar** data to detect and map internet outages globally. This reveals:
+World Monitor integrates **[Cloudflare Radar](https://radar.cloudflare.com/)** data to detect and map internet outages globally. This reveals:
 
 - **Government-ordered shutdowns** during protests or elections
 - **Infrastructure failures** from natural disasters or attacks
@@ -160,7 +160,7 @@ World Monitor doesn't replace your SIEM, your EDR, or your threat intelligence p
 ## Frequently Asked Questions
 
 **How often is the cyber threat data updated?**
-Threat feeds from Feodo Tracker, URLhaus, and AlienVault OTX are refreshed regularly through automated seed pipelines. Cloudflare Radar outage data updates in near real-time. The freshness of each data source is visible in the platform's health dashboard.
+Threat feeds from [Feodo Tracker](https://feodotracker.abuse.ch/), [URLhaus](https://urlhaus.abuse.ch/), and [AlienVault OTX](https://otx.alienvault.com/) are refreshed regularly through automated seed pipelines. Cloudflare Radar outage data updates in near real-time. The freshness of each data source is visible in the platform's health dashboard.
 
 **Can I integrate World Monitor's cyber threat data into my existing SIEM?**
 Yes. World Monitor's API provides typed endpoints for all cyber threat data. You can pull C2 server locations, malware URLs, and threat intelligence pulses programmatically and feed them into Splunk, Elastic, or any SIEM that accepts JSON data.

--- a/blog-site/src/content/blog/five-dashboards-one-platform-worldmonitor-variants.md
+++ b/blog-site/src/content/blog/five-dashboards-one-platform-worldmonitor-variants.md
@@ -70,14 +70,14 @@ Finance Monitor is for [traders and analysts](/blog/posts/real-time-market-intel
 
 - 92 global stock exchanges with trading hours and market caps
 - 7-signal macro radar with composite BUY/CASH verdict
-- 13 central bank policy trackers with BIS data
+- 13 central bank policy trackers with [BIS](https://www.bis.org/) data
 - Stablecoin peg monitoring (USDT, USDC, DAI, FDUSD, USDe)
 - BTC spot ETF flow tracker (IBIT, FBTC, GBTC, and 7 more)
 - Fear & Greed Index with 30-day history
 - Bitcoin technical signals (SMA50, SMA200, VWAP, Mayer Multiple)
 - 64 Gulf FDI investments (Saudi/UAE Vision 2030)
 - 19 financial centers ranked by GFCI
-- Polymarket prediction market integration
+- [Polymarket](https://polymarket.com/) prediction market integration
 - Forex, bonds, and derivatives panels
 
 **Who it's for:** Retail and institutional traders, macro investors, financial analysts, emerging market researchers, fintech builders.
@@ -130,7 +130,7 @@ Regardless of which variant you use, you get the full platform engine:
 
 ### Interactive 3D Globe + Flat Map
 
-Dual map engines (globe.gl/Three.js for 3D, deck.gl for flat WebGL) that switch at runtime. Both support all 45 data layers.
+Dual map engines ([globe.gl](https://globe.gl/)/[Three.js](https://threejs.org/) for 3D, [deck.gl](https://deck.gl/) for flat WebGL) that switch at runtime. Both support all 45 data layers.
 
 ### AI Analysis
 

--- a/blog-site/src/content/blog/live-webcams-from-geopolitical-hotspots.md
+++ b/blog-site/src/content/blog/live-webcams-from-geopolitical-hotspots.md
@@ -94,10 +94,10 @@ The webcam becomes a ground-truth check against the signals.
 
 World Monitor also integrates **30+ live news video streams** from major broadcasters:
 
-- **Bloomberg TV** for real-time financial coverage
-- **Sky News** for UK/international breaking news
-- **Al Jazeera** for Middle East and global south perspective
-- **Reuters** and **CNN** for general breaking coverage
+- **[Bloomberg TV](https://www.bloomberg.com/live)** for real-time financial coverage
+- **[Sky News](https://news.sky.com/)** for UK/international breaking news
+- **[Al Jazeera](https://www.aljazeera.com/)** for Middle East and global south perspective
+- **[Reuters](https://www.reuters.com/)** and **[CNN](https://www.cnn.com/)** for general breaking coverage
 - **Regional broadcasters** for local context
 
 These streams use HLS (HTTP Live Streaming) and YouTube Live, with automatic quality adaptation for your connection speed.

--- a/blog-site/src/content/blog/monitor-global-supply-chains-and-commodity-disruptions.md
+++ b/blog-site/src/content/blog/monitor-global-supply-chains-and-commodity-disruptions.md
@@ -86,7 +86,7 @@ When you overlay the conflict layer, you immediately see which ports are near ac
 
 ## AIS Maritime Tracking
 
-World Monitor's AIS (Automatic Identification System) layer shows live vessel positions from AISStream.io, merged with USNI fleet reports. For supply chain monitoring, this means:
+World Monitor's AIS (Automatic Identification System) layer shows live vessel positions from [AISStream.io](https://aisstream.io/), merged with [USNI](https://news.usni.org/) fleet reports. For supply chain monitoring, this means:
 
 - **Track bulk carriers** moving commodities between ports
 - **Detect dark vessels** that have turned off transponders (potential sanctions evasion)
@@ -141,8 +141,8 @@ These cascade effects are what turn a localized incident into a global supply ch
 
 Supply chains don't just face geopolitical risk. Environmental events are equally disruptive:
 
-- **USGS Earthquakes (M4.5+):** Automatic alerts for seismic events near industrial infrastructure
-- **NASA FIRMS (VIIRS):** Satellite-detected fires that could affect agricultural regions or industrial facilities
+- **[USGS](https://earthquake.usgs.gov/) Earthquakes (M4.5+):** Automatic alerts for seismic events near industrial infrastructure
+- **[NASA FIRMS](https://firms.modaps.eosdis.nasa.gov/) (VIIRS):** Satellite-detected fires that could affect agricultural regions or industrial facilities
 - **NASA EONET:** Volcanic eruptions, floods, and severe storms
 - **Cloudflare Radar:** Internet outages that disrupt digital supply chains
 

--- a/blog-site/src/content/blog/natural-disaster-monitoring-earthquakes-fires-volcanoes.md
+++ b/blog-site/src/content/blog/natural-disaster-monitoring-earthquakes-fires-volcanoes.md
@@ -16,7 +16,7 @@ World Monitor aggregates exactly these data sources into a single, layered view,
 
 ### 1. Earthquakes (USGS)
 
-World Monitor integrates the **U.S. Geological Survey earthquake feed** for all events magnitude 4.5 and above, globally. Each earthquake appears on the map with:
+World Monitor integrates the **[U.S. Geological Survey earthquake feed](https://earthquake.usgs.gov/earthquakes/feed/)** for all events magnitude 4.5 and above, globally. Each earthquake appears on the map with:
 
 - **Magnitude** (size-scaled marker)
 - **Depth** (color-coded: shallow events are more destructive)
@@ -30,7 +30,7 @@ The USGS feed updates within minutes of a seismic event. For major earthquakes, 
 
 ### 2. Satellite Fire Detection (NASA FIRMS / VIIRS)
 
-The **Visible Infrared Imaging Radiometer Suite (VIIRS)** on NASA's Suomi NPP satellite detects thermal anomalies across the planet. World Monitor maps these detections with:
+The **[Visible Infrared Imaging Radiometer Suite (VIIRS)](https://firms.modaps.eosdis.nasa.gov/)** on NASA's Suomi NPP satellite detects thermal anomalies across the planet. World Monitor maps these detections with:
 
 - **Fire Radiative Power (FRP):** How intense is the fire?
 - **Location** with sub-kilometer accuracy

--- a/blog-site/src/content/blog/osint-for-everyone-open-source-intelligence-democratized.md
+++ b/blog-site/src/content/blog/osint-for-everyone-open-source-intelligence-democratized.md
@@ -16,16 +16,16 @@ World Monitor collapses that entire workflow into a single interactive dashboard
 
 If you've ever tried to monitor a developing situation, whether it's a military escalation, a natural disaster, or a supply chain disruption, you know the drill:
 
-1. Open FlightRadar24 for aircraft movements
-2. Open MarineTraffic for ship positions
-3. Open USGS for earthquake data
-4. Open ACLED for conflict events
-5. Open Liveuamap for real-time mapping
-6. Open Reuters, AP, and Al Jazeera for news
+1. Open [FlightRadar24](https://www.flightradar24.com/) for aircraft movements
+2. Open [MarineTraffic](https://www.marinetraffic.com/) for ship positions
+3. Open [USGS](https://earthquake.usgs.gov/) for earthquake data
+4. Open [ACLED](https://acleddata.com/) for conflict events
+5. Open [Liveuamap](https://liveuamap.com/) for real-time mapping
+6. Open [Reuters](https://www.reuters.com/), [AP](https://apnews.com/), and [Al Jazeera](https://www.aljazeera.com/) for news
 7. Open Telegram for raw OSINT channels
-8. Open Polymarket for prediction markets
-9. Open gpsjam.org for GPS interference
-10. Open NASA FIRMS for fire detection
+8. Open [Polymarket](https://polymarket.com/) for prediction markets
+9. Open [gpsjam.org](https://gpsjam.org/) for GPS interference
+10. Open [NASA FIRMS](https://firms.modaps.eosdis.nasa.gov/) for fire detection
 
 Each tool has its own interface, its own refresh cycle, its own learning curve. Cross-referencing between them is manual and slow. By the time you've built a picture, the situation has moved.
 

--- a/blog-site/src/content/blog/prediction-markets-ai-forecasting-geopolitics.md
+++ b/blog-site/src/content/blog/prediction-markets-ai-forecasting-geopolitics.md
@@ -10,7 +10,7 @@ pubDate: "2026-03-03"
 
 Intelligence is about the past and present. Forecasting is about what comes next. Most dashboards give you one or the other. World Monitor gives you both.
 
-By integrating **Polymarket prediction market data** with **AI-powered geopolitical forecasting**, World Monitor lets you see not just what's happening, but what the collective intelligence of bettors and algorithms thinks will happen.
+By integrating **[Polymarket](https://polymarket.com/) prediction market data** with **AI-powered geopolitical forecasting**, World Monitor lets you see not just what's happening, but what the collective intelligence of bettors and algorithms thinks will happen.
 
 ## Polymarket Integration: The Wisdom of Crowds
 

--- a/blog-site/src/content/blog/real-time-market-intelligence-for-traders-and-analysts.md
+++ b/blog-site/src/content/blog/real-time-market-intelligence-for-traders-and-analysts.md
@@ -51,7 +51,7 @@ Interest rates drive everything. World Monitor tracks policy decisions from 13 c
 - Bank of Korea (BoK)
 - Central Bank of Brazil (BCB)
 - Saudi Arabian Monetary Authority (SAMA)
-- BIS and IMF for systemic indicators
+- [BIS](https://www.bis.org/) and [IMF](https://www.imf.org/en/Data) for systemic indicators
 
 Each tracker includes BIS data on policy rates, real effective exchange rates (REER), and credit-to-GDP ratios, the indicators that matter for macro positioning.
 
@@ -87,7 +87,7 @@ For anyone investing in MENA, this is context that Bloomberg charges premium for
 
 ## Prediction Markets Integration
 
-World Monitor integrates **Polymarket** data directly into country dossiers and the prediction panel. See what bettors think about upcoming elections, military escalations, trade deals, and policy changes.
+World Monitor integrates **[Polymarket](https://polymarket.com/)** data directly into country dossiers and the prediction panel. See what bettors think about upcoming elections, military escalations, trade deals, and policy changes.
 
 Prediction markets are consistently among the best forecasting tools available. Having them alongside news feeds and geopolitical scoring lets you triangulate signal from noise. Explore how [prediction markets and AI forecasting](/blog/posts/prediction-markets-ai-forecasting-geopolitics/) work together in World Monitor.
 

--- a/blog-site/src/content/blog/satellite-imagery-orbital-surveillance.md
+++ b/blog-site/src/content/blog/satellite-imagery-orbital-surveillance.md
@@ -46,7 +46,7 @@ After a reported strike on a pipeline, port, or datacenter, satellite imagery sh
 
 ### Environmental Monitoring
 
-Track deforestation, mining expansion, flooding, and fire damage. The NASA FIRMS fire layer shows active hotspots; satellite imagery shows the aftermath and extent. For more on natural hazard tracking, see [natural disaster monitoring with World Monitor](/blog/posts/natural-disaster-monitoring-earthquakes-fires-volcanoes/).
+Track deforestation, mining expansion, flooding, and fire damage. The [NASA FIRMS](https://firms.modaps.eosdis.nasa.gov/) fire layer shows active hotspots; satellite imagery shows the aftermath and extent. For more on natural hazard tracking, see [natural disaster monitoring with World Monitor](/blog/posts/natural-disaster-monitoring-earthquakes-fires-volcanoes/).
 
 ### Maritime Intelligence
 
@@ -71,7 +71,7 @@ The orbital layer becomes most powerful when combined with World Monitor's other
 | Port blockade | AIS + maritime + news | Ship congestion visualization |
 | Nuclear activity | Nuclear facilities + CII | Construction changes, thermal signatures |
 | Protest camp | Conflict + Telegram OSINT | Crowd size estimation, barricade placement |
-| Natural disaster | USGS + NASA FIRMS | Damage footprint, flood extent |
+| Natural disaster | [USGS](https://earthquake.usgs.gov/) + NASA FIRMS | Damage footprint, flood extent |
 
 No other free dashboard lets you overlay satellite imagery on top of real-time conflict data, military tracking, and AI-scored intelligence, in the same view. Explore the full [OSINT capabilities World Monitor offers](/blog/posts/osint-for-everyone-open-source-intelligence-democratized/).
 

--- a/blog-site/src/content/blog/track-global-conflicts-in-real-time.md
+++ b/blog-site/src/content/blog/track-global-conflicts-in-real-time.md
@@ -18,8 +18,8 @@ World Monitor's core dashboard (worldmonitor.app) is designed around one questio
 
 The answer comes from layering multiple intelligence sources onto a single interactive 3D globe:
 
-- **ACLED conflict data** for armed clashes, protests, and political violence
-- **UCDP warfare events** for state-based and non-state conflicts
+- **[ACLED](https://acleddata.com/) conflict data** for armed clashes, protests, and political violence
+- **[UCDP](https://ucdp.uu.se/) warfare events** for state-based and non-state conflicts
 - **Live ADS-B tracking** for military aircraft positions
 - **AIS vessel monitoring** merged with USNI fleet reports for naval movements
 - **26 Telegram OSINT channels** for raw, low-latency intelligence
@@ -92,7 +92,7 @@ Each base includes facility type, operating nation, and strategic context. Overl
 
 Two of World Monitor's most operationally significant layers:
 
-**ADS-B (Aircraft):** Military and civilian aircraft transponder data from OpenSky, enriched by Wingbits for aircraft type identification. Filter for military callsigns to track reconnaissance flights, tanker orbits, and transport movements in real time.
+**ADS-B (Aircraft):** Military and civilian aircraft transponder data from [OpenSky](https://opensky-network.org/), enriched by [Wingbits](https://wingbits.com/) for aircraft type identification. Filter for military callsigns to track reconnaissance flights, tanker orbits, and transport movements in real time.
 
 **AIS (Maritime):** Ship positions from AISStream.io merged with editorial analysis from USNI Fleet Reports. This fusion gives you both the "where" (transponder position) and the "why" (fleet deployment context). Dark vessel detection flags ships that have gone silent, a common indicator of sanctions evasion or military operations.
 

--- a/blog-site/src/content/blog/tracking-global-trade-routes-chokepoints-freight-costs.md
+++ b/blog-site/src/content/blog/tracking-global-trade-routes-chokepoints-freight-costs.md
@@ -125,13 +125,13 @@ No single data source shows this full picture. World Monitor puts chokepoint sta
 Transparency matters. Here is where the data comes from:
 
 - **Vessel transit data**: AIS (Automatic Identification System) feeds, cross-referenced with historical baselines
-- **Conflict events**: ACLED (Armed Conflict Location & Event Data Project), 7-day rolling windows
+- **Conflict events**: [ACLED](https://acleddata.com/) (Armed Conflict Location & Event Data Project), 7-day rolling windows
 - **Shipping advisories**: AI-generated from combined conflict, navigational, and AIS disruption signals
-- **Container indices**: Shanghai Shipping Exchange (SSE) public JSON API
-- **Bulk indices**: Baltic Exchange via HandyBulk daily reports
-- **Economic indices**: FRED (Federal Reserve Economic Data)
-- **Trade policy**: WTO I-TIP (Integrated Trade Intelligence Portal)
-- **Critical minerals**: USGS mineral commodity data with HHI calculations
+- **Container indices**: [Shanghai Shipping Exchange (SSE)](https://en.sse.net.cn/) public JSON API
+- **Bulk indices**: [Baltic Exchange](https://www.balticexchange.com/) via HandyBulk daily reports
+- **Economic indices**: [FRED](https://fred.stlouisfed.org/) (Federal Reserve Economic Data)
+- **Trade policy**: [WTO I-TIP](https://i-tip.wto.org/) (Integrated Trade Intelligence Portal)
+- **Critical minerals**: [USGS](https://www.usgs.gov/centers/national-minerals-information-center) mineral commodity data with HHI calculations
 
 All sources are public. No proprietary data feeds. No paywall.
 

--- a/blog-site/src/content/blog/what-is-worldmonitor-real-time-global-intelligence.md
+++ b/blog-site/src/content/blog/what-is-worldmonitor-real-time-global-intelligence.md
@@ -20,7 +20,7 @@ It's the kind of tool that used to be locked behind six-figure enterprise contra
 
 ## What You See When You Open World Monitor
 
-The first thing you notice is the globe. A 3D interactive map powered by globe.gl and Three.js, dotted with live data points: conflict zones pulsing red, military bases marked by operator, undersea cables tracing the ocean floor, and ADS-B aircraft positions updating in real time.
+The first thing you notice is the globe. A 3D interactive map powered by [globe.gl](https://globe.gl/) and [Three.js](https://threejs.org/), dotted with live data points: conflict zones pulsing red, military bases marked by operator, undersea cables tracing the ocean floor, and ADS-B aircraft positions updating in real time.
 
 On the left, a panel system lets you pull up any combination of 45+ data layers:
 
@@ -28,8 +28,8 @@ On the left, a panel system lets you pull up any combination of 45+ data layers:
 - **Military:** 210+ military bases, live flight tracking, naval vessel positions merged with USNI fleet reports, GPS jamming detection zones
 - **Infrastructure:** Nuclear facilities, AI datacenters (111 mapped), undersea cables, pipelines, strategic ports (83), and airports (107)
 - **Financial:** 92 stock exchanges, 13 central bank policy trackers, commodity prices, Fear & Greed Index, Bitcoin ETF flows, stablecoin peg monitoring
-- **Natural Disasters:** USGS earthquakes (M4.5+), NASA satellite fire detection, volcanic activity, flood alerts
-- **Cyber Threats:** Feodo Tracker botnet C2 servers, URLhaus malicious URLs, internet outage detection via Cloudflare Radar
+- **Natural Disasters:** [USGS](https://earthquake.usgs.gov/) earthquakes (M4.5+), [NASA satellite fire detection](https://firms.modaps.eosdis.nasa.gov/), volcanic activity, flood alerts
+- **Cyber Threats:** [Feodo Tracker](https://feodotracker.abuse.ch/) botnet C2 servers, [URLhaus](https://urlhaus.abuse.ch/) malicious URLs, internet outage detection via [Cloudflare Radar](https://radar.cloudflare.com/)
 
 Every data point is sourced from public, verifiable feeds: 435+ RSS sources, government APIs, satellite data, and open maritime/aviation transponders.
 

--- a/blog-site/src/content/blog/worldmonitor-in-21-languages-global-intelligence-for-everyone.md
+++ b/blog-site/src/content/blog/worldmonitor-in-21-languages-global-intelligence-for-everyone.md
@@ -78,7 +78,7 @@ World Monitor handles all of these. The command palette accepts CJK input during
 
 This is where multilingual support goes beyond interface translation. World Monitor's **435+ RSS feeds** include **locale-specific sources**:
 
-When you switch World Monitor to French, you don't just see English headlines translated. You see French-language sources: Le Monde, France 24, AFP. Switch to Arabic and you see Al Jazeera Arabic, Al Arabiya, local MENA outlets. Switch to Japanese and Japanese news sources appear.
+When you switch World Monitor to French, you don't just see English headlines translated. You see French-language sources: [Le Monde](https://www.lemonde.fr/), [France 24](https://www.france24.com/fr/), [AFP](https://www.afp.com/fr). Switch to Arabic and you see [Al Jazeera Arabic](https://www.aljazeera.net/), [Al Arabiya](https://www.alarabiya.net/), local MENA outlets. Switch to Japanese and Japanese news sources appear.
 
 This matters because:
 

--- a/blog-site/src/content/blog/worldmonitor-vs-traditional-intelligence-tools.md
+++ b/blog-site/src/content/blog/worldmonitor-vs-traditional-intelligence-tools.md
@@ -8,7 +8,7 @@ heroImage: "/blog/images/blog/worldmonitor-vs-traditional-intelligence-tools.jpg
 pubDate: "2026-03-11"
 ---
 
-A Bloomberg Terminal costs $24,000 per year. A Palantir deployment starts in the millions. Dataminr licenses run six figures for enterprise teams. Recorded Future isn't cheap either.
+A [Bloomberg Terminal](https://www.bloomberg.com/professional/products/bloomberg-terminal/) costs $24,000 per year. A [Palantir](https://www.palantir.com/) deployment starts in the millions. [Dataminr](https://www.dataminr.com/) licenses run six figures for enterprise teams. [Recorded Future](https://www.recordedfuture.com/) isn't cheap either.
 
 These tools are powerful. They're also gatekept behind budgets that exclude most of the world's analysts, researchers, journalists, and security professionals.
 

--- a/index.html
+++ b/index.html
@@ -117,6 +117,61 @@
     }
     </script>
 
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "name": "World Monitor",
+      "alternateName": "WorldMonitor",
+      "url": "https://www.worldmonitor.app/",
+      "logo": "https://www.worldmonitor.app/favico/apple-touch-icon.png",
+      "description": "Open-source real-time global intelligence platform aggregating conflicts, military movements, markets, infrastructure, and geopolitical data. Used by 2M+ people across 190+ countries.",
+      "founder": {
+        "@type": "Person",
+        "name": "Elie Habib",
+        "url": "https://x.com/eliehabib",
+        "sameAs": ["https://x.com/eliehabib", "https://github.com/koala73"]
+      },
+      "sameAs": [
+        "https://github.com/koala73/worldmonitor",
+        "https://x.com/worldmonitorai",
+        "https://discord.gg/re63kWKxaz",
+        "https://www.wired.me/story/the-music-streaming-ceo-who-built-a-global-war-map"
+      ],
+      "contactPoint": {
+        "@type": "ContactPoint",
+        "contactType": "customer support",
+        "email": "support@worldmonitor.app",
+        "url": "https://www.worldmonitor.app/pro"
+      }
+    }
+    </script>
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "World Monitor",
+      "alternateName": "WorldMonitor",
+      "url": "https://www.worldmonitor.app/",
+      "description": "Real-time global intelligence dashboard — live news, markets, military tracking, infrastructure monitoring, and geopolitical data.",
+      "publisher": {
+        "@type": "Organization",
+        "name": "World Monitor",
+        "url": "https://www.worldmonitor.app/"
+      },
+      "potentialAction": {
+        "@type": "SearchAction",
+        "target": {
+          "@type": "EntryPoint",
+          "urlTemplate": "https://www.worldmonitor.app/?q={search_term_string}"
+        },
+        "query-input": "required name=search_term_string"
+      },
+      "inLanguage": ["en", "fr", "de", "es", "it", "pt", "nl", "sv", "pl", "cs", "ro", "bg", "el", "ru", "tr", "ar", "zh", "ja", "ko", "th", "vi"]
+    }
+    </script>
+
     <!--
       Umami Analytics — async (not defer): defer blocks DOMContentLoaded if abacus is slow/down (15s observed when origin 502s).
       data-domains is temporarily reduced to worldmonitor.app + happy.worldmonitor.app while upstream Umami issue #4183
@@ -212,7 +267,32 @@
     <link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Tajawal:wght@200;300;400;500;700;800;900&display=swap" rel="stylesheet">
   </head>
   <body>
-    <h1 style="position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip-path:inset(50%);white-space:nowrap">World Monitor - Real-Time Global Intelligence Dashboard</h1>
+    <div id="seo-prerender" style="position:absolute;left:-9999px;top:-9999px;overflow:hidden;width:1px;height:1px;">
+      <h1>World Monitor — Real-Time Global Intelligence Dashboard</h1>
+      <p>Free, open-source intelligence platform aggregating live news, markets, military movements, conflicts, and infrastructure into one real-time dashboard. Used by 2M+ people across 190+ countries. <a href="https://www.wired.me/story/the-music-streaming-ceo-who-built-a-global-war-map">Featured in WIRED</a>.</p>
+
+      <h2>What it tracks</h2>
+      <p>Live conflict events from <a href="https://acleddata.com/">ACLED</a> and <a href="https://ucdp.uu.se/">UCDP</a>, satellite fire detection from <a href="https://firms.modaps.eosdis.nasa.gov/">NASA FIRMS</a>, earthquakes from <a href="https://www.usgs.gov/programs/earthquake-hazards">USGS</a>, military and civilian aircraft from <a href="https://opensky-network.org/">OpenSky Network</a>, ship AIS positions from <a href="https://aisstream.io/">AISStream</a>, macro and central bank data from <a href="https://fred.stlouisfed.org/">FRED</a>, <a href="https://www.imf.org/en/Data">IMF</a>, and <a href="https://www.bis.org/">BIS</a>, plus 500+ curated RSS feeds, 50+ map layers, and AI-synthesized country briefings.</p>
+
+      <h2>Five dashboards, one platform</h2>
+      <ul>
+        <li><a href="https://www.worldmonitor.app/">World Monitor</a> — geopolitics, conflicts, military, infrastructure</li>
+        <li><a href="https://tech.worldmonitor.app/">Tech Monitor</a> — AI labs, startups, cloud, cybersecurity</li>
+        <li><a href="https://finance.worldmonitor.app/">Finance Monitor</a> — global markets, central banks, forex, crypto</li>
+        <li><a href="https://commodity.worldmonitor.app/">Commodity Monitor</a> — mining, energy, supply chains, freight</li>
+        <li><a href="https://happy.worldmonitor.app/">Happy Monitor</a> — positive news, breakthroughs, conservation</li>
+      </ul>
+
+      <h2>Learn more</h2>
+      <ul>
+        <li><a href="https://www.worldmonitor.app/pro">World Monitor Pro</a> — AI analyst, personalized digests, MCP for Claude &amp; GPT</li>
+        <li><a href="https://www.worldmonitor.app/blog/">Blog</a> — OSINT guides, geopolitics, market intelligence</li>
+        <li><a href="https://www.worldmonitor.app/blog/posts/what-is-worldmonitor-real-time-global-intelligence/">What is World Monitor?</a></li>
+        <li><a href="https://www.worldmonitor.app/blog/posts/osint-for-everyone-open-source-intelligence-democratized/">OSINT for everyone — open-source intelligence democratized</a></li>
+        <li><a href="https://www.worldmonitor.app/blog/posts/five-dashboards-one-platform-worldmonitor-variants/">Five dashboards, one platform — the variants explained</a></li>
+        <li><a href="https://github.com/koala73/worldmonitor">Open source on GitHub (AGPL-3.0)</a></li>
+      </ul>
+    </div>
     <div id="app">
       <!-- Pre-render skeleton: visible instantly, replaced when JS calls renderLayout() -->
       <div class="skeleton-shell" aria-hidden="true">
@@ -254,9 +334,9 @@
     </aside>
     <noscript>
       <div style="max-width:800px;margin:0 auto;padding:40px 20px;font-family:system-ui,sans-serif;color:#e5e5e5;background:#0a0a0a;">
-        <h1>World Monitor — Real-Time Global Intelligence Dashboard</h1>
+        <h2>World Monitor — Real-Time Global Intelligence Dashboard</h2>
         <p>AI-powered real-time global intelligence dashboard with live news, markets, military tracking, infrastructure monitoring, and geopolitical data. Used by 2M+ people across 190+ countries.</p>
-        <h2>Features</h2>
+        <h3>Features</h3>
         <ul>
           <li>Real-time conflict tracking (ACLED, UCDP)</li>
           <li>Military ADS-B flight monitoring</li>

--- a/index.html
+++ b/index.html
@@ -267,7 +267,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Nunito:ital,wght@0,300;0,400;0,600;0,700;1,400&family=Tajawal:wght@200;300;400;500;700;800;900&display=swap" rel="stylesheet">
   </head>
   <body>
-    <div id="seo-prerender" style="position:absolute;left:-9999px;top:-9999px;overflow:hidden;width:1px;height:1px;">
+    <!--
+      Canonical English crawler content. The SPA is multilingual (21 locales) but
+      this prerender block is the indexable surface — language-specific content
+      hydrates client-side after JS boots. WebSite JSON-LD already advertises all
+      inLanguage values; this block is the en-US fallback.
+    -->
+    <div id="seo-prerender" lang="en" aria-hidden="true" style="position:absolute;left:-9999px;top:-9999px;overflow:hidden;width:1px;height:1px;">
       <h1>World Monitor — Real-Time Global Intelligence Dashboard</h1>
       <p>Free, open-source intelligence platform aggregating live news, markets, military movements, conflicts, and infrastructure into one real-time dashboard. Used by 2M+ people across 190+ countries. <a href="https://www.wired.me/story/the-music-streaming-ceo-who-built-a-global-war-map">Featured in WIRED</a>.</p>
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -55,32 +55,40 @@ const VARIANT_HOST_MAP: Record<string, string> = {
 };
 
 // Source of truth: src/config/variant-meta.ts — keep in sync when variant metadata changes.
-const VARIANT_OG: Record<string, { title: string; description: string; image: string; url: string }> = {
+// `name` is the short brand for JSON-LD `WebApplication.name`; `title` is the full
+// page <title>. They are split fields (not derived via title.split(' - ')) so a
+// future title format change cannot silently corrupt the JSON-LD name.
+const VARIANT_OG: Record<string, { name: string; title: string; description: string; image: string; url: string }> = {
   tech: {
+    name: 'Tech Monitor',
     title: 'Tech Monitor - Real-Time AI & Tech Industry Dashboard',
     description: 'Real-time AI and tech industry dashboard tracking tech giants, AI labs, startup ecosystems, funding rounds, and tech events worldwide.',
     image: 'https://tech.worldmonitor.app/favico/tech/og-image.png',
     url: 'https://tech.worldmonitor.app/',
   },
   finance: {
+    name: 'Finance Monitor',
     title: 'Finance Monitor - Real-Time Markets & Trading Dashboard',
     description: 'Real-time finance and trading dashboard tracking global markets, stock exchanges, central banks, commodities, forex, crypto, and economic indicators worldwide.',
     image: 'https://finance.worldmonitor.app/favico/finance/og-image.png',
     url: 'https://finance.worldmonitor.app/',
   },
   commodity: {
+    name: 'Commodity Monitor',
     title: 'Commodity Monitor - Real-Time Commodity Markets & Supply Chain Dashboard',
     description: 'Real-time commodity markets dashboard tracking mining sites, processing plants, commodity ports, supply chains, and global commodity trade flows.',
     image: 'https://commodity.worldmonitor.app/favico/commodity/og-image.png',
     url: 'https://commodity.worldmonitor.app/',
   },
   happy: {
+    name: 'Happy Monitor',
     title: 'Happy Monitor - Good News & Global Progress',
     description: 'Curated positive news, progress data, and uplifting stories from around the world.',
     image: 'https://happy.worldmonitor.app/favico/happy/og-image.png',
     url: 'https://happy.worldmonitor.app/',
   },
   energy: {
+    name: 'Energy Atlas',
     title: 'Energy Atlas - Real-Time Global Energy Intelligence Dashboard',
     description: 'Real-time global energy atlas tracking oil and gas pipelines, storage facilities, chokepoints, fuel shortages, tanker flows, and disruption events worldwide.',
     image: 'https://energy.worldmonitor.app/favico/energy/og-image.png',
@@ -102,6 +110,19 @@ function isAllowedHost(host: string): boolean {
   return ALLOWED_HOSTS.has(host) || VERCEL_PREVIEW_RE.test(host);
 }
 
+// HTML-escape a string for safe interpolation into BOTH text content and
+// double-quoted attribute values. Required because VARIANT_OG values are
+// hand-edited prose and a future double-quote, ampersand, or angle bracket
+// would otherwise close the attribute early or corrupt the document.
+function escHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 export default function middleware(request: Request) {
   const url = new URL(request.url);
   const ua = request.headers.get('user-agent') ?? '';
@@ -121,10 +142,17 @@ export default function middleware(request: Request) {
       if (variant && isAllowedHost(host)) {
         const og = VARIANT_OG[variant as keyof typeof VARIANT_OG];
         if (og) {
+          // Pre-escape every VARIANT_OG field used in the template. JSON-LD is
+          // safe via JSON.stringify, but the OG/Twitter/canonical attributes
+          // and the visible <h1>/<p> body need explicit HTML escaping.
+          const eTitle = escHtml(og.title);
+          const eDesc = escHtml(og.description);
+          const eImage = escHtml(og.image);
+          const eUrl = escHtml(og.url);
           const jsonLd = isAI ? `\n<script type="application/ld+json">${JSON.stringify({
             '@context': 'https://schema.org',
             '@type': 'WebApplication',
-            name: og.title.split(' - ')[0],
+            name: og.name,
             url: og.url,
             description: og.description,
             applicationCategory: 'BusinessApplication',
@@ -142,8 +170,8 @@ export default function middleware(request: Request) {
             ],
           })}</script>` : '';
           const aiBody = isAI ? `
-<h1>${og.title}</h1>
-<p>${og.description}</p>
+<h1>${eTitle}</h1>
+<p>${eDesc}</p>
 <h2>Explore the platform</h2>
 <ul>
 <li><a href="https://www.worldmonitor.app/">World Monitor — geopolitics &amp; intelligence</a></li>
@@ -157,18 +185,18 @@ export default function middleware(request: Request) {
 </ul>
 <h2>Sources</h2>
 <p>Data ingested live from <a href="https://acleddata.com/">ACLED</a>, <a href="https://ucdp.uu.se/">UCDP</a>, <a href="https://firms.modaps.eosdis.nasa.gov/">NASA FIRMS</a>, <a href="https://earthquake.usgs.gov/">USGS</a>, <a href="https://opensky-network.org/">OpenSky</a>, <a href="https://aisstream.io/">AISStream</a>, <a href="https://fred.stlouisfed.org/">FRED</a>, <a href="https://www.imf.org/en/Data">IMF</a>, and <a href="https://www.bis.org/">BIS</a>.</p>` : '';
-          const html = `<!DOCTYPE html><html><head>
+          const html = `<!DOCTYPE html><html lang="en"><head>
 <meta property="og:type" content="website"/>
-<meta property="og:title" content="${og.title}"/>
-<meta property="og:description" content="${og.description}"/>
-<meta property="og:image" content="${og.image}"/>
-<meta property="og:url" content="${og.url}"/>
+<meta property="og:title" content="${eTitle}"/>
+<meta property="og:description" content="${eDesc}"/>
+<meta property="og:image" content="${eImage}"/>
+<meta property="og:url" content="${eUrl}"/>
 <meta name="twitter:card" content="summary_large_image"/>
-<meta name="twitter:title" content="${og.title}"/>
-<meta name="twitter:description" content="${og.description}"/>
-<meta name="twitter:image" content="${og.image}"/>
-<link rel="canonical" href="${og.url}"/>
-<title>${og.title}</title>${jsonLd}
+<meta name="twitter:title" content="${eTitle}"/>
+<meta name="twitter:description" content="${eDesc}"/>
+<meta name="twitter:image" content="${eImage}"/>
+<link rel="canonical" href="${eUrl}"/>
+<title>${eTitle}</title>${jsonLd}
 </head><body>${aiBody}</body></html>`;
           return new Response(html, {
             status: 200,

--- a/middleware.ts
+++ b/middleware.ts
@@ -4,6 +4,12 @@ const BOT_UA =
 const SOCIAL_PREVIEW_UA =
   /twitterbot|facebookexternalhit|linkedinbot|slackbot|telegrambot|whatsapp|discordbot|redditbot/i;
 
+// AI crawlers / AEO scanners: serve a variant-aware static stub on subdomain
+// roots so each variant (tech / finance / commodity / happy / energy) is
+// indexed under its own identity rather than inheriting the 'full' SPA HTML.
+const AI_CRAWLER_UA =
+  /gptbot|claudebot|ccbot|google-extended|perplexitybot|anthropic-ai|bytespider|cohere-ai|youbot|applebot-extended|amazonbot/i;
+
 const SOCIAL_PREVIEW_PATHS = new Set(['/api/story', '/api/og-story']);
 
 // Paths that bypass bot/script UA filtering below. Each must carry its own
@@ -102,13 +108,56 @@ export default function middleware(request: Request) {
   const path = url.pathname;
   const host = normalizeHost(request.headers.get('host') ?? url.hostname);
 
-  // Social bot OG response for variant subdomain root pages
-  if (path === '/' && SOCIAL_PREVIEW_UA.test(ua)) {
-    const variant = VARIANT_HOST_MAP[host];
-    if (variant && isAllowedHost(host)) {
-      const og = VARIANT_OG[variant as keyof typeof VARIANT_OG];
-      if (og) {
-        const html = `<!DOCTYPE html><html><head>
+  // Variant-aware crawlable stub for social preview bots AND AI crawlers
+  // (GPTBot, ClaudeBot, PerplexityBot, etc.) when hitting variant subdomain
+  // roots. Social bots get OG-only; AI crawlers additionally get JSON-LD
+  // WebApplication + a body with internal links and external citations so
+  // each variant is indexed under its own identity.
+  if (path === '/') {
+    const isSocial = SOCIAL_PREVIEW_UA.test(ua);
+    const isAI = AI_CRAWLER_UA.test(ua);
+    if (isSocial || isAI) {
+      const variant = VARIANT_HOST_MAP[host];
+      if (variant && isAllowedHost(host)) {
+        const og = VARIANT_OG[variant as keyof typeof VARIANT_OG];
+        if (og) {
+          const jsonLd = isAI ? `\n<script type="application/ld+json">${JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'WebApplication',
+            name: og.title.split(' - ')[0],
+            url: og.url,
+            description: og.description,
+            applicationCategory: 'BusinessApplication',
+            operatingSystem: 'Web, Windows, macOS, Linux',
+            offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+            screenshot: og.image,
+            isPartOf: {
+              '@type': 'WebSite',
+              name: 'World Monitor',
+              url: 'https://www.worldmonitor.app/',
+            },
+            sameAs: [
+              'https://github.com/koala73/worldmonitor',
+              'https://x.com/worldmonitorai',
+            ],
+          })}</script>` : '';
+          const aiBody = isAI ? `
+<h1>${og.title}</h1>
+<p>${og.description}</p>
+<h2>Explore the platform</h2>
+<ul>
+<li><a href="https://www.worldmonitor.app/">World Monitor — geopolitics &amp; intelligence</a></li>
+<li><a href="https://tech.worldmonitor.app/">Tech Monitor</a></li>
+<li><a href="https://finance.worldmonitor.app/">Finance Monitor</a></li>
+<li><a href="https://commodity.worldmonitor.app/">Commodity Monitor</a></li>
+<li><a href="https://happy.worldmonitor.app/">Happy Monitor</a></li>
+<li><a href="https://www.worldmonitor.app/pro">World Monitor Pro</a></li>
+<li><a href="https://www.worldmonitor.app/blog/">Blog</a></li>
+<li><a href="https://github.com/koala73/worldmonitor">Open source on GitHub</a></li>
+</ul>
+<h2>Sources</h2>
+<p>Data ingested live from <a href="https://acleddata.com/">ACLED</a>, <a href="https://ucdp.uu.se/">UCDP</a>, <a href="https://firms.modaps.eosdis.nasa.gov/">NASA FIRMS</a>, <a href="https://earthquake.usgs.gov/">USGS</a>, <a href="https://opensky-network.org/">OpenSky</a>, <a href="https://aisstream.io/">AISStream</a>, <a href="https://fred.stlouisfed.org/">FRED</a>, <a href="https://www.imf.org/en/Data">IMF</a>, and <a href="https://www.bis.org/">BIS</a>.</p>` : '';
+          const html = `<!DOCTYPE html><html><head>
 <meta property="og:type" content="website"/>
 <meta property="og:title" content="${og.title}"/>
 <meta property="og:description" content="${og.description}"/>
@@ -118,16 +167,18 @@ export default function middleware(request: Request) {
 <meta name="twitter:title" content="${og.title}"/>
 <meta name="twitter:description" content="${og.description}"/>
 <meta name="twitter:image" content="${og.image}"/>
-<title>${og.title}</title>
-</head><body></body></html>`;
-        return new Response(html, {
-          status: 200,
-          headers: {
-            'Content-Type': 'text/html; charset=utf-8',
-            'Cache-Control': 'no-store',
-            'Vary': 'User-Agent, Host',
-          },
-        });
+<link rel="canonical" href="${og.url}"/>
+<title>${og.title}</title>${jsonLd}
+</head><body>${aiBody}</body></html>`;
+          return new Response(html, {
+            status: 200,
+            headers: {
+              'Content-Type': 'text/html; charset=utf-8',
+              'Cache-Control': 'no-store',
+              'Vary': 'User-Agent, Host',
+            },
+          });
+        }
       }
     }
   }

--- a/pro-test/index.html
+++ b/pro-test/index.html
@@ -143,22 +143,32 @@
       ]
     }
     </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "World Monitor", "item": "https://www.worldmonitor.app/" },
+        { "@type": "ListItem", "position": 2, "name": "Pro", "item": "https://www.worldmonitor.app/pro" }
+      ]
+    }
+    </script>
     <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit" async defer></script>
   </head>
   <body>
     <div id="root"></div>
     <noscript>
       <div style="max-width:800px;margin:0 auto;padding:40px 20px;font-family:system-ui,sans-serif;color:#e5e5e5;background:#0a0a0a;">
-        <h1>World Monitor Pro — The Geopolitical AI Layer</h1>
+        <h2>World Monitor Pro — The Geopolitical AI Layer</h2>
         <p>Ask it, subscribe to it, build on it. WM Analyst chat across 30+ live services, an AI digest delivered daily, twice-daily, or weekly to Slack, Discord, Telegram, Email, or webhook, a custom widget builder, and MCP for Claude and GPT.</p>
         <p><a href="https://www.worldmonitor.app" style="color:#4ade80;">Try the free dashboard</a></p>
-        <h2>Three pillars</h2>
+        <h3>Three pillars</h3>
         <ul>
           <li><strong>Ask it</strong> — WM Analyst chat. All 30+ services queryable in plain English.</li>
           <li><strong>Subscribe to it</strong> — AI digest on your schedule: daily, twice-daily, or weekly. Slack, Discord, Telegram, Email, webhook.</li>
           <li><strong>Build on it</strong> — Custom Widget Builder (HTML/CSS/JS + AI) and MCP for Claude, GPT, custom LLMs.</li>
         </ul>
-        <h2>What's included in Pro</h2>
+        <h3>What's included in Pro</h3>
         <ul>
           <li>WM Analyst chat — query all 30+ services conversationally</li>
           <li>AI digest with daily/twice-daily/weekly cadence (up to 30 ranked items per send), multi-channel delivery, AES-256 encrypted</li>
@@ -169,7 +179,7 @@
           <li>Flight search and price comparison</li>
           <li>Market watchlist, macro and central bank tracking</li>
         </ul>
-        <h2>FAQ</h2>
+        <h3>FAQ</h3>
         <dl>
           <dt>Is World Monitor still free?</dt>
           <dd>Yes. The core platform remains free. Pro adds the AI analyst, the personal intelligence digest, MCP connectors, and the widget builder.</dd>

--- a/pro-test/prerender.mjs
+++ b/pro-test/prerender.mjs
@@ -57,7 +57,7 @@ const seoContent = `
   <h3>${en.proShowcase.riskMonitoring}</h3><p>${en.proShowcase.riskMonitoringDesc}</p>
   <h3>${en.proShowcase.orbitalSurveillance}</h3><p>${en.proShowcase.orbitalSurveillanceDesc}</p>
   <h3>${en.proShowcase.morningBriefs}</h3><p>${en.proShowcase.morningBriefsDesc}</p>
-  <h3>${en.proShowcase.oneKey}</h3><p>${en.proShowcase.oneKeyDesc}</p>
+  <h3>${en.proShowcase.oneKey}</h3><p>Ingested live: <a href="https://finnhub.io/">Finnhub</a>, <a href="https://fred.stlouisfed.org/">FRED</a>, <a href="https://acleddata.com/">ACLED</a>, <a href="https://ucdp.uu.se/">UCDP</a>, <a href="https://firms.modaps.eosdis.nasa.gov/">NASA FIRMS</a>, <a href="https://aisstream.io/">AISStream</a>, <a href="https://opensky-network.org/">OpenSky</a>, <a href="https://www.usgs.gov/programs/earthquake-hazards">USGS</a>, <a href="https://www.imf.org/en/Data">IMF</a>, <a href="https://www.bis.org/">BIS</a>, and more — all active under one key, no separate registrations.</p>
 
   <h2>${en.deliveryDesk.title}</h2>
   <p>${en.deliveryDesk.body}</p>
@@ -103,6 +103,20 @@ const seoContent = `
 
   <h2>${en.finalCta.title}</h2>
   <p>${en.finalCta.subtitle}</p>
+
+  <h2>Explore more</h2>
+  <ul>
+    <li><a href="https://www.worldmonitor.app/">World Monitor — geopolitics &amp; intelligence dashboard</a></li>
+    <li><a href="https://tech.worldmonitor.app/">Tech Monitor — AI labs, startups, cloud</a></li>
+    <li><a href="https://finance.worldmonitor.app/">Finance Monitor — markets, central banks, forex</a></li>
+    <li><a href="https://commodity.worldmonitor.app/">Commodity Monitor — mining, energy, supply chains</a></li>
+    <li><a href="https://happy.worldmonitor.app/">Happy Monitor — positive news &amp; progress</a></li>
+    <li><a href="https://www.worldmonitor.app/blog/">World Monitor Blog — OSINT guides &amp; analysis</a></li>
+    <li><a href="https://www.worldmonitor.app/blog/posts/what-is-worldmonitor-real-time-global-intelligence/">What is World Monitor?</a></li>
+    <li><a href="https://www.worldmonitor.app/blog/posts/build-on-worldmonitor-developer-api-open-source/">Build on World Monitor — developer API &amp; MCP</a></li>
+    <li><a href="https://github.com/koala73/worldmonitor">Open source on GitHub (AGPL-3.0)</a></li>
+    <li><a href="https://www.wired.me/story/the-music-streaming-ceo-who-built-a-global-war-map">Featured in WIRED</a></li>
+  </ul>
 </div>`;
 
 // Fail loudly if any key resolved to undefined — this prevents the build from

--- a/pro-test/prerender.mjs
+++ b/pro-test/prerender.mjs
@@ -17,7 +17,7 @@ const htmlPath = resolve(__dirname, '../public/pro/index.html');
 const en = JSON.parse(readFileSync(resolve(__dirname, 'src/locales/en.json'), 'utf-8'));
 
 const seoContent = `
-<div id="seo-prerender" style="position:absolute;left:-9999px;top:-9999px;overflow:hidden;width:1px;height:1px;">
+<div id="seo-prerender" lang="en" aria-hidden="true" style="position:absolute;left:-9999px;top:-9999px;overflow:hidden;width:1px;height:1px;">
   <h1>World Monitor Pro — From ${en.hero.noiseWord} to ${en.hero.signalWord}</h1>
   <p>${en.hero.valueProps}</p>
   <p>${en.hero.launchingDate}</p>
@@ -57,6 +57,7 @@ const seoContent = `
   <h3>${en.proShowcase.riskMonitoring}</h3><p>${en.proShowcase.riskMonitoringDesc}</p>
   <h3>${en.proShowcase.orbitalSurveillance}</h3><p>${en.proShowcase.orbitalSurveillanceDesc}</p>
   <h3>${en.proShowcase.morningBriefs}</h3><p>${en.proShowcase.morningBriefsDesc}</p>
+  ${/* en.proShowcase.oneKeyDesc is intentionally NOT used here — the React UI renders that plain-text version at App.tsx:734; this prerender block ships a link-rich variant for AEO source-citation credit. Do not remove oneKeyDesc from en.json; the React app still depends on it. */ ''}
   <h3>${en.proShowcase.oneKey}</h3><p>Ingested live: <a href="https://finnhub.io/">Finnhub</a>, <a href="https://fred.stlouisfed.org/">FRED</a>, <a href="https://acleddata.com/">ACLED</a>, <a href="https://ucdp.uu.se/">UCDP</a>, <a href="https://firms.modaps.eosdis.nasa.gov/">NASA FIRMS</a>, <a href="https://aisstream.io/">AISStream</a>, <a href="https://opensky-network.org/">OpenSky</a>, <a href="https://www.usgs.gov/programs/earthquake-hazards">USGS</a>, <a href="https://www.imf.org/en/Data">IMF</a>, <a href="https://www.bis.org/">BIS</a>, and more — all active under one key, no separate registrations.</p>
 
   <h2>${en.deliveryDesk.title}</h2>

--- a/public/pro/index.html
+++ b/public/pro/index.html
@@ -244,7 +244,7 @@
   </dl>
 
   <h2>Start with Pro. Scale to Enterprise.</h2>
-  <p>Keep using <a href="https://www.worldmonitor.app/">World Monitor</a> for free, or upgrade for equity research, macro analytics, and AI briefings. If your organization needs team access, TV apps, or API support, talk to us.</p>
+  <p>Keep using World Monitor for free, or upgrade for equity research, macro analytics, and AI briefings. If your organization needs team access, TV apps, or API support, talk to us.</p>
 
   <h2>Explore more</h2>
   <ul>

--- a/public/pro/index.html
+++ b/public/pro/index.html
@@ -159,7 +159,7 @@
   </head>
   <body>
     <div id="root">
-<div id="seo-prerender" style="position:absolute;left:-9999px;top:-9999px;overflow:hidden;width:1px;height:1px;">
+<div id="seo-prerender" lang="en" aria-hidden="true" style="position:absolute;left:-9999px;top:-9999px;overflow:hidden;width:1px;height:1px;">
   <h1>World Monitor Pro — From Noise to Signal</h1>
   <p>The intelligence geopolitical AI layer — ask it, subscribe to it, build on it.</p>
   <p>Live now</p>
@@ -199,6 +199,7 @@
   <h3>Risk Monitoring & Scenarios</h3><p>Global risk scoring, scenario analysis, and geopolitical risk assessment. Convergence detection across market and political signals.</p>
   <h3>Orbital Surveillance</h3><p>(Soon) Overhead pass predictions, revisit frequency analysis, and imaging window alerts. Know when intelligence satellites are watching your areas of interest.</p>
   <h3>Personal Intelligence Desk</h3><p>Up to 30 ranked stories per digest, deduped across 500+ sources. Pick daily, twice-daily, or weekly cadence — or real-time alerts for critical events. AI Assessment and Signals to watch delivered to Slack, Discord, Telegram, Email, or webhook. Not a newsletter — an analyst.</p>
+  
   <h3>30+ Services, 1 Key</h3><p>Ingested live: <a href="https://finnhub.io/">Finnhub</a>, <a href="https://fred.stlouisfed.org/">FRED</a>, <a href="https://acleddata.com/">ACLED</a>, <a href="https://ucdp.uu.se/">UCDP</a>, <a href="https://firms.modaps.eosdis.nasa.gov/">NASA FIRMS</a>, <a href="https://aisstream.io/">AISStream</a>, <a href="https://opensky-network.org/">OpenSky</a>, <a href="https://www.usgs.gov/programs/earthquake-hazards">USGS</a>, <a href="https://www.imf.org/en/Data">IMF</a>, <a href="https://www.bis.org/">BIS</a>, and more — all active under one key, no separate registrations.</p>
 
   <h2>Your personal intelligence desk</h2>

--- a/public/pro/index.html
+++ b/public/pro/index.html
@@ -143,6 +143,16 @@
       ]
     }
     </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement": [
+        { "@type": "ListItem", "position": 1, "name": "World Monitor", "item": "https://www.worldmonitor.app/" },
+        { "@type": "ListItem", "position": 2, "name": "Pro", "item": "https://www.worldmonitor.app/pro" }
+      ]
+    }
+    </script>
     <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit" async defer></script>
     <script type="module" crossorigin src="/pro/assets/index-cpXKHxXo.js"></script>
     <link rel="stylesheet" crossorigin href="/pro/assets/index-xSEP0-ib.css">
@@ -189,7 +199,7 @@
   <h3>Risk Monitoring & Scenarios</h3><p>Global risk scoring, scenario analysis, and geopolitical risk assessment. Convergence detection across market and political signals.</p>
   <h3>Orbital Surveillance</h3><p>(Soon) Overhead pass predictions, revisit frequency analysis, and imaging window alerts. Know when intelligence satellites are watching your areas of interest.</p>
   <h3>Personal Intelligence Desk</h3><p>Up to 30 ranked stories per digest, deduped across 500+ sources. Pick daily, twice-daily, or weekly cadence — or real-time alerts for critical events. AI Assessment and Signals to watch delivered to Slack, Discord, Telegram, Email, or webhook. Not a newsletter — an analyst.</p>
-  <h3>30+ Services, 1 Key</h3><p>Finnhub, FRED, ACLED, UCDP, NASA FIRMS, AISStream, OpenSky, and more — all active, no separate registrations.</p>
+  <h3>30+ Services, 1 Key</h3><p>Ingested live: <a href="https://finnhub.io/">Finnhub</a>, <a href="https://fred.stlouisfed.org/">FRED</a>, <a href="https://acleddata.com/">ACLED</a>, <a href="https://ucdp.uu.se/">UCDP</a>, <a href="https://firms.modaps.eosdis.nasa.gov/">NASA FIRMS</a>, <a href="https://aisstream.io/">AISStream</a>, <a href="https://opensky-network.org/">OpenSky</a>, <a href="https://www.usgs.gov/programs/earthquake-hazards">USGS</a>, <a href="https://www.imf.org/en/Data">IMF</a>, <a href="https://www.bis.org/">BIS</a>, and more — all active under one key, no separate registrations.</p>
 
   <h2>Your personal intelligence desk</h2>
   <p>Up to 30 ranked items per send, deduped across 500+ sources, scored against your watchlist. Choose your cadence — daily, twice-daily, or weekly — with an AI Assessment and Signals to watch delivered to Slack, Discord, Telegram, Email, or webhook.</p>
@@ -234,20 +244,34 @@
   </dl>
 
   <h2>Start with Pro. Scale to Enterprise.</h2>
-  <p>Keep using World Monitor for free, or upgrade for equity research, macro analytics, and AI briefings. If your organization needs team access, TV apps, or API support, talk to us.</p>
+  <p>Keep using <a href="https://www.worldmonitor.app/">World Monitor</a> for free, or upgrade for equity research, macro analytics, and AI briefings. If your organization needs team access, TV apps, or API support, talk to us.</p>
+
+  <h2>Explore more</h2>
+  <ul>
+    <li><a href="https://www.worldmonitor.app/">World Monitor — geopolitics &amp; intelligence dashboard</a></li>
+    <li><a href="https://tech.worldmonitor.app/">Tech Monitor — AI labs, startups, cloud</a></li>
+    <li><a href="https://finance.worldmonitor.app/">Finance Monitor — markets, central banks, forex</a></li>
+    <li><a href="https://commodity.worldmonitor.app/">Commodity Monitor — mining, energy, supply chains</a></li>
+    <li><a href="https://happy.worldmonitor.app/">Happy Monitor — positive news &amp; progress</a></li>
+    <li><a href="https://www.worldmonitor.app/blog/">World Monitor Blog — OSINT guides &amp; analysis</a></li>
+    <li><a href="https://www.worldmonitor.app/blog/posts/what-is-worldmonitor-real-time-global-intelligence/">What is World Monitor?</a></li>
+    <li><a href="https://www.worldmonitor.app/blog/posts/build-on-worldmonitor-developer-api-open-source/">Build on World Monitor — developer API &amp; MCP</a></li>
+    <li><a href="https://github.com/koala73/worldmonitor">Open source on GitHub (AGPL-3.0)</a></li>
+    <li><a href="https://www.wired.me/story/the-music-streaming-ceo-who-built-a-global-war-map">Featured in WIRED</a></li>
+  </ul>
 </div></div>
     <noscript>
       <div style="max-width:800px;margin:0 auto;padding:40px 20px;font-family:system-ui,sans-serif;color:#e5e5e5;background:#0a0a0a;">
-        <h1>World Monitor Pro — The Geopolitical AI Layer</h1>
+        <h2>World Monitor Pro — The Geopolitical AI Layer</h2>
         <p>Ask it, subscribe to it, build on it. WM Analyst chat across 30+ live services, an AI digest delivered daily, twice-daily, or weekly to Slack, Discord, Telegram, Email, or webhook, a custom widget builder, and MCP for Claude and GPT.</p>
         <p><a href="https://www.worldmonitor.app" style="color:#4ade80;">Try the free dashboard</a></p>
-        <h2>Three pillars</h2>
+        <h3>Three pillars</h3>
         <ul>
           <li><strong>Ask it</strong> — WM Analyst chat. All 30+ services queryable in plain English.</li>
           <li><strong>Subscribe to it</strong> — AI digest on your schedule: daily, twice-daily, or weekly. Slack, Discord, Telegram, Email, webhook.</li>
           <li><strong>Build on it</strong> — Custom Widget Builder (HTML/CSS/JS + AI) and MCP for Claude, GPT, custom LLMs.</li>
         </ul>
-        <h2>What's included in Pro</h2>
+        <h3>What's included in Pro</h3>
         <ul>
           <li>WM Analyst chat — query all 30+ services conversationally</li>
           <li>AI digest with daily/twice-daily/weekly cadence (up to 30 ranked items per send), multi-channel delivery, AES-256 encrypted</li>
@@ -258,7 +282,7 @@
           <li>Flight search and price comparison</li>
           <li>Market watchlist, macro and central bank tracking</li>
         </ul>
-        <h2>FAQ</h2>
+        <h3>FAQ</h3>
         <dl>
           <dt>Is World Monitor still free?</dt>
           <dd>Yes. The core platform remains free. Pro adds the AI analyst, the personal intelligence digest, MCP connectors, and the widget builder.</dd>


### PR DESCRIPTION
## Summary

AEO scanner findings on root + /pro + 5 variant subdomains + 17 blog posts — all addressed.

- **Single H1** (was 2 on root + /pro): demote second H1 to H2 in `index.html` and the pro `noscript` fallback. Pre-push hook caught that `public/pro/` is a built artifact, so changes landed in `pro-test/index.html` + `pro-test/prerender.mjs` and the bundle was rebuilt.
- **Internal links** (was 0 in body on SPA pages): rich crawler-visible SEO blocks on `index.html` and `pro-test/prerender.mjs` with 5–8 contextual internal links per page (variants, blog, GitHub, /pro).
- **External citation links** (was 1 across 17 blog posts → 74): linkified first mention of every named data source — ACLED, UCDP, NASA FIRMS, USGS, OpenSky, AISStream, IMF, FRED, BIS, Cloudflare Radar, Polymarket, Reuters, etc. Plus 12 external citations on root + /pro inline content.
- **Structured data** (was 2/9 types): added `Organization` + `WebSite`+`SearchAction` on root; `BreadcrumbList` on /pro. Root and /pro each now ship 3 JSON-LD types.
- **Per-variant identity**: web build ships one HTML for all 5 variant subdomains, so the existing `htmlVariantPlugin` JSON-LD swap only fires for desktop. Extended `middleware.ts` social-preview branch to also serve AI crawlers (GPTBot, ClaudeBot, PerplexityBot, CCBot, Google-Extended, etc.) variant-specific `WebApplication` JSON-LD + linked body on tech/finance/commodity/happy/energy subdomains.

## Expected scanner deltas on re-scan

| Check | Before | After |
|---|---|---|
| Single H1 | 1/5 | 5/5 |
| Heading hierarchy | 4/4 | 4/4 |
| Structured data | 2/9 | ~5/9 |
| Open Graph | 4/4 | 4/4 |
| Alt text | 3/3 | 3/3 |
| Internal links | 0/18 | ~16/18 |
| External citations | 2/7 | 7/7 |
| llms.txt | 3/3 | 3/3 |

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean
- [x] `npm run lint` (biome) — exit 0
- [x] `npm run test:data` — 9631/9631 pass (334s)
- [x] `node --test tests/edge-functions.test.mjs` — 199/199 pass
- [x] `npm run lint:md` — 0 errors on 59 files
- [x] esbuild middleware.ts edge bundle — clean
- [x] `cd pro-test && npm run build` — rebuilt artifact matches source
- [x] Pre-push hook (full suite) — passed; pro-test bundle freshness check passed
- [ ] After deploy: re-run AEO scanner and confirm scores updated
- [ ] After deploy: spot-check `curl -A "GPTBot" https://tech.worldmonitor.app/` to confirm variant-specific JSON-LD ships