### PR TITLE
Fix liquid reserve freshness tracking

### DIFF
--- a/server/worldmonitor/resilience/v1/_dimension-freshness.ts
+++ b/server/worldmonitor/resilience/v1/_dimension-freshness.ts
@@ -20,10 +20,12 @@
 
 import {
   classifyStaleness,
+  type ResilienceCadence,
   type StalenessLevel,
 } from '../../../_shared/resilience-freshness';
 import type { ResilienceDimensionId } from './_dimension-scorers';
 import { INDICATOR_REGISTRY, getIndicatorSourceKeys } from './_indicator-registry';
+import { STANDALONE_SOURCE_META_MAX_STALE_MIN } from './_standalone-source-thresholds';
 
 export interface DimensionFreshnessResult {
   /** Oldest (min) `fetchedAt` across the dimension's indicators. 0 when nothing ever observed. */
@@ -147,6 +149,33 @@ const STALENESS_ORDER: Record<StalenessLevel, number> = {
   stale: 2,
 };
 
+const MINUTE_MS = 60 * 1000;
+
+function classifySourceKeyFreshness(
+  sourceKey: string,
+  lastObservedAtMs: number | null,
+  cadence: ResilienceCadence,
+  nowMs: number,
+): StalenessLevel {
+  const result = classifyStaleness({
+    lastObservedAtMs,
+    cadence,
+    nowMs,
+  });
+
+  const maxStaleMin = STANDALONE_SOURCE_META_MAX_STALE_MIN[resolveSeedMetaKey(sourceKey)];
+  if (
+    typeof maxStaleMin === 'number'
+    && lastObservedAtMs != null
+    && Number.isFinite(lastObservedAtMs)
+    && nowMs - lastObservedAtMs > maxStaleMin * MINUTE_MS
+  ) {
+    return 'stale';
+  }
+
+  return result.staleness;
+}
+
 /**
  * Aggregate freshness across all indicators in a dimension.
  *
@@ -175,17 +204,19 @@ export function classifyDimensionFreshness(
 
   let oldestMs = Number.POSITIVE_INFINITY;
   let worstStaleness: StalenessLevel = 'fresh';
+  const effectiveNowMs = nowMs ?? Date.now();
 
   for (const indicator of indicators) {
     for (const sourceKey of getIndicatorSourceKeys(indicator)) {
       const lastObservedAtMs = freshnessMap.get(sourceKey) ?? null;
-      const result = classifyStaleness({
+      const staleness = classifySourceKeyFreshness(
+        sourceKey,
         lastObservedAtMs,
-        cadence: indicator.cadence,
-        nowMs,
-      });
-      if (STALENESS_ORDER[result.staleness] > STALENESS_ORDER[worstStaleness]) {
-        worstStaleness = result.staleness;
+        indicator.cadence,
+        effectiveNowMs,
+      );
+      if (STALENESS_ORDER[staleness] > STALENESS_ORDER[worstStaleness]) {
+        worstStaleness = staleness;
       }
       if (lastObservedAtMs != null && Number.isFinite(lastObservedAtMs) && lastObservedAtMs < oldestMs) {
         oldestMs = lastObservedAtMs;

--- a/server/worldmonitor/resilience/v1/_indicator-registry.ts
+++ b/server/worldmonitor/resilience/v1/_indicator-registry.ts
@@ -1198,6 +1198,10 @@ export const INDICATOR_REGISTRY: IndicatorSpec[] = [
     goalposts: { worst: 1, best: 12 },
     weight: 1.0,
     sourceKey: 'resilience:recovery:reserve-adequacy:v1',
+    sourceKeys: [
+      'resilience:recovery:reserve-adequacy:v1',
+      'resilience:recovery:reexport-share:v1',
+    ],
     scope: 'global',
     cadence: 'annual',
     tier: 'core',

--- a/server/worldmonitor/resilience/v1/_source-failure.ts
+++ b/server/worldmonitor/resilience/v1/_source-failure.ts
@@ -10,6 +10,8 @@
 import type { ResilienceDimensionId, ResilienceSeedReader } from './_dimension-scorers';
 import { resolveSeedMetaKey } from './_dimension-freshness';
 import { INDICATOR_REGISTRY, getIndicatorSourceKeys, type IndicatorSpec } from './_indicator-registry';
+import { STANDALONE_SOURCE_META_MAX_STALE_MIN } from './_standalone-source-thresholds';
+export { STANDALONE_SOURCE_META_MAX_STALE_MIN } from './_standalone-source-thresholds';
 
 // Must match RESILIENCE_STATIC_META_KEY in scripts/seed-resilience-static.mjs.
 export const RESILIENCE_STATIC_META_KEY = 'seed-meta:resilience:static';
@@ -106,47 +108,6 @@ const IGNORED_STANDALONE_SOURCE_META_KEYS = new Set([
   // source-failure logs while the dimension is intentionally inactive.
   'seed-meta:resilience:recovery:fuel-stocks',
 ]);
-
-// Resolved `seed-meta:*` thresholds for standalone CRI inputs. Most values
-// mirror api/health.js SEED_META; a few direct scorer inputs are not health
-// probes yet and are explicitly locked in tests. This intentionally uses
-// seeder health cadence, not INDICATOR_REGISTRY source-data cadence: an annual
-// source can still have a monthly/daily seeder whose missed runs should
-// surface as source-failure.
-export const STANDALONE_SOURCE_META_MAX_STALE_MIN: Readonly<Record<string, number>> = {
-  'seed-meta:economic:imf-macro': 100800,
-  'seed-meta:economic:national-debt': 86400,
-  'seed-meta:economic:imf-labor': 100800,
-  'seed-meta:economic:bis': 10080,
-  'seed-meta:economic:bis-dsr': 2160,
-  'seed-meta:trade:restrictions:v1:tariff-overview:50': 480,
-  'seed-meta:trade:barriers:v1:tariff-gap:50': 480,
-  'seed-meta:economic:wb-external-debt': 100800,
-  'seed-meta:economic:bis-lbs': 14400,
-  'seed-meta:economic:fatf-listing': 60480,
-  'seed-meta:cyber:threats': 240,
-  'seed-meta:infra:outages': 30,
-  'seed-meta:intelligence:gpsjam': 1440,
-  'seed-meta:supply_chain:shipping_stress': 45,
-  'seed-meta:supply_chain:transit-summaries': 30,
-  'seed-meta:economic:owid-energy-mix': 50400,
-  'seed-meta:energy:gas-storage-countries': 2880,
-  'seed-meta:economic:energy-prices': 150,
-  'seed-meta:resilience:fossil-electricity-share': 11520,
-  'seed-meta:resilience:low-carbon-generation': 11520,
-  'seed-meta:resilience:power-losses': 11520,
-  'seed-meta:displacement:summary': 720,
-  'seed-meta:unrest:events': 120,
-  'seed-meta:conflict:ucdp-events': 420,
-  'seed-meta:intelligence:social-reddit': 180,
-  'seed-meta:news:threat-summary': 60,
-  'seed-meta:resilience:recovery:fiscal-space': 129600,
-  'seed-meta:resilience:recovery:reserve-adequacy': 86400,
-  'seed-meta:resilience:recovery:reexport-share': 86400,
-  'seed-meta:resilience:recovery:sovereign-wealth': 86400,
-  'seed-meta:resilience:recovery:external-debt': 86400,
-  'seed-meta:resilience:recovery:import-hhi': 50400,
-};
 
 /**
  * Read standalone seed-meta records referenced by INDICATOR_REGISTRY and map

--- a/server/worldmonitor/resilience/v1/_source-failure.ts
+++ b/server/worldmonitor/resilience/v1/_source-failure.ts
@@ -142,6 +142,7 @@ export const STANDALONE_SOURCE_META_MAX_STALE_MIN: Readonly<Record<string, numbe
   'seed-meta:news:threat-summary': 60,
   'seed-meta:resilience:recovery:fiscal-space': 129600,
   'seed-meta:resilience:recovery:reserve-adequacy': 86400,
+  'seed-meta:resilience:recovery:reexport-share': 86400,
   'seed-meta:resilience:recovery:sovereign-wealth': 86400,
   'seed-meta:resilience:recovery:external-debt': 86400,
   'seed-meta:resilience:recovery:import-hhi': 50400,

--- a/server/worldmonitor/resilience/v1/_standalone-source-thresholds.ts
+++ b/server/worldmonitor/resilience/v1/_standalone-source-thresholds.ts
@@ -1,0 +1,40 @@
+// Resolved `seed-meta:*` thresholds for standalone CRI inputs. Most values
+// mirror api/health.js SEED_META; a few direct scorer inputs are not health
+// probes yet and are explicitly locked in tests. This intentionally uses
+// seeder health cadence, not INDICATOR_REGISTRY source-data cadence: an annual
+// source can still have a monthly/daily seeder whose missed runs should
+// surface in operational health.
+export const STANDALONE_SOURCE_META_MAX_STALE_MIN: Readonly<Record<string, number>> = {
+  'seed-meta:economic:imf-macro': 100800,
+  'seed-meta:economic:national-debt': 86400,
+  'seed-meta:economic:imf-labor': 100800,
+  'seed-meta:economic:bis': 10080,
+  'seed-meta:economic:bis-dsr': 2160,
+  'seed-meta:trade:restrictions:v1:tariff-overview:50': 480,
+  'seed-meta:trade:barriers:v1:tariff-gap:50': 480,
+  'seed-meta:economic:wb-external-debt': 100800,
+  'seed-meta:economic:bis-lbs': 14400,
+  'seed-meta:economic:fatf-listing': 60480,
+  'seed-meta:cyber:threats': 240,
+  'seed-meta:infra:outages': 30,
+  'seed-meta:intelligence:gpsjam': 1440,
+  'seed-meta:supply_chain:shipping_stress': 45,
+  'seed-meta:supply_chain:transit-summaries': 30,
+  'seed-meta:economic:owid-energy-mix': 50400,
+  'seed-meta:energy:gas-storage-countries': 2880,
+  'seed-meta:economic:energy-prices': 150,
+  'seed-meta:resilience:fossil-electricity-share': 11520,
+  'seed-meta:resilience:low-carbon-generation': 11520,
+  'seed-meta:resilience:power-losses': 11520,
+  'seed-meta:displacement:summary': 720,
+  'seed-meta:unrest:events': 120,
+  'seed-meta:conflict:ucdp-events': 420,
+  'seed-meta:intelligence:social-reddit': 180,
+  'seed-meta:news:threat-summary': 60,
+  'seed-meta:resilience:recovery:fiscal-space': 129600,
+  'seed-meta:resilience:recovery:reserve-adequacy': 86400,
+  'seed-meta:resilience:recovery:reexport-share': 86400,
+  'seed-meta:resilience:recovery:sovereign-wealth': 86400,
+  'seed-meta:resilience:recovery:external-debt': 86400,
+  'seed-meta:resilience:recovery:import-hhi': 50400,
+};

--- a/tests/resilience-dimension-freshness.test.mts
+++ b/tests/resilience-dimension-freshness.test.mts
@@ -13,6 +13,7 @@ import {
   INDICATOR_REGISTRY,
   getIndicatorSourceKeys,
 } from '../server/worldmonitor/resilience/v1/_indicator-registry.ts';
+import { STANDALONE_SOURCE_META_MAX_STALE_MIN } from '../server/worldmonitor/resilience/v1/_standalone-source-thresholds.ts';
 import {
   AGING_MULTIPLIER,
   FRESH_MULTIPLIER,
@@ -28,6 +29,8 @@ import type { ResilienceDimensionId } from '../server/worldmonitor/resilience/v1
 const NOW = 1_700_000_000_000;
 const RECOVERY_RESERVE_ADEQUACY_KEY = 'resilience:recovery:reserve-adequacy:v1';
 const RECOVERY_REEXPORT_SHARE_KEY = 'resilience:recovery:reexport-share:v1';
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MINUTE_MS = 60 * 1000;
 
 function freshAt(cadenceKey: Parameters<typeof cadenceUnitMs>[0], factor = 0.5): number {
   // factor < FRESH_MULTIPLIER keeps the age in the fresh band.
@@ -45,12 +48,28 @@ function staleAt(cadenceKey: Parameters<typeof cadenceUnitMs>[0]): number {
   return NOW - cadenceUnitMs(cadenceKey) * (AGING_MULTIPLIER + 2);
 }
 
+function daysAgo(days: number): number {
+  return NOW - days * DAY_MS;
+}
+
+function freshSourceAt(
+  sourceKey: string,
+  cadenceKey: Parameters<typeof cadenceUnitMs>[0],
+  factor = 0.5,
+): number {
+  const maxStaleMin = STANDALONE_SOURCE_META_MAX_STALE_MIN[resolveSeedMetaKey(sourceKey)];
+  if (typeof maxStaleMin === 'number') {
+    return NOW - maxStaleMin * MINUTE_MS * factor;
+  }
+  return freshAt(cadenceKey, factor);
+}
+
 function buildAllFreshMap(dimensionId: ResilienceDimensionId): Map<string, number> {
   const map = new Map<string, number>();
   for (const indicator of INDICATOR_REGISTRY) {
     if (indicator.dimension !== dimensionId) continue;
     for (const sourceKey of getIndicatorSourceKeys(indicator)) {
-      map.set(sourceKey, freshAt(indicator.cadence));
+      map.set(sourceKey, freshSourceAt(sourceKey, indicator.cadence));
     }
   }
   return map;
@@ -70,16 +89,19 @@ describe('classifyDimensionFreshness (T1.5 propagation pass)', () => {
   });
 
   it('one aging indicator + rest fresh returns aging and stays below stale', () => {
-    // Pick a dimension with multiple source keys so we can tip one to aging.
-    // socialCohesion has 3 indicators across 3 source keys.
-    const dimensionId: ResilienceDimensionId = 'socialCohesion';
+    // Pick a dimension with multiple source keys and tip a static source
+    // without a standalone seed-health SLA to aging. Source keys with
+    // explicit seed-health SLAs may jump directly from fresh to stale.
+    const dimensionId: ResilienceDimensionId = 'energy';
     const map = new Map<string, number>();
     const indicators = INDICATOR_REGISTRY.filter((i) => i.dimension === dimensionId);
     assert.ok(indicators.length >= 2);
-    map.set(indicators[0]!.sourceKey, agingAt(indicators[0]!.cadence));
-    for (let i = 1; i < indicators.length; i += 1) {
-      map.set(indicators[i]!.sourceKey, freshAt(indicators[i]!.cadence));
+    for (const indicator of indicators) {
+      for (const sourceKey of getIndicatorSourceKeys(indicator)) {
+        map.set(sourceKey, freshSourceAt(sourceKey, indicator.cadence));
+      }
     }
+    map.set('resilience:static:{ISO2}', agingAt('annual'));
     const result = classifyDimensionFreshness(dimensionId, map, NOW);
     assert.equal(result.staleness, 'aging', 'one aging + rest fresh should escalate to aging');
   });
@@ -106,7 +128,7 @@ describe('classifyDimensionFreshness (T1.5 propagation pass)', () => {
 
   it('liquidReserveAdequacy is stale when the re-export-share modifier is missing', () => {
     const map = new Map<string, number>([
-      [RECOVERY_RESERVE_ADEQUACY_KEY, freshAt('annual')],
+      [RECOVERY_RESERVE_ADEQUACY_KEY, freshSourceAt(RECOVERY_RESERVE_ADEQUACY_KEY, 'annual')],
     ]);
 
     const result = classifyDimensionFreshness('liquidReserveAdequacy', map, NOW);
@@ -120,7 +142,7 @@ describe('classifyDimensionFreshness (T1.5 propagation pass)', () => {
 
   it('liquidReserveAdequacy is stale when the re-export-share modifier is stale', () => {
     const map = new Map<string, number>([
-      [RECOVERY_RESERVE_ADEQUACY_KEY, freshAt('annual')],
+      [RECOVERY_RESERVE_ADEQUACY_KEY, freshSourceAt(RECOVERY_RESERVE_ADEQUACY_KEY, 'annual')],
       [RECOVERY_REEXPORT_SHARE_KEY, staleAt('annual')],
     ]);
 
@@ -133,10 +155,25 @@ describe('classifyDimensionFreshness (T1.5 propagation pass)', () => {
     );
   });
 
+  it('liquidReserveAdequacy is stale when re-export-share exceeds its seed-health SLA', () => {
+    const map = new Map<string, number>([
+      [RECOVERY_RESERVE_ADEQUACY_KEY, daysAgo(30)],
+      [RECOVERY_REEXPORT_SHARE_KEY, daysAgo(70)],
+    ]);
+
+    const result = classifyDimensionFreshness('liquidReserveAdequacy', map, NOW);
+
+    assert.equal(
+      result.staleness,
+      'stale',
+      '70-day-old re-export-share must stale the badge even though annual cadence alone would still be fresh',
+    );
+  });
+
   it('liquidReserveAdequacy stays fresh when reserve adequacy and re-export-share are both fresh', () => {
     const map = new Map<string, number>([
-      [RECOVERY_RESERVE_ADEQUACY_KEY, freshAt('annual', 0.25)],
-      [RECOVERY_REEXPORT_SHARE_KEY, freshAt('annual', 0.5)],
+      [RECOVERY_RESERVE_ADEQUACY_KEY, daysAgo(10)],
+      [RECOVERY_REEXPORT_SHARE_KEY, daysAgo(30)],
     ]);
 
     const result = classifyDimensionFreshness('liquidReserveAdequacy', map, NOW);

--- a/tests/resilience-dimension-freshness.test.mts
+++ b/tests/resilience-dimension-freshness.test.mts
@@ -26,6 +26,8 @@ import type { ResilienceDimensionId } from '../server/worldmonitor/resilience/v1
 // wiring) can consume the aggregated freshness with confidence.
 
 const NOW = 1_700_000_000_000;
+const RECOVERY_RESERVE_ADEQUACY_KEY = 'resilience:recovery:reserve-adequacy:v1';
+const RECOVERY_REEXPORT_SHARE_KEY = 'resilience:recovery:reexport-share:v1';
 
 function freshAt(cadenceKey: Parameters<typeof cadenceUnitMs>[0], factor = 0.5): number {
   // factor < FRESH_MULTIPLIER keeps the age in the fresh band.
@@ -100,6 +102,51 @@ describe('classifyDimensionFreshness (T1.5 propagation pass)', () => {
     const result = classifyDimensionFreshness('macroFiscal', emptyMap, NOW);
     assert.equal(result.staleness, 'stale', 'no data = stale');
     assert.equal(result.lastObservedAtMs, 0, 'no data = lastObservedAtMs zero');
+  });
+
+  it('liquidReserveAdequacy is stale when the re-export-share modifier is missing', () => {
+    const map = new Map<string, number>([
+      [RECOVERY_RESERVE_ADEQUACY_KEY, freshAt('annual')],
+    ]);
+
+    const result = classifyDimensionFreshness('liquidReserveAdequacy', map, NOW);
+
+    assert.equal(
+      result.staleness,
+      'stale',
+      'fresh reserve-adequacy alone must not mask missing re-export-share modifier freshness',
+    );
+  });
+
+  it('liquidReserveAdequacy is stale when the re-export-share modifier is stale', () => {
+    const map = new Map<string, number>([
+      [RECOVERY_RESERVE_ADEQUACY_KEY, freshAt('annual')],
+      [RECOVERY_REEXPORT_SHARE_KEY, staleAt('annual')],
+    ]);
+
+    const result = classifyDimensionFreshness('liquidReserveAdequacy', map, NOW);
+
+    assert.equal(
+      result.staleness,
+      'stale',
+      'stale re-export-share modifier freshness must dominate fresh reserve-adequacy freshness',
+    );
+  });
+
+  it('liquidReserveAdequacy stays fresh when reserve adequacy and re-export-share are both fresh', () => {
+    const map = new Map<string, number>([
+      [RECOVERY_RESERVE_ADEQUACY_KEY, freshAt('annual', 0.25)],
+      [RECOVERY_REEXPORT_SHARE_KEY, freshAt('annual', 0.5)],
+    ]);
+
+    const result = classifyDimensionFreshness('liquidReserveAdequacy', map, NOW);
+
+    assert.equal(result.staleness, 'fresh');
+    assert.equal(
+      result.lastObservedAtMs,
+      map.get(RECOVERY_REEXPORT_SHARE_KEY),
+      'lastObservedAtMs should remain the oldest fresh liquid-reserve source',
+    );
   });
 
   it('dimension with no registry indicators returns empty payload (defensive)', () => {
@@ -377,6 +424,10 @@ describe('resolveSeedMetaKey (T1.5 propagation pass, P1 fix)', () => {
     assert.equal(resolveSeedMetaKey('infra:outages:v1'), 'seed-meta:infra:outages');
     assert.equal(resolveSeedMetaKey('unrest:events:v1'), 'seed-meta:unrest:events');
     assert.equal(resolveSeedMetaKey('intelligence:gpsjam:v2'), 'seed-meta:intelligence:gpsjam');
+    assert.equal(
+      resolveSeedMetaKey(RECOVERY_REEXPORT_SHARE_KEY),
+      'seed-meta:resilience:recovery:reexport-share',
+    );
     assert.equal(
       resolveSeedMetaKey('economic:national-debt:v1'),
       'seed-meta:economic:national-debt',


### PR DESCRIPTION
## Summary
- Register the re-export-share recovery seed as part of the liquid reserve adequacy source set
- Track the re-export-share seed-meta key in standalone source-failure freshness thresholds
- Add regression coverage for missing, stale, and fresh re-export-share modifier freshness

## Root Cause
`liquidReserveAdequacy` scores with `resilience:recovery:reexport-share:v1`, but the active `recoveryLiquidReserveMonths` registry row only declared `resilience:recovery:reserve-adequacy:v1`. Registry-driven freshness and source-failure checks could therefore miss stale or absent re-export-share metadata for hub-style reserve adjustments.

## Validation
- `./node_modules/.bin/tsx --test tests/resilience-dimension-freshness.test.mts tests/resilience-source-failure.test.mts tests/resilience-indicator-registry.test.mts tests/resilience-doc-parity.test.mts tests/resilience-methodology-lint.test.mts`
- pre-push hook on `git push -u origin codex/fix-liquid-reserve-freshness` ran typecheck, API typecheck, boundary/safe-html/rate-limit/premium-fetch checks, resilience tests, server handler tests, and version sync