### PR TITLE
Disclose news digest feed inventory in docs

### DIFF
--- a/docs/data-sources.mdx
+++ b/docs/data-sources.mdx
@@ -317,6 +317,76 @@ Resource management is aggressive — iframes are lazy-loaded via Intersection O
 
 Rather than each client browser independently fetching dozens of RSS feeds through individual edge function invocations, the `listFeedDigest` RPC endpoint aggregates all feeds server-side into a single categorized response.
 
+The public server digest feed inventory below is source-backed from `server/worldmonitor/news/v1/_feeds.ts`; that code file remains the source of truth for exact URLs, Google News query wrappers, and locale-specific URL parameters. Feed choices are intentionally visible here so regional coverage, official-source inclusion, and politically sensitive inclusions such as `Trump - Truth Social` can be reviewed rather than hidden behind a generic "RSS" label. Language-scoped feeds are marked with their language code and are only included when the request language matches. The `full` variant also appends `INTEL_SOURCES` under the `intel` category.
+
+| Variant | Category | Server feed sources |
+| --- | --- | --- |
+| `full` | `politics` | BBC World; Guardian World; AP News; Reuters World; CNN World; Trump - Truth Social |
+| `full` | `us` | Reuters US; NPR News; PBS NewsHour; ABC News; CBS News; NBC News; Wall Street Journal; Politico; The Hill; Axios |
+| `full` | `europe` | France 24; EuroNews; Le Monde; DW News; Tagesschau (de); ANSA (it); NOS Nieuws (nl); SVT Nyheter (sv); Telex (hu); Index.hu (hu); HVG (hu); 444.hu (hu); 24.hu (hu); Híradó (hu); Portfolio.hu (hu); ATV (hu); N1 Croatia (hr); Index.hr (hr); Jutarnji list (hr); Balkan Insight |
+| `full` | `middleeast` | BBC Middle East; Al Jazeera; Guardian ME; Oman Observer; BBC Persian (fa); The National |
+| `full` | `tech` | Hacker News; Ars Technica; The Verge; MIT Tech Review |
+| `full` | `ai` | AI News; VentureBeat AI; The Verge AI; MIT Tech Review; ArXiv AI |
+| `full` | `finance` | CNBC; MarketWatch; Yahoo Finance; Financial Times; Reuters Business |
+| `full` | `gov` | White House; White House Actions; State Dept; Pentagon; Federal Reserve; SEC; UN News; CISA; Treasury; DOJ |
+| `full` | `africa` | BBC Africa; News24; Africanews; Jeune Afrique (fr); Premium Times |
+| `full` | `latam` | BBC Latin America; Guardian Americas; Primicias (es); Infobae Americas (es); El Universo (es); Clarín (es); InSight Crime |
+| `full` | `asia` | BBC Asia; The Diplomat; Nikkei Asia; CNA; NDTV; South China Morning Post; The Hindu; Asia News; BBC Hindi (hi); Aaj Tak (hi); NDTV India (hi); Amar Ujala (hi) |
+| `full` | `energy` | Oil & Gas; Reuters Energy; Nuclear Energy |
+| `full` | `thinktanks` | Foreign Policy; Atlantic Council; Foreign Affairs; War on the Rocks; CSIS |
+| `full` | `crisis` | CrisisWatch; IAEA; WHO |
+| `full` | `layoffs` | Layoffs.fyi; TechCrunch Layoffs; Layoffs News |
+| `full` | `intel` | Defense One; The War Zone; Defense News; Military Times; Task & Purpose; USNI News; gCaptain; Oryx OSINT; Foreign Policy; Foreign Affairs; Atlantic Council; Bellingcat; Krebs Security; Arms Control Assn; Bulletin of Atomic Scientists; FAO News; OCCRP; DFRLab; Lighthouse Reports; The Sentry; GITOC; VSquare; Correctiv |
+| `tech` | `tech` | TechCrunch; The Verge; Ars Technica; Hacker News |
+| `tech` | `ai` | AI News; VentureBeat AI; The Verge AI; ArXiv AI |
+| `tech` | `startups` | TechCrunch Startups; VentureBeat; Crunchbase News |
+| `tech` | `vcblogs` | Y Combinator Blog; a16z Blog; First Round Review; Sequoia Blog; Stratechery |
+| `tech` | `regionalStartups` | EU Startups; Tech.eu; Sifted (Europe); Tech in Asia; TechCabal (Africa); Inc42 (India) |
+| `tech` | `unicorns` | Unicorn News; Decacorn News |
+| `tech` | `accelerators` | YC News; YC Blog; Demo Day News |
+| `tech` | `security` | Krebs Security; Dark Reading |
+| `tech` | `policy` | Politico Tech; AI Regulation; Tech Antitrust |
+| `tech` | `github` | GitHub Blog |
+| `tech` | `funding` | VC News |
+| `tech` | `cloud` | InfoQ; The New Stack |
+| `tech` | `layoffs` | Layoffs.fyi; TechCrunch Layoffs |
+| `tech` | `finance` | CNBC Tech; Yahoo Finance |
+| `tech` | `dev` | Dev.to; Lobsters; Changelog; Show HN |
+| `tech` | `ipo` | IPO News; Tech IPO News |
+| `tech` | `producthunt` | Product Hunt |
+| `tech` | `hardware` | Tom's Hardware; SemiAnalysis; Semiconductor News |
+| `tech` | `outages` | AWS Status; Cloud Outages |
+| `finance` | `markets` | CNBC; Yahoo Finance; Seeking Alpha |
+| `finance` | `forex` | Forex News |
+| `finance` | `bonds` | Bond Market |
+| `finance` | `commodities` | Oil & Gas; Gold & Metals |
+| `finance` | `crypto` | CoinDesk; Cointelegraph; The Block; Decrypt; The Defiant; Bitcoin Magazine; DL News; CryptoSlate; Unchained; DeFi News; Bloomberg Crypto; Reuters Crypto; Wu Blockchain; Messari; NFT News; Stablecoin Policy |
+| `finance` | `centralbanks` | Federal Reserve |
+| `finance` | `economic` | Economic Data |
+| `finance` | `ipo` | IPO News |
+| `finance` | `derivatives` | Options Market; Futures Trading |
+| `finance` | `fintech` | Fintech News; Trading Tech; Blockchain Finance |
+| `finance` | `fin-regulation` | SEC; Financial Regulation; Banking Rules; Crypto Regulation |
+| `finance` | `institutional` | Hedge Fund News; Private Equity; Sovereign Wealth |
+| `finance` | `analysis` | Market Outlook; Risk & Volatility; Bank Research |
+| `finance` | `gccNews` | Arabian Business; The National; Arab News; Gulf FDI; Gulf Investments; Vision 2030 |
+| `commodity` | `commodity-news` | Kitco News; Mining.com; Bloomberg Commodities; Reuters Commodities; S&P Global Commodity; CNBC Commodities |
+| `commodity` | `gold-silver` | Kitco Gold; Gold Price News; Silver Price News; Precious Metals; World Gold Council |
+| `commodity` | `energy` | OilPrice.com; Rigzone; EIA Reports; OPEC News; Natural Gas News; Energy Intel; Reuters Energy |
+| `commodity` | `mining-news` | Mining Journal; Northern Miner; Mining Weekly; Mining Technology; Australian Mining; Mine Web (SNL); Resource World |
+| `commodity` | `critical-minerals` | Benchmark Mineral; Lithium Market; Cobalt Market; Rare Earths News; EV Battery Supply; IEA Critical Minerals; Uranium Market |
+| `commodity` | `base-metals` | LME Metals; Copper Market; Nickel News; Aluminum & Zinc; Iron Ore Market; Metals Bulletin |
+| `commodity` | `mining-companies` | BHP News; Rio Tinto News; Glencore & Vale; Gold Majors; Freeport & Copper Miners; Critical Mineral Companies |
+| `commodity` | `supply-chain` | Shipping & Freight; Trade Routes; China Commodity Imports; Port & Logistics |
+| `commodity` | `commodity-regulation` | Mining Regulation; ESG in Mining; Trade & Tariffs; Indonesia Nickel Policy; China Mineral Policy |
+| `commodity` | `markets` | Yahoo Finance Commodities; CNBC Markets; Seeking Alpha Metals; Commodity Futures |
+| `commodity` | `finance` | CNBC; MarketWatch; Yahoo Finance; Financial Times; Reuters Business |
+| `happy` | `positive` | Good News Network; Positive.News; Reasons to be Cheerful; Optimist Daily |
+| `happy` | `science` | ScienceDaily; Nature News; Singularity Hub; Human Progress |
+| `happy` | `nature` | Mongabay; Conservation Optimism |
+| `happy` | `inspiring` | GNN Heroes; GNN Health |
+| `happy` | `community` | Yes! Magazine; Shareable |
+
 **Architecture**:
 
 ```
@@ -333,7 +403,7 @@ Client (1 RPC call) → listFeedDigest → Redis check (digest:v1:{variant}:{lan
                            └────────┬────────────────┘
                                     │
                               ┌─────┴─────┐
-                              │ Per-feed   │ ← cached 600s per URL
+                              │ Per-feed   │ ← healthy 3600s, empty/failed 300s
                               │ Redis      │
                               └─────┬─────┘
                                     │
@@ -345,7 +415,7 @@ Client (1 RPC call) → listFeedDigest → Redis check (digest:v1:{variant}:{lan
                            └─────────────────────────┘
 ```
 
-The digest cache key is `news:digest:v1:{variant}:{lang}` with a 900-second TTL. Individual feed results are separately cached per URL for 600 seconds. Items per feed are capped at 5, categories at 20 items each. XML parsing is edge-runtime-compatible (regex-based, no DOM parser), handling both RSS item and Atom entry formats. Each item is keyword-classified at aggregation time. An in-memory fallback cache (capped at 50 entries) provides last-known-good data if Redis fails.
+The digest cache key is `news:digest:v1:{variant}:{lang}` with a 900-second TTL. Individual feed results are separately cached per URL: healthy parsed feeds use 3600 seconds, while empty or failed zero-item parses use 300 seconds so transient blocks are retried sooner. Items per feed are capped at 5, categories at 20 items each. XML parsing is edge-runtime-compatible (regex-based, no DOM parser), handling both RSS item and Atom entry formats. Each item is keyword-classified at aggregation time. An in-memory fallback cache (capped at 50 entries) provides last-known-good data if Redis fails.
 
 This eliminates per-client feed fan-out — 1,000 concurrent users each polling 25 feed categories would have generated 25,000 edge invocations per poll cycle. With server-side aggregation, they generate exactly 1 (or 0 if the digest is cached).
 

--- a/docs/panels/indicators-and-signals.mdx
+++ b/docs/panels/indicators-and-signals.mdx
@@ -110,6 +110,6 @@ These panels visualise cross-domain correlation over a rolling window — useful
 ## Related
 
 - [Features & Interface](/features) — overview of the panel system, Cmd+K, and layout.
-- [Data Sources](/data-sources) — full upstream source list.
+- [Data Sources](/data-sources) — server digest feed inventory and broader upstream source list.
 - [Finance Data](/finance-data) — deeper reference for the financial tiles as a family.
 - [Country Instability Index](/country-instability-index) and [Country Resilience Index](/methodology/country-resilience-index) — the country-level risk complements.

--- a/docs/panels/news-feeds.mdx
+++ b/docs/panels/news-feeds.mdx
@@ -137,5 +137,5 @@ All free. Stream configuration lives in `src/config/variants/happy.ts`.
 
 - [Signal Intelligence](/signal-intelligence) — structural overview of how news feeds are classified, deduplicated, and ranked.
 - [News Digest and Briefing methodology](/methodology/news-digest-and-briefing) — canonical scoring, freshness, story tracking, brief filtering, cooldown, LLM, and bias controls.
-- [Data Sources](/data-sources) — the full upstream source list.
+- [Data Sources](/data-sources) — the server digest feed inventory and broader upstream source list.
 - [My Monitors](/panels/monitors) — how keyword monitors work across news feeds.

--- a/tests/news-digest-methodology-parity.test.mjs
+++ b/tests/news-digest-methodology-parity.test.mjs
@@ -18,12 +18,28 @@ const docText = readFileSync(
   resolve(repoRoot, 'docs/methodology/news-digest-and-briefing.mdx'),
   'utf8',
 );
+const dataSourcesText = readFileSync(
+  resolve(repoRoot, 'docs/data-sources.mdx'),
+  'utf8',
+);
+const panelNewsFeedsText = readFileSync(
+  resolve(repoRoot, 'docs/panels/news-feeds.mdx'),
+  'utf8',
+);
+const panelIndicatorsText = readFileSync(
+  resolve(repoRoot, 'docs/panels/indicators-and-signals.mdx'),
+  'utf8',
+);
 const digestSrc = readFileSync(
   resolve(repoRoot, 'server/worldmonitor/news/v1/list-feed-digest.ts'),
   'utf8',
 );
 const summarizeSrc = readFileSync(
   resolve(repoRoot, 'server/worldmonitor/news/v1/summarize-article.ts'),
+  'utf8',
+);
+const feedsSrc = readFileSync(
+  resolve(repoRoot, 'server/worldmonitor/news/v1/_feeds.ts'),
   'utf8',
 );
 const cacheKeysSrc = readFileSync(
@@ -175,6 +191,86 @@ function extractYamlSchemaBlock(yamlText, schemaName) {
   return lines.slice(start, end === -1 ? undefined : end).join('\n');
 }
 
+function formatFeedName(name, lang) {
+  return lang ? `${name} (${lang})` : name;
+}
+
+function extractFeedInventoryRows(src) {
+  const rows = [];
+  let inVariants = false;
+  let currentVariant = null;
+  let currentCategory = null;
+
+  for (const line of src.split(/\r?\n/)) {
+    if (line.startsWith('export const VARIANT_FEEDS')) {
+      inVariants = true;
+      continue;
+    }
+    if (!inVariants) continue;
+    if (line.startsWith('};')) break;
+
+    const variantMatch = line.match(/^  ([A-Za-z][A-Za-z0-9_]*): \{$/);
+    if (variantMatch) {
+      currentVariant = variantMatch[1];
+      currentCategory = null;
+      continue;
+    }
+    if (currentVariant && line === '  },') {
+      currentVariant = null;
+      currentCategory = null;
+      continue;
+    }
+
+    const categoryMatch = line.match(/^    (?:(['"])(.*?)\1|([A-Za-z][A-Za-z0-9_]*)):\s\[$/);
+    if (currentVariant && categoryMatch) {
+      currentCategory = categoryMatch[2] ?? categoryMatch[3];
+      rows.push({ variant: currentVariant, category: currentCategory, sources: [] });
+      continue;
+    }
+    if (currentCategory && line === '    ],') {
+      currentCategory = null;
+      continue;
+    }
+
+    const feedMatch = line.match(/\{\s*name:\s*(['"])(.*?)\1,/);
+    if (currentVariant && currentCategory && feedMatch) {
+      const lang = line.match(/lang:\s*'([^']+)'/)?.[1];
+      rows.at(-1).sources.push(formatFeedName(feedMatch[2], lang));
+    }
+  }
+
+  const intelSources = [];
+  let inIntelSources = false;
+  for (const line of src.split(/\r?\n/)) {
+    if (line.startsWith('export const INTEL_SOURCES')) {
+      inIntelSources = true;
+      continue;
+    }
+    if (!inIntelSources) continue;
+    if (line.startsWith('];')) break;
+    const feedMatch = line.match(/\{\s*name:\s*(['"])(.*?)\1,/);
+    if (feedMatch) {
+      const lang = line.match(/lang:\s*'([^']+)'/)?.[1];
+      intelSources.push(formatFeedName(feedMatch[2], lang));
+    }
+  }
+
+  assert.ok(rows.length > 0, 'failed to extract VARIANT_FEEDS inventory rows');
+  assert.ok(intelSources.length > 0, 'failed to extract INTEL_SOURCES inventory');
+  const fullSectionInsertAt = rows.findLastIndex((row) => row.variant === 'full');
+  assert.notEqual(fullSectionInsertAt, -1, 'failed to extract full variant rows for INTEL_SOURCES insertion');
+  rows.splice(
+    fullSectionInsertAt + 1,
+    0,
+    { variant: 'full', category: 'intel', sources: intelSources },
+  );
+  return rows;
+}
+
+function formatInventoryRow(row) {
+  return `| \`${row.variant}\` | \`${row.category}\` | ${row.sources.join('; ')} |`;
+}
+
 function assertDocIncludes(value, label) {
   assert.ok(
     docText.includes(String(value)),
@@ -225,6 +321,78 @@ describe('news digest methodology parity', () => {
         'SummarizeArticle docs must not retain the stale max-8 contract',
       );
     }
+  });
+
+  it('documents the server news feed inventory in public data-source docs', () => {
+    assert.ok(
+      dataSourcesText.includes('source-backed from `server/worldmonitor/news/v1/_feeds.ts`'),
+      'data sources page must identify _feeds.ts as the server inventory source of truth',
+    );
+
+    const rows = extractFeedInventoryRows(feedsSrc);
+    assert.equal(
+      rows.length,
+      65,
+      'server news feed inventory row count changed; update _feeds.ts, docs/data-sources.mdx, and this assertion together',
+    );
+    for (const row of rows) {
+      assert.ok(
+        dataSourcesText.includes(formatInventoryRow(row)),
+        `data sources page must disclose feed inventory row ${row.variant}/${row.category}`,
+      );
+    }
+
+    assert.ok(
+      dataSourcesText.includes('Trump - Truth Social'),
+      'data sources page must disclose politically sensitive source choices',
+    );
+    assert.ok(
+      panelNewsFeedsText.includes('server digest feed inventory'),
+      'news-feeds panel docs should point readers to disclosed server inventory',
+    );
+    for (const [label, text] of [
+      ['news-feeds panel docs', panelNewsFeedsText],
+      ['indicators-and-signals panel docs', panelIndicatorsText],
+    ]) {
+      assert.doesNotMatch(
+        text,
+        /full upstream source list/i,
+        `${label} must not reintroduce the unbacked full upstream source list claim`,
+      );
+    }
+  });
+
+  it('documents news digest cache TTLs from the implementation', () => {
+    const healthyTtl = extractNumericConst(digestSrc, 'CACHE_TTL_HEALTHY_S');
+    const emptyTtl = extractNumericConst(digestSrc, 'CACHE_TTL_EMPTY_S');
+    const digestTtl = digestSrc.match(/cachedFetchJson<ListFeedDigestResponse>\(\s*digestCacheKey,\s*([0-9_]+)/s);
+
+    assert.equal(
+      healthyTtl,
+      3600,
+      'healthy feed TTL changed; update data-sources and methodology docs plus this disclosure guard together',
+    );
+    assert.equal(
+      emptyTtl,
+      300,
+      'empty or failed feed TTL changed; update data-sources and methodology docs plus this disclosure guard together',
+    );
+    assert.equal(
+      Number(digestTtl?.[1]?.replace(/_/g, '')),
+      900,
+      'digest cache TTL changed; update docs/data-sources.mdx and this disclosure guard together',
+    );
+
+    for (const text of [docText, dataSourcesText]) {
+      assert.ok(text.includes(`${healthyTtl} seconds`), 'docs must mention healthy feed TTL');
+      assert.ok(text.includes(`${emptyTtl} seconds`), 'docs must mention empty or failed feed TTL');
+    }
+    assert.ok(dataSourcesText.includes('900-second TTL'), 'data sources page must mention digest TTL');
+    assert.doesNotMatch(
+      dataSourcesText,
+      /cached\s+600s\s+per URL|per URL for 600 seconds/i,
+      'data sources page must not retain stale 600s per-feed TTL wording',
+    );
   });
 
   it('documents the accepted feed digest variants from VALID_VARIANTS', () => {


### PR DESCRIPTION
## Summary

- add a source-backed server news digest feed inventory table to docs/data-sources.mdx
- correct news digest TTL documentation to healthy parsed feeds at 3600s, empty/failed zero-item parses at 300s, and digest cache at 900s
- extend the focused news digest methodology parity test to guard feed inventory disclosure and TTL drift

## Validation

- node --test tests/news-digest-methodology-parity.test.mjs
- git diff --check
- pre-push hook passed: typecheck, API typecheck, boundary/safe HTML/rate-limit/premium-fetch checks, changed test file, markdown lint, MDX lint, version check
