### PR TITLE
Preserve variant-specific panel configs

### DIFF
--- a/src/app/search-manager.ts
+++ b/src/app/search-manager.ts
@@ -5,7 +5,7 @@ import type { MapView } from '@/components';
 import type { Command } from '@/config/commands';
 import { SearchModal } from '@/components';
 import { CIIPanel } from '@/components';
-import { SITE_VARIANT, STORAGE_KEYS, ALL_PANELS, isPanelEntitled } from '@/config';
+import { SITE_VARIANT, STORAGE_KEYS, ALL_PANELS, getEffectivePanelConfig, isPanelEntitled } from '@/config';
 import { getAllowedLayerKeys, isLayerExecutable } from '@/config/map-layer-definitions';
 import type { MapRenderer } from '@/config/map-layer-definitions';
 import type { MapVariant } from '@/config/map-layer-definitions';
@@ -765,7 +765,7 @@ export class SearchManager implements AppModule {
     );
     this.ctx.searchModal.setAvailablePanels(
       Object.keys(this.ctx.panelSettings).filter((k) => {
-        const cfg = ALL_PANELS[k];
+        const cfg = ALL_PANELS[k] ? getEffectivePanelConfig(k, SITE_VARIANT) : undefined;
         return cfg ? isPanelEntitled(k, cfg, isPro) : false;
       })
     );

--- a/src/app/search-manager.ts
+++ b/src/app/search-manager.ts
@@ -765,6 +765,8 @@ export class SearchManager implements AppModule {
     );
     this.ctx.searchModal.setAvailablePanels(
       Object.keys(this.ctx.panelSettings).filter((k) => {
+        // Keep unregistered/dynamic keys out of search; the resolver would
+        // otherwise return a disabled synthetic fallback for unknown keys.
         const cfg = ALL_PANELS[k] ? getEffectivePanelConfig(k, SITE_VARIANT) : undefined;
         return cfg ? isPanelEntitled(k, cfg, isPro) : false;
       })

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -740,6 +740,8 @@ export class UnifiedSettings {
     const pro = isProUser();
     const entries = this.getVisiblePanelEntries();
     setTrustedHtml(container, trustedHtml(entries.map(([key, panel]) => {
+      // Preserve saved config for dynamic cw-* panels; unknown keys should not
+      // collapse to getEffectivePanelConfig's disabled synthetic fallback.
       const resolvedPanel = ALL_PANELS[key] ? getEffectivePanelConfig(key, SITE_VARIANT) : panel;
       const entitled = isPanelEntitled(key, resolvedPanel, pro);
       const locked = !entitled;
@@ -783,6 +785,8 @@ export class UnifiedSettings {
   private toggleDraftPanel(key: string): void {
     const panel = this.draftPanelSettings[key];
     if (!panel) return;
+    // Preserve saved config for dynamic cw-* panels; unknown keys should not
+    // collapse to getEffectivePanelConfig's disabled synthetic fallback.
     const resolvedPanel = ALL_PANELS[key] ? getEffectivePanelConfig(key, SITE_VARIANT) : panel;
     if (!panel.enabled && !isPanelEntitled(key, resolvedPanel, isProUser())) return;
     if (!panel.enabled && !isProUser()) {

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -740,15 +740,16 @@ export class UnifiedSettings {
     const pro = isProUser();
     const entries = this.getVisiblePanelEntries();
     setTrustedHtml(container, trustedHtml(entries.map(([key, panel]) => {
-      const entitled = isPanelEntitled(key, ALL_PANELS[key] ?? panel, pro);
+      const resolvedPanel = ALL_PANELS[key] ? getEffectivePanelConfig(key, SITE_VARIANT) : panel;
+      const entitled = isPanelEntitled(key, resolvedPanel, pro);
       const locked = !entitled;
       const changed = !locked && savedSettings[key]?.enabled !== panel.enabled;
-      const displayName = this.config.getLocalizedPanelName(key, getEffectivePanelConfig(key, SITE_VARIANT).name ?? panel.name);
+      const displayName = this.config.getLocalizedPanelName(key, resolvedPanel.name ?? panel.name);
       return `
         <div class="panel-toggle-item ${panel.enabled && !locked ? 'active' : ''}${changed ? ' changed' : ''}${locked ? ' pro-locked' : ''}" data-panel="${escapeHtml(key)}" aria-pressed="${panel.enabled && !locked}" ${locked ? 'data-pro-locked="1"' : ''}>
           <div class="panel-toggle-checkbox">${panel.enabled && !locked ? '\u2713' : ''}${locked ? '\uD83D\uDD12' : ''}</div>
           <span class="panel-toggle-label">${escapeHtml(displayName)}</span>
-          ${(locked || (ALL_PANELS[key] ?? panel).premium) ? '<span class="panel-toggle-pro-badge">PRO</span>' : ''}
+          ${(locked || resolvedPanel.premium) ? '<span class="panel-toggle-pro-badge">PRO</span>' : ''}
         </div>
       `;
     }).join(''), "legacy direct innerHTML migration"));
@@ -782,7 +783,8 @@ export class UnifiedSettings {
   private toggleDraftPanel(key: string): void {
     const panel = this.draftPanelSettings[key];
     if (!panel) return;
-    if (!panel.enabled && !isPanelEntitled(key, ALL_PANELS[key] ?? panel, isProUser())) return;
+    const resolvedPanel = ALL_PANELS[key] ? getEffectivePanelConfig(key, SITE_VARIANT) : panel;
+    if (!panel.enabled && !isPanelEntitled(key, resolvedPanel, isProUser())) return;
     if (!panel.enabled && !isProUser()) {
       const enabledCount = Object.entries(this.draftPanelSettings).filter(([k, p]) => p.enabled && !k.startsWith('cw-')).length;
       if (enabledCount >= FREE_MAX_PANELS) {

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -1088,7 +1088,9 @@ const ENERGY_MOBILE_MAP_LAYERS: MapLayers = {
 // UNIFIED PANEL REGISTRY
 // ============================================
 
-const VARIANT_PANEL_CONFIGS: Record<string, Record<string, PanelConfig>> = {
+type PanelVariant = 'full' | 'tech' | 'finance' | 'commodity' | 'energy' | 'happy';
+
+const VARIANT_PANEL_CONFIGS: Record<PanelVariant, Record<string, PanelConfig>> = {
   full: FULL_PANELS,
   tech: TECH_PANELS,
   finance: FINANCE_PANELS,
@@ -1096,6 +1098,12 @@ const VARIANT_PANEL_CONFIGS: Record<string, Record<string, PanelConfig>> = {
   energy: ENERGY_PANELS,
   happy: HAPPY_PANELS,
 };
+
+function getVariantPanelConfigs(variant: string): Record<string, PanelConfig> | undefined {
+  return Object.prototype.hasOwnProperty.call(VARIANT_PANEL_CONFIGS, variant)
+    ? VARIANT_PANEL_CONFIGS[variant as PanelVariant]
+    : undefined;
+}
 
 /** All panels from all variants — canonical cross-variant registry. */
 export const ALL_PANELS: Record<string, PanelConfig> = {
@@ -1109,12 +1117,12 @@ export const ALL_PANELS: Record<string, PanelConfig> = {
 
 /** Per-variant canonical panel order (keys = which panels are enabled by default). */
 export const VARIANT_DEFAULTS: Record<string, string[]> = {
-  full:      Object.keys(FULL_PANELS),
-  tech:      Object.keys(TECH_PANELS),
-  finance:   Object.keys(FINANCE_PANELS),
-  commodity: Object.keys(COMMODITY_PANELS),
-  energy:    Object.keys(ENERGY_PANELS),
-  happy:     Object.keys(HAPPY_PANELS),
+  full:      Object.keys(VARIANT_PANEL_CONFIGS.full),
+  tech:      Object.keys(VARIANT_PANEL_CONFIGS.tech),
+  finance:   Object.keys(VARIANT_PANEL_CONFIGS.finance),
+  commodity: Object.keys(VARIANT_PANEL_CONFIGS.commodity),
+  energy:    Object.keys(VARIANT_PANEL_CONFIGS.energy),
+  happy:     Object.keys(VARIANT_PANEL_CONFIGS.happy),
 };
 
 /**
@@ -1152,7 +1160,7 @@ export const VARIANT_PANEL_OVERRIDES: Partial<Record<string, Partial<Record<stri
  * applying variant-specific display overrides (name, premium, etc.).
  */
 export function getEffectivePanelConfig(key: string, variant: string): PanelConfig {
-  const base = VARIANT_PANEL_CONFIGS[variant]?.[key] ?? ALL_PANELS[key];
+  const base = getVariantPanelConfigs(variant)?.[key] ?? ALL_PANELS[key];
   if (!base) return { name: key, enabled: false, priority: 2 };
   const override = VARIANT_PANEL_OVERRIDES[variant]?.[key] ?? {};
   return { ...base, ...override };

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -1088,7 +1088,16 @@ const ENERGY_MOBILE_MAP_LAYERS: MapLayers = {
 // UNIFIED PANEL REGISTRY
 // ============================================
 
-/** All panels from all variants — union with FULL taking precedence for duplicate keys. */
+const VARIANT_PANEL_CONFIGS: Record<string, Record<string, PanelConfig>> = {
+  full: FULL_PANELS,
+  tech: TECH_PANELS,
+  finance: FINANCE_PANELS,
+  commodity: COMMODITY_PANELS,
+  energy: ENERGY_PANELS,
+  happy: HAPPY_PANELS,
+};
+
+/** All panels from all variants — canonical cross-variant registry. */
 export const ALL_PANELS: Record<string, PanelConfig> = {
   ...HAPPY_PANELS,
   ...COMMODITY_PANELS,
@@ -1143,7 +1152,7 @@ export const VARIANT_PANEL_OVERRIDES: Partial<Record<string, Partial<Record<stri
  * applying variant-specific display overrides (name, premium, etc.).
  */
 export function getEffectivePanelConfig(key: string, variant: string): PanelConfig {
-  const base = ALL_PANELS[key];
+  const base = VARIANT_PANEL_CONFIGS[variant]?.[key] ?? ALL_PANELS[key];
   if (!base) return { name: key, enabled: false, priority: 2 };
   const override = VARIANT_PANEL_OVERRIDES[variant]?.[key] ?? {};
   return { ...base, ...override };

--- a/src/settings-window.ts
+++ b/src/settings-window.ts
@@ -55,6 +55,8 @@ export function initSettingsWindow(): void {
     const panelHtml = panelEntries
       .map(
         ([key, panel]) => {
+          // Preserve saved config for dynamic cw-* panels; unknown keys should
+          // not collapse to getEffectivePanelConfig's disabled synthetic fallback.
           const resolvedPanel = ALL_PANELS[key] ? getEffectivePanelConfig(key, SITE_VARIANT) : panel;
           return `
         <div class="panel-toggle-item ${panel.enabled ? 'active' : ''}" data-panel="${escapeHtml(key)}">
@@ -74,6 +76,8 @@ export function initSettingsWindow(): void {
           const panelKey = (item as HTMLElement).dataset.panel!;
           const config = panelSettings[panelKey];
           if (config) {
+            // Preserve saved config for dynamic cw-* panels; unknown keys should
+            // not collapse to getEffectivePanelConfig's disabled synthetic fallback.
             const resolvedConfig = ALL_PANELS[panelKey] ? getEffectivePanelConfig(panelKey, SITE_VARIANT) : config;
             if (!config.enabled && !isPanelEntitled(panelKey, resolvedConfig, isProUser())) return;
             if (!config.enabled && !isProUser()) {

--- a/src/settings-window.ts
+++ b/src/settings-window.ts
@@ -54,12 +54,15 @@ export function initSettingsWindow(): void {
     );
     const panelHtml = panelEntries
       .map(
-        ([key, panel]) => `
+        ([key, panel]) => {
+          const resolvedPanel = ALL_PANELS[key] ? getEffectivePanelConfig(key, SITE_VARIANT) : panel;
+          return `
         <div class="panel-toggle-item ${panel.enabled ? 'active' : ''}" data-panel="${escapeHtml(key)}">
           <div class="panel-toggle-checkbox">${panel.enabled ? '✓' : ''}</div>
-          <span class="panel-toggle-label">${escapeHtml(getLocalizedPanelName(key, panel.name))}</span>
+          <span class="panel-toggle-label">${escapeHtml(getLocalizedPanelName(key, resolvedPanel.name ?? panel.name))}</span>
         </div>
-      `
+      `;
+        }
       )
       .join('');
 

--- a/src/settings-window.ts
+++ b/src/settings-window.ts
@@ -71,7 +71,8 @@ export function initSettingsWindow(): void {
           const panelKey = (item as HTMLElement).dataset.panel!;
           const config = panelSettings[panelKey];
           if (config) {
-            if (!config.enabled && !isPanelEntitled(panelKey, ALL_PANELS[panelKey] ?? config, isProUser())) return;
+            const resolvedConfig = ALL_PANELS[panelKey] ? getEffectivePanelConfig(panelKey, SITE_VARIANT) : config;
+            if (!config.enabled && !isPanelEntitled(panelKey, resolvedConfig, isProUser())) return;
             if (!config.enabled && !isProUser()) {
               const enabledCount = Object.entries(panelSettings).filter(([k, p]) => p.enabled && !k.startsWith('cw-')).length;
               if (enabledCount >= FREE_MAX_PANELS) return;

--- a/tests/panel-variant-config.test.mts
+++ b/tests/panel-variant-config.test.mts
@@ -33,6 +33,21 @@ describe('variant panel config resolution', () => {
     );
   });
 
+  it('does not inherit full desktop premium metadata for variant-specific supply-chain panels', () => {
+    const panels = src('src/config/panels.ts');
+    const definitionFor = (variant: string): string => {
+      const match = panels.match(new RegExp(`const ${variant}_PANELS[\\s\\S]*?'supply-chain': \\{([^}]*)\\}`));
+      assert.ok(match, `${variant}_PANELS must define supply-chain`);
+      return match[1] ?? '';
+    };
+
+    assert.match(definitionFor('FULL'), /premium:\s*'enhanced'/);
+    assert.doesNotMatch(definitionFor('COMMODITY'), /premium:/);
+    assert.doesNotMatch(definitionFor('ENERGY'), /premium:/);
+    assert.equal(getEffectivePanelConfig('supply-chain', 'commodity').premium, undefined);
+    assert.equal(getEffectivePanelConfig('supply-chain', 'energy').premium, undefined);
+  });
+
   it('still falls back to the cross-variant registry for panels outside a variant default set', () => {
     const forecast = getEffectivePanelConfig('forecast', 'happy');
 

--- a/tests/panel-variant-config.test.mts
+++ b/tests/panel-variant-config.test.mts
@@ -1,0 +1,64 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { getEffectivePanelConfig } from '../src/config/panels.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+function src(relPath: string): string {
+  return readFileSync(resolve(root, relPath), 'utf-8');
+}
+
+describe('variant panel config resolution', () => {
+  it('prefers the happy variant config over a duplicate full panel key', () => {
+    const giving = getEffectivePanelConfig('giving', 'happy');
+
+    assert.equal(giving.name, 'Global Giving');
+    assert.equal(giving.enabled, true);
+    assert.equal(giving.priority, 1);
+  });
+
+  it('preserves commodity and energy labels for shared supply-chain panels', () => {
+    assert.equal(
+      getEffectivePanelConfig('supply-chain', 'commodity').name,
+      'Supply Chain & Logistics',
+    );
+    assert.equal(
+      getEffectivePanelConfig('supply-chain', 'energy').name,
+      'Chokepoints & Routes',
+    );
+  });
+
+  it('still falls back to the cross-variant registry for panels outside a variant default set', () => {
+    const forecast = getEffectivePanelConfig('forecast', 'happy');
+
+    assert.equal(forecast.name, 'AI Forecasts');
+    assert.equal(forecast.enabled, true);
+  });
+
+  it('does not use the canonical registry directly for entitlement or pro badge metadata', () => {
+    const files = [
+      'src/components/UnifiedSettings.ts',
+      'src/app/search-manager.ts',
+      'src/settings-window.ts',
+    ];
+
+    for (const file of files) {
+      const text = src(file);
+      assert.doesNotMatch(
+        text,
+        /isPanelEntitled\([^\n]*ALL_PANELS\[/,
+        `${file} must resolve variant-specific panel config before entitlement checks`,
+      );
+      assert.doesNotMatch(
+        text,
+        /\(ALL_PANELS\[[^\]]+\]\s*\?\?[^)]*\)\.premium/,
+        `${file} must resolve variant-specific panel config before PRO badge checks`,
+      );
+    }
+  });
+});

--- a/tests/panel-variant-config.test.mts
+++ b/tests/panel-variant-config.test.mts
@@ -40,6 +40,14 @@ describe('variant panel config resolution', () => {
     assert.equal(forecast.enabled, true);
   });
 
+  it('applies variant overrides on top of the variant-specific base config', () => {
+    const financeMap = getEffectivePanelConfig('map', 'finance');
+
+    assert.equal(financeMap.name, 'Global Markets Map');
+    assert.equal(financeMap.enabled, true);
+    assert.equal(financeMap.priority, 1);
+  });
+
   it('does not use the canonical registry directly for entitlement or pro badge metadata', () => {
     const files = [
       'src/components/UnifiedSettings.ts',
@@ -60,5 +68,20 @@ describe('variant panel config resolution', () => {
         `${file} must resolve variant-specific panel config before PRO badge checks`,
       );
     }
+  });
+
+  it('standalone settings render uses resolved variant names instead of saved panel names', () => {
+    const text = src('src/settings-window.ts');
+
+    assert.match(
+      text,
+      /const resolvedPanel = ALL_PANELS\[key\] \? getEffectivePanelConfig\(key, SITE_VARIANT\) : panel;/,
+      'settings-window render must resolve variant-specific panel config per entry',
+    );
+    assert.match(
+      text,
+      /getLocalizedPanelName\(key, resolvedPanel\.name \?\? panel\.name\)/,
+      'settings-window render must prefer the resolved variant name before saved panel.name',
+    );
   });
 });


### PR DESCRIPTION
## Summary

Fixes #3525.

- Resolve panel config through the active variant before falling back to the canonical all-panel registry.
- Keep `ALL_PANELS` as the cross-variant key registry, but stop using its duplicate-key metadata for variant-aware entitlement/search/settings decisions.
- Add focused regression coverage for happy `giving`, commodity/energy `supply-chain`, cross-variant fallback, and direct-registry entitlement/PRO-badge bypasses.

## Root Cause

`ALL_PANELS` spreads `FULL_PANELS` last, so duplicate panel keys inherited full-variant fields before variant-specific configs could apply. That disabled happy `giving` and could leak full-variant label/premium metadata into commodity and energy panels.

## Validation

- `npx tsx --test tests/panel-variant-config.test.mts tests/panel-config-guardrails.test.mjs`
- `npm run typecheck`
- `git diff --check`
- Pre-push hook passed, including source/API typechecks, Convex typecheck, CJS syntax, Unicode safety, boundary check, rate-limit policy check, premium-fetch parity, edge bundle check, full unit suite, edge function tests, markdown lint, MDX lint, proto freshness check, pro-test bundle freshness check, and version sync check.

## Notes

Existing saved localStorage panel settings from older broken builds may retain stale per-user values until reseeded/reset; this PR fixes config resolution and new/default merge behavior.