### PR TITLE
Pin import HHI staleness slope coverage

### DIFF
--- a/tests/resilience-construct-invariants.test.mts
+++ b/tests/resilience-construct-invariants.test.mts
@@ -77,6 +77,8 @@ describe('construct invariants — importConcentration', () => {
   });
 
   it('stale import-HHI fallback source years derate coverage without changing the HHI score', async () => {
+    assert.equal(computeImportHhiCertaintyCoverage(2021, 2026), 0.8);
+    assert.equal(computeImportHhiCertaintyCoverage(2020, 2026), 0.6);
     assert.equal(computeImportHhiCertaintyCoverage(2018, 2026), 0.3);
     const freshSourceYear = new Date().getFullYear() - 3;
     const fresh = await scoreWith(0.2, freshSourceYear);


### PR DESCRIPTION
## Summary
- Add mid-slope coverage assertions for `computeImportHhiCertaintyCoverage` so the import-HHI stale-year derate remains linear after the 4-year full-confidence window.
- Preserve existing fresh-window, floor, and missing-year behavior coverage.

## Validation
- `./node_modules/.bin/tsx --test tests/resilience-construct-invariants.test.mts`
- `git diff --check`
- Pre-push hook on `git push -u origin codex/resilience-import-hhi-slope-test` passed, including typecheck, API typecheck, boundary/safe-html/rate-limit/premium-fetch checks, resilience test sweep, and version sync.