### PR TITLE
Harden deterministic CII replay scoring

### DIFF
--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -862,7 +862,7 @@ export function computeCIIScores(
   }
 
   // --- Earthquakes (Phase 1) — magnitude >= 5.5, within 7-day lookback ---
-  const eqCutoff = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  const eqCutoff = computedAt - 7 * 24 * 60 * 60 * 1000;
   for (const eq of aux.earthquakes ?? []) {
     const mag = safeNonNegativeNum(eq.magnitude);
     if (mag < 5.5) continue;

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -878,6 +878,63 @@ describe('CII scoring', () => {
     assert.ok(ua.components!.newsActivity >= 0, 'negative threat counts must not lower news below zero');
   });
 
+  it('replays ACLED age weights, earthquake lookback, trend prior, and computedAt from fixed nowMs', () => {
+    const replayNowMs = Date.UTC(2020, 0, 10, 12, 0, 0);
+    const recentAcled = [
+      { ...acledEvent('United States', 'Protests', 0), daysAgo: 7 },
+      { ...acledEvent('United States', 'Battles', 2), daysAgo: 7 },
+    ];
+    const tailAcled = [
+      { ...acledEvent('United States', 'Protests', 0), daysAgo: 8 },
+      { ...acledEvent('United States', 'Battles', 2), daysAgo: 8 },
+    ];
+
+    const base = scoreFor(computeCIIScores([], emptyAux(), { nowMs: replayNowMs }), 'US')!;
+    const recent = scoreFor(computeCIIScores(recentAcled, emptyAux(), { nowMs: replayNowMs }), 'US')!;
+    const tail = scoreFor(computeCIIScores(tailAcled, emptyAux(), { nowMs: replayNowMs }), 'US')!;
+    assert.equal(base.computedAt, replayNowMs);
+    assert.equal(recent.computedAt, replayNowMs);
+    assert.equal(tail.computedAt, replayNowMs);
+    assert.ok(
+      recent.components!.ciiContribution > tail.components!.ciiContribution,
+      `0-7d ACLED weight (${recent.components!.ciiContribution}) should exceed 8-30d tail weight (${tail.components!.ciiContribution})`,
+    );
+    assert.ok(
+      tail.components!.ciiContribution > base.components!.ciiContribution,
+      '8-30d ACLED tail still contributes to deterministic replay scoring',
+    );
+
+    const withRecentEqAux = emptyAux();
+    withRecentEqAux.earthquakes = [
+      { magnitude: 7.0, occurredAt: replayNowMs - 24 * 60 * 60 * 1000, location: { latitude: 39, longitude: -98 } },
+    ];
+    const withStaleEqAux = emptyAux();
+    withStaleEqAux.earthquakes = [
+      { magnitude: 7.0, occurredAt: replayNowMs - 8 * 24 * 60 * 60 * 1000, location: { latitude: 39, longitude: -98 } },
+    ];
+    const withRecentEq = scoreFor(computeCIIScores([], withRecentEqAux, { nowMs: replayNowMs }), 'US')!;
+    const withStaleEq = scoreFor(computeCIIScores([], withStaleEqAux, { nowMs: replayNowMs }), 'US')!;
+    assert.ok(withRecentEq.combinedScore > base.combinedScore, 'earthquake inside fixed 7d replay window raises score');
+    assert.equal(withStaleEq.combinedScore, base.combinedScore, 'earthquake outside fixed 7d replay window is ignored');
+
+    const targetSnapshot = trendSnapshot(replayNowMs - CII_TREND_TARGET_AGE_MS);
+    targetSnapshot.ciiScores = [priorCiiScore('US', withRecentEq.combinedScore - 5, targetSnapshot.capturedAt)];
+    const recentSnapshot = trendSnapshot(replayNowMs - 10 * 60 * 1000);
+    recentSnapshot.ciiScores = [priorCiiScore('US', withRecentEq.combinedScore + 40, recentSnapshot.capturedAt)];
+    const selectedPrior = selectCiiTrendPriorSnapshot([recentSnapshot, targetSnapshot], replayNowMs);
+    const replayed = scoreFor(
+      computeCIIScores([], withRecentEqAux, {
+        nowMs: replayNowMs,
+        priorScores: selectedPrior?.ciiScores ?? null,
+      }),
+      'US',
+    )!;
+    assert.equal(selectedPrior, targetSnapshot);
+    assert.equal(replayed.computedAt, replayNowMs);
+    assert.equal(replayed.dynamicScore, 5);
+    assert.equal(replayed.trend, 'TREND_DIRECTION_RISING');
+  });
+
   it('cold-start emits flat movement instead of baseline delta', () => {
     const us = scoreFor(computeCIIScores([], emptyAux(), { nowMs: TREND_TEST_NOW }), 'US')!;
     assert.notEqual(us.combinedScore - us.staticBaseline, 0, 'fixture should have a non-zero structural baseline gap');

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -878,8 +878,10 @@ describe('CII scoring', () => {
     assert.ok(ua.components!.newsActivity >= 0, 'negative threat counts must not lower news below zero');
   });
 
-  it('replays ACLED age weights, earthquake lookback, trend prior, and computedAt from fixed nowMs', () => {
+  it('applies ACLED bucket weights and replays earthquake lookback, trend prior, and computedAt from fixed nowMs', () => {
     const replayNowMs = Date.UTC(2020, 0, 10, 12, 0, 0);
+    // ACLED `daysAgo` is computed before computeCIIScores runs; this guards the
+    // scorer's bucket weights, not clock-derived ACLED age calculation.
     const recentAcled = [
       { ...acledEvent('United States', 'Protests', 0), daysAgo: 7 },
       { ...acledEvent('United States', 'Battles', 2), daysAgo: 7 },
@@ -901,7 +903,7 @@ describe('CII scoring', () => {
     );
     assert.ok(
       tail.components!.ciiContribution > base.components!.ciiContribution,
-      '8-30d ACLED tail still contributes to deterministic replay scoring',
+      '8-30d ACLED bucket still contributes to scoring',
     );
 
     const withRecentEqAux = emptyAux();


### PR DESCRIPTION
## Summary
- use the injected CII scorer clock for earthquake lookback
- add fixed-now replay coverage for earthquake lookback, trend prior selection, dynamicScore, and computedAt
- guard ACLED 0-7d vs 8-30d bucket weighting while documenting that ACLED `daysAgo` is precomputed before scorer replay

## Validation
- ./node_modules/.bin/tsx --test tests/cii-scoring.test.mts
- git diff --check
- npm run typecheck:api
- pre-push hook passed full typecheck/guardrails, server handler tests, changed CII tests, and version sync