### PR TITLE
Fix risk scores region filter contract

### DIFF
--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -815,6 +815,33 @@ export function computeStrategicRisks(ciiScores: CiiScore[]): StrategicRisk[] {
   ];
 }
 
+export function normalizeRiskScoreRegion(region: string | undefined | null): string | null {
+  const normalized = String(region || '').trim().toUpperCase();
+  return /^[A-Z]{2}$/.test(normalized) ? normalized : null;
+}
+
+function hasRiskScoreRegionFilter(region: string | undefined | null): boolean {
+  return String(region || '').trim() !== '';
+}
+
+export function filterRiskScoresResponse(
+  response: GetRiskScoresResponse,
+  region: string | undefined | null,
+): GetRiskScoresResponse {
+  if (!hasRiskScoreRegionFilter(region)) return response;
+  const normalizedRegion = normalizeRiskScoreRegion(region);
+  if (!normalizedRegion) return { ciiScores: [], strategicRisks: [] };
+
+  return {
+    ciiScores: response.ciiScores.filter((score) => score.region.toUpperCase() === normalizedRegion),
+    // StrategicRisk is currently a global top-N roll-up. Recomputing it over a
+    // single filtered country would still label the result "global", so a
+    // region-filtered response only returns region-specific strategic risks if
+    // such risks are added later.
+    strategicRisks: response.strategicRisks.filter((risk) => risk.region.toUpperCase() === normalizedRegion),
+  };
+}
+
 // ========================================================================
 // Cache keys
 // ========================================================================
@@ -838,7 +865,7 @@ const RISK_STALE_TTL = 3600;
 
 export async function getRiskScores(
   _ctx: ServerContext,
-  _req: GetRiskScoresRequest,
+  req: GetRiskScoresRequest,
 ): Promise<GetRiskScoresResponse> {
   try {
     const { data: result, source } = await cachedFetchJsonWithMeta<GetRiskScoresResponse>(
@@ -887,13 +914,13 @@ export async function getRiskScores(
           ).catch(() => {});
         }
       }
-      return result;
+      return filterRiskScoresResponse(result, req.region);
     }
   } catch { /* upstream failed, fall through to stale */ }
 
   const stale = (await getCachedJson(RISK_STALE_CACHE_KEY)) as GetRiskScoresResponse | null;
-  if (stale) return stale;
+  if (stale) return filterRiskScoresResponse(stale, req.region);
   const emptyAux: AuxiliarySources = { ucdpEvents: [], outages: [], climate: [], cyber: [], fires: [], gpsHexes: [], iranEvents: [], orefData: null, advisories: null, displacedByIso3: {}, newsTopStories: [], threatSummaryByCountry: null, aviationAlerts: [], earthquakes: [], sanctionsCountries: [], temporalAnomalies: [], militaryCii: null };
   const ciiScores = computeCIIScores([], emptyAux);
-  return { ciiScores, strategicRisks: computeStrategicRisks(ciiScores) };
+  return filterRiskScoresResponse({ ciiScores, strategicRisks: computeStrategicRisks(ciiScores) }, req.region);
 }

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -856,6 +856,9 @@ export function filterRiskScoresResponse(
 // not the payload itself.
 const RISK_CACHE_KEY = 'risk:scores:sebuf:v3';
 const RISK_STALE_CACHE_KEY = 'risk:scores:sebuf:stale:v3';
+// `region` is deliberately excluded from the Redis key: this endpoint caches
+// the all-country payload once and applies any region filter as a read-only
+// projection at return time, so per-region requests cannot poison global cache.
 const RISK_CACHE_TTL = 600;
 const RISK_STALE_TTL = 3600;
 

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -20,6 +20,7 @@ import {
   EVENT_MULTIPLIER,
   computeCIIScores,
   computeStrategicRisks,
+  filterRiskScoresResponse,
 } from '../server/worldmonitor/intelligence/v1/get-risk-scores.ts';
 import {
   CII_BASELINE_RISK as SHARED_BASELINE_RISK,
@@ -536,6 +537,44 @@ describe('CII scoring', () => {
     // STRATEGIC_RISK_SCALE_FACTOR sanity (used in the doc).
     assert.equal(STRATEGIC_RISK_SCALE_FACTOR, 0.7,
       `STRATEGIC_RISK_SCALE_FACTOR is documented as 0.7 — bump CII_FORMULA_VERSION and update docs/methodology/cii-risk-scores.mdx if changing.`);
+  });
+
+  it('region filter normalizes ISO2 input and omits global strategic risk', () => {
+    const ciiScores = computeCIIScores([], emptyAux());
+    const response = {
+      ciiScores,
+      strategicRisks: computeStrategicRisks(ciiScores),
+    };
+
+    const filtered = filterRiskScoresResponse(response, ' us ');
+    assert.equal(filtered.ciiScores.length, 1);
+    assert.equal(filtered.ciiScores[0]!.region, 'US');
+    assert.deepEqual(filtered.strategicRisks, [],
+      'country-filtered responses must not relabel the global strategic roll-up as country-scoped');
+    assert.equal(response.ciiScores.length, ciiScores.length,
+      'filtering is a post-cache projection and must not mutate the cached all-country payload');
+    assert.equal(response.strategicRisks.length, 1);
+  });
+
+  it('region filter returns empty arrays for unknown ISO2 regions', () => {
+    const ciiScores = computeCIIScores([], emptyAux());
+    const filtered = filterRiskScoresResponse(
+      { ciiScores, strategicRisks: computeStrategicRisks(ciiScores) },
+      'zz',
+    );
+
+    assert.deepEqual(filtered, { ciiScores: [], strategicRisks: [] });
+  });
+
+  it('region filter leaves empty requests on the all-country response and rejects malformed non-empty input', () => {
+    const ciiScores = computeCIIScores([], emptyAux());
+    const response = {
+      ciiScores,
+      strategicRisks: computeStrategicRisks(ciiScores),
+    };
+
+    assert.equal(filterRiskScoresResponse(response, '').ciiScores.length, ciiScores.length);
+    assert.deepEqual(filterRiskScoresResponse(response, 'USA'), { ciiScores: [], strategicRisks: [] });
   });
 
   // ===== Methodology doc drift guard (issue #3725) =====


### PR DESCRIPTION
## Summary

- implement the public GetRiskScores.region query filter as a post-cache projection
- normalize valid ISO2 input and return only the matching CII score
- keep global cached payloads unpoisoned and omit global strategic-risk rollups from country-filtered responses
- return empty arrays for unknown or malformed non-empty region filters

## Validation

- ./node_modules/.bin/tsx --test tests/cii-scoring.test.mts
- npm run typecheck:api
- pre-push hook: typecheck, API typecheck, Convex type check, CJS syntax, Unicode safety, boundary lint, safe HTML, rate-limit policy, premium-fetch parity, edge bundle check, server handler tests, changed CII tests, version check