### PR TITLE
fix(resilience): harden static seeder data quality

### DIFF
--- a/scripts/seed-resilience-static.mjs
+++ b/scripts/seed-resilience-static.mjs
@@ -668,7 +668,8 @@ export function parseFsinRows(csvText) {
       source: 'hdx-ipc',
       year,
       // Output matches the shape that scoreFoodWater() reads from staticRecord.fao.
-      // phase3plus == total people in Phase 3 or above (IPC definition of "in crisis").
+      // phase3plus is the IPC Phase 3+ total when present; otherwise Phase 4+5
+      // is a conservative lower-bound fallback for rows missing the aggregate.
       peopleInCrisis: peopleInCrisis > 0 ? roundMetric(peopleInCrisis, 0) : null,
       phase: `IPC Phase ${highestPhase}`,
     });

--- a/scripts/seed-resilience-static.mjs
+++ b/scripts/seed-resilience-static.mjs
@@ -513,6 +513,8 @@ export function parseEurostatEnergyDataset(data, { enforceEuMemberFloor = false 
 }
 
 export async function fetchEnergyDependencyDataset() {
+  // Eurostat is the authoritative EU slice; if it is unavailable or collapses,
+  // fail the whole iea adapter so recovery preserves the previous full snapshot.
   const [eurostatData, worldBankRows] = await Promise.all([
     withRetry(() => fetchJson(EUROSTAT_ENERGY_URL), 2, 750).catch((err) => {
       throw new Error(`Energy dependency: Eurostat fetch failed: ${err.message}`);

--- a/scripts/seed-resilience-static.mjs
+++ b/scripts/seed-resilience-static.mjs
@@ -42,7 +42,9 @@ export const RESILIENCE_STATIC_TTL_SECONDS = 400 * 24 * 60 * 60;
 // seed — the new whitelist would never run, the static index would
 // remain at ~222 entries, and the universe filter would silently
 // not take effect. Caught by reviewer post-PR-3435 push.
-export const RESILIENCE_STATIC_SOURCE_VERSION = 'resilience-static-v8';
+// v9 adds static-data quality provenance and guards, so current-year
+// successful v8 snapshots must not skip the updated publish path.
+export const RESILIENCE_STATIC_SOURCE_VERSION = 'resilience-static-v9';
 export const RESILIENCE_STATIC_WINDOW_CRON = '0 */4 1-3 10 *';
 
 const LOCK_DOMAIN = 'resilience:static';
@@ -65,6 +67,12 @@ const RSF_RANKING_URL = 'https://rsf.org/en/ranking';
 const EUROSTAT_ENERGY_URL = 'https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/nrg_ind_id?freq=A';
 const WB_ENERGY_IMPORT_INDICATOR = 'EG.IMP.CONS.ZS';
 const COUNTRY_RESOLVERS = createCountryResolvers();
+const EUROSTAT_ENERGY_EU_MEMBER_FLOOR = 24;
+const EUROSTAT_EU_MEMBER_ISO2 = new Set([
+  'AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI',
+  'FR', 'DE', 'GR', 'HU', 'IE', 'IT', 'LV', 'LT', 'LU',
+  'MT', 'NL', 'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE',
+]);
 
 export function countryRedisKey(iso2) {
   return `${RESILIENCE_STATIC_PREFIX}${iso2}`;
@@ -468,7 +476,15 @@ function parseLatestEurostatValue(data, geoCode) {
   };
 }
 
-export function parseEurostatEnergyDataset(data) {
+export function validateEurostatEnergyEuMemberFloor(parsed, floor = EUROSTAT_ENERGY_EU_MEMBER_FLOOR) {
+  const euRows = [...EUROSTAT_EU_MEMBER_ISO2].filter((iso2) => parsed.has(iso2)).length;
+  if (euRows < floor) {
+    throw new Error(`Eurostat energy dependency parsed ${euRows} EU member rows (expected at least ${floor})`);
+  }
+  return { euRows, floor };
+}
+
+export function parseEurostatEnergyDataset(data, { enforceEuMemberFloor = false } = {}) {
   const ids = Array.isArray(data?.id) ? data.id : [];
   const dimensions = data?.dimension || {};
   if (!data?.value || !ids.length) {
@@ -492,6 +508,7 @@ export function parseEurostatEnergyDataset(data) {
     });
   }
 
+  if (enforceEuMemberFloor) validateEurostatEnergyEuMemberFloor(parsed);
   return parsed;
 }
 
@@ -504,9 +521,9 @@ export async function fetchEnergyDependencyDataset() {
   let merged = new Map();
   if (eurostatData) {
     try {
-      merged = parseEurostatEnergyDataset(eurostatData);
-    } catch {
-      merged = new Map();
+      merged = parseEurostatEnergyDataset(eurostatData, { enforceEuMemberFloor: true });
+    } catch (err) {
+      throw new Error(`Energy dependency: Eurostat parse/floor check failed: ${err.message}`);
     }
   }
   const worldBankFallback = selectLatestWorldBankByCountry(worldBankRows);
@@ -643,12 +660,14 @@ export function parseFsinRows(csvText) {
       .filter((v) => v != null && v > 2000);
     const year = yearCandidates.length ? Math.max(...yearCandidates) : null;
     const highestPhase = phase5 ? 5 : phase4 ? 4 : 3;
+    const higherPhaseTotal = (phase4 ?? 0) + (phase5 ?? 0);
+    const peopleInCrisis = phase3plus && phase3plus > 0 ? phase3plus : higherPhaseTotal;
     parsed.set(iso2, {
       source: 'hdx-ipc',
       year,
       // Output matches the shape that scoreFoodWater() reads from staticRecord.fao.
       // phase3plus == total people in Phase 3 or above (IPC definition of "in crisis").
-      peopleInCrisis: phase3plus != null ? roundMetric(phase3plus, 0) : null,
+      peopleInCrisis: peopleInCrisis > 0 ? roundMetric(peopleInCrisis, 0) : null,
       phase: `IPC Phase ${highestPhase}`,
     });
   }
@@ -796,12 +815,28 @@ export function finalizeCountryPayloads(datasetMaps, seedYear = nowSeedYear(), s
   return merged;
 }
 
-export function buildManifest(countryPayloads, failedDatasets, seedYear, seededAt) {
+function normalizeRecoveredDatasets(recoveredDatasets = {}) {
+  return Object.entries(recoveredDatasets)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .reduce((acc, [dataset, info]) => {
+      acc[dataset] = {
+        recordCount: Number(info?.recordCount) || 0,
+        countries: [...(info?.countries ?? [])].sort(),
+        seedYears: [...(info?.seedYears ?? [])].sort((left, right) => left - right),
+        seededAts: [...(info?.seededAts ?? [])].sort(),
+        sourceYears: [...(info?.sourceYears ?? [])].sort((left, right) => left - right),
+      };
+      return acc;
+    }, {});
+}
+
+export function buildManifest(countryPayloads, failedDatasets, seedYear, seededAt, recoveredDatasets = {}) {
   const countries = [...countryPayloads.keys()].sort();
   return {
     countries,
     recordCount: countries.length,
     failedDatasets: [...failedDatasets].sort(),
+    recoveredDatasets: normalizeRecoveredDatasets(recoveredDatasets),
     seedYear,
     seededAt,
     sourceVersion: RESILIENCE_STATIC_SOURCE_VERSION,
@@ -826,6 +861,57 @@ export function buildFailureRefreshKeys(manifest) {
     if (isIso2(iso2)) keys.add(countryRedisKey(iso2));
   }
   return [...keys];
+}
+
+function collectSourceYears(value, years = new Set()) {
+  if (!value || typeof value !== 'object') return years;
+  for (const [key, nested] of Object.entries(value)) {
+    if (key === 'seedYear') continue;
+    if (/year$/i.test(key) && typeof nested !== 'object') {
+      const numeric = safeNum(nested);
+      if (numeric != null && numeric >= 1900 && numeric <= 2100) years.add(numeric);
+      continue;
+    }
+    collectSourceYears(nested, years);
+  }
+  return years;
+}
+
+function recoveredDatasetProvenance(dataset, countryPayload, datasetValue) {
+  const seedYear = safeNum(countryPayload?.seedYear);
+  const seededAt = typeof countryPayload?.seededAt === 'string' ? countryPayload.seededAt : null;
+  const sourceYears = [...collectSourceYears(datasetValue)].sort((left, right) => left - right);
+  return {
+    dataset,
+    ...(seedYear != null ? { seedYear } : {}),
+    ...(seededAt ? { seededAt } : {}),
+    ...(sourceYears.length ? { sourceYears } : {}),
+  };
+}
+
+function annotateRecoveredDatasetValue(dataset, countryPayload, datasetValue) {
+  if (!datasetValue || typeof datasetValue !== 'object' || Array.isArray(datasetValue)) return datasetValue;
+  return {
+    ...datasetValue,
+    _recovered: recoveredDatasetProvenance(dataset, countryPayload, datasetValue),
+  };
+}
+
+function noteRecoveredDataset(recoveredDatasets, dataset, iso2, countryPayload, datasetValue) {
+  const provenance = recoveredDatasetProvenance(dataset, countryPayload, datasetValue);
+  const info = recoveredDatasets[dataset] ?? {
+    recordCount: 0,
+    countries: new Set(),
+    seedYears: new Set(),
+    seededAts: new Set(),
+    sourceYears: new Set(),
+  };
+  info.recordCount += 1;
+  info.countries.add(iso2);
+  if (provenance.seedYear != null) info.seedYears.add(provenance.seedYear);
+  if (provenance.seededAt) info.seededAts.add(provenance.seededAt);
+  for (const year of provenance.sourceYears ?? []) info.sourceYears.add(year);
+  recoveredDatasets[dataset] = info;
 }
 
 async function redisPipeline(commands) {
@@ -966,7 +1052,8 @@ async function fetchAllDatasetMaps() {
 // Throws if the Redis recovery reads themselves fail — the caller must then call
 // preservePreviousSnapshotOnFailure and abort, rather than publishing corrupt data.
 export async function recoverFailedDatasets(datasetMaps, failedDatasets, { readIndex, readPipeline }) {
-  if (failedDatasets.length === 0) return;
+  const recoveredDatasets = {};
+  if (failedDatasets.length === 0) return { recoveredDatasets };
 
   let existingIndex;
   try {
@@ -978,7 +1065,7 @@ export async function recoverFailedDatasets(datasetMaps, failedDatasets, { readI
   const existingCountries = existingIndex?.countries ?? [];
   if (existingCountries.length === 0) {
     console.warn(`  [fallback] dataset(s) failed (${failedDatasets.join(', ')}) — no prior snapshot to recover from`);
-    return;
+    return { recoveredDatasets };
   }
 
   let pipelineResults;
@@ -995,7 +1082,8 @@ export async function recoverFailedDatasets(datasetMaps, failedDatasets, { readI
     if (!existing) continue;
     for (const key of failedDatasets) {
       if (existing[key] != null && datasetMaps[key] instanceof Map && !datasetMaps[key].has(iso2)) {
-        datasetMaps[key].set(iso2, existing[key]);
+        datasetMaps[key].set(iso2, annotateRecoveredDatasetValue(key, existing, existing[key]));
+        noteRecoveredDataset(recoveredDatasets, key, iso2, existing, existing[key]);
       }
     }
   }
@@ -1003,6 +1091,8 @@ export async function recoverFailedDatasets(datasetMaps, failedDatasets, { readI
   for (const key of failedDatasets) {
     console.warn(`  [fallback] dataset '${key}' failed — preserved ${datasetMaps[key].size} existing Redis records from prior snapshot`);
   }
+
+  return { recoveredDatasets: normalizeRecoveredDatasets(recoveredDatasets) };
 }
 
 export async function seedResilienceStatic() {
@@ -1019,8 +1109,9 @@ export async function seedResilienceStatic() {
 
   const { datasetMaps, failedDatasets } = await fetchAllDatasetMaps();
 
+  let recovery = { recoveredDatasets: {} };
   try {
-    await recoverFailedDatasets(datasetMaps, failedDatasets, {
+    recovery = await recoverFailedDatasets(datasetMaps, failedDatasets, {
       readIndex: () => readJsonKey(RESILIENCE_STATIC_INDEX_KEY),
       readPipeline: redisPipeline,
     });
@@ -1037,7 +1128,7 @@ export async function seedResilienceStatic() {
 
   const seededAt = new Date().toISOString();
   const countryPayloads = finalizeCountryPayloads(datasetMaps, seedYear, seededAt);
-  const manifest = buildManifest(countryPayloads, failedDatasets, seedYear, seededAt);
+  const manifest = buildManifest(countryPayloads, failedDatasets, seedYear, seededAt, recovery?.recoveredDatasets ?? {});
 
   if (manifest.recordCount === 0) {
     const failure = await preservePreviousSnapshotOnFailure(

--- a/scripts/seed-resilience-static.mjs
+++ b/scripts/seed-resilience-static.mjs
@@ -514,17 +514,17 @@ export function parseEurostatEnergyDataset(data, { enforceEuMemberFloor = false 
 
 export async function fetchEnergyDependencyDataset() {
   const [eurostatData, worldBankRows] = await Promise.all([
-    withRetry(() => fetchJson(EUROSTAT_ENERGY_URL), 2, 750).catch(() => null),
+    withRetry(() => fetchJson(EUROSTAT_ENERGY_URL), 2, 750).catch((err) => {
+      throw new Error(`Energy dependency: Eurostat fetch failed: ${err.message}`);
+    }),
     fetchWorldBankIndicatorRows(WB_ENERGY_IMPORT_INDICATOR, { mrv: '12' }).catch(() => []),
   ]);
 
   let merged = new Map();
-  if (eurostatData) {
-    try {
-      merged = parseEurostatEnergyDataset(eurostatData, { enforceEuMemberFloor: true });
-    } catch (err) {
-      throw new Error(`Energy dependency: Eurostat parse/floor check failed: ${err.message}`);
-    }
+  try {
+    merged = parseEurostatEnergyDataset(eurostatData, { enforceEuMemberFloor: true });
+  } catch (err) {
+    throw new Error(`Energy dependency: Eurostat parse/floor check failed: ${err.message}`);
   }
   const worldBankFallback = selectLatestWorldBankByCountry(worldBankRows);
 

--- a/tests/resilience-static-seed.test.mjs
+++ b/tests/resilience-static-seed.test.mjs
@@ -26,6 +26,7 @@ import {
   resolveIso2,
   shouldSkipSeedYear,
   transformWhoPhysicianDensity,
+  validateEurostatEnergyEuMemberFloor,
 } from '../scripts/seed-resilience-static.mjs';
 
 // Helpers for inline CSV construction
@@ -179,6 +180,22 @@ describe('resilience static seed CSV parsers', () => {
       const result = parseFsinRows(csv);
       assert.ok(!result.has('NO'), 'NO should be skipped (all phases are zero)');
       assert.ok(result.has('YE'));
+    });
+
+    it('falls back to Phase 4 + Phase 5 when Phase 3+ is blank or zero', () => {
+      const csv = csvRows(
+        'Country (ISO3),Phase 3+ #,Phase 4 #,Phase 5 #,Period',
+        [
+          'YEM,,6200000,161000,2025-03',
+          'SOM,0,3100000,0,2025-04',
+        ],
+      );
+      const result = parseFsinRows(csv);
+
+      assert.equal(result.get('YE')?.peopleInCrisis, 6361000);
+      assert.equal(result.get('YE')?.phase, 'IPC Phase 5');
+      assert.equal(result.get('SO')?.peopleInCrisis, 3100000);
+      assert.equal(result.get('SO')?.phase, 'IPC Phase 4');
     });
 
     it('throws when no usable rows parsed', () => {
@@ -414,6 +431,19 @@ describe('resilience static seed parsers', () => {
     });
     assert.equal(parsed.get('US').energyImportDependency.value, 8.5);
   });
+
+  it('fails the Eurostat EU-member floor before World Bank fallback can mask a parse collapse', () => {
+    const parsed = new Map([
+      ['NO', { energyImportDependency: { value: -13.3, year: 2024, source: 'eurostat' } }],
+      ['US', { energyImportDependency: { value: 8.5, year: 2024, source: 'eurostat' } }],
+      ['DE', { energyImportDependency: { value: 45.1, year: 2024, source: 'eurostat' } }],
+    ]);
+
+    assert.throws(
+      () => validateEurostatEnergyEuMemberFloor(parsed),
+      /parsed 1 EU member rows \(expected at least 24\)/,
+    );
+  });
 });
 
 describe('resilience static seed payload assembly', () => {
@@ -479,6 +509,7 @@ describe('resilience static seed payload assembly', () => {
       countries: ['NO', 'US', 'YE'],
       recordCount: 3,
       failedDatasets: ['aquastat', 'gpi'],
+      recoveredDatasets: {},
       seedYear: 2026,
       seededAt: '2026-04-03T12:00:00.000Z',
       sourceVersion: RESILIENCE_STATIC_SOURCE_VERSION,
@@ -529,15 +560,39 @@ describe('recoverFailedDatasets', () => {
 
   it('injects prior fao values when FSIN fails and a prior snapshot exists', async () => {
     const maps = makeDatasetMaps();
-    await recoverFailedDatasets(maps, ['fao'], {
+    const recovery = await recoverFailedDatasets(maps, ['fao'], {
       readIndex: async () => ({ countries: ['YE', 'SO'] }),
       readPipeline: async () => [
-        { result: JSON.stringify({ fao: existingFao, wgi: { source: 'worldbank-wgi' } }) },
-        { result: JSON.stringify({ fao: existingSo, wgi: null }) },
+        { result: JSON.stringify({ seedYear: 2025, seededAt: '2025-10-02T00:00:00.000Z', fao: existingFao, wgi: { source: 'worldbank-wgi' } }) },
+        { result: JSON.stringify({ seedYear: 2025, seededAt: '2025-10-02T00:00:00.000Z', fao: existingSo, wgi: null }) },
       ],
     });
-    assert.deepEqual(maps.fao.get('YE'), existingFao, 'YE fao should be recovered');
-    assert.deepEqual(maps.fao.get('SO'), existingSo, 'SO fao should be recovered');
+    assert.deepEqual(
+      maps.fao.get('YE'),
+      {
+        ...existingFao,
+        _recovered: {
+          dataset: 'fao',
+          seedYear: 2025,
+          seededAt: '2025-10-02T00:00:00.000Z',
+          sourceYears: [2025],
+        },
+      },
+      'YE fao should be recovered with field-level provenance',
+    );
+    assert.deepEqual(
+      recovery.recoveredDatasets,
+      {
+        fao: {
+          recordCount: 2,
+          countries: ['SO', 'YE'],
+          seedYears: [2025],
+          seededAts: ['2025-10-02T00:00:00.000Z'],
+          sourceYears: [2025],
+        },
+      },
+      'manifest recovery summary should preserve prior seed/source-year provenance',
+    );
     // Verify recovered shape has the fields scoreFoodWater() reads.
     // If this fails, a FSIN failover would silently produce null for the crisis sub-metric.
     assert.ok(typeof maps.fao.get('YE').peopleInCrisis === 'number', 'recovered fao must have peopleInCrisis for scoreFoodWater()');
@@ -590,13 +645,47 @@ describe('recoverFailedDatasets', () => {
     await recoverFailedDatasets(maps, ['aquastat'], {
       readIndex: async () => ({ countries: ['DE'] }),
       readPipeline: async () => [
-        { result: JSON.stringify({ aquastat: existingAquastat }) },
+        { result: JSON.stringify({ seedYear: 2026, seededAt: '2026-10-02T00:00:00.000Z', aquastat: existingAquastat }) },
       ],
     });
     const de = maps.aquastat.get('DE');
-    assert.deepEqual(de, existingAquastat, 'DE aquastat should be recovered');
+    assert.deepEqual(de, {
+      ...existingAquastat,
+      _recovered: {
+        dataset: 'aquastat',
+        seedYear: 2026,
+        seededAt: '2026-10-02T00:00:00.000Z',
+        sourceYears: [2022],
+      },
+    }, 'DE aquastat should be recovered with provenance');
     assert.ok(typeof de.value === 'number', 'recovered aquastat must have numeric value for scoreAquastatValue()');
     assert.ok(typeof de.indicator === 'string', 'recovered aquastat must have indicator string for scoreAquastatValue()');
+  });
+
+  it('adds recovered dataset provenance to the manifest', () => {
+    const countryPayloads = new Map([
+      ['DE', { coverage: { availableDatasets: 1 } }],
+      ['YE', { coverage: { availableDatasets: 1 } }],
+    ]);
+    const manifest = buildManifest(countryPayloads, ['fao'], 2026, '2026-10-03T00:00:00.000Z', {
+      fao: {
+        recordCount: 2,
+        countries: ['YE', 'DE'],
+        seedYears: [2025],
+        seededAts: ['2025-10-02T00:00:00.000Z'],
+        sourceYears: [2024, 2025],
+      },
+    });
+
+    assert.deepEqual(manifest.recoveredDatasets, {
+      fao: {
+        recordCount: 2,
+        countries: ['DE', 'YE'],
+        seedYears: [2025],
+        seededAts: ['2025-10-02T00:00:00.000Z'],
+        sourceYears: [2024, 2025],
+      },
+    });
   });
 });
 

--- a/tests/resilience-static-seed.test.mjs
+++ b/tests/resilience-static-seed.test.mjs
@@ -482,6 +482,59 @@ describe('resilience static seed parsers', () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it('fails energy dependency when Eurostat parses below the EU floor even if World Bank has data', async () => {
+    const collapsedEurostatPayload = {
+      id: ['freq', 'siec', 'unit', 'geo', 'time'],
+      size: [1, 1, 1, 1, 1],
+      dimension: {
+        freq: { category: { index: { A: 0 } } },
+        siec: { category: { index: { TOTAL: 0 } } },
+        unit: { category: { index: { PC: 0 } } },
+        geo: { category: { index: { DE: 0 } } },
+        time: { category: { index: { 2024: 0 } } },
+      },
+      value: { 0: 63.2 },
+    };
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      const href = String(url);
+      if (href.includes('ec.europa.eu/eurostat/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => collapsedEurostatPayload,
+        };
+      }
+      if (href.includes('api.worldbank.org/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            { pages: 1 },
+            [
+              {
+                country: { id: 'FR', value: 'France' },
+                countryiso3code: 'FRA',
+                date: '2024',
+                value: 44.1,
+              },
+            ],
+          ],
+        };
+      }
+      throw new Error(`Unexpected test URL: ${href}`);
+    };
+
+    try {
+      await assert.rejects(
+        () => fetchEnergyDependencyDataset(),
+        /Energy dependency: Eurostat parse\/floor check failed: Eurostat energy dependency parsed 1 EU member rows \(expected at least 24\)/,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });
 
 describe('resilience static seed payload assembly', () => {

--- a/tests/resilience-static-seed.test.mjs
+++ b/tests/resilience-static-seed.test.mjs
@@ -18,6 +18,7 @@ import {
   gpiUrlForYear,
   resolveGpiCsv,
   buildAquastatWbMap,
+  fetchEnergyDependencyDataset,
   parseEurostatEnergyDataset,
   parseFsinRows,
   parseGpiRows,
@@ -443,6 +444,43 @@ describe('resilience static seed parsers', () => {
       () => validateEurostatEnergyEuMemberFloor(parsed),
       /parsed 1 EU member rows \(expected at least 24\)/,
     );
+  });
+
+  it('fails energy dependency when Eurostat is unreachable instead of publishing World Bank-only data', async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      const href = String(url);
+      if (href.includes('ec.europa.eu/eurostat/')) {
+        throw Object.assign(new Error('Eurostat unavailable'), { nonRetryable: true });
+      }
+      if (href.includes('api.worldbank.org/')) {
+        return {
+          ok: true,
+          status: 200,
+          json: async () => [
+            { pages: 1 },
+            [
+              {
+                country: { id: 'DE', value: 'Germany' },
+                countryiso3code: 'DEU',
+                date: '2024',
+                value: 63.2,
+              },
+            ],
+          ],
+        };
+      }
+      throw new Error(`Unexpected test URL: ${href}`);
+    };
+
+    try {
+      await assert.rejects(
+        () => fetchEnergyDependencyDataset(),
+        /Energy dependency: Eurostat fetch failed: Eurostat unavailable/,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- enforce a Eurostat EU-member floor for resilience static energy dependency so World Bank fallback cannot mask a collapsed Eurostat parse
- preserve recovered static field provenance with `_recovered` metadata and manifest-level `recoveredDatasets`
- fall back to IPC/FSIN Phase 4 + Phase 5 counts when Phase 3+ is blank or zero

## Validation
- `node --test tests/resilience-static-seed.test.mjs`
- `npm run typecheck:api`
- `git diff --check`
- pre-push hook ran typecheck/typecheck:api and many guardrails, then full unit suite failed on unrelated timing-sensitive `tests/with-timeout.test.mts`; isolated rerun passed with `npx tsx --test tests/with-timeout.test.mts`

## Audit Items
- P2-5: fixed and covered by Eurostat EU-member floor regression test
- P2-6: fixed and covered by recovered provenance + manifest regression test
- P2-7: fixed and covered by FSIN Phase 4 + Phase 5 fallback regression test