### PR TITLE
Guard CII inline scoring formula literals

### DIFF
--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -247,12 +247,13 @@ export const CACHE_TOOLS: ToolDef[] = [
     _seedMetaKey: 'seed-meta:conflict:ucdp-events',
     _maxStaleMin: 30,
     // NOTE: `GET /api/intelligence/v1/get-risk-scores` is NOT covered here.
-    // The audit-time hint matched on 3 keys (conflict:ucdp-events:v1,
-    // conflict:iran-events:v1, risk:scores:sebuf:stale:v6) but the handler at
-    // server/worldmonitor/intelligence/v1/get-risk-scores.ts:242-256 reads 12
-    // cross-domain keys (infra outages, climate anomalies, cyber threats,
-    // wildfires, GPS jamming, OREF history, security advisories, displacement,
-    // news insights, news threats). Excluded as `deferred-to-future-tool` —
+    // The audit-time hint matched only this tool's conflict/risk cache keys,
+    // but the handler at server/worldmonitor/intelligence/v1/get-risk-scores.ts
+    // reads a broader cross-domain set (infra outages, climate anomalies,
+    // cyber threats, wildfires, GPS jamming, OREF history, security
+    // advisories, displacement, news insights, news threats, aviation,
+    // earthquakes, sanctions, temporal anomalies, and military CII). Excluded
+    // as `deferred-to-future-tool` —
     // belongs in a future expanded_risk_scores composite tool, not here.
     _apiPaths: [
       "GET /api/conflict/v1/list-iran-events",

--- a/docs/Docs_To_Review/TODO_Performance.md
+++ b/docs/Docs_To_Review/TODO_Performance.md
@@ -343,7 +343,7 @@ Status:  · 🔄 Partial · ❌ Not started
 ### PERF-040 — Move CII Calculation to Web Worker
 
 - **Impact:** 🟡 Medium | **Effort:** ~4 hours
-- **Status:** Deprecated premise — the proposed CII worker file was never added. Published CII is server-authoritative v5 for 31 Tier-1 countries from `shared/cii-weights.ts`; the frontend normally renders cached risk scores and only uses `calculateCII()` as the local fallback path.
+- **Status:** Deprecated premise — the proposed CII worker file was never added. Published CII is server-authoritative v6 for 31 Tier-1 countries from `shared/cii-weights.ts`; the frontend normally renders cached risk scores and only uses `calculateCII()` as the local fallback path.
 - **Expected gain:** Re-open only with fresh profiling evidence that the local fallback path, not cached server-score ingestion, causes measurable main-thread stalls.
 
 ### PERF-041 — SharedArrayBuffer for Large Datasets

--- a/docs/Docs_To_Review/todo.md
+++ b/docs/Docs_To_Review/todo.md
@@ -193,7 +193,7 @@ Overlay the map with country-colored fills based on CII score.
 | **Depends on** | — |
 
 **Description**
-CII currently publishes server-authoritative v5 scores for 31 Tier-1 countries
+CII currently publishes server-authoritative v6 scores for 31 Tier-1 countries
 from `shared/cii-weights.ts`, then the browser ingests the cached risk-score
 feed with a local `country-instability.ts` fallback. This TODO is only current
 if reframed as user-defined Tier 2 monitoring layered on top of that contract.

--- a/docs/methodology/cii-risk-scores.mdx
+++ b/docs/methodology/cii-risk-scores.mdx
@@ -85,7 +85,8 @@ The current version is **v6**.
 
 > **Heads up — score contract changes.** Any edit that changes server/API
 > per-country baselines, event multipliers, strategic-risk roll-up
-> coefficients, or CII movement semantics MUST come with a bump of
+> coefficients, inline server formula literals, or CII movement semantics MUST
+> come with a bump of
 > `CII_FORMULA_VERSION` in
 > `server/worldmonitor/intelligence/v1/_risk-config.ts`, an update to this
 > document in the same commit, and a public CHANGELOG entry. Source-of-truth

--- a/docs/methodology/cii-risk-scores.mdx
+++ b/docs/methodology/cii-risk-scores.mdx
@@ -85,7 +85,8 @@ The current version is **v6**.
 
 > **Heads up — score contract changes.** Any edit that changes server/API
 > per-country baselines, event multipliers, strategic-risk roll-up
-> coefficients, inline server formula literals, or CII movement semantics MUST
+> coefficients, inline server formula literals, guarded top-level formula
+> constants, or CII movement semantics MUST
 > come with a bump of
 > `CII_FORMULA_VERSION` in
 > `server/worldmonitor/intelligence/v1/_risk-config.ts`, an update to this

--- a/tests/cached-risk-scores.test.mts
+++ b/tests/cached-risk-scores.test.mts
@@ -26,6 +26,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { transformSync } from 'esbuild';
+import ts from 'typescript';
 
 import { TIER1_COUNTRIES } from '../src/config/countries.ts';
 import { CII_COUNTRY_WEIGHTS } from '../shared/cii-weights.ts';
@@ -34,6 +35,49 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
 const sourcePath = resolve(root, 'src/services/cached-risk-scores.ts');
 const source = readFileSync(sourcePath, 'utf-8');
+const sourceFile = ts.createSourceFile(
+  sourcePath,
+  source,
+  ts.ScriptTarget.Latest,
+  true,
+  ts.ScriptKind.TS,
+);
+
+function findFunctionDeclaration(name: string): ts.FunctionDeclaration {
+  let found: ts.FunctionDeclaration | undefined;
+
+  function visit(node: ts.Node): void {
+    if (ts.isFunctionDeclaration(node) && node.name?.text === name) {
+      found = node;
+      return;
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  assert.ok(found, `${name} must exist in cached-risk-scores.ts`);
+  return found;
+}
+
+function functionBodyText(name: string): string {
+  const fn = findFunctionDeclaration(name);
+  assert.ok(fn.body, `${name} must have a function body`);
+  return fn.body.getText(sourceFile).replace(/\s+/g, ' ').trim();
+}
+
+function topLevelConstNamesMatching(pattern: RegExp): string[] {
+  const matches: string[] = [];
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    if ((statement.declarationList.flags & ts.NodeFlags.Const) === 0) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (ts.isIdentifier(declaration.name) && pattern.test(declaration.name.text)) {
+        matches.push(declaration.name.text);
+      }
+    }
+  }
+  return matches;
+}
 
 // ============================================================
 // 1. Static analysis: source guarantees no fabrication
@@ -81,18 +125,18 @@ describe('cached-risk-scores — no fabricated timestamps in source', () => {
       'frontend Tier-1 country names must stay in parity with shared CII weights',
     );
     assert.match(
-      source,
-      /function\s+isKnownTier1Code[\s\S]*hasOwnProperty\.call\(TIER1_COUNTRIES,\s*value\)/,
+      functionBodyText('isKnownTier1Code'),
+      /hasOwnProperty\.call\(TIER1_COUNTRIES,\s*value\)/,
       'localStorage validator must validate ISO2 codes against TIER1_COUNTRIES',
     );
     assert.match(
-      source,
-      /function\s+canonicalizeCachedCiiEntry[\s\S]*name:\s*TIER1_COUNTRIES\[entry\.code\]\s*\?\?\s*entry\.code/,
+      functionBodyText('canonicalizeCachedCiiEntry'),
+      /name:\s*TIER1_COUNTRIES\[entry\.code\]\s*\?\?\s*entry\.code/,
       'localStorage canonicalizer must rewrite display names from TIER1_COUNTRIES',
     );
-    assert.doesNotMatch(
-      source,
-      /const\s+(?:TIER1_NAMES|KNOWN_TIER1_COUNTRIES|VALID_TIER1_COUNTRIES)\b/,
+    assert.deepEqual(
+      topLevelConstNamesMatching(/^(?:TIER1_(?!COUNTRIES$)\w+|(?:KNOWN_|VALID_)?TIER1_\w+|(?:KNOWN_|VALID_)?COUNTRY_(?:CODES|LIST|NAMES))$/),
+      [],
       'cached-risk-scores.ts must not reintroduce a second Tier-1 name/code list',
     );
   });

--- a/tests/cached-risk-scores.test.mts
+++ b/tests/cached-risk-scores.test.mts
@@ -27,6 +27,9 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { transformSync } from 'esbuild';
 
+import { TIER1_COUNTRIES } from '../src/config/countries.ts';
+import { CII_COUNTRY_WEIGHTS } from '../shared/cii-weights.ts';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
 const sourcePath = resolve(root, 'src/services/cached-risk-scores.ts');
@@ -68,6 +71,29 @@ describe('cached-risk-scores — no fabricated timestamps in source', () => {
       source,
       /interface\s+CachedRiskScores\b[\s\S]*?computedAt:\s*string\s*\|\s*null/,
       'CachedRiskScores.computedAt must be `string | null`',
+    );
+  });
+
+  it('localStorage Tier-1 validation uses the canonical country table, not a second hardcoded list', () => {
+    assert.deepEqual(
+      Object.keys(TIER1_COUNTRIES).sort(),
+      Object.keys(CII_COUNTRY_WEIGHTS).sort(),
+      'frontend Tier-1 country names must stay in parity with shared CII weights',
+    );
+    assert.match(
+      source,
+      /function\s+isKnownTier1Code[\s\S]*hasOwnProperty\.call\(TIER1_COUNTRIES,\s*value\)/,
+      'localStorage validator must validate ISO2 codes against TIER1_COUNTRIES',
+    );
+    assert.match(
+      source,
+      /function\s+canonicalizeCachedCiiEntry[\s\S]*name:\s*TIER1_COUNTRIES\[entry\.code\]\s*\?\?\s*entry\.code/,
+      'localStorage canonicalizer must rewrite display names from TIER1_COUNTRIES',
+    );
+    assert.doesNotMatch(
+      source,
+      /const\s+(?:TIER1_NAMES|KNOWN_TIER1_COUNTRIES|VALID_TIER1_COUNTRIES)\b/,
+      'cached-risk-scores.ts must not reintroduce a second Tier-1 name/code list',
     );
   });
 });

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -48,11 +48,11 @@ const REPO_ROOT = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
 
 const CII_PROTOCOL_SNAPSHOT_HASH_BY_VERSION: Record<string, string> = {
   v5: '13a339323a4b1c92bec967a2b006d97330ef7f1d596326bf8a438a129fa89c10',
-  // v6 (#4147/#4148/#4149): attribution, climate-wiring, observability and
-  // advisory-fallback changes did not touch any *hashed* coefficient
-  // (country weights, defaults, strategic constants, getScoreLevel cutoffs),
-  // so the protocol snapshot is unchanged from v5.
-  v6: '13a339323a4b1c92bec967a2b006d97330ef7f1d596326bf8a438a129fa89c10',
+  // v6 (#4147/#4148/#4149/#4151): attribution/climate fixes plus the
+  // formula guard expansion. The guard now includes score-relevant inline
+  // literals from get-risk-scores.ts, so a v7 scoring branch must refresh this
+  // hash after it deliberately changes formula literals.
+  v6: '522a12cf805357a7a4df5c32186591c4af11053f5fd6decbff6572abd7e8a9ad',
 };
 
 function readRepoFile(path: string): string {
@@ -144,6 +144,117 @@ function parseScoreLevelFunction(source: string, functionName: string): ParsedSc
 
 function extractScoreLevelCutoffs(source: string, functionName: string): ScoreLevelCutoff[] {
   return parseScoreLevelFunction(source, functionName).cutoffs;
+}
+
+interface ScoreFormulaLiteral {
+  region: string;
+  order: number;
+  value: number;
+  context: string;
+}
+
+function enclosingFormulaContext(node: ts.Node, sourceFile: ts.SourceFile, rangeEnd: number): string {
+  let current: ts.Node = node;
+  while (current.parent && current.parent.end <= rangeEnd) {
+    current = current.parent;
+    if (
+      ts.isVariableDeclaration(current)
+      || ts.isConditionalExpression(current)
+      || ts.isCallExpression(current)
+      || ts.isBinaryExpression(current)
+      || ts.isReturnStatement(current)
+    ) {
+      return current.getText(sourceFile).replace(/\s+/g, ' ').trim();
+    }
+  }
+  return node.getText(sourceFile).replace(/\s+/g, ' ').trim();
+}
+
+function numericLiteralValue(node: ts.Node): number | null {
+  if (ts.isNumericLiteral(node)) return Number(node.text.replace(/_/g, ''));
+  if (
+    ts.isPrefixUnaryExpression(node)
+    && node.operator === ts.SyntaxKind.MinusToken
+    && ts.isNumericLiteral(node.operand)
+  ) {
+    return -Number(node.operand.text.replace(/_/g, ''));
+  }
+  return null;
+}
+
+function collectNumericLiteralsInRange(
+  sourceFile: ts.SourceFile,
+  region: string,
+  rangeStart: number,
+  rangeEnd: number,
+  orderOffset: number,
+): ScoreFormulaLiteral[] {
+  const literals: ScoreFormulaLiteral[] = [];
+
+  function visit(node: ts.Node): void {
+    if (node.end < rangeStart || node.getStart(sourceFile) > rangeEnd) return;
+
+    const value = numericLiteralValue(node);
+    if (value !== null) {
+      literals.push({
+        region,
+        order: orderOffset + literals.length,
+        value,
+        context: enclosingFormulaContext(node, sourceFile, rangeEnd),
+      });
+      return;
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return literals;
+}
+
+function extractScoreFormulaLiterals(source: string): ScoreFormulaLiteral[] {
+  const sourceFile = ts.createSourceFile(
+    'get-risk-scores.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const guardedFunctions = ['climateSeverityScore', 'computeCIIScores'];
+  const literals: ScoreFormulaLiteral[] = [];
+
+  for (const functionName of guardedFunctions) {
+    const fn = findFunctionDeclaration(sourceFile, functionName);
+    assert.ok(fn.body, `${functionName} must have a function body`);
+    literals.push(
+      ...collectNumericLiteralsInRange(
+        sourceFile,
+        functionName,
+        fn.body.getStart(sourceFile),
+        fn.body.end,
+        literals.length,
+      ),
+    );
+  }
+
+  assert.ok(literals.length > 0, 'CII scorer must expose numeric formula literals to the snapshot guard');
+  return literals;
+}
+
+function assertFormulaLiteralCovered(
+  literals: ScoreFormulaLiteral[],
+  region: string,
+  value: number,
+  contextSnippet: string,
+): void {
+  assert.ok(
+    literals.some((literal) => (
+      literal.region === region
+      && literal.value === value
+      && literal.context.includes(contextSnippet)
+    )),
+    `CII formula snapshot must cover ${region} literal ${value} in context: ${contextSnippet}`,
+  );
 }
 
 function evaluateScoreLevel(parsed: ParsedScoreLevelFunction, score: number): string {
@@ -949,6 +1060,12 @@ describe('CII scoring', () => {
     );
 
     const cachedRiskSource = readRepoFile('src/services/cached-risk-scores.ts');
+    const getRiskScoresSource = readRepoFile('server/worldmonitor/intelligence/v1/get-risk-scores.ts');
+    const scoreFormulaLiterals = extractScoreFormulaLiterals(getRiskScoresSource);
+    assertFormulaLiteralCovered(scoreFormulaLiterals, 'climateSeverityScore', 5, 'return 5');
+    assertFormulaLiteralCovered(scoreFormulaLiterals, 'computeCIIScores', 0.4, '(ev.daysAgo ?? 0) <= 7 ? 1.0 : 0.4');
+    assertFormulaLiteralCovered(scoreFormulaLiterals, 'computeCIIScores', 360, 'safeNonNegativeNum(f.brightness) >= 360');
+    assertFormulaLiteralCovered(scoreFormulaLiterals, 'computeCIIScores', 5.5, 'mag < 5.5');
     const snapshot = {
       countryWeights: Object.fromEntries(
         Object.entries(CII_COUNTRY_WEIGHTS).sort(([a], [b]) => a.localeCompare(b)),
@@ -965,13 +1082,14 @@ describe('CII scoring', () => {
         STRATEGIC_RISK_SCALE_FLOOR,
         STRATEGIC_RISK_TOP_N,
       },
+      scoreFormulaLiterals,
       scoreLevelCutoffs: extractScoreLevelCutoffs(cachedRiskSource, 'getScoreLevel'),
     };
 
     assert.equal(
       hashJson(snapshot),
       expectedHash,
-      'CII coefficient/cutoff snapshot changed. Bump CII_FORMULA_VERSION, update methodology docs/changelogs, and add the new version-keyed snapshot hash.',
+      'CII coefficient/formula/cutoff snapshot changed. Bump CII_FORMULA_VERSION, update methodology docs/changelogs, and add the new version-keyed snapshot hash.',
     );
   });
 

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -182,6 +182,13 @@ function numericLiteralValue(node: ts.Node): number | null {
   return null;
 }
 
+function isInsideTypeNode(node: ts.Node): boolean {
+  for (let current: ts.Node | undefined = node.parent; current; current = current.parent) {
+    if (ts.isTypeNode(current) || ts.isTypeParameterDeclaration(current)) return true;
+  }
+  return false;
+}
+
 function collectNumericLiteralsInRange(
   sourceFile: ts.SourceFile,
   region: string,
@@ -193,9 +200,10 @@ function collectNumericLiteralsInRange(
 
   function visit(node: ts.Node): void {
     if (node.end < rangeStart || node.getStart(sourceFile) > rangeEnd) return;
+    if (ts.isTypeNode(node) || ts.isTypeParameterDeclaration(node)) return;
 
     const value = numericLiteralValue(node);
-    if (value !== null) {
+    if (value !== null && !isInsideTypeNode(node)) {
       literals.push({
         region,
         order: orderOffset + literals.length,

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -50,10 +50,13 @@ const CII_PROTOCOL_SNAPSHOT_HASH_BY_VERSION: Record<string, string> = {
   v5: '13a339323a4b1c92bec967a2b006d97330ef7f1d596326bf8a438a129fa89c10',
   // v6 (#4147/#4148/#4149/#4151): attribution/climate fixes plus the
   // formula guard expansion. The guard now includes score-relevant inline
-  // literals from get-risk-scores.ts, so a v7 scoring branch must refresh this
-  // hash after it deliberately changes formula literals.
+  // literals and guarded top-level formula constants from get-risk-scores.ts,
+  // so a v7 scoring branch must refresh this hash after it deliberately
+  // changes formula literals.
   v6: '522a12cf805357a7a4df5c32186591c4af11053f5fd6decbff6572abd7e8a9ad',
 };
+
+const GUARDED_TOP_LEVEL_SCORE_CONST_NAMES = ['NEWS_THREAT_WEIGHT'];
 
 function readRepoFile(path: string): string {
   return readFileSync(resolve(REPO_ROOT, path), 'utf8');
@@ -83,6 +86,22 @@ function findFunctionDeclaration(sourceFile: ts.SourceFile, functionName: string
   visit(sourceFile);
   assert.ok(found, `missing function declaration: ${functionName}`);
   return found;
+}
+
+function findTopLevelConstDeclaration(
+  sourceFile: ts.SourceFile,
+  constName: string,
+): ts.VariableDeclaration | null {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    if ((statement.declarationList.flags & ts.NodeFlags.Const) === 0) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (ts.isIdentifier(declaration.name) && declaration.name.text === constName) {
+        return declaration;
+      }
+    }
+  }
+  return null;
 }
 
 function getReturnString(statement: ts.Statement): string | null {
@@ -230,6 +249,21 @@ function extractScoreFormulaLiterals(source: string): ScoreFormulaLiteral[] {
   );
   const guardedFunctions = ['climateSeverityScore', 'computeCIIScores'];
   const literals: ScoreFormulaLiteral[] = [];
+
+  for (const constName of GUARDED_TOP_LEVEL_SCORE_CONST_NAMES) {
+    const declaration = findTopLevelConstDeclaration(sourceFile, constName);
+    if (!declaration) continue;
+    assert.ok(declaration.initializer, `${constName} must have an initializer`);
+    literals.push(
+      ...collectNumericLiteralsInRange(
+        sourceFile,
+        constName,
+        declaration.initializer.getStart(sourceFile),
+        declaration.initializer.end,
+        literals.length,
+      ),
+    );
+  }
 
   for (const functionName of guardedFunctions) {
     const fn = findFunctionDeclaration(sourceFile, functionName);
@@ -1074,6 +1108,10 @@ describe('CII scoring', () => {
     assertFormulaLiteralCovered(scoreFormulaLiterals, 'computeCIIScores', 0.4, '(ev.daysAgo ?? 0) <= 7 ? 1.0 : 0.4');
     assertFormulaLiteralCovered(scoreFormulaLiterals, 'computeCIIScores', 360, 'safeNonNegativeNum(f.brightness) >= 360');
     assertFormulaLiteralCovered(scoreFormulaLiterals, 'computeCIIScores', 5.5, 'mag < 5.5');
+    if (getRiskScoresSource.includes('NEWS_THREAT_WEIGHT')) {
+      assertFormulaLiteralCovered(scoreFormulaLiterals, 'NEWS_THREAT_WEIGHT', 4, 'critical: 4');
+      assertFormulaLiteralCovered(scoreFormulaLiterals, 'NEWS_THREAT_WEIGHT', 0.5, 'low: 0.5');
+    }
     const snapshot = {
       countryWeights: Object.fromEntries(
         Object.entries(CII_COUNTRY_WEIGHTS).sort(([a], [b]) => a.localeCompare(b)),
@@ -1099,6 +1137,27 @@ describe('CII scoring', () => {
       expectedHash,
       'CII coefficient/formula/cutoff snapshot changed. Bump CII_FORMULA_VERSION, update methodology docs/changelogs, and add the new version-keyed snapshot hash.',
     );
+  });
+
+  it('CII protocol snapshot includes guarded top-level score constants', () => {
+    const literals = extractScoreFormulaLiterals(`
+      const NEWS_THREAT_WEIGHT: Record<string, number> = {
+        critical: 4,
+        high: 2,
+        medium: 1,
+        low: 0.5,
+        info: 0,
+      };
+      function climateSeverityScore(): number {
+        return 5;
+      }
+      export function computeCIIScores(): number {
+        return 1;
+      }
+    `);
+
+    assertFormulaLiteralCovered(literals, 'NEWS_THREAT_WEIGHT', 4, 'critical: 4');
+    assertFormulaLiteralCovered(literals, 'NEWS_THREAT_WEIGHT', 0.5, 'low: 0.5');
   });
 
   it('getScoreLevel uses canonical CII UI bands at 81/66/51/31', () => {


### PR DESCRIPTION
## Summary
- add an AST-backed CII protocol guard for inline scoring literals in get-risk-scores.ts, including climate severity, event decay, fire thresholds, earthquake cutoffs, caps, floors, boosts, and blends
- add localStorage Tier-1 parity coverage and tighten the methodology note so formula literal edits require version/hash refreshes
- clean stale v5 docs residue and the cache-tools key-count comment

## Validation
- node --import tsx --test tests/cii-scoring.test.mts tests/cached-risk-scores.test.mts tests/frontend-cii-closeout.test.mts tests/frontend-cii-source-of-truth.test.mts tests/cii-docs-drift.test.mts
- git diff --check
- npm run typecheck
- pre-push hook: typecheck, API typecheck, Convex typecheck, CJS syntax, Unicode safety, lint:boundaries, lint:safe-html, Sentry coverage, rate-limit policy coverage, premium-fetch parity, edge bundle check, changed test files, edge function tests, markdown lint, MDX lint, version sync

## Merge-order notes
- This branch intentionally accepts the current v6 CII formula snapshot. A v7 attribution/formula branch should refresh CII_FORMULA_VERSION, docs, and the formula snapshot hash after its score-shifting changes land.
- Scope is guards/docs/tests only; no scoring algorithm changes are included.