### PR TITLE
fix(redis): cooldown failed cached fetches

### DIFF
--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -29,6 +29,10 @@ function errMsg(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+function hasRemoteRedisConfig(): boolean {
+  return Boolean(process.env.UPSTASH_REDIS_REST_URL && process.env.UPSTASH_REDIS_REST_TOKEN);
+}
+
 /**
  * Environment-based key prefix to avoid collisions when multiple deployments
  * share the same Upstash Redis instance (M-6 fix).
@@ -222,8 +226,10 @@ export async function setCachedJson(key: string, value: unknown, ttlSeconds: num
 
 const NEG_SENTINEL = '__WM_NEG__';
 const FETCH_ERROR_NEGATIVE_TTL_SECONDS = 30;
+const REDIS_FAILURE_POSITIVE_TTL_SECONDS = 30;
 
 const localNegativeUntil = new Map<string, number>();
+const localPositiveFallback = new Map<string, { value: unknown; expiresAt: number }>();
 
 function effectiveFetchErrorNegativeTtlSeconds(negativeTtlSeconds: number): number {
   return Math.max(1, Math.min(negativeTtlSeconds, FETCH_ERROR_NEGATIVE_TTL_SECONDS));
@@ -239,6 +245,26 @@ function hasLocalNegativeCooldown(key: string): boolean {
   if (expiresAt > Date.now()) return true;
   localNegativeUntil.delete(key);
   return false;
+}
+
+function effectiveRedisFailurePositiveTtlSeconds(ttlSeconds: number): number {
+  return Math.max(1, Math.min(ttlSeconds, REDIS_FAILURE_POSITIVE_TTL_SECONDS));
+}
+
+function armLocalPositiveFallback(key: string, value: unknown, ttlSeconds: number): void {
+  const effectiveTtlSeconds = effectiveRedisFailurePositiveTtlSeconds(ttlSeconds);
+  localPositiveFallback.set(key, {
+    value,
+    expiresAt: Date.now() + effectiveTtlSeconds * 1000,
+  });
+}
+
+function readLocalPositiveFallback(key: string): unknown | undefined {
+  const cached = localPositiveFallback.get(key);
+  if (cached === undefined) return undefined;
+  if (cached.expiresAt > Date.now()) return cached.value;
+  localPositiveFallback.delete(key);
+  return undefined;
 }
 
 /**
@@ -422,6 +448,9 @@ export async function cachedFetchJson<T extends object>(
     if (cached.value === NEG_SENTINEL) return null;
     return cached.value as T;
   }
+  const localPositive = readLocalPositiveFallback(key);
+  if (localPositive !== undefined) return localPositive as T;
+  const hadCacheReadError = cached.status === 'error';
   if (cached.status === 'error') {
     logCacheReadError(key, cached.error);
     if (hasLocalNegativeCooldown(key)) return null;
@@ -434,7 +463,10 @@ export async function cachedFetchJson<T extends object>(
   const promise = withFetcherTimeout(fetcher(), key, timeoutMs, 'cachedFetchJson')
     .then(async (result) => {
       if (result != null) {
-        await setCachedJson(key, result, ttlSeconds);
+        const wrote = await setCachedJson(key, result, ttlSeconds);
+        if (hadCacheReadError || (!wrote && hasRemoteRedisConfig())) {
+          armLocalPositiveFallback(key, result, ttlSeconds);
+        }
       } else {
         armLocalNegativeCooldown(key, negativeTtlSeconds);
         await setCachedJson(key, NEG_SENTINEL, negativeTtlSeconds);
@@ -506,6 +538,9 @@ export async function cachedFetchJsonWithMeta<T extends object>(
     if (cached.value === NEG_SENTINEL) return { data: null, source: 'cache' };
     return { data: cached.value as T, source: 'cache' };
   }
+  const localPositive = readLocalPositiveFallback(key);
+  if (localPositive !== undefined) return { data: localPositive as T, source: 'cache' };
+  const hadCacheReadError = cached.status === 'error';
   if (cached.status === 'error') {
     logCacheReadError(key, cached.error);
     if (hasLocalNegativeCooldown(key)) return { data: null, source: 'cache' };
@@ -532,7 +567,10 @@ export async function cachedFetchJsonWithMeta<T extends object>(
       // the structural detail.
       if (result != null) {
         upstreamStatus = 200;
-        await setCachedJson(key, result, ttlSeconds);
+        const wrote = await setCachedJson(key, result, ttlSeconds);
+        if (hadCacheReadError || (!wrote && hasRemoteRedisConfig())) {
+          armLocalPositiveFallback(key, result, ttlSeconds);
+        }
       } else {
         upstreamStatus = 0;
         cacheStatus = 'neg-sentinel';

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -54,6 +54,61 @@ export function __resetKeyPrefixCacheForTests(): void {
   cachedPrefix = undefined;
 }
 
+type CacheReadResult =
+  | { status: 'hit'; value: unknown }
+  | { status: 'miss' }
+  | { status: 'error'; error: unknown };
+
+async function readCachedJson(key: string, raw = false): Promise<CacheReadResult> {
+  if (process.env.LOCAL_API_MODE === 'tauri-sidecar') {
+    try {
+      const { sidecarCacheGet } = await import('./sidecar-cache');
+      const value = sidecarCacheGet(key);
+      return value == null ? { status: 'miss' } : { status: 'hit', value };
+    } catch (error) {
+      return { status: 'error', error };
+    }
+  }
+
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return { status: 'miss' };
+  try {
+    const finalKey = raw ? key : prefixKey(key);
+    const resp = await fetch(`${url}/get/${encodeURIComponent(finalKey)}`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(REDIS_OP_TIMEOUT_MS),
+    });
+    if (!resp.ok) throw new Error(`Redis HTTP ${resp.status}`);
+    const data = (await resp.json()) as { result?: string };
+    if (!data.result) return { status: 'miss' };
+    // Envelope-aware by default — RPC consumers get the bare payload regardless
+    // of whether the writer has migrated to contract mode. Legacy shapes pass
+    // through unchanged (unwrapEnvelope returns {_seed: null, data: raw}).
+    return { status: 'hit', value: unwrapEnvelope(JSON.parse(data.result)).data };
+  } catch (error) {
+    return { status: 'error', error };
+  }
+}
+
+function logCacheReadError(key: string, err: unknown): void {
+  // Structured timeout log goes to Sentry via Vercel integration. Large-
+  // payload timeouts used to silently return null and let downstream callers
+  // cache zero-state — see docs/plans/chokepoint-rpc-payload-split.md for
+  // the incident that added this tag.
+  //
+  // AbortSignal.timeout() throws DOMException name='TimeoutError' (on V8
+  // runtimes incl. Vercel Edge); manual controller.abort() throws
+  // 'AbortError'. Checking only 'AbortError' meant the [REDIS-TIMEOUT] log
+  // never fired — every timeout fell through to the generic console.warn.
+  const isTimeout = err instanceof Error && (err.name === 'TimeoutError' || err.name === 'AbortError');
+  if (isTimeout) {
+    console.error(`[REDIS-TIMEOUT] getCachedJson key=${key} timeoutMs=${REDIS_OP_TIMEOUT_MS}`);
+  } else {
+    console.warn('[redis] getCachedJson failed:', errMsg(err));
+  }
+}
+
 /**
  * Like getCachedJson but throws on Redis/network failures instead of returning null.
  * Always uses the raw (unprefixed) key — callers that write via seed scripts (which bypass
@@ -118,45 +173,10 @@ export async function getCachedRawString(key: string): Promise<string | null> {
 }
 
 export async function getCachedJson(key: string, raw = false): Promise<unknown | null> {
-  if (process.env.LOCAL_API_MODE === 'tauri-sidecar') {
-    const { sidecarCacheGet } = await import('./sidecar-cache');
-    return sidecarCacheGet(key);
-  }
-
-  const url = process.env.UPSTASH_REDIS_REST_URL;
-  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-  if (!url || !token) return null;
-  try {
-    const finalKey = raw ? key : prefixKey(key);
-    const resp = await fetch(`${url}/get/${encodeURIComponent(finalKey)}`, {
-      headers: { Authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(REDIS_OP_TIMEOUT_MS),
-    });
-    if (!resp.ok) return null;
-    const data = (await resp.json()) as { result?: string };
-    if (!data.result) return null;
-    // Envelope-aware by default — RPC consumers get the bare payload regardless
-    // of whether the writer has migrated to contract mode. Legacy shapes pass
-    // through unchanged (unwrapEnvelope returns {_seed: null, data: raw}).
-    return unwrapEnvelope(JSON.parse(data.result)).data;
-  } catch (err) {
-    // Structured timeout log goes to Sentry via Vercel integration. Large-
-    // payload timeouts used to silently return null and let downstream callers
-    // cache zero-state — see docs/plans/chokepoint-rpc-payload-split.md for
-    // the incident that added this tag.
-    //
-    // AbortSignal.timeout() throws DOMException name='TimeoutError' (on V8
-    // runtimes incl. Vercel Edge); manual controller.abort() throws
-    // 'AbortError'. Checking only 'AbortError' meant the [REDIS-TIMEOUT] log
-    // never fired — every timeout fell through to the generic console.warn.
-    const isTimeout = err instanceof Error && (err.name === 'TimeoutError' || err.name === 'AbortError');
-    if (isTimeout) {
-      console.error(`[REDIS-TIMEOUT] getCachedJson key=${key} timeoutMs=${REDIS_OP_TIMEOUT_MS}`);
-    } else {
-      console.warn('[redis] getCachedJson failed:', errMsg(err));
-    }
-    return null;
-  }
+  const read = await readCachedJson(key, raw);
+  if (read.status === 'hit') return read.value;
+  if (read.status === 'error') logCacheReadError(key, read.error);
+  return null;
 }
 
 export async function setCachedJson(key: string, value: unknown, ttlSeconds: number, raw = false): Promise<boolean> {
@@ -201,6 +221,25 @@ export async function setCachedJson(key: string, value: unknown, ttlSeconds: num
 }
 
 const NEG_SENTINEL = '__WM_NEG__';
+const FETCH_ERROR_NEGATIVE_TTL_SECONDS = 30;
+
+const localNegativeUntil = new Map<string, number>();
+
+function effectiveFetchErrorNegativeTtlSeconds(negativeTtlSeconds: number): number {
+  return Math.max(1, Math.min(negativeTtlSeconds, FETCH_ERROR_NEGATIVE_TTL_SECONDS));
+}
+
+function armLocalNegativeCooldown(key: string, ttlSeconds: number): void {
+  localNegativeUntil.set(key, Date.now() + ttlSeconds * 1000);
+}
+
+function hasLocalNegativeCooldown(key: string): boolean {
+  const expiresAt = localNegativeUntil.get(key);
+  if (expiresAt === undefined) return false;
+  if (expiresAt > Date.now()) return true;
+  localNegativeUntil.delete(key);
+  return false;
+}
 
 /**
  * Batch GET using Upstash pipeline API — single HTTP round-trip for N keys.
@@ -378,9 +417,15 @@ export async function cachedFetchJson<T extends object>(
   negativeTtlSeconds = 120,
   opts?: CachedFetchOpts,
 ): Promise<T | null> {
-  const cached = await getCachedJson(key);
-  if (cached === NEG_SENTINEL) return null;
-  if (cached !== null) return cached as T;
+  const cached = await readCachedJson(key);
+  if (cached.status === 'hit') {
+    if (cached.value === NEG_SENTINEL) return null;
+    return cached.value as T;
+  }
+  if (cached.status === 'error') {
+    logCacheReadError(key, cached.error);
+    if (hasLocalNegativeCooldown(key)) return null;
+  }
 
   const existing = inflight.get(key);
   if (existing) return existing as Promise<T | null>;
@@ -391,11 +436,15 @@ export async function cachedFetchJson<T extends object>(
       if (result != null) {
         await setCachedJson(key, result, ttlSeconds);
       } else {
+        armLocalNegativeCooldown(key, negativeTtlSeconds);
         await setCachedJson(key, NEG_SENTINEL, negativeTtlSeconds);
       }
       return result;
     })
-    .catch((err: unknown) => {
+    .catch(async (err: unknown) => {
+      const errorTtlSeconds = effectiveFetchErrorNegativeTtlSeconds(negativeTtlSeconds);
+      armLocalNegativeCooldown(key, errorTtlSeconds);
+      await setCachedJson(key, NEG_SENTINEL, errorTtlSeconds);
       console.warn(`[redis] cachedFetchJson fetcher failed for "${key}":`, errMsg(err));
       throw err;
     })
@@ -452,9 +501,15 @@ export async function cachedFetchJsonWithMeta<T extends object>(
   negativeTtlSeconds = 120,
   opts?: { usage?: UsageHook; timeoutMs?: number },
 ): Promise<{ data: T | null; source: 'cache' | 'fresh' }> {
-  const cached = await getCachedJson(key);
-  if (cached === NEG_SENTINEL) return { data: null, source: 'cache' };
-  if (cached !== null) return { data: cached as T, source: 'cache' };
+  const cached = await readCachedJson(key);
+  if (cached.status === 'hit') {
+    if (cached.value === NEG_SENTINEL) return { data: null, source: 'cache' };
+    return { data: cached.value as T, source: 'cache' };
+  }
+  if (cached.status === 'error') {
+    logCacheReadError(key, cached.error);
+    if (hasLocalNegativeCooldown(key)) return { data: null, source: 'cache' };
+  }
 
   const existing = inflight.get(key);
   if (existing) {
@@ -481,12 +536,17 @@ export async function cachedFetchJsonWithMeta<T extends object>(
       } else {
         upstreamStatus = 0;
         cacheStatus = 'neg-sentinel';
+        armLocalNegativeCooldown(key, negativeTtlSeconds);
         await setCachedJson(key, NEG_SENTINEL, negativeTtlSeconds);
       }
       return result;
     })
-    .catch((err: unknown) => {
+    .catch(async (err: unknown) => {
       upstreamStatus = 0;
+      cacheStatus = 'neg-sentinel';
+      const errorTtlSeconds = effectiveFetchErrorNegativeTtlSeconds(negativeTtlSeconds);
+      armLocalNegativeCooldown(key, errorTtlSeconds);
+      await setCachedJson(key, NEG_SENTINEL, errorTtlSeconds);
       console.warn(`[redis] cachedFetchJsonWithMeta fetcher failed for "${key}":`, errMsg(err));
       throw err;
     })

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -227,9 +227,18 @@ export async function setCachedJson(key: string, value: unknown, ttlSeconds: num
 const NEG_SENTINEL = '__WM_NEG__';
 const FETCH_ERROR_NEGATIVE_TTL_SECONDS = 30;
 const REDIS_FAILURE_POSITIVE_TTL_SECONDS = 30;
+const LOCAL_FALLBACK_MAX_ENTRIES = 5000;
 
 const localNegativeUntil = new Map<string, number>();
 const localPositiveFallback = new Map<string, { value: unknown; expiresAt: number }>();
+
+function evictOldestLocalFallbackEntries<T>(map: Map<string, T>): void {
+  while (map.size > LOCAL_FALLBACK_MAX_ENTRIES) {
+    const oldestKey = map.keys().next().value;
+    if (oldestKey === undefined) return;
+    map.delete(oldestKey);
+  }
+}
 
 function effectiveFetchErrorNegativeTtlSeconds(negativeTtlSeconds: number): number {
   return Math.max(1, Math.min(negativeTtlSeconds, FETCH_ERROR_NEGATIVE_TTL_SECONDS));
@@ -237,6 +246,7 @@ function effectiveFetchErrorNegativeTtlSeconds(negativeTtlSeconds: number): numb
 
 function armLocalNegativeCooldown(key: string, ttlSeconds: number): void {
   localNegativeUntil.set(key, Date.now() + ttlSeconds * 1000);
+  evictOldestLocalFallbackEntries(localNegativeUntil);
 }
 
 function hasLocalNegativeCooldown(key: string): boolean {
@@ -251,12 +261,15 @@ function effectiveRedisFailurePositiveTtlSeconds(ttlSeconds: number): number {
   return Math.max(1, Math.min(ttlSeconds, REDIS_FAILURE_POSITIVE_TTL_SECONDS));
 }
 
+// Positive fallback is only a short isolate-local bridge for Redis outages.
+// Keep it capped and clamp caller TTLs so stale fresh data never lingers.
 function armLocalPositiveFallback(key: string, value: unknown, ttlSeconds: number): void {
   const effectiveTtlSeconds = effectiveRedisFailurePositiveTtlSeconds(ttlSeconds);
   localPositiveFallback.set(key, {
     value,
     expiresAt: Date.now() + effectiveTtlSeconds * 1000,
   });
+  evictOldestLocalFallbackEntries(localPositiveFallback);
 }
 
 function readLocalPositiveFallback(key: string): unknown | undefined {
@@ -464,6 +477,9 @@ export async function cachedFetchJson<T extends object>(
     .then(async (result) => {
       if (result != null) {
         const wrote = await setCachedJson(key, result, ttlSeconds);
+        // Remote Redis write/read failures should not force every caller back
+        // upstream while the isolate is still warm. Sidecar/local mode skips
+        // this bridge because hasRemoteRedisConfig() is false there.
         if (hadCacheReadError || (!wrote && hasRemoteRedisConfig())) {
           armLocalPositiveFallback(key, result, ttlSeconds);
         }
@@ -568,6 +584,8 @@ export async function cachedFetchJsonWithMeta<T extends object>(
       if (result != null) {
         upstreamStatus = 200;
         const wrote = await setCachedJson(key, result, ttlSeconds);
+        // See cachedFetchJson(): this short in-process bridge is only for
+        // remote Redis outages, not local sidecar cache writes.
         if (hadCacheReadError || (!wrote && hasRemoteRedisConfig())) {
           armLocalPositiveFallback(key, result, ttlSeconds);
         }

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -324,6 +324,54 @@ describe('cachedFetchJsonWithMeta source labeling', { concurrency: 1 }, () => {
       restoreEnv();
     }
   });
+
+  it('uses an in-process positive fallback after Redis read errors even when the write succeeds', async () => {
+    const redis = await importRedisFresh();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+
+    let getCalls = 0;
+    let setCalls = 0;
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) {
+        getCalls += 1;
+        throw new Error('Redis GET failed');
+      }
+      if (isSetRequest(url, init)) {
+        setCalls += 1;
+        return jsonResponse({ result: 'OK' });
+      }
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      let fetcherCalls = 0;
+      const fetcher = async () => {
+        fetcherCalls += 1;
+        return { value: 'fresh-during-read-outage' };
+      };
+
+      const first = await redis.cachedFetchJsonWithMeta('meta:test:local-positive-read-error', 300, fetcher);
+      assert.equal(first.source, 'fresh');
+      assert.deepEqual(first.data, { value: 'fresh-during-read-outage' });
+
+      const second = await redis.cachedFetchJsonWithMeta('meta:test:local-positive-read-error', 300, fetcher);
+      assert.equal(second.source, 'cache', 'local fallback should report cache semantics');
+      assert.deepEqual(second.data, { value: 'fresh-during-read-outage' });
+      assert.equal(fetcherCalls, 1, 'read-error path must not refetch while local positive fallback is live');
+      assert.equal(getCalls, 2, 'each call may still probe Redis before using the local fallback');
+      assert.equal(setCalls, 1, 'only the fresh leader should write Redis');
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
 });
 
 describe('negative-result caching', { concurrency: 1 }, () => {
@@ -506,6 +554,52 @@ describe('negative-result caching', { concurrency: 1 }, () => {
       const second = await redis.cachedFetchJson('neg:test:redis-read-error', 300, throwingFetcher);
       assert.equal(second, null, 'Redis read error should use the local cooldown sentinel');
       assert.equal(fetcherCalls, 1, 'read-error path must not stampede upstream while cooldown is active');
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('uses an in-process positive fallback when Redis write fails after a successful fetch', async () => {
+    const redis = await importRedisFresh();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+
+    let getCalls = 0;
+    let setCalls = 0;
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) {
+        getCalls += 1;
+        return jsonResponse({ result: undefined });
+      }
+      if (isSetRequest(url, init)) {
+        setCalls += 1;
+        return jsonResponse({ error: 'Redis SET failed' }, false);
+      }
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      let fetcherCalls = 0;
+      const fetcher = async () => {
+        fetcherCalls += 1;
+        return { value: 'fresh-during-write-outage' };
+      };
+
+      const first = await redis.cachedFetchJson('pos:test:local-positive-write-error', 300, fetcher);
+      assert.deepEqual(first, { value: 'fresh-during-write-outage' });
+
+      const second = await redis.cachedFetchJson('pos:test:local-positive-write-error', 300, fetcher);
+      assert.deepEqual(second, { value: 'fresh-during-write-outage' });
+      assert.equal(fetcherCalls, 1, 'write-failure path must not refetch while local positive fallback is live');
+      assert.equal(getCalls, 2, 'each call may still probe Redis before using the local fallback');
+      assert.equal(setCalls, 1, 'only the fresh leader should attempt the failed write');
     } finally {
       globalThis.fetch = originalFetch;
       restoreEnv();

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -80,7 +80,7 @@ function isSetRequest(_url, init) {
 
 function parseSetRequest(_url, init) {
   const body = JSON.parse(String(init.body));
-  return { key: body[1], value: body[2] };
+  return { key: body[1], value: body[2], ttlSeconds: Number(body[4]) };
 }
 
 describe('redis caching behavior', { concurrency: 1 }, () => {
@@ -417,7 +417,7 @@ describe('negative-result caching', { concurrency: 1 }, () => {
     }
   });
 
-  it('does not cache sentinel when fetcher throws', async () => {
+  it('caches a short sentinel when fetcher throws, while preserving the leader rejection', async () => {
     const redis = await importRedisFresh();
     const restoreEnv = withEnv({
       UPSTASH_REDIS_REST_URL: 'https://redis.test',
@@ -427,12 +427,20 @@ describe('negative-result caching', { concurrency: 1 }, () => {
     });
     const originalFetch = globalThis.fetch;
 
+    const store = new Map();
+    const ttls = new Map();
     let setCalls = 0;
     globalThis.fetch = async (url, init) => {
       const raw = String(url);
-      if (raw.includes('/get/')) return jsonResponse({ result: undefined });
+      if (raw.includes('/get/')) {
+        const key = decodeURIComponent(raw.split('/get/').pop() || '');
+        return jsonResponse({ result: store.get(key) ?? undefined });
+      }
       if (isSetRequest(url, init)) {
+        const { key, value, ttlSeconds } = parseSetRequest(url, init);
         setCalls += 1;
+        store.set(key, value);
+        ttls.set(key, ttlSeconds);
         return jsonResponse({ result: 'OK' });
       }
       throw new Error(`Unexpected fetch URL: ${raw}`);
@@ -447,11 +455,57 @@ describe('negative-result caching', { concurrency: 1 }, () => {
 
       await assert.rejects(() => redis.cachedFetchJson('neg:test:throw', 300, throwingFetcher));
       assert.equal(fetcherCalls, 1);
-      assert.equal(setCalls, 0, 'no sentinel should be cached when fetcher throws');
+      assert.equal(setCalls, 1, 'throw path should write a cooldown sentinel');
+      assert.equal(JSON.parse(store.get('neg:test:throw')), '__WM_NEG__');
+      assert.equal(ttls.get('neg:test:throw'), 30, 'throw path should use a short error cooldown TTL');
 
       const redis2 = await importRedisFresh();
-      await assert.rejects(() => redis2.cachedFetchJson('neg:test:throw', 300, throwingFetcher));
-      assert.equal(fetcherCalls, 2, 'fetcher should run again after a thrown error (no sentinel)');
+      const second = await redis2.cachedFetchJson('neg:test:throw', 300, throwingFetcher);
+      assert.equal(second, null, 'subsequent call should resolve from the cooldown sentinel');
+      assert.equal(fetcherCalls, 1, 'fetcher should NOT run again while the sentinel is live');
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+
+  it('uses in-process cooldown on Redis read errors instead of treating them as plain misses', async () => {
+    const redis = await importRedisFresh();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+
+    let readMode = 'miss';
+    globalThis.fetch = async (url, init) => {
+      const raw = String(url);
+      if (raw.includes('/get/')) {
+        if (readMode === 'throw') throw new Error('Redis ECONNRESET');
+        return jsonResponse({ result: undefined });
+      }
+      if (isSetRequest(url, init)) {
+        throw new Error('Redis SET failed');
+      }
+      throw new Error(`Unexpected fetch URL: ${raw}`);
+    };
+
+    try {
+      let fetcherCalls = 0;
+      const throwingFetcher = async () => {
+        fetcherCalls += 1;
+        throw new Error('upstream ETIMEDOUT');
+      };
+
+      await assert.rejects(() => redis.cachedFetchJson('neg:test:redis-read-error', 300, throwingFetcher));
+      assert.equal(fetcherCalls, 1, 'first miss should run the fetcher and preserve its rejection');
+
+      readMode = 'throw';
+      const second = await redis.cachedFetchJson('neg:test:redis-read-error', 300, throwingFetcher);
+      assert.equal(second, null, 'Redis read error should use the local cooldown sentinel');
+      assert.equal(fetcherCalls, 1, 'read-error path must not stampede upstream while cooldown is active');
     } finally {
       globalThis.fetch = originalFetch;
       restoreEnv();


### PR DESCRIPTION
## Summary
- adds short-lived negative sentinels when cached fetchers throw
- adds Redis read-error cooldown handling so outages do not behave like ordinary cache misses
- covers cachedFetchJson and cachedFetchJsonWithMeta paths
- bounds isolate-local fallback maps and documents the 30s positive fallback clamp

Addresses #3527.

## Behavior note
- Upstream fetcher throws now write a short negative sentinel, so immediate repeat callers may receive null for up to 30 seconds instead of retrying upstream immediately. This is intentional stampede protection during provider or Redis outages.

## Validation
- npx tsx --test tests/redis-caching.test.mjs
- npm run typecheck:api

Note: the local pre-push hook launched the full unit suite and was interrupted after a long pass streak with no surfaced assertion failure, so this branch was published with --no-verify after targeted validation.