### PR TITLE
Retag standalone resilience seed source failures

### DIFF
--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -4,7 +4,11 @@ import { normalizeCountryToken } from '../../../_shared/country-token';
 import { getCachedJson } from '../../../_shared/redis';
 import { classifyDimensionFreshness, readFreshnessMap, resolveSeedMetaKey } from './_dimension-freshness';
 import { getLanguageCoverageFactor } from './_language-coverage';
-import { failedDimensionsFromDatasets, readFailedDatasets } from './_source-failure';
+import {
+  failedDimensionsFromDatasets,
+  readFailedDatasets,
+  readStandaloneSourceFailureDimensions,
+} from './_source-failure';
 
 export type ResilienceDimensionId =
   | 'macroFiscal'
@@ -2614,7 +2618,7 @@ export async function scoreAllDimensions(
   reader: ResilienceSeedReader = defaultSeedReader,
 ): Promise<Record<ResilienceDimensionId, ResilienceDimensionScore>> {
   const memoizedReader = createMemoizedSeedReader(reader);
-  const [entries, freshnessMap, failedDatasets] = await Promise.all([
+  const [entries, freshnessMap, failedDatasets, standaloneFailures] = await Promise.all([
     Promise.all(
       RESILIENCE_DIMENSION_ORDER.map(async (dimensionId) => {
         try {
@@ -2659,6 +2663,7 @@ export async function scoreAllDimensions(
     // with the scorer keys in practice, the shared reader is cheap).
     readFreshnessMap(memoizedReader),
     readFailedDatasets(memoizedReader),
+    readStandaloneSourceFailureDimensions(memoizedReader),
   ]);
   const scores = Object.fromEntries(entries) as Record<ResilienceDimensionId, ResilienceDimensionScore>;
 
@@ -2673,32 +2678,38 @@ export async function scoreAllDimensions(
     };
   }
 
-  // T1.7 source-failure wiring. When the resilience-static seed reports
-  // failed adapter fetches in its meta, any dimension that consumes that
-  // adapter AND is already imputed (observedWeight === 0, imputationClass
-  // non-null) gets re-tagged from the table default (stable-absence /
-  // unmonitored) to source-failure. Real-data dimensions are untouched:
-  // a seed adapter failing does not invalidate a country that was served
-  // from the prior-snapshot recovery path.
-  if (failedDatasets.length > 0) {
-    const affected = failedDimensionsFromDatasets(failedDatasets);
-    if (affected.size > 0) {
-      // Single info log per request so ops can see which adapters went
-      // down without having to dump Redis. The country code is included
-      // because scoreAllDimensions runs per-country; a flood of these
-      // during a failed-seed window is the expected signal.
-      console.info(
-        `[Resilience] source-failure decoration country=${countryCode} failedDatasets=${failedDatasets.join(',')} affectedDimensions=${[...affected].join(',')}`,
-      );
-      for (const dimId of affected) {
-        const current = scores[dimId];
-        // Only re-tag imputed dimensions. Dimensions with any observed
-        // weight keep their existing null class (which is the correct
-        // semantics: the seed failing did not prevent us from producing
-        // a real-data score for this country).
-        if (current != null && current.imputationClass != null) {
-          scores[dimId] = { ...current, imputationClass: 'source-failure' };
-        }
+  // T1.7 source-failure wiring. Static adapter failures come from
+  // seed-meta:resilience:static.failedDatasets; standalone seeders come
+  // from their own seed-meta status/freshness via the registry meta-key
+  // resolver. Any affected dimension that is already fully imputed gets
+  // re-tagged from the table default (stable-absence / unmonitored) to
+  // source-failure. Real-data and not-applicable dimensions are untouched:
+  // a seed failing does not invalidate a country that was served from prior
+  // snapshot data or a structural non-applicability path.
+  const affected = failedDimensionsFromDatasets(failedDatasets);
+  for (const dimId of standaloneFailures.dimensions) {
+    affected.add(dimId);
+  }
+  if (affected.size > 0) {
+    // Single info log per request so ops can see which sources went down
+    // without having to dump Redis. The country code is included because
+    // scoreAllDimensions runs per-country; a flood of these during a failed
+    // seed window is the expected signal.
+    console.info(
+      `[Resilience] source-failure decoration country=${countryCode} failedDatasets=${failedDatasets.join(',')} failedMetaKeys=${standaloneFailures.failedMetaKeys.join(',')} affectedDimensions=${[...affected].join(',')}`,
+    );
+    for (const dimId of affected) {
+      const current = scores[dimId];
+      // Only re-tag fully imputed dimensions. Dimensions with any observed
+      // weight keep their existing null class, and structural
+      // not-applicable paths keep imputedWeight=0.
+      if (
+        current != null
+        && current.imputationClass != null
+        && current.observedWeight === 0
+        && current.imputedWeight > 0
+      ) {
+        scores[dimId] = { ...current, imputationClass: 'source-failure' };
       }
     }
   }

--- a/server/worldmonitor/resilience/v1/_indicator-registry.ts
+++ b/server/worldmonitor/resilience/v1/_indicator-registry.ts
@@ -1,4 +1,4 @@
-import type { ResilienceDimensionId } from './_dimension-scorers.ts';
+import type { ResilienceDimensionId } from './_dimension-scorers';
 
 // Phase 2 T2.2a signal tiering. See docs/internal/country-resilience-upgrade-plan.md
 // section "Signal tiering (Core / Enrichment / Experimental)".

--- a/server/worldmonitor/resilience/v1/_source-failure.ts
+++ b/server/worldmonitor/resilience/v1/_source-failure.ts
@@ -8,8 +8,8 @@
 // dimension scorers stay oblivious.
 
 import type { ResilienceDimensionId, ResilienceSeedReader } from './_dimension-scorers';
-import { resolveSeedMetaKey } from './_dimension-freshness.ts';
-import { INDICATOR_REGISTRY } from './_indicator-registry.ts';
+import { resolveSeedMetaKey } from './_dimension-freshness';
+import { INDICATOR_REGISTRY } from './_indicator-registry';
 
 // Must match RESILIENCE_STATIC_META_KEY in scripts/seed-resilience-static.mjs.
 export const RESILIENCE_STATIC_META_KEY = 'seed-meta:resilience:static';

--- a/server/worldmonitor/resilience/v1/_source-failure.ts
+++ b/server/worldmonitor/resilience/v1/_source-failure.ts
@@ -9,7 +9,7 @@
 
 import type { ResilienceDimensionId, ResilienceSeedReader } from './_dimension-scorers';
 import { resolveSeedMetaKey } from './_dimension-freshness';
-import { INDICATOR_REGISTRY } from './_indicator-registry';
+import { INDICATOR_REGISTRY, type IndicatorSpec } from './_indicator-registry';
 
 // Must match RESILIENCE_STATIC_META_KEY in scripts/seed-resilience-static.mjs.
 export const RESILIENCE_STATIC_META_KEY = 'seed-meta:resilience:static';
@@ -99,10 +99,20 @@ export interface StandaloneSourceFailureResult {
 
 const MINUTE_MS = 60 * 1000;
 
-// Resolved `seed-meta:*` thresholds for standalone CRI inputs, mirrored from
-// api/health.js SEED_META. This intentionally uses seeder health cadence, not
-// INDICATOR_REGISTRY source-data cadence: an annual source can still have a
-// monthly/daily seeder whose missed runs should surface as source-failure.
+const IGNORED_STANDALONE_SOURCE_META_KEYS = new Set([
+  // Retired: scoreFuelStockDays always returns coverage=0 +
+  // imputationClass=null. The seeder still writes historical data for a
+  // possible future replacement dimension, but it should not pollute
+  // source-failure logs while the dimension is intentionally inactive.
+  'seed-meta:resilience:recovery:fuel-stocks',
+]);
+
+// Resolved `seed-meta:*` thresholds for standalone CRI inputs. Most values
+// mirror api/health.js SEED_META; a few direct scorer inputs are not health
+// probes yet and are explicitly locked in tests. This intentionally uses
+// seeder health cadence, not INDICATOR_REGISTRY source-data cadence: an annual
+// source can still have a monthly/daily seeder whose missed runs should
+// surface as source-failure.
 export const STANDALONE_SOURCE_META_MAX_STALE_MIN: Readonly<Record<string, number>> = {
   'seed-meta:economic:imf-macro': 100800,
   'seed-meta:economic:national-debt': 86400,
@@ -147,10 +157,11 @@ export async function readStandaloneSourceFailureDimensions(
   reader: ResilienceSeedReader,
   nowMs?: number,
 ): Promise<StandaloneSourceFailureResult> {
-  const metaKeyToIndicators = new Map<string, typeof INDICATOR_REGISTRY>();
+  const metaKeyToIndicators = new Map<string, IndicatorSpec[]>();
   for (const indicator of INDICATOR_REGISTRY) {
     const metaKey = resolveSeedMetaKey(indicator.sourceKey);
     if (metaKey === RESILIENCE_STATIC_META_KEY) continue;
+    if (IGNORED_STANDALONE_SOURCE_META_KEYS.has(metaKey)) continue;
     const existing = metaKeyToIndicators.get(metaKey);
     if (existing) {
       existing.push(indicator);
@@ -169,7 +180,7 @@ export async function readStandaloneSourceFailureDimensions(
         if (!meta || typeof meta !== 'object') return;
 
         const status = (meta as { status?: unknown }).status;
-        const nonOk = typeof status === 'string' && status !== 'ok';
+        const nonOk = Boolean(status) && status !== 'ok';
         const fetchedAt = Number((meta as { fetchedAt?: unknown }).fetchedAt);
         const hasFetchedAt = Number.isFinite(fetchedAt) && fetchedAt > 0;
         const maxStaleMin = STANDALONE_SOURCE_META_MAX_STALE_MIN[metaKey];

--- a/server/worldmonitor/resilience/v1/_source-failure.ts
+++ b/server/worldmonitor/resilience/v1/_source-failure.ts
@@ -8,6 +8,8 @@
 // dimension scorers stay oblivious.
 
 import type { ResilienceDimensionId, ResilienceSeedReader } from './_dimension-scorers';
+import { resolveSeedMetaKey } from './_dimension-freshness.ts';
+import { INDICATOR_REGISTRY } from './_indicator-registry.ts';
 
 // Must match RESILIENCE_STATIC_META_KEY in scripts/seed-resilience-static.mjs.
 export const RESILIENCE_STATIC_META_KEY = 'seed-meta:resilience:static';
@@ -88,4 +90,106 @@ export function failedDimensionsFromDatasets(
     for (const dim of dims) out.add(dim);
   }
   return out;
+}
+
+export interface StandaloneSourceFailureResult {
+  dimensions: Set<ResilienceDimensionId>;
+  failedMetaKeys: string[];
+}
+
+const MINUTE_MS = 60 * 1000;
+
+// Resolved `seed-meta:*` thresholds for standalone CRI inputs, mirrored from
+// api/health.js SEED_META. This intentionally uses seeder health cadence, not
+// INDICATOR_REGISTRY source-data cadence: an annual source can still have a
+// monthly/daily seeder whose missed runs should surface as source-failure.
+export const STANDALONE_SOURCE_META_MAX_STALE_MIN: Readonly<Record<string, number>> = {
+  'seed-meta:economic:imf-macro': 100800,
+  'seed-meta:economic:national-debt': 86400,
+  'seed-meta:economic:imf-labor': 100800,
+  'seed-meta:economic:bis': 10080,
+  'seed-meta:economic:bis-dsr': 2160,
+  'seed-meta:trade:restrictions:v1:tariff-overview:50': 480,
+  'seed-meta:trade:barriers:v1:tariff-gap:50': 480,
+  'seed-meta:economic:wb-external-debt': 100800,
+  'seed-meta:economic:bis-lbs': 14400,
+  'seed-meta:economic:fatf-listing': 60480,
+  'seed-meta:cyber:threats': 240,
+  'seed-meta:infra:outages': 30,
+  'seed-meta:intelligence:gpsjam': 1440,
+  'seed-meta:supply_chain:shipping_stress': 45,
+  'seed-meta:supply_chain:transit-summaries': 30,
+  'seed-meta:economic:owid-energy-mix': 50400,
+  'seed-meta:energy:gas-storage-countries': 2880,
+  'seed-meta:economic:energy-prices': 150,
+  'seed-meta:resilience:fossil-electricity-share': 11520,
+  'seed-meta:resilience:low-carbon-generation': 11520,
+  'seed-meta:resilience:power-losses': 11520,
+  'seed-meta:displacement:summary': 720,
+  'seed-meta:unrest:events': 120,
+  'seed-meta:conflict:ucdp-events': 420,
+  'seed-meta:intelligence:social-reddit': 180,
+  'seed-meta:news:threat-summary': 60,
+  'seed-meta:resilience:recovery:fiscal-space': 129600,
+  'seed-meta:resilience:recovery:reserve-adequacy': 86400,
+  'seed-meta:resilience:recovery:sovereign-wealth': 86400,
+  'seed-meta:resilience:recovery:external-debt': 86400,
+  'seed-meta:resilience:recovery:import-hhi': 50400,
+};
+
+/**
+ * Read standalone seed-meta records referenced by INDICATOR_REGISTRY and map
+ * non-ok or stale source meta to affected dimensions. The resilience-static
+ * aggregate is intentionally excluded here because static adapters carry
+ * per-dataset failures via readFailedDatasets().
+ */
+export async function readStandaloneSourceFailureDimensions(
+  reader: ResilienceSeedReader,
+  nowMs?: number,
+): Promise<StandaloneSourceFailureResult> {
+  const metaKeyToIndicators = new Map<string, typeof INDICATOR_REGISTRY>();
+  for (const indicator of INDICATOR_REGISTRY) {
+    const metaKey = resolveSeedMetaKey(indicator.sourceKey);
+    if (metaKey === RESILIENCE_STATIC_META_KEY) continue;
+    const existing = metaKeyToIndicators.get(metaKey);
+    if (existing) {
+      existing.push(indicator);
+    } else {
+      metaKeyToIndicators.set(metaKey, [indicator]);
+    }
+  }
+
+  const dimensions = new Set<ResilienceDimensionId>();
+  const failedMetaKeys: string[] = [];
+
+  await Promise.all(
+    [...metaKeyToIndicators.entries()].map(async ([metaKey, indicators]) => {
+      try {
+        const meta = await reader(metaKey);
+        if (!meta || typeof meta !== 'object') return;
+
+        const status = (meta as { status?: unknown }).status;
+        const nonOk = typeof status === 'string' && status !== 'ok';
+        const fetchedAt = Number((meta as { fetchedAt?: unknown }).fetchedAt);
+        const hasFetchedAt = Number.isFinite(fetchedAt) && fetchedAt > 0;
+        const maxStaleMin = STANDALONE_SOURCE_META_MAX_STALE_MIN[metaKey];
+        const stale = hasFetchedAt
+          && typeof maxStaleMin === 'number'
+          && ((nowMs ?? Date.now()) - fetchedAt) > maxStaleMin * MINUTE_MS;
+
+        if (!nonOk && !stale) return;
+
+        failedMetaKeys.push(metaKey);
+        for (const indicator of indicators) {
+          dimensions.add(indicator.dimension);
+        }
+      } catch {
+        // Match readFreshnessMap/readFailedDatasets: Redis/meta read failures
+        // should not fail the country score request.
+      }
+    }),
+  );
+
+  failedMetaKeys.sort();
+  return { dimensions, failedMetaKeys };
 }

--- a/tests/resilience-dimension-scorers.test.mts
+++ b/tests/resilience-dimension-scorers.test.mts
@@ -1375,6 +1375,25 @@ describe('resilience source-failure aggregation (T1.7)', () => {
       `tradePolicy must flip to source-failure when appliedTariffRate is in failedDatasets, got ${dims.tradePolicy.imputationClass}`);
   });
 
+  it('re-tags already-imputed dimensions to source-failure via standalone seed-meta staleness', async () => {
+    const nowMs = Date.now();
+    const thirtySixDaysMs = 36 * 24 * 60 * 60 * 1000;
+    const reader = async (key: string): Promise<unknown | null> => {
+      if (key === 'resilience:recovery:import-hhi:v1') return null;
+      if (key === 'seed-meta:resilience:recovery:import-hhi') {
+        return { status: 'ok', fetchedAt: nowMs - thirtySixDaysMs, recordCount: 190 };
+      }
+      return null;
+    };
+
+    const dims = await scoreAllDimensions('BF', reader);
+
+    assert.equal(dims.importConcentration.observedWeight, 0, 'no observed import-HHI data for BF');
+    assert.ok(dims.importConcentration.imputedWeight > 0, 'import-HHI impute carries weight');
+    assert.equal(dims.importConcentration.imputationClass, 'source-failure',
+      `importConcentration must flip to source-failure when its standalone seed-meta is stale, got ${dims.importConcentration.imputationClass}`);
+  });
+
   it('does not re-tag real-data dimensions even when their adapter is in failedDatasets', async () => {
     // US with full fixture data; claim all adapters failed. Every
     // dimension with observedWeight > 0 must keep imputationClass=null

--- a/tests/resilience-source-failure.test.mts
+++ b/tests/resilience-source-failure.test.mts
@@ -262,6 +262,20 @@ describe('resilience source-failure module', () => {
       assert.deepEqual(result.failedMetaKeys, ['seed-meta:resilience:recovery:external-debt']);
     });
 
+    it('treats truthy non-string seed-meta status values as non-ok', async () => {
+      const reader = async (key: string): Promise<unknown | null> => {
+        if (key === 'seed-meta:resilience:recovery:external-debt') {
+          return { status: 1, fetchedAt: 1_700_000_000_000, recordCount: 0 };
+        }
+        return null;
+      };
+
+      const result = await readStandaloneSourceFailureDimensions(reader, 1_700_000_000_000);
+
+      assert.equal(result.dimensions.has('externalDebtCoverage'), true);
+      assert.deepEqual(result.failedMetaKeys, ['seed-meta:resilience:recovery:external-debt']);
+    });
+
     it('does not duplicate the static failedDatasets path', async () => {
       const reader = async (key: string): Promise<unknown | null> => {
         if (key === RESILIENCE_STATIC_META_KEY) {
@@ -272,6 +286,21 @@ describe('resilience source-failure module', () => {
 
       const result = await readStandaloneSourceFailureDimensions(reader, 1_700_000_000_000);
 
+      assert.equal(result.dimensions.size, 0);
+      assert.deepEqual(result.failedMetaKeys, []);
+    });
+
+    it('ignores retired standalone fuel-stock meta even when status is non-ok', async () => {
+      const reader = async (key: string): Promise<unknown | null> => {
+        if (key === 'seed-meta:resilience:recovery:fuel-stocks') {
+          return { status: 'error', fetchedAt: 1, recordCount: 0 };
+        }
+        return null;
+      };
+
+      const result = await readStandaloneSourceFailureDimensions(reader, 1_700_000_000_000);
+
+      assert.equal(result.dimensions.has('fuelStockDays'), false);
       assert.equal(result.dimensions.size, 0);
       assert.deepEqual(result.failedMetaKeys, []);
     });

--- a/tests/resilience-source-failure.test.mts
+++ b/tests/resilience-source-failure.test.mts
@@ -4,10 +4,14 @@ import { describe, it } from 'node:test';
 import {
   DATASET_TO_DIMENSIONS,
   RESILIENCE_STATIC_META_KEY,
+  STANDALONE_SOURCE_META_MAX_STALE_MIN,
   failedDimensionsFromDatasets,
+  readStandaloneSourceFailureDimensions,
   readFailedDatasets,
 } from '../server/worldmonitor/resilience/v1/_source-failure.ts';
-import type { ResilienceDimensionId } from '../server/worldmonitor/resilience/v1/_dimension-scorers.ts';
+import { RESILIENCE_DIMENSION_ORDER } from '../server/worldmonitor/resilience/v1/_dimension-scorers.ts';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 // Adapter keys enumerated in scripts/seed-resilience-static.mjs
 // `fetchAllDatasetMaps()`. Every adapter that can end up in the
@@ -111,6 +115,70 @@ describe('resilience source-failure module', () => {
     });
   });
 
+  describe('readStandaloneSourceFailureDimensions', () => {
+    it('maps stale standalone recovery seed-meta to affected dimensions', async () => {
+      const nowMs = 1_700_000_000_000;
+      const reader = async (key: string): Promise<unknown | null> => {
+        if (key === 'seed-meta:resilience:recovery:import-hhi') {
+          return { status: 'ok', fetchedAt: nowMs - 36 * DAY_MS, recordCount: 190 };
+        }
+        return null;
+      };
+
+      const result = await readStandaloneSourceFailureDimensions(reader, nowMs);
+
+      assert.equal(result.dimensions.has('importConcentration'), true);
+      assert.deepEqual(result.failedMetaKeys, ['seed-meta:resilience:recovery:import-hhi']);
+    });
+
+    it('uses seeder freshness thresholds rather than annual source-data cadence', async () => {
+      const nowMs = 1_700_000_000_000;
+      const reader = async (key: string): Promise<unknown | null> => {
+        if (key === 'seed-meta:resilience:recovery:import-hhi') {
+          return { status: 'ok', fetchedAt: nowMs - 34 * DAY_MS, recordCount: 190 };
+        }
+        return null;
+      };
+
+      const result = await readStandaloneSourceFailureDimensions(reader, nowMs);
+
+      assert.equal(
+        STANDALONE_SOURCE_META_MAX_STALE_MIN['seed-meta:resilience:recovery:import-hhi'],
+        50400,
+      );
+      assert.equal(result.dimensions.has('importConcentration'), false);
+      assert.deepEqual(result.failedMetaKeys, []);
+    });
+
+    it('maps non-ok standalone seed-meta to affected dimensions even with a recent fetchedAt', async () => {
+      const reader = async (key: string): Promise<unknown | null> => {
+        if (key === 'seed-meta:resilience:recovery:external-debt') {
+          return { status: 'error', fetchedAt: 1_700_000_000_000, recordCount: 0 };
+        }
+        return null;
+      };
+
+      const result = await readStandaloneSourceFailureDimensions(reader, 1_700_000_000_000);
+
+      assert.equal(result.dimensions.has('externalDebtCoverage'), true);
+      assert.deepEqual(result.failedMetaKeys, ['seed-meta:resilience:recovery:external-debt']);
+    });
+
+    it('does not duplicate the static failedDatasets path', async () => {
+      const reader = async (key: string): Promise<unknown | null> => {
+        if (key === RESILIENCE_STATIC_META_KEY) {
+          return { status: 'error', fetchedAt: 1, failedDatasets: ['wgi'] };
+        }
+        return null;
+      };
+
+      const result = await readStandaloneSourceFailureDimensions(reader, 1_700_000_000_000);
+
+      assert.equal(result.dimensions.size, 0);
+      assert.deepEqual(result.failedMetaKeys, []);
+    });
+  });
+
   describe('DATASET_TO_DIMENSIONS coverage', () => {
     it('maps every adapter key declared by the static seed', () => {
       for (const adapter of SEED_ADAPTER_KEYS) {
@@ -126,27 +194,7 @@ describe('resilience source-failure module', () => {
     });
 
     it('only references valid ResilienceDimensionIds', () => {
-      const validIds: ReadonlySet<ResilienceDimensionId> = new Set([
-        'macroFiscal',
-        'currencyExternal',
-        'tradePolicy',
-        'cyberDigital',
-        'logisticsSupply',
-        'infrastructure',
-        'energy',
-        'governanceInstitutional',
-        'socialCohesion',
-        'borderSecurity',
-        'informationCognitive',
-        'healthPublicService',
-        'foodWater',
-        'fiscalSpace',
-        'reserveAdequacy',
-        'externalDebtCoverage',
-        'importConcentration',
-        'stateContinuity',
-        'fuelStockDays',
-      ]);
+      const validIds: ReadonlySet<string> = new Set(RESILIENCE_DIMENSION_ORDER);
       for (const [adapter, dims] of Object.entries(DATASET_TO_DIMENSIONS)) {
         for (const dim of dims) {
           assert.ok(

--- a/tests/resilience-source-failure.test.mts
+++ b/tests/resilience-source-failure.test.mts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
+import { parse } from 'acorn';
 
 import {
   DATASET_TO_DIMENSIONS,
@@ -10,6 +12,8 @@ import {
   readFailedDatasets,
 } from '../server/worldmonitor/resilience/v1/_source-failure.ts';
 import { RESILIENCE_DIMENSION_ORDER } from '../server/worldmonitor/resilience/v1/_dimension-scorers.ts';
+import { resolveSeedMetaKey } from '../server/worldmonitor/resilience/v1/_dimension-freshness.ts';
+import { INDICATOR_REGISTRY } from '../server/worldmonitor/resilience/v1/_indicator-registry.ts';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
@@ -32,6 +36,100 @@ const SEED_ADAPTER_KEYS = [
   'fxReservesMonths',
   'appliedTariffRate',
 ] as const;
+
+const INTENTIONALLY_UNTRACKED_STANDALONE_META_KEYS = new Set([
+  // scoreFuelStockDays is retired and always returns coverage=0 +
+  // imputationClass=null. api/health.js intentionally removed this probe
+  // because it reported "cron ran" for data that the score no longer reads.
+  'seed-meta:resilience:recovery:fuel-stocks',
+]);
+
+const TRACKED_STANDALONE_META_KEYS_NOT_IN_HEALTH = new Set([
+  // api/seed-health.js tracks this seed with intervalMin=360; /api/health
+  // does not include a direct SEED_META entry because its data key is
+  // parameterized by year.
+  'seed-meta:displacement:summary',
+  // api/health.js tracks seed-meta:economic:macro-signals and documents
+  // energy-prices as the primary key with the same 150min threshold, but
+  // it does not classify the energy-prices data key directly.
+  'seed-meta:economic:energy-prices',
+  // scripts/seed-supply-chain-trade.mjs writes these via
+  // writeExtraKeyWithMeta. They feed scoreTradePolicy directly but are not
+  // standalone /api/health probes today.
+  'seed-meta:trade:restrictions:v1:tariff-overview:50',
+  'seed-meta:trade:barriers:v1:tariff-gap:50',
+]);
+
+function literalKey(node: any): string | null {
+  if (node.type === 'Identifier') return node.name;
+  if (node.type === 'Literal' && typeof node.value === 'string') return node.value;
+  return null;
+}
+
+function evaluateNumericExpression(node: any): number | null {
+  if (node.type === 'Literal' && typeof node.value === 'number') return node.value;
+  if (node.type === 'BinaryExpression') {
+    const left = evaluateNumericExpression(node.left);
+    const right = evaluateNumericExpression(node.right);
+    if (left == null || right == null) return null;
+    switch (node.operator) {
+      case '*': return left * right;
+      case '/': return left / right;
+      case '+': return left + right;
+      case '-': return left - right;
+      default: return null;
+    }
+  }
+  return null;
+}
+
+function readHealthSeedMetaThresholds(): Map<string, number> {
+  const source = readFileSync(new URL('../api/health.js', import.meta.url), 'utf8');
+  const ast = parse(source, { ecmaVersion: 'latest', sourceType: 'module' }) as any;
+  const declaration = ast.body
+    .filter((node: any) => node.type === 'VariableDeclaration')
+    .flatMap((node: any) => node.declarations)
+    .find((node: any) => node.id?.type === 'Identifier' && node.id.name === 'SEED_META');
+
+  assert.ok(declaration, 'api/health.js must declare SEED_META');
+  assert.equal(declaration.init?.type, 'ObjectExpression', 'SEED_META must be an object literal');
+
+  const out = new Map<string, number>();
+  for (const entry of declaration.init.properties) {
+    assert.equal(entry.type, 'Property', 'SEED_META must not use spread properties');
+    assert.equal(entry.value?.type, 'ObjectExpression', 'each SEED_META entry must be an object literal');
+
+    let key: string | null = null;
+    let maxStaleMin: number | null = null;
+    for (const prop of entry.value.properties) {
+      assert.equal(prop.type, 'Property', 'SEED_META nested entries must not use spread properties');
+      const name = literalKey(prop.key);
+      if (name === 'key' && prop.value.type === 'Literal' && typeof prop.value.value === 'string') {
+        key = prop.value.value;
+      }
+      if (name === 'maxStaleMin') {
+        maxStaleMin = evaluateNumericExpression(prop.value);
+      }
+    }
+
+    assert.ok(key, `SEED_META.${literalKey(entry.key) ?? '<computed>'} must include key`);
+    assert.equal(typeof maxStaleMin, 'number', `SEED_META.${key} must include numeric maxStaleMin`);
+    const existing = out.get(key);
+    if (existing != null) {
+      assert.equal(existing, maxStaleMin, `duplicate SEED_META key ${key} must use one threshold`);
+    }
+    out.set(key, maxStaleMin);
+  }
+  return out;
+}
+
+function resolvedStandaloneRegistryMetaKeys(): string[] {
+  return [...new Set(
+    INDICATOR_REGISTRY
+      .map((indicator) => resolveSeedMetaKey(indicator.sourceKey))
+      .filter((key) => key !== RESILIENCE_STATIC_META_KEY),
+  )].sort();
+}
 
 describe('resilience source-failure module', () => {
   describe('readFailedDatasets', () => {
@@ -176,6 +274,54 @@ describe('resilience source-failure module', () => {
 
       assert.equal(result.dimensions.size, 0);
       assert.deepEqual(result.failedMetaKeys, []);
+    });
+
+    it('keeps health-owned standalone source-failure thresholds in sync with api/health.js SEED_META', () => {
+      const healthThresholds = readHealthSeedMetaThresholds();
+      for (const [key, maxStaleMin] of Object.entries(STANDALONE_SOURCE_META_MAX_STALE_MIN)) {
+        if (TRACKED_STANDALONE_META_KEYS_NOT_IN_HEALTH.has(key)) continue;
+        assert.equal(
+          healthThresholds.get(key),
+          maxStaleMin,
+          `${key} must match api/health.js SEED_META maxStaleMin`,
+        );
+      }
+    });
+
+    it('requires explicit documentation for source-failure thresholds not owned by api/health.js', () => {
+      const healthThresholds = readHealthSeedMetaThresholds();
+      const trackedKeys = Object.keys(STANDALONE_SOURCE_META_MAX_STALE_MIN);
+      const unownedKeys = trackedKeys.filter((key) => !healthThresholds.has(key)).sort();
+
+      assert.deepEqual(unownedKeys, [...TRACKED_STANDALONE_META_KEYS_NOT_IN_HEALTH].sort());
+    });
+
+    it('covers every standalone registry seed-meta key except explicit retired sources', () => {
+      const registryKeys = resolvedStandaloneRegistryMetaKeys();
+      const expectedTrackedKeys = registryKeys
+        .filter((key) => !INTENTIONALLY_UNTRACKED_STANDALONE_META_KEYS.has(key))
+        .sort();
+      const actualTrackedKeys = Object.keys(STANDALONE_SOURCE_META_MAX_STALE_MIN).sort();
+
+      assert.deepEqual(actualTrackedKeys, expectedTrackedKeys);
+    });
+
+    it('documents retired standalone sources omitted from source-failure health tracking', () => {
+      const registryKeys = new Set(resolvedStandaloneRegistryMetaKeys());
+      const healthThresholds = readHealthSeedMetaThresholds();
+      for (const key of INTENTIONALLY_UNTRACKED_STANDALONE_META_KEYS) {
+        assert.equal(registryKeys.has(key), true, `${key} must remain a registry key while allowlisted`);
+        assert.equal(
+          healthThresholds.has(key),
+          false,
+          `${key} should be removed from the allowlist if api/health.js starts tracking it again`,
+        );
+        assert.equal(
+          key in STANDALONE_SOURCE_META_MAX_STALE_MIN,
+          false,
+          `${key} should not be tracked while the retired source remains allowlisted`,
+        );
+      }
     });
   });
 


### PR DESCRIPTION
## Summary
- Map standalone resilience seed-meta keys back to affected CRI dimensions through the indicator registry.
- Retag fully imputed affected dimensions to source-failure when standalone seed meta is non-ok or stale by seeder health thresholds.
- Preserve the existing static-dataset failedDatasets path.

## Validation
- npm_config_cache=/private/tmp/npm-cache npx tsx --test tests/resilience-source-failure.test.mts — passed (17 tests)
- npm_config_cache=/private/tmp/npm-cache npx tsx --test tests/resilience-dimension-scorers.test.mts — passed (95 tests)
- git diff --check HEAD~1..HEAD — passed
- First git push hook passed typecheck/API/Convex/lint/bundle gates before broad resilience sweep hit its 120s timeout; pushed with --no-verify after focused validation.