### PR TITLE
fix(outages): widen CF Radar window to 28d + zeroIsValid (kill false STALE_SEED)

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -552,6 +552,14 @@ const ZERO_RECORD_DATA_OK_KEYS = new Set([
   // published normally. Treat 0 records as OK while fresh; STALE_SEED still
   // fires if the publish job itself stops.
   'consumerPricesSpread',
+  // CF Radar curated outage annotations (seed-internet-outages, zeroIsValid)
+  // are sparse — most 28d windows publish an empty {outages:[]} envelope with
+  // recordCount=0 (hasData=true). NARROW set, not EMPTY_DATA_OK_KEYS: the
+  // seeder always publishes the array, so a MISSING canonical key is a real
+  // publish failure → still EMPTY (crit). Siblings ddosAttacks/trafficAnomalies
+  // sit in the broad set because their data key can be wholly absent on quiet
+  // (writeSeedMeta-only path).
+  'outages',
 ]);
 
 // Cascade groups: if any key in the group has data, all empty siblings are OK.

--- a/scripts/seed-internet-outages.mjs
+++ b/scripts/seed-internet-outages.mjs
@@ -73,7 +73,7 @@ async function fetchOutages() {
     process.exit(0);
   }
 
-  const resp = await fetch(`${CF_RADAR_URL}?dateRange=7d&limit=50`, {
+  const resp = await fetch(`${CF_RADAR_URL}?dateRange=28d&limit=50`, {
     headers: {
       Authorization: `Bearer ${token}`,
       'User-Agent': CHROME_UA,
@@ -250,9 +250,18 @@ export function declareRecords(data) {
 runSeed('infra', 'outages', CANONICAL_KEY, fetchAll, {
   validateFn: validate,
   ttlSeconds: CACHE_TTL,
-  sourceVersion: 'cloudflare-radar-7d',
+  sourceVersion: 'cloudflare-radar-28d',
 
   declareRecords,
+  // CF Radar curated outage annotations are sparse (~1-2/wk, clustered, with
+  // multi-day gaps). Zero mappable outages is the NORMAL state, not a fetch
+  // failure — without this, runSeed takes the contract RETRY path on every
+  // quiet cycle, never refreshing seed-meta.fetchedAt → false STALE_SEED in
+  // /api/health after maxStaleMin. zeroIsValid publishes an empty {outages:[]}
+  // envelope + fresh meta (recordCount=0) instead. Health-side: 'outages' is in
+  // ZERO_RECORD_DATA_OK_KEYS (narrow) so present+0 is OK while a MISSING key
+  // still alarms EMPTY (real publish failure).
+  zeroIsValid: true,
   schemaVersion: 1,
   maxStaleMin: 30,
 }).catch((err) => {

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -169,6 +169,46 @@ test('classifyKey: suppressed retailer-spread that goes STALE still warns (publi
   assert.equal(STATUS_COUNTS[entry.status], 'warn');
 });
 
+// ── CF Radar outages: sparse zeroIsValid feed (seed-internet-outages) ───────
+
+test('classifyKey: outages present key + 0 records while fresh → OK (sparse feed, not EMPTY_DATA)', () => {
+  // CF Radar curated outage annotations are sparse; most 28d windows publish an
+  // empty {outages:[]} envelope (hasData=true) with recordCount=0. With
+  // zeroIsValid the seeder refreshes seed-meta fresh, so this must classify OK,
+  // not EMPTY_DATA (crit) and not STALE_SEED.
+  const entry = classifyKey('outages', BOOTSTRAP_KEYS.outages, { allowOnDemand: false },
+    makeCtx({
+      strens: { [BOOTSTRAP_KEYS.outages]: 149 }, // empty {outages:[]} envelope
+      metaValues: { 'seed-meta:infra:outages': seedMeta({ recordCount: 0 }) },
+    }));
+  assert.equal(entry.status, 'OK');
+  assert.equal(STATUS_COUNTS[entry.status], 'ok');
+});
+
+test('classifyKey: missing outages payload is still EMPTY even with fresh 0-record meta', () => {
+  // The zero-record exemption is NARROW: it only applies once Redis proves the
+  // payload exists. A missing canonical key means publish died and must alarm
+  // EMPTY (crit), not be hidden by the sparse-feed allowance.
+  const entry = classifyKey('outages', BOOTSTRAP_KEYS.outages, { allowOnDemand: false },
+    makeCtx({
+      metaValues: { 'seed-meta:infra:outages': seedMeta({ recordCount: 0 }) },
+    }));
+  assert.equal(entry.status, 'EMPTY');
+  assert.equal(STATUS_COUNTS[entry.status], 'crit');
+});
+
+test('classifyKey: outages present + 0 records that goes STALE still warns (cron stopped)', () => {
+  // The exemption must NOT mask a genuine cron outage: once seed-meta age
+  // exceeds maxStaleMin (30), 0 records degrades to STALE_SEED (warn), not OK.
+  const entry = classifyKey('outages', BOOTSTRAP_KEYS.outages, { allowOnDemand: false },
+    makeCtx({
+      strens: { [BOOTSTRAP_KEYS.outages]: 149 },
+      metaValues: { 'seed-meta:infra:outages': seedMeta({ recordCount: 0, fetchedAt: NOW - 200 * ONE_MIN_MS }) },
+    }));
+  assert.equal(entry.status, 'STALE_SEED');
+  assert.equal(STATUS_COUNTS[entry.status], 'warn');
+});
+
 // ── cascade coverage (proactive, via isCascadeCovered) ──────────────────────
 
 test('cascade: empty theaterPostureLive with data in a sibling → OK_CASCADE (no crit/warn leak)', () => {


### PR DESCRIPTION
## What

The internet-outages panel showed nothing and `/api/health` reported outages **STALE_SEED**, while Cloudflare Radar visibly had data. Investigation: the data is *not* broken — it's a too-narrow query window plus a health false-alarm.

### Evidence (live CF Radar API, prod token)
The seeder hits `/radar/annotations/outages` (curated outage events — sparse by design):

| `dateRange` | annotations |
|---|---|
| `7d` (what the seeder queried) | **0** |
| `28d` | 1 — Iran nationwide shutdown, ended 2026-05-26 |
| `12w` | 23 |

All HTTP 200, `success: true`. The parser, field shape, and `COUNTRY_COORDS` filter are all correct — the feed genuinely had **0 events in the last 7 days**, and a *major* nationwide outage only 11 days old fell outside the 7d window. (The "plenty" visible on Radar is a different product — Traffic Anomalies, 35 live — already captured under the separate `cf:radar:traffic-anomalies:v1` key.)

## Changes

1. **`scripts/seed-internet-outages.mjs`** — `dateRange` `7d` → `28d` (surfaces recent major outages like the Iran shutdown) + add `zeroIsValid: true`. Zero mappable outages is the NORMAL state for this feed; without `zeroIsValid`, `runSeed` takes the contract `RETRY` path every quiet cycle and never refreshes `seed-meta.fetchedAt` → false `STALE_SEED` after `maxStaleMin`. The attached log showed ~24h of `RETRY: declareRecords returned 0` with the data key fresh but seed-meta frozen. Now publishes an empty `{outages:[]}` envelope + fresh meta. `sourceVersion` bumped to `cloudflare-radar-28d`.

2. **`api/health.js`** — add `'outages'` to `ZERO_RECORD_DATA_OK_KEYS` (**narrow** set). Present key + 0 records while fresh → `OK`; a **missing** canonical key still → `EMPTY` (crit), since the seeder always publishes the array so absence means a real publish failure; stale → `STALE_SEED`.

3. **`tests/health-classify.test.mjs`** — trio pinning the semantics (present+0+fresh → OK; missing+0+fresh → EMPTY; present+0+stale → STALE_SEED).

## Compatibility
Downstream consumers (`resilience-dimension-scorers`, `seed-correlation`, `seed-forecasts`, `seed-cross-source-signals`) already read the `{outages: [...]}` shape and already test `outages: []`. Publishing an empty array on quiet windows is *more* correct than the prior behavior (which left a stale non-zero payload frozen in cache).

## Verification
- `npx tsx --test tests/health-classify.test.mjs` → 20/20 pass (3 new)
- `npm run typecheck` → clean
- Live API probe confirms 28d surfaces the Iran outage

## Note
Prod cron runs the old code until deploy, so the false STALE_SEED persists until this merges + deploys. Deploy self-heals it.