### PR TITLE
fix(cyber-seed): populate firstSeenAt for all sources (#4008)

### DIFF
--- a/scripts/seed-cyber-threats.mjs
+++ b/scripts/seed-cyber-threats.mjs
@@ -524,23 +524,34 @@ function dedupeThreats(threats) {
   return Array.from(map.values());
 }
 
-// Issue #4008 — pure merge of WorldMonitor-observed first-seen. For each threat:
-// prefer a real upstream discovery date; else carry forward the earliest time we
-// previously observed the indicator; else stamp `nowMs` (first sighting). Mutates
-// each threat's `firstSeen` in place and returns the next persisted map, rebuilt
-// from only the indicators present this run (self-pruning). Keyed by indicator
-// identity (`indicatorType:indicator`) so the same IOC seen via multiple sources
-// shares one first-seen. Pure (no I/O) so it is unit-testable.
+// Issue #4008 — pure merge of WorldMonitor-observed first-seen. Resolves one
+// canonical first-seen per indicator = min(every upstream date present this run,
+// the prior persisted value); if no real date exists anywhere, stamps `nowMs`
+// (first sighting). Two passes so the value is order-independent: every
+// occurrence of the same IOC (e.g. seen via URLhaus + AbuseIPDB in one run) gets
+// the SAME firstSeen even on the first run, regardless of which source's row
+// comes first. Mutates each threat's `firstSeen` in place and returns the next
+// persisted map, rebuilt from only the indicators present this run (self-pruning).
+// Keyed by indicator identity (`indicatorType:indicator`). Pure (no I/O) so it is
+// unit-testable.
 export function mergeObservedFirstSeen(threats, priorMap, nowMs) {
   const prior = priorMap && typeof priorMap === 'object' ? priorMap : {};
   const next = {};
+  // Pass 1: fold the earliest *real* (>0) date across all occurrences + prior.
+  // Keys with no real date anywhere are recorded as 0 (resolved to nowMs below).
   for (const t of threats) {
     const key = `${t.indicatorType}:${t.indicator}`;
     const upstream = Number(t.firstSeen) > 0 ? Number(t.firstSeen) : 0;
     const stored = Number(prior[key]) > 0 ? Number(prior[key]) : 0;
-    const firstSeen = upstream && stored ? Math.min(upstream, stored) : (upstream || stored || nowMs);
-    t.firstSeen = firstSeen;
-    next[key] = next[key] ? Math.min(next[key], firstSeen) : firstSeen;
+    const candidates = [upstream, stored, next[key]].filter((v) => Number(v) > 0);
+    next[key] = candidates.length ? Math.min(...candidates) : (next[key] ?? 0);
+  }
+  // Pass 2: any key still without a real date is a first sighting → nowMs; then
+  // assign the resolved value to every occurrence so the snapshot is consistent.
+  for (const t of threats) {
+    const key = `${t.indicatorType}:${t.indicator}`;
+    if (!(Number(next[key]) > 0)) next[key] = nowMs;
+    t.firstSeen = next[key];
   }
   return { threats, nextMap: next };
 }

--- a/scripts/seed-cyber-threats.mjs
+++ b/scripts/seed-cyber-threats.mjs
@@ -12,6 +12,17 @@ const CANONICAL_KEY = 'cyber:threats:v2';
 const BOOTSTRAP_KEY = 'cyber:threats-bootstrap:v2';
 const CACHE_TTL = 10800; // 3h — survives 1 missed 2h cron cycle
 
+// Issue #4008: the bulk sources (AbuseIPDB blacklist, C2Intel plaintext) carry
+// no upstream first-seen, so `firstSeenAt` was 0 for the majority of records,
+// leaving downstream consumers (cyberDigital discovery-day grouping, #3971/#4009)
+// without a usable discovery timestamp. We persist a WorldMonitor-observed
+// first-seen per indicator across runs: upstream first-seen wins when present,
+// otherwise the first run that observes an indicator stamps it. The map is
+// rebuilt from the current feed each run, so it self-prunes to ~feed size
+// instead of growing unbounded. Internal cache key (cache: prefix), not public.
+const FIRST_SEEN_KEY = 'cache:cyber:first-seen:v1';
+const FIRST_SEEN_TTL = 14 * 24 * 60 * 60; // 14d — refreshed every run; survives multi-day cron gaps
+
 const FEODO_URL = 'https://feodotracker.abuse.ch/downloads/ipblocklist.json';
 const URLHAUS_RECENT_URL = (limit) => `https://urlhaus-api.abuse.ch/v1/urls/recent/limit/${limit}/`;
 const C2INTEL_URL = 'https://raw.githubusercontent.com/drb-ra/C2IntelFeeds/master/feeds/IPC2s-30day.csv';
@@ -330,8 +341,11 @@ async function fetchUrlhaus(cutoffMs) {
       const indType = ipCand ? 'ip' : (hostname ? 'domain' : 'url');
       const indicator = ipCand || hostname || rawUrl;
       if (!indicator) continue;
-      const firstSeen = toEpochMs(r?.dateadded || r?.firstseen || r?.first_seen);
-      const lastSeen = toEpochMs(r?.last_online || r?.last_seen || r?.dateadded);
+      // URLhaus /v1/urls/recent/ returns `date_added` (snake_case, e.g.
+      // "2026-06-01 12:00:00 UTC"); the prior `dateadded` key never matched, so
+      // both timestamps fell through to 0 (#4008). Keep the old keys as fallbacks.
+      const firstSeen = toEpochMs(r?.date_added || r?.dateadded || r?.firstseen || r?.first_seen);
+      const lastSeen = toEpochMs(r?.last_online || r?.last_seen || r?.date_added || r?.dateadded);
       if ((lastSeen || firstSeen) && (lastSeen || firstSeen) < cutoffMs) continue;
       const threat = clean(r?.threat || r?.threat_type || '', 40).toLowerCase();
       const allTags = tags.join(' ');
@@ -510,6 +524,46 @@ function dedupeThreats(threats) {
   return Array.from(map.values());
 }
 
+// Issue #4008 — pure merge of WorldMonitor-observed first-seen. For each threat:
+// prefer a real upstream discovery date; else carry forward the earliest time we
+// previously observed the indicator; else stamp `nowMs` (first sighting). Mutates
+// each threat's `firstSeen` in place and returns the next persisted map, rebuilt
+// from only the indicators present this run (self-pruning). Keyed by indicator
+// identity (`indicatorType:indicator`) so the same IOC seen via multiple sources
+// shares one first-seen. Pure (no I/O) so it is unit-testable.
+export function mergeObservedFirstSeen(threats, priorMap, nowMs) {
+  const prior = priorMap && typeof priorMap === 'object' ? priorMap : {};
+  const next = {};
+  for (const t of threats) {
+    const key = `${t.indicatorType}:${t.indicator}`;
+    const upstream = Number(t.firstSeen) > 0 ? Number(t.firstSeen) : 0;
+    const stored = Number(prior[key]) > 0 ? Number(prior[key]) : 0;
+    const firstSeen = upstream && stored ? Math.min(upstream, stored) : (upstream || stored || nowMs);
+    t.firstSeen = firstSeen;
+    next[key] = next[key] ? Math.min(next[key], firstSeen) : firstSeen;
+  }
+  return { threats, nextMap: next };
+}
+
+// Redis wrapper around mergeObservedFirstSeen. Read/write failures are non-fatal:
+// a missing prior map degrades to stamping `nowMs`, and a failed write just means
+// next run re-stamps — neither should fail the seed.
+async function applyObservedFirstSeen(threats, nowMs) {
+  let prior = {};
+  try {
+    const raw = await verifySeedKey(FIRST_SEEN_KEY);
+    if (raw && typeof raw === 'object') prior = raw;
+  } catch (e) {
+    console.warn(`  first-seen map read failed — ${e?.message || e}`);
+  }
+  const { nextMap } = mergeObservedFirstSeen(threats, prior, nowMs);
+  try {
+    await writeExtraKey(FIRST_SEEN_KEY, nextMap, FIRST_SEEN_TTL);
+  } catch (e) {
+    console.warn(`  first-seen map write failed — ${e?.message || e}`);
+  }
+}
+
 function toProto(raw) {
   return {
     id: raw.id,
@@ -552,6 +606,11 @@ async function fetchAllThreats() {
 
   console.log(`  Combined (deduped): ${combined.length}`);
 
+  // #4008: stamp a stable per-indicator first-seen (upstream when present, else
+  // WorldMonitor-observed) before sort/proto so `firstSeenAt` is populated for
+  // every source, including AbuseIPDB/C2Intel which carry no upstream date.
+  await applyObservedFirstSeen(combined, now);
+
   const hydrated = await hydrateCoordinates(combined);
 
   // Keep all threats — geo-resolved first, then unresolved (so the seed never returns 0
@@ -580,16 +639,23 @@ export function declareRecords(data) {
   return Array.isArray(data?.threats) ? data.threats.length : 0;
 }
 
-runSeed('cyber', 'threats', CANONICAL_KEY, fetchAllThreats, {
-  validateFn: validate,
-  ttlSeconds: CACHE_TTL,
-  sourceVersion: 'multi-ioc-v2',
-  extraKeys: [{ key: BOOTSTRAP_KEY, declareRecords }],
+// isMain guard so tests can import the pure helpers (mergeObservedFirstSeen,
+// declareRecords) without triggering a live seed run. Matches the repo
+// convention (see feedback_seed_isMain_guard); Railway still runs the seed via
+// `node scripts/seed-cyber-threats.mjs` because argv[1] resolves to this file.
+const isMain = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/^.*[\\/]/, ''));
+if (isMain) {
+  runSeed('cyber', 'threats', CANONICAL_KEY, fetchAllThreats, {
+    validateFn: validate,
+    ttlSeconds: CACHE_TTL,
+    sourceVersion: 'multi-ioc-v2',
+    extraKeys: [{ key: BOOTSTRAP_KEY, declareRecords }],
 
-  declareRecords,
-  schemaVersion: 1,
-  maxStaleMin: 240,
-}).catch((err) => {
-  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
-  process.exit(1);
-});
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 240,
+  }).catch((err) => {
+    const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
+    process.exit(1);
+  });
+}

--- a/tests/seed-cyber-first-seen.test.mjs
+++ b/tests/seed-cyber-first-seen.test.mjs
@@ -1,0 +1,69 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { mergeObservedFirstSeen } from '../scripts/seed-cyber-threats.mjs';
+
+// Issue #4008: WorldMonitor-observed first-seen merge. The cyber feed's bulk
+// sources (AbuseIPDB blacklist, C2Intel plaintext) carry no upstream first-seen,
+// so firstSeenAt was 0 for ~80% of records. mergeObservedFirstSeen stamps a
+// stable per-indicator discovery timestamp across runs.
+
+const NOW = 1_780_000_000_000;
+const DAY = 86_400_000;
+
+describe('mergeObservedFirstSeen (#4008)', () => {
+  it('stamps nowMs for a brand-new indicator with no upstream date', () => {
+    const threats = [{ indicatorType: 'ip', indicator: '1.2.3.4', firstSeen: 0 }];
+    const { threats: out, nextMap } = mergeObservedFirstSeen(threats, {}, NOW);
+    assert.equal(out[0].firstSeen, NOW, 'new upstream-less indicator is stamped now');
+    assert.equal(nextMap['ip:1.2.3.4'], NOW, 'persisted for next run');
+  });
+
+  it('carries forward a stored observation instead of re-stamping now', () => {
+    const earlier = NOW - 5 * DAY;
+    const threats = [{ indicatorType: 'ip', indicator: '1.2.3.4', firstSeen: 0 }];
+    const { threats: out, nextMap } = mergeObservedFirstSeen(threats, { 'ip:1.2.3.4': earlier }, NOW);
+    assert.equal(out[0].firstSeen, earlier, 'prior sighting is preserved, not reset');
+    assert.equal(nextMap['ip:1.2.3.4'], earlier);
+  });
+
+  it('prefers a real upstream discovery date over a later stored sighting', () => {
+    const upstream = NOW - 10 * DAY;
+    const stored = NOW - 3 * DAY;
+    const threats = [{ indicatorType: 'ip', indicator: '1.2.3.4', firstSeen: upstream }];
+    const { threats: out } = mergeObservedFirstSeen(threats, { 'ip:1.2.3.4': stored }, NOW);
+    assert.equal(out[0].firstSeen, upstream, 'earliest known (upstream) wins');
+  });
+
+  it('keeps the earlier value when both upstream and stored exist', () => {
+    const upstream = NOW - 2 * DAY;   // upstream is LATER than stored here
+    const stored = NOW - 9 * DAY;
+    const threats = [{ indicatorType: 'ip', indicator: '1.2.3.4', firstSeen: upstream }];
+    const { threats: out } = mergeObservedFirstSeen(threats, { 'ip:1.2.3.4': stored }, NOW);
+    assert.equal(out[0].firstSeen, stored, 'min(upstream, stored) — never moves first-seen later');
+  });
+
+  it('self-prunes: nextMap contains only indicators present this run', () => {
+    const threats = [{ indicatorType: 'ip', indicator: 'a', firstSeen: 0 }];
+    const prior = { 'ip:a': NOW - DAY, 'ip:gone': NOW - 30 * DAY };
+    const { nextMap } = mergeObservedFirstSeen(threats, prior, NOW);
+    assert.deepEqual(Object.keys(nextMap), ['ip:a'], 'absent indicators are dropped, bounding map size');
+  });
+
+  it('unifies first-seen across sources for the same indicator (min wins)', () => {
+    const threats = [
+      { indicatorType: 'ip', indicator: '9.9.9.9', firstSeen: NOW - 2 * DAY }, // urlhaus
+      { indicatorType: 'ip', indicator: '9.9.9.9', firstSeen: 0 },             // abuseipdb (no date)
+    ];
+    const { threats: out, nextMap } = mergeObservedFirstSeen(threats, {}, NOW);
+    assert.equal(nextMap['ip:9.9.9.9'], NOW - 2 * DAY, 'shared indicator keeps the earliest observation');
+    // the upstream-less duplicate still gets a concrete (non-zero) stamp
+    assert.ok(out[1].firstSeen > 0, 'no record is left at firstSeen=0');
+  });
+
+  it('treats invalid/zero prior entries as missing', () => {
+    const threats = [{ indicatorType: 'ip', indicator: '1.2.3.4', firstSeen: 0 }];
+    const { threats: out } = mergeObservedFirstSeen(threats, { 'ip:1.2.3.4': 0 }, NOW);
+    assert.equal(out[0].firstSeen, NOW, 'a stored 0 is not a valid prior sighting');
+  });
+});

--- a/tests/seed-cyber-first-seen.test.mjs
+++ b/tests/seed-cyber-first-seen.test.mjs
@@ -50,15 +50,28 @@ describe('mergeObservedFirstSeen (#4008)', () => {
     assert.deepEqual(Object.keys(nextMap), ['ip:a'], 'absent indicators are dropped, bounding map size');
   });
 
-  it('unifies first-seen across sources for the same indicator (min wins)', () => {
+  it('unifies first-seen across sources for the same indicator (dated row first)', () => {
     const threats = [
       { indicatorType: 'ip', indicator: '9.9.9.9', firstSeen: NOW - 2 * DAY }, // urlhaus
       { indicatorType: 'ip', indicator: '9.9.9.9', firstSeen: 0 },             // abuseipdb (no date)
     ];
     const { threats: out, nextMap } = mergeObservedFirstSeen(threats, {}, NOW);
     assert.equal(nextMap['ip:9.9.9.9'], NOW - 2 * DAY, 'shared indicator keeps the earliest observation');
-    // the upstream-less duplicate still gets a concrete (non-zero) stamp
-    assert.ok(out[1].firstSeen > 0, 'no record is left at firstSeen=0');
+    assert.equal(out[0].firstSeen, NOW - 2 * DAY);
+    assert.equal(out[1].firstSeen, NOW - 2 * DAY, 'both occurrences share one first-seen, even on first run');
+  });
+
+  it('unifies first-seen across sources regardless of row order (dated row second)', () => {
+    // Regression for the single-pass order bug: the dated row appears AFTER the
+    // undated one, so a one-pass merge would finalize out[0] to nowMs first.
+    const threats = [
+      { indicatorType: 'ip', indicator: '9.9.9.9', firstSeen: 0 },             // abuseipdb (no date)
+      { indicatorType: 'ip', indicator: '9.9.9.9', firstSeen: NOW - 2 * DAY }, // urlhaus
+    ];
+    const { threats: out, nextMap } = mergeObservedFirstSeen(threats, {}, NOW);
+    assert.equal(nextMap['ip:9.9.9.9'], NOW - 2 * DAY);
+    assert.equal(out[0].firstSeen, NOW - 2 * DAY, 'undated row adopts the dated sibling, not nowMs');
+    assert.equal(out[1].firstSeen, NOW - 2 * DAY);
   });
 
   it('treats invalid/zero prior entries as missing', () => {


### PR DESCRIPTION
## Summary
`firstSeenAt` was `0` for ~100% of `cyber:threats:v2` records (verified live 2026-06-01: 0/1006 non-zero), leaving downstream consumers without a usable discovery timestamp. Two root causes:

1. **Parse bug** — URLhaus `/v1/urls/recent/` returns `date_added` (snake_case), but the seeder read `dateadded`, so URLhaus (180 records) lost both `firstSeen` and `lastSeen` (the latter falls back to the same field). Fixed the field name; old keys kept as fallbacks.
2. **Structural gap** — AbuseIPDB blacklist (500) and C2Intel plaintext (300) carry **no** upstream first-seen at all.

Live per-source evidence:

| source | n | firstSeen>0 | lastSeen>0 |
|---|---|---|---|
| AbuseIPDB | 500 | 0 | 500 |
| C2Intel | 300 | 0 | 0 |
| URLhaus | 180 | 0 (parse bug) | 0 (parse bug) |
| OTX | 26 | 0 | 0 |

## Fix
Persist a **WorldMonitor-observed first-seen** per indicator across runs (`cache:cyber:first-seen:v1`, internal cache key):
- Upstream discovery date wins when present (`min`, so first-seen never moves later).
- Otherwise the first run that observes an indicator stamps it; subsequent runs carry it forward.
- The map is rebuilt from the current feed each run, so it **self-prunes** to ~feed size (no unbounded growth).
- Read/write are non-fatal — a Redis blip degrades to stamping `now`, never fails the seed.

This is the prerequisite for genuine burst-vs-sustained `cyberDigital` discrimination (the discovery-day grouping deferred from #3971 / the EWMA option in #4009).

## No scoring impact / no cache bump
The merged #4006 `cyberDigital` fix uses a **per-snapshot total cap** that reads neither `firstSeenAt` nor `lastSeenAt`, so this change does not alter any current resilience score — it only populates the field for future use. Other `cyber:threats:v2` consumers (panel/MCP) strictly improve (was 0, now populated).

## Implementation notes
- `mergeObservedFirstSeen(threats, priorMap, nowMs)` — pure, exported, unit-tested.
- `applyObservedFirstSeen` — non-fatal Redis wrapper, called after dedup in `fetchAllThreats`.
- Added the standard `isMain` guard so tests can import the helper without triggering a live seed.

## Validation
- `npx tsx --test tests/seed-cyber-first-seen.test.mjs` — 7 cases (stamp-now, carry-forward, upstream-wins, min-never-later, self-prune, cross-source unify, invalid-prior). All pass.
- `node --check scripts/seed-cyber-threats.mjs` — OK
- `npx biome lint scripts/seed-cyber-threats.mjs tests/seed-cyber-first-seen.test.mjs` — clean

Fixes #4008.