### PR TITLE
Reduce residual dependency audit debt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6258,6 +6258,21 @@
         "node": ">= 20.19.4"
       }
     },
+    "node_modules/@react-native/dev-middleware/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/@react-native/dev-middleware/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -15606,6 +15621,21 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/jayson/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -17252,6 +17282,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/metro/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/metro/node_modules/wrap-ansi": {
@@ -19148,6 +19193,21 @@
         "ws": "^7"
       }
     },
+    "node_modules/react-devtools-core/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/react-devtools-core/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -19336,6 +19396,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/react-native/node_modules/utf-8-validate": {
+      "version": "5.0.10",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
+      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
       }
     },
     "node_modules/react-native/node_modules/wrap-ansi": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.82.0",
+        "@anthropic-ai/sdk": "^0.91.1",
         "@aws-sdk/client-s3": "^3.1009.0",
         "@clerk/clerk-js": "^6.13.0",
         "@deck.gl/aggregation-layers": "^9.2.11",
@@ -133,9 +133,9 @@
       "peer": true
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.82.0.tgz",
-      "integrity": "sha512-xdHTjL1GlUlDugHq/I47qdOKp/ROPvuHl7ROJCgUQigbvPu7asf9KcAcU1EqdrP2LuVhEKaTs7Z+ShpZDRzHdQ==",
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -6258,21 +6258,6 @@
         "node": ">= 20.19.4"
       }
     },
-    "node_modules/@react-native/dev-middleware/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/@react-native/dev-middleware/node_modules/ws": {
       "version": "7.5.10",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
@@ -7770,12 +7755,12 @@
       }
     },
     "node_modules/@solana-mobile/mobile-wallet-adapter-protocol": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@solana-mobile/mobile-wallet-adapter-protocol/-/mobile-wallet-adapter-protocol-2.2.6.tgz",
-      "integrity": "sha512-4mktUZRXdOcNHaMF6MrxN1yZpV32q616IpqsJLq/eI9Agz/+h31v5mzejIjtXCeorI7G0awfmI4ZtGIs+N/iYQ==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@solana-mobile/mobile-wallet-adapter-protocol/-/mobile-wallet-adapter-protocol-2.2.8.tgz",
+      "integrity": "sha512-c3FQsrM7nV62DqVaHGKtr2osE2w5gS3/wjy8ILF0zczS/s1mERX+JTmf+UHd8xgESmEj/IM7q+U2Qhrmac1PdA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solana/codecs-strings": "^4.0.0",
+        "@solana/codecs-strings": "^6.0.0",
         "@solana/wallet-standard-features": "^1.3.0",
         "@solana/wallet-standard-util": "^1.1.2",
         "@wallet-standard/core": "^1.1.1",
@@ -7786,30 +7771,30 @@
       }
     },
     "node_modules/@solana-mobile/mobile-wallet-adapter-protocol-web3js": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@solana-mobile/mobile-wallet-adapter-protocol-web3js/-/mobile-wallet-adapter-protocol-web3js-2.2.6.tgz",
-      "integrity": "sha512-akbJgxlYR/BbcNPNQW5bwHv4Bf85iMu+YsUy3KJgfQympQzOQaK9/24monwCMZUG2IfQ3lBL4pi18Z1doq2BnA==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@solana-mobile/mobile-wallet-adapter-protocol-web3js/-/mobile-wallet-adapter-protocol-web3js-2.2.8.tgz",
+      "integrity": "sha512-W9DbsFvl5lSOe7KT3dJX4tjbxfYIoOtOTJpvLMgkojyRU0UKChQ4vHvbOZQ3GkUJ8wOIS4qdrM0Yytd1Vy+YQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.6",
+        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.8",
         "bs58": "^6.0.0",
         "js-base64": "^3.7.5"
       },
       "peerDependencies": {
-        "@solana/web3.js": "^1.58.0"
+        "@solana/web3.js": "^1.98.4"
       }
     },
     "node_modules/@solana-mobile/wallet-adapter-mobile": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@solana-mobile/wallet-adapter-mobile/-/wallet-adapter-mobile-2.2.6.tgz",
-      "integrity": "sha512-6m+h0pasnafcFfeJma+hhWKE6QSPFyIhR5QUwTAy495Y3M/aCNzmcKWRgQ6NrrfFcU7Vzuky19P13EOv2OBP2Q==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@solana-mobile/wallet-adapter-mobile/-/wallet-adapter-mobile-2.2.8.tgz",
+      "integrity": "sha512-ZbXY3/0+UnnyS0hvArpO1b1pYzaQAiVIp+HBUm11aLEkE5+ISvHTRPr/bCEUXZfPkez/1n9zH3H0leK25Lj6Nw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.6",
-        "@solana-mobile/mobile-wallet-adapter-protocol-web3js": "^2.2.6",
-        "@solana-mobile/wallet-standard-mobile": "^0.5.0",
-        "@solana/wallet-adapter-base": "^0.9.23",
-        "@solana/wallet-standard-features": "^1.2.0",
+        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.8",
+        "@solana-mobile/mobile-wallet-adapter-protocol-web3js": "^2.2.8",
+        "@solana-mobile/wallet-standard-mobile": "^0.5.2",
+        "@solana/wallet-adapter-base": "^0.9.27",
+        "@solana/wallet-standard-features": "^1.3.0",
         "@wallet-standard/core": "^1.1.1",
         "bs58": "^6.0.0",
         "js-base64": "^3.7.5",
@@ -7819,19 +7804,19 @@
         "@react-native-async-storage/async-storage": "^1.17.7"
       },
       "peerDependencies": {
-        "@solana/web3.js": "^1.98.0",
+        "@solana/web3.js": "^1.98.4",
         "react-native": ">0.74"
       }
     },
     "node_modules/@solana-mobile/wallet-standard-mobile": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@solana-mobile/wallet-standard-mobile/-/wallet-standard-mobile-0.5.0.tgz",
-      "integrity": "sha512-4eTrdw6hxMIBohJD+tGeNGv1MaXbyPHCtFxJ1Ru4olphiTrD6u6PvAYBL2WebQAMSWzZzDN3fCCTzludpYmwyg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@solana-mobile/wallet-standard-mobile/-/wallet-standard-mobile-0.5.2.tgz",
+      "integrity": "sha512-orEGv4N/Ttd0umwfWUzGcEnVc9eJDTgRSEcDitvFWpIf2D968h6128L0rq9/y7sUw88Gvu/lU0euoC2ASEijqQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.6",
-        "@solana/wallet-standard-chains": "^1.1.0",
-        "@solana/wallet-standard-features": "^1.2.0",
+        "@solana-mobile/mobile-wallet-adapter-protocol": "^2.2.8",
+        "@solana/wallet-standard-chains": "^1.1.1",
+        "@solana/wallet-standard-features": "^1.3.0",
         "@wallet-standard/base": "^1.0.1",
         "@wallet-standard/features": "^1.0.3",
         "@wallet-standard/wallet": "^1.1.0",
@@ -7858,62 +7843,80 @@
       }
     },
     "node_modules/@solana/codecs-core": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-4.0.0.tgz",
-      "integrity": "sha512-28kNUsyIlhU3MO3/7ZLDqeJf2YAm32B4tnTjl5A9HrbBqsTZ+upT/RzxZGP1MMm7jnPuIKCMwmTpsyqyR6IUpw==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-6.9.0.tgz",
+      "integrity": "sha512-F2BmLecG/1nTtnjyD509NsEc254pxJKa2bpvotymv1lL1WfEn3zchcZ9SMIiLyL4G6J8b9F3OKIq2YSZho2AOQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "4.0.0"
+        "@solana/errors": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": ">=5.3.3"
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/codecs-numbers": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-4.0.0.tgz",
-      "integrity": "sha512-z9zpjtcwzqT9rbkKVZpkWB5/0V7+6YRKs6BccHkGJlaDx8Pe/+XOvPi2rEdXPqrPd9QWb5Xp1iBfcgaDMyiOiA==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-6.9.0.tgz",
+      "integrity": "sha512-XMI0FOHV2h7yPAllxWCX8z+J1msidNjXzN1mRjH5KR6C+vfzyKa2xWHve0bNSV/bjVAhqqhc7dQCpBKuF4+ScQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "4.0.0",
-        "@solana/errors": "4.0.0"
+        "@solana/codecs-core": "6.9.0",
+        "@solana/errors": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": ">=5.3.3"
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/codecs-strings": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-4.0.0.tgz",
-      "integrity": "sha512-XvyD+sQ1zyA0amfxbpoFZsucLoe+yASQtDiLUGMDg5TZ82IHE3B7n82jE8d8cTAqi0HgqQiwU13snPhvg1O0Ow==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-6.9.0.tgz",
+      "integrity": "sha512-PTqYQxMsmdfEEq29bV1AnALD4FjFEsSxOj1fYNqooOSTEQEpUoYEQtsd55/kBsnIKltXbvYwXYXBusm19n1sQA==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "4.0.0",
-        "@solana/codecs-numbers": "4.0.0",
-        "@solana/errors": "4.0.0"
+        "@solana/codecs-core": "6.9.0",
+        "@solana/codecs-numbers": "6.9.0",
+        "@solana/errors": "6.9.0"
       },
       "engines": {
         "node": ">=20.18.0"
       },
       "peerDependencies": {
         "fastestsmallesttextencoderdecoder": "^1.0.22",
-        "typescript": ">=5.3.3"
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "fastestsmallesttextencoderdecoder": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/errors": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-4.0.0.tgz",
-      "integrity": "sha512-3YEtvcMvtcnTl4HahqLt0VnaGVf7vVWOnt6/uPky5e0qV6BlxDSbGkbBzttNjxLXHognV0AQi3pjvrtfUnZmbg==",
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-6.9.0.tgz",
+      "integrity": "sha512-7i+b07KMnkbHvFlz7uWade3jvyc22UmVm8o9taxPK8YV3JNM/NkS8oQFvMac2MIaLPAlEs7I8MHyVLUal1yY4g==",
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",
-        "commander": "14.0.1"
+        "commander": "14.0.3"
       },
       "bin": {
         "errors": "bin/cli.mjs"
@@ -7922,7 +7925,12 @@
         "node": ">=20.18.0"
       },
       "peerDependencies": {
-        "typescript": ">=5.3.3"
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@solana/wallet-adapter-base": {
@@ -11267,9 +11275,9 @@
       ]
     },
     "node_modules/commander": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.1.tgz",
-      "integrity": "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==",
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -11366,14 +11374,14 @@
       "peer": true
     },
     "node_modules/convex": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.34.0.tgz",
-      "integrity": "sha512-TbC509Z4urZMChZR2aLPgalQ8gMhAYSz2VMxaYsCvba8YqB0Uxma7zWnXwRn7aEGXuA8ro5/uHgD1IJ0HhYYPg==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.40.0.tgz",
+      "integrity": "sha512-jChWEB45q+9Ibryc7hg0l6hB1xA4zwE2y6ZhkhGP6oJkqYeiURkMagA2ZQZYMy1/T8PZ9ztoVJJtbL/+Ob851Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.27.0",
         "prettier": "^3.0.0",
-        "ws": "8.18.0"
+        "ws": "8.20.1"
       },
       "bin": {
         "convex": "bin/main.js"
@@ -11385,6 +11393,7 @@
       "peerDependencies": {
         "@auth0/auth0-react": "^2.0.1",
         "@clerk/clerk-react": "^4.12.8 || ^5.0.0",
+        "@clerk/react": "^6.4.3",
         "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
@@ -11392,6 +11401,9 @@
           "optional": true
         },
         "@clerk/clerk-react": {
+          "optional": true
+        },
+        "@clerk/react": {
           "optional": true
         },
         "react": {
@@ -11864,27 +11876,6 @@
         "@esbuild/win32-arm64": "0.27.0",
         "@esbuild/win32-ia32": "0.27.0",
         "@esbuild/win32-x64": "0.27.0"
-      }
-    },
-    "node_modules/convex/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/core-assert": {
@@ -13832,13 +13823,6 @@
         "node": ">= 4.9.1"
       }
     },
-    "node_modules/fastestsmallesttextencoderdecoder": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
-      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
-      "license": "CC0-1.0",
-      "peer": true
-    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -14892,9 +14876,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -15621,21 +15605,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/jayson/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
     },
     "node_modules/jayson/node_modules/ws": {
       "version": "7.5.10",
@@ -17285,21 +17254,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/metro/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/metro/node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -18070,9 +18024,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -18831,9 +18785,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -18851,7 +18805,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -19047,9 +19001,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
       "license": "MIT"
     },
     "node_modules/pump": {
@@ -19192,21 +19146,6 @@
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
-      }
-    },
-    "node_modules/react-devtools-core/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
       }
     },
     "node_modules/react-devtools-core/node_modules/ws": {
@@ -19397,21 +19336,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/react-native/node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
       }
     },
     "node_modules/react-native/node_modules/wrap-ansi": {
@@ -19838,9 +19762,9 @@
       }
     },
     "node_modules/rpc-websockets/node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -21967,9 +21891,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.47.6",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.6.tgz",
-      "integrity": "sha512-zExmbI99NGvMdYa7fmqSTLgkwh48dmhgEqFrUgkpL4kfG4XkVefZ8dZqIKVUhZo6Uhf0FrrEXOsHm9LUyIvI2Q==",
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.52.0.tgz",
+      "integrity": "sha512-py2QPYe9e1f4DmPJCsXF7zHmyZ0PkJrBxdQZ5dvNXvzy3UzWkUn7dNfC0TMeNm6Qv1tKw3b6qXXExpx6L0oMbw==",
       "funding": [
         {
           "type": "github",
@@ -21984,8 +21908,8 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.7",
-        "ws": "8.18.3"
+        "ox": "0.14.27",
+        "ws": "8.20.1"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -22024,9 +21948,9 @@
       }
     },
     "node_modules/viem/node_modules/ox": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.7.tgz",
-      "integrity": "sha512-zSQ/cfBdolj7U4++NAvH7sI+VG0T3pEohITCgcQj8KlawvTDY4vGVhDT64Atsm0d6adWfIYHDpu88iUBMMp+AQ==",
+      "version": "0.14.27",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.27.tgz",
+      "integrity": "sha512-+xhLHo/f+f4BH121/1Pomm/1vgBBda1wYiFpTvjSo8o5OcEj76Pf1hGPJiepoYMTQoTm2SKdSBvWkFWk5l07PA==",
       "funding": [
         {
           "type": "github",
@@ -22049,27 +21973,6 @@
       },
       "peerDependenciesMeta": {
         "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/viem/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
           "optional": true
         }
       }
@@ -23460,9 +23363,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "vitest": "^4.1.0"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.82.0",
+    "@anthropic-ai/sdk": "^0.91.1",
     "@aws-sdk/client-s3": "^3.1009.0",
     "@clerk/clerk-js": "^6.13.0",
     "@deck.gl/aggregation-layers": "^9.2.11",

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -8,7 +8,7 @@
       "name": "worldmonitor-railway-relay",
       "version": "1.1.1",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.82.0",
+        "@anthropic-ai/sdk": "^0.91.1",
         "@aws-sdk/client-s3": "^3.1009.0",
         "convex": "^1",
         "exceljs": "^4.4.0",
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.82.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.82.0.tgz",
-      "integrity": "sha512-xdHTjL1GlUlDugHq/I47qdOKp/ROPvuHl7ROJCgUQigbvPu7asf9KcAcU1EqdrP2LuVhEKaTs7Z+ShpZDRzHdQ==",
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -875,37 +875,17 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.12.tgz",
-      "integrity": "sha512-xjyucfn+F+kMf25c+LIUnvX3oyLSlj9T0Vncs5WMQI6G36JdnSwC8g0qf8RajfmSClXr660EpTz7FFKluZ4BqQ==",
+      "version": "3.972.27",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.27.tgz",
+      "integrity": "sha512-hpsCXCOI436kxWpjtRuIHVvuPP81MOw8f18jzfZeg+UOiiOvlqWcmWChzEhJEu16cOC6+ku4ncBN+7rdt+DZ9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.1",
-        "fast-xml-parser": "5.5.6",
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/xml-builder/node_modules/fast-xml-parser": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.6.tgz",
-      "integrity": "sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "fast-xml-builder": "^1.1.4",
-        "path-expression-matcher": "^1.1.3",
-        "strnum": "^2.1.2"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
@@ -1376,6 +1356,18 @@
         "lodash.isundefined": "^3.0.1",
         "lodash.uniq": "^4.5.0"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@react-email/render": {
       "version": "1.1.2",
@@ -1912,9 +1904,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-      "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2481,14 +2473,14 @@
       "license": "MIT"
     },
     "node_modules/convex": {
-      "version": "1.34.1",
-      "resolved": "https://registry.npmjs.org/convex/-/convex-1.34.1.tgz",
-      "integrity": "sha512-ooyFnZVVq0u6b5zt0Ptq8QB2ixhf/2vXe+PIcUtdtrs0lq/TwpkmmruHdqkFmWgMd6N+Tmfy8AGkz6QnZUYZBA==",
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/convex/-/convex-1.40.0.tgz",
+      "integrity": "sha512-jChWEB45q+9Ibryc7hg0l6hB1xA4zwE2y6ZhkhGP6oJkqYeiURkMagA2ZQZYMy1/T8PZ9ztoVJJtbL/+Ob851Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "esbuild": "0.27.0",
         "prettier": "^3.0.0",
-        "ws": "8.18.0"
+        "ws": "8.20.1"
       },
       "bin": {
         "convex": "bin/main.js"
@@ -2500,6 +2492,7 @@
       "peerDependencies": {
         "@auth0/auth0-react": "^2.0.1",
         "@clerk/clerk-react": "^4.12.8 || ^5.0.0",
+        "@clerk/react": "^6.4.3",
         "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
@@ -2509,28 +2502,10 @@
         "@clerk/clerk-react": {
           "optional": true
         },
-        "react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/convex/node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
+        "@clerk/react": {
           "optional": true
         },
-        "utf-8-validate": {
+        "react": {
           "optional": true
         }
       }
@@ -2879,9 +2854,9 @@
       "license": "MIT"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -2890,7 +2865,29 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fs-constants": {
@@ -3192,9 +3189,9 @@
       "license": "ISC"
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3569,9 +3566,9 @@
       "license": "MIT"
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
       "funding": [
         {
           "type": "github",
@@ -3859,9 +3856,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "funding": [
         {
           "type": "github",
@@ -3913,9 +3910,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -4124,9 +4121,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -4142,6 +4139,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlchars": {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -10,7 +10,7 @@
     "seed-bundle-regional": "node seed-bundle-regional.mjs"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.82.0",
+    "@anthropic-ai/sdk": "^0.91.1",
     "@aws-sdk/client-s3": "^3.1009.0",
     "convex": "^1",
     "exceljs": "^4.4.0",


### PR DESCRIPTION
## Summary

- Bump the root `@anthropic-ai/sdk` dependency to `^0.91.1` and refresh compatible lockfile packages to reduce residual moderate audit debt without broad major upgrades.
- Apply the same Anthropic SDK cleanup to the independently installed `scripts/` relay package so Railway/Nixpacks relay installs do not retain the old high/moderate advisory path.
- Restore npm 10 lockfile metadata for optional peer `utf-8-validate@5.0.10` placements so GitHub Actions `npm ci` accepts the refreshed root lockfile.
- Leave the remaining compatible blockers documented: root Clerk/Solana wallet stack still pulls `@solana/web3.js -> jayson -> uuid <11.1.1`, and `exceljs -> uuid` remains in both root dev/scripts package paths with no compatible non-major fix.

## Supply-chain note

- `scripts/package-lock.json` now includes `@nodable/entities@2.1.1` as a new transitive dependency via `fast-xml-parser@5.7.3`, pulled through `@aws-sdk/xml-builder@3.972.27`.
- Vetting: npm registry tarball resolves from `registry.npmjs.org`, package license is MIT, funding points to GitHub Sponsors for `nodable`, and the package is only present as a transitive XML entity helper in the standalone relay install path.

## Validation

- `NPM_CONFIG_CACHE=/tmp/worldmonitor-npm-cache npx npm@10.9.8 install --package-lock-only --ignore-scripts`
- `NPM_CONFIG_CACHE=/tmp/worldmonitor-npm-cache npx npm@10.9.8 ci --ignore-scripts`
- `npm audit --omit=dev --json` -> 0 critical, 0 high, 12 moderate
- `npm audit --json` -> 0 critical, 0 high, 13 moderate
- `npm audit --prefix scripts --omit=dev --json` -> 0 critical, 0 high, 2 moderate
- `npm ci --prefix scripts --omit=dev`
- `node -e "import('@anthropic-ai/sdk').then((m) => console.log(typeof m.default))"` from `scripts/`
- `node --test scripts/ais-relay-rss.test.cjs`
- `node --test tests/widget-builder.test.mjs`
- `npm run typecheck`
- `npm run build`
- `git diff --check`
- pre-push hook completed successfully on the initial push and again after the npm 10 lockfile metadata fix

## Local note

- Full local `npm ci` with scripts enabled got past the prior lock-sync failure, then failed while compiling `sharp` under the macOS sandbox due xcrun cache write restrictions and local libvips linkage. GitHub Actions runs Linux and the reproduced CI blocker was the npm 10 lock metadata, which now passes locally with npm 10 `ci --ignore-scripts`.