### PR TITLE
fix(cii): harden cached score validation

### DIFF
--- a/src/services/cached-risk-scores.ts
+++ b/src/services/cached-risk-scores.ts
@@ -144,11 +144,43 @@ export function toRiskScores(resp: GetRiskScoresResponse): CachedRiskScores {
 // ---- Shape validator (localStorage is attacker-controlled) ----
 
 const VALID_LEVELS = new Set(['low', 'normal', 'elevated', 'high', 'critical']);
+const VALID_TRENDS = new Set(['rising', 'stable', 'falling']);
+const ISO2_RE = /^[A-Z]{2}$/;
+const COMPONENT_KEYS = ['unrest', 'conflict', 'security', 'information'] as const;
+
+function isFiniteInRange(value: unknown, min: number, max: number): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= min && value <= max;
+}
+
+function isKnownTier1Code(value: unknown): value is string {
+  return typeof value === 'string'
+    && ISO2_RE.test(value)
+    && Object.prototype.hasOwnProperty.call(TIER1_COUNTRIES, value);
+}
+
+function isValidComponents(value: unknown): value is ComponentScores {
+  if (!value || typeof value !== 'object') return false;
+  const components = value as Record<string, unknown>;
+  return COMPONENT_KEYS.every((key) => isFiniteInRange(components[key], 0, 100));
+}
 
 function isValidCiiEntry(e: unknown): e is CachedCIIScore {
   if (!e || typeof e !== 'object') return false;
   const o = e as Record<string, unknown>;
-  return typeof o.code === 'string' && Number.isFinite(o.score) && VALID_LEVELS.has(o.level as string);
+  return isKnownTier1Code(o.code)
+    && typeof o.name === 'string'
+    && isFiniteInRange(o.score, 0, 100)
+    && VALID_LEVELS.has(o.level as string)
+    && VALID_TRENDS.has(o.trend as string)
+    && isFiniteInRange(o.change24h, -100, 100)
+    && isValidComponents(o.components);
+}
+
+function canonicalizeCachedCiiEntry(entry: CachedCIIScore): CachedCIIScore {
+  return {
+    ...entry,
+    name: TIER1_COUNTRIES[entry.code] ?? entry.code,
+  };
 }
 
 // ---- localStorage persistence (sync prime for getCachedScores) ----
@@ -173,7 +205,7 @@ function loadFromStorage(): CachedRiskScores | null {
       localStorage.removeItem(LS_KEY);
       return null;
     }
-    return data;
+    return { ...data, cii: data.cii.map(canonicalizeCachedCiiEntry) };
   } catch { return null; }
 }
 

--- a/src/services/cached-risk-scores.ts
+++ b/src/services/cached-risk-scores.ts
@@ -147,6 +147,8 @@ const VALID_LEVELS = new Set(['low', 'normal', 'elevated', 'high', 'critical']);
 const VALID_TRENDS = new Set(['rising', 'stable', 'falling']);
 const ISO2_RE = /^[A-Z]{2}$/;
 const COMPONENT_KEYS = ['unrest', 'conflict', 'security', 'information'] as const;
+const CACHED_CII_TIMESTAMP_MIN_MS = Date.UTC(2000, 0, 1);
+const CACHED_CII_TIMESTAMP_MAX_FUTURE_MS = 5 * 60 * 1000;
 
 function isFiniteInRange(value: unknown, min: number, max: number): value is number {
   return typeof value === 'number' && Number.isFinite(value) && value >= min && value <= max;
@@ -164,6 +166,15 @@ function isValidComponents(value: unknown): value is ComponentScores {
   return COMPONENT_KEYS.every((key) => isFiniteInRange(components[key], 0, 100));
 }
 
+function isValidCachedCiiTimestamp(value: unknown): value is string | null {
+  if (value === null) return true;
+  if (typeof value !== 'string') return false;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp)
+    && timestamp >= CACHED_CII_TIMESTAMP_MIN_MS
+    && timestamp <= Date.now() + CACHED_CII_TIMESTAMP_MAX_FUTURE_MS;
+}
+
 function isValidCiiEntry(e: unknown): e is CachedCIIScore {
   if (!e || typeof e !== 'object') return false;
   const o = e as Record<string, unknown>;
@@ -173,7 +184,8 @@ function isValidCiiEntry(e: unknown): e is CachedCIIScore {
     && VALID_LEVELS.has(o.level as string)
     && VALID_TRENDS.has(o.trend as string)
     && isFiniteInRange(o.change24h, -100, 100)
-    && isValidComponents(o.components);
+    && isValidComponents(o.components)
+    && isValidCachedCiiTimestamp(o.lastUpdated);
 }
 
 function canonicalizeCachedCiiEntry(entry: CachedCIIScore): CachedCIIScore {

--- a/tests/cached-risk-scores.test.mts
+++ b/tests/cached-risk-scores.test.mts
@@ -326,6 +326,17 @@ describe('cached-risk-scores — functional adapter behavior', () => {
     assert.deepEqual(removedKeys, []);
   });
 
+  it('accepts null localStorage CII lastUpdated values', async () => {
+    const { getCachedScores, removedKeys } = await loadAdapter({
+      storageValue: makeStoredScores([makeCachedCii({ lastUpdated: null })]),
+    });
+
+    const cached = getCachedScores();
+    assert.ok(cached);
+    assert.equal(cached.cii[0]?.lastUpdated, null);
+    assert.deepEqual(removedKeys, []);
+  });
+
   it('rejects localStorage CII scores outside the safe render ranges', async () => {
     const invalidEntries = [
       makeCachedCii({ score: 10_000 }),
@@ -334,6 +345,22 @@ describe('cached-risk-scores — functional adapter behavior', () => {
       makeCachedCii({ change24h: -250 }),
       makeCachedCii({ components: { unrest: 10, conflict: 20, security: 30, information: 101 } }),
       makeCachedCii({ components: { unrest: -1, conflict: 20, security: 30, information: 40 } }),
+    ];
+
+    for (const entry of invalidEntries) {
+      const { getCachedScores, removedKeys } = await loadAdapter({
+        storageValue: makeStoredScores([entry]),
+      });
+      assert.equal(getCachedScores(), null);
+      assert.deepEqual(removedKeys, ['wm:risk-scores']);
+    }
+  });
+
+  it('rejects localStorage CII entries with unparseable or unreasonable lastUpdated values', async () => {
+    const invalidEntries = [
+      makeCachedCii({ lastUpdated: 'not-a-date' }),
+      makeCachedCii({ lastUpdated: '1999-12-31T23:59:59.999Z' }),
+      makeCachedCii({ lastUpdated: new Date(Date.now() + 10 * 60 * 1000).toISOString() }),
     ];
 
     for (const entry of invalidEntries) {

--- a/tests/cached-risk-scores.test.mts
+++ b/tests/cached-risk-scores.test.mts
@@ -303,10 +303,13 @@ describe('cached-risk-scores — functional adapter behavior', () => {
     });
 
     const cached = getCachedScores();
-    assert.equal(cached?.cii[0]!.code, 'US');
-    assert.equal(cached?.cii[0]!.name, 'United States');
-    assert.equal(cached?.cii[0]!.score, 42);
-    assert.deepEqual(cached?.cii[0]!.components, { unrest: 10, conflict: 20, security: 30, information: 40 });
+    assert.ok(cached);
+    const row = cached.cii[0];
+    assert.ok(row);
+    assert.equal(row.code, 'US');
+    assert.equal(row.name, 'United States');
+    assert.equal(row.score, 42);
+    assert.deepEqual(row.components, { unrest: 10, conflict: 20, security: 30, information: 40 });
     assert.deepEqual(removedKeys, []);
   });
 
@@ -315,7 +318,11 @@ describe('cached-risk-scores — functional adapter behavior', () => {
       storageValue: makeStoredScores([makeCachedCii({ name: 'Poisoned United States Display Name' })]),
     });
 
-    assert.equal(getCachedScores()?.cii[0]!.name, 'United States');
+    const cached = getCachedScores();
+    assert.ok(cached);
+    const row = cached.cii[0];
+    assert.ok(row);
+    assert.equal(row.name, 'United States');
     assert.deepEqual(removedKeys, []);
   });
 

--- a/tests/cached-risk-scores.test.mts
+++ b/tests/cached-risk-scores.test.mts
@@ -76,7 +76,7 @@ describe('cached-risk-scores — no fabricated timestamps in source', () => {
 // 2. Functional: exercise toRiskScores with stubbed imports
 // ============================================================
 
-async function loadAdapter() {
+async function loadAdapter(options: { storageValue?: string | null } = {}) {
   // Replace side-effecting imports with inert stubs so the module evaluates
   // without an RPC client, bootstrap, or circuit breaker.
   const patched = source
@@ -86,7 +86,7 @@ async function loadAdapter() {
     )
     .replace(
       "import { setHasCachedScores } from './country-instability';",
-      'const setHasCachedScores = (_: boolean) => {};',
+      'const setHasCachedScores = (value: boolean) => { (globalThis as any).__wmCachedRiskScoresHasCached = value; };',
     )
     .replace(
       "import { TIER1_COUNTRIES } from '@/config/countries';",
@@ -98,7 +98,7 @@ async function loadAdapter() {
     )
     .replace(
       "import { createCircuitBreaker } from '@/utils';",
-      'const createCircuitBreaker = <T,>(_opts: any) => ({ getCached: () => null as T | null, recordSuccess: (_: T) => {}, execute: async (fn: () => Promise<T>, _fb: T, _o: any) => fn() });',
+      'const createCircuitBreaker = <T,>(_opts: any) => ({ getCached: () => (globalThis as any).__wmCachedRiskScoresRecorded as T | null, recordSuccess: (value: T) => { (globalThis as any).__wmCachedRiskScoresRecorded = value; }, execute: async (fn: () => Promise<T>, _fb: T, _o: any) => fn() });',
     )
     .replace(
       "import { getHydratedData } from '@/services/bootstrap';",
@@ -109,11 +109,16 @@ async function loadAdapter() {
       'type ComponentScores = { unrest: number; conflict: number; security: number; information: number }; type CountryScore = any;',
     );
 
+  const removedKeys: string[] = [];
+  const storageValue = options.storageValue ?? null;
+  (globalThis as any).__wmCachedRiskScoresRecorded = null;
+  (globalThis as any).__wmCachedRiskScoresHasCached = false;
+
   // Stub localStorage so module-level loadFromStorage() doesn't throw under Node.
   (globalThis as unknown as { localStorage: Storage }).localStorage = {
-    getItem: () => null,
+    getItem: () => storageValue,
     setItem: () => {},
-    removeItem: () => {},
+    removeItem: (key: string) => { removedKeys.push(key); },
     clear: () => {},
     key: () => null,
     length: 0,
@@ -125,8 +130,8 @@ async function loadAdapter() {
     target: 'es2022',
   });
 
-  const dataUrl = `data:text/javascript;base64,${Buffer.from(transformed.code).toString('base64')}`;
-  return (await import(dataUrl)) as {
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(transformed.code).toString('base64')}#${Date.now()}-${Math.random()}`;
+  const mod = await import(dataUrl) as {
     toRiskScores: (resp: {
       ciiScores: Array<{
         region: string;
@@ -149,7 +154,17 @@ async function loadAdapter() {
       lastUpdated: Date | null;
       [k: string]: unknown;
     };
+    getCachedScores: () => {
+      cii: Array<{
+        code: string;
+        name: string;
+        score: number;
+        change24h: number;
+        components: { unrest: number; conflict: number; security: number; information: number };
+      }>;
+    } | null;
   };
+  return { ...mod, removedKeys };
 }
 
 function makeCii(region: string, computedAt: number, dynamicScore = 5, staticBaseline = 10, combinedScore = 30): {
@@ -174,6 +189,33 @@ function makeCii(region: string, computedAt: number, dynamicScore = 5, staticBas
     methodologyVersion: 'v1',
     eventMultiplier: 1,
   };
+}
+
+function makeCachedCii(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    code: 'US',
+    name: 'United States',
+    score: 42,
+    level: 'normal',
+    trend: 'stable',
+    change24h: 3,
+    components: { unrest: 10, conflict: 20, security: 30, information: 40 },
+    lastUpdated: new Date(1_700_000_000_000).toISOString(),
+    ...overrides,
+  };
+}
+
+function makeStoredScores(cii: Array<Record<string, unknown>>): string {
+  return JSON.stringify({
+    savedAt: Date.now(),
+    data: {
+      cii,
+      strategicRisk: { score: 0, level: 'low', trend: 'stable', lastUpdated: null, contributors: [] },
+      protestCount: 0,
+      computedAt: null,
+      cached: true,
+    },
+  });
 }
 
 describe('cached-risk-scores — functional adapter behavior', () => {
@@ -253,6 +295,63 @@ describe('cached-risk-scores — functional adapter behavior', () => {
 
     assert.equal(out.cii[0]!.name, 'Lebanon');
     assert.equal(out.strategicRisk.contributors[0]!.country, 'Lebanon');
+  });
+
+  it('primes the circuit breaker from valid localStorage CII scores', async () => {
+    const { getCachedScores, removedKeys } = await loadAdapter({
+      storageValue: makeStoredScores([makeCachedCii()]),
+    });
+
+    const cached = getCachedScores();
+    assert.equal(cached?.cii[0]!.code, 'US');
+    assert.equal(cached?.cii[0]!.name, 'United States');
+    assert.equal(cached?.cii[0]!.score, 42);
+    assert.deepEqual(cached?.cii[0]!.components, { unrest: 10, conflict: 20, security: 30, information: 40 });
+    assert.deepEqual(removedKeys, []);
+  });
+
+  it('normalizes localStorage CII names from the known Tier-1 country table', async () => {
+    const { getCachedScores, removedKeys } = await loadAdapter({
+      storageValue: makeStoredScores([makeCachedCii({ name: 'Poisoned United States Display Name' })]),
+    });
+
+    assert.equal(getCachedScores()?.cii[0]!.name, 'United States');
+    assert.deepEqual(removedKeys, []);
+  });
+
+  it('rejects localStorage CII scores outside the safe render ranges', async () => {
+    const invalidEntries = [
+      makeCachedCii({ score: 10_000 }),
+      makeCachedCii({ score: -1 }),
+      makeCachedCii({ change24h: 250 }),
+      makeCachedCii({ change24h: -250 }),
+      makeCachedCii({ components: { unrest: 10, conflict: 20, security: 30, information: 101 } }),
+      makeCachedCii({ components: { unrest: -1, conflict: 20, security: 30, information: 40 } }),
+    ];
+
+    for (const entry of invalidEntries) {
+      const { getCachedScores, removedKeys } = await loadAdapter({
+        storageValue: makeStoredScores([entry]),
+      });
+      assert.equal(getCachedScores(), null);
+      assert.deepEqual(removedKeys, ['wm:risk-scores']);
+    }
+  });
+
+  it('rejects localStorage CII entries with malformed or unknown ISO2 codes', async () => {
+    const invalidEntries = [
+      makeCachedCii({ code: 'us' }),
+      makeCachedCii({ code: 'USA' }),
+      makeCachedCii({ code: 'ZZ' }),
+    ];
+
+    for (const entry of invalidEntries) {
+      const { getCachedScores, removedKeys } = await loadAdapter({
+        storageValue: makeStoredScores([entry]),
+      });
+      assert.equal(getCachedScores(), null);
+      assert.deepEqual(removedKeys, ['wm:risk-scores']);
+    }
   });
 
   it('toCountryScore returns Date for non-null cached lastUpdated', async () => {


### PR DESCRIPTION
## Summary
- Harden localStorage cached CII admission with bounded score/component/change validation and known Tier-1 ISO2 codes.
- Canonicalize cached CII country names from the Tier-1 table before rendering cached data.
- Add regression coverage for valid cache priming, poisoned numeric/code rejection, and cached-name normalization.

## Validation
- npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/cached-risk-scores.test.mts tests/frontend-cii-closeout.test.mts
- npm run typecheck
- git diff --check
- normal git push pre-push hook passed