### PR TITLE
docs(blog): refresh stale service/proto counts + gate blog-site in docs-stats

### DIFF
--- a/blog-site/src/content/blog/ai-powered-intelligence-without-the-cloud.md
+++ b/blog-site/src/content/blog/ai-powered-intelligence-without-the-cloud.md
@@ -138,7 +138,7 @@ Material non-public information (MNPI) requirements mean certain geopolitical an
 
 You don't have to take our word for the privacy claims. World Monitor is fully open source under AGPL-3.0. Every network call, every data flow, every AI prompt is in the codebase for you to audit. Developers can explore the full [typed API layer and proto-first architecture](/blog/posts/build-on-worldmonitor-developer-api-open-source/) to verify exactly how data flows through the system.
 
-The proto-first API architecture (92 proto files, 22 typed services) means even the API contracts are transparent. You can see exactly what data each endpoint expects and returns.
+The proto-first API architecture (276 proto files, 34 typed services) means even the API contracts are transparent. You can see exactly what data each endpoint expects and returns.
 
 ## Frequently Asked Questions
 

--- a/blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md
+++ b/blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md
@@ -1,6 +1,6 @@
 ---
 title: "Build on World Monitor: Open APIs, Proto-First Architecture, and the Developer Platform"
-description: "Build intelligence apps on World Monitor's typed API: 22 services, 92 proto files, 60+ edge functions, and auto-generated TypeScript clients. AGPL-3.0."
+description: "Build intelligence apps on World Monitor's typed API: 34 services, 276 proto files, 60+ edge functions, and auto-generated TypeScript clients. AGPL-3.0."
 metaTitle: "Developer API & Open Source Platform | World Monitor"
 keywords: "open source intelligence API, OSINT API free, geopolitical data API, intelligence platform developer, proto-first API architecture"
 audience: "Developers, data engineers, startup builders, academic researchers, open-source contributors"
@@ -16,8 +16,8 @@ World Monitor is designed differently. The entire intelligence platform, every d
 
 World Monitor uses **Protocol Buffers (protobuf)** as the single source of truth for all API contracts. The codebase contains:
 
-- **92 proto files** defining every data structure and service
-- **22 typed service domains** covering all intelligence verticals
+- **276 proto files** defining every data structure and service
+- **34 typed service domains** covering all intelligence verticals
 - **Auto-generated TypeScript** clients for type-safe API consumption
 - **Auto-generated OpenAPI** documentation for REST compatibility
 
@@ -39,34 +39,46 @@ Protocol Buffers enforce a contract between client and server that can't drift:
 
 For developers building on World Monitor, this means you can trust the API contracts completely. If the proto says a field is `int64`, it's `int64`. If it says `repeated string`, it's an array of strings.
 
-## 22 Service Domains
+## 34 Service Domains
 
 World Monitor's API is organized into domain-specific services:
 
 | Domain | What It Covers |
 |--------|---------------|
-| **Conflict** | [ACLED](https://acleddata.com/) events, [UCDP](https://ucdp.uu.se/) data, hotspot scoring |
-| **Military** | Bases, ADS-B flights, AIS vessels, [USNI](https://news.usni.org/) reports |
-| **Market** | Stock quotes, forex, commodities, sector performance |
-| **Crypto** | BTC signals, stablecoin pegs, ETF flows, Fear & Greed |
 | **Aviation** | Airport delays, flight tracking, airspace data |
-| **Maritime** | Vessel positions, port status, dark vessel detection |
 | **Climate** | Temperature anomalies, precipitation, sea level |
-| **Imagery** | Satellite data via STAC API |
-| **News** | Aggregated RSS feeds, trending keywords |
-| **Intelligence** | CII scores, theater posture, convergence events |
-| **Infrastructure** | Cables, pipelines, nuclear facilities, datacenters |
-| **Prediction** | [Polymarket](https://polymarket.com/) data, forecast probabilities |
+| **Conflict** | [ACLED](https://acleddata.com/) events, [UCDP](https://ucdp.uu.se/) data, hotspot scoring |
+| **Consumer Prices** | CPI and consumer-price intelligence |
 | **Cyber** | Threat feeds, C2 servers, malware URLs |
-| **Disaster** | Earthquakes, fires, volcanic events |
 | **Displacement** | UNHCR refugee and IDP data |
-| **Travel** | Government advisories, risk levels |
-| **Central Bank** | Policy rates, [BIS](https://www.bis.org/) data, REER |
-| **Tech** | AI labs, startups, accelerators, tech hubs |
-| **Commodity** | Mining sites, exchange hubs, energy infrastructure |
-| **Regulation** | AI policy tracking, regulatory changes |
+| **Economic** | Macro data from FRED, World Bank, EIA; central-bank rates |
+| **Forecast** | AI probabilistic forecasts and scenario simulations |
+| **Giving** | Global philanthropy and personal-giving tracking |
 | **Health** | System health, data freshness, circuit breaker status |
-| **Bootstrap** | Hydration data for initial app load |
+| **Imagery** | Satellite data via STAC API |
+| **Infrastructure** | Cables, pipelines, nuclear facilities, datacenters |
+| **Intelligence** | CII scores, theater posture, convergence events |
+| **Leads** | Enterprise contact and Pro-waitlist capture |
+| **Maritime** | Vessel positions, port status, dark vessel detection |
+| **Market** | Stock quotes, forex, commodities, crypto, sector performance |
+| **Military** | Bases, ADS-B flights, AIS vessels, [USNI](https://news.usni.org/) reports |
+| **Natural** | Aggregated natural-disaster events |
+| **News** | Aggregated RSS feeds, trending keywords |
+| **Positive Events** | Geocoded positive and constructive news events |
+| **Prediction** | [Polymarket](https://polymarket.com/) data, forecast probabilities |
+| **Radiation** | Normalized environmental radiation readings |
+| **Research** | Academic papers, trending repos, tech news |
+| **Resilience** | Country Resilience Index (CRI) scores and rankings |
+| **Sanctions** | Sanctions lists and designations |
+| **Scenario** | Scenario engine: jobs, status, and template catalog |
+| **Seismology** | [USGS](https://earthquake.usgs.gov/) earthquake monitoring |
+| **Shipping** | Partner chokepoint route intelligence and disruption webhooks |
+| **Supply Chain** | Chokepoints, critical minerals, route impact, pipelines |
+| **Thermal** | Thermal escalation and fire-hotspot detection |
+| **Trade** | WTO and US Treasury trade-policy intelligence |
+| **Unrest** | Social unrest from ACLED and GDELT |
+| **Webcam** | Live public webcam feeds |
+| **Wildfire** | Wildfire tracking and perimeters |
 
 Each domain has its own edge function, proto definitions, and TypeScript client.
 
@@ -173,7 +185,7 @@ For reference, World Monitor is built with:
 | 3D Globe | globe.gl, Three.js |
 | Flat Map | deck.gl, MapLibre |
 | API | Vercel Edge Functions |
-| Contracts | Protocol Buffers (92 files) |
+| Contracts | Protocol Buffers (276 files) |
 | Desktop | Tauri (Rust) |
 | Sidecar | Node.js |
 | Caching | Redis |
@@ -209,4 +221,4 @@ Define your data structures in a proto file, implement a handler function, wire 
 
 ---
 
-**Start building at [github.com/koala73/worldmonitor](https://github.com/koala73/worldmonitor). 22 services, 92 proto files, and a global intelligence dataset waiting for your application.**
+**Start building at [github.com/koala73/worldmonitor](https://github.com/koala73/worldmonitor). 34 services, 276 proto files, and a global intelligence dataset waiting for your application.**

--- a/blog-site/src/content/blog/what-is-worldmonitor-real-time-global-intelligence.md
+++ b/blog-site/src/content/blog/what-is-worldmonitor-real-time-global-intelligence.md
@@ -78,7 +78,7 @@ The dashboard serves a surprisingly wide audience:
 - **Journalists** who need instant context for breaking stories
 - **Supply chain managers** monitoring disruption risk at ports and commodity hubs
 - **Policy researchers** studying government spending and trade policy
-- **Developers** who want to build on top of open, typed APIs (92 proto files, 22 services). See the [Developer API and Open Source guide](/blog/posts/build-on-worldmonitor-developer-api-open-source/) for details.
+- **Developers** who want to build on top of open, typed APIs (276 proto files, 34 services). See the [Developer API and Open Source guide](/blog/posts/build-on-worldmonitor-developer-api-open-source/) for details.
 
 ## Available Everywhere
 

--- a/blog-site/src/content/blog/worldmonitor-vs-traditional-intelligence-tools.md
+++ b/blog-site/src/content/blog/worldmonitor-vs-traditional-intelligence-tools.md
@@ -158,7 +158,7 @@ Every scoring algorithm is auditable. Every data source is documented. Every API
 
 - **Security teams** can verify there are no backdoors or data exfiltration
 - **Researchers** can reproduce and cite the scoring methodologies
-- **Developers** can build custom integrations using the 22 typed API services
+- **Developers** can build custom integrations using the 34 typed API services
 - **Organizations** can self-host for complete control. See the [Developer API and Open Source guide](/blog/posts/build-on-worldmonitor-developer-api-open-source/) for integration details.
 
 The AGPL-3.0 license ensures that improvements to the core platform benefit everyone. Forks must also be open source. The commons stays common.

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -216,6 +216,7 @@ function claims(s) {
     { file: 'blog-site/src/content/blog/what-is-worldmonitor-real-time-global-intelligence.md', re: /typed APIs \(\d+\s+proto files, (\d+)\s+services\)/, value: s.protoServices },
     { file: 'blog-site/src/content/blog/ai-powered-intelligence-without-the-cloud.md', re: /architecture \((\d+)\s+proto files, \d+\s+typed services\)/, value: s.protoFiles },
     { file: 'blog-site/src/content/blog/ai-powered-intelligence-without-the-cloud.md', re: /architecture \(\d+\s+proto files, (\d+)\s+typed services\)/, value: s.protoServices },
+    { file: 'blog-site/src/content/blog/worldmonitor-vs-traditional-intelligence-tools.md', re: /using the (\d+)\s+typed API services/, value: s.protoServices },
   ];
 }
 

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -201,6 +201,20 @@ function claims(s) {
     { file: 'docs/data-sources.mdx', re: /\*\*Tier 3\*\* \| (\d+)\s+\|/, value: s.telegramFullTierCounts['3'] },
     { file: 'docs/algorithms.mdx', re: /local (\d+)-country priority population table/, value: s.populationPriorityCountries },
     { file: 'docs/algorithms.mdx', re: /and (\d+)\s+tracked world-leader names/, value: s.leaderNames },
+
+    // ---- Blog posts (blog-site/) — capability counts quoted in evergreen developer/overview posts ----
+    { file: 'blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md', re: /typed API: (\d+)\s+services/, value: s.protoServices },
+    { file: 'blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md', re: /typed API: \d+\s+services, (\d+)\s+proto files/, value: s.protoFiles },
+    { file: 'blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md', re: /\*\*(\d+)\s+proto files\*\* defining/, value: s.protoFiles },
+    { file: 'blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md', re: /\*\*(\d+)\s+typed service domains\*\*/, value: s.protoServices },
+    { file: 'blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md', re: /##\s+(\d+)\s+Service Domains/, value: s.protoServices },
+    { file: 'blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md', re: /Protocol Buffers \((\d+)\s+files\)/, value: s.protoFiles },
+    { file: 'blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md', re: /worldmonitor\)\. (\d+)\s+services, \d+\s+proto files, and a global/, value: s.protoServices },
+    { file: 'blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md', re: /worldmonitor\)\. \d+\s+services, (\d+)\s+proto files, and a global/, value: s.protoFiles },
+    { file: 'blog-site/src/content/blog/what-is-worldmonitor-real-time-global-intelligence.md', re: /typed APIs \((\d+)\s+proto files, \d+\s+services\)/, value: s.protoFiles },
+    { file: 'blog-site/src/content/blog/what-is-worldmonitor-real-time-global-intelligence.md', re: /typed APIs \(\d+\s+proto files, (\d+)\s+services\)/, value: s.protoServices },
+    { file: 'blog-site/src/content/blog/ai-powered-intelligence-without-the-cloud.md', re: /architecture \((\d+)\s+proto files, \d+\s+typed services\)/, value: s.protoFiles },
+    { file: 'blog-site/src/content/blog/ai-powered-intelligence-without-the-cloud.md', re: /architecture \(\d+\s+proto files, (\d+)\s+typed services\)/, value: s.protoServices },
   ];
 }
 

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -207,7 +207,8 @@ function claims(s) {
     { file: 'blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md', re: /typed API: \d+\s+services, (\d+)\s+proto files/, value: s.protoFiles },
     { file: 'blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md', re: /\*\*(\d+)\s+proto files\*\* defining/, value: s.protoFiles },
     { file: 'blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md', re: /\*\*(\d+)\s+typed service domains\*\*/, value: s.protoServices },
-    { file: 'blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md', re: /##\s+(\d+)\s+Service Domains/, value: s.protoServices },
+    // Heading labels the table below it, which is enumerated from server/worldmonitor/* dirs → pin to serverDomains (not protoServices; the two equal 34 today but a domain with two `service` blocks would diverge them).
+    { file: 'blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md', re: /##\s+(\d+)\s+Service Domains/, value: s.serverDomains },
     { file: 'blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md', re: /Protocol Buffers \((\d+)\s+files\)/, value: s.protoFiles },
     { file: 'blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md', re: /worldmonitor\)\. (\d+)\s+services, \d+\s+proto files, and a global/, value: s.protoServices },
     { file: 'blog-site/src/content/blog/build-on-worldmonitor-developer-api-open-source.md', re: /worldmonitor\)\. \d+\s+services, (\d+)\s+proto files, and a global/, value: s.protoFiles },


### PR DESCRIPTION
## Summary

Three evergreen blog posts advertised **22 services / 92 proto files** — ~12 below reality. The live counts (derived by `scripts/docs-stats.mjs`) are **34 services / 276 proto files**. They drifted because `blog-site/` was never registered in the `docs-stats` `claims()` array (it only covered README / docs/*.mdx / llms-full / PRESS_KIT).

**Fixes**
- Refresh `22 → 34` services and `92 → 276` proto files across all three posts:
  - `build-on-worldmonitor-developer-api-open-source.md` (description, intro bullets, stack table, footer)
  - `what-is-worldmonitor-real-time-global-intelligence.md` (developer bullet)
  - `ai-powered-intelligence-without-the-cloud.md` (proto-first paragraph)
- **Rebuild the dev post's service-domain table** — it was titled "22 Service Domains" and listed exactly 22 rows, several conceptual (`Crypto`, `Travel`, `Central Bank`, `Tech`, `Regulation`, `Bootstrap`). Now enumerates the real **34 `server/worldmonitor/*` domains**, with descriptions pulled from each `proto/.../service.proto` doc-comment.
- **Gate blog-site in CI:** add **12 blog claims** to `docs-stats` `claims()` (now **55 total**) so the always-on `docs-stats` job fails on any future re-drift. `docs-stats` reads paths relative to repo root, so `blog-site/...` claims work in the existing job with no wiring changes.

**Deliberately not touched:** locale drift (`21 → 24`). Two spots still say 21 — the dev post's `i18next (21 locales)` stack line and the what-is post's "21 languages", the latter linking to a *branded* `/blog/posts/worldmonitor-in-21-languages-…` post that has "21" in its slug + title. Bumping one place would create a worse split; it needs its own coordinated refresh (body + title + slug + hero).

## Test plan

- [x] `npm run docs:check` — 55 doc claims match code (was 43; +12 blog claims)
- [x] `npm run lint` — biome clean (covers `scripts/docs-stats.mjs`)
- [x] `npm run lint:md` — markdown clean (3 edited blog files verified)
- [x] Verified no `22 services` / `92 proto` strings remain in `blog-site/`
- [x] Verified rebuilt domain table has exactly 34 rows
- [n/a] typecheck / api / edge / test:data / version:check — diff is markdown + one `.mjs`; touches no TS, api, edge, or version files