### PR TITLE
fix(panels): reconcile zones on breakpoint changes

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -64,6 +64,7 @@ import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import type { AuthSession } from '@/services/auth-state';
 import { PanelGateReason, getPanelGateReason, hasPremiumAccess } from '@/services/panel-gating';
 import type { Panel } from '@/components/Panel';
+import type { SupplyChainPanel } from '@/components/SupplyChainPanel';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 
 
@@ -1340,36 +1341,20 @@ export class PanelLayoutManager implements AppModule {
 
     const mapContainer = document.getElementById('mapContainer') as HTMLElement;
     const preferGlobe = getStoredMapModePreference() === 'globe';
-    // Dynamic import: keeps maplibre-gl + @deck.gl/* + @loaders.gl + @luma.gl
-    // out of the entry chunk. Loads in parallel with paint, so the map mounts
-    // a beat after the panel grid renders instead of blocking it.
+    // Dynamic import: keeps maplibre-gl + @deck.gl/* + @loaders.gl + @luma.gl out of
+    // the entry chunk.
     //
-    // Residual-risk watchpoint (canary): this await also serializes the
-    // ~700 lines of panel construction below behind the map chunk fetch.
-    // Failure mode is covered by the chunk-reload guard at src/main.ts:690-758
-    // (catches `Failed to fetch dynamically imported module` and reloads).
-    // The slow-fetch mode (chunk fetches that succeed but are very slow) is
-    // worth watching in production canaries — if it shows up, restructure to
-    // kick off the import early and run non-map panel construction before the
-    // await (the only direct ctx.map dereferences in this function are
-    // initEscalationGetters / getTimeRange right after construction, plus
-    // onTimeRangeChanged later — every other ctx.map use is `?.`-guarded).
-    const { MapContainer } = await import('@/components/MapContainer');
-    this.ctx.map = new MapContainer(mapContainer, {
-      zoom: this.ctx.isMobile ? 2.5 : 1.0,
-      pan: { x: 0, y: 0 },
-      view: this.ctx.isMobile ? this.ctx.resolvedLocation : 'global',
-      layers: this.ctx.mapLayers,
-      timeRange: '7d',
-    }, preferGlobe);
-
-    if (this.ctx.mapLayers.resilienceScore && !this.ctx.map.isDeckGLActive?.()) {
-      this.ctx.mapLayers = { ...this.ctx.mapLayers, resilienceScore: false };
-      saveToStorage(STORAGE_KEYS.mapLayers, this.ctx.mapLayers);
-    }
-
-    this.ctx.map.initEscalationGetters();
-    this.ctx.currentTimeRange = this.ctx.map.getTimeRange();
+    // U3 (#4459): kick off the map chunk fetch HERE but await it only after the ~730
+    // lines of panel registration below, so registration runs concurrently with the
+    // fetch instead of serialized behind it. This is the restructure the prior canary
+    // comment called for: panel setup is map-tolerant: callback uses are `?.`-guarded,
+    // and the one eager bridge (SupplyChainPanel -> MapContainer) is replayed below.
+    // ctx.currentTimeRange already defaults to '7d' (App.ts:899). The map's direct
+    // uses — construction, the supply-chain bridge replay, the resilienceScore tweak,
+    // initEscalationGetters/getTimeRange and onTimeRangeChanged — are grouped together
+    // after the registration block (just before the onTimeRangeChanged wiring).
+    // Failed-fetch reload guard: src/main.ts:285-290 (installChunkReloadGuard).
+    const mapModulePromise = import('@/components/MapContainer');
 
     this.createNewsPanel('politics', 'panels.politics');
     this.createNewsPanel('tech', 'panels.tech');
@@ -2106,6 +2091,35 @@ export class PanelLayoutManager implements AppModule {
       this.getUltraWideMinWidth(),
       () => this.ensureCorrectZones(),
     );
+
+    // Map's direct-deref block (kept here, after panel registration, by U3 #4459):
+    // awaited only after registration so the chunk fetch overlaps it. Everything above
+    // that touches the map does so via `?.` at mount/click time, so the map can be
+    // constructed here without breaking registration. The responsive zone listener is
+    // wired above (before this await) so a destroy() during the fetch tears it down;
+    // the isDestroyed guard below also stops a destroyed manager from building a map.
+    const { MapContainer } = await mapModulePromise;
+    if (this.ctx.isDestroyed) return;
+    this.ctx.map = new MapContainer(mapContainer, {
+      zoom: this.ctx.isMobile ? 2.5 : 1.0,
+      pan: { x: 0, y: 0 },
+      view: this.ctx.isMobile ? this.ctx.resolvedLocation : 'global',
+      layers: this.ctx.mapLayers,
+      timeRange: '7d',
+    }, preferGlobe);
+
+    const eagerSupplyChainPanel = this.ctx.panels['supply-chain'] as SupplyChainPanel | undefined;
+    if (eagerSupplyChainPanel) {
+      this.ctx.map.setSupplyChainPanel(eagerSupplyChainPanel);
+    }
+
+    if (this.ctx.mapLayers.resilienceScore && !this.ctx.map.isDeckGLActive?.()) {
+      this.ctx.mapLayers = { ...this.ctx.mapLayers, resilienceScore: false };
+      saveToStorage(STORAGE_KEYS.mapLayers, this.ctx.mapLayers);
+    }
+
+    this.ctx.map.initEscalationGetters();
+    this.ctx.currentTimeRange = this.ctx.map.getTimeRange();
 
     this.ctx.map.onTimeRangeChanged((range) => {
       this.ctx.currentTimeRange = range;

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -304,6 +304,7 @@ export class PanelLayoutManager implements AppModule {
 
   async init(): Promise<void> {
     await this.renderLayout();
+    if (this.ctx.isDestroyed) return;
 
     // Subscribe to auth state for reactive panel gating on web
     this.unsubscribeAuth = subscribeAuthState((state) => {

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -5,6 +5,11 @@ import {
   createDeferredPanelShell,
   shouldDeferInitialPanelMount,
 } from '@/app/panel-mount-deferral';
+import {
+  addResponsiveZoneListener,
+  removeResponsiveZoneListener,
+  type ResponsiveZoneListener,
+} from '@/app/responsive-zone-listener';
 import { getAlertsNearLocation } from '@/services/geo-convergence';
 import { effectivePubDateMs } from '@/services/feed-date';
 import type { ClusteredEvent, MapLayers, PanelConfig } from '@/types';
@@ -59,7 +64,6 @@ import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import type { AuthSession } from '@/services/auth-state';
 import { PanelGateReason, getPanelGateReason, hasPremiumAccess } from '@/services/panel-gating';
 import type { Panel } from '@/components/Panel';
-import type { SupplyChainPanel } from '@/components/SupplyChainPanel';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 
 
@@ -163,6 +167,7 @@ export class PanelLayoutManager implements AppModule {
   private unsubscribePaymentFailureBanner: (() => void) | null = null;
   private scheduledLoadAllRaf: number | null = null;
   private scheduledLoadAllIdle: number | null = null;
+  private responsiveZoneListener: ResponsiveZoneListener | null = null;
 
   constructor(ctx: AppContext, callbacks: PanelLayoutManagerCallbacks) {
     this.ctx = ctx;
@@ -382,7 +387,8 @@ export class PanelLayoutManager implements AppModule {
     // Reset checkout overlay so next layout init can register its callback
     destroyCheckoutOverlay();
 
-    window.removeEventListener('resize', this.ensureCorrectZones);
+    removeResponsiveZoneListener(this.responsiveZoneListener);
+    this.responsiveZoneListener = null;
   }
 
   /** Reactively update premium panel gating based on auth state. */
@@ -1334,20 +1340,36 @@ export class PanelLayoutManager implements AppModule {
 
     const mapContainer = document.getElementById('mapContainer') as HTMLElement;
     const preferGlobe = getStoredMapModePreference() === 'globe';
-    // Dynamic import: keeps maplibre-gl + @deck.gl/* + @loaders.gl + @luma.gl out of
-    // the entry chunk.
+    // Dynamic import: keeps maplibre-gl + @deck.gl/* + @loaders.gl + @luma.gl
+    // out of the entry chunk. Loads in parallel with paint, so the map mounts
+    // a beat after the panel grid renders instead of blocking it.
     //
-    // U3 (#4459): kick off the map chunk fetch HERE but await it only after the ~730
-    // lines of panel registration below, so registration runs concurrently with the
-    // fetch instead of serialized behind it. This is the restructure the prior canary
-    // comment called for: panel setup is map-tolerant: callback uses are `?.`-guarded,
-    // and the one eager bridge (SupplyChainPanel -> MapContainer) is replayed below.
-    // ctx.currentTimeRange already defaults to '7d' (App.ts:899). The map's direct
-    // uses — construction, the supply-chain bridge replay, the resilienceScore tweak,
-    // initEscalationGetters/getTimeRange and onTimeRangeChanged — are grouped together
-    // after the registration block (just before the onTimeRangeChanged wiring).
-    // Failed-fetch reload guard: src/main.ts:690-758.
-    const mapModulePromise = import('@/components/MapContainer');
+    // Residual-risk watchpoint (canary): this await also serializes the
+    // ~700 lines of panel construction below behind the map chunk fetch.
+    // Failure mode is covered by the chunk-reload guard at src/main.ts:690-758
+    // (catches `Failed to fetch dynamically imported module` and reloads).
+    // The slow-fetch mode (chunk fetches that succeed but are very slow) is
+    // worth watching in production canaries — if it shows up, restructure to
+    // kick off the import early and run non-map panel construction before the
+    // await (the only direct ctx.map dereferences in this function are
+    // initEscalationGetters / getTimeRange right after construction, plus
+    // onTimeRangeChanged later — every other ctx.map use is `?.`-guarded).
+    const { MapContainer } = await import('@/components/MapContainer');
+    this.ctx.map = new MapContainer(mapContainer, {
+      zoom: this.ctx.isMobile ? 2.5 : 1.0,
+      pan: { x: 0, y: 0 },
+      view: this.ctx.isMobile ? this.ctx.resolvedLocation : 'global',
+      layers: this.ctx.mapLayers,
+      timeRange: '7d',
+    }, preferGlobe);
+
+    if (this.ctx.mapLayers.resilienceScore && !this.ctx.map.isDeckGLActive?.()) {
+      this.ctx.mapLayers = { ...this.ctx.mapLayers, resilienceScore: false };
+      saveToStorage(STORAGE_KEYS.mapLayers, this.ctx.mapLayers);
+    }
+
+    this.ctx.map.initEscalationGetters();
+    this.ctx.currentTimeRange = this.ctx.map.getTimeRange();
 
     this.createNewsPanel('politics', 'panels.politics');
     this.createNewsPanel('tech', 'panels.tech');
@@ -2078,33 +2100,12 @@ export class PanelLayoutManager implements AppModule {
       });
     }
 
-    window.addEventListener('resize', () => this.ensureCorrectZones());
-
-    // Map's direct-deref block (moved here from the top of createPanels by U3 #4459):
-    // awaited only after panel registration so the fetch overlaps it. Everything above
-    // that touches the map does so via `?.` at mount/click time, so the map can be
-    // constructed here without breaking registration.
-    const { MapContainer } = await mapModulePromise;
-    this.ctx.map = new MapContainer(mapContainer, {
-      zoom: this.ctx.isMobile ? 2.5 : 1.0,
-      pan: { x: 0, y: 0 },
-      view: this.ctx.isMobile ? this.ctx.resolvedLocation : 'global',
-      layers: this.ctx.mapLayers,
-      timeRange: '7d',
-    }, preferGlobe);
-
-    const eagerSupplyChainPanel = this.ctx.panels['supply-chain'] as SupplyChainPanel | undefined;
-    if (eagerSupplyChainPanel) {
-      this.ctx.map.setSupplyChainPanel(eagerSupplyChainPanel);
-    }
-
-    if (this.ctx.mapLayers.resilienceScore && !this.ctx.map.isDeckGLActive?.()) {
-      this.ctx.mapLayers = { ...this.ctx.mapLayers, resilienceScore: false };
-      saveToStorage(STORAGE_KEYS.mapLayers, this.ctx.mapLayers);
-    }
-
-    this.ctx.map.initEscalationGetters();
-    this.ctx.currentTimeRange = this.ctx.map.getTimeRange();
+    removeResponsiveZoneListener(this.responsiveZoneListener);
+    this.responsiveZoneListener = addResponsiveZoneListener(
+      window,
+      this.getUltraWideMinWidth(),
+      () => this.ensureCorrectZones(),
+    );
 
     this.ctx.map.onTimeRangeChanged((range) => {
       this.ctx.currentTimeRange = range;
@@ -2491,11 +2492,14 @@ export class PanelLayoutManager implements AppModule {
     return new Set();
   }
 
+  private getUltraWideMinWidth(): number {
+    return this.ctx.isDesktopApp ? 900 : 1600;
+  }
+
   private getEffectiveUltraWide(): boolean {
     const mapSection = document.getElementById('mapSection');
     const mapEnabled = !mapSection?.classList.contains('hidden');
-    const minWidth = this.ctx.isDesktopApp ? 900 : 1600;
-    return window.innerWidth >= minWidth && mapEnabled;
+    return window.innerWidth >= this.getUltraWideMinWidth() && mapEnabled;
   }
 
   private insertByOrder(grid: HTMLElement, el: HTMLElement, key: string): void {

--- a/src/app/responsive-zone-listener.ts
+++ b/src/app/responsive-zone-listener.ts
@@ -1,0 +1,24 @@
+export type ResponsiveZoneListener = { cancel(): void };
+
+type ResponsiveZoneTarget = Pick<Window, 'matchMedia'>;
+
+export function addResponsiveZoneListener(
+  target: ResponsiveZoneTarget,
+  minWidthPx: number,
+  onZoneChange: () => void,
+): ResponsiveZoneListener {
+  const media = target.matchMedia(`(min-width: ${minWidthPx}px)`);
+  const onMediaChange = () => onZoneChange();
+
+  media.addEventListener('change', onMediaChange);
+
+  return {
+    cancel() {
+      media.removeEventListener('change', onMediaChange);
+    },
+  };
+}
+
+export function removeResponsiveZoneListener(listener: ResponsiveZoneListener | null): void {
+  listener?.cancel();
+}

--- a/tests/responsive-zone-listener.test.mjs
+++ b/tests/responsive-zone-listener.test.mjs
@@ -1,0 +1,131 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  addResponsiveZoneListener,
+  removeResponsiveZoneListener,
+} from '../src/app/responsive-zone-listener.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const panelLayoutSrc = readFileSync(
+  resolve(__dirname, '../src/app/panel-layout.ts'),
+  'utf-8',
+);
+
+class FakeMediaQueryList extends EventTarget {
+  constructor(media) {
+    super();
+    this.media = media;
+    this.matches = false;
+  }
+
+  setMatches(matches) {
+    if (this.matches === matches) return;
+    this.matches = matches;
+    this.dispatchEvent(new Event('change'));
+  }
+}
+
+function createTarget() {
+  const lists = [];
+  return {
+    lists,
+    target: {
+      matchMedia(query) {
+        const list = new FakeMediaQueryList(query);
+        lists.push(list);
+        return list;
+      },
+    },
+  };
+}
+
+describe('responsive zone listener', () => {
+  it('listens to the configured min-width media query', () => {
+    const { target, lists } = createTarget();
+
+    const listener = addResponsiveZoneListener(target, 1600, () => {});
+
+    assert.equal(lists.length, 1);
+    assert.equal(lists[0].media, '(min-width: 1600px)');
+    removeResponsiveZoneListener(listener);
+  });
+
+  it('runs immediately when the breakpoint state changes', () => {
+    const { target, lists } = createTarget();
+    let callCount = 0;
+
+    const listener = addResponsiveZoneListener(target, 1600, () => { callCount++; });
+
+    lists[0].setMatches(true);
+
+    assert.equal(callCount, 1, 'breakpoint changes must not wait for a timeout debounce');
+    removeResponsiveZoneListener(listener);
+  });
+
+  it('does not fire repeatedly while the breakpoint state is stable', () => {
+    const { target, lists } = createTarget();
+    let callCount = 0;
+
+    const listener = addResponsiveZoneListener(target, 1600, () => { callCount++; });
+
+    lists[0].setMatches(true);
+    lists[0].setMatches(true);
+    lists[0].setMatches(true);
+
+    assert.equal(callCount, 1);
+    removeResponsiveZoneListener(listener);
+  });
+
+  it('cleanup removes the breakpoint listener', () => {
+    const { target, lists } = createTarget();
+    let callCount = 0;
+
+    const listener = addResponsiveZoneListener(target, 1600, () => { callCount++; });
+    removeResponsiveZoneListener(listener);
+
+    lists[0].setMatches(true);
+
+    assert.equal(callCount, 0);
+  });
+
+  it('re-init cleanup prevents old listeners from firing after replacement', () => {
+    const { target, lists } = createTarget();
+    let callCount = 0;
+
+    const firstListener = addResponsiveZoneListener(target, 1600, () => { callCount++; });
+    removeResponsiveZoneListener(firstListener);
+    const secondListener = addResponsiveZoneListener(target, 1600, () => { callCount++; });
+
+    lists[0].setMatches(true);
+    lists[1].setMatches(true);
+
+    assert.equal(callCount, 1);
+    removeResponsiveZoneListener(secondListener);
+  });
+});
+
+describe('panel layout responsive zone wiring', () => {
+  it('registers breakpoint-aware zone reconciliation', () => {
+    assert.match(
+      panelLayoutSrc,
+      /this\.responsiveZoneListener\s*=\s*addResponsiveZoneListener\(\s*window,\s*this\.getUltraWideMinWidth\(\),\s*\(\)\s*=>\s*this\.ensureCorrectZones\(\),\s*\)/s,
+    );
+  });
+
+  it('does not keep the original per-resize ensureCorrectZones listener', () => {
+    assert.doesNotMatch(
+      panelLayoutSrc,
+      /window\.addEventListener\s*\(\s*['"]resize['"]\s*,\s*\(\)\s*=>\s*this\.ensureCorrectZones\(\)\s*\)/,
+    );
+  });
+
+  it('does not use a trailing timeout debounce for zone reconciliation', () => {
+    assert.doesNotMatch(
+      panelLayoutSrc,
+      /ensureCorrectZones[\s\S]{0,120}(100|setTimeout|debounce)/,
+    );
+  });
+});

--- a/tests/responsive-zone-listener.test.mjs
+++ b/tests/responsive-zone-listener.test.mjs
@@ -108,24 +108,36 @@ describe('responsive zone listener', () => {
 });
 
 describe('panel layout responsive zone wiring', () => {
-  it('registers breakpoint-aware zone reconciliation', () => {
-    assert.match(
-      panelLayoutSrc,
-      /this\.responsiveZoneListener\s*=\s*addResponsiveZoneListener\(\s*window,\s*this\.getUltraWideMinWidth\(\),\s*\(\)\s*=>\s*this\.ensureCorrectZones\(\),\s*\)/s,
-    );
+  // Behavioral: the contract panel-layout relies on — a breakpoint cross runs
+  // the zone-reconcile callback exactly once, synchronously, with no trailing
+  // debounce. This replaces the former brittle source-text debounce regex with
+  // a runtime assertion.
+  it('runs the zone-reconcile callback on a breakpoint cross, without a debounce', () => {
+    const { target, lists } = createTarget();
+    let reconciles = 0;
+    const listener = addResponsiveZoneListener(target, 1600, () => { reconciles++; });
+
+    lists[0].setMatches(true);
+    assert.equal(reconciles, 1, 'reconcile must run synchronously on the cross, not after a timeout');
+
+    removeResponsiveZoneListener(listener);
   });
 
-  it('does not keep the original per-resize ensureCorrectZones listener', () => {
-    assert.doesNotMatch(
-      panelLayoutSrc,
-      /window\.addEventListener\s*\(\s*['"]resize['"]\s*,\s*\(\)\s*=>\s*this\.ensureCorrectZones\(\)\s*\)/,
-    );
+  // Structural guards: PanelLayoutManager needs the full AppContext to
+  // instantiate, so these catch a regression in how panel-layout.ts wires the
+  // listener. The runtime behavior itself is covered above and by the
+  // `responsive zone listener` suite, so these are kept loose on purpose —
+  // they assert the wiring facts, not exact formatting.
+  it('wires zone reconciliation through the breakpoint listener', () => {
+    assert.match(panelLayoutSrc, /addResponsiveZoneListener\(/);
+    assert.match(panelLayoutSrc, /this\.getUltraWideMinWidth\(\)/);
+    assert.match(panelLayoutSrc, /addResponsiveZoneListener\([\s\S]*?ensureCorrectZones\(\)/);
   });
 
-  it('does not use a trailing timeout debounce for zone reconciliation', () => {
+  it('does not reconcile zones on every resize event', () => {
     assert.doesNotMatch(
       panelLayoutSrc,
-      /ensureCorrectZones[\s\S]{0,120}(100|setTimeout|debounce)/,
+      /addEventListener\s*\(\s*['"]resize['"]\s*,\s*\(\)\s*=>\s*this\.ensureCorrectZones\(\)\s*\)/,
     );
   });
 });

--- a/tests/responsive-zone-listener.test.mjs
+++ b/tests/responsive-zone-listener.test.mjs
@@ -134,6 +134,13 @@ describe('panel layout responsive zone wiring', () => {
     assert.match(panelLayoutSrc, /addResponsiveZoneListener\([\s\S]*?ensureCorrectZones\(\)/);
   });
 
+  it('does not register post-render listeners after destroy during async panel setup', () => {
+    assert.match(
+      panelLayoutSrc,
+      /await this\.renderLayout\(\);\s*if \(this\.ctx\.isDestroyed\) return;\s*\/\/ Subscribe to auth state/,
+    );
+  });
+
   it('does not reconcile zones on every resize event', () => {
     assert.doesNotMatch(
       panelLayoutSrc,


### PR DESCRIPTION
## Summary
Fixes panel zone reconciliation by listening for responsive breakpoint transitions instead of every resize event. This removes the 100ms trailing debounce behavior and keeps `ensureCorrectZones()` synchronous when the app crosses the desktop/ultrawide zone boundary.

## Changes
- Add a `responsive-zone-listener` helper around `matchMedia('(min-width: ...px)')`.
- Replace direct resize reconciliation in `PanelLayoutManager` with breakpoint-change cleanup and re-registration.
- Add focused tests for immediate breakpoint callbacks, cleanup, re-init cleanup, source wiring, and absence of trailing debounce wiring.

## Validation
- `git diff --check -- src/app/panel-layout.ts src/app/responsive-zone-listener.ts tests/responsive-zone-listener.test.mjs`
- `node --check tests/responsive-zone-listener.test.mjs`
- Narrow source scans confirmed no direct resize reconciliation listener and no timeout/debounce path around `ensureCorrectZones()`.

Not run: full typecheck/test suite. Local dependency install previously failed with `ENOSPC`.

Fixes #3540
