### PR TITLE
perf(mcp): disable rate-limiter Redis retries to unblock test suite

### DIFF
--- a/api/mcp/auth.ts
+++ b/api/mcp/auth.ts
@@ -41,7 +41,7 @@ function getMcpRatelimit(): Ratelimit | null {
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
   if (!url || !token) return null;
   mcpRatelimit = new Ratelimit({
-    redis: new Redis({ url, token }),
+    redis: new Redis({ url, token, retry: false }),
     limiter: Ratelimit.slidingWindow(60, '60 s'),
     prefix: 'rl:mcp',
     analytics: false,
@@ -55,7 +55,7 @@ function getMcpProMinRatelimit(): Ratelimit | null {
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
   if (!url || !token) return null;
   mcpProMinRatelimit = new Ratelimit({
-    redis: new Redis({ url, token }),
+    redis: new Redis({ url, token, retry: false }),
     limiter: Ratelimit.slidingWindow(60, '60 s'),
     prefix: 'rl:mcp:pro-min',
     analytics: false,


### PR DESCRIPTION
## Summary
- `npm run test:data` went from **~7 min → ~1m30s** (10,190 pass / 0 fail) via a 2-line change in `api/mcp/auth.ts`.
- **Root cause:** the MCP rate limiter's `@upstash/redis` client used the default 5-retry exponential backoff. In handler tests that set `UPSTASH_REDIS_REST_URL='https://fake.upstash.io'` and mock `globalThis.fetch` for `/get/` cache reads only, the limiter's `EVALSHA` fell through to the **real network** and burned **~4.3s of backoff per `tools/call`** before `applyPerMinuteLimit` degraded open. `tests/mcp.test.mjs` alone was **5m29s** — the long pole of the suite (it runs in parallel with everything else under default process isolation).
- **Fix:** `retry: false` on the two rate-limiter Redis clients. The limiter now degrades open immediately on an unreachable Redis instead of stalling — the right behaviour for a best-effort 60/min limiter (never add retry latency to a user request during an Upstash blip). Enforcement during an outage is unchanged (open either way). 429 enforcement tests use dep-injected pipeline mocks, so they're unaffected.

### Before / After
| | Before | After |
|---|---|---|
| `tests/mcp.test.mjs` | 5m29s | ~2s |
| full `npm run test:data` | ~7 min | ~1m30s |

## Test plan
- [x] `npm run typecheck` + `npm run typecheck:api`
- [x] `npm run lint` (biome)
- [x] `npm run test:data` — 10,190 pass / 0 fail / 6 skipped
- [x] `node --test tests/edge-functions.test.mjs`
- [x] esbuild bundle check on `api/*.js`
- [x] `npm run lint:md` + `npm run version:check`
- [ ] Confirm prod rate-limiter behaviour acceptable: degrades open faster on Upstash unavailability (no enforcement-during-outage change)