### PR TITLE
Guard relay service status seed loop

### DIFF
--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -4518,10 +4518,7 @@ async function seedCiiWarmPing() {
 
 function startCiiWarmPingLoop() {
   console.log(`[CII] Warm-ping loop starting (interval ${CII_WARM_PING_INTERVAL_MS / 1000 / 60}min)`);
-  seedCiiWarmPing().catch((e) => console.warn('[CII] Initial warm-ping error:', e?.message || e));
-  setInterval(() => {
-    seedCiiWarmPing().catch((e) => console.warn('[CII] Warm-ping error:', e?.message || e));
-  }, CII_WARM_PING_INTERVAL_MS).unref?.();
+  startBootSeedLoop('CII', 'seed-meta:intelligence:risk-scores', CII_WARM_PING_INTERVAL_MS, seedCiiWarmPing, (e) => console.warn('[CII] Initial warm-ping error:', e?.message || e), (e) => console.warn('[CII] Warm-ping error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -4557,10 +4554,7 @@ async function seedChokepointWarmPing() {
 
 function startChokepointWarmPingLoop() {
   console.log(`[Chokepoints] Warm-ping loop starting (interval ${CHOKEPOINT_WARM_PING_INTERVAL_MS / 1000 / 60}min)`);
-  seedChokepointWarmPing().catch((e) => console.warn('[Chokepoints] Initial warm-ping error:', e?.message || e));
-  setInterval(() => {
-    seedChokepointWarmPing().catch((e) => console.warn('[Chokepoints] Warm-ping error:', e?.message || e));
-  }, CHOKEPOINT_WARM_PING_INTERVAL_MS).unref?.();
+  startBootSeedLoop('Chokepoints', 'seed-meta:supply_chain:chokepoints', CHOKEPOINT_WARM_PING_INTERVAL_MS, seedChokepointWarmPing, (e) => console.warn('[Chokepoints] Initial warm-ping error:', e?.message || e), (e) => console.warn('[Chokepoints] Warm-ping error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────
@@ -4595,10 +4589,7 @@ async function seedCableHealthWarmPing() {
 
 function startCableHealthWarmPingLoop() {
   console.log(`[CableHealth] Warm-ping loop starting (interval ${CABLE_HEALTH_WARM_PING_INTERVAL_MS / 1000 / 60}min)`);
-  seedCableHealthWarmPing().catch((e) => console.warn('[CableHealth] Initial warm-ping error:', e?.message || e));
-  setInterval(() => {
-    seedCableHealthWarmPing().catch((e) => console.warn('[CableHealth] Warm-ping error:', e?.message || e));
-  }, CABLE_HEALTH_WARM_PING_INTERVAL_MS).unref?.();
+  startBootSeedLoop('CableHealth', 'seed-meta:cable-health', CABLE_HEALTH_WARM_PING_INTERVAL_MS, seedCableHealthWarmPing, (e) => console.warn('[CableHealth] Initial warm-ping error:', e?.message || e), (e) => console.warn('[CableHealth] Warm-ping error:', e?.message || e));
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -3903,10 +3903,7 @@ async function seedServiceStatuses() {
 
 function startServiceStatusesSeedLoop() {
   console.log(`[ServiceStatuses] Seed loop starting (interval ${SERVICE_STATUSES_SEED_INTERVAL_MS / 1000 / 60}min)`);
-  seedServiceStatuses().catch((e) => console.warn('[ServiceStatuses] Initial seed error:', e?.message || e));
-  setInterval(() => {
-    seedServiceStatuses().catch((e) => console.warn('[ServiceStatuses] Seed error:', e?.message || e));
-  }, SERVICE_STATUSES_SEED_INTERVAL_MS).unref?.();
+  startBootSeedLoop('ServiceStatuses', 'seed-meta:infra:service-statuses', SERVICE_STATUSES_SEED_INTERVAL_MS, seedServiceStatuses, (e) => console.warn('[ServiceStatuses] Initial seed error:', e?.message || e), (e) => console.warn('[ServiceStatuses] Seed error:', e?.message || e));
 }
 
 
@@ -7784,7 +7781,7 @@ setInterval(() => {
   if (upstreamSocket?.readyState === WebSocket.OPEN || vessels.size > 0) {
     buildSnapshot();
   }
-}, SNAPSHOT_INTERVAL_MS);
+}, SNAPSHOT_INTERVAL_MS).unref?.();
 
 async function seedChokepointTransits() {
   const now = Date.now();
@@ -9134,7 +9131,7 @@ setInterval(() => {
   for (const [key, ts] of logThrottleState) {
     if (now - ts > RELAY_LOG_THROTTLE_MS * 6) logThrottleState.delete(key);
   }
-}, 60 * 1000);
+}, 60 * 1000).unref?.();
 
 // ── Yahoo Finance Chart Proxy ──────────────────────────────────────
 const YAHOO_CHART_CACHE_TTL_MS = 300_000; // 5 min
@@ -9448,7 +9445,7 @@ setInterval(() => {
     const ttl = key.startsWith('vid:') ? 3600000 : YT_CACHE_TTL;
     if (now - val.ts > ttl * 2) ytLiveCache.delete(key);
   }
-}, 5 * 60 * 1000);
+}, 5 * 60 * 1000).unref?.();
 
 // ─────────────────────────────────────────────────────────────
 // NOTAM proxy — ICAO API times out from Vercel edge, relay proxies
@@ -11660,7 +11657,7 @@ setInterval(() => {
     yahooChartCache.clear();
     if (global.gc) global.gc();
   }
-}, 60 * 1000);
+}, 60 * 1000).unref?.();
 
 // Graceful shutdown — disconnect Telegram BEFORE container dies.
 // Railway sends SIGTERM during deploys; without this, the old container keeps

--- a/tests/relay-boot-seed-freshness-guard.test.mjs
+++ b/tests/relay-boot-seed-freshness-guard.test.mjs
@@ -45,6 +45,12 @@ function extractFunction(src, signature) {
   throw new Error(`unbalanced braces for ${signature}`);
 }
 
+function extractNamedFunction(src, name) {
+  const match = new RegExp(`(?:async\\s+)?function\\s+${name}\\s*\\([^)]*\\)`).exec(src);
+  assert.ok(match, `missing function: ${name}`);
+  return extractFunction(src, match[0]);
+}
+
 const delayFnText = extractFunction(relaySource, 'async function bootSeedDelayMs(label, metaKey, intervalMs)');
 const loopFnText = extractFunction(relaySource, 'function startBootSeedLoop(label, metaKey, intervalMs, seedFn, onInitialError, onSeedError = onInitialError)');
 
@@ -178,6 +184,7 @@ const SEEDERS = [
   ['Market', "'seed-meta:market:stocks'", 'MARKET_SEED_INTERVAL_MS', 'seedAllMarketData'],
   ['PositiveEvents', "'seed-meta:positive-events:geo'", 'POSITIVE_EVENTS_INTERVAL_MS', 'seedPositiveEvents'],
   ['Classify', "'seed-meta:classify'", 'CLASSIFY_SEED_INTERVAL_MS', 'seedClassify'],
+  ['ServiceStatuses', "'seed-meta:infra:service-statuses'", 'SERVICE_STATUSES_SEED_INTERVAL_MS', 'seedServiceStatuses'],
   ['TheaterPosture', "'seed-meta:theater-posture'", 'THEATER_POSTURE_SEED_INTERVAL_MS', 'seedTheaterPosture'],
   ['Weather', "'seed-meta:weather:alerts'", 'WEATHER_SEED_INTERVAL_MS', 'seedWeatherAlerts'],
   ['Spending', "'seed-meta:economic:spending'", 'SPENDING_SEED_INTERVAL_MS', 'seedUsaSpending'],
@@ -210,15 +217,41 @@ test('exactly the expected number of boot seeds are scheduled (no drift)', () =>
   assert.equal(count, SEEDERS.length, `expected ${SEEDERS.length} gated boot seeds, found ${count}`);
 });
 
+test('every relay seed loop is routed through startBootSeedLoop instead of raw setInterval', () => {
+  const seedLoopNames = [...relaySource.matchAll(/(?:async\s+)?function\s+(start[A-Za-z0-9]+SeedLoop)\s*\(/g)]
+    .map(([, name]) => name)
+    .filter((name) => name !== 'startBootSeedLoop');
+
+  assert.ok(seedLoopNames.length > 0, 'expected to find relay seed loop functions');
+
+  const rawIntervalSeedLoops = [];
+  const ungatedSeedLoops = [];
+  for (const name of seedLoopNames) {
+    const fnText = extractNamedFunction(relaySource, name);
+    if (/setInterval\s*\(/.test(fnText)) rawIntervalSeedLoops.push(name);
+    if (!/startBootSeedLoop\(/.test(fnText)) ungatedSeedLoops.push(name);
+  }
+
+  assert.deepEqual(
+    rawIntervalSeedLoops,
+    [],
+    `seed loops must not schedule raw setInterval; use startBootSeedLoop: ${rawIntervalSeedLoops.join(', ')}`,
+  );
+  assert.deepEqual(
+    ungatedSeedLoops,
+    [],
+    `seed loops must call startBootSeedLoop: ${ungatedSeedLoops.join(', ')}`,
+  );
+});
+
 // ── Exclusions: internal warm-pings short-circuit at their own endpoint when the
 // data is fresh (cheap), so gating them adds risk for no benefit; real-time
 // pollers must run continuously. None of these may be wrapped. ───────────────
 test('internal warm-pings are NOT gated (self-limiting at the endpoint)', () => {
-  for (const label of ['ServiceStatuses', 'CII', 'Chokepoints', 'CableHealth']) {
+  for (const label of ['CII', 'Chokepoints', 'CableHealth']) {
     assert.ok(!relaySource.includes(`startBootSeedLoop('${label}'`), `warm-ping ${label} must not be gated`);
   }
   // and the warm-pings still fire their immediate boot ping
-  assert.match(relaySource, /seedServiceStatuses\(\)\.catch/);
   assert.match(relaySource, /seedCiiWarmPing\(\)\.catch/);
 });
 

--- a/tests/relay-boot-seed-freshness-guard.test.mjs
+++ b/tests/relay-boot-seed-freshness-guard.test.mjs
@@ -16,8 +16,8 @@
 // ais-relay.cjs calls server.listen() at top level and has no module.exports, so
 // it cannot be imported. These tests (1) extract the real guard/scheduler bodies
 // and exercise them against mocked Redis/timers, and (2) assert the source wires
-// every fixed-schedule external seeder through the scheduler while leaving
-// real-time pollers / internal warm-pings untouched.
+// every fixed-schedule external seeder AND internal warm-ping through the
+// scheduler while leaving real-time pollers (Telegram/OREF) untouched.
 
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
@@ -184,7 +184,15 @@ const SEEDERS = [
   ['Market', "'seed-meta:market:stocks'", 'MARKET_SEED_INTERVAL_MS', 'seedAllMarketData'],
   ['PositiveEvents', "'seed-meta:positive-events:geo'", 'POSITIVE_EVENTS_INTERVAL_MS', 'seedPositiveEvents'],
   ['Classify', "'seed-meta:classify'", 'CLASSIFY_SEED_INTERVAL_MS', 'seedClassify'],
+  // Internal warm-pings — gated on the seed-meta key their own RPC handler writes,
+  // so frequent relay recycling no longer re-pings these endpoints on every boot.
+  // (Previously excluded; the endpoints self-limit, so gating is risk-free here —
+  // a missing key fails open to an immediate ping — and also dedupes the boot ping
+  // against organic traffic that already kept the cache warm.)
   ['ServiceStatuses', "'seed-meta:infra:service-statuses'", 'SERVICE_STATUSES_SEED_INTERVAL_MS', 'seedServiceStatuses'],
+  ['CII', "'seed-meta:intelligence:risk-scores'", 'CII_WARM_PING_INTERVAL_MS', 'seedCiiWarmPing'],
+  ['Chokepoints', "'seed-meta:supply_chain:chokepoints'", 'CHOKEPOINT_WARM_PING_INTERVAL_MS', 'seedChokepointWarmPing'],
+  ['CableHealth', "'seed-meta:cable-health'", 'CABLE_HEALTH_WARM_PING_INTERVAL_MS', 'seedCableHealthWarmPing'],
   ['TheaterPosture', "'seed-meta:theater-posture'", 'THEATER_POSTURE_SEED_INTERVAL_MS', 'seedTheaterPosture'],
   ['Weather', "'seed-meta:weather:alerts'", 'WEATHER_SEED_INTERVAL_MS', 'seedWeatherAlerts'],
   ['Spending', "'seed-meta:economic:spending'", 'SPENDING_SEED_INTERVAL_MS', 'seedUsaSpending'],
@@ -217,12 +225,12 @@ test('exactly the expected number of boot seeds are scheduled (no drift)', () =>
   assert.equal(count, SEEDERS.length, `expected ${SEEDERS.length} gated boot seeds, found ${count}`);
 });
 
-test('every relay seed loop is routed through startBootSeedLoop instead of raw setInterval', () => {
-  const seedLoopNames = [...relaySource.matchAll(/(?:async\s+)?function\s+(start[A-Za-z0-9]+SeedLoop)\s*\(/g)]
+test('every relay seed loop and warm-ping loop is routed through startBootSeedLoop instead of raw setInterval', () => {
+  const seedLoopNames = [...relaySource.matchAll(/(?:async\s+)?function\s+(start[A-Za-z0-9]+(?:SeedLoop|WarmPingLoop))\s*\(/g)]
     .map(([, name]) => name)
     .filter((name) => name !== 'startBootSeedLoop');
 
-  assert.ok(seedLoopNames.length > 0, 'expected to find relay seed loop functions');
+  assert.ok(seedLoopNames.length > 0, 'expected to find relay seed/warm-ping loop functions');
 
   const rawIntervalSeedLoops = [];
   const ungatedSeedLoops = [];
@@ -235,24 +243,28 @@ test('every relay seed loop is routed through startBootSeedLoop instead of raw s
   assert.deepEqual(
     rawIntervalSeedLoops,
     [],
-    `seed loops must not schedule raw setInterval; use startBootSeedLoop: ${rawIntervalSeedLoops.join(', ')}`,
+    `seed/warm-ping loops must not schedule raw setInterval; use startBootSeedLoop: ${rawIntervalSeedLoops.join(', ')}`,
   );
   assert.deepEqual(
     ungatedSeedLoops,
     [],
-    `seed loops must call startBootSeedLoop: ${ungatedSeedLoops.join(', ')}`,
+    `seed/warm-ping loops must call startBootSeedLoop: ${ungatedSeedLoops.join(', ')}`,
   );
 });
 
-// ── Exclusions: internal warm-pings short-circuit at their own endpoint when the
-// data is fresh (cheap), so gating them adds risk for no benefit; real-time
-// pollers must run continuously. None of these may be wrapped. ───────────────
-test('internal warm-pings are NOT gated (self-limiting at the endpoint)', () => {
-  for (const label of ['CII', 'Chokepoints', 'CableHealth']) {
-    assert.ok(!relaySource.includes(`startBootSeedLoop('${label}'`), `warm-ping ${label} must not be gated`);
+// ── Internal warm-pings (ServiceStatuses, CII, Chokepoints, CableHealth) are
+// gated like every other fixed-schedule seeder — each routes through
+// startBootSeedLoop on the seed-meta key its RPC handler writes (asserted in the
+// SEEDERS table above). They must NOT fire an unconditional immediate boot ping,
+// so a relay reboot storm can't re-ping these endpoints on every recycle. ────────
+test('internal warm-pings no longer fire an unconditional immediate boot ping', () => {
+  for (const fn of ['seedServiceStatuses', 'seedCiiWarmPing', 'seedChokepointWarmPing', 'seedCableHealthWarmPing']) {
+    assert.doesNotMatch(
+      relaySource,
+      new RegExp(`${fn}\\(\\)\\.catch`),
+      `${fn} must be scheduled via startBootSeedLoop, not an ungated boot ping`,
+    );
   }
-  // and the warm-pings still fire their immediate boot ping
-  assert.match(relaySource, /seedCiiWarmPing\(\)\.catch/);
 });
 
 test('real-time pollers are NOT gated (must run continuously on every boot)', () => {


### PR DESCRIPTION
## Summary
- route the relay Service Statuses seed loop through `startBootSeedLoop` using the handler-written `seed-meta:infra:service-statuses` freshness key
- unref the relay snapshot/cache/YouTube-cache/memory utility intervals so they do not keep the process alive
- extend the boot-seed source guard to cover Service Statuses and fail future raw `setInterval` seed loops

## Validation
- `npm run worktree:bootstrap:test-only`
- `node --test tests/relay-boot-seed-freshness-guard.test.mjs`
- `node --check scripts/ais-relay.cjs`
- `./node_modules/.bin/tsx --test tests/relay-warm-ping-auth.test.mts`
- normal `git push` pre-push hook: typecheck, API typecheck, boundary/safe-html/rate-limit/premium-fetch checks, edge bundle check, changed relay guard test, version check
