### PR TITLE
fix(redis): preserve empty-string values in getHashFieldsBatch

### DIFF
--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -738,7 +738,7 @@ export async function getHashFieldsBatch(key: string, fields: string[], raw = fa
     const values = data[0]?.result;
     if (values) {
       for (let i = 0; i < fields.length; i++) {
-        if (values[i]) result.set(fields[i]!, values[i]!);
+        if (values[i] != null) result.set(fields[i]!, values[i]!);
       }
     }
   } catch (err) {

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -1414,3 +1414,36 @@ describe('setCachedJson wire shape and failure reporting', { concurrency: 1 }, (
     }
   });
 });
+
+describe('getHashFieldsBatch empty-string handling', { concurrency: 1 }, () => {
+  it('preserves empty-string values (does not drop them)', async () => {
+    const redis = await importRedisFresh();
+    const restoreEnv = withEnv({
+      UPSTASH_REDIS_REST_URL: 'https://redis.test',
+      UPSTASH_REDIS_REST_TOKEN: 'token',
+      VERCEL_ENV: undefined,
+      VERCEL_GIT_COMMIT_SHA: undefined,
+    });
+    const originalFetch = globalThis.fetch;
+
+
+    globalThis.fetch = async (_url, init = {}) => {
+      const pipeline = JSON.parse(String(init.body));
+      // Mock HMGET response: ["", null, "value"] — empty string, null, and a real value
+      return jsonResponse([
+        { result: ['', null, 'value'] },
+      ]);
+    };
+
+    try {
+      const map = await redis.getHashFieldsBatch('test:key', ['fieldA', 'fieldB', 'fieldC']);
+      assert.equal(map.size, 2, 'should have 2 fields (empty string + value, null skipped)');
+      assert.equal(map.get('fieldA'), '', 'empty string must be preserved');
+      assert.equal(map.has('fieldB'), false, 'null should be skipped');
+      assert.equal(map.get('fieldC'), 'value', 'real value should be present');
+    } finally {
+      globalThis.fetch = originalFetch;
+      restoreEnv();
+    }
+  });
+});

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -1427,8 +1427,7 @@ describe('getHashFieldsBatch empty-string handling', { concurrency: 1 }, () => {
     const originalFetch = globalThis.fetch;
 
 
-    globalThis.fetch = async (_url, init = {}) => {
-      const pipeline = JSON.parse(String(init.body));
+    globalThis.fetch = async (_url, _init = {}) => {
       // Mock HMGET response: ["", null, "value"] — empty string, null, and a real value
       return jsonResponse([
         { result: ['', null, 'value'] },


### PR DESCRIPTION
## Summary
\getHashFieldsBatch\ used a falsy check \if (values[i])\ that dropped empty-string Redis hash values. \\\ is a legitimate Redis value but was treated the same as \
ull\/missing.

## Problem
\server/_shared/redis.ts\ line 741:
\\\	s
if (values[i]) result.set(fields[i]!, values[i]!);  // '' is falsy — dropped!
\\\

## Solution
Replace falsy check with \!= null\, which preserves empty strings while still skipping \
ull\ (missing field):
\\\	s
if (values[i] != null) result.set(fields[i]!, values[i]!);
\\\

## Testing
- [x] New test \preserves empty-string values (does not drop them)\ added to \	ests/redis-caching.test.mjs\
- [x] Test passes: \\\ → preserved, \
ull\ → skipped, \'value'\ → preserved
- [x] All 29 tests in \edis-caching.test.mjs\ pass

## Files Changed
- \server/_shared/redis.ts\ — fix falsy check to \!= null\
- \	ests/redis-caching.test.mjs\ — add unit test for empty-string handling

Fixes #3530