### PR TITLE
fix(health/seeders): clear DEGRADED — suppressed spread, bot-walled NZ, FRED proxy TLS retry

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -521,14 +521,26 @@ const ON_DEMAND_KEYS = new Set([
                                    // never-provisioned Railway promotes EMPTY_ON_DEMAND → EMPTY (CRIT).
 ]);
 
-// Keys where 0 records is a valid healthy state (e.g. no airports closed,
-// no earnings events this week, econ calendar quiet between seasons).
-// The key must still exist in Redis; only the record count can be 0.
+// Legacy broad empty-data exemptions. classifyKey uses this set in both the
+// missing-key and zero-record branches, so entries here can be OK while fresh
+// even when the data key has strlen=0. For producer-specific cases where the
+// payload must exist but recordCount=0 is valid, add to ZERO_RECORD_DATA_OK_KEYS
+// only.
 const EMPTY_DATA_OK_KEYS = new Set([
   'notamClosures', 'faaDelays', 'intlDelays', 'gpsjam', 'positiveGeoEvents', 'weatherAlerts',
   'earningsCalendar', 'econCalendar', 'cotPositioning',
   'usniFleet', // usniFleetStale covers the fallback; relay outages → WARN not CRIT
   'newsThreatSummary', // only written when classify produces country matches; quiet news periods = 0 countries, no write
+  'recoveryFiscalSpace',
+  'ddosAttacks', 'trafficAnomalies', // zero events during quiet periods is valid, not critical
+  'resilienceStaticFao', // empty aggregate = no IPC Phase 3+ countries this year (possible in theory); the key must exist but count=0 is fine
+  'cableHealth', // `cables: {}` = no active subsea cable disruptions per NGA NAVAREA warnings — all cables implicitly healthy. Also covers NGA-upstream-down windows where get-cable-health writes back the fallback response (empty cables); without this, those would alarm EMPTY_DATA.
+]);
+
+// Keys where a present payload with meta recordCount=0 is valid, but the data
+// key itself must still exist. Do not use this set in the missing-key branch.
+const ZERO_RECORD_DATA_OK_KEYS = new Set([
+  ...EMPTY_DATA_OK_KEYS,
   // retailer-spread is SUPPRESSED to an explicit 0 by the aggregate job when a
   // market's retailers share < MIN_SPREAD_ITEMS (4) common basket items —
   // consumer-prices-core/src/jobs/aggregate.ts writes `retailer_spread_pct: 0`
@@ -538,12 +550,8 @@ const EMPTY_DATA_OK_KEYS = new Set([
   // late-May 2026 while the seeder kept running fresh (seedAgeMin well inside
   // maxStaleMin) and the sibling keys (overview/categories/movers/basket-series)
   // published normally. Treat 0 records as OK while fresh; STALE_SEED still
-  // fires if the publish job itself stops. Same shape as newsThreatSummary above.
+  // fires if the publish job itself stops.
   'consumerPricesSpread',
-  'recoveryFiscalSpace',
-  'ddosAttacks', 'trafficAnomalies', // zero events during quiet periods is valid, not critical
-  'resilienceStaticFao', // empty aggregate = no IPC Phase 3+ countries this year (possible in theory); the key must exist but count=0 is fine
-  'cableHealth', // `cables: {}` = no active subsea cable disruptions per NGA NAVAREA warnings — all cables implicitly healthy. Also covers NGA-upstream-down windows where get-cable-health writes back the fallback response (empty cables); without this, those would alarm EMPTY_DATA.
 ]);
 
 // Cascade groups: if any key in the group has data, all empty siblings are OK.
@@ -680,7 +688,7 @@ function classifyKey(name, redisKey, opts, ctx) {
   } else if (records === 0) {
     // hasData is true in this branch, so cascade can never apply (isCascadeCovered
     // short-circuits when hasData=true). Cascade only shields wholly absent keys.
-    if (EMPTY_DATA_OK_KEYS.has(name)) status = seedStale === true ? 'STALE_SEED' : 'OK';
+    if (ZERO_RECORD_DATA_OK_KEYS.has(name)) status = seedStale === true ? 'STALE_SEED' : 'OK';
     else if (isOnDemand) status = 'EMPTY_ON_DEMAND';
     else status = 'EMPTY_DATA';
   } else if (seedStale === true) status = 'STALE_SEED';

--- a/api/health.js
+++ b/api/health.js
@@ -529,6 +529,17 @@ const EMPTY_DATA_OK_KEYS = new Set([
   'earningsCalendar', 'econCalendar', 'cotPositioning',
   'usniFleet', // usniFleetStale covers the fallback; relay outages → WARN not CRIT
   'newsThreatSummary', // only written when classify produces country matches; quiet news periods = 0 countries, no write
+  // retailer-spread is SUPPRESSED to an explicit 0 by the aggregate job when a
+  // market's retailers share < MIN_SPREAD_ITEMS (4) common basket items —
+  // consumer-prices-core/src/jobs/aggregate.ts writes `retailer_spread_pct: 0`
+  // ("prevent stale noisy value persisting") and logs "spread suppressed
+  // (N/4 common items)". That is a valid data-coverage state, not a pipeline
+  // outage: the AE basket's cross-retailer overlap shrank 2/4 → 1/4 → 0/4 over
+  // late-May 2026 while the seeder kept running fresh (seedAgeMin well inside
+  // maxStaleMin) and the sibling keys (overview/categories/movers/basket-series)
+  // published normally. Treat 0 records as OK while fresh; STALE_SEED still
+  // fires if the publish job itself stops. Same shape as newsThreatSummary above.
+  'consumerPricesSpread',
   'recoveryFiscalSpace',
   'ddosAttacks', 'trafficAnomalies', // zero events during quiet periods is valid, not critical
   'resilienceStaticFao', // empty aggregate = no IPC Phase 3+ countries this year (possible in theory); the key must exist but count=0 is fine

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -672,19 +672,30 @@ export async function httpsProxyFetchRaw(url, proxyAuth, { accept = '*/*', timeo
   return { buffer: result.buffer, contentType: result.contentType };
 }
 
+// Whether a proxy error should be retried (the Decodo proxy rotates exit IP per
+// attempt). Covers 5xx/522, DNS/socket errors, AND mid-handshake TLS tears — the
+// last group is load-bearing: if a TLS-tear isn't classified transient, the
+// retry loop breaks on attempt 1 and falls to a direct FRED fetch, which a
+// datacenter IP gets rate-limited/blocked on → the whole batch fails. Exported
+// for unit testing (the proxy fetch itself is network-bound and not injectable).
+export function isTransientProxyError(message) {
+  return /HTTP 5\d{2}|522|timeout|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|EPIPE|socket (disconnected|hang up)|TLS connection|tls_get_more_records|packet length too long|SSL routines|secure TLS connection/i.test(message || '');
+}
+
 // Fetch JSON from a FRED URL, routing through proxy when available.
 // Proxy-first: FRED consistently blocks/throttles Railway datacenter IPs,
 // so try proxy first to avoid 20s timeout on every direct attempt.
 export async function fredFetchJson(url, proxyAuth) {
   if (proxyAuth) {
-    // Decodo proxy flaps on 5xx/522 — retry up to 3 times with backoff before falling back direct.
+    // Retry the proxy (rotates exit IP per attempt) before falling back direct.
+    // isTransientProxyError covers TLS-handshake tears — see its doc comment.
     let lastProxyErr;
     for (let attempt = 1; attempt <= 3; attempt++) {
       try {
         return await httpsProxyFetchJson(url, proxyAuth);
       } catch (proxyErr) {
         lastProxyErr = proxyErr;
-        const transient = /HTTP 5\d{2}|522|timeout|ECONNRESET|ETIMEDOUT|EAI_AGAIN/i.test(proxyErr.message || '');
+        const transient = isTransientProxyError(proxyErr.message);
         if (attempt < 3 && transient) {
           await new Promise((r) => setTimeout(r, 400 * attempt + Math.random() * 300));
           continue;

--- a/scripts/seed-fuel-prices.mjs
+++ b/scripts/seed-fuel-prices.mjs
@@ -613,7 +613,21 @@ export function parseCREStationPrices(xml) {
 // CONNECTs by policy, and direct fetch fails undici TLS handshake. Until a
 // working route is found, gating publish on Brazil's freshness means every
 // run exits 1 → Railway "Deployment crashed" banner + STALE_SEED flip.
-const TOLERATED_FAILURES = new Set(['Brazil']);
+//
+// New Zealand (MBIE) joined this set 2026-06-01: mbie.govt.nz moved its ENTIRE
+// domain (apex, data page, and the weekly-table.csv asset) behind an Incapsula
+// (Imperva) JS bot-wall ~2026-05-20. It now returns HTTP 200 text/html (~212B,
+// `_Incapsula_Resource` stub) instead of the CSV — verified blocked from a
+// residential IP, a datacenter IP, AND the Decodo residential proxy, so the
+// older "proxy-preferred + retry" path (written for an IP-reputation 403)
+// cannot pass it. A plain fetch can't solve a JS challenge from any IP, and
+// data.govt.nz / figure.nz fallbacks are also Incapsula-walled. Until NZ is
+// restored via a headless/challenge-solver fetch (tracked separately), gating
+// publish on NZ rejected the whole multi-source fuel-prices snapshot every run
+// (validation failed → seed-meta never refreshed → 12d STALE_SEED), even though
+// ≥30 countries + US/GB/MY were present. fetchNewZealand() still runs and
+// carries NZ automatically the moment the source returns CSV again.
+const TOLERATED_FAILURES = new Set(['Brazil', 'New Zealand']);
 
 // Publish gate. Exported so tests can lock in the contract.
 //

--- a/tests/fred-proxy-transient-classify.test.mjs
+++ b/tests/fred-proxy-transient-classify.test.mjs
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isTransientProxyError } from '../scripts/_seed-utils.mjs';
+
+// fredFetchJson retries the (IP-rotating) Decodo proxy only when the error is
+// classified transient; otherwise it breaks to a direct FRED fetch, which a
+// datacenter IP gets rate-limited/blocked on → the whole seed-economy batch
+// fails and fredBatch/economicStress/macroSignals go stale. The TLS-handshake
+// tear signatures below are the EXACT strings seen in the failing-run logs and
+// MUST be retried — they did not match the original 5xx/timeout-only regex.
+//
+// Run: node --test tests/fred-proxy-transient-classify.test.mjs
+
+test('TLS-handshake tear signatures (from the real failing logs) are transient', () => {
+  const tlsTears = [
+    '80D38646D17F0000:error:0A0000C6:SSL routines:tls_get_more_records:packet length too long:ssl/record/methods/tls_common.c:662:',
+    'Client network socket disconnected before secure TLS connection was established',
+  ];
+  for (const msg of tlsTears) {
+    assert.equal(isTransientProxyError(msg), true, `should retry: ${msg}`);
+  }
+});
+
+test('classic transient signatures still classify transient (no regression)', () => {
+  for (const msg of [
+    'HTTP 522', 'HTTP 503', 'proxy fetch timeout',
+    'ECONNRESET', 'ETIMEDOUT', 'EAI_AGAIN', 'socket hang up',
+  ]) {
+    assert.equal(isTransientProxyError(msg), true, `should retry: ${msg}`);
+  }
+});
+
+test('genuinely non-transient errors are NOT retried (fall straight to direct)', () => {
+  for (const msg of ['HTTP 401', 'HTTP 403', 'HTTP 404', 'Missing FRED_API_KEY', '']) {
+    assert.equal(isTransientProxyError(msg), false, `should NOT retry: "${msg}"`);
+  }
+  assert.equal(isTransientProxyError(undefined), false);
+  assert.equal(isTransientProxyError(null), false);
+});

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -100,6 +100,43 @@ test('classifyKey: empty on-demand standalone key → EMPTY_ON_DEMAND (warn)', (
   assert.equal(STATUS_COUNTS[entry.status], 'warn');
 });
 
+test('classifyKey: suppressed retailer-spread (present key, 0 records) while fresh → OK, not EMPTY_DATA', () => {
+  // The consumer-prices aggregate job writes retailer_spread_pct: 0 ("spread
+  // suppressed (N/4 common items)") when a market's retailers share < 4 common
+  // basket items — a valid data-coverage state, not an outage. The key exists
+  // (296-byte payload → hasData=true) with metaCount=0, so without the
+  // EMPTY_DATA_OK_KEYS exemption it would wrongly classify EMPTY_DATA (crit) and
+  // tip /api/health to DEGRADED. Fresh seed-meta → OK.
+  const entry = classifyKey('consumerPricesSpread', BOOTSTRAP_KEYS.consumerPricesSpread,
+    { allowOnDemand: false },
+    makeCtx({
+      strens: { [BOOTSTRAP_KEYS.consumerPricesSpread]: 296 },
+      metaValues: {
+        'seed-meta:consumer-prices:retailer-spread:ae:essentials-ae':
+          seedMeta({ recordCount: 0 }),
+      },
+    }));
+  assert.equal(entry.status, 'OK');
+  assert.equal(STATUS_COUNTS[entry.status], 'ok');
+});
+
+test('classifyKey: suppressed retailer-spread that goes STALE still warns (publish job stopped)', () => {
+  // The EMPTY_DATA_OK exemption must NOT mask a genuine publish-job outage:
+  // once seed-meta age exceeds maxStaleMin (1500), 0 records degrades to
+  // STALE_SEED (warn), not silent OK.
+  const entry = classifyKey('consumerPricesSpread', BOOTSTRAP_KEYS.consumerPricesSpread,
+    { allowOnDemand: false },
+    makeCtx({
+      strens: { [BOOTSTRAP_KEYS.consumerPricesSpread]: 296 },
+      metaValues: {
+        'seed-meta:consumer-prices:retailer-spread:ae:essentials-ae':
+          seedMeta({ recordCount: 0, fetchedAt: NOW - 2000 * ONE_MIN_MS }),
+      },
+    }));
+  assert.equal(entry.status, 'STALE_SEED');
+  assert.equal(STATUS_COUNTS[entry.status], 'warn');
+});
+
 // ── cascade coverage (proactive, via isCascadeCovered) ──────────────────────
 
 test('cascade: empty theaterPostureLive with data in a sibling → OK_CASCADE (no crit/warn leak)', () => {

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -105,7 +105,7 @@ test('classifyKey: suppressed retailer-spread (present key, 0 records) while fre
   // suppressed (N/4 common items)") when a market's retailers share < 4 common
   // basket items — a valid data-coverage state, not an outage. The key exists
   // (296-byte payload → hasData=true) with metaCount=0, so without the
-  // EMPTY_DATA_OK_KEYS exemption it would wrongly classify EMPTY_DATA (crit) and
+  // zero-record exemption it would wrongly classify EMPTY_DATA (crit) and
   // tip /api/health to DEGRADED. Fresh seed-meta → OK.
   const entry = classifyKey('consumerPricesSpread', BOOTSTRAP_KEYS.consumerPricesSpread,
     { allowOnDemand: false },
@@ -120,8 +120,24 @@ test('classifyKey: suppressed retailer-spread (present key, 0 records) while fre
   assert.equal(STATUS_COUNTS[entry.status], 'ok');
 });
 
+test('classifyKey: missing retailer-spread payload is still EMPTY even with fresh 0-record meta', () => {
+  // The suppressed-spread exemption only applies once Redis proves the payload
+  // exists. A missing canonical key is still a publish/write failure and must
+  // not be hidden by the zero-record allowance.
+  const entry = classifyKey('consumerPricesSpread', BOOTSTRAP_KEYS.consumerPricesSpread,
+    { allowOnDemand: false },
+    makeCtx({
+      metaValues: {
+        'seed-meta:consumer-prices:retailer-spread:ae:essentials-ae':
+          seedMeta({ recordCount: 0 }),
+      },
+    }));
+  assert.equal(entry.status, 'EMPTY');
+  assert.equal(STATUS_COUNTS[entry.status], 'crit');
+});
+
 test('classifyKey: suppressed retailer-spread that goes STALE still warns (publish job stopped)', () => {
-  // The EMPTY_DATA_OK exemption must NOT mask a genuine publish-job outage:
+  // The zero-record exemption must NOT mask a genuine publish-job outage:
   // once seed-meta age exceeds maxStaleMin (1500), 0 records degrades to
   // STALE_SEED (warn), not silent OK.
   const entry = classifyKey('consumerPricesSpread', BOOTSTRAP_KEYS.consumerPricesSpread,

--- a/tests/seed-fuel-prices.test.mjs
+++ b/tests/seed-fuel-prices.test.mjs
@@ -62,6 +62,34 @@ test('validateFuel accepts when only a TOLERATED source (Brazil) failed', () => 
   );
 });
 
+test('validateFuel accepts when only TOLERATED New Zealand failed (Incapsula bot-wall)', () => {
+  // MBIE moved behind an Incapsula JS bot-wall ~2026-05-20 — unreachable by plain
+  // fetch from any IP (residential/datacenter/proxy). It must not gate the whole
+  // multi-source publish, or fuel-prices goes STALE_SEED while ≥30 countries +
+  // US/GB/MY are present. Same rationale as Brazil.
+  assert.equal(
+    validateFuel({ countries: HEALTHY_COUNTRIES, failedSources: ['New Zealand'] }),
+    true,
+    'NZ MBIE is JS-bot-walled; must not gate publish (≥30 countries + US/GB/MY still required)',
+  );
+});
+
+test('validateFuel still accepts when BOTH tolerated sources (Brazil + New Zealand) failed', () => {
+  assert.equal(
+    validateFuel({ countries: HEALTHY_COUNTRIES, failedSources: ['Brazil', 'New Zealand'] }),
+    true,
+  );
+});
+
+test('validateFuel still REJECTS a tolerated + an untolerated failure together', () => {
+  // Tolerating NZ must not weaken the gate for a real critical-source outage.
+  assert.equal(
+    validateFuel({ countries: HEALTHY_COUNTRIES, failedSources: ['New Zealand', 'Mexico'] }),
+    false,
+    'an untolerated failure (Mexico) must still reject even when a tolerated one (NZ) is also present',
+  );
+});
+
 test('validateFuel rejects when country count < 30', () => {
   const countries = [
     { code: 'US' }, { code: 'GB' }, { code: 'MY' },


### PR DESCRIPTION
## Summary

Triaged the live **DEGRADED** `/api/health` against Railway logs + cron history. Three genuine code defects fixed here; the remaining crit (`militaryCii`) is infra-only and noted below.

### Fix 1 — `consumerPricesSpread` wrongly crit (`api/health.js`)
The consumer-prices aggregate job *deliberately* writes `retailer_spread_pct: 0` when a market's retailers share < `MIN_SPREAD_ITEMS` (4) common basket items (`aggregate.ts:247`). AE's cross-retailer overlap fell `2/4 -> 1/4 -> 0/4` while the publish job stayed fresh (`seedAgeMin=111` << 1500) and siblings published normally — yet health crit'd the present-but-zero key as `EMPTY_DATA` -> DEGRADED.

Fix: added a **zero-record-only** exemption for `consumerPricesSpread` (`ZERO_RECORD_DATA_OK_KEYS`) while keeping the missing-payload branch strict. That means `recordCount: 0` is OK while the seed is fresh **only when the payload key exists**; a missing retailer-spread payload still classifies `EMPTY`, and `STALE_SEED` still fires if the publish job stops.

### Fix 2 — fuel-prices blocked by JS-bot-walled NZ (`scripts/seed-fuel-prices.mjs`)
`mbie.govt.nz` moved its whole domain behind an **Incapsula JS bot-wall** (~2026-05-20) — returns a 212B `_Incapsula_Resource` stub, not CSV. **Verified blocked from residential IP, datacenter IP, AND the Decodo proxy** (data.govt.nz/figure.nz also walled). NZ failing rejected the *whole* validated publish every run -> 12d STALE_SEED. Added `'New Zealand'` to `TOLERATED_FAILURES` (Brazil precedent; gate not weakened — NZ+Mexico still rejects). Proper restore tracked in **#4010**.

### Fix 3 — seed-economy FRED proxy TLS-tear not retried (`scripts/_seed-utils.mjs`)
seed-economy has been **running every ~15min and failing every run** (red dot; ~2m34s vs ~37s healthy = a step hanging to timeout) -> `fredBatch` + `economicStress` + `macroSignals` stale. Root cause: `fredFetchJson`'s transient classifier. The Decodo proxy flaps **mid-TLS-handshake**; the failing-run logs show hundreds of `tls_get_more_records: packet length too long` and `Client network socket disconnected before secure TLS connection was established` — **neither matched the old `5xx|522|timeout|ECONNRESET|ETIMEDOUT|EAI_AGAIN` regex**, so `transient=false` -> the 3x proxy retry broke on attempt 1 and fell to a **direct** FRED fetch, which Railway's datacenter IP gets rate-limited on -> all 24 series burned their full retry+20s-timeout budget (the ~2min slowdown) and the batch came back empty. (`FRED_API_KEY` is **valid** — tested HTTP 200 — so it's transport, not auth.) Fix: extracted `isTransientProxyError()` and added the TLS-tear/socket signatures so the proxy is retried (it rotates exit IP per attempt -> a fresh IP completes the handshake, which is why the captured window still hit 24/24 via retries). seed-economy's pipeline is already fail-soft, so restoring FRED success is the fix.

## NOT in this PR
- **`militaryCii`**: `seed-military-cii.mjs` was never provisioned as a Railway cron (PR #3864's commit message flags it). No seed-meta ever written; key still live-consumed by `get-risk-scores.ts`. -> provision the cron.
- **Decodo proxy TLS stability**: this PR retries transient TLS-handshake tears so seed-economy survives the current flapping proxy behavior. It does not cure an upstream proxy/provider degradation; if the TLS failures become persistent, the job will still burn the bounded retry budget and needs provider/proxy follow-up.

## Test plan
- [x] `tests/health-classify.test.mjs` 16/16 (3 new, including the missing-payload regression)
- [x] `tests/seed-fuel-prices.test.mjs` 14/14 (4 new, fail->pass + NZ+Mexico still-rejects)
- [x] `tests/fred-proxy-transient-classify.test.mjs` 3/3 (TLS-tear strings from the real logs; fail->pass against old regex)
- [x] seed-utils consumers (envelope/retry/dockerfile-import guards) 31/31 · full health suite 38/38
- [x] docs:check · biome · esbuild bundle — clean

Follow-up for NZ restore: #4010
