### PR TITLE
Fix CII realtime coverage health semantics

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -302,7 +302,7 @@ const SEED_META = {
   fxYoy:            { key: 'seed-meta:economic:fx-yoy',           maxStaleMin: 1500 }, // daily cron; 25h tolerance + 1h drift
   gpsjam:           { key: 'seed-meta:intelligence:gpsjam',       maxStaleMin: 1440 }, // Wingbits API (scripts/fetch-gpsjam.mjs); 1440min = 24h tolerance gives operator headroom to handle upstream outages and monthly quota exhaustion (HTTP 402 observed 2026-04-29) without dashboard noise. Seeder catch-block extends TTL on fail without refreshing fetchedAt, so STALE_SEED via age is the only alarm path.
   positiveGeoEvents:{ key: 'seed-meta:positive-events:geo',       maxStaleMin: 60 },
-  riskScores:       { key: 'seed-meta:intelligence:risk-scores',  maxStaleMin: 30 }, // CII warm-ping every 8min; 30min = ~3.5x interval,
+  riskScores:       { key: 'seed-meta:intelligence:risk-scores',  maxStaleMin: 30, minRecordCount: 3 }, // CII warm-ping every 8min; recordCount is realtime signal-density coverage for score-relevant ACLED/news/cyber families, not raw feed availability; quiet-but-fresh feeds may warn COVERAGE_PARTIAL.
   iranEvents:       { key: 'seed-meta:conflict:iran-events',      maxStaleMin: 20160 }, // manual seed from LiveUAMap; 20160 = 14d = 2× weekly cadence
   ucdpEvents:       { key: 'seed-meta:conflict:ucdp-events',      maxStaleMin: 420 },
   militaryFlights:  { key: 'seed-meta:military:flights',           maxStaleMin: 30 }, // cron ~10min (LIVE_TTL=600s); 30min = 3x interval,

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -91,6 +91,13 @@ Some keys use fallback chains. If any sibling has data, empty siblings report `O
 - **Military Flights:** `militaryFlights` -> `militaryFlightsStale`
 - **Displacement:** `displacement` (current UTC year) -> `displacementPrev` (prior year, covers the Jan-1 window before the new-year seed runs)
 
+`riskScores` is intentionally stricter than a raw feed heartbeat. Its
+`recordCount` is realtime signal-density coverage: the count of score-relevant
+Tier-1 ACLED, news, and cyber signal families present during the CII refresh.
+When those feeds are reachable but quiet, `riskScores` can still report
+`COVERAGE_PARTIAL`; underlying feed freshness is tracked by the source-specific
+health entries where those feeds publish seed metadata.
+
 ### Staleness Thresholds (maxStaleMin)
 
 Selected thresholds from `SEED_META`:

--- a/docs/strategic-risk.mdx
+++ b/docs/strategic-risk.mdx
@@ -267,4 +267,8 @@ responses set `degraded=true` and `stale=true`; cold baseline-only responses set
 The relay CII warm-ping loop is active in `scripts/ais-relay.cjs`: it calls
 `/api/intelligence/v1/get-risk-scores` every 8 minutes, lets the RPC handler
 refresh live/stale cache state, and writes `seed-meta:intelligence:risk-scores`
-for health monitoring when scores are returned.
+for health monitoring when scores are returned. That seed-meta `recordCount`
+is realtime signal-density coverage, not raw feed availability: it counts the
+score-relevant Tier-1 ACLED, news, and cyber signal families present in the CII
+refresh. Quiet-but-fresh realtime feeds can therefore produce
+`COVERAGE_PARTIAL`; source-specific freshness remains the feed-heartbeat view.

--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -527,6 +527,18 @@ interface AuxiliarySources {
   militaryCii: Record<string, any> | null;
 }
 
+const NEWS_THREAT_WEIGHT: Record<string, number> = {
+  critical: 4,
+  high: 2,
+  medium: 1,
+  elevated: 1,
+  moderate: 0.5,
+  low: 0.5,
+  info: 0,
+};
+
+export const CII_REALTIME_REQUIRED_SIGNAL_FAMILY_COUNT = 3;
+
 function emptyAuxiliarySources(): AuxiliarySources {
   return {
     ucdpEvents: [],
@@ -867,11 +879,8 @@ export function computeCIIScores(
   }
 
   // --- News insights threat scoring ---
-  const THREAT_WEIGHT: Record<string, number> = {
-    critical: 4, high: 2, medium: 1, elevated: 1, moderate: 0.5, low: 0.5, info: 0,
-  };
   for (const story of aux.newsTopStories) {
-    const weight = THREAT_WEIGHT[story.threatLevel] ?? 0;
+    const weight = NEWS_THREAT_WEIGHT[story.threatLevel] ?? 0;
     if (weight === 0) continue;
     // Primary attribution via countryCode from seed-insights geo-extraction
     let code: string | null = story.countryCode && data[story.countryCode] ? story.countryCode : null;
@@ -1095,37 +1104,63 @@ function hasRiskScoreRegionFilter(region: string | undefined | null): boolean {
   return String(region || '').trim() !== '';
 }
 
-// Lazy so Edge cold starts do not do baseline score work unless fresh CII
-// scoring needs the signal-coverage comparison.
-let baselineOnlyScoresByRegion: Map<string, number> | null = null;
-
-function getBaselineOnlyScoresByRegion(): Map<string, number> {
-  if (!baselineOnlyScoresByRegion) {
-    baselineOnlyScoresByRegion = new Map(
-      computeCIIScores([], emptyAuxiliarySources()).map((score) => [score.region.toUpperCase(), score.combinedScore]),
-    );
-  }
-  return baselineOnlyScoresByRegion;
+function isTier1CountryCode(code: string | undefined | null): boolean {
+  return Object.prototype.hasOwnProperty.call(TIER1_COUNTRIES, String(code || '').trim().toUpperCase());
 }
 
-function hasLiveCiiSignalCoverage(score: CiiScore): boolean {
-  const components = score.components;
-  if (
-    components
-    && (components.newsActivity > 0
-      || components.ciiContribution > 0
-      || components.geoConvergence > 0
-      || components.militaryActivity > 0)
-  ) {
-    return true;
+export function countCiiRealtimeSignalDensityCoverage(
+  acled: Array<{ country: string; event_type: string; fatalities: number; daysAgo?: number }> | undefined | null,
+  aux: AuxiliarySources | undefined | null,
+): number {
+  // Health semantics: this is signal-density coverage for score-relevant
+  // realtime families, not a raw feed heartbeat. Quiet-but-available feeds may
+  // produce 0 here; underlying feed freshness is monitored by their own
+  // seed-meta/TTL health entries where available.
+  const coveredFamilies = new Set<'acled' | 'news' | 'cyber'>();
+
+  if ((acled ?? []).some((ev) => isTier1CountryCode(normalizeCountryName(ev.country)))) {
+    coveredFamilies.add('acled');
   }
 
-  const baselineOnly = getBaselineOnlyScoresByRegion().get(String(score.region || '').toUpperCase());
-  return baselineOnly !== undefined && score.combinedScore !== baselineOnly;
-}
+  for (const story of aux?.newsTopStories ?? []) {
+    const weight = NEWS_THREAT_WEIGHT[String(story.threatLevel || '').toLowerCase()] ?? 0;
+    if (weight <= 0) continue;
+    if (
+      isTier1CountryCode(story.countryCode)
+      || isTier1CountryCode(normalizeCountryName(story.primaryTitle))
+    ) {
+      coveredFamilies.add('news');
+      break;
+    }
+  }
 
-export function countCiiSignalCoverage(ciiScores: CiiScore[] | undefined | null): number {
-  return (ciiScores ?? []).filter(hasLiveCiiSignalCoverage).length;
+  if (!coveredFamilies.has('news')) {
+    for (const [code, counts] of Object.entries(aux?.threatSummaryByCountry ?? {})) {
+      if (!isTier1CountryCode(code)) continue;
+      const weightedCount = Object.entries(NEWS_THREAT_WEIGHT).reduce(
+        (sum, [level, weight]) => sum + safeNonNegativeNum(counts[level as keyof typeof counts]) * weight,
+        0,
+      );
+      if (weightedCount > 0) {
+        coveredFamilies.add('news');
+        break;
+      }
+    }
+  }
+
+  for (const threat of aux?.cyber ?? []) {
+    const code = String(threat.country || '').trim().toUpperCase();
+    const severity = String(threat.severity || '').toLowerCase().replace(/^criticality_level_/, '');
+    if (
+      isTier1CountryCode(code)
+      && (severity === 'critical' || severity === 'high' || severity === 'medium')
+    ) {
+      coveredFamilies.add('cyber');
+      break;
+    }
+  }
+
+  return coveredFamilies.size;
 }
 
 function withRiskScoreRuntimeState(
@@ -1284,6 +1319,7 @@ export async function getRiskScores(
   req: GetRiskScoresRequest,
 ): Promise<GetRiskScoresResponse> {
   try {
+    let realtimeSignalDensityCoverageCount = 0;
     const { data: result, source, leader } = await cachedFetchJsonWithMeta<GetRiskScoresResponse>(
       RISK_CACHE_KEY,
       RISK_CACHE_TTL,
@@ -1295,6 +1331,7 @@ export async function getRiskScores(
           readCiiTrendPriorScores(nowMs),
         ]);
         if (!priorCiiScores?.length) recordCiiTrendPriorGap(nowMs);
+        realtimeSignalDensityCoverageCount = countCiiRealtimeSignalDensityCoverage(acled, aux);
         const ciiScores = computeCIIScores(acled, aux, { priorScores: priorCiiScores, nowMs });
         const strategicRisks = computeStrategicRisks(ciiScores);
         return { ciiScores, strategicRisks, degraded: false, stale: false };
@@ -1327,13 +1364,12 @@ export async function getRiskScores(
       // 7-day TTL matches the warm-ping write so health.maxStaleMin (30min)
       // logic is unchanged.
       if (source === 'fresh' && leader) {
-        const signalCoverageCount = countCiiSignalCoverage(freshResult.ciiScores);
         const writes: Array<Promise<unknown>> = [
           setCachedJson(RISK_STALE_CACHE_KEY, freshResult, RISK_STALE_TTL),
           persistCiiTrendSnapshot(freshResult),
           setCachedJson(
             'seed-meta:intelligence:risk-scores',
-            { fetchedAt: Date.now(), recordCount: signalCoverageCount },
+            { fetchedAt: Date.now(), recordCount: realtimeSignalDensityCoverageCount },
             604800,
           ),
         ];

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -19,11 +19,12 @@ import {
 import { TIER1_COUNTRIES as SERVER_TIER1_COUNTRIES } from '../server/worldmonitor/intelligence/v1/_shared.ts';
 import {
   BASELINE_RISK,
+  CII_REALTIME_REQUIRED_SIGNAL_FAMILY_COUNT,
   CII_TREND_BUCKET_LOOKUP_RADIUS,
   CII_TREND_BUCKET_MS,
   CII_TREND_TARGET_AGE_MS,
   EVENT_MULTIPLIER,
-  countCiiSignalCoverage,
+  countCiiRealtimeSignalDensityCoverage,
   computeCIIScores,
   computeStrategicRisks,
   filterRiskScoresResponse,
@@ -190,6 +191,19 @@ function acledEvents(country: string, type: string, count: number) {
 
 function scoreFor(scores: ReturnType<typeof computeCIIScores>, code: string) {
   return scores.find((s) => s.region === code);
+}
+
+function countScoredRealtimeComponents(scores: ReturnType<typeof computeCIIScores>): number {
+  return scores.filter((score) => {
+    const components = score.components;
+    return Boolean(
+      components
+      && (components.newsActivity > 0
+        || components.ciiContribution > 0
+        || components.geoConvergence > 0
+        || components.militaryActivity > 0),
+    );
+  }).length;
 }
 
 const TREND_TEST_NOW = 1_700_000_000_000;
@@ -1037,23 +1051,89 @@ describe('CII scoring', () => {
     assert.equal(risks[0]!.score, STRATEGIC_RISK_SCALE_FLOOR);
   });
 
-  it('riskScores health coverage ignores structural Tier-1 baseline rows', () => {
+  it('riskScores health coverage reports zero for total real-time outage', () => {
+    const aux = emptyAux();
     const scores = computeCIIScores([], emptyAux());
 
     assert.equal(scores.length, Object.keys(SERVER_TIER1_COUNTRIES).length);
     assert.equal(
-      countCiiSignalCoverage(scores),
+      countScoredRealtimeComponents(scores),
       0,
       'baseline-only CII emits Tier-1 rows but must report zero live signal coverage to seed health',
     );
+    assert.equal(
+      countCiiRealtimeSignalDensityCoverage([], aux),
+      0,
+      'no ACLED/news/cyber-style inputs means riskScores seed health must fail closed',
+    );
   });
 
-  it('riskScores health coverage counts countries with live component or supplemental signals', () => {
+  it('riskScores health coverage ignores slow/static score movers during real-time outage', () => {
+    const aux = emptyAux();
+    aux.displacedByIso3 = { USA: 5_600_000 };
+    aux.sanctionsCountryCounts = { US: 2_500 };
+    aux.advisories = { byCountry: { US: 'do-not-travel' } };
+    const baseline = scoreFor(computeCIIScores([], emptyAux()), 'US')!;
+    const slowOnly = scoreFor(computeCIIScores([], aux), 'US')!;
+    const scores = computeCIIScores([], aux);
+
+    assert.ok(
+      slowOnly.combinedScore > baseline.combinedScore,
+      'slow/static displacement, sanctions, and advisory inputs still move the CII score',
+    );
+    assert.equal(
+      countScoredRealtimeComponents(scores),
+      0,
+      'slow/static-only score deltas must not count as live component coverage',
+    );
+    assert.equal(
+      countCiiRealtimeSignalDensityCoverage([], aux),
+      0,
+      'slow/static-only score deltas must not keep /api/health.riskScores green',
+    );
+  });
+
+  it('riskScores health coverage reports partial when only one required real-time family is alive', () => {
     const aux = emptyAux();
     aux.cyber = [{ country: 'US', severity: 'CRITICALITY_LEVEL_CRITICAL' }];
-    const scores = computeCIIScores([acledEvent('Ukraine', 'Battles', 0)], aux);
 
-    assert.equal(countCiiSignalCoverage(scores), 2);
+    assert.equal(
+      countCiiRealtimeSignalDensityCoverage([], aux),
+      1,
+      'one surviving real-time family must stay below the health minRecordCount threshold',
+    );
+  });
+
+  it('riskScores health coverage counts normal mixed real-time source families', () => {
+    const acled = [acledEvent('Ukraine', 'Battles', 0)];
+    const aux = emptyAux();
+    aux.cyber = [{ country: 'US', severity: 'CRITICALITY_LEVEL_CRITICAL' }];
+    aux.newsTopStories = [{ countryCode: 'GB', threatLevel: 'high', primaryTitle: 'UK security alert' }];
+    const scores = computeCIIScores(acled, aux);
+
+    assert.equal(
+      countScoredRealtimeComponents(scores),
+      2,
+      'ACLED and news feed scored CII components for UA and GB',
+    );
+    assert.equal(
+      countCiiRealtimeSignalDensityCoverage(acled, aux),
+      CII_REALTIME_REQUIRED_SIGNAL_FAMILY_COUNT,
+      'health coverage counts ACLED, news, and cyber source families even when cyber lands as supplemental boost',
+    );
+  });
+
+  it('riskScores health coverage ignores non-Tier-1 realtime family inputs', () => {
+    const acled = [acledEvent('Andorra', 'Battles', 0)];
+    const aux = emptyAux();
+    aux.newsTopStories = [{ countryCode: null, threatLevel: 'high', primaryTitle: 'Andorra security alert' }];
+    aux.cyber = [{ country: 'AD', severity: 'CRITICALITY_LEVEL_CRITICAL' }];
+
+    assert.equal(
+      countCiiRealtimeSignalDensityCoverage(acled, aux),
+      0,
+      'non-Tier-1 ACLED/news/cyber inputs must not satisfy Tier-1 CII realtime health coverage',
+    );
   });
 
   it('strategic risk uses positional decay 1 - i * 0.15 (top-5 weights = [1, 0.85, 0.7, 0.55, 0.4])', () => {

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -86,6 +86,19 @@ test('classifyKey: present-but-stale seed → STALE_SEED (warn), data still pres
   assert.equal(STATUS_COUNTS[entry.status], 'warn');
 });
 
+test('classifyKey: riskScores partial realtime family coverage → COVERAGE_PARTIAL', () => {
+  const entry = classifyKey('riskScores', BOOTSTRAP_KEYS.riskScores, { allowOnDemand: false },
+    makeCtx({
+      strens: { [BOOTSTRAP_KEYS.riskScores]: 1234 },
+      metaValues: { 'seed-meta:intelligence:risk-scores': seedMeta({ recordCount: 1 }) },
+    }));
+
+  assert.equal(entry.status, 'COVERAGE_PARTIAL');
+  assert.equal(entry.records, 1);
+  assert.equal(entry.minRecordCount, 3);
+  assert.equal(STATUS_COUNTS[entry.status], 'warn');
+});
+
 test('classifyKey: socialVelocity error seed-meta → SEED_ERROR while data is preserved', () => {
   const entry = classifyKey('socialVelocity', BOOTSTRAP_KEYS.socialVelocity, { allowOnDemand: false },
     makeCtx({

--- a/tests/seed-health-risk-scores.test.mjs
+++ b/tests/seed-health-risk-scores.test.mjs
@@ -41,6 +41,16 @@ test('seed-health CII risk score freshness mirrors api/health riskScores', () =>
     healthRiskScores.minutes,
     'seed-health intervalMin*2 must match api/health.js riskScores maxStaleMin',
   );
+  assert.match(
+    health,
+    /riskScores:\s*\{\s*key:\s*'seed-meta:intelligence:risk-scores',\s*maxStaleMin:\s*30,\s*minRecordCount:\s*3\s*\}/,
+    'api/health.js riskScores must degrade partial realtime signal-density coverage via minRecordCount=3',
+  );
+  assert.match(
+    health,
+    /signal-density coverage/i,
+    'api/health.js riskScores comment must document that recordCount is not raw feed availability',
+  );
   assert.ok(
     seedHealth.includes('api/health.js riskScores'),
     'seed-health CII comment should keep the alignment target explicit',
@@ -88,7 +98,12 @@ test('relay CII warm-ping delegates risk-score health count to the RPC handler',
   );
   assert.match(
     handler,
-    /countCiiSignalCoverage\(freshResult\.ciiScores\)/,
-    'get-risk-scores handler must remain the source of truth for riskScores signal-coverage recordCount',
+    /countCiiRealtimeSignalDensityCoverage\(acled,\s*aux\)/,
+    'get-risk-scores handler must derive riskScores recordCount from real-time CII signal-density coverage',
+  );
+  assert.match(
+    handler,
+    /not a raw feed heartbeat/i,
+    'get-risk-scores handler must document that signal-density health can differ from feed availability',
   );
 });


### PR DESCRIPTION
## Summary
- Separate CII health coverage from slow/static score movement by counting required realtime signal families for risk-score seed metadata.
- Require three realtime coverage families in `/api/health.riskScores`, so partial realtime outages surface as `COVERAGE_PARTIAL` instead of green.
- Add regression tests for total realtime outage, slow/static-only score movers, partial realtime coverage, and normal mixed realtime coverage.

## Validation
- `./node_modules/.bin/tsx --test tests/cii-scoring.test.mts`
- `node --test tests/health-classify.test.mjs`
- `node --test tests/seed-health-risk-scores.test.mjs`
- `git diff --check`
- `npm_config_cache=/tmp/worldmonitor-npm-cache npm run typecheck`
- Pre-push hook on `git push -u origin codex/cii-realtime-coverage-health`, including typecheck, API typecheck, boundary/safety lint, changed tests, edge function tests, and version check

## Merge Notes
- Based on `origin/main` at `341543918` (`Guard CII formula protocol docs (#4151)`).
- Depends on the existing CII observability/formula guard stack already merged through #4151.
- No frontend badge, bbox/climate attribution, or formula snapshot changes are included.