### PR TITLE
fix(market): keep insider transactions public

### DIFF
--- a/src/shared/premium-paths.ts
+++ b/src/shared/premium-paths.ts
@@ -8,7 +8,6 @@ export const PREMIUM_RPC_PATHS = new Set<string>([
   '/api/market/v1/analyze-stock',
   '/api/market/v1/get-stock-analysis-history',
   '/api/market/v1/backtest-stock',
-  '/api/market/v1/get-insider-transactions',
   '/api/market/v1/list-stored-stock-backtests',
   '/api/intelligence/v1/deduct-situation',
   '/api/intelligence/v1/list-market-implications',

--- a/tests/premium-fetch.test.mts
+++ b/tests/premium-fetch.test.mts
@@ -39,6 +39,8 @@ const TARGET = 'https://api.worldmonitor.app/api/sanctions/v1/list-sanctions-pre
 // A real PUBLIC path used to verify the path-gating bypass: hits below
 // fetch the same way but should NOT see Bearer attached.
 const PUBLIC_TARGET = 'https://api.worldmonitor.app/api/economic/v1/get-fred-series-batch';
+const PUBLIC_INSIDER_TRANSACTIONS_TARGET =
+  'https://api.worldmonitor.app/api/market/v1/get-insider-transactions?symbol=AAPL';
 
 // ---------------------------------------------------------------------------
 // Suite
@@ -200,6 +202,12 @@ describe('premiumFetch', () => {
     assert.equal(sentHeaders().get('X-WorldMonitor-Key'), null);
   });
 
+  it('public insider transactions path: Clerk JWT NOT attached', async () => {
+    setup({ testerKey: '', clerkToken: 'clerk-token-should-be-skipped' });
+    await premiumFetch(PUBLIC_INSIDER_TRANSACTIONS_TARGET);
+    assert.equal(sentHeaders().get('Authorization'), null);
+  });
+
   it('non-premium path: tester key still attached (works on any path)', async () => {
     setup({ testerKey: 'valid-key', clerkToken: 'clerk-token' });
     await premiumFetch(PUBLIC_TARGET);
@@ -221,4 +229,3 @@ describe('premiumFetch', () => {
     assert.equal(sentHeaders().get('Authorization'), 'Bearer caller-supplied');
   });
 });
-

--- a/tests/premium-stock-gateway.test.mts
+++ b/tests/premium-stock-gateway.test.mts
@@ -59,7 +59,7 @@ afterEach(() => {
 });
 
 describe('premium gateway API key enforcement', () => {
-  it('requires credentials for premium endpoints regardless of origin', async () => {
+  it('enforces premium credentials while allowing public market session auth', async () => {
     const handler = createDomainGateway([
       {
         method: 'GET',

--- a/tests/premium-stock-gateway.test.mts
+++ b/tests/premium-stock-gateway.test.mts
@@ -81,6 +81,11 @@ describe('premium gateway API key enforcement', () => {
         path: '/api/market/v1/list-market-quotes',
         handler: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
       },
+      {
+        method: 'GET',
+        path: '/api/market/v1/get-insider-transactions',
+        handler: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      },
     ]);
 
     process.env.WORLDMONITOR_VALID_KEYS = 'real-key-123';
@@ -133,12 +138,17 @@ describe('premium gateway API key enforcement', () => {
     }));
     assert.equal(unknownNoKey.status, 403);
 
-    // Public endpoint — anonymous browsers authenticate via the wms_ session token
+    // Public endpoints — anonymous browsers authenticate via the wms_ session token
     // (issue #3541; previously this was a trusted-origin bypass).
     const publicAllowed = await handler(new Request('https://worldmonitor.app/api/market/v1/list-market-quotes?symbols=AAPL', {
       headers: { Origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': SESSION_TOKEN },
     }));
     assert.equal(publicAllowed.status, 200);
+
+    const insiderTransactionsAllowed = await handler(new Request('https://worldmonitor.app/api/market/v1/get-insider-transactions?symbol=AAPL', {
+      headers: { Origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': SESSION_TOKEN },
+    }));
+    assert.equal(insiderTransactionsAllowed.status, 200);
   });
 
   it('PR #3557 review: anonymous wms_ session token does NOT unlock premium endpoints', async () => {


### PR DESCRIPTION
## Summary

Insider transactions now stay on the public market RPC path, so signed-in browsers no longer trigger the legacy Pro bearer gate and see 401 noise when a Clerk Bearer token is unavailable. Stock analysis and the other premium market RPCs remain gated.

The regression coverage now locks both sides of the contract: premiumFetch must not attach a Clerk Bearer token for insider transactions, and the gateway must accept the normal anonymous browser session token for that RPC.

## Validation

- TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/premium-stock-gateway.test.mts tests/premium-fetch.test.mts tests/premium-paths-guard.test.mts tests/insider-transactions.test.mts
- npm run typecheck
- git diff --check
- pre-push hook: typecheck, typecheck:api, lint:boundaries, lint:safe-html, lint:rate-limit-policies, lint:premium-fetch, changed tests, edge function tests, version:check

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)