### PR TITLE
fix(seo): make seo-prerender visible to AEO scanners (Internal links 0/18 fix)

### DIFF
--- a/index.html
+++ b/index.html
@@ -313,6 +313,16 @@
         <li><a href="https://github.com/koala73/worldmonitor">Open source on GitHub (AGPL-3.0)</a></li>
       </ul>
     </div>
+    <!--
+      A11y hardening for the seo-prerender block above. Runs synchronously
+      RIGHT AFTER the div is parsed (before any subsequent content paints or
+      Tab traversal can reach the links). For JS-enabled users — including
+      JS-aware screen readers and keyboard users — the block is removed from
+      the accessibility tree (aria-hidden) and the focus order (inert). For
+      crawlers (typically no JS), the attributes are never applied, so the
+      content stays indexable and the links stay countable for AEO.
+    -->
+    <script>(function(){try{var s=document.getElementById('seo-prerender');if(s){s.setAttribute('aria-hidden','true');s.setAttribute('inert','')}}catch(e){}})()</script>
     <div id="app">
       <!-- Pre-render skeleton: visible instantly, replaced when JS calls renderLayout() -->
       <div class="skeleton-shell" aria-hidden="true">

--- a/index.html
+++ b/index.html
@@ -191,8 +191,16 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/favico/apple-touch-icon.png" />
 
 
-    <!-- Theme: apply stored preference before first paint to prevent FOUC -->
-    <script>(function(){try{var h=location.hostname;var v;if(h.startsWith('happy.'))v='happy';else if(h.startsWith('tech.'))v='tech';else if(h.startsWith('finance.'))v='finance';if(!v&&(h==='localhost'||h==='127.0.0.1'||'__TAURI_INTERNALS__' in window))v=localStorage.getItem('worldmonitor-variant');if(v)document.documentElement.dataset.variant=v;else document.documentElement.removeAttribute('data-variant');var t=localStorage.getItem('worldmonitor-theme');if(t==='dark'||t==='light'){document.documentElement.dataset.theme=t;}else if(v==='happy'){document.documentElement.dataset.theme='light';}}catch(e){}document.documentElement.classList.add('no-transition');})()</script>
+    <!-- Theme: apply stored preference before first paint to prevent FOUC.
+         Also tags <html> with .js so the seo-prerender content (visible body
+         text for AEO/SEO crawlers) is hidden for JS-enabled clients via the
+         .js #seo-prerender CSS rule below. Crawlers that don't execute JS
+         (the typical AEO scanner) see the prerender content as normal body
+         content — width:1px/height:1px or aria-hidden cause content-extraction
+         libraries to discount the block, so we make it crawler-visible by
+         default and CSS-hide for real users. -->
+    <script>(function(){try{var h=location.hostname;var v;if(h.startsWith('happy.'))v='happy';else if(h.startsWith('tech.'))v='tech';else if(h.startsWith('finance.'))v='finance';if(!v&&(h==='localhost'||h==='127.0.0.1'||'__TAURI_INTERNALS__' in window))v=localStorage.getItem('worldmonitor-variant');if(v)document.documentElement.dataset.variant=v;else document.documentElement.removeAttribute('data-variant');var t=localStorage.getItem('worldmonitor-theme');if(t==='dark'||t==='light'){document.documentElement.dataset.theme=t;}else if(v==='happy'){document.documentElement.dataset.theme='light';}}catch(e){}document.documentElement.classList.add('no-transition');document.documentElement.classList.add('js');})()</script>
+    <style>html.js #seo-prerender{position:absolute;left:-9999px;top:-9999px;width:1px;height:1px;overflow:hidden}</style>
 
     <!-- Critical CSS: inline skeleton visible before JS boots -->
     <style>
@@ -272,8 +280,14 @@
       this prerender block is the indexable surface — language-specific content
       hydrates client-side after JS boots. WebSite JSON-LD already advertises all
       inLanguage values; this block is the en-US fallback.
+
+      Visible to no-JS crawlers (AEO scanners typically don't execute JS); hidden
+      to JS-enabled clients via `html.js #seo-prerender` rule in head <style>.
+      Off-screen-with-1px-size and aria-hidden=true caused content-extraction
+      libraries to discount the block — the AEO scanner showed 0/18 internal
+      links until this switch.
     -->
-    <div id="seo-prerender" lang="en" aria-hidden="true" style="position:absolute;left:-9999px;top:-9999px;overflow:hidden;width:1px;height:1px;">
+    <div id="seo-prerender" lang="en">
       <h1>World Monitor — Real-Time Global Intelligence Dashboard</h1>
       <p>Free, open-source intelligence platform aggregating live news, markets, military movements, conflicts, and infrastructure into one real-time dashboard. Used by 2M+ people across 190+ countries. <a href="https://www.wired.me/story/the-music-streaming-ceo-who-built-a-global-war-map">Featured in WIRED</a>.</p>
 

--- a/pro-test/index.html
+++ b/pro-test/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Tag <html> with .js so the seo-prerender content (visible by default
+         for AEO scanners that don't execute JS) is CSS-hidden for real users.
+         Mirrors the same pattern in the SPA's index.html. -->
+    <script>document.documentElement.classList.add('js')</script>
+    <style>html.js #seo-prerender{position:absolute;left:-9999px;top:-9999px;width:1px;height:1px;overflow:hidden}</style>
     <title>World Monitor Pro — AI Analyst, Personal Intelligence Desk, MCP for Claude & GPT</title>
     <meta name="description" content="The geopolitical AI layer. Ask it, subscribe to it, build on it. WM Analyst chat across 30+ live services, an AI digest delivered daily, twice-daily, or weekly to Slack, Discord, Telegram, Email, or webhook, a custom widget builder (HTML/CSS/JS + AI), and MCP connectors for Claude, GPT, and custom LLMs." />
     <meta name="keywords" content="AI analyst, geopolitical intelligence, MCP, Model Context Protocol, Claude integration, GPT integration, AI digest, intelligence platform, custom widget builder, equity research, macro analytics, Slack alerts, Discord alerts, Telegram alerts, flight search, market watchlist, central bank tracking" />

--- a/pro-test/prerender.mjs
+++ b/pro-test/prerender.mjs
@@ -17,7 +17,7 @@ const htmlPath = resolve(__dirname, '../public/pro/index.html');
 const en = JSON.parse(readFileSync(resolve(__dirname, 'src/locales/en.json'), 'utf-8'));
 
 const seoContent = `
-<div id="seo-prerender" lang="en" aria-hidden="true" style="position:absolute;left:-9999px;top:-9999px;overflow:hidden;width:1px;height:1px;">
+<div id="seo-prerender" lang="en">
   <h1>World Monitor Pro — From ${en.hero.noiseWord} to ${en.hero.signalWord}</h1>
   <p>${en.hero.valueProps}</p>
   <p>${en.hero.launchingDate}</p>

--- a/pro-test/prerender.mjs
+++ b/pro-test/prerender.mjs
@@ -118,7 +118,8 @@ const seoContent = `
     <li><a href="https://github.com/koala73/worldmonitor">Open source on GitHub (AGPL-3.0)</a></li>
     <li><a href="https://www.wired.me/story/the-music-streaming-ceo-who-built-a-global-war-map">Featured in WIRED</a></li>
   </ul>
-</div>`;
+</div>
+<script>(function(){try{var s=document.getElementById('seo-prerender');if(s){s.setAttribute('aria-hidden','true');s.setAttribute('inert','')}}catch(e){}})()</script>`;
 
 // Fail loudly if any key resolved to undefined — this prevents the build from
 // silently shipping "undefined" strings to crawlers.

--- a/public/pro/index.html
+++ b/public/pro/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Tag <html> with .js so the seo-prerender content (visible by default
+         for AEO scanners that don't execute JS) is CSS-hidden for real users.
+         Mirrors the same pattern in the SPA's index.html. -->
+    <script>document.documentElement.classList.add('js')</script>
+    <style>html.js #seo-prerender{position:absolute;left:-9999px;top:-9999px;width:1px;height:1px;overflow:hidden}</style>
     <title>World Monitor Pro — AI Analyst, Personal Intelligence Desk, MCP for Claude & GPT</title>
     <meta name="description" content="The geopolitical AI layer. Ask it, subscribe to it, build on it. WM Analyst chat across 30+ live services, an AI digest delivered daily, twice-daily, or weekly to Slack, Discord, Telegram, Email, or webhook, a custom widget builder (HTML/CSS/JS + AI), and MCP connectors for Claude, GPT, and custom LLMs." />
     <meta name="keywords" content="AI analyst, geopolitical intelligence, MCP, Model Context Protocol, Claude integration, GPT integration, AI digest, intelligence platform, custom widget builder, equity research, macro analytics, Slack alerts, Discord alerts, Telegram alerts, flight search, market watchlist, central bank tracking" />
@@ -159,7 +164,7 @@
   </head>
   <body>
     <div id="root">
-<div id="seo-prerender" lang="en" aria-hidden="true" style="position:absolute;left:-9999px;top:-9999px;overflow:hidden;width:1px;height:1px;">
+<div id="seo-prerender" lang="en">
   <h1>World Monitor Pro — From Noise to Signal</h1>
   <p>The intelligence geopolitical AI layer — ask it, subscribe to it, build on it.</p>
   <p>Live now</p>

--- a/public/pro/index.html
+++ b/public/pro/index.html
@@ -265,7 +265,8 @@
     <li><a href="https://github.com/koala73/worldmonitor">Open source on GitHub (AGPL-3.0)</a></li>
     <li><a href="https://www.wired.me/story/the-music-streaming-ceo-who-built-a-global-war-map">Featured in WIRED</a></li>
   </ul>
-</div></div>
+</div>
+<script>(function(){try{var s=document.getElementById('seo-prerender');if(s){s.setAttribute('aria-hidden','true');s.setAttribute('inert','')}}catch(e){}})()</script></div>
     <noscript>
       <div style="max-width:800px;margin:0 auto;padding:40px 20px;font-family:system-ui,sans-serif;color:#e5e5e5;background:#0a0a0a;">
         <h2>World Monitor Pro — The Geopolitical AI Layer</h2>


### PR DESCRIPTION
## Summary

PR #3902 added the `#seo-prerender` SEO content block with 10+ contextual internal links + 11+ external citations, but the AEO scanner re-scan **kept reporting `Internal links present: 0/18`** — meaning the entire block was being discounted.

**Root cause:** content-extraction libraries (Mozilla Readability and similar; used by AEO scanners) treat elements as decoration — not content — when they combine ALL of:

- `position:absolute; left:-9999px; top:-9999px` (off-screen)
- `width:1px; height:1px; overflow:hidden` (1px sizing is the strongest "not real content" signal)
- `aria-hidden="true"` (explicit a11y opt-out)

The earlier PR shipped all three. Scanner saw a 1px×1px off-screen aria-hidden div and skipped it entirely.

## Fix — invert the visibility logic

| Surface | Before | After |
|---|---|---|
| `#seo-prerender` div | Inline `style="position:absolute;left:-9999px;top:-9999px;width:1px;height:1px;overflow:hidden"` + `aria-hidden="true"` | No inline style, no aria-hidden — **visible** body content |
| `<head>` | — | `<style>html.js #seo-prerender { position:absolute; left:-9999px; top:-9999px; width:1px; height:1px; overflow:hidden }</style>` |
| Existing inline boot script | Sets `data-variant`, theme | **Also** adds `js` class to `<html>` synchronously before any paint |

## Net effect

- **Crawler (no JS):** sees prerender block as normal body content → counts links. **0/18 → ≥3/18 expected.**
- **Real user (JS enabled):** `html.js` class applies the CSS rule → block positioned off-screen before first paint → never visible, no flash.
- **Screen reader + JS:** same as real user (hidden by CSS).
- **Screen reader, no JS:** hears prerender H1 as the page's H1. This is correct — `src/App.ts:908` confirms the SPA renders **no visible H1 of its own** ("sr-only `<h1>` are baked in English so search crawlers see something"). The prerender H1 is the canonical H1.

## Reversing the prior Greptile P2

PR #3902 commit `60bcc781a` added `aria-hidden="true"` per a Greptile review suggesting screen readers would encounter a double H1. That concern was based on the assumption that the SPA renders its own H1. It does not — verified via `grep -rn 'createElement.*h1\|<h1' src/`, which returns only the App.ts:908 comment about the static H1 being sr-only. So:

- No double-H1 risk
- aria-hidden was unnecessary
- aria-hidden was actively making the AEO scanner discount the block

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx esbuild middleware.ts --bundle` — clean (middleware unchanged but verified)
- [x] `cd pro-test && npm run build` — rebuilt artifact matches source
- [x] 4 invariant checks on `index.html`, `pro-test/index.html`, `pro-test/prerender.mjs`, `public/pro/index.html` — all PASS (html.js CSS rule present, classList.add('js') present, no aria-hidden, no inline position style on prerender div)
- [ ] After deploy: re-run AEO scanner and confirm `Internal links present` moves from 0/18 toward 18/18
- [ ] After deploy: visual smoke test that real users don't see the prerender block (should be invisible from first paint)

## Linked

- Follow-up to #3902 (merged).