### PR TITLE
Harden resilience stats numeric helpers

### DIFF
--- a/server/_shared/resilience-stats.ts
+++ b/server/_shared/resilience-stats.ts
@@ -17,10 +17,14 @@ const TREND_THRESHOLD = 0.005;
 const CHANGEPOINT_DEFAULT_THRESHOLD = 2.0;
 const Z_95 = 1.96;
 
+function finiteOrDefault(value: number | undefined, fallback = 0): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
 function linearRegression(values: number[]): { slope: number; intercept: number } {
   const count = values.length;
   if (count < 2) {
-    return { slope: 0, intercept: values[0] ?? 0 };
+    return { slope: 0, intercept: finiteOrDefault(values[0]) };
   }
 
   let sumX = 0;
@@ -29,7 +33,7 @@ function linearRegression(values: number[]): { slope: number; intercept: number 
   let sumX2 = 0;
 
   for (let index = 0; index < count; index += 1) {
-    const value = values[index] ?? 0;
+    const value = finiteOrDefault(values[index]);
     sumX += index;
     sumY += value;
     sumXY += index * value;
@@ -52,8 +56,8 @@ function rmse(actual: number[], forecast: number[]): number {
 
   let sumSquares = 0;
   for (let index = 0; index < count; index += 1) {
-    const actualValue = actual[index] ?? 0;
-    const forecastValue = forecast[index] ?? 0;
+    const actualValue = finiteOrDefault(actual[index]);
+    const forecastValue = finiteOrDefault(forecast[index]);
     sumSquares += (actualValue - forecastValue) ** 2;
   }
 
@@ -61,25 +65,29 @@ function rmse(actual: number[], forecast: number[]): number {
 }
 
 function clampScore(value: number): number {
+  if (!Number.isFinite(value)) return 0;
   return Math.max(0, Math.min(100, value));
 }
 
 export function round(value: number, digits = 2): number {
-  return Number(value.toFixed(digits));
+  if (!Number.isFinite(value)) return 0;
+  const safeDigits = Number.isFinite(digits) ? digits : 2;
+  return Number(value.toFixed(safeDigits));
 }
 
 export function minMaxNormalize(values: number[]): number[] {
   if (values.length === 0) return [];
 
-  const min = values.reduce((smallest, value) => (value < smallest ? value : smallest), Infinity);
-  const max = values.reduce((largest, value) => (value > largest ? value : largest), -Infinity);
+  const sanitized = values.map((value) => finiteOrDefault(value));
+  const min = sanitized.reduce((smallest, value) => (value < smallest ? value : smallest), Infinity);
+  const max = sanitized.reduce((largest, value) => (value > largest ? value : largest), -Infinity);
   const range = max - min;
 
   if (range === 0) {
     return values.map(() => 0.5);
   }
 
-  return values.map((value) => (value - min) / range);
+  return sanitized.map((value) => (value - min) / range);
 }
 
 export function cronbachAlpha(items: number[][]): number {
@@ -90,13 +98,13 @@ export function cronbachAlpha(items: number[][]): number {
   const itemVariances: number[] = [];
 
   for (let column = 0; column < itemCount; column += 1) {
-    const sample = items.map((row) => row[column] ?? 0);
+    const sample = items.map((row) => finiteOrDefault(row[column]));
     const mean = sample.reduce((sum, value) => sum + value, 0) / observationCount;
     const variance = sample.reduce((sum, value) => sum + (value - mean) ** 2, 0) / (observationCount - 1);
     itemVariances.push(variance);
   }
 
-  const totalScores = items.map((row) => row.reduce((sum, value) => sum + value, 0));
+  const totalScores = items.map((row) => row.reduce((sum, value) => sum + finiteOrDefault(value), 0));
   const totalMean = totalScores.reduce((sum, value) => sum + value, 0) / observationCount;
   const totalVariance = totalScores.reduce((sum, value) => sum + (value - totalMean) ** 2, 0) / (observationCount - 1);
 
@@ -108,6 +116,7 @@ export function cronbachAlpha(items: number[][]): number {
 
 export function detectTrend(values: number[]): ResilienceTrendDirection {
   if (values.length < 3) return 'stable';
+  if (values.some((value) => !Number.isFinite(value))) return 'stable';
 
   const { slope } = linearRegression(values);
   const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
@@ -120,6 +129,7 @@ export function detectTrend(values: number[]): ResilienceTrendDirection {
 
 export function detectChangepoints(values: number[], threshold = CHANGEPOINT_DEFAULT_THRESHOLD): number[] {
   if (values.length < 6) return [];
+  if (values.some((value) => !Number.isFinite(value))) return [];
 
   const mean = values.reduce((sum, value) => sum + value, 0) / values.length;
   const variance = values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / (values.length - 1);
@@ -150,11 +160,13 @@ export function detectChangepoints(values: number[], threshold = CHANGEPOINT_DEF
 export function exponentialSmoothing(values: number[], alpha = 0.3): number[] {
   if (values.length === 0) return [];
 
-  const smoothed = [values[0] ?? 0];
+  const sanitized = values.map((value) => finiteOrDefault(value));
+  const smoothingAlpha = Number.isFinite(alpha) ? alpha : 0.3;
+  const smoothed = [sanitized[0] ?? 0];
   for (let index = 1; index < values.length; index += 1) {
-    const current = values[index] ?? 0;
+    const current = sanitized[index] ?? 0;
     const previous = smoothed[index - 1] ?? current;
-    smoothed.push(alpha * current + (1 - alpha) * previous);
+    smoothed.push(smoothingAlpha * current + (1 - smoothingAlpha) * previous);
   }
 
   return smoothed;
@@ -165,8 +177,9 @@ export function nrcForecast(
   horizonDays: number,
   alpha = 0.3,
 ): ResilienceForecastResult {
-  if (history.length < 3) {
-    const lastValue = clampScore(history[history.length - 1] ?? 50);
+  const finiteHistory = history.filter((value) => Number.isFinite(value));
+  if (finiteHistory.length < 3) {
+    const lastValue = clampScore(finiteHistory[finiteHistory.length - 1] ?? 50);
     return {
       values: Array.from({ length: horizonDays }, () => lastValue),
       confidenceIntervals: Array.from({ length: horizonDays }, () => ({
@@ -179,10 +192,10 @@ export function nrcForecast(
     };
   }
 
-  const smoothed = exponentialSmoothing(history, alpha);
-  const { slope } = linearRegression(history);
-  const baseline = smoothed[smoothed.length - 1] ?? history[history.length - 1] ?? 50;
-  const modelError = rmse(history, smoothed);
+  const smoothed = exponentialSmoothing(finiteHistory, alpha);
+  const { slope } = linearRegression(finiteHistory);
+  const baseline = smoothed[smoothed.length - 1] ?? finiteHistory[finiteHistory.length - 1] ?? 50;
+  const modelError = rmse(finiteHistory, smoothed);
   const values: number[] = [];
   const confidenceIntervals: ResilienceConfidenceInterval[] = [];
 
@@ -201,7 +214,7 @@ export function nrcForecast(
   }
 
   const lastForecast = values[values.length - 1] ?? baseline;
-  const lastActual = history[history.length - 1] ?? baseline;
+  const lastActual = finiteHistory[finiteHistory.length - 1] ?? baseline;
   const probabilityUp = lastForecast > lastActual
     ? Math.min(0.95, 0.5 + (lastForecast - lastActual) * 0.05)
     : Math.max(0.05, 0.5 - (lastActual - lastForecast) * 0.05);

--- a/tests/resilience-stats.test.mts
+++ b/tests/resilience-stats.test.mts
@@ -8,6 +8,7 @@ import {
   exponentialSmoothing,
   minMaxNormalize,
   nrcForecast,
+  round,
 } from '../server/_shared/resilience-stats';
 
 test('cronbachAlpha returns the expected coefficient for a known matrix', () => {
@@ -45,6 +46,20 @@ test('detectTrend treats fewer than 3 values as stable', () => {
   assert.equal(detectTrend([10, 15]), 'stable');
 });
 
+test('round returns a finite safe default for non-finite values', () => {
+  assert.equal(round(12.345, 2), 12.35);
+  assert.equal(round(12.345, Number.NaN), 12.35);
+  assert.equal(round(Number.NaN), 0);
+  assert.equal(round(Number.POSITIVE_INFINITY), 0);
+  assert.equal(round(Number.NEGATIVE_INFINITY), 0);
+});
+
+test('detectTrend returns stable when a series contains non-finite values', () => {
+  assert.equal(detectTrend([10, 20, Number.NaN, 40]), 'stable');
+  assert.equal(detectTrend([10, Number.POSITIVE_INFINITY, 30, 40]), 'stable');
+  assert.equal(detectTrend([40, 30, Number.NEGATIVE_INFINITY, 10]), 'stable');
+});
+
 test('detectChangepoints finds a structural break in a bimodal series', () => {
   const changepoints = detectChangepoints([10, 11, 9, 10, 10, 50, 52, 48, 51, 49]);
   assert.ok(changepoints.some((index) => index >= 5), `expected changepoint at the break, got ${changepoints}`);
@@ -55,16 +70,31 @@ test('detectChangepoints returns [] for constant and short series', () => {
   assert.deepEqual(detectChangepoints([1, 2, 3, 4, 5]), []);
 });
 
+test('detectChangepoints returns [] when a series contains non-finite values', () => {
+  assert.deepEqual(detectChangepoints([10, 11, 9, Number.NaN, 10, 50, 52, 48]), []);
+  assert.deepEqual(detectChangepoints([10, 11, 9, Number.POSITIVE_INFINITY, 10, 50, 52, 48]), []);
+});
+
 test('minMaxNormalize handles empty input, identical values, and negatives', () => {
   assert.deepEqual(minMaxNormalize([]), []);
   assert.deepEqual(minMaxNormalize([7, 7, 7]), [0.5, 0.5, 0.5]);
   assert.deepEqual(minMaxNormalize([-10, 0, 10]), [0, 0.5, 1]);
 });
 
+test('minMaxNormalize returns finite values for non-finite input', () => {
+  assert.deepEqual(minMaxNormalize([Number.NaN, 0, 10]), [0, 0, 1]);
+  assert.deepEqual(minMaxNormalize([Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]), [0.5, 0.5]);
+});
+
 test('exponentialSmoothing smooths a noisy series without changing length', () => {
   const result = exponentialSmoothing([10, 20, 15, 25], 0.5);
   assert.equal(result.length, 4);
   assert.deepEqual(result.map((value) => Number(value.toFixed(2))), [10, 15, 15, 20]);
+});
+
+test('exponentialSmoothing returns finite values for non-finite input', () => {
+  const result = exponentialSmoothing([10, Number.NaN, 20, Number.POSITIVE_INFINITY], 0.5);
+  assert.deepEqual(result.map((value) => Number(value.toFixed(2))), [10, 5, 12.5, 6.25]);
 });
 
 test('nrcForecast returns the requested horizon with bounded confidence intervals', () => {
@@ -91,6 +121,19 @@ test('nrcForecast falls back to a flat 50/50 outlook for short history', () => {
     { lower: 79.2, upper: 96.8, level: 95 },
     { lower: 79.2, upper: 96.8, level: 95 },
     { lower: 79.2, upper: 96.8, level: 95 },
+  ]);
+  assert.equal(forecast.probabilityUp, 0.5);
+  assert.equal(forecast.probabilityDown, 0.5);
+});
+
+test('nrcForecast does not emit non-finite forecast values from non-finite history', () => {
+  const forecast = nrcForecast([Number.NaN, Number.POSITIVE_INFINITY], 3);
+
+  assert.deepEqual(forecast.values, [50, 50, 50]);
+  assert.deepEqual(forecast.confidenceIntervals, [
+    { lower: 45, upper: 55, level: 95 },
+    { lower: 45, upper: 55, level: 95 },
+    { lower: 45, upper: 55, level: 95 },
   ]);
   assert.equal(forecast.probabilityUp, 0.5);
   assert.equal(forecast.probabilityDown, 0.5);


### PR DESCRIPTION
## Summary
- Harden resilience stats helpers so NaN/Infinity cannot leak through rounding, trend, changepoint, normalization, smoothing, or forecast output
- Preserve finite-number behavior while returning conservative safe defaults for invalid numeric inputs
- Add focused regression coverage for non-finite stats inputs

## Validation
- `./node_modules/.bin/tsx --test tests/resilience-stats.test.mts`
- `npm run typecheck:api`
- `git diff --check`
- Pre-push hook completed successfully during `git push -u origin codex/resilience-stats-numeric-hardening`