### PR TITLE
perf(E): preconnect api.worldmonitor.app (-680 ms LCP)

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,6 +265,11 @@
       [data-variant="happy"][data-theme="dark"] .skeleton-line{background:linear-gradient(90deg,rgba(139,175,122,.05) 25%,rgba(139,175,122,.10) 50%,rgba(139,175,122,.05) 75%);background-size:200% 100%;animation:skel-shimmer 1.5s infinite}
     </style>
 
+    <!-- Preconnect: critical first-paint origins -->
+    <link rel="preconnect" href="https://api.worldmonitor.app" crossorigin>
+    <link rel="preconnect" href="https://o4509927897890816.ingest.us.sentry.io" crossorigin>
+    <link rel="dns-prefetch" href="https://clerk.worldmonitor.app">
+
     <!-- Preconnect: map tiles + assets -->
     <link rel="preconnect" href="https://maps.worldmonitor.app" crossorigin>
     <link rel="dns-prefetch" href="https://protomaps.github.io">

--- a/index.html
+++ b/index.html
@@ -265,8 +265,13 @@
       [data-variant="happy"][data-theme="dark"] .skeleton-line{background:linear-gradient(90deg,rgba(139,175,122,.05) 25%,rgba(139,175,122,.10) 50%,rgba(139,175,122,.05) 75%);background-size:200% 100%;animation:skel-shimmer 1.5s infinite}
     </style>
 
-    <!-- Preconnect: critical first-paint origins -->
-    <link rel="preconnect" href="https://api.worldmonitor.app" crossorigin>
+    <!-- Preconnect: critical first-paint origins.
+         api.worldmonitor.app: credentialed CORS (runtime.ts defaults
+         credentials: 'include') — must use `use-credentials` so the
+         pre-opened socket lands in the same connection pool as the
+         credentialed fetches.
+         Sentry ingest: anonymous (DSN key in headers, no cookies). -->
+    <link rel="preconnect" href="https://api.worldmonitor.app" crossorigin="use-credentials">
     <link rel="preconnect" href="https://o4509927897890816.ingest.us.sentry.io" crossorigin>
     <link rel="dns-prefetch" href="https://clerk.worldmonitor.app">
 


### PR DESCRIPTION
Closes #3992. Parent: #3987.

## What changed

`index.html` head adds three first-paint hints:

- `<link rel="preconnect" href="https://api.worldmonitor.app" crossorigin>` — origin hit by every initial data fetch (Lighthouse-estimated −680 ms LCP)
- `<link rel="preconnect" href="https://o4509927897890816.ingest.us.sentry.io" crossorigin>` — Sentry ingest host (−310 ms). DSN host **verified** against the live production bundle (`o4509927897890816.ingest.us.sentry.io` matches what's hard-coded in `VITE_SENTRY_DSN` and what the issue specified).
- `<link rel="dns-prefetch" href="https://clerk.worldmonitor.app">` — low-cost backup for the Clerk auth host that's now lazy-loaded via `requestIdleCallback` (per #3999).

## Scope decision: preconnect cleanup deferred

The issue's Approach also said "remove the two unused preconnects Lighthouse flagged". The current `<head>` has 4 preconnect/dns-prefetch entries:

| Origin | Hint | Used at first paint? |
|---|---|---|
| `maps.worldmonitor.app` | preconnect | After MapContainer hydrates (now deferred per #4002) |
| `protomaps.github.io` | dns-prefetch | After MapContainer hydrates |
| `fonts.googleapis.com` | preconnect | Yes — stylesheet on `index.html:275` |
| `fonts.gstatic.com` | preconnect | Yes — fonts referenced by the stylesheet |

Fonts are clearly used. The map origins are deferred but still hit. Without a fresh Lighthouse audit (can't run from this agent's environment), I can't deterministically identify which two Lighthouse flags as "unused". The issue allows for this: *"If the call is ambiguous, leave the existing preconnect alone — adding `api.worldmonitor.app` is the load-bearing change; removing extras is secondary."*

The 3 added hints are the load-bearing change. Cleanup can be a follow-up if a fresh audit confirms specific origins miss the 10 s connection window.

## How I verified

- `npm run typecheck`: pass
- `npm run lint`: pass (one pre-existing unrelated warning in `scripts/__tests__/ci-shape.test.mjs` for regex spacing — not touched by this PR)
- `npm run build`: pass

`dist/index.html` head, preconnect/dns-prefetch lines (deterministic acceptance):

Before:
```
<link rel="preconnect" href="https://maps.worldmonitor.app" crossorigin>
<link rel="dns-prefetch" href="https://protomaps.github.io">
<link rel="preconnect" href="https://fonts.googleapis.com">
<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
```

After:
```
<link rel="preconnect" href="https://api.worldmonitor.app" crossorigin>        ← new
<link rel="preconnect" href="https://o4509927897890816.ingest.us.sentry.io" crossorigin>  ← new
<link rel="dns-prefetch" href="https://clerk.worldmonitor.app">                ← new
<link rel="preconnect" href="https://maps.worldmonitor.app" crossorigin>
<link rel="dns-prefetch" href="https://protomaps.github.io">
<link rel="preconnect" href="https://fonts.googleapis.com">
<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
```

### Acceptance checklist

- [x] `api.worldmonitor.app` preconnect added (the load-bearing change Lighthouse flagged)
- [x] Sentry ingest preconnect added — DSN host verified against live production
- [x] Clerk dns-prefetch backup added
- [ ] "Unused preconnect" warnings — see scope note above; can't verify without re-running Lighthouse
- [ ] LCP improvement of ~0.5–1.0 s — will measure via post-merge recording; single-sample noise band is ±2 s so a single recording may or may not show the −680 ms cleanly

## Test plan

- [ ] Vercel preview comes up clean (no new console errors on the home route)
- [ ] After merge: production HTML contains the 3 new tags
- [ ] After merge: capture post-merge Playwright recording and post delta comment on #3987

🤖 Generated with [Claude Code](https://claude.com/claude-code)