### PR TITLE
Fix stale CII review-doc formula version drift

### DIFF
--- a/docs/Docs_To_Review/COMPONENTS.md
+++ b/docs/Docs_To_Review/COMPONENTS.md
@@ -592,7 +592,7 @@ domain-specific markup.
 |---|---|
 | **File** | `src/components/CIIPanel.ts` |
 | **Panel ID** | `cii` |
-| **Purpose** | Renders server-authoritative CII v7 scores for 31 Tier-1 countries from cached risk-score ingestion, with local fallback scoring when forced or no cached data is available. |
+| **Purpose** | Renders server-authoritative CII v8 scores for 31 Tier-1 countries from cached risk-score ingestion, with local fallback scoring when forced or no cached data is available. |
 | **Key methods** | `setShareStoryHandler()`, `setCountryClickHandler()`, `refresh(forceLocal?)`, `renderFromCached(cached)`, `getScores()` |
 | **DOM** | `.cii-list` → `.cii-country` each with header (emoji flag, name, score, trend arrow, share button), colour bar, sub-score row (U/C/S/I). |
 | **Services** | `toCountryScore()`, `calculateCII()` fallback path, `getCSSColor` |

--- a/docs/Docs_To_Review/TODO_Performance.md
+++ b/docs/Docs_To_Review/TODO_Performance.md
@@ -343,7 +343,7 @@ Status:  · 🔄 Partial · ❌ Not started
 ### PERF-040 — Move CII Calculation to Web Worker
 
 - **Impact:** 🟡 Medium | **Effort:** ~4 hours
-- **Status:** Deprecated premise — the proposed CII worker file was never added. Published CII is server-authoritative v6 for 31 Tier-1 countries from `shared/cii-weights.ts`; the frontend normally renders cached risk scores and only uses `calculateCII()` as the local fallback path.
+- **Status:** Deprecated premise — the proposed CII worker file was never added. Published CII is server-authoritative v8 for 31 Tier-1 countries from `shared/cii-weights.ts`; the frontend normally renders cached risk scores and only uses `calculateCII()` as the local fallback path.
 - **Expected gain:** Re-open only with fresh profiling evidence that the local fallback path, not cached server-score ingestion, causes measurable main-thread stalls.
 
 ### PERF-041 — SharedArrayBuffer for Large Datasets

--- a/docs/Docs_To_Review/todo.md
+++ b/docs/Docs_To_Review/todo.md
@@ -193,7 +193,7 @@ Overlay the map with country-colored fills based on CII score.
 | **Depends on** | — |
 
 **Description**
-CII currently publishes server-authoritative v6 scores for 31 Tier-1 countries
+CII currently publishes server-authoritative v8 scores for 31 Tier-1 countries
 from `shared/cii-weights.ts`, then the browser ingests the cached risk-score
 feed with a local `country-instability.ts` fallback. This TODO is only current
 if reframed as user-defined Tier 2 monitoring layered on top of that contract.

--- a/docs/Docs_To_Review/todo_docs.md
+++ b/docs/Docs_To_Review/todo_docs.md
@@ -178,7 +178,7 @@
 - [ ] **Threat Classification** (`threat-classifier.ts`): hybrid keyword + LLM pipeline
 - [ ] **Signal Correlation** (`correlation.ts`): cross-source pattern matching logic
 - [ ] **Hotspot Escalation** (`hotspot-escalation.ts`): 4-signal scoring methodology
-- [ ] **Country Instability Index** (`server/worldmonitor/intelligence/v1/get-risk-scores.ts`, `shared/cii-weights.ts`): server-authoritative CII v7 scoring for 31 Tier-1 countries, with frontend cached risk-score ingestion and `country-instability.ts` retained as the local fallback renderer path
+- [ ] **Country Instability Index** (`server/worldmonitor/intelligence/v1/get-risk-scores.ts`, `shared/cii-weights.ts`): server-authoritative CII v8 scoring for 31 Tier-1 countries, with frontend cached risk-score ingestion and `country-instability.ts` retained as the local fallback renderer path
 - [ ] **Temporal Baseline** (`temporal-baseline.ts`): Welford's online algorithm for anomaly detection
 - [ ] **Trending Keywords** (`trending-keywords.ts`): 2h vs 7d window spike detection
 - [ ] **Infrastructure Cascade** (`infrastructure-cascade.ts`): BFS propagation model

--- a/tests/cii-docs-drift.test.mts
+++ b/tests/cii-docs-drift.test.mts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, it } from 'node:test';
+import { CII_FORMULA_VERSION } from '../server/worldmonitor/intelligence/v1/_risk-config.ts';
 
 const root = resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
 
@@ -44,6 +45,14 @@ describe('CII docs drift guards', () => {
       'docs/Docs_To_Review/TODO_Performance.md',
       'docs/Docs_To_Review/COMPONENTS.md',
     ];
+    const staleCiiFormulaVersionClaim = new RegExp(
+      String.raw`\bCII\s+(?!${CII_FORMULA_VERSION}\b)v\d+\s+(?:stability|stress|instability|scores?|scoring|formula)\b`,
+      'i',
+    );
+    const stalePublishedCiiVersionClaim = new RegExp(
+      String.raw`\b(?:server-authoritative|published)\s+CII\s+(?:is\s+)?(?:server-authoritative\s+)?(?!${CII_FORMULA_VERSION}\b)v\d+\b`,
+      'i',
+    );
     const stalePatterns = [
       /22-country CII computation/i,
       /20 hardcoded Tier 1 countries/i,
@@ -51,6 +60,8 @@ describe('CII docs drift guards', () => {
       /\breal-time\s+CII\s+v5\s+instability\s+score\b/i,
       /\bComputes\s+CII\s+v5\s+scores\b/i,
       /\bserver-authoritative\s+CII\s+v5\s+scoring\b/i,
+      staleCiiFormulaVersionClaim,
+      stalePublishedCiiVersionClaim,
       /src\/workers\/cii\.worker\.ts/i,
       /src\/components\/CIIPanel\.ts` \(150 lines\)/i,
       /\*\*Country Instability Index\*\* \(`country-instability\.ts`\)/i,

--- a/tests/cii-docs-drift.test.mts
+++ b/tests/cii-docs-drift.test.mts
@@ -45,13 +45,28 @@ describe('CII docs drift guards', () => {
       'docs/Docs_To_Review/TODO_Performance.md',
       'docs/Docs_To_Review/COMPONENTS.md',
     ];
+    const escapedFormulaVersion = CII_FORMULA_VERSION.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const staleCiiFormulaVersionClaim = new RegExp(
-      String.raw`\bCII\s+(?!${CII_FORMULA_VERSION}\b)v\d+\s+(?:stability|stress|instability|scores?|scoring|formula)\b`,
+      String.raw`\bCII\s+(?!${escapedFormulaVersion}\b)v\d+\s+(?:stability|stress|instability|scores?|scoring|formula)\b`,
       'i',
     );
     const stalePublishedCiiVersionClaim = new RegExp(
-      String.raw`\b(?:server-authoritative|published)\s+CII\s+(?:is\s+)?(?:server-authoritative\s+)?(?!${CII_FORMULA_VERSION}\b)v\d+\b`,
+      String.raw`\b(?:server-authoritative|published)\s+CII\s+(?:is\s+)?(?:server-authoritative\s+)?(?!${escapedFormulaVersion}\b)v\d+\b`,
       'i',
+    );
+    const staleCurrentCiiPublishedVersionClaim = new RegExp(
+      String.raw`\bCII\b[^\n.]{0,80}\bserver-authoritative\s+(?!${escapedFormulaVersion}\b)v\d+\s+scores?\b`,
+      'i',
+    );
+    assert.match(
+      'CII currently publishes server-authoritative v6 scores for 31 Tier-1 countries',
+      staleCurrentCiiPublishedVersionClaim,
+      'internal docs guard must catch todo.md-style stale formula-version wording',
+    );
+    assert.doesNotMatch(
+      `CII currently publishes server-authoritative ${CII_FORMULA_VERSION} scores for 31 Tier-1 countries`,
+      staleCurrentCiiPublishedVersionClaim,
+      'internal docs guard must allow the current formula version in todo.md-style wording',
     );
     const stalePatterns = [
       /22-country CII computation/i,
@@ -62,6 +77,7 @@ describe('CII docs drift guards', () => {
       /\bserver-authoritative\s+CII\s+v5\s+scoring\b/i,
       staleCiiFormulaVersionClaim,
       stalePublishedCiiVersionClaim,
+      staleCurrentCiiPublishedVersionClaim,
       /src\/workers\/cii\.worker\.ts/i,
       /src\/components\/CIIPanel\.ts` \(150 lines\)/i,
       /\*\*Country Instability Index\*\* \(`country-instability\.ts`\)/i,


### PR DESCRIPTION
## Summary
- Update archived/internal Docs_To_Review CII references from stale v6/v7 wording to current v8 wording.
- Extend the focused CII docs drift guard so Docs_To_Review rejects non-current CII formula-version claims derived from CII_FORMULA_VERSION.

## Why
The 2026-06-07 CII post-merge audit found that active public methodology docs were aligned to v8, but internal Docs_To_Review files still contained stale v6/v7 CII wording that could be mistaken for current behavior.

## Validation
- npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/cii-docs-drift.test.mts
- npm_config_cache=/tmp/worldmonitor-npm-cache npx markdownlint-cli2 docs/Docs_To_Review/todo_docs.md docs/Docs_To_Review/COMPONENTS.md docs/Docs_To_Review/TODO_Performance.md docs/Docs_To_Review/todo.md
- git diff --check
- pre-push hook passed: typecheck, typecheck:api, Convex type check, CJS syntax, Unicode safety, boundary lint, safe HTML, rate-limit policy coverage, premium-fetch parity, changed test files, repo markdown lint, version sync