### PR TITLE
fix(resilience): single-source WGI indicator keys

### DIFF
--- a/scripts/seed-resilience-static.mjs
+++ b/scripts/seed-resilience-static.mjs
@@ -19,6 +19,7 @@ import {
   resolveIso2,
 } from './_country-resolver.mjs';
 import { isInRankableUniverse } from './shared/rankable-universe.mjs';
+import wgiIndicatorKeys from '../shared/wgi-indicator-keys.json' with { type: 'json' };
 
 export { createCountryResolvers, resolveIso2 } from './_country-resolver.mjs';
 
@@ -49,7 +50,7 @@ const LOCK_DOMAIN = 'resilience:static';
 const LOCK_TTL_MS = 2 * 60 * 60 * 1000;
 const TOTAL_DATASET_SLOTS = 11;
 const COUNTRY_DATASET_FIELDS = ['wgi', 'infrastructure', 'gpi', 'rsf', 'who', 'fao', 'aquastat', 'iea', 'tradeToGdp', 'fxReservesMonths', 'appliedTariffRate'];
-const WGI_INDICATORS = ['VA.EST', 'PV.EST', 'GE.EST', 'RQ.EST', 'RL.EST', 'CC.EST'];
+export const WGI_INDICATORS = wgiIndicatorKeys;
 const INFRASTRUCTURE_INDICATORS = ['EG.ELC.ACCS.ZS', 'IS.ROD.PAVE.ZS', 'EG.USE.ELEC.KH.PC', 'IT.NET.BBND.P2'];
 const WHO_INDICATORS = {
   hospitalBeds: 'WHS6_102',

--- a/scripts/shared/wgi-indicator-keys.json
+++ b/scripts/shared/wgi-indicator-keys.json
@@ -1,8 +1,0 @@
-[
-  "VA.EST",
-  "PV.EST",
-  "GE.EST",
-  "RQ.EST",
-  "RL.EST",
-  "CC.EST"
-]

--- a/tests/edge-functions.test.mjs
+++ b/tests/edge-functions.test.mjs
@@ -58,8 +58,13 @@ describe('scripts/shared/ stays in sync with shared/', () => {
     // by the audit script under scripts/. Must stay byte-identical.
     'url-classifier.js',
   ]);
+  const rootSharedOnlyFiles = new Set([
+    // Resilience .mjs scripts import this directly from ../shared/. Keeping a
+    // scripts/shared copy would reintroduce the WGI scorer/seeder drift risk.
+    'wgi-indicator-keys.json',
+  ]);
   const sharedFiles = readdirSync(sharedDir).filter(
-    (f) => f.endsWith('.json') || f.endsWith('.cjs') || explicitMirroredFiles.has(f),
+    (f) => !rootSharedOnlyFiles.has(f) && (f.endsWith('.json') || f.endsWith('.cjs') || explicitMirroredFiles.has(f)),
   );
   for (const file of sharedFiles) {
     it(`scripts/shared/${file} matches shared/${file}`, () => {

--- a/tests/resilience-dimension-scorers.test.mts
+++ b/tests/resilience-dimension-scorers.test.mts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import wgiIndicatorKeys from '../shared/wgi-indicator-keys.json' with { type: 'json' };
 
 import {
   IMPUTATION,
@@ -79,6 +80,11 @@ function staticRecordReader(staticRecord: unknown): ResilienceSeedReader {
   };
 }
 
+function wgiIndicatorsFromValues(values: readonly number[]): Record<string, { value: number; year: number }> {
+  assert.equal(values.length, wgiIndicatorKeys.length, 'test fixture must provide one value per canonical WGI indicator');
+  return Object.fromEntries(wgiIndicatorKeys.map((key, i) => [key, { value: values[i]!, year: 2025 }]));
+}
+
 describe('resilience dimension scorers', () => {
   it('produce plausible country ordering for the economic dimensions', async () => {
     const macro = await scoreTriple(scoreMacroFiscal);
@@ -122,14 +128,7 @@ describe('resilience dimension scorers', () => {
     const values = [-1.5, -0.9, 0.2, 0.6, 1.1, 1.8] as const;
     const staticRecord = {
       wgi: {
-        indicators: {
-          'VA.EST': { value: values[0], year: 2025 },
-          'PV.EST': { value: values[1], year: 2025 },
-          'GE.EST': { value: values[2], year: 2025 },
-          'RQ.EST': { value: values[3], year: 2025 },
-          'RL.EST': { value: values[4], year: 2025 },
-          'CC.EST': { value: values[5], year: 2025 },
-        },
+        indicators: wgiIndicatorsFromValues(values),
       },
     };
     const expectedSlotScores = values.map((value) => roundScore(((value + 2.5) / 5) * 100));
@@ -139,7 +138,7 @@ describe('resilience dimension scorers', () => {
 
     assert.equal(result.score, expectedScore);
     assert.equal(result.coverage, 1);
-    assert.equal(result.observedWeight, 6);
+    assert.equal(result.observedWeight, wgiIndicatorKeys.length);
     assert.equal(result.imputedWeight, 0);
   });
 

--- a/tests/resilience-indicator-extraction-plan.test.mjs
+++ b/tests/resilience-indicator-extraction-plan.test.mjs
@@ -13,6 +13,7 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import wgiIndicatorKeys from '../shared/wgi-indicator-keys.json' with { type: 'json' };
 
 const scriptMod = await import('../scripts/compare-resilience-current-vs-proposed.mjs');
 const registryMod = await import('../server/worldmonitor/resilience/v1/_indicator-registry.ts');
@@ -136,31 +137,36 @@ test('applyExtractionRule — static-wgi reads .wgi.indicators[code].value', () 
   assert.equal(applyExtractionRule(rule, sources, 'DE'), 1.2);
 });
 
+test('WGI extraction rules stay aligned with the canonical shared key list', () => {
+  const wgiRegistryIds = [
+    'wgiVoiceAccountability',
+    'wgiPoliticalStability',
+    'wgiGovernmentEffectiveness',
+    'wgiRegulatoryQuality',
+    'wgiRuleOfLaw',
+    'wgiControlOfCorruption',
+  ];
+  const extractionCodes = wgiRegistryIds.map((id) => EXTRACTION_RULES[id]?.code);
+  assert.deepEqual(extractionCodes, wgiIndicatorKeys);
+});
+
 test('applyExtractionRule — static-wgi-mean averages all six WGI sub-pillars', () => {
   const rule = { type: 'static-wgi-mean' };
-  const sources = { staticRecord: { wgi: { indicators: {
-    'VA.EST': { value: 1.0 },
-    'PV.EST': { value: -1.0 },
-    'GE.EST': { value: 0.5 },
-    'RQ.EST': { value: -0.5 },
-    'RL.EST': { value: 2.0 },
-    'CC.EST': { value: 0.0 },
-  } } } };
-  assert.equal(applyExtractionRule(rule, sources, 'DE'), (1.0 + -1.0 + 0.5 + -0.5 + 2.0 + 0.0) / 6);
+  const values = [1.0, -1.0, 0.5, -0.5, 2.0, 0.0];
+  const indicators = Object.fromEntries(wgiIndicatorKeys.map((key, i) => [key, { value: values[i] }]));
+  const sources = { staticRecord: { wgi: { indicators } } };
+  assert.equal(applyExtractionRule(rule, sources, 'DE'), values.reduce((sum, value) => sum + value, 0) / wgiIndicatorKeys.length);
 });
 
 test('applyExtractionRule — static-wgi-mean ignores WGI keys outside the scorer contract', () => {
   const rule = { type: 'static-wgi-mean' };
-  const sources = { staticRecord: { wgi: { indicators: {
-    'VA.EST': { value: 1.0 },
-    'PV.EST': { value: -1.0 },
-    'GE.EST': { value: 0.5 },
-    'RQ.EST': { value: -0.5 },
-    'RL.EST': { value: 2.0 },
-    'CC.EST': { value: 0.0 },
+  const values = [1.0, -1.0, 0.5, -0.5, 2.0, 0.0];
+  const indicators = {
+    ...Object.fromEntries(wgiIndicatorKeys.map((key, i) => [key, { value: values[i] }])),
     'ROGUE.EST': { value: -2.5 },
-  } } } };
-  assert.equal(applyExtractionRule(rule, sources, 'DE'), (1.0 + -1.0 + 0.5 + -0.5 + 2.0 + 0.0) / 6);
+  };
+  const sources = { staticRecord: { wgi: { indicators } } };
+  assert.equal(applyExtractionRule(rule, sources, 'DE'), values.reduce((sum, value) => sum + value, 0) / wgiIndicatorKeys.length);
 });
 
 test('applyExtractionRule — missing values return null (pairwise-drop contract)', () => {

--- a/tests/resilience-static-seed.test.mjs
+++ b/tests/resilience-static-seed.test.mjs
@@ -3,11 +3,13 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import wgiIndicatorKeys from '../shared/wgi-indicator-keys.json' with { type: 'json' };
 
 import {
   RESILIENCE_STATIC_INDEX_KEY,
   RESILIENCE_STATIC_META_KEY,
   RESILIENCE_STATIC_SOURCE_VERSION,
+  WGI_INDICATORS,
   buildFailureRefreshKeys,
   buildFaoAggregate,
   buildFaoAggregateForPublish,
@@ -78,6 +80,12 @@ describe('resilience static seed country normalization', () => {
     assert.equal(resolveIso2({ iso3: 'YEM' }, resolvers), 'YE');
     assert.equal(resolveIso2({ name: 'Cape Verde' }, resolvers), 'CV');
     assert.equal(resolveIso2({ name: 'OECS' }, resolvers), null);
+  });
+});
+
+describe('resilience static seed WGI indicator contract', () => {
+  it('fetchWgiDataset uses the canonical shared WGI key list', () => {
+    assert.deepEqual(WGI_INDICATORS, wgiIndicatorKeys);
   });
 });
 


### PR DESCRIPTION
## Summary

- imports the resilience static seeder WGI indicator list from the canonical shared/wgi-indicator-keys.json
- removes the unused duplicate scripts/shared/wgi-indicator-keys.json
- adds focused parity coverage so the seeder, scorer fixtures, and extraction harness stay aligned with the canonical WGI list

## Validation

- npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/resilience-static-seed.test.mjs
- npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/resilience-dimension-scorers.test.mts
- npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/resilience-indicator-extraction-plan.test.mjs
- git diff --check
- npm_config_cache=/tmp/worldmonitor-npm-cache npm ci
- npm_config_cache=/tmp/worldmonitor-npm-cache npm run typecheck
- normal git push -u origin codex/wgi-indicator-single-source pre-push hook passed, including typecheck, API typecheck, boundary/safe-html/rate-limit/premium-fetch checks, resilience tests, seed tests, and version sync

## Notes

Direct npx initially hit a local root-owned ~/.npm cache error, so validation used npm_config_cache=/tmp/worldmonitor-npm-cache.