### PR TITLE
fix(auth): stop uncaught Clerk "not loaded with Ui components" flood

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -305,6 +305,7 @@ Sentry.init({
     /Octal literals are not allowed in strict mode/, // Runtime SyntaxError from injected extension script; our TS bundle never emits octal literals and doesn't eval (WORLDMONITOR-NV)
     /Unexpected identifier 'm'/, // Foreign script injection on Opera; pre-compiled bundle can't parse-fail at runtime (WORLDMONITOR-NT)
     /PlayerControlsInterface\.\w+ is not a function/, // Android Chrome WebView native bridge injection (Bilibili/UC/QQ-style host) — never emitted by our code (WORLDMONITOR-P2)
+    /github\.com\/styled-components\/styled-components\/blob/, // styled-components runtime error (errors.md#N URL); we don't depend on styled-components, so it can only be a browser extension (Grammarly et al.) injecting its own bundle — WORLDMONITOR-SE
   ],
   beforeSend(event) {
     const msg = event.exception?.values?.[0]?.value ?? '';

--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -197,11 +197,11 @@ export function getClerk(): ClerkInstance | null {
 // import keeps @sentry/browser off this module's static graph (clerk.ts is
 // imported by Node test files where the browser SDK is unwanted) and makes
 // telemetry strictly best-effort — it must never throw into a click handler.
-function captureClerkSurfaceFailure(action: string, err: unknown): void {
+function captureClerkSurfaceFailure(action: string, err: unknown, reason: string): void {
   void import('@sentry/browser')
     .then((Sentry) => {
       Sentry.captureException(err instanceof Error ? err : new Error(String(err)), {
-        tags: { surface: 'clerk', action, reason: 'ui-components-not-ready' },
+        tags: { surface: 'clerk', action, reason },
       });
     })
     .catch(() => {});
@@ -254,21 +254,24 @@ function openClerkSurface(action: 'open-sign-in' | 'open-sign-up'): void {
   const open = action === 'open-sign-in'
     ? () => clerkInstance?.openSignIn({ appearance: getAppearance() })
     : () => clerkInstance?.openSignUp({ appearance: getAppearance() });
-  const onFail = (err: unknown): void => {
-    console.error(`[clerk] ${action} failed:`, err);
-    captureClerkSurfaceFailure(action, err);
+  // Distinct reasons so Sentry can tell the "components not attached" race
+  // (the surface open threw) apart from a "Clerk bundle never loaded" failure
+  // (initClerk rejected: dynamic-import 4xx/5xx, transient network) — querying
+  // by `reason` must not mix the two or it dilutes the race alert signal.
+  const onFail = (reason: string) => (err: unknown): void => {
+    console.error(`[clerk] ${action} failed (${reason}):`, err);
+    captureClerkSurfaceFailure(action, err, reason);
   };
   if (clerkInstance) {
-    runClerkSurfaceOpen(open, onFail);
+    runClerkSurfaceOpen(open, onFail('ui-components-not-ready'));
     return;
   }
   // Deferred-load fast path: user clicked before the idle callback fired.
   // Force the load, then open once the SDK is live so the click never
-  // silently no-ops. A `load()` rejection (dynamic-import 4xx/5xx, transient
-  // network) is now reported instead of escaping as an uncaught rejection.
+  // silently no-ops.
   void initClerk()
-    .then(() => runClerkSurfaceOpen(open, onFail))
-    .catch(onFail);
+    .then(() => runClerkSurfaceOpen(open, onFail('ui-components-not-ready')))
+    .catch(onFail('clerk-load-failed'));
 }
 
 /** Open the Clerk sign-in modal. */

--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -193,16 +193,87 @@ export function getClerk(): ClerkInstance | null {
   return clerkInstance;
 }
 
-/** Open the Clerk sign-in modal. */
-export function openSignIn(): void {
+// Report a Clerk UI-open failure as a single handled Sentry event. Lazy
+// import keeps @sentry/browser off this module's static graph (clerk.ts is
+// imported by Node test files where the browser SDK is unwanted) and makes
+// telemetry strictly best-effort — it must never throw into a click handler.
+function captureClerkSurfaceFailure(action: string, err: unknown): void {
+  void import('@sentry/browser')
+    .then((Sentry) => {
+      Sentry.captureException(err instanceof Error ? err : new Error(String(err)), {
+        tags: { surface: 'clerk', action, reason: 'ui-components-not-ready' },
+      });
+    })
+    .catch(() => {});
+}
+
+function scheduleNextFrame(cb: () => void): void {
+  if (typeof requestAnimationFrame === 'function') requestAnimationFrame(() => cb());
+  else setTimeout(cb, 50);
+}
+
+/**
+ * Open a Clerk UI surface (sign-in / sign-up modal) with one retry.
+ *
+ * Clerk's `openSignIn` / `openSignUp` call an internal
+ * `assertComponentsReady` that throws SYNCHRONOUSLY ("Clerk was not loaded
+ * with Ui components") when the session layer loaded but the UI component
+ * controller never attached — a `load()`-resolved-before-components-mounted
+ * race, or the component bundle being blocked by an ad-blocker / CSP. Left
+ * unguarded that throw escaped as an uncaught error on every Sign In /
+ * Create Account click (WORLDMONITOR-SC / -SD: ~2.3k events / ~1k users).
+ *
+ * Retry once on the next frame to absorb the mount race; if it still fails,
+ * report a single handled event so a genuine regression still alarms without
+ * flooding Sentry. Deliberately does NOT reset `clerkInstance` — that would
+ * orphan the active auth-state listeners (`attachPendingSubscribers` drains
+ * its queue, so a fresh load can't re-attach them).
+ *
+ * Exported for testing — the retry/capture state machine, decoupled from
+ * Clerk and the frame scheduler.
+ */
+export function runClerkSurfaceOpen(
+  open: () => void,
+  onPersistentFailure: (err: unknown) => void,
+  scheduleRetry: (cb: () => void) => void = scheduleNextFrame,
+): void {
+  try {
+    open();
+  } catch {
+    scheduleRetry(() => {
+      try {
+        open();
+      } catch (err) {
+        onPersistentFailure(err);
+      }
+    });
+  }
+}
+
+function openClerkSurface(action: 'open-sign-in' | 'open-sign-up'): void {
+  const open = action === 'open-sign-in'
+    ? () => clerkInstance?.openSignIn({ appearance: getAppearance() })
+    : () => clerkInstance?.openSignUp({ appearance: getAppearance() });
+  const onFail = (err: unknown): void => {
+    console.error(`[clerk] ${action} failed:`, err);
+    captureClerkSurfaceFailure(action, err);
+  };
   if (clerkInstance) {
-    clerkInstance.openSignIn({ appearance: getAppearance() });
+    runClerkSurfaceOpen(open, onFail);
     return;
   }
-  // Deferred-load fast path: user clicked Sign In before the idle
-  // callback fired. Trigger immediate load and open the modal once the
-  // SDK is live so the click never silently no-ops.
-  void initClerk().then(() => clerkInstance?.openSignIn({ appearance: getAppearance() }));
+  // Deferred-load fast path: user clicked before the idle callback fired.
+  // Force the load, then open once the SDK is live so the click never
+  // silently no-ops. A `load()` rejection (dynamic-import 4xx/5xx, transient
+  // network) is now reported instead of escaping as an uncaught rejection.
+  void initClerk()
+    .then(() => runClerkSurfaceOpen(open, onFail))
+    .catch(onFail);
+}
+
+/** Open the Clerk sign-in modal. */
+export function openSignIn(): void {
+  openClerkSurface('open-sign-in');
 }
 
 /**
@@ -215,14 +286,7 @@ export function openSignIn(): void {
  * footer link.
  */
 export function openSignUp(): void {
-  if (clerkInstance) {
-    clerkInstance.openSignUp({ appearance: getAppearance() });
-    return;
-  }
-  // Same deferred-load fast path as openSignIn — Create Account clicks
-  // during the load window kick off the import and open the modal once
-  // the SDK is live.
-  void initClerk().then(() => clerkInstance?.openSignUp({ appearance: getAppearance() }));
+  openClerkSurface('open-sign-up');
 }
 
 /**

--- a/tests/clerk-surface-open.test.mts
+++ b/tests/clerk-surface-open.test.mts
@@ -1,0 +1,90 @@
+/**
+ * Regression coverage for the Clerk UI-open retry/capture state machine
+ * (`runClerkSurfaceOpen`) added to fix WORLDMONITOR-SC / WORLDMONITOR-SD.
+ *
+ * Clerk's `openSignIn` / `openSignUp` throw SYNCHRONOUSLY ("Clerk was not
+ * loaded with Ui components") when the session layer loaded but the UI
+ * component controller never attached. The old code called the Clerk method
+ * unguarded, so the throw escaped as an uncaught error on every Sign In /
+ * Create Account click. `runClerkSurfaceOpen` must:
+ *   1. swallow the synchronous throw (no uncaught error),
+ *   2. retry once on the next frame (absorb the load()-vs-mount race),
+ *   3. report exactly one handled event only when the retry ALSO fails.
+ *
+ * The full openSignIn() path needs a browser + Clerk SDK; this exercises the
+ * decoupled state machine, which is the part most likely to regress.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { runClerkSurfaceOpen } from '../src/services/clerk.ts';
+
+describe('runClerkSurfaceOpen', () => {
+  it('opens once and never schedules a retry when the surface is ready', () => {
+    let opens = 0;
+    let retries = 0;
+    let failures = 0;
+    runClerkSurfaceOpen(
+      () => { opens += 1; },
+      () => { failures += 1; },
+      () => { retries += 1; },
+    );
+    assert.equal(opens, 1);
+    assert.equal(retries, 0);
+    assert.equal(failures, 0);
+  });
+
+  it('does not let a synchronous throw escape (the WORLDMONITOR-SC/-SD crash)', () => {
+    assert.doesNotThrow(() => {
+      runClerkSurfaceOpen(
+        () => { throw new Error('Clerk was not loaded with Ui components'); },
+        () => {},
+        // Never run the retry so we isolate the first-call guarantee.
+        () => {},
+      );
+    });
+  });
+
+  it('recovers when the surface becomes ready on the retry frame — no capture', () => {
+    let opens = 0;
+    let failures = 0;
+    runClerkSurfaceOpen(
+      () => {
+        opens += 1;
+        if (opens === 1) throw new Error('Clerk was not loaded with Ui components');
+        // second call (retry frame) succeeds — components finished mounting
+      },
+      () => { failures += 1; },
+      (cb) => { cb(); }, // run the scheduled retry synchronously
+    );
+    assert.equal(opens, 2);
+    assert.equal(failures, 0);
+  });
+
+  it('reports exactly one handled failure when the retry also throws', () => {
+    let opens = 0;
+    const captured: unknown[] = [];
+    runClerkSurfaceOpen(
+      () => { opens += 1; throw new Error('Clerk was not loaded with Ui components'); },
+      (err) => { captured.push(err); },
+      (cb) => { cb(); },
+    );
+    assert.equal(opens, 2); // initial + one retry
+    assert.equal(captured.length, 1);
+    assert.ok(captured[0] instanceof Error);
+    assert.match((captured[0] as Error).message, /not loaded with Ui components/);
+  });
+
+  it('schedules the retry rather than calling open synchronously twice', () => {
+    let opens = 0;
+    let scheduled: (() => void) | null = null;
+    runClerkSurfaceOpen(
+      () => { opens += 1; throw new Error('not ready'); },
+      () => {},
+      (cb) => { scheduled = cb; }, // capture but do not run
+    );
+    assert.equal(opens, 1, 'retry must be deferred, not run inline');
+    assert.equal(typeof scheduled, 'function');
+  });
+});


### PR DESCRIPTION
## Summary

`openSignIn` / `openSignUp` threw an **uncaught** error on every signed-out user's first auth click — **WORLDMONITOR-SC + -SD: ~2.3k events / ~1k users** since 2026-06-02.

**Root cause — a perf win exposed a latent race.** #3999 ("lazy-load Clerk", shipped in `2.8.0`) moved `clerk.load()` off the critical path to *after* user intent. The Sign In / Create Account click now races Clerk's UI component-controller mount: in clerk-js v5, `load()` resolving does **not** guarantee components are ready, so `openSignIn()` hits `assertComponentsReady`, which throws **synchronously**. Both call paths were unguarded — the fast path had no `try`, the deferred path had no `.catch` — so the throw escaped uncaught. Under the old *eager* load this was dormant (seconds elapsed before any click); lazy-load turned it into the first-interaction failure of nearly every signed-out visitor.

## Changes

- **`src/services/clerk.ts`** — route both open paths through a new `runClerkSurfaceOpen` helper that:
  - retries the open **once on the next frame** (recovers the mount race), and
  - reports a single **handled** Sentry event only if the retry *also* fails — instead of flooding Sentry with uncaught errors.
  - The deferred path now also `.catch`es a `load()` rejection.
  - Deliberately does **not** reset `clerkInstance` — that would orphan the active auth-state listeners (`attachPendingSubscribers` drains its queue, so a fresh load can't re-attach them).
- **`src/main.ts`** — `ignoreErrors` filter for styled-components runtime errors (**WORLDMONITOR-SE**); we don't depend on styled-components, so the `errors.md` URL can only come from a browser extension injecting its own bundle.
- **`tests/clerk-surface-open.test.mts`** — 5 new tests for the retry/capture state machine (sync-throw never escapes, recovers on retry, reports exactly once when retry also fails, retry is deferred not inline).

## Test plan

- [x] `npm run typecheck` + `typecheck:api`
- [x] `npm run lint` (Biome) + `lint:md`
- [x] `npm run test:data` — 10,573 tests, 0 fail (incl. new `runClerkSurfaceOpen` suite)
- [x] `node --test tests/sentry-beforesend.test.mjs` — 146/146 (styled-components filter doesn't disturb beforeSend)
- [x] edge-function bundle + tests, `version:check`