### PR TITLE
fix(resilience): validate interval methodology in readers

### DIFF
--- a/server/worldmonitor/resilience/v1/_shared.ts
+++ b/server/worldmonitor/resilience/v1/_shared.ts
@@ -383,11 +383,13 @@ interface ResilienceHistoryPoint {
   formula: CacheFormulaTag;
 }
 
-interface CachedScoreIntervalPayload extends ScoreInterval {
-  _formula?: CacheFormulaTag;
-  draws?: number;
-  computedAt?: string;
-  methodology?: string;
+export interface ResilienceIntervalPayload {
+  p05?: unknown;
+  p95?: unknown;
+  _formula?: unknown;
+  draws?: unknown;
+  computedAt?: unknown;
+  methodology?: unknown;
 }
 
 interface ResilienceStaticIndex {
@@ -413,10 +415,8 @@ function intervalCacheKey(countryCode: string): string {
 }
 
 async function readScoreInterval(countryCode: string): Promise<ScoreInterval | undefined> {
-  const raw = await getCachedJson(intervalCacheKey(countryCode), true) as CachedScoreIntervalPayload | null;
-  if (!raw || typeof raw.p05 !== 'number' || typeof raw.p95 !== 'number') return undefined;
-  if (raw._formula !== currentCacheFormula()) return undefined;
-  return { p05: raw.p05, p95: raw.p95 };
+  const raw = await getCachedJson(intervalCacheKey(countryCode), true) as ResilienceIntervalPayload | null;
+  return toCurrentScoreInterval(raw);
 }
 
 function historyKey(countryCode: string): string {
@@ -898,6 +898,31 @@ export function rankingCacheTagMatches(payload: unknown): boolean {
   const tag = (payload as { _formula?: unknown })._formula;
   const intervalMethodology = (payload as { _intervalMethodology?: unknown })._intervalMethodology;
   return tag === currentCacheFormula() && intervalMethodology === RESILIENCE_INTERVAL_METHODOLOGY;
+}
+
+export function isCurrentResilienceIntervalPayload(
+  value: unknown,
+): value is ResilienceIntervalPayload & {
+  p05: number;
+  p95: number;
+  _formula: string;
+  methodology: typeof RESILIENCE_INTERVAL_METHODOLOGY;
+} {
+  if (!value || typeof value !== 'object') return false;
+  const payload = value as ResilienceIntervalPayload;
+  return (
+    typeof payload.p05 === 'number' &&
+    Number.isFinite(payload.p05) &&
+    typeof payload.p95 === 'number' &&
+    Number.isFinite(payload.p95) &&
+    payload._formula === currentCacheFormula() &&
+    payload.methodology === RESILIENCE_INTERVAL_METHODOLOGY
+  );
+}
+
+export function toCurrentScoreInterval(value: unknown): ScoreInterval | undefined {
+  if (!isCurrentResilienceIntervalPayload(value)) return undefined;
+  return { p05: value.p05, p95: value.p95 };
 }
 
 export async function ensureResilienceScoreCached(countryCode: string, reader?: ResilienceSeedReader): Promise<GetResilienceScoreResponse> {

--- a/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
+++ b/server/worldmonitor/resilience/v1/get-resilience-ranking.ts
@@ -19,12 +19,12 @@ import {
   RESILIENCE_RANKING_META_TTL_SECONDS,
   buildRankingItem,
   getCachedResilienceScores,
-  getCurrentCacheFormula,
   listScorableCountries,
   rankingCacheTagMatches,
   sortRankingItems,
   stampRankingCacheTag,
   scoreCacheKey,
+  toCurrentScoreInterval,
   warmMissingResilienceScores,
   type ScoreInterval,
 } from './_shared';
@@ -112,20 +112,13 @@ async function fetchIntervals(countryCodes: string[]): Promise<Map<string, Score
     true,
   );
   const map = new Map<string, ScoreInterval>();
-  const current = getCurrentCacheFormula();
   for (let i = 0; i < countryCodes.length; i++) {
     const raw = results[i]?.result;
     if (typeof raw !== 'string') continue;
     try {
       // Envelope-aware: interval keys come through seed-resilience-scores' extra-key path.
-      const parsed = unwrapEnvelope(JSON.parse(raw)).data as {
-        p05?: number;
-        p95?: number;
-        _formula?: string;
-      } | null;
-      if (parsed && typeof parsed.p05 === 'number' && typeof parsed.p95 === 'number' && parsed._formula === current) {
-        map.set(countryCodes[i]!, { p05: parsed.p05, p95: parsed.p95 });
-      }
+      const interval = toCurrentScoreInterval(unwrapEnvelope(JSON.parse(raw)).data);
+      if (interval) map.set(countryCodes[i]!, interval);
     } catch {
       /* ignore malformed interval entries */
     }

--- a/server/worldmonitor/resilience/v1/get-resilience-runtime-manifest.ts
+++ b/server/worldmonitor/resilience/v1/get-resilience-runtime-manifest.ts
@@ -14,7 +14,9 @@ import {
   RESILIENCE_INTERVAL_METHODOLOGY,
   RESILIENCE_INTERVALS_META_KEY,
   getCurrentCacheFormula,
+  isCurrentResilienceIntervalPayload,
   isEnergyV2Enabled,
+  type ResilienceIntervalPayload,
 } from './_shared';
 
 const MANIFEST_VERSION = 4;
@@ -45,14 +47,6 @@ interface RankingMeta {
   total?: unknown;
 }
 
-interface IntervalPayload {
-  p05?: unknown;
-  p95?: unknown;
-  _formula?: unknown;
-  methodology?: unknown;
-  computedAt?: unknown;
-}
-
 function toIsoDate(value: unknown): string {
   const iso = toIsoTimestamp(value);
   return iso ? iso.slice(0, 10) : '';
@@ -81,27 +75,14 @@ function latestIsoTimestamp(values: unknown[]): string {
   return new Date(Math.max(...timestamps)).toISOString();
 }
 
-function isCurrentIntervalPayload(value: unknown): value is IntervalPayload {
-  if (!value || typeof value !== 'object') return false;
-  const payload = value as IntervalPayload;
-  return (
-    typeof payload.p05 === 'number' &&
-    Number.isFinite(payload.p05) &&
-    typeof payload.p95 === 'number' &&
-    Number.isFinite(payload.p95) &&
-    payload._formula === getCurrentCacheFormula() &&
-    payload.methodology === RESILIENCE_INTERVAL_METHODOLOGY
-  );
-}
-
 async function getIntervalState(): Promise<ResilienceRuntimeIntervalState> {
   const [intervalMeta, sampleInterval] = await Promise.all([
     getCachedJson(RESILIENCE_INTERVALS_META_KEY, true) as Promise<SeedMeta | null>,
-    getCachedJson(`${RESILIENCE_INTERVAL_KEY_PREFIX}${INTERVAL_SAMPLE_COUNTRY}`, true) as Promise<IntervalPayload | null>,
+    getCachedJson(`${RESILIENCE_INTERVAL_KEY_PREFIX}${INTERVAL_SAMPLE_COUNTRY}`, true) as Promise<ResilienceIntervalPayload | null>,
   ]);
 
   return {
-    available: isCurrentIntervalPayload(sampleInterval),
+    available: isCurrentResilienceIntervalPayload(sampleInterval),
     methodology: RESILIENCE_INTERVAL_METHODOLOGY,
     sampleCountry: INTERVAL_SAMPLE_COUNTRY,
     lastObservedAt: latestIsoTimestamp([

--- a/tests/resilience-intervals-handler.test.mts
+++ b/tests/resilience-intervals-handler.test.mts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
 
 import { getResilienceScore } from '../server/worldmonitor/resilience/v1/get-resilience-score.ts';
+import { RESILIENCE_INTERVAL_METHODOLOGY } from '../server/worldmonitor/resilience/v1/_shared.ts';
 import { createRedisFetch } from './helpers/fake-upstash-redis.mts';
 import { RESILIENCE_FIXTURES } from './helpers/resilience-fixtures.mts';
 
@@ -38,7 +39,7 @@ describe('resilience score interval integration', () => {
         _formula: 'd6',
         draws: 100,
         computedAt: '2026-04-06T00:00:00.000Z',
-        methodology: 'weight-perturbation-sensitivity-v3',
+        methodology: RESILIENCE_INTERVAL_METHODOLOGY,
       },
     };
 
@@ -69,7 +70,7 @@ describe('resilience score interval integration', () => {
         _formula: 'pc',
         draws: 100,
         computedAt: '2026-04-06T00:00:00.000Z',
-        methodology: 'weight-perturbation-sensitivity-v3',
+        methodology: RESILIENCE_INTERVAL_METHODOLOGY,
       },
     };
 
@@ -82,6 +83,35 @@ describe('resilience score interval integration', () => {
     );
 
     assert.equal(response.scoreInterval, undefined, 'stale-formula scoreInterval should be ignored');
+  });
+
+  it('omits wrong-methodology interval data', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    process.env.RESILIENCE_PILLAR_COMBINE_ENABLED = 'false';
+    delete process.env.VERCEL_ENV;
+
+    const fixtures = {
+      ...RESILIENCE_FIXTURES,
+      'resilience:intervals:v8:US': {
+        p05: 65.2,
+        p95: 72.8,
+        _formula: 'd6',
+        draws: 100,
+        computedAt: '2026-04-06T00:00:00.000Z',
+        methodology: 'legacy-weight-perturbation-v2',
+      },
+    };
+
+    const { fetchImpl } = createRedisFetch(fixtures);
+    globalThis.fetch = fetchImpl;
+
+    const response = await getResilienceScore(
+      { request: new Request('https://example.com') } as never,
+      { countryCode: 'US' },
+    );
+
+    assert.equal(response.scoreInterval, undefined, 'wrong-methodology scoreInterval should be ignored');
   });
 
   it('omits untagged interval data', async () => {

--- a/tests/resilience-ranking.test.mts
+++ b/tests/resilience-ranking.test.mts
@@ -657,8 +657,18 @@ describe('resilience ranking contracts', () => {
         _formula: 'd6',
       }),
     );
-    redis.set(`${RESILIENCE_INTERVAL_KEY_PREFIX}NO`, JSON.stringify({ p05: 78, p95: 84, _formula: 'd6' }));
-    redis.set(`${RESILIENCE_INTERVAL_KEY_PREFIX}US`, JSON.stringify({ p05: 50, p95: 72, _formula: 'd6' }));
+    redis.set(`${RESILIENCE_INTERVAL_KEY_PREFIX}NO`, JSON.stringify({
+      p05: 78,
+      p95: 84,
+      _formula: 'd6',
+      methodology: RESILIENCE_INTERVAL_METHODOLOGY,
+    }));
+    redis.set(`${RESILIENCE_INTERVAL_KEY_PREFIX}US`, JSON.stringify({
+      p05: 50,
+      p95: 72,
+      _formula: 'd6',
+      methodology: RESILIENCE_INTERVAL_METHODOLOGY,
+    }));
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
 
@@ -717,7 +727,12 @@ describe('resilience ranking contracts', () => {
         _formula: 'd6',
       }),
     );
-    redis.set(`${RESILIENCE_INTERVAL_KEY_PREFIX}NO`, JSON.stringify({ p05: 78, p95: 84, _formula: 'pc' }));
+    redis.set(`${RESILIENCE_INTERVAL_KEY_PREFIX}NO`, JSON.stringify({
+      p05: 78,
+      p95: 84,
+      _formula: 'pc',
+      methodology: RESILIENCE_INTERVAL_METHODOLOGY,
+    }));
     redis.set(`${RESILIENCE_INTERVAL_KEY_PREFIX}US`, JSON.stringify({ p05: 58, p95: 64 }));
 
     const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
@@ -726,6 +741,61 @@ describe('resilience ranking contracts', () => {
     const us = response.items.find((item) => item.countryCode === 'US');
     assert.equal(no?.rankStable, false, 'stale pc interval must be ignored under d6');
     assert.equal(us?.rankStable, false, 'untagged interval must be ignored');
+  });
+
+  it('sets rankStable=false for wrong-methodology interval data', async () => {
+    process.env.RESILIENCE_PILLAR_COMBINE_ENABLED = 'false';
+    const { redis } = installRedis(RESILIENCE_FIXTURES);
+    redis.set(
+      'resilience:static:index:v1',
+      JSON.stringify({
+        countries: ['NO'],
+        recordCount: 1,
+        failedDatasets: [],
+        seedYear: 2026,
+      }),
+    );
+    redis.set(
+      `${RESILIENCE_SCORE_CACHE_PREFIX}NO`,
+      JSON.stringify({
+        countryCode: 'NO',
+        overallScore: 82,
+        level: 'high',
+        domains: [
+          {
+            id: 'political',
+            score: 80,
+            weight: 0.2,
+            dimensions: [
+              {
+                id: 'd1',
+                score: 80,
+                coverage: 0.9,
+                observedWeight: 1,
+                imputedWeight: 0,
+              },
+            ],
+          },
+        ],
+        trend: 'stable',
+        change30d: 1.2,
+        lowConfidence: false,
+        imputationShare: 0.05,
+        headlineEligible: true,
+        _formula: 'd6',
+      }),
+    );
+    redis.set(`${RESILIENCE_INTERVAL_KEY_PREFIX}NO`, JSON.stringify({
+      p05: 78,
+      p95: 84,
+      _formula: 'd6',
+      methodology: 'legacy-weight-perturbation-v2',
+    }));
+
+    const response = await getResilienceRanking({ request: new Request('https://example.com') } as never, {});
+
+    const no = response.items.find((item) => item.countryCode === 'NO');
+    assert.equal(no?.rankStable, false, 'wrong-methodology stable-width interval must be ignored');
   });
 
   it('does not cache the ranking at 80% coverage', async () => {

--- a/tests/resilience-runtime-manifest.test.mts
+++ b/tests/resilience-runtime-manifest.test.mts
@@ -161,6 +161,34 @@ describe('resilience runtime manifest', () => {
     });
   });
 
+  it('reports interval metadata unavailable when the sample methodology is stale', async () => {
+    const modules = await loadRuntimeManifestModules();
+    process.env.RESILIENCE_PILLAR_COMBINE_ENABLED = 'true';
+    installRedis({
+      [modules.RESILIENCE_INTERVALS_META_KEY]: {
+        fetchedAt: Date.parse('2026-05-30T10:00:00.000Z'),
+      },
+      'resilience:intervals:v8:US': {
+        p05: 65.2,
+        p95: 72.8,
+        _formula: 'pc',
+        computedAt: '2026-05-30T11:00:00.000Z',
+        methodology: 'legacy-weight-perturbation-v2',
+      },
+    }, { keepVercelEnv: true });
+
+    const response = await modules.getResilienceRuntimeManifest({
+      request: new Request('https://worldmonitor.app/api/resilience/v1/get-runtime-manifest'),
+    } as never);
+
+    assert.deepEqual(response.intervals, {
+      available: false,
+      methodology: 'weight-perturbation-sensitivity-v3',
+      sampleCountry: 'US',
+      lastObservedAt: '2026-05-30T11:00:00.000Z',
+    });
+  });
+
   it('exposes derived construct state without raw env names, cache keys, or secrets', async () => {
     const modules = await loadRuntimeManifestModules();
     process.env.RESILIENCE_PILLAR_COMBINE_ENABLED = 'true';


### PR DESCRIPTION
**Summary**
- Add a shared current resilience interval payload validator for finite p05/p95, current formula, and current interval methodology.
- Reuse it in the runtime manifest, score interval reader, and ranking interval reader while preserving envelope-aware cache reads.
- Add regression coverage for wrong-methodology intervals being omitted from scoreInterval, rankStable, and runtime interval availability.

**Validation**
- npm_config_cache=/private/tmp/npm-cache npx tsx --test tests/resilience-intervals-handler.test.mts tests/resilience-runtime-manifest.test.mts
- npm_config_cache=/private/tmp/npm-cache npx tsx --test tests/resilience-ranking.test.mts
- npm run typecheck
- npm run typecheck:api
- git push pre-push hook passed: typecheck, typecheck:api, Convex type check, CJS syntax, Unicode safety, lint:boundaries, lint:safe-html, lint:rate-limit-policies, lint:premium-fetch, edge bundle check, resilience changed-file test sweep, server handler tests, version check