### PR TITLE
fix(sentry): filter intentional ConvexError FREE_CAP throws

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -290,6 +290,7 @@ Sentry.init({
     /Possible side-effect in debug-evaluate/, // Chrome DevTools internal EvalError
     /ConvexError: CONFLICT/, // Expected OCC rejection on concurrent preference saves
     /ConvexError: API_ACCESS_REQUIRED/, // Expected business error: free user opens API Keys tab; client handles gracefully (UnifiedSettings.ts:731-738) — WORLDMONITOR-NA
+    /ConvexError: \{"kind":"FREE_CAP"/, // Expected business error: free user hits followed-countries cap of 3; client catches at src/services/followed-countries.ts:1155 and triggers upgrade UX via src/utils/follow-button.ts:413. Convex's server-side auto-Sentry forwards the throw regardless. Match the object-data prefix uniquely — string `ConvexError: {"kind":"FREE_CAP"` cannot be emitted by our minified bundle. WORLDMONITOR-RV.
     /\[CONVEX [AQM]\(.+?\)\] Connection lost while action was in flight/, // Convex SDK transient WS disconnect
     /^Invalid start version: \d+:\d+:\d+, transitioning from \d+:\d+:\d+$/, // Convex SDK internal sync protocol error from `remote_query_set.js` (server republished query mid-transition or WS reconnect race) — WORLDMONITOR-Q5
     /Response did not contain `success` or `data`/, // DuckDuckGo browser internal tracker/content-block response — never emitted by our code


### PR DESCRIPTION
## Summary

- Adds `/ConvexError: \{"kind":"FREE_CAP"/` to `src/main.ts` `ignoreErrors`, mirroring the existing `CONFLICT` and `API_ACCESS_REQUIRED` entries on the two lines above.
- The `followedCountries.followCountry` mutation throws `ConvexError({kind:"FREE_CAP", currentCount, limit})` when a free-tier user hits the 3-country cap. The client catches at `src/services/followed-countries.ts:1155` via `_extractConvexErrorKind` and translates to `{ok:false, reason:'FREE_CAP'}`; the UI opens the upgrade modal at `src/utils/follow-button.ts:413`. Expected business behavior, not a bug.
- Convex Cloud's server-side auto-Sentry forwards EVERY server throw — including intentional `ConvexError` used for client signaling — to the project DSN. The filter suppresses the noise so signal stays visible.
- Object-data ConvexError serializes as `ConvexError: {"kind":"FREE_CAP",...}`, requiring the JSON-prefix shape in the regex. The literal `ConvexError: {"kind":"FREE_CAP"` cannot be emitted by our minified bundle.

Resolves `WORLDMONITOR-RV`.

## Test plan

- [x] `npm run typecheck` + `npm run typecheck:api` PASS
- [x] `npm run lint` (Biome) PASS
- [x] `npm run lint:md` PASS
- [x] `npm run test:data` PASS (9922/9922)
- [x] `node --test tests/edge-functions.test.mjs` PASS (203/203)
- [x] Edge function bundle check (every `api/*.js` esbuilds) PASS
- [x] CJS syntax check (`node -c scripts/*.cjs`) PASS
- [x] `npm run version:check` PASS
- [x] `npx tsx --test tests/followed-countries-service.test.mjs tests/follow-button.test.mjs` PASS (48/48) — confirms client-side FREE_CAP catch contract intact

## Notes

Third instance of the Convex auto-Sentry filter pattern (after `CONFLICT` for `userPreferences` OCC rejection and `API_ACCESS_REQUIRED` for the free-user API Keys tab). The recurrence has been captured in `~/.claude/skills/convex-gotchas/reference/convex-autosentry-forwards-intentional-convexerror-throws.md` for future agent sessions.