### PR TITLE
fix(token-panels): don't clobber good panels with empty writes on partial fetch

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1123,6 +1123,18 @@ export function parseYahooChart(data, symbol) {
   return { symbol, name: symbol, display: symbol, price, change: +change.toFixed(2), sparkline };
 }
 
+/**
+ * Decide whether an extra-key write should be skipped to preserve last-good
+ * cached data. Opt-in per extra-key via `skipWhenEmpty: true` — when set and the
+ * resolved recordCount is 0, runSeed skips the write (and extends the key's TTL)
+ * instead of clobbering a good cached payload with an empty recordCount=0 one on
+ * a partial upstream fetch. The canonical key is already guarded by validateFn;
+ * this closes the same gap for extra keys. Pure function — extracted for tests.
+ */
+export function shouldSkipEmptyExtraKey(ek, recordCount) {
+  return Boolean(ek && ek.skipWhenEmpty) && recordCount === 0;
+}
+
 export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}) {
   const {
     validateFn,
@@ -1444,6 +1456,15 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
             await releaseLock(`${domain}:${resource}`, runId);
             console.error(`  CONTRACT VIOLATION on extraKey ${ek.key}: ${err.message || err}`);
             process.exit(1);
+          }
+          // Opt-in skip-empty: don't overwrite a good cached extra-key payload
+          // with a recordCount=0 write on a partial fetch (e.g. a token panel
+          // whose IDs the upstream dropped this cycle). Preserve last-good by
+          // extending the existing key's TTL instead.
+          if (shouldSkipEmptyExtraKey(ek, ekCount)) {
+            await extendExistingTtl([ek.key], ek.ttl || ttlSeconds || 600);
+            console.log(`  [extraKey] ${ek.key} empty (recordCount=0) — skipped write, extended TTL to preserve last-good`);
+            continue;
           }
           ekEnvelope = {
             fetchedAt: envelopeMeta.fetchedAt,

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1445,6 +1445,12 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     // the canonical one.
     if (extraKeys) {
       for (const ek of extraKeys) {
+        // skipWhenEmpty needs a resolved recordCount, which only exists in
+        // contract mode (declareRecords). Warn loudly on misconfig instead of
+        // silently writing the empty payload the flag was meant to guard against.
+        if (ek.skipWhenEmpty && !contractMode) {
+          console.warn(`  [extraKey] ${ek.key} declares skipWhenEmpty but ${domain}:${resource} is not in contract mode (no declareRecords) — guard inactive`);
+        }
         const ekData = ek.transform ? ek.transform(data) : data;
         let ekEnvelope = null;
         if (contractMode) {

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -2512,20 +2512,35 @@ async function seedTokenPanels() {
     try { data = await fetchTokenPanelsCoinPaprika(allIds); } catch (e2) { console.warn(`[TokenPanels] CoinPaprika also failed: ${e2.message} — skipping`); return 0; }
   }
   const byId = new Map(data.map((c) => [c.id, c]));
-  const defi = { tokens: _mapTokens(_defiCfg.ids, _defiCfg.meta, byId) };
-  const ai = { tokens: _mapTokens(_aiCfg.ids, _aiCfg.meta, byId) };
-  const other = { tokens: _mapTokens(_otherCfg.ids, _otherCfg.meta, byId) };
-  if (defi.tokens.length === 0 && ai.tokens.length === 0 && other.tokens.length === 0) {
+  const panels = [
+    { key: 'market:defi-tokens:v1',  payload: { tokens: _mapTokens(_defiCfg.ids, _defiCfg.meta, byId) },  sourceVersion: 'market-defi-tokens',  label: 'DeFi' },
+    { key: 'market:ai-tokens:v1',    payload: { tokens: _mapTokens(_aiCfg.ids, _aiCfg.meta, byId) },      sourceVersion: 'market-ai-tokens',    label: 'AI' },
+    { key: 'market:other-tokens:v1', payload: { tokens: _mapTokens(_otherCfg.ids, _otherCfg.meta, byId) }, sourceVersion: 'market-other-tokens', label: 'Other' },
+  ];
+  const total = panels.reduce((n, p) => n + p.payload.tokens.length, 0);
+  if (total === 0) {
     console.warn('[TokenPanels] All panels empty after mapping — skipping Redis write to preserve cached data');
     return 0;
   }
-  const ok1 = await envelopeWrite('market:defi-tokens:v1', defi, TOKEN_PANELS_SEED_TTL, { recordCount: defi.tokens.length, sourceVersion: 'market-defi-tokens' });
-  const ok2 = await envelopeWrite('market:ai-tokens:v1', ai, TOKEN_PANELS_SEED_TTL, { recordCount: ai.tokens.length, sourceVersion: 'market-ai-tokens' });
-  const ok3 = await envelopeWrite('market:other-tokens:v1', other, TOKEN_PANELS_SEED_TTL, { recordCount: other.tokens.length, sourceVersion: 'market-other-tokens' });
-  await upstashSet('seed-meta:market:token-panels', { fetchedAt: Date.now(), recordCount: defi.tokens.length + ai.tokens.length + other.tokens.length }, 604800);
-  const total = defi.tokens.length + ai.tokens.length + other.tokens.length;
-  const allOk = ok1 && ok2 && ok3;
-  console.log(`[TokenPanels] Seeded ${defi.tokens.length} DeFi, ${ai.tokens.length} AI, ${other.tokens.length} Other (${total} total, redis: ${allOk ? 'OK' : 'PARTIAL'})`);
+  // Write each panel ONLY when it mapped >=1 token. CoinGecko's
+  // /coins/markets?ids= endpoint returns only the IDs it has data for, so a
+  // partial response (e.g. it drops the DeFi+AI IDs but keeps Other) maps an
+  // individual panel to 0 tokens. Writing that empty panel would clobber the
+  // good cached payload with recordCount=0 — blanking the UI panel AND tripping
+  // the seed-contract probe's minRecords:1 floor (false 503). Skip the write and
+  // extend the existing key's TTL so the last-good panel is preserved instead.
+  const results = [];
+  for (const p of panels) {
+    if (p.payload.tokens.length === 0) {
+      try { await upstashExpire(p.key, TOKEN_PANELS_SEED_TTL); } catch {}
+      results.push(`${p.label}:skip-empty`);
+      continue;
+    }
+    const ok = await envelopeWrite(p.key, p.payload, TOKEN_PANELS_SEED_TTL, { recordCount: p.payload.tokens.length, sourceVersion: p.sourceVersion });
+    results.push(`${p.label}:${p.payload.tokens.length}${ok ? '' : '(FAIL)'}`);
+  }
+  await upstashSet('seed-meta:market:token-panels', { fetchedAt: Date.now(), recordCount: total }, 604800);
+  console.log(`[TokenPanels] Seeded ${results.join(', ')} (${total} total)`);
   return total;
 }
 

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -2532,8 +2532,13 @@ async function seedTokenPanels() {
   const results = [];
   for (const p of panels) {
     if (p.payload.tokens.length === 0) {
-      try { await upstashExpire(p.key, TOKEN_PANELS_SEED_TTL); } catch {}
-      results.push(`${p.label}:skip-empty`);
+      // Preserve last-good by extending the existing key's TTL. upstashExpire
+      // resolves false when the key is already missing/expired — surface that as
+      // (TTL-MISS) so the log never implies a cache was preserved when it wasn't
+      // (the probe will then legitimately read `missing` until the next good write).
+      const extended = await upstashExpire(p.key, TOKEN_PANELS_SEED_TTL);
+      if (!extended) console.warn(`[TokenPanels] ${p.key} EXPIRE no-op — key missing/expired, last-good NOT preserved`);
+      results.push(`${p.label}:skip-empty${extended ? '' : '(TTL-MISS)'}`);
       continue;
     }
     const ok = await envelopeWrite(p.key, p.payload, TOKEN_PANELS_SEED_TTL, { recordCount: p.payload.tokens.length, sourceVersion: p.sourceVersion });

--- a/scripts/seed-token-panels.mjs
+++ b/scripts/seed-token-panels.mjs
@@ -118,6 +118,19 @@ export function declareRecords(data) {
   return Array.isArray(data?.tokens) ? data.tokens.length : 0;
 }
 
+// Each panel has its own {tokens, ...} shape — reuse canonical declareRecords
+// since the transformed extra-key payloads are structurally identical to the
+// canonical one (a single panel). `skipWhenEmpty` guards against a partial
+// upstream fetch (CoinGecko dropping the AI or Other IDs for a cycle while DeFi
+// still resolves, so validateFn passes on the canonical panel): without it,
+// runSeed would clobber the good cached AI/Other panel with a recordCount=0
+// write — blanking the UI panel and tripping the seed-contract probe's
+// minRecords:1 floor (false 503). Exported so a test can assert the guard.
+export const TOKEN_PANEL_EXTRA_KEYS = [
+  { key: AI_KEY,    transform: (data) => data.ai,    ttl: CACHE_TTL, declareRecords, skipWhenEmpty: true },
+  { key: OTHER_KEY, transform: (data) => data.other, ttl: CACHE_TTL, declareRecords, skipWhenEmpty: true },
+];
+
 // isMain guard — required so tests/agents can `import` declareRecords without
 // firing runSeed on module load (which would touch Redis and process.exit).
 const isMain = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/^file:\/\//, ''));
@@ -127,13 +140,7 @@ if (isMain) runSeed('market', 'token-panels', DEFI_KEY, fetchTokenPanels, {
   sourceVersion: 'coingecko-paprika-fallback',
   recordCount: (data) => data.total,
   publishTransform: (data) => data.defi,
-  extraKeys: [
-    // Each panel has its own {tokens, ...} shape — reuse canonical declareRecords
-    // since the transformed extra-key payloads are structurally identical to the
-    // canonical one (a single panel).
-    { key: AI_KEY,    transform: (data) => data.ai,    ttl: CACHE_TTL, declareRecords },
-    { key: OTHER_KEY, transform: (data) => data.other, ttl: CACHE_TTL, declareRecords },
-  ],
+  extraKeys: TOKEN_PANEL_EXTRA_KEYS,
 
   declareRecords,
   schemaVersion: 1,

--- a/tests/seed-contract-transform-regressions.test.mjs
+++ b/tests/seed-contract-transform-regressions.test.mjs
@@ -65,6 +65,44 @@ test('seed-token-panels: per-extra-key declareRecords gets transformed AI/OTHER 
   assert.equal(declareRecords(otherTransformed), 1, 'OTHER extra must count tokens correctly');
 });
 
+// ─── partial-fetch clobber guard (false-503 root cause) ──────────────────
+// CoinGecko's /coins/markets?ids= returns only the IDs it has data for. A
+// partial response that drops the AI or Other IDs (while DeFi still resolves,
+// so validateFn passes on the canonical panel) would otherwise write an empty
+// recordCount=0 AI/Other panel — blanking the UI AND tripping the seed-contract
+// probe's minRecords:1 floor (recurring false 503). `skipWhenEmpty` prevents it.
+
+test('shouldSkipEmptyExtraKey: skips an opted-in extra key only when recordCount is 0', async () => {
+  const { shouldSkipEmptyExtraKey } = await import('../scripts/_seed-utils.mjs');
+  assert.equal(shouldSkipEmptyExtraKey({ skipWhenEmpty: true }, 0), true);
+  assert.equal(shouldSkipEmptyExtraKey({ skipWhenEmpty: true }, 3), false, 'non-empty must still write');
+  assert.equal(shouldSkipEmptyExtraKey({ skipWhenEmpty: false }, 0), false, 'not opted in → write (legacy)');
+  assert.equal(shouldSkipEmptyExtraKey({}, 0), false, 'no flag → write (legacy)');
+  assert.equal(shouldSkipEmptyExtraKey(undefined, 0), false);
+});
+
+test('seed-token-panels: AI + Other extra keys opt into skipWhenEmpty', async () => {
+  const { TOKEN_PANEL_EXTRA_KEYS } = await import('../scripts/seed-token-panels.mjs');
+  assert.equal(TOKEN_PANEL_EXTRA_KEYS.length, 2);
+  for (const ek of TOKEN_PANEL_EXTRA_KEYS) {
+    assert.equal(ek.skipWhenEmpty, true, `${ek.key} must guard against empty-panel clobber`);
+  }
+});
+
+test('seed-token-panels: an empty AI panel from a partial fetch is skipped, not clobbered', async () => {
+  // End-to-end of the decision: empty transformed panel → declareRecords 0 →
+  // shouldSkipEmptyExtraKey true → runSeed skips the write (preserving last-good).
+  const { declareRecords, TOKEN_PANEL_EXTRA_KEYS } = await import('../scripts/seed-token-panels.mjs');
+  const { shouldSkipEmptyExtraKey } = await import('../scripts/_seed-utils.mjs');
+  const aiEk = TOKEN_PANEL_EXTRA_KEYS.find((ek) => ek.key === 'market:ai-tokens:v1');
+  const emptyAiPanel = aiEk.transform({ ai: { tokens: [] } }); // upstream dropped AI ids
+  assert.equal(declareRecords(emptyAiPanel), 0);
+  assert.equal(shouldSkipEmptyExtraKey(aiEk, declareRecords(emptyAiPanel)), true);
+  // A populated panel still writes.
+  const fullAiPanel = aiEk.transform({ ai: { tokens: [{ symbol: 'FET' }] } });
+  assert.equal(shouldSkipEmptyExtraKey(aiEk, declareRecords(fullAiPanel)), false);
+});
+
 // ─── validateFn also runs on post-transform shape ────────────────────────
 //
 // atomicPublish() calls validateFn(publishData). A validate() written against


### PR DESCRIPTION
## Summary

**Root-cause fix for the recurring `api/seed-contract-probe` 503s.** A background watcher caught the probe returning a clean `ok:false` 503 while the zone was healthy:

```
FAILS[ market:defi-tokens:v1:records:0<1 , market:ai-tokens:v1:records:0<1 ]
```

Confirmed live in Redis at the same moment: `defi=0, ai=0, other=1` (recordCount, state=OK, fresh). CoinGecko's `/coins/markets?ids=` endpoint returns **only the IDs it currently has data for**, so a partial response maps an individual panel to 0 tokens while others stay populated. Both token-panel writers then **overwrote the good cached panel with a `recordCount=0` payload** — which both blanks the UI panel and trips the seed-contract probe's `minRecords:1` floor (the recurring false 503).

## The two writers, both fixed to preserve last-good per-panel

**1. `scripts/ais-relay.cjs` — `seedTokenPanels()` (the live Railway writer):**
The empty-guard required **all three** panels empty (`defi==0 && ai==0 && other==0`) but the writes are per-panel — so a partial fetch sailed past the guard and clobbered the empty panels. Now each panel writes **only when it mapped ≥1 token**; an empty panel is skipped and its TTL extended to keep last-good alive.

**2. `scripts/seed-token-panels.mjs` — cron via `runSeed` (`_seed-utils.mjs`):**
`validateFn` already protects the canonical defi key, but `runSeed`'s `extraKeys` loop wrote `ai`/`other` **unconditionally**. Added an opt-in **`skipWhenEmpty`** per-extra-key (`shouldSkipEmptyExtraKey`) that skips the write and extends the key's TTL when `recordCount===0`. The AI/Other extra keys opt in. Backward-compatible: every other seeder's extra keys are unaffected (default off).

## Test plan

- [x] `tests/seed-contract-transform-regressions.test.mjs` — added `shouldSkipEmptyExtraKey` unit cases + a `TOKEN_PANEL_EXTRA_KEYS` wiring assertion + an end-to-end "empty AI panel from a partial fetch is skipped" check (18 pass)
- [x] `npm run test:data` — 10655 pass / 0 fail (incl. `ais-relay CoinPaprika fallback`)
- [x] `npm run typecheck` + `typecheck:api` — pass
- [x] `npm run lint` (biome) + `lint:md` — pass
- [x] CJS syntax (`node -c scripts/ais-relay.cjs`) — pass
- [x] `npm run version:check` — pass

## Relationship to #4111

This is the **source-level fix** for the *probe-logic* class of 503 (token panel written empty). **#4111** hardens the probe itself against genuine sub-second transients (`withRetry`) and prevents opaque platform 503s (`resp.json()` guard + handler try/catch). They're complementary and independent.

A second, *infra-level* class of 503 also exists (zone-wide `api.worldmonitor.app` unreachability → Cloudflare 503, both probe + product-catalog dark simultaneously) — not addressed by code; tracked separately, best mitigated by making the uptime monitor require N consecutive failures before alerting.