### PR TITLE
fix(sentry): guard formatPrice + filter extension fetch noise

### DIFF
--- a/src/components/MarketPanel.ts
+++ b/src/components/MarketPanel.ts
@@ -475,9 +475,13 @@ export class CommoditiesPanel extends Panel {
       return;
     }
 
-    // Metals/Commodities tab — exclude FX and spot gold symbols from the display grid
+    // Metals/Commodities tab — exclude FX and spot gold symbols from the display grid.
+    // Require a finite numeric price: the feed sometimes omits `price` (undefined),
+    // and `d.price !== null` lets undefined through to `formatPrice(c.price!)`
+    // (WORLDMONITOR-SH). A finite-price guard also keeps the adjacent `c.change!`
+    // row meaningful (a record with no price carries no usable change either).
     const validData = this._commodityData.filter(
-      (d) => d.price !== null && !d.symbol?.endsWith('=X'),
+      (d) => typeof d.price === 'number' && Number.isFinite(d.price) && !d.symbol?.endsWith('=X'),
     );
     if (validData.length === 0) {
       if (!hasFx) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -438,6 +438,24 @@ Sentry.init({
     // A first-party frame elsewhere in the stack means the error likely originated in our code; surface it even if
     // an extension wrapped the call.
     if (!hasFirstParty && frames.some(f => /^(?:chrome|moz|safari(?:-web)?)-extension:\/\//.test(f.filename ?? ''))) return null;
+    // Bare `Failed to fetch` leaking via onunhandledrejection when a browser
+    // extension has monkeypatched `window.fetch` (e.g. Adjust SDK's
+    // injectScriptAdjust.js, page-inspector extensions) and chained an uncaught
+    // `.then()` on the result. A transient network blip rejects the underlying
+    // fetch and the extension's orphan promise surfaces as an unhandled rejection.
+    // Our first-party frames (the runtime fetch interceptor + country-geometry
+    // loader) appear ONLY because our wrapper sits in the call chain — our own
+    // fetch callers already wrap rejections in try/catch (country-geometry's
+    // ensureLoaded logs a warning and resolves), so this is NOT a first-party
+    // leak. Unlike the generic `!hasFirstParty` `Failed to fetch` gate below,
+    // this fires WITH first-party frames present, but only when an extension has
+    // a `window.fetch` frame on the stack — a genuine API outage (host-suffixed
+    // `Failed to fetch (<host>)`, handled above) and any non-extension user are
+    // unaffected (WORLDMONITOR-SG).
+    if (/^(?:TypeError: )?Failed to fetch$/.test(msg)
+        && frames.some(f => /^(?:chrome|moz|safari(?:-web)?)-extension:\/\//.test(f.filename ?? '') && /fetch/i.test(f.function ?? ''))) {
+      return null;
+    }
     // Suppress Sentry SDK DOM breadcrumb null-access on document.activeElement/contains.
     // Gated on !hasFirstParty because Sentry wraps first-party handlers, so a genuine app `el.contains(...)` bug
     // can produce a stack containing both main-*.js and sentry-*.js frames.

--- a/src/main.ts
+++ b/src/main.ts
@@ -449,11 +449,14 @@ Sentry.init({
     // ensureLoaded logs a warning and resolves), so this is NOT a first-party
     // leak. Unlike the generic `!hasFirstParty` `Failed to fetch` gate below,
     // this fires WITH first-party frames present, but only when an extension has
-    // a `window.fetch` frame on the stack — a genuine API outage (host-suffixed
-    // `Failed to fetch (<host>)`, handled above) and any non-extension user are
-    // unaffected (WORLDMONITOR-SG).
+    // a monkeypatched-`window.fetch` frame on the stack — a genuine API outage
+    // (host-suffixed `Failed to fetch (<host>)`, handled above) and any
+    // non-extension user are unaffected. The function match is anchored to
+    // exactly `window.fetch` / `fetch` (not a loose `/fetch/`) so an extension
+    // frame named `fetchContent` / `prefetch` does NOT swallow a real bare
+    // `Failed to fetch` from our own code (WORLDMONITOR-SG).
     if (/^(?:TypeError: )?Failed to fetch$/.test(msg)
-        && frames.some(f => /^(?:chrome|moz|safari(?:-web)?)-extension:\/\//.test(f.filename ?? '') && /fetch/i.test(f.function ?? ''))) {
+        && frames.some(f => /^(?:chrome|moz|safari(?:-web)?)-extension:\/\//.test(f.filename ?? '') && /^(?:window\.)?fetch$/i.test(f.function ?? ''))) {
       return null;
     }
     // Suppress Sentry SDK DOM breadcrumb null-access on document.activeElement/contains.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -19,7 +19,12 @@ export function formatTime(date: Date): string {
   }
 }
 
-export function formatPrice(price: number): string {
+export function formatPrice(price: number | null | undefined): string {
+  // Live feeds occasionally omit `price` (undefined) rather than sending null,
+  // and `null`/NaN slip through call-site `!` assertions on `number | null`
+  // fields. Guard here so a missing price renders the unavailable placeholder
+  // instead of throwing `undefined.toLocaleString()` (WORLDMONITOR-SH).
+  if (typeof price !== 'number' || !Number.isFinite(price)) return '--';
   if (price >= 1000) {
     return `$${price.toLocaleString(undefined, {
       minimumFractionDigits: 0,

--- a/tests/format-price-nullsafe.test.mts
+++ b/tests/format-price-nullsafe.test.mts
@@ -1,0 +1,59 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { transformSync } from 'esbuild';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// `src/utils/index.ts` is a barrel that re-exports from `./proxy`, which reads
+// `import.meta.env.DEV` at module load — a documented gotcha that breaks plain
+// tsx/node imports (see comments in src/utils/cloud-prefs-migrations.ts and
+// src/components/resilience-widget-utils.ts). The pure formatters in the barrel
+// (formatPrice/formatChange/...) have no env or DOM dependency, so we strip the
+// side-effecting re-export/import lines and evaluate just the standalone code.
+async function loadUtils(): Promise<{ formatPrice: (p: number | null | undefined) => string }> {
+  const src = readFileSync(resolve(__dirname, '../src/utils/index.ts'), 'utf-8');
+  const stripped = src
+    .split('\n')
+    .filter((line) => !/^\s*(export\s+(type\s+)?\{[^}]*\}\s+from|export\s+\*\s+from|import\s+(type\s+)?\{[^}]*\}\s+from)\s+['"]/.test(line))
+    .join('\n');
+  const { code } = transformSync(stripped, { loader: 'ts', format: 'esm' });
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(code).toString('base64')}#${Date.now()}-${Math.random()}`;
+  return import(dataUrl);
+}
+
+// Reproduces WORLDMONITOR-SH: a commodity/stock record whose `price` is
+// `undefined` (the live feed omits the field rather than sending `null`)
+// reached `formatPrice`, which unconditionally called `price.toLocaleString()`.
+// `undefined >= 1000` is false, so the else branch ran `undefined.toLocaleString()`
+// → "TypeError: Cannot read properties of undefined (reading 'toLocaleString')".
+// MarketPanel's `validData` filter only excluded `null` (`d.price !== null`),
+// so `undefined` slipped through to `formatPrice(c.price!)`.
+describe('formatPrice null-safety (WORLDMONITOR-SH)', () => {
+  it('does not throw on undefined and returns the unavailable placeholder', async () => {
+    const { formatPrice } = await loadUtils();
+    assert.doesNotThrow(() => formatPrice(undefined));
+    assert.equal(formatPrice(undefined), '--');
+  });
+
+  it('does not throw on null and returns the unavailable placeholder', async () => {
+    const { formatPrice } = await loadUtils();
+    assert.doesNotThrow(() => formatPrice(null));
+    assert.equal(formatPrice(null), '--');
+  });
+
+  it('returns the unavailable placeholder for NaN / non-finite input', async () => {
+    const { formatPrice } = await loadUtils();
+    assert.equal(formatPrice(NaN), '--');
+    assert.equal(formatPrice(Infinity), '--');
+  });
+
+  it('preserves existing formatting for valid prices', async () => {
+    const { formatPrice } = await loadUtils();
+    assert.equal(formatPrice(1500), '$1,500');
+    assert.equal(formatPrice(12.5), '$12.50');
+    assert.equal(formatPrice(0), '$0.00');
+  });
+});

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -445,6 +445,34 @@ describe('existing beforeSend filters', () => {
     assert.ok(beforeSend(event) !== null, 'Plain first-party fetch failure should surface');
   });
 
+  it('suppresses bare "Failed to fetch" when an extension monkeypatched window.fetch (WORLDMONITOR-SG)', () => {
+    // Real WORLDMONITOR-SG stack: our runtime fetch interceptor + country-geometry
+    // loader are first-party frames, but the leaked rejection comes from an
+    // extension (Adjust SDK injectScriptAdjust.js / page-inspector) that wrapped
+    // window.fetch and chained an uncaught `.then()`. hasFirstParty is true, so
+    // the generic !hasFirstParty gate misses it; the extension `window.fetch`
+    // frame is what proves third-party interference.
+    const event = makeEvent('Failed to fetch', 'TypeError', [
+      { filename: '/assets/main-BHkAr2lX.js', lineno: 1394, function: 'rS.init' },
+      { filename: '/assets/panels-B8qWCRUs.js', lineno: 63, function: 'd1' },
+      { filename: '/assets/panels-B8qWCRUs.js', lineno: 61, function: 'DY.window.fetch' },
+      { filename: 'chrome-extension://dbjbempljhcmhlfpfacalomonjpalpko/scripts/inspector.js', lineno: 7, function: 'window.fetch' },
+      { filename: 'chrome-extension://bkkbcggnhapdmkeljlodobbkopceiche/injectScriptAdjust.js', lineno: 1, function: 'doDefault' },
+    ]);
+    assert.equal(beforeSend(event), null, 'Extension-wrapped window.fetch network blip should be suppressed');
+  });
+
+  it('does NOT suppress bare "Failed to fetch" with a first-party frame and a NON-fetch extension frame', () => {
+    // Precision guard for WORLDMONITOR-SG: an extension frame whose function is
+    // not a fetch wrapper is NOT evidence the extension owns the orphan fetch
+    // promise, so a genuine first-party fetch failure must still surface.
+    const event = makeEvent('Failed to fetch', 'TypeError', [
+      { filename: '/assets/panels-wF5GXf0N.js', lineno: 100, function: 'MyApiCall' },
+      { filename: 'chrome-extension://abcdefghijklmnopabcdefghijklmnop/content.js', lineno: 1, function: 'inject' },
+    ]);
+    assert.ok(beforeSend(event) !== null, 'First-party fetch failure with a non-fetch extension frame must surface');
+  });
+
   it('does NOT suppress "Failed to fetch (<hostname>)" when no maplibre frame is present', () => {
     // Guards against broad message-only suppression hiding a real first-party fetch
     // regression that happens to wrap host into the message.

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -473,6 +473,20 @@ describe('existing beforeSend filters', () => {
     assert.ok(beforeSend(event) !== null, 'First-party fetch failure with a non-fetch extension frame must surface');
   });
 
+  it('does NOT suppress when the extension frame function merely CONTAINS "fetch" (prefetch/fetchContent)', () => {
+    // The function match is anchored to exactly `window.fetch`/`fetch`, not a
+    // loose `/fetch/`, so an extension frame named `prefetch` or `fetchContent`
+    // is not treated as a monkeypatched window.fetch — a real bare "Failed to
+    // fetch" from our own code must still surface (Greptile review on #4157).
+    for (const fn of ['prefetch', 'fetchContent', 'fetchUserData']) {
+      const event = makeEvent('Failed to fetch', 'TypeError', [
+        { filename: '/assets/panels-wF5GXf0N.js', lineno: 100, function: 'MyApiCall' },
+        { filename: 'chrome-extension://abcdefghijklmnopabcdefghijklmnop/inject.js', lineno: 1, function: fn },
+      ]);
+      assert.ok(beforeSend(event) !== null, `extension frame function "${fn}" must not trigger SG suppression`);
+    }
+  });
+
   it('does NOT suppress "Failed to fetch (<hostname>)" when no maplibre frame is present', () => {
     // Guards against broad message-only suppression hiding a real first-party fetch
     // regression that happens to wrap host into the message.


### PR DESCRIPTION
## Summary

Resolves two production Sentry issues found during triage.

- **WORLDMONITOR-SH** — `TypeError: Cannot read properties of undefined (reading 'toLocaleString')` (3 events / 3 users, in the commodities panel). The live feed omits `price` (sends `undefined`, not `null`), so `MarketPanel`'s `d.price !== null` filter let it through to `formatPrice(c.price!)`, which unconditionally calls `.toLocaleString()`. Fixed at both layers:
  - `formatPrice` now accepts `number | null | undefined` and returns the `--` placeholder for non-finite input — protects all 7 call sites (several pass `x!` on `number | null` fields).
  - `MarketPanel` commodities `validData` filter now requires a finite numeric price (root cause; also keeps the adjacent `c.change!` row honest).
- **WORLDMONITOR-SG** — `TypeError: Failed to fetch` via `onunhandledrejection`. A browser extension that monkeypatched `window.fetch` (Adjust SDK `injectScriptAdjust.js`) chained an uncaught `.then()` and leaked the rejection on a network blip. Our runtime fetch interceptor sits in the call chain, so the existing `!hasFirstParty` gate never fires. Added a `beforeSend` rule that suppresses bare `Failed to fetch` **only** when an extension-origin `window.fetch` frame is present — host-suffixed `Failed to fetch (<host>)` and non-extension users still surface.

Both issues were marked resolved in Sentry with `inNextRelease: true` (auto-reopen on recurrence). A third issue (WORLDMONITOR-RX, Upstash Lua-script timeout) was left untouched — `api/_rate-limit.js` already captures it at `warning` by design.

## Test plan

- [x] `tests/format-price-nullsafe.test.mts` (new) — reproduces the SH crash (failing→passing); covers undefined/null/NaN/Infinity + preserved formatting
- [x] `tests/sentry-beforesend.test.mjs` — +2 cases: SG suppression + precision guard (non-fetch extension frame still surfaces)
- [x] `npm run typecheck` + `npm run typecheck:api`
- [x] `npm run lint` (biome) + `npm run lint:md`
- [x] `npm run test:data` — 10772 pass / 0 fail
- [x] edge bundle check + `tests/edge-functions.test.mjs` (204 pass)
- [x] `npm run version:check`