### PR TITLE
fix: align frontend CII scoring parity

### DIFF
--- a/src/services/cached-risk-scores.ts
+++ b/src/services/cached-risk-scores.ts
@@ -1,6 +1,7 @@
 import type { CountryScore, ComponentScores } from './country-instability';
 import { getRpcBaseUrl } from '@/services/rpc-client';
 import { setHasCachedScores } from './country-instability';
+import { TIER1_COUNTRIES } from '@/config/countries';
 import {
   IntelligenceServiceClient,
   type GetRiskScoresResponse,
@@ -53,14 +54,6 @@ export interface CachedRiskScores {
 
 // ---- Proto → legacy adapters ----
 
-const TIER1_NAMES: Record<string, string> = {
-  US: 'United States', RU: 'Russia', CN: 'China', UA: 'Ukraine', IR: 'Iran',
-  IL: 'Israel', TW: 'Taiwan', KP: 'North Korea', SA: 'Saudi Arabia', TR: 'Turkey',
-  PL: 'Poland', DE: 'Germany', FR: 'France', GB: 'United Kingdom', IN: 'India',
-  PK: 'Pakistan', SY: 'Syria', YE: 'Yemen', MM: 'Myanmar', VE: 'Venezuela',
-  CU: 'Cuba', MX: 'Mexico', BR: 'Brazil', AE: 'United Arab Emirates',
-};
-
 const TREND_REVERSE: Record<string, 'rising' | 'stable' | 'falling'> = {
   TREND_DIRECTION_RISING: 'rising',
   TREND_DIRECTION_STABLE: 'stable',
@@ -86,7 +79,7 @@ function getScoreLevel(score: number): 'low' | 'normal' | 'elevated' | 'high' | 
 function toCachedCII(proto: CiiScore): CachedCIIScore {
   return {
     code: proto.region,
-    name: TIER1_NAMES[proto.region] || proto.region,
+    name: TIER1_COUNTRIES[proto.region] || proto.region,
     score: proto.combinedScore,
     level: getScoreLevel(proto.combinedScore),
     trend: TREND_REVERSE[proto.trend] || 'stable',
@@ -128,7 +121,7 @@ function toCachedStrategicRisk(
     contributors: (global?.factors ?? []).map((code) => {
       const cii = ciiMap.get(code);
       return {
-        country: TIER1_NAMES[code] || code,
+        country: TIER1_COUNTRIES[code] || code,
         code,
         score: cii?.combinedScore ?? 0,
         level: cii ? getScoreLevel(cii.combinedScore) : 'low',

--- a/src/services/country-instability.ts
+++ b/src/services/country-instability.ts
@@ -97,18 +97,37 @@ export function hasAnyIntelligenceData(): boolean {
     if (
       data.conflicts.length > 0 ||
       data.protests.length > 0 ||
+      data.newsEvents.length > 0 ||
       data.strikes.length > 0 ||
       data.militaryFlights.length > 0 ||
       data.militaryVessels.length > 0 ||
       data.outages.length > 0 ||
+      data.aviationDisruptions.length > 0 ||
       data.ucdpStatus !== null ||
       data.hapiSummary !== null ||
+      data.displacementOutflow > 0 ||
       data.climateStress > 0 ||
+      data.orefAlertCount > 0 ||
+      data.orefHistoryCount24h > 0 ||
+      data.advisoryCount > 0 ||
+      data.advisoryMaxLevel !== null ||
       data.gpsJammingHighCount > 0 ||
       data.gpsJammingMediumCount > 0 ||
       data.aisDisruptionHighCount > 0 ||
       data.aisDisruptionElevatedCount > 0 ||
-      data.aisDisruptionLowCount > 0
+      data.aisDisruptionLowCount > 0 ||
+      data.satelliteFireCount > 0 ||
+      data.satelliteFireHighCount > 0 ||
+      data.cyberThreatCriticalCount > 0 ||
+      data.cyberThreatHighCount > 0 ||
+      data.cyberThreatMediumCount > 0 ||
+      data.temporalAnomalyCount > 0 ||
+      data.temporalAnomalyCriticalCount > 0 ||
+      data.earthquakeSignificantCount > 0 ||
+      data.earthquakeMajorCount > 0 ||
+      data.earthquakeSevereCount > 0 ||
+      data.sanctionsEntryCount > 0 ||
+      data.sanctionsNewEntryCount > 0
     ) {
       return true;
     }
@@ -776,8 +795,8 @@ export function ingestSanctionsForCII(countries: CountrySanctionsPressure[]): vo
     const code = c.countryCode.toUpperCase();
     if (!countryDataMap.has(code)) countryDataMap.set(code, initCountryData());
     const data = countryDataMap.get(code)!;
-    data.sanctionsEntryCount = c.entryCount;
-    data.sanctionsNewEntryCount = c.newEntryCount;
+    data.sanctionsEntryCount += c.entryCount;
+    data.sanctionsNewEntryCount += c.newEntryCount;
   }
 }
 
@@ -992,6 +1011,52 @@ function getTrend(code: string, current: number): CountryScore['trend'] {
   return 'stable';
 }
 
+function calculateCountryScoreSnapshot(
+  code: string,
+  data: CountryData,
+  focalUrgency: 'watch' | 'elevated' | 'critical' | null | undefined,
+): { score: number; components: ComponentScores } {
+  const baselineRisk = CURATED_COUNTRIES[code]?.baselineRisk ?? DEFAULT_BASELINE_RISK;
+
+  const components: ComponentScores = {
+    unrest: Math.round(calcUnrestScore(data, code)),
+    conflict: Math.round(calcConflictScore(data, code)),
+    security: Math.round(calcSecurityScore(data)),
+    information: Math.round(calcInformationScore(data, code)),
+  };
+
+  const eventScore = components.unrest * 0.25 + components.conflict * 0.30 + components.security * 0.20 + components.information * 0.25;
+  const hotspotBoost = getHotspotBoost(code);
+  const newsUrgencyBoost = components.information >= 70 ? 5
+    : components.information >= 50 ? 3
+    : 0;
+  const focalBoost = focalUrgency === 'critical' ? 8
+    : focalUrgency === 'elevated' ? 4
+    : 0;
+
+  const displacementBoost = getDisplacementBoost(data.displacementOutflow);
+  const climateBoost = data.climateStress;
+  const advisoryBoost = getAdvisoryBoost(data);
+  const supplementalSignalBoost = getSupplementalSignalBoost(data);
+  const blendedScore = baselineRisk * 0.4
+    + eventScore * 0.6
+    + hotspotBoost
+    + newsUrgencyBoost
+    + focalBoost
+    + displacementBoost
+    + climateBoost
+    + getOrefBlendBoost(code, data)
+    + advisoryBoost
+    + supplementalSignalBoost
+    + getEarthquakeBoost(data)
+    + getSanctionsBoost(data);
+
+  const floor = Math.max(getUcdpFloor(data), getAdvisoryFloor(data));
+  const score = Math.round(Math.min(100, Math.max(floor, blendedScore)));
+
+  return { score, components };
+}
+
 export function calculateCII(): CountryScore[] {
   const scores: CountryScore[] = [];
   const focalUrgencies = focalPointDetector.getCountryUrgencyMap();
@@ -1004,35 +1069,7 @@ export function calculateCII(): CountryScore[] {
   for (const code of countryCodes) {
     const name = CURATED_COUNTRIES[code]?.name || getCountryNameByCode(code) || code;
     const data = countryDataMap.get(code) || initCountryData();
-    const baselineRisk = CURATED_COUNTRIES[code]?.baselineRisk ?? DEFAULT_BASELINE_RISK;
-
-    const components: ComponentScores = {
-      unrest: Math.round(calcUnrestScore(data, code)),
-      conflict: Math.round(calcConflictScore(data, code)),
-      security: Math.round(calcSecurityScore(data)),
-      information: Math.round(calcInformationScore(data, code)),
-    };
-
-    const eventScore = components.unrest * 0.25 + components.conflict * 0.30 + components.security * 0.20 + components.information * 0.25;
-
-    const hotspotBoost = getHotspotBoost(code);
-    const newsUrgencyBoost = components.information >= 70 ? 5
-      : components.information >= 50 ? 3
-      : 0;
-    const focalUrgency = focalUrgencies.get(code);
-    const focalBoost = focalUrgency === 'critical' ? 8
-      : focalUrgency === 'elevated' ? 4
-      : 0;
-
-    const displacementBoost = getDisplacementBoost(data.displacementOutflow);
-    const climateBoost = data.climateStress;
-
-    const advisoryBoost = getAdvisoryBoost(data);
-    const supplementalSignalBoost = getSupplementalSignalBoost(data);
-    const blendedScore = baselineRisk * 0.4 + eventScore * 0.6 + hotspotBoost + newsUrgencyBoost + focalBoost + displacementBoost + climateBoost + getOrefBlendBoost(code, data) + advisoryBoost + supplementalSignalBoost + getEarthquakeBoost(data) + getSanctionsBoost(data);
-
-    const floor = Math.max(getUcdpFloor(data), getAdvisoryFloor(data));
-    const score = Math.round(Math.min(100, Math.max(floor, blendedScore)));
+    const { score, components } = calculateCountryScoreSnapshot(code, data, focalUrgencies.get(code));
 
     const prev = previousScores.get(code) ?? score;
 
@@ -1058,32 +1095,13 @@ export function getTopUnstableCountries(limit = 10): CountryScore[] {
 }
 
 export function getCountryScore(code: string): number | null {
-  const data = countryDataMap.get(code);
+  const normalizedCode = code.toUpperCase();
+  const data = countryDataMap.get(normalizedCode);
   if (!data) return null;
 
-  const baselineRisk = CURATED_COUNTRIES[code]?.baselineRisk ?? DEFAULT_BASELINE_RISK;
-  const components: ComponentScores = {
-    unrest: calcUnrestScore(data, code),
-    conflict: calcConflictScore(data, code),
-    security: calcSecurityScore(data),
-    information: calcInformationScore(data, code),
-  };
-
-  const eventScore = components.unrest * 0.25 + components.conflict * 0.30 + components.security * 0.20 + components.information * 0.25;
-  const hotspotBoost = getHotspotBoost(code);
-  const newsUrgencyBoost = components.information >= 70 ? 5
-    : components.information >= 50 ? 3
-    : 0;
-  const focalUrgency = focalPointDetector.getCountryUrgency(code);
-  const focalBoost = focalUrgency === 'critical' ? 8
-    : focalUrgency === 'elevated' ? 4
-    : 0;
-  const displacementBoost = getDisplacementBoost(data.displacementOutflow);
-  const climateBoost = data.climateStress;
-  const advisoryBoost = getAdvisoryBoost(data);
-  const supplementalSignalBoost = getSupplementalSignalBoost(data);
-  const blendedScore = baselineRisk * 0.4 + eventScore * 0.6 + hotspotBoost + newsUrgencyBoost + focalBoost + displacementBoost + climateBoost + getOrefBlendBoost(code, data) + advisoryBoost + supplementalSignalBoost;
-
-  const floor = Math.max(getUcdpFloor(data), getAdvisoryFloor(data));
-  return Math.round(Math.min(100, Math.max(floor, blendedScore)));
+  return calculateCountryScoreSnapshot(
+    normalizedCode,
+    data,
+    focalPointDetector.getCountryUrgency(normalizedCode),
+  ).score;
 }

--- a/src/services/cross-module-integration.ts
+++ b/src/services/cross-module-integration.ts
@@ -590,8 +590,9 @@ export function checkCIIChanges(): UnifiedAlert[] {
 }
 
 function getHighestComponent(score: CountryScore): string {
-  const { unrest, security, information } = score.components;
-  if (unrest >= security && unrest >= information) return 'Civil Unrest';
+  const { unrest, conflict, security, information } = score.components;
+  if (unrest >= conflict && unrest >= security && unrest >= information) return 'Civil Unrest';
+  if (conflict >= security && conflict >= information) return 'Conflict Activity';
   if (security >= information) return 'Security Activity';
   return 'Information Velocity';
 }

--- a/tests/cached-risk-scores.test.mts
+++ b/tests/cached-risk-scores.test.mts
@@ -89,6 +89,10 @@ async function loadAdapter() {
       'const setHasCachedScores = (_: boolean) => {};',
     )
     .replace(
+      "import { TIER1_COUNTRIES } from '@/config/countries';",
+      'const TIER1_COUNTRIES: Record<string, string> = { US: "United States", CN: "China", RU: "Russia", LB: "Lebanon", IQ: "Iraq", AF: "Afghanistan", KR: "South Korea", EG: "Egypt", JP: "Japan", QA: "Qatar" };',
+    )
+    .replace(
       /import\s*\{[^}]*IntelligenceServiceClient[^}]*\}\s*from\s*'@\/generated\/client\/worldmonitor\/intelligence\/v1\/service_client';/,
       'class IntelligenceServiceClient { constructor(..._args: any[]) {} async getRiskScores(_: any) { return { ciiScores: [], strategicRisks: [] }; } }',
     )
@@ -223,6 +227,20 @@ describe('cached-risk-scores — functional adapter behavior', () => {
     });
     assert.equal(out.strategicRisk.lastUpdated, null);
     assert.equal(out.computedAt, null);
+  });
+
+  it('uses the shared Tier-1 country table for newer cached CII country names', async () => {
+    const { toRiskScores } = await loadAdapter();
+    const out = toRiskScores({
+      ciiScores: [makeCii('LB', 1_700_000_000_000)],
+      strategicRisks: [{ region: 'GLOBAL', level: 'SEVERITY_LEVEL_LOW', score: 12, factors: ['LB'], trend: 'TREND_DIRECTION_STABLE' }],
+    }) as unknown as {
+      cii: Array<{ code: string; name: string }>;
+      strategicRisk: { contributors: Array<{ code: string; country: string }> };
+    };
+
+    assert.equal(out.cii[0]!.name, 'Lebanon');
+    assert.equal(out.strategicRisk.contributors[0]!.country, 'Lebanon');
   });
 
   it('toCountryScore returns Date for non-null cached lastUpdated', async () => {

--- a/tests/frontend-cii-closeout.test.mts
+++ b/tests/frontend-cii-closeout.test.mts
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+import { transformSync } from 'esbuild';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const countryInstabilityPath = resolve(root, 'src/services/country-instability.ts');
+const crossModulePath = resolve(root, 'src/services/cross-module-integration.ts');
+const cachedRiskScoresPath = resolve(root, 'src/services/cached-risk-scores.ts');
+
+const countryInstabilitySource = readFileSync(countryInstabilityPath, 'utf8');
+const crossModuleSource = readFileSync(crossModulePath, 'utf8');
+const cachedRiskScoresSource = readFileSync(cachedRiskScoresPath, 'utf8');
+
+async function loadCountryInstability() {
+  const patched = countryInstabilitySource
+    .replace(
+      "import { tokenizeForMatch, matchKeyword } from '@/utils/keyword-match';",
+      `const tokenizeForMatch = (value: string) => value.toLowerCase().split(/\\W+/).filter(Boolean);
+const matchKeyword = (tokens: string[], keyword: string) => tokens.includes(keyword.toLowerCase());`,
+    )
+    .replace(
+      "import { INTEL_HOTSPOTS, CONFLICT_ZONES, STRATEGIC_WATERWAYS } from '@/config/geo';",
+      'const INTEL_HOTSPOTS: any[] = []; const CONFLICT_ZONES: any[] = []; const STRATEGIC_WATERWAYS: any[] = [];',
+    )
+    .replace(
+      "import { CURATED_COUNTRIES, DEFAULT_BASELINE_RISK, DEFAULT_EVENT_MULTIPLIER, getHotspotCountries } from '@/config/countries';",
+      `const CURATED_COUNTRIES: Record<string, any> = {
+  US: { name: "United States", scoringKeywords: ["united", "states", "america"], baselineRisk: 10, eventMultiplier: 0.5 },
+};
+const DEFAULT_BASELINE_RISK = 5;
+const DEFAULT_EVENT_MULTIPLIER = 1;
+const getHotspotCountries = (_: string) => [];`,
+    )
+    .replace(
+      "export { TIER1_COUNTRIES } from '@/config/countries';",
+      'export const TIER1_COUNTRIES: Record<string, string> = { US: "United States" };',
+    )
+    .replace(
+      "import { focalPointDetector } from './focal-point-detector';",
+      'const focalPointDetector = { getCountryUrgencyMap: () => new Map(), getCountryUrgency: (_: string) => null };',
+    )
+    .replace(
+      "import { getCountryAtCoordinates, iso3ToIso2Code, nameToCountryCode, getCountryNameByCode, matchCountryNamesInText, ME_STRIKE_BOUNDS, resolveCountryFromBounds } from './country-geometry';",
+      `const getCountryAtCoordinates = (lat: number, lon: number) => Number.isFinite(lat) && Number.isFinite(lon) ? { code: "US", name: "United States" } : null;
+const iso3ToIso2Code = (_: string) => null;
+const nameToCountryCode = (name: string) => ({ "united states": "US", usa: "US", america: "US" } as Record<string, string>)[name.toLowerCase()] ?? null;
+const getCountryNameByCode = (code: string) => ({ US: "United States" } as Record<string, string>)[code] ?? null;
+const matchCountryNamesInText = (_: string) => [];
+const ME_STRIKE_BOUNDS = {};
+const resolveCountryFromBounds = (_lat: number, _lon: number, _bounds: unknown) => null;`,
+    );
+
+  const transformed = transformSync(patched, {
+    loader: 'ts',
+    format: 'esm',
+    target: 'es2022',
+  });
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(transformed.code).toString('base64')}`;
+  return (await import(dataUrl)) as {
+    clearCountryData: () => void;
+    calculateCII: () => Array<{ code: string; score: number }>;
+    getCountryScore: (code: string) => number | null;
+    getCountryData: (code: string) => {
+      sanctionsEntryCount: number;
+      sanctionsNewEntryCount: number;
+    } | undefined;
+    hasAnyIntelligenceData: () => boolean;
+    ingestSanctionsForCII: (countries: Array<{ countryCode: string; entryCount: number; newEntryCount: number }>) => void;
+    ingestEarthquakesForCII: (earthquakes: Array<{ magnitude: number; occurredAt: number; location: { latitude: number; longitude: number } }>, now?: number) => void;
+    ingestCyberThreatsForCII: (threats: Array<{ country: string; severity: string; lat: number; lon: number }>) => void;
+  };
+}
+
+describe('frontend CII closeout regressions', () => {
+  it('getCountryScore uses the same earthquake and sanctions blend as calculateCII', async () => {
+    const cii = await loadCountryInstability();
+    cii.clearCountryData();
+
+    const now = Date.now();
+    cii.ingestEarthquakesForCII([
+      { magnitude: 7.0, occurredAt: now, location: { latitude: 39, longitude: -98 } },
+    ], now);
+    cii.ingestSanctionsForCII([
+      { countryCode: 'US', entryCount: 60, newEntryCount: 1 },
+      { countryCode: 'US', entryCount: 60, newEntryCount: 0 },
+    ]);
+
+    const tableScore = cii.calculateCII().find((score) => score.code === 'US')?.score;
+    assert.equal(cii.getCountryScore('US'), tableScore);
+  });
+
+  it('frontend sanctions ingestion accumulates duplicate ISO2 rows', async () => {
+    const cii = await loadCountryInstability();
+    cii.clearCountryData();
+
+    cii.ingestSanctionsForCII([
+      { countryCode: 'US', entryCount: 60, newEntryCount: 1 },
+      { countryCode: 'US', entryCount: 60, newEntryCount: 0 },
+    ]);
+
+    const data = cii.getCountryData('US');
+    assert.equal(data?.sanctionsEntryCount, 120);
+    assert.equal(data?.sanctionsNewEntryCount, 1);
+  });
+
+  it('hasAnyIntelligenceData recognizes newer local CII signals', async () => {
+    const cii = await loadCountryInstability();
+    cii.clearCountryData();
+    assert.equal(cii.hasAnyIntelligenceData(), false);
+
+    cii.ingestCyberThreatsForCII([
+      { country: 'US', severity: 'critical', lat: 39, lon: -98 },
+    ]);
+    assert.equal(cii.hasAnyIntelligenceData(), true);
+
+    cii.clearCountryData();
+    cii.ingestSanctionsForCII([{ countryCode: 'US', entryCount: 1, newEntryCount: 0 }]);
+    assert.equal(cii.hasAnyIntelligenceData(), true);
+  });
+});
+
+describe('cached CII names', () => {
+  it('cached risk score adapter derives country names from the shared Tier-1 table', () => {
+    assert.match(
+      cachedRiskScoresSource,
+      /import\s+\{\s*TIER1_COUNTRIES\s+\}\s+from\s+'@\/config\/countries';/,
+    );
+    assert.doesNotMatch(cachedRiskScoresSource, /const\s+TIER1_NAMES\b/);
+  });
+});
+
+describe('cross-module CII alert labeling', () => {
+  it('highest-component labeling includes conflict-led CII changes', () => {
+    assert.match(crossModuleSource, /Conflict Activity/);
+    assert.match(crossModuleSource, /\{\s*unrest,\s*conflict,\s*security,\s*information\s*\}\s*=\s*score\.components/);
+  });
+});


### PR DESCRIPTION
## Summary
- Share the frontend CII score blend between `calculateCII()` and `getCountryScore()` so earthquake and sanctions boosts cannot drift.
- Accumulate duplicate ISO2 sanctions rows to match server semantics.
- Expand local CII readiness detection for newer signals, derive cached country names from `TIER1_COUNTRIES`, and label conflict-led CII alerts correctly.
- Add focused frontend regression coverage plus cached-name adapter coverage.

## Validation
- `npm run typecheck`
- `npm exec -- tsx --test tests/frontend-cii-closeout.test.mts tests/cached-risk-scores.test.mts tests/cii-scoring.test.mts`
- Pre-push hook on `git push -u origin codex/cii-frontend-closeout`: typecheck, API typecheck, boundary lint, safe HTML check, rate-limit policy check, premium-fetch parity, changed tests, edge function tests, version sync.