### PR TITLE
fix(sentry): classify Convex WorkerOverloaded as transient; mute Clerk FE-API fetch noise

### DIFF
--- a/api/_convex-error.js
+++ b/api/_convex-error.js
@@ -18,18 +18,6 @@
  */
 
 /**
- * Extract the named-error `kind` from a Convex client throw. Prefers the
- * structured `err.data.kind` (server-side `ConvexError({ kind, ... })`),
- * falls back to substring-matching the legacy string-data error message
- * (`ConvexError("CONFLICT")`) for the deploy-ordering window where the
- * Vercel build may run against an older Convex deployment.
- *
- * @param {unknown} err
- * @param {string} msg `err.message` (passed in to avoid re-coercing in
- *   callers that already computed it).
- * @returns {string | null} the kind, or null when neither path matches.
- */
-/**
  * Match a Convex platform-error JSON body's `"code":"X"` field, tolerating the
  * optional whitespace a non-default serializer may emit after the colon
  * (`"code": "X"`). Convex's runtime uses `JSON.stringify` (no spaces) today, so
@@ -47,6 +35,18 @@ function hasConvexCode(msg, code) {
   return new RegExp(`"code":\\s*"${code}"`).test(msg);
 }
 
+/**
+ * Extract the named-error `kind` from a Convex client throw. Prefers the
+ * structured `err.data.kind` (server-side `ConvexError({ kind, ... })`),
+ * falls back to substring-matching the legacy string-data error message
+ * (`ConvexError("CONFLICT")`) for the deploy-ordering window where the
+ * Vercel build may run against an older Convex deployment.
+ *
+ * @param {unknown} err
+ * @param {string} msg `err.message` (passed in to avoid re-coercing in
+ *   callers that already computed it).
+ * @returns {string | null} the kind, or null when neither path matches.
+ */
 export function extractConvexErrorKind(err, msg) {
   const data = /** @type {{ data?: unknown } | null | undefined} */ (err)?.data;
   if (data && typeof data === 'object' && 'kind' in data) {

--- a/api/_convex-error.js
+++ b/api/_convex-error.js
@@ -29,6 +29,24 @@
  *   callers that already computed it).
  * @returns {string | null} the kind, or null when neither path matches.
  */
+/**
+ * Match a Convex platform-error JSON body's `"code":"X"` field, tolerating the
+ * optional whitespace a non-default serializer may emit after the colon
+ * (`"code": "X"`). Convex's runtime uses `JSON.stringify` (no spaces) today, so
+ * this is defensive — it keeps the whole platform-code family
+ * (ServiceUnavailable / InternalServerError / WorkerOverloaded / Unauthenticated)
+ * from sharing a brittle no-whitespace assumption that would break them all at
+ * once if an intermediary ever re-serialized the body. The `code` values are
+ * fixed internal literals (no regex metacharacters), so interpolation is safe.
+ *
+ * @param {string} msg
+ * @param {string} code
+ * @returns {boolean}
+ */
+function hasConvexCode(msg, code) {
+  return new RegExp(`"code":\\s*"${code}"`).test(msg);
+}
+
 export function extractConvexErrorKind(err, msg) {
   const data = /** @type {{ data?: unknown } | null | undefined} */ (err)?.data;
   if (data && typeof data === 'object' && 'kind' in data) {
@@ -43,7 +61,7 @@ export function extractConvexErrorKind(err, msg) {
   // we detect via the JSON-shape substring. Edge maps this to a 503
   // response with Retry-After so clients back off rather than treating
   // it as a permanent 500.
-  if (msg.includes('"code":"ServiceUnavailable"')) return 'SERVICE_UNAVAILABLE';
+  if (hasConvexCode(msg, 'ServiceUnavailable')) return 'SERVICE_UNAVAILABLE';
   // Client-side fetch timeout (AbortSignal.timeout fires) — Convex stalled
   // long enough that we aborted before Vercel's 25s edge wall-clock could
   // kill the function with a generic 500. Same remediation as the platform
@@ -80,7 +98,7 @@ export function extractConvexErrorKind(err, msg) {
   // Map to the same UNAUTHENTICATED kind as the structured-data path so
   // the edge handler maps it to 401 and tags it as `convex_auth_drift`
   // (WORLDMONITOR-PG).
-  if (msg.includes('"code":"Unauthenticated"')) return 'UNAUTHENTICATED';
+  if (hasConvexCode(msg, 'Unauthenticated')) return 'UNAUTHENTICATED';
   // Convex platform-level 500: `{"code":"InternalServerError","message":
   // "Your request couldn't be completed. Try again later."}` — runtime
   // signals an internal failure that the SDK can't classify further. Same
@@ -89,7 +107,17 @@ export function extractConvexErrorKind(err, msg) {
   // Sentry `error_shape` discriminates via msg-pattern fallback so the
   // dashboard can tell internal-500s apart from genuine ServiceUnavailable
   // 503s (WORLDMONITOR-PG / WORLDMONITOR-PH).
-  if (msg.includes('"code":"InternalServerError"')) return 'SERVICE_UNAVAILABLE';
+  if (hasConvexCode(msg, 'InternalServerError')) return 'SERVICE_UNAVAILABLE';
+  // Convex platform-level worker saturation: `{"code":"WorkerOverloaded",
+  // "message":"There are no available workers to process the request"}` —
+  // the deployment briefly has no free function workers. Same transient
+  // retry-with-back-off remediation as the platform 503/500, so reuse
+  // SERVICE_UNAVAILABLE → 503 + Retry-After rather than surfacing a 500.
+  // Without this match the catch fell to the 'unknown' error_shape bucket
+  // at error level (WORLDMONITOR-PG: 11 events / 9 users). Sentry's
+  // classifier tags these `convex_worker_overloaded` so they stay queryable
+  // apart from genuine ServiceUnavailable 503s and InternalServerError 500s.
+  if (hasConvexCode(msg, 'WorkerOverloaded')) return 'SERVICE_UNAVAILABLE';
   if (msg.includes('CONFLICT')) return 'CONFLICT';
   if (msg.includes('BLOB_TOO_LARGE')) return 'BLOB_TOO_LARGE';
   if (msg.includes('UNAUTHENTICATED')) return 'UNAUTHENTICATED';

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -371,14 +371,25 @@ export function buildSentryContext(
     // WORLDMONITOR-PG: the JSON-cased variant was previously falling
     // through to 'unknown' because the `/UNAUTHENTICATED/` regex is
     // case-sensitive.
-    ?? (/UNAUTHENTICATED|"code":"Unauthenticated"/.test(msg) ? 'convex_auth_drift'
-      : /"code":"ServiceUnavailable"/.test(msg) ? 'convex_service_unavailable'
+    // The `"code":\s*"X"` forms tolerate the optional post-colon whitespace a
+    // non-default serializer may emit (`"code": "X"`), mirroring `hasConvexCode`
+    // in _convex-error.js so this Sentry bucket and the kind→503 mapping stay in
+    // lockstep — a with-whitespace body classifies identically on both sides.
+    ?? (/UNAUTHENTICATED|"code":\s*"Unauthenticated"/.test(msg) ? 'convex_auth_drift'
+      : /"code":\s*"ServiceUnavailable"/.test(msg) ? 'convex_service_unavailable'
       // Convex platform 500 — runtime can't recover the request. Same
       // 503-with-Retry-After remediation as ServiceUnavailable in
       // _convex-error.js, but kept as its own Sentry bucket so on-call can
       // tell internal-500s apart from genuine 503s when triaging
       // (WORLDMONITOR-PG/PH).
-      : /"code":"InternalServerError"/.test(msg) ? 'convex_internal_error'
+      : /"code":\s*"InternalServerError"/.test(msg) ? 'convex_internal_error'
+      // Convex platform worker saturation: `{"code":"WorkerOverloaded",
+      // "message":"There are no available workers to process the request"}`.
+      // Mapped to SERVICE_UNAVAILABLE (503 + Retry-After) in _convex-error.js,
+      // same as InternalServerError/ServiceUnavailable; kept as its own Sentry
+      // bucket so on-call can tell worker-saturation apart from internal-500s
+      // and genuine 503s when triaging (WORLDMONITOR-PG).
+      : /"code":\s*"WorkerOverloaded"/.test(msg) ? 'convex_worker_overloaded'
       : /\[Request ID:\s*[a-f0-9]+\]\s*Server Error/i.test(msg) ? 'convex_server_error'
       // Cloudflare edge error (520-527) fronting the Convex deployment — see
       // _convex-error.js. Mapped to SERVICE_UNAVAILABLE (503 + Retry-After)

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,14 @@ const THIRD_PARTY_FETCH_HOST_ALLOWLIST = new Set([
   'basemaps.cartocdn.com',
   'tiles.openfreemap.org',
   'protomaps.github.io',
+  // Clerk Frontend API (CNAME → Clerk's auth infra). The bundled Clerk SDK
+  // fetches it for session/token refresh and retries transient failures
+  // itself (`retryImmediately`); a `Failed to fetch (clerk.worldmonitor.app)`
+  // that leaks to onunhandledrejection is a Clerk-SDK-internal network blip,
+  // not our code — same disposition as the existing `/ClerkJS: Network error/`
+  // ignoreError. NOT our `api.worldmonitor.app`, which stays off the list so
+  // genuine API regressions still surface (WORLDMONITOR-SA/SB).
+  'clerk.worldmonitor.app',
 ]);
 
 // Initialize Sentry error tracking (early as possible)

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -422,6 +422,22 @@ describe('existing beforeSend filters', () => {
     assert.equal(beforeSend(event), null, 'Allowlisted AJAX host should be suppressed regardless of stack shape');
   });
 
+  it('suppresses Clerk SDK "Failed to fetch (clerk.worldmonitor.app)" even with a clerk first-party frame', () => {
+    // WORLDMONITOR-SA/SB: the bundled Clerk SDK fetches its Frontend API
+    // (clerk.worldmonitor.app, a CNAME to Clerk's auth infra) for token
+    // refresh and retries transient failures itself. A leaked
+    // `Failed to fetch (clerk.worldmonitor.app)` is a Clerk-SDK-internal
+    // network blip, not our code — same disposition as `/ClerkJS: Network
+    // error/`. The clerk-*.js chunk reads as first-party (not in the vendor
+    // list), so the host allowlist — not hasFirstParty — must decide.
+    const event = makeEvent('Failed to fetch (clerk.worldmonitor.app)', 'TypeError', [
+      { filename: '/assets/clerk-DC7Q2aDh.js', lineno: 848, function: 'i' },
+      { filename: 'chrome-extension://ebeglcfoffnnadgncmppkkohfcigngkj/js/injected/hook.js', lineno: 1, function: 'Object.apply' },
+      { filename: '/assets/panels-CYSIkWVK.js', lineno: 45, function: 'window.fetch' },
+    ]);
+    assert.equal(beforeSend(event), null, 'Clerk Frontend API fetch failure should be suppressed');
+  });
+
   it('does NOT suppress plain "Failed to fetch" from first-party code without maplibre frames', () => {
     const event = makeEvent('Failed to fetch', 'TypeError', [
       { filename: '/assets/panels-wF5GXf0N.js', lineno: 100, function: 'MyApiCall' },

--- a/tests/user-prefs-convex-error.test.mjs
+++ b/tests/user-prefs-convex-error.test.mjs
@@ -131,6 +131,40 @@ describe('extractConvexErrorKind — Convex client error → kind', () => {
     });
   });
 
+  describe('Convex platform worker saturation — WorkerOverloaded JSON body (WORLDMONITOR-PG)', () => {
+    it('detects SERVICE_UNAVAILABLE from the {"code":"WorkerOverloaded"} JSON shape', () => {
+      // Convex runtime surfaces
+      //   `{"code":"WorkerOverloaded","message":"There are no available
+      //     workers to process the request"}`
+      // when the deployment briefly has no free function workers. Same
+      // retry-with-backoff remediation as ServiceUnavailable/InternalServerError,
+      // so we map to SERVICE_UNAVAILABLE → 503 + Retry-After instead of a 500.
+      const err = new Error('{"code":"WorkerOverloaded","message":"There are no available workers to process the request"}');
+      assert.equal(extractConvexErrorKind(err, err.message), 'SERVICE_UNAVAILABLE');
+    });
+
+    it('does NOT match the loose phrase "no available workers" without the JSON code field', () => {
+      // Defensive: detector keys off the exact JSON shape, not free-form prose.
+      const err = new Error('the pool reported no available workers, backing off');
+      assert.equal(extractConvexErrorKind(err, err.message), null);
+    });
+
+    it('tolerates optional whitespace after the colon ("code": "WorkerOverloaded")', () => {
+      // The whole platform-code family is matched whitespace-tolerantly so a
+      // body re-serialized by an intermediary (`"code": "X"`) still classifies.
+      // Convex emits no-space today; this locks in the defensive behaviour.
+      const err = new Error('{"code": "WorkerOverloaded", "message": "There are no available workers to process the request"}');
+      assert.equal(extractConvexErrorKind(err, err.message), 'SERVICE_UNAVAILABLE');
+    });
+
+    it('structured-data path still wins over JSON-shape WorkerOverloaded (forward-compat)', () => {
+      const err = Object.assign(new Error('{"code":"WorkerOverloaded","message":"x"}'), {
+        data: { kind: 'CONFLICT' },
+      });
+      assert.equal(extractConvexErrorKind(err, err.message), 'CONFLICT');
+    });
+  });
+
   describe('Vercel edge transient — "Network connection lost." (WORLDMONITOR-QE)', () => {
     it('detects SERVICE_UNAVAILABLE from the exact "Network connection lost." shape', () => {
       // Vercel/Cloudflare edge runtime surface this when the upstream socket

--- a/tests/user-prefs-sentry-context.test.mts
+++ b/tests/user-prefs-sentry-context.test.mts
@@ -141,6 +141,30 @@ describe('buildSentryContext — backwards-compat for non-CONFLICT callers', () 
     assert.equal(ctx.tags.error_shape, 'convex_internal_error');
   });
 
+  it('JSON-shape "code":"WorkerOverloaded" classifies as convex_worker_overloaded', () => {
+    // WORLDMONITOR-PG: Convex runtime worker saturation
+    //   `{"code":"WorkerOverloaded","message":"There are no available workers
+    //     to process the request"}`
+    // was previously bucketed as 'unknown' at error level (11 events / 9 users),
+    // conflating a transient platform-capacity event with genuinely-novel error
+    // shapes. Its own bucket + the SERVICE_UNAVAILABLE mapping in
+    // `_convex-error.js` mean on-call sees it tagged distinctly without a
+    // 500 → 503 user-impact regression.
+    const err = new Error('{"code":"WorkerOverloaded","message":"There are no available workers to process the request"}');
+    const ctx = buildSentryContext(err, err.message, baseOpts);
+    assert.equal(ctx.tags.error_shape, 'convex_worker_overloaded');
+  });
+
+  it('tolerates optional whitespace after the colon ("code": "WorkerOverloaded")', () => {
+    // Mirrors `hasConvexCode` in _convex-error.js so the Sentry bucket and the
+    // kind→503 mapping stay in lockstep: a with-whitespace body must classify
+    // identically on both sides, never splitting into a 503-but-'unknown'-tag
+    // state.
+    const err = new Error('{"code": "WorkerOverloaded", "message": "There are no available workers to process the request"}');
+    const ctx = buildSentryContext(err, err.message, baseOpts);
+    assert.equal(ctx.tags.error_shape, 'convex_worker_overloaded');
+  });
+
   it('JSON-shape "code":"Unauthenticated" classifies as convex_auth_drift (mixed-case OIDC failure)', () => {
     // WORLDMONITOR-PG: Convex platform-level 401 ships a JSON body
     //   `{"code":"Unauthenticated","message":"Could not verify OIDC token claim..."}`


### PR DESCRIPTION
## Summary

Sentry triage of 7 unresolved issues. The bulk were the same Convex/Upstash platform transients surfacing across three independent Sentry layers (browser, Vercel edge `captureSilentError`, and Convex Cloud auto-Sentry).

- **WORLDMONITOR-PG** (`api/user-prefs`, edge): Convex returned `{"code":"WorkerOverloaded","message":"There are no available workers to process the request"}`, but `extractConvexErrorKind` had no mapping for it — so the catch fell through to a generic **500 + error-level** capture (`error_shape: 'unknown'`). Now mapped to `SERVICE_UNAVAILABLE` → **503 + Retry-After**, captured at **warning**, exactly like the sibling `ServiceUnavailable`/`InternalServerError` platform transients. Gets its own `convex_worker_overloaded` Sentry bucket so on-call can tell worker-saturation apart from internal-500s.
- **Whitespace hardening**: routed the whole platform-code family through a `hasConvexCode()` helper (`/"code":\s*"X"/`) in `_convex-error.js`, and added `\s*` to the matching `error_shape` regex chain in `user-prefs.ts`, so the kind→503 mapping and the Sentry bucket stay in **lockstep** (a re-serialized `"code": "X"` body can't split into "503 but `unknown` tag"). Production payloads (no-space `JSON.stringify`) classify byte-identically — this only *adds* tolerance.
- **WORLDMONITOR-SA / SB** (browser): `Failed to fetch (clerk.worldmonitor.app)` is the bundled Clerk SDK failing to reach its Frontend API and retrying itself (`retryImmediately`). Added `clerk.worldmonitor.app` to `THIRD_PARTY_FETCH_HOST_ALLOWLIST` — same disposition as the existing `/ClerkJS: Network error/` ignoreError. `api.worldmonitor.app` intentionally stays **off** the list so genuine API regressions still surface.

### Already handled / not in scope
- **WORLDMONITOR-RX** (rate-limit Redis script timeout) and **RQ** (`InternalServerError`) were already classified at `warning` by existing code — resolved in Sentry, no code change.
- **WORLDMONITOR-S5 / S9** are `sdk: convex` events (Convex Cloud auto-Sentry, zero stack frames). Per the documented `convex-autosentry` pattern, client-side filters are inert and there's no throwing function in `convex/` to refactor — they're **not repo-filterable** and need dashboard-level muting / a capacity escalation to Convex (S5 is 70 events / 13 users).

## Test plan

- [x] `npm run typecheck` + `npm run typecheck:api`
- [x] `npm run lint` (biome) + `npm run lint:md`
- [x] `npm run test:data` (full unit + data suite)
- [x] `node --test tests/edge-functions.test.mjs`
- [x] Edge-function esbuild bundle check
- [x] `npm run version:check`
- [x] New regression tests: WorkerOverloaded → `SERVICE_UNAVAILABLE` + `convex_worker_overloaded` bucket (incl. with-whitespace variants); Clerk-host suppression with the real production stack shape