### PR TITLE
Document energy v2 artifact closeout requirements

### DIFF
--- a/docs/methodology/energy-v2-flag-flip-runbook.md
+++ b/docs/methodology/energy-v2-flag-flip-runbook.md
@@ -29,6 +29,35 @@ checked-in energy-v2-specific acceptance generator today. Do not use
 legacy six-domain aggregate against the pillar-combined formula and is not
 an energy-v2 post-flip acceptance harness.
 
+### What can be verified without secrets
+
+The public runtime state can be rechecked without credentials, but that is not
+enough to create either acceptance artifact:
+
+```bash
+node --input-type=module -e 'const ua="Mozilla/5.0"; const base="https://www.worldmonitor.app"; const read=async (p)=>(await fetch(base+p,{headers:{"user-agent":ua,accept:"application/json"}})).json(); const [manifest,health]=await Promise.all([read("/api/resilience/v1/get-runtime-manifest"),read("/api/health")]); console.log(JSON.stringify({formulaTag:manifest.formulaTag,constructEnergy:manifest.constructVersions?.energy,rankingCache:manifest.rankingCache,energyV2SeedChecks:{lowCarbonGeneration:health.checks?.lowCarbonGeneration?.status,fossilElectricityShare:health.checks?.fossilElectricityShare?.status,powerLosses:health.checks?.powerLosses?.status}},null,2));'
+```
+
+Expected public evidence after the flip:
+
+- manifest: `formulaTag == "pc"`, `constructVersions.energy == "v2"`,
+  and `rankingCache.count == rankingCache.scored == rankingCache.total == 196`
+- health: `lowCarbonGeneration`, `fossilElectricityShare`, and `powerLosses`
+  are `OK`
+
+The ranking and formula-anchor endpoints still require Pro/API auth:
+
+```bash
+API_BASE=https://www.worldmonitor.app \
+  RESILIENCE_RANKING_REFRESH=false \
+  node scripts/freeze-resilience-ranking.mjs
+# Expected without WORLDMONITOR_API_KEY:
+# HTTP 401 from /api/resilience/v1/get-resilience-score?... Pro authentication required
+```
+
+Treat the public manifest/health check as audit context only. Do not rename it
+into a ranking snapshot and do not use it as acceptance evidence.
+
 ### Required operator artifact capture
 
 Run from the repo root with production credentials:
@@ -64,6 +93,67 @@ environment names for the shared Upstash client are
 `REDIS_OP_TIMEOUT_MS=10000`, and `REDIS_PIPELINE_TIMEOUT_MS=30000`; the active
 post-flip runtime state still needs to be verified through the public manifest,
 not inferred from a local `RESILIENCE_ENERGY_V2_ENABLED` value.
+
+### Energy-v2 acceptance artifact contract
+
+Once the dedicated harness exists, the committed JSON must be named
+`docs/snapshots/resilience-energy-v2-acceptance-{date}.json` and must not be
+the output of `scripts/compare-resilience-current-vs-proposed.mjs`. The minimum
+machine-checkable shape is:
+
+```json
+{
+  "artifactType": "resilience-energy-v2-post-flip-acceptance",
+  "generatedAt": "2026-06-02T00:00:00.000Z",
+  "capturedAt": "2026-06-02",
+  "runtime": {
+    "manifest": {
+      "formulaTag": "pc",
+      "constructVersions": { "energy": "v2" },
+      "rankingCache": { "count": 196, "scored": 196, "total": 196 }
+    },
+    "health": {
+      "energyV2SeedChecks": {
+        "lowCarbonGeneration": "OK",
+        "fossilElectricityShare": "OK",
+        "powerLosses": "OK"
+      }
+    }
+  },
+  "baseline": {
+    "rankingSnapshot": "docs/snapshots/resilience-ranking-live-pre-pr1-flip-YYYY-MM-DD.json"
+  },
+  "postFlip": {
+    "rankingSnapshot": "docs/snapshots/resilience-ranking-live-post-pr1-YYYY-MM-DD.json"
+  },
+  "acceptanceGates": {
+    "verdict": "PASS",
+    "results": [
+      { "id": "gate-1-spearman", "status": "pass" },
+      { "id": "gate-2-country-drift", "status": "pass" },
+      { "id": "gate-6-cohort-median", "status": "pass" },
+      { "id": "gate-7-matched-pair", "status": "pass" },
+      { "id": "gate-9-effective-influence-baseline", "status": "pass" }
+    ]
+  }
+}
+```
+
+If the credentialed ranking snapshot or the dedicated acceptance harness is
+still unavailable, attach this exact closeout status to the resilience issue
+instead of committing placeholder JSON:
+
+```text
+Energy v2 is live: manifest formulaTag=pc, constructVersions.energy=v2,
+rankingCache=196/196, and health is OK for lowCarbonGeneration,
+fossilElectricityShare, and powerLosses.
+
+Artifact status: BLOCKED. docs/snapshots/resilience-ranking-live-post-pr1-*.json
+requires WORLDMONITOR_API_KEY because freeze-resilience-ranking verifies score
+anchors through get-resilience-score. docs/snapshots/resilience-energy-v2-acceptance-*.json
+is also blocked until the dedicated energy-v2 acceptance
+harness exists. No synthetic snapshots committed.
+```
 
 Follow the original gated procedure below for future rollback/replay drills.
 

--- a/scripts/freeze-resilience-ranking.mjs
+++ b/scripts/freeze-resilience-ranking.mjs
@@ -225,7 +225,7 @@ async function fetchJson(url, headers) {
   const response = await fetch(url, { headers });
   if (!response.ok) {
     const body = await response.text().catch(() => '');
-    const credentialHint = response.status === 401 && url.startsWith(SCORE_URL) && !process.env.WORLDMONITOR_API_KEY
+    const credentialHint = response.status === 401 && SCORE_URL && url.startsWith(SCORE_URL) && !process.env.WORLDMONITOR_API_KEY
       ? ' Set WORLDMONITOR_API_KEY to a Pro/API key; post-flip ranking snapshots must verify score anchors through get-resilience-score and cannot be captured from an unauthenticated shell.'
       : '';
     throw new Error(`HTTP ${response.status} from ${url}: ${body}${credentialHint}`);

--- a/scripts/freeze-resilience-ranking.mjs
+++ b/scripts/freeze-resilience-ranking.mjs
@@ -224,7 +224,11 @@ async function buildAuthHeaders() {
 async function fetchJson(url, headers) {
   const response = await fetch(url, { headers });
   if (!response.ok) {
-    throw new Error(`HTTP ${response.status} from ${url}: ${await response.text().catch(() => '')}`);
+    const body = await response.text().catch(() => '');
+    const credentialHint = response.status === 401 && url.startsWith(SCORE_URL) && !process.env.WORLDMONITOR_API_KEY
+      ? ' Set WORLDMONITOR_API_KEY to a Pro/API key; post-flip ranking snapshots must verify score anchors through get-resilience-score and cannot be captured from an unauthenticated shell.'
+      : '';
+    throw new Error(`HTTP ${response.status} from ${url}: ${body}${credentialHint}`);
   }
   return response.json();
 }

--- a/tests/resilience-validation-artifacts-schema.test.mts
+++ b/tests/resilience-validation-artifacts-schema.test.mts
@@ -54,6 +54,11 @@ function readJson(path: string): unknown {
   return JSON.parse(readFileSync(path, 'utf8'));
 }
 
+function readTextFile(path: string): string {
+  assert.ok(existsSync(path), `${path} must exist`);
+  return readFileSync(path, 'utf8');
+}
+
 function listSnapshotFiles(re: RegExp): string[] {
   if (!existsSync(snapshotDir)) return [];
   return readdirSync(snapshotDir)
@@ -100,6 +105,66 @@ function assertFormulaMetadata(artifact: Record<string, unknown>, label: string)
       artifact.generatedAt >= PC_VALIDATION_ARTIFACT_MIN_GENERATED_AT,
       `${label} pc artifact generatedAt ${new Date(artifact.generatedAt).toISOString()} must be at or after ${new Date(PC_VALIDATION_ARTIFACT_MIN_GENERATED_AT).toISOString()}`,
     );
+  }
+}
+
+function assertEnergyV2AcceptanceArtifact(artifact: Record<string, unknown>, filename: string): void {
+  const [, fileDate] = ENERGY_V2_ACCEPTANCE_RE.exec(filename)!;
+
+  assert.equal(artifact.artifactType, 'resilience-energy-v2-post-flip-acceptance');
+  assert.equal(artifact.capturedAt, fileDate, `${filename}.capturedAt must match the filename date`);
+  assert.ok(!('_note' in artifact), `${filename} must not be a placeholder`);
+  assert.notEqual(
+    artifact.comparison,
+    'currentDomainAggregate_vs_proposedPillarCombined',
+    `${filename} must not be the pillar-combine comparison harness output.`,
+  );
+  const generatedAt = assertString(artifact.generatedAt, `${filename}.generatedAt`);
+  const generatedAtMs = Date.parse(generatedAt);
+  assert.ok(!Number.isNaN(generatedAtMs), `${filename}.generatedAt must be an ISO timestamp`);
+  assert.ok(
+    generatedAtMs >= PC_VALIDATION_ARTIFACT_MIN_GENERATED_AT,
+    `${filename}.generatedAt ${new Date(generatedAtMs).toISOString()} must be at or after ${new Date(PC_VALIDATION_ARTIFACT_MIN_GENERATED_AT).toISOString()}`,
+  );
+
+  const runtime = asRecord(artifact.runtime, `${filename}.runtime`);
+  const manifest = asRecord(runtime.manifest, `${filename}.runtime.manifest`);
+  assert.equal(manifest.formulaTag, 'pc');
+  assert.equal(asRecord(manifest.constructVersions, `${filename}.runtime.manifest.constructVersions`).energy, 'v2');
+  const rankingCache = asRecord(manifest.rankingCache, `${filename}.runtime.manifest.rankingCache`);
+  assert.equal(rankingCache.count, 196);
+  assert.equal(rankingCache.scored, 196);
+  assert.equal(rankingCache.total, 196);
+
+  const health = asRecord(runtime.health, `${filename}.runtime.health`);
+  const checks = asRecord(health.energyV2SeedChecks, `${filename}.runtime.health.energyV2SeedChecks`);
+  for (const checkName of ['lowCarbonGeneration', 'fossilElectricityShare', 'powerLosses']) {
+    assert.equal(checks[checkName], 'OK', `${filename} health check ${checkName} must be OK`);
+  }
+
+  const baseline = asRecord(artifact.baseline, `${filename}.baseline`);
+  assert.match(
+    assertString(baseline.rankingSnapshot, `${filename}.baseline.rankingSnapshot`),
+    /docs\/snapshots\/resilience-ranking-live-(?:pre-pr1-flip|pre-repair)-\d{4}-\d{2}-\d{2}\.json$/,
+  );
+  const postFlip = asRecord(artifact.postFlip, `${filename}.postFlip`);
+  assert.match(
+    assertString(postFlip.rankingSnapshot, `${filename}.postFlip.rankingSnapshot`),
+    /docs\/snapshots\/resilience-ranking-live-post-pr1-\d{4}-\d{2}-\d{2}\.json$/,
+  );
+
+  const acceptanceGates = asRecord(artifact.acceptanceGates, `${filename}.acceptanceGates`);
+  assert.equal(acceptanceGates.verdict, 'PASS');
+  const results = acceptanceGates.results;
+  assert.ok(Array.isArray(results), `${filename}.acceptanceGates.results must be an array`);
+  const resultById = new Map(results.map((rawResult) => {
+    const result = asRecord(rawResult, `${filename}.acceptanceGates.result`);
+    return [assertString(result.id, `${filename}.acceptanceGates.result.id`), result];
+  }));
+  for (const gateId of REQUIRED_ENERGY_V2_ACCEPTANCE_GATES) {
+    const gate = resultById.get(gateId);
+    assert.ok(gate, `${filename} must include ${gateId}`);
+    assert.equal(gate.status, 'pass', `${filename} ${gateId} must pass for a committed post-flip acceptance artifact`);
   }
 }
 
@@ -206,10 +271,10 @@ describe('resilience validation artifacts', () => {
   it('keeps missing post-flip energy-v2 artifact capture explicit and actionable', () => {
     const postFlipRankingFiles = listSnapshotFiles(POST_FLIP_RANKING_RE);
     const energyV2AcceptanceFiles = listSnapshotFiles(ENERGY_V2_ACCEPTANCE_RE);
-    const runbook = readFileSync(runbookPath, 'utf8');
-    const methodology = readFileSync(methodologyPath, 'utf8');
-    const freezeScript = readFileSync(freezeScriptPath, 'utf8');
-    const compareScript = readFileSync(compareScriptPath, 'utf8');
+    const runbook = readTextFile(runbookPath);
+    const methodology = readTextFile(methodologyPath);
+    const freezeScript = readTextFile(freezeScriptPath);
+    const compareScript = readTextFile(compareScriptPath);
 
     assert.match(
       runbook,
@@ -311,55 +376,49 @@ describe('resilience validation artifacts', () => {
     }
   });
 
+  it('rejects backdated energy-v2 post-flip acceptance artifact timestamps', () => {
+    const filename = 'resilience-energy-v2-acceptance-2026-06-03.json';
+    const backdatedArtifact = {
+      artifactType: 'resilience-energy-v2-post-flip-acceptance',
+      capturedAt: '2026-06-03',
+      comparison: 'energyV2PostFlipAcceptance',
+      generatedAt: '2026-05-27T00:00:00.000Z',
+      runtime: {
+        manifest: {
+          formulaTag: 'pc',
+          constructVersions: { energy: 'v2' },
+          rankingCache: { count: 196, scored: 196, total: 196 },
+        },
+        health: {
+          energyV2SeedChecks: {
+            lowCarbonGeneration: 'OK',
+            fossilElectricityShare: 'OK',
+            powerLosses: 'OK',
+          },
+        },
+      },
+      baseline: {
+        rankingSnapshot: 'docs/snapshots/resilience-ranking-live-pre-pr1-flip-2026-05-27.json',
+      },
+      postFlip: {
+        rankingSnapshot: 'docs/snapshots/resilience-ranking-live-post-pr1-2026-06-03.json',
+      },
+      acceptanceGates: {
+        verdict: 'PASS',
+        results: REQUIRED_ENERGY_V2_ACCEPTANCE_GATES.map((id) => ({ id, status: 'pass' })),
+      },
+    };
+
+    assert.throws(
+      () => assertEnergyV2AcceptanceArtifact(backdatedArtifact, filename),
+      /must be at or after/,
+    );
+  });
+
   it('validates any committed energy-v2 post-flip acceptance artifacts', () => {
     for (const filename of listSnapshotFiles(ENERGY_V2_ACCEPTANCE_RE)) {
-      const [, fileDate] = ENERGY_V2_ACCEPTANCE_RE.exec(filename)!;
       const artifact = asRecord(readJson(resolve(snapshotDir, filename)), filename);
-
-      assert.equal(artifact.artifactType, 'resilience-energy-v2-post-flip-acceptance');
-      assert.equal(artifact.capturedAt, fileDate, `${filename}.capturedAt must match the filename date`);
-      assert.ok(!('_note' in artifact), `${filename} must not be a placeholder`);
-      assert.notEqual(
-        artifact.comparison,
-        'currentDomainAggregate_vs_proposedPillarCombined',
-        `${filename} must not be the pillar-combine comparison harness output.`,
-      );
-      const generatedAt = assertString(artifact.generatedAt, `${filename}.generatedAt`);
-      assert.ok(!Number.isNaN(Date.parse(generatedAt)), `${filename}.generatedAt must be an ISO timestamp`);
-
-      const runtime = asRecord(artifact.runtime, `${filename}.runtime`);
-      const manifest = asRecord(runtime.manifest, `${filename}.runtime.manifest`);
-      assert.equal(manifest.formulaTag, 'pc');
-      assert.equal(asRecord(manifest.constructVersions, `${filename}.runtime.manifest.constructVersions`).energy, 'v2');
-      const rankingCache = asRecord(manifest.rankingCache, `${filename}.runtime.manifest.rankingCache`);
-      assert.equal(rankingCache.count, 196);
-      assert.equal(rankingCache.scored, 196);
-      assert.equal(rankingCache.total, 196);
-
-      const health = asRecord(runtime.health, `${filename}.runtime.health`);
-      const checks = asRecord(health.energyV2SeedChecks, `${filename}.runtime.health.energyV2SeedChecks`);
-      for (const checkName of ['lowCarbonGeneration', 'fossilElectricityShare', 'powerLosses']) {
-        assert.equal(checks[checkName], 'OK', `${filename} health check ${checkName} must be OK`);
-      }
-
-      const baseline = asRecord(artifact.baseline, `${filename}.baseline`);
-      assert.match(assertString(baseline.rankingSnapshot, `${filename}.baseline.rankingSnapshot`), /docs\/snapshots\/resilience-ranking-live-(?:pre-pr1-flip|pre-repair)-\d{4}-\d{2}-\d{2}\.json$/);
-      const postFlip = asRecord(artifact.postFlip, `${filename}.postFlip`);
-      assert.match(assertString(postFlip.rankingSnapshot, `${filename}.postFlip.rankingSnapshot`), /docs\/snapshots\/resilience-ranking-live-post-pr1-\d{4}-\d{2}-\d{2}\.json$/);
-
-      const acceptanceGates = asRecord(artifact.acceptanceGates, `${filename}.acceptanceGates`);
-      assert.equal(acceptanceGates.verdict, 'PASS');
-      const results = acceptanceGates.results;
-      assert.ok(Array.isArray(results), `${filename}.acceptanceGates.results must be an array`);
-      const resultById = new Map(results.map((rawResult) => {
-        const result = asRecord(rawResult, `${filename}.acceptanceGates.result`);
-        return [assertString(result.id, `${filename}.acceptanceGates.result.id`), result];
-      }));
-      for (const gateId of REQUIRED_ENERGY_V2_ACCEPTANCE_GATES) {
-        const gate = resultById.get(gateId);
-        assert.ok(gate, `${filename} must include ${gateId}`);
-        assert.equal(gate.status, 'pass', `${filename} ${gateId} must pass for a committed post-flip acceptance artifact`);
-      }
+      assertEnergyV2AcceptanceArtifact(artifact, filename);
     }
   });
 });

--- a/tests/resilience-validation-artifacts-schema.test.mts
+++ b/tests/resilience-validation-artifacts-schema.test.mts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
@@ -14,6 +14,11 @@ const here = dirname(fileURLToPath(import.meta.url));
 const validationDir = resolve(here, '../docs/methodology/country-resilience-index/validation');
 const benchmarkPath = resolve(validationDir, 'benchmark-results.json');
 const backtestPath = resolve(validationDir, 'backtest-results.json');
+const snapshotDir = resolve(here, '../docs/snapshots');
+const runbookPath = resolve(here, '../docs/methodology/energy-v2-flag-flip-runbook.md');
+const methodologyPath = resolve(here, '../docs/methodology/country-resilience-index.mdx');
+const freezeScriptPath = resolve(here, '../scripts/freeze-resilience-ranking.mjs');
+const compareScriptPath = resolve(here, '../scripts/compare-resilience-current-vs-proposed.mjs');
 
 const EXPECTED_BENCHMARK_INDICES = ['HDI', 'INFORM', 'WorldRiskIndex'];
 const EXPECTED_BACKTEST_FAMILIES = [
@@ -34,9 +39,26 @@ const EXPECTED_BACKTEST_DATA_SOURCES = new Map<string, string>([
   ['sanctions-shocks', 'hardcoded'],
   ['sovereign-stress', 'hardcoded'],
 ]);
+const POST_FLIP_RANKING_RE = /^resilience-ranking-live-post-pr1-(\d{4}-\d{2}-\d{2})\.json$/;
+const ENERGY_V2_ACCEPTANCE_RE = /^resilience-energy-v2-acceptance-(\d{4}-\d{2}-\d{2})\.json$/;
+const REQUIRED_ENERGY_V2_ACCEPTANCE_GATES = [
+  'gate-1-spearman',
+  'gate-2-country-drift',
+  'gate-6-cohort-median',
+  'gate-7-matched-pair',
+  'gate-9-effective-influence-baseline',
+];
+
 function readJson(path: string): unknown {
   assert.ok(existsSync(path), `${path} must exist`);
   return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function listSnapshotFiles(re: RegExp): string[] {
+  if (!existsSync(snapshotDir)) return [];
+  return readdirSync(snapshotDir)
+    .filter((filename) => re.test(filename))
+    .sort();
 }
 
 function asRecord(value: unknown, label: string): Record<string, unknown> {
@@ -179,5 +201,165 @@ describe('resilience validation artifacts', () => {
     assert.equal(summary.failed, 0);
     assertFiniteNumber(summary.totalCountries, 'backtest.summary.totalCountries');
     assert.ok(summary.totalCountries > 0, 'backtest.summary.totalCountries must be positive');
+  });
+
+  it('keeps missing post-flip energy-v2 artifact capture explicit and actionable', () => {
+    const postFlipRankingFiles = listSnapshotFiles(POST_FLIP_RANKING_RE);
+    const energyV2AcceptanceFiles = listSnapshotFiles(ENERGY_V2_ACCEPTANCE_RE);
+    const runbook = readFileSync(runbookPath, 'utf8');
+    const methodology = readFileSync(methodologyPath, 'utf8');
+    const freezeScript = readFileSync(freezeScriptPath, 'utf8');
+    const compareScript = readFileSync(compareScriptPath, 'utf8');
+
+    assert.match(
+      runbook,
+      /formulaTag == "pc"[\s\S]*constructVersions\.energy == "v2"[\s\S]*rankingCache\.count == rankingCache\.scored == rankingCache\.total == 196/,
+      'runbook must preserve the public post-flip manifest evidence needed for closeout triage.',
+    );
+    assert.match(
+      runbook,
+      /lowCarbonGeneration[\s\S]*fossilElectricityShare[\s\S]*powerLosses[\s\S]*OK/,
+      'runbook must name the three energy-v2 health checks and their expected OK status.',
+    );
+    if (postFlipRankingFiles.length === 0 || energyV2AcceptanceFiles.length === 0) {
+      assert.match(
+        methodology,
+        /post-flip ranking and acceptance artifacts still need a credentialed operator capture/,
+        'methodology doc must not imply the post-flip closeout artifacts are already committed while either required artifact is absent.',
+      );
+    }
+    assert.match(
+      freezeScript,
+      /post-flip ranking snapshots must verify score anchors through get-resilience-score/,
+      'freeze script must explain why unauthenticated post-flip snapshot capture is insufficient.',
+    );
+    assert.match(
+      compareScript,
+      /currentDomainAggregate_vs_proposedPillarCombined/,
+      'compare script must remain identifiable as the pillar-combine harness, not the energy-v2 post-flip acceptance artifact.',
+    );
+
+    if (postFlipRankingFiles.length === 0) {
+      assert.match(
+        runbook,
+        /WORLDMONITOR_API_KEY[\s\S]*get-resilience-score[\s\S]*Pro authentication required/,
+        'runbook must explain that the post-flip ranking artifact requires a Pro/API key for score-anchor verification.',
+      );
+      assert.ok(
+        runbook.includes('resilience-ranking-live-post-pr1-*.json') ||
+          runbook.includes('resilience-ranking-live-post-pr1-{date}.json'),
+        'runbook must name the required post-flip ranking artifact pattern.',
+      );
+    }
+
+    if (energyV2AcceptanceFiles.length === 0) {
+      assert.match(
+        runbook,
+        /dedicated energy-v2 acceptance harness[\s\S]*do not commit (?:a )?synthetic acceptance JSON/i,
+        'runbook must block synthetic energy-v2 acceptance artifacts while the dedicated harness is absent.',
+      );
+      assert.match(
+        runbook,
+        /resilience-energy-v2-acceptance-\{date\}\.json/,
+        'runbook must name the required energy-v2 acceptance artifact pattern.',
+      );
+    }
+  });
+
+  it('validates any committed post-flip PR1 ranking artifacts', () => {
+    for (const filename of listSnapshotFiles(POST_FLIP_RANKING_RE)) {
+      const [, fileDate] = POST_FLIP_RANKING_RE.exec(filename)!;
+      const snapshot = asRecord(readJson(resolve(snapshotDir, filename)), filename);
+
+      assert.equal(snapshot.capturedAt, fileDate, `${filename}.capturedAt must match the date in the filename`);
+      assert.equal(snapshot.schemaVersion, '2.0', `${filename}.schemaVersion must match the live score shape`);
+      assert.equal(snapshot.methodologyFormula, 'pillar-combined-penalized-v1');
+      assert.ok(!('_note' in snapshot), `${filename} must not be a placeholder`);
+
+      const formulaVerification = asRecord(snapshot.formulaVerification, `${filename}.formulaVerification`);
+      assert.equal(formulaVerification.declaredFormula, 'pillar-combined-penalized-v1');
+      assert.match(assertString(formulaVerification.scoreEndpoint, `${filename}.formulaVerification.scoreEndpoint`), /\/api\/resilience\/v1\/get-resilience-score$/);
+      assert.match(assertString(formulaVerification.rankingEndpoint, `${filename}.formulaVerification.rankingEndpoint`), /\/api\/resilience\/v1\/get-resilience-ranking\?refresh=1$/);
+      const checks = formulaVerification.checks;
+      assert.ok(Array.isArray(checks) && checks.length >= 2, `${filename} must verify at least two score anchors`);
+      for (const rawCheck of checks) {
+        const check = asRecord(rawCheck, `${filename}.formulaVerification.check`);
+        assert.match(assertString(check.countryCode, `${filename}.formulaVerification.check.countryCode`), /^[A-Z]{2}$/);
+        assertFiniteNumber(check.absoluteError, `${filename}.formulaVerification.${check.countryCode}.absoluteError`);
+        assertFiniteNumber(check.rankingAbsoluteError, `${filename}.formulaVerification.${check.countryCode}.rankingAbsoluteError`);
+        assert.ok(
+          check.absoluteError <= Number(formulaVerification.tolerance),
+          `${filename} ${check.countryCode} must match the declared formula within tolerance`,
+        );
+        assert.ok(
+          check.rankingAbsoluteError <= Number(formulaVerification.tolerance),
+          `${filename} ${check.countryCode} ranking score must match the score endpoint within tolerance`,
+        );
+      }
+
+      const totals = asRecord(snapshot.totals, `${filename}.totals`);
+      assertFiniteNumber(totals.rankedCountries, `${filename}.totals.rankedCountries`);
+      assertFiniteNumber(totals.greyedOutCount, `${filename}.totals.greyedOutCount`);
+      assert.ok(
+        totals.rankedCountries + totals.greyedOutCount >= 190,
+        `${filename} must represent the full country universe, got ranked=${totals.rankedCountries} greyedOut=${totals.greyedOutCount}`,
+      );
+      assert.ok(Array.isArray(snapshot.items), `${filename}.items must be an array`);
+      assert.ok(Array.isArray(snapshot.greyedOut), `${filename}.greyedOut must be an array`);
+      assert.equal((snapshot.items as unknown[]).length, totals.rankedCountries);
+      assert.equal((snapshot.greyedOut as unknown[]).length, totals.greyedOutCount);
+    }
+  });
+
+  it('validates any committed energy-v2 post-flip acceptance artifacts', () => {
+    for (const filename of listSnapshotFiles(ENERGY_V2_ACCEPTANCE_RE)) {
+      const [, fileDate] = ENERGY_V2_ACCEPTANCE_RE.exec(filename)!;
+      const artifact = asRecord(readJson(resolve(snapshotDir, filename)), filename);
+
+      assert.equal(artifact.artifactType, 'resilience-energy-v2-post-flip-acceptance');
+      assert.equal(artifact.capturedAt, fileDate, `${filename}.capturedAt must match the filename date`);
+      assert.ok(!('_note' in artifact), `${filename} must not be a placeholder`);
+      assert.notEqual(
+        artifact.comparison,
+        'currentDomainAggregate_vs_proposedPillarCombined',
+        `${filename} must not be the pillar-combine comparison harness output.`,
+      );
+      const generatedAt = assertString(artifact.generatedAt, `${filename}.generatedAt`);
+      assert.ok(!Number.isNaN(Date.parse(generatedAt)), `${filename}.generatedAt must be an ISO timestamp`);
+
+      const runtime = asRecord(artifact.runtime, `${filename}.runtime`);
+      const manifest = asRecord(runtime.manifest, `${filename}.runtime.manifest`);
+      assert.equal(manifest.formulaTag, 'pc');
+      assert.equal(asRecord(manifest.constructVersions, `${filename}.runtime.manifest.constructVersions`).energy, 'v2');
+      const rankingCache = asRecord(manifest.rankingCache, `${filename}.runtime.manifest.rankingCache`);
+      assert.equal(rankingCache.count, 196);
+      assert.equal(rankingCache.scored, 196);
+      assert.equal(rankingCache.total, 196);
+
+      const health = asRecord(runtime.health, `${filename}.runtime.health`);
+      const checks = asRecord(health.energyV2SeedChecks, `${filename}.runtime.health.energyV2SeedChecks`);
+      for (const checkName of ['lowCarbonGeneration', 'fossilElectricityShare', 'powerLosses']) {
+        assert.equal(checks[checkName], 'OK', `${filename} health check ${checkName} must be OK`);
+      }
+
+      const baseline = asRecord(artifact.baseline, `${filename}.baseline`);
+      assert.match(assertString(baseline.rankingSnapshot, `${filename}.baseline.rankingSnapshot`), /docs\/snapshots\/resilience-ranking-live-(?:pre-pr1-flip|pre-repair)-\d{4}-\d{2}-\d{2}\.json$/);
+      const postFlip = asRecord(artifact.postFlip, `${filename}.postFlip`);
+      assert.match(assertString(postFlip.rankingSnapshot, `${filename}.postFlip.rankingSnapshot`), /docs\/snapshots\/resilience-ranking-live-post-pr1-\d{4}-\d{2}-\d{2}\.json$/);
+
+      const acceptanceGates = asRecord(artifact.acceptanceGates, `${filename}.acceptanceGates`);
+      assert.equal(acceptanceGates.verdict, 'PASS');
+      const results = acceptanceGates.results;
+      assert.ok(Array.isArray(results), `${filename}.acceptanceGates.results must be an array`);
+      const resultById = new Map(results.map((rawResult) => {
+        const result = asRecord(rawResult, `${filename}.acceptanceGates.result`);
+        return [assertString(result.id, `${filename}.acceptanceGates.result.id`), result];
+      }));
+      for (const gateId of REQUIRED_ENERGY_V2_ACCEPTANCE_GATES) {
+        const gate = resultById.get(gateId);
+        assert.ok(gate, `${filename} must include ${gateId}`);
+        assert.equal(gate.status, 'pass', `${filename} ${gateId} must pass for a committed post-flip acceptance artifact`);
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary
- document the no-secret energy v2 post-flip verification path and the credentialed artifact-capture boundary
- add a concrete schema contract for future energy-v2 acceptance artifacts
- improve unauthenticated freeze failure guidance and test the missing-artifact/future-artifact states

## Validation
- npx tsx --test tests/resilience-validation-artifacts-schema.test.mts
- npm run typecheck
- git diff --check
- pre-push hook passed: typecheck, API typecheck, Convex type check, CJS syntax, Unicode safety, architectural boundary, rate-limit policy, premium-fetch parity, edge bundle checks, unit/data suite, markdown lint, MDX lint, proto freshness skip, pro-test bundle freshness, version sync