### PR TITLE
Fix frontend CII fallback source ordering

### DIFF
--- a/src/app/search-manager.ts
+++ b/src/app/search-manager.ts
@@ -11,6 +11,7 @@ import type { MapRenderer } from '@/config/map-layer-definitions';
 import type { MapVariant } from '@/config/map-layer-definitions';
 import { LAYER_PRESETS, LAYER_KEY_MAP } from '@/config/commands';
 import { calculateCII, TIER1_COUNTRIES } from '@/services/country-instability';
+import { getCachedCountryScores } from '@/services/cached-risk-scores';
 import { CURATED_COUNTRIES } from '@/config/countries';
 import { getCountryBbox } from '@/services/country-geometry';
 import { INTEL_HOTSPOTS, CONFLICT_ZONES, MILITARY_BASES, UNDERSEA_CABLES, NUCLEAR_FACILITIES } from '@/config/geo';
@@ -774,8 +775,11 @@ export class SearchManager implements AppModule {
   }
 
   private buildCountrySearchItems(): { id: string; title: string; subtitle: string; data: { code: string; name: string } }[] {
+    const cachedScores = getCachedCountryScores();
     const panelScores = (this.ctx.panels.cii as CIIPanel | undefined)?.getScores() ?? [];
-    const scores = panelScores.length > 0 ? panelScores : calculateCII();
+    const scores = cachedScores.length > 0
+      ? cachedScores
+      : (panelScores.length > 0 ? panelScores : calculateCII());
     const ciiByCode = new Map(scores.map((score) => [score.code, score]));
     return Object.entries(TIER1_COUNTRIES).map(([code, name]) => {
       const score = ciiByCode.get(code);

--- a/src/components/InsightsPanel.ts
+++ b/src/components/InsightsPanel.ts
@@ -6,6 +6,7 @@ import { signalAggregator, type RegionalConvergence } from '@/services/signal-ag
 import { focalPointDetector } from '@/services/focal-point-detector';
 import { stripOrefLabels } from '@/services/oref-alerts';
 import { ingestNewsForCII, getCountryScore } from '@/services/country-instability';
+import { getCachedCountryScoreValue } from '@/services/cached-risk-scores';
 import { getTheaterPostureSummaries } from '@/services/military-surge';
 import { getCachedPosture } from '@/services/cached-theater-posture';
 import { isMobileDevice } from '@/utils';
@@ -24,6 +25,10 @@ import { extractEntitiesFromTitle } from '@/services/entity-extraction';
 import { getEntityIndex } from '@/services/entity-index';
 
 import type { ClusteredEvent, FocalPoint, MilitaryFlight } from '@/types';
+
+function getAuthoritativeCountryScore(code: string): number | null {
+  return getCachedCountryScoreValue(code) ?? getCountryScore(code);
+}
 
 export class InsightsPanel extends Panel {
   private lastBriefUpdate = 0;
@@ -272,11 +277,11 @@ export class InsightsPanel extends Panel {
       const sortedStories = [...serverInsights.topStories].sort((a, b) => {
         const isqA = computeISQ(
           { sourceCount: a.sourceCount, isAlert: a.isAlert, threatLevel: a.threatLevel ?? undefined, countryCode: a.countryCode, velocity: a.velocity },
-          focalFnServer, getCountryScore, isFocalReadyServer,
+          focalFnServer, getAuthoritativeCountryScore, isFocalReadyServer,
         );
         const isqB = computeISQ(
           { sourceCount: b.sourceCount, isAlert: b.isAlert, threatLevel: b.threatLevel ?? undefined, countryCode: b.countryCode, velocity: b.velocity },
-          focalFnServer, getCountryScore, isFocalReadyServer,
+          focalFnServer, getAuthoritativeCountryScore, isFocalReadyServer,
         );
         return isqB.composite - isqA.composite;
       });
@@ -373,7 +378,7 @@ export class InsightsPanel extends Panel {
       const isFocalReady = () => (focalPointDetector.getLastSummary()?.topCountries.some(
         fp => fp.signalCount > 0 || fp.signalTypes.includes('active_strike')
       ) ?? false);
-      const importantItems = this.selectTopStories(clusters, 8, focalFn, getCountryScore, isFocalReady);
+      const importantItems = this.selectTopStories(clusters, 8, focalFn, getAuthoritativeCountryScore, isFocalReady);
       const importantClusters = importantItems.map(({ cluster }) => cluster);
 
       if (importantClusters.length === 0) {

--- a/tests/frontend-cii-source-of-truth.test.mts
+++ b/tests/frontend-cii-source-of-truth.test.mts
@@ -348,6 +348,8 @@ describe('frontend CII source of truth', () => {
     const militarySrc = readSrc('src/services/military-surge.ts');
     const mapSrc = readSrc('src/components/Map.ts');
     const deckSrc = readSrc('src/components/DeckGLMap.ts');
+    const searchSrc = readSrc('src/app/search-manager.ts');
+    const insightsSrc = readSrc('src/components/InsightsPanel.ts');
 
     assert.doesNotMatch(storySrc, /hasIntelligenceSignalsLoaded/);
     assert.match(storySrc, /const normalizedCountryCode = normalizeCiiCountryCode\(countryCode\);/);
@@ -367,6 +369,10 @@ describe('frontend CII source of truth', () => {
     assert.match(militarySrc, /getCachedCountryScoreValue\(code\) \?\? getCountryScore\(code\)/);
     assert.match(mapSrc, /setCIIGetter\(\(code\) => getCachedCountryScoreValue\(code\) \?\? getCountryScore\(code\)\)/);
     assert.match(deckSrc, /setCIIGetter\(\(code\) => getCachedCountryScoreValue\(code\) \?\? getCountryScore\(code\)\)/);
+    assert.match(searchSrc, /const cachedScores = getCachedCountryScores\(\);[\s\S]*const scores = cachedScores\.length > 0[\s\S]*\? cachedScores[\s\S]*: \(panelScores\.length > 0 \? panelScores : calculateCII\(\)\);/);
+    assert.match(insightsSrc, /function getAuthoritativeCountryScore\(code: string\): number \| null \{[\s\S]*return getCachedCountryScoreValue\(code\) \?\? getCountryScore\(code\);[\s\S]*\}/);
+    assert.match(insightsSrc, /focalFnServer, getAuthoritativeCountryScore, isFocalReadyServer/);
+    assert.match(insightsSrc, /this\.selectTopStories\(clusters, 8, focalFn, getAuthoritativeCountryScore, isFocalReady\)/);
   });
 
   it('aligns CII badge and fill colors to the canonical frontend bands', () => {


### PR DESCRIPTION
## Summary
- Prefer cached/server CII in country search before rendered panel or local fallback scores
- Route InsightsPanel ISQ ranking through cached CII before local getCountryScore()
- Extend the frontend CII source-of-truth guard to cover search and insights consumers

## Why
The backend cached CII path is authoritative, but two frontend on-demand consumers could still surface local fallback CII while cached scores were available. This keeps those consumers cached-first without redesigning the local fallback engine or changing CII_FORMULA_VERSION.

## Validation
- ./node_modules/.bin/tsx --test tests/frontend-cii-source-of-truth.test.mts tests/frontend-cii-closeout.test.mts tests/cached-risk-scores.test.mts
- npm run typecheck
- git diff --check
- pre-push hook: typecheck, typecheck:api, Convex type check, CJS syntax, Unicode safety, boundaries, safe HTML, rate-limit policies, premium-fetch parity, edge bundle check, changed test files, edge function tests, version check