### PR TITLE
Fix resilience seed refresh auth timing comparison

### DIFF
--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -51,6 +51,7 @@ import {
   type CacheTier as UsageCacheTier,
   type RequestReason,
 } from './_shared/usage';
+import { timingSafeEqual } from './_shared/internal-auth';
 import type { ServerOptions } from '../src/generated/server/worldmonitor/seismology/v1/service_server';
 
 export const serverOptions: ServerOptions = { onError: mapErrorToResponse };
@@ -375,7 +376,7 @@ function withAuthenticatedUserId(request: Request, userId: string): Request {
   return cloneRequestWithHeaders(request, headers);
 }
 
-function isResilienceRankingSeedRefreshRequest(request: Request, pathname: string): boolean {
+async function isResilienceRankingSeedRefreshRequest(request: Request, pathname: string): Promise<boolean> {
   if (pathname !== '/api/resilience/v1/get-resilience-ranking') return false;
   const expected = process.env.WORLDMONITOR_SEED_REFRESH_KEY?.trim() ?? '';
   if (!expected) return false;
@@ -385,7 +386,8 @@ function isResilienceRankingSeedRefreshRequest(request: Request, pathname: strin
   } catch {
     return false;
   }
-  return request.headers.get('X-WorldMonitor-Key') === expected;
+  const candidate = request.headers.get('X-WorldMonitor-Key') ?? '';
+  return timingSafeEqual(candidate, expected);
 }
 
 export function createDomainGateway(
@@ -754,7 +756,7 @@ export function createDomainGateway(
     // tier ≥ 1 + mcpAccess === true. Re-running the JWT path on a request
     // that has no Authorization header would just no-op anyway.
     const isPublicNoAuthRpc = PUBLIC_NO_AUTH_RPC_PATHS.has(pathname);
-    const seedRefreshVerified = isResilienceRankingSeedRefreshRequest(request, pathname);
+    const seedRefreshVerified = await isResilienceRankingSeedRefreshRequest(request, pathname);
     const isTierGated = !internalMcpVerified && !isPublicNoAuthRpc && !seedRefreshVerified && getRequiredTier(pathname) !== null;
     const needsLegacyProBearerGate = !internalMcpVerified && !isPublicNoAuthRpc && PREMIUM_RPC_PATHS.has(pathname) && !isTierGated;
 

--- a/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
+++ b/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
@@ -9,6 +9,7 @@ import {
 
 import { compareAndDeleteRedisKey, getCachedJson, runRedisPipeline } from '../../../_shared/redis';
 import { unwrapEnvelope } from '../../../_shared/seed-envelope';
+import { timingSafeEqual } from '../../../_shared/internal-auth';
 import { isInRankableUniverse } from './_rankable-universe';
 import {
   RESILIENCE_INTERVAL_KEY_PREFIX,
@@ -58,10 +59,11 @@ function isRefreshRequested(ctx: ServerContext): boolean {
   }
 }
 
-function isSeedRefreshAuthorized(ctx: ServerContext): boolean {
+async function isSeedRefreshAuthorized(ctx: ServerContext): Promise<boolean> {
   const expected = process.env.WORLDMONITOR_SEED_REFRESH_KEY?.trim() ?? '';
   if (!expected) return false;
-  return ctx.request.headers.get('X-WorldMonitor-Key') === expected;
+  const candidate = ctx.request.headers.get('X-WorldMonitor-Key') ?? '';
+  return timingSafeEqual(candidate, expected);
 }
 
 function makeLockToken(): string {
@@ -288,7 +290,7 @@ export const getResilienceRanking: ResilienceServiceHandler['getResilienceRankin
   // standard cache-first read path. Only the dedicated seed refresh secret is
   // accepted, and a short Redis slot bounds rapid/concurrent refresh attempts.
   const refreshRequested = isRefreshRequested(ctx);
-  const refreshAuthorized = refreshRequested && isSeedRefreshAuthorized(ctx);
+  const refreshAuthorized = refreshRequested && await isSeedRefreshAuthorized(ctx);
   let refreshSlotDenied = false;
   let forceRefresh = false;
   let lockToRelease: { key: string; token: string } | null = null;

--- a/tests/resilience-seed-refresh-auth.test.mts
+++ b/tests/resilience-seed-refresh-auth.test.mts
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const SEED_REFRESH_AUTH_FILES = [
+  '../server/gateway.ts',
+  '../server/worldmonitor/resilience/v1/get-resilience-ranking.ts',
+] as const;
+
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/.*$/gm, '');
+}
+
+describe('resilience seed-refresh auth', () => {
+  it('does not directly compare X-WorldMonitor-Key to WORLDMONITOR_SEED_REFRESH_KEY-derived expected values', async () => {
+    const headerGetter = String.raw`(?:ctx\.request\.headers|request\.headers)\.get\(\s*['"]X-WorldMonitor-Key['"]\s*\)`;
+    const directHeaderCompare = new RegExp(
+      String.raw`${headerGetter}\s*={2,3}\s*\bexpected\b|\bexpected\b\s*={2,3}\s*${headerGetter}`,
+    );
+    const violations: string[] = [];
+
+    for (const path of SEED_REFRESH_AUTH_FILES) {
+      const source = stripComments(await readFile(new URL(path, import.meta.url), 'utf8'));
+      if (!source.includes('WORLDMONITOR_SEED_REFRESH_KEY')) continue;
+      if (directHeaderCompare.test(source)) violations.push(path);
+    }
+
+    assert.deepEqual(
+      violations,
+      [],
+      `Seed refresh auth must use timingSafeEqual from server/_shared/internal-auth.ts, not direct equality: ${violations.join(', ')}`,
+    );
+  });
+});

--- a/tests/resilience-seed-refresh-auth.test.mts
+++ b/tests/resilience-seed-refresh-auth.test.mts
@@ -13,17 +13,51 @@ function stripComments(source: string): string {
     .replace(/\/\/.*$/gm, '');
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 describe('resilience seed-refresh auth', () => {
-  it('does not directly compare X-WorldMonitor-Key to WORLDMONITOR_SEED_REFRESH_KEY-derived expected values', async () => {
+  it('uses timingSafeEqual for X-WorldMonitor-Key and WORLDMONITOR_SEED_REFRESH_KEY comparisons', async () => {
     const headerGetter = String.raw`(?:ctx\.request\.headers|request\.headers)\.get\(\s*['"]X-WorldMonitor-Key['"]\s*\)`;
-    const directHeaderCompare = new RegExp(
-      String.raw`${headerGetter}\s*={2,3}\s*\bexpected\b|\bexpected\b\s*={2,3}\s*${headerGetter}`,
+    const identifier = String.raw`[A-Za-z_$][\w$]*`;
+    const seedRefreshKeyBinding = new RegExp(
+      String.raw`\b(?:const|let|var)\s+(${identifier})\s*=\s*[\s\S]{0,160}?process\.env\.WORLDMONITOR_SEED_REFRESH_KEY\b`,
+      'g',
+    );
+    const headerBinding = new RegExp(
+      String.raw`\b(?:const|let|var)\s+(${identifier})\s*=\s*${headerGetter}\b`,
+      'g',
     );
     const violations: string[] = [];
 
     for (const path of SEED_REFRESH_AUTH_FILES) {
       const source = stripComments(await readFile(new URL(path, import.meta.url), 'utf8'));
       if (!source.includes('WORLDMONITOR_SEED_REFRESH_KEY')) continue;
+
+      assert.match(
+        source,
+        /\btimingSafeEqual\s*\(/,
+        `${path} must keep using timingSafeEqual for seed-refresh auth`,
+      );
+
+      const seedRefreshKeyNames = Array.from(
+        source.matchAll(seedRefreshKeyBinding),
+        (match) => String.raw`\b${escapeRegExp(match[1] ?? '')}\b`,
+      );
+      const headerNames = Array.from(
+        source.matchAll(headerBinding),
+        (match) => String.raw`\b${escapeRegExp(match[1] ?? '')}\b`,
+      );
+      const seedRefreshKeyOperands = [
+        String.raw`process\.env\.WORLDMONITOR_SEED_REFRESH_KEY\b`,
+        ...seedRefreshKeyNames,
+      ].filter(Boolean);
+      const headerOperands = [headerGetter, ...headerNames].filter(Boolean);
+      const directHeaderCompare = new RegExp(
+        String.raw`(?:${headerOperands.join('|')})\s*={2,3}\s*(?:${seedRefreshKeyOperands.join('|')})|(?:${seedRefreshKeyOperands.join('|')})\s*={2,3}\s*(?:${headerOperands.join('|')})`,
+      );
+
       if (directHeaderCompare.test(source)) violations.push(path);
     }
 


### PR DESCRIPTION
## Summary
- use timingSafeEqual for resilience seed-refresh auth in the gateway and ranking handler
- preserve missing/blank env and absent-header denial behavior
- add a focused static guard against direct seed-refresh key equality regressions

## Validation
- npx tsx --test tests/resilience-handlers.test.mts tests/resilience-ranking.test.mts tests/resilience-cache-keys-health-sync.test.mts tests/resilience-seed-refresh-auth.test.mts
- npm run typecheck:api
- npm run typecheck
- pre-push hook completed successfully during git push