### PR TITLE
Fix MCP news variant and auth docs

### DIFF
--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -36,8 +36,9 @@ export const RPC_TOOLS: ToolDef[] = [
     annotations: { readOnlyHint: true, destructiveHint: false, idempotentHint: false, openWorldHint: true },
     _execute: async (params, base, context) => {
       const UA = 'worldmonitor-mcp-edge/1.0';
-      // Step 1: fetch current geopolitical headlines (budget: 6 s, leaves ~24 s for LLM)
-      const digestUrl = `${base}/api/news/v1/list-feed-digest?variant=geo&lang=en`;
+      // Step 1: fetch current geopolitical headlines (budget: 6 s, leaves ~24 s for LLM).
+      // `full` is the documented geopolitical/default digest variant.
+      const digestUrl = `${base}/api/news/v1/list-feed-digest?variant=full&lang=en`;
       const digestAuth = await buildAuthHeaders(context, 'GET', digestUrl, null);
       const digestRes = await fetch(digestUrl, {
         headers: { ...digestAuth, 'User-Agent': UA },
@@ -63,7 +64,7 @@ export const RPC_TOOLS: ToolDef[] = [
         bodies,
         mode: 'brief',
         geoContext: String(params.geo_context ?? ''),
-        variant: 'geo',
+        variant: 'full',
         lang: 'en',
       });
       const briefAuth = await buildAuthHeaders(context, 'POST', briefUrl, briefBody);
@@ -114,7 +115,7 @@ export const RPC_TOOLS: ToolDef[] = [
       // 2 s + 22 s brief = 24 s worst-case; 6 s margin before the 30 s Edge kill.
       let contextParam = '';
       try {
-        const digestUrl = `${base}/api/news/v1/list-feed-digest?variant=geo&lang=en`;
+        const digestUrl = `${base}/api/news/v1/list-feed-digest?variant=full&lang=en`;
         const digestAuth = await buildAuthHeaders(context, 'GET', digestUrl, null);
         const digestRes = await fetch(digestUrl, {
           headers: { ...digestAuth, 'User-Agent': UA },

--- a/docs/mcp-quickstart.mdx
+++ b/docs/mcp-quickstart.mdx
@@ -153,14 +153,14 @@ curl -s https://worldmonitor.app/mcp \
 EOF
 ```
 
-The `wm_…` user key goes in `X-WorldMonitor-Key`, **not** as a `Bearer` token — sending it as a bearer fails OAuth resolution and returns `401 invalid_token`. If you already have an OAuth access token from `/api/oauth/token`, use `Authorization: Bearer $TOKEN` instead and drop the `X-WorldMonitor-Key` header.
+The `wm_…` user API key goes in `X-WorldMonitor-Key`, **not** as a `Bearer` token — sending it as a bearer fails OAuth resolution and returns `401 invalid_token`. If you already have an OAuth access token from `/api/oauth/token`, use `Authorization: Bearer $TOKEN` instead and drop the `X-WorldMonitor-Key` header.
 
 ## Where to go next
 
 - **[JMESPath guide](/mcp-jmespath)** — projection grammar with 12 worked examples against real response shapes. Read this before your second day of MCP use; it will pay for itself in saved tokens within an hour.
 - **[MCP Tools Reference](/mcp-tools-reference)** — per-tool parameters, freshness budgets, API endpoint mapping, and `curl` examples for every tool.
 - **[MCP Server reference](/mcp-server)** — auth modes, OAuth setup, plans & quotas, error codes, and freshness model.
-- **[Authentication overview](/authentication)** — when to use a `wm_…` user key vs. OAuth vs. browser session.
+- **[Authentication overview](/authentication)** — when to use an API key in `X-WorldMonitor-Key` vs. OAuth vs. browser session.
 
 ## Operational note (for ops, not callers)
 

--- a/scripts/capture-mcp-fixture.mjs
+++ b/scripts/capture-mcp-fixture.mjs
@@ -9,7 +9,13 @@
  * filter arg via `--arg key=value` to capture a narrowed response.
  *
  * Usage:
- *   WM_MCP_BEARER="wm_live_..." node scripts/capture-mcp-fixture.mjs \
+ *   WM_MCP_KEY="wm_0123456789abcdef0123456789abcdef01234567" \
+ *     node scripts/capture-mcp-fixture.mjs \
+ *     --tool get_market_data \
+ *     --name fat-get-market-data
+ *
+ *   # Or use an OAuth access token from /api/oauth/token:
+ *   WM_MCP_OAUTH_TOKEN="eyJhbGciOi..." node scripts/capture-mcp-fixture.mjs \
  *     --tool get_market_data \
  *     --name fat-get-market-data
  *
@@ -17,9 +23,9 @@
  *   node scripts/capture-mcp-fixture.mjs --tool get_conflict_events \
  *     --name medium-get-conflict-events --arg limit=30
  *
- * The bearer must be one of:
- *   - A wm_live_... env key (header: X-WorldMonitor-Key)
- *   - A wm_pro_... Pro MCP token (header: Authorization: Bearer ...)
+ * Authentication:
+ *   - WM_MCP_KEY sends X-WorldMonitor-Key: <key>
+ *   - WM_MCP_OAUTH_TOKEN sends Authorization: Bearer <token>
  *
  * Endpoint defaults to https://worldmonitor.app/mcp; override with
  * WM_MCP_ENDPOINT for staging.
@@ -32,7 +38,8 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(HERE, '..');
 const FIXTURES_DIR = resolve(ROOT, 'tests/fixtures/jmespath-samples');
 const ENDPOINT = process.env.WM_MCP_ENDPOINT ?? 'https://worldmonitor.app/mcp';
-const BEARER = process.env.WM_MCP_BEARER;
+const API_KEY = process.env.WM_MCP_KEY;
+const OAUTH_TOKEN = process.env.WM_MCP_OAUTH_TOKEN;
 
 function parseArgs(argv) {
   const out = { args: {} };
@@ -60,11 +67,12 @@ function fail(msg) { process.stderr.write(`ERROR: ${msg}\n`); process.exit(1); }
 const { tool, name, args } = parseArgs(process.argv);
 if (!tool) fail('--tool required (e.g. get_market_data)');
 if (!name) fail('--name required (e.g. fat-get-market-data)');
-if (!BEARER) fail('WM_MCP_BEARER env var required');
+if (API_KEY && OAUTH_TOKEN) fail('Set only one of WM_MCP_KEY or WM_MCP_OAUTH_TOKEN');
+if (!API_KEY && !OAUTH_TOKEN) fail('WM_MCP_KEY or WM_MCP_OAUTH_TOKEN env var required');
 
 const headers = { 'Content-Type': 'application/json' };
-if (BEARER.startsWith('wm_pro_')) headers['Authorization'] = `Bearer ${BEARER}`;
-else headers['X-WorldMonitor-Key'] = BEARER;
+if (OAUTH_TOKEN) headers['Authorization'] = `Bearer ${OAUTH_TOKEN}`;
+else headers['X-WorldMonitor-Key'] = API_KEY;
 
 const body = JSON.stringify({
   jsonrpc: '2.0', id: 1,

--- a/scripts/capture-mcp-fixture.mjs
+++ b/scripts/capture-mcp-fixture.mjs
@@ -2,7 +2,7 @@
 /**
  * Capture a real MCP tool response for the JMESPath fixture set (U6).
  *
- * Hits the production MCP HTTP endpoint with a supplied bearer and writes
+ * Hits the production MCP HTTP endpoint with supplied MCP credentials and writes
  * the response envelope (`{cached_at, stale, data}` for cache tools, or
  * the raw RPC return for `_execute` tools) to disk under
  * `tests/fixtures/jmespath-samples/`. Pass `summary: true` or any other

--- a/tests/fixtures/jmespath-samples/README.md
+++ b/tests/fixtures/jmespath-samples/README.md
@@ -17,8 +17,10 @@ the committed fixtures produces byte-identical numbers.
 ## How to (re)capture
 
 ```bash
-# Use either a wm_live_... env key or a wm_pro_... Pro MCP token.
-export WM_MCP_BEARER="wm_live_..."
+# Use either a user API key or an OAuth access token from /api/oauth/token.
+export WM_MCP_KEY="wm_0123456789abcdef0123456789abcdef01234567"
+# Or:
+# export WM_MCP_OAUTH_TOKEN="eyJhbGciOi..."
 
 # Fat — no filter args, full bootstrap.
 node scripts/capture-mcp-fixture.mjs --tool get_market_data \

--- a/tests/mcp-news-auth-docs-contract.test.mjs
+++ b/tests/mcp-news-auth-docs-contract.test.mjs
@@ -109,5 +109,6 @@ describe('MCP news/auth public contract', () => {
     const captureScript = readRepoFile('scripts/capture-mcp-fixture.mjs');
     assert.match(captureScript, /WM_MCP_KEY/, 'fixture capture should expose an API-key env var');
     assert.match(captureScript, /WM_MCP_OAUTH_TOKEN/, 'fixture capture should expose an OAuth-token env var');
+    assert.doesNotMatch(captureScript, /supplied bearer/i, 'fixture capture should not call API-key credentials bearer credentials');
   });
 });

--- a/tests/mcp-news-auth-docs-contract.test.mjs
+++ b/tests/mcp-news-auth-docs-contract.test.mjs
@@ -1,0 +1,113 @@
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import { __testing__ } from '../api/mcp.ts';
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function readRepoFile(path) {
+  return readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+}
+
+function rpcTool(name) {
+  const tool = __testing__.TOOL_REGISTRY.find((candidate) => candidate.name === name);
+  assert.ok(tool, `${name} must be registered`);
+  assert.equal(typeof tool._execute, 'function', `${name} must be an RPC tool`);
+  return tool;
+}
+
+async function captureRpcFetches(toolName, params) {
+  const calls = [];
+  globalThis.fetch = async (input, init = {}) => {
+    const url = String(input);
+    calls.push({ url, init });
+    const { pathname } = new URL(url);
+
+    if (pathname === '/api/news/v1/list-feed-digest') {
+      return new Response(JSON.stringify({
+        generatedAt: '2026-06-07T00:00:00.000Z',
+        categories: {
+          world: {
+            items: [
+              {
+                title: 'Headline used for MCP grounding',
+                snippet: 'Short RSS context used by the LLM prompt.',
+              },
+            ],
+          },
+        },
+      }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+    }
+
+    if (pathname === '/api/news/v1/summarize-article') {
+      return new Response(JSON.stringify({ summary: 'Grounded world brief.' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    if (pathname === '/api/intelligence/v1/get-country-intel-brief') {
+      return new Response(JSON.stringify({ brief: 'Grounded country brief.' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    throw new Error(`Unexpected fetch in ${toolName}: ${url}`);
+  };
+
+  await rpcTool(toolName)._execute(params, 'https://worldmonitor.app', {
+    kind: 'env_key',
+    apiKey: 'wm_test_key_mcp_news_contract',
+  });
+  return calls;
+}
+
+describe('MCP news/auth public contract', () => {
+  it('RPC news-brief tools use the documented full digest variant for grounding', async () => {
+    const worldCalls = await captureRpcFetches('get_world_brief', { geo_context: 'Middle East tensions' });
+    const countryCalls = await captureRpcFetches('get_country_brief', { country_code: 'US' });
+    const allCalls = [...worldCalls, ...countryCalls];
+
+    const digestUrls = allCalls
+      .map((call) => new URL(call.url))
+      .filter((url) => url.pathname === '/api/news/v1/list-feed-digest');
+    assert.equal(digestUrls.length, 2, 'both RPC brief tools should ground on list-feed-digest');
+    assert.deepEqual(
+      digestUrls.map((url) => url.searchParams.get('variant')),
+      ['full', 'full'],
+      'MCP RPC tools must not rely on unsupported digest variants such as geo',
+    );
+
+    const summarizeCall = allCalls.find((call) => new URL(call.url).pathname === '/api/news/v1/summarize-article');
+    assert.ok(summarizeCall, 'get_world_brief should call summarize-article');
+    assert.equal(JSON.parse(String(summarizeCall.init.body)).variant, 'full');
+  });
+
+  it('MCP-facing docs and fixture helpers do not teach stale API-key prefixes', () => {
+    const mcpFacingFiles = [
+      'docs/mcp-quickstart.mdx',
+      'tests/fixtures/jmespath-samples/README.md',
+      'scripts/capture-mcp-fixture.mjs',
+    ];
+
+    for (const path of mcpFacingFiles) {
+      const text = readRepoFile(path);
+      assert.doesNotMatch(text, /wm_live_|wm_pro_/, `${path} must use current wm_ API-key/OAuth-token wording`);
+    }
+
+    const quickstart = readRepoFile('docs/mcp-quickstart.mdx');
+    assert.match(quickstart, /X-WorldMonitor-Key/, 'quickstart must teach API keys via X-WorldMonitor-Key');
+    assert.match(quickstart, /Authorization: Bearer \$TOKEN/, 'quickstart may teach Bearer only for OAuth tokens');
+    assert.doesNotMatch(quickstart, /Authorization:\s*Bearer\s+\$WM_KEY/, 'quickstart must not show API keys as bearer tokens');
+
+    const captureScript = readRepoFile('scripts/capture-mcp-fixture.mjs');
+    assert.match(captureScript, /WM_MCP_KEY/, 'fixture capture should expose an API-key env var');
+    assert.match(captureScript, /WM_MCP_OAUTH_TOKEN/, 'fixture capture should expose an OAuth-token env var');
+  });
+});

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -2590,7 +2590,7 @@ describe('api/mcp.ts — U7 Pro-path', () => {
     // Sign for digest endpoint.
     const signed = await signInternalMcpRequest({
       method: 'GET',
-      url: 'https://worldmonitor.app/api/news/v1/list-feed-digest?lang=en&variant=geo',
+      url: 'https://worldmonitor.app/api/news/v1/list-feed-digest?lang=en&variant=full',
       body: null,
       userId: PRO_USER_ID,
       secret: HMAC_SECRET,


### PR DESCRIPTION
## Summary
- make MCP world/country brief grounding call the documented `full` news digest variant instead of relying on unsupported `geo` fallback behavior
- update MCP quickstart and fixture-capture docs to use `wm_...` API keys via `X-WorldMonitor-Key`, with Bearer reserved for OAuth tokens
- add a focused MCP contract test for supported digest variants and stale auth wording

## Tests
- `npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/mcp-news-auth-docs-contract.test.mjs`
- `npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test --test-name-pattern "signed header for /api/news/v1/list-feed-digest" tests/mcp.test.mjs`
- `npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/mcp-tool-annotations.test.mjs tests/mcp-api-parity.test.mjs`
- `npm_config_cache=/tmp/worldmonitor-npm-cache npx markdownlint-cli2 docs/mcp-quickstart.mdx tests/fixtures/jmespath-samples/README.md`
- `git diff --check`
- pre-push hook: typecheck, API typecheck, boundary/safe-html/rate-limit/premium-fetch checks, changed MCP tests, edge function tests, markdown/MDX lint, version sync