### PR TITLE
fix(resilience): lazy-load country resilience widget

### DIFF
--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -2579,7 +2579,10 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
       slot.parentNode.replaceChild(next, slot);
       return;
     }
-    slot.replaceChildren(next);
+    if (typeof slot.parentNode?.insertBefore === 'function' && typeof slot.parentNode?.removeChild === 'function') {
+      slot.parentNode.insertBefore(next, slot);
+      slot.parentNode.removeChild(slot);
+    }
   }
 
   private tearDownFollowButton(): void {

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -41,7 +41,6 @@ import type {
 } from '@/services/supply-chain';
 import { fetchMultiSectorCostShock, HS2_SHORT_LABELS } from '@/services/supply-chain';
 import type { MapContainer } from './MapContainer';
-import { ResilienceWidget } from './ResilienceWidget';
 import { dedupeHeadlines } from './CountryDeepDivePanel-news-utils';
 import { renderFollowButton } from '@/utils/follow-button';
 import { renderNotifyCountryLink } from '@/utils/notify-country-link';
@@ -122,7 +121,9 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
   private timelineBody: HTMLElement | null = null;
   private scoreCard: HTMLElement | null = null;
   private factsBody: HTMLElement | null = null;
-  private resilienceWidget: ResilienceWidget | null = null;
+  private resilienceWidget: import('@/components/ResilienceWidget').ResilienceWidget | null = null;
+  private pendingResilienceEnergyMix: CountryEnergyProfileData | null = null;
+  private resilienceWidgetRequestId = 0;
   private energyBody: HTMLElement | null = null;
   private maritimeBody: HTMLElement | null = null;
   private tradeExposureBody: HTMLElement | null = null;
@@ -893,6 +894,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
   public updateEnergyProfile(data: CountryEnergyProfileData): void {
     if (!this.energyBody) return;
     this.renderEnergyProfile(data);
+    this.pendingResilienceEnergyMix = data;
     this.resilienceWidget?.setEnergyMix(data);
   }
 
@@ -2445,9 +2447,8 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
       scoreCard.append(this.makeEmpty(t('countryBrief.ciiUnavailable')));
     }
 
-    this.resilienceWidget = new ResilienceWidget(code);
     const summaryGrid = this.el('div', 'cdp-summary-grid');
-    summaryGrid.append(scoreCard, this.resilienceWidget.getElement());
+    summaryGrid.append(scoreCard, this.renderResilienceWidgetSlot(code));
 
     const bodyGrid = this.el('div', 'cdp-grid');
     const [signalsCard, signalBody] = this.sectionCard(t('countryBrief.activeSignals'));
@@ -2539,8 +2540,46 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
   }
 
   private destroyResilienceWidget(): void {
+    this.resilienceWidgetRequestId += 1;
     this.resilienceWidget?.destroy();
     this.resilienceWidget = null;
+    this.pendingResilienceEnergyMix = null;
+  }
+
+  private renderResilienceWidgetSlot(code: string): HTMLElement {
+    const slot = this.el('div', 'cdp-card resilience-widget');
+    slot.append(this.makeLoading('Loading resilience score...'));
+    const requestId = ++this.resilienceWidgetRequestId;
+
+    import('@/components/ResilienceWidget')
+      .then(({ ResilienceWidget }) => {
+        if (requestId !== this.resilienceWidgetRequestId) return;
+        if (typeof ResilienceWidget !== 'function') return;
+        const widget = new ResilienceWidget(code);
+        this.resilienceWidget = widget;
+        if (this.pendingResilienceEnergyMix) {
+          widget.setEnergyMix(this.pendingResilienceEnergyMix);
+        }
+        this.replaceResilienceSlot(slot, widget.getElement());
+      }, (error) => {
+        if (requestId !== this.resilienceWidgetRequestId) return;
+        console.warn('[CountryDeepDivePanel] Failed to load resilience widget', error);
+        slot.replaceChildren(this.makeEmpty('Resilience score unavailable.'));
+      });
+
+    return slot;
+  }
+
+  private replaceResilienceSlot(slot: HTMLElement, next: HTMLElement): void {
+    if (typeof slot.replaceWith === 'function') {
+      slot.replaceWith(next);
+      return;
+    }
+    if (typeof slot.parentNode?.replaceChild === 'function') {
+      slot.parentNode.replaceChild(next, slot);
+      return;
+    }
+    slot.replaceChildren(next);
   }
 
   private tearDownFollowButton(): void {

--- a/src/components/ResilienceWidget.ts
+++ b/src/components/ResilienceWidget.ts
@@ -206,7 +206,7 @@ export class ResilienceWidget {
         if (gateReason === PanelGateReason.ANONYMOUS) {
           void import('@/services/clerk')
             .then((module) => module.openSignIn())
-            .catch(() => undefined);
+            .catch(() => this.showAuthUnavailable());
           return;
         }
         void this.openUpgradeFlow().catch(() => {
@@ -222,6 +222,17 @@ export class ResilienceWidget {
       h('div', { className: 'panel-locked-desc resilience-widget__gate-desc' }, description),
       button,
     );
+  }
+
+  private async showAuthUnavailable(): Promise<void> {
+    const message = 'Sign-in is temporarily unavailable. Please try again.';
+    try {
+      const { showCheckoutErrorToast } = await import('@/services/checkout-error-toast');
+      showCheckoutErrorToast(message);
+      return;
+    } catch {
+      window.alert(message);
+    }
   }
 
   private renderError(message: string): HTMLElement {

--- a/src/components/ResilienceWidget.ts
+++ b/src/components/ResilienceWidget.ts
@@ -1,10 +1,6 @@
-import { DEFAULT_UPGRADE_PRODUCT } from '@/config/products';
 import { type AuthSession, getAuthState, subscribeAuthState } from '@/services/auth-state';
-import { openSignIn } from '@/services/clerk';
 import { PanelGateReason, getPanelGateReason } from '@/services/panel-gating';
 import { getResilienceScore, type ResilienceDomain, type ResilienceScoreResponse } from '@/services/resilience';
-import { isDesktopRuntime } from '@/services/runtime';
-import { invokeTauri } from '@/services/tauri-bridge';
 import { h, replaceChildren } from '@/utils/dom-utils';
 import {
   type DimensionConfidence,
@@ -208,10 +204,14 @@ export class ResilienceWidget {
       className: 'panel-locked-cta resilience-widget__cta',
       onclick: () => {
         if (gateReason === PanelGateReason.ANONYMOUS) {
-          openSignIn();
+          void import('@/services/clerk')
+            .then((module) => module.openSignIn())
+            .catch(() => undefined);
           return;
         }
-        this.openUpgradeFlow();
+        void this.openUpgradeFlow().catch(() => {
+          window.open('https://worldmonitor.app/pro', '_blank');
+        });
       },
     }, cta) as HTMLButtonElement;
 
@@ -460,14 +460,20 @@ export class ResilienceWidget {
     return h('div', { className: 'cdp-empty' }, text);
   }
 
-  private openUpgradeFlow(): void {
+  private async openUpgradeFlow(): Promise<void> {
+    const [{ DEFAULT_UPGRADE_PRODUCT }, { isDesktopRuntime }] = await Promise.all([
+      import('@/config/products'),
+      import('@/services/runtime'),
+    ]);
+
     if (isDesktopRuntime()) {
-      void invokeTauri<void>('open_url', { url: 'https://worldmonitor.app/pro' })
-        .catch(() => window.open('https://worldmonitor.app/pro', '_blank'));
+      const { invokeTauri } = await import('@/services/tauri-bridge');
+      await invokeTauri<void>('open_url', { url: 'https://worldmonitor.app/pro' })
+        .catch(() => { window.open('https://worldmonitor.app/pro', '_blank'); });
       return;
     }
 
-    import('@/services/checkout')
+    await import('@/services/checkout')
       .then((module) => module.startCheckout(DEFAULT_UPGRADE_PRODUCT))
       .catch(() => {
         window.open('https://worldmonitor.app/pro', '_blank');

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -102,5 +102,4 @@ export * from './ClimateNewsPanel';
 export * from './DiseaseOutbreaksPanel';
 export * from './SocialVelocityPanel';
 export * from './WsbTickerScannerPanel';
-export * from './ResilienceWidget';
 export * from './EnergyCrisisPanel';

--- a/tests/helpers/country-deep-dive-panel-harness.mjs
+++ b/tests/helpers/country-deep-dive-panel-harness.mjs
@@ -161,6 +161,7 @@ async function loadCountryDeepDivePanel() {
     ['@/utils/supplier-route-risk', 'supplier-route-risk-stub'],
     ['@/services/supply-chain', 'supply-chain-stub'],
     ['./ResilienceWidget', 'resilience-widget-stub'],
+    ['@/components/ResilienceWidget', 'resilience-widget-stub'],
     ['@/services/runtime', 'runtime-stub'],
     ['@/generated/client/worldmonitor/intelligence/v1/service_client', 'intelligence-client-stub'],
     ['@/services/panel-gating', 'panel-gating-stub'],

--- a/tests/helpers/country-deep-dive-panel-harness.mjs
+++ b/tests/helpers/country-deep-dive-panel-harness.mjs
@@ -128,11 +128,15 @@ async function loadCountryDeepDivePanel() {
         constructor(code) {
           this.code = code;
           this.destroyCount = 0;
+          this.energyMixData = null;
           this.element = document.createElement('section');
           this.element.className = 'resilience-widget-stub';
           this.element.setAttribute('data-country-code', code);
           this.element.textContent = 'Resilience ' + code;
           state.widgets.push(this);
+        }
+        setEnergyMix(data) {
+          this.energyMixData = data;
         }
         getElement() {
           return this.element;

--- a/tests/resilience-country-brief.test.mjs
+++ b/tests/resilience-country-brief.test.mjs
@@ -38,11 +38,17 @@ const emptySignals = {
   gpsJammingHexes: 0,
 };
 
+async function flushLazyWidget() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 test('country deep-dive panel mounts the resilience widget beside the score card', async () => {
   const harness = await createCountryDeepDivePanelHarness();
   try {
     const panel = harness.createPanel();
     panel.show('Norway', 'NO', sampleScore, emptySignals);
+    await flushLazyWidget();
 
     const root = harness.getPanelRoot();
     const summaryGrid = root?.querySelector('.cdp-summary-grid');
@@ -65,6 +71,7 @@ test('country deep-dive panel destroys each resilience widget exactly once acros
     const panel = harness.createPanel();
 
     panel.show('Norway', 'NO', sampleScore, emptySignals);
+    await flushLazyWidget();
     const firstWidget = harness.getWidgets().at(-1);
     panel.showLoading();
 
@@ -73,6 +80,7 @@ test('country deep-dive panel destroys each resilience widget exactly once acros
     assert.equal(harness.document.querySelectorAll('.resilience-widget-stub').length, 0);
 
     panel.show('Yemen', 'YE', sampleScore, emptySignals);
+    await flushLazyWidget();
     const secondWidget = harness.getWidgets().at(-1);
     panel.showGeoError(() => {});
 
@@ -81,6 +89,7 @@ test('country deep-dive panel destroys each resilience widget exactly once acros
     assert.equal(harness.document.querySelectorAll('.resilience-widget-stub').length, 0);
 
     panel.show('United States', 'US', sampleScore, emptySignals);
+    await flushLazyWidget();
     const thirdWidget = harness.getWidgets().at(-1);
     panel.hide();
 

--- a/tests/resilience-country-brief.test.mjs
+++ b/tests/resilience-country-brief.test.mjs
@@ -38,9 +38,75 @@ const emptySignals = {
   gpsJammingHexes: 0,
 };
 
-async function flushLazyWidget() {
-  await Promise.resolve();
-  await Promise.resolve();
+const sampleEnergyProfile = {
+  mixAvailable: false,
+  mixYear: 2025,
+  coalShare: 0,
+  gasShare: 35,
+  oilShare: 5,
+  nuclearShare: 0,
+  renewShare: 60,
+  windShare: 20,
+  solarShare: 10,
+  hydroShare: 30,
+  importShare: 15,
+  gasStorageAvailable: false,
+  gasStorageFillPct: 0,
+  gasStorageChange1d: 0,
+  gasStorageTrend: '',
+  gasStorageDate: '',
+  electricityAvailable: false,
+  electricityPriceMwh: 0,
+  electricitySource: '',
+  electricityDate: '',
+  jodiOilAvailable: false,
+  jodiOilDataMonth: '',
+  gasolineDemandKbd: 0,
+  gasolineImportsKbd: 0,
+  dieselDemandKbd: 0,
+  dieselImportsKbd: 0,
+  jetDemandKbd: 0,
+  jetImportsKbd: 0,
+  lpgDemandKbd: 0,
+  lpgImportsKbd: 0,
+  crudeImportsKbd: 0,
+  jodiGasAvailable: false,
+  jodiGasDataMonth: '',
+  gasTotalDemandTj: 0,
+  gasLngImportsTj: 0,
+  gasPipeImportsTj: 0,
+  gasLngShare: 0,
+  ieaStocksAvailable: false,
+  ieaStocksDataMonth: '',
+  ieaDaysOfCover: 0,
+  ieaNetExporter: false,
+  ieaBelowObligation: false,
+  emberFossilShare: 40,
+  emberRenewShare: 60,
+  emberNuclearShare: 0,
+  emberCoalShare: 0,
+  emberGasShare: 35,
+  emberDemandTwh: 120,
+  emberDataMonth: '2026-04',
+  emberAvailable: false,
+  sprRegime: '',
+  sprCapacityMb: 0,
+  sprOperator: '',
+  sprIeaMember: false,
+  sprStockholdingModel: '',
+  sprNote: '',
+  sprSource: '',
+  sprAsOf: '',
+  sprAvailable: false,
+};
+
+async function waitForLazyWidget(harness) {
+  for (let attempt = 0; attempt < 25; attempt += 1) {
+    const widget = harness.getPanelRoot()?.querySelector('.resilience-widget-stub');
+    if (widget) return widget;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  assert.fail('expected lazy resilience widget to render');
 }
 
 test('country deep-dive panel mounts the resilience widget beside the score card', async () => {
@@ -48,11 +114,10 @@ test('country deep-dive panel mounts the resilience widget beside the score card
   try {
     const panel = harness.createPanel();
     panel.show('Norway', 'NO', sampleScore, emptySignals);
-    await flushLazyWidget();
+    const widget = await waitForLazyWidget(harness);
 
     const root = harness.getPanelRoot();
     const summaryGrid = root?.querySelector('.cdp-summary-grid');
-    const widget = summaryGrid?.querySelector('.resilience-widget-stub');
 
     assert.ok(root, 'expected panel root to be created');
     assert.ok(summaryGrid, 'expected summary grid to render');
@@ -71,7 +136,7 @@ test('country deep-dive panel destroys each resilience widget exactly once acros
     const panel = harness.createPanel();
 
     panel.show('Norway', 'NO', sampleScore, emptySignals);
-    await flushLazyWidget();
+    await waitForLazyWidget(harness);
     const firstWidget = harness.getWidgets().at(-1);
     panel.showLoading();
 
@@ -80,7 +145,7 @@ test('country deep-dive panel destroys each resilience widget exactly once acros
     assert.equal(harness.document.querySelectorAll('.resilience-widget-stub').length, 0);
 
     panel.show('Yemen', 'YE', sampleScore, emptySignals);
-    await flushLazyWidget();
+    await waitForLazyWidget(harness);
     const secondWidget = harness.getWidgets().at(-1);
     panel.showGeoError(() => {});
 
@@ -89,7 +154,7 @@ test('country deep-dive panel destroys each resilience widget exactly once acros
     assert.equal(harness.document.querySelectorAll('.resilience-widget-stub').length, 0);
 
     panel.show('United States', 'US', sampleScore, emptySignals);
-    await flushLazyWidget();
+    await waitForLazyWidget(harness);
     const thirdWidget = harness.getWidgets().at(-1);
     panel.hide();
 
@@ -97,6 +162,23 @@ test('country deep-dive panel destroys each resilience widget exactly once acros
     assert.equal(thirdWidget.destroyCount, 1, 'hide() must destroy widget subscriptions');
     // hide() keeps DOM intact (panel is visually hidden); DOM is cleared on next show()
     assert.equal(harness.document.querySelectorAll('.resilience-widget-stub').length, 1, 'hide() does not clear DOM');
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test('country deep-dive panel forwards pending energy mix to the lazy resilience widget', async () => {
+  const harness = await createCountryDeepDivePanelHarness();
+  try {
+    const panel = harness.createPanel();
+
+    panel.show('Norway', 'NO', sampleScore, emptySignals);
+    panel.updateEnergyProfile(sampleEnergyProfile);
+    await waitForLazyWidget(harness);
+
+    const widget = harness.getWidgets().at(-1);
+    assert.ok(widget, 'expected lazy widget instance');
+    assert.equal(widget.energyMixData, sampleEnergyProfile);
   } finally {
     harness.cleanup();
   }

--- a/tests/resilience-widget.test.mts
+++ b/tests/resilience-widget.test.mts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
 import {
@@ -42,6 +43,17 @@ const baseResponse: ResilienceScoreResponse = {
   imputationShare: 0,
   dataVersion: '2026-04-03',
 };
+
+test('ResilienceWidget stays out of the components barrel and loads through CountryDeepDivePanel dynamically', async () => {
+  const [barrelSource, deepDiveSource] = await Promise.all([
+    readFile(new URL('../src/components/index.ts', import.meta.url), 'utf8'),
+    readFile(new URL('../src/components/CountryDeepDivePanel.ts', import.meta.url), 'utf8'),
+  ]);
+
+  assert.doesNotMatch(barrelSource, /export\s+\*\s+from\s+['"]\.\/ResilienceWidget['"]/);
+  assert.doesNotMatch(deepDiveSource, /import\s+\{\s*ResilienceWidget\s*\}\s+from\s+['"]\.\/ResilienceWidget['"]/);
+  assert.match(deepDiveSource, /import\(['"]@\/components\/ResilienceWidget['"]\)/);
+});
 
 test('getResilienceVisualLevel maps the score thresholds from the widget spec', () => {
   assert.equal(getResilienceVisualLevel(80), 'very_high');


### PR DESCRIPTION
## Summary
- lazy-load the Country Resilience widget from the country deep-dive panel
- move CRI widget sign-in/upgrade dependencies behind click-time dynamic imports
- remove the unused ResilienceWidget barrel re-export and add lazy-boundary regression coverage

## Evidence
- Before: Vite listed ResilienceWidget.ts as a static importer of services/clerk.ts, services/runtime.ts, services/tauri-bridge.ts, and config/products.ts.
- After: ResilienceWidget.ts is listed only as a dynamic importer for those paths; config/products.ts warning is gone.
- After build emitted dist/assets/ResilienceWidget-C6KfO76y.js (9.54 kB minified / 3.18 kB gzip) and products-kU4ukwEt.js (0.34 kB).
- panels chunk decreased from 2,464.45 kB to 2,445.06 kB minified.
- emitted HTML had no ResilienceWidget/products/clerk/map stack preload references.

## Validation
- npm run typecheck
- npx tsx --test tests/resilience-widget.test.mts tests/resilience-map-layer.test.mts tests/resilience-country-brief.test.mjs
- npm run build
- npx tsx --test tests/product-catalog-freshness.test.mjs
- pre-push hook on git push (typecheck, API typecheck, Convex type check, boundaries, bundle checks, full unit suite, edge tests, markdown/MDX lint, version sync)