### PR TITLE
Clarify API key alias docs and skill key guard

### DIFF
--- a/docs/usage-auth.mdx
+++ b/docs/usage-auth.mdx
@@ -23,7 +23,7 @@ Some endpoints explicitly reject anonymous browser session cookies and require a
 - `/api/widget-agent`
 - Vendor / partner endpoints
 
-For these, you **must** send `X-WorldMonitor-Key`.
+For these, you **must** send an API key; `X-WorldMonitor-Key` is the canonical header.
 
 ## Browser session mode
 
@@ -53,7 +53,7 @@ X-WorldMonitor-Key: wm_0123456789abcdef0123456789abcdef01234567
 
 User-issued keys are exactly `wm_` followed by 40 lowercase hex characters. Enterprise keys are opaque operator-issued strings and are only distributed out of band. Keep keys out of client-side code — use a server-side proxy if you need to call from the browser to a `forceKey` endpoint.
 
-`X-WorldMonitor-Key` is the canonical header. Gateway-backed API-key routes also accept `X-Api-Key` as an alias for compatibility with generic API clients.
+`X-WorldMonitor-Key` is the canonical header. API-key-authenticated endpoints also accept `X-Api-Key` as an alias for compatibility with generic API clients, including standalone edge functions that use `validateApiKey()` and gateway-backed routes.
 
 ### Server-side validation
 

--- a/tests/agent-skills-index.test.mjs
+++ b/tests/agent-skills-index.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { execFileSync } from 'node:child_process';
-import { readFileSync, readdirSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -103,7 +103,9 @@ describe('agent readiness: agent-skills index', () => {
     const hexKey = /wm_[0-9a-f]{40}/;
     const stalePrefixes = /wm_live_|wm_pro_/;
     for (const name of listSkillDirs()) {
-      const skill = readFileSync(join(SKILLS_DIR, name, 'SKILL.md'), 'utf-8');
+      const skillPath = join(SKILLS_DIR, name, 'SKILL.md');
+      assert.ok(existsSync(skillPath), `${name}/SKILL.md missing`);
+      const skill = readFileSync(skillPath, 'utf-8');
       assert.match(skill, hexKey, `${name} must show the current user API-key shape`);
       assert.doesNotMatch(skill, stalePrefixes, `${name} must not teach stale API-key prefixes`);
     }

--- a/tests/agent-skills-index.test.mjs
+++ b/tests/agent-skills-index.test.mjs
@@ -41,6 +41,13 @@ function assertInRange(value, min, max, fieldName) {
   );
 }
 
+function listSkillDirs() {
+  return readdirSync(SKILLS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort();
+}
+
 // Guards for the Agent Skills discovery manifest (#3310 / epic #3306).
 // Agents trust the index.json sha256 fields; if they drift from the
 // served SKILL.md bytes, every downstream verification check fails.
@@ -87,10 +94,7 @@ describe('agent readiness: agent-skills index', () => {
   });
 
   it('every SKILL.md directory is represented in the index (no orphans)', () => {
-    const dirs = readdirSync(SKILLS_DIR, { withFileTypes: true })
-      .filter((d) => d.isDirectory())
-      .map((d) => d.name)
-      .sort();
+    const dirs = listSkillDirs();
     const names = index.skills.map((s) => s.name).sort();
     assert.deepEqual(names, dirs, 'every skill directory must have an index entry');
   });
@@ -98,7 +102,7 @@ describe('agent readiness: agent-skills index', () => {
   it('public skills use the current wm_<40 hex> API-key shape', () => {
     const hexKey = /wm_[0-9a-f]{40}/;
     const stalePrefixes = /wm_live_|wm_pro_/;
-    for (const name of ['fetch-country-brief', 'fetch-resilience-score']) {
+    for (const name of listSkillDirs()) {
       const skill = readFileSync(join(SKILLS_DIR, name, 'SKILL.md'), 'utf-8');
       assert.match(skill, hexKey, `${name} must show the current user API-key shape`);
       assert.doesNotMatch(skill, stalePrefixes, `${name} must not teach stale API-key prefixes`);


### PR DESCRIPTION
## Summary
- clarify that X-WorldMonitor-Key is canonical while X-Api-Key is accepted as an alias on API-key-authenticated endpoints, including standalone validateApiKey edge functions and gateway-backed routes
- update the agent-skills key-shape guard to iterate all present public skill directories instead of hardcoding the current two skills

## Validation
- npx tsx --test tests/agent-skills-index.test.mjs
- npx markdownlint-cli2 docs/usage-auth.mdx
- git push pre-push hook: typecheck, typecheck:api, changed test files, markdown lint, MDX lint, version sync