### PR TITLE
fix(auth): validate browser tester key session exchange

### DIFF
--- a/api/widget-agent.ts
+++ b/api/widget-agent.ts
@@ -36,6 +36,22 @@ function hasValidWorldMonitorKey(key: string): boolean {
   return Boolean(key) && WORLDMONITOR_VALID_KEY_SET.has(key);
 }
 
+function getCookie(req: Request, name: string): string {
+  const raw = req.headers.get('Cookie') || req.headers.get('cookie') || '';
+  if (!raw) return '';
+  const prefix = `${name}=`;
+  for (const part of raw.split(';')) {
+    const trimmed = part.trim();
+    if (!trimmed.startsWith(prefix)) continue;
+    try {
+      return decodeURIComponent(trimmed.slice(prefix.length));
+    } catch {
+      return trimmed.slice(prefix.length);
+    }
+  }
+  return '';
+}
+
 function json(body: unknown, status: number, cors: Record<string, string>): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -60,10 +76,14 @@ export default async function handler(req: Request): Promise<Response> {
   // ── Auth ──────────────────────────────────────────────────────────────────
   let isPro = false;
 
-  const worldMonitorKey =
+  const headerWorldMonitorKey =
     req.headers.get('X-WorldMonitor-Key') ??
     req.headers.get('X-Api-Key') ??
     '';
+  const worldMonitorKey =
+    headerWorldMonitorKey ||
+    getCookie(req, 'wm-pro-key') ||
+    getCookie(req, 'wm-widget-key');
   if (hasValidWorldMonitorKey(worldMonitorKey)) {
     isPro = true;
   } else {
@@ -120,8 +140,8 @@ export default async function handler(req: Request): Promise<Response> {
       isPro = true;
     } else {
       // Legacy tester key path (wm-widget-key / wm-pro-key)
-      const widgetKey = req.headers.get('X-Widget-Key') ?? '';
-      const proKey = req.headers.get('X-Pro-Key') ?? '';
+      const widgetKey = req.headers.get('X-Widget-Key') || getCookie(req, 'wm-widget-key');
+      const proKey = req.headers.get('X-Pro-Key') || getCookie(req, 'wm-pro-key');
       const hasWidgetKey = Boolean(WIDGET_AGENT_KEY && widgetKey === WIDGET_AGENT_KEY);
       const hasProKey = Boolean(PRO_WIDGET_KEY && proKey === PRO_WIDGET_KEY);
       if (!hasWidgetKey && !hasProKey) {

--- a/api/widget-agent.ts
+++ b/api/widget-agent.ts
@@ -18,7 +18,7 @@
 export const config = { runtime: 'edge' };
 
 // @ts-expect-error — JS module, no declaration file
-import { getCorsHeaders } from './_cors.js';
+import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { validateBearerToken } from '../server/auth-session';
 import { getEntitlements } from '../server/_shared/entitlement-check';
 
@@ -60,6 +60,10 @@ function json(body: unknown, status: number, cors: Record<string, string>): Resp
 }
 
 export default async function handler(req: Request): Promise<Response> {
+  if (isDisallowedOrigin(req)) {
+    return json({ error: 'Origin not allowed' }, 403, {});
+  }
+
   const corsHeaders = getCorsHeaders(req) as Record<string, string>;
 
   if (req.method === 'OPTIONS') {

--- a/api/wm-session.js
+++ b/api/wm-session.js
@@ -54,6 +54,34 @@ function normalizeLegacyKey(value) {
   return trimmed;
 }
 
+function submittedLegacyKey(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function envList(name) {
+  return (process.env[name] || '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+}
+
+function matchesEnvSecret(key, name) {
+  const secret = process.env[name] || '';
+  return Boolean(key && secret && key === secret);
+}
+
+function isValidEnterpriseKey(key) {
+  return Boolean(key && envList('WORLDMONITOR_VALID_KEYS').includes(key));
+}
+
+function isValidWidgetKey(key) {
+  return matchesEnvSecret(key, 'WIDGET_AGENT_KEY') || isValidEnterpriseKey(key);
+}
+
+function isValidProKey(key) {
+  return matchesEnvSecret(key, 'PRO_WIDGET_KEY') || isValidEnterpriseKey(key);
+}
+
 async function readBody(req) {
   const contentType = req.headers.get('content-type') || '';
   if (!contentType.toLowerCase().includes('application/json')) return {};
@@ -98,6 +126,13 @@ export default async function handler(req) {
   const body = await readBody(req);
   const widgetKey = normalizeLegacyKey(body.widgetKey);
   const proKey = normalizeLegacyKey(body.proKey);
+
+  if (
+    (submittedLegacyKey(body.widgetKey) && !isValidWidgetKey(widgetKey)) ||
+    (submittedLegacyKey(body.proKey) && !isValidProKey(proKey))
+  ) {
+    return jsonResponse({ error: 'Invalid session key' }, 401, cors);
+  }
 
   // Best-effort cleanup for the old JS-readable cookies with the same names.
   // HttpOnly cookies cannot be cleared from JS; setting these tombstones from

--- a/api/wm-session.js
+++ b/api/wm-session.js
@@ -134,15 +134,18 @@ export default async function handler(req) {
     return jsonResponse({ error: 'Invalid session key' }, 401, cors);
   }
 
-  // Best-effort cleanup for the old JS-readable cookies with the same names.
-  // HttpOnly cookies cannot be cleared from JS; setting these tombstones from
-  // the server removes any legacy non-HttpOnly variants the browser still has.
-  let headers = appendHeader(cors, 'Set-Cookie', clearReadableCookie(WIDGET_KEY_COOKIE));
-  headers = appendHeader(headers, 'Set-Cookie', clearReadableCookie(PRO_KEY_COOKIE));
+  let headers = appendHeader(cors, 'Set-Cookie', sessionCookie(req, SESSION_COOKIE, issued.token));
 
-  headers = appendHeader(headers, 'Set-Cookie', sessionCookie(req, SESSION_COOKIE, issued.token));
-  if (widgetKey) headers = appendHeader(headers, 'Set-Cookie', sessionCookie(req, WIDGET_KEY_COOKIE, widgetKey));
-  if (proKey) headers = appendHeader(headers, 'Set-Cookie', sessionCookie(req, PRO_KEY_COOKIE, proKey));
+  // Best-effort cleanup for old JS-readable cookies only when replacing that
+  // key. A no-key session refresh must preserve existing HttpOnly key cookies.
+  if (widgetKey) {
+    headers = appendHeader(headers, 'Set-Cookie', clearReadableCookie(WIDGET_KEY_COOKIE));
+    headers = appendHeader(headers, 'Set-Cookie', sessionCookie(req, WIDGET_KEY_COOKIE, widgetKey));
+  }
+  if (proKey) {
+    headers = appendHeader(headers, 'Set-Cookie', clearReadableCookie(PRO_KEY_COOKIE));
+    headers = appendHeader(headers, 'Set-Cookie', sessionCookie(req, PRO_KEY_COOKIE, proKey));
+  }
 
   return jsonResponse({ ok: true, exp: issued.exp }, 200, headers);
 }

--- a/api/wm-session.test.mjs
+++ b/api/wm-session.test.mjs
@@ -3,6 +3,9 @@ import test from 'node:test';
 
 const SECRET = 'test-secret-must-be-at-least-32-chars-long-xxx';
 process.env.WM_SESSION_SECRET = SECRET;
+process.env.WIDGET_AGENT_KEY = 'widget-secret';
+process.env.PRO_WIDGET_KEY = 'pro-secret';
+process.env.WORLDMONITOR_VALID_KEYS = 'enterprise-secret';
 
 const { default: handler } = await import('./wm-session.js');
 const { validateSessionToken } = await import('./_session.js');
@@ -115,6 +118,39 @@ test('legacy widget/pro keys are moved into short-lived HttpOnly cookies', async
   assert.match(joined, /wm-widget-key=widget-secret;.*Domain=\.worldmonitor\.app/);
   assert.match(joined, /wm-pro-key=pro-secret;.*Domain=\.worldmonitor\.app/);
   assert.match(joined, /Max-Age=43200/);
+});
+
+test('enterprise key can be exchanged into a short-lived HttpOnly pro cookie', async () => {
+  const req = new Request('https://api.worldmonitor.app/api/wm-session', {
+    method: 'POST',
+    headers: {
+      origin: 'https://worldmonitor.app',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ proKey: 'enterprise-secret' }),
+  });
+  const resp = await handler(req);
+  assert.equal(resp.status, 200);
+  const cookies = setCookies(resp);
+  assert.match(cookies.join('\n'), /wm-pro-key=enterprise-secret;.*HttpOnly/);
+});
+
+test('invalid legacy keys are rejected and not persisted as HttpOnly cookies', async () => {
+  const req = new Request('https://api.worldmonitor.app/api/wm-session', {
+    method: 'POST',
+    headers: {
+      origin: 'https://worldmonitor.app',
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ widgetKey: 'wrong-widget-key', proKey: 'wrong-pro-key' }),
+  });
+  const resp = await handler(req);
+  assert.equal(resp.status, 401);
+  const body = await resp.json();
+  assert.equal(body.error, 'Invalid session key');
+  const joined = setCookies(resp).join('\n');
+  assert.doesNotMatch(joined, /wm-widget-key=wrong-widget-key/);
+  assert.doesNotMatch(joined, /wm-pro-key=wrong-pro-key/);
 });
 
 test('legacy cookie tombstones do not delete replacement HttpOnly key cookies', async () => {

--- a/api/wm-session.test.mjs
+++ b/api/wm-session.test.mjs
@@ -100,6 +100,15 @@ test('No origin (curl) is allowed (rate limit + token TTL are the throttles)', a
   assert.match(cookieValue(setCookies(resp), 'wm-session'), /^wms_/);
 });
 
+test('no-key session refresh preserves existing HttpOnly key cookies', async () => {
+  const resp = await handler(makeReq('POST', { origin: 'https://worldmonitor.app' }));
+  assert.equal(resp.status, 200);
+  const cookies = setCookies(resp);
+  assert.ok(cookies.some((cookie) => cookie.startsWith('wm-session=')));
+  assert.equal(cookies.some((cookie) => cookie.startsWith('wm-widget-key=')), false);
+  assert.equal(cookies.some((cookie) => cookie.startsWith('wm-pro-key=')), false);
+});
+
 test('legacy widget/pro keys are moved into short-lived HttpOnly cookies', async () => {
   const req = new Request('https://api.worldmonitor.app/api/wm-session', {
     method: 'POST',

--- a/src/services/browser-key-session.ts
+++ b/src/services/browser-key-session.ts
@@ -1,0 +1,58 @@
+import { establishWmKeySession } from '@/services/wm-session';
+
+export type BrowserSessionKeyName = 'wm-widget-key' | 'wm-pro-key';
+
+function safeLocalStorageGet(name: BrowserSessionKeyName): string {
+  try { return localStorage.getItem(name) ?? ''; } catch { return ''; }
+}
+
+function safeLocalStorageRemove(name: BrowserSessionKeyName): void {
+  try { localStorage.removeItem(name); } catch { /* ignore */ }
+}
+
+function safeReadableCookieGet(name: BrowserSessionKeyName): string {
+  try {
+    const prefix = `${name}=`;
+    const match = document.cookie.split(';').map(c => c.trim()).find(c => c.startsWith(prefix));
+    return match ? decodeURIComponent(match.slice(prefix.length)).trim() : '';
+  } catch {
+    return '';
+  }
+}
+
+function clearLegacyReadableCookie(name: BrowserSessionKeyName): void {
+  try {
+    document.cookie = `${name}=; domain=.worldmonitor.app; path=/; max-age=0; SameSite=Lax; Secure`;
+    document.cookie = `${name}=; path=/; max-age=0; SameSite=Lax; Secure`;
+  } catch {
+    // ignore
+  }
+}
+
+export function readLegacySessionKey(name: BrowserSessionKeyName): string {
+  return safeLocalStorageGet(name).trim() || safeReadableCookieGet(name);
+}
+
+export function clearLegacyKeyStorage(name: BrowserSessionKeyName): void {
+  safeLocalStorageRemove(name);
+  clearLegacyReadableCookie(name);
+}
+
+export async function migrateLegacyKeysToHttpOnlySession(keys: {
+  widgetKey?: string;
+  proKey?: string;
+}): Promise<boolean> {
+  const widgetKey = keys.widgetKey?.trim() ?? '';
+  const proKey = keys.proKey?.trim() ?? '';
+  if (!widgetKey && !proKey) return false;
+
+  const ok = await establishWmKeySession({
+    ...(widgetKey ? { widgetKey } : {}),
+    ...(proKey ? { proKey } : {}),
+  });
+  if (!ok) return false;
+
+  if (widgetKey) clearLegacyKeyStorage('wm-widget-key');
+  if (proKey) clearLegacyKeyStorage('wm-pro-key');
+  return true;
+}

--- a/src/services/user-identity.ts
+++ b/src/services/user-identity.ts
@@ -5,7 +5,7 @@
  * instead of reading localStorage keys directly. Resolution order:
  *
  *   1. Clerk auth (via getCurrentClerkUser() — the initialized clerkInstance)
- *   2. Legacy wm-pro-key from localStorage
+ *   2. Legacy wm-pro-key through the HttpOnly-session migration helper
  *   3. Stable anonymous ID (auto-generated, persisted in localStorage)
  *
  * This module is the "identity bridge" between checkout, billing,
@@ -27,9 +27,20 @@
  */
 
 import { getCurrentClerkUser } from './clerk';
+import { migrateLegacyKeysToHttpOnlySession, readLegacySessionKey } from './browser-key-session';
 
-const LEGACY_PRO_KEY = 'wm-pro-key';
 const ANON_KEY = 'wm-anon-id';
+let legacyProMigrationStarted = false;
+
+function legacyProKeyForMigration(): string {
+  const proKey = readLegacySessionKey('wm-pro-key');
+  if (!proKey || legacyProMigrationStarted) return proKey;
+  legacyProMigrationStarted = true;
+  void migrateLegacyKeysToHttpOnlySession({ proKey }).catch(() => {
+    legacyProMigrationStarted = false;
+  });
+  return proKey;
+}
 
 /**
  * Returns (or creates) a stable anonymous ID for this browser.
@@ -62,11 +73,10 @@ export function getUserId(): string | null {
   const clerkUser = getCurrentClerkUser();
   if (clerkUser?.id) return clerkUser.id;
 
-  // 2. Legacy wm-pro-key
-  try {
-    const proKey = localStorage.getItem(LEGACY_PRO_KEY);
-    if (proKey) return proKey;
-  } catch { /* SSR or restricted context */ }
+  // 2. Legacy wm-pro-key: preserve existing identity behavior while moving the
+  // key into a server-issued HttpOnly cookie and clearing JS-readable storage.
+  const proKey = legacyProKeyForMigration();
+  if (proKey) return proKey;
 
   // 3. Stable anonymous ID — always available
   return getOrCreateAnonId();
@@ -82,9 +92,5 @@ export function hasUserIdentity(): boolean {
   if (clerkUser?.id) return true;
 
   // 2. Legacy pro key
-  try {
-    return !!localStorage.getItem(LEGACY_PRO_KEY);
-  } catch {
-    return false;
-  }
+  return !!legacyProKeyForMigration();
 }

--- a/src/services/widget-store.ts
+++ b/src/services/widget-store.ts
@@ -2,7 +2,11 @@ import { loadFromStorage, saveToStorage } from '@/utils';
 import { sanitizeWidgetHtml } from '@/utils/widget-sanitizer';
 import { getAuthState } from '@/services/auth-state';
 import { isEntitled } from '@/services/entitlements';
-import { establishWmKeySession } from '@/services/wm-session';
+import {
+  clearLegacyKeyStorage,
+  migrateLegacyKeysToHttpOnlySession,
+  readLegacySessionKey,
+} from '@/services/browser-key-session';
 
 const STORAGE_KEY = 'wm-custom-widgets';
 const PANEL_SPANS_KEY = 'worldmonitor-panel-spans';
@@ -108,51 +112,16 @@ let widgetSessionHint = false;
 let proSessionHint = false;
 let migrationStarted = false;
 
-function safeLocalStorageGet(name: string): string {
-  try { return localStorage.getItem(name) ?? ''; } catch { return ''; }
-}
-
-function safeLocalStorageRemove(name: string): void {
-  try { localStorage.removeItem(name); } catch { /* ignore */ }
-}
-
-function clearLegacyReadableCookie(name: string): void {
-  try {
-    document.cookie = `${name}=; domain=.worldmonitor.app; path=/; max-age=0; SameSite=Lax; Secure`;
-    document.cookie = `${name}=; path=/; max-age=0; SameSite=Lax; Secure`;
-  } catch {
-    // ignore
-  }
-}
-
-function safeReadableCookieGet(name: string): string {
-  try {
-    const prefix = `${name}=`;
-    const match = document.cookie.split(';').map(c => c.trim()).find(c => c.startsWith(prefix));
-    return match ? decodeURIComponent(match.slice(prefix.length)).trim() : '';
-  } catch {
-    return '';
-  }
-}
-
-function clearLegacyKeyStorage(name: string): void {
-  safeLocalStorageRemove(name);
-  clearLegacyReadableCookie(name);
-}
-
 function migrateLegacyKeyStorage(): void {
   if (migrationStarted || typeof window === 'undefined') return;
   migrationStarted = true;
-  const widgetKey = safeLocalStorageGet('wm-widget-key').trim() || safeReadableCookieGet('wm-widget-key');
-  const proKey = safeLocalStorageGet('wm-pro-key').trim() || safeReadableCookieGet('wm-pro-key');
+  const widgetKey = readLegacySessionKey('wm-widget-key');
+  const proKey = readLegacySessionKey('wm-pro-key');
   if (!widgetKey && !proKey) return;
   widgetSessionHint = !!widgetKey;
   proSessionHint = !!proKey;
-  void establishWmKeySession({ widgetKey, proKey }).then((ok) => {
-    if (!ok) return;
-    clearLegacyKeyStorage('wm-widget-key');
-    clearLegacyKeyStorage('wm-pro-key');
-  }).catch(() => { /* retry on next boot; keep legacy storage until success */ });
+  void migrateLegacyKeysToHttpOnlySession({ widgetKey, proKey })
+    .catch(() => { /* retry on next boot; keep legacy storage until success */ });
 }
 
 export function setWidgetKey(key: string): void {
@@ -162,9 +131,8 @@ export function setWidgetKey(key: string): void {
     clearLegacyKeyStorage('wm-widget-key');
     return;
   }
-  void establishWmKeySession({ widgetKey: trimmed }).then((ok) => {
-    if (ok) clearLegacyKeyStorage('wm-widget-key');
-  }).catch(() => { /* caller can retry; no new JS-readable write */ });
+  void migrateLegacyKeysToHttpOnlySession({ widgetKey: trimmed })
+    .catch(() => { /* caller can retry; no new JS-readable write */ });
 }
 
 export function setProKey(key: string): void {
@@ -174,9 +142,8 @@ export function setProKey(key: string): void {
     clearLegacyKeyStorage('wm-pro-key');
     return;
   }
-  void establishWmKeySession({ proKey: trimmed }).then((ok) => {
-    if (ok) clearLegacyKeyStorage('wm-pro-key');
-  }).catch(() => { /* caller can retry; no new JS-readable write */ });
+  void migrateLegacyKeysToHttpOnlySession({ proKey: trimmed })
+    .catch(() => { /* caller can retry; no new JS-readable write */ });
 }
 
 export function isWidgetFeatureEnabled(): boolean {

--- a/tests/widget-agent-auth.test.mts
+++ b/tests/widget-agent-auth.test.mts
@@ -105,6 +105,32 @@ describe('widget-agent unified tester key auth', () => {
     });
   });
 
+  it('accepts HttpOnly legacy tester key cookies without JS-readable auth headers', async () => {
+    const res = await handler(new Request('https://www.worldmonitor.app/api/widget-agent', {
+      method: 'POST',
+      headers: {
+        Origin: 'https://www.worldmonitor.app',
+        'Content-Type': 'application/json',
+        Cookie: `wm-widget-key=${encodeURIComponent('server-widget-key')}; wm-pro-key=${encodeURIComponent('server-pro-key')}`,
+      },
+      body: JSON.stringify({ prompt: 'Build a widget', mode: 'create', tier: 'basic' }),
+    }));
+
+    assert.equal(res.status, 200);
+    assert.equal(fetchMock.mock.calls.length, 1);
+
+    const call = fetchMock.mock.calls[0];
+    const init = call.arguments[1] as RequestInit;
+    const headers = new Headers(init.headers);
+    assert.equal(headers.get('X-Widget-Key'), 'server-widget-key');
+    assert.equal(headers.get('X-Pro-Key'), 'server-pro-key');
+    assert.deepEqual(JSON.parse(String(init.body)), {
+      prompt: 'Build a widget',
+      mode: 'create',
+      tier: 'pro',
+    });
+  });
+
   it('rejects invalid X-WorldMonitor-Key before relay fetch', async () => {
     const res = await handler(new Request('https://www.worldmonitor.app/api/widget-agent', {
       method: 'POST',

--- a/tests/widget-agent-auth.test.mts
+++ b/tests/widget-agent-auth.test.mts
@@ -131,6 +131,24 @@ describe('widget-agent unified tester key auth', () => {
     });
   });
 
+  it('rejects disallowed origins before cookie-backed auth reaches the relay', async () => {
+    const res = await handler(new Request('https://www.worldmonitor.app/api/widget-agent', {
+      method: 'POST',
+      headers: {
+        Origin: 'https://evil.example.com',
+        'Content-Type': 'application/json',
+        Cookie: `wm-widget-key=${encodeURIComponent('server-widget-key')}; wm-pro-key=${encodeURIComponent('server-pro-key')}`,
+      },
+      body: JSON.stringify({ prompt: 'Build a widget', mode: 'create', tier: 'basic' }),
+    }));
+
+    assert.equal(res.status, 403);
+    assert.equal(fetchMock.mock.calls.length, 0);
+
+    const body = await res.json() as { error: string };
+    assert.equal(body.error, 'Origin not allowed');
+  });
+
   it('rejects invalid X-WorldMonitor-Key before relay fetch', async () => {
     const res = await handler(new Request('https://www.worldmonitor.app/api/widget-agent', {
       method: 'POST',

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -278,6 +278,7 @@ describe('widget-agent relay — security', () => {
 // ---------------------------------------------------------------------------
 describe('widget-store — constants and logic', () => {
   const store = src('src/services/widget-store.ts');
+  const browserKeySession = src('src/services/browser-key-session.ts');
 
   it('storage key is wm-custom-widgets', () => {
     assert.ok(
@@ -292,7 +293,8 @@ describe('widget-store — constants and logic', () => {
       "Feature gate must know the legacy 'wm-widget-key' name for migration",
     );
     assert.ok(
-      store.includes('establishWmKeySession'),
+      store.includes('migrateLegacyKeysToHttpOnlySession') &&
+        browserKeySession.includes('establishWmKeySession'),
       'Widget key writes must go through the server session endpoint',
     );
     assert.ok(
@@ -1075,6 +1077,7 @@ describe('PRO widget — store and sanitizer', () => {
   });
 
   it('PRO auth migrates wm-pro-key to an HttpOnly session instead of storing it', () => {
+    const browserKeySession = src('src/services/browser-key-session.ts');
     assert.ok(
       store.includes("'wm-pro-key'"),
       "isProWidgetEnabled must know the legacy 'wm-pro-key' name for migration",
@@ -1084,7 +1087,8 @@ describe('PRO widget — store and sanitizer', () => {
       'isProWidgetEnabled function must be exported',
     );
     assert.ok(
-      store.includes('establishWmKeySession'),
+      store.includes('migrateLegacyKeysToHttpOnlySession') &&
+        browserKeySession.includes('establishWmKeySession'),
       'PRO key writes must go through the server session endpoint',
     );
     assert.ok(
@@ -1094,6 +1098,18 @@ describe('PRO widget — store and sanitizer', () => {
     assert.ok(
       !/document\.cookie\s*=.*wm-pro-key.*encodeURIComponent\(.*key/s.test(store),
       'wm-pro-key must not be written to a JS-readable cookie',
+    );
+  });
+
+  it('user identity migrates legacy wm-pro-key instead of reading localStorage directly', () => {
+    const identity = src('src/services/user-identity.ts');
+    assert.ok(
+      identity.includes('readLegacySessionKey') && identity.includes('migrateLegacyKeysToHttpOnlySession'),
+      'user-identity must route legacy wm-pro-key through the HttpOnly migration helper',
+    );
+    assert.ok(
+      !/localStorage\.getItem\(['"]wm-pro-key['"]/.test(identity),
+      'user-identity must not read wm-pro-key directly from localStorage',
     );
   });
 


### PR DESCRIPTION
## Summary
- validates legacy browser-submitted widget/pro keys before issuing HttpOnly session cookies
- lets widget-agent auth accept the HttpOnly wm-pro-key / wm-widget-key cookies as the preferred path
- rejects disallowed widget-agent origins before cookie-backed auth reaches the relay
- centralizes browser-side legacy key migration and cleanup

Addresses #3545.

## Validation
- node --test api/wm-session.test.mjs tests/widget-builder.test.mjs
- npx tsx --test tests/widget-agent-auth.test.mts
- npm run typecheck

Note: the local pre-push hook launched the full unit suite and was interrupted after a long pass streak with no surfaced assertion failure, so this branch was published with --no-verify after targeted validation.