### PR TITLE
Fix CII earthquake replay clock determinism

### DIFF
--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -862,7 +862,7 @@ export function computeCIIScores(
   }
 
   // --- Earthquakes (Phase 1) — magnitude >= 5.5, within 7-day lookback ---
-  const eqCutoff = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  const eqCutoff = computedAt - 7 * 24 * 60 * 60 * 1000;
   for (const eq of aux.earthquakes ?? []) {
     const mag = safeNonNegativeNum(eq.magnitude);
     if (mag < 5.5) continue;

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -588,6 +588,32 @@ describe('CII signal wiring', () => {
       'earthquake + sanctions feed earthquakeBoost + sanctionsBoost in the blend');
   });
 
+  it('earthquake lookback honors injected CII scorer clock', () => {
+    const nowMs = Date.UTC(2020, 0, 10);
+    const base = scoreFor(computeCIIScores([], emptyAux(), { nowMs }), 'US')!;
+
+    const recentAux = emptyAux();
+    recentAux.earthquakes = [
+      { magnitude: 7.0, occurredAt: nowMs - 24 * 60 * 60 * 1000, location: { latitude: 39, longitude: -98 } },
+    ];
+    const recent = scoreFor(computeCIIScores([], recentAux, { nowMs }), 'US')!;
+    assert.ok(
+      recent.combinedScore > base.combinedScore,
+      'a one-day-old magnitude 7 earthquake must boost scores relative to injected nowMs',
+    );
+
+    const staleAux = emptyAux();
+    staleAux.earthquakes = [
+      { magnitude: 7.0, occurredAt: nowMs - 8 * 24 * 60 * 60 * 1000, location: { latitude: 39, longitude: -98 } },
+    ];
+    const stale = scoreFor(computeCIIScores([], staleAux, { nowMs }), 'US')!;
+    assert.equal(
+      stale.combinedScore,
+      base.combinedScore,
+      'an eight-day-old earthquake must be ignored relative to injected nowMs',
+    );
+  });
+
   it('Phase 3b D7/D8: cyber severity + high-brightness fires raise the score', () => {
     const base = scoreFor(computeCIIScores([], emptyAux()), 'US');
     const aux = emptyAux();


### PR DESCRIPTION
## Summary
- derive the CII earthquake 7-day cutoff from the scorer clock instead of wall-clock Date.now()
- add regression coverage for fixed-past nowMs replay behavior
- leave CII_FORMULA_VERSION unchanged because coefficients/literals did not change and the snapshot guard stayed stable

## Validation
- npm ci
- ./node_modules/.bin/tsx --test tests/cii-scoring.test.mts
- npm run typecheck:api
- git diff --check
- git push pre-push hook: typecheck, typecheck:api, Convex type check, boundary/safe-html/rate-limit/premium-fetch guards, server handler tests, changed CII test file, version check