### PR TITLE
docs(resilience): align SWF not-applicable comments

### DIFF
--- a/scripts/compare-resilience-current-vs-proposed.mjs
+++ b/scripts/compare-resilience-current-vs-proposed.mjs
@@ -377,8 +377,8 @@ const EXTRACTION_RULES = {
   recoveryFuelStockDays: { type: 'recovery-country-field', key: 'resilience:recovery:fuel-stocks:v1', field: 'stockDays' },
   // PR 2 §3.4: SWF seed. Field is totalEffectiveMonths (pre-haircut sum
   // across a country's manifest funds). Countries without a manifest
-  // entry score 0 via the substantive-no-SWF branch in the scorer;
-  // the harness treats "absent from payload" as 0 for correlation math.
+  // entry are structurally not-applicable in the scorer; the harness
+  // treats "absent from payload" as 0 for correlation math.
   recoverySovereignWealthEffectiveMonths: { type: 'recovery-country-field', key: 'resilience:recovery:sovereign-wealth:v1', field: 'totalEffectiveMonths' },
 
   // ── stateContinuity derived signals ─────────────────────────────────

--- a/scripts/seed-sovereign-wealth.mjs
+++ b/scripts/seed-sovereign-wealth.mjs
@@ -74,10 +74,11 @@
 //   }
 //
 // Countries WITHOUT an entry in the manifest are absent from this
-// payload. The scorer is expected to treat "no entry in payload" as
-// "no sovereign wealth fund" and score 0 with full coverage (plan
-// §3.4 "What happens to no-SWF countries"). This is substantively
-// different from IMPUTE fallback (which is "data-source-failed").
+// payload. When the payload exists, the scorer treats "no entry in
+// payload" as structurally not-applicable: score 0, coverage 0,
+// observedWeight 0, imputedWeight 0, imputationClass 'not-applicable'.
+// This is substantively different from the IMPUTE fallback for a
+// missing SWF seed key.
 
 import { loadEnvFile, CHROME_UA, runSeed, readSeedSnapshot, SHARED_FX_FALLBACKS, getSharedFxRates, getBundleRunStartedAtMs } from './_seed-utils.mjs';
 import iso3ToIso2 from './shared/iso3-to-iso2.json' with { type: 'json' };
@@ -810,8 +811,9 @@ export async function fetchSovereignWealth() {
       // WB `NE.IMP.GNFS.CD` missing for this country (transient outage
       // or a country with spotty WB coverage). Silently dropping would
       // let the downstream scorer interpret the absence as "no SWF" and
-      // score 0 with full coverage — substantively wrong. Log it
-      // loudly and surface via the unmatched list so the seed-meta
+      // exclude the dim as structurally not-applicable — substantively
+      // wrong for a manifest country whose import denominator is missing.
+      // Log it loudly and surface via the unmatched list so the seed-meta
       // observer can alert.
       console.warn(`[seed-sovereign-wealth] ${iso2} skipped: World Bank imports (${IMPORTS_INDICATOR}) missing — cannot compute rawMonths denominator`);
       for (const fund of funds) unmatched.push(`${fund.country}:${fund.fund} (no WB imports)`);

--- a/scripts/shared/swf-classification-manifest.yaml
+++ b/scripts/shared/swf-classification-manifest.yaml
@@ -50,11 +50,11 @@
 # months in the 100s) from dominating the recovery pillar out of
 # proportion to their marginal resilience benefit.
 #
-# Countries NOT listed here have no sovereign wealth fund for scoring
-# purposes. Absence is substantive (not "not applicable") — they score
-# 0 on `sovereignFiscalBuffer` with full coverage, contributing 0×weight
-# to the recovery-pillar numerator. See plan §3.4 "What happens to no-
-# SWF countries."
+# Countries NOT listed here have no sovereign wealth fund in this
+# construct. When the SWF payload is present, scorer Path 3 treats that
+# absence as structurally not-applicable: score 0, coverage 0,
+# observedWeight 0, imputedWeight 0, imputationClass 'not-applicable'.
+# This is distinct from the IMPUTE fallback for a missing SWF seed key.
 #
 # Adding / removing a fund: open a PR that updates this manifest, cites
 # the source (annual report URL, IFSWF profile, LM index page), and

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -355,8 +355,9 @@ const RESILIENCE_RECOVERY_REEXPORT_SHARE_KEY = 'resilience:recovery:reexport-sha
 // (landed in #3305, wired into the resilience-recovery Railway bundle in
 // #3319). Per-country shape: { funds: [...], totalEffectiveMonths,
 // annualImports, expectedFunds, matchedFunds, completeness }. Countries
-// not in the manifest are absent from the payload (substantive "no SWF"
-// signal, distinct from the IMPUTE fallback below).
+// not in the manifest are absent from the payload; scorer Path 3 treats
+// that as structurally not-applicable, distinct from the missing-seed
+// IMPUTE fallback below.
 const RESILIENCE_RECOVERY_SOVEREIGN_WEALTH_KEY = 'resilience:recovery:sovereign-wealth:v1';
 // RESILIENCE_RECOVERY_FUEL_STOCKS_KEY removed in PR 3: scoreFuelStockDays
 // no longer reads any source key. If a new globally-comparable

--- a/server/worldmonitor/resilience/v1/_indicator-registry.ts
+++ b/server/worldmonitor/resilience/v1/_indicator-registry.ts
@@ -1141,11 +1141,12 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
   // transform: score = 100 × (1 − exp(−effectiveMonths / 12)) to prevent
   // Norway-type outliers from dominating the recovery pillar.
   //
-  // Coverage for the registry entry is the current manifest size (8
-  // funds across NO / AE / SA / KW / QA / SG). Countries NOT in the
-  // manifest score 0 with full coverage (substantive "no SWF" signal,
-  // not imputation) — this is by design per plan §3.4 "What happens to
-  // no-SWF countries."
+  // Registry coverage remains 8 as conservative metadata from the first
+  // SWF seed rollout; it is not the live YAML manifest count and not the
+  // per-country Path 3 coverage. Countries NOT in the manifest are
+  // not-applicable for this construct when the SWF payload is present
+  // (score 0, coverage 0, imputationClass 'not-applicable'), distinct
+  // from missing-seed IMPUTE.
   {
     id: 'recoverySovereignWealthEffectiveMonths',
     dimension: 'sovereignFiscalBuffer',
@@ -1156,7 +1157,7 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     sourceKey: 'resilience:recovery:sovereign-wealth:v1',
     scope: 'global',
     cadence: 'quarterly',
-    // tier='experimental' because the manifest ships with 8 funds (< the
+    // tier='experimental' because the manifest ships below the
     // 180-country core-tier threshold / 137-country §3.6 gate). Non-SWF
     // countries are scored as dim-not-applicable (score 0, coverage 0,
     // imputationClass 'not-applicable') per plan 2026-04-26-001 §U3 —

--- a/tests/resilience-dimension-scorers.test.mts
+++ b/tests/resilience-dimension-scorers.test.mts
@@ -1656,11 +1656,11 @@ describe('resilience source-failure aggregation (T1.7)', () => {
     }
   });
 
-  // PR 2 §3.4 — scoreSovereignFiscalBuffer has three code paths per
-  // plan §3.4: (1) seed absent → IMPUTE, (2) seed present but country
-  // not in manifest → substantive "no SWF" (score=0, coverage=1.0),
-  // (3) country in payload → saturating transform on
-  // totalEffectiveMonths.
+  // PR 2 §3.4 — scoreSovereignFiscalBuffer has three code paths:
+  // (1) seed absent → IMPUTE, (2) seed present but country not in
+  // manifest → structurally not-applicable (score=0, coverage=0,
+  // imputationClass='not-applicable'), (3) country in payload →
+  // saturating transform on totalEffectiveMonths.
   describe('scoreSovereignFiscalBuffer — three code paths', () => {
     it('path 1: seed key absent → IMPUTE fallback', async () => {
       const emptyReader = async (_key: string): Promise<unknown | null> => null;

--- a/tests/seed-utils-with-retry.test.mjs
+++ b/tests/seed-utils-with-retry.test.mjs
@@ -103,19 +103,28 @@ describe('withRetry', () => {
     // exponential backoff would have been ~1ms, we MUST sleep ≥200ms so the
     // upstream rate-limit hint is respected.
     let attempts = 0;
-    const t0 = Date.now();
-    await assert.rejects(
-      withRetry(async () => {
-        attempts++;
-        const err = new Error('rate limited');
-        if (attempts === 1) err.retryAfterMs = 200;  // hint only on first failure
-        throw err;
-      }, 1, 1),  // baseWait would otherwise be 1ms
-      /rate limited/,
-    );
-    const elapsed = Date.now() - t0;
-    assert.ok(elapsed >= 200, `expected ≥200ms (Retry-After hint), got ${elapsed}ms`);
-    assert.ok(elapsed < 1000, `expected <1000ms (cap respected), got ${elapsed}ms`);
+    const sleeps = [];
+    const originalSetTimeout = globalThis.setTimeout;
+    globalThis.setTimeout = (callback, ms, ...args) => {
+      sleeps.push(ms);
+      queueMicrotask(() => callback(...args));
+      return 0;
+    };
+    try {
+      await assert.rejects(
+        withRetry(async () => {
+          attempts++;
+          const err = new Error('rate limited');
+          if (attempts === 1) err.retryAfterMs = 200;  // hint only on first failure
+          throw err;
+        }, 1, 1),  // baseWait would otherwise be 1ms
+        /rate limited/,
+      );
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+    assert.equal(attempts, 2, 'initial attempt + one retry');
+    assert.deepEqual(sleeps, [200], 'Retry-After hint must drive the backoff delay');
   });
 });
 

--- a/tests/swf-classification-manifest.test.mjs
+++ b/tests/swf-classification-manifest.test.mjs
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 import { describe, it } from 'node:test';
 
 import {
@@ -101,6 +102,24 @@ describe('SWF classification manifest — shipped YAML', () => {
     assert.ok((byCountry.get('AE') ?? []).length >= 2, 'AE should have ADIA + Mubadala at minimum');
     assert.ok((byCountry.get('SG') ?? []).length >= 2, 'SG should have GIC + Temasek at minimum');
     assert.ok((byCountry.get('NO') ?? []).length >= 1, 'NO should have GPFG');
+  });
+
+  it('source comments do not preserve the superseded full-coverage no-SWF semantics', () => {
+    const surfaces = [
+      ['scripts/shared/swf-classification-manifest.yaml', new URL('../scripts/shared/swf-classification-manifest.yaml', import.meta.url)],
+      ['scripts/seed-sovereign-wealth.mjs', new URL('../scripts/seed-sovereign-wealth.mjs', import.meta.url)],
+      ['server/worldmonitor/resilience/v1/_indicator-registry.ts', new URL('../server/worldmonitor/resilience/v1/_indicator-registry.ts', import.meta.url)],
+      ['scripts/compare-resilience-current-vs-proposed.mjs', new URL('../scripts/compare-resilience-current-vs-proposed.mjs', import.meta.url)],
+    ];
+
+    for (const [label, url] of surfaces) {
+      const source = readFileSync(url, 'utf8');
+      assert.doesNotMatch(
+        source,
+        /score 0 with full coverage|score 0 on `sovereignFiscalBuffer` with full coverage|substantive-no-SWF branch|Coverage for the registry entry is the current manifest size/i,
+        `${label} must not preserve the superseded non-SWF full-coverage semantics; scorer Path 3 is not-applicable coverage=0.`,
+      );
+    }
   });
 });
 

--- a/tests/swf-classification-manifest.test.mjs
+++ b/tests/swf-classification-manifest.test.mjs
@@ -109,6 +109,7 @@ describe('SWF classification manifest — shipped YAML', () => {
       ['scripts/shared/swf-classification-manifest.yaml', new URL('../scripts/shared/swf-classification-manifest.yaml', import.meta.url)],
       ['scripts/seed-sovereign-wealth.mjs', new URL('../scripts/seed-sovereign-wealth.mjs', import.meta.url)],
       ['server/worldmonitor/resilience/v1/_indicator-registry.ts', new URL('../server/worldmonitor/resilience/v1/_indicator-registry.ts', import.meta.url)],
+      ['server/worldmonitor/resilience/v1/_dimension-scorers.ts', new URL('../server/worldmonitor/resilience/v1/_dimension-scorers.ts', import.meta.url)],
       ['scripts/compare-resilience-current-vs-proposed.mjs', new URL('../scripts/compare-resilience-current-vs-proposed.mjs', import.meta.url)],
     ];
 
@@ -116,7 +117,7 @@ describe('SWF classification manifest — shipped YAML', () => {
       const source = readFileSync(url, 'utf8');
       assert.doesNotMatch(
         source,
-        /score 0 with full coverage|score 0 on `sovereignFiscalBuffer` with full coverage|substantive-no-SWF branch|Coverage for the registry entry is the current manifest size/i,
+        /score 0 with full coverage|score 0 on `sovereignFiscalBuffer` with full coverage|substantive-no-SWF branch|substantive.*no.SWF|Coverage for the registry entry is the current manifest size/i,
         `${label} must not preserve the superseded non-SWF full-coverage semantics; scorer Path 3 is not-applicable coverage=0.`,
       );
     }


### PR DESCRIPTION
## Summary
- align SWF manifest, seeder, registry, scorer, and comparison-harness comments with current Path 3 not-applicable semantics
- clarify that registry coverage metadata is conservative first-rollout metadata, not live manifest size or per-country SWF coverage
- add a focused guardrail that rejects stale full-coverage no-SWF wording

## Validation
- npx tsx --test tests/swf-classification-manifest.test.mjs
- npx tsx --test tests/resilience-dimension-scorers.test.mts
- git diff --check
- pre-push hook passed during git push: typecheck, typecheck:api, full unit suite, edge tests, markdown/MDX lint, pro-test bundle freshness, version sync