### PR TITLE
fix(resilience): hide no-data baseline stress row

### DIFF
--- a/src/components/ResilienceWidget.ts
+++ b/src/components/ResilienceWidget.ts
@@ -21,6 +21,7 @@ import {
   getResilienceVisualLevel,
   getStalenessIcon,
   getStalenessLabel,
+  shouldRenderResilienceBaselineStress,
 } from './resilience-widget-utils';
 import type { CountryEnergyProfileData } from './CountryBriefPanel';
 
@@ -293,7 +294,7 @@ export class ResilienceWidget {
           ),
         ),
       ),
-      ...(data.baselineScore != null && data.stressScore != null
+      ...(shouldRenderResilienceBaselineStress(data, overallDisplay)
         ? [h(
             'div',
             { className: 'resilience-widget__baseline-stress' },

--- a/src/components/resilience-widget-utils.ts
+++ b/src/components/resilience-widget-utils.ts
@@ -247,6 +247,13 @@ export function getResilienceOverallDisplay(data: Pick<ResilienceScoreResponse, 
   };
 }
 
+export function shouldRenderResilienceBaselineStress(
+  data: Pick<ResilienceScoreResponse, 'overallScore' | 'level' | 'baselineScore' | 'stressScore'>,
+  overallDisplay: Pick<ResilienceOverallDisplay, 'hasScore'> = getResilienceOverallDisplay(data),
+): boolean {
+  return overallDisplay.hasScore && data.baselineScore != null && data.stressScore != null;
+}
+
 export interface ResilienceMethodologySummary {
   activeDimensionCount: number;
   // Kept for server/fixture parity tests; tooltip copy intentionally shows active dimensions only.

--- a/tests/resilience-widget.test.mts
+++ b/tests/resilience-widget.test.mts
@@ -22,6 +22,7 @@ import {
   getResilienceVisualLevel,
   getStalenessIcon,
   getStalenessLabel,
+  shouldRenderResilienceBaselineStress,
 } from '../src/components/resilience-widget-utils';
 import type { ResilienceScoreResponse } from '../src/services/resilience';
 
@@ -322,6 +323,34 @@ test('formatBaselineStress renders the expected breakdown string (no Impact)', (
   assert.equal(formatBaselineStress(80, 100), 'Baseline: 80 | Stress: 100');
   assert.equal(formatBaselineStress(50, 0), 'Baseline: 50 | Stress: 0');
   assert.equal(formatBaselineStress(NaN, 50), 'Baseline: 0 | Stress: 50');
+});
+
+test('shouldRenderResilienceBaselineStress hides the row when the overall score is unavailable', () => {
+  const noScoreResponse: ResilienceScoreResponse = {
+    ...baseResponse,
+    overallScore: 0,
+    baselineScore: 0,
+    stressScore: 0,
+    level: 'unknown',
+    lowConfidence: true,
+  };
+
+  assert.equal(getResilienceOverallDisplay(noScoreResponse).hasScore, false);
+  assert.equal(shouldRenderResilienceBaselineStress(noScoreResponse), false);
+  assert.equal(formatResilienceConfidence(noScoreResponse), 'Low confidence — sparse data');
+});
+
+test('shouldRenderResilienceBaselineStress keeps explicit zero scores when the API level is real', () => {
+  const zeroScoreResponse: ResilienceScoreResponse = {
+    ...baseResponse,
+    overallScore: 0,
+    baselineScore: 0,
+    stressScore: 0,
+    level: 'low',
+  };
+
+  assert.equal(getResilienceOverallDisplay(zeroScoreResponse).hasScore, true);
+  assert.equal(shouldRenderResilienceBaselineStress(zeroScoreResponse), true);
 });
 
 test('formatResilienceScoreInterval renders the overall score interval badge', () => {


### PR DESCRIPTION
## Summary
- hide the ResilienceWidget baseline/stress row whenever the overall display has no score
- keep the sparse-data confidence/footer behavior intact
- add regression coverage for unknown-level zero-score responses and explicit real zero-score responses

## Root cause
`renderScoreCard()` used `getResilienceOverallDisplay(data)` for the headline, but rendered the baseline/stress row solely from non-null component scores. No-score responses with `overallScore: 0`, `level: "unknown"`, `baselineScore: 0`, and `stressScore: 0` could therefore show `Baseline: 0 | Stress: 0` under an `Insufficient data` headline.

## Validation
- `NPM_CONFIG_CACHE=/tmp/worldmonitor-npm-cache npx tsx --test tests/resilience-widget.test.mts`
- `git diff --check`
- pre-push hook passed: typecheck, API typecheck, boundary/safe HTML/rate-limit/premium-fetch checks, edge bundle/tests, resilience tests, version check