### PR TITLE
Align documentation methodology with current code

### DIFF
--- a/docs/algorithms.mdx
+++ b/docs/algorithms.mdx
@@ -80,7 +80,7 @@ compositeScore =
 
 ### Population Exposure Estimation
 
-Active events (conflicts, earthquakes, floods, wildfires) are cross-referenced against WorldPop population density data to estimate the number of civilians within the impact zone. Event-specific radii reflect typical impact footprints:
+Active events (conflicts, earthquakes, floods, wildfires) are matched to the nearest centroid in the local 20-country priority population table and then estimated from `population / area` density. This is a coarse exposure approximation, not a live WorldPop lookup. Event-specific radii reflect typical impact footprints:
 
 | Event Type      | Radius | Rationale                                |
 | --------------- | ------ | ---------------------------------------- |
@@ -89,7 +89,7 @@ Active events (conflicts, earthquakes, floods, wildfires) are cross-referenced a
 | **Floods**      | 100 km | Watershed and drainage basin extent      |
 | **Wildfires**   | 30 km  | Smoke and evacuation perimeter           |
 
-API calls to WorldPop are batched concurrently (max 10 parallel requests) to handle multiple simultaneous events without sequential bottlenecks. The Population Exposure panel displays a summary header with total affected population and a per-event breakdown table.
+If an event falls outside the priority centroid table, the fallback density uses a synthetic `50,000,000 / 500,000 km2` country profile. The Population Exposure panel displays a summary header with total affected population and a per-event breakdown table.
 
 ---
 
@@ -165,14 +165,15 @@ Beyond displaying static cable routes on the map, the system actively monitors c
 
 Advisories are classified by severity: `fault` (cable break, cut, or damage — potential traffic rerouting) or `degraded` (repair work in progress with partial capacity). Impact descriptions are generated dynamically, linking the advisory to the specific cable and the countries it serves — enabling questions like "which cables serving South Asia are currently under repair?"
 
-**Health scoring algorithm** — Each cable receives a composite health score (0–100) computed from weighted signals with exponential time decay:
+**Health scoring algorithm** — Each cable receives a status score computed from the strongest live signal after linear per-signal TTL decay:
 
 ```
-signal_weight = severity × (e^(-λ × age_hours))     where λ = ln(2) / 168 (7-day half-life)
-health_score  = max(0, 100 − Σ(signal_weights) × 100)
+recency_weight = clamp(1 - age_seconds / ttl_seconds, 0, 1)
+effective      = severity * confidence * recency_weight
+score          = round(max(effective) * 100) / 100
 ```
 
-Signals are classified into two kinds: `operator_fault` (confirmed cable damage — severity 1.0) and `cable_advisory` (repair operations, navigational warnings — severity 0.6). Geographic matching uses cosine-latitude-corrected equirectangular approximation to find the nearest cataloged cable within 50km of each NGA warning's coordinates. Results are cached in Redis (6-hour TTL for complete results, 10 minutes for partial) with an in-memory fallback that serves stale data when Redis is unavailable — ensuring the cable health layer never shows blank data even during cache failures.
+Signals are classified as `operator_fault`, `cable_advisory`, or `repair_activity`, each with its own severity, confidence, and TTL. A cable is marked `FAULT` when the top effective score is at least `0.80` and an operator-fault signal is present; `DEGRADED` when the top score is at least `0.50`, or at least `0.80` with repair activity; otherwise `OK`. Geographic matching uses cosine-latitude-corrected equirectangular distance to find the nearest cataloged cable within `555km` (about 5 degrees at the equator) of each NGA warning coordinate. Computed cable-health results are Redis-cached for `1800` seconds, and the NGA warning fetch is cached for `86400` seconds.
 
 ### Infrastructure Cascade Modeling
 
@@ -225,19 +226,22 @@ Entity matching uses word-boundary regex to prevent false positives (e.g., "Iran
 
 ### Headline Scoring
 
-The AI Insights panel ranks news items by geopolitical significance using a multi-signal importance scoring algorithm. Rather than displaying stories in chronological order, the algorithm surfaces the most consequential developments by applying keyword-weighted scoring across five severity tiers:
+The AI Insights panel ranks news clusters by geopolitical significance using `scoreImportance` in `scripts/_clustering.mjs`. Rather than displaying stories in chronological order, the algorithm combines upstream classifier scores, source quality, corroboration, keyword groups, recency, and demotion rules:
 
-| Category | Base Score | Per-Match Bonus | Keywords |
-| --- | --- | --- | --- |
-| **Violence** | +100 | +25 | killed, dead, death, shot, casualty, massacre, crackdown |
-| **Military** | +80 | +20 | war, invasion, airstrike, missile, troops, combat, fleet |
-| **Unrest** | +40 | +15 | protest, uprising, riot, demonstration, revolution |
-| **Flashpoint** | — | +20 | iran, russia, china, taiwan, ukraine, israel, gaza, north korea, syria, yemen, hamas, hezbollah, nato, kremlin |
-| **Crisis** | — | +10 | sanctions, escalation, breaking, urgent, humanitarian |
+| Signal | Scoring rule |
+| --- | --- |
+| **Upstream classifier** | `upstreamImportanceScore * 2.2` when present |
+| **Threat level** | LLM-sourced threats add critical `+220`, high `+150`, medium `+80`, low `+20`; non-LLM threat scores contribute 35% only when backed by upstream signal and not keyword-historical downgrade |
+| **Source tier** | Tier 1 `+35`, Tier 2 `+20`, Tier 3 `+8` |
+| **Source count** | `min(sourceCount, 6) * 12` |
+| **Entity corroboration** | `+45` when the cluster has corroborated entities |
+| **Keyword groups** | Violence `+50 + 12/match`; military `+40 + 10/match`; unrest `+35 + 9/match`; flashpoint `+30 + 8/match`; diplomacy `+35 + 9/match`; crisis `+15 + 5/match` |
+| **Flashpoint interaction** | Violence, unrest, or diplomacy terms combined with flashpoint terms multiply the score by `1.25` |
+| **Recency** | A 16-hour linear recency multiplier bottoms out at `0.5` |
 
-**Source confirmation boost** — each additional independent source reporting the same story adds +10 points, rewarding multi-source corroboration over single-source reporting.
+**Source confirmation boost** — source count and entity corroboration reward multi-source reporting over single-source reporting.
 
-**Demotion keywords** — corporate and financial noise (CEO, earnings, stock, startup, revenue) reduces scores, preventing business news from crowding out geopolitical developments in the full/geopolitical variant.
+**Demotion keywords** — corporate and financial noise reduces scores to 35% when no corroborated entity or strong non-keyword signal is present, preventing business news from crowding out geopolitical developments in the full/geopolitical variant.
 
 **Theater posture integration** — when the Strategic Posture Assessment detects elevated military activity (e.g., unusual flight patterns in a theater), related news stories receive additional scoring boosts, surfacing contextually relevant reporting alongside the military signal.
 
@@ -254,7 +258,7 @@ Every RSS headline is tokenized into individual terms and tracked in per-term fr
 | **Source diversity** | ≥ 2 unique RSS feed sources                   |
 | **Cooldown**         | 30 minutes since last spike for the same term |
 
-The tokenizer extracts CVE identifiers (`CVE-2024-xxxxx`), APT/FIN threat actor designators, and 12 compound terms for world leaders (e.g., "Xi Jinping", "Kim Jong Un") that would be lost by naive whitespace splitting. A configurable blocklist suppresses common noise terms.
+The tokenizer extracts CVE identifiers (`CVE-2024-xxxxx`), APT/FIN threat actor designators, and 16 compound terms for world leaders (e.g., "Xi Jinping", "Kim Jong Un") that would be lost by naive whitespace splitting. A configurable blocklist suppresses common noise terms.
 
 Detected spikes are auto-summarized via Groq (rate-limited to 5 summaries/hour) and emitted as `keyword_spike` signals into the correlation engine, where they compound with other signal types for convergence detection. The term registry is capped at 10,000 entries with LRU eviction to bound memory usage. All thresholds (spike multiplier, min count, cooldown, blocked terms) are configurable via the Settings panel.
 

--- a/docs/data-sources.mdx
+++ b/docs/data-sources.mdx
@@ -49,7 +49,7 @@ description: "Comprehensive documentation of all data sources, feed tiers, and c
 - Critical mineral deposits
 - NASA FIRMS satellite fire detection (VIIRS thermal hotspots)
 - 19 global trade routes (container, energy, bulk) with multi-segment arcs through strategic chokepoints
-- Airport delays and closures across 107 monitored airports (FAA + AviationStack + ICAO NOTAM)
+- Airport delays and closures across 111 monitored airports (FAA + AviationStack + ICAO NOTAM)
 - **Aviation intelligence** — 6-tab airline intel panel (ops, flights, airlines, tracking, news, prices) with customizable airport/airline watchlists, live ADS-B flight tracking, and flight price search
 
 </details>
@@ -85,7 +85,7 @@ description: "Comprehensive documentation of all data sources, feed tiers, and c
 <details>
 <summary><strong>Finance & Markets</strong> (Finance variant)</summary>
 
-- 92 global stock exchanges — mega (NYSE, NASDAQ, Shanghai, Euronext, Tokyo), major (Hong Kong, London, NSE/BSE, Toronto, Korea, Saudi Tadawul), and emerging markets — with market caps and trading hours
+- 29 global stock exchanges — mega (NYSE, NASDAQ, Shanghai, Euronext, Tokyo), major (Hong Kong, London, NSE/BSE, Toronto, Korea, Saudi Tadawul), and emerging markets — with market caps and trading hours
 - 19 financial centers — ranked by Global Financial Centres Index (New York #1 through offshore centers: Cayman Islands, Luxembourg, Bermuda, Channel Islands)
 - 13 central banks — Federal Reserve, ECB, BoJ, BoE, PBoC, SNB, RBA, BoC, RBI, BoK, BCB, SAMA, plus supranational institutions (BIS, IMF)
 - BIS central bank data — policy rates across major economies, real effective exchange rates (REER), and credit-to-GDP ratios sourced from the Bank for International Settlements
@@ -101,13 +101,13 @@ description: "Comprehensive documentation of all data sources, feed tiers, and c
 
 ### Telegram OSINT Intelligence Feed
 
-26 curated Telegram channels provide a raw, low-latency intelligence feed covering conflict zones, OSINT analysis, and breaking news — sources that are often minutes ahead of traditional wire services during fast-moving events.
+56 enabled channels in the default `full` Telegram channel set provide a raw, low-latency intelligence feed covering conflict zones, OSINT analysis, and breaking news — sources that are often minutes ahead of traditional wire services during fast-moving events.
 
-| Tier       | Channels                                                                                                              |
-| ---------- | --------------------------------------------------------------------------------------------------------------------- |
-| **Tier 1** | VahidOnline (Iran politics)                                                                                           |
-| **Tier 2** | Abu Ali Express, Aurora Intel, BNO News, Clash Report, DeepState, Defender Dome, Iran International, LiveUAMap, OSINTdefender, OSINT Updates, Ukraine Air Force (kpszsu), Povitryani Tryvoha |
-| **Tier 3** | Bellingcat, CyberDetective, GeopoliticalCenter, Middle East Spectator, Middle East Now Breaking, NEXTA, OSINT Industries, OsintOps News, OSINT Live, OsintTV, The Spectator Index, War Monitor, WFWitness |
+| Tier       | Enabled channels in `full` set |
+| ---------- | ------------------------------ |
+| **Tier 1** | 3                              |
+| **Tier 2** | 23                             |
+| **Tier 3** | 30                             |
 
 **Architecture**: A GramJS MTProto client running on the Railway relay polls all channels sequentially on a 60-second cycle. Each channel has a 15-second timeout (GramJS `getEntity`/`getMessages` can hang indefinitely on FLOOD_WAIT or MTProto stalls), and the entire cycle has a 3-minute hard timeout. A stuck-poll guard force-clears the mutex after 3.5 minutes, and FLOOD_WAIT errors from Telegram's API stop the cycle early rather than propagating to every remaining channel.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -94,6 +94,7 @@
               "methodology/disruptions",
               "methodology/cii-risk-scores",
               "methodology/disease-alert-level",
+              "methodology/thermal-escalation",
               "corrections",
               "geographic-convergence",
               "strategic-risk",

--- a/docs/fear-greed-index-2.0-brief.md
+++ b/docs/fear-greed-index-2.0-brief.md
@@ -46,10 +46,10 @@ Each category scores **0–100** (0 = Extreme Fear, 100 = Extreme Greed). The we
 | CNN F&G | CNN dataviz API | 0–100 score + label |
 | AAII Bear % | AAII survey | vs historical average |
 | AAII Bull % | AAII survey | vs historical average |
-| Put/Call Ratio | CBOE CDN CSV | vs 1yr average |
+| Put/Call Ratio | Barchart `$CPC` scrape | current total put/call ratio |
 | VIX | Yahoo / FRED | % change |
 | HY Spread | FRED | vs long-term average |
-| % > 200 DMA | Yahoo `^MMTH` | vs recent peak |
+| % > 200 DMA | Barchart `$S5TH` scrape | exact S&P 500 share above 200 DMA |
 | 10Y Yield | FRED | level |
 | Fed Rate | FRED | current range |
 
@@ -86,10 +86,10 @@ All sources are free with no paid API keys required.
 |--------|----------|--------|------|-------------|
 | **CNN Fear & Greed** | `production.dataviz.cnn.io/index/fearandgreed/graphdata/{date}` | JSON | User-Agent header | MEDIUM |
 | **AAII Sentiment** | `aaii.com/sentimentsurvey` (HTML scrape) | HTML | User-Agent header | LOW (blocks bots) |
-| **CBOE Total P/C** | `cdn.cboe.com/.../totalpc.csv` | CSV | None | HIGH |
-| **CBOE Equity P/C** | `cdn.cboe.com/.../equitypc.csv` | CSV | None | HIGH |
+| **Barchart Total P/C** | `barchart.com/stocks/quotes/%24CPC` | HTML / Next data | User-Agent header | MEDIUM |
+| **Barchart S&P 500 > 200 DMA** | `barchart.com/stocks/quotes/%24S5TH` | HTML / Next data | User-Agent header | MEDIUM |
 
-### Yahoo Finance Symbols (19 total)
+### Yahoo Finance Symbols (22 total)
 
 Uses `query1.finance.yahoo.com/v8/finance/chart` — no API key, User-Agent header only.
 
@@ -100,26 +100,29 @@ Uses `query1.finance.yahoo.com/v8/finance/chart` — no API key, User-Agent head
 | 3 | `^VIX9D` | Volatility | 9-day VIX for term structure |
 | 4 | `^VIX3M` | Volatility | 3-month VIX for term structure |
 | 5 | `^SKEW` | Positioning | CBOE SKEW index |
-| 6 | `^MMTH` | Breadth | % of stocks above 200 DMA |
-| 7 | `^NYA` | Breadth | NYSE Composite for breadth divergence |
-| 8 | `C:ISSU` | Breadth | NYSE advances/declines/unchanged |
-| 9 | `GLD` | Cross-Asset | Gold proxy |
-| 10 | `TLT` | Cross-Asset | Bonds proxy |
-| 11 | `SPY` | Cross-Asset, Breadth | Equity benchmark |
-| 12 | `RSP` | Breadth | Equal-weight S&P 500 (vs SPY divergence) |
-| 13 | `DX-Y.NYB` | Cross-Asset | USD Dollar Index |
-| 14 | `HYG` | Credit | HY bond ETF trend |
-| 15 | `LQD` | Credit | IG bond ETF trend |
-| 16 | `XLK` | Momentum | Tech sector |
-| 17 | `XLF` | Momentum | Financial sector |
-| 18 | `XLE` | Momentum | Energy sector |
-| 19 | `XLV` | Momentum | Healthcare sector |
+| 6 | `GLD` | Cross-Asset | Gold proxy |
+| 7 | `TLT` | Cross-Asset | Bonds proxy |
+| 8 | `HYG` | Credit | HY bond ETF stress input |
+| 9 | `SPY` | Cross-Asset, Breadth | Equity benchmark |
+| 10 | `RSP` | Breadth | Equal-weight S&P 500 (vs SPY divergence) |
+| 11 | `DX-Y.NYB` | Cross-Asset | USD Dollar Index |
+| 12 | `XLK` | Momentum | Tech sector |
+| 13 | `XLF` | Momentum | Financial sector |
+| 14 | `XLE` | Momentum | Energy sector |
+| 15 | `XLV` | Momentum | Healthcare sector |
+| 16 | `XLY` | Momentum | Consumer discretionary sector |
+| 17 | `XLP` | Momentum | Consumer staples sector |
+| 18 | `XLI` | Momentum | Industrials sector |
+| 19 | `XLB` | Momentum | Materials sector |
+| 20 | `XLU` | Momentum | Utilities sector |
+| 21 | `XLRE` | Momentum | Real estate sector |
+| 22 | `XLC` | Momentum | Communication services sector |
 
 **Notes:**
 
-- `^MMTH` = % above **200-day** MA (not `^MMTW` which is 20-day)
-- `C:ISSU` = NYSE advance/decline/unchanged data. **Unvalidated via `/v8/finance/chart` endpoint** — must confirm it returns advance/decline figures before relying on it. If unavailable, Breadth drops `ad_score` and reweights: `breadth_score * 0.57 + rsp_score * 0.43`
-- Fallback: Finnhub candle API for ETF symbols; breadth symbols Yahoo-only
+- `$S5TH` from Barchart is the implemented % above **200-day** MA input; `^MMTH` is not fetched by the current seeder.
+- Advance/decline ratio is currently `null`. Breadth drops `ad_score` and reweights to `breadth_score * 0.57 + rsp_score * 0.43`.
+- Fallback: VIX can fall back to FRED `VIXCLS`; Yahoo failures for ETF symbols leave their derived categories neutral or degraded.
 
 ---
 
@@ -144,7 +147,7 @@ score = CNN_FG  // 100% weight on CNN F&G; crypto F&G from Redis as secondary si
 
 ```
 inputs: VIX, VIX_Term_Structure
-vix_score = clamp(100 - ((VIX - 12) / 28) * 100, 0, 100)  // VIX 12=100, VIX 40=0
+vix_score = clamp(100 - ((VIX - 12) / 23) * 100, 0, 100)  // VIX 12=100, VIX 35=0
 term_score = contango ? 70 : backwardation ? 30 : 50
 score = vix_score * 0.7 + term_score * 0.3
 ```
@@ -170,11 +173,13 @@ score = (above_count / 3) * 50 + clamp(distance_200 * 500 + 50, 0, 100) * 0.5
 ### 5. Breadth (10%)
 
 ```
-inputs: Pct_Above_200DMA, Advance_Decline, RSP_SPY_Divergence
+inputs: Pct_Above_200DMA from Barchart $S5TH, Advance_Decline, RSP_SPY_Divergence
 breadth_score = Pct_Above_200DMA  // already 0-100
 ad_score = clamp((AD_Ratio - 0.5) / 1.5 * 100, 0, 100)
 rsp_score = clamp(RSP_SPY_30d_diff * 10 + 50, 0, 100)
 score = breadth_score * 0.4 + ad_score * 0.3 + rsp_score * 0.3
+// implemented degraded path when AD_Ratio is null:
+score = breadth_score * 0.57 + rsp_score * 0.43
 ```
 
 ### 6. Momentum (10%)
@@ -190,7 +195,7 @@ score = rsi_score * 0.5 + roc_score * 0.5
 
 ```
 inputs: M2_YoY_Change, Fed_Balance_Sheet_Change, SOFR_Rate
-m2_score = clamp(M2_YoY * 10 + 50, 0, 100)
+m2_score = clamp(M2_YoY * 5 + 50, 0, 100)
 fed_score = clamp(Fed_BS_MoM * 20 + 50, 0, 100)
 sofr_score = clamp(100 - SOFR * 15, 0, 100)
 score = m2_score * 0.4 + fed_score * 0.3 + sofr_score * 0.3
@@ -200,8 +205,8 @@ score = m2_score * 0.4 + fed_score * 0.3 + sofr_score * 0.3
 
 ```
 inputs: HY_Spread, IG_Spread, HY_Spread_Change_30d
-hy_score = clamp(100 - ((HY_Spread - 3.0) / 5.0) * 100, 0, 100)
-ig_score = clamp(100 - ((IG_Spread - 0.8) / 2.0) * 100, 0, 100)
+hy_score = clamp(100 - ((HY_Spread - 2.0) / 8.0) * 100, 0, 100)
+ig_score = clamp(100 - ((IG_Spread - 0.4) / 2.6) * 100, 0, 100)
 trend_score = HY_narrowing ? 70 : HY_widening ? 30 : 50
 score = hy_score * 0.4 + ig_score * 0.3 + trend_score * 0.3
 ```
@@ -235,9 +240,9 @@ score = weighted combination with mean reversion
 | VIX Term Structure | ^VIX, ^VIX9D, ^VIX3M | `VIX/VIX3M` ratio (&lt;1 = contango) | Volatility |
 | Sector RSI (14d) | XLK/XLF/XLE/XLV | Standard RSI formula | Momentum |
 | Cross-asset 30d returns | GLD, TLT, SPY, DXY | `rateOfChange(prices, 30)` | Cross-Asset |
-| M2 YoY change | M2SL | `(latest - 12mo_ago) / 12mo_ago` | Liquidity |
+| M2 YoY change | M2SL | `(latest - 52wk_ago) / 52wk_ago` | Liquidity |
 | Fed BS MoM change | WALCL | `(latest - 4wk_ago) / 4wk_ago` | Liquidity |
-| HY spread trend | BAMLH0A0HYM2 | `30d change direction` | Credit |
+| HY spread trend | BAMLH0A0HYM2 | `20 trading-day change direction` | Credit |
 | RSP/SPY ratio | RSP, SPY | `RSP_return_30d - SPY_return_30d` | Breadth |
 
 ---
@@ -265,14 +270,14 @@ seed-lock:market:fear-greed       # Concurrency lock
 
 | Source | Calls | Rate Limited? | Auth |
 |--------|-------|--------------|------|
-| Yahoo Finance | 19 symbols | 150ms gaps | User-Agent only |
-| CBOE CDN | 2 CSVs | No | None |
+| Yahoo Finance | 22 symbols | 150ms gaps | User-Agent only |
+| Barchart | 2 HTML quote pages (`$CPC`, `$S5TH`) | No | User-Agent only |
 | CNN dataviz | 1 | No | User-Agent only |
 | AAII | 1 | Blocks bots | User-Agent + scrape |
 | Redis reads | ~10 FRED series | No | Bearer token |
-| **Total** | **~33** | — | — |
+| **Total** | **~34** | — | — |
 
-**Estimated runtime**: ~3s (Yahoo sequential) + ~2s (CBOE/CNN/AAII parallel) + ~1s (Redis) = **~6s per run**
+**Estimated runtime**: ~3.3s (Yahoo sequential) + ~2s (Barchart/CNN/AAII parallel) + ~1s (Redis) = **~6-7s per run**
 
 **Timeouts**: Set `AbortSignal.timeout(8000)` on AAII scrape (frequently stalls). AAII failure must not block the entire seed run — wrap in `try/catch`, log warn, continue with degraded Sentiment scoring.
 
@@ -370,7 +375,7 @@ Build the initial version using only data we already have + easy additions:
 6. **Sentiment** — CNN F&G endpoint + crypto F&G (already have)
 7. **Momentum** — Sector ETF returns from Yahoo
 8. **Cross-Asset** — GLD/TLT/SPY/DXY returns from Yahoo
-9. **Positioning** — CBOE put/call CSVs + SKEW from Yahoo
-10. **Breadth** — ^MMTH + RSP/SPY divergence + C:ISSU from Yahoo
+9. **Positioning** — Barchart `$CPC` put/call + SKEW from Yahoo
+10. **Breadth** — Barchart `$S5TH` + RSP/SPY divergence, with advance/decline currently null
 
 All 10 categories covered from day one. No paid sources needed.

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -34,5 +34,15 @@
   "workflowCount": 14,
   "freshnessSources": 35,
   "freshnessRequiredForRisk": 2,
-  "feedDefinitions": 567
+  "feedDefinitions": 567,
+  "airportCount": 111,
+  "stockExchangeCount": 29,
+  "telegramFullEnabledChannels": 56,
+  "telegramFullTierCounts": {
+    "1": 3,
+    "2": 23,
+    "3": 30
+  },
+  "leaderNames": 16,
+  "populationPriorityCountries": 20
 }

--- a/docs/methodology/thermal-escalation.mdx
+++ b/docs/methodology/thermal-escalation.mdx
@@ -1,0 +1,64 @@
+---
+title: "Thermal Escalation Methodology"
+description: "How WorldMonitor clusters FIRMS/VIIRS thermal detections, compares them with local baselines, and assigns thermal escalation status and relevance."
+---
+
+## Overview
+
+Thermal Escalation turns FIRMS/VIIRS hotspot detections into clustered, baseline-aware watch items for the `thermal-escalation` panel. The implementation lives in `scripts/lib/thermal-escalation.mjs`.
+
+## Clustering
+
+Detections are sorted by observation time and grouped by region label. A detection joins the nearest existing cluster in the same region when it falls within `20km`; otherwise it starts a new cluster. Cluster centroids are updated incrementally as detections are added.
+
+Each cluster is assigned to a 0.5-degree baseline cell by rounding latitude and longitude to the nearest 0.5 degrees.
+
+## Baseline and Persistence
+
+The scorer keeps 30 days of cell history and uses the last 7 days as the comparison baseline. For each cluster it computes:
+
+| Metric | Meaning |
+| --- | --- |
+| `baselineExpectedCount` | Average prior observation count in the cell |
+| `baselineExpectedFrp` | Average prior total fire radiative power in the cell |
+| `countDelta` | Current observation count minus baseline count |
+| `frpDelta` | Current total FRP minus baseline FRP |
+| `zScore` | Count delta divided by baseline count standard deviation |
+| `persistenceHours` | Duration since the first current or recent prior observation |
+
+Prior observations within 18 hours extend persistence. The panel display window is 24 hours.
+
+## Status Rules
+
+| Status | Rule |
+| --- | --- |
+| `persistent` | `persistenceHours >= 12` and either `countDelta >= 3` or `totalFrp >= 80` |
+| `spike` | `zScore >= 2.5`, `countDelta >= 6`, `frpDelta >= 120`, or `observationCount >= 8` with `totalFrp >= 150` |
+| `elevated` | `zScore >= 1.5`, `countDelta >= 3`, `frpDelta >= 50`, or no baseline with `observationCount >= 5` |
+| `normal` | None of the above |
+
+## Context and Relevance
+
+Conflict adjacency is determined from the cluster's region label, not from a live distance join against conflict events. The current conflict-region allowlist is:
+
+Ukraine, Russia, Israel/Gaza, Syria, Iran, Taiwan, North Korea, Yemen, Myanmar, Sudan, South Sudan, Ethiopia, Somalia, Democratic Republic of the Congo, Libya, Mali, Burkina Faso, Niger, Iraq, and Pakistan.
+
+Strategic relevance is assigned as:
+
+| Relevance | Rule |
+| --- | --- |
+| `high` | Conflict-adjacent and status is `spike` or `persistent` |
+| `medium` | Status is `persistent`, total FRP is at least `120`, or persistence is at least 12 hours |
+| `low` | None of the above |
+
+The current implementation does not perform infrastructure-proximity matching. `nearbyAssets` is emitted as an empty array until an asset matcher is wired into the seeder.
+
+## Confidence
+
+| Confidence | Rule |
+| --- | --- |
+| `high` | At least 8 observations, at least 2 unique satellite sources, and at least 4 baseline samples |
+| `medium` | At least 4 observations and at least 2 baseline samples |
+| `low` | Anything below the medium threshold |
+
+Rows are sorted by relevance, then status severity, total FRP, and observation count.

--- a/docs/panels/forecast.mdx
+++ b/docs/panels/forecast.mdx
@@ -30,12 +30,42 @@ Panel id is `forecast`; canonical component is `src/components/ForecastPanel.ts`
 
 ## Data sources
 
-Primary RPC: `GET /api/forecast/v1/get-forecasts`. The panel also consumes two adjacent RPCs for the richer deep-simulation surface:
+Primary RPC: `GET /api/forecast/v1/get-forecasts`. The panel also consumes adjacent RPCs for the richer deep-simulation surface:
 
 - `GET /api/forecast/v1/get-simulation-package` — the most recent simulation inputs bundle.
 - `GET /api/forecast/v1/get-simulation-outcome` — the most recent simulation result.
+- `POST /api/forecast/v1/trigger-simulation` — starts a fresh simulation run outside the cached cron output.
 
 The forecasting pipeline runs as a Railway cron that pulls recent conflict, intelligence, markets, and supply-chain signals, runs them through the forecasting model, and writes the aggregated result at `forecast:predictions:v2` in Redis. Macro-region classification comes from `shared/forecast-macro-regions.js`.
+
+## Scoring and calibration
+
+Published forecasts are capped and deduplicated before they reach the panel:
+
+| Rule | Cap |
+| --- | --- |
+| Forecasts per situation | 3 |
+| Forecasts per situation/domain pair | 2 |
+| Forecasts per family | 4 |
+| Forecasts per family/domain pair | 2 |
+| Target published count | 10-14 |
+| Cyber probability ceiling | 0.72 |
+
+When a forecast can be matched to a geopolitical prediction market, the seeder records the market title, market price, drift from the internal probability, and market source. The final probability is then blended as `0.4 * market_probability + 0.6 * internal_probability`.
+
+Probability projections are anchored to the forecast's own time horizon and then expanded to 24h, 7d, and 30d with domain curves:
+
+| Domain | 24h | 7d | 30d |
+| --- | ---: | ---: | ---: |
+| Conflict | 0.91 | 1.00 | 0.78 |
+| Market | 1.00 | 0.58 | 0.42 |
+| Supply chain | 0.91 | 1.00 | 0.64 |
+| Political | 0.83 | 0.87 | 1.00 |
+| Military | 1.00 | 0.91 | 0.65 |
+| Cyber | 1.00 | 0.78 | 0.40 |
+| Infrastructure | 1.00 | 0.50 | 0.25 |
+
+Trend is serialized as a string, not an enum. The current values are `rising`, `falling`, and `stable`, based on a +/- `0.05` probability delta versus the prior forecast snapshot.
 
 ## Refresh cadence
 
@@ -47,5 +77,5 @@ On **web**, AI Forecasts is currently in **trial** — free to anyone, including
 
 ## API reference
 
-- [Forecast service](/api/ForecastService.openapi.yaml) — covers `get-forecasts`, `get-simulation-outcome`, and `get-simulation-package`.
+- [Forecast service](/api/ForecastService.openapi.yaml) — covers `get-forecasts`, `get-simulation-outcome`, `get-simulation-package`, and `trigger-simulation`.
 - For **programmatic prediction generation** (fresh probabilities outside the cached cron output), see the [MCP `generate_forecasts` tool](/mcp-server#ai-intelligence-live-llm).

--- a/docs/panels/thermal-escalation.mdx
+++ b/docs/panels/thermal-escalation.mdx
@@ -3,7 +3,7 @@ title: "Thermal Escalation"
 description: "FIRMS/VIIRS thermal anomaly clusters with baseline comparison, persistence tracking, and conflict-adjacency flags — for spotting abnormal thermal activity that may signal conflict, industrial disruption, or escalation."
 ---
 
-The **Thermal Escalation** panel turns raw thermal-satellite detections (hotspots) into clustered events and evaluates each cluster against its local baseline and context. It answers two questions: where is thermal activity **abnormal**, and which clusters are **strategically relevant** — adjacent to conflict, critical infrastructure, or other high-signal contexts.
+The **Thermal Escalation** panel turns raw thermal-satellite detections (hotspots) into clustered events and evaluates each cluster against its local baseline and context. It answers two questions: where is thermal activity **abnormal**, and which clusters are **strategically relevant** — currently conflict-adjacent, persistent, or high-FRP activity.
 
 ## What the panel shows
 
@@ -12,12 +12,13 @@ A card list of thermal clusters with:
 - **Status label** per cluster: `normal`, `elevated`, `spike`, or `persistent`.
 - **Baseline comparison** — how the current detection density differs from the cluster's baseline.
 - **Persistence tracking** — clusters that re-appear across successive windows are flagged `persistent`.
-- **Conflict-adjacent flag** — clusters near active conflict events.
-- **High-relevance flag** — clusters near critical infrastructure or other strategic context.
+- **Conflict-adjacent flag** — clusters whose region label is in the current conflict-region allowlist.
+- **High-relevance flag** — conflict-adjacent clusters that are `spike` or `persistent`.
 
 A summary bar across the top counts: total clusters, elevated, spike, persistent, conflict-adjacent, and high-relevance.
 
 **Row interactions**:
+
 - Click a cluster card to jump the map to that cluster's coordinates.
 
 Panel id is `thermal-escalation`; canonical component is `src/components/ThermalEscalationPanel.ts`.
@@ -38,6 +39,12 @@ A single RPC backs the panel: `GET /api/thermal/v1/list-thermal-escalations`. Th
 ## Refresh cadence
 
 The seeder runs on a **~2-hour** cron. The key is allowed up to **6 hours** (`maxStaleMin: 360`) in `api/health.js` — 3× the nominal interval — before the health surface escalates. The longer grace window accommodates FIRMS refresh cycles and the clustering step's runtime.
+
+## Methodology
+
+The current scorer clusters detections within `20km`, compares each 0.5-degree cell against a 7-day local baseline, tracks 18-hour persistence, and retains 30 days of history for baseline continuity. Conflict adjacency is allowlist-based rather than infrastructure-proximity based; the current payload's `nearbyAssets` array is intentionally empty until an asset matcher is wired.
+
+See [Thermal Escalation Methodology](/methodology/thermal-escalation) for thresholds, status rules, confidence bands, and the current conflict-region allowlist.
 
 ## Tier & gating
 

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -76,6 +76,36 @@ function computeStats() {
   // ---- Feed definitions (src/config/feeds.ts) — floor metric ----
   const feedDefinitions = (read('src/config/feeds.ts').match(/name:\s*'/g) || []).length;
 
+  // ---- Operational source counts used by data-source and methodology docs ----
+  const airportCount = (read('src/config/airports.ts').match(/\biata:\s*'/g) || []).length;
+
+  const financeGeo = read('src/config/finance-geo.ts');
+  const stockExchangeBlock = financeGeo.slice(
+    financeGeo.indexOf('export const STOCK_EXCHANGES'),
+    financeGeo.indexOf('export const FINANCIAL_CENTERS'),
+  );
+  const stockExchangeCount = (stockExchangeBlock.match(/\bid:\s*'/g) || []).length;
+
+  const telegram = JSON.parse(read('data/telegram-channels.json'));
+  const telegramFullEnabled = Array.isArray(telegram?.channels?.full)
+    ? telegram.channels.full.filter((c) => c?.enabled !== false)
+    : [];
+  const telegramFullTierCounts = telegramFullEnabled.reduce((acc, c) => {
+    const tier = String(c?.tier ?? 'unknown');
+    acc[tier] = (acc[tier] || 0) + 1;
+    return acc;
+  }, {});
+
+  const leaderBlock = read('src/services/trending-keywords.ts').match(/const LEADER_NAMES = \[([\s\S]*?)\];/);
+  const leaderNames = leaderBlock ? (leaderBlock[1].match(/'[^']+'/g) || []).length : 0;
+
+  const populationBlock = read('src/services/population-exposure.ts').match(
+    /const PRIORITY_COUNTRIES:[\s\S]*?=\s*\{([\s\S]*?)\n\};/,
+  );
+  const populationPriorityCountries = populationBlock
+    ? (populationBlock[1].match(/^\s+[A-Z]{3}:\s*\{/gm) || []).length
+    : 0;
+
   return {
     _generated: 'scripts/docs-stats.mjs — do not edit by hand; run `npm run docs:stats`',
     layerDefinitions,
@@ -91,6 +121,12 @@ function computeStats() {
     freshnessSources,
     freshnessRequiredForRisk,
     feedDefinitions,
+    airportCount,
+    stockExchangeCount,
+    telegramFullEnabledChannels: telegramFullEnabled.length,
+    telegramFullTierCounts,
+    leaderNames,
+    populationPriorityCountries,
   };
 }
 
@@ -128,6 +164,15 @@ function claims(s) {
     { file: 'docs/api-reference.mdx', re: /all (\d+)\s+services/, value: s.protoServices },
 
     { file: 'docs/data-sources.mdx', re: /monitors (\d+)\s+data sources/, value: s.freshnessSources },
+    { file: 'docs/data-sources.mdx', re: /across (\d+)\s+monitored airports/, value: s.airportCount },
+    { file: 'docs/data-sources.mdx', re: /^(\d+)\s+airports across 5 regions/m, value: s.airportCount },
+    { file: 'docs/data-sources.mdx', re: /(\d+)\s+global stock exchanges/, value: s.stockExchangeCount },
+    { file: 'docs/data-sources.mdx', re: /^(\d+)\s+enabled channels in the default `full` Telegram channel set/m, value: s.telegramFullEnabledChannels },
+    { file: 'docs/data-sources.mdx', re: /\*\*Tier 1\*\* \| (\d+)\s+\|/, value: s.telegramFullTierCounts['1'] },
+    { file: 'docs/data-sources.mdx', re: /\*\*Tier 2\*\* \| (\d+)\s+\|/, value: s.telegramFullTierCounts['2'] },
+    { file: 'docs/data-sources.mdx', re: /\*\*Tier 3\*\* \| (\d+)\s+\|/, value: s.telegramFullTierCounts['3'] },
+    { file: 'docs/algorithms.mdx', re: /local (\d+)-country priority population table/, value: s.populationPriorityCountries },
+    { file: 'docs/algorithms.mdx', re: /and (\d+)\s+compound terms for world leaders/, value: s.leaderNames },
   ];
 }
 

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -80,10 +80,12 @@ function computeStats() {
   const airportCount = (read('src/config/airports.ts').match(/\biata:\s*'/g) || []).length;
 
   const financeGeo = read('src/config/finance-geo.ts');
-  const stockExchangeBlock = financeGeo.slice(
-    financeGeo.indexOf('export const STOCK_EXCHANGES'),
-    financeGeo.indexOf('export const FINANCIAL_CENTERS'),
-  );
+  const stockExchangeStart = financeGeo.indexOf('export const STOCK_EXCHANGES');
+  const stockExchangeEnd = financeGeo.indexOf('export const FINANCIAL_CENTERS');
+  if (stockExchangeStart === -1 || stockExchangeEnd === -1 || stockExchangeEnd <= stockExchangeStart) {
+    throw new Error('docs-stats: could not isolate STOCK_EXCHANGES block in src/config/finance-geo.ts');
+  }
+  const stockExchangeBlock = financeGeo.slice(stockExchangeStart, stockExchangeEnd);
   const stockExchangeCount = (stockExchangeBlock.match(/\bid:\s*'/g) || []).length;
 
   const telegram = JSON.parse(read('data/telegram-channels.json'));
@@ -96,8 +98,13 @@ function computeStats() {
     return acc;
   }, {});
 
-  const leaderBlock = read('src/services/trending-keywords.ts').match(/const LEADER_NAMES = \[([\s\S]*?)\];/);
-  const leaderNames = leaderBlock ? (leaderBlock[1].match(/'[^']+'/g) || []).length : 0;
+  const leaderBlock = read('src/services/trending-keywords.ts').match(
+    /const\s+LEADER_NAMES\s*(?::[^=]*)?\s*=\s*\[([\s\S]*?)\];/,
+  );
+  if (!leaderBlock) {
+    throw new Error('docs-stats: could not find LEADER_NAMES array in src/services/trending-keywords.ts');
+  }
+  const leaderNames = (leaderBlock[1].match(/'[^']+'/g) || []).length;
 
   const populationBlock = read('src/services/population-exposure.ts').match(
     /const PRIORITY_COUNTRIES:[\s\S]*?=\s*\{([\s\S]*?)\n\};/,


### PR DESCRIPTION
## Summary

- Align algorithms and data-source docs with the current implementation for population exposure, cable health, headline scoring, leader names, airports, stock exchanges, and Telegram channel counts.
- Document current forecast publication caps, market calibration blend, projection curves, trend strings, and trigger-simulation endpoint.
- Update Fear & Greed and Thermal Escalation methodology docs, including a new thermal methodology page and docs-nav entry.
- Extend docs:check with focused count guards for the drift-prone documentation claims.

## Validation

- npm run docs:stats
- npm run docs:check
- npm_config_cache=/tmp/worldmonitor-npm-cache npx --yes markdownlint-cli2@0.21.0 docs/algorithms.mdx docs/data-sources.mdx docs/fear-greed-index-2.0-brief.md docs/panels/forecast.mdx docs/panels/thermal-escalation.mdx docs/methodology/thermal-escalation.mdx
- node --test tests/thermal-escalation-model.test.mjs tests/thermal-escalation-handler-guardrail.test.mjs
- node -e JSON.parse docs/docs.json
- git diff --check
- Pre-push hook on git push -u origin codex/docs-alignment-audit completed successfully, including typecheck, API typecheck, boundary lint, safe HTML guard, rate-limit policy, premium-fetch parity, markdown lint, MDX lint, proto freshness skip, pro-test freshness skip, and version sync.