### PR TITLE
[codex] Fix panel chunk TDZ startup crash

### DIFF
--- a/tests/chunk-assignment.test.mjs
+++ b/tests/chunk-assignment.test.mjs
@@ -1,77 +1,50 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync, readdirSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const viteConfigSource = readFileSync(resolve(__dirname, '../vite.config.ts'), 'utf-8');
+const manualChunksMatch = viteConfigSource.match(
+  /manualChunks\(id\)\s*\{([\s\S]*?)\n\s*\/\/ Give lazy-loaded locale chunks/,
+);
+assert.ok(
+  manualChunksMatch,
+  'Could not locate the manualChunks body in vite.config.ts; chunk guardrails would otherwise be vacuous.',
+);
+const manualChunksSource = manualChunksMatch[1];
 
-/**
- * Extract all quoted string entries from a `new Set([...])` block.
- */
-function extractSetEntries(varName) {
-  const re = new RegExp(`const ${varName}\\s*=\\s*new Set\\(\\[([\\s\\S]*?)\\]\\)`, 'm');
-  const match = viteConfigSource.match(re);
-  if (!match) return new Set();
-  // Match only quoted strings — ignores comments and whitespace
-  const entries = match[1].match(/'([^']+)'/g) || [];
-  return new Set(entries.map(s => s.replace(/^'|'$/g, '')));
-}
-
-const CORE = extractSetEntries('CORE_PANEL_FILES');
-const HAPPY = extractSetEntries('HAPPY_PANEL_FILES');
-const FINANCE = extractSetEntries('FINANCE_PANEL_FILES');
-const FULL = extractSetEntries('FULL_PANEL_FILES');
-const TECH = extractSetEntries('TECH_PANEL_FILES');
-const ALL_ASSIGNED = new Set([...CORE, ...HAPPY, ...FINANCE, ...FULL, ...TECH]);
-
-const componentFiles = readdirSync(resolve(__dirname, '../src/components'))
-  .filter(f => f.endsWith('.ts') && !f.includes('.test.'))
-  .map(f => f.replace(/\.ts$/, ''));
-
-const panelFiles = componentFiles.filter(f => f.endsWith('Panel') || f === 'Panel');
-
-describe('chunk assignment sync enforcement', () => {
-  it('every *Panel.ts component is assigned to exactly one chunk set', () => {
-    const unassigned = panelFiles.filter(f => !ALL_ASSIGNED.has(f));
-    assert.deepEqual(
-      unassigned,
-      [],
-      `Unassigned panel files (add to a *_PANEL_FILES set in vite.config.ts): ${unassigned.join(', ')}`
+describe('panel chunk assignment guardrails', () => {
+  it('keeps panel component modules in one chunk until TDZ-prone singletons are removed', () => {
+    assert.match(
+      manualChunksSource,
+      /id\.includes\('\/src\/components\/'\)\s*&&\s*id\.endsWith\('Panel\.ts'\)[\s\S]*?return\s+'panels'/,
+      'Panel component modules must stay in the single panels chunk until top-level service clients are lazy-initialized.',
     );
   });
 
-  it('no panel appears in multiple chunk sets', () => {
-    const sets = { CORE, HAPPY, FINANCE, FULL, TECH };
-    const dupes = [];
-    for (const file of ALL_ASSIGNED) {
-      const inSets = Object.entries(sets)
-        .filter(([, s]) => s.has(file))
-        .map(([name]) => name);
-      if (inSets.length > 1) {
-        dupes.push(`${file} → ${inSets.join(', ')}`);
-      }
-    }
-    assert.deepEqual(dupes, [], `Panels in multiple chunk sets:\n${dupes.join('\n')}`);
-  });
-
-  it('chunk sets do not reference non-existent component files', () => {
-    const fileSet = new Set(componentFiles);
-    const ghosts = [...ALL_ASSIGNED].filter(f => !fileSet.has(f));
-    assert.deepEqual(
-      ghosts,
-      [],
-      `Chunk sets reference files that don't exist in src/components/: ${ghosts.join(', ')}`
+  it('does not re-enable variant panel chunks that create circular ESM evaluation', () => {
+    assert.doesNotMatch(
+      manualChunksSource,
+      /return\s+'(?:core|full|finance|happy|tech)-panels'/,
+      'Variant panel chunks can reintroduce core-panels -> full-panels -> core-panels cycles and startup TDZ crashes.',
     );
   });
 
-  it('vite.config.ts has no silent Panel catch-all fallback', () => {
+  it('does not retain unused staged panel-cluster config', () => {
     assert.doesNotMatch(
       viteConfigSource,
-      /if\s*\(fileName\.endsWith\('Panel'\).*\)\s*return\s*'core-panels'/,
-      'The silent catch-all that routes unassigned panels to core-panels must not exist. ' +
-      'Use the throw-on-unassigned pattern instead.'
+      /\bPANEL_CLUSTER\b/,
+      'Unused staged panel-cluster maps add maintenance surface and can be mistaken for active build routing.',
+    );
+  });
+
+  it('does not wire domain panel chunks into manualChunks', () => {
+    assert.doesNotMatch(
+      manualChunksSource,
+      /return\s+['"`]panels-[a-z-]+['"`]/,
+      'Domain panel chunks can reintroduce startup TDZ crashes while panel modules still have top-level service clients.',
     );
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,72 +11,6 @@ import { VARIANT_META, type VariantMeta } from './src/config/variant-meta';
 // Env-dependent constants moved inside defineConfig function
 
 
-// Panel chunk assignment — derived from src/config/panels.ts variant definitions.
-// Panels in 3+ variants go to core-panels. Panels in 1-2 variants go to their
-// most specific variant chunk. Base components always go to core-panels.
-const CORE_PANEL_FILES = new Set([
-  // Base components and shared infrastructure
-  'Panel', 'VirtualList', 'Map', 'DeckGLMap', 'MapContainer', 'MapPopup',
-  'SignalModal', 'PlaybackControl', 'SearchModal', 'MobileWarningModal',
-  'PizzIntIndicator', 'LlmStatusIndicator', 'IntelligenceGapBadge',
-  'UnifiedSettings', 'BreakingNewsBanner', 'ResilienceWidget', 'StatusPanel',
-  'AviationCommandBar',
-  // Panels in 3+ variants (full, tech, finance, commodity share many)
-  'NewsPanel', 'MarketPanel', 'LiveNewsPanel', 'LiveWebcamsPanel',
-  'PinnedWebcamsPanel', 'InsightsPanel', 'PredictionPanel', 'MonitorPanel',
-  'EconomicPanel', 'MacroSignalsPanel', 'ETFFlowsPanel', 'StablecoinPanel',
-  'WorldClockPanel', 'AirlineIntelPanel',
-  // Shared across full + finance + commodity (3 variants)
-  // Note: CommoditiesPanel and HeatmapPanel are sub-exports of MarketPanel.ts, not standalone files
-  'EnergyComplexPanel', 'OilInventoriesPanel', 'LatestBriefPanel',
-  'PipelineStatusPanel', 'PositioningPanel',
-  'TradePolicyPanel', 'SupplyChainPanel',
-  'SanctionsPressurePanel', 'GulfEconomiesPanel', 'ConsumerPricesPanel',
-  'LiquidityShiftsPanel', 'GoldIntelligencePanel',
-  // Programmatic / multi-variant panels (used dynamically or across 2+ variants)
-  'CustomWidgetPanel', 'McpDataPanel', 'CountryBriefPanel',
-  'CountryDeepDivePanel', 'TechHubsPanel', 'RegulationPanel',
-]);
-
-const HAPPY_PANEL_FILES = new Set([
-  'PositiveNewsFeedPanel', 'ProgressChartsPanel', 'CountersPanel',
-  'HeroSpotlightPanel', 'BreakthroughsTickerPanel', 'GoodThingsDigestPanel',
-  'SpeciesComebackPanel', 'RenewableEnergyPanel', 'GivingPanel',
-]);
-
-const FINANCE_PANEL_FILES = new Set([
-  'StockAnalysisPanel', 'StockBacktestPanel', 'DailyMarketBriefPanel',
-  'FearGreedPanel', 'AAIISentimentPanel', 'MarketBreadthPanel',
-  'MacroTilesPanel', 'FSIPanel', 'YieldCurvePanel',
-  'EarningsCalendarPanel', 'EconomicCalendarPanel', 'CotPositioningPanel',
-  'WsbTickerScannerPanel',
-  'GroceryBasketPanel', 'BigMacPanel', 'FuelPricesPanel', 'FaoFoodPriceIndexPanel',
-]);
-
-const FULL_PANEL_FILES = new Set([
-  'GdeltIntelPanel', 'CIIPanel', 'CascadePanel',
-  'StrategicRiskPanel', 'StrategicPosturePanel',
-  'CorrelationPanel', 'MilitaryCorrelationPanel', 'EscalationCorrelationPanel',
-  'EconomicCorrelationPanel', 'DisasterCorrelationPanel',
-  'DisplacementPanel', 'ClimateAnomalyPanel', 'PopulationExposurePanel',
-  'SecurityAdvisoriesPanel', 'DefensePatentsPanel',
-  'RadiationWatchPanel', 'ThermalEscalationPanel', 'OrefSirensPanel',
-  'TelegramIntelPanel', 'InvestmentsPanel', 'NationalDebtPanel',
-  'MarketImplicationsPanel', 'SatelliteFiresPanel', 'HormuzPanel',
-  'UcdpEventsPanel', 'ClimateNewsPanel', 'DiseaseOutbreaksPanel',
-  'SocialVelocityPanel', 'EnergyCrisisPanel',
-  'ChokepointStripPanel', 'StorageFacilityMapPanel', 'FuelShortagePanel',
-  'EnergyDisruptionsPanel', 'EnergyRiskOverviewPanel',
-  // Full-only panels
-  'ForecastPanel', 'ChatAnalystPanel', 'CrossSourceSignalsPanel',
-  'DeductionPanel', 'GeoHubsPanel',
-]);
-
-const TECH_PANEL_FILES = new Set([
-  'TechEventsPanel', 'ServiceStatusPanel', 'InternetDisruptionsPanel',
-  'TechReadinessPanel', 'RuntimeConfigPanel',
-]);
-
 const brotliCompressAsync = promisify(brotliCompress);
 const BROTLI_EXTENSIONS = new Set(['.js', '.mjs', '.css', '.html', '.svg', '.json', '.txt', '.xml', '.wasm']);
 
@@ -92,79 +26,6 @@ const LAZY_HTML_PRELOAD_CHUNKS = ['maplibre', 'deck-stack', 'MapContainer'] as c
 const LAZY_HTML_PRELOAD_RE = new RegExp(
   `/(${LAZY_HTML_PRELOAD_CHUNKS.join('|')})-[A-Za-z0-9_-]+\\.js$`,
 );
-
-// Panel-cluster manualChunks map. Splits the previously monolithic ~2.3MB
-// `panels` chunk into per-domain chunks so cache invalidation is local to
-// the cluster a panel lives in and per-variant builds can prune unused
-// clusters. Unmapped panels fall through to a generic `panels` chunk.
-const PANEL_CLUSTER: Record<string, string> = {
-  // Markets / equities / crypto positioning
-  AAIISentiment: 'panels-markets', CotPositioning: 'panels-markets',
-  ETFFlows: 'panels-markets', EarningsCalendar: 'panels-markets',
-  EconomicCalendar: 'panels-markets', FearGreed: 'panels-markets',
-  GoldIntelligence: 'panels-markets', LiquidityShifts: 'panels-markets',
-  MacroSignals: 'panels-markets', Market: 'panels-markets',
-  MarketBreadth: 'panels-markets', MarketImplications: 'panels-markets',
-  Positioning: 'panels-markets', Stablecoin: 'panels-markets',
-  StockAnalysis: 'panels-markets', StockBacktest: 'panels-markets',
-  WsbTickerScanner: 'panels-markets', YieldCurve: 'panels-markets',
-  // Energy / commodities / supply infra
-  ChokepointStrip: 'panels-energy', EnergyComplex: 'panels-energy',
-  EnergyCrisis: 'panels-energy', EnergyDisruptions: 'panels-energy',
-  EnergyRiskOverview: 'panels-energy', FuelPrices: 'panels-energy',
-  FuelShortage: 'panels-energy', Hormuz: 'panels-energy',
-  OilInventories: 'panels-energy', PipelineStatus: 'panels-energy',
-  StorageFacilityMap: 'panels-energy', RenewableEnergy: 'panels-energy',
-  // Defense / military / aviation
-  AirlineIntel: 'panels-defense', DefensePatents: 'panels-defense',
-  OrefSirens: 'panels-defense', StrategicPosture: 'panels-defense',
-  StrategicRisk: 'panels-defense', ThermalEscalation: 'panels-defense',
-  UcdpEvents: 'panels-defense',
-  // News / feeds / briefs
-  BreakthroughsTicker: 'panels-news', ClimateNews: 'panels-news',
-  DailyMarketBrief: 'panels-news', GdeltIntel: 'panels-news',
-  GoodThingsDigest: 'panels-news', LatestBrief: 'panels-news',
-  LiveNews: 'panels-news', News: 'panels-news',
-  PositiveNewsFeed: 'panels-news', TelegramIntel: 'panels-news',
-  // Macro / prices / trade
-  BigMac: 'panels-economy', ConsumerPrices: 'panels-economy',
-  Economic: 'panels-economy',
-  FaoFoodPriceIndex: 'panels-economy', FSI: 'panels-economy',
-  GroceryBasket: 'panels-economy', GulfEconomies: 'panels-economy',
-  Investments: 'panels-economy', MacroTiles: 'panels-economy',
-  NationalDebt: 'panels-economy', SanctionsPressure: 'panels-economy',
-  SupplyChain: 'panels-economy', TradePolicy: 'panels-economy',
-  // Country briefs / signals / monitors / agent surfaces.
-  // CorrelationPanel base lives here, so all *Correlation consumers MUST stay
-  // in this cluster — splitting them across clusters caused TDZ on init.
-  ChatAnalyst: 'panels-intel', CII: 'panels-intel',
-  Cascade: 'panels-intel', Correlation: 'panels-intel',
-  CountryBrief: 'panels-intel', CountryDeepDive: 'panels-intel',
-  CrossSourceSignals: 'panels-intel', CustomWidget: 'panels-intel',
-  Deduction: 'panels-intel',
-  DisasterCorrelation: 'panels-intel',
-  EconomicCorrelation: 'panels-intel',
-  EscalationCorrelation: 'panels-intel',
-  MilitaryCorrelation: 'panels-intel',
-  Forecast: 'panels-intel',
-  HeroSpotlight: 'panels-intel', Insights: 'panels-intel',
-  LiveWebcams: 'panels-intel', McpData: 'panels-intel',
-  Monitor: 'panels-intel', PinnedWebcams: 'panels-intel',
-  Prediction: 'panels-intel', ProgressCharts: 'panels-intel',
-  Regulation: 'panels-intel',
-  // Disasters / climate / connectivity / society
-  ClimateAnomaly: 'panels-risk', Counters: 'panels-risk',
-  DiseaseOutbreaks: 'panels-risk',
-  Displacement: 'panels-risk', GeoHubs: 'panels-risk',
-  Giving: 'panels-risk', InternetDisruptions: 'panels-risk',
-  PopulationExposure: 'panels-risk', RadiationWatch: 'panels-risk',
-  RuntimeConfig: 'panels-risk', SatelliteFires: 'panels-risk',
-  SecurityAdvisories: 'panels-risk', ServiceStatus: 'panels-risk',
-  SocialVelocity: 'panels-risk', SpeciesComeback: 'panels-risk',
-  Status: 'panels-risk', TechEvents: 'panels-risk',
-  TechHubs: 'panels-risk', TechReadiness: 'panels-risk',
-  WorldClock: 'panels-risk',
-};
 
 function brotliPrecompressPlugin(): Plugin {
   return {
@@ -1083,24 +944,13 @@ export default defineConfig(({ mode }) => {
                 return 'sentry';
               }
             }
-            if (id.includes('/src/components/') && id.endsWith('.ts')) {
-              const match = id.match(/\/([^/]+)\.ts$/);
-              if (match) {
-                const fileName = match[1];
-                if (CORE_PANEL_FILES.has(fileName)) return 'core-panels';
-                if (HAPPY_PANEL_FILES.has(fileName)) return 'happy-panels';
-                if (FINANCE_PANEL_FILES.has(fileName)) return 'finance-panels';
-                if (FULL_PANEL_FILES.has(fileName)) return 'full-panels';
-                if (TECH_PANEL_FILES.has(fileName)) return 'tech-panels';
-                // Fail on unassigned panel files — add new panels to the correct set above
-                if (fileName.endsWith('Panel') || fileName === 'Panel') {
-                  throw new Error(
-                    `[manualChunks] Unassigned panel component: ${fileName}. ` +
-                    `Add it to CORE_PANEL_FILES, FULL_PANEL_FILES, HAPPY_PANEL_FILES, ` +
-                    `FINANCE_PANEL_FILES, or TECH_PANEL_FILES in vite.config.ts.`
-                  );
-                }
-              }
+            if (id.includes('/src/components/') && id.endsWith('Panel.ts')) {
+              // Keep panel modules in one chunk for now. Splitting them by
+              // variant or domain exposes ESM TDZ crashes because several
+              // panel modules still create generated service clients at the
+              // top level. Revisit finer panel chunking only after those
+              // imports are lazy-initialized.
+              return 'panels';
             }
             // Give lazy-loaded locale chunks a recognizable prefix so the
             // service worker can exclude them from precache (en.json is


### PR DESCRIPTION
## Summary
- keep panel component modules in the single `panels` chunk to avoid the `core-panels`/`full-panels` ESM TDZ startup crash
- remove the unused staged panel-cluster map after review feedback
- strengthen chunk guard tests so variant/domain panel chunks cannot be re-enabled silently while top-level service clients remain

## Tradeoff
This is an explicit stability-first rollback of the panel chunk split from #3113. The merged build still statically imports/modulepreloads the unified `panels` chunk, so the whole panel bundle downloads eagerly at boot and one-panel edits invalidate that shared chunk for all users. That cost is accepted here because the split was crashing production.

## Follow-up
Track the performance recovery in #3944: lazy-initialize panel service-client singletons, then re-split panel chunks and relax/update the guard tests once the TDZ risk is removed.

## Validation
- `node --test tests/chunk-assignment.test.mjs`
- `git diff --check`
- `npm run build:full`
- production preview smoke with Playwright: HTTP 200, no page errors, no `ReferenceError`
- `./.husky/pre-push`