### PR TITLE
fix(resilience): derive frozen ranking dimension count

### DIFF
--- a/scripts/freeze-resilience-ranking.mjs
+++ b/scripts/freeze-resilience-ranking.mjs
@@ -15,31 +15,34 @@
 
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { execSync } from 'node:child_process';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const REPO_ROOT = path.resolve(__dirname, '..');
+const RESILIENCE_SCORER_PATH = path.join(
+  REPO_ROOT,
+  'server',
+  'worldmonitor',
+  'resilience',
+  'v1',
+  '_dimension-scorers.ts',
+);
 
 const API_BASE = (process.env.API_BASE || '').replace(/\/$/, '');
-if (!API_BASE) {
-  console.error('[freeze-resilience-ranking] API_BASE env var required (e.g. https://api.worldmonitor.app)');
-  process.exit(2);
-}
-
-const API_ORIGIN = new URL(API_BASE).origin;
-const RANKING_BASE_URL = `${API_BASE}/api/resilience/v1/get-resilience-ranking`;
-const SCORE_URL = `${API_BASE}/api/resilience/v1/get-resilience-score`;
-const SESSION_URL = `${API_BASE}/api/wm-session`;
+const API_ORIGIN = API_BASE ? new URL(API_BASE).origin : '';
+const RANKING_BASE_URL = API_BASE ? `${API_BASE}/api/resilience/v1/get-resilience-ranking` : '';
+const SCORE_URL = API_BASE ? `${API_BASE}/api/resilience/v1/get-resilience-score` : '';
+const SESSION_URL = API_BASE ? `${API_BASE}/api/wm-session` : '';
 const USER_AGENT = process.env.USER_AGENT
   || 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36';
 const FORCE_RANKING_REFRESH = (process.env.RESILIENCE_RANKING_REFRESH ?? '1').toLowerCase() !== 'false';
-const RANKING_URL = (() => {
+const RANKING_URL = API_BASE ? (() => {
   const url = new URL(RANKING_BASE_URL);
   if (FORCE_RANKING_REFRESH) url.searchParams.set('refresh', '1');
   return url.toString();
-})();
+})() : '';
 const METHODOLOGY_FORMULA =
   process.env.RESILIENCE_RANKING_METHODOLOGY_FORMULA || 'pillar-combined-penalized-v1';
 const FORMULA_CHECK_COUNTRIES = (process.env.RESILIENCE_RANKING_FORMULA_CHECK_COUNTRIES || 'NO,US,YE')
@@ -91,13 +94,6 @@ if (FORMULA_CHECK_COUNTRIES.length === 0) {
   process.exit(2);
 }
 
-if (FORCE_RANKING_REFRESH && !process.env.WORLDMONITOR_API_KEY) {
-  console.error(
-    '[freeze-resilience-ranking] WORLDMONITOR_API_KEY is required when RESILIENCE_RANKING_REFRESH is enabled; set RESILIENCE_RANKING_REFRESH=false to capture the cached public ranking instead',
-  );
-  process.exit(2);
-}
-
 function commitSha() {
   try {
     return execSync('git rev-parse HEAD', { cwd: REPO_ROOT, stdio: ['ignore', 'pipe', 'ignore'] })
@@ -105,6 +101,61 @@ function commitSha() {
   } catch {
     return 'unknown';
   }
+}
+
+function getExportedStringCollection(sourceText, exportName) {
+  const declarationRe = new RegExp(
+    `export\\s+const\\s+${exportName}\\b[\\s\\S]*?=\\s*(?:new\\s+Set\\s*\\()?\\s*\\[([\\s\\S]*?)\\]\\s*\\)?\\s*;`,
+  );
+  const match = sourceText.match(declarationRe);
+  if (!match) {
+    throw new Error(`Could not find exported ${exportName} in ${RESILIENCE_SCORER_PATH}`);
+  }
+
+  const arrayBody = match[1]
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/[^\n]*/g, '');
+  const values = [...arrayBody.matchAll(/['"]([^'"]+)['"]/g)].map((entry) => entry[1]);
+  if (values.length === 0) {
+    throw new Error(`${exportName} must contain at least one string literal`);
+  }
+
+  return values;
+}
+
+export function computeResilienceMethodologyMetadataFromSource(sourceText) {
+  const domainOrder = getExportedStringCollection(sourceText, 'RESILIENCE_DOMAIN_ORDER');
+  const dimensionOrder = getExportedStringCollection(sourceText, 'RESILIENCE_DIMENSION_ORDER');
+  const retiredDimensions = new Set(getExportedStringCollection(sourceText, 'RESILIENCE_RETIRED_DIMENSIONS'));
+  const activeDimensionCount = dimensionOrder.filter((dimensionId) => !retiredDimensions.has(dimensionId)).length;
+
+  if (activeDimensionCount <= 0) {
+    throw new Error(`Derived invalid active dimension count: ${activeDimensionCount}`);
+  }
+
+  return {
+    domainCount: domainOrder.length,
+    serializedDimensionCount: dimensionOrder.length,
+    retiredDimensionCount: retiredDimensions.size,
+    activeDimensionCount,
+  };
+}
+
+async function loadResilienceMethodologyMetadata() {
+  const sourceText = await fs.readFile(RESILIENCE_SCORER_PATH, 'utf8');
+  return computeResilienceMethodologyMetadataFromSource(sourceText);
+}
+
+export function buildSnapshotMethodology(methodologyConfig, methodologyMetadata) {
+  return {
+    ...methodologyConfig,
+    domainCount: methodologyMetadata.domainCount,
+    dimensionCount: methodologyMetadata.activeDimensionCount,
+    pillarCount: 3,
+    coverageLabel:
+      `Mean dimension coverage (avg of the ${methodologyMetadata.activeDimensionCount} per-dimension coverage values). Labelled 'Dimension coverage' in publications to avoid the ambiguity of 'Data coverage'.`,
+    greyOutThreshold: 0.40,
+  };
 }
 
 async function loadCountryNameMap() {
@@ -330,7 +381,19 @@ function enrichItems(items, nameMap, startRank) {
 }
 
 async function main() {
+  if (!API_BASE) {
+    console.error('[freeze-resilience-ranking] API_BASE env var required (e.g. https://api.worldmonitor.app)');
+    process.exit(2);
+  }
+  if (FORCE_RANKING_REFRESH && !process.env.WORLDMONITOR_API_KEY) {
+    console.error(
+      '[freeze-resilience-ranking] WORLDMONITOR_API_KEY is required when RESILIENCE_RANKING_REFRESH is enabled; set RESILIENCE_RANKING_REFRESH=false to capture the cached public ranking instead',
+    );
+    process.exit(2);
+  }
+
   const nameMap = await loadCountryNameMap();
+  const methodologyMetadata = await loadResilienceMethodologyMetadata();
   const headers = await buildAuthHeaders();
   const formulaCheck = await verifyDeclaredFormula(headers);
   const ranking = await fetchRanking(headers);
@@ -349,15 +412,10 @@ async function main() {
     schemaVersion: '2.0',
     methodologyFormula: METHODOLOGY_FORMULA,
     formulaVerification,
-    methodology: {
-      ...METHODOLOGY_BY_FORMULA[METHODOLOGY_FORMULA],
-      domainCount: 6,
-      dimensionCount: 19,
-      pillarCount: 3,
-      coverageLabel:
-        "Mean dimension coverage (avg of the 19 per-dimension coverage values). Labelled 'Dimension coverage' in publications to avoid the ambiguity of 'Data coverage'.",
-      greyOutThreshold: 0.40,
-    },
+    methodology: buildSnapshotMethodology(
+      METHODOLOGY_BY_FORMULA[METHODOLOGY_FORMULA],
+      methodologyMetadata,
+    ),
     totals: {
       rankedCountries: ranked.length,
       greyedOutCount: greyedOut.length,
@@ -378,7 +436,9 @@ async function main() {
   console.log(`[freeze-resilience-ranking] items=${ranked.length} greyedOut=${greyedOut.length} commit=${snapshot.commitSha.slice(0, 10)}`);
 }
 
-main().catch((err) => {
-  console.error('[freeze-resilience-ranking] failed:', err);
-  process.exit(1);
-});
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error('[freeze-resilience-ranking] failed:', err);
+    process.exit(1);
+  });
+}

--- a/tests/freeze-resilience-ranking-metadata-parity.test.mts
+++ b/tests/freeze-resilience-ranking-metadata-parity.test.mts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+
+import {
+  RESILIENCE_DIMENSION_ORDER,
+  RESILIENCE_DOMAIN_ORDER,
+  RESILIENCE_RETIRED_DIMENSIONS,
+} from '../server/worldmonitor/resilience/v1/_dimension-scorers.ts';
+import { computeResilienceMethodologyMetadataFromSource } from '../scripts/freeze-resilience-ranking.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SCORER_PATH = resolve(here, '../server/worldmonitor/resilience/v1/_dimension-scorers.ts');
+const sourceText = readFileSync(SCORER_PATH, 'utf8');
+
+describe('freeze-resilience-ranking methodology parser parity', () => {
+  it('matches the runtime scorer registries used by the resilience scorer', () => {
+    const expectedActiveDimensionCount = RESILIENCE_DIMENSION_ORDER
+      .filter((dimensionId) => !RESILIENCE_RETIRED_DIMENSIONS.has(dimensionId))
+      .length;
+
+    assert.deepEqual(computeResilienceMethodologyMetadataFromSource(sourceText), {
+      domainCount: RESILIENCE_DOMAIN_ORDER.length,
+      serializedDimensionCount: RESILIENCE_DIMENSION_ORDER.length,
+      retiredDimensionCount: RESILIENCE_RETIRED_DIMENSIONS.size,
+      activeDimensionCount: expectedActiveDimensionCount,
+    });
+  });
+});

--- a/tests/freeze-resilience-ranking-metadata.test.mjs
+++ b/tests/freeze-resilience-ranking-metadata.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+
+import {
+  buildSnapshotMethodology,
+  computeResilienceMethodologyMetadataFromSource,
+} from '../scripts/freeze-resilience-ranking.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SCORER_PATH = resolve(here, '../server/worldmonitor/resilience/v1/_dimension-scorers.ts');
+const sourceText = readFileSync(SCORER_PATH, 'utf8');
+
+describe('freeze-resilience-ranking methodology metadata', () => {
+  it('derives the active dimension count from the scorer registries', () => {
+    const metadata = computeResilienceMethodologyMetadataFromSource(sourceText);
+
+    assert.equal(metadata.domainCount, 6);
+    assert.equal(metadata.serializedDimensionCount, 22);
+    assert.equal(metadata.retiredDimensionCount, 2);
+    assert.equal(metadata.activeDimensionCount, 20);
+  });
+
+  it('builds frozen snapshot methodology with the live active dimension count', () => {
+    const metadata = computeResilienceMethodologyMetadataFromSource(sourceText);
+    const methodology = buildSnapshotMethodology(
+      { overallScoreFormula: 'test formula' },
+      metadata,
+    );
+
+    assert.equal(methodology.dimensionCount, metadata.activeDimensionCount);
+    assert.match(methodology.coverageLabel, /20 per-dimension coverage values/);
+  });
+});

--- a/tests/resilience-ranking-snapshot.test.mts
+++ b/tests/resilience-ranking-snapshot.test.mts
@@ -4,6 +4,12 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
 
+import {
+  RESILIENCE_DIMENSION_ORDER,
+  RESILIENCE_DOMAIN_ORDER,
+  RESILIENCE_RETIRED_DIMENSIONS,
+} from '../server/worldmonitor/resilience/v1/_dimension-scorers.ts';
+
 // Regression-verifies the frozen resilience-ranking snapshots under
 // docs/snapshots/. Two shapes are supported:
 //
@@ -32,8 +38,10 @@ const SNAPSHOT_DIR = path.join(REPO_ROOT, 'docs', 'snapshots');
 const HIGH_BAND_ANCHORS = new Set(['NO', 'CH', 'DK', 'IS', 'FI', 'SE', 'NZ']);
 const LOW_BAND_ANCHORS = new Set(['YE', 'SO', 'SD', 'CD']);
 const POST_PILLAR_COMBINE_CAPTURE_DATE = '2026-05-28';
+const ACTIVE_DIMENSION_COUNT_FIX_DATE = '2026-06-01';
 const MIN_FULL_UNIVERSE_RANKED_COUNTRIES = 160;
 const MIN_FULL_UNIVERSE_TOTAL_COUNTRIES = 190;
+const CURRENT_ACTIVE_DIMENSION_COUNT = RESILIENCE_DIMENSION_ORDER.length - RESILIENCE_RETIRED_DIMENSIONS.size;
 
 const METHODOLOGY_BANDS: Record<string, { highFloor: number; lowCeiling: number }> = {
   'domain-weighted-6d': { highFloor: 70, lowCeiling: 45 },
@@ -273,9 +281,17 @@ describe('resilience-ranking snapshots', () => {
         assert.equal(snapshot.schemaVersion, '2.0');
       });
 
-      it('methodology pins the 6-domain / 19-dimension / 3-pillar shape', () => {
-        assert.equal(snapshot.methodology.domainCount, 6);
-        assert.equal(snapshot.methodology.dimensionCount, 19);
+      it('methodology pins the domain / active-dimension / pillar shape', () => {
+        assert.equal(snapshot.methodology.domainCount, RESILIENCE_DOMAIN_ORDER.length);
+        if (snapshot.capturedAt >= ACTIVE_DIMENSION_COUNT_FIX_DATE) {
+          assert.equal(snapshot.methodology.dimensionCount, CURRENT_ACTIVE_DIMENSION_COUNT);
+        } else {
+          assert.ok(
+            snapshot.methodology.dimensionCount === 19 ||
+              snapshot.methodology.dimensionCount === CURRENT_ACTIVE_DIMENSION_COUNT,
+            `historical snapshot dimensionCount must be the legacy 19 or current active count ${CURRENT_ACTIVE_DIMENSION_COUNT}, got ${snapshot.methodology.dimensionCount}`,
+          );
+        }
         assert.equal(snapshot.methodology.pillarCount, 3);
         assert.equal(snapshot.methodology.greyOutThreshold, 0.40);
       });


### PR DESCRIPTION
## Summary
- derive frozen ranking methodology `dimensionCount` from the scorer dimension registries instead of a literal 19
- update the generated coverage label to use the derived active dimension count
- add focused regression coverage for scorer metadata and post-fix frozen ranking snapshots

## Validation
- `node --test tests/freeze-resilience-ranking-metadata.test.mjs`
- `node --check scripts/freeze-resilience-ranking.mjs`
- `git diff --check`
- pre-push hook passed during `git push -u origin codex/p3-resilience-dimension-count`