### PR TITLE
Fix resilience freshness non-color cues

### DIFF
--- a/src/components/ResilienceWidget.ts
+++ b/src/components/ResilienceWidget.ts
@@ -23,6 +23,7 @@ import {
   getResilienceDomainLabel,
   getResilienceTrendArrow,
   getResilienceVisualLevel,
+  getStalenessIcon,
   getStalenessLabel,
 } from './resilience-widget-utils';
 import type { CountryEnergyProfileData } from './CountryBriefPanel';
@@ -394,7 +395,7 @@ export class ResilienceWidget {
           className: freshnessClassName,
           'aria-label': dim.staleness ? getStalenessLabel(dim.staleness) : undefined,
         },
-        dim.staleness ? '\u25CF' : '',
+        getStalenessIcon(dim.staleness),
       ),
     );
   }

--- a/src/components/resilience-widget-utils.ts
+++ b/src/components/resilience-widget-utils.ts
@@ -545,6 +545,12 @@ const STALENESS_LABELS: Record<Exclude<DimensionStaleness, null>, string> = {
   stale: 'Stale (beyond 3x cadence)',
 };
 
+const STALENESS_ICONS: Record<Exclude<DimensionStaleness, null>, string> = {
+  fresh: '\u25CF',
+  aging: '\u25D0',
+  stale: '\u25CB',
+};
+
 export function getImputationClassLabel(c: DimensionImputationClass): string {
   if (!c) return 'Unknown imputation class';
   return IMPUTATION_CLASS_LABELS[c];
@@ -558,6 +564,11 @@ export function getImputationClassIcon(c: DimensionImputationClass): string {
 export function getStalenessLabel(s: DimensionStaleness): string {
   if (!s) return 'Unknown freshness';
   return STALENESS_LABELS[s];
+}
+
+export function getStalenessIcon(s: DimensionStaleness): string {
+  if (!s) return '';
+  return STALENESS_ICONS[s];
 }
 
 /**

--- a/src/styles/country-deep-dive.css
+++ b/src/styles/country-deep-dive.css
@@ -1060,12 +1060,12 @@
 .resilience-widget__dimension-imputation--source-failure { color: #ef4444; }
 .resilience-widget__dimension-imputation--not-applicable { color: var(--text-faint); }
 
-/* T1.5 propagation: freshness dot at the far right. Colors mirror the
-   fresh/aging/stale staleness levels from the classifier. Empty span
-   when freshness is unknown so the grid column reserves its 10px slot
-   and rows stay aligned. */
+/* T1.5 propagation: freshness glyph at the far right. Shape and color
+   both mirror the fresh/aging/stale staleness levels from the
+   classifier. Empty span when freshness is unknown so the grid column
+   reserves its 10px slot and rows stay aligned. */
 .resilience-widget__dimension-freshness {
-  font-size: 8px;
+  font-size: 9px;
   line-height: 1;
   text-align: center;
   cursor: help;

--- a/tests/resilience-widget.test.mts
+++ b/tests/resilience-widget.test.mts
@@ -19,6 +19,7 @@ import {
   getResilienceDomainLabel,
   getResilienceTrendArrow,
   getResilienceVisualLevel,
+  getStalenessIcon,
   getStalenessLabel,
 } from '../src/components/resilience-widget-utils';
 import type { ResilienceScoreResponse } from '../src/services/resilience';
@@ -671,6 +672,13 @@ test('getStalenessLabel returns a non-empty string for each level', () => {
     assert.ok(label.length > 0, `${s} should have a tooltip label`);
   }
   assert.ok(getStalenessLabel(null).length > 0);
+});
+
+test('getStalenessIcon gives each visible freshness level a distinct non-color cue', () => {
+  const icons = ['fresh', 'aging', 'stale'].map((s) => getStalenessIcon(s));
+  assert.deepEqual(icons, ['\u25CF', '\u25D0', '\u25CB']);
+  assert.equal(new Set(icons).size, icons.length);
+  assert.equal(getStalenessIcon(null), '');
 });
 
 test('LOCKED_PREVIEW smoke: at least one dimension has imputationClass and one has staleness set (PR 3 / T1.6)', () => {

--- a/tests/resilience-widget.test.mts
+++ b/tests/resilience-widget.test.mts
@@ -675,7 +675,7 @@ test('getStalenessLabel returns a non-empty string for each level', () => {
 });
 
 test('getStalenessIcon gives each visible freshness level a distinct non-color cue', () => {
-  const icons = ['fresh', 'aging', 'stale'].map((s) => getStalenessIcon(s));
+  const icons = (['fresh', 'aging', 'stale'] as const).map((s) => getStalenessIcon(s));
   assert.deepEqual(icons, ['\u25CF', '\u25D0', '\u25CB']);
   assert.equal(new Set(icons).size, icons.length);
   assert.equal(getStalenessIcon(null), '');


### PR DESCRIPTION
## Summary

- adds a shape-based freshness icon mapping for resilience dimension staleness states
- renders fresh / aging / stale as distinct visible glyphs while preserving existing color, ARIA, and tooltip labels
- adds focused coverage that pins each freshness state to a distinct non-color cue

## Root cause

The resilience dimension freshness slot used the same visible bullet for fresh, aging, and stale, so sighted users who could not distinguish the color alone had no equivalent visible cue.

## Validation

- env npm_config_cache=/tmp/codex-npm-cache npx tsx --test tests/resilience-widget.test.mts - 44/44
- git diff --check
- pre-push hook on git push -u origin codex/resilience-freshness-cues, including typecheck, API typecheck, full unit suite, edge-function tests, markdown lint, MDX lint, pro-test bundle freshness, and version sync