### PR TITLE
Fix CII runtime polish edge cases

### DIFF
--- a/scripts/seed-sanctions-pressure.mjs
+++ b/scripts/seed-sanctions-pressure.mjs
@@ -568,11 +568,6 @@ runSeed('sanctions', 'pressure', CANONICAL_KEY, fetchSanctionsPressure, {
       ttl: CACHE_TTL,
       transform: (data) => data._state,
     },
-    {
-      key: COUNTRY_COUNTS_KEY,
-      ttl: CACHE_TTL,
-      transform: (data) => data._countryCounts,
-    },
   ],
   afterPublish: async (data, _ctx) => {
     // Write entity lookup index with seed-meta so health.js can monitor it.

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -574,9 +574,10 @@ export interface UsageHook {
  * Use when callers need to distinguish cache hits from fresh fetches
  * (e.g. to set provider/cached metadata on responses).
  *
- * Returns { data, source } where source is:
+ * Returns { data, source, leader } where source is:
  *   'cache'  — served from Redis
  *   'fresh'  — fetcher ran (leader) or joined an in-flight fetch (follower)
+ * and leader is true only for the caller that actually ran the fetcher.
  *
  * If `opts.usage` is supplied, an upstream event is emitted on the fresh
  * path (issue #3381). Pass-through for callers that don't care about

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -588,24 +588,24 @@ export async function cachedFetchJsonWithMeta<T extends object>(
   fetcher: () => Promise<T | null>,
   negativeTtlSeconds = 120,
   opts?: { usage?: UsageHook; timeoutMs?: number },
-): Promise<{ data: T | null; source: 'cache' | 'fresh' }> {
+): Promise<{ data: T | null; source: 'cache' | 'fresh'; leader: boolean }> {
   const cached = await readCachedJson(key);
   if (cached.status === 'hit') {
-    if (cached.value === NEG_SENTINEL) return { data: null, source: 'cache' };
-    return { data: cached.value as T, source: 'cache' };
+    if (cached.value === NEG_SENTINEL) return { data: null, source: 'cache', leader: false };
+    return { data: cached.value as T, source: 'cache', leader: false };
   }
   const localPositive = readLocalPositiveFallback(key);
-  if (localPositive !== undefined) return { data: localPositive as T, source: 'cache' };
+  if (localPositive !== undefined) return { data: localPositive as T, source: 'cache', leader: false };
   const hadCacheReadError = cached.status === 'error';
   if (cached.status === 'error') {
     logCacheReadError(key, cached.error);
-    if (hasLocalNegativeCooldown(key)) return { data: null, source: 'cache' };
+    if (hasLocalNegativeCooldown(key)) return { data: null, source: 'cache', leader: false };
   }
 
   const existing = inflight.get(key);
   if (existing) {
     const data = (await existing) as T | null;
-    return { data, source: 'fresh' };
+    return { data, source: 'fresh', leader: false };
   }
 
   const fetchT0 = Date.now();
@@ -657,7 +657,7 @@ export async function cachedFetchJsonWithMeta<T extends object>(
   } finally {
     emitUpstreamFromHook(opts?.usage, upstreamStatus, Date.now() - fetchT0, cacheStatus);
   }
-  return { data, source: 'fresh' };
+  return { data, source: 'fresh', leader: true };
 }
 
 function emitUpstreamFromHook(usage: UsageHook | undefined, status: number, durationMs: number, cacheStatus: 'miss' | 'fresh' | 'stale-while-revalidate' | 'neg-sentinel'): void {

--- a/server/worldmonitor/infrastructure/v1/list-service-statuses.ts
+++ b/server/worldmonitor/infrastructure/v1/list-service-statuses.ts
@@ -312,7 +312,7 @@ export async function listServiceStatuses(
   req: ListServiceStatusesRequest,
 ): Promise<ListServiceStatusesResponse> {
   try {
-    const { data: results, source } = await cachedFetchJsonWithMeta<ServiceStatus[]>(INFRA_CACHE_KEY, INFRA_CACHE_TTL, async () => {
+    const { data: results, source, leader } = await cachedFetchJsonWithMeta<ServiceStatus[]>(INFRA_CACHE_KEY, INFRA_CACHE_TTL, async () => {
       const fresh = await Promise.all(SERVICES.map(checkServiceStatus));
       return fresh.length > 0 ? fresh : null;
     });
@@ -320,7 +320,7 @@ export async function listServiceStatuses(
     const effective = results || fallbackStatusesCache?.data || [];
     if (results) {
       fallbackStatusesCache = { data: results, ts: Date.now() };
-      if (source === 'fresh') {
+      if (source === 'fresh' && leader) {
         setCachedJson('seed-meta:infra:service-statuses', { fetchedAt: Date.now(), recordCount: results.length }, 604800).catch(() => {});
       }
     }

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -135,9 +135,10 @@ export const ZONE_COUNTRY_MAP: Record<string, string[]> = {
 };
 
 const ADVISORY_LEVELS_FALLBACK: Record<string, 'do-not-travel' | 'reconsider' | 'caution'> = {
+  // These floors are score-affecting methodology inputs; new country additions
+  // must go through a formula-version/docs changelog batch.
   UA: 'do-not-travel', SY: 'do-not-travel', YE: 'do-not-travel', MM: 'do-not-travel',
-  KP: 'do-not-travel',
-  IL: 'reconsider', IR: 'reconsider', PK: 'reconsider', VE: 'reconsider', CU: 'reconsider', MX: 'reconsider', CN: 'reconsider',
+  IL: 'reconsider', IR: 'reconsider', PK: 'reconsider', VE: 'reconsider', CU: 'reconsider', MX: 'reconsider',
   RU: 'caution', TR: 'caution', IQ: 'reconsider', AF: 'do-not-travel', LB: 'reconsider',
 };
 

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -136,7 +136,8 @@ export const ZONE_COUNTRY_MAP: Record<string, string[]> = {
 
 const ADVISORY_LEVELS_FALLBACK: Record<string, 'do-not-travel' | 'reconsider' | 'caution'> = {
   UA: 'do-not-travel', SY: 'do-not-travel', YE: 'do-not-travel', MM: 'do-not-travel',
-  IL: 'reconsider', IR: 'reconsider', PK: 'reconsider', VE: 'reconsider', CU: 'reconsider', MX: 'reconsider',
+  KP: 'do-not-travel',
+  IL: 'reconsider', IR: 'reconsider', PK: 'reconsider', VE: 'reconsider', CU: 'reconsider', MX: 'reconsider', CN: 'reconsider',
   RU: 'caution', TR: 'caution', IQ: 'reconsider', AF: 'do-not-travel', LB: 'reconsider',
 };
 
@@ -280,6 +281,10 @@ export function geoToCountry(lat: number, lon: number): string | null {
 function safeNum(v: unknown): number {
   const n = Number(v);
   return Number.isFinite(n) ? n : 0;
+}
+
+function safeNonNegativeNum(v: unknown): number {
+  return Math.max(0, safeNum(v));
 }
 
 function logScaledScore(raw: number, cap: number, pivot: number): number {
@@ -558,8 +563,8 @@ async function fetchAuxiliarySources(): Promise<AuxiliarySources> {
 
   let orefData: AuxiliarySources['orefData'] = null;
   if (orefRaw && typeof orefRaw === 'object') {
-    const alertCount = safeNum((orefRaw as any).activeAlertCount);
-    const histCount = safeNum((orefRaw as any).historyCount24h);
+    const alertCount = safeNonNegativeNum((orefRaw as any).activeAlertCount);
+    const histCount = safeNonNegativeNum((orefRaw as any).historyCount24h);
     orefData = { activeAlertCount: alertCount, historyCount24h: histCount };
   }
 
@@ -568,14 +573,14 @@ async function fetchAuxiliarySources(): Promise<AuxiliarySources> {
   const dispCountries: any[] = arr(displacementRaw, 'countries');
   for (const c of dispCountries) {
     const iso3 = String(c.code || '').toUpperCase();
-    if (iso3) displacedByIso3[iso3] = safeNum(c.totalDisplaced);
+    if (iso3) displacedByIso3[iso3] = safeNonNegativeNum(c.totalDisplaced);
   }
   // Also try nested summary.countries (seed wraps in { summary: { countries: [...] } })
   if (dispCountries.length === 0) {
     const summaryCountries: any[] = arr((displacementRaw as any)?.summary, 'countries');
     for (const c of summaryCountries) {
       const iso3 = String(c.code || '').toUpperCase();
-      if (iso3) displacedByIso3[iso3] = safeNum(c.totalDisplaced);
+      if (iso3) displacedByIso3[iso3] = safeNonNegativeNum(c.totalDisplaced);
     }
   }
 
@@ -595,7 +600,7 @@ async function fetchAuxiliarySources(): Promise<AuxiliarySources> {
   if (sanctionsCountsRaw && typeof sanctionsCountsRaw === 'object' && !Array.isArray(sanctionsCountsRaw)) {
     for (const [rawCode, rawCount] of Object.entries(sanctionsCountsRaw as Record<string, unknown>)) {
       const code = String(rawCode || '').toUpperCase();
-      const count = safeNum(rawCount);
+      const count = safeNonNegativeNum(rawCount);
       if (/^[A-Z]{2}$/.test(code) && count > 0) sanctionsCountryCounts[code] = count;
     }
   }
@@ -656,12 +661,13 @@ export function computeCIIScores(
     if (!code || !data[code]) continue;
     const type = ev.event_type.toLowerCase();
     const weight = (ev.daysAgo ?? 0) <= 7 ? 1.0 : 0.4;
-    const fat = safeNum(ev.fatalities) * weight;
+    const fatalities = safeNonNegativeNum(ev.fatalities);
+    const fat = fatalities * weight;
     if (type.includes('protest')) {
       data[code].protests += weight;
       data[code].protestFatalities += fat;
       // High-severity = the event killed someone (classifySeverity rule).
-      if (safeNum(ev.fatalities) > 0) data[code].highSeverityUnrest += weight;
+      if (fatalities > 0) data[code].highSeverityUnrest += weight;
     } else if (type.includes('riot')) {
       data[code].riots += weight;
       data[code].protestFatalities += fat;
@@ -736,7 +742,7 @@ export function computeCIIScores(
     if (!code || !data[code]) continue;
     data[code].fireCount++;
     // "High" fire — bright or high radiative power (Phase 3b / D8, matches the frontend).
-    if (safeNum(f.brightness) >= 360 || safeNum(f.frp) >= 50) data[code].fireHighCount++;
+    if (safeNonNegativeNum(f.brightness) >= 360 || safeNonNegativeNum(f.frp) >= 50) data[code].fireHighCount++;
   }
 
   // --- GPS hex severity split ---
@@ -766,7 +772,7 @@ export function computeCIIScores(
   // --- Earthquakes (Phase 1) — magnitude >= 5.5, within 7-day lookback ---
   const eqCutoff = Date.now() - 7 * 24 * 60 * 60 * 1000;
   for (const eq of aux.earthquakes ?? []) {
-    const mag = safeNum(eq.magnitude);
+    const mag = safeNonNegativeNum(eq.magnitude);
     if (mag < 5.5) continue;
     if (safeNum(eq.occurredAt) < eqCutoff) continue;
     const code = geoToCountry(safeNum(eq.location?.latitude), safeNum(eq.location?.longitude));
@@ -783,7 +789,7 @@ export function computeCIIScores(
   for (const [rawCode, rawCount] of Object.entries(fullSanctionsCounts ?? {})) {
     const code = String(rawCode || '').toUpperCase();
     if (!data[code]) continue;
-    data[code].sanctionsEntryCount = safeNum(rawCount);
+    data[code].sanctionsEntryCount = safeNonNegativeNum(rawCount);
   }
   for (const c of aux.sanctionsCountries ?? []) {
     const code = String(c.countryCode || '').toUpperCase();
@@ -791,9 +797,9 @@ export function computeCIIScores(
     // Accumulate (not assign): the producer keys per-country rows by `code:name`, so one
     // ISO2 can appear in multiple rows when the source spells the name differently.
     if (!fullSanctionsCounts || !Object.prototype.hasOwnProperty.call(fullSanctionsCounts, code)) {
-      data[code].sanctionsEntryCount += safeNum(c.entryCount);
+      data[code].sanctionsEntryCount += safeNonNegativeNum(c.entryCount);
     }
-    data[code].sanctionsNewEntryCount += safeNum(c.newEntryCount);
+    data[code].sanctionsNewEntryCount += safeNonNegativeNum(c.newEntryCount);
   }
 
   // --- Temporal anomalies (Phase 1) — region is ISO2 or country name; skip 'global' ---
@@ -810,13 +816,13 @@ export function computeCIIScores(
   for (const [code, m] of Object.entries(aux.militaryCii ?? {})) {
     const d = data[code];
     if (!d || !m || typeof m !== 'object') continue;
-    d.militaryOwnFlights = safeNum((m as any).ownFlights);
-    d.militaryForeignFlights = safeNum((m as any).foreignFlights);
-    d.militaryOwnVessels = safeNum((m as any).ownVessels);
-    d.militaryForeignVessels = safeNum((m as any).foreignVessels);
-    d.aisDisruptionHighCount = safeNum((m as any).aisDisruptionHigh);
-    d.aisDisruptionElevatedCount = safeNum((m as any).aisDisruptionElevated);
-    d.aisDisruptionLowCount = safeNum((m as any).aisDisruptionLow);
+    d.militaryOwnFlights = safeNonNegativeNum((m as any).ownFlights);
+    d.militaryForeignFlights = safeNonNegativeNum((m as any).foreignFlights);
+    d.militaryOwnVessels = safeNonNegativeNum((m as any).ownVessels);
+    d.militaryForeignVessels = safeNonNegativeNum((m as any).foreignVessels);
+    d.aisDisruptionHighCount = safeNonNegativeNum((m as any).aisDisruptionHigh);
+    d.aisDisruptionElevatedCount = safeNonNegativeNum((m as any).aisDisruptionElevated);
+    d.aisDisruptionLowCount = safeNonNegativeNum((m as any).aisDisruptionLow);
   }
 
   // --- Iran strikes with severity ---
@@ -859,7 +865,7 @@ export function computeCIIScores(
       if (!signals) continue;
       let score = 0;
       for (const [lvl, w] of Object.entries(SUMMARY_WEIGHT)) {
-        score += (counts[lvl as keyof typeof counts] || 0) * w;
+        score += safeNonNegativeNum(counts[lvl as keyof typeof counts]) * w;
       }
       signals.threatSummaryScore = Math.min(20, score);
     }
@@ -1179,6 +1185,20 @@ async function readCiiTrendPriorScores(nowMs: number): Promise<CiiScore[] | null
   return selectCiiTrendPriorSnapshot(snapshots, nowMs)?.ciiScores ?? null;
 }
 
+const CII_TREND_PRIOR_GAP_LOG_THROTTLE_MS = 10 * 60 * 1000;
+let lastCiiTrendPriorGapLogAt = 0;
+
+function recordCiiTrendPriorGap(nowMs: number): void {
+  if (nowMs - lastCiiTrendPriorGapLogAt < CII_TREND_PRIOR_GAP_LOG_THROTTLE_MS) return;
+  lastCiiTrendPriorGapLogAt = nowMs;
+  console.info('[cii] trend prior unavailable; returning stable movement labels until 24h trend history is populated', {
+    nowMs,
+    candidateBuckets: getCiiTrendPriorCandidateBuckets(nowMs),
+    targetAgeMs: CII_TREND_TARGET_AGE_MS,
+    bucketMs: CII_TREND_BUCKET_MS,
+  });
+}
+
 async function persistCiiTrendSnapshot(response: GetRiskScoresResponse): Promise<void> {
   const snapshot = ciiTrendSnapshotFromResponse(response);
   if (!snapshot) return;
@@ -1199,7 +1219,7 @@ export async function getRiskScores(
   req: GetRiskScoresRequest,
 ): Promise<GetRiskScoresResponse> {
   try {
-    const { data: result, source } = await cachedFetchJsonWithMeta<GetRiskScoresResponse>(
+    const { data: result, source, leader } = await cachedFetchJsonWithMeta<GetRiskScoresResponse>(
       RISK_CACHE_KEY,
       RISK_CACHE_TTL,
       async () => {
@@ -1209,14 +1229,15 @@ export async function getRiskScores(
           fetchAuxiliarySources(),
           readCiiTrendPriorScores(nowMs),
         ]);
+        if (!priorCiiScores?.length) recordCiiTrendPriorGap(nowMs);
         const ciiScores = computeCIIScores(acled, aux, { priorScores: priorCiiScores, nowMs });
         const strategicRisks = computeStrategicRisks(ciiScores);
         return { ciiScores, strategicRisks };
       },
     );
     if (result) {
-      await setCachedJson(RISK_STALE_CACHE_KEY, result, RISK_STALE_TTL).catch(() => {});
-      // Write seed-meta on every FRESH upstream fetch so /api/health.riskScores
+      // Write stale fallback, trend history, and seed-meta on every FRESH upstream
+      // fetch by the true in-process leader so /api/health.riskScores
       // stays green from real user traffic, independent of the ais-relay
       // CII warm-ping. Pre-2026-05-02 the warm-ping was the SOLE writer of
       // this seed-meta — when the relay → api.worldmonitor.app auth path
@@ -1226,8 +1247,10 @@ export async function getRiskScores(
       // via real user traffic. This brings riskScores into the same pattern
       // as those two: defense-in-depth, no single point of freshness failure.
       //
-      // Gated on source === 'fresh' (PR #3562 review P2): cachedFetchJsonWithMeta
-      // returns immediately on cache hits with `source: 'cache'`. Stamping
+      // Gated on source === 'fresh' && leader (PR #3562 review P2 + CII P3
+      // runtime polish): cachedFetchJsonWithMeta returns immediately on cache
+      // hits with `source: 'cache'`, and concurrent followers of the same miss
+      // get `leader: false`. Stamping
       // `fetchedAt: Date.now()` on cache hits would conflate "data was
       // recently re-fetched" with "data was recently served," letting
       // health.riskScores stay fresh even when upstream stopped responding
@@ -1237,16 +1260,20 @@ export async function getRiskScores(
       // hit). Only stamp on actual upstream re-fetches.
       // 7-day TTL matches the warm-ping write so health.maxStaleMin (30min)
       // logic is unchanged.
-      if (source === 'fresh') {
-        await persistCiiTrendSnapshot(result).catch(() => {});
+      if (source === 'fresh' && leader) {
         const count = result.ciiScores?.length || 0;
+        const writes: Array<Promise<unknown>> = [
+          setCachedJson(RISK_STALE_CACHE_KEY, result, RISK_STALE_TTL),
+          persistCiiTrendSnapshot(result),
+        ];
         if (count > 0) {
-          await setCachedJson(
+          writes.push(setCachedJson(
             'seed-meta:intelligence:risk-scores',
             { fetchedAt: Date.now(), recordCount: count },
             604800,
-          ).catch(() => {});
+          ));
         }
+        await Promise.all(writes.map((write) => write.catch(() => undefined)));
       }
       return filterRiskScoresResponse(result, req.region);
     }

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -369,7 +369,7 @@ describe('CII scoring', () => {
 
   it('advisory do-not-travel floor: composite >= 60', () => {
     const scores = computeCIIScores([], emptyAux());
-    for (const code of ['UA', 'SY', 'YE', 'MM', 'KP']) {
+    for (const code of ['UA', 'SY', 'YE', 'MM']) {
       const s = scoreFor(scores, code)!;
       assert.ok(s.combinedScore >= 60, `${code} score ${s.combinedScore} should be >= 60 (do-not-travel)`);
     }
@@ -377,7 +377,7 @@ describe('CII scoring', () => {
 
   it('advisory reconsider floor: composite >= 50', () => {
     const scores = computeCIIScores([], emptyAux());
-    for (const code of ['MX', 'IR', 'PK', 'VE', 'CU', 'CN']) {
+    for (const code of ['MX', 'IR', 'PK', 'VE', 'CU']) {
       const s = scoreFor(scores, code)!;
       assert.ok(s.combinedScore >= 50, `${code} score ${s.combinedScore} should be >= 50 (reconsider)`);
     }

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -369,7 +369,7 @@ describe('CII scoring', () => {
 
   it('advisory do-not-travel floor: composite >= 60', () => {
     const scores = computeCIIScores([], emptyAux());
-    for (const code of ['UA', 'SY', 'YE', 'MM']) {
+    for (const code of ['UA', 'SY', 'YE', 'MM', 'KP']) {
       const s = scoreFor(scores, code)!;
       assert.ok(s.combinedScore >= 60, `${code} score ${s.combinedScore} should be >= 60 (do-not-travel)`);
     }
@@ -377,7 +377,7 @@ describe('CII scoring', () => {
 
   it('advisory reconsider floor: composite >= 50', () => {
     const scores = computeCIIScores([], emptyAux());
-    for (const code of ['MX', 'IR', 'PK', 'VE', 'CU']) {
+    for (const code of ['MX', 'IR', 'PK', 'VE', 'CU', 'CN']) {
       const s = scoreFor(scores, code)!;
       assert.ok(s.combinedScore >= 50, `${code} score ${s.combinedScore} should be >= 50 (reconsider)`);
     }
@@ -514,6 +514,32 @@ describe('CII scoring', () => {
     assert.ok(us.combinedScore >= 2 && us.combinedScore <= 10, `US baseline score ${us.combinedScore} should be ~2-10`);
   });
 
+  it('clamps negative upstream counts before score math', () => {
+    const aux = emptyAux();
+    aux.militaryCii = {
+      UA: {
+        ownFlights: -5,
+        foreignFlights: -3,
+        ownVessels: -2,
+        foreignVessels: -1,
+        aisDisruptionHigh: -4,
+        aisDisruptionElevated: -8,
+        aisDisruptionLow: -13,
+      },
+    };
+    aux.orefData = { activeAlertCount: -5, historyCount24h: -12 };
+    aux.threatSummaryByCountry = { UA: { critical: -2, high: -3, medium: -5, low: -8, info: -13 } };
+    aux.sanctionsCountryCounts = { UA: -200 };
+
+    const scores = computeCIIScores([acledEvent('Ukraine', 'Battles', -9)], aux, { nowMs: TREND_TEST_NOW });
+    const ua = scoreFor(scores, 'UA')!;
+
+    assert.equal(Number.isFinite(ua.combinedScore), true, 'negative fatalities must not produce NaN scores');
+    assert.equal(Number.isFinite(ua.components!.ciiContribution), true, 'negative counts must not produce NaN components');
+    assert.ok(ua.components!.militaryActivity >= 0, 'negative military counts must not lower security below zero');
+    assert.ok(ua.components!.newsActivity >= 0, 'negative threat counts must not lower news below zero');
+  });
+
   it('cold-start emits flat movement instead of baseline delta', () => {
     const us = scoreFor(computeCIIScores([], emptyAux(), { nowMs: TREND_TEST_NOW }), 'US')!;
     assert.notEqual(us.combinedScore - us.staticBaseline, 0, 'fixture should have a non-zero structural baseline gap');
@@ -624,11 +650,15 @@ describe('CII scoring', () => {
       'get-risk-scores.ts',
     );
     const handlerSource = readFileSync(handlerPath, 'utf8');
-    const freshGateIndex = handlerSource.indexOf("if (source === 'fresh')");
-    const trendPersistIndex = handlerSource.indexOf('await persistCiiTrendSnapshot(result)');
+    const freshGateIndex = handlerSource.indexOf("if (source === 'fresh' && leader)");
+    const trendPersistIndex = handlerSource.indexOf('persistCiiTrendSnapshot(result)');
 
     assert.match(handlerSource, /readCiiTrendPriorScores\(nowMs\)/);
     assert.doesNotMatch(handlerSource, /priorRiskScores/);
+    assert.match(handlerSource, /recordCiiTrendPriorGap\(nowMs\)/,
+      'fresh computations without a valid 24h prior must leave an operator-visible trend gap signal');
+    assert.match(handlerSource, /Promise\.all\(writes\.map/,
+      'leader-only post-fetch writes should run in parallel instead of serially');
     assert.ok(trendPersistIndex > freshGateIndex, 'trend history writes must be gated to fresh upstream computations');
   });
 

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -224,11 +224,12 @@ describe('cachedFetchJsonWithMeta source labeling', { concurrency: 1 }, () => {
     };
 
     try {
-      const { data, source } = await redis.cachedFetchJsonWithMeta('meta:test:miss', 60, async () => {
+      const { data, source, leader } = await redis.cachedFetchJsonWithMeta('meta:test:miss', 60, async () => {
         return { value: 'fresh-data' };
       });
 
       assert.equal(source, 'fresh', 'should report source=fresh on cache miss');
+      assert.equal(leader, true, 'cache miss caller that runs the fetcher should be marked leader');
       assert.deepEqual(data, { value: 'fresh-data' });
     } finally {
       globalThis.fetch = originalFetch;
@@ -236,7 +237,7 @@ describe('cachedFetchJsonWithMeta source labeling', { concurrency: 1 }, () => {
     }
   });
 
-  it('reports source=fresh for ALL coalesced concurrent callers', async () => {
+  it('reports source=fresh for all coalesced callers but marks only the fetch leader', async () => {
     const redis = await importRedisFresh();
     const restoreEnv = withEnv({
       UPSTASH_REDIS_REST_URL: 'https://redis.test',
@@ -271,6 +272,7 @@ describe('cachedFetchJsonWithMeta source labeling', { concurrency: 1 }, () => {
       assert.equal(a.source, 'fresh', 'leader should report fresh');
       assert.equal(b.source, 'fresh', 'follower 1 should report fresh (not cache)');
       assert.equal(c.source, 'fresh', 'follower 2 should report fresh (not cache)');
+      assert.equal([a, b, c].filter((r) => r.leader).length, 1, 'only one coalesced caller should be the write leader');
       assert.deepEqual(a.data, { value: 'coalesced' });
       assert.deepEqual(b.data, { value: 'coalesced' });
       assert.deepEqual(c.data, { value: 'coalesced' });

--- a/tests/sanctions-pressure.test.mjs
+++ b/tests/sanctions-pressure.test.mjs
@@ -51,6 +51,24 @@ describe('handler: _state stripping', () => {
       'extraKeys must reference STATE_KEY to write _state separately from canonical payload',
     );
   });
+
+  it('seed writes country counts only through afterPublish metadata path', () => {
+    const extraKeysStart = seedSrc.indexOf('extraKeys: [');
+    const afterPublishStart = seedSrc.indexOf('afterPublish: async');
+    assert.ok(extraKeysStart >= 0 && afterPublishStart > extraKeysStart, 'seed must define extraKeys before afterPublish');
+
+    const extraKeysBlock = seedSrc.slice(extraKeysStart, afterPublishStart);
+    assert.doesNotMatch(
+      extraKeysBlock,
+      /COUNTRY_COUNTS_KEY/,
+      'COUNTRY_COUNTS_KEY must not be duplicated in extraKeys; afterPublish writes it with seed-meta for health',
+    );
+    assert.match(
+      seedSrc.slice(afterPublishStart),
+      /writeExtraKeyWithMeta\(\s*COUNTRY_COUNTS_KEY/s,
+      'afterPublish must keep writing COUNTRY_COUNTS_KEY with freshness metadata',
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- clamp non-negative CII runtime inputs without touching signed coordinate parsing
- expose sparse trend-history gaps in logs and gate post-fetch writes to the true cache leader
- preserve sanctions country-count seed metadata while removing the duplicate key write
- add KP/CN advisory fallback coverage

## Validation
- env npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/cii-scoring.test.mts
- node --test tests/sanctions-pressure.test.mjs
- env npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/redis-caching.test.mjs
- npm run typecheck:api
- git diff --check
- pre-push hook on git push: typecheck, typecheck:api, lint guards, edge bundle check, changed tests, version check