### PR TITLE
Fix digest lead/card ordering coherence

### DIFF
--- a/scripts/lib/brief-compose.mjs
+++ b/scripts/lib/brief-compose.mjs
@@ -667,6 +667,13 @@ function digestStoryToUpstreamTopStory(s) {
     primaryLink: typeof s?.link === 'string' ? s.link : undefined,
     threatLevel: s?.severity,
     importanceScore: Number.isFinite(Number(s?.currentScore)) ? Number(s.currentScore) : undefined,
+    // Transient coherence signal from story:track:v1. Not written into
+    // BriefStory; shared/brief-filter.js consumes it before envelope
+    // assembly to keep an entity-corroborated flashpoint-diplomacy lead
+    // aligned with the first rendered card when the LLM ranked it first.
+    entityCorroborationCount: Number.isFinite(Number(s?.entityCorroborationCount))
+      ? Number(s.entityCorroborationCount)
+      : 0,
     // `category` IS carried on story:track:v1 (persisted by
     // buildStoryTrackHsetFields, passed through buildDigest's stories.push).
     // Pre-stamp residue rows missing the field fall back to 'General' via
@@ -730,6 +737,7 @@ function digestStoryToUpstreamTopStory(s) {
  * @param {{
  *   nowMs?: number,
  *   onDrop?: import('../../shared/brief-filter.js').DropMetricsFn,
+ *   onOrder?: import('../../shared/brief-filter.js').OrderMetricsFn,
  *   synthesis?: {
  *     lead?: string,
  *     threads?: Array<{ tag: string, teaser: string }>,
@@ -743,13 +751,15 @@ function digestStoryToUpstreamTopStory(s) {
  *   `onDrop` is forwarded to filterTopStories so the seeder can
  *   aggregate per-user filter-drop counts without this module knowing
  *   how they are reported.
+ *   `onOrder` is forwarded the same way for aggregate-only ordering
+ *   telemetry; the callback receives no raw headlines.
  *   `synthesis` (when provided) substitutes envelope.digest.lead /
  *   threads / signals / publicLead with the canonical synthesis from
  *   the orchestration layer. `synthesis.rankedStoryHashes` is passed to
  *   the filter as a tie-breaker after severity/topic-cluster ordering,
  *   before applying the cap.
  */
-export function composeBriefFromDigestStories(rule, digestStories, insightsNumbers, { nowMs = Date.now(), onDrop, synthesis } = {}) {
+export function composeBriefFromDigestStories(rule, digestStories, insightsNumbers, { nowMs = Date.now(), onDrop, onOrder, synthesis } = {}) {
   if (!Array.isArray(digestStories) || digestStories.length === 0) return null;
   // Default to 'high' (NOT 'all') for undefined sensitivity, aligning
   // with buildDigest at scripts/seed-digest-notifications.mjs:392 and
@@ -768,6 +778,7 @@ export function composeBriefFromDigestStories(rule, digestStories, insightsNumbe
     sensitivity,
     maxStories: MAX_STORIES_PER_USER,
     onDrop,
+    onOrder,
     rankedStoryHashes: synthesis?.rankedStoryHashes,
   });
   if (stories.length === 0) return null;

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -657,6 +657,12 @@ async function buildDigest(rule, windowStartMs) {
       // pre-stamp residue rows. Display-side word-wise titleCase happens
       // once at the envelope-build site in shared/brief-filter.js.
       category: typeof track.category === 'string' ? track.category : '',
+      // Cross-title entity corroboration persisted by list-feed-digest.
+      // This is distinct from exact-title source sets: the brief composer
+      // uses it only for the narrow lead/card coherence override when
+      // the LLM's top-ranked story is a corroborated flashpoint-diplomacy
+      // development.
+      entityCorroborationCount: parseInt(track.entityCorroborationCount ?? '0', 10) || 0,
     });
   }
 
@@ -1762,6 +1768,9 @@ async function composeAndStoreBriefForUser(userId, annotated, insightsNumbers, d
     institutional_static_page: 0,
     in: winnerStories.length,
   };
+  const orderStats = {
+    leadDiplomacyOverride: false,
+  };
   const envelope = composeBriefFromDigestStories(
     winner.rule,
     winnerStories,
@@ -1769,6 +1778,7 @@ async function composeAndStoreBriefForUser(userId, annotated, insightsNumbers, d
     {
       nowMs,
       onDrop: (ev) => { dropStats[ev.reason] = (dropStats[ev.reason] ?? 0) + 1; },
+      onOrder: (ev) => { orderStats.leadDiplomacyOverride = ev.leadDiplomacyOverride === true; },
       synthesis: synthesis || publicLead
         ? {
             ...(synthesis ?? {}),
@@ -1833,9 +1843,13 @@ async function composeAndStoreBriefForUser(userId, annotated, insightsNumbers, d
     // the wrong fit here: a single headline can carry ≥4 anchors,
     // tripping its size-based threshold up to 2.
     const coherent = leadGroundsAgainstStory(synthesis.lead, card1Headline);
+    const coherentVia = !coherent
+      ? 'mismatch'
+      : (orderStats.leadDiplomacyOverride ? 'lead_diplomacy_override' : 'natural');
     console.log(
       `[digest] lead card1 coherence user=${userId} ` +
         `coherent=${coherent} synthesis_level=${synthesisLevel} ` +
+        `coherent_via=${coherentVia} ` +
         `card1_clusterId=${card1?.clusterId ?? '?'}`,
     );
     if (!coherent) {

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -1085,6 +1085,13 @@ function buildStoryTrackHsetFields(
     // (treats as legacy row) instead of being mis-classified as a stale
     // row with a bogus timestamp.
     'publishedAt', Number.isFinite(item.publishedAt) ? String(item.publishedAt) : '',
+    // Entity-level cross-title corroboration count. Distinct from exact
+    // normalized-title sourceCount: this captures related flashpoint +
+    // diplomacy reports that do not collapse into the same story hash.
+    // The digest composer uses it as a narrow lead/card coherence signal.
+    'entityCorroborationCount', Number.isFinite(item.entityCorroborationCount)
+      ? String(item.entityCorroborationCount)
+      : '0',
     // Opinion/analysis flag (classifyOpinion). '1' = op-ed/column,
     // '0' = hard news. buildDigest's read-path filter excludes '1' rows
     // from the brief pool. Written unconditionally for the same

--- a/shared/brief-filter.d.ts
+++ b/shared/brief-filter.d.ts
@@ -57,6 +57,10 @@ export type DropMetricsFn = (event: {
   sourceUrl?: string;
 }) => void;
 
+export type OrderMetricsFn = (event: {
+  leadDiplomacyOverride: boolean;
+}) => void;
+
 /**
  * Filters the upstream `topStories` array against a user's
  * `alertRules.sensitivity` setting and caps at `maxStories`. Stories
@@ -74,7 +78,10 @@ export type DropMetricsFn = (event: {
  * concentrated top severity before breadth: a block with two critical
  * stories sorts ahead of a block with one critical plus many high
  * stories. `rankedStoryHashes` remains a tie-breaker inside similarly
- * severe/sized blocks, matched by short-hash prefix (≥4 chars). This
+ * severe/sized blocks, matched by short-hash prefix (≥4 chars), except
+ * for the rank-0 lead coherence override: an entity-corroborated
+ * flashpoint-diplomacy story selected first by the synthesis ranks
+ * ahead of severity-only ordering so the lead and card #1 align. This
  * keeps critical topic clusters contiguous instead of letting model
  * ranking pull unrelated singletons above them.
  *
@@ -91,6 +98,7 @@ export function filterTopStories(input: {
   maxStories?: number;
   maxPerSourceTopic?: number;
   onDrop?: DropMetricsFn;
+  onOrder?: OrderMetricsFn;
   rankedStoryHashes?: string[];
 }): BriefStory[];
 
@@ -150,6 +158,17 @@ export interface UpstreamTopStory {
    * compose paths write this from story:track:v1.currentScore.
    */
   importanceScore?: unknown;
+  /**
+   * Transient entity-level corroboration count from story:track:v1.
+   * Used only by the rank-0 flashpoint-diplomacy lead coherence override
+   * before BriefStory assembly; not serialized into the envelope.
+   */
+  entityCorroborationCount?: unknown;
+  /**
+   * Boolean alias retained for callers that already precompute
+   * entity-level corroboration.
+   */
+  entityCorroboration?: unknown;
   /**
    * Legacy upstream score alias retained for callers that still feed
    * raw news:insights:v1 rows directly into filterTopStories.

--- a/shared/brief-filter.js
+++ b/shared/brief-filter.js
@@ -64,10 +64,89 @@ const SEVERITY_RANK = {
   low: 3,
 };
 
+const DIPLOMACY_KEYWORDS = [
+  'ceasefire', 'truce', 'armistice', 'treaty', 'accord', 'pact', 'diplomatic',
+  'diplomacy', 'mediate', 'mediator', 'negotiation', 'negotiations', 'negotiate',
+  'normalization', 'normalisation',
+];
+
+const FLASHPOINT_KEYWORDS = [
+  'iran', 'tehran', 'russia', 'moscow', 'china', 'beijing', 'taiwan', 'ukraine', 'kyiv',
+  'north korea', 'pyongyang', 'israel', 'gaza', 'west bank', 'syria', 'damascus',
+  'yemen', 'hezbollah', 'hamas', 'kremlin', 'pentagon', 'nato', 'wagner',
+];
+
+const DIPLOMACY_FLASHPOINT_PAIRS = [
+  ['iran', 'deal'],
+  ['iran', 'talks'],
+  ['iran', 'ceasefire'],
+  ['iran', 'treaty'],
+  ['iran', 'accord'],
+  ['iran', 'peace'],
+  ['israel', 'ceasefire'],
+  ['israel', 'truce'],
+  ['israel', 'accord'],
+  ['gaza', 'ceasefire'],
+  ['gaza', 'truce'],
+  ['ukraine', 'ceasefire'],
+  ['ukraine', 'talks'],
+  ['russia', 'talks'],
+  ['russia', 'treaty'],
+  ['hamas', 'truce'],
+  ['hezbollah', 'truce'],
+  ['syria', 'ceasefire'],
+  ['china', 'talks'],
+  ['china', 'accord'],
+  ['taiwan', 'talks'],
+  ['yemen', 'ceasefire'],
+  ['north korea', 'talks'],
+  ['pyongyang', 'talks'],
+];
+
+const LEAD_COHERENCE_MIN_ENTITY_CORROBORATION = 2;
+
 /** @param {unknown} v */
 function finiteNumberOrZero(v) {
   const n = typeof v === 'number' ? v : Number(v);
   return Number.isFinite(n) ? n : 0;
+}
+
+/** @param {string} text */
+function normalizeScoringText(text) {
+  return text.toLowerCase().replace(/[^a-z0-9\s]/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+/** @param {string} text @param {string[]} keywords */
+function hasAnySignal(text, keywords) {
+  return keywords.some((kw) => text.includes(kw));
+}
+
+/**
+ * @param {Record<string, unknown>} story
+ * @returns {boolean}
+ */
+function hasDiplomacyFlashpointSignal(story) {
+  const title = asTrimmedString(story?.primaryTitle);
+  const description = asTrimmedString(story?.description);
+  const text = normalizeScoringText(`${title} ${description}`.trim());
+  if (!text) return false;
+  if (
+    DIPLOMACY_FLASHPOINT_PAIRS.some(([entity, action]) =>
+      text.includes(entity) && text.includes(action),
+    )
+  ) {
+    return true;
+  }
+  return hasAnySignal(text, DIPLOMACY_KEYWORDS) && hasAnySignal(text, FLASHPOINT_KEYWORDS);
+}
+
+/**
+ * @param {Record<string, unknown>} story
+ * @returns {boolean}
+ */
+function hasEntityCorroboration(story) {
+  if (story?.entityCorroboration === true) return true;
+  return finiteNumberOrZero(story?.entityCorroborationCount) >= LEAD_COHERENCE_MIN_ENTITY_CORROBORATION;
 }
 
 /** @param {unknown} v */
@@ -139,6 +218,10 @@ function titleCase(v) {
 
 /**
  * @typedef {(event: { reason: 'severity'|'headline'|'url'|'shape'|'cap'|'source_topic_cap'|'institutional_static_page', severity?: string, sourceUrl?: string }) => void} DropMetricsFn
+ */
+
+/**
+ * @typedef {(event: { leadDiplomacyOverride: boolean }) => void} OrderMetricsFn
  */
 
 /**
@@ -216,20 +299,27 @@ function topicKeyForStory(story, originalIndex) {
  * @param {Array<Record<string, unknown>>} stories
  * @param {Set<BriefThreatLevel>} allowed
  * @param {unknown} rankedStoryHashes
+ * @param {OrderMetricsFn | undefined} onOrder
  * @returns {Array<Record<string, unknown>>}
  */
-function orderBriefCandidates(stories, allowed, rankedStoryHashes) {
+function orderBriefCandidates(stories, allowed, rankedStoryHashes, onOrder) {
   const annotated = stories.map((story, originalIndex) => {
     const threatLevel = normaliseThreatLevel(story?.threatLevel);
     const severityRank = threatLevel ? (SEVERITY_RANK[threatLevel] ?? Infinity) : Infinity;
+    const eligible = Boolean(threatLevel && allowed.has(threatLevel));
+    const rank = rankForStory(story, rankedStoryHashes);
     return {
       story,
       originalIndex,
       topicKey: topicKeyForStory(story, originalIndex),
       threatLevel,
       severityRank,
-      eligible: Boolean(threatLevel && allowed.has(threatLevel)),
-      rank: rankForStory(story, rankedStoryHashes),
+      eligible,
+      rank,
+      leadDiplomacyOverride: eligible &&
+        rank === 0 &&
+        hasEntityCorroboration(story) &&
+        hasDiplomacyFlashpointSignal(story),
       score: finiteNumberOrZero(story?.importanceScore ?? story?.currentScore),
     };
   });
@@ -252,6 +342,10 @@ function orderBriefCandidates(stories, allowed, rankedStoryHashes) {
         // Best (lowest) LLM rank seen across any eligible member in
         // this block, not the rank of the highest-scoring member.
         bestLlmRank: Infinity,
+        // Narrow coherence override: if the synthesis lead selected an
+        // entity-corroborated flashpoint-diplomacy story as rank #1, its
+        // topic block must render before severity-only conflict matches.
+        bestLeadDiplomacyRank: Infinity,
       };
       blocks.set(item.topicKey, block);
     }
@@ -261,6 +355,9 @@ function orderBriefCandidates(stories, allowed, rankedStoryHashes) {
       block.eligibleCount += 1;
       block.maxScore = Math.max(block.maxScore, item.score);
       block.bestLlmRank = Math.min(block.bestLlmRank, item.rank);
+      if (item.leadDiplomacyOverride) {
+        block.bestLeadDiplomacyRank = Math.min(block.bestLeadDiplomacyRank, item.rank);
+      }
       if (item.severityRank < block.bestSeverityRank) {
         block.bestSeverityRank = item.severityRank;
         block.bestSeverityCount = 1;
@@ -271,6 +368,12 @@ function orderBriefCandidates(stories, allowed, rankedStoryHashes) {
   }
 
   const orderedBlocks = [...blocks.values()].sort((a, b) => {
+    const aLead = Number.isFinite(a.bestLeadDiplomacyRank);
+    const bLead = Number.isFinite(b.bestLeadDiplomacyRank);
+    if (aLead !== bLead) return aLead ? -1 : 1;
+    if (aLead && a.bestLeadDiplomacyRank !== b.bestLeadDiplomacyRank) {
+      return a.bestLeadDiplomacyRank - b.bestLeadDiplomacyRank;
+    }
     if (a.bestSeverityRank !== b.bestSeverityRank) return a.bestSeverityRank - b.bestSeverityRank;
     if (a.bestSeverityCount !== b.bestSeverityCount) return b.bestSeverityCount - a.bestSeverityCount;
     if (a.eligibleCount !== b.eligibleCount) return b.eligibleCount - a.eligibleCount;
@@ -283,6 +386,7 @@ function orderBriefCandidates(stories, allowed, rankedStoryHashes) {
   for (const block of orderedBlocks) {
     block.items.sort((a, b) => {
       if (a.eligible !== b.eligible) return a.eligible ? -1 : 1;
+      if (a.leadDiplomacyOverride !== b.leadDiplomacyOverride) return a.leadDiplomacyOverride ? -1 : 1;
       if (a.severityRank !== b.severityRank) return a.severityRank - b.severityRank;
       if (a.rank !== b.rank) return a.rank - b.rank;
       if (a.score !== b.score) return b.score - a.score;
@@ -290,14 +394,18 @@ function orderBriefCandidates(stories, allowed, rankedStoryHashes) {
     });
     for (const item of block.items) ordered.push(item.story);
   }
+  if (typeof onOrder === 'function') {
+    const first = orderedBlocks[0]?.items?.[0];
+    onOrder({ leadDiplomacyOverride: first?.leadDiplomacyOverride === true });
+  }
   return ordered;
 }
 
 /**
- * @param {{ stories: UpstreamTopStory[]; sensitivity: AlertSensitivity; maxStories?: number; maxPerSourceTopic?: number; onDrop?: DropMetricsFn; rankedStoryHashes?: string[] }} input
+ * @param {{ stories: UpstreamTopStory[]; sensitivity: AlertSensitivity; maxStories?: number; maxPerSourceTopic?: number; onDrop?: DropMetricsFn; onOrder?: OrderMetricsFn; rankedStoryHashes?: string[] }} input
  * @returns {BriefStory[]}
  */
-export function filterTopStories({ stories, sensitivity, maxStories = 12, maxPerSourceTopic = 2, onDrop, rankedStoryHashes }) {
+export function filterTopStories({ stories, sensitivity, maxStories = 12, maxPerSourceTopic = 2, onDrop, onOrder, rankedStoryHashes }) {
   if (!Array.isArray(stories)) return [];
   const allowed = ALLOWED_LEVELS_BY_SENSITIVITY[sensitivity];
   if (!allowed) return [];
@@ -312,7 +420,7 @@ export function filterTopStories({ stories, sensitivity, maxStories = 12, maxPer
   // topic-block mass dominate so a critical cluster stays contiguous
   // and reaches the rendered brief ahead of lower-severity singletons;
   // rankedStoryHashes remains a tie-breaker inside that frame.
-  const orderedStories = orderBriefCandidates(stories, allowed, rankedStoryHashes);
+  const orderedStories = orderBriefCandidates(stories, allowed, rankedStoryHashes, onOrder);
 
   /** @type {BriefStory[]} */
   const out = [];

--- a/tests/brief-from-digest-stories.test.mjs
+++ b/tests/brief-from-digest-stories.test.mjs
@@ -1039,6 +1039,137 @@ describe('composeBriefFromDigestStories — synthesis splice', () => {
       ],
     );
   });
+
+  it('promotes the LLM rank-0 entity-corroborated flashpoint-diplomacy story to card #1', () => {
+    const stories = [
+      digestStory({
+        hash: 'lng-critical-1111',
+        title: 'LNG Tanker Exits Hormuz For India For First Time Since War Began',
+        severity: 'critical',
+        currentScore: 150,
+        sources: ['Energy Wire'],
+        link: 'https://example.com/lng-tanker-hormuz',
+        category: 'energy',
+        briefTopicId: 'lng',
+      }),
+      digestStory({
+        hash: 'iran-deal-2222',
+        title: 'Iran says progress has been reached on many topics in a potential deal',
+        severity: 'high',
+        currentScore: 130,
+        sources: ['Reuters', 'AP News', 'Axios'],
+        link: 'https://example.com/iran-deal-progress',
+        category: 'diplomacy',
+        entityCorroborationCount: 3,
+        briefTopicId: 'iran-deal',
+      }),
+    ];
+    const orderEvents = [];
+    const env = composeBriefFromDigestStories(
+      rule({ sensitivity: 'high' }),
+      stories,
+      { clusters: 2, multiSource: 1 },
+      {
+        nowMs: NOW,
+        onOrder: (event) => orderEvents.push(event),
+        synthesis: {
+          lead: 'Iran says progress has been reached on many topics in a potential deal.',
+          rankedStoryHashes: ['iran-deal'],
+        },
+      },
+    );
+    assert.ok(env);
+    assert.equal(env.data.stories[0].headline, 'Iran says progress has been reached on many topics in a potential deal');
+    assert.equal(env.data.stories[1].headline, 'LNG Tanker Exits Hormuz For India For First Time Since War Began');
+    assert.deepEqual(orderEvents, [{ leadDiplomacyOverride: true }]);
+  });
+
+  it('does not let rankedStoryHashes alone beat critical severity without entity corroboration', () => {
+    const stories = [
+      digestStory({
+        hash: 'lng-critical-1111',
+        title: 'LNG Tanker Exits Hormuz For India For First Time Since War Began',
+        severity: 'critical',
+        currentScore: 150,
+        sources: ['Energy Wire'],
+        link: 'https://example.com/lng-tanker-hormuz',
+        category: 'energy',
+        briefTopicId: 'lng',
+      }),
+      digestStory({
+        hash: 'iran-deal-2222',
+        title: 'Iran says progress has been reached on many topics in a potential deal',
+        severity: 'high',
+        currentScore: 130,
+        sources: ['Reuters'],
+        link: 'https://example.com/iran-deal-progress',
+        category: 'diplomacy',
+        entityCorroborationCount: 0,
+        briefTopicId: 'iran-deal',
+      }),
+    ];
+    const orderEvents = [];
+    const env = composeBriefFromDigestStories(
+      rule({ sensitivity: 'high' }),
+      stories,
+      { clusters: 2, multiSource: 0 },
+      {
+        nowMs: NOW,
+        onOrder: (event) => orderEvents.push(event),
+        synthesis: {
+          lead: 'Iran says progress has been reached on many topics in a potential deal.',
+          rankedStoryHashes: ['iran-deal'],
+        },
+      },
+    );
+    assert.ok(env);
+    assert.equal(env.data.stories[0].headline, 'LNG Tanker Exits Hormuz For India For First Time Since War Began');
+    assert.equal(env.data.stories[1].headline, 'Iran says progress has been reached on many topics in a potential deal');
+    assert.deepEqual(orderEvents, [{ leadDiplomacyOverride: false }]);
+  });
+
+  it('ignores nonexistent rankedStoryHashes without firing the lead override', () => {
+    const stories = [
+      digestStory({
+        hash: 'lng-critical-1111',
+        title: 'LNG Tanker Exits Hormuz For India For First Time Since War Began',
+        severity: 'critical',
+        currentScore: 150,
+        sources: ['Energy Wire'],
+        link: 'https://example.com/lng-tanker-hormuz',
+        category: 'energy',
+        briefTopicId: 'lng',
+      }),
+      digestStory({
+        hash: 'iran-deal-2222',
+        title: 'Iran says progress has been reached on many topics in a potential deal',
+        severity: 'high',
+        currentScore: 130,
+        sources: ['Reuters', 'AP News', 'Axios'],
+        link: 'https://example.com/iran-deal-progress',
+        category: 'diplomacy',
+        entityCorroborationCount: 3,
+        briefTopicId: 'iran-deal',
+      }),
+    ];
+    const orderEvents = [];
+    const env = composeBriefFromDigestStories(
+      rule({ sensitivity: 'high' }),
+      stories,
+      { clusters: 2, multiSource: 1 },
+      {
+        nowMs: NOW,
+        onOrder: (event) => orderEvents.push(event),
+        synthesis: {
+          lead: 'Iran says progress has been reached on many topics in a potential deal.',
+          rankedStoryHashes: ['nonexistent-hash'],
+        },
+      },
+    );
+    assert.ok(env);
+    assert.equal(env.data.stories[0].headline, 'LNG Tanker Exits Hormuz For India For First Time Since War Began');
+    assert.deepEqual(orderEvents, [{ leadDiplomacyOverride: false }]);
+  });
 });
 
 // ── Sprint 1 / U3 — stable clusterId wiring (canonical cluster-rep hash) ──

--- a/tests/importance-score-parity.test.mjs
+++ b/tests/importance-score-parity.test.mjs
@@ -36,6 +36,10 @@ const clusteringSrc = readFileSync(
   resolve(repoRoot, 'scripts/_clustering.mjs'),
   'utf-8',
 );
+const briefFilterSrc = readFileSync(
+  resolve(repoRoot, 'shared/brief-filter.js'),
+  'utf-8',
+);
 
 // Shared source of truth: both sides load this JSON at runtime.
 // The test uses it as the oracle for tier lookups.
@@ -137,6 +141,9 @@ const relayEntityScorePerSource = extractNumericConst(relaySrc, 'RELAY_ENTITY_CO
 const clusteringDiplomacyKeywords = extractArrayLiteral(clusteringSrc, 'DIPLOMACY_KEYWORDS');
 const clusteringFlashpointKeywords = extractArrayLiteral(clusteringSrc, 'FLASHPOINT_KEYWORDS');
 const clusteringDiplomacyPairs = extractArrayLiteral(clusteringSrc, 'ENTITY_BIGRAMS');
+const briefFilterDiplomacyKeywords = extractArrayLiteral(briefFilterSrc, 'DIPLOMACY_KEYWORDS');
+const briefFilterFlashpointKeywords = extractArrayLiteral(briefFilterSrc, 'FLASHPOINT_KEYWORDS');
+const briefFilterDiplomacyPairs = extractArrayLiteral(briefFilterSrc, 'DIPLOMACY_FLASHPOINT_PAIRS');
 
 // ── Reconstruct the scorers as pure functions for output comparison ─────────
 
@@ -288,10 +295,17 @@ describe('diplomacy / entity boost parity (digest ↔ relay)', () => {
     assert.deepEqual(clusteringDiplomacyPairs, digestDiplomacyPairs);
   });
 
+  it('keeps brief lead-coherence diplomacy constants aligned with digest scoring', () => {
+    assert.deepEqual(briefFilterDiplomacyKeywords, digestDiplomacyKeywords);
+    assert.deepEqual(briefFilterFlashpointKeywords, digestFlashpointKeywords);
+    assert.deepEqual(briefFilterDiplomacyPairs, digestDiplomacyPairs);
+  });
+
   it('does not include generic business deal as a diplomacy keyword', () => {
     assert.equal(digestDiplomacyKeywords.includes('deal'), false);
     assert.equal(relayDiplomacyKeywords.includes('deal'), false);
     assert.equal(clusteringDiplomacyKeywords.includes('deal'), false);
+    assert.equal(briefFilterDiplomacyKeywords.includes('deal'), false);
   });
 });
 

--- a/tests/news-story-track-description-persistence.test.mts
+++ b/tests/news-story-track-description-persistence.test.mts
@@ -208,6 +208,7 @@ describe('buildStoryTrackHsetFields — story:track:v1 HSET contract', () => {
     const fields = buildStoryTrackHsetFields(item, '1745000000001', 99);
     const m = fieldsToMap(fields);
     assert.strictEqual(m.get('severity'), 'high');
+    assert.strictEqual(m.get('entityCorroborationCount'), '5');
   });
 
   it('does not promote generic business deals or under-corroborated diplomacy titles', () => {


### PR DESCRIPTION
## Summary
- persist entityCorroborationCount from story:track rows into digest compose input
- pass the corroboration count through as transient brief-filter metadata
- promote only the LLM rank-0 entity-corroborated flashpoint-diplomacy story ahead of severity-only ordering so the lead and card #1 align
- extend parity and regression coverage for the diplomacy constants and LNG/Hormuz vs Iran-deal failure case

## Tests
- node --test tests/brief-from-digest-stories.test.mjs tests/brief-filter.test.mjs tests/importance-score-parity.test.mjs
- npx tsx --test tests/news-story-track-description-persistence.test.mts
- npm run typecheck:api
- npm run test:data
