### PR TITLE
docs(agent): align discovery header cache claim

### DIFF
--- a/docs/agent-discovery.mdx
+++ b/docs/agent-discovery.mdx
@@ -46,7 +46,7 @@ Link: </.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+j
 | [`/llms-full.txt`](https://worldmonitor.app/llms-full.txt) | (extension) | Long-form variant covering all data layers, panels, and data sources |
 | [`/api/health`](https://api.worldmonitor.app/api/health) | (custom) | Per-key seed status, freshness, record counts — agents can gate fetches on this |
 
-The static discovery assets (`.well-known/*`, `/openapi.yaml`, `/llms*.txt`) serve `Access-Control-Allow-Origin: *` and are cached `public, max-age=3600` — safe to memoize. `/api/health` uses the normal API CORS allowlist and is **not** cached (`private, no-store`) because it reflects real-time seed freshness; agents should hit it fresh whenever they need to gate on data availability.
+The header-discoverable static assets (`.well-known/*`, `/openapi.yaml`) serve `Access-Control-Allow-Origin: *` and are cached `public, max-age=3600` — safe to memoize. `/api/health` uses the normal API CORS allowlist and is **not** cached (`private, no-store`) because it reflects real-time seed freshness; agents should hit it fresh whenever they need to gate on data availability.
 
 ## Agent walkthroughs
 


### PR DESCRIPTION
## Summary
- narrow the Agent Discovery header/cache wording to the static assets that vercel.json explicitly covers
- leave /llms.txt and /llms-full.txt discoverable without claiming the .well-known/openapi header contract

## Validation
- node --test tests/deploy-config.test.mjs
- parsed vercel.json headers for /.well-known/(.*), /openapi.yaml, /llms.txt, and /llms-full.txt
- rg stale-overclaim checks for llms header/cache wording
- git diff --check
- pre-push hook completed: typecheck, API typecheck, Convex type check, CJS syntax, Unicode safety, architectural boundary check, safe HTML, Sentry coverage, rate-limit policy, premium-fetch parity, edge bundle check, markdown lint, MDX lint, proto freshness skip, pro-test freshness skip, version sync