### PR TITLE
Fix resilience Railway bundle registry coverage

### DIFF
--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -299,6 +299,39 @@ All new services share these settings:
 
 ---
 
+## Registry-covered live resilience services
+
+These live Country Resilience services are not slot-saving consolidation
+migrations and should not be counted in the 35-slot savings plan above. They
+are listed here so their Railway start commands are first-class registry-covered
+entries.
+
+### seed-bundle-resilience-recovery
+
+| Setting | Value |
+|---|---|
+| **Service name** | `seed-bundle-resilience-recovery` |
+| **Start command** | `node scripts/seed-bundle-resilience-recovery.mjs` |
+| **Cron schedule** | Monthly recovery cadence; use the active Railway schedule for the existing service |
+| **Watch paths** | `scripts/**`, `shared/**` |
+| **Purpose** | Dedicated Country Resilience recovery inputs bundle |
+| **Members** | Fiscal Space, Reserve Adequacy, External Debt, Import HHI, Fuel Stocks, Re-export Share, Sovereign Wealth |
+| **Note** | This is the service referenced by the Import-HHI controls below. It is registry-covered so nixpacks packaging and start-command drift are tested. |
+
+### seed-bundle-resilience-energy-v2
+
+| Setting | Value |
+|---|---|
+| **Service name** | `seed-bundle-resilience-energy-v2` |
+| **Start command** | `node scripts/seed-bundle-resilience-energy-v2.mjs` |
+| **Cron schedule** | `0 6 * * *` (daily 06:00 UTC; per-slot interval gates real seeds to 7 days) |
+| **Watch paths** | `scripts/**`, `shared/**` |
+| **Purpose** | Dedicated Country Resilience energy-v2 input bundle |
+| **Members** | Low Carbon Generation, Fossil Electricity Share, Power Losses |
+| **Note** | Daily cron avoids the weekly dead window described in `scripts/seed-bundle-resilience-energy-v2.mjs`; the bundle's 7-day section intervals prevent unnecessary World Bank polling. |
+
+---
+
 ## Services that STAY unchanged (54 total)
 
 ### Infrastructure (4)

--- a/scripts/railway-services.json
+++ b/scripts/railway-services.json
@@ -76,6 +76,18 @@
     "documentedAt": "docs/railway-seed-consolidation-runbook.md#seed-bundle-resilience"
   },
   {
+    "entry": "scripts/seed-bundle-resilience-recovery.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "seed-bundle-resilience-recovery",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#seed-bundle-resilience-recovery"
+  },
+  {
+    "entry": "scripts/seed-bundle-resilience-energy-v2.mjs",
+    "deployMode": "nixpacks-root-scripts",
+    "service": "seed-bundle-resilience-energy-v2",
+    "documentedAt": "docs/railway-seed-consolidation-runbook.md#seed-bundle-resilience-energy-v2"
+  },
+  {
     "entry": "scripts/seed-bundle-derived-signals.mjs",
     "deployMode": "nixpacks-root-scripts",
     "service": "seed-bundle-derived-signals",

--- a/tests/railway-services-registry-coverage.test.mts
+++ b/tests/railway-services-registry-coverage.test.mts
@@ -55,6 +55,11 @@ const DOCKERFILE_CMD_RE = /^\s*CMD\s+\[\s*"node"\s*,\s*"(scripts\/[^"]+)"\s*\]/m
 // Also tolerates `node` paths without backticks in case the runbook drifts.
 const RUNBOOK_START_RE = /\|\s*\*\*Start command\*\*\s*\|\s*`?node\s+(scripts\/\S+?\.(?:mjs|cjs|js))`?\s*\|/g;
 
+// Match script headers that document a manually provisioned Railway service:
+//   - Service name: seed-bundle-foo
+// The script filename itself is the start command source for this shape.
+const SCRIPT_HEADER_SERVICE_RE = /^\s*\/\/\s*-\s*Service name:\s*([a-z0-9-]+)\s*$/m;
+
 describe('Railway service registry coverage', () => {
   it('every Dockerfile.* CMD has a matching registry entry', () => {
     const dockerfiles = readdirSync(repoRoot)
@@ -120,6 +125,40 @@ describe('Railway service registry coverage', () => {
     }
   });
 
+  it('every script header-documented Railway service is registered', () => {
+    const missing: string[] = [];
+    const scriptFiles = readdirSync(resolve(repoRoot, 'scripts'))
+      .filter((f) => /\.(?:mjs|cjs|js)$/.test(f))
+      .sort();
+
+    for (const file of scriptFiles) {
+      const entry = `scripts/${file}`;
+      const src = readFileSync(resolve(repoRoot, entry), 'utf8');
+      const m = src.match(SCRIPT_HEADER_SERVICE_RE);
+      if (!m) continue;
+
+      const service = m[1]!;
+      const registered = registry.find((r) => r.entry === entry);
+      if (!registered) {
+        missing.push(`${entry} documents Railway service '${service}' but registry has no matching entry`);
+        continue;
+      }
+      if (registered.service !== service) {
+        missing.push(
+          `${entry} documents Railway service '${service}' but registry service is '${registered.service}'`,
+        );
+      }
+    }
+
+    if (missing.length > 0) {
+      assert.fail(
+        `Script header-documented Railway services drift from scripts/railway-services.json:\n` +
+          missing.map((s) => `  - ${s}`).join('\n') +
+          `\n\nAdd the missing entry to the registry or update the documented service header.`,
+      );
+    }
+  });
+
   // Self-fixture: prove BOTH regex shapes match what they're supposed to.
   // Without this, a future "simplification" of either regex could silently
   // stop matching one shape, and the audit above would pass coincidentally
@@ -138,5 +177,16 @@ describe('Railway service registry coverage', () => {
     const m = RUNBOOK_START_RE.exec(sample);
     assert.ok(m, 'RUNBOOK_START_RE failed to match canonical Start command shape');
     assert.equal(m![1], 'scripts/seed-fake.mjs');
+  });
+
+  it('SCRIPT_HEADER_SERVICE_RE matches the documented script service header shape', () => {
+    const sample = [
+      '// Railway service config (set up manually via Railway dashboard or',
+      '// `railway service`):',
+      '//   - Service name: seed-bundle-fake',
+    ].join('\n');
+    const m = sample.match(SCRIPT_HEADER_SERVICE_RE);
+    assert.ok(m, 'SCRIPT_HEADER_SERVICE_RE failed to match canonical service header shape');
+    assert.equal(m![1], 'seed-bundle-fake');
   });
 });


### PR DESCRIPTION
## Summary
- register the resilience recovery and energy-v2 Railway bundle services
- document both bundle start commands as first-class runbook entries
- harden registry coverage for script header-documented Railway services

## Validation
- npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/railway-services-registry-coverage.test.mts tests/scripts-railway-nixpacks-no-escape-import.test.mts
- git diff --check
- pre-push hook passed on git push