### PR TITLE
fix(resilience): clarify frontend score bands

### DIFF
--- a/e2e/variant-live-smoke.spec.ts
+++ b/e2e/variant-live-smoke.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Request } from '@playwright/test';
 import { PREMIUM_RPC_PATHS } from '../src/shared/premium-paths';
 
 type VariantName = 'full' | 'tech' | 'finance' | 'commodity' | 'energy' | 'happy';
@@ -108,7 +108,7 @@ test.describe('variant live reliability smoke', () => {
     const variant = normalizeVariant(process.env.VITE_VARIANT);
     const expectedPanelIds = EXPECTED_BOOT_PANELS[variant];
     const apiResponses: ApiDiagnostic[] = [];
-    const apiRequestMetadata = new Map<string, { method: string; resourceType: string }>();
+    const apiRequestMetadata = new WeakMap<Request, { method: string; resourceType: string }>();
     const failedApiRequests: Array<{ failure: string; method: string; path: string; url: string }> = [];
     const pageErrors: string[] = [];
     const consoleIssues: Array<{ text: string; type: string }> = [];
@@ -116,7 +116,7 @@ test.describe('variant live reliability smoke', () => {
     page.on('request', (request) => {
       const url = request.url();
       if (!isLocalApiUrl(url)) return;
-      apiRequestMetadata.set(url, {
+      apiRequestMetadata.set(request, {
         method: request.method(),
         resourceType: request.resourceType(),
       });
@@ -125,7 +125,7 @@ test.describe('variant live reliability smoke', () => {
     page.on('response', (response) => {
       const url = response.url();
       if (!isLocalApiUrl(url)) return;
-      const requestMetadata = apiRequestMetadata.get(url);
+      const requestMetadata = apiRequestMetadata.get(response.request());
       apiResponses.push({
         method: requestMetadata?.method ?? 'unknown',
         path: apiPath(url),

--- a/e2e/variant-live-smoke.spec.ts
+++ b/e2e/variant-live-smoke.spec.ts
@@ -108,18 +108,28 @@ test.describe('variant live reliability smoke', () => {
     const variant = normalizeVariant(process.env.VITE_VARIANT);
     const expectedPanelIds = EXPECTED_BOOT_PANELS[variant];
     const apiResponses: ApiDiagnostic[] = [];
+    const apiRequestMetadata = new Map<string, { method: string; resourceType: string }>();
     const failedApiRequests: Array<{ failure: string; method: string; path: string; url: string }> = [];
     const pageErrors: string[] = [];
     const consoleIssues: Array<{ text: string; type: string }> = [];
 
+    page.on('request', (request) => {
+      const url = request.url();
+      if (!isLocalApiUrl(url)) return;
+      apiRequestMetadata.set(url, {
+        method: request.method(),
+        resourceType: request.resourceType(),
+      });
+    });
+
     page.on('response', (response) => {
       const url = response.url();
       if (!isLocalApiUrl(url)) return;
-      const request = response.request();
+      const requestMetadata = apiRequestMetadata.get(url);
       apiResponses.push({
-        method: request.method(),
+        method: requestMetadata?.method ?? 'unknown',
         path: apiPath(url),
-        resourceType: request.resourceType(),
+        resourceType: requestMetadata?.resourceType ?? 'unknown',
         status: response.status(),
         url,
       });

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -141,8 +141,10 @@ import type { ResilienceRankingItem } from '@/services/resilience';
 import {
   RESILIENCE_CHOROPLETH_COLORS,
   buildResilienceChoroplethMap,
+  formatResilienceChoroplethLevel,
   normalizeExclusiveChoropleths,
 } from './resilience-choropleth-utils';
+import { formatResilienceServerLevel } from './resilience-widget-utils';
 
 import { isAllowedPreviewUrl } from '@/utils/imagery-preview';
 import { pinWebcam, isPinned } from '@/services/webcams/pinned-store';
@@ -4539,8 +4541,10 @@ export class DeckGLMap {
         }
         const [red, green, blue] = RESILIENCE_CHOROPLETH_COLORS[resilienceEntry.level];
         const levelColor = `rgb(${red}, ${green}, ${blue})`;
+        const visualBand = formatResilienceChoroplethLevel(resilienceEntry.level);
+        const serverLevel = formatResilienceServerLevel(resilienceEntry.serverLevel);
         return {
-          html: `<div class="deckgl-tooltip"><strong>${text(resilienceName)}</strong><br/>Resilience: <span style="color:${levelColor};font-weight:600">${resilienceEntry.overallScore.toFixed(1)}/100</span><br/><span style="text-transform:capitalize;opacity:.7">${text(resilienceEntry.serverLevel)}</span>${resilienceEntry.lowConfidence ? '<br/><span style="opacity:.7">Low confidence</span>' : ''}</div>`,
+          html: `<div class="deckgl-tooltip"><strong>${text(resilienceName)}</strong><br/>Resilience: <span style="color:${levelColor};font-weight:600">${resilienceEntry.overallScore.toFixed(1)}/100</span><br/><span style="text-transform:capitalize;opacity:.7">Visual band: ${text(visualBand)}</span><br/><span style="text-transform:capitalize;opacity:.7">API level: ${text(serverLevel)}</span>${resilienceEntry.lowConfidence ? '<br/><span style="opacity:.7">Low confidence</span>' : ''}</div>`,
         };
       }
       case 'species-recovery-layer': {

--- a/src/components/ResilienceWidget.ts
+++ b/src/components/ResilienceWidget.ts
@@ -32,6 +32,7 @@ import type { CountryEnergyProfileData } from './CountryBriefPanel';
 // full ResilienceWidget class transitive graph (the class indirectly
 // depends on import.meta.env.DEV via proxy.ts, which breaks plain
 // node test runners). Moved in the PR #2949 review round.
+const METHODOLOGY_HELP_TITLE = formatResilienceMethodologyHelpTitle();
 
 function normalizeCountryCode(countryCode: string | null | undefined): string | null {
   const normalized = String(countryCode || '').trim().toUpperCase();
@@ -154,7 +155,7 @@ export class ResilienceWidget {
           'span',
           {
             className: 'resilience-widget__help',
-            title: formatResilienceMethodologyHelpTitle(),
+            title: METHODOLOGY_HELP_TITLE,
             'aria-label': 'Resilience score methodology',
           },
           '?',

--- a/src/components/ResilienceWidget.ts
+++ b/src/components/ResilienceWidget.ts
@@ -12,10 +12,12 @@ import {
   RESILIENCE_VISUAL_LEVEL_COLORS,
   collectDimensionConfidences,
   formatBaselineStress,
+  formatResilienceMethodologyHelpTitle,
   formatResilienceChange30d,
   formatResilienceConfidence,
   formatResilienceDataVersion,
   formatResilienceScoreInterval,
+  getResilienceOverallDisplay,
   getImputationClassIcon,
   getImputationClassLabel,
   getResilienceDomainLabel,
@@ -152,7 +154,7 @@ export class ResilienceWidget {
           'span',
           {
             className: 'resilience-widget__help',
-            title: 'Composite resilience score from 20 dimensions across 6 domains (economic, infrastructure, energy, social & governance, health & food, recovery), grouped into 3 pillars (structural readiness, live shock exposure, recovery capacity). Weights sum to 1.00; recovery carries the largest single-domain weight (0.25).',
+            title: formatResilienceMethodologyHelpTitle(),
             'aria-label': 'Resilience score methodology',
           },
           '?',
@@ -238,10 +240,9 @@ export class ResilienceWidget {
   }
 
   private renderScoreCard(data: ResilienceScoreResponse, preview = false): HTMLElement {
-    const visualLevel = getResilienceVisualLevel(data.overallScore);
-    const levelLabel = visualLevel.replace('_', ' ').toUpperCase();
-    const levelColor = RESILIENCE_VISUAL_LEVEL_COLORS[visualLevel];
-    const scoreInterval = formatResilienceScoreInterval(data.scoreInterval);
+    const overallDisplay = getResilienceOverallDisplay(data);
+    const levelColor = RESILIENCE_VISUAL_LEVEL_COLORS[overallDisplay.visualLevel];
+    const scoreInterval = overallDisplay.hasScore ? formatResilienceScoreInterval(data.scoreInterval) : null;
 
     return h(
       'div',
@@ -250,20 +251,30 @@ export class ResilienceWidget {
         'div',
         { className: 'resilience-widget__overall' },
         this.renderBarBlock(
-          clampScore(data.overallScore),
+          overallDisplay.scoreForBar,
           levelColor,
           h(
             'div',
             { className: 'resilience-widget__overall-meta' },
-            h('span', { className: 'resilience-widget__overall-score' }, String(Math.round(clampScore(data.overallScore)))),
+            h('span', { className: 'resilience-widget__overall-score' }, overallDisplay.scoreLabel),
             ...(scoreInterval
               ? [h('span', {
                   className: 'resilience-widget__overall-interval',
                   title: scoreInterval.title,
                 }, scoreInterval.label)]
               : []),
-            h('span', { className: 'resilience-widget__overall-level', style: { color: levelColor } }, levelLabel),
-            h('span', { className: 'resilience-widget__overall-trend' }, `${getResilienceTrendArrow(data.trend)} ${data.trend}`),
+            h(
+              'span',
+              {
+                className: 'resilience-widget__overall-level',
+                style: { color: levelColor },
+                title: overallDisplay.serverLevelLabel,
+              },
+              overallDisplay.visualLevelLabel,
+            ),
+            ...(overallDisplay.hasScore
+              ? [h('span', { className: 'resilience-widget__overall-trend' }, `${getResilienceTrendArrow(data.trend)} ${data.trend}`)]
+              : []),
           ),
         ),
       ),

--- a/src/components/resilience-choropleth-utils.ts
+++ b/src/components/resilience-choropleth-utils.ts
@@ -1,5 +1,6 @@
 import type { ResilienceRankingItem } from '@/services/resilience';
 import type { MapLayers } from '@/types';
+import { getResilienceVisualLevel } from './resilience-widget-utils';
 
 export type ResilienceChoroplethLevel = 'very_low' | 'low' | 'moderate' | 'high' | 'very_high' | 'insufficient_data';
 
@@ -24,11 +25,8 @@ function clampScore(score: number): number {
 }
 
 export function getResilienceChoroplethLevel(score: number): ResilienceChoroplethLevel {
-  if (score >= 80) return 'very_high';
-  if (score >= 60) return 'high';
-  if (score >= 40) return 'moderate';
-  if (score >= 20) return 'low';
-  return 'very_low';
+  const visualLevel = getResilienceVisualLevel(score);
+  return visualLevel === 'unknown' ? 'insufficient_data' : visualLevel;
 }
 
 export function formatResilienceChoroplethLevel(level: ResilienceChoroplethLevel): string {

--- a/src/components/resilience-widget-utils.ts
+++ b/src/components/resilience-widget-utils.ts
@@ -262,6 +262,7 @@ export function getResilienceMethodologySummary(data: ResilienceScoreResponse = 
 }
 
 export function formatResilienceMethodologyHelpTitle(summary = getResilienceMethodologySummary()): string {
+  // Keep the human-readable domain/pillar labels in sync if the methodology count parity tests change.
   return `Composite resilience score from ${summary.activeDimensionCount} active dimensions across ${summary.domainCount} domains (economic, infrastructure, energy, social & governance, health & food, recovery). The current methodology groups scores into ${summary.pillarCount} pillars (structural readiness, live shock exposure, recovery capacity); pillar detail appears when the API response includes it. Weights sum to 1.00; recovery carries the largest single-domain weight (0.25).`;
 }
 

--- a/src/components/resilience-widget-utils.ts
+++ b/src/components/resilience-widget-utils.ts
@@ -245,6 +245,7 @@ export function getResilienceOverallDisplay(data: Pick<ResilienceScoreResponse, 
 
 export interface ResilienceMethodologySummary {
   activeDimensionCount: number;
+  // Kept for server/fixture parity tests; tooltip copy intentionally shows active dimensions only.
   serializedDimensionCount: number;
   domainCount: number;
   pillarCount: number;

--- a/src/components/resilience-widget-utils.ts
+++ b/src/components/resilience-widget-utils.ts
@@ -175,6 +175,12 @@ export const RESILIENCE_VISUAL_LEVEL_COLORS: Record<ResilienceVisualLevel, strin
   unknown: 'var(--text-faint)',
 };
 
+export const RESILIENCE_PILLAR_IDS = [
+  'structural-readiness',
+  'live-shock-exposure',
+  'recovery-capacity',
+] as const;
+
 const DOMAIN_LABELS: Record<string, string> = {
   economic: 'Economic',
   infrastructure: 'Infra & Supply',
@@ -185,12 +191,77 @@ const DOMAIN_LABELS: Record<string, string> = {
 };
 
 export function getResilienceVisualLevel(score: number): ResilienceVisualLevel {
-  if (!Number.isFinite(score)) return 'unknown';
+  if (!Number.isFinite(score) || score < 0) return 'unknown';
   if (score >= 80) return 'very_high';
   if (score >= 60) return 'high';
   if (score >= 40) return 'moderate';
   if (score >= 20) return 'low';
   return 'very_low';
+}
+
+export function formatResilienceVisualLevel(level: ResilienceVisualLevel): string {
+  if (level === 'unknown') return 'Insufficient data';
+  return level.replace(/_/g, ' ');
+}
+
+export function formatResilienceServerLevel(level: string | null | undefined): string {
+  const normalized = String(level || '').trim().toLowerCase();
+  return normalized.length > 0 ? normalized.replace(/_/g, ' ') : 'unknown';
+}
+
+export interface ResilienceOverallDisplay {
+  hasScore: boolean;
+  scoreForBar: number;
+  scoreLabel: string;
+  visualLevel: ResilienceVisualLevel;
+  visualLevelLabel: string;
+  serverLevelLabel: string;
+}
+
+export function getResilienceOverallDisplay(data: Pick<ResilienceScoreResponse, 'overallScore' | 'level'>): ResilienceOverallDisplay {
+  const rawScore = Number(data.overallScore);
+  const visualLevel = getResilienceVisualLevel(rawScore);
+  if (visualLevel === 'unknown') {
+    return {
+      hasScore: false,
+      scoreForBar: 0,
+      scoreLabel: 'n/a',
+      visualLevel,
+      visualLevelLabel: 'Insufficient data',
+      serverLevelLabel: `API level: ${formatResilienceServerLevel(data.level)}`,
+    };
+  }
+
+  const clampedScore = Math.min(100, Math.max(0, rawScore));
+  return {
+    hasScore: true,
+    scoreForBar: clampedScore,
+    scoreLabel: String(Math.round(clampedScore)),
+    visualLevel,
+    visualLevelLabel: `Visual band: ${formatResilienceVisualLevel(visualLevel).toUpperCase()}`,
+    serverLevelLabel: `API level: ${formatResilienceServerLevel(data.level)}`,
+  };
+}
+
+export interface ResilienceMethodologySummary {
+  activeDimensionCount: number;
+  serializedDimensionCount: number;
+  domainCount: number;
+  pillarCount: number;
+}
+
+export function getResilienceMethodologySummary(data: ResilienceScoreResponse = LOCKED_PREVIEW): ResilienceMethodologySummary {
+  const dimensions = data.domains.flatMap((domain) => domain.dimensions);
+  return {
+    activeDimensionCount: dimensions.filter((dimension) => !RESILIENCE_RETIRED_DIMENSION_IDS.has(dimension.id)).length,
+    serializedDimensionCount: dimensions.length,
+    domainCount: data.domains.length,
+    pillarCount: data.pillars.length > 0 ? data.pillars.length : RESILIENCE_PILLAR_IDS.length,
+  };
+}
+
+export function formatResilienceMethodologyHelpTitle(summary = getResilienceMethodologySummary()): string {
+  return `Composite resilience score from ${summary.activeDimensionCount} active dimensions across ${summary.domainCount} domains (economic, infrastructure, energy, social & governance, health & food, recovery). The current methodology groups scores into ${summary.pillarCount} pillars (structural readiness, live shock exposure, recovery capacity); pillar detail appears when the API response includes it. Weights sum to 1.00; recovery carries the largest single-domain weight (0.25).`;
 }
 
 export function getResilienceTrendArrow(trend: string): string {

--- a/tests/resilience-widget.test.mts
+++ b/tests/resilience-widget.test.mts
@@ -6,12 +6,15 @@ import {
   collectDimensionConfidences,
   formatBaselineStress,
   formatDimensionConfidence,
+  formatResilienceMethodologyHelpTitle,
   formatResilienceChange30d,
   formatResilienceConfidence,
   formatResilienceDataVersion,
   formatResilienceScoreInterval,
   getImputationClassIcon,
   getImputationClassLabel,
+  getResilienceMethodologySummary,
+  getResilienceOverallDisplay,
   getResilienceDimensionLabel,
   getResilienceDomainLabel,
   getResilienceTrendArrow,
@@ -47,6 +50,55 @@ test('getResilienceVisualLevel maps the score thresholds from the widget spec', 
   assert.equal(getResilienceVisualLevel(20), 'low');
   assert.equal(getResilienceVisualLevel(19), 'very_low');
   assert.equal(getResilienceVisualLevel(Number.NaN), 'unknown');
+  assert.equal(getResilienceVisualLevel(-1), 'unknown');
+});
+
+test('getResilienceOverallDisplay treats negative and non-finite scores as insufficient data', () => {
+  assert.deepEqual(getResilienceOverallDisplay({ overallScore: -1, level: 'unknown' }), {
+    hasScore: false,
+    scoreForBar: 0,
+    scoreLabel: 'n/a',
+    visualLevel: 'unknown',
+    visualLevelLabel: 'Insufficient data',
+    serverLevelLabel: 'API level: unknown',
+  });
+  assert.deepEqual(getResilienceOverallDisplay({ overallScore: Number.NaN, level: 'low' }), {
+    hasScore: false,
+    scoreForBar: 0,
+    scoreLabel: 'n/a',
+    visualLevel: 'unknown',
+    visualLevelLabel: 'Insufficient data',
+    serverLevelLabel: 'API level: low',
+  });
+});
+
+test('getResilienceOverallDisplay separates visual band from API level', () => {
+  assert.deepEqual(getResilienceOverallDisplay({ overallScore: 61.2, level: 'medium' }), {
+    hasScore: true,
+    scoreForBar: 61.2,
+    scoreLabel: '61',
+    visualLevel: 'high',
+    visualLevelLabel: 'Visual band: HIGH',
+    serverLevelLabel: 'API level: medium',
+  });
+});
+
+test('resilience methodology help copy derives current counts from the preview fixture', async () => {
+  const { RESILIENCE_DIMENSION_ORDER, RESILIENCE_RETIRED_DIMENSIONS, RESILIENCE_DOMAIN_ORDER } = await import('../server/worldmonitor/resilience/v1/_dimension-scorers.ts');
+  const { PILLAR_ORDER } = await import('../server/worldmonitor/resilience/v1/_pillar-membership.ts');
+  const summary = getResilienceMethodologySummary();
+  assert.deepEqual(summary, {
+    activeDimensionCount: RESILIENCE_DIMENSION_ORDER.length - RESILIENCE_RETIRED_DIMENSIONS.size,
+    serializedDimensionCount: RESILIENCE_DIMENSION_ORDER.length,
+    domainCount: RESILIENCE_DOMAIN_ORDER.length,
+    pillarCount: PILLAR_ORDER.length,
+  });
+
+  const title = formatResilienceMethodologyHelpTitle(summary);
+  assert.match(title, new RegExp(`${summary.activeDimensionCount} active dimensions`));
+  assert.match(title, new RegExp(`${summary.domainCount} domains`));
+  assert.match(title, new RegExp(`${summary.pillarCount} pillars`));
+  assert.match(title, /pillar detail appears when the API response includes it/i);
 });
 
 test('getResilienceTrendArrow renders the expected glyphs', () => {


### PR DESCRIPTION
## Summary
- Fixes Country Resilience Index audit P2-9, P2-10, and P2-16 frontend coherence issues.
- Derives widget methodology counts from the locked preview fixture and regression-tests parity against server dimension/domain/pillar config.
- Separates visual score bands from API/server levels in the widget/map tooltip.
- Treats negative or non-finite overallScore values as insufficient data in the widget.

## Validation
- ./node_modules/.bin/tsx --test tests/resilience-widget.test.mts tests/resilience-map-layer.test.mts tests/resilience-retired-dimensions-parity.test.mts tests/resilience-staleness-factor-parity.test.mts
- npm run typecheck
- git diff --check
- git push pre-push hook: typecheck, API typecheck, Convex typecheck, CJS/unicode/boundary checks, edge bundle check, full unit suite, markdown/MDX lint, proto/pro-test freshness, version sync