### PR TITLE
Centralize CII risk score cache keys

### DIFF
--- a/api/_cii-risk-cache-keys.d.ts
+++ b/api/_cii-risk-cache-keys.d.ts
@@ -1,0 +1,5 @@
+export const CII_RISK_SCORE_CACHE_KEYS: Readonly<{
+  live: 'risk:scores:sebuf:v7';
+  stale: 'risk:scores:sebuf:stale:v7';
+  trendHistoryPrefix: 'risk:scores:sebuf:trend-history:v7';
+}>;

--- a/api/_cii-risk-cache-keys.js
+++ b/api/_cii-risk-cache-keys.js
@@ -1,0 +1,5 @@
+export const CII_RISK_SCORE_CACHE_KEYS = Object.freeze({
+  live: 'risk:scores:sebuf:v7',
+  stale: 'risk:scores:sebuf:stale:v7',
+  trendHistoryPrefix: 'risk:scores:sebuf:trend-history:v7',
+});

--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -4,6 +4,7 @@ import { jsonResponse } from './_json-response.js';
 // @ts-expect-error — JS module, no declaration file
 import { redisPipeline } from './_upstash-json.js';
 import { unwrapEnvelope } from './_seed-envelope.js';
+import { CII_RISK_SCORE_CACHE_KEYS } from './_cii-risk-cache-keys.js';
 
 export const config = { runtime: 'edge' };
 
@@ -58,7 +59,7 @@ const BOOTSTRAP_CACHE_KEYS = {
   renewableEnergy:  'economic:worldbank-renewable:v1',
   positiveGeoEvents: 'positive_events:geo-bootstrap:v1',
   theaterPosture: 'theater_posture:sebuf:stale:v1',
-  riskScores: 'risk:scores:sebuf:stale:v7',
+  riskScores: CII_RISK_SCORE_CACHE_KEYS.stale,
   naturalEvents: 'natural:events:v1',
   flightDelays: 'aviation:delays-bootstrap:v2',
   insights: 'news:insights:v1',

--- a/api/health.js
+++ b/api/health.js
@@ -7,6 +7,7 @@ import { jsonResponse } from './_json-response.js';
 import { unwrapEnvelope } from './_seed-envelope.js';
 // @ts-expect-error — JS module, no declaration file
 import { redisPipeline, getRedisCredentials } from './_upstash-json.js';
+import { CII_RISK_SCORE_CACHE_KEYS } from './_cii-risk-cache-keys.js';
 
 export const config = { runtime: 'edge' };
 
@@ -28,7 +29,7 @@ const BOOTSTRAP_KEYS = {
   progressData:      'economic:worldbank-progress:v1',
   renewableEnergy:   'economic:worldbank-renewable:v1',
   positiveGeoEvents: 'positive_events:geo-bootstrap:v1',
-  riskScores:        'risk:scores:sebuf:stale:v7',
+  riskScores:        CII_RISK_SCORE_CACHE_KEYS.stale,
   naturalEvents:     'natural:events:v1',
   flightDelays:      'aviation:delays-bootstrap:v2',
   newsInsights:      'news:insights:v1',
@@ -132,7 +133,7 @@ const STANDALONE_KEYS = {
   theaterPosture:        'theater_posture:sebuf:stale:v1',
   theaterPostureLive:    'theater-posture:sebuf:v1',
   theaterPostureBackup:  'theater-posture:sebuf:backup:v1',
-  riskScoresLive:        'risk:scores:sebuf:v7',
+  riskScoresLive:        CII_RISK_SCORE_CACHE_KEYS.live,
   usniFleet:             'usni-fleet:sebuf:v1',
   usniFleetStale:        'usni-fleet:sebuf:stale:v1',
   faaDelays:             'aviation:delays:faa:v1',

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -1,4 +1,5 @@
 import ISO2_TO_ISO3 from '../../../shared/iso2-to-iso3.js';
+import { CII_RISK_SCORE_CACHE_KEYS } from '../../_cii-risk-cache-keys.js';
 import { DEFAULT_LIST_LIMIT } from '../constants';
 import {
   argBool,
@@ -242,7 +243,7 @@ export const CACHE_TOOLS: ToolDef[] = [
       'conflict:ucdp-events:v1',
       'conflict:iran-events:v1',
       'unrest:events:v1',
-      'risk:scores:sebuf:stale:v7',
+      CII_RISK_SCORE_CACHE_KEYS.stale,
     ],
     _seedMetaKey: 'seed-meta:conflict:ucdp-events',
     _maxStaleMin: 30,

--- a/scripts/_cii-risk-cache-keys.mjs
+++ b/scripts/_cii-risk-cache-keys.mjs
@@ -1,0 +1,5 @@
+export const CII_RISK_SCORE_CACHE_KEYS = Object.freeze({
+  live: 'risk:scores:sebuf:v7',
+  stale: 'risk:scores:sebuf:stale:v7',
+  trendHistoryPrefix: 'risk:scores:sebuf:trend-history:v7',
+});

--- a/scripts/regional-snapshot/balance-vector.mjs
+++ b/scripts/regional-snapshot/balance-vector.mjs
@@ -5,6 +5,7 @@
 
 import { clip, num, weightedAverage, percentile } from './_helpers.mjs';
 import { sanitizeEvidenceString } from './_sanitize.mjs';
+import { CII_RISK_SCORE_CACHE_KEYS } from '../_cii-risk-cache-keys.mjs';
 // Use scripts/shared mirror (not repo-root shared/): Railway service has
 // rootDirectory=scripts so ../../shared/ escapes the deploy root. See #2954.
 import {
@@ -128,7 +129,7 @@ function computeCoercivePressure(region, sources, drivers) {
 }
 
 function computeDomesticFragility(countries, sources, drivers) {
-  const cii = sources['risk:scores:sebuf:stale:v7'];
+  const cii = sources[CII_RISK_SCORE_CACHE_KEYS.stale];
   const ciiScores = Array.isArray(cii?.ciiScores) ? cii.ciiScores : [];
   const inRegion = ciiScores.filter((s) => countries.has(String(s?.region ?? '')));
   if (!inRegion.length) return 0;

--- a/scripts/regional-snapshot/evidence-collector.mjs
+++ b/scripts/regional-snapshot/evidence-collector.mjs
@@ -5,6 +5,7 @@
 
 import { num } from './_helpers.mjs';
 import { sanitizeEvidenceString } from './_sanitize.mjs';
+import { CII_RISK_SCORE_CACHE_KEYS } from '../_cii-risk-cache-keys.mjs';
 // Use scripts/shared mirror (not repo-root shared/): Railway service has
 // rootDirectory=scripts so ../../shared/ escapes the deploy root. See #2954.
 import { REGIONS, getRegionCorridors, isSignalInRegion } from '../shared/geography.js';
@@ -44,7 +45,7 @@ export function collectEvidence(regionId, sources) {
   }
 
   // CII spikes for region countries
-  const cii = sources['risk:scores:sebuf:stale:v7']?.ciiScores;
+  const cii = sources[CII_RISK_SCORE_CACHE_KEYS.stale]?.ciiScores;
   if (Array.isArray(cii)) {
     const regionCountries = new Set(region.keyCountries);
     for (const c of cii) {

--- a/scripts/regional-snapshot/freshness.mjs
+++ b/scripts/regional-snapshot/freshness.mjs
@@ -6,6 +6,8 @@
 // The snapshot writer marks inputs as stale or missing based on this table
 // and feeds those flags into SnapshotMeta.snapshot_confidence.
 
+import { CII_RISK_SCORE_CACHE_KEYS } from '../_cii-risk-cache-keys.mjs';
+
 /**
  * @typedef {object} SourceFreshnessSpec
  * @property {string} key      - Redis key (literal, no template variables)
@@ -28,7 +30,7 @@
  * @type {SourceFreshnessSpec[]}
  */
 export const FRESHNESS_REGISTRY = [
-  { key: 'risk:scores:sebuf:stale:v7',          maxAgeMin: 30,    feedsAxes: ['domestic_fragility', 'coercive_pressure'], metaKey: 'seed-meta:intelligence:risk-scores' },
+  { key: CII_RISK_SCORE_CACHE_KEYS.stale,        maxAgeMin: 30,    feedsAxes: ['domestic_fragility', 'coercive_pressure'], metaKey: 'seed-meta:intelligence:risk-scores' },
   { key: 'forecast:predictions:v2',              maxAgeMin: 180,   feedsAxes: ['scenarios', 'actors'] },
   { key: 'supply_chain:chokepoints:v4',          maxAgeMin: 30,    feedsAxes: ['maritime_access', 'corridors'] },
   { key: 'supply_chain:transit-summaries:v1',    maxAgeMin: 30,    feedsAxes: ['maritime_access'], metaKey: 'seed-meta:supply_chain:transit-summaries' },

--- a/scripts/regional-snapshot/trigger-evaluator.mjs
+++ b/scripts/regional-snapshot/trigger-evaluator.mjs
@@ -4,6 +4,7 @@
 
 import { num } from './_helpers.mjs';
 import { TRIGGER_DEFS } from './triggers.config.mjs';
+import { CII_RISK_SCORE_CACHE_KEYS } from '../_cii-risk-cache-keys.mjs';
 
 /**
  * @param {string} regionId
@@ -87,7 +88,7 @@ function resolveMetric(metric, sources, balance, regionId) {
   if (metric.startsWith('cii:')) {
     const parts = metric.split(':');
     const [, iso] = parts;
-    const cii = sources['risk:scores:sebuf:stale:v7']?.ciiScores;
+    const cii = sources[CII_RISK_SCORE_CACHE_KEYS.stale]?.ciiScores;
     if (!Array.isArray(cii)) return null;
     const entry = cii.find((s) => s?.region === iso);
     return entry ? num(entry.combinedScore) : null;

--- a/scripts/seed-cross-source-signals.mjs
+++ b/scripts/seed-cross-source-signals.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { loadEnvFile, runSeed, getRedisCredentials } from './_seed-utils.mjs';
+import { CII_RISK_SCORE_CACHE_KEYS } from './_cii-risk-cache-keys.mjs';
 
 loadEnvFile(import.meta.url);
 
@@ -30,7 +31,7 @@ const SOURCE_KEYS = [
   'gdelt:intel:tone:nuclear',
   'gdelt:intel:tone:maritime',
   'weather:alerts:v1',
-  'risk:scores:sebuf:stale:v7',
+  CII_RISK_SCORE_CACHE_KEYS.stale,
   'regulatory:actions:v1',
 ];
 
@@ -694,7 +695,7 @@ function extractMediaToneDeterioration(d) {
 }
 
 function extractRiskScoreSpike(d) {
-  const payload = d['risk:scores:sebuf:stale:v7'];
+  const payload = d[CII_RISK_SCORE_CACHE_KEYS.stale];
   if (!payload) return [];
   const ciiScores = Array.isArray(payload.ciiScores) ? payload.ciiScores : [];
   const spiking = ciiScores.filter(s => safeNum(s.combinedScore) > 80 || s.trend === 'TREND_DIRECTION_RISING');

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -11,6 +11,7 @@ import { resolveR2StorageConfig, putR2JsonObject, getR2JsonObject } from './_r2-
 import { extractFirstJsonObject, extractFirstJsonArray, cleanJsonText } from './_llm-json.mjs';
 import { loadTickerSet } from './_ticker-validation.mjs';
 import { computeEmaWindows, computeRisk24h } from './_ema-threat-engine.mjs';
+import { CII_RISK_SCORE_CACHE_KEYS } from './_cii-risk-cache-keys.mjs';
 // Queue / outcome / runId constants live in the shared shim so the
 // HTTP-trigger handler (server/_shared/simulation-queue.ts) and this
 // seeder agree on the Redis schema. See #3734 + docs/plans/2026-05-18-
@@ -679,7 +680,7 @@ async function readInputKeys() {
   const { url, token } = getRedisCredentials();
   const fredKeys = FRED_MARKET_SERIES.map((seriesId) => FRED_MARKET_INPUT_KEYS[seriesId]);
   const keys = [
-    'risk:scores:sebuf:stale:v7',
+    CII_RISK_SCORE_CACHE_KEYS.stale,
     'temporal:anomalies:v1',
     'theater_posture:sebuf:stale:v1',
     'military:forecast-inputs:stale:v1',
@@ -764,7 +765,7 @@ async function readInputKeys() {
   );
 
   return {
-    ciiScores: parsedByKey['risk:scores:sebuf:stale:v7'],
+    ciiScores: parsedByKey[CII_RISK_SCORE_CACHE_KEYS.stale],
     temporalAnomalies: parsedByKey['temporal:anomalies:v1'],
     theaterPosture: parsedByKey['theater_posture:sebuf:stale:v1'],
     militaryForecastInputs: parsedByKey['military:forecast-inputs:stale:v1'],

--- a/server/_shared/cache-keys.ts
+++ b/server/_shared/cache-keys.ts
@@ -56,6 +56,16 @@ export const DIGEST_ACCUMULATOR_TTL = 172800; // 48h — lookback window for dig
 export const SIMULATION_OUTCOME_LATEST_KEY = 'forecast:simulation-outcome:latest';
 export const SIMULATION_PACKAGE_LATEST_KEY = 'forecast:simulation-package:latest';
 export const REGULATORY_ACTIONS_KEY = 'regulatory:actions:v1';
+
+/**
+ * CII risk-score payload key family. Keep runtime-local mirrors in
+ * api/_cii-risk-cache-keys.js and scripts/_cii-risk-cache-keys.mjs aligned.
+ */
+export const CII_RISK_SCORE_CACHE_KEYS = {
+  live: 'risk:scores:sebuf:v7',
+  stale: 'risk:scores:sebuf:stale:v7',
+  trendHistoryPrefix: 'risk:scores:sebuf:trend-history:v7',
+} as const;
 export const CLIMATE_ANOMALIES_KEY = 'climate:anomalies:v2';
 export const CLIMATE_AIR_QUALITY_KEY = 'climate:air-quality:v1';
 export const CLIMATE_ZONE_NORMALS_KEY = 'climate:zone-normals:v1';
@@ -174,7 +184,7 @@ export const BOOTSTRAP_CACHE_KEYS: Record<string, string> = {
   renewableEnergy:  'economic:worldbank-renewable:v1',
   positiveGeoEvents: 'positive_events:geo-bootstrap:v1',
   theaterPosture:   'theater_posture:sebuf:stale:v1',
-  riskScores:       'risk:scores:sebuf:stale:v7',
+  riskScores:       CII_RISK_SCORE_CACHE_KEYS.stale,
   naturalEvents:    'natural:events:v1',
   flightDelays:     'aviation:delays-bootstrap:v2',
   insights:         'news:insights:v1',

--- a/server/worldmonitor/intelligence/v1/brief-story-context.ts
+++ b/server/worldmonitor/intelligence/v1/brief-story-context.ts
@@ -17,6 +17,7 @@
  */
 
 import { getCachedJson } from '../../../_shared/redis';
+import { CII_RISK_SCORE_CACHE_KEYS } from '../../../_shared/cache-keys';
 
 import {
   buildWorldBrief,
@@ -69,7 +70,7 @@ export async function assembleBriefStoryContext(
     countryResult,
   ] = await Promise.allSettled([
     getCachedJson('news:insights:v1', true),
-    getCachedJson('risk:scores:sebuf:stale:v7', true),
+    getCachedJson(CII_RISK_SCORE_CACHE_KEYS.stale, true),
     getCachedJson('forecast:predictions:v2', true),
     getCachedJson('market:stocks-bootstrap:v1', true),
     getCachedJson('market:commodities-bootstrap:v1', true),

--- a/server/worldmonitor/intelligence/v1/chat-analyst-context.ts
+++ b/server/worldmonitor/intelligence/v1/chat-analyst-context.ts
@@ -19,6 +19,7 @@ import {
   SPR_POLICIES_KEY,
   REFINERY_INPUTS_KEY,
   ENERGY_SPINE_KEY_PREFIX,
+  CII_RISK_SCORE_CACHE_KEYS,
 } from '../../../_shared/cache-keys';
 
 // TODO: multi-language digest search — currently only queries news:digest:v1:full:en.
@@ -798,7 +799,7 @@ export async function assembleAnalystContext(
 ): Promise<AnalystContext> {
   const keys = {
     insights: 'news:insights:v1',
-    riskScores: 'risk:scores:sebuf:stale:v7',
+    riskScores: CII_RISK_SCORE_CACHE_KEYS.stale,
     marketImplications: 'intelligence:market-implications:v1',
     forecasts: 'forecast:predictions:v2',
     stocks: 'market:stocks-bootstrap:v1',

--- a/server/worldmonitor/intelligence/v1/get-country-risk.ts
+++ b/server/worldmonitor/intelligence/v1/get-country-risk.ts
@@ -6,9 +6,10 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/intelligence/v1/service_server';
 
 import { getCachedJson } from '../../../_shared/redis';
+import { CII_RISK_SCORE_CACHE_KEYS } from '../../../_shared/cache-keys';
 import { TIER1_COUNTRIES } from './_shared';
 
-const RISK_SCORES_KEY = 'risk:scores:sebuf:stale:v7';
+const RISK_SCORES_KEY = CII_RISK_SCORE_CACHE_KEYS.stale;
 const ADVISORIES_KEY = 'intelligence:advisories:v1';
 // Full ISO2 → entryCount map across all OFAC entries (not the top-12 summary slice).
 const SANCTIONS_COUNTS_KEY = 'sanctions:country-counts:v1';

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, resolve, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { CII_RISK_SCORE_CACHE_KEYS } from '../api/_cii-risk-cache-keys.js';
+import { __testing__ as healthTesting } from '../api/health.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
@@ -14,6 +16,14 @@ describe('Bootstrap cache key registry', () => {
 
   const cacheKeysBlock = cacheKeysSrc.match(/BOOTSTRAP_CACHE_KEYS[^{]*\{([^}]+)\}/)?.[1] ?? '';
 
+  const resolveCiiCacheKeyRef = (prop) => {
+    assert.ok(
+      Object.hasOwn(CII_RISK_SCORE_CACHE_KEYS, prop),
+      `Unknown CII_RISK_SCORE_CACHE_KEYS property '${prop}'`,
+    );
+    return CII_RISK_SCORE_CACHE_KEYS[prop];
+  };
+
   it('exports BOOTSTRAP_CACHE_KEYS with at least 10 entries', () => {
     const matches = cacheKeysBlock.match(/^\s+\w+:\s+'[^']+'/gm);
     assert.ok(matches && matches.length >= 10, `Expected ≥10 keys, found ${matches?.length ?? 0}`);
@@ -23,10 +33,12 @@ describe('Bootstrap cache key registry', () => {
     const extractKeys = (src) => {
       const block = src.match(/BOOTSTRAP_CACHE_KEYS[^=]*=\s*\{([^}]+)\}/);
       if (!block) return {};
-      const re = /(\w+):\s+'([a-z0-9_-]+(?::[a-z0-9_-]+)+)'/g;
+      const re = /(\w+):\s*(?:'([a-z0-9_-]+(?::[a-z0-9_-]+)+)'|CII_RISK_SCORE_CACHE_KEYS\.(\w+))/g;
       const keys = {};
       let m;
-      while ((m = re.exec(block[1])) !== null) keys[m[1]] = m[2];
+      while ((m = re.exec(block[1])) !== null) {
+        keys[m[1]] = m[2] ?? resolveCiiCacheKeyRef(m[3]);
+      }
       return keys;
     };
     const canonical = extractKeys(cacheKeysSrc);
@@ -41,11 +53,11 @@ describe('Bootstrap cache key registry', () => {
   });
 
   it('every cache key matches a handler cache key pattern', () => {
-    const keyRe = /:\s+'([^']+)'/g;
+    const keyRe = /:\s*(?:'([^']+)'|CII_RISK_SCORE_CACHE_KEYS\.(\w+))/g;
     let m;
     const keys = [];
     while ((m = keyRe.exec(cacheKeysBlock)) !== null) {
-      keys.push(m[1]);
+      keys.push(m[1] ?? resolveCiiCacheKeyRef(m[2]));
     }
     for (const key of keys) {
       assert.match(key, /^[a-z0-9_-]+(?::[a-z0-9_-]+)+(?::v\d+)?(?::[a-z0-9_-]+)*$/, `Cache key "${key}" does not match expected pattern`);
@@ -53,11 +65,11 @@ describe('Bootstrap cache key registry', () => {
   });
 
   it('has no duplicate cache keys', () => {
-    const keyRe = /:\s+'([^']+)'/g;
+    const keyRe = /:\s*(?:'([^']+)'|CII_RISK_SCORE_CACHE_KEYS\.(\w+))/g;
     let m;
     const keys = [];
     while ((m = keyRe.exec(cacheKeysBlock)) !== null) {
-      keys.push(m[1]);
+      keys.push(m[1] ?? resolveCiiCacheKeyRef(m[2]));
     }
     const unique = new Set(keys);
     assert.equal(unique.size, keys.length, `Found duplicate cache keys: ${keys.filter((k, i) => keys.indexOf(k) !== i)}`);
@@ -240,7 +252,7 @@ describe('Bootstrap key hydration coverage', () => {
   it('every bootstrap key has a getHydratedData consumer in src/', () => {
     const bootstrapSrc = readFileSync(join(root, 'api', 'bootstrap.js'), 'utf-8');
     const block = bootstrapSrc.match(/BOOTSTRAP_CACHE_KEYS\s*=\s*\{([^}]+)\}/);
-    const keyRe = /(\w+):\s+'[a-z0-9_-]+(?::[a-z0-9_-]+)+'/g;
+    const keyRe = /(\w+):\s*(?:'[a-z0-9_-]+(?::[a-z0-9_-]+)+'|CII_RISK_SCORE_CACHE_KEYS\.\w+)/g;
     const keys = [];
     let m;
     while ((m = keyRe.exec(block[1])) !== null) keys.push(m[1]);
@@ -285,15 +297,8 @@ describe('Bootstrap key hydration coverage', () => {
 
 describe('Health key registries', () => {
   it('does not duplicate Redis keys across BOOTSTRAP_KEYS and STANDALONE_KEYS', () => {
-    const healthSrc = readFileSync(join(root, 'api', 'health.js'), 'utf-8');
-    const extractValues = (name) => {
-      const block = healthSrc.match(new RegExp(`${name}\\s*=\\s*\\{([\\s\\S]*?)\\n\\};`));
-      if (!block) return [];
-      return [...block[1].matchAll(/:\s+'([^']+)'/g)].map((m) => m[1]);
-    };
-
-    const bootstrap = new Set(extractValues('BOOTSTRAP_KEYS'));
-    const standalone = new Set(extractValues('STANDALONE_KEYS'));
+    const bootstrap = new Set(Object.values(healthTesting.BOOTSTRAP_KEYS));
+    const standalone = new Set(Object.values(healthTesting.STANDALONE_KEYS));
     const overlap = [...bootstrap].filter((key) => standalone.has(key));
 
     assert.deepEqual(overlap, [], `health.js duplicates keys across registries: ${overlap.join(', ')}`);
@@ -314,7 +319,7 @@ describe('Bootstrap tier definitions', () => {
   function extractBootstrapKeys(src) {
     const block = src.match(/BOOTSTRAP_CACHE_KEYS\s*=\s*\{([^}]+)\}/);
     if (!block) return new Set();
-    return new Set([...block[1].matchAll(/(\w+):\s+'/g)].map(x => x[1]));
+    return new Set([...block[1].matchAll(/(\w+):\s*(?:'|CII_RISK_SCORE_CACHE_KEYS\.)/g)].map(x => x[1]));
   }
 
   function extractTierKeys(src) {

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -1775,30 +1775,50 @@ describe('CII scoring', () => {
     const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
     const expectedLiveKey = `risk:scores:sebuf:${CII_FORMULA_VERSION}`;
     const expectedStaleKey = `risk:scores:sebuf:stale:${CII_FORMULA_VERSION}`;
-    const keyPattern = /risk:scores:sebuf(?::stale)?:v\d+/g;
-    const consumers: Array<{ relPath: string; expectedKeys: string[] }> = [
-      { relPath: 'api/bootstrap.js', expectedKeys: [expectedStaleKey] },
-      { relPath: 'api/health.js', expectedKeys: [expectedStaleKey, expectedLiveKey] },
-      { relPath: 'api/mcp/registry/cache-tools.ts', expectedKeys: [expectedStaleKey] },
-      { relPath: 'server/_shared/cache-keys.ts', expectedKeys: [expectedStaleKey] },
-      { relPath: 'server/worldmonitor/intelligence/v1/brief-story-context.ts', expectedKeys: [expectedStaleKey] },
-      { relPath: 'server/worldmonitor/intelligence/v1/chat-analyst-context.ts', expectedKeys: [expectedStaleKey] },
-      { relPath: 'server/worldmonitor/intelligence/v1/get-country-risk.ts', expectedKeys: [expectedStaleKey] },
-      { relPath: 'scripts/seed-cross-source-signals.mjs', expectedKeys: [expectedStaleKey] },
-      { relPath: 'scripts/seed-forecasts.mjs', expectedKeys: [expectedStaleKey] },
-      { relPath: 'scripts/regional-snapshot/balance-vector.mjs', expectedKeys: [expectedStaleKey] },
-      { relPath: 'scripts/regional-snapshot/evidence-collector.mjs', expectedKeys: [expectedStaleKey] },
-      { relPath: 'scripts/regional-snapshot/freshness.mjs', expectedKeys: [expectedStaleKey] },
-      { relPath: 'scripts/regional-snapshot/trigger-evaluator.mjs', expectedKeys: [expectedStaleKey] },
-      { relPath: 'tests/mcp-bootstrap-parity.test.mjs', expectedKeys: [expectedLiveKey, expectedStaleKey] },
-      { relPath: 'tests/regional-snapshot.test.mjs', expectedKeys: [expectedStaleKey] },
+    const expectedTrendPrefix = `risk:scores:sebuf:trend-history:${CII_FORMULA_VERSION}`;
+    const keyPattern = /risk:scores:sebuf(?::(?:stale|trend-history))?:v\d+/g;
+    const consumers: Array<{ relPath: string; expectedKeys?: string[]; expectedRefs?: string[] }> = [
+      {
+        relPath: 'api/_cii-risk-cache-keys.js',
+        expectedKeys: [expectedLiveKey, expectedStaleKey, expectedTrendPrefix],
+      },
+      {
+        relPath: 'api/_cii-risk-cache-keys.d.ts',
+        expectedKeys: [expectedLiveKey, expectedStaleKey, expectedTrendPrefix],
+      },
+      {
+        relPath: 'scripts/_cii-risk-cache-keys.mjs',
+        expectedKeys: [expectedLiveKey, expectedStaleKey, expectedTrendPrefix],
+      },
+      {
+        relPath: 'server/_shared/cache-keys.ts',
+        expectedKeys: [expectedLiveKey, expectedStaleKey, expectedTrendPrefix],
+        expectedRefs: ['riskScores:       CII_RISK_SCORE_CACHE_KEYS.stale'],
+      },
+      { relPath: 'api/bootstrap.js', expectedRefs: ['CII_RISK_SCORE_CACHE_KEYS.stale'] },
+      { relPath: 'api/health.js', expectedRefs: ['CII_RISK_SCORE_CACHE_KEYS.stale', 'CII_RISK_SCORE_CACHE_KEYS.live'] },
+      { relPath: 'api/mcp/registry/cache-tools.ts', expectedRefs: ['CII_RISK_SCORE_CACHE_KEYS.stale'] },
+      { relPath: 'server/worldmonitor/intelligence/v1/brief-story-context.ts', expectedRefs: ['CII_RISK_SCORE_CACHE_KEYS.stale'] },
+      { relPath: 'server/worldmonitor/intelligence/v1/chat-analyst-context.ts', expectedRefs: ['CII_RISK_SCORE_CACHE_KEYS.stale'] },
+      { relPath: 'server/worldmonitor/intelligence/v1/get-country-risk.ts', expectedRefs: ['CII_RISK_SCORE_CACHE_KEYS.stale'] },
+      { relPath: 'scripts/seed-cross-source-signals.mjs', expectedRefs: ['CII_RISK_SCORE_CACHE_KEYS.stale'] },
+      { relPath: 'scripts/seed-forecasts.mjs', expectedRefs: ['CII_RISK_SCORE_CACHE_KEYS.stale'] },
+      { relPath: 'scripts/regional-snapshot/balance-vector.mjs', expectedRefs: ['CII_RISK_SCORE_CACHE_KEYS.stale'] },
+      { relPath: 'scripts/regional-snapshot/evidence-collector.mjs', expectedRefs: ['CII_RISK_SCORE_CACHE_KEYS.stale'] },
+      { relPath: 'scripts/regional-snapshot/freshness.mjs', expectedRefs: ['CII_RISK_SCORE_CACHE_KEYS.stale'] },
+      { relPath: 'scripts/regional-snapshot/trigger-evaluator.mjs', expectedRefs: ['CII_RISK_SCORE_CACHE_KEYS.stale'] },
+      { relPath: 'tests/mcp-bootstrap-parity.test.mjs', expectedRefs: ['CII_RISK_SCORE_CACHE_KEYS.live', 'CII_RISK_SCORE_CACHE_KEYS.stale'] },
+      { relPath: 'tests/regional-snapshot.test.mjs', expectedRefs: ['CII_RISK_SCORE_CACHE_KEYS.stale'] },
     ];
 
     const violations: string[] = [];
-    for (const { relPath, expectedKeys } of consumers) {
+    for (const { relPath, expectedKeys = [], expectedRefs = [] } of consumers) {
       const source = readFileSync(resolve(root, relPath), 'utf8');
       for (const expectedKey of expectedKeys) {
         if (!source.includes(expectedKey)) violations.push(`${relPath}: missing ${expectedKey}`);
+      }
+      for (const expectedRef of expectedRefs) {
+        if (!source.includes(expectedRef)) violations.push(`${relPath}: missing ${expectedRef}`);
       }
       for (const match of source.matchAll(keyPattern)) {
         if (!expectedKeys.includes(match[0])) violations.push(`${relPath}: stale ${match[0]}`);

--- a/tests/cross-source-signals-regulatory.test.mjs
+++ b/tests/cross-source-signals-regulatory.test.mjs
@@ -2,6 +2,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import vm from 'node:vm';
+import { CII_RISK_SCORE_CACHE_KEYS } from '../scripts/_cii-risk-cache-keys.mjs';
 
 function normalize(value) {
   return JSON.parse(JSON.stringify(value));
@@ -19,7 +20,7 @@ const pureSrc = seedSrc
   // body still evaluates as a plain declaration.
   .replace(/^export\s+(function\s+declareRecords)/m, '$1');
 
-const ctx = vm.createContext({ console, Date, Math, Number, Array, Map, Set, String, RegExp });
+const ctx = vm.createContext({ console, Date, Math, Number, Array, Map, Set, String, RegExp, CII_RISK_SCORE_CACHE_KEYS });
 vm.runInContext(`${pureSrc}\n;globalThis.__exports = { SOURCE_KEYS, TYPE_CATEGORY, BASE_WEIGHT, scoreTier, extractRegulatoryAction, detectCompositeEscalation };`, ctx);
 
 const {

--- a/tests/mcp-bootstrap-parity.test.mjs
+++ b/tests/mcp-bootstrap-parity.test.mjs
@@ -15,6 +15,7 @@ import assert from 'node:assert/strict';
 
 import { __testing__ as healthTesting } from '../api/health.js';
 import { __testing__ as mcpTesting } from '../api/mcp.ts';
+import { CII_RISK_SCORE_CACHE_KEYS } from '../api/_cii-risk-cache-keys.js';
 
 const { BOOTSTRAP_KEYS, STANDALONE_KEYS } = healthTesting;
 const { TOOL_REGISTRY } = mcpTesting;
@@ -55,8 +56,8 @@ const EXCLUDED_FROM_MCP = new Map([
     'cascade-mirror: live counterpart of theater_posture:sebuf:stale:v1 (covered by get_military_posture). CASCADE_GROUPS theaterPosture entry.'],
   ['theater-posture:sebuf:backup:v1',
     'cascade-mirror: backup counterpart of theater_posture:sebuf:stale:v1 (covered by get_military_posture). CASCADE_GROUPS theaterPosture entry.'],
-  ['risk:scores:sebuf:v7',
-    'cascade-mirror: live counterpart of risk:scores:sebuf:stale:v7 (covered by get_conflict_events).'],
+  [CII_RISK_SCORE_CACHE_KEYS.live,
+    `cascade-mirror: live counterpart of ${CII_RISK_SCORE_CACHE_KEYS.stale} (covered by get_conflict_events).`],
   ['military:flights:v1',
     'cascade-mirror: live counterpart of military:flights:stale:v1 — deferred to a future expanded military tool (no current tool exposes either variant).'],
   ['military:flights:stale:v1',

--- a/tests/redis-caching.test.mjs
+++ b/tests/redis-caching.test.mjs
@@ -803,6 +803,7 @@ describe('country risk freshness behavior', { concurrency: 1 }, () => {
     return importPatchedTsModule('server/worldmonitor/intelligence/v1/get-country-risk.ts', {
       './_shared': resolve(root, 'server/worldmonitor/intelligence/v1/_shared.ts'),
       '../../../_shared/redis': resolve(root, 'server/_shared/redis.ts'),
+      '../../../_shared/cache-keys': resolve(root, 'server/_shared/cache-keys.ts'),
     });
   }
 

--- a/tests/regional-snapshot.test.mjs
+++ b/tests/regional-snapshot.test.mjs
@@ -28,6 +28,7 @@ import { resolveTransmissions, TEMPLATE_VERSION } from '../scripts/regional-snap
 import { collectEvidence } from '../scripts/regional-snapshot/evidence-collector.mjs';
 import { buildPreMeta, buildFinalMeta, MODEL_VERSION } from '../scripts/regional-snapshot/snapshot-meta.mjs';
 import { diffRegionalSnapshot, inferTriggerReason } from '../scripts/regional-snapshot/diff-snapshot.mjs';
+import { CII_RISK_SCORE_CACHE_KEYS } from '../scripts/_cii-risk-cache-keys.mjs';
 import { generateSnapshotId, clip, percentile } from '../scripts/regional-snapshot/_helpers.mjs';
 import { classifyInputs, FRESHNESS_REGISTRY } from '../scripts/regional-snapshot/freshness.mjs';
 
@@ -202,7 +203,7 @@ describe('helpers', () => {
 // ────────────────────────────────────────────────────────────────────────────
 
 const baseSources = () => ({
-  'risk:scores:sebuf:stale:v7': {
+  [CII_RISK_SCORE_CACHE_KEYS.stale]: {
     ciiScores: [
       { region: 'IR', combinedScore: 65, trend: 'TREND_DIRECTION_UP' },
       { region: 'IL', combinedScore: 55, trend: 'TREND_DIRECTION_STABLE' },
@@ -281,7 +282,7 @@ describe('computeBalanceVector', () => {
 
   it('weighted-tail domestic fragility amplifies high-criticality countries', () => {
     const sources = {
-      'risk:scores:sebuf:stale:v7': {
+      [CII_RISK_SCORE_CACHE_KEYS.stale]: {
         ciiScores: [
           // Low CII for low-criticality countries
           { region: 'JO', combinedScore: 10 },
@@ -549,9 +550,9 @@ describe('snapshot meta', () => {
 
   it('buildPreMeta marks stale inputs based on max-age', () => {
     const old = { fetchedAt: Date.now() - 999_999_999 };
-    const sources = { 'risk:scores:sebuf:stale:v7': old };
+    const sources = { [CII_RISK_SCORE_CACHE_KEYS.stale]: old };
     const { pre } = buildPreMeta(sources, '1.0.0', '1.0.0');
-    assert.ok(pre.stale_inputs.includes('risk:scores:sebuf:stale:v7'));
+    assert.ok(pre.stale_inputs.includes(CII_RISK_SCORE_CACHE_KEYS.stale));
   });
 
   it('buildFinalMeta merges pre + finalFields preserving snapshot_id', () => {
@@ -572,16 +573,16 @@ describe('snapshot meta', () => {
   // snapshot_confidence whenever an upstream seeder stalled without a
   // timestamp. Flipped to stale so the confidence score reflects reality.
   it('buildPreMeta treats present-but-undated inputs as stale (#3728)', () => {
-    // risk:scores:sebuf:stale:v7 has no metaKey and the payload below has
+    // CII stale scores rely on seed-meta freshness; the payload below has
     // no parseable timestamp field — exactly the case that used to slip
     // through as "fresh".
     const { pre } = buildPreMeta(
-      { 'risk:scores:sebuf:stale:v7': { ciiScores: [] } },
+      { [CII_RISK_SCORE_CACHE_KEYS.stale]: { ciiScores: [] } },
       '1.0.0',
       '1.0.0',
     );
     assert.ok(
-      pre.stale_inputs.includes('risk:scores:sebuf:stale:v7'),
+      pre.stale_inputs.includes(CII_RISK_SCORE_CACHE_KEYS.stale),
       'undated payload should land in stale_inputs, not be silently treated as fresh',
     );
   });
@@ -591,12 +592,12 @@ describe('snapshot meta', () => {
   // old would advertise validity 5.7 hours past the point where its
   // upstream input goes stale. Derive from the registry instead.
   it('valid_until reflects oldest fresh input TTL (#3728)', () => {
-    // risk:scores:sebuf:stale:v7 has maxAgeMin=30. With fetchedAt=20min
+    // CII stale scores have maxAgeMin=30. With fetchedAt=20min
     // ago, the input expires in ~10min, well before the 6h cap.
     const now = Date.now();
     const fetchedAt = now - 20 * 60_000;
     const { pre } = buildPreMeta(
-      { 'risk:scores:sebuf:stale:v7': { ciiScores: [], fetchedAt } },
+      { [CII_RISK_SCORE_CACHE_KEYS.stale]: { ciiScores: [], fetchedAt } },
       '1.0.0',
       '1.0.0',
     );
@@ -699,7 +700,7 @@ describe('snapshot meta', () => {
   // metaKey hint (or the companion key going missing) would re-introduce
   // the on-deploy STALE noise this PR removes.
   for (const [inputKey, metaKey] of [
-    ['risk:scores:sebuf:stale:v7',          'seed-meta:intelligence:risk-scores'],
+    [CII_RISK_SCORE_CACHE_KEYS.stale,        'seed-meta:intelligence:risk-scores'],
     ['intelligence:cross-source-signals:v1', 'seed-meta:intelligence:cross-source-signals'],
     ['energy:mix:v1:_all',                   'seed-meta:economic:owid-energy-mix'],
     ['supply_chain:transit-summaries:v1',    'seed-meta:supply_chain:transit-summaries'],
@@ -732,7 +733,7 @@ describe('snapshot meta', () => {
     // entry points at an existing seed-meta:* companion. Lock the wiring
     // in so a later removal will trip a test, not production.
     const expected = {
-      'risk:scores:sebuf:stale:v7':          'seed-meta:intelligence:risk-scores',
+      [CII_RISK_SCORE_CACHE_KEYS.stale]:      'seed-meta:intelligence:risk-scores',
       'intelligence:cross-source-signals:v1': 'seed-meta:intelligence:cross-source-signals',
       'energy:mix:v1:_all':                   'seed-meta:economic:owid-energy-mix',
       'supply_chain:transit-summaries:v1':    'seed-meta:supply_chain:transit-summaries',
@@ -1030,7 +1031,7 @@ describe('writer-side XSS hardening (issue #3730)', () => {
         },
       ],
     },
-    'risk:scores:sebuf:stale:v7': {
+    [CII_RISK_SCORE_CACHE_KEYS.stale]: {
       ciiScores: [
         { region: 'IR', combinedScore: 75, trend: `RISING${IMG_XSS}`, computedAt: Date.now() },
       ],


### PR DESCRIPTION
## Summary
- add runtime-local CII risk-score cache-key helpers for Edge API, server TypeScript, and Node seed/regional scripts
- route downstream CII live/stale/trend cache-key consumers through those helpers without changing v7 key values
- strengthen drift/parity tests so helper-valued keys stay covered across bootstrap, health, MCP, and regional snapshot paths

## Validation
- ./node_modules/.bin/tsx --test tests/bootstrap.test.mjs
- ./node_modules/.bin/tsx --test tests/cii-scoring.test.mts tests/mcp-bootstrap-parity.test.mjs tests/regional-snapshot.test.mjs tests/seed-health-risk-scores.test.mjs tests/health-classify.test.mjs
- npm run typecheck:api
- git diff --check
- pre-push hook on git push, including typecheck, typecheck:api, Convex, CJS, Unicode, boundaries, safe HTML, Sentry coverage, rate-limit policies, premium-fetch parity, edge bundle/tests, changed tests, markdown/MDX/proto/pro-test skips, and version sync

## Notes
- No CII_FORMULA_VERSION bump; score semantics are unchanged.
- The same-runtime helper split preserves Edge/API constraints instead of importing server code into api/*.js.