### PR TITLE
fix(brief): drop ephemeral live teasers

### DIFF
--- a/Dockerfile.digest-notifications
+++ b/Dockerfile.digest-notifications
@@ -73,7 +73,7 @@ COPY shared/brief-filter.js shared/brief-filter.d.ts ./shared/
 COPY shared/url-classifier.js ./shared/
 # brief-filter.js and digest compose paths import ephemeral-live-classifier.js
 # to drop expiring WATCH LIVE / live-event programming from delayed briefs.
-COPY shared/ephemeral-live-classifier.js ./shared/
+COPY shared/ephemeral-live-classifier.js shared/ephemeral-live-classifier.d.ts ./shared/
 # brief-filter.js imports diplomacy-keywords.json (canonical lead-coherence
 # keyword set). seed-digest-notifications.mjs ALSO imports it directly.
 # Without this COPY, the cron crashes at startup with ERR_MODULE_NOT_FOUND

--- a/Dockerfile.digest-notifications
+++ b/Dockerfile.digest-notifications
@@ -71,6 +71,9 @@ COPY shared/brief-filter.js shared/brief-filter.d.ts ./shared/
 # See feedback_validation_docker_ship_full_scripts_dir.md — the tight COPY
 # list keeps biting whenever a shared/*.js file gets a new cross-file import.
 COPY shared/url-classifier.js ./shared/
+# brief-filter.js and digest compose paths import ephemeral-live-classifier.js
+# to drop expiring WATCH LIVE / live-event programming from delayed briefs.
+COPY shared/ephemeral-live-classifier.js ./shared/
 # brief-filter.js imports diplomacy-keywords.json (canonical lead-coherence
 # keyword set). seed-digest-notifications.mjs ALSO imports it directly.
 # Without this COPY, the cron crashes at startup with ERR_MODULE_NOT_FOUND

--- a/scripts/lib/brief-compose.mjs
+++ b/scripts/lib/brief-compose.mjs
@@ -23,6 +23,7 @@ import {
   filterTopStories,
   issueDateInTz,
 } from '../../shared/brief-filter.js';
+import { classifyEphemeralLiveCoverage } from '../../shared/ephemeral-live-classifier.js';
 import { sanitizeForPrompt, sanitizeHeadline } from '../../server/_shared/llm-sanitize.js';
 
 // ── Rule dedupe (one brief per user, not per variant) ───────────────────────
@@ -754,6 +755,7 @@ function digestStoryToUpstreamTopStory(s) {
   // become "Philippine senator flees ICC arrest".
   const cleanTitle = stripHeadlineSuffix(stripHeadlinePrefix(rawTitle), primarySource);
   const rawDescription = typeof s?.description === 'string' ? s.description.trim() : '';
+  const primaryLink = typeof s?.link === 'string' ? s.link : undefined;
   return {
     primaryTitle: cleanTitle,
     // When upstream persists a real RSS description (via story:track:v1
@@ -762,7 +764,15 @@ function digestStoryToUpstreamTopStory(s) {
     // something to ground on.
     description: rawDescription || cleanTitle,
     primarySource,
-    primaryLink: typeof s?.link === 'string' ? s.link : undefined,
+    primaryLink,
+    // Preserve the raw-title verdict across display cleanup. Without this,
+    // "Watch: Press conference live" would be stripped to "Press conference
+    // live" before filterTopStories can tell it was an expiring viewing invite.
+    isEphemeralLiveCoverage: classifyEphemeralLiveCoverage({
+      title: rawTitle,
+      link: primaryLink,
+      description: rawDescription,
+    }),
     threatLevel: s?.severity,
     importanceScore: Number.isFinite(Number(s?.currentScore)) ? Number(s.currentScore) : undefined,
     // Transient coherence signal from story:track:v1. Not written into

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -82,6 +82,17 @@ import { readCooldownConfig } from './lib/digest-cooldown-config.mjs';
 import { evaluateCooldown } from './lib/digest-cooldown-decision.mjs';
 import { emitCooldownShadowLog } from './lib/digest-cooldown-shadow-log.mjs';
 
+const EPHEMERAL_LIVE_LOG_TITLE_SAMPLE_LIMIT = 5;
+const EPHEMERAL_LIVE_LOG_TITLE_MAX_CHARS = 160;
+
+function compactDroppedEphemeralLiveTitle(title) {
+  const compact = String(title ?? '').replace(/\s+/g, ' ').trim();
+  if (!compact) return '<missing title>';
+  return compact.length > EPHEMERAL_LIVE_LOG_TITLE_MAX_CHARS
+    ? `${compact.slice(0, EPHEMERAL_LIVE_LOG_TITLE_MAX_CHARS - 3)}...`
+    : compact;
+}
+
 // ── Config ────────────────────────────────────────────────────────────────────
 
 const UPSTASH_URL = process.env.UPSTASH_REDIS_REST_URL ?? '';
@@ -561,6 +572,7 @@ async function buildDigest(rule, windowStartMs) {
   let droppedOpinion = 0;
   let droppedFeelGood = 0;
   let droppedEphemeralLive = 0;
+  const droppedEphemeralLiveTitleSamples = [];
   for (let i = 0; i < hashes.length; i++) {
     const raw = trackResults[i]?.result;
     if (!Array.isArray(raw) || raw.length === 0) continue;
@@ -641,6 +653,9 @@ async function buildDigest(rule, windowStartMs) {
       }))
     ) {
       droppedEphemeralLive++;
+      if (droppedEphemeralLiveTitleSamples.length < EPHEMERAL_LIVE_LOG_TITLE_SAMPLE_LIMIT) {
+        droppedEphemeralLiveTitleSamples.push(compactDroppedEphemeralLiveTitle(track.title));
+      }
       continue;
     }
 
@@ -703,10 +718,14 @@ async function buildDigest(rule, windowStartMs) {
   }
 
   if (droppedEphemeralLive > 0) {
+    const titleSampleSuffix = droppedEphemeralLiveTitleSamples.length > 0
+      ? ` sample_titles=${JSON.stringify(droppedEphemeralLiveTitleSamples)}`
+      : '';
     console.log(
       `[digest] buildDigest ephemeral-live filter dropped ${droppedEphemeralLive} ` +
         `live-programming teaser(s) from the pool (variant=${rule.variant ?? 'full'} ` +
-        `lang=${rule.lang ?? 'en'} sensitivity=${rule.sensitivity ?? 'high'})`,
+        `lang=${rule.lang ?? 'en'} sensitivity=${rule.sensitivity ?? 'high'})` +
+        titleSampleSuffix,
     );
   }
 

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -34,6 +34,7 @@ const { normalizeResendSender } = require('./lib/resend-from.cjs');
 import { readRawJsonFromUpstash, redisPipeline } from '../api/_upstash-json.js';
 import { classifyOpinion } from '../server/_shared/opinion-classifier.js';
 import { classifyFeelGood } from '../server/_shared/feelgood-classifier.js';
+import { classifyEphemeralLiveCoverage } from '../shared/ephemeral-live-classifier.js';
 import {
   composeBriefFromDigestStories,
   compareRules,
@@ -559,6 +560,7 @@ async function buildDigest(rule, windowStartMs) {
   let droppedStaleAtRead = 0;
   let droppedOpinion = 0;
   let droppedFeelGood = 0;
+  let droppedEphemeralLive = 0;
   for (let i = 0; i < hashes.length; i++) {
     const raw = trackResults[i]?.result;
     if (!Array.isArray(raw) || raw.length === 0) continue;
@@ -621,6 +623,27 @@ async function buildDigest(rule, windowStartMs) {
       continue;
     }
 
+    // Ephemeral live-programming exclusion. This is intentionally a digest/
+    // brief read-path filter, not a global news-feed drop: live video teasers
+    // can be acceptable inside a live news surface, but a delayed daily brief
+    // should not tell readers hours later to "WATCH LIVE" a briefing that may
+    // address something.
+    const stampedEphemeralLive = track.isEphemeralLiveCoverage === '1';
+    const ephemeralLiveStampMissing =
+      typeof track.isEphemeralLiveCoverage !== 'string' ||
+      track.isEphemeralLiveCoverage.length === 0;
+    if (
+      stampedEphemeralLive ||
+      (ephemeralLiveStampMissing && classifyEphemeralLiveCoverage({
+        title: track.title,
+        link: track.link ?? '',
+        description: typeof track.description === 'string' ? track.description : '',
+      }))
+    ) {
+      droppedEphemeralLive++;
+      continue;
+    }
+
     const phase = derivePhase(track);
     if (phase === 'fading') continue;
     if (!matchesSensitivity(rule.sensitivity ?? 'high', track.severity)) continue;
@@ -675,6 +698,14 @@ async function buildDigest(rule, windowStartMs) {
     console.log(
       `[digest] buildDigest feel-good filter dropped ${droppedFeelGood} ` +
         `feel-good/lifestyle item(s) from the pool (variant=${rule.variant ?? 'full'} ` +
+        `lang=${rule.lang ?? 'en'} sensitivity=${rule.sensitivity ?? 'high'})`,
+    );
+  }
+
+  if (droppedEphemeralLive > 0) {
+    console.log(
+      `[digest] buildDigest ephemeral-live filter dropped ${droppedEphemeralLive} ` +
+        `live-programming teaser(s) from the pool (variant=${rule.variant ?? 'full'} ` +
         `lang=${rule.lang ?? 'en'} sensitivity=${rule.sensitivity ?? 'high'})`,
     );
   }
@@ -1805,6 +1836,7 @@ async function composeAndStoreBriefForUser(userId, annotated, insightsNumbers, d
     cap: 0,
     source_topic_cap: 0,
     institutional_static_page: 0,
+    ephemeral_live: 0,
     in: winnerStories.length,
   };
   const orderStats = {
@@ -1863,6 +1895,7 @@ async function composeAndStoreBriefForUser(userId, annotated, insightsNumbers, d
       `dropped_cap=${dropStats.cap} ` +
       `dropped_source_topic_cap=${dropStats.source_topic_cap} ` +
       `dropped_institutional_static_page=${dropStats.institutional_static_page} ` +
+      `dropped_ephemeral_live=${dropStats.ephemeral_live} ` +
       `out=${out}`,
   );
 

--- a/server/_shared/cache-keys.ts
+++ b/server/_shared/cache-keys.ts
@@ -1,6 +1,7 @@
 // ── Story persistence tracking keys (E3) ─────────────────────────────────────
 // Hash: firstSeen, lastSeen, mentionCount, sourceCount, currentScore, peakScore,
-//       title, link, severity, lang, description, isOpinion, isFeelGood, category
+//       title, link, severity, lang, description, isOpinion, isFeelGood,
+//       isEphemeralLiveCoverage, category
 // description is authoritative per-mention: written unconditionally on every
 // HSET (empty string when the current mention has no body), so an earlier
 // mention's body never silently grounds LLMs for the current mention.
@@ -16,7 +17,7 @@ export const DIGEST_ACCUMULATOR_KEY_PREFIX = 'digest:accumulator:v1:';
  * Story tracking keys — written by list-feed-digest.ts, read by digest cron (E2).
  * All keys use 32-char SHA-256 hex prefix of the normalised title as ${titleHash}.
  *
- *   story:track:v1:${titleHash}     Hash   firstSeen/lastSeen/title/link/severity/mentionCount/currentScore/lang/description/isOpinion/isFeelGood/category (always-written)
+ *   story:track:v1:${titleHash}     Hash   firstSeen/lastSeen/title/link/severity/mentionCount/currentScore/lang/description/isOpinion/isFeelGood/isEphemeralLiveCoverage/category (always-written)
  *   story:sources:v1:${titleHash}   Set    feed IDs (SADD per appearance)
  *   story:peak:v1:${titleHash}      ZSet   single member "peak", score = highest importanceScore (ZADD GT)
  *   digest:accumulator:v1:${variant}:${lang} ZSet  member=titleHash, score=lastSeen_ms (updated every appearance)

--- a/server/worldmonitor/news/v1/list-feed-digest.ts
+++ b/server/worldmonitor/news/v1/list-feed-digest.ts
@@ -16,6 +16,7 @@ import { VARIANT_FEEDS, INTEL_SOURCES, type ServerFeed } from './_feeds';
 import { classifyByKeyword, hasHistoricalMarker, type ThreatLevel } from './_classifier';
 import { classifyOpinion } from '../../../_shared/opinion-classifier.js';
 import { classifyFeelGood } from '../../../_shared/feelgood-classifier.js';
+import { classifyEphemeralLiveCoverage } from '../../../../shared/ephemeral-live-classifier.js';
 import { buildClassifyCacheKey } from '../../intelligence/v1/_shared';
 import { getSourceTier } from '../../../_shared/source-tiers';
 import {
@@ -184,6 +185,11 @@ interface ParsedItem {
   // event. See docs/plans/2026-05-17-001-fix-feelgood-lifestyle-filter-plan.md
   // (Veterans-warplanes anchor case, May 17 0802 brief).
   isFeelGood: boolean;
+  // Ephemeral live-programming classification. "WATCH LIVE: ..." and
+  // live briefing/hearing previews are not durable event stories for a
+  // delayed digest/brief, even when conflict vocabulary makes them score high.
+  // Stamped here and re-classified by buildDigest for pre-stamp residue.
+  isEphemeralLiveCoverage: boolean;
 }
 
 const MAX_DESCRIPTION_LEN = 400;
@@ -383,26 +389,24 @@ async function fetchAndParseRss(
   variant: string,
   signal: AbortSignal,
 ): Promise<ParseResult> {
-  // v4 cache shape: identical struct to v3 but a new prefix invalidates
-  // every pre-fix entry on deploy. v3 entries cached pre-PR contain
-  // ParsedItems without the new isFeelGood field. If a cache hit
+  // v5 cache shape: identical struct to v4 but a new prefix invalidates
+  // every pre-fix entry on deploy. v4 entries cached pre-PR contain
+  // ParsedItems without the new isEphemeralLiveCoverage field. If a cache hit
   // returned one of those, buildStoryTrackHsetFields would write
-  // `'isFeelGood', undefined ? '1' : '0'` → '0' onto the story:track:v1
-  // row, and buildDigest's `stampMissing = typeof !== 'string' || length === 0`
-  // check would treat '0' as a genuine "not feel-good" verdict and
-  // skip the residue catch. Feel-good content could then silently slip
-  // through during the 1h healthy-cache rollout window. Bumping the
-  // prefix forces cold parseRssXml runs that stamp isFeelGood correctly.
+  // `'isEphemeralLiveCoverage', undefined ? '1' : '0'` → '0' onto the
+  // story:track:v1 row, and buildDigest's stampMissing check would treat
+  // '0' as a genuine "not ephemeral live" verdict and skip the residue catch.
+  // Live-programming teasers could then silently slip through during the 1h
+  // healthy-cache rollout window. Bumping the prefix forces cold parseRssXml
+  // runs that stamp isEphemeralLiveCoverage correctly.
   //
-  // (Same class of cache-prefix bump as v2→v3, which this codebase
+  // (Same class of cache-prefix bump as v2→v3 and v3→v4, which this codebase
   // already established as the correct cutover pattern for parsed-cache
-  // shape changes. The same bug exists latently in PR #3690's isOpinion
-  // path; a separate backport bumps the prefix once rather than for
-  // every sibling classifier — out of scope for this PR.)
-  const cacheKey = `rss:feed:v4:${variant}:${feed.url}`;
+  // shape changes.)
+  const cacheKey = `rss:feed:v5:${variant}:${feed.url}`;
 
   try {
-    // Read cache unconditionally — the v3 prefix guarantees pre-fix
+    // Read cache unconditionally — the v5 prefix guarantees pre-fix
     // poisoning can't reach this read, so we don't need a parsedTotal
     // bypass. Honoring cached zero-from-zero entries IS the throttle:
     // setCachedJson below writes them with CACHE_TTL_EMPTY_S, so the next
@@ -576,6 +580,7 @@ function parseRssXml(xml: string, feed: ServerFeed, variant: string): ParseResul
       description,
       isOpinion: classifyOpinion({ title, link, description }),
       isFeelGood: classifyFeelGood({ title, link, description }),
+      isEphemeralLiveCoverage: classifyEphemeralLiveCoverage({ title, link, description }),
     });
   }
 
@@ -1086,6 +1091,11 @@ function buildStoryTrackHsetFields(
     // exclusion. Pre-stamp rows are re-classified by buildDigest from
     // title/link/description (residue catch).
     'isFeelGood', item.isFeelGood ? '1' : '0',
+    // Ephemeral live-programming flag (classifyEphemeralLiveCoverage).
+    // Same write semantics as the opinion/feel-good stamps: overwrite on
+    // every mention so a collapsed story row reflects the current headline
+    // verdict; buildDigest re-classifies pre-stamp rows for the TTL window.
+    'isEphemeralLiveCoverage', item.isEphemeralLiveCoverage ? '1' : '0',
     // Event category (classifyByKeyword EventCategory enum, possibly
     // overridden by enrichWithAiCache). Persisted so the brief's
     // threads card + magazine story-page + public-thread fallback

--- a/shared/brief-filter.d.ts
+++ b/shared/brief-filter.d.ts
@@ -43,6 +43,11 @@ export type AlertSensitivity = 'all' | 'high' | 'critical';
  * matches the static-institutional-page denylist (e.g.
  * `defense.gov/About/Section-508/`). Both `severity` and `sourceUrl`
  * are populated.
+ *
+ * `ephemeral_live` fires when a story is a live-programming teaser
+ * ("WATCH LIVE:", live briefing/hearing preview, etc.) rather than a
+ * durable event story suitable for a delayed daily brief. Both
+ * `severity` and `sourceUrl` are populated.
  */
 export type DropMetricsFn = (event: {
   reason:
@@ -52,7 +57,8 @@ export type DropMetricsFn = (event: {
     | 'shape'
     | 'cap'
     | 'source_topic_cap'
-    | 'institutional_static_page';
+    | 'institutional_static_page'
+    | 'ephemeral_live';
   severity?: string;
   sourceUrl?: string;
 }) => void;
@@ -149,6 +155,12 @@ export interface UpstreamTopStory {
    * surfaced story to have a working source link).
    */
   primaryLink?: unknown;
+  /**
+   * Transient raw-title classifier verdict from digestStoryToUpstreamTopStory.
+   * Lets filterTopStories drop "Watch: ... live" rows even after display
+   * cleanup has stripped the "Watch:" prefix from primaryTitle.
+   */
+  isEphemeralLiveCoverage?: unknown;
   description?: unknown;
   threatLevel?: unknown;
   category?: unknown;

--- a/shared/brief-filter.js
+++ b/shared/brief-filter.js
@@ -453,13 +453,15 @@ export function filterTopStories({ stories, sensitivity, maxStories = 12, maxPer
       continue;
     }
 
+    const stampedEphemeralLive = raw.isEphemeralLiveCoverage === true;
+    const ephemeralLiveStampMissing = typeof raw.isEphemeralLiveCoverage !== 'boolean';
     if (
-      raw.isEphemeralLiveCoverage === true ||
-      classifyEphemeralLiveCoverage({
+      stampedEphemeralLive ||
+      (ephemeralLiveStampMissing && classifyEphemeralLiveCoverage({
         title: raw.primaryTitle,
         link: sourceUrl,
         description: raw.description,
-      })
+      }))
     ) {
       if (emit) emit({ reason: 'ephemeral_live', severity: threatLevel, sourceUrl });
       continue;

--- a/shared/brief-filter.js
+++ b/shared/brief-filter.js
@@ -8,6 +8,7 @@
 import { BRIEF_ENVELOPE_VERSION } from './brief-envelope.js';
 import { assertBriefEnvelope } from '../server/_shared/brief-render.js';
 import { isInstitutionalStaticPage } from './url-classifier.js';
+import { classifyEphemeralLiveCoverage } from './ephemeral-live-classifier.js';
 import diplomacyKeywordsData from './diplomacy-keywords.json' with { type: 'json' };
 
 /**
@@ -202,7 +203,7 @@ function titleCase(v) {
 }
 
 /**
- * @typedef {(event: { reason: 'severity'|'headline'|'url'|'shape'|'cap'|'source_topic_cap'|'institutional_static_page', severity?: string, sourceUrl?: string }) => void} DropMetricsFn
+ * @typedef {(event: { reason: 'severity'|'headline'|'url'|'shape'|'cap'|'source_topic_cap'|'institutional_static_page'|'ephemeral_live', severity?: string, sourceUrl?: string }) => void} DropMetricsFn
  */
 
 /**
@@ -449,6 +450,18 @@ export function filterTopStories({ stories, sensitivity, maxStories = 12, maxPer
     const sourceUrl = normaliseSourceUrl(raw.primaryLink);
     if (!sourceUrl) {
       if (emit) emit({ reason: 'url', severity: threatLevel, sourceUrl: typeof raw.primaryLink === 'string' ? raw.primaryLink : undefined });
+      continue;
+    }
+
+    if (
+      raw.isEphemeralLiveCoverage === true ||
+      classifyEphemeralLiveCoverage({
+        title: raw.primaryTitle,
+        link: sourceUrl,
+        description: raw.description,
+      })
+    ) {
+      if (emit) emit({ reason: 'ephemeral_live', severity: threatLevel, sourceUrl });
       continue;
     }
 

--- a/shared/ephemeral-live-classifier.d.ts
+++ b/shared/ephemeral-live-classifier.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Classify whether a story is an expiring live-programming teaser rather than
+ * a durable event suitable for a delayed digest/brief.
+ *
+ * @param story - { title, link, description } — only title is currently used;
+ * link and description are accepted for API symmetry with other classifiers.
+ * @returns true = ephemeral live coverage (exclude from the brief).
+ */
+export function classifyEphemeralLiveCoverage(story: {
+  title?: unknown;
+  link?: unknown;
+  description?: unknown;
+}): boolean;

--- a/shared/ephemeral-live-classifier.js
+++ b/shared/ephemeral-live-classifier.js
@@ -2,7 +2,7 @@
 //
 // The daily digest/brief is delivered after a delay and often read hours
 // later. "Watch live" programming invites and live event previews are not
-// durable intelligence items: once the stream/briefing/hearing has passed, the
+// durable intelligence items: once the livestream/briefing/hearing has passed, the
 // headline is stale even if it contains conflict terms that score as HIGH.
 //
 // Keep this deliberately narrower than stripHeadlinePrefix("Watch:"/"Live:").
@@ -15,9 +15,9 @@ const WATCH_PREFIX_WITH_LIVE_RE = /^\s*watch\s*:\s*.*\blive\b/i;
 
 const LIVE_PREFIX_RE = /^\s*live\s*:\s*/i;
 const LIVE_EVENT_NOUN_RE =
-  /\b(?:briefing|press\s+briefing|press\s+conference|conference|hearing|testimony|remarks|speech|address|town\s+hall|livestream|live\s+stream|stream)\b/i;
+  /\b(?:briefing|press\s+briefing|press\s+conference|conference|hearing|testimony|remarks|speech|address|town\s+hall|livestream|live\s+stream)\b/i;
 const LIVE_PROGRAMMING_VERB_RE =
-  /\b(?:watch|stream|broadcast|airs?|airing|listen|tune\s+in|follow\s+live)\b/i;
+  /\b(?:watch|broadcast|airs?|airing|listen|tune\s+in|follow\s+live)\b/i;
 
 /**
  * Classify whether a story is an expiring live-programming teaser rather than

--- a/shared/ephemeral-live-classifier.js
+++ b/shared/ephemeral-live-classifier.js
@@ -1,0 +1,43 @@
+// Ephemeral live-coverage classifier for the WorldMonitor brief pipeline.
+//
+// The daily digest/brief is delivered after a delay and often read hours
+// later. "Watch live" programming invites and live event previews are not
+// durable intelligence items: once the stream/briefing/hearing has passed, the
+// headline is stale even if it contains conflict terms that score as HIGH.
+//
+// Keep this deliberately narrower than stripHeadlinePrefix("Watch:"/"Live:").
+// A "Watch: tornadoes swirl through Oklahoma" video can still describe a
+// concrete event; "WATCH LIVE: White House briefing..." is an expiring viewing
+// instruction.
+
+const WATCH_LIVE_PREFIX_RE = /^\s*(?:watch\s+live|watch\s*:\s*live)\b[\s:;\-–—]*/i;
+const WATCH_PREFIX_WITH_LIVE_RE = /^\s*watch\s*:\s*.*\blive\b/i;
+
+const LIVE_PREFIX_RE = /^\s*live\s*:\s*/i;
+const LIVE_EVENT_NOUN_RE =
+  /\b(?:briefing|press\s+briefing|press\s+conference|conference|hearing|testimony|remarks|speech|address|town\s+hall|livestream|live\s+stream|stream)\b/i;
+const LIVE_PROGRAMMING_VERB_RE =
+  /\b(?:watch|stream|broadcast|airs?|airing|listen|tune\s+in|follow\s+live)\b/i;
+
+/**
+ * Classify whether a story is an expiring live-programming teaser rather than
+ * a durable event suitable for a delayed digest/brief.
+ *
+ * @param {{ title?: unknown; link?: unknown; description?: unknown }} story
+ * @returns {boolean} true = ephemeral live coverage (exclude from the brief).
+ */
+export function classifyEphemeralLiveCoverage(story) {
+  const title = typeof story?.title === 'string' ? story.title.trim() : '';
+  if (!title) return false;
+
+  if (WATCH_LIVE_PREFIX_RE.test(title)) return true;
+  if (WATCH_PREFIX_WITH_LIVE_RE.test(title)) return true;
+
+  if (LIVE_PREFIX_RE.test(title)) {
+    const afterPrefix = title.replace(LIVE_PREFIX_RE, '').trim();
+    if (LIVE_EVENT_NOUN_RE.test(afterPrefix)) return true;
+    if (LIVE_PROGRAMMING_VERB_RE.test(afterPrefix)) return true;
+  }
+
+  return false;
+}

--- a/tests/brief-filter.test.mjs
+++ b/tests/brief-filter.test.mjs
@@ -499,6 +499,24 @@ describe('filterTopStories — onDrop metrics', () => {
     assert.equal(calls[0].sourceUrl, 'ftp://bad');
   });
 
+  it('fires onDrop with reason=ephemeral_live for expiring live-programming teasers', () => {
+    const calls = [];
+    filterTopStories({
+      stories: [
+        upstreamStory({
+          primaryTitle: "WATCH LIVE: White House briefing with Dr. Oz may address Pulte's new role, Iran war",
+          primaryLink: 'https://example.com/watch-live-white-house-briefing',
+        }),
+      ],
+      sensitivity,
+      onDrop: (ev) => calls.push(ev),
+    });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].reason, 'ephemeral_live');
+    assert.equal(calls[0].severity, 'high');
+    assert.equal(calls[0].sourceUrl, 'https://example.com/watch-live-white-house-briefing');
+  });
+
   it('fires onDrop with reason=shape for non-object input', () => {
     const calls = [];
     filterTopStories({
@@ -591,7 +609,7 @@ describe('filterTopStories — onDrop metrics', () => {
 
   it('reconciliation invariant: in === out + sum(dropped_*) across all reasons', () => {
     // Locks in the operator-facing invariant that motivated adding `cap`.
-    const tally = { severity: 0, headline: 0, url: 0, shape: 0, cap: 0, source_topic_cap: 0, institutional_static_page: 0 };
+    const tally = { severity: 0, headline: 0, url: 0, shape: 0, cap: 0, source_topic_cap: 0, institutional_static_page: 0, ephemeral_live: 0 };
     const stories = [
       upstreamStory({ primaryTitle: 'A' }),
       upstreamStory({ primaryTitle: 'B' }),
@@ -614,7 +632,7 @@ describe('filterTopStories — onDrop metrics', () => {
       maxPerSourceTopic: Infinity,
       onDrop: (ev) => { tally[ev.reason]++; },
     });
-    const totalDrops = tally.severity + tally.headline + tally.url + tally.shape + tally.cap + tally.source_topic_cap + tally.institutional_static_page;
+    const totalDrops = tally.severity + tally.headline + tally.url + tally.shape + tally.cap + tally.source_topic_cap + tally.institutional_static_page + tally.ephemeral_live;
     assert.equal(stories.length, out.length + totalDrops);
   });
 });

--- a/tests/brief-filter.test.mjs
+++ b/tests/brief-filter.test.mjs
@@ -517,6 +517,24 @@ describe('filterTopStories — onDrop metrics', () => {
     assert.equal(calls[0].sourceUrl, 'https://example.com/watch-live-white-house-briefing');
   });
 
+  it('trusts explicit false isEphemeralLiveCoverage stamps before fallback classification', () => {
+    const calls = [];
+    const out = filterTopStories({
+      stories: [
+        upstreamStory({
+          primaryTitle: "WATCH LIVE: White House briefing with Dr. Oz may address Pulte's new role, Iran war",
+          primaryLink: 'https://example.com/explicit-durable-watch-live',
+          isEphemeralLiveCoverage: false,
+        }),
+      ],
+      sensitivity,
+      onDrop: (ev) => calls.push(ev),
+    });
+    assert.equal(out.length, 1);
+    assert.equal(out[0].sourceUrl, 'https://example.com/explicit-durable-watch-live');
+    assert.equal(calls.length, 0);
+  });
+
   it('fires onDrop with reason=shape for non-object input', () => {
     const calls = [];
     filterTopStories({

--- a/tests/brief-from-digest-stories.test.mjs
+++ b/tests/brief-from-digest-stories.test.mjs
@@ -643,6 +643,46 @@ describe('composeBriefFromDigestStories — continued', () => {
     assert.deepEqual(env.data.stories.map((s) => s.headline), ['A', 'B']);
   });
 
+  it('drops WATCH LIVE programming teasers before they become brief cards', () => {
+    const drops = [];
+    const env = composeBriefFromDigestStories(
+      rule(),
+      [
+        digestStory({
+          title: "WATCH LIVE: White House briefing with Dr. Oz may address Pulte's new role, Iran war",
+          link: 'https://example.com/watch-live-white-house-briefing',
+          sources: ['CBS News'],
+          severity: 'high',
+        }),
+      ],
+      { clusters: 1, multiSource: 0 },
+      { nowMs: NOW, onDrop: (ev) => drops.push(ev) },
+    );
+    assert.equal(env, null);
+    assert.equal(drops.length, 1);
+    assert.equal(drops[0].reason, 'ephemeral_live');
+  });
+
+  it('drops Watch: live teasers even though display cleanup would strip Watch:', () => {
+    const drops = [];
+    const env = composeBriefFromDigestStories(
+      rule(),
+      [
+        digestStory({
+          title: 'Watch: Press conference live',
+          link: 'https://example.com/watch-press-conference-live',
+          sources: ['Reuters'],
+          severity: 'high',
+        }),
+      ],
+      { clusters: 1, multiSource: 0 },
+      { nowMs: NOW, onDrop: (ev) => drops.push(ev) },
+    );
+    assert.equal(env, null);
+    assert.equal(drops.length, 1);
+    assert.equal(drops[0].reason, 'ephemeral_live');
+  });
+
   it('caps at 12 stories per brief by default (env-tunable via DIGEST_MAX_STORIES_PER_USER)', () => {
     // Default kept at 12. Offline sweep harness against 2026-04-24
     // production replay showed cap=16 dropped visible_quality from

--- a/tests/digest-buildDigest-ephemeral-live-filter.test.mjs
+++ b/tests/digest-buildDigest-ephemeral-live-filter.test.mjs
@@ -36,8 +36,11 @@ describe('buildDigest ephemeral-live filter wiring', () => {
 
   it('declares and logs the droppedEphemeralLive counter', () => {
     assert.ok(buildDigestBody.includes('let droppedEphemeralLive = 0;'));
+    assert.ok(buildDigestBody.includes('const droppedEphemeralLiveTitleSamples = [];'));
+    assert.ok(buildDigestBody.includes('compactDroppedEphemeralLiveTitle(track.title)'));
     assert.ok(seedSrc.includes('[digest] buildDigest ephemeral-live filter dropped '));
     assert.ok(seedSrc.includes('live-programming teaser(s) from the pool'));
+    assert.ok(seedSrc.includes('sample_titles=${JSON.stringify(droppedEphemeralLiveTitleSamples)}'));
   });
 
   it('trusts the ingest stamp and re-classifies stamp-missing residue rows', () => {

--- a/tests/digest-buildDigest-ephemeral-live-filter.test.mjs
+++ b/tests/digest-buildDigest-ephemeral-live-filter.test.mjs
@@ -1,0 +1,74 @@
+// Source-textual guard for buildDigest's ephemeral live-coverage filter.
+//
+// buildDigest is not exported from scripts/seed-digest-notifications.mjs.
+// The pure classifier behavior is covered in
+// tests/ephemeral-live-classifier.test.mjs; this file locks the digest
+// read-path wiring that keeps pre-stamp Redis residue out of delayed briefs.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const seedSrc = readFileSync(
+  resolve(__dirname, '..', 'scripts', 'seed-digest-notifications.mjs'),
+  'utf-8',
+);
+
+const buildDigestStart = seedSrc.indexOf('async function buildDigest(rule, windowStartMs)');
+const afterBuildDigest = seedSrc.indexOf('\nfunction ', buildDigestStart + 1);
+const afterBuildDigestAsync = seedSrc.indexOf('\nasync function ', buildDigestStart + 1);
+const buildDigestEnd = Math.min(
+  afterBuildDigest === -1 ? Number.POSITIVE_INFINITY : afterBuildDigest,
+  afterBuildDigestAsync === -1 ? Number.POSITIVE_INFINITY : afterBuildDigestAsync,
+);
+const buildDigestBody = seedSrc.slice(buildDigestStart, buildDigestEnd);
+
+describe('buildDigest ephemeral-live filter wiring', () => {
+  it('imports classifyEphemeralLiveCoverage from the shared classifier', () => {
+    assert.ok(
+      seedSrc.includes("import { classifyEphemeralLiveCoverage } from '../shared/ephemeral-live-classifier.js'"),
+      'must import the same classifier used by ingest and compose',
+    );
+  });
+
+  it('declares and logs the droppedEphemeralLive counter', () => {
+    assert.ok(buildDigestBody.includes('let droppedEphemeralLive = 0;'));
+    assert.ok(seedSrc.includes('[digest] buildDigest ephemeral-live filter dropped '));
+    assert.ok(seedSrc.includes('live-programming teaser(s) from the pool'));
+  });
+
+  it('trusts the ingest stamp and re-classifies stamp-missing residue rows', () => {
+    assert.ok(
+      buildDigestBody.includes("track.isEphemeralLiveCoverage === '1'"),
+      'must trust ingest-time isEphemeralLiveCoverage=1',
+    );
+    assert.ok(
+      /typeof\s+track\.isEphemeralLiveCoverage\s*!==\s*'string'\s*\|\|\s*track\.isEphemeralLiveCoverage\.length\s*===\s*0/.test(buildDigestBody),
+      'missing/non-string stamp must be residue-eligible',
+    );
+    assert.ok(
+      /classifyEphemeralLiveCoverage\(\{[\s\S]*?title:\s*track\.title/.test(buildDigestBody),
+      'must re-classify residue using the persisted title',
+    );
+    assert.ok(
+      /classifyEphemeralLiveCoverage\(\{[\s\S]*?link:\s*track\.link\s*\?\?\s*''/.test(buildDigestBody),
+      'must pass track.link ?? "" to the residue classifier',
+    );
+    assert.ok(
+      /classifyEphemeralLiveCoverage\(\{[\s\S]*?description:\s*typeof\s+track\.description\s*===\s*'string'\s*\?\s*track\.description\s*:\s*''/.test(buildDigestBody),
+      'must defensively pass track.description as string',
+    );
+  });
+
+  it('runs before phase/sensitivity filtering so live teasers never enter the digest pool', () => {
+    const ephemeralIdx = buildDigestBody.indexOf('classifyEphemeralLiveCoverage(');
+    const derivePhaseIdx = buildDigestBody.indexOf('derivePhase(');
+    const matchesSensitivityIdx = buildDigestBody.indexOf('matchesSensitivity(');
+    assert.ok(ephemeralIdx !== -1, 'classifier call must exist');
+    assert.ok(ephemeralIdx < derivePhaseIdx, 'ephemeral filter precedes derivePhase');
+    assert.ok(ephemeralIdx < matchesSensitivityIdx, 'ephemeral filter precedes matchesSensitivity');
+  });
+});

--- a/tests/ephemeral-live-classifier.test.mjs
+++ b/tests/ephemeral-live-classifier.test.mjs
@@ -33,11 +33,27 @@ describe('classifyEphemeralLiveCoverage', () => {
       true,
     );
     assert.equal(
+      classifyEphemeralLiveCoverage({ title: 'LIVE: live stream of Senate hearing' }),
+      true,
+    );
+    assert.equal(
+      classifyEphemeralLiveCoverage({ title: 'LIVE: livestream of Senate hearing' }),
+      true,
+    );
+    assert.equal(
       classifyEphemeralLiveCoverage({ title: 'Live updates: Iran launches new missile barrage' }),
       false,
     );
     assert.equal(
       classifyEphemeralLiveCoverage({ title: 'Live broadcasts paused during emergency' }),
+      false,
+    );
+    assert.equal(
+      classifyEphemeralLiveCoverage({ title: 'Live: stream of refugees crosses border' }),
+      false,
+    );
+    assert.equal(
+      classifyEphemeralLiveCoverage({ title: 'Live: data stream shows outage expanding' }),
       false,
     );
   });

--- a/tests/ephemeral-live-classifier.test.mjs
+++ b/tests/ephemeral-live-classifier.test.mjs
@@ -1,0 +1,50 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyEphemeralLiveCoverage } from '../shared/ephemeral-live-classifier.js';
+
+describe('classifyEphemeralLiveCoverage', () => {
+  it('drops WATCH LIVE programming teasers that become stale by digest time', () => {
+    assert.equal(
+      classifyEphemeralLiveCoverage({
+        title: "WATCH LIVE: White House briefing with Dr. Oz may address Pulte's new role, Iran war",
+      }),
+      true,
+    );
+    assert.equal(
+      classifyEphemeralLiveCoverage({ title: 'Watch live as the president addresses reporters' }),
+      true,
+    );
+  });
+
+  it('drops Watch: headlines only when they are explicitly live programming', () => {
+    assert.equal(
+      classifyEphemeralLiveCoverage({ title: 'Watch: Press conference live' }),
+      true,
+    );
+    assert.equal(
+      classifyEphemeralLiveCoverage({ title: 'Watch: tornadoes swirl through Oklahoma' }),
+      false,
+    );
+  });
+
+  it('drops Live: event broadcasts but preserves live-update hard-news blogs', () => {
+    assert.equal(
+      classifyEphemeralLiveCoverage({ title: 'LIVE: Senate hearing on Iran policy' }),
+      true,
+    );
+    assert.equal(
+      classifyEphemeralLiveCoverage({ title: 'Live updates: Iran launches new missile barrage' }),
+      false,
+    );
+    assert.equal(
+      classifyEphemeralLiveCoverage({ title: 'Live broadcasts paused during emergency' }),
+      false,
+    );
+  });
+
+  it('handles missing and non-string values without throwing', () => {
+    assert.equal(classifyEphemeralLiveCoverage({}), false);
+    assert.equal(classifyEphemeralLiveCoverage({ title: null }), false);
+    assert.equal(classifyEphemeralLiveCoverage({ title: 42 }), false);
+  });
+});

--- a/tests/news-rss-description-extract.test.mts
+++ b/tests/news-rss-description-extract.test.mts
@@ -241,6 +241,29 @@ describe('parseRssXml — integration with description', () => {
     assert.strictEqual(items[1]!.isFeelGood, true, 'Veterans-warplanes item is feel-good (STRONG /features/ URL)');
   });
 
+  it('every ParsedItem carries an isEphemeralLiveCoverage flag for delayed brief exclusion', () => {
+    const xml = wrapRss(`
+      <item>
+        <title>WATCH LIVE: White House briefing with Dr. Oz may address Pulte's new role, Iran war</title>
+        <link>https://news.example.com/video/watch-live-white-house-briefing</link>
+        <pubDate>Thu, 24 Apr 2026 08:01:00 GMT</pubDate>
+        <description><![CDATA[<p>The White House briefing is being carried live this afternoon.</p>]]></description>
+      </item>
+      <item>
+        <title>Live updates: Iran launches new missile barrage</title>
+        <link>https://news.example.com/world/live-updates-iran-missiles</link>
+        <pubDate>Thu, 24 Apr 2026 08:02:00 GMT</pubDate>
+        <description><![CDATA[<p>Officials reported new launches and air-defense interceptions.</p>]]></description>
+      </item>
+    `);
+    const result = parseRssXml(xml, FEED, 'full');
+    assert.ok(result);
+    const items = result!.items;
+    assert.strictEqual(items.length, 2);
+    assert.strictEqual(items[0]!.isEphemeralLiveCoverage, true, 'WATCH LIVE teaser is ephemeral');
+    assert.strictEqual(items[1]!.isEphemeralLiveCoverage, false, 'live-update hard news is preserved');
+  });
+
   it('Atom feed ParsedItems carry a description field from <summary>/<content>', () => {
     const xml = wrapAtom(`
       <entry>

--- a/tests/news-story-track-description-persistence.test.mts
+++ b/tests/news-story-track-description-persistence.test.mts
@@ -40,6 +40,7 @@ function baseItem(overrides: Record<string, unknown> = {}) {
     description: '',
     isOpinion: false,
     isFeelGood: false,
+    isEphemeralLiveCoverage: false,
     ...overrides,
   };
 }
@@ -99,7 +100,7 @@ describe('buildStoryTrackHsetFields — story:track:v1 HSET contract', () => {
     // ParseResult with isFeelGood-less items writing '0' onto fresh
     // story:track:v1 rows, defeating buildDigest's residue catch) is
     // closed by the rss:feed:v4 cache-prefix bump in fetchAndParseRss —
-    // see test "rss:feed cache prefix is v4 (post-isFeelGood)" below.
+    // see test "rss:feed cache prefix is v5" below.
     // After the bump, no cached pre-PR ParseResult can reach this code
     // path: every cache miss forces a fresh parseRssXml run that
     // stamps isFeelGood correctly. Genuinely-pre-existing story:track:v1
@@ -110,6 +111,25 @@ describe('buildStoryTrackHsetFields — story:track:v1 HSET contract', () => {
     delete (legacyItem as Record<string, unknown>).isFeelGood;
     assert.strictEqual(
       fieldsToMap(buildStoryTrackHsetFields(legacyItem as Parameters<typeof buildStoryTrackHsetFields>[0], '1745000000000', 42)).get('isFeelGood'),
+      '0',
+    );
+  });
+
+  it('writes isEphemeralLiveCoverage as "1" / "0" — stamps expiring live-programming teasers', () => {
+    const liveItem = baseItem({ isEphemeralLiveCoverage: true });
+    assert.strictEqual(
+      fieldsToMap(buildStoryTrackHsetFields(liveItem, '1745000000000', 42)).get('isEphemeralLiveCoverage'),
+      '1',
+    );
+    const durableItem = baseItem({ isEphemeralLiveCoverage: false });
+    assert.strictEqual(
+      fieldsToMap(buildStoryTrackHsetFields(durableItem, '1745000000000', 42)).get('isEphemeralLiveCoverage'),
+      '0',
+    );
+    const legacyItem = baseItem();
+    delete (legacyItem as Record<string, unknown>).isEphemeralLiveCoverage;
+    assert.strictEqual(
+      fieldsToMap(buildStoryTrackHsetFields(legacyItem as Parameters<typeof buildStoryTrackHsetFields>[0], '1745000000000', 42)).get('isEphemeralLiveCoverage'),
       '0',
     );
   });
@@ -326,29 +346,30 @@ describe('buildStoryTrackHsetFields — story:track:v1 HSET contract', () => {
 });
 
 describe('fetchAndParseRss — cache prefix invalidation contract', () => {
-  it('rss:feed cache prefix is v4 (post-isFeelGood), not v3 (pre-isFeelGood)', () => {
-    // Pre-PR ParsedItems cached at rss:feed:v3 lack the isFeelGood
-    // field. If a cache hit returned one of those, the falsy-coerce in
+  it('rss:feed cache prefix is v5 (post-isEphemeralLiveCoverage), not v4', () => {
+    // Pre-PR ParsedItems cached at rss:feed:v4 lack the
+    // isEphemeralLiveCoverage field. If a cache hit returned one of those,
+    // the falsy-coerce in
     // buildStoryTrackHsetFields would stamp '0' onto the row, and
     // buildDigest's stampMissing check (`typeof !== 'string' || length === 0`)
-    // would treat '0' as a genuine "not feel-good" verdict — defeating
-    // the residue catch for the 1h healthy-cache rollout window. The v4
+    // would treat '0' as a genuine "not ephemeral-live" verdict — defeating
+    // the residue catch for the 1h healthy-cache rollout window. The v5
     // prefix invalidates every pre-PR entry; cold reads on the first
     // post-deploy cron tick force fresh parseRssXml runs that stamp
-    // isFeelGood correctly. This test locks the cutover so a future
-    // refactor cannot silently revert to v3.
+    // isEphemeralLiveCoverage correctly. This test locks the cutover so a future
+    // refactor cannot silently revert to v4.
     const __dirname = dirname(fileURLToPath(import.meta.url));
     const src = readFileSync(
       resolve(__dirname, '..', 'server', 'worldmonitor', 'news', 'v1', 'list-feed-digest.ts'),
       'utf-8',
     );
     assert.ok(
-      src.includes("`rss:feed:v4:${variant}:${feed.url}`"),
-      'rss:feed cache key must use v4 prefix — see comment above the cacheKey assignment in fetchAndParseRss',
+      src.includes("`rss:feed:v5:${variant}:${feed.url}`"),
+      'rss:feed cache key must use v5 prefix — see comment above the cacheKey assignment in fetchAndParseRss',
     );
     assert.ok(
-      !src.includes("`rss:feed:v3:${variant}:${feed.url}`"),
-      'must NOT leave a residual v3 cacheKey assignment — would silently revert the cutover',
+      !src.includes("`rss:feed:v4:${variant}:${feed.url}`"),
+      'must NOT leave a residual v4 cacheKey assignment — would silently revert the cutover',
     );
   });
 });


### PR DESCRIPTION
## Summary
- Add a shared ephemeral-live classifier for expiring WATCH LIVE / live-event programming teasers.
- Stamp RSS story tracks with the classifier result, filter stamped and residue rows out of digest assembly, and re-check digest-to-brief conversion before display cleanup strips prefixes.
- Log up to five compact dropped-title samples from digest assembly so rollout false positives are auditable without dumping the whole pool.
- Bump the parsed RSS cache prefix and ship the new shared classifier plus its type declaration in the digest-notifications Docker image.

## Validation
- ./node_modules/.bin/tsx --test tests/ephemeral-live-classifier.test.mjs tests/brief-filter.test.mjs tests/brief-from-digest-stories.test.mjs tests/news-story-track-description-persistence.test.mts tests/news-rss-description-extract.test.mts tests/digest-buildDigest-ephemeral-live-filter.test.mjs tests/dockerfile-digest-notifications-imports.test.mjs
- git diff --check
- normal pre-push hook passed on push, including npm run typecheck, npm run typecheck:api, full unit suite, edge function tests, edge bundle check, markdown/MDX lint, pro-test bundle freshness, and version sync