### PR TITLE
Serialize resilience ranking cache warms

### DIFF
--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -88,11 +88,7 @@ export function getClientIp(request: Request): string {
   return cf || xr || UNKNOWN_CLIENT_IP;
 }
 
-function tooManyRequestsResponse(
-  limit: number,
-  reset: number,
-  corsHeaders: Record<string, string>,
-): Response {
+function tooManyRequestsResponse(limit: number, reset: number, corsHeaders: Record<string, string>): Response {
   return new Response(JSON.stringify({ error: 'Too many requests' }), {
     status: 429,
     headers: {
@@ -107,17 +103,14 @@ function tooManyRequestsResponse(
 }
 
 function rateLimitDegradedResponse(corsHeaders: Record<string, string>): Response {
-  return new Response(
-    JSON.stringify({ error: 'Rate-limit service temporarily unavailable' }),
-    {
-      status: 503,
-      headers: {
-        'Content-Type': 'application/json',
-        ...RATE_LIMIT_DEGRADED_HEADERS,
-        ...corsHeaders,
-      },
+  return new Response(JSON.stringify({ error: 'Rate-limit service temporarily unavailable' }), {
+    status: 503,
+    headers: {
+      'Content-Type': 'application/json',
+      ...RATE_LIMIT_DEGRADED_HEADERS,
+      ...corsHeaders,
     },
-  );
+  });
 }
 
 export interface RateLimitOptions {
@@ -132,11 +125,7 @@ export interface RateLimitOptions {
   failClosed?: boolean;
 }
 
-export async function checkRateLimit(
-  request: Request,
-  corsHeaders: Record<string, string>,
-  opts: RateLimitOptions = {},
-): Promise<Response | null> {
+export async function checkRateLimit(request: Request, corsHeaders: Record<string, string>, opts: RateLimitOptions = {}): Promise<Response | null> {
   const rl = getRatelimit();
   if (!rl) {
     if (opts.failClosed) {
@@ -197,6 +186,9 @@ export const ENDPOINT_RATE_POLICIES: Record<string, EndpointRatePolicy> = {
   // = 6 req/min/IP base load. 60/min headroom covers tab refreshes + zoom
   // pans within a single user without flagging legitimate traffic.
   '/api/maritime/v1/get-vessel-snapshot': { limit: 60, window: '60 s' },
+  // Country Resilience ranking can synchronously warm the full country table
+  // on cold/stale cache paths; keep it well below the global 600/min fallback.
+  '/api/resilience/v1/get-resilience-ranking': { limit: 30, window: '60 s' },
   // #3805 / PR #3821: MCP proxy is a top-level Vercel Edge Function in
   // `api/mcp-proxy.ts` (registered as `external-protocol` in
   // api/api-route-exceptions.json — JSON-RPC shape dictated by the MCP spec),
@@ -237,22 +229,14 @@ export function hasEndpointRatePolicy(pathname: string): boolean {
   return pathname in ENDPOINT_RATE_POLICIES;
 }
 
-export async function checkEndpointRateLimit(
-  request: Request,
-  pathname: string,
-  corsHeaders: Record<string, string>,
-  opts: RateLimitOptions = {},
-): Promise<Response | null> {
+export async function checkEndpointRateLimit(request: Request, pathname: string, corsHeaders: Record<string, string>, opts: RateLimitOptions = {}): Promise<Response | null> {
   if (!hasEndpointRatePolicy(pathname)) return null;
 
   const rl = getEndpointRatelimit(pathname);
   if (!rl) {
     const failClosed = opts.failClosed ?? true;
     if (failClosed) {
-      logRateLimitDegraded(
-        `checkEndpointRateLimit:${pathname}:missing-config`,
-        new Error('Upstash Redis is not configured'),
-      );
+      logRateLimitDegraded(`checkEndpointRateLimit:${pathname}:missing-config`, new Error('Upstash Redis is not configured'));
       return rateLimitDegradedResponse(corsHeaders);
     }
     return null;
@@ -330,12 +314,7 @@ export interface ScopedRateLimitResult {
  * (#3531). The Redis error itself is logged once per call so silent bypass
  * windows are visible in logs / Sentry.
  */
-export async function checkScopedRateLimit(
-  scope: string,
-  limit: number,
-  window: Duration,
-  identifier: string,
-): Promise<ScopedRateLimitResult> {
+export async function checkScopedRateLimit(scope: string, limit: number, window: Duration, identifier: string): Promise<ScopedRateLimitResult> {
   const rl = getScopedRatelimit(scope, limit, window);
   if (!rl) return { allowed: true, limit, reset: 0, degraded: true };
   try {

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -58,10 +58,7 @@ export function __resetKeyPrefixCacheForTests(): void {
   cachedPrefix = undefined;
 }
 
-type CacheReadResult =
-  | { status: 'hit'; value: unknown }
-  | { status: 'miss' }
-  | { status: 'error'; error: unknown };
+type CacheReadResult = { status: 'hit'; value: unknown } | { status: 'miss' } | { status: 'error'; error: unknown };
 
 async function readCachedJson(key: string, raw = false): Promise<CacheReadResult> {
   if (process.env.LOCAL_API_MODE === 'tauri-sidecar') {
@@ -89,7 +86,10 @@ async function readCachedJson(key: string, raw = false): Promise<CacheReadResult
     // Envelope-aware by default — RPC consumers get the bare payload regardless
     // of whether the writer has migrated to contract mode. Legacy shapes pass
     // through unchanged (unwrapEnvelope returns {_seed: null, data: raw}).
-    return { status: 'hit', value: unwrapEnvelope(JSON.parse(data.result)).data };
+    return {
+      status: 'hit',
+      value: unwrapEnvelope(JSON.parse(data.result)).data,
+    };
   } catch (error) {
     return { status: 'error', error };
   }
@@ -212,7 +212,10 @@ export async function setCachedJson(key: string, value: unknown, ttlSeconds: num
       body: JSON.stringify(['SET', finalKey, JSON.stringify(value), 'EX', String(ttlSeconds)]),
       signal: AbortSignal.timeout(REDIS_PIPELINE_TIMEOUT_MS),
     });
-    const data = await resp.json().catch(() => null) as { result?: string; error?: string } | null;
+    const data = (await resp.json().catch(() => null)) as {
+      result?: string;
+      error?: string;
+    } | null;
     if (!resp.ok || data?.error) {
       console.warn(`[redis] setCachedJson failed:`, data?.error ?? `HTTP ${resp.status}`);
       return false;
@@ -296,7 +299,10 @@ export async function getCachedJsonBatch(keys: string[]): Promise<Map<string, un
     const pipeline = keys.map((k) => ['GET', prefixKey(k)]);
     const resp = await fetch(`${url}/pipeline`, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
       body: JSON.stringify(pipeline),
       signal: AbortSignal.timeout(REDIS_PIPELINE_TIMEOUT_MS),
     });
@@ -312,7 +318,9 @@ export async function getCachedJsonBatch(keys: string[]): Promise<Map<string, un
           // Envelope-aware: unwrap contract-mode canonical keys; legacy values
           // pass through.
           result.set(keys[i]!, unwrapEnvelope(parsed).data);
-        } catch { /* skip malformed */ }
+        } catch {
+          /* skip malformed */
+        }
       }
     }
   } catch (err) {
@@ -330,10 +338,7 @@ function normalizePipelineCommand(command: RedisPipelineCommand, raw: boolean): 
   return [verb, prefixKey(key), ...rest];
 }
 
-export async function runRedisPipeline(
-  commands: RedisPipelineCommand[],
-  raw = false,
-): Promise<Array<{ result?: unknown }>> {
+export async function runRedisPipeline(commands: RedisPipelineCommand[], raw = false): Promise<Array<{ result?: unknown }>> {
   if (process.env.LOCAL_API_MODE === 'tauri-sidecar') return [];
   if (commands.length === 0) return [];
 
@@ -344,7 +349,10 @@ export async function runRedisPipeline(
   try {
     const response = await fetch(`${url}/pipeline`, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
       body: JSON.stringify(commands.map((command) => normalizePipelineCommand(command, raw))),
       signal: AbortSignal.timeout(REDIS_PIPELINE_TIMEOUT_MS),
     });
@@ -352,10 +360,47 @@ export async function runRedisPipeline(
       console.warn(`[redis] runRedisPipeline HTTP ${response.status}`);
       return [];
     }
-    return await response.json() as Array<{ result?: unknown }>;
+    return (await response.json()) as Array<{ result?: unknown }>;
   } catch (err) {
     console.warn('[redis] runRedisPipeline failed:', errMsg(err));
     return [];
+  }
+}
+
+export async function compareAndDeleteRedisKey(key: string, expectedValue: string, raw = false): Promise<boolean> {
+  if (process.env.LOCAL_API_MODE === 'tauri-sidecar') return false;
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token || !expectedValue) return false;
+
+  const finalKey = raw ? key : prefixKey(key);
+  const script = "if redis.call('GET', KEYS[1]) == ARGV[1] then return redis.call('DEL', KEYS[1]) else return 0 end";
+  try {
+    const response = await fetch(`${url}/`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(['EVAL', script, '1', finalKey, expectedValue]),
+      signal: AbortSignal.timeout(REDIS_PIPELINE_TIMEOUT_MS),
+    });
+    if (!response.ok) {
+      console.warn(`[redis] compareAndDeleteRedisKey HTTP ${response.status}`);
+      return false;
+    }
+    const data = (await response.json().catch(() => null)) as {
+      result?: unknown;
+      error?: string;
+    } | null;
+    if (data?.error) {
+      console.warn('[redis] compareAndDeleteRedisKey failed:', data.error);
+      return false;
+    }
+    return data?.result === 1;
+  } catch (err) {
+    console.warn('[redis] compareAndDeleteRedisKey failed:', errMsg(err));
+    return false;
   }
 }
 
@@ -410,12 +455,7 @@ export function __resetFetcherTimeoutForTests(): void {
  * threading an AbortSignal through the fetcher contract, which is a wider
  * refactor across every cached-fetch call site.
  */
-function withFetcherTimeout<T>(
-  promise: Promise<T>,
-  key: string,
-  timeoutMs: number,
-  callerName: 'cachedFetchJson' | 'cachedFetchJsonWithMeta',
-): Promise<T> {
+function withFetcherTimeout<T>(promise: Promise<T>, key: string, timeoutMs: number, callerName: 'cachedFetchJson' | 'cachedFetchJsonWithMeta'): Promise<T> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
@@ -620,12 +660,7 @@ export async function cachedFetchJsonWithMeta<T extends object>(
   return { data, source: 'fresh' };
 }
 
-function emitUpstreamFromHook(
-  usage: UsageHook | undefined,
-  status: number,
-  durationMs: number,
-  cacheStatus: 'miss' | 'fresh' | 'stale-while-revalidate' | 'neg-sentinel',
-): void {
+function emitUpstreamFromHook(usage: UsageHook | undefined, status: number, durationMs: number, cacheStatus: 'miss' | 'fresh' | 'stale-while-revalidate' | 'neg-sentinel'): void {
   // Emit only when caller labels the provider — avoids "unknown" pollution.
   if (!usage?.provider) return;
   // Single waitUntil() registered synchronously here — no nested
@@ -655,22 +690,19 @@ function emitUpstreamFromHook(
   }
 }
 
-export async function geoSearchByBox(
-  key: string, lon: number, lat: number,
-  widthKm: number, heightKm: number, count: number, raw = false,
-): Promise<string[]> {
+export async function geoSearchByBox(key: string, lon: number, lat: number, widthKm: number, heightKm: number, count: number, raw = false): Promise<string[]> {
   const url = process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
   if (!url || !token) return [];
   try {
     const finalKey = raw ? key : prefixKey(key);
-    const pipeline = [
-      ['GEOSEARCH', finalKey, 'FROMLONLAT', String(lon), String(lat),
-       'BYBOX', String(widthKm), String(heightKm), 'km', 'ASC', 'COUNT', String(count)],
-    ];
+    const pipeline = [['GEOSEARCH', finalKey, 'FROMLONLAT', String(lon), String(lat), 'BYBOX', String(widthKm), String(heightKm), 'km', 'ASC', 'COUNT', String(count)]];
     const resp = await fetch(`${url}/pipeline`, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
       body: JSON.stringify(pipeline),
       signal: AbortSignal.timeout(REDIS_PIPELINE_TIMEOUT_MS),
     });
@@ -683,9 +715,7 @@ export async function geoSearchByBox(
   }
 }
 
-export async function getHashFieldsBatch(
-  key: string, fields: string[], raw = false,
-): Promise<Map<string, string>> {
+export async function getHashFieldsBatch(key: string, fields: string[], raw = false): Promise<Map<string, string>> {
   const result = new Map<string, string>();
   if (fields.length === 0) return result;
   const url = process.env.UPSTASH_REDIS_REST_URL;
@@ -696,7 +726,10 @@ export async function getHashFieldsBatch(
     const pipeline = [['HMGET', finalKey, ...fields]];
     const resp = await fetch(`${url}/pipeline`, {
       method: 'POST',
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
       body: JSON.stringify(pipeline),
       signal: AbortSignal.timeout(REDIS_PIPELINE_TIMEOUT_MS),
     });

--- a/server/error-mapper.ts
+++ b/server/error-mapper.ts
@@ -16,12 +16,7 @@
 function isNetworkError(error: unknown): boolean {
   if (!(error instanceof TypeError)) return false;
   const msg = error.message.toLowerCase();
-  return msg.includes('fetch') ||
-    msg.includes('network') ||
-    msg.includes('connect') ||
-    msg.includes('econnrefused') ||
-    msg.includes('enotfound') ||
-    msg.includes('socket');
+  return msg.includes('fetch') || msg.includes('network') || msg.includes('connect') || msg.includes('econnrefused') || msg.includes('enotfound') || msg.includes('socket');
 }
 
 /**
@@ -42,15 +37,12 @@ export function mapErrorToResponse(error: unknown, _req: Request): Response {
     const statusCode = (error as Error & { statusCode: number }).statusCode;
     // Only expose error.message for 4xx (client errors). Use generic message for 5xx
     // to avoid leaking internal details like upstream URLs or API key fragments (H-3 fix).
-    const message = statusCode >= 400 && statusCode < 500
-      ? error.message
-      : 'Internal server error';
+    const retryAfter = (statusCode === 429 || statusCode === 503) && 'retryAfter' in error ? Number((error as Error & { retryAfter: number }).retryAfter) : null;
+    const isRetryableUnavailable = statusCode === 503 && retryAfter != null && Number.isFinite(retryAfter);
+    const message = (statusCode >= 400 && statusCode < 500) || isRetryableUnavailable ? error.message : 'Internal server error';
     const body: Record<string, unknown> = { message };
 
     // Rate limit: include retryAfter if present
-    const retryAfter = statusCode === 429 && 'retryAfter' in error
-      ? Number((error as Error & { retryAfter: number }).retryAfter)
-      : null;
     if (retryAfter != null && Number.isFinite(retryAfter)) {
       body.retryAfter = retryAfter;
     }

--- a/server/error-mapper.ts
+++ b/server/error-mapper.ts
@@ -38,8 +38,11 @@ export function mapErrorToResponse(error: unknown, _req: Request): Response {
     // Only expose error.message for 4xx (client errors). Use generic message for 5xx
     // to avoid leaking internal details like upstream URLs or API key fragments (H-3 fix).
     const retryAfter = (statusCode === 429 || statusCode === 503) && 'retryAfter' in error ? Number((error as Error & { retryAfter: number }).retryAfter) : null;
-    const isRetryableUnavailable = statusCode === 503 && retryAfter != null && Number.isFinite(retryAfter);
-    const message = (statusCode >= 400 && statusCode < 500) || isRetryableUnavailable ? error.message : 'Internal server error';
+    const exposesRetryableUnavailable = statusCode === 503
+      && retryAfter != null
+      && Number.isFinite(retryAfter)
+      && (error as Error & { exposeMessage?: boolean }).exposeMessage === true;
+    const message = (statusCode >= 400 && statusCode < 500) || exposesRetryableUnavailable ? error.message : 'Internal server error';
     const body: Record<string, unknown> = { message };
 
     // Rate limit: include retryAfter if present

--- a/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
+++ b/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
@@ -7,7 +7,7 @@ import {
   type ResilienceRankingItem,
 } from '../../../../src/generated/server/worldmonitor/resilience/v1/service_server';
 
-import { getCachedJson, runRedisPipeline } from '../../../_shared/redis';
+import { compareAndDeleteRedisKey, getCachedJson, runRedisPipeline } from '../../../_shared/redis';
 import { unwrapEnvelope } from '../../../_shared/seed-envelope';
 import { isInRankableUniverse } from './_rankable-universe';
 import {
@@ -41,12 +41,14 @@ const SYNC_WARM_LIMIT = 1000;
 // Minimum fraction of scorable countries that must have a cached score before
 // publishing the ranking. A 75% table looked healthy to consumers while hiding
 // a large serving gap; require at least 90%, and label/shorten sub-95% publishes.
-const RANKING_CACHE_MIN_COVERAGE = 0.90;
+const RANKING_CACHE_MIN_COVERAGE = 0.9;
 const RANKING_FULL_COVERAGE = 0.95;
 const PARTIAL_RANKING_CACHE_TTL_SECONDS = 2 * 60 * 60;
-const RANKING_PERSISTENCE_MIN_PARITY = 0.90;
+const RANKING_PERSISTENCE_MIN_PARITY = 0.9;
 const RANKING_REFRESH_LOCK_KEY = 'resilience:ranking:refresh-lock:v1';
 const RANKING_REFRESH_LOCK_TTL_SECONDS = 30;
+const RANKING_WARM_LOCK_KEY = 'resilience:ranking:warm-lock:v1';
+const RANKING_WARM_LOCK_TTL_SECONDS = 60;
 
 function isRefreshRequested(ctx: ServerContext): boolean {
   try {
@@ -62,25 +64,50 @@ function isSeedRefreshAuthorized(ctx: ServerContext): boolean {
   return ctx.request.headers.get('X-WorldMonitor-Key') === expected;
 }
 
-async function tryAcquireRefreshSlot(): Promise<boolean> {
-  const token = `${Date.now()}:${Math.random().toString(36).slice(2)}`;
-  const result = await runRedisPipeline([
-    ['SET', RANKING_REFRESH_LOCK_KEY, token, 'EX', RANKING_REFRESH_LOCK_TTL_SECONDS, 'NX'],
-  ]);
-  return result[0]?.result === 'OK';
+function makeLockToken(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}:${Math.random().toString(36).slice(2)}`;
+}
+
+async function tryAcquireRankingLock(lockKey: string, ttlSeconds: number): Promise<string | null> {
+  const token = makeLockToken();
+  const result = await runRedisPipeline([['SET', lockKey, token, 'EX', ttlSeconds, 'NX']]);
+  return result[0]?.result === 'OK' ? token : null;
+}
+
+async function releaseRankingLock(lockKey: string, token: string): Promise<void> {
+  await compareAndDeleteRedisKey(lockKey, token);
 }
 
 function throwRefreshSlotBusy(): never {
-  const err = new ApiError(429, 'Resilience ranking refresh already in progress', JSON.stringify({
-    retryAfter: RANKING_REFRESH_LOCK_TTL_SECONDS,
-  }));
+  const err = new ApiError(
+    429,
+    'Resilience ranking refresh already in progress',
+    JSON.stringify({
+      retryAfter: RANKING_REFRESH_LOCK_TTL_SECONDS,
+    }),
+  );
   (err as ApiError & { retryAfter: number }).retryAfter = RANKING_REFRESH_LOCK_TTL_SECONDS;
+  throw err;
+}
+
+function throwRankingWarmBusy(): never {
+  const err = new ApiError(
+    503,
+    'Resilience ranking temporarily unavailable while cache warm is in progress',
+    JSON.stringify({
+      retryAfter: RANKING_WARM_LOCK_TTL_SECONDS,
+    }),
+  );
+  (err as ApiError & { retryAfter: number }).retryAfter = RANKING_WARM_LOCK_TTL_SECONDS;
   throw err;
 }
 
 async function fetchIntervals(countryCodes: string[]): Promise<Map<string, ScoreInterval>> {
   if (countryCodes.length === 0) return new Map();
-  const results = await runRedisPipeline(countryCodes.map((cc) => ['GET', `${RESILIENCE_INTERVAL_KEY_PREFIX}${cc}`]), true);
+  const results = await runRedisPipeline(
+    countryCodes.map((cc) => ['GET', `${RESILIENCE_INTERVAL_KEY_PREFIX}${cc}`]),
+    true,
+  );
   const map = new Map<string, ScoreInterval>();
   const current = getCurrentCacheFormula();
   for (let i = 0; i < countryCodes.length; i++) {
@@ -88,11 +115,17 @@ async function fetchIntervals(countryCodes: string[]): Promise<Map<string, Score
     if (typeof raw !== 'string') continue;
     try {
       // Envelope-aware: interval keys come through seed-resilience-scores' extra-key path.
-      const parsed = unwrapEnvelope(JSON.parse(raw)).data as { p05?: number; p95?: number; _formula?: string } | null;
+      const parsed = unwrapEnvelope(JSON.parse(raw)).data as {
+        p05?: number;
+        p95?: number;
+        _formula?: string;
+      } | null;
       if (parsed && typeof parsed.p05 === 'number' && typeof parsed.p95 === 'number' && parsed._formula === current) {
         map.set(countryCodes[i]!, { p05: parsed.p05, p95: parsed.p95 });
       }
-    } catch { /* ignore malformed interval entries */ }
+    } catch {
+      /* ignore malformed interval entries */
+    }
   }
   return map;
 }
@@ -137,7 +170,10 @@ function rankingCacheMetadataMatches(payload: Partial<GetResilienceRankingRespon
 }
 
 function coerceCachedRankingResponse(
-  payload: GetResilienceRankingResponse & { _formula?: string; _intervalMethodology?: string },
+  payload: GetResilienceRankingResponse & {
+    _formula?: string;
+    _intervalMethodology?: string;
+  },
   items: ResilienceRankingItem[],
   greyedOut: ResilienceRankingItem[],
 ): GetResilienceRankingResponse {
@@ -150,6 +186,94 @@ function coerceCachedRankingResponse(
     coverage: roundCoverage(payload.coverage),
     partial: payload.partial,
   };
+}
+
+async function readValidCachedRankingResponse(): Promise<GetResilienceRankingResponse | null> {
+  const cached = (await getCachedJson(RESILIENCE_RANKING_CACHE_KEY)) as
+    | (GetResilienceRankingResponse & {
+        _formula?: string;
+        _intervalMethodology?: string;
+      })
+    | null;
+  // Stale-cache gate: the ranking payload carries the score formula,
+  // interval methodology, and public freshness metadata that were active
+  // when rankStable was computed. Rejecting entries with stale/missing
+  // tags or metadata prevents old ranking payloads from serving baked
+  // rankStable values or blank partial/freshness fields after cache
+  // rotations.
+  const cacheMatches = cached != null && rankingCacheTagMatches(cached) && rankingCacheMetadataMatches(cached);
+  if (!cacheMatches || (cached!.items.length === 0 && (cached!.greyedOut?.length ?? 0) === 0)) {
+    return null;
+  }
+
+  // Plan 2026-04-26-002 §U2 (PR 1, review fixup): defense-in-depth
+  // universe filter at the cached-response read too. Without this,
+  // the cache hit path returns a stale 222-country payload (pre-PR-1
+  // ranking) until either the 12h TTL expires or someone runs
+  // ?refresh=1. The filter is idempotent — a fresh post-PR-1 ranking
+  // is already universe-filtered, so this is a no-op then; a stale
+  // pre-PR-1 cached payload gets filtered at handler-time. Same
+  // recipe as `_shared.ts:listScorableCountries`. The filter
+  // preserves the rest of the cache hit (rankCounts, percentile
+  // anchors, etc.) so we don't pay the recompute cost just for
+  // universe membership.
+  const filteredItems = cached!.items.filter((item) => isInRankableUniverse(item.countryCode));
+  const filteredGreyedOut = (cached!.greyedOut ?? []).filter((item) => isInRankableUniverse(item.countryCode));
+  const droppedCount = cached!.items.length - filteredItems.length + ((cached!.greyedOut?.length ?? 0) - filteredGreyedOut.length);
+  if (droppedCount > 0) {
+    console.log(`[resilience-ranking] Filtered ${droppedCount} non-rankable territories from cached ranking response (transitional — next recompute will publish a clean payload)`);
+  }
+  // Plan 2026-04-26-002 §U7 (PR 6) — backfill semantic flips.
+  //
+  // At v16 (PR 2), every score build emitted `headlineEligible: true`
+  // unconditionally, so a cache entry missing the field meant
+  // "pre-field v16 entry" → backfilling to `true` matched the
+  // PR-2 contract.
+  //
+  // At v17 (PR 6), every legitimate cache writer STAMPS the field
+  // explicitly (true or false based on the gate). A v17 cache entry
+  // missing the field is anomalous — partially-migrated cache,
+  // manual seed that forgot the field, or a future writer bug.
+  // Defaulting missing → `true` would let the anomaly through as
+  // headline-eligible. Per Greptile P2 review, the conservative
+  // default at v17 is `false`: the gate is the single source of
+  // truth, and anything not stamped is not trusted to pass it.
+  // The next recompute will write a clean payload.
+  const backfillEligibilityConservative = <T extends { headlineEligible?: boolean }>(item: T): T =>
+    item.headlineEligible === undefined ? { ...item, headlineEligible: false } : item;
+  // Plan 2026-04-26-002 §U7 (PR 6) — apply the headline-eligible
+  // gate SYMMETRICALLY across both arrays: any item with
+  // `headlineEligible === true` ends up in items[] regardless of
+  // which cached array it was in; anything else ends up in
+  // greyedOut[]. Asymmetric gating (only filtering items → greyedOut)
+  // would leave a cached greyedOut entry permanently demoted even
+  // if it now passes the gate, until a full recompute. Symmetric
+  // gating makes the predicate the single source of truth across
+  // every code path that returns items[] / greyedOut[] to callers.
+  // Per Greptile P2 review of PR #3472.
+  const itemsWithEligibility = filteredItems.map(backfillEligibilityConservative);
+  const greyedWithEligibility = filteredGreyedOut.map(backfillEligibilityConservative);
+  const eligibleItems = itemsWithEligibility.filter((item) => item.headlineEligible === true);
+  const ineligibleFromItems = itemsWithEligibility.filter((item) => item.headlineEligible !== true);
+  const promotedFromGreyed = greyedWithEligibility.filter((item) => item.headlineEligible === true);
+  const stillGreyed = greyedWithEligibility.filter((item) => item.headlineEligible !== true);
+  // Strip the cache-only tag before returning to callers so the
+  // wire shape matches the generated proto response type.
+  const { _formula: _dropFormula, _intervalMethodology: _dropIntervalMethodology, ...publicResponse } = cached!;
+  void _dropFormula;
+  void _dropIntervalMethodology;
+  // Re-sort items[] after the symmetric promotion. A high-scoring
+  // item promoted from greyedOut[] would otherwise be appended at
+  // the end of items[] instead of landing in its correct rank
+  // position. The recompute path always sorts before publishing
+  // (line ~225 below), so the cache-hit path must too — otherwise
+  // a cache-hit response visibly differs from a fresh recompute
+  // for the same data, breaking the front-of-house ranking sort.
+  // Per Greptile P2 review of PR #3472 follow-up.
+  return coerceCachedRankingResponse(publicResponse as GetResilienceRankingResponse, sortRankingItems([...eligibleItems, ...promotedFromGreyed]), [
+    ...stillGreyed,
+    ...ineligibleFromItems,
+  ]);
 }
 
 export const getResilienceRanking: ResilienceServiceHandler['getResilienceRanking'] = async (
@@ -166,242 +290,185 @@ export const getResilienceRanking: ResilienceServiceHandler['getResilienceRankin
   const refreshAuthorized = refreshRequested && isSeedRefreshAuthorized(ctx);
   let refreshSlotDenied = false;
   let forceRefresh = false;
+  let lockToRelease: { key: string; token: string } | null = null;
   if (refreshRequested && !refreshAuthorized) {
     console.warn('[resilience] refresh=1 rejected: dedicated seed refresh secret missing or invalid');
   } else if (refreshAuthorized) {
-    forceRefresh = await tryAcquireRefreshSlot();
+    const token = await tryAcquireRankingLock(RANKING_REFRESH_LOCK_KEY, RANKING_REFRESH_LOCK_TTL_SECONDS);
+    forceRefresh = token !== null;
+    if (token) lockToRelease = { key: RANKING_REFRESH_LOCK_KEY, token };
     refreshSlotDenied = !forceRefresh;
     if (refreshSlotDenied) {
       console.warn('[resilience] refresh=1 skipped: ranking refresh slot already held');
     }
   }
   if (!forceRefresh) {
-    const cached = await getCachedJson(RESILIENCE_RANKING_CACHE_KEY) as (
-      GetResilienceRankingResponse & { _formula?: string; _intervalMethodology?: string }
-    ) | null;
-    // Stale-cache gate: the ranking payload carries the score formula,
-    // interval methodology, and public freshness metadata that were active
-    // when rankStable was computed. Rejecting entries with stale/missing
-    // tags or metadata prevents old ranking payloads from serving baked
-    // rankStable values or blank partial/freshness fields after cache
-    // rotations.
-    const cacheMatches = cached != null && rankingCacheTagMatches(cached) && rankingCacheMetadataMatches(cached);
-    if (cacheMatches && (cached!.items.length > 0 || (cached!.greyedOut?.length ?? 0) > 0)) {
-      // Plan 2026-04-26-002 §U2 (PR 1, review fixup): defense-in-depth
-      // universe filter at the cached-response read too. Without this,
-      // the cache hit path returns a stale 222-country payload (pre-PR-1
-      // ranking) until either the 12h TTL expires or someone runs
-      // ?refresh=1. The filter is idempotent — a fresh post-PR-1 ranking
-      // is already universe-filtered, so this is a no-op then; a stale
-      // pre-PR-1 cached payload gets filtered at handler-time. Same
-      // recipe as `_shared.ts:listScorableCountries`. The filter
-      // preserves the rest of the cache hit (rankCounts, percentile
-      // anchors, etc.) so we don't pay the recompute cost just for
-      // universe membership.
-      const filteredItems = cached!.items.filter((item) => isInRankableUniverse(item.countryCode));
-      const filteredGreyedOut = (cached!.greyedOut ?? []).filter((item) => isInRankableUniverse(item.countryCode));
-      const droppedCount = (cached!.items.length - filteredItems.length) + ((cached!.greyedOut?.length ?? 0) - filteredGreyedOut.length);
-      if (droppedCount > 0) {
-        console.log(`[resilience-ranking] Filtered ${droppedCount} non-rankable territories from cached ranking response (transitional — next recompute will publish a clean payload)`);
-      }
-      // Plan 2026-04-26-002 §U7 (PR 6) — backfill semantic flips.
-      //
-      // At v16 (PR 2), every score build emitted `headlineEligible: true`
-      // unconditionally, so a cache entry missing the field meant
-      // "pre-field v16 entry" → backfilling to `true` matched the
-      // PR-2 contract.
-      //
-      // At v17 (PR 6), every legitimate cache writer STAMPS the field
-      // explicitly (true or false based on the gate). A v17 cache entry
-      // missing the field is anomalous — partially-migrated cache,
-      // manual seed that forgot the field, or a future writer bug.
-      // Defaulting missing → `true` would let the anomaly through as
-      // headline-eligible. Per Greptile P2 review, the conservative
-      // default at v17 is `false`: the gate is the single source of
-      // truth, and anything not stamped is not trusted to pass it.
-      // The next recompute will write a clean payload.
-      const backfillEligibilityConservative = <T extends { headlineEligible?: boolean }>(item: T): T =>
-        (item.headlineEligible === undefined ? { ...item, headlineEligible: false } : item);
-      // Plan 2026-04-26-002 §U7 (PR 6) — apply the headline-eligible
-      // gate SYMMETRICALLY across both arrays: any item with
-      // `headlineEligible === true` ends up in items[] regardless of
-      // which cached array it was in; anything else ends up in
-      // greyedOut[]. Asymmetric gating (only filtering items → greyedOut)
-      // would leave a cached greyedOut entry permanently demoted even
-      // if it now passes the gate, until a full recompute. Symmetric
-      // gating makes the predicate the single source of truth across
-      // every code path that returns items[] / greyedOut[] to callers.
-      // Per Greptile P2 review of PR #3472.
-      const itemsWithEligibility = filteredItems.map(backfillEligibilityConservative);
-      const greyedWithEligibility = filteredGreyedOut.map(backfillEligibilityConservative);
-      const eligibleItems = itemsWithEligibility.filter((item) => item.headlineEligible === true);
-      const ineligibleFromItems = itemsWithEligibility.filter((item) => item.headlineEligible !== true);
-      const promotedFromGreyed = greyedWithEligibility.filter((item) => item.headlineEligible === true);
-      const stillGreyed = greyedWithEligibility.filter((item) => item.headlineEligible !== true);
-      // Strip the cache-only tag before returning to callers so the
-      // wire shape matches the generated proto response type.
-      const { _formula: _dropFormula, _intervalMethodology: _dropIntervalMethodology, ...publicResponse } = cached!;
-      void _dropFormula;
-      void _dropIntervalMethodology;
-      // Re-sort items[] after the symmetric promotion. A high-scoring
-      // item promoted from greyedOut[] would otherwise be appended at
-      // the end of items[] instead of landing in its correct rank
-      // position. The recompute path always sorts before publishing
-      // (line ~225 below), so the cache-hit path must too — otherwise
-      // a cache-hit response visibly differs from a fresh recompute
-      // for the same data, breaking the front-of-house ranking sort.
-      // Per Greptile P2 review of PR #3472 follow-up.
-      return coerceCachedRankingResponse(
-        publicResponse as GetResilienceRankingResponse,
-        sortRankingItems([...eligibleItems, ...promotedFromGreyed]),
-        [...stillGreyed, ...ineligibleFromItems],
-      );
-    }
+    const cached = await readValidCachedRankingResponse();
+    if (cached) return cached;
     if (refreshSlotDenied) throwRefreshSlotBusy();
-  }
 
-  const countryCodes = await listScorableCountries();
-  if (countryCodes.length === 0) {
-    return buildRankingResponse([], [], { fetchedAtMs: Date.now(), scored: 0, total: 0 });
-  }
-
-  const cachedScores = await getCachedResilienceScores(countryCodes);
-  const missing = countryCodes.filter((countryCode) => !cachedScores.has(countryCode));
-  // Track the country codes whose scores were JUST warmed by this invocation.
-  // The persistence parity check below samples from THIS set specifically —
-  // pre-warmed entries from `getCachedResilienceScores` already proved they
-  // exist (we just read them), so verifying them is uninformative; the keys
-  // whose durability is in question are the ones we just SET via the
-  // batched pipeline inside `warmMissingResilienceScores`.
-  const warmedCountryCodes: string[] = [];
-  if (missing.length > 0) {
-    try {
-      // Merge warm results into cachedScores directly rather than re-reading
-      // from Redis. Upstash REST writes (/set) aren't always visible to an
-      // immediately-following /pipeline GET in the same Vercel invocation,
-      // which collapsed coverage to 0/N and silently dropped the ranking
-      // publish. The warmer already holds every score in memory — trust it.
-      // See `feedback_upstash_write_reread_race_in_handler.md`.
-      const warmed = await warmMissingResilienceScores(missing.slice(0, SYNC_WARM_LIMIT));
-      for (const [countryCode, score] of warmed) {
-        cachedScores.set(countryCode, score);
-        warmedCountryCodes.push(countryCode);
-      }
-    } catch (err) {
-      console.warn('[resilience] ranking warmup failed:', err);
+    const token = await tryAcquireRankingLock(RANKING_WARM_LOCK_KEY, RANKING_WARM_LOCK_TTL_SECONDS);
+    if (!token) {
+      const fallback = await readValidCachedRankingResponse();
+      if (fallback) return fallback;
+      throwRankingWarmBusy();
     }
+    lockToRelease = { key: RANKING_WARM_LOCK_KEY, token };
   }
 
-  const intervals = await fetchIntervals([...cachedScores.keys()]);
-  const allItems = countryCodes.map((countryCode) => buildRankingItem(countryCode, cachedScores.get(countryCode), intervals.get(countryCode)));
-  // Plan 2026-04-26-002 §U7 (PR 6) — headline-eligible gate. The
-  // headline ranking endpoint returns ONLY items with
-  // `headlineEligible: true`; ineligible items move to `greyedOut`
-  // alongside the existing low-coverage greyout. This is the load-
-  // bearing change from PR 2's "headlineEligible: true everywhere"
-  // contract: real eligibility logic now decides the front-of-house
-  // ranking. Raw API endpoints (get-resilience-score per-country)
-  // continue to return the full set with `headlineEligible: false`
-  // surfaced; only the *ranking* endpoint applies the filter.
-  //
-  // `headlineEligible: true` already implies overallCoverage >= 0.65
-  // (HEADLINE_ELIGIBLE_MIN_COVERAGE in _shared.ts), which is well
-  // above GREY_OUT_COVERAGE_THRESHOLD (0.40); checking the threshold
-  // here would be dead code per Greptile P2. Reduced to the single
-  // load-bearing predicate. Items with low coverage that somehow
-  // arrive with headlineEligible:true (e.g. from a corrupted cache
-  // entry) are intentionally trusted — the gate is the source of
-  // truth for this decision, not coverage alone.
-  const passesHeadlineGate = (item: ResilienceRankingItem): boolean =>
-    item.headlineEligible === true;
-  const fetchedAtMs = Date.now();
-  const response = buildRankingResponse(
-    sortRankingItems(allItems.filter(passesHeadlineGate)),
-    allItems.filter((item) => !passesHeadlineGate(item)),
-    { fetchedAtMs, scored: cachedScores.size, total: countryCodes.length },
-  );
+  try {
+    const countryCodes = await listScorableCountries();
+    if (countryCodes.length === 0) {
+      return buildRankingResponse([], [], {
+        fetchedAtMs: Date.now(),
+        scored: 0,
+        total: 0,
+      });
+    }
 
-  // Cache the ranking when we have substantive coverage — don't hold out for 100%.
-  // The previous gate (stillMissing === 0) meant a single failing-to-warm country
-  // permanently blocked the write, leaving the cache null for days while the 6h TTL
-  // expired between cron ticks. Countries that fail to warm already land in
-  // `greyedOut` with coverage 0, so the response is correct for partial states.
-  const coverageRatio = cachedScores.size / countryCodes.length;
-  if (coverageRatio >= RANKING_CACHE_MIN_COVERAGE) {
-    // Persistence parity check: confirm the score SETs actually landed in
-    // Redis before declaring success and writing seed-meta. Upstash REST
-    // /pipeline returns `result:'OK'` per command, but under saturated edge-
-    // runtime conditions that OK can be a transport-level acknowledgement
-    // that doesn't translate to durable persistence — observed 2026-04-27
-    // when seed-meta:resilience:ranking said scored=196 while a SCAN of
-    // resilience:score:v16:* returned just 2 keys. Without this check the
-    // meta would lie about success, downstream health flips between OK and
-    // EMPTY, and operators chase phantom TTL/cron issues.
-    //
-    // Critical: sample from `warmedCountryCodes` (entries SET by THIS
-    // invocation), NOT from all of cachedScores. Pre-warmed entries came
-    // from `getCachedResilienceScores` — we just READ them, so they are
-    // tautologically present. The keys whose durability is uncertain are
-    // the ones we just WROTE. A naïve `slice(0, 20)` over cachedScores
-    // creates a blind spot: if the first 20 are pre-warmed and the
-    // durability failure only affects the warmed tail, the check passes
-    // and meta still lies (reviewer catch on PR #3458).
-    //
-    // Within the warmed set, shuffle before slicing so the same N entries
-    // aren't checked every invocation — partial-failure modes that
-    // consistently affect the same subset (e.g. last batch of 30 fails
-    // due to queue saturation) are more likely to be sampled.
-    //
-    // Cost: one extra ~50-200ms round-trip on Edge. Skip entirely when
-    // there were no warmed writes (cache hit on every country).
-    if (warmedCountryCodes.length > 0) {
-      const shuffled = [...warmedCountryCodes].sort(() => Math.random() - 0.5);
-      const sampleKeys = shuffled.slice(0, 20).map(scoreCacheKey);
-      const verifyResults = await runRedisPipeline(sampleKeys.map((k) => ['EXISTS', k]));
-      const actualPersisted = verifyResults.filter((r) => r?.result === 1).length;
-      if (actualPersisted < sampleKeys.length * RANKING_PERSISTENCE_MIN_PARITY) {
-        console.warn(
-          `[resilience] persistence parity fail: ${actualPersisted}/${sampleKeys.length} ` +
-          `sampled WARMED score keys exist in Redis (warmed=${warmedCountryCodes.length}, ` +
-          `cachedScores.size=${cachedScores.size}, coverage=${(coverageRatio * 100).toFixed(0)}%) — ` +
-          `refusing meta write to avoid lying about ranking publish.`,
-        );
-        return response;
+    const cachedScores = await getCachedResilienceScores(countryCodes);
+    const missing = countryCodes.filter((countryCode) => !cachedScores.has(countryCode));
+    // Track the country codes whose scores were JUST warmed by this invocation.
+    // The persistence parity check below samples from THIS set specifically —
+    // pre-warmed entries from `getCachedResilienceScores` already proved they
+    // exist (we just read them), so verifying them is uninformative; the keys
+    // whose durability is in question are the ones we just SET via the
+    // batched pipeline inside `warmMissingResilienceScores`.
+    const warmedCountryCodes: string[] = [];
+    if (missing.length > 0) {
+      try {
+        // Merge warm results into cachedScores directly rather than re-reading
+        // from Redis. Upstash REST writes (/set) aren't always visible to an
+        // immediately-following /pipeline GET in the same Vercel invocation,
+        // which collapsed coverage to 0/N and silently dropped the ranking
+        // publish. The warmer already holds every score in memory — trust it.
+        // See `feedback_upstash_write_reread_race_in_handler.md`.
+        const warmed = await warmMissingResilienceScores(missing.slice(0, SYNC_WARM_LIMIT));
+        for (const [countryCode, score] of warmed) {
+          cachedScores.set(countryCode, score);
+          warmedCountryCodes.push(countryCode);
+        }
+      } catch (err) {
+        console.warn('[resilience] ranking warmup failed:', err);
       }
     }
 
-    // Upstash REST /pipeline is not transactional: each SET can succeed or
-    // fail independently. A partial write (ranking OK, meta missed) would
-    // leave health.js reading a stale meta over a fresh ranking — the seeder
-    // self-heal here ensures we at least log it, and the seeder also verifies
-    // BOTH keys post-refresh. If either SET didn't return OK we log a warning
-    // that ops can grep for, rather than silently succeeding.
-    // Tag the persisted ranking so the stale-formula gate above can
-    // detect a cross-formula cache hit after a flag flip. The tag is
-    // stripped on read before the response crosses back to callers.
-    const persistedRanking = stampRankingCacheTag(response);
-    const ttlSeconds = coverageRatio >= RANKING_FULL_COVERAGE
-      ? RESILIENCE_RANKING_CACHE_TTL_SECONDS
-      : PARTIAL_RANKING_CACHE_TTL_SECONDS;
-    const pipelineResult = await runRedisPipeline([
-      ['SET', RESILIENCE_RANKING_CACHE_KEY, JSON.stringify(persistedRanking), 'EX', ttlSeconds],
-      ['SET', RESILIENCE_RANKING_META_KEY, JSON.stringify({
-        fetchedAt: fetchedAtMs,
-        count: response.items.length + response.greyedOut.length,
-        scored: cachedScores.size,
-        total: countryCodes.length,
-        coverage: response.coverage,
-        partial: response.partial,
-      }), 'EX', Math.min(RESILIENCE_RANKING_META_TTL_SECONDS, ttlSeconds)],
-    ]);
-    const rankingOk = pipelineResult[0]?.result === 'OK';
-    const metaOk = pipelineResult[1]?.result === 'OK';
-    if (!rankingOk || !metaOk) {
-      console.warn(`[resilience] ranking publish partial: ranking=${rankingOk ? 'OK' : 'FAIL'} meta=${metaOk ? 'OK' : 'FAIL'}`);
-    }
-  } else {
-    console.warn(`[resilience] ranking not cached — coverage ${cachedScores.size}/${countryCodes.length} below ${RANKING_CACHE_MIN_COVERAGE * 100}% threshold`);
-  }
+    const intervals = await fetchIntervals([...cachedScores.keys()]);
+    const allItems = countryCodes.map((countryCode) => buildRankingItem(countryCode, cachedScores.get(countryCode), intervals.get(countryCode)));
+    // Plan 2026-04-26-002 §U7 (PR 6) — headline-eligible gate. The
+    // headline ranking endpoint returns ONLY items with
+    // `headlineEligible: true`; ineligible items move to `greyedOut`
+    // alongside the existing low-coverage greyout. This is the load-
+    // bearing change from PR 2's "headlineEligible: true everywhere"
+    // contract: real eligibility logic now decides the front-of-house
+    // ranking. Raw API endpoints (get-resilience-score per-country)
+    // continue to return the full set with `headlineEligible: false`
+    // surfaced; only the *ranking* endpoint applies the filter.
+    //
+    // `headlineEligible: true` already implies overallCoverage >= 0.65
+    // (HEADLINE_ELIGIBLE_MIN_COVERAGE in _shared.ts), which is well
+    // above GREY_OUT_COVERAGE_THRESHOLD (0.40); checking the threshold
+    // here would be dead code per Greptile P2. Reduced to the single
+    // load-bearing predicate. Items with low coverage that somehow
+    // arrive with headlineEligible:true (e.g. from a corrupted cache
+    // entry) are intentionally trusted — the gate is the source of
+    // truth for this decision, not coverage alone.
+    const passesHeadlineGate = (item: ResilienceRankingItem): boolean => item.headlineEligible === true;
+    const fetchedAtMs = Date.now();
+    const response = buildRankingResponse(
+      sortRankingItems(allItems.filter(passesHeadlineGate)),
+      allItems.filter((item) => !passesHeadlineGate(item)),
+      { fetchedAtMs, scored: cachedScores.size, total: countryCodes.length },
+    );
 
-  return response;
+    // Cache the ranking when we have substantive coverage — don't hold out for 100%.
+    // The previous gate (stillMissing === 0) meant a single failing-to-warm country
+    // permanently blocked the write, leaving the cache null for days while the 6h TTL
+    // expired between cron ticks. Countries that fail to warm already land in
+    // `greyedOut` with coverage 0, so the response is correct for partial states.
+    const coverageRatio = cachedScores.size / countryCodes.length;
+    if (coverageRatio >= RANKING_CACHE_MIN_COVERAGE) {
+      // Persistence parity check: confirm the score SETs actually landed in
+      // Redis before declaring success and writing seed-meta. Upstash REST
+      // /pipeline returns `result:'OK'` per command, but under saturated edge-
+      // runtime conditions that OK can be a transport-level acknowledgement
+      // that doesn't translate to durable persistence — observed 2026-04-27
+      // when seed-meta:resilience:ranking said scored=196 while a SCAN of
+      // resilience:score:v16:* returned just 2 keys. Without this check the
+      // meta would lie about success, downstream health flips between OK and
+      // EMPTY, and operators chase phantom TTL/cron issues.
+      //
+      // Critical: sample from `warmedCountryCodes` (entries SET by THIS
+      // invocation), NOT from all of cachedScores. Pre-warmed entries came
+      // from `getCachedResilienceScores` — we just READ them, so they are
+      // tautologically present. The keys whose durability is uncertain are
+      // the ones we just WROTE. A naïve `slice(0, 20)` over cachedScores
+      // creates a blind spot: if the first 20 are pre-warmed and the
+      // durability failure only affects the warmed tail, the check passes
+      // and meta still lies (reviewer catch on PR #3458).
+      //
+      // Within the warmed set, shuffle before slicing so the same N entries
+      // aren't checked every invocation — partial-failure modes that
+      // consistently affect the same subset (e.g. last batch of 30 fails
+      // due to queue saturation) are more likely to be sampled.
+      //
+      // Cost: one extra ~50-200ms round-trip on Edge. Skip entirely when
+      // there were no warmed writes (cache hit on every country).
+      if (warmedCountryCodes.length > 0) {
+        const shuffled = [...warmedCountryCodes].sort(() => Math.random() - 0.5);
+        const sampleKeys = shuffled.slice(0, 20).map(scoreCacheKey);
+        const verifyResults = await runRedisPipeline(sampleKeys.map((k) => ['EXISTS', k]));
+        const actualPersisted = verifyResults.filter((r) => r?.result === 1).length;
+        if (actualPersisted < sampleKeys.length * RANKING_PERSISTENCE_MIN_PARITY) {
+          console.warn(
+            `[resilience] persistence parity fail: ${actualPersisted}/${sampleKeys.length} ` +
+              `sampled WARMED score keys exist in Redis (warmed=${warmedCountryCodes.length}, ` +
+              `cachedScores.size=${cachedScores.size}, coverage=${(coverageRatio * 100).toFixed(0)}%) — ` +
+              `refusing meta write to avoid lying about ranking publish.`,
+          );
+          return response;
+        }
+      }
+
+      // Upstash REST /pipeline is not transactional: each SET can succeed or
+      // fail independently. A partial write (ranking OK, meta missed) would
+      // leave health.js reading a stale meta over a fresh ranking — the seeder
+      // self-heal here ensures we at least log it, and the seeder also verifies
+      // BOTH keys post-refresh. If either SET didn't return OK we log a warning
+      // that ops can grep for, rather than silently succeeding.
+      // Tag the persisted ranking so the stale-formula gate above can
+      // detect a cross-formula cache hit after a flag flip. The tag is
+      // stripped on read before the response crosses back to callers.
+      const persistedRanking = stampRankingCacheTag(response);
+      const ttlSeconds = coverageRatio >= RANKING_FULL_COVERAGE ? RESILIENCE_RANKING_CACHE_TTL_SECONDS : PARTIAL_RANKING_CACHE_TTL_SECONDS;
+      const pipelineResult = await runRedisPipeline([
+        ['SET', RESILIENCE_RANKING_CACHE_KEY, JSON.stringify(persistedRanking), 'EX', ttlSeconds],
+        [
+          'SET',
+          RESILIENCE_RANKING_META_KEY,
+          JSON.stringify({
+            fetchedAt: fetchedAtMs,
+            count: response.items.length + response.greyedOut.length,
+            scored: cachedScores.size,
+            total: countryCodes.length,
+            coverage: response.coverage,
+            partial: response.partial,
+          }),
+          'EX',
+          Math.min(RESILIENCE_RANKING_META_TTL_SECONDS, ttlSeconds),
+        ],
+      ]);
+      const rankingOk = pipelineResult[0]?.result === 'OK';
+      const metaOk = pipelineResult[1]?.result === 'OK';
+      if (!rankingOk || !metaOk) {
+        console.warn(`[resilience] ranking publish partial: ranking=${rankingOk ? 'OK' : 'FAIL'} meta=${metaOk ? 'OK' : 'FAIL'}`);
+      }
+    } else {
+      console.warn(`[resilience] ranking not cached — coverage ${cachedScores.size}/${countryCodes.length} below ${RANKING_CACHE_MIN_COVERAGE * 100}% threshold`);
+    }
+
+    return response;
+  } finally {
+    if (lockToRelease) await releaseRankingLock(lockToRelease.key, lockToRelease.token);
+  }
 };

--- a/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
+++ b/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
@@ -98,7 +98,8 @@ function throwRankingWarmBusy(): never {
       retryAfter: RANKING_WARM_LOCK_TTL_SECONDS,
     }),
   );
-  (err as ApiError & { retryAfter: number }).retryAfter = RANKING_WARM_LOCK_TTL_SECONDS;
+  (err as ApiError & { exposeMessage: boolean; retryAfter: number }).exposeMessage = true;
+  (err as ApiError & { exposeMessage: boolean; retryAfter: number }).retryAfter = RANKING_WARM_LOCK_TTL_SECONDS;
   throw err;
 }
 

--- a/tests/helpers/fake-upstash-redis.mts
+++ b/tests/helpers/fake-upstash-redis.mts
@@ -129,6 +129,8 @@ export function createRedisFetch(fixtures: Record<string, unknown>): FakeRedisSt
         if (normalizedVerb === 'EVALSHA' || normalizedVerb === 'EVALSHA_RO') {
           const numericArgs = args.map(Number).filter((value) => Number.isFinite(value));
           const limit = numericArgs.length > 0 ? Math.max(...numericArgs) : 600;
+          // Mirrors the Upstash rate-limit Lua response shape enough for gateway
+          // policy tests: [remaining, reset_at_ms].
           return { result: [Math.max(0, limit - 1), limit] };
         }
 

--- a/tests/helpers/fake-upstash-redis.mts
+++ b/tests/helpers/fake-upstash-redis.mts
@@ -58,7 +58,9 @@ export function createRedisFetch(fixtures: Record<string, unknown>): FakeRedisSt
     const parsed = new URL(url);
     if (parsed.pathname.startsWith('/get/')) {
       const key = decodeURIComponent(parsed.pathname.slice('/get/'.length));
-      return new Response(JSON.stringify({ result: redis.get(key) ?? null }), { status: 200 });
+      return new Response(JSON.stringify({ result: redis.get(key) ?? null }), {
+        status: 200,
+      });
     }
 
     if (parsed.pathname.startsWith('/set/')) {
@@ -73,12 +75,26 @@ export function createRedisFetch(fixtures: Record<string, unknown>): FakeRedisSt
       const command = JSON.parse(typeof init?.body === 'string' ? init.body : '[]') as string[];
       const [verb, key = '', value = ''] = command;
       if (verb === 'SET') {
-        const opts = command.slice(3).map(String).map((item) => item.toUpperCase());
+        const opts = command
+          .slice(3)
+          .map(String)
+          .map((item) => item.toUpperCase());
         if (opts.includes('NX') && redis.has(key)) {
-          return new Response(JSON.stringify({ result: null }), { status: 200 });
+          return new Response(JSON.stringify({ result: null }), {
+            status: 200,
+          });
         }
         redis.set(key, value);
         return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+      }
+      if (String(verb).toUpperCase() === 'EVAL') {
+        const keyArg = String(command[3] ?? '');
+        const expected = String(command[4] ?? '');
+        if (redis.get(keyArg) === expected) {
+          redis.delete(keyArg);
+          return new Response(JSON.stringify({ result: 1 }), { status: 200 });
+        }
+        return new Response(JSON.stringify({ result: 0 }), { status: 200 });
       }
       throw new Error(`Unexpected POST / command: ${verb}`);
     }
@@ -87,14 +103,18 @@ export function createRedisFetch(fixtures: Record<string, unknown>): FakeRedisSt
       const commands = JSON.parse(typeof init?.body === 'string' ? init.body : '[]') as Array<Array<string | number>>;
       const result = commands.map((command) => {
         const [verb, key = '', ...args] = command;
+        const normalizedVerb = String(verb).toUpperCase();
         const redisKey = String(key);
 
-        if (verb === 'GET') {
+        if (normalizedVerb === 'GET') {
           return { result: redis.get(redisKey) ?? null };
         }
 
-        if (verb === 'SET') {
-          const opts = args.slice(1).map(String).map((item) => item.toUpperCase());
+        if (normalizedVerb === 'SET') {
+          const opts = args
+            .slice(1)
+            .map(String)
+            .map((item) => item.toUpperCase());
           if (opts.includes('NX') && redis.has(redisKey)) {
             return { result: null };
           }
@@ -102,14 +122,24 @@ export function createRedisFetch(fixtures: Record<string, unknown>): FakeRedisSt
           return { result: 'OK' };
         }
 
-        if (verb === 'EXISTS') {
+        if (normalizedVerb === 'DEL') {
+          return { result: redis.delete(redisKey) ? 1 : 0 };
+        }
+
+        if (normalizedVerb === 'EVALSHA' || normalizedVerb === 'EVALSHA_RO') {
+          const numericArgs = args.map(Number).filter((value) => Number.isFinite(value));
+          const limit = numericArgs.length > 0 ? Math.max(...numericArgs) : 600;
+          return { result: [Math.max(0, limit - 1), limit] };
+        }
+
+        if (normalizedVerb === 'EXISTS') {
           // Real Redis EXISTS returns 1/0 for single key, count for multi-key.
           // The handler's parity check uses single-key form per pipeline entry,
           // so we just mirror that shape here.
           return { result: redis.has(redisKey) ? 1 : 0 };
         }
 
-        if (verb === 'ZADD') {
+        if (normalizedVerb === 'ZADD') {
           let added = 0;
           for (let index = 0; index < args.length; index += 2) {
             const existed = (sortedSets.get(redisKey) ?? []).some((e) => e.member === String(args[index + 1] ?? ''));
@@ -119,21 +149,23 @@ export function createRedisFetch(fixtures: Record<string, unknown>): FakeRedisSt
           return { result: added };
         }
 
-        if (verb === 'ZRANGE') {
+        if (normalizedVerb === 'ZRANGE') {
           const items = readByRank(redisKey, Number(args[0] ?? 0), Number(args[1] ?? 0));
           const withScores = args.map(String).includes('WITHSCORES');
           if (!withScores) return { result: items.map((item) => item.member) };
-          return { result: items.flatMap((item) => [item.member, String(item.score)]) };
+          return {
+            result: items.flatMap((item) => [item.member, String(item.score)]),
+          };
         }
 
-        if (verb === 'ZREMRANGEBYRANK') {
+        if (normalizedVerb === 'ZREMRANGEBYRANK') {
           const before = (sortedSets.get(redisKey) ?? []).length;
           removeByRank(redisKey, Number(args[0] ?? 0), Number(args[1] ?? 0));
           const after = (sortedSets.get(redisKey) ?? []).length;
           return { result: before - after };
         }
 
-        if (verb === 'EXPIRE') {
+        if (normalizedVerb === 'EXPIRE') {
           expires.set(redisKey, Number(args[0] ?? 0));
           return { result: 1 };
         }

--- a/tests/premium-stock-gateway.test.mts
+++ b/tests/premium-stock-gateway.test.mts
@@ -5,9 +5,30 @@ import { generateKeyPair, exportJWK, SignJWT } from 'jose';
 
 import { createDomainGateway } from '../server/gateway.ts';
 import { issueSessionToken } from '../api/_session.js';
+import { createRedisFetch } from './helpers/fake-upstash-redis.mts';
 
 const originalKeys = process.env.WORLDMONITOR_VALID_KEYS;
 const originalSessionSecret = process.env.WM_SESSION_SECRET;
+const originalRedisUrl = process.env.UPSTASH_REDIS_REST_URL;
+const originalRedisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+const originalFetch = globalThis.fetch;
+
+function installRateLimitRedisFake(): void {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+  const { fetchImpl } = createRedisFetch({});
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+    if (url.startsWith(process.env.UPSTASH_REDIS_REST_URL || '')) {
+      return fetchImpl(input, init);
+    }
+    return originalFetch(input, init);
+  }) as typeof fetch;
+}
 
 // Public routes now require a wms_ session token (issue #3541) — header-only
 // origin trust is gone. Mint one for tests that previously relied on
@@ -15,11 +36,23 @@ const originalSessionSecret = process.env.WM_SESSION_SECRET;
 process.env.WM_SESSION_SECRET = originalSessionSecret
   ?? 'test-secret-must-be-at-least-32-chars-long-xxx';
 let SESSION_TOKEN: string;
-before(async () => { SESSION_TOKEN = (await issueSessionToken()).token; });
+before(async () => {
+  installRateLimitRedisFake();
+  SESSION_TOKEN = (await issueSessionToken()).token;
+});
+
+after(() => {
+  globalThis.fetch = originalFetch;
+  if (originalRedisUrl == null) delete process.env.UPSTASH_REDIS_REST_URL;
+  else process.env.UPSTASH_REDIS_REST_URL = originalRedisUrl;
+  if (originalRedisToken == null) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  else process.env.UPSTASH_REDIS_REST_TOKEN = originalRedisToken;
+});
 
 afterEach(() => {
   if (originalKeys == null) delete process.env.WORLDMONITOR_VALID_KEYS;
   else process.env.WORLDMONITOR_VALID_KEYS = originalKeys;
+  installRateLimitRedisFake();
   // Keep the session secret stable across tests so SESSION_TOKEN stays valid.
   process.env.WM_SESSION_SECRET = originalSessionSecret
     ?? 'test-secret-must-be-at-least-32-chars-long-xxx';
@@ -178,7 +211,7 @@ describe('premium gateway API key enforcement', () => {
     process.env.CONVEX_SERVER_SHARED_SECRET = 'test-secret';
     process.env.WORLDMONITOR_VALID_KEYS = 'real-key-123';
 
-    globalThis.fetch = (async (input: RequestInfo | URL) => {
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const url =
         typeof input === 'string'
           ? input
@@ -209,7 +242,10 @@ describe('premium gateway API key enforcement', () => {
           { status: 200, headers: { 'Content-Type': 'application/json' } },
         );
       }
-      return new Response('not-mocked', { status: 404 });
+      if (url.startsWith(process.env.CONVEX_SITE_URL || '')) {
+        return new Response('not-mocked', { status: 404 });
+      }
+      return originalFetch(input, init);
     }) as typeof fetch;
 
     try {

--- a/tests/resilience-ranking.test.mts
+++ b/tests/resilience-ranking.test.mts
@@ -1410,11 +1410,24 @@ describe('resilience ranking contracts', () => {
   it('ApiError retryAfter maps temporary-unavailable warm contention to explicit 503 + Retry-After', async () => {
     const err = new ApiError(503, 'Resilience ranking temporarily unavailable while cache warm is in progress', '');
     (err as ApiError & { retryAfter: number }).retryAfter = 60;
+    (err as ApiError & { exposeMessage: boolean }).exposeMessage = true;
     const response = mapErrorToResponse(err, new Request('https://example.com'));
     assert.equal(response.status, 503);
     assert.equal(response.headers.get('Retry-After'), '60');
     assert.deepEqual(await response.json(), {
       message: 'Resilience ranking temporarily unavailable while cache warm is in progress',
+      retryAfter: 60,
+    });
+  });
+
+  it('ApiError retryAfter does not expose generic 503 messages without explicit opt-in', async () => {
+    const err = new ApiError(503, 'Internal upstream URL https://secret.example failed', '');
+    (err as ApiError & { retryAfter: number }).retryAfter = 60;
+    const response = mapErrorToResponse(err, new Request('https://example.com'));
+    assert.equal(response.status, 503);
+    assert.equal(response.headers.get('Retry-After'), '60');
+    assert.deepEqual(await response.json(), {
+      message: 'Internal server error',
       retryAfter: 60,
     });
   });

--- a/tests/resilience-ranking.test.mts
+++ b/tests/resilience-ranking.test.mts
@@ -3,6 +3,7 @@ import { afterEach, describe, it } from 'node:test';
 
 import { createDomainGateway } from '../server/gateway.ts';
 import { mapErrorToResponse } from '../server/error-mapper.ts';
+import { ENDPOINT_RATE_POLICIES } from '../server/_shared/rate-limit.ts';
 import { getResilienceRanking } from '../server/worldmonitor/resilience/v1/get-resilience-ranking.ts';
 import { ApiError } from '../src/generated/server/worldmonitor/resilience/v1/service_server.ts';
 import {
@@ -16,7 +17,7 @@ import {
   sortRankingItems,
   warmMissingResilienceScores,
 } from '../server/worldmonitor/resilience/v1/_shared.ts';
-import { __resetKeyPrefixCacheForTests } from '../server/_shared/redis.ts';
+import { __resetKeyPrefixCacheForTests, compareAndDeleteRedisKey } from '../server/_shared/redis.ts';
 import { installRedis } from './helpers/fake-upstash-redis.mts';
 import { RESILIENCE_FIXTURES } from './helpers/resilience-fixtures.mts';
 
@@ -69,16 +70,47 @@ afterEach(() => {
 describe('resilience ranking contracts', () => {
   it('sorts descending by overall score and keeps unscored placeholders at the end', () => {
     const sorted = sortRankingItems([
-      { countryCode: 'US', overallScore: 61, level: 'medium', lowConfidence: false },
-      { countryCode: 'YE', overallScore: -1, level: 'unknown', lowConfidence: true },
-      { countryCode: 'NO', overallScore: 82, level: 'high', lowConfidence: false },
-      { countryCode: 'DE', overallScore: -1, level: 'unknown', lowConfidence: true },
-      { countryCode: 'JP', overallScore: 61, level: 'medium', lowConfidence: false },
+      {
+        countryCode: 'US',
+        overallScore: 61,
+        level: 'medium',
+        lowConfidence: false,
+      },
+      {
+        countryCode: 'YE',
+        overallScore: -1,
+        level: 'unknown',
+        lowConfidence: true,
+      },
+      {
+        countryCode: 'NO',
+        overallScore: 82,
+        level: 'high',
+        lowConfidence: false,
+      },
+      {
+        countryCode: 'DE',
+        overallScore: -1,
+        level: 'unknown',
+        lowConfidence: true,
+      },
+      {
+        countryCode: 'JP',
+        overallScore: 61,
+        level: 'medium',
+        lowConfidence: false,
+      },
     ]);
 
     assert.deepEqual(
       sorted.map((item) => [item.countryCode, item.overallScore]),
-      [['NO', 82], ['JP', 61], ['US', 61], ['DE', -1], ['YE', -1]],
+      [
+        ['NO', 82],
+        ['JP', 61],
+        ['US', 61],
+        ['DE', -1],
+        ['YE', -1],
+      ],
     );
   });
 
@@ -89,8 +121,22 @@ describe('resilience ranking contracts', () => {
     // dedicated backfill test in resilience-headline-eligible-field.test.mts.
     const cachedPublic = {
       items: [
-        { countryCode: 'NO', overallScore: 82, level: 'high', lowConfidence: false, overallCoverage: 0.95, headlineEligible: true },
-        { countryCode: 'US', overallScore: 61, level: 'medium', lowConfidence: false, overallCoverage: 0.88, headlineEligible: true },
+        {
+          countryCode: 'NO',
+          overallScore: 82,
+          level: 'high',
+          lowConfidence: false,
+          overallCoverage: 0.95,
+          headlineEligible: true,
+        },
+        {
+          countryCode: 'US',
+          overallScore: 61,
+          level: 'medium',
+          lowConfidence: false,
+          overallCoverage: 0.88,
+          headlineEligible: true,
+        },
       ],
       greyedOut: [],
       ...RANKING_META,
@@ -119,10 +165,22 @@ describe('resilience ranking contracts', () => {
     const { redis } = installRedis(RESILIENCE_FIXTURES);
     const legacyCached = {
       items: [
-        { countryCode: 'NO', overallScore: 82, level: 'high', lowConfidence: false, overallCoverage: 0.95 },
+        {
+          countryCode: 'NO',
+          overallScore: 82,
+          level: 'high',
+          lowConfidence: false,
+          overallCoverage: 0.95,
+        },
       ],
       greyedOut: [
-        { countryCode: 'SS', overallScore: 12, level: 'critical', lowConfidence: true, overallCoverage: 0.15 },
+        {
+          countryCode: 'SS',
+          overallScore: 12,
+          level: 'critical',
+          lowConfidence: true,
+          overallCoverage: 0.15,
+        },
       ],
       ...RANKING_META,
     };
@@ -134,14 +192,13 @@ describe('resilience ranking contracts', () => {
     // backfill flips it to false, then the gate routes it to greyedOut.
     const noItem = [...response.items, ...response.greyedOut].find((item) => item.countryCode === 'NO');
     const ssItem = [...response.items, ...response.greyedOut].find((item) => item.countryCode === 'SS');
-    assert.equal(noItem?.headlineEligible, false,
-      'v17 cache-read backfill must default missing headlineEligible to false (conservative — gate is SoT)');
-    assert.equal(ssItem?.headlineEligible, false,
-      'v17 cache-read backfill must default missing headlineEligible to false on greyedOut[] too');
-    assert.ok(response.greyedOut.some((item) => item.countryCode === 'NO'),
-      'NO with missing headlineEligible must route to greyedOut[] (not items[]) after conservative backfill + gate filter');
-    assert.ok(!response.items.some((item) => item.countryCode === 'NO'),
-      'NO must NOT appear in items[] — conservative default sends it to greyedOut');
+    assert.equal(noItem?.headlineEligible, false, 'v17 cache-read backfill must default missing headlineEligible to false (conservative — gate is SoT)');
+    assert.equal(ssItem?.headlineEligible, false, 'v17 cache-read backfill must default missing headlineEligible to false on greyedOut[] too');
+    assert.ok(
+      response.greyedOut.some((item) => item.countryCode === 'NO'),
+      'NO with missing headlineEligible must route to greyedOut[] (not items[]) after conservative backfill + gate filter',
+    );
+    assert.ok(!response.items.some((item) => item.countryCode === 'NO'), 'NO must NOT appear in items[] — conservative default sends it to greyedOut');
   });
 
   it('returns all-greyed-out cached payload without rewarming (items=[], greyedOut non-empty)', async () => {
@@ -157,8 +214,22 @@ describe('resilience ranking contracts', () => {
     const cachedPublic = {
       items: [],
       greyedOut: [
-        { countryCode: 'SS', overallScore: 12, level: 'critical', lowConfidence: true, overallCoverage: 0.15, headlineEligible: false },
-        { countryCode: 'ER', overallScore: 10, level: 'critical', lowConfidence: true, overallCoverage: 0.12, headlineEligible: false },
+        {
+          countryCode: 'SS',
+          overallScore: 12,
+          level: 'critical',
+          lowConfidence: true,
+          overallCoverage: 0.15,
+          headlineEligible: false,
+        },
+        {
+          countryCode: 'ER',
+          overallScore: 10,
+          level: 'critical',
+          lowConfidence: true,
+          overallCoverage: 0.12,
+          headlineEligible: false,
+        },
       ],
       ...RANKING_META,
     };
@@ -185,27 +256,62 @@ describe('resilience ranking contracts', () => {
     // ranking warm path runs for the untagged country (meaning the
     // bulk read skipped it).
     const { redis } = installRedis(RESILIENCE_FIXTURES);
-    redis.set('resilience:static:index:v1', JSON.stringify({
-      countries: ['NO', 'US'],
-      recordCount: 2,
-      failedDatasets: [],
-      seedYear: 2026,
-    }));
+    redis.set(
+      'resilience:static:index:v1',
+      JSON.stringify({
+        countries: ['NO', 'US'],
+        recordCount: 2,
+        failedDatasets: [],
+        seedYear: 2026,
+      }),
+    );
 
-    const domain = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
+    const domain = [
+      {
+        id: 'political',
+        score: 80,
+        weight: 0.2,
+        dimensions: [
+          {
+            id: 'd1',
+            score: 80,
+            coverage: 0.9,
+            observedWeight: 1,
+            imputedWeight: 0,
+          },
+        ],
+      },
+    ];
     // Tagged entry: served as-is.
-    redis.set(`${RESILIENCE_SCORE_CACHE_PREFIX}NO`, JSON.stringify({
-      countryCode: 'NO', overallScore: 82, level: 'high',
-      domains: domain, trend: 'stable', change30d: 1.2,
-      lowConfidence: false, imputationShare: 0.05, _formula: 'd6',
-    }));
+    redis.set(
+      `${RESILIENCE_SCORE_CACHE_PREFIX}NO`,
+      JSON.stringify({
+        countryCode: 'NO',
+        overallScore: 82,
+        level: 'high',
+        domains: domain,
+        trend: 'stable',
+        change30d: 1.2,
+        lowConfidence: false,
+        imputationShare: 0.05,
+        _formula: 'd6',
+      }),
+    );
     // Untagged entry: must be rejected, ranking warm rebuilds US.
-    redis.set(`${RESILIENCE_SCORE_CACHE_PREFIX}US`, JSON.stringify({
-      countryCode: 'US', overallScore: 61, level: 'medium',
-      domains: domain, trend: 'rising', change30d: 4.3,
-      lowConfidence: false, imputationShare: 0.1,
-      // NOTE: no _formula field.
-    }));
+    redis.set(
+      `${RESILIENCE_SCORE_CACHE_PREFIX}US`,
+      JSON.stringify({
+        countryCode: 'US',
+        overallScore: 61,
+        level: 'medium',
+        domains: domain,
+        trend: 'rising',
+        change30d: 4.3,
+        lowConfidence: false,
+        imputationShare: 0.1,
+        // NOTE: no _formula field.
+      }),
+    );
 
     await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
@@ -235,7 +341,13 @@ describe('resilience ranking contracts', () => {
     const { redis } = installRedis(RESILIENCE_FIXTURES);
     const stale = {
       items: [
-        { countryCode: 'NO', overallScore: 99, level: 'high', lowConfidence: false, overallCoverage: 0.95 },
+        {
+          countryCode: 'NO',
+          overallScore: 99,
+          level: 'high',
+          lowConfidence: false,
+          overallCoverage: 0.95,
+        },
       ],
       greyedOut: [],
       ...RANKING_META,
@@ -246,17 +358,10 @@ describe('resilience ranking contracts', () => {
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
-    assert.notDeepEqual(
-      response,
-      { items: stale.items, greyedOut: stale.greyedOut },
-      'stale-formula ranking must be rejected, not served',
-    );
+    assert.notDeepEqual(response, { items: stale.items, greyedOut: stale.greyedOut }, 'stale-formula ranking must be rejected, not served');
     // Recompute path warms missing per-country scores, so YE (in
     // RESILIENCE_FIXTURES) must get scored during this call.
-    assert.ok(
-      redis.has(`${RESILIENCE_SCORE_CACHE_PREFIX}YE`),
-      'stale-formula reject must trigger the recompute-and-warm path',
-    );
+    assert.ok(redis.has(`${RESILIENCE_SCORE_CACHE_PREFIX}YE`), 'stale-formula reject must trigger the recompute-and-warm path');
   });
 
   it('rejects a same-formula ranking cache entry missing interval methodology metadata', async () => {
@@ -265,77 +370,197 @@ describe('resilience ranking contracts', () => {
     // Current cache hits must therefore prove both the score formula and
     // interval methodology, not just `_formula`.
     const { redis } = installRedis(RESILIENCE_FIXTURES);
-    redis.set('resilience:static:index:v1', JSON.stringify({
-      countries: ['NO', 'US'],
-      recordCount: 2,
-      failedDatasets: [],
-      seedYear: 2026,
-    }));
-    const domainWithCoverage = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
-    redis.set(`${RESILIENCE_SCORE_CACHE_PREFIX}NO`, JSON.stringify({
-      countryCode: 'NO', overallScore: 82, level: 'high',
-      domains: domainWithCoverage, trend: 'stable', change30d: 1.2,
-      lowConfidence: false, imputationShare: 0.05, headlineEligible: true, _formula: 'd6',
-    }));
-    redis.set(`${RESILIENCE_SCORE_CACHE_PREFIX}US`, JSON.stringify({
-      countryCode: 'US', overallScore: 61, level: 'medium',
-      domains: domainWithCoverage, trend: 'rising', change30d: 4.3,
-      lowConfidence: false, imputationShare: 0.1, headlineEligible: true, _formula: 'd6',
-    }));
-    redis.set(RESILIENCE_RANKING_CACHE_KEY, JSON.stringify({
-      items: [
-        { countryCode: 'NO', overallScore: 99, level: 'high', lowConfidence: false, overallCoverage: 0.95, headlineEligible: true, rankStable: true },
-        { countryCode: 'US', overallScore: 98, level: 'high', lowConfidence: false, overallCoverage: 0.95, headlineEligible: true, rankStable: true },
-      ],
-      greyedOut: [],
-      ...RANKING_META,
-      _formula: 'd6',
-      // Deliberately missing _intervalMethodology: old ranking payload.
-    }));
+    redis.set(
+      'resilience:static:index:v1',
+      JSON.stringify({
+        countries: ['NO', 'US'],
+        recordCount: 2,
+        failedDatasets: [],
+        seedYear: 2026,
+      }),
+    );
+    const domainWithCoverage = [
+      {
+        id: 'political',
+        score: 80,
+        weight: 0.2,
+        dimensions: [
+          {
+            id: 'd1',
+            score: 80,
+            coverage: 0.9,
+            observedWeight: 1,
+            imputedWeight: 0,
+          },
+        ],
+      },
+    ];
+    redis.set(
+      `${RESILIENCE_SCORE_CACHE_PREFIX}NO`,
+      JSON.stringify({
+        countryCode: 'NO',
+        overallScore: 82,
+        level: 'high',
+        domains: domainWithCoverage,
+        trend: 'stable',
+        change30d: 1.2,
+        lowConfidence: false,
+        imputationShare: 0.05,
+        headlineEligible: true,
+        _formula: 'd6',
+      }),
+    );
+    redis.set(
+      `${RESILIENCE_SCORE_CACHE_PREFIX}US`,
+      JSON.stringify({
+        countryCode: 'US',
+        overallScore: 61,
+        level: 'medium',
+        domains: domainWithCoverage,
+        trend: 'rising',
+        change30d: 4.3,
+        lowConfidence: false,
+        imputationShare: 0.1,
+        headlineEligible: true,
+        _formula: 'd6',
+      }),
+    );
+    redis.set(
+      RESILIENCE_RANKING_CACHE_KEY,
+      JSON.stringify({
+        items: [
+          {
+            countryCode: 'NO',
+            overallScore: 99,
+            level: 'high',
+            lowConfidence: false,
+            overallCoverage: 0.95,
+            headlineEligible: true,
+            rankStable: true,
+          },
+          {
+            countryCode: 'US',
+            overallScore: 98,
+            level: 'high',
+            lowConfidence: false,
+            overallCoverage: 0.95,
+            headlineEligible: true,
+            rankStable: true,
+          },
+        ],
+        greyedOut: [],
+        ...RANKING_META,
+        _formula: 'd6',
+        // Deliberately missing _intervalMethodology: old ranking payload.
+      }),
+    );
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
     assert.deepEqual(
       response.items.map((item) => [item.countryCode, item.overallScore, item.rankStable]),
-      [['NO', 82, false], ['US', 61, false]],
+      [
+        ['NO', 82, false],
+        ['US', 61, false],
+      ],
       'same-formula cache without interval methodology must recompute and not preserve baked rankStable',
     );
   });
 
   it('rejects a same-formula ranking cache entry missing response metadata', async () => {
     const { redis } = installRedis(RESILIENCE_FIXTURES);
-    redis.set('resilience:static:index:v1', JSON.stringify({
-      countries: ['NO', 'US'],
-      recordCount: 2,
-      failedDatasets: [],
-      seedYear: 2026,
-    }));
-    const domainWithCoverage = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
-    redis.set(`${RESILIENCE_SCORE_CACHE_PREFIX}NO`, JSON.stringify({
-      countryCode: 'NO', overallScore: 82, level: 'high',
-      domains: domainWithCoverage, trend: 'stable', change30d: 1.2,
-      lowConfidence: false, imputationShare: 0.05, headlineEligible: true, _formula: 'd6',
-    }));
-    redis.set(`${RESILIENCE_SCORE_CACHE_PREFIX}US`, JSON.stringify({
-      countryCode: 'US', overallScore: 61, level: 'medium',
-      domains: domainWithCoverage, trend: 'rising', change30d: 4.3,
-      lowConfidence: false, imputationShare: 0.1, headlineEligible: true, _formula: 'd6',
-    }));
-    redis.set(RESILIENCE_RANKING_CACHE_KEY, JSON.stringify({
-      items: [
-        { countryCode: 'NO', overallScore: 99, level: 'high', lowConfidence: false, overallCoverage: 0.95, headlineEligible: true, rankStable: true },
-        { countryCode: 'US', overallScore: 98, level: 'high', lowConfidence: false, overallCoverage: 0.95, headlineEligible: true, rankStable: true },
-      ],
-      greyedOut: [],
-      ...D6_RANKING_CACHE_TAG,
-      // Deliberately missing fetchedAt/scored/total/coverage/partial.
-    }));
+    redis.set(
+      'resilience:static:index:v1',
+      JSON.stringify({
+        countries: ['NO', 'US'],
+        recordCount: 2,
+        failedDatasets: [],
+        seedYear: 2026,
+      }),
+    );
+    const domainWithCoverage = [
+      {
+        id: 'political',
+        score: 80,
+        weight: 0.2,
+        dimensions: [
+          {
+            id: 'd1',
+            score: 80,
+            coverage: 0.9,
+            observedWeight: 1,
+            imputedWeight: 0,
+          },
+        ],
+      },
+    ];
+    redis.set(
+      `${RESILIENCE_SCORE_CACHE_PREFIX}NO`,
+      JSON.stringify({
+        countryCode: 'NO',
+        overallScore: 82,
+        level: 'high',
+        domains: domainWithCoverage,
+        trend: 'stable',
+        change30d: 1.2,
+        lowConfidence: false,
+        imputationShare: 0.05,
+        headlineEligible: true,
+        _formula: 'd6',
+      }),
+    );
+    redis.set(
+      `${RESILIENCE_SCORE_CACHE_PREFIX}US`,
+      JSON.stringify({
+        countryCode: 'US',
+        overallScore: 61,
+        level: 'medium',
+        domains: domainWithCoverage,
+        trend: 'rising',
+        change30d: 4.3,
+        lowConfidence: false,
+        imputationShare: 0.1,
+        headlineEligible: true,
+        _formula: 'd6',
+      }),
+    );
+    redis.set(
+      RESILIENCE_RANKING_CACHE_KEY,
+      JSON.stringify({
+        items: [
+          {
+            countryCode: 'NO',
+            overallScore: 99,
+            level: 'high',
+            lowConfidence: false,
+            overallCoverage: 0.95,
+            headlineEligible: true,
+            rankStable: true,
+          },
+          {
+            countryCode: 'US',
+            overallScore: 98,
+            level: 'high',
+            lowConfidence: false,
+            overallCoverage: 0.95,
+            headlineEligible: true,
+            rankStable: true,
+          },
+        ],
+        greyedOut: [],
+        ...D6_RANKING_CACHE_TAG,
+        // Deliberately missing fetchedAt/scored/total/coverage/partial.
+      }),
+    );
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
     assert.deepEqual(
       response.items.map((item) => [item.countryCode, item.overallScore]),
-      [['NO', 82], ['US', 61]],
+      [
+        ['NO', 82],
+        ['US', 61],
+      ],
       'same-formula cache without response metadata must recompute so freshness/partial fields are real',
     );
     assert.match(response.fetchedAt, /^\d{4}-\d{2}-\d{2}T/);
@@ -344,50 +569,94 @@ describe('resilience ranking contracts', () => {
   it('warms missing scores synchronously and returns complete ranking on first call', async () => {
     const { redis } = installRedis(RESILIENCE_FIXTURES);
     const domainWithCoverage = [{ name: 'political', dimensions: [{ name: 'd1', coverage: 0.9 }] }];
-    redis.set(`${RESILIENCE_SCORE_CACHE_PREFIX}NO`, JSON.stringify({
-      countryCode: 'NO',
-      overallScore: 82,
-      level: 'high',
-      domains: domainWithCoverage,
-      trend: 'stable',
-      change30d: 1.2,
-      lowConfidence: false,
-      imputationShare: 0.05,
-    }));
-    redis.set(`${RESILIENCE_SCORE_CACHE_PREFIX}US`, JSON.stringify({
-      countryCode: 'US',
-      overallScore: 61,
-      level: 'medium',
-      domains: domainWithCoverage,
-      trend: 'rising',
-      change30d: 4.3,
-      lowConfidence: false,
-      imputationShare: 0.1,
-    }));
+    redis.set(
+      `${RESILIENCE_SCORE_CACHE_PREFIX}NO`,
+      JSON.stringify({
+        countryCode: 'NO',
+        overallScore: 82,
+        level: 'high',
+        domains: domainWithCoverage,
+        trend: 'stable',
+        change30d: 1.2,
+        lowConfidence: false,
+        imputationShare: 0.05,
+      }),
+    );
+    redis.set(
+      `${RESILIENCE_SCORE_CACHE_PREFIX}US`,
+      JSON.stringify({
+        countryCode: 'US',
+        overallScore: 61,
+        level: 'medium',
+        domains: domainWithCoverage,
+        trend: 'rising',
+        change30d: 4.3,
+        lowConfidence: false,
+        imputationShare: 0.1,
+      }),
+    );
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
     const totalItems = response.items.length + (response.greyedOut?.length ?? 0);
     assert.equal(totalItems, 3, `expected 3 total items across ranked + greyedOut, got ${totalItems}`);
     assert.ok(redis.has(`${RESILIENCE_SCORE_CACHE_PREFIX}YE`), 'missing country should be warmed during first call');
-    assert.ok(response.items.every((item) => item.overallScore >= 0), 'ranked items should all have computed scores');
+    assert.ok(
+      response.items.every((item) => item.overallScore >= 0),
+      'ranked items should all have computed scores',
+    );
     assert.ok(redis.has(RESILIENCE_RANKING_CACHE_KEY), 'fully scored ranking should be cached');
   });
 
   it('sets rankStable=true when interval data exists and width <= 8', async () => {
     process.env.RESILIENCE_PILLAR_COMBINE_ENABLED = 'false';
     const { redis } = installRedis(RESILIENCE_FIXTURES);
-    const domainWithCoverage = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
-    redis.set(`${RESILIENCE_SCORE_CACHE_PREFIX}NO`, JSON.stringify({
-      countryCode: 'NO', overallScore: 82, level: 'high',
-      domains: domainWithCoverage, trend: 'stable', change30d: 1.2,
-      lowConfidence: false, imputationShare: 0.05, headlineEligible: true, _formula: 'd6',
-    }));
-    redis.set(`${RESILIENCE_SCORE_CACHE_PREFIX}US`, JSON.stringify({
-      countryCode: 'US', overallScore: 61, level: 'medium',
-      domains: domainWithCoverage, trend: 'rising', change30d: 4.3,
-      lowConfidence: false, imputationShare: 0.1, headlineEligible: true, _formula: 'd6',
-    }));
+    const domainWithCoverage = [
+      {
+        id: 'political',
+        score: 80,
+        weight: 0.2,
+        dimensions: [
+          {
+            id: 'd1',
+            score: 80,
+            coverage: 0.9,
+            observedWeight: 1,
+            imputedWeight: 0,
+          },
+        ],
+      },
+    ];
+    redis.set(
+      `${RESILIENCE_SCORE_CACHE_PREFIX}NO`,
+      JSON.stringify({
+        countryCode: 'NO',
+        overallScore: 82,
+        level: 'high',
+        domains: domainWithCoverage,
+        trend: 'stable',
+        change30d: 1.2,
+        lowConfidence: false,
+        imputationShare: 0.05,
+        headlineEligible: true,
+        _formula: 'd6',
+      }),
+    );
+    redis.set(
+      `${RESILIENCE_SCORE_CACHE_PREFIX}US`,
+      JSON.stringify({
+        countryCode: 'US',
+        overallScore: 61,
+        level: 'medium',
+        domains: domainWithCoverage,
+        trend: 'rising',
+        change30d: 4.3,
+        lowConfidence: false,
+        imputationShare: 0.1,
+        headlineEligible: true,
+        _formula: 'd6',
+      }),
+    );
     redis.set(`${RESILIENCE_INTERVAL_KEY_PREFIX}NO`, JSON.stringify({ p05: 78, p95: 84, _formula: 'd6' }));
     redis.set(`${RESILIENCE_INTERVAL_KEY_PREFIX}US`, JSON.stringify({ p05: 50, p95: 72, _formula: 'd6' }));
 
@@ -402,17 +671,52 @@ describe('resilience ranking contracts', () => {
   it('sets rankStable=false for stale-formula or untagged interval data', async () => {
     process.env.RESILIENCE_PILLAR_COMBINE_ENABLED = 'false';
     const { redis } = installRedis(RESILIENCE_FIXTURES);
-    const domainWithCoverage = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
-    redis.set(`${RESILIENCE_SCORE_CACHE_PREFIX}NO`, JSON.stringify({
-      countryCode: 'NO', overallScore: 82, level: 'high',
-      domains: domainWithCoverage, trend: 'stable', change30d: 1.2,
-      lowConfidence: false, imputationShare: 0.05, headlineEligible: true, _formula: 'd6',
-    }));
-    redis.set(`${RESILIENCE_SCORE_CACHE_PREFIX}US`, JSON.stringify({
-      countryCode: 'US', overallScore: 61, level: 'medium',
-      domains: domainWithCoverage, trend: 'rising', change30d: 4.3,
-      lowConfidence: false, imputationShare: 0.1, headlineEligible: true, _formula: 'd6',
-    }));
+    const domainWithCoverage = [
+      {
+        id: 'political',
+        score: 80,
+        weight: 0.2,
+        dimensions: [
+          {
+            id: 'd1',
+            score: 80,
+            coverage: 0.9,
+            observedWeight: 1,
+            imputedWeight: 0,
+          },
+        ],
+      },
+    ];
+    redis.set(
+      `${RESILIENCE_SCORE_CACHE_PREFIX}NO`,
+      JSON.stringify({
+        countryCode: 'NO',
+        overallScore: 82,
+        level: 'high',
+        domains: domainWithCoverage,
+        trend: 'stable',
+        change30d: 1.2,
+        lowConfidence: false,
+        imputationShare: 0.05,
+        headlineEligible: true,
+        _formula: 'd6',
+      }),
+    );
+    redis.set(
+      `${RESILIENCE_SCORE_CACHE_PREFIX}US`,
+      JSON.stringify({
+        countryCode: 'US',
+        overallScore: 61,
+        level: 'medium',
+        domains: domainWithCoverage,
+        trend: 'rising',
+        change30d: 4.3,
+        lowConfidence: false,
+        imputationShare: 0.1,
+        headlineEligible: true,
+        _formula: 'd6',
+      }),
+    );
     redis.set(`${RESILIENCE_INTERVAL_KEY_PREFIX}NO`, JSON.stringify({ p05: 78, p95: 84, _formula: 'pc' }));
     redis.set(`${RESILIENCE_INTERVAL_KEY_PREFIX}US`, JSON.stringify({ p05: 58, p95: 64 }));
 
@@ -426,34 +730,53 @@ describe('resilience ranking contracts', () => {
 
   it('does not cache the ranking at 80% coverage', async () => {
     const { redis, fetchImpl } = installRedis(RESILIENCE_FIXTURES);
-    redis.set('resilience:static:index:v1', JSON.stringify({
-      countries: ['NO', 'US', 'YE', 'CA', 'FR', 'DE', 'JP', 'BR', 'IN', 'ZA'],
-      recordCount: 10,
-      failedDatasets: [],
-      seedYear: 2026,
-    }));
-    const domainWithCoverage = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
+    redis.set(
+      'resilience:static:index:v1',
+      JSON.stringify({
+        countries: ['NO', 'US', 'YE', 'CA', 'FR', 'DE', 'JP', 'BR', 'IN', 'ZA'],
+        recordCount: 10,
+        failedDatasets: [],
+        seedYear: 2026,
+      }),
+    );
+    const domainWithCoverage = [
+      {
+        id: 'political',
+        score: 80,
+        weight: 0.2,
+        dimensions: [
+          {
+            id: 'd1',
+            score: 80,
+            coverage: 0.9,
+            observedWeight: 1,
+            imputedWeight: 0,
+          },
+        ],
+      },
+    ];
     for (const [index, countryCode] of ['NO', 'US', 'YE', 'CA', 'FR', 'DE', 'JP', 'BR'].entries()) {
-      redis.set(`${RESILIENCE_SCORE_CACHE_PREFIX}${countryCode}`, JSON.stringify({
-        countryCode,
-        overallScore: 80 - index,
-        level: 'high',
-        domains: domainWithCoverage,
-        trend: 'stable',
-        change30d: 0,
-        lowConfidence: false,
-        imputationShare: 0,
-        headlineEligible: true,
-        _formula: 'd6',
-      }));
+      redis.set(
+        `${RESILIENCE_SCORE_CACHE_PREFIX}${countryCode}`,
+        JSON.stringify({
+          countryCode,
+          overallScore: 80 - index,
+          level: 'high',
+          domains: domainWithCoverage,
+          trend: 'stable',
+          change30d: 0,
+          lowConfidence: false,
+          imputationShare: 0,
+          headlineEligible: true,
+          _formula: 'd6',
+        }),
+      );
     }
     const failScoreSets = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
       if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
         const commands = JSON.parse(init.body) as Array<Array<string>>;
-        const allScoreSets = commands.length > 0 && commands.every(
-          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith(RESILIENCE_SCORE_CACHE_PREFIX),
-        );
+        const allScoreSets = commands.length > 0 && commands.every((cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith(RESILIENCE_SCORE_CACHE_PREFIX));
         if (allScoreSets) {
           return new Response(JSON.stringify(commands.map(() => ({ result: null }))), { status: 200 });
         }
@@ -470,35 +793,54 @@ describe('resilience ranking contracts', () => {
 
   it('caches a 90%-94% partial ranking with explicit metadata and a short TTL', async () => {
     const { redis, fetchImpl } = installRedis(RESILIENCE_FIXTURES);
-    redis.set('resilience:static:index:v1', JSON.stringify({
-      countries: ['NO', 'US', 'YE', 'CA', 'FR', 'DE', 'JP', 'BR', 'IN', 'ZA'],
-      recordCount: 10,
-      failedDatasets: [],
-      seedYear: 2026,
-    }));
-    const domainWithCoverage = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
+    redis.set(
+      'resilience:static:index:v1',
+      JSON.stringify({
+        countries: ['NO', 'US', 'YE', 'CA', 'FR', 'DE', 'JP', 'BR', 'IN', 'ZA'],
+        recordCount: 10,
+        failedDatasets: [],
+        seedYear: 2026,
+      }),
+    );
+    const domainWithCoverage = [
+      {
+        id: 'political',
+        score: 80,
+        weight: 0.2,
+        dimensions: [
+          {
+            id: 'd1',
+            score: 80,
+            coverage: 0.9,
+            observedWeight: 1,
+            imputedWeight: 0,
+          },
+        ],
+      },
+    ];
     for (const [index, countryCode] of ['NO', 'US', 'YE', 'CA', 'FR', 'DE', 'JP', 'BR', 'IN'].entries()) {
-      redis.set(`${RESILIENCE_SCORE_CACHE_PREFIX}${countryCode}`, JSON.stringify({
-        countryCode,
-        overallScore: 80 - index,
-        level: 'high',
-        domains: domainWithCoverage,
-        trend: 'stable',
-        change30d: 0,
-        lowConfidence: false,
-        imputationShare: 0,
-        headlineEligible: true,
-        _formula: 'd6',
-      }));
+      redis.set(
+        `${RESILIENCE_SCORE_CACHE_PREFIX}${countryCode}`,
+        JSON.stringify({
+          countryCode,
+          overallScore: 80 - index,
+          level: 'high',
+          domains: domainWithCoverage,
+          trend: 'stable',
+          change30d: 0,
+          lowConfidence: false,
+          imputationShare: 0,
+          headlineEligible: true,
+          _formula: 'd6',
+        }),
+      );
     }
     const rankingSetCommands: Array<Array<string>> = [];
     const failScoreSetsAndCaptureRanking = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
       if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
         const commands = JSON.parse(init.body) as Array<Array<string>>;
-        const allScoreSets = commands.length > 0 && commands.every(
-          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith(RESILIENCE_SCORE_CACHE_PREFIX),
-        );
+        const allScoreSets = commands.length > 0 && commands.every((cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith(RESILIENCE_SCORE_CACHE_PREFIX));
         if (allScoreSets) {
           return new Response(JSON.stringify(commands.map(() => ({ result: null }))), { status: 200 });
         }
@@ -529,12 +871,15 @@ describe('resilience ranking contracts', () => {
 
   it('returns explicit partial metadata for an empty scorable universe without caching', async () => {
     const { redis } = installRedis({});
-    redis.set('resilience:static:index:v1', JSON.stringify({
-      countries: [],
-      recordCount: 0,
-      failedDatasets: [],
-      seedYear: 2026,
-    }));
+    redis.set(
+      'resilience:static:index:v1',
+      JSON.stringify({
+        countries: [],
+        recordCount: 0,
+        failedDatasets: [],
+        seedYear: 2026,
+      }),
+    );
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
@@ -560,12 +905,15 @@ describe('resilience ranking contracts', () => {
     // return null, coverage = 0% < 90%, handler skips the write. Post-fix,
     // the in-memory merge carries both scores, coverage = 100%, write
     // proceeds.
-    redis.set('resilience:static:index:v1', JSON.stringify({
-      countries: ['NO', 'US'],
-      recordCount: 2,
-      failedDatasets: [],
-      seedYear: 2026,
-    }));
+    redis.set(
+      'resilience:static:index:v1',
+      JSON.stringify({
+        countries: ['NO', 'US'],
+        recordCount: 2,
+        failedDatasets: [],
+        seedYear: 2026,
+      }),
+    );
 
     // Stale pipeline-GETs for score keys: pretend Redis hasn't caught up with
     // the /set writes yet. /set calls still mutate the underlying map so the
@@ -574,15 +922,10 @@ describe('resilience ranking contracts', () => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
       if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
         const commands = JSON.parse(init.body) as Array<Array<string>>;
-        const allScoreReads = commands.length > 0 && commands.every(
-          (cmd) => cmd[0] === 'GET' && typeof cmd[1] === 'string' && cmd[1].startsWith(RESILIENCE_SCORE_CACHE_PREFIX),
-        );
+        const allScoreReads = commands.length > 0 && commands.every((cmd) => cmd[0] === 'GET' && typeof cmd[1] === 'string' && cmd[1].startsWith(RESILIENCE_SCORE_CACHE_PREFIX));
         if (allScoreReads) {
           // Simulate visibility lag: pretend no scores are cached yet.
-          return new Response(
-            JSON.stringify(commands.map(() => ({ result: null }))),
-            { status: 200 },
-          );
+          return new Response(JSON.stringify(commands.map(() => ({ result: null }))), { status: 200 });
         }
       }
       return fetchImpl(input, init);
@@ -609,12 +952,15 @@ describe('resilience ranking contracts', () => {
     // doesn't lie. Simulate this by making SETs return OK in the warm path
     // but NOT actually mutating the underlying redis map for those keys.
     const { redis, fetchImpl } = installRedis(RESILIENCE_FIXTURES);
-    redis.set('resilience:static:index:v1', JSON.stringify({
-      countries: ['NO', 'US'],
-      recordCount: 2,
-      failedDatasets: [],
-      seedYear: 2026,
-    }));
+    redis.set(
+      'resilience:static:index:v1',
+      JSON.stringify({
+        countries: ['NO', 'US'],
+        recordCount: 2,
+        failedDatasets: [],
+        seedYear: 2026,
+      }),
+    );
 
     // Hijack /pipeline so SETs to score:v16:* return OK but don't actually
     // persist (simulating Upstash's optimistic-OK under load). Other commands
@@ -623,15 +969,10 @@ describe('resilience ranking contracts', () => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
       if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
         const commands = JSON.parse(init.body) as Array<Array<string>>;
-        const allScoreSets = commands.length > 0 && commands.every(
-          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith(RESILIENCE_SCORE_CACHE_PREFIX),
-        );
+        const allScoreSets = commands.length > 0 && commands.every((cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith(RESILIENCE_SCORE_CACHE_PREFIX));
         if (allScoreSets) {
           // Return OK without mutating redis — the lying-Upstash scenario.
-          return new Response(
-            JSON.stringify(commands.map(() => ({ result: 'OK' }))),
-            { status: 200 },
-          );
+          return new Response(JSON.stringify(commands.map(() => ({ result: 'OK' }))), { status: 200 });
         }
       }
       return fetchImpl(input, init);
@@ -640,10 +981,8 @@ describe('resilience ranking contracts', () => {
 
     await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
-    assert.equal(redis.has(RESILIENCE_RANKING_CACHE_KEY), false,
-      'ranking must NOT be published when score SETs returned OK but did not durably persist');
-    assert.equal(redis.has('seed-meta:resilience:ranking'), false,
-      'seed-meta must NOT be written when parity check fails — that would be a lying meta');
+    assert.equal(redis.has(RESILIENCE_RANKING_CACHE_KEY), false, 'ranking must NOT be published when score SETs returned OK but did not durably persist');
+    assert.equal(redis.has('seed-meta:resilience:ranking'), false, 'seed-meta must NOT be written when parity check fails — that would be a lying meta');
   });
 
   it('parity check: catches mixed persisted-tail failure (pre-warmed keys exist; new warmed-tail SETs return OK but do not persist)', async () => {
@@ -663,24 +1002,60 @@ describe('resilience ranking contracts', () => {
     // (YE + ZZ) get warmed via the SET pipeline, but our mock returns
     // OK without actually persisting them.
     const { redis, fetchImpl } = installRedis(RESILIENCE_FIXTURES);
-    redis.set('resilience:static:index:v1', JSON.stringify({
-      countries: ['NO', 'US', 'YE', 'ZZ'],
-      recordCount: 4,
-      failedDatasets: [],
-      seedYear: 2026,
-    }));
-    const domainWithCoverage = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
+    redis.set(
+      'resilience:static:index:v1',
+      JSON.stringify({
+        countries: ['NO', 'US', 'YE', 'ZZ'],
+        recordCount: 4,
+        failedDatasets: [],
+        seedYear: 2026,
+      }),
+    );
+    const domainWithCoverage = [
+      {
+        id: 'political',
+        score: 80,
+        weight: 0.2,
+        dimensions: [
+          {
+            id: 'd1',
+            score: 80,
+            coverage: 0.9,
+            observedWeight: 1,
+            imputedWeight: 0,
+          },
+        ],
+      },
+    ];
     // Pre-cache NO + US WITH formula tag so getCachedResilienceScores admits them.
-    redis.set(`${RESILIENCE_SCORE_CACHE_PREFIX}NO`, JSON.stringify({
-      countryCode: 'NO', overallScore: 82, level: 'high',
-      domains: domainWithCoverage, trend: 'stable', change30d: 1.2,
-      lowConfidence: false, imputationShare: 0.05, _formula: 'd6',
-    }));
-    redis.set(`${RESILIENCE_SCORE_CACHE_PREFIX}US`, JSON.stringify({
-      countryCode: 'US', overallScore: 61, level: 'medium',
-      domains: domainWithCoverage, trend: 'rising', change30d: 4.3,
-      lowConfidence: false, imputationShare: 0.1, _formula: 'd6',
-    }));
+    redis.set(
+      `${RESILIENCE_SCORE_CACHE_PREFIX}NO`,
+      JSON.stringify({
+        countryCode: 'NO',
+        overallScore: 82,
+        level: 'high',
+        domains: domainWithCoverage,
+        trend: 'stable',
+        change30d: 1.2,
+        lowConfidence: false,
+        imputationShare: 0.05,
+        _formula: 'd6',
+      }),
+    );
+    redis.set(
+      `${RESILIENCE_SCORE_CACHE_PREFIX}US`,
+      JSON.stringify({
+        countryCode: 'US',
+        overallScore: 61,
+        level: 'medium',
+        domains: domainWithCoverage,
+        trend: 'rising',
+        change30d: 4.3,
+        lowConfidence: false,
+        imputationShare: 0.1,
+        _formula: 'd6',
+      }),
+    );
 
     // Hijack /pipeline so SETs to score:v16:* return OK but don't persist —
     // simulating Upstash optimistic-OK on the warmed tail. Other commands
@@ -690,16 +1065,11 @@ describe('resilience ranking contracts', () => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
       if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
         const commands = JSON.parse(init.body) as Array<Array<string>>;
-        const allScoreSets = commands.length > 0 && commands.every(
-          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith(RESILIENCE_SCORE_CACHE_PREFIX),
-        );
+        const allScoreSets = commands.length > 0 && commands.every((cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith(RESILIENCE_SCORE_CACHE_PREFIX));
         if (allScoreSets) {
           // Return OK without mutating redis — the warmed-tail keys
           // (YE, ZZ) "say" they landed but actually don't.
-          return new Response(
-            JSON.stringify(commands.map(() => ({ result: 'OK' }))),
-            { status: 200 },
-          );
+          return new Response(JSON.stringify(commands.map(() => ({ result: 'OK' }))), { status: 200 });
         }
       }
       return fetchImpl(input, init);
@@ -715,10 +1085,12 @@ describe('resilience ranking contracts', () => {
     // Post-fix (sample from warmedCountryCodes only): YE + ZZ are
     // sampled, neither exists in Redis, parity check fails, meta
     // refused.
-    assert.equal(redis.has(RESILIENCE_RANKING_CACHE_KEY), false,
-      'ranking must NOT be published when warmed-tail keys returned OK but did not persist (mixed-failure mode)');
-    assert.equal(redis.has('seed-meta:resilience:ranking'), false,
-      'seed-meta must NOT lie when only the warmed tail failed — sampling must focus on warmed entries, not cachedScores broadly');
+    assert.equal(redis.has(RESILIENCE_RANKING_CACHE_KEY), false, 'ranking must NOT be published when warmed-tail keys returned OK but did not persist (mixed-failure mode)');
+    assert.equal(
+      redis.has('seed-meta:resilience:ranking'),
+      false,
+      'seed-meta must NOT lie when only the warmed tail failed — sampling must focus on warmed entries, not cachedScores broadly',
+    );
   });
 
   it('pipeline SETs apply env prefix so preview warms do not leak into production namespace', async () => {
@@ -737,12 +1109,15 @@ describe('resilience ranking contracts', () => {
     __resetKeyPrefixCacheForTests();
 
     const { redis, fetchImpl } = installRedis({ ...RESILIENCE_FIXTURES }, { keepVercelEnv: true });
-    redis.set('resilience:static:index:v1', JSON.stringify({
-      countries: ['NO', 'US'],
-      recordCount: 2,
-      failedDatasets: [],
-      seedYear: 2026,
-    }));
+    redis.set(
+      'resilience:static:index:v1',
+      JSON.stringify({
+        countries: ['NO', 'US'],
+        recordCount: 2,
+        failedDatasets: [],
+        seedYear: 2026,
+      }),
+    );
 
     const pipelineBodies: Array<Array<Array<unknown>>> = [];
     const capturing = (async (input: RequestInfo | URL, init?: RequestInit) => {
@@ -762,10 +1137,7 @@ describe('resilience ranking contracts', () => {
       .map((cmd) => cmd[1] as string);
     assert.ok(scoreSetKeys.length >= 2, `expected at least 2 score SETs, got ${scoreSetKeys.length}`);
     for (const key of scoreSetKeys) {
-      assert.ok(
-        key.startsWith('preview:abcdef12:'),
-        `score SET key must carry preview prefix; got ${key} — writes would poison the production namespace`,
-      );
+      assert.ok(key.startsWith('preview:abcdef12:'), `score SET key must carry preview prefix; got ${key} — writes would poison the production namespace`);
     }
   });
 
@@ -778,16 +1150,33 @@ describe('resilience ranking contracts', () => {
     process.env.WORLDMONITOR_API_KEY = 'legacy-read-key';
     process.env.WORLDMONITOR_SEED_REFRESH_KEY = 'seed-refresh-secret';
     const { redis } = installRedis({ ...RESILIENCE_FIXTURES });
-    redis.set('resilience:static:index:v1', JSON.stringify({
-      countries: ['NO', 'US'],
-      recordCount: 2,
-      failedDatasets: [],
-      seedYear: 2026,
-    }));
+    redis.set(
+      'resilience:static:index:v1',
+      JSON.stringify({
+        countries: ['NO', 'US'],
+        recordCount: 2,
+        failedDatasets: [],
+        seedYear: 2026,
+      }),
+    );
     // Stale sentinel tagged with the current (flag-off default) formula so
     // these refresh-auth assertions exercise the refresh gate, not formula
     // invalidation. NR is rankable but absent from the static-index fixture.
-    const stale = { items: [{ countryCode: 'NR', overallScore: 1, level: 'low', lowConfidence: true, overallCoverage: 0.5, headlineEligible: true }], greyedOut: [], ...RANKING_META, ...D6_RANKING_CACHE_TAG };
+    const stale = {
+      items: [
+        {
+          countryCode: 'NR',
+          overallScore: 1,
+          level: 'low',
+          lowConfidence: true,
+          overallCoverage: 0.5,
+          headlineEligible: true,
+        },
+      ],
+      greyedOut: [],
+      ...RANKING_META,
+      ...D6_RANKING_CACHE_TAG,
+    };
     redis.set(RESILIENCE_RANKING_CACHE_KEY, JSON.stringify(stale));
 
     const assertFallsBackToCache = async (request: Request, message: string) => {
@@ -796,10 +1185,7 @@ describe('resilience ranking contracts', () => {
       assert.equal(response.items[0]?.countryCode, 'NR', message);
     };
 
-    await assertFallsBackToCache(
-      new Request('https://example.com/api/resilience/v1/get-resilience-ranking?refresh=1'),
-      'refresh=1 without key must fall back to cached response',
-    );
+    await assertFallsBackToCache(new Request('https://example.com/api/resilience/v1/get-resilience-ranking?refresh=1'), 'refresh=1 without key must fall back to cached response');
     await assertFallsBackToCache(
       new Request('https://example.com/api/resilience/v1/get-resilience-ranking?refresh=1', {
         headers: { Authorization: 'Bearer pro-session-token' },
@@ -825,7 +1211,7 @@ describe('resilience ranking contracts', () => {
       headers: { 'X-WorldMonitor-Key': 'seed-refresh-secret' },
     });
     const authedResp = await getResilienceRanking({ request: authed } as never, {});
-    const codes = (authedResp.items.concat(authedResp.greyedOut ?? [])).map((i) => i.countryCode);
+    const codes = authedResp.items.concat(authedResp.greyedOut ?? []).map((i) => i.countryCode);
     assert.ok(!codes.includes('NR'), 'refresh=1 with dedicated seed refresh key must recompute');
   });
 
@@ -836,15 +1222,31 @@ describe('resilience ranking contracts', () => {
     // instead of stale-but-present.
     process.env.WORLDMONITOR_SEED_REFRESH_KEY = 'seed-refresh-secret';
     const { redis } = installRedis({ ...RESILIENCE_FIXTURES });
-    redis.set('resilience:static:index:v1', JSON.stringify({
-      countries: ['NO', 'US'],
-      recordCount: 2,
-      failedDatasets: [],
-      seedYear: 2026,
-    }));
+    redis.set(
+      'resilience:static:index:v1',
+      JSON.stringify({
+        countries: ['NO', 'US'],
+        recordCount: 2,
+        failedDatasets: [],
+        seedYear: 2026,
+      }),
+    );
     // Seed a pre-existing ranking so the cache-hit early-return would
     // normally fire. ?refresh=1 (with valid seed key) must ignore it.
-    const stale = { items: [{ countryCode: 'ZZ', overallScore: 1, level: 'low', lowConfidence: true, overallCoverage: 0.5 }], greyedOut: [], ...RANKING_META, ...D6_RANKING_CACHE_TAG };
+    const stale = {
+      items: [
+        {
+          countryCode: 'ZZ',
+          overallScore: 1,
+          level: 'low',
+          lowConfidence: true,
+          overallCoverage: 0.5,
+        },
+      ],
+      greyedOut: [],
+      ...RANKING_META,
+      ...D6_RANKING_CACHE_TAG,
+    };
     redis.set(RESILIENCE_RANKING_CACHE_KEY, JSON.stringify(stale));
 
     const request = new Request('https://example.com/api/resilience/v1/get-resilience-ranking?refresh=1', {
@@ -857,31 +1259,58 @@ describe('resilience ranking contracts', () => {
     assert.ok(returnedCountries.includes('NO') || returnedCountries.includes('US'), 'recomputed ranking must reflect the current static index');
   });
 
-  it('?refresh=1 seed-secret recomputes are bounded by a short Redis refresh slot', async () => {
+  it('?refresh=1 seed-secret recomputes release the Redis refresh slot by token', async () => {
     process.env.WORLDMONITOR_SEED_REFRESH_KEY = 'seed-refresh-secret';
     const { redis } = installRedis({ ...RESILIENCE_FIXTURES });
-    redis.set('resilience:static:index:v1', JSON.stringify({
-      countries: ['NO', 'US'],
-      recordCount: 2,
-      failedDatasets: [],
-      seedYear: 2026,
-    }));
+    redis.set(
+      'resilience:static:index:v1',
+      JSON.stringify({
+        countries: ['NO', 'US'],
+        recordCount: 2,
+        failedDatasets: [],
+        seedYear: 2026,
+      }),
+    );
 
-    const request = () => new Request('https://example.com/api/resilience/v1/get-resilience-ranking?refresh=1', {
-      headers: { 'X-WorldMonitor-Key': 'seed-refresh-secret' },
-    });
+    const request = () =>
+      new Request('https://example.com/api/resilience/v1/get-resilience-ranking?refresh=1', {
+        headers: { 'X-WorldMonitor-Key': 'seed-refresh-secret' },
+      });
     const first = await getResilienceRanking({ request: request() } as never, {});
     const firstCodes = first.items.concat(first.greyedOut ?? []).map((i) => i.countryCode);
     assert.ok(firstCodes.includes('NO') || firstCodes.includes('US'), 'first seed refresh must recompute');
+    assert.equal(redis.has('resilience:ranking:refresh-lock:v1'), false, 'refresh slot must be released in finally after recompute');
 
-    const stale = { items: [{ countryCode: 'NR', overallScore: 1, level: 'low', lowConfidence: true, overallCoverage: 0.5, headlineEligible: true }], greyedOut: [], ...RANKING_META, ...D6_RANKING_CACHE_TAG };
+    const stale = {
+      items: [
+        {
+          countryCode: 'NR',
+          overallScore: 1,
+          level: 'low',
+          lowConfidence: true,
+          overallCoverage: 0.5,
+          headlineEligible: true,
+        },
+      ],
+      greyedOut: [],
+      ...RANKING_META,
+      ...D6_RANKING_CACHE_TAG,
+    };
     redis.set(RESILIENCE_RANKING_CACHE_KEY, JSON.stringify(stale));
     const second = await getResilienceRanking({ request: request() } as never, {});
-    assert.equal(
-      second.items[0]?.countryCode,
-      'NR',
-      'rapid second seed refresh must use the cached path while the refresh slot is held',
-    );
+    const secondCodes = second.items.concat(second.greyedOut ?? []).map((i) => i.countryCode);
+    assert.ok(!secondCodes.includes('NR'), 'released refresh slot must allow a later authorized refresh to recompute');
+    assert.equal(redis.has('resilience:ranking:refresh-lock:v1'), false, 'second refresh must also release the slot');
+  });
+
+  it('Redis lock release uses token compare-and-delete semantics', async () => {
+    const { redis } = installRedis({});
+    redis.set('resilience:ranking:refresh-lock:v1', 'owner-a');
+
+    assert.equal(await compareAndDeleteRedisKey('resilience:ranking:refresh-lock:v1', 'owner-b'), false);
+    assert.equal(redis.get('resilience:ranking:refresh-lock:v1'), 'owner-a', 'wrong token must not delete another owner lock');
+    assert.equal(await compareAndDeleteRedisKey('resilience:ranking:refresh-lock:v1', 'owner-a'), true);
+    assert.equal(redis.has('resilience:ranking:refresh-lock:v1'), false, 'matching token must delete the lock');
   });
 
   it('?refresh=1 seed-secret slot denial returns explicit 429 instead of empty 200 on cold cache', async () => {
@@ -890,15 +1319,17 @@ describe('resilience ranking contracts', () => {
     redis.set('resilience:ranking:refresh-lock:v1', 'held');
 
     await assert.rejects(
-      () => getResilienceRanking({
-        request: new Request('https://example.com/api/resilience/v1/get-resilience-ranking?refresh=1', {
-          headers: { 'X-WorldMonitor-Key': 'seed-refresh-secret' },
-        }),
-      } as never, {}),
-      (err) => err instanceof ApiError
-        && err.statusCode === 429
-        && (err as ApiError & { retryAfter?: number }).retryAfter === 30
-        && /refresh already in progress/.test(err.message),
+      () =>
+        getResilienceRanking(
+          {
+            request: new Request('https://example.com/api/resilience/v1/get-resilience-ranking?refresh=1', {
+              headers: { 'X-WorldMonitor-Key': 'seed-refresh-secret' },
+            }),
+          } as never,
+          {},
+        ),
+      (err) =>
+        err instanceof ApiError && err.statusCode === 429 && (err as ApiError & { retryAfter?: number }).retryAfter === 30 && /refresh already in progress/.test(err.message),
     );
   });
 
@@ -914,17 +1345,100 @@ describe('resilience ranking contracts', () => {
     });
   });
 
+  it('normal cache-miss warm path returns explicit temporary unavailable when the warm lock is held and no cache exists', async () => {
+    const { redis } = installRedis({ ...RESILIENCE_FIXTURES });
+    redis.set(
+      'resilience:static:index:v1',
+      JSON.stringify({
+        countries: ['NO', 'US'],
+        recordCount: 2,
+        failedDatasets: [],
+        seedYear: 2026,
+      }),
+    );
+    redis.set('resilience:ranking:warm-lock:v1', 'held');
+
+    await assert.rejects(
+      () =>
+        getResilienceRanking(
+          {
+            request: new Request('https://example.com/api/resilience/v1/get-resilience-ranking'),
+          } as never,
+          {},
+        ),
+      (err) => err instanceof ApiError && err.statusCode === 503 && (err as ApiError & { retryAfter?: number }).retryAfter === 60 && /temporarily unavailable/.test(err.message),
+    );
+    assert.equal(redis.has(`${RESILIENCE_SCORE_CACHE_PREFIX}NO`), false, 'lock contention must not start a duplicate warm');
+    assert.equal(redis.has(`${RESILIENCE_SCORE_CACHE_PREFIX}US`), false, 'lock contention must not start a duplicate warm');
+  });
+
+  it('normal cache-miss warm path does not serve a stale-tag cache entry during lock contention', async () => {
+    const { redis } = installRedis({ ...RESILIENCE_FIXTURES });
+    redis.set('resilience:ranking:warm-lock:v1', 'held');
+    redis.set(
+      RESILIENCE_RANKING_CACHE_KEY,
+      JSON.stringify({
+        items: [
+          {
+            countryCode: 'NO',
+            overallScore: 82,
+            level: 'high',
+            lowConfidence: false,
+            overallCoverage: 0.95,
+            headlineEligible: true,
+          },
+        ],
+        greyedOut: [],
+        ...RANKING_META,
+        _formula: 'stale-formula',
+        _intervalMethodology: RESILIENCE_INTERVAL_METHODOLOGY,
+      }),
+    );
+
+    await assert.rejects(
+      () =>
+        getResilienceRanking(
+          {
+            request: new Request('https://example.com/api/resilience/v1/get-resilience-ranking'),
+          } as never,
+          {},
+        ),
+      (err) => err instanceof ApiError && err.statusCode === 503,
+    );
+  });
+
+  it('ApiError retryAfter maps temporary-unavailable warm contention to explicit 503 + Retry-After', async () => {
+    const err = new ApiError(503, 'Resilience ranking temporarily unavailable while cache warm is in progress', '');
+    (err as ApiError & { retryAfter: number }).retryAfter = 60;
+    const response = mapErrorToResponse(err, new Request('https://example.com'));
+    assert.equal(response.status, 503);
+    assert.equal(response.headers.get('Retry-After'), '60');
+    assert.deepEqual(await response.json(), {
+      message: 'Resilience ranking temporarily unavailable while cache warm is in progress',
+      retryAfter: 60,
+    });
+  });
+
+  it('gateway has a dedicated low-RPM endpoint policy for resilience ranking', () => {
+    assert.deepEqual(ENDPOINT_RATE_POLICIES['/api/resilience/v1/get-resilience-ranking'], { limit: 30, window: '60 s' });
+  });
+
   it('gateway seed-refresh bypass is scoped to ranking ?refresh=1 only', async () => {
     process.env.WORLDMONITOR_VALID_KEYS = 'normal-read-key';
     process.env.WORLDMONITOR_SEED_REFRESH_KEY = 'seed-refresh-secret';
+    installRedis({});
     const handler = createDomainGateway([
       {
         method: 'GET',
         path: '/api/resilience/v1/get-resilience-ranking',
-        handler: async (request) => new Response(JSON.stringify({
-          key: request.headers.get('X-WorldMonitor-Key'),
-          refresh: new URL(request.url).searchParams.get('refresh'),
-        }), { status: 200, headers: { 'Content-Type': 'application/json' } }),
+        handler: async (request) =>
+          new Response(
+            JSON.stringify({
+              key: request.headers.get('X-WorldMonitor-Key'),
+              refresh: new URL(request.url).searchParams.get('refresh'),
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          ),
       },
       {
         method: 'GET',
@@ -933,27 +1447,41 @@ describe('resilience ranking contracts', () => {
       },
     ]);
 
-    const seedRefresh = await handler(new Request('https://worldmonitor.app/api/resilience/v1/get-resilience-ranking?refresh=1', {
-      headers: { 'X-WorldMonitor-Key': 'seed-refresh-secret' },
-    }));
+    const seedRefresh = await handler(
+      new Request('https://worldmonitor.app/api/resilience/v1/get-resilience-ranking?refresh=1', {
+        headers: { 'X-WorldMonitor-Key': 'seed-refresh-secret' },
+      }),
+    );
     assert.equal(seedRefresh.status, 200);
-    assert.deepEqual(await seedRefresh.json(), { key: 'seed-refresh-secret', refresh: '1' });
+    assert.deepEqual(await seedRefresh.json(), {
+      key: 'seed-refresh-secret',
+      refresh: '1',
+    });
 
-    const seedWithoutRefresh = await handler(new Request('https://worldmonitor.app/api/resilience/v1/get-resilience-ranking', {
-      headers: { 'X-WorldMonitor-Key': 'seed-refresh-secret' },
-    }));
+    const seedWithoutRefresh = await handler(
+      new Request('https://worldmonitor.app/api/resilience/v1/get-resilience-ranking', {
+        headers: { 'X-WorldMonitor-Key': 'seed-refresh-secret' },
+      }),
+    );
     assert.equal(seedWithoutRefresh.status, 401, 'seed secret must not bypass normal ranking-read auth');
 
-    const seedWrongPath = await handler(new Request('https://worldmonitor.app/api/resilience/v1/get-resilience-score?countryCode=US&refresh=1', {
-      headers: { 'X-WorldMonitor-Key': 'seed-refresh-secret' },
-    }));
+    const seedWrongPath = await handler(
+      new Request('https://worldmonitor.app/api/resilience/v1/get-resilience-score?countryCode=US&refresh=1', {
+        headers: { 'X-WorldMonitor-Key': 'seed-refresh-secret' },
+      }),
+    );
     assert.equal(seedWrongPath.status, 401, 'seed secret must not bypass auth on other resilience paths');
 
-    const normalReadRefresh = await handler(new Request('https://worldmonitor.app/api/resilience/v1/get-resilience-ranking?refresh=1', {
-      headers: { 'X-WorldMonitor-Key': 'normal-read-key' },
-    }));
+    const normalReadRefresh = await handler(
+      new Request('https://worldmonitor.app/api/resilience/v1/get-resilience-ranking?refresh=1', {
+        headers: { 'X-WorldMonitor-Key': 'normal-read-key' },
+      }),
+    );
     assert.equal(normalReadRefresh.status, 200, 'normal read keys must keep existing ranking-read access');
-    assert.deepEqual(await normalReadRefresh.json(), { key: 'normal-read-key', refresh: '1' });
+    assert.deepEqual(await normalReadRefresh.json(), {
+      key: 'normal-read-key',
+      refresh: '1',
+    });
   });
 
   it('warms via batched pipeline SETs (avoids 600KB single-pipeline timeout)', async () => {
@@ -962,21 +1490,23 @@ describe('resilience ranking contracts', () => {
     // Splitting into smaller batches keeps each pipeline well under timeout.
     // We assert the SET path uses MULTIPLE pipelines, not one giant one.
     const { redis, fetchImpl } = installRedis({ ...RESILIENCE_FIXTURES });
-    redis.set('resilience:static:index:v1', JSON.stringify({
-      countries: ['NO', 'US', 'YE'],
-      recordCount: 3,
-      failedDatasets: [],
-      seedYear: 2026,
-    }));
+    redis.set(
+      'resilience:static:index:v1',
+      JSON.stringify({
+        countries: ['NO', 'US', 'YE'],
+        recordCount: 3,
+        failedDatasets: [],
+        seedYear: 2026,
+      }),
+    );
 
     const setPipelineSizes: number[] = [];
     const observing = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
       if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
         const commands = JSON.parse(init.body) as Array<Array<string>>;
-        const isAllScoreSets = commands.length > 0 && commands.every(
-          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && (cmd[1] as string).includes(RESILIENCE_SCORE_CACHE_PREFIX),
-        );
+        const isAllScoreSets =
+          commands.length > 0 && commands.every((cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && (cmd[1] as string).includes(RESILIENCE_SCORE_CACHE_PREFIX));
         if (isAllScoreSets) setPipelineSizes.push(commands.length);
       }
       return fetchImpl(input, init);
@@ -1016,7 +1546,22 @@ describe('resilience ranking contracts', () => {
       warnings.push(args.map(String).join(' '));
     };
     try {
-      const domainWithCoverage = [{ id: 'political', score: 80, weight: 0.2, dimensions: [{ id: 'd1', score: 80, coverage: 0.9, observedWeight: 1, imputedWeight: 0 }] }];
+      const domainWithCoverage = [
+        {
+          id: 'political',
+          score: 80,
+          weight: 0.2,
+          dimensions: [
+            {
+              id: 'd1',
+              score: 80,
+              coverage: 0.9,
+              observedWeight: 1,
+              imputedWeight: 0,
+            },
+          ],
+        },
+      ];
       const warmed = await warmMissingResilienceScores(['NO', 'US'], async (countryCode) => {
         if (countryCode === 'US') throw new Error('synthetic compute failure');
         return {
@@ -1055,12 +1600,15 @@ describe('resilience ranking contracts', () => {
     // With writes broken at the Upstash layer, coverage should NOT pass the
     // gate and neither the ranking nor its meta should be published.
     const { redis, fetchImpl } = installRedis({ ...RESILIENCE_FIXTURES });
-    redis.set('resilience:static:index:v1', JSON.stringify({
-      countries: ['NO', 'US'],
-      recordCount: 2,
-      failedDatasets: [],
-      seedYear: 2026,
-    }));
+    redis.set(
+      'resilience:static:index:v1',
+      JSON.stringify({
+        countries: ['NO', 'US'],
+        recordCount: 2,
+        failedDatasets: [],
+        seedYear: 2026,
+      }),
+    );
 
     // Intercept any pipeline SET to resilience:score:v17:* and reply with
     // non-OK results (persisted but authoritative signal says no). /set and
@@ -1069,14 +1617,9 @@ describe('resilience ranking contracts', () => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
       if (url.endsWith('/pipeline') && typeof init?.body === 'string') {
         const commands = JSON.parse(init.body) as Array<Array<string>>;
-        const allScoreSets = commands.length > 0 && commands.every(
-          (cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith(RESILIENCE_SCORE_CACHE_PREFIX),
-        );
+        const allScoreSets = commands.length > 0 && commands.every((cmd) => cmd[0] === 'SET' && typeof cmd[1] === 'string' && cmd[1].startsWith(RESILIENCE_SCORE_CACHE_PREFIX));
         if (allScoreSets) {
-          return new Response(
-            JSON.stringify(commands.map(() => ({ error: 'simulated write failure' }))),
-            { status: 200 },
-          );
+          return new Response(JSON.stringify(commands.map(() => ({ error: 'simulated write failure' }))), { status: 200 });
         }
       }
       return fetchImpl(input, init);
@@ -1091,10 +1634,18 @@ describe('resilience ranking contracts', () => {
 
   it('defaults rankStable=false when no interval data exists', () => {
     const item = buildRankingItem('ZZ', {
-      countryCode: 'ZZ', overallScore: 50, level: 'medium',
-      domains: [], trend: 'stable', change30d: 0,
-      lowConfidence: false, imputationShare: 0,
-      baselineScore: 50, stressScore: 50, stressFactor: 0.5, dataVersion: '',
+      countryCode: 'ZZ',
+      overallScore: 50,
+      level: 'medium',
+      domains: [],
+      trend: 'stable',
+      change30d: 0,
+      lowConfidence: false,
+      imputationShare: 0,
+      baselineScore: 50,
+      stressScore: 50,
+      stressFactor: 0.5,
+      dataVersion: '',
     });
     assert.equal(item.rankStable, false, 'missing interval should default to unstable');
   });


### PR DESCRIPTION
## Summary
- serialize normal CRI ranking cache warms behind a Redis lock
- release refresh/warm locks with token-CAS and serve valid cache under contention
- return explicit retryable unavailable/rate-limit responses when no valid cache exists under contention
- add the dedicated gateway rate-limit policy and focused gateway/ranking tests

## Validation
- npm_config_cache=/tmp/npm-cache npx tsx --test tests/resilience-ranking.test.mts
- npm_config_cache=/tmp/npm-cache npx tsx --test tests/premium-stock-gateway.test.mts
- npm run typecheck
- npm run typecheck:api
- git diff --check
- git push pre-push hook completed successfully, including broad tests, lint, bundle freshness, and version sync