### PR TITLE
Fix resilience interval seed health verification

### DIFF
--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -7,6 +7,8 @@ import { redisPipeline } from './_upstash-json.js';
 
 export const config = { runtime: 'edge' };
 
+// Keep these literals in sync with scripts/_resilience-intervals.mjs. Edge
+// functions cannot import from scripts/, so tests enforce this mirror.
 const RESILIENCE_INTERVAL_KEY_PREFIX = 'resilience:intervals:v8:';
 const RESILIENCE_INTERVAL_METHODOLOGY = 'weight-perturbation-sensitivity-v3';
 const RESILIENCE_INTERVAL_SOURCE_VERSION = `resilience-intervals:${RESILIENCE_INTERVAL_KEY_PREFIX}${RESILIENCE_INTERVAL_METHODOLOGY}`;

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -1,10 +1,16 @@
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { validateApiKey } from './_api-key.js';
 import { jsonResponse } from './_json-response.js';
+import { unwrapEnvelope } from './_seed-envelope.js';
 // @ts-expect-error — JS module, no declaration file
 import { redisPipeline } from './_upstash-json.js';
 
 export const config = { runtime: 'edge' };
+
+const RESILIENCE_INTERVAL_KEY_PREFIX = 'resilience:intervals:v8:';
+const RESILIENCE_INTERVAL_METHODOLOGY = 'weight-perturbation-sensitivity-v3';
+const RESILIENCE_INTERVAL_SOURCE_VERSION = `resilience-intervals:${RESILIENCE_INTERVAL_KEY_PREFIX}${RESILIENCE_INTERVAL_METHODOLOGY}`;
+const RESILIENCE_INTERVAL_PROBE_KEY = `${RESILIENCE_INTERVAL_KEY_PREFIX}US`;
 
 const SEED_DOMAINS = {
   // Phase 1 — Snapshot endpoints
@@ -77,7 +83,15 @@ const SEED_DOMAINS = {
   'economic:grocery-basket':  { key: 'seed-meta:economic:grocery-basket',  intervalMin: 5040 }, // weekly seed; intervalMin = maxStaleMin / 2
   'economic:bigmac':          { key: 'seed-meta:economic:bigmac',          intervalMin: 5040 }, // weekly seed; intervalMin = maxStaleMin / 2
   'resilience:static':        { key: 'seed-meta:resilience:static',        intervalMin: 288000 }, // annual October snapshot; intervalMin = health.js maxStaleMin / 2 (400d alert threshold)
-  'resilience:intervals':     { key: 'seed-meta:resilience:intervals',     intervalMin: 10080 }, // weekly cron; intervalMin = health.js maxStaleMin / 2 (20160 / 2)
+  'resilience:intervals':     {
+    key: 'seed-meta:resilience:intervals',
+    intervalMin: 420, // Same 840min freshness budget as api/health.js, expressed as intervalMin * 2.
+    dataProbe: {
+      key: RESILIENCE_INTERVAL_PROBE_KEY,
+      methodology: RESILIENCE_INTERVAL_METHODOLOGY,
+      sourceVersion: RESILIENCE_INTERVAL_SOURCE_VERSION,
+    },
+  },
   'regulatory:actions':       { key: 'seed-meta:regulatory:actions',       intervalMin: 120 }, // 2h cron; intervalMin = maxStaleMin / 3
   'economic:owid-energy-mix': { key: 'seed-meta:economic:owid-energy-mix', intervalMin: 25200 }, // monthly cron on 1st; intervalMin = health.js maxStaleMin / 2 (50400 / 2)
   'economic:fao-ffpi':        { key: 'seed-meta:economic:fao-ffpi',        intervalMin: 43200 }, // monthly seed; intervalMin = health.js maxStaleMin / 2 (86400 / 2)
@@ -111,19 +125,91 @@ const SEED_DOMAINS = {
   'resilience:recovery:sovereign-wealth': { key: 'seed-meta:resilience:recovery:sovereign-wealth', intervalMin: 43200 }, // monthly bundle cron (30d); intervalMin*2 = 60d matches health.js maxStaleMin
 };
 
-async function getMetaBatch(keys) {
-  const pipeline = keys.map((k) => ['GET', k]);
-  const data = await redisPipeline(pipeline, 3000);
-  if (!data) throw new Error('Redis not configured');
+function parseJsonValue(raw) {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
 
-  const result = new Map();
-  for (let i = 0; i < keys.length; i++) {
-    const raw = data[i]?.result;
-    if (raw) {
-      try { result.set(keys[i], JSON.parse(raw)); } catch { /* skip */ }
+function evaluateDataProbe(cfg, raw) {
+  if (!cfg) return null;
+  if (!raw) {
+    return {
+      ok: false,
+      status: 'data_missing',
+      key: cfg.key,
+      requiredMethodology: cfg.methodology ?? null,
+      requiredSourceVersion: cfg.sourceVersion ?? null,
+    };
+  }
+
+  const parsed = unwrapEnvelope(parseJsonValue(raw)).data;
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      status: 'data_invalid',
+      key: cfg.key,
+      requiredMethodology: cfg.methodology ?? null,
+      requiredSourceVersion: cfg.sourceVersion ?? null,
+    };
+  }
+
+  const methodology = typeof parsed.methodology === 'string' ? parsed.methodology : null;
+  if (cfg.methodology && methodology !== cfg.methodology) {
+    return {
+      ok: false,
+      status: 'methodology_mismatch',
+      key: cfg.key,
+      methodology,
+      requiredMethodology: cfg.methodology,
+      requiredSourceVersion: cfg.sourceVersion ?? null,
+    };
+  }
+
+  return {
+    ok: true,
+    status: 'ok',
+    key: cfg.key,
+    methodology,
+    requiredMethodology: cfg.methodology ?? null,
+    requiredSourceVersion: cfg.sourceVersion ?? null,
+    formula: typeof parsed._formula === 'string' ? parsed._formula : null,
+    computedAt: typeof parsed.computedAt === 'string' ? parsed.computedAt : null,
+  };
+}
+
+async function getSeedBatch(entries) {
+  const commands = [];
+  const metaSlots = [];
+  const probeSlots = [];
+  for (const [domain, cfg] of entries) {
+    metaSlots.push({ domain, key: cfg.key, index: commands.length });
+    commands.push(['GET', cfg.key]);
+    if (cfg.dataProbe?.key) {
+      probeSlots.push({ domain, index: commands.length });
+      commands.push(['GET', cfg.dataProbe.key]);
     }
   }
-  return result;
+
+  const data = await redisPipeline(commands, 3000);
+  if (!data) throw new Error('Redis not configured');
+
+  const metaMap = new Map();
+  const probeMap = new Map();
+  for (const slot of metaSlots) {
+    const raw = data[slot.index]?.result;
+    if (raw) {
+      const parsed = parseJsonValue(raw);
+      if (parsed) metaMap.set(slot.key, parsed);
+    }
+  }
+  for (const slot of probeSlots) {
+    probeMap.set(slot.domain, data[slot.index]?.result ?? null);
+  }
+  return { metaMap, probeMap };
 }
 
 export default async function handler(req) {
@@ -140,11 +226,11 @@ export default async function handler(req) {
 
   const now = Date.now();
   const entries = Object.entries(SEED_DOMAINS);
-  const metaKeys = entries.map(([, v]) => v.key);
 
   let metaMap;
+  let probeMap;
   try {
-    metaMap = await getMetaBatch(metaKeys);
+    ({ metaMap, probeMap } = await getSeedBatch(entries));
   } catch {
     return jsonResponse({ error: 'Redis unavailable' }, 503, cors);
   }
@@ -165,17 +251,33 @@ export default async function handler(req) {
 
     const ageMs = now - (meta.fetchedAt || 0);
     const isError = meta.status === 'error';
-    const stale = ageMs > maxStalenessMs || isError;
+    const probe = evaluateDataProbe(cfg.dataProbe, probeMap.get(domain));
+    const sourceMismatch = Boolean(
+      cfg.dataProbe?.sourceVersion &&
+      typeof meta.sourceVersion === 'string' &&
+      meta.sourceVersion !== '' &&
+      meta.sourceVersion !== cfg.dataProbe.sourceVersion
+    );
+    const stale = ageMs > maxStalenessMs || isError || sourceMismatch || probe?.ok === false;
     if (stale) staleCount++;
 
     seeds[domain] = {
-      status: stale ? (isError ? 'error' : 'stale') : 'ok',
+      status: isError
+        ? 'error'
+        : sourceMismatch
+          ? 'source_version_mismatch'
+          : probe?.ok === false
+            ? probe.status
+            : stale
+              ? 'stale'
+              : 'ok',
       fetchedAt: meta.fetchedAt,
       recordCount: meta.recordCount ?? null,
       sourceVersion: meta.sourceVersion || null,
       ageMinutes: Math.round(ageMs / 60000),
       stale,
     };
+    if (probe) seeds[domain].dataProbe = probe;
   }
 
   const overall = missingCount > 0 ? 'degraded' : staleCount > 0 ? 'warning' : 'healthy';

--- a/scripts/seed-resilience-scores.mjs
+++ b/scripts/seed-resilience-scores.mjs
@@ -10,6 +10,7 @@ import { isInRankableUniverse } from './shared/rankable-universe.mjs';
 import {
   DRAWS,
   RESILIENCE_INTERVAL_KEY_PREFIX as INTERVAL_KEY_PREFIX,
+  RESILIENCE_INTERVAL_METHODOLOGY as INTERVAL_METHODOLOGY,
   buildScoreIntervalPayload,
   computeIntervals,
   createIntervalDiagnostics,
@@ -81,6 +82,7 @@ export const RESILIENCE_SCORE_SECTION_META_TTL_SECONDS = 12 * 60 * 60;
 export const RESILIENCE_STATIC_INDEX_KEY = 'resilience:static:index:v1';
 
 const INTERVAL_TTL_SECONDS = 7 * 24 * 60 * 60;
+const INTERVAL_SOURCE_VERSION = `resilience-intervals:${INTERVAL_KEY_PREFIX}${INTERVAL_METHODOLOGY}`;
 export { computeIntervals };
 
 function isKnownScoreFormulaTag(value) {
@@ -276,7 +278,7 @@ async function computeAndWriteIntervals(url, token, countryCodes, pipelineResult
     );
   }
 
-  await writeFreshnessMetadata('resilience', 'intervals', commands.length, '', INTERVAL_TTL_SECONDS);
+  await writeFreshnessMetadata('resilience', 'intervals', commands.length, INTERVAL_SOURCE_VERSION, INTERVAL_TTL_SECONDS);
   return { recordCount: commands.length, diagnostics };
 }
 

--- a/tests/resilience-cache-keys-health-sync.test.mts
+++ b/tests/resilience-cache-keys-health-sync.test.mts
@@ -87,6 +87,20 @@ describe('resilience cache-key health-registry sync (T1.9)', () => {
     );
   });
 
+  it('api/seed-health.js resilience interval probe mirrors the script prefix and methodology', () => {
+    const seedHealthText = readFileSync(join(repoRoot, 'api/seed-health.js'), 'utf-8');
+    assert.ok(
+      seedHealthText.includes(`const RESILIENCE_INTERVAL_KEY_PREFIX = '${SCRIPT_INTERVAL_KEY_PREFIX}';`) ||
+        seedHealthText.includes(`const RESILIENCE_INTERVAL_KEY_PREFIX = "${SCRIPT_INTERVAL_KEY_PREFIX}";`),
+      `api/seed-health.js must mirror scripts/_resilience-intervals.mjs RESILIENCE_INTERVAL_KEY_PREFIX=${SCRIPT_INTERVAL_KEY_PREFIX}`,
+    );
+    assert.ok(
+      seedHealthText.includes(`const RESILIENCE_INTERVAL_METHODOLOGY = '${SCRIPT_INTERVAL_METHODOLOGY}';`) ||
+        seedHealthText.includes(`const RESILIENCE_INTERVAL_METHODOLOGY = "${SCRIPT_INTERVAL_METHODOLOGY}";`),
+      `api/seed-health.js must mirror scripts/_resilience-intervals.mjs RESILIENCE_INTERVAL_METHODOLOGY=${SCRIPT_INTERVAL_METHODOLOGY}`,
+    );
+  });
+
   it('score and ranking cache namespaces share the same methodology generation', () => {
     const scoreVersion = cacheVersion(
       'RESILIENCE_SCORE_CACHE_PREFIX',

--- a/tests/seed-health-resilience-intervals.test.mjs
+++ b/tests/seed-health-resilience-intervals.test.mjs
@@ -19,6 +19,26 @@ const PROBE_KEY = 'resilience:intervals:v8:US';
 const METHODOLOGY = 'weight-perturbation-sensitivity-v3';
 const SOURCE_VERSION = `resilience-intervals:resilience:intervals:v8:${METHODOLOGY}`;
 
+function intervalMeta(overrides = {}) {
+  return {
+    fetchedAt: Date.now(),
+    recordCount: 196,
+    sourceVersion: SOURCE_VERSION,
+    ...overrides,
+  };
+}
+
+function intervalPayload(overrides = {}) {
+  return {
+    p05: 65.2,
+    p95: 72.8,
+    _formula: 'pc',
+    computedAt: '2026-06-04T18:03:20.983Z',
+    methodology: METHODOLOGY,
+    ...overrides,
+  };
+}
+
 before(() => {
   process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
   process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
@@ -64,11 +84,7 @@ async function readSeedHealth() {
 
 test('seed-health flags fresh resilience interval meta when the current v8 data probe is absent', async () => {
   installPipelineMock(new Map([
-    [META_KEY, {
-      fetchedAt: Date.now(),
-      recordCount: 196,
-      sourceVersion: SOURCE_VERSION,
-    }],
+    [META_KEY, intervalMeta()],
   ]));
 
   const { res, body } = await readSeedHealth();
@@ -89,18 +105,8 @@ test('seed-health flags fresh resilience interval meta when the current v8 data 
 
 test('seed-health keeps resilience intervals green when fresh meta matches the current probe methodology', async () => {
   installPipelineMock(new Map([
-    [META_KEY, {
-      fetchedAt: Date.now(),
-      recordCount: 196,
-      sourceVersion: SOURCE_VERSION,
-    }],
-    [PROBE_KEY, {
-      p05: 65.2,
-      p95: 72.8,
-      _formula: 'pc',
-      computedAt: '2026-06-04T18:03:20.983Z',
-      methodology: METHODOLOGY,
-    }],
+    [META_KEY, intervalMeta()],
+    [PROBE_KEY, intervalPayload()],
   ]));
 
   const { res, body } = await readSeedHealth();
@@ -113,4 +119,46 @@ test('seed-health keeps resilience intervals green when fresh meta matches the c
   assert.equal(body.seeds['resilience:intervals'].dataProbe.key, PROBE_KEY);
   assert.equal(body.seeds['resilience:intervals'].dataProbe.methodology, METHODOLOGY);
   assert.equal(body.seeds['resilience:intervals'].dataProbe.formula, 'pc');
+});
+
+test('seed-health flags resilience interval methodology mismatches', async () => {
+  installPipelineMock(new Map([
+    [META_KEY, intervalMeta()],
+    [PROBE_KEY, intervalPayload({ methodology: 'weight-perturbation-sensitivity-v2' })],
+  ]));
+
+  const { res, body } = await readSeedHealth();
+
+  assert.equal(res.status, 200);
+  assert.equal(body.overall, 'warning');
+  assert.equal(body.seeds['resilience:intervals'].status, 'methodology_mismatch');
+  assert.equal(body.seeds['resilience:intervals'].stale, true);
+  assert.deepEqual(body.seeds['resilience:intervals'].dataProbe, {
+    ok: false,
+    status: 'methodology_mismatch',
+    key: PROBE_KEY,
+    methodology: 'weight-perturbation-sensitivity-v2',
+    requiredMethodology: METHODOLOGY,
+    requiredSourceVersion: SOURCE_VERSION,
+  });
+});
+
+test('seed-health flags resilience interval source-version mismatches', async () => {
+  installPipelineMock(new Map([
+    [META_KEY, intervalMeta({ sourceVersion: 'resilience-intervals:resilience:intervals:v7:old-methodology' })],
+    [PROBE_KEY, intervalPayload()],
+  ]));
+
+  const { res, body } = await readSeedHealth();
+
+  assert.equal(res.status, 200);
+  assert.equal(body.overall, 'warning');
+  assert.equal(body.seeds['resilience:intervals'].status, 'source_version_mismatch');
+  assert.equal(body.seeds['resilience:intervals'].stale, true);
+  assert.equal(
+    body.seeds['resilience:intervals'].sourceVersion,
+    'resilience-intervals:resilience:intervals:v7:old-methodology',
+  );
+  assert.equal(body.seeds['resilience:intervals'].dataProbe.ok, true);
+  assert.equal(body.seeds['resilience:intervals'].dataProbe.requiredSourceVersion, SOURCE_VERSION);
 });

--- a/tests/seed-health-resilience-intervals.test.mjs
+++ b/tests/seed-health-resilience-intervals.test.mjs
@@ -1,0 +1,116 @@
+import { after, before, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+  UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+  UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
+  WORLDMONITOR_VALID_KEYS: process.env.WORLDMONITOR_VALID_KEYS,
+};
+
+process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+process.env.WORLDMONITOR_VALID_KEYS = 'test-key';
+
+const { default: handler } = await import('../api/seed-health.js');
+
+const META_KEY = 'seed-meta:resilience:intervals';
+const PROBE_KEY = 'resilience:intervals:v8:US';
+const METHODOLOGY = 'weight-perturbation-sensitivity-v3';
+const SOURCE_VERSION = `resilience-intervals:resilience:intervals:v8:${METHODOLOGY}`;
+
+before(() => {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+  process.env.WORLDMONITOR_VALID_KEYS = 'test-key';
+});
+
+after(() => {
+  globalThis.fetch = originalFetch;
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value == null) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+function installPipelineMock(values) {
+  globalThis.fetch = async (_url, init) => {
+    const commands = JSON.parse(init.body);
+    const results = commands.map((command) => {
+      const [op, key] = command;
+      assert.equal(op, 'GET');
+      const value = values.has(key)
+        ? values.get(key)
+        : String(key).startsWith('seed-meta:')
+          ? { fetchedAt: Date.now(), recordCount: 1, sourceVersion: 'test' }
+          : null;
+      return { result: value == null ? null : JSON.stringify(value) };
+    });
+    return new Response(JSON.stringify(results), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+}
+
+async function readSeedHealth() {
+  const req = new Request('https://api.worldmonitor.app/api/seed-health', {
+    headers: { 'X-WorldMonitor-Key': 'test-key' },
+  });
+  const res = await handler(req);
+  const body = await res.json();
+  return { res, body };
+}
+
+test('seed-health flags fresh resilience interval meta when the current v8 data probe is absent', async () => {
+  installPipelineMock(new Map([
+    [META_KEY, {
+      fetchedAt: Date.now(),
+      recordCount: 196,
+      sourceVersion: SOURCE_VERSION,
+    }],
+  ]));
+
+  const { res, body } = await readSeedHealth();
+
+  assert.equal(res.status, 200);
+  assert.equal(body.overall, 'warning');
+  assert.equal(body.seeds['resilience:intervals'].status, 'data_missing');
+  assert.equal(body.seeds['resilience:intervals'].stale, true);
+  assert.equal(body.seeds['resilience:intervals'].recordCount, 196);
+  assert.deepEqual(body.seeds['resilience:intervals'].dataProbe, {
+    ok: false,
+    status: 'data_missing',
+    key: PROBE_KEY,
+    requiredMethodology: METHODOLOGY,
+    requiredSourceVersion: SOURCE_VERSION,
+  });
+});
+
+test('seed-health keeps resilience intervals green when fresh meta matches the current probe methodology', async () => {
+  installPipelineMock(new Map([
+    [META_KEY, {
+      fetchedAt: Date.now(),
+      recordCount: 196,
+      sourceVersion: SOURCE_VERSION,
+    }],
+    [PROBE_KEY, {
+      p05: 65.2,
+      p95: 72.8,
+      _formula: 'pc',
+      computedAt: '2026-06-04T18:03:20.983Z',
+      methodology: METHODOLOGY,
+    }],
+  ]));
+
+  const { res, body } = await readSeedHealth();
+
+  assert.equal(res.status, 200);
+  assert.equal(body.seeds['resilience:intervals'].status, 'ok');
+  assert.equal(body.seeds['resilience:intervals'].stale, false);
+  assert.equal(body.seeds['resilience:intervals'].sourceVersion, SOURCE_VERSION);
+  assert.equal(body.seeds['resilience:intervals'].dataProbe.ok, true);
+  assert.equal(body.seeds['resilience:intervals'].dataProbe.key, PROBE_KEY);
+  assert.equal(body.seeds['resilience:intervals'].dataProbe.methodology, METHODOLOGY);
+  assert.equal(body.seeds['resilience:intervals'].dataProbe.formula, 'pc');
+});


### PR DESCRIPTION
## Summary
- make /api/seed-health validate the current resilience:intervals:v8:US probe and methodology before reporting resilience:intervals as green
- align the seed-health interval budget with /api/health's 840 minute resilience interval freshness window
- stamp resilience interval seed-meta with the interval namespace and methodology source version
- add a regression test for fresh interval seed-meta with the current v8 data key absent

## Root Cause
The parent audit showed fresh seed-meta:resilience:intervals while /api/health and the score endpoint proved current interval data was absent. Current code already makes the seeder fail when it writes zero interval keys, so the remaining actionable gap was observability: /api/seed-health only read seed-meta and could stay green even when the current interval namespace was not published or was produced by a stale deploy.

## Validation
- node --test tests/seed-health-resilience-intervals.test.mjs tests/resilience-scores-seed.test.mjs tests/resilience-intervals.test.mjs
- npx tsx --test tests/resilience-cache-keys-health-sync.test.mts tests/resilience-intervals-handler.test.mts tests/resilience-runtime-manifest.test.mts
- npm run typecheck
- npm run typecheck:api
- pre-push hook: typecheck, API typecheck, Convex type check, CJS syntax, Unicode safety, boundary lint, safe HTML, Sentry coverage, rate-limit policy, premium-fetch parity, edge bundle check, resilience tests, seed tests, changed tests, edge function tests, version check