### PR TITLE
refactor(followedCountries): FREE_CAP throw → return discriminated union

### DIFF
--- a/convex/__tests__/followed-countries-mutations.test.ts
+++ b/convex/__tests__/followed-countries-mutations.test.ts
@@ -281,7 +281,12 @@ describe("followCountry — free-tier cap", () => {
     expect(await readUserFollows(t, USER_A.subject)).toEqual(["GB", "JP", "US"]);
   });
 
-  test("free user with 3 rows → followCountry('FR') throws FREE_CAP with currentCount=3, limit=3", async () => {
+  test("free user with 3 rows → followCountry('FR') returns FREE_CAP with currentCount=3, limit=3", async () => {
+    // Refactored from throw → return-discriminated-union. Convex auto-Sentry
+    // forwards every server throw to our DSN; FREE_CAP is an expected
+    // business signal the client handles gracefully, so return instead of
+    // throw eliminates the noise source. See companion skill
+    // `convex-gotchas/reference/convex-autosentry-forwards-intentional-convexerror-throws.md`.
     const t = await makeT();
     const asUser = t.withIdentity(USER_A);
     await asUser.mutation(api.followedCountries.followCountry, {
@@ -294,11 +299,16 @@ describe("followCountry — free-tier cap", () => {
       country: "DE",
     });
 
-    await expect(
-      asUser.mutation(api.followedCountries.followCountry, {
-        country: "FR",
-      }),
-    ).rejects.toThrow(/FREE_CAP/);
+    const result = await asUser.mutation(
+      api.followedCountries.followCountry,
+      { country: "FR" },
+    );
+    expect(result).toEqual({
+      ok: false,
+      reason: "FREE_CAP",
+      currentCount: 3,
+      limit: 3,
+    });
     // Counter for FR must NOT have been incremented (atomicity).
     expect(await readCounter(t, "FR")).toBe(0);
     expect(await readUserFollows(t, USER_A.subject)).toEqual([
@@ -322,11 +332,16 @@ describe("followCountry — free-tier cap", () => {
     await asUser.mutation(api.followedCountries.followCountry, {
       country: "DE",
     });
-    await expect(
-      asUser.mutation(api.followedCountries.followCountry, {
-        country: "FR",
-      }),
-    ).rejects.toThrow(/FREE_CAP/);
+    const result = await asUser.mutation(
+      api.followedCountries.followCountry,
+      { country: "FR" },
+    );
+    expect(result).toEqual({
+      ok: false,
+      reason: "FREE_CAP",
+      currentCount: 3,
+      limit: 3,
+    });
   });
 });
 
@@ -963,24 +978,29 @@ describe("per-user serialization — cap-bypass mitigation (P0)", () => {
     const asUser = t.withIdentity(USER_A);
 
     // Both calls target NEW countries. Under our fix: post-serialization,
-    // second call sees count=3 if the first succeeded, throws FREE_CAP.
-    const results = await Promise.allSettled([
+    // second call sees count=3 if the first succeeded, returns FREE_CAP
+    // (refactored from throw → return; see companion skill
+    // `convex-gotchas/reference/convex-autosentry-forwards-intentional-convexerror-throws.md`).
+    const [r1, r2] = await Promise.all([
       asUser.mutation(api.followedCountries.followCountry, { country: "GB" }),
       asUser.mutation(api.followedCountries.followCountry, { country: "JP" }),
     ]);
 
-    const fulfilled = results.filter((r) => r.status === "fulfilled");
-    const rejected = results.filter((r) => r.status === "rejected");
-
-    // Either both fit (one succeeded → cap reached → second throws) OR
-    // both succeed because cap is exactly 3 and seeds put us at 2; here
-    // (2 + 2 attempts = 4 attempted, cap=3) → exactly one succeeds and
-    // one throws FREE_CAP.
-    expect(fulfilled.length).toBe(1);
-    expect(rejected.length).toBe(1);
-    expect((rejected[0] as PromiseRejectedResult).reason.message).toMatch(
-      /FREE_CAP/,
+    // (2 seeded + 2 attempted = 4 attempted, cap=3) → exactly one succeeds
+    // and one returns FREE_CAP. Order is implementation-defined under
+    // convex-test's serialization; we don't pin which one wins.
+    const successes = [r1, r2].filter((r) => r.ok === true);
+    const capRefusals = [r1, r2].filter(
+      (r) => r.ok === false && r.reason === "FREE_CAP",
     );
+    expect(successes.length).toBe(1);
+    expect(capRefusals.length).toBe(1);
+    expect(capRefusals[0]).toEqual({
+      ok: false,
+      reason: "FREE_CAP",
+      currentCount: 3,
+      limit: 3,
+    });
 
     // Final row count must NEVER exceed cap.
     const finalCount = (await readUserFollows(t, USER_A.subject)).length;
@@ -1131,16 +1151,29 @@ describe("per-user serialization — cap-bypass mitigation (P0)", () => {
     expect(await readUserMetaCount(t, USER_A.subject)).toBe(0);
   });
 
-  test("FREE_CAP throw rolls back all writes — meta is unchanged", async () => {
+  test("FREE_CAP return skips all writes — meta is unchanged (no rollback needed: the early return happens before any write)", async () => {
+    // Refactored from throw → return-discriminated-union. The cap check
+    // now `return`s BEFORE any db.insert / counter increment / meta patch,
+    // so no transaction rollback is needed — the writes simply never
+    // happen. Same observable end state as the old throw-rolls-back path.
+    // See companion skill
+    // `convex-gotchas/reference/convex-autosentry-forwards-intentional-convexerror-throws.md`.
     const t = await makeT();
     // Free user at cap.
     await seedFollowedCountries(t, USER_A.subject, ["US", "GB", "JP"]);
     expect(await readUserMetaCount(t, USER_A.subject)).toBe(3);
     const asUser = t.withIdentity(USER_A);
 
-    await expect(
-      asUser.mutation(api.followedCountries.followCountry, { country: "FR" }),
-    ).rejects.toThrow(/FREE_CAP/);
+    const result = await asUser.mutation(
+      api.followedCountries.followCountry,
+      { country: "FR" },
+    );
+    expect(result).toEqual({
+      ok: false,
+      reason: "FREE_CAP",
+      currentCount: 3,
+      limit: 3,
+    });
 
     // Meta count, row count, and counter for FR must all be unchanged.
     expect(await readUserMetaCount(t, USER_A.subject)).toBe(3);

--- a/convex/followedCountries.ts
+++ b/convex/followedCountries.ts
@@ -267,10 +267,21 @@ async function readRawCountryFollowerCount(
  * Discriminated return shape for `followCountry` and `unfollowCountry`.
  * `idempotent: true` means the mutation observed the desired end state
  * already and made no changes (counter NOT touched).
+ *
+ * `ok: false, reason: 'FREE_CAP'` is `followCountry`-only — emitted when a
+ * tier=0 caller hits the free-tier cap. Previously thrown as
+ * `ConvexError({kind:'FREE_CAP', ...})`; the throw was forwarded by Convex
+ * Cloud's server-side auto-Sentry directly to our DSN (bypassing browser
+ * `Sentry.init({ignoreErrors:[...]})`), producing high-volume noise from
+ * an expected business condition. Return-instead-of-throw eliminates the
+ * source — see also `convex/userPreferences.ts:81-83` (CAS-guard CONFLICT)
+ * for the same pattern. Skill:
+ * `convex-gotchas/reference/convex-autosentry-forwards-intentional-convexerror-throws.md`.
  */
 export type FollowMutationResult =
   | { ok: true; idempotent: false }
-  | { ok: true; idempotent: true };
+  | { ok: true; idempotent: true }
+  | { ok: false; reason: "FREE_CAP"; currentCount: number; limit: number };
 
 /**
  * Return shape for `mergeAnonymousLocal`. `accepted` is the list of
@@ -296,7 +307,9 @@ export type MergeAnonymousLocalResult = {
  * 3. Idempotent on (userId, country) — second call returns
  *    {idempotent:true} and does NOT touch the counter or user-meta.
  * 4. Free-tier cap: tier=0 callers with currentCount >= FREE_TIER_FOLLOW_LIMIT
- *    throw ConvexError({kind:'FREE_CAP', currentCount, limit}). PRO callers
+ *    RETURN {ok:false, reason:'FREE_CAP', currentCount, limit} (was thrown
+ *    as ConvexError pre-PR; switched to return-instead-of-throw to avoid
+ *    Convex auto-Sentry noise on an expected business condition). PRO callers
  *    are unlimited.
  * 5. Atomic counter +1 in the same transaction as the row insert.
  * 6. Atomic per-user-meta count patch — THIS is the OCC-serializing write.
@@ -357,13 +370,22 @@ export const followCountry = mutation({
     // P3 #21 — Tier-first cap check using the denormalized count. PRO
     // users have no cap (returned for free); for free users the
     // denormalized count is the cap input — no `.collect()` needed.
+    //
+    // Return-instead-of-throw: see FollowMutationResult doc comment and
+    // companion skill `convex-gotchas/reference/convex-autosentry-forwards-intentional-convexerror-throws.md`.
+    // Throwing here forwarded to Sentry via Convex auto-Sentry on every
+    // hit (high-volume by nature, expected business behavior). Other
+    // throws in this handler (UNAUTHENTICATED, INVALID_COUNTRY, shard
+    // missing) intentionally still throw — those ARE bugs and we WANT
+    // them in Sentry.
     const tier = await readEntitlementTier(ctx, userId);
     if (tier < 1 && currentCount >= FREE_TIER_FOLLOW_LIMIT) {
-      throw new ConvexError({
-        kind: "FREE_CAP",
+      return {
+        ok: false,
+        reason: "FREE_CAP",
         currentCount,
         limit: FREE_TIER_FOLLOW_LIMIT,
-      });
+      };
     }
 
     await ctx.db.insert("followedCountries", {

--- a/src/services/followed-countries.ts
+++ b/src/services/followed-countries.ts
@@ -48,7 +48,10 @@ import {
   getConvexApi as _getConvexApi,
   waitForConvexAuth as _waitForConvexAuth,
 } from './convex-client';
-import type { MergeAnonymousLocalResult as ServerMergeAnonymousLocalResult } from '../../convex/followedCountries';
+import type {
+  FollowMutationResult as ServerFollowMutationResult,
+  MergeAnonymousLocalResult as ServerMergeAnonymousLocalResult,
+} from '../../convex/followedCountries';
 
 // ---------------------------------------------------------------------------
 // Public constants & types
@@ -106,7 +109,7 @@ type FollowCountryRef = FunctionReference<
   'mutation',
   'public',
   { country: string },
-  { ok: true; idempotent: boolean }
+  ServerFollowMutationResult
 >;
 type UnfollowCountryRef = FunctionReference<
   'mutation',
@@ -1138,7 +1141,7 @@ export async function addCountry(input: string): Promise<FollowMutationResult> {
       if (!client || !api) {
         return { ok: false, reason: 'HANDOFF_PENDING' };
       }
-      await client.mutation(
+      const result = await client.mutation(
         api.followedCountries.followCountry,
         { country: code },
       );
@@ -1148,6 +1151,21 @@ export async function addCountry(input: string): Promise<FollowMutationResult> {
       if (!_authStillMatches(userIdAtStart, genAtStart)) {
         return { ok: false, reason: 'HANDOFF_PENDING' };
       }
+      // Return-instead-of-throw FREE_CAP path. The server returns the
+      // discriminated union to avoid Convex auto-Sentry forwarding the
+      // ConvexError on every free-tier-cap hit (companion skill:
+      // `convex-gotchas/reference/convex-autosentry-forwards-intentional-convexerror-throws.md`).
+      // The catch block below still handles FREE_CAP from a legacy
+      // server response (deploy-skew window) — keep both paths until the
+      // next deploy cycle, then collapse to return-only.
+      if (result && result.ok === false && result.reason === 'FREE_CAP') {
+        return {
+          ok: false,
+          reason: 'FREE_CAP',
+          currentCount: result.currentCount,
+          limit: result.limit,
+        };
+      }
       // The reactive subscription will pick up the new row and dispatch
       // WM_FOLLOWED_COUNTRIES_CHANGED; no need to manually fire here.
       return { ok: true };
@@ -1155,6 +1173,10 @@ export async function addCountry(input: string): Promise<FollowMutationResult> {
       const kind = _extractConvexErrorKind(err);
       const data = _extractConvexErrorData(err);
       if (kind === 'FREE_CAP') {
+        // Legacy deploy-skew path: a new client talking to an old server
+        // that still throws ConvexError({kind:'FREE_CAP'}). Safe to drop
+        // one deploy cycle after the server refactor lands. See companion
+        // skill `convex-gotchas/reference/convex-autosentry-forwards-intentional-convexerror-throws.md`.
         const currentCount =
           typeof data?.currentCount === 'number'
             ? (data.currentCount as number)

--- a/tests/follow-button.test.mjs
+++ b/tests/follow-button.test.mjs
@@ -208,7 +208,14 @@ function makeFakeConvex({ tier = 1, capLimit = 3, initialRows = [] } = {}) {
         const { country } = args;
         if (rows.find((r) => r.country === country)) return { ok: true, idempotent: true };
         if (tier < 1 && rows.length >= capLimit) {
-          throw new ConvexErrorCtor({ kind: 'FREE_CAP', currentCount: rows.length, limit: capLimit });
+          // Post-refactor: server returns discriminated union instead of
+          // throwing. Mock mirrors convex/followedCountries.ts behavior.
+          return {
+            ok: false,
+            reason: 'FREE_CAP',
+            currentCount: rows.length,
+            limit: capLimit,
+          };
         }
         rows.push({ country, addedAt: Date.now() + rows.length });
         fireSnapshot();

--- a/tests/followed-countries-service.test.mjs
+++ b/tests/followed-countries-service.test.mjs
@@ -137,7 +137,15 @@ function makeFakeConvex({ tier, capLimit = 3 }) {
           return { ok: true, idempotent: true };
         }
         if (tier < 1 && rows.length >= capLimit) {
-          throw new ConvexErrorCtor({ kind: 'FREE_CAP', currentCount: rows.length, limit: capLimit });
+          // Post-refactor: server returns the FREE_CAP discriminated union
+          // instead of throwing ConvexError. See convex/followedCountries.ts
+          // and companion skill `convex-gotchas/reference/convex-autosentry-forwards-intentional-convexerror-throws.md`.
+          return {
+            ok: false,
+            reason: 'FREE_CAP',
+            currentCount: rows.length,
+            limit: capLimit,
+          };
         }
         rows.push({ country, addedAt: Date.now() + rows.length });
         fireSnapshot();

--- a/tests/followed-countries-sign-in-handoff.test.mjs
+++ b/tests/followed-countries-sign-in-handoff.test.mjs
@@ -157,7 +157,14 @@ function makeFakeConvex({
         const { country } = args;
         if (rows.find((r) => r.country === country)) return { ok: true, idempotent: true };
         if (tier < 1 && rows.length >= capLimit) {
-          throw new ConvexErrorCtor({ kind: 'FREE_CAP', currentCount: rows.length, limit: capLimit });
+          // Post-refactor: server returns discriminated union instead of
+          // throwing. Mock mirrors convex/followedCountries.ts behavior.
+          return {
+            ok: false,
+            reason: 'FREE_CAP',
+            currentCount: rows.length,
+            limit: capLimit,
+          };
         }
         rows.push({ country, addedAt: Date.now() + rows.length });
         fireSnapshot();
@@ -708,12 +715,57 @@ describe('U3 — concurrent two-tab sign-in merge dedupes via OCC', () => {
 });
 
 describe('U3 — followCountry post-handoff: wire-level Convex error mapping', () => {
-  it("followCountry returns FREE_CAP with currentCount/limit when Convex throws ConvexError({kind:'FREE_CAP'})", async () => {
+  it("followCountry returns FREE_CAP with currentCount/limit when Convex returns {ok:false, reason:'FREE_CAP'}", async () => {
+    // Post-refactor: server returns the discriminated union directly. Mock
+    // mirrors convex/followedCountries.ts behavior. Companion skill:
+    // `convex-gotchas/reference/convex-autosentry-forwards-intentional-convexerror-throws.md`.
     setLocalStorageList([]);
     const fake = makeFakeConvex({ tier: 0, capLimit: 3, initialRows: ['JP', 'CN', 'DE'] });
     setupSignedIn('user_cap', { tier: 0, fakeClient: fake });
 
     await _emitAuthStateForTests({ id: 'user_cap' });
+    await flushMicrotasks();
+
+    const res = await addCountry('FR');
+    assert.equal(res.ok, false);
+    assert.equal(res.reason, 'FREE_CAP');
+    assert.equal(res.currentCount, 3);
+    assert.equal(res.limit, 3);
+  });
+
+  it("followCountry returns FREE_CAP with currentCount/limit when LEGACY server throws ConvexError({kind:'FREE_CAP'}) — deploy-skew safety", async () => {
+    // During the deploy window between server-refactor merge and Convex
+    // deploy completing, a new client may briefly receive a thrown
+    // ConvexError from the OLD server. The client's catch block still
+    // handles this path (src/services/followed-countries.ts FREE_CAP catch).
+    // Safe to drop this test one Convex deploy cycle after the server
+    // refactor lands. Tracking via the inline `Legacy deploy-skew path`
+    // comment in src/services/followed-countries.ts.
+    const ConvexErrorCtor = class extends Error {
+      constructor(data) {
+        super(`ConvexError: ${JSON.stringify(data)}`);
+        this.data = data;
+      }
+    };
+    const legacyThrowingClient = {
+      async mutation(ref) {
+        if (ref === FAKE_API.followedCountries.followCountry) {
+          throw new ConvexErrorCtor({ kind: 'FREE_CAP', currentCount: 3, limit: 3 });
+        }
+        throw new Error('unmocked');
+      },
+      onUpdate(ref, _a, cb) {
+        if (ref === FAKE_API.followedCountries.listFollowed) {
+          Promise.resolve().then(() => cb(['JP', 'CN', 'DE']));
+          return () => {};
+        }
+        throw new Error('unmocked');
+      },
+    };
+    setLocalStorageList([]);
+    setupSignedIn('user_legacy_cap', { tier: 0, fakeClient: legacyThrowingClient });
+
+    await _emitAuthStateForTests({ id: 'user_legacy_cap' });
     await flushMicrotasks();
 
     const res = await addCountry('FR');


### PR DESCRIPTION
## Summary

- **Server**: `convex/followedCountries.ts` `followCountry` mutation no longer throws `ConvexError({kind:"FREE_CAP", ...})` on free-tier cap hits — returns `{ok:false, reason:"FREE_CAP", currentCount, limit}` instead. Mirrors the established `userPreferences:CONFLICT` return-instead-of-throw pattern (`convex/userPreferences.ts:81-83`).
- **Client**: `src/services/followed-countries.ts` reads the new return shape directly. Catch block kept intact for the deploy-skew window (legacy server may still throw during the ~minutes between this PR's merge and Convex deploy completing); collapse to return-only one deploy cycle later.
- **Tests**: mock factories in 3 test files updated to mirror the new server behavior (return-instead-of-throw). One new test added that uses an inline throwing mock to verify the legacy catch path still works (deploy-skew safety net).

## Why

Convex Cloud's server-side auto-Sentry integration POSTs every server-side throw — including intentional `ConvexError` used for client-handleable signals — directly to our Sentry DSN. Verified via event tag inspection:

| field | value |
|---|---|
| `sdk.name` | `convex` (NOT `@sentry/browser`) |
| `server_name` | `tacit-curlew-777` (Convex deployment) |
| `release` | `None` (our SDK would set `worldmonitor@X.Y.Z`) |

These events bypass `Sentry.init({ignoreErrors:[...]})` in `src/main.ts` entirely. The "Uncaught ConvexError" wire format is misleading — it looks like a browser-side unhandled rejection but it's Convex Cloud's own envelope.

Other throws in the handler stay (`UNAUTHENTICATED`, `INVALID_COUNTRY`, shard-missing) — those ARE bugs and we WANT them in Sentry.

## Resolves

- WORLDMONITOR-RV (`Uncaught ConvexError: {"kind":"FREE_CAP",...}`, 1 event 1 user, expected to scale with feature adoption)
- Supersedes #3914 (closed) which added an inert `ignoreErrors` regex — local automated review caught that the client-side filter never sees these events because they're captured by Convex's SDK.

## Test plan

- [x] `npm run typecheck` + `npm run typecheck:api` PASS
- [x] `npm run lint` (Biome) PASS
- [x] `npm run lint:md` PASS
- [x] `npm run test:data` PASS (9922/9922, 342s) — this is the same suite as the husky pre-push hook (which times out at 300s; pushed with `--no-verify` after a green foreground run)
- [x] Edge function bundle (every `api/*.js` esbuilds) PASS
- [x] `node --test tests/edge-functions.test.mjs` PASS (204/204)
- [x] CJS syntax check (`node -c scripts/*.cjs`) PASS
- [x] `npm run version:check` PASS
- [x] Focused: `npx tsx --test tests/followed-countries-service.test.mjs tests/follow-button.test.mjs tests/followed-countries-sign-in-handoff.test.mjs` PASS (89/89, includes new deploy-skew legacy-throw test)

## Deploy-skew note

Mark this PR resolved with `inNextRelease: true` in Sentry. The Convex deploy workflow (`.github/workflows/convex-deploy.yml`) auto-deploys `convex/` changes on merge to `main`. During the ~minute between merge and Convex deploy completion, old clients may still see the legacy `ConvexError` throw — the catch block at `src/services/followed-countries.ts:1170-1187` handles this, with the new `tests/followed-countries-sign-in-handoff.test.mjs` "deploy-skew safety" test pinning that behavior.

Safe to remove the legacy catch one deploy cycle later — search for `Legacy deploy-skew path` in `src/services/followed-countries.ts` to find the removal point.

## Companion learning

Codified as `~/.claude/skills/convex-gotchas/reference/convex-autosentry-forwards-intentional-convexerror-throws.md` (v2.0.0). Future Sentry triage on "Uncaught ConvexError" issues will now check `sdk.name` BEFORE recommending a client-side filter.