### PR TITLE
Fix Route Explorer resilience confidence display

### DIFF
--- a/src/components/RouteExplorer/RouteExplorer.ts
+++ b/src/components/RouteExplorer/RouteExplorer.ts
@@ -258,7 +258,8 @@ export class RouteExplorer {
       const { getResilienceScore } = await import('@/services/resilience');
       const res = await getResilienceScore(iso2);
       if (!this.isOpen || gen !== this.generationId) return;
-      this.leftRail.updateResilience(res.overallScore ?? null);
+      this.leftRail.updateResilience(res);
+      this.impactTab.updateResilience(res);
     } catch {
       if (gen !== this.generationId) return;
       this.leftRail.updateResilience(null);
@@ -275,9 +276,6 @@ export class RouteExplorer {
       this.leftRail.updateDependencyFlags(data.dependencyFlags);
       if (data.comtradeSource === 'bilateral-hs4') {
         this.trackEvent('route-explorer:impact-viewed', { toIso2, hs2 });
-      }
-      if (data.resilienceScore > 0) {
-        this.leftRail.updateResilience(data.resilienceScore);
       }
       if (this.state.tab === 4) this.showActiveTab();
     } catch {

--- a/src/components/RouteExplorer/RouteExplorer.ts
+++ b/src/components/RouteExplorer/RouteExplorer.ts
@@ -263,6 +263,7 @@ export class RouteExplorer {
     } catch {
       if (gen !== this.generationId) return;
       this.leftRail.updateResilience(null);
+      this.impactTab.updateResilience(null);
     }
   }
 

--- a/src/components/RouteExplorer/components/LeftRail.ts
+++ b/src/components/RouteExplorer/components/LeftRail.ts
@@ -9,6 +9,11 @@
 
 import type { GetRouteExplorerLaneResponse, DependencyFlag } from '@/generated/server/worldmonitor/supply_chain/v1/service_server';
 import {
+  formatResilienceConfidence,
+  formatResilienceScoreInterval,
+} from '@/components/resilience-widget-utils';
+import type { ResilienceScoreResponse } from '@/services/resilience';
+import {
   formatTransitRange,
   formatFreightRange,
   formatDisruptionScore,
@@ -22,7 +27,7 @@ import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 
 export class LeftRail {
   public readonly element: HTMLElement;
-  private resilienceScore: number | null = null;
+  private resilience: ResilienceScoreResponse | null = null;
 
   constructor() {
     this.element = document.createElement('aside');
@@ -32,7 +37,7 @@ export class LeftRail {
   }
 
   public updateLane(data: GetRouteExplorerLaneResponse | null, mode?: 'loading' | 'error' | 'gate'): void {
-    this.resilienceScore = null;
+    this.resilience = null;
     if (mode === 'loading') { this.renderLoading(); return; }
     if (mode === 'error') { this.renderError(); return; }
     if (mode === 'gate') { this.renderGate(); return; }
@@ -40,12 +45,12 @@ export class LeftRail {
     this.renderSummary(data);
   }
 
-  public updateResilience(score: number | null): void {
-    this.resilienceScore = score;
+  public updateResilience(resilience: ResilienceScoreResponse | null): void {
+    this.resilience = resilience;
     const el = this.element.querySelector('.re-leftrail__resilience-value');
-    if (el) {
-      el.textContent = score !== null ? `${Math.round(score)}/100` : '\u2014';
-    }
+    if (el) el.textContent = LeftRail.formatResilienceScore(resilience);
+    const metaEl = this.element.querySelector('.re-leftrail__resilience-meta');
+    if (metaEl) setTrustedHtml(metaEl, trustedHtml(LeftRail.renderResilienceMeta(resilience), "legacy direct innerHTML migration"));
   }
 
   private renderPlaceholder(): void {
@@ -88,10 +93,34 @@ export class LeftRail {
     setTrustedHtml(el, trustedHtml(`<h3 class="re-leftrail__title">Dependency Flags</h3><div class="re-leftrail__flags">${flagHtml}</div>`, "legacy direct innerHTML migration"));
   }
 
+  private static formatResilienceScore(resilience: ResilienceScoreResponse | null): string {
+    const score = resilience?.overallScore;
+    return typeof score === 'number' && Number.isFinite(score) && score > 0
+      ? `${Math.round(score)}/100`
+      : '\u2014';
+  }
+
+  private static renderResilienceMeta(resilience: ResilienceScoreResponse | null): string {
+    if (!resilience) return '';
+    const score = resilience.overallScore;
+    if (typeof score !== 'number' || !Number.isFinite(score) || score <= 0) {
+      return '<span class="re-resilience-confidence re-resilience-confidence--low">No scored resilience data</span>';
+    }
+    const confidence = formatResilienceConfidence(resilience);
+    const interval = formatResilienceScoreInterval(resilience.scoreInterval);
+    return [
+      `<span class="re-resilience-confidence${resilience.lowConfidence ? ' re-resilience-confidence--low' : ''}">${escapeHtml(confidence)}</span>`,
+      ...(interval
+        ? [`<span class="re-resilience-interval" title="${escapeHtml(interval.title)}">${escapeHtml(interval.label)}</span>`]
+        : []),
+    ].join('');
+  }
+
   private renderSummary(data: GetRouteExplorerLaneResponse): void {
     const riskCls = warRiskTierClass(data.warRiskTier);
     const disruptCls = disruptionScoreClass(data.disruptionScore);
-    const resValue = this.resilienceScore !== null ? `${Math.round(this.resilienceScore)}/100` : '\u2014';
+    const resValue = LeftRail.formatResilienceScore(this.resilience);
+    const resMeta = LeftRail.renderResilienceMeta(this.resilience);
 
     setTrustedHtml(this.element, trustedHtml([
       '<div class="re-leftrail__card">',
@@ -119,6 +148,7 @@ export class LeftRail {
       `    <span class="re-leftrail__label">${escapeHtml(data.toIso2)} score</span>`,
       `    <span class="re-leftrail__value re-leftrail__resilience-value">${resValue}</span>`,
       '  </div>',
+      `  <div class="re-leftrail__resilience-meta">${resMeta}</div>`,
       '</div>',
       '<div class="re-leftrail__card re-leftrail__card--flags">',
       '  <h3 class="re-leftrail__title">Dependency Flags</h3>',

--- a/src/components/RouteExplorer/components/LeftRail.ts
+++ b/src/components/RouteExplorer/components/LeftRail.ts
@@ -95,15 +95,17 @@ export class LeftRail {
 
   private static formatResilienceScore(resilience: ResilienceScoreResponse | null): string {
     const score = resilience?.overallScore;
-    return typeof score === 'number' && Number.isFinite(score) && score > 0
-      ? `${Math.round(score)}/100`
+    const rounded = typeof score === 'number' && Number.isFinite(score) ? Math.round(score) : 0;
+    return rounded > 0
+      ? `${rounded}/100`
       : '\u2014';
   }
 
   private static renderResilienceMeta(resilience: ResilienceScoreResponse | null): string {
     if (!resilience) return '';
     const score = resilience.overallScore;
-    if (typeof score !== 'number' || !Number.isFinite(score) || score <= 0) {
+    const rounded = typeof score === 'number' && Number.isFinite(score) ? Math.round(score) : 0;
+    if (rounded <= 0) {
       return '<span class="re-resilience-confidence re-resilience-confidence--low">No scored resilience data</span>';
     }
     const confidence = formatResilienceConfidence(resilience);

--- a/src/components/RouteExplorer/tabs/CountryImpactTab.ts
+++ b/src/components/RouteExplorer/tabs/CountryImpactTab.ts
@@ -11,6 +11,11 @@ import type {
   GetRouteImpactResponse,
   StrategicProduct,
 } from '@/generated/server/worldmonitor/supply_chain/v1/service_server';
+import {
+  formatResilienceConfidence,
+  formatResilienceScoreInterval,
+} from '@/components/resilience-widget-utils';
+import type { ResilienceScoreResponse } from '@/services/resilience';
 import { escapeHtml } from './route-utils';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 
@@ -40,6 +45,8 @@ const FLAG_LABELS: Record<string, string> = {
 export class CountryImpactTab {
   public readonly element: HTMLDivElement;
   private opts: CountryImpactTabOptions;
+  private data: GetRouteImpactResponse | null = null;
+  private resilience: ResilienceScoreResponse | null = null;
 
   constructor(opts: CountryImpactTabOptions = {}) {
     this.opts = opts;
@@ -50,11 +57,20 @@ export class CountryImpactTab {
   }
 
   public update(data: GetRouteImpactResponse | null): void {
+    this.data = data;
+    if (!data) this.resilience = null;
     if (!data) { this.renderPlaceholder(); return; }
     if (data.comtradeSource === 'missing') { this.renderMissing(); return; }
     if (data.comtradeSource === 'empty') { this.renderEmpty(); return; }
     if (data.comtradeSource === 'lazy') { this.renderLazy(); return; }
     this.renderData(data);
+  }
+
+  public updateResilience(resilience: ResilienceScoreResponse | null): void {
+    this.resilience = resilience;
+    if (this.data && this.data.comtradeSource !== 'missing' && this.data.comtradeSource !== 'empty' && this.data.comtradeSource !== 'lazy') {
+      this.renderData(this.data);
+    }
   }
 
   private renderPlaceholder(): void {
@@ -100,14 +116,37 @@ export class CountryImpactTab {
       ? `<div class="re-impact__flags">${data.dependencyFlags.map((f) => `<span class="re-impact__flag re-impact__flag--${f.toLowerCase().replace(/^dependency_flag_/, '')}">${escapeHtml(FLAG_LABELS[f] ?? f)}</span>`).join('')}</div>`
       : '';
 
-    const resHtml = data.resilienceScore > 0
-      ? `<div class="re-impact__resilience">Resilience: <strong>${Math.round(data.resilienceScore)}/100</strong></div>`
-      : '';
+    const resHtml = this.renderResilience(data);
 
     const productsHtml = this.renderProducts(data.topStrategicProducts);
 
     setTrustedHtml(this.element, trustedHtml(`${bannerHtml}${laneHtml}${flagsHtml}${resHtml}<h3 class="re-impact__products-title">Top strategic products</h3>${productsHtml}`, "legacy direct innerHTML migration"));
     this.attachDrillListeners();
+  }
+
+  private renderResilience(data: GetRouteImpactResponse): string {
+    const resilience = this.resilience;
+    const score = resilience?.overallScore;
+    if (resilience && typeof score === 'number' && Number.isFinite(score) && score > 0) {
+      const confidence = formatResilienceConfidence(resilience);
+      const interval = formatResilienceScoreInterval(resilience.scoreInterval);
+      return [
+        '<div class="re-impact__resilience">',
+        `  <span>Resilience: <strong>${Math.round(score)}/100</strong></span>`,
+        ...(interval
+          ? [`  <span class="re-resilience-interval" title="${escapeHtml(interval.title)}">${escapeHtml(interval.label)}</span>`]
+          : []),
+        `  <span class="re-resilience-confidence${resilience.lowConfidence ? ' re-resilience-confidence--low' : ''}">${escapeHtml(confidence)}</span>`,
+        '</div>',
+      ].join('');
+    }
+    if (resilience) {
+      return '<div class="re-impact__resilience"><span>Resilience: <strong>\u2014</strong></span><span class="re-resilience-confidence re-resilience-confidence--low">No scored resilience data</span></div>';
+    }
+    if (data.resilienceScore > 0) {
+      return `<div class="re-impact__resilience"><span>Resilience: <strong>${Math.round(data.resilienceScore)}/100</strong></span><span class="re-resilience-confidence">Confidence unavailable</span></div>`;
+    }
+    return '';
   }
 
   private renderProducts(products: StrategicProduct[]): string {

--- a/src/components/RouteExplorer/tabs/CountryImpactTab.ts
+++ b/src/components/RouteExplorer/tabs/CountryImpactTab.ts
@@ -69,7 +69,7 @@ export class CountryImpactTab {
   public updateResilience(resilience: ResilienceScoreResponse | null): void {
     this.resilience = resilience;
     if (this.data && this.data.comtradeSource !== 'missing' && this.data.comtradeSource !== 'empty' && this.data.comtradeSource !== 'lazy') {
-      this.renderData(this.data);
+      this.updateResilienceSlot(this.data);
     }
   }
 
@@ -116,23 +116,28 @@ export class CountryImpactTab {
       ? `<div class="re-impact__flags">${data.dependencyFlags.map((f) => `<span class="re-impact__flag re-impact__flag--${f.toLowerCase().replace(/^dependency_flag_/, '')}">${escapeHtml(FLAG_LABELS[f] ?? f)}</span>`).join('')}</div>`
       : '';
 
-    const resHtml = this.renderResilience(data);
-
     const productsHtml = this.renderProducts(data.topStrategicProducts);
 
-    setTrustedHtml(this.element, trustedHtml(`${bannerHtml}${laneHtml}${flagsHtml}${resHtml}<h3 class="re-impact__products-title">Top strategic products</h3>${productsHtml}`, "legacy direct innerHTML migration"));
+    setTrustedHtml(this.element, trustedHtml(`${bannerHtml}${laneHtml}${flagsHtml}<div class="re-impact__resilience-slot">${this.renderResilience(data)}</div><h3 class="re-impact__products-title">Top strategic products</h3>${productsHtml}`, "legacy direct innerHTML migration"));
     this.attachDrillListeners();
+  }
+
+  private updateResilienceSlot(data: GetRouteImpactResponse): void {
+    const slot = this.element.querySelector('.re-impact__resilience-slot');
+    if (!slot) return;
+    setTrustedHtml(slot, trustedHtml(this.renderResilience(data), "legacy direct innerHTML migration"));
   }
 
   private renderResilience(data: GetRouteImpactResponse): string {
     const resilience = this.resilience;
     const score = resilience?.overallScore;
-    if (resilience && typeof score === 'number' && Number.isFinite(score) && score > 0) {
+    const roundedScore = typeof score === 'number' && Number.isFinite(score) ? Math.round(score) : 0;
+    if (resilience && roundedScore > 0) {
       const confidence = formatResilienceConfidence(resilience);
       const interval = formatResilienceScoreInterval(resilience.scoreInterval);
       return [
         '<div class="re-impact__resilience">',
-        `  <span>Resilience: <strong>${Math.round(score)}/100</strong></span>`,
+        `  <span>Resilience: <strong>${roundedScore}/100</strong></span>`,
         ...(interval
           ? [`  <span class="re-resilience-interval" title="${escapeHtml(interval.title)}">${escapeHtml(interval.label)}</span>`]
           : []),
@@ -143,8 +148,9 @@ export class CountryImpactTab {
     if (resilience) {
       return '<div class="re-impact__resilience"><span>Resilience: <strong>\u2014</strong></span><span class="re-resilience-confidence re-resilience-confidence--low">No scored resilience data</span></div>';
     }
-    if (data.resilienceScore > 0) {
-      return `<div class="re-impact__resilience"><span>Resilience: <strong>${Math.round(data.resilienceScore)}/100</strong></span><span class="re-resilience-confidence">Confidence unavailable</span></div>`;
+    const fallbackScore = Number.isFinite(data.resilienceScore) ? Math.round(data.resilienceScore) : 0;
+    if (fallbackScore > 0) {
+      return `<div class="re-impact__resilience"><span>Resilience: <strong>${fallbackScore}/100</strong></span><span class="re-resilience-confidence">Confidence unavailable</span></div>`;
     }
     return '';
   }

--- a/src/styles/route-explorer.css
+++ b/src/styles/route-explorer.css
@@ -237,6 +237,14 @@
 .re-leftrail__label { color: var(--text-dim, #8b949e); }
 .re-leftrail__value { font-weight: 500; }
 
+.re-leftrail__resilience-meta {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 11px;
+  color: var(--text-dim, #8b949e);
+}
+
 .re-leftrail__placeholder,
 .re-leftrail__empty,
 .re-leftrail__placeholder-text {
@@ -543,9 +551,22 @@
 .re-impact__flag--diversifiable { background: rgba(34, 197, 94, 0.15); color: #22c55e; }
 
 .re-impact__resilience {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
   font-size: 14px;
   margin-bottom: 16px;
   color: var(--text-dim, #8b949e);
+}
+
+.re-resilience-confidence,
+.re-resilience-interval {
+  font-size: 11px;
+  color: var(--text-dim, #8b949e);
+}
+
+.re-resilience-confidence--low {
+  color: var(--semantic-elevated, #f59e0b);
 }
 
 .re-impact__products-title {


### PR DESCRIPTION
## Summary
- pass the full country resilience response into RouteExplorer rail/impact UI
- treat resilience scores <= 0 as unscored instead of rendering 0/100
- surface existing resilience confidence and score interval metadata in the Route Explorer UI

## Validation
- npm run typecheck
- git diff --check
- pre-push hook passed on push, including typecheck, API typecheck, boundary checks, edge function tests, and version sync

## Notes
- Draft PR for review.
- No browser visual pass was run.