### PR TITLE
Fix resilience interval seed health reporting

### DIFF
--- a/scripts/_resilience-intervals.mjs
+++ b/scripts/_resilience-intervals.mjs
@@ -58,6 +58,16 @@ export function createIntervalDiagnostics() {
     activeScoreClampSamples: [],
     formulaSkipCount: 0,
     formulaSkipSamples: [],
+    missingScorePayloadCount: 0,
+    missingScorePayloadSamples: [],
+    staleScorePayloadCount: 0,
+    staleScorePayloadSamples: [],
+    invalidScorePayloadCount: 0,
+    invalidScorePayloadSamples: [],
+    malformedScorePayloadCount: 0,
+    malformedScorePayloadSamples: [],
+    intervalPayloadSkipCount: 0,
+    intervalPayloadSkipSamples: [],
   };
 }
 

--- a/scripts/seed-resilience-scores.mjs
+++ b/scripts/seed-resilience-scores.mjs
@@ -74,6 +74,17 @@ export const RESILIENCE_STATIC_INDEX_KEY = 'resilience:static:index:v1';
 const INTERVAL_TTL_SECONDS = 7 * 24 * 60 * 60;
 export { computeIntervals };
 
+function recordDiagnosticSample(diagnostics, sampleKey, countryCode, details = {}) {
+  const samples = diagnostics?.[sampleKey];
+  if (!Array.isArray(samples) || samples.length >= 5) return;
+  samples.push({ countryCode, ...details });
+}
+
+function recordDiagnosticCount(diagnostics, countKey, sampleKey, countryCode, details = {}) {
+  diagnostics[countKey] = (Number(diagnostics[countKey]) || 0) + 1;
+  recordDiagnosticSample(diagnostics, sampleKey, countryCode, details);
+}
+
 function currentCacheFormulaLocal() {
   const combine = (process.env.RESILIENCE_PILLAR_COMBINE_ENABLED ?? 'false').toLowerCase() === 'true';
   const schemaV2 = (process.env.RESILIENCE_SCHEMA_V2_ENABLED ?? 'true').toLowerCase() === 'true';
@@ -129,19 +140,66 @@ function countCachedFromPipeline(results) {
   return count;
 }
 
+export function buildIntervalPayloadFromCachedScore(raw, countryCode, diagnostics) {
+  if (!raw || raw === 'null') {
+    recordDiagnosticCount(diagnostics, 'missingScorePayloadCount', 'missingScorePayloadSamples', countryCode);
+    return null;
+  }
+
+  try {
+    const score = unwrapEnvelope(JSON.parse(raw)).data;
+    if (!score || typeof score !== 'object' || Array.isArray(score)) {
+      recordDiagnosticCount(diagnostics, 'invalidScorePayloadCount', 'invalidScorePayloadSamples', countryCode);
+      return null;
+    }
+
+    const formula = typeof score?._formula === 'string' ? score._formula : undefined;
+    if (formula !== 'pc' && formula !== 'd6') {
+      buildScoreIntervalPayload(score, { draws: DRAWS, diagnostics });
+      return null;
+    }
+
+    if (formula !== currentCacheFormulaLocal()) {
+      recordDiagnosticCount(diagnostics, 'staleScorePayloadCount', 'staleScorePayloadSamples', countryCode, {
+        formula,
+        expectedFormula: currentCacheFormulaLocal(),
+      });
+      return null;
+    }
+
+    const currentScore = parseCachedScorePayload(raw);
+    if (!currentScore) {
+      recordDiagnosticCount(diagnostics, 'invalidScorePayloadCount', 'invalidScorePayloadSamples', countryCode, { formula });
+      return null;
+    }
+
+    const payload = buildScoreIntervalPayload(currentScore, { draws: DRAWS, diagnostics });
+    if (!payload) {
+      recordDiagnosticCount(diagnostics, 'intervalPayloadSkipCount', 'intervalPayloadSkipSamples', countryCode, {
+        formula: typeof currentScore?._formula === 'string' ? currentScore._formula : undefined,
+      });
+      return null;
+    }
+    return payload;
+  } catch (err) {
+    recordDiagnosticCount(diagnostics, 'malformedScorePayloadCount', 'malformedScorePayloadSamples', countryCode, {
+      error: err instanceof Error ? err.message.slice(0, 120) : String(err).slice(0, 120),
+    });
+    return null;
+  }
+}
+
 async function computeAndWriteIntervals(url, token, countryCodes, pipelineResults) {
   const commands = [];
   const diagnostics = createIntervalDiagnostics();
 
   for (let i = 0; i < countryCodes.length; i++) {
     const raw = pipelineResults[i]?.result ?? null;
-    if (!raw || raw === 'null') continue;
-    try {
-      const score = unwrapEnvelope(JSON.parse(raw)).data;
-      const payload = buildScoreIntervalPayload(score, { draws: DRAWS, diagnostics });
-      if (!payload) continue;
-      commands.push(['SET', `${INTERVAL_KEY_PREFIX}${countryCodes[i]}`, JSON.stringify(payload), 'EX', INTERVAL_TTL_SECONDS]);
-    } catch { /* skip malformed */ }
+    const countryCode = countryCodes[i];
+    const payload = buildIntervalPayloadFromCachedScore(raw, countryCode, diagnostics);
+    if (payload) {
+      commands.push(['SET', `${INTERVAL_KEY_PREFIX}${countryCode}`, JSON.stringify(payload), 'EX', INTERVAL_TTL_SECONDS]);
+    }
   }
 
   if (diagnostics.formulaSkipCount > 0) {
@@ -152,7 +210,15 @@ async function computeAndWriteIntervals(url, token, countryCodes, pipelineResult
   }
 
   if (commands.length === 0) {
-    console.log('[resilience-scores] No domain data available for intervals');
+    console.warn(
+      `[resilience-scores] No interval keys written for ${countryCodes.length} countries ` +
+      `(missingScorePayloads=${diagnostics.missingScorePayloadCount}, ` +
+      `staleScorePayloads=${diagnostics.staleScorePayloadCount}, ` +
+      `invalidScorePayloads=${diagnostics.invalidScorePayloadCount}, ` +
+      `malformedScorePayloads=${diagnostics.malformedScorePayloadCount}, ` +
+      `intervalPayloadSkips=${diagnostics.intervalPayloadSkipCount}, ` +
+      `formulaSkips=${diagnostics.formulaSkipCount})`,
+    );
     return { recordCount: 0, diagnostics };
   }
 
@@ -170,6 +236,65 @@ async function computeAndWriteIntervals(url, token, countryCodes, pipelineResult
 
   await writeFreshnessMetadata('resilience', 'intervals', commands.length, '', INTERVAL_TTL_SECONDS);
   return { recordCount: commands.length, diagnostics };
+}
+
+export function getIntervalWriteFailure(result) {
+  if (result?.skipped) return null;
+  const total = Number(result?.total ?? 0);
+  const intervalsWritten = Number(result?.intervalsWritten ?? 0);
+  if (!Number.isFinite(total) || total <= 0) return null;
+  if (Number.isFinite(intervalsWritten) && intervalsWritten > 0) return null;
+
+  const scoreCount = Number(result?.recordCount ?? 0);
+  const formulaSkipCount = Number(result?.intervalFormulaSkipCount ?? 0);
+  const missingScorePayloadCount = Number(result?.intervalMissingScorePayloadCount ?? 0);
+  const staleScorePayloadCount = Number(result?.intervalStaleScorePayloadCount ?? 0);
+  const intervalPayloadSkipCount = Number(result?.intervalPayloadSkipCount ?? 0);
+  let reason = 'empty_interval_writes';
+  if (staleScorePayloadCount > 0) reason = 'stale_score_cache';
+  else if (scoreCount <= 0 || missingScorePayloadCount >= total) reason = 'missing_score_cache';
+  else if (formulaSkipCount > 0) reason = 'unusable_score_formula';
+  else if (intervalPayloadSkipCount > 0) reason = 'unusable_score_payload';
+
+  return {
+    reason,
+    message:
+      `resilience interval seed wrote 0 interval keys for ${total} rankable countries ` +
+      `(cachedScores=${Number.isFinite(scoreCount) ? scoreCount : 0}, ` +
+      `missingScorePayloads=${Number.isFinite(missingScorePayloadCount) ? missingScorePayloadCount : 0}, ` +
+      `staleScorePayloads=${Number.isFinite(staleScorePayloadCount) ? staleScorePayloadCount : 0}, ` +
+      `formulaSkips=${Number.isFinite(formulaSkipCount) ? formulaSkipCount : 0}, ` +
+      `intervalPayloadSkips=${Number.isFinite(intervalPayloadSkipCount) ? intervalPayloadSkipCount : 0})`,
+  };
+}
+
+export function buildSeedResultLogExtra(result) {
+  const intervalFailure = getIntervalWriteFailure(result);
+  return {
+    extra: {
+      skipped: Boolean(result.skipped),
+      ...(result.total != null && { total: result.total }),
+      ...(result.reason != null && { reason: result.reason }),
+      ...(result.intervalsWritten != null && { intervalsWritten: result.intervalsWritten }),
+      ...(result.intervalClampCount != null && { intervalClampCount: result.intervalClampCount }),
+      ...(result.intervalClampMaxDelta != null && { intervalClampMaxDelta: result.intervalClampMaxDelta }),
+      ...(result.intervalFormulaSkipCount != null && { intervalFormulaSkipCount: result.intervalFormulaSkipCount }),
+      ...(result.intervalFormulaSkipSamples?.length ? { intervalFormulaSkipSamples: result.intervalFormulaSkipSamples } : {}),
+      ...(result.intervalMissingScorePayloadCount != null && { intervalMissingScorePayloadCount: result.intervalMissingScorePayloadCount }),
+      ...(result.intervalMissingScorePayloadSamples?.length ? { intervalMissingScorePayloadSamples: result.intervalMissingScorePayloadSamples } : {}),
+      ...(result.intervalStaleScorePayloadCount != null && { intervalStaleScorePayloadCount: result.intervalStaleScorePayloadCount }),
+      ...(result.intervalStaleScorePayloadSamples?.length ? { intervalStaleScorePayloadSamples: result.intervalStaleScorePayloadSamples } : {}),
+      ...(result.intervalInvalidScorePayloadCount != null && { intervalInvalidScorePayloadCount: result.intervalInvalidScorePayloadCount }),
+      ...(result.intervalInvalidScorePayloadSamples?.length ? { intervalInvalidScorePayloadSamples: result.intervalInvalidScorePayloadSamples } : {}),
+      ...(result.intervalMalformedScorePayloadCount != null && { intervalMalformedScorePayloadCount: result.intervalMalformedScorePayloadCount }),
+      ...(result.intervalMalformedScorePayloadSamples?.length ? { intervalMalformedScorePayloadSamples: result.intervalMalformedScorePayloadSamples } : {}),
+      ...(result.intervalPayloadSkipCount != null && { intervalPayloadSkipCount: result.intervalPayloadSkipCount }),
+      ...(result.intervalPayloadSkipSamples?.length ? { intervalPayloadSkipSamples: result.intervalPayloadSkipSamples } : {}),
+      ...(intervalFailure && { status: 'ERROR', error: intervalFailure.message, intervalFailureReason: intervalFailure.reason }),
+    },
+    intervalFailure,
+    exitCode: intervalFailure ? 1 : 0,
+  };
 }
 
 async function seedResilienceScores() {
@@ -280,6 +405,16 @@ async function seedResilienceScores() {
       intervalClampMaxDelta: intervalResult.diagnostics.activeScoreClampMaxDelta,
       intervalFormulaSkipCount: intervalResult.diagnostics.formulaSkipCount,
       intervalFormulaSkipSamples: intervalResult.diagnostics.formulaSkipSamples,
+      intervalMissingScorePayloadCount: intervalResult.diagnostics.missingScorePayloadCount,
+      intervalMissingScorePayloadSamples: intervalResult.diagnostics.missingScorePayloadSamples,
+      intervalStaleScorePayloadCount: intervalResult.diagnostics.staleScorePayloadCount,
+      intervalStaleScorePayloadSamples: intervalResult.diagnostics.staleScorePayloadSamples,
+      intervalInvalidScorePayloadCount: intervalResult.diagnostics.invalidScorePayloadCount,
+      intervalInvalidScorePayloadSamples: intervalResult.diagnostics.invalidScorePayloadSamples,
+      intervalMalformedScorePayloadCount: intervalResult.diagnostics.malformedScorePayloadCount,
+      intervalMalformedScorePayloadSamples: intervalResult.diagnostics.malformedScorePayloadSamples,
+      intervalPayloadSkipCount: intervalResult.diagnostics.intervalPayloadSkipCount,
+      intervalPayloadSkipSamples: intervalResult.diagnostics.intervalPayloadSkipSamples,
       rankingPresent,
     };
   }
@@ -300,6 +435,16 @@ async function seedResilienceScores() {
     intervalClampMaxDelta: intervalResult.diagnostics.activeScoreClampMaxDelta,
     intervalFormulaSkipCount: intervalResult.diagnostics.formulaSkipCount,
     intervalFormulaSkipSamples: intervalResult.diagnostics.formulaSkipSamples,
+    intervalMissingScorePayloadCount: intervalResult.diagnostics.missingScorePayloadCount,
+    intervalMissingScorePayloadSamples: intervalResult.diagnostics.missingScorePayloadSamples,
+    intervalStaleScorePayloadCount: intervalResult.diagnostics.staleScorePayloadCount,
+    intervalStaleScorePayloadSamples: intervalResult.diagnostics.staleScorePayloadSamples,
+    intervalInvalidScorePayloadCount: intervalResult.diagnostics.invalidScorePayloadCount,
+    intervalInvalidScorePayloadSamples: intervalResult.diagnostics.invalidScorePayloadSamples,
+    intervalMalformedScorePayloadCount: intervalResult.diagnostics.malformedScorePayloadCount,
+    intervalMalformedScorePayloadSamples: intervalResult.diagnostics.malformedScorePayloadSamples,
+    intervalPayloadSkipCount: intervalResult.diagnostics.intervalPayloadSkipCount,
+    intervalPayloadSkipSamples: intervalResult.diagnostics.intervalPayloadSkipSamples,
     rankingPresent,
   };
 }
@@ -418,16 +563,12 @@ async function main() {
 
   const result = await seedResilienceScores();
   await writeScoreSectionHeartbeat(result);
-  logSeedResult('resilience:scores', result.recordCount ?? 0, Date.now() - startedAt, {
-    skipped: Boolean(result.skipped),
-    ...(result.total != null && { total: result.total }),
-    ...(result.reason != null && { reason: result.reason }),
-    ...(result.intervalsWritten != null && { intervalsWritten: result.intervalsWritten }),
-    ...(result.intervalClampCount != null && { intervalClampCount: result.intervalClampCount }),
-    ...(result.intervalClampMaxDelta != null && { intervalClampMaxDelta: result.intervalClampMaxDelta }),
-    ...(result.intervalFormulaSkipCount != null && { intervalFormulaSkipCount: result.intervalFormulaSkipCount }),
-    ...(result.intervalFormulaSkipSamples?.length ? { intervalFormulaSkipSamples: result.intervalFormulaSkipSamples } : {}),
-  });
+  const { extra, intervalFailure, exitCode } = buildSeedResultLogExtra(result);
+  logSeedResult('resilience:scores', result.recordCount ?? 0, Date.now() - startedAt, extra);
+  if (intervalFailure) {
+    console.error(`[resilience-scores] ${intervalFailure.message}`);
+    process.exitCode = exitCode;
+  }
   if (!result.skipped && (result.recordCount ?? 0) > 0 && !result.rankingPresent) {
     // Observability only — seeder never writes seed-meta. Health will flag the
     // stale meta on its own if this persists across multiple cron ticks.

--- a/scripts/seed-resilience-scores.mjs
+++ b/scripts/seed-resilience-scores.mjs
@@ -155,14 +155,16 @@ export function buildIntervalPayloadFromCachedScore(raw, countryCode, diagnostic
 
     const formula = typeof score?._formula === 'string' ? score._formula : undefined;
     if (formula !== 'pc' && formula !== 'd6') {
+      // buildScoreIntervalPayload records formula skip diagnostics for ambiguous cached scores.
       buildScoreIntervalPayload(score, { draws: DRAWS, diagnostics });
       return null;
     }
 
-    if (formula !== currentCacheFormulaLocal()) {
+    const expectedFormula = currentCacheFormulaLocal();
+    if (formula !== expectedFormula) {
       recordDiagnosticCount(diagnostics, 'staleScorePayloadCount', 'staleScorePayloadSamples', countryCode, {
         formula,
-        expectedFormula: currentCacheFormulaLocal(),
+        expectedFormula,
       });
       return null;
     }
@@ -249,10 +251,14 @@ export function getIntervalWriteFailure(result) {
   const formulaSkipCount = Number(result?.intervalFormulaSkipCount ?? 0);
   const missingScorePayloadCount = Number(result?.intervalMissingScorePayloadCount ?? 0);
   const staleScorePayloadCount = Number(result?.intervalStaleScorePayloadCount ?? 0);
+  const invalidScorePayloadCount = Number(result?.intervalInvalidScorePayloadCount ?? 0);
+  const malformedScorePayloadCount = Number(result?.intervalMalformedScorePayloadCount ?? 0);
   const intervalPayloadSkipCount = Number(result?.intervalPayloadSkipCount ?? 0);
   let reason = 'empty_interval_writes';
   if (staleScorePayloadCount > 0) reason = 'stale_score_cache';
-  else if (scoreCount <= 0 || missingScorePayloadCount >= total) reason = 'missing_score_cache';
+  else if (missingScorePayloadCount >= total || (scoreCount <= 0 && missingScorePayloadCount > 0)) reason = 'missing_score_cache';
+  else if (malformedScorePayloadCount > 0) reason = 'malformed_score_cache';
+  else if (invalidScorePayloadCount > 0) reason = 'invalid_score_cache';
   else if (formulaSkipCount > 0) reason = 'unusable_score_formula';
   else if (intervalPayloadSkipCount > 0) reason = 'unusable_score_payload';
 
@@ -263,6 +269,8 @@ export function getIntervalWriteFailure(result) {
       `(cachedScores=${Number.isFinite(scoreCount) ? scoreCount : 0}, ` +
       `missingScorePayloads=${Number.isFinite(missingScorePayloadCount) ? missingScorePayloadCount : 0}, ` +
       `staleScorePayloads=${Number.isFinite(staleScorePayloadCount) ? staleScorePayloadCount : 0}, ` +
+      `invalidScorePayloads=${Number.isFinite(invalidScorePayloadCount) ? invalidScorePayloadCount : 0}, ` +
+      `malformedScorePayloads=${Number.isFinite(malformedScorePayloadCount) ? malformedScorePayloadCount : 0}, ` +
       `formulaSkips=${Number.isFinite(formulaSkipCount) ? formulaSkipCount : 0}, ` +
       `intervalPayloadSkips=${Number.isFinite(intervalPayloadSkipCount) ? intervalPayloadSkipCount : 0})`,
   };

--- a/tests/resilience-scores-seed.test.mjs
+++ b/tests/resilience-scores-seed.test.mjs
@@ -164,6 +164,32 @@ describe('interval seed health classification', () => {
     assert.match(failure?.message ?? '', /staleScorePayloads=196/);
   });
 
+  it('fails with malformed-cache reason when cached score payload JSON cannot be parsed', () => {
+    const failure = getIntervalWriteFailure({
+      skipped: false,
+      total: 196,
+      recordCount: 0,
+      intervalsWritten: 0,
+      intervalMalformedScorePayloadCount: 196,
+    });
+
+    assert.equal(failure?.reason, 'malformed_score_cache');
+    assert.match(failure?.message ?? '', /malformedScorePayloads=196/);
+  });
+
+  it('fails with invalid-cache reason when cached score payload shape is unusable', () => {
+    const failure = getIntervalWriteFailure({
+      skipped: false,
+      total: 196,
+      recordCount: 0,
+      intervalsWritten: 0,
+      intervalInvalidScorePayloadCount: 196,
+    });
+
+    assert.equal(failure?.reason, 'invalid_score_cache');
+    assert.match(failure?.message ?? '', /invalidScorePayloads=196/);
+  });
+
   it('fails with a formula-specific reason when cached score payloads are unusable for intervals', () => {
     const failure = getIntervalWriteFailure({
       skipped: false,

--- a/tests/resilience-scores-seed.test.mjs
+++ b/tests/resilience-scores-seed.test.mjs
@@ -2,14 +2,44 @@ import { before, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  createIntervalDiagnostics,
+} from '../scripts/_resilience-intervals.mjs';
+import {
   RESILIENCE_RANKING_CACHE_KEY,
   RESILIENCE_RANKING_CACHE_TTL_SECONDS,
   RESILIENCE_SCORE_SECTION_META_TTL_SECONDS,
   RESILIENCE_SCORE_CACHE_PREFIX,
   RESILIENCE_STATIC_INDEX_KEY,
+  buildIntervalPayloadFromCachedScore,
+  buildSeedResultLogExtra,
   computeIntervals,
+  getIntervalWriteFailure,
   parseCachedScorePayload,
 } from '../scripts/seed-resilience-scores.mjs';
+
+const D6_DOMAINS = [
+  { id: 'economic', score: 70, weight: 0.17 },
+  { id: 'infrastructure', score: 72, weight: 0.15 },
+  { id: 'energy', score: 68, weight: 0.11 },
+  { id: 'social-governance', score: 74, weight: 0.19 },
+  { id: 'health-food', score: 69, weight: 0.13 },
+  { id: 'recovery', score: 71, weight: 0.25 },
+];
+
+function withD6CacheFormula(fn) {
+  const originalCombine = process.env.RESILIENCE_PILLAR_COMBINE_ENABLED;
+  const originalSchema = process.env.RESILIENCE_SCHEMA_V2_ENABLED;
+  process.env.RESILIENCE_PILLAR_COMBINE_ENABLED = 'false';
+  process.env.RESILIENCE_SCHEMA_V2_ENABLED = 'true';
+  try {
+    return fn();
+  } finally {
+    if (originalCombine == null) delete process.env.RESILIENCE_PILLAR_COMBINE_ENABLED;
+    else process.env.RESILIENCE_PILLAR_COMBINE_ENABLED = originalCombine;
+    if (originalSchema == null) delete process.env.RESILIENCE_SCHEMA_V2_ENABLED;
+    else process.env.RESILIENCE_SCHEMA_V2_ENABLED = originalSchema;
+  }
+}
 
 describe('exported constants', () => {
   it('RESILIENCE_RANKING_CACHE_KEY matches the canonical resilience:ranking shape', () => {
@@ -99,6 +129,153 @@ describe('score cache payload validation', () => {
       if (originalSchema == null) delete process.env.RESILIENCE_SCHEMA_V2_ENABLED;
       else process.env.RESILIENCE_SCHEMA_V2_ENABLED = originalSchema;
     }
+  });
+});
+
+describe('interval seed health classification', () => {
+  it('does not fail interval health for an intentionally empty static index skip', () => {
+    assert.equal(getIntervalWriteFailure({ skipped: true, reason: 'no_index' }), null);
+  });
+
+  it('fails when current score cache stays missing or stale after warmup', () => {
+    const failure = getIntervalWriteFailure({
+      skipped: false,
+      total: 196,
+      recordCount: 0,
+      intervalsWritten: 0,
+      intervalMissingScorePayloadCount: 196,
+    });
+
+    assert.equal(failure?.reason, 'missing_score_cache');
+    assert.match(failure?.message ?? '', /wrote 0 interval keys for 196 rankable countries/);
+    assert.match(failure?.message ?? '', /cachedScores=0/);
+  });
+
+  it('fails with a stale-cache reason when score payloads have an old formula tag', () => {
+    const failure = getIntervalWriteFailure({
+      skipped: false,
+      total: 196,
+      recordCount: 0,
+      intervalsWritten: 0,
+      intervalStaleScorePayloadCount: 196,
+    });
+
+    assert.equal(failure?.reason, 'stale_score_cache');
+    assert.match(failure?.message ?? '', /staleScorePayloads=196/);
+  });
+
+  it('fails with a formula-specific reason when cached score payloads are unusable for intervals', () => {
+    const failure = getIntervalWriteFailure({
+      skipped: false,
+      total: 196,
+      recordCount: 196,
+      intervalsWritten: 0,
+      intervalFormulaSkipCount: 196,
+    });
+
+    assert.equal(failure?.reason, 'unusable_score_formula');
+  });
+
+  it('passes when at least one interval key is written', () => {
+    assert.equal(getIntervalWriteFailure({
+      skipped: false,
+      total: 196,
+      recordCount: 196,
+      intervalsWritten: 196,
+    }), null);
+  });
+});
+
+describe('cached score interval payload classification', () => {
+  it('records formula skips for score payloads missing formula tags', () => {
+    withD6CacheFormula(() => {
+      const diagnostics = createIntervalDiagnostics();
+      const payload = buildIntervalPayloadFromCachedScore(JSON.stringify({
+        countryCode: 'MS',
+        overallScore: 70,
+        domains: D6_DOMAINS,
+      }), 'MS', diagnostics);
+
+      assert.equal(payload, null);
+      assert.equal(diagnostics.formulaSkipCount, 1);
+      assert.deepEqual(diagnostics.formulaSkipSamples[0], {
+        countryCode: 'MS',
+        formula: undefined,
+        reason: 'missing_formula',
+      });
+      assert.equal(diagnostics.invalidScorePayloadCount, 0);
+    });
+  });
+
+  it('records stale score payloads separately from formula skips', () => {
+    withD6CacheFormula(() => {
+      const diagnostics = createIntervalDiagnostics();
+      const payload = buildIntervalPayloadFromCachedScore(JSON.stringify({
+        countryCode: 'ST',
+        _formula: 'pc',
+        overallScore: 70,
+        domains: D6_DOMAINS,
+      }), 'ST', diagnostics);
+
+      assert.equal(payload, null);
+      assert.equal(diagnostics.staleScorePayloadCount, 1);
+      assert.equal(diagnostics.formulaSkipCount, 0);
+      assert.deepEqual(diagnostics.staleScorePayloadSamples[0], {
+        countryCode: 'ST',
+        formula: 'pc',
+        expectedFormula: 'd6',
+      });
+    });
+  });
+
+  it('builds intervals for current tagged score payloads', () => {
+    withD6CacheFormula(() => {
+      const diagnostics = createIntervalDiagnostics();
+      const payload = buildIntervalPayloadFromCachedScore(JSON.stringify({
+        countryCode: 'OK',
+        _formula: 'd6',
+        overallScore: 70,
+        domains: D6_DOMAINS,
+      }), 'OK', diagnostics);
+
+      assert.ok(payload);
+      assert.equal(payload._formula, 'd6');
+      assert.equal(diagnostics.formulaSkipCount, 0);
+      assert.equal(diagnostics.staleScorePayloadCount, 0);
+      assert.equal(diagnostics.invalidScorePayloadCount, 0);
+    });
+  });
+});
+
+describe('seed result logging and exit classification', () => {
+  it('marks zero interval writes as an error and non-zero exit decision', () => {
+    const { extra, intervalFailure, exitCode } = buildSeedResultLogExtra({
+      skipped: false,
+      total: 196,
+      recordCount: 0,
+      intervalsWritten: 0,
+      intervalMissingScorePayloadCount: 196,
+    });
+
+    assert.equal(exitCode, 1);
+    assert.equal(intervalFailure?.reason, 'missing_score_cache');
+    assert.equal(extra.status, 'ERROR');
+    assert.equal(extra.intervalFailureReason, 'missing_score_cache');
+    assert.match(extra.error, /wrote 0 interval keys/);
+  });
+
+  it('keeps successful interval writes as normal seed-complete metadata', () => {
+    const { extra, intervalFailure, exitCode } = buildSeedResultLogExtra({
+      skipped: false,
+      total: 196,
+      recordCount: 196,
+      intervalsWritten: 196,
+    });
+
+    assert.equal(exitCode, 0);
+    assert.equal(intervalFailure, null);
+    assert.equal(extra.status, undefined);
+    assert.equal(extra.intervalsWritten, 196);
   });
 });
 
@@ -194,6 +371,20 @@ describe('script is self-contained .mjs', () => {
     assert.match(src, /intervalFormulaSkipSamples/);
   });
 
+  it('reports missing and malformed score payload diagnostics when interval writes are empty', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const { dirname, join } = await import('node:path');
+    const dir = dirname(fileURLToPath(import.meta.url));
+    const src = readFileSync(join(dir, '..', 'scripts', 'seed-resilience-scores.mjs'), 'utf8');
+    assert.match(src, /missingScorePayloadCount/);
+    assert.match(src, /staleScorePayloadCount/);
+    assert.match(src, /invalidScorePayloadCount/);
+    assert.match(src, /malformedScorePayloadCount/);
+    assert.match(src, /intervalPayloadSkipCount/);
+    assert.match(src, /intervalFailureReason/);
+  });
+
   it('builds intervals only from tagged Redis score payloads', async () => {
     const { readFileSync } = await import('node:fs');
     const { fileURLToPath } = await import('node:url');
@@ -205,8 +396,7 @@ describe('script is self-contained .mjs', () => {
       src.indexOf('async function seedResilienceScores'),
     );
     assert.match(src, /\['GET', `\$\{RESILIENCE_SCORE_CACHE_PREFIX\}\$\{c\}`\]/);
-    assert.match(intervalWriter, /unwrapEnvelope\(JSON\.parse\(raw\)\)\.data/);
-    assert.match(intervalWriter, /buildScoreIntervalPayload\(score, \{ draws: DRAWS, diagnostics \}\)/);
+    assert.match(intervalWriter, /buildIntervalPayloadFromCachedScore\(raw, countryCode, diagnostics\)/);
     assert.doesNotMatch(intervalWriter, /get-resilience-score\?countryCode=/);
     assert.doesNotMatch(intervalWriter, /allowLegacyFormulaInference:\s*true/);
   });


### PR DESCRIPTION
## Summary
- fail resilience score seed runs when a non-empty country universe writes zero interval keys
- classify missing, stale, invalid, malformed, and formula-skipped score payloads before interval writes
- add behavioral tests for interval seed failure logging/exit decisions

## Validation
- `./node_modules/.bin/tsx --test tests/resilience-scores-seed.test.mjs`
- `./node_modules/.bin/tsx --test tests/resilience-scores-seed.test.mjs tests/resilience-intervals.test.mjs tests/resilience-intervals-handler.test.mts tests/resilience-ranking.test.mts tests/resilience-cache-keys-health-sync.test.mts`
- `git diff --check`
- pre-push hook: typecheck, API typecheck, edge bundle checks, full unit suite, edge function tests, markdown lint, MDX lint, proto freshness check, pro-test bundle freshness check, and version sync check passed

## Ops note
This code makes future empty interval writes fail/report as seed errors with diagnostics. Existing live Redis state still needs the production seed job rerun after deploy to repopulate `resilience:interval:*` keys.
