### PR TITLE
Fix frontend CII source of truth fallback

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -375,7 +375,8 @@ export class DataLoaderManager implements AppModule {
       return;
     }
 
-    (this.ctx.panels['cii'] as CIIPanel)?.refresh(forceLocal);
+    const shouldUseLocalFallback = forceLocal || !this.cachedRiskScores;
+    (this.ctx.panels['cii'] as CIIPanel)?.refresh(shouldUseLocalFallback);
     this.callbacks.refreshOpenCountryBrief();
     const scores = calculateCII();
     this.applyCiiScoresToMap(scores);
@@ -2390,7 +2391,7 @@ export class DataLoaderManager implements AppModule {
     if (hasLocalCiiData) {
       setIntelligenceSignalsLoaded();
     }
-    this.refreshCiiAndBrief(hasLocalCiiData);
+    this.refreshCiiAndBrief();
     console.log('[Intelligence] All signals loaded for CII calculation');
   }
 

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -112,7 +112,7 @@ import { updateAndCheck, consumeServerAnomalies, fetchLiveAnomalies } from '@/se
 import { fetchAllFires, flattenFires, computeRegionStats, toMapFires } from '@/services/wildfires';
 import { analyzeFlightsForSurge, surgeAlertToSignal, detectForeignMilitaryPresence, foreignPresenceToSignal, type TheaterPostureSummary } from '@/services/military-surge';
 import { fetchCachedTheaterPosture } from '@/services/cached-theater-posture';
-import { ingestProtestsForCII, ingestMilitaryForCII, ingestNewsForCII, ingestOutagesForCII, ingestConflictsForCII, ingestUcdpForCII, ingestHapiForCII, ingestDisplacementForCII, ingestClimateForCII, ingestStrikesForCII, ingestOrefForCII, ingestAviationForCII, ingestAdvisoriesForCII, ingestGpsJammingForCII, ingestAisDisruptionsForCII, ingestSatelliteFiresForCII, ingestCyberThreatsForCII, ingestTemporalAnomaliesForCII, ingestEarthquakesForCII, ingestSanctionsForCII, isInLearningMode, resetHotspotActivity, setIntelligenceSignalsLoaded, hasAnyIntelligenceData, calculateCII } from '@/services/country-instability';
+import { ingestProtestsForCII, ingestMilitaryForCII, ingestNewsForCII, ingestOutagesForCII, ingestConflictsForCII, ingestUcdpForCII, ingestHapiForCII, ingestDisplacementForCII, ingestClimateForCII, ingestStrikesForCII, ingestOrefForCII, ingestAviationForCII, ingestAdvisoriesForCII, ingestGpsJammingForCII, ingestAisDisruptionsForCII, ingestSatelliteFiresForCII, ingestCyberThreatsForCII, ingestTemporalAnomaliesForCII, ingestEarthquakesForCII, ingestSanctionsForCII, isInLearningMode, resetHotspotActivity, setIntelligenceSignalsLoaded, hasAnyIntelligenceData, calculateCII, type CountryScore } from '@/services/country-instability';
 import { fetchGpsInterference } from '@/services/gps-interference';
 import { fetchSatelliteTLEs, initSatRecs, propagatePositions, startPropagationLoop } from '@/services/satellites';
 import type { SatRecEntry } from '@/services/satellites';
@@ -195,7 +195,7 @@ import {
   type YieldCurveContext,
   type SectorBriefContext,
 } from '@/services/daily-market-brief';
-import { fetchCachedRiskScores } from '@/services/cached-risk-scores';
+import { fetchCachedRiskScores, getCachedScores, toCountryScore, type CachedRiskScores } from '@/services/cached-risk-scores';
 import type { ThreatLevel as ClientThreatLevel } from '@/types';
 import type { NewsItem as ProtoNewsItem, ThreatLevel as ProtoThreatLevel } from '@/generated/client/worldmonitor/news/v1/service_client';
 import { fetchMarketImplications } from '@/services/market-implications';
@@ -293,6 +293,8 @@ export class DataLoaderManager implements AppModule {
   private dailyBriefFrameworkUnsubscribe: (() => void) | null = null;
   private marketImplicationsFrameworkUnsubscribe: (() => void) | null = null;
   private cachedSatRecs: SatRecEntry[] | null = null;
+  private cachedRiskScores: CachedRiskScores | null = null;
+  private preferLocalCii = false;
 
   private digestBreaker = { state: 'closed' as 'closed' | 'open' | 'half-open', failures: 0, cooldownUntil: 0 };
   private readonly digestRequestTimeoutMs = 8000;
@@ -343,12 +345,40 @@ export class DataLoaderManager implements AppModule {
     this.marketImplicationsFrameworkUnsubscribe = null;
   }
 
+  private getAuthoritativeCachedRiskScores(forceLocal: boolean): CachedRiskScores | null {
+    if (forceLocal) {
+      this.preferLocalCii = true;
+      this.cachedRiskScores = null;
+      return null;
+    }
+    if (this.preferLocalCii) return null;
+    const cached = this.cachedRiskScores ?? getCachedScores();
+    return cached?.cii.length ? cached : null;
+  }
+
+  private applyCiiScoresToMap(scores: CountryScore[]): void {
+    this.ctx.map?.setCIIScores(scores.map(s => ({ code: s.code, score: s.score, level: s.level })));
+    this.ctx.map?.setLayerReady('ciiChoropleth', scores.length > 0);
+  }
+
+  private renderCachedCiiScores(cached: CachedRiskScores): void {
+    this.cachedRiskScores = cached;
+    (this.ctx.panels['cii'] as CIIPanel)?.renderFromCached(cached);
+    this.applyCiiScoresToMap(cached.cii.map(toCountryScore));
+  }
+
   private refreshCiiAndBrief(forceLocal = false): void {
+    const cached = this.getAuthoritativeCachedRiskScores(forceLocal);
+    if (cached) {
+      this.renderCachedCiiScores(cached);
+      this.callbacks.refreshOpenCountryBrief();
+      return;
+    }
+
     (this.ctx.panels['cii'] as CIIPanel)?.refresh(forceLocal);
     this.callbacks.refreshOpenCountryBrief();
     const scores = calculateCII();
-    this.ctx.map?.setCIIScores(scores.map(s => ({ code: s.code, score: s.score, level: s.level })));
-    this.ctx.map?.setLayerReady('ciiChoropleth', scores.length > 0);
+    this.applyCiiScoresToMap(scores);
   }
 
   private async tryFetchDigest(): Promise<ListFeedDigestResponse | null> {
@@ -551,9 +581,7 @@ export class DataLoaderManager implements AppModule {
       try {
         const cached = await fetchCachedRiskScores().catch(() => null);
         if (cached && cached.cii.length > 0) {
-          (this.ctx.panels['cii'] as CIIPanel)?.renderFromCached(cached);
-          this.ctx.map?.setCIIScores(cached.cii.map(s => ({ code: s.code, score: s.score, level: s.level })));
-          this.ctx.map?.setLayerReady('ciiChoropleth', true);
+          this.renderCachedCiiScores(cached);
         }
       } catch { /* non-fatal */ }
     }
@@ -2358,10 +2386,11 @@ export class DataLoaderManager implements AppModule {
       dataFreshness.recordError('worldpop', String(error));
     }
 
-    if (hasAnyIntelligenceData()) {
+    const hasLocalCiiData = hasAnyIntelligenceData();
+    if (hasLocalCiiData) {
       setIntelligenceSignalsLoaded();
     }
-    this.refreshCiiAndBrief(true);
+    this.refreshCiiAndBrief(hasLocalCiiData);
     console.log('[Intelligence] All signals loaded for CII calculation');
   }
 

--- a/src/components/StrategicRiskPanel.ts
+++ b/src/components/StrategicRiskPanel.ts
@@ -18,8 +18,8 @@ import {
   type DataSourceState,
   type DataFreshnessSummary,
 } from '@/services/data-freshness';
-import { getLearningProgress } from '@/services/country-instability';
-import { fetchCachedRiskScores } from '@/services/cached-risk-scores';
+import { getLearningProgress, hasIntelligenceSignalsLoaded, type CountryScore } from '@/services/country-instability';
+import { fetchCachedRiskScores, toCountryScore, type CachedRiskScores } from '@/services/cached-risk-scores';
 import { getCachedPosture } from '@/services/cached-theater-posture';
 import { refreshDataFreshnessFromHealth } from '@/services/health-freshness';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
@@ -123,21 +123,24 @@ export class StrategicRiskPanel extends Panel {
     const postures = cached?.postures;
     const staleFactor = cached?.stale ? 0.5 : 1;
 
-    this.overview = calculateStrategicRiskOverview(
+    const localOverview = calculateStrategicRiskOverview(
       this.convergenceAlerts,
       postures ?? undefined,
       breakingScore,
       staleFactor
     );
+    this.overview = localOverview;
     this.alerts = getRecentAlerts(24);
 
     // Try to get cached scores during learning mode OR when data sources are insufficient
     const { inLearning } = getLearningProgress();
     this.usedCachedScores = false;
-    if (inLearning || this.freshnessSummary.overallStatus === 'insufficient') {
+    const shouldUseCachedScores = inLearning || !hasIntelligenceSignalsLoaded() || this.freshnessSummary.overallStatus === 'insufficient';
+    if (shouldUseCachedScores) {
       const cached = await fetchCachedRiskScores(this.signal);
       if (!this.element?.isConnected) return false;
       if (cached?.strategicRisk) {
+        this.applyCachedRiskOverview(cached, localOverview);
         this.usedCachedScores = true;
         console.log('[StrategicRiskPanel] Using cached scores from backend');
       }
@@ -149,10 +152,10 @@ export class StrategicRiskPanel extends Panel {
         total: this.freshnessSummary.totalSources,
       })
       : undefined;
-    if (!this.freshnessSummary || this.freshnessSummary.activeSources === 0) {
-      this.setDataBadge('unavailable');
-    } else if (this.usedCachedScores) {
+    if (this.usedCachedScores) {
       this.setDataBadge('cached', badgeDetail);
+    } else if (!this.freshnessSummary || this.freshnessSummary.activeSources === 0) {
+      this.setDataBadge('unavailable');
     } else {
       this.setDataBadge('live', badgeDetail);
     }
@@ -177,6 +180,47 @@ export class StrategicRiskPanel extends Panel {
     } finally {
       this.lastHealthFreshnessRefreshAt = Date.now();
     }
+  }
+
+  private cachedTrendToOverviewTrend(trend: string): StrategicRiskOverview['trend'] {
+    if (trend === 'rising' || trend === 'escalating') return 'escalating';
+    if (trend === 'falling' || trend === 'de-escalating') return 'de-escalating';
+    return 'stable';
+  }
+
+  private cachedTimestamp(cached: CachedRiskScores): Date {
+    const raw = cached.strategicRisk.lastUpdated ?? cached.computedAt;
+    if (!raw) return new Date();
+    const parsed = new Date(raw);
+    return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+  }
+
+  private cachedTopRisks(cached: CachedRiskScores, ciiScores: CountryScore[]): string[] {
+    const contributors = cached.strategicRisk.contributors
+      .filter((c) => c.score > 0)
+      .slice(0, 5)
+      .map((c) => `${c.country}: ${c.score} (${c.level})`);
+    if (contributors.length > 0) return contributors;
+    return ciiScores
+      .filter((s) => s.score > 0)
+      .slice(0, 5)
+      .map((s) => `${s.name}: ${s.score} (${s.level})`);
+  }
+
+  private applyCachedRiskOverview(cached: CachedRiskScores, localOverview: StrategicRiskOverview): void {
+    const ciiScores = cached.cii
+      .map(toCountryScore)
+      .sort((a, b) => b.score - a.score);
+
+    this.overview = {
+      ...localOverview,
+      avgCIIDeviation: ciiScores[0]?.score ?? cached.strategicRisk.score,
+      compositeScore: Math.max(0, Math.min(100, Math.round(cached.strategicRisk.score))),
+      trend: this.cachedTrendToOverviewTrend(cached.strategicRisk.trend),
+      topRisks: this.cachedTopRisks(cached, ciiScores),
+      unstableCountries: ciiScores.filter(s => s.score >= 50).slice(0, 5),
+      timestamp: this.cachedTimestamp(cached),
+    };
   }
 
   private getScoreColor(score: number): string {

--- a/src/components/StrategicRiskPanel.ts
+++ b/src/components/StrategicRiskPanel.ts
@@ -188,11 +188,11 @@ export class StrategicRiskPanel extends Panel {
     return 'stable';
   }
 
-  private cachedTimestamp(cached: CachedRiskScores): Date {
+  private cachedTimestamp(cached: CachedRiskScores): Date | null {
     const raw = cached.strategicRisk.lastUpdated ?? cached.computedAt;
-    if (!raw) return new Date();
+    if (!raw) return null;
     const parsed = new Date(raw);
-    return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
   }
 
   private cachedTopRisks(cached: CachedRiskScores, ciiScores: CountryScore[]): string[] {
@@ -382,7 +382,7 @@ export class StrategicRiskPanel extends Panel {
         ${this.renderRecentAlerts()}
 
         <div class="risk-footer">
-          <span class="risk-updated">${t('components.strategicRisk.updated', { time: this.overview.timestamp.toLocaleTimeString() })}</span>
+          <span class="risk-updated">${t('components.strategicRisk.updated', { time: this.formatOverviewTimestamp() })}</span>
           <button class="risk-refresh-btn">${t('components.strategicRisk.refresh')}</button>
         </div>
       </div>
@@ -543,6 +543,10 @@ export class StrategicRiskPanel extends Panel {
     if (minutes < 60) return t('components.strategicRisk.time.minutesAgo', { count: String(minutes) });
     if (hours < 24) return t('components.strategicRisk.time.hoursAgo', { count: String(hours) });
     return date.toLocaleDateString();
+  }
+
+  private formatOverviewTimestamp(): string {
+    return this.overview?.timestamp ? this.overview.timestamp.toLocaleTimeString() : '&mdash;';
   }
 
   private render(): void {

--- a/src/services/cross-module-integration.ts
+++ b/src/services/cross-module-integration.ts
@@ -94,7 +94,7 @@ export interface StrategicRiskOverview {
   topRisks: string[];
   topConvergenceZones: { cellId: string; lat: number; lon: number; score: number }[];
   unstableCountries: CountryScore[];
-  timestamp: Date;
+  timestamp: Date | null;
 }
 
 const alerts: UnifiedAlert[] = [];

--- a/src/services/story-data.ts
+++ b/src/services/story-data.ts
@@ -1,4 +1,5 @@
-import { calculateCII, type CountryScore } from './country-instability';
+import { calculateCII, hasIntelligenceSignalsLoaded, type CountryScore } from './country-instability';
+import { getCachedScores, toCountryScore } from './cached-risk-scores';
 import type { ClusteredEvent } from '@/types';
 import type { ThreatLevel } from './threat-classifier';
 import { CURATED_COUNTRIES } from '@/config/countries';
@@ -62,8 +63,15 @@ export function collectStoryData(
   signals?: { protests: number; militaryFlights: number; militaryVessels: number; outages: number; gpsJammingHexes: number },
   convergence?: { score: number; signalTypes: string[]; regionalDescriptions: string[] } | null,
 ): StoryData {
-  const scores = calculateCII();
-  const countryScore = scores.find(s => s.code === countryCode) || null;
+  let countryScore: CountryScore | null = null;
+  if (!hasIntelligenceSignalsLoaded()) {
+    const cached = getCachedScores()?.cii.find(s => s.code === countryCode);
+    if (cached) countryScore = toCountryScore(cached);
+  }
+  if (!countryScore) {
+    const scores = calculateCII();
+    countryScore = scores.find(s => s.code === countryCode) || null;
+  }
 
   const keywords = CURATED_COUNTRIES[countryCode]?.scoringKeywords || [countryName.toLowerCase()];
   const countryNews = allNews.filter(e => {
@@ -138,4 +146,3 @@ export function collectStoryData(
     convergence: convergence || null,
   };
 }
-

--- a/tests/feed-date-ranking-uses-effective.test.mts
+++ b/tests/feed-date-ranking-uses-effective.test.mts
@@ -92,7 +92,7 @@ const ALLOW_LIST: AllowEntry[] = [
   },
   {
     file: 'src/app/data-loader.ts',
-    line: 3290,
+    line: 3319,
     reason: 'Cache serialization step — wraps pubDate.getTime() into the persisted entry payload, not a comparator.',
   },
 ];

--- a/tests/feed-date-ranking-uses-effective.test.mts
+++ b/tests/feed-date-ranking-uses-effective.test.mts
@@ -92,7 +92,7 @@ const ALLOW_LIST: AllowEntry[] = [
   },
   {
     file: 'src/app/data-loader.ts',
-    line: 3319,
+    line: 3320,
     reason: 'Cache serialization step — wraps pubDate.getTime() into the persisted entry payload, not a comparator.',
   },
 ];

--- a/tests/frontend-cii-source-of-truth.test.mts
+++ b/tests/frontend-cii-source-of-truth.test.mts
@@ -47,9 +47,16 @@ describe('frontend CII source of truth', () => {
 
   it('renders Strategic Risk from cached strategic risk/CII instead of only marking the badge cached', () => {
     const src = readSrc('src/components/StrategicRiskPanel.ts');
+    const overviewSrc = readSrc('src/services/cross-module-integration.ts');
     const refreshBody = extractMethod(src, 'public async refresh(): Promise<boolean>');
+    const cachedTimestampBody = extractMethod(src, 'private cachedTimestamp(cached: CachedRiskScores): Date | null');
 
+    assert.match(overviewSrc, /export interface StrategicRiskOverview[\s\S]*timestamp: Date \| null;/);
     assert.match(src, /private applyCachedRiskOverview\(cached: CachedRiskScores, localOverview: StrategicRiskOverview\): void/);
+    assert.match(cachedTimestampBody, /if \(!raw\) return null;/);
+    assert.match(cachedTimestampBody, /Number\.isNaN\(parsed\.getTime\(\)\) \? null : parsed/);
+    assert.doesNotMatch(cachedTimestampBody, /new Date\(\)/);
+    assert.match(src, /private formatOverviewTimestamp\(\): string \{[\s\S]*return this\.overview\?\.timestamp \? this\.overview\.timestamp\.toLocaleTimeString\(\) : '&mdash;';[\s\S]*\}/);
     assert.match(src, /compositeScore: Math\.max\(0, Math\.min\(100, Math\.round\(cached\.strategicRisk\.score\)\)\)/);
     assert.match(src, /unstableCountries: ciiScores\.filter\(s => s\.score >= 50\)\.slice\(0, 5\)/);
     assert.match(refreshBody, /this\.applyCachedRiskOverview\(cached, localOverview\);[\s\S]*this\.usedCachedScores = true;/);

--- a/tests/frontend-cii-source-of-truth.test.mts
+++ b/tests/frontend-cii-source-of-truth.test.mts
@@ -34,11 +34,14 @@ describe('frontend CII source of truth', () => {
     assert.match(src, /private preferLocalCii = false;/);
     assert.match(src, /private getAuthoritativeCachedRiskScores\(forceLocal: boolean\): CachedRiskScores \| null/);
     assert.match(src, /if \(forceLocal\) \{[\s\S]*this\.preferLocalCii = true;[\s\S]*return null;[\s\S]*\}/);
-    assert.match(src, /const hasLocalCiiData = hasAnyIntelligenceData\(\);[\s\S]*if \(hasLocalCiiData\) \{[\s\S]*setIntelligenceSignalsLoaded\(\);[\s\S]*\}[\s\S]*this\.refreshCiiAndBrief\(hasLocalCiiData\);/);
+    assert.match(src, /const hasLocalCiiData = hasAnyIntelligenceData\(\);[\s\S]*if \(hasLocalCiiData\) \{[\s\S]*setIntelligenceSignalsLoaded\(\);[\s\S]*\}[\s\S]*this\.refreshCiiAndBrief\(\);/);
+    assert.doesNotMatch(src, /this\.refreshCiiAndBrief\(hasLocalCiiData\);/);
     assert.doesNotMatch(src, /this\.refreshCiiAndBrief\(true\);/);
 
     assert.match(refreshBody, /const cached = this\.getAuthoritativeCachedRiskScores\(forceLocal\);/);
     assert.match(refreshBody, /if \(cached\) \{[\s\S]*this\.renderCachedCiiScores\(cached\);[\s\S]*return;[\s\S]*\}/);
+    assert.match(refreshBody, /const shouldUseLocalFallback = forceLocal \|\| !this\.cachedRiskScores;/);
+    assert.match(refreshBody, /\(this\.ctx\.panels\['cii'\] as CIIPanel\)\?\.refresh\(shouldUseLocalFallback\);/);
     assert.match(refreshBody, /const scores = calculateCII\(\);[\s\S]*this\.applyCiiScoresToMap\(scores\);/);
   });
 

--- a/tests/frontend-cii-source-of-truth.test.mts
+++ b/tests/frontend-cii-source-of-truth.test.mts
@@ -1,0 +1,65 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+
+function readSrc(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8');
+}
+
+function extractMethod(src: string, signature: string): string {
+  const start = src.indexOf(signature);
+  assert.notEqual(start, -1, `missing method signature: ${signature}`);
+  const bodyStart = src.indexOf('{', start);
+  assert.notEqual(bodyStart, -1, `missing method body: ${signature}`);
+
+  let depth = 0;
+  for (let i = bodyStart; i < src.length; i++) {
+    const ch = src[i];
+    if (ch === '{') depth++;
+    if (ch === '}') depth--;
+    if (depth === 0) return src.slice(start, i + 1);
+  }
+  throw new Error(`unterminated method body: ${signature}`);
+}
+
+describe('frontend CII source of truth', () => {
+  it('keeps cached backend CII authoritative until the explicit force-local path', () => {
+    const src = readSrc('src/app/data-loader.ts');
+    const refreshBody = extractMethod(src, 'private refreshCiiAndBrief(forceLocal = false): void');
+
+    assert.match(src, /private cachedRiskScores: CachedRiskScores \| null = null;/);
+    assert.match(src, /private preferLocalCii = false;/);
+    assert.match(src, /private getAuthoritativeCachedRiskScores\(forceLocal: boolean\): CachedRiskScores \| null/);
+    assert.match(src, /if \(forceLocal\) \{[\s\S]*this\.preferLocalCii = true;[\s\S]*return null;[\s\S]*\}/);
+    assert.match(src, /const hasLocalCiiData = hasAnyIntelligenceData\(\);[\s\S]*if \(hasLocalCiiData\) \{[\s\S]*setIntelligenceSignalsLoaded\(\);[\s\S]*\}[\s\S]*this\.refreshCiiAndBrief\(hasLocalCiiData\);/);
+    assert.doesNotMatch(src, /this\.refreshCiiAndBrief\(true\);/);
+
+    assert.match(refreshBody, /const cached = this\.getAuthoritativeCachedRiskScores\(forceLocal\);/);
+    assert.match(refreshBody, /if \(cached\) \{[\s\S]*this\.renderCachedCiiScores\(cached\);[\s\S]*return;[\s\S]*\}/);
+    assert.match(refreshBody, /const scores = calculateCII\(\);[\s\S]*this\.applyCiiScoresToMap\(scores\);/);
+  });
+
+  it('renders Strategic Risk from cached strategic risk/CII instead of only marking the badge cached', () => {
+    const src = readSrc('src/components/StrategicRiskPanel.ts');
+    const refreshBody = extractMethod(src, 'public async refresh(): Promise<boolean>');
+
+    assert.match(src, /private applyCachedRiskOverview\(cached: CachedRiskScores, localOverview: StrategicRiskOverview\): void/);
+    assert.match(src, /compositeScore: Math\.max\(0, Math\.min\(100, Math\.round\(cached\.strategicRisk\.score\)\)\)/);
+    assert.match(src, /unstableCountries: ciiScores\.filter\(s => s\.score >= 50\)\.slice\(0, 5\)/);
+    assert.match(refreshBody, /this\.applyCachedRiskOverview\(cached, localOverview\);[\s\S]*this\.usedCachedScores = true;/);
+    assert.match(refreshBody, /if \(this\.usedCachedScores\) \{[\s\S]*this\.setDataBadge\('cached', badgeDetail\);[\s\S]*\} else if \(!this\.freshnessSummary \|\| this\.freshnessSummary\.activeSources === 0\) \{[\s\S]*this\.setDataBadge\('unavailable'\);/);
+  });
+
+  it('uses cached CII for story data until local intelligence ingestion is ready', () => {
+    const src = readSrc('src/services/story-data.ts');
+
+    assert.match(src, /hasIntelligenceSignalsLoaded/);
+    assert.match(src, /getCachedScores/);
+    assert.match(src, /toCountryScore/);
+    assert.match(src, /if \(!hasIntelligenceSignalsLoaded\(\)\) \{[\s\S]*getCachedScores\(\)\?\.cii\.find[\s\S]*toCountryScore\(cached\);[\s\S]*\}/);
+    assert.match(src, /if \(!countryScore\) \{[\s\S]*const scores = calculateCII\(\);[\s\S]*\}/);
+  });
+});


### PR DESCRIPTION
## Summary

- Keep backend cached/sebuf CII authoritative in the CII panel and map until local intelligence ingestion has actual data to replace it.
- Apply cached backend strategic risk and CII values to the Strategic Risk panel render path instead of only showing a cached badge.
- Use cached CII for story data while local intelligence ingestion is not ready, and add focused regression guardrails for the source-of-truth policy.

## Root Cause

The frontend initially rendered cached backend CII, but later refreshes always recomputed local CII and overwrote the CII panel/map even when local data was partial or unavailable. Strategic Risk had the inverse cosmetic issue: it marked cached data as used but continued rendering the local overview.

## Validation

- `npm run typecheck`
- `npx tsx --test tests/frontend-cii-source-of-truth.test.mts tests/cached-risk-scores.test.mts`
- Pre-push hook on `git push -u origin codex/cii-source-of-truth-fallback`, including src/API typecheck, Convex string audit, boundaries, safe HTML, rate-limit and premium-fetch checks, changed tests, edge-function tests, and version sync.