### PR TITLE
Fix low-carbon source-year alignment

### DIFF
--- a/scripts/_wb-country-dict-content-age-helpers.mjs
+++ b/scripts/_wb-country-dict-content-age-helpers.mjs
@@ -10,7 +10,7 @@
 //
 //   - seed-power-reliability.mjs     (EG.ELC.LOSS.ZS)              — Sprint 4 PR #3602
 //   - seed-low-carbon-generation.mjs (EG.ELC.NUCL.ZS + RNEW + HYRO,
-//                                     summed value, MAX year of 3)
+//                                     summed at latest common component year)
 //   - seed-fossil-electricity-share.mjs (EG.ELC.FOSL.ZS)
 //
 // Why a shared helper instead of one per seeder: the contentMeta math is

--- a/scripts/seed-low-carbon-generation.mjs
+++ b/scripts/seed-low-carbon-generation.mjs
@@ -19,14 +19,17 @@
 // the power-system security intent.
 //
 // All three series are annual; WDI reports latest observed year per
-// country. We fetch up to 5 most-recent years (mrv=5) and pick the
-// latest non-null per country, then sum by ISO2. The mrv=5 + null-skip
-// recipe is documented in skill `wb-bulk-mrv1-null-coverage-trap`;
-// applied to this file in PR #3432 (review fixup).
-// Missing any of the three (e.g. a country with no nuclear filing)
-// is treated as 0 for that slice — the scorer's 0..80 saturating
-// goalpost tolerates partial coverage without dropping the indicator
-// to null.
+// country. We fetch up to 5 most-recent years (mrv=5), keep the per-year
+// history for each country, and sum only the latest COMMON source year
+// across the component series available for that country. That prevents a
+// 2024 hydro filing from being added to a 2021 renewables-ex-hydro filing
+// and then labelled as 2024. The mrv=5 + null-skip recipe is documented in
+// skill `wb-bulk-mrv1-null-coverage-trap`; applied to this file in PR #3432
+// (review fixup).
+// Missing an entire component series for a country is treated as 0 for that
+// slice, but if a component series exists for the country it must have data
+// in the selected common year. The scorer's 0..80 saturating goalpost
+// tolerates partial coverage without dropping the indicator to null.
 
 import { loadEnvFile, CHROME_UA, runSeed } from './_seed-utils.mjs';
 import iso3ToIso2 from './shared/iso3-to-iso2.json' with { type: 'json' };
@@ -34,15 +37,13 @@ import iso3ToIso2 from './shared/iso3-to-iso2.json' with { type: 'json' };
 // Per-seeder budget lives below — same shape, different publication lags.
 import { wbCountryDictContentMeta } from './_wb-country-dict-content-age-helpers.mjs';
 
-// 36mo budget — verified against live WB API on 2026-05-05: max year across
-// the three constituent indicators (NUCL/RNEW/HYRO) is 2024 (driven by
-// nuclear and hydro; renewables lags to 2021 but is masked by MAX-of-3 in
-// the seeder's countries[iso2].year). End-of-2024 = ~17mo before NOW, so
-// fresh-arrival lag is comfortably inside 36mo. Steady-state ceiling for
-// annual WB indicators = max_publication_lag (~18mo) + cycle_length (12mo)
-// = 30mo. 36mo = 30mo ceiling + 6mo slack. Same math as power-reliability
-// (#3602 review); see `_power-reliability-helpers.mjs` JSDoc for full
-// derivation.
+// 36mo budget — verified against live WB API on 2026-05-05. This seeder now
+// publishes the latest common component year per country, not the max of
+// independently latest component years, so content-age is conservative for
+// the actual composite being scored. Steady-state ceiling for annual WB
+// indicators = max_publication_lag (~18mo) + cycle_length (12mo) = 30mo.
+// 36mo = 30mo ceiling + 6mo slack. Same math as power-reliability (#3602
+// review); see `_power-reliability-helpers.mjs` JSDoc for full derivation.
 const MAX_CONTENT_AGE_MIN = 36 * 30 * 24 * 60;
 
 loadEnvFile(import.meta.url);
@@ -75,7 +76,7 @@ async function fetchIndicator(indicatorId) {
   return pages;
 }
 
-function collectByIso2(records) {
+export function collectByIsoYear(records) {
   const out = new Map();
   for (const record of records) {
     const rawCode = record?.countryiso3code ?? record?.country?.id ?? '';
@@ -93,36 +94,65 @@ function collectByIso2(records) {
     if (!Number.isFinite(value)) continue;
     const year = Number(record?.date);
     if (!Number.isFinite(year)) continue;
-    // Per-country latest-non-null (mrv=5 returns up to 5 records per country).
-    const existing = out.get(iso2);
-    if (!existing || year > existing.year) {
-      out.set(iso2, { value, year });
+    let byYear = out.get(iso2);
+    if (!byYear) {
+      byYear = new Map();
+      out.set(iso2, byYear);
     }
+    byYear.set(year, value);
   }
   return out;
 }
 
-async function fetchLowCarbonGeneration() {
-  const [nuclearRecords, renewRecords, hydroRecords] = await Promise.all(INDICATORS.map(fetchIndicator));
-  const nuclearByIso = collectByIso2(nuclearRecords);
-  const renewByIso = collectByIso2(renewRecords);
-  const hydroByIso = collectByIso2(hydroRecords);
+function latestCommonYear(componentMaps) {
+  const populated = componentMaps.filter((m) => m instanceof Map && m.size > 0);
+  if (populated.length === 0) return null;
 
+  const [first, ...rest] = populated;
+  const commonYears = [...first.keys()].filter((year) => rest.every((m) => m.has(year)));
+  if (commonYears.length === 0) return null;
+  return Math.max(...commonYears);
+}
+
+export function buildLowCarbonCountries({ nuclearByIso, renewByIso, hydroByIso }) {
   const allIso = new Set([...nuclearByIso.keys(), ...renewByIso.keys(), ...hydroByIso.keys()]);
   const countries = {};
+
   for (const iso2 of allIso) {
-    const nuc = nuclearByIso.get(iso2);
-    const ren = renewByIso.get(iso2);
-    const hyd = hydroByIso.get(iso2);
-    const sum = (nuc?.value ?? 0) + (ren?.value ?? 0) + (hyd?.value ?? 0);
-    // Year: most-recent of the three (they can diverge by a year or two
-    // between filings). Use the MAX so freshness reflects newest input.
-    const years = [nuc?.year, ren?.year, hyd?.year].filter((y) => y != null);
+    const nuc = nuclearByIso.get(iso2) ?? new Map();
+    const ren = renewByIso.get(iso2) ?? new Map();
+    const hyd = hydroByIso.get(iso2) ?? new Map();
+    const year = latestCommonYear([nuc, ren, hyd]);
+    if (year == null) continue;
+
+    const nuclearShare = nuc.get(year) ?? 0;
+    const renewablesExHydroShare = ren.get(year) ?? 0;
+    const hydroShare = hyd.get(year) ?? 0;
+    const sum = nuclearShare + renewablesExHydroShare + hydroShare;
+
     countries[iso2] = {
       value: Math.min(sum, 100), // guard against impossible sums from revised filings
-      year: years.length > 0 ? Math.max(...years) : null,
+      year,
+      nuclearShare,
+      renewablesExHydroShare,
+      hydroShare,
+      sourceYears: {
+        nuclear: nuc.has(year) ? year : null,
+        renewablesExHydro: ren.has(year) ? year : null,
+        hydro: hyd.has(year) ? year : null,
+      },
     };
   }
+
+  return countries;
+}
+
+async function fetchLowCarbonGeneration() {
+  const [nuclearRecords, renewRecords, hydroRecords] = await Promise.all(INDICATORS.map(fetchIndicator));
+  const nuclearByIso = collectByIsoYear(nuclearRecords);
+  const renewByIso = collectByIsoYear(renewRecords);
+  const hydroByIso = collectByIsoYear(hydroRecords);
+  const countries = buildLowCarbonCountries({ nuclearByIso, renewByIso, hydroByIso });
   return { countries, seededAt: new Date().toISOString() };
 }
 
@@ -148,9 +178,9 @@ if (process.argv[1]?.endsWith('seed-low-carbon-generation.mjs')) {
     maxStaleMin: 8 * 24 * 60, // weekly cadence + 1 day slack
 
     // ── Content-age contract (Sprint 4 cohort follow-up) ──
-    // Seeder takes MAX year across NUCL/RNEW/HYRO per country (line ~109);
-    // contentMeta then takes MAX year across countries. Budget rationale
-    // documented at the MAX_CONTENT_AGE_MIN constant above.
+    // Seeder publishes the latest COMMON component year across NUCL/RNEW/HYRO
+    // per country; contentMeta then takes MAX year across countries. Budget
+    // rationale documented at the MAX_CONTENT_AGE_MIN constant above.
     contentMeta: wbCountryDictContentMeta,
     maxContentAgeMin: MAX_CONTENT_AGE_MIN,
   }).catch((err) => {

--- a/tests/seed-low-carbon-generation.test.mjs
+++ b/tests/seed-low-carbon-generation.test.mjs
@@ -50,3 +50,22 @@ test('low-carbon generation omits countries with no common component year', () =
 
   assert.equal(countries.FR, undefined);
 });
+
+test('low-carbon generation treats an absent component series as zero', () => {
+  const nuclearByIso = collectByIsoYear(records('NOR', { 2024: 1 }));
+  const renewByIso = new Map();
+  const hydroByIso = collectByIsoYear(records('NOR', { 2024: 95 }));
+
+  const countries = buildLowCarbonCountries({ nuclearByIso, renewByIso, hydroByIso });
+
+  assert.equal(countries.NO.value, 96);
+  assert.equal(countries.NO.year, 2024);
+  assert.deepEqual(countries.NO.sourceYears, {
+    nuclear: 2024,
+    renewablesExHydro: null,
+    hydro: 2024,
+  });
+  assert.equal(countries.NO.nuclearShare, 1);
+  assert.equal(countries.NO.renewablesExHydroShare, 0);
+  assert.equal(countries.NO.hydroShare, 95);
+});

--- a/tests/seed-low-carbon-generation.test.mjs
+++ b/tests/seed-low-carbon-generation.test.mjs
@@ -1,0 +1,52 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildLowCarbonCountries,
+  collectByIsoYear,
+} from '../scripts/seed-low-carbon-generation.mjs';
+
+function records(iso3, valuesByYear) {
+  return Object.entries(valuesByYear).map(([date, value]) => ({
+    countryiso3code: iso3,
+    date,
+    value,
+  }));
+}
+
+test('low-carbon generation uses latest common source year, not max mixed component year', () => {
+  const nuclearByIso = collectByIsoYear(records('USA', {
+    2024: 18,
+    2021: 20,
+  }));
+  const renewByIso = collectByIsoYear(records('USA', {
+    2021: 15,
+  }));
+  const hydroByIso = collectByIsoYear(records('USA', {
+    2024: 7,
+    2021: 6,
+  }));
+
+  const countries = buildLowCarbonCountries({ nuclearByIso, renewByIso, hydroByIso });
+
+  assert.equal(countries.US.value, 41);
+  assert.equal(countries.US.year, 2021);
+  assert.deepEqual(countries.US.sourceYears, {
+    nuclear: 2021,
+    renewablesExHydro: 2021,
+    hydro: 2021,
+  });
+  assert.equal(countries.US.nuclearShare, 20);
+  assert.equal(countries.US.renewablesExHydroShare, 15);
+  assert.equal(countries.US.hydroShare, 6);
+});
+
+test('low-carbon generation omits countries with no common component year', () => {
+  const nuclearByIso = collectByIsoYear(records('FRA', { 2024: 65 }));
+  const renewByIso = collectByIsoYear(records('FRA', { 2021: 12 }));
+  const hydroByIso = collectByIsoYear(records('FRA', { 2024: 10 }));
+
+  const countries = buildLowCarbonCountries({ nuclearByIso, renewByIso, hydroByIso });
+
+  assert.equal(countries.FR, undefined);
+});

--- a/tests/wb-country-dict-content-age.test.mjs
+++ b/tests/wb-country-dict-content-age.test.mjs
@@ -106,8 +106,9 @@ const LOW_CARBON_BUDGET = 36 * 30 * 24 * 60;     // see seed-low-carbon-generati
 const FOSSIL_BUDGET = 48 * 30 * 24 * 60;          // see seed-fossil-electricity-share.mjs
 
 test('low-carbon: fresh-arrival regression guard — max year 2024 (~17mo) within 36mo budget', () => {
-  // NUCL/HYRO max = 2024 verified live 2026-05-05; RNEW lags but is masked
-  // by MAX-of-3 in the seeder's countries[iso2].year computation.
+  // Payload year is the seeder's aligned per-country composite year. When
+  // a country has common NUCL/RNEW/HYRO year 2024, that should remain within
+  // the low-carbon content-age budget.
   const data = { countries: { US: { value: 60.5, year: 2024 } } };
   const cm = wbCountryDictContentMeta(data, FIXED_NOW);
   const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;


### PR DESCRIPTION
## Summary

- Align low-carbon generation composites to the latest common source year across NUCL/RNEW/HYRO per country.
- Preserve component-level provenance in the low-carbon seed output.
- Add a focused regression test for the stale RNEW / max-year stamp failure mode.

## Root Cause

The low-carbon seeder selected each component's latest non-null World Bank value independently, summed those potentially mismatched years, and stamped the country entry with the max component year. That could hide a stale renewables-ex-hydro component behind fresher nuclear or hydro filings.

## Validation

- `node --test tests/seed-low-carbon-generation.test.mjs`
- `node --test tests/wb-country-dict-content-age.test.mjs`
- `node --test tests/seeder-content-age-coverage.test.mjs`
- `./node_modules/.bin/tsx --test tests/resilience-energy-v2.test.mts`
- `git diff --check`
- Pre-push hook completed successfully, including typecheck, API typecheck, full unit suite, edge tests, markdown/MDX lint, pro-test bundle freshness, and version sync.