### PR TITLE
Fix CII UCDP future-date guard

### DIFF
--- a/server/worldmonitor/intelligence/v1/get-risk-scores.ts
+++ b/server/worldmonitor/intelligence/v1/get-risk-scores.ts
@@ -444,6 +444,14 @@ const UCDP_CLASSIFICATION_WINDOW_MS = 2 * 365 * 24 * 60 * 60 * 1000;
 
 type UcdpIntensity = 'minor' | 'war';
 
+function isRecentUcdpClassificationDate(dateStart: unknown, nowMs: number): boolean {
+  const eventMs = finiteNumber(dateStart);
+  return eventMs !== null
+    && Number.isFinite(nowMs)
+    && eventMs <= nowMs
+    && nowMs - eventMs < UCDP_CLASSIFICATION_WINDOW_MS;
+}
+
 /**
  * Classify each Tier-1 country's live UCDP conflict intensity from the cached event list,
  * matching the frontend `deriveUcdpClassifications` heuristic. Returns only countries that
@@ -466,7 +474,7 @@ function deriveUcdpIntensityByRegion(
   for (const [countryName, events] of eventsByCountryName) {
     const code = normalizeCountryName(countryName);
     if (!code || !isTier1CountryCode(code)) continue;
-    const recent = events.filter((e) => nowMs - (safeNum(e?.dateStart)) < UCDP_CLASSIFICATION_WINDOW_MS);
+    const recent = events.filter((e) => isRecentUcdpClassificationDate(e?.dateStart, nowMs));
     const totalDeaths = recent.reduce((sum, e) => sum + safeNonNegativeNum(e?.deathsBest), 0);
     const eventCount = recent.length;
     let intensity: UcdpIntensity | null = null;

--- a/src/services/conflict/index.ts
+++ b/src/services/conflict/index.ts
@@ -168,6 +168,14 @@ function toHapiSummary(proto: ProtoHumanSummary): HapiConflictSummary {
 
 // ---- UCDP classification derivation heuristic ----
 
+function isRecentUcdpClassificationDate(dateStart: unknown, now: number, windowMs: number): boolean {
+  const eventMs = Number(dateStart);
+  return Number.isFinite(eventMs)
+    && Number.isFinite(now)
+    && eventMs <= now
+    && now - eventMs < windowMs;
+}
+
 function deriveUcdpClassifications(events: ProtoUcdpEvent[]): Map<string, UcdpConflictStatus> {
   const byCountry = new Map<string, ProtoUcdpEvent[]>();
   for (const e of events) {
@@ -182,7 +190,7 @@ function deriveUcdpClassifications(events: ProtoUcdpEvent[]): Map<string, UcdpCo
 
   for (const [country, countryEvents] of byCountry) {
     // Filter to trailing 2-year window
-    const recentEvents = countryEvents.filter(e => (now - e.dateStart) < twoYearsMs);
+    const recentEvents = countryEvents.filter(e => isRecentUcdpClassificationDate(e.dateStart, now, twoYearsMs));
     const totalDeaths = recentEvents.reduce((sum, e) => sum + e.deathsBest, 0);
     const eventCount = recentEvents.length;
 

--- a/tests/cii-scoring.test.mts
+++ b/tests/cii-scoring.test.mts
@@ -394,6 +394,8 @@ function countScoredRealtimeComponents(scores: ReturnType<typeof computeCIIScore
 }
 
 const TREND_TEST_NOW = 1_700_000_000_000;
+const CII_TEST_DAY_MS = 24 * 60 * 60 * 1000;
+const UCDP_TEST_WINDOW_MS = 2 * 365 * CII_TEST_DAY_MS;
 
 function priorCiiScore(region: string, combinedScore: number, computedAt = TREND_TEST_NOW - CII_TREND_TARGET_AGE_MS) {
   return {
@@ -778,6 +780,36 @@ describe('CII scoring', () => {
     auxQuiet.ucdpEvents = [{ country: 'Brazil', violenceType: 'UCDP_VIOLENCE_TYPE_NON_STATE', deathsBest: 1, dateStart: Date.now() }];
     const br = scoreFor(computeCIIScores([], auxQuiet), 'BR')!;
     assert.ok(br.combinedScore < 50, `BR with a single quiet UCDP event must not reach the minor floor, got ${br.combinedScore}`);
+  });
+
+  it('UCDP date guard ignores future and non-finite dates for conflict floors', () => {
+    const baseline = scoreFor(computeCIIScores([], emptyAux(), { nowMs: TREND_TEST_NOW }), 'UA')!;
+    const aux = emptyAux();
+    aux.ucdpEvents = [
+      ucdpEvent('Ukraine', 2000, TREND_TEST_NOW + 365 * CII_TEST_DAY_MS),
+      ucdpEvent('Ukraine', 2000, Number.NaN),
+      { country: 'Ukraine', violenceType: 'UCDP_VIOLENCE_TYPE_STATE_BASED', deathsBest: 2000 },
+    ];
+
+    const ua = scoreFor(computeCIIScores([], aux, { nowMs: TREND_TEST_NOW }), 'UA')!;
+    assert.equal(
+      ua.combinedScore,
+      baseline.combinedScore,
+      `future/non-finite UCDP rows must not impose a war floor; got ${ua.combinedScore} vs baseline ${baseline.combinedScore}`,
+    );
+    assert.ok(ua.combinedScore < 70, `future-dated UCDP row must not trigger war floor, got ${ua.combinedScore}`);
+  });
+
+  it('UCDP date guard preserves valid current and trailing-window conflict floors', () => {
+    for (const dateStart of [
+      TREND_TEST_NOW,
+      TREND_TEST_NOW - UCDP_TEST_WINDOW_MS + CII_TEST_DAY_MS,
+    ]) {
+      const aux = emptyAux();
+      aux.ucdpEvents = [ucdpEvent('Ukraine', 2000, dateStart)];
+      const ua = scoreFor(computeCIIScores([], aux, { nowMs: TREND_TEST_NOW }), 'UA')!;
+      assert.ok(ua.combinedScore >= 70, `valid UCDP date ${dateStart} must still trigger war floor, got ${ua.combinedScore}`);
+    }
   });
 
   it('advisory do-not-travel floor: composite >= 60', () => {
@@ -1526,9 +1558,22 @@ describe('CII scoring', () => {
     );
   });
 
+  it('riskScores UCDP health coverage ignores future-dated conflict rows', () => {
+    const aux = emptyAux();
+    aux.ucdpEvents = [ucdpEvent('Ukraine', 1500, TREND_TEST_NOW + 365 * CII_TEST_DAY_MS)];
+    aux.newsTopStories = [{ countryCode: 'GB', threatLevel: 'high', primaryTitle: 'UK security alert' }];
+    aux.cyber = [{ country: 'US', severity: 'CRITICALITY_LEVEL_CRITICAL' }];
+
+    assert.equal(
+      countCiiRealtimeSignalDensityCoverage([], aux, TREND_TEST_NOW),
+      2,
+      'future-dated UCDP rows must not satisfy the conflict family when ACLED is empty',
+    );
+  });
+
   it('riskScores UCDP health coverage uses the supplied clock', () => {
     const aux = emptyAux();
-    aux.ucdpEvents = [ucdpEvent('Ukraine', 1500, TREND_TEST_NOW - 24 * 60 * 60 * 1000)];
+    aux.ucdpEvents = [ucdpEvent('Ukraine', 1500, TREND_TEST_NOW - CII_TEST_DAY_MS)];
     aux.newsTopStories = [{ countryCode: 'GB', threatLevel: 'high', primaryTitle: 'UK security alert' }];
     aux.cyber = [{ country: 'US', severity: 'CRITICALITY_LEVEL_CRITICAL' }];
 

--- a/tests/conflict-ucdp-date-window.test.mts
+++ b/tests/conflict-ucdp-date-window.test.mts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { transformSync } from 'esbuild';
+
+const root = resolve(import.meta.dirname, '..');
+const conflictServiceSource = readFileSync(resolve(root, 'src/services/conflict/index.ts'), 'utf8');
+
+let moduleCounter = 0;
+
+async function loadUcdpDeriver() {
+  const patched = conflictServiceSource
+    .replace(
+      "import { getRpcBaseUrl } from '@/services/rpc-client';",
+      "const getRpcBaseUrl = () => '';",
+    )
+    .replace(
+      /import \{\n[\s\S]*?\} from '@\/generated\/client\/worldmonitor\/conflict\/v1\/service_client';/,
+      `class ConflictServiceClient {
+  constructor(..._args: unknown[]) {}
+  listAcledEvents() { return { events: [], pagination: undefined }; }
+  listUcdpEvents() { return { events: [], pagination: undefined }; }
+}
+class ApiError extends Error {}
+type AcledConflictEvent = any;
+type UcdpViolenceEvent = any;
+type HumanitarianCountrySummary = any;
+type ListAcledEventsResponse = any;
+type ListUcdpEventsResponse = any;
+type GetHumanitarianSummaryResponse = any;
+type GetHumanitarianSummaryBatchResponse = any;
+type IranEvent = any;
+type ListIranEventsResponse = any;`,
+    )
+    .replace(
+      "import type { UcdpGeoEvent, UcdpEventType } from '@/types';",
+      'type UcdpGeoEvent = any; type UcdpEventType = any;',
+    )
+    .replace(
+      "import { createCircuitBreaker } from '@/utils';",
+      'const createCircuitBreaker = (_config: unknown) => ({ execute: async (_fn: unknown, fallback: unknown) => fallback });',
+    )
+    .replace(
+      "import { getHydratedData } from '@/services/bootstrap';",
+      'const getHydratedData = (_key: string) => null;',
+    )
+    .replace(
+      "import { toApiUrl } from '@/services/runtime';",
+      'const toApiUrl = (path: string) => path;',
+    )
+    .concat('\nexport { deriveUcdpClassifications };\n');
+
+  const transformed = transformSync(patched, {
+    loader: 'ts',
+    format: 'esm',
+    target: 'es2022',
+  });
+  const dataUrl = `data:text/javascript;base64,${Buffer.from(transformed.code).toString('base64')}#${++moduleCounter}`;
+  return (await import(dataUrl)) as {
+    deriveUcdpClassifications: (events: any[]) => Map<string, { intensity: string }>;
+  };
+}
+
+function ucdpEvent(country: string, deathsBest: number, dateStart: number) {
+  return {
+    country,
+    deathsBest,
+    dateStart,
+    violenceType: 'UCDP_VIOLENCE_TYPE_STATE_BASED',
+  };
+}
+
+describe('frontend UCDP classification date guard', () => {
+  it('ignores future and non-finite dates while preserving valid current/past rows', async () => {
+    const { deriveUcdpClassifications } = await loadUcdpDeriver();
+    const now = 1_700_000_000_000;
+    const dayMs = 24 * 60 * 60 * 1000;
+    const twoYearsMs = 2 * 365 * dayMs;
+    const originalDateNow = Date.now;
+    Date.now = () => now;
+    try {
+      assert.equal(
+        deriveUcdpClassifications([ucdpEvent('Ukraine', 2000, now + 365 * dayMs)]).get('Ukraine')?.intensity,
+        'none',
+        'future-dated high-death UCDP rows must not classify as war',
+      );
+      assert.equal(
+        deriveUcdpClassifications([ucdpEvent('Ukraine', 2000, Number.NaN)]).get('Ukraine')?.intensity,
+        'none',
+        'non-finite UCDP dates must fail closed',
+      );
+      assert.equal(
+        deriveUcdpClassifications([ucdpEvent('Ukraine', 2000, now)]).get('Ukraine')?.intensity,
+        'war',
+        'current UCDP rows must still classify',
+      );
+      assert.equal(
+        deriveUcdpClassifications([ucdpEvent('Ukraine', 2000, now - twoYearsMs + dayMs)]).get('Ukraine')?.intensity,
+        'war',
+        'past UCDP rows inside the trailing window must still classify',
+      );
+    } finally {
+      Date.now = originalDateNow;
+    }
+  });
+});

--- a/tests/conflict-ucdp-date-window.test.mts
+++ b/tests/conflict-ucdp-date-window.test.mts
@@ -9,15 +9,23 @@ const conflictServiceSource = readFileSync(resolve(root, 'src/services/conflict/
 
 let moduleCounter = 0;
 
+function replaceRequired(source: string, search: string | RegExp, replacement: string, label: string): string {
+  const patched = source.replace(search, replacement);
+  assert.notEqual(patched, source, `failed to patch conflict service import: ${label}`);
+  return patched;
+}
+
 async function loadUcdpDeriver() {
-  const patched = conflictServiceSource
-    .replace(
-      "import { getRpcBaseUrl } from '@/services/rpc-client';",
-      "const getRpcBaseUrl = () => '';",
-    )
-    .replace(
-      /import \{\n[\s\S]*?\} from '@\/generated\/client\/worldmonitor\/conflict\/v1\/service_client';/,
-      `class ConflictServiceClient {
+  let patched = replaceRequired(
+    conflictServiceSource,
+    "import { getRpcBaseUrl } from '@/services/rpc-client';",
+    "const getRpcBaseUrl = () => '';",
+    'rpc-client',
+  );
+  patched = replaceRequired(
+    patched,
+    /import \{\n[\s\S]*?\} from '@\/generated\/client\/worldmonitor\/conflict\/v1\/service_client';/,
+    `class ConflictServiceClient {
   constructor(..._args: unknown[]) {}
   listAcledEvents() { return { events: [], pagination: undefined }; }
   listUcdpEvents() { return { events: [], pagination: undefined }; }
@@ -32,24 +40,33 @@ type GetHumanitarianSummaryResponse = any;
 type GetHumanitarianSummaryBatchResponse = any;
 type IranEvent = any;
 type ListIranEventsResponse = any;`,
-    )
-    .replace(
-      "import type { UcdpGeoEvent, UcdpEventType } from '@/types';",
-      'type UcdpGeoEvent = any; type UcdpEventType = any;',
-    )
-    .replace(
-      "import { createCircuitBreaker } from '@/utils';",
-      'const createCircuitBreaker = (_config: unknown) => ({ execute: async (_fn: unknown, fallback: unknown) => fallback });',
-    )
-    .replace(
-      "import { getHydratedData } from '@/services/bootstrap';",
-      'const getHydratedData = (_key: string) => null;',
-    )
-    .replace(
-      "import { toApiUrl } from '@/services/runtime';",
-      'const toApiUrl = (path: string) => path;',
-    )
-    .concat('\nexport { deriveUcdpClassifications };\n');
+    'generated conflict client',
+  );
+  patched = replaceRequired(
+    patched,
+    "import type { UcdpGeoEvent, UcdpEventType } from '@/types';",
+    'type UcdpGeoEvent = any; type UcdpEventType = any;',
+    'types',
+  );
+  patched = replaceRequired(
+    patched,
+    "import { createCircuitBreaker } from '@/utils';",
+    'const createCircuitBreaker = (_config: unknown) => ({ execute: async (_fn: unknown, fallback: unknown) => fallback });',
+    'utils',
+  );
+  patched = replaceRequired(
+    patched,
+    "import { getHydratedData } from '@/services/bootstrap';",
+    'const getHydratedData = (_key: string) => null;',
+    'bootstrap',
+  );
+  patched = replaceRequired(
+    patched,
+    "import { toApiUrl } from '@/services/runtime';",
+    'const toApiUrl = (path: string) => path;',
+    'runtime',
+  );
+  patched = `${patched}\nexport { deriveUcdpClassifications };\n`;
 
   const transformed = transformSync(patched, {
     loader: 'ts',


### PR DESCRIPTION
## Summary
- Require finite, non-future UCDP `dateStart` values before server CII conflict-floor classification
- Apply the same date-window guard to the frontend UCDP classification heuristic
- Add regressions for future/non-finite UCDP rows, preserving valid current/past UCDP behavior and the v8 field shape

## Validation
- `./node_modules/.bin/tsx --test tests/cii-scoring.test.mts`
- `./node_modules/.bin/tsx --test tests/conflict-ucdp-date-window.test.mts`
- `npm run typecheck`
- Normal pre-push hook passed triggered checks, including typecheck, API typecheck, server handler tests, changed tests, edge function tests, lint/boundary/safe HTML/rate-limit/premium-fetch checks, and version sync