### PR TITLE
Remove loadAllData startup batch sleep

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -644,21 +644,15 @@ export class DataLoaderManager implements AppModule {
       tasks.push({ name: 'crossSourceSignals', task: runGuarded('crossSourceSignals', () => this.loadCrossSourceSignals()) });
     }
 
-    // Stagger startup: run tasks in small batches to avoid hammering upstreams
-    const BATCH_SIZE = 4;
-    const BATCH_DELAY_MS = 300;
-    for (let i = 0; i < tasks.length; i += BATCH_SIZE) {
-      const batch = tasks.slice(i, i + BATCH_SIZE);
-      const results = await Promise.allSettled(batch.map(t => t.task));
-      results.forEach((result, idx) => {
-        if (result.status === 'rejected') {
-          console.error(`[App] ${batch[idx]?.name} load failed:`, result.reason);
-        }
-      });
-      if (i + BATCH_SIZE < tasks.length) {
-        await new Promise(r => setTimeout(r, BATCH_DELAY_MS));
+    // Task promises are created above as soon as they are pushed. Await all
+    // guarded loads together; source-specific throttling belongs inside the
+    // individual loaders/services that actually touch constrained upstreams.
+    const results = await Promise.allSettled(tasks.map(t => t.task));
+    results.forEach((result, idx) => {
+      if (result.status === 'rejected') {
+        console.error(`[App] ${tasks[idx]?.name} load failed:`, result.reason);
       }
-    }
+    });
 
     this.updateSearchIndex();
 

--- a/tests/feed-date-ranking-uses-effective.test.mts
+++ b/tests/feed-date-ranking-uses-effective.test.mts
@@ -92,7 +92,7 @@ const ALLOW_LIST: AllowEntry[] = [
   },
   {
     file: 'src/app/data-loader.ts',
-    line: 3337,
+    line: 3331,
     reason: 'Cache serialization step — wraps pubDate.getTime() into the persisted entry payload, not a comparator.',
   },
 ];

--- a/tests/load-all-data-scheduling.test.mts
+++ b/tests/load-all-data-scheduling.test.mts
@@ -1,0 +1,45 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const REPO_ROOT = resolve(import.meta.dirname, '..');
+const DATA_LOADER_TS = readFileSync(resolve(REPO_ROOT, 'src/app/data-loader.ts'), 'utf8');
+
+function extractMethodBody(src: string, signature: string): string {
+  const signatureStart = src.indexOf(signature);
+  assert.ok(signatureStart >= 0, `could not find ${signature}`);
+
+  const bodyStart = src.indexOf('{', signatureStart);
+  assert.ok(bodyStart > signatureStart, `could not find body for ${signature}`);
+
+  let depth = 0;
+  for (let i = bodyStart; i < src.length; i++) {
+    const ch = src[i]!;
+    if (ch === '{') depth++;
+    if (ch === '}') depth--;
+    if (depth === 0) return src.slice(bodyStart + 1, i);
+  }
+
+  assert.fail(`could not find end of body for ${signature}`);
+}
+
+describe('loadAllData scheduler', () => {
+  const loadAllDataBody = extractMethodBody(DATA_LOADER_TS, 'async loadAllData(');
+
+  it('does not add a blanket inter-batch startup delay', () => {
+    assert.doesNotMatch(
+      loadAllDataBody,
+      /\bBATCH_DELAY_MS\b|\bBATCH_SIZE\b|setTimeout\s*\(/,
+      'loadAllData must not reintroduce a fixed startup batch sleep; throttle constrained sources in their loader/service instead',
+    );
+  });
+
+  it('awaits the scheduled guarded load promises together', () => {
+    assert.match(
+      loadAllDataBody,
+      /await\s+Promise\.allSettled\s*\(\s*tasks\.map\s*\(\s*t\s*=>\s*t\.task\s*\)\s*\)/,
+      'loadAllData should settle the task promises without artificial inter-batch waits',
+    );
+  });
+});

--- a/tests/load-all-data-scheduling.test.mts
+++ b/tests/load-all-data-scheduling.test.mts
@@ -2,43 +2,154 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import ts from 'typescript';
 
 const REPO_ROOT = resolve(import.meta.dirname, '..');
-const DATA_LOADER_TS = readFileSync(resolve(REPO_ROOT, 'src/app/data-loader.ts'), 'utf8');
+const DATA_LOADER_PATH = resolve(REPO_ROOT, 'src/app/data-loader.ts');
+const DATA_LOADER_TS = readFileSync(DATA_LOADER_PATH, 'utf8');
+const DATA_LOADER_SOURCE = ts.createSourceFile(
+  DATA_LOADER_PATH,
+  DATA_LOADER_TS,
+  ts.ScriptTarget.Latest,
+  true,
+  ts.ScriptKind.TS,
+);
 
-function extractMethodBody(src: string, signature: string): string {
-  const signatureStart = src.indexOf(signature);
-  assert.ok(signatureStart >= 0, `could not find ${signature}`);
+function visitDescendants(node: ts.Node, visitor: (child: ts.Node) => void): void {
+  node.forEachChild(child => {
+    visitor(child);
+    visitDescendants(child, visitor);
+  });
+}
 
-  const bodyStart = src.indexOf('{', signatureStart);
-  assert.ok(bodyStart > signatureStart, `could not find body for ${signature}`);
+function findLoadAllDataMethod(): ts.MethodDeclaration {
+  let match: ts.MethodDeclaration | undefined;
 
-  let depth = 0;
-  for (let i = bodyStart; i < src.length; i++) {
-    const ch = src[i]!;
-    if (ch === '{') depth++;
-    if (ch === '}') depth--;
-    if (depth === 0) return src.slice(bodyStart + 1, i);
+  visitDescendants(DATA_LOADER_SOURCE, node => {
+    if (
+      ts.isMethodDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === 'loadAllData'
+    ) {
+      match = node;
+    }
+  });
+
+  assert.ok(match, 'could not find loadAllData method');
+  assert.ok(match.body, 'loadAllData method has no body');
+  return match;
+}
+
+function isTasksMapTaskCall(node: ts.Node): boolean {
+  if (!ts.isCallExpression(node)) {
+    return false;
   }
 
-  assert.fail(`could not find end of body for ${signature}`);
+  const expression = node.expression;
+  if (
+    !ts.isPropertyAccessExpression(expression) ||
+    !ts.isIdentifier(expression.expression) ||
+    expression.expression.text !== 'tasks' ||
+    expression.name.text !== 'map'
+  ) {
+    return false;
+  }
+
+  const callback = node.arguments[0];
+  if (!callback || !ts.isArrowFunction(callback) || callback.parameters.length !== 1) {
+    return false;
+  }
+
+  const parameter = callback.parameters[0]!.name;
+  return (
+    ts.isIdentifier(parameter) &&
+    ts.isPropertyAccessExpression(callback.body) &&
+    ts.isIdentifier(callback.body.expression) &&
+    callback.body.expression.text === parameter.text &&
+    callback.body.name.text === 'task'
+  );
+}
+
+function isPromiseAllSettledCall(node: ts.Node): node is ts.CallExpression {
+  return (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    ts.isIdentifier(node.expression.expression) &&
+    node.expression.expression.text === 'Promise' &&
+    node.expression.name.text === 'allSettled'
+  );
+}
+
+function hasAwaitedAllTasksSettle(node: ts.Node): boolean {
+  let found = false;
+
+  visitDescendants(node, child => {
+    if (
+      ts.isAwaitExpression(child) &&
+      isPromiseAllSettledCall(child.expression) &&
+      child.expression.arguments.length === 1 &&
+      isTasksMapTaskCall(child.expression.arguments[0]!)
+    ) {
+      found = true;
+    }
+  });
+
+  return found;
+}
+
+function findBlockedBatchIdentifiers(node: ts.Node): string[] {
+  const hits: string[] = [];
+  const blocked = new Set(['BATCH_DELAY_MS', 'BATCH_SIZE']);
+
+  visitDescendants(node, child => {
+    if (ts.isIdentifier(child) && blocked.has(child.text)) {
+      hits.push(child.text);
+    }
+  });
+
+  return hits;
+}
+
+function findTasksSliceCalls(node: ts.Node): string[] {
+  const hits: string[] = [];
+
+  visitDescendants(node, child => {
+    if (
+      ts.isCallExpression(child) &&
+      ts.isPropertyAccessExpression(child.expression) &&
+      ts.isIdentifier(child.expression.expression) &&
+      child.expression.expression.text === 'tasks' &&
+      child.expression.name.text === 'slice'
+    ) {
+      hits.push(child.getText(DATA_LOADER_SOURCE));
+    }
+  });
+
+  return hits;
 }
 
 describe('loadAllData scheduler', () => {
-  const loadAllDataBody = extractMethodBody(DATA_LOADER_TS, 'async loadAllData(');
+  const loadAllDataMethod = findLoadAllDataMethod();
 
   it('does not add a blanket inter-batch startup delay', () => {
-    assert.doesNotMatch(
-      loadAllDataBody,
-      /\bBATCH_DELAY_MS\b|\bBATCH_SIZE\b|setTimeout\s*\(/,
-      'loadAllData must not reintroduce a fixed startup batch sleep; throttle constrained sources in their loader/service instead',
+    const batchIdentifiers = findBlockedBatchIdentifiers(loadAllDataMethod);
+    const taskSliceCalls = findTasksSliceCalls(loadAllDataMethod);
+
+    assert.deepEqual(
+      batchIdentifiers,
+      [],
+      'loadAllData must not reintroduce fixed startup batch constants; throttle constrained sources in their loader/service instead',
+    );
+    assert.deepEqual(
+      taskSliceCalls,
+      [],
+      'loadAllData must not batch the startup task list; throttle constrained sources in their loader/service instead',
     );
   });
 
   it('awaits the scheduled guarded load promises together', () => {
-    assert.match(
-      loadAllDataBody,
-      /await\s+Promise\.allSettled\s*\(\s*tasks\.map\s*\(\s*t\s*=>\s*t\.task\s*\)\s*\)/,
+    assert.ok(
+      hasAwaitedAllTasksSettle(loadAllDataMethod),
       'loadAllData should settle the task promises without artificial inter-batch waits',
     );
   });


### PR DESCRIPTION
## Summary

- Remove the universal `loadAllData` startup batch sleep that waited 300ms between groups of already-created task promises.
- Keep loader-level/source-specific throttling as the place for constrained upstream protection.
- Add a focused regression guard so the fixed startup batch delay is not reintroduced.

Closes #3537.

## Intent

The issue asked whether the global startup stagger was still warranted. The current code was more direct than the issue suggested: `loadAllData` builds an array of eager guarded promises, so the batch loop did not actually stagger request start times. It delayed `loadAllData()` completion and follow-on work instead.

This PR deliberately keeps the fix narrow: it removes the artificial completion delay without converting tasks to lazy thunks, changing request fan-out, or touching Redis/cache/source-specific throttles. Live deploy-preview rate telemetry was not run, so this PR does not claim production 429 measurements.

## Validation Matrix

| Check | Status |
| --- | --- |
| `./node_modules/.bin/tsx --test tests/load-all-data-scheduling.test.mts` | Passed |
| `./node_modules/.bin/tsx --test tests/flush-stale-refreshes.test.mjs` | Passed |
| `./node_modules/.bin/tsx --test tests/redis-caching.test.mjs` | Passed |
| `./node_modules/.bin/tsx --test tests/feed-date-ranking-uses-effective.test.mts` | Passed |
| `npm run typecheck` | Passed |
| `git diff --cached --check` | Passed |
| Docs/comment applicability search | Passed; no public/global startup stagger docs required edits |
| Live deploy-preview upstream-rate telemetry | Blocked/not run; requires preview/log access and is not essential because the patch preserves already-eager request fan-out |
| Browser smoke | Not applicable; no UI rendering, routing, layout, or interaction changes |

Note: the `tsx` tests initially hit sandbox IPC `EPERM` on the local pipe and were rerun outside the sandbox with the same commands.

Post-PR follow-up: the first CI unit run exposed a stale line-number allowlist entry in `tests/feed-date-ranking-uses-effective.test.mts` caused by the data-loader deletion. The allowlist was repinned to the current line and the focused guard now passes locally.

Greptile follow-up: two current comments flagged the initial scheduler test's source scanner and broad `setTimeout` regex as brittle. The guard now parses `data-loader.ts` with the TypeScript AST, checks real identifiers/calls instead of raw strings/comments, and avoids the broad `setTimeout` text match.

## Documentation

No docs changed. Existing docs that mention staggered requests describe source-specific Yahoo/request throttling or the separate refresh scheduler behavior, which this PR does not modify.

## Residual Findings

None.
