### PR TITLE
fix(resilience): enforce displacement seed floor

### DIFF
--- a/scripts/seed-displacement-summary.mjs
+++ b/scripts/seed-displacement-summary.mjs
@@ -6,6 +6,7 @@ loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY_PREFIX = 'displacement:summary:v1';
 const CACHE_TTL = 86400; // 24 hours — UNHCR data is annual
+export const MIN_DISPLACEMENT_COUNTRIES = 100;
 
 const COUNTRY_CENTROIDS = {
   AFG: [33.9, 67.7], SYR: [35.0, 38.0], UKR: [48.4, 31.2], SDN: [15.5, 32.5],
@@ -213,12 +214,12 @@ async function fetchDisplacementSummary() {
   };
 }
 
-function validate(data) {
+export function validate(data) {
   return (
     data?.summary &&
     typeof data.summary.year === 'number' &&
     Array.isArray(data.summary.countries) &&
-    data.summary.countries.length >= 1
+    data.summary.countries.length >= MIN_DISPLACEMENT_COUNTRIES
   );
 }
 
@@ -229,14 +230,17 @@ export function declareRecords(data) {
   return data?.summary?.countries?.length ?? 0;
 }
 
-runSeed('displacement', 'summary', canonicalKey, fetchDisplacementSummary, {
-  validateFn: validate,
-  ttlSeconds: CACHE_TTL,
-  sourceVersion: `unhcr-${currentYear}`,
-  declareRecords,
-  schemaVersion: 1,
-  maxStaleMin: 3600,
-}).catch((err) => {
-  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
-  process.exit(1);
-});
+if (process.argv[1]?.endsWith('seed-displacement-summary.mjs')) {
+  runSeed('displacement', 'summary', canonicalKey, fetchDisplacementSummary, {
+    validateFn: validate,
+    ttlSeconds: CACHE_TTL,
+    sourceVersion: `unhcr-${currentYear}`,
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 3600,
+    emptyDataIsFailure: true,
+  }).catch((err) => {
+    const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
+    process.exit(1);
+  });
+}

--- a/scripts/seed-displacement-summary.mjs
+++ b/scripts/seed-displacement-summary.mjs
@@ -215,7 +215,7 @@ async function fetchDisplacementSummary() {
 }
 
 export function validate(data) {
-  return (
+  return Boolean(
     data?.summary &&
     typeof data.summary.year === 'number' &&
     Array.isArray(data.summary.countries) &&
@@ -230,16 +230,18 @@ export function declareRecords(data) {
   return data?.summary?.countries?.length ?? 0;
 }
 
+export const seedOptions = {
+  validateFn: validate,
+  ttlSeconds: CACHE_TTL,
+  sourceVersion: `unhcr-${currentYear}`,
+  declareRecords,
+  schemaVersion: 1,
+  maxStaleMin: 3600,
+  emptyDataIsFailure: true,
+};
+
 if (process.argv[1]?.endsWith('seed-displacement-summary.mjs')) {
-  runSeed('displacement', 'summary', canonicalKey, fetchDisplacementSummary, {
-    validateFn: validate,
-    ttlSeconds: CACHE_TTL,
-    sourceVersion: `unhcr-${currentYear}`,
-    declareRecords,
-    schemaVersion: 1,
-    maxStaleMin: 3600,
-    emptyDataIsFailure: true,
-  }).catch((err) => {
+  runSeed('displacement', 'summary', canonicalKey, fetchDisplacementSummary, seedOptions).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
     process.exit(1);
   });

--- a/tests/seed-displacement-summary.test.mjs
+++ b/tests/seed-displacement-summary.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { describe, it } from 'node:test';
+
+import {
+  MIN_DISPLACEMENT_COUNTRIES,
+  declareRecords,
+  validate,
+} from '../scripts/seed-displacement-summary.mjs';
+
+function payloadWithCountries(count) {
+  return {
+    summary: {
+      year: new Date().getFullYear(),
+      globalTotals: { refugees: 0, asylumSeekers: 0, idps: 0, stateless: 0, total: 0 },
+      countries: Array.from({ length: count }, (_, index) => ({
+        code: `X${index}`,
+        name: `Country ${index}`,
+        totalDisplaced: 0,
+        hostTotal: 0,
+      })),
+      topFlows: [],
+    },
+  };
+}
+
+describe('seed-displacement-summary validation floor', () => {
+  it('rejects a one-country partial UNHCR payload', () => {
+    assert.equal(validate(payloadWithCountries(1)), false);
+  });
+
+  it('rejects payloads below the displacement country floor', () => {
+    assert.equal(validate(payloadWithCountries(MIN_DISPLACEMENT_COUNTRIES - 1)), false);
+  });
+
+  it('accepts payloads at the displacement country floor', () => {
+    assert.equal(validate(payloadWithCountries(MIN_DISPLACEMENT_COUNTRIES)), true);
+  });
+
+  it('declares the same country count that validation gates', () => {
+    const payload = payloadWithCountries(MIN_DISPLACEMENT_COUNTRIES);
+    assert.equal(declareRecords(payload), MIN_DISPLACEMENT_COUNTRIES);
+  });
+
+  it('treats sub-floor validation failure as a strict seeder failure', () => {
+    const src = readFileSync(new URL('../scripts/seed-displacement-summary.mjs', import.meta.url), 'utf8');
+    assert.match(src, /emptyDataIsFailure:\s*true/);
+  });
+});

--- a/tests/seed-displacement-summary.test.mjs
+++ b/tests/seed-displacement-summary.test.mjs
@@ -1,10 +1,10 @@
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
 
 import {
   MIN_DISPLACEMENT_COUNTRIES,
   declareRecords,
+  seedOptions,
   validate,
 } from '../scripts/seed-displacement-summary.mjs';
 
@@ -29,6 +29,11 @@ describe('seed-displacement-summary validation floor', () => {
     assert.equal(validate(payloadWithCountries(1)), false);
   });
 
+  it('returns strict false for missing payloads', () => {
+    assert.equal(validate(null), false);
+    assert.equal(validate(undefined), false);
+  });
+
   it('rejects payloads below the displacement country floor', () => {
     assert.equal(validate(payloadWithCountries(MIN_DISPLACEMENT_COUNTRIES - 1)), false);
   });
@@ -43,7 +48,7 @@ describe('seed-displacement-summary validation floor', () => {
   });
 
   it('treats sub-floor validation failure as a strict seeder failure', () => {
-    const src = readFileSync(new URL('../scripts/seed-displacement-summary.mjs', import.meta.url), 'utf8');
-    assert.match(src, /emptyDataIsFailure:\s*true/);
+    assert.equal(seedOptions.emptyDataIsFailure, true);
+    assert.equal(seedOptions.validateFn(payloadWithCountries(MIN_DISPLACEMENT_COUNTRIES - 1)), false);
   });
 });


### PR DESCRIPTION
## Summary
- enforce a 100-country minimum in the displacement summary seed validator
- keep the seed module importable for regression tests without running the seeder
- add focused coverage proving 1-country and below-floor payloads fail before publish

## Root cause
The displacement seed validator only checked that `summary.countries` existed, so a successful but tiny 1-country fetch could pass validation and overwrite the existing good Redis blob.

## Validation
- node --test tests/seed-displacement-summary.test.mjs
- node --test tests/seed-utils-empty-data-failure.test.mjs tests/seed-empty-data-is-failure.test.mjs
- git diff --check
- pre-push hook on git push: typecheck, typecheck:api, full unit suite, edge function tests, markdown lint, MDX lint, version sync