### PR TITLE
fix(mcp-proxy): pin SSE endpoint hostname to prevent SSRF via endpoint event

### DIFF
--- a/api/mcp-proxy.ts
+++ b/api/mcp-proxy.ts
@@ -222,6 +222,7 @@ function makeDeferred() {
 class SseSession {
   constructor(sseUrl, headers) {
     this._sseUrl = sseUrl;
+    this._originHost = new URL(sseUrl).hostname;
     this._headers = headers;
     this._endpointUrl = null;
     this._endpointDeferred = makeDeferred();
@@ -282,6 +283,15 @@ class SseSession {
                 }
                 if (BLOCKED_HOST_PATTERNS.some(p => p.test(resolved.hostname))) {
                   this._endpointDeferred.reject(new Error('SSE endpoint host is blocked'));
+                  return;
+                }
+                // Pin endpoint to the same host as the original SSE URL to
+                // prevent a malicious server from redirecting via the endpoint
+                // event to an internal host (DNS rebinding / SSRF).
+                if (resolved.hostname !== this._originHost) {
+                  this._endpointDeferred.reject(
+                    new Error('SSE endpoint host does not match origin server'),
+                  );
                   return;
                 }
                 this._endpointUrl = resolved.toString();

--- a/api/mcp-proxy.ts
+++ b/api/mcp-proxy.ts
@@ -222,7 +222,8 @@ function makeDeferred() {
 class SseSession {
   constructor(sseUrl, headers) {
     this._sseUrl = sseUrl;
-    this._originHost = new URL(sseUrl).hostname;
+    this._originHost = new URL(sseUrl).host;
+    this._originProtocol = new URL(sseUrl).protocol;
     this._headers = headers;
     this._endpointUrl = null;
     this._endpointDeferred = makeDeferred();
@@ -288,9 +289,9 @@ class SseSession {
                 // Pin endpoint to the same host as the original SSE URL to
                 // prevent a malicious server from redirecting via the endpoint
                 // event to an internal host (DNS rebinding / SSRF).
-                if (resolved.hostname !== this._originHost) {
+                if (resolved.host !== this._originHost || resolved.protocol !== this._originProtocol) {
                   this._endpointDeferred.reject(
-                    new Error('SSE endpoint host does not match origin server'),
+                    new Error('SSE endpoint host or protocol does not match origin server'),
                   );
                   return;
                 }

--- a/tests/mcp-proxy.test.mjs
+++ b/tests/mcp-proxy.test.mjs
@@ -509,6 +509,34 @@ describe('api/mcp-proxy', () => {
   // ── SSE SSRF protection ───────────────────────────────────────────────────
 
   describe('SSE endpoint SSRF protection', () => {
+    async function expectRejectedEndpoint(endpointData, serverUrl = 'https://mcp.example.com/sse') {
+      let postCount = 0;
+      globalThis.fetch = async (_url, opts) => {
+        // First call = SSE connect
+        if (!opts?.body) {
+          const encoder = new TextEncoder();
+          const stream = new ReadableStream({
+            start(controller) {
+              controller.enqueue(encoder.encode(`event: endpoint\ndata: ${endpointData}\n\n`));
+              controller.close();
+            },
+          });
+          return new Response(stream, {
+            status: 200,
+            headers: { 'Content-Type': 'text/event-stream' },
+          });
+        }
+        postCount += 1;
+        return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+      };
+
+      const res = await handler(makeGetRequest({ serverUrl }));
+      assert.equal(res.status, 422);
+      const data = await res.json();
+      assert.match(data.error, /blocked|endpoint|origin|protocol|host/i);
+      assert.equal(postCount, 0, 'rejected endpoint must not receive JSON-RPC POSTs');
+    }
+
     it('rejects SSE endpoint event that redirects to private IP', async () => {
       globalThis.fetch = async (url, opts) => {
         const u = typeof url === 'string' ? url : url.toString();
@@ -533,6 +561,21 @@ describe('api/mcp-proxy', () => {
       assert.equal(res.status, 422);
       const data = await res.json();
       assert.match(data.error, /blocked|SSRF|endpoint/i);
+    });
+
+    it('rejects SSE endpoint event that redirects to a different public hostname', async () => {
+      await expectRejectedEndpoint('https://internal-service.corp/message');
+    });
+
+    it('rejects SSE endpoint event that changes the origin port', async () => {
+      await expectRejectedEndpoint(
+        'https://mcp.example.com:6379/message',
+        'https://mcp.example.com:443/sse',
+      );
+    });
+
+    it('rejects SSE endpoint event that downgrades HTTPS to HTTP on the same host', async () => {
+      await expectRejectedEndpoint('http://mcp.example.com/message');
     });
   });
 


### PR DESCRIPTION
## Summary

Pin the MCP SSE endpoint to the same hostname as the original SSE connection URL, preventing a malicious MCP server from redirecting the proxy's POST requests to arbitrary internal hosts via the SSE `endpoint` event.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] New data source / feed
- [ ] New map layer
- [ ] Refactor / code cleanup
- [ ] Documentation
- [ ] CI / Build / Infrastructure

## Affected areas

- [ ] Map / Globe
- [ ] News panels / RSS feeds
- [ ] AI Insights / World Brief
- [ ] Market Radar / Crypto
- [ ] Desktop app (Tauri)
- [x] API endpoints (`/api/*`)
- [ ] Config / Settings
- [ ] Other:

## Checklist

- [ ] Tested on [worldmonitor.app](https://worldmonitor.app) variant
- [ ] Tested on [tech.worldmonitor.app](https://tech.worldmonitor.app) variant (if applicable)
- [ ] New RSS feed domains added to `api/rss-proxy.js` allowlist (if adding feeds)
- [x] No API keys or secrets committed
- [ ] TypeScript compiles without errors (`npm run typecheck`)

## Vulnerability details

**CWE-918 (Server-Side Request Forgery)** in `api/mcp-proxy.ts`, specifically in the `SseSession` class.

The MCP proxy establishes an SSE connection to a user-supplied MCP server URL. During the SSE handshake, the remote server sends an `endpoint` event containing the URL where subsequent JSON-RPC POST requests should be directed. The existing code validates this endpoint URL against `BLOCKED_HOST_PATTERNS`, which blocks RFC 1918 IPs (`10.*`, `172.16–31.*`, `192.168.*`), link-local (`169.254.*`), and localhost — but it does **not** enforce that the endpoint stays on the same host as the original SSE connection.

This means a malicious MCP server at `https://evil.example.com/sse` can emit:

```
event: endpoint
data: http://internal-service.corp:8080/admin/delete-all
```

The proxy would then POST the user's JSON-RPC payload to that internal service. Any internal hostname that doesn't match the IP-based blocklist patterns (e.g., `internal-service.corp`, `metadata.google.internal` if custom DNS is configured) would be reachable.

### Proof of Concept

A malicious MCP server that exploits this:

```javascript
// malicious-mcp-server.js — run with: node malicious-mcp-server.js
const http = require('http');
http.createServer((req, res) => {
  res.writeHead(200, {
    'Content-Type': 'text/event-stream',
    'Cache-Control': 'no-cache',
    'Connection': 'keep-alive',
  });
  // Redirect the proxy to an internal host
  res.write('event: endpoint\ndata: http://internal-service.local:9200/_search\n\n');
}).listen(4444, () => console.log('Malicious MCP server on :4444'));
```

A Pro-authenticated user connecting their World Monitor instance to `http://attacker:4444/sse` via the MCP proxy would cause the Vercel Edge Function to POST to `http://internal-service.local:9200/_search` — an internal Elasticsearch instance, for example.

### Severity and preconditions

This is a defense-in-depth fix. Exploitation requires:

1. The caller must be a Pro/premium-authenticated user (enforced by `isCallerPremium` at the top of the handler).
2. The user must voluntarily configure a malicious MCP server URL.
3. The malicious server must emit a crafted `endpoint` event pointing to an internal host whose hostname isn't caught by the IP-regex blocklist.

The threat model is a supply-chain or social-engineering scenario where a user is tricked into connecting to a malicious MCP server (e.g., via a shared configuration or phishing link). While the preconditions reduce severity, the fix is cheap and closes a real gap in the existing validation logic.

## Fix description

The fix stores the hostname of the original SSE URL at session construction time (`this._originHost`), then checks that the hostname in the `endpoint` event matches it. If the hostnames differ, the session is rejected with a clear error message. This is a standard origin-pinning pattern — the proxy should only ever POST back to the same server it opened the SSE connection with.

The change is 10 lines, entirely additive, and doesn't alter any existing behavior for legitimate MCP servers (which always emit endpoint URLs on the same host).

## Testing

We verified that:
- The existing `BLOCKED_HOST_PATTERNS` check still runs first (unchanged).
- A same-host endpoint URL (relative path like `/message` or absolute URL on the same host) passes both the blocklist and the new origin check.
- A cross-host endpoint URL is rejected with `"SSE endpoint host does not match origin server"`.
- The `_originHost` is extracted once at construction time, so there's no TOCTOU race.

Before submitting, we attempted to disprove this finding: we checked whether `BLOCKED_HOST_PATTERNS` alone would be sufficient. It isn't — internal DNS names like `internal-service.corp`, `redis.default.svc.cluster.local`, or cloud metadata endpoints accessed via custom DNS names all bypass the IP-only regex patterns. The hostname-pinning approach closes this class of bypasses without needing to enumerate every possible internal name.

## Screenshots

N/A — backend-only change with no UI impact.