### PR TITLE
fix(reddit-relay): sanitize SCRAPECREATORS_API_KEY against pasted smart quotes

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -5775,7 +5775,18 @@ const REDDIT_AUTH_COOLDOWN_MS = 5 * 60 * 1000;
 // Policy 2026). Returns native Reddit fields in a flat `posts` array, so the
 // downstream consumers are unchanged. When unset, the relay falls back to OAuth
 // (pre-policy creds only) then the public endpoint — today's behavior, no regression.
-const SCRAPECREATORS_API_KEY = process.env.SCRAPECREATORS_API_KEY || '';
+// Sanitize: trim whitespace and strip surrounding quotes — straight AND curly
+// (U+2018/U+2019/U+201C/U+201D). A smart-quote pasted into the env var makes the
+// `x-api-key` header un-encodable ("Cannot convert argument to a ByteString …
+// value 8221") which throws on EVERY fetch and silently disables the vendor path
+// (observed in prod 2026-06-06). Stripping surrounding quotes makes the common
+// paste mistake harmless; a clear warning fires if a non-Latin1 byte survives.
+const SCRAPECREATORS_API_KEY = (process.env.SCRAPECREATORS_API_KEY || '')
+  .trim()
+  .replace(/^[\s"'‘’“”]+|[\s"'‘’“”]+$/g, '');
+if (SCRAPECREATORS_API_KEY && /[^ -ÿ]/.test(SCRAPECREATORS_API_KEY)) {
+  console.warn('[Reddit] SCRAPECREATORS_API_KEY contains a non-Latin1 character (likely a smart quote or stray Unicode) — the vendor path will fail to build its header. Re-paste the key as plain ASCII.');
+}
 const SCRAPECREATORS_ENABLED = !!SCRAPECREATORS_API_KEY;
 // The SC subreddit endpoint has no `limit` param — only `after` cursor pagination.
 // Cap the page walk so a caller asking for `limit` posts can't run away on credits

--- a/tests/reddit-oauth-fetch.test.mjs
+++ b/tests/reddit-oauth-fetch.test.mjs
@@ -57,7 +57,10 @@ test('shared helper prefers oauth.reddit.com and falls back to the public endpoi
 });
 
 test('ScrapeCreators is the gated, preferred path with bounded cursor pagination (no limit param)', () => {
-  assert.match(relaySource, /const SCRAPECREATORS_API_KEY = process\.env\.SCRAPECREATORS_API_KEY \|\| ''/);
+  assert.match(relaySource, /const SCRAPECREATORS_API_KEY = \(process\.env\.SCRAPECREATORS_API_KEY \|\| ''\)/);
+  assert.match(relaySource, /\.trim\(\)/);
+  assert.match(relaySource, /\.replace\(\/\^\[\\s"'‘’“”\]\+\|\[\\s"'‘’“”\]\+\$\/g, ''\)/);
+  assert.match(relaySource, /non-Latin1 character/);
   assert.match(relaySource, /const SCRAPECREATORS_ENABLED = !!SCRAPECREATORS_API_KEY/);
   assert.match(relaySource, /const SC_MAX_PAGES = 4/);
   const body = fnBody('async function fetchRedditHotListing(subreddit', 5200);

--- a/tests/reddit-oauth-fetch.test.mjs
+++ b/tests/reddit-oauth-fetch.test.mjs
@@ -57,10 +57,10 @@ test('shared helper prefers oauth.reddit.com and falls back to the public endpoi
 });
 
 test('ScrapeCreators is the gated, preferred path with bounded cursor pagination (no limit param)', () => {
-  assert.match(relaySource, /const SCRAPECREATORS_API_KEY = \(process\.env\.SCRAPECREATORS_API_KEY \|\| ''\)/);
-  assert.match(relaySource, /\.trim\(\)/);
-  assert.match(relaySource, /\.replace\(\/\^\[\\s"'‘’“”\]\+\|\[\\s"'‘’“”\]\+\$\/g, ''\)/);
-  assert.match(relaySource, /non-Latin1 character/);
+  assert.match(
+    relaySource,
+    /const SCRAPECREATORS_API_KEY = \(process\.env\.SCRAPECREATORS_API_KEY \|\| ''\)\n\s+\.trim\(\)\n\s+\.replace\(\/\^\[\\s"'‘’“”\]\+\|\[\\s"'‘’“”\]\+\$\/g, ''\);\nif \(SCRAPECREATORS_API_KEY && [^\n]+\) \{\n\s+console\.warn\('[^']*non-Latin1 character/
+  );
   assert.match(relaySource, /const SCRAPECREATORS_ENABLED = !!SCRAPECREATORS_API_KEY/);
   assert.match(relaySource, /const SC_MAX_PAGES = 4/);
   const body = fnBody('async function fetchRedditHotListing(subreddit', 5200);


### PR DESCRIPTION
## Summary

The relay (`scripts/ais-relay.cjs`) read `SCRAPECREATORS_API_KEY` and used it raw as the `x-api-key` header in `fetchRedditHotListing`. A smart/curly quote pasted into the env var (prod had **U+201D ” at index 29** on 2026-06-06) makes the header value un-encodable — Node/undici throws:

```
Cannot convert argument to a ByteString because the character at index 29
has a value of 8221 which is greater than 255
```

This throws on **every** ScrapeCreators fetch. The error is swallowed by the SC try/catch and falls through to the (currently 403-walled) public Reddit endpoint, **silently disabling the preferred vendor path for ALL subreddits** — the relay logged this for all 5 subs.

### Fix
- Trim whitespace and strip surrounding quotes — straight (`"`/`'`) AND curly (U+2018/U+2019/U+201C/U+201D) — so the common copy-paste mistake is harmless.
- Emit a clear `console.warn` if a non-Latin1 byte survives, so a malformed key is diagnosable instead of silently disabling the vendor path.

Scope: only `scripts/ais-relay.cjs` + `tests/reddit-oauth-fetch.test.mjs`.

## Test plan
- `node --check scripts/ais-relay.cjs` — passes
- `npx tsx --test tests/reddit-oauth-fetch.test.mjs` — all 12 green (existing "ScrapeCreators is the gated, preferred path…" test updated to assert the new sanitization: `(process.env… || '')`, `.trim()`, the quote-stripping `.replace(…)`, and the `non-Latin1 character` warning).
- `npm run typecheck` — clean.