### PR TITLE
chore(hooks): dedup TESTS_CHANGED against category test globs

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -142,7 +142,14 @@ SERVER_TESTS=$(printf '%s\n' "tests/handlers.test.mts" "tests/server-handlers.te
 # resilience/handlers/seed test file is captured in BOTH the category run
 # AND the TESTS_CHANGED run, so the same test executes twice on every
 # push. Per greptile-apps review on PR #3928.
-if [ -n "$TESTS_CHANGED" ]; then
+#
+# IMPORTANT: gated on RUN_ALL != true. When RUN_ALL=true the category
+# runners below are skipped (only CI runs the full suite), so there's
+# nothing to dedup against — and subtracting category files unconditionally
+# would silently drop them from the TESTS_CHANGED runner too, since that
+# block runs regardless of RUN_ALL. Net effect of an unconditional dedup:
+# changed test files don't run anywhere locally when RUN_ALL fires.
+if [ "$RUN_ALL" != true ] && [ -n "$TESTS_CHANGED" ]; then
   if [ "$RUN_RESILIENCE" = true ]; then
     TESTS_CHANGED=$(echo "$TESTS_CHANGED" | grep -v "^tests/resilience-" || true)
   fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -127,6 +127,31 @@ fi
 # 10k-test suite. Matches both .mjs and .mts under tests/.
 TESTS_CHANGED=$(echo "$CHANGED_FILES" | grep -E "^tests/.*\.test\.(mjs|mts)$" | while read -r t; do [ -f "$t" ] && echo "$t"; done || true)
 
+# Compute SEED_TESTS up-front (rather than inside the RUN_SEED block) so
+# the TESTS_CHANGED subtraction below can deduplicate against it without
+# recomputing the mapping. The RUN_SEED block consumes this same variable.
+SEED_TESTS=$(echo "$CHANGED_FILES" | grep "^scripts/" | sed 's|scripts/seed-\(.*\)\.mjs|tests/\1-seed.test.mjs|' | grep "^tests/" | while read -r t; do [ -f "$t" ] && echo "$t"; done)
+
+# Subtract any test file that's already going to be run by a category
+# glob (RUN_RESILIENCE's resilience-* glob, RUN_SERVER's handlers globs,
+# or RUN_SEED's derived SEED_TESTS list). Without this, a changed
+# resilience/handlers/seed test file is captured in BOTH the category run
+# AND the TESTS_CHANGED run, so the same test executes twice on every
+# push. Per greptile-apps review on PR #3928.
+if [ -n "$TESTS_CHANGED" ]; then
+  if [ "$RUN_RESILIENCE" = true ]; then
+    TESTS_CHANGED=$(echo "$TESTS_CHANGED" | grep -v "^tests/resilience-" || true)
+  fi
+  if [ "$RUN_SERVER" = true ]; then
+    TESTS_CHANGED=$(echo "$TESTS_CHANGED" | grep -v -E "^tests/(handlers|server-handlers)\.test\.(mjs|mts)$" || true)
+  fi
+  if [ -n "$SEED_TESTS" ]; then
+    # grep -vxF -f <(...): drop lines from TESTS_CHANGED that exactly
+    # match (full line, literal string, no regex) any line in SEED_TESTS.
+    TESTS_CHANGED=$(echo "$TESTS_CHANGED" | grep -vxF -f <(echo "$SEED_TESTS") || true)
+  fi
+fi
+
 if [ "$RUN_ALL" = true ]; then
   echo "Skipping local full unit test suite (${RUN_ALL_REASON:-broad check requested}; CI runs the full suite on PR open)."
 fi
@@ -138,7 +163,6 @@ if [ "$RUN_ALL" != true ]; then
   fi
   if [ "$RUN_SEED" = true ]; then
     echo "Running seed tests (scripts/ changed)..."
-    SEED_TESTS=$(echo "$CHANGED_FILES" | grep "^scripts/" | sed 's|scripts/seed-\(.*\)\.mjs|tests/\1-seed.test.mjs|' | grep "^tests/" | while read -r t; do [ -f "$t" ] && echo "$t"; done)
     if [ -n "$SEED_TESTS" ]; then
       timeout 120 npx tsx --test $SEED_TESTS || exit 1
     else

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -127,14 +127,18 @@ fi
 # 10k-test suite. Matches both .mjs and .mts under tests/.
 TESTS_CHANGED=$(echo "$CHANGED_FILES" | grep -E "^tests/.*\.test\.(mjs|mts)$" | while read -r t; do [ -f "$t" ] && echo "$t"; done || true)
 
-# Compute SEED_TESTS up-front (rather than inside the RUN_SEED block) so
-# the TESTS_CHANGED subtraction below can deduplicate against it without
-# recomputing the mapping. The RUN_SEED block consumes this same variable.
+# Compute SEED_TESTS and SERVER_TESTS up-front (rather than inside their
+# RUN_* blocks) so the TESTS_CHANGED subtraction below can deduplicate
+# against the SAME literal file list the category run will execute. The
+# RUN_SEED / RUN_SERVER blocks consume these same variables — single
+# source of truth prevents drift between "what runs" and "what's
+# subtracted from TESTS_CHANGED".
 SEED_TESTS=$(echo "$CHANGED_FILES" | grep "^scripts/" | sed 's|scripts/seed-\(.*\)\.mjs|tests/\1-seed.test.mjs|' | grep "^tests/" | while read -r t; do [ -f "$t" ] && echo "$t"; done)
+SERVER_TESTS=$(printf '%s\n' "tests/handlers.test.mts" "tests/server-handlers.test.mjs")
 
 # Subtract any test file that's already going to be run by a category
-# glob (RUN_RESILIENCE's resilience-* glob, RUN_SERVER's handlers globs,
-# or RUN_SEED's derived SEED_TESTS list). Without this, a changed
+# glob (RUN_RESILIENCE's resilience-* glob, RUN_SERVER's SERVER_TESTS
+# list, or RUN_SEED's derived SEED_TESTS list). Without this, a changed
 # resilience/handlers/seed test file is captured in BOTH the category run
 # AND the TESTS_CHANGED run, so the same test executes twice on every
 # push. Per greptile-apps review on PR #3928.
@@ -143,7 +147,12 @@ if [ -n "$TESTS_CHANGED" ]; then
     TESTS_CHANGED=$(echo "$TESTS_CHANGED" | grep -v "^tests/resilience-" || true)
   fi
   if [ "$RUN_SERVER" = true ]; then
-    TESTS_CHANGED=$(echo "$TESTS_CHANGED" | grep -v -E "^tests/(handlers|server-handlers)\.test\.(mjs|mts)$" || true)
+    # grep -vxF -f <(...): drop lines from TESTS_CHANGED that exactly
+    # match (full line, literal string, no regex) the SERVER_TESTS list.
+    # Exact literal match here — not a regex like (handlers|server-handlers)
+    # over (mjs|mts) — so we never strip a file from TESTS_CHANGED that
+    # the category run isn't actually going to execute.
+    TESTS_CHANGED=$(echo "$TESTS_CHANGED" | grep -vxF -f <(echo "$SERVER_TESTS") || true)
   fi
   if [ -n "$SEED_TESTS" ]; then
     # grep -vxF -f <(...): drop lines from TESTS_CHANGED that exactly
@@ -171,7 +180,8 @@ if [ "$RUN_ALL" != true ]; then
   fi
   if [ "$RUN_SERVER" = true ]; then
     echo "Running server handler tests (server/ changed)..."
-    timeout 120 npx tsx --test tests/handlers.test.mts tests/server-handlers.test.mjs || exit 1
+    # shellcheck disable=SC2086 — intentional word-split for tsx --test arglist
+    timeout 120 npx tsx --test $SERVER_TESTS || exit 1
   fi
   if [ "$RUN_RESILIENCE" = false ] && [ "$RUN_SEED" = false ] && [ "$RUN_SERVER" = false ] && [ -z "$TESTS_CHANGED" ]; then
     echo "Skipping unit tests (frontend-only changes; CI runs the full suite on PR open)."


### PR DESCRIPTION
## Summary

Follow-up to #3928. [greptile-apps review](https://github.com/koala73/worldmonitor/pull/3928#discussion_r-greptile) caught a real overlap defect: a changed `tests/resilience-*.test.*` / `tests/handlers.test.*` / `tests/server-handlers.test.*` / `tests/*-seed.test.*` file is captured in BOTH the category run (RUN_RESILIENCE / RUN_SERVER / RUN_SEED globs) AND the new `TESTS_CHANGED` unconditional block, so the same test executes twice on every push.

This PR subtracts category-covered tests from `TESTS_CHANGED` right after capture:

- `tests/resilience-*` removed when `RUN_RESILIENCE` fires (the resilience-* glob already runs them)
- `tests/handlers.test.*` / `tests/server-handlers.test.*` removed when `RUN_SERVER` fires
- Any test file matching the `SEED_TESTS` derivation (`scripts/seed-X.mjs` → `tests/X-seed.test.mjs`) removed when `RUN_SEED`'s list is non-empty (uses `grep -vxF -f <(...)` for full-line literal match)

`SEED_TESTS` computation is hoisted out of the `RUN_SEED` block to the same scope as `TESTS_CHANGED` so the subtraction doesn't re-derive the mapping. The `RUN_SEED` block consumes the same variable.

## Test plan

Smoke-tested both scenarios in isolation (Bash subshell, no real test execution):

```bash
# Scenario 1: resilience + non-resilience tests both change
CHANGED_FILES="tests/resilience-foo.test.mjs\ntests/other.test.mjs\nsrc/something.ts"
RUN_RESILIENCE=true
# Before: tests/resilience-foo.test.mjs tests/other.test.mjs
# After:  tests/other.test.mjs ✓

# Scenario 2: handlers + non-handlers tests
CHANGED_FILES="tests/handlers.test.mts\ntests/server-handlers.test.mjs\ntests/foo.test.mjs\nserver/x.ts"
RUN_SERVER=true
# Before: tests/handlers.test.mts tests/server-handlers.test.mjs tests/foo.test.mjs
# After:  tests/foo.test.mjs ✓
```

Pushed with the new hook self-validating (`git -c core.hooksPath="$(pwd)/.husky" push`).

## Why follow-up vs amend

PR #3928 was already merged (squash) by the time the review comment came in. Rebasing onto main and force-pushing would have rewritten merged history. Clean append is correct.