### PR TITLE
fix(resilience): widen low-carbon content-age budget 36mo→60mo (interim, #4219)

### DIFF
--- a/scripts/seed-low-carbon-generation.mjs
+++ b/scripts/seed-low-carbon-generation.mjs
@@ -37,14 +37,16 @@ import iso3ToIso2 from './shared/iso3-to-iso2.json' with { type: 'json' };
 // Per-seeder budget lives below — same shape, different publication lags.
 import { wbCountryDictContentMeta } from './_wb-country-dict-content-age-helpers.mjs';
 
-// 36mo budget — verified against live WB API on 2026-05-05. This seeder now
-// publishes the latest common component year per country, not the max of
-// independently latest component years, so content-age is conservative for
-// the actual composite being scored. Steady-state ceiling for annual WB
-// indicators = max_publication_lag (~18mo) + cycle_length (12mo) = 30mo.
-// 36mo = 30mo ceiling + 6mo slack. Same math as power-reliability (#3602
-// review); see `_power-reliability-helpers.mjs` JSDoc for full derivation.
-const MAX_CONTENT_AGE_MIN = 36 * 30 * 24 * 60;
+// 60mo budget (INTERIM). The binding constraint is the latest COMMON component
+// year (min across NUCL/RNEW/HYRO), and one component (hydro/nuclear) is frozen
+// at 2021 in WB WDI — so the live composite is ~53mo old (verified 2026-06),
+// well past the original 36mo estimate. That 36mo assumed an ~18mo per-component
+// publication lag, which does NOT hold for the min-common-year composite when
+// one WB series stalls. 60mo clears the genuine WB lag while still tripping a
+// real regression (a 2020 freeze is ~64mo > 60mo). This is a STOPGAP: the
+// durable fix is migrating low-carbon generation to a fresher source (Ember/OWID,
+// which publish 2023+ electricity mix) and restoring a tight budget — issue #4219.
+const MAX_CONTENT_AGE_MIN = 60 * 30 * 24 * 60;
 
 loadEnvFile(import.meta.url);
 

--- a/tests/wb-country-dict-content-age.test.mjs
+++ b/tests/wb-country-dict-content-age.test.mjs
@@ -135,9 +135,9 @@ test('low-carbon: live-reality regression guard — frozen at 2021 (~53mo) stays
   );
 });
 
-test('low-carbon: catastrophic stall — max year 2020 (~64mo) trips STALE_CONTENT', () => {
+test('low-carbon: catastrophic stall — max year 2020 (~65mo) trips STALE_CONTENT', () => {
   // A regression below the known-frozen 2021 floor (e.g. the seeder picking an
-  // even older common year) must still alarm: 2020 is ~64mo > 60mo budget.
+  // even older common year) must still alarm: 2020 is ~65mo > 60mo budget.
   const data = { countries: { US: { value: 60.5, year: 2020 } } };
   const cm = wbCountryDictContentMeta(data, FIXED_NOW);
   const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;

--- a/tests/wb-country-dict-content-age.test.mjs
+++ b/tests/wb-country-dict-content-age.test.mjs
@@ -102,10 +102,13 @@ test('contentMeta excludes future-dated years beyond 1h clock-skew tolerance', (
 // run), (b) steady-state under budget (no false-positive mid-cycle when
 // next year publishes late but legitimately).
 
-const LOW_CARBON_BUDGET = 36 * 30 * 24 * 60;     // see seed-low-carbon-generation.mjs
+// INTERIM 60mo — the live min-common-year composite is frozen at 2021 (one of
+// NUCL/HYRO stalled in WB WDI), so the real content age is ~53mo, more than the
+// fossil-share lag. Durable fix tracked in issue #4219 (migrate to Ember/OWID).
+const LOW_CARBON_BUDGET = 60 * 30 * 24 * 60;     // see seed-low-carbon-generation.mjs
 const FOSSIL_BUDGET = 48 * 30 * 24 * 60;          // see seed-fossil-electricity-share.mjs
 
-test('low-carbon: fresh-arrival regression guard — max year 2024 (~17mo) within 36mo budget', () => {
+test('low-carbon: fresh-arrival regression guard — max year 2024 (~17mo) within 60mo budget', () => {
   // Payload year is the seeder's aligned per-country composite year. When
   // a country has common NUCL/RNEW/HYRO year 2024, that should remain within
   // the low-carbon content-age budget.
@@ -114,30 +117,33 @@ test('low-carbon: fresh-arrival regression guard — max year 2024 (~17mo) withi
   const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
   assert.ok(
     ageMin < LOW_CARBON_BUDGET,
-    `${Math.round(ageMin / 60 / 24 / 30)}mo < 36mo budget — fresh arrival within tolerance`,
+    `${Math.round(ageMin / 60 / 24 / 30)}mo < 60mo budget — fresh arrival within tolerance`,
   );
 });
 
-test('low-carbon: steady-state regression guard — max year 2023 (~29mo) within 36mo budget', () => {
-  // Just before NUCL/HYRO 2025 data publishes (legitimately late at
-  // L=18mo). Cache age = 29mo. 36mo budget = 30mo ceiling + 6mo slack
-  // (Sprint 4 PR #3602 review lesson).
-  const data = { countries: { US: { value: 60.5, year: 2023 } } };
+test('low-carbon: live-reality regression guard — frozen at 2021 (~53mo) stays within 60mo budget', () => {
+  // The bug the 60mo bump fixes: WB WDI's hydro/nuclear component is stuck at
+  // 2021, so the min-common-year composite is ~53mo old. Under the old 36mo
+  // budget this false-positived STALE_CONTENT every cron run even though 2021
+  // IS the latest WB publishes. Durable fix = issue #4219.
+  const data = { countries: { US: { value: 60.5, year: 2021 } } };
   const cm = wbCountryDictContentMeta(data, FIXED_NOW);
   const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
   assert.ok(
     ageMin < LOW_CARBON_BUDGET,
-    `${Math.round(ageMin / 60 / 24 / 30)}mo < 36mo budget — within steady-state ceiling`,
+    `${Math.round(ageMin / 60 / 24 / 30)}mo < 60mo budget — the frozen-2021 live state must not false-positive`,
   );
 });
 
-test('low-carbon: catastrophic stall — max year 2020 (~65mo) trips STALE_CONTENT', () => {
+test('low-carbon: catastrophic stall — max year 2020 (~64mo) trips STALE_CONTENT', () => {
+  // A regression below the known-frozen 2021 floor (e.g. the seeder picking an
+  // even older common year) must still alarm: 2020 is ~64mo > 60mo budget.
   const data = { countries: { US: { value: 60.5, year: 2020 } } };
   const cm = wbCountryDictContentMeta(data, FIXED_NOW);
   const ageMin = (FIXED_NOW - cm.newestItemAt) / 60000;
   assert.ok(
     ageMin > LOW_CARBON_BUDGET,
-    `${Math.round(ageMin / 60 / 24 / 30)}mo > 36mo budget — STALE_CONTENT correctly fires`,
+    `${Math.round(ageMin / 60 / 24 / 30)}mo > 60mo budget — STALE_CONTENT correctly fires`,
   );
 });
 
@@ -179,12 +185,14 @@ test('fossil-share: catastrophic stall — max year 2018 (~89mo) trips STALE_CON
   );
 });
 
-test('per-seeder budget separation: a 41mo cache trips low-carbon (36mo) but NOT fossil-share (48mo)', () => {
-  // Demonstrates why per-seeder budgets matter: a low-carbon cache stuck
-  // at 2022 for 41mo is a real stall (NUCL/HYRO normally publish 2024 by
-  // now), but a fossil-share cache stuck at 2022 is just normal
-  // steady-state (FOSL publishes ~30mo lag). Same age, different verdicts.
-  const ageMs41 = 41 * 30 * 24 * 60 * 60 * 1000;
-  assert.ok(ageMs41 / 60000 > LOW_CARBON_BUDGET, '41mo > low-carbon 36mo budget — trips');
-  assert.ok(ageMs41 / 60000 < FOSSIL_BUDGET, '41mo < fossil-share 48mo budget — does NOT trip');
+test('per-seeder budget separation: a 52mo cache trips fossil-share (48mo) but NOT low-carbon (60mo)', () => {
+  // Per-seeder budgets matter — and the ordering is the REVERSE of the original
+  // assumption. Low-carbon's binding min-common-year composite is frozen at 2021
+  // (one of NUCL/HYRO stalled in WB WDI), so it lags MORE than fossil-share
+  // (FOSL ~2023) and now carries the LARGER (interim) budget. A 52mo cache is a
+  // real stall for fossil-share but within low-carbon's tolerance. Same age,
+  // different verdicts. (Durable fix to shrink low-carbon's budget: issue #4219.)
+  const ageMs52 = 52 * 30 * 24 * 60 * 60 * 1000;
+  assert.ok(ageMs52 / 60000 > FOSSIL_BUDGET, '52mo > fossil-share 48mo budget — trips');
+  assert.ok(ageMs52 / 60000 < LOW_CARBON_BUDGET, '52mo < low-carbon 60mo budget — does NOT trip');
 });


### PR DESCRIPTION
## Summary

`/api/health.lowCarbonGeneration` reads **`STALE_CONTENT`** — content age ~**53 months** vs the 36-month budget.

**Genuine World Bank upstream lag, not a seeder bug.** `resilience:low-carbon-generation:v1` sums three WB electricity indicators (`EG.ELC.NUCL.ZS` + `RNEW.ZS` + `HYRO.ZS`) at their **latest common year**, which is **2021** (one component — hydro/nuclear — is frozen there in WB WDI). The seeder correctly picks the latest common year; 2021 *is* the newest WB publishes. The original 36mo budget assumed an ~18mo per-component lag that doesn't hold for the min-common-year composite when one series stalls.

## Change (interim stopgap)

- `scripts/seed-low-carbon-generation.mjs`: `MAX_CONTENT_AGE_MIN` 36mo → **60mo**. Clears the warn while still tripping a real regression (a 2020 freeze is ~64mo > 60mo).
- This **inverts** the low-carbon vs fossil-share budget ordering (low-carbon 60mo > fossil 48mo) because low-carbon genuinely lags *more* than fossil (FOSL ~2023). Tests updated to match.

## Tests

- `tests/wb-country-dict-content-age.test.mjs`: budget → 60mo; refreshed the boundary cases; **added a frozen-at-2021 (~53mo) regression guard** documenting why the bump exists; rewrote the per-seeder separation test for the inverted ordering (52mo trips fossil-48 but not low-carbon-60).
- Verified: content-age 15 ✓, seeder 3 ✓, resilience doc-parity/registry/energy-v2/power-reliability 84 ✓, seeder-content-age-coverage 4 ✓, typecheck ✓, lint ✓. (Pre-push gate passed.)

## Durable follow-up

This is a **stopgap** — it widens tolerance, it doesn't refresh the data. The real fix (migrate low-carbon generation to Ember/OWID, which publish 2023+ electricity mix, and restore a tight ~13–18mo budget) is tracked in **#4219**.