### PR TITLE
Align chokepoint flow API descriptions

### DIFF
--- a/scripts/seed-wb-external-debt.mjs
+++ b/scripts/seed-wb-external-debt.mjs
@@ -17,7 +17,7 @@
 //   shortTermDebtPctGni = (DT.DOD.DSTC.CD / NY.GNP.MKTP.CD) * 100
 //
 // Coverage: ~125 LMICs (low- and middle-income countries). HIC are not
-// published by WB IDS — those countries fall through to the BIS LBS
+// published by WB IDS — those countries fall through to the BIS CBS
 // structural-exposure component in the resilience scorer (see
 // `scoreFinancialSystemExposure` in `_dimension-scorers.ts`).
 //

--- a/tests/chokepoint-scenario-doc-parity.test.mjs
+++ b/tests/chokepoint-scenario-doc-parity.test.mjs
@@ -180,6 +180,22 @@ describe('chokepoint methodology docs match scoring code', () => {
       assert.match(text, /top1 \* 0\.5 \+ top2 \* 0\.3 \+ top3 \* 0\.2/, `${label} must document the vulnerability formula`);
     }
   });
+
+  it('documents flow-estimate source and hazard fields on contract surfaces', () => {
+    for (const [label, text] of [
+      ['supply-chain proto', supplyChainProto],
+      ['SupplyChainService OpenAPI', supplyChainOpenApi],
+      ['bundled OpenAPI', bundledOpenApi],
+    ]) {
+      assert.match(text, /portwatch-dwt/i, `${label} must document the DWT-backed flow source`);
+      assert.match(text, /portwatch-counts/i, `${label} must document the count-backed flow source`);
+      assert.match(text, /GDACS/i, `${label} must document GDACS hazard enrichment`);
+      assert.match(text, /500 km/i, `${label} must document the hazard matching radius`);
+      assert.match(text, /RED/i, `${label} must document RED hazard alerts`);
+      assert.match(text, /ORANGE/i, `${label} must document ORANGE hazard alerts`);
+      assert.match(text, /empty string/i, `${label} must document the absent-hazard wire value`);
+    }
+  });
 });
 
 describe('scenario docs match worker scope and impact math', () => {

--- a/tests/chokepoint-scenario-doc-parity.test.mjs
+++ b/tests/chokepoint-scenario-doc-parity.test.mjs
@@ -187,13 +187,16 @@ describe('chokepoint methodology docs match scoring code', () => {
       ['SupplyChainService OpenAPI', supplyChainOpenApi],
       ['bundled OpenAPI', bundledOpenApi],
     ]) {
-      assert.match(text, /portwatch-dwt/i, `${label} must document the DWT-backed flow source`);
-      assert.match(text, /portwatch-counts/i, `${label} must document the count-backed flow source`);
-      assert.match(text, /GDACS/i, `${label} must document GDACS hazard enrichment`);
-      assert.match(text, /500 km/i, `${label} must document the hazard matching radius`);
-      assert.match(text, /RED/i, `${label} must document RED hazard alerts`);
-      assert.match(text, /ORANGE/i, `${label} must document ORANGE hazard alerts`);
-      assert.match(text, /empty string/i, `${label} must document the absent-hazard wire value`);
+      const flowEstimateContract = label === 'supply-chain proto'
+        ? extractProtoMessage(text, 'FlowEstimate')
+        : extractYamlSchema(text, label === 'bundled OpenAPI' ? 'worldmonitor_supply_chain_v1_FlowEstimate' : 'FlowEstimate');
+      assert.match(flowEstimateContract, /portwatch-dwt/i, `${label} must document the DWT-backed flow source`);
+      assert.match(flowEstimateContract, /portwatch-counts/i, `${label} must document the count-backed flow source`);
+      assert.match(flowEstimateContract, /GDACS/i, `${label} must document GDACS hazard enrichment`);
+      assert.match(flowEstimateContract, /configured radius/i, `${label} must document the hazard matching radius`);
+      assert.match(flowEstimateContract, /"RED"/, `${label} must document RED hazard alerts`);
+      assert.match(flowEstimateContract, /"ORANGE"/, `${label} must document ORANGE hazard alerts`);
+      assert.match(flowEstimateContract, /empty string/i, `${label} must document the absent-hazard wire value`);
     }
   });
 });


### PR DESCRIPTION
## Summary
- update the WB external-debt seed comment from BIS LBS to BIS CBS without renaming historical Redis keys
- add FlowEstimate proto comments for source and GDACS hazard fields
- regenerate SupplyChain and bundled OpenAPI specs, plus add a narrow parity guard

## Validation
- make generate
- node --test tests/chokepoint-scenario-doc-parity.test.mjs
- npm run docs:check
- git diff --check
- pre-push hook: typecheck, API typecheck, boundary/safe-html/rate-limit/premium-fetch guards, changed tests, markdown/MDX lint, proto freshness, version sync