### PR TITLE
Guard RSF feed direction in static seeder

### DIFF
--- a/scripts/seed-resilience-static.mjs
+++ b/scripts/seed-resilience-static.mjs
@@ -63,6 +63,8 @@ const WORLD_BANK_BASE = 'https://api.worldbank.org/v2';
 const WHO_BASE = 'https://ghoapi.azureedge.net/api';
 const RSF_RANKING_URL = 'https://rsf.org/en/ranking';
 const RSF_TOP_RANK_DIRECTION_GUARD_MAX_RANK = 10;
+// Top-10 RSF countries currently score in the 5-20 range; 30 is a conservative
+// upper bound before treating the feed as direction-inverted.
 const RSF_TOP_RANK_ABUSE_INDEX_MAX_SCORE = 30;
 const EUROSTAT_ENERGY_URL = 'https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/nrg_ind_id?freq=A';
 const WB_ENERGY_IMPORT_INDICATOR = 'EG.IMP.CONS.ZS';

--- a/scripts/seed-resilience-static.mjs
+++ b/scripts/seed-resilience-static.mjs
@@ -62,6 +62,8 @@ const WHO_INDICATORS = {
 const WORLD_BANK_BASE = 'https://api.worldbank.org/v2';
 const WHO_BASE = 'https://ghoapi.azureedge.net/api';
 const RSF_RANKING_URL = 'https://rsf.org/en/ranking';
+const RSF_TOP_RANK_DIRECTION_GUARD_MAX_RANK = 10;
+const RSF_TOP_RANK_ABUSE_INDEX_MAX_SCORE = 30;
 const EUROSTAT_ENERGY_URL = 'https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/nrg_ind_id?freq=A';
 const WB_ENERGY_IMPORT_INDICATOR = 'EG.IMP.CONS.ZS';
 const COUNTRY_RESOLVERS = createCountryResolvers();
@@ -382,6 +384,24 @@ function parseDecimal(value) {
   return safeNum(String(value || '').replace(',', '.'));
 }
 
+function validateRsfFeedDirection(byCountry) {
+  const topRanked = [...byCountry.values()]
+    .filter((row) => row.rank <= RSF_TOP_RANK_DIRECTION_GUARD_MAX_RANK);
+
+  if (byCountry.size >= 100 && topRanked.length === 0) {
+    throw new Error('RSF ranking feed direction guard found no top-ranked countries');
+  }
+
+  const highScoreTopRanked = topRanked.filter((row) => row.score > RSF_TOP_RANK_ABUSE_INDEX_MAX_SCORE);
+  if (highScoreTopRanked.length === 0) return;
+
+  const examples = highScoreTopRanked
+    .slice(0, 3)
+    .map((row) => `rank ${row.rank} score ${row.score}`)
+    .join(', ');
+  throw new Error(`RSF ranking feed direction guard failed: top-ranked countries must have low lower-is-better abuse-index scores (${examples})`);
+}
+
 export function parseRsfRanking(html) {
   const byCountry = new Map();
   const rowRegex = /^\s*\|(\d+)\|([^|]+)\|([0-9]+(?:[.,][0-9]+)?)\|([^|]+)\|\s*(?:<[^>]+>)?\s*$/gm;
@@ -400,6 +420,7 @@ export function parseRsfRanking(html) {
       year: null,
     });
   }
+  validateRsfFeedDirection(byCountry);
   return byCountry;
 }
 

--- a/tests/resilience-static-seed.test.mjs
+++ b/tests/resilience-static-seed.test.mjs
@@ -434,6 +434,28 @@ describe('resilience static seed parsers', () => {
     );
   });
 
+  it('rejects full RSF feeds when no top-ranked countries resolve', () => {
+    const countryNames = JSON.parse(readFileSync(resolve('shared/country-names.json'), 'utf8'));
+    const rows = [];
+    const seenIso2 = new Set();
+
+    for (const countryName of Object.keys(countryNames)) {
+      const iso2 = resolveIso2({ name: countryName });
+      if (!iso2 || seenIso2.has(iso2)) continue;
+      seenIso2.add(iso2);
+      rows.push(`|${rows.length + 11}|${countryName}|42,00|0 (${rows.length + 11})|`);
+      if (rows.length >= 100) break;
+    }
+
+    assert.equal(rows.length, 100, 'fixture must exercise the full-feed guard path');
+    const html = `<div class="field__item">|Rank|Country|Note|Differential|\n${rows.join('\n')}</div>`;
+
+    assert.throws(
+      () => parseRsfRanking(html),
+      /RSF ranking feed direction guard found no top-ranked countries/,
+    );
+  });
+
   it('accepts current known RSF fixture shape with low top-ranked scores', () => {
     const html = `
       <div class="field__item">|Rank|Country|Note|Differential|

--- a/tests/resilience-static-seed.test.mjs
+++ b/tests/resilience-static-seed.test.mjs
@@ -394,7 +394,7 @@ describe('resilience static seed CSV parsers', () => {
 });
 
 describe('resilience static seed parsers', () => {
-  it('parses RSF ranking rows and skips aggregate entries', () => {
+  it('parses lower-is-better RSF abuse-index rows and skips aggregate entries', () => {
     const html = `
       <div class="field__item">|Rank|Country|Note|Differential|
       |3|Norway|6,52|-2 (1)|
@@ -418,6 +418,35 @@ describe('resilience static seed parsers', () => {
       rows.get('NO').score < rows.get('YE').score,
       'RSF parser must preserve feed direction: top-ranked country has lower raw RSF score than low-ranked country',
     );
+  });
+
+  it('rejects inverted high-score top-ranked RSF feeds', () => {
+    const html = `
+      <div class="field__item">|Rank|Country|Note|Differential|
+      |1|Finland|93,62|+1 (2)|
+      |3|Norway|93,48|-2 (1)|
+      |169|Yemen|30,78|+2 (171)|</div>
+    `;
+
+    assert.throws(
+      () => parseRsfRanking(html),
+      /RSF ranking feed direction guard failed: top-ranked countries must have low lower-is-better abuse-index scores/,
+    );
+  });
+
+  it('accepts current known RSF fixture shape with low top-ranked scores', () => {
+    const html = `
+      <div class="field__item">|Rank|Country|Note|Differential|
+      |1|Finland|6,38|+1 (2)|
+      |3|Norway|6,52|-2 (1)|
+      |32|United States|18,22|+15 (47)|</div>
+    `;
+
+    const rows = parseRsfRanking(html);
+    assert.equal(rows.get('FI')?.rank, 1);
+    assert.equal(rows.get('FI')?.score, 6.38);
+    assert.equal(rows.get('NO')?.rank, 3);
+    assert.equal(rows.get('NO')?.score, 6.52);
   });
 
   it('parses Eurostat energy dependency and keeps the latest TOTAL series value', () => {


### PR DESCRIPTION
## Summary
- add a fail-closed RSF parser invariant for top-ranked countries carrying high scores
- keep RSF lower-is-better scorer math unchanged
- add focused parser coverage for accepted lower-is-better rows, inverted rejection, and current FI/NO fixture shape

## Validation
- ./node_modules/.bin/tsx --test tests/resilience-static-seed.test.mjs
- ./node_modules/.bin/tsx --test tests/resilience-dimension-scorers.test.mts
- ./node_modules/.bin/biome lint scripts/seed-resilience-static.mjs tests/resilience-static-seed.test.mjs
- npm run typecheck
- live RSF parser smoke: status 200, parsed 176 countries, FI rank 1 score 6.38, NO rank 3 score 6.52
- git push pre-push hook: typecheck, typecheck:api, boundary/safe-html/rate-limit/premium-fetch checks, resilience tests, seed tests, version check