### PR TITLE
Validate resilience interval seed-health probes

### DIFF
--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -194,19 +194,20 @@ function evaluateDataProbe(cfg, raw) {
   }
 
   const methodology = typeof parsed.methodology === 'string' ? parsed.methodology : null;
+  const formula = typeof parsed._formula === 'string' ? parsed._formula : null;
   if (cfg.methodology && methodology !== cfg.methodology) {
     return {
       ok: false,
       status: 'methodology_mismatch',
       key: cfg.key,
       methodology,
+      formula,
       requiredMethodology: cfg.methodology,
       requiredSourceVersion: cfg.sourceVersion ?? null,
       requiredFormula,
     };
   }
 
-  const formula = typeof parsed._formula === 'string' ? parsed._formula : null;
   if (requiredFormula && formula !== requiredFormula) {
     return {
       ok: false,

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -13,6 +13,8 @@ const RESILIENCE_INTERVAL_KEY_PREFIX = 'resilience:intervals:v8:';
 const RESILIENCE_INTERVAL_METHODOLOGY = 'weight-perturbation-sensitivity-v3';
 const RESILIENCE_INTERVAL_SOURCE_VERSION = `resilience-intervals:${RESILIENCE_INTERVAL_KEY_PREFIX}${RESILIENCE_INTERVAL_METHODOLOGY}`;
 const RESILIENCE_INTERVAL_PROBE_KEY = `${RESILIENCE_INTERVAL_KEY_PREFIX}US`;
+const RESILIENCE_INTERVAL_SCORE_MIN = 0;
+const RESILIENCE_INTERVAL_SCORE_MAX = 100;
 
 const SEED_DOMAINS = {
   // Phase 1 — Snapshot endpoints
@@ -90,7 +92,9 @@ const SEED_DOMAINS = {
     intervalMin: 420, // Same 840min freshness budget as api/health.js, expressed as intervalMin * 2.
     dataProbe: {
       key: RESILIENCE_INTERVAL_PROBE_KEY,
+      kind: 'resilience_interval',
       methodology: RESILIENCE_INTERVAL_METHODOLOGY,
+      formula: currentResilienceCacheFormula(),
       sourceVersion: RESILIENCE_INTERVAL_SOURCE_VERSION,
     },
   },
@@ -136,8 +140,36 @@ function parseJsonValue(raw) {
   }
 }
 
+function isEnabledEnv(name, defaultValue) {
+  return String(process.env[name] ?? defaultValue).toLowerCase() === 'true';
+}
+
+function currentResilienceCacheFormula() {
+  // Mirrors server/worldmonitor/resilience/v1/_shared.ts currentCacheFormula().
+  // Edge functions cannot import the server module, so this is intentionally
+  // duplicated and guarded by tests.
+  return isEnabledEnv('RESILIENCE_PILLAR_COMBINE_ENABLED', 'false') &&
+    isEnabledEnv('RESILIENCE_SCHEMA_V2_ENABLED', 'true')
+    ? 'pc'
+    : 'd6';
+}
+
+function isValidResilienceIntervalPayload(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return false;
+  if (typeof payload.p05 !== 'number' || !Number.isFinite(payload.p05)) return false;
+  if (typeof payload.p95 !== 'number' || !Number.isFinite(payload.p95)) return false;
+  return (
+    payload.p05 >= RESILIENCE_INTERVAL_SCORE_MIN &&
+    payload.p05 <= RESILIENCE_INTERVAL_SCORE_MAX &&
+    payload.p95 >= RESILIENCE_INTERVAL_SCORE_MIN &&
+    payload.p95 <= RESILIENCE_INTERVAL_SCORE_MAX &&
+    payload.p05 <= payload.p95
+  );
+}
+
 function evaluateDataProbe(cfg, raw) {
   if (!cfg) return null;
+  const requiredFormula = cfg.formula ?? null;
   if (!raw) {
     return {
       ok: false,
@@ -145,6 +177,7 @@ function evaluateDataProbe(cfg, raw) {
       key: cfg.key,
       requiredMethodology: cfg.methodology ?? null,
       requiredSourceVersion: cfg.sourceVersion ?? null,
+      requiredFormula,
     };
   }
 
@@ -156,6 +189,7 @@ function evaluateDataProbe(cfg, raw) {
       key: cfg.key,
       requiredMethodology: cfg.methodology ?? null,
       requiredSourceVersion: cfg.sourceVersion ?? null,
+      requiredFormula,
     };
   }
 
@@ -168,6 +202,36 @@ function evaluateDataProbe(cfg, raw) {
       methodology,
       requiredMethodology: cfg.methodology,
       requiredSourceVersion: cfg.sourceVersion ?? null,
+      requiredFormula,
+    };
+  }
+
+  const formula = typeof parsed._formula === 'string' ? parsed._formula : null;
+  if (requiredFormula && formula !== requiredFormula) {
+    return {
+      ok: false,
+      status: 'formula_mismatch',
+      key: cfg.key,
+      formula,
+      requiredFormula,
+      methodology,
+      requiredMethodology: cfg.methodology ?? null,
+      requiredSourceVersion: cfg.sourceVersion ?? null,
+    };
+  }
+
+  if (cfg.kind === 'resilience_interval' && !isValidResilienceIntervalPayload(parsed)) {
+    return {
+      ok: false,
+      status: 'data_invalid',
+      key: cfg.key,
+      formula,
+      requiredFormula,
+      methodology,
+      requiredMethodology: cfg.methodology ?? null,
+      requiredSourceVersion: cfg.sourceVersion ?? null,
+      p05: typeof parsed.p05 === 'number' && Number.isFinite(parsed.p05) ? parsed.p05 : null,
+      p95: typeof parsed.p95 === 'number' && Number.isFinite(parsed.p95) ? parsed.p95 : null,
     };
   }
 
@@ -178,7 +242,8 @@ function evaluateDataProbe(cfg, raw) {
     methodology,
     requiredMethodology: cfg.methodology ?? null,
     requiredSourceVersion: cfg.sourceVersion ?? null,
-    formula: typeof parsed._formula === 'string' ? parsed._formula : null,
+    formula,
+    requiredFormula,
     computedAt: typeof parsed.computedAt === 'string' ? parsed.computedAt : null,
   };
 }

--- a/server/worldmonitor/resilience/v1/_shared.ts
+++ b/server/worldmonitor/resilience/v1/_shared.ts
@@ -915,6 +915,11 @@ export function isCurrentResilienceIntervalPayload(
     Number.isFinite(payload.p05) &&
     typeof payload.p95 === 'number' &&
     Number.isFinite(payload.p95) &&
+    payload.p05 >= 0 &&
+    payload.p05 <= 100 &&
+    payload.p95 >= 0 &&
+    payload.p95 <= 100 &&
+    payload.p05 <= payload.p95 &&
     payload._formula === currentCacheFormula() &&
     payload.methodology === RESILIENCE_INTERVAL_METHODOLOGY
   );

--- a/tests/resilience-cache-keys-health-sync.test.mts
+++ b/tests/resilience-cache-keys-health-sync.test.mts
@@ -87,7 +87,7 @@ describe('resilience cache-key health-registry sync (T1.9)', () => {
     );
   });
 
-  it('api/seed-health.js resilience interval probe mirrors the script prefix and methodology', () => {
+  it('api/seed-health.js resilience interval probe mirrors the script prefix, methodology, and formula gate', () => {
     const seedHealthText = readFileSync(join(repoRoot, 'api/seed-health.js'), 'utf-8');
     assert.ok(
       seedHealthText.includes(`const RESILIENCE_INTERVAL_KEY_PREFIX = '${SCRIPT_INTERVAL_KEY_PREFIX}';`) ||
@@ -98,6 +98,19 @@ describe('resilience cache-key health-registry sync (T1.9)', () => {
       seedHealthText.includes(`const RESILIENCE_INTERVAL_METHODOLOGY = '${SCRIPT_INTERVAL_METHODOLOGY}';`) ||
         seedHealthText.includes(`const RESILIENCE_INTERVAL_METHODOLOGY = "${SCRIPT_INTERVAL_METHODOLOGY}";`),
       `api/seed-health.js must mirror scripts/_resilience-intervals.mjs RESILIENCE_INTERVAL_METHODOLOGY=${SCRIPT_INTERVAL_METHODOLOGY}`,
+    );
+    assert.ok(
+      seedHealthText.includes("function currentResilienceCacheFormula()") &&
+        seedHealthText.includes("RESILIENCE_PILLAR_COMBINE_ENABLED") &&
+        seedHealthText.includes("RESILIENCE_SCHEMA_V2_ENABLED") &&
+        seedHealthText.includes("formula: currentResilienceCacheFormula()"),
+      'api/seed-health.js must mirror the server currentCacheFormula gate for resilience interval probes',
+    );
+    assert.ok(
+      seedHealthText.includes("kind: 'resilience_interval'") &&
+        seedHealthText.includes('isValidResilienceIntervalPayload') &&
+        seedHealthText.includes('payload.p05 <= payload.p95'),
+      'api/seed-health.js must validate resilience interval payload shape before reporting healthy',
     );
   });
 

--- a/tests/resilience-intervals-handler.test.mts
+++ b/tests/resilience-intervals-handler.test.mts
@@ -141,6 +141,43 @@ describe('resilience score interval integration', () => {
     assert.equal(response.scoreInterval, undefined, 'untagged scoreInterval should be ignored');
   });
 
+  it('omits malformed interval bounds', async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+    process.env.RESILIENCE_PILLAR_COMBINE_ENABLED = 'false';
+    delete process.env.VERCEL_ENV;
+
+    const cases = [
+      { name: 'reversed', p05: 80, p95: 70 },
+      { name: 'below range', p05: -1, p95: 70 },
+      { name: 'above range', p05: 65.2, p95: 101 },
+    ];
+
+    for (const item of cases) {
+      const fixtures = {
+        ...RESILIENCE_FIXTURES,
+        'resilience:intervals:v8:US': {
+          p05: item.p05,
+          p95: item.p95,
+          _formula: 'd6',
+          draws: 100,
+          computedAt: '2026-04-06T00:00:00.000Z',
+          methodology: RESILIENCE_INTERVAL_METHODOLOGY,
+        },
+      };
+
+      const { fetchImpl } = createRedisFetch(fixtures);
+      globalThis.fetch = fetchImpl;
+
+      const response = await getResilienceScore(
+        { request: new Request('https://example.com') } as never,
+        { countryCode: 'US' },
+      );
+
+      assert.equal(response.scoreInterval, undefined, `${item.name} scoreInterval should be ignored`);
+    }
+  });
+
   it('omits scoreInterval when Redis has no interval data', async () => {
     process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example';
     process.env.UPSTASH_REDIS_REST_TOKEN = 'token';

--- a/tests/seed-health-resilience-intervals.test.mjs
+++ b/tests/seed-health-resilience-intervals.test.mjs
@@ -6,11 +6,15 @@ const originalEnv = {
   UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
   UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
   WORLDMONITOR_VALID_KEYS: process.env.WORLDMONITOR_VALID_KEYS,
+  RESILIENCE_PILLAR_COMBINE_ENABLED: process.env.RESILIENCE_PILLAR_COMBINE_ENABLED,
+  RESILIENCE_SCHEMA_V2_ENABLED: process.env.RESILIENCE_SCHEMA_V2_ENABLED,
 };
 
 process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
 process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
 process.env.WORLDMONITOR_VALID_KEYS = 'test-key';
+process.env.RESILIENCE_PILLAR_COMBINE_ENABLED = 'true';
+process.env.RESILIENCE_SCHEMA_V2_ENABLED = 'true';
 
 const { default: handler } = await import('../api/seed-health.js');
 
@@ -43,6 +47,8 @@ before(() => {
   process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
   process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
   process.env.WORLDMONITOR_VALID_KEYS = 'test-key';
+  process.env.RESILIENCE_PILLAR_COMBINE_ENABLED = 'true';
+  process.env.RESILIENCE_SCHEMA_V2_ENABLED = 'true';
 });
 
 after(() => {
@@ -100,6 +106,7 @@ test('seed-health flags fresh resilience interval meta when the current v8 data 
     key: PROBE_KEY,
     requiredMethodology: METHODOLOGY,
     requiredSourceVersion: SOURCE_VERSION,
+    requiredFormula: 'pc',
   });
 });
 
@@ -119,6 +126,7 @@ test('seed-health keeps resilience intervals green when fresh meta matches the c
   assert.equal(body.seeds['resilience:intervals'].dataProbe.key, PROBE_KEY);
   assert.equal(body.seeds['resilience:intervals'].dataProbe.methodology, METHODOLOGY);
   assert.equal(body.seeds['resilience:intervals'].dataProbe.formula, 'pc');
+  assert.equal(body.seeds['resilience:intervals'].dataProbe.requiredFormula, 'pc');
 });
 
 test('seed-health flags resilience interval methodology mismatches', async () => {
@@ -140,7 +148,68 @@ test('seed-health flags resilience interval methodology mismatches', async () =>
     methodology: 'weight-perturbation-sensitivity-v2',
     requiredMethodology: METHODOLOGY,
     requiredSourceVersion: SOURCE_VERSION,
+    requiredFormula: 'pc',
   });
+});
+
+test('seed-health flags resilience interval formula mismatches even when meta is fresh', async () => {
+  installPipelineMock(new Map([
+    [META_KEY, intervalMeta()],
+    [PROBE_KEY, intervalPayload({ _formula: 'd6' })],
+  ]));
+
+  const { res, body } = await readSeedHealth();
+
+  assert.equal(res.status, 200);
+  assert.equal(body.overall, 'warning');
+  assert.equal(body.seeds['resilience:intervals'].status, 'formula_mismatch');
+  assert.equal(body.seeds['resilience:intervals'].stale, true);
+  assert.deepEqual(body.seeds['resilience:intervals'].dataProbe, {
+    ok: false,
+    status: 'formula_mismatch',
+    key: PROBE_KEY,
+    formula: 'd6',
+    requiredFormula: 'pc',
+    methodology: METHODOLOGY,
+    requiredMethodology: METHODOLOGY,
+    requiredSourceVersion: SOURCE_VERSION,
+  });
+});
+
+test('seed-health flags malformed resilience interval payloads even when meta is fresh', async () => {
+  const cases = [
+    { name: 'missing p05', payload: intervalPayload({ p05: undefined }), p05: null, p95: 72.8 },
+    { name: 'non-finite p95', payload: intervalPayload({ p95: Number.POSITIVE_INFINITY }), p05: 65.2, p95: null },
+    { name: 'reversed bounds', payload: intervalPayload({ p05: 80, p95: 70 }), p05: 80, p95: 70 },
+    { name: 'p05 below range', payload: intervalPayload({ p05: -1, p95: 70 }), p05: -1, p95: 70 },
+    { name: 'p95 above range', payload: intervalPayload({ p05: 65, p95: 101 }), p05: 65, p95: 101 },
+  ];
+
+  for (const item of cases) {
+    installPipelineMock(new Map([
+      [META_KEY, intervalMeta()],
+      [PROBE_KEY, item.payload],
+    ]));
+
+    const { res, body } = await readSeedHealth();
+
+    assert.equal(res.status, 200, item.name);
+    assert.equal(body.overall, 'warning', item.name);
+    assert.equal(body.seeds['resilience:intervals'].status, 'data_invalid', item.name);
+    assert.equal(body.seeds['resilience:intervals'].stale, true, item.name);
+    assert.deepEqual(body.seeds['resilience:intervals'].dataProbe, {
+      ok: false,
+      status: 'data_invalid',
+      key: PROBE_KEY,
+      formula: 'pc',
+      requiredFormula: 'pc',
+      methodology: METHODOLOGY,
+      requiredMethodology: METHODOLOGY,
+      requiredSourceVersion: SOURCE_VERSION,
+      p05: item.p05,
+      p95: item.p95,
+    }, item.name);
+  }
 });
 
 test('seed-health flags resilience interval source-version mismatches', async () => {

--- a/tests/seed-health-resilience-intervals.test.mjs
+++ b/tests/seed-health-resilience-intervals.test.mjs
@@ -47,8 +47,6 @@ before(() => {
   process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
   process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
   process.env.WORLDMONITOR_VALID_KEYS = 'test-key';
-  process.env.RESILIENCE_PILLAR_COMBINE_ENABLED = 'true';
-  process.env.RESILIENCE_SCHEMA_V2_ENABLED = 'true';
 });
 
 after(() => {
@@ -132,7 +130,7 @@ test('seed-health keeps resilience intervals green when fresh meta matches the c
 test('seed-health flags resilience interval methodology mismatches', async () => {
   installPipelineMock(new Map([
     [META_KEY, intervalMeta()],
-    [PROBE_KEY, intervalPayload({ methodology: 'weight-perturbation-sensitivity-v2' })],
+    [PROBE_KEY, intervalPayload({ _formula: 'd6', methodology: 'weight-perturbation-sensitivity-v2' })],
   ]));
 
   const { res, body } = await readSeedHealth();
@@ -146,6 +144,7 @@ test('seed-health flags resilience interval methodology mismatches', async () =>
     status: 'methodology_mismatch',
     key: PROBE_KEY,
     methodology: 'weight-perturbation-sensitivity-v2',
+    formula: 'd6',
     requiredMethodology: METHODOLOGY,
     requiredSourceVersion: SOURCE_VERSION,
     requiredFormula: 'pc',


### PR DESCRIPTION
## Summary
- make seed-health reject resilience interval probes with stale formula tags
- validate interval payload bounds before reporting the seed healthy
- align the server interval reader with the same finite, ordered, in-range bounds

## Validation
- node --test tests/seed-health-resilience-intervals.test.mjs
- npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/resilience-cache-keys-health-sync.test.mts
- npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/resilience-intervals-handler.test.mts
- git diff --check
- pre-push hook passed during git push