### PR TITLE
Record dependency audit follow-up

### DIFF
--- a/docs/Docs_To_Review/dependency-audit-2026-06-02.md
+++ b/docs/Docs_To_Review/dependency-audit-2026-06-02.md
@@ -254,7 +254,7 @@ Conclusion: the dependency-audit gap is intentionally bounded, not green. Close 
 
 ## Round 11 / delegated CII dependency-audit follow-up - 2026-06-06
 
-Scope: delegated dependency-audit follow-up against fetched `origin/main` / detached HEAD `a560cb8c8f64cfd23058a42a41d4017ffadbe5f2` in `/Users/eliehabib/.codex/worktrees/28ba/worldmonitor`. This pass checked whether a minimal safe manifest or lockfile movement now exists for the residual `uuid <11.1.1` moderate advisory chain. No package manifest, lockfile, runtime code, or override was changed.
+Scope: delegated dependency-audit follow-up against fetched `origin/main` / detached HEAD `a560cb8c8f64cfd23058a42a41d4017ffadbe5f2` in an isolated Codex worktree. This pass checked whether a minimal safe manifest or lockfile movement now exists for the residual `uuid <11.1.1` moderate advisory chain. No package manifest, lockfile, runtime code, or override was changed.
 
 Current runtime for this check:
 

--- a/docs/Docs_To_Review/dependency-audit-2026-06-02.md
+++ b/docs/Docs_To_Review/dependency-audit-2026-06-02.md
@@ -251,3 +251,42 @@ Commands run for this check:
 The targeted package-lock-only update dry run for the implicated packages also reported 0 added, 0 removed, and 0 changed. No manifest, lockfile, or override change was applied because there is no current compatible package or lockfile movement that reduces the audit count without exceeding the current auth/wallet/export dependency envelope.
 
 Conclusion: the dependency-audit gap is intentionally bounded, not green. Close the CII audit item only as documented residual dependency debt; re-open remediation when Clerk removes or updates the Solana wallet pins, Solana wallet adapters accept a patched Solana web3 line, Solana web3 1.x removes `jayson -> uuid@8`, or `jayson`/`exceljs` publish compatible `uuid@>=11.1.1` support.
+
+## Round 11 / delegated CII dependency-audit follow-up - 2026-06-06
+
+Scope: delegated dependency-audit follow-up against fetched `origin/main` / detached HEAD `a560cb8c8f64cfd23058a42a41d4017ffadbe5f2` in `/Users/eliehabib/.codex/worktrees/28ba/worldmonitor`. This pass checked whether a minimal safe manifest or lockfile movement now exists for the residual `uuid <11.1.1` moderate advisory chain. No package manifest, lockfile, runtime code, or override was changed.
+
+Current runtime for this check:
+
+- `node -v`: `v24.15.0`
+- `npm -v`: `11.12.1`
+
+Current audit results:
+
+- `npm_config_cache=/tmp/worldmonitor-npm-cache npm audit --omit=dev --json`: 0 critical, 0 high, 12 moderate.
+- `npm_config_cache=/tmp/worldmonitor-npm-cache npm audit --json`: 0 critical, 0 high, 13 moderate.
+
+Lockfile dependency graph evidence:
+
+- `npm ls @clerk/clerk-js @solana/web3.js exceljs uuid jayson` returned an empty tree in this isolated worktree because `node_modules` was not installed.
+- `npm ls --package-lock-only @clerk/clerk-js @solana/web3.js exceljs uuid jayson` confirmed the production path: `@clerk/clerk-js@6.13.0 -> @solana/wallet-adapter-base@0.9.27` / `@solana/wallet-adapter-react@0.15.39 -> @solana/web3.js@1.98.4 -> jayson@4.3.0 -> uuid@8.3.2`.
+- The all-dependency-only extra path remains `exceljs@4.4.0 -> uuid@8.3.2`.
+
+Current registry and dry-run checks:
+
+- Latest `@clerk/clerk-js` is `6.14.0`, but it still depends on `@solana/wallet-adapter-base@0.9.27`, `@solana/wallet-adapter-react@0.15.39`, and `@solana/wallet-standard@1.1.4`.
+- Latest `@solana/wallet-adapter-base` is `0.9.27` and latest `@solana/wallet-adapter-react` is `0.15.39`; both still peer on `@solana/web3.js@^1.98.0`.
+- Latest stable `@solana/web3.js` is `1.98.4` and still depends on `jayson@^4.1.1`. `@solana/web3.js@2.0.0` is published, but forcing that line would exceed the wallet adapter peer envelope.
+- Latest `jayson` is `4.3.0` and still depends on `uuid@^8.3.2`.
+- Latest `exceljs` is `4.4.0` and still depends on `uuid@^8.3.0`.
+- `npm_config_cache=/tmp/worldmonitor-npm-cache npm audit fix --package-lock-only --dry-run --json` reported 0 added, 0 removed, and 0 changed, with the same 13 moderate all-dependency audit result.
+- `npm_config_cache=/tmp/worldmonitor-npm-cache npm update @clerk/clerk-js @solana/wallet-adapter-base @solana/wallet-adapter-react @solana/wallet-standard @solana/wallet-standard-wallet-adapter @solana/wallet-standard-wallet-adapter-base @solana/wallet-standard-wallet-adapter-react @solana/web3.js jayson uuid exceljs --package-lock-only --ignore-scripts --dry-run --json` reported 0 added, 0 removed, and 0 changed.
+
+The only npm-reported fix paths remain semver-major or downgrade-shaped changes:
+
+- `@clerk/clerk-js` 6.x -> 5.114.1, which would change the direct auth package major line.
+- `exceljs` 4.4.0 -> 3.4.0, which would downgrade the spreadsheet export dependency.
+
+Conclusion: no minimal safe package or lockfile change exists for this dependency-audit follow-up on 2026-06-06. Do not force a `uuid@>=11.1.1` override under `jayson` or `exceljs`; it would violate their declared `uuid@^8` dependency ranges. Do not force `@solana/web3.js@2.x` in this narrow audit closeout; that is a broader auth/wallet compatibility migration.
+
+Reopen dependency remediation when one of these lands and validates cleanly without broad auth/wallet/export churn: Clerk removes or updates the Solana wallet pins, Solana wallet adapters accept a patched Solana web3 line, Solana web3 1.x removes `jayson -> uuid@8`, `jayson` publishes compatible `uuid@>=11.1.1` support, or `exceljs` publishes compatible `uuid@>=11.1.1` support.


### PR DESCRIPTION
## Summary
- append the delegated dependency-audit follow-up evidence for the residual CII audit debt
- document the current Clerk/Solana/Jayson/UUID and ExcelJS/UUID blocker chains
- record why no safe manifest, lockfile, override, or Solana 2.x change was applied

## Validation
- npm_config_cache=/tmp/worldmonitor-npm-cache npx markdownlint-cli2 docs/Docs_To_Review/dependency-audit-2026-06-02.md
- git diff --check
- pre-push hook: typecheck, typecheck:api, lint:boundaries, lint:safe-html, lint:rate-limit-policies, lint:premium-fetch, edge function bundle check, lint:md, version:check

## Audit evidence
- npm audit --omit=dev --json: 12 moderate, 0 high, 0 critical
- npm audit --json: 13 moderate, 0 high, 0 critical
- npm audit fix --package-lock-only --dry-run --json: 0 added, 0 removed, 0 changed
- targeted package-lock-only update dry run for implicated packages: 0 added, 0 removed, 0 changed