### PR TITLE
Use timing-safe enterprise key comparison

### DIFF
--- a/api/_api-key.js
+++ b/api/_api-key.js
@@ -1,4 +1,5 @@
 import { isSessionTokenShape, validateSessionToken } from './_session.js';
+import { timingSafeIncludes } from './_crypto.js';
 
 const DESKTOP_ORIGIN_PATTERNS = [
   /^https?:\/\/tauri\.localhost(:\d+)?$/,
@@ -11,10 +12,10 @@ function isDesktopOrigin(origin) {
   return Boolean(origin) && DESKTOP_ORIGIN_PATTERNS.some(p => p.test(origin));
 }
 
-function isValidEnterpriseKey(key) {
+async function isValidEnterpriseKey(key) {
   if (!key) return false;
   const validKeys = (process.env.WORLDMONITOR_VALID_KEYS || '').split(',').filter(Boolean);
-  return validKeys.includes(key);
+  return timingSafeIncludes(key, validKeys);
 }
 
 function getCookie(req, name) {
@@ -63,7 +64,7 @@ export async function validateApiKey(req, options = {}) {
   // Desktop app — always require an enterprise key.
   if (isDesktopOrigin(origin)) {
     if (!headerKey) return { valid: false, required: true, error: 'API key required for desktop access' };
-    if (!isValidEnterpriseKey(headerKey)) return { valid: false, required: true, error: 'Invalid API key' };
+    if (!await isValidEnterpriseKey(headerKey)) return { valid: false, required: true, error: 'Invalid API key' };
     return { valid: true, required: true, kind: 'enterprise' };
   }
 
@@ -93,7 +94,7 @@ export async function validateApiKey(req, options = {}) {
   // Collision risk is negligible (wm_ user keys carry ≥192 bits of entropy
   // and would have to be added to the static env list to be honored at all,
   // which itself requires server-env-write access).
-  if (key && isValidEnterpriseKey(key)) {
+  if (key && await isValidEnterpriseKey(key)) {
     return { valid: true, required: true, kind: 'enterprise' };
   }
 

--- a/api/_api-key.test.mjs
+++ b/api/_api-key.test.mjs
@@ -1,4 +1,5 @@
 import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
 const SECRET = 'test-secret-must-be-at-least-32-chars-long-xxx';
@@ -114,6 +115,20 @@ test('enterprise key carries kind=enterprise (the only key kind that bypasses en
   const r = await validateApiKey(makeReq({ key: ENTERPRISE_KEY }));
   assert.equal(r.valid, true);
   assert.equal(r.kind, 'enterprise');
+});
+
+test('enterprise key allowlist uses timingSafeIncludes, not Array.includes', async () => {
+  const source = await readFile(new URL('./_api-key.js', import.meta.url), 'utf8');
+  assert.match(
+    source,
+    /import\s*\{[^}]*\btimingSafeIncludes\b[^}]*\}\s*from\s*['"]\.\/_crypto\.js['"]/,
+    'api/_api-key.js must use the Edge-safe timingSafeIncludes helper',
+  );
+  assert.doesNotMatch(
+    source,
+    /\bvalidKeys\.includes\s*\(\s*key\s*\)/,
+    'enterprise key validation must not use non-constant-time Array.includes(key)',
+  );
 });
 
 test('valid wms_ session token works even when Origin is also forged (not redundant — no privilege escalation)', async () => {


### PR DESCRIPTION
## Summary
- Replace enterprise API key allowlist Array.includes with the existing Edge-safe timingSafeIncludes helper.
- Add a focused API-key regression test to prevent reintroducing validKeys.includes(key).

## Validation
- node --test api/_api-key.test.mjs
- env npm_config_cache=/private/tmp/npm-cache npx tsx --test tests/no-non-timing-safe-secret-compare.test.mts
- git diff --check
- Pre-push hook on git push -u origin codex/timing-safe-enterprise-key passed: typecheck, API typecheck, Convex typecheck, boundary/rate-limit/premium-fetch checks, edge bundle/tests, version sync.