### PR TITLE
Fix resilience round5 source metadata parity

### DIFF
--- a/docs/methodology/indicator-sources.yaml
+++ b/docs/methodology/indicator-sources.yaml
@@ -140,7 +140,7 @@
   coveragePct: 0.75
   lastObservedYear: 2025
   license: Open
-  mechanismTestRationale: Active trade restrictions (in-force, weighted 3×) directly measure market-access loss.
+  mechanismTestRationale: WTO restriction severity directly measures market-access friction (low=0, moderate=1, high=2; lower is better).
   constructStatus: observed-mechanism
 
 - indicator: tradeBarriers
@@ -506,15 +506,15 @@
 - indicator: rsfPressFreedom
   dimension: informationCognitive
   domain: social-governance
-  weight: TBD
-  direction: higher-better
+  weight: 0.55
+  direction: lower-better
   source: Reporters Sans Frontieres
   seriesId: Press Freedom Index
   seriesUrl: https://rsf.org/en/index
   coveragePct: 0.85
   lastObservedYear: 2024
-  license: Proprietary-with-fair-use
-  mechanismTestRationale: Press freedom proxies quality of information-shock response and independent verification capacity.
+  license: open-attribution
+  mechanismTestRationale: RSF press-freedom risk directly measures information-environment fragility and independent-verification constraints; lower RSF score is better.
   constructStatus: observed-mechanism
 
 - indicator: languageNormalizedSocialVelocity

--- a/tests/resilience-doc-parity.test.mts
+++ b/tests/resilience-doc-parity.test.mts
@@ -781,6 +781,56 @@ describe('methodology doc parity (Plan 2026-04-26-002 §U8)', () => {
     );
   });
 
+  it('indicator source catalog mirrors scorer-derived metadata for round5 repaired rows', () => {
+    const repairedIds = ['tradeRestrictions', 'rsfPressFreedom'] as const;
+
+    for (const id of repairedIds) {
+      const block = extractIndicatorSourceBlock(indicatorSourceCatalogText, id);
+      const scorerSpec = SCORER_DOC_PARITY_SPECS.find((spec) => spec.id === id);
+      const registrySpec = INDICATOR_REGISTRY.find((indicator) => indicator.id === id);
+      assert.ok(scorerSpec, `${id} must be covered by scorer doc parity specs.`);
+      assert.ok(registrySpec, `${id} must exist in INDICATOR_REGISTRY.`);
+
+      assert.equal(
+        extractIndicatorSourceScalar(block, 'dimension'),
+        scorerSpec.dimension,
+        `${id} source-catalog dimension must mirror the scorer-derived dimension.`,
+      );
+      assert.equal(
+        Number(extractIndicatorSourceScalar(block, 'weight')),
+        scorerSpec.weight,
+        `${id} source-catalog weight must mirror the scorer-derived weightedBlend row.`,
+      );
+      assert.equal(
+        extractIndicatorSourceScalar(block, 'direction'),
+        indicatorSourceDirection(scorerSpec.registryDirection),
+        `${id} source-catalog direction must mirror scorer normalization.`,
+      );
+      assert.equal(
+        registrySpec.direction,
+        scorerSpec.registryDirection,
+        `${id} registry direction must mirror scorer normalization.`,
+      );
+      assert.deepEqual(
+        registrySpec.goalposts,
+        scorerSpec.registryGoalposts,
+        `${id} registry goalposts must mirror scorer normalization anchors.`,
+      );
+    }
+
+    const tradeRestrictionsBlock = extractIndicatorSourceBlock(indicatorSourceCatalogText, 'tradeRestrictions');
+    assert.doesNotMatch(
+      tradeRestrictionsBlock,
+      /weighted\s*3[×x]|in-force,\s*weighted/i,
+      'tradeRestrictions catalog rationale must not describe the retired active-restriction 3x count model.',
+    );
+    assert.match(
+      extractIndicatorSourceScalar(tradeRestrictionsBlock, 'mechanismTestRationale'),
+      /severity[\s\S]*low=0[\s\S]*moderate=1[\s\S]*high=2/i,
+      'tradeRestrictions catalog rationale must document the current WTO severity scoring model.',
+    );
+  });
+
   it('generated OpenAPI pillar weight prose matches PILLAR_WEIGHTS and formula semantics', () => {
     const expectedWeightList = PILLAR_ORDER
       .map((id) => PILLAR_WEIGHTS[id].toFixed(2))
@@ -955,6 +1005,12 @@ function extractIndicatorSourceScalar(block: string, field: string): string {
   const match = new RegExp(`^\\s*${escapeRegex(field)}:\\s*(.+)$`, 'm').exec(block);
   assert.ok(match, `indicator-sources.yaml field "${field}" not found in block:\n${block}`);
   return match[1].trim();
+}
+
+function indicatorSourceDirection(direction: 'higherBetter' | 'lowerBetter' | 'indicatorSemantics'): string {
+  if (direction === 'higherBetter') return 'higher-better';
+  if (direction === 'lowerBetter') return 'lower-better';
+  return 'composite';
 }
 
 function extractIndicatorRowForSection(


### PR DESCRIPTION
## Summary
- Align docs/methodology/indicator-sources.yaml with current Country Resilience scorer and indicator registry metadata for rsfPressFreedom and tradeRestrictions.
- Add a focused doc-parity guard so those round5 repaired rows mirror scorer-derived dimension, weight, direction, and registry goalposts.
- Remove the stale WTO in-force weighted 3x rationale and document the current severity model.

## Validation
- ./node_modules/.bin/tsx --test tests/resilience-doc-parity.test.mts
- ./node_modules/.bin/tsx --test tests/resilience-trade-policy-formula.test.mts
- git diff --check
- Pre-push hook passed, including typecheck, API typecheck, boundary/safe HTML/rate-limit/premium-fetch checks, resilience-triggered tests, version sync.