### PR TITLE
Clarify MCP API-key quota contract

### DIFF
--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -48,7 +48,7 @@ The MCP handler accepts two auth modes, in priority order:
 1. **OAuth 2.1 bearer** — `Authorization: Bearer <token>` where `<token>` was issued by `/api/oauth/token`. This is what Claude Desktop, claude.ai, Cursor, and MCP Inspector use automatically. Required for any client that hits MCP from a browser origin.
 2. **Direct API key** — `X-WorldMonitor-Key: wm_0123456789abcdef0123456789abcdef01234567` for user-issued keys, or an opaque operator-issued enterprise key. Intended for server-side scripts, `curl`, and custom integrations. Do **not** send an API key as a `Bearer` token — it will fail OAuth resolution and return `401 invalid_token`.
 
-Both modes check the same PRO entitlement before every tool call, so a subscription downgrade revokes access on the next request.
+OAuth bearer requests re-check the resolved MCP token, user binding, and active entitlement before dispatch, so a subscription downgrade revokes OAuth MCP access on the next request. Direct `X-WorldMonitor-Key` requests validate the configured API key and then use the per-key limiter; their REST/API plan allowances are enforced outside the Pro/OAuth MCP daily reservation path.
 
 ### Redirect URI allowlist
 

--- a/tests/mcp-capability-parity.test.mjs
+++ b/tests/mcp-capability-parity.test.mjs
@@ -233,4 +233,18 @@ describe('api/mcp.ts — capability parity (advertised AND non-empty)', () => {
     }
     assert.match(notes, /Per-minute .* counts ALL methods/i, 'notes must distinguish per-minute from daily exemptions');
   });
+
+  it('mcp-server docs keep API-key auth separate from the Pro/OAuth daily reservation path', () => {
+    const docs = readFileSync(new URL('../docs/mcp-server.mdx', import.meta.url), 'utf8');
+    assert.doesNotMatch(docs, /Both modes check the same PRO entitlement/i,
+      'docs must not claim API-key requests use the OAuth/Pro entitlement pre-check path');
+    assert.match(docs, /OAuth bearer requests re-check .* active entitlement before dispatch/i,
+      'docs must describe the OAuth entitlement re-check path');
+    assert.match(docs, /Direct `X-WorldMonitor-Key` requests validate the configured API key and then use the per-key limiter/i,
+      'docs must describe API-key MCP auth and per-key minute limiting without implying Pro daily quota reservation');
+    assert.match(docs, /REST\/API plan allowances are enforced outside the Pro\/OAuth MCP daily reservation path/i,
+      'docs must keep REST/API plan allowances separate from MCP daily reservation semantics');
+    assert.match(docs, /`wm_…` MCP calls have \*\*no MCP daily reservation\*\*/i,
+      'docs must state that wm_ API-key MCP calls have no MCP daily reservation');
+  });
 });

--- a/tests/mcp-capability-parity.test.mjs
+++ b/tests/mcp-capability-parity.test.mjs
@@ -234,17 +234,20 @@ describe('api/mcp.ts — capability parity (advertised AND non-empty)', () => {
     assert.match(notes, /Per-minute .* counts ALL methods/i, 'notes must distinguish per-minute from daily exemptions');
   });
 
-  it('mcp-server docs keep API-key auth separate from the Pro/OAuth daily reservation path', () => {
+});
+
+describe('docs/mcp-server.mdx — API-key quota contract', () => {
+  it('keeps API-key auth separate from the Pro/OAuth daily reservation path', () => {
     const docs = readFileSync(new URL('../docs/mcp-server.mdx', import.meta.url), 'utf8');
     assert.doesNotMatch(docs, /Both modes check the same PRO entitlement/i,
       'docs must not claim API-key requests use the OAuth/Pro entitlement pre-check path');
-    assert.match(docs, /OAuth bearer requests re-check .* active entitlement before dispatch/i,
+    assert.match(docs, /OAuth bearer requests re-check[\s\S]*active entitlement[\s\S]*before dispatch/i,
       'docs must describe the OAuth entitlement re-check path');
-    assert.match(docs, /Direct `X-WorldMonitor-Key` requests validate the configured API key and then use the per-key limiter/i,
+    assert.match(docs, /Direct `X-WorldMonitor-Key` requests[\s\S]*configured API key[\s\S]*per-key (?:rate )?limiter/i,
       'docs must describe API-key MCP auth and per-key minute limiting without implying Pro daily quota reservation');
-    assert.match(docs, /REST\/API plan allowances are enforced outside the Pro\/OAuth MCP daily reservation path/i,
+    assert.match(docs, /REST\/API plan allowances[\s\S]*outside[\s\S]*Pro\/OAuth MCP daily reservation path/i,
       'docs must keep REST/API plan allowances separate from MCP daily reservation semantics');
-    assert.match(docs, /`wm_…` MCP calls have \*\*no MCP daily reservation\*\*/i,
+    assert.match(docs, /`wm_…` MCP calls[\s\S]*no MCP daily reservation/i,
       'docs must state that wm_ API-key MCP calls have no MCP daily reservation');
   });
 });


### PR DESCRIPTION
## Summary
- clarify MCP auth docs so OAuth bearer requests are the only path described as re-checking MCP token/user entitlement before dispatch
- document direct X-WorldMonitor-Key requests as API-key validation plus per-key limiter, with REST/API plan allowances outside the Pro/OAuth MCP daily reservation path
- add a parity guard that prevents the MCP server docs from re-conflating API-key callers with the Pro/OAuth daily reservation path

## Validation
- npx tsx --test tests/mcp-capability-parity.test.mjs tests/mcp-resources.test.mjs tests/mcp-api-parity.test.mjs
- npm run docs:check
- npx tsx --test tests/mdx-lint.test.mjs
- npx markdownlint-cli2 docs/mcp-server.mdx
- git diff --check
- pre-push hook on git push (typecheck, typecheck:api, Convex type check, CJS syntax, Unicode safety, boundary lint, safe HTML, rate-limit policies, premium-fetch parity, changed tests, markdown lint, MDX lint, proto freshness skip, pro-test freshness skip, version sync)