### PR TITLE
Fix documentation count drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 - **Dual map engine** — 3D globe (globe.gl) and WebGL flat map (deck.gl) with 56 map layer types
 - **Cross-stream correlation** — military, economic, disaster, and escalation signal convergence
 - **Country Intelligence Index** — composite risk scoring across 12 signal categories
-- **Finance radar** — 92 stock exchanges, commodities, crypto, and 7-signal market composite
+- **Finance radar** — 29 stock exchanges, commodities, crypto, and 7-signal market composite
 - **Local AI** — run everything with Ollama, no API keys required
 - **6 site variants** from a single codebase (world, tech, finance, commodity, happy, energy)
 - **Native desktop app** (Tauri 2) for macOS, Windows, and Linux

--- a/docs/COMMUNITY-PROMOTION-GUIDE.md
+++ b/docs/COMMUNITY-PROMOTION-GUIDE.md
@@ -136,7 +136,7 @@ Run AI summarization entirely on your own hardware — no API keys, no cloud, no
 ### For Finance/OSINT Audience
 
 - "7-signal crypto macro radar with BUY/CASH composite verdict"
-- "92 global stock exchanges mapped with market caps and trading hours"
+- "29 global stock exchanges mapped with market caps and trading hours"
 - "Country Instability Index tracking 31 Tier-1 countries in real time"
 - "Prediction market integration for geopolitical forecasting"
 - "Air-gapped AI analysis — run Ollama locally for sensitive intelligence work"
@@ -159,7 +159,7 @@ Run AI summarization entirely on your own hardware — no API keys, no cloud, no
 | v2.4.1 | Ultra-wide layout (panels wrap around map on 2000px+ screens) |
 | v2.4.0 | Live webcams from 19 geopolitical hotspots, 4 regions |
 | v2.3.9 | Full i18n: 19 languages including Japanese, Arabic (RTL), Chinese |
-| v2.3.8 | Finance variant with 92 exchanges, Gulf FDI investments |
+| v2.3.8 | Finance variant with 29 exchanges, Gulf FDI investments |
 | v2.3.7 | Light/dark theme system, UCDP/UNHCR/Climate panels |
 | v2.3.6 | Desktop app with Tauri, OS keychain, auto-updates |
 | v2.3.0 | Country Intelligence dossiers, story sharing |

--- a/docs/Docs_To_Review/DOCUMENTATION.md
+++ b/docs/Docs_To_Review/DOCUMENTATION.md
@@ -360,7 +360,7 @@ This provides a unified command center for all intelligence findings, whether ge
 
 ### Signal Types
 
-The system detects 12 distinct signal types across news, markets, military, and infrastructure domains:
+The system lists 13 distinct signal types across news, markets, military, and infrastructure domains:
 
 **News & Source Signals**
 

--- a/docs/Docs_To_Review/DOCUMENTATION.md
+++ b/docs/Docs_To_Review/DOCUMENTATION.md
@@ -360,7 +360,7 @@ This provides a unified command center for all intelligence findings, whether ge
 
 ### Signal Types
 
-The system lists 13 distinct signal types across news, markets, military, and infrastructure domains:
+The system lists 14 distinct signal types across news, markets, military, and infrastructure domains:
 
 **News & Source Signals**
 
@@ -369,6 +369,7 @@ The system lists 13 distinct signal types across news, markets, military, and in
 | **◉ Convergence** | 3+ source types report same story within 30 minutes | Multiple independent channels confirming the same event—higher likelihood of significance |
 | **△ Triangulation** | Wire + Government + Intel sources align | The "authority triangle"—when official channels, wire services, and defense specialists all report the same thing |
 | **🔥 Velocity Spike** | Topic mention rate doubles with 6+ sources/hour | A story is accelerating rapidly across the news ecosystem |
+| **📊 Keyword Spike** | Term frequency rises significantly above baseline | A keyword is breaking out across monitored sources—early indication of a developing story |
 
 **Market Signals**
 

--- a/docs/PRESS_KIT.md
+++ b/docs/PRESS_KIT.md
@@ -119,7 +119,7 @@ World Monitor aggregates publicly available data from dozens of sources. No prop
 | Languages supported | 21 (including RTL) |
 | Military bases mapped | 210+ |
 | AI datacenters mapped | 111 |
-| Stock exchanges mapped | 92 |
+| Stock exchanges mapped | 29 |
 | Strategic ports mapped | 83 |
 | Undersea cables tracked | 55+ |
 | Pipelines mapped | 88 |

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -280,7 +280,7 @@ World Monitor uses 60+ Vercel Edge Functions as a lightweight API layer, split i
 - **Market Intelligence** — macro signals, ETF flows, and stablecoin monitors compute derived analytics server-side (VWAP, SMA, peg deviation, flow estimates) and cache results in Redis
 - **Temporal Baseline** — Welford's algorithm state is persisted in Redis across requests, building statistical baselines without a traditional database
 - **Custom Scrapers** — sources without RSS feeds (FwdStart, GitHub Trending, tech events) are scraped and transformed into RSS-compatible formats
-- **Finance Geo Data** — stock exchanges (92), financial centers (19), central banks (13), and commodity hubs (10) are served as static typed datasets with market caps, GFCI rankings, trading hours, and commodity specializations
+- **Finance Geo Data** — stock exchanges (29), financial centers (19), central-bank and supranational finance institutions (14), and commodity hubs (10) are served as static typed datasets with market caps, GFCI rankings, trading hours, and commodity specializations
 - **BIS Integration** — policy rates, real effective exchange rates, and credit-to-GDP ratios from the Bank for International Settlements, cached with 30-minute TTL
 - **WTO Trade Policy** — trade restrictions, tariff trends, bilateral trade flows, and SPS/TBT barriers from the World Trade Organization
 - **Supply Chain Intelligence** — maritime chokepoint disruption scores (cross-referencing NGA warnings + AIS data), FRED shipping freight indices with spike detection, and critical mineral supply concentration via Herfindahl-Hirschman Index analysis

--- a/docs/data-sources.mdx
+++ b/docs/data-sources.mdx
@@ -87,7 +87,7 @@ description: "Comprehensive documentation of all data sources, feed tiers, and c
 
 - 29 global stock exchanges — mega (NYSE, NASDAQ, Shanghai, Euronext, Tokyo), major (Hong Kong, London, NSE/BSE, Toronto, Korea, Saudi Tadawul), and emerging markets — with market caps and trading hours
 - 19 financial centers — ranked by Global Financial Centres Index (New York #1 through offshore centers: Cayman Islands, Luxembourg, Bermuda, Channel Islands)
-- 13 central banks — Federal Reserve, ECB, BoJ, BoE, PBoC, SNB, RBA, BoC, RBI, BoK, BCB, SAMA, plus supranational institutions (BIS, IMF)
+- 14 central-bank and supranational finance institutions — 12 policy-rate institutions (Federal Reserve, ECB, BoJ, BoE, PBoC, SNB, RBA, BoC, RBI, BoK, BCB, SAMA) plus BIS and IMF
 - BIS central bank data — policy rates across major economies, real effective exchange rates (REER), and credit-to-GDP ratios sourced from the Bank for International Settlements
 - 10 commodity hubs — exchanges (CME Group, ICE, LME, SHFE, DCE, TOCOM, DGCX, MCX) and physical hubs (Rotterdam, Houston)
 - Gulf FDI investment layer — 64 Saudi/UAE foreign direct investments plotted globally, color-coded by status (operational, under-construction, announced), sized by investment amount

--- a/docs/features.mdx
+++ b/docs/features.mdx
@@ -109,7 +109,7 @@ Beyond raw data feeds, the dashboard provides synthesized intelligence panels:
 | **Displacement Tracking** | UN OCHA HAPI refugee, asylum seeker, and IDP data with origin/host country perspectives |
 | **Gulf Economies** | Indices, currencies, and oil data for 6 GCC countries (Saudi, UAE, Qatar, Kuwait, Bahrain, Oman) |
 | **WTO Trade Policy** | Active trade restrictions, tariff trends, bilateral trade flows, and SPS/TBT barriers |
-| **Central Banks & BIS** | Policy rates and monetary decisions from 13 central banks via BIS data |
+| **Central Banks, BIS & IMF** | Policy-rate and institutional finance signals from 14 central-bank and supranational finance institutions |
 | **Market Watchlist** | User-defined stock/commodity/crypto symbol lists (up to 50 symbols) |
 
 These panels transform raw signals into actionable intelligence by applying scoring algorithms, trend detection, and cross-source correlation.

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -37,6 +37,7 @@
   "feedDefinitions": 567,
   "airportCount": 111,
   "stockExchangeCount": 29,
+  "centralBankInstitutionCount": 14,
   "telegramFullEnabledChannels": 56,
   "telegramFullTierCounts": {
     "1": 3,

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -107,7 +107,7 @@ The finance variant ([finance.worldmonitor.app](https://finance.worldmonitor.app
 |-------|-------------|
 | **Stock Exchanges** | Major global stock exchanges with live status |
 | **Financial Centers** | Key financial hubs and banking districts |
-| **Central Banks** | 13 central banks with policy rate tracking |
+| **Central Banks & Institutions** | 14 central-bank and supranational finance institutions, including policy-rate tracking plus BIS/IMF context |
 | **Commodity Hubs** | Commodity exchanges (LME, CME, SHFE, NYMEX) |
 | **Gulf Investments** | GCC sovereign wealth and investment zones |
 

--- a/docs/signal-intelligence.mdx
+++ b/docs/signal-intelligence.mdx
@@ -32,7 +32,7 @@ This provides a unified command center for all intelligence findings, whether ge
 
 ### Signal Types
 
-The system lists 13 distinct signal types across news, markets, military, and infrastructure domains:
+The system lists 14 distinct signal types across news, markets, military, and infrastructure domains:
 
 **News & Source Signals**
 
@@ -41,6 +41,7 @@ The system lists 13 distinct signal types across news, markets, military, and in
 | **◉ Convergence** | 3+ source types report same story within 30 minutes | Multiple independent channels confirming the same event—higher likelihood of significance |
 | **△ Triangulation** | Wire + Government + Intel sources align | The "authority triangle"—when official channels, wire services, and defense specialists all report the same thing |
 | **🔥 Velocity Spike** | Topic mention rate doubles with 6+ sources/hour | A story is accelerating rapidly across the news ecosystem |
+| **📊 Keyword Spike** | Term frequency rises significantly above baseline | A keyword is breaking out across monitored sources—early indication of a developing story |
 
 **Market Signals**
 

--- a/docs/signal-intelligence.mdx
+++ b/docs/signal-intelligence.mdx
@@ -32,7 +32,7 @@ This provides a unified command center for all intelligence findings, whether ge
 
 ### Signal Types
 
-The system detects 12 distinct signal types across news, markets, military, and infrastructure domains:
+The system lists 13 distinct signal types across news, markets, military, and infrastructure domains:
 
 **News & Source Signals**
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -73,9 +73,9 @@ The project is built with TypeScript, Vite, MapLibre GL JS, deck.gl, D3.js, and 
 
 ## Data Layers — Finance & Markets (Finance Variant)
 
-- **Stock Exchanges**: 92 global exchanges — mega (NYSE, NASDAQ, Shanghai, Euronext, Tokyo), major (Hong Kong, London, NSE/BSE, Toronto, Korea, Saudi Tadawul), and emerging markets — with market caps and trading hours
+- **Stock Exchanges**: 29 global exchanges — mega (NYSE, NASDAQ, Shanghai, Euronext, Tokyo), major (Hong Kong, London, NSE/BSE, Toronto, Korea, Saudi Tadawul), and emerging markets — with market caps and trading hours
 - **Financial Centers**: 19 centers ranked by Global Financial Centres Index (New York through offshore centers)
-- **Central Banks**: 13 institutions (Federal Reserve, ECB, BoJ, BoE, PBoC, SNB, RBA, BoC, RBI, BoK, BCB, SAMA) plus supranational (BIS, IMF)
+- **Central Banks & Institutions**: 14 central-bank and supranational finance institutions — 12 policy-rate institutions (Federal Reserve, ECB, BoJ, BoE, PBoC, SNB, RBA, BoC, RBI, BoK, BCB, SAMA) plus BIS and IMF
 - **Commodity Hubs**: 10 exchanges and physical hubs (CME Group, ICE, LME, SHFE, DCE, TOCOM, DGCX, MCX, Rotterdam, Houston)
 - **Gulf FDI Investments**: 64 Saudi/UAE foreign direct investments plotted globally, color-coded by status (operational, under-construction, announced), sized by investment amount — across ports, energy, manufacturing, renewables, megaprojects, telecoms
 
@@ -160,7 +160,7 @@ A single codebase produces three specialized dashboards controlled by the VITE_V
 
 - **World Monitor** (worldmonitor.app): ~25 RSS categories, 44 panels. Focus: geopolitics, military, conflicts, infrastructure security. Unique layers: military bases, nuclear facilities, hotspots, APT groups, spaceports, critical minerals
 - **Tech Monitor** (tech.worldmonitor.app): ~20 RSS categories, 31 panels. Focus: AI/ML, startups, cybersecurity, cloud. Unique layers: tech HQs, cloud regions, startup hubs, accelerators, tech events
-- **Finance Monitor** (finance.worldmonitor.app): ~18 RSS categories, 30 panels. Focus: global markets, trading, central banks, Gulf FDI. Unique layers: 92 stock exchanges, 19 financial centers, 13 central banks, 10 commodity hubs, 64 Gulf FDI investments
+- **Finance Monitor** (finance.worldmonitor.app): ~18 RSS categories, 30 panels. Focus: global markets, trading, central banks, Gulf FDI. Unique layers: 29 stock exchanges, 19 financial centers, 14 central-bank and supranational finance institutions, 10 commodity hubs, 64 Gulf FDI investments
 
 Build-time: Vite HTML plugin transforms meta tags, Open Graph data, PWA manifest, and JSON-LD structured data. Each variant tree-shakes unused data files. Runtime: variant selector in header navigates between deployed domains (web) or sets localStorage preference (desktop).
 

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -87,6 +87,13 @@ function computeStats() {
   }
   const stockExchangeBlock = financeGeo.slice(stockExchangeStart, stockExchangeEnd);
   const stockExchangeCount = (stockExchangeBlock.match(/\bid:\s*'/g) || []).length;
+  const centralBankStart = financeGeo.indexOf('export const CENTRAL_BANKS');
+  const centralBankEnd = financeGeo.indexOf('export const COMMODITY_HUBS');
+  if (centralBankStart === -1 || centralBankEnd === -1 || centralBankEnd <= centralBankStart) {
+    throw new Error('docs-stats: could not isolate CENTRAL_BANKS block in src/config/finance-geo.ts');
+  }
+  const centralBankBlock = financeGeo.slice(centralBankStart, centralBankEnd);
+  const centralBankInstitutionCount = (centralBankBlock.match(/\bid:\s*'/g) || []).length;
 
   const telegram = JSON.parse(read('data/telegram-channels.json'));
   const telegramFullEnabled = Array.isArray(telegram?.channels?.full)
@@ -130,6 +137,7 @@ function computeStats() {
     feedDefinitions,
     airportCount,
     stockExchangeCount,
+    centralBankInstitutionCount,
     telegramFullEnabledChannels: telegramFullEnabled.length,
     telegramFullTierCounts,
     leaderNames,
@@ -174,6 +182,14 @@ function claims(s) {
     { file: 'docs/data-sources.mdx', re: /across (\d+)\s+monitored airports/, value: s.airportCount },
     { file: 'docs/data-sources.mdx', re: /^(\d+)\s+airports across 5 regions/m, value: s.airportCount },
     { file: 'docs/data-sources.mdx', re: /(\d+)\s+global stock exchanges/, value: s.stockExchangeCount },
+    { file: 'docs/data-sources.mdx', re: /(\d+)\s+central-bank and supranational finance institutions/, value: s.centralBankInstitutionCount },
+    { file: 'docs/features.mdx', re: /signals from (\d+)\s+central-bank and supranational finance institutions/, value: s.centralBankInstitutionCount },
+    { file: 'docs/overview.mdx', re: /(\d+)\s+central-bank and supranational finance institutions/, value: s.centralBankInstitutionCount },
+    { file: 'docs/architecture.mdx', re: /stock exchanges \((\d+)\)/, value: s.stockExchangeCount },
+    { file: 'docs/architecture.mdx', re: /central-bank and supranational finance institutions \((\d+)\)/, value: s.centralBankInstitutionCount },
+    { file: 'docs/COMMUNITY-PROMOTION-GUIDE.md', re: /"(\d+)\s+global stock exchanges mapped/, value: s.stockExchangeCount },
+    { file: 'docs/COMMUNITY-PROMOTION-GUIDE.md', re: /Finance variant with (\d+)\s+exchanges/, value: s.stockExchangeCount },
+    { file: 'docs/PRESS_KIT.md', re: /\| Stock exchanges mapped \| (\d+) \|/, value: s.stockExchangeCount },
     { file: 'docs/data-sources.mdx', re: /^(\d+)\s+enabled channels in the default `full` Telegram channel set/m, value: s.telegramFullEnabledChannels },
     { file: 'docs/data-sources.mdx', re: /\*\*Tier 1\*\* \| (\d+)\s+\|/, value: s.telegramFullTierCounts['1'] },
     { file: 'docs/data-sources.mdx', re: /\*\*Tier 2\*\* \| (\d+)\s+\|/, value: s.telegramFullTierCounts['2'] },

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -158,6 +158,7 @@ function claims(s) {
     { file: 'README.md', re: /(\d+)\s+services\)/, value: s.protoServices },
     { file: 'README.md', re: /(\d+)\s+languages/, value: s.locales },
     { file: 'README.md', re: /(\d+)\+\s+curated news feeds/, value: s.feedDefinitions, min: true },
+    { file: 'README.md', re: /(\d+)\s+stock exchanges/, value: s.stockExchangeCount },
     { file: 'docs/overview.mdx', re: /(\d+)\+\s+curated news feeds/, value: s.feedDefinitions, min: true },
 
     { file: 'docs/architecture.mdx', re: /(\d+)\s+service domains, and (?:\d+)\s+map layers/, value: s.protoServices },
@@ -190,6 +191,10 @@ function claims(s) {
     { file: 'docs/COMMUNITY-PROMOTION-GUIDE.md', re: /"(\d+)\s+global stock exchanges mapped/, value: s.stockExchangeCount },
     { file: 'docs/COMMUNITY-PROMOTION-GUIDE.md', re: /Finance variant with (\d+)\s+exchanges/, value: s.stockExchangeCount },
     { file: 'docs/PRESS_KIT.md', re: /\| Stock exchanges mapped \| (\d+) \|/, value: s.stockExchangeCount },
+    { file: 'public/llms-full.txt', re: /Stock Exchanges\*\*: (\d+)\s+global exchanges/, value: s.stockExchangeCount },
+    { file: 'public/llms-full.txt', re: /Central Banks & Institutions\*\*: (\d+)\s+central-bank and supranational finance institutions/, value: s.centralBankInstitutionCount },
+    { file: 'public/llms-full.txt', re: /Unique layers: (\d+)\s+stock exchanges/, value: s.stockExchangeCount },
+    { file: 'public/llms-full.txt', re: /Unique layers: \d+\s+stock exchanges, \d+\s+financial centers, (\d+)\s+central-bank and supranational finance institutions/, value: s.centralBankInstitutionCount },
     { file: 'docs/data-sources.mdx', re: /^(\d+)\s+enabled channels in the default `full` Telegram channel set/m, value: s.telegramFullEnabledChannels },
     { file: 'docs/data-sources.mdx', re: /\*\*Tier 1\*\* \| (\d+)\s+\|/, value: s.telegramFullTierCounts['1'] },
     { file: 'docs/data-sources.mdx', re: /\*\*Tier 2\*\* \| (\d+)\s+\|/, value: s.telegramFullTierCounts['2'] },

--- a/tests/docs-signal-alignment.test.mts
+++ b/tests/docs-signal-alignment.test.mts
@@ -10,6 +10,21 @@ function readRepo(path: string): string {
   return readFileSync(resolve(root, path), 'utf8');
 }
 
+function countSignalTableRows(doc: string): number {
+  const section = doc.match(/### Signal Types([\s\S]*?)### How It Works/);
+  assert.ok(section, 'signal docs must include a Signal Types section before How It Works');
+  return (section[1].match(/^\| \*\*/gm) || []).length;
+}
+
+test('public signal docs keep their listed signal count in sync with the tables', () => {
+  for (const path of ['docs/signal-intelligence.mdx', 'docs/Docs_To_Review/DOCUMENTATION.md'] as const) {
+    const doc = readRepo(path);
+    const countMatch = doc.match(/lists (\d+) distinct signal types/);
+    assert.ok(countMatch, `${path} must publish the listed signal type count`);
+    assert.equal(Number(countMatch[1]), countSignalTableRows(doc), `${path} signal count must match listed rows`);
+  }
+});
+
 test('public signal docs stay aligned with hotspot escalation math', () => {
   const hotspotCode = readRepo('src/services/hotspot-escalation.ts');
   const hotspotsDoc = readRepo('docs/hotspots.mdx');

--- a/tests/docs-signal-alignment.test.mts
+++ b/tests/docs-signal-alignment.test.mts
@@ -16,12 +16,21 @@ function countSignalTableRows(doc: string): number {
   return (section[1].match(/^\| \*\*/gm) || []).length;
 }
 
-test('public signal docs keep their listed signal count in sync with the tables', () => {
+function countAnalysisSignalTypes(): number {
+  const source = readRepo('src/utils/analysis-constants.ts');
+  const union = source.match(/export type SignalType =([\s\S]*?);/);
+  assert.ok(union, 'analysis constants must define SignalType union');
+  return (union[1].match(/^\s*\|\s*'[^']+'/gm) || []).length;
+}
+
+test('public signal docs keep their listed signal count in sync with the SignalType union', () => {
+  const expectedCount = countAnalysisSignalTypes();
   for (const path of ['docs/signal-intelligence.mdx', 'docs/Docs_To_Review/DOCUMENTATION.md'] as const) {
     const doc = readRepo(path);
     const countMatch = doc.match(/lists (\d+) distinct signal types/);
     assert.ok(countMatch, `${path} must publish the listed signal type count`);
-    assert.equal(Number(countMatch[1]), countSignalTableRows(doc), `${path} signal count must match listed rows`);
+    assert.equal(Number(countMatch[1]), expectedCount, `${path} signal headline count must match SignalType`);
+    assert.equal(countSignalTableRows(doc), expectedCount, `${path} signal table rows must match SignalType`);
   }
 });
 


### PR DESCRIPTION
## Summary

- Update public and supporting docs to say 13 listed signal types, 14 central-bank and supranational finance institutions, and 29 global stock exchanges.
- Clarify finance wording so BIS/IMF are described as supranational finance institutions rather than ordinary central banks.
- Add focused drift guards for signal table counts and source-backed finance counts, then regenerate docs stats.

## Validation

- `npm run docs:stats`
- `npm run docs:check`
- `node --test tests/docs-signal-alignment.test.mts`
- pre-push hook: typecheck, API typecheck, Convex type check, CJS syntax, Unicode safety, boundary lint, safe HTML, rate-limit policy coverage, premium-fetch parity, edge bundle check, changed test files, markdown lint, MDX lint, proto freshness skip, pro-test freshness skip, version sync

## Notes

- No finance config or signal implementation changes.
- `npm install` during the pre-push hook reported the existing audit count but the hook completed successfully.