### PR TITLE
Align signal algorithm docs with code

### DIFF
--- a/docs/algorithms.mdx
+++ b/docs/algorithms.mdx
@@ -41,11 +41,17 @@ Intelligence hotspots receive dynamic escalation scores blending four normalized
 - **Geo-convergence alerts** (25%) — spatial binning detects 3+ event types (protests + military + earthquakes) co-occurring within 1° lat/lon cells
 - **Military activity** (15%) — vessel clusters and flight density near the hotspot
 
-The system blends static baseline risk (40%) with detected events (60%) and tracks trends via linear regression on 48-hour history. Signal emissions cool down for 2 hours to prevent alert fatigue.
+The dynamic raw score is converted from 0-100 onto the hotspot's 1-5 escalation
+scale, then blended as `staticBaseline × 0.30 + dynamicScore × 0.70`.
+`staticBaseline` is the hotspot config's `escalationScore` (default `3`) and
+the dynamic component is the weighted news/CII/geo/military signal. Signal
+emissions cool down for 2 hours and fire on whole-band upward crossings at
+`>=2/5`, rapid increases of at least `0.5`, or first entry into the critical
+band at `>=4.5/5`.
 
 ### Geographic Convergence Detection
 
-Events (protests, military flights, vessels, earthquakes) are binned into 1°×1° geographic cells within a 24-hour window. When 3+ distinct event types converge in one cell, a convergence alert fires. Scoring is based on type diversity (×25pts per unique type) plus event count bonuses (×2pts). Alerts are reverse-geocoded to human-readable names using conflict zones, waterways, and hotspot databases.
+Events (protests, military flights, vessels, earthquakes) are binned into 1°×1° geographic cells within a 24-hour window. When 3+ distinct event types converge in one cell, a convergence alert fires. Scoring is based on type diversity (×25pts per unique type) plus event count bonuses (×2pts, capped at 25). Current emitted alerts are high or critical priority: 4 types or score ≥90 is critical; 3-type alerts below 90 are high. Alerts are reverse-geocoded to human-readable names using conflict zones, waterways, and hotspot databases.
 
 ### Strategic Risk Score Algorithm
 
@@ -57,7 +63,7 @@ When cached server scores are unavailable, the browser renders a local fallback 
 
 ```
 compositeScore =
-    convergenceScore × 0.30     // multi-type events co-located in same H3 cell
+    convergenceScore × 0.30     // multi-type events co-located in same 1° cell
   + ciiRiskScore     × 0.50     // CII top-5 country weighted blend
   + infraScore       × 0.20     // infrastructure cascade incidents
   + theaterBoost     (0–25)     // military asset density + strike packaging
@@ -76,7 +82,7 @@ compositeScore =
 - `sanctionsScore` — Up to 10 points from new sanctions entries, largest-country entry volume, and sanctioned vessel/aircraft counts
 - `radiationScore` — Up to 12 points from radiation-watch spikes, elevated readings, and corroborated observations, reduced by low-confidence or conflicting observations
 
-**Alert fusion**: Alerts from convergence detection, CII spikes (≥10-point change), and infrastructure cascades are merged when they occur within a 2-hour window and are within 200km or in the same country. Merged alerts carry the highest priority and combine summaries. The alert queue caps at 50 entries with 24-hour pruning.
+**Alert fusion**: Alerts from convergence detection, CII spikes (≥10-point change), infrastructure cascades, sanctions pressure, and radiation watch are merged when they occur within a 2-hour window and are within 200km or in the same country. Merged alerts carry the highest priority and combine summaries. Direct inserts pop the oldest alert after 50 entries; the Strategic Risk refresh path then sorts by newest timestamp and trims the recomputed queue to 100 entries after 24-hour pruning.
 
 **Trend detection**: Delta ≥3 from previous composite = "escalating", ≤−3 = "de-escalating", otherwise "stable". A 15-minute learning period after panel initialization suppresses CII spike alerts to prevent false positives from initial data loading.
 
@@ -330,6 +336,15 @@ Beyond aggregating signals by geography, the system detects meaningful correlati
 | `military_surge`          | Theater posture assessment detects unusual force concentration                 | Military escalation warning                              |
 
 Each signal carries a severity (low/medium/high), geographic coordinates, a human-readable summary, and the raw data that triggered it. Signals are deduplicated per-type with configurable cooldown windows (30 minutes to 6 hours) to prevent alert fatigue. The correlation output feeds into the AI Insights panel, where the narrative synthesis engine weaves detected correlations into a structured intelligence brief.
+
+The Escalation Monitor correlation adapter clusters by country over a 48-hour
+window and emits cards at a composite threshold of `20`. Its current signal
+weights are `conflict_event` 45%, `escalation_outage` 25%, and `news_severity`
+30%. Conflict/protest severities map high/medium/low to `85/55/30`; internet
+outages map total/major/partial to `90/70/40` and are only kept for countries
+that also have a conflict event; qualifying news clusters must be medium or
+higher, match escalation keywords, and map critical/high/medium threat levels
+to `85/65/45`.
 
 ### PizzINT Activity Monitor & GDELT Tension Index
 

--- a/docs/geographic-convergence.mdx
+++ b/docs/geographic-convergence.mdx
@@ -27,11 +27,19 @@ convergence_score = min(100, type_score + count_boost)
 
 ## Alert Thresholds
 
-| Types Converging | Score Range | Alert Level |
-|-----------------|-------------|-------------|
-| **4 types** | 80-100 | Critical |
-| **3 types** | 60-80 | High |
-| **3 types** (low count) | 40-60 | Medium |
+The detector only emits convergence alerts after **3+ distinct event types** are
+present in a cell. The Strategic Risk alert priority layer then classifies the
+alert using both type diversity and score:
+
+| Types Converging | Score Range | Alert Priority |
+|-----------------|-------------|----------------|
+| **4 types** | 100 | Critical |
+| **3 types** with high event count | 90-100 | Critical |
+| **3 types** with lower event count | 81-89 | High |
+
+The shared priority helper still has a defensive `medium` branch for scores
+`>=50`, but current detector output does not reach it because emitted alerts
+must already have at least 3 event types.
 
 ## Example Scenarios
 
@@ -39,7 +47,8 @@ convergence_score = min(100, type_score + count_boost)
 
 - Cell: `25°N, 121°E`
 - Events: Military flights (3), Naval vessels (2), Protests (1)
-- Score: 75 + 12 = 87 (Critical)
+- Score: 75 + 12 = 87
+- Priority: High
 - Signal: "Geographic Convergence (3 types) - military flights, naval vessels, protests"
 
 **Middle East Flashpoint**
@@ -47,6 +56,7 @@ convergence_score = min(100, type_score + count_boost)
 - Cell: `32°N, 35°E`
 - Events: Military flights (5), Protests (8), Earthquake (1)
 - Score: 75 + 25 = 100 (Critical)
+- Priority: Critical
 - Signal: Multiple activity streams converging on region
 
 ## Why This Matters

--- a/docs/hotspots.mdx
+++ b/docs/hotspots.mdx
@@ -46,17 +46,25 @@ Each hotspot's escalation score blends four weighted components:
 **Score Calculation**
 
 ```
-static_baseline = hotspot.baselineRisk  // 1-5 per hotspot
-dynamic_score = (
+static_baseline = hotspot.escalationScore ?? 3  // 1-5 per hotspot
+dynamic_raw = (
   news_component × 0.35 +
   cii_component × 0.25 +
   geo_component × 0.25 +
   military_component × 0.15
 )
-proximity_boost = hotspot_proximity_multiplier  // 1.0-2.0
 
-final_score = (static_baseline × 0.30 + dynamic_score × 0.70) × proximity_boost
+dynamic_score = 1 + (dynamic_raw / 100) × 4  // maps 0-100 inputs onto 1-5
+final_score = static_baseline × 0.30 + dynamic_score × 0.70
 ```
+
+The static baseline is the editorial `escalationScore` on each hotspot config
+(default `3` when absent). It is deliberately kept on the same 1-5 scale as the
+dynamic output; the popup exposes it as `staticBaseline` alongside the component
+bars so users can separate structural risk from live movement. Many hotspots
+also carry a `whyItMatters` narrative rationale for the popup, but that text is
+not score-affecting. The code does not apply a geographic proximity multiplier
+to the final score.
 
 **Trend Detection**
 
@@ -71,9 +79,10 @@ The system maintains 48-point history (24 hours at 30-minute intervals) per hots
 
 Escalation signals (`hotspot_escalation`) are emitted when:
 
-1. Final score exceeds threshold (typically 60)
+1. A hotspot crosses into a higher whole-number score band at or above `2/5`
 2. At least 2 hours since last signal for this hotspot (cooldown)
-3. Trend is rising or score is critical (>80)
+3. Or the score rises by at least `0.5` points
+4. Or the score first reaches the critical threshold (`>=4.5/5`)
 
 **Signal Context**
 

--- a/docs/panels/indicators-and-signals.mdx
+++ b/docs/panels/indicators-and-signals.mdx
@@ -81,7 +81,7 @@ These panels visualise cross-domain correlation over a rolling window — useful
 | Panel id | Title | Cross-domain pair |
 |---|---|---|
 | `military-correlation` | Force Posture | Military × events |
-| `escalation-correlation` | Escalation Monitor | Conflict × tone |
+| `escalation-correlation` | Escalation Monitor | Conflict/protest events (45%) + conflict-linked outages (25%) + escalation news severity (30%) over 48h |
 | `economic-correlation` | Economic Warfare | Sanctions × markets |
 | `disaster-correlation` | Disaster Cascade | Natural × infra |
 | `cross-source-signals` | Cross-Source Signals | Multi-source signal agreement |

--- a/docs/strategic-risk.mdx
+++ b/docs/strategic-risk.mdx
@@ -85,9 +85,9 @@ Index country-score bands documented in
 
 | Priority | Criteria |
 |----------|----------|
-| **Critical** | CII country Critical band (81-100), convergence score ≥80, cascade critical impact |
-| **High** | CII country High band (66-80), convergence score ≥60, cascade affecting ≥5 countries |
-| **Medium** | CII change ≥10 points, convergence score ≥40 |
+| **Critical** | CII country Critical band (81-100), convergence has 4+ types or score ≥90, cascade critical impact, high-impact radiation/sanctions signal |
+| **High** | CII country High band (66-80) or ≥30-point CII move, convergence has 3+ types or score ≥70, cascade affecting ≥5 countries |
+| **Medium** | CII country Elevated band or ≥15-point CII move, convergence score ≥50, cascade medium impact or ≥3 countries |
 | **Low** | Minor changes and low-impact events |
 
 ### Trend Detection

--- a/tests/docs-signal-alignment.test.mts
+++ b/tests/docs-signal-alignment.test.mts
@@ -1,0 +1,84 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+
+function readRepo(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8');
+}
+
+test('public signal docs stay aligned with hotspot escalation math', () => {
+  const hotspotCode = readRepo('src/services/hotspot-escalation.ts');
+  const hotspotsDoc = readRepo('docs/hotspots.mdx');
+  const algorithmsDoc = readRepo('docs/algorithms.mdx');
+
+  assert.match(hotspotCode, /return hotspot\.escalationScore \?\? 3;/);
+  assert.match(hotspotCode, /return 1 \+ \(raw \/ 100\) \* 4;/);
+  assert.match(hotspotCode, /return staticBaseline \* 0\.3 \+ dynamicScore \* 0\.7;/);
+
+  for (const [label, doc] of [
+    ['docs/hotspots.mdx', hotspotsDoc],
+    ['docs/algorithms.mdx', algorithmsDoc],
+  ] as const) {
+    assert.match(
+      doc,
+      /static_?baseline[\s\S]{0,120}escalationScore|escalationScore[\s\S]{0,120}staticBaseline/i,
+      `${label} must publish hotspot static baseline source`,
+    );
+    assert.match(doc, /0\.30[\s\S]{0,120}0\.70/, `${label} must publish hotspot 30\/70 blend`);
+    assert.match(doc, /1-5/, `${label} must state hotspot scores are on a 1-5 scale`);
+    assert.doesNotMatch(doc, /proximity_boost/, `${label} must not document a nonexistent hotspot proximity boost`);
+  }
+});
+
+test('public convergence and alert docs stay aligned with current priority and queue caps', () => {
+  const geoCode = readRepo('src/services/geo-convergence.ts');
+  const crossModuleCode = readRepo('src/services/cross-module-integration.ts');
+  const geoDoc = readRepo('docs/geographic-convergence.mdx');
+  const strategicRiskDoc = readRepo('docs/strategic-risk.mdx');
+  const algorithmsDoc = readRepo('docs/algorithms.mdx');
+
+  assert.match(geoCode, /const CONVERGENCE_THRESHOLD = 3;/);
+  assert.match(crossModuleCode, /if \(typeCount >= 4 \|\| score >= 90\) return 'critical';/);
+  assert.match(crossModuleCode, /if \(typeCount >= 3 \|\| score >= 70\) return 'high';/);
+  assert.match(crossModuleCode, /if \(alerts\.length > 50\) alerts\.pop\(\);/);
+  assert.match(crossModuleCode, /if \(alerts\.length > 100\) \{[\s\S]*alerts\.length = 100;/);
+
+  assert.match(geoDoc, /3\+ distinct event types/);
+  assert.match(geoDoc, /4 types[\s\S]*100[\s\S]*Critical/);
+  assert.match(geoDoc, /3 types[\s\S]*81-89[\s\S]*High/);
+  assert.doesNotMatch(geoDoc, /3 types\*\* \(low count\)[\s\S]*Medium/);
+
+  assert.match(strategicRiskDoc, /convergence has 4\+ types or score [^\s]+90/);
+  assert.match(strategicRiskDoc, /convergence has 3\+ types or score [^\s]+70/);
+  assert.match(algorithmsDoc, /Direct inserts pop the oldest alert after 50 entries[\s\S]*trims the recomputed queue to 100 entries/);
+});
+
+test('public Escalation Monitor docs publish the current adapter weights and gates', () => {
+  const adapterCode = readRepo('src/services/correlation-engine/adapters/escalation.ts');
+  const indicatorsDoc = readRepo('docs/panels/indicators-and-signals.mdx');
+  const algorithmsDoc = readRepo('docs/algorithms.mdx');
+
+  assert.match(adapterCode, /conflict_event: 0\.45/);
+  assert.match(adapterCode, /escalation_outage: 0\.25/);
+  assert.match(adapterCode, /news_severity: 0\.30/);
+  assert.match(adapterCode, /timeWindow: 48/);
+  assert.match(adapterCode, /threshold: 20/);
+  assert.match(
+    adapterCode,
+    /signals\.filter\(s => s\.type !== 'escalation_outage' \|\| conflictCountries\.has\(s\.country\)\)/,
+  );
+
+  for (const [label, doc] of [
+    ['docs/panels/indicators-and-signals.mdx', indicatorsDoc],
+    ['docs/algorithms.mdx', algorithmsDoc],
+  ] as const) {
+    assert.match(doc, /45%/, `${label} must publish conflict_event weight`);
+    assert.match(doc, /25%/, `${label} must publish escalation_outage weight`);
+    assert.match(doc, /30%/, `${label} must publish news_severity weight`);
+    assert.match(doc, /48h|48-hour/, `${label} must publish Escalation Monitor window`);
+  }
+});


### PR DESCRIPTION
## Summary

- Align hotspot escalation docs with the current 1-5 scoring scale, static escalationScore baseline, 30/70 blend, and signal emission thresholds.
- Correct geographic convergence and Strategic Risk docs for current 1-degree cell detection, high/critical convergence priorities, Strategic Risk display bands, and unified alert queue caps.
- Document the Escalation Monitor adapter's current signal weights/gates and add a focused docs/code parity test for these contracts.

## Validation

- npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/frontend-cii-source-of-truth.test.mts tests/escalation-country-merge.test.mts tests/docs-signal-alignment.test.mts
- npm_config_cache=/tmp/worldmonitor-npm-cache npx markdownlint-cli2 docs/hotspots.mdx docs/geographic-convergence.mdx docs/strategic-risk.mdx docs/algorithms.mdx docs/panels/indicators-and-signals.mdx
- git diff --check
- Pre-push hook completed successfully, including typecheck, API typecheck, boundary/safe-HTML/policy checks, changed tests, markdown lint, MDX lint, proto freshness skip, pro-test bundle freshness skip, and version sync.