### PR TITLE
Tighten news digest methodology parity

### DIFF
--- a/docs/methodology/news-digest-and-briefing.mdx
+++ b/docs/methodology/news-digest-and-briefing.mdx
@@ -187,12 +187,19 @@ briefs can read the same story pool.
 | `story:peak:v1:{titleHash}` | ZSet | Single `peak` member holding the highest score seen. | 7 days |
 | `digest:accumulator:v1:{variant}:{lang}` | ZSet | Story hashes by last-seen time for digest windows. | 48 hours |
 
-The story-track hash fields are:
+The story-track hash fields written today are:
 
-`firstSeen`, `lastSeen`, `mentionCount`, `sourceCount`, `currentScore`,
-`peakScore`, `title`, `link`, `severity`, `lang`, `description`,
-`publishedAt`, `entityCorroborationCount`, `isOpinion`, `isFeelGood`,
+`firstSeen`, `lastSeen`, `mentionCount`, `currentScore`, `title`, `link`,
+`severity`, `lang`, `description`, `publishedAt`,
+`entityCorroborationCount`, `isOpinion`, `isFeelGood`,
 `isEphemeralLiveCoverage`, and `category`.
+
+`sourceCount` is not stored in the story-track hash for current rows.
+Distinct feed names are written to `story:sources:v1:{titleHash}` with
+`SADD`; consumers that need the real source count must read the set and count
+it with `SCARD` or equivalent set cardinality. `peakScore` is likewise a
+reserved read-path placeholder in the story-track hash; the live peak score is
+kept in the `story:peak:v1:{titleHash}` ZSet.
 
 The title hash is a SHA-256 hash of a normalised title: lowercased, stripped
 of common publisher suffixes, stripped to Unicode letters/numbers/spaces,
@@ -325,14 +332,18 @@ The canonical digest prose and direct fallback `whyMatters` paths pin the
 provider chain to OpenRouter by skipping Ollama and Groq, so the live brief
 uses Gemini 2.5 Flash (`google/gemini-2.5-flash`) for those surfaces when the
 LLM layer is enabled. Digest prose and story-description calls use
-temperature `0.4`; the regional weekly brief provider chain uses temperature
-`0.3`. The digest prompt requires a named actor/event lead, bans generic
-editorial phrases such as "the global stage" and weak stitching phrases such
-as "this comes as" or "meanwhile", requires substantive linkage before a lead
-combines two stories, and validates cache hits and fresh outputs through the
-same shape and proper-noun grounding gate. Per-story prompts also require
-named actors where possible and can use the RSS description as grounding
-context.
+temperature `0.4`. Regional weekly briefs intentionally differ from those
+digest prose and `whyMatters` surfaces: `scripts/regional-snapshot/weekly-brief.mjs`
+tries Groq first with `llama-3.3-70b-versatile`, then falls back to
+OpenRouter `google/gemini-2.5-flash`, and sends both providers temperature
+`0.3` because the output is structured weekly JSON for regional snapshots
+rather than per-user digest prose. The digest prompt requires a named
+actor/event lead, bans generic editorial phrases such as "the global stage"
+and weak stitching phrases such as "this comes as" or "meanwhile", requires
+substantive linkage before a lead combines two stories, and validates cache
+hits and fresh outputs through the same shape and proper-noun grounding gate.
+Per-story prompts also require named actors where possible and can use the RSS
+description as grounding context.
 
 ## Bias Posture
 

--- a/server/_shared/cache-keys.ts
+++ b/server/_shared/cache-keys.ts
@@ -1,8 +1,12 @@
 // ── Story persistence tracking keys (E3) ─────────────────────────────────────
-// Hash: firstSeen, lastSeen, mentionCount, sourceCount, currentScore, peakScore,
+// Hash: firstSeen, lastSeen, mentionCount, currentScore,
 //       title, link, severity, lang, description, publishedAt,
 //       entityCorroborationCount, isOpinion, isFeelGood,
 //       isEphemeralLiveCoverage, category
+// sourceCount is not a hash field for current rows: distinct feed names live in
+// story:sources:v1 and should be counted from the Set. peakScore is held in
+// story:peak:v1's ZSet; the hash-side peakScore reader remains a reserved
+// placeholder for future score-history support.
 // description is authoritative per-mention: written unconditionally on every
 // HSET (empty string when the current mention has no body), so an earlier
 // mention's body never silently grounds LLMs for the current mention.
@@ -18,7 +22,7 @@ export const DIGEST_ACCUMULATOR_KEY_PREFIX = 'digest:accumulator:v1:';
  * Story tracking keys — written by list-feed-digest.ts, read by digest cron (E2).
  * All keys use 32-char SHA-256 hex prefix of the normalised title as ${titleHash}.
  *
- *   story:track:v1:${titleHash}     Hash   firstSeen/lastSeen/title/link/severity/mentionCount/currentScore/peakScore/lang/description/publishedAt/entityCorroborationCount/isOpinion/isFeelGood/isEphemeralLiveCoverage/category (always-written)
+ *   story:track:v1:${titleHash}     Hash   firstSeen/lastSeen/title/link/severity/mentionCount/currentScore/lang/description/publishedAt/entityCorroborationCount/isOpinion/isFeelGood/isEphemeralLiveCoverage/category (always-written)
  *   story:sources:v1:${titleHash}   Set    feed IDs (SADD per appearance)
  *   story:peak:v1:${titleHash}      ZSet   single member "peak", score = highest importanceScore (ZADD GT)
  *   digest:accumulator:v1:${variant}:${lang} ZSet  member=titleHash, score=lastSeen_ms (updated every appearance)

--- a/tests/news-digest-methodology-parity.test.mjs
+++ b/tests/news-digest-methodology-parity.test.mjs
@@ -122,6 +122,10 @@ const briefFilterSrc = readFileSync(
   resolve(repoRoot, 'shared/brief-filter.js'),
   'utf8',
 );
+const weeklyBriefSrc = readFileSync(
+  resolve(repoRoot, 'scripts/regional-snapshot/weekly-brief.mjs'),
+  'utf8',
+);
 const protoText = readFileSync(
   resolve(repoRoot, 'proto/worldmonitor/news/v1/list_feed_digest.proto'),
   'utf8',
@@ -261,6 +265,30 @@ function extractEntityCorroborationCap(src) {
   const match = body.match(/Math\.min\(\s*Math\.max\([^,]+,\s*0\s*\),\s*([0-9]+)\s*\)/);
   assert.ok(match, 'failed to locate entity corroboration source cap');
   return Number(match[1]);
+}
+
+function extractStoryTrackWriterFields(src) {
+  const body = extractFunctionBody(src, 'buildStoryTrackHsetFields');
+  const hsetFields = [...body.matchAll(/^\s*'([A-Za-z][A-Za-z0-9]*)',/gm)]
+    .map((m) => m[1]);
+  assert.ok(hsetFields.length > 0, 'failed to extract story-track HSET fields');
+
+  const writeStoryTrackingBody = extractFunctionBody(src, 'writeStoryTracking');
+  const commandFields = [...writeStoryTrackingBody.matchAll(
+    /\['(?:HSETNX|HINCRBY)',\s*trackKey,\s*'([A-Za-z][A-Za-z0-9]*)'/g,
+  )].map((m) => m[1]);
+  assert.ok(commandFields.includes('firstSeen'), 'failed to extract story-track HSETNX firstSeen field');
+  assert.ok(commandFields.includes('mentionCount'), 'failed to extract story-track HINCRBY mentionCount field');
+
+  return [...new Set([...hsetFields, ...commandFields])].sort();
+}
+
+function extractDocStoryTrackHashFields(text) {
+  const match = text.match(/The story-track hash fields written today are:\n\n([\s\S]*?)\n\n/);
+  assert.ok(match, 'failed to locate documented story-track hash field list');
+  return [...match[1].matchAll(/`([A-Za-z][A-Za-z0-9]*)`/g)]
+    .map((m) => m[1])
+    .sort();
 }
 
 function openApiDescription(schemaName, propertyName, nestedPropertyName) {
@@ -712,29 +740,29 @@ describe('news digest methodology parity', () => {
   });
 
   it('documents story-track fields and TTL split', () => {
-    const expectedFields = [
-      'firstSeen',
-      'lastSeen',
-      'mentionCount',
-      'sourceCount',
-      'currentScore',
-      'peakScore',
-      'title',
-      'link',
-      'severity',
-      'lang',
-      'description',
-      'publishedAt',
-      'entityCorroborationCount',
-      'isOpinion',
-      'isFeelGood',
-      'isEphemeralLiveCoverage',
-      'category',
-    ];
+    const expectedFields = extractStoryTrackWriterFields(digestSrc);
+    assert.deepEqual(extractDocStoryTrackHashFields(docText), expectedFields);
     for (const field of expectedFields) {
       assert.ok(cacheKeysSrc.includes(field), `cache-key contract comment must mention ${field}`);
       assertDocIncludes(`\`${field}\``, `story-track field ${field}`);
     }
+    for (const reservedField of ['sourceCount', 'peakScore']) {
+      const hashSummary = cacheKeysSrc.match(/^\/\/ Hash:[^\n]*(?:\n\/\/       [^\n]*)*/m)?.[0] ?? '';
+      const alwaysWrittenSummary = cacheKeysSrc.match(/story:track:v1:\$\{titleHash\}.*\(always-written\)/)?.[0] ?? '';
+      assert.ok(hashSummary.length > 0, 'failed to locate cache-key hash summary comment');
+      assert.ok(alwaysWrittenSummary.length > 0, 'failed to locate cache-key always-written summary comment');
+      assert.ok(
+        !hashSummary.includes(reservedField) && !alwaysWrittenSummary.includes(reservedField),
+        `cache-key contract comment must not list ${reservedField} as an always-written hash field`,
+      );
+      assertDocMatches(
+        new RegExp('`' + reservedField + '`[\\s\\S]*(?:not stored|reserved|placeholder|live .*? (?:Set|ZSet))'),
+        `story-track ${reservedField} caveat`,
+      );
+    }
+    assertDocIncludes('`story:sources:v1:{titleHash}` with\n`SADD`', 'story sources set write path');
+    assertDocIncludes('`SCARD`', 'story source-count set cardinality');
+    assertDocIncludes('`story:peak:v1:{titleHash}` ZSet', 'story peak score ZSet');
     assertDocIncludes('`story:track:v1:{titleHash}`', 'story track key');
     assertDocIncludes('7 days', 'story tracking TTL');
     assertDocIncludes('48 hours', 'digest accumulator TTL');
@@ -753,6 +781,31 @@ describe('news digest methodology parity', () => {
     assertDocMatches(
       /notification cron[\s\S]*more than 24 hours of silence[\s\S]*`fading`/,
       'digest read-path fading phase',
+    );
+  });
+
+  it('documents regional weekly brief provider chain separately from digest prose', () => {
+    const providerNames = [...weeklyBriefSrc.matchAll(/name:\s*'([^']+)'/g)]
+      .map((m) => m[1]);
+    const providerModels = [...weeklyBriefSrc.matchAll(/model:\s*'([^']+)'/g)]
+      .map((m) => m[1]);
+    const weeklyTemperature = extractNumericConst(weeklyBriefSrc, 'BRIEF_TEMPERATURE');
+
+    assert.deepEqual(providerNames, ['groq', 'openrouter']);
+    assert.deepEqual(providerModels, ['llama-3.3-70b-versatile', 'google/gemini-2.5-flash']);
+    assert.equal(weeklyTemperature, 0.3);
+
+    assertDocMatches(
+      /Regional weekly briefs[\s\S]*tr(?:y|ies) Groq first[\s\S]*`llama-3\.3-70b-versatile`[\s\S]*OpenRouter `google\/gemini-2\.5-flash`[\s\S]*temperature\s+`0\.3`/,
+      'regional weekly brief provider order, models, and temperature',
+    );
+    assertDocMatches(
+      /intentionally differ[\s\S]*digest prose and `whyMatters` surfaces/,
+      'regional weekly brief chain differs from digest prose and whyMatters',
+    );
+    assertDocMatches(
+      /provider chain to OpenRouter by skipping Ollama and Groq[\s\S]*`google\/gemini-2\.5-flash`/,
+      'digest prose and whyMatters OpenRouter-only posture',
     );
   });
 

--- a/tests/news-digest-methodology-parity.test.mjs
+++ b/tests/news-digest-methodology-parity.test.mjs
@@ -746,11 +746,11 @@ describe('news digest methodology parity', () => {
       assert.ok(cacheKeysSrc.includes(field), `cache-key contract comment must mention ${field}`);
       assertDocIncludes(`\`${field}\``, `story-track field ${field}`);
     }
+    const hashSummary = cacheKeysSrc.match(/^\/\/ Hash:[^\n]*(?:\n\/\/       [^\n]*)*/m)?.[0] ?? '';
+    const alwaysWrittenSummary = cacheKeysSrc.match(/story:track:v1:\$\{titleHash\}.*\(always-written\)/)?.[0] ?? '';
+    assert.ok(hashSummary.length > 0, 'failed to locate cache-key hash summary comment');
+    assert.ok(alwaysWrittenSummary.length > 0, 'failed to locate cache-key always-written summary comment');
     for (const reservedField of ['sourceCount', 'peakScore']) {
-      const hashSummary = cacheKeysSrc.match(/^\/\/ Hash:[^\n]*(?:\n\/\/       [^\n]*)*/m)?.[0] ?? '';
-      const alwaysWrittenSummary = cacheKeysSrc.match(/story:track:v1:\$\{titleHash\}.*\(always-written\)/)?.[0] ?? '';
-      assert.ok(hashSummary.length > 0, 'failed to locate cache-key hash summary comment');
-      assert.ok(alwaysWrittenSummary.length > 0, 'failed to locate cache-key always-written summary comment');
       assert.ok(
         !hashSummary.includes(reservedField) && !alwaysWrittenSummary.includes(reservedField),
         `cache-key contract comment must not list ${reservedField} as an always-written hash field`,
@@ -760,7 +760,7 @@ describe('news digest methodology parity', () => {
         `story-track ${reservedField} caveat`,
       );
     }
-    assertDocIncludes('`story:sources:v1:{titleHash}` with\n`SADD`', 'story sources set write path');
+    assertDocMatches(/`story:sources:v1:\{titleHash\}`[\s\S]*?`SADD`/, 'story sources set write path');
     assertDocIncludes('`SCARD`', 'story source-count set cardinality');
     assertDocIncludes('`story:peak:v1:{titleHash}` ZSet', 'story peak score ZSet');
     assertDocIncludes('`story:track:v1:{titleHash}`', 'story track key');


### PR DESCRIPTION
## Summary
- correct the news digest methodology story-track hash field list so sourceCount is documented as living in the story:sources set
- document the regional weekly brief provider/model chain separately from digest prose and whyMatters
- tighten the methodology parity guard to derive written story-track fields from HSET/HSETNX/HINCRBY writers and assert the weekly brief LLM constants

## Validation
- npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/news-digest-methodology-parity.test.mjs
- npm_config_cache=/tmp/worldmonitor-npm-cache npx markdownlint-cli2 docs/methodology/news-digest-and-briefing.mdx
- pre-push hook: npm run typecheck, npm run typecheck:api, Convex type check, CJS syntax check, Unicode safety check, lint:boundaries, lint:safe-html, Sentry coverage check, lint:rate-limit-policies, lint:premium-fetch, edge function bundle check, server handler tests, changed test files only, markdown lint, MDX lint, proto freshness check, pro-test bundle freshness check, version:check