### PR TITLE
fix(seed): add validation floors for derived signal seeders

### DIFF
--- a/scripts/seed-correlation.mjs
+++ b/scripts/seed-correlation.mjs
@@ -7,6 +7,8 @@ loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'correlation:cards-bootstrap:v1';
 const CACHE_TTL = 1200; // 20min — outlives maxStaleMin:15 with buffer (cron runs every 5min)
+const MIN_CORRELATION_CARDS = 1;
+const CORRELATION_CARD_DOMAINS = ['military', 'escalation', 'economic', 'disaster'];
 
 const INPUT_KEYS = [
   'military:flights:v1',
@@ -727,14 +729,27 @@ async function computeCorrelation() {
 }
 
 export function declareRecords(data) {
-  return (data?.military?.length ?? 0) + (data?.escalation?.length ?? 0) + (data?.economic?.length ?? 0) + (data?.disaster?.length ?? 0);
+  return CORRELATION_CARD_DOMAINS.reduce((total, domain) => {
+    const cards = data?.[domain];
+    return total + (Array.isArray(cards) ? cards.length : 0);
+  }, 0);
+}
+
+export function validateFn(data) {
+  return (
+    data != null &&
+    typeof data === 'object' &&
+    CORRELATION_CARD_DOMAINS.every((domain) => Array.isArray(data[domain])) &&
+    declareRecords(data) >= MIN_CORRELATION_CARDS
+  );
 }
 
 if (process.argv[1]?.endsWith('seed-correlation.mjs')) {
   runSeed('correlation', 'cards', CANONICAL_KEY, computeCorrelation, {
     ttlSeconds: CACHE_TTL,
     sourceVersion: 'correlation-engine-v1',
-    recordCount: (data) => (data.military?.length ?? 0) + (data.escalation?.length ?? 0) + (data.economic?.length ?? 0) + (data.disaster?.length ?? 0),
+    validateFn,
+    recordCount: declareRecords,
     extraKeys: [
       { key: 'correlation:military:v1', ttl: CACHE_TTL },
       { key: 'correlation:escalation:v1', ttl: CACHE_TTL },

--- a/scripts/seed-thermal-escalation.mjs
+++ b/scripts/seed-thermal-escalation.mjs
@@ -53,7 +53,7 @@ async function main() {
     ttlSeconds: CACHE_TTL,
     lockTtlMs: 180_000,
     sourceVersion: SOURCE_VERSION,
-    recordCount: (data) => data?.clusters?.length ?? 0,
+    recordCount: declareRecords,
     declareRecords,
     schemaVersion: 1,
     maxStaleMin: 360,

--- a/scripts/seed-thermal-escalation.mjs
+++ b/scripts/seed-thermal-escalation.mjs
@@ -9,6 +9,7 @@ const CANONICAL_KEY = 'thermal:escalation:v1';
 const HISTORY_KEY = 'thermal:escalation:history:v1';
 const CACHE_TTL = 6 * 60 * 60; // 6h — cron runs every 2h; 3x interval so one missed run does not expire the key (was 3h = 1.5x, too tight)
 const SOURCE_VERSION = 'thermal-escalation-v1';
+const MIN_THERMAL_ESCALATION_CLUSTERS = 1;
 let latestHistoryPayload = { updatedAt: '', cells: {} };
 
 async function fetchEscalations() {
@@ -39,12 +40,16 @@ export function declareRecords(data) {
   return Array.isArray(data?.clusters) ? data.clusters.length : 0;
 }
 
+export function validateFn(data) {
+  return declareRecords(data) >= MIN_THERMAL_ESCALATION_CLUSTERS;
+}
+
 async function main() {
   await runSeed('thermal', 'escalation', CANONICAL_KEY, async () => {
     const result = await fetchEscalations();
     return result.watch;
   }, {
-    validateFn: (data) => Array.isArray(data?.clusters),
+    validateFn,
     ttlSeconds: CACHE_TTL,
     lockTtlMs: 180_000,
     sourceVersion: SOURCE_VERSION,
@@ -63,7 +68,9 @@ async function main() {
   });
 }
 
-main().catch((err) => {
-  console.error('FATAL:', err.message || err);
-  process.exit(1);
-});
+if (process.argv[1]?.endsWith('seed-thermal-escalation.mjs')) {
+  main().catch((err) => {
+    console.error('FATAL:', err.message || err);
+    process.exit(1);
+  });
+}

--- a/tests/seeder-validation-floors.test.mjs
+++ b/tests/seeder-validation-floors.test.mjs
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  declareRecords as declareCorrelationRecords,
+  validateFn as validateCorrelationCards,
+} from '../scripts/seed-correlation.mjs';
+import {
+  declareRecords as declareThermalEscalationRecords,
+  validateFn as validateThermalEscalation,
+} from '../scripts/seed-thermal-escalation.mjs';
+
+describe('seeder validation floors', () => {
+  it('seed-correlation requires at least one real correlation card', () => {
+    const emptyDeck = { military: [], escalation: [], economic: [], disaster: [] };
+    const oneCardDeck = { ...emptyDeck, economic: [{ id: 'economic:oil', title: 'Oil spike', score: 78 }] };
+
+    assert.equal(declareCorrelationRecords(emptyDeck), 0);
+    assert.equal(validateCorrelationCards(emptyDeck), false);
+    assert.equal(declareCorrelationRecords(oneCardDeck), 1);
+    assert.equal(validateCorrelationCards(oneCardDeck), true);
+  });
+
+  it('seed-correlation rejects malformed domain buckets instead of counting incidental length', () => {
+    assert.equal(validateCorrelationCards(null), false);
+    assert.equal(validateCorrelationCards({ military: 'not-an-array', escalation: [], economic: [], disaster: [] }), false);
+    assert.equal(declareCorrelationRecords({ military: 'not-an-array', escalation: [], economic: [], disaster: [] }), 0);
+  });
+
+  it('seed-thermal-escalation requires a non-empty cluster array', () => {
+    assert.equal(validateThermalEscalation(null), false);
+    assert.equal(validateThermalEscalation({}), false);
+    assert.equal(validateThermalEscalation({ clusters: [] }), false);
+    assert.equal(declareThermalEscalationRecords({ clusters: [] }), 0);
+    assert.equal(validateThermalEscalation({ clusters: [{ id: 'ua:50-5-30-5:20260610' }] }), true);
+    assert.equal(declareThermalEscalationRecords({ clusters: [{ id: 'ua:50-5-30-5:20260610' }] }), 1);
+  });
+});

--- a/tests/seeder-validation-floors.test.mjs
+++ b/tests/seeder-validation-floors.test.mjs
@@ -30,6 +30,8 @@ describe('seeder validation floors', () => {
   it('seed-thermal-escalation requires a non-empty cluster array', () => {
     assert.equal(validateThermalEscalation(null), false);
     assert.equal(validateThermalEscalation({}), false);
+    assert.equal(validateThermalEscalation({ clusters: 'not-an-array' }), false);
+    assert.equal(declareThermalEscalationRecords({ clusters: 'not-an-array' }), 0);
     assert.equal(validateThermalEscalation({ clusters: [] }), false);
     assert.equal(declareThermalEscalationRecords({ clusters: [] }), 0);
     assert.equal(validateThermalEscalation({ clusters: [{ id: 'ua:50-5-30-5:20260610' }] }), true);


### PR DESCRIPTION
## Summary

- Add a real exported `validateFn` floor to `seed-correlation` so malformed or empty correlation-card decks skip publish instead of relying on incidental lengths.
- Tighten `seed-thermal-escalation` validation to require at least one cluster, and guard script execution so the validator can be imported safely in tests.
- Add focused regression coverage for both seeder validation floors.

## Validation

- `node --test tests/seeder-validation-floors.test.mjs`
- `node --test tests/seed-contract.test.mjs`
- `node --test tests/seeder-validation-floors.test.mjs tests/thermal-escalation-model.test.mjs`
- `node --test tests/seeder-validation-floors.test.mjs tests/thermal-escalation-model.test.mjs tests/seed-contract.test.mjs`
- Pre-push hook via `git push -u origin HEAD`
