### PR TITLE
Fix forecast provenance calibration docs

### DIFF
--- a/docs/panels/forecast.mdx
+++ b/docs/panels/forecast.mdx
@@ -59,7 +59,9 @@ Published forecasts are capped and deduplicated before they reach the panel:
 | Forecasts per family | 4 |
 | Forecasts per family/domain pair | 2 |
 | Target published count | 10-14 |
-| Conflict base detector probability ceiling | 0.90 |
+| Conflict base detector probability ceiling (before velocity spike) | 0.90 |
+| UCDP conflict-zone base probability ceiling (before velocity spike) | 0.85 |
+| Conflict velocity-spike override ceiling | 0.99 |
 | Market probability ceiling | 0.85 |
 | Supply-chain / maritime probability ceiling | 0.85 |
 | GPS supply-chain detector probability ceiling | 0.60 |
@@ -82,6 +84,10 @@ Market-bucket scenario calibration is an editorial calibration layer in `scripts
 | Semis | `0.13 / 0.08 / 0.09 / 0.12` | `0.04 / 0.04 / 0.02 / -` | Semiconductor shocks need targeted infrastructure or shipping evidence. |
 | Crypto / stablecoins | `0.11 / 0.07 / 0.08 / 0.12` | `0.03 / 0.05 / 0.02 / -` | Digital-asset stress is useful context but gets a lighter macro lift. |
 | Defense | `0.08 / 0.04 / 0.05 / 0.10` | `-0.03 / 0 / -0.03 / 0.12` | Defense signals are intentionally damped to avoid over-reacting to noisy security headlines. |
+
+The conflict and UCDP conflict-zone rows are base detector caps. When the matching EMA risk score has `velocitySpike`, the seeder adds a `+0.08` probability override after the base cap and clamps the result to `0.99`.
+
+Defense state calibration has additional direct-confirmation terms outside the table: each unit of direct `defense_repricing` confirmation adds `+0.12` pressure and `+0.08` confidence. When that direct defense confirmation is absent, pressure subtracts the table-driven `dampener` (`0.12`) and confidence subtracts a separate `0.04` absence penalty.
 
 Probability projections are anchored to the forecast's own time horizon and then expanded to 24h, 7d, and 30d with domain curves:
 

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -104,6 +104,13 @@ const CYBER_SCORE_CRITICAL_MULTIPLIER = 0.75; // bonus per critical-class threat
 const CYBER_PROB_MAX = 0.72;                // probability ceiling for cyber forecasts
 const CYBER_PROB_VOLUME_WEIGHT = 0.5;       // weight of volume in probability formula
 const CYBER_PROB_TYPE_WEIGHT = 0.15;        // weight of type diversity in probability formula
+const CONFLICT_BASE_DETECTOR_PROB_MAX = 0.90;
+const UCDP_CONFLICT_ZONE_PROB_MAX = 0.85;
+const VELOCITY_SPIKE_PROBABILITY_LIFT = 0.08;
+const VELOCITY_SPIKE_PROBABILITY_MAX = 0.99;
+const DEFENSE_DIRECT_CONFIRMATION_PRESSURE_LIFT = 0.12;
+const DEFENSE_DIRECT_CONFIRMATION_CONFIDENCE_LIFT = 0.08;
+const DEFENSE_ABSENT_CONFIRMATION_CONFIDENCE_PENALTY = 0.04;
 const MAX_MILITARY_SURGE_AGE_MS = 3 * 60 * 60 * 1000;
 const MAX_MILITARY_BUNDLE_DRIFT_MS = 5 * 60 * 1000;
 
@@ -1002,7 +1009,7 @@ function detectConflictScenarios(inputs, emaRiskScores) {
 
     const ciiNorm = normalize(c.score, 50, 100);
     const eventBoost = (matchingIran.length + matchingUcdp.length) > 0 ? 0.1 : 0;
-    let prob = Math.min(0.9, ciiNorm * 0.6 + eventBoost + (c.trend === 'rising' ? 0.1 : 0));
+    let prob = Math.min(CONFLICT_BASE_DETECTOR_PROB_MAX, ciiNorm * 0.6 + eventBoost + (c.trend === 'rising' ? 0.1 : 0));
 
     const emaRisk = emaRiskScores?.get(countryName ?? '');
     if (emaRisk?.velocitySpike) {
@@ -1011,7 +1018,7 @@ function detectConflictScenarios(inputs, emaRiskScores) {
         value: `EMA z-score: ${emaRisk.zscore.toFixed(1)} (${emaRisk.risk24h}/100 risk)`,
         weight: 0.35,
       });
-      prob = Math.min(0.99, prob + 0.08);
+      prob = Math.min(VELOCITY_SPIKE_PROBABILITY_MAX, prob + VELOCITY_SPIKE_PROBABILITY_LIFT);
       sourceCount++;
     }
 
@@ -1855,7 +1862,7 @@ function detectUcdpConflictZones(inputs, emaRiskScores) {
     if (count < 10) continue;
 
     const signals = [{ type: 'ucdp', value: `${count} UCDP conflict events`, weight: 0.5 }];
-    let prob = Math.min(0.85, normalize(count, 5, 100) * 0.7);
+    let prob = Math.min(UCDP_CONFLICT_ZONE_PROB_MAX, normalize(count, 5, 100) * 0.7);
 
     const emaRisk = emaRiskScores?.get(country?.toLowerCase?.() ?? '');
     if (emaRisk?.velocitySpike) {
@@ -1864,7 +1871,7 @@ function detectUcdpConflictZones(inputs, emaRiskScores) {
         value: `EMA z-score: ${emaRisk.zscore.toFixed(1)} (${emaRisk.risk24h}/100 risk)`,
         weight: 0.35,
       });
-      prob = Math.min(0.99, prob + 0.08);
+      prob = Math.min(VELOCITY_SPIKE_PROBABILITY_MAX, prob + VELOCITY_SPIKE_PROBABILITY_LIFT);
     }
 
     predictions.push(makePrediction(
@@ -10213,13 +10220,13 @@ function buildMarketState(worldSignals, transmissionGraph) {
     const calibratedPressure = (pressureNumerator / divisor)
       + (macroConfirmation * Number(calibration.macroLift || 0))
       + (edgeDensity * Number(calibration.edgeLift || 0))
-      + (defenseSignalConfirmation * 0.12)
+      + (defenseSignalConfirmation * DEFENSE_DIRECT_CONFIRMATION_PRESSURE_LIFT)
       - (!defenseSignalConfirmation && config.id === 'defense' ? Number(calibration.dampener || 0) : 0);
     const calibratedConfidence = (confidenceNumerator / divisor)
       + Math.min(0.08, macroSignals.length * 0.02)
       + (edgeDensity * Number(calibration.confidenceLift || 0))
-      + (defenseSignalConfirmation * 0.08)
-      - (!defenseSignalConfirmation && config.id === 'defense' ? 0.04 : 0);
+      + (defenseSignalConfirmation * DEFENSE_DIRECT_CONFIRMATION_CONFIDENCE_LIFT)
+      - (!defenseSignalConfirmation && config.id === 'defense' ? DEFENSE_ABSENT_CONFIRMATION_CONFIDENCE_PENALTY : 0);
     const pressureScore = +clampUnitInterval(calibratedPressure).toFixed(3);
     const confidence = +clampUnitInterval(calibratedConfidence).toFixed(3);
     return {

--- a/tests/forecast-integrity-provenance.test.mjs
+++ b/tests/forecast-integrity-provenance.test.mjs
@@ -16,6 +16,14 @@ function formatProbability(value) {
   return value.toFixed(2).replace(/0+$/, '').replace(/\.$/, '');
 }
 
+function formatProbabilityFixed(value) {
+  return value.toFixed(2);
+}
+
+function formatSignedProbability(value) {
+  return `${value >= 0 ? '+' : '-'}${Math.abs(value).toFixed(2)}`;
+}
+
 describe('forecast integrity and provenance surfaces', () => {
   it('labels simulation path confidence separately from event probability', () => {
     const src = read('src/components/ForecastPanel.ts');
@@ -55,6 +63,13 @@ describe('forecast integrity and provenance surfaces', () => {
     const docs = read('docs/panels/forecast.mdx');
     const seeder = read('scripts/seed-forecasts.mjs');
     const cyberProbMax = parseNumericConst(seeder, 'CYBER_PROB_MAX');
+    const conflictBaseMax = parseNumericConst(seeder, 'CONFLICT_BASE_DETECTOR_PROB_MAX');
+    const ucdpConflictZoneMax = parseNumericConst(seeder, 'UCDP_CONFLICT_ZONE_PROB_MAX');
+    const velocitySpikeLift = parseNumericConst(seeder, 'VELOCITY_SPIKE_PROBABILITY_LIFT');
+    const velocitySpikeMax = parseNumericConst(seeder, 'VELOCITY_SPIKE_PROBABILITY_MAX');
+    const defensePressureLift = parseNumericConst(seeder, 'DEFENSE_DIRECT_CONFIRMATION_PRESSURE_LIFT');
+    const defenseConfidenceLift = parseNumericConst(seeder, 'DEFENSE_DIRECT_CONFIRMATION_CONFIDENCE_LIFT');
+    const defenseAbsentConfidencePenalty = parseNumericConst(seeder, 'DEFENSE_ABSENT_CONFIRMATION_CONFIDENCE_PENALTY');
 
     assert.doesNotMatch(docs, /probability-calibrated/);
     assert.match(docs, /deterministic, rule-based signal detectors/);
@@ -63,7 +78,23 @@ describe('forecast integrity and provenance surfaces', () => {
     assert.match(docs, /OpenRouter `google\/gemini-2\.5-flash`/);
     assert.match(docs, /market-calibrated only when/);
     assert.match(docs, /calibration: null/);
-    assert.match(docs, /Conflict base detector probability ceiling \| 0\.90/);
+    assert.doesNotMatch(docs, /Conflict base detector probability ceiling \| 0\.90/);
+    assert.ok(
+      docs.includes(`| Conflict base detector probability ceiling (before velocity spike) | ${formatProbabilityFixed(conflictBaseMax)} |`),
+      `forecast panel doc must disclose conflict base detector cap from CONFLICT_BASE_DETECTOR_PROB_MAX=${conflictBaseMax}`,
+    );
+    assert.ok(
+      docs.includes(`| UCDP conflict-zone base probability ceiling (before velocity spike) | ${formatProbabilityFixed(ucdpConflictZoneMax)} |`),
+      `forecast panel doc must disclose UCDP conflict-zone cap from UCDP_CONFLICT_ZONE_PROB_MAX=${ucdpConflictZoneMax}`,
+    );
+    assert.ok(
+      docs.includes(`| Conflict velocity-spike override ceiling | ${formatProbabilityFixed(velocitySpikeMax)} |`),
+      `forecast panel doc must disclose velocity-spike ceiling from VELOCITY_SPIKE_PROBABILITY_MAX=${velocitySpikeMax}`,
+    );
+    assert.ok(
+      docs.includes(`adds a \`${formatSignedProbability(velocitySpikeLift)}\` probability override after the base cap`),
+      `forecast panel doc must disclose velocity-spike lift from VELOCITY_SPIKE_PROBABILITY_LIFT=${velocitySpikeLift}`,
+    );
     assert.match(docs, /Market probability ceiling \| 0\.85/);
     assert.match(docs, /Supply-chain \/ maritime probability ceiling \| 0\.85/);
     assert.match(docs, /GPS supply-chain detector probability ceiling \| 0\.60/);
@@ -73,6 +104,14 @@ describe('forecast integrity and provenance surfaces', () => {
     assert.match(seeder, /Math\.min\(CYBER_PROB_MAX,/);
     assert.match(docs, /Market-bucket scenario calibration is an editorial calibration layer/);
     assert.match(docs, /Defense.*0\.12/);
+    assert.ok(
+      docs.includes(`each unit of direct \`defense_repricing\` confirmation adds \`${formatSignedProbability(defensePressureLift)}\` pressure and \`${formatSignedProbability(defenseConfidenceLift)}\` confidence`),
+      'forecast panel doc must disclose direct defense_repricing pressure and confidence lifts',
+    );
+    assert.ok(
+      docs.includes(`confidence subtracts a separate \`${formatProbabilityFixed(defenseAbsentConfidencePenalty)}\` absence penalty`),
+      'forecast panel doc must distinguish the extra confidence penalty from the table-driven pressure dampener',
+    );
     assert.match(docs, /1% floor and 95% cap/);
     assert.match(seeder, /const PROJECTION_PROBABILITY_FLOOR = 0\.01;/);
     assert.match(seeder, /const PROJECTION_PROBABILITY_CAP = 0\.95;/);

--- a/tests/forecast-integrity-provenance.test.mjs
+++ b/tests/forecast-integrity-provenance.test.mjs
@@ -24,6 +24,10 @@ function formatSignedProbability(value) {
   return `${value >= 0 ? '+' : '-'}${Math.abs(value).toFixed(2)}`;
 }
 
+function countMatches(source, pattern) {
+  return [...source.matchAll(pattern)].length;
+}
+
 describe('forecast integrity and provenance surfaces', () => {
   it('labels simulation path confidence separately from event probability', () => {
     const src = read('src/components/ForecastPanel.ts');
@@ -102,6 +106,13 @@ describe('forecast integrity and provenance surfaces', () => {
     assert.match(docs, /Military probability ceiling \| 0\.90/);
     assert.match(docs, /Infrastructure probability ceiling \| 0\.85/);
     assert.match(seeder, /Math\.min\(CYBER_PROB_MAX,/);
+    assert.match(seeder, /Math\.min\(CONFLICT_BASE_DETECTOR_PROB_MAX,/);
+    assert.match(seeder, /Math\.min\(UCDP_CONFLICT_ZONE_PROB_MAX,/);
+    assert.equal(
+      countMatches(seeder, /Math\.min\(VELOCITY_SPIKE_PROBABILITY_MAX,\s*prob \+ VELOCITY_SPIKE_PROBABILITY_LIFT\)/g),
+      2,
+      'forecast seeder must apply the shared velocity-spike max/lift in both conflict detectors',
+    );
     assert.match(docs, /Market-bucket scenario calibration is an editorial calibration layer/);
     assert.match(docs, /Defense.*0\.12/);
     assert.ok(


### PR DESCRIPTION
## Summary

- Document conflict and UCDP base caps separately from the EMA velocity-spike override ceiling.
- Extract forecast provenance calibration literals to named seeder constants without changing scoring behavior.
- Harden the forecast provenance guard so docs derive cap, spike, and defense calibration disclosures from code constants.

## Validation

- npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/forecast-integrity-provenance.test.mjs
- npm_config_cache=/tmp/worldmonitor-npm-cache npx markdownlint-cli2 docs/panels/forecast.mdx
- git diff --check
- Pre-push hook passed through typecheck, API typecheck, boundary checks, safe HTML, rate-limit policies, premium-fetch parity, changed forecast test, markdown lint, MDX lint, proto skip, pro-test skip, and version sync before the first push attempt failed only on DNS resolving github.com.