### PR TITLE
fix(resilience): align v23 cache bump prose

### DIFF
--- a/scripts/seed-resilience-scores.mjs
+++ b/scripts/seed-resilience-scores.mjs
@@ -60,8 +60,12 @@ function requireSeedRefreshKey() {
 // v21 → v22 for country-resilience audit round 2 P2-N2/P2-N3: currencyExternal
 // inflation stability and NaN-safe blend math change published score values, so
 // seeder-written scores and rankings must share the server reader namespace.
-// v22 → v23 for country-resilience audit P3-8: observed zero-outage feeds now
-// score as observed-quiet in infrastructure, matching cyberDigital.
+// v22 → v23 batches three same-tag `pc` scorer changes: import-HHI stale /
+// missing source years now derate certainty coverage (#4088), observed
+// zero-outage feeds score as observed-quiet in infrastructure (P3-8), and WTO
+// tradePolicy restriction/barrier rows score one-row-per-reporter severity
+// instead of stale count anchors (P2-1). Seeder-written scores and rankings must
+// share the server reader namespace for the full batch.
 export const RESILIENCE_SCORE_CACHE_PREFIX = 'resilience:score:v23:';
 export const RESILIENCE_RANKING_CACHE_KEY = 'resilience:ranking:v23';
 // Must match the server-side RESILIENCE_RANKING_CACHE_TTL_SECONDS. Extended

--- a/tests/resilience-doc-parity.test.mts
+++ b/tests/resilience-doc-parity.test.mts
@@ -73,10 +73,14 @@ const DOCUMENTATION_PATH = resolve(here, '../docs/documentation.mdx');
 const FEATURES_PATH = resolve(here, '../docs/features.mdx');
 const STATIC_SEED_SCRIPT_PATH = resolve(here, '../scripts/seed-resilience-static.mjs');
 const HEALTH_API_PATH = resolve(here, '../api/health.js');
+const SEED_RESILIENCE_SCORES_PATH = resolve(here, '../scripts/seed-resilience-scores.mjs');
+const RESILIENCE_SHARED_PATH = resolve(here, '../server/worldmonitor/resilience/v1/_shared.ts');
 const RESILIENCE_OPENAPI_YAML_PATH = resolve(here, '../docs/api/ResilienceService.openapi.yaml');
 const RESILIENCE_OPENAPI_JSON_PATH = resolve(here, '../docs/api/ResilienceService.openapi.json');
 const BUNDLED_OPENAPI_YAML_PATH = resolve(here, '../docs/api/worldmonitor.openapi.yaml');
 const docText = readFileSync(DOC_PATH, 'utf8');
+const seedResilienceScoresText = readFileSync(SEED_RESILIENCE_SCORES_PATH, 'utf8');
+const resilienceSharedText = readFileSync(RESILIENCE_SHARED_PATH, 'utf8');
 const indicatorSourceCatalogText = readFileSync(INDICATOR_SOURCE_CATALOG_PATH, 'utf8');
 const staticSeedScriptText = readFileSync(STATIC_SEED_SCRIPT_PATH, 'utf8');
 const healthApiText = readFileSync(HEALTH_API_PATH, 'utf8');
@@ -110,6 +114,10 @@ const GENERATED_OPENAPI_SURFACES = [
     text: readFileSync(BUNDLED_OPENAPI_YAML_PATH, 'utf8'),
   },
 ];
+const RESILIENCE_V23_CACHE_BUMP_BATCH = {
+  previousVersion: 22,
+  currentVersion: 23,
+};
 const ACTIVE_ENERGY_V2_INDICATOR_WEIGHTS = new Map([
   ['importedFossilDependence', 0.35],
   ['lowCarbonGenerationShare', 0.20],
@@ -701,6 +709,54 @@ describe('methodology doc parity (Plan 2026-04-26-002 §U8)', () => {
     );
   });
 
+  it('v23 cache-bump prose names the same batched scorer changes in seeder, server, and docs', () => {
+    const { previousVersion, currentVersion } = RESILIENCE_V23_CACHE_BUMP_BATCH;
+    const surfaces = [
+      [
+        'scripts/seed-resilience-scores.mjs',
+        extractCommentBlockForCacheBump(
+          seedResilienceScoresText,
+          'RESILIENCE_SCORE_CACHE_PREFIX',
+          previousVersion,
+          currentVersion,
+        ),
+      ],
+      [
+        'server/worldmonitor/resilience/v1/_shared.ts',
+        extractCommentBlockForCacheBump(
+          resilienceSharedText,
+          'RESILIENCE_SCORE_CACHE_PREFIX',
+          previousVersion,
+          currentVersion,
+        ),
+      ],
+      [
+        'docs/methodology/country-resilience-index.mdx',
+        extractBoldParagraph(docText, '**Cache prefix bumps.**'),
+      ],
+    ] as const;
+
+    for (const [label, cacheBumpProse] of surfaces) {
+      assert.ok(
+        cacheBumpProse.includes(`v${previousVersion}`) && cacheBumpProse.includes(`v${currentVersion}`),
+        `${label} must describe the v${previousVersion} -> v${currentVersion} resilience cache bump`,
+      );
+      assert.ok(
+        cacheBumpProse.includes('import-HHI') &&
+          /certainty[\s\S]{0,80}derat|derat[\s\S]{0,80}certainty/.test(cacheBumpProse),
+        `${label} v23 cache-bump prose must mention the import-HHI source-year certainty derate`,
+      );
+      assert.ok(
+        cacheBumpProse.includes('P3-8') && cacheBumpProse.includes('observed-quiet'),
+        `${label} v23 cache-bump prose must mention P3-8 outage observed-quiet semantics`,
+      );
+      assert.ok(
+        cacheBumpProse.includes('WTO') && /severity scor|scor[\s\S]{0,80}severity/.test(cacheBumpProse),
+        `${label} v23 cache-bump prose must mention WTO trade-policy severity scoring`,
+      );
+    }
+  });
+
   it('indicator source catalog labels energy-v2 rows as active and legacy-only rows as replaced', () => {
     for (const id of ACTIVE_ENERGY_V2_INDICATOR_WEIGHTS.keys()) {
       const block = extractIndicatorSourceBlock(indicatorSourceCatalogText, id);
@@ -903,6 +959,37 @@ function extractIndicatorTextRowsForSection(
     });
   }
   return rows;
+}
+
+function extractBoldParagraph(text: string, startMarker: string): string {
+  const startIndex = text.indexOf(startMarker);
+  assert.notEqual(startIndex, -1, `Start marker "${startMarker}" not found.`);
+
+  const nextBoldParagraphMatch = /\n\n\*\*/.exec(text.slice(startIndex + startMarker.length));
+  assert.ok(nextBoldParagraphMatch, `Next bold paragraph marker not found after "${startMarker}".`);
+
+  return text.slice(startIndex, startIndex + startMarker.length + nextBoldParagraphMatch.index);
+}
+
+function extractCommentBlockForCacheBump(
+  text: string,
+  exportName: string,
+  previousVersion: number,
+  currentVersion: number,
+): string {
+  const exportIndex = text.indexOf(`export const ${exportName}`);
+  assert.notEqual(exportIndex, -1, `Export "${exportName}" not found.`);
+
+  const blockStart = text.lastIndexOf(`// v${previousVersion}`, exportIndex);
+  assert.notEqual(
+    blockStart,
+    -1,
+    `v${previousVersion} -> v${currentVersion} comment block not found before "${exportName}".`,
+  );
+
+  const nextBumpIndex = text.indexOf(`\n// v${currentVersion}`, blockStart + 1);
+  const blockEnd = nextBumpIndex !== -1 && nextBumpIndex < exportIndex ? nextBumpIndex : exportIndex;
+  return text.slice(blockStart, blockEnd);
 }
 
 function extractSectionText(text: string, sectionHeading: string): string {


### PR DESCRIPTION
## Summary
- Align the resilience score seeder's v23 cache-bump comment with the canonical server and methodology documentation.
- Add a focused doc/source parity assertion so the v23 batch continues to name import-HHI certainty derating, P3-8 observed-quiet outage semantics, and WTO severity scoring across seeder, server, and docs.

## Validation
- npm ci
- npx tsx --test tests/resilience-cache-keys-health-sync.test.mts
- npx tsx --test tests/resilience-doc-parity.test.mts
- npx tsx --test tests/resilience-scores-seed.test.mjs
- git diff --check
- pre-push hook on git push -u origin codex/resilience-v23-cache-comment-parity passed, including typecheck, API typecheck, boundary/safe-html/rate-limit/premium-fetch checks, resilience tests, seed tests, and version sync.