### PR TITLE
Harden resilience runtime scorer inputs

### DIFF
--- a/docs/methodology/country-resilience-index/reference-edition/2026/manifest.json
+++ b/docs/methodology/country-resilience-index/reference-edition/2026/manifest.json
@@ -50,7 +50,7 @@
     "countries": {
       "NO": {
         "countryCode": "NO",
-        "overallScore": 74.85,
+        "overallScore": 75.42,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -83,9 +83,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -178,7 +178,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 87,
@@ -215,7 +215,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 47.53,
+            "score": 74.44,
             "weight": 0.15
           },
           "energy": {
@@ -241,7 +241,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 88.49,
+            "score": 90.32,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -252,7 +252,7 @@
       },
       "US": {
         "countryCode": "US",
-        "overallScore": 52.2,
+        "overallScore": 52.55,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -285,9 +285,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 92,
-            "coverage": 0.45,
-            "observedWeight": 0.45,
+            "score": 96,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -380,7 +380,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 75,
@@ -417,7 +417,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 73.96,
+            "score": 81.1,
             "weight": 0.15
           },
           "energy": {
@@ -443,7 +443,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 83.81,
+            "score": 85.16,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -454,7 +454,7 @@
       },
       "TR": {
         "countryCode": "TR",
-        "overallScore": 43.67,
+        "overallScore": 44.29,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -487,9 +487,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 58,
-            "coverage": 0.65,
-            "observedWeight": 0.65,
+            "score": 73,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -619,7 +619,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 51.78,
+            "score": 60.59,
             "weight": 0.15
           },
           "energy": {
@@ -645,7 +645,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 59.6,
+            "score": 61.89,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -656,7 +656,7 @@
       },
       "YE": {
         "countryCode": "YE",
-        "overallScore": 29.2,
+        "overallScore": 30.97,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -689,9 +689,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 85,
-            "coverage": 0.2,
-            "observedWeight": 0.2,
+            "score": 97,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -821,7 +821,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 77.43,
+            "score": 86.69,
             "weight": 0.15
           },
           "energy": {
@@ -847,7 +847,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 39.91,
+            "score": 47.27,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -858,7 +858,7 @@
       },
       "CH": {
         "countryCode": "CH",
-        "overallScore": 73.25,
+        "overallScore": 74.95,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -891,9 +891,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -986,7 +986,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 88,
@@ -1023,7 +1023,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 47.53,
+            "score": 74.44,
             "weight": 0.15
           },
           "energy": {
@@ -1049,7 +1049,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 79.12,
+            "score": 82.44,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -1060,7 +1060,7 @@
       },
       "AE": {
         "countryCode": "AE",
-        "overallScore": 59.26,
+        "overallScore": 62.32,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -1093,9 +1093,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -1188,7 +1188,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 74,
@@ -1225,7 +1225,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 84.37,
+            "score": 92.38,
             "weight": 0.15
           },
           "energy": {
@@ -1251,7 +1251,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 66.73,
+            "score": 72.01,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -1262,7 +1262,7 @@
       },
       "IN": {
         "countryCode": "IN",
-        "overallScore": 47.66,
+        "overallScore": 51.91,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -1295,9 +1295,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -1427,7 +1427,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 50.74,
+            "score": 76,
             "weight": 0.15
           },
           "energy": {
@@ -1453,7 +1453,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 54.7,
+            "score": 61.89,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -1464,7 +1464,7 @@
       },
       "SY": {
         "countryCode": "SY",
-        "overallScore": 21.88,
+        "overallScore": 23.3,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -1497,9 +1497,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -1592,7 +1592,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 5,
@@ -1629,7 +1629,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 78.21,
+            "score": 89.38,
             "weight": 0.15
           },
           "energy": {
@@ -1655,7 +1655,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 57.65,
+            "score": 64.38,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -1666,7 +1666,7 @@
       },
       "NR": {
         "countryCode": "NR",
-        "overallScore": 60.77,
+        "overallScore": 64.33,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -1699,9 +1699,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -1794,7 +1794,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 75,
@@ -1831,7 +1831,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 47.53,
+            "score": 74.44,
             "weight": 0.15
           },
           "energy": {
@@ -1857,7 +1857,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 66.38,
+            "score": 71.72,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -1868,7 +1868,7 @@
       },
       "ER": {
         "countryCode": "ER",
-        "overallScore": 35.03,
+        "overallScore": 36.75,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -1901,9 +1901,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -1996,7 +1996,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 42,
@@ -2033,7 +2033,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 32.86,
+            "score": 57.27,
             "weight": 0.15
           },
           "energy": {
@@ -2059,7 +2059,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 51.78,
+            "score": 58.58,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -2075,7 +2075,7 @@
     "countries": {
       "NO": {
         "countryCode": "NO",
-        "overallScore": 74.85,
+        "overallScore": 75.42,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -2108,9 +2108,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -2203,7 +2203,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 87,
@@ -2240,7 +2240,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 47.53,
+            "score": 74.44,
             "weight": 0.15
           },
           "energy": {
@@ -2266,7 +2266,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 88.49,
+            "score": 90.32,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -2277,7 +2277,7 @@
       },
       "US": {
         "countryCode": "US",
-        "overallScore": 52.2,
+        "overallScore": 52.55,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -2310,9 +2310,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 92,
-            "coverage": 0.45,
-            "observedWeight": 0.45,
+            "score": 96,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -2405,7 +2405,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 75,
@@ -2442,7 +2442,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 73.96,
+            "score": 81.1,
             "weight": 0.15
           },
           "energy": {
@@ -2468,7 +2468,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 83.81,
+            "score": 85.16,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -2479,7 +2479,7 @@
       },
       "TR": {
         "countryCode": "TR",
-        "overallScore": 43.67,
+        "overallScore": 44.29,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -2512,9 +2512,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 58,
-            "coverage": 0.65,
-            "observedWeight": 0.65,
+            "score": 73,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -2644,7 +2644,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 51.78,
+            "score": 60.59,
             "weight": 0.15
           },
           "energy": {
@@ -2670,7 +2670,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 59.6,
+            "score": 61.89,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -2681,7 +2681,7 @@
       },
       "YE": {
         "countryCode": "YE",
-        "overallScore": 29.2,
+        "overallScore": 30.97,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -2714,9 +2714,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 85,
-            "coverage": 0.2,
-            "observedWeight": 0.2,
+            "score": 97,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -2846,7 +2846,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 77.43,
+            "score": 86.69,
             "weight": 0.15
           },
           "energy": {
@@ -2872,7 +2872,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 39.91,
+            "score": 47.27,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -2883,7 +2883,7 @@
       },
       "CH": {
         "countryCode": "CH",
-        "overallScore": 73.25,
+        "overallScore": 74.95,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -2916,9 +2916,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -3011,7 +3011,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 88,
@@ -3048,7 +3048,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 47.53,
+            "score": 74.44,
             "weight": 0.15
           },
           "energy": {
@@ -3074,7 +3074,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 79.12,
+            "score": 82.44,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -3085,7 +3085,7 @@
       },
       "AE": {
         "countryCode": "AE",
-        "overallScore": 59.26,
+        "overallScore": 62.32,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -3118,9 +3118,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -3213,7 +3213,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 74,
@@ -3250,7 +3250,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 84.37,
+            "score": 92.38,
             "weight": 0.15
           },
           "energy": {
@@ -3276,7 +3276,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 66.73,
+            "score": 72.01,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -3287,7 +3287,7 @@
       },
       "IN": {
         "countryCode": "IN",
-        "overallScore": 47.66,
+        "overallScore": 51.91,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -3320,9 +3320,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -3452,7 +3452,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 50.74,
+            "score": 76,
             "weight": 0.15
           },
           "energy": {
@@ -3478,7 +3478,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 54.7,
+            "score": 61.89,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -3489,7 +3489,7 @@
       },
       "SY": {
         "countryCode": "SY",
-        "overallScore": 21.88,
+        "overallScore": 23.3,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -3522,9 +3522,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -3617,7 +3617,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 5,
@@ -3654,7 +3654,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 78.21,
+            "score": 89.38,
             "weight": 0.15
           },
           "energy": {
@@ -3680,7 +3680,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 57.65,
+            "score": 64.38,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -3691,7 +3691,7 @@
       },
       "NR": {
         "countryCode": "NR",
-        "overallScore": 60.77,
+        "overallScore": 64.33,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -3724,9 +3724,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -3819,7 +3819,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 75,
@@ -3856,7 +3856,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 47.53,
+            "score": 74.44,
             "weight": 0.15
           },
           "energy": {
@@ -3882,7 +3882,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 66.38,
+            "score": 71.72,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -3893,7 +3893,7 @@
       },
       "ER": {
         "countryCode": "ER",
-        "overallScore": 35.03,
+        "overallScore": 36.75,
         "formula": "pc",
         "dataVersion": "2026-04-08",
         "dimensions": {
@@ -3926,9 +3926,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -4021,7 +4021,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 42,
@@ -4058,7 +4058,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 32.86,
+            "score": 57.27,
             "weight": 0.15
           },
           "energy": {
@@ -4084,7 +4084,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 51.78,
+            "score": 58.58,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -4100,8 +4100,9 @@
     "countries": {
       "NO": {
         "countryCode": "NO",
-        "overallScore": 74.85,
+        "overallScore": 75.42,
         "formula": "pc",
+        "dataVersion": "2026-04-08",
         "dimensions": {
           "macroFiscal": {
             "score": 91,
@@ -4132,9 +4133,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -4227,7 +4228,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 87,
@@ -4264,7 +4265,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 47.53,
+            "score": 74.44,
             "weight": 0.15
           },
           "energy": {
@@ -4290,7 +4291,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 88.49,
+            "score": 90.32,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -4301,8 +4302,9 @@
       },
       "US": {
         "countryCode": "US",
-        "overallScore": 52.2,
+        "overallScore": 52.55,
         "formula": "pc",
+        "dataVersion": "2026-04-08",
         "dimensions": {
           "macroFiscal": {
             "score": 69,
@@ -4333,9 +4335,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 92,
-            "coverage": 0.45,
-            "observedWeight": 0.45,
+            "score": 96,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -4428,7 +4430,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 75,
@@ -4465,7 +4467,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 73.96,
+            "score": 81.1,
             "weight": 0.15
           },
           "energy": {
@@ -4491,7 +4493,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 83.81,
+            "score": 85.16,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -4502,8 +4504,9 @@
       },
       "TR": {
         "countryCode": "TR",
-        "overallScore": 43.67,
+        "overallScore": 44.29,
         "formula": "pc",
+        "dataVersion": "2026-04-08",
         "dimensions": {
           "macroFiscal": {
             "score": 59,
@@ -4534,9 +4537,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 58,
-            "coverage": 0.65,
-            "observedWeight": 0.65,
+            "score": 73,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -4666,7 +4669,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 51.78,
+            "score": 60.59,
             "weight": 0.15
           },
           "energy": {
@@ -4692,7 +4695,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 59.6,
+            "score": 61.89,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -4703,8 +4706,9 @@
       },
       "YE": {
         "countryCode": "YE",
-        "overallScore": 29.2,
+        "overallScore": 30.97,
         "formula": "pc",
+        "dataVersion": "2026-04-08",
         "dimensions": {
           "macroFiscal": {
             "score": 30,
@@ -4735,9 +4739,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 85,
-            "coverage": 0.2,
-            "observedWeight": 0.2,
+            "score": 97,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -4867,7 +4871,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 77.43,
+            "score": 86.69,
             "weight": 0.15
           },
           "energy": {
@@ -4893,7 +4897,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 39.91,
+            "score": 47.27,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -4904,8 +4908,9 @@
       },
       "CH": {
         "countryCode": "CH",
-        "overallScore": 73.25,
+        "overallScore": 74.95,
         "formula": "pc",
+        "dataVersion": "2026-04-08",
         "dimensions": {
           "macroFiscal": {
             "score": 75,
@@ -4936,9 +4941,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -5031,7 +5036,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 88,
@@ -5068,7 +5073,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 47.53,
+            "score": 74.44,
             "weight": 0.15
           },
           "energy": {
@@ -5094,7 +5099,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 79.12,
+            "score": 82.44,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -5105,8 +5110,9 @@
       },
       "AE": {
         "countryCode": "AE",
-        "overallScore": 59.26,
+        "overallScore": 62.32,
         "formula": "pc",
+        "dataVersion": "2026-04-08",
         "dimensions": {
           "macroFiscal": {
             "score": 73,
@@ -5137,9 +5143,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -5232,7 +5238,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 74,
@@ -5269,7 +5275,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 84.37,
+            "score": 92.38,
             "weight": 0.15
           },
           "energy": {
@@ -5295,7 +5301,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 66.73,
+            "score": 72.01,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -5306,8 +5312,9 @@
       },
       "IN": {
         "countryCode": "IN",
-        "overallScore": 47.66,
+        "overallScore": 51.91,
         "formula": "pc",
+        "dataVersion": "2026-04-08",
         "dimensions": {
           "macroFiscal": {
             "score": 61,
@@ -5338,9 +5345,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -5470,7 +5477,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 50.74,
+            "score": 76,
             "weight": 0.15
           },
           "energy": {
@@ -5496,7 +5503,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 54.7,
+            "score": 61.89,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -5507,8 +5514,9 @@
       },
       "SY": {
         "countryCode": "SY",
-        "overallScore": 21.88,
+        "overallScore": 23.3,
         "formula": "pc",
+        "dataVersion": "2026-04-08",
         "dimensions": {
           "macroFiscal": {
             "score": 0,
@@ -5539,9 +5547,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -5634,7 +5642,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 5,
@@ -5671,7 +5679,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 78.21,
+            "score": 89.38,
             "weight": 0.15
           },
           "energy": {
@@ -5697,7 +5705,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 57.65,
+            "score": 64.38,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -5708,8 +5716,9 @@
       },
       "NR": {
         "countryCode": "NR",
-        "overallScore": 60.77,
+        "overallScore": 64.33,
         "formula": "pc",
+        "dataVersion": "2026-04-08",
         "dimensions": {
           "macroFiscal": {
             "score": 89,
@@ -5740,9 +5749,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -5835,7 +5844,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 75,
@@ -5872,7 +5881,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 47.53,
+            "score": 74.44,
             "weight": 0.15
           },
           "energy": {
@@ -5898,7 +5907,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 66.38,
+            "score": 71.72,
             "weight": 0.35
           },
           "recovery-capacity": {
@@ -5909,8 +5918,9 @@
       },
       "ER": {
         "countryCode": "ER",
-        "overallScore": 35.03,
+        "overallScore": 36.75,
         "formula": "pc",
+        "dataVersion": "2026-04-08",
         "dimensions": {
           "macroFiscal": {
             "score": 0,
@@ -5941,9 +5951,9 @@
             "imputationClass": ""
           },
           "cyberDigital": {
-            "score": 0,
-            "coverage": 0,
-            "observedWeight": 0,
+            "score": 100,
+            "coverage": 1,
+            "observedWeight": 1,
             "imputedWeight": 0,
             "imputationClass": ""
           },
@@ -6036,7 +6046,7 @@
             "coverage": 0.3,
             "observedWeight": 0,
             "imputedWeight": 1,
-            "imputationClass": "unmonitored"
+            "imputationClass": "source-failure"
           },
           "stateContinuity": {
             "score": 42,
@@ -6073,7 +6083,7 @@
             "weight": 0.17
           },
           "infrastructure": {
-            "score": 32.86,
+            "score": 57.27,
             "weight": 0.15
           },
           "energy": {
@@ -6099,7 +6109,7 @@
             "weight": 0.4
           },
           "live-shock-exposure": {
-            "score": 51.78,
+            "score": 58.58,
             "weight": 0.35
           },
           "recovery-capacity": {

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -8,6 +8,7 @@ import {
   failedDimensionsFromDatasets,
   readFailedDatasets,
   readStandaloneSourceFailureDimensions,
+  STANDALONE_SOURCE_META_MAX_STALE_MIN,
 } from './_source-failure';
 
 export type ResilienceDimensionId =
@@ -321,6 +322,15 @@ const RESILIENCE_SOCIAL_VELOCITY_KEY = 'intelligence:social:reddit:v1';
 const RESILIENCE_NEWS_THREAT_SUMMARY_KEY = 'news:threat:summary:v1';
 const RESILIENCE_ENERGY_PRICES_KEY = 'economic:energy:v1:all';
 const RESILIENCE_ENERGY_MIX_KEY_PREFIX = 'energy:mix:v1:';
+
+async function readDisplacementSummaryWithFallback(
+  reader: ResilienceSeedReader,
+): Promise<unknown | null> {
+  const currentYear = new Date().getFullYear();
+  const current = await reader(`${RESILIENCE_DISPLACEMENT_PREFIX}:${currentYear}`);
+  if (current != null) return current;
+  return reader(`${RESILIENCE_DISPLACEMENT_PREFIX}:${currentYear - 1}`);
+}
 
 const RESILIENCE_RECOVERY_FISCAL_SPACE_KEY = 'resilience:recovery:fiscal-space:v1';
 const RESILIENCE_RECOVERY_RESERVE_ADEQUACY_KEY = 'resilience:recovery:reserve-adequacy:v1';
@@ -658,6 +668,8 @@ const IMPUTATION_CLASS_TIE_BREAK: readonly ImputationClass[] = [
   'not-applicable',
 ];
 
+const MINUTE_MS = 60 * 1000;
+
 function weightedBlend(metrics: WeightedMetric[]): ResilienceDimensionScore {
   const totalWeight = metrics.reduce((sum, metric) => sum + metric.weight, 0);
   const available = metrics.filter((metric) => metric.score != null);
@@ -734,6 +746,16 @@ function weightedBlend(metrics: WeightedMetric[]): ResilienceDimensionScore {
     imputationClass,
     freshness: { lastObservedAtMs: 0, staleness: '' },
   };
+}
+
+function isSeedMetaPreflightUnhealthy(sourceKey: string, meta: unknown, nowMs = Date.now()): boolean {
+  if (!meta || typeof meta !== 'object') return true;
+  const status = (meta as { status?: unknown }).status;
+  if (Object.prototype.hasOwnProperty.call(meta, 'status') && status !== 'ok') return true;
+  const fetchedAt = Number((meta as { fetchedAt?: unknown }).fetchedAt);
+  if (!Number.isFinite(fetchedAt) || fetchedAt <= 0) return true;
+  const maxStaleMin = STANDALONE_SOURCE_META_MAX_STALE_MIN[resolveSeedMetaKey(sourceKey)];
+  return typeof maxStaleMin === 'number' && (nowMs - fetchedAt) > maxStaleMin * MINUTE_MS;
 }
 
 function extractMetric<T>(value: T | null | undefined, scorer: (item: T) => number | null): number | null {
@@ -987,6 +1009,14 @@ function isInWtoReporterSet(raw: unknown, countryCode: string): boolean {
   const reporters = (raw as { _reporterCountries?: string[] } | null)?._reporterCountries;
   if (!Array.isArray(reporters) || reporters.length === 0) return true;
   return reporters.includes(countryCode);
+}
+
+function hasArrayField(raw: unknown, field: string): boolean {
+  return raw != null && typeof raw === 'object' && Array.isArray((raw as Record<string, unknown>)[field]);
+}
+
+function hasNonEmptyArrayField(raw: unknown, field: string): boolean {
+  return hasArrayField(raw, field) && ((raw as Record<string, unknown>)[field] as unknown[]).length > 0;
 }
 
 export function summarizeOutages(raw: unknown, countryCode: string): { total: number; major: number; partial: number } {
@@ -1383,7 +1413,7 @@ export async function scoreFinancialSystemExposure(
     };
   }
 
-  // Preflight: verify the 3 required seed envelopes are published.
+  // Preflight: verify the 3 required seed envelopes are published and fresh.
   // `runSeed` (scripts/_seed-utils.mjs) STRIPS the trailing :v\d+ from the
   // data key when it writes seed-meta — so `economic:wb-external-debt:v1`
   // gets a freshness key of `seed-meta:economic:wb-external-debt`, NOT
@@ -1398,19 +1428,19 @@ export async function scoreFinancialSystemExposure(
     RESILIENCE_BIS_LBS_KEY,
     RESILIENCE_FATF_LISTING_KEY,
   ] as const;
-  const missing: string[] = [];
+  const unhealthy: string[] = [];
   for (const key of requiredSeedKeys) {
     const meta = await reader(resolveSeedMetaKey(key));
-    if (!meta) missing.push(key);
+    if (isSeedMetaPreflightUnhealthy(key, meta)) unhealthy.push(key);
   }
-  if (missing.length > 0) {
+  if (unhealthy.length > 0) {
     throw new ResilienceConfigurationError(
-      `RESILIENCE_FIN_SYS_EXPOSURE_ENABLED=true but required seed-meta absent for: ${missing.join(', ')}. ` +
+      `RESILIENCE_FIN_SYS_EXPOSURE_ENABLED=true but required seed-meta absent or unhealthy for: ${unhealthy.join(', ')}. ` +
         'Provision the macro bundle component seeders (seed-bis-lbs, seed-fatf-listing, ' +
         'seed-wb-external-debt) and confirm Redis populates BEFORE flipping the flag. ' +
         'Or set RESILIENCE_FIN_SYS_EXPOSURE_ENABLED=false to keep the dim dark. ' +
         'See plan 2026-04-25-004 §Fail-closed preflight.',
-      missing,
+      unhealthy,
     );
   }
 
@@ -1540,9 +1570,9 @@ export async function scoreCyberDigital(
   const gpsPenalty = gps.high * 3 + gps.medium;
 
   return weightedBlend([
-    { score: cyberRaw != null && cyber.weightedCount > 0 ? normalizeLowerBetter(cyber.weightedCount, 0, 25) : null, weight: 0.45 },
-    { score: outagesRaw != null && outagePenalty > 0 ? normalizeLowerBetter(outagePenalty, 0, 20) : null, weight: 0.35 },
-    { score: gpsRaw != null && gpsPenalty > 0 ? normalizeLowerBetter(gpsPenalty, 0, 20) : null, weight: 0.2 },
+    { score: hasNonEmptyArrayField(cyberRaw, 'threats') ? normalizeLowerBetter(cyber.weightedCount, 0, 25) : null, weight: 0.45 },
+    { score: hasNonEmptyArrayField(outagesRaw, 'outages') ? normalizeLowerBetter(outagePenalty, 0, 20) : null, weight: 0.35 },
+    { score: hasNonEmptyArrayField(gpsRaw, 'hexes') ? normalizeLowerBetter(gpsPenalty, 0, 20) : null, weight: 0.2 },
   ]);
 }
 
@@ -1810,7 +1840,7 @@ export async function scoreSocialCohesion(
 ): Promise<ResilienceDimensionScore> {
   const [staticRecord, displacementRaw, unrestRaw, imfLaborRaw] = await Promise.all([
     readStaticCountry(countryCode, reader),
-    reader(`${RESILIENCE_DISPLACEMENT_PREFIX}:${new Date().getFullYear()}`),
+    readDisplacementSummaryWithFallback(reader),
     reader(RESILIENCE_UNREST_KEY),
     reader(RESILIENCE_IMF_LABOR_KEY),
   ]);
@@ -1969,7 +1999,7 @@ export async function scoreBorderSecurity(
 ): Promise<ResilienceDimensionScore> {
   const [ucdpRaw, displacementRaw, imfLaborRaw] = await Promise.all([
     reader(RESILIENCE_UCDP_KEY),
-    reader(`${RESILIENCE_DISPLACEMENT_PREFIX}:${new Date().getFullYear()}`),
+    readDisplacementSummaryWithFallback(reader),
     reader(RESILIENCE_IMF_LABOR_KEY),
   ]);
   const ucdp = summarizeUcdp(ucdpRaw, countryCode);
@@ -2421,7 +2451,7 @@ export async function scoreStateContinuity(
   const [staticRecord, ucdpRaw, displacementRaw] = await Promise.all([
     readStaticCountry(countryCode, reader),
     reader(RESILIENCE_UCDP_KEY),
-    reader(`${RESILIENCE_DISPLACEMENT_PREFIX}:${new Date().getFullYear()}`),
+    readDisplacementSummaryWithFallback(reader),
   ]);
 
   const wgiValues = getStaticWgiValues(staticRecord);

--- a/tests/resilience-dimension-scorers.test.mts
+++ b/tests/resilience-dimension-scorers.test.mts
@@ -54,8 +54,6 @@ function assertOrdered(label: string, no: number, us: number, ye: number) {
 function cyberOnlyReader(threats: unknown[]): ResilienceSeedReader {
   return async (key: string): Promise<unknown | null> => {
     if (key === 'cyber:threats:v2') return { threats };
-    if (key === 'infra:outages:v1') return { outages: [] };
-    if (key === 'intelligence:gpsjam:v2') return { hexes: [] };
     return null;
   };
 }
@@ -440,16 +438,70 @@ describe('resilience dimension scorers', () => {
       `seed outage must not inflate coverage beyond ucdp weight, got ${score.coverage}`);
   });
 
-  it('scoreCyberDigital: country with zero threats in loaded feed gets null, not 100', async () => {
+  it('displacement-backed scorers fall back to previous-year summary when current-year key is absent', async () => {
+    const currentYear = new Date().getFullYear();
+    const currentKey = `displacement:summary:v1:${currentYear}`;
+    const previousKey = `displacement:summary:v1:${currentYear - 1}`;
+    const calls: string[] = [];
+    const reader = async (key: string): Promise<unknown | null> => {
+      calls.push(key);
+      if (key === currentKey) return null;
+      if (key === previousKey) {
+        return { summary: { countries: [{ code: 'FI', totalDisplaced: 100, hostTotal: 50 }] } };
+      }
+      if (key === 'conflict:ucdp-events:v1') return { events: [] };
+      if (key === 'unrest:events:v1') return { events: [] };
+      return null;
+    };
+
+    const social = await scoreSocialCohesion('FI', reader);
+    const border = await scoreBorderSecurity('FI', reader);
+    const continuity = await scoreStateContinuity('FI', reader);
+
+    assert.equal(calls.filter((key) => key === currentKey).length, 3, 'each displacement-backed scorer must try current-year key first');
+    assert.equal(calls.filter((key) => key === previousKey).length, 3, 'each displacement-backed scorer must fall back to previous-year key');
+    assert.ok(social.observedWeight > 0, `socialCohesion must consume previous-year displacement, got observedWeight=${social.observedWeight}`);
+    assert.ok(border.observedWeight > 0, `borderSecurity must consume previous-year displacement, got observedWeight=${border.observedWeight}`);
+    assert.ok(continuity.observedWeight > 0, `stateContinuity must consume previous-year displacement, got observedWeight=${continuity.observedWeight}`);
+  });
+
+  it('scoreCyberDigital: country with zero events in loaded feeds scores as observed quiet', async () => {
     const reader = async (key: string): Promise<unknown | null> => {
       if (key === 'cyber:threats:v2') return { threats: [{ country: 'United States', severity: 'CRITICALITY_LEVEL_HIGH' }] };
+      if (key === 'infra:outages:v1') return { outages: [{ countryCode: 'US', severity: 'OUTAGE_SEVERITY_PARTIAL' }] };
+      if (key === 'intelligence:gpsjam:v2') return { hexes: [{ country: 'US', level: 'high' }] };
+      return null;
+    };
+    const score = await scoreCyberDigital('FI', reader);
+    assert.equal(score.score, 100, 'zero events in loaded feeds must be a high-score observed absence');
+    assert.equal(score.coverage, 1, 'zero events in loaded feeds must contribute full observed coverage');
+    assert.equal(score.observedWeight, 1, 'zero events in loaded feeds must be observed, not imputed');
+  });
+
+  it('scoreCyberDigital: malformed non-null feeds do not score as observed quiet', async () => {
+    const reader = async (key: string): Promise<unknown | null> => {
+      if (key === 'cyber:threats:v2') return {};
+      if (key === 'infra:outages:v1') return { outages: null };
+      if (key === 'intelligence:gpsjam:v2') return { hexes: {} };
+      return null;
+    };
+    const score = await scoreCyberDigital('FI', reader);
+    assert.equal(score.score, 0, 'malformed non-null feeds must not be treated as zero-event observations');
+    assert.equal(score.coverage, 0, 'malformed non-null feeds must not contribute observed coverage');
+    assert.equal(score.observedWeight, 0, 'malformed non-null feeds must remain no-data');
+  });
+
+  it('scoreCyberDigital: globally empty feeds do not score every country as observed quiet', async () => {
+    const reader = async (key: string): Promise<unknown | null> => {
+      if (key === 'cyber:threats:v2') return { threats: [] };
       if (key === 'infra:outages:v1') return { outages: [] };
       if (key === 'intelligence:gpsjam:v2') return { hexes: [] };
       return null;
     };
     const score = await scoreCyberDigital('FI', reader);
-    assert.equal(score.score, 0, 'zero events in all three loaded feeds must yield score=0 (not 100)');
-    assert.equal(score.coverage, 0, 'zero events in all three loaded feeds must yield coverage=0');
+    assert.equal(score.score, 0, 'globally empty feeds must not score as all-country observed quiet');
+    assert.equal(score.coverage, 0, 'globally empty feeds must not contribute observed coverage');
+    assert.equal(score.observedWeight, 0, 'globally empty feeds must remain no-data');
   });
 
   it('scoreCyberDigital: country with real threats scores normally', async () => {
@@ -459,7 +511,7 @@ describe('resilience dimension scorers', () => {
         { country: 'Finland', severity: 'CRITICALITY_LEVEL_MEDIUM' },
       ] };
       if (key === 'infra:outages:v1') return { outages: [{ countryCode: 'FI', severity: 'OUTAGE_SEVERITY_PARTIAL' }] };
-      if (key === 'intelligence:gpsjam:v2') return { hexes: [] };
+      if (key === 'intelligence:gpsjam:v2') return { hexes: [{ country: 'US', level: 'high' }] };
       return null;
     };
     const score = await scoreCyberDigital('FI', reader);
@@ -501,7 +553,7 @@ describe('resilience dimension scorers', () => {
   });
 
   it('scoreCyberDigital: a same-snapshot burst floors at the cap, not at zero', async () => {
-    // cyberOnlyReader leaves outages/gps empty, so the dimension score IS the
+    // cyberOnlyReader leaves outages/gps null, so the dimension score IS the
     // cyber sub-score = normalizeLowerBetter(weightedCount, 0, 25). A burst is
     // capped at CYBER_SNAPSHOT_WEIGHT_CAP, so its score floors at a fixed,
     // cap-derived value rather than collapsing to 0 — which is what bounds the

--- a/tests/resilience-financial-system-exposure.test.mts
+++ b/tests/resilience-financial-system-exposure.test.mts
@@ -133,6 +133,58 @@ describe('scoreFinancialSystemExposure — fail-closed preflight', () => {
     );
   });
 
+  it('throws ResilienceConfigurationError when required seed-meta status is non-ok', async () => {
+    const reader: ResilienceSeedReader = async (key) => {
+      if (key === 'seed-meta:economic:wb-external-debt') return { fetchedAt: Date.now(), status: 'ok' };
+      if (key === 'seed-meta:economic:bis-lbs') return { fetchedAt: Date.now(), status: 'error' };
+      if (key === 'seed-meta:economic:fatf-listing') return { fetchedAt: Date.now(), status: 'ok' };
+      return null;
+    };
+    await assert.rejects(
+      () => scoreFinancialSystemExposure(TEST_ISO2, reader),
+      (err: unknown) => {
+        if (!(err instanceof ResilienceConfigurationError)) return false;
+        return err.missingKeys.includes('economic:bis-lbs:v1');
+      },
+      'must throw ResilienceConfigurationError naming the non-ok seed key',
+    );
+  });
+
+  it('throws ResilienceConfigurationError when required seed-meta status is explicitly null', async () => {
+    const reader: ResilienceSeedReader = async (key) => {
+      if (key === 'seed-meta:economic:wb-external-debt') return { fetchedAt: Date.now(), status: 'ok' };
+      if (key === 'seed-meta:economic:bis-lbs') return { fetchedAt: Date.now(), status: null };
+      if (key === 'seed-meta:economic:fatf-listing') return { fetchedAt: Date.now(), status: 'ok' };
+      return null;
+    };
+    await assert.rejects(
+      () => scoreFinancialSystemExposure(TEST_ISO2, reader),
+      (err: unknown) => {
+        if (!(err instanceof ResilienceConfigurationError)) return false;
+        return err.missingKeys.includes('economic:bis-lbs:v1');
+      },
+      'must reject explicitly present non-ok falsy seed-meta status',
+    );
+  });
+
+  it('throws ResilienceConfigurationError when required seed-meta is stale', async () => {
+    const staleFetchedAt = Date.now() - 90 * 24 * 60 * 60 * 1000;
+    const reader: ResilienceSeedReader = async (key) => {
+      if (key === 'seed-meta:economic:wb-external-debt') return { fetchedAt: Date.now(), status: 'ok' };
+      if (key === 'seed-meta:economic:bis-lbs') return { fetchedAt: Date.now(), status: 'ok' };
+      if (key === 'seed-meta:economic:fatf-listing') return { fetchedAt: staleFetchedAt, status: 'ok' };
+      return null;
+    };
+    await assert.rejects(
+      () => scoreFinancialSystemExposure(TEST_ISO2, reader),
+      (err: unknown) => {
+        if (!(err instanceof ResilienceConfigurationError)) return false;
+        return err.missingKeys.includes('economic:fatf-listing:v1');
+      },
+      'must throw ResilienceConfigurationError naming the stale seed key',
+    );
+  });
+
   it('ResilienceConfigurationError carries missingKeys array (not undefined) — two-arg constructor', async () => {
     const reader: ResilienceSeedReader = async () => null;
     try {


### PR DESCRIPTION
## Summary
- Fixes Country Resilience Index audit P2-3, P2-4, and P2-8 runtime scorer input issues.
- Adds current-year then previous-year displacement summary fallback for displacement-backed dimensions.
- Fails closed on missing, malformed, non-ok, or stale financialSystemExposure seed-meta before scoring.
- Treats valid zero-event cyber/outage/GPS feeds as observed quiet while keeping malformed non-null payloads as no-data.
- Refreshes the 2026 reference-edition manifest scores to match the corrected zero-event cyber semantics over the frozen Redis inputs.

## Validation
- `./node_modules/.bin/tsx --test tests/resilience-dimension-scorers.test.mts tests/resilience-financial-system-exposure.test.mts tests/resilience-reference-recompute.test.mts`
- `npm run typecheck:api`
- `git diff --check`
- Normal `git push` pre-push hook passed: typecheck, API typecheck, Convex typecheck, CJS syntax, Unicode safety, boundary lint, rate-limit policy lint, premium-fetch parity, edge bundle check, full unit suite, markdown/MDX lint, proto freshness, pro-test bundle freshness, and version sync.