### PR TITLE
Fix frontend CII source of truth for on-demand surfaces

### DIFF
--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -22,7 +22,7 @@ import {
   nameToCountryCode,
 } from '@/services/country-geometry';
 import { calculateCII, getCountryData, TIER1_COUNTRIES, type CountryScore } from '@/services/country-instability';
-import { getCachedCountryScore } from '@/services/cached-risk-scores';
+import { getCachedCountryScore, normalizeCiiCountryCode } from '@/services/cached-risk-scores';
 import { signalAggregator } from '@/services/signal-aggregator';
 import { dataFreshness } from '@/services/data-freshness';
 import { fetchCountryMarkets } from '@/services/prediction';
@@ -216,7 +216,8 @@ export class CountryIntelManager implements AppModule {
     const canonicalName = TIER1_COUNTRIES[code] || CountryIntelManager.resolveCountryName(code);
     if (canonicalName !== code) country = canonicalName;
 
-    const score = getCachedCountryScore(code) ?? calculateCII().find((s) => s.code === code) ?? null;
+    const scoreCode = normalizeCiiCountryCode(code);
+    const score = getCachedCountryScore(scoreCode) ?? calculateCII().find((s) => s.code === scoreCode) ?? null;
 
     const signals = this.getCountrySignals(code, country);
 
@@ -732,7 +733,8 @@ export class CountryIntelManager implements AppModule {
     const code = page.getCode();
     if (!code || code === '__loading__' || code === '__error__') return;
     const name = TIER1_COUNTRIES[code] ?? CountryIntelManager.resolveCountryName(code);
-    const score = getCachedCountryScore(code) ?? calculateCII().find((s) => s.code === code) ?? null;
+    const scoreCode = normalizeCiiCountryCode(code);
+    const score = getCachedCountryScore(scoreCode) ?? calculateCII().find((s) => s.code === scoreCode) ?? null;
     const signals = this.getCountrySignals(code, name);
     page.updateScore?.(score, signals);
   }

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -21,8 +21,8 @@ import {
   iso3ToIso2Code,
   nameToCountryCode,
 } from '@/services/country-geometry';
-import { calculateCII, getCountryData, TIER1_COUNTRIES, hasIntelligenceSignalsLoaded, type CountryScore } from '@/services/country-instability';
-import { getCachedScores, toCountryScore } from '@/services/cached-risk-scores';
+import { calculateCII, getCountryData, TIER1_COUNTRIES, type CountryScore } from '@/services/country-instability';
+import { getCachedCountryScore } from '@/services/cached-risk-scores';
 import { signalAggregator } from '@/services/signal-aggregator';
 import { dataFreshness } from '@/services/data-freshness';
 import { fetchCountryMarkets } from '@/services/prediction';
@@ -216,13 +216,7 @@ export class CountryIntelManager implements AppModule {
     const canonicalName = TIER1_COUNTRIES[code] || CountryIntelManager.resolveCountryName(code);
     if (canonicalName !== code) country = canonicalName;
 
-    const scores = calculateCII();
-    let score = scores.find((s) => s.code === code) ?? null;
-
-    if (!hasIntelligenceSignalsLoaded()) {
-      const cached = getCachedScores()?.cii.find((c) => c.code === code);
-      if (cached) score = toCountryScore(cached);
-    }
+    const score = getCachedCountryScore(code) ?? calculateCII().find((s) => s.code === code) ?? null;
 
     const signals = this.getCountrySignals(code, country);
 
@@ -738,12 +732,7 @@ export class CountryIntelManager implements AppModule {
     const code = page.getCode();
     if (!code || code === '__loading__' || code === '__error__') return;
     const name = TIER1_COUNTRIES[code] ?? CountryIntelManager.resolveCountryName(code);
-    const scores = calculateCII();
-    let score = scores.find((s) => s.code === code) ?? null;
-    if (!hasIntelligenceSignalsLoaded()) {
-      const cached = getCachedScores()?.cii.find((c) => c.code === code);
-      if (cached) score = toCountryScore(cached);
-    }
+    const score = getCachedCountryScore(code) ?? calculateCII().find((s) => s.code === code) ?? null;
     const signals = this.getCountrySignals(code, name);
     page.updateScore?.(score, signals);
   }

--- a/src/components/CountryIntelModal.ts
+++ b/src/components/CountryIntelModal.ts
@@ -103,7 +103,7 @@ export class CountryIntelModal {
 
   private scoreBar(score: number): string {
     const pct = Math.min(100, Math.max(0, score));
-    const color = pct >= 70 ? getCSSColor('--semantic-critical') : pct >= 50 ? getCSSColor('--semantic-high') : pct >= 30 ? getCSSColor('--semantic-elevated') : getCSSColor('--semantic-normal');
+    const color = pct >= 81 ? getCSSColor('--semantic-critical') : pct >= 66 ? getCSSColor('--semantic-high') : pct >= 51 ? getCSSColor('--semantic-elevated') : getCSSColor('--semantic-normal');
     return `
       <div class="cii-score-bar">
         <div class="cii-score-fill" style="width:${pct}%;background:${color}"></div>

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -128,6 +128,7 @@ import {
   setGeoAlertGetter,
 } from '@/services/hotspot-escalation';
 import { getCountryScore } from '@/services/country-instability';
+import { getCachedCountryScoreValue } from '@/services/cached-risk-scores';
 import { getAlertsNearLocation } from '@/services/geo-convergence';
 import type { PositiveGeoEvent } from '@/services/positive-events-geo';
 import type { KindnessPoint } from '@/services/kindness-data';
@@ -6611,7 +6612,7 @@ export class DeckGLMap {
   }
 
   public initEscalationGetters(): void {
-    setCIIGetter(getCountryScore);
+    setCIIGetter((code) => getCachedCountryScoreValue(code) ?? getCountryScore(code));
     setGeoAlertGetter(getAlertsNearLocation);
   }
 

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -57,6 +57,7 @@ import {
   setGeoAlertGetter,
 } from '@/services/hotspot-escalation';
 import { getCountryScore } from '@/services/country-instability';
+import { getCachedCountryScoreValue } from '@/services/cached-risk-scores';
 import { getAlertsNearLocation } from '@/services/geo-convergence';
 import { getCountryAtCoordinates, getCountryBbox } from '@/services/country-geometry';
 import type { CountryClickPayload } from './DeckGLMap';
@@ -3352,7 +3353,7 @@ export class MapComponent {
   }
 
   public initEscalationGetters(): void {
-    setCIIGetter(getCountryScore);
+    setCIIGetter((code) => getCachedCountryScoreValue(code) ?? getCountryScore(code));
     setGeoAlertGetter(getAlertsNearLocation);
   }
 

--- a/src/components/StrategicRiskPanel.ts
+++ b/src/components/StrategicRiskPanel.ts
@@ -18,7 +18,7 @@ import {
   type DataSourceState,
   type DataFreshnessSummary,
 } from '@/services/data-freshness';
-import { getLearningProgress, hasIntelligenceSignalsLoaded, type CountryScore } from '@/services/country-instability';
+import { getLearningProgress, type CountryScore } from '@/services/country-instability';
 import { fetchCachedRiskScores, toCountryScore, type CachedRiskScores } from '@/services/cached-risk-scores';
 import { getCachedPosture } from '@/services/cached-theater-posture';
 import { refreshDataFreshnessFromHealth } from '@/services/health-freshness';
@@ -119,9 +119,9 @@ export class StrategicRiskPanel extends Panel {
     breakingScore = Math.min(15, breakingScore);
 
     // Gather theater postures from cached service
-    const cached = getCachedPosture();
-    const postures = cached?.postures;
-    const staleFactor = cached?.stale ? 0.5 : 1;
+    const cachedPosture = getCachedPosture();
+    const postures = cachedPosture?.postures;
+    const staleFactor = cachedPosture?.stale ? 0.5 : 1;
 
     const localOverview = calculateStrategicRiskOverview(
       this.convergenceAlerts,
@@ -132,18 +132,18 @@ export class StrategicRiskPanel extends Panel {
     this.overview = localOverview;
     this.alerts = getRecentAlerts(24);
 
-    // Try to get cached scores during learning mode OR when data sources are insufficient
+    // Prefer server/cached scores whenever available so CII-derived overview values
+    // do not diverge from the CII panel, map, and on-demand surfaces.
     const { inLearning } = getLearningProgress();
     this.usedCachedScores = false;
-    const shouldUseCachedScores = inLearning || !hasIntelligenceSignalsLoaded() || this.freshnessSummary.overallStatus === 'insufficient';
-    if (shouldUseCachedScores) {
-      const cached = await fetchCachedRiskScores(this.signal);
-      if (!this.element?.isConnected) return false;
-      if (cached?.strategicRisk) {
-        this.applyCachedRiskOverview(cached, localOverview);
-        this.usedCachedScores = true;
-        console.log('[StrategicRiskPanel] Using cached scores from backend');
-      }
+    const cachedRiskScores = await fetchCachedRiskScores(this.signal);
+    if (!this.element?.isConnected) return false;
+    if (cachedRiskScores?.strategicRisk) {
+      this.applyCachedRiskOverview(cachedRiskScores, localOverview);
+      this.usedCachedScores = true;
+      console.log('[StrategicRiskPanel] Using cached scores from backend');
+    } else if (inLearning || this.freshnessSummary.overallStatus === 'insufficient') {
+      console.log('[StrategicRiskPanel] Cached backend scores unavailable; using local fallback');
     }
 
     const badgeDetail = this.freshnessSummary
@@ -224,9 +224,9 @@ export class StrategicRiskPanel extends Panel {
   }
 
   private getScoreColor(score: number): string {
-    if (score >= 70) return getCSSColor('--semantic-critical');
-    if (score >= 50) return getCSSColor('--semantic-high');
-    if (score >= 30) return getCSSColor('--semantic-elevated');
+    if (score >= 81) return getCSSColor('--semantic-critical');
+    if (score >= 66) return getCSSColor('--semantic-high');
+    if (score >= 51) return getCSSColor('--semantic-elevated');
     return getCSSColor('--semantic-normal');
   }
 

--- a/src/components/StrategicRiskPanel.ts
+++ b/src/components/StrategicRiskPanel.ts
@@ -123,6 +123,13 @@ export class StrategicRiskPanel extends Panel {
     const postures = cachedPosture?.postures;
     const staleFactor = cachedPosture?.stale ? 0.5 : 1;
 
+    // Prefer server/cached scores before calculating the overview so the
+    // cross-module alert baseline is not seeded from local CII on first refresh.
+    const { inLearning } = getLearningProgress();
+    this.usedCachedScores = false;
+    const cachedRiskScores = await fetchCachedRiskScores(this.signal);
+    if (!this.element?.isConnected) return false;
+
     const localOverview = calculateStrategicRiskOverview(
       this.convergenceAlerts,
       postures ?? undefined,
@@ -132,12 +139,6 @@ export class StrategicRiskPanel extends Panel {
     this.overview = localOverview;
     this.alerts = getRecentAlerts(24);
 
-    // Prefer server/cached scores whenever available so CII-derived overview values
-    // do not diverge from the CII panel, map, and on-demand surfaces.
-    const { inLearning } = getLearningProgress();
-    this.usedCachedScores = false;
-    const cachedRiskScores = await fetchCachedRiskScores(this.signal);
-    if (!this.element?.isConnected) return false;
     if (cachedRiskScores?.strategicRisk) {
       this.applyCachedRiskOverview(cachedRiskScores, localOverview);
       this.usedCachedScores = true;

--- a/src/services/cached-risk-scores.ts
+++ b/src/services/cached-risk-scores.ts
@@ -295,3 +295,19 @@ export function toCountryScore(cached: CachedCIIScore): CountryScore {
     lastUpdated: cached.lastUpdated ? new Date(cached.lastUpdated) : null,
   };
 }
+
+export function getCachedCountryScore(code: string): CountryScore | null {
+  const normalizedCode = code.toUpperCase();
+  const cached = getCachedScores()?.cii.find((score) => score.code === normalizedCode);
+  return cached ? toCountryScore(cached) : null;
+}
+
+export function getCachedCountryScoreValue(code: string): number | null {
+  return getCachedCountryScore(code)?.score ?? null;
+}
+
+export function getCachedCountryScores(): CountryScore[] {
+  const cached = getCachedScores();
+  if (!cached?.cii.length) return [];
+  return cached.cii.map(toCountryScore).sort((a, b) => b.score - a.score);
+}

--- a/src/services/cached-risk-scores.ts
+++ b/src/services/cached-risk-scores.ts
@@ -296,8 +296,12 @@ export function toCountryScore(cached: CachedCIIScore): CountryScore {
   };
 }
 
+export function normalizeCiiCountryCode(code: string): string {
+  return code.toUpperCase();
+}
+
 export function getCachedCountryScore(code: string): CountryScore | null {
-  const normalizedCode = code.toUpperCase();
+  const normalizedCode = normalizeCiiCountryCode(code);
   const cached = getCachedScores()?.cii.find((score) => score.code === normalizedCode);
   return cached ? toCountryScore(cached) : null;
 }

--- a/src/services/cross-module-integration.ts
+++ b/src/services/cross-module-integration.ts
@@ -4,6 +4,7 @@ import { getLatestSanctionsPressure, type SanctionsPressureResult } from './sanc
 import { getLatestRadiationWatch, type RadiationObservation } from './radiation';
 import type { CascadeResult, CascadeImpactLevel } from '@/types';
 import { calculateCII, isInLearningMode } from './country-instability';
+import { getCachedCountryScores } from './cached-risk-scores';
 import { getCountryNameByCode } from './country-geometry';
 import { t } from '@/services/i18n';
 import type { TheaterPostureSummary } from '@/services/military-surge';
@@ -101,6 +102,11 @@ const alerts: UnifiedAlert[] = [];
 const previousCIIScores = new Map<string, number>();
 const ALERT_MERGE_WINDOW_MS = 2 * 60 * 60 * 1000;
 const ALERT_MERGE_DISTANCE_KM = 200;
+
+function getAuthoritativeCIIScores(): CountryScore[] {
+  const cachedScores = getCachedCountryScores();
+  return cachedScores.length > 0 ? cachedScores : calculateCII();
+}
 
 let alertIdCounter = 0;
 function generateAlertId(): string {
@@ -560,7 +566,7 @@ function getCountriesNearLocation(lat: number, lon: number): string[] {
 
 export function checkCIIChanges(): UnifiedAlert[] {
   const newAlerts: UnifiedAlert[] = [];
-  const scores = calculateCII();
+  const scores = getAuthoritativeCIIScores();
 
   // Skip alerting during learning mode - data not yet reliable
   const inLearning = isInLearningMode();
@@ -628,7 +634,7 @@ export function calculateStrategicRiskOverview(
   breakingAlertScore?: number,
   theaterStaleFactor?: number
 ): StrategicRiskOverview {
-  const ciiScores = calculateCII();
+  const ciiScores = getAuthoritativeCIIScores();
 
   // Update the alerts array with current data
   updateAlerts(convergenceAlerts);

--- a/src/services/cross-module-integration.ts
+++ b/src/services/cross-module-integration.ts
@@ -826,6 +826,8 @@ export function getRecentAlerts(hours: number = 24): UnifiedAlert[] {
 
 export function clearAlerts(): void {
   alerts.length = 0;
+  previousCIIScores.clear();
+  previousCIIScoreSource = null;
 }
 
 export function getAlertCount(): { critical: number; high: number; medium: number; low: number } {

--- a/src/services/cross-module-integration.ts
+++ b/src/services/cross-module-integration.ts
@@ -103,9 +103,15 @@ const previousCIIScores = new Map<string, number>();
 const ALERT_MERGE_WINDOW_MS = 2 * 60 * 60 * 1000;
 const ALERT_MERGE_DISTANCE_KM = 200;
 
-function getAuthoritativeCIIScores(): CountryScore[] {
+type CIIScoreSource = 'cached' | 'local';
+let previousCIIScoreSource: CIIScoreSource | null = null;
+
+function getAuthoritativeCIIScores(): { scores: CountryScore[]; source: CIIScoreSource } {
   const cachedScores = getCachedCountryScores();
-  return cachedScores.length > 0 ? cachedScores : calculateCII();
+  if (cachedScores.length > 0) {
+    return { scores: cachedScores, source: 'cached' };
+  }
+  return { scores: calculateCII(), source: 'local' };
 }
 
 let alertIdCounter = 0;
@@ -566,7 +572,11 @@ function getCountriesNearLocation(lat: number, lon: number): string[] {
 
 export function checkCIIChanges(): UnifiedAlert[] {
   const newAlerts: UnifiedAlert[] = [];
-  const scores = getAuthoritativeCIIScores();
+  const { scores, source } = getAuthoritativeCIIScores();
+  if (previousCIIScoreSource !== null && previousCIIScoreSource !== source) {
+    previousCIIScores.clear();
+  }
+  previousCIIScoreSource = source;
 
   // Skip alerting during learning mode - data not yet reliable
   const inLearning = isInLearningMode();
@@ -634,7 +644,7 @@ export function calculateStrategicRiskOverview(
   breakingAlertScore?: number,
   theaterStaleFactor?: number
 ): StrategicRiskOverview {
-  const ciiScores = getAuthoritativeCIIScores();
+  const { scores: ciiScores } = getAuthoritativeCIIScores();
 
   // Update the alerts array with current data
   updateAlerts(convergenceAlerts);

--- a/src/services/military-surge.ts
+++ b/src/services/military-surge.ts
@@ -3,6 +3,7 @@ import type { SignalType } from '@/utils/analysis-constants';
 import { MILITARY_BASES_EXPANDED } from '@/config/bases-expanded';
 import { focalPointDetector } from './focal-point-detector';
 import { getCountryScore } from './country-instability';
+import { getCachedCountryScoreValue } from './cached-risk-scores';
 
 // Foreign military concentration detection - immediate alerts, no baseline needed
 interface GeoRegion {
@@ -958,7 +959,7 @@ export function recalcPostureWithVessels(postures: TheaterPostureSummary[]): voi
     if (theater.targetNation) {
       const code = TARGET_NATION_CODES[theater.targetNation];
       if (code) {
-        const cii = getCountryScore(code);
+        const cii = getCachedCountryScoreValue(code) ?? getCountryScore(code);
         if (cii !== null) {
           ciiLevel = cii >= 85 ? 2 : cii >= 70 ? 1 : 0;
         }

--- a/src/services/story-data.ts
+++ b/src/services/story-data.ts
@@ -1,5 +1,5 @@
-import { calculateCII, hasIntelligenceSignalsLoaded, type CountryScore } from './country-instability';
-import { getCachedScores, toCountryScore } from './cached-risk-scores';
+import { calculateCII, type CountryScore } from './country-instability';
+import { getCachedCountryScore } from './cached-risk-scores';
 import type { ClusteredEvent } from '@/types';
 import type { ThreatLevel } from './threat-classifier';
 import { CURATED_COUNTRIES } from '@/config/countries';
@@ -63,11 +63,7 @@ export function collectStoryData(
   signals?: { protests: number; militaryFlights: number; militaryVessels: number; outages: number; gpsJammingHexes: number },
   convergence?: { score: number; signalTypes: string[]; regionalDescriptions: string[] } | null,
 ): StoryData {
-  let countryScore: CountryScore | null = null;
-  if (!hasIntelligenceSignalsLoaded()) {
-    const cached = getCachedScores()?.cii.find(s => s.code === countryCode);
-    if (cached) countryScore = toCountryScore(cached);
-  }
+  let countryScore: CountryScore | null = getCachedCountryScore(countryCode);
   if (!countryScore) {
     const scores = calculateCII();
     countryScore = scores.find(s => s.code === countryCode) || null;

--- a/src/services/story-data.ts
+++ b/src/services/story-data.ts
@@ -105,7 +105,7 @@ export function collectStoryData(
   }
 
   return {
-    countryCode,
+    countryCode: normalizedCountryCode,
     countryName,
     cii: countryScore ? {
       score: countryScore.score,

--- a/src/services/story-data.ts
+++ b/src/services/story-data.ts
@@ -1,5 +1,5 @@
 import { calculateCII, type CountryScore } from './country-instability';
-import { getCachedCountryScore } from './cached-risk-scores';
+import { getCachedCountryScore, normalizeCiiCountryCode } from './cached-risk-scores';
 import type { ClusteredEvent } from '@/types';
 import type { ThreatLevel } from './threat-classifier';
 import { CURATED_COUNTRIES } from '@/config/countries';
@@ -63,13 +63,14 @@ export function collectStoryData(
   signals?: { protests: number; militaryFlights: number; militaryVessels: number; outages: number; gpsJammingHexes: number },
   convergence?: { score: number; signalTypes: string[]; regionalDescriptions: string[] } | null,
 ): StoryData {
-  let countryScore: CountryScore | null = getCachedCountryScore(countryCode);
+  const normalizedCountryCode = normalizeCiiCountryCode(countryCode);
+  let countryScore: CountryScore | null = getCachedCountryScore(normalizedCountryCode);
   if (!countryScore) {
     const scores = calculateCII();
-    countryScore = scores.find(s => s.code === countryCode) || null;
+    countryScore = scores.find(s => s.code === normalizedCountryCode) || null;
   }
 
-  const keywords = CURATED_COUNTRIES[countryCode]?.scoringKeywords || [countryName.toLowerCase()];
+  const keywords = CURATED_COUNTRIES[normalizedCountryCode]?.scoringKeywords || [countryName.toLowerCase()];
   const countryNews = allNews.filter(e => {
     const tokens = tokenizeForMatch(e.primaryTitle);
     return keywords.some(kw => matchKeyword(tokens, kw));

--- a/tests/frontend-cii-source-of-truth.test.mts
+++ b/tests/frontend-cii-source-of-truth.test.mts
@@ -63,7 +63,69 @@ const matchKeyword = (tokens: string[], keyword: string) => tokens.includes(keyw
       allNews: unknown[],
       theaterPostures: unknown[],
       predictionMarkets: unknown[],
-    ) => { cii: { score: number; level: string; trend: string; change24h: number } | null };
+    ) => { countryCode: string; cii: { score: number; level: string; trend: string; change24h: number } | null };
+  };
+}
+
+async function loadCrossModuleForTest() {
+  const src = readSrc('src/services/cross-module-integration.ts')
+    .replace(
+      "import { getLocationName, type GeoConvergenceAlert } from './geo-convergence';",
+      `type GeoConvergenceAlert = any;
+const getLocationName = () => 'Test Location';`,
+    )
+    .replace(
+      "import type { CountryScore } from './country-instability';",
+      `type CountryScore = any;`,
+    )
+    .replace(
+      "import { getLatestSanctionsPressure, type SanctionsPressureResult } from './sanctions-pressure';",
+      `type SanctionsPressureResult = any;
+const getLatestSanctionsPressure = () => null;`,
+    )
+    .replace(
+      "import { getLatestRadiationWatch, type RadiationObservation } from './radiation';",
+      `type RadiationObservation = any;
+const getLatestRadiationWatch = () => null;`,
+    )
+    .replace(
+      "import type { CascadeResult, CascadeImpactLevel } from '@/types';",
+      `type CascadeResult = any;
+type CascadeImpactLevel = any;`,
+    )
+    .replace(
+      "import { calculateCII, isInLearningMode } from './country-instability';",
+      `const calculateCII = () => (globalThis as any).__ciiSourceTruthTest.localScores;
+const isInLearningMode = () => Boolean((globalThis as any).__ciiSourceTruthTest.inLearning);`,
+    )
+    .replace(
+      "import { getCachedCountryScores } from './cached-risk-scores';",
+      `const getCachedCountryScores = () => (globalThis as any).__ciiSourceTruthTest.cachedScores;`,
+    )
+    .replace(
+      "import { getCountryNameByCode } from './country-geometry';",
+      `const getCountryNameByCode = (code: string) => ({ IR: 'Iran' } as Record<string, string>)[code] || code;`,
+    )
+    .replace(
+      "import { t } from '@/services/i18n';",
+      `const t = (key: string, params?: Record<string, unknown>) => String(params?.country ?? key);`,
+    )
+    .replace(
+      "import type { TheaterPostureSummary } from '@/services/military-surge';",
+      `type TheaterPostureSummary = any;`,
+    );
+
+  const transformed = transformSync(src, {
+    loader: 'ts',
+    format: 'esm',
+    target: 'es2022',
+  });
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(transformed.code).toString('base64')}#${++moduleCounter}`;
+  return (await import(dataUrl)) as {
+    checkCIIChanges: () => Array<{
+      type: string;
+      components: { ciiChange?: { previousScore: number; currentScore: number } };
+    }>;
   };
 }
 
@@ -167,8 +229,49 @@ describe('frontend CII source of truth', () => {
     const story = await loadStoryDataForTest();
 
     const result = story.collectStoryData('ir', 'Iran', [], [], []);
+    assert.equal(result.countryCode, 'IR');
     assert.equal(result.cii?.score, 55);
     assert.equal(result.cii?.level, 'elevated');
+  });
+
+  it('does not emit false CII-spike alerts when score source switches from local to cached', async () => {
+    const previousDocument = (globalThis as any).document;
+    const previousCustomEvent = (globalThis as any).CustomEvent;
+    (globalThis as any).document = { dispatchEvent: () => undefined };
+    (globalThis as any).CustomEvent = class CustomEvent {
+      constructor(public type: string) {}
+    };
+
+    try {
+      (globalThis as any).__ciiSourceTruthTest = {
+        cachedScores: [],
+        localScores: [makeScore(5)],
+        inLearning: false,
+      };
+      const crossModule = await loadCrossModuleForTest();
+
+      assert.equal(crossModule.checkCIIChanges().length, 0);
+
+      (globalThis as any).__ciiSourceTruthTest.cachedScores = [makeScore(80)];
+      assert.equal(
+        crossModule.checkCIIChanges().length,
+        0,
+        'local-to-cached source switch must rebaseline instead of alerting on formula drift',
+      );
+
+      (globalThis as any).__ciiSourceTruthTest.cachedScores = [makeScore(95)];
+      const alerts = crossModule.checkCIIChanges();
+      assert.equal(alerts.length, 1, 'same-source cached changes should still emit CII spike alerts');
+      assert.equal(alerts[0]?.type, 'cii_spike');
+      assert.equal(alerts[0]?.components.ciiChange?.previousScore, 80);
+      assert.equal(alerts[0]?.components.ciiChange?.currentScore, 95);
+    } finally {
+      if (previousDocument === undefined) delete (globalThis as any).document;
+      else (globalThis as any).document = previousDocument;
+      if (previousCustomEvent === undefined) delete (globalThis as any).CustomEvent;
+      else (globalThis as any).CustomEvent = previousCustomEvent;
+      delete (globalThis as any).__ciiSourceTruthTest;
+    }
   });
 
   it('routes remaining on-demand CII consumers through cached/server scores first', () => {
@@ -182,6 +285,7 @@ describe('frontend CII source of truth', () => {
     assert.doesNotMatch(storySrc, /hasIntelligenceSignalsLoaded/);
     assert.match(storySrc, /const normalizedCountryCode = normalizeCiiCountryCode\(countryCode\);/);
     assert.match(storySrc, /getCachedCountryScore\(normalizedCountryCode\)[\s\S]*s\.code === normalizedCountryCode/);
+    assert.match(storySrc, /countryCode: normalizedCountryCode/);
 
     assert.doesNotMatch(countryIntelSrc, /hasIntelligenceSignalsLoaded/);
     assert.match(countryIntelSrc, /const scoreCode = normalizeCiiCountryCode\(code\);[\s\S]*getCachedCountryScore\(scoreCode\) \?\? calculateCII\(\)\.find\(\(s\) => s\.code === scoreCode\)/);
@@ -191,6 +295,7 @@ describe('frontend CII source of truth', () => {
     assert.match(crossModuleSrc, /if \(previousCIIScoreSource !== null && previousCIIScoreSource !== source\) \{[\s\S]*previousCIIScores\.clear\(\);[\s\S]*\}/);
     assert.match(crossModuleSrc, /const \{ scores, source \} = getAuthoritativeCIIScores\(\);/);
     assert.match(crossModuleSrc, /const \{ scores: ciiScores \} = getAuthoritativeCIIScores\(\);/);
+    assert.match(crossModuleSrc, /export function clearAlerts\(\): void \{[\s\S]*previousCIIScores\.clear\(\);[\s\S]*previousCIIScoreSource = null;[\s\S]*\}/);
 
     assert.match(militarySrc, /getCachedCountryScoreValue\(code\) \?\? getCountryScore\(code\)/);
     assert.match(mapSrc, /setCIIGetter\(\(code\) => getCachedCountryScoreValue\(code\) \?\? getCountryScore\(code\)\)/);

--- a/tests/frontend-cii-source-of-truth.test.mts
+++ b/tests/frontend-cii-source-of-truth.test.mts
@@ -36,8 +36,9 @@ async function loadStoryDataForTest() {
 const calculateCII = () => (globalThis as any).__ciiSourceTruthTest.calculateCII();`,
     )
     .replace(
-      "import { getCachedCountryScore } from './cached-risk-scores';",
-      `const getCachedCountryScore = (code: string) => (globalThis as any).__ciiSourceTruthTest.getCachedCountryScore(code);`,
+      "import { getCachedCountryScore, normalizeCiiCountryCode } from './cached-risk-scores';",
+      `const getCachedCountryScore = (code: string) => (globalThis as any).__ciiSourceTruthTest.getCachedCountryScore(code);
+const normalizeCiiCountryCode = (code: string) => code.toUpperCase();`,
     )
     .replace(
       "import { CURATED_COUNTRIES } from '@/config/countries';",
@@ -71,7 +72,15 @@ function makeScore(score: number) {
     code: 'IR',
     name: 'Iran',
     score,
-    level: score >= 81 ? 'critical' : 'high',
+    level: score >= 81
+      ? 'critical'
+      : score >= 66
+        ? 'high'
+        : score >= 51
+          ? 'elevated'
+          : score >= 31
+            ? 'normal'
+            : 'low',
     trend: 'stable',
     change24h: 0,
     components: { unrest: 0, conflict: 0, security: 0, information: 0 },
@@ -150,6 +159,18 @@ describe('frontend CII source of truth', () => {
     assert.equal(localCalls, 1);
   });
 
+  it('story data normalizes country code before cached and local score lookup', async () => {
+    (globalThis as any).__ciiSourceTruthTest = {
+      getCachedCountryScore: () => null,
+      calculateCII: () => [makeScore(55)],
+    };
+    const story = await loadStoryDataForTest();
+
+    const result = story.collectStoryData('ir', 'Iran', [], [], []);
+    assert.equal(result.cii?.score, 55);
+    assert.equal(result.cii?.level, 'elevated');
+  });
+
   it('routes remaining on-demand CII consumers through cached/server scores first', () => {
     const storySrc = readSrc('src/services/story-data.ts');
     const countryIntelSrc = readSrc('src/app/country-intel.ts');
@@ -159,15 +180,17 @@ describe('frontend CII source of truth', () => {
     const deckSrc = readSrc('src/components/DeckGLMap.ts');
 
     assert.doesNotMatch(storySrc, /hasIntelligenceSignalsLoaded/);
-    assert.match(storySrc, /getCachedCountryScore\(countryCode\)[\s\S]*calculateCII\(\)/);
+    assert.match(storySrc, /const normalizedCountryCode = normalizeCiiCountryCode\(countryCode\);/);
+    assert.match(storySrc, /getCachedCountryScore\(normalizedCountryCode\)[\s\S]*s\.code === normalizedCountryCode/);
 
     assert.doesNotMatch(countryIntelSrc, /hasIntelligenceSignalsLoaded/);
-    assert.match(countryIntelSrc, /getCachedCountryScore\(code\) \?\? calculateCII\(\)\.find/);
+    assert.match(countryIntelSrc, /const scoreCode = normalizeCiiCountryCode\(code\);[\s\S]*getCachedCountryScore\(scoreCode\) \?\? calculateCII\(\)\.find\(\(s\) => s\.code === scoreCode\)/);
 
-    assert.match(crossModuleSrc, /function getAuthoritativeCIIScores\(\): CountryScore\[\]/);
-    assert.match(crossModuleSrc, /const cachedScores = getCachedCountryScores\(\);[\s\S]*return cachedScores\.length > 0 \? cachedScores : calculateCII\(\);/);
-    assert.match(crossModuleSrc, /const scores = getAuthoritativeCIIScores\(\);/);
-    assert.match(crossModuleSrc, /const ciiScores = getAuthoritativeCIIScores\(\);/);
+    assert.match(crossModuleSrc, /type CIIScoreSource = 'cached' \| 'local';/);
+    assert.match(crossModuleSrc, /let previousCIIScoreSource: CIIScoreSource \| null = null;/);
+    assert.match(crossModuleSrc, /if \(previousCIIScoreSource !== null && previousCIIScoreSource !== source\) \{[\s\S]*previousCIIScores\.clear\(\);[\s\S]*\}/);
+    assert.match(crossModuleSrc, /const \{ scores, source \} = getAuthoritativeCIIScores\(\);/);
+    assert.match(crossModuleSrc, /const \{ scores: ciiScores \} = getAuthoritativeCIIScores\(\);/);
 
     assert.match(militarySrc, /getCachedCountryScoreValue\(code\) \?\? getCountryScore\(code\)/);
     assert.match(mapSrc, /setCIIGetter\(\(code\) => getCachedCountryScoreValue\(code\) \?\? getCountryScore\(code\)\)/);

--- a/tests/frontend-cii-source-of-truth.test.mts
+++ b/tests/frontend-cii-source-of-truth.test.mts
@@ -26,6 +26,14 @@ function extractMethod(src: string, signature: string): string {
   throw new Error(`unterminated method body: ${signature}`);
 }
 
+function assertBefore(src: string, first: string, second: string): void {
+  const firstIndex = src.indexOf(first);
+  const secondIndex = src.indexOf(second);
+  assert.notEqual(firstIndex, -1, `missing first marker: ${first}`);
+  assert.notEqual(secondIndex, -1, `missing second marker: ${second}`);
+  assert.ok(firstIndex < secondIndex, `expected "${first}" before "${second}"`);
+}
+
 let moduleCounter = 0;
 
 async function loadStoryDataForTest() {
@@ -185,6 +193,11 @@ describe('frontend CII source of truth', () => {
     assert.match(src, /compositeScore: Math\.max\(0, Math\.min\(100, Math\.round\(cached\.strategicRisk\.score\)\)\)/);
     assert.match(src, /unstableCountries: ciiScores\.filter\(s => s\.score >= 50\)\.slice\(0, 5\)/);
     assert.doesNotMatch(src, /hasIntelligenceSignalsLoaded/);
+    assertBefore(
+      refreshBody,
+      'const cachedRiskScores = await fetchCachedRiskScores(this.signal);',
+      'const localOverview = calculateStrategicRiskOverview(',
+    );
     assert.match(refreshBody, /this\.applyCachedRiskOverview\(cachedRiskScores, localOverview\);[\s\S]*this\.usedCachedScores = true;/);
     assert.match(refreshBody, /if \(this\.usedCachedScores\) \{[\s\S]*this\.setDataBadge\('cached', badgeDetail\);[\s\S]*\} else if \(!this\.freshnessSummary \|\| this\.freshnessSummary\.activeSources === 0\) \{[\s\S]*this\.setDataBadge\('unavailable'\);/);
   });

--- a/tests/frontend-cii-source-of-truth.test.mts
+++ b/tests/frontend-cii-source-of-truth.test.mts
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { transformSync } from 'esbuild';
 
 const root = resolve(import.meta.dirname, '..');
 
@@ -23,6 +24,59 @@ function extractMethod(src: string, signature: string): string {
     if (depth === 0) return src.slice(start, i + 1);
   }
   throw new Error(`unterminated method body: ${signature}`);
+}
+
+let moduleCounter = 0;
+
+async function loadStoryDataForTest() {
+  const src = readSrc('src/services/story-data.ts')
+    .replace(
+      "import { calculateCII, type CountryScore } from './country-instability';",
+      `type CountryScore = any;
+const calculateCII = () => (globalThis as any).__ciiSourceTruthTest.calculateCII();`,
+    )
+    .replace(
+      "import { getCachedCountryScore } from './cached-risk-scores';",
+      `const getCachedCountryScore = (code: string) => (globalThis as any).__ciiSourceTruthTest.getCachedCountryScore(code);`,
+    )
+    .replace(
+      "import { CURATED_COUNTRIES } from '@/config/countries';",
+      `const CURATED_COUNTRIES: Record<string, any> = {};`,
+    )
+    .replace(
+      "import { tokenizeForMatch, matchKeyword } from '@/utils/keyword-match';",
+      `const tokenizeForMatch = (value: string) => value.toLowerCase().split(/\\W+/).filter(Boolean);
+const matchKeyword = (tokens: string[], keyword: string) => tokens.includes(keyword.toLowerCase());`,
+    );
+
+  const transformed = transformSync(src, {
+    loader: 'ts',
+    format: 'esm',
+    target: 'es2022',
+  });
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(transformed.code).toString('base64')}#${++moduleCounter}`;
+  return (await import(dataUrl)) as {
+    collectStoryData: (
+      countryCode: string,
+      countryName: string,
+      allNews: unknown[],
+      theaterPostures: unknown[],
+      predictionMarkets: unknown[],
+    ) => { cii: { score: number; level: string; trend: string; change24h: number } | null };
+  };
+}
+
+function makeScore(score: number) {
+  return {
+    code: 'IR',
+    name: 'Iran',
+    score,
+    level: score >= 81 ? 'critical' : 'high',
+    trend: 'stable',
+    change24h: 0,
+    components: { unrest: 0, conflict: 0, security: 0, information: 0 },
+    lastUpdated: null,
+  };
 }
 
 describe('frontend CII source of truth', () => {
@@ -59,17 +113,72 @@ describe('frontend CII source of truth', () => {
     assert.match(src, /private formatOverviewTimestamp\(\): string \{[\s\S]*return this\.overview\?\.timestamp \? this\.overview\.timestamp\.toLocaleTimeString\(\) : '&mdash;';[\s\S]*\}/);
     assert.match(src, /compositeScore: Math\.max\(0, Math\.min\(100, Math\.round\(cached\.strategicRisk\.score\)\)\)/);
     assert.match(src, /unstableCountries: ciiScores\.filter\(s => s\.score >= 50\)\.slice\(0, 5\)/);
-    assert.match(refreshBody, /this\.applyCachedRiskOverview\(cached, localOverview\);[\s\S]*this\.usedCachedScores = true;/);
+    assert.doesNotMatch(src, /hasIntelligenceSignalsLoaded/);
+    assert.match(refreshBody, /this\.applyCachedRiskOverview\(cachedRiskScores, localOverview\);[\s\S]*this\.usedCachedScores = true;/);
     assert.match(refreshBody, /if \(this\.usedCachedScores\) \{[\s\S]*this\.setDataBadge\('cached', badgeDetail\);[\s\S]*\} else if \(!this\.freshnessSummary \|\| this\.freshnessSummary\.activeSources === 0\) \{[\s\S]*this\.setDataBadge\('unavailable'\);/);
   });
 
-  it('uses cached CII for story data until local intelligence ingestion is ready', () => {
-    const src = readSrc('src/services/story-data.ts');
+  it('story data consumes cached/server CII before recomputing local scores', async () => {
+    let localCalls = 0;
+    (globalThis as any).__ciiSourceTruthTest = {
+      getCachedCountryScore: () => makeScore(87),
+      calculateCII: () => {
+        localCalls++;
+        return [makeScore(12)];
+      },
+    };
+    const story = await loadStoryDataForTest();
 
-    assert.match(src, /hasIntelligenceSignalsLoaded/);
-    assert.match(src, /getCachedScores/);
-    assert.match(src, /toCountryScore/);
-    assert.match(src, /if \(!hasIntelligenceSignalsLoaded\(\)\) \{[\s\S]*getCachedScores\(\)\?\.cii\.find[\s\S]*toCountryScore\(cached\);[\s\S]*\}/);
-    assert.match(src, /if \(!countryScore\) \{[\s\S]*const scores = calculateCII\(\);[\s\S]*\}/);
+    const result = story.collectStoryData('IR', 'Iran', [], [], []);
+    assert.equal(result.cii?.score, 87);
+    assert.equal(localCalls, 0, 'local calculateCII must not run when cached CII exists');
+  });
+
+  it('story data falls back to local scores only when cached/server CII is absent', async () => {
+    let localCalls = 0;
+    (globalThis as any).__ciiSourceTruthTest = {
+      getCachedCountryScore: () => null,
+      calculateCII: () => {
+        localCalls++;
+        return [makeScore(67)];
+      },
+    };
+    const story = await loadStoryDataForTest();
+
+    const result = story.collectStoryData('IR', 'Iran', [], [], []);
+    assert.equal(result.cii?.score, 67);
+    assert.equal(localCalls, 1);
+  });
+
+  it('routes remaining on-demand CII consumers through cached/server scores first', () => {
+    const storySrc = readSrc('src/services/story-data.ts');
+    const countryIntelSrc = readSrc('src/app/country-intel.ts');
+    const crossModuleSrc = readSrc('src/services/cross-module-integration.ts');
+    const militarySrc = readSrc('src/services/military-surge.ts');
+    const mapSrc = readSrc('src/components/Map.ts');
+    const deckSrc = readSrc('src/components/DeckGLMap.ts');
+
+    assert.doesNotMatch(storySrc, /hasIntelligenceSignalsLoaded/);
+    assert.match(storySrc, /getCachedCountryScore\(countryCode\)[\s\S]*calculateCII\(\)/);
+
+    assert.doesNotMatch(countryIntelSrc, /hasIntelligenceSignalsLoaded/);
+    assert.match(countryIntelSrc, /getCachedCountryScore\(code\) \?\? calculateCII\(\)\.find/);
+
+    assert.match(crossModuleSrc, /function getAuthoritativeCIIScores\(\): CountryScore\[\]/);
+    assert.match(crossModuleSrc, /const cachedScores = getCachedCountryScores\(\);[\s\S]*return cachedScores\.length > 0 \? cachedScores : calculateCII\(\);/);
+    assert.match(crossModuleSrc, /const scores = getAuthoritativeCIIScores\(\);/);
+    assert.match(crossModuleSrc, /const ciiScores = getAuthoritativeCIIScores\(\);/);
+
+    assert.match(militarySrc, /getCachedCountryScoreValue\(code\) \?\? getCountryScore\(code\)/);
+    assert.match(mapSrc, /setCIIGetter\(\(code\) => getCachedCountryScoreValue\(code\) \?\? getCountryScore\(code\)\)/);
+    assert.match(deckSrc, /setCIIGetter\(\(code\) => getCachedCountryScoreValue\(code\) \?\? getCountryScore\(code\)\)/);
+  });
+
+  it('aligns CII badge and fill colors to the canonical frontend bands', () => {
+    const modalSrc = readSrc('src/components/CountryIntelModal.ts');
+    const strategicRiskSrc = readSrc('src/components/StrategicRiskPanel.ts');
+
+    assert.match(extractMethod(modalSrc, 'private scoreBar(score: number): string'), /pct >= 81[\s\S]*pct >= 66[\s\S]*pct >= 51/);
+    assert.match(extractMethod(strategicRiskSrc, 'private getScoreColor(score: number): string'), /score >= 81[\s\S]*score >= 66[\s\S]*score >= 51/);
   });
 });


### PR DESCRIPTION
## Summary
- Route remaining on-demand CII consumers through cached/server scores before local fallback.
- Add shared cached CII score accessors for country brief, story data, cross-module alerts, military posture, and hotspot escalation.
- Align CountryIntelModal and StrategicRiskPanel color thresholds to the canonical CII bands.

## Root Cause
Several frontend surfaces still recomputed or preferred local `country-instability.ts` scores after server-authoritative CII scores were available, so visible CII-derived values could diverge from the CII panel and choropleth.

## Validation
- `npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/frontend-cii-source-of-truth.test.mts tests/frontend-cii-closeout.test.mts tests/cached-risk-scores.test.mts`
- `npm run typecheck`
- Pre-push hook passed: typecheck, API typecheck, boundary/safe-html/rate-limit/premium-fetch checks, changed test files, edge function tests, version check