### PR TITLE
Fix governance WGI indicator slot weighting

### DIFF
--- a/scripts/compare-resilience-current-vs-proposed.mjs
+++ b/scripts/compare-resilience-current-vs-proposed.mjs
@@ -399,6 +399,9 @@ const EXTRACTION_RULES = {
 // before the includes() calls at L770-776).
 const AQUASTAT_STRESS_KEYWORDS = ['stress', 'withdrawal', 'dependency'];
 const AQUASTAT_AVAILABILITY_KEYWORDS = ['availability', 'renewable', 'access'];
+// Keep in sync with server/worldmonitor/resilience/v1/_dimension-scorers.ts.
+// This plain .mjs comparison harness duplicates the documented six-slot WGI
+// contract instead of importing TypeScript scorer internals.
 const WGI_INDICATOR_KEYS = ['VA.EST', 'PV.EST', 'GE.EST', 'RQ.EST', 'RL.EST', 'CC.EST'];
 
 function normalizeLowerBetter(value, best, worst) {

--- a/scripts/compare-resilience-current-vs-proposed.mjs
+++ b/scripts/compare-resilience-current-vs-proposed.mjs
@@ -25,6 +25,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { RESILIENCE_COHORTS } from '../tests/helpers/resilience-cohorts.mts';
 import { MATCHED_PAIRS } from '../tests/helpers/resilience-matched-pairs.mts';
+import wgiIndicatorKeys from '../shared/wgi-indicator-keys.json' with { type: 'json' };
 
 const __filename = fileURLToPath(import.meta.url);
 const REPO_ROOT = path.resolve(path.dirname(__filename), '..');
@@ -399,10 +400,7 @@ const EXTRACTION_RULES = {
 // before the includes() calls at L770-776).
 const AQUASTAT_STRESS_KEYWORDS = ['stress', 'withdrawal', 'dependency'];
 const AQUASTAT_AVAILABILITY_KEYWORDS = ['availability', 'renewable', 'access'];
-// Keep in sync with server/worldmonitor/resilience/v1/_dimension-scorers.ts.
-// This plain .mjs comparison harness duplicates the documented six-slot WGI
-// contract instead of importing TypeScript scorer internals.
-const WGI_INDICATOR_KEYS = ['VA.EST', 'PV.EST', 'GE.EST', 'RQ.EST', 'RL.EST', 'CC.EST'];
+const WGI_INDICATOR_KEYS = wgiIndicatorKeys;
 
 function normalizeLowerBetter(value, best, worst) {
   return Math.max(0, Math.min(100, 100 * (1 - (value - best) / (worst - best))));

--- a/scripts/compare-resilience-current-vs-proposed.mjs
+++ b/scripts/compare-resilience-current-vs-proposed.mjs
@@ -399,6 +399,7 @@ const EXTRACTION_RULES = {
 // before the includes() calls at L770-776).
 const AQUASTAT_STRESS_KEYWORDS = ['stress', 'withdrawal', 'dependency'];
 const AQUASTAT_AVAILABILITY_KEYWORDS = ['availability', 'renewable', 'access'];
+const WGI_INDICATOR_KEYS = ['VA.EST', 'PV.EST', 'GE.EST', 'RQ.EST', 'RL.EST', 'CC.EST'];
 
 function normalizeLowerBetter(value, best, worst) {
   return Math.max(0, Math.min(100, 100 * (1 - (value - best) / (worst - best))));
@@ -433,8 +434,12 @@ const STATIC_EXTRACTORS = {
   'static-wgi': (rule, { staticRecord }) =>
     staticRecord?.wgi?.indicators?.[rule.code]?.value ?? null,
   'static-wgi-mean': (_rule, { staticRecord }) => {
-    const entries = Object.values(staticRecord?.wgi?.indicators ?? {})
-      .map((e) => (typeof e?.value === 'number' ? e.value : null))
+    const indicators = staticRecord?.wgi?.indicators ?? {};
+    const entries = WGI_INDICATOR_KEYS
+      .map((key) => {
+        const value = indicators[key]?.value;
+        return typeof value === 'number' ? value : null;
+      })
       .filter((v) => v != null);
     if (entries.length === 0) return null;
     return entries.reduce((s, v) => s + v, 0) / entries.length;

--- a/scripts/shared/wgi-indicator-keys.json
+++ b/scripts/shared/wgi-indicator-keys.json
@@ -1,0 +1,8 @@
+[
+  "VA.EST",
+  "PV.EST",
+  "GE.EST",
+  "RQ.EST",
+  "RL.EST",
+  "CC.EST"
+]

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -1,5 +1,6 @@
 import countryNames from '../../../../shared/country-names.json';
 import iso2ToIso3Json from '../../../../shared/iso2-to-iso3.json';
+import wgiIndicatorKeys from '../../../../shared/wgi-indicator-keys.json';
 import { normalizeCountryToken } from '../../../_shared/country-token';
 import { getCachedJson } from '../../../_shared/redis';
 import { classifyDimensionFreshness, readFreshnessMap, resolveSeedMetaKey } from './_dimension-freshness';
@@ -691,9 +692,7 @@ const IMPUTATION_CLASS_TIE_BREAK: readonly ImputationClass[] = [
 ];
 
 const MINUTE_MS = 60 * 1000;
-// Keep in sync with scripts/compare-resilience-current-vs-proposed.mjs. The
-// methodology documents exactly these six equal-weight WGI indicator slots.
-const WGI_INDICATOR_KEYS = ['VA.EST', 'PV.EST', 'GE.EST', 'RQ.EST', 'RL.EST', 'CC.EST'] as const;
+const WGI_INDICATOR_KEYS: readonly string[] = wgiIndicatorKeys;
 
 function weightedBlend(metrics: WeightedMetric[]): ResilienceDimensionScore {
   const totalWeight = metrics.reduce((sum, metric) => sum + metric.weight, 0);

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -691,6 +691,7 @@ const IMPUTATION_CLASS_TIE_BREAK: readonly ImputationClass[] = [
 ];
 
 const MINUTE_MS = 60 * 1000;
+const WGI_INDICATOR_KEYS = ['VA.EST', 'PV.EST', 'GE.EST', 'RQ.EST', 'RL.EST', 'CC.EST'] as const;
 
 function weightedBlend(metrics: WeightedMetric[]): ResilienceDimensionScore {
   const totalWeight = metrics.reduce((sum, metric) => sum + metric.weight, 0);
@@ -909,9 +910,20 @@ function getStaticIndicatorValue(
 
 function getStaticWgiValues(record: ResilienceStaticCountryRecord | null): number[] {
   const indicators = record?.wgi?.indicators ?? {};
-  return Object.values(indicators)
-    .map((entry) => safeNum(entry?.value))
+  return WGI_INDICATOR_KEYS
+    .map((key) => safeNum(indicators[key]?.value))
     .filter((value): value is number => value != null);
+}
+
+function getStaticWgiRows(record: ResilienceStaticCountryRecord | null): WeightedMetric[] {
+  const indicators = record?.wgi?.indicators ?? {};
+  return WGI_INDICATOR_KEYS.map((key) => {
+    const value = safeNum(indicators[key]?.value);
+    return {
+      score: value == null ? null : normalizeHigherBetter(value, -2.5, 2.5),
+      weight: 1,
+    };
+  });
 }
 
 function getImfMacroEntry(raw: unknown, countryCode: string): ImfMacroEntry | null {
@@ -1886,8 +1898,7 @@ export async function scoreGovernanceInstitutional(
   reader: ResilienceSeedReader = defaultSeedReader,
 ): Promise<ResilienceDimensionScore> {
   const staticRecord = await readStaticCountry(countryCode, reader);
-  const wgiScores = getStaticWgiValues(staticRecord).map((value) => normalizeHigherBetter(value, -2.5, 2.5));
-  return weightedBlend(wgiScores.map((score) => ({ score, weight: 1 })));
+  return weightedBlend(getStaticWgiRows(staticRecord));
 }
 
 export async function scoreSocialCohesion(

--- a/server/worldmonitor/resilience/v1/_dimension-scorers.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-scorers.ts
@@ -691,6 +691,8 @@ const IMPUTATION_CLASS_TIE_BREAK: readonly ImputationClass[] = [
 ];
 
 const MINUTE_MS = 60 * 1000;
+// Keep in sync with scripts/compare-resilience-current-vs-proposed.mjs. The
+// methodology documents exactly these six equal-weight WGI indicator slots.
 const WGI_INDICATOR_KEYS = ['VA.EST', 'PV.EST', 'GE.EST', 'RQ.EST', 'RL.EST', 'CC.EST'] as const;
 
 function weightedBlend(metrics: WeightedMetric[]): ResilienceDimensionScore {

--- a/shared/wgi-indicator-keys.json
+++ b/shared/wgi-indicator-keys.json
@@ -1,0 +1,8 @@
+[
+  "VA.EST",
+  "PV.EST",
+  "GE.EST",
+  "RQ.EST",
+  "RL.EST",
+  "CC.EST"
+]

--- a/tests/helpers/resilience-fixtures.mts
+++ b/tests/helpers/resilience-fixtures.mts
@@ -4,12 +4,12 @@ export const RESILIENCE_FIXTURES: FixtureMap = {
   'resilience:static:NO': {
     wgi: {
       indicators: {
-        VA: { value: 1.9, year: 2025 },
-        PV: { value: 1.7, year: 2025 },
-        GE: { value: 1.8, year: 2025 },
-        RQ: { value: 1.9, year: 2025 },
-        RL: { value: 1.8, year: 2025 },
-        CC: { value: 1.9, year: 2025 },
+        'VA.EST': { value: 1.9, year: 2025 },
+        'PV.EST': { value: 1.7, year: 2025 },
+        'GE.EST': { value: 1.8, year: 2025 },
+        'RQ.EST': { value: 1.9, year: 2025 },
+        'RL.EST': { value: 1.8, year: 2025 },
+        'CC.EST': { value: 1.9, year: 2025 },
       },
     },
     infrastructure: {
@@ -41,12 +41,12 @@ export const RESILIENCE_FIXTURES: FixtureMap = {
   'resilience:static:US': {
     wgi: {
       indicators: {
-        VA: { value: 0.9, year: 2025 },
-        PV: { value: 0.6, year: 2025 },
-        GE: { value: 1.1, year: 2025 },
-        RQ: { value: 1.2, year: 2025 },
-        RL: { value: 1.0, year: 2025 },
-        CC: { value: 1.1, year: 2025 },
+        'VA.EST': { value: 0.9, year: 2025 },
+        'PV.EST': { value: 0.6, year: 2025 },
+        'GE.EST': { value: 1.1, year: 2025 },
+        'RQ.EST': { value: 1.2, year: 2025 },
+        'RL.EST': { value: 1.0, year: 2025 },
+        'CC.EST': { value: 1.1, year: 2025 },
       },
     },
     infrastructure: {
@@ -78,12 +78,12 @@ export const RESILIENCE_FIXTURES: FixtureMap = {
   'resilience:static:YE': {
     wgi: {
       indicators: {
-        VA: { value: -1.9, year: 2025 },
-        PV: { value: -2.3, year: 2025 },
-        GE: { value: -1.8, year: 2025 },
-        RQ: { value: -1.7, year: 2025 },
-        RL: { value: -2.0, year: 2025 },
-        CC: { value: -2.1, year: 2025 },
+        'VA.EST': { value: -1.9, year: 2025 },
+        'PV.EST': { value: -2.3, year: 2025 },
+        'GE.EST': { value: -1.8, year: 2025 },
+        'RQ.EST': { value: -1.7, year: 2025 },
+        'RL.EST': { value: -2.0, year: 2025 },
+        'CC.EST': { value: -2.1, year: 2025 },
       },
     },
     infrastructure: {

--- a/tests/resilience-dimension-monotonicity.test.mts
+++ b/tests/resilience-dimension-monotonicity.test.mts
@@ -127,16 +127,16 @@ describe('resilience dimension monotonicity — scoreImportConcentration', () =>
 
 describe('resilience dimension monotonicity — scoreGovernanceInstitutional', () => {
   async function scoreWith(wgiMeanValue: number) {
-    // Static-record shape per `getStaticWgiValues`: `wgi.indicators.<name>.value`.
+    // Static-record shape per `getStaticWgiValues`: `wgi.indicators.<WGI code>.value`.
     const staticRecord = {
       wgi: {
         indicators: {
-          voiceAccountability:    { value: wgiMeanValue },
-          politicalStability:     { value: wgiMeanValue },
-          governmentEffectiveness:{ value: wgiMeanValue },
-          regulatoryQuality:      { value: wgiMeanValue },
-          ruleOfLaw:              { value: wgiMeanValue },
-          controlOfCorruption:    { value: wgiMeanValue },
+          'VA.EST': { value: wgiMeanValue },
+          'PV.EST': { value: wgiMeanValue },
+          'GE.EST': { value: wgiMeanValue },
+          'RQ.EST': { value: wgiMeanValue },
+          'RL.EST': { value: wgiMeanValue },
+          'CC.EST': { value: wgiMeanValue },
         },
       },
     };

--- a/tests/resilience-dimension-scorers.test.mts
+++ b/tests/resilience-dimension-scorers.test.mts
@@ -72,6 +72,13 @@ function assertResilientAboveImputed(label: string, no: number, us: number, ye: 
   assert.ok(us > ye, `${label}: expected US (${us}) > YE (${ye})`);
 }
 
+function staticRecordReader(staticRecord: unknown): ResilienceSeedReader {
+  return async (key: string): Promise<unknown | null> => {
+    if (key === 'resilience:static:XX') return staticRecord;
+    return null;
+  };
+}
+
 describe('resilience dimension scorers', () => {
   it('produce plausible country ordering for the economic dimensions', async () => {
     const macro = await scoreTriple(scoreMacroFiscal);
@@ -109,6 +116,79 @@ describe('resilience dimension scorers', () => {
     assertOrdered('informationCognitive', information.no.score, information.us.score, information.ye.score);
     assertOrdered('healthPublicService', health.no.score, health.us.score, health.ye.score);
     assertOrdered('foodWater', foodWater.no.score, foodWater.us.score, foodWater.ye.score);
+  });
+
+  it('scoreGovernanceInstitutional: all six documented WGI indicators keep the exact equal-weight formula', async () => {
+    const values = [-1.5, -0.9, 0.2, 0.6, 1.1, 1.8] as const;
+    const staticRecord = {
+      wgi: {
+        indicators: {
+          'VA.EST': { value: values[0], year: 2025 },
+          'PV.EST': { value: values[1], year: 2025 },
+          'GE.EST': { value: values[2], year: 2025 },
+          'RQ.EST': { value: values[3], year: 2025 },
+          'RL.EST': { value: values[4], year: 2025 },
+          'CC.EST': { value: values[5], year: 2025 },
+        },
+      },
+    };
+    const expectedScore = roundScore(values.reduce((sum, value) => sum + ((value + 2.5) / 5) * 100, 0) / values.length);
+
+    const result = await scoreGovernanceInstitutional('XX', staticRecordReader(staticRecord));
+
+    assert.equal(result.score, expectedScore);
+    assert.equal(result.coverage, 1);
+    assert.equal(result.observedWeight, 6);
+    assert.equal(result.imputedWeight, 0);
+  });
+
+  it('scoreGovernanceInstitutional: ignores rogue WGI indicators outside the documented six-code contract', async () => {
+    const staticRecord = {
+      wgi: {
+        indicators: {
+          'VA.EST': { value: -1.5, year: 2025 },
+          'PV.EST': { value: -0.9, year: 2025 },
+          'GE.EST': { value: 0.2, year: 2025 },
+          'RQ.EST': { value: 0.6, year: 2025 },
+          'RL.EST': { value: 1.1, year: 2025 },
+          'CC.EST': { value: 1.8, year: 2025 },
+        },
+      },
+    };
+    const withRogue = {
+      wgi: {
+        indicators: {
+          ...staticRecord.wgi.indicators,
+          'ROGUE.EST': { value: -2.5, year: 2025 },
+        },
+      },
+    };
+
+    const baseline = await scoreGovernanceInstitutional('XX', staticRecordReader(staticRecord));
+    const rogue = await scoreGovernanceInstitutional('XX', staticRecordReader(withRogue));
+
+    assert.deepEqual(rogue, baseline);
+  });
+
+  it('scoreGovernanceInstitutional: missing documented WGI keys lower coverage instead of reporting full coverage', async () => {
+    const staticRecord = {
+      wgi: {
+        indicators: {
+          'VA.EST': { value: -1.5, year: 2025 },
+          'PV.EST': { value: -0.9, year: 2025 },
+          'GE.EST': { value: 0.2, year: 2025 },
+          'RQ.EST': { value: 0.6, year: 2025 },
+          'RL.EST': { value: 1.1, year: 2025 },
+        },
+      },
+    };
+
+    const result = await scoreGovernanceInstitutional('XX', staticRecordReader(staticRecord));
+
+    assert.equal(result.coverage, 0.83);
+    assert.equal(result.observedWeight, 5);
+    assert.equal(result.imputedWeight, 0);
+    assert.equal(result.imputationClass, null);
   });
 
   it('returns all serialized dimensions with bounded scores and coverage', async () => {

--- a/tests/resilience-dimension-scorers.test.mts
+++ b/tests/resilience-dimension-scorers.test.mts
@@ -132,7 +132,8 @@ describe('resilience dimension scorers', () => {
         },
       },
     };
-    const expectedScore = roundScore(values.reduce((sum, value) => sum + ((value + 2.5) / 5) * 100, 0) / values.length);
+    const expectedSlotScores = values.map((value) => roundScore(((value + 2.5) / 5) * 100));
+    const expectedScore = roundScore(expectedSlotScores.reduce((sum, score) => sum + score, 0) / expectedSlotScores.length);
 
     const result = await scoreGovernanceInstitutional('XX', staticRecordReader(staticRecord));
 

--- a/tests/resilience-indicator-extraction-plan.test.mjs
+++ b/tests/resilience-indicator-extraction-plan.test.mjs
@@ -149,6 +149,20 @@ test('applyExtractionRule — static-wgi-mean averages all six WGI sub-pillars',
   assert.equal(applyExtractionRule(rule, sources, 'DE'), (1.0 + -1.0 + 0.5 + -0.5 + 2.0 + 0.0) / 6);
 });
 
+test('applyExtractionRule — static-wgi-mean ignores WGI keys outside the scorer contract', () => {
+  const rule = { type: 'static-wgi-mean' };
+  const sources = { staticRecord: { wgi: { indicators: {
+    'VA.EST': { value: 1.0 },
+    'PV.EST': { value: -1.0 },
+    'GE.EST': { value: 0.5 },
+    'RQ.EST': { value: -0.5 },
+    'RL.EST': { value: 2.0 },
+    'CC.EST': { value: 0.0 },
+    'ROGUE.EST': { value: -2.5 },
+  } } } };
+  assert.equal(applyExtractionRule(rule, sources, 'DE'), (1.0 + -1.0 + 0.5 + -0.5 + 2.0 + 0.0) / 6);
+});
+
 test('applyExtractionRule — missing values return null (pairwise-drop contract)', () => {
   const rule = { type: 'static-path', path: ['iea', 'energyImportDependency', 'value'] };
   assert.equal(applyExtractionRule(rule, {}, 'AE'), null);


### PR DESCRIPTION
## Summary
- Pin governance WGI scoring to the documented six World Bank indicator codes: VA.EST, PV.EST, GE.EST, RQ.EST, RL.EST, CC.EST.
- Ignore rogue extra WGI keys and materialize missing documented keys as null rows so coverage drops instead of reporting full coverage.
- Update resilience fixtures and monotonicity tests to use the canonical seeder key names.

## Missing-key semantics
A missing documented WGI key contributes a fixed-weight null row. weightedBlend still averages the score over available documented indicators, but coverage is computed against all six design-time slots. One missing key reports coverage 0.83, observedWeight 5, imputedWeight 0, imputationClass null.

## Validation
- ./node_modules/.bin/tsx --test tests/resilience-dimension-scorers.test.mts tests/resilience-dimension-monotonicity.test.mts tests/resilience-doc-parity.test.mts tests/resilience-indicator-registry.test.mts
- npm run typecheck
- Pre-push hook on git push -u origin codex/r4-4-wgi-fixed-contract passed full required checks, including API typecheck, lint guards, resilience tests, server handler tests, and version check.