### PR TITLE
fix(deduction): preserve probability ranges

### DIFF
--- a/src/components/DeductionPanel.ts
+++ b/src/components/DeductionPanel.ts
@@ -10,6 +10,7 @@ import { buildNewsContext } from '@/utils/news-context';
 import { getActiveFrameworkForPanel } from '@/services/analysis-framework-store';
 import { hasPremiumAccess } from '@/services/panel-gating';
 import { FrameworkSelector } from './FrameworkSelector';
+import { extractDeductionProbability } from './deduction-probability';
 
 // deduct-situation + list-market-implications are premium-gated.
 const client = new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: premiumFetch });
@@ -156,7 +157,7 @@ export class DeductionPanel extends Panel {
             if (group.cls === 'ds-primary') {
                 const headingNode = group.nodes[0];
                 const fullText = headingNode?.textContent ?? '';
-                const probMatch = /(\d{1,3})\s*%/.exec(fullText);
+                const probability = extractDeductionProbability(fullText);
                 const timeMatch = /\(([^)]+)\)/.exec(fullText);
                 labelEl.textContent = group.label;
                 if (timeMatch) {
@@ -165,10 +166,11 @@ export class DeductionPanel extends Panel {
                     timeSpan.textContent = timeMatch[1] ?? '';
                     labelEl.appendChild(timeSpan);
                 }
-                if (probMatch) {
+                if (probability) {
                     const badge = document.createElement('span');
                     badge.className = 'ds-prob-badge';
-                    badge.textContent = `${probMatch[1]}%`;
+                    badge.textContent = probability.label;
+                    badge.title = probability.isRange ? 'Rough probability range from the source' : 'Approximate probability from the source';
                     labelEl.appendChild(badge);
                 }
             } else {
@@ -195,12 +197,13 @@ export class DeductionPanel extends Panel {
                     bodyNodes.forEach(n => {
                         if (n.tagName === 'UL') {
                             n.querySelectorAll('li').forEach(li => {
-                                const probMatch = /^(\d{1,3})\s*%\s*[:\s]?(.*)/.exec(li.textContent ?? '');
-                                if (probMatch) {
+                                const probability = extractDeductionProbability(li.textContent ?? '', { leadingOnly: true });
+                                if (probability) {
                                     const badge = document.createElement('span');
                                     badge.className = 'ds-alt-prob';
-                                    badge.textContent = `${probMatch[1]}%`;
-                                    li.textContent = (probMatch[2] ?? '').replace(/^\s*[:\s]+/, '').trim();
+                                    badge.textContent = probability.label;
+                                    badge.title = probability.isRange ? 'Rough probability range from the source' : 'Approximate probability from the source';
+                                    li.textContent = probability.remainder;
                                     li.insertBefore(badge, li.firstChild);
                                 }
                             });

--- a/src/components/deduction-probability.ts
+++ b/src/components/deduction-probability.ts
@@ -1,0 +1,56 @@
+export interface DeductionProbabilityBadge {
+  label: string;
+  remainder: string;
+  isRange: boolean;
+}
+
+const RANGE_SEPARATOR_RE = String.raw`(?:%?\s*[-–—]\s*)`;
+const RANGE_RE = new RegExp(String.raw`\b(\d{1,3})\s*${RANGE_SEPARATOR_RE}(\d{1,3})\s*%`);
+const LEADING_RANGE_RE = new RegExp(String.raw`^\s*(\d{1,3})\s*${RANGE_SEPARATOR_RE}(\d{1,3})\s*%\s*[:\s-]*`);
+const SINGLE_RE = /\b(\d{1,3})\s*%/;
+const LEADING_SINGLE_RE = /^\s*(\d{1,3})\s*%\s*[:\s-]*/;
+
+function isValidProbability(value: number): boolean {
+  return Number.isInteger(value) && value >= 0 && value <= 100;
+}
+
+function formatRangeLabel(low: number, high: number): string {
+  return `${low}-${high}% range`;
+}
+
+function formatSingleLabel(value: number): string {
+  return `~${value}%`;
+}
+
+function toValidInt(value: string): number | null {
+  const parsed = Number.parseInt(value, 10);
+  return isValidProbability(parsed) ? parsed : null;
+}
+
+export function extractDeductionProbability(text: string, options: { leadingOnly?: boolean } = {}): DeductionProbabilityBadge | null {
+  const rangeMatch = (options.leadingOnly ? LEADING_RANGE_RE : RANGE_RE).exec(text);
+  if (rangeMatch) {
+    const low = toValidInt(rangeMatch[1] ?? '');
+    const high = toValidInt(rangeMatch[2] ?? '');
+    if (low !== null && high !== null) {
+      return {
+        label: formatRangeLabel(low, high),
+        remainder: options.leadingOnly ? text.slice(rangeMatch[0].length).trim() : text,
+        isRange: true,
+      };
+    }
+    return null;
+  }
+
+  const singleMatch = (options.leadingOnly ? LEADING_SINGLE_RE : SINGLE_RE).exec(text);
+  if (!singleMatch) return null;
+
+  const value = toValidInt(singleMatch[1] ?? '');
+  if (value === null) return null;
+
+  return {
+    label: formatSingleLabel(value),
+    remainder: options.leadingOnly ? text.slice(singleMatch[0].length).trim() : text,
+    isRange: false,
+  };
+}

--- a/src/components/deduction-probability.ts
+++ b/src/components/deduction-probability.ts
@@ -5,10 +5,15 @@ export interface DeductionProbabilityBadge {
 }
 
 const RANGE_SEPARATOR_RE = String.raw`(?:%?\s*[-–—]\s*)`;
-const RANGE_RE = new RegExp(String.raw`\b(\d{1,3})\s*${RANGE_SEPARATOR_RE}(\d{1,3})\s*%`);
+const RANGE_RE_GLOBAL = new RegExp(String.raw`\b(\d{1,3})\s*${RANGE_SEPARATOR_RE}(\d{1,3})\s*%`, 'g');
 const LEADING_RANGE_RE = new RegExp(String.raw`^\s*(\d{1,3})\s*${RANGE_SEPARATOR_RE}(\d{1,3})\s*%\s*[:\s-]*`);
-const SINGLE_RE = /\b(\d{1,3})\s*%/;
+const SINGLE_RE_GLOBAL = /\b(\d{1,3})\s*%/g;
 const LEADING_SINGLE_RE = /^\s*(\d{1,3})\s*%\s*[:\s-]*/;
+
+interface Span {
+  start: number;
+  end: number;
+}
 
 function isValidProbability(value: number): boolean {
   return Number.isInteger(value) && value >= 0 && value <= 100;
@@ -27,22 +32,55 @@ function toValidInt(value: string): number | null {
   return isValidProbability(parsed) ? parsed : null;
 }
 
+function isInsideSpan(index: number, spans: Span[]): boolean {
+  return spans.some(span => index >= span.start && index < span.end);
+}
+
 export function extractDeductionProbability(text: string, options: { leadingOnly?: boolean } = {}): DeductionProbabilityBadge | null {
-  const rangeMatch = (options.leadingOnly ? LEADING_RANGE_RE : RANGE_RE).exec(text);
+  const rangeMatch = options.leadingOnly ? LEADING_RANGE_RE.exec(text) : null;
   if (rangeMatch) {
     const low = toValidInt(rangeMatch[1] ?? '');
     const high = toValidInt(rangeMatch[2] ?? '');
-    if (low !== null && high !== null) {
+    if (low !== null && high !== null && low <= high) {
       return {
         label: formatRangeLabel(low, high),
-        remainder: options.leadingOnly ? text.slice(rangeMatch[0].length).trim() : text,
+        remainder: text.slice(rangeMatch[0].length).trim(),
         isRange: true,
       };
     }
     return null;
   }
 
-  const singleMatch = (options.leadingOnly ? LEADING_SINGLE_RE : SINGLE_RE).exec(text);
+  if (!options.leadingOnly) {
+    const invalidRangeSpans: Span[] = [];
+    for (const match of text.matchAll(RANGE_RE_GLOBAL)) {
+      const low = toValidInt(match[1] ?? '');
+      const high = toValidInt(match[2] ?? '');
+      if (low !== null && high !== null && low <= high) {
+        return {
+          label: formatRangeLabel(low, high),
+          remainder: text,
+          isRange: true,
+        };
+      }
+      invalidRangeSpans.push({ start: match.index ?? 0, end: (match.index ?? 0) + match[0].length });
+    }
+
+    for (const match of text.matchAll(SINGLE_RE_GLOBAL)) {
+      if (isInsideSpan(match.index ?? 0, invalidRangeSpans)) continue;
+      const value = toValidInt(match[1] ?? '');
+      if (value === null) continue;
+      return {
+        label: formatSingleLabel(value),
+        remainder: text,
+        isRange: false,
+      };
+    }
+
+    return null;
+  }
+
+  const singleMatch = LEADING_SINGLE_RE.exec(text);
   if (!singleMatch) return null;
 
   const value = toValidInt(singleMatch[1] ?? '');

--- a/src/components/deduction-probability.ts
+++ b/src/components/deduction-probability.ts
@@ -15,12 +15,16 @@ interface Span {
   end: number;
 }
 
+interface Candidate extends DeductionProbabilityBadge {
+  start: number;
+}
+
 function isValidProbability(value: number): boolean {
   return Number.isInteger(value) && value >= 0 && value <= 100;
 }
 
 function formatRangeLabel(low: number, high: number): string {
-  return `${low}-${high}% range`;
+  return `${low}-${high}%`;
 }
 
 function formatSingleLabel(value: number): string {
@@ -53,15 +57,18 @@ export function extractDeductionProbability(text: string, options: { leadingOnly
 
   if (!options.leadingOnly) {
     const invalidRangeSpans: Span[] = [];
+    const candidates: Candidate[] = [];
     for (const match of text.matchAll(RANGE_RE_GLOBAL)) {
       const low = toValidInt(match[1] ?? '');
       const high = toValidInt(match[2] ?? '');
       if (low !== null && high !== null && low <= high) {
-        return {
+        candidates.push({
+          start: match.index ?? 0,
           label: formatRangeLabel(low, high),
           remainder: text,
           isRange: true,
-        };
+        });
+        continue;
       }
       invalidRangeSpans.push({ start: match.index ?? 0, end: (match.index ?? 0) + match[0].length });
     }
@@ -70,14 +77,22 @@ export function extractDeductionProbability(text: string, options: { leadingOnly
       if (isInsideSpan(match.index ?? 0, invalidRangeSpans)) continue;
       const value = toValidInt(match[1] ?? '');
       if (value === null) continue;
-      return {
+      candidates.push({
+        start: match.index ?? 0,
         label: formatSingleLabel(value),
         remainder: text,
         isRange: false,
-      };
+      });
     }
 
-    return null;
+    candidates.sort((a, b) => a.start - b.start);
+    const candidate = candidates[0];
+    if (!candidate) return null;
+    return {
+      label: candidate.label,
+      remainder: candidate.remainder,
+      isRange: candidate.isRange,
+    };
   }
 
   const singleMatch = LEADING_SINGLE_RE.exec(text);

--- a/tests/deduction-probability.test.mts
+++ b/tests/deduction-probability.test.mts
@@ -1,0 +1,58 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { extractDeductionProbability } from '../src/components/deduction-probability';
+
+describe('deduction probability parsing', () => {
+  it('preserves rough ranges from primary path headings', () => {
+    const parsed = extractDeductionProbability('Most likely path (next 24-72h, 40-55%)');
+
+    assert.deepEqual(parsed, {
+      label: '40-55% range',
+      remainder: 'Most likely path (next 24-72h, 40-55%)',
+      isRange: true,
+    });
+  });
+
+  it('supports single percentages as approximate values', () => {
+    const parsed = extractDeductionProbability('Most likely path (next 24-72h, 55%)');
+
+    assert.deepEqual(parsed, {
+      label: '~55%',
+      remainder: 'Most likely path (next 24-72h, 55%)',
+      isRange: false,
+    });
+  });
+
+  it('extracts leading alternative path ranges without collapsing to one endpoint', () => {
+    const parsed = extractDeductionProbability('40-55%: Negotiated pause after shuttle diplomacy', { leadingOnly: true });
+
+    assert.deepEqual(parsed, {
+      label: '40-55% range',
+      remainder: 'Negotiated pause after shuttle diplomacy',
+      isRange: true,
+    });
+  });
+
+  it('supports leading alternative path single percentages', () => {
+    const parsed = extractDeductionProbability('35% spillover risk if talks fail', { leadingOnly: true });
+
+    assert.deepEqual(parsed, {
+      label: '~35%',
+      remainder: 'spillover risk if talks fail',
+      isRange: false,
+    });
+  });
+
+  it('does not badge non-leading alternative path percentages', () => {
+    const parsed = extractDeductionProbability('Spillover risk rises toward 35% if talks fail', { leadingOnly: true });
+
+    assert.equal(parsed, null);
+  });
+
+  it('does not badge invalid percentage values', () => {
+    assert.equal(extractDeductionProbability('Most likely path (125%)'), null);
+    assert.equal(extractDeductionProbability('Most likely path (125-90%)'), null);
+    assert.equal(extractDeductionProbability('125-150%: impossible range', { leadingOnly: true }), null);
+  });
+});

--- a/tests/deduction-probability.test.mts
+++ b/tests/deduction-probability.test.mts
@@ -53,6 +53,18 @@ describe('deduction probability parsing', () => {
   it('does not badge invalid percentage values', () => {
     assert.equal(extractDeductionProbability('Most likely path (125%)'), null);
     assert.equal(extractDeductionProbability('Most likely path (125-90%)'), null);
+    assert.equal(extractDeductionProbability('Most likely path (90-40%)'), null);
+    assert.equal(extractDeductionProbability('40-125%: impossible range', { leadingOnly: true }), null);
     assert.equal(extractDeductionProbability('125-150%: impossible range', { leadingOnly: true }), null);
+  });
+
+  it('skips invalid range endpoints before falling back to a later standalone percentage', () => {
+    const parsed = extractDeductionProbability('Most likely path (40-125%, ~50%)');
+
+    assert.deepEqual(parsed, {
+      label: '~50%',
+      remainder: 'Most likely path (40-125%, ~50%)',
+      isRange: false,
+    });
   });
 });

--- a/tests/deduction-probability.test.mts
+++ b/tests/deduction-probability.test.mts
@@ -8,7 +8,7 @@ describe('deduction probability parsing', () => {
     const parsed = extractDeductionProbability('Most likely path (next 24-72h, 40-55%)');
 
     assert.deepEqual(parsed, {
-      label: '40-55% range',
+      label: '40-55%',
       remainder: 'Most likely path (next 24-72h, 40-55%)',
       isRange: true,
     });
@@ -28,7 +28,7 @@ describe('deduction probability parsing', () => {
     const parsed = extractDeductionProbability('40-55%: Negotiated pause after shuttle diplomacy', { leadingOnly: true });
 
     assert.deepEqual(parsed, {
-      label: '40-55% range',
+      label: '40-55%',
       remainder: 'Negotiated pause after shuttle diplomacy',
       isRange: true,
     });
@@ -64,6 +64,16 @@ describe('deduction probability parsing', () => {
     assert.deepEqual(parsed, {
       label: '~50%',
       remainder: 'Most likely path (40-125%, ~50%)',
+      isRange: false,
+    });
+  });
+
+  it('uses document order when a single percentage appears before a later range', () => {
+    const parsed = extractDeductionProbability('55% likely, escalation case 30-40%');
+
+    assert.deepEqual(parsed, {
+      label: '~55%',
+      remainder: '55% likely, escalation case 30-40%',
       isRange: false,
     });
   });


### PR DESCRIPTION
## Summary
- Preserve rough probability ranges in Deduction Panel badges instead of collapsing them to a single endpoint.
- Render single percentages as approximate values and only badge leading alternative-path likelihoods.
- Add focused parser coverage for ranges, single percentages, non-leading percentages, and invalid values.

## Root Cause
The Deduction prompt asks for rough probability ranges, but the UI extracted a single percentage match for badges. Range outputs like `40-55%` could therefore appear as a precise single-value badge.

## Validation
- `git diff --cached --check`
- `npx tsx --test tests/deduction-probability.test.mts`
- `npm run typecheck`
- Pre-push hook: typecheck, API typecheck, Convex audit, CJS syntax, Unicode safety, boundaries, safe HTML, rate-limit policy, premium-fetch parity, edge bundle check, changed tests, edge function tests, version sync
