### PR TITLE
docs(resilience): align BIS LBS goalpost docs

### DIFF
--- a/docs/methodology/country-resilience-index.mdx
+++ b/docs/methodology/country-resilience-index.mdx
@@ -130,7 +130,7 @@ The dimension uses a **fail-closed preflight** pattern (mirrors `scoreEnergy` v2
 | Indicator | Description | Direction | Goalposts (worst-best) | Weight | Source | Cadence |
 |---|---|---|---|---|---|---|
 | shortTermExternalDebtPctGni | Short-term external debt as % of GNI (WB IDS DT.DOD.DSTC.IR.ZS × DT.DOD.DECT.GN.ZS); IMF Article IV vulnerability threshold is 15% GNI | Lower is better | 15 - 0 | 0.35 | World Bank IDS | Annual |
-| bisLbsXborderPctGdp | BIS LBS sum of by-parent cross-border claims (US/UK/major-EU/CH/JP/CA/AU/SG) as % of GDP; U-shape band — both isolation (under 5%) and over-exposure (above 60%) score low | Lower is better (U-shape) | 60 - 15 | 0.30 | BIS LBS | Quarterly |
+| bisLbsXborderPctGdp | BIS LBS sum of by-parent cross-border claims (US/UK/major-EU/CH/JP/CA/AU/SG) as % of GDP; U-shape band — both isolation (under 5%) and over-exposure (above 60%) score low | Lower is better (U-shape) | 60 - 25 | 0.30 | BIS LBS | Quarterly |
 | fatfListingStatus | FATF AML/CFT listing status — black list (call for action) → 0, gray list (increased monitoring) → 30, compliant → 100 | Higher is better | 0 - 100 | 0.20 | FATF | Monthly |
 | financialCenterRedundancy | Count of distinct BIS LBS by-parent reporters with non-trivial (>1% GDP) cross-border claims; rewards multi-counterparty financial centers, balances Component 2 over-exposure penalty | Higher is better | 1 - 10 | 0.15 | BIS LBS | Quarterly |
 

--- a/tests/resilience-doc-parity.test.mts
+++ b/tests/resilience-doc-parity.test.mts
@@ -356,6 +356,23 @@ describe('methodology doc parity (Plan 2026-04-26-002 §U8)', () => {
     );
   });
 
+  it('Financial System Exposure bisLbsXborderPctGdp row matches registry U-shape goalpost anchors', () => {
+    const row = extractIndicatorRowForSection(docText, 'Financial System Exposure', 'bisLbsXborderPctGdp');
+    const spec = INDICATOR_REGISTRY.find((indicator) => indicator.id === 'bisLbsXborderPctGdp');
+    assert.ok(spec, 'bisLbsXborderPctGdp must exist in INDICATOR_REGISTRY.');
+
+    assert.equal(
+      row.goalposts,
+      `${spec.goalposts.worst} - ${spec.goalposts.best}`,
+      'bisLbsXborderPctGdp methodology goalposts must mirror INDICATOR_REGISTRY U-shape documentation anchors.',
+    );
+    assert.equal(
+      row.direction,
+      'Lower is better (U-shape)',
+      'bisLbsXborderPctGdp direction must keep the U-shape caveat visible in the methodology table.',
+    );
+  });
+
   it('generated OpenAPI pillar weight prose matches PILLAR_WEIGHTS and formula semantics', () => {
     const expectedWeightList = PILLAR_ORDER
       .map((id) => PILLAR_WEIGHTS[id].toFixed(2))


### PR DESCRIPTION
## Summary

- Align the Country Resilience methodology table for `bisLbsXborderPctGdp` with the registry U-shape documentation anchors (`60 - 25`).
- Add a focused resilience doc-parity assertion so the methodology row mirrors `INDICATOR_REGISTRY` and keeps the U-shape caveat visible.

## Root Cause

The methodology doc still listed the BIS LBS goalposts as `60 - 15`, while `server/worldmonitor/resilience/v1/_indicator-registry.ts` documents the U-shape peak and uses `goalposts: { worst: 60, best: 25 }`.

## Validation

- `npm exec -- tsx --test tests/resilience-doc-parity.test.mts`
- `git diff --check`
- Pre-push hook completed successfully, including typecheck, API typecheck, boundary/rate-limit/premium-fetch checks, edge bundle check, full unit suite, markdown lint, MDX lint, proto freshness, pro-test bundle freshness, and version sync.