### PR TITLE
docs: archive deleted CountryIntelModal references

### DIFF
--- a/docs/Docs_To_Review/COMPONENTS.md
+++ b/docs/Docs_To_Review/COMPONENTS.md
@@ -1000,14 +1000,6 @@ small UI affordances.
 | **Audio** | Inline base64-encoded WAV notification sound. |
 | **Types** | `CorrelationSignal`, `UnifiedAlert` |
 
-### CountryIntelModal
-
-| Field | Detail |
-|---|---|
-| **File** | `src/components/CountryIntelModal.ts` |
-| **Purpose** | AI-generated country intelligence briefing modal. |
-| **Services** | `getCSSColor`, `country-instability` types. |
-
 ### CountryBriefPage
 
 | Field | Detail |
@@ -1138,7 +1130,6 @@ small UI affordances.
 | LanguageSelector | ✅ | ✅ | ✅ |
 | PlaybackControl | ✅ | ✅ | ✅ |
 | SignalModal | ✅ | ✅ | ✅ |
-| CountryIntelModal | ✅ | ✅ | — |
 | CountryBriefPage | ✅ | ✅ | — |
 | CountryTimeline | ✅ | ✅ | — |
 | StoryModal | ✅ | ✅ | ✅ |
@@ -1228,7 +1219,6 @@ graph TD
 
     subgraph Modals["Modals & Widgets"]
         SIG[SignalModal]
-        CIM[CountryIntelModal]
         CBP[CountryBriefPage]
         CTL[CountryTimeline]
         STM[StoryModal]
@@ -1345,7 +1335,6 @@ export { SearchModal } from './SearchModal';
 
 // Modals & widgets
 export { SignalModal } from './SignalModal';
-export { CountryIntelModal } from './CountryIntelModal';
 export { CountryBriefPage } from './CountryBriefPage';
 export { CountryTimeline } from './CountryTimeline';
 export { PlaybackControl } from './PlaybackControl';

--- a/docs/Docs_To_Review/bugs.md
+++ b/docs/Docs_To_Review/bugs.md
@@ -45,7 +45,8 @@ Keep the `App` class as a thin composition root that wires controllers together.
 | Field | Value |
 |---|---|
 | **Severity** | Critical (security) |
-| **Affected** | `src/components/MapPopup.ts`, `src/components/DeckGLMap.ts`, `src/components/CascadePanel.ts`, `src/components/CountryBriefPage.ts`, `src/components/CountryIntelModal.ts`, `src/components/InsightsPanel.ts`, `src/App.ts` (lines ~2763, ~2817) |
+| **Affected** | `src/components/MapPopup.ts`, `src/components/DeckGLMap.ts`, `src/components/CascadePanel.ts`, `src/components/CountryBriefPage.ts`, `src/components/InsightsPanel.ts`, `src/App.ts` (lines ~2763, ~2817) |
+| **Historical removals** | CountryIntelModal was part of the original audit set but has since been deleted as an unused orphan. |
 | **Depends on** | — |
 
 **Description**


### PR DESCRIPTION
## Summary
- remove deleted CountryIntelModal from archived component inventory, matrix, diagram, and sample exports
- keep BUG-002 affected-file scope limited to active files
- move CountryIntelModal into a historical removals row so audits do not treat it as live architecture

## Verification
- rg -n "CountryIntelModal|country-intel-" docs/Docs_To_Review docs src tests
- npm_config_cache=/tmp/worldmonitor-npm-cache npx markdownlint-cli2 docs/Docs_To_Review/COMPONENTS.md docs/Docs_To_Review/bugs.md
- pre-push hook: typecheck, typecheck:api, Convex type check, CJS syntax, Unicode safety, lint:boundaries, lint:safe-html, lint:rate-limit-policies, lint:premium-fetch, edge function bundle check, lint:md, version:check

## Notes
- Docs-only cleanup; generated API docs intentionally untouched.
