### PR TITLE
fix(resilience): recognize planned WTO trade status

### DIFF
--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -1036,7 +1036,7 @@ export function countTradeBarriers(raw: unknown, countryCode: string): number {
 function tradePolicyStatusSeverity(status: unknown): number {
   const normalized = String(status ?? '').trim().toUpperCase().replace(/[^A-Z0-9]+/g, '_');
   if (normalized === 'LOW') return 0;
-  if (normalized === 'MODERATE' || normalized === 'MEDIUM') return 1;
+  if (normalized === 'MODERATE' || normalized === 'MEDIUM' || normalized === 'PLANNED') return 1;
   if (normalized === 'HIGH' || normalized === 'IN_FORCE') return 2;
   if (normalized !== '') {
     console.warn(`[Resilience] tradePolicyStatusSeverity: unrecognized status "${status}", defaulting to moderate`);

--- a/tests/resilience-trade-policy-formula.test.mts
+++ b/tests/resilience-trade-policy-formula.test.mts
@@ -246,7 +246,7 @@ describe('scoreTradePolicy — 3-component weighted-blend formula (Ship 1 contra
       };
       const result = await scoreTradePolicy(TEST_ISO2, reader);
       assert.equal(result.score, 50, `unknown statuses must keep moderate fallback scoring, got ${result.score}`);
-      assert.equal(warnings.length, 2, `expected one warning per unknown WTO status, got ${warnings.length}`);
+      assert.equal(warnings.length, 2, `expected 2 warnings, one per unknown WTO status, got ${warnings.length}`);
       assert.ok(
         warnings.every((warning) => warning.includes('unrecognized status') && warning.includes('defaulting to moderate')),
         `unexpected warning text: ${JSON.stringify(warnings)}`,

--- a/tests/resilience-trade-policy-formula.test.mts
+++ b/tests/resilience-trade-policy-formula.test.mts
@@ -184,7 +184,7 @@ describe('scoreTradePolicy — 3-component weighted-blend formula (Ship 1 contra
     assert.equal(result.coverage, 0.60, `WTO-only coverage must remain 0.60, got ${result.coverage}`);
   });
 
-  it('unrecognized WTO statuses warn and default to moderate', async () => {
+  it('planned WTO status is a recognized moderate-severity row and does not warn', async () => {
     const originalWarn = console.warn;
     const warnings: string[] = [];
     console.warn = (message?: unknown) => { warnings.push(String(message)); };
@@ -194,7 +194,41 @@ describe('scoreTradePolicy — 3-component weighted-blend formula (Ship 1 contra
           return {
             restrictions: [{
               reportingCountry: TEST_ISO2,
-              status: 'modearte',
+              status: 'PLANNED',
+            }],
+            _reporterCountries: [TEST_ISO2],
+          };
+        }
+        if (key === 'trade:barriers:v1:tariff-gap:50') {
+          return {
+            barriers: [{
+              notifyingCountry: TEST_ISO2,
+              status: 'planned',
+            }],
+            _reporterCountries: [TEST_ISO2],
+          };
+        }
+        return null;
+      };
+      const result = await scoreTradePolicy(TEST_ISO2, reader);
+      assert.equal(result.score, 50, `planned statuses must score at moderate severity, got ${result.score}`);
+      assert.deepEqual(warnings, [], `planned statuses must not warn, got ${JSON.stringify(warnings)}`);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  it('UNKNOWN WTO statuses still warn and default to moderate', async () => {
+    const originalWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (message?: unknown) => { warnings.push(String(message)); };
+    try {
+      const reader: ResilienceSeedReader = async (key) => {
+        if (key === 'trade:restrictions:v1:tariff-overview:50') {
+          return {
+            restrictions: [{
+              reportingCountry: TEST_ISO2,
+              status: 'UNKNOWN',
             }],
             _reporterCountries: [TEST_ISO2],
           };


### PR DESCRIPTION
## Summary
- Recognize WTO PLANNED trade-policy statuses as the expected moderate severity bucket.
- Keep warnings for truly unrecognized non-empty statuses, including UNKNOWN.
- Add focused trade-policy tests for PLANNED no-warn behavior and UNKNOWN warning fallback.

## Verification
- ./node_modules/.bin/tsx --test tests/resilience-trade-policy-formula.test.mts
- ./node_modules/.bin/tsx --test tests/resilience-release-gate.test.mts
- git push pre-push hook: typecheck, typecheck:api, Convex type check, lint/guardrails, resilience tests, server handler tests, version check

## Live feed check
- Repo fixture verified: tests/helpers/resilience-release-fixtures.mts emits status: PLANNED.
- Local environment has no WTO_API_KEY, so live WTO seed fetch was not run.
- Current seeder code emits low/moderate/high through deriveWtoSeverityStatus().