### PR TITLE
docs: align residual public contract notes

### DIFF
--- a/docs/methodology/chokepoints.mdx
+++ b/docs/methodology/chokepoints.mdx
@@ -58,6 +58,13 @@ reported as zero flow.
 The `disrupted` boolean is separate from the color badge: it is true when each
 of the latest three individual days is below 85% of the same `baseline90d`.
 
+Each published flow estimate may also include live hazard context from
+`portwatch:disruptions:active:v1`. The seeder looks for the nearest active
+GDACS `RED` or `ORANGE` alert within 500 km of the supported chokepoint and
+surfaces it as `hazardAlertLevel` and `hazardAlertName`. This is annotation
+only: hazard enrichment does not change `currentMbd`, `flowRatio`, or the
+`disrupted` calculation.
+
 ## Score Badge
 
 The public `status` field on `ChokepointInfo` is a traffic-light score badge:

--- a/docs/panels/fsi.mdx
+++ b/docs/panels/fsi.mdx
@@ -37,6 +37,15 @@ Upstream KCFSI data is from the Federal Reserve Bank of Kansas City; EU FSI is
 from the ECB CISS `SS_CIN` daily series, the live successor to the legacy
 `SS_CI` series.
 
+EU FSI label buckets follow the seeded CISS value directly:
+
+| ECB CISS `SS_CIN` value | Label |
+|---:|---|
+| `< 0.2` | Low Stress |
+| `>= 0.2` and `< 0.4` | Moderate Stress |
+| `>= 0.4` and `< 0.6` | Elevated Stress |
+| `>= 0.6` | High Stress |
+
 ## Refresh cadence
 
 Weekly for KCFSI (published by KC Fed). EU FSI is seeded daily from the ECB

--- a/docs/scenario-engine.mdx
+++ b/docs/scenario-engine.mdx
@@ -30,7 +30,7 @@ The currently shipped types are:
 | `sanctions` | Targeted trade restrictions (e.g. Russia / Baltic grain suspension). |
 | `tariff_shock` | A sudden tariff action and its cost pass-through (e.g. US tariff escalation on electronics). |
 
-Each template declares the chokepoints it affects (IDs from the chokepoint registry), a duration in days, affected HS2 sectors, and a cost-shock multiplier. Run them as-is — there are no sliders in v1. The `ScenarioType` union leaves room for `infrastructure` and `pandemic` categories, but no templates of those types ship today.
+Each template declares the chokepoints it affects (IDs from the chokepoint registry), a duration in days, affected HS2 sectors, and a cost-shock multiplier. On the template-list wire shape, `affectedHs2: []` means all HS2 chapters (the registry stores that sentinel as `null`). Run templates as-is — there are no sliders in v1. The `ScenarioType` union leaves room for `infrastructure` and `pandemic` categories, but no templates of those types ship today.
 
 ## What you get back
 
@@ -38,7 +38,7 @@ A completed scenario returns:
 
 - **Affected chokepoints** — which ones go red on the map.
 - **Impact ranking** — the top affected seeded reporter countries by ISO-2, ordered by the worker's relative weighted impact score. `totalImpact` is not a currency amount.
-- **Sector scope** — the targeted HS2 chapters declared by the selected template. `affectedHs2: []` means all HS2 chapters; the worker does not compute a separate per-sector impact ranking in v1.
+- **Template echo** — the selected template's display name, duration, disruption percent, and cost-shock multiplier so clients can render the run without re-looking up the catalog. The status result does not repeat `affectedHs2`; read sector scope from `/list-scenario-templates`.
 - **A summary card** injected into the Supply Chain panel that stays visible until you deactivate the scenario.
 
 The UI is state-driven, not modal — activating a scenario sets a `scenarioState` on every map renderer (deck.gl, globe, SVG fallback) so chokepoint colors and country choropleths reflect the disruption until you deactivate. This is coordinated by `MapContainer.activateScenario` at `src/components/MapContainer.ts:1010`, which is explicitly PRO-gated.

--- a/scripts/seed-fear-greed.mjs
+++ b/scripts/seed-fear-greed.mjs
@@ -11,7 +11,7 @@ const FEAR_GREED_TTL = 64800; // 18h = 3x 6h interval
 
 const FRED_PREFIX = 'economic:fred:v1';
 
-// --- Yahoo Finance fetching (15 symbols, 150ms gaps) ---
+// --- Yahoo Finance fetching (22 symbols, 150ms gaps) ---
 const YAHOO_SYMBOLS = ['^GSPC','^VIX','^VIX9D','^VIX3M','^SKEW','GLD','TLT','HYG','SPY','RSP','DX-Y.NYB','XLK','XLF','XLE','XLV','XLY','XLP','XLI','XLB','XLU','XLRE','XLC'];
 
 async function fetchYahooSymbol(symbol) {

--- a/tests/chokepoint-flows-seed.test.mjs
+++ b/tests/chokepoint-flows-seed.test.mjs
@@ -103,6 +103,23 @@ describe('seed-chokepoint-flows.mjs exports', () => {
     assert.match(src, /0\.85/);
   });
 
+  it('enriches flow estimates with nearby active RED/ORANGE GDACS hazards within 500 km', () => {
+    assert.match(src, /const DISRUPTIONS_KEY = 'portwatch:disruptions:active:v1'/);
+    assert.match(src, /const HAZARD_RADIUS_KM = 500/);
+    assert.match(src, /ev\.alertLevel !== 'RED' && ev\.alertLevel !== 'ORANGE'/);
+    assert.match(src, /if \(!ev\.active\) continue/);
+    assert.match(src, /hazardAlertLevel: hazard\?\.alertLevel \?\? null/);
+    assert.match(src, /hazardAlertName: hazard\?\.eventName \?\? null/);
+  });
+
+  it('documents hazard enrichment as metadata-only flow annotation', () => {
+    const doc = readFileSync(resolve(root, 'docs/methodology/chokepoints.mdx'), 'utf-8');
+    assert.match(doc, /portwatch:disruptions:active:v1/);
+    assert.match(doc, /GDACS `RED` or `ORANGE` alert within 500 km/);
+    assert.match(doc, /hazardAlertLevel` and `hazardAlertName/);
+    assert.match(doc, /does not change `currentMbd`, `flowRatio`, or the\s+`disrupted` calculation/);
+  });
+
   it('wraps runSeed in isMain guard', () => {
     assert.match(src, /isMain.*=.*process\.argv/s);
     assert.match(src, /if\s*\(isMain\)/);

--- a/tests/market-methodology-doc-contracts.test.mjs
+++ b/tests/market-methodology-doc-contracts.test.mjs
@@ -47,9 +47,11 @@ function parseFsiBands(source) {
 }
 
 function parseEuCissBands(source) {
-  const matches = [...source.matchAll(/if\s*\(value\s*<\s*([0-9.]+)\)\s*return\s*'([^']+)'/g)]
+  const fnBody = source.match(/function classifyLabel\([^)]*\)\s*\{([^}]+)\}/)?.[1];
+  assert.ok(fnBody, 'classifyLabel function not found in EU FSI seeder');
+  const matches = [...fnBody.matchAll(/if\s*\(value\s*<\s*([0-9.]+)\)\s*return\s*'([^']+)'/g)]
     .map(([, upperExclusive, label]) => ({ upperExclusive, label }));
-  const fallback = source.match(/return\s*'([^']+)';\s*\}/);
+  const fallback = fnBody.match(/return\s*'([^']+)'/);
   assert.equal(matches.length, 3, 'expected three upper-bound EU CISS bands in seeder');
   assert.ok(fallback, 'expected fallback EU CISS band in seeder');
   return [...matches, { upperExclusive: null, label: fallback[1] }];

--- a/tests/market-methodology-doc-contracts.test.mjs
+++ b/tests/market-methodology-doc-contracts.test.mjs
@@ -46,6 +46,15 @@ function parseFsiBands(source) {
   return [...thresholdBands, { threshold: null, label: fallback[1] }];
 }
 
+function parseEuCissBands(source) {
+  const matches = [...source.matchAll(/if\s*\(value\s*<\s*([0-9.]+)\)\s*return\s*'([^']+)'/g)]
+    .map(([, upperExclusive, label]) => ({ upperExclusive, label }));
+  const fallback = source.match(/return\s*'([^']+)';\s*\}/);
+  assert.equal(matches.length, 3, 'expected three upper-bound EU CISS bands in seeder');
+  assert.ok(fallback, 'expected fallback EU CISS band in seeder');
+  return [...matches, { upperExclusive: null, label: fallback[1] }];
+}
+
 function compactComparisonWhitespace(text) {
   return text.replace(/\s+/g, '');
 }
@@ -56,6 +65,7 @@ describe('market and health methodology docs match source contracts', () => {
   const fearGreedProto = readRepo('proto/worldmonitor/market/v1/get_fear_greed_index.proto');
   const marketOpenApi = readRepo('docs/api/MarketService.openapi.yaml');
   const fsiPanelDoc = readRepo('docs/panels/fsi.mdx');
+  const fsiEuSeeder = readRepo('scripts/seed-fsi-eu.mjs');
   const diseaseMethodology = readRepo('docs/methodology/disease-alert-level.mdx');
 
   it('documents the current Fear & Greed data sources and derived inputs', () => {
@@ -64,6 +74,8 @@ describe('market and health methodology docs match source contracts', () => {
     const sectorEtfs = parseMomentumSectorEtfs(fearGreedSeeder);
     const yahooSymbols = new Set(parseYahooSymbols(fearGreedSeeder));
 
+    assert.equal(yahooSymbols.size, 22, 'Yahoo source universe should stay aligned with docs and seeder comment');
+    assert.match(fearGreedSeeder, /Yahoo Finance fetching \(22 symbols, 150ms gaps\)/);
     assert.ok(fearGreedDoc.includes(cnnEndpoint), `Fear & Greed doc must include CNN endpoint ${cnnEndpoint}`);
     assert.doesNotMatch(fearGreedDoc, /graphdata\/\{date\}/);
     assert.match(fearGreedDoc, new RegExp(`AAII_Bull_Percentile = clamp\\(bull% / ${bull} \\* 100, 0, 100\\)`));
@@ -73,6 +85,7 @@ describe('market and health methodology docs match source contracts', () => {
       assert.ok(yahooSymbols.has(symbol), `sector RSI ETF ${symbol} should be fetched from Yahoo`);
     }
     assert.ok(fearGreedDoc.includes(`all ${sectorEtfs.length} GICS sector ETFs: ${sectorEtfs.join(', ')}`));
+    assert.ok(fearGreedDoc.includes(`Yahoo Finance | ${yahooSymbols.size} symbols`));
   });
 
   it('documents the bespoke Fear & Greed header FSI separately from the FSI panel', () => {
@@ -114,9 +127,19 @@ describe('market and health methodology docs match source contracts', () => {
   });
 
   it('documents EU FSI as the daily ECB SS_CIN successor series', () => {
+    const bands = parseEuCissBands(fsiEuSeeder);
+
     assert.match(fsiPanelDoc, /ECB CISS `SS_CIN` daily series/);
     assert.match(fsiPanelDoc, /EU FSI is seeded daily/);
     assert.match(fsiPanelDoc, /legacy\s+`SS_CI` series/);
     assert.doesNotMatch(fsiPanelDoc, /Weekly for both KCFSI.*EU FSI/);
+
+    for (const { upperExclusive, label } of bands) {
+      assert.ok(fsiPanelDoc.includes(`${label} Stress`), `FSI panel doc must include EU CISS band ${label}`);
+      if (upperExclusive != null) {
+        assert.ok(fsiPanelDoc.includes(`< ${upperExclusive}`), `FSI panel doc must include EU CISS cutoff < ${upperExclusive}`);
+      }
+    }
+    assert.ok(fsiPanelDoc.includes('>= 0.6'), 'FSI panel doc must include EU CISS High cutoff >= 0.6');
   });
 });


### PR DESCRIPTION
## Summary
- clarify Scenario Engine status results do not repeat affectedHs2 and keep the all-sector sentinel on template docs
- align Fear & Greed, EU FSI, and chokepoint hazard-enrichment public docs with seeded contracts
- add/tighten focused doc-contract guards for Yahoo symbol count, EU CISS bands, and chokepoint hazard metadata

## Validation
- npx --cache /tmp/codex-npm-cache tsx --test tests/market-methodology-doc-contracts.test.mjs
- npx --cache /tmp/codex-npm-cache tsx --test tests/chokepoint-flows-seed.test.mjs
- npx --cache /tmp/codex-npm-cache tsx --test tests/chokepoint-scenario-doc-parity.test.mjs
- npx --cache /tmp/codex-npm-cache markdownlint-cli2 docs/scenario-engine.mdx docs/panels/fsi.mdx docs/methodology/chokepoints.mdx
- git diff --check
- pre-push hook: typecheck, typecheck:api, boundary/safe-html/rate-limit/premium-fetch checks, changed tests, markdown lint, MDX lint, version check