### PR TITLE
fix(gateway): scoped internal auth for relay warm-pings (fix 401s)

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -3854,16 +3854,12 @@ async function seedServiceStatuses() {
   try {
     const resp = await fetch(SERVICE_STATUSES_RPC_URL, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'User-Agent': CHROME_UA,
-        Origin: 'https://worldmonitor.app',
-      },
+      headers: warmPingHeaders({ 'Content-Type': 'application/json' }),
       body: '{}',
       signal: AbortSignal.timeout(60_000),
     });
     if (!resp.ok) {
-      console.warn(`[ServiceStatuses] Seed ping failed: HTTP ${resp.status}`);
+      console.warn(`[ServiceStatuses] Seed ping failed: HTTP ${resp.status}${RELAY_API_KEY ? '' : ' (WORLDMONITOR_RELAY_KEY not set — 401 expected; set it on the relay AND the Vercel api project)'}`);
       return;
     }
     const data = await resp.json();

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -4422,31 +4422,32 @@ function startTheaterPostureSeedLoop() {
 // ─────────────────────────────────────────────────────────────
 // Warm-ping shared auth — relay → api.worldmonitor.app
 //
-// All warm-pings call api.worldmonitor.app/api/* edge functions. Pre-2026-05-02
-// these used Origin-trust alone (the relay sent `Origin: https://worldmonitor.app`
-// which `api/_api-key.js::validateApiKey` accepts via BROWSER_ORIGIN_PATTERNS).
-// On 2026-05-02 ALL three warm-pings (CII + Chokepoints + CableHealth) started
-// returning HTTP 401 simultaneously despite the relay sending the correct
-// Origin header. Root cause unclear (Vercel firewall change, CDN cache
-// poisoning, deploy mismatch) — but Origin-trust is fragile by nature: any
-// intermediary (CF, Vercel firewall, future CDN) can strip or rewrite Origin
-// without leaving a trace.
+// All warm-pings call api.worldmonitor.app/api/* edge functions. These are
+// non-premium but NOT anonymous: in normal traffic they require a browser
+// session token or an API key. Origin-trust used to satisfy them, but the
+// gateway dropped all Origin/Referer trust in the #3541 hardening — Origin
+// headers are client-forgeable, so they are no longer an auth signal. There is
+// NO Origin-only fallback anymore: without a recognized key, every warm-ping
+// 401s (observed in prod 2026-06-06 — all three warm-pings dark).
 //
-// Defense-in-depth: send an explicit X-WorldMonitor-Key in addition to the
-// Origin header. The gateway accepts EITHER, so when Origin trust breaks
-// the key carries the auth. When the key isn't configured, fall through to
-// Origin-only — preserves backward compatibility for local dev / before the
-// env var is provisioned on Railway.
+// The relay authenticates as a trusted internal caller via X-WorldMonitor-Key =
+// WORLDMONITOR_RELAY_KEY. The gateway validates this (timing-safe) against its
+// OWN WORLDMONITOR_RELAY_KEY for the warm-ping path allowlist only
+// (server/gateway.ts isRelayWarmPingRequest / RELAY_WARM_PING_PATHS). It is a
+// DEDICATED relay↔gateway secret — it does NOT need to be a
+// WORLDMONITOR_VALID_KEYS enterprise key, and shouldn't be (least privilege: it
+// unlocks only a cache-warm on these free endpoints, nothing else).
 //
-// Required env var on Railway ais-relay service:
-//   WORLDMONITOR_RELAY_KEY=<value present in Vercel WORLDMONITOR_VALID_KEYS>
+// Required env var, SAME value on BOTH sides:
+//   Railway ais-relay service  : WORLDMONITOR_RELAY_KEY=<dedicated secret>
+//   Vercel api project (gateway): WORLDMONITOR_RELAY_KEY=<same dedicated secret>
 // ─────────────────────────────────────────────────────────────
 const RELAY_API_KEY = process.env.WORLDMONITOR_RELAY_KEY || '';
 // Surface the auth-mode at boot so misconfig (env var on wrong service,
 // typo'd name, missing on a fresh Railway deploy) is visible in the first
 // log lines instead of waiting for the first 401. PR #3565 review P2.
 if (!RELAY_API_KEY) {
-  console.warn('[Relay] WORLDMONITOR_RELAY_KEY not set — warm-pings will rely on Origin-trust only (fragile against CDN/firewall changes)');
+  console.warn('[Relay] WORLDMONITOR_RELAY_KEY not set — warm-pings will 401 (no Origin-trust fallback since #3541). Set the same value on the Railway relay and the Vercel api project.');
 } else {
   console.log('[Relay] WORLDMONITOR_RELAY_KEY configured — warm-pings will send X-WorldMonitor-Key');
 }
@@ -4482,7 +4483,7 @@ async function seedCiiWarmPing() {
       signal: AbortSignal.timeout(60_000),
     });
     if (!resp.ok) {
-      console.warn(`[CII] Warm-ping failed: HTTP ${resp.status}${RELAY_API_KEY ? '' : ' (no WORLDMONITOR_RELAY_KEY set; relying on Origin-trust)'}`);
+      console.warn(`[CII] Warm-ping failed: HTTP ${resp.status}${RELAY_API_KEY ? '' : ' (WORLDMONITOR_RELAY_KEY not set — 401 expected; set it on the relay AND the Vercel api project)'}`);
       return;
     }
     const data = await resp.json();
@@ -4519,7 +4520,7 @@ async function seedChokepointWarmPing() {
       signal: AbortSignal.timeout(60_000),
     });
     if (!resp.ok) {
-      console.warn(`[Chokepoints] Warm-ping failed: HTTP ${resp.status}${RELAY_API_KEY ? '' : ' (no WORLDMONITOR_RELAY_KEY set; relying on Origin-trust)'}`);
+      console.warn(`[Chokepoints] Warm-ping failed: HTTP ${resp.status}${RELAY_API_KEY ? '' : ' (WORLDMONITOR_RELAY_KEY not set — 401 expected; set it on the relay AND the Vercel api project)'}`);
       return;
     }
     const data = await resp.json();
@@ -4557,7 +4558,7 @@ async function seedCableHealthWarmPing() {
       signal: AbortSignal.timeout(60_000),
     });
     if (!resp.ok) {
-      console.warn(`[CableHealth] Warm-ping failed: HTTP ${resp.status}${RELAY_API_KEY ? '' : ' (no WORLDMONITOR_RELAY_KEY set; relying on Origin-trust)'}`);
+      console.warn(`[CableHealth] Warm-ping failed: HTTP ${resp.status}${RELAY_API_KEY ? '' : ' (WORLDMONITOR_RELAY_KEY not set — 401 expected; set it on the relay AND the Vercel api project)'}`);
       return;
     }
     const data = await resp.json();

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -332,6 +332,25 @@ export const PUBLIC_NO_AUTH_RPC_PATHS = new Set<string>([
   '/api/resilience/v1/get-runtime-manifest',
 ]);
 
+// Cacheable, non-premium RPC endpoints the Railway relay periodically warm-pings
+// to keep their compute caches hot (so the first real user request isn't a cold
+// miss). These require a browser session token or an API key in normal traffic;
+// the relay is a trusted internal service with neither, so it authenticates as
+// itself via WORLDMONITOR_RELAY_KEY (validated below in isRelayWarmPingRequest).
+//
+// Least privilege: WORLDMONITOR_RELAY_KEY is a DEDICATED relay↔gateway secret —
+// it does NOT need to be (and should not be) a WORLDMONITOR_VALID_KEYS enterprise
+// key. It unlocks ONLY a cache-warm on these specific free endpoints — exactly
+// what any session holder could already trigger — so the blast radius of the
+// secret is a recompute on public data: no premium access, no entitlement bypass
+// beyond anonymous-equivalent. Mirrors the isResilienceRankingSeedRefreshRequest
+// internal-auth path below.
+export const RELAY_WARM_PING_PATHS = new Set<string>([
+  '/api/intelligence/v1/get-risk-scores',
+  '/api/supply-chain/v1/get-chokepoint-status',
+  '/api/infrastructure/v1/get-cable-health',
+]);
+
 /**
  * Creates a Vercel Edge handler for a single domain's routes.
  *
@@ -386,6 +405,19 @@ async function isResilienceRankingSeedRefreshRequest(request: Request, pathname:
   } catch {
     return false;
   }
+  const candidate = request.headers.get('X-WorldMonitor-Key') ?? '';
+  return timingSafeEqual(candidate, expected);
+}
+
+// Authenticate a relay warm-ping as a trusted internal caller. True only when
+// the path is an explicit warm-ping target AND the request carries the dedicated
+// relay secret in X-WorldMonitor-Key (timing-safe compared). Returns false when
+// the secret is unset so a misconfigured deploy fails CLOSED (no bypass) rather
+// than silently opening these paths. Mirrors isResilienceRankingSeedRefreshRequest.
+export async function isRelayWarmPingRequest(request: Request, pathname: string): Promise<boolean> {
+  if (!RELAY_WARM_PING_PATHS.has(pathname)) return false;
+  const expected = process.env.WORLDMONITOR_RELAY_KEY?.trim() ?? '';
+  if (!expected) return false;
   const candidate = request.headers.get('X-WorldMonitor-Key') ?? '';
   return timingSafeEqual(candidate, expected);
 }
@@ -757,7 +789,8 @@ export function createDomainGateway(
     // that has no Authorization header would just no-op anyway.
     const isPublicNoAuthRpc = PUBLIC_NO_AUTH_RPC_PATHS.has(pathname);
     const seedRefreshVerified = await isResilienceRankingSeedRefreshRequest(request, pathname);
-    const isTierGated = !internalMcpVerified && !isPublicNoAuthRpc && !seedRefreshVerified && getRequiredTier(pathname) !== null;
+    const relayWarmPingVerified = await isRelayWarmPingRequest(request, pathname);
+    const isTierGated = !internalMcpVerified && !isPublicNoAuthRpc && !seedRefreshVerified && !relayWarmPingVerified && getRequiredTier(pathname) !== null;
     const needsLegacyProBearerGate = !internalMcpVerified && !isPublicNoAuthRpc && PREMIUM_RPC_PATHS.has(pathname) && !isTierGated;
 
     // Session resolution — extract userId from bearer token (Clerk JWT) if present.
@@ -782,7 +815,7 @@ export function createDomainGateway(
     // request). Telemetry stays attributed via the verified userId set
     // above; entitlement re-check (`features.tier ≥ 1 && mcpAccess`) was
     // already performed before flipping `internalMcpVerified = true`.
-    let keyCheck: { valid: boolean; required: boolean; error?: string; kind?: 'enterprise' | 'session' | 'user' } = internalMcpVerified || isPublicNoAuthRpc || seedRefreshVerified
+    let keyCheck: { valid: boolean; required: boolean; error?: string; kind?: 'enterprise' | 'session' | 'user' } = internalMcpVerified || isPublicNoAuthRpc || seedRefreshVerified || relayWarmPingVerified
       ? { valid: true, required: false }
       : ((await validateApiKey(request, {
           forceKey: (isTierGated && !sessionUserId) || needsLegacyProBearerGate,
@@ -925,7 +958,7 @@ export function createDomainGateway(
     // routes require tier 2, but Pro MCP callers only reach the gateway
     // through the MCP edge's whitelisted tool set.
     const isEnterpriseAuth = keyCheck.valid && wmKey && !isUserApiKey && keyCheck.kind === 'enterprise';
-    if (!isEnterpriseAuth && !internalMcpVerified && !seedRefreshVerified) {
+    if (!isEnterpriseAuth && !internalMcpVerified && !seedRefreshVerified && !relayWarmPingVerified) {
       const entitlementResponse = await checkEntitlement(sessionUserId, pathname, corsHeaders);
       if (entitlementResponse) {
         const entReason: RequestReason =

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -346,9 +346,10 @@ export const PUBLIC_NO_AUTH_RPC_PATHS = new Set<string>([
 // beyond anonymous-equivalent. Mirrors the isResilienceRankingSeedRefreshRequest
 // internal-auth path below.
 export const RELAY_WARM_PING_PATHS = new Set<string>([
+  '/api/infrastructure/v1/list-service-statuses',
+  '/api/infrastructure/v1/get-cable-health',
   '/api/intelligence/v1/get-risk-scores',
   '/api/supply-chain/v1/get-chokepoint-status',
-  '/api/infrastructure/v1/get-cable-health',
 ]);
 
 /**

--- a/tests/relay-warm-ping-auth.test.mts
+++ b/tests/relay-warm-ping-auth.test.mts
@@ -1,0 +1,93 @@
+// Relay warm-ping internal-auth — behavioral + wiring regression tests.
+//
+// The Railway relay warm-pings three cacheable, non-premium RPC endpoints
+// (get-risk-scores, get-chokepoint-status, get-cable-health) to keep their
+// compute caches hot. These require a session token or API key in normal
+// traffic, and the #3541 hardening removed Origin-trust — so all three warm-
+// pings 401'd in prod (2026-06-06). The relay now authenticates as a trusted
+// internal caller via X-WorldMonitor-Key = WORLDMONITOR_RELAY_KEY, validated by
+// the gateway against its own WORLDMONITOR_RELAY_KEY for these paths only.
+//
+// These tests exercise the real isRelayWarmPingRequest verifier and pin the
+// least-privilege scoping + timing-safe comparison so a future edit can't widen
+// the bypass or regress to a forgeable direct-equality check.
+
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { isRelayWarmPingRequest, RELAY_WARM_PING_PATHS } from '../server/gateway.ts';
+
+const SECRET = 'test-relay-warm-ping-secret-xxxxxxxxxxxxxxxxxxxx';
+const WARM_PATH = '/api/supply-chain/v1/get-chokepoint-status';
+const NON_WARM_PATH = '/api/intelligence/v1/get-country-risk';
+
+function req(pathname: string, key?: string): Request {
+  const headers: Record<string, string> = {};
+  if (key !== undefined) headers['X-WorldMonitor-Key'] = key;
+  return new Request(`https://api.worldmonitor.app${pathname}`, { headers });
+}
+
+describe('relay warm-ping internal auth', () => {
+  const original = process.env.WORLDMONITOR_RELAY_KEY;
+  beforeEach(() => { process.env.WORLDMONITOR_RELAY_KEY = SECRET; });
+  afterEach(() => {
+    if (original === undefined) delete process.env.WORLDMONITOR_RELAY_KEY;
+    else process.env.WORLDMONITOR_RELAY_KEY = original;
+  });
+
+  it('covers exactly the three free warm-ping endpoints', () => {
+    assert.deepEqual(
+      [...RELAY_WARM_PING_PATHS].sort(),
+      [
+        '/api/infrastructure/v1/get-cable-health',
+        '/api/intelligence/v1/get-risk-scores',
+        '/api/supply-chain/v1/get-chokepoint-status',
+      ],
+    );
+  });
+
+  it('accepts a warm-ping path carrying the correct relay key', async () => {
+    assert.equal(await isRelayWarmPingRequest(req(WARM_PATH, SECRET), WARM_PATH), true);
+  });
+
+  it('rejects the wrong key on a warm-ping path', async () => {
+    assert.equal(await isRelayWarmPingRequest(req(WARM_PATH, 'nope'), WARM_PATH), false);
+  });
+
+  it('rejects a warm-ping path with no key header', async () => {
+    assert.equal(await isRelayWarmPingRequest(req(WARM_PATH), WARM_PATH), false);
+  });
+
+  it('does NOT bypass a non-warm-ping path even with the correct relay key (scoping)', async () => {
+    assert.equal(await isRelayWarmPingRequest(req(NON_WARM_PATH, SECRET), NON_WARM_PATH), false);
+  });
+
+  it('fails CLOSED when WORLDMONITOR_RELAY_KEY is unset (no bypass)', async () => {
+    delete process.env.WORLDMONITOR_RELAY_KEY;
+    assert.equal(await isRelayWarmPingRequest(req(WARM_PATH, SECRET), WARM_PATH), false);
+  });
+
+  it('fails CLOSED when the relay key is blank/whitespace', async () => {
+    process.env.WORLDMONITOR_RELAY_KEY = '   ';
+    assert.equal(await isRelayWarmPingRequest(req(WARM_PATH, '   '), WARM_PATH), false);
+  });
+});
+
+// Source-text guardrail — mirrors tests/resilience-seed-refresh-auth.test.mts.
+// The relay key comparison MUST stay timing-safe, and the verifier MUST remain
+// wired into BOTH the key-check bypass and the entitlement skip so the bypass
+// can't silently drift to a forgeable check or grant entitlement access.
+describe('relay warm-ping auth wiring (source guardrail)', () => {
+  it('uses timingSafeEqual (no direct equality) and is wired into both gates', async () => {
+    const src = await readFile(new URL('../server/gateway.ts', import.meta.url), 'utf8');
+    // verifier uses the timing-safe comparator against the env secret + header
+    assert.match(src, /isRelayWarmPingRequest/);
+    assert.match(src, /RELAY_WARM_PING_PATHS\.has\(pathname\)/);
+    assert.match(src, /timingSafeEqual\(candidate, expected\)/);
+    assert.doesNotMatch(src, /candidate\s*===?\s*expected/, 'relay key compare must be timing-safe, not direct equality');
+    // key-check bypass includes relayWarmPingVerified
+    assert.match(src, /seedRefreshVerified \|\| relayWarmPingVerified\b/);
+    // entitlement skip excludes verified relay warm-pings
+    assert.match(src, /!seedRefreshVerified && !relayWarmPingVerified/);
+  });
+});

--- a/tests/relay-warm-ping-auth.test.mts
+++ b/tests/relay-warm-ping-auth.test.mts
@@ -1,12 +1,13 @@
 // Relay warm-ping internal-auth — behavioral + wiring regression tests.
 //
-// The Railway relay warm-pings three cacheable, non-premium RPC endpoints
-// (get-risk-scores, get-chokepoint-status, get-cable-health) to keep their
-// compute caches hot. These require a session token or API key in normal
-// traffic, and the #3541 hardening removed Origin-trust — so all three warm-
-// pings 401'd in prod (2026-06-06). The relay now authenticates as a trusted
-// internal caller via X-WorldMonitor-Key = WORLDMONITOR_RELAY_KEY, validated by
-// the gateway against its own WORLDMONITOR_RELAY_KEY for these paths only.
+// The Railway relay warm-pings cacheable, non-premium RPC endpoints
+// (service-statuses, get-risk-scores, get-chokepoint-status, get-cable-health)
+// to keep their compute caches hot. These require a session token or API key in
+// normal traffic, and the #3541 hardening removed Origin-trust — so relay
+// warm-pings 401 without a real credential. The relay now authenticates as a
+// trusted internal caller via X-WorldMonitor-Key = WORLDMONITOR_RELAY_KEY,
+// validated by the gateway against its own WORLDMONITOR_RELAY_KEY for these
+// paths only.
 //
 // These tests exercise the real isRelayWarmPingRequest verifier and pin the
 // least-privilege scoping + timing-safe comparison so a future edit can't widen
@@ -35,19 +36,22 @@ describe('relay warm-ping internal auth', () => {
     else process.env.WORLDMONITOR_RELAY_KEY = original;
   });
 
-  it('covers exactly the three free warm-ping endpoints', () => {
+  it('covers exactly the free relay warm-ping endpoints', () => {
     assert.deepEqual(
       [...RELAY_WARM_PING_PATHS].sort(),
       [
         '/api/infrastructure/v1/get-cable-health',
+        '/api/infrastructure/v1/list-service-statuses',
         '/api/intelligence/v1/get-risk-scores',
         '/api/supply-chain/v1/get-chokepoint-status',
       ],
     );
   });
 
-  it('accepts a warm-ping path carrying the correct relay key', async () => {
-    assert.equal(await isRelayWarmPingRequest(req(WARM_PATH, SECRET), WARM_PATH), true);
+  it('accepts warm-ping paths carrying the correct relay key', async () => {
+    for (const path of RELAY_WARM_PING_PATHS) {
+      assert.equal(await isRelayWarmPingRequest(req(path, SECRET), path), true, path);
+    }
   });
 
   it('rejects the wrong key on a warm-ping path', async () => {
@@ -78,6 +82,16 @@ describe('relay warm-ping internal auth', () => {
 // wired into BOTH the key-check bypass and the entitlement skip so the bypass
 // can't silently drift to a forgeable check or grant entitlement access.
 describe('relay warm-ping auth wiring (source guardrail)', () => {
+  it('keeps the active Service Statuses relay loop on shared warm-ping auth headers', async () => {
+    const src = await readFile(new URL('../scripts/ais-relay.cjs', import.meta.url), 'utf8');
+    assert.match(src, /const SERVICE_STATUSES_RPC_URL = 'https:\/\/api\.worldmonitor\.app\/api\/infrastructure\/v1\/list-service-statuses'/);
+    assert.match(
+      src,
+      /fetch\(SERVICE_STATUSES_RPC_URL,\s*\{[\s\S]{0,240}?headers: warmPingHeaders\(\{ 'Content-Type': 'application\/json' \}\)/,
+      'Service Statuses warm-ping must keep sending the relay key via warmPingHeaders()',
+    );
+  });
+
   it('uses timingSafeEqual (no direct equality) and is wired into both gates', async () => {
     const src = await readFile(new URL('../server/gateway.ts', import.meta.url), 'utf8');
     // verifier uses the timing-safe comparator against the env secret + header


### PR DESCRIPTION
## Summary

All **three** relay warm-pings — CII (`get-risk-scores`), chokepoint (`get-chokepoint-status`), and cable (`get-cable-health`) — are returning **HTTP 401**, so their compute caches are no longer kept warm by the relay.

**Root cause (verified live):** these endpoints are non-premium but **not anonymous** — normal traffic authenticates with a browser session token or an API key. The #3541 hardening removed Origin/Referer trust (those headers are client-forgeable), so the relay's old "Origin-only fallback" is **dead**. The relay sends `X-WorldMonitor-Key = WORLDMONITOR_RELAY_KEY`, but that value isn't in `WORLDMONITOR_VALID_KEYS`, so `validateApiKey` 401s it.

```
GET get-risk-scores       no key → 401   enterprise key → 200
GET get-chokepoint-status no key → 401   enterprise key → 200
```

(The earlier hypothesis that risk-scores was "public" was wrong — both require auth.)

## Fix — least-privilege internal auth (not an enterprise key)

Handing the relay a `WORLDMONITOR_VALID_KEYS` enterprise key would work but is **over-privileged** — enterprise keys bypass *all* entitlement checks everywhere. Instead, recognize the relay as a trusted internal caller for **only the three warm-ping paths**, mirroring the existing `isResilienceRankingSeedRefreshRequest` internal-auth precedent:

- **`server/gateway.ts`**: `RELAY_WARM_PING_PATHS` + `isRelayWarmPingRequest(request, pathname)` — true only when the path is a warm-ping target **and** `X-WorldMonitor-Key` timing-safe-equals `WORLDMONITOR_RELAY_KEY`. Wired into the same three decision points as `seedRefreshVerified` (`isTierGated`, the `keyCheck` bypass, the entitlement skip). **Fails closed** when the secret is unset.
- **`scripts/ais-relay.cjs`**: corrects the stale `Origin-trust` comments + boot/failure warnings (that fallback has been dead since #3541) and documents that `WORLDMONITOR_RELAY_KEY` is a **dedicated relay↔gateway secret** set on **both** the Railway relay and the Vercel api project. The relay already sends the key — no functional relay change.

**Blast radius of the secret:** a cache-warm (recompute) on three *free* endpoints — exactly what any session holder can already trigger. No premium data, no entitlement bypass beyond anonymous-equivalent.

## Test plan

- [x] `tests/relay-warm-ping-auth.test.mts` (new, 8 tests): behavioral coverage of the real `isRelayWarmPingRequest` — correct key → accept; wrong/missing key → reject; **non-warm-ping path → reject even with the key** (scoping); unset/blank secret → **fail closed** — plus a source-text guardrail (timing-safe compare, no direct equality, wired into both gates) mirroring `tests/resilience-seed-refresh-auth.test.mts`.
- [x] `npm run typecheck` / `typecheck:api`
- [x] `node -c scripts/ais-relay.cjs`
- [x] `npm run lint` (clean on changed files)
- [x] `npm run test:data` — 10879 pass, 0 fail
- [x] edge tests (204) / `lint:md` / `version:check`

## Deploy / operator step

Set `WORLDMONITOR_RELAY_KEY` to the **same dedicated secret** on:
1. the **Railway `ais-relay`** service, and
2. the **Vercel api project** (gateway).

It need **not** be a `WORLDMONITOR_VALID_KEYS` enterprise key (least privilege). Until both are set, warm-pings keep 401ing (fail closed) — no behavior change vs. today.

cc @SebastienMelki (gateway auth owner).