### PR TITLE
fix(resilience): clarify SWF empty payload semantics

### DIFF
--- a/scripts/seed-sovereign-wealth.mjs
+++ b/scripts/seed-sovereign-wealth.mjs
@@ -1085,9 +1085,10 @@ if (process.argv[1]?.endsWith('seed-sovereign-wealth.mjs')) {
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: 86400,
-    // Empty payload is still acceptable while tiers 1/2 are stubbed
-    // and any transient Wikipedia outage occurs; downstream IMPUTE
-    // path handles it.
+    // Empty payload is publishable so seed-meta record_count=0 can
+    // surface total SWF coverage loss operationally. A present
+    // `{countries:{}}` payload is not IMPUTE downstream: scorer Path 3
+    // treats each country as structurally not-applicable.
     emptyDataIsFailure: false,
   }).catch((err) => {
     const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';


### PR DESCRIPTION
## Summary

- Correct the stale local `runSeed` comment in `scripts/seed-sovereign-wealth.mjs`.
- Clarify that an empty-but-present SWF payload is publishable for operational `record_count=0` visibility, but downstream scorer Path 3 treats `{countries:{}}` as structurally not-applicable rather than IMPUTE.
- Keep runtime behavior unchanged; existing tests already pin the total-outage/country-not-in-manifest semantics.

## Validation

- `./node_modules/.bin/tsx --test tests/resilience-construct-invariants.test.mts tests/resilience-dimension-scorers.test.mts tests/seed-sovereign-wealth.test.mjs` (`173` passed, `0` failed)
- `git diff --check`
- Pre-push hook on `git push -u origin codex/fix-swf-empty-payload-comment` passed: typecheck, API typecheck, Convex type check, CJS syntax, Unicode safety, boundary lint, safe HTML, Sentry coverage, rate-limit policies, premium-fetch parity, edge function bundle check, version sync