### PR TITLE
fix(gateway): assert MCP HMAC cold-start config

### DIFF
--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -423,9 +423,18 @@ export async function isRelayWarmPingRequest(request: Request, pathname: string)
   return timingSafeEqual(candidate, expected);
 }
 
+function assertProMcpGatewayHmacConfig(): void {
+  const proGrantSecret = process.env.MCP_PRO_GRANT_HMAC_SECRET?.trim() ?? '';
+  const internalSecret = process.env.MCP_INTERNAL_HMAC_SECRET?.trim() ?? '';
+  if (proGrantSecret && !internalSecret) {
+    throw new Error('MCP_INTERNAL_HMAC_SECRET must be configured when MCP_PRO_GRANT_HMAC_SECRET is set');
+  }
+}
+
 export function createDomainGateway(
   routes: RouteDescriptor[],
 ): (req: Request, ctx?: GatewayCtx) => Promise<Response> {
+  assertProMcpGatewayHmacConfig();
   const router = createRouter(routes);
 
   return async function handler(originalRequest: Request, ctx?: GatewayCtx): Promise<Response> {

--- a/tests/gateway-internal-mcp.test.mjs
+++ b/tests/gateway-internal-mcp.test.mjs
@@ -172,6 +172,57 @@ async function buildSignedRequest({
 }
 
 // ===========================================================================
+// COLD-START CONFIG ASSERTIONS
+// ===========================================================================
+describe('gateway internal-MCP HMAC config — cold start', () => {
+  it('throws during gateway construction when Pro grant signing is configured without MCP_INTERNAL_HMAC_SECRET', () => {
+    process.env.MCP_PRO_GRANT_HMAC_SECRET = 'test-pro-grant-secret-32bytes-padding';
+    delete process.env.MCP_INTERNAL_HMAC_SECRET;
+
+    assert.throws(
+      () => makeGateway(),
+      /MCP_INTERNAL_HMAC_SECRET must be configured when MCP_PRO_GRANT_HMAC_SECRET is set/,
+    );
+  });
+
+  it('treats an empty MCP_INTERNAL_HMAC_SECRET as missing when Pro grant signing is configured', () => {
+    process.env.MCP_PRO_GRANT_HMAC_SECRET = 'test-pro-grant-secret-32bytes-padding';
+    process.env.MCP_INTERNAL_HMAC_SECRET = '';
+
+    assert.throws(
+      () => makeGateway(),
+      /MCP_INTERNAL_HMAC_SECRET must be configured when MCP_PRO_GRANT_HMAC_SECRET is set/,
+    );
+  });
+
+  it('treats a whitespace-only MCP_INTERNAL_HMAC_SECRET as missing when Pro grant signing is configured', () => {
+    process.env.MCP_PRO_GRANT_HMAC_SECRET = 'test-pro-grant-secret-32bytes-padding';
+    process.env.MCP_INTERNAL_HMAC_SECRET = '   ';
+
+    assert.throws(
+      () => makeGateway(),
+      /MCP_INTERNAL_HMAC_SECRET must be configured when MCP_PRO_GRANT_HMAC_SECRET is set/,
+    );
+  });
+
+  it('does not require either HMAC secret when Pro grant signing is not configured', () => {
+    delete process.env.MCP_PRO_GRANT_HMAC_SECRET;
+    delete process.env.MCP_INTERNAL_HMAC_SECRET;
+    assert.doesNotThrow(() => makeGateway());
+
+    process.env.MCP_PRO_GRANT_HMAC_SECRET = '';
+    assert.doesNotThrow(() => makeGateway());
+  });
+
+  it('allows gateway construction when both Pro grant signing and internal HMAC are configured', () => {
+    process.env.MCP_PRO_GRANT_HMAC_SECRET = 'test-pro-grant-secret-32bytes-padding';
+    process.env.MCP_INTERNAL_HMAC_SECRET = HMAC_SECRET;
+
+    assert.doesNotThrow(() => makeGateway());
+  });
+});
+
+// ===========================================================================
 // HAPPY PATHS
 // ===========================================================================
 describe('gateway internal-MCP HMAC verify — happy paths', () => {
@@ -449,6 +500,7 @@ describe('gateway internal-MCP HMAC verify — error paths', () => {
   });
 
   it('MCP_INTERNAL_HMAC_SECRET unset → 500 CONFIGURATION on the HMAC-attempt path', async () => {
+    delete process.env.MCP_PRO_GRANT_HMAC_SECRET;
     delete process.env.MCP_INTERNAL_HMAC_SECRET;
     const handler = makeGateway();
     const req = new Request('https://api.worldmonitor.app/api/news/v1/summarize-article', {
@@ -467,6 +519,7 @@ describe('gateway internal-MCP HMAC verify — error paths', () => {
   });
 
   it('legacy wm_ caller (no internal-MCP headers) → unaffected by missing MCP_INTERNAL_HMAC_SECRET', async () => {
+    delete process.env.MCP_PRO_GRANT_HMAC_SECRET;
     delete process.env.MCP_INTERNAL_HMAC_SECRET;
     const handler = makeGateway();
     // wm_-key flow: send a valid WORLDMONITOR_VALID_KEYS key on a non-tier-gated route.

--- a/tests/gateway-internal-mcp.test.mjs
+++ b/tests/gateway-internal-mcp.test.mjs
@@ -212,6 +212,9 @@ describe('gateway internal-MCP HMAC config — cold start', () => {
 
     process.env.MCP_PRO_GRANT_HMAC_SECRET = '';
     assert.doesNotThrow(() => makeGateway());
+
+    process.env.MCP_PRO_GRANT_HMAC_SECRET = '   ';
+    assert.doesNotThrow(() => makeGateway());
   });
 
   it('allows gateway construction when both Pro grant signing and internal HMAC are configured', () => {


### PR DESCRIPTION
## Summary
Gateway cold starts now fail fast when Pro MCP grant signing is configured without the internal MCP HMAC verifier secret. That keeps the gateway aligned with the existing `api/mcp` Pro auth preflight and prevents a deploy from minting Pro MCP grants while downstream gateway verification is impossible.

The guard trims both HMAC env values, so empty or whitespace-only secrets are treated as missing. Focused tests cover the missing, empty, and whitespace cases while preserving the legacy raw HMAC-attempt `500 CONFIGURATION` path when Pro grant signing is not configured.

## Tests
- `./node_modules/.bin/tsx --test tests/gateway-internal-mcp.test.mjs`
- `./node_modules/.bin/tsx --test tests/mcp.test.mjs`
- `npm run typecheck:api`
- `git push` pre-push hook: `npm run typecheck`, `npm run typecheck:api`, Convex type check, CJS syntax check, Unicode safety, boundary lint, safe HTML lint, rate-limit policy lint, premium-fetch parity, edge bundle check, server handler tests, changed gateway test file, version sync

## Review Follow-Up
- Applied Greptile P2 coverage request for whitespace-only `MCP_PRO_GRANT_HMAC_SECRET`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
