### PR TITLE
fix(sentry): filter 4 triage noise classes (SQ/SP/RE) + mute handled RX

### DIFF
--- a/api/symbol-search.ts
+++ b/api/symbol-search.ts
@@ -175,12 +175,24 @@ export default async function handler(
       // backs off rather than treating it as a permanent failure.
       const status = resp.status === 429 ? 503 : 502;
       console.warn(`[symbol-search] Finnhub HTTP ${resp.status} for q="${q}"`);
-      captureSilentError(new Error(`Finnhub search HTTP ${resp.status}`), {
-        tags: { route: 'api/symbol-search', step: 'finnhub_fetch' },
-        extra: { q, finnhubStatus: resp.status },
-        level: 'warning',
-        ctx,
-      });
+      // Upstream gateway transients (502/503/504) are Finnhub-side infra blips —
+      // not our bug, not our quota, not our auth. Like the 422 skip above, the
+      // client already receives a 502/503 and backs off, so capturing each one
+      // only pages at warning on an unactionable transient (WORLDMONITOR-RE). A
+      // sustained Finnhub outage surfaces via uptime monitoring on the 5xx the
+      // client sees. Auth failures (401/403 = our API key broke / Finnhub-side
+      // misconfig) and 429 (quota — actionable: bump the plan) still capture so a
+      // real regression isn't silently swallowed.
+      const isUpstreamGatewayTransient =
+        resp.status === 502 || resp.status === 503 || resp.status === 504;
+      if (!isUpstreamGatewayTransient) {
+        captureSilentError(new Error(`Finnhub search HTTP ${resp.status}`), {
+          tags: { route: 'api/symbol-search', step: 'finnhub_fetch' },
+          extra: { q, finnhubStatus: resp.status },
+          level: 'warning',
+          ctx,
+        });
+      }
       return jsonResponse({ error: 'SYMBOL_SEARCH_UNAVAILABLE' }, status, cors);
     }
     const data = (await resp.json()) as { result?: FinnhubSearchResult[] };

--- a/src/main.ts
+++ b/src/main.ts
@@ -615,8 +615,13 @@ Sentry.init({
     // stack as the CALLER, not the source. Gate on the presence of a deck-stack /
     // maplibre vendor frame so a genuine first-party SyntaxError elsewhere still
     // surfaces (WORLDMONITOR-SP).
+    // `(?:SyntaxError: )?` mirrors the EOF/token gates above (lines 588, 601):
+    // some engines embed the exception type in the `value` field, so `msg` can be
+    // either `Invalid or unexpected token` or `SyntaxError: Invalid or unexpected
+    // token`. Anchoring without the optional prefix would let the prefixed variant
+    // slip through here despite the first-party `MapContainer` frame (Greptile P2).
     if (excType === 'SyntaxError'
-        && /^(?:Invalid or unexpected token|Unexpected (?:token|keyword|identifier|EOF|end of script))/.test(msg)
+        && /^(?:SyntaxError: )?(?:Invalid or unexpected token|Unexpected (?:token|keyword|identifier|EOF|end of script))/.test(msg)
         && frames.some(f => /\/(?:maplibre|deck-stack)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
     return event;
   },

--- a/src/main.ts
+++ b/src/main.ts
@@ -126,6 +126,7 @@ Sentry.init({
     /Unexpected end of script/,
     /Style is not done loading/,
     /Event `CustomEvent`.*captured as promise rejection/,
+    /Event `ProgressEvent`.*captured as promise rejection/, // resource/XHR `error` ProgressEvent leaking via onunhandledrejection (img/script/audio/EventSource load failure). Our IDB/worker/FileReader onerror handlers all reject with wrapped Errors (never a raw ProgressEvent); the only XHR caller is fire-and-forget + Tauri-desktop-only where Sentry is disabled — so a raw ProgressEvent rejection can never originate from our bundle. Sibling of the CustomEvent entry above — WORLDMONITOR-SQ
     /getProgramInfoLog/,
     /__firefox__/,
     /ifameElement\.contentDocument/,
@@ -604,6 +605,19 @@ Sentry.init({
       || /Connection lost while action was in flight/.test(msg)
       || /WEBGLRenderPipeline.*Link error/.test(msg)
     )) return null;
+    // `SyntaxError: Invalid or unexpected token` (and the Unexpected token/keyword/EOF
+    // family) surfacing THROUGH the deck.gl/maplibre WebGL init path. Our compiled,
+    // already-parsed bundle cannot emit a JS parse error at the first-party
+    // `MapContainer.initDeck` call site — a runtime SyntaxError here means deck.gl /
+    // maplibre parsed external content (a Worker script, a `new Function` shader
+    // builder, or a stale/corrupt lazily-loaded chunk after a deploy). The
+    // `!hasFirstParty` token-parse gate above misses this because `initDeck` rides the
+    // stack as the CALLER, not the source. Gate on the presence of a deck-stack /
+    // maplibre vendor frame so a genuine first-party SyntaxError elsewhere still
+    // surfaces (WORLDMONITOR-SP).
+    if (excType === 'SyntaxError'
+        && /^(?:Invalid or unexpected token|Unexpected (?:token|keyword|identifier|EOF|end of script))/.test(msg)
+        && frames.some(f => /\/(?:maplibre|deck-stack)-[A-Za-z0-9_-]+\.js/.test(f.filename ?? ''))) return null;
     return event;
   },
 });

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -38,6 +38,26 @@ assert.ok(tpMatch, 'THIRD_PARTY_FETCH_HOST_ALLOWLIST must be defined in src/main
 // eslint-disable-next-line no-new-func
 const beforeSend = new Function('event', `${tpMatch[0]}\n${fnBody}`);
 
+// Extract the `ignoreErrors` array literal so tests can assert which messages
+// Sentry's built-in (pre-beforeSend) filter drops. The array body contains
+// regex/string literals and `//` comments — all valid inside a JS array literal,
+// so it eval's directly. Closing token is the dedented `\n  ],`.
+const ieStart = mainSrc.indexOf('ignoreErrors: [');
+assert.ok(ieStart !== -1, 'ignoreErrors array must exist in src/main.ts');
+const ieEnd = mainSrc.indexOf('\n  ],', ieStart);
+assert.ok(ieEnd > ieStart, 'Failed to find ignoreErrors closing bracket');
+const ieBody = mainSrc.slice(ieStart + 'ignoreErrors: ['.length, ieEnd);
+// The body's final entry ends in a `//` comment with no trailing newline, so the
+// closing bracket must go on its own line or it gets swallowed by that comment.
+// eslint-disable-next-line no-new-func
+const ignoreErrors = new Function(`return [${ieBody}\n]`)();
+
+/** Mirror Sentry's ignoreErrors semantics: RegExp → test, string → substring. */
+function isIgnored(msg) {
+  return ignoreErrors.some(p =>
+    p instanceof RegExp ? p.test(msg) : typeof p === 'string' ? msg.includes(p) : false);
+}
+
 /** Helper to build a minimal Sentry event. */
 function makeEvent(value, type = 'Error', frames = []) {
   return {
@@ -795,4 +815,79 @@ describe('existing beforeSend filters', () => {
     assert.ok(beforeSend(event) !== null, '3+ char variable names must surface');
   });
 
+});
+
+// ─── WORLDMONITOR-SQ: ProgressEvent rejection ignoreErrors entry ──────────
+//
+// A raw DOM `ProgressEvent` (type=error) from a failed resource/XHR load that
+// leaks via onunhandledrejection. Sentry synthesizes the message
+// `Event `ProgressEvent` (type=error) captured as promise rejection`. No
+// first-party path rejects a promise with a raw ProgressEvent (our IDB/worker/
+// FileReader onerror handlers all reject wrapped Errors; the lone XHR caller is
+// fire-and-forget + Tauri-only where Sentry is disabled), so it goes in
+// ignoreErrors alongside the CustomEvent sibling.
+describe('ignoreErrors — ProgressEvent promise rejection (WORLDMONITOR-SQ)', () => {
+  const PROD_MSG = 'Event `ProgressEvent` (type=error) captured as promise rejection';
+  const progressEventPattern = ignoreErrors.find(
+    p => p instanceof RegExp && /ProgressEvent/.test(p.source));
+
+  it('defines a ProgressEvent ignore pattern', () => {
+    assert.ok(progressEventPattern, 'a /ProgressEvent/ ignoreErrors pattern must exist');
+  });
+
+  it('suppresses the exact production ProgressEvent rejection message', () => {
+    assert.ok(isIgnored(PROD_MSG), `ignoreErrors must drop: ${PROD_MSG}`);
+  });
+
+  it('is scoped to the rejection phrase, not a bare ProgressEvent reference', () => {
+    // Guards against an over-broad `/ProgressEvent/` that would mask a real
+    // first-party error merely mentioning the word.
+    assert.ok(!progressEventPattern.test('ProgressEvent fired during upload'),
+      'pattern must require the "captured as promise rejection" phrase');
+  });
+});
+
+// ─── WORLDMONITOR-SP: SyntaxError through the deck.gl/maplibre init path ───
+//
+// `SyntaxError: Invalid or unexpected token` (and the Unexpected token/EOF
+// family) surfacing through deck.gl/maplibre WebGL init. Our compiled bundle
+// can't emit a JS parse error at the first-party `MapContainer.initDeck` call
+// site — the parse failure is in vendor-loaded content (a Worker script, a
+// `new Function` shader builder, or a stale/corrupt lazy chunk). The pre-
+// existing `!hasFirstParty` token-parse gate misses it because `initDeck` rides
+// the stack as the caller, so this gate keys off a deck-stack/maplibre frame.
+describe('SyntaxError via deck.gl/maplibre init path (WORLDMONITOR-SP)', () => {
+  // Mirrors the real WORLDMONITOR-SP stack: deck-stack + maplibre vendor frames
+  // plus the first-party MapContainer.initDeck caller.
+  const mapInitStack = [
+    { filename: '/assets/deck-stack-Dq2qX5Bt.js', lineno: 1606, function: 'Go._getViews' },
+    { filename: '/assets/maplibre-BniwwzLw.js', lineno: 811, function: 'lo.addControl' },
+    { filename: '/assets/MapContainer-C6imt_dN.js', lineno: 1632, function: 'os.initDeck' },
+  ];
+
+  it('suppresses "Invalid or unexpected token" through the map init path despite a first-party initDeck frame', () => {
+    const event = makeEvent('Invalid or unexpected token', 'SyntaxError', mapInitStack);
+    assert.equal(beforeSend(event), null,
+      'deploy/asset parse failure through deck.gl/maplibre init must be suppressed');
+  });
+
+  it('suppresses the Safari "Unexpected EOF" variant through the same path', () => {
+    assert.equal(beforeSend(makeEvent('Unexpected EOF', 'SyntaxError', mapInitStack)), null);
+  });
+
+  it('does NOT suppress the same SyntaxError when no deck/maplibre frame is present', () => {
+    // A genuine first-party parse failure (no map vendor frame) must still surface.
+    const event = makeEvent('Invalid or unexpected token', 'SyntaxError', [
+      firstPartyFrame('/assets/panels-DzUv7BBV.js', 'loadTab'),
+    ]);
+    assert.ok(beforeSend(event) !== null,
+      'first-party SyntaxError without a map frame must reach Sentry');
+  });
+
+  it('does NOT suppress a non-SyntaxError TypeError that merely has a map frame', () => {
+    // Gate is scoped to excType === SyntaxError + the token-parse message family.
+    const event = makeEvent('something broke', 'TypeError', mapInitStack);
+    assert.ok(beforeSend(event) !== null,
+      'non-SyntaxError with a map frame must not be swept up by the SP gate');
+  });
 });

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -875,6 +875,15 @@ describe('SyntaxError via deck.gl/maplibre init path (WORLDMONITOR-SP)', () => {
     assert.equal(beforeSend(makeEvent('Unexpected EOF', 'SyntaxError', mapInitStack)), null);
   });
 
+  it('suppresses the type-prefixed value variant ("SyntaxError: Invalid or unexpected token")', () => {
+    // Some engines embed the exception type in the value field — the gate must
+    // tolerate the `SyntaxError: ` prefix like the sibling EOF/token gates do.
+    assert.equal(
+      beforeSend(makeEvent('SyntaxError: Invalid or unexpected token', 'SyntaxError', mapInitStack)),
+      null,
+    );
+  });
+
   it('does NOT suppress the same SyntaxError when no deck/maplibre frame is present', () => {
     // A genuine first-party parse failure (no map vendor frame) must still surface.
     const event = makeEvent('Invalid or unexpected token', 'SyntaxError', [

--- a/tests/symbol-search-sentry-capture.test.mts
+++ b/tests/symbol-search-sentry-capture.test.mts
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import { after, describe, it } from 'node:test';
+
+// ─── WORLDMONITOR-RE: symbol-search Sentry-capture policy ──────────────────
+//
+// PR #4233 made `api/symbol-search.ts` SKIP the `captureSilentError` call for
+// upstream gateway transients (502/503/504) — Finnhub-side infra blips that
+// were paging at `warning` on an unactionable transient — while STILL
+// capturing genuinely actionable failures (401/403 auth, 429 quota, other
+// 5xx like 500). This is the only behavioural change in the PR that wasn't
+// pinned by a test; the sibling SQ/SP fixes both have boundary tests.
+//
+// `captureSilentError` no-ops unless `_sentry-common.js` parsed a DSN in its
+// import-time `parseDsn()` IIFE (`if (!_envelopeUrl || !_key) return`), so we
+// activate a throwaway DSN BEFORE the handler's module graph is loaded — hence
+// the dynamic `import()` below, after the env writes. Each `*.test.mts` file
+// runs in its own `tsx --test` subprocess, so this DSN never leaks into the
+// statically-imported handler in `symbol-search.test.mts`.
+//
+// We observe the edge transport's envelope POST (the fire-and-forget delivery
+// `deliver()` fires at `_envelopeUrl`). The 401/403/429/500 cases double as a
+// POSITIVE CONTROL: if the DSN never activated, `envelopeHits` would be 0 and
+// those assertions fail loudly — so a 0-hit on a 502/503/504 case can never be
+// a silent false-pass.
+
+const TEST_KEY = 'wm-test-enterprise-key';
+
+// Set before the dynamic import so parseDsn() wires up the envelope transport.
+process.env.VITE_SENTRY_DSN = 'https://testpublickey@sentry.test/12345';
+process.env.WORLDMONITOR_VALID_KEYS = TEST_KEY;
+process.env.FINNHUB_API_KEY = 'test-key';
+// Leave UPSTASH_* unset: both the cache helpers and the rate limiter guard on
+// those vars and return early WITHOUT fetching, so Finnhub + the Sentry
+// envelope are the only two URLs the handler ever hits.
+
+// parseDsn() derives `${protocol}//${host}/api/${projectId}/envelope/` from the
+// DSN above → this prefix.
+const ENVELOPE_URL_PREFIX = 'https://sentry.test/api/12345/envelope';
+
+const { default: handler } = await import('../api/symbol-search.ts');
+
+const originalFetch = globalThis.fetch;
+after(() => { globalThis.fetch = originalFetch; });
+
+function makeReq(q = 'nvidia'): Request {
+  return new Request(
+    `https://worldmonitor.app/api/symbol-search?q=${encodeURIComponent(q)}`,
+    { headers: { 'X-WorldMonitor-Key': TEST_KEY } },
+  );
+}
+
+/**
+ * Drive the handler against a mocked Finnhub status and report how many Sentry
+ * envelope POSTs the edge transport fired, plus the client-facing status. A
+ * `ctx.waitUntil` collector lets us await the fire-and-forget delivery before
+ * asserting.
+ */
+async function runWithFinnhubStatus(finnhubStatus: number): Promise<{ envelopeHits: number; status: number }> {
+  let envelopeHits = 0;
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    if (url.startsWith(ENVELOPE_URL_PREFIX)) {
+      envelopeHits++;
+      return new Response('', { status: 200 });
+    }
+    if (url.includes('finnhub.io')) return new Response('upstream', { status: finnhubStatus });
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as typeof fetch;
+
+  const tasks: Array<Promise<unknown>> = [];
+  const res = await handler(makeReq(), { waitUntil: (p: Promise<unknown>) => { tasks.push(p); } });
+  await Promise.allSettled(tasks);
+  return { envelopeHits, status: res.status };
+}
+
+describe('symbol-search Sentry-capture policy (WORLDMONITOR-RE)', () => {
+  // ── Actionable failures STILL capture (also the DSN-activation control) ──
+  for (const finnhubStatus of [401, 403, 500]) {
+    it(`captures an actionable Finnhub ${finnhubStatus} and surfaces 502 to the client`, async () => {
+      const { envelopeHits, status } = await runWithFinnhubStatus(finnhubStatus);
+      assert.equal(envelopeHits, 1, `Finnhub ${finnhubStatus} (auth/server error) must reach Sentry`);
+      assert.equal(status, 502);
+    });
+  }
+
+  it('captures a Finnhub 429 (quota — actionable: bump the plan) and maps it to client 503', async () => {
+    const { envelopeHits, status } = await runWithFinnhubStatus(429);
+    assert.equal(envelopeHits, 1, 'quota exhaustion must reach Sentry');
+    assert.equal(status, 503);
+  });
+
+  // ── The fix: upstream gateway transients are NOT captured ──
+  for (const finnhubStatus of [502, 503, 504]) {
+    it(`skips capture for upstream gateway transient ${finnhubStatus}`, async () => {
+      const { envelopeHits, status } = await runWithFinnhubStatus(finnhubStatus);
+      assert.equal(envelopeHits, 0, `gateway transient ${finnhubStatus} must NOT page Sentry (WORLDMONITOR-RE)`);
+      assert.equal(status, 502, 'client still receives 502 so it backs off and uptime monitoring fires');
+    });
+  }
+
+  it('skips capture for a malformed-query 422 (returns 400, user-input noise)', async () => {
+    const { envelopeHits, status } = await runWithFinnhubStatus(422);
+    assert.equal(envelopeHits, 0, '422 bad-query is user-input noise, not a Sentry-worthy upstream failure');
+    assert.equal(status, 400);
+  });
+});


### PR DESCRIPTION
## Summary

Daily Sentry triage surfaced **4 unresolved issues, all non-actionable noise** (zero bugs in our logic). Each is filtered at the correct layer so genuine first-party signal is preserved.

| Issue | Title | Vol | Fix |
|-------|-------|-----|-----|
| **SQ** | `ProgressEvent (type=error) captured as promise rejection` | 1ev/1u | `ignoreErrors` (browser) — mirrors the existing `CustomEvent` entry |
| **SP** | `SyntaxError: Invalid or unexpected token` via deck.gl/maplibre init | 1ev/1u | `beforeSend` gate (browser) keyed off a deck-stack/maplibre frame |
| **RE** | `Finnhub search HTTP 502` (edge) | 9ev/3u | skip capture for upstream 502/503/504 at call site |
| **RX** | Upstash Lua `execution timed out` (edge) | 54ev/54u | **no code change** — already absorbed by #3964; muted in Sentry |

### Why these are noise (not bugs)

- **SQ** — a raw DOM `ProgressEvent` (resource/XHR load error) leaking via `onunhandledrejection`. No first-party path rejects a promise with a raw `ProgressEvent`: our IDB/worker/`FileReader` `onerror` handlers all reject **wrapped Errors**, and the lone `XMLHttpRequest` caller (`breaking-news-alerts.ts`) is fire-and-forget + Tauri-desktop-only, where Sentry is disabled. Safe for `ignoreErrors` (message-only match), alongside the existing `CustomEvent` sibling.
- **SP** — a runtime `SyntaxError` surfacing through the deck.gl/maplibre WebGL init path (`MapContainer.initDeck → addControl → deck _getViews`). Our pre-parsed bundle cannot emit a parse error at the `initDeck` call site — the failure is in vendor-loaded content (a Worker script, a `new Function` shader builder, or a stale/corrupt lazy chunk after a deploy). The pre-existing `!hasFirstParty` token-parse gate **misses it** because `MapContainer-*.js` is classified first-party and rides the stack as the caller, so the new gate keys off a `deck-stack`/`maplibre` vendor frame being present.
- **RE** — a transient upstream Finnhub gateway blip. The edge runtime has **no `ignoreErrors`/`beforeSend` layer** (errors are captured via explicit `captureSilentError` calls), so the fix is a call-site skip mirroring the existing 422 skip in the same file. **401/403 (auth) and 429 (quota) still capture** so a real regression isn't swallowed; a sustained Finnhub outage surfaces via uptime monitoring on the 5xx the client already receives.
- **RX** — Upstash's Lua limiter script timing out under fan-out load. Already handled by #3964 (`rateLimitErrorLevel()` downgrades it to `warning`, the limiter fails open so users are unaffected). The live event is already `level: warning`, confirming the fix shipped. Muted in Sentry with an escalation threshold (re-alert if >150 in 60 min) rather than resolved, because it recurs daily and `resolve/inNextRelease` would reopen it on every deploy.

## Test plan

- [x] `npm run typecheck` + `typecheck:api` — PASS
- [x] `npm run lint` (biome + safe-html) — PASS
- [x] `npm run test:data` — **11024 pass / 0 fail** (includes +7 new cases)
- [x] edge bundle check (19 `api/*.js`) — PASS
- [x] `node --test tests/edge-functions.test.mjs` — 204/0
- [x] `npm run lint:md` + `version:check` — PASS

New tests in `tests/sentry-beforesend.test.mjs`: ProgressEvent ignore-pattern matching (incl. scoping guard), SP gate suppress/surface boundaries, and an `ignoreErrors` array extractor.

Sentry issues already updated via API: SQ/SP/RE resolved (next release), RX muted.