### PR TITLE
Harden resilience numeric score guards

### DIFF
--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -600,8 +600,8 @@ function safeNum(value: unknown): number | null {
   return Number.isFinite(numeric) ? numeric : null;
 }
 
-function sqrtCount(value: number): number {
-  return Math.sqrt(Math.max(0, value));
+export function sqrtCount(value: number): number {
+  return Math.sqrt(Math.max(0, Number.isFinite(value) ? value : 0));
 }
 
 function normalizeLowerBetter(value: number, best: number, worst: number): number {

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -586,7 +586,8 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
-function roundScore(value: number): number {
+export function roundScore(value: number): number {
+  if (!Number.isFinite(value)) return 0;
   return Math.round(clamp(value, 0, 100));
 }
 
@@ -599,13 +600,19 @@ function safeNum(value: unknown): number | null {
   return Number.isFinite(numeric) ? numeric : null;
 }
 
+function sqrtCount(value: number): number {
+  return Math.sqrt(Math.max(0, value));
+}
+
 function normalizeLowerBetter(value: number, best: number, worst: number): number {
+  if (!Number.isFinite(value)) return Number.NaN;
   if (worst <= best) return 50;
   const ratio = (worst - value) / (worst - best);
   return roundScore(ratio * 100);
 }
 
 function normalizeHigherBetter(value: number, worst: number, best: number): number {
+  if (!Number.isFinite(value)) return Number.NaN;
   if (best <= worst) return 50;
   const ratio = (value - worst) / (best - worst);
   return roundScore(ratio * 100);
@@ -1891,7 +1898,7 @@ export async function scoreSocialCohesion(
   // outliers ≈ 10 events/M (calibrated empirically against the live
   // unrest:events:v1 distribution).
   const popDenominator = readPopulationMillions(imfLaborRaw, countryCode);
-  const unrestMetric = (unrest.unrestCount + Math.sqrt(unrest.fatalities)) / popDenominator;
+  const unrestMetric = (unrest.unrestCount + sqrtCount(unrest.fatalities)) / popDenominator;
 
   // GPI empirical range: 1.1 (Iceland) – 3.4 (Yemen 2024). Anchor worst=3.6 (slightly
   // above observed max) so the worst-peace countries score near 0, not 20.
@@ -2050,7 +2057,7 @@ export async function scoreBorderSecurity(
   // must scale per-capita too. Pre-fix the unnormalized typeWeight could
   // dominate the per-capita metric for high-event countries (US/IN type
   // peaceful but high-volume), defeating §U6's intended scaling.
-  const conflictMetric = (ucdp.eventCount * 2 + ucdp.typeWeight + Math.sqrt(ucdp.deaths)) / popDenominator;
+  const conflictMetric = (ucdp.eventCount * 2 + ucdp.typeWeight + sqrtCount(ucdp.deaths)) / popDenominator;
   const displacementMetric = safeNum(displacement?.hostTotal) ?? safeNum(displacement?.totalDisplaced);
 
   return weightedBlend([
@@ -2491,7 +2498,7 @@ export async function scoreStateContinuity(
   const wgiMean = mean(wgiValues);
 
   const ucdpSummary = summarizeUcdp(ucdpRaw, countryCode);
-  const ucdpRawScore = ucdpSummary.eventCount * 2 + ucdpSummary.typeWeight + Math.sqrt(ucdpSummary.deaths);
+  const ucdpRawScore = ucdpSummary.eventCount * 2 + ucdpSummary.typeWeight + sqrtCount(ucdpSummary.deaths);
 
   const displacement = getCountryDisplacement(displacementRaw, countryCode);
   const totalDisplaced = safeNum(displacement?.totalDisplaced);

--- a/tests/resilience-dimension-scorers.test.mts
+++ b/tests/resilience-dimension-scorers.test.mts
@@ -31,6 +31,7 @@ import {
   scoreStateContinuity,
   scoreInflationStability,
   scoreTradePolicy,
+  roundScore,
   summarizeCyber,
   CYBER_SNAPSHOT_WEIGHT_CAP,
 } from '../server/worldmonitor/resilience/v1/_dimension-scorers.ts';
@@ -133,6 +134,46 @@ describe('resilience dimension scorers', () => {
     assert.equal(score.coverage, 0.20, 'coverage must count only the finite observed metric');
     assert.equal(score.observedWeight, 0.2, 'observedWeight must exclude NaN metrics');
     assert.equal(score.imputedWeight, 0, 'NaN metrics must not be counted as imputed either');
+  });
+
+  it('roundScore clamps finite scores and maps non-finite values to a safe numeric floor', () => {
+    assert.equal(roundScore(12.6), 13, 'finite values still round normally');
+    assert.equal(roundScore(-1), 0, 'finite low values clamp to 0');
+    assert.equal(roundScore(101), 100, 'finite high values clamp to 100');
+    assert.equal(roundScore(Number.NaN), 0, 'NaN must not leak through as a score');
+    assert.equal(roundScore(Number.POSITIVE_INFINITY), 0, '+Infinity must not leak through as a score');
+    assert.equal(roundScore(Number.NEGATIVE_INFINITY), 0, '-Infinity must not leak through as a score');
+  });
+
+  it('negative unrest fatalities stay bounded and keep socialCohesion unrest observed', async () => {
+    const reader = async (key: string): Promise<unknown | null> => {
+      if (key === 'unrest:events:v1') return { events: [{ country: 'ZZ', severity: 'HIGH', fatalities: -4 }] };
+      return null;
+    };
+    const score = await scoreSocialCohesion('ZZ', reader);
+
+    assert.equal(score.score, 60, 'negative fatalities are floored before sqrt instead of making the unrest metric NaN');
+    assert.equal(score.coverage, 0.2, 'the unrest metric must remain observed');
+    assert.equal(score.observedWeight, 0.2, 'negative fatalities must not drop observed unrest weight');
+    assert.equal(score.imputedWeight, 0, 'negative fatalities are not an imputation path');
+  });
+
+  it('negative UCDP deaths stay bounded and keep conflict-backed dimensions observed', async () => {
+    const reader = async (key: string): Promise<unknown | null> => {
+      if (key === 'conflict:ucdp-events:v1') {
+        return { events: [{ country: 'ZZ', deathsBest: -9, violenceType: 'UCDP_VIOLENCE_TYPE_STATE_BASED' }] };
+      }
+      return null;
+    };
+    const border = await scoreBorderSecurity('ZZ', reader);
+    const continuity = await scoreStateContinuity('ZZ', reader);
+
+    assert.equal(border.score, 47, 'borderSecurity floors negative deaths before sqrt');
+    assert.equal(border.coverage, 0.65, 'borderSecurity must keep the UCDP row observed');
+    assert.equal(border.observedWeight, 0.65, 'borderSecurity must not drop UCDP weight for negative deaths');
+    assert.equal(continuity.score, 87, 'stateContinuity floors negative deaths before sqrt');
+    assert.equal(continuity.coverage, 0.3, 'stateContinuity must keep the UCDP row observed');
+    assert.equal(continuity.observedWeight, 0.3, 'stateContinuity must not drop UCDP weight for negative deaths');
   });
 
   it('scoreEnergy with full data uses 7-metric blend and high coverage', async () => {

--- a/tests/resilience-dimension-scorers.test.mts
+++ b/tests/resilience-dimension-scorers.test.mts
@@ -32,6 +32,7 @@ import {
   scoreInflationStability,
   scoreTradePolicy,
   roundScore,
+  sqrtCount,
   summarizeCyber,
   CYBER_SNAPSHOT_WEIGHT_CAP,
 } from '../server/worldmonitor/resilience/v1/_dimension-scorers.ts';
@@ -143,6 +144,14 @@ describe('resilience dimension scorers', () => {
     assert.equal(roundScore(Number.NaN), 0, 'NaN must not leak through as a score');
     assert.equal(roundScore(Number.POSITIVE_INFINITY), 0, '+Infinity must not leak through as a score');
     assert.equal(roundScore(Number.NEGATIVE_INFINITY), 0, '-Infinity must not leak through as a score');
+  });
+
+  it('sqrtCount floors negative and non-finite counts before square root', () => {
+    assert.equal(sqrtCount(9), 3, 'positive counts still use sqrt scaling');
+    assert.equal(sqrtCount(-4), 0, 'negative counts floor to zero');
+    assert.equal(sqrtCount(Number.NaN), 0, 'NaN counts must not propagate');
+    assert.equal(sqrtCount(Number.POSITIVE_INFINITY), 0, '+Infinity counts must not propagate');
+    assert.equal(sqrtCount(Number.NEGATIVE_INFINITY), 0, '-Infinity counts must not propagate');
   });
 
   it('negative unrest fatalities stay bounded and keep socialCohesion unrest observed', async () => {


### PR DESCRIPTION
## Summary
- floor count inputs before sqrt in resilience unrest/UCDP scoring paths
- make roundScore finite-safe for NaN/Infinity while preserving existing malformed-metric filtering at normalization boundaries
- add focused scorer regressions for negative feed counts and non-finite roundScore inputs

## Tests
- npx --cache /tmp/worldmonitor-npm-cache tsx --test tests/resilience-dimension-scorers.test.mts
- git diff --check
- pre-push hook: typecheck, typecheck:api, full unit suite, edge function tests, markdown/MDX lint, proto freshness, pro-test bundle freshness, version sync