### PR TITLE
Clarify brief issue slot URL semantics

### DIFF
--- a/api/api-route-exceptions.json
+++ b/api/api-route-exceptions.json
@@ -472,7 +472,7 @@
     {
       "path": "api/brief/[userId]/[issueDate].ts",
       "category": "deferred",
-      "reason": "Fetches a specific brief by user + issue date. Part of the brief/v1 service work.",
+      "reason": "Fetches a specific brief by user + frozen issue slot. Part of the brief/v1 service work.",
       "owner": "@SebastienMelki",
       "removal_issue": "TBD"
     },

--- a/api/brief/public/[hash].ts
+++ b/api/brief/public/[hash].ts
@@ -9,7 +9,7 @@
  *            recipient's perspective; no distinguishing signal)
  *   -> 503 when Upstash is unreachable
  *
- * Unlike /api/brief/{userId}/{issueDate} which is HMAC-token-gated
+ * Unlike /api/brief/{userId}/{issueSlot} which is HMAC-token-gated
  * and personalised, this route is unauth'd. The hash in the URL is
  * the credential — anyone holding a valid hash reads the public
  * mirror until the pointer expires (7 days).

--- a/scripts/lib/brief-url-sign.mjs
+++ b/scripts/lib/brief-url-sign.mjs
@@ -75,6 +75,8 @@ export async function signBriefToken(userId, issueDate, secret) {
 
 /**
  * @param {{ userId: string; issueDate: string; baseUrl: string; secret: string }} opts
+ *   issueDate is the legacy property name for the issueSlot-shaped
+ *   value (`YYYY-MM-DD-HHMM`).
  * @returns {Promise<string>}
  */
 export async function signBriefUrl({ userId, issueDate, baseUrl, secret }) {

--- a/scripts/lib/brief-url-sign.mjs
+++ b/scripts/lib/brief-url-sign.mjs
@@ -56,9 +56,12 @@ async function hmacSha256(secret, message) {
 }
 
 /**
- * Deterministically sign `${userId}:${issueDate}` and return a
- * base64url-encoded token (43 chars, no padding).
- * @param {string} userId @param {string} issueDate @param {string} secret
+ * Deterministically sign `${userId}:${issueSlot}` and return a
+ * base64url-encoded token (43 chars, no padding). The parameter is
+ * still named issueDate for parity with the edge helper, but the value
+ * is the frozen issue slot.
+ * @param {string} userId @param {string} issueDate issueSlot-shaped value
+ * @param {string} secret
  * @returns {Promise<string>}
  */
 export async function signBriefToken(userId, issueDate, secret) {

--- a/server/_shared/brief-render.js
+++ b/server/_shared/brief-render.js
@@ -1164,7 +1164,7 @@ const STYLE_BLOCK = `<style>
 
 /**
  * Inline share-button client. The hosted magazine route has already
- * derived the share URL server-side (it has the userId, issueDate,
+ * derived the share URL server-side (it has the userId, issueSlot,
  * and BRIEF_SHARE_SECRET — the same inputs the share-url endpoint
  * uses) and embedded it as `data-share-url` on the button. At click
  * time we just invoke navigator.share with a clipboard fallback.

--- a/server/_shared/brief-url.ts
+++ b/server/_shared/brief-url.ts
@@ -1,7 +1,7 @@
 /**
  * HMAC-signed URL helpers for the WorldMonitor Brief magazine route.
  *
- * The hosted magazine at /api/brief/{userId}/{issueDate} is auth-less
+ * The hosted magazine at /api/brief/{userId}/{issueSlot} is auth-less
  * in the traditional sense (no Clerk session, no cookie). The signed
  * token IS the credential: a recipient with the URL can read the
  * magazine; without it, no. This matches the push / email delivery
@@ -80,9 +80,11 @@ function constantTimeEqual(a: Uint8Array, b: Uint8Array): boolean {
 }
 
 /**
- * Deterministically sign `${userId}:${issueDate}` and return a
- * base64url-encoded token. Throws BriefUrlError on malformed inputs or
- * missing secret.
+ * Deterministically sign `${userId}:${issueSlot}` and return a
+ * base64url-encoded token. The parameter is still named issueDate for
+ * compatibility with earlier callers, but the accepted value is the
+ * frozen issue slot. Throws BriefUrlError on malformed inputs or missing
+ * secret.
  */
 export async function signBriefToken(
   userId: string,
@@ -98,13 +100,14 @@ export async function signBriefToken(
 }
 
 /**
- * Verify a token against userId + issueDate. Accepts the primary
+ * Verify a token against userId + issueSlot. Accepts the primary
  * secret and (if provided) a previous secret during rotation. Returns
  * `true` only on a byte-for-byte match under either secret.
  *
  * The token is rejected without ever touching crypto if its shape is
- * invalid (wrong length, illegal chars). userId and issueDate are
- * shape-validated before any HMAC computation to prevent probing.
+ * invalid (wrong length, illegal chars). userId and the slot-shaped
+ * issueDate parameter are shape-validated before any HMAC computation to
+ * prevent probing.
  */
 export async function verifyBriefToken(
   userId: string,

--- a/server/_shared/brief-url.ts
+++ b/server/_shared/brief-url.ts
@@ -157,7 +157,8 @@ function base64urlDecode(token: string): Uint8Array | null {
  * Compose the full magazine URL with signed token.
  *
  * Producers should always go through this helper rather than string-
- * concatenating URLs by hand. Example:
+ * concatenating URLs by hand. `issueDate` is the legacy property name
+ * for the issueSlot-shaped value (`YYYY-MM-DD-HHMM`). Example:
  *
  *   const url = await signBriefUrl({
  *     userId: 'user_abc',
@@ -173,6 +174,7 @@ export async function signBriefUrl({
   secret,
 }: {
   userId: string;
+  /** Legacy name for the frozen issueSlot (`YYYY-MM-DD-HHMM`). */
   issueDate: string;
   baseUrl: string;
   secret: string;

--- a/tests/news-digest-methodology-parity.test.mjs
+++ b/tests/news-digest-methodology-parity.test.mjs
@@ -86,6 +86,10 @@ const latestBriefApiSrc = readFileSync(
   resolve(repoRoot, 'api/latest-brief.ts'),
   'utf8',
 );
+const apiRouteExceptionsText = readFileSync(
+  resolve(repoRoot, 'api/api-route-exceptions.json'),
+  'utf8',
+);
 const briefShareUrlApiSrc = readFileSync(
   resolve(repoRoot, 'api/brief/share-url.ts'),
   'utf8',
@@ -104,6 +108,18 @@ const sharedBriefEnvelopeText = readFileSync(
 );
 const briefShareUrlSrc = readFileSync(
   resolve(repoRoot, 'server/_shared/brief-share-url.ts'),
+  'utf8',
+);
+const briefUrlSrc = readFileSync(
+  resolve(repoRoot, 'server/_shared/brief-url.ts'),
+  'utf8',
+);
+const briefRenderSrc = readFileSync(
+  resolve(repoRoot, 'server/_shared/brief-render.js'),
+  'utf8',
+);
+const scriptBriefUrlSignSrc = readFileSync(
+  resolve(repoRoot, 'scripts/lib/brief-url-sign.mjs'),
   'utf8',
 );
 const briefComposeSrc = readFileSync(
@@ -813,6 +829,23 @@ describe('news digest methodology parity', () => {
         briefShareUrlSrc.includes('brief:{userId}:{issueSlot}'),
       'brief share-url helper comments must describe slot-keyed public sharing',
     );
+    assert.ok(
+      briefUrlSrc.includes('/api/brief/{userId}/{issueSlot}') &&
+        briefUrlSrc.includes('sign `${userId}:${issueSlot}`') &&
+        briefUrlSrc.includes('token against userId + issueSlot'),
+      'brief URL signer comments must describe slot-keyed magazine tokens',
+    );
+    assert.ok(
+      scriptBriefUrlSignSrc.includes('sign `${userId}:${issueSlot}`') &&
+        scriptBriefUrlSignSrc.includes('issueSlot-shaped value'),
+      'cron brief URL signer comments must describe slot-keyed magazine tokens',
+    );
+    assert.ok(
+      publicBriefApiSrc.includes('/api/brief/{userId}/{issueSlot}') &&
+        briefRenderSrc.includes('userId, issueSlot') &&
+        apiRouteExceptionsText.includes('user + frozen issue slot'),
+      'brief route comments and route exceptions must describe the path segment as issueSlot',
+    );
     for (const text of [apiBriefText, latestBriefPanelText]) {
       assert.ok(text.includes('`brief:{userId}:{issueSlot}`'), 'brief docs must document slot-keyed envelope');
       assert.ok(text.includes('`brief:latest:{userId}`'), 'brief docs must document latest pointer');
@@ -827,9 +860,13 @@ describe('news digest methodology parity', () => {
     for (const [label, text] of Object.entries({
       sharedBriefEnvelopeText,
       briefShareUrlSrc,
+      briefUrlSrc,
+      briefRenderSrc,
+      scriptBriefUrlSignSrc,
       seedDigestSrc,
       signedBriefApiSrc,
       publicBriefApiSrc,
+      apiRouteExceptionsText,
     })) {
       assert.doesNotMatch(
         text,
@@ -837,11 +874,13 @@ describe('news digest methodology parity', () => {
         `${label} must not retain stale issueDate Redis key shape`,
       );
     }
-    assert.doesNotMatch(
-      briefShareUrlSrc,
-      /HMAC over \(userId, issueDate\)/,
-      'brief share-url helper must not describe share hashes as issueDate-bound',
-    );
+    for (const [label, text] of Object.entries({ briefShareUrlSrc, briefUrlSrc, scriptBriefUrlSignSrc })) {
+      assert.doesNotMatch(
+        text,
+        /HMAC over \(userId, issueDate\)|userId \+ issueDate|\/api\/brief\/\{userId\}\/\{issueDate\}/,
+        `${label} must not describe brief URLs or hashes as issueDate-bound`,
+      );
+    }
     assert.doesNotMatch(
       latestBriefPanelText,
       /strictly daily|once per eligible user per day/,

--- a/tests/news-digest-methodology-parity.test.mjs
+++ b/tests/news-digest-methodology-parity.test.mjs
@@ -832,12 +832,15 @@ describe('news digest methodology parity', () => {
     assert.ok(
       briefUrlSrc.includes('/api/brief/{userId}/{issueSlot}') &&
         briefUrlSrc.includes('sign `${userId}:${issueSlot}`') &&
-        briefUrlSrc.includes('token against userId + issueSlot'),
+        briefUrlSrc.includes('token against userId + issueSlot') &&
+        briefUrlSrc.includes('issueDate` is the legacy property name') &&
+        briefUrlSrc.includes('Legacy name for the frozen issueSlot'),
       'brief URL signer comments must describe slot-keyed magazine tokens',
     );
     assert.ok(
       scriptBriefUrlSignSrc.includes('sign `${userId}:${issueSlot}`') &&
-        scriptBriefUrlSignSrc.includes('issueSlot-shaped value'),
+        scriptBriefUrlSignSrc.includes('issueSlot-shaped value') &&
+        scriptBriefUrlSignSrc.includes('issueDate is the legacy property name'),
       'cron brief URL signer comments must describe slot-keyed magazine tokens',
     );
     assert.ok(


### PR DESCRIPTION
## Summary
- clarify brief URL and public-share comments to describe the route segment as a frozen issueSlot, not the display issueDate
- align the API route exception note with slot-keyed brief lookup semantics
- extend the news/digest methodology parity test to guard brief URL/share comments against issueDate-bound drift

## Validation
- npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/news-digest-methodology-parity.test.mjs tests/brief-share-url.test.mts tests/brief-url-sign.test.mjs tests/brief-edge-route-smoke.test.mjs
- npm_config_cache=/tmp/worldmonitor-npm-cache npx markdownlint-cli2 docs/methodology/news-digest-and-briefing.mdx docs/api-brief.mdx docs/panels/latest-brief.mdx
- git diff --check
- pre-push hook on git push -u origin codex/brief-issue-slot-doc-parity