### PR TITLE
fix(gateway): remove dead auth debug field

### DIFF
--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -898,7 +898,7 @@ export function createDomainGateway(
           // Valid pro session (Clerk role OR Dodo entitlement) — fall through to route handling.
         } else {
           emitRequest(401, 'auth_401', null);
-          return new Response(JSON.stringify({ error: keyCheck.error, _debug: (keyCheck as any)._debug }), {
+          return new Response(JSON.stringify({ error: keyCheck.error }), {
             status: 401,
             headers: { 'Content-Type': 'application/json', ...corsHeaders },
           });

--- a/tests/premium-stock-gateway.test.mts
+++ b/tests/premium-stock-gateway.test.mts
@@ -90,6 +90,7 @@ describe('premium gateway API key enforcement', () => {
       headers: { Origin: 'https://worldmonitor.app' },
     }));
     assert.equal(browserNoKey.status, 401);
+    assert.deepEqual(await browserNoKey.json(), { error: 'API key required' });
 
     const resilienceScoreNoKey = await handler(new Request('https://worldmonitor.app/api/resilience/v1/get-resilience-score?countryCode=US', {
       headers: { Origin: 'https://worldmonitor.app' },


### PR DESCRIPTION
## Summary
- remove the dead `_debug` field from the premium gateway 401 response
- pin the missing-credentials response body in the premium gateway test

## Validation
- `./node_modules/.bin/tsx --test tests/premium-stock-gateway.test.mts`
- `git diff --check`
- `git push -u origin codex/gateway-401-debug` (pre-push hook completed successfully, including typecheck, API typecheck, full unit suite, edge tests, markdown/MDX lint, proto freshness check, pro-test bundle freshness check, and version sync)