### PR TITLE
Align resilience indicator source catalog with registry

### DIFF
--- a/docs/methodology/indicator-sources.yaml
+++ b/docs/methodology/indicator-sources.yaml
@@ -11,6 +11,7 @@
 #   domain                 — parent domain id
 #   weight                 — current nominal weight inside the dimension blend
 #   direction              — higher-better | lower-better | composite
+#   scoringTier            — registry tier when the row is backed by INDICATOR_REGISTRY: core | enrichment | experimental
 #   source                 — authority that publishes the series
 #   seriesId               — canonical series id where applicable (e.g. EG.IMP.CONS.ZS)
 #   seriesUrl              — direct link to source documentation
@@ -32,8 +33,9 @@
 - indicator: govRevenuePct
   dimension: macroFiscal
   domain: economic
-  weight: 0.50
+  weight: 0.40
   direction: higher-better
+  scoringTier: core
   source: IMF
   seriesId: GGR_G01_GDP_PT
   seriesUrl: https://www.imf.org/external/datamapper/GGR_G01_GDP_PT@FM/
@@ -49,6 +51,7 @@
   domain: economic
   weight: 0.20
   direction: lower-better
+  scoringTier: core
   source: National debt databases (IMF + WB cross-source)
   seriesId: TBD
   seriesUrl: TBD
@@ -61,8 +64,9 @@
 - indicator: currentAccountPct
   dimension: macroFiscal
   domain: economic
-  weight: 0.30
+  weight: 0.20
   direction: higher-better
+  scoringTier: core
   source: IMF
   seriesId: BCA_NGDPD
   seriesUrl: https://www.imf.org/external/datamapper/BCA_NGDPD@WEO/
@@ -72,41 +76,60 @@
   mechanismTestRationale: Current account surplus indicates external-payments resilience; deficit indicates vulnerability to external-finance shocks.
   constructStatus: observed-mechanism
 
-- indicator: fxVolatility
+- indicator: unemploymentPct
+  dimension: macroFiscal
+  domain: economic
+  weight: 0.15
+  direction: lower-better
+  scoringTier: enrichment
+  source: IMF
+  seriesId: LUR
+  seriesUrl: https://www.imf.org/external/datamapper/LUR@WEO/
+  coveragePct: 0.68
+  lastObservedYear: 2024
+  license: Proprietary-with-fair-use
+  mechanismTestRationale: Unemployment rate measures labor-market slack and reduced fiscal absorption capacity during shocks.
+  constructStatus: observed-mechanism
+  reviewNotes: Active macroFiscal Enrichment scorer input; included in the weighted dimension blend at 0.15.
+
+- indicator: householdDebtService
+  dimension: macroFiscal
+  domain: economic
+  weight: 0.05
+  direction: lower-better
+  scoringTier: enrichment
+  source: BIS
+  seriesId: Household debt service ratio
+  seriesUrl: https://data.bis.org/topics/DSR
+  coveragePct: 0.18
+  lastObservedYear: 2024
+  license: Proprietary-with-fair-use
+  mechanismTestRationale: Household debt service burden measures private-sector balance-sheet strain that can amplify banking and fiscal shocks.
+  constructStatus: regional-only
+  reviewNotes: Active macroFiscal Enrichment scorer input for curated BIS economies; conservative imputation applies outside coverage.
+
+- indicator: inflationStability
   dimension: currencyExternal
   domain: economic
   weight: 0.60
   direction: lower-better
-  source: BIS Data Portal
-  seriesId: Broad Effective Exchange Rate
-  seriesUrl: https://data.bis.org/topics/EER
-  coveragePct: 0.30  # BIS covers 64 economies
+  scoringTier: core
+  source: IMF
+  seriesId: PCPIPCH
+  seriesUrl: https://www.imf.org/external/datamapper/PCPIPCH@WEO/
+  coveragePct: 0.83
   lastObservedYear: 2024
-  license: CC-BY
-  mechanismTestRationale: FX volatility measures monetary-shock transmission risk.
-  constructStatus: regional-only
-  reviewNotes: BIS EER covers only 64 economies. Replace with FR.INR.RINR (real interest rate) or IMF inflation volatility in PR 3.
-
-- indicator: fxDeviation
-  dimension: currencyExternal
-  domain: economic
-  weight: 0.25
-  direction: lower-better
-  source: BIS Data Portal
-  seriesId: EER deviation from equilibrium
-  seriesUrl: https://data.bis.org/topics/EER
-  coveragePct: 0.30
-  lastObservedYear: 2024
-  license: CC-BY
-  mechanismTestRationale: EER deviation from equilibrium proxies mis-aligned exchange rates that create abrupt-correction risk.
-  constructStatus: regional-only
-  reviewNotes: Same 64-economy limitation. Retire in PR 3.
+  license: Proprietary-with-fair-use
+  mechanismTestRationale: Inflation stability measures currency purchasing-power shock risk; the scorer rewards the 1-3% target band and penalizes deflation or high inflation.
+  constructStatus: observed-mechanism
+  reviewNotes: Active currencyExternal Core scorer input after PR 3 §3.5; paired with reserves adequacy at 0.40.
 
 - indicator: fxReservesAdequacy
   dimension: currencyExternal
   domain: economic
-  weight: 0.15
+  weight: 0.40
   direction: higher-better
+  scoringTier: core
   source: World Bank
   seriesId: FI.RES.TOTL.MO
   seriesUrl: https://data.worldbank.org/indicator/FI.RES.TOTL.MO
@@ -115,7 +138,39 @@
   license: CC-BY-4.0
   mechanismTestRationale: Reserves in months of imports directly measures immediate external-finance cushion.
   constructStatus: observed-mechanism
-  reviewNotes: Also enters reserveAdequacy at 1.0 weight. Double-counting risk across dimensions; review in PR 2.
+  reviewNotes: Active currencyExternal Core scorer input after PR 3 §3.5; paired with inflationStability at 0.60.
+
+- indicator: fxVolatility
+  dimension: currencyExternal
+  domain: economic
+  weight: 0.60
+  direction: lower-better
+  scoringTier: experimental
+  source: BIS Data Portal
+  seriesId: Broad Effective Exchange Rate
+  seriesUrl: https://data.bis.org/topics/EER
+  coveragePct: 0.30  # BIS covers 64 economies
+  lastObservedYear: 2024
+  license: CC-BY
+  mechanismTestRationale: FX volatility measures monetary-shock transmission risk.
+  constructStatus: regional-only
+  reviewNotes: Experimental/enrichment-only registry row after PR 3 §3.5; BIS EER covers only about 64 economies and scoreCurrencyExternal no longer reads it.
+
+- indicator: fxDeviation
+  dimension: currencyExternal
+  domain: economic
+  weight: 0.25
+  direction: lower-better
+  scoringTier: experimental
+  source: BIS Data Portal
+  seriesId: EER deviation from equilibrium
+  seriesUrl: https://data.bis.org/topics/EER
+  coveragePct: 0.30
+  lastObservedYear: 2024
+  license: CC-BY
+  mechanismTestRationale: EER deviation from equilibrium proxies mis-aligned exchange rates that create abrupt-correction risk.
+  constructStatus: regional-only
+  reviewNotes: Experimental/enrichment-only registry row after PR 3 §3.5; BIS EER covers only about 64 economies and scoreCurrencyExternal no longer reads it.
 
 # tradeSanctions → tradePolicy renamed in plan 2026-04-25-004 Phase 1
 # (Ship 1). The OFAC `sanctionCount` indicator was DROPPED — counting
@@ -134,6 +189,7 @@
   domain: economic
   weight: 0.30
   direction: lower-better
+  scoringTier: enrichment
   source: WTO
   seriesId: Trade Monitoring Database
   seriesUrl: https://www.wto.org/english/tratop_e/tpr_e/trade_monitoring_e.htm
@@ -148,6 +204,7 @@
   domain: economic
   weight: 0.30
   direction: lower-better
+  scoringTier: enrichment
   source: WTO
   seriesId: Trade Barriers Notifications
   seriesUrl: https://tradebarriers.wto.org/
@@ -162,6 +219,7 @@
   domain: economic
   weight: 0.40
   direction: lower-better
+  scoringTier: core
   source: World Bank / WITS
   seriesId: TM.TAX.MRCH.WM.AR.ZS
   seriesUrl: https://data.worldbank.org/indicator/TM.TAX.MRCH.WM.AR.ZS
@@ -171,6 +229,70 @@
   mechanismTestRationale: Applied tariff rates measure cost of trade restriction on imports.
   constructStatus: observed-mechanism
 
+- indicator: shortTermExternalDebtPctGni
+  dimension: financialSystemExposure
+  domain: economic
+  weight: 0.35
+  direction: lower-better
+  scoringTier: enrichment
+  source: World Bank IDS
+  seriesId: DT.DOD.DSTC.IR.ZS × DT.DOD.DECT.GN.ZS
+  seriesUrl: https://data.worldbank.org/
+  coveragePct: 0.56
+  lastObservedYear: 2024
+  license: CC-BY-4.0
+  mechanismTestRationale: Short-term external debt as % of GNI measures rollover funding pressure against the IMF Article IV vulnerability threshold.
+  constructStatus: observed-mechanism
+  reviewNotes: Active financialSystemExposure Enrichment scorer input.
+
+- indicator: bisLbsXborderPctGdp
+  dimension: financialSystemExposure
+  domain: economic
+  weight: 0.30
+  direction: lower-better
+  scoringTier: enrichment
+  source: BIS Locational Banking Statistics
+  seriesId: By-parent cross-border claims as % GDP
+  seriesUrl: https://data.bis.org/topics/LBS
+  coveragePct: 0.90
+  lastObservedYear: 2024
+  license: Proprietary-with-fair-use
+  mechanismTestRationale: Cross-border banking claims as % GDP measure external financial-channel exposure; the scorer applies a U-shape penalty for isolation and over-exposure.
+  constructStatus: regional-only
+  reviewNotes: Active financialSystemExposure Enrichment scorer input from curated BIS reporters.
+
+- indicator: fatfListingStatus
+  dimension: financialSystemExposure
+  domain: economic
+  weight: 0.20
+  direction: higher-better
+  scoringTier: core
+  source: FATF
+  seriesId: AML/CFT listing status
+  seriesUrl: https://www.fatf-gafi.org/en/countries/black-and-grey-lists.html
+  coveragePct: 0.90
+  lastObservedYear: 2026
+  license: Open
+  mechanismTestRationale: FATF status measures direct financial-system access risk; compliant countries score above gray-list and black-list countries.
+  constructStatus: observed-mechanism
+  reviewNotes: Active financialSystemExposure Core scorer input.
+
+- indicator: financialCenterRedundancy
+  dimension: financialSystemExposure
+  domain: economic
+  weight: 0.15
+  direction: higher-better
+  scoringTier: enrichment
+  source: BIS Locational Banking Statistics
+  seriesId: Count of by-parent reporters with non-trivial claims
+  seriesUrl: https://data.bis.org/topics/LBS
+  coveragePct: 0.90
+  lastObservedYear: 2024
+  license: Proprietary-with-fair-use
+  mechanismTestRationale: Distinct cross-border counterparties measure redundancy in financial-center links and offset single-counterparty exposure.
+  constructStatus: regional-only
+  reviewNotes: Active financialSystemExposure Enrichment scorer input from curated BIS reporters.
+
 # INFRASTRUCTURE DOMAIN (weight 0.15) -------------------------------------
 
 - indicator: cyberThreats
@@ -178,6 +300,7 @@
   domain: infrastructure
   weight: 0.45
   direction: lower-better
+  scoringTier: core
   source: Cyber threat feeds (mixed Western-origin)
   seriesId: severity-weighted count (critical 3×, high 2×, medium 1×, low 0.5×)
   seriesUrl: Internal seed
@@ -193,6 +316,7 @@
   domain: infrastructure
   weight: 0.35
   direction: lower-better
+  scoringTier: core
   source: Cloudflare Radar + internal monitoring
   seriesId: Outage penalty (total 4×, major 2×, partial 1×)
   seriesUrl: https://radar.cloudflare.com/
@@ -207,6 +331,7 @@
   domain: infrastructure
   weight: 0.20
   direction: lower-better
+  scoringTier: core
   source: GPSJam
   seriesId: Hex penalty (high 3×, medium 1×)
   seriesUrl: https://gpsjam.org/
@@ -229,7 +354,55 @@
   license: CC-BY-4.0
   mechanismTestRationale: Logistics Performance Index measures functional capacity to move goods; directly shocks during supply-chain disruptions.
   constructStatus: observed-mechanism
-  reviewNotes: Goalpost anchors OECD-centric; PR 4 review.
+  reviewNotes: Legacy catalog alias only; active logisticsSupply parity is represented by roadsPavedLogistics, shippingStress, and transitDisruption.
+
+- indicator: roadsPavedLogistics
+  dimension: logisticsSupply
+  domain: infrastructure
+  weight: 0.50
+  direction: higher-better
+  scoringTier: core
+  source: World Bank Open Data
+  seriesId: IS.ROD.PAVE.ZS
+  seriesUrl: https://data.worldbank.org/indicator/IS.ROD.PAVE.ZS
+  coveragePct: 0.85
+  lastObservedYear: 2024
+  license: CC-BY-4.0
+  mechanismTestRationale: Paved-road share measures physical logistics capacity for moving goods during supply-chain disruption.
+  constructStatus: observed-mechanism
+  reviewNotes: Active logisticsSupply Core scorer input.
+
+- indicator: shippingStress
+  dimension: logisticsSupply
+  domain: infrastructure
+  weight: 0.25
+  direction: lower-better
+  scoringTier: core
+  source: Supply-chain monitor
+  seriesId: supply_chain:shipping_stress:v1
+  seriesUrl: Internal seed
+  coveragePct: 0.88
+  lastObservedYear: 2026
+  license: Open with attribution
+  mechanismTestRationale: Shipping stress measures current maritime logistics shock pressure.
+  constructStatus: observed-mechanism
+  reviewNotes: Active logisticsSupply Core scorer input.
+
+- indicator: transitDisruption
+  dimension: logisticsSupply
+  domain: infrastructure
+  weight: 0.25
+  direction: lower-better
+  scoringTier: core
+  source: Supply-chain monitor
+  seriesId: supply_chain:transit-summaries:v1
+  seriesUrl: Internal seed
+  coveragePct: 0.88
+  lastObservedYear: 2026
+  license: Open with attribution
+  mechanismTestRationale: Transit-corridor disruption measures near-term goods-movement friction through disruption percentage and incident counts.
+  constructStatus: observed-mechanism
+  reviewNotes: Active logisticsSupply Core scorer input.
 
 - indicator: infrastructureSubcomponents
   dimension: infrastructure
@@ -244,12 +417,62 @@
   license: Mixed
   mechanismTestRationale: Physical infrastructure quality is the baseline capacity for delivering services during normal and crisis periods.
   constructStatus: observed-mechanism
+  reviewNotes: Legacy catalog alias only; active infrastructure parity is represented by electricityAccess, roadsPavedInfra, infraOutages, and broadband.
+
+- indicator: electricityAccess
+  dimension: infrastructure
+  domain: infrastructure
+  weight: 0.30
+  direction: higher-better
+  scoringTier: core
+  source: World Bank Open Data
+  seriesId: EG.ELC.ACCS.ZS
+  seriesUrl: https://data.worldbank.org/indicator/EG.ELC.ACCS.ZS
+  coveragePct: 0.98
+  lastObservedYear: 2024
+  license: CC-BY-4.0
+  mechanismTestRationale: Electricity access measures baseline infrastructure reach for resilient public and commercial service delivery.
+  constructStatus: observed-mechanism
+  reviewNotes: Active infrastructure Core scorer input.
+
+- indicator: roadsPavedInfra
+  dimension: infrastructure
+  domain: infrastructure
+  weight: 0.30
+  direction: higher-better
+  scoringTier: core
+  source: World Bank Open Data
+  seriesId: IS.ROD.PAVE.ZS
+  seriesUrl: https://data.worldbank.org/indicator/IS.ROD.PAVE.ZS
+  coveragePct: 0.85
+  lastObservedYear: 2024
+  license: CC-BY-4.0
+  mechanismTestRationale: Paved-road share measures physical infrastructure quality for continuity of service delivery and goods movement.
+  constructStatus: observed-mechanism
+  reviewNotes: Active infrastructure Core scorer input.
+
+- indicator: infraOutages
+  dimension: infrastructure
+  domain: infrastructure
+  weight: 0.25
+  direction: lower-better
+  scoringTier: core
+  source: Cloudflare Radar + internal monitoring
+  seriesId: Outage penalty (total 4×, major 2×, partial 1×)
+  seriesUrl: https://radar.cloudflare.com/
+  coveragePct: 0.88
+  lastObservedYear: 2026
+  license: CC-BY-4.0
+  mechanismTestRationale: Infrastructure outage events measure service-availability stress under current operating conditions.
+  constructStatus: observed-mechanism
+  reviewNotes: Active infrastructure Core scorer input.
 
 - indicator: broadband
   dimension: infrastructure
   domain: infrastructure
   weight: 0.15
   direction: higher-better
+  scoringTier: core
   source: World Bank Open Data
   seriesId: IT.NET.BBND.P2
   seriesUrl: https://data.worldbank.org/indicator/IT.NET.BBND.P2
@@ -282,6 +505,7 @@
   domain: energy
   weight: 0.12
   direction: lower-better
+  scoringTier: experimental
   source: IEA World Energy Balances via static seed
   seriesId: Natural gas share of primary energy
   seriesUrl: https://www.iea.org/data-and-statistics/data-browser
@@ -297,6 +521,7 @@
   domain: energy
   weight: 0.08
   direction: lower-better
+  scoringTier: experimental
   source: IEA World Energy Balances via static seed
   seriesId: Coal share of primary energy
   seriesUrl: https://www.iea.org/data-and-statistics/data-browser
@@ -312,6 +537,7 @@
   domain: energy
   weight: 0.05
   direction: higher-better
+  scoringTier: experimental
   source: IEA / World Bank
   seriesId: EG.ELC.RNEW.ZS
   seriesUrl: https://data.worldbank.org/indicator/EG.ELC.RNEW.ZS
@@ -341,7 +567,8 @@
   dimension: energy
   domain: energy
   weight: 0.15
-  direction: composite
+  direction: lower-better
+  scoringTier: core
   source: Energy prices + fossil-electricity exposure composite
   seriesId: Derived
   seriesUrl: economic:energy:v1:all
@@ -357,6 +584,7 @@
   domain: energy
   weight: 0.30
   direction: higher-better
+  scoringTier: experimental
   source: World Bank
   seriesId: EG.USE.ELEC.KH.PC
   seriesUrl: https://data.worldbank.org/indicator/EG.USE.ELEC.KH.PC
@@ -372,6 +600,7 @@
   domain: energy
   weight: 0.35
   direction: lower-better
+  scoringTier: core
   source: World Bank + static net-import dependency seed
   seriesId: EG.ELC.FOSL.ZS × max(EG.IMP.CONS.ZS, 0) / 100
   seriesUrl: https://data.worldbank.org/indicator/EG.ELC.FOSL.ZS
@@ -387,6 +616,7 @@
   domain: energy
   weight: 0.20
   direction: higher-better
+  scoringTier: core
   source: World Bank
   seriesId: EG.ELC.NUCL.ZS + EG.ELC.RNEW.ZS + EG.ELC.HYRO.ZS
   seriesUrl: https://data.worldbank.org/indicator/EG.ELC.NUCL.ZS
@@ -402,6 +632,7 @@
   domain: energy
   weight: 0.20
   direction: lower-better
+  scoringTier: core
   source: World Bank
   seriesId: EG.ELC.LOSS.ZS
   seriesUrl: https://data.worldbank.org/indicator/EG.ELC.LOSS.ZS
@@ -417,6 +648,7 @@
   domain: energy
   weight: 0.10
   direction: lower-better
+  scoringTier: enrichment
   source: GIE AGSI+
   seriesId: EU gas storage fill % (per country)
   seriesUrl: https://agsi.gie.eu/
@@ -442,13 +674,110 @@
   license: CC-BY-4.0
   mechanismTestRationale: WGI subscores measure state capacity to design and enforce policy response to shocks. Passes the mechanism test conditionally — the composite is a direct policy-response-capacity signal.
   constructStatus: observed-mechanism
-  reviewNotes: Weights review in PR 4. Individual WGI subscores may need separate weighting vs equal-blend.
+  reviewNotes: Legacy catalog alias only; active governanceInstitutional parity is represented by the six WGI subscore rows below.
+
+- indicator: wgiVoiceAccountability
+  dimension: governanceInstitutional
+  domain: social-governance
+  weight: 0.16666666666666666
+  direction: higher-better
+  scoringTier: core
+  source: World Bank WGI
+  seriesId: Voice and Accountability
+  seriesUrl: https://info.worldbank.org/governance/wgi/
+  coveragePct: 0.96
+  lastObservedYear: 2023
+  license: Public-domain
+  mechanismTestRationale: Voice and Accountability measures civic accountability capacity that supports policy legitimacy during shocks.
+  constructStatus: observed-mechanism
+  reviewNotes: Active governanceInstitutional Core scorer input.
+
+- indicator: wgiPoliticalStability
+  dimension: governanceInstitutional
+  domain: social-governance
+  weight: 0.16666666666666666
+  direction: higher-better
+  scoringTier: core
+  source: World Bank WGI
+  seriesId: Political Stability and Absence of Violence
+  seriesUrl: https://info.worldbank.org/governance/wgi/
+  coveragePct: 0.96
+  lastObservedYear: 2023
+  license: Public-domain
+  mechanismTestRationale: Political Stability measures institutional continuity and absence-of-violence capacity under shock conditions.
+  constructStatus: observed-mechanism
+  reviewNotes: Active governanceInstitutional Core scorer input.
+
+- indicator: wgiGovernmentEffectiveness
+  dimension: governanceInstitutional
+  domain: social-governance
+  weight: 0.16666666666666666
+  direction: higher-better
+  scoringTier: core
+  source: World Bank WGI
+  seriesId: Government Effectiveness
+  seriesUrl: https://info.worldbank.org/governance/wgi/
+  coveragePct: 0.96
+  lastObservedYear: 2023
+  license: Public-domain
+  mechanismTestRationale: Government Effectiveness measures administrative capacity to deliver services and execute policy response.
+  constructStatus: observed-mechanism
+  reviewNotes: Active governanceInstitutional Core scorer input.
+
+- indicator: wgiRegulatoryQuality
+  dimension: governanceInstitutional
+  domain: social-governance
+  weight: 0.16666666666666666
+  direction: higher-better
+  scoringTier: core
+  source: World Bank WGI
+  seriesId: Regulatory Quality
+  seriesUrl: https://info.worldbank.org/governance/wgi/
+  coveragePct: 0.96
+  lastObservedYear: 2023
+  license: Public-domain
+  mechanismTestRationale: Regulatory Quality measures policy design capacity that supports resilient markets and public systems.
+  constructStatus: observed-mechanism
+  reviewNotes: Active governanceInstitutional Core scorer input.
+
+- indicator: wgiRuleOfLaw
+  dimension: governanceInstitutional
+  domain: social-governance
+  weight: 0.16666666666666666
+  direction: higher-better
+  scoringTier: core
+  source: World Bank WGI
+  seriesId: Rule of Law
+  seriesUrl: https://info.worldbank.org/governance/wgi/
+  coveragePct: 0.96
+  lastObservedYear: 2023
+  license: Public-domain
+  mechanismTestRationale: Rule of Law measures enforcement predictability and institutional trust during shocks.
+  constructStatus: observed-mechanism
+  reviewNotes: Active governanceInstitutional Core scorer input.
+
+- indicator: wgiControlOfCorruption
+  dimension: governanceInstitutional
+  domain: social-governance
+  weight: 0.16666666666666666
+  direction: higher-better
+  scoringTier: core
+  source: World Bank WGI
+  seriesId: Control of Corruption
+  seriesUrl: https://info.worldbank.org/governance/wgi/
+  coveragePct: 0.96
+  lastObservedYear: 2023
+  license: Public-domain
+  mechanismTestRationale: Control of Corruption measures leakage and capture risk in policy-response capacity.
+  constructStatus: observed-mechanism
+  reviewNotes: Active governanceInstitutional Core scorer input.
 
 - indicator: gpiScore
   dimension: socialCohesion
   domain: social-governance
-  weight: 0.40  # approximate
+  weight: 0.55
   direction: lower-better
+  scoringTier: enrichment
   source: Institute for Economics and Peace
   seriesId: Global Peace Index
   seriesUrl: https://www.visionofhumanity.org/
@@ -457,28 +786,30 @@
   license: Proprietary-with-fair-use
   mechanismTestRationale: GPI measures internal conflict, militarization, and external conflict intensity — direct social-cohesion-shock exposure.
   constructStatus: observed-mechanism
-  reviewNotes: Known Western-democracy bias in GPI methodology; PR 4 review.
+  reviewNotes: Active socialCohesion Enrichment scorer input; known Western-democracy bias in GPI methodology.
 
-- indicator: displacementMetric
+- indicator: displacementTotal
   dimension: socialCohesion
   domain: social-governance
-  weight: 0.30  # approximate
+  weight: 0.25
   direction: lower-better
+  scoringTier: core
   source: UNHCR
   seriesId: totalDisplaced
   seriesUrl: https://data.unhcr.org/
   coveragePct: 0.95
   lastObservedYear: 2025
   license: Open
-  mechanismTestRationale: Total displaced persons directly measures ongoing forced-migration pressure. BIAS: currently blends origin + host; penalizes Jordan/Turkey/Germany for HOSTING.
-  constructStatus: wealth-proxy  # classified as biased — bias label
-  reviewNotes: PR 4 §4.2 splits origin (negative signal) from host (mixed signal).
+  mechanismTestRationale: "Total displaced persons directly measures ongoing forced-migration pressure; the live scorer uses log10 absolute displaced-person counts."
+  constructStatus: observed-mechanism
+  reviewNotes: Active socialCohesion Core scorer input; not population-normalized and no longer documented as the retired displacementMetric alias.
 
-- indicator: unrestMetric
+- indicator: unrestEvents
   dimension: socialCohesion
   domain: social-governance
-  weight: 0.30  # approximate
+  weight: 0.20
   direction: lower-better
+  scoringTier: core
   source: Internal unrest seed (cross-source signals + UCDP)
   seriesId: unrestCount + sqrt(fatalities)
   seriesUrl: Internal seed
@@ -487,6 +818,7 @@
   license: Mixed
   mechanismTestRationale: Active unrest events measure current social-cohesion stress.
   constructStatus: observed-mechanism
+  reviewNotes: Active socialCohesion Core scorer input; event counts divide by max(populationMillions, 0.5) in the live scorer.
 
 - indicator: borderSecuritySubs
   dimension: borderSecurity
@@ -501,13 +833,46 @@
   license: Mixed
   mechanismTestRationale: Border-security composite captures cross-border shock transmission exposure.
   constructStatus: observed-mechanism
-  reviewNotes: Inherits displacement host-vs-sending bias from socialCohesion. PR 4 fix.
+  reviewNotes: Legacy catalog alias only; active borderSecurity parity is represented by ucdpConflict and displacementHosted.
+
+- indicator: ucdpConflict
+  dimension: borderSecurity
+  domain: social-governance
+  weight: 0.65
+  direction: lower-better
+  scoringTier: core
+  source: UCDP
+  seriesId: Armed conflict events / fatalities
+  seriesUrl: https://ucdp.uu.se/
+  coveragePct: 0.87
+  lastObservedYear: 2026
+  license: Research-only
+  mechanismTestRationale: UCDP conflict intensity measures armed-conflict event pressure and fatalities as a direct continuity shock.
+  constructStatus: observed-mechanism
+  reviewNotes: Active borderSecurity Core scorer input.
+
+- indicator: displacementHosted
+  dimension: borderSecurity
+  domain: social-governance
+  weight: 0.35
+  direction: lower-better
+  scoringTier: core
+  source: UNHCR
+  seriesId: hosted / total displaced persons
+  seriesUrl: https://data.unhcr.org/
+  coveragePct: 0.90
+  lastObservedYear: 2025
+  license: Open
+  mechanismTestRationale: Hosted displaced-person pressure measures refugee and forced-migration stress on state services and borders.
+  constructStatus: observed-mechanism
+  reviewNotes: Active borderSecurity Core scorer input.
 
 - indicator: rsfPressFreedom
   dimension: informationCognitive
   domain: social-governance
   weight: 0.55
   direction: lower-better
+  scoringTier: core
   source: Reporters Sans Frontieres
   seriesId: Press Freedom Index
   seriesUrl: https://rsf.org/en/index
@@ -530,6 +895,39 @@
   license: Mixed
   mechanismTestRationale: Language-normalized social-information velocity measures information-shock propagation speed adjusted for source-density bias.
   constructStatus: observed-mechanism
+  reviewNotes: Legacy catalog alias only; active informationCognitive parity is represented by rsfPressFreedom, socialVelocity, and newsThreatScore.
+
+- indicator: socialVelocity
+  dimension: informationCognitive
+  domain: social-governance
+  weight: 0.15
+  direction: lower-better
+  scoringTier: core
+  source: Reddit social monitor
+  seriesId: intelligence:social:reddit:v1
+  seriesUrl: Internal seed
+  coveragePct: 0.88
+  lastObservedYear: 2026
+  license: Open with attribution
+  mechanismTestRationale: Social velocity measures information-shock propagation speed after language-coverage weighting.
+  constructStatus: observed-mechanism
+  reviewNotes: Active informationCognitive Core scorer input.
+
+- indicator: newsThreatScore
+  dimension: informationCognitive
+  domain: social-governance
+  weight: 0.30
+  direction: lower-better
+  scoringTier: core
+  source: AI news threat summary
+  seriesId: news:threat:summary:v1
+  seriesUrl: Internal seed
+  coveragePct: 0.88
+  lastObservedYear: 2026
+  license: Open with attribution
+  mechanismTestRationale: Threat-weighted news intensity measures current information-environment stress.
+  constructStatus: observed-mechanism
+  reviewNotes: Active informationCognitive Core scorer input.
 
 # HEALTH-FOOD DOMAIN (weight 0.13) ---------------------------------------
 
@@ -538,6 +936,7 @@
   domain: health-food
   weight: 0.15
   direction: higher-better
+  scoringTier: core
   source: WHO Global Health Observatory
   seriesId: HWF_0001
   seriesUrl: https://www.who.int/data/gho
@@ -553,6 +952,7 @@
   domain: health-food
   weight: 0.15
   direction: higher-better
+  scoringTier: core
   source: WHO Global Health Observatory
   seriesId: GHED_CHE_pc_US_SHA2011
   seriesUrl: https://www.who.int/data/gho
@@ -563,11 +963,76 @@
   constructStatus: wealth-proxy
   reviewNotes: Active healthPublicService Core scorer input. PR 4 §4.9 tracks replacement with a direct surge-capacity signal; kept Core here because it is already in the public scorer and clears coverage-influence tiering.
 
+- indicator: uhcIndex
+  dimension: healthPublicService
+  domain: health-food
+  weight: 0.35
+  direction: higher-better
+  scoringTier: core
+  source: WHO Global Health Observatory
+  seriesId: Universal Health Coverage service coverage index
+  seriesUrl: https://www.who.int/data/gho
+  coveragePct: 0.87
+  lastObservedYear: 2022
+  license: WHO public-domain/open-data
+  mechanismTestRationale: Universal Health Coverage index measures baseline service coverage available before and during public-health shocks.
+  constructStatus: observed-mechanism
+  reviewNotes: Active healthPublicService Core scorer input.
+
+- indicator: measlesCoverage
+  dimension: healthPublicService
+  domain: health-food
+  weight: 0.25
+  direction: higher-better
+  scoringTier: core
+  source: WHO Global Health Observatory
+  seriesId: Measles immunization coverage among 1-year-olds
+  seriesUrl: https://www.who.int/data/gho
+  coveragePct: 0.87
+  lastObservedYear: 2022
+  license: WHO public-domain/open-data
+  mechanismTestRationale: Measles immunization coverage measures preventive-health reach and public-service delivery capacity.
+  constructStatus: observed-mechanism
+  reviewNotes: Active healthPublicService Core scorer input.
+
+- indicator: hospitalBeds
+  dimension: healthPublicService
+  domain: health-food
+  weight: 0.10
+  direction: higher-better
+  scoringTier: core
+  source: WHO Global Health Observatory
+  seriesId: Hospital beds per 1,000 people
+  seriesUrl: https://www.who.int/data/gho
+  coveragePct: 0.87
+  lastObservedYear: 2022
+  license: WHO public-domain/open-data
+  mechanismTestRationale: Hospital-bed density measures physical care capacity available for health-system surge response.
+  constructStatus: observed-mechanism
+  reviewNotes: Active healthPublicService Core scorer input.
+
+- indicator: ipcPeopleInCrisis
+  dimension: foodWater
+  domain: health-food
+  weight: 0.45
+  direction: lower-better
+  scoringTier: core
+  source: FAO IPC (Integrated Food Security Phase Classification)
+  seriesId: People in food crisis (log10 scale)
+  seriesUrl: https://www.ipcinfo.org/
+  coveragePct: 0.88
+  lastObservedYear: 2025
+  license: Open
+  mechanismTestRationale: People in crisis measures population-scale food-security pressure, with log scaling for extreme crises.
+  constructStatus: observed-mechanism
+  reviewNotes: Active foodWater Core scorer input.
+
 - indicator: ipcPhase
   dimension: foodWater
   domain: health-food
   weight: 0.15
   direction: lower-better
+  scoringTier: core
   source: FAO IPC (Integrated Food Security Phase Classification)
   seriesId: IPC Phase (1-5)
   seriesUrl: https://www.ipcinfo.org/
@@ -582,7 +1047,8 @@
   dimension: foodWater
   domain: health-food
   weight: 0.40
-  direction: indicator-semantics
+  direction: composite
+  scoringTier: core
   source: FAO AQUASTAT
   seriesId: Indicator-tagged water stress / withdrawal / dependency / availability / renewable / access reading
   seriesUrl: https://www.fao.org/aquastat/
@@ -599,6 +1065,7 @@
   domain: recovery
   weight: 0.25
   direction: higher-better
+  scoringTier: core
   source: IMF
   seriesId: GGR_G01_GDP_PT
   seriesUrl: https://www.imf.org/external/datamapper/GGR_G01_GDP_PT@FM/
@@ -614,6 +1081,7 @@
   domain: recovery
   weight: 0.20
   direction: higher-better
+  scoringTier: core
   source: IMF
   seriesId: GGXCNL_G01_GDP_PT
   seriesUrl: https://www.imf.org/external/datamapper/GGXCNL_G01_GDP_PT@FM/
@@ -629,6 +1097,7 @@
   domain: recovery
   weight: 0.20
   direction: lower-better
+  scoringTier: core
   source: IMF
   seriesId: GGXWDG_NGDP_PT
   seriesUrl: https://www.imf.org/external/datamapper/GGXWDG_NGDP_PT@FM/
@@ -644,6 +1113,7 @@
   domain: recovery
   weight: 0.35
   direction: higher-better
+  scoringTier: enrichment
   source: IMF (5 series composite — see formula in country-resilience-index.mdx §Fiscal Space)
   seriesId: GGXONLB_NGDP × GGXCNL_NGDP × GGXWDG_NGDP × NGDP_RPCH × PCPIPCH
   seriesUrl: https://www.imf.org/external/datamapper/datasets/WEO
@@ -673,6 +1143,7 @@
   domain: recovery
   weight: 1.00
   direction: higher-better
+  scoringTier: experimental
   source: World Bank
   seriesId: FI.RES.TOTL.MO
   seriesUrl: https://data.worldbank.org/indicator/FI.RES.TOTL.MO
@@ -681,13 +1152,30 @@
   license: CC-BY-4.0
   mechanismTestRationale: Central-bank reserves in months of imports — immediate external-liquidity cushion.
   constructStatus: observed-mechanism
-  reviewNotes: PR 2 §3.4 renames to liquidReserveAdequacy; new dimension sovereignFiscalBuffer added.
+  reviewNotes: Experimental rollback row only; active recovery parity moved to recoveryLiquidReserveMonths under liquidReserveAdequacy.
+
+- indicator: recoveryLiquidReserveMonths
+  dimension: liquidReserveAdequacy
+  domain: recovery
+  weight: 1.00
+  direction: higher-better
+  scoringTier: core
+  source: World Bank
+  seriesId: FI.RES.TOTL.MO
+  seriesUrl: https://data.worldbank.org/indicator/FI.RES.TOTL.MO
+  coveragePct: 0.85
+  lastObservedYear: 2023
+  license: CC-BY-4.0
+  mechanismTestRationale: Central-bank reserves in months of imports measure immediate external-liquidity cushion; sovereign-wealth assets score separately.
+  constructStatus: observed-mechanism
+  reviewNotes: Active liquidReserveAdequacy Core scorer input replacing the reserveAdequacy rollback dimension.
 
 - indicator: recoveryDebtToReserves
   dimension: externalDebtCoverage
   domain: recovery
   weight: 1.00
   direction: lower-better
+  scoringTier: core
   source: World Bank
   seriesId: DT.DOD.DSTC.CD / FI.RES.TOTL.CD
   seriesUrl: https://data.worldbank.org/indicator/DT.DOD.DSTC.CD
@@ -703,6 +1191,7 @@
   domain: recovery
   weight: 1.00
   direction: lower-better
+  scoringTier: core
   source: UN Comtrade
   seriesId: HS2 bilateral Herfindahl-Hirschman Index
   seriesUrl: https://comtrade.un.org/
@@ -718,6 +1207,7 @@
   domain: recovery
   weight: 0.50
   direction: higher-better
+  scoringTier: core
   source: World Bank WGI
   seriesId: Mean of WGI subscores
   seriesUrl: https://info.worldbank.org/governance/wgi/
@@ -733,6 +1223,7 @@
   domain: recovery
   weight: 0.30
   direction: lower-better
+  scoringTier: core
   source: UCDP
   seriesId: Armed conflict events / fatalities
   seriesUrl: https://ucdp.uu.se/
@@ -747,6 +1238,7 @@
   domain: recovery
   weight: 0.20
   direction: lower-better
+  scoringTier: core
   source: UNHCR
   seriesId: Displacement as share of population
   seriesUrl: https://data.unhcr.org/
@@ -762,6 +1254,7 @@
   domain: recovery
   weight: 1.00
   direction: higher-better
+  scoringTier: experimental
   source: IEA / EIA
   seriesId: Days of fuel stock cover
   seriesUrl: https://www.iea.org/data-and-statistics/data-tools/oil-stocks-of-iea-countries

--- a/tests/resilience-doc-parity.test.mts
+++ b/tests/resilience-doc-parity.test.mts
@@ -27,6 +27,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { describe, it } from 'node:test';
+import { parse as parseYaml } from 'yaml';
 
 import {
   RESILIENCE_SCORE_CACHE_PREFIX,
@@ -171,6 +172,15 @@ interface MethodologyIndicatorTextRow {
   direction: string;
   goalposts: string;
   weight: string;
+}
+
+interface IndicatorSourceCatalogRow {
+  indicator: string;
+  dimension: string;
+  weight: number | string;
+  direction: string;
+  scoringTier?: string;
+  reviewNotes?: string;
 }
 
 describe('methodology doc parity (Plan 2026-04-26-002 §U8)', () => {
@@ -801,6 +811,73 @@ describe('methodology doc parity (Plan 2026-04-26-002 §U8)', () => {
       /PR 1 additions \(not yet in the scorer\)/,
       'indicator source catalog must not describe active energy-v2 inputs as pending/not yet in the scorer.',
     );
+  });
+
+  it('indicator source catalog mirrors every active registry-backed indicator row', () => {
+    const catalogRows = parseYaml(indicatorSourceCatalogText) as IndicatorSourceCatalogRow[];
+    assert.ok(Array.isArray(catalogRows), 'indicator-sources.yaml must parse to a YAML sequence.');
+
+    const catalogById = new Map<string, IndicatorSourceCatalogRow>();
+    for (const row of catalogRows) {
+      assert.ok(row.indicator, 'each indicator-sources.yaml row must declare indicator.');
+      assert.equal(
+        catalogById.has(row.indicator),
+        false,
+        `indicator-sources.yaml must not duplicate registry/catalog row "${row.indicator}".`,
+      );
+      catalogById.set(row.indicator, row);
+    }
+
+    for (const registrySpec of INDICATOR_REGISTRY) {
+      const catalogRow = catalogById.get(registrySpec.id);
+      if (catalogRow?.scoringTier != null) {
+        assert.equal(
+          catalogRow.scoringTier,
+          registrySpec.tier,
+          `${registrySpec.id} scoringTier must mirror INDICATOR_REGISTRY.`,
+        );
+      }
+
+      if (registrySpec.tier === 'experimental') {
+        if (catalogRow == null) continue;
+        assert.equal(
+          catalogRow.scoringTier,
+          'experimental',
+          `${registrySpec.id} experimental registry row must be excluded from active catalog parity.`,
+        );
+        assert.match(
+          catalogRow.reviewNotes ?? '',
+          /experimental|rollback|legacy|removes|replaces|replaced|retires|collapses|no longer reads/i,
+          `${registrySpec.id} experimental catalog row must explain why it is not an active scorer input.`,
+        );
+        continue;
+      }
+
+      assert.ok(
+        catalogRow,
+        `${registrySpec.id} is ${registrySpec.tier} in INDICATOR_REGISTRY and must have an active indicator-sources.yaml row.`,
+      );
+      assert.equal(
+        catalogRow.dimension,
+        registrySpec.dimension,
+        `${registrySpec.id} source-catalog dimension must mirror INDICATOR_REGISTRY.`,
+      );
+      assert.equal(
+        Number(catalogRow.weight),
+        registrySpec.weight,
+        `${registrySpec.id} source-catalog weight must mirror INDICATOR_REGISTRY.`,
+      );
+      assert.equal(
+        catalogRow.direction,
+        indicatorSourceDirection(registrySpec.direction),
+        `${registrySpec.id} source-catalog direction must mirror INDICATOR_REGISTRY.`,
+      );
+      assert.equal(
+        catalogRow.scoringTier,
+        registrySpec.tier,
+        `${registrySpec.id} active source-catalog row must declare the live registry scoringTier.`,
+      );
+    }
   });
 
   it('indicator source catalog covers newly registered static scorer inputs', () => {

--- a/tests/resilience-doc-parity.test.mts
+++ b/tests/resilience-doc-parity.test.mts
@@ -827,16 +827,18 @@ describe('methodology doc parity (Plan 2026-04-26-002 §U8)', () => {
       );
       catalogById.set(row.indicator, row);
     }
+    const registryById = new Map(INDICATOR_REGISTRY.map((spec) => [spec.id, spec]));
+
+    for (const [id, catalogRow] of catalogById) {
+      if (catalogRow.scoringTier !== 'core' && catalogRow.scoringTier !== 'enrichment') continue;
+      assert.ok(
+        registryById.has(id),
+        `${id} is marked scoringTier=${catalogRow.scoringTier} in indicator-sources.yaml and must exist in INDICATOR_REGISTRY.`,
+      );
+    }
 
     for (const registrySpec of INDICATOR_REGISTRY) {
       const catalogRow = catalogById.get(registrySpec.id);
-      if (catalogRow?.scoringTier != null) {
-        assert.equal(
-          catalogRow.scoringTier,
-          registrySpec.tier,
-          `${registrySpec.id} scoringTier must mirror INDICATOR_REGISTRY.`,
-        );
-      }
 
       if (registrySpec.tier === 'experimental') {
         if (catalogRow == null) continue;


### PR DESCRIPTION
## Summary
- align docs/methodology/indicator-sources.yaml with the live resilience indicator registry
- add scoringTier metadata for registry-backed catalog rows
- add a YAML parser-based parity test covering every non-experimental registry row

## Validation
- npx tsx --test tests/resilience-doc-parity.test.mts tests/resilience-indicator-registry.test.mts
- git diff --check
- git push pre-push hook passed: typecheck, API typecheck, boundary/safe-html/rate-limit/premium-fetch checks, edge bundle check, resilience suites, and version sync

## Notes
- Experimental catalog rows are retained only when marked experimental and documented as rollback, legacy, replaced, retired, or no longer read by active scoring.