### PR TITLE
fix(cors): allow eliewm team-scope Vercel previews across all CORS surfaces

### DIFF
--- a/api/_cors.js
+++ b/api/_cors.js
@@ -1,6 +1,10 @@
 const ALLOWED_ORIGIN_PATTERNS = [
   /^https:\/\/(.*\.)?worldmonitor\.app$/,
-  /^https:\/\/worldmonitor-[a-z0-9-]+-elie-[a-z0-9]+\.vercel\.app$/,
+  // Vercel preview deployments under the "eliewm" team scope, e.g.
+  //   worldmonitor-git-<branch>-eliewm.vercel.app  (git-branch alias)
+  //   worldmonitor-<hash>-eliewm.vercel.app        (deployment URL)
+  // Tight on purpose: never a bare *.vercel.app (this is a security allowlist).
+  /^https:\/\/worldmonitor-[a-z0-9-]+-eliewm\.vercel\.app$/,
   /^https?:\/\/tauri\.localhost(:\d+)?$/,
   /^https?:\/\/[a-z0-9-]+\.tauri\.localhost(:\d+)?$/i,
   /^tauri:\/\/localhost$/,

--- a/public/wm-widget-sandbox.html
+++ b/public/wm-widget-sandbox.html
@@ -11,20 +11,22 @@
   var handled = false;
 
   // Vercel preview hostnames have the shape
-  //   {project-slug}-{branch-slug}-{team-slug}-{hash}.vercel.app
-  // The team-slug segment is the URL-safe Vercel team identifier and is the
+  //   worldmonitor-git-{branch-slug}-{team-slug}.vercel.app   (git-branch alias)
+  //   worldmonitor-{hash}-{team-slug}.vercel.app              (deployment URL)
+  // The team-slug is the LAST segment before .vercel.app and is the
   // load-bearing security invariant: an attacker who registers a Vercel
   // project named `worldmonitor-...` under their OWN team account would get
   // a different team-slug, so gating on this list rejects look-alike previews.
-  // Add a teammate's Vercel team slug here when they need to mount PRO
-  // widgets in preview deployments; never widen this to a wildcard.
-  var ALLOWED_VERCEL_TEAM_SLUGS = ['elie'];
+  // The project deploys under the "eliewm" team scope. Add a teammate's Vercel
+  // team slug here when they need to mount PRO widgets in preview deployments;
+  // never widen this to a wildcard.
+  var ALLOWED_VERCEL_TEAM_SLUGS = ['eliewm'];
 
   function isAllowedVercelPreview(hostname) {
     for (var i = 0; i < ALLOWED_VERCEL_TEAM_SLUGS.length; i++) {
       var team = ALLOWED_VERCEL_TEAM_SLUGS[i];
       if (!/^[a-z0-9-]+$/.test(team)) continue;
-      var re = new RegExp('^worldmonitor-[a-z0-9-]+-' + team + '-[a-z0-9]+\\.vercel\\.app$');
+      var re = new RegExp('^worldmonitor-[a-z0-9-]+-' + team + '\\.vercel\\.app$');
       if (re.test(hostname)) return true;
     }
     return false;

--- a/server/cors.ts
+++ b/server/cors.ts
@@ -7,7 +7,11 @@
 
 const PRODUCTION_PATTERNS: RegExp[] = [
   /^https:\/\/(.*\.)?worldmonitor\.app$/,
-  /^https:\/\/worldmonitor-[a-z0-9-]+-elie-[a-z0-9]+\.vercel\.app$/,
+  // Vercel preview deployments under the "eliewm" team scope, e.g.
+  //   worldmonitor-git-<branch>-eliewm.vercel.app  (git-branch alias)
+  //   worldmonitor-<hash>-eliewm.vercel.app        (deployment URL)
+  // Tight on purpose: never a bare *.vercel.app (this is a security allowlist).
+  /^https:\/\/worldmonitor-[a-z0-9-]+-eliewm\.vercel\.app$/,
   /^https?:\/\/tauri\.localhost(:\d+)?$/,
   /^https?:\/\/[a-z0-9-]+\.tauri\.localhost(:\d+)?$/i,
   /^tauri:\/\/localhost$/,

--- a/tests/cors-fail-closed.test.mts
+++ b/tests/cors-fail-closed.test.mts
@@ -2,7 +2,8 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
 
-import { getCorsHeaders } from '../server/cors.ts';
+import { getCorsHeaders, isAllowedOrigin } from '../server/cors.ts';
+import { isDisallowedOrigin as isDisallowedOriginJs } from '../api/_cors.js';
 
 // Regression coverage for issue #3705: CORS-header generation errors must
 // fail closed rather than fall back to a wildcard ACAO.
@@ -41,6 +42,67 @@ describe('cors helper', () => {
     } as unknown as Request;
     assert.throws(() => getCorsHeaders(throwingReq), /simulated header failure/);
   });
+});
+
+// The Vercel project moved from the personal scope (worldmonitor-*-elie-<hash>)
+// to the "eliewm" team scope. Browsers send Origin on the POST to
+// /api/wm-session, so a stale allowlist 403s every preview deployment and the
+// anonymous session can never be minted (dashboard + /welcome teasers stay dark).
+describe('isAllowedOrigin — Vercel preview allowlist (eliewm team scope)', () => {
+  // Origin for the JS twin (api/_cors.js exports isDisallowedOrigin, not the
+  // bare predicate) — same allow/deny outcome proves both files stay in sync.
+  const allowedByJsTwin = (origin: string) =>
+    !isDisallowedOriginJs(new Request('https://worldmonitor.app/x', { headers: { Origin: origin } }));
+
+  const ALLOWED = [
+    ['git-branch alias URL', 'https://worldmonitor-git-feature-eliewm.vercel.app'],
+    ['hash deployment URL', 'https://worldmonitor-abc123def456-eliewm.vercel.app'],
+    ['apex production origin', 'https://worldmonitor.app'],
+    ['production subdomain', 'https://tech.worldmonitor.app'],
+  ];
+
+  const REJECTED = [
+    ['non-worldmonitor vercel.app origin', 'https://some-other-app-eliewm.vercel.app'],
+    ['foreign team scope', 'https://worldmonitor-git-feature-attacker.vercel.app'],
+    ['bare worldmonitor vercel.app (no scope segment)', 'https://worldmonitor.vercel.app'],
+    ['suffix-spoofed eliewm origin', 'https://worldmonitor-git-feature-eliewm.vercel.app.evil.com'],
+    ['dead personal-scope preview (post-migration)', 'https://worldmonitor-feature-elie-abc123.vercel.app'],
+  ];
+
+  for (const [label, origin] of ALLOWED) {
+    it(`allows ${label}`, () => {
+      assert.equal(isAllowedOrigin(origin), true, `server/cors.ts must allow ${origin}`);
+      assert.equal(allowedByJsTwin(origin), true, `api/_cors.js must allow ${origin}`);
+    });
+  }
+
+  for (const [label, origin] of REJECTED) {
+    it(`rejects ${label}`, () => {
+      assert.equal(isAllowedOrigin(origin), false, `server/cors.ts must reject ${origin}`);
+      assert.equal(allowedByJsTwin(origin), false, `api/_cors.js must reject ${origin}`);
+    });
+  }
+});
+
+describe('CORS twin parity — eliewm preview pattern stays tight in both files', () => {
+  // Root cause of the original 403s was the two twins drifting. Guard both:
+  // (1) the eliewm-scoped preview pattern is present, and
+  // (2) no bare *.vercel.app wildcard sneaks in as a "fix".
+  const TWINS = ['../server/cors.ts', '../api/_cors.js'];
+
+  for (const rel of TWINS) {
+    it(`${rel} scopes Vercel previews to the eliewm team`, async () => {
+      const source = await readFile(new URL(rel, import.meta.url), 'utf8');
+      assert.ok(
+        source.includes('-eliewm\\.vercel\\.app'),
+        `${rel} must allow worldmonitor-*-eliewm.vercel.app previews`,
+      );
+      assert.ok(
+        !source.includes('worldmonitor-[a-z0-9-]+\\.vercel\\.app'),
+        `${rel} must not widen to a bare *.vercel.app wildcard (security allowlist)`,
+      );
+    });
+  }
 });
 
 describe('gateway CORS error path (issue #3705)', () => {

--- a/tests/cors-fail-closed.test.mts
+++ b/tests/cors-fail-closed.test.mts
@@ -4,6 +4,7 @@ import { describe, it } from 'node:test';
 
 import { getCorsHeaders, isAllowedOrigin } from '../server/cors.ts';
 import { isDisallowedOrigin as isDisallowedOriginJs } from '../api/_cors.js';
+import { isAllowedOrigin as isAllowedOriginWorker } from '../workers/api-cors-preflight/src/index.js';
 
 // Regression coverage for issue #3705: CORS-header generation errors must
 // fail closed rather than fall back to a wildcard ACAO.
@@ -84,11 +85,19 @@ describe('isAllowedOrigin — Vercel preview allowlist (eliewm team scope)', () 
   }
 });
 
-describe('CORS twin parity — eliewm preview pattern stays tight in both files', () => {
-  // Root cause of the original 403s was the two twins drifting. Guard both:
+describe('CORS triplet parity — eliewm preview pattern stays tight in all three twins', () => {
+  // Root cause of the original 403s was twins drifting. THREE surfaces gate
+  // Vercel-preview CORS and must move together; guard each for:
   // (1) the eliewm-scoped preview pattern is present, and
   // (2) no bare *.vercel.app wildcard sneaks in as a "fix".
-  const TWINS = ['../server/cors.ts', '../api/_cors.js'];
+  // The Cloudflare Worker is the load-bearing one: it short-circuits OPTIONS at
+  // the edge, so if it drifts narrower the browser blocks the preflight before
+  // Vercel is ever consulted.
+  const TWINS = [
+    '../server/cors.ts',
+    '../api/_cors.js',
+    '../workers/api-cors-preflight/src/index.js',
+  ];
 
   for (const rel of TWINS) {
     it(`${rel} scopes Vercel previews to the eliewm team`, async () => {
@@ -101,6 +110,53 @@ describe('CORS twin parity — eliewm preview pattern stays tight in both files'
         !source.includes('worldmonitor-[a-z0-9-]+\\.vercel\\.app'),
         `${rel} must not widen to a bare *.vercel.app wildcard (security allowlist)`,
       );
+    });
+  }
+});
+
+describe('CORS Worker superset invariant — edge allowlist ⊇ function allowlist', () => {
+  // The api-cors-preflight Worker (workers/api-cors-preflight) short-circuits
+  // OPTIONS preflights at the edge, so its allowlist MUST be a superset of
+  // api/_cors.js. If the Worker rejects an origin the function would accept,
+  // the preflight echoes the canonical worldmonitor.app fallback and the
+  // browser blocks the request before it reaches Vercel.
+  //
+  // The Worker's own test (workers/api-cors-preflight/index.test.mjs) lives
+  // OUTSIDE the test:data glob and only runs in deploy-worker.yml on
+  // workers/** changes — so a function-only change can silently leave the
+  // Worker narrower. THIS gate-resident check is what actually catches
+  // function↔Worker drift (the bug that left eliewm previews dark).
+  //
+  // Localhost/127 are intentionally omitted: they are DEV-only on the function
+  // side (NODE_ENV-gated) and never reach the prod-only Worker.
+  const fnAllows = (origin: string) =>
+    !isDisallowedOriginJs(new Request('https://worldmonitor.app/x', { headers: { Origin: origin } }));
+
+  const PROD_ORIGINS = [
+    'https://worldmonitor.app',
+    'https://www.worldmonitor.app',
+    'https://tech.worldmonitor.app',
+    'https://worldmonitor-git-feature-eliewm.vercel.app',
+    'https://worldmonitor-abc123def456-eliewm.vercel.app',
+    'tauri://localhost',
+    'asset://localhost',
+    // Negatives — the function rejects these, so the superset assertion is a
+    // no-op for them; included to document the boundary.
+    'https://some-other-app-eliewm.vercel.app',
+    'https://worldmonitor-git-feature-attacker.vercel.app',
+    'https://worldmonitor-feature-elie-abc123.vercel.app',
+    'https://evil.com',
+  ];
+
+  for (const origin of PROD_ORIGINS) {
+    it(`Worker allows everything the function allows: ${origin}`, () => {
+      if (fnAllows(origin)) {
+        assert.equal(
+          isAllowedOriginWorker(origin),
+          true,
+          `Worker rejects ${origin} that api/_cors.js accepts — its OPTIONS preflight will echo the worldmonitor.app fallback and the browser will block it`,
+        );
+      }
     });
   }
 });

--- a/tests/gateway-cdn-origin-policy.test.mts
+++ b/tests/gateway-cdn-origin-policy.test.mts
@@ -65,7 +65,7 @@ describe('gateway CDN origin policy', () => {
   });
 
   it('enables CDN caching for preview origins', async () => {
-    const origin = 'https://worldmonitor-feature-elie-abc123.vercel.app';
+    const origin = 'https://worldmonitor-git-feature-eliewm.vercel.app';
     const res = await requestPublicRoute(origin);
     assert.equal(res.status, 200);
     assert.equal(res.headers.get('Access-Control-Allow-Origin'), origin);

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -1289,31 +1289,37 @@ describe('PRO widget — store and sanitizer', () => {
       .split(',')
       .map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
       .filter(Boolean);
-    assert.ok(slugs.includes('elie'), 'project-owner team slug must remain in the allowlist');
+    assert.ok(slugs.includes('eliewm'), 'project-owner team slug must remain in the allowlist');
     for (const slug of slugs) {
       assert.match(slug, /^[a-z0-9-]+$/, `team slug "${slug}" must be url-safe`);
     }
     // Reconstruct the actual match function and exercise it against the
     // production slug list — this is what protects against regex drift
-    // when teammate slugs are added later.
+    // when teammate slugs are added later. The team slug is the LAST hostname
+    // segment before .vercel.app (eliewm team scope); keep this shape in lock-
+    // step with isAllowedVercelPreview in public/wm-widget-sandbox.html.
     const matchesAllowedTeam = (hostname) =>
       slugs.some((team) =>
-        new RegExp('^worldmonitor-[a-z0-9-]+-' + team + '-[a-z0-9]+\\.vercel\\.app$').test(hostname),
+        new RegExp('^worldmonitor-[a-z0-9-]+-' + team + '\\.vercel\\.app$').test(hostname),
       );
-    assert.equal(matchesAllowedTeam('worldmonitor-feature-elie-abc123.vercel.app'), true);
-    assert.equal(matchesAllowedTeam('worldmonitor-feature-attacker-abc123.vercel.app'), false);
-    assert.equal(matchesAllowedTeam('worldmonitor-feature-elie-abc123.vercel.app.evil.com'), false);
+    assert.equal(matchesAllowedTeam('worldmonitor-git-feature-eliewm.vercel.app'), true);
+    assert.equal(matchesAllowedTeam('worldmonitor-abc123-eliewm.vercel.app'), true);
+    assert.equal(matchesAllowedTeam('worldmonitor-feature-attacker.vercel.app'), false);
+    assert.equal(matchesAllowedTeam('worldmonitor-git-feature-eliewm.vercel.app.evil.com'), false);
+    assert.equal(matchesAllowedTeam('worldmonitor-feature-xeliewm.vercel.app'), false);
     assert.equal(matchesAllowedTeam('evilworldmonitor.app'), false);
+    // The retired personal scope (worldmonitor-*-elie-<hash>) must no longer match.
+    assert.equal(matchesAllowedTeam('worldmonitor-feature-elie-abc123.vercel.app'), false);
     // A teammate slug added to the list must extend coverage WITHOUT
     // matching look-alike teams whose slug merely starts with the same
     // letters.
-    const withTeammate = ['elie', 'kieran'];
+    const withTeammate = ['eliewm', 'kieran'];
     const matchesWithTeammate = (hostname) =>
       withTeammate.some((team) =>
-        new RegExp('^worldmonitor-[a-z0-9-]+-' + team + '-[a-z0-9]+\\.vercel\\.app$').test(hostname),
+        new RegExp('^worldmonitor-[a-z0-9-]+-' + team + '\\.vercel\\.app$').test(hostname),
       );
-    assert.equal(matchesWithTeammate('worldmonitor-feature-kieran-abc123.vercel.app'), true);
-    assert.equal(matchesWithTeammate('worldmonitor-feature-kieranfake-abc123.vercel.app'), false);
+    assert.equal(matchesWithTeammate('worldmonitor-feature-kieran.vercel.app'), true);
+    assert.equal(matchesWithTeammate('worldmonitor-feature-kieranfake.vercel.app'), false);
   });
 
   it('widget sandbox behavior accepts Vercel previews and blocks spoofed parents', () => {
@@ -1354,9 +1360,9 @@ describe('PRO widget — store and sanitizer', () => {
       return { parent, readyMessages, writes, message };
     }
 
-    const allowed = runSandbox('https://worldmonitor-feature-elie-abc123.vercel.app/dashboard');
+    const allowed = runSandbox('https://worldmonitor-git-feature-eliewm.vercel.app/dashboard');
     assert.equal(allowed.readyMessages.length, 1);
-    assert.equal(allowed.readyMessages[0].targetOrigin, 'https://worldmonitor-feature-elie-abc123.vercel.app');
+    assert.equal(allowed.readyMessages[0].targetOrigin, 'https://worldmonitor-git-feature-eliewm.vercel.app');
     assert.deepEqual(JSON.parse(JSON.stringify(allowed.readyMessages[0].payload)), {
       type: 'wm-widget-ready',
       id: 'wm-1',
@@ -1364,16 +1370,16 @@ describe('PRO widget — store and sanitizer', () => {
     });
     allowed.message({
       data: { type: 'wm-html', id: 'wm-1', token: 'test-token', html: '<p>ok</p>' },
-      origin: 'https://worldmonitor-feature-elie-abc123.vercel.app',
+      origin: 'https://worldmonitor-git-feature-eliewm.vercel.app',
       source: allowed.parent,
     });
     assert.deepEqual(allowed.writes, ['<p>ok</p>']);
 
-    const spoofed = runSandbox('https://worldmonitor-feature-elie-abc123.vercel.app.evil.com/');
+    const spoofed = runSandbox('https://worldmonitor-git-feature-eliewm.vercel.app.evil.com/');
     assert.deepEqual(spoofed.readyMessages, []);
     spoofed.message({
       data: { type: 'wm-html', id: 'wm-1', token: 'test-token', html: '<p>bad</p>' },
-      origin: 'https://worldmonitor-feature-elie-abc123.vercel.app.evil.com',
+      origin: 'https://worldmonitor-git-feature-eliewm.vercel.app.evil.com',
       source: spoofed.parent,
     });
     assert.deepEqual(spoofed.writes, []);

--- a/workers/api-cors-preflight/index.test.mjs
+++ b/workers/api-cors-preflight/index.test.mjs
@@ -46,22 +46,20 @@ test('isAllowedOrigin accepts apex worldmonitor.app and subdomains', () => {
   assert.equal(isAllowedOrigin('https://commodity.worldmonitor.app'), true);
 });
 
-test('isAllowedOrigin accepts Vercel preview deploys (mirroring api/_cors.js shape)', () => {
-  // The Worker mirrors api/_cors.js's preview regex EXACTLY. That regex
-  // requires [a-z0-9]+ (no hyphens) after `-elie-`, so `*-elie-habib.vercel.app`
-  // matches and `*-elie-habib-projects.vercel.app` does NOT. That looks like
-  // a latent bug in api/_cors.js for teams named `elie-habib-projects`, but
-  // tightening it is out of scope for this PR — the Worker must stay in lock-
-  // step with the function, not silently widen.
-  assert.equal(isAllowedOrigin('https://worldmonitor-r6q9o-elie-habib.vercel.app'), true);
-  assert.equal(isAllowedOrigin('https://worldmonitor-git-feat-x-elie-habib.vercel.app'), true);
-  // NOTE: assertion below documents the latent narrowness — flip to `true`
-  // ONLY after updating both the Worker AND api/_cors.js together.
-  assert.equal(
-    isAllowedOrigin('https://worldmonitor-abc-elie-habib-projects.vercel.app'),
-    false,
-    'Worker preview regex mirrors api/_cors.js; widen BOTH together if needed',
-  );
+test('isAllowedOrigin accepts Vercel preview deploys under the eliewm team scope (mirrors api/_cors.js)', () => {
+  // The project deploys previews under the "eliewm" Vercel team scope, so URLs
+  // end in `-eliewm.vercel.app` (git-branch alias AND hash deployment forms).
+  // The Worker MUST mirror api/_cors.js exactly — if it stays narrower, eliewm
+  // preview preflights echo the canonical worldmonitor.app fallback and the
+  // browser blocks them before the request ever reaches Vercel.
+  assert.equal(isAllowedOrigin('https://worldmonitor-git-feat-x-eliewm.vercel.app'), true);
+  assert.equal(isAllowedOrigin('https://worldmonitor-r6q9o-eliewm.vercel.app'), true);
+  // Tight allowlist: a foreign team scope, a non-worldmonitor app, and the
+  // retired personal scope (worldmonitor-*-elie-<hash>, migration complete)
+  // must all stay rejected. Never a bare *.vercel.app.
+  assert.equal(isAllowedOrigin('https://worldmonitor-feat-x-attacker.vercel.app'), false);
+  assert.equal(isAllowedOrigin('https://some-other-app-eliewm.vercel.app'), false);
+  assert.equal(isAllowedOrigin('https://worldmonitor-abc-elie-habib.vercel.app'), false);
 });
 
 test('isAllowedOrigin accepts Tauri desktop runtime origins', () => {

--- a/workers/api-cors-preflight/src/index.js
+++ b/workers/api-cors-preflight/src/index.js
@@ -24,7 +24,10 @@
 // echoed back and fail CORS at the browser.
 const ALLOWED_ORIGIN_PATTERNS = [
   /^https:\/\/(.*\.)?worldmonitor\.app$/,
-  /^https:\/\/worldmonitor-[a-z0-9-]+-elie-[a-z0-9]+\.vercel\.app$/,
+  // Vercel previews under the "eliewm" team scope, e.g.
+  //   worldmonitor-git-<branch>-eliewm.vercel.app / worldmonitor-<hash>-eliewm.vercel.app
+  // Mirror of api/_cors.js + server/cors.ts (see superset note above).
+  /^https:\/\/worldmonitor-[a-z0-9-]+-eliewm\.vercel\.app$/,
   /^https?:\/\/tauri\.localhost(:\d+)?$/,
   /^https?:\/\/[a-z0-9-]+\.tauri\.localhost(:\d+)?$/i,
   /^tauri:\/\/localhost$/,


### PR DESCRIPTION
## Summary

Preview deployments moved from the personal Vercel scope (`worldmonitor-*-elie-<hash>`) to the **`eliewm`** team scope (`worldmonitor-git-<branch>-eliewm.vercel.app`, `worldmonitor-<hash>-eliewm.vercel.app`). Multiple origin allowlists were still pinned to the dead personal scope, so previews could never authenticate or render live data.

**Browsers send `Origin` on `POST /api/wm-session`** → a stale allowlist 403s it (`isDisallowedOrigin`) → the anonymous session is never minted → every session-authed call 401s. Verified live 2026-06-10.

This PR fixes **all four** surfaces that gate Vercel-preview origins and adds a gate-resident guard so they can't silently drift again.

## Surfaces fixed

| Surface | File | Was | Now |
|---|---|---|---|
| sebuf gateway (TS) | `server/cors.ts` | `-elie-[a-z0-9]+` | `-eliewm` |
| Vercel functions (JS twin) | `api/_cors.js` | `-elie-[a-z0-9]+` | `-eliewm` |
| **Cloudflare Worker** (edge preflight) | `workers/api-cors-preflight/src/index.js` | `-elie-[a-z0-9]+` | `-eliewm` |
| **PRO widget sandbox** | `public/wm-widget-sandbox.html` | `-<team>-<hash>`, slug `elie` | team-as-final-segment, slug `eliewm` |

All kept tight — never a bare `*.vercel.app` (these are security allowlists).

### Why the Worker mattered (HIGH)
The `api-cors-preflight` Worker short-circuits `OPTIONS` at the edge, so its allowlist **must be a superset** of `api/_cors.js`. Fixing only the functions left the Worker strictly *narrower* → eliewm preflights echo the canonical `worldmonitor.app` fallback and the browser blocks the request before it reaches Vercel. The Worker's own test lives outside the `test:data` glob (runs only in `deploy-worker.yml` on `workers/**` changes), and both the Worker and its test pinned the old literal — so the drift was invisible to CI.

### Why the widget sandbox mattered
Its regex hard-coded a stale Vercel hostname shape (`-{team}-{hash}`), so even swapping the slug couldn't match `worldmonitor-…-eliewm.vercel.app` (scope is the final segment now). PRO widgets stayed dark on every preview. `youtube/embed.js` is unaffected (already has a bare preview line).

## Drift guards added (always-run gate)
In `tests/cors-fail-closed.test.mts`:
- **Three-twin source parity** — `server/cors.ts`, `api/_cors.js`, and the Worker must each contain the eliewm pattern and none may widen to a bare `*.vercel.app`.
- **Worker ⊇ function superset test** — imports both real predicates and asserts the Worker allows every origin the function allows. This always-run check catches function↔Worker drift (the gap that hid this bug).

## Tests
- `isAllowedOrigin` coverage on both function twins: git-branch alias, hash deployment, apex/subdomain; rejects non-worldmonitor `.vercel.app`, foreign team scope, bare `worldmonitor.vercel.app`, suffix-spoof, dead personal scope.
- Worker unit test updated to the eliewm shape (19/19).
- Widget sandbox: vm-driven behavior test + look-alike rejections (foreign team, suffix spoof, `xeliewm` prefix collision, retired personal scope) updated (210/210).

## Test plan
- [x] `npm run typecheck` + `npm run typecheck:api`
- [x] `npm run lint` + `npm run lint:md`
- [x] CJS syntax + `npm run version:check`
- [x] edge bundle + `tests/edge-functions.test.mjs` (204/204)
- [x] `npm run test:data` — 11098 pass / 0 fail / 6 skipped
- [x] `node --test workers/api-cors-preflight/index.test.mjs` — 19/19
- [x] cors + gateway origin-policy + widget-builder — all green