### PR TITLE
perf(F): restore bfcache by dropping no-store from HTML

### DIFF
--- a/scripts/vercel-ignore.sh
+++ b/scripts/vercel-ignore.sh
@@ -8,7 +8,7 @@ if [ "$VERCEL_GIT_COMMIT_REF" = "main" ] && [ -n "$VERCEL_GIT_PREVIOUS_SHA" ]; t
     WEB_CHANGES=$(git diff --name-only "$VERCEL_GIT_PREVIOUS_SHA" HEAD -- \
       'src/' 'api/' 'server/' 'shared/' 'public/' 'blog-site/' 'pro-test/' 'proto/' 'convex/' \
       'package.json' 'package-lock.json' 'vite.config.ts' 'tsconfig.json' \
-      'tsconfig.api.json' 'vercel.json' 'middleware.ts' | head -1)
+      'tsconfig.api.json' 'vercel.json' 'middleware.ts' 'index.html' | head -1)
     [ -z "$WEB_CHANGES" ] && echo "Skipping: no web-relevant changes on main" && exit 0
   }
   exit 1
@@ -68,6 +68,7 @@ git diff --name-only "$COMPARE_SHA" HEAD -- \
   'tsconfig.api.json' \
   'vercel.json' \
   'middleware.ts' \
+  'index.html' \
   | grep -q . && exit 1
 
 # Nothing web-relevant changed, skip the build

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -26,7 +26,7 @@ const getCspDirectiveTokens = (csp, directive) => {
 };
 
 describe('deploy/cache configuration guardrails', () => {
-  it('disables caching for HTML entry routes on Vercel', () => {
+  it('requires revalidation for HTML entry routes on Vercel without disabling bfcache', () => {
     // /mcp-grant added to the negative-lookahead by plan 2026-05-10-001 U3 — apex
     // Pro-MCP consent page must opt out of the SPA catch-all rewrite (it is its
     // own HTML entry registered in vite.config.ts rollupOptions.input).
@@ -35,8 +35,17 @@ describe('deploy/cache configuration guardrails', () => {
     // rather than a non-capturing group with `?` quantifier — Vercel's
     // path-to-regexp source-pattern parser rejects `(?:...)` in `source` fields
     // (deploy-fail PR #3646 round-2 review).
+    //
+    // The header uses `private, no-cache, must-revalidate` rather than the
+    // previous `no-cache, no-store, must-revalidate` (PR #4004 / issue #3993).
+    // `no-store` fully disabled Chrome's bfcache (Lighthouse flagged 7 failure
+    // reasons rooted in this header). `no-cache` without `no-store` still
+    // revalidates on every navigation but lets bfcache restore on back/forward.
+    // `private` keeps shared caches (CDN, corporate proxies) from holding
+    // personalized HTML.
     const spaNoCache = getCacheHeaderValue('/((?!api|mcp|oauth|assets|blog|docs|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)');
-    assert.equal(spaNoCache, 'no-cache, no-store, must-revalidate');
+    assert.equal(spaNoCache, 'private, no-cache, must-revalidate');
+    assert.ok(!spaNoCache.includes('no-store'), 'HTML must not set no-store — it disables bfcache');
   });
 
   it('disables caching for the apex /mcp-grant Pro-MCP consent page (both URL forms)', () => {

--- a/vercel.json
+++ b/vercel.json
@@ -108,14 +108,14 @@
     {
       "source": "/",
       "headers": [
-        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" },
+        { "key": "Cache-Control", "value": "private, no-cache, must-revalidate" },
         { "key": "Link", "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\", </openapi.yaml>; rel=\"service-desc\"; type=\"application/vnd.oai.openapi\", </docs/documentation>; rel=\"service-doc\"; type=\"text/html\", </api/health>; rel=\"status\"; type=\"application/json\", </.well-known/oauth-protected-resource>; rel=\"http://www.iana.org/assignments/relation/oauth-protected-resource\", </.well-known/oauth-authorization-server>; rel=\"http://www.iana.org/assignments/relation/oauth-authorization-server\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\"; anchor=\"/mcp\", </.well-known/agent-skills/index.json>; rel=\"agent-skills-index\"; type=\"application/json\"" }
       ]
     },
     {
       "source": "/index.html",
       "headers": [
-        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" },
+        { "key": "Cache-Control", "value": "private, no-cache, must-revalidate" },
         { "key": "Link", "value": "</.well-known/api-catalog>; rel=\"api-catalog\"; type=\"application/linkset+json\", </openapi.yaml>; rel=\"service-desc\"; type=\"application/vnd.oai.openapi\", </docs/documentation>; rel=\"service-doc\"; type=\"text/html\", </api/health>; rel=\"status\"; type=\"application/json\", </.well-known/oauth-protected-resource>; rel=\"http://www.iana.org/assignments/relation/oauth-protected-resource\", </.well-known/oauth-authorization-server>; rel=\"http://www.iana.org/assignments/relation/oauth-authorization-server\", </.well-known/mcp/server-card.json>; rel=\"mcp-server-card\"; anchor=\"/mcp\", </.well-known/agent-skills/index.json>; rel=\"agent-skills-index\"; type=\"application/json\"" }
       ]
     },
@@ -134,7 +134,7 @@
     {
       "source": "/((?!api|mcp|oauth|assets|blog|docs|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)",
       "headers": [
-        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+        { "key": "Cache-Control", "value": "private, no-cache, must-revalidate" }
       ]
     },
     {
@@ -158,13 +158,13 @@
     {
       "source": "/pro/:path*",
       "headers": [
-        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+        { "key": "Cache-Control", "value": "private, no-cache, must-revalidate" }
       ]
     },
     {
       "source": "/pro",
       "headers": [
-        { "key": "Cache-Control", "value": "no-cache, no-store, must-revalidate" }
+        { "key": "Cache-Control", "value": "private, no-cache, must-revalidate" }
       ]
     },
     {


### PR DESCRIPTION
Closes #3993. Parent: #3987.

## What changed

### `vercel.json` (the actual perf(F) work)
Changed `Cache-Control` from `no-cache, no-store, must-revalidate` → `private, no-cache, must-revalidate` on the four HTML routes the issue called out:

| Line | Source | Before | After |
|---|---|---|---|
| 111 | `/` (root) | `no-cache, no-store, must-revalidate` | `private, no-cache, must-revalidate` |
| 118 | `/index.html` | `no-cache, no-store, must-revalidate` | `private, no-cache, must-revalidate` |
| 137 | SPA catch-all `/((?!api\|mcp\|oauth\|assets\|…).*)` | `no-cache, no-store, must-revalidate` | `private, no-cache, must-revalidate` |
| 161 | `/pro/:path*` | `no-cache, no-store, must-revalidate` | `private, no-cache, must-revalidate` |
| 167 | `/pro` | `no-cache, no-store, must-revalidate` | `private, no-cache, must-revalidate` |

`no-store` fully disables Chrome's bfcache. `no-cache` (without `no-store`) still revalidates on every navigation, but lets bfcache restore the page instantly on back/forward. `private` keeps shared caches (CDN, corporate proxies) from holding personalized HTML.

The Pro routes (161, 167) are listed as optional in the issue; I included them because they have the same dynamics as the main HTML.

### Explicitly **not** touched
- Lines 125, 131 (`/mcp-grant`, `/mcp-grant.html`) — OAuth landing pages where bfcache is undesirable.
- Lines 143+ (`/assets/(.*)` and friends) — already correctly `public, max-age=31536000, immutable`.
- `/api/*` — those legitimately need `no-store`.
- COEP — issue explicitly warns it will break Clerk/Sentry if added blind. Did not add.

### `scripts/vercel-ignore.sh` (bundled bugfix — root cause for PR #4003)
Added `index.html` to both path allowlists (the main-branch diff at line 8–11 and the merge-base diff at line 54–71).

**Why this is in the PR:** PR #4003 (perf E — preconnect `api.worldmonitor.app`) merged as `df932d39` but never deployed to production. The only file it changed was `index.html`, which was not in the allowlist, so the Ignored Build Step returned exit 0 and Vercel canceled both production builds (`dpl_HBkM6keWjyQm66dbJrbLLgnQbYpQ` and `dpl_7cMVUV8361bTDovMeQUHcHFMDvTq`, Canceled in 3–5s). One-line allowlist add prevents future HTML-only PRs from silently no-op'ing in production. Production HTML state today still shows PR #4002's bundle (`main-CxoYF3Df.js`) with no preconnect tag.

**Side effect:** because `vercel.json` *is* already in the allowlist, this PR's merge will trigger a production build that picks up both perf F (this PR) and the still-pending perf E. The post-merge recording will reflect E+F combined, and the parent-issue update will attribute deltas accordingly.

## Verification

Local:
- `npm run typecheck` ✅
- `npm run lint` ✅ (1 pre-existing warning in `tests/ci-workflow-coverage.test.mts:96` unrelated to this PR)
- `npm run build` ✅ (vercel.json doesn't affect build output, but confirmed dist is clean)

Deterministic acceptance (post-deploy):
- `curl -sI https://www.worldmonitor.app/` shows `Cache-Control: private, no-cache, must-revalidate` (not `no-store`)
- Chrome DevTools → Application → Back/Forward Cache → "Test back/forward cache" reports "Back/forward cache is available"
- Lighthouse drops the 7 bfcache failure reasons currently logged in `new_wm_lighthouse_report.pdf`

Qualitative regression check (manual post-merge):
- Sign in → click a link → hit back → still signed in (that's correct behavior — session state lives in cookies, not the HTML body)

## Notes on impact

F's win is qualitative (bfcache restoration → instant back/forward), not raw timing. Single-sample recording timings won't reliably show this — the load-bearing signals are the production response header and DevTools' bfcache check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)