### PR TITLE
docs(mcp): error catalog + tools-reference outputSchema/describe_tool

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -186,6 +186,7 @@
               "mcp-server",
               "mcp-tools-reference",
               "mcp-jmespath",
+              "mcp-error-catalog",
               "api-oauth",
               "api-notifications"
             ]

--- a/docs/mcp-error-catalog.mdx
+++ b/docs/mcp-error-catalog.mdx
@@ -82,7 +82,7 @@ Content-Type: application/json
 
 Two distinct triggers share this code; the HTTP status disambiguates.
 
-**Per-minute throttle — HTTP 200.** Sliding-window limiter at **60 requests / minute** keyed per API key (Starter+) or per Pro user (combined across all that user's tokens). Both `tools/call` and metadata methods (`tools/list`, `describe_tool`, `prompts/list`, `resources/list`) count toward this limit; `initialize` does not. Comes back as a JSON-RPC error inside HTTP 200 because the limiter is upstream of any per-id correlation.
+**Per-minute throttle — HTTP 200.** Sliding-window limiter at **60 requests / minute** keyed per API key (Starter+) or per Pro user (combined across all that user's tokens). The limiter runs in `api/mcp/handler.ts` **before** the method-dispatch switch, so **every** request that reaches it counts — `tools/call`, all metadata methods (`tools/list`, `describe_tool`, `prompts/list`, `resources/list`), AND the lifecycle methods (`initialize`, `notifications/initialized`, `ping`). There is no per-method exemption. (The Pro daily-cap exemption set is separate and narrower — see below.) Comes back as a JSON-RPC error inside HTTP 200 because the limiter is upstream of any per-id correlation. Fails OPEN on Upstash transient errors — single spikes in limiter-backend latency won't take the API down.
 
 ```json
 {
@@ -95,7 +95,7 @@ Two distinct triggers share this code; the HTTP status disambiguates.
 }
 ```
 
-**Pro daily cap — HTTP 429 + `Retry-After`.** Hard daily cap (default **50 tool calls / UTC day** for Pro; API tiers have larger allowances) enforced by an atomic Redis reservation BEFORE the tool runs, so the exact call that crosses the boundary rejects. Only `tools/call` and `resources/read` (the auth-symmetric resources path) count; `describe_tool`, `tools/list`, `prompts/*`, and `resources/list` are exempt.
+**Pro daily cap — HTTP 429 + `Retry-After`.** Hard daily cap (default **50 tool calls / UTC day** for Pro; API tiers have larger allowances) enforced by an atomic Redis reservation BEFORE the tool runs, so the exact call that crosses the boundary rejects. Only `tools/call` and `resources/read` (the auth-symmetric resources path) count. **Exempt from the daily cap:** `describe_tool`, `tools/list`, `prompts/list`, `prompts/get`, `resources/list`, `initialize`, `notifications/initialized`, `ping`. (These methods still count toward the per-minute limit above — daily and per-minute exemption sets are different.)
 
 ```json
 {

--- a/docs/mcp-error-catalog.mdx
+++ b/docs/mcp-error-catalog.mdx
@@ -84,6 +84,15 @@ Two distinct triggers share this code; the HTTP status disambiguates.
 
 **Per-minute throttle — HTTP 200.** Sliding-window limiter at **60 requests / minute** keyed per API key (Starter+) or per Pro user (combined across all that user's tokens). The limiter runs in `api/mcp/handler.ts` **before** the method-dispatch switch, so **every** request that reaches it counts — `tools/call`, all metadata methods (`tools/list`, `describe_tool`, `prompts/list`, `resources/list`), AND the lifecycle methods (`initialize`, `notifications/initialized`, `ping`). There is no per-method exemption. (The Pro daily-cap exemption set is separate and narrower — see below.) Comes back as a JSON-RPC error inside HTTP 200 because the limiter is upstream of any per-id correlation. Fails OPEN on Upstash transient errors — single spikes in limiter-backend latency won't take the API down.
 
+The `message` text identifies which limiter fired. Two distinct strings:
+
+| Auth context           | `message`                                                        | Site                  |
+|------------------------|------------------------------------------------------------------|-----------------------|
+| `X-WorldMonitor-Key`   | `Rate limit exceeded. Max 60 requests per minute per API key.`   | `api/mcp/auth.ts:249` |
+| Pro OAuth bearer       | `Rate limit exceeded. Max 60 requests per minute per Pro user.`  | `api/mcp/auth.ts:257` |
+
+Example payload (Pro variant — env_key clients get the same envelope shape with the API-key message string):
+
 ```json
 {
   "jsonrpc": "2.0",

--- a/docs/mcp-error-catalog.mdx
+++ b/docs/mcp-error-catalog.mdx
@@ -95,7 +95,7 @@ Two distinct triggers share this code; the HTTP status disambiguates.
 }
 ```
 
-**Pro daily cap — HTTP 429 + `Retry-After`.** Hard daily cap (default **50 tool calls / UTC day** for Pro; API tiers have larger allowances) enforced by an atomic Redis reservation BEFORE the tool runs, so the exact call that crosses the boundary rejects. Only `tools/call` and `resources/read` (the auth-symmetric resources path) count. **Exempt from the daily cap:** `describe_tool`, `tools/list`, `prompts/list`, `prompts/get`, `resources/list`, `initialize`, `notifications/initialized`, `ping`. (These methods still count toward the per-minute limit above — daily and per-minute exemption sets are different.)
+**Pro daily cap — HTTP 429 + `Retry-After`.** Hard daily cap (default **50 tool calls / UTC day** for Pro; API tiers have larger allowances) enforced by an atomic Redis reservation BEFORE the tool runs, so the exact call that crosses the boundary rejects. Only `tools/call` and `resources/read` (the auth-symmetric resources path) count. **Exempt from the daily cap:** `describe_tool`, `tools/list`, `prompts/list`, `prompts/get`, `resources/list`, `logging/setLevel`, `initialize`, `notifications/initialized`, `ping`. (These methods still count toward the per-minute limit above — daily and per-minute exemption sets are different.)
 
 ```json
 {
@@ -196,6 +196,16 @@ HTTP/1.1 503 Service Unavailable
 Retry-After: 5
 Content-Type: application/json
 ```
+
+The `message` text identifies the trigger. Three sites emit a 503; two distinct strings:
+
+| Trigger                                         | `message`                                              | Site                              |
+|-------------------------------------------------|--------------------------------------------------------|-----------------------------------|
+| OAuth resolution service threw (Convex blip)    | `Auth service temporarily unavailable. Try again.`     | `api/mcp/auth.ts:142`             |
+| `MCP_INTERNAL_HMAC_SECRET` unset (Pro path)     | `Service temporarily unavailable, retry in a moment.`  | `api/mcp/auth.ts:204`             |
+| Pro quota-reservation Redis failure (non-cap)   | `Service temporarily unavailable, retry in a moment.`  | `api/mcp/dispatch.ts:141`         |
+
+Client recovery is identical for all three (honour `Retry-After: 5`); the message disambiguates only for log analysis.
 
 **HTTP 200 — `resources/read` payload was empty or unparseable.** Defensive guard inside `resources/read` for the never-should-happen case where the inner `tools/call` dispatcher returned no `content[0].text` or non-JSON text.
 

--- a/docs/mcp-error-catalog.mdx
+++ b/docs/mcp-error-catalog.mdx
@@ -1,0 +1,348 @@
+---
+title: "MCP Error Catalog"
+description: "Every error shape WorldMonitor's MCP server can emit — JSON-RPC codes, HTTP statuses, and soft-behavior envelopes — with triggers, payloads, and what the client should do."
+---
+
+{/*
+  Source-of-truth references — keep this comment in sync when handlers move.
+  Every code/envelope in this page should resolve to a line below; every
+  emission site below should appear in the page.
+
+  - JSON-RPC envelope helpers           api/mcp/rpc.ts:7-13
+  - Origin / method gates               api/mcp/handler.ts:35-49
+  - Top-level dispatch / -32600/-32601  api/mcp/handler.ts:66-164
+  - Auth -32001 / -32603 emitters       api/mcp/auth.ts:126-238
+  - Per-minute -32029                   api/mcp/auth.ts:243-260
+  - Pro daily-cap -32029 (HTTP 429)     api/mcp/dispatch.ts:130-144
+  - Tool exec -32603                    api/mcp/dispatch.ts:230-270
+  - _budget_exceeded envelope           api/mcp/dispatch.ts:183-229
+  - _jmespath_error envelope            api/mcp/jmespath.ts:46-94
+  - JMESPath caps                       api/mcp/constants.ts:213-214
+  - Prompts -32602                      api/mcp/prompts/index.ts:296-316
+  - Resources -32602 / -32603           api/mcp/resources/index.ts:198-289
+*/}
+
+This page is the practical reference: a payload arrives, you look it up, and you know what to do next. The server signals failure on three independent layers — **HTTP status**, **JSON-RPC `error.code`**, and **soft-behavior envelopes inside `result.content[0].text`** — and a single failure can touch one, two, or all three. Triage from the outside in: HTTP status → JSON-RPC code → soft envelope.
+
+For the projection grammar itself, see the [JMESPath guide](/mcp-jmespath). For per-tool parameters and freshness budgets, see the [Tools Reference](/mcp-tools-reference).
+
+## Quick orientation
+
+- **HTTP status** is the transport-layer answer. Most JSON-RPC replies — successes AND errors — come back as **HTTP 200**, per the JSON-RPC 2.0 convention. The handler only escalates the status when the failure is something a generic HTTP client must react to (auth, daily cap, service unavailable) and benefits from a `Retry-After` / `WWW-Authenticate` header.
+- **JSON-RPC `error.code`** is the application-layer answer. Six codes are in use: `-32001`, `-32029`, `-32600`, `-32601`, `-32602`, `-32603`. The handler never emits another code — if you see one, treat it as a wire bug and file an issue.
+- **Soft-behavior envelopes** are the high-volume failure mode. `tools/call` succeeds at the JSON-RPC layer (HTTP 200, no `error` field), but the JSON sitting inside `result.content[0].text` carries a `_budget_exceeded` or `_jmespath_error` discriminator. Clients that only inspect the JSON-RPC envelope will silently treat these as successes — parse `result.content[0].text` and check for a leading `_` key before consuming the payload as data.
+- **Quota rollback is automatic** for soft envelopes. `_budget_exceeded` and tool-execution errors (`-32603`) refund the Pro daily-quota slot — you do not pay for a response you cannot use. `_jmespath_error` does NOT refund, because the tool fetch succeeded; the user-supplied projection is what failed.
+- **Both 401 paths set `WWW-Authenticate`** with `realm="worldmonitor"` and a `resource_metadata` pointer at `/.well-known/oauth-protected-resource`. RFC 9728-aware clients (Claude Desktop, MCP Inspector) bounce through the OAuth flow on this header without further intervention.
+
+## JSON-RPC error codes
+
+| Code      | Meaning (this server)                                                  | Paired HTTP status        | Recovery                                                              |
+|-----------|------------------------------------------------------------------------|---------------------------|-----------------------------------------------------------------------|
+| `-32001`  | Unauthenticated, invalid token, or subscription not active             | **401**                   | Re-authenticate via OAuth or fix the `X-WorldMonitor-Key` header      |
+| `-32029`  | Rate-limited — per-minute throttle OR Pro daily quota cap              | **200** (per-min) / **429** (daily) | Honour `Retry-After`; for 200/per-min back off ~1s                    |
+| `-32600`  | Malformed JSON-RPC request envelope                                    | **200**                   | Fix the request encoder; this is a client bug                         |
+| `-32601`  | Method not found                                                       | **200**                   | Use a method advertised in the initialize result's `capabilities`     |
+| `-32602`  | Invalid params — missing/unknown tool, prompt, or resource URI         | **200**                   | Fix the params; consult `tools/list`, `prompts/list`, or `resources/list` |
+| `-32603`  | Internal error — auth service / quota / tool execution failure         | **200** (tool) / **503** (infra) | Retry with backoff; if persistent, file an issue                      |
+
+Subsections below give the literal payload, the trigger site, and what to do for each code.
+
+### `-32001` — Unauthenticated / invalid credentials
+
+Fires on five sites in `api/mcp/auth.ts`, always paired with HTTP **401** and a `WWW-Authenticate` header. The five triggers, in order of how clients hit them:
+
+1. **No `Authorization` bearer AND no `X-WorldMonitor-Key`** — the client called `/mcp` with no credentials.
+2. **`Authorization: Bearer <token>` but `<token>` is invalid or expired** — the token didn't resolve to a context (revoked / TTL expired / never minted by `/api/oauth/token`).
+3. **`X-WorldMonitor-Key: <key>` but `<key>` isn't in the valid set** — the API key is wrong.
+4. **OAuth token resolves but the Pro MCP token row is missing or cross-bound** — the `mcpTokenId` no longer maps to the userId. Typically a revoke from Settings → Connected MCP clients.
+5. **OAuth token resolves but the subscription went away** — entitlement re-check found `tier < 1`, `mcpAccess !== true`, or `validUntil < now`. Includes the entitlements-service-unavailable fail-closed path.
+
+Example wire payload (case 1):
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": null,
+  "error": {
+    "code": -32001,
+    "message": "Authentication required. Use OAuth (/oauth/token) or pass your API key via X-WorldMonitor-Key header."
+  }
+}
+```
+
+```http
+HTTP/1.1 401 Unauthorized
+WWW-Authenticate: Bearer realm="worldmonitor", resource_metadata="https://worldmonitor.app/.well-known/oauth-protected-resource"
+Content-Type: application/json
+```
+
+**What to do.** Re-run the OAuth flow (`/api/oauth/token` with a fresh authorization code, OR refresh-grant with a valid refresh token). For API-key clients, double-check the `X-WorldMonitor-Key` header — `wm_live_…` keys must go in that header, NOT as `Authorization: Bearer`. The `WWW-Authenticate` header's `resource_metadata` pointer is the canonical place to start the discovery flow from scratch.
+
+### `-32029` — Rate limited (per-minute OR daily)
+
+Two distinct triggers share this code; the HTTP status disambiguates.
+
+**Per-minute throttle — HTTP 200.** Sliding-window limiter at **60 requests / minute** keyed per API key (Starter+) or per Pro user (combined across all that user's tokens). Both `tools/call` and metadata methods (`tools/list`, `describe_tool`, `prompts/list`, `resources/list`) count toward this limit; `initialize` does not. Comes back as a JSON-RPC error inside HTTP 200 because the limiter is upstream of any per-id correlation.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": null,
+  "error": {
+    "code": -32029,
+    "message": "Rate limit exceeded. Max 60 requests per minute per Pro user."
+  }
+}
+```
+
+**Pro daily cap — HTTP 429 + `Retry-After`.** Hard daily cap (default **50 tool calls / UTC day** for Pro; API tiers have larger allowances) enforced by an atomic Redis reservation BEFORE the tool runs, so the exact call that crosses the boundary rejects. Only `tools/call` and `resources/read` (the auth-symmetric resources path) count; `describe_tool`, `tools/list`, `prompts/*`, and `resources/list` are exempt.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 7,
+  "error": {
+    "code": -32029,
+    "message": "Daily MCP quota exceeded (50/day). Resets at next UTC midnight."
+  }
+}
+```
+
+```http
+HTTP/1.1 429 Too Many Requests
+Retry-After: 41200
+Content-Type: application/json
+```
+
+**What to do.** For HTTP 200 / per-minute: back off ~1 second and retry. The limiter is a sliding window, not a token bucket — sustained 60 rpm is fine; bursts above 60 in any 60-second window reject. For HTTP 429 / daily: honour `Retry-After` (the value is `seconds-until-UTC-midnight`); upgrade to a higher tier (API Starter 1,000/day, API Business 10,000/day, Enterprise unlimited) if the daily cap is the binding constraint.
+
+### `-32600` — Invalid request envelope
+
+Fires when the request body either isn't valid JSON or is valid JSON without a string `method` field. Two sites in `api/mcp/handler.ts`. Strictly a client encoder bug — well-formed JSON-RPC clients will never see this in production.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": null,
+  "error": { "code": -32600, "message": "Invalid request: missing method" }
+}
+```
+
+**What to do.** Audit the request encoder. The body must be a JSON object with a string `method` and (for any method besides `notifications/*`) an `id` field. If you see `-32600` from a known-good client library, file an issue against this server — it should never reach you.
+
+### `-32601` — Method not found
+
+The `method` field was a string but didn't match any handler. Methods this server speaks: `initialize`, `notifications/initialized`, `ping`, `tools/list`, `tools/call`, `prompts/list`, `prompts/get`, `resources/list`, `resources/read`, `logging/setLevel`.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "error": { "code": -32601, "message": "Method not found: tools/run" }
+}
+```
+
+**What to do.** Use a method present in the `capabilities` block of your `initialize` response. Note that `resources/subscribe` is **not** implemented (the initialize handshake advertises `resources.subscribe: false` explicitly) — clients that try it get `-32601`.
+
+### `-32602` — Invalid params
+
+The most common error code, shared across `tools/call`, `prompts/get`, `resources/read`, and `logging/setLevel`. Six concrete triggers:
+
+| Trigger                                                | Site                              | Example `message`                                                          |
+|--------------------------------------------------------|-----------------------------------|----------------------------------------------------------------------------|
+| `tools/call` with no/non-string `name`                 | `api/mcp/dispatch.ts:113`         | `Invalid params: missing tool name`                                        |
+| `tools/call` with `name` that isn't in the registry    | `api/mcp/dispatch.ts:117`         | `Unknown tool: get_foo`                                                    |
+| `prompts/get` with no/non-string `name`                | `api/mcp/handler.ts:133`          | `Invalid params: missing prompt name`                                      |
+| `prompts/get` with unknown name or missing required arg | `api/mcp/prompts/index.ts:302`    | `Unknown prompt: …` / `Missing required argument "country_code" for prompt "country-briefing"` |
+| `resources/read` with no/unknown/malformed `uri`       | `api/mcp/resources/index.ts:200`  | `Invalid params: missing resource uri` / `Unknown resource uri "..."` |
+| `logging/setLevel` with non-string or out-of-set level | `api/mcp/handler.ts:156`          | `Invalid params: level must be one of debug, info, notice, warning, error, critical, alert, emergency` |
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 4,
+  "error": { "code": -32602, "message": "Unknown tool: get_marekt_data" }
+}
+```
+
+**What to do.** Read the `message` — it always tells you what was missing or wrong. For tools, names are in `tools/list`. For prompts, names + argument schemas are in `prompts/list`. For resources, the four supported URI shapes are in `resources/list`. For `logging/setLevel`, valid levels are the [RFC 5424 subset](https://www.rfc-editor.org/rfc/rfc5424#section-6.2.1) listed above.
+
+### `-32603` — Internal error
+
+Three distinct conditions share this code; the HTTP status disambiguates whether retry is reasonable.
+
+**HTTP 200 — tool-execution failure.** A tool dispatcher threw. Most commonly: every Redis key the tool reads returned null (`cache_all_null` — transient Redis blip or a still-warming seeder), or a sibling internal fetch failed mid-call. Pro quota is rolled back automatically; you do not pay for this.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 5,
+  "error": { "code": -32603, "message": "Internal error: data fetch failed" }
+}
+```
+
+**HTTP 503 + `Retry-After: 5` — service unavailable.** Either the OAuth resolution service threw (Convex transient blip), or `MCP_INTERNAL_HMAC_SECRET` is unset on the deploy (a misconfig — Pro tool calls cannot sign their downstream fetches without it), or the Pro daily-quota reservation Redis pipeline failed with something other than `cap-exceeded`.
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": null,
+  "error": { "code": -32603, "message": "Auth service temporarily unavailable. Try again." }
+}
+```
+
+```http
+HTTP/1.1 503 Service Unavailable
+Retry-After: 5
+Content-Type: application/json
+```
+
+**HTTP 200 — `resources/read` payload was empty or unparseable.** Defensive guard inside `resources/read` for the never-should-happen case where the inner `tools/call` dispatcher returned no `content[0].text` or non-JSON text.
+
+**What to do.** For HTTP 200 tool errors: retry once after ~1 second; if a specific tool returns `-32603` consistently, check [status.worldmonitor.app](https://status.worldmonitor.app) for the relevant seeder. For HTTP 503: honour `Retry-After`. For the `resources/read` defensive case: file an issue — it indicates a dispatcher contract violation upstream of your call.
+
+## HTTP statuses
+
+Every status the MCP handler can return. Most JSON-RPC replies — including most errors — are HTTP 200 by convention; the table calls out the cases where the handler escalates.
+
+| Status | Body shape                | JSON-RPC code(s) | Cause                                                                 |
+|--------|---------------------------|------------------|-----------------------------------------------------------------------|
+| **200** | JSON-RPC envelope         | success OR `-32029` / `-32600` / `-32601` / `-32602` / `-32603` | Any successful call, OR an application-layer error that doesn't merit a transport escalation |
+| **202** | empty                     | n/a              | `notifications/initialized` — JSON-RPC notifications take no response body, per spec |
+| **204** | empty                     | n/a              | `OPTIONS` preflight                                                  |
+| **401** | JSON-RPC envelope         | `-32001`         | Missing/invalid/expired credentials, revoked Pro MCP token, inactive subscription. `WWW-Authenticate` header set. |
+| **403** | plain `"Forbidden"`       | n/a (NOT JSON-RPC)| `Origin` header is present and is not `https://claude.ai` or `https://claude.com`. Server-to-server callers (no `Origin`) are exempt. |
+| **405** | empty                     | n/a              | Request method is not `POST`, `HEAD`, or `OPTIONS`. `Allow: POST, HEAD, OPTIONS` header set. |
+| **429** | JSON-RPC envelope         | `-32029`         | **Pro daily cap exceeded only.** `Retry-After: <seconds-until-UTC-midnight>` set. (Per-minute throttle returns `-32029` inside HTTP 200 — see `-32029` above.) |
+| **503** | JSON-RPC envelope         | `-32603`         | Auth service unavailable, `MCP_INTERNAL_HMAC_SECRET` misconfigured, or quota-reservation Redis failure. `Retry-After: 5`. |
+
+Two HTTP statuses appear that aren't JSON-RPC errors:
+
+- **403 with a plain `Forbidden` body** comes from origin-validation BEFORE the JSON-RPC layer runs. Don't try to `JSON.parse` the body. This is only relevant to browser-origin clients; CLI clients, Claude Desktop, and `curl` send no `Origin` header and are exempt.
+- **405 with an empty body** comes from method-validation BEFORE JSON-RPC. The handler accepts `POST` (the JSON-RPC path), `HEAD` (a 200 ack with `Content-Type: application/json`, used by uptime probes), and `OPTIONS` (CORS preflight). Anything else gets 405 + `Allow: POST, HEAD, OPTIONS`.
+
+## Soft-behavior envelopes
+
+Soft envelopes are the high-volume failure mode and the single most common parsing bug for clients that only inspect the JSON-RPC layer. The `tools/call` returns **HTTP 200** with **no `error` field**, the `result.content[0].text` parses as JSON, and the resulting object has a leading-underscore discriminator key. Always:
+
+1. Parse `result.content[0].text` as JSON.
+2. Check whether the parsed object has a `_budget_exceeded` or `_jmespath_error` key at its top level. If yes, treat as an error and do not consume sibling fields as data.
+3. Otherwise, treat the parsed object as the tool's normal response (cache tools wrap it as `{ cached_at, stale, data }`; RPC tools return their declared shape).
+
+### `_budget_exceeded` — response too big for the per-tool budget
+
+Every tool declares a per-tool output budget (`_outputBudgetBytes`) sized to keep responses inside the typical agent context window. When the serialised response exceeds that budget **after** all per-tool filters, `summary`, and JMESPath have been applied, the dispatcher swaps the oversized payload for this envelope — still inside the normal MCP result, still HTTP 200, still no `isError`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 12,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"_budget_exceeded\":true,\"budget_bytes\":65536,\"actual_bytes\":142337,\"hint\":\"Response still exceeds tool output budget after JMESPath projection. Use a more selective expression to project fewer fields, or apply tool-level filters to narrow the result set.\"}"
+      }
+    ]
+  }
+}
+```
+
+Decoded `text` payload:
+
+```json
+{
+  "_budget_exceeded": true,
+  "budget_bytes": 65536,
+  "actual_bytes": 142337,
+  "hint": "Response still exceeds tool output budget after JMESPath projection. Use a more selective expression to project fewer fields, or apply tool-level filters to narrow the result set."
+}
+```
+
+Fields:
+
+- `_budget_exceeded: true` — discriminator. Always literally `true`; never present on success responses.
+- `budget_bytes: number` — the per-tool budget the response was checked against.
+- `actual_bytes: number` — UTF-8 byte length of the serialised response after all narrowing.
+- `hint: string` — recovery advice. The text varies based on whether the caller already passed a `jmespath` argument; both phrasings tell you to narrow the result.
+
+**Quota.** The Pro daily-quota slot is rolled back automatically. You do not pay for a response you cannot use.
+
+**Recovery.** Make the projection more selective, layer a tool-level filter (`country`, `since`, `limit`), or both. The [JMESPath guide](/mcp-jmespath) has worked examples for projection. The `summary: true` flag (every cache tool accepts it) returns a server-built counts-and-samples digest that is always under budget.
+
+### `_jmespath_error` — projection failed
+
+Three failure kinds, all returned with the same envelope shape. The `_jmespath_error` value is a **string** (not an object); its content is `<kind>: <details>`. The discriminator is the **leading kind token** before the first `:`.
+
+```json
+{
+  "_jmespath_error": "invalid_expression: Parse error at column 32: …",
+  "original_keys": ["stocks-bootstrap", "commodities-bootstrap", "crypto", "sectors", "etf-flows", "gulf-quotes", "fear-greed"]
+}
+```
+
+`original_keys` is the top-level keys of the unprojected response (bounded at 50 entries, with a `...<N more>` sentinel when truncated). It is included specifically so the LLM can self-correct on its next `tools/call` without refetching — the projection failed, but the tool fetch itself succeeded.
+
+**Quota.** The Pro daily-quota slot is **NOT** rolled back. The tool fetch succeeded; the user-supplied projection is what failed. A bad expression consumes one quota slot per attempt, which is why `original_keys` exists — to make the retry self-correcting in one extra call rather than guesswork over N.
+
+The three kinds:
+
+#### `expression_too_long`
+
+The JMESPath expression itself exceeds **1024 UTF-8 bytes** (`JMESPATH_MAX_EXPR_BYTES`). The cap is intentionally generous — typical real expressions are 50–200 bytes — and a 1024+ byte expression almost always indicates accidental copy/paste of a full payload into the argument.
+
+```json
+{
+  "_jmespath_error": "expression_too_long: 1156 > 1024",
+  "original_keys": ["stocks-bootstrap", "commodities-bootstrap", "crypto"]
+}
+```
+
+**Recovery.** Shorten the expression. If you genuinely need a >1KB projection, split the work across multiple calls.
+
+#### `invalid_expression`
+
+The expression parsed by the JMESPath engine threw — bad syntax, unclosed bracket, unknown function. The `details` after the kind token is the parser's error message verbatim.
+
+```json
+{
+  "_jmespath_error": "invalid_expression: Parse error at column 32: expected one of [LBRACKET, DOT]",
+  "original_keys": ["ucdp-events"]
+}
+```
+
+**Recovery.** Fix the expression. The two most common bugs are (a) using double quotes around string literals (`[?country == "Iraq"]`) when JMESPath wants single quotes (`[?country == 'Iraq']`), and (b) using bare numeric literals (`[?deathsBest > 0]`) when JMESPath wants backticks (`[?deathsBest > \`0\`]`). The [JMESPath guide](/mcp-jmespath) covers both pitfalls.
+
+#### `projection_too_large`
+
+The expression parsed and ran, but the projected output exceeded **256 KB** (`JMESPATH_MAX_OUTPUT_BYTES`) after stringification. Almost always indicates a runaway multiselect-hash or multiselect-list duplicating fields across a large array.
+
+```json
+{
+  "_jmespath_error": "projection_too_large: 412338 > 262144",
+  "original_keys": ["ucdp-events"]
+}
+```
+
+**Recovery.** Use a slimmer multiselect-hash (drop fields), filter the input array first (`[?...]`), or slice the result (`[0:N]`). Pipe combinators (see example 12 in the [JMESPath guide](/mcp-jmespath)) compose well here.
+
+### Other tool-specific envelopes
+
+A handful of tools return their own application-level error envelopes inside `content[0].text` rather than via JSON-RPC `-32602`. These are documented per-tool in the [Tools Reference](/mcp-tools-reference) — the catalog calls them out so a client can recognise the pattern:
+
+- **`describe_tool`** returns `{ "error": "missing_tool_name", "hint": "..." }` or `{ "error": "unknown_tool", "requested": "...", "available": [...] }`. Quota-exempt — bad input does not consume a quota slot. See [Tools Reference → `describe_tool`](/mcp-tools-reference#describe_tool).
+
+If you build a generic envelope detector, key off the leading underscore (`_budget_exceeded`, `_jmespath_error`) for the catalog-class envelopes and off a top-level `error: string` for per-tool envelopes.
+
+## Roadmap
+
+- **Auto-summarize on budget exceed.** A future protocol revision may have `_budget_exceeded` responses ship a server-built summary inline (one annotated content block in addition to the envelope) for the subset of tools where a summary is well-defined. Deferred until production telemetry justifies the per-tool tradeoff.
+
+## See also
+
+- [MCP Server overview](/mcp-server) — endpoints, auth modes, OAuth setup, plans and quotas.
+- [JMESPath Projection Guide](/mcp-jmespath) — projection grammar + 12 worked examples; the right place to learn how to fix `_jmespath_error` and recover from `_budget_exceeded`.
+- [MCP Tools Reference](/mcp-tools-reference) — per-tool parameters, response shapes, and per-tool soft envelopes (e.g. `describe_tool`).
+- [MCP Quickstart](/mcp-quickstart) — five-minute zero-to-first-call onboarding.
+- [JSON-RPC 2.0 spec](https://www.jsonrpc.org/specification) — the wire envelope shape the catalog references throughout.
+- [RFC 9728 — OAuth 2.0 Protected Resource Metadata](https://www.rfc-editor.org/rfc/rfc9728) — what the `WWW-Authenticate` `resource_metadata` pointer means.

--- a/docs/mcp-jmespath.mdx
+++ b/docs/mcp-jmespath.mdx
@@ -456,20 +456,16 @@ The recovery is always the same: **make the projection more selective**, or laye
 
 ### `_jmespath_error` — when the projection itself fails
 
-A JMESPath expression can fail in two ways: it can be syntactically invalid, or it can blow up the per-call output limit (256 KB) via a runaway multiselect-hash. Either way you get this envelope back:
+A JMESPath expression can fail three ways: the expression itself exceeds 1024 bytes, it's syntactically invalid, or it blows up the 256 KB output cap via a runaway multiselect-hash. Either way you get this envelope back — note that `_jmespath_error` is a **string** (`<kind>: <details>`), not an object:
 
 ```json
 {
-  "_jmespath_error": {
-    "kind": "invalid_expression",
-    "message": "Parse error: …",
-    "expression": "data.\"stocks-bootstrap\".quotes[*"
-  },
+  "_jmespath_error": "invalid_expression: Parse error at column 32: expected one of [LBRACKET, DOT]",
   "original_keys": ["stocks-bootstrap", "commodities-bootstrap", "crypto", "sectors", "etf-flows", "gulf-quotes", "fear-greed"]
 }
 ```
 
-`original_keys` is the top-level keys of the unprojected response — enough context for the model to retry with a corrected expression in one extra call. A bad expression **does** consume one daily quota slot per attempt; the echoed `original_keys` exists specifically to make the retry self-correcting rather than guesswork.
+`original_keys` is the top-level keys of the unprojected response — enough context for the model to retry with a corrected expression in one extra call. A bad expression **does** consume one daily quota slot per attempt; the echoed `original_keys` exists specifically to make the retry self-correcting rather than guesswork. The three kinds (`expression_too_long`, `invalid_expression`, `projection_too_large`) and their exact discriminator strings live in the [MCP Error Catalog](/mcp-error-catalog#_jmespath_error--projection-failed).
 
 ## Complements to projection
 
@@ -492,3 +488,4 @@ When `tools/list` returns a compressed description that's ambiguous about a tool
 - [MCP Quickstart](/mcp-quickstart) — five-minute zero-to-first-call onboarding.
 - [MCP Tools Reference](/mcp-tools-reference) — per-tool parameters, freshness budgets, and response shapes for every tool.
 - [MCP Server reference](/mcp-server) — auth, OAuth setup, plans, quotas, errors.
+- [MCP Error Catalog](/mcp-error-catalog) — every JSON-RPC code, HTTP status, and soft envelope (including `_budget_exceeded` and the three `_jmespath_error` kinds).

--- a/docs/mcp-jmespath.mdx
+++ b/docs/mcp-jmespath.mdx
@@ -456,7 +456,7 @@ The recovery is always the same: **make the projection more selective**, or laye
 
 ### `_jmespath_error` — when the projection itself fails
 
-A JMESPath expression can fail three ways: the expression itself exceeds 1024 bytes, it's syntactically invalid, or it blows up the 256 KB output cap via a runaway multiselect-hash. Either way you get this envelope back — note that `_jmespath_error` is a **string** (`<kind>: <details>`), not an object:
+A JMESPath expression can fail three ways: the expression itself exceeds 1024 bytes, it's syntactically invalid, or it blows up the 256 KB output cap via a runaway multiselect-hash. In all cases you get this envelope back — note that `_jmespath_error` is a **string** (`<kind>: <details>`), not an object:
 
 ```json
 {

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -360,21 +360,26 @@ Seed-level health per key: [status.worldmonitor.app](https://status.worldmonitor
 
 ## Errors
 
-| Code | Meaning |
-|------|---------|
-| 401 | Invalid / missing token |
-| 403 | Token valid but account not PRO |
-| 404 | Unknown tool name |
-| 429 | Rate limited (60 req/min/key) |
-| 503 | Upstream cache unavailable |
+The MCP handler signals failure on three independent layers — **HTTP status**, **JSON-RPC `error.code`**, and **soft-behavior envelopes inside `result.content[0].text`** — and a single failure can touch any combination.
 
-Tool-level errors return `isError: true` with a text explanation in `content`.
+| Layer        | Common shapes                                                    | Where to look       |
+|--------------|------------------------------------------------------------------|---------------------|
+| HTTP status  | `200` (default for JSON-RPC), `401`, `429`, `503`                | `WWW-Authenticate` / `Retry-After` headers |
+| JSON-RPC     | `-32001` auth · `-32029` rate-limited · `-32602` bad params · `-32603` internal | `error.code` + `error.message`           |
+| Soft envelope | `_budget_exceeded` (response too big), `_jmespath_error` (projection failed) | `result.content[0].text` parsed as JSON |
+
+Triage from the outside in: HTTP status → JSON-RPC code → soft envelope. The full per-shape reference (trigger, paired status, recovery, example payload) lives in the [MCP Error Catalog](/mcp-error-catalog). A few high-frequency callouts:
+
+- **401 + `-32001`** carries a `WWW-Authenticate` header with `resource_metadata` pointing at `/.well-known/oauth-protected-resource`. RFC 9728-aware clients re-run the OAuth flow on this header automatically.
+- **429 + `-32029`** is the Pro daily cap (`Retry-After: <seconds-until-UTC-midnight>`). The per-minute rate limit returns `-32029` inside HTTP 200, not 429 — see the catalog for the distinction.
+- **Soft envelopes return HTTP 200** with no JSON-RPC `error` field — clients that inspect only the JSON-RPC layer will silently treat them as successes. Always parse `result.content[0].text` and check for a leading-underscore discriminator key (`_budget_exceeded`, `_jmespath_error`) before consuming the payload as data.
 
 ## Related
 
 - [MCP Quickstart](/mcp-quickstart) — five-minute zero-to-first-call walkthrough
 - [JMESPath guide](/mcp-jmespath) — projection grammar + 12 worked examples
 - [MCP Tools Reference](/mcp-tools-reference) — per-tool parameters and `curl` examples
+- [MCP Error Catalog](/mcp-error-catalog) — every JSON-RPC code, HTTP status, and soft envelope the server emits
 - [Authentication overview](/authentication) — browser vs bearer vs OAuth
 - [API Reference](/api-reference) — the same data via REST
 - [Pro features](https://www.worldmonitor.app/pro)

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -104,7 +104,7 @@ Each authorization mints a separate row, so revoking Claude Desktop does not aff
 | **API Business** | ✅ Yes | OAuth **or** `wm_…` key | **10,000 requests / day** | Higher daily throughput. |
 | **Enterprise** | ✅ Yes | OAuth **or** `wm_…` key | **Unlimited** | Custom SLA available. |
 
-Per-minute throttling of 60 calls/minute/key (API tiers) or 60/minute/user (Pro) protects against burst storms across all paid tiers. `tools/list` and `initialize` are **never** counted against either limit — only `tools/call` reservations consume quota.
+Per-minute throttling of 60 calls/minute/key (API tiers) or 60/minute/user (Pro) protects against burst storms across all paid tiers. **The per-minute limiter runs before method dispatch, so every method (including `initialize`, `tools/list`, `prompts/list`, `resources/list`, `describe_tool`, etc.) counts toward 60/min.** Only the daily-quota cap is selective — that one is consumed exclusively by `tools/call` and `resources/read` reservations (see [Daily limit (Pro tier)](#daily-limit-pro-tier) above, and the [Error Catalog](/mcp-error-catalog#-32029--rate-limited-per-minute-or-daily) for the full method-exemption tables for both limits).
 
 Pro's 60/min is per-USER (a Pro user with 3 Claude installations shares one 60/min pool); API tiers' 60/min is per-KEY (multiple keys = higher throughput).
 

--- a/docs/mcp-tools-reference.mdx
+++ b/docs/mcp-tools-reference.mdx
@@ -67,7 +67,7 @@ Response — identical shape to a `tools/list` entry, with the full uncompressed
 `describe_tool` returns two soft-error envelopes inside the normal `content[0].text`:
 
 - `{ "error": "missing_tool_name", "hint": "Pass tool_name as a non-empty string matching a tool from tools/list." }` — `tool_name` was omitted, empty, or non-string.
-- `{ "error": "unknown_tool", "requested": "<the bad name>", "available": [...sorted list of all 39 tool names...] }` — `tool_name` didn't match. The `available` array lets the LLM self-correct in one extra call.
+- `{ "error": "unknown_tool", "requested": "<the bad name>", "available": [...sorted list of all tool names...] }` — `tool_name` didn't match. The `available` array lets the LLM self-correct in one extra call.
 
 The full per-tool reference for `describe_tool` (parameters, response shape, quota posture) is at [`describe_tool`](#describe_tool) under Meta.
 
@@ -1181,7 +1181,7 @@ Returns the full uncompressed definition of any other tool by name. Use when the
 **Soft errors** (HTTP 200, returned inside the normal `content[0].text` envelope — NOT JSON-RPC errors):
 
 - `{ "error": "missing_tool_name", "hint": "Pass tool_name as a non-empty string matching a tool from tools/list." }` — `tool_name` was omitted, empty, or non-string.
-- `{ "error": "unknown_tool", "requested": "<the bad name>", "available": [...sorted list of all 39 tool names...] }` — `tool_name` didn't match any registered tool. The `available` array lets the LLM self-correct in one extra call.
+- `{ "error": "unknown_tool", "requested": "<the bad name>", "available": [...sorted list of all tool names...] }` — `tool_name` didn't match any registered tool. The `available` array lets the LLM self-correct in one extra call.
 
 - **API endpoints:** none — server-local lookup, no upstream call.
 - **Kind:** metadata lookup — sub-millisecond, no Redis, no LLM.

--- a/docs/mcp-tools-reference.mdx
+++ b/docs/mcp-tools-reference.mdx
@@ -25,6 +25,126 @@ If you've completed the OAuth flow instead, replace `-H "X-WorldMonitor-Key: $WM
 **Recently added** (May 2026): `get_displacement_data`, `get_health_signals`, `get_energy_intelligence`, `get_consumer_prices`, `get_tariff_trends`, `get_chokepoint_status` — six new bundled tools that exposed previously-cached domains via MCP.
 </Tip>
 
+## Discovering tools
+
+Before diving into the per-tool reference, two affordances make discovery cheaper than reading this page top-to-bottom.
+
+### `describe_tool` — full uncompressed definition on demand
+
+Since v1.5.0, `tools/list` returns each tool's `description` truncated to the first sentence (≤120 UTF-8 bytes). That keeps the per-session input-token cost low when the LLM only needs to scan names — and the same `tools/list` entry now ships an `outputSchema` (v1.6.0) so the model can author a JMESPath projection on the first call. When the compressed description is ambiguous, call `describe_tool` for the long form:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": { "name": "describe_tool", "arguments": { "tool_name": "get_chokepoint_status" } }
+}
+```
+
+Response — identical shape to a `tools/list` entry, with the full uncompressed `description` and the full `inputSchema.properties` text:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "content": [
+      {
+        "type": "text",
+        "text": "{\"name\":\"get_chokepoint_status\",\"description\":\"Live maritime chokepoint status: per-chokepoint vessel transit counts (10-min cadence), rolling transit summaries, per-port activity, plus static reference data and flow aggregates. Covers Suez, Hormuz, Malacca, Bab-el-Mandeb, Panama, etc.\",\"inputSchema\":{ /* full properties with full descriptions */ },\"outputSchema\":{ /* … */ },\"annotations\":{\"readOnlyHint\":true,\"destructiveHint\":false,\"idempotentHint\":true,\"openWorldHint\":false}}"
+      }
+    ]
+  }
+}
+```
+
+`describe_tool` is **exempt from the Pro daily quota** (per-minute rate limit still applies). The exemption is intentional — counting metadata lookups against the 50/day cap would discourage exploration, defeating the compression. Two common workflows:
+
+- **Compressed entry is ambiguous about behaviour or argument semantics.** Call `describe_tool` to see the full long-form description plus every property's full description.
+- **First-time JMESPath authoring against an unfamiliar response.** Call `describe_tool` to read the `outputSchema` (see next section) without paying a quota slot for a real `tools/call`.
+
+`describe_tool` returns two soft-error envelopes inside the normal `content[0].text`:
+
+- `{ "error": "missing_tool_name", "hint": "Pass tool_name as a non-empty string matching a tool from tools/list." }` — `tool_name` was omitted, empty, or non-string.
+- `{ "error": "unknown_tool", "requested": "<the bad name>", "available": [...sorted list of all 39 tool names...] }` — `tool_name` didn't match. The `available` array lets the LLM self-correct in one extra call.
+
+The full per-tool reference for `describe_tool` (parameters, response shape, quota posture) is at [`describe_tool`](#describe_tool) under Meta.
+
+### `outputSchema` — typed parsing without a sample call
+
+As of v1.6.0, every tool's `tools/list` entry declares a spec-defined [MCP 2025-06-18 `Tool.outputSchema`](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-result-schema). The schema describes the shape of the JSON that lives inside `result.content[0].text` for that tool — letting clients author projections, validate responses, or generate types without ever issuing a real `tools/call`.
+
+Schemas are emitted **unconditionally** on every `tools/list`, regardless of the negotiated `protocolVersion`. Clients on the older `2025-03-26` floor still receive them and (per spec) are expected to ignore unknown fields rather than fail.
+
+Worked example — the `outputSchema` for `get_country_risk`:
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "country_code": { "type": "string" },
+    "cii": { "type": ["number", "null"], "description": "Composite Instability Index 0-100." },
+    "components": {
+      "type": "object",
+      "properties": {
+        "unrest":   { "type": ["number", "null"] },
+        "conflict": { "type": ["number", "null"] },
+        "security": { "type": ["number", "null"] },
+        "news":     { "type": ["number", "null"] }
+      }
+    },
+    "travelAdvisory":    { "type": ["object", "string", "null"] },
+    "sanctionsExposure": { "type": ["object", "array", "null"] }
+  }
+}
+```
+
+Cache tools wrap their declared `data` shape in the standard freshness envelope:
+
+```json
+{
+  "type": "object",
+  "required": ["cached_at", "stale", "data"],
+  "properties": {
+    "cached_at": { "type": ["string", "null"], "description": "ISO-8601 timestamp of the OLDEST contributing cache key." },
+    "stale":     { "type": "boolean", "description": "True when any contributing cache key is older than its per-key maxStaleMin freshness budget." },
+    "data":      { "type": "object", "properties": { /* per-tool fields */ } }
+  }
+}
+```
+
+A typed-parsing sketch in TypeScript using the schema for compile-time hints:
+
+```ts
+// Synthesise types from the schema once (e.g. with json-schema-to-typescript).
+type CountryRisk = {
+  country_code: string;
+  cii: number | null;
+  components: { unrest: number | null; conflict: number | null; security: number | null; news: number | null };
+  travelAdvisory: object | string | null;
+  sanctionsExposure: object | unknown[] | null;
+};
+
+const reply = await callTool('get_country_risk', { country_code: 'IR' });
+const text = reply.result?.content?.[0]?.text;
+if (typeof text !== 'string') throw new Error('no text payload');
+
+const parsed = JSON.parse(text) as CountryRisk | { _budget_exceeded: true };
+// Check for the soft-envelope discriminator BEFORE consuming sibling fields as data.
+if ('_budget_exceeded' in parsed) {
+  // narrow with jmespath / filters and retry — see /mcp-error-catalog
+} else {
+  console.log(parsed.cii, parsed.components.conflict);
+}
+```
+
+Things to know:
+
+- `additionalProperties` is left implicit (= true) on every schema, so producer-side forward-compatible additions don't suddenly fail validation.
+- Per-array `items.properties` lists known fields but does NOT enumerate every observed key — the schema is a **hint surface** for JMESPath authoring, not a bytecode-level contract.
+- Schemas describe the success-path payload only. The two catalog-class soft envelopes (`_budget_exceeded`, `_jmespath_error`) are NOT in the per-tool schema — they replace the payload entirely and have their own shapes. See the [MCP Error Catalog](/mcp-error-catalog) for both envelopes.
+
 ## Markets & economy
 
 ### `get_market_data`

--- a/docs/mcp-tools-reference.mdx
+++ b/docs/mcp-tools-reference.mdx
@@ -130,10 +130,18 @@ const reply = await callTool('get_country_risk', { country_code: 'IR' });
 const text = reply.result?.content?.[0]?.text;
 if (typeof text !== 'string') throw new Error('no text payload');
 
-const parsed = JSON.parse(text) as CountryRisk | { _budget_exceeded: true };
-// Check for the soft-envelope discriminator BEFORE consuming sibling fields as data.
+type SoftEnvelope =
+  | { _budget_exceeded: true; budget_bytes: number; actual_bytes: number; hint: string }
+  | { _jmespath_error: string; original_keys: string[] };
+
+const parsed = JSON.parse(text) as CountryRisk | SoftEnvelope;
+// Check for BOTH soft-envelope discriminators BEFORE consuming sibling fields as data.
+// A `_jmespath_error` payload that falls through to the success branch would silently
+// dereference undefined — the exact anti-pattern the catalog warns against.
 if ('_budget_exceeded' in parsed) {
   // narrow with jmespath / filters and retry — see /mcp-error-catalog
+} else if ('_jmespath_error' in parsed) {
+  // fix the projection using `original_keys` as the schema hint — see /mcp-error-catalog
 } else {
   console.log(parsed.cii, parsed.components.conflict);
 }


### PR DESCRIPTION
## Summary

Pure docs PR — zero `api/` changes. Closes out the deferred docs after `docs/mcp-quickstart.mdx` and `docs/mcp-jmespath.mdx` shipped in #3862.

- **New `docs/mcp-error-catalog.mdx`** — the single authoritative reference for every error shape the MCP server can emit. Three layers, lookup-first organization:
  - **JSON-RPC error codes** — `-32001`, `-32029`, `-32600`, `-32601`, `-32602`, `-32603` — per-code subsection with trigger sites, paired HTTP status, example payload, and recovery.
  - **HTTP statuses** — table mapping 200 / 202 / 204 / 401 / 403 / 405 / 429 / 503 to body shape, paired JSON-RPC code(s), and cause.
  - **Soft-behavior envelopes** — full subsections for `_budget_exceeded` (with `budget_bytes` / `actual_bytes` / `hint` schema) and `_jmespath_error` (string discriminator, three kinds: `expression_too_long`, `invalid_expression`, `projection_too_large`). The catalog leads with the parsing-bug callout: clients that only inspect the JSON-RPC layer silently miss these.
  - HTML source-of-truth comment at the top listing every `api/mcp/*.ts` file the catalog draws from with line ranges, so anchor drift is visible in PR diffs.
- **`docs/mcp-tools-reference.mdx`** — new "Discovering tools" section near the top with two worked examples:
  - `describe_tool` — full request/response, quota-exempt callout, two-soft-error documentation.
  - `outputSchema` — full schema for `get_country_risk`, cache-envelope wrap pattern, typed-parsing TS sketch with the soft-envelope discriminator check baked in.
- **`docs/mcp-server.mdx`** — old five-row errors table (outdated: cited `404` and `503 upstream cache unavailable` neither of which the server actually emits) replaced with a three-layer triage table that links to the new catalog. Added the catalog to "Related."
- **`docs/mcp-jmespath.mdx`** — `_jmespath_error` example fixed to match the actual code: the server emits `_jmespath_error: "<kind>: <details>"` as a **string**, not the `{ kind, message, expression }` object the doc previously claimed (which would mislead readers writing a generic envelope detector). Added the catalog to "See also."
- **`docs/docs.json`** — `mcp-error-catalog` registered in the MCP & Integrations nav group so the page resolves and renders.

### Decision outcomes

| #  | Decision                                  | Outcome                                                                                            |
|----|-------------------------------------------|----------------------------------------------------------------------------------------------------|
| 1  | Catalog organization                      | Option (a) — one section per error class. The reader has a payload in hand; layer triage matches that flow. |
| 2  | Include `-32600`?                         | Yes, with a "you should never see this; if you do, your encoder is broken" framing. Documenting absence-of-this saves a future debug session. |
| 3  | Soft envelopes — only `_budget_exceeded`? | Both `_budget_exceeded` AND the three `_jmespath_error` kinds, with exact discriminator strings.   |
| 4  | Document PR 5a auto-summarize?            | No — PR 5a is deferred. Added a one-line Roadmap entry instead.                                    |
| 5  | Example payload shape                     | Literal JSON-RPC envelope the client will see (jsonrpc, id, error or result). For soft envelopes, both the outer wire shape AND the decoded `text` payload. |
| 6  | HTTP status section scope                 | Table with body shape + paired JSON-RPC code(s). Calls out the 403/405 non-JSON-RPC bodies explicitly. |
| 7  | `describe_tool` examples                  | One full worked example with both soft-error envelopes documented.                                 |
| 8  | `outputSchema` examples                   | One full schema (`get_country_risk`) + cache-envelope wrap pattern + TypeScript typed-parsing sketch. |

### Scope NOT in this PR (filed separately)

- **`SERVER_INSTRUCTIONS` trim in `api/mcp/constants.ts`** — replacing inline JMESPath examples with a single link to `docs/mcp-jmespath.mdx`. That's a wire-impacting change (byte-budget across every `initialize` response) and does not belong in a doc PR. Will file as a separate follow-up.

## Test plan

- [x] `npm run typecheck:api` green
- [x] `npm run lint` green
- [x] `npm run test:data` green — 9679 / 9679 passing (baseline preserved)
- [x] Every `-3200x` / `-3260x` literal in `api/mcp/*.ts` cross-checked against the catalog — six codes in code, six codes documented.
- [x] Soft envelope keys (`_budget_exceeded`, `_jmespath_error`) cross-checked.
- [ ] **Mintlify preview** — verify cross-links from `mcp-server.mdx`, `mcp-jmespath.mdx`, and `mcp-tools-reference.mdx` to `/mcp-error-catalog` all resolve, and the page renders without MDX/JSX parse errors.
- [ ] Manual sanity: a fresh engineer reads only the catalog page and can answer "I got a 429 from `/api/mcp` — what do I do?" within 60s.

## /ultrareview

Doc-only PR, very low blast radius — but the docs become a load-bearing reference for every future MCP client, and the catalog makes wire claims (envelope shapes, paired HTTP statuses, quota-rollback behavior) that need to stay synchronized with the code. Happy to run `/ultrareview` if you'd like a second pass against the source-of-truth files. Otherwise the source-of-truth comment at the top of the catalog gives reviewers an anchored map to walk against.