### PR TITLE
Refresh internal CII review docs

### DIFF
--- a/docs/Docs_To_Review/COMPONENTS.md
+++ b/docs/Docs_To_Review/COMPONENTS.md
@@ -590,12 +590,12 @@ domain-specific markup.
 
 | Field | Detail |
 |---|---|
-| **File** | `src/components/CIIPanel.ts` (150 lines) |
+| **File** | `src/components/CIIPanel.ts` |
 | **Panel ID** | `cii` |
-| **Purpose** | Ranks countries by a composite instability score (U/C/S/I sub-scores). |
-| **Key methods** | `setShareStoryHandler()`, `refresh(forceLocal?)`, `getScores()` |
+| **Purpose** | Renders server-authoritative CII v5 scores for 31 Tier-1 countries from cached risk-score ingestion, with local fallback scoring when forced or no cached data is available. |
+| **Key methods** | `setShareStoryHandler()`, `setCountryClickHandler()`, `refresh(forceLocal?)`, `renderFromCached(cached)`, `getScores()` |
 | **DOM** | `.cii-list` → `.cii-country` each with header (emoji flag, name, score, trend arrow, share button), colour bar, sub-score row (U/C/S/I). |
-| **Services** | `calculateCII()`, `getCSSColor` |
+| **Services** | `toCountryScore()`, `calculateCII()` fallback path, `getCSSColor` |
 | **Variant** | `full` only |
 
 #### GdeltIntelPanel

--- a/docs/Docs_To_Review/TODO_Performance.md
+++ b/docs/Docs_To_Review/TODO_Performance.md
@@ -108,7 +108,6 @@ Status:  · 🔄 Partial · ❌ Not started
 - Several components build HTML strings and assign to `innerHTML`. For complex panels, pre-build a `DocumentFragment` off-DOM and append once.
 - **Expected gain:** Single reflow per panel update instead of multiple.
 
-
 ### PERF-012 — Remove Inline `<style>` Tags from Panel Renders
 
 - **Impact:** 🟡 Medium | **Effort:** ~1 day
@@ -344,8 +343,8 @@ Status:  · 🔄 Partial · ❌ Not started
 ### PERF-040 — Move CII Calculation to Web Worker
 
 - **Impact:** 🟡 Medium | **Effort:** ~4 hours
-- **Status:**  — `src/workers/cii.worker.ts` computes Country Instability Index scores for 20+ countries off the main thread, eliminating 50–150ms main-thread stalls.
-- **Expected gain:** Eliminates 50–150ms main-thread stalls during CII refresh.
+- **Status:** Deprecated premise — the proposed CII worker file was never added. Published CII is server-authoritative v5 for 31 Tier-1 countries from `shared/cii-weights.ts`; the frontend normally renders cached risk scores and only uses `calculateCII()` as the local fallback path.
+- **Expected gain:** Re-open only with fresh profiling evidence that the local fallback path, not cached server-score ingestion, causes measurable main-thread stalls.
 
 ### PERF-041 — SharedArrayBuffer for Large Datasets
 

--- a/docs/Docs_To_Review/todo.md
+++ b/docs/Docs_To_Review/todo.md
@@ -193,14 +193,16 @@ Overlay the map with country-colored fills based on CII score.
 | **Depends on** | — |
 
 **Description**
-CII currently monitors 20 hardcoded Tier 1 countries.
-Allow users to add custom countries to a Tier 2 watchlist with the same scoring pipeline.
+CII currently publishes server-authoritative v5 scores for 31 Tier-1 countries
+from `shared/cii-weights.ts`, then the browser ingests the cached risk-score
+feed with a local `country-instability.ts` fallback. This TODO is only current
+if reframed as user-defined Tier 2 monitoring layered on top of that contract.
 
 **AI instructions**
 
 1. Add a "+" button in the CII panel to search and add countries by name.
 2. Store Tier 2 list in localStorage.
-3. Run the same `calculateCII()` pipeline for Tier 2 countries (without conflict-zone floor scores).
+3. Define whether Tier 2 scores are server/API-backed or explicitly local-only fallback scores.
 4. Display Tier 2 countries in a collapsible sub-section of the CII panel.
 
 ---

--- a/docs/Docs_To_Review/todo_docs.md
+++ b/docs/Docs_To_Review/todo_docs.md
@@ -178,7 +178,7 @@
 - [ ] **Threat Classification** (`threat-classifier.ts`): hybrid keyword + LLM pipeline
 - [ ] **Signal Correlation** (`correlation.ts`): cross-source pattern matching logic
 - [ ] **Hotspot Escalation** (`hotspot-escalation.ts`): 4-signal scoring methodology
-- [ ] **Country Instability Index** (`country-instability.ts`): 22-country CII computation
+- [ ] **Country Instability Index** (`server/worldmonitor/intelligence/v1/get-risk-scores.ts`, `shared/cii-weights.ts`): server-authoritative CII v5 scoring for 31 Tier-1 countries, with frontend cached risk-score ingestion and `country-instability.ts` retained as the local fallback renderer path
 - [ ] **Temporal Baseline** (`temporal-baseline.ts`): Welford's online algorithm for anomaly detection
 - [ ] **Trending Keywords** (`trending-keywords.ts`): 2h vs 7d window spike detection
 - [ ] **Infrastructure Cascade** (`infrastructure-cascade.ts`): BFS propagation model

--- a/tests/cii-docs-drift.test.mts
+++ b/tests/cii-docs-drift.test.mts
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+
+const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+
+describe('CII docs drift guards', () => {
+  it('internal review docs do not retain stale CII country-count or source-of-truth claims', () => {
+    const internalDocPaths = [
+      'docs/Docs_To_Review/todo_docs.md',
+      'docs/Docs_To_Review/todo.md',
+      'docs/Docs_To_Review/TODO_Performance.md',
+      'docs/Docs_To_Review/COMPONENTS.md',
+    ];
+    const stalePatterns = [
+      /22-country CII computation/i,
+      /20 hardcoded Tier 1 countries/i,
+      /src\/workers\/cii\.worker\.ts/i,
+      /src\/components\/CIIPanel\.ts` \(150 lines\)/i,
+      /\*\*Country Instability Index\*\* \(`country-instability\.ts`\)/i,
+    ];
+
+    const violations: string[] = [];
+    for (const relPath of internalDocPaths) {
+      const text = readFileSync(resolve(root, relPath), 'utf8');
+      for (const pattern of stalePatterns) {
+        if (pattern.test(text)) violations.push(`${relPath}: ${pattern}`);
+      }
+    }
+
+    assert.equal(
+      violations.length,
+      0,
+      `internal CII review docs contain stale claims:\n  ${violations.join('\n  ')}`,
+    );
+  });
+});

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -1068,6 +1068,37 @@ describe('CII scoring', () => {
     );
   });
 
+  it('internal review docs do not retain stale CII country-count or source-of-truth claims', () => {
+    const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+    const internalDocPaths = [
+      'docs/Docs_To_Review/todo_docs.md',
+      'docs/Docs_To_Review/todo.md',
+      'docs/Docs_To_Review/TODO_Performance.md',
+      'docs/Docs_To_Review/COMPONENTS.md',
+    ];
+    const stalePatterns = [
+      /22-country CII computation/i,
+      /20 hardcoded Tier 1 countries/i,
+      /src\/workers\/cii\.worker\.ts/i,
+      /src\/components\/CIIPanel\.ts` \(150 lines\)/i,
+      /\*\*Country Instability Index\*\* \(`country-instability\.ts`\)/i,
+    ];
+
+    const violations: string[] = [];
+    for (const relPath of internalDocPaths) {
+      const text = readFileSync(resolve(root, relPath), 'utf8');
+      for (const pattern of stalePatterns) {
+        if (pattern.test(text)) violations.push(`${relPath}: ${pattern}`);
+      }
+    }
+
+    assert.equal(
+      violations.length,
+      0,
+      `internal CII review docs contain stale claims:\n  ${violations.join('\n  ')}`,
+    );
+  });
+
   it('methodology doc and browser CII engine expose the current conflict curve coefficients', () => {
     const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
     const doc = readFileSync(resolve(root, 'docs', 'methodology', 'cii-risk-scores.mdx'), 'utf8');

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -1068,37 +1068,6 @@ describe('CII scoring', () => {
     );
   });
 
-  it('internal review docs do not retain stale CII country-count or source-of-truth claims', () => {
-    const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
-    const internalDocPaths = [
-      'docs/Docs_To_Review/todo_docs.md',
-      'docs/Docs_To_Review/todo.md',
-      'docs/Docs_To_Review/TODO_Performance.md',
-      'docs/Docs_To_Review/COMPONENTS.md',
-    ];
-    const stalePatterns = [
-      /22-country CII computation/i,
-      /20 hardcoded Tier 1 countries/i,
-      /src\/workers\/cii\.worker\.ts/i,
-      /src\/components\/CIIPanel\.ts` \(150 lines\)/i,
-      /\*\*Country Instability Index\*\* \(`country-instability\.ts`\)/i,
-    ];
-
-    const violations: string[] = [];
-    for (const relPath of internalDocPaths) {
-      const text = readFileSync(resolve(root, relPath), 'utf8');
-      for (const pattern of stalePatterns) {
-        if (pattern.test(text)) violations.push(`${relPath}: ${pattern}`);
-      }
-    }
-
-    assert.equal(
-      violations.length,
-      0,
-      `internal CII review docs contain stale claims:\n  ${violations.join('\n  ')}`,
-    );
-  });
-
   it('methodology doc and browser CII engine expose the current conflict curve coefficients', () => {
     const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
     const doc = readFileSync(resolve(root, 'docs', 'methodology', 'cii-risk-scores.mdx'), 'utf8');


### PR DESCRIPTION
## Summary
- update internal Docs_To_Review CII references to server-authoritative v5, 31 Tier-1 countries, and cached frontend ingestion with local fallback
- mark the obsolete CII worker performance TODO as deprecated premise
- add a lightweight internal review doc drift guard for stale CII claims

## Validation
- ./node_modules/.bin/tsx --test tests/cii-scoring.test.mts tests/frontend-cii-closeout.test.mts
- ./node_modules/.bin/markdownlint-cli2 docs/Docs_To_Review/todo_docs.md docs/Docs_To_Review/todo.md docs/Docs_To_Review/TODO_Performance.md docs/Docs_To_Review/COMPONENTS.md
- git diff --check
- pre-push hook on git push -u origin codex/cii-docs-drift