### PR TITLE
fix(iea-oil-stocks): widen content-age threshold to 150d for real ~M+4 lag

### DIFF
--- a/scripts/_iea-oil-stocks-helpers.mjs
+++ b/scripts/_iea-oil-stocks-helpers.mjs
@@ -64,32 +64,41 @@ export function ieaOilStocksContentMeta(data, nowMs = Date.now()) {
 }
 
 /**
- * Threshold for STALE_CONTENT alerting (120 days).
+ * Threshold for STALE_CONTENT alerting (150 days / ~5 months).
  *
- * IEA monthly oil stocks publish on an M+2 cadence — August data
- * (`dataMonth = "2024-08"`, end-of-month = Aug 31) ships in late Oct
- * / early Nov, which is ~60-65 days AFTER end-of-observation-month.
- * That means at fresh-arrival the helper's `newestItemAt` is already
- * 60d old, before any real staleness has accrued.
+ * IEA monthly net-imports/oil-stocks publish on an observed ~M+4 cadence
+ * (NOT the M+2 the earlier comment assumed). The latest available month is
+ * ~3.5-4 calendar months behind end-of-observation-month, so the helper's
+ * `newestItemAt` is already ~95-100d old at the moment the freshest
+ * snapshot first arrives — before any real staleness has accrued.
  *
- * Budget breakdown: ~60d for the natural M+2 lag + ~60d slack for
- * up-to-two missed publications = 120d total. STALE_CONTENT trips
- * when more than two months are missed (e.g. cache stuck at
- * "2024-08" past mid-Feb when "2024-11" should have landed).
+ * Budget breakdown: ~100d for the natural M+4 lag at fresh-arrival + ~30d
+ * for normal intra-cycle aging (the freshest month must remain the served
+ * value until the NEXT month publishes ~a month later, so a healthy cache
+ * naturally reaches ~128d before the next publication lands) + ~22d grace.
+ * STALE_CONTENT trips only when the cache is frozen ~2 months past the
+ * normal cycle (a genuine multi-month upstream freeze or seeder failure).
  *
  * Iteration history:
  *   - Sprint 3b initial PR (#3599) shipped 45d, which would have
  *     fired STALE_CONTENT on every fresh seed because 45d < natural
  *     lag. Greptile P1 caught it.
- *   - Sprint 3b shipped at 90d (60d M+2 lag + 30d slack for one
+ *   - Sprint 3b shipped at 90d (assumed 60d M+2 lag + 30d slack for one
  *     missed publication).
  *   - 2026-05-09: bumped to 120d after IEA delayed Feb 2026 data by
- *     >24 days past expected mid-April publish window. Direct probe
- *     of `https://api.iea.org/netimports/monthly/?year=2026&month=02`
- *     returned `[]` (no data on the upstream itself), confirming this
- *     was a real publication delay, not a parser/network bug. The 90d
- *     budget was sized for "one missed publication"; IEA's recent
- *     pattern of 1-2 month delays makes 120d a better fit. Real
- *     "IEA went silent" incidents (>2 month gaps) still surface.
+ *     >24 days past expected publish window. Direct probe of
+ *     `https://api.iea.org/netimports/monthly/?year=2026&month=02`
+ *     returned `[]` at that time (no data on the upstream itself).
+ *   - 2026-06-06: bumped to 150d. Live probe of
+ *     `https://api.iea.org/netimports/latest` returned dataMonth
+ *     `2026-02` (end-of-Feb, content age ~97.7d on Jun 6) as the NEWEST
+ *     available month; `2026-03`/`2026-04` monthly endpoints returned
+ *     `[]` (not yet published). So the freshest data the seeder can
+ *     possibly serve is ~98d old, and the prior cached month (`2026-01`,
+ *     ~125.7d) was already breaching the 120d budget despite no seeder or
+ *     parse bug — the upstream simply runs ~M+4. 120d false-fires near
+ *     the end of every normal publication cycle (healthy cache reaches
+ *     ~128d before the next month lands). 150d absorbs the real cadence
+ *     while still catching a genuine ~2-month freeze.
  */
-export const IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN = 120 * 24 * 60;
+export const IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN = 150 * 24 * 60;

--- a/scripts/seed-iea-oil-stocks.mjs
+++ b/scripts/seed-iea-oil-stocks.mjs
@@ -273,12 +273,14 @@ if (isMain) {
 
     // ── Content-age contract (Sprint 3b of the 2026-05-04 health-readiness plan) ──
     //
-    // 90-day budget = ~60d natural M+2 lag + ~30d missed-publication slack.
-    // August data (dataMonth="2024-08", end-of-month Aug 31) ships in late
-    // Oct/early Nov, so at fresh-arrival `newestItemAt` is already ~60d
-    // old. STALE_CONTENT trips only when a month is missed entirely (e.g.
-    // cache stuck at "2024-08" past mid-Jan when "2024-10" should have
-    // landed → /api/health surfaces STALE_CONTENT).
+    // 150-day budget = ~100d natural ~M+4 lag at fresh-arrival + ~30d normal
+    // intra-cycle aging + ~22d grace. IEA net-imports run on an observed ~M+4
+    // cadence (live probe 2026-06-06: latest dataMonth="2026-02", ~97.7d old,
+    // with 2026-03/04 still empty upstream), so even the freshest snapshot the
+    // seeder can serve is already ~98d old. STALE_CONTENT trips only when the
+    // cache is frozen ~2 months past the normal cycle (genuine upstream freeze
+    // or seeder failure). See IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN JSDoc for the
+    // full iteration history (45d → 90d → 120d → 150d).
     //
     // ieaOilStocksContentMeta parses data.dataMonth ("YYYY-MM") into
     // end-of-month UTC ms. Single-snapshot shape: newest === oldest.

--- a/tests/iea-oil-stocks-content-age.test.mjs
+++ b/tests/iea-oil-stocks-content-age.test.mjs
@@ -15,15 +15,17 @@ import {
 
 const FIXED_NOW = 1700000000000;     // 2023-11-14T22:13:20.000Z — stable test "now"
 
-test('IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN is 120 days', () => {
-  // 120d = ~60d natural M+2 lag + ~60d slack for up-to-two missed
-  // publications. See helper module's JSDoc for the iteration history
-  // (45d → 90d → 120d). The 2026-05-09 bump from 90d → 120d followed an
-  // IEA Feb 2026 publication delay confirmed via direct upstream probe:
-  // `https://api.iea.org/netimports/monthly/?year=2026&month=02` returned
-  // `[]`, so the staleness was a real upstream delay rather than a
-  // parser/network bug.
-  assert.equal(IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN, 120 * 24 * 60);
+test('IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN is 150 days', () => {
+  // 150d = ~100d natural ~M+4 lag at fresh-arrival + ~30d normal intra-cycle
+  // aging + ~22d grace. See helper module's JSDoc for the iteration history
+  // (45d → 90d → 120d → 150d). The 2026-06-06 bump from 120d → 150d followed
+  // a live upstream probe: `https://api.iea.org/netimports/latest` returned
+  // dataMonth "2026-02" (~97.7d old) as the NEWEST available month, with
+  // `.../monthly/?year=2026&month=03` and `&month=04` returning `[]` (not yet
+  // published). The prior cached month ("2026-01", ~125.7d) was breaching the
+  // 120d budget despite no seeder/parse bug — IEA simply runs ~M+4, so 120d
+  // false-fired near the end of every normal publication cycle.
+  assert.equal(IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN, 150 * 24 * 60);
 });
 
 // ── dataMonthToEndOfMonthMs ──────────────────────────────────────────────
@@ -107,7 +109,7 @@ test('contentMeta accepts last fully-completed month', () => {
   assert.equal(new Date(cm.newestItemAt).toISOString(), '2023-10-31T23:59:59.999Z');
 });
 
-// ── Pilot threshold sanity (anti-drift on the 90-day budget) ────────────
+// ── Pilot threshold sanity (anti-drift on the 150-day budget) ───────────
 
 test('fresh-arrival regression guard: ~60d-old fresh M+2 data does NOT trip STALE_CONTENT', () => {
   // The exact failure mode caught by Greptile P1 on the initial 45d budget:
@@ -127,24 +129,40 @@ test('fresh-arrival regression guard: ~60d-old fresh M+2 data does NOT trip STAL
   );
 });
 
-test('pilot threshold: dataMonth ~14 days old is within 90-day budget (no false positive)', () => {
+test('pilot threshold: dataMonth ~14 days old is within 150-day budget (no false positive)', () => {
   // FIXED_NOW = 2023-11-14. "2023-10" → end-of-Oct = ~14d ago. Trivially fresh.
   const cm = ieaOilStocksContentMeta({ dataMonth: '2023-10' }, FIXED_NOW);
   const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
   assert.ok(
     ageMin < IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN,
-    `${Math.round(ageMin)}min < budget ${IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN}min — STALE_CONTENT does NOT fire on normal M+2 cadence`,
+    `${Math.round(ageMin)}min < budget ${IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN}min — STALE_CONTENT does NOT fire on normal ~M+4 cadence`,
   );
 });
 
-test('threshold: dataMonth ~168d old (multiple missed publications) trips STALE_CONTENT', () => {
-  // FIXED_NOW = 2023-11-14T22:13:20Z. "2023-05" → end-of-May = ~168d ago,
-  // past the 120d budget. Simulates "Jun, Jul AND Aug data all missed" or
-  // "Jun arrived very late" — at least three monthly publications late, on-call
-  // should be paged. Pre-bump this test used "2023-07" (~106d) which was past
-  // the old 90d budget but well WITHIN the new 120d budget; pushed back two
-  // months so the trip remains decisive.
-  const cm = ieaOilStocksContentMeta({ dataMonth: '2023-05' }, FIXED_NOW);
+test('live-cadence regression guard: ~M+4 freshest IEA data does NOT trip STALE_CONTENT', () => {
+  // The exact false-positive the 2026-06-06 120d→150d bump fixed. Live probe
+  // 2026-06-06: `https://api.iea.org/netimports/latest` → dataMonth "2026-02"
+  // (~97.7d old) was the NEWEST available month (2026-03/04 empty upstream).
+  // Worst case under steady cadence: that freshest snapshot must remain the
+  // served value until 2026-03 publishes (~a month later), aging to ~128d.
+  // A healthy cache at the END of its normal cycle MUST NOT page.
+  const NOW = Date.UTC(2026, 6, 6);              // Jul 6 2026 — ~1mo after probe, before 2026-03 lands
+  const cm = ieaOilStocksContentMeta({ dataMonth: '2026-02' }, NOW);
+  const ageMin = (NOW - cm.newestItemAt) / 60000;
+  assert.ok(
+    ageMin < IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN,
+    `2026-02 (freshest IEA month) aged to ${Math.round(ageMin / 60 / 24)}d < ${IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN / 60 / 24}d budget — normal ~M+4 cycle does NOT page`,
+  );
+});
+
+test('threshold: dataMonth ~198d old (multiple missed publications) trips STALE_CONTENT', () => {
+  // FIXED_NOW = 2023-11-14T22:13:20Z. "2023-04" → end-of-Apr = ~198d ago,
+  // past the 150d budget. Simulates a genuine multi-month upstream freeze
+  // (~2 months past the normal ~M+4 cycle) — on-call should be paged.
+  // Pre-bump this test used "2023-05" (~168d) which was decisively past the
+  // old 120d budget but only ~18d past the new 150d budget; pushed back one
+  // month so the trip remains unambiguous.
+  const cm = ieaOilStocksContentMeta({ dataMonth: '2023-04' }, FIXED_NOW);
   const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
   assert.ok(
     ageMin > IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN,
@@ -152,18 +170,19 @@ test('threshold: dataMonth ~168d old (multiple missed publications) trips STALE_
   );
 });
 
-test('threshold: M+2 lag scenario — Aug data still in cache by Feb 1 (5+ months later) trips STALE_CONTENT', () => {
-  // Realistic incident pattern: cache holds dataMonth="2023-08" (Aug data,
-  // M+2 publication = late Oct 2023). By Feb 1 2024 — three full months past
-  // expected publication of Sep AND Oct data — staleness is unambiguous.
-  // ~154d > 120d budget: clearly trips. Pre-bump this used dataMonth="2023-09"
-  // (~122d), which was only 2d past the new 120d budget — too close to the
-  // boundary to be a useful regression guard. Pushed back one month.
-  const FIXED_FUTURE = Date.UTC(2024, 1, 1);     // Feb 1 2024 UTC
+test('threshold: ~M+4 data frozen ~2 extra months trips STALE_CONTENT', () => {
+  // Realistic freeze incident: cache holds dataMonth="2023-08" (Aug data).
+  // Under the normal ~M+4 cadence Aug would be the served value through ~Dec,
+  // refreshed to Sep around Jan. By Mar 15 2024 — ~2 months past when Sep/Oct
+  // data should have rolled in — staleness is unambiguous. ~197d > 150d
+  // budget: clearly trips. Pre-bump this used Feb 1 2024 (~154d), only ~4d
+  // past the new 150d budget — too close to the boundary to be a useful
+  // regression guard. Pushed forward six weeks.
+  const FIXED_FUTURE = Date.UTC(2024, 2, 15);    // Mar 15 2024 UTC
   const cm = ieaOilStocksContentMeta({ dataMonth: '2023-08' }, FIXED_FUTURE);
   const ageMin = (FIXED_FUTURE - cm.newestItemAt) / 60000;
   assert.ok(
     ageMin > IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN,
-    `Aug 2023 data on Feb 1 2024: ${Math.round(ageMin / 60 / 24)}d > ${IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN / 60 / 24}d budget — STALE_CONTENT trips`,
+    `Aug 2023 data on Mar 15 2024: ${Math.round(ageMin / 60 / 24)}d > ${IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN / 60 / 24}d budget — STALE_CONTENT trips`,
   );
 });


### PR DESCRIPTION
## Summary

`/api/health` was reporting `ieaOilStocks = STALE_CONTENT`. Live diagnosis shows this is a **false alarm caused by a too-tight content-age threshold**, not a seeder/parse bug. The fix **widens** `IEA_OIL_STOCKS_MAX_CONTENT_AGE_MIN` from 120d to **150d** to match IEA's real publication cadence.

### Live probe (2026-06-06)

Replicating the seeder's exact request shape (`https://api.iea.org/netimports/latest` → `.../monthly/?year=&month=`, keyless, Chrome UA):

| dataMonth | upstream records | content age (end-of-month → now) |
|-----------|-----------------|----------------------------------|
| `2026-01` | 37 | **125.66d** ← what the live cache was holding (matches the diagnosed ~125.6d) |
| `2026-02` | 37 | **97.66d** ← `/latest` returns this; the NEWEST available month |
| `2026-03` | **0 (`[]`)** | (not yet published) |
| `2026-04` | **0 (`[]`)** | (not yet published) |

So IEA's freshest available data is **`2026-02`, ~97.7 days old**, and `2026-03`/`2026-04` are genuinely empty upstream. The seeder's next monthly run picks up `2026-02` (97.7d, healthy); the 125.6d staleness was the prior `2026-01` snapshot before `2026-02` propagated.

### Decision: WIDEN the threshold (not a seeder fix)

The earlier comment assumed an **M+2** lag (~60d). The observed lag is **~M+4** (~97.7d) — IEA's cadence slipped ~2 months. Even a perfectly healthy seeder serving the *newest* IEA month is already ~98d old at arrival, and that month must stay the served value until the next one publishes (~30d later), reaching **~128d before any real freeze**. So 120d false-fires near the end of every normal cycle.

New budget **150d** = ~100d natural ~M+4 lag at fresh-arrival + ~30d intra-cycle aging (→~128d worst-case healthy) + ~22d grace. Still trips on a genuine ~2-month freeze.

### Changes
- `scripts/_iea-oil-stocks-helpers.mjs`: `120 * 24 * 60` → `150 * 24 * 60` + updated JSDoc with the 2026-06-06 probe and iteration history (45d → 90d → 120d → 150d).
- `scripts/seed-iea-oil-stocks.mjs`: refreshed the stale inline content-age contract comment (was still describing the old 90d/M+2 framing).
- `tests/iea-oil-stocks-content-age.test.mjs`: assert 150d; **added a live-cadence regression guard** (the freshest `2026-02` month aged to ~128d does NOT page); pushed the two trip-scenario tests off the 150d boundary so they stay decisive (~198d and ~197d).

## Test plan
- `node --check scripts/seed-iea-oil-stocks.mjs scripts/_iea-oil-stocks-helpers.mjs` — OK
- `node --test tests/iea-oil-stocks-content-age.test.mjs` — 17/17 pass
- `node --test tests/iea-oil-stocks-seed.test.mjs tests/seeder-content-age-coverage.test.mjs tests/seed-content-age-contract.test.mjs` — 64/64 pass (combined run with the above)
- `tsc --noEmit` — clean