### PR TITLE
Fix CII risk score observability docs

### DIFF
--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -50,7 +50,7 @@ const SEED_DOMAINS = {
   'aviation:faa':             { key: 'seed-meta:aviation:faa',             intervalMin: 45 },
   'news:insights':            { key: 'seed-meta:news:insights',            intervalMin: 15 },
   'positive-events:geo':      { key: 'seed-meta:positive-events:geo',      intervalMin: 30 },
-  'risk:scores:sebuf':        { key: 'seed-meta:risk:scores:sebuf',        intervalMin: 15 },
+  'intelligence:risk-scores': { key: 'seed-meta:intelligence:risk-scores', intervalMin: 15 }, // CII warm-ping every 8min; intervalMin*2 = 30min, aligned with api/health.js riskScores.
   'conflict:iran-events':     { key: 'seed-meta:conflict:iran-events',     intervalMin: 5040 },
   'conflict:ucdp-events':     { key: 'seed-meta:conflict:ucdp-events',     intervalMin: 210 },
   'weather:alerts':           { key: 'seed-meta:weather:alerts',           intervalMin: 15 },

--- a/docs/algorithms.mdx
+++ b/docs/algorithms.mdx
@@ -11,7 +11,7 @@ description: "Detailed documentation of World Monitor's scoring formulas, detect
 
 Every Tier-1 country receives a live instability score (0-100). CII v3 tracks 31 Tier-1 countries with shared server/frontend `baselineRisk` and `eventMultiplier` coefficients: US, Russia, China, Ukraine, Iran, Israel, Taiwan, North Korea, Saudi Arabia, Turkey, Poland, Germany, France, UK, India, Pakistan, Syria, Yemen, Myanmar, Venezuela, Cuba, Mexico, Brazil, UAE, South Korea, Iraq, Afghanistan, Lebanon, Egypt, Japan, and Qatar. Countries outside the curated Tier-1 set use the default editorial coefficients when they are scored by supporting systems (`DEFAULT_CII_BASELINE_RISK = 15`, `DEFAULT_CII_EVENT_MULTIPLIER = 1.0`).
 
-The server-side score (`get-risk-scores.ts`) uses the same formulas as the frontend (`country-instability.ts`):
+Authoritative CII scores come from the server-side `GET /api/intelligence/v1/get-risk-scores` RPC (`server/worldmonitor/intelligence/v1/get-risk-scores.ts`) and are served to the browser through the cached risk-score feed. The frontend `country-instability.ts` path shares the published `baselineRisk` / `eventMultiplier` coefficients and v3 conflict curve constants, but it is a fallback/local renderer path after cached backend scores, not the source of truth for published scores:
 
 | Component            | Weight | Details |
 | -------------------- | ------ | ------- |
@@ -20,7 +20,7 @@ The server-side score (`get-risk-scores.ts`) uses the same formulas as the front
 
 **Unrest score** (0-100): Log2 dampening for high-volume low-multiplier countries (`multiplier &lt; 0.7`), linear otherwise. Base capped at 50, plus protest/riot fatality boost (up to 30), plus outage severity boost (TOTAL: 30pts, MAJOR: 15pts, PARTIAL: 5pts, capped at 50).
 
-**Conflict score** (0-100): Weighted ACLED events (battles x3, explosions x4, civilian violence x5, capped at 50), sqrt-scaled fatalities (up to 40), civilian boost (up to 10), Iran strike boost with severity weighting (up to 50), and OREF alert boost for Israel (25 base + 5 per active alert, up to 50 total). Rolling 24-hour history adds a secondary boost: 3-9 alerts contribute +5, 10+ contribute +10 to the blended score.
+**Conflict score** (0-100): Weighted ACLED activity (battles x3, explosions x4, civilian violence x5, multiplied by `eventMultiplier`) is log-scaled with the v3 curve `min(70, log1p(rawActivity) / log1p(4000) * 70)` before additional boosts. Sqrt-scaled fatalities contribute up to 40, civilian targeting up to 10, Iran strike severity up to 50, and OREF alerts for Israel add 25 base + 5 per active alert up to 50 total. Rolling 24-hour OREF history contributes through the Israel blend boost described below.
 
 **Security score** (0-100): Military flights (3pts each, capped at 50), military vessels (5pts each, capped at 30), aviation closures/delays (severity-weighted, capped at 40), and GPS/GNSS jamming (high: 5pts, medium: 2pts per hex, capped at 35). Foreign military presence is weighted ×2.
 

--- a/docs/methodology/cii-risk-scores.mdx
+++ b/docs/methodology/cii-risk-scores.mdx
@@ -4,7 +4,7 @@ description: "Editorial methodology behind the Composite Instability Index (CII)
 ---
 
 Published methodology note for the **Composite Instability Index (CII)** and
-the **Strategic Risk** roll-up surfaced by `GET /api/intelligence/risk-scores`
+the **Strategic Risk** roll-up surfaced by `GET /api/intelligence/v1/get-risk-scores`
 (proto `worldmonitor.intelligence.v1.GetRiskScoresResponse`).
 
 These weights are **editorial** — authored by the WorldMonitor intelligence

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -683,6 +683,47 @@ describe('CII scoring', () => {
       `methodology doc must mention current CII_FORMULA_VERSION '${CII_FORMULA_VERSION}' — bump the version and update the doc together.`);
   });
 
+  it('public CII docs reference the current RPC route and backend-authoritative v3 conflict curve', () => {
+    const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+    const methodologyDoc = readFileSync(resolve(root, 'docs', 'methodology', 'cii-risk-scores.mdx'), 'utf8');
+    const algorithmsDoc = readFileSync(resolve(root, 'docs', 'algorithms.mdx'), 'utf8');
+
+    assert.ok(
+      methodologyDoc.includes('GET /api/intelligence/v1/get-risk-scores'),
+      'methodology doc must point to the current get-risk-scores RPC route',
+    );
+    assert.doesNotMatch(
+      methodologyDoc,
+      /GET \/api\/intelligence\/risk-scores/,
+      'methodology doc must not reference the retired pre-RPC CII route',
+    );
+    assert.match(
+      algorithmsDoc,
+      /Authoritative CII scores come from the server-side `GET \/api\/intelligence\/v1\/get-risk-scores` RPC/,
+      'algorithms doc must identify the server RPC as the authoritative CII source',
+    );
+    assert.match(
+      algorithmsDoc,
+      /fallback\/local renderer path after cached backend scores/,
+      'algorithms doc must describe frontend scoring as fallback/local rendering after cached backend scores',
+    );
+    assert.match(
+      algorithmsDoc,
+      /min\(70, log1p\(rawActivity\) \/ log1p\(4000\) \* 70\)/,
+      'algorithms doc must publish the v3 conflict activity cap=70 curve',
+    );
+    assert.doesNotMatch(
+      algorithmsDoc,
+      /server-side score .* uses the same formulas as the frontend/i,
+      'algorithms doc must not overclaim server/frontend formula parity',
+    );
+    assert.doesNotMatch(
+      algorithmsDoc,
+      /Weighted ACLED events .* capped at 50/i,
+      'algorithms doc must not describe the server-authoritative v3 conflict activity cap as 50',
+    );
+  });
+
   it('current public CII docs do not reintroduce pre-v3 stale claims', () => {
     const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
     const publicDocPaths = [

--- a/tests/seed-health-risk-scores.test.mjs
+++ b/tests/seed-health-risk-scores.test.mjs
@@ -1,0 +1,50 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const repoRoot = resolve(import.meta.dirname, '..');
+
+function readRepoFile(path) {
+  return readFileSync(resolve(repoRoot, path), 'utf8');
+}
+
+function extractObjectEntry(source, entryName) {
+  const pattern = new RegExp(`${entryName}:\\s*\\{\\s*key:\\s*'([^']+)',\\s*(?:maxStaleMin|intervalMin):\\s*([0-9_]+)`);
+  const match = source.match(pattern);
+  assert.ok(match, `missing ${entryName} freshness entry`);
+  return { key: match[1], minutes: Number(match[2].replaceAll('_', '')) };
+}
+
+test('seed-health CII risk score freshness mirrors api/health riskScores', () => {
+  const seedHealth = readRepoFile('api/seed-health.js');
+  const health = readRepoFile('api/health.js');
+
+  const healthRiskScores = extractObjectEntry(health, 'riskScores');
+  const seedHealthMatch = seedHealth.match(
+    /'intelligence:risk-scores':\s*\{\s*key:\s*'([^']+)',\s*intervalMin:\s*([0-9_]+)/,
+  );
+
+  assert.ok(seedHealthMatch, 'api/seed-health.js must register intelligence:risk-scores');
+  assert.equal(seedHealthMatch[1], 'seed-meta:intelligence:risk-scores');
+  assert.equal(healthRiskScores.key, seedHealthMatch[1]);
+  assert.equal(
+    Number(seedHealthMatch[2].replaceAll('_', '')) * 2,
+    healthRiskScores.minutes,
+    'seed-health intervalMin*2 must match api/health.js riskScores maxStaleMin',
+  );
+  assert.ok(
+    seedHealth.includes('api/health.js riskScores'),
+    'seed-health CII comment should keep the alignment target explicit',
+  );
+  assert.doesNotMatch(
+    seedHealth,
+    /seed-meta:risk:scores:sebuf/,
+    'seed-health must not drift back to the retired risk:scores:sebuf seed-meta key',
+  );
+  assert.doesNotMatch(
+    seedHealth,
+    /'risk:scores:sebuf':/,
+    'seed-health must not publish the retired risk:scores:sebuf seed domain',
+  );
+});


### PR DESCRIPTION
## Summary
- align /api/seed-health CII risk-score freshness with the current seed-meta:intelligence:risk-scores key
- correct the published CII RPC route to GET /api/intelligence/v1/get-risk-scores
- update algorithms docs to describe backend CII as authoritative and publish the v3 conflict curve cap=70
- add regression coverage for seed-health/API-health freshness parity and doc drift

## Validation
- node --test tests/seed-health-risk-scores.test.mjs
- npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/cii-scoring.test.mts
- node --test tests/seed-health-resilience-intervals.test.mjs
- npm_config_cache=/tmp/worldmonitor-npm-cache npx markdownlint-cli2 docs/algorithms.mdx docs/methodology/cii-risk-scores.mdx
- git diff --check
- pre-push hook: typecheck, typecheck:api, boundary/safe-html/rate-limit/premium-fetch checks, edge function tests, markdown/MDX lint, version sync