### PR TITLE
fix(billing): surface Dodo portal-create failures as structured ConvexError

### DIFF
--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -109,10 +109,32 @@ async function createCustomerPortalUrlForUser(
   }
 
   const client = getDodoClient();
-  const session = await client.customers.customerPortal.create(
-    dodoCustomerId,
-    { send_email: false },
-  );
+  let session;
+  try {
+    session = await client.customers.customerPortal.create(
+      dodoCustomerId,
+      { send_email: false },
+    );
+  } catch (err) {
+    // The Dodo REST SDK throws a plain Error (APIError on a non-2xx Dodo
+    // response, or a transport failure) when the portal-session create
+    // fails. Convex's action runtime then masks any NON-ConvexError throw
+    // as an opaque `[Request ID: X] Server Error`, dropping the real cause
+    // from the wire — the exact opacity WORLDMONITOR-R5 fought for the
+    // missing-customer path above (this was the last unwrapped throw site).
+    // Re-throw as a structured ConvexError so the client receives
+    // `err.data.kind === 'DODO_PORTAL_ERROR'` for proper Sentry
+    // classification (browser → `extractBillingErrorKind` → tag
+    // `billing_error_kind`; the user still falls back to the generic Dodo
+    // portal), and log the underlying cause here so it survives in the
+    // Convex function logs for server-side triage. WORLDMONITOR-ST.
+    const cause = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[billing] Dodo customer-portal create failed for customer ${dodoCustomerId}:`,
+      cause,
+    );
+    throw new ConvexError({ kind: "DODO_PORTAL_ERROR" });
+  }
 
   return { portal_url: session.link };
 }

--- a/src/services/_billing-error.ts
+++ b/src/services/_billing-error.ts
@@ -4,7 +4,7 @@
  * Mirrors the edge-runtime `extractConvexErrorKind` helper in
  * `api/_convex-error.js`, scoped to the data shapes this Convex action
  * produces: `{ kind: 'NO_CUSTOMER' | 'DODO_API_KEY_MISSING' |
- * 'USER_ID_REQUIRED' }`.
+ * 'USER_ID_REQUIRED' | 'DODO_PORTAL_ERROR' }`.
  *
  * Zero deps so it can be unit-tested from `node --test` without pulling
  * the rest of `src/services/billing.ts`' browser-only import graph

--- a/tests/billing-convex-error.test.mts
+++ b/tests/billing-convex-error.test.mts
@@ -39,6 +39,18 @@ describe('extractBillingErrorKind — structured-data path', () => {
     assert.equal(extractBillingErrorKind(err), 'USER_ID_REQUIRED');
   });
 
+  it('reads DODO_PORTAL_ERROR from err.data.kind', () => {
+    // WORLDMONITOR-ST: the Dodo portal-create call used to throw a plain
+    // Error, which Convex masked as an opaque `[Request ID: X] Server
+    // Error` (err.data === undefined → unclassified error-level capture).
+    // The action now re-throws `new ConvexError({ kind: 'DODO_PORTAL_ERROR' })`
+    // so the event buckets under a `billing_error_kind` Sentry tag.
+    const err = Object.assign(new Error('[Request ID: x] Server Error'), {
+      data: { kind: 'DODO_PORTAL_ERROR' },
+    });
+    assert.equal(extractBillingErrorKind(err), 'DODO_PORTAL_ERROR');
+  });
+
   it('returns null when err.data.kind is non-string', () => {
     const err = Object.assign(new Error(''), { data: { kind: 42 } });
     assert.equal(extractBillingErrorKind(err), null);


### PR DESCRIPTION
## Summary

Sentry triage fix for **WORLDMONITOR-ST** (`ConvexError: getCustomerPortalUrl … Server Error`).

The Dodo `customerPortal.create()` call in `getCustomerPortalUrl` was the **last unwrapped throw site** in `convex/payments/billing.ts`. When the Dodo REST SDK threw (non-2xx Dodo response or a transport failure), Convex's action runtime masked it as an opaque `[Request ID: X] Server Error` and dropped the real cause from the wire — the exact opacity the WORLDMONITOR-R5 work fought for the `NO_CUSTOMER` / `DODO_API_KEY_MISSING` paths right above it.

- Wrap the `customerPortal.create()` call and re-throw `ConvexError({ kind: 'DODO_PORTAL_ERROR' })`.
- Browser now receives `err.data.kind` → classified via `extractBillingErrorKind` → Sentry `billing_error_kind` tag (instead of an unclassified error-level capture).
- The underlying Dodo error is `console.error`-logged server-side so it survives in the Convex function logs for triage.
- **User behaviour unchanged**: the frontend still falls back to the generic Dodo portal (`DODO_PORTAL_FALLBACK_URL`). `extractBillingErrorKind` is generic so no helper change was needed.

### Sentry dispositions applied during triage (no code needed)
The other three open issues are already correctly handled in code — deliberate `warning`-level captures of transient external-system failures behind fail-open paths — so they were archived **until escalating** (auto-reopen on a real volume spike) rather than resolved:
- **WORLDMONITOR-QJ** — carousel render timeout (already downgraded to `warning`, fail-open 503, cron retries).
- **WORLDMONITOR-SR** — Convex `InternalServerError` on `setPreferences` (mapped to 503 + Retry-After, `warning`).
- **WORLDMONITOR-SS** — Convex `WorkerOverloaded` on `setPreferences` (same fail-open path).

## Test plan

- [x] `npm run typecheck` — PASS
- [x] `npm run typecheck:api` (+ Convex string-call audit) — PASS
- [x] `npm run lint` — PASS
- [x] `npm run test:data` — PASS
- [x] `node --test tests/billing-convex-error.test.mts` — 11/11 PASS (added `DODO_PORTAL_ERROR` case)
- [x] edge bundle check + `tests/edge-functions.test.mjs` — PASS
- [x] `npm run lint:md` + `npm run version:check` — PASS
- [ ] Post-deploy: confirm a future Dodo portal-create failure lands under `billing_error_kind: DODO_PORTAL_ERROR` with the real cause in Convex logs (the underlying Dodo failure could not be root-caused from the browser side — this fix preserves it for next time).