### PR TITLE
fix(resilience): preserve unknown zero display

### DIFF
--- a/src/components/resilience-widget-utils.ts
+++ b/src/components/resilience-widget-utils.ts
@@ -230,7 +230,7 @@ export function getResilienceOverallDisplay(data: Pick<ResilienceScoreResponse, 
       hasScore: false,
       scoreForBar: 0,
       scoreLabel: 'n/a',
-      visualLevel,
+      visualLevel: 'unknown',
       visualLevelLabel: 'Insufficient data',
       serverLevelLabel: `API level: ${formatResilienceServerLevel(data.level)}`,
     };

--- a/src/components/resilience-widget-utils.ts
+++ b/src/components/resilience-widget-utils.ts
@@ -209,6 +209,10 @@ export function formatResilienceServerLevel(level: string | null | undefined): s
   return normalized.length > 0 ? normalized.replace(/_/g, ' ') : 'unknown';
 }
 
+function isUnknownResilienceServerLevel(level: string | null | undefined): boolean {
+  return String(level || '').trim().toLowerCase() === 'unknown';
+}
+
 export interface ResilienceOverallDisplay {
   hasScore: boolean;
   scoreForBar: number;
@@ -221,7 +225,7 @@ export interface ResilienceOverallDisplay {
 export function getResilienceOverallDisplay(data: Pick<ResilienceScoreResponse, 'overallScore' | 'level'>): ResilienceOverallDisplay {
   const rawScore = Number(data.overallScore);
   const visualLevel = getResilienceVisualLevel(rawScore);
-  if (visualLevel === 'unknown') {
+  if (visualLevel === 'unknown' || (rawScore === 0 && isUnknownResilienceServerLevel(data.level))) {
     return {
       hasScore: false,
       scoreForBar: 0,

--- a/tests/resilience-widget.test.mts
+++ b/tests/resilience-widget.test.mts
@@ -107,7 +107,7 @@ test('getResilienceOverallDisplay preserves API unknown zero as no score', () =>
     hasScore: false,
     scoreForBar: 0,
     scoreLabel: 'n/a',
-    visualLevel: 'very_low',
+    visualLevel: 'unknown',
     visualLevelLabel: 'Insufficient data',
     serverLevelLabel: 'API level: unknown',
   });

--- a/tests/resilience-widget.test.mts
+++ b/tests/resilience-widget.test.mts
@@ -101,6 +101,29 @@ test('getResilienceOverallDisplay treats negative and non-finite scores as insuf
   });
 });
 
+test('getResilienceOverallDisplay preserves API unknown zero as no score', () => {
+  assert.equal(getResilienceVisualLevel(0), 'very_low');
+  assert.deepEqual(getResilienceOverallDisplay({ overallScore: 0, level: 'unknown' }), {
+    hasScore: false,
+    scoreForBar: 0,
+    scoreLabel: 'n/a',
+    visualLevel: 'very_low',
+    visualLevelLabel: 'Insufficient data',
+    serverLevelLabel: 'API level: unknown',
+  });
+});
+
+test('getResilienceOverallDisplay keeps explicit zero scores when API level is real', () => {
+  assert.deepEqual(getResilienceOverallDisplay({ overallScore: 0, level: 'low' }), {
+    hasScore: true,
+    scoreForBar: 0,
+    scoreLabel: '0',
+    visualLevel: 'very_low',
+    visualLevelLabel: 'Visual band: VERY LOW',
+    serverLevelLabel: 'API level: low',
+  });
+});
+
 test('getResilienceOverallDisplay separates visual band from API level', () => {
   assert.deepEqual(getResilienceOverallDisplay({ overallScore: 61.2, level: 'medium' }), {
     hasScore: true,


### PR DESCRIPTION
## Summary
- Treat API/model sentinel level unknown with overallScore 0 as a no-score resilience display state.
- Preserve legitimate finite zero scores when the API level is explicit/real.
- Add focused widget utility regressions for both paths.

## Validation
- npm ci --cache /tmp/codex-npm-cache
- ./node_modules/.bin/tsx --test tests/resilience-widget.test.mts
- git diff --check
- git push pre-push hook: typecheck, typecheck:api, resilience tests, edge function tests, version sync