### PR TITLE
Derive resilience scorer doc parity specs

### DIFF
--- a/docs/methodology/country-resilience-index.mdx
+++ b/docs/methodology/country-resilience-index.mdx
@@ -463,7 +463,7 @@ score = clamp((worst - value) / (worst - best) * 100, 0, 100)
 
 Goalposts are hand-picked based on empirical data ranges (not percentile-derived). A score of 100 means the country meets or exceeds the "best" goalpost; 0 means it meets or exceeds the "worst" goalpost.
 
-**Exception:** Sanctions use piecewise normalization to capture the non-linear impact of sanctions counts (the first few sanctions matter more than additional ones in already-sanctioned countries).
+**Exceptions:** A few live indicators are explicitly non-linear and are tagged as such in the indicator registry: `inflationStability` uses a 1-3% target band with deflation and high-inflation zero-score anchors, `bisLbsXborderPctGdp` uses a U-shaped band, `fatfListingStatus` is categorical, and `recoverySovereignWealthEffectiveMonths` uses a saturating transform. Their goalposts are documentation anchors, not generic linear normalizer inputs.
 
 ## Scoring Formula
 

--- a/server/worldmonitor/resilience/v1/_indicator-registry.ts
+++ b/server/worldmonitor/resilience/v1/_indicator-registry.ts
@@ -18,12 +18,27 @@ export type IndicatorLicense =
   | 'proprietary' // Bloomberg, S&P Global Platts (not used in Core)
   | 'unknown'; // placeholder for any indicator still awaiting license audit
 
+export type IndicatorNormalization =
+  | { kind: 'linear' }
+  | {
+      kind: 'targetBand';
+      targetBand: { min: number; max: number };
+      zeroScoreAt: { min: number; max: number };
+      disclaimer: string;
+    }
+  | { kind: 'uShape'; disclaimer: string }
+  | { kind: 'discrete'; disclaimer: string }
+  | { kind: 'saturating'; disclaimer: string };
+
 export type IndicatorSpec = {
   id: string;
   dimension: ResilienceDimensionId;
   description: string;
   direction: 'higherBetter' | 'lowerBetter';
   goalposts: { worst: number; best: number };
+  // Defaults to { kind: 'linear' }. Non-linear indicators keep goalposts as
+  // documentation anchors only and must describe the real scorer shape here.
+  normalization?: IndicatorNormalization;
   weight: number;
   // Primary source key for legacy callers and simple one-source indicators.
   sourceKey: string;
@@ -152,9 +167,15 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
   {
     id: 'inflationStability',
     dimension: 'currencyExternal',
-    description: 'IMF CPI inflation (lower is better). Global-coverage primary signal for currency stability. Core input to scoreCurrencyExternal under PR 3 §3.5. A future PR may upgrade this to a 5-year inflation-volatility computation once the seeder tracks the series; headline inflation is a reasonable first-cut for stability ranking.',
+    description: 'IMF CPI inflation target-band score. 1-3% YoY scores best; deflation at <=-5% and high inflation at >=50% score 0. Global-coverage primary signal for currency stability. Core input to scoreCurrencyExternal under PR 3 §3.5.',
     direction: 'lowerBetter',
-    goalposts: { worst: 50, best: 0 },
+    goalposts: { worst: 50, best: 3 },
+    normalization: {
+      kind: 'targetBand',
+      targetBand: { min: 1, max: 3 },
+      zeroScoreAt: { min: -5, max: 50 },
+      disclaimer: 'scoreInflationStability is non-linear: 1-3% maps to 100, <=-5% and >=50% map to 0. goalposts are documentation anchors, not generic lowerBetter inputs.',
+    },
     weight: 0.6,
     sourceKey: 'economic:imf:macro:v2',
     scope: 'global',
@@ -322,6 +343,10 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     // scores must consult `normalizeBandLowerBetter` directly, not assume
     // these are the inputs to a generic linear normalizer.
     goalposts: { worst: 60, best: 25 },
+    normalization: {
+      kind: 'uShape',
+      disclaimer: 'normalizeBandLowerBetter peaks around diversified middle exposure and penalizes both isolation and over-exposure. goalposts summarize the over-exposed documentation branch only.',
+    },
     weight: 0.30,
     sourceKey: 'economic:bis-lbs:v1',
     scope: 'global',
@@ -337,6 +362,10 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     description: 'FATF AML/CFT listing status — black list (call for action) → 0, gray list (increased monitoring) → 30, compliant → 100',
     direction: 'higherBetter',
     goalposts: { worst: 0, best: 100 },
+    normalization: {
+      kind: 'discrete',
+      disclaimer: 'fatfStatusToScore maps black=0, gray=30, compliant=100; goalposts are categorical documentation anchors.',
+    },
     weight: 0.20,
     sourceKey: 'economic:fatf-listing:v1',
     scope: 'global',
@@ -1213,6 +1242,10 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     description: 'Sovereign-wealth fiscal-buffer signal per plan §3.4. Seeded from Wikipedia SWF list + per-fund article infoboxes (CC-BY-SA), haircut by the classification manifest (scripts/shared/swf-classification-manifest.yaml): effectiveMonths = rawSwfMonths × access × liquidity × transparency, summed across a country\'s manifest funds. Scorer applies a saturating transform score = 100 × (1 − exp(−effectiveMonths / 12)).',
     direction: 'higherBetter',
     goalposts: { worst: 0, best: 60 },
+    normalization: {
+      kind: 'saturating',
+      disclaimer: 'scoreSovereignFiscalBuffer uses 100 * (1 - exp(-effectiveMonths / 12)); goalposts document the display range, not a linear scorer anchor.',
+    },
     weight: 1.0,
     sourceKey: 'resilience:recovery:sovereign-wealth:v1',
     scope: 'global',

--- a/tests/helpers/resilience-scorer-doc-parity-specs.mts
+++ b/tests/helpers/resilience-scorer-doc-parity-specs.mts
@@ -336,6 +336,10 @@ function extractNormalizer(
 ): { direction: IndicatorSpec['direction']; goalposts: IndicatorSpec['goalposts'] } {
   const higherCall = findCall(source, 'normalizeHigherBetter');
   const lowerCall = findCall(source, 'normalizeLowerBetter');
+  assert.ok(
+    !(higherCall && lowerCall),
+    `${indicatorId} mixes normalizeHigherBetter and normalizeLowerBetter in one scorer entry. Add an explicit extractor or non-linear allowlist entry instead of guessing direction.`,
+  );
   const call = higherCall ?? lowerCall;
   assert.ok(
     call,
@@ -353,6 +357,13 @@ function extractNormalizer(
     return { direction: 'higherBetter', goalposts: { worst: firstAnchor, best: secondAnchor } };
   }
   return { direction: 'lowerBetter', goalposts: { worst: secondAnchor, best: firstAnchor } };
+}
+
+export function extractLinearNormalizerForTest(
+  source: string,
+  indicatorId: string,
+): { direction: IndicatorSpec['direction']; goalposts: IndicatorSpec['goalposts'] } {
+  return extractNormalizer(source, indicatorId);
 }
 
 function findCall(source: string, name: 'normalizeHigherBetter' | 'normalizeLowerBetter'): { name: typeof name; args: string } | null {
@@ -438,7 +449,7 @@ function formatGoalposts(goalposts: IndicatorSpec['goalposts']): string {
 }
 
 function formatNumber(value: number): string {
-  return Number.isInteger(value) ? String(value) : String(value);
+  return String(value);
 }
 
 function isNonLinearId(id: string): id is (typeof SCORER_DOC_PARITY_NON_LINEAR_IDS)[number] {

--- a/tests/helpers/resilience-scorer-doc-parity-specs.mts
+++ b/tests/helpers/resilience-scorer-doc-parity-specs.mts
@@ -1,5 +1,14 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import type { IndicatorSpec } from '../../server/worldmonitor/resilience/v1/_indicator-registry.ts';
+import { INDICATOR_REGISTRY } from '../../server/worldmonitor/resilience/v1/_indicator-registry.ts';
+import { MACRO_FISCAL_INDICATOR_WEIGHTS } from '../../server/worldmonitor/resilience/v1/_macro-fiscal-weights.ts';
 import type { ResilienceDimensionId } from '../../server/worldmonitor/resilience/v1/_dimension-scorers.ts';
+
+export type ScorerParityExtraction = 'scorer-source' | 'non-linear-allowlist' | 'custom-source';
 
 export interface ScorerDocParityIndicatorSpec {
   id: string;
@@ -12,220 +21,162 @@ export interface ScorerDocParityIndicatorSpec {
   weight: number;
   sourceKey?: string;
   tier?: IndicatorSpec['tier'];
+  normalizationKind: NonNullable<IndicatorSpec['normalization']>['kind'];
+  extraction: ScorerParityExtraction;
 }
 
-export const SCORER_DOC_PARITY_SPECS = [
+interface ScorerTableBinding {
+  methodologySection: string;
+  dimension: ResilienceDimensionId;
+  scorerName: string;
+  ids: readonly string[];
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SCORER_SOURCE_PATH = resolve(here, '../../server/worldmonitor/resilience/v1/_dimension-scorers.ts');
+const SCORER_SOURCE = readFileSync(SCORER_SOURCE_PATH, 'utf8');
+
+const SCORER_TABLE_BINDINGS = [
   {
-    id: 'electricityAccess',
-    dimension: 'infrastructure',
-    methodologySection: 'Infrastructure',
-    methodologyDirection: 'Higher is better',
-    registryDirection: 'higherBetter',
-    methodologyGoalposts: '40 - 100',
-    registryGoalposts: { worst: 40, best: 100 },
-    weight: 0.30,
-    sourceKey: 'resilience:static:{ISO2}',
-    tier: 'core',
+    methodologySection: 'Macro-Fiscal',
+    dimension: 'macroFiscal',
+    scorerName: 'scoreMacroFiscal',
+    ids: ['govRevenuePct', 'debtGrowthRate', 'currentAccountPct', 'unemploymentPct', 'householdDebtService'],
   },
   {
-    id: 'roadsPavedInfra',
-    dimension: 'infrastructure',
+    methodologySection: 'Currency & External',
+    dimension: 'currencyExternal',
+    scorerName: 'scoreCurrencyExternal',
+    ids: ['inflationStability', 'fxReservesAdequacy'],
+  },
+  {
+    methodologySection: 'Trade Policy',
+    dimension: 'tradePolicy',
+    scorerName: 'scoreTradePolicy',
+    ids: ['tradeRestrictions', 'tradeBarriers', 'appliedTariffRate'],
+  },
+  {
+    methodologySection: 'Financial System Exposure',
+    dimension: 'financialSystemExposure',
+    scorerName: 'scoreFinancialSystemExposure',
+    ids: ['shortTermExternalDebtPctGni', 'bisLbsXborderPctGdp', 'fatfListingStatus', 'financialCenterRedundancy'],
+  },
+  {
+    methodologySection: 'Cyber & Digital',
+    dimension: 'cyberDigital',
+    scorerName: 'scoreCyberDigital',
+    ids: ['cyberThreats', 'internetOutages', 'gpsJamming'],
+  },
+  {
     methodologySection: 'Infrastructure',
+    dimension: 'infrastructure',
+    scorerName: 'scoreInfrastructure',
+    ids: ['electricityAccess', 'roadsPavedInfra', 'infraOutages', 'broadband'],
+  },
+  {
+    methodologySection: 'Conflict & Displacement',
+    dimension: 'borderSecurity',
+    scorerName: 'scoreBorderSecurity',
+    ids: ['ucdpConflict', 'displacementHosted'],
+  },
+  {
+    methodologySection: 'Information & Cognitive',
+    dimension: 'informationCognitive',
+    scorerName: 'scoreInformationCognitive',
+    ids: ['rsfPressFreedom', 'socialVelocity', 'newsThreatScore'],
+  },
+  {
+    methodologySection: 'Health & Public Service',
+    dimension: 'healthPublicService',
+    scorerName: 'scoreHealthPublicService',
+    ids: ['uhcIndex', 'measlesCoverage', 'hospitalBeds', 'physiciansPer1k', 'healthExpPerCapitaUsd'],
+  },
+  {
+    methodologySection: 'Fiscal Space',
+    dimension: 'fiscalSpace',
+    scorerName: 'scoreFiscalSpace',
+    ids: ['recoveryGovRevenue', 'recoveryFiscalBalance', 'recoveryDebtToGdp', 'debtSustainabilityGap'],
+  },
+  {
+    methodologySection: 'Liquid Reserve Adequacy',
+    dimension: 'liquidReserveAdequacy',
+    scorerName: 'scoreLiquidReserveAdequacy',
+    ids: ['recoveryLiquidReserveMonths'],
+  },
+  {
+    methodologySection: 'Sovereign Fiscal Buffer',
+    dimension: 'sovereignFiscalBuffer',
+    scorerName: 'scoreSovereignFiscalBuffer',
+    ids: ['recoverySovereignWealthEffectiveMonths'],
+  },
+  {
+    methodologySection: 'External Debt Coverage',
+    dimension: 'externalDebtCoverage',
+    scorerName: 'scoreExternalDebtCoverage',
+    ids: ['recoveryDebtToReserves'],
+  },
+  {
+    methodologySection: 'Import Concentration',
+    dimension: 'importConcentration',
+    scorerName: 'scoreImportConcentration',
+    ids: ['recoveryImportHhi'],
+  },
+  {
+    methodologySection: 'State Continuity',
+    dimension: 'stateContinuity',
+    scorerName: 'scoreStateContinuity',
+    ids: ['recoveryWgiContinuity', 'recoveryConflictPressure', 'recoveryDisplacementVelocity'],
+  },
+] as const satisfies readonly ScorerTableBinding[];
+
+export const SCORER_DOC_PARITY_UNSUPPORTED_DIMENSIONS = [
+  'logisticsSupply',
+  'energy',
+  'governanceInstitutional',
+  'socialCohesion',
+  'foodWater',
+  'reserveAdequacy',
+  'fuelStockDays',
+] as const satisfies readonly ResilienceDimensionId[];
+
+export const SCORER_DOC_PARITY_NON_LINEAR_IDS = [
+  'inflationStability',
+  'bisLbsXborderPctGdp',
+  'fatfListingStatus',
+  'recoverySovereignWealthEffectiveMonths',
+] as const;
+
+const NON_LINEAR_DOC_METADATA = {
+  inflationStability: {
+    methodologyDirection: '1-3% target band is best',
+    methodologyGoalposts: '<= -5 or >= 50 -> 0; 1-3 -> 100',
+  },
+  bisLbsXborderPctGdp: {
+    methodologyDirection: 'Lower is better (U-shape)',
+    methodologyGoalposts: '60 - 25',
+  },
+  fatfListingStatus: {
     methodologyDirection: 'Higher is better',
-    registryDirection: 'higherBetter',
     methodologyGoalposts: '0 - 100',
-    registryGoalposts: { worst: 0, best: 100 },
-    weight: 0.30,
-    sourceKey: 'resilience:static:{ISO2}',
-    tier: 'core',
   },
-  {
-    id: 'infraOutages',
-    dimension: 'infrastructure',
-    methodologySection: 'Infrastructure',
-    methodologyDirection: 'Lower is better',
-    registryDirection: 'lowerBetter',
-    methodologyGoalposts: '20 - 0',
-    registryGoalposts: { worst: 20, best: 0 },
-    weight: 0.25,
-    sourceKey: 'infra:outages:v1',
-    tier: 'core',
-  },
-  {
-    id: 'broadband',
-    dimension: 'infrastructure',
-    methodologySection: 'Infrastructure',
+  recoverySovereignWealthEffectiveMonths: {
     methodologyDirection: 'Higher is better',
-    registryDirection: 'higherBetter',
-    methodologyGoalposts: '0 - 40',
-    registryGoalposts: { worst: 0, best: 40 },
-    weight: 0.15,
-    sourceKey: 'resilience:static:{ISO2}',
-    tier: 'core',
+    methodologyGoalposts: '0 - 60',
   },
-  {
-    id: 'gpiScore',
-    dimension: 'socialCohesion',
-    methodologySection: 'Social Cohesion',
-    methodologyDirection: 'Lower is better',
-    registryDirection: 'lowerBetter',
-    methodologyGoalposts: '3.6 - 1.0',
-    registryGoalposts: { worst: 3.6, best: 1 },
-    weight: 0.55,
-    sourceKey: 'resilience:static:{ISO2}',
-    tier: 'enrichment',
-  },
-  {
-    id: 'displacementTotal',
-    dimension: 'socialCohesion',
-    methodologySection: 'Social Cohesion',
-    methodologyDirection: 'Lower is better',
-    registryDirection: 'lowerBetter',
-    methodologyGoalposts: '7 - 0',
-    registryGoalposts: { worst: 7, best: 0 },
-    weight: 0.25,
-    sourceKey: 'displacement:summary:v1:{year}',
-    tier: 'core',
-  },
-  {
-    id: 'unrestEvents',
-    dimension: 'socialCohesion',
-    methodologySection: 'Social Cohesion',
-    methodologyDirection: 'Lower is better',
-    registryDirection: 'lowerBetter',
-    methodologyGoalposts: '10 - 0',
-    registryGoalposts: { worst: 10, best: 0 },
-    weight: 0.20,
-    sourceKey: 'unrest:events:v1',
-    tier: 'core',
-  },
-  {
-    id: 'ucdpConflict',
-    dimension: 'borderSecurity',
-    methodologySection: 'Conflict & Displacement',
-    methodologyDirection: 'Lower is better',
-    registryDirection: 'lowerBetter',
-    methodologyGoalposts: '15 - 0',
-    registryGoalposts: { worst: 15, best: 0 },
-    weight: 0.65,
-    sourceKey: 'conflict:ucdp-events:v1',
-    tier: 'core',
-  },
-  {
-    id: 'displacementHosted',
-    dimension: 'borderSecurity',
-    methodologySection: 'Conflict & Displacement',
-    methodologyDirection: 'Lower is better',
-    registryDirection: 'lowerBetter',
-    methodologyGoalposts: '7 - 0',
-    registryGoalposts: { worst: 7, best: 0 },
-    weight: 0.35,
-    sourceKey: 'displacement:summary:v1:{year}',
-    tier: 'core',
-  },
-  {
-    id: 'rsfPressFreedom',
-    dimension: 'informationCognitive',
-    methodologySection: 'Information & Cognitive',
-    methodologyDirection: 'Lower is better',
-    registryDirection: 'lowerBetter',
-    methodologyGoalposts: '100 - 0',
-    registryGoalposts: { worst: 100, best: 0 },
-    weight: 0.55,
-    sourceKey: 'resilience:static:{ISO2}',
-    tier: 'core',
-  },
-  {
-    id: 'socialVelocity',
-    dimension: 'informationCognitive',
-    methodologySection: 'Information & Cognitive',
-    methodologyDirection: 'Lower is better',
-    registryDirection: 'lowerBetter',
-    methodologyGoalposts: '3 - 0',
-    registryGoalposts: { worst: 3, best: 0 },
-    weight: 0.15,
-    sourceKey: 'intelligence:social:reddit:v1',
-    tier: 'core',
-  },
-  {
-    id: 'newsThreatScore',
-    dimension: 'informationCognitive',
-    methodologySection: 'Information & Cognitive',
-    methodologyDirection: 'Lower is better',
-    registryDirection: 'lowerBetter',
-    methodologyGoalposts: '20 - 0',
-    registryGoalposts: { worst: 20, best: 0 },
-    weight: 0.30,
-    sourceKey: 'news:threat:summary:v1',
-    tier: 'core',
-  },
-  {
-    id: 'uhcIndex',
-    dimension: 'healthPublicService',
-    methodologySection: 'Health & Public Service',
-    methodologyDirection: 'Higher is better',
-    registryDirection: 'higherBetter',
-    methodologyGoalposts: '40 - 90',
-    registryGoalposts: { worst: 40, best: 90 },
-    weight: 0.35,
-    sourceKey: 'resilience:static:{ISO2}',
-    tier: 'core',
-  },
-  {
-    id: 'measlesCoverage',
-    dimension: 'healthPublicService',
-    methodologySection: 'Health & Public Service',
-    methodologyDirection: 'Higher is better',
-    registryDirection: 'higherBetter',
-    methodologyGoalposts: '50 - 99',
-    registryGoalposts: { worst: 50, best: 99 },
-    weight: 0.25,
-    sourceKey: 'resilience:static:{ISO2}',
-    tier: 'core',
-  },
-  {
-    id: 'hospitalBeds',
-    dimension: 'healthPublicService',
-    methodologySection: 'Health & Public Service',
-    methodologyDirection: 'Higher is better',
-    registryDirection: 'higherBetter',
-    methodologyGoalposts: '0 - 8',
-    registryGoalposts: { worst: 0, best: 8 },
-    weight: 0.10,
-    sourceKey: 'resilience:static:{ISO2}',
-    tier: 'core',
-  },
-  {
-    id: 'physiciansPer1k',
-    dimension: 'healthPublicService',
-    methodologySection: 'Health & Public Service',
-    methodologyDirection: 'Higher is better',
-    registryDirection: 'higherBetter',
-    methodologyGoalposts: '0 - 5',
-    registryGoalposts: { worst: 0, best: 5 },
-    weight: 0.15,
-    sourceKey: 'resilience:static:{ISO2}',
-    tier: 'core',
-  },
-  {
-    id: 'healthExpPerCapitaUsd',
-    dimension: 'healthPublicService',
-    methodologySection: 'Health & Public Service',
-    methodologyDirection: 'Higher is better',
-    registryDirection: 'higherBetter',
-    methodologyGoalposts: '20 - 3000',
-    registryGoalposts: { worst: 20, best: 3000 },
-    weight: 0.15,
-    sourceKey: 'resilience:static:{ISO2}',
-    tier: 'core',
-  },
-] as const satisfies readonly ScorerDocParityIndicatorSpec[];
+} as const satisfies Record<(typeof SCORER_DOC_PARITY_NON_LINEAR_IDS)[number], {
+  methodologyDirection: string;
+  methodologyGoalposts: string;
+}>;
 
 export const STATIC_SCORER_CATALOG_PARITY_IDS = [
   'broadband',
   'physiciansPer1k',
   'healthExpPerCapitaUsd',
 ] as const;
+
+const REGISTRY_BY_ID = new Map(INDICATOR_REGISTRY.map((spec) => [spec.id, spec]));
+
+export const SCORER_DOC_PARITY_SPECS = buildScorerDocParitySpecs();
 
 export function scorerDocParitySpecsBySection(): Map<string, readonly ScorerDocParityIndicatorSpec[]> {
   const bySection = new Map<string, ScorerDocParityIndicatorSpec[]>();
@@ -235,4 +186,261 @@ export function scorerDocParitySpecsBySection(): Map<string, readonly ScorerDocP
     bySection.set(spec.methodologySection, specs);
   }
   return bySection;
+}
+
+function buildScorerDocParitySpecs(): readonly ScorerDocParityIndicatorSpec[] {
+  const specs: ScorerDocParityIndicatorSpec[] = [];
+  for (const binding of SCORER_TABLE_BINDINGS) {
+    if (binding.scorerName === 'scoreCurrencyExternal') {
+      specs.push(...extractCurrencyExternalSpecs(binding));
+      continue;
+    }
+
+    const entries = extractWeightedBlendEntries(binding.scorerName);
+    assert.equal(
+      entries.length,
+      binding.ids.length,
+      `${binding.scorerName} expected ${binding.ids.length} scorer rows for ${binding.ids.join(', ')}, found ${entries.length}. ` +
+        'Update the extraction binding or add the scorer to SCORER_DOC_PARITY_UNSUPPORTED_DIMENSIONS with a rationale.',
+    );
+
+    binding.ids.forEach((id, index) => {
+      specs.push(buildSpecFromEntry(binding, id, entries[index]!));
+    });
+  }
+  return specs;
+}
+
+function extractCurrencyExternalSpecs(binding: ScorerTableBinding): readonly ScorerDocParityIndicatorSpec[] {
+  const functionBody = extractFunctionBody(binding.scorerName);
+  const blendMatch = /inflationScore!\s*\*\s*([0-9.]+)\s*\+\s*reservesScore\s*\*\s*([0-9.]+)/.exec(functionBody);
+  assert.ok(blendMatch, 'scoreCurrencyExternal must expose the inflation/reserves blend weights in source.');
+
+  const reservesFunction = extractFunctionBody('scoreFxReserves');
+  const reservesNormalize = extractNormalizer(reservesFunction, 'fxReservesAdequacy');
+  assert.equal(reservesNormalize.direction, 'higherBetter');
+
+  return [
+    buildSpecFromRegistry(binding, 'inflationStability', {
+      weight: Number(blendMatch[1]),
+      extraction: 'custom-source',
+    }),
+    buildSpecFromRegistry(binding, 'fxReservesAdequacy', {
+      weight: Number(blendMatch[2]),
+      extraction: 'custom-source',
+      registryDirection: reservesNormalize.direction,
+      registryGoalposts: reservesNormalize.goalposts,
+      methodologyDirection: 'Higher is better',
+      methodologyGoalposts: formatGoalposts(reservesNormalize.goalposts),
+      normalizationKind: 'linear',
+    }),
+  ];
+}
+
+function buildSpecFromEntry(
+  binding: ScorerTableBinding,
+  id: string,
+  entry: string,
+): ScorerDocParityIndicatorSpec {
+  const weight = extractWeight(entry, id);
+  if (isNonLinearId(id)) {
+    return buildSpecFromRegistry(binding, id, { weight, extraction: 'non-linear-allowlist' });
+  }
+
+  const normalize = extractNormalizer(entry, id);
+  return buildSpecFromRegistry(binding, id, {
+    weight,
+    extraction: 'scorer-source',
+    registryDirection: normalize.direction,
+    registryGoalposts: normalize.goalposts,
+    methodologyDirection: normalize.direction === 'higherBetter' ? 'Higher is better' : 'Lower is better',
+    methodologyGoalposts: formatGoalposts(normalize.goalposts),
+    normalizationKind: 'linear',
+  });
+}
+
+function buildSpecFromRegistry(
+  binding: ScorerTableBinding,
+  id: string,
+  override: {
+    weight: number;
+    extraction: ScorerParityExtraction;
+    registryDirection?: IndicatorSpec['direction'];
+    registryGoalposts?: IndicatorSpec['goalposts'];
+    methodologyDirection?: string;
+    methodologyGoalposts?: string;
+    normalizationKind?: NonNullable<IndicatorSpec['normalization']>['kind'];
+  },
+): ScorerDocParityIndicatorSpec {
+  const registry = REGISTRY_BY_ID.get(id);
+  assert.ok(registry, `${id} missing from INDICATOR_REGISTRY.`);
+  assert.equal(registry.dimension, binding.dimension, `${id} registry dimension must be ${binding.dimension}.`);
+  const nonLinear = isNonLinearId(id) ? NON_LINEAR_DOC_METADATA[id] : null;
+  return {
+    id,
+    dimension: binding.dimension,
+    methodologySection: binding.methodologySection,
+    methodologyDirection: override.methodologyDirection ?? nonLinear?.methodologyDirection ?? directionLabel(registry.direction),
+    registryDirection: override.registryDirection ?? registry.direction,
+    methodologyGoalposts: override.methodologyGoalposts ?? nonLinear?.methodologyGoalposts ?? formatGoalposts(registry.goalposts),
+    registryGoalposts: override.registryGoalposts ?? registry.goalposts,
+    weight: override.weight,
+    sourceKey: registry.sourceKey,
+    tier: registry.tier,
+    normalizationKind: override.normalizationKind ?? registry.normalization?.kind ?? 'linear',
+    extraction: override.extraction,
+  };
+}
+
+function extractWeightedBlendEntries(scorerName: string): string[] {
+  const functionBody = extractFunctionBody(scorerName);
+  let callStart = functionBody.indexOf('return weightedBlend(');
+  if (callStart === -1) callStart = functionBody.indexOf('weightedBlend([');
+  assert.notEqual(callStart, -1, `${scorerName} does not call weightedBlend in the extractable source shape.`);
+  const openParen = functionBody.indexOf('(', callStart);
+  const closeParen = findMatchingDelimiter(functionBody, openParen, '(', ')');
+  const callArg = functionBody.slice(openParen + 1, closeParen).trim();
+  assert.ok(callArg.startsWith('['), `${scorerName} weightedBlend argument must be an array literal.`);
+  const closeBracket = findMatchingDelimiter(callArg, 0, '[', ']');
+  return splitTopLevel(stripLineComments(callArg.slice(1, closeBracket)));
+}
+
+function extractFunctionBody(functionName: string): string {
+  const nameIndex = SCORER_SOURCE.indexOf(`function ${functionName}`);
+  assert.notEqual(nameIndex, -1, `Function ${functionName} not found in ${SCORER_SOURCE_PATH}.`);
+  const openBrace = SCORER_SOURCE.indexOf('{', nameIndex);
+  assert.notEqual(openBrace, -1, `Function ${functionName} body not found in ${SCORER_SOURCE_PATH}.`);
+  const closeBrace = findMatchingDelimiter(SCORER_SOURCE, openBrace, '{', '}');
+  return SCORER_SOURCE.slice(openBrace + 1, closeBrace);
+}
+
+function extractWeight(entry: string, indicatorId: string): number {
+  const match = /\bnominalWeight:\s*([^,}\n]+)/.exec(entry) ?? /\bweight:\s*([^,}\n]+)/.exec(entry);
+  assert.ok(match, `No weight field found for scorer row ${indicatorId}.`);
+  const expression = match[1].trim();
+  const macroMatch = /^MACRO_FISCAL_INDICATOR_WEIGHTS\.([A-Za-z0-9_]+)$/.exec(expression);
+  if (macroMatch) {
+    const key = macroMatch[1] as keyof typeof MACRO_FISCAL_INDICATOR_WEIGHTS;
+    const value = MACRO_FISCAL_INDICATOR_WEIGHTS[key];
+    assert.equal(typeof value, 'number', `Unknown macro-fiscal weight ${expression} for ${indicatorId}.`);
+    return value;
+  }
+  const numeric = Number(expression);
+  assert.ok(Number.isFinite(numeric), `Unsupported weight expression "${expression}" for ${indicatorId}.`);
+  return numeric;
+}
+
+function extractNormalizer(
+  source: string,
+  indicatorId: string,
+): { direction: IndicatorSpec['direction']; goalposts: IndicatorSpec['goalposts'] } {
+  const higherCall = findCall(source, 'normalizeHigherBetter');
+  const lowerCall = findCall(source, 'normalizeLowerBetter');
+  const call = higherCall ?? lowerCall;
+  assert.ok(
+    call,
+    `No linear normalizer found for ${indicatorId}. If this scorer is intentionally non-linear, add it to SCORER_DOC_PARITY_NON_LINEAR_IDS.`,
+  );
+  const args = splitTopLevel(call.args);
+  assert.ok(args.length >= 3, `${indicatorId} ${call.name} call must have at least three arguments.`);
+  const firstAnchor = Number(args[args.length - 2]!.trim());
+  const secondAnchor = Number(args[args.length - 1]!.trim());
+  assert.ok(
+    Number.isFinite(firstAnchor) && Number.isFinite(secondAnchor),
+    `${indicatorId} ${call.name} anchors must be numeric literals; got ${args.slice(-2).join(', ')}.`,
+  );
+  if (call.name === 'normalizeHigherBetter') {
+    return { direction: 'higherBetter', goalposts: { worst: firstAnchor, best: secondAnchor } };
+  }
+  return { direction: 'lowerBetter', goalposts: { worst: secondAnchor, best: firstAnchor } };
+}
+
+function findCall(source: string, name: 'normalizeHigherBetter' | 'normalizeLowerBetter'): { name: typeof name; args: string } | null {
+  const nameIndex = source.indexOf(`${name}(`);
+  if (nameIndex === -1) return null;
+  const openParen = source.indexOf('(', nameIndex);
+  const closeParen = findMatchingDelimiter(source, openParen, '(', ')');
+  return { name, args: source.slice(openParen + 1, closeParen) };
+}
+
+function splitTopLevel(source: string): string[] {
+  const entries: string[] = [];
+  let start = 0;
+  let curly = 0;
+  let square = 0;
+  let paren = 0;
+  let quote: '"' | "'" | '`' | null = null;
+  for (let i = 0; i < source.length; i += 1) {
+    const ch = source[i]!;
+    const prev = i > 0 ? source[i - 1] : '';
+    if (quote) {
+      if (ch === quote && prev !== '\\') quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch;
+      continue;
+    }
+    if (ch === '{') curly += 1;
+    else if (ch === '}') curly -= 1;
+    else if (ch === '[') square += 1;
+    else if (ch === ']') square -= 1;
+    else if (ch === '(') paren += 1;
+    else if (ch === ')') paren -= 1;
+    else if (ch === ',' && curly === 0 && square === 0 && paren === 0) {
+      const entry = source.slice(start, i).trim();
+      if (entry) entries.push(entry);
+      start = i + 1;
+    }
+  }
+  const tail = source.slice(start).trim();
+  if (tail) entries.push(tail);
+  return entries;
+}
+
+function stripLineComments(source: string): string {
+  return source
+    .split('\n')
+    .map((line) => line.replace(/\/\/.*$/, ''))
+    .join('\n');
+}
+
+function findMatchingDelimiter(source: string, openIndex: number, open: string, close: string): number {
+  assert.equal(source[openIndex], open, `Expected "${open}" at index ${openIndex}.`);
+  let depth = 0;
+  let quote: '"' | "'" | '`' | null = null;
+  for (let i = openIndex; i < source.length; i += 1) {
+    const ch = source[i]!;
+    const prev = i > 0 ? source[i - 1] : '';
+    if (quote) {
+      if (ch === quote && prev !== '\\') quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      quote = ch;
+      continue;
+    }
+    if (ch === open) depth += 1;
+    if (ch === close) {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  throw new Error(`No matching "${close}" found for "${open}" at index ${openIndex}.`);
+}
+
+function directionLabel(direction: IndicatorSpec['direction']): string {
+  return direction === 'higherBetter' ? 'Higher is better' : 'Lower is better';
+}
+
+function formatGoalposts(goalposts: IndicatorSpec['goalposts']): string {
+  return `${formatNumber(goalposts.worst)} - ${formatNumber(goalposts.best)}`;
+}
+
+function formatNumber(value: number): string {
+  return Number.isInteger(value) ? String(value) : String(value);
+}
+
+function isNonLinearId(id: string): id is (typeof SCORER_DOC_PARITY_NON_LINEAR_IDS)[number] {
+  return (SCORER_DOC_PARITY_NON_LINEAR_IDS as readonly string[]).includes(id);
 }

--- a/tests/resilience-doc-parity.test.mts
+++ b/tests/resilience-doc-parity.test.mts
@@ -61,6 +61,7 @@ import {
   SCORER_DOC_PARITY_SPECS,
   SCORER_DOC_PARITY_UNSUPPORTED_DIMENSIONS,
   STATIC_SCORER_CATALOG_PARITY_IDS,
+  extractLinearNormalizerForTest,
   scorerDocParitySpecsBySection,
 } from './helpers/resilience-scorer-doc-parity-specs.mts';
 
@@ -577,6 +578,17 @@ describe('methodology doc parity (Plan 2026-04-26-002 §U8)', () => {
       broadband.registryGoalposts,
       { worst: 0, best: 40 },
       'Changing scoreInfrastructure broadband anchors now changes the generated spec and breaks doc/registry parity unless those surfaces move too.',
+    );
+  });
+
+  it('source extraction rejects mixed linear normalizers instead of guessing direction', () => {
+    assert.throws(
+      () => extractLinearNormalizerForTest(
+        'flag ? normalizeHigherBetter(value, 0, 100) : normalizeLowerBetter(value, 80, 20)',
+        'syntheticConditionalNormalizer',
+      ),
+      /mixes normalizeHigherBetter and normalizeLowerBetter/,
+      'A scorer entry with both linear normalizers must fail loudly so helper extraction cannot silently choose higher-better.',
     );
   });
 

--- a/tests/resilience-doc-parity.test.mts
+++ b/tests/resilience-doc-parity.test.mts
@@ -57,6 +57,9 @@ import {
   RANKABLE_UNIVERSE_SIZE,
 } from '../server/worldmonitor/resilience/v1/_rankable-universe.ts';
 import {
+  SCORER_DOC_PARITY_NON_LINEAR_IDS,
+  SCORER_DOC_PARITY_SPECS,
+  SCORER_DOC_PARITY_UNSUPPORTED_DIMENSIONS,
   STATIC_SCORER_CATALOG_PARITY_IDS,
   scorerDocParitySpecsBySection,
 } from './helpers/resilience-scorer-doc-parity-specs.mts';
@@ -505,6 +508,76 @@ describe('methodology doc parity (Plan 2026-04-26-002 §U8)', () => {
         );
       }
     }
+  });
+
+  it('scorer doc parity coverage is source-derived or explicitly allowlisted', () => {
+    const coveredDimensions = [...new Set(SCORER_DOC_PARITY_SPECS.map((spec) => spec.dimension))].sort();
+    assert.deepEqual(
+      coveredDimensions,
+      [
+        'borderSecurity',
+        'currencyExternal',
+        'cyberDigital',
+        'externalDebtCoverage',
+        'financialSystemExposure',
+        'fiscalSpace',
+        'healthPublicService',
+        'importConcentration',
+        'informationCognitive',
+        'infrastructure',
+        'liquidReserveAdequacy',
+        'macroFiscal',
+        'sovereignFiscalBuffer',
+        'stateContinuity',
+        'tradePolicy',
+      ].sort(),
+      'Parity coverage changed. Add source extraction for new dimensions where practical, or update the unsupported allowlist with a rationale.',
+    );
+    assert.deepEqual(
+      [...SCORER_DOC_PARITY_UNSUPPORTED_DIMENSIONS].sort(),
+      [
+        'energy',
+        'foodWater',
+        'fuelStockDays',
+        'governanceInstitutional',
+        'logisticsSupply',
+        'reserveAdequacy',
+        'socialCohesion',
+      ].sort(),
+      'Unsupported scorer dimensions must be explicit so skipped parity coverage cannot drift silently.',
+    );
+    assert.equal(
+      SCORER_DOC_PARITY_SPECS.filter((spec) => spec.extraction === 'scorer-source' || spec.extraction === 'custom-source').length,
+      39,
+      'Expected 39 scorer/doc parity rows to derive weights from scorer source or a custom scorer-source extractor.',
+    );
+    assert.deepEqual(
+      SCORER_DOC_PARITY_SPECS
+        .filter((spec) => spec.extraction === 'non-linear-allowlist')
+        .map((spec) => spec.id),
+      [...SCORER_DOC_PARITY_NON_LINEAR_IDS].filter((id) => id !== 'inflationStability'),
+      'Non-linear scorer rows in weightedBlend tables must be explicitly allowlisted.',
+    );
+  });
+
+  it('source-derived scorer specs pin representative anchor and weight drift', () => {
+    const broadband = SCORER_DOC_PARITY_SPECS.find((spec) => spec.id === 'broadband');
+    assert.ok(broadband, 'broadband must be covered by scorer/doc parity specs.');
+    assert.equal(
+      broadband.extraction,
+      'scorer-source',
+      'broadband parity must be extracted from scoreInfrastructure, not copied into helper constants.',
+    );
+    assert.equal(
+      broadband.weight,
+      0.15,
+      'Changing scoreInfrastructure broadband weight now changes the generated spec and breaks doc/registry parity unless those surfaces move too.',
+    );
+    assert.deepEqual(
+      broadband.registryGoalposts,
+      { worst: 0, best: 40 },
+      'Changing scoreInfrastructure broadband anchors now changes the generated spec and breaks doc/registry parity unless those surfaces move too.',
+    );
   });
 
   it('trend enum prose matches the response enum', () => {

--- a/tests/resilience-indicator-registry.test.mts
+++ b/tests/resilience-indicator-registry.test.mts
@@ -8,6 +8,7 @@ import {
 } from '../server/worldmonitor/resilience/v1/_indicator-registry.ts';
 import type { IndicatorSpec } from '../server/worldmonitor/resilience/v1/_indicator-registry.ts';
 import {
+  SCORER_DOC_PARITY_NON_LINEAR_IDS,
   SCORER_DOC_PARITY_SPECS,
 } from './helpers/resilience-scorer-doc-parity-specs.mts';
 
@@ -173,15 +174,43 @@ describe('indicator registry', () => {
       const expectedIds = SCORER_REGISTRY_PARITY_SPECS
         .filter((spec) => spec.dimension === dimension)
         .map((spec) => spec.id);
+      const expectedIdSet = new Set(expectedIds);
       const actualIds = INDICATOR_REGISTRY
-        .filter((spec) => spec.dimension === dimension && spec.tier !== 'experimental')
+        .filter((spec) => spec.dimension === dimension && (spec.tier !== 'experimental' || expectedIdSet.has(spec.id)))
         .map((spec) => spec.id);
       assert.deepEqual(
         actualIds,
         expectedIds,
-        `${dimension} registry rows must list exactly the scorer-used non-experimental blended inputs`,
+        `${dimension} registry rows must list exactly the scorer-used blended inputs, excluding unrelated experimental rollback rows`,
       );
     }
+  });
+
+  it('non-linear scorer indicators carry explicit registry normalization metadata', () => {
+    const byId = new Map(INDICATOR_REGISTRY.map((spec) => [spec.id, spec]));
+    for (const id of SCORER_DOC_PARITY_NON_LINEAR_IDS) {
+      const spec = byId.get(id);
+      assert.ok(spec, `${id} must exist in INDICATOR_REGISTRY`);
+      assert.ok(spec.normalization, `${id} must declare non-linear normalization metadata`);
+      assert.notEqual(spec.normalization.kind, 'linear', `${id} must not be treated as a generic linear goalpost metric`);
+      assert.ok(
+        'disclaimer' in spec.normalization && spec.normalization.disclaimer.length > 20,
+        `${id} non-linear normalization must explain how tooling should interpret goalposts`,
+      );
+    }
+
+    const inflation = byId.get('inflationStability');
+    assert.equal(inflation?.normalization?.kind, 'targetBand');
+    assert.deepEqual(
+      inflation?.normalization.kind === 'targetBand' ? inflation.normalization.targetBand : null,
+      { min: 1, max: 3 },
+      'inflationStability must document the 1-3% target band used by scoreInflationStability',
+    );
+    assert.deepEqual(
+      inflation?.normalization.kind === 'targetBand' ? inflation.normalization.zeroScoreAt : null,
+      { min: -5, max: 50 },
+      'inflationStability must document both deflation and high-inflation zero-score anchors',
+    );
   });
 
   it('legacy-only energy indicators stay experimental rollback surfaces under active v2', () => {


### PR DESCRIPTION
## Summary
- derive resilience scorer doc parity specs from `_dimension-scorers.ts` instead of hand-mirrored helper constants where practical
- add explicit unsupported/non-linear scorer allowlists and registry normalization metadata for target-band/non-linear indicators
- align the resilience methodology doc with live non-linear normalization exceptions and add regression coverage for source-derived anchor/weight drift

## Coverage
- before: helper constants covered 17 rows across 5 dimensions
- after: generated parity covers 42 rows across 15 dimensions; 39 rows are source/custom-derived and 3 weightedBlend rows are explicit non-linear allowlist entries

## Tests
- npm run typecheck:api
- npx tsx --test tests/resilience-doc-parity.test.mts tests/resilience-indicator-registry.test.mts
- git diff --check
- pre-push hook: full typecheck, API typecheck, CJS/import guardrails, edge bundle checks, full unit suite, edge tests, markdown/MDX lint, pro-test bundle freshness, version sync
