### PR TITLE
docs(cii): align Strategic Risk documentation

### DIFF
--- a/docs/algorithms.mdx
+++ b/docs/algorithms.mdx
@@ -49,9 +49,9 @@ Events (protests, military flights, vessels, earthquakes) are binned into 1°×1
 
 ### Strategic Risk Score Algorithm
 
-The Strategic Risk panel prefers the cached server score from `GET /api/intelligence/v1/get-risk-scores`. In cached mode, the authoritative `StrategicRisk[0]` score is the server roll-up of the top five CII `combinedScore` values with weights `[1.00, 0.85, 0.70, 0.55, 0.40]`, scale factor `0.70`, floor `15`, and server severity bands High >= 70, Medium 40-69, Low < 40.
+The Strategic Risk panel prefers the cached server-published Strategic Risk headline from `GET /api/intelligence/v1/get-risk-scores`. In cached mode, the authoritative `StrategicRisk[0]` score is the server roll-up of the top-5 CII `combinedScore` values with weights `[1.00, 0.85, 0.70, 0.55, 0.40]`, scale factor `0.70`, floor `15`, and server severity bands High >= 70, Medium 40-69, Low < 40.
 
-When cached server scores are unavailable, the browser renders a local fallback overview that synthesizes locally available module data into a temporary 0-100 metric. This fallback is useful for continuity during cache misses, but it is not the published Strategic Risk contract.
+When cached server scores are unavailable, the browser renders a local fallback overview that synthesizes locally available module data into temporary panel context. This panel-local context is useful for continuity during cache misses, but it is not the published Strategic Risk contract.
 
 **Browser/local fallback composite formula**:
 

--- a/docs/algorithms.mdx
+++ b/docs/algorithms.mdx
@@ -49,19 +49,11 @@ Events (protests, military flights, vessels, earthquakes) are binned into 1°×1
 
 ### Strategic Risk Score Algorithm
 
-The server-published Strategic Risk headline score comes from
-`GET /api/intelligence/v1/get-risk-scores`: it rolls up the top 5 countries by
-server-authoritative CII `combinedScore`, using positional weights
-`[1.00, 0.85, 0.70, 0.55, 0.40]`, then applies `score = round(weightedAvg * 0.70 + 15)`.
-That server value is the headline score displayed by the Strategic Risk
-overview.
+The Strategic Risk panel prefers the cached server score from `GET /api/intelligence/v1/get-risk-scores`. In cached mode, the authoritative `StrategicRisk[0]` score is the server roll-up of the top five CII `combinedScore` values with weights `[1.00, 0.85, 0.70, 0.55, 0.40]`, scale factor `0.70`, floor `15`, and server severity bands High >= 70, Medium 40-69, Low < 40.
 
-The Strategic Risk panel also computes additional local context from map-side
-convergence, infrastructure, theater posture, breaking-news, sanctions, and
-radiation-watch signals. These terms inform panel context and alerts; they are
-not the server headline Strategic Risk score.
+When cached server scores are unavailable, the browser renders a local fallback overview that synthesizes locally available module data into a temporary 0-100 metric. This fallback is useful for continuity during cache misses, but it is not the published Strategic Risk contract.
 
-**Panel-local context formula**:
+**Browser/local fallback composite formula**:
 
 ```
 compositeScore =
@@ -77,7 +69,7 @@ compositeScore =
 **Sub-scores**:
 
 - `convergenceScore` — `min(100, convergenceAlertCount × 25)`. Each geographic cell with 3+ distinct event types contributing 25 points
-- `ciiRiskScore` — panel-local CII context from top countries and elevated-country counts. The server headline instead uses the top-5 CII roll-up documented above and in [CII Risk Scoring Methodology](/methodology/cii-risk-scores#3-strategic-risk-roll-up).
+- `ciiRiskScore` — Local fallback only: top 5 locally available country scores, weighted `[0.40, 0.25, 0.20, 0.10, 0.05]`, with a bonus of `min(20, elevatedCount × 5)` for each country above CII 50
 - `infraScore` — `min(100, cascadeAlertCount × 25)`. Each infrastructure cascade incident contributing 25 points
 - `theaterBoost` — For each theater posture summary: `min(10, floor((aircraft + vessels) / 5))` + 5 if strike-capable (tanker + AWACS + fighters co-present). Summed across theaters, capped at 25. Halved when posture data is stale
 - `breakingBoost` — Critical breaking news alerts add 15 points, high adds 8, capped at 15. Breaking alerts expire after 30 minutes

--- a/docs/strategic-risk.mdx
+++ b/docs/strategic-risk.mdx
@@ -8,22 +8,27 @@ The Strategic Risk system provides a composite dashboard for global risk triage.
 
 The Strategic Risk Overview displays the server-side Strategic Risk headline and nearby operational context from the browser panel.
 
-### Composite Score (0-100)
+### Server Score and Browser Fallback (0-100)
 
 The displayed/server headline score comes from `GetRiskScores.strategicRisks[0]`.
-The server derives it from the weighted top 5 CII countries, not from the
-additive panel context formula:
+The server derives it from the weighted top 5 CII countries by `combinedScore`,
+not from the additive panel context formula:
 
 ```
-top5         = ciiScores.slice(0, 5)
-weights      = [1.00, 0.85, 0.70, 0.55, 0.40]
-weightedAvg  = sum(CII[i] * weight[i]) / sum(weights)
-headline     = round(weightedAvg * 0.70 + 15)
+topScores = top 5 countries by combinedScore
+weights = [1.00, 0.85, 0.70, 0.55, 0.40]
+weightedAvg = sum(topScores[i] * weights[i]) / sum(weights)
+headline = round(weightedAvg * 0.70 + 15)
 ```
 
-The browser panel may also compute additive context from map-side convergence,
-infrastructure, theater posture, breaking news, sanctions, and radiation-watch
-signals:
+See
+[CII Risk Scoring Methodology](/methodology/cii-risk-scores#3-strategic-risk-roll-up)
+for the exact top-5 window, scale factor, floor, and severity bands.
+
+When cached server scores are unavailable, the browser can render a local
+fallback overview that combines map-side convergence, infrastructure, theater
+posture, breaking news, sanctions, radiation-watch signals, and the locally
+available CII summary:
 
 ```
 compositeScore =
@@ -36,27 +41,20 @@ compositeScore =
   + radiationScore
 ```
 
-The server-side Strategic Risk API derives its global score from the weighted
-top 5 CII countries. The additive terms above are panel context and alerting
-inputs, not the server headline formula. See
-[CII Risk Scoring Methodology](/methodology/cii-risk-scores#3-strategic-risk-roll-up)
-for the exact top-5 weights, scale factor, and severity bands.
-
-Additional additive terms come from sanctions pressure and radiation-watch
-signals when those modules have fresh data: `sanctionsScore` is capped at 10
-from new sanctions entries, largest-country entry volume, and sanctioned
-vessel/aircraft counts; `radiationScore` is capped at 12 from radiation-watch
-spikes, elevated readings, and corroborated observations, reduced by
-low-confidence or conflicting observations.
+Those additive terms are local fallback context, not the server Strategic Risk
+contract. `sanctionsScore` is capped at 10 from new sanctions entries,
+largest-country entry volume, and sanctioned vessel/aircraft counts;
+`radiationScore` is capped at 12 from radiation-watch spikes, elevated readings,
+and corroborated observations, reduced by low-confidence or conflicting
+observations.
 
 ### Risk Levels
 
 | Score | Level | Trend Icon | Meaning |
 |-------|-------|------------|---------|
-| 70-100 | **Critical** | Escalating | Multiple converging crises |
-| 50-69 | **Elevated** | Stable | Heightened global tension |
-| 30-49 | **Moderate** | Stable | Normal fluctuation |
-| 0-29 | **Low** | De-escalating | Unusually quiet period |
+| 70-100 | **High** | Escalating | Multiple converging crises |
+| 40-69 | **Medium** | Stable | Heightened global tension |
+| 0-39 | **Low** | De-escalating | Lower global strategic pressure |
 
 ### Unified Alert System
 

--- a/docs/strategic-risk.mdx
+++ b/docs/strategic-risk.mdx
@@ -78,10 +78,15 @@ Priority: Critical
 
 ### Alert Priority
 
+Alert priority is separate from the server Strategic Risk High/Medium/Low
+bands. References to Critical and High CII below use the Country Instability
+Index country-score bands documented in
+[Country Instability Index](/country-instability-index#instability-levels).
+
 | Priority | Criteria |
 |----------|----------|
-| **Critical** | CII critical level, convergence score ≥80, cascade critical impact |
-| **High** | CII high level, convergence score ≥60, cascade affecting ≥5 countries |
+| **Critical** | CII country Critical band (81-100), convergence score ≥80, cascade critical impact |
+| **High** | CII country High band (66-80), convergence score ≥60, cascade affecting ≥5 countries |
 | **Medium** | CII change ≥10 points, convergence score ≥40 |
 | **Low** | Minor changes and low-impact events |
 

--- a/tests/cii-docs-drift.test.mts
+++ b/tests/cii-docs-drift.test.mts
@@ -6,12 +6,31 @@ import { describe, it } from 'node:test';
 
 const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
 
+function findNextMarkdownHeadingOffset(text: string, start: number): number {
+  const remainder = text.slice(start);
+  const lines = remainder.split('\n');
+  let offset = 0;
+  let inFence = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (/^\s*(?:```|~~~)/.test(line)) {
+      inFence = !inFence;
+    } else if (!inFence && /^#{1,3} /.test(line)) {
+      return offset;
+    }
+    offset += line.length + (i < lines.length - 1 ? 1 : 0);
+  }
+
+  return -1;
+}
+
 function markdownSection(text: string, heading: string): string {
   const marker = `${heading}\n`;
   const start = text.indexOf(marker);
   assert.notEqual(start, -1, `Expected markdown section heading "${heading}"`);
   const sectionStart = start + marker.length;
-  const nextHeading = text.slice(sectionStart).search(/^#{1,3} /m);
+  const nextHeading = findNextMarkdownHeadingOffset(text, sectionStart);
   return nextHeading === -1
     ? text.slice(sectionStart)
     : text.slice(sectionStart, sectionStart + nextHeading);
@@ -77,13 +96,34 @@ describe('CII docs drift guards', () => {
     );
   });
 
+  it('section extraction ignores heading-looking lines inside fenced code blocks', () => {
+    const section = markdownSection(
+      [
+        '### Target',
+        'Before fence.',
+        '```sh',
+        '# install',
+        '### not a section boundary',
+        '```',
+        'After fence.',
+        '### Next',
+        'Outside target.',
+      ].join('\n'),
+      '### Target',
+    );
+
+    assert.match(section, /### not a section boundary/);
+    assert.match(section, /After fence\./);
+    assert.doesNotMatch(section, /Outside target\./);
+  });
+
   it('algorithms doc separates authoritative Strategic Risk from local fallback', () => {
     const doc = readFileSync(resolve(root, 'docs', 'algorithms.mdx'), 'utf8');
     const section = markdownSection(doc, '### Strategic Risk Score Algorithm');
 
     assert.match(
       section,
-      /authoritative `StrategicRisk\[0\]` score is the server roll-up of the top five CII `combinedScore` values with weights `\[1\.00, 0\.85, 0\.70, 0\.55, 0\.40\]`, scale factor `0\.70`, floor `15`/i,
+      /authoritative `StrategicRisk\[0\]` score is the server roll-up of the top(?: five|-5) CII `combinedScore` values with weights `\[1\.00, 0\.85, 0\.70, 0\.55, 0\.40\]`, scale factor `0\.70`, floor `15`/i,
       'algorithms doc must identify the server roll-up as authoritative Strategic Risk',
     );
     assert.match(

--- a/tests/cii-docs-drift.test.mts
+++ b/tests/cii-docs-drift.test.mts
@@ -6,6 +6,17 @@ import { describe, it } from 'node:test';
 
 const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
 
+function markdownSection(text: string, heading: string): string {
+  const marker = `${heading}\n`;
+  const start = text.indexOf(marker);
+  assert.notEqual(start, -1, `Expected markdown section heading "${heading}"`);
+  const sectionStart = start + marker.length;
+  const nextHeading = text.slice(sectionStart).search(/^#{1,3} /m);
+  return nextHeading === -1
+    ? text.slice(sectionStart)
+    : text.slice(sectionStart, sectionStart + nextHeading);
+}
+
 describe('CII docs drift guards', () => {
   it('internal review docs do not retain stale CII country-count or source-of-truth claims', () => {
     const internalDocPaths = [
@@ -38,6 +49,62 @@ describe('CII docs drift guards', () => {
       violations.length,
       0,
       `internal CII review docs contain stale claims:\n  ${violations.join('\n  ')}`,
+    );
+  });
+
+  it('strategic risk doc publishes current server severity bands and roll-up', () => {
+    const doc = readFileSync(resolve(root, 'docs', 'strategic-risk.mdx'), 'utf8');
+    const scoreSection = markdownSection(doc, '### Server Score and Browser Fallback (0-100)');
+    const riskLevels = markdownSection(doc, '### Risk Levels');
+
+    assert.match(
+      scoreSection,
+      /weights = \[1\.00, 0\.85, 0\.70, 0\.55, 0\.40\][\s\S]*\* 0\.70 \+ 15/,
+      'strategic-risk doc must publish the server top-5 weights, scale factor, and floor',
+    );
+    assert.match(
+      scoreSection,
+      /local\s+fallback/i,
+      'strategic-risk doc must label the additive overview as browser/local fallback',
+    );
+    assert.match(riskLevels, /\|\s*70-100\s*\|\s*\*\*High\*\*/);
+    assert.match(riskLevels, /\|\s*40-69\s*\|\s*\*\*Medium\*\*/);
+    assert.match(riskLevels, /\|\s*0-39\s*\|\s*\*\*Low\*\*/);
+    assert.doesNotMatch(
+      riskLevels,
+      /\*\*(?:Critical|Elevated|Moderate)\*\*|50-69|30-49/,
+      'strategic-risk risk-level table must not retain old Critical/Elevated/Moderate 70/50/30 semantics',
+    );
+  });
+
+  it('algorithms doc separates authoritative Strategic Risk from local fallback', () => {
+    const doc = readFileSync(resolve(root, 'docs', 'algorithms.mdx'), 'utf8');
+    const section = markdownSection(doc, '### Strategic Risk Score Algorithm');
+
+    assert.match(
+      section,
+      /authoritative `StrategicRisk\[0\]` score is the server roll-up of the top five CII `combinedScore` values with weights `\[1\.00, 0\.85, 0\.70, 0\.55, 0\.40\]`, scale factor `0\.70`, floor `15`/i,
+      'algorithms doc must identify the server roll-up as authoritative Strategic Risk',
+    );
+    assert.match(
+      section,
+      /server severity bands High >= 70, Medium 40-69, Low < 40/i,
+      'algorithms doc must publish current server Strategic Risk severity bands',
+    );
+    assert.match(
+      section,
+      /Browser\/local fallback composite formula[\s\S]*`ciiRiskScore` — Local fallback only:[\s\S]*`\[0\.40, 0\.25, 0\.20, 0\.10, 0\.05\]`/,
+      'algorithms doc may describe old additive weights only as local fallback',
+    );
+    assert.doesNotMatch(
+      section,
+      /`ciiRiskScore` — Top 5 countries by CII score, weighted `\[0\.40, 0\.25, 0\.20, 0\.10, 0\.05\]`/,
+      'algorithms doc must not present the old fallback CII weights as canonical',
+    );
+    assert.doesNotMatch(
+      section,
+      /Critical\/Elevated\/Moderate|70\/50\/30/,
+      'algorithms Strategic Risk section must not reintroduce old four-band risk semantics',
     );
   });
 });


### PR DESCRIPTION
## Summary

- Align `docs/strategic-risk.mdx` with the server Strategic Risk roll-up and current High/Medium/Low bands.
- Clarify in `docs/algorithms.mdx` that the additive convergence/CII/infra/theater/breaking/sanctions/radiation formula is browser/local fallback only.
- Add CII docs drift guards so the old 70/50/30 Critical/Elevated/Moderate semantics and old fallback CII weights cannot return as canonical documentation.

## Validation

- `./node_modules/.bin/tsx --test tests/frontend-cii-source-of-truth.test.mts tests/cii-scoring.test.mts tests/cii-docs-drift.test.mts`
- `npm run typecheck`
- Pre-push hook on `git push -u origin codex/cii-strategic-risk-doc-parity`, including typecheck, API typecheck, boundary/safe-html/rate-limit/premium-fetch checks, changed test files, markdown lint, MDX lint, proto freshness skip, pro-test freshness skip, and version sync.

## Notes

No scoring code changed.