### PR TITLE
Align Strategic Risk display bands with CII levels

### DIFF
--- a/src/components/StrategicRiskPanel.ts
+++ b/src/components/StrategicRiskPanel.ts
@@ -241,15 +241,11 @@ export class StrategicRiskPanel extends Panel {
   }
 
   private getScoreColor(score: number): string {
-    return getCSSColor(this.getScoreBand(score).colorVar);
+    return getCSSColor(this.getFallbackScoreBand(score).colorVar);
   }
 
   private getScoreLevel(score: number): string {
-    return t(`countryBrief.levels.${this.getScoreBand(score).levelKey}`);
-  }
-
-  private getScoreBand(score: number): typeof STRATEGIC_RISK_BANDS[number] {
-    return this.getFallbackScoreBand(score);
+    return t(`countryBrief.levels.${this.getFallbackScoreBand(score).levelKey}`);
   }
 
   private getFallbackScoreBand(score: number): typeof STRATEGIC_RISK_BANDS[number] {

--- a/src/components/StrategicRiskPanel.ts
+++ b/src/components/StrategicRiskPanel.ts
@@ -24,26 +24,23 @@ import { getCachedPosture } from '@/services/cached-theater-posture';
 import { refreshDataFreshnessFromHealth } from '@/services/health-freshness';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 
-type StrategicRiskDisplayLevel = 'high' | 'medium' | 'low';
+type StrategicRiskDisplayLevel = 'critical' | 'high' | 'elevated' | 'normal' | 'low';
+type StrategicRiskDisplayBand = {
+  min: number;
+  levelKey: StrategicRiskDisplayLevel;
+  colorVar: string;
+};
 
-const STRATEGIC_RISK_BANDS = [
-  { min: 70, levelKey: 'high', colorVar: '--semantic-critical' },
-  { min: 40, levelKey: 'medium', colorVar: '--semantic-elevated' },
+const STRATEGIC_RISK_BANDS: readonly StrategicRiskDisplayBand[] = [
+  { min: 81, levelKey: 'critical', colorVar: '--semantic-critical' },
+  { min: 66, levelKey: 'high', colorVar: '--semantic-high' },
+  { min: 51, levelKey: 'elevated', colorVar: '--semantic-elevated' },
+  { min: 31, levelKey: 'normal', colorVar: '--semantic-normal' },
   { min: 0, levelKey: 'low', colorVar: '--semantic-low' },
 ] as const;
 
-const STRATEGIC_RISK_LEVEL_ALIASES: Record<string, StrategicRiskDisplayLevel> = {
-  HIGH: 'high',
-  MEDIUM: 'medium',
-  LOW: 'low',
-  SEVERITY_LEVEL_HIGH: 'high',
-  SEVERITY_LEVEL_MEDIUM: 'medium',
-  SEVERITY_LEVEL_LOW: 'low',
-};
-
 export class StrategicRiskPanel extends Panel {
   private overview: StrategicRiskOverview | null = null;
-  private strategicRiskLevel: StrategicRiskDisplayLevel | null = null;
   private alerts: UnifiedAlert[] = [];
   private convergenceAlerts: GeoConvergenceAlert[] = [];
   private freshnessSummary: DataFreshnessSummary | null = null;
@@ -154,7 +151,6 @@ export class StrategicRiskPanel extends Panel {
       staleFactor
     );
     this.overview = localOverview;
-    this.strategicRiskLevel = null;
     this.alerts = getRecentAlerts(24);
 
     if (cachedRiskScores?.strategicRisk) {
@@ -242,9 +238,6 @@ export class StrategicRiskPanel extends Panel {
       degraded: cached.degraded,
       stale: cached.stale,
     };
-    this.strategicRiskLevel =
-      this.normalizeStrategicRiskLevel(cached.strategicRisk.level)
-      ?? this.getFallbackScoreBand(cached.strategicRisk.score).levelKey;
   }
 
   private getScoreColor(score: number): string {
@@ -252,24 +245,15 @@ export class StrategicRiskPanel extends Panel {
   }
 
   private getScoreLevel(score: number): string {
-    return t(`components.strategicRisk.levels.${this.getScoreBand(score).levelKey}`);
+    return t(`countryBrief.levels.${this.getScoreBand(score).levelKey}`);
   }
 
   private getScoreBand(score: number): typeof STRATEGIC_RISK_BANDS[number] {
-    if (this.strategicRiskLevel) return this.getBandForLevel(this.strategicRiskLevel);
     return this.getFallbackScoreBand(score);
   }
 
   private getFallbackScoreBand(score: number): typeof STRATEGIC_RISK_BANDS[number] {
     return STRATEGIC_RISK_BANDS.find((band) => score >= band.min) ?? STRATEGIC_RISK_BANDS[STRATEGIC_RISK_BANDS.length - 1]!;
-  }
-
-  private getBandForLevel(level: StrategicRiskDisplayLevel): typeof STRATEGIC_RISK_BANDS[number] {
-    return STRATEGIC_RISK_BANDS.find((band) => band.levelKey === level) ?? STRATEGIC_RISK_BANDS[STRATEGIC_RISK_BANDS.length - 1]!;
-  }
-
-  private normalizeStrategicRiskLevel(level: string | undefined | null): StrategicRiskDisplayLevel | null {
-    return STRATEGIC_RISK_LEVEL_ALIASES[String(level ?? '').trim().toUpperCase()] ?? null;
   }
 
   private getTrendEmoji(trend: string): string {

--- a/tests/frontend-cii-source-of-truth.test.mts
+++ b/tests/frontend-cii-source-of-truth.test.mts
@@ -390,15 +390,17 @@ describe('frontend CII source of truth', () => {
 
     assert.match(serverRiskSrc, /overallScore >= 70[\s\S]*'SEVERITY_LEVEL_HIGH'[\s\S]*overallScore >= 40[\s\S]*'SEVERITY_LEVEL_MEDIUM'[\s\S]*'SEVERITY_LEVEL_LOW'/);
     assert.match(methodologySrc, /`SEVERITY_LEVEL_HIGH` if `overallScore ≥ 70`[\s\S]*`SEVERITY_LEVEL_MEDIUM` if `40 ≤ overallScore < 70`[\s\S]*`SEVERITY_LEVEL_LOW` if `overallScore < 40`/);
-    assert.match(strategicRiskSrc, /const STRATEGIC_RISK_BANDS: readonly StrategicRiskDisplayBand\[\] = \[[\s\S]*min: 81[\s\S]*levelKey: 'critical'[\s\S]*colorVar: '--semantic-critical'[\s\S]*min: 66[\s\S]*levelKey: 'high'[\s\S]*colorVar: '--semantic-high'[\s\S]*min: 51[\s\S]*levelKey: 'elevated'[\s\S]*colorVar: '--semantic-elevated'[\s\S]*min: 31[\s\S]*levelKey: 'normal'[\s\S]*colorVar: '--semantic-normal'[\s\S]*min: 0[\s\S]*levelKey: 'low'[\s\S]*colorVar: '--semantic-low'/);
-    assert.doesNotMatch(strategicRiskSrc, /min: 70[\s\S]*levelKey: 'high'/);
-    assert.doesNotMatch(strategicRiskSrc, /min: 40[\s\S]*levelKey: 'medium'/);
-    assert.doesNotMatch(strategicRiskSrc, /min: 50[\s\S]*levelKey: 'elevated'/);
-    assert.doesNotMatch(strategicRiskSrc, /min: 30[\s\S]*levelKey: 'moderate'/);
+    const strategicRiskBands = strategicRiskSrc.match(/const STRATEGIC_RISK_BANDS: readonly StrategicRiskDisplayBand\[\] = \[[\s\S]*?\] as const;/)?.[0] ?? '';
+    assert.notEqual(strategicRiskBands, '', 'missing Strategic Risk display band table');
+    assert.match(strategicRiskBands, /min: 81[\s\S]*levelKey: 'critical'[\s\S]*colorVar: '--semantic-critical'[\s\S]*min: 66[\s\S]*levelKey: 'high'[\s\S]*colorVar: '--semantic-high'[\s\S]*min: 51[\s\S]*levelKey: 'elevated'[\s\S]*colorVar: '--semantic-elevated'[\s\S]*min: 31[\s\S]*levelKey: 'normal'[\s\S]*colorVar: '--semantic-normal'[\s\S]*min: 0[\s\S]*levelKey: 'low'[\s\S]*colorVar: '--semantic-low'/);
+    assert.doesNotMatch(strategicRiskBands, /min: 70[\s\S]*levelKey: 'high'/);
+    assert.doesNotMatch(strategicRiskBands, /min: 40[\s\S]*levelKey: 'medium'/);
+    assert.doesNotMatch(strategicRiskBands, /min: 50[\s\S]*levelKey: 'elevated'/);
+    assert.doesNotMatch(strategicRiskBands, /min: 30[\s\S]*levelKey: 'moderate'/);
     assert.doesNotMatch(strategicRiskSrc, /normalizeStrategicRiskLevel|STRATEGIC_RISK_LEVEL_ALIASES|strategicRiskLevel/);
-    assert.match(extractMethod(strategicRiskSrc, 'private getScoreColor(score: number): string'), /this\.getScoreBand\(score\)\.colorVar/);
-    assert.match(extractMethod(strategicRiskSrc, 'private getScoreLevel(score: number): string'), /t\(`countryBrief\.levels\.\$\{this\.getScoreBand\(score\)\.levelKey\}`\)/);
-    assert.match(extractMethod(strategicRiskSrc, 'private getScoreBand(score: number): typeof STRATEGIC_RISK_BANDS[number]'), /return this\.getFallbackScoreBand\(score\);/);
+    assert.doesNotMatch(strategicRiskSrc, /private getScoreBand\(score: number\)/);
+    assert.match(extractMethod(strategicRiskSrc, 'private getScoreColor(score: number): string'), /this\.getFallbackScoreBand\(score\)\.colorVar/);
+    assert.match(extractMethod(strategicRiskSrc, 'private getScoreLevel(score: number): string'), /t\(`countryBrief\.levels\.\$\{this\.getFallbackScoreBand\(score\)\.levelKey\}`\)/);
   });
 
   it('keeps shared CII level labels complete in every locale', () => {

--- a/tests/frontend-cii-source-of-truth.test.mts
+++ b/tests/frontend-cii-source-of-truth.test.mts
@@ -390,27 +390,31 @@ describe('frontend CII source of truth', () => {
 
     assert.match(serverRiskSrc, /overallScore >= 70[\s\S]*'SEVERITY_LEVEL_HIGH'[\s\S]*overallScore >= 40[\s\S]*'SEVERITY_LEVEL_MEDIUM'[\s\S]*'SEVERITY_LEVEL_LOW'/);
     assert.match(methodologySrc, /`SEVERITY_LEVEL_HIGH` if `overallScore ≥ 70`[\s\S]*`SEVERITY_LEVEL_MEDIUM` if `40 ≤ overallScore < 70`[\s\S]*`SEVERITY_LEVEL_LOW` if `overallScore < 40`/);
-    assert.match(strategicRiskSrc, /const STRATEGIC_RISK_BANDS = \[[\s\S]*min: 70[\s\S]*levelKey: 'high'[\s\S]*colorVar: '--semantic-critical'[\s\S]*min: 40[\s\S]*levelKey: 'medium'[\s\S]*min: 0[\s\S]*levelKey: 'low'/);
+    assert.match(strategicRiskSrc, /const STRATEGIC_RISK_BANDS: readonly StrategicRiskDisplayBand\[\] = \[[\s\S]*min: 81[\s\S]*levelKey: 'critical'[\s\S]*colorVar: '--semantic-critical'[\s\S]*min: 66[\s\S]*levelKey: 'high'[\s\S]*colorVar: '--semantic-high'[\s\S]*min: 51[\s\S]*levelKey: 'elevated'[\s\S]*colorVar: '--semantic-elevated'[\s\S]*min: 31[\s\S]*levelKey: 'normal'[\s\S]*colorVar: '--semantic-normal'[\s\S]*min: 0[\s\S]*levelKey: 'low'[\s\S]*colorVar: '--semantic-low'/);
+    assert.doesNotMatch(strategicRiskSrc, /min: 70[\s\S]*levelKey: 'high'/);
+    assert.doesNotMatch(strategicRiskSrc, /min: 40[\s\S]*levelKey: 'medium'/);
     assert.doesNotMatch(strategicRiskSrc, /min: 50[\s\S]*levelKey: 'elevated'/);
     assert.doesNotMatch(strategicRiskSrc, /min: 30[\s\S]*levelKey: 'moderate'/);
-    assert.match(strategicRiskSrc, /this\.strategicRiskLevel =[\s\S]*this\.normalizeStrategicRiskLevel\(cached\.strategicRisk\.level\)[\s\S]*this\.getFallbackScoreBand\(cached\.strategicRisk\.score\)\.levelKey/);
+    assert.doesNotMatch(strategicRiskSrc, /normalizeStrategicRiskLevel|STRATEGIC_RISK_LEVEL_ALIASES|strategicRiskLevel/);
     assert.match(extractMethod(strategicRiskSrc, 'private getScoreColor(score: number): string'), /this\.getScoreBand\(score\)\.colorVar/);
-    assert.match(extractMethod(strategicRiskSrc, 'private getScoreLevel(score: number): string'), /this\.getScoreBand\(score\)\.levelKey/);
-    assert.match(extractMethod(strategicRiskSrc, 'private getScoreBand(score: number): typeof STRATEGIC_RISK_BANDS[number]'), /this\.strategicRiskLevel[\s\S]*this\.getBandForLevel\(this\.strategicRiskLevel\)[\s\S]*this\.getFallbackScoreBand\(score\)/);
+    assert.match(extractMethod(strategicRiskSrc, 'private getScoreLevel(score: number): string'), /t\(`countryBrief\.levels\.\$\{this\.getScoreBand\(score\)\.levelKey\}`\)/);
+    assert.match(extractMethod(strategicRiskSrc, 'private getScoreBand(score: number): typeof STRATEGIC_RISK_BANDS[number]'), /return this\.getFallbackScoreBand\(score\);/);
   });
 
-  it('keeps Strategic Risk level labels complete in every locale', () => {
+  it('keeps shared CII level labels complete in every locale', () => {
     const localeDir = resolve(root, 'src/locales');
     const localeFiles = readdirSync(localeDir).filter((file) => file.endsWith('.json')).sort();
 
     for (const file of localeFiles) {
       const locale = JSON.parse(readFileSync(resolve(localeDir, file), 'utf8')) as {
-        components?: { strategicRisk?: { levels?: Record<string, string> } };
+        countryBrief?: { levels?: Record<string, string> };
       };
-      const levels = locale.components?.strategicRisk?.levels;
-      assert.ok(levels?.high, `${file} must define components.strategicRisk.levels.high`);
-      assert.ok(levels?.medium, `${file} must define components.strategicRisk.levels.medium`);
-      assert.ok(levels?.low, `${file} must define components.strategicRisk.levels.low`);
+      const levels = locale.countryBrief?.levels;
+      assert.ok(levels?.critical, `${file} must define countryBrief.levels.critical`);
+      assert.ok(levels?.high, `${file} must define countryBrief.levels.high`);
+      assert.ok(levels?.elevated, `${file} must define countryBrief.levels.elevated`);
+      assert.ok(levels?.normal, `${file} must define countryBrief.levels.normal`);
+      assert.ok(levels?.low, `${file} must define countryBrief.levels.low`);
     }
   });
 });


### PR DESCRIPTION
## Summary

- Align StrategicRiskPanel display bands with canonical CII UI levels: 81 critical, 66 high, 51 elevated, 31 normal, 0 low.
- Remove the panel-local legacy severity override path so score labels and colors come from the canonical band table.
- Update the frontend CII source-of-truth guard to reject the legacy Strategic Risk thresholds and reuse existing shared CII labels across locales.

## Validation

- npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/frontend-cii-source-of-truth.test.mts tests/cii-scoring.test.mts
- Full pre-push hook passed on git push -u origin codex/strategic-risk-cii-bands, including typecheck, API typecheck, boundary/safe HTML/rate-limit/premium-fetch guards, changed tests, edge function tests, and version sync.

## Notes

- The GitHub connector returned 404: Link not found, so the PR was created with the documented gh CLI fallback.