### PR TITLE
fix(test): widen gateway-internal-mcp HMAC timestamp offsets to 60s (closes #3848)

### DIFF
--- a/tests/gateway-internal-mcp.test.mjs
+++ b/tests/gateway-internal-mcp.test.mjs
@@ -366,17 +366,17 @@ describe('gateway internal-MCP HMAC verify — error paths', () => {
     assert.equal(res.status, 401, 'mutated body must 401');
   });
 
-  it('timestamp 31s in the past → 401', async () => {
+  it('timestamp 60s in the past → 401', async () => {
     const handler = makeGateway();
-    const past = Math.floor(Date.now() / 1000) - 31;
+    const past = Math.floor(Date.now() / 1000) - 60;
     const req = await buildSignedRequest({ now: past });
     const res = await handler(req);
     assert.equal(res.status, 401);
   });
 
-  it('timestamp 31s in the future → 401', async () => {
+  it('timestamp 60s in the future → 401', async () => {
     const handler = makeGateway();
-    const future = Math.floor(Date.now() / 1000) + 31;
+    const future = Math.floor(Date.now() / 1000) + 60;
     const req = await buildSignedRequest({ now: future });
     const res = await handler(req);
     assert.equal(res.status, 401);


### PR DESCRIPTION
## Problem

`tests/gateway-internal-mcp.test.mjs` — `timestamp 31s in the future → 401` flakes intermittently in CI (`200 !== 401`), e.g. PR #3847's unit job (passed on re-run).

## Root cause

The validator (`server/_shared/mcp-internal-hmac.ts:393`) rejects only when `Math.abs(nowSec - ts) > 30` — so an offset of **exactly 30s is accepted** (inclusive boundary). The test signs `ts = floor(Date.now()/1000) + 31` and asserts rejection. On a busy runner, a single wall-clock second can elapse between the test's `Date.now()` and the validator's, so the validator perceives the offset as exactly `30` → accepts → `200` instead of `401`.

The symmetric `-31s` past test can't flake — rounding slip only pushes its offset further outside the window.

## Fix

Widen both boundary offsets to **60s** (30s clear of the window edge) so no realistic scheduling jitter can reach the inclusive-accept boundary. The `-31 → -60` change is risk-free and kept for symmetry. Test names updated to match. Validator left untouched (the 30s tolerance is intentional).

## Verification

- `tsx --test tests/gateway-internal-mcp.test.mjs` → 30/30 pass
- `npm run typecheck` → clean

Closes #3848
