### PR TITLE
Document resilience interval recovery command

### DIFF
--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -461,8 +461,40 @@ IMPORT_HHI_VERBOSE=1 FORCE_RESEED=true node scripts/seed-recovery-import-hhi.mjs
 Then warm live scores so `importConcentration` reads the refreshed canonical key:
 
 ```bash
-WORLDMONITOR_API_KEY=<key> node scripts/seed-resilience-scores.mjs
+API_BASE_URL=https://api.worldmonitor.app \
+WORLDMONITOR_SEED_REFRESH_KEY=<seed-refresh-key> \
+WORLDMONITOR_API_KEY=<read-key> \
+node scripts/seed-resilience-scores.mjs
 ```
+
+`WORLDMONITOR_SEED_REFRESH_KEY` is required: the resilience score seeder uses it
+for the seed-only `get-resilience-ranking?refresh=1` recompute path. Keep
+`WORLDMONITOR_API_KEY` or `WORLDMONITOR_VALID_KEYS` available too so laggard
+per-country score warms can fall back to the normal premium read endpoint. In
+Railway, the service environment should already provide the Upstash Redis
+credentials; for a local force-run, export `UPSTASH_REDIS_REST_URL` and
+`UPSTASH_REDIS_REST_TOKEN` as well.
+
+If the run is fixing missing interval data, the success signal is the
+`seed_complete` log for `domain="resilience:scores"` with
+`intervalsWritten > 0` and no `status="ERROR"`. A failed interval recovery
+sets `status="ERROR"` plus `intervalFailureReason` and includes the diagnostic
+counts `intervalMissingScorePayloadCount`, `intervalStaleScorePayloadCount`,
+`intervalInvalidScorePayloadCount`, `intervalMalformedScorePayloadCount`,
+`intervalFormulaSkipCount`, and `intervalPayloadSkipCount`.
+
+Verify the public audit surfaces after the run:
+
+```bash
+curl -fsS https://api.worldmonitor.app/api/resilience/v1/get-runtime-manifest \
+  | jq '{formulaTag, rankingCache, constructVersions, intervals}'
+curl -fsS https://api.worldmonitor.app/api/health \
+  | jq '.checks.resilienceIntervals'
+```
+
+Pass condition for interval recovery: runtime manifest reports
+`intervals.available=true`, and `/api/health` reports
+`resilienceIntervals.status="OK"` with `records > 0`.
 
 ### Verification
 

--- a/scripts/post-pr3427-force-refresh.mjs
+++ b/scripts/post-pr3427-force-refresh.mjs
@@ -56,5 +56,5 @@ if (failed > 0) {
 }
 
 console.log('[post-pr3427] All seeders refreshed. Now run:');
-console.log('  WORLDMONITOR_API_KEY=<key> node scripts/seed-resilience-scores.mjs');
+console.log('  API_BASE_URL=https://api.worldmonitor.app WORLDMONITOR_SEED_REFRESH_KEY=<seed-refresh-key> WORLDMONITOR_API_KEY=<read-key> node scripts/seed-resilience-scores.mjs');
 console.log('to bulk-warm the v15 score cache against the corrected seed data.');

--- a/scripts/post-pr3487-force-refresh.mjs
+++ b/scripts/post-pr3487-force-refresh.mjs
@@ -69,4 +69,4 @@ console.log('  redis-cli GET resilience:recovery:import-hhi:v1 | jq .countries.A
 console.log('');
 console.log('[post-pr3487] Then trigger a fresh ranking warmup so AE\'s importConcentration dim');
 console.log('[post-pr3487] re-scores against the new HHI value (or wait ~6h for the next cron tick):');
-console.log('  WORLDMONITOR_API_KEY=<key> node scripts/seed-resilience-scores.mjs');
+console.log('  API_BASE_URL=https://api.worldmonitor.app WORLDMONITOR_SEED_REFRESH_KEY=<seed-refresh-key> WORLDMONITOR_API_KEY=<read-key> node scripts/seed-resilience-scores.mjs');

--- a/tests/resilience-scores-seed.test.mjs
+++ b/tests/resilience-scores-seed.test.mjs
@@ -686,6 +686,37 @@ describe('seed-bundle-resilience section interval keeps refresh alive', () => {
     assert.match(section, /seedMetaKey:\s*'resilience:scores'/);
     assert.doesNotMatch(section, /seedMetaKey:\s*'resilience:intervals'/);
   });
+
+  it('operator force-refresh docs include the required seed refresh key', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const { dirname, join } = await import('node:path');
+    const dir = dirname(fileURLToPath(import.meta.url));
+    const files = [
+      join(dir, '..', 'docs', 'railway-seed-consolidation-runbook.md'),
+      join(dir, '..', 'scripts', 'post-pr3427-force-refresh.mjs'),
+      join(dir, '..', 'scripts', 'post-pr3487-force-refresh.mjs'),
+    ];
+
+    for (const file of files) {
+      const src = readFileSync(file, 'utf8');
+      const scoreWarmCommands = [...src.matchAll(/node scripts\/seed-resilience-scores\.mjs/g)];
+      assert.ok(scoreWarmCommands.length > 0, `${file} must document the score warm command`);
+      for (const match of scoreWarmCommands) {
+        const commandContext = src.slice(Math.max(0, match.index - 240), match.index + match[0].length);
+        assert.match(
+          commandContext,
+          /WORLDMONITOR_SEED_REFRESH_KEY=<seed-refresh-key>/,
+          `${file} must include WORLDMONITOR_SEED_REFRESH_KEY for seed-resilience-scores`,
+        );
+      }
+      assert.doesNotMatch(
+        src,
+        /WORLDMONITOR_API_KEY=<key> node scripts\/seed-resilience-scores\.mjs/,
+        `${file} must not document the pre-refresh-key score warm command`,
+      );
+    }
+  });
 });
 
 describe('handler warm pipeline is chunked', () => {

--- a/tests/resilience-scores-seed.test.mjs
+++ b/tests/resilience-scores-seed.test.mjs
@@ -686,7 +686,9 @@ describe('seed-bundle-resilience section interval keeps refresh alive', () => {
     assert.match(section, /seedMetaKey:\s*'resilience:scores'/);
     assert.doesNotMatch(section, /seedMetaKey:\s*'resilience:intervals'/);
   });
+});
 
+describe('resilience operator docs', () => {
   it('operator force-refresh docs include the required seed refresh key', async () => {
     const { readFileSync } = await import('node:fs');
     const { fileURLToPath } = await import('node:url');


### PR DESCRIPTION
## Summary
- document the required resilience interval recovery command with `WORLDMONITOR_SEED_REFRESH_KEY`
- update stale force-refresh helper prompts to include the seed refresh key
- add a regression test so operator docs keep the required seed refresh key

## Validation
- `npm_config_cache=/private/tmp/npm-cache npx tsx --test tests/resilience-scores-seed.test.mjs tests/resilience-intervals.test.mjs tests/resilience-intervals-handler.test.mts`
- `npm_config_cache=/private/tmp/npm-cache npx tsx --test --test-name-pattern "^resilience runtime manifest (returns|reports|exposes)" tests/resilience-runtime-manifest.test.mts`
- `git diff --check`
- `git push -u origin codex/resilience-interval-runbook` pre-push hook, including full unit/data suite, edge function tests, markdown lint, MDX lint, pro-test bundle freshness check, and version sync check

## Notes
- The production interval outage still requires live seed credentials and execution; this PR only makes the required recovery command explicit and test-guarded.