### PR TITLE
fix(cloud-prefs): adopt syncVersion from keepalive flush to stop recurring 409s

### DIFF
--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -693,6 +693,7 @@ export function install(variant: string): void {
     // CURRENT_PREFS_SCHEMA_VERSION onto unmigrated local data, even on
     // best-effort unload flush.
     const blob = migrateLocalBlobIfNeeded();
+    const myGeneration = _authGeneration;
     const payload = JSON.stringify({ variant: _currentVariant, data: blob, expectedSyncVersion: getSyncVersion(), schemaVersion: CURRENT_PREFS_SCHEMA_VERSION });
     fetch('/api/user-prefs', {
       method: 'POST',
@@ -702,6 +703,34 @@ export function install(variant: string): void {
         Authorization: `Bearer ${_cachedToken}`,
       },
       body: payload,
+    }).then(async (res) => {
+      // The flush's most common trigger is NOT a real unload — it's
+      // visibilitychange→hidden on a tab switch, after which the tab stays
+      // alive. A successful flush advances the server row's syncVersion, so
+      // skipping the response here strands local KEY_SYNC_VERSION one
+      // version behind and GUARANTEES a 409 on the next pref save. Adopt
+      // the new version when the response is observable (true unloads never
+      // get here; the next boot's onSignIn GET heals those instead).
+      //
+      // Non-2xx (409/5xx): change nothing — keeping the stale version and
+      // the dirty keys is what routes the next upload through the
+      // conflict-merge path, which is the correct recovery.
+      if (!res.ok) return;
+      const body = (await res.json().catch(() => null)) as { syncVersion?: number } | null;
+      if (typeof body?.syncVersion !== 'number') return;
+      // Auth generation: a sign-out or user switch while the flush was in
+      // flight already cleared/replaced sync state — don't resurrect a
+      // version marker for the previous session.
+      if (_authGeneration !== myGeneration) return;
+      // Monotonic: a slow flush response must not regress the version past
+      // a newer upload (or conflict-merge) that completed meanwhile.
+      if (body.syncVersion <= getSyncVersion()) return;
+      setSyncVersion(body.syncVersion);
+      clearSettledDirtyKeys(blob);
+      Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
+      // Only claim 'synced' when no newer edit re-armed the debounce while
+      // the flush was in flight.
+      if (_debounceTimer === null) setState('synced');
     }).catch(() => { /* best-effort on unload */ });
   };
 

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -119,6 +119,15 @@ function clearSettledDirtyKeys(postedBlob: Record<string, string>): void {
 let _retryTimer: ReturnType<typeof setTimeout> | null = null;
 let _authGeneration = 0;
 
+// Count of uploadNow calls currently in their async phase. `_debounceTimer`
+// alone can't tell "no upload of any kind in progress" — the debounce
+// callback nulls the timer synchronously BEFORE uploadNow starts awaiting,
+// so a late flush response checking only the timer would claim 'synced'
+// mid-upload (and observers would see a synced → conflict/error regression
+// if that upload then fails). onSignIn doesn't need this: it bumps
+// _authGeneration on entry, which already makes stale flush handlers bail.
+let _uploadsInFlight = 0;
+
 function clearRetryTimer(): void {
   if (_retryTimer !== null) {
     clearTimeout(_retryTimer);
@@ -558,14 +567,15 @@ async function uploadNow(variant: string): Promise<void> {
   // called by the debounced upload path), so we want to inherit the current
   // generation, not start a new one.
   const myGeneration = _authGeneration;
-
-  const token = await getClerkToken();
-  if (!token) return;
-  _cachedToken = token;
-
-  setState('syncing');
+  _uploadsInFlight += 1;
 
   try {
+    const token = await getClerkToken();
+    if (!token) return;
+    _cachedToken = token;
+
+    setState('syncing');
+
     const postedBlob = migrateLocalBlobIfNeeded();
     const result = await postCloudPrefs(token, variant, postedBlob, getSyncVersion());
 
@@ -605,6 +615,8 @@ async function uploadNow(variant: string): Promise<void> {
     }
     console.warn('[cloud-prefs] uploadNow failed:', err);
     setState(!navigator.onLine || (err instanceof TypeError && err.message.includes('fetch')) ? 'offline' : 'error');
+  } finally {
+    _uploadsInFlight -= 1;
   }
 }
 
@@ -728,9 +740,11 @@ export function install(variant: string): void {
       setSyncVersion(body.syncVersion);
       clearSettledDirtyKeys(blob);
       Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
-      // Only claim 'synced' when no newer edit re-armed the debounce while
-      // the flush was in flight.
-      if (_debounceTimer === null) setState('synced');
+      // Only claim 'synced' when no newer edit re-armed the debounce AND no
+      // uploadNow is mid-flight (the debounce callback nulls the timer
+      // synchronously before uploadNow's async work, so the timer alone
+      // can't distinguish "idle" from "upload in progress").
+      if (_debounceTimer === null && _uploadsInFlight === 0) setState('synced');
     }).catch(() => { /* best-effort on unload */ });
   };
 

--- a/tests/cloud-prefs-flush-version-guard.test.mjs
+++ b/tests/cloud-prefs-flush-version-guard.test.mjs
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+const root = resolve(import.meta.dirname, '..');
+
+const cloudSyncSrc = readFileSync(resolve(root, 'src/utils/cloud-prefs-sync.ts'), 'utf-8');
+
+// The visibilitychange→hidden flush fires on every tab switch with a pending
+// debounce. Its POST advances the server row's syncVersion; if the client
+// drops the response, local KEY_SYNC_VERSION stays one behind and the next
+// pref save is guaranteed a 409 CONFLICT. These guards pin the response
+// handling that keeps the common alive-tab flush version-coherent.
+describe('cloud prefs flush version guardrails', () => {
+  const flushBody = (() => {
+    const start = cloudSyncSrc.indexOf('const flushOnUnload');
+    assert.notEqual(start, -1, 'flushOnUnload must exist in cloud-prefs-sync.ts');
+    const end = cloudSyncSrc.indexOf('document.addEventListener', start);
+    assert.notEqual(end, -1, 'flushOnUnload must be wired before the visibilitychange listener');
+    return cloudSyncSrc.slice(start, end);
+  })();
+
+  it('adopts the syncVersion echoed by a successful keepalive flush', () => {
+    assert.match(
+      flushBody,
+      /\.then\(async \(res\) => \{/,
+      'flushOnUnload must read the keepalive response instead of fire-and-forget',
+    );
+    assert.match(
+      flushBody,
+      /if \(!res\.ok\) return;/,
+      'flushOnUnload must leave local state untouched on 409/5xx so conflict-merge recovers',
+    );
+    assert.match(
+      flushBody,
+      /setSyncVersion\(body\.syncVersion\)/,
+      'flushOnUnload must persist the new syncVersion on a 200',
+    );
+    assert.match(
+      flushBody,
+      /clearSettledDirtyKeys\(blob\)/,
+      'flushOnUnload must settle the dirty keys it durably uploaded',
+    );
+  });
+
+  it('guards version adoption against auth changes and stale responses', () => {
+    assert.match(
+      flushBody,
+      /const myGeneration = _authGeneration;/,
+      'flushOnUnload must capture the auth generation before posting',
+    );
+    assert.match(
+      flushBody,
+      /if \(_authGeneration !== myGeneration\) return;/,
+      'flushOnUnload must not resurrect sync state after sign-out/user switch',
+    );
+    assert.match(
+      flushBody,
+      /if \(body\.syncVersion <= getSyncVersion\(\)\) return;/,
+      'flushOnUnload must never regress the version past a newer upload',
+    );
+  });
+});

--- a/tests/cloud-prefs-flush-version-guard.test.mjs
+++ b/tests/cloud-prefs-flush-version-guard.test.mjs
@@ -61,4 +61,33 @@ describe('cloud prefs flush version guardrails', () => {
       'flushOnUnload must never regress the version past a newer upload',
     );
   });
+
+  it('only claims synced when nothing newer is pending or in flight', () => {
+    // The debounce callback nulls _debounceTimer synchronously BEFORE
+    // uploadNow starts awaiting, so the timer alone cannot distinguish
+    // "idle" from "upload mid-flight" — a late flush response would flash
+    // 'synced' during an active upload (Greptile P2 on PR #4267).
+    assert.match(
+      flushBody,
+      /if \(_debounceTimer === null && _uploadsInFlight === 0\) setState\('synced'\);/,
+      'flushOnUnload must not claim synced while a debounce is armed or an upload is in flight',
+    );
+    const uploadNowBody = (() => {
+      const start = cloudSyncSrc.indexOf('async function uploadNow');
+      assert.notEqual(start, -1, 'uploadNow must exist in cloud-prefs-sync.ts');
+      const end = cloudSyncSrc.indexOf('function schedulePrefUpload', start);
+      assert.notEqual(end, -1, 'uploadNow must precede schedulePrefUpload');
+      return cloudSyncSrc.slice(start, end);
+    })();
+    assert.match(
+      uploadNowBody,
+      /_uploadsInFlight \+= 1;/,
+      'uploadNow must mark itself in flight before any async work',
+    );
+    assert.match(
+      uploadNowBody,
+      /\} finally \{\s*_uploadsInFlight -= 1;\s*\}/,
+      'uploadNow must balance the in-flight counter on every exit path',
+    );
+  });
 });


### PR DESCRIPTION
## Summary
Follow-up to #4264 — the `POST /api/user-prefs 409 (Conflict)` console errors persisted because they were never in #4264's scope. Root cause:

- `flushOnUnload` in `src/utils/cloud-prefs-sync.ts` fires on every `visibilitychange→hidden` (i.e. every **tab switch**) while a 5s debounce is pending
- its keepalive POST succeeds and advances the server row's `syncVersion`, but the response was fire-and-forget
- local `wm-cloud-sync-version` stays one behind → the **next** pref save is guaranteed a 409 (then auto-recovered by `resolveConflictWithMerge`, but the red console line + Sentry breadcrumb remain)

Repro: edit panels → switch tab within 5s → return → edit again → 409.

## Fix
Read the keepalive response when the tab stays alive (the common case — true unloads never observe it and keep self-healing via the next boot's `onSignIn` GET):
- adopt the echoed `syncVersion`, guarded by auth-generation capture (no resurrecting state after sign-out/user switch) and monotonicity (a slow flush response can't regress past a newer upload)
- settle the dirty keys the flush durably uploaded
- non-2xx responses change nothing, so the existing conflict-merge path stays the recovery route

Remaining 409s after this are genuine multi-device conflicts, which the CAS guard exists for and the client merges.

## Tests
- `tests/cloud-prefs-flush-version-guard.test.mjs` (new static guard, house style — cloud-prefs-sync.ts is not importable under node:test)
- `./node_modules/.bin/tsx --test tests/cloud-prefs-*.test.* tests/save-to-storage-quota-guard.test.mjs` → 38/38 pass
- `npm run typecheck` green
- full pre-push battery passed