### PR TITLE
fix: guard isDynamicPanel with ALL_PANELS check to prevent built-in panel prefix collision

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -512,7 +512,7 @@ export class App {
     let panelSettings: Record<string, PanelConfig>;
 
     // Panels that must survive variant switches: desktop config, user-created widgets, MCP panels.
-    const isDynamicPanel = (k: string) => k === 'runtime-config' || k.startsWith('cw-') || k.startsWith('mcp-');
+    const isDynamicPanel = (k: string) => !ALL_PANELS[k] && (k === 'runtime-config' || k.startsWith('cw-') || k.startsWith('mcp-'));
 
     // Check if variant changed - reset all settings to variant defaults
     const storedVariant = localStorage.getItem('worldmonitor-variant');

--- a/tests/panel-config-guardrails.test.mjs
+++ b/tests/panel-config-guardrails.test.mjs
@@ -322,6 +322,27 @@ describe('panel-config guardrails', () => {
       `  Stale PANEL_CATEGORY_MAP panelKeys (remove from panels.ts): ${staleCategory.join(', ') || '—'}`,
     );
   });
+
+  // Guards the convention that App.ts isDynamicPanel() relies on: the `cw-`
+  // (custom widget) and `mcp-` prefixes are reserved for runtime-created,
+  // user-owned panels. A *registered* built-in using either prefix would be
+  // misclassified as dynamic — surviving variant resets it should undergo and
+  // dodging enforceFreeTierLimits gating. The ALL_PANELS membership check in
+  // isDynamicPanel handles the collision at runtime; this locks the invariant
+  // at its source so a mis-prefixed registration fails CI instead.
+  it('no registered panel uses a reserved dynamic-panel prefix (cw-/mcp-)', () => {
+    const collisions = [...allRegistryPanelIds()]
+      .filter((id) => id.startsWith('cw-') || id.startsWith('mcp-'))
+      .sort();
+    assert.deepStrictEqual(
+      collisions,
+      [],
+      `Registered built-in panels using a reserved dynamic-panel prefix:\n  ${collisions.join(', ')}\n` +
+      `App.ts isDynamicPanel() treats cw-/mcp- keys as user-created widgets. A built-in with this\n` +
+      `prefix would be skipped on variant switches and bypass free-tier gating. Rename to a\n` +
+      `non-reserved prefix.`,
+    );
+  });
 });
 
 function levenshtein(a, b) {


### PR DESCRIPTION
## Summary

`isDynamicPanel` used prefix-matching (`k.startsWith('cw-') || k.startsWith('mcp-')`) to identify user-created panels that should survive variant switches. Any future built-in panel registered with a key starting `cw-` or `mcp-` would be silently treated as dynamic — surviving variant resets when it should be reset, and potentially dodging `enforceFreeTierLimits` paths.

## Fix

Check membership in `ALL_PANELS` first — if a key is a registered built-in panel, it's not dynamic regardless of its prefix.

```diff
- const isDynamicPanel = (k: string) => k === 'runtime-config' || k.startsWith('cw-') || k.startsWith('mcp-');
+ const isDynamicPanel = (k: string) => !ALL_PANELS[k] && (k === 'runtime-config' || k.startsWith('cw-') || k.startsWith('mcp-'));
```

## Verification
- `npm run typecheck`: ✅ passed
- `npm run typecheck:api`: ✅ passed  
- `npm run test:data`: ✅ 10664 passed, 0 failed

Fixes #3532