### PR TITLE
Clarify Strategic Risk display and API severity bands

### DIFF
--- a/docs/strategic-risk.mdx
+++ b/docs/strategic-risk.mdx
@@ -50,24 +50,31 @@ observations.
 
 ### Risk Levels
 
-The panel-visible headline label uses the same five display bands as the
-Country Instability Index:
+The browser panel and the server API intentionally expose two related but
+different level schemes for the same 0-100 headline score.
 
-| Score | Panel label | Meaning |
-|-------|-------------|---------|
-| 81-100 | **Critical** | Extreme global strategic pressure |
-| 66-80 | **High** | Multiple converging crises |
-| 51-65 | **Elevated** | Heightened global tension |
-| 31-50 | **Normal** | Watchful but below elevated pressure |
-| 0-30 | **Low** | Lower global strategic pressure |
+**Panel-visible display labels** use the same five CII-aligned bands as country
+risk rows:
 
-The server `StrategicRisk.level` enum remains a coarser API severity field:
+| Headline score | Panel label | Meaning |
+|----------------|-------------|---------|
+| >=81 | **Critical** | Active crisis or major escalation |
+| 66-80 | **High** | Significant instability requiring close monitoring |
+| 51-65 | **Elevated** | Above-normal activity patterns |
+| 31-50 | **Normal** | Baseline geopolitical activity |
+| &lt;31 | **Low** | Unusually quiet period |
 
-| Score | Server enum | Meaning |
-|-------|-------------|---------|
-| 70-100 | `SEVERITY_LEVEL_HIGH` | High API severity |
-| 40-69 | `SEVERITY_LEVEL_MEDIUM` | Medium API severity |
-| 0-39 | `SEVERITY_LEVEL_LOW` | Low API severity |
+**Server/on-wire enum labels** remain the three-tier `StrategicRisk.level`
+contract returned by `GetRiskScores`:
+
+| Headline score | `StrategicRisk.level` | Meaning |
+|----------------|-----------------------|---------|
+| 70-100 | `SEVERITY_LEVEL_HIGH` | Multiple converging crises |
+| 40-69 | `SEVERITY_LEVEL_MEDIUM` | Heightened global tension |
+| 0-39 | `SEVERITY_LEVEL_LOW` | Lower global strategic pressure |
+
+API clients should treat `StrategicRisk.level` as the server severity enum and
+the Strategic Risk panel label as a display mapping of `StrategicRisk.score`.
 
 ### Unified Alert System
 

--- a/tests/cii-docs-drift.test.mts
+++ b/tests/cii-docs-drift.test.mts
@@ -56,6 +56,8 @@ function parseStrategicRiskDisplayBands(source: string): Array<{ min: number; la
 function displayBandRows(bands: Array<{ min: number; label: string }>): Array<{ range: string; label: string }> {
   return bands.map((band, index) => {
     const upper = index === 0 ? 100 : bands[index - 1]!.min - 1;
+    if (index === 0) return { range: `>=${band.min}`, label: band.label };
+    if (band.min === 0) return { range: `&lt;${upper + 1}`, label: band.label };
     return { range: `${band.min}-${upper}`, label: band.label };
   });
 }
@@ -135,10 +137,13 @@ describe('CII docs drift guards', () => {
     );
   });
 
-  it('strategic risk doc publishes current server severity bands and roll-up', () => {
+  it('strategic risk doc publishes current panel display bands, server severity bands, and roll-up', () => {
     const doc = readFileSync(resolve(root, 'docs', 'strategic-risk.mdx'), 'utf8');
-    const panelSource = readFileSync(resolve(root, 'src/components/StrategicRiskPanel.ts'), 'utf8');
-    const serverSource = readFileSync(resolve(root, 'server/worldmonitor/intelligence/v1/get-risk-scores.ts'), 'utf8');
+    const panelSource = readFileSync(resolve(root, 'src', 'components', 'StrategicRiskPanel.ts'), 'utf8');
+    const serverSource = readFileSync(
+      resolve(root, 'server', 'worldmonitor', 'intelligence', 'v1', 'get-risk-scores.ts'),
+      'utf8',
+    );
     const scoreSection = markdownSection(doc, '### Server Score and Browser Fallback (0-100)');
     const riskLevels = markdownSection(doc, '### Risk Levels');
     const trendSection = markdownSection(doc, '### Trend Detection');
@@ -156,8 +161,8 @@ describe('CII docs drift guards', () => {
       /local\s+fallback/i,
       'strategic-risk doc must label the additive overview as browser/local fallback',
     );
-    assert.match(riskLevels, /panel-visible headline label/i);
-    assert.match(riskLevels, /server `StrategicRisk\.level` enum/i);
+    assert.match(riskLevels, /Panel-visible display labels/i);
+    assert.match(riskLevels, /Server\/on-wire enum labels/i);
     for (const { range, label } of displayBandRows(parseStrategicRiskDisplayBands(panelSource))) {
       assert.match(
         riskLevels,
@@ -230,8 +235,8 @@ describe('CII docs drift guards', () => {
     );
     assert.doesNotMatch(
       riskLevels,
-      /\*\*Moderate\*\*|50-69|30-49/,
-      'strategic-risk risk-level table must not retain old Moderate 70/50/30 semantics',
+      /70\/50\/30|50-69|30-49|\*\*Moderate\*\*/,
+      'strategic-risk risk-level tables must not retain old 70/50/30 display semantics',
     );
   });
 


### PR DESCRIPTION
## Summary
- Document the Strategic Risk panel-visible five-tier CII-aligned display labels separately from the server/on-wire three-tier StrategicRisk.level enum.
- Update the CII docs drift guard to validate the split against the panel and server source files instead of pinning the stale display table.
- Rebased directly onto current main after PR #4221 merged, leaving this PR as a two-file Strategic Risk docs/test follow-up with no stacked audit commits.

## Validation
- npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/cii-docs-drift.test.mts
- npm_config_cache=/tmp/worldmonitor-npm-cache npx tsx --test tests/mdx-lint.test.mjs
- git diff --check
- git push --force-with-lease pre-push hook (typecheck, API typecheck, boundary/safe-html/rate-limit/premium-fetch/bundle checks, changed tests, markdown/MDX lint, version sync)