### PR TITLE
Fix CII browser climate zone fallback parity

### DIFF
--- a/src/services/country-instability.ts
+++ b/src/services/country-instability.ts
@@ -332,11 +332,14 @@ export function ingestDisplacementForCII(countries: CountryDisplacement[]): void
 
 const ZONE_COUNTRY_MAP: Record<string, string[]> = {
   'Ukraine': ['UA'],
+  'Europe': ['DE', 'FR', 'GB', 'PL', 'TR', 'UA'],
+  'East Asia': ['CN', 'TW', 'KP', 'KR', 'JP'],
   'Middle East': ['IR', 'IL', 'SA', 'SY', 'YE', 'AE', 'IQ', 'LB', 'QA'],
   'South Asia': ['PK', 'IN', 'AF'],
   'Myanmar': ['MM'],
   'California': ['US'],
   'Amazon': ['BR'],
+  'Latin America': ['VE', 'CU', 'MX', 'BR'],
   'Taiwan Strait': ['TW', 'CN'],
   'Caribbean': ['CU', 'MX'],
   'Mediterranean': ['TR', 'IL', 'SY', 'LB', 'EG'],

--- a/src/services/country-instability.ts
+++ b/src/services/country-instability.ts
@@ -331,15 +331,18 @@ export function ingestDisplacementForCII(countries: CountryDisplacement[]): void
 }
 
 const ZONE_COUNTRY_MAP: Record<string, string[]> = {
+  'North America': ['US'],
   'Ukraine': ['UA'],
   'Europe': ['DE', 'FR', 'GB', 'PL', 'TR', 'UA'],
   'East Asia': ['CN', 'TW', 'KP', 'KR', 'JP'],
   'Middle East': ['IR', 'IL', 'SA', 'SY', 'YE', 'AE', 'IQ', 'LB', 'QA'],
-  'South Asia': ['PK', 'IN', 'AF'],
+  'South Asia': ['IN', 'PK', 'MM', 'AF'],
+  'Russia': ['RU'],
   'Myanmar': ['MM'],
   'California': ['US'],
   'Amazon': ['BR'],
   'Latin America': ['VE', 'CU', 'MX', 'BR'],
+  'North Africa': ['EG'],
   'Taiwan Strait': ['TW', 'CN'],
   'Caribbean': ['CU', 'MX'],
   'Mediterranean': ['TR', 'IL', 'SY', 'LB', 'EG'],

--- a/tests/frontend-cii-closeout.test.mts
+++ b/tests/frontend-cii-closeout.test.mts
@@ -133,6 +133,9 @@ describe('frontend CII closeout regressions', () => {
       { zone: 'Amazon', severity: 'moderate' },
       { zone: 'Taiwan Strait', severity: 'extreme' },
       { zone: 'Caribbean', severity: 'moderate' },
+      { zone: 'Europe', severity: 'extreme' },
+      { zone: 'East Asia', severity: 'extreme' },
+      { zone: 'Latin America', severity: 'moderate' },
     ]);
 
     assert.equal(cii.getCountryData('US')?.climateStress, 15);
@@ -141,6 +144,14 @@ describe('frontend CII closeout regressions', () => {
     assert.equal(cii.getCountryData('CN')?.climateStress, 15);
     assert.equal(cii.getCountryData('MX')?.climateStress, 8);
     assert.equal(cii.getCountryData('CU')?.climateStress, 8);
+    assert.equal(cii.getCountryData('PL')?.climateStress, 15);
+    assert.equal(cii.getCountryData('DE')?.climateStress, 15);
+    assert.equal(cii.getCountryData('FR')?.climateStress, 15);
+    assert.equal(cii.getCountryData('GB')?.climateStress, 15);
+    assert.equal(cii.getCountryData('KP')?.climateStress, 15);
+    assert.equal(cii.getCountryData('KR')?.climateStress, 15);
+    assert.equal(cii.getCountryData('JP')?.climateStress, 15);
+    assert.equal(cii.getCountryData('VE')?.climateStress, 8);
   });
 });
 

--- a/tests/frontend-cii-closeout.test.mts
+++ b/tests/frontend-cii-closeout.test.mts
@@ -4,16 +4,82 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
 import { transformSync } from 'esbuild';
+import ts from 'typescript';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
 const countryInstabilityPath = resolve(root, 'src/services/country-instability.ts');
+const serverRiskScoresPath = resolve(root, 'server/worldmonitor/intelligence/v1/get-risk-scores.ts');
 const crossModulePath = resolve(root, 'src/services/cross-module-integration.ts');
 const cachedRiskScoresPath = resolve(root, 'src/services/cached-risk-scores.ts');
 
 const countryInstabilitySource = readFileSync(countryInstabilityPath, 'utf8');
+const serverRiskScoresSource = readFileSync(serverRiskScoresPath, 'utf8');
 const crossModuleSource = readFileSync(crossModulePath, 'utf8');
 const cachedRiskScoresSource = readFileSync(cachedRiskScoresPath, 'utf8');
+
+function findTopLevelConstDeclaration(
+  sourceFile: ts.SourceFile,
+  constName: string,
+): ts.VariableDeclaration | null {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    if ((statement.declarationList.flags & ts.NodeFlags.Const) === 0) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (ts.isIdentifier(declaration.name) && declaration.name.text === constName) {
+        return declaration;
+      }
+    }
+  }
+  return null;
+}
+
+function propertyNameText(name: ts.PropertyName, sourceFile: ts.SourceFile): string {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNoSubstitutionTemplateLiteral(name)) {
+    return name.text;
+  }
+  assert.fail(`unsupported ZONE_COUNTRY_MAP key syntax: ${name.getText(sourceFile)}`);
+}
+
+function extractTopLevelStringArrayRecord(
+  source: string,
+  fileName: string,
+  constName: string,
+): Record<string, string[]> {
+  const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const declaration = findTopLevelConstDeclaration(sourceFile, constName);
+  assert.ok(declaration, `${fileName} must declare top-level const ${constName}`);
+  assert.ok(declaration.initializer, `${fileName} ${constName} must have an initializer`);
+  assert.ok(
+    ts.isObjectLiteralExpression(declaration.initializer),
+    `${fileName} ${constName} must be an object literal`,
+  );
+
+  const out: Record<string, string[]> = {};
+  for (const property of declaration.initializer.properties) {
+    assert.ok(
+      ts.isPropertyAssignment(property),
+      `${fileName} ${constName} must only contain property assignments`,
+    );
+    assert.ok(
+      ts.isArrayLiteralExpression(property.initializer),
+      `${fileName} ${constName}.${property.name.getText(sourceFile)} must be an array literal`,
+    );
+
+    out[propertyNameText(property.name, sourceFile)] = property.initializer.elements.map((element) => {
+      assert.ok(
+        ts.isStringLiteral(element) || ts.isNoSubstitutionTemplateLiteral(element),
+        `${fileName} ${constName}.${property.name.getText(sourceFile)} entries must be string literals`,
+      );
+      return element.text;
+    });
+  }
+  return out;
+}
+
+function sortRecord<T>(record: Record<string, T>): Record<string, T> {
+  return Object.fromEntries(Object.entries(record).sort(([left], [right]) => left.localeCompare(right)));
+}
 
 async function loadCountryInstability() {
   const patched = countryInstabilitySource
@@ -171,6 +237,21 @@ describe('frontend CII closeout regressions', () => {
     assert.equal(cii.getCountryData('RU')?.climateStress, 15);
     assert.equal(cii.getCountryData('EG')?.climateStress, 8);
     assert.equal(cii.getCountryData('MM')?.climateStress, 15);
+  });
+
+  it('browser and server CII climate zone maps stay in lockstep', () => {
+    const browserMap = extractTopLevelStringArrayRecord(
+      countryInstabilitySource,
+      'src/services/country-instability.ts',
+      'ZONE_COUNTRY_MAP',
+    );
+    const serverMap = extractTopLevelStringArrayRecord(
+      serverRiskScoresSource,
+      'server/worldmonitor/intelligence/v1/get-risk-scores.ts',
+      'ZONE_COUNTRY_MAP',
+    );
+
+    assert.deepEqual(sortRecord(browserMap), sortRecord(serverMap));
   });
 });
 

--- a/tests/frontend-cii-closeout.test.mts
+++ b/tests/frontend-cii-closeout.test.mts
@@ -148,10 +148,29 @@ describe('frontend CII closeout regressions', () => {
     assert.equal(cii.getCountryData('DE')?.climateStress, 15);
     assert.equal(cii.getCountryData('FR')?.climateStress, 15);
     assert.equal(cii.getCountryData('GB')?.climateStress, 15);
+    assert.equal(cii.getCountryData('UA')?.climateStress, 15);
+    assert.equal(cii.getCountryData('TR')?.climateStress, 15);
     assert.equal(cii.getCountryData('KP')?.climateStress, 15);
     assert.equal(cii.getCountryData('KR')?.climateStress, 15);
     assert.equal(cii.getCountryData('JP')?.climateStress, 15);
     assert.equal(cii.getCountryData('VE')?.climateStress, 8);
+  });
+
+  it('frontend climate fallback accepts backend-named CII climate zones', async () => {
+    const cii = await loadCountryInstability();
+    cii.clearCountryData();
+
+    cii.ingestClimateForCII([
+      { zone: 'North America', severity: 'moderate' },
+      { zone: 'Russia', severity: 'extreme' },
+      { zone: 'North Africa', severity: 'moderate' },
+      { zone: 'South Asia', severity: 'extreme' },
+    ]);
+
+    assert.equal(cii.getCountryData('US')?.climateStress, 8);
+    assert.equal(cii.getCountryData('RU')?.climateStress, 15);
+    assert.equal(cii.getCountryData('EG')?.climateStress, 8);
+    assert.equal(cii.getCountryData('MM')?.climateStress, 15);
   });
 });
 


### PR DESCRIPTION
## Summary

- Align the browser-only CII climate fallback zone map with the backend producer mappings for Europe, East Asia, and Latin America.
- Extend the frontend CII closeout regression test so PL/DE/FR/GB, KP/KR/JP, and VE keep receiving climate stress when cached backend CII is unavailable.

## Root Cause

The backend CII scorer and climate producer knew about Europe, East Asia, and Latin America, but the browser fallback map in `src/services/country-instability.ts` only recognized older local zone names. That meant the fallback path could silently drop score-relevant climate boosts for several countries even though published/server CII remained correct.

## Validation

- `./node_modules/.bin/tsx --test tests/frontend-cii-closeout.test.mts tests/cii-scoring.test.mts`
- `npm run typecheck`
- Normal `git push` pre-push hook, including typecheck, API typecheck, boundary/safe-html/rate-limit/premium-fetch checks, edge bundle check, changed tests, edge function tests, and version sync.