### PR TITLE
fix(health): return 503 on REDIS_DOWN so HTTP monitors detect total outage

### DIFF
--- a/api/health-cors.test.mjs
+++ b/api/health-cors.test.mjs
@@ -1,6 +1,19 @@
 import { strict as assert } from 'node:assert';
 import test from 'node:test';
-import handler from './health.js';
+
+// Make this suite independent of the ambient environment. The handler reads
+// Redis credentials per-request via getRedisCredentials(); if a developer (or
+// CI job) has real UPSTASH_REDIS_REST_URL/TOKEN exported, the GET test below
+// would take the live 200 path instead of the deterministic REDIS_DOWN→503
+// path and fail spuriously. Clearing the creds before importing the handler
+// forces the no-Redis path regardless of env — the CORS headers under test are
+// identical on both paths, so this only stabilizes the status code.
+for (const k of [
+  'UPSTASH_REDIS_REST_URL', 'KV_REST_API_URL', 'REDIS_REST_URL',
+  'UPSTASH_REDIS_REST_TOKEN', 'KV_REST_API_TOKEN', 'REDIS_REST_TOKEN',
+]) delete process.env[k];
+
+const { default: handler } = await import('./health.js');
 
 function makePreflight(origin) {
   return new Request('https://api.worldmonitor.app/api/health?compact=1', {
@@ -30,11 +43,11 @@ test('health GET response is compatible with credentialed browser fetches', asyn
     },
   }));
 
-  // No Upstash credentials in the test env → the handler short-circuits to
-  // REDIS_DOWN, which returns HTTP 503 (the one hard-down state with a non-200
-  // code — see api/health.js). The point of this test is that the CORS headers
-  // a credentialed browser fetch needs are present on the outage path too, not
-  // just the healthy 200 path.
+  // Redis credentials are cleared at module load (see top of file), so the
+  // handler deterministically short-circuits to REDIS_DOWN → HTTP 503 (the one
+  // hard-down state with a non-200 code — see api/health.js). The point of this
+  // test is that the CORS headers a credentialed browser fetch needs are present
+  // on the outage path too, not just the healthy 200 path.
   assert.equal(resp.status, 503);
   const body = await resp.json();
   assert.equal(body.status, 'REDIS_DOWN');

--- a/api/health-cors.test.mjs
+++ b/api/health-cors.test.mjs
@@ -30,7 +30,14 @@ test('health GET response is compatible with credentialed browser fetches', asyn
     },
   }));
 
-  assert.equal(resp.status, 200);
+  // No Upstash credentials in the test env → the handler short-circuits to
+  // REDIS_DOWN, which returns HTTP 503 (the one hard-down state with a non-200
+  // code — see api/health.js). The point of this test is that the CORS headers
+  // a credentialed browser fetch needs are present on the outage path too, not
+  // just the healthy 200 path.
+  assert.equal(resp.status, 503);
+  const body = await resp.json();
+  assert.equal(body.status, 'REDIS_DOWN');
   assert.equal(resp.headers.get('access-control-allow-origin'), 'https://www.worldmonitor.app');
   assert.equal(resp.headers.get('access-control-allow-credentials'), 'true');
   assert.equal(resp.headers.get('cache-control'), 'private, no-store, max-age=0');

--- a/api/health.js
+++ b/api/health.js
@@ -797,11 +797,16 @@ export default async function handler(req, ctx) {
     results = await redisPipeline(commands, 8_000);
     if (!results) throw new Error('Redis request failed');
   } catch (err) {
+    // REDIS_DOWN is the one hard-down state that returns 503: with Redis
+    // unreachable the endpoint can assess nothing, so a plain HTTP-status
+    // monitor (UptimeRobot, k8s probe, LB) must see a failure. DEGRADED/
+    // UNHEALTHY/WARNING stay 200 (verdict in body) so warn-level seed jitter
+    // doesn't flap HTTP monitors — see #2699 and the always-200 main response.
     return jsonResponse({
       status: 'REDIS_DOWN',
       error: err.message,
       checkedAt: new Date(now).toISOString(),
-    }, 200, headers);
+    }, 503, headers);
   }
 
   // keyStrens: byte length per data key (0 = missing/empty/sentinel)

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -198,7 +198,11 @@ Use `/api/health` as the monitor URL. The HTTP status code only distinguishes a 
 - `503` = `REDIS_DOWN` (Redis unreachable — a true hard outage)
 - `200` = every other state, including `DEGRADED` and `UNHEALTHY`
 
-So an HTTP-status-only monitor catches a full backend outage but **not** degraded/unhealthy data. For those, add a keyword monitor that alerts when `"status":"HEALTHY"` is **absent** from the response body (or parse `summary.crit > 0`).
+So an HTTP-status-only monitor catches a full backend outage but **not** degraded/unhealthy data. For those, add a keyword monitor.
+
+Point the keyword monitor at `https://api.worldmonitor.app/api/health?compact=1` and alert when the compact token `"status":"HEALTHY"` (no space after the colon) is **absent** from the response body. Compact mode serializes with no indentation, so this exact token is stable regardless of formatting.
+
+> The bare `/api/health` URL pretty-prints the body, so the healthy token there is `"status": "HEALTHY"` **with a space** after the colon. If you monitor the non-compact URL, match that spaced token instead — the no-space `"status":"HEALTHY"` is absent even when healthy and will false-alert. Prefer `?compact=1`, or parse `summary.crit > 0`.
 
 ### Custom Alerting
 

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -23,9 +23,11 @@ Primary health endpoint. Checks all Redis-backed data keys and seed freshness me
 |-------------|---------------|---------|
 | `200` | `HEALTHY` | All checks OK, no warnings |
 | `200` | `WARNING` | Some keys stale or on-demand keys empty, but no critical failures |
-| `503` | `DEGRADED` | 1-3 bootstrap keys empty |
-| `503` | `UNHEALTHY` | 4+ bootstrap keys empty |
-| `503` | `REDIS_DOWN` | Could not connect to Redis |
+| `200` | `DEGRADED` | Critical keys empty, but ≤3% of all probed keys |
+| `200` | `UNHEALTHY` | Critical keys empty, >3% of all probed keys |
+| `503` | `REDIS_DOWN` | Could not connect to Redis — the **only** state that returns a non-200 code |
+
+> The overall health verdict lives in the JSON `status` field, not the HTTP code. Every state except `REDIS_DOWN` returns `200` so warn-level seed jitter doesn't flap HTTP-status monitors (see PR #2699). `REDIS_DOWN` returns `503` because with Redis unreachable the endpoint can assess nothing, so a plain HTTP probe must see a failure.
 
 ### Response Body
 
@@ -33,9 +35,11 @@ Primary health endpoint. Checks all Redis-backed data keys and seed freshness me
 {
   "status": "HEALTHY | WARNING | DEGRADED | UNHEALTHY | REDIS_DOWN",
   "summary": {
-    "total": 57,
-    "ok": 52,
+    "total": 194,
+    "ok": 180,
     "warn": 5,
+    "onDemandWarn": 9,
+    "staleContent": 0,
     "crit": 0
   },
   "checkedAt": "2026-03-11T14:00:00.000Z",
@@ -49,6 +53,8 @@ Primary health endpoint. Checks all Redis-backed data keys and seed freshness me
   }
 }
 ```
+
+`summary` fields: `total` is one entry per probed key (currently ~194 and growing as panels are added). `warn` **excludes** on-demand-empty keys — those are surfaced separately as `onDemandWarn` so they don't drive the overall verdict to `WARNING`. `staleContent` is a **subset** of `warn` (fresh seeder but the upstream feed stopped advancing). Only `crit` (`EMPTY`/`EMPTY_DATA`) drives `DEGRADED`/`UNHEALTHY`.
 
 With `?compact=1`, the `checks` object is replaced by `problems` containing only non-OK keys.
 
@@ -69,9 +75,13 @@ Keys are grouped into three tiers that determine alert severity:
 | `OK` | Green | Data present, seed fresh |
 | `OK_CASCADE` | Green | Key empty but a sibling in the cascade group has data (e.g., theater posture fallback chain) |
 | `STALE_SEED` | Warn | Data present but `seed-meta` age exceeds `maxStaleMin` |
-| `EMPTY_ON_DEMAND` | Warn | On-demand key has no data yet |
-| `EMPTY` | Crit | Bootstrap or standalone key has no data |
-| `EMPTY_DATA` | Crit | Key exists but contains zero records |
+| `STALE_CONTENT` | Warn | Seeder is fresh but the upstream content stopped advancing (frozen feed); counted in `summary.staleContent` |
+| `COVERAGE_PARTIAL` | Warn | Record count is below the key's declared `minRecordCount` (e.g. 10/13 chokepoints) |
+| `SEED_ERROR` | Warn | `seed-meta` reports `status: "error"` from the last seed run |
+| `REDIS_PARTIAL` | Warn | A single per-command Redis error on this key's STRLEN/GET (not a full outage) |
+| `EMPTY_ON_DEMAND` | Warn | On-demand key has no data yet (expected until first request); counted in `summary.onDemandWarn` |
+| `EMPTY` | Crit | Bootstrap or seeded standalone key has no data |
+| `EMPTY_DATA` | Crit | Key exists but contains zero records (and 0 is not a valid state for it) |
 
 ### Cascade Groups
 
@@ -79,6 +89,7 @@ Some keys use fallback chains. If any sibling has data, empty siblings report `O
 
 - **Theater Posture:** `theaterPostureLive` -> `theaterPosture` (stale) -> `theaterPostureBackup`
 - **Military Flights:** `militaryFlights` -> `militaryFlightsStale`
+- **Displacement:** `displacement` (current UTC year) -> `displacementPrev` (prior year, covers the Jan-1 window before the new-year seed runs)
 
 ### Staleness Thresholds (maxStaleMin)
 
@@ -86,14 +97,16 @@ Selected thresholds from `SEED_META`:
 
 | Domain | Max Stale (min) | Notes |
 |--------|----------------|-------|
-| Market quotes, crypto, sectors | 30 | High-frequency relay loops |
-| Earthquakes, unrest, insights | 30 | Critical event data |
-| Predictions | 15 | Polymarket, fast-moving |
-| Military flights | 15 | Near-real-time tracking |
-| Flight delays (FAA) | 60 | Airport delay snapshots |
-| Wildfires, climate anomalies | 120 | Slower-moving natural events |
-| Cyber threats | 480 | APT data updated less frequently |
-| BIS data, World Bank, minerals | 2880-10080 | Institutional data, weekly/monthly updates |
+| Market quotes, crypto, sectors, earthquakes, insights | 30 | High-frequency relay loops / critical event data |
+| Military flights | 30 | Near-real-time tracking |
+| Predictions, flight delays (FAA) | 90 | Polymarket / airport snapshots |
+| Unrest | 120 | 45min cron, 2h grace |
+| Cyber threats | 240 | APT data updated less frequently |
+| Wildfires | 360 | FIRMS NRT accumulates over hours |
+| Climate anomalies | 540 | 3h cron, 3× cadence |
+| BIS extended, World Bank, IMF | 2160-100800 | Institutional data, weekly/monthly/annual |
+
+> These are illustrative; `SEED_META` in `api/health.js` is the source of truth and each entry documents its own cadence rationale.
 
 ### Example Requests
 
@@ -106,7 +119,8 @@ curl -s "https://api.worldmonitor.app/api/health?compact=1" | jq .
 
 # UptimeRobot / monitoring: check HTTP status code
 curl -o /dev/null -s -w "%{http_code}" https://api.worldmonitor.app/api/health
-# Returns 200 (healthy/warning) or 503 (degraded/unhealthy)
+# Returns 503 only when Redis is unreachable (REDIS_DOWN); 200 for every other
+# state — the verdict (HEALTHY/WARNING/DEGRADED/UNHEALTHY) is in the body's `status`.
 ```
 
 ## `/api/seed-health`
@@ -179,12 +193,12 @@ curl -s https://api.worldmonitor.app/api/seed-health \
 
 ### UptimeRobot
 
-Use `/api/health` as the monitor URL. UptimeRobot checks HTTP status:
+Use `/api/health` as the monitor URL. The HTTP status code only distinguishes a total Redis outage from everything else:
 
-- `200` = up
-- `503` = down
+- `503` = `REDIS_DOWN` (Redis unreachable — a true hard outage)
+- `200` = every other state, including `DEGRADED` and `UNHEALTHY`
 
-For keyword monitoring, check for `"status":"HEALTHY"` in the response body.
+So an HTTP-status-only monitor catches a full backend outage but **not** degraded/unhealthy data. For those, add a keyword monitor that alerts when `"status":"HEALTHY"` is **absent** from the response body (or parse `summary.crit > 0`).
 
 ### Custom Alerting
 
@@ -209,4 +223,4 @@ fi
 | **Data fetched** | Full Redis values (to count records) | Only `seed-meta:*` keys |
 | **HTTP 503** | Yes (DEGRADED/UNHEALTHY) | No (always 200 unless Redis down) |
 | **Best for** | Uptime monitoring, dashboard health | Debugging seed loop issues |
-| **Response size** | Larger (57+ keys with record counts) | Smaller (42 seed domains) |
+| **Response size** | Larger (~194 keys with record counts) | Smaller (seed-meta domains only) |

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -225,6 +225,6 @@ fi
 | **Scope** | Data keys + seed metadata | Seed metadata only |
 | **Auth** | None (public) | API key or allowed origin |
 | **Data fetched** | Full Redis values (to count records) | Only `seed-meta:*` keys |
-| **HTTP 503** | Yes (DEGRADED/UNHEALTHY) | No (always 200 unless Redis down) |
+| **HTTP 503** | Only `REDIS_DOWN` (DEGRADED/UNHEALTHY return 200) | No (always 200 unless Redis down) |
 | **Best for** | Uptime monitoring, dashboard health | Debugging seed loop issues |
 | **Response size** | Larger (~194 keys with record counts) | Smaller (seed-meta domains only) |

--- a/src/services/health-freshness.ts
+++ b/src/services/health-freshness.ts
@@ -112,9 +112,21 @@ export async function refreshDataFreshnessFromHealth(options: RefreshHealthFresh
     headers: { Accept: 'application/json' },
     signal: options.signal,
   });
-  if (!resp.ok) throw new Error(`health freshness fetch failed: ${resp.status}`);
 
-  const payload = await resp.json() as HealthResponse;
+  // REDIS_DOWN now returns HTTP 503 with a JSON body {status:'REDIS_DOWN', ...}
+  // and no `checks` (see api/health.js). Parse the body first and only treat a
+  // non-2xx as a hard fetch failure when it ISN'T a recognized Redis-outage
+  // payload — otherwise the outage branch below never runs and mapped sources
+  // keep stale freshness state during an outage instead of being flagged.
+  let payload: HealthResponse | null = null;
+  try {
+    payload = await resp.json() as HealthResponse;
+  } catch {
+    payload = null;
+  }
+  if (!payload || (!resp.ok && !isRedisOutageStatus(payload.status))) {
+    throw new Error(`health freshness fetch failed: ${resp.status}`);
+  }
   const checkedAtMs = payload.checkedAt ? Date.parse(payload.checkedAt) : Date.now();
   const checkedAt = Number.isFinite(checkedAtMs) ? checkedAtMs : Date.now();
   const updatesBySource = new Map<DataSourceId, SeedHealthUpdate>();

--- a/tests/data-freshness-health.test.mts
+++ b/tests/data-freshness-health.test.mts
@@ -12,10 +12,10 @@ import {
 
 const repoRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
 
-function jsonResponse(body: unknown): Response {
+function jsonResponse(body: unknown, status = 200): Response {
   return {
-    ok: true,
-    status: 200,
+    ok: status >= 200 && status < 300,
+    status,
     json: async () => body,
   } as Response;
 }
@@ -155,10 +155,14 @@ describe('health freshness ingestion', () => {
     const applied = await refreshDataFreshnessFromHealth({
       endpoint: '/api/health',
       urlResolver: (path) => path,
+      // REDIS_DOWN returns HTTP 503 (api/health.js). The consumer must parse the
+      // body before bailing on !resp.ok, or this outage branch never runs and
+      // mapped sources keep stale freshness. Mocking 503 (not 200) makes this a
+      // real guard for that regression.
       fetchFn: async () => jsonResponse({
         status: 'REDIS_DOWN',
         checkedAt: new Date(checkedAtMs).toISOString(),
-      }),
+      }, 503),
     });
 
     assert.equal(applied, mappedSources.size);

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -1,0 +1,178 @@
+// Health classifier — classify + cascade + overall-status regression tests.
+//
+// Exercises the REAL /api/health classifier surface exported via `__testing__`
+// (classifyKey + STATUS_COUNTS) plus the overall-status thresholds the handler
+// applies inline. classifyKey resolves cascade coverage PROACTIVELY
+// (isCascadeCovered) at classify time — there is no separate downgrade pass —
+// so cascade behavior is asserted through classifyKey's returned status.
+//
+// Uses node:test + node:assert to match the repo's data-test runner
+// (`tsx --test tests/*.test.mjs` / `node --test`), the same harness as
+// tests/health-content-age.test.mjs. Vitest's describe/it is NOT compatible
+// with the bare node test runner used here.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { __testing__ } from '../api/health.js';
+
+const { classifyKey, STATUS_COUNTS, BOOTSTRAP_KEYS, STANDALONE_KEYS } = __testing__;
+
+const NOW = 1_700_000_000_000;
+const ONE_MIN_MS = 60_000;
+
+// Build the same ctx shape the handler constructs: four Maps + now.
+//   strens:     { redisDataKey -> byteLen }
+//   errors:     { redisDataKey -> errMsg }
+//   metaValues: { seedMetaKey  -> raw JSON string }
+//   metaErrors: { seedMetaKey  -> errMsg }
+function makeCtx({ strens = {}, errors = {}, metaValues = {}, metaErrors = {} } = {}) {
+  return {
+    keyStrens: new Map(Object.entries(strens)),
+    keyErrors: new Map(Object.entries(errors)),
+    keyMetaValues: new Map(Object.entries(metaValues).map(([k, v]) => [k, typeof v === 'string' ? v : JSON.stringify(v)])),
+    keyMetaErrors: new Map(Object.entries(metaErrors)),
+    now: NOW,
+  };
+}
+
+const seedMeta = (over = {}) => JSON.stringify({ fetchedAt: NOW - ONE_MIN_MS, recordCount: 5, ...over });
+
+// Mirror of the handler's overall-status computation (api/health.js ~850-859).
+// The handler computes this inline; replicating it here regression-locks the
+// HEALTHY/WARNING/DEGRADED/UNHEALTHY thresholds. /api/health always returns
+// HTTP 200 — UptimeRobot reads the JSON `status`, not the HTTP code.
+function computeOverall(critCount, realWarnCount, totalChecks) {
+  let status;
+  if (critCount === 0 && realWarnCount === 0) status = 'HEALTHY';
+  else if (critCount === 0) status = 'WARNING';
+  else if (critCount / totalChecks <= 0.03) status = 'DEGRADED';
+  else status = 'UNHEALTHY';
+  return { status, http: 200 };
+}
+
+// ── STATUS_COUNTS buckets ───────────────────────────────────────────────────
+
+test('STATUS_COUNTS buckets OK/cascade to ok, empty to crit, on-demand/stale to warn', () => {
+  assert.equal(STATUS_COUNTS.OK, 'ok');
+  assert.equal(STATUS_COUNTS.OK_CASCADE, 'ok');
+  assert.equal(STATUS_COUNTS.EMPTY, 'crit');
+  assert.equal(STATUS_COUNTS.EMPTY_DATA, 'crit');
+  assert.equal(STATUS_COUNTS.EMPTY_ON_DEMAND, 'warn');
+  assert.equal(STATUS_COUNTS.STALE_SEED, 'warn');
+});
+
+// ── classifyKey core statuses ───────────────────────────────────────────────
+
+test('classifyKey: fresh seed + data → OK', () => {
+  const entry = classifyKey('earthquakes', BOOTSTRAP_KEYS.earthquakes, { allowOnDemand: false },
+    makeCtx({
+      strens: { [BOOTSTRAP_KEYS.earthquakes]: 1234 },
+      metaValues: { 'seed-meta:seismology:earthquakes': seedMeta() },
+    }));
+  assert.equal(entry.status, 'OK');
+});
+
+test('classifyKey: present-but-stale seed → STALE_SEED (warn), data still present', () => {
+  const entry = classifyKey('earthquakes', BOOTSTRAP_KEYS.earthquakes, { allowOnDemand: false },
+    makeCtx({
+      strens: { [BOOTSTRAP_KEYS.earthquakes]: 1234 },
+      // earthquakes maxStaleMin=30; 200 min exceeds it
+      metaValues: { 'seed-meta:seismology:earthquakes': seedMeta({ fetchedAt: NOW - 200 * ONE_MIN_MS }) },
+    }));
+  assert.equal(entry.status, 'STALE_SEED');
+  assert.equal(STATUS_COUNTS[entry.status], 'warn');
+});
+
+test('classifyKey: empty bootstrap key (no cascade) → EMPTY (crit)', () => {
+  const entry = classifyKey('earthquakes', BOOTSTRAP_KEYS.earthquakes, { allowOnDemand: false },
+    makeCtx({ metaValues: { 'seed-meta:seismology:earthquakes': seedMeta() } }));
+  assert.equal(entry.status, 'EMPTY');
+  assert.equal(STATUS_COUNTS[entry.status], 'crit');
+});
+
+test('classifyKey: empty on-demand standalone key → EMPTY_ON_DEMAND (warn)', () => {
+  // minerals is in ON_DEMAND_KEYS and has no SEED_META entry.
+  const entry = classifyKey('minerals', STANDALONE_KEYS.minerals, { allowOnDemand: true }, makeCtx({}));
+  assert.equal(entry.status, 'EMPTY_ON_DEMAND');
+  assert.equal(STATUS_COUNTS[entry.status], 'warn');
+});
+
+// ── cascade coverage (proactive, via isCascadeCovered) ──────────────────────
+
+test('cascade: empty theaterPostureLive with data in a sibling → OK_CASCADE (no crit/warn leak)', () => {
+  // group ['theaterPosture','theaterPostureLive','theaterPostureBackup']
+  const entry = classifyKey('theaterPostureLive', STANDALONE_KEYS.theaterPostureLive, { allowOnDemand: true },
+    makeCtx({
+      strens: {
+        [STANDALONE_KEYS.theaterPostureLive]: 0,   // empty
+        [STANDALONE_KEYS.theaterPosture]: 4096,    // sibling (stale fallback) has data
+      },
+    }));
+  assert.equal(entry.status, 'OK_CASCADE');
+  assert.equal(STATUS_COUNTS[entry.status], 'ok');
+});
+
+test('cascade: all theater-posture members empty → EMPTY (no false OK_CASCADE)', () => {
+  // theaterPostureLive is NOT in ON_DEMAND_KEYS, so a wholly-empty group is a
+  // real outage → EMPTY (crit). The cascade only shields a member when a
+  // SIBLING has data; when every member is empty there is nothing to cascade
+  // from, so the status falls through to the strict EMPTY path.
+  const entry = classifyKey('theaterPostureLive', STANDALONE_KEYS.theaterPostureLive, { allowOnDemand: true },
+    makeCtx({
+      strens: {
+        [STANDALONE_KEYS.theaterPostureLive]: 0,
+        [STANDALONE_KEYS.theaterPosture]: 0,
+        [STANDALONE_KEYS.theaterPostureBackup]: 0,
+      },
+    }));
+  assert.equal(entry.status, 'EMPTY');
+  assert.equal(STATUS_COUNTS[entry.status], 'crit');
+});
+
+test('cascade: militaryFlights stale-fallback sibling with data shields the empty live key', () => {
+  // group ['militaryFlights','militaryFlightsStale']
+  const entry = classifyKey('militaryFlights', STANDALONE_KEYS.militaryFlights, { allowOnDemand: true },
+    makeCtx({
+      strens: {
+        [STANDALONE_KEYS.militaryFlights]: 0,
+        [STANDALONE_KEYS.militaryFlightsStale]: 8192,
+      },
+    }));
+  assert.equal(entry.status, 'OK_CASCADE');
+});
+
+test('cascade: a member that HAS data classifies on its own merits (OK), never downgraded', () => {
+  const entry = classifyKey('militaryFlights', STANDALONE_KEYS.militaryFlights, { allowOnDemand: true },
+    makeCtx({
+      strens: {
+        [STANDALONE_KEYS.militaryFlights]: 8192,
+        [STANDALONE_KEYS.militaryFlightsStale]: 8192,
+      },
+      metaValues: { 'seed-meta:military:flights': seedMeta() },
+    }));
+  assert.equal(entry.status, 'OK');
+});
+
+// ── overall status thresholds ───────────────────────────────────────────────
+
+test('overall: 0 crit / 0 warn → HEALTHY / 200', () => {
+  assert.deepEqual(computeOverall(0, 0, 150), { status: 'HEALTHY', http: 200 });
+});
+
+test('overall: warn>0 (no crit) → WARNING / 200', () => {
+  assert.deepEqual(computeOverall(0, 1, 150), { status: 'WARNING', http: 200 });
+  assert.deepEqual(computeOverall(0, 40, 150), { status: 'WARNING', http: 200 });
+});
+
+test('overall: crit within ~3% of total → DEGRADED / 200', () => {
+  // 3/150 = 0.02 <= 0.03
+  assert.deepEqual(computeOverall(3, 0, 150), { status: 'DEGRADED', http: 200 });
+  assert.deepEqual(computeOverall(1, 5, 150), { status: 'DEGRADED', http: 200 });
+});
+
+test('overall: crit above ~3% of total → UNHEALTHY / 200', () => {
+  // 5/150 = 0.033 > 0.03
+  assert.deepEqual(computeOverall(5, 0, 150), { status: 'UNHEALTHY', http: 200 });
+  assert.deepEqual(computeOverall(20, 2, 150), { status: 'UNHEALTHY', http: 200 });
+});

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -39,9 +39,11 @@ function makeCtx({ strens = {}, errors = {}, metaValues = {}, metaErrors = {} } 
 const seedMeta = (over = {}) => JSON.stringify({ fetchedAt: NOW - ONE_MIN_MS, recordCount: 5, ...over });
 
 // Mirror of the handler's overall-status computation (api/health.js ~850-859).
-// The handler computes this inline; replicating it here regression-locks the
-// HEALTHY/WARNING/DEGRADED/UNHEALTHY thresholds. /api/health always returns
-// HTTP 200 — UptimeRobot reads the JSON `status`, not the HTTP code.
+// The handler computes this inline; these tests exercise the LOCAL replica —
+// they document the intended HEALTHY/WARNING/DEGRADED/UNHEALTHY thresholds but
+// do NOT catch handler drift if the 0.03 constant or branch order changes in
+// api/health.js without updating here. Non-REDIS_DOWN states return HTTP 200
+// (verdict in the JSON `status`); REDIS_DOWN returns 503.
 function computeOverall(critCount, realWarnCount, totalChecks) {
   let status;
   if (critCount === 0 && realWarnCount === 0) status = 'HEALTHY';

--- a/tests/health-history-endpoint.test.mjs
+++ b/tests/health-history-endpoint.test.mjs
@@ -52,7 +52,11 @@ describe('api/health ?history=1', () => {
     const req = new Request('https://api.worldmonitor.app/api/health?compact=1');
     const res = await handler(req);
 
-    assert.equal(res.status, 200);
+    // With Upstash unconfigured the non-history path short-circuits to
+    // REDIS_DOWN, which returns 503 (the one hard-down state that surfaces a
+    // non-200 HTTP code — see api/health.js REDIS_DOWN handler). The point of
+    // this test is the shape (no history-specific keys), not the status code.
+    assert.equal(res.status, 503);
     const body = await res.json();
     assert.ok(
       !Object.hasOwn(body, 'lastFailure'),

--- a/tests/health-redis-down-status.test.mjs
+++ b/tests/health-redis-down-status.test.mjs
@@ -1,0 +1,48 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+// /api/health returns HTTP 503 ONLY for the hard-down REDIS_DOWN state, so a
+// plain HTTP-status monitor (UptimeRobot, k8s probe, LB) detects a total
+// backend outage. Every other state (HEALTHY/WARNING/DEGRADED/UNHEALTHY)
+// intentionally returns 200 with the status in the body — see #2699, which
+// moved off per-severity HTTP codes to stop warn-level seed jitter from
+// flapping HTTP monitors.
+//
+// Run: node --test tests/health-redis-down-status.test.mjs
+
+// Force the no-credentials path: with no Upstash/KV/Redis REST env vars set,
+// getRedisCredentials() returns null → the handler throws → REDIS_DOWN.
+for (const k of [
+  'UPSTASH_REDIS_REST_URL', 'KV_REST_API_URL', 'REDIS_REST_URL',
+  'UPSTASH_REDIS_REST_TOKEN', 'KV_REST_API_TOKEN', 'REDIS_REST_TOKEN',
+]) delete process.env[k];
+
+const { default: handler } = await import('../api/health.js');
+
+test('REDIS_DOWN returns HTTP 503 with status REDIS_DOWN', async () => {
+  // Real Request (no Origin header) — the handler reads req.headers.get('origin')
+  // via isDisallowedOrigin/getCorsHeaders, so a plain object would crash.
+  const req = new Request('https://api.worldmonitor.app/api/health');
+  const res = await handler(req);
+  assert.equal(res.status, 503);
+  const body = await res.json();
+  assert.equal(body.status, 'REDIS_DOWN');
+  assert.ok('checkedAt' in body, 'snapshot must carry checkedAt');
+  // No Origin → getCorsHeaders falls back to the canonical app origin (the
+  // origin-gated handler does not emit ACAO:* for unknown/absent origins).
+  assert.equal(res.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app');
+});
+
+test('OPTIONS preflight returns 204 (never 503)', async () => {
+  const req = new Request('https://api.worldmonitor.app/api/health', { method: 'OPTIONS' });
+  const res = await handler(req);
+  assert.equal(res.status, 204);
+});
+
+test('disallowed Origin is rejected with 403 before any Redis work', async () => {
+  const req = new Request('https://api.worldmonitor.app/api/health', {
+    headers: { origin: 'https://evil.example.com' },
+  });
+  const res = await handler(req);
+  assert.equal(res.status, 403);
+});


### PR DESCRIPTION
## Summary

`/api/health` hardcoded HTTP `200` for **every** state — intentional since #2699, which moved off per-severity HTTP codes to stop UptimeRobot from flapping on warn-level seed jitter. But that also made a **fully-unreachable Redis return 200**, so a total backend outage was invisible to any plain HTTP-status monitor (UptimeRobot, k8s probe, load balancer). Meanwhile the docs still promised `503` for `DEGRADED`/`UNHEALTHY`/`REDIS_DOWN` — a silent code↔docs contract mismatch.

**Fix:** return `503` for `REDIS_DOWN` only — the one hard-down state where the endpoint can assess nothing. `DEGRADED`/`UNHEALTHY`/`WARNING` keep returning `200` with the verdict in the JSON `status` field, preserving the anti-flapping behavior from #2699.

### Also in this PR
- **Docs** (`docs/health-endpoints.mdx`) resynced with the code: status table (`DEGRADED`/`UNHEALTHY` are `200`; `REDIS_DOWN` the only `503`), `summary.total` `57` → `~194`, documented `onDemandWarn`/`staleContent`, the 4 missing per-key statuses (`STALE_CONTENT`, `COVERAGE_PARTIAL`, `SEED_ERROR`, `REDIS_PARTIAL`), the `displacement → displacementPrev` cascade group, refreshed staleness thresholds, corrected UptimeRobot guidance.
- **Tests** — first regression coverage for the classifier:
  - `tests/health-classify.test.mjs` — `STATUS_COUNTS` buckets, `classifyKey` core statuses, proactive cascade shielding, HEALTHY/WARNING/DEGRADED/UNHEALTHY thresholds.
  - `tests/health-redis-down-status.test.mjs` — locks `REDIS_DOWN → 503`, `OPTIONS → 204`, disallowed-origin → `403`.
  - `tests/health-history-endpoint.test.mjs` — updated the one assertion expecting the old `200`-on-no-Redis behavior (its real assertion — absence of history-specific keys — preserved).

No change to `SEED_META` thresholds, key registries, the origin-gated CORS handler, or the always-200 main-response path.

## Test plan

- [x] `npm run typecheck` + `npm run typecheck:api`
- [x] `npm run lint` (biome) — 1 pre-existing warning, unrelated
- [x] `for f in scripts/*.cjs; do node -c "$f"; done`
- [x] `npm run test:data` — the only failure (`classify:sebuf:vN` audit in `tests/news-classify-cache-prefix-audit.test.mjs`) is a pre-existing env flake (its repo-wide `grep` tripped on a transient fixture dir); run alone it is 24/24 pass, and `server/`+`scripts/` are byte-identical to `origin/main`
- [x] `node --test tests/edge-functions.test.mjs`
- [x] `npx esbuild api/health.js --bundle --format=esm --platform=browser` — clean
- [x] `npm run docs:check` + `npm run version:check` — pass
- [x] `markdownlint docs/health-endpoints.mdx` — 0 errors
- [x] New health suites — 37/37 with siblings