### PR TITLE
fix(regional): unwrap {_seed,data} envelope so regime engine stops reporting flat 'calm'

### DIFF
--- a/scripts/regional-snapshot/_helpers.mjs
+++ b/scripts/regional-snapshot/_helpers.mjs
@@ -43,3 +43,38 @@ export function generateSnapshotId() {
   const r = Math.random().toString(16).slice(2, 14).padStart(12, '0');
   return `${t}-${r}`;
 }
+
+/**
+ * Unwrap the `{ _seed, data }` envelope written by the relay's envelopeWrite-based
+ * seeders (cross-source-signals, forecasts, national-debt, transit-summaries, …)
+ * so the compute modules — which read flat fields like `.signals`, `.predictions`,
+ * `.entries`, `.summaries` — see the payload shape they were written for.
+ *
+ * Without this, `sources['intelligence:cross-source-signals:v1'].signals` is
+ * `undefined` (the signals live at `.data.signals`), so coercive_pressure scored
+ * 0 for every region and the regime engine reported a flat `calm` regardless of
+ * actual conflict. Flat payloads (no `_seed`) pass through unchanged.
+ *
+ * Freshness classification (freshness.mjs) keeps working after the unwrap: every
+ * enveloped input either declares a companion seed-meta key or carries its own
+ * timestamp inside `data` (forecast `generatedAt`, debt `seededAt`, transit
+ * `fetchedAt`) — and forecast:predictions:v2, whose `generatedAt` was hidden one
+ * level down, now dates correctly instead of reading as present-but-undated.
+ *
+ * @template T
+ * @param {T} parsed
+ * @returns {T | unknown}
+ */
+export function unwrapEnvelope(parsed) {
+  if (
+    parsed !== null &&
+    typeof parsed === 'object' &&
+    !Array.isArray(parsed) &&
+    'data' in parsed &&
+    parsed._seed !== null &&
+    typeof parsed._seed === 'object'
+  ) {
+    return parsed.data;
+  }
+  return parsed;
+}

--- a/scripts/regional-snapshot/_helpers.mjs
+++ b/scripts/regional-snapshot/_helpers.mjs
@@ -1,6 +1,8 @@
 // @ts-check
 // Shared helpers for snapshot compute modules.
 
+import { stripSeedEnvelope } from '../_seed-envelope-source.mjs';
+
 /** Clamp a number to the [lo, hi] range. */
 export function clip(value, lo, hi) {
   if (Number.isNaN(value) || !Number.isFinite(value)) return lo;
@@ -61,20 +63,15 @@ export function generateSnapshotId() {
  * `fetchedAt`) — and forecast:predictions:v2, whose `generatedAt` was hidden one
  * level down, now dates correctly instead of reading as present-but-undated.
  *
+ * Uses the repo's canonical seed-envelope contract: only well-formed envelopes
+ * with a numeric `_seed.fetchedAt` unwrap. Malformed `_seed` objects pass through
+ * unchanged so seed-contract violations stay visible instead of being silently
+ * accepted as valid regional inputs.
+ *
  * @template T
  * @param {T} parsed
  * @returns {T | unknown}
  */
 export function unwrapEnvelope(parsed) {
-  if (
-    parsed !== null &&
-    typeof parsed === 'object' &&
-    !Array.isArray(parsed) &&
-    'data' in parsed &&
-    parsed._seed !== null &&
-    typeof parsed._seed === 'object'
-  ) {
-    return parsed.data;
-  }
-  return parsed;
+  return stripSeedEnvelope(parsed);
 }

--- a/scripts/regional-snapshot/balance-vector.mjs
+++ b/scripts/regional-snapshot/balance-vector.mjs
@@ -20,7 +20,13 @@ import iso3ToIso2Raw from '../shared/iso3-to-iso2.json' with { type: 'json' };
 /** @type {Record<string, string>} */
 const ISO3_TO_ISO2 = iso3ToIso2Raw;
 
-const SCORING_VERSION = '1.0.0';
+// 1.1.0: balance vector now consumes the cross-source-signals, forecasts,
+// national-debt, and transit-summaries inputs that were silently dropped while
+// they were stored as { _seed, data } envelopes but read flat (coercive_pressure
+// scored 0 for every region → flat 'calm'). Fixed at the loader via
+// unwrapEnvelope; bumped so the scoring_version in snapshot meta makes the
+// resulting score shift traceable.
+const SCORING_VERSION = '1.1.0';
 
 export { SCORING_VERSION };
 

--- a/scripts/seed-regional-snapshots.mjs
+++ b/scripts/seed-regional-snapshots.mjs
@@ -41,7 +41,7 @@ import { buildPreMeta, buildFinalMeta } from './regional-snapshot/snapshot-meta.
 import { diffRegionalSnapshot, inferTriggerReason } from './regional-snapshot/diff-snapshot.mjs';
 import { persistSnapshot, readLatestSnapshot } from './regional-snapshot/persist-snapshot.mjs';
 import { ALL_INPUT_KEYS, ALL_META_KEYS } from './regional-snapshot/freshness.mjs';
-import { generateSnapshotId } from './regional-snapshot/_helpers.mjs';
+import { generateSnapshotId, unwrapEnvelope } from './regional-snapshot/_helpers.mjs';
 import { generateRegionalNarrative, emptyNarrative } from './regional-snapshot/narrative.mjs';
 import { emitRegionalAlerts } from './regional-snapshot/alert-emitter.mjs';
 import { buildMobilityState } from './regional-snapshot/mobility.mjs';
@@ -77,14 +77,19 @@ async function readAllInputs() {
   const metaSources = {};
   for (let i = 0; i < keys.length; i += 1) {
     const key = keys[i];
-    const target = i < ALL_INPUT_KEYS.length ? sources : metaSources;
+    const isInput = i < ALL_INPUT_KEYS.length;
+    const target = isInput ? sources : metaSources;
     const raw = results[i]?.result;
     if (raw === null || raw === undefined) {
       target[key] = null;
       continue;
     }
     try {
-      target[key] = JSON.parse(raw);
+      const parsed = JSON.parse(raw);
+      // Input payloads written via the relay's envelopeWrite ({ _seed, data })
+      // must be unwrapped to their flat shape so compute modules read the right
+      // fields. seed-meta:* payloads are always flat and pass through untouched.
+      target[key] = isInput ? unwrapEnvelope(parsed) : parsed;
     } catch {
       target[key] = null;
     }

--- a/tests/regional-snapshot-envelope-unwrap.test.mjs
+++ b/tests/regional-snapshot-envelope-unwrap.test.mjs
@@ -16,24 +16,73 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import { unwrapEnvelope } from '../scripts/regional-snapshot/_helpers.mjs';
 import { computeBalanceVector } from '../scripts/regional-snapshot/balance-vector.mjs';
+import { scoreActors } from '../scripts/regional-snapshot/actor-scoring.mjs';
+import { buildScenarioSets } from '../scripts/regional-snapshot/scenario-builder.mjs';
 
 const XSS_KEY = 'intelligence:cross-source-signals:v1';
+const FORECAST_KEY = 'forecast:predictions:v2';
+const DEBT_KEY = 'economic:national-debt:v1';
+const MACRO_KEY = 'economic:macro-signals:v1';
+const CHOKEPOINT_KEY = 'supply_chain:chokepoints:v4';
+const TRANSIT_KEY = 'supply_chain:transit-summaries:v1';
+
+function seedEnvelope(data, sourceVersion = 'test-v1') {
+  return {
+    _seed: { fetchedAt: Date.now(), recordCount: 1, sourceVersion, schemaVersion: 1, state: 'OK' },
+    data,
+  };
+}
 
 // The real Redis shape: { _seed: {...}, data: { signals: [...] } }, with the
 // enum-form severity strings the seeder actually emits.
 function envelopedSignals() {
-  return {
-    _seed: { fetchedAt: Date.now(), recordCount: 3, sourceVersion: 'cross-source-v1', schemaVersion: 1, state: 'OK' },
-    data: {
-      evaluatedAt: Date.now(),
-      compositeCount: 3,
-      signals: [
-        { id: 'sig1', type: 'CROSS_SOURCE_SIGNAL_TYPE_MILITARY_FLIGHT_SURGE', theater: 'Middle East', severity: 'CROSS_SOURCE_SIGNAL_SEVERITY_CRITICAL', severityScore: 90 },
-        { id: 'sig2', type: 'CROSS_SOURCE_SIGNAL_TYPE_GPS_JAMMING', theater: 'Middle East', severity: 'CROSS_SOURCE_SIGNAL_SEVERITY_HIGH', severityScore: 70 },
-        { id: 'sig3', type: 'CROSS_SOURCE_SIGNAL_TYPE_NEWS_SPIKE', theater: 'Middle East', severity: 'CROSS_SOURCE_SIGNAL_SEVERITY_HIGH', severityScore: 60 },
-      ],
+  return seedEnvelope({
+    evaluatedAt: Date.now(),
+    compositeCount: 3,
+    signals: [
+      { id: 'sig1', type: 'CROSS_SOURCE_SIGNAL_TYPE_MILITARY_FLIGHT_SURGE', theater: 'Middle East', severity: 'CROSS_SOURCE_SIGNAL_SEVERITY_CRITICAL', severityScore: 90 },
+      { id: 'sig2', type: 'CROSS_SOURCE_SIGNAL_TYPE_GPS_JAMMING', theater: 'Middle East', severity: 'CROSS_SOURCE_SIGNAL_SEVERITY_HIGH', severityScore: 70 },
+      { id: 'sig3', type: 'CROSS_SOURCE_SIGNAL_TYPE_NEWS_SPIKE', theater: 'Middle East', severity: 'CROSS_SOURCE_SIGNAL_SEVERITY_HIGH', severityScore: 60 },
+    ],
+  }, 'cross-source-v1');
+}
+
+function envelopedForecasts() {
+  return seedEnvelope({
+    generatedAt: Date.now(),
+    predictions: [
+      {
+        id: 'forecast-mena-1',
+        region: 'Middle East',
+        trend: 'rising',
+        domain: 'military',
+        probability: 0.9,
+        confidence: 0.8,
+        timeHorizon: 'h24',
+        caseFile: { summary: 'Iran military alliance coordination near Hormuz' },
+      },
+    ],
+  }, 'forecast-v2');
+}
+
+function envelopedDebt() {
+  return seedEnvelope({
+    seededAt: new Date().toISOString(),
+    entries: [
+      { iso3: 'IRN', debtToGdp: 180 },
+      { iso3: 'ISR', debtToGdp: 160 },
+      { iso3: 'SAU', debtToGdp: 150 },
+    ],
+  }, 'national-debt-v1');
+}
+
+function envelopedTransitSummaries() {
+  return seedEnvelope({
+    fetchedAt: Date.now(),
+    summaries: {
+      hormuz: { todayTotal: 25, wowChangePct: -100 },
     },
-  };
+  }, 'transit-summaries-v1');
 }
 
 // ── unwrapEnvelope unit behavior ─────────────────────────────────────────────
@@ -51,11 +100,13 @@ test('unwrapEnvelope passes flat payloads through untouched', () => {
   assert.equal(unwrapEnvelope(flat), flat);
 });
 
-test('unwrapEnvelope passes through objects that lack _seed or data', () => {
+test('unwrapEnvelope passes through objects that lack _seed', () => {
   const onlyData = { data: { a: 1 } };          // no _seed → not an envelope
-  const onlySeed = { _seed: { fetchedAt: 1 } }; // no data  → not an envelope
   assert.equal(unwrapEnvelope(onlyData), onlyData);
-  assert.equal(unwrapEnvelope(onlySeed), onlySeed);
+});
+
+test('unwrapEnvelope follows canonical behavior for a valid _seed with no data field', () => {
+  assert.equal(unwrapEnvelope({ _seed: { fetchedAt: 1 } }), undefined);
 });
 
 test('unwrapEnvelope passes through arrays, null, and primitives', () => {
@@ -64,8 +115,13 @@ test('unwrapEnvelope passes through arrays, null, and primitives', () => {
   assert.equal(unwrapEnvelope(null), null);
   assert.equal(unwrapEnvelope(7), 7);
   assert.equal(unwrapEnvelope('s'), 's');
-  // an envelope whose data is null still unwraps to null (data present)
-  assert.equal(unwrapEnvelope({ _seed: {}, data: null }), null);
+  // a well-formed envelope whose data is null still unwraps to null
+  assert.equal(unwrapEnvelope({ _seed: { fetchedAt: Date.now() }, data: null }), null);
+});
+
+test('unwrapEnvelope leaves malformed _seed objects visible as legacy payloads', () => {
+  const malformed = { _seed: { sourceVersion: 'missing-fetched-at' }, data: { signals: [{ id: 'x' }] } };
+  assert.equal(unwrapEnvelope(malformed), malformed);
 });
 
 // ── End-to-end: the bug and its fix ──────────────────────────────────────────
@@ -97,4 +153,46 @@ test('FIX: unwrap localizes signals to the right region (other regions unaffecte
   const latam = computeBalanceVector('latam', sources).vector;
   assert.ok(mena.coercive_pressure > 0, 'MENA (matching theater) must score coercive');
   assert.equal(latam.coercive_pressure, 0, 'LATAM (no matching theater) must stay 0');
+});
+
+test('FIX: unwrapped forecasts reach balance, actor, and scenario consumers', () => {
+  const rawSources = { [FORECAST_KEY]: envelopedForecasts() };
+  const fixedSources = { [FORECAST_KEY]: unwrapEnvelope(envelopedForecasts()) };
+
+  const rawBalance = computeBalanceVector('mena', rawSources).vector;
+  const fixedBalance = computeBalanceVector('mena', fixedSources).vector;
+  assert.equal(rawBalance.coercive_pressure, 0, 'raw forecast envelope must starve forecast-driven coercive pressure');
+  assert.ok(fixedBalance.coercive_pressure > rawBalance.coercive_pressure, 'unwrapped forecasts must affect coercive pressure');
+
+  assert.equal(scoreActors('mena', rawSources).actors.length, 0, 'raw forecast envelope must starve actor extraction');
+  assert.ok(scoreActors('mena', fixedSources).actors.some((actor) => actor.name === 'Iran'), 'unwrapped forecasts must feed actor extraction');
+
+  const emptyTriggers = { active: [], watching: [], dormant: [] };
+  const raw24h = buildScenarioSets('mena', rawSources, emptyTriggers).find((set) => set.horizon === '24h');
+  const fixed24h = buildScenarioSets('mena', fixedSources, emptyTriggers).find((set) => set.horizon === '24h');
+  const rawEscalation = raw24h?.lanes.find((lane) => lane.name === 'escalation')?.probability ?? 0;
+  const fixedEscalation = fixed24h?.lanes.find((lane) => lane.name === 'escalation')?.probability ?? 0;
+  assert.ok(fixedEscalation > rawEscalation, 'unwrapped forecasts must raise the matching scenario lane');
+});
+
+test('FIX: unwrapped national-debt entries drive capital_stress', () => {
+  const base = { [MACRO_KEY]: { verdict: 'BUY' } };
+  const rawSources = { ...base, [DEBT_KEY]: envelopedDebt() };
+  const fixedSources = { ...base, [DEBT_KEY]: unwrapEnvelope(envelopedDebt()) };
+
+  const raw = computeBalanceVector('mena', rawSources).vector;
+  const fixed = computeBalanceVector('mena', fixedSources).vector;
+  assert.equal(raw.capital_stress, 0, 'raw debt envelope must be ignored by debt entry reads');
+  assert.ok(fixed.capital_stress > raw.capital_stress, 'unwrapped debt entries must raise capital_stress');
+});
+
+test('FIX: unwrapped transit summaries drive maritime_access throughput', () => {
+  const chokepoints = { chokepoints: [{ id: 'hormuz', name: 'Strait of Hormuz', threatLevel: 'normal' }] };
+  const rawSources = { [CHOKEPOINT_KEY]: chokepoints, [TRANSIT_KEY]: envelopedTransitSummaries() };
+  const fixedSources = { [CHOKEPOINT_KEY]: chokepoints, [TRANSIT_KEY]: unwrapEnvelope(envelopedTransitSummaries()) };
+
+  const raw = computeBalanceVector('mena', rawSources).vector;
+  const fixed = computeBalanceVector('mena', fixedSources).vector;
+  assert.ok(raw.maritime_access > fixed.maritime_access, 'raw transit envelope must miss the throughput collapse');
+  assert.ok(fixed.maritime_access < 0.7, 'unwrapped transit summaries must lower maritime_access when throughput collapses');
 });

--- a/tests/regional-snapshot-envelope-unwrap.test.mjs
+++ b/tests/regional-snapshot-envelope-unwrap.test.mjs
@@ -1,0 +1,100 @@
+// Regional-snapshot envelope unwrap — regression test.
+//
+// Production bug (2026-06-06): the relay's envelopeWrite-based seeders store
+// several balance-vector inputs as `{ _seed, data }` envelopes, but the compute
+// modules read them flat (`xss.signals`, `fc.predictions`, `debt.entries`,
+// `transitData.summaries`). So `coercive_pressure` scored 0 for EVERY region —
+// the regime engine reported a flat `calm` even with active wars in Iran and
+// Ukraine. The existing computeBalanceVector tests fed the FLAT shape, so they
+// passed while production silently dropped the inputs.
+//
+// `readAllInputs` now unwraps the envelope at the loader via `unwrapEnvelope`.
+// These tests pin the unwrap helper AND prove the end-to-end effect on
+// coercive_pressure using the REAL enveloped payload shape from Redis.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { unwrapEnvelope } from '../scripts/regional-snapshot/_helpers.mjs';
+import { computeBalanceVector } from '../scripts/regional-snapshot/balance-vector.mjs';
+
+const XSS_KEY = 'intelligence:cross-source-signals:v1';
+
+// The real Redis shape: { _seed: {...}, data: { signals: [...] } }, with the
+// enum-form severity strings the seeder actually emits.
+function envelopedSignals() {
+  return {
+    _seed: { fetchedAt: Date.now(), recordCount: 3, sourceVersion: 'cross-source-v1', schemaVersion: 1, state: 'OK' },
+    data: {
+      evaluatedAt: Date.now(),
+      compositeCount: 3,
+      signals: [
+        { id: 'sig1', type: 'CROSS_SOURCE_SIGNAL_TYPE_MILITARY_FLIGHT_SURGE', theater: 'Middle East', severity: 'CROSS_SOURCE_SIGNAL_SEVERITY_CRITICAL', severityScore: 90 },
+        { id: 'sig2', type: 'CROSS_SOURCE_SIGNAL_TYPE_GPS_JAMMING', theater: 'Middle East', severity: 'CROSS_SOURCE_SIGNAL_SEVERITY_HIGH', severityScore: 70 },
+        { id: 'sig3', type: 'CROSS_SOURCE_SIGNAL_TYPE_NEWS_SPIKE', theater: 'Middle East', severity: 'CROSS_SOURCE_SIGNAL_SEVERITY_HIGH', severityScore: 60 },
+      ],
+    },
+  };
+}
+
+// ── unwrapEnvelope unit behavior ─────────────────────────────────────────────
+
+test('unwrapEnvelope returns .data for a { _seed, data } envelope', () => {
+  const env = envelopedSignals();
+  const out = unwrapEnvelope(env);
+  assert.equal(out, env.data);
+  assert.ok(Array.isArray(out.signals));
+  assert.equal(out.signals.length, 3);
+});
+
+test('unwrapEnvelope passes flat payloads through untouched', () => {
+  const flat = { signals: [{ id: 'x' }] };
+  assert.equal(unwrapEnvelope(flat), flat);
+});
+
+test('unwrapEnvelope passes through objects that lack _seed or data', () => {
+  const onlyData = { data: { a: 1 } };          // no _seed → not an envelope
+  const onlySeed = { _seed: { fetchedAt: 1 } }; // no data  → not an envelope
+  assert.equal(unwrapEnvelope(onlyData), onlyData);
+  assert.equal(unwrapEnvelope(onlySeed), onlySeed);
+});
+
+test('unwrapEnvelope passes through arrays, null, and primitives', () => {
+  const arr = [1, 2, 3];
+  assert.equal(unwrapEnvelope(arr), arr);
+  assert.equal(unwrapEnvelope(null), null);
+  assert.equal(unwrapEnvelope(7), 7);
+  assert.equal(unwrapEnvelope('s'), 's');
+  // an envelope whose data is null still unwraps to null (data present)
+  assert.equal(unwrapEnvelope({ _seed: {}, data: null }), null);
+});
+
+// ── End-to-end: the bug and its fix ──────────────────────────────────────────
+
+test('BUG REPRO: raw enveloped signals score coercive_pressure = 0', () => {
+  // Feeding the raw envelope (what readAllInputs did before the fix) — the
+  // compute reads `xss.signals` which is undefined inside an envelope.
+  const sources = { [XSS_KEY]: envelopedSignals() };
+  const { vector } = computeBalanceVector('mena', sources);
+  assert.equal(vector.coercive_pressure, 0, 'raw envelope must reproduce the starved-coercive bug');
+});
+
+test('FIX: unwrapped signals score coercive_pressure > 0 for the war region', () => {
+  // After the loader unwrap, the compute sees the flat { signals } payload.
+  const sources = { [XSS_KEY]: unwrapEnvelope(envelopedSignals()) };
+  const { vector } = computeBalanceVector('mena', sources);
+  assert.ok(vector.coercive_pressure > 0, `unwrapped signals must drive coercive_pressure > 0, got ${vector.coercive_pressure}`);
+  // and the CRITICAL signal is surfaced as a driver (enum-form severity matched)
+  assert.ok(
+    vector.pressures.some((d) => d.axis === 'coercive_pressure'),
+    'a coercive_pressure driver must be emitted from the unwrapped signals',
+  );
+});
+
+test('FIX: unwrap localizes signals to the right region (other regions unaffected)', () => {
+  // Middle East signals must not leak into an unrelated region.
+  const sources = { [XSS_KEY]: unwrapEnvelope(envelopedSignals()) };
+  const mena = computeBalanceVector('mena', sources).vector;
+  const latam = computeBalanceVector('latam', sources).vector;
+  assert.ok(mena.coercive_pressure > 0, 'MENA (matching theater) must score coercive');
+  assert.equal(latam.coercive_pressure, 0, 'LATAM (no matching theater) must stay 0');
+});


### PR DESCRIPTION
## Summary

Every region's regional snapshot reported **`regime = calm`** regardless of actual conflict — Iran and Ukraine scored identically to a quiet region (all 8 regions `calm`, `triggers = 0`).

**Root cause:** the relay's `envelopeWrite`-based seeders store four balance-vector inputs as `{ _seed, data }` envelopes, but the compute modules read them **flat**:

| Redis key | Stored | Code reads | Result |
|---|---|---|---|
| `intelligence:cross-source-signals:v1` | `{_seed, data:{signals}}` | `xss.signals` | `undefined` → **coercive = 0** |
| `forecast:predictions:v2` | `{_seed, data:{predictions}}` | `fc.predictions` | `undefined` |
| `economic:national-debt:v1` | `{_seed, data:{entries}}` | `debt.entries` | `undefined` |
| `supply_chain:transit-summaries:v1` | `{_seed, data:{summaries}}` | `transitData.summaries` | `undefined` |

`readAllInputs` did `JSON.parse(raw)` and never unwrapped `.data`. `coercive_pressure` is driven almost entirely by cross-source-signals + forecasts (both enveloped), so it scored **0 for every region**. With pressures floored, `net_balance ≥ -0.1` everywhere and `deriveRegime` fell through to `calm` for all 8 regions.

Live Redis confirmed the feed is healthy — CRITICAL military-flight + GPS-jamming signals are present (Eastern Europe / Global / Middle East); they were just read one level too high. The existing `computeBalanceVector` tests fed the **flat** shape, so they passed while production silently dropped the inputs.

> Note: `snapshot_confidence` being identical (`0.953`) across regions is **by design** — it measures global input freshness/completeness, not per-region risk — and is unrelated to this bug. A separate "CII feed null" suspicion turned out to be a false alarm (the live key is `risk:scores:sebuf:stale:**v8**`, healthy with 31 scores; an earlier probe used `:v1`).

## Fix

Unwrap the envelope **once at the loader** — `unwrapEnvelope` in `regional-snapshot/_helpers.mjs`, applied to input sources in `readAllInputs`. Every downstream consumer (balance-vector, actor-scoring, evidence-collector, scenario-builder, trigger-evaluator) is fixed in one place; flat payloads pass through unchanged.

**Freshness is unaffected:** enveloped inputs either declare a `seed-meta` key or carry their own timestamp inside `data` (forecast `generatedAt`, debt `seededAt`, transit `fetchedAt`). `forecast:predictions:v2`, whose `generatedAt` was hidden one level down (→ falsely "present-but-undated"), now dates correctly — so `snapshot_confidence` improves too.

`SCORING_VERSION` `1.0.0 → 1.1.0` so the score shift is traceable in snapshot meta (pure metadata; nothing gates on the value).

## Test plan

- [x] `tests/regional-snapshot-envelope-unwrap.test.mjs` (new): unit-tests `unwrapEnvelope` (envelope→data, flat/array/null/primitive passthrough, `_seed`-without-`data` passthrough) and proves end-to-end with the **real enveloped payload shape** that raw envelope → `coercive_pressure = 0` (bug repro) and unwrapped → `coercive_pressure > 0`, localized to the matching region (MENA scores, LATAM stays 0).
- [x] `npm run typecheck` / `typecheck:api`
- [x] `npm run lint` (clean on changed files)
- [x] `npm run test:data` — 10825 pass, 0 fail (incl. existing `regional-snapshot.test.mjs`, 93 region tests)
- [x] edge tests / `lint:md` / `version:check`

## Rollout

Scores recompute on the next `seed-regional-snapshots` run (6h cron). Expect war regions (MENA, Europe, East-Asia) to move off `calm` once `coercive_pressure` reflects the live signals; `scoring_version` will read `1.1.0`.