### PR TITLE
fix(military): export USNI response helpers

### DIFF
--- a/server/worldmonitor/military/v1/get-usni-fleet-report.ts
+++ b/server/worldmonitor/military/v1/get-usni-fleet-report.ts
@@ -10,6 +10,35 @@ import { getCachedJson } from '../../../_shared/redis';
 const USNI_CACHE_KEY = 'usni-fleet:sebuf:v1';
 const USNI_STALE_CACHE_KEY = 'usni-fleet:sebuf:stale:v1';
 
+export function buildUSNIFleetReportForceRefreshResponse(): GetUSNIFleetReportResponse {
+  return {
+    report: undefined,
+    cached: false,
+    stale: false,
+    error: 'forceRefresh is no longer supported (data is seeded by Railway relay)',
+  };
+}
+
+export function buildUSNIFleetReportCacheResponse(
+  report: USNIFleetReport | null,
+  stale: USNIFleetReport | null,
+): GetUSNIFleetReportResponse {
+  if (report) {
+    return { report, cached: true, stale: false, error: '' };
+  }
+
+  if (stale) {
+    return { report: stale, cached: true, stale: true, error: 'Using cached data' };
+  }
+
+  return {
+    report: undefined,
+    cached: false,
+    stale: false,
+    error: 'No USNI fleet data in cache (waiting for seed)',
+  };
+}
+
 // ========================================================================
 // RPC handler (Redis-read-only — Railway relay seeds the data)
 // ========================================================================
@@ -19,21 +48,17 @@ export async function getUSNIFleetReport(
   req: GetUSNIFleetReportRequest,
 ): Promise<GetUSNIFleetReportResponse> {
   if (req.forceRefresh) {
-    return { report: undefined, cached: false, stale: false, error: 'forceRefresh is no longer supported (data is seeded by Railway relay)' };
+    return buildUSNIFleetReportForceRefreshResponse();
   }
 
   try {
     const report = (await getCachedJson(USNI_CACHE_KEY)) as USNIFleetReport | null;
     if (report) {
-      return { report, cached: true, stale: false, error: '' };
+      return buildUSNIFleetReportCacheResponse(report, null);
     }
 
     const stale = (await getCachedJson(USNI_STALE_CACHE_KEY)) as USNIFleetReport | null;
-    if (stale) {
-      return { report: stale, cached: true, stale: true, error: 'Using cached data' };
-    }
-
-    return { report: undefined, cached: false, stale: false, error: 'No USNI fleet data in cache (waiting for seed)' };
+    return buildUSNIFleetReportCacheResponse(null, stale);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     console.warn('[USNI Fleet] Error:', message);

--- a/tests/handlers.test.mts
+++ b/tests/handlers.test.mts
@@ -3,13 +3,13 @@
  *
  * Covers exported pure functions from:
  *   - server/worldmonitor/cyber/v1/_shared.ts
+ *   - server/worldmonitor/military/v1/get-usni-fleet-report.ts
  *   - server/worldmonitor/news/v1/_shared.ts  (+ dedup.mjs + hash.ts)
  *   - server/worldmonitor/infrastructure/v1/get-cable-health.ts
  *
- * NOTE: server/worldmonitor/military/v1/get-usni-fleet-report.ts has many useful
- * pure helpers (hullToVesselType, detectDeploymentStatus, extractHomePort,
- * stripHtml, getRegionCoords, parseUSNIArticle) but they are NOT exported.
- * A follow-up PR should export those functions to enable testing.
+ * USNI parsing now happens in the Railway relay seed path; these tests cover
+ * the server handler's pure cache-response helpers without resurrecting the
+ * stale in-handler parser path.
  */
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
@@ -29,6 +29,15 @@ import {
 } from '../server/worldmonitor/cyber/v1/_shared.ts';
 
 // ---------------------------------------------------------------------------
+// Military / USNI fleet report helpers
+// ---------------------------------------------------------------------------
+import {
+  buildUSNIFleetReportCacheResponse,
+  buildUSNIFleetReportForceRefreshResponse,
+} from '../server/worldmonitor/military/v1/get-usni-fleet-report.ts';
+import type { USNIFleetReport } from '../src/generated/server/worldmonitor/military/v1/service_server.ts';
+
+// ---------------------------------------------------------------------------
 // News domain helpers
 // ---------------------------------------------------------------------------
 import { deduplicateHeadlines } from '../server/worldmonitor/news/v1/dedup.mjs';
@@ -46,6 +55,66 @@ import {
   processNgaSignals,
   computeHealthMap,
 } from '../server/worldmonitor/infrastructure/v1/get-cable-health.ts';
+
+
+// ========================================================================
+// USNI fleet report response helpers
+// ========================================================================
+
+describe('USNI fleet report response helpers', () => {
+  const makeReport = (overrides: Partial<USNIFleetReport> = {}): USNIFleetReport => ({
+    articleUrl: 'https://news.usni.org/2026/06/01/usni-news-fleet-and-marine-tracker',
+    articleDate: '2026-06-01T12:00:00Z',
+    articleTitle: 'USNI News Fleet and Marine Tracker',
+    vessels: [],
+    strikeGroups: [],
+    regions: [],
+    parsingWarnings: [],
+    timestamp: 1_780_310_400_000,
+    ...overrides,
+  });
+
+  it('returns an unsupported force-refresh response without a report', () => {
+    const result = buildUSNIFleetReportForceRefreshResponse();
+
+    assert.equal(result.report, undefined);
+    assert.equal(result.cached, false);
+    assert.equal(result.stale, false);
+    assert.match(result.error, /forceRefresh is no longer supported/);
+  });
+
+  it('prefers live cache data over stale fallback data', () => {
+    const live = makeReport({ articleTitle: 'Live USNI report' });
+    const stale = makeReport({ articleTitle: 'Stale USNI report' });
+
+    const result = buildUSNIFleetReportCacheResponse(live, stale);
+
+    assert.equal(result.report, live);
+    assert.equal(result.cached, true);
+    assert.equal(result.stale, false);
+    assert.equal(result.error, '');
+  });
+
+  it('uses stale cache data when live cache data is unavailable', () => {
+    const stale = makeReport({ articleTitle: 'Stale USNI report' });
+
+    const result = buildUSNIFleetReportCacheResponse(null, stale);
+
+    assert.equal(result.report, stale);
+    assert.equal(result.cached, true);
+    assert.equal(result.stale, true);
+    assert.equal(result.error, 'Using cached data');
+  });
+
+  it('reports a cache miss without fabricating an empty report', () => {
+    const result = buildUSNIFleetReportCacheResponse(null, null);
+
+    assert.equal(result.report, undefined);
+    assert.equal(result.cached, false);
+    assert.equal(result.stale, false);
+    assert.match(result.error, /No USNI fleet data in cache/);
+  });
+});
 
 
 // ========================================================================


### PR DESCRIPTION
## Summary
USNI fleet report fallback behavior is now testable without touching Redis. The server handler exposes only the pure response builders for unsupported force refresh and live/stale/miss cache selection, and the stale parser-export note now reflects that USNI parsing lives in the Railway relay seed path.

## Tests
- `./node_modules/.bin/tsx --test tests/handlers.test.mts`
- `npm run typecheck:api`
- normal pre-push hook completed, including root typecheck, API typecheck, boundary checks, safe HTML, rate-limit policy, premium-fetch parity, edge bundle check, server handler tests, and version sync

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
