### PR TITLE
Align MCP JMESPath examples with fixtures

### DIFF
--- a/docs/mcp-jmespath.mdx
+++ b/docs/mcp-jmespath.mdx
@@ -241,7 +241,7 @@ Omit `limit: 0` for ordinary use: cache tools default-cap list- and map-shaped f
 
 ### 7. `length()` for counting
 
-**Intent.** How many UCDP events are in the latest bundle?
+**Intent.** How many UCDP events are in the default-capped latest bundle?
 
 **Tool call:**
 
@@ -257,10 +257,12 @@ Omit `limit: 0` for ordinary use: cache tools default-cap list- and map-shaped f
 **Projected response:**
 
 ```json
-38
+30
 ```
 
 **Why this works.** `length()` is one of JMESPath's built-in functions; it works on arrays, strings, and objects (where it returns the key count). Useful as a sanity check before a longer call — a `length()` projection returns a single integer, costs nothing in tokens, and tells the model whether the bundle is empty before deciding what to project next.
+
+Because this call omits `limit`, the tool-level default cap is applied before JMESPath, so the count is the capped candidate set (30). Pass `limit: 0` when you need to count the full underlying bundle instead.
 
 ---
 
@@ -388,7 +390,8 @@ This is the workhorse shape for "give me the top-N by some metric". The same sha
   { "risk": "critical", "count": 28  },
   { "risk": "critical", "count": 627 },
   { "risk": "critical", "count": 33  },
-  { "risk": "critical", "count": 735 }
+  { "risk": "critical", "count": 735 },
+  { "risk": "critical", "count": 274 }
 ]
 ```
 

--- a/tests/mcp-jmespath-doc-parity.test.mjs
+++ b/tests/mcp-jmespath-doc-parity.test.mjs
@@ -1,0 +1,50 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+
+function readJson(path) {
+  return JSON.parse(readFileSync(resolve(root, path), 'utf8'));
+}
+
+function readText(path) {
+  return readFileSync(resolve(root, path), 'utf8');
+}
+
+function section(doc, heading) {
+  const start = doc.indexOf(heading);
+  assert.notEqual(start, -1, `missing section heading: ${heading}`);
+  const next = doc.indexOf('\n### ', start + heading.length);
+  return doc.slice(start, next === -1 ? undefined : next);
+}
+
+describe('docs/mcp-jmespath.mdx fixture-backed examples', () => {
+  const doc = readText('docs/mcp-jmespath.mdx');
+
+  it('example 7 count matches the default-capped conflict-events fixture', () => {
+    const fixture = readJson('tests/fixtures/jmespath-samples/medium-get-conflict-events.response.json');
+    const count = fixture.data['ucdp-events'].events.length;
+    const example = section(doc, '### 7. `length()` for counting');
+
+    assert.equal(count, 30, 'fixture should represent the no-limit default cap');
+    assert.match(example, /```json\n30\n```/, 'example 7 projected response must match fixture count');
+    assert.match(example, /default cap is applied before JMESPath/, 'example 7 must disclose the pre-projection default cap');
+  });
+
+  it('example 11 critical chokepoint counts match the thin chokepoint fixture', () => {
+    const fixture = readJson('tests/fixtures/jmespath-samples/thin-get-chokepoint-status.response.json');
+    const summaries = fixture.data['transit-summaries'].summaries;
+    const counts = Object.values(summaries)
+      .filter((row) => row.riskLevel === 'critical')
+      .map((row) => row.incidentCount7d)
+      .sort((a, b) => a - b);
+    const example = section(doc, '### 11. Object-as-map projection');
+
+    assert.deepEqual(counts, [28, 33, 274, 627, 735]);
+    for (const count of counts) {
+      assert.match(example, new RegExp(`"count": ${count}\\b`), `example 11 must include critical count ${count}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- update MCP JMESPath example 7 to show the default-capped UCDP count and explain that the tool limit applies before projection
- add the missing critical Bosphorus chokepoint count to example 11
- add fixture-backed docs parity coverage for both examples

## Validation
- npx tsx --test tests/mcp-jmespath-doc-parity.test.mjs
- npx markdownlint-cli2 docs/mcp-jmespath.mdx
- npx tsx --test tests/mcp-tools-list-compression.test.mjs tests/mcp-resources.test.mjs tests/mcp-api-parity.test.mjs tests/mcp-jmespath.test.mjs tests/mcp-output-budget.test.mjs tests/mcp-output-schema-coverage.test.mjs tests/mcp-jmespath-doc-parity.test.mjs
- git diff --check
- git push pre-push hook: typecheck, typecheck:api, Convex type check, CJS syntax, Unicode, lint:boundaries, lint:safe-html, rate-limit policy, premium-fetch, edge bundle, changed tests, markdown lint, MDX lint, proto freshness, version check