### PR TITLE
Guard CII formula protocol docs

### DIFF
--- a/docs/methodology/cii-risk-scores.mdx
+++ b/docs/methodology/cii-risk-scores.mdx
@@ -102,8 +102,8 @@ exposed on the wire as `CiiComponents`:
 
 | Wire field | Editorial meaning |
 |---|---|
-| `cii_contribution` (**U**nrest) | Civil disorder pressure: ACLED protests + riots, fatalities from those events, and confirmed internet/power outages. Reflects pre-violent friction. |
-| `geo_convergence` (**C**onflict) | Kinetic activity: ACLED battles, explosions/remote violence, and violence-against-civilians events, plus Iran-region strike intensity. Event activity is log-scaled before the component cap so moderate and extreme event volumes remain ordered; square-root fatality scaling prevents single-event saturation. |
+| `cii_contribution` (**U**nrest) | Civil disorder pressure: ACLED protests + riots, fatalities from those events, confirmed internet/power outages, and a high-severity unrest boost. Reflects pre-violent friction. |
+| `geo_convergence` (**C**onflict) | Kinetic activity: ACLED battles, explosions/remote violence, and violence-against-civilians events, plus Iran-region strike intensity and Israel OREF alert pressure. Event activity is log-scaled before the component cap so moderate and extreme event volumes remain ordered; square-root fatality scaling prevents single-event saturation. |
 | `military_activity` (**S**ecurity) | Hard-security tempo near the country: military flight activity, military vessel activity, aviation disruptions (closures/delays), and GPS-jamming hex density. Foreign military presence is weighted ×2. |
 | `news_activity` (**I**nformation) | Information-environment pressure: weighted count of classified critical/high/medium news headlines geo-attributed to the country. |
 
@@ -125,6 +125,26 @@ composite = baseline * 0.4
           + sanctionsBoost    (≤ 14)
           + aisBoost          (≤ 10, AIS disruptions)
 ```
+
+Component details that are easy to miss:
+
+- **Unrest severity boost**: high-severity ACLED unrest events (for example,
+  riots) add `min(20, highSeverityUnrest * 10 * eventMultiplier)` inside the
+  Unrest component.
+- **Conflict civilian boost**: violence-against-civilians events add
+  `min(10, civilianViolence * 3)` after the log-scaled conflict activity and
+  fatality terms.
+- **Conflict OREF boost**: for Israel only, active OREF rocket-alert pressure
+  adds `25 + min(25, activeAlertCount * 5)` inside the Conflict component, so
+  the component-level OREF contribution is capped at `+50`. This is separate
+  from the composite `orefBlendBoost` term listed above, which is also Israel
+  only and capped at `+25`.
+- **Information severity handling**: classified top stories use weights
+  `critical = 4`, `high = 2`, `medium/elevated = 1`,
+  `moderate/low = 0.5`, and `info = 0`. The per-country threat-summary feed
+  uses `critical = 4`, `high = 2`, `medium = 1`, `low = 0.5`, and `info = 0`,
+  with that threat-summary sub-score capped at `20`; the combined Information
+  component is capped at `100`.
 
 `composite` is then clamped to `[floor, 100]` where `floor` is the larger of:
 

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
+import ts from 'typescript';
 
 import { CURATED_COUNTRIES, TIER1_COUNTRIES } from '../src/config/countries.ts';
 import {
@@ -53,32 +54,98 @@ function readRepoFile(path: string): string {
   return readFileSync(resolve(REPO_ROOT, path), 'utf8');
 }
 
-function extractFunctionBody(source: string, functionName: string): string {
-  const signatureStart = source.indexOf(`function ${functionName}(`);
-  assert.notEqual(signatureStart, -1, `missing function ${functionName}`);
-  const bodyStart = source.indexOf('{', signatureStart);
-  assert.notEqual(bodyStart, -1, `missing body for function ${functionName}`);
+interface ScoreLevelCutoff {
+  min: number;
+  level: string;
+}
 
-  let depth = 0;
-  for (let i = bodyStart; i < source.length; i++) {
-    const ch = source[i];
-    if (ch === '{') depth++;
-    if (ch === '}') depth--;
-    if (depth === 0) return source.slice(bodyStart + 1, i);
+interface ParsedScoreLevelFunction {
+  cutoffs: ScoreLevelCutoff[];
+  fallback: string;
+}
+
+function findFunctionDeclaration(sourceFile: ts.SourceFile, functionName: string): ts.FunctionDeclaration {
+  let found: ts.FunctionDeclaration | null = null;
+
+  function visit(node: ts.Node): void {
+    if (ts.isFunctionDeclaration(node) && node.name?.text === functionName) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
   }
-  throw new Error(`unterminated function ${functionName}`);
+
+  visit(sourceFile);
+  assert.ok(found, `missing function declaration: ${functionName}`);
+  return found;
 }
 
-function extractScoreLevelCutoffs(source: string, functionName: string) {
-  const body = extractFunctionBody(source, functionName);
-  return Array.from(body.matchAll(/if\s*\(\s*score\s*>=\s*(\d+)\s*\)\s*return\s*'([^']+)'/g))
-    .map((match) => ({ min: Number(match[1]), level: match[2] }));
+function getReturnString(statement: ts.Statement): string | null {
+  const returnStatement = ts.isBlock(statement)
+    ? statement.statements.length === 1 && ts.isReturnStatement(statement.statements[0])
+      ? statement.statements[0]
+      : null
+    : ts.isReturnStatement(statement)
+      ? statement
+      : null;
+
+  const expression = returnStatement?.expression;
+  if (!expression) return null;
+  return ts.isStringLiteral(expression) || ts.isNoSubstitutionTemplateLiteral(expression)
+    ? expression.text
+    : null;
 }
 
-function evaluateScoreLevel(source: string, functionName: string, score: number): string {
-  const body = extractFunctionBody(source, functionName);
-  const fn = new Function('score', body) as (score: number) => string;
-  return fn(score);
+function getScoreCutoff(expression: ts.Expression): number | null {
+  if (!ts.isBinaryExpression(expression)) return null;
+  if (expression.operatorToken.kind !== ts.SyntaxKind.GreaterThanEqualsToken) return null;
+  if (!ts.isIdentifier(expression.left) || expression.left.text !== 'score') return null;
+  return ts.isNumericLiteral(expression.right) ? Number(expression.right.text) : null;
+}
+
+function parseScoreLevelFunction(source: string, functionName: string): ParsedScoreLevelFunction {
+  const sourceFile = ts.createSourceFile(
+    `${functionName}.ts`,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const fn = findFunctionDeclaration(sourceFile, functionName);
+  assert.ok(fn.body, `${functionName} must have a function body`);
+
+  const cutoffs: ScoreLevelCutoff[] = [];
+  let fallback: string | null = null;
+
+  for (const statement of fn.body.statements) {
+    if (ts.isIfStatement(statement)) {
+      const min = getScoreCutoff(statement.expression);
+      const level = getReturnString(statement.thenStatement);
+      assert.notEqual(min, null, `${functionName} has an unsupported cutoff condition`);
+      assert.notEqual(level, null, `${functionName} cutoff ${min} must return a string literal`);
+      cutoffs.push({ min, level });
+      continue;
+    }
+
+    if (ts.isReturnStatement(statement)) {
+      fallback = getReturnString(statement);
+    }
+  }
+
+  assert.ok(cutoffs.length > 0, `${functionName} must declare score >= cutoff returns`);
+  assert.ok(fallback, `${functionName} must end with a string fallback return`);
+  return { cutoffs, fallback };
+}
+
+function extractScoreLevelCutoffs(source: string, functionName: string): ScoreLevelCutoff[] {
+  return parseScoreLevelFunction(source, functionName).cutoffs;
+}
+
+function evaluateScoreLevel(parsed: ParsedScoreLevelFunction, score: number): string {
+  for (const cutoff of parsed.cutoffs) {
+    if (score >= cutoff.min) return cutoff.level;
+  }
+  return parsed.fallback;
 }
 
 function hashJson(value: unknown): string {
@@ -906,6 +973,8 @@ describe('CII scoring', () => {
   it('getScoreLevel uses canonical CII UI bands at 81/66/51/31', () => {
     const cachedRiskSource = readRepoFile('src/services/cached-risk-scores.ts');
     const browserCiiSource = readRepoFile('src/services/country-instability.ts');
+    const cachedScoreLevel = parseScoreLevelFunction(cachedRiskSource, 'getScoreLevel');
+    const browserScoreLevel = parseScoreLevelFunction(browserCiiSource, 'getLevel');
     const expectedCutoffs = [
       { min: 81, level: 'critical' },
       { min: 66, level: 'high' },
@@ -913,8 +982,10 @@ describe('CII scoring', () => {
       { min: 31, level: 'normal' },
     ];
 
-    assert.deepEqual(extractScoreLevelCutoffs(cachedRiskSource, 'getScoreLevel'), expectedCutoffs);
-    assert.deepEqual(extractScoreLevelCutoffs(browserCiiSource, 'getLevel'), expectedCutoffs);
+    assert.deepEqual(cachedScoreLevel.cutoffs, expectedCutoffs);
+    assert.deepEqual(browserScoreLevel.cutoffs, expectedCutoffs);
+    assert.equal(cachedScoreLevel.fallback, 'low');
+    assert.equal(browserScoreLevel.fallback, 'low');
 
     for (const [score, level] of [
       [81, 'critical'], [80, 'high'],
@@ -922,9 +993,9 @@ describe('CII scoring', () => {
       [51, 'elevated'], [50, 'normal'],
       [31, 'normal'], [30, 'low'],
     ] as const) {
-      assert.equal(evaluateScoreLevel(cachedRiskSource, 'getScoreLevel', score), level,
+      assert.equal(evaluateScoreLevel(cachedScoreLevel, score), level,
         `cached getScoreLevel(${score}) should be ${level}`);
-      assert.equal(evaluateScoreLevel(browserCiiSource, 'getLevel', score), level,
+      assert.equal(evaluateScoreLevel(browserScoreLevel, score), level,
         `browser getLevel(${score}) should be ${level}`);
     }
   });

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -37,8 +38,52 @@ import {
   CII_BASELINE_RISK as SHARED_BASELINE_RISK,
   CII_COUNTRY_WEIGHTS,
   CII_EVENT_MULTIPLIER as SHARED_EVENT_MULTIPLIER,
+  DEFAULT_CII_BASELINE_RISK,
+  DEFAULT_CII_EVENT_MULTIPLIER,
 } from '../shared/cii-weights.ts';
 import { CLIMATE_ZONES } from '../scripts/_climate-zones.mjs';
+
+const REPO_ROOT = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+
+const CII_PROTOCOL_SNAPSHOT_HASH_BY_VERSION: Record<string, string> = {
+  v5: '13a339323a4b1c92bec967a2b006d97330ef7f1d596326bf8a438a129fa89c10',
+};
+
+function readRepoFile(path: string): string {
+  return readFileSync(resolve(REPO_ROOT, path), 'utf8');
+}
+
+function extractFunctionBody(source: string, functionName: string): string {
+  const signatureStart = source.indexOf(`function ${functionName}(`);
+  assert.notEqual(signatureStart, -1, `missing function ${functionName}`);
+  const bodyStart = source.indexOf('{', signatureStart);
+  assert.notEqual(bodyStart, -1, `missing body for function ${functionName}`);
+
+  let depth = 0;
+  for (let i = bodyStart; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === '{') depth++;
+    if (ch === '}') depth--;
+    if (depth === 0) return source.slice(bodyStart + 1, i);
+  }
+  throw new Error(`unterminated function ${functionName}`);
+}
+
+function extractScoreLevelCutoffs(source: string, functionName: string) {
+  const body = extractFunctionBody(source, functionName);
+  return Array.from(body.matchAll(/if\s*\(\s*score\s*>=\s*(\d+)\s*\)\s*return\s*'([^']+)'/g))
+    .map((match) => ({ min: Number(match[1]), level: match[2] }));
+}
+
+function evaluateScoreLevel(source: string, functionName: string, score: number): string {
+  const body = extractFunctionBody(source, functionName);
+  const fn = new Function('score', body) as (score: number) => string;
+  return fn(score);
+}
+
+function hashJson(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
 
 function emptyAux() {
   return {
@@ -821,6 +866,66 @@ describe('CII scoring', () => {
       const actualMult = (s as unknown as { eventMultiplier: number }).eventMultiplier;
       assert.equal(actualMult, expected.eventMultiplier,
         `${code} eventMultiplier ${actualMult} should match shared eventMultiplier ${expected.eventMultiplier}`);
+    }
+  });
+
+  it('CII protocol coefficients are snapshot-keyed to CII_FORMULA_VERSION', () => {
+    const expectedHash = CII_PROTOCOL_SNAPSHOT_HASH_BY_VERSION[CII_FORMULA_VERSION];
+    assert.ok(
+      expectedHash,
+      `No CII protocol snapshot for ${CII_FORMULA_VERSION}. Add a new snapshot hash when bumping CII_FORMULA_VERSION.`,
+    );
+
+    const cachedRiskSource = readRepoFile('src/services/cached-risk-scores.ts');
+    const snapshot = {
+      countryWeights: Object.fromEntries(
+        Object.entries(CII_COUNTRY_WEIGHTS).sort(([a], [b]) => a.localeCompare(b)),
+      ),
+      defaultWeight: {
+        baselineRisk: DEFAULT_CII_BASELINE_RISK,
+        eventMultiplier: DEFAULT_CII_EVENT_MULTIPLIER,
+      },
+      riskConfig: {
+        CII_CONFLICT_ACTIVITY_CAP,
+        CII_CONFLICT_ACTIVITY_PIVOT,
+        STRATEGIC_RISK_POSITIONAL_DECAY,
+        STRATEGIC_RISK_SCALE_FACTOR,
+        STRATEGIC_RISK_SCALE_FLOOR,
+        STRATEGIC_RISK_TOP_N,
+      },
+      scoreLevelCutoffs: extractScoreLevelCutoffs(cachedRiskSource, 'getScoreLevel'),
+    };
+
+    assert.equal(
+      hashJson(snapshot),
+      expectedHash,
+      'CII coefficient/cutoff snapshot changed. Bump CII_FORMULA_VERSION, update methodology docs/changelogs, and add the new version-keyed snapshot hash.',
+    );
+  });
+
+  it('getScoreLevel uses canonical CII UI bands at 81/66/51/31', () => {
+    const cachedRiskSource = readRepoFile('src/services/cached-risk-scores.ts');
+    const browserCiiSource = readRepoFile('src/services/country-instability.ts');
+    const expectedCutoffs = [
+      { min: 81, level: 'critical' },
+      { min: 66, level: 'high' },
+      { min: 51, level: 'elevated' },
+      { min: 31, level: 'normal' },
+    ];
+
+    assert.deepEqual(extractScoreLevelCutoffs(cachedRiskSource, 'getScoreLevel'), expectedCutoffs);
+    assert.deepEqual(extractScoreLevelCutoffs(browserCiiSource, 'getLevel'), expectedCutoffs);
+
+    for (const [score, level] of [
+      [81, 'critical'], [80, 'high'],
+      [66, 'high'], [65, 'elevated'],
+      [51, 'elevated'], [50, 'normal'],
+      [31, 'normal'], [30, 'low'],
+    ] as const) {
+      assert.equal(evaluateScoreLevel(cachedRiskSource, 'getScoreLevel', score), level,
+        `cached getScoreLevel(${score}) should be ${level}`);
+      assert.equal(evaluateScoreLevel(browserCiiSource, 'getLevel', score), level,
+        `browser getLevel(${score}) should be ${level}`);
     }
   });
 

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -48,6 +48,11 @@ const REPO_ROOT = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
 
 const CII_PROTOCOL_SNAPSHOT_HASH_BY_VERSION: Record<string, string> = {
   v5: '13a339323a4b1c92bec967a2b006d97330ef7f1d596326bf8a438a129fa89c10',
+  // v6 (#4147/#4148/#4149): attribution, climate-wiring, observability and
+  // advisory-fallback changes did not touch any *hashed* coefficient
+  // (country weights, defaults, strategic constants, getScoreLevel cutoffs),
+  // so the protocol snapshot is unchanged from v5.
+  v6: '13a339323a4b1c92bec967a2b006d97330ef7f1d596326bf8a438a129fa89c10',
 };
 
 function readRepoFile(path: string): string {


### PR DESCRIPTION
## Summary

- Add a version-keyed CII protocol snapshot guard for shared country weights, default weights, strategic-risk constants, conflict curve constants, and getScoreLevel cutoffs.
- Pin canonical CII UI bands at 81/66/51/31 across the cached adapter and browser fallback.
- Document existing CII methodology details for unrest severityBoost, conflict civilianBoost, Israel OREF alert pressure, and Information severity handling without bumping CII_FORMULA_VERSION.

## Coordination

This intentionally does not bump CII_FORMULA_VERSION; the separate codex/cii-v6-score-attribution-climate branch should own the v5-to-v6 formula bump and score-shifting narrative. When that branch lands, update the version-keyed protocol snapshot for the new formula version.

## Validation

- npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/cii-scoring.test.mts
- npm run typecheck
- git diff --check
- pre-push hook passed on git push -u origin codex/cii-version-doc-guardrails, including npm run typecheck, npm run typecheck:api, changed CII tests, markdown lint, MDX lint, architectural boundary checks, safe HTML guard, and version sync.