### PR TITLE
fix(api/latest-brief): retry Upstash read once on transient timeout

### DIFF
--- a/api/latest-brief.ts
+++ b/api/latest-brief.ts
@@ -39,6 +39,58 @@ import { assertBriefEnvelope } from '../server/_shared/brief-render.js';
 // server/_shared/brief-url.ts — the signer rejects anything else.
 const ISSUE_SLOT_RE = /^\d{4}-\d{2}-\d{2}-\d{4}$/;
 
+// Per-attempt timeouts for the cache-read retry helper. Worst-case wall
+// time = FIRST_ATTEMPT_MS + RETRY_ATTEMPT_MS per read × 2 reads = 18s,
+// which leaves headroom under Vercel Edge's ~25s initial-response cap
+// after `validateBearerToken` + `getEntitlements` preflight. Retry uses
+// a shorter budget on the theory that a transient blip clears in <3s; a
+// real Upstash outage will time out the retry quickly and fall through
+// to the 503 fallback before the platform kills the function.
+export const FIRST_ATTEMPT_MS = 6_000;
+export const RETRY_ATTEMPT_MS = 3_000;
+
+// Re-run an Upstash read once if the first attempt aborts on
+// AbortSignal.timeout. Empirically (WORLDMONITOR-QJ — 4 events / 19 days,
+// including a 2026-05-13 same-minute double-fire across us-west + eu-central
+// = real Upstash regional incident) the timeouts come in short clusters
+// rather than sustained outages, so one retry converts the transient blip
+// into a success. The first attempt gets a generous 6s budget; the retry
+// shortens to 3s so total wall time stays bounded under the platform cap.
+//
+// Recovery telemetry: every retry attempt (regardless of outcome) fires
+// a low-cardinality Sentry capture tagged `upstash-retry-attempt` so we
+// retain visibility into "blipped but recovered" frequency. Without this,
+// successful retries would only appear in Vercel logs and we'd lose the
+// signal that informs whether the timeout budget is sized correctly.
+//
+// Duck-types on `err.name === 'TimeoutError'` rather than
+// `err instanceof DOMException` to survive cross-realm cases in test
+// runners where undici's DOMException may differ from globalThis.
+//
+// Exported as a test seam (like `executeTool` in api/mcp/dispatch.ts) so
+// the retry semantics can be asserted directly without standing up Clerk
+// JWT validation + Convex entitlement reads.
+export async function readWithOneRetry<T>(
+  attempt: (timeoutMs: number) => Promise<T>,
+  label: string,
+  ctx?: { waitUntil: (p: Promise<unknown>) => void },
+): Promise<T> {
+  try {
+    return await attempt(FIRST_ATTEMPT_MS);
+  } catch (err) {
+    const name = (err as { name?: string } | null)?.name;
+    if (name === 'TimeoutError') {
+      console.warn(`[api/latest-brief] ${label} aborted on timeout — retrying once (${RETRY_ATTEMPT_MS}ms)`);
+      captureSilentError(err, {
+        tags: { route: 'api/latest-brief', step: 'upstash-retry-attempt', label },
+        ctx,
+      });
+      return await attempt(RETRY_ATTEMPT_MS);
+    }
+    throw err;
+  }
+}
+
 function todayInUtc(): string {
   return new Date().toISOString().slice(0, 10);
 }
@@ -53,9 +105,10 @@ type BriefPreview = {
 async function readBriefPreview(
   userId: string,
   issueSlot: string,
+  timeoutMs: number,
   ctx?: { waitUntil: (p: Promise<unknown>) => void },
 ): Promise<BriefPreview | null> {
-  const raw = await readRawJsonFromUpstash(`brief:${userId}:${issueSlot}`);
+  const raw = await readRawJsonFromUpstash(`brief:${userId}:${issueSlot}`, timeoutMs);
   if (raw == null) return null;
   // Reuse the renderer's strict validator so a "ready" preview never
   // points at an envelope that the hosted magazine route will reject.
@@ -89,8 +142,8 @@ async function readBriefPreview(
  * SETEX. Returns null when no pointer exists (user never received a
  * brief, or the pointer has expired past its 7d TTL).
  */
-async function readLatestPointer(userId: string): Promise<string | null> {
-  const raw = await readRawJsonFromUpstash(`brief:latest:${userId}`);
+async function readLatestPointer(userId: string, timeoutMs: number): Promise<string | null> {
+  const raw = await readRawJsonFromUpstash(`brief:latest:${userId}`, timeoutMs);
   if (raw == null) return null;
   const slot = (raw as { issueSlot?: unknown } | null)?.issueSlot;
   if (typeof slot !== 'string' || !ISSUE_SLOT_RE.test(slot)) return null;
@@ -168,12 +221,28 @@ export default async function handler(
   const requestedSlot =
     slotParam !== null && ISSUE_SLOT_RE.test(slotParam) ? slotParam : null;
 
+  // Hoist the narrowed userId so the retry-helper arrow closures capture a
+  // `string` rather than `string | undefined` — TypeScript's narrowing on
+  // `session.userId` (guarded above at the UNAUTHENTICATED gate) does not
+  // survive into closure capture sites.
+  const userId: string = session.userId;
+
   let issueSlot: string | null = null;
   let preview: BriefPreview | null = null;
   try {
-    const targetSlot = requestedSlot ?? (await readLatestPointer(session.userId));
+    const targetSlot =
+      requestedSlot ??
+      (await readWithOneRetry(
+        (timeoutMs) => readLatestPointer(userId, timeoutMs),
+        'readLatestPointer',
+        ctx,
+      ));
     if (targetSlot) {
-      const hit = await readBriefPreview(session.userId, targetSlot, ctx);
+      const hit = await readWithOneRetry(
+        (timeoutMs) => readBriefPreview(userId, targetSlot, timeoutMs, ctx),
+        'readBriefPreview',
+        ctx,
+      );
       if (hit) {
         issueSlot = targetSlot;
         preview = hit;

--- a/api/latest-brief.ts
+++ b/api/latest-brief.ts
@@ -63,7 +63,7 @@ export const RETRY_ATTEMPT_MS = 3_000;
 // successful retries would only appear in Vercel logs and we'd lose the
 // signal that informs whether the timeout budget is sized correctly.
 //
-// Duck-types on `err.name === 'TimeoutError'` rather than
+// Duck-types on abort-like `err.name` values rather than
 // `err instanceof DOMException` to survive cross-realm cases in test
 // runners where undici's DOMException may differ from globalThis.
 //
@@ -79,7 +79,7 @@ export async function readWithOneRetry<T>(
     return await attempt(FIRST_ATTEMPT_MS);
   } catch (err) {
     const name = (err as { name?: string } | null)?.name;
-    if (name === 'TimeoutError') {
+    if (name === 'TimeoutError' || name === 'AbortError') {
       console.warn(`[api/latest-brief] ${label} aborted on timeout — retrying once (${RETRY_ATTEMPT_MS}ms)`);
       captureSilentError(err, {
         tags: { route: 'api/latest-brief', step: 'upstash-retry-attempt', label },

--- a/tests/brief-edge-route-smoke.test.mjs
+++ b/tests/brief-edge-route-smoke.test.mjs
@@ -266,3 +266,84 @@ describe('assertBriefEnvelope is shared between renderer and preview', () => {
     assert.throws(() => assertBriefEnvelope(partial), /digest\.numbers/);
   });
 });
+
+describe('api/latest-brief retry-on-Upstash-timeout', () => {
+  // Regression guard for WORLDMONITOR-QJ. Locks in the retry contract:
+  // (a) one retry fires on DOMException-like `name === 'TimeoutError'`,
+  // (b) no retry on other error shapes, (c) per-attempt budgets are
+  // FIRST_ATTEMPT_MS then RETRY_ATTEMPT_MS so worst-case wall time stays
+  // under Vercel Edge's response cap. If the err-name check or attempt
+  // budgets are refactored these tests must update — they're the source
+  // of truth for the retry semantics.
+
+  it('retries once on TimeoutError and returns the second attempt result', async () => {
+    const { readWithOneRetry } = await import('../api/latest-brief.ts');
+    let calls = 0;
+    const attempt = async () => {
+      calls += 1;
+      if (calls === 1) {
+        const err = new Error('The operation was aborted due to timeout');
+        err.name = 'TimeoutError';
+        throw err;
+      }
+      return 'second-attempt-payload';
+    };
+    const out = await readWithOneRetry(attempt, 'test-label');
+    assert.equal(calls, 2, 'helper must invoke the attempt twice on TimeoutError');
+    assert.equal(out, 'second-attempt-payload');
+  });
+
+  it('does NOT retry on non-TimeoutError (preserves fast-fail on real bugs)', async () => {
+    const { readWithOneRetry } = await import('../api/latest-brief.ts');
+    let calls = 0;
+    const attempt = async () => {
+      calls += 1;
+      throw new Error('readRawJsonFromUpstash: Upstash GET key returned HTTP 500');
+    };
+    await assert.rejects(
+      () => readWithOneRetry(attempt, 'test-label'),
+      /HTTP 500/,
+    );
+    assert.equal(calls, 1, 'non-Timeout error must surface on first attempt without retry');
+  });
+
+  it('re-throws when BOTH attempts fail with TimeoutError (503 fallback path)', async () => {
+    const { readWithOneRetry } = await import('../api/latest-brief.ts');
+    let calls = 0;
+    const attempt = async () => {
+      calls += 1;
+      const err = new Error('The operation was aborted due to timeout');
+      err.name = 'TimeoutError';
+      throw err;
+    };
+    await assert.rejects(
+      () => readWithOneRetry(attempt, 'test-label'),
+      /aborted due to timeout/,
+    );
+    assert.equal(calls, 2, 'helper must exhaust exactly two attempts on sustained outage');
+  });
+
+  it('first attempt receives FIRST_ATTEMPT_MS, retry receives RETRY_ATTEMPT_MS', async () => {
+    const mod = await import('../api/latest-brief.ts');
+    const observed = [];
+    const attempt = async (timeoutMs) => {
+      observed.push(timeoutMs);
+      if (observed.length === 1) {
+        const err = new Error('The operation was aborted due to timeout');
+        err.name = 'TimeoutError';
+        throw err;
+      }
+      return null;
+    };
+    await mod.readWithOneRetry(attempt, 'test-label');
+    assert.deepEqual(
+      observed,
+      [mod.FIRST_ATTEMPT_MS, mod.RETRY_ATTEMPT_MS],
+      'per-attempt budgets must shrink on retry to bound worst-case wall time',
+    );
+    // Sanity-check the absolute values so a future bump above the Vercel
+    // Edge response cap is loudly caught.
+    assert.equal(mod.FIRST_ATTEMPT_MS, 6_000);
+    assert.equal(mod.RETRY_ATTEMPT_MS, 3_000);
+  });
+});

--- a/tests/brief-edge-route-smoke.test.mjs
+++ b/tests/brief-edge-route-smoke.test.mjs
@@ -269,7 +269,7 @@ describe('assertBriefEnvelope is shared between renderer and preview', () => {
 
 describe('api/latest-brief retry-on-Upstash-timeout', () => {
   // Regression guard for WORLDMONITOR-QJ. Locks in the retry contract:
-  // (a) one retry fires on DOMException-like `name === 'TimeoutError'`,
+  // (a) one retry fires on DOMException-like timeout/abort names,
   // (b) no retry on other error shapes, (c) per-attempt budgets are
   // FIRST_ATTEMPT_MS then RETRY_ATTEMPT_MS so worst-case wall time stays
   // under Vercel Edge's response cap. If the err-name check or attempt
@@ -293,7 +293,24 @@ describe('api/latest-brief retry-on-Upstash-timeout', () => {
     assert.equal(out, 'second-attempt-payload');
   });
 
-  it('does NOT retry on non-TimeoutError (preserves fast-fail on real bugs)', async () => {
+  it('retries once on AbortError and returns the second attempt result', async () => {
+    const { readWithOneRetry } = await import('../api/latest-brief.ts');
+    let calls = 0;
+    const attempt = async () => {
+      calls += 1;
+      if (calls === 1) {
+        const err = new Error('The operation was aborted');
+        err.name = 'AbortError';
+        throw err;
+      }
+      return 'second-attempt-payload';
+    };
+    const out = await readWithOneRetry(attempt, 'test-label');
+    assert.equal(calls, 2, 'helper must invoke the attempt twice on AbortError');
+    assert.equal(out, 'second-attempt-payload');
+  });
+
+  it('does NOT retry on non-timeout/abort errors (preserves fast-fail on real bugs)', async () => {
     const { readWithOneRetry } = await import('../api/latest-brief.ts');
     let calls = 0;
     const attempt = async () => {


### PR DESCRIPTION
## Summary

Two related changes:

**`fix(api/latest-brief)`** — Resolves WORLDMONITOR-QJ (`DOMException: The operation was aborted due to timeout` on Upstash GET). Frequency: 4 events / 19 days, including a 2026-05-13 same-minute double-fire across us-west and eu-central, which confirms transient Upstash regional incidents rather than per-user noise. Users hit a 503 panel on the brief dashboard.

The fix adds a one-retry helper around `readLatestPointer` + `readBriefPreview`:
- First attempt: 6s timeout (up from the shared 3s default, opt-in via explicit `timeoutMs` arg so other Upstash callers keep fast-fail)
- Retry: 3s (shorter — a transient blip clears fast; a real outage burns the retry quickly and hits the existing 503 fallback)
- Worst-case wall clock: 18s, safely under Vercel Edge's ~25s initial-response cap after `validateBearerToken` + `getEntitlements` preflight
- Recovery telemetry: every retry attempt fires `captureSilentError` tagged `step: 'upstash-retry-attempt'` so the "blipped but recovered" rate stays visible in Sentry (without it, successes would only land in Vercel logs)

Duck-types on `err.name === 'TimeoutError'` rather than `instanceof DOMException` to survive cross-realm cases in test runners.

**`chore(hooks)`** — Scopes the pre-push hook to changed test files. The unit test suite has grown past the hook's 300s timeout (current runtime: 357s for 10072 tests), so every PR touching `tests/` was failing the hook by timeout alone, mid-flight in `tests/mcp.test.mjs`. Now:
- `RUN_ALL` fires only on `package.json` / `tsconfig` changes (semantically required for global recompile)
- `TESTS_CHANGED` runs just the `.test.mjs` / `.test.mts` files that changed
- Full-suite verification still happens in CI on PR open — the pre-push hook is the fast pre-flight, not the merge gate

This PR was the first to validate the new hook: the scoped run completed in <1s for one test file versus the 357s+ full suite that was previously triggered + timed out.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:api` — clean (after hoisting `session.userId` to a local const so the retry-helper arrow closures capture `string` rather than `string | undefined`)
- [x] `npm run lint` — clean (exit 0; pre-existing project-wide warnings unaffected)
- [x] `npm run test:data` — 10072/10072 pass (357s, includes the 4 new retry-path tests)
- [x] `node --test tests/edge-functions.test.mjs` — 204/204 pass
- [x] `npm run lint:md` — clean
- [x] `npm run version:check` — clean
- [x] Edge function bundle check (esbuild) — clean
- [x] Pre-push hook (with new scoped-test logic) — passed: ran `brief-edge-route-smoke.test.mjs` (21/21) + `edge-functions.test.mjs` (204/204) + version sync

### New regression tests (`tests/brief-edge-route-smoke.test.mjs`)

- [x] `retries once on TimeoutError and returns the second attempt result`
- [x] `does NOT retry on non-TimeoutError (preserves fast-fail on real bugs)`
- [x] `re-throws when BOTH attempts fail with TimeoutError (503 fallback path)`
- [x] `first attempt receives FIRST_ATTEMPT_MS, retry receives RETRY_ATTEMPT_MS` — pins the 6_000 / 3_000 budgets so any future bump above the Vercel Edge response cap is loudly caught

### Blast radius (intentionally narrow)

- `api/_upstash-json.js` shared defaults remain at 3s. The longer 6s budget is opt-in via explicit `timeoutMs` from `latest-brief.ts` only.
- 13 other Upstash callers (MCP fan-out, brief share-url, symbol-search, brief-why-matters, gpsjam, etc.) keep their fast-fail semantics.