### PR TITLE
fix(resilience): align zero-score display semantics

### DIFF
--- a/src/components/RouteExplorer/components/LeftRail.ts
+++ b/src/components/RouteExplorer/components/LeftRail.ts
@@ -11,6 +11,7 @@ import type { GetRouteExplorerLaneResponse, DependencyFlag } from '@/generated/s
 import {
   formatResilienceConfidence,
   formatResilienceScoreInterval,
+  hasScoredResilienceOverall,
 } from '@/components/resilience-widget-utils';
 import type { ResilienceScoreResponse } from '@/services/resilience';
 import {
@@ -94,18 +95,13 @@ export class LeftRail {
   }
 
   private static formatResilienceScore(resilience: ResilienceScoreResponse | null): string {
-    const score = resilience?.overallScore;
-    const rounded = typeof score === 'number' && Number.isFinite(score) ? Math.round(score) : 0;
-    return rounded > 0
-      ? `${rounded}/100`
-      : '\u2014';
+    if (!resilience || !hasScoredResilienceOverall(resilience)) return '\u2014';
+    return `${Math.round(resilience.overallScore)}/100`;
   }
 
   private static renderResilienceMeta(resilience: ResilienceScoreResponse | null): string {
     if (!resilience) return '';
-    const score = resilience.overallScore;
-    const rounded = typeof score === 'number' && Number.isFinite(score) ? Math.round(score) : 0;
-    if (rounded <= 0) {
+    if (!hasScoredResilienceOverall(resilience)) {
       return '<span class="re-resilience-confidence re-resilience-confidence--low">No scored resilience data</span>';
     }
     const confidence = formatResilienceConfidence(resilience);

--- a/src/components/RouteExplorer/components/LeftRail.ts
+++ b/src/components/RouteExplorer/components/LeftRail.ts
@@ -9,6 +9,7 @@
 
 import type { GetRouteExplorerLaneResponse, DependencyFlag } from '@/generated/server/worldmonitor/supply_chain/v1/service_server';
 import {
+  formatScoredResilienceOverallLabel,
   formatResilienceConfidence,
   formatResilienceScoreInterval,
   hasScoredResilienceOverall,
@@ -96,7 +97,7 @@ export class LeftRail {
 
   private static formatResilienceScore(resilience: ResilienceScoreResponse | null): string {
     if (!resilience || !hasScoredResilienceOverall(resilience)) return '\u2014';
-    return `${Math.round(resilience.overallScore)}/100`;
+    return `${formatScoredResilienceOverallLabel(resilience.overallScore)}/100`;
   }
 
   private static renderResilienceMeta(resilience: ResilienceScoreResponse | null): string {

--- a/src/components/RouteExplorer/tabs/CountryImpactTab.ts
+++ b/src/components/RouteExplorer/tabs/CountryImpactTab.ts
@@ -12,6 +12,7 @@ import type {
   StrategicProduct,
 } from '@/generated/server/worldmonitor/supply_chain/v1/service_server';
 import {
+  formatScoredResilienceOverallLabel,
   formatResilienceConfidence,
   formatResilienceScoreInterval,
   hasScoredResilienceOverall,
@@ -131,14 +132,13 @@ export class CountryImpactTab {
 
   private renderResilience(data: GetRouteImpactResponse): string {
     const resilience = this.resilience;
-    const score = resilience?.overallScore;
-    const roundedScore = typeof score === 'number' && Number.isFinite(score) ? Math.round(score) : 0;
     if (resilience && hasScoredResilienceOverall(resilience)) {
+      const scoreLabel = formatScoredResilienceOverallLabel(resilience.overallScore);
       const confidence = formatResilienceConfidence(resilience);
       const interval = formatResilienceScoreInterval(resilience.scoreInterval);
       return [
         '<div class="re-impact__resilience">',
-        `  <span>Resilience: <strong>${roundedScore}/100</strong></span>`,
+        `  <span>Resilience: <strong>${escapeHtml(scoreLabel)}/100</strong></span>`,
         ...(interval
           ? [`  <span class="re-resilience-interval" title="${escapeHtml(interval.title)}">${escapeHtml(interval.label)}</span>`]
           : []),

--- a/src/components/RouteExplorer/tabs/CountryImpactTab.ts
+++ b/src/components/RouteExplorer/tabs/CountryImpactTab.ts
@@ -14,6 +14,7 @@ import type {
 import {
   formatResilienceConfidence,
   formatResilienceScoreInterval,
+  hasScoredResilienceOverall,
 } from '@/components/resilience-widget-utils';
 import type { ResilienceScoreResponse } from '@/services/resilience';
 import { escapeHtml } from './route-utils';
@@ -132,7 +133,7 @@ export class CountryImpactTab {
     const resilience = this.resilience;
     const score = resilience?.overallScore;
     const roundedScore = typeof score === 'number' && Number.isFinite(score) ? Math.round(score) : 0;
-    if (resilience && roundedScore > 0) {
+    if (resilience && hasScoredResilienceOverall(resilience)) {
       const confidence = formatResilienceConfidence(resilience);
       const interval = formatResilienceScoreInterval(resilience.scoreInterval);
       return [

--- a/src/components/resilience-widget-utils.ts
+++ b/src/components/resilience-widget-utils.ts
@@ -224,6 +224,13 @@ export function hasScoredResilienceOverall(
   return data.overallScore !== 0 || hasAuthoritativeResilienceServerLevel(data.level);
 }
 
+export function formatScoredResilienceOverallLabel(score: number): string {
+  const clampedScore = Math.min(100, Math.max(0, score));
+  const roundedScore = Math.round(clampedScore);
+  if (clampedScore > 0 && roundedScore === 0) return '<1';
+  return String(roundedScore);
+}
+
 export interface ResilienceOverallDisplay {
   hasScore: boolean;
   scoreForBar: number;
@@ -251,7 +258,7 @@ export function getResilienceOverallDisplay(data: Pick<ResilienceScoreResponse, 
   return {
     hasScore: true,
     scoreForBar: clampedScore,
-    scoreLabel: String(Math.round(clampedScore)),
+    scoreLabel: formatScoredResilienceOverallLabel(clampedScore),
     visualLevel,
     visualLevelLabel: `Visual band: ${formatResilienceVisualLevel(visualLevel).toUpperCase()}`,
     serverLevelLabel: `API level: ${formatResilienceServerLevel(data.level)}`,

--- a/src/components/resilience-widget-utils.ts
+++ b/src/components/resilience-widget-utils.ts
@@ -209,8 +209,19 @@ export function formatResilienceServerLevel(level: string | null | undefined): s
   return normalized.length > 0 ? normalized.replace(/_/g, ' ') : 'unknown';
 }
 
-function isUnknownResilienceServerLevel(level: string | null | undefined): boolean {
-  return String(level || '').trim().toLowerCase() === 'unknown';
+function hasAuthoritativeResilienceServerLevel(level: string | null | undefined): boolean {
+  const normalized = String(level || '').trim().toLowerCase();
+  return normalized.length > 0 && normalized !== 'unknown';
+}
+
+export function hasScoredResilienceOverall(
+  data: Pick<ResilienceScoreResponse, 'overallScore' | 'level'> | null | undefined,
+): boolean {
+  if (!data || typeof data.overallScore !== 'number' || !Number.isFinite(data.overallScore) || data.overallScore < 0) {
+    return false;
+  }
+  // Zero is a valid explicit score only when the API also supplies a real level.
+  return data.overallScore !== 0 || hasAuthoritativeResilienceServerLevel(data.level);
 }
 
 export interface ResilienceOverallDisplay {
@@ -225,7 +236,7 @@ export interface ResilienceOverallDisplay {
 export function getResilienceOverallDisplay(data: Pick<ResilienceScoreResponse, 'overallScore' | 'level'>): ResilienceOverallDisplay {
   const rawScore = Number(data.overallScore);
   const visualLevel = getResilienceVisualLevel(rawScore);
-  if (visualLevel === 'unknown' || (rawScore === 0 && isUnknownResilienceServerLevel(data.level))) {
+  if (!hasScoredResilienceOverall(data)) {
     return {
       hasScore: false,
       scoreForBar: 0,

--- a/tests/resilience-widget.test.mts
+++ b/tests/resilience-widget.test.mts
@@ -15,6 +15,7 @@ import {
   getImputationClassIcon,
   getImputationClassLabel,
   getResilienceMethodologySummary,
+  formatScoredResilienceOverallLabel,
   getResilienceOverallDisplay,
   getResilienceDimensionLabel,
   getResilienceDomainLabel,
@@ -124,6 +125,20 @@ test('getResilienceOverallDisplay keeps explicit zero scores when API level is r
     hasScore: true,
     scoreForBar: 0,
     scoreLabel: '0',
+    visualLevel: 'very_low',
+    visualLevelLabel: 'Visual band: VERY LOW',
+    serverLevelLabel: 'API level: low',
+  });
+});
+
+test('getResilienceOverallDisplay distinguishes positive sub-1 scores from explicit zero', () => {
+  assert.equal(hasScoredResilienceOverall({ overallScore: 0.4, level: 'low' }), true);
+  assert.equal(formatScoredResilienceOverallLabel(0), '0');
+  assert.equal(formatScoredResilienceOverallLabel(0.4), '<1');
+  assert.deepEqual(getResilienceOverallDisplay({ overallScore: 0.4, level: 'low' }), {
+    hasScore: true,
+    scoreForBar: 0.4,
+    scoreLabel: '<1',
     visualLevel: 'very_low',
     visualLevelLabel: 'Visual band: VERY LOW',
     serverLevelLabel: 'API level: low',

--- a/tests/resilience-widget.test.mts
+++ b/tests/resilience-widget.test.mts
@@ -20,6 +20,7 @@ import {
   getResilienceDomainLabel,
   getResilienceTrendArrow,
   getResilienceVisualLevel,
+  hasScoredResilienceOverall,
   getStalenessIcon,
   getStalenessLabel,
 } from '../src/components/resilience-widget-utils';
@@ -101,7 +102,11 @@ test('getResilienceOverallDisplay treats negative and non-finite scores as insuf
   });
 });
 
-test('getResilienceOverallDisplay preserves API unknown zero as no score', () => {
+test('getResilienceOverallDisplay treats null, undefined, and API unknown zero as no score', () => {
+  assert.equal(hasScoredResilienceOverall(null), false);
+  assert.equal(hasScoredResilienceOverall(undefined), false);
+  assert.equal(hasScoredResilienceOverall({ overallScore: null as unknown as number, level: 'low' }), false);
+  assert.equal(hasScoredResilienceOverall({ overallScore: undefined as unknown as number, level: 'low' }), false);
   assert.equal(getResilienceVisualLevel(0), 'very_low');
   assert.deepEqual(getResilienceOverallDisplay({ overallScore: 0, level: 'unknown' }), {
     hasScore: false,
@@ -114,6 +119,7 @@ test('getResilienceOverallDisplay preserves API unknown zero as no score', () =>
 });
 
 test('getResilienceOverallDisplay keeps explicit zero scores when API level is real', () => {
+  assert.equal(hasScoredResilienceOverall({ overallScore: 0, level: 'low' }), true);
   assert.deepEqual(getResilienceOverallDisplay({ overallScore: 0, level: 'low' }), {
     hasScore: true,
     scoreForBar: 0,

--- a/tests/route-explorer-resilience-ui.test.mts
+++ b/tests/route-explorer-resilience-ui.test.mts
@@ -275,6 +275,17 @@ describe('RouteExplorer resilience UI surfaces', () => {
       assert.match(meta.innerHTML, /Coverage 90%/);
       assert.doesNotMatch(meta.innerHTML, /No scored resilience data/);
     });
+
+    it('renders positive sub-1 resilience scores distinctly from explicit zero', () => {
+      const rail = new LeftRail();
+      const { value, meta } = seedLeftRailResilienceNodes(rail);
+
+      rail.updateResilience(resilienceFixture({ overallScore: 0.4, level: 'low' }));
+
+      assert.equal(value.textContent, '<1/100');
+      assert.match(meta.innerHTML, /Coverage 90%/);
+      assert.doesNotMatch(meta.innerHTML, /No scored resilience data/);
+    });
   });
 
   describe('CountryImpactTab', () => {
@@ -382,6 +393,19 @@ describe('RouteExplorer resilience UI surfaces', () => {
       tab.updateResilience(resilienceFixture({ overallScore: 0, level: 'low' }));
 
       assert.match(slot.innerHTML, /Resilience: <strong>0\/100<\/strong>/);
+      assert.match(slot.innerHTML, /Coverage 90%/);
+      assert.doesNotMatch(slot.innerHTML, /No scored resilience data/);
+      assert.doesNotMatch(slot.innerHTML, /44\/100/);
+    });
+
+    it('renders endpoint positive sub-1 resilience scores distinctly from explicit zero', () => {
+      const tab = new CountryImpactTab();
+      tab.update(impactFixture({ resilienceScore: 44 }));
+      const slot = seedImpactResilienceSlot(tab);
+
+      tab.updateResilience(resilienceFixture({ overallScore: 0.4, level: 'low' }));
+
+      assert.match(slot.innerHTML, /Resilience: <strong>&lt;1\/100<\/strong>/);
       assert.match(slot.innerHTML, /Coverage 90%/);
       assert.doesNotMatch(slot.innerHTML, /No scored resilience data/);
       assert.doesNotMatch(slot.innerHTML, /44\/100/);

--- a/tests/route-explorer-resilience-ui.test.mts
+++ b/tests/route-explorer-resilience-ui.test.mts
@@ -242,7 +242,8 @@ describe('RouteExplorer resilience UI surfaces', () => {
       const cases: Array<[string, ResilienceScoreResponse | null]> = [
         ['null response', null],
         ['null score', resilienceFixture({ overallScore: null as unknown as number })],
-        ['zero score', resilienceFixture({ overallScore: 0 })],
+        ['unknown-level zero score', resilienceFixture({ overallScore: 0, level: 'unknown' })],
+        ['missing-level zero score', resilienceFixture({ overallScore: 0, level: undefined as unknown as string })],
         ['negative score', resilienceFixture({ overallScore: -1 })],
         ['NaN score', resilienceFixture({ overallScore: Number.NaN })],
       ];
@@ -262,6 +263,17 @@ describe('RouteExplorer resilience UI surfaces', () => {
           assert.equal(meta.innerHTML, '', label);
         }
       }
+    });
+
+    it('renders explicit zero resilience scores when the API level is real', () => {
+      const rail = new LeftRail();
+      const { value, meta } = seedLeftRailResilienceNodes(rail);
+
+      rail.updateResilience(resilienceFixture({ overallScore: 0, level: 'low' }));
+
+      assert.equal(value.textContent, '0/100');
+      assert.match(meta.innerHTML, /Coverage 90%/);
+      assert.doesNotMatch(meta.innerHTML, /No scored resilience data/);
     });
   });
 
@@ -339,10 +351,11 @@ describe('RouteExplorer resilience UI surfaces', () => {
       assert.doesNotMatch(slot.innerHTML, /re-resilience-interval/);
     });
 
-    it('renders endpoint no-score state for null, zero, negative, and NaN sentinels', () => {
+    it('renders endpoint no-score state for null, unknown-level zero, negative, and NaN sentinels', () => {
       const cases: Array<[string, ResilienceScoreResponse]> = [
         ['null score', resilienceFixture({ overallScore: null as unknown as number })],
-        ['zero score', resilienceFixture({ overallScore: 0 })],
+        ['unknown-level zero score', resilienceFixture({ overallScore: 0, level: 'unknown' })],
+        ['missing-level zero score', resilienceFixture({ overallScore: 0, level: undefined as unknown as string })],
         ['negative score', resilienceFixture({ overallScore: -1 })],
         ['NaN score', resilienceFixture({ overallScore: Number.NaN })],
       ];
@@ -359,6 +372,19 @@ describe('RouteExplorer resilience UI surfaces', () => {
         assert.match(slot.innerHTML, /re-resilience-confidence--low/, label);
         assert.doesNotMatch(slot.innerHTML, /44\/100/, label);
       }
+    });
+
+    it('renders endpoint explicit zero resilience scores when the API level is real', () => {
+      const tab = new CountryImpactTab();
+      tab.update(impactFixture({ resilienceScore: 44 }));
+      const slot = seedImpactResilienceSlot(tab);
+
+      tab.updateResilience(resilienceFixture({ overallScore: 0, level: 'low' }));
+
+      assert.match(slot.innerHTML, /Resilience: <strong>0\/100<\/strong>/);
+      assert.match(slot.innerHTML, /Coverage 90%/);
+      assert.doesNotMatch(slot.innerHTML, /No scored resilience data/);
+      assert.doesNotMatch(slot.innerHTML, /44\/100/);
     });
   });
 });


### PR DESCRIPTION
## Summary
- add shared resilience score-presence semantics for overall score display
- use the shared rule in Route Explorer LeftRail and CountryImpactTab
- preserve explicit 0/100 scores when the API provides a real level, while keeping null, missing, non-finite, negative, and unknown-level zero as no-score

## Validation
- npm_config_cache=/tmp/codex-npm-cache npx tsx --test tests/resilience-widget.test.mts tests/route-explorer-resilience-ui.test.mts
- npm run typecheck
- pre-push hook passed during git push, including API typecheck, boundary/safe-html/rate-limit/premium-fetch checks, resilience tests, changed tests, edge function tests, and version sync