### PR TITLE
feat(relay): Reddit via ScrapeCreators + 3h scrape cadence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -200,6 +200,22 @@ AISSTREAM_API_KEY=
 OPENSKY_CLIENT_ID=
 OPENSKY_CLIENT_SECRET=
 
+# Reddit data for the relay (social-velocity + WSB-tickers). The unauthenticated
+# www.reddit.com/.../hot.json endpoint is policy-blocked (HTTP 403) regardless of
+# IP/UA, and Reddit removed self-serve API-app creation (Responsible Builder
+# Policy 2026), so a new OAuth app can't be created. Path precedence in the relay:
+#   1. SCRAPECREATORS_API_KEY (PREFERRED) — third-party Reddit vendor, the only
+#      path that works without a Reddit app. 1 credit/request; same key the
+#      /last30days skill uses. Get one at scrapecreators.com.
+#   2. REDDIT_CLIENT_ID/SECRET — oauth.reddit.com userless client_credentials.
+#      Usable ONLY with a PRE-policy (pre-~March-2026) "script" app's creds;
+#      new apps can no longer be created. Set REDDIT_USER_AGENT to your username.
+#   3. (none set) → public endpoint, which currently 403s → SEED_ERROR surfaced.
+SCRAPECREATORS_API_KEY=
+REDDIT_CLIENT_ID=
+REDDIT_CLIENT_SECRET=
+REDDIT_USER_AGENT=
+
 
 # ------ Telegram OSINT (Railway relay) ------
 # Telegram MTProto keys (free): https://my.telegram.org/apps

--- a/api/health.js
+++ b/api/health.js
@@ -384,8 +384,8 @@ const SEED_META = {
   shippingStress:    { key: 'seed-meta:supply_chain:shipping_stress',  maxStaleMin: 45 }, // relay loop every 15min; 45 = 3x interval (was 30 = 2×, too tight on relay hiccup)
   diseaseOutbreaks:  { key: 'seed-meta:health:disease-outbreaks',      maxStaleMin: 2880 }, // daily seed; 2880 = 48h = 2x interval
   healthAirQuality:  { key: 'seed-meta:health:air-quality',            maxStaleMin: 180 }, // hourly cron; 180 = 3x interval for shared health/climate seed
-  socialVelocity:    { key: 'seed-meta:intelligence:social-reddit',    maxStaleMin: 180 }, // relay loop every 60min (hourly, bumped from 10min to reduce Reddit IP blocking); 180 = 3x interval
-  wsbTickers:        { key: 'seed-meta:intelligence:wsb-tickers',      maxStaleMin: 180 }, // relay loop every 60min; 180 = 3x interval
+  socialVelocity:    { key: 'seed-meta:intelligence:social-reddit',    maxStaleMin: 540 }, // relay loop every 180min (3h; was 60min, dropped now that ScrapeCreators handles Reddit); 540 = 3x interval. Co-pinned with SOCIAL_VELOCITY_TTL=32400 (ais-relay.cjs): TTL ≥ maxStaleMin avoids the EMPTY-vs-STALE_SEED gap.
+  wsbTickers:        { key: 'seed-meta:intelligence:wsb-tickers',      maxStaleMin: 540 }, // relay loop every 180min (3h); 540 = 3x interval. Co-pinned with WSB_TICKERS_TTL=32400 (ais-relay.cjs).
   pizzint:           { key: 'seed-meta:intelligence:pizzint',          maxStaleMin: 30 }, // relay loop every 10min; 30 = 3x interval
   productCatalog:    { key: 'seed-meta:product-catalog',               maxStaleMin: 1080 }, // relay loop every 6h; 1080 = 18h = 3x interval
   vpdTrackerRealtime:   { key: 'seed-meta:health:vpd-tracker',         maxStaleMin: 2880 }, // daily seed (0 2 * * *); 2880min = 48h = 2x interval

--- a/api/health.js
+++ b/api/health.js
@@ -384,8 +384,8 @@ const SEED_META = {
   shippingStress:    { key: 'seed-meta:supply_chain:shipping_stress',  maxStaleMin: 45 }, // relay loop every 15min; 45 = 3x interval (was 30 = 2×, too tight on relay hiccup)
   diseaseOutbreaks:  { key: 'seed-meta:health:disease-outbreaks',      maxStaleMin: 2880 }, // daily seed; 2880 = 48h = 2x interval
   healthAirQuality:  { key: 'seed-meta:health:air-quality',            maxStaleMin: 180 }, // hourly cron; 180 = 3x interval for shared health/climate seed
-  socialVelocity:    { key: 'seed-meta:intelligence:social-reddit',    maxStaleMin: 540 }, // relay loop every 180min (3h; was 60min, dropped now that ScrapeCreators handles Reddit); 540 = 3x interval. Co-pinned with SOCIAL_VELOCITY_TTL=32400 (ais-relay.cjs): TTL ≥ maxStaleMin avoids the EMPTY-vs-STALE_SEED gap.
-  wsbTickers:        { key: 'seed-meta:intelligence:wsb-tickers',      maxStaleMin: 540 }, // relay loop every 180min (3h); 540 = 3x interval. Co-pinned with WSB_TICKERS_TTL=32400 (ais-relay.cjs).
+  socialVelocity:    { key: 'seed-meta:intelligence:social-reddit',    maxStaleMin: 540 }, // relay loop every 180min (3h; was 60min, dropped now that ScrapeCreators handles Reddit); 540 = 3x interval. Co-pinned with SOCIAL_VELOCITY_TTL=43200 (ais-relay.cjs): the data-key TTL must STRICTLY exceed this (720min > 540min) so a dead relay shows STALE_SEED before the key expires to EMPTY.
+  wsbTickers:        { key: 'seed-meta:intelligence:wsb-tickers',      maxStaleMin: 540 }, // relay loop every 180min (3h); 540 = 3x interval. Co-pinned with WSB_TICKERS_TTL=43200 (ais-relay.cjs); TTL strictly > maxStaleMin (see socialVelocity note).
   pizzint:           { key: 'seed-meta:intelligence:pizzint',          maxStaleMin: 30 }, // relay loop every 10min; 30 = 3x interval
   productCatalog:    { key: 'seed-meta:product-catalog',               maxStaleMin: 1080 }, // relay loop every 6h; 1080 = 18h = 3x interval
   vpdTrackerRealtime:   { key: 'seed-meta:health:vpd-tracker',         maxStaleMin: 2880 }, // daily seed (0 2 * * *); 2880min = 48h = 2x interval

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -77,8 +77,8 @@ const SEED_DOMAINS = {
   'intelligence:gdelt-intel': { key: 'seed-meta:intelligence:gdelt-intel', intervalMin: 210 }, // 420min maxStaleMin / 2 — aligned with health.js (6h cron + 1h grace)
   'correlation:cards':        { key: 'seed-meta:correlation:cards',        intervalMin: 5 },
   'intelligence:advisories':  { key: 'seed-meta:intelligence:advisories',  intervalMin: 60 },
-  'intelligence:social-reddit': { key: 'seed-meta:intelligence:social-reddit', intervalMin: 90 }, // 60min relay loop (hourly, bumped from 10min to reduce Reddit IP blocking); intervalMin = maxStaleMin / 2 (180 / 2)
-  'intelligence:wsb-tickers': { key: 'seed-meta:intelligence:wsb-tickers', intervalMin: 90 }, // 60min relay loop (hourly, bumped from 10min); intervalMin = maxStaleMin / 2 (180 / 2)
+  'intelligence:social-reddit': { key: 'seed-meta:intelligence:social-reddit', intervalMin: 270 }, // 180min relay loop (3h; dropped from 60min now that ScrapeCreators handles Reddit); intervalMin = maxStaleMin / 2 (540 / 2), matching api/health.js
+  'intelligence:wsb-tickers': { key: 'seed-meta:intelligence:wsb-tickers', intervalMin: 270 }, // 180min relay loop (3h); intervalMin = maxStaleMin / 2 (540 / 2), matching api/health.js
   'trade:customs-revenue':    { key: 'seed-meta:trade:customs-revenue',    intervalMin: 720 },
   'thermal:escalation':       { key: 'seed-meta:thermal:escalation',       intervalMin: 180 },
   'radiation:observations':   { key: 'seed-meta:radiation:observations',   intervalMin: 15 },

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -5747,6 +5747,170 @@ async function startShippingStressSeedLoop() {
 }
 
 // ─────────────────────────────────────────────────────────────
+// Reddit data fetch (shared across social-velocity + WSB tickers)
+// ─────────────────────────────────────────────────────────────
+// Reddit's Responsible Builder Policy (2026) serves an HTML 403 to the
+// unauthenticated www.reddit.com/r/<sub>/hot.json endpoint regardless of exit
+// IP or User-Agent (verified 2026-06-05: residential IP, Decodo residential
+// proxy, browser UA, and WM UA ALL 403 with the same HTML block page — it is a
+// policy block on the endpoint, NOT an IP/UA block, so a proxy does not help)
+// AND removed self-serve API-app creation, so a NEW OAuth app cannot be made.
+// Both Reddit consumers route through fetchRedditHotListing(); see its own
+// comment for the ScrapeCreators → OAuth → public path precedence. OAuth (usable
+// only with pre-policy app creds) and the public endpoint are kept as fallbacks
+// (the public path is today's no-cred default that surfaces SEED_ERROR — no
+// regression when no key is set).
+const REDDIT_CLIENT_ID = process.env.REDDIT_CLIENT_ID || '';
+const REDDIT_CLIENT_SECRET = process.env.REDDIT_CLIENT_SECRET || '';
+const REDDIT_OAUTH_ENABLED = !!(REDDIT_CLIENT_ID && REDDIT_CLIENT_SECRET);
+// Reddit requires a unique, descriptive UA: "<platform>:<appid>:<version> (by
+// /u/<username>)". Set REDDIT_USER_AGENT to include the developer's reddit
+// username so requests are attributable per Reddit's API rules.
+const REDDIT_USER_AGENT = process.env.REDDIT_USER_AGENT || 'server:app.worldmonitor:1.0 (by /u/worldmonitor)';
+const REDDIT_AUTH_COOLDOWN_MS = 5 * 60 * 1000;
+
+// ScrapeCreators — third-party Reddit data vendor (same key /last30days uses).
+// PREFERRED path: it's the only one that works now that Reddit 403s the public
+// .json endpoint AND removed self-serve API-app creation (Responsible Builder
+// Policy 2026). Returns native Reddit fields in a flat `posts` array, so the
+// downstream consumers are unchanged. When unset, the relay falls back to OAuth
+// (pre-policy creds only) then the public endpoint — today's behavior, no regression.
+const SCRAPECREATORS_API_KEY = process.env.SCRAPECREATORS_API_KEY || '';
+const SCRAPECREATORS_ENABLED = !!SCRAPECREATORS_API_KEY;
+
+let _redditToken = null;
+let _redditTokenExpiry = 0;
+let _redditTokenPromise = null;
+let _redditAuthCooldownUntil = 0;
+
+async function _fetchRedditToken() {
+  const basic = Buffer.from(`${REDDIT_CLIENT_ID}:${REDDIT_CLIENT_SECRET}`).toString('base64');
+  const resp = await fetch('https://www.reddit.com/api/v1/access_token', {
+    method: 'POST',
+    headers: {
+      Authorization: `Basic ${basic}`,
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'User-Agent': REDDIT_USER_AGENT,
+    },
+    body: 'grant_type=client_credentials',
+    signal: AbortSignal.timeout(10000),
+  });
+  if (!resp.ok) throw new Error(`token HTTP ${resp.status}`);
+  const json = await resp.json();
+  if (!json.access_token) throw new Error(`no access_token (${json.error || 'unknown'})`);
+  return { token: json.access_token, expiresIn: Number(json.expires_in) || 3600 };
+}
+
+// Returns a cached userless bearer token, or null when auth is unavailable.
+// Single-flight (concurrent callers share one in-flight fetch) with a 5-min
+// cooldown after a failure so a broken credential doesn't hammer the auth
+// endpoint every seed cycle.
+async function getRedditToken() {
+  const now = Date.now();
+  if (_redditToken && now < _redditTokenExpiry) return _redditToken;
+  if (now < _redditAuthCooldownUntil) return null;
+  if (_redditTokenPromise) return _redditTokenPromise;
+  _redditTokenPromise = (async () => {
+    try {
+      const { token, expiresIn } = await _fetchRedditToken();
+      _redditToken = token;
+      _redditTokenExpiry = Date.now() + Math.max(60, expiresIn - 60) * 1000; // refresh 60s early
+      console.log(`[Reddit] OAuth token acquired, expires in ${expiresIn}s`);
+      return token;
+    } catch (e) {
+      _redditToken = null;
+      _redditTokenExpiry = 0;
+      _redditAuthCooldownUntil = Date.now() + REDDIT_AUTH_COOLDOWN_MS;
+      console.warn(`[Reddit] OAuth token fetch failed: ${e?.message || e} — cooldown ${REDDIT_AUTH_COOLDOWN_MS / 1000}s`);
+      return null;
+    } finally {
+      _redditTokenPromise = null;
+    }
+  })();
+  return _redditTokenPromise;
+}
+
+// Coerce a Reddit timestamp to epoch SECONDS. Native Reddit (and the Reddit
+// hosts with raw_json=1) return numeric seconds (~1.7e9); a vendor could hand
+// back milliseconds (~1.7e12) or an ISO string. The downstream velocity math
+// (ageSec = now/1000 - created_utc) and createdAt (created_utc * 1000) both
+// assume seconds, so normalize before the consumers see it.
+function _redditEpochSeconds(v) {
+  if (typeof v === 'number') return v > 1e12 ? Math.floor(v / 1000) : v;
+  if (typeof v === 'string') {
+    const n = Number(v);
+    if (Number.isFinite(n)) return n > 1e12 ? Math.floor(n / 1000) : n;
+    const ms = Date.parse(v);
+    return Number.isFinite(ms) ? Math.floor(ms / 1000) : undefined;
+  }
+  return v;
+}
+
+// The Reddit hosts pass raw_json=1, which un-escapes &amp; &lt; &gt; in text
+// fields. A vendor response may still be HTML-escaped, so decode the few entities
+// Reddit emits to keep panel titles identical across paths.
+function _decodeRedditEntities(s) {
+  if (typeof s !== 'string') return s;
+  return s.replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"').replace(/&#39;/g, "'");
+}
+
+// Normalize a ScrapeCreators post so its shape matches the OAuth/public paths
+// exactly (numeric-seconds created_utc, unescaped title/selftext). Other native
+// fields (score, upvote_ratio, num_comments, id, permalink, url) pass through.
+function _normalizeVendorPost(p) {
+  if (!p || typeof p !== 'object') return p;
+  return { ...p, created_utc: _redditEpochSeconds(p.created_utc), title: _decodeRedditEntities(p.title), selftext: _decodeRedditEntities(p.selftext) };
+}
+
+// Shared "hot" listing fetch for every Reddit consumer. Returns
+// { ok, status, posts, source } and never throws on an HTTP status (network/
+// timeout errors still bubble to the caller's try/catch). `source` names the
+// path that actually ran ('scrapecreators' | 'oauth' | 'public') so the caller's
+// SEED_ERROR reason is accurate. Path precedence:
+//   1. ScrapeCreators (vendor) when SCRAPECREATORS_API_KEY is set — preferred.
+//   2. oauth.reddit.com when REDDIT_CLIENT_ID/SECRET are set (pre-policy app creds).
+//   3. public www.reddit.com/.../hot.json (currently 403-walled; correct no-cred default).
+// All paths yield the same per-post native field names (score, upvote_ratio,
+// num_comments, created_utc, id, title, permalink, url), so downstream consumers
+// are unchanged. ScrapeCreators returns a flat `posts` array (normalized via
+// _normalizeVendorPost); the Reddit hosts return data.children[].data.
+async function fetchRedditHotListing(subreddit, { limit = 25, legacyUserAgent } = {}) {
+  // 1. ScrapeCreators (preferred) — flat { posts, after } with native Reddit fields.
+  if (SCRAPECREATORS_ENABLED) {
+    const scUrl = `https://api.scrapecreators.com/v1/reddit/subreddit?subreddit=${encodeURIComponent(subreddit)}&sort=hot`;
+    const resp = await fetch(scUrl, {
+      headers: { 'x-api-key': SCRAPECREATORS_API_KEY, Accept: 'application/json' },
+      signal: AbortSignal.timeout(10000),
+    });
+    if (!resp.ok) return { ok: false, status: resp.status, posts: [], source: 'scrapecreators' };
+    const data = await resp.json();
+    const posts = (Array.isArray(data?.posts) ? data.posts : []).filter(Boolean).slice(0, limit).map(_normalizeVendorPost);
+    return { ok: true, status: resp.status, posts, source: 'scrapecreators' };
+  }
+  let url;
+  let headers;
+  let source;
+  if (REDDIT_OAUTH_ENABLED) {
+    const token = await getRedditToken();
+    if (token) {
+      url = `https://oauth.reddit.com/r/${subreddit}/hot?limit=${limit}&raw_json=1`;
+      headers = { Authorization: `Bearer ${token}`, 'User-Agent': REDDIT_USER_AGENT, Accept: 'application/json' };
+      source = 'oauth';
+    }
+  }
+  if (!url) {
+    url = `https://www.reddit.com/r/${subreddit}/hot.json?limit=${limit}&raw_json=1`;
+    headers = { Accept: 'application/json', 'User-Agent': legacyUserAgent || REDDIT_USER_AGENT };
+    source = 'public';
+  }
+  const resp = await fetch(url, { headers, signal: AbortSignal.timeout(10000) });
+  if (!resp.ok) return { ok: false, status: resp.status, posts: [], source };
+  const data = await resp.json();
+  return { ok: true, status: resp.status, posts: (data?.data?.children || []).map(c => c.data).filter(Boolean), source };
+}
+
+// ─────────────────────────────────────────────────────────────
 // Social Velocity — Reddit r/worldnews + r/geopolitics trending
 // ─────────────────────────────────────────────────────────────
 
@@ -5756,8 +5920,8 @@ const SOCIAL_VELOCITY_SEED_META_KEY = 'seed-meta:intelligence:social-reddit';
 // after ~50min of 10-min polling (empirically observed 2026-04-16: both subs
 // returned HTTP 403 on every cycle after 16:26 UTC). Dropping the success-path
 // frequency to 1/hour reduces the traffic Reddit's behavioral heuristic flags on.
-const SOCIAL_VELOCITY_TTL = 10800; // 3h — 3× the 60min interval
-const SOCIAL_VELOCITY_INTERVAL_MS = 60 * 60 * 1000;
+const SOCIAL_VELOCITY_TTL = 32400; // 9h — co-pinned ≥ health maxStaleMin=540 (api/health.js) so the data key never expires before STALE_SEED fires (avoids the EMPTY-vs-STALE_SEED gap); ~3× the 3h interval
+const SOCIAL_VELOCITY_INTERVAL_MS = 3 * 60 * 60 * 1000; // 3h — velocity decays over ~6h; hourly was a Reddit-rate-limit leftover, not a freshness need
 const REDDIT_SUBREDDITS = ['worldnews', 'geopolitics'];
 
 let socialVelocityInFlight = false;
@@ -5797,19 +5961,17 @@ async function writeSocialVelocityHealthyMeta(recordCount) {
 }
 
 async function fetchRedditHot(subreddit, failures = []) {
-  const url = `https://www.reddit.com/r/${subreddit}/hot.json?limit=25&raw_json=1`;
-  const resp = await fetch(url, {
-    headers: { Accept: 'application/json', 'User-Agent': 'WorldMonitor/1.0 (contact: info@worldmonitor.app)' },
-    signal: AbortSignal.timeout(10000),
+  const { ok, status, posts, source } = await fetchRedditHotListing(subreddit, {
+    limit: 25,
+    legacyUserAgent: 'WorldMonitor/1.0 (contact: info@worldmonitor.app)',
   });
-  if (!resp.ok) {
-    const failure = `r/${subreddit} HTTP ${resp.status}`;
+  if (!ok) {
+    const failure = `r/${subreddit} HTTP ${status} (${source})`;
     failures.push(failure);
     console.warn(`[SocialVelocity] Reddit ${failure}`);
     return [];
   }
-  const data = await resp.json();
-  return (data?.data?.children || []).map(c => c.data).filter(Boolean);
+  return posts;
 }
 
 async function seedSocialVelocity() {
@@ -5900,8 +6062,8 @@ async function startSocialVelocitySeedLoop() {
 const WSB_TICKERS_REDIS_KEY = 'intelligence:wsb-tickers:v1';
 // Hourly cadence (bumped from 10min). Same Reddit-datacenter-IP blocking
 // rationale as SocialVelocity — see comment above.
-const WSB_TICKERS_TTL = 10800; // 3h — 3× the 60min interval
-const WSB_TICKERS_INTERVAL_MS = 60 * 60 * 1000;
+const WSB_TICKERS_TTL = 32400; // 9h — co-pinned ≥ health maxStaleMin=540 (api/health.js) so the data key never expires before STALE_SEED fires (avoids the EMPTY-vs-STALE_SEED gap); ~3× the 3h interval
+const WSB_TICKERS_INTERVAL_MS = 3 * 60 * 60 * 1000; // 3h — same cadence rationale as SocialVelocity above
 const WSB_TICKERS_RETRY_MS = 20 * 60 * 1000;
 const WSB_SUBREDDITS = ['wallstreetbets', 'stocks', 'investing'];
 
@@ -5937,14 +6099,9 @@ async function loadWsbTickerSet() {
 }
 
 async function fetchWsbRedditHot(subreddit) {
-  const url = `https://www.reddit.com/r/${subreddit}/hot.json?limit=50&raw_json=1`;
-  const resp = await fetch(url, {
-    headers: { Accept: 'application/json', 'User-Agent': CHROME_UA },
-    signal: AbortSignal.timeout(10000),
-  });
-  if (!resp.ok) { console.warn(`[WsbTickers] Reddit r/${subreddit} HTTP ${resp.status}`); return []; }
-  const data = await resp.json();
-  return (data?.data?.children || []).map(c => c.data).filter(Boolean);
+  const { ok, status, posts, source } = await fetchRedditHotListing(subreddit, { limit: 50, legacyUserAgent: CHROME_UA });
+  if (!ok) { console.warn(`[WsbTickers] Reddit r/${subreddit} HTTP ${status} (${source})`); return []; }
+  return posts;
 }
 
 function normalizeTicker(raw) {

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -5877,16 +5877,28 @@ function _normalizeVendorPost(p) {
 // _normalizeVendorPost); the Reddit hosts return data.children[].data.
 async function fetchRedditHotListing(subreddit, { limit = 25, legacyUserAgent } = {}) {
   // 1. ScrapeCreators (preferred) — flat { posts, after } with native Reddit fields.
+  // On success return immediately. On ANY failure (non-2xx OR network/timeout
+  // throw) log and FALL THROUGH to OAuth → public, honoring the ordered-fallback
+  // contract: SC is preferred but a runtime blip shouldn't skip the other paths
+  // when their creds are configured. `&limit` is sent best-effort (the endpoint
+  // documents `after` pagination, not limit; the .slice below caps regardless).
   if (SCRAPECREATORS_ENABLED) {
-    const scUrl = `https://api.scrapecreators.com/v1/reddit/subreddit?subreddit=${encodeURIComponent(subreddit)}&sort=hot`;
-    const resp = await fetch(scUrl, {
-      headers: { 'x-api-key': SCRAPECREATORS_API_KEY, Accept: 'application/json' },
-      signal: AbortSignal.timeout(10000),
-    });
-    if (!resp.ok) return { ok: false, status: resp.status, posts: [], source: 'scrapecreators' };
-    const data = await resp.json();
-    const posts = (Array.isArray(data?.posts) ? data.posts : []).filter(Boolean).slice(0, limit).map(_normalizeVendorPost);
-    return { ok: true, status: resp.status, posts, source: 'scrapecreators' };
+    const scUrl = `https://api.scrapecreators.com/v1/reddit/subreddit?subreddit=${encodeURIComponent(subreddit)}&sort=hot&limit=${limit}`;
+    try {
+      const resp = await fetch(scUrl, {
+        headers: { 'x-api-key': SCRAPECREATORS_API_KEY, Accept: 'application/json' },
+        signal: AbortSignal.timeout(10000),
+      });
+      if (resp.ok) {
+        const data = await resp.json();
+        const posts = (Array.isArray(data?.posts) ? data.posts : []).filter(Boolean).slice(0, limit).map(_normalizeVendorPost);
+        return { ok: true, status: resp.status, posts, source: 'scrapecreators' };
+      }
+      console.warn(`[Reddit] ScrapeCreators HTTP ${resp.status} for r/${subreddit} — falling back to OAuth/public`);
+    } catch (e) {
+      console.warn(`[Reddit] ScrapeCreators error for r/${subreddit}: ${e?.message || e} — falling back to OAuth/public`);
+    }
+    // fall through to OAuth → public
   }
   let url;
   let headers;

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -5920,7 +5920,7 @@ const SOCIAL_VELOCITY_SEED_META_KEY = 'seed-meta:intelligence:social-reddit';
 // after ~50min of 10-min polling (empirically observed 2026-04-16: both subs
 // returned HTTP 403 on every cycle after 16:26 UTC). Dropping the success-path
 // frequency to 1/hour reduces the traffic Reddit's behavioral heuristic flags on.
-const SOCIAL_VELOCITY_TTL = 32400; // 9h — co-pinned ≥ health maxStaleMin=540 (api/health.js) so the data key never expires before STALE_SEED fires (avoids the EMPTY-vs-STALE_SEED gap); ~3× the 3h interval
+const SOCIAL_VELOCITY_TTL = 43200; // 12h — STRICTLY > health maxStaleMin=540min (9h) so a dead relay surfaces STALE_SEED (warn) for the 9h–12h window while the key is still present, BEFORE it expires and escalates to EMPTY (crit). TTL==maxStaleMin would skip STALE_SEED entirely: classifyKey checks !hasData before seedStale (api/health.js). On failure cycles the relay re-extends this TTL (upstashExpire below), so a live-but-failing relay keeps last-good present.
 const SOCIAL_VELOCITY_INTERVAL_MS = 3 * 60 * 60 * 1000; // 3h — velocity decays over ~6h; hourly was a Reddit-rate-limit leftover, not a freshness need
 const REDDIT_SUBREDDITS = ['worldnews', 'geopolitics'];
 
@@ -6062,7 +6062,7 @@ async function startSocialVelocitySeedLoop() {
 const WSB_TICKERS_REDIS_KEY = 'intelligence:wsb-tickers:v1';
 // Hourly cadence (bumped from 10min). Same Reddit-datacenter-IP blocking
 // rationale as SocialVelocity — see comment above.
-const WSB_TICKERS_TTL = 32400; // 9h — co-pinned ≥ health maxStaleMin=540 (api/health.js) so the data key never expires before STALE_SEED fires (avoids the EMPTY-vs-STALE_SEED gap); ~3× the 3h interval
+const WSB_TICKERS_TTL = 43200; // 12h — STRICTLY > health maxStaleMin=540min (9h) so a dead relay surfaces STALE_SEED before the key expires to EMPTY (see SOCIAL_VELOCITY_TTL note); re-extended on failure cycles via upstashExpire below.
 const WSB_TICKERS_INTERVAL_MS = 3 * 60 * 60 * 1000; // 3h — same cadence rationale as SocialVelocity above
 const WSB_TICKERS_RETRY_MS = 20 * 60 * 1000;
 const WSB_SUBREDDITS = ['wallstreetbets', 'stocks', 'investing'];

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -5884,30 +5884,30 @@ async function fetchRedditHotListing(subreddit, { limit = 25, legacyUserAgent } 
   // NO `limit` param) until we reach `limit` posts or run out of pages, capped at
   // SC_MAX_PAGES to bound credit spend — this preserves the old limit:50 coverage
   // for WSB even if the vendor's first page is smaller. Failure handling honors the
-  // ordered-fallback contract: a page-1 HTTP failure (non-2xx) OR any network/
-  // timeout throw logs and FALLS THROUGH to OAuth → public; a failure AFTER page 1
-  // keeps the pages already gathered. The loop degrades to first-page-only if the
-  // vendor ever omits the `after` cursor.
+  // ordered-fallback contract: a page-1 HTTP failure (non-2xx) OR page-1 network/
+  // timeout/parse throw logs and FALLS THROUGH to OAuth → public; a failure AFTER
+  // page 1 keeps the pages already gathered. The loop degrades to first-page-only
+  // if the vendor ever omits the `after` cursor.
   if (SCRAPECREATORS_ENABLED) {
+    const collected = [];
+    let after = '';
+    let anyOk = false;
+    let lastOkStatus = 0;
     try {
-      const collected = [];
-      let after = '';
-      let anyOk = false;
-      let lastStatus = 0;
       for (let page = 0; page < SC_MAX_PAGES && collected.length < limit; page++) {
         const scUrl = `https://api.scrapecreators.com/v1/reddit/subreddit?subreddit=${encodeURIComponent(subreddit)}&sort=hot${after ? `&after=${encodeURIComponent(after)}` : ''}`;
         const resp = await fetch(scUrl, {
           headers: { 'x-api-key': SCRAPECREATORS_API_KEY, Accept: 'application/json' },
           signal: AbortSignal.timeout(10000),
         });
-        lastStatus = resp.status;
         if (!resp.ok) {
           if (collected.length > 0) break; // keep what we already paginated
           console.warn(`[Reddit] ScrapeCreators HTTP ${resp.status} for r/${subreddit} — falling back to OAuth/public`);
           break; // page-1 failure → fall through below
         }
-        anyOk = true;
         const data = await resp.json();
+        anyOk = true;
+        lastOkStatus = resp.status;
         const pagePosts = (Array.isArray(data?.posts) ? data.posts : []).filter(Boolean);
         collected.push(...pagePosts);
         after = typeof data?.after === 'string' ? data.after : '';
@@ -5916,9 +5916,13 @@ async function fetchRedditHotListing(subreddit, { limit = 25, legacyUserAgent } 
       // anyOk distinguishes "vendor responded (even with 0 posts)" from "page-1
       // failed" — only the latter falls through; a legit empty SC response returns ok.
       if (anyOk) {
-        return { ok: true, status: lastStatus, posts: collected.slice(0, limit).map(_normalizeVendorPost), source: 'scrapecreators' };
+        return { ok: true, status: lastOkStatus, posts: collected.slice(0, limit).map(_normalizeVendorPost), source: 'scrapecreators' };
       }
     } catch (e) {
+      if (anyOk) {
+        console.warn(`[Reddit] ScrapeCreators error after ${collected.length} posts for r/${subreddit}: ${e?.message || e} — using partial ScrapeCreators data`);
+        return { ok: true, status: lastOkStatus, posts: collected.slice(0, limit).map(_normalizeVendorPost), source: 'scrapecreators' };
+      }
       console.warn(`[Reddit] ScrapeCreators error for r/${subreddit}: ${e?.message || e} — falling back to OAuth/public`);
     }
     // fall through to OAuth → public

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -5777,6 +5777,10 @@ const REDDIT_AUTH_COOLDOWN_MS = 5 * 60 * 1000;
 // (pre-policy creds only) then the public endpoint — today's behavior, no regression.
 const SCRAPECREATORS_API_KEY = process.env.SCRAPECREATORS_API_KEY || '';
 const SCRAPECREATORS_ENABLED = !!SCRAPECREATORS_API_KEY;
+// The SC subreddit endpoint has no `limit` param — only `after` cursor pagination.
+// Cap the page walk so a caller asking for `limit` posts can't run away on credits
+// (≈25 posts/page → 4 pages covers WSB's limit:50 with headroom).
+const SC_MAX_PAGES = 4;
 
 let _redditToken = null;
 let _redditTokenExpiry = 0;
@@ -5876,25 +5880,44 @@ function _normalizeVendorPost(p) {
 // are unchanged. ScrapeCreators returns a flat `posts` array (normalized via
 // _normalizeVendorPost); the Reddit hosts return data.children[].data.
 async function fetchRedditHotListing(subreddit, { limit = 25, legacyUserAgent } = {}) {
-  // 1. ScrapeCreators (preferred) — flat { posts, after } with native Reddit fields.
-  // On success return immediately. On ANY failure (non-2xx OR network/timeout
-  // throw) log and FALL THROUGH to OAuth → public, honoring the ordered-fallback
-  // contract: SC is preferred but a runtime blip shouldn't skip the other paths
-  // when their creds are configured. `&limit` is sent best-effort (the endpoint
-  // documents `after` pagination, not limit; the .slice below caps regardless).
+  // 1. ScrapeCreators (preferred). Cursor-paginate with `after` (the endpoint has
+  // NO `limit` param) until we reach `limit` posts or run out of pages, capped at
+  // SC_MAX_PAGES to bound credit spend — this preserves the old limit:50 coverage
+  // for WSB even if the vendor's first page is smaller. Failure handling honors the
+  // ordered-fallback contract: a page-1 HTTP failure (non-2xx) OR any network/
+  // timeout throw logs and FALLS THROUGH to OAuth → public; a failure AFTER page 1
+  // keeps the pages already gathered. The loop degrades to first-page-only if the
+  // vendor ever omits the `after` cursor.
   if (SCRAPECREATORS_ENABLED) {
-    const scUrl = `https://api.scrapecreators.com/v1/reddit/subreddit?subreddit=${encodeURIComponent(subreddit)}&sort=hot&limit=${limit}`;
     try {
-      const resp = await fetch(scUrl, {
-        headers: { 'x-api-key': SCRAPECREATORS_API_KEY, Accept: 'application/json' },
-        signal: AbortSignal.timeout(10000),
-      });
-      if (resp.ok) {
+      const collected = [];
+      let after = '';
+      let anyOk = false;
+      let lastStatus = 0;
+      for (let page = 0; page < SC_MAX_PAGES && collected.length < limit; page++) {
+        const scUrl = `https://api.scrapecreators.com/v1/reddit/subreddit?subreddit=${encodeURIComponent(subreddit)}&sort=hot${after ? `&after=${encodeURIComponent(after)}` : ''}`;
+        const resp = await fetch(scUrl, {
+          headers: { 'x-api-key': SCRAPECREATORS_API_KEY, Accept: 'application/json' },
+          signal: AbortSignal.timeout(10000),
+        });
+        lastStatus = resp.status;
+        if (!resp.ok) {
+          if (collected.length > 0) break; // keep what we already paginated
+          console.warn(`[Reddit] ScrapeCreators HTTP ${resp.status} for r/${subreddit} — falling back to OAuth/public`);
+          break; // page-1 failure → fall through below
+        }
+        anyOk = true;
         const data = await resp.json();
-        const posts = (Array.isArray(data?.posts) ? data.posts : []).filter(Boolean).slice(0, limit).map(_normalizeVendorPost);
-        return { ok: true, status: resp.status, posts, source: 'scrapecreators' };
+        const pagePosts = (Array.isArray(data?.posts) ? data.posts : []).filter(Boolean);
+        collected.push(...pagePosts);
+        after = typeof data?.after === 'string' ? data.after : '';
+        if (!after || pagePosts.length === 0) break; // no more pages
       }
-      console.warn(`[Reddit] ScrapeCreators HTTP ${resp.status} for r/${subreddit} — falling back to OAuth/public`);
+      // anyOk distinguishes "vendor responded (even with 0 posts)" from "page-1
+      // failed" — only the latter falls through; a legit empty SC response returns ok.
+      if (anyOk) {
+        return { ok: true, status: lastStatus, posts: collected.slice(0, limit).map(_normalizeVendorPost), source: 'scrapecreators' };
+      }
     } catch (e) {
       console.warn(`[Reddit] ScrapeCreators error for r/${subreddit}: ${e?.message || e} — falling back to OAuth/public`);
     }
@@ -5928,10 +5951,12 @@ async function fetchRedditHotListing(subreddit, { limit = 25, legacyUserAgent } 
 
 const SOCIAL_VELOCITY_REDIS_KEY = 'intelligence:social:reddit:v1';
 const SOCIAL_VELOCITY_SEED_META_KEY = 'seed-meta:intelligence:social-reddit';
-// Hourly cadence (bumped from 10min). Reddit rate-limits Railway datacenter IPs
-// after ~50min of 10-min polling (empirically observed 2026-04-16: both subs
-// returned HTTP 403 on every cycle after 16:26 UTC). Dropping the success-path
-// frequency to 1/hour reduces the traffic Reddit's behavioral heuristic flags on.
+// 3h cadence (was hourly, originally 10min). History: Reddit rate-limited the
+// Railway datacenter IP under fast polling (2026-04-16: both subs 403 every cycle
+// after ~50min of 10-min polling), which forced hourly. Now that fetches go via
+// ScrapeCreators (not Reddit directly) the IP-rate-limit driver is gone, so the
+// interval is set purely by freshness need: velocity decays over ~6h, so 3h is
+// ample. See SOCIAL_VELOCITY_INTERVAL_MS / _TTL below.
 const SOCIAL_VELOCITY_TTL = 43200; // 12h — STRICTLY > health maxStaleMin=540min (9h) so a dead relay surfaces STALE_SEED (warn) for the 9h–12h window while the key is still present, BEFORE it expires and escalates to EMPTY (crit). TTL==maxStaleMin would skip STALE_SEED entirely: classifyKey checks !hasData before seedStale (api/health.js). On failure cycles the relay re-extends this TTL (upstashExpire below), so a live-but-failing relay keeps last-good present.
 const SOCIAL_VELOCITY_INTERVAL_MS = 3 * 60 * 60 * 1000; // 3h — velocity decays over ~6h; hourly was a Reddit-rate-limit leftover, not a freshness need
 const REDDIT_SUBREDDITS = ['worldnews', 'geopolitics'];
@@ -6072,8 +6097,7 @@ async function startSocialVelocitySeedLoop() {
 // ─────────────────────────────────────────────────────────────
 
 const WSB_TICKERS_REDIS_KEY = 'intelligence:wsb-tickers:v1';
-// Hourly cadence (bumped from 10min). Same Reddit-datacenter-IP blocking
-// rationale as SocialVelocity — see comment above.
+// 3h cadence — same history + ScrapeCreators rationale as SocialVelocity above.
 const WSB_TICKERS_TTL = 43200; // 12h — STRICTLY > health maxStaleMin=540min (9h) so a dead relay surfaces STALE_SEED before the key expires to EMPTY (see SOCIAL_VELOCITY_TTL note); re-extended on failure cycles via upstashExpire below.
 const WSB_TICKERS_INTERVAL_MS = 3 * 60 * 60 * 1000; // 3h — same cadence rationale as SocialVelocity above
 const WSB_TICKERS_RETRY_MS = 20 * 60 * 1000;

--- a/server/worldmonitor/resilience/v1/_standalone-source-thresholds.ts
+++ b/server/worldmonitor/resilience/v1/_standalone-source-thresholds.ts
@@ -29,7 +29,7 @@ export const STANDALONE_SOURCE_META_MAX_STALE_MIN: Readonly<Record<string, numbe
   'seed-meta:displacement:summary': 720,
   'seed-meta:unrest:events': 120,
   'seed-meta:conflict:ucdp-events': 420,
-  'seed-meta:intelligence:social-reddit': 540,
+  'seed-meta:intelligence:social-reddit': 540, // mirrors api/health.js maxStaleMin (3h relay cadence × 3). NOTE: the sibling seed-meta:intelligence:wsb-tickers is intentionally NOT here — WSB tickers is a finance signal, not a resilience (CRI) source, so it has no standalone-source entry despite sharing the same relay + health budget.
   'seed-meta:news:threat-summary': 60,
   'seed-meta:resilience:recovery:fiscal-space': 129600,
   'seed-meta:resilience:recovery:reserve-adequacy': 86400,

--- a/server/worldmonitor/resilience/v1/_standalone-source-thresholds.ts
+++ b/server/worldmonitor/resilience/v1/_standalone-source-thresholds.ts
@@ -29,7 +29,7 @@ export const STANDALONE_SOURCE_META_MAX_STALE_MIN: Readonly<Record<string, numbe
   'seed-meta:displacement:summary': 720,
   'seed-meta:unrest:events': 120,
   'seed-meta:conflict:ucdp-events': 420,
-  'seed-meta:intelligence:social-reddit': 180,
+  'seed-meta:intelligence:social-reddit': 540,
   'seed-meta:news:threat-summary': 60,
   'seed-meta:resilience:recovery:fiscal-space': 129600,
   'seed-meta:resilience:recovery:reserve-adequacy': 86400,

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -118,9 +118,12 @@ test('classifyKey: socialVelocity/wsbTickers tolerate the 3h cadence — fresh a
   }
 });
 
-test('classifyKey: socialVelocity/wsbTickers still alarm if the relay stops — stale at 600min → STALE_SEED', () => {
-  // The raised maxStaleMin (540) must not mask a genuine relay outage: 600min (>540)
-  // still degrades to STALE_SEED (warn).
+test('classifyKey: dead relay, data still present (9h–12h window) → STALE_SEED (warn)', () => {
+  // A dead relay stops refreshing seed-meta, but the data key lives for its full
+  // 12h TTL (> maxStaleMin=540min/9h), so 540–720min is a real present-but-stale
+  // window → STALE_SEED. This is reachable in production ONLY because the data-key
+  // TTL (43200s) STRICTLY exceeds maxStaleMin; at TTL==maxStaleMin the key would
+  // expire exactly when staleness begins and classifyKey would emit EMPTY instead.
   for (const [name, metaKey] of [
     ['socialVelocity', 'seed-meta:intelligence:social-reddit'],
     ['wsbTickers', 'seed-meta:intelligence:wsb-tickers'],
@@ -130,8 +133,28 @@ test('classifyKey: socialVelocity/wsbTickers still alarm if the relay stops — 
         strens: { [BOOTSTRAP_KEYS[name]]: 4096 },
         metaValues: { [metaKey]: seedMeta({ fetchedAt: NOW - 600 * ONE_MIN_MS }) },
       }));
-    assert.equal(entry.status, 'STALE_SEED', `${name} at 600min should be STALE_SEED`);
+    assert.equal(entry.status, 'STALE_SEED', `${name} at 600min (data present) should be STALE_SEED`);
     assert.equal(STATUS_COUNTS[entry.status], 'warn');
+  }
+});
+
+test('classifyKey: dead relay past the 12h TTL, data key expired → EMPTY (crit) escalation', () => {
+  // Once the data key expires (after the 12h TTL on a fully-dead relay),
+  // hasData=false → classifyKey hits the !hasData branch (checked BEFORE seedStale,
+  // api/health.js) and returns EMPTY (crit), escalating from the earlier STALE_SEED
+  // warn. Verified shape: { status: 'EMPTY', records: 0 }.
+  for (const [name, metaKey] of [
+    ['socialVelocity', 'seed-meta:intelligence:social-reddit'],
+    ['wsbTickers', 'seed-meta:intelligence:wsb-tickers'],
+  ]) {
+    const entry = classifyKey(name, BOOTSTRAP_KEYS[name], { allowOnDemand: false },
+      makeCtx({
+        // no strens entry → data key absent (expired)
+        metaValues: { [metaKey]: seedMeta({ fetchedAt: NOW - 800 * ONE_MIN_MS }) },
+      }));
+    assert.equal(entry.status, 'EMPTY', `${name} with expired data should be EMPTY`);
+    assert.equal(STATUS_COUNTS[entry.status], 'crit');
+    assert.equal(entry.records, 0);
   }
 });
 

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -102,6 +102,39 @@ test('classifyKey: socialVelocity error seed-meta → SEED_ERROR while data is p
   assert.equal(entry.records, 1);
 });
 
+test('classifyKey: socialVelocity/wsbTickers tolerate the 3h cadence — fresh at 300min → OK', () => {
+  // Cadence dropped 1h→3h (ScrapeCreators), so maxStaleMin was raised 180→540.
+  // A healthy seed-meta aged 300min (5h, inside 540) must NOT false-alarm.
+  for (const [name, metaKey] of [
+    ['socialVelocity', 'seed-meta:intelligence:social-reddit'],
+    ['wsbTickers', 'seed-meta:intelligence:wsb-tickers'],
+  ]) {
+    const entry = classifyKey(name, BOOTSTRAP_KEYS[name], { allowOnDemand: false },
+      makeCtx({
+        strens: { [BOOTSTRAP_KEYS[name]]: 4096 },
+        metaValues: { [metaKey]: seedMeta({ fetchedAt: NOW - 300 * ONE_MIN_MS }) },
+      }));
+    assert.equal(entry.status, 'OK', `${name} at 300min should be OK`);
+  }
+});
+
+test('classifyKey: socialVelocity/wsbTickers still alarm if the relay stops — stale at 600min → STALE_SEED', () => {
+  // The raised maxStaleMin (540) must not mask a genuine relay outage: 600min (>540)
+  // still degrades to STALE_SEED (warn).
+  for (const [name, metaKey] of [
+    ['socialVelocity', 'seed-meta:intelligence:social-reddit'],
+    ['wsbTickers', 'seed-meta:intelligence:wsb-tickers'],
+  ]) {
+    const entry = classifyKey(name, BOOTSTRAP_KEYS[name], { allowOnDemand: false },
+      makeCtx({
+        strens: { [BOOTSTRAP_KEYS[name]]: 4096 },
+        metaValues: { [metaKey]: seedMeta({ fetchedAt: NOW - 600 * ONE_MIN_MS }) },
+      }));
+    assert.equal(entry.status, 'STALE_SEED', `${name} at 600min should be STALE_SEED`);
+    assert.equal(STATUS_COUNTS[entry.status], 'warn');
+  }
+});
+
 test('classifyKey: empty bootstrap key (no cascade) → EMPTY (crit)', () => {
   const entry = classifyKey('earthquakes', BOOTSTRAP_KEYS.earthquakes, { allowOnDemand: false },
     makeCtx({ metaValues: { 'seed-meta:seismology:earthquakes': seedMeta() } }));

--- a/tests/reddit-oauth-fetch.test.mjs
+++ b/tests/reddit-oauth-fetch.test.mjs
@@ -48,7 +48,7 @@ test('token is cached single-flight with early refresh and a post-failure cooldo
 });
 
 test('shared helper prefers oauth.reddit.com and falls back to the public endpoint', () => {
-  const body = fnBody('async function fetchRedditHotListing(subreddit', 2600);
+  const body = fnBody('async function fetchRedditHotListing(subreddit', 2900);
   assert.match(body, /if \(REDDIT_OAUTH_ENABLED\) \{/);
   assert.match(body, /https:\/\/oauth\.reddit\.com\/r\/\$\{subreddit\}\/hot\?limit=\$\{limit\}/);
   assert.match(body, /https:\/\/www\.reddit\.com\/r\/\$\{subreddit\}\/hot\.json\?limit=\$\{limit\}/);
@@ -59,19 +59,33 @@ test('shared helper prefers oauth.reddit.com and falls back to the public endpoi
 test('ScrapeCreators is gated on the api key and is the preferred path', () => {
   assert.match(relaySource, /const SCRAPECREATORS_API_KEY = process\.env\.SCRAPECREATORS_API_KEY \|\| ''/);
   assert.match(relaySource, /const SCRAPECREATORS_ENABLED = !!SCRAPECREATORS_API_KEY/);
-  const body = fnBody('async function fetchRedditHotListing(subreddit', 2600);
-  // vendor branch: subreddit posts endpoint, sort=hot, x-api-key header, returns data.posts
+  const body = fnBody('async function fetchRedditHotListing(subreddit', 2900);
+  // vendor branch: subreddit posts endpoint, sort=hot, passes limit, x-api-key header
   assert.match(body, /if \(SCRAPECREATORS_ENABLED\) \{/);
-  assert.match(body, /https:\/\/api\.scrapecreators\.com\/v1\/reddit\/subreddit\?subreddit=\$\{encodeURIComponent\(subreddit\)\}&sort=hot/);
+  assert.match(body, /https:\/\/api\.scrapecreators\.com\/v1\/reddit\/subreddit\?subreddit=\$\{encodeURIComponent\(subreddit\)\}&sort=hot&limit=\$\{limit\}/);
   assert.match(body, /'x-api-key': SCRAPECREATORS_API_KEY/);
   // array-guarded, capped to limit, and normalized to match the OAuth/public shape
   assert.match(body, /\(Array\.isArray\(data\?\.posts\) \? data\.posts : \[\]\)\.filter\(Boolean\)\.slice\(0, limit\)\.map\(_normalizeVendorPost\)/);
-  // error contract preserved, tagged with its source
-  assert.match(body, /if \(!resp\.ok\) return \{ ok: false, status: resp\.status, posts: \[\], source: 'scrapecreators' \}/);
+  // success returns immediately, tagged with its source
+  assert.match(body, /return \{ ok: true, status: resp\.status, posts, source: 'scrapecreators' \}/);
+});
+
+test('ScrapeCreators failure (non-2xx OR throw) falls through to OAuth/public, not an immediate return', () => {
+  const body = fnBody('async function fetchRedditHotListing(subreddit', 2900);
+  // wrapped in try/catch; only resp.ok returns from the SC branch
+  assert.match(body, /try \{/);
+  assert.match(body, /if \(resp\.ok\) \{/);
+  // both failure modes log and fall through (no immediate return)
+  assert.match(body, /ScrapeCreators HTTP \$\{resp\.status\}/);
+  assert.match(body, /catch \(e\) \{/);
+  assert.match(body, /ScrapeCreators error for r\/\$\{subreddit\}/);
+  assert.match(body, /falling back to OAuth\/public/);
+  // a SC failure must NOT short-circuit with {ok:false, source:'scrapecreators'} (that skipped the fallback)
+  assert.doesNotMatch(body, /return \{ ok: false[^}]*source: 'scrapecreators'/);
 });
 
 test('path precedence is ScrapeCreators -> OAuth -> public (ordered in source)', () => {
-  const body = fnBody('async function fetchRedditHotListing(subreddit', 2600);
+  const body = fnBody('async function fetchRedditHotListing(subreddit', 2900);
   const sc = body.indexOf('if (SCRAPECREATORS_ENABLED)');
   const oauth = body.indexOf('if (REDDIT_OAUTH_ENABLED)');
   const pub = body.indexOf('www.reddit.com/r/${subreddit}/hot.json');
@@ -120,7 +134,7 @@ test('both reddit consumers route through fetchRedditHotListing and label failur
 });
 
 test('helper tags each path with a source for accurate SEED_ERROR reasons', () => {
-  const body = fnBody('async function fetchRedditHotListing(subreddit', 2600);
+  const body = fnBody('async function fetchRedditHotListing(subreddit', 2900);
   assert.match(body, /source: 'scrapecreators'/);
   assert.match(body, /source = 'oauth'/);
   assert.match(body, /source = 'public'/);

--- a/tests/reddit-oauth-fetch.test.mjs
+++ b/tests/reddit-oauth-fetch.test.mjs
@@ -48,7 +48,7 @@ test('token is cached single-flight with early refresh and a post-failure cooldo
 });
 
 test('shared helper prefers oauth.reddit.com and falls back to the public endpoint', () => {
-  const body = fnBody('async function fetchRedditHotListing(subreddit', 3600);
+  const body = fnBody('async function fetchRedditHotListing(subreddit', 5200);
   assert.match(body, /if \(REDDIT_OAUTH_ENABLED\) \{/);
   assert.match(body, /https:\/\/oauth\.reddit\.com\/r\/\$\{subreddit\}\/hot\?limit=\$\{limit\}/);
   assert.match(body, /https:\/\/www\.reddit\.com\/r\/\$\{subreddit\}\/hot\.json\?limit=\$\{limit\}/);
@@ -60,7 +60,7 @@ test('ScrapeCreators is the gated, preferred path with bounded cursor pagination
   assert.match(relaySource, /const SCRAPECREATORS_API_KEY = process\.env\.SCRAPECREATORS_API_KEY \|\| ''/);
   assert.match(relaySource, /const SCRAPECREATORS_ENABLED = !!SCRAPECREATORS_API_KEY/);
   assert.match(relaySource, /const SC_MAX_PAGES = 4/);
-  const body = fnBody('async function fetchRedditHotListing(subreddit', 3600);
+  const body = fnBody('async function fetchRedditHotListing(subreddit', 5200);
   assert.match(body, /if \(SCRAPECREATORS_ENABLED\) \{/);
   // subreddit posts endpoint, sort=hot, x-api-key — and NO &limit (endpoint has no such param)
   assert.match(body, /https:\/\/api\.scrapecreators\.com\/v1\/reddit\/subreddit\?subreddit=\$\{encodeURIComponent\(subreddit\)\}&sort=hot/);
@@ -71,25 +71,28 @@ test('ScrapeCreators is the gated, preferred path with bounded cursor pagination
   assert.match(body, /\$\{after \? `&after=\$\{encodeURIComponent\(after\)\}` : ''\}/);
   assert.match(body, /after = typeof data\?\.after === 'string' \? data\.after : ''/);
   // normalized + capped to limit on success, tagged with source
-  assert.match(body, /return \{ ok: true, status: lastStatus, posts: collected\.slice\(0, limit\)\.map\(_normalizeVendorPost\), source: 'scrapecreators' \}/);
+  assert.match(body, /return \{ ok: true, status: lastOkStatus, posts: collected\.slice\(0, limit\)\.map\(_normalizeVendorPost\), source: 'scrapecreators' \}/);
 });
 
 test('ScrapeCreators failure falls through to OAuth/public (page-1 non-2xx OR throw); later-page failure keeps data', () => {
-  const body = fnBody('async function fetchRedditHotListing(subreddit', 3600);
+  const body = fnBody('async function fetchRedditHotListing(subreddit', 5200);
   assert.match(body, /try \{/);
   // a later-page failure keeps the pages already gathered; a page-1 failure logs + falls through
   assert.match(body, /if \(collected\.length > 0\) break;/);
   assert.match(body, /ScrapeCreators HTTP \$\{resp\.status\}/);
   assert.match(body, /catch \(e\) \{/);
+  assert.match(body, /if \(anyOk\) \{/);
+  assert.match(body, /using partial ScrapeCreators data/);
+  assert.match(body, /return \{ ok: true, status: lastOkStatus, posts: collected\.slice\(0, limit\)\.map\(_normalizeVendorPost\), source: 'scrapecreators' \}/);
   assert.match(body, /ScrapeCreators error for r\/\$\{subreddit\}/);
   assert.match(body, /falling back to OAuth\/public/);
-  // only a vendor that actually responded (anyOk) returns from the SC branch; else fall through
-  assert.match(body, /if \(anyOk\) \{/);
+  // only a vendor page that parsed successfully (anyOk) returns from the SC branch; else fall through
   assert.doesNotMatch(body, /return \{ ok: false[^}]*source: 'scrapecreators'/);
+  assert.doesNotMatch(body, /status: lastStatus/);
 });
 
 test('path precedence is ScrapeCreators -> OAuth -> public (ordered in source)', () => {
-  const body = fnBody('async function fetchRedditHotListing(subreddit', 3600);
+  const body = fnBody('async function fetchRedditHotListing(subreddit', 5200);
   const sc = body.indexOf('if (SCRAPECREATORS_ENABLED)');
   const oauth = body.indexOf('if (REDDIT_OAUTH_ENABLED)');
   const pub = body.indexOf('www.reddit.com/r/${subreddit}/hot.json');
@@ -138,7 +141,7 @@ test('both reddit consumers route through fetchRedditHotListing and label failur
 });
 
 test('helper tags each path with a source for accurate SEED_ERROR reasons', () => {
-  const body = fnBody('async function fetchRedditHotListing(subreddit', 3600);
+  const body = fnBody('async function fetchRedditHotListing(subreddit', 5200);
   assert.match(body, /source: 'scrapecreators'/);
   assert.match(body, /source = 'oauth'/);
   assert.match(body, /source = 'public'/);

--- a/tests/reddit-oauth-fetch.test.mjs
+++ b/tests/reddit-oauth-fetch.test.mjs
@@ -1,0 +1,120 @@
+// Reddit OAuth fetch — source-structure regression tests.
+//
+// ais-relay.cjs calls server.listen() at top level (no require.main guard) and
+// has no module.exports, so it cannot be imported for unit execution. Like
+// tests/social-velocity-seed-health.test.mjs, these assert against the source
+// text: that both Reddit consumers route through the shared OAuth-aware helper,
+// the userless client_credentials flow is correct, and the public endpoint
+// remains a graceful fallback when credentials are absent.
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const relaySource = readFileSync(resolve(here, '../scripts/ais-relay.cjs'), 'utf8');
+
+function fnBody(name, approxLen = 1200) {
+  const start = relaySource.indexOf(name);
+  assert.notEqual(start, -1, `missing function: ${name}`);
+  return relaySource.slice(start, start + approxLen);
+}
+
+test('reddit oauth is gated on BOTH client id and secret (absent → fallback, no regression)', () => {
+  assert.match(relaySource, /const REDDIT_CLIENT_ID = process\.env\.REDDIT_CLIENT_ID \|\| ''/);
+  assert.match(relaySource, /const REDDIT_CLIENT_SECRET = process\.env\.REDDIT_CLIENT_SECRET \|\| ''/);
+  assert.match(relaySource, /const REDDIT_OAUTH_ENABLED = !!\(REDDIT_CLIENT_ID && REDDIT_CLIENT_SECRET\)/);
+});
+
+test('token uses userless client_credentials grant with HTTP Basic auth on www.reddit.com', () => {
+  const body = fnBody('async function _fetchRedditToken()');
+  assert.match(body, /https:\/\/www\.reddit\.com\/api\/v1\/access_token/);
+  assert.match(body, /method: 'POST'/);
+  assert.match(body, /Authorization: `Basic \$\{basic\}`/);
+  assert.match(body, /body: 'grant_type=client_credentials'/);
+  // Reddit requires a descriptive, attributable User-Agent.
+  assert.match(relaySource, /const REDDIT_USER_AGENT = process\.env\.REDDIT_USER_AGENT/);
+});
+
+test('token is cached single-flight with early refresh and a post-failure cooldown', () => {
+  const body = fnBody('async function getRedditToken()', 900);
+  assert.match(body, /if \(_redditToken && now < _redditTokenExpiry\) return _redditToken/);
+  assert.match(body, /if \(now < _redditAuthCooldownUntil\) return null/);
+  assert.match(body, /if \(_redditTokenPromise\) return _redditTokenPromise/);
+  assert.match(body, /_redditTokenExpiry = Date\.now\(\) \+ Math\.max\(60, expiresIn - 60\) \* 1000/);
+  assert.match(body, /_redditAuthCooldownUntil = Date\.now\(\) \+ REDDIT_AUTH_COOLDOWN_MS/);
+});
+
+test('shared helper prefers oauth.reddit.com and falls back to the public endpoint', () => {
+  const body = fnBody('async function fetchRedditHotListing(subreddit', 2600);
+  assert.match(body, /if \(REDDIT_OAUTH_ENABLED\) \{/);
+  assert.match(body, /https:\/\/oauth\.reddit\.com\/r\/\$\{subreddit\}\/hot\?limit=\$\{limit\}/);
+  assert.match(body, /https:\/\/www\.reddit\.com\/r\/\$\{subreddit\}\/hot\.json\?limit=\$\{limit\}/);
+  // never throws on HTTP status — returns a typed result (with source) the callers branch on
+  assert.match(body, /if \(!resp\.ok\) return \{ ok: false, status: resp\.status, posts: \[\], source \}/);
+});
+
+test('ScrapeCreators is gated on the api key and is the preferred path', () => {
+  assert.match(relaySource, /const SCRAPECREATORS_API_KEY = process\.env\.SCRAPECREATORS_API_KEY \|\| ''/);
+  assert.match(relaySource, /const SCRAPECREATORS_ENABLED = !!SCRAPECREATORS_API_KEY/);
+  const body = fnBody('async function fetchRedditHotListing(subreddit', 2600);
+  // vendor branch: subreddit posts endpoint, sort=hot, x-api-key header, returns data.posts
+  assert.match(body, /if \(SCRAPECREATORS_ENABLED\) \{/);
+  assert.match(body, /https:\/\/api\.scrapecreators\.com\/v1\/reddit\/subreddit\?subreddit=\$\{encodeURIComponent\(subreddit\)\}&sort=hot/);
+  assert.match(body, /'x-api-key': SCRAPECREATORS_API_KEY/);
+  // array-guarded, capped to limit, and normalized to match the OAuth/public shape
+  assert.match(body, /\(Array\.isArray\(data\?\.posts\) \? data\.posts : \[\]\)\.filter\(Boolean\)\.slice\(0, limit\)\.map\(_normalizeVendorPost\)/);
+  // error contract preserved, tagged with its source
+  assert.match(body, /if \(!resp\.ok\) return \{ ok: false, status: resp\.status, posts: \[\], source: 'scrapecreators' \}/);
+});
+
+test('path precedence is ScrapeCreators -> OAuth -> public (ordered in source)', () => {
+  const body = fnBody('async function fetchRedditHotListing(subreddit', 2600);
+  const sc = body.indexOf('if (SCRAPECREATORS_ENABLED)');
+  const oauth = body.indexOf('if (REDDIT_OAUTH_ENABLED)');
+  const pub = body.indexOf('www.reddit.com/r/${subreddit}/hot.json');
+  assert.ok(sc !== -1 && oauth !== -1 && pub !== -1, 'all three branches present');
+  assert.ok(sc < oauth && oauth < pub, `expected ScrapeCreators < OAuth < public, got ${sc}/${oauth}/${pub}`);
+});
+
+test('cadence is 3h and data-key TTL is co-pinned to 9h (>= health maxStaleMin)', () => {
+  assert.match(relaySource, /const SOCIAL_VELOCITY_INTERVAL_MS = 3 \* 60 \* 60 \* 1000/);
+  assert.match(relaySource, /const WSB_TICKERS_INTERVAL_MS = 3 \* 60 \* 60 \* 1000/);
+  assert.match(relaySource, /const SOCIAL_VELOCITY_TTL = 32400/);
+  assert.match(relaySource, /const WSB_TICKERS_TTL = 32400/);
+});
+
+test('both reddit consumers route through fetchRedditHotListing and label failures with the real source', () => {
+  const social = fnBody('async function fetchRedditHot(subreddit, failures', 600);
+  assert.match(social, /const \{ ok, status, posts, source \} = await fetchRedditHotListing\(subreddit, \{/);
+  // failure label names the path that actually ran (not a hardcoded "(oauth)")
+  assert.match(social, /r\/\$\{subreddit\} HTTP \$\{status\} \(\$\{source\}\)/);
+  const wsb = fnBody('async function fetchWsbRedditHot(subreddit)', 400);
+  assert.match(wsb, /const \{ ok, status, posts, source \} = await fetchRedditHotListing\(subreddit, \{ limit: 50/);
+  assert.match(wsb, /HTTP \$\{status\} \(\$\{source\}\)/);
+  // The old unauthenticated direct fetches inside these two fetchers are gone.
+  assert.doesNotMatch(social, /www\.reddit\.com\/r\/\$\{subreddit\}\/hot\.json/);
+  assert.doesNotMatch(wsb, /www\.reddit\.com\/r\/\$\{subreddit\}\/hot\.json/);
+});
+
+test('helper tags each path with a source for accurate SEED_ERROR reasons', () => {
+  const body = fnBody('async function fetchRedditHotListing(subreddit', 2600);
+  assert.match(body, /source: 'scrapecreators'/);
+  assert.match(body, /source = 'oauth'/);
+  assert.match(body, /source = 'public'/);
+});
+
+test('ScrapeCreators posts are normalized to the OAuth/public shape (seconds + unescaped)', () => {
+  // created_utc coerced to epoch seconds (ms → s at the 1e12 threshold)
+  assert.match(relaySource, /function _redditEpochSeconds\(v\)/);
+  assert.match(relaySource, /v > 1e12 \? Math\.floor\(v \/ 1000\) : v/);
+  // HTML entities decoded (raw_json=1 equivalent for the vendor path)
+  assert.match(relaySource, /function _decodeRedditEntities\(s\)/);
+  assert.match(relaySource, /\.replace\(\/&amp;\/g, '&'\)/);
+  // normalizer maps the timestamp + text fields, passes the rest through
+  assert.match(relaySource, /function _normalizeVendorPost\(p\)/);
+  assert.match(relaySource, /created_utc: _redditEpochSeconds\(p\.created_utc\)/);
+  assert.match(relaySource, /title: _decodeRedditEntities\(p\.title\)/);
+});

--- a/tests/reddit-oauth-fetch.test.mjs
+++ b/tests/reddit-oauth-fetch.test.mjs
@@ -48,7 +48,7 @@ test('token is cached single-flight with early refresh and a post-failure cooldo
 });
 
 test('shared helper prefers oauth.reddit.com and falls back to the public endpoint', () => {
-  const body = fnBody('async function fetchRedditHotListing(subreddit', 2900);
+  const body = fnBody('async function fetchRedditHotListing(subreddit', 3600);
   assert.match(body, /if \(REDDIT_OAUTH_ENABLED\) \{/);
   assert.match(body, /https:\/\/oauth\.reddit\.com\/r\/\$\{subreddit\}\/hot\?limit=\$\{limit\}/);
   assert.match(body, /https:\/\/www\.reddit\.com\/r\/\$\{subreddit\}\/hot\.json\?limit=\$\{limit\}/);
@@ -56,36 +56,40 @@ test('shared helper prefers oauth.reddit.com and falls back to the public endpoi
   assert.match(body, /if \(!resp\.ok\) return \{ ok: false, status: resp\.status, posts: \[\], source \}/);
 });
 
-test('ScrapeCreators is gated on the api key and is the preferred path', () => {
+test('ScrapeCreators is the gated, preferred path with bounded cursor pagination (no limit param)', () => {
   assert.match(relaySource, /const SCRAPECREATORS_API_KEY = process\.env\.SCRAPECREATORS_API_KEY \|\| ''/);
   assert.match(relaySource, /const SCRAPECREATORS_ENABLED = !!SCRAPECREATORS_API_KEY/);
-  const body = fnBody('async function fetchRedditHotListing(subreddit', 2900);
-  // vendor branch: subreddit posts endpoint, sort=hot, passes limit, x-api-key header
+  assert.match(relaySource, /const SC_MAX_PAGES = 4/);
+  const body = fnBody('async function fetchRedditHotListing(subreddit', 3600);
   assert.match(body, /if \(SCRAPECREATORS_ENABLED\) \{/);
-  assert.match(body, /https:\/\/api\.scrapecreators\.com\/v1\/reddit\/subreddit\?subreddit=\$\{encodeURIComponent\(subreddit\)\}&sort=hot&limit=\$\{limit\}/);
+  // subreddit posts endpoint, sort=hot, x-api-key — and NO &limit (endpoint has no such param)
+  assert.match(body, /https:\/\/api\.scrapecreators\.com\/v1\/reddit\/subreddit\?subreddit=\$\{encodeURIComponent\(subreddit\)\}&sort=hot/);
+  assert.doesNotMatch(body, /scrapecreators\.com[^`]*&limit=/);
   assert.match(body, /'x-api-key': SCRAPECREATORS_API_KEY/);
-  // array-guarded, capped to limit, and normalized to match the OAuth/public shape
-  assert.match(body, /\(Array\.isArray\(data\?\.posts\) \? data\.posts : \[\]\)\.filter\(Boolean\)\.slice\(0, limit\)\.map\(_normalizeVendorPost\)/);
-  // success returns immediately, tagged with its source
-  assert.match(body, /return \{ ok: true, status: resp\.status, posts, source: 'scrapecreators' \}/);
+  // cursor pagination bounded by SC_MAX_PAGES and the requested limit
+  assert.match(body, /for \(let page = 0; page < SC_MAX_PAGES && collected\.length < limit; page\+\+\)/);
+  assert.match(body, /\$\{after \? `&after=\$\{encodeURIComponent\(after\)\}` : ''\}/);
+  assert.match(body, /after = typeof data\?\.after === 'string' \? data\.after : ''/);
+  // normalized + capped to limit on success, tagged with source
+  assert.match(body, /return \{ ok: true, status: lastStatus, posts: collected\.slice\(0, limit\)\.map\(_normalizeVendorPost\), source: 'scrapecreators' \}/);
 });
 
-test('ScrapeCreators failure (non-2xx OR throw) falls through to OAuth/public, not an immediate return', () => {
-  const body = fnBody('async function fetchRedditHotListing(subreddit', 2900);
-  // wrapped in try/catch; only resp.ok returns from the SC branch
+test('ScrapeCreators failure falls through to OAuth/public (page-1 non-2xx OR throw); later-page failure keeps data', () => {
+  const body = fnBody('async function fetchRedditHotListing(subreddit', 3600);
   assert.match(body, /try \{/);
-  assert.match(body, /if \(resp\.ok\) \{/);
-  // both failure modes log and fall through (no immediate return)
+  // a later-page failure keeps the pages already gathered; a page-1 failure logs + falls through
+  assert.match(body, /if \(collected\.length > 0\) break;/);
   assert.match(body, /ScrapeCreators HTTP \$\{resp\.status\}/);
   assert.match(body, /catch \(e\) \{/);
   assert.match(body, /ScrapeCreators error for r\/\$\{subreddit\}/);
   assert.match(body, /falling back to OAuth\/public/);
-  // a SC failure must NOT short-circuit with {ok:false, source:'scrapecreators'} (that skipped the fallback)
+  // only a vendor that actually responded (anyOk) returns from the SC branch; else fall through
+  assert.match(body, /if \(anyOk\) \{/);
   assert.doesNotMatch(body, /return \{ ok: false[^}]*source: 'scrapecreators'/);
 });
 
 test('path precedence is ScrapeCreators -> OAuth -> public (ordered in source)', () => {
-  const body = fnBody('async function fetchRedditHotListing(subreddit', 2900);
+  const body = fnBody('async function fetchRedditHotListing(subreddit', 3600);
   const sc = body.indexOf('if (SCRAPECREATORS_ENABLED)');
   const oauth = body.indexOf('if (REDDIT_OAUTH_ENABLED)');
   const pub = body.indexOf('www.reddit.com/r/${subreddit}/hot.json');
@@ -134,7 +138,7 @@ test('both reddit consumers route through fetchRedditHotListing and label failur
 });
 
 test('helper tags each path with a source for accurate SEED_ERROR reasons', () => {
-  const body = fnBody('async function fetchRedditHotListing(subreddit', 2900);
+  const body = fnBody('async function fetchRedditHotListing(subreddit', 3600);
   assert.match(body, /source: 'scrapecreators'/);
   assert.match(body, /source = 'oauth'/);
   assert.match(body, /source = 'public'/);

--- a/tests/reddit-oauth-fetch.test.mjs
+++ b/tests/reddit-oauth-fetch.test.mjs
@@ -79,11 +79,31 @@ test('path precedence is ScrapeCreators -> OAuth -> public (ordered in source)',
   assert.ok(sc < oauth && oauth < pub, `expected ScrapeCreators < OAuth < public, got ${sc}/${oauth}/${pub}`);
 });
 
-test('cadence is 3h and data-key TTL is co-pinned to 9h (>= health maxStaleMin)', () => {
+test('cadence is 3h and data-key TTL STRICTLY exceeds health maxStaleMin (real STALE_SEED window)', () => {
   assert.match(relaySource, /const SOCIAL_VELOCITY_INTERVAL_MS = 3 \* 60 \* 60 \* 1000/);
   assert.match(relaySource, /const WSB_TICKERS_INTERVAL_MS = 3 \* 60 \* 60 \* 1000/);
-  assert.match(relaySource, /const SOCIAL_VELOCITY_TTL = 32400/);
-  assert.match(relaySource, /const WSB_TICKERS_TTL = 32400/);
+  assert.match(relaySource, /const SOCIAL_VELOCITY_TTL = 43200/);
+  assert.match(relaySource, /const WSB_TICKERS_TTL = 43200/);
+  // TTL minutes (43200/60 = 720) must be > health maxStaleMin (540) so a dead relay
+  // shows STALE_SEED before the key expires to EMPTY. TTL==maxStaleMin defeats this.
+  assert.ok(43200 / 60 > 540, 'data-key TTL minutes must exceed maxStaleMin=540');
+});
+
+// Staleness budget is mirrored across THREE surfaces — api/health.js SEED_META,
+// the resilience _standalone-source-thresholds.ts, and api/seed-health.js (which
+// marks stale at intervalMin * 2). This pins all three to the same 540min budget
+// for the Reddit keys so a future cadence edit can't drift one surface silently.
+test('seed-health.js Reddit budget (intervalMin*2) matches api/health.js maxStaleMin=540', () => {
+  const seedHealth = readFileSync(resolve(here, '../api/seed-health.js'), 'utf8');
+  const health = readFileSync(resolve(here, '../api/health.js'), 'utf8');
+  for (const key of ['social-reddit', 'wsb-tickers']) {
+    const m = seedHealth.match(new RegExp(`intelligence:${key}'[^}]*intervalMin:\\s*(\\d+)`));
+    assert.ok(m, `seed-health.js must define intelligence:${key} intervalMin`);
+    assert.equal(Number(m[1]) * 2, 540, `seed-health ${key} intervalMin*2 must equal 540`);
+  }
+  // api/health.js side of the mirror
+  assert.match(health, /socialVelocity:.*maxStaleMin: 540/);
+  assert.match(health, /wsbTickers:.*maxStaleMin: 540/);
 });
 
 test('both reddit consumers route through fetchRedditHotListing and label failures with the real source', () => {


### PR DESCRIPTION
## Summary

The relay's two Reddit fetchers (social-velocity, WSB tickers) stopped working: Reddit's unauthenticated `www.reddit.com/.../hot.json` is policy-blocked (HTTP 403, IP/UA-independent — verified across residential IP, Decodo proxy, browser UA, WM UA) and the **Responsible Builder Policy (2026) removed self-serve API-app creation**, so a new OAuth app can't even be made (`prefs/apps` redirects to the policy page). This routes both fetchers through a shared helper that prefers **ScrapeCreators** (a third-party Reddit data vendor — the only path that still works; same `SCRAPECREATORS_API_KEY` the `/last30days` skill uses), with OAuth (pre-policy creds) and the public endpoint as ordered fallbacks.

- **Shared `fetchRedditHotListing(subreddit, {limit})`** — precedence **ScrapeCreators → OAuth → public**; returns `{ ok, status, posts, source }`, never throws on HTTP status. Both `fetchRedditHot` (social) and `fetchWsbRedditHot` (WSB) route through it, so one change fixes both panels.
- **Vendor-shape normalization** — ScrapeCreators returns native Reddit field names in a flat `posts` array, but `created_utc` is coerced to epoch-seconds and `title`/`selftext` HTML entities are decoded so the payload is byte-compatible with the OAuth/public (`raw_json=1`) paths. Downstream velocity/ticker logic is unchanged.
- **Accurate diagnostics** — failures report the path that actually ran (`(scrapecreators)` / `(oauth)` / `(public)`) in the `seed-meta` `errorReason`, not a hardcoded `(oauth)`.
- **Cadence 1h → 3h** — velocity decays over ~6h; hourly was a leftover Reddit-rate-limit workaround. Data-key TTL co-pinned `10800 → 32400` (9h) and health `maxStaleMin` `180 → 540` (mirrored in resilience `_standalone-source-thresholds.ts`) so neither STALE_SEED jitter nor the EMPTY-vs-STALE_SEED TTL gap can fire.
- Gated on `SCRAPECREATORS_API_KEY`; **when unset, behavior is identical to today** (no regression). Documented in `.env.example`.

**Operator step (post-merge):** set `SCRAPECREATORS_API_KEY` on the **relay** Railway service (the one running `node scripts/ais-relay.cjs`) → redeploy. The next 3h cycle clears the `socialVelocity` SEED_ERROR. Cost ~$2.40/mo for both panels (40 scrapes/day @ $0.002).

> Scoped deliberately to the ScrapeCreators work — the outages sparse-feed fix (#4141) and the CII warm-ping change (#4151) are already on `main` and excluded from this branch.

## Test plan

- [x] `npm run typecheck` + `typecheck:api`
- [x] `npm run lint` (biome)
- [x] `npm run test:data` — 10778 pass, 0 fail
- [x] edge bundle check (`api/*.js`) + `tests/edge-functions.test.mjs` (204 pass)
- [x] `npm run lint:md`, `version:check`
- [x] New `tests/reddit-oauth-fetch.test.mjs` — vendor path, precedence, source labels, normalization, cadence/TTL constants
- [x] `tests/health-classify.test.mjs` — social/wsb tolerate 3h cadence (fresh@300min → OK; stale@600min → STALE_SEED)
- [x] `tests/resilience-source-failure.test.mjs` + `resilience-dimension-freshness` — maxStaleMin mirror parity (540)
- [ ] **Post-merge:** set `SCRAPECREATORS_API_KEY` on the relay; confirm `socialVelocity` off SEED_ERROR + `seed-meta:intelligence:social-reddit` status=ok. Verify the live vendor `created_utc` is epoch-seconds (normalization handles either way).