### PR TITLE
fix(map): suppress deck race through sentry wrapper

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -418,6 +418,9 @@ const CHOKEPOINT_PULSE_AMP = 0.3;
 // or recreateWithFallback rebuilds the map.
 let __deckInterleavedRaceFilterInstalled = false;
 
+const DECK_INTERLEAVED_RACE_MESSAGE_RE = /Cannot read properties of null \(reading 'id'\)|null is not an object \(evaluating '[\w.]+\.id'\)/;
+const DECK_INTERLEAVED_RACE_SOURCE_RE = /(?:^|[/(])deck-stack-[A-Za-z0-9_-]+\.js/;
+
 /**
  * Swallow the well-known deck.gl 9.x + maplibre-gl 5.x interleaved-mode race:
  *
@@ -438,11 +441,13 @@ let __deckInterleavedRaceFilterInstalled = false;
  * artifact, so swallowing here is safe.
  *
  * Sentry's beforeSend in main.ts already filters this exact pattern for
- * telemetry (lines 313-315), but the browser still logs "Uncaught TypeError"
- * to the console — this listener suppresses that.
+ * telemetry, but the browser still logs "Uncaught TypeError" to the console
+ * — this listener suppresses that.
  *
- * Narrow on BOTH the message shape AND the deck-stack chunk filename so an
- * unrelated null-id crash in first-party code still surfaces.
+ * Narrow on BOTH the message shape AND deck-stack chunk evidence so an
+ * unrelated null-id crash in first-party code still surfaces. Some browsers
+ * surface the exception through Sentry's rAF wrapper, so ev.filename can point
+ * at sentry-*.js while ev.error.stack still contains deck-stack-*.js.
  */
 function installDeckInterleavedRaceFilter(): void {
   if (__deckInterleavedRaceFilterInstalled) return;
@@ -450,9 +455,11 @@ function installDeckInterleavedRaceFilter(): void {
   window.addEventListener('error', (ev) => {
     const msg = ev.error?.message ?? ev.message ?? '';
     const file = ev.filename ?? '';
+    const stack = typeof ev.error?.stack === 'string' ? ev.error.stack : '';
+    const source = `${file}\n${stack}`;
     if (
-      /Cannot read properties of null \(reading 'id'\)|null is not an object \(evaluating '[\w.]+\.id'\)/.test(msg)
-      && /\/deck-stack-[A-Za-z0-9_-]+\.js/.test(file)
+      DECK_INTERLEAVED_RACE_MESSAGE_RE.test(msg)
+      && DECK_INTERLEAVED_RACE_SOURCE_RE.test(source)
     ) {
       ev.preventDefault();
       ev.stopImmediatePropagation();

--- a/tests/deckgl-interleaved-race-filter.test.mjs
+++ b/tests/deckgl-interleaved-race-filter.test.mjs
@@ -7,8 +7,8 @@ import { fileURLToPath } from 'node:url';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const deckGlMapSrc = readFileSync(resolve(__dirname, '../src/components/DeckGLMap.ts'), 'utf-8');
 
-function extractRegexConst(name) {
-  const match = deckGlMapSrc.match(new RegExp(`const ${name} = (/[^;]+/);`));
+function extractRegexConst(name, source = deckGlMapSrc) {
+  const match = source.match(new RegExp(`const ${name} = (/[^;]+/[dgimsuvy]*);`));
   assert.ok(match, `${name} must remain a regex literal`);
   // eslint-disable-next-line no-new-func
   return new Function(`return ${match[1]}`)();
@@ -66,5 +66,11 @@ describe('DeckGLMap interleaved render race console filter', () => {
   it('uses ev.error.stack in the installed error listener', () => {
     assert.match(deckGlMapSrc, /ev\.error\?\.stack/);
     assert.match(deckGlMapSrc, /DECK_INTERLEAVED_RACE_SOURCE_RE\.test\(source\)/);
+  });
+
+  it('preserves regex flags when extracting literals from source', () => {
+    const re = extractRegexConst('EXAMPLE_RE', 'const EXAMPLE_RE = /^deck-stack-.+\\.js$/m;');
+    assert.equal(re.flags, 'm');
+    assert.equal(re.test('first line\ndeck-stack-Dq2qX5Bt.js'), true);
   });
 });

--- a/tests/deckgl-interleaved-race-filter.test.mjs
+++ b/tests/deckgl-interleaved-race-filter.test.mjs
@@ -1,0 +1,70 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const deckGlMapSrc = readFileSync(resolve(__dirname, '../src/components/DeckGLMap.ts'), 'utf-8');
+
+function extractRegexConst(name) {
+  const match = deckGlMapSrc.match(new RegExp(`const ${name} = (/[^;]+/);`));
+  assert.ok(match, `${name} must remain a regex literal`);
+  // eslint-disable-next-line no-new-func
+  return new Function(`return ${match[1]}`)();
+}
+
+const messageRe = extractRegexConst('DECK_INTERLEAVED_RACE_MESSAGE_RE');
+const sourceRe = extractRegexConst('DECK_INTERLEAVED_RACE_SOURCE_RE');
+
+function shouldSuppress({ message, filename = '', stack = '' }) {
+  return messageRe.test(message) && sourceRe.test(`${filename}\n${stack}`);
+}
+
+describe('DeckGLMap interleaved render race console filter', () => {
+  it('matches the deck.gl null-id race when Sentry owns ev.filename but deck-stack is in the stack', () => {
+    const stack = [
+      "TypeError: Cannot read properties of null (reading 'id')",
+      '    at DeckRenderer._drawLayers (https://app.worldmonitor.app/assets/deck-stack-Dq2qX5Bt.js:1606:18)',
+      '    at LayerManager.renderLayers (https://app.worldmonitor.app/assets/deck-stack-Dq2qX5Bt.js:5000:12)',
+      '    at r (https://app.worldmonitor.app/assets/sentry-DMxp_zBn.js:488:7)',
+    ].join('\n');
+
+    assert.equal(shouldSuppress({
+      message: "Cannot read properties of null (reading 'id')",
+      filename: 'https://app.worldmonitor.app/assets/sentry-DMxp_zBn.js',
+      stack,
+    }), true);
+  });
+
+  it('still matches direct deck-stack filenames, including bare chunk names', () => {
+    assert.equal(shouldSuppress({
+      message: "Cannot read properties of null (reading 'id')",
+      filename: 'deck-stack-Dq2qX5Bt.js',
+    }), true);
+    assert.equal(shouldSuppress({
+      message: "Cannot read properties of null (reading 'id')",
+      filename: 'https://app.worldmonitor.app/assets/deck-stack-Dq2qX5Bt.js',
+    }), true);
+  });
+
+  it('does not suppress the same null-id message without deck-stack evidence', () => {
+    assert.equal(shouldSuppress({
+      message: "Cannot read properties of null (reading 'id')",
+      filename: 'https://app.worldmonitor.app/assets/main-Dq2qX5Bt.js',
+      stack: '    at firstPartyRender (https://app.worldmonitor.app/assets/main-Dq2qX5Bt.js:10:2)',
+    }), false);
+  });
+
+  it('does not suppress unrelated errors from deck-stack chunks', () => {
+    assert.equal(shouldSuppress({
+      message: "Cannot read properties of null (reading 'type')",
+      filename: 'https://app.worldmonitor.app/assets/deck-stack-Dq2qX5Bt.js',
+    }), false);
+  });
+
+  it('uses ev.error.stack in the installed error listener', () => {
+    assert.match(deckGlMapSrc, /ev\.error\?\.stack/);
+    assert.match(deckGlMapSrc, /DECK_INTERLEAVED_RACE_SOURCE_RE\.test\(source\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- Broaden the DeckGLMap console-side interleaved race filter to inspect ev.error.stack when Sentry owns ev.filename.
- Keep the null-id message gate plus deck-stack evidence gate so unrelated first-party null id crashes still surface.
- Add a regression test for the Sentry-wrapper filename case, bare deck-stack chunk names, and negative cases.

## Tests
- node --test tests/deckgl-interleaved-race-filter.test.mjs
- node --test tests/sentry-beforesend.test.mjs
- npm run typecheck
- git diff --check
- git push pre-push hook: typecheck, typecheck:api, Convex/CJS/Unicode/boundary/safe-html/rate-limit/premium-fetch/edge bundle checks, changed test files, edge function tests, version check