### PR TITLE
chore(forecast): pre-wire skipWhenEmpty guard on prior extra key

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -16093,6 +16093,18 @@ export function declareRecords(data) {
   return Array.isArray(data?.predictions) ? data.predictions.length : 0;
 }
 
+export const FORECAST_EXTRA_KEYS = [
+  {
+    key: PRIOR_KEY,
+    transform: (data) => ({
+      predictions: data.predictions.map(buildPriorForecastSnapshot),
+    }),
+    ttl: 7200,
+    declareRecords,
+    skipWhenEmpty: true,
+  },
+];
+
 if (_isDirectRun) {
   const refreshRequest = await readForecastRefreshRequest();
   const triggerContext = buildForecastTriggerContext(refreshRequest);
@@ -16206,16 +16218,7 @@ if (_isDirectRun) {
         console.warn(`  [MarketImplications] Stage failed: ${err.message}`);
       }
     },
-    extraKeys: [
-      {
-        key: PRIOR_KEY,
-        transform: (data) => ({
-          predictions: data.predictions.map(buildPriorForecastSnapshot),
-        }),
-        ttl: 7200,
-        declareRecords,
-      },
-    ],
+    extraKeys: FORECAST_EXTRA_KEYS,
   });
 }
 

--- a/tests/forecast-integrity-provenance.test.mjs
+++ b/tests/forecast-integrity-provenance.test.mjs
@@ -131,4 +131,31 @@ describe('forecast integrity and provenance surfaces', () => {
       `forecast panel doc must derive cyber ceiling from CYBER_PROB_MAX=${cyberProbMax}`,
     );
   });
+
+  it('keeps forecast extra keys from clobbering last-good snapshots on empty transformed payloads', async () => {
+    const { FORECAST_EXTRA_KEYS, PRIOR_KEY, declareRecords } = await import('../scripts/seed-forecasts.mjs');
+    const { shouldSkipEmptyExtraKey } = await import('../scripts/_seed-utils.mjs');
+
+    assert.ok(FORECAST_EXTRA_KEYS.length > 0, 'forecast seeder must expose extraKeys through FORECAST_EXTRA_KEYS');
+    for (const ek of FORECAST_EXTRA_KEYS) {
+      assert.equal(
+        ek.skipWhenEmpty,
+        true,
+        `${ek.key} must opt into skipWhenEmpty so future forecast extraKeys do not overwrite last-good data with empty transforms`,
+      );
+    }
+
+    const priorExtraKey = FORECAST_EXTRA_KEYS.find((ek) => ek.key === PRIOR_KEY);
+    assert.ok(priorExtraKey, `FORECAST_EXTRA_KEYS must include ${PRIOR_KEY}`);
+
+    const emptyPriorPayload = priorExtraKey.transform({ predictions: [] });
+    const recordCount = declareRecords(emptyPriorPayload);
+
+    assert.equal(recordCount, 0, 'empty prior snapshot transforms must resolve to recordCount=0');
+    assert.equal(
+      shouldSkipEmptyExtraKey(priorExtraKey, recordCount),
+      true,
+      `${PRIOR_KEY} must skip empty writes instead of clobbering the last-good prior snapshot`,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

Defensive hardening — **not** a live clobber fix. The overwrite this guards against cannot occur on the current forecast seeder path; this PR makes the protection explicit and test-locked for future divergence.

### Why it can't fire today

The prior extra-key's record count is *identical* to the canonical count — both are 1:1 `.map()`s of the same `data.predictions`:

- canonical: `buildPublishedSeedPayload` → `predictions.map(buildPublishedForecastPayload)`
- prior key: `data.predictions.map(buildPriorForecastSnapshot)`

So the prior payload is empty **iff** the canonical is empty. And an empty canonical (no `zeroIsValid`) short-circuits at the contract `RETRY` branch in `runSeed` — which exits *before* the extra-key loop and already extends the prior key's TTL. The empty case is therefore already last-good-preserving; nothing was being clobbered, and `skipWhenEmpty` is never reached.

### Why keep it

The guard becomes load-bearing the moment the seeder diverges — e.g. a future second extra key whose transform derives a *subset* (a filtered/high-confidence slice) that can legitimately be empty while the canonical is non-empty, or flipping the canonical to `zeroIsValid: true`. To make that safe-by-default, extra keys are centralized in `FORECAST_EXTRA_KEYS` and the new test requires **every** entry to opt into `skipWhenEmpty`, so a future writer can't silently reopen the clobber path.

Normal non-empty prior snapshot writes keep identical runtime behavior; the extraction to `FORECAST_EXTRA_KEYS` is a pure refactor.

## Test Plan

- `node --test tests/forecast-integrity-provenance.test.mjs tests/seed-contract-transform-regressions.test.mjs`
- `git diff --check`
- Pre-push hook passed: `npm run typecheck`, `npm run typecheck:api`, boundary lint, safe HTML, rate-limit policy coverage, premium-fetch parity, edge function bundle check, changed forecast integrity test, and version sync

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
