### PR TITLE
[codex] fix panel drag reorder semantics

### DIFF
--- a/e2e/panel-drag-reorder.spec.ts
+++ b/e2e/panel-drag-reorder.spec.ts
@@ -16,7 +16,15 @@ async function loadHappyDashboard(page: Page): Promise<void> {
 
 async function waitForPanelCount(page: Page, minCount: number, gridSelector = '#panelsGrid'): Promise<void> {
   await expect
-    .poll(async () => (await panelIds(page, gridSelector)).length, { timeout: 60_000 })
+    .poll(
+      async () => {
+        const before = await panelIds(page, gridSelector);
+        await page.waitForTimeout(250);
+        const after = await panelIds(page, gridSelector);
+        return before.length >= minCount && before.join('\0') === after.join('\0') ? after.length : 0;
+      },
+      { timeout: 60_000 },
+    )
     .toBeGreaterThanOrEqual(minCount);
 }
 
@@ -44,7 +52,7 @@ async function nextAnimationFrame(page: Page): Promise<void> {
 
 async function dragPanelToPoint(page: Page, sourceId: string, x: number, y: number): Promise<void> {
   const sourceHeader = page.locator(`${panelSelector(sourceId)} > .panel-header`).first();
-  await sourceHeader.scrollIntoViewIfNeeded();
+  await expect(sourceHeader).toBeVisible();
   const sourceBox = await boundingBoxOrThrow(sourceHeader, `source panel ${sourceId}`);
   const startX = sourceBox.x + Math.min(48, sourceBox.width / 2);
   const startY = sourceBox.y + sourceBox.height / 2;
@@ -54,6 +62,19 @@ async function dragPanelToPoint(page: Page, sourceId: string, x: number, y: numb
   await page.mouse.move(startX + 12, startY + 12, { steps: 3 });
   await page.mouse.move(x, y, { steps: 12 });
   await nextAnimationFrame(page);
+  await page.mouse.up();
+}
+
+async function dragPanelBelowThreshold(page: Page, sourceId: string): Promise<void> {
+  const sourceHeader = page.locator(`${panelSelector(sourceId)} > .panel-header`).first();
+  await sourceHeader.scrollIntoViewIfNeeded();
+  const sourceBox = await boundingBoxOrThrow(sourceHeader, `source panel ${sourceId}`);
+  const startX = sourceBox.x + Math.min(48, sourceBox.width / 2);
+  const startY = sourceBox.y + sourceBox.height / 2;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX + 4, startY + 4);
   await page.mouse.up();
 }
 
@@ -69,6 +90,33 @@ async function dragPanelToPanel(
   const targetX = targetBox.x + targetBox.width / 2;
   const targetY = targetBox.y + targetBox.height * (position === 'upper' ? 0.25 : 0.75);
   await dragPanelToPoint(page, sourceId, targetX, targetY);
+}
+
+async function sameGridGapPoint(page: Page, sourceId: string): Promise<{ x: number; y: number }> {
+  return page.evaluate((id) => {
+    const grid = document.querySelector<HTMLElement>('#panelsGrid');
+    const source = document.querySelector<HTMLElement>(`.panel[data-panel="${CSS.escape(id)}"]`);
+    if (!grid || !source) throw new Error('Missing panels grid or source panel');
+
+    const gridRect = grid.getBoundingClientRect();
+    const sourceRect = source.getBoundingClientRect();
+    const panelRects = Array.from(grid.querySelectorAll<HTMLElement>(':scope > .panel[data-panel]:not(.hidden)'))
+      .filter((panel) => panel !== source)
+      .map((panel) => panel.getBoundingClientRect());
+    if (panelRects.length === 0) throw new Error('Need another panel to find an interior grid gap');
+
+    const maxPanelBottom = Math.max(...panelRects.map((rect) => rect.bottom));
+    for (let y = Math.ceil(sourceRect.bottom) + 1; y < Math.floor(maxPanelBottom) - 1; y += 2) {
+      for (let x = Math.ceil(gridRect.left) + 2; x < Math.floor(gridRect.right) - 2; x += 8) {
+        const hit = document.elementFromPoint(x, y);
+        if (!(hit instanceof HTMLElement)) continue;
+        if (hit.closest('.panel') || hit.closest('.add-panel-block')) continue;
+        if (hit === grid || hit.closest('#panelsGrid') === grid) return { x, y };
+      }
+    }
+
+    throw new Error('No same-grid interior gap point found');
+  }, sourceId);
 }
 
 async function storedPanelOrder(page: Page): Promise<string[]> {
@@ -98,6 +146,33 @@ test.describe('panel drag reorder semantics', () => {
     await expect.poll(async () => (await panelIds(page)).slice(0, 4)).toEqual(expectedPrefix);
   });
 
+  test('moves a panel before the indicated same-grid target', async ({ page }) => {
+    await loadHappyDashboard(page);
+    const before = await panelIds(page);
+    const [first, second, third, fourth] = before;
+    expect(first && second && third && fourth).toBeTruthy();
+
+    await dragPanelToPanel(page, fourth!, second!, 'upper');
+
+    const expectedPrefix = [first, fourth, second, third];
+    await expect.poll(async () => (await panelIds(page)).slice(0, 4)).toEqual(expectedPrefix);
+    expect((await storedPanelOrder(page)).slice(0, 4)).toEqual(expectedPrefix);
+  });
+
+  test('same-grid interior gap drops do not jump the panel to the end', async ({ page }) => {
+    await loadHappyDashboard(page);
+    const before = await panelIds(page);
+    const [sourceId] = before;
+    expect(sourceId).toBeTruthy();
+    const storedBefore = await page.evaluate(() => localStorage.getItem('panel-order'));
+    const gap = await sameGridGapPoint(page, sourceId!);
+
+    await dragPanelToPoint(page, sourceId!, gap.x, gap.y);
+
+    await expect.poll(async () => await panelIds(page)).toEqual(before);
+    expect(await page.evaluate(() => localStorage.getItem('panel-order'))).toBe(storedBefore);
+  });
+
   test('moves a panel into empty bottom-grid space and restores it after reload', async ({ page }) => {
     await loadHappyDashboard(page);
     const [sourceId] = await panelIds(page);
@@ -117,6 +192,19 @@ test.describe('panel drag reorder semantics', () => {
     await waitForPanelCount(page, 3);
     await expect(page.locator(`#mapBottomGrid > ${panelSelector(sourceId!)}`)).toHaveCount(1);
     expect(await storedBottomSet(page)).toContain(sourceId);
+  });
+
+  test('sub-threshold mouse movement does not start a drag or persist order', async ({ page }) => {
+    await loadHappyDashboard(page);
+    const before = await panelIds(page);
+    const [sourceId] = before;
+    expect(sourceId).toBeTruthy();
+    const storedBefore = await page.evaluate(() => localStorage.getItem('panel-order'));
+
+    await dragPanelBelowThreshold(page, sourceId!);
+
+    expect(await panelIds(page)).toEqual(before);
+    expect(await page.evaluate(() => localStorage.getItem('panel-order'))).toBe(storedBefore);
   });
 
   test('Escape cancels an in-progress drag without persisting order', async ({ page }) => {

--- a/e2e/panel-drag-reorder.spec.ts
+++ b/e2e/panel-drag-reorder.spec.ts
@@ -1,0 +1,148 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+const DASHBOARD_VIEWPORT = { width: 1700, height: 900 };
+
+async function loadHappyDashboard(page: Page): Promise<void> {
+  await page.setViewportSize(DASHBOARD_VIEWPORT);
+  await page.addInitScript(() => {
+    if (sessionStorage.getItem('__panel_drag_reorder_init_done')) return;
+    localStorage.clear();
+    localStorage.setItem('worldmonitor-variant', 'happy');
+    sessionStorage.setItem('__panel_drag_reorder_init_done', '1');
+  });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await waitForPanelCount(page, 4);
+}
+
+async function waitForPanelCount(page: Page, minCount: number, gridSelector = '#panelsGrid'): Promise<void> {
+  await expect
+    .poll(async () => (await panelIds(page, gridSelector)).length, { timeout: 60_000 })
+    .toBeGreaterThanOrEqual(minCount);
+}
+
+async function panelIds(page: Page, gridSelector = '#panelsGrid'): Promise<string[]> {
+  return page.locator(`${gridSelector} > .panel[data-panel]:not(.hidden)`).evaluateAll((els) =>
+    els
+      .map((el) => (el as HTMLElement).dataset.panel)
+      .filter((id): id is string => typeof id === 'string' && id.length > 0),
+  );
+}
+
+function panelSelector(id: string): string {
+  return `.panel[data-panel="${id}"]`;
+}
+
+async function boundingBoxOrThrow(locator: Locator, label: string) {
+  const box = await locator.boundingBox();
+  expect(box, `${label} should have a rendered bounding box`).not.toBeNull();
+  return box!;
+}
+
+async function nextAnimationFrame(page: Page): Promise<void> {
+  await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
+}
+
+async function dragPanelToPoint(page: Page, sourceId: string, x: number, y: number): Promise<void> {
+  const sourceHeader = page.locator(`${panelSelector(sourceId)} > .panel-header`).first();
+  await sourceHeader.scrollIntoViewIfNeeded();
+  const sourceBox = await boundingBoxOrThrow(sourceHeader, `source panel ${sourceId}`);
+  const startX = sourceBox.x + Math.min(48, sourceBox.width / 2);
+  const startY = sourceBox.y + sourceBox.height / 2;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(startX + 12, startY + 12, { steps: 3 });
+  await page.mouse.move(x, y, { steps: 12 });
+  await nextAnimationFrame(page);
+  await page.mouse.up();
+}
+
+async function dragPanelToPanel(
+  page: Page,
+  sourceId: string,
+  targetId: string,
+  position: 'upper' | 'lower',
+): Promise<void> {
+  const target = page.locator(panelSelector(targetId)).first();
+  await target.scrollIntoViewIfNeeded();
+  const targetBox = await boundingBoxOrThrow(target, `target panel ${targetId}`);
+  const targetX = targetBox.x + targetBox.width / 2;
+  const targetY = targetBox.y + targetBox.height * (position === 'upper' ? 0.25 : 0.75);
+  await dragPanelToPoint(page, sourceId, targetX, targetY);
+}
+
+async function storedPanelOrder(page: Page): Promise<string[]> {
+  return page.evaluate(() => JSON.parse(localStorage.getItem('panel-order') || '[]') as string[]);
+}
+
+async function storedBottomSet(page: Page): Promise<string[]> {
+  return page.evaluate(() => JSON.parse(localStorage.getItem('panel-order-bottom-set') || '[]') as string[]);
+}
+
+test.describe('panel drag reorder semantics', () => {
+  test('moves a panel after the indicated same-grid target instead of swapping', async ({ page }) => {
+    await loadHappyDashboard(page);
+    const before = await panelIds(page);
+    const [first, second, third, fourth] = before;
+    expect(first && second && third && fourth).toBeTruthy();
+
+    await dragPanelToPanel(page, first!, fourth!, 'lower');
+
+    const expectedPrefix = [second, third, fourth, first];
+    await expect.poll(async () => (await panelIds(page)).slice(0, 4)).toEqual(expectedPrefix);
+    expect((await panelIds(page)).slice(0, 4)).not.toEqual([fourth, second, third, first]);
+    expect((await storedPanelOrder(page)).slice(0, 4)).toEqual(expectedPrefix);
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await waitForPanelCount(page, 4);
+    await expect.poll(async () => (await panelIds(page)).slice(0, 4)).toEqual(expectedPrefix);
+  });
+
+  test('moves a panel into empty bottom-grid space and restores it after reload', async ({ page }) => {
+    await loadHappyDashboard(page);
+    const [sourceId] = await panelIds(page);
+    expect(sourceId).toBeTruthy();
+
+    const bottomGrid = page.locator('#mapBottomGrid');
+    const bottomBox = await boundingBoxOrThrow(bottomGrid, 'bottom grid');
+    expect(bottomBox.height).toBeGreaterThan(20);
+
+    await dragPanelToPoint(page, sourceId!, bottomBox.x + bottomBox.width / 2, bottomBox.y + bottomBox.height / 2);
+
+    await expect(page.locator(`#mapBottomGrid > ${panelSelector(sourceId!)}`)).toHaveCount(1);
+    await expect(page.locator(`#panelsGrid > ${panelSelector(sourceId!)}`)).toHaveCount(0);
+    expect(await storedBottomSet(page)).toContain(sourceId);
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await waitForPanelCount(page, 3);
+    await expect(page.locator(`#mapBottomGrid > ${panelSelector(sourceId!)}`)).toHaveCount(1);
+    expect(await storedBottomSet(page)).toContain(sourceId);
+  });
+
+  test('Escape cancels an in-progress drag without persisting order', async ({ page }) => {
+    await loadHappyDashboard(page);
+    const before = await panelIds(page);
+    const [sourceId, , , targetId] = before;
+    expect(sourceId && targetId).toBeTruthy();
+    const storedBefore = await page.evaluate(() => localStorage.getItem('panel-order'));
+
+    const target = page.locator(panelSelector(targetId!)).first();
+    await target.scrollIntoViewIfNeeded();
+    const targetBox = await boundingBoxOrThrow(target, `target panel ${targetId}`);
+    const sourceHeader = page.locator(`${panelSelector(sourceId!)} > .panel-header`).first();
+    const sourceBox = await boundingBoxOrThrow(sourceHeader, `source panel ${sourceId}`);
+    const startX = sourceBox.x + Math.min(48, sourceBox.width / 2);
+    const startY = sourceBox.y + sourceBox.height / 2;
+
+    await page.mouse.move(startX, startY);
+    await page.mouse.down();
+    await page.mouse.move(startX + 12, startY + 12, { steps: 3 });
+    await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height * 0.75, { steps: 12 });
+    await nextAnimationFrame(page);
+    await page.keyboard.press('Escape');
+    await page.mouse.up();
+
+    await expect.poll(async () => await panelIds(page)).toEqual(before);
+    expect(await page.evaluate(() => localStorage.getItem('panel-order'))).toBe(storedBefore);
+  });
+});

--- a/e2e/panel-drag-reorder.spec.ts
+++ b/e2e/panel-drag-reorder.spec.ts
@@ -50,7 +50,7 @@ async function nextAnimationFrame(page: Page): Promise<void> {
   await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
 }
 
-async function dragPanelToPoint(page: Page, sourceId: string, x: number, y: number): Promise<void> {
+async function beginDragToPoint(page: Page, sourceId: string, x: number, y: number): Promise<void> {
   const sourceHeader = page.locator(`${panelSelector(sourceId)} > .panel-header`).first();
   await expect(sourceHeader).toBeVisible();
   const sourceBox = await boundingBoxOrThrow(sourceHeader, `source panel ${sourceId}`);
@@ -62,7 +62,15 @@ async function dragPanelToPoint(page: Page, sourceId: string, x: number, y: numb
   await page.mouse.move(startX + 12, startY + 12, { steps: 3 });
   await page.mouse.move(x, y, { steps: 12 });
   await nextAnimationFrame(page);
+}
+
+async function releaseDrag(page: Page): Promise<void> {
   await page.mouse.up();
+}
+
+async function dragPanelToPoint(page: Page, sourceId: string, x: number, y: number): Promise<void> {
+  await beginDragToPoint(page, sourceId, x, y);
+  await releaseDrag(page);
 }
 
 async function dragPanelBelowThreshold(page: Page, sourceId: string): Promise<void> {
@@ -78,7 +86,7 @@ async function dragPanelBelowThreshold(page: Page, sourceId: string): Promise<vo
   await page.mouse.up();
 }
 
-async function dragPanelToPanel(
+async function beginDragToPanel(
   page: Page,
   sourceId: string,
   targetId: string,
@@ -89,7 +97,17 @@ async function dragPanelToPanel(
   const targetBox = await boundingBoxOrThrow(target, `target panel ${targetId}`);
   const targetX = targetBox.x + targetBox.width / 2;
   const targetY = targetBox.y + targetBox.height * (position === 'upper' ? 0.25 : 0.75);
-  await dragPanelToPoint(page, sourceId, targetX, targetY);
+  await beginDragToPoint(page, sourceId, targetX, targetY);
+}
+
+async function dragPanelToPanel(
+  page: Page,
+  sourceId: string,
+  targetId: string,
+  position: 'upper' | 'lower',
+): Promise<void> {
+  await beginDragToPanel(page, sourceId, targetId, position);
+  await releaseDrag(page);
 }
 
 async function sameGridGapPoint(page: Page, sourceId: string): Promise<{ x: number; y: number }> {
@@ -214,21 +232,9 @@ test.describe('panel drag reorder semantics', () => {
     expect(sourceId && targetId).toBeTruthy();
     const storedBefore = await page.evaluate(() => localStorage.getItem('panel-order'));
 
-    const target = page.locator(panelSelector(targetId!)).first();
-    await target.scrollIntoViewIfNeeded();
-    const targetBox = await boundingBoxOrThrow(target, `target panel ${targetId}`);
-    const sourceHeader = page.locator(`${panelSelector(sourceId!)} > .panel-header`).first();
-    const sourceBox = await boundingBoxOrThrow(sourceHeader, `source panel ${sourceId}`);
-    const startX = sourceBox.x + Math.min(48, sourceBox.width / 2);
-    const startY = sourceBox.y + sourceBox.height / 2;
-
-    await page.mouse.move(startX, startY);
-    await page.mouse.down();
-    await page.mouse.move(startX + 12, startY + 12, { steps: 3 });
-    await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height * 0.75, { steps: 12 });
-    await nextAnimationFrame(page);
+    await beginDragToPanel(page, sourceId!, targetId!, 'lower');
     await page.keyboard.press('Escape');
-    await page.mouse.up();
+    await releaseDrag(page);
 
     await expect.poll(async () => await panelIds(page)).toEqual(before);
     expect(await page.evaluate(() => localStorage.getItem('panel-order'))).toBe(storedBefore);

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -2152,8 +2152,13 @@ export class PanelLayoutManager implements AppModule {
       if (panel) {
         if (panel === el || panel.parentElement !== grid) return false;
 
+        if (insertBefore) {
+          if (el.nextSibling === panel) return false;
+        } else {
+          if (panel.nextSibling === el) return false;
+        }
+
         const referenceNode = insertBefore ? panel : panel.nextSibling;
-        if (referenceNode === el || (insertBefore && el.nextSibling === panel)) return false;
         if (referenceNode && referenceNode.parentNode !== grid) return false;
 
         grid.insertBefore(el, referenceNode);

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -2132,6 +2132,20 @@ export class PanelLayoutManager implements AppModule {
       return grid.querySelector('.add-panel-block');
     };
 
+    const canAppendToGrid = (grid: HTMLElement, clientY: number): boolean => {
+      if (grid !== originalParent) return true;
+      const panelBottoms = Array.from(grid.children)
+        .filter((child): child is HTMLElement =>
+          child instanceof HTMLElement &&
+          child !== el &&
+          child.classList.contains('panel') &&
+          !child.classList.contains('hidden'),
+        )
+        .map((panel) => panel.getBoundingClientRect().bottom);
+      if (panelBottoms.length === 0) return false;
+      return clientY > Math.max(...panelBottoms);
+    };
+
     const commitDrop = (dropPos: DropPosition, clientX: number, clientY: number): boolean => {
       const { grid, panel, insertBefore } = dropPos;
 
@@ -2149,6 +2163,7 @@ export class PanelLayoutManager implements AppModule {
       if (grid === originalParent && isWithinOriginalRect(clientX, clientY)) {
         return false;
       }
+      if (!canAppendToGrid(grid, clientY)) return false;
 
       const referenceNode = getAppendReference(grid);
       if (referenceNode && referenceNode.parentNode !== grid) return false;
@@ -2215,7 +2230,9 @@ export class PanelLayoutManager implements AppModule {
       const { grid, panel, insertBefore } = dropPos;
       if (!dropIndicator) return;
 
-      if (!panel && grid === originalParent && isWithinOriginalRect(clientX, clientY)) {
+      const noOpEmptyDrop = !panel &&
+        ((grid === originalParent && isWithinOriginalRect(clientX, clientY)) || !canAppendToGrid(grid, clientY));
+      if (noOpEmptyDrop) {
         dropIndicator.style.opacity = '0';
         if (lastTargetPanel) {
           lastTargetPanel.classList.remove('panel-drop-target');

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -2041,6 +2041,12 @@ export class PanelLayoutManager implements AppModule {
   }
 
   private makeDraggable(el: HTMLElement, key: string): void {
+    type DropPosition = {
+      grid: HTMLElement;
+      panel: HTMLElement | null;
+      insertBefore: boolean;
+    };
+
     el.dataset.panel = key;
     let isDragging = false;
     let dragStarted = false;
@@ -2053,6 +2059,7 @@ export class PanelLayoutManager implements AppModule {
     let dragOffsetX = 0;
     let dragOffsetY = 0;
     let originalIndex = -1;
+    let originalRect: DOMRect | null = null;
     let onKeyDown: ((e: KeyboardEvent) => void) | null = null;
     const DRAG_THRESHOLD = 8;
 
@@ -2112,28 +2119,44 @@ export class PanelLayoutManager implements AppModule {
       document.body.appendChild(indicator);
       return indicator;
     };
-    const swapElements = (a: HTMLElement, b: HTMLElement) => {
-      if (a === b) return;
-      const aParent = a.parentElement;
-      const bParent = b.parentElement;
-      if (!aParent || !bParent) return;
 
-      const aNext = a.nextSibling;
-      const bNext = b.nextSibling;
+    const isWithinOriginalRect = (clientX: number, clientY: number) =>
+      !!originalRect &&
+      clientX >= originalRect.left &&
+      clientX <= originalRect.right &&
+      clientY >= originalRect.top &&
+      clientY <= originalRect.bottom;
 
-      if (aParent === bParent) {
-        if (aNext === b) {
-          aParent.insertBefore(b, a);
-        } else if (bNext === a) {
-          aParent.insertBefore(a, b);
-        } else {
-          aParent.insertBefore(b, aNext);
-          aParent.insertBefore(a, bNext);
-        }
-      } else {
-        aParent.insertBefore(b, aNext);
-        bParent.insertBefore(a, bNext);
+    const getAppendReference = (grid: HTMLElement): ChildNode | null => {
+      if (grid.id !== 'panelsGrid') return null;
+      return grid.querySelector('.add-panel-block');
+    };
+
+    const commitDrop = (dropPos: DropPosition, clientX: number, clientY: number): boolean => {
+      const { grid, panel, insertBefore } = dropPos;
+
+      if (panel) {
+        if (panel === el || panel.parentElement !== grid) return false;
+
+        const referenceNode = insertBefore ? panel : panel.nextSibling;
+        if (referenceNode === el || (insertBefore && el.nextSibling === panel)) return false;
+        if (referenceNode && referenceNode.parentNode !== grid) return false;
+
+        grid.insertBefore(el, referenceNode);
+        return true;
       }
+
+      if (grid === originalParent && isWithinOriginalRect(clientX, clientY)) {
+        return false;
+      }
+
+      const referenceNode = getAppendReference(grid);
+      if (referenceNode && referenceNode.parentNode !== grid) return false;
+      if (referenceNode === el) return false;
+      if (el.parentElement === grid && el.nextSibling === referenceNode) return false;
+
+      grid.insertBefore(el, referenceNode);
+      return true;
     };
 
     const updateGhostPosition = (clientX: number, clientY: number) => {
@@ -2142,7 +2165,7 @@ export class PanelLayoutManager implements AppModule {
       ghostEl.style.top = (clientY - dragOffsetY) + 'px';
     };
 
-    const findDropPosition = (clientX: number, clientY: number) => {
+    const findDropPosition = (clientX: number, clientY: number): DropPosition | null => {
       const grid = document.getElementById('panelsGrid');
       const bottomGrid = document.getElementById('mapBottomGrid');
       if (!grid || !bottomGrid) return null;
@@ -2162,10 +2185,17 @@ export class PanelLayoutManager implements AppModule {
 
       const currentTargetGrid = targetGrid || (targetPanel ? targetPanel.parentElement as HTMLElement : null);
       if (!currentTargetGrid || (currentTargetGrid !== grid && currentTargetGrid !== bottomGrid)) return null;
+      const panel = targetPanel && targetPanel !== el ? targetPanel : null;
+      let insertBefore = false;
+      if (panel) {
+        const panelRect = panel.getBoundingClientRect();
+        insertBefore = clientY < panelRect.top + panelRect.height / 2;
+      }
 
       return {
         grid: currentTargetGrid,
-        panel: targetPanel && targetPanel !== el ? targetPanel : null,
+        panel,
+        insertBefore,
       };
     };
 
@@ -2182,8 +2212,17 @@ export class PanelLayoutManager implements AppModule {
         return;
       }
 
-      const { grid, panel } = dropPos;
+      const { grid, panel, insertBefore } = dropPos;
       if (!dropIndicator) return;
+
+      if (!panel && grid === originalParent && isWithinOriginalRect(clientX, clientY)) {
+        dropIndicator.style.opacity = '0';
+        if (lastTargetPanel) {
+          lastTargetPanel.classList.remove('panel-drop-target');
+          lastTargetPanel = null;
+        }
+        return;
+      }
 
       // highlight hovered panel
       if (panel !== lastTargetPanel) {
@@ -2199,11 +2238,9 @@ export class PanelLayoutManager implements AppModule {
 
       if (panel) {
         const panelRect = panel.getBoundingClientRect();
-        const panelMid = panelRect.top + panelRect.height / 2;
-        const shouldInsertBefore = clientY < panelMid;
         width = panelRect.width;
         left = panelRect.left;
-        top = shouldInsertBefore ? panelRect.top - 4 : panelRect.bottom;
+        top = insertBefore ? panelRect.top - 4 : panelRect.bottom;
       } else {
         // dropping into empty grid: position at grid bottom
         const gridRect = grid.getBoundingClientRect();
@@ -2233,6 +2270,7 @@ export class PanelLayoutManager implements AppModule {
         el.classList.add('dragging-source');
         originalParent = el.parentElement as HTMLElement;
         originalIndex = Array.from(originalParent.children).indexOf(el);
+        originalRect = el.getBoundingClientRect();
         ghostEl = createGhostElement();
         dropIndicator = createDropIndicator();
         onKeyDown = (e: KeyboardEvent) => {
@@ -2270,6 +2308,7 @@ export class PanelLayoutManager implements AppModule {
             onKeyDown = null;
             isDragging = false;
             dragStarted = false;
+            originalRect = null;
             if (rafId) { cancelAnimationFrame(rafId); rafId = 0; }
           }
         };
@@ -2298,16 +2337,7 @@ export class PanelLayoutManager implements AppModule {
       if (dragStarted) {
         // Find final drop position using most recent cursor coords
         const dropPos = findDropPosition(lastX, lastY);
-        
-        if (dropPos) {
-          const { grid, panel } = dropPos;
-
-          if (panel && panel !== el) {
-            swapElements(el, panel);
-          } else if (grid !== originalParent) {
-            grid.appendChild(el);
-          }
-        }
+        const moved = dropPos ? commitDrop(dropPos, lastX, lastY) : false;
         
         // Clean up drag visualization
         el.classList.remove('dragging-source');
@@ -2328,16 +2358,18 @@ export class PanelLayoutManager implements AppModule {
           lastTargetPanel = null;
         }
         
-        // Update status
-        const isInBottom = !!el.closest('.map-bottom-grid');
-        if (isInBottom) {
-          this.bottomSetMemory.add(key);
-        } else {
-          this.bottomSetMemory.delete(key);
+        if (moved) {
+          const isInBottom = !!el.closest('.map-bottom-grid');
+          if (isInBottom) {
+            this.bottomSetMemory.add(key);
+          } else {
+            this.bottomSetMemory.delete(key);
+          }
+          this.savePanelOrder();
         }
-        this.savePanelOrder();
       }
       dragStarted = false;
+      originalRect = null;
       if (onKeyDown) {
         document.removeEventListener('keydown', onKeyDown);
         onKeyDown = null;
@@ -2364,6 +2396,7 @@ export class PanelLayoutManager implements AppModule {
       if (dropIndicator) dropIndicator.remove();
       isDragging = false;
       dragStarted = false;
+      originalRect = null;
       el.classList.remove('dragging-source');
     });
   }


### PR DESCRIPTION
## Summary
- replace panel drag/drop swap behavior with insert-before/after reorder semantics
- reuse the drop indicator midpoint intent for the final DOM move
- add Playwright coverage for same-grid reorder, bottom-grid persistence, reload persistence, and Escape cancellation

## Root cause
The drag UI calculated before/after intent for the drop indicator, but the mouseup path ignored that intent and called swapElements(), which swapped the dragged panel with the target panel. Cross-grid swaps could also move the target panel without updating its bottom-grid membership.

Fixes #3934

## Validation
- npm run typecheck
- npx biome check src/app/panel-layout.ts e2e/panel-drag-reorder.spec.ts
- npx playwright test e2e/panel-drag-reorder.spec.ts
- pre-push hook: typecheck, API typecheck, Convex check, boundary check, Unicode check, rate-limit and premium-fetch guards, edge function bundle/tests, version check