### PR TITLE
fix(health): cover webcams and digest cron heartbeat

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -516,6 +516,11 @@ const ON_DEMAND_KEYS = new Set([
   'climateNewsRelayHeartbeat',     // TRANSITIONAL (PR #3133): same deploy-order rationale.
                                    // 30min initial loop, so window is shorter but still present.
                                    // Remove after ~7 days alongside the chokepoint-flows entry.
+  'digestNotifications',           // TRANSITIONAL (PR #4253): seed-digest-notifications.mjs writes
+                                   // `digest:last-run` on the first cron run after deploy. Vercel
+                                   // can publish this health registry before Railway's 30min cron
+                                   // ticks, so gate only the first absent-key window as WARN. Remove
+                                   // after ~7 days of clean `seed-meta:digest:last-run` writes.
   'eiaPetroleum',                  // TRANSITIONAL: gold-standard migration of /api/eia/petroleum
                                    // from live Vercel fetch to Redis-reader (seed-bundle-energy-sources
                                    // daily cron). SEED_META entry above enforces 72h staleness — this

--- a/api/health.js
+++ b/api/health.js
@@ -233,6 +233,8 @@ const STANDALONE_KEYS = {
   chokepointFlowsRelayHeartbeat: 'relay:heartbeat:chokepoint-flows',
   climateNewsRelayHeartbeat:     'relay:heartbeat:climate-news',
   telegramFeed:                  'intelligence:telegram-feed:v1',
+  digestNotifications:           'digest:last-run',
+  webcams:                       'webcam:cameras:active',
 };
 
 const SEED_META = {
@@ -314,6 +316,7 @@ const SEED_META = {
   techEvents:       { key: 'seed-meta:research:tech-events',       maxStaleMin: 480 },
   gdeltIntel:       { key: 'seed-meta:intelligence:gdelt-intel',   maxStaleMin: 720 }, // 6h cron; 12h staleness = 2× cadence = 1 missed tick + cron jitter, alerts at 2 missed ticks. Bumped from 420 (1.16× cadence, virtually zero margin) on 2026-05-12 after the same Railway-deploy-preempted-tick pattern that hit resilienceIntervals on 2026-05-10 (PR #3652): seedAgeMin=467 vs maxStale=420 → ~1min UptimeRobot WARNING flip when a deploy preempted the 15:00 UTC tick. CACHE_TTL is 24h so per-topic merge always has a prior snapshot even at the upper end of the new budget.
   telegramFeed:     { key: 'seed-meta:intelligence:telegram-feed:v1', maxStaleMin: 10 }, // 60s poll interval; 10min grace catches poll failures before they go stale in the panel
+  digestNotifications: { key: 'seed-meta:digest:last-run',          maxStaleMin: 90 }, // Railway digest-notifications cron runs every 30min; 90 = 3x cadence and detects a dead cron before daily digests are missed.
   forecasts:        { key: 'seed-meta:forecast:predictions',       maxStaleMin: 90 },
   sectors:          { key: 'seed-meta:market:sectors',             maxStaleMin: 30 },
   techReadiness:    { key: 'seed-meta:economic:worldbank-techreadiness:v1', maxStaleMin: 10080 },
@@ -446,6 +449,7 @@ const SEED_META = {
   lowCarbonGeneration:     { key: 'seed-meta:resilience:low-carbon-generation',     maxStaleMin: 11520 },
   fossilElectricityShare:  { key: 'seed-meta:resilience:fossil-electricity-share',  maxStaleMin: 11520 },
   powerLosses:             { key: 'seed-meta:resilience:power-losses',              maxStaleMin: 11520 },
+  webcams:                 { key: 'seed-meta:webcam:cameras:geo',                   maxStaleMin: 1440 }, // seed-webcams writes 24h geo/meta keys plus a 30h active pointer; stale at 24h before the layer goes blank.
 };
 
 // Standalone keys that are populated on-demand by RPC handlers (not seeds).

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -117,6 +117,7 @@ const RESEND_FROM =
 const DIGEST_LAST_RUN_KEY = 'digest:last-run';
 const DIGEST_LAST_RUN_META_KEY = 'seed-meta:digest:last-run';
 const DIGEST_LAST_RUN_TTL_SECONDS = 7 * 24 * 60 * 60;
+let digestRunStartedAtMs = null;
 
 if (process.env.DIGEST_CRON_ENABLED === '0') {
   console.log('[digest] DIGEST_CRON_ENABLED=0 — skipping run');
@@ -2141,6 +2142,7 @@ async function composeAndStoreBriefForUser(userId, annotated, insightsNumbers, d
 
 async function main() {
   const nowMs = Date.now();
+  digestRunStartedAtMs = nowMs;
   console.log('[digest] Cron run start:', new Date(nowMs).toISOString());
 
   let rules;
@@ -3000,9 +3002,11 @@ async function main() {
 }
 
 main().catch(async (err) => {
+  const finishedAtMs = Date.now();
   console.error('[digest] Fatal:', err);
   await writeDigestLastRunMeta({
-    startedAtMs: Date.now(),
+    startedAtMs: digestRunStartedAtMs ?? finishedAtMs,
+    finishedAtMs,
     status: 'error',
     errorReason: `fatal:${err?.message ?? err}`,
   });

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -114,6 +114,9 @@ const RESEND_FROM =
     process.env.RESEND_FROM_BRIEF ?? process.env.RESEND_FROM_EMAIL,
     'WorldMonitor Brief',
   ) ?? 'WorldMonitor Brief <brief@worldmonitor.app>';
+const DIGEST_LAST_RUN_KEY = 'digest:last-run';
+const DIGEST_LAST_RUN_META_KEY = 'seed-meta:digest:last-run';
+const DIGEST_LAST_RUN_TTL_SECONDS = 7 * 24 * 60 * 60;
 
 if (process.env.DIGEST_CRON_ENABLED === '0') {
   console.log('[digest] DIGEST_CRON_ENABLED=0 — skipping run');
@@ -345,6 +348,45 @@ async function upstashPipeline(commands) {
     return [];
   }
   return res.json();
+}
+
+function compactDigestLastRunReason(reason) {
+  return String(reason ?? 'unknown').replace(/\s+/g, ' ').trim().slice(0, 240);
+}
+
+async function writeDigestLastRunMeta({
+  startedAtMs,
+  finishedAtMs = Date.now(),
+  status = 'ok',
+  sentCount = 0,
+  errorReason = null,
+}) {
+  const run = {
+    fetchedAt: finishedAtMs,
+    recordCount: 1,
+    status,
+    sentCount,
+    startedAt: startedAtMs,
+    durationMs: Math.max(0, finishedAtMs - startedAtMs),
+  };
+  if (errorReason) run.errorReason = compactDigestLastRunReason(errorReason);
+
+  try {
+    const result = await upstashPipeline([
+      ['SET', DIGEST_LAST_RUN_KEY, JSON.stringify(run), 'EX', String(DIGEST_LAST_RUN_TTL_SECONDS)],
+      ['SET', DIGEST_LAST_RUN_META_KEY, JSON.stringify(run), 'EX', String(DIGEST_LAST_RUN_TTL_SECONDS)],
+    ]);
+    const ok = Array.isArray(result)
+      && result.length === 2
+      && result.every((cell) => cell && typeof cell === 'object' && !('error' in cell));
+    if (!ok) {
+      console.warn('[digest] last-run health write did not confirm both keys');
+    }
+    return ok;
+  } catch (err) {
+    console.warn(`[digest] last-run health write failed: ${err?.message ?? err}`);
+    return false;
+  }
 }
 
 // ── Schedule helpers ──────────────────────────────────────────────────────────
@@ -2113,16 +2155,27 @@ async function main() {
     });
     if (!res.ok) {
       console.error('[digest] Failed to fetch rules:', res.status);
+      await writeDigestLastRunMeta({
+        startedAtMs: nowMs,
+        status: 'error',
+        errorReason: `fetch_rules_http_${res.status}`,
+      });
       return;
     }
     rules = await res.json();
   } catch (err) {
     console.error('[digest] Fetch rules failed:', err.message);
+    await writeDigestLastRunMeta({
+      startedAtMs: nowMs,
+      status: 'error',
+      errorReason: `fetch_rules_failed:${err.message}`,
+    });
     return;
   }
 
   if (!Array.isArray(rules) || rules.length === 0) {
     console.log('[digest] No digest rules found — nothing to do');
+    await writeDigestLastRunMeta({ startedAtMs: nowMs, sentCount: 0 });
     return;
   }
 
@@ -2160,6 +2213,7 @@ async function main() {
       console.warn(
         `[digest] No rules matched userId=${onlyUserFilter.userId} — nothing to do (exiting green).`,
       );
+      await writeDigestLastRunMeta({ startedAtMs: nowMs, sentCount: 0 });
       return;
     }
   } else if (onlyUserFilter.kind === 'reject') {
@@ -2933,11 +2987,24 @@ async function main() {
     console.warn(
       `[digest] brief: exiting non-zero — compose_failed=${composeFailed} compose_success=${composeSuccess} crossed the threshold`,
     );
+    await writeDigestLastRunMeta({
+      startedAtMs: nowMs,
+      status: 'error',
+      sentCount,
+      errorReason: `brief_compose_failed:${composeFailed}:success:${composeSuccess}`,
+    });
     process.exit(1);
   }
+
+  await writeDigestLastRunMeta({ startedAtMs: nowMs, sentCount });
 }
 
-main().catch((err) => {
+main().catch(async (err) => {
   console.error('[digest] Fatal:', err);
+  await writeDigestLastRunMeta({
+    startedAtMs: Date.now(),
+    status: 'error',
+    errorReason: `fatal:${err?.message ?? err}`,
+  });
   process.exit(1);
 });

--- a/tests/digest-last-run-health.test.mjs
+++ b/tests/digest-last-run-health.test.mjs
@@ -1,0 +1,78 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(
+  resolve(__dirname, '../scripts/seed-digest-notifications.mjs'),
+  'utf-8',
+);
+
+function sourceBetween(start, end) {
+  const startIndex = src.indexOf(start);
+  assert.notEqual(startIndex, -1, `missing source marker: ${start}`);
+  const endIndex = src.indexOf(end, startIndex);
+  assert.notEqual(endIndex, -1, `missing source marker: ${end}`);
+  return src.slice(startIndex, endIndex);
+}
+
+describe('digest-notifications last-run health heartbeat', () => {
+  it('defines keys that match api/health.js digestNotifications', () => {
+    assert.match(src, /const DIGEST_LAST_RUN_KEY = 'digest:last-run'/);
+    assert.match(src, /const DIGEST_LAST_RUN_META_KEY = 'seed-meta:digest:last-run'/);
+    assert.match(src, /const DIGEST_LAST_RUN_TTL_SECONDS = 7 \* 24 \* 60 \* 60/);
+  });
+
+  it('writes both the data heartbeat and seed-meta heartbeat with positive recordCount', () => {
+    const writer = sourceBetween(
+      'async function writeDigestLastRunMeta({',
+      'function toLocalHour(nowMs, timezone)',
+    );
+
+    assert.match(writer, /recordCount: 1/);
+    assert.match(writer, /status,/);
+    assert.match(writer, /sentCount,/);
+    assert.match(writer, /errorReason/);
+    assert.match(writer, /\['SET', DIGEST_LAST_RUN_KEY, JSON\.stringify\(run\), 'EX', String\(DIGEST_LAST_RUN_TTL_SECONDS\)\]/);
+    assert.match(writer, /\['SET', DIGEST_LAST_RUN_META_KEY, JSON\.stringify\(run\), 'EX', String\(DIGEST_LAST_RUN_TTL_SECONDS\)\]/);
+  });
+
+  it('stamps SEED_ERROR metadata for rule-fetch failures', () => {
+    assert.match(
+      src,
+      /if \(!res\.ok\) \{[\s\S]*?await writeDigestLastRunMeta\(\{[\s\S]*?status: 'error'[\s\S]*?errorReason: `fetch_rules_http_\$\{res\.status\}`,[\s\S]*?\}\);[\s\S]*?return;/,
+    );
+    assert.match(
+      src,
+      /catch \(err\) \{[\s\S]*?await writeDigestLastRunMeta\(\{[\s\S]*?status: 'error'[\s\S]*?errorReason: `fetch_rules_failed:\$\{err\.message\}`,[\s\S]*?\}\);[\s\S]*?return;/,
+    );
+  });
+
+  it('stamps a healthy run even when there is nothing to send', () => {
+    assert.match(
+      src,
+      /No digest rules found[\s\S]*?await writeDigestLastRunMeta\(\{ startedAtMs: nowMs, sentCount: 0 \}\);[\s\S]*?return;/,
+    );
+    assert.match(
+      src,
+      /No rules matched userId=\$\{onlyUserFilter\.userId\}[\s\S]*?await writeDigestLastRunMeta\(\{ startedAtMs: nowMs, sentCount: 0 \}\);[\s\S]*?return;/,
+    );
+  });
+
+  it('stamps brief-compose failures before nonzero exit and healthy runs at the end', () => {
+    assert.match(
+      src,
+      /if \(shouldExitOnBriefFailures\(\{ success: composeSuccess, failed: composeFailed \}\)\) \{[\s\S]*?await writeDigestLastRunMeta\(\{[\s\S]*?status: 'error'[\s\S]*?sentCount,[\s\S]*?brief_compose_failed:\$\{composeFailed\}:success:\$\{composeSuccess\}[\s\S]*?\}\);[\s\S]*?process\.exit\(1\);/,
+    );
+    assert.match(src, /await writeDigestLastRunMeta\(\{ startedAtMs: nowMs, sentCount \}\);/);
+  });
+
+  it('stamps fatal crashes before process.exit(1)', () => {
+    assert.match(
+      src,
+      /main\(\)\.catch\(async \(err\) => \{[\s\S]*?await writeDigestLastRunMeta\(\{[\s\S]*?status: 'error'[\s\S]*?errorReason: `fatal:\$\{err\?\.message \?\? err\}`,[\s\S]*?\}\);[\s\S]*?process\.exit\(1\);/,
+    );
+  });
+});

--- a/tests/digest-last-run-health.test.mjs
+++ b/tests/digest-last-run-health.test.mjs
@@ -75,4 +75,17 @@ describe('digest-notifications last-run health heartbeat', () => {
       /main\(\)\.catch\(async \(err\) => \{[\s\S]*?await writeDigestLastRunMeta\(\{[\s\S]*?status: 'error'[\s\S]*?errorReason: `fatal:\$\{err\?\.message \?\? err\}`,[\s\S]*?\}\);[\s\S]*?process\.exit\(1\);/,
     );
   });
+
+  it('uses the main start time for fatal-crash duration metadata', () => {
+    assert.match(src, /let digestRunStartedAtMs = null;/);
+    assert.match(src, /const nowMs = Date\.now\(\);\s+digestRunStartedAtMs = nowMs;/);
+    assert.match(
+      src,
+      /main\(\)\.catch\(async \(err\) => \{[\s\S]*?const finishedAtMs = Date\.now\(\);[\s\S]*?startedAtMs: digestRunStartedAtMs \?\? finishedAtMs,[\s\S]*?finishedAtMs,[\s\S]*?process\.exit\(1\);/,
+    );
+    assert.doesNotMatch(
+      src,
+      /main\(\)\.catch\(async \(err\) => \{[\s\S]*?startedAtMs: Date\.now\(\)/,
+    );
+  });
 });

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -185,6 +185,37 @@ test('classifyKey: empty on-demand standalone key → EMPTY_ON_DEMAND (warn)', (
   assert.equal(STATUS_COUNTS[entry.status], 'warn');
 });
 
+test('classifyKey: webcams active pointer is registered with seed-meta freshness', () => {
+  const entry = classifyKey('webcams', STANDALONE_KEYS.webcams, { allowOnDemand: true },
+    makeCtx({
+      strens: { [STANDALONE_KEYS.webcams]: 13 },
+      metaValues: { 'seed-meta:webcam:cameras:geo': seedMeta({ recordCount: 65000 }) },
+    }));
+
+  assert.equal(STANDALONE_KEYS.webcams, 'webcam:cameras:active');
+  assert.equal(entry.status, 'OK');
+  assert.equal(entry.records, 65000);
+  assert.equal(entry.maxStaleMin, 1440);
+});
+
+test('classifyKey: digestNotifications heartbeat goes stale when the cron stops', () => {
+  const entry = classifyKey('digestNotifications', STANDALONE_KEYS.digestNotifications, { allowOnDemand: true },
+    makeCtx({
+      strens: { [STANDALONE_KEYS.digestNotifications]: 256 },
+      metaValues: {
+        'seed-meta:digest:last-run': seedMeta({
+          fetchedAt: NOW - 120 * ONE_MIN_MS,
+          sentCount: 0,
+        }),
+      },
+    }));
+
+  assert.equal(STANDALONE_KEYS.digestNotifications, 'digest:last-run');
+  assert.equal(entry.status, 'STALE_SEED');
+  assert.equal(entry.maxStaleMin, 90);
+  assert.equal(STATUS_COUNTS[entry.status], 'warn');
+});
+
 test('classifyKey: suppressed retailer-spread (present key, 0 records) while fresh → OK, not EMPTY_DATA', () => {
   // The consumer-prices aggregate job writes retailer_spread_pct: 0 ("spread
   // suppressed (N/4 common items)") when a market's retailers share < 4 common

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -216,6 +216,16 @@ test('classifyKey: digestNotifications heartbeat goes stale when the cron stops'
   assert.equal(STATUS_COUNTS[entry.status], 'warn');
 });
 
+test('classifyKey: digestNotifications missing before first cron run is transitional warn', () => {
+  const entry = classifyKey('digestNotifications', STANDALONE_KEYS.digestNotifications, { allowOnDemand: true },
+    makeCtx({}));
+
+  assert.equal(entry.status, 'EMPTY_ON_DEMAND');
+  assert.equal(entry.records, 0);
+  assert.equal(entry.maxStaleMin, 90);
+  assert.equal(STATUS_COUNTS[entry.status], 'warn');
+});
+
 test('classifyKey: suppressed retailer-spread (present key, 0 records) while fresh → OK, not EMPTY_DATA', () => {
   // The consumer-prices aggregate job writes retailer_spread_pct: 0 ("spread
   // suppressed (N/4 common items)") when a market's retailers share < 4 common

--- a/tests/mcp-bootstrap-parity.test.mjs
+++ b/tests/mcp-bootstrap-parity.test.mjs
@@ -158,6 +158,8 @@ const EXCLUDED_FROM_MCP = new Map([
     'deferred to a future region-aware intelligence tool.'],
   ['intelligence:market-implications:v1',
     'deferred: LLM-generated narrative composite; underlying inputs already exposed via existing data tools. A future LLM-narrative tool would bundle this.'],
+  ['webcam:cameras:active',
+    'deferred: Windy webcam active-version pointer for app map markers. A future webcam MCP tool would expose decoded camera entries, not the raw Redis pointer.'],
   ['supply_chain:hormuz_tracker:v1',
     'deferred: specialized Strait-of-Hormuz tracker; broader chokepoint coverage via get_chokepoint_status. Hormuz-specific tool deferred.'],
   ['thermal:escalation:v1',
@@ -292,6 +294,8 @@ const EXCLUDED_FROM_MCP = new Map([
     'operational: relay loop heartbeat — covered by /api/health, not a user-facing data slice for MCP.'],
   ['relay:heartbeat:climate-news',
     'operational: relay loop heartbeat — covered by /api/health, not a user-facing data slice for MCP.'],
+  ['digest:last-run',
+    'operational: digest-notifications cron heartbeat — covered by /api/health, not a user-facing data slice for MCP.'],
 ]);
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Webcam and digest-notifications operational coverage now show up in `/api/health` with seed freshness instead of falling outside the health registry.
- Digest notifications now publishes `digest:last-run` and `seed-meta:digest:last-run` on successful runs, no-op runs, rule-fetch failures, brief-compose failures, and fatal crashes.
- MCP seeded-key parity documents the new operational keys as health-only rather than user-facing tool data.

## Tests
- `node --test tests/health-classify.test.mjs tests/digest-last-run-health.test.mjs`
- `./node_modules/.bin/tsx --test tests/mcp-bootstrap-parity.test.mjs`
- `node --test tests/bootstrap.test.mjs`
- `git diff --check origin/main...HEAD`
- pre-push hook: `npm run typecheck`, `npm run typecheck:api`, Convex type check, CJS syntax, Unicode safety, boundary/safe-html/Sentry/rate-limit/premium-fetch checks, changed tests, edge-function tests, version check
