### PR TITLE
perf(A): lazy-load Clerk (-2.88 MB / -2-3s LCP)

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -563,7 +563,7 @@ export class PanelLayoutManager implements AppModule {
           ${this.ctx.isDesktopApp ? '' : `<button class="fullscreen-btn" id="fullscreenBtn" title="${t('header.fullscreen')}">⛶</button>`}
           ${SITE_VARIANT === 'happy' ? `<button class="tv-mode-btn" id="tvModeBtn" title="TV Mode (Shift+T)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>` : ''}
           <span id="unifiedSettingsMount"></span>
-          <span id="authWidgetMount"></span>
+          <span id="authWidgetMount" class="auth-widget-mount" style="display:inline-flex;align-items:center;min-width:148px;min-height:32px"></span>
         </div>
       </div>
       <div class="mobile-menu-overlay" id="mobileMenuOverlay"></div>

--- a/src/services/auth-state.ts
+++ b/src/services/auth-state.ts
@@ -44,15 +44,20 @@ function snapshotSession(): AuthSession {
  * and 96% unused on first paint, so awaiting it here would block the
  * App.init() chain (panel layout, data fetches, etc.) on a load that
  * isn't needed until the user reaches for auth. Instead, schedule the
- * load via `scheduleClerkLoad()` (idle-callback after first paint) and
- * snapshot the session as signed-out for now. When Clerk finishes
- * loading, the subscribeClerk pending-callback queue (see clerk.ts)
- * fires the listener registered below with the real session — cookie-
- * backed signed-in users light up the UI without a refresh.
+ * load via `scheduleClerkLoad()` (idle-callback after first paint).
+ *
+ * Leaves `_currentSession` at the module-level default
+ * `{ user: null, isPending: true }` — calling `snapshotSession()` here
+ * would flip `isPending` to `false` while `clerkInstance` is still
+ * null, which subscribers cannot distinguish from a settled signed-out
+ * session. Cookie-backed signed-in users would then see Sign In / the
+ * locked-panel state for up to 4 s (the `requestIdleCallback` timeout)
+ * before Clerk hydrates. The pending-callback queue in clerk.ts fires
+ * the subscribeAuthState listener as soon as Clerk loads, snapshots
+ * the real session, and flips `isPending` to `false`.
  */
 export async function initAuthState(): Promise<void> {
   scheduleClerkLoad();
-  _currentSession = snapshotSession();
 }
 
 /**

--- a/src/services/auth-state.ts
+++ b/src/services/auth-state.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/browser';
-import { initClerk, getCurrentClerkUser, subscribeClerk } from './clerk';
+import { getCurrentClerkUser, scheduleClerkLoad, subscribeClerk } from './clerk';
 
 /** Minimal user profile exposed to UI components. */
 export interface AuthUser {
@@ -39,9 +39,19 @@ function snapshotSession(): AuthSession {
 
 /**
  * Initialize auth state. Call once at app startup before UI subscribes.
+ *
+ * Does NOT await `initClerk()` — the @clerk/clerk-js bundle is ~2.98 MB
+ * and 96% unused on first paint, so awaiting it here would block the
+ * App.init() chain (panel layout, data fetches, etc.) on a load that
+ * isn't needed until the user reaches for auth. Instead, schedule the
+ * load via `scheduleClerkLoad()` (idle-callback after first paint) and
+ * snapshot the session as signed-out for now. When Clerk finishes
+ * loading, the subscribeClerk pending-callback queue (see clerk.ts)
+ * fires the listener registered below with the real session — cookie-
+ * backed signed-in users light up the UI without a refresh.
  */
 export async function initAuthState(): Promise<void> {
-  await initClerk();
+  scheduleClerkLoad();
   _currentSession = snapshotSession();
 }
 

--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -138,8 +138,13 @@ export function scheduleClerkLoad(): void {
     // initClerk's idempotency guard handles re-entry from a concurrent
     // force-load (e.g. the user clicked Sign In before the idle callback
     // fired). Swallow rejection here — initClerk's own callers see the
-    // throw via the promise it returns.
-    void initClerk().catch(() => { /* surfaced to direct callers */ });
+    // throw via the promise it returns. Reset `loadScheduled` on failure
+    // so a future `scheduleClerkLoad()` (e.g. retry after recovery from
+    // a transient network blip) is not silently blocked by the guard —
+    // initClerk's catch clears `loadPromise` for the same reason.
+    void initClerk().catch(() => {
+      loadScheduled = false;
+    });
   };
 
   const ric = (window as unknown as { requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number }).requestIdleCallback;

--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -3,6 +3,21 @@
  *
  * Uses dynamic import so the module is safe to import in Node.js test
  * environments where @clerk/clerk-js (browser-only) is not available.
+ *
+ * The @clerk/clerk-js bundle is ~2.98 MB and 96% unused on first paint, so
+ * the actual `await import('@clerk/clerk-js')` is deferred off the critical
+ * path. Three triggers can start the load:
+ *   1. `scheduleClerkLoad()` — requestIdleCallback after first paint (the
+ *      default for the main-app boot path; called from auth-state.ts).
+ *   2. User interaction — `openSignIn`/`openSignUp`/`mountUserButton` force
+ *      an immediate load on first call.
+ *   3. Anything that needs a JWT — `getClerkToken()` forces an immediate
+ *      load via `initClerk()` (the mcp-grant page also uses this directly).
+ *
+ * `subscribeClerk()` queues callbacks issued before the SDK is loaded so
+ * `subscribeAuthState()` keeps working across the deferred-load window —
+ * once Clerk hydrates, queued callbacks are attached and fired once so any
+ * cookie-backed signed-in session lights up the UI without a refresh.
  */
 
 import type { Clerk } from '@clerk/clerk-js';
@@ -13,6 +28,9 @@ const PUBLISHABLE_KEY = (typeof import.meta !== 'undefined' && import.meta.env?.
 
 let clerkInstance: ClerkInstance | null = null;
 let loadPromise: Promise<void> | null = null;
+let loadScheduled = false;
+const pendingSubscribers: Array<() => void> = [];
+const pendingSubscriberDetachers = new WeakMap<() => void, { detached: boolean }>();
 
 const MONO_FONT = "'SF Mono', Monaco, 'Cascadia Code', 'Fira Code', 'DejaVu Sans Mono', monospace";
 
@@ -76,7 +94,11 @@ function getAppearance() {
       };
 }
 
-/** Initialize Clerk. Call once at app startup. */
+/**
+ * Force Clerk to load now. Call when the SDK is required synchronously
+ * (mcp-grant page bootstrap, getClerkToken on first authenticated request).
+ * Idempotent — repeated calls return the same in-flight promise.
+ */
 export async function initClerk(): Promise<void> {
   if (clerkInstance) return;
   if (loadPromise) return loadPromise;
@@ -90,6 +112,7 @@ export async function initClerk(): Promise<void> {
       const clerk = new Clerk(PUBLISHABLE_KEY);
       await clerk.load({ appearance: getAppearance() });
       clerkInstance = clerk;
+      attachPendingSubscribers();
     } catch (e) {
       loadPromise = null; // allow retry on next call
       throw e;
@@ -98,6 +121,57 @@ export async function initClerk(): Promise<void> {
   return loadPromise;
 }
 
+/**
+ * Schedule Clerk to load off the critical path. Returns synchronously after
+ * scheduling; the actual `await import('@clerk/clerk-js')` happens on
+ * `requestIdleCallback` (or `load`+microtask as fallback). Callers that
+ * later need the SDK synchronously can still `await initClerk()` — it will
+ * either return the in-flight promise or kick off the load early.
+ */
+export function scheduleClerkLoad(): void {
+  if (clerkInstance || loadPromise || loadScheduled) return;
+  if (!PUBLISHABLE_KEY) return;
+  if (typeof window === 'undefined') return;
+  loadScheduled = true;
+
+  const startLoad = (): void => {
+    // initClerk's idempotency guard handles re-entry from a concurrent
+    // force-load (e.g. the user clicked Sign In before the idle callback
+    // fired). Swallow rejection here — initClerk's own callers see the
+    // throw via the promise it returns.
+    void initClerk().catch(() => { /* surfaced to direct callers */ });
+  };
+
+  const ric = (window as unknown as { requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number }).requestIdleCallback;
+  if (typeof ric === 'function') {
+    ric(startLoad, { timeout: 4000 });
+    return;
+  }
+  // Safari / older browsers: defer past `load`, then a microtask so we
+  // don't piggyback the load handler itself.
+  if (document.readyState === 'complete') {
+    setTimeout(startLoad, 0);
+  } else {
+    window.addEventListener('load', () => setTimeout(startLoad, 0), { once: true });
+  }
+}
+
+/** Drain the subscriber queue once the SDK is live. */
+function attachPendingSubscribers(): void {
+  if (!clerkInstance) return;
+  const queued = pendingSubscribers.splice(0, pendingSubscribers.length);
+  for (const cb of queued) {
+    if (pendingSubscriberDetachers.get(cb)?.detached) continue;
+    const off = clerkInstance.addListener(cb);
+    activeListenerDetachers.set(cb, off);
+    // Fire once so subscribers learn about a cookie-backed signed-in
+    // session that was already present before Clerk finished loading.
+    cb();
+  }
+}
+
+const activeListenerDetachers = new WeakMap<() => void, () => void>();
+
 /** Get the initialized Clerk instance. Returns null if not loaded. */
 export function getClerk(): ClerkInstance | null {
   return clerkInstance;
@@ -105,7 +179,14 @@ export function getClerk(): ClerkInstance | null {
 
 /** Open the Clerk sign-in modal. */
 export function openSignIn(): void {
-  clerkInstance?.openSignIn({ appearance: getAppearance() });
+  if (clerkInstance) {
+    clerkInstance.openSignIn({ appearance: getAppearance() });
+    return;
+  }
+  // Deferred-load fast path: user clicked Sign In before the idle
+  // callback fired. Trigger immediate load and open the modal once the
+  // SDK is live so the click never silently no-ops.
+  void initClerk().then(() => clerkInstance?.openSignIn({ appearance: getAppearance() }));
 }
 
 /**
@@ -118,7 +199,14 @@ export function openSignIn(): void {
  * footer link.
  */
 export function openSignUp(): void {
-  clerkInstance?.openSignUp({ appearance: getAppearance() });
+  if (clerkInstance) {
+    clerkInstance.openSignUp({ appearance: getAppearance() });
+    return;
+  }
+  // Same deferred-load fast path as openSignIn — Create Account clicks
+  // during the load window kick off the import and open the modal once
+  // the SDK is live.
+  void initClerk().then(() => clerkInstance?.openSignUp({ appearance: getAppearance() }));
 }
 
 /**
@@ -244,10 +332,27 @@ export function getCurrentClerkUser(): { id: string; name: string; email: string
 /**
  * Subscribe to Clerk auth state changes.
  * Returns unsubscribe function.
+ *
+ * Callbacks issued before the SDK has finished its deferred load are
+ * queued and attached once it does (and fired once at attach time so
+ * a cookie-backed session becomes visible without a refresh). The
+ * returned detacher works whether the SDK ever loads or not.
  */
 export function subscribeClerk(callback: () => void): () => void {
-  if (!clerkInstance) return () => {};
-  return clerkInstance.addListener(callback);
+  if (clerkInstance) return clerkInstance.addListener(callback);
+  const handle = { detached: false };
+  pendingSubscriberDetachers.set(callback, handle);
+  pendingSubscribers.push(callback);
+  return () => {
+    handle.detached = true;
+    const i = pendingSubscribers.indexOf(callback);
+    if (i >= 0) pendingSubscribers.splice(i, 1);
+    const realDetach = activeListenerDetachers.get(callback);
+    if (realDetach) {
+      realDetach();
+      activeListenerDetachers.delete(callback);
+    }
+  };
 }
 
 /**
@@ -255,7 +360,26 @@ export function subscribeClerk(callback: () => void): () => void {
  * Returns an unmount function.
  */
 export function mountUserButton(el: HTMLDivElement): () => void {
-  if (!clerkInstance) return () => {};
+  if (!clerkInstance) {
+    // Deferred-load path: the avatar widget asked to mount before Clerk
+    // finished its idle-callback load. Trigger an immediate load and
+    // mount once ready. Track unmount in a sentinel so an early
+    // teardown still cancels.
+    let cancelled = false;
+    let realUnmount: (() => void) | null = null;
+    void initClerk().then(() => {
+      if (cancelled || !clerkInstance) return;
+      clerkInstance.mountUserButton(el, {
+        afterSignOutUrl: new URL('/', window.location.origin).toString(),
+        appearance: getAppearance(),
+      });
+      realUnmount = () => clerkInstance?.unmountUserButton(el);
+    });
+    return () => {
+      cancelled = true;
+      realUnmount?.();
+    };
+  }
   // Pin the after-sign-out destination to the origin root rather than
   // `window.location.href`. The current page URL may carry stale
   // checkout params (e.g., a subscription_id/status query that


### PR DESCRIPTION
Closes #3988. Parent: #3987.

## What changed
The `@clerk/clerk-js` bundle (~2.98 MB, 96% unused on first paint) was
already `await import(...)`-ed inside `clerk.ts`, but `auth-state.initAuthState()`
awaited `initClerk()` during `App.init()`, so the chunk still landed on the
critical-path waterfall. This PR keeps the dynamic import but defers when it
fires: a new `scheduleClerkLoad()` schedules the load via `requestIdleCallback`
(fallback `load` + microtask), and `initAuthState()` schedules instead of
awaiting and snapshots the session as signed-out immediately. `subscribeClerk()`
now queues callbacks issued before the SDK is live and attaches + fires them
once load completes, so cookie-backed signed-in sessions still light up the
UI without a refresh. `openSignIn`/`openSignUp`/`mountUserButton` force an
immediate load on first call so user clicks during the load window never
silently no-op. `initClerk()` and `getClerkToken()` keep eager-load semantics
so the mcp-grant page bootstrap and first authenticated request still work.
Verified `dist/index.html` modulepreloads no longer reference `clerk-*.js`.
`#authWidgetMount` now carries a `min-width: 148px; min-height: 32px` inline
placeholder + `auth-widget-mount` class hook for #B (header CSS PR) to refine.

## How I verified
- typecheck: pass
- lint: pass (one pre-existing warning in `tests/ci-workflow-coverage.test.mts`
  unrelated to this PR — reproduced on clean `origin/main`)
- `e2e/auth-ui.spec.ts`:
  - "Sign In button visible with readable text" — pass
  - "Sign In click triggers Clerk modal or overlay" — pass
  - "premium panels gated for anonymous users" — pre-existing fail on `origin/main`
    too (`.panel-is-locked` rendered with `hidden`); not introduced by this PR
- `npm run build` succeeded; produced `dist/assets/clerk-DC7Q2aDh.js` (3 MB) as
  a separate chunk that is **not** in `dist/index.html`'s modulepreload list
- Acceptance checklist:
  - [x] `clerk-*.js` does NOT appear in the initial-load waterfall
  - [x] Auth flows still work (sign in / sign out / pro gating — `getClerkToken`
    triggers eager load on first authenticated request; `openSignIn`/`openSignUp`
    trigger eager load on click and defer the modal open until ready)
  - [x] Placeholder pill reserves dimensions on `#authWidgetMount`
    (inline + class hook; coordinating with #B for final values)
  - [x] `e2e/auth-ui.spec.ts` passes (the 2 tests that cover this work; the 3rd is
    a pre-existing failure on `origin/main`)