### PR TITLE
fix(forecast): honor Retry-After in LLM provider loop

### DIFF
--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -510,6 +510,64 @@ export async function withRetry(fn, maxRetries = 3, delayMs = 1000) {
   throw lastErr;
 }
 
+/**
+ * Read a header from either a fetch `Headers` instance or a plain object
+ * (test transports commonly pass `{ 'retry-after': '2' }`). Case-insensitive.
+ */
+export function getResponseHeader(headers, name) {
+  if (!headers) return null;
+  if (typeof headers.get === 'function') return headers.get(name);
+  const lowerName = name.toLowerCase();
+  const foundKey = Object.keys(headers).find((key) => key.toLowerCase() === lowerName);
+  return foundKey ? headers[foundKey] : null;
+}
+
+/** 408 / 429 / 5xx are transient; every other status is a permanent client error. */
+export function isRetryableHttpStatus(status) {
+  return status === 408 || status === 429 || (typeof status === 'number' && status >= 500 && status <= 599);
+}
+
+/**
+ * Build an Error from a non-ok provider response for use with `withRetry`.
+ * Tags `nonRetryable` for permanent statuses and attaches a capped
+ * `retryAfterMs` hint when the server sent one:
+ *   - `maxRetryAfterMs` caps a generous server hint (e.g. a 10s ceiling).
+ *   - `capMs` (the caller's remaining wall-clock budget) caps it further and,
+ *     when <= 0, marks the error non-retryable so the loop stops instead of
+ *     sleeping past its deadline.
+ */
+export function httpRetryError(resp, { maxRetryAfterMs, capMs } = {}) {
+  const status = resp?.status;
+  const err = new Error(`HTTP ${status}`);
+  err.status = status;
+  err.nonRetryable = !isRetryableHttpStatus(status);
+  let retryAfterMs = parseRetryAfterMs(getResponseHeader(resp?.headers, 'Retry-After'));
+  if (retryAfterMs != null) {
+    if (Number.isFinite(maxRetryAfterMs)) retryAfterMs = Math.min(retryAfterMs, maxRetryAfterMs);
+    if (Number.isFinite(capMs)) retryAfterMs = Math.min(retryAfterMs, Math.max(0, capMs));
+    if (retryAfterMs > 0) err.retryAfterMs = retryAfterMs;
+    else err.nonRetryable = true;
+  }
+  return err;
+}
+
+/**
+ * Sentinel error for "the LLM call's time budget is spent". `nonRetryable`
+ * stops `withRetry` immediately; `llmBudgetExhausted` lets the provider loop
+ * distinguish a budget stop (give up, ship degraded) from a provider error
+ * (fall through to the next provider).
+ */
+export function createLlmBudgetError(message = 'llm time budget exhausted') {
+  const err = new Error(message);
+  err.nonRetryable = true;
+  err.llmBudgetExhausted = true;
+  return err;
+}
+
+export function isLlmBudgetError(err) {
+  return Boolean(err?.llmBudgetExhausted);
+}
+
 export function logSeedResult(domain, count, durationMs, extra = {}) {
   console.log(JSON.stringify({
     event: 'seed_complete',

--- a/scripts/regional-snapshot/narrative.mjs
+++ b/scripts/regional-snapshot/narrative.mjs
@@ -21,11 +21,26 @@
 //     prompt + parser without network.
 
 import { extractFirstJsonObject, cleanJsonText } from '../_llm-json.mjs';
+import { withRetry, httpRetryError, createLlmBudgetError, isLlmBudgetError } from '../_seed-utils.mjs';
 
 const CHROME_UA = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 
 const NARRATIVE_MAX_TOKENS = 900;
 const NARRATIVE_TEMPERATURE = 0.3;
+// Bounded retry for the per-region narrative call. One call per region per 6h
+// cycle under the regional bundle's section timeout: honor a provider's
+// Retry-After (429/503) instead of dropping straight to the next provider, but
+// never sleep/fetch past the remaining per-call budget.
+const NARRATIVE_LLM_MAX_RETRIES = 2;
+const NARRATIVE_LLM_RETRY_BASE_MS = 1_000;
+const NARRATIVE_LLM_RETRY_AFTER_MAX_MS = 10_000;
+const NARRATIVE_LLM_CALL_BUDGET_MS = 45_000;
+const NARRATIVE_LLM_CALL_BUDGET_GUARD_MS = 5_000;
+
+let narrativeFetchForTests = null;
+export function __setNarrativeTransportForTests(overrides = null) {
+  narrativeFetchForTests = typeof overrides?.fetch === 'function' ? overrides.fetch : null;
+}
 const MAX_ACTORS_IN_PROMPT = 5;
 const MAX_EVIDENCE_IN_PROMPT = 15;
 const MAX_TRANSMISSIONS_IN_PROMPT = 5;
@@ -291,32 +306,45 @@ export function parseNarrativeJson(text, validEvidenceIds) {
  * @param {{ validate?: (text: string) => boolean }} [opts]
  * @returns {Promise<{ text: string, provider: string, model: string } | null>}
  */
-async function callLlmDefault({ systemPrompt, userPrompt }, opts = {}) {
+export async function callLlmDefault({ systemPrompt, userPrompt }, opts = {}) {
   const validate = opts.validate;
+  const narrativeFetch = narrativeFetchForTests || ((...args) => globalThis.fetch(...args));
+  const callBudgetMs = Number.isFinite(opts.callBudgetMs)
+    ? Math.max(0, Math.floor(opts.callBudgetMs))
+    : NARRATIVE_LLM_CALL_BUDGET_MS;
+  const retryDelayMs = Number.isFinite(opts.retryDelayMs)
+    ? Math.max(0, Math.floor(opts.retryDelayMs))
+    : NARRATIVE_LLM_RETRY_BASE_MS;
+  const budgetStartedAtMs = Date.now();
+  const usableBudgetMs = () => Math.max(0, budgetStartedAtMs + callBudgetMs - Date.now() - NARRATIVE_LLM_CALL_BUDGET_GUARD_MS);
+
   for (const provider of DEFAULT_PROVIDERS) {
     const envVal = process.env[provider.envKey];
     if (!envVal) continue;
     try {
-      const resp = await fetch(provider.apiUrl, {
-        method: 'POST',
-        headers: provider.headers(envVal),
-        body: JSON.stringify({
-          model: provider.model,
-          messages: [
-            { role: 'system', content: systemPrompt },
-            { role: 'user', content: userPrompt },
-          ],
-          max_tokens: NARRATIVE_MAX_TOKENS,
-          temperature: NARRATIVE_TEMPERATURE,
-          response_format: { type: 'json_object' },
-        }),
-        signal: AbortSignal.timeout(provider.timeout),
-      });
-
-      if (!resp.ok) {
-        console.warn(`[narrative] ${provider.name}: HTTP ${resp.status}`);
-        continue;
-      }
+      const resp = await withRetry(async () => {
+        const usable = usableBudgetMs();
+        if (usable <= 0) throw createLlmBudgetError('narrative llm budget exhausted');
+        const response = await narrativeFetch(provider.apiUrl, {
+          method: 'POST',
+          headers: provider.headers(envVal),
+          body: JSON.stringify({
+            model: provider.model,
+            messages: [
+              { role: 'system', content: systemPrompt },
+              { role: 'user', content: userPrompt },
+            ],
+            max_tokens: NARRATIVE_MAX_TOKENS,
+            temperature: NARRATIVE_TEMPERATURE,
+            response_format: { type: 'json_object' },
+          }),
+          signal: AbortSignal.timeout(Math.max(1, Math.min(provider.timeout, usable))),
+        });
+        if (!response.ok) {
+          throw httpRetryError(response, { maxRetryAfterMs: NARRATIVE_LLM_RETRY_AFTER_MAX_MS, capMs: usableBudgetMs() });
+        }
+        return response;
+      }, NARRATIVE_LLM_MAX_RETRIES, retryDelayMs);
 
       const json = /** @type {any} */ (await resp.json());
       const text = json?.choices?.[0]?.message?.content;
@@ -340,6 +368,8 @@ async function callLlmDefault({ systemPrompt, userPrompt }, opts = {}) {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.warn(`[narrative] ${provider.name}: ${msg}`);
+      // Budget spent — give up rather than burning the next provider's timeout.
+      if (isLlmBudgetError(err)) return null;
     }
   }
   return null;

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -4,7 +4,7 @@
 
 import crypto from 'node:crypto';
 import { readFileSync } from 'node:fs';
-import { loadEnvFile, runSeed, CHROME_UA, withRetry, parseRetryAfterMs } from './_seed-utils.mjs';
+import { loadEnvFile, runSeed, CHROME_UA, withRetry, parseRetryAfterMs, getResponseHeader, isRetryableHttpStatus } from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { tagRegions } from './_prediction-scoring.mjs';
 import { resolveR2StorageConfig, putR2JsonObject, getR2JsonObject } from './_r2-storage.mjs';
@@ -14039,6 +14039,27 @@ const FORECAST_LLM_RETRY_AFTER_MAX_MS = 10_000;
 // The forecast seed lock is 180s; leave headroom for non-LLM work and cleanup.
 const FORECAST_LLM_STAGE_BUDGET_MS = 120_000;
 const FORECAST_LLM_STAGE_BUDGET_GUARD_MS = 5_000;
+// Cumulative LLM ceiling for one seed run. The per-stage budget bounds a single
+// call, but a run makes ~10 LLM calls (scenario/combined/critique/impact +
+// market-implications in afterPublish) — all under the same 180s lock with no
+// lock renewal. Without a run-level cap, several degraded stages still serialize
+// past 180s and the lock expires mid-run, letting the next cron tick start a
+// duplicate. 150s leaves ~30s for input reads, publish, and cleanup.
+const FORECAST_LLM_RUN_BUDGET_MS = 150_000;
+// Anchored at the start of the direct seed run; null in tests and the deep-forecast
+// worker (separate entry/lock) so only the per-stage budget applies there.
+let forecastLlmRunDeadlineMs = null;
+
+function beginForecastLlmRunBudget(runBudgetMs = FORECAST_LLM_RUN_BUDGET_MS) {
+  forecastLlmRunDeadlineMs = Number.isFinite(runBudgetMs) && runBudgetMs > 0
+    ? Date.now() + Math.floor(runBudgetMs)
+    : null;
+  return forecastLlmRunDeadlineMs;
+}
+
+function __setForecastLlmRunDeadlineForTests(deadlineMs = null) {
+  forecastLlmRunDeadlineMs = Number.isFinite(deadlineMs) ? deadlineMs : null;
+}
 
 function parseForecastProviderOrder(raw) {
   if (typeof raw !== 'string' || !raw.trim()) return null;
@@ -14340,20 +14361,6 @@ async function __callForecastLlmForTests(systemPrompt, userPrompt, options = {})
   return await callForecastLLM(systemPrompt, userPrompt, options);
 }
 
-function isForecastLlmRetryableStatus(status) {
-  return status === 408 || status === 429 || (status >= 500 && status <= 599);
-}
-
-function getResponseHeader(headers, name) {
-  if (!headers) return null;
-  if (typeof headers.get === 'function') {
-    return headers.get(name);
-  }
-  const lowerName = name.toLowerCase();
-  const foundKey = Object.keys(headers).find((key) => key.toLowerCase() === lowerName);
-  return foundKey ? headers[foundKey] : null;
-}
-
 function getForecastLlmRetryAfterMs(resp) {
   const retryAfterMs = parseRetryAfterMs(getResponseHeader(resp?.headers, 'Retry-After'));
   return retryAfterMs == null ? null : Math.min(retryAfterMs, FORECAST_LLM_RETRY_AFTER_MAX_MS);
@@ -14361,7 +14368,7 @@ function getForecastLlmRetryAfterMs(resp) {
 
 function createForecastLlmBudgetError(stage, budgetStartedAtMs, stageBudgetMs) {
   const elapsedMs = Math.max(0, Date.now() - budgetStartedAtMs);
-  const err = new Error(`stage budget exhausted after ${elapsedMs}ms (budget ${stageBudgetMs}ms)`);
+  const err = new Error(`llm budget exhausted after ${elapsedMs}ms (stage budget ${stageBudgetMs}ms)`);
   err.nonRetryable = true;
   err.forecastLlmBudgetExhausted = true;
   err.stage = stage;
@@ -14375,7 +14382,13 @@ function getForecastLlmStageBudgetMs(options = {}) {
 }
 
 function getRemainingForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs) {
-  return Math.max(0, budgetStartedAtMs + stageBudgetMs - Date.now());
+  const stageRemaining = budgetStartedAtMs + stageBudgetMs - Date.now();
+  // The run deadline (when set) caps cumulative LLM time across all stages so
+  // the seed can't outlive its 180s lock; whichever budget is tighter wins.
+  const runRemaining = forecastLlmRunDeadlineMs == null
+    ? Infinity
+    : forecastLlmRunDeadlineMs - Date.now();
+  return Math.max(0, Math.min(stageRemaining, runRemaining));
 }
 
 function getUsableForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs) {
@@ -14389,7 +14402,7 @@ function isForecastLlmBudgetError(err) {
 function createForecastLlmHttpError(resp, usableBudgetMs = Infinity) {
   const err = new Error(`HTTP ${resp.status}`);
   err.status = resp.status;
-  err.nonRetryable = !isForecastLlmRetryableStatus(resp.status);
+  err.nonRetryable = !isRetryableHttpStatus(resp.status);
   const retryAfterMs = getForecastLlmRetryAfterMs(resp);
   if (retryAfterMs != null) {
     const cappedRetryAfterMs = Number.isFinite(usableBudgetMs)
@@ -16198,6 +16211,10 @@ if (_isDirectRun) {
   const triggerContext = buildForecastTriggerContext(refreshRequest);
   console.log(`  [Trigger] source=${triggerContext.triggerSource}${triggerContext.triggerRequest?.requester ? ` requester=${triggerContext.triggerRequest.requester}` : ''}`);
 
+  // Bound cumulative LLM time across every stage of this run (fetchForecasts +
+  // afterPublish market-implications) so the seed can't outlive its 180s lock.
+  beginForecastLlmRunBudget();
+
   await runSeed('forecast', 'predictions', CANONICAL_KEY, async () => {
     const data = await fetchForecasts();
     return {
@@ -17610,5 +17627,6 @@ export {
   __callForecastLlmForTests,
   __setForecastLlmCallOverrideForTests,
   __setForecastLlmTransportForTests,
+  __setForecastLlmRunDeadlineForTests,
   __setRedisStoreForTests,
 };

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -14035,7 +14035,7 @@ const FORECAST_LLM_PROVIDERS = [
 const FORECAST_LLM_PROVIDER_NAMES = new Set(FORECAST_LLM_PROVIDERS.map(provider => provider.name));
 const FORECAST_LLM_PROVIDER_MAX_RETRIES = 2;
 const FORECAST_LLM_RETRY_BASE_MS = 1_000;
-const FORECAST_LLM_RETRY_AFTER_MAX_MS = 2_000;
+const FORECAST_LLM_RETRY_AFTER_MAX_MS = 10_000;
 
 function parseForecastProviderOrder(raw) {
   if (typeof raw !== 'string' || !raw.trim()) return null;
@@ -14344,7 +14344,7 @@ function isForecastLlmRetryableStatus(status) {
 function getResponseHeader(headers, name) {
   if (!headers) return null;
   if (typeof headers.get === 'function') {
-    return headers.get(name) || headers.get(name.toLowerCase()) || headers.get(name.toUpperCase());
+    return headers.get(name);
   }
   const lowerName = name.toLowerCase();
   const foundKey = Object.keys(headers).find((key) => key.toLowerCase() === lowerName);

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -14036,6 +14036,9 @@ const FORECAST_LLM_PROVIDER_NAMES = new Set(FORECAST_LLM_PROVIDERS.map(provider 
 const FORECAST_LLM_PROVIDER_MAX_RETRIES = 2;
 const FORECAST_LLM_RETRY_BASE_MS = 1_000;
 const FORECAST_LLM_RETRY_AFTER_MAX_MS = 10_000;
+// The forecast seed lock is 180s; leave headroom for non-LLM work and cleanup.
+const FORECAST_LLM_STAGE_BUDGET_MS = 120_000;
+const FORECAST_LLM_STAGE_BUDGET_GUARD_MS = 5_000;
 
 function parseForecastProviderOrder(raw) {
   if (typeof raw !== 'string' || !raw.trim()) return null;
@@ -14356,12 +14359,48 @@ function getForecastLlmRetryAfterMs(resp) {
   return retryAfterMs == null ? null : Math.min(retryAfterMs, FORECAST_LLM_RETRY_AFTER_MAX_MS);
 }
 
-function createForecastLlmHttpError(resp) {
+function createForecastLlmBudgetError(stage, budgetStartedAtMs, stageBudgetMs) {
+  const elapsedMs = Math.max(0, Date.now() - budgetStartedAtMs);
+  const err = new Error(`stage budget exhausted after ${elapsedMs}ms (budget ${stageBudgetMs}ms)`);
+  err.nonRetryable = true;
+  err.forecastLlmBudgetExhausted = true;
+  err.stage = stage;
+  return err;
+}
+
+function getForecastLlmStageBudgetMs(options = {}) {
+  return Number.isFinite(options.stageBudgetMs)
+    ? Math.max(0, Math.floor(options.stageBudgetMs))
+    : FORECAST_LLM_STAGE_BUDGET_MS;
+}
+
+function getRemainingForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs) {
+  return Math.max(0, budgetStartedAtMs + stageBudgetMs - Date.now());
+}
+
+function getUsableForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs) {
+  return Math.max(0, getRemainingForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs) - FORECAST_LLM_STAGE_BUDGET_GUARD_MS);
+}
+
+function isForecastLlmBudgetError(err) {
+  return Boolean(err?.forecastLlmBudgetExhausted);
+}
+
+function createForecastLlmHttpError(resp, usableBudgetMs = Infinity) {
   const err = new Error(`HTTP ${resp.status}`);
   err.status = resp.status;
   err.nonRetryable = !isForecastLlmRetryableStatus(resp.status);
   const retryAfterMs = getForecastLlmRetryAfterMs(resp);
-  if (retryAfterMs != null) err.retryAfterMs = retryAfterMs;
+  if (retryAfterMs != null) {
+    const cappedRetryAfterMs = Number.isFinite(usableBudgetMs)
+      ? Math.min(retryAfterMs, Math.max(0, usableBudgetMs))
+      : retryAfterMs;
+    if (cappedRetryAfterMs > 0) {
+      err.retryAfterMs = cappedRetryAfterMs;
+    } else {
+      err.nonRetryable = true;
+    }
+  }
   return err;
 }
 
@@ -14371,6 +14410,8 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
   }
   const stage = options.stage || 'default';
   const providers = resolveForecastLlmProviders(options);
+  const stageBudgetMs = getForecastLlmStageBudgetMs(options);
+  const budgetStartedAtMs = Date.now();
   const requestedOrder = Array.isArray(options.providerOrder) && options.providerOrder.length > 0
     ? options.providerOrder.join(',')
     : providers.map(provider => provider.name).join(',');
@@ -14385,6 +14426,8 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
         ? Math.max(0, Math.floor(options.retryDelayMs))
         : FORECAST_LLM_RETRY_BASE_MS;
       const resp = await withRetry(async () => {
+        const usableBudgetMs = getUsableForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs);
+        if (usableBudgetMs <= 0) throw createForecastLlmBudgetError(stage, budgetStartedAtMs, stageBudgetMs);
         const response = await forecastFetch(provider.apiUrl, {
           method: 'POST',
           headers: {
@@ -14402,9 +14445,14 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
             max_tokens: options.maxTokens || 1500,
             temperature: options.temperature ?? 0.3,
           }),
-          signal: AbortSignal.timeout(provider.timeout),
+          signal: AbortSignal.timeout(Math.max(1, Math.min(provider.timeout, usableBudgetMs))),
         });
-        if (!response.ok) throw createForecastLlmHttpError(response);
+        if (!response.ok) {
+          throw createForecastLlmHttpError(
+            response,
+            getUsableForecastLlmBudgetMs(budgetStartedAtMs, stageBudgetMs),
+          );
+        }
         return response;
       }, FORECAST_LLM_PROVIDER_MAX_RETRIES, retryDelayMs);
 
@@ -14422,6 +14470,7 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
       return { text, model, provider: provider.name };
     } catch (err) {
       console.warn(`  [LLM:${stage}] ${provider.name} ${err.message}`);
+      if (isForecastLlmBudgetError(err)) return null;
     }
   }
   return null;

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -4,7 +4,7 @@
 
 import crypto from 'node:crypto';
 import { readFileSync } from 'node:fs';
-import { loadEnvFile, runSeed, CHROME_UA, withRetry } from './_seed-utils.mjs';
+import { loadEnvFile, runSeed, CHROME_UA, withRetry, parseRetryAfterMs } from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 import { tagRegions } from './_prediction-scoring.mjs';
 import { resolveR2StorageConfig, putR2JsonObject, getR2JsonObject } from './_r2-storage.mjs';
@@ -14033,6 +14033,9 @@ const FORECAST_LLM_PROVIDERS = [
   { name: 'openrouter', envKey: 'OPENROUTER_API_KEY', apiUrl: 'https://openrouter.ai/api/v1/chat/completions', model: 'google/gemini-2.5-flash', timeout: 25_000 },
 ];
 const FORECAST_LLM_PROVIDER_NAMES = new Set(FORECAST_LLM_PROVIDERS.map(provider => provider.name));
+const FORECAST_LLM_PROVIDER_MAX_RETRIES = 2;
+const FORECAST_LLM_RETRY_BASE_MS = 1_000;
+const FORECAST_LLM_RETRY_AFTER_MAX_MS = 2_000;
 
 function parseForecastProviderOrder(raw) {
   if (typeof raw !== 'string' || !raw.trim()) return null;
@@ -14320,9 +14323,46 @@ function getEnrichmentFailureReason({ result, raw, scenarios = 0, perspectives =
 }
 
 let forecastLlmCallOverrideForTests = null;
+let forecastLlmFetchForTests = null;
 
 function __setForecastLlmCallOverrideForTests(override = null) {
   forecastLlmCallOverrideForTests = typeof override === 'function' ? override : null;
+}
+
+function __setForecastLlmTransportForTests(overrides = null) {
+  forecastLlmFetchForTests = typeof overrides?.fetch === 'function' ? overrides.fetch : null;
+}
+
+async function __callForecastLlmForTests(systemPrompt, userPrompt, options = {}) {
+  return await callForecastLLM(systemPrompt, userPrompt, options);
+}
+
+function isForecastLlmRetryableStatus(status) {
+  return status === 408 || status === 429 || (status >= 500 && status <= 599);
+}
+
+function getResponseHeader(headers, name) {
+  if (!headers) return null;
+  if (typeof headers.get === 'function') {
+    return headers.get(name) || headers.get(name.toLowerCase()) || headers.get(name.toUpperCase());
+  }
+  const lowerName = name.toLowerCase();
+  const foundKey = Object.keys(headers).find((key) => key.toLowerCase() === lowerName);
+  return foundKey ? headers[foundKey] : null;
+}
+
+function getForecastLlmRetryAfterMs(resp) {
+  const retryAfterMs = parseRetryAfterMs(getResponseHeader(resp?.headers, 'Retry-After'));
+  return retryAfterMs == null ? null : Math.min(retryAfterMs, FORECAST_LLM_RETRY_AFTER_MAX_MS);
+}
+
+function createForecastLlmHttpError(resp) {
+  const err = new Error(`HTTP ${resp.status}`);
+  err.status = resp.status;
+  err.nonRetryable = !isForecastLlmRetryableStatus(resp.status);
+  const retryAfterMs = getForecastLlmRetryAfterMs(resp);
+  if (retryAfterMs != null) err.retryAfterMs = retryAfterMs;
+  return err;
 }
 
 async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
@@ -14340,30 +14380,41 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
     const apiKey = process.env[provider.envKey];
     if (!apiKey) continue;
     try {
-      const resp = await fetch(provider.apiUrl, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          'Content-Type': 'application/json',
-          'User-Agent': CHROME_UA,
-          ...(provider.name === 'openrouter' ? { 'HTTP-Referer': 'https://worldmonitor.app', 'X-Title': 'World Monitor' } : {}),
-        },
-        body: JSON.stringify({
-          model: provider.model,
-          messages: [
-            { role: 'system', content: systemPrompt },
-            { role: 'user', content: userPrompt },
-          ],
-          max_tokens: options.maxTokens || 1500,
-          temperature: options.temperature ?? 0.3,
-        }),
-        signal: AbortSignal.timeout(provider.timeout),
-      });
-      if (!resp.ok) {
-        console.warn(`  [LLM:${stage}] ${provider.name} HTTP ${resp.status}`);
+      const forecastFetch = forecastLlmFetchForTests || ((...args) => globalThis.fetch(...args));
+      const retryDelayMs = Number.isFinite(options.retryDelayMs)
+        ? Math.max(0, Math.floor(options.retryDelayMs))
+        : FORECAST_LLM_RETRY_BASE_MS;
+      const resp = await withRetry(async () => {
+        const response = await forecastFetch(provider.apiUrl, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+            'User-Agent': CHROME_UA,
+            ...(provider.name === 'openrouter' ? { 'HTTP-Referer': 'https://worldmonitor.app', 'X-Title': 'World Monitor' } : {}),
+          },
+          body: JSON.stringify({
+            model: provider.model,
+            messages: [
+              { role: 'system', content: systemPrompt },
+              { role: 'user', content: userPrompt },
+            ],
+            max_tokens: options.maxTokens || 1500,
+            temperature: options.temperature ?? 0.3,
+          }),
+          signal: AbortSignal.timeout(provider.timeout),
+        });
+        if (!response.ok) throw createForecastLlmHttpError(response);
+        return response;
+      }, FORECAST_LLM_PROVIDER_MAX_RETRIES, retryDelayMs);
+
+      let json;
+      try {
+        json = await resp.json();
+      } catch (err) {
+        console.warn(`  [LLM:${stage}] ${provider.name} invalid response: ${err.message}`);
         continue;
       }
-      const json = await resp.json();
       const text = json.choices?.[0]?.message?.content?.trim();
       if (!text || text.length < 20) continue;
       const model = json.model || provider.model;
@@ -17507,6 +17558,8 @@ export {
   PROMPT_LAST_ATTEMPT_KEY,
   readImpactPromptLearnedSection,
   clearImpactPromptLearnedSection,
+  __callForecastLlmForTests,
   __setForecastLlmCallOverrideForTests,
+  __setForecastLlmTransportForTests,
   __setRedisStoreForTests,
 };

--- a/scripts/seed-insights.mjs
+++ b/scripts/seed-insights.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, getRedisCredentials, runSeed } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, getRedisCredentials, runSeed, withRetry, httpRetryError, createLlmBudgetError, isLlmBudgetError } from './_seed-utils.mjs';
 import {
   clusterItems,
   computeEntityCorroboration,
@@ -28,7 +28,12 @@ import { validateNoHallucinatedProperNouns } from './shared/brief-llm-core.js';
 const BRIEF_VALIDATOR_MODE =
   process.env.BRIEF_VALIDATOR_MODE === 'enforce' ? 'enforce' : 'shadow';
 
-loadEnvFile(import.meta.url);
+// True only when run directly as a cron entry (node seed-insights.mjs), false
+// when imported by tests — so importing the module doesn't load .env or fire a
+// live seed. Mirrors seed-forecasts.mjs.
+const _isDirectRun = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/'));
+
+if (_isDirectRun) loadEnvFile(import.meta.url);
 
 const CANONICAL_KEY = 'news:insights:v1';
 const DIGEST_KEY = 'news:digest:v1:full:en';
@@ -141,9 +146,34 @@ const LLM_PROVIDERS = [
   },
 ];
 
-async function callLLM(headline) {
+// Bounded retry for the brief LLM call. seed-insights holds a 120s seed lock
+// and makes one callLLM per run, so cap total LLM time well under it: honor a
+// provider's Retry-After (429/503) instead of dropping straight to the next
+// provider, but never sleep/fetch past the remaining call budget.
+const INSIGHTS_LLM_MAX_RETRIES = 2;
+const INSIGHTS_LLM_RETRY_BASE_MS = 1_000;
+const INSIGHTS_LLM_RETRY_AFTER_MAX_MS = 10_000;
+const INSIGHTS_LLM_CALL_BUDGET_MS = 60_000;
+const INSIGHTS_LLM_CALL_BUDGET_GUARD_MS = 5_000;
+
+let insightsLlmFetchForTests = null;
+function __setInsightsLlmTransportForTests(overrides = null) {
+  insightsLlmFetchForTests = typeof overrides?.fetch === 'function' ? overrides.fetch : null;
+}
+
+async function callLLM(headline, options = {}) {
   const systemPrompt = briefSystemPrompt(new Date().toISOString().split('T')[0]);
   const userPrompt = briefUserPrompt(headline);
+
+  const insightsFetch = insightsLlmFetchForTests || ((...args) => globalThis.fetch(...args));
+  const callBudgetMs = Number.isFinite(options.callBudgetMs)
+    ? Math.max(0, Math.floor(options.callBudgetMs))
+    : INSIGHTS_LLM_CALL_BUDGET_MS;
+  const retryDelayMs = Number.isFinite(options.retryDelayMs)
+    ? Math.max(0, Math.floor(options.retryDelayMs))
+    : INSIGHTS_LLM_RETRY_BASE_MS;
+  const budgetStartedAtMs = Date.now();
+  const usableBudgetMs = () => Math.max(0, budgetStartedAtMs + callBudgetMs - Date.now() - INSIGHTS_LLM_CALL_BUDGET_GUARD_MS);
 
   for (const provider of LLM_PROVIDERS) {
     const envVal = process.env[provider.envKey];
@@ -153,26 +183,29 @@ async function callLLM(headline) {
     const model = typeof provider.model === 'function' ? provider.model() : provider.model;
 
     try {
-      const resp = await fetch(apiUrl, {
-        method: 'POST',
-        headers: provider.headers(envVal),
-        body: JSON.stringify({
-          model,
-          messages: [
-            { role: 'system', content: systemPrompt },
-            { role: 'user', content: userPrompt },
-          ],
-          max_tokens: 300,
-          temperature: 0.1,
-          ...provider.extraBody,
-        }),
-        signal: AbortSignal.timeout(provider.timeout),
-      });
-
-      if (!resp.ok) {
-        console.warn(`  ${provider.name} API error: ${resp.status}`);
-        continue;
-      }
+      const resp = await withRetry(async () => {
+        const usable = usableBudgetMs();
+        if (usable <= 0) throw createLlmBudgetError('insights llm budget exhausted');
+        const response = await insightsFetch(apiUrl, {
+          method: 'POST',
+          headers: provider.headers(envVal),
+          body: JSON.stringify({
+            model,
+            messages: [
+              { role: 'system', content: systemPrompt },
+              { role: 'user', content: userPrompt },
+            ],
+            max_tokens: 300,
+            temperature: 0.1,
+            ...provider.extraBody,
+          }),
+          signal: AbortSignal.timeout(Math.max(1, Math.min(provider.timeout, usable))),
+        });
+        if (!response.ok) {
+          throw httpRetryError(response, { maxRetryAfterMs: INSIGHTS_LLM_RETRY_AFTER_MAX_MS, capMs: usableBudgetMs() });
+        }
+        return response;
+      }, INSIGHTS_LLM_MAX_RETRIES, retryDelayMs);
 
       const json = await resp.json();
       const rawText = json.choices?.[0]?.message?.content?.trim();
@@ -195,6 +228,8 @@ async function callLLM(headline) {
       return { text, model: json.model || model, provider: provider.name };
     } catch (err) {
       console.warn(`  ${provider.name} failed: ${err.message}`);
+      // Budget spent — give up rather than burning the next provider's timeout.
+      if (isLlmBudgetError(err)) return null;
     }
   }
 
@@ -474,16 +509,20 @@ export function declareRecords(data) {
   return Array.isArray(data?.topStories) ? data.topStories.length : 0;
 }
 
-runSeed('news', 'insights', CANONICAL_KEY, fetchInsights, {
-  validateFn: validate,
-  ttlSeconds: CACHE_TTL,
-  sourceVersion: 'digest-clustering-v2-importance-diversity',
+export { callLLM, __setInsightsLlmTransportForTests };
 
-  declareRecords,
-  schemaVersion: 1,
-  maxStaleMin: 30,
-}).catch((err) => {
-  const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
-  // Exit gracefully for cron — health endpoint flags stale data via seed-meta.
-  process.exit(0);
-});
+if (_isDirectRun) {
+  runSeed('news', 'insights', CANONICAL_KEY, fetchInsights, {
+    validateFn: validate,
+    ttlSeconds: CACHE_TTL,
+    sourceVersion: 'digest-clustering-v2-importance-diversity',
+
+    declareRecords,
+    schemaVersion: 1,
+    maxStaleMin: 30,
+  }).catch((err) => {
+    const _cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : ''; console.error('FATAL:', (err.message || err) + _cause);
+    // Exit gracefully for cron — health endpoint flags stale data via seed-meta.
+    process.exit(0);
+  });
+}

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -1267,6 +1267,51 @@ describe('forecast llm overrides', () => {
     }
   });
 
+  it('caps oversized Retry-After hints before retrying a forecast LLM provider', async () => {
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
+    const originalSetTimeout = globalThis.setTimeout;
+    const waits = [];
+    let calls = 0;
+    globalThis.setTimeout = (fn, ms, ...args) => {
+      waits.push(ms);
+      fn(...args);
+      return 0;
+    };
+
+    try {
+      __setForecastLlmTransportForTests({
+        fetch: async () => {
+          calls += 1;
+          if (calls === 1) {
+            return {
+              ok: false,
+              status: 429,
+              headers: { get: (name) => (name.toLowerCase() === 'retry-after' ? '30' : null) },
+            };
+          }
+          return {
+            ok: true,
+            status: 200,
+            headers: { get: () => null },
+            json: async () => ({
+              model: 'llama-3.1-8b-instant',
+              choices: [{ message: { content: 'Groq capped retry succeeded with enough narrative content.' } }],
+            }),
+          };
+        },
+      });
+
+      const result = await __callForecastLlmForTests('system', 'user', { stage: 'scenario', retryDelayMs: 0 });
+
+      assert.deepEqual(waits, [10000]);
+      assert.equal(calls, 2);
+      assert.equal(result?.provider, 'groq');
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+
   it('falls back to openrouter after exhausting groq retries and preserves provider/model', async () => {
     process.env.GROQ_API_KEY = 'groq-test-key';
     process.env.OPENROUTER_API_KEY = 'openrouter-test-key';

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -79,6 +79,7 @@ import {
   PROJECTION_CURVES,
   __setForecastLlmCallOverrideForTests,
   __setForecastLlmTransportForTests,
+  __setForecastLlmRunDeadlineForTests,
 } from '../scripts/seed-forecasts.mjs';
 
 const originalForecastEnv = {
@@ -95,6 +96,7 @@ const originalForecastEnv = {
 afterEach(() => {
   __setForecastLlmCallOverrideForTests(null);
   __setForecastLlmTransportForTests(null);
+  __setForecastLlmRunDeadlineForTests(null);
   for (const [key, value] of Object.entries(originalForecastEnv)) {
     if (value === undefined) delete process.env[key];
     else process.env[key] = value;
@@ -1351,6 +1353,55 @@ describe('forecast llm overrides', () => {
       assert.equal(result, null);
       assert.equal(calls, 2);
       assert.deepEqual(waits, [10000, 2000]);
+    } finally {
+      Date.now = originalDateNow;
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+
+  it('caps cumulative LLM time by the run budget even when the stage budget is generous', async () => {
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
+    const originalDateNow = Date.now;
+    const originalSetTimeout = globalThis.setTimeout;
+    const waits = [];
+    let now = 1_000;
+    let calls = 0;
+    Date.now = () => now;
+    globalThis.setTimeout = (fn, ms, ...args) => {
+      waits.push(ms);
+      now += ms;
+      fn(...args);
+      return 0;
+    };
+
+    try {
+      // Run deadline 12s out; a single 7s usable window remains after the 5s
+      // guard, so exactly one attempt fires and its Retry-After sleep is capped
+      // to the remaining RUN budget — not the (generous) per-stage budget.
+      __setForecastLlmRunDeadlineForTests(now + 12_000);
+      __setForecastLlmTransportForTests({
+        fetch: async (url) => {
+          calls += 1;
+          assert.ok(String(url).includes('api.groq.com'), 'run-budget stop should not fall through to the next provider');
+          return {
+            ok: false,
+            status: 429,
+            headers: { get: (name) => (name.toLowerCase() === 'retry-after' ? '30' : null) },
+          };
+        },
+      });
+
+      const result = await __callForecastLlmForTests('system', 'user', {
+        stage: 'scenario',
+        providerOrder: ['groq', 'openrouter'],
+        retryDelayMs: 0,
+        stageBudgetMs: 120_000,
+      });
+
+      assert.equal(result, null);
+      assert.equal(calls, 1);
+      assert.deepEqual(waits, [7000]);
     } finally {
       Date.now = originalDateNow;
       globalThis.setTimeout = originalSetTimeout;

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -1312,6 +1312,51 @@ describe('forecast llm overrides', () => {
     }
   });
 
+  it('bounds Retry-After sleeps by the forecast LLM stage budget', async () => {
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
+    const originalDateNow = Date.now;
+    const originalSetTimeout = globalThis.setTimeout;
+    const waits = [];
+    let now = 1_000;
+    let calls = 0;
+    Date.now = () => now;
+    globalThis.setTimeout = (fn, ms, ...args) => {
+      waits.push(ms);
+      now += ms;
+      fn(...args);
+      return 0;
+    };
+
+    try {
+      __setForecastLlmTransportForTests({
+        fetch: async (url) => {
+          calls += 1;
+          assert.ok(String(url).includes('api.groq.com'), 'budget exhaustion should not fall through to the next provider');
+          return {
+            ok: false,
+            status: 429,
+            headers: { get: (name) => (name.toLowerCase() === 'retry-after' ? '30' : null) },
+          };
+        },
+      });
+
+      const result = await __callForecastLlmForTests('system', 'user', {
+        stage: 'scenario',
+        providerOrder: ['groq', 'openrouter'],
+        retryDelayMs: 0,
+        stageBudgetMs: 17_000,
+      });
+
+      assert.equal(result, null);
+      assert.equal(calls, 2);
+      assert.deepEqual(waits, [10000, 2000]);
+    } finally {
+      Date.now = originalDateNow;
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+
   it('falls back to openrouter after exhausting groq retries and preserves provider/model', async () => {
     process.env.GROQ_API_KEY = 'groq-test-key';
     process.env.OPENROUTER_API_KEY = 'openrouter-test-key';

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -60,6 +60,7 @@ import {
   parseForecastProviderOrder,
   getForecastLlmCallOptions,
   resolveForecastLlmProviders,
+  __callForecastLlmForTests,
   buildFallbackScenario,
   buildFallbackBaseCase,
   buildFallbackEscalatoryCase,
@@ -77,6 +78,7 @@ import {
   DEFAULT_CASCADE_RULES,
   PROJECTION_CURVES,
   __setForecastLlmCallOverrideForTests,
+  __setForecastLlmTransportForTests,
 } from '../scripts/seed-forecasts.mjs';
 
 const originalForecastEnv = {
@@ -84,12 +86,15 @@ const originalForecastEnv = {
   FORECAST_LLM_COMBINED_PROVIDER_ORDER: process.env.FORECAST_LLM_COMBINED_PROVIDER_ORDER,
   FORECAST_LLM_MODEL_OPENROUTER: process.env.FORECAST_LLM_MODEL_OPENROUTER,
   FORECAST_LLM_COMBINED_MODEL_OPENROUTER: process.env.FORECAST_LLM_COMBINED_MODEL_OPENROUTER,
+  GROQ_API_KEY: process.env.GROQ_API_KEY,
+  OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
   UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
   UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
 };
 
 afterEach(() => {
   __setForecastLlmCallOverrideForTests(null);
+  __setForecastLlmTransportForTests(null);
   for (const [key, value] of Object.entries(originalForecastEnv)) {
     if (value === undefined) delete process.env[key];
     else process.env[key] = value;
@@ -1210,6 +1215,132 @@ describe('forecast llm overrides', () => {
     assert.equal(providers.length, 1);
     assert.equal(providers[0]?.name, 'openrouter');
     assert.equal(providers[0]?.model, 'google/gemini-2.5-flash-lite-preview');
+  });
+
+  it('retries a 429 Retry-After response on the same provider and returns groq', async () => {
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
+    const originalSetTimeout = globalThis.setTimeout;
+    const calls = [];
+    const waits = [];
+    globalThis.setTimeout = (fn, ms, ...args) => {
+      waits.push(ms);
+      fn(...args);
+      return 0;
+    };
+
+    try {
+      __setForecastLlmTransportForTests({
+        fetch: async (url) => {
+          calls.push(String(url));
+          if (calls.length <= 2) {
+            return {
+              ok: false,
+              status: 429,
+              headers: { get: (name) => (name.toLowerCase() === 'retry-after' ? '2' : null) },
+            };
+          }
+          return {
+            ok: true,
+            status: 200,
+            headers: { get: () => null },
+            json: async () => ({
+              model: 'llama-3.1-8b-instant',
+              choices: [{ message: { content: 'Groq retry succeeded with enough narrative content.' } }],
+            }),
+          };
+        },
+      });
+
+      const result = await __callForecastLlmForTests('system', 'user', { stage: 'scenario', retryDelayMs: 0 });
+
+      assert.deepEqual(waits, [2000, 2000]);
+      assert.equal(calls.length, 3);
+      assert.ok(calls.every((url) => url.includes('api.groq.com')));
+      assert.deepEqual(result, {
+        text: 'Groq retry succeeded with enough narrative content.',
+        model: 'llama-3.1-8b-instant',
+        provider: 'groq',
+      });
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+
+  it('falls back to openrouter after exhausting groq retries and preserves provider/model', async () => {
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
+    const providers = [];
+
+    __setForecastLlmTransportForTests({
+      fetch: async (url) => {
+        const href = String(url);
+        providers.push(href.includes('api.groq.com') ? 'groq' : 'openrouter');
+        if (href.includes('api.groq.com')) {
+          return {
+            ok: false,
+            status: 503,
+            headers: { get: () => null },
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          headers: { get: () => null },
+          json: async () => ({
+            model: 'openrouter/gemini-test',
+            choices: [{ message: { content: 'OpenRouter fallback succeeded with enough narrative content.' } }],
+          }),
+        };
+      },
+    });
+
+    const result = await __callForecastLlmForTests('system', 'user', { stage: 'scenario', retryDelayMs: 0 });
+
+    assert.deepEqual(providers, ['groq', 'groq', 'groq', 'openrouter']);
+    assert.deepEqual(result, {
+      text: 'OpenRouter fallback succeeded with enough narrative content.',
+      model: 'openrouter/gemini-test',
+      provider: 'openrouter',
+    });
+  });
+
+  it('does not retry non-retryable 402 before falling back', async () => {
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
+    const providers = [];
+
+    __setForecastLlmTransportForTests({
+      fetch: async (url) => {
+        const href = String(url);
+        providers.push(href.includes('api.groq.com') ? 'groq' : 'openrouter');
+        if (href.includes('api.groq.com')) {
+          return {
+            ok: false,
+            status: 402,
+            headers: { get: () => null },
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          headers: { get: () => null },
+          json: async () => ({
+            model: 'openrouter/no-retry-test',
+            choices: [{ message: { content: 'OpenRouter fallback after non retryable status has enough content.' } }],
+          }),
+        };
+      },
+    });
+
+    const result = await __callForecastLlmForTests('system', 'user', { stage: 'scenario', retryDelayMs: 0 });
+
+    assert.deepEqual(providers, ['groq', 'openrouter']);
+    assert.deepEqual(result, {
+      text: 'OpenRouter fallback after non retryable status has enough content.',
+      model: 'openrouter/no-retry-test',
+      provider: 'openrouter',
+    });
   });
 
   it('recovers impact expansion output after an initial invalid parse', async () => {

--- a/tests/regional-snapshot-narrative-retry.test.mjs
+++ b/tests/regional-snapshot-narrative-retry.test.mjs
@@ -1,0 +1,139 @@
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { callLlmDefault, __setNarrativeTransportForTests } from '../scripts/regional-snapshot/narrative.mjs';
+
+const PROMPT = { systemPrompt: 'system', userPrompt: 'user' };
+
+const originalEnv = {
+  GROQ_API_KEY: process.env.GROQ_API_KEY,
+  OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
+};
+
+afterEach(() => {
+  __setNarrativeTransportForTests(null);
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+function okResponse(model, content) {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    json: async () => ({ model, choices: [{ message: { content } }] }),
+  };
+}
+
+describe('narrative callLlmDefault retry/budget', () => {
+  it('honors a 429 Retry-After on the same provider before falling through', async () => {
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
+    const originalSetTimeout = globalThis.setTimeout;
+    const waits = [];
+    const calls = [];
+    globalThis.setTimeout = (fn, ms, ...args) => { waits.push(ms); fn(...args); return 0; };
+
+    try {
+      __setNarrativeTransportForTests({
+        fetch: async (url) => {
+          calls.push(String(url));
+          if (calls.length <= 2) {
+            return { ok: false, status: 429, headers: { get: (n) => (n.toLowerCase() === 'retry-after' ? '2' : null) } };
+          }
+          return okResponse('llama-3.3-70b-versatile', '{"situation":"ok"}');
+        },
+      });
+
+      const result = await callLlmDefault(PROMPT, { retryDelayMs: 0 });
+
+      assert.deepEqual(waits, [2000, 2000]);
+      assert.equal(calls.length, 3);
+      assert.ok(calls.every((u) => u.includes('api.groq.com')));
+      assert.equal(result?.provider, 'groq');
+      assert.equal(result?.model, 'llama-3.3-70b-versatile');
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+
+  it('caps an oversized Retry-After hint before retrying', async () => {
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
+    const originalSetTimeout = globalThis.setTimeout;
+    const waits = [];
+    let calls = 0;
+    globalThis.setTimeout = (fn, ms, ...args) => { waits.push(ms); fn(...args); return 0; };
+
+    try {
+      __setNarrativeTransportForTests({
+        fetch: async () => {
+          calls += 1;
+          if (calls === 1) return { ok: false, status: 503, headers: { get: (n) => (n.toLowerCase() === 'retry-after' ? '30' : null) } };
+          return okResponse('llama-3.3-70b-versatile', '{"situation":"ok"}');
+        },
+      });
+
+      const result = await callLlmDefault(PROMPT, { retryDelayMs: 0 });
+
+      assert.deepEqual(waits, [10000]);
+      assert.equal(calls, 2);
+      assert.equal(result?.provider, 'groq');
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+
+  it('stops at the call budget without falling through to the next provider', async () => {
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
+    const originalDateNow = Date.now;
+    const originalSetTimeout = globalThis.setTimeout;
+    const waits = [];
+    let now = 1_000;
+    let calls = 0;
+    Date.now = () => now;
+    globalThis.setTimeout = (fn, ms, ...args) => { waits.push(ms); now += ms; fn(...args); return 0; };
+
+    try {
+      __setNarrativeTransportForTests({
+        fetch: async (url) => {
+          calls += 1;
+          assert.ok(String(url).includes('api.groq.com'), 'budget stop must not fall through to openrouter');
+          return { ok: false, status: 429, headers: { get: (n) => (n.toLowerCase() === 'retry-after' ? '30' : null) } };
+        },
+      });
+
+      const result = await callLlmDefault(PROMPT, { retryDelayMs: 0, callBudgetMs: 17_000 });
+
+      assert.equal(result, null);
+      assert.equal(calls, 2);
+      assert.deepEqual(waits, [10000, 2000]);
+    } finally {
+      Date.now = originalDateNow;
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+
+  it('falls through to the next provider after a non-retryable 402', async () => {
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
+    const providers = [];
+
+    __setNarrativeTransportForTests({
+      fetch: async (url) => {
+        const href = String(url);
+        providers.push(href.includes('api.groq.com') ? 'groq' : 'openrouter');
+        if (href.includes('api.groq.com')) return { ok: false, status: 402, headers: { get: () => null } };
+        return okResponse('openrouter/gemini', '{"situation":"ok"}');
+      },
+    });
+
+    const result = await callLlmDefault(PROMPT, { retryDelayMs: 0 });
+
+    assert.deepEqual(providers, ['groq', 'openrouter']);
+    assert.equal(result?.provider, 'openrouter');
+  });
+});

--- a/tests/seed-insights-llm-retry.test.mjs
+++ b/tests/seed-insights-llm-retry.test.mjs
@@ -1,0 +1,144 @@
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { callLLM, __setInsightsLlmTransportForTests } from '../scripts/seed-insights.mjs';
+
+const LONG_BRIEF = 'Insights brief succeeded with more than enough narrative content to pass.';
+
+const originalEnv = {
+  GROQ_API_KEY: process.env.GROQ_API_KEY,
+  OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY,
+  OLLAMA_API_URL: process.env.OLLAMA_API_URL,
+};
+
+afterEach(() => {
+  __setInsightsLlmTransportForTests(null);
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+function okResponse(content) {
+  return {
+    ok: true,
+    status: 200,
+    headers: { get: () => null },
+    json: async () => ({ model: 'llama-3.1-8b-instant', choices: [{ message: { content } }] }),
+  };
+}
+
+describe('seed-insights callLLM retry/budget', () => {
+  it('honors a 429 Retry-After on the same provider before falling through', async () => {
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
+    delete process.env.OLLAMA_API_URL;
+    const originalSetTimeout = globalThis.setTimeout;
+    const waits = [];
+    const calls = [];
+    globalThis.setTimeout = (fn, ms, ...args) => { waits.push(ms); fn(...args); return 0; };
+
+    try {
+      __setInsightsLlmTransportForTests({
+        fetch: async (url) => {
+          calls.push(String(url));
+          if (calls.length <= 2) {
+            return { ok: false, status: 429, headers: { get: (n) => (n.toLowerCase() === 'retry-after' ? '2' : null) } };
+          }
+          return okResponse(LONG_BRIEF);
+        },
+      });
+
+      const result = await callLLM('Some breaking headline', { retryDelayMs: 0 });
+
+      assert.deepEqual(waits, [2000, 2000]);
+      assert.equal(calls.length, 3);
+      assert.ok(calls.every((u) => u.includes('api.groq.com')));
+      assert.equal(result?.provider, 'groq');
+      assert.equal(result?.text, LONG_BRIEF);
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+
+  it('caps an oversized Retry-After hint before retrying', async () => {
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
+    delete process.env.OLLAMA_API_URL;
+    const originalSetTimeout = globalThis.setTimeout;
+    const waits = [];
+    let calls = 0;
+    globalThis.setTimeout = (fn, ms, ...args) => { waits.push(ms); fn(...args); return 0; };
+
+    try {
+      __setInsightsLlmTransportForTests({
+        fetch: async () => {
+          calls += 1;
+          if (calls === 1) return { ok: false, status: 429, headers: { get: (n) => (n.toLowerCase() === 'retry-after' ? '30' : null) } };
+          return okResponse(LONG_BRIEF);
+        },
+      });
+
+      const result = await callLLM('Some breaking headline', { retryDelayMs: 0 });
+
+      assert.deepEqual(waits, [10000]);
+      assert.equal(calls, 2);
+      assert.equal(result?.provider, 'groq');
+    } finally {
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+
+  it('stops at the call budget without falling through to the next provider', async () => {
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
+    delete process.env.OLLAMA_API_URL;
+    const originalDateNow = Date.now;
+    const originalSetTimeout = globalThis.setTimeout;
+    const waits = [];
+    let now = 1_000;
+    let calls = 0;
+    Date.now = () => now;
+    globalThis.setTimeout = (fn, ms, ...args) => { waits.push(ms); now += ms; fn(...args); return 0; };
+
+    try {
+      __setInsightsLlmTransportForTests({
+        fetch: async (url) => {
+          calls += 1;
+          assert.ok(String(url).includes('api.groq.com'), 'budget stop must not fall through to openrouter');
+          return { ok: false, status: 429, headers: { get: (n) => (n.toLowerCase() === 'retry-after' ? '30' : null) } };
+        },
+      });
+
+      const result = await callLLM('Some breaking headline', { retryDelayMs: 0, callBudgetMs: 17_000 });
+
+      assert.equal(result, null);
+      assert.equal(calls, 2);
+      assert.deepEqual(waits, [10000, 2000]);
+    } finally {
+      Date.now = originalDateNow;
+      globalThis.setTimeout = originalSetTimeout;
+    }
+  });
+
+  it('falls through to the next provider after a non-retryable 402', async () => {
+    process.env.GROQ_API_KEY = 'groq-test-key';
+    process.env.OPENROUTER_API_KEY = 'openrouter-test-key';
+    delete process.env.OLLAMA_API_URL;
+    const providers = [];
+
+    __setInsightsLlmTransportForTests({
+      fetch: async (url) => {
+        const href = String(url);
+        providers.push(href.includes('api.groq.com') ? 'groq' : 'openrouter');
+        if (href.includes('api.groq.com')) return { ok: false, status: 402, headers: { get: () => null } };
+        return okResponse(LONG_BRIEF);
+      },
+    });
+
+    const result = await callLLM('Some breaking headline', { retryDelayMs: 0 });
+
+    assert.deepEqual(providers, ['groq', 'openrouter']);
+    assert.equal(result?.provider, 'openrouter');
+  });
+});

--- a/tests/seed-utils-with-retry.test.mjs
+++ b/tests/seed-utils-with-retry.test.mjs
@@ -5,6 +5,11 @@ import {
   withRetry,
   parseRetryAfterMs,
   PERMANENT_4XX_STATUSES,
+  getResponseHeader,
+  isRetryableHttpStatus,
+  httpRetryError,
+  createLlmBudgetError,
+  isLlmBudgetError,
 } from '../scripts/_seed-utils.mjs';
 
 describe('PERMANENT_4XX_STATUSES classification', () => {
@@ -286,5 +291,85 @@ describe('atomicPublish retry-on-transient (WM 2026-05-10 incident fix)', () => 
     } finally {
       teardown();
     }
+  });
+});
+
+describe('getResponseHeader', () => {
+  it('reads from a fetch Headers-like object (case-insensitive .get)', () => {
+    const headers = { get: (n) => (n.toLowerCase() === 'retry-after' ? '5' : null) };
+    assert.equal(getResponseHeader(headers, 'Retry-After'), '5');
+  });
+
+  it('reads from a plain object case-insensitively', () => {
+    assert.equal(getResponseHeader({ 'retry-after': '7' }, 'Retry-After'), '7');
+    assert.equal(getResponseHeader({ 'Retry-After': '9' }, 'retry-after'), '9');
+  });
+
+  it('returns null for missing headers or missing key', () => {
+    assert.equal(getResponseHeader(null, 'Retry-After'), null);
+    assert.equal(getResponseHeader({}, 'Retry-After'), null);
+  });
+});
+
+describe('isRetryableHttpStatus', () => {
+  it('treats 408/429/5xx as retryable and everything else as permanent', () => {
+    for (const code of [408, 429, 500, 502, 503, 504, 599]) {
+      assert.equal(isRetryableHttpStatus(code), true, `expected ${code} retryable`);
+    }
+    for (const code of [200, 400, 401, 402, 403, 404, 410, 422, 451]) {
+      assert.equal(isRetryableHttpStatus(code), false, `expected ${code} permanent`);
+    }
+  });
+});
+
+describe('httpRetryError', () => {
+  it('tags permanent statuses nonRetryable with no retryAfterMs', () => {
+    const err = httpRetryError({ status: 402, headers: { get: () => null } });
+    assert.equal(err.status, 402);
+    assert.equal(err.nonRetryable, true);
+    assert.equal(err.retryAfterMs, undefined);
+  });
+
+  it('attaches a Retry-After hint for retryable statuses', () => {
+    const err = httpRetryError({ status: 429, headers: { get: (n) => (n.toLowerCase() === 'retry-after' ? '3' : null) } });
+    assert.equal(err.nonRetryable, false);
+    assert.equal(err.retryAfterMs, 3000);
+  });
+
+  it('caps the hint by maxRetryAfterMs (server ceiling)', () => {
+    const err = httpRetryError(
+      { status: 503, headers: { get: (n) => (n.toLowerCase() === 'retry-after' ? '30' : null) } },
+      { maxRetryAfterMs: 10_000 },
+    );
+    assert.equal(err.retryAfterMs, 10_000);
+  });
+
+  it('caps the hint by capMs (remaining budget) and turns nonRetryable when budget <= 0', () => {
+    const within = httpRetryError(
+      { status: 429, headers: { get: (n) => (n.toLowerCase() === 'retry-after' ? '30' : null) } },
+      { maxRetryAfterMs: 10_000, capMs: 4_000 },
+    );
+    assert.equal(within.retryAfterMs, 4_000);
+
+    const exhausted = httpRetryError(
+      { status: 429, headers: { get: (n) => (n.toLowerCase() === 'retry-after' ? '30' : null) } },
+      { maxRetryAfterMs: 10_000, capMs: 0 },
+    );
+    assert.equal(exhausted.retryAfterMs, undefined);
+    assert.equal(exhausted.nonRetryable, true);
+  });
+});
+
+describe('createLlmBudgetError / isLlmBudgetError', () => {
+  it('produces a nonRetryable, recognizable budget sentinel', () => {
+    const err = createLlmBudgetError('forecast budget spent');
+    assert.equal(err.nonRetryable, true);
+    assert.equal(isLlmBudgetError(err), true);
+    assert.match(err.message, /forecast budget spent/);
+  });
+
+  it('does not misclassify ordinary errors', () => {
+    assert.equal(isLlmBudgetError(new Error('boom')), false);
+    assert.equal(isLlmBudgetError(null), false);
   });
 });


### PR DESCRIPTION
## Summary

- add bounded `withRetry()` handling around each forecast LLM provider call
- honor parsed `Retry-After` hints for retryable 408/429/5xx provider responses, capped for the forecast cron path
- keep provider fallback provenance intact so successful fallbacks still report the provider/model that produced the narrative

## Tests

- `node --check scripts/seed-forecasts.mjs`
- `node --test tests/forecast-detectors.test.mjs`
- `node --test tests/forecast-integrity-provenance.test.mjs`
- `git diff --check`
- pre-push hook on `git push -u origin codex/qw8-forecast-llm-retry-after`
