### PR TITLE
fix(resilience): harden country widget lazy fallback

### DIFF
--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -2548,26 +2548,47 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
 
   private renderResilienceWidgetSlot(code: string): HTMLElement {
     const slot = this.el('div', 'cdp-card resilience-widget');
-    slot.append(this.makeLoading('Loading resilience score...'));
+    slot.append(this.makeLoading(t('countryBrief.loadingResilienceScore')));
     const requestId = ++this.resilienceWidgetRequestId;
+
+    const renderFallback = (error: unknown) => {
+      if (requestId !== this.resilienceWidgetRequestId) return;
+      console.warn('[CountryDeepDivePanel] Failed to load resilience widget', error);
+      this.captureResilienceWidgetLoadFailure(error, code);
+      slot.replaceChildren(this.makeEmpty(t('countryBrief.resilienceScoreUnavailable')));
+    };
 
     import('@/components/ResilienceWidget')
       .then(({ ResilienceWidget }) => {
         if (requestId !== this.resilienceWidgetRequestId) return;
-        if (typeof ResilienceWidget !== 'function') return;
+        if (typeof ResilienceWidget !== 'function') throw new Error('ResilienceWidget export is unavailable.');
         const widget = new ResilienceWidget(code);
         this.resilienceWidget = widget;
         if (this.pendingResilienceEnergyMix) {
           widget.setEnergyMix(this.pendingResilienceEnergyMix);
         }
         this.replaceResilienceSlot(slot, widget.getElement());
-      }, (error) => {
-        if (requestId !== this.resilienceWidgetRequestId) return;
-        console.warn('[CountryDeepDivePanel] Failed to load resilience widget', error);
-        slot.replaceChildren(this.makeEmpty('Resilience score unavailable.'));
-      });
+      })
+      .catch(renderFallback);
 
     return slot;
+  }
+
+  private captureResilienceWidgetLoadFailure(error: unknown, countryCode: string): void {
+    void import('@sentry/browser')
+      .then((Sentry) => {
+        Sentry.addBreadcrumb?.({
+          category: 'country-deep-dive',
+          level: 'warning',
+          message: 'Resilience widget lazy load failed',
+          data: { countryCode },
+        });
+        Sentry.captureException(error instanceof Error ? error : new Error(String(error)), {
+          tags: { surface: 'country-deep-dive', widget: 'resilience' },
+          extra: { countryCode },
+        });
+      })
+      .catch(() => {});
   }
 
   private replaceResilienceSlot(slot: HTMLElement, next: HTMLElement): void {

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -2563,11 +2563,16 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
         if (requestId !== this.resilienceWidgetRequestId) return;
         if (typeof ResilienceWidget !== 'function') throw new Error('ResilienceWidget export is unavailable.');
         const widget = new ResilienceWidget(code);
-        this.resilienceWidget = widget;
-        if (this.pendingResilienceEnergyMix) {
-          widget.setEnergyMix(this.pendingResilienceEnergyMix);
+        try {
+          if (this.pendingResilienceEnergyMix) {
+            widget.setEnergyMix(this.pendingResilienceEnergyMix);
+          }
+          this.replaceResilienceSlot(slot, widget.getElement());
+          this.resilienceWidget = widget;
+        } catch (error) {
+          widget.destroy();
+          throw error;
         }
-        this.replaceResilienceSlot(slot, widget.getElement());
       })
       .catch(renderFallback);
 

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -2553,6 +2553,8 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
 
     const renderFallback = (error: unknown) => {
       if (requestId !== this.resilienceWidgetRequestId) return;
+      this.resilienceWidget?.destroy();
+      this.resilienceWidget = null;
       console.warn('[CountryDeepDivePanel] Failed to load resilience widget', error);
       this.captureResilienceWidgetLoadFailure(error, code);
       slot.replaceChildren(this.makeEmpty(t('countryBrief.resilienceScoreUnavailable')));
@@ -2588,7 +2590,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
           message: 'Resilience widget lazy load failed',
           data: { countryCode },
         });
-        Sentry.captureException(error instanceof Error ? error : new Error(String(error)), {
+        Sentry.captureException?.(error instanceof Error ? error : new Error(String(error)), {
           tags: { surface: 'country-deep-dive', widget: 'resilience' },
           extra: { countryCode },
         });

--- a/src/components/ResilienceWidget.ts
+++ b/src/components/ResilienceWidget.ts
@@ -58,7 +58,9 @@ export class ResilienceWidget {
     this.unsubscribeAuth = subscribeAuthState((state) => {
       this.authState = state;
       const gateReason = this.getGateReason();
-      if (gateReason === PanelGateReason.NONE && this.currentCountryCode && !this.loading && this.currentData?.countryCode !== this.currentCountryCode) {
+      const loadedCountryCode = normalizeCountryCode(this.currentData?.countryCode);
+      const needsRefresh = !this.currentData || (loadedCountryCode !== null && loadedCountryCode !== this.currentCountryCode);
+      if (gateReason === PanelGateReason.NONE && this.currentCountryCode && !this.loading && needsRefresh) {
         void this.refresh();
         return;
       }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -75,6 +75,8 @@
     "closeBtn": "Close",
     "limitedCoverage": "Limited coverage",
     "instabilityIndex": "Instability Index",
+    "loadingResilienceScore": "Loading resilience score…",
+    "resilienceScoreUnavailable": "Resilience score unavailable.",
     "notTracked": "Not tracked — {{country}} is not in the CII tier-1 list",
     "intelBrief": "Intelligence Brief",
     "generatingBrief": "Generating intelligence brief...",

--- a/tests/helpers/country-deep-dive-panel-harness.mjs
+++ b/tests/helpers/country-deep-dive-panel-harness.mjs
@@ -36,9 +36,47 @@ function defineGlobal(name, value) {
   });
 }
 
-async function loadCountryDeepDivePanel() {
+async function loadCountryDeepDivePanel(options = {}) {
+  const resilienceWidgetMode = options.resilienceWidgetMode ?? 'success';
   const tempDir = mkdtempSync(join(tmpdir(), 'wm-country-deep-dive-'));
   const outfile = join(tempDir, 'CountryDeepDivePanel.bundle.mjs');
+  const resilienceWidgetStub = resilienceWidgetMode === 'import-reject'
+    ? `
+      throw new Error('synthetic resilience widget chunk failure');
+      export class ResilienceWidget {}
+    `
+    : resilienceWidgetMode === 'constructor-throw'
+      ? `
+        export class ResilienceWidget {
+          constructor() {
+            throw new Error('synthetic resilience widget constructor failure');
+          }
+        }
+      `
+      : `
+        const state = globalThis.__wmCountryDeepDiveTestState;
+        export class ResilienceWidget {
+          constructor(code) {
+            this.code = code;
+            this.destroyCount = 0;
+            this.energyMixData = null;
+            this.element = document.createElement('section');
+            this.element.className = 'resilience-widget-stub';
+            this.element.setAttribute('data-country-code', code);
+            this.element.textContent = 'Resilience ' + code;
+            state.widgets.push(this);
+          }
+          setEnergyMix(data) {
+            this.energyMixData = data;
+          }
+          getElement() {
+            return this.element;
+          }
+          destroy() {
+            this.destroyCount += 1;
+          }
+        }
+      `;
 
   const stubModules = new Map([
     ['feeds-stub', `
@@ -122,28 +160,20 @@ async function loadCountryDeepDivePanel() {
     ['auth-state-stub', `
       export function getAuthState() { return { user: null }; }
     `],
-    ['resilience-widget-stub', `
+    ['resilience-widget-stub', resilienceWidgetStub],
+    ['sentry-browser-stub', `
       const state = globalThis.__wmCountryDeepDiveTestState;
-      export class ResilienceWidget {
-        constructor(code) {
-          this.code = code;
-          this.destroyCount = 0;
-          this.energyMixData = null;
-          this.element = document.createElement('section');
-          this.element.className = 'resilience-widget-stub';
-          this.element.setAttribute('data-country-code', code);
-          this.element.textContent = 'Resilience ' + code;
-          state.widgets.push(this);
-        }
-        setEnergyMix(data) {
-          this.energyMixData = data;
-        }
-        getElement() {
-          return this.element;
-        }
-        destroy() {
-          this.destroyCount += 1;
-        }
+      export function addBreadcrumb(breadcrumb) {
+        state.sentryBreadcrumbs.push(breadcrumb);
+      }
+      export function captureException(error, context) {
+        state.sentryExceptions.push({ error, context });
+      }
+      export function captureMessage(message, context) {
+        state.sentryMessages.push({ message, context });
+      }
+      export function setUser(user) {
+        state.sentryUser = user;
       }
     `],
   ]);
@@ -170,6 +200,7 @@ async function loadCountryDeepDivePanel() {
     ['@/generated/client/worldmonitor/intelligence/v1/service_client', 'intelligence-client-stub'],
     ['@/services/panel-gating', 'panel-gating-stub'],
     ['@/services/auth-state', 'auth-state-stub'],
+    ['@sentry/browser', 'sentry-browser-stub'],
   ]);
 
   const plugin = {
@@ -208,7 +239,7 @@ async function loadCountryDeepDivePanel() {
   };
 }
 
-export async function createCountryDeepDivePanelHarness() {
+export async function createCountryDeepDivePanelHarness(options = {}) {
   const originalGlobals = {
     document: snapshotGlobal('document'),
     window: snapshotGlobal('window'),
@@ -220,7 +251,7 @@ export async function createCountryDeepDivePanelHarness() {
     HTMLButtonElement: snapshotGlobal('HTMLButtonElement'),
   };
   const browserEnvironment = createBrowserEnvironment();
-  const state = { widgets: [] };
+  const state = { widgets: [], sentryBreadcrumbs: [], sentryExceptions: [], sentryMessages: [], sentryUser: undefined };
 
   defineGlobal('document', browserEnvironment.document);
   defineGlobal('window', browserEnvironment.window);
@@ -235,7 +266,7 @@ export async function createCountryDeepDivePanelHarness() {
   let CountryDeepDivePanel;
   let cleanupBundle;
   try {
-    ({ CountryDeepDivePanel, cleanupBundle } = await loadCountryDeepDivePanel());
+    ({ CountryDeepDivePanel, cleanupBundle } = await loadCountryDeepDivePanel(options));
   } catch (error) {
     delete globalThis.__wmCountryDeepDiveTestState;
     restoreGlobal('document', originalGlobals.document);
@@ -276,6 +307,12 @@ export async function createCountryDeepDivePanelHarness() {
     getPanelRoot,
     getWidgets() {
       return state.widgets;
+    },
+    getSentryBreadcrumbs() {
+      return state.sentryBreadcrumbs;
+    },
+    getSentryExceptions() {
+      return state.sentryExceptions;
     },
     cleanup,
   };

--- a/tests/helpers/country-deep-dive-panel-harness.mjs
+++ b/tests/helpers/country-deep-dive-panel-harness.mjs
@@ -53,6 +53,27 @@ async function loadCountryDeepDivePanel(options = {}) {
           }
         }
       `
+      : resilienceWidgetMode === 'get-element-throw'
+        ? `
+          const state = globalThis.__wmCountryDeepDiveTestState;
+          export class ResilienceWidget {
+            constructor(code) {
+              this.code = code;
+              this.destroyCount = 0;
+              this.energyMixData = null;
+              state.widgets.push(this);
+            }
+            setEnergyMix(data) {
+              this.energyMixData = data;
+            }
+            getElement() {
+              throw new Error('synthetic resilience widget getElement failure');
+            }
+            destroy() {
+              this.destroyCount += 1;
+            }
+          }
+        `
       : `
         const state = globalThis.__wmCountryDeepDiveTestState;
         export class ResilienceWidget {

--- a/tests/resilience-country-brief.test.mjs
+++ b/tests/resilience-country-brief.test.mjs
@@ -109,6 +109,24 @@ async function waitForLazyWidget(harness) {
   assert.fail('expected lazy resilience widget to render');
 }
 
+async function waitForResilienceFallback(harness) {
+  for (let attempt = 0; attempt < 25; attempt += 1) {
+    const slot = harness.getPanelRoot()?.querySelector('.resilience-widget');
+    const fallback = slot?.querySelector('.cdp-empty');
+    if (fallback) return { slot, fallback };
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  assert.fail('expected lazy resilience widget fallback to render');
+}
+
+async function waitForSentryFailure(harness) {
+  for (let attempt = 0; attempt < 25; attempt += 1) {
+    if (harness.getSentryBreadcrumbs().length > 0 && harness.getSentryExceptions().length > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+  assert.fail('expected resilience widget lazy-load failure telemetry');
+}
+
 test('country deep-dive panel mounts the resilience widget beside the score card', async () => {
   const harness = await createCountryDeepDivePanelHarness();
   try {
@@ -125,6 +143,42 @@ test('country deep-dive panel mounts the resilience widget beside the score card
     assert.ok(widget, 'expected resilience widget to render');
     assert.equal(widget?.getAttribute('data-country-code'), 'NO');
     assert.equal(summaryGrid?.childElementCount, 2);
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test('country deep-dive panel renders fallback when the resilience widget chunk rejects', async () => {
+  const harness = await createCountryDeepDivePanelHarness({ resilienceWidgetMode: 'import-reject' });
+  try {
+    const panel = harness.createPanel();
+    panel.show('Norway', 'NO', sampleScore, emptySignals);
+    const { slot, fallback } = await waitForResilienceFallback(harness);
+
+    assert.equal(fallback.textContent, 'countryBrief.resilienceScoreUnavailable');
+    assert.equal(slot.querySelector('.cdp-loading-inline'), null, 'fallback must replace loading state');
+    assert.equal(harness.getWidgets().length, 0, 'chunk failure must not create a widget');
+    await waitForSentryFailure(harness);
+    assert.equal(harness.getSentryBreadcrumbs().length, 1);
+    assert.equal(harness.getSentryExceptions().length, 1);
+  } finally {
+    harness.cleanup();
+  }
+});
+
+test('country deep-dive panel renders fallback when the resilience widget success handler throws', async () => {
+  const harness = await createCountryDeepDivePanelHarness({ resilienceWidgetMode: 'constructor-throw' });
+  try {
+    const panel = harness.createPanel();
+    panel.show('Norway', 'NO', sampleScore, emptySignals);
+    const { slot, fallback } = await waitForResilienceFallback(harness);
+
+    assert.equal(fallback.textContent, 'countryBrief.resilienceScoreUnavailable');
+    assert.equal(slot.querySelector('.cdp-loading-inline'), null, 'fallback must replace loading state');
+    assert.equal(harness.getWidgets().length, 0, 'constructor failure must not retain a widget');
+    await waitForSentryFailure(harness);
+    assert.equal(harness.getSentryBreadcrumbs().length, 1);
+    assert.equal(harness.getSentryExceptions().length, 1);
   } finally {
     harness.cleanup();
   }

--- a/tests/resilience-country-brief.test.mjs
+++ b/tests/resilience-country-brief.test.mjs
@@ -184,6 +184,26 @@ test('country deep-dive panel renders fallback when the resilience widget succes
   }
 });
 
+test('country deep-dive panel destroys a constructed resilience widget when setup throws', async () => {
+  const harness = await createCountryDeepDivePanelHarness({ resilienceWidgetMode: 'get-element-throw' });
+  try {
+    const panel = harness.createPanel();
+    panel.show('Norway', 'NO', sampleScore, emptySignals);
+    const { slot, fallback } = await waitForResilienceFallback(harness);
+    const widget = harness.getWidgets().at(-1);
+
+    assert.equal(fallback.textContent, 'countryBrief.resilienceScoreUnavailable');
+    assert.equal(slot.querySelector('.cdp-loading-inline'), null, 'fallback must replace loading state');
+    assert.ok(widget, 'post-construction failure should create a widget before setup throws');
+    assert.equal(widget.destroyCount, 1, 'failed setup must not leave widget subscriptions live');
+    await waitForSentryFailure(harness);
+    assert.equal(harness.getSentryBreadcrumbs().length, 1);
+    assert.equal(harness.getSentryExceptions().length, 1);
+  } finally {
+    harness.cleanup();
+  }
+});
+
 test('country deep-dive panel destroys each resilience widget exactly once across state transitions', async () => {
   const harness = await createCountryDeepDivePanelHarness();
   try {

--- a/tests/resilience-widget.test.mts
+++ b/tests/resilience-widget.test.mts
@@ -53,6 +53,22 @@ test('ResilienceWidget stays out of the components barrel and loads through Coun
   assert.doesNotMatch(barrelSource, /export\s+\*\s+from\s+['"]\.\/ResilienceWidget['"]/);
   assert.doesNotMatch(deepDiveSource, /import\s+\{\s*ResilienceWidget\s*\}\s+from\s+['"]\.\/ResilienceWidget['"]/);
   assert.match(deepDiveSource, /import\(['"]@\/components\/ResilienceWidget['"]\)/);
+  assert.match(deepDiveSource, /import\(['"]@\/components\/ResilienceWidget['"]\)[\s\S]*?\.then\(\(\{\s*ResilienceWidget\s*\}\)\s*=>[\s\S]*?\)\s*\.catch\(renderFallback\)/);
+});
+
+test('ResilienceWidget auth refresh guard tolerates malformed server countryCode values', async () => {
+  const source = await readFile(new URL('../src/components/ResilienceWidget.ts', import.meta.url), 'utf8');
+
+  assert.match(
+    source,
+    /const loadedCountryCode = normalizeCountryCode\(this\.currentData\?\.countryCode\);/,
+    'auth refresh guard must validate the server countryCode before comparing it',
+  );
+  assert.match(
+    source,
+    /const needsRefresh = !this\.currentData \|\| \(loadedCountryCode !== null && loadedCountryCode !== this\.currentCountryCode\);/,
+    'malformed legacy countryCode values must not cause repeated auth-state refreshes',
+  );
 });
 
 test('getResilienceVisualLevel maps the score thresholds from the widget spec', () => {


### PR DESCRIPTION
## Summary
- Route the Country Resilience lazy widget loading and unavailable strings through the countryBrief i18n namespace.
- Make the ResilienceWidget lazy import degrade to the fallback for both chunk/import failures and success-handler exceptions.
- Add lazy Sentry breadcrumb/exception capture for the widget load failure path without statically importing the SDK.
- Harden the widget auth refresh predicate so malformed or legacy server countryCode values do not trigger redundant refetch loops.
- Extend the CountryDeepDivePanel harness and tests for import rejection and constructor/success-handler failures.

## Validation
- npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/resilience-country-brief.test.mjs tests/resilience-widget.test.mts
- npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/country-brief-i18n.test.mjs
- npm run typecheck
- git diff --check
- pre-push hook on normal git push: typecheck, typecheck:api, Convex type check, CJS syntax, Unicode safety, lint:boundaries, Sentry coverage, rate-limit policies, premium-fetch parity, edge bundle check, full unit suite, edge function tests, markdown lint, MDX lint, proto freshness skip, pro-test bundle freshness, version sync check

## Notes
- The focused fallback tests intentionally emit the synthetic console.warn messages for the simulated lazy-load failures.
- No new static import of ResilienceWidget through the components barrel.