### PR TITLE
Fix cleanup loops and cap retained signal state

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -23,6 +23,8 @@ import {
   initAisStream,
   isOutagesConfigured,
   disconnectAisStream,
+  startFlightHistoryCleanup,
+  startVesselHistoryCleanup,
   stopFlightHistoryCleanup,
   stopVesselHistoryCleanup,
 } from '@/services';
@@ -933,6 +935,8 @@ export class App {
     });
 
     await initDB();
+    startFlightHistoryCleanup();
+    startVesselHistoryCleanup();
     await initI18n();
     // Localize the static index.html shell — <title>, meta description, and
     // sr-only <h1> are baked in English so search crawlers see something

--- a/src/App.ts
+++ b/src/App.ts
@@ -16,7 +16,16 @@ import {
 } from '@/config';
 import { sanitizeLayersForVariant } from '@/config/map-layer-definitions';
 import type { MapVariant } from '@/config/map-layer-definitions';
-import { initDB, cleanOldSnapshots, isAisConfigured, initAisStream, isOutagesConfigured, disconnectAisStream } from '@/services';
+import {
+  initDB,
+  cleanOldSnapshots,
+  isAisConfigured,
+  initAisStream,
+  isOutagesConfigured,
+  disconnectAisStream,
+  stopFlightHistoryCleanup,
+  stopVesselHistoryCleanup,
+} from '@/services';
 import { isProUser } from '@/services/widget-store';
 import { mlWorker } from '@/services/ml-worker';
 import { getAiFlowSettings, subscribeAiFlowChange, isHeadlineMemoryEnabled } from '@/services/ai-flow-settings';
@@ -1454,6 +1463,8 @@ export class App {
     }
     this.state.map?.destroy();
     disconnectAisStream();
+    stopFlightHistoryCleanup();
+    stopVesselHistoryCleanup();
     // Unregister every WebMCP tool so a same-document re-init (tests,
     // HMR, SPA harness) doesn't leave the browser with stale bindings
     // pointing at a disposed App.

--- a/src/services/analysis-core.ts
+++ b/src/services/analysis-core.ts
@@ -82,6 +82,7 @@ function aggregateThreats(
 const TOPIC_BASELINE_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
 const TOPIC_BASELINE_SPIKE_MULTIPLIER = 3;
 const TOPIC_HISTORY_MAX_POINTS = 1000;
+export const MAX_CLUSTER_NEWS_ITEMS = 1000;
 
 interface TopicVelocityPoint {
   timestamp: number;
@@ -219,7 +220,18 @@ export function clusterNewsCore(
 ): ClusteredEventCore[] {
   if (items.length === 0) return [];
 
-  const itemsWithTier: NewsItemWithTier[] = items.map(item => ({
+  const boundedItems = items.length > MAX_CLUSTER_NEWS_ITEMS
+    ? [...items]
+        .sort((a, b) =>
+          effectivePubDateMs(b) - effectivePubDateMs(a)
+          || a.source.localeCompare(b.source)
+          || a.title.localeCompare(b.title)
+          || a.link.localeCompare(b.link)
+        )
+        .slice(0, MAX_CLUSTER_NEWS_ITEMS)
+    : items;
+
+  const itemsWithTier: NewsItemWithTier[] = boundedItems.map(item => ({
     ...item,
     tier: item.tier ?? getSourceTier(item.source),
   }));

--- a/src/services/clustering.ts
+++ b/src/services/clustering.ts
@@ -16,6 +16,20 @@ export function clusterNews(items: NewsItem[]): ClusteredEvent[] {
   return clusterNewsCore(items, getSourceTier) as ClusteredEvent[];
 }
 
+function compareClustersForSemanticCandidate(a: ClusteredEvent, b: ClusteredEvent): number {
+  const alertDelta = Number(b.isAlert) - Number(a.isAlert);
+  if (alertDelta !== 0) return alertDelta;
+
+  const sourceDelta = b.sourceCount - a.sourceCount;
+  if (sourceDelta !== 0) return sourceDelta;
+
+  const tierDelta = getSourceTier(a.primarySource) - getSourceTier(b.primarySource);
+  if (tierDelta !== 0) return tierDelta;
+
+  return b.lastUpdated.getTime() - a.lastUpdated.getTime()
+    || a.id.localeCompare(b.id);
+}
+
 /**
  * Hybrid clustering: Jaccard first, then semantic refinement if ML available
  */
@@ -29,8 +43,9 @@ export async function clusterNewsHybrid(items: NewsItem[]): Promise<ClusteredEve
   }
 
   try {
-    const semanticCandidates = jaccardClusters.slice(0, MAX_SEMANTIC_CLUSTER_INPUT);
-    const overflowClusters = jaccardClusters.slice(MAX_SEMANTIC_CLUSTER_INPUT);
+    const rankedSemanticInput = [...jaccardClusters].sort(compareClustersForSemanticCandidate);
+    const semanticCandidates = rankedSemanticInput.slice(0, MAX_SEMANTIC_CLUSTER_INPUT);
+    const overflowClusters = rankedSemanticInput.slice(MAX_SEMANTIC_CLUSTER_INPUT);
 
     // Get cluster primary titles for embedding
     const clusterTexts = semanticCandidates.map(c => ({

--- a/src/services/clustering.ts
+++ b/src/services/clustering.ts
@@ -10,6 +10,8 @@ import { clusterNewsCore } from './analysis-core';
 import { mlWorker } from './ml-worker';
 import { ML_THRESHOLDS } from '@/config/ml-config';
 
+export const MAX_SEMANTIC_CLUSTER_INPUT = 250;
+
 export function clusterNews(items: NewsItem[]): ClusteredEvent[] {
   return clusterNewsCore(items, getSourceTier) as ClusteredEvent[];
 }
@@ -27,8 +29,11 @@ export async function clusterNewsHybrid(items: NewsItem[]): Promise<ClusteredEve
   }
 
   try {
+    const semanticCandidates = jaccardClusters.slice(0, MAX_SEMANTIC_CLUSTER_INPUT);
+    const overflowClusters = jaccardClusters.slice(MAX_SEMANTIC_CLUSTER_INPUT);
+
     // Get cluster primary titles for embedding
-    const clusterTexts = jaccardClusters.map(c => ({
+    const clusterTexts = semanticCandidates.map(c => ({
       id: c.id,
       text: c.primaryTitle,
     }));
@@ -40,7 +45,9 @@ export async function clusterNewsHybrid(items: NewsItem[]): Promise<ClusteredEve
     );
 
     // Merge semantically similar clusters
-    return mergeSemanticallySimilarClusters(jaccardClusters, semanticGroups);
+    const mergedSemanticClusters = mergeSemanticallySimilarClusters(semanticCandidates, semanticGroups);
+    return [...mergedSemanticClusters, ...overflowClusters]
+      .sort((a, b) => b.lastUpdated.getTime() - a.lastUpdated.getTime());
   } catch (error) {
     console.warn('[Clustering] Semantic clustering failed, using Jaccard only:', error);
     return jaccardClusters;

--- a/src/services/military-flights.ts
+++ b/src/services/military-flights.ts
@@ -484,8 +484,9 @@ function cleanupFlightHistory(): void {
   }
 }
 
-// Set up periodic cleanup
-if (typeof window !== 'undefined') {
+/** Start the periodic flight-history cleanup if it is not already running. */
+export function startFlightHistoryCleanup(): void {
+  if (typeof window === 'undefined' || historyCleanupIntervalId) return;
   historyCleanupIntervalId = setInterval(cleanupFlightHistory, HISTORY_CLEANUP_INTERVAL);
 }
 
@@ -496,6 +497,8 @@ export function stopFlightHistoryCleanup(): void {
     historyCleanupIntervalId = null;
   }
 }
+
+startFlightHistoryCleanup();
 
 /**
  * Main function to fetch military flights

--- a/src/services/military-vessels.ts
+++ b/src/services/military-vessels.ts
@@ -496,8 +496,9 @@ function clusterVessels(vessels: MilitaryVessel[]): MilitaryVesselCluster[] {
   return clusters;
 }
 
-// Initialize cleanup interval
-if (typeof window !== 'undefined') {
+/** Start the periodic vessel-history cleanup if it is not already running. */
+export function startVesselHistoryCleanup(): void {
+  if (typeof window === 'undefined' || historyCleanupIntervalId) return;
   historyCleanupIntervalId = setInterval(cleanup, HISTORY_CLEANUP_INTERVAL);
 }
 
@@ -508,6 +509,8 @@ export function stopVesselHistoryCleanup(): void {
     historyCleanupIntervalId = null;
   }
 }
+
+startVesselHistoryCleanup();
 
 /**
  * Initialize military vessel tracking

--- a/src/services/signal-aggregator.ts
+++ b/src/services/signal-aggregator.ts
@@ -15,6 +15,8 @@ import type { CountrySanctionsPressure } from './sanctions-pressure';
 import type { RadiationObservation } from './radiation';
 import { getCountryAtCoordinates, getCountryNameByCode, nameToCountryCode, ME_STRIKE_BOUNDS, resolveCountryFromBounds } from './country-geometry';
 
+export const SIGNAL_AGGREGATOR_MAX_SIGNALS = 1000;
+
 export type SignalType =
   | 'internet_outage'
   | 'military_flight'
@@ -113,6 +115,27 @@ class SignalAggregator {
 
   private clearSignalType(type: SignalType): void {
     this.signals = this.signals.filter(s => s.type !== type);
+    this.syncTheaterPostureReferences();
+  }
+
+  private enforceSignalCap(): void {
+    if (this.signals.length <= SIGNAL_AGGREGATOR_MAX_SIGNALS) return;
+
+    const keep = new Set(
+      this.signals
+        .map((signal, index) => ({ signal, index }))
+        .sort((a, b) => b.signal.timestamp.getTime() - a.signal.timestamp.getTime() || b.index - a.index)
+        .slice(0, SIGNAL_AGGREGATOR_MAX_SIGNALS)
+        .map((entry) => entry.signal)
+    );
+    this.signals = this.signals.filter(s => keep.has(s));
+    this.syncTheaterPostureReferences();
+  }
+
+  private syncTheaterPostureReferences(): void {
+    if (this.theaterPostureSignals.length === 0) return;
+    const retained = new Set(this.signals);
+    this.theaterPostureSignals = this.theaterPostureSignals.filter(s => retained.has(s));
   }
 
   ingestOutages(outages: InternetOutage[]): void {
@@ -486,6 +509,7 @@ class SignalAggregator {
         this.theaterPostureSignals.push(sig);
       }
     }
+    this.pruneOld();
   }
 
   private coordsToCountry(lat: number, lon: number): string {
@@ -502,6 +526,8 @@ class SignalAggregator {
   private pruneOld(): void {
     const cutoff = Date.now() - this.WINDOW_MS;
     this.signals = this.signals.filter(s => s.timestamp.getTime() > cutoff);
+    this.syncTheaterPostureReferences();
+    this.enforceSignalCap();
   }
 
   getCountryClusters(): CountrySignalCluster[] {
@@ -642,6 +668,8 @@ class SignalAggregator {
 
   clear(): void {
     this.signals = [];
+    this.temporalSourceMap = new WeakMap<GeoSignal, string>();
+    this.theaterPostureSignals = [];
   }
 
   getSignalCount(): number {

--- a/tests/app-destroy-lifecycle.test.mjs
+++ b/tests/app-destroy-lifecycle.test.mjs
@@ -8,12 +8,28 @@ const appSrc = readFileSync(resolve(root, 'src/App.ts'), 'utf8');
 const militaryFlightsSrc = readFileSync(resolve(root, 'src/services/military-flights.ts'), 'utf8');
 const militaryVesselsSrc = readFileSync(resolve(root, 'src/services/military-vessels.ts'), 'utf8');
 
+function methodBody(source, signature) {
+  const signatureIndex = source.indexOf(signature);
+  assert.notEqual(signatureIndex, -1, `could not locate ${signature}`);
+
+  const openBraceIndex = source.indexOf('{', signatureIndex);
+  assert.notEqual(openBraceIndex, -1, `could not locate ${signature} opening brace`);
+
+  let depth = 0;
+  for (let index = openBraceIndex; index < source.length; index++) {
+    const char = source[index];
+    if (char === '{') depth++;
+    if (char === '}') depth--;
+    if (depth === 0) {
+      return source.slice(openBraceIndex + 1, index);
+    }
+  }
+
+  assert.fail(`could not locate ${signature} closing brace`);
+}
+
 function appDestroyBody() {
-  const match = appSrc.match(
-    /public destroy\(\): void \{([\s\S]*?)\n {2}\}(?=\n\n {2}(?:public|private) )/,
-  );
-  assert.ok(match, 'could not locate App.destroy() body');
-  return match[1];
+  return methodBody(appSrc, 'public destroy(): void');
 }
 
 describe('App.destroy lifecycle cleanup contract', () => {

--- a/tests/app-destroy-lifecycle.test.mjs
+++ b/tests/app-destroy-lifecycle.test.mjs
@@ -5,6 +5,8 @@ import { resolve } from 'node:path';
 
 const root = resolve(import.meta.dirname, '..');
 const appSrc = readFileSync(resolve(root, 'src/App.ts'), 'utf8');
+const militaryFlightsSrc = readFileSync(resolve(root, 'src/services/military-flights.ts'), 'utf8');
+const militaryVesselsSrc = readFileSync(resolve(root, 'src/services/military-vessels.ts'), 'utf8');
 
 function appDestroyBody() {
   const match = appSrc.match(
@@ -25,6 +27,15 @@ describe('App.destroy lifecycle cleanup contract', () => {
     }
   });
 
+  it('restarts flight and vessel history cleanup on same-document re-init', () => {
+    assert.match(appSrc, /startFlightHistoryCleanup,\n\s+startVesselHistoryCleanup,/);
+    assert.match(appSrc, /await initDB\(\);\n\s+startFlightHistoryCleanup\(\);\n\s+startVesselHistoryCleanup\(\);/);
+    assert.match(militaryFlightsSrc, /export function startFlightHistoryCleanup\(\): void \{[\s\S]*?historyCleanupIntervalId = setInterval\(cleanupFlightHistory, HISTORY_CLEANUP_INTERVAL\);[\s\S]*?\}/);
+    assert.match(militaryFlightsSrc, /startFlightHistoryCleanup\(\);/);
+    assert.match(militaryVesselsSrc, /export function startVesselHistoryCleanup\(\): void \{[\s\S]*?historyCleanupIntervalId = setInterval\(cleanup, HISTORY_CLEANUP_INTERVAL\);[\s\S]*?\}/);
+    assert.match(militaryVesselsSrc, /startVesselHistoryCleanup\(\);/);
+  });
+
   it('preserves existing map/AIS/WebMCP teardown', () => {
     const body = appDestroyBody();
     for (const expected of [
@@ -35,4 +46,5 @@ describe('App.destroy lifecycle cleanup contract', () => {
       assert.ok(body.includes(expected), `App.destroy() must keep ${expected}`);
     }
   });
+
 });

--- a/tests/app-destroy-lifecycle.test.mjs
+++ b/tests/app-destroy-lifecycle.test.mjs
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+const appSrc = readFileSync(resolve(root, 'src/App.ts'), 'utf8');
+
+function appDestroyBody() {
+  const match = appSrc.match(
+    /public destroy\(\): void \{([\s\S]*?)\n {2}\}(?=\n\n {2}(?:public|private) )/,
+  );
+  assert.ok(match, 'could not locate App.destroy() body');
+  return match[1];
+}
+
+describe('App.destroy lifecycle cleanup contract', () => {
+  it('stops background flight and vessel history cleanup intervals', () => {
+    const body = appDestroyBody();
+    for (const expected of [
+      'stopFlightHistoryCleanup()',
+      'stopVesselHistoryCleanup()',
+    ]) {
+      assert.ok(body.includes(expected), `App.destroy() must call ${expected}`);
+    }
+  });
+
+  it('preserves existing map/AIS/WebMCP teardown', () => {
+    const body = appDestroyBody();
+    for (const expected of [
+      'this.state.map?.destroy()',
+      'disconnectAisStream()',
+      'this.webMcpController?.abort()',
+    ]) {
+      assert.ok(body.includes(expected), `App.destroy() must keep ${expected}`);
+    }
+  });
+});

--- a/tests/clustering-cap.test.mjs
+++ b/tests/clustering-cap.test.mjs
@@ -1,0 +1,32 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = resolve(import.meta.dirname, '..');
+const clusteringSrc = readFileSync(resolve(root, 'src/services/clustering.ts'), 'utf8');
+
+describe('clusterNewsHybrid semantic clustering cap', () => {
+  it('caps the ML semantic-refinement input and preserves overflow clusters', () => {
+    assert.match(
+      clusteringSrc,
+      /export const MAX_SEMANTIC_CLUSTER_INPUT = \d+;/,
+      'clustering.ts must expose the semantic refinement cap',
+    );
+    assert.match(
+      clusteringSrc,
+      /const semanticCandidates = jaccardClusters\.slice\(0, MAX_SEMANTIC_CLUSTER_INPUT\);/,
+      'clusterNewsHybrid must cap the clusters sent to semantic refinement',
+    );
+    assert.match(
+      clusteringSrc,
+      /const overflowClusters = jaccardClusters\.slice\(MAX_SEMANTIC_CLUSTER_INPUT\);/,
+      'clusterNewsHybrid must retain clusters beyond the semantic cap',
+    );
+    assert.match(
+      clusteringSrc,
+      /return \[\.\.\.mergedSemanticClusters, \.\.\.overflowClusters\]/,
+      'clusterNewsHybrid must append uncapped overflow clusters after semantic refinement',
+    );
+  });
+});

--- a/tests/clustering-cap.test.mjs
+++ b/tests/clustering-cap.test.mjs
@@ -31,12 +31,22 @@ describe('news clustering caps unbounded input work', () => {
     );
     assert.match(
       clusteringSrc,
-      /const semanticCandidates = jaccardClusters\.slice\(0, MAX_SEMANTIC_CLUSTER_INPUT\);/,
-      'clusterNewsHybrid must cap the clusters sent to semantic refinement',
+      /function compareClustersForSemanticCandidate\(a: ClusteredEvent, b: ClusteredEvent\): number \{[\s\S]*?b\.sourceCount - a\.sourceCount[\s\S]*?getSourceTier\(a\.primarySource\) - getSourceTier\(b\.primarySource\)[\s\S]*?b\.lastUpdated\.getTime\(\) - a\.lastUpdated\.getTime\(\)/,
+      'clusterNewsHybrid must rank semantic candidates by signal strength before capping',
     );
     assert.match(
       clusteringSrc,
-      /const overflowClusters = jaccardClusters\.slice\(MAX_SEMANTIC_CLUSTER_INPUT\);/,
+      /const rankedSemanticInput = \[\.\.\.jaccardClusters\]\.sort\(compareClustersForSemanticCandidate\);/,
+      'clusterNewsHybrid must sort the semantic candidate pool before slicing',
+    );
+    assert.match(
+      clusteringSrc,
+      /const semanticCandidates = rankedSemanticInput\.slice\(0, MAX_SEMANTIC_CLUSTER_INPUT\);/,
+      'clusterNewsHybrid must cap the ranked clusters sent to semantic refinement',
+    );
+    assert.match(
+      clusteringSrc,
+      /const overflowClusters = rankedSemanticInput\.slice\(MAX_SEMANTIC_CLUSTER_INPUT\);/,
       'clusterNewsHybrid must retain clusters beyond the semantic cap',
     );
     assert.match(

--- a/tests/clustering-cap.test.mjs
+++ b/tests/clustering-cap.test.mjs
@@ -4,10 +4,26 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const root = resolve(import.meta.dirname, '..');
+const analysisCoreSrc = readFileSync(resolve(root, 'src/services/analysis-core.ts'), 'utf8');
 const clusteringSrc = readFileSync(resolve(root, 'src/services/clustering.ts'), 'utf8');
+const workerSrc = readFileSync(resolve(root, 'src/workers/analysis.worker.ts'), 'utf8');
 
-describe('clusterNewsHybrid semantic clustering cap', () => {
-  it('caps the ML semantic-refinement input and preserves overflow clusters', () => {
+describe('news clustering caps unbounded input work', () => {
+  it('caps the shared clustering input before O(n^2) dedupe work', () => {
+    assert.match(
+      analysisCoreSrc,
+      /export const MAX_CLUSTER_NEWS_ITEMS = \d+;/,
+      'analysis-core must expose the shared clustering input cap',
+    );
+    const capIdx = analysisCoreSrc.indexOf('const boundedItems = items.length > MAX_CLUSTER_NEWS_ITEMS');
+    const worksetIdx = analysisCoreSrc.indexOf('const itemsWithTier: NewsItemWithTier[] = boundedItems.map');
+    assert.ok(capIdx !== -1, 'clusterNewsCore must build a bounded input set');
+    assert.ok(worksetIdx !== -1, 'clusterNewsCore must cluster from boundedItems');
+    assert.ok(capIdx < worksetIdx, 'clusterNewsCore must cap input before tokenization/dedupe work starts');
+    assert.match(workerSrc, /const clusters = clusterNewsCore\(items, getSourceTier\);/);
+  });
+
+  it('caps ML semantic-refinement input and preserves overflow clusters', () => {
     assert.match(
       clusteringSrc,
       /export const MAX_SEMANTIC_CLUSTER_INPUT = \d+;/,

--- a/tests/feed-date-ranking-uses-effective.test.mts
+++ b/tests/feed-date-ranking-uses-effective.test.mts
@@ -62,22 +62,22 @@ const ALLOW_LIST: AllowEntry[] = [
   },
   {
     file: 'src/services/analysis-core.ts',
-    line: 207,
+    line: 208,
     reason: 'generateClusterId sort produces a stable identity string from earliest pubDate; not a freshness comparator.',
   },
   {
     file: 'src/services/analysis-core.ts',
-    line: 209,
+    line: 210,
     reason: 'generateClusterId uses earliest pubDate.getTime() in the identity string prefix.',
   },
   {
     file: 'src/services/analysis-core.ts',
-    line: 297,
+    line: 309,
     reason: 'cluster date aggregation for firstSeen/lastUpdated metadata; not a per-item ranking comparator.',
   },
   {
     file: 'src/services/clustering.ts',
-    line: 116,
+    line: 138,
     reason: 'allDates aggregation for cluster firstSeen/lastUpdated metadata; not a per-item ranking comparator.',
   },
   {

--- a/tests/signal-aggregator-cap.test.mts
+++ b/tests/signal-aggregator-cap.test.mts
@@ -1,0 +1,57 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  SIGNAL_AGGREGATOR_MAX_SIGNALS,
+  signalAggregator,
+} from '@/services/signal-aggregator';
+
+describe('signalAggregator caps retained singleton state', () => {
+  beforeEach(() => {
+    signalAggregator.clear();
+  });
+
+  it('keeps the newest signals when ingestion exceeds the cap', () => {
+    signalAggregator.ingestTemporalAnomalies(
+      Array.from({ length: SIGNAL_AGGREGATOR_MAX_SIGNALS + 50 }, (_, index) => ({
+        type: `cap-${index}`,
+        region: `Region ${index}`,
+        currentCount: index + 1,
+        expectedCount: 0,
+        zScore: 10,
+        message: `Temporal signal ${index}`,
+        severity: 'high' as const,
+      })),
+    );
+
+    assert.equal(signalAggregator.getSignalCount(), SIGNAL_AGGREGATOR_MAX_SIGNALS);
+    assert.equal(signalAggregator.getSummary().totalSignals, SIGNAL_AGGREGATOR_MAX_SIGNALS);
+
+    const titles = new Set(signalAggregator.getSummary().topCountries.flatMap((cluster) => cluster.signals.map((signal) => signal.title)));
+    assert.equal(titles.has('Temporal signal 0'), false, 'oldest overflow signal should be trimmed');
+    assert.equal(
+      titles.has(`Temporal signal ${SIGNAL_AGGREGATOR_MAX_SIGNALS + 49}`),
+      true,
+      'newest overflow signal should be retained',
+    );
+  });
+
+  it('clear resets retained signals and theater-posture references', () => {
+    signalAggregator.ingestTheaterPostures([
+      {
+        targetNation: 'Iran',
+        totalAircraft: 4,
+        totalVessels: 3,
+        postureLevel: 'elevated',
+        theaterName: 'Gulf',
+      },
+    ]);
+    assert.equal(signalAggregator.getSignalCount(), 2);
+
+    signalAggregator.clear();
+    assert.equal(signalAggregator.getSignalCount(), 0);
+
+    signalAggregator.ingestTheaterPostures([]);
+    assert.equal(signalAggregator.getSignalCount(), 0);
+  });
+});


### PR DESCRIPTION
Summary: Stop App.destroy flight/vessel cleanup intervals, cap signalAggregator retained singleton signals, and cap semantic clustering ML input while preserving overflow clusters. Tests: env TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/app-destroy-lifecycle.test.mjs tests/clustering-cap.test.mjs tests/signal-aggregator-cap.test.mts; full pre-push gates during git push.