### PR TITLE
Align public CII risk docs with v3

### DIFF
--- a/docs/COMMUNITY-PROMOTION-GUIDE.md
+++ b/docs/COMMUNITY-PROMOTION-GUIDE.md
@@ -137,7 +137,7 @@ Run AI summarization entirely on your own hardware — no API keys, no cloud, no
 
 - "7-signal crypto macro radar with BUY/CASH composite verdict"
 - "92 global stock exchanges mapped with market caps and trading hours"
-- "Country Instability Index tracking 22 nations in real-time"
+- "Country Instability Index tracking 31 Tier-1 countries in real time"
 - "Prediction market integration for geopolitical forecasting"
 - "Air-gapped AI analysis — run Ollama locally for sensitive intelligence work"
 

--- a/docs/Docs_To_Review/DOCUMENTATION.md
+++ b/docs/Docs_To_Review/DOCUMENTATION.md
@@ -43,7 +43,7 @@ The primary variant focuses on geopolitical intelligence, military tracking, and
 |-------|---------|
 | **AI Insights** | LLM-synthesized world brief with focal point detection |
 | **AI Strategic Posture** | Theater-level military force aggregation with strike capability assessment |
-| **Country Instability Index** | Real-time stability scores for 20 monitored countries |
+| **Country Instability Index** | Real-time CII v3 stability scores for 31 Tier-1 countries |
 | **Strategic Risk Overview** | Composite risk score combining all intelligence modules |
 | **Infrastructure Cascade** | Dependency analysis for cables, pipelines, and chokepoints |
 | **Live Intelligence** | GDELT-powered topic feeds (Military, Cyber, Nuclear, Sanctions) |
@@ -191,7 +191,7 @@ Beyond raw data feeds, the dashboard provides synthesized intelligence panels:
 |-------|---------|
 | **AI Strategic Posture** | Theater-level military aggregation with strike capability analysis |
 | **Strategic Risk Overview** | Composite risk score combining all intelligence modules |
-| **Country Instability Index** | Real-time stability scores for 20 monitored countries |
+| **Country Instability Index** | Real-time CII v3 stability scores for 31 Tier-1 countries |
 | **Infrastructure Cascade** | Dependency analysis for cables, pipelines, and chokepoints |
 | **Live Intelligence** | GDELT-powered topic feeds (Military, Cyber, Nuclear, Sanctions) |
 | **Intel Feed** | Curated defense and security news sources |
@@ -939,80 +939,42 @@ Pin state persists across sessions via localStorage.
 
 ## Country Instability Index (CII)
 
-The dashboard maintains a **real-time instability score** for 20 strategically significant countries. Rather than relying on static risk ratings, the CII dynamically reflects current conditions based on multiple input streams.
+The dashboard maintains a **real-time CII v3 instability score** for 31
+Tier-1 countries. Rather than relying on static risk ratings, CII combines an
+editorial baseline with live unrest, conflict, security, and information
+signals.
 
-### Monitored Countries (Tier 1)
+This review copy intentionally does not duplicate the full formula table. The
+canonical public source is
+[CII Risk Scoring Methodology](methodology/cii-risk-scores.mdx); update that
+document with any formula or coefficient changes.
 
-| Region | Countries |
-|--------|-----------|
-| **Americas** | United States, Venezuela |
-| **Europe** | Germany, France, United Kingdom, Poland |
-| **Eastern Europe** | Russia, Ukraine |
-| **Middle East** | Iran, Israel, Saudi Arabia, Turkey, Syria, Yemen |
-| **Asia-Pacific** | China, Taiwan, North Korea, India, Pakistan, Myanmar |
+### Current Score Model
 
-### Three Component Scores
-
-Each country's CII is computed from three weighted components:
-
-| Component | Weight | Data Sources | What It Measures |
-|-----------|--------|--------------|------------------|
-| **Unrest** | 40% | ACLED protests, GDELT events | Civil unrest intensity, fatalities, event severity |
-| **Security** | 30% | Military flights, naval vessels | Unusual military activity patterns |
-| **Information** | 30% | News velocity, alert clusters | Media attention intensity and acceleration |
-
-### Scoring Algorithm
+Each score blends four event components with static baseline risk:
 
 ```
-Unrest Score:
-  base = min(50, protest_count × 8)
-  fatality_boost = min(30, total_fatalities × 5)
-  severity_boost = min(20, high_severity_count × 10)
-  unrest = min(100, base + fatality_boost + severity_boost)
+eventScore = Unrest * 0.25
+           + Conflict * 0.30
+           + Security * 0.20
+           + Information * 0.25
 
-Security Score:
-  flight_score = min(50, military_flights × 3)
-  vessel_score = min(30, naval_vessels × 5)
-  security = min(100, flight_score + vessel_score)
-
-Information Score:
-  base = min(40, news_count × 5)
-  velocity_boost = min(40, avg_velocity × 10)
-  alert_boost = 20 if any_alert else 0
-  information = min(100, base + velocity_boost + alert_boost)
-
-Final CII = round(unrest × 0.4 + security × 0.3 + information × 0.3)
+combinedScore = baselineRisk * 0.40
+              + eventScore * 0.60
+              + supplemental boosts
 ```
 
-### Scoring Bias Prevention
+| Component | Weight | Main Inputs |
+|-----------|-------:|-------------|
+| **Unrest** | 25% | ACLED protests/riots, protest fatalities, high-severity unrest, outages |
+| **Conflict** | 30% | ACLED battles/explosions/civilian violence, fatalities, Iran strikes, OREF alerts |
+| **Security** | 20% | Military flights, military vessels, aviation disruptions, GPS/GNSS jamming |
+| **Information** | 25% | Classified news headlines and country-attributed threat summaries |
 
-Raw news volume creates a natural bias—English-language media generates far more coverage of the US, UK, and Western Europe than conflict zones. Without correction, stable democracies would consistently score higher than actual crisis regions.
-
-**Log Scaling for High-Volume Countries**
-
-Countries with high media coverage receive logarithmic dampening on their unrest and information scores:
-
-```
-if (newsVolume > threshold):
-  dampingFactor = 1 / (1 + log10(newsVolume / threshold))
-  score = rawScore × dampingFactor
-```
-
-This ensures the US receiving 50 news mentions about routine political activity doesn't outscore Ukraine with 10 mentions about active combat.
-
-**Conflict Zone Floor Scores**
-
-Active conflict zones have minimum score floors that prevent them from appearing stable during data gaps or low-coverage periods:
-
-| Country | Floor | Rationale |
-|---------|-------|-----------|
-| Ukraine | 55 | Active war with Russia |
-| Syria | 50 | Ongoing civil war |
-| Yemen | 50 | Ongoing civil war |
-| Myanmar | 45 | Military coup, civil conflict |
-| Israel | 45 | Active Gaza conflict |
-
-The floor applies *after* the standard calculation—if the computed score exceeds the floor, the computed score is used. This prevents false "all clear" signals while preserving sensitivity to actual escalations.
+Supplemental boosts include advisory, OREF, climate, cyber, fire,
+displacement, news urgency, earthquake, sanctions, and AIS disruption signals.
+UCDP conflict and State Department advisory floors prevent active crises from
+appearing stable during data gaps.
 
 ### Instability Levels
 
@@ -1024,46 +986,16 @@ The floor applies *after* the standard calculation—if the computed score excee
 | **Normal** | 31-50 | Gray | Baseline geopolitical activity |
 | **Low** | 0-30 | Green | Unusually quiet period |
 
-### Trend Detection
-
-The CII tracks 24-hour changes to identify trajectory:
-
-- **Rising**: Score increased by ≥5 points (escalating situation)
-- **Stable**: Change within ±5 points (steady state)
-- **Falling**: Score decreased by ≥5 points (de-escalation)
-
-### Contextual Score Boosts
-
-Beyond the base component scores, several contextual factors can boost a country's CII score (up to a combined maximum of 23 additional points):
-
-| Boost Type | Max Points | Condition | Purpose |
-|------------|------------|-----------|---------|
-| **Hotspot Activity** | 10 | Events near defined hotspots | Captures localized escalation |
-| **News Urgency** | 5 | Information component ≥50 | High media attention indicator |
-| **Focal Point** | 8 | AI focal point detection on country | Multi-source convergence indicator |
-
-**Hotspot Boost Calculation**:
-
-- Hotspot activity (0-100) scaled by 1.5× then capped at 10
-- Zero boost for countries with no associated hotspot activity
-
-**News Urgency Boost Tiers**:
-
-- Information ≥70: +5 points
-- Information ≥50: +3 points
-- Information <50: +0 points
-
-**Focal Point Boost Tiers**:
-
-- Critical urgency: +8 points
-- Elevated urgency: +4 points
-- Normal urgency: +0 points
-
-These boosts are designed to elevate scores only when corroborating evidence exists—a country must have both high base scores AND contextual signals to reach extreme levels.
-
 ### Server-Side Pre-Computation
 
-To eliminate the "cold start" problem where new users would see blank data during the Learning Mode warmup, CII scores are **pre-computed server-side** via the `/api/risk-scores` endpoint. See the [Server-Side Risk Score API](#server-side-risk-score-api) section for details.
+To eliminate the "cold start" problem, CII scores are pre-computed
+server-side via `GET /api/intelligence/v1/get-risk-scores` and cached in
+versioned Redis live/stale keys.
+
+The Railway relay process also runs an active CII warm-ping loop every 8
+minutes against the same RPC and writes
+`seed-meta:intelligence:risk-scores` for health monitoring when scores are
+returned.
 
 ### Learning Mode (15-Minute Warmup)
 
@@ -1103,16 +1035,6 @@ After 15 minutes: Learning Complete
 ```
 
 This ensures users understand that early scores are provisional while preventing alert fatigue during the calibration period.
-
-### Keyword Attribution
-
-Countries are matched to data via keyword lists:
-
-- **Russia**: `russia`, `moscow`, `kremlin`, `putin`
-- **China**: `china`, `beijing`, `xi jinping`, `prc`
-- **Taiwan**: `taiwan`, `taipei`
-
-This enables attribution of news and events to specific countries even when formal country codes aren't present in the source data.
 
 ---
 
@@ -3089,43 +3011,29 @@ Strategic risk and Country Instability Index (CII) scores are pre-computed serve
 
 ### How It Works
 
-The `/api/risk-scores` edge function:
+The `GET /api/intelligence/v1/get-risk-scores` RPC handler:
 
-1. Fetches recent protest/riot data from ACLED (7-day window)
-2. Computes CII scores for 20 Tier 1 countries
-3. Derives strategic risk from weighted top-5 CII scores
-4. Caches results in Redis (10-minute TTL)
+1. Fetches recent ACLED unrest/conflict events.
+2. Reads auxiliary Redis sources for conflict floors, advisories, outages, climate, cyber, fires, GPS jamming, OREF alerts, displacement, news threat summaries, aviation alerts, earthquakes, sanctions, and military/AIS CII aggregates.
+3. Computes CII v3 scores for 31 Tier-1 countries.
+4. Derives Strategic Risk from the weighted top 5 CII scores.
+5. Caches results in Redis using versioned live and stale keys tied to the current CII formula version.
 
 ### CII Score Calculation
 
-Each country's score combines:
+Each country combines `baselineRisk * 0.40` with a dynamic event blend:
 
-**Baseline Risk** (0–50 points): Static geopolitical risk based on historical instability, ongoing conflicts, and authoritarian governance.
+| Component | Weight | Main Inputs |
+|-----------|-------:|-------------|
+| Unrest | 25% | Protests, riots, protest fatalities, high-severity unrest, outages |
+| Conflict | 30% | Battles, explosions, violence against civilians, fatalities, Iran strikes, OREF alerts |
+| Security | 20% | Military flights, military vessels, aviation disruptions, GPS/GNSS jamming |
+| Information | 25% | Classified news headlines and country-attributed threat summaries |
 
-| Country | Baseline | Rationale |
-|---------|----------|-----------|
-| Syria, Ukraine, Yemen | 50 | Active conflict zones |
-| Myanmar, Venezuela, North Korea | 40-45 | Civil unrest, authoritarian |
-| Iran, Israel, Pakistan | 35-45 | Regional tensions |
-| Saudi Arabia, Turkey, India | 20-25 | Moderate instability |
-| Germany, UK, US | 5-10 | Stable democracies |
-
-**Unrest Component** (0–50 points): Recent protest and riot activity, weighted by event significance multiplier.
-
-**Information Component** (0–25 points): News coverage intensity (proxy for international attention).
-
-**Security Component** (0–25 points): Baseline plus riot contribution.
-
-### Event Significance Multipliers
-
-Events in some countries carry more global significance than others:
-
-| Multiplier | Countries | Rationale |
-|------------|-----------|-----------|
-| 3.0× | North Korea | Any visible unrest is highly unusual |
-| 2.0-2.5× | China, Russia, Iran, Saudi Arabia | Authoritarian states suppress protests |
-| 1.5-1.8× | Taiwan, Pakistan, Myanmar, Venezuela | Regional flashpoints |
-| 0.5-0.8× | US, UK, France, Germany | Protests are routine in democracies |
+Supplemental boosts and floors are documented in
+[CII Risk Scoring Methodology](methodology/cii-risk-scores.mdx), which is the
+canonical source for per-country baselines, event multipliers, and formula
+version changes.
 
 ### Strategic Risk Derivation
 
@@ -3140,12 +3048,14 @@ The top countries contribute most heavily, with diminishing influence for lower-
 
 ### Fallback Behavior
 
-When ACLED data is unavailable (API errors, rate limits, expired auth):
+When upstream data is unavailable (API errors, rate limits, expired auth):
 
-1. **Stale cache** (1-hour TTL): Return recent scores with `stale: true` flag
-2. **Baseline fallback**: Return scores using only static baseline values with `baseline: true` flag
+1. **Stale cache**: Return the latest versioned stale risk-score payload when available.
+2. **Baseline fallback**: Return scores using static baselines and available floors when no usable live or stale payload exists.
 
-This ensures the dashboard always displays meaningful data even during upstream outages.
+The relay CII warm-ping loop in `scripts/ais-relay.cjs` calls the RPC every
+8 minutes and writes `seed-meta:intelligence:risk-scores` when scores are
+returned, keeping the cache warm for bootstrap and health monitoring.
 
 ---
 
@@ -3654,7 +3564,7 @@ See [ROADMAP.md](ROADMAP.md) for detailed planning. Recent intelligence enhancem
 - ✅ **WebGL Map (deck.gl)** - High-performance rendering for desktop users
 - ✅ **Browser ML Fallback** - ONNX Runtime for offline summarization capability
 - ✅ **Multi-Signal Geographic Convergence** - Alerts when 3+ data types converge on same region within 24h
-- ✅ **Country Instability Index (CII)** - Real-time composite risk score for 20 Tier-1 countries
+- ✅ **Country Instability Index (CII)** - Real-time composite risk score for 31 Tier-1 countries
 - ✅ **Infrastructure Cascade Visualization** - Dependency graph showing downstream effects of disruptions
 - ✅ **Strategic Risk Overview** - Unified alert system with cross-module correlation and deduplication
 - ✅ **GDELT Topic Intelligence** - Categorized feeds for military, cyber, nuclear, and sanctions topics

--- a/docs/algorithms.mdx
+++ b/docs/algorithms.mdx
@@ -9,7 +9,7 @@ description: "Detailed documentation of World Monitor's scoring formulas, detect
 
 ### Country Instability Index (CII)
 
-Every country with incoming event data receives a live instability score (0-100). 24 curated tier-1 nations (US, Russia, China, Ukraine, Iran, Israel, Taiwan, North Korea, Saudi Arabia, Turkey, Poland, Germany, France, UK, India, Pakistan, Syria, Yemen, Myanmar, Venezuela, Cuba, Mexico, Brazil, UAE) have individually tuned baseline risk profiles and keyword lists. All other countries that generate any signal (protests, conflicts, outages, displacement flows, climate anomalies) are scored automatically using a universal default baseline (`DEFAULT_BASELINE_RISK = 15`, `DEFAULT_EVENT_MULTIPLIER = 1.0`).
+Every Tier-1 country receives a live instability score (0-100). CII v3 tracks 31 Tier-1 countries with shared server/frontend `baselineRisk` and `eventMultiplier` coefficients: US, Russia, China, Ukraine, Iran, Israel, Taiwan, North Korea, Saudi Arabia, Turkey, Poland, Germany, France, UK, India, Pakistan, Syria, Yemen, Myanmar, Venezuela, Cuba, Mexico, Brazil, UAE, South Korea, Iraq, Afghanistan, Lebanon, Egypt, Japan, and Qatar. Countries outside the curated Tier-1 set use the default editorial coefficients when they are scored by supporting systems (`DEFAULT_CII_BASELINE_RISK = 15`, `DEFAULT_CII_EVENT_MULTIPLIER = 1.0`).
 
 The server-side score (`get-risk-scores.ts`) uses the same formulas as the frontend (`country-instability.ts`):
 
@@ -22,15 +22,15 @@ The server-side score (`get-risk-scores.ts`) uses the same formulas as the front
 
 **Conflict score** (0-100): Weighted ACLED events (battles x3, explosions x4, civilian violence x5, capped at 50), sqrt-scaled fatalities (up to 40), civilian boost (up to 10), Iran strike boost with severity weighting (up to 50), and OREF alert boost for Israel (25 base + 5 per active alert, up to 50 total). Rolling 24-hour history adds a secondary boost: 3-9 alerts contribute +5, 10+ contribute +10 to the blended score.
 
-**Security score** (0-100): GPS/GNSS jamming (high: 5pts, medium: 2pts per hex, capped at 35). Jamming classification thresholds: Low 0-2% (hidden), Medium 2-10% (amber), High >10% (red).
+**Security score** (0-100): Military flights (3pts each, capped at 50), military vessels (5pts each, capped at 30), aviation closures/delays (severity-weighted, capped at 40), and GPS/GNSS jamming (high: 5pts, medium: 2pts per hex, capped at 35). Foreign military presence is weighted ×2.
 
-**Information score**: Reserved (0); no server-side news data available.
+**Information score** (0-100): Country-attributed classified news pressure from top-story country attribution and threat summaries. Critical/high/medium headlines contribute with descending weights; info-level headlines do not move the score.
 
 **Floors**: UCDP active war pins score at >= 70, UCDP minor conflict at >= 50. Travel advisory do-not-travel pins at >= 60, reconsider at >= 50.
 
-**Boosts**: Advisory boost (+15 do-not-travel, +10 reconsider, +5 caution), OREF blend boost for Israel (+15 active alerts, +5/10 based on 24h history count), climate severity (up to +15), cyber threats (up to +10), wildfires (up to +8).
+**Boosts**: Advisory boost (+15 do-not-travel, +10 reconsider, +5 caution), OREF blend boost for Israel (+15 active alerts, +5/10 based on 24h history count), climate severity (up to +15), cyber threats (up to +12), wildfires (up to +8), displacement (up to +20), news urgency (up to +5), earthquakes (up to +25), sanctions (up to +14), and AIS disruptions (up to +10).
 
-See [CII Risk Scoring Methodology](/methodology/cii-risk-scores) for the published per-country `baselineRisk` and `eventMultiplier` tables, the strategic-risk band derivation, and the known 7-country server vs frontend drift.
+See [CII Risk Scoring Methodology](/methodology/cii-risk-scores) for the published per-country `baselineRisk` and `eventMultiplier` tables, the v3 formula, and the strategic-risk band derivation.
 
 ### Hotspot Escalation Scoring
 
@@ -60,6 +60,8 @@ compositeScore =
   + infraScore       × 0.20     // infrastructure cascade incidents
   + theaterBoost     (0–25)     // military asset density + strike packaging
   + breakingBoost    (0–15)     // breaking news severity injection
+  + sanctionsScore   (0–10)     // sanctions pressure and targeted-asset activity
+  + radiationScore   (0–12)     // radiation-watch spikes and corroboration
 ```
 
 **Sub-scores**:
@@ -69,6 +71,8 @@ compositeScore =
 - `infraScore` — `min(100, cascadeAlertCount × 25)`. Each infrastructure cascade incident contributing 25 points
 - `theaterBoost` — For each theater posture summary: `min(10, floor((aircraft + vessels) / 5))` + 5 if strike-capable (tanker + AWACS + fighters co-present). Summed across theaters, capped at 25. Halved when posture data is stale
 - `breakingBoost` — Critical breaking news alerts add 15 points, high adds 8, capped at 15. Breaking alerts expire after 30 minutes
+- `sanctionsScore` — Up to 10 points from new sanctions entries, largest-country entry volume, and sanctioned vessel/aircraft counts
+- `radiationScore` — Up to 12 points from radiation-watch spikes, elevated readings, and corroborated observations, reduced by low-confidence or conflicting observations
 
 **Alert fusion**: Alerts from convergence detection, CII spikes (≥10-point change), and infrastructure cascades are merged when they occur within a 2-hour window and are within 200km or in the same country. Merged alerts carry the highest priority and combine summaries. The alert queue caps at 50 entries with 24-hour pruning.
 

--- a/docs/country-instability-index.mdx
+++ b/docs/country-instability-index.mdx
@@ -1,180 +1,125 @@
 ---
 title: "Country Instability Index"
-description: "Real-time stability scoring for 24 strategically significant countries, combining unrest, security, and information signals into a dynamic instability metric."
+description: "Real-time CII v3 stability scoring for 31 Tier-1 countries, combining baseline risk with unrest, conflict, security, and information signals."
 ---
-The Country Instability Index maintains a real-time instability score for strategically significant countries. Rather than relying on static risk ratings, the CII dynamically reflects current conditions based on multiple input streams.
+The Country Instability Index (CII) maintains a high-frequency instability
+score for the 31 Tier-1 countries tracked by the Strategic Risk API. Rather
+than relying on static ratings, CII blends an editorial baseline with live
+event pressure and publishes the result through the server-side
+`GetRiskScores` RPC.
 
-## Monitored Countries (Tier 1)
+For the full v3 formula, coefficient table, and change history, see
+[CII Risk Scoring Methodology](/methodology/cii-risk-scores). This page is
+the operator-facing overview.
+
+## Monitored Countries
+
+The current Tier-1 set is:
 
 | Region | Countries |
 |--------|-----------|
 | **Americas** | United States, Venezuela, Brazil, Mexico, Cuba |
 | **Europe** | Germany, France, United Kingdom, Poland |
 | **Eastern Europe** | Russia, Ukraine |
-| **Middle East** | Iran, Israel, Saudi Arabia, United Arab Emirates, Turkey, Syria, Yemen |
-| **Asia-Pacific** | China, Taiwan, North Korea, India, Pakistan, Myanmar |
+| **Middle East** | Iran, Israel, Saudi Arabia, United Arab Emirates, Turkey, Syria, Yemen, Iraq, Lebanon, Egypt, Qatar |
+| **Asia-Pacific** | China, Taiwan, North Korea, India, Pakistan, Myanmar, South Korea, Japan |
+| **Central/South Asia** | Afghanistan |
 
-## Three Component Scores
+## Score Model
 
-Each country's CII is computed from three weighted components:
-
-| Component | Weight | Data Sources | What It Measures |
-|-----------|--------|--------------|------------------|
-| **Unrest** | 40% | ACLED protests, GDELT events | Civil unrest intensity, fatalities, event severity |
-| **Security** | 30% | Military flights, naval vessels | Unusual military activity patterns |
-| **Information** | 30% | News velocity, alert clusters | Media attention intensity and acceleration |
-
-## Scoring Algorithm
+Each country's score combines a static baseline with a dynamic event score:
 
 ```
-Unrest Score:
-  base = min(50, protest_count × 8)
-  fatality_boost = min(30, total_fatalities × 5)
-  severity_boost = min(20, high_severity_count × 10)
-  unrest = min(100, base + fatality_boost + severity_boost)
+eventScore = Unrest * 0.25
+           + Conflict * 0.30
+           + Security * 0.20
+           + Information * 0.25
 
-Security Score:
-  flight_score = min(50, military_flights × 3)
-  vessel_score = min(30, naval_vessels × 5)
-  security = min(100, flight_score + vessel_score)
-
-Information Score:
-  base = min(40, news_count × 5)
-  velocity_boost = min(40, avg_velocity × 10)
-  alert_boost = 20 if any_alert else 0
-  information = min(100, base + velocity_boost + alert_boost)
-
-Final CII = round(unrest × 0.4 + security × 0.3 + information × 0.3)
+combinedScore = baselineRisk * 0.40
+              + eventScore * 0.60
+              + supplemental boosts
 ```
 
-## Scoring Bias Prevention
+The result is clamped by active conflict and travel-advisory floors, then
+bounded to 0-100.
 
-Raw news volume creates a natural bias: English-language media generates far more coverage of the US, UK, and Western Europe than conflict zones. Without correction, stable democracies would consistently score higher than actual crisis regions.
+| Component | What It Measures | Main Inputs |
+|-----------|------------------|-------------|
+| **Unrest** | Civil disorder pressure before or below open conflict | ACLED protests and riots, protest fatalities, high-severity unrest, internet/power outages |
+| **Conflict** | Kinetic violence and strike activity | ACLED battles, explosions, violence against civilians, fatalities, Iran-region strike intensity, OREF alerts for Israel |
+| **Security** | Hard-security tempo near the country | Military flights, military vessels, aviation closures/delays, GPS/GNSS jamming |
+| **Information** | Information-environment pressure | Classified news headlines and country-attributed threat summaries |
 
-### Log Scaling for High-Volume Countries
+## Boosts And Floors
 
-Countries with high media coverage receive logarithmic dampening on their unrest and information scores:
+Supplemental boosts can raise the blended score when corroborating signals
+arrive outside the base event components:
 
-```
-if (newsVolume > threshold):
-  dampingFactor = 1 / (1 + log10(newsVolume / threshold))
-  score = rawScore × dampingFactor
-```
+| Boost | Max | Trigger |
+|-------|----:|---------|
+| Climate anomalies | 15 | Country-attributed climate severity |
+| Cyber threats | 12 | Severity-weighted cyber threat counts |
+| Wildfires | 8 | High-brightness and total fire counts |
+| Travel advisories | 15 | Do-not-travel, reconsider, or caution advisories |
+| OREF blend | 25 | Active and 24-hour Israel alert pressure |
+| Displacement | 20 | Log-scaled humanitarian displacement |
+| News urgency | 5 | High Information component pressure |
+| Earthquakes | 25 | Significant, major, or severe earthquakes |
+| Sanctions | 14 | Sanctions entry volume and new-entry activity |
+| AIS disruptions | 10 | Maritime disruption buckets |
 
-This ensures the US receiving 50 news mentions about routine political activity doesn't outscore Ukraine with 10 mentions about active combat.
+The score floor is the larger of UCDP conflict floors and State Department
+advisory floors:
 
-### Conflict Zone Floor Scores
-
-Active conflict zones have minimum score floors that prevent them from appearing stable during data gaps or low-coverage periods:
-
-| Country | Floor | Rationale |
-|---------|-------|-----------|
-| Ukraine | 55 | Active war with Russia |
-| Syria | 50 | Ongoing civil war |
-| Yemen | 50 | Ongoing civil war |
-| Myanmar | 45 | Military coup, civil conflict |
-| Israel | 45 | Active Gaza conflict |
-
-The floor applies *after* the standard calculation. If the computed score exceeds the floor, the computed score is used. This prevents false "all clear" signals while preserving sensitivity to actual escalations.
+| Floor | Threshold |
+|-------|----------:|
+| UCDP active war | 70 |
+| UCDP minor conflict | 50 |
+| Do-not-travel advisory | 60 |
+| Reconsider-travel advisory | 50 |
 
 ## Instability Levels
 
-| Level | Score Range | Visual | Meaning |
-|-------|-------------|--------|---------|
-| **Critical** | 81-100 | Red | Active crisis or major escalation |
-| **High** | 66-80 | Orange | Significant instability requiring close monitoring |
-| **Elevated** | 51-65 | Yellow | Above-normal activity patterns |
-| **Normal** | 31-50 | Gray | Baseline geopolitical activity |
-| **Low** | 0-30 | Green | Unusually quiet period |
+| Level | Score Range | Meaning |
+|-------|-------------|---------|
+| **Critical** | 81-100 | Active crisis or major escalation |
+| **High** | 66-80 | Significant instability requiring close monitoring |
+| **Elevated** | 51-65 | Above-normal activity patterns |
+| **Normal** | 31-50 | Baseline geopolitical activity |
+| **Low** | 0-30 | Unusually quiet period |
 
-## Trend Detection
+## Bias Prevention
 
-The CII tracks 24-hour changes to identify trajectory:
+CII is intentionally not a raw media-volume index. The v3 model separates
+news pressure from conflict scoring, applies lower event multipliers and log
+dampening in high-observability countries, and uses conflict/advisory floors
+so active crises do not appear quiet during data gaps.
 
-- **Rising**: Score increased by ≥5 points (escalating situation)
-- **Stable**: Change within ±5 points (steady state)
-- **Falling**: Score decreased by ≥5 points (de-escalation)
-
-## Contextual Score Boosts
-
-Beyond the base component scores, several contextual factors can boost a country's CII score (up to a combined maximum of 23 additional points):
-
-| Boost Type | Max Points | Condition | Purpose |
-|------------|------------|-----------|---------|
-| **Hotspot Activity** | 10 | Events near defined hotspots | Captures localized escalation |
-| **News Urgency** | 5 | Information component ≥50 | High media attention indicator |
-| **Focal Point** | 8 | AI focal point detection on country | Multi-source convergence indicator |
-
-**Hotspot Boost Calculation**:
-
-- Hotspot activity (0-100) scaled by 1.5x then capped at 10
-- Zero boost for countries with no associated hotspot activity
-
-**News Urgency Boost Tiers**:
-
-- Information ≥70: +5 points
-- Information ≥50: +3 points
-- Information &lt;50: +0 points
-
-**Focal Point Boost Tiers**:
-
-- Critical urgency: +8 points
-- Elevated urgency: +4 points
-- Normal urgency: +0 points
-
-These boosts are designed to elevate scores only when corroborating evidence exists. A country must have both high base scores AND contextual signals to reach extreme levels.
-
-See [Geographic Convergence](/geographic-convergence) for the full algorithm.
+The editorial rationale and per-country `baselineRisk` / `eventMultiplier`
+values are published in
+[CII Risk Scoring Methodology](/methodology/cii-risk-scores).
 
 ## Server-Side Pre-Computation
 
-To eliminate the "cold start" problem where new users would see blank data during the Learning Mode warmup, CII scores are **pre-computed server-side** via the `/api/risk-scores` endpoint. See the [Server-Side Risk Score API](/strategic-risk#server-side-risk-score-api) section for details.
+CII scores are computed server-side by `GET /api/intelligence/v1/get-risk-scores`
+and cached in Redis. The live cache is versioned by the current
+`methodology_version` (`v3`), with a stale-cache key used as a fallback during
+upstream outages.
 
-## Learning Mode (15-Minute Warmup)
+The Railway relay process also runs an active CII warm-ping loop every 8
+minutes against the same RPC. That keeps the server-side risk-score cache warm
+for bootstrap and health monitoring while preserving the RPC handler as the
+scoring source of truth.
 
-On dashboard startup, the CII system enters **Learning Mode**, a 15-minute calibration period where scores are calculated but alerts are suppressed. This prevents the flood of false-positive alerts that would otherwise occur as the system establishes baseline values.
+## Trend Detection
 
-**Note**: Server-side pre-computation now provides immediate scores to new users. Learning Mode primarily affects client-side dynamic adjustments and alert generation rather than initial score display.
+The dashboard tracks recent score changes to identify trajectory:
 
-**Why 15 minutes?** Real-world testing showed that CII scores stabilize after approximately 10-20 minutes of data collection. The 15-minute window provides sufficient time for:
+- **Rising**: score increased by at least 5 points
+- **Stable**: change is within 5 points
+- **Falling**: score decreased by at least 5 points
 
-- Multiple refresh cycles across all data sources
-- Trend detection to establish direction (rising/stable/falling)
-- Cross-source correlation to normalize bias
-
-### Visual Indicators
-
-During Learning Mode, the dashboard provides clear visual feedback:
-
-| Location | Indicator |
-|----------|-----------|
-| **CII Panel** | Yellow banner with progress bar and countdown timer |
-| **Strategic Risk Overview** | "Learning Mode - Xm until reliable" status |
-| **Score Display** | Scores shown at 60% opacity (dimmed) |
-
-### Behavior
-
-```
-Minutes 0-15: Learning Mode Active
-  - CII scores calculated and displayed (dimmed)
-  - Trend detection active (stores baseline)
-  - All CII-related alerts suppressed
-  - Progress bar fills as time elapses
-
-After 15 minutes: Learning Complete
-  - Full opacity scores
-  - Alert generation enabled (threshold ≥10 point change)
-  - "All data sources active" status shown
-```
-
-This ensures users understand that early scores are provisional while preventing alert fatigue during the calibration period.
-
-## Keyword Attribution
-
-Countries are matched to data via keyword lists:
-
-- **Russia**: `russia`, `moscow`, `kremlin`, `putin`
-- **China**: `china`, `beijing`, `xi jinping`, `prc`
-- **Taiwan**: `taiwan`, `taipei`
-
-This enables attribution of news and events to specific countries even when formal country codes aren't present in the source data.
+During initial dashboard startup, Learning Mode suppresses noisy early CII
+alerts while data and trend baselines settle. Server-side pre-computation means
+users still receive immediate scores; Learning Mode primarily affects local
+alert generation.

--- a/docs/features.mdx
+++ b/docs/features.mdx
@@ -99,7 +99,7 @@ Beyond raw data feeds, the dashboard provides synthesized intelligence panels:
 |-------|---------|
 | **AI Strategic Posture** | Theater-level military aggregation with strike capability analysis |
 | **Strategic Risk Overview** | Composite risk score combining all intelligence modules |
-| **Country Instability Index** | Real-time stability scores for 24 monitored countries |
+| **Country Instability Index** | Real-time CII v3 stability scores for 31 Tier-1 countries |
 | **Infrastructure Cascade** | Dependency analysis for cables, pipelines, and chokepoints |
 | **Live Intelligence** | GDELT-powered topic feeds (Military, Cyber, Nuclear, Sanctions) |
 | **Intel Feed** | Curated defense and security news sources |
@@ -245,7 +245,7 @@ Two full-screen, keyboard-first workflows complement the map + panels experience
 
 Two complementary country-scoring surfaces:
 
-- **[Country Instability Index](/country-instability-index)** — a high-frequency stress score that blends conflict, unrest, news velocity, and security signals for a curated country set.
+- **[Country Instability Index](/country-instability-index)** — a high-frequency CII v3 stress score that blends unrest, conflict, security, and information signals for 31 Tier-1 countries.
 - **[Country Resilience Index](/methodology/country-resilience-index)** — a 0-100 resilience score for the 196-country public rankable universe across 6 domains and 20 active dimensions (grouped into 3 pillars: structural readiness, live shock exposure, recovery capacity; plus 2 retired dimensions kept for schema continuity), refreshed every 6 hours and sourced from official/authoritative providers with transparent imputation.
 
 CII and CRI answer different questions and are not interchangeable: CII is short-horizon stress; CRI is structural resilience plus live shock exposure.

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -38,7 +38,7 @@ The primary variant focuses on geopolitical intelligence, military tracking, and
 |-------|---------|
 | **AI Insights** | LLM-synthesized world brief with focal point detection |
 | **AI Strategic Posture** | Theater-level military force aggregation with strike capability assessment |
-| **Country Instability Index** | Real-time stability scores for 24 monitored countries |
+| **Country Instability Index** | Real-time CII v3 stability scores for 31 Tier-1 countries |
 | **Strategic Risk Overview** | Composite risk score combining all intelligence modules |
 | **Infrastructure Cascade** | Dependency analysis for cables, pipelines, and chokepoints |
 | **Live Intelligence** | GDELT-powered topic feeds (Military, Cyber, Nuclear, Sanctions) |

--- a/docs/strategic-risk.mdx
+++ b/docs/strategic-risk.mdx
@@ -2,7 +2,7 @@
 title: "Strategic Risk"
 description: "Composite risk scoring that synthesizes all intelligence modules into a unified strategic assessment, including the Pentagon Pizza Index and server-side risk computation."
 ---
-The Strategic Risk system provides a composite dashboard that synthesizes all intelligence modules into a single risk assessment, combining convergence detection, country instability, and infrastructure monitoring into actionable risk levels.
+The Strategic Risk system provides a composite dashboard that synthesizes all intelligence modules into a single risk assessment, combining convergence detection, country instability, infrastructure monitoring, theater posture, and breaking-news pressure into actionable risk levels.
 
 ## Strategic Risk Overview
 
@@ -10,13 +10,31 @@ The Strategic Risk Overview synthesizes all intelligence modules into a single r
 
 ### Composite Score (0-100)
 
-The strategic risk score combines three components:
+The Strategic Risk panel combines map-side convergence and infrastructure
+signals with the server-side CII roll-up:
 
-| Component | Weight | Calculation |
-|-----------|--------|-------------|
-| **Convergence** | 40% | `min(100, convergence_zones × 20)` |
-| **CII Deviation** | 35% | `min(100, avg_deviation × 2)` |
-| **Infrastructure** | 25% | `min(100, incidents × 25)` |
+```
+compositeScore =
+    convergenceScore * 0.30
+  + ciiRiskScore     * 0.50
+  + infraScore       * 0.20
+  + theaterBoost
+  + breakingBoost
+  + sanctionsScore
+  + radiationScore
+```
+
+The server-side Strategic Risk API derives its global score from the weighted
+top 5 CII countries. See
+[CII Risk Scoring Methodology](/methodology/cii-risk-scores#3-strategic-risk-roll-up)
+for the exact top-5 weights, scale factor, and severity bands.
+
+Additional additive terms come from sanctions pressure and radiation-watch
+signals when those modules have fresh data: `sanctionsScore` is capped at 10
+from new sanctions entries, largest-country entry volume, and sanctioned
+vessel/aircraft counts; `radiationScore` is capped at 12 from radiation-watch
+spikes, elevated readings, and corroborated observations, reduced by
+low-confidence or conflicting observations.
 
 ### Risk Levels
 
@@ -159,35 +177,26 @@ Strategic risk and Country Instability Index (CII) scores are pre-computed serve
 
 The `GetRiskScores` RPC handler (`get-risk-scores.ts`):
 
-1. Fetches recent protest/riot/battle/explosion/civilian-violence data from ACLED (7-day window)
-2. Fetches auxiliary sources from Redis: UCDP conflicts, outages, climate, cyber threats, fires, GPS jamming, Iran events, OREF alerts
-3. Computes CII scores for 24 Tier 1 countries using the same formulas as the frontend
-4. Derives strategic risk from weighted top-5 CII scores
-5. Caches results in Redis (10-minute TTL, 1-hour stale fallback)
+1. Fetches recent protest/riot/battle/explosion/civilian-violence data from ACLED.
+2. Fetches auxiliary sources from Redis, including UCDP conflicts, outages, climate, cyber threats, fires, GPS jamming, Iran events, OREF alerts, advisories, displacement, classified news summaries, aviation alerts, earthquakes, sanctions, and military/AIS CII aggregates.
+3. Computes CII v3 scores for 31 Tier-1 countries using the shared coefficient table documented in [CII Risk Scoring Methodology](/methodology/cii-risk-scores).
+4. Derives Strategic Risk from the weighted top 5 CII scores.
+5. Caches results in Redis with versioned live and stale keys tied to the current CII formula version.
 
 ### CII Score Calculation
 
 Each country's score combines a static baseline (40%) with a dynamic event score (60%), plus supplemental boosts and floors.
 
-**Baseline Risk** (0-50 points): Static geopolitical risk reflecting structural fragility.
-
-| Country | Baseline | Rationale |
-|---------|----------|-----------|
-| Syria, Ukraine, Yemen | 50 | Active conflict zones |
-| Myanmar, North Korea, Cuba | 45 | Civil unrest, authoritarian |
-| Iran, Israel, Pakistan, Venezuela, Mexico | 35-40 | Regional tensions, organized crime |
-| Taiwan, Saudi Arabia, Turkey, Russia, China, India | 20-35 | Moderate instability |
-| Brazil, Mexico | 15-35 | Variable instability |
-| Germany, UK, US, France, Poland, UAE | 5-10 | Stable/low risk |
+**Baseline Risk** (0-50 points): Static geopolitical risk reflecting structural fragility. The canonical per-country values live in [CII Risk Scoring Methodology](/methodology/cii-risk-scores#2-per-country-baselinerisk-and-eventmultiplier).
 
 **Event Score** blends four sub-components:
 
 | Sub-component | Weight | Scoring |
 |---------------|--------|---------|
-| Unrest | 25% | Log2 dampening for democracies (multiplier &lt; 0.7), linear for authoritarian states. Base capped at 50, plus protest fatality boost (up to 30), plus outage severity boost (TOTAL 30pts, MAJOR 15pts, PARTIAL 5pts, capped at 50) |
-| Conflict | 30% | Weighted ACLED events (battles x3, explosions x4, civilian violence x5), sqrt-scaled fatalities, civilian boost, Iran strike severity, OREF alert boost (IL only: 25 base + 5 per alert) |
-| Security | 20% | GPS/GNSS jamming hexes (high: 5pts, medium: 2pts, capped at 35) |
-| Information | 25% | Reserved (0); no server-side news data |
+| Unrest | 25% | ACLED protests/riots, protest fatalities, high-severity unrest, and outage severity |
+| Conflict | 30% | Weighted ACLED battles/explosions/civilian violence, fatalities, Iran strike severity, and OREF alert pressure |
+| Security | 20% | Military flights, military vessels, aviation closures/delays, and GPS/GNSS jamming |
+| Information | 25% | Classified news headlines and country-attributed threat summaries |
 
 **Floors** (minimum score guarantees):
 
@@ -198,7 +207,7 @@ Each country's score combines a static baseline (40%) with a dynamic event score
 | Advisory do-not-travel | >= 60 | UA, SY, YE, MM |
 | Advisory reconsider | >= 50 | IL, IR, PK, VE, CU, MX |
 
-**Supplemental Boosts**: Advisory boost (+15/+10/+5), OREF blend boost for IL (+15 active + history tiers), climate (+15 max), cyber (+10 max), fires (+8 max).
+**Supplemental Boosts**: Advisory boost (+15/+10/+5), OREF blend boost for IL (+15 active + history tiers), climate (+15 max), cyber (+12 max), fires (+8 max), displacement (+20 max), news urgency (+5 max), earthquakes (+25 max), sanctions (+14 max), and AIS disruptions (+10 max).
 
 ### Event Significance Multipliers
 
@@ -229,19 +238,28 @@ The top countries contribute most heavily, with diminishing influence for lower-
 |--------|-----------|----------|
 | ACLED | Fetched live via API | Protests, riots, battles, explosions, civilian violence, fatalities |
 | UCDP | `conflict:ucdp-events:v1` | War/minor conflict floors |
-| Outages | `infra:outages:v1` | Unrest outage boost (TOTAL/MAJOR/PARTIAL severity) |
+| Outages | `infra:outages:v1` | Unrest outage boost |
 | Climate | `climate:anomalies:v2` | Climate severity boost |
-| Cyber | `cyber:threats-bootstrap:v2` | Cyber threat count boost |
-| Fires | `wildfire:fires:v1` | Wildfire count boost |
-| GPS Jamming | `intelligence:gpsjam:v2` | Security score (high/medium hex levels) |
+| Cyber | `cyber:threats-bootstrap:v2` | Severity-weighted cyber boost |
+| Fires | `wildfire:fires:v1` | Severity-weighted wildfire boost |
+| GPS Jamming | `intelligence:gpsjam:v2` | Security score |
+| Military CII | Relay/seeded military aggregate | Security score and AIS disruption boost |
+| Aviation Alerts | Seeded aviation disruption data | Security score |
 | Iran Events | `conflict:iran-events:v1` | Strike boost with severity weighting |
-| OREF Alerts | `relay:oref:history:v1` | IL conflict boost + blend boost (activeAlertCount, historyCount24h) |
+| OREF Alerts | `relay:oref:history:v1` | IL conflict boost and blend boost |
+| News Threats | Classified headline summaries | Information score and news urgency boost |
+| Displacement | Humanitarian displacement aggregate | Displacement boost |
+| Earthquakes | Earthquake feed | Earthquake boost |
+| Sanctions | Sanctions country aggregate | Sanctions boost |
 
 ### Fallback Behavior
 
 When upstream data is unavailable (API errors, rate limits):
 
-1. **Stale cache** (1-hour TTL): Return recent scores
-2. **Baseline fallback**: Return scores using only static baselines and advisory floors
+1. **Stale cache**: Return the latest versioned stale risk-score payload when available.
+2. **Baseline fallback**: Return scores using static baselines and available floors when no usable live or stale payload exists.
 
-This ensures the dashboard always displays meaningful data even during upstream outages. The relay CII seed loop is disabled; the RPC handler computes scores on-demand with `cachedFetchJson` coalescing concurrent requests.
+The relay CII warm-ping loop is active in `scripts/ais-relay.cjs`: it calls
+`/api/intelligence/v1/get-risk-scores` every 8 minutes, lets the RPC handler
+refresh live/stale cache state, and writes `seed-meta:intelligence:risk-scores`
+for health monitoring when scores are returned.

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -644,6 +644,42 @@ describe('CII scoring', () => {
       `methodology doc must mention current CII_FORMULA_VERSION '${CII_FORMULA_VERSION}' — bump the version and update the doc together.`);
   });
 
+  it('current public CII docs do not reintroduce pre-v3 stale claims', () => {
+    const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+    const publicDocPaths = [
+      'docs/country-instability-index.mdx',
+      'docs/strategic-risk.mdx',
+      'docs/algorithms.mdx',
+      'docs/overview.mdx',
+      'docs/features.mdx',
+      'docs/COMMUNITY-PROMOTION-GUIDE.md',
+    ];
+    const stalePatterns = [
+      /\b(?:20|22|24)\s+(?:curated\s+)?(?:monitored\s+|strategically\s+significant\s+)?(?:Tier[- ]?1\s+)?(?:countries|nations)\b/i,
+      /\b(?:20|22|24)\s+(?:curated\s+)?tier[- ]?1\b/i,
+      /Information\s+score:\s+Reserved\s+\(0\)/i,
+      /Information\s*\|\s*25%\s*\|\s*Reserved\s+\(0\)/i,
+      /known\s+7-country\s+server\s+vs\s+frontend\s+drift/i,
+      /relay\s+CII\s+seed\s+loop\s+is\s+disabled/i,
+      /GPS[-/ ]only\s+security/i,
+      /GPS\s+jamming\s+only/i,
+    ];
+
+    const violations: string[] = [];
+    for (const relPath of publicDocPaths) {
+      const text = readFileSync(resolve(root, relPath), 'utf8');
+      for (const pattern of stalePatterns) {
+        if (pattern.test(text)) violations.push(`${relPath}: ${pattern}`);
+      }
+    }
+
+    assert.equal(
+      violations.length,
+      0,
+      `public CII docs contain pre-v3 stale claims:\n  ${violations.join('\n  ')}`,
+    );
+  });
+
   it('methodology doc and browser CII engine expose the v3 conflict curve coefficients', () => {
     const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
     const doc = readFileSync(resolve(root, 'docs', 'methodology', 'cii-risk-scores.mdx'), 'utf8');


### PR DESCRIPTION
## Summary
- align public CII and Strategic Risk docs with CII v3: 31 Tier-1 countries, four components, current boosts/floors, and active relay warm-ping behavior
- reduce duplicated formula detail in stale docs and point to the canonical CII methodology page
- add a public-doc drift guard for stale pre-v3 CII wording and broaden the stale count checks

## Validation
- ./node_modules/.bin/tsx --test tests/cii-scoring.test.mts
- node --test tests/mdx-lint.test.mjs
- ./node_modules/.bin/markdownlint-cli2 docs/COMMUNITY-PROMOTION-GUIDE.md
- targeted stale-phrase rg sweep
- git diff --check
- pre-push hook on git push (typecheck, api typecheck, boundaries, safe-html, rate-limit policies, premium-fetch parity, changed tests, markdown lint, MDX lint, version sync)