### PR TITLE
fix(resilience): update indicator source footer

### DIFF
--- a/docs/methodology/indicator-sources.yaml
+++ b/docs/methodology/indicator-sources.yaml
@@ -1265,14 +1265,14 @@
   constructStatus: imputed-floor
   reviewNotes: PR 3 §3.5 retires from core score (permanent). Enrichment-only if IEA/EIA connector ever wires.
 
-# DEFERRED ADDITIONS FOR PR 1+ --------------------------------------------
+# FOOTER STATUS NOTES ------------------------------------------------------
 
-# PR 1 deferred addition:
+# Deferred additions:
 # - reserveMarginPct → IEA electricity balance (generation reserve margin, higher-better)
 
-# PR 2 additions (not yet in the scorer):
-# - liquidReserveAdequacy  → FI.RES.TOTL.MO (rename of current reserveMonths)
+# Landed active dimensions:
+# - liquidReserveAdequacy  → FI.RES.TOTL.MO (active replacement for reserveAdequacy)
 # - sovereignFiscalBuffer  → IFSWF + official disclosures × access × liquidity × transparency
 
-# PR 3 replacements (not yet in the scorer):
+# Future replacement candidate (not yet in the scorer):
 # - realInterestRate       → FR.INR.RINR (replaces currencyExternal for non-BIS countries)

--- a/tests/resilience-doc-parity.test.mts
+++ b/tests/resilience-doc-parity.test.mts
@@ -882,6 +882,26 @@ describe('methodology doc parity (Plan 2026-04-26-002 §U8)', () => {
     }
   });
 
+  it('indicator source catalog does not list active scorer dimensions as deferred', () => {
+    const activeDimensionIds = new Set(
+      RESILIENCE_DIMENSION_ORDER.filter((id) => !RESILIENCE_RETIRED_DIMENSIONS.has(id)),
+    );
+    const deferredScorerDimensionIds = [
+      ...indicatorSourceCatalogText.matchAll(/#[^\n]*not yet in the scorer[^\n]*(?:\n# -[^\n]*)*/gi),
+      ...indicatorSourceCatalogText.matchAll(/#[^\n]*\bdeferred\b[^\n]*(?:\n# -[^\n]*)*/gi),
+    ].flatMap((match) =>
+      [...match[0].matchAll(/^# -\s*([A-Za-z][A-Za-z0-9]*)\b/gm)].map((bulletMatch) => bulletMatch[1])
+    );
+
+    for (const dimensionId of deferredScorerDimensionIds) {
+      assert.equal(
+        activeDimensionIds.has(dimensionId as ResilienceDimensionId),
+        false,
+        `indicator-sources.yaml must not describe active dimension "${dimensionId}" as not yet in the scorer.`,
+      );
+    }
+  });
+
   it('indicator source catalog covers newly registered static scorer inputs', () => {
     for (const id of STATIC_SCORER_CATALOG_PARITY_IDS) {
       const block = extractIndicatorSourceBlock(indicatorSourceCatalogText, id);

--- a/tests/resilience-doc-parity.test.mts
+++ b/tests/resilience-doc-parity.test.mts
@@ -886,18 +886,32 @@ describe('methodology doc parity (Plan 2026-04-26-002 §U8)', () => {
     const activeDimensionIds = new Set(
       RESILIENCE_DIMENSION_ORDER.filter((id) => !RESILIENCE_RETIRED_DIMENSIONS.has(id)),
     );
-    const deferredScorerDimensionIds = [
-      ...indicatorSourceCatalogText.matchAll(/#[^\n]*not yet in the scorer[^\n]*(?:\n# -[^\n]*)*/gi),
-      ...indicatorSourceCatalogText.matchAll(/#[^\n]*\bdeferred\b[^\n]*(?:\n# -[^\n]*)*/gi),
-    ].flatMap((match) =>
-      [...match[0].matchAll(/^# -\s*([A-Za-z][A-Za-z0-9]*)\b/gm)].map((bulletMatch) => bulletMatch[1])
+    const extractFooterBulletIds = (patterns: RegExp[]) => patterns.flatMap((pattern) =>
+      [...indicatorSourceCatalogText.matchAll(pattern)].flatMap((match) =>
+        [...match[0].matchAll(/^# -\s*([A-Za-z][A-Za-z0-9]*)\b/gm)].map((bulletMatch) => bulletMatch[1])
+      )
     );
+    const deferredScorerDimensionIds = extractFooterBulletIds([
+      /#[^\n]*not yet in the scorer[^\n]*(?:\n# -[^\n]*)*/gi,
+      /#[^\n]*\bdeferred\b[^\n]*(?:\n# -[^\n]*)*/gi,
+    ]);
+    const landedActiveDimensionIds = extractFooterBulletIds([
+      /#[^\n]*landed active dimensions[^\n]*(?:\n# -[^\n]*)*/gi,
+    ]);
 
     for (const dimensionId of deferredScorerDimensionIds) {
       assert.equal(
         activeDimensionIds.has(dimensionId as ResilienceDimensionId),
         false,
         `indicator-sources.yaml must not describe active dimension "${dimensionId}" as not yet in the scorer.`,
+      );
+    }
+
+    for (const dimensionId of landedActiveDimensionIds) {
+      assert.equal(
+        activeDimensionIds.has(dimensionId as ResilienceDimensionId),
+        true,
+        `indicator-sources.yaml must not describe inactive dimension "${dimensionId}" as landed active.`,
       );
     }
   });


### PR DESCRIPTION
## Summary
- replace the stale Country Resilience indicator-source footer with current-state status notes
- keep reserveMarginPct and realInterestRate as deferred/future items while marking liquidReserveAdequacy and sovereignFiscalBuffer as landed active dimensions
- add a parity guard so active scorer dimensions cannot be listed as deferred/not-yet-scored bullets

## Validation
- npm ci
- npx tsx --test tests/resilience-doc-parity.test.mts tests/resilience-methodology-lint.test.mts
- npx biome lint tests/resilience-doc-parity.test.mts
- git diff --check
- pre-push hook passed: npm run typecheck, npm run typecheck:api, lint guardrails, resilience tests (976/976), version check

## Note
- Direct markdownlint on docs/methodology/indicator-sources.yaml still reports existing YAML-comment parsing errors because markdownlint treats YAML # comments as Markdown headings/lists.