### PR TITLE
fix(seed-contract-probe): retry transient check failures to stop 503 flapping

### DIFF
--- a/api/seed-contract-probe.ts
+++ b/api/seed-contract-probe.ts
@@ -124,6 +124,16 @@ function hasEnvelopeShape(parsed: unknown): boolean {
   return !!seed && typeof seed === 'object' && typeof (seed as { fetchedAt?: unknown }).fetchedAt === 'number';
 }
 
+/**
+ * Serialise a thrown value for an operator-facing reason string. Strict-mode
+ * `catch` binds `err` as `unknown`, so a non-Error throw (`throw "str"`, a
+ * rejected plain object) would make `(err as Error).message` resolve to
+ * `undefined` at runtime — `String(err)` keeps the message useful.
+ */
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 export async function checkProbe(spec: ProbeSpec): Promise<ProbeResult> {
   const url = process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
@@ -136,7 +146,7 @@ export async function checkProbe(spec: ProbeSpec): Promise<ProbeResult> {
       signal: AbortSignal.timeout(3_000),
     });
   } catch (err) {
-    return { key: spec.key, shape: spec.shape, pass: false, reason: `fetch:${(err as Error).message}` };
+    return { key: spec.key, shape: spec.shape, pass: false, reason: `fetch:${errMessage(err)}` };
   }
   if (!resp.ok) return { key: spec.key, shape: spec.shape, pass: false, reason: `redis:${resp.status}` };
 
@@ -266,7 +276,7 @@ async function probeBoundaryOnce(
     }
     return { endpoint, pass: true, status: r.status };
   } catch (err) {
-    return { endpoint, pass: false, reason: `fetch:${(err as Error).message}` };
+    return { endpoint, pass: false, reason: `fetch:${errMessage(err)}` };
   }
 }
 
@@ -317,6 +327,6 @@ export default async function handler(req: Request): Promise<Response> {
     // than letting the edge function crash into an opaque Vercel platform 503 —
     // which would read identically to a real seed-contract failure in the
     // uptime monitor and send operators chasing the wrong thing.
-    return jsonResponse({ ok: false, error: `probe-exception:${(err as Error).message}` }, 503, cors);
+    return jsonResponse({ ok: false, error: `probe-exception:${errMessage(err)}` }, 503, cors);
   }
 }

--- a/api/seed-contract-probe.ts
+++ b/api/seed-contract-probe.ts
@@ -47,6 +47,8 @@ export interface ProbeResult {
   state?: string;
   records?: number;
   ageMs?: number;
+  /** Set when the first attempt failed but the retry passed (transient blip). */
+  recovered?: boolean;
 }
 
 export interface BoundaryResult {
@@ -54,6 +56,35 @@ export interface BoundaryResult {
   pass: boolean;
   status?: number;
   reason?: string;
+  /** Set when the first attempt failed but the retry passed (transient blip). */
+  recovered?: boolean;
+}
+
+/**
+ * A transient infra blip — an Upstash read timing out under its 3s budget, a
+ * Vercel cold-start on a boundary endpoint, or the sub-second window while a
+ * seeder rewrites a probed key — would otherwise flip this AND-of-12 health
+ * check to 503 on a single unlucky poll, surfacing as recurring ~3-minute
+ * "incidents" in uptime monitors even though no contract regressed.
+ *
+ * Retry each FAILING check exactly once: a real regression fails both attempts
+ * and still 503s; a transient passes the retry and stays green. Passing checks
+ * never retry, so the happy (all-green) path keeps its single-round-trip cost.
+ * `recovered` flags a check that only passed on the second attempt so operators
+ * can still see genuine flakiness in the response body.
+ */
+const RETRY_DELAY_MS = 500;
+
+export async function withRetry<T extends { pass: boolean; recovered?: boolean }>(
+  attempt: () => Promise<T>,
+  delayMs: number = RETRY_DELAY_MS,
+): Promise<T> {
+  const first = await attempt();
+  if (first.pass) return first;
+  if (delayMs > 0) await new Promise((resolve) => setTimeout(resolve, delayMs));
+  const second = await attempt();
+  if (second.pass) second.recovered = true;
+  return second;
 }
 
 /**
@@ -109,7 +140,16 @@ export async function checkProbe(spec: ProbeSpec): Promise<ProbeResult> {
   }
   if (!resp.ok) return { key: spec.key, shape: spec.shape, pass: false, reason: `redis:${resp.status}` };
 
-  const body = (await resp.json()) as { result?: string };
+  let body: { result?: string };
+  try {
+    body = (await resp.json()) as { result?: string };
+  } catch {
+    // Upstash returned a non-JSON body (a transient proxy/5xx error page served
+    // with a 2xx status). Surface it as a transient fail so withRetry() can
+    // recover it, instead of letting the throw bubble up and crash the edge
+    // function into an opaque Vercel platform 503.
+    return { key: spec.key, shape: spec.shape, pass: false, reason: 'redis-bad-json-body' };
+  }
   if (!body.result) return { key: spec.key, shape: spec.shape, pass: false, reason: 'missing' };
 
   let parsed: unknown;
@@ -163,7 +203,10 @@ const BOUNDARY_CHECKS: BoundaryCheck[] = [
   { endpoint: '/api/bootstrap' },
 ];
 
-export async function checkPublicBoundary(origin: string): Promise<BoundaryResult[]> {
+export async function checkPublicBoundary(
+  origin: string,
+  retryDelayMs: number = RETRY_DELAY_MS,
+): Promise<BoundaryResult[]> {
   // Endpoints behind validateApiKey() (e.g. /api/bootstrap) used to accept the
   // trusted-browser-origin path without a key. PR #3557 closed that bypass: the
   // ONLY no-Pro path now is a wms_-prefixed HMAC-signed session token. Mint one
@@ -173,81 +216,107 @@ export async function checkPublicBoundary(origin: string): Promise<BoundaryResul
   // If WM_SESSION_SECRET isn't configured, fall back to the bare request — the
   // boundary check will surface the missing-secret error as a 401 from
   // /api/bootstrap, which is the right operator signal.
+  // Mint the token ONCE and share it across both endpoints and any retry, so a
+  // recovered transient never pays for an extra signing round.
   let sessionToken: string | null = null;
   try { sessionToken = (await issueSessionToken()).token; } catch { /* no-op */ }
 
-  return Promise.all(BOUNDARY_CHECKS.map(async ({ endpoint, requireSourceHeader }): Promise<BoundaryResult> => {
-    try {
-      const headers: Record<string, string> = {
-        Origin: 'https://worldmonitor.app',
-        'User-Agent': 'WorldMonitor-SeedContractProbe/1.0',
-      };
-      if (sessionToken) headers['X-WorldMonitor-Key'] = sessionToken;
-      const r = await fetch(`${origin}${endpoint}`, {
-        signal: AbortSignal.timeout(5_000),
-        headers,
-      });
-      const text = await r.text();
-      // Detect any envelope leak in the response body. A substring match on
-      // the literal `"_seed":` is sufficient because `_seed` only appears on
-      // our envelopes — no third-party API we consume emits that key.
-      if (/"_seed"\s*:/.test(text)) {
-        return { endpoint, pass: false, status: r.status, reason: 'seed-leak' };
-      }
-      if (!r.ok) return { endpoint, pass: false, status: r.status, reason: `status:${r.status}` };
-      if (requireSourceHeader) {
-        // Header names are ASCII case-insensitive per RFC 7230; Response.headers.get()
-        // handles that. Comparing values case-insensitively too so a casing drift
-        // in the handler doesn't mask a broken cache-hit path.
-        const actual = r.headers.get(requireSourceHeader.name);
-        if ((actual ?? '').toLowerCase() !== requireSourceHeader.value.toLowerCase()) {
-          return {
-            endpoint, pass: false, status: r.status,
-            reason: `source:${actual ?? 'missing'}!=${requireSourceHeader.value}`,
-          };
-        }
-      }
-      return { endpoint, pass: true, status: r.status };
-    } catch (err) {
-      return { endpoint, pass: false, reason: `fetch:${(err as Error).message}` };
+  const headers: Record<string, string> = {
+    Origin: 'https://worldmonitor.app',
+    'User-Agent': 'WorldMonitor-SeedContractProbe/1.0',
+  };
+  if (sessionToken) headers['X-WorldMonitor-Key'] = sessionToken;
+
+  return Promise.all(
+    BOUNDARY_CHECKS.map((check) =>
+      withRetry(() => probeBoundaryOnce(origin, check, headers), retryDelayMs),
+    ),
+  );
+}
+
+async function probeBoundaryOnce(
+  origin: string,
+  { endpoint, requireSourceHeader }: BoundaryCheck,
+  headers: Record<string, string>,
+): Promise<BoundaryResult> {
+  try {
+    const r = await fetch(`${origin}${endpoint}`, {
+      signal: AbortSignal.timeout(5_000),
+      headers,
+    });
+    const text = await r.text();
+    // Detect any envelope leak in the response body. A substring match on
+    // the literal `"_seed":` is sufficient because `_seed` only appears on
+    // our envelopes — no third-party API we consume emits that key.
+    if (/"_seed"\s*:/.test(text)) {
+      return { endpoint, pass: false, status: r.status, reason: 'seed-leak' };
     }
-  }));
+    if (!r.ok) return { endpoint, pass: false, status: r.status, reason: `status:${r.status}` };
+    if (requireSourceHeader) {
+      // Header names are ASCII case-insensitive per RFC 7230; Response.headers.get()
+      // handles that. Comparing values case-insensitively too so a casing drift
+      // in the handler doesn't mask a broken cache-hit path.
+      const actual = r.headers.get(requireSourceHeader.name);
+      if ((actual ?? '').toLowerCase() !== requireSourceHeader.value.toLowerCase()) {
+        return {
+          endpoint, pass: false, status: r.status,
+          reason: `source:${actual ?? 'missing'}!=${requireSourceHeader.value}`,
+        };
+      }
+    }
+    return { endpoint, pass: true, status: r.status };
+  } catch (err) {
+    return { endpoint, pass: false, reason: `fetch:${(err as Error).message}` };
+  }
 }
 
 export default async function handler(req: Request): Promise<Response> {
   const cors = getCorsHeaders(req);
   if (req.method === 'OPTIONS') return new Response(null, { status: 204, headers: cors });
 
-  // Reuse RELAY_SHARED_SECRET — already provisioned for Vercel↔Railway
-  // internal auth, same trust boundary (ops/internal-only callers).
-  // Constant-time compare via the shared helper avoids the timing oracle
-  // a `!==` comparison would leak (see issue #3803 / PR #3823).
-  const secret = req.headers.get('x-probe-secret') ?? '';
-  const expected = process.env.RELAY_SHARED_SECRET;
-  if (!expected) return jsonResponse({ error: 'not-configured' }, 503, cors);
-  if (!(await timingSafeEqual(secret, expected))) {
-    return jsonResponse({ error: 'unauthorized' }, 401, cors);
+  try {
+    // Reuse RELAY_SHARED_SECRET — already provisioned for Vercel↔Railway
+    // internal auth, same trust boundary (ops/internal-only callers).
+    // Constant-time compare via the shared helper avoids the timing oracle
+    // a `!==` comparison would leak (see issue #3803 / PR #3823).
+    const secret = req.headers.get('x-probe-secret') ?? '';
+    const expected = process.env.RELAY_SHARED_SECRET;
+    if (!expected) return jsonResponse({ error: 'not-configured' }, 503, cors);
+    if (!(await timingSafeEqual(secret, expected))) {
+      return jsonResponse({ error: 'unauthorized' }, 401, cors);
+    }
+
+    // Each check retries once on failure so a single transient blip (Upstash
+    // timeout, cold-start, mid-rewrite key) doesn't flap the probe to 503.
+    const [checks, boundary] = await Promise.all([
+      Promise.all(DEFAULT_PROBES.map((spec) => withRetry(() => checkProbe(spec)))),
+      checkPublicBoundary(new URL(req.url).origin),
+    ]);
+
+    const passedKeys = checks.filter(c => c.pass).length;
+    const failedKeys = checks.length - passedKeys;
+    const passedBoundary = boundary.filter(b => b.pass).length;
+    const failedBoundary = boundary.length - passedBoundary;
+    const recovered = [...checks, ...boundary].filter(r => r.recovered).length;
+    const ok = failedKeys === 0 && failedBoundary === 0;
+
+    return jsonResponse({
+      ok,
+      summary: {
+        probes: { passed: passedKeys, failed: failedKeys, total: checks.length },
+        boundary: { passed: passedBoundary, failed: failedBoundary, total: boundary.length },
+        recovered,
+      },
+      checks,
+      boundary,
+      checkedAt: new Date().toISOString(),
+    }, ok ? 200 : 503, cors);
+  } catch (err) {
+    // A guard slipped somewhere (an unexpected throw from issueSessionToken, a
+    // malformed upstream response, etc.). Return a clean, debuggable 503 rather
+    // than letting the edge function crash into an opaque Vercel platform 503 —
+    // which would read identically to a real seed-contract failure in the
+    // uptime monitor and send operators chasing the wrong thing.
+    return jsonResponse({ ok: false, error: `probe-exception:${(err as Error).message}` }, 503, cors);
   }
-
-  const [checks, boundary] = await Promise.all([
-    Promise.all(DEFAULT_PROBES.map(checkProbe)),
-    checkPublicBoundary(new URL(req.url).origin),
-  ]);
-
-  const passedKeys = checks.filter(c => c.pass).length;
-  const failedKeys = checks.length - passedKeys;
-  const passedBoundary = boundary.filter(b => b.pass).length;
-  const failedBoundary = boundary.length - passedBoundary;
-  const ok = failedKeys === 0 && failedBoundary === 0;
-
-  return jsonResponse({
-    ok,
-    summary: {
-      probes: { passed: passedKeys, failed: failedKeys, total: checks.length },
-      boundary: { passed: passedBoundary, failed: failedBoundary, total: boundary.length },
-    },
-    checks,
-    boundary,
-    checkedAt: new Date().toISOString(),
-  }, ok ? 200 : 503, cors);
 }

--- a/tests/seed-contract-probe.test.mjs
+++ b/tests/seed-contract-probe.test.mjs
@@ -13,7 +13,7 @@ process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
 process.env.RELAY_SHARED_SECRET = 'test-secret';
 
 // tsx resolves .ts imports for node:test.
-const { checkProbe, checkPublicBoundary, DEFAULT_PROBES } = await import('../api/seed-contract-probe.ts');
+const { checkProbe, checkPublicBoundary, DEFAULT_PROBES, withRetry } = await import('../api/seed-contract-probe.ts');
 
 const originalFetch = globalThis.fetch;
 afterEach(() => { globalThis.fetch = originalFetch; });
@@ -136,7 +136,7 @@ test('checkPublicBoundary: product-catalog served from cache + bootstrap no leak
     },
     { '/api/product-catalog': { 'x-product-catalog-source': 'cache' } },
   );
-  const res = await checkPublicBoundary('https://example.test');
+  const res = await checkPublicBoundary('https://example.test', 0);
   assert.equal(res.every(r => r.pass), true, JSON.stringify(res));
 });
 
@@ -150,7 +150,7 @@ test('checkPublicBoundary: product-catalog served from fallback fails source-hea
     },
     { '/api/product-catalog': { 'x-product-catalog-source': 'fallback' } },
   );
-  const res = await checkPublicBoundary('https://example.test');
+  const res = await checkPublicBoundary('https://example.test', 0);
   const pc = res.find(r => r.endpoint === '/api/product-catalog');
   assert.equal(pc.pass, false);
   assert.match(pc.reason, /source:fallback!=cache/);
@@ -161,7 +161,7 @@ test('checkPublicBoundary: product-catalog missing source header fails', async (
     '/api/product-catalog': JSON.stringify({ tiers: [] }),
     '/api/bootstrap':       JSON.stringify({}),
   });
-  const res = await checkPublicBoundary('https://example.test');
+  const res = await checkPublicBoundary('https://example.test', 0);
   const pc = res.find(r => r.endpoint === '/api/product-catalog');
   assert.equal(pc.pass, false);
   assert.match(pc.reason, /source:missing!=cache/);
@@ -175,7 +175,7 @@ test('checkPublicBoundary: response leaking _seed fails before source check', as
     },
     { '/api/product-catalog': { 'x-product-catalog-source': 'cache' } },
   );
-  const res = await checkPublicBoundary('https://example.test');
+  const res = await checkPublicBoundary('https://example.test', 0);
   assert.ok(res.some(r => !r.pass && r.reason === 'seed-leak'));
 });
 
@@ -183,7 +183,7 @@ test('checkPublicBoundary: bad status fails', async () => {
   globalThis.fetch = async () => ({
     ok: false, status: 502, text: async () => '', headers: { get: () => null },
   });
-  const res = await checkPublicBoundary('https://example.test');
+  const res = await checkPublicBoundary('https://example.test', 0);
   assert.ok(res.every(r => !r.pass && r.reason.startsWith('status:')));
 });
 
@@ -204,4 +204,64 @@ test('DEFAULT_PROBES: token-panels regression guards present (minRecords on all 
     assert.equal(p.shape, 'envelope');
     assert.equal(p.minRecords, 1, `${key} must enforce minRecords≥1`);
   }
+});
+
+// ─── retry / transient-recovery behavior ─────────────────────────────────
+// Regression guard for the recurring ~3-min 503 incidents: a single transient
+// blip on any one of the 12 checks must NOT flap the probe red. withRetry()
+// gives each failing check exactly one second chance.
+
+test('withRetry: passes a first-attempt success straight through (no second call)', async () => {
+  let calls = 0;
+  const r = await withRetry(async () => { calls += 1; return { pass: true, value: 1 }; }, 0);
+  assert.equal(calls, 1, 'a passing check must not retry');
+  assert.equal(r.pass, true);
+  assert.equal(r.recovered, undefined);
+});
+
+test('withRetry: recovers a transient failure on the retry and flags recovered', async () => {
+  let calls = 0;
+  const r = await withRetry(async () => { calls += 1; return { pass: calls > 1 }; }, 0);
+  assert.equal(calls, 2);
+  assert.equal(r.pass, true);
+  assert.equal(r.recovered, true, 'a check that only passed on retry must be flagged recovered');
+});
+
+test('withRetry: a persistent failure fails both attempts without recovered', async () => {
+  let calls = 0;
+  const r = await withRetry(async () => { calls += 1; return { pass: false, reason: 'hard' }; }, 0);
+  assert.equal(calls, 2, 'a real regression must be re-checked, not trusted on one read');
+  assert.equal(r.pass, false);
+  assert.equal(r.recovered, undefined);
+});
+
+test('checkProbe: non-JSON Redis body returns reason=redis-bad-json-body (no throw → no platform 503)', async () => {
+  globalThis.fetch = async () => ({
+    ok: true,
+    json: async () => { throw new SyntaxError('Unexpected token < in JSON'); },
+  });
+  const r = await checkProbe({ key: 'economic:fsi-eu:v1', shape: 'envelope' });
+  assert.equal(r.pass, false);
+  assert.equal(r.reason, 'redis-bad-json-body');
+});
+
+test('checkPublicBoundary: a transient first-attempt failure on each endpoint recovers on retry', async () => {
+  // First call to each endpoint 503s (cold start); the retry returns a healthy
+  // cache-served catalog + clean bootstrap → the boundary stays green.
+  const callCount = {};
+  globalThis.fetch = async (url) => {
+    const path = new URL(url).pathname;
+    callCount[path] = (callCount[path] || 0) + 1;
+    if (callCount[path] === 1) {
+      return { ok: false, status: 503, text: async () => '', headers: { get: () => null } };
+    }
+    const body = path === '/api/product-catalog'
+      ? JSON.stringify({ tiers: [{ id: 'pro' }], fetchedAt: 1 })
+      : JSON.stringify({ market: { quotes: [] } });
+    const hdrs = new Headers(path === '/api/product-catalog' ? { 'x-product-catalog-source': 'cache' } : {});
+    return { ok: true, status: 200, text: async () => body, headers: { get: (n) => hdrs.get(n) } };
+  };
+  const res = await checkPublicBoundary('https://example.test', 0);
+  assert.equal(res.every(r => r.pass), true, JSON.stringify(res));
+  assert.ok(res.every(r => r.recovered === true), 'both endpoints should be flagged recovered');
 });

--- a/tests/seed-contract-probe.test.mjs
+++ b/tests/seed-contract-probe.test.mjs
@@ -235,6 +235,16 @@ test('withRetry: a persistent failure fails both attempts without recovered', as
   assert.equal(r.recovered, undefined);
 });
 
+test('checkProbe: a non-Error fetch rejection is serialised via String(), not undefined', async () => {
+  // Strict-mode catch binds the thrown value as `unknown`; a library that
+  // `throw`s a bare string/object would make `(err as Error).message` resolve
+  // to `undefined`. errMessage() must keep the reason useful.
+  globalThis.fetch = async () => { throw 'kaboom'; };
+  const r = await checkProbe({ key: 'economic:fsi-eu:v1', shape: 'envelope' });
+  assert.equal(r.pass, false);
+  assert.equal(r.reason, 'fetch:kaboom');
+});
+
 test('checkProbe: non-JSON Redis body returns reason=redis-bad-json-body (no throw → no platform 503)', async () => {
   globalThis.fetch = async () => ({
     ok: true,


### PR DESCRIPTION
## Summary

`api/seed-contract-probe` was the source of recurring **503 "Service Unavailable"** incidents in our uptime monitor over the past 24h (~9 incidents/day, mostly 3–4 min each, auto-resolving).

**Root cause — probe sensitivity, not a regression.** The probe is a logical **AND of 12 independent health checks** (10 Upstash key reads at 3s timeout each + `/api/bootstrap` and `/api/product-catalog` at 5s) and returns `503` the moment *any one* fails (`ok ? 200 : 503`). With **zero retry tolerance**, a single sub-second transient flips the whole probe red:
- an Upstash read tripping its 3s budget,
- a Vercel cold-start on a boundary endpoint exceeding 5s, or
- the brief window while a seeder rewrites a probed key (e.g. `product-catalog:v2` momentarily absent → endpoint serves `dodo`/`fallback` → `source:cache` assert fails).

Uptime monitors re-check on their own cadence, so one failed poll surfaces as a multi-minute "incident" even though no seed contract regressed.

I traced every dependency and **nothing in the probe, the 10 probed-key seeders, or the two boundary endpoints changed in the failure window**; the live probe stayed green with healthy TTL/latency margins throughout. So this hardens the probe rather than the monitored system.

## Changes

- **`withRetry()`** — each *failing* check gets exactly one retry. A real regression fails both attempts and still 503s; a transient passes the retry and stays green. Passing checks never retry (all-green path keeps its single round-trip). Recovered checks are flagged via `recovered` and counted in `summary.recovered` so genuine flakiness stays visible to operators.
- **Crash-proofing** — guard `await resp.json()` in `checkProbe` (`reason=redis-bad-json-body`) and wrap the handler in `try/catch`. A malformed upstream body now degrades to a clean, debuggable `503` instead of crashing the edge function into an opaque Vercel **platform** 503 (which reads identically to a real contract failure).

## Test plan

- [x] `tests/seed-contract-probe.test.mjs` — 22 tests pass; added coverage for `withRetry` (pass-through / recovers-transient / persistent-fail), the `resp.json()` guard, and per-endpoint boundary recovery
- [x] `npm run typecheck` + `typecheck:api` — pass
- [x] `npm run lint` (biome) + `lint:md` — pass
- [x] `npm run test:data` — 10641 pass / 0 fail
- [x] `tests/edge-functions.test.mjs` — pass
- [x] `npm run version:check` — pass
- [x] CJS syntax check — pass

## Follow-up

A background watcher is still polling the live probe to capture the exact flapping check empirically (which one fires first). The structural fix above is independent of which check flaps — it tolerates a single transient on any of the 12.