### PR TITLE
fix(relay): gate boot seeds on freshness to stop reboot-storm abuse

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -213,9 +213,21 @@ if (UPSTASH_ENABLED) {
   console.log(`[Relay] Upstash Redis enabled (key: ${OREF_REDIS_KEY})`);
 }
 
-function upstashGet(key) {
+function upstashGet(key, onFailure) {
   return new Promise((resolve) => {
     if (!UPSTASH_ENABLED) return resolve(null);
+    let settled = false;
+    const finish = (value) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+    const fail = (reason) => {
+      if (settled) return;
+      settled = true;
+      if (onFailure) onFailure(reason);
+      resolve(null);
+    };
     const url = new URL(`/get/${encodeURIComponent(key)}`, UPSTASH_REDIS_REST_URL);
     const req = https.request(url, {
       method: 'GET',
@@ -224,20 +236,28 @@ function upstashGet(key) {
     }, (resp) => {
       if (resp.statusCode < 200 || resp.statusCode >= 300) {
         resp.resume();
-        return resolve(null);
+        return fail(`HTTP ${resp.statusCode}`);
       }
       let data = '';
       resp.on('data', (chunk) => { data += chunk; });
       resp.on('end', () => {
         try {
           const parsed = JSON.parse(data);
-          if (parsed?.result) return resolve(JSON.parse(parsed.result));
-          resolve(null);
-        } catch { resolve(null); }
+          if (parsed?.result) {
+            try {
+              return finish(JSON.parse(parsed.result));
+            } catch (e) {
+              return fail(`JSON result parse failed: ${(e && e.message) || e}`);
+            }
+          }
+          finish(null);
+        } catch (e) {
+          fail(`JSON response parse failed: ${(e && e.message) || e}`);
+        }
       });
     });
-    req.on('error', () => resolve(null));
-    req.on('timeout', () => { req.destroy(); resolve(null); });
+    req.on('error', (e) => fail((e && e.message) || e));
+    req.on('timeout', () => { req.destroy(); fail('timeout'); });
     req.end();
   });
 }
@@ -422,23 +442,21 @@ function upstashSetNx(key, value, ttlSeconds) {
 //
 // `metaKey` is the FULL Redis key the seeder writes (usually `seed-meta:<key>`,
 // sometimes a `relay:heartbeat:<key>` for script-delegated seeders). On any
-// read/parse failure the guard fails OPEN (returns 0 delay, so the caller seeds)
-// so a Redis blip never starves a panel.
+// read/parse failure the guard logs and fails OPEN (returns 0 delay, so the
+// caller seeds) so a Redis blip never starves a panel.
 async function bootSeedDelayMs(label, metaKey, intervalMs) {
   if (UPSTASH_ENABLED && metaKey && intervalMs > 0) {
-    try {
-      const meta = await upstashGet(metaKey);
-      const fetchedAt = Number(meta && meta.fetchedAt) || 0;
-      if (fetchedAt > 0) {
-        const ageMs = Date.now() - fetchedAt;
-        if (ageMs >= 0 && ageMs < intervalMs) {
-          const delayMs = intervalMs - ageMs;
-          console.log(`[${label}] Boot seed delayed — data fresh (age ${Math.round(ageMs / 60000)}min < ${Math.round(intervalMs / 60000)}min interval); next refresh in ${Math.round(delayMs / 60000)}min`);
-          return delayMs;
-        }
+    const meta = await upstashGet(metaKey, (reason) => {
+      console.warn(`[${label}] Boot freshness check failed (${reason}); seeding`);
+    });
+    const fetchedAt = Number(meta && meta.fetchedAt) || 0;
+    if (fetchedAt > 0) {
+      const ageMs = Date.now() - fetchedAt;
+      if (ageMs >= 0 && ageMs < intervalMs) {
+        const delayMs = intervalMs - ageMs;
+        console.log(`[${label}] Boot seed delayed — data fresh (age ${Math.round(ageMs / 60000)}min < ${Math.round(intervalMs / 60000)}min interval); next refresh in ${Math.round(delayMs / 60000)}min`);
+        return delayMs;
       }
-    } catch (e) {
-      console.warn(`[${label}] Boot freshness check failed (${(e && e.message) || e}); seeding`);
     }
   }
   return 0;

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -404,12 +404,14 @@ function upstashSetNx(key, value, ttlSeconds) {
 // ScrapeCreators, and rate-limit/ban risk for Reddit, Yahoo, CoinGecko, UCDP,
 // OpenSky, CelesTrak, USNI, etc.
 //
-// maybeBootSeed gates the immediate boot seed on the existing seed-meta age: it
-// runs the seed only when the data is already older than its interval (i.e. a
-// refresh is actually due). On a frequently-recycled relay this self-throttles
-// the boot seed to the intended cadence; on a long-lived relay it runs once at
-// boot (if due) and the setInterval takes over — both correct. The interval path
-// is intentionally untouched: when the timer fires the data is due by definition.
+// bootSeedDelayMs gates the immediate boot seed on the existing seed-meta age:
+// it runs the seed immediately only when the data is already older than its
+// interval (i.e. a refresh is actually due). On a frequently-recycled relay this
+// self-throttles the boot seed to the intended cadence. On a long-lived relay,
+// startBootSeedLoop schedules the first skipped refresh for the remaining
+// freshness window and only then starts the recurring interval, so a restart near
+// the end of a long interval does not push the next fetch out by another full
+// interval.
 //
 // It keys on `fetchedAt` ("recently attempted — don't re-attempt"), NOT
 // recordCount/status, so a recent FAILED attempt also suppresses the next-boot
@@ -420,10 +422,9 @@ function upstashSetNx(key, value, ttlSeconds) {
 //
 // `metaKey` is the FULL Redis key the seeder writes (usually `seed-meta:<key>`,
 // sometimes a `relay:heartbeat:<key>` for script-delegated seeders). On any
-// read/parse failure the guard fails OPEN (seeds) so a Redis blip never starves a
-// panel. Returns the seedFn() promise (or a resolved promise when skipped) so the
-// call site's existing `.catch` still applies.
-async function maybeBootSeed(label, metaKey, intervalMs, seedFn) {
+// read/parse failure the guard fails OPEN (returns 0 delay, so the caller seeds)
+// so a Redis blip never starves a panel.
+async function bootSeedDelayMs(label, metaKey, intervalMs) {
   if (UPSTASH_ENABLED && metaKey && intervalMs > 0) {
     try {
       const meta = await upstashGet(metaKey);
@@ -431,15 +432,46 @@ async function maybeBootSeed(label, metaKey, intervalMs, seedFn) {
       if (fetchedAt > 0) {
         const ageMs = Date.now() - fetchedAt;
         if (ageMs >= 0 && ageMs < intervalMs) {
-          console.log(`[${label}] Boot seed skipped — data fresh (age ${Math.round(ageMs / 60000)}min < ${Math.round(intervalMs / 60000)}min interval); next refresh via setInterval or a later reboot`);
-          return;
+          const delayMs = intervalMs - ageMs;
+          console.log(`[${label}] Boot seed delayed — data fresh (age ${Math.round(ageMs / 60000)}min < ${Math.round(intervalMs / 60000)}min interval); next refresh in ${Math.round(delayMs / 60000)}min`);
+          return delayMs;
         }
       }
     } catch (e) {
       console.warn(`[${label}] Boot freshness check failed (${(e && e.message) || e}); seeding`);
     }
   }
-  return seedFn();
+  return 0;
+}
+
+function startBootSeedLoop(label, metaKey, intervalMs, seedFn, onInitialError, onSeedError = onInitialError) {
+  let intervalStarted = false;
+  const startInterval = () => {
+    if (intervalStarted) return;
+    intervalStarted = true;
+    setInterval(() => {
+      seedFn().catch(onSeedError);
+    }, intervalMs).unref?.();
+  };
+
+  bootSeedDelayMs(label, metaKey, intervalMs).then((delayMs) => {
+    if (delayMs > 0) {
+      const timer = setTimeout(() => {
+        Promise.resolve()
+          .then(seedFn)
+          .catch(onInitialError)
+          .finally(startInterval);
+      }, delayMs);
+      timer.unref?.();
+      return;
+    }
+    seedFn().catch(onInitialError);
+    startInterval();
+  }).catch((e) => {
+    onInitialError(e);
+    seedFn().catch(onInitialError);
+    startInterval();
+  });
 }
 
 function upstashDel(key) {
@@ -1637,10 +1669,7 @@ async function startUcdpSeedLoop() {
     return;
   }
   console.log(`[UCDP] Seed loop starting (interval ${UCDP_POLL_INTERVAL_MS / 1000 / 60}min, token: ${UCDP_ACCESS_TOKEN ? 'yes' : 'no'})`);
-  maybeBootSeed('UCDP', 'seed-meta:conflict:ucdp-events', UCDP_POLL_INTERVAL_MS, seedUcdpEvents).catch(e => console.warn('[UCDP] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedUcdpEvents().catch(e => console.warn('[UCDP] Seed error:', e?.message || e));
-  }, UCDP_POLL_INTERVAL_MS).unref?.();
+  startBootSeedLoop('UCDP', 'seed-meta:conflict:ucdp-events', UCDP_POLL_INTERVAL_MS, seedUcdpEvents, e => console.warn('[UCDP] Initial seed error:', e?.message || e), e => console.warn('[UCDP] Seed error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -1770,10 +1799,7 @@ async function startSatelliteSeedLoop() {
     return;
   }
   console.log(`[Satellites] Seed loop starting (interval ${SAT_SEED_INTERVAL_MS / 1000 / 60}min)`);
-  maybeBootSeed('Satellites', 'seed-meta:intelligence:satellites', SAT_SEED_INTERVAL_MS, seedSatelliteTLEs).catch(e => console.warn('[Satellites] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedSatelliteTLEs().catch(e => console.warn('[Satellites] Seed error:', e?.message || e));
-  }, SAT_SEED_INTERVAL_MS).unref?.();
+  startBootSeedLoop('Satellites', 'seed-meta:intelligence:satellites', SAT_SEED_INTERVAL_MS, seedSatelliteTLEs, e => console.warn('[Satellites] Initial seed error:', e?.message || e), e => console.warn('[Satellites] Seed error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -2624,10 +2650,7 @@ async function startMarketDataSeedLoop() {
     return;
   }
   console.log(`[Market] Seed loop starting (interval ${MARKET_SEED_INTERVAL_MS / 1000 / 60}min, finnhub: ${FINNHUB_API_KEY ? 'yes' : 'no'})`);
-  maybeBootSeed('Market', 'seed-meta:market:stocks', MARKET_SEED_INTERVAL_MS, seedAllMarketData).catch((e) => console.warn('[Market] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedAllMarketData().catch((e) => console.warn('[Market] Seed error:', e?.message || e));
-  }, MARKET_SEED_INTERVAL_MS).unref?.();
+  startBootSeedLoop('Market', 'seed-meta:market:stocks', MARKET_SEED_INTERVAL_MS, seedAllMarketData, (e) => console.warn('[Market] Initial seed error:', e?.message || e), (e) => console.warn('[Market] Seed error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -3017,10 +3040,7 @@ async function startCyberThreatsSeedLoop() {
     return;
   }
   console.log(`[Cyber] Seed loop starting (interval ${CYBER_SEED_INTERVAL_MS / 1000 / 60 / 60}h, urlhaus:${URLHAUS_AUTH_KEY ? 'yes' : 'no'} otx:${OTX_API_KEY ? 'yes' : 'no'} abuseipdb:${ABUSEIPDB_API_KEY ? 'yes' : 'no'})`);
-  maybeBootSeed('Cyber', 'seed-meta:cyber:threats', CYBER_SEED_INTERVAL_MS, seedCyberThreats).catch((e) => console.warn('[Cyber] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedCyberThreats().catch((e) => console.warn('[Cyber] Seed error:', e?.message || e));
-  }, CYBER_SEED_INTERVAL_MS).unref?.();
+  startBootSeedLoop('Cyber', 'seed-meta:cyber:threats', CYBER_SEED_INTERVAL_MS, seedCyberThreats, (e) => console.warn('[Cyber] Initial seed error:', e?.message || e), (e) => console.warn('[Cyber] Seed error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -3199,10 +3219,7 @@ async function startPositiveEventsSeedLoop() {
     return;
   }
   console.log(`[PositiveEvents] Seed loop starting (interval ${POSITIVE_EVENTS_INTERVAL_MS / 1000 / 60}min)`);
-  maybeBootSeed('PositiveEvents', 'seed-meta:positive-events:geo', POSITIVE_EVENTS_INTERVAL_MS, seedPositiveEvents).catch((e) => console.warn('[PositiveEvents] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedPositiveEvents().catch((e) => console.warn('[PositiveEvents] Seed error:', e?.message || e));
-  }, POSITIVE_EVENTS_INTERVAL_MS).unref?.();
+  startBootSeedLoop('PositiveEvents', 'seed-meta:positive-events:geo', POSITIVE_EVENTS_INTERVAL_MS, seedPositiveEvents, (e) => console.warn('[PositiveEvents] Initial seed error:', e?.message || e), (e) => console.warn('[PositiveEvents] Seed error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -3803,10 +3820,7 @@ async function startClassifySeedLoop() {
   }
   const activeProviders = CLASSIFY_LLM_PROVIDERS.filter((p) => !!process.env[p.envKey]).map((p) => p.name);
   console.log(`[Classify] Seed loop starting (interval ${CLASSIFY_SEED_INTERVAL_MS / 1000 / 60}min, providers:${activeProviders.length ? activeProviders.join(',') : 'none'})`);
-  maybeBootSeed('Classify', 'seed-meta:classify', CLASSIFY_SEED_INTERVAL_MS, seedClassify).catch((e) => console.warn('[Classify] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedClassify().catch((e) => console.warn('[Classify] Seed error:', e?.message || e));
-  }, CLASSIFY_SEED_INTERVAL_MS).unref?.();
+  startBootSeedLoop('Classify', 'seed-meta:classify', CLASSIFY_SEED_INTERVAL_MS, seedClassify, (e) => console.warn('[Classify] Initial seed error:', e?.message || e), (e) => console.warn('[Classify] Seed error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -4381,10 +4395,7 @@ function startTheaterPostureSeedLoop() {
   console.log(`[TheaterPosture] Seed loop starting (interval ${THEATER_POSTURE_SEED_INTERVAL_MS / 1000 / 60}min)`);
   // Delay initial seed 30s to let the relay's OpenSky proxy start up
   setTimeout(() => {
-    maybeBootSeed('TheaterPosture', 'seed-meta:theater-posture', THEATER_POSTURE_SEED_INTERVAL_MS, seedTheaterPosture).catch((e) => console.warn('[TheaterPosture] Initial seed error:', e?.message || e));
-    setInterval(() => {
-      seedTheaterPosture().catch((e) => console.warn('[TheaterPosture] Seed error:', e?.message || e));
-    }, THEATER_POSTURE_SEED_INTERVAL_MS).unref?.();
+    startBootSeedLoop('TheaterPosture', 'seed-meta:theater-posture', THEATER_POSTURE_SEED_INTERVAL_MS, seedTheaterPosture, (e) => console.warn('[TheaterPosture] Initial seed error:', e?.message || e), (e) => console.warn('[TheaterPosture] Seed error:', e?.message || e));
   }, 30_000);
 }
 
@@ -4670,10 +4681,7 @@ async function startWeatherSeedLoop() {
     return;
   }
   console.log(`[Weather] Seed loop starting (interval ${WEATHER_SEED_INTERVAL_MS / 1000 / 60}min)`);
-  maybeBootSeed('Weather', 'seed-meta:weather:alerts', WEATHER_SEED_INTERVAL_MS, seedWeatherAlerts).catch((e) => console.warn('[Weather] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedWeatherAlerts().catch((e) => console.warn('[Weather] Seed error:', e?.message || e));
-  }, WEATHER_SEED_INTERVAL_MS).unref?.();
+  startBootSeedLoop('Weather', 'seed-meta:weather:alerts', WEATHER_SEED_INTERVAL_MS, seedWeatherAlerts, (e) => console.warn('[Weather] Initial seed error:', e?.message || e), (e) => console.warn('[Weather] Seed error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -4767,10 +4775,7 @@ async function startSpendingSeedLoop() {
     return;
   }
   console.log(`[Spending] Seed loop starting (interval ${SPENDING_SEED_INTERVAL_MS / 1000 / 60}min)`);
-  maybeBootSeed('Spending', 'seed-meta:economic:spending', SPENDING_SEED_INTERVAL_MS, seedUsaSpending).catch((e) => console.warn('[Spending] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedUsaSpending().catch((e) => console.warn('[Spending] Seed error:', e?.message || e));
-  }, SPENDING_SEED_INTERVAL_MS).unref?.();
+  startBootSeedLoop('Spending', 'seed-meta:economic:spending', SPENDING_SEED_INTERVAL_MS, seedUsaSpending, (e) => console.warn('[Spending] Initial seed error:', e?.message || e), (e) => console.warn('[Spending] Seed error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -4882,10 +4887,7 @@ async function startGscpiSeedLoop() {
     return;
   }
   console.log('[GSCPI] Seed loop starting (interval 24h)');
-  maybeBootSeed('GSCPI', 'seed-meta:economic:gscpi', GSCPI_SEED_INTERVAL_MS, seedGscpi).catch((e) => console.warn('[GSCPI] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedGscpi().catch((e) => console.warn('[GSCPI] Seed error:', e?.message || e));
-  }, GSCPI_SEED_INTERVAL_MS).unref?.();
+  startBootSeedLoop('GSCPI', 'seed-meta:economic:gscpi', GSCPI_SEED_INTERVAL_MS, seedGscpi, (e) => console.warn('[GSCPI] Initial seed error:', e?.message || e), (e) => console.warn('[GSCPI] Seed error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -5091,10 +5093,7 @@ async function startTechEventsSeedLoop() {
     return;
   }
   console.log(`[TechEvents] Seed loop starting (interval ${TECH_EVENTS_SEED_INTERVAL_MS / 1000 / 60 / 60}h)`);
-  maybeBootSeed('TechEvents', 'seed-meta:research:tech-events', TECH_EVENTS_SEED_INTERVAL_MS, seedTechEvents).catch((e) => console.warn('[TechEvents] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedTechEvents().catch((e) => console.warn('[TechEvents] Seed error:', e?.message || e));
-  }, TECH_EVENTS_SEED_INTERVAL_MS).unref?.();
+  startBootSeedLoop('TechEvents', 'seed-meta:research:tech-events', TECH_EVENTS_SEED_INTERVAL_MS, seedTechEvents, (e) => console.warn('[TechEvents] Initial seed error:', e?.message || e), (e) => console.warn('[TechEvents] Seed error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -5353,10 +5352,7 @@ async function startWorldBankSeedLoop() {
     return;
   }
   console.log(`[WB] Seed loop starting (interval ${WB_SEED_INTERVAL_MS / 1000 / 60 / 60}h)`);
-  maybeBootSeed('WB', `seed-meta:${WB_BOOTSTRAP_KEY}`, WB_SEED_INTERVAL_MS, seedWorldBank).catch(e => console.warn('[WB] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedWorldBank().catch(e => console.warn('[WB] Seed error:', e?.message || e));
-  }, WB_SEED_INTERVAL_MS).unref?.();
+  startBootSeedLoop('WB', `seed-meta:${WB_BOOTSTRAP_KEY}`, WB_SEED_INTERVAL_MS, seedWorldBank, e => console.warn('[WB] Initial seed error:', e?.message || e), e => console.warn('[WB] Seed error:', e?.message || e));
 }
 
 const PORTWATCH_REDIS_KEY = 'supply_chain:portwatch:v1';
@@ -5457,10 +5453,7 @@ async function startCorridorRiskSeedLoop() {
     return;
   }
   console.log(`[CorridorRisk] Seed loop starting (interval ${CORRIDOR_RISK_SEED_INTERVAL_MS / 1000 / 60}min)`);
-  maybeBootSeed('CorridorRisk', 'seed-meta:supply_chain:corridorrisk', CORRIDOR_RISK_SEED_INTERVAL_MS, seedCorridorRisk).catch(e => console.warn('[CorridorRisk] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedCorridorRisk().catch(e => console.warn('[CorridorRisk] Seed error:', e?.message || e));
-  }, CORRIDOR_RISK_SEED_INTERVAL_MS).unref?.();
+  startBootSeedLoop('CorridorRisk', 'seed-meta:supply_chain:corridorrisk', CORRIDOR_RISK_SEED_INTERVAL_MS, seedCorridorRisk, e => console.warn('[CorridorRisk] Initial seed error:', e?.message || e), e => console.warn('[CorridorRisk] Seed error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -5706,10 +5699,7 @@ async function startUsniFleetSeedLoop() {
     return;
   }
   console.log(`[USNI] Seed loop starting (interval ${USNI_SEED_INTERVAL_MS / 1000 / 60 / 60}h)`);
-  maybeBootSeed('USNI', 'seed-meta:military:usni-fleet', USNI_SEED_INTERVAL_MS, seedUsniFleet).catch(e => console.warn('[USNI] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedUsniFleet().catch(e => console.warn('[USNI] Seed error:', e?.message || e));
-  }, USNI_SEED_INTERVAL_MS).unref?.();
+  startBootSeedLoop('USNI', 'seed-meta:military:usni-fleet', USNI_SEED_INTERVAL_MS, seedUsniFleet, e => console.warn('[USNI] Initial seed error:', e?.message || e), e => console.warn('[USNI] Seed error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -5791,10 +5781,7 @@ async function startShippingStressSeedLoop() {
     return;
   }
   console.log(`[ShippingStress] Seed loop starting (interval ${SHIPPING_STRESS_INTERVAL_MS / 1000 / 60}min)`);
-  maybeBootSeed('ShippingStress', 'seed-meta:supply_chain:shipping_stress', SHIPPING_STRESS_INTERVAL_MS, seedShippingStress).catch(e => console.warn('[ShippingStress] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedShippingStress().catch(e => console.warn('[ShippingStress] Seed error:', e?.message || e));
-  }, SHIPPING_STRESS_INTERVAL_MS).unref?.();
+  startBootSeedLoop('ShippingStress', 'seed-meta:supply_chain:shipping_stress', SHIPPING_STRESS_INTERVAL_MS, seedShippingStress, e => console.warn('[ShippingStress] Initial seed error:', e?.message || e), e => console.warn('[ShippingStress] Seed error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -6152,10 +6139,7 @@ async function startSocialVelocitySeedLoop() {
     return;
   }
   console.log(`[SocialVelocity] Seed loop starting (interval ${SOCIAL_VELOCITY_INTERVAL_MS / 1000 / 60}min)`);
-  maybeBootSeed('SocialVelocity', SOCIAL_VELOCITY_SEED_META_KEY, SOCIAL_VELOCITY_INTERVAL_MS, seedSocialVelocity).catch(e => console.warn('[SocialVelocity] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedSocialVelocity().catch(e => console.warn('[SocialVelocity] Seed error:', e?.message || e));
-  }, SOCIAL_VELOCITY_INTERVAL_MS).unref?.();
+  startBootSeedLoop('SocialVelocity', SOCIAL_VELOCITY_SEED_META_KEY, SOCIAL_VELOCITY_INTERVAL_MS, seedSocialVelocity, e => console.warn('[SocialVelocity] Initial seed error:', e?.message || e), e => console.warn('[SocialVelocity] Seed error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -6344,10 +6328,7 @@ async function startWsbTickersSeedLoop() {
     return;
   }
   console.log(`[WsbTickers] Seed loop starting (interval ${WSB_TICKERS_INTERVAL_MS / 1000 / 60}min)`);
-  maybeBootSeed('WsbTickers', 'seed-meta:intelligence:wsb-tickers', WSB_TICKERS_INTERVAL_MS, seedWsbTickers).catch(e => console.warn('[WsbTickers] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedWsbTickers().catch(e => console.warn('[WsbTickers] Seed error:', e?.message || e));
-  }, WSB_TICKERS_INTERVAL_MS).unref?.();
+  startBootSeedLoop('WsbTickers', 'seed-meta:intelligence:wsb-tickers', WSB_TICKERS_INTERVAL_MS, seedWsbTickers, e => console.warn('[WsbTickers] Initial seed error:', e?.message || e), e => console.warn('[WsbTickers] Seed error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -6420,10 +6401,7 @@ function startClimateNewsSeedLoop() {
     return;
   }
   console.log(`[ClimateNewsSeed] Seed loop starting (interval ${CLIMATE_NEWS_SEED_INTERVAL_MS / 1000 / 60}min)`);
-  maybeBootSeed('ClimateNewsSeed', 'relay:heartbeat:climate-news', CLIMATE_NEWS_SEED_INTERVAL_MS, seedClimateNews).catch((e) => console.warn('[ClimateNewsSeed] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedClimateNews().catch((e) => console.warn('[ClimateNewsSeed] Seed error:', e?.message || e));
-  }, CLIMATE_NEWS_SEED_INTERVAL_MS).unref?.();
+  startBootSeedLoop('ClimateNewsSeed', 'relay:heartbeat:climate-news', CLIMATE_NEWS_SEED_INTERVAL_MS, seedClimateNews, (e) => console.warn('[ClimateNewsSeed] Initial seed error:', e?.message || e), (e) => console.warn('[ClimateNewsSeed] Seed error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -6492,10 +6470,7 @@ function startChokepointFlowsSeedLoop() {
     return;
   }
   console.log(`[ChokepointFlows] Seed loop starting (interval ${CHOKEPOINT_FLOWS_SEED_INTERVAL_MS / 1000 / 60}min)`);
-  maybeBootSeed('ChokepointFlows', 'relay:heartbeat:chokepoint-flows', CHOKEPOINT_FLOWS_SEED_INTERVAL_MS, seedChokepointFlows).catch((e) => console.warn('[ChokepointFlows] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedChokepointFlows().catch((e) => console.warn('[ChokepointFlows] Seed error:', e?.message || e));
-  }, CHOKEPOINT_FLOWS_SEED_INTERVAL_MS).unref?.();
+  startBootSeedLoop('ChokepointFlows', 'relay:heartbeat:chokepoint-flows', CHOKEPOINT_FLOWS_SEED_INTERVAL_MS, seedChokepointFlows, (e) => console.warn('[ChokepointFlows] Initial seed error:', e?.message || e), (e) => console.warn('[ChokepointFlows] Seed error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -6622,10 +6597,7 @@ function startPizzintSeedLoop() {
     return;
   }
   console.log(`[PizzINT] Seed loop starting (interval ${PIZZINT_SEED_INTERVAL_MS / 1000 / 60}min)`);
-  maybeBootSeed('PizzINT', 'seed-meta:intelligence:pizzint', PIZZINT_SEED_INTERVAL_MS, seedPizzint).catch((e) => console.warn('[PizzINT] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedPizzint().catch((e) => console.warn('[PizzINT] Seed error:', e?.message || e));
-  }, PIZZINT_SEED_INTERVAL_MS).unref?.();
+  startBootSeedLoop('PizzINT', 'seed-meta:intelligence:pizzint', PIZZINT_SEED_INTERVAL_MS, seedPizzint, (e) => console.warn('[PizzINT] Initial seed error:', e?.message || e), (e) => console.warn('[PizzINT] Seed error:', e?.message || e));
 }
 
 
@@ -6776,10 +6748,7 @@ function startDodoPriceSeedLoop() {
   if (!UPSTASH_ENABLED) { console.log('[DodoPrices] Disabled (no Upstash Redis)'); return; }
   if (!DODO_PRICE_API_KEY) { console.log('[DodoPrices] Disabled (no DODO_API_KEY)'); return; }
   console.log(`[DodoPrices] Seed loop starting (interval ${DODO_PRICE_SEED_INTERVAL_MS / 1000 / 60}min)`);
-  maybeBootSeed('DodoPrices', 'seed-meta:product-catalog', DODO_PRICE_SEED_INTERVAL_MS, seedDodoPrices).catch((e) => console.warn('[DodoPrices] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedDodoPrices().catch((e) => console.warn('[DodoPrices] Seed error:', e?.message || e));
-  }, DODO_PRICE_SEED_INTERVAL_MS).unref?.();
+  startBootSeedLoop('DodoPrices', 'seed-meta:product-catalog', DODO_PRICE_SEED_INTERVAL_MS, seedDodoPrices, (e) => console.warn('[DodoPrices] Initial seed error:', e?.message || e), (e) => console.warn('[DodoPrices] Seed error:', e?.message || e));
 }
 
 
@@ -7792,11 +7761,8 @@ async function seedChokepointTransits() {
 }
 
 setTimeout(() => {
-  maybeBootSeed('Transit', 'seed-meta:supply_chain:chokepoint_transits', CHOKEPOINT_TRANSIT_INTERVAL_MS, seedChokepointTransits).catch(err => console.error('[Transit] Initial seed error:', err.message));
+  startBootSeedLoop('Transit', 'seed-meta:supply_chain:chokepoint_transits', CHOKEPOINT_TRANSIT_INTERVAL_MS, seedChokepointTransits, err => console.error('[Transit] Initial seed error:', err.message), err => console.error('[Transit] Seed error:', err.message));
 }, 30_000);
-setInterval(() => {
-  seedChokepointTransits().catch(err => console.error('[Transit] Seed error:', err.message));
-}, CHOKEPOINT_TRANSIT_INTERVAL_MS).unref?.();
 
 // --- Pre-assembled Transit Summaries (Railway advantage: avoids large Redis reads on Vercel) ---
 // Split storage: compact summary (no history, ~30KB) + per-id history keys (~35KB each).
@@ -7948,11 +7914,8 @@ async function seedTransitSummaries() {
 
 // Seed transit summaries every 10 min (same as transit counter)
 setTimeout(() => {
-  maybeBootSeed('TransitSummary', 'seed-meta:supply_chain:transit-summaries', TRANSIT_SUMMARY_INTERVAL_MS, seedTransitSummaries).catch(e => console.warn('[TransitSummary] Initial seed error:', e?.message || e));
+  startBootSeedLoop('TransitSummary', 'seed-meta:supply_chain:transit-summaries', TRANSIT_SUMMARY_INTERVAL_MS, seedTransitSummaries, e => console.warn('[TransitSummary] Initial seed error:', e?.message || e), e => console.warn('[TransitSummary] Seed error:', e?.message || e));
 }, 35_000);
-setInterval(() => {
-  seedTransitSummaries().catch(e => console.warn('[TransitSummary] Seed error:', e?.message || e));
-}, TRANSIT_SUMMARY_INTERVAL_MS).unref?.();
 
 // UCDP GED Events cache (persistent in-memory — Railway advantage)
 const UCDP_CACHE_TTL_MS = 6 * 60 * 60 * 1000; // 6 hours

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -391,6 +391,57 @@ function upstashSetNx(key, value, ttlSeconds) {
   });
 }
 
+// ─────────────────────────────────────────────────────────────
+// Boot-seed freshness guard
+//
+// ais-relay is a long-running HTTP service on proxy.worldmonitor.app that
+// Railway recycles frequently (deploys, crashes, OOM). Every seed loop fires an
+// IMMEDIATE seed on boot and then schedules a setInterval at its real cadence —
+// but the process is usually recycled long before that interval elapses, so the
+// boot seed, not the interval, is the de-facto scheduler. During a reboot storm
+// that means every upstream gets re-fetched on every boot (~8 min apart in the
+// wild, observed 2026-06-06) instead of on its interval: paid credits burned for
+// ScrapeCreators, and rate-limit/ban risk for Reddit, Yahoo, CoinGecko, UCDP,
+// OpenSky, CelesTrak, USNI, etc.
+//
+// maybeBootSeed gates the immediate boot seed on the existing seed-meta age: it
+// runs the seed only when the data is already older than its interval (i.e. a
+// refresh is actually due). On a frequently-recycled relay this self-throttles
+// the boot seed to the intended cadence; on a long-lived relay it runs once at
+// boot (if due) and the setInterval takes over — both correct. The interval path
+// is intentionally untouched: when the timer fires the data is due by definition.
+//
+// It keys on `fetchedAt` ("recently attempted — don't re-attempt"), NOT
+// recordCount/status, so a recent FAILED attempt also suppresses the next-boot
+// retry. That is deliberate: re-attempting a failing paid upstream on every 8-min
+// reboot is the exact abuse being prevented. Seeders that only write seed-meta on
+// success leave `fetchedAt` stale on failure and so still retry on boot; the
+// in-process retry timers cover stable relays.
+//
+// `metaKey` is the FULL Redis key the seeder writes (usually `seed-meta:<key>`,
+// sometimes a `relay:heartbeat:<key>` for script-delegated seeders). On any
+// read/parse failure the guard fails OPEN (seeds) so a Redis blip never starves a
+// panel. Returns the seedFn() promise (or a resolved promise when skipped) so the
+// call site's existing `.catch` still applies.
+async function maybeBootSeed(label, metaKey, intervalMs, seedFn) {
+  if (UPSTASH_ENABLED && metaKey && intervalMs > 0) {
+    try {
+      const meta = await upstashGet(metaKey);
+      const fetchedAt = Number(meta && meta.fetchedAt) || 0;
+      if (fetchedAt > 0) {
+        const ageMs = Date.now() - fetchedAt;
+        if (ageMs >= 0 && ageMs < intervalMs) {
+          console.log(`[${label}] Boot seed skipped — data fresh (age ${Math.round(ageMs / 60000)}min < ${Math.round(intervalMs / 60000)}min interval); next refresh via setInterval or a later reboot`);
+          return;
+        }
+      }
+    } catch (e) {
+      console.warn(`[${label}] Boot freshness check failed (${(e && e.message) || e}); seeding`);
+    }
+  }
+  return seedFn();
+}
+
 function upstashDel(key) {
   return new Promise((resolve) => {
     if (!UPSTASH_ENABLED) return resolve(false);
@@ -1586,7 +1637,7 @@ async function startUcdpSeedLoop() {
     return;
   }
   console.log(`[UCDP] Seed loop starting (interval ${UCDP_POLL_INTERVAL_MS / 1000 / 60}min, token: ${UCDP_ACCESS_TOKEN ? 'yes' : 'no'})`);
-  seedUcdpEvents().catch(e => console.warn('[UCDP] Initial seed error:', e?.message || e));
+  maybeBootSeed('UCDP', 'seed-meta:conflict:ucdp-events', UCDP_POLL_INTERVAL_MS, seedUcdpEvents).catch(e => console.warn('[UCDP] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedUcdpEvents().catch(e => console.warn('[UCDP] Seed error:', e?.message || e));
   }, UCDP_POLL_INTERVAL_MS).unref?.();
@@ -1719,7 +1770,7 @@ async function startSatelliteSeedLoop() {
     return;
   }
   console.log(`[Satellites] Seed loop starting (interval ${SAT_SEED_INTERVAL_MS / 1000 / 60}min)`);
-  seedSatelliteTLEs().catch(e => console.warn('[Satellites] Initial seed error:', e?.message || e));
+  maybeBootSeed('Satellites', 'seed-meta:intelligence:satellites', SAT_SEED_INTERVAL_MS, seedSatelliteTLEs).catch(e => console.warn('[Satellites] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedSatelliteTLEs().catch(e => console.warn('[Satellites] Seed error:', e?.message || e));
   }, SAT_SEED_INTERVAL_MS).unref?.();
@@ -2573,7 +2624,7 @@ async function startMarketDataSeedLoop() {
     return;
   }
   console.log(`[Market] Seed loop starting (interval ${MARKET_SEED_INTERVAL_MS / 1000 / 60}min, finnhub: ${FINNHUB_API_KEY ? 'yes' : 'no'})`);
-  seedAllMarketData().catch((e) => console.warn('[Market] Initial seed error:', e?.message || e));
+  maybeBootSeed('Market', 'seed-meta:market:stocks', MARKET_SEED_INTERVAL_MS, seedAllMarketData).catch((e) => console.warn('[Market] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedAllMarketData().catch((e) => console.warn('[Market] Seed error:', e?.message || e));
   }, MARKET_SEED_INTERVAL_MS).unref?.();
@@ -2966,7 +3017,7 @@ async function startCyberThreatsSeedLoop() {
     return;
   }
   console.log(`[Cyber] Seed loop starting (interval ${CYBER_SEED_INTERVAL_MS / 1000 / 60 / 60}h, urlhaus:${URLHAUS_AUTH_KEY ? 'yes' : 'no'} otx:${OTX_API_KEY ? 'yes' : 'no'} abuseipdb:${ABUSEIPDB_API_KEY ? 'yes' : 'no'})`);
-  seedCyberThreats().catch((e) => console.warn('[Cyber] Initial seed error:', e?.message || e));
+  maybeBootSeed('Cyber', 'seed-meta:cyber:threats', CYBER_SEED_INTERVAL_MS, seedCyberThreats).catch((e) => console.warn('[Cyber] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedCyberThreats().catch((e) => console.warn('[Cyber] Seed error:', e?.message || e));
   }, CYBER_SEED_INTERVAL_MS).unref?.();
@@ -3148,7 +3199,7 @@ async function startPositiveEventsSeedLoop() {
     return;
   }
   console.log(`[PositiveEvents] Seed loop starting (interval ${POSITIVE_EVENTS_INTERVAL_MS / 1000 / 60}min)`);
-  seedPositiveEvents().catch((e) => console.warn('[PositiveEvents] Initial seed error:', e?.message || e));
+  maybeBootSeed('PositiveEvents', 'seed-meta:positive-events:geo', POSITIVE_EVENTS_INTERVAL_MS, seedPositiveEvents).catch((e) => console.warn('[PositiveEvents] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedPositiveEvents().catch((e) => console.warn('[PositiveEvents] Seed error:', e?.message || e));
   }, POSITIVE_EVENTS_INTERVAL_MS).unref?.();
@@ -3752,7 +3803,7 @@ async function startClassifySeedLoop() {
   }
   const activeProviders = CLASSIFY_LLM_PROVIDERS.filter((p) => !!process.env[p.envKey]).map((p) => p.name);
   console.log(`[Classify] Seed loop starting (interval ${CLASSIFY_SEED_INTERVAL_MS / 1000 / 60}min, providers:${activeProviders.length ? activeProviders.join(',') : 'none'})`);
-  seedClassify().catch((e) => console.warn('[Classify] Initial seed error:', e?.message || e));
+  maybeBootSeed('Classify', 'seed-meta:classify', CLASSIFY_SEED_INTERVAL_MS, seedClassify).catch((e) => console.warn('[Classify] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedClassify().catch((e) => console.warn('[Classify] Seed error:', e?.message || e));
   }, CLASSIFY_SEED_INTERVAL_MS).unref?.();
@@ -4330,7 +4381,7 @@ function startTheaterPostureSeedLoop() {
   console.log(`[TheaterPosture] Seed loop starting (interval ${THEATER_POSTURE_SEED_INTERVAL_MS / 1000 / 60}min)`);
   // Delay initial seed 30s to let the relay's OpenSky proxy start up
   setTimeout(() => {
-    seedTheaterPosture().catch((e) => console.warn('[TheaterPosture] Initial seed error:', e?.message || e));
+    maybeBootSeed('TheaterPosture', 'seed-meta:theater-posture', THEATER_POSTURE_SEED_INTERVAL_MS, seedTheaterPosture).catch((e) => console.warn('[TheaterPosture] Initial seed error:', e?.message || e));
     setInterval(() => {
       seedTheaterPosture().catch((e) => console.warn('[TheaterPosture] Seed error:', e?.message || e));
     }, THEATER_POSTURE_SEED_INTERVAL_MS).unref?.();
@@ -4619,7 +4670,7 @@ async function startWeatherSeedLoop() {
     return;
   }
   console.log(`[Weather] Seed loop starting (interval ${WEATHER_SEED_INTERVAL_MS / 1000 / 60}min)`);
-  seedWeatherAlerts().catch((e) => console.warn('[Weather] Initial seed error:', e?.message || e));
+  maybeBootSeed('Weather', 'seed-meta:weather:alerts', WEATHER_SEED_INTERVAL_MS, seedWeatherAlerts).catch((e) => console.warn('[Weather] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedWeatherAlerts().catch((e) => console.warn('[Weather] Seed error:', e?.message || e));
   }, WEATHER_SEED_INTERVAL_MS).unref?.();
@@ -4716,7 +4767,7 @@ async function startSpendingSeedLoop() {
     return;
   }
   console.log(`[Spending] Seed loop starting (interval ${SPENDING_SEED_INTERVAL_MS / 1000 / 60}min)`);
-  seedUsaSpending().catch((e) => console.warn('[Spending] Initial seed error:', e?.message || e));
+  maybeBootSeed('Spending', 'seed-meta:economic:spending', SPENDING_SEED_INTERVAL_MS, seedUsaSpending).catch((e) => console.warn('[Spending] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedUsaSpending().catch((e) => console.warn('[Spending] Seed error:', e?.message || e));
   }, SPENDING_SEED_INTERVAL_MS).unref?.();
@@ -4831,7 +4882,7 @@ async function startGscpiSeedLoop() {
     return;
   }
   console.log('[GSCPI] Seed loop starting (interval 24h)');
-  seedGscpi().catch((e) => console.warn('[GSCPI] Initial seed error:', e?.message || e));
+  maybeBootSeed('GSCPI', 'seed-meta:economic:gscpi', GSCPI_SEED_INTERVAL_MS, seedGscpi).catch((e) => console.warn('[GSCPI] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedGscpi().catch((e) => console.warn('[GSCPI] Seed error:', e?.message || e));
   }, GSCPI_SEED_INTERVAL_MS).unref?.();
@@ -5040,7 +5091,7 @@ async function startTechEventsSeedLoop() {
     return;
   }
   console.log(`[TechEvents] Seed loop starting (interval ${TECH_EVENTS_SEED_INTERVAL_MS / 1000 / 60 / 60}h)`);
-  seedTechEvents().catch((e) => console.warn('[TechEvents] Initial seed error:', e?.message || e));
+  maybeBootSeed('TechEvents', 'seed-meta:research:tech-events', TECH_EVENTS_SEED_INTERVAL_MS, seedTechEvents).catch((e) => console.warn('[TechEvents] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedTechEvents().catch((e) => console.warn('[TechEvents] Seed error:', e?.message || e));
   }, TECH_EVENTS_SEED_INTERVAL_MS).unref?.();
@@ -5302,7 +5353,7 @@ async function startWorldBankSeedLoop() {
     return;
   }
   console.log(`[WB] Seed loop starting (interval ${WB_SEED_INTERVAL_MS / 1000 / 60 / 60}h)`);
-  seedWorldBank().catch(e => console.warn('[WB] Initial seed error:', e?.message || e));
+  maybeBootSeed('WB', `seed-meta:${WB_BOOTSTRAP_KEY}`, WB_SEED_INTERVAL_MS, seedWorldBank).catch(e => console.warn('[WB] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedWorldBank().catch(e => console.warn('[WB] Seed error:', e?.message || e));
   }, WB_SEED_INTERVAL_MS).unref?.();
@@ -5406,7 +5457,7 @@ async function startCorridorRiskSeedLoop() {
     return;
   }
   console.log(`[CorridorRisk] Seed loop starting (interval ${CORRIDOR_RISK_SEED_INTERVAL_MS / 1000 / 60}min)`);
-  seedCorridorRisk().catch(e => console.warn('[CorridorRisk] Initial seed error:', e?.message || e));
+  maybeBootSeed('CorridorRisk', 'seed-meta:supply_chain:corridorrisk', CORRIDOR_RISK_SEED_INTERVAL_MS, seedCorridorRisk).catch(e => console.warn('[CorridorRisk] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedCorridorRisk().catch(e => console.warn('[CorridorRisk] Seed error:', e?.message || e));
   }, CORRIDOR_RISK_SEED_INTERVAL_MS).unref?.();
@@ -5655,7 +5706,7 @@ async function startUsniFleetSeedLoop() {
     return;
   }
   console.log(`[USNI] Seed loop starting (interval ${USNI_SEED_INTERVAL_MS / 1000 / 60 / 60}h)`);
-  seedUsniFleet().catch(e => console.warn('[USNI] Initial seed error:', e?.message || e));
+  maybeBootSeed('USNI', 'seed-meta:military:usni-fleet', USNI_SEED_INTERVAL_MS, seedUsniFleet).catch(e => console.warn('[USNI] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedUsniFleet().catch(e => console.warn('[USNI] Seed error:', e?.message || e));
   }, USNI_SEED_INTERVAL_MS).unref?.();
@@ -5740,7 +5791,7 @@ async function startShippingStressSeedLoop() {
     return;
   }
   console.log(`[ShippingStress] Seed loop starting (interval ${SHIPPING_STRESS_INTERVAL_MS / 1000 / 60}min)`);
-  seedShippingStress().catch(e => console.warn('[ShippingStress] Initial seed error:', e?.message || e));
+  maybeBootSeed('ShippingStress', 'seed-meta:supply_chain:shipping_stress', SHIPPING_STRESS_INTERVAL_MS, seedShippingStress).catch(e => console.warn('[ShippingStress] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedShippingStress().catch(e => console.warn('[ShippingStress] Seed error:', e?.message || e));
   }, SHIPPING_STRESS_INTERVAL_MS).unref?.();
@@ -6101,7 +6152,7 @@ async function startSocialVelocitySeedLoop() {
     return;
   }
   console.log(`[SocialVelocity] Seed loop starting (interval ${SOCIAL_VELOCITY_INTERVAL_MS / 1000 / 60}min)`);
-  seedSocialVelocity().catch(e => console.warn('[SocialVelocity] Initial seed error:', e?.message || e));
+  maybeBootSeed('SocialVelocity', SOCIAL_VELOCITY_SEED_META_KEY, SOCIAL_VELOCITY_INTERVAL_MS, seedSocialVelocity).catch(e => console.warn('[SocialVelocity] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedSocialVelocity().catch(e => console.warn('[SocialVelocity] Seed error:', e?.message || e));
   }, SOCIAL_VELOCITY_INTERVAL_MS).unref?.();
@@ -6293,7 +6344,7 @@ async function startWsbTickersSeedLoop() {
     return;
   }
   console.log(`[WsbTickers] Seed loop starting (interval ${WSB_TICKERS_INTERVAL_MS / 1000 / 60}min)`);
-  seedWsbTickers().catch(e => console.warn('[WsbTickers] Initial seed error:', e?.message || e));
+  maybeBootSeed('WsbTickers', 'seed-meta:intelligence:wsb-tickers', WSB_TICKERS_INTERVAL_MS, seedWsbTickers).catch(e => console.warn('[WsbTickers] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedWsbTickers().catch(e => console.warn('[WsbTickers] Seed error:', e?.message || e));
   }, WSB_TICKERS_INTERVAL_MS).unref?.();
@@ -6369,7 +6420,7 @@ function startClimateNewsSeedLoop() {
     return;
   }
   console.log(`[ClimateNewsSeed] Seed loop starting (interval ${CLIMATE_NEWS_SEED_INTERVAL_MS / 1000 / 60}min)`);
-  seedClimateNews().catch((e) => console.warn('[ClimateNewsSeed] Initial seed error:', e?.message || e));
+  maybeBootSeed('ClimateNewsSeed', 'relay:heartbeat:climate-news', CLIMATE_NEWS_SEED_INTERVAL_MS, seedClimateNews).catch((e) => console.warn('[ClimateNewsSeed] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedClimateNews().catch((e) => console.warn('[ClimateNewsSeed] Seed error:', e?.message || e));
   }, CLIMATE_NEWS_SEED_INTERVAL_MS).unref?.();
@@ -6441,7 +6492,7 @@ function startChokepointFlowsSeedLoop() {
     return;
   }
   console.log(`[ChokepointFlows] Seed loop starting (interval ${CHOKEPOINT_FLOWS_SEED_INTERVAL_MS / 1000 / 60}min)`);
-  seedChokepointFlows().catch((e) => console.warn('[ChokepointFlows] Initial seed error:', e?.message || e));
+  maybeBootSeed('ChokepointFlows', 'relay:heartbeat:chokepoint-flows', CHOKEPOINT_FLOWS_SEED_INTERVAL_MS, seedChokepointFlows).catch((e) => console.warn('[ChokepointFlows] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedChokepointFlows().catch((e) => console.warn('[ChokepointFlows] Seed error:', e?.message || e));
   }, CHOKEPOINT_FLOWS_SEED_INTERVAL_MS).unref?.();
@@ -6571,7 +6622,7 @@ function startPizzintSeedLoop() {
     return;
   }
   console.log(`[PizzINT] Seed loop starting (interval ${PIZZINT_SEED_INTERVAL_MS / 1000 / 60}min)`);
-  seedPizzint().catch((e) => console.warn('[PizzINT] Initial seed error:', e?.message || e));
+  maybeBootSeed('PizzINT', 'seed-meta:intelligence:pizzint', PIZZINT_SEED_INTERVAL_MS, seedPizzint).catch((e) => console.warn('[PizzINT] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedPizzint().catch((e) => console.warn('[PizzINT] Seed error:', e?.message || e));
   }, PIZZINT_SEED_INTERVAL_MS).unref?.();
@@ -6725,7 +6776,7 @@ function startDodoPriceSeedLoop() {
   if (!UPSTASH_ENABLED) { console.log('[DodoPrices] Disabled (no Upstash Redis)'); return; }
   if (!DODO_PRICE_API_KEY) { console.log('[DodoPrices] Disabled (no DODO_API_KEY)'); return; }
   console.log(`[DodoPrices] Seed loop starting (interval ${DODO_PRICE_SEED_INTERVAL_MS / 1000 / 60}min)`);
-  seedDodoPrices().catch((e) => console.warn('[DodoPrices] Initial seed error:', e?.message || e));
+  maybeBootSeed('DodoPrices', 'seed-meta:product-catalog', DODO_PRICE_SEED_INTERVAL_MS, seedDodoPrices).catch((e) => console.warn('[DodoPrices] Initial seed error:', e?.message || e));
   setInterval(() => {
     seedDodoPrices().catch((e) => console.warn('[DodoPrices] Seed error:', e?.message || e));
   }, DODO_PRICE_SEED_INTERVAL_MS).unref?.();
@@ -7741,7 +7792,7 @@ async function seedChokepointTransits() {
 }
 
 setTimeout(() => {
-  seedChokepointTransits().catch(err => console.error('[Transit] Initial seed error:', err.message));
+  maybeBootSeed('Transit', 'seed-meta:supply_chain:chokepoint_transits', CHOKEPOINT_TRANSIT_INTERVAL_MS, seedChokepointTransits).catch(err => console.error('[Transit] Initial seed error:', err.message));
 }, 30_000);
 setInterval(() => {
   seedChokepointTransits().catch(err => console.error('[Transit] Seed error:', err.message));
@@ -7897,7 +7948,7 @@ async function seedTransitSummaries() {
 
 // Seed transit summaries every 10 min (same as transit counter)
 setTimeout(() => {
-  seedTransitSummaries().catch(e => console.warn('[TransitSummary] Initial seed error:', e?.message || e));
+  maybeBootSeed('TransitSummary', 'seed-meta:supply_chain:transit-summaries', TRANSIT_SUMMARY_INTERVAL_MS, seedTransitSummaries).catch(e => console.warn('[TransitSummary] Initial seed error:', e?.message || e));
 }, 35_000);
 setInterval(() => {
   seedTransitSummaries().catch(e => console.warn('[TransitSummary] Seed error:', e?.message || e));

--- a/tests/relay-boot-seed-freshness-guard.test.mjs
+++ b/tests/relay-boot-seed-freshness-guard.test.mjs
@@ -1,0 +1,187 @@
+// Boot-seed freshness guard — behavioral + wiring regression tests.
+//
+// ais-relay is recycled frequently on proxy.worldmonitor.app. Every seed loop
+// fires an IMMEDIATE seed on boot and then schedules a setInterval at its real
+// cadence — but the process is usually recycled long before that interval
+// elapses, so the boot seed is the de-facto scheduler. During a reboot storm
+// that re-fetches every upstream on every boot (~8 min apart) instead of on its
+// interval: paid ScrapeCreators credits, plus rate-limit/ban risk for Reddit,
+// Yahoo, CoinGecko, UCDP, OpenSky, etc.
+//
+// `maybeBootSeed(label, metaKey, intervalMs, seedFn)` gates the boot seed on the
+// existing seed-meta age and only runs the seed when a refresh is actually due.
+//
+// ais-relay.cjs calls server.listen() at top level and has no module.exports, so
+// it cannot be imported. These tests (1) extract the real maybeBootSeed body and
+// exercise its behavior against mocked Redis, and (2) assert the source wires
+// every fixed-schedule external seeder through it while leaving the setInterval
+// path — and real-time pollers / internal warm-pings — untouched.
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const relaySource = readFileSync(resolve(here, '../scripts/ais-relay.cjs'), 'utf8');
+
+// ── Extract the real maybeBootSeed function body via brace-matching ──────────
+function extractFunction(src, signature) {
+  const start = src.indexOf(signature);
+  assert.notEqual(start, -1, `missing function: ${signature}`);
+  const open = src.indexOf('{', start);
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    const c = src[i];
+    if (c === '{') depth++;
+    else if (c === '}') {
+      depth--;
+      if (depth === 0) return src.slice(start, i + 1);
+    }
+  }
+  throw new Error(`unbalanced braces for ${signature}`);
+}
+
+const fnText = extractFunction(relaySource, 'async function maybeBootSeed(label, metaKey, intervalMs, seedFn)');
+
+// Rebuild the function with its free variables injected as closure params.
+// (It references UPSTASH_ENABLED, upstashGet, console, plus globals Date/Number/Math.)
+function buildGuard({ enabled = true, get = async () => null } = {}) {
+  const logs = [];
+  const fakeConsole = { log: (...a) => logs.push(['log', ...a]), warn: (...a) => logs.push(['warn', ...a]) };
+  const factory = new Function('UPSTASH_ENABLED', 'upstashGet', 'console', `return (${fnText});`);
+  return { guard: factory(enabled, get, fakeConsole), logs };
+}
+
+const MIN = 60 * 1000;
+
+test('skips the boot seed when data is fresher than the interval', async () => {
+  let called = false;
+  const { guard } = buildGuard({ get: async () => ({ fetchedAt: Date.now() - 5 * MIN, recordCount: 10 }) });
+  await guard('X', 'seed-meta:x', 180 * MIN, async () => { called = true; });
+  assert.equal(called, false, 'fresh data must suppress the boot seed');
+});
+
+test('runs the boot seed when data is older than the interval (refresh due)', async () => {
+  let called = false;
+  const { guard } = buildGuard({ get: async () => ({ fetchedAt: Date.now() - 200 * MIN, recordCount: 10 }) });
+  await guard('X', 'seed-meta:x', 180 * MIN, async () => { called = true; });
+  assert.equal(called, true, 'stale data must trigger the boot seed');
+});
+
+test('runs the boot seed when there is no prior seed-meta', async () => {
+  let called = false;
+  const { guard } = buildGuard({ get: async () => null });
+  await guard('X', 'seed-meta:x', 180 * MIN, async () => { called = true; });
+  assert.equal(called, true);
+});
+
+test('fails OPEN — a Redis read error still seeds (never starves a panel)', async () => {
+  let called = false;
+  const { guard, logs } = buildGuard({ get: async () => { throw new Error('redis down'); } });
+  await guard('X', 'seed-meta:x', 180 * MIN, async () => { called = true; });
+  assert.equal(called, true, 'a meta read failure must fall through to seeding');
+  assert.ok(logs.some(([lvl, msg]) => lvl === 'warn' && /freshness check failed/.test(String(msg))));
+});
+
+test('runs the boot seed when Upstash is disabled (no gate possible)', async () => {
+  let called = false;
+  const { guard } = buildGuard({ enabled: false, get: async () => ({ fetchedAt: Date.now() }) });
+  await guard('X', 'seed-meta:x', 180 * MIN, async () => { called = true; });
+  assert.equal(called, true);
+});
+
+test('a future-dated fetchedAt (negative age) is treated defensively — seeds', async () => {
+  let called = false;
+  const { guard } = buildGuard({ get: async () => ({ fetchedAt: Date.now() + 60 * MIN }) });
+  await guard('X', 'seed-meta:x', 180 * MIN, async () => { called = true; });
+  assert.equal(called, true, 'corrupt future timestamp must not permanently suppress seeding');
+});
+
+test('intervalMs<=0 disables the gate (always seeds)', async () => {
+  let called = false;
+  const { guard } = buildGuard({ get: async () => ({ fetchedAt: Date.now() }) });
+  await guard('X', 'seed-meta:x', 0, async () => { called = true; });
+  assert.equal(called, true);
+});
+
+test('propagates the seedFn promise so the call site .catch still applies', async () => {
+  const { guard } = buildGuard({ get: async () => null });
+  await assert.rejects(
+    () => guard('X', 'seed-meta:x', 180 * MIN, async () => { throw new Error('seed boom'); }),
+    /seed boom/,
+  );
+});
+
+// ── Wiring: every fixed-schedule external seeder routes its boot seed through
+// maybeBootSeed with the exact (label, metaKey, intervalConst, seedFn). The
+// exact-string match pins all four arguments so a future edit can't silently
+// drift the meta key or interval and re-open the boot-abuse hole. ────────────
+const SEEDERS = [
+  ['UCDP', "'seed-meta:conflict:ucdp-events'", 'UCDP_POLL_INTERVAL_MS', 'seedUcdpEvents'],
+  ['Satellites', "'seed-meta:intelligence:satellites'", 'SAT_SEED_INTERVAL_MS', 'seedSatelliteTLEs'],
+  ['Market', "'seed-meta:market:stocks'", 'MARKET_SEED_INTERVAL_MS', 'seedAllMarketData'],
+  ['PositiveEvents', "'seed-meta:positive-events:geo'", 'POSITIVE_EVENTS_INTERVAL_MS', 'seedPositiveEvents'],
+  ['Classify', "'seed-meta:classify'", 'CLASSIFY_SEED_INTERVAL_MS', 'seedClassify'],
+  ['TheaterPosture', "'seed-meta:theater-posture'", 'THEATER_POSTURE_SEED_INTERVAL_MS', 'seedTheaterPosture'],
+  ['Weather', "'seed-meta:weather:alerts'", 'WEATHER_SEED_INTERVAL_MS', 'seedWeatherAlerts'],
+  ['Spending', "'seed-meta:economic:spending'", 'SPENDING_SEED_INTERVAL_MS', 'seedUsaSpending'],
+  ['GSCPI', "'seed-meta:economic:gscpi'", 'GSCPI_SEED_INTERVAL_MS', 'seedGscpi'],
+  ['TechEvents', "'seed-meta:research:tech-events'", 'TECH_EVENTS_SEED_INTERVAL_MS', 'seedTechEvents'],
+  ['WB', '`seed-meta:${WB_BOOTSTRAP_KEY}`', 'WB_SEED_INTERVAL_MS', 'seedWorldBank'],
+  ['CorridorRisk', "'seed-meta:supply_chain:corridorrisk'", 'CORRIDOR_RISK_SEED_INTERVAL_MS', 'seedCorridorRisk'],
+  ['USNI', "'seed-meta:military:usni-fleet'", 'USNI_SEED_INTERVAL_MS', 'seedUsniFleet'],
+  ['ShippingStress', "'seed-meta:supply_chain:shipping_stress'", 'SHIPPING_STRESS_INTERVAL_MS', 'seedShippingStress'],
+  ['SocialVelocity', 'SOCIAL_VELOCITY_SEED_META_KEY', 'SOCIAL_VELOCITY_INTERVAL_MS', 'seedSocialVelocity'],
+  ['WsbTickers', "'seed-meta:intelligence:wsb-tickers'", 'WSB_TICKERS_INTERVAL_MS', 'seedWsbTickers'],
+  ['ClimateNewsSeed', "'relay:heartbeat:climate-news'", 'CLIMATE_NEWS_SEED_INTERVAL_MS', 'seedClimateNews'],
+  ['ChokepointFlows', "'relay:heartbeat:chokepoint-flows'", 'CHOKEPOINT_FLOWS_SEED_INTERVAL_MS', 'seedChokepointFlows'],
+  ['PizzINT', "'seed-meta:intelligence:pizzint'", 'PIZZINT_SEED_INTERVAL_MS', 'seedPizzint'],
+  ['DodoPrices', "'seed-meta:product-catalog'", 'DODO_PRICE_SEED_INTERVAL_MS', 'seedDodoPrices'],
+  ['Transit', "'seed-meta:supply_chain:chokepoint_transits'", 'CHOKEPOINT_TRANSIT_INTERVAL_MS', 'seedChokepointTransits'],
+  ['TransitSummary', "'seed-meta:supply_chain:transit-summaries'", 'TRANSIT_SUMMARY_INTERVAL_MS', 'seedTransitSummaries'],
+  ['Cyber', "'seed-meta:cyber:threats'", 'CYBER_SEED_INTERVAL_MS', 'seedCyberThreats'],
+];
+
+for (const [label, metaKey, intervalConst, seedFn] of SEEDERS) {
+  test(`${label} boot seed is gated through maybeBootSeed(${intervalConst}, ${seedFn})`, () => {
+    const call = `maybeBootSeed('${label}', ${metaKey}, ${intervalConst}, ${seedFn})`;
+    assert.ok(relaySource.includes(call), `expected boot-seed wiring: ${call}`);
+    // The setInterval (real-cadence) path must remain a direct, UNGATED call so a
+    // long-lived relay still refreshes when the timer fires (data is due then).
+    assert.ok(relaySource.includes(`${seedFn}().catch`), `${seedFn} interval path must stay a direct call`);
+  });
+}
+
+test('exactly the expected number of boot seeds are gated (no drift)', () => {
+  const count = (relaySource.match(/maybeBootSeed\('/g) || []).length;
+  assert.equal(count, SEEDERS.length, `expected ${SEEDERS.length} gated boot seeds, found ${count}`);
+});
+
+// ── Exclusions: internal warm-pings short-circuit at their own endpoint when the
+// data is fresh (cheap), so gating them adds risk for no benefit; real-time
+// pollers must run continuously. None of these may be wrapped. ───────────────
+test('internal warm-pings are NOT gated (self-limiting at the endpoint)', () => {
+  for (const label of ['ServiceStatuses', 'CII', 'Chokepoints', 'CableHealth']) {
+    assert.ok(!relaySource.includes(`maybeBootSeed('${label}'`), `warm-ping ${label} must not be gated`);
+  }
+  // and the warm-pings still fire their immediate boot ping
+  assert.match(relaySource, /seedServiceStatuses\(\)\.catch/);
+  assert.match(relaySource, /seedCiiWarmPing\(\)\.catch/);
+});
+
+test('real-time pollers are NOT gated (must run continuously on every boot)', () => {
+  for (const label of ['Telegram', 'Oref', 'OREF']) {
+    assert.ok(!relaySource.includes(`maybeBootSeed('${label}'`), `poller ${label} must not be gated`);
+  }
+});
+
+test('maybeBootSeed fails open and keys on fetchedAt (source contract)', () => {
+  // guard only engages when Upstash is on AND a key + positive interval are given
+  assert.match(fnText, /if \(UPSTASH_ENABLED && metaKey && intervalMs > 0\)/);
+  // sane positive age strictly under the interval → skip
+  assert.match(fnText, /if \(ageMs >= 0 && ageMs < intervalMs\)/);
+  // terminal path always seeds (fail-open / not-fresh)
+  assert.match(fnText, /return seedFn\(\);\s*}$/);
+});

--- a/tests/relay-boot-seed-freshness-guard.test.mjs
+++ b/tests/relay-boot-seed-freshness-guard.test.mjs
@@ -8,14 +8,16 @@
 // interval: paid ScrapeCreators credits, plus rate-limit/ban risk for Reddit,
 // Yahoo, CoinGecko, UCDP, OpenSky, etc.
 //
-// `maybeBootSeed(label, metaKey, intervalMs, seedFn)` gates the boot seed on the
-// existing seed-meta age and only runs the seed when a refresh is actually due.
+// `bootSeedDelayMs(label, metaKey, intervalMs)` gates the boot seed on the
+// existing seed-meta age, and `startBootSeedLoop` schedules the first skipped
+// refresh for the remaining freshness window before starting the recurring
+// interval.
 //
 // ais-relay.cjs calls server.listen() at top level and has no module.exports, so
-// it cannot be imported. These tests (1) extract the real maybeBootSeed body and
-// exercise its behavior against mocked Redis, and (2) assert the source wires
-// every fixed-schedule external seeder through it while leaving the setInterval
-// path — and real-time pollers / internal warm-pings — untouched.
+// it cannot be imported. These tests (1) extract the real guard/scheduler bodies
+// and exercise them against mocked Redis/timers, and (2) assert the source wires
+// every fixed-schedule external seeder through the scheduler while leaving
+// real-time pollers / internal warm-pings untouched.
 
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
@@ -26,7 +28,7 @@ import assert from 'node:assert/strict';
 const here = dirname(fileURLToPath(import.meta.url));
 const relaySource = readFileSync(resolve(here, '../scripts/ais-relay.cjs'), 'utf8');
 
-// ── Extract the real maybeBootSeed function body via brace-matching ──────────
+// -- Extract real function bodies via brace-matching ---------------------------
 function extractFunction(src, signature) {
   const start = src.indexOf(signature);
   assert.notEqual(start, -1, `missing function: ${signature}`);
@@ -43,81 +45,128 @@ function extractFunction(src, signature) {
   throw new Error(`unbalanced braces for ${signature}`);
 }
 
-const fnText = extractFunction(relaySource, 'async function maybeBootSeed(label, metaKey, intervalMs, seedFn)');
+const delayFnText = extractFunction(relaySource, 'async function bootSeedDelayMs(label, metaKey, intervalMs)');
+const loopFnText = extractFunction(relaySource, 'function startBootSeedLoop(label, metaKey, intervalMs, seedFn, onInitialError, onSeedError = onInitialError)');
 
 // Rebuild the function with its free variables injected as closure params.
 // (It references UPSTASH_ENABLED, upstashGet, console, plus globals Date/Number/Math.)
-function buildGuard({ enabled = true, get = async () => null } = {}) {
+function buildDelayResolver({ enabled = true, get = async () => null } = {}) {
   const logs = [];
   const fakeConsole = { log: (...a) => logs.push(['log', ...a]), warn: (...a) => logs.push(['warn', ...a]) };
-  const factory = new Function('UPSTASH_ENABLED', 'upstashGet', 'console', `return (${fnText});`);
-  return { guard: factory(enabled, get, fakeConsole), logs };
+  const factory = new Function('UPSTASH_ENABLED', 'upstashGet', 'console', `return (${delayFnText});`);
+  return { resolveDelay: factory(enabled, get, fakeConsole), logs };
+}
+
+function buildLoop({ delay = 0 } = {}) {
+  const timeouts = [];
+  const intervals = [];
+  const initialErrors = [];
+  const seedErrors = [];
+  let seedCalls = 0;
+  const fakeSetTimeout = (fn, ms) => {
+    const timer = { fn, ms, unrefCalled: false, unref() { this.unrefCalled = true; } };
+    timeouts.push(timer);
+    return timer;
+  };
+  const fakeSetInterval = (fn, ms) => {
+    const timer = { fn, ms, unrefCalled: false, unref() { this.unrefCalled = true; } };
+    intervals.push(timer);
+    return timer;
+  };
+  const fakeDelayResolver = async () => delay;
+  const factory = new Function('bootSeedDelayMs', 'setTimeout', 'setInterval', `return (${loopFnText});`);
+  const loop = factory(fakeDelayResolver, fakeSetTimeout, fakeSetInterval);
+  const seedFn = async () => { seedCalls++; };
+  const onInitialError = (e) => { initialErrors.push(e); };
+  const onSeedError = (e) => { seedErrors.push(e); };
+  return {
+    loop,
+    seedFn,
+    onInitialError,
+    onSeedError,
+    timeouts,
+    intervals,
+    initialErrors,
+    seedErrors,
+    get seedCalls() { return seedCalls; },
+  };
 }
 
 const MIN = 60 * 1000;
 
-test('skips the boot seed when data is fresher than the interval', async () => {
-  let called = false;
-  const { guard } = buildGuard({ get: async () => ({ fetchedAt: Date.now() - 5 * MIN, recordCount: 10 }) });
-  await guard('X', 'seed-meta:x', 180 * MIN, async () => { called = true; });
-  assert.equal(called, false, 'fresh data must suppress the boot seed');
+async function flushMicrotasks() {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+test('returns the remaining freshness window when data is fresher than the interval', async () => {
+  const { resolveDelay } = buildDelayResolver({ get: async () => ({ fetchedAt: Date.now() - 5 * MIN, recordCount: 10 }) });
+  const delayMs = await resolveDelay('X', 'seed-meta:x', 180 * MIN);
+  assert.ok(delayMs > 174 * MIN && delayMs <= 175 * MIN, `fresh data should delay roughly 175min, got ${delayMs}`);
 });
 
-test('runs the boot seed when data is older than the interval (refresh due)', async () => {
-  let called = false;
-  const { guard } = buildGuard({ get: async () => ({ fetchedAt: Date.now() - 200 * MIN, recordCount: 10 }) });
-  await guard('X', 'seed-meta:x', 180 * MIN, async () => { called = true; });
-  assert.equal(called, true, 'stale data must trigger the boot seed');
+test('returns 0 delay when data is older than the interval (refresh due)', async () => {
+  const { resolveDelay } = buildDelayResolver({ get: async () => ({ fetchedAt: Date.now() - 200 * MIN, recordCount: 10 }) });
+  assert.equal(await resolveDelay('X', 'seed-meta:x', 180 * MIN), 0);
 });
 
-test('runs the boot seed when there is no prior seed-meta', async () => {
-  let called = false;
-  const { guard } = buildGuard({ get: async () => null });
-  await guard('X', 'seed-meta:x', 180 * MIN, async () => { called = true; });
-  assert.equal(called, true);
+test('returns 0 delay when there is no prior seed-meta', async () => {
+  const { resolveDelay } = buildDelayResolver({ get: async () => null });
+  assert.equal(await resolveDelay('X', 'seed-meta:x', 180 * MIN), 0);
 });
 
-test('fails OPEN — a Redis read error still seeds (never starves a panel)', async () => {
-  let called = false;
-  const { guard, logs } = buildGuard({ get: async () => { throw new Error('redis down'); } });
-  await guard('X', 'seed-meta:x', 180 * MIN, async () => { called = true; });
-  assert.equal(called, true, 'a meta read failure must fall through to seeding');
+test('fails OPEN — a Redis read error returns 0 delay (never starves a panel)', async () => {
+  const { resolveDelay, logs } = buildDelayResolver({ get: async () => { throw new Error('redis down'); } });
+  assert.equal(await resolveDelay('X', 'seed-meta:x', 180 * MIN), 0);
   assert.ok(logs.some(([lvl, msg]) => lvl === 'warn' && /freshness check failed/.test(String(msg))));
 });
 
-test('runs the boot seed when Upstash is disabled (no gate possible)', async () => {
-  let called = false;
-  const { guard } = buildGuard({ enabled: false, get: async () => ({ fetchedAt: Date.now() }) });
-  await guard('X', 'seed-meta:x', 180 * MIN, async () => { called = true; });
-  assert.equal(called, true);
+test('returns 0 delay when Upstash is disabled (no gate possible)', async () => {
+  const { resolveDelay } = buildDelayResolver({ enabled: false, get: async () => ({ fetchedAt: Date.now() }) });
+  assert.equal(await resolveDelay('X', 'seed-meta:x', 180 * MIN), 0);
 });
 
-test('a future-dated fetchedAt (negative age) is treated defensively — seeds', async () => {
-  let called = false;
-  const { guard } = buildGuard({ get: async () => ({ fetchedAt: Date.now() + 60 * MIN }) });
-  await guard('X', 'seed-meta:x', 180 * MIN, async () => { called = true; });
-  assert.equal(called, true, 'corrupt future timestamp must not permanently suppress seeding');
+test('a future-dated fetchedAt (negative age) is treated defensively — 0 delay', async () => {
+  const { resolveDelay } = buildDelayResolver({ get: async () => ({ fetchedAt: Date.now() + 60 * MIN }) });
+  assert.equal(await resolveDelay('X', 'seed-meta:x', 180 * MIN), 0);
 });
 
-test('intervalMs<=0 disables the gate (always seeds)', async () => {
-  let called = false;
-  const { guard } = buildGuard({ get: async () => ({ fetchedAt: Date.now() }) });
-  await guard('X', 'seed-meta:x', 0, async () => { called = true; });
-  assert.equal(called, true);
+test('intervalMs<=0 disables the gate (0 delay)', async () => {
+  const { resolveDelay } = buildDelayResolver({ get: async () => ({ fetchedAt: Date.now() }) });
+  assert.equal(await resolveDelay('X', 'seed-meta:x', 0), 0);
 });
 
-test('propagates the seedFn promise so the call site .catch still applies', async () => {
-  const { guard } = buildGuard({ get: async () => null });
-  await assert.rejects(
-    () => guard('X', 'seed-meta:x', 180 * MIN, async () => { throw new Error('seed boom'); }),
-    /seed boom/,
-  );
+test('startBootSeedLoop seeds immediately and starts the recurring interval when delay is 0', async () => {
+  const harness = buildLoop({ delay: 0 });
+  harness.loop('X', 'seed-meta:x', 180 * MIN, harness.seedFn, harness.onInitialError, harness.onSeedError);
+  await flushMicrotasks();
+  assert.equal(harness.seedCalls, 1);
+  assert.equal(harness.timeouts.length, 0);
+  assert.equal(harness.intervals.length, 1);
+  assert.equal(harness.intervals[0].ms, 180 * MIN);
+  assert.equal(harness.intervals[0].unrefCalled, true);
 });
 
-// ── Wiring: every fixed-schedule external seeder routes its boot seed through
-// maybeBootSeed with the exact (label, metaKey, intervalConst, seedFn). The
+test('startBootSeedLoop waits the remaining freshness window before first skipped refresh', async () => {
+  const harness = buildLoop({ delay: 60 * MIN });
+  harness.loop('X', 'seed-meta:x', 180 * MIN, harness.seedFn, harness.onInitialError, harness.onSeedError);
+  await flushMicrotasks();
+  assert.equal(harness.seedCalls, 0, 'fresh data must not seed at boot');
+  assert.equal(harness.intervals.length, 0, 'recurring interval must not start before the due refresh');
+  assert.equal(harness.timeouts.length, 1);
+  assert.equal(harness.timeouts[0].ms, 60 * MIN);
+  assert.equal(harness.timeouts[0].unrefCalled, true);
+
+  harness.timeouts[0].fn();
+  await flushMicrotasks();
+  assert.equal(harness.seedCalls, 1, 'remaining-window timer should run the skipped boot seed');
+  assert.equal(harness.intervals.length, 1, 'recurring interval starts after the due refresh');
+  assert.equal(harness.intervals[0].ms, 180 * MIN);
+});
+
+// -- Wiring: every fixed-schedule external seeder routes through
+// startBootSeedLoop with the exact (label, metaKey, intervalConst, seedFn). The
 // exact-string match pins all four arguments so a future edit can't silently
-// drift the meta key or interval and re-open the boot-abuse hole. ────────────
+// drift the meta key or interval and re-open the boot-abuse hole.
 const SEEDERS = [
   ['UCDP', "'seed-meta:conflict:ucdp-events'", 'UCDP_POLL_INTERVAL_MS', 'seedUcdpEvents'],
   ['Satellites', "'seed-meta:intelligence:satellites'", 'SAT_SEED_INTERVAL_MS', 'seedSatelliteTLEs'],
@@ -145,17 +194,14 @@ const SEEDERS = [
 ];
 
 for (const [label, metaKey, intervalConst, seedFn] of SEEDERS) {
-  test(`${label} boot seed is gated through maybeBootSeed(${intervalConst}, ${seedFn})`, () => {
-    const call = `maybeBootSeed('${label}', ${metaKey}, ${intervalConst}, ${seedFn})`;
+  test(`${label} boot seed is scheduled through startBootSeedLoop(${intervalConst}, ${seedFn})`, () => {
+    const call = `startBootSeedLoop('${label}', ${metaKey}, ${intervalConst}, ${seedFn},`;
     assert.ok(relaySource.includes(call), `expected boot-seed wiring: ${call}`);
-    // The setInterval (real-cadence) path must remain a direct, UNGATED call so a
-    // long-lived relay still refreshes when the timer fires (data is due then).
-    assert.ok(relaySource.includes(`${seedFn}().catch`), `${seedFn} interval path must stay a direct call`);
   });
 }
 
-test('exactly the expected number of boot seeds are gated (no drift)', () => {
-  const count = (relaySource.match(/maybeBootSeed\('/g) || []).length;
+test('exactly the expected number of boot seeds are scheduled (no drift)', () => {
+  const count = (relaySource.match(/startBootSeedLoop\('/g) || []).length;
   assert.equal(count, SEEDERS.length, `expected ${SEEDERS.length} gated boot seeds, found ${count}`);
 });
 
@@ -164,7 +210,7 @@ test('exactly the expected number of boot seeds are gated (no drift)', () => {
 // pollers must run continuously. None of these may be wrapped. ───────────────
 test('internal warm-pings are NOT gated (self-limiting at the endpoint)', () => {
   for (const label of ['ServiceStatuses', 'CII', 'Chokepoints', 'CableHealth']) {
-    assert.ok(!relaySource.includes(`maybeBootSeed('${label}'`), `warm-ping ${label} must not be gated`);
+    assert.ok(!relaySource.includes(`startBootSeedLoop('${label}'`), `warm-ping ${label} must not be gated`);
   }
   // and the warm-pings still fire their immediate boot ping
   assert.match(relaySource, /seedServiceStatuses\(\)\.catch/);
@@ -173,15 +219,18 @@ test('internal warm-pings are NOT gated (self-limiting at the endpoint)', () => 
 
 test('real-time pollers are NOT gated (must run continuously on every boot)', () => {
   for (const label of ['Telegram', 'Oref', 'OREF']) {
-    assert.ok(!relaySource.includes(`maybeBootSeed('${label}'`), `poller ${label} must not be gated`);
+    assert.ok(!relaySource.includes(`startBootSeedLoop('${label}'`), `poller ${label} must not be gated`);
   }
 });
 
-test('maybeBootSeed fails open and keys on fetchedAt (source contract)', () => {
+test('bootSeedDelayMs fails open and keys on fetchedAt (source contract)', () => {
   // guard only engages when Upstash is on AND a key + positive interval are given
-  assert.match(fnText, /if \(UPSTASH_ENABLED && metaKey && intervalMs > 0\)/);
-  // sane positive age strictly under the interval → skip
-  assert.match(fnText, /if \(ageMs >= 0 && ageMs < intervalMs\)/);
-  // terminal path always seeds (fail-open / not-fresh)
-  assert.match(fnText, /return seedFn\(\);\s*}$/);
+  assert.match(delayFnText, /if \(UPSTASH_ENABLED && metaKey && intervalMs > 0\)/);
+  // sane positive age strictly under the interval -> delay until the data is due
+  assert.match(delayFnText, /if \(ageMs >= 0 && ageMs < intervalMs\)/);
+  assert.match(delayFnText, /const delayMs = intervalMs - ageMs/);
+  // terminal path always returns 0 delay (fail-open / not-fresh)
+  assert.match(delayFnText, /return 0;\s*}$/);
+  assert.match(loopFnText, /setTimeout\(\(\) => \{/);
+  assert.match(loopFnText, /\.finally\(startInterval\)/);
 });

--- a/tests/relay-boot-seed-freshness-guard.test.mjs
+++ b/tests/relay-boot-seed-freshness-guard.test.mjs
@@ -115,7 +115,12 @@ test('returns 0 delay when there is no prior seed-meta', async () => {
 });
 
 test('fails OPEN — a Redis read error returns 0 delay (never starves a panel)', async () => {
-  const { resolveDelay, logs } = buildDelayResolver({ get: async () => { throw new Error('redis down'); } });
+  const { resolveDelay, logs } = buildDelayResolver({
+    get: async (_key, onFailure) => {
+      onFailure('redis down');
+      return null;
+    },
+  });
   assert.equal(await resolveDelay('X', 'seed-meta:x', 180 * MIN), 0);
   assert.ok(logs.some(([lvl, msg]) => lvl === 'warn' && /freshness check failed/.test(String(msg))));
 });
@@ -226,11 +231,13 @@ test('real-time pollers are NOT gated (must run continuously on every boot)', ()
 test('bootSeedDelayMs fails open and keys on fetchedAt (source contract)', () => {
   // guard only engages when Upstash is on AND a key + positive interval are given
   assert.match(delayFnText, /if \(UPSTASH_ENABLED && metaKey && intervalMs > 0\)/);
+  assert.match(delayFnText, /upstashGet\(metaKey, \(reason\) => \{/);
   // sane positive age strictly under the interval -> delay until the data is due
   assert.match(delayFnText, /if \(ageMs >= 0 && ageMs < intervalMs\)/);
   assert.match(delayFnText, /const delayMs = intervalMs - ageMs/);
   // terminal path always returns 0 delay (fail-open / not-fresh)
   assert.match(delayFnText, /return 0;\s*}$/);
+  assert.doesNotMatch(delayFnText, /catch \(e\)/);
   assert.match(loopFnText, /setTimeout\(\(\) => \{/);
   assert.match(loopFnText, /\.finally\(startInterval\)/);
 });


### PR DESCRIPTION
## Summary

`ais-relay` is a long-running HTTP service on `proxy.worldmonitor.app` that Railway recycles frequently (deploys, crashes, OOM). Every seed loop fires an **immediate seed on boot** and then schedules a `setInterval` at its real cadence — but the process is usually recycled long before that interval elapses, so **the boot seed, not the interval, is the de-facto scheduler**.

During a reboot storm that re-fetches every upstream on *every boot* (~8 min apart, observed on the ScrapeCreators dashboard 2026‑06‑06) instead of on its interval:
- **paid credits burned** for ScrapeCreators (~13 credits/cycle), and
- **rate‑limit / ban risk** for Reddit, Yahoo, CoinGecko, UCDP, OpenSky, CelesTrak, USNI, etc.

When the relay is *stable* the 3h/6h/etc. intervals govern correctly — the abuse only manifests during reboot churn, which the relay can't assume won't happen.

## Fix

New shared helper `maybeBootSeed(label, metaKey, intervalMs, seedFn)`:
- reads the existing `seed-meta:*` and runs the boot seed **only when the data is already older than its interval** (a refresh is actually due);
- on a frequently‑recycled relay this self‑throttles the boot seed to the intended cadence; on a long‑lived relay it runs once at boot (if due) and the `setInterval` takes over — **both correct**;
- the **interval path is intentionally untouched** (the timer only fires when data is due by definition);
- keys on `fetchedAt` ("recently attempted — don't re‑attempt"), so a recent **failed** attempt also suppresses the next‑boot retry. Deliberate: re‑hammering a failing *paid* upstream on every reboot is the exact abuse being prevented. Seeders that only write seed‑meta on success leave `fetchedAt` stale on failure and so still retry on boot; the in‑process 20‑min retry timers cover stable relays;
- **fails OPEN** on any Redis read/parse error so a blip never starves a panel.

### Scope — 23 fixed‑schedule external‑fetch seeders gated
UCDP, Satellites, Market, PositiveEvents, Classify, TheaterPosture, Weather, Spending, GSCPI, TechEvents, WorldBank, CorridorRisk, USNI, ShippingStress, **SocialVelocity + WsbTickers (ScrapeCreators, paid)**, ClimateNews, ChokepointFlows, PizzINT, DodoPrices, Transit, TransitSummary, Cyber.

### Intentionally excluded
- **Internal warm‑pings** (ServiceStatuses, CII, Chokepoints, CableHealth) — they hit our own API and the endpoint short‑circuits to a cheap cache read when fresh, so they're already self‑limiting; the expensive recompute only happens when stale (exactly when we *want* the warm‑ping).
- **Real‑time pollers** (Telegram long‑poll, OREF alert poll) — must run continuously on every boot.
- `Cyber`'s start loop isn't currently wired into boot, but it's guarded for parity / future‑proofing.

## Test plan

- [x] `tests/relay-boot-seed-freshness-guard.test.mjs` (new, 35 tests):
  - **behavioral** — extracts the *real* `maybeBootSeed` body and exercises it: skip‑when‑fresh, seed‑when‑stale, seed‑when‑no‑meta, fail‑open on Redis error, seed‑when‑Upstash‑disabled, defensive future‑timestamp, `intervalMs<=0` disables the gate, promise propagation to the call‑site `.catch`;
  - **wiring** — exact‑string assertion pinning all four args (`label`, `metaKey`, `intervalConst`, `seedFn`) for each of the 23 seeders, a count guard against drift, and that the `setInterval` path stays a direct ungated call;
  - **exclusions** — warm‑pings and pollers are not gated.
- [x] `npm run typecheck` / `typecheck:api`
- [x] `node -c` all `scripts/*.cjs`
- [x] `npm run lint` (no new warnings)
- [x] `npm run test:data` — 10853 pass, 0 fail
- [x] edge bundle check + `tests/edge-functions.test.mjs` (204 pass)
- [x] `npm run lint:md` / `version:check`