### PR TITLE
Fix resilience map greyed-out score semantics

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -4543,8 +4543,13 @@ export class DeckGLMap {
         const levelColor = `rgb(${red}, ${green}, ${blue})`;
         const visualBand = formatResilienceChoroplethLevel(resilienceEntry.level);
         const serverLevel = formatResilienceServerLevel(resilienceEntry.serverLevel);
+        const confidenceNote = resilienceEntry.lowConfidence
+          ? '<br/><span style="opacity:.7">Low confidence</span>'
+          : resilienceEntry.outsideHeadlineRanking
+            ? '<br/><span style="opacity:.7">Outside headline ranking</span>'
+            : '';
         return {
-          html: `<div class="deckgl-tooltip"><strong>${text(resilienceName)}</strong><br/>Resilience: <span style="color:${levelColor};font-weight:600">${resilienceEntry.overallScore.toFixed(1)}/100</span><br/><span style="text-transform:capitalize;opacity:.7">Visual band: ${text(visualBand)}</span><br/><span style="text-transform:capitalize;opacity:.7">API level: ${text(serverLevel)}</span>${resilienceEntry.lowConfidence ? '<br/><span style="opacity:.7">Low confidence</span>' : ''}</div>`,
+          html: `<div class="deckgl-tooltip"><strong>${text(resilienceName)}</strong><br/>Resilience: <span style="color:${levelColor};font-weight:600">${resilienceEntry.overallScore.toFixed(1)}/100</span><br/><span style="text-transform:capitalize;opacity:.7">Visual band: ${text(visualBand)}</span><br/><span style="text-transform:capitalize;opacity:.7">API level: ${text(serverLevel)}</span>${confidenceNote}</div>`,
         };
       }
       case 'species-recovery-layer': {

--- a/src/components/resilience-choropleth-utils.ts
+++ b/src/components/resilience-choropleth-utils.ts
@@ -1,6 +1,6 @@
 import type { ResilienceRankingItem } from '@/services/resilience';
 import type { MapLayers } from '@/types';
-import { getResilienceVisualLevel } from './resilience-widget-utils';
+import { getResilienceVisualLevel, hasScoredResilienceOverall } from './resilience-widget-utils';
 
 export type ResilienceChoroplethLevel = 'very_low' | 'low' | 'moderate' | 'high' | 'very_high' | 'insufficient_data';
 
@@ -9,6 +9,7 @@ export interface ResilienceChoroplethEntry {
   level: ResilienceChoroplethLevel;
   serverLevel: string;
   lowConfidence: boolean;
+  outsideHeadlineRanking: boolean;
 }
 
 export const RESILIENCE_CHOROPLETH_COLORS: Record<ResilienceChoroplethLevel, [number, number, number, number]> = {
@@ -20,8 +21,46 @@ export const RESILIENCE_CHOROPLETH_COLORS: Record<ResilienceChoroplethLevel, [nu
   insufficient_data: [120, 120, 120, 60],
 };
 
+const INSUFFICIENT_SERVER_LEVELS = new Set(['insufficient', 'insufficient_data', 'insufficient data', 'insufficient-data']);
+
 function clampScore(score: number): number {
   return Math.max(0, Math.min(100, Number(score.toFixed(1))));
+}
+
+function normalizeServerLevel(level: string | null | undefined): string {
+  return String(level || 'unknown').trim().toLowerCase();
+}
+
+function hasScoredResilienceRankingItem(item: ResilienceRankingItem): boolean {
+  const overallScore = Number(item.overallScore);
+  if (!hasScoredResilienceOverall({ overallScore, level: item.level })) return false;
+
+  const serverLevel = normalizeServerLevel(item.level);
+  return overallScore !== 0 || !INSUFFICIENT_SERVER_LEVELS.has(serverLevel);
+}
+
+function toResilienceChoroplethEntry(item: ResilienceRankingItem): [string, ResilienceChoroplethEntry] | null {
+  const countryCode = String(item.countryCode || '').trim().toUpperCase();
+  if (!/^[A-Z]{2}$/.test(countryCode)) return null;
+
+  if (!hasScoredResilienceRankingItem(item)) {
+    return [countryCode, {
+      overallScore: 0,
+      level: 'insufficient_data',
+      serverLevel: normalizeServerLevel(item.level),
+      lowConfidence: true,
+      outsideHeadlineRanking: false,
+    }];
+  }
+
+  const normalizedScore = clampScore(Number(item.overallScore));
+  return [countryCode, {
+    overallScore: normalizedScore,
+    level: getResilienceChoroplethLevel(normalizedScore),
+    serverLevel: normalizeServerLevel(item.level),
+    lowConfidence: Boolean(item.lowConfidence),
+    outsideHeadlineRanking: item.headlineEligible === false,
+  }];
 }
 
 export function getResilienceChoroplethLevel(score: number): ResilienceChoroplethLevel {
@@ -40,28 +79,13 @@ export function buildResilienceChoroplethMap(
   const scores = new Map<string, ResilienceChoroplethEntry>();
 
   for (const item of items) {
-    const countryCode = String(item.countryCode || '').trim().toUpperCase();
-    const overallScore = Number(item.overallScore);
-    if (!/^[A-Z]{2}$/.test(countryCode) || !Number.isFinite(overallScore) || overallScore < 0) continue;
-
-    const normalizedScore = clampScore(overallScore);
-    scores.set(countryCode, {
-      overallScore: normalizedScore,
-      level: getResilienceChoroplethLevel(normalizedScore),
-      serverLevel: String(item.level || 'unknown'),
-      lowConfidence: Boolean(item.lowConfidence),
-    });
+    const entry = toResilienceChoroplethEntry(item);
+    if (entry) scores.set(entry[0], entry[1]);
   }
 
   for (const item of greyedOut) {
-    const countryCode = String(item.countryCode || '').trim().toUpperCase();
-    if (!/^[A-Z]{2}$/.test(countryCode)) continue;
-    scores.set(countryCode, {
-      overallScore: 0,
-      level: 'insufficient_data',
-      serverLevel: 'insufficient_data',
-      lowConfidence: true,
-    });
+    const entry = toResilienceChoroplethEntry(item);
+    if (entry) scores.set(entry[0], entry[1]);
   }
 
   return scores;

--- a/tests/resilience-map-layer.test.mts
+++ b/tests/resilience-map-layer.test.mts
@@ -49,7 +49,7 @@ describe('resilience choropleth thresholds', () => {
     const scores = buildResilienceChoroplethMap([
       { countryCode: 'NO', overallScore: 82, level: 'high', lowConfidence: false },
       { countryCode: 'US', overallScore: 61.234, level: 'medium', lowConfidence: true },
-      { countryCode: 'YE', overallScore: -1, level: 'unknown', lowConfidence: true },
+      { countryCode: 'YEM', overallScore: -1, level: 'unknown', lowConfidence: true },
     ]);
 
     assert.equal(scores.size, 2);
@@ -58,14 +58,98 @@ describe('resilience choropleth thresholds', () => {
       level: 'very_high',
       serverLevel: 'high',
       lowConfidence: false,
+      outsideHeadlineRanking: false,
     });
     assert.deepEqual(scores.get('US'), {
       overallScore: 61.2,
       level: 'high',
       serverLevel: 'medium',
       lowConfidence: true,
+      outsideHeadlineRanking: false,
     });
-    assert.equal(scores.has('YE'), false);
+    assert.equal(scores.has('YEM'), false);
+  });
+
+  it('preserves scored greyedOut countries that are outside the headline ranking', () => {
+    const scores = buildResilienceChoroplethMap([], [
+      {
+        countryCode: 'TV',
+        overallScore: 70,
+        level: 'medium',
+        lowConfidence: false,
+        overallCoverage: 0.7,
+        rankStable: false,
+        headlineEligible: false,
+      },
+    ]);
+
+    assert.deepEqual(scores.get('TV'), {
+      overallScore: 70,
+      level: 'high',
+      serverLevel: 'medium',
+      lowConfidence: false,
+      outsideHeadlineRanking: true,
+    });
+  });
+
+  it('renders true greyedOut no-score sentinels as insufficient data', () => {
+    const scores = buildResilienceChoroplethMap([], [
+      {
+        countryCode: 'AQ',
+        overallScore: 0,
+        level: 'insufficient',
+        lowConfidence: true,
+        overallCoverage: 0,
+        rankStable: false,
+        headlineEligible: false,
+      },
+    ]);
+
+    assert.deepEqual(scores.get('AQ'), {
+      overallScore: 0,
+      level: 'insufficient_data',
+      serverLevel: 'insufficient',
+      lowConfidence: true,
+      outsideHeadlineRanking: false,
+    });
+  });
+
+  it('renders true items no-score sentinels as insufficient data', () => {
+    const scores = buildResilienceChoroplethMap([
+      {
+        countryCode: 'ZZ',
+        overallScore: 0,
+        level: 'unknown',
+        lowConfidence: false,
+        overallCoverage: 0,
+        rankStable: false,
+        headlineEligible: true,
+      },
+      {
+        countryCode: 'YE',
+        overallScore: -1,
+        level: 'medium',
+        lowConfidence: true,
+        overallCoverage: 0.4,
+        rankStable: false,
+        headlineEligible: false,
+      },
+    ]);
+
+    assert.deepEqual(scores.get('ZZ'), {
+      overallScore: 0,
+      level: 'insufficient_data',
+      serverLevel: 'unknown',
+      lowConfidence: true,
+      outsideHeadlineRanking: false,
+    });
+    assert.deepEqual(scores.get('YE'), {
+      overallScore: 0,
+      level: 'insufficient_data',
+      serverLevel: 'medium',
+      lowConfidence: true,
+      outsideHeadlineRanking: false,
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- Preserve valid Country Resilience scores and server levels for scored `greyedOut[]` ranking entries.
- Carry `outsideHeadlineRanking` into choropleth entries and show that label in the DeckGL tooltip when appropriate.
- Normalize true no-score sentinels from both `items[]` and `greyedOut[]` to `insufficient_data`.

## Root Cause

The resilience map treated every `greyedOut[]` item as insufficient data, even though the ranking contract also uses `greyedOut[]` for scored countries outside the headline ranking.

## Validation

- `env npm_config_cache=/private/tmp/worldmonitor-r7-1-npm-cache npx tsx --test tests/resilience-map-layer.test.mts`
- `env npm_config_cache=/private/tmp/worldmonitor-r7-1-npm-cache npm run typecheck`
- `git diff --check`
- Pre-push hook passed: typecheck, API typecheck, Convex type check, CJS syntax, Unicode safety, boundary lint, safe HTML, rate-limit policy, premium-fetch parity, edge bundle check, resilience test batch, edge function tests, version sync.
