### PR TITLE
fix(seed-forecasts): surface market-implications LLM failures as SEED_ERROR

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -15976,6 +15976,39 @@ function validateMarketImplications(cards, allowedTickers = ALL_ALLOWED_TICKERS)
   return valid;
 }
 
+const MARKET_IMPLICATIONS_META_KEY = 'seed-meta:intelligence:market-implications';
+const MARKET_IMPLICATIONS_META_TTL = 86400 * 7;
+
+function marketImplicationsMetaErrorReason(reason) {
+  return String(reason || 'unknown').replace(/\s+/g, ' ').slice(0, 240);
+}
+
+// Surface a producer-side LLM failure to /api/health instead of silently
+// returning. Without this the success-only seed-meta write freezes at the
+// last-good fetchedAt; the canonical key then TTLs out and health reports
+// `marketImplications: EMPTY` — indistinguishable from a stopped cron. Writing
+// a `status:'error'` seed-meta makes api/health.js classifyKey emit SEED_ERROR
+// (warn: producer failing) per the socialVelocity precedent (PR #4084). We also
+// re-EXPIRE the canonical key so the last-good cards survive while the LLM step
+// retries on the next cron, rather than expiring to EMPTY mid-outage.
+async function writeMarketImplicationsFailureMeta(reason) {
+  const { url, token } = getRedisCredentials();
+  const meta = {
+    fetchedAt: Date.now(),
+    recordCount: 0,
+    status: 'error',
+    errorReason: marketImplicationsMetaErrorReason(reason),
+  };
+  await redisSet(url, token, MARKET_IMPLICATIONS_META_KEY, meta, MARKET_IMPLICATIONS_META_TTL);
+  // EXPIRE is a best-effort last-good preservation hint — failure here only
+  // shortens how long stale cards linger, it never loses the error signal above.
+  try {
+    await redisCommand(url, token, ['EXPIRE', MARKET_IMPLICATIONS_KEY, String(MARKET_IMPLICATIONS_TTL)]);
+  } catch (err) {
+    console.warn(`  [MarketImplications] last-good EXPIRE refresh failed: ${err.message}`);
+  }
+}
+
 async function buildAndSeedMarketImplications(inputs) {
   const startMs = Date.now();
   console.log('  [MarketImplications] Building world-state context...');
@@ -15991,7 +16024,8 @@ async function buildAndSeedMarketImplications(inputs) {
   });
 
   if (!result?.text) {
-    console.warn('  [MarketImplications] LLM returned no response — skipping write');
+    console.warn('  [MarketImplications] LLM returned no response — writing error seed-meta');
+    await writeMarketImplicationsFailureMeta('llm_no_response');
     return;
   }
 
@@ -16000,6 +16034,7 @@ async function buildAndSeedMarketImplications(inputs) {
 
   if (!Array.isArray(rawCards) || rawCards.length === 0) {
     console.warn(`  [MarketImplications] No parseable cards in LLM response (diagnostics: ${JSON.stringify(parsed.diagnostics)})`);
+    await writeMarketImplicationsFailureMeta('no_parseable_cards');
     return;
   }
 
@@ -16026,7 +16061,8 @@ async function buildAndSeedMarketImplications(inputs) {
 
   const cards = validateMarketImplications(rawCards, effectiveTickers);
   if (cards.length === 0) {
-    console.warn('  [MarketImplications] All cards failed validation — skipping write');
+    console.warn('  [MarketImplications] All cards failed validation — writing error seed-meta');
+    await writeMarketImplicationsFailureMeta('all_cards_failed_validation');
     return;
   }
   if (cards.length < rawCards.length) {
@@ -16036,9 +16072,8 @@ async function buildAndSeedMarketImplications(inputs) {
   const payload = { cards, generatedAt: new Date().toISOString(), model: result.model || '' };
   await redisSet(url, token, MARKET_IMPLICATIONS_KEY, payload, MARKET_IMPLICATIONS_TTL);
 
-  const metaKey = 'seed-meta:intelligence:market-implications';
-  const meta = { fetchedAt: Date.now(), recordCount: cards.length };
-  await redisSet(url, token, metaKey, meta, 86400 * 7);
+  const meta = { fetchedAt: Date.now(), recordCount: cards.length, status: 'ok' };
+  await redisSet(url, token, MARKET_IMPLICATIONS_META_KEY, meta, MARKET_IMPLICATIONS_META_TTL);
 
   const durationMs = Date.now() - startMs;
   console.log(`  [MarketImplications] Published ${cards.length} cards to ${MARKET_IMPLICATIONS_KEY} (${Math.round(durationMs)}ms, model=${result.model || 'unknown'})`);

--- a/tests/market-implications-seed-health.test.mjs
+++ b/tests/market-implications-seed-health.test.mjs
@@ -1,0 +1,69 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const seederSource = readFileSync(resolve(here, '../scripts/seed-forecasts.mjs'), 'utf8');
+
+function sourceBetween(start, end) {
+  const startIndex = seederSource.indexOf(start);
+  assert.notEqual(startIndex, -1, `missing source marker: ${start}`);
+  const endIndex = seederSource.indexOf(end, startIndex);
+  assert.notEqual(endIndex, -1, `missing source marker: ${end}`);
+  return seederSource.slice(startIndex, endIndex);
+}
+
+test('market implications defines an error seed-meta writer keyed for /api/health', () => {
+  assert.match(
+    seederSource,
+    /const MARKET_IMPLICATIONS_META_KEY = 'seed-meta:intelligence:market-implications'/,
+    'meta key must match api/health.js SEED_META.marketImplications',
+  );
+  assert.match(seederSource, /async function writeMarketImplicationsFailureMeta\(reason\)/);
+
+  const writerRegion = sourceBetween(
+    'async function writeMarketImplicationsFailureMeta(reason)',
+    'async function buildAndSeedMarketImplications(inputs)',
+  );
+  // status:'error' is what api/health.js readSeedMeta promotes to seedError ->
+  // classifyKey emits SEED_ERROR (warn) instead of a silently-frozen EMPTY.
+  assert.match(writerRegion, /status: 'error'/);
+  assert.match(writerRegion, /errorReason: marketImplicationsMetaErrorReason\(reason\)/);
+  assert.match(writerRegion, /recordCount: 0/);
+  // Last-good canonical cards are preserved across the LLM outage via EXPIRE.
+  assert.match(writerRegion, /\['EXPIRE', MARKET_IMPLICATIONS_KEY, String\(MARKET_IMPLICATIONS_TTL\)\]/);
+});
+
+test('all three LLM-failure guards write an error seed-meta before returning', () => {
+  const buildRegion = sourceBetween(
+    'async function buildAndSeedMarketImplications(inputs)',
+    'export function declareRecords(data)',
+  );
+
+  // Guard 1: LLM returned no response.
+  assert.match(
+    buildRegion,
+    /if \(!result\?\.text\) \{[\s\S]*?await writeMarketImplicationsFailureMeta\('llm_no_response'\);\s*return;/,
+  );
+  // Guard 2: no parseable cards.
+  assert.match(
+    buildRegion,
+    /rawCards\.length === 0\) \{[\s\S]*?await writeMarketImplicationsFailureMeta\('no_parseable_cards'\);\s*return;/,
+  );
+  // Guard 3: all cards failed validation.
+  assert.match(
+    buildRegion,
+    /cards\.length === 0\) \{[\s\S]*?await writeMarketImplicationsFailureMeta\('all_cards_failed_validation'\);\s*return;/,
+  );
+});
+
+test('market implications success path still writes a healthy seed-meta', () => {
+  const buildRegion = sourceBetween(
+    'async function buildAndSeedMarketImplications(inputs)',
+    'export function declareRecords(data)',
+  );
+  assert.match(buildRegion, /recordCount: cards\.length, status: 'ok'/);
+  assert.match(buildRegion, /await redisSet\(url, token, MARKET_IMPLICATIONS_META_KEY, meta, MARKET_IMPLICATIONS_META_TTL\)/);
+});


### PR DESCRIPTION
## Summary

`/api/health` was reporting `marketImplications: EMPTY` (crit) with **no signal that the producer was failing**. Root cause: `buildAndSeedMarketImplications` in `scripts/seed-forecasts.mjs` writes its seed-meta only on full success (generate → parse → validate). Its three LLM-failure guards each just `return`ed:

1. `if (!result?.text)` — LLM returned no response
2. `rawCards.length === 0` — no parseable cards
3. `cards.length === 0` — all cards failed validation

On any LLM failure (e.g. OpenRouter credits exhausted) the seed-meta `seed-meta:intelligence:market-implications` stays **frozen at the last-good `fetchedAt`**. The canonical key `intelligence:market-implications:v1` then expires on its TTL and `/api/health` reports EMPTY — **indistinguishable from a stopped cron**.

Live 2026-06-06: meta frozen ~54h, data key expired, while the sibling `forecasts` key stayed healthy → only the market-implications LLM step was failing, and there was zero observability for it.

## Fix (observability/resilience only — no LLM/credits/provider logic touched)

Mirrors the established **socialVelocity precedent (PR #4084)**:

- Added `writeMarketImplicationsFailureMeta(reason)` — writes a `status:'error'` seed-meta with a short `errorReason` (`llm_no_response` / `no_parseable_cards` / `all_cards_failed_validation`) and `recordCount: 0` to `seed-meta:intelligence:market-implications`.
- Wired it into each of the 3 failure guards (before their `return`).
- Re-`EXPIRE`s the canonical key so **last-good cards survive** while the LLM step retries on the next cron, rather than expiring to EMPTY mid-outage.
- **Success path unchanged** (now also tags `status:'ok'` to match the socialVelocity healthy-meta shape; the classifier only special-cases `status:'error'`, so this is inert for classification).

### Why this surfaces correctly

`api/health.js` already classifies this: `readSeedMeta` promotes `meta.status === 'error'` to `seedError: true` (health.js:611), and `classifyKey` maps `seedError → 'SEED_ERROR'` (health.js:690), which is severity **warn**. The `marketImplications` SEED_META entry (health.js:431, `maxStaleMin: 120`) is already registered. **No `api/health.js` change was needed.**

## Test plan

- `node --check scripts/seed-forecasts.mjs` — passes
- `npm run typecheck` — clean
- `node --test tests/market-implications-seed-health.test.mjs` — 3/3 pass (new source-assertion test, matching the socialVelocity test style: asserts the writer exists, all 3 guards call it before returning, and the success path still writes a healthy meta)
- `npx tsx --test tests/market-implications.test.mts` — 4/4 pass (existing consumer-side test, unaffected)

Did NOT run full `npm run test:data` (too heavy per scope).