### PR TITLE
feat(mobile): category navigation chips + breaking/critical banner parity

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1252,10 +1252,8 @@ export class App {
       });
     }
 
-    if (!this.state.isMobile) {
-      initBreakingNewsAlerts();
-      this.state.breakingBanner = new BreakingNewsBanner();
-    }
+    initBreakingNewsAlerts();
+    this.state.breakingBanner = new BreakingNewsBanner();
 
     // Phase 3: UI setup methods
     this.eventHandlers.startHeaderClock();

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -720,6 +720,13 @@ export class PanelLayoutManager implements AppModule {
     this.mobilePanelNav.refresh();
   }
 
+  private updateMobileMapCollapseBtn(isCollapsed: boolean): void {
+    if (!this.mobileMapCollapseBtn) return;
+    this.mobileMapCollapseBtn.textContent = isCollapsed
+      ? `▶ ${t('components.map.showMap')}`
+      : `▼ ${t('components.map.hideMap')}`;
+  }
+
   private setupMobileMapToggle(): void {
     const mapSection = document.getElementById('mapSection');
     const headerLeft = mapSection?.querySelector('.panel-header-left');
@@ -729,19 +736,15 @@ export class PanelLayoutManager implements AppModule {
     const collapsed = stored === 'true';
     if (collapsed) mapSection.classList.add('collapsed');
 
-    const updateBtn = (btn: HTMLButtonElement, isCollapsed: boolean) => {
-      btn.textContent = isCollapsed ? `▶ ${t('components.map.showMap')}` : `▼ ${t('components.map.hideMap')}`;
-    };
-
     const btn = document.createElement('button');
     btn.className = 'map-collapse-btn';
-    updateBtn(btn, collapsed);
     headerLeft.after(btn);
     this.mobileMapCollapseBtn = btn;
+    this.updateMobileMapCollapseBtn(collapsed);
 
     btn.addEventListener('click', () => {
       const isCollapsed = mapSection.classList.toggle('collapsed');
-      updateBtn(btn, isCollapsed);
+      this.updateMobileMapCollapseBtn(isCollapsed);
       localStorage.setItem('mobile-map-collapsed', String(isCollapsed));
       if (!isCollapsed) window.dispatchEvent(new Event('resize'));
     });
@@ -758,9 +761,7 @@ export class PanelLayoutManager implements AppModule {
     if (mapSection.classList.contains('collapsed')) {
       mapSection.classList.remove('collapsed');
       localStorage.setItem('mobile-map-collapsed', 'false');
-      if (this.mobileMapCollapseBtn) {
-        this.mobileMapCollapseBtn.textContent = `▼ ${t('components.map.hideMap')}`;
-      }
+      this.updateMobileMapCollapseBtn(false);
       window.dispatchEvent(new Event('resize'));
     }
     document.querySelector('.main-content')?.scrollTo({ top: 0 });

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -85,6 +85,7 @@ import {
   WsbTickerScannerPanel,
   AAIISentimentPanel,
   EnergyCrisisPanel,
+  MobilePanelNav,
 } from '@/components';
 import { SatelliteFiresPanel } from '@/components/SatelliteFiresPanel';
 import { focusInvestmentOnMap } from '@/services/investments-focus';
@@ -188,6 +189,8 @@ export class PanelLayoutManager implements AppModule {
   private resolvedPanelOrder: string[] = [];
   private bottomSetMemory: Set<string> = new Set();
   private criticalBannerEl: HTMLElement | null = null;
+  private mobilePanelNav: MobilePanelNav | null = null;
+  private mobileMapCollapseBtn: HTMLButtonElement | null = null;
   private aviationCommandBar: AviationCommandBar | null = null;
   private readonly applyTimeRangeFilterDebounced: (() => void) & { cancel(): void };
   private unsubscribeAuth: (() => void) | null = null;
@@ -373,6 +376,9 @@ export class PanelLayoutManager implements AppModule {
       this.criticalBannerEl.remove();
       this.criticalBannerEl = null;
     }
+    this.mobilePanelNav?.destroy();
+    this.mobilePanelNav = null;
+    this.mobileMapCollapseBtn = null;
     // Clean up happy variant panels
     this.ctx.tvMode?.destroy();
     this.ctx.tvMode = null;
@@ -702,7 +708,16 @@ export class PanelLayoutManager implements AppModule {
 
     if (this.ctx.isMobile) {
       this.setupMobileMapToggle();
+      this.setupMobilePanelNav();
     }
+  }
+
+  private setupMobilePanelNav(): void {
+    const grid = document.getElementById('panelsGrid');
+    if (!grid) return;
+    this.mobilePanelNav = new MobilePanelNav(() => this.ctx.panelSettings);
+    grid.before(this.mobilePanelNav.getElement());
+    this.mobilePanelNav.refresh();
   }
 
   private setupMobileMapToggle(): void {
@@ -722,6 +737,7 @@ export class PanelLayoutManager implements AppModule {
     btn.className = 'map-collapse-btn';
     updateBtn(btn, collapsed);
     headerLeft.after(btn);
+    this.mobileMapCollapseBtn = btn;
 
     btn.addEventListener('click', () => {
       const isCollapsed = mapSection.classList.toggle('collapsed');
@@ -731,16 +747,23 @@ export class PanelLayoutManager implements AppModule {
     });
   }
 
-  renderCriticalBanner(postures: TheaterPostureSummary[]): void {
-    if (this.ctx.isMobile) {
-      if (this.criticalBannerEl) {
-        this.criticalBannerEl.remove();
-        this.criticalBannerEl = null;
+  /** Expand the mobile map (no-op if already expanded) so a banner's
+   *  "View Region" fly-to is actually visible, then scroll it into view. */
+  private revealMobileMap(): void {
+    const mapSection = document.getElementById('mapSection');
+    if (!mapSection) return;
+    if (mapSection.classList.contains('collapsed')) {
+      mapSection.classList.remove('collapsed');
+      localStorage.setItem('mobile-map-collapsed', 'false');
+      if (this.mobileMapCollapseBtn) {
+        this.mobileMapCollapseBtn.textContent = `▼ ${t('components.map.hideMap')}`;
       }
-      document.body.classList.remove('has-critical-banner');
-      return;
+      window.dispatchEvent(new Event('resize'));
     }
+    document.querySelector('.main-content')?.scrollTo({ top: 0 });
+  }
 
+  renderCriticalBanner(postures: TheaterPostureSummary[]): void {
     const dismissedAt = sessionStorage.getItem('banner-dismissed');
     if (dismissedAt && Date.now() - parseInt(dismissedAt, 10) < 30 * 60 * 1000) {
       return;
@@ -786,6 +809,7 @@ export class PanelLayoutManager implements AppModule {
       console.log('[Banner] View Region clicked:', top.theaterId, 'lat:', top.centerLat, 'lon:', top.centerLon);
       trackCriticalBannerAction('view', top.theaterId);
       if (typeof top.centerLat === 'number' && typeof top.centerLon === 'number') {
+        if (this.ctx.isMobile) this.revealMobileMap();
         this.ctx.map?.setCenter(top.centerLat, top.centerLon, 4);
       } else {
         console.error('[Banner] Missing coordinates for', top.theaterId);
@@ -817,6 +841,7 @@ export class PanelLayoutManager implements AppModule {
       const panel = this.ctx.panels[key];
       panel?.toggle(config.enabled);
     });
+    this.mobilePanelNav?.refresh();
   }
 
   /**

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -752,6 +752,9 @@ export class PanelLayoutManager implements AppModule {
   private revealMobileMap(): void {
     const mapSection = document.getElementById('mapSection');
     if (!mapSection) return;
+    // Map panel disabled in settings — nothing to reveal; scrolling to an
+    // empty top would read as the tap doing nothing.
+    if (mapSection.classList.contains('hidden')) return;
     if (mapSection.classList.contains('collapsed')) {
       mapSection.classList.remove('collapsed');
       localStorage.setItem('mobile-map-collapsed', 'false');
@@ -2142,6 +2145,9 @@ export class PanelLayoutManager implements AppModule {
       if (savedConfig && !savedConfig.enabled) {
         this.ctx.panels[key]?.hide();
       }
+      // Same late-mount problem for the mobile category filter: the user may
+      // have picked a chip while this import was in flight.
+      this.mobilePanelNav?.applyToNewPanel(el);
     }).catch((err) => {
       console.error(`[panel] failed to lazy-load "${key}"`, err);
     });

--- a/src/components/BreakingNewsBanner.ts
+++ b/src/components/BreakingNewsBanner.ts
@@ -177,6 +177,9 @@ export class BreakingNewsBanner {
   }
 
   private scrollToPanel(panelId: string): void {
+    // Synchronous: lets the mobile category nav clear a filter that would
+    // leave the target display:none (scrollIntoView would silently no-op).
+    window.dispatchEvent(new CustomEvent('wm:reveal-panel', { detail: { panelId } }));
     const panel = document.querySelector(`[data-panel="${panelId}"]`);
     if (!panel) return;
     panel.scrollIntoView({ behavior: 'smooth', block: 'center' });

--- a/src/components/BreakingNewsBanner.ts
+++ b/src/components/BreakingNewsBanner.ts
@@ -2,6 +2,7 @@ import type { BreakingAlert } from '@/services/breaking-news-alerts';
 import { getAlertSettings } from '@/services/breaking-news-alerts';
 import { getSourcePanelId } from '@/config/feeds';
 import { t } from '@/services/i18n';
+import { isMobileDevice } from '@/utils';
 
 const MAX_ALERTS = 3;
 const CRITICAL_DISMISS_MS = 60_000;
@@ -29,11 +30,21 @@ export class BreakingNewsBanner {
   private boundOnResize: () => void;
   private dismissed = new Map<string, number>();
   private highlightTimers = new WeakMap<Element, ReturnType<typeof setTimeout>>();
+  private readonly inFlow: boolean;
 
   constructor() {
     this.container = document.createElement('div');
     this.container.className = 'breaking-news-container';
-    document.body.appendChild(this.container);
+    // Desktop: fixed body-level overlay. Mobile: join the app flex column
+    // below the header (same slot as the critical posture banner, which
+    // stays above when both are present) so alerts push content down
+    // instead of covering the sticky chip nav / map header band.
+    const anchor = isMobileDevice()
+      ? document.querySelector('.critical-posture-banner') ?? document.querySelector('.header')
+      : null;
+    this.inFlow = !!anchor;
+    if (anchor) anchor.insertAdjacentElement('afterend', this.container);
+    else document.body.appendChild(this.container);
 
     this.initAudio();
     this.updatePosition();
@@ -97,6 +108,12 @@ export class BreakingNewsBanner {
   }
 
   private updatePosition(): void {
+    // In-flow (mobile) container: document flow handles stacking under the
+    // header/posture banner; inline `top` is meaningless on static position.
+    if (this.inFlow) {
+      this.updateOffset();
+      return;
+    }
     let top = 50;
     if (document.body?.classList.contains('has-critical-banner')) {
       this.attachResizeObserverIfNeeded();

--- a/src/components/MobilePanelNav.ts
+++ b/src/components/MobilePanelNav.ts
@@ -35,6 +35,7 @@ export class MobilePanelNav {
     this.getPanelSettings = getPanelSettings;
     this.element = document.createElement('nav');
     this.element.className = 'mobile-panel-nav';
+    this.element.setAttribute('aria-label', t('components.mobileNav.panelCategories'));
     this.element.addEventListener('click', (e) => {
       const chip = (e.target as HTMLElement).closest<HTMLButtonElement>('[data-category]');
       if (chip?.dataset.category) this.select(chip.dataset.category);
@@ -126,11 +127,26 @@ export class MobilePanelNav {
     window.dispatchEvent(new Event('resize'));
   }
 
-  /** Scroll the bar to the top of the viewport so filtered panels are in view. */
+  /** Scroll so the filtered results are in view: bring the bar to the top
+   *  of the scrollport when it isn't there yet, and when it's already
+   *  stuck (user was deep in the list) bring the first visible panel up
+   *  underneath it — otherwise a chip tap can leave the viewport on
+   *  filtered-out empty space. */
   private scrollToPanels(): void {
     const scroller = this.element.parentElement;
     if (!scroller) return;
-    const delta = this.element.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
-    if (delta > 0) scroller.scrollTo({ top: scroller.scrollTop + delta });
+    const navRect = this.element.getBoundingClientRect();
+    const scrollerRect = scroller.getBoundingClientRect();
+    const delta = navRect.top - scrollerRect.top;
+    if (delta > 0) {
+      scroller.scrollTo({ top: scroller.scrollTop + delta });
+      return;
+    }
+    const first = document.querySelector<HTMLElement>(
+      '#panelsGrid [data-panel]:not(.mobile-cat-hidden):not(.hidden)',
+    );
+    if (!first) return;
+    const target = scroller.scrollTop + first.getBoundingClientRect().top - scrollerRect.top - navRect.height;
+    if (scroller.scrollTop > target) scroller.scrollTo({ top: Math.max(0, target) });
   }
 }

--- a/src/components/MobilePanelNav.ts
+++ b/src/components/MobilePanelNav.ts
@@ -1,0 +1,98 @@
+import { PANEL_CATEGORY_MAP, getVariantPanelCategories } from '@/config/panels';
+import { SITE_VARIANT } from '@/config';
+import { t } from '@/services/i18n';
+import type { PanelConfig } from '@/types';
+
+/**
+ * Mobile-only sticky category chip bar mounted above the panels grid.
+ * Turns the single-column panel scroll into navigable sections: tapping a
+ * category hides every grid panel outside it via `.mobile-cat-hidden`
+ * (CSS scoped to the ≤768px media query, so widening the viewport
+ * restores the full grid without JS involvement).
+ *
+ * Visibility interplay: Panel.toggle() uses `.hidden` for settings-driven
+ * visibility; this class is additive and never touches `.hidden`, so the
+ * two compose — a panel renders only when BOTH say visible.
+ */
+export class MobilePanelNav {
+  private element: HTMLElement;
+  private activeCategory = 'all';
+  private getPanelSettings: () => Record<string, PanelConfig>;
+
+  constructor(getPanelSettings: () => Record<string, PanelConfig>) {
+    this.getPanelSettings = getPanelSettings;
+    this.element = document.createElement('nav');
+    this.element.className = 'mobile-panel-nav';
+    this.element.addEventListener('click', (e) => {
+      const chip = (e.target as HTMLElement).closest<HTMLButtonElement>('[data-category]');
+      if (chip?.dataset.category) this.select(chip.dataset.category);
+    });
+  }
+
+  public getElement(): HTMLElement {
+    return this.element;
+  }
+
+  /** Rebuild chips from current panel settings, then re-apply the filter. */
+  public refresh(): void {
+    const categories = [
+      { key: 'all', label: t('header.sourceRegionAll') },
+      ...getVariantPanelCategories(this.getPanelSettings(), SITE_VARIANT)
+        .map(({ key, labelKey }) => ({ key, label: t(labelKey) })),
+    ];
+    if (!categories.some((c) => c.key === this.activeCategory)) {
+      this.activeCategory = 'all';
+    }
+    this.element.replaceChildren(...categories.map(({ key, label }) => {
+      const chip = document.createElement('button');
+      chip.className = 'mobile-panel-nav-chip';
+      chip.dataset.category = key;
+      chip.textContent = label;
+      this.setChipState(chip, key === this.activeCategory);
+      return chip;
+    }));
+    this.applyFilter();
+  }
+
+  public destroy(): void {
+    this.element.remove();
+  }
+
+  private setChipState(chip: HTMLElement, active: boolean): void {
+    chip.classList.toggle('active', active);
+    chip.setAttribute('aria-pressed', String(active));
+  }
+
+  private select(key: string): void {
+    if (key === this.activeCategory) return;
+    this.activeCategory = key;
+    this.element.querySelectorAll<HTMLElement>('.mobile-panel-nav-chip').forEach((chip) => {
+      this.setChipState(chip, chip.dataset.category === key);
+    });
+    this.applyFilter();
+    this.scrollToPanels();
+  }
+
+  private applyFilter(): void {
+    const grid = document.getElementById('panelsGrid');
+    if (!grid) return;
+    const def = this.activeCategory === 'all' ? undefined : PANEL_CATEGORY_MAP[this.activeCategory];
+    const allowed = def ? new Set(def.panelKeys) : null;
+    grid.classList.toggle('mobile-cat-filtered', !!allowed);
+    grid.querySelectorAll<HTMLElement>('[data-panel]').forEach((el) => {
+      const panelKey = el.dataset.panel ?? '';
+      el.classList.toggle('mobile-cat-hidden', !!allowed && !allowed.has(panelKey));
+    });
+    // Charts rendered while display:none come back at zero width — same
+    // recalc nudge the mobile map toggle uses.
+    window.dispatchEvent(new Event('resize'));
+  }
+
+  /** Scroll the bar to the top of the viewport so filtered panels are in view. */
+  private scrollToPanels(): void {
+    const scroller = this.element.parentElement;
+    if (!scroller) return;
+    const delta = this.element.getBoundingClientRect().top - scroller.getBoundingClientRect().top;
+    if (delta > 0) scroller.scrollTo({ top: scroller.scrollTop + delta });
+  }
+}

--- a/src/components/MobilePanelNav.ts
+++ b/src/components/MobilePanelNav.ts
@@ -1,7 +1,10 @@
-import { PANEL_CATEGORY_MAP, getVariantPanelCategories } from '@/config/panels';
+import { PANEL_CATEGORY_MAP, getVariantPanelCategories, getProPanelKeys } from '@/config/panels';
 import { SITE_VARIANT } from '@/config';
 import { t } from '@/services/i18n';
 import type { PanelConfig } from '@/types';
+
+// Synthetic chip key — must not collide with PANEL_CATEGORY_MAP keys.
+const PRO_CATEGORY = '__pro__';
 
 /**
  * Mobile-only sticky category chip bar mounted above the panels grid.
@@ -17,6 +20,7 @@ import type { PanelConfig } from '@/types';
 export class MobilePanelNav {
   private element: HTMLElement;
   private activeCategory = 'all';
+  private proPanelKeys: Set<string> = new Set();
   private getPanelSettings: () => Record<string, PanelConfig>;
 
   constructor(getPanelSettings: () => Record<string, PanelConfig>) {
@@ -35,9 +39,16 @@ export class MobilePanelNav {
 
   /** Rebuild chips from current panel settings, then re-apply the filter. */
   public refresh(): void {
+    const settings = this.getPanelSettings();
+    this.proPanelKeys = new Set(getProPanelKeys(settings, SITE_VARIANT));
     const categories = [
       { key: 'all', label: t('header.sourceRegionAll') },
-      ...getVariantPanelCategories(this.getPanelSettings(), SITE_VARIANT)
+      // PRO right after All: one tap surfaces the whole premium suite —
+      // each panel renders its own unlock CTA (the mobile conversion path).
+      ...(this.proPanelKeys.size > 0
+        ? [{ key: PRO_CATEGORY, label: `⚡ ${t('widgets.proBadge')}` }]
+        : []),
+      ...getVariantPanelCategories(settings, SITE_VARIANT)
         .map(({ key, labelKey }) => ({ key, label: t(labelKey) })),
     ];
     if (!categories.some((c) => c.key === this.activeCategory)) {
@@ -45,7 +56,9 @@ export class MobilePanelNav {
     }
     this.element.replaceChildren(...categories.map(({ key, label }) => {
       const chip = document.createElement('button');
-      chip.className = 'mobile-panel-nav-chip';
+      chip.className = key === PRO_CATEGORY
+        ? 'mobile-panel-nav-chip mobile-panel-nav-chip-pro'
+        : 'mobile-panel-nav-chip';
       chip.dataset.category = key;
       chip.textContent = label;
       this.setChipState(chip, key === this.activeCategory);
@@ -73,11 +86,17 @@ export class MobilePanelNav {
     this.scrollToPanels();
   }
 
+  private allowedKeysForActiveCategory(): Set<string> | null {
+    if (this.activeCategory === 'all') return null;
+    if (this.activeCategory === PRO_CATEGORY) return this.proPanelKeys;
+    const def = PANEL_CATEGORY_MAP[this.activeCategory];
+    return def ? new Set(def.panelKeys) : null;
+  }
+
   private applyFilter(): void {
     const grid = document.getElementById('panelsGrid');
     if (!grid) return;
-    const def = this.activeCategory === 'all' ? undefined : PANEL_CATEGORY_MAP[this.activeCategory];
-    const allowed = def ? new Set(def.panelKeys) : null;
+    const allowed = this.allowedKeysForActiveCategory();
     grid.classList.toggle('mobile-cat-filtered', !!allowed);
     grid.querySelectorAll<HTMLElement>('[data-panel]').forEach((el) => {
       const panelKey = el.dataset.panel ?? '';

--- a/src/components/MobilePanelNav.ts
+++ b/src/components/MobilePanelNav.ts
@@ -22,6 +22,14 @@ export class MobilePanelNav {
   private activeCategory = 'all';
   private proPanelKeys: Set<string> = new Set();
   private getPanelSettings: () => Record<string, PanelConfig>;
+  // Consumers that navigate to a panel (e.g. breaking-alert tap) dispatch
+  // this so an active filter can't swallow their scrollIntoView.
+  private boundRevealPanel = (e: Event): void => {
+    const key = (e as CustomEvent<{ panelId?: string }>).detail?.panelId;
+    if (!key) return;
+    const allowed = this.allowedKeysForActiveCategory();
+    if (allowed && !allowed.has(key)) this.select('all');
+  };
 
   constructor(getPanelSettings: () => Record<string, PanelConfig>) {
     this.getPanelSettings = getPanelSettings;
@@ -31,6 +39,7 @@ export class MobilePanelNav {
       const chip = (e.target as HTMLElement).closest<HTMLButtonElement>('[data-category]');
       if (chip?.dataset.category) this.select(chip.dataset.category);
     });
+    window.addEventListener('wm:reveal-panel', this.boundRevealPanel);
   }
 
   public getElement(): HTMLElement {
@@ -68,7 +77,17 @@ export class MobilePanelNav {
   }
 
   public destroy(): void {
+    window.removeEventListener('wm:reveal-panel', this.boundRevealPanel);
     this.element.remove();
+  }
+
+  /** Stamp the active filter onto a panel mounted AFTER refresh() ran —
+   *  lazy-loaded panels would otherwise leak into a filtered view. No
+   *  resize dispatch: a freshly mounted panel renders at correct width. */
+  public applyToNewPanel(el: HTMLElement): void {
+    const allowed = this.allowedKeysForActiveCategory();
+    const key = el.dataset.panel ?? '';
+    el.classList.toggle('mobile-cat-hidden', !!allowed && !allowed.has(key));
   }
 
   private setChipState(chip: HTMLElement, active: boolean): void {

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -1,6 +1,6 @@
 import '@/styles/settings-window.css';
 import { CANONICAL_FEEDS, INTEL_SOURCES, SOURCE_REGION_MAP } from '@/config/feeds';
-import { PANEL_CATEGORY_MAP, ALL_PANELS, VARIANT_DEFAULTS, getEffectivePanelConfig, isPanelEntitled, FREE_MAX_PANELS } from '@/config/panels';
+import { PANEL_CATEGORY_MAP, ALL_PANELS, VARIANT_DEFAULTS, getEffectivePanelConfig, getVariantPanelCategories, isPanelEntitled, FREE_MAX_PANELS } from '@/config/panels';
 import { isProUser } from '@/services/widget-store';
 import { SITE_VARIANT } from '@/config/variant';
 import { t } from '@/services/i18n';
@@ -677,20 +677,11 @@ export class UnifiedSettings {
   }
 
   private getAvailablePanelCategories(): Array<{ key: string; label: string }> {
-    const settings = this.config.getPanelSettings();
-    const categories: Array<{ key: string; label: string }> = [
-      { key: 'all', label: t('header.sourceRegionAll') }
+    return [
+      { key: 'all', label: t('header.sourceRegionAll') },
+      ...getVariantPanelCategories(this.config.getPanelSettings(), SITE_VARIANT)
+        .map(({ key, labelKey }) => ({ key, label: t(labelKey) })),
     ];
-
-    for (const [catKey, catDef] of Object.entries(PANEL_CATEGORY_MAP)) {
-      if (!this.categoryMatchesVariant(catDef)) continue;
-      const hasEnabledPanel = catDef.panelKeys.some(pk => settings[pk]?.enabled);
-      if (hasEnabledPanel) {
-        categories.push({ key: catKey, label: t(catDef.labelKey) });
-      }
-    }
-
-    return categories;
   }
 
   private getVisiblePanelEntries(): Array<[string, PanelConfig]> {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -24,6 +24,7 @@ export * from './EnergyComplexPanel';
 export * from './OilInventoriesPanel';
 export * from './SearchModal';
 export * from './MobileWarningModal';
+export * from './MobilePanelNav';
 export * from './PizzIntIndicator';
 export * from './LlmStatusIndicator';
 export * from './GdeltIntelPanel';

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -1263,74 +1263,91 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
     panelKeys: ['map', 'live-news', 'live-webcams', 'windy-webcams', 'insights', 'strategic-posture', 'latest-brief'],
   },
 
-  // Full (geopolitical) variant
+  // Full (geopolitical) variant — marketsFinance/topical/dataTracking are
+  // shared with the energy variant, which has no dedicated category block.
   intelligence: {
     labelKey: 'header.panelCatIntelligence',
     panelKeys: ['cii', 'strategic-risk', 'intel', 'gdelt-intel', 'cascade', 'telegram-intel', 'forecast', 'cross-source-signals', 'regional-intelligence', 'deduction', 'chat-analyst', 'thermal-escalation', 'social-velocity', 'geo-hubs'],
+    variants: ['full'],
   },
   correlation: {
     labelKey: 'header.panelCatCorrelation',
     panelKeys: ['military-correlation', 'escalation-correlation', 'economic-correlation', 'disaster-correlation'],
+    variants: ['full'],
   },
   regionalNews: {
     labelKey: 'header.panelCatRegionalNews',
     panelKeys: ['politics', 'us', 'europe', 'middleeast', 'africa', 'latam', 'asia'],
+    variants: ['full'],
   },
   marketsFinance: {
     labelKey: 'header.panelCatMarketsFinance',
     panelKeys: ['commodities', 'energy-complex', 'energy-risk-overview', 'pipeline-status', 'storage-facility-map', 'oil-inventories', 'fuel-prices', 'chokepoint-strip', 'fuel-shortages', 'energy-disruptions', 'hormuz-tracker', 'energy-crisis', 'markets', 'economic', 'trade-policy', 'sanctions-pressure', 'supply-chain', 'finance', 'polymarket', 'macro-signals', 'gulf-economies', 'etf-flows', 'stablecoins', 'crypto', 'heatmap', 'aaii-sentiment', 'cot-positioning', 'earnings-calendar', 'economic-calendar', 'fear-greed', 'fsi', 'macro-tiles', 'market-breadth', 'liquidity-shifts', 'national-debt', 'positioning-247', 'wsb-ticker-scanner', 'yield-curve', 'gold-intelligence', 'bigmac', 'market-implications'],
+    variants: ['full', 'energy'],
   },
   topical: {
     labelKey: 'header.panelCatTopical',
     panelKeys: ['energy', 'gov', 'thinktanks', 'tech', 'ai', 'layoffs'],
+    variants: ['full', 'energy'],
   },
   dataTracking: {
     labelKey: 'header.panelCatDataTracking',
     panelKeys: ['monitors', 'satellite-fires', 'ucdp-events', 'displacement', 'climate', 'climate-news', 'population-exposure', 'security-advisories', 'radiation-watch', 'oref-sirens', 'world-clock', 'tech-readiness', 'disease-outbreaks', 'fao-food-price-index', 'grocery-basket', 'defense-patents'],
+    variants: ['full', 'energy'],
   },
 
   // Tech variant
   techAi: {
     labelKey: 'header.panelCatTechAi',
     panelKeys: ['ai', 'tech', 'hardware', 'cloud', 'dev', 'github', 'producthunt', 'events', 'service-status', 'tech-readiness', 'internet-disruptions', 'tech-hubs'],
+    variants: ['tech'],
   },
   startupsVc: {
     labelKey: 'header.panelCatStartupsVc',
     panelKeys: ['startups', 'vcblogs', 'regionalStartups', 'unicorns', 'accelerators', 'funding', 'ipo'],
+    variants: ['tech'],
   },
   securityPolicy: {
     labelKey: 'header.panelCatSecurityPolicy',
     panelKeys: ['security', 'policy', 'ai-regulation'],
+    variants: ['tech'],
   },
   techMarkets: {
     labelKey: 'header.panelCatMarkets',
     panelKeys: ['markets', 'finance', 'crypto', 'economic', 'sanctions-pressure', 'polymarket', 'macro-signals', 'etf-flows', 'stablecoins', 'layoffs', 'monitors', 'world-clock'],
+    variants: ['tech'],
   },
 
   // Finance variant
   finMarkets: {
     labelKey: 'header.panelCatMarkets',
     panelKeys: ['markets', 'stock-analysis', 'stock-backtest', 'daily-market-brief', 'markets-news', 'heatmap', 'macro-signals', 'analysis', 'polymarket'],
+    variants: ['finance'],
   },
   fixedIncomeFx: {
     labelKey: 'header.panelCatFixedIncomeFx',
     panelKeys: ['forex', 'bonds'],
+    variants: ['finance'],
   },
   finCommodities: {
     labelKey: 'header.panelCatCommodities',
     panelKeys: ['commodities', 'energy-complex', 'commodities-news'],
+    variants: ['finance'],
   },
   cryptoDigital: {
     labelKey: 'header.panelCatCryptoDigital',
     panelKeys: ['crypto', 'crypto-heatmap', 'defi-tokens', 'ai-tokens', 'other-tokens', 'crypto-news', 'etf-flows', 'stablecoins', 'fintech'],
+    variants: ['finance'],
   },
   centralBanksEcon: {
     labelKey: 'header.panelCatCentralBanks',
     panelKeys: ['centralbanks', 'economic', 'energy-complex', 'trade-policy', 'sanctions-pressure', 'supply-chain', 'economic-news'],
+    variants: ['finance'],
   },
   dealsInstitutional: {
     labelKey: 'header.panelCatDeals',
     panelKeys: ['ipo', 'derivatives', 'institutional', 'fin-regulation'],
+    variants: ['finance'],
   },
   gulfMena: {
     labelKey: 'header.panelCatGulfMena',
@@ -1342,10 +1359,12 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
   commodityPrices: {
     labelKey: 'header.panelCatCommodityPrices',
     panelKeys: ['commodities', 'energy-complex', 'gold-silver', 'energy', 'base-metals', 'critical-minerals', 'markets', 'heatmap', 'macro-signals'],
+    variants: ['commodity'],
   },
   miningIndustry: {
     labelKey: 'header.panelCatMining',
     panelKeys: ['commodity-news', 'mining-news', 'mining-companies', 'supply-chain', 'commodity-regulation'],
+    variants: ['commodity'],
   },
   commodityEcon: {
     labelKey: 'header.panelCatCommodityEcon',
@@ -1365,6 +1384,25 @@ export const PANEL_CATEGORY_MAP: Record<string, { labelKey: string; panelKeys: s
     variants: ['happy'],
   },
 };
+
+export interface VariantPanelCategory {
+  key: string;
+  labelKey: string;
+  panelKeys: string[];
+}
+
+// Categories applicable to `variant` that contain at least one enabled panel.
+// Shared by the settings panel-tab filter and the mobile category nav —
+// callers prepend their own "all" entry and localize labelKey via t().
+export function getVariantPanelCategories(
+  panelSettings: Record<string, PanelConfig>,
+  variant: string,
+): VariantPanelCategory[] {
+  return Object.entries(PANEL_CATEGORY_MAP)
+    .filter(([, def]) => !def.variants || def.variants.includes(variant))
+    .filter(([, def]) => def.panelKeys.some((pk) => panelSettings[pk]?.enabled))
+    .map(([key, def]) => ({ key, labelKey: def.labelKey, panelKeys: def.panelKeys }));
+}
 
 // Monitor palette — fixed category colors persisted to localStorage (not theme-dependent)
 export const MONITOR_COLORS = [

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -1404,6 +1404,19 @@ export function getVariantPanelCategories(
     .map(([key, def]) => ({ key, labelKey: def.labelKey, panelKeys: def.panelKeys }));
 }
 
+// Enabled panels that carry a premium gate on the current surface — drives
+// the mobile nav's PRO chip. getEffectivePanelConfig folds in per-variant
+// premium overrides; unknown keys (custom widgets, MCP panels) resolve to a
+// premium-less stub and drop out.
+export function getProPanelKeys(
+  panelSettings: Record<string, PanelConfig>,
+  variant: string,
+): string[] {
+  return Object.keys(panelSettings).filter((key) =>
+    panelSettings[key]?.enabled && Boolean(getEffectivePanelConfig(key, variant).premium),
+  );
+}
+
 // Monitor palette — fixed category colors persisted to localStorage (not theme-dependent)
 export const MONITOR_COLORS = [
   '#44ff88',

--- a/src/locales/ar.json
+++ b/src/locales/ar.json
@@ -2360,6 +2360,9 @@
         "sampleLabel": "إشارات انقطاع AIS",
         "creditName": "نقاط عبور النفط العالمية بوكالة معلومات الطاقة"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/bg.json
+++ b/src/locales/bg.json
@@ -2296,6 +2296,9 @@
         "sampleLabel": "AIS сигнали за прекъсване",
         "creditName": "EIA World Oil Transit Chokepoints"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/cs.json
+++ b/src/locales/cs.json
@@ -2328,6 +2328,9 @@
         "sampleLabel": "Signály narušení AIS",
         "creditName": "EIA World Oil Transit Chokepoints"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -2296,6 +2296,9 @@
         "sampleLabel": "AIS-Unterbrechungssignale",
         "creditName": "EIA World Oil Transit Chokepoints"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -2296,6 +2296,9 @@
         "sampleLabel": "Σήματα διακοπής AIS",
         "creditName": "EIA World Oil Transit Chokepoints"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1691,6 +1691,9 @@
       "sortNewest": "Newest",
       "sortRelevance": "Relevance"
     },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
+    },
     "breakingNews": {
       "critical": "CRITICAL",
       "high": "HIGH",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -2312,6 +2312,9 @@
         "sampleLabel": "Señales de disrupción AIS",
         "creditName": "Puntos Críticos de Tránsito de Petróleo Mundial de la EIA"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -2312,6 +2312,9 @@
         "sampleLabel": "Signaux de perturbation AIS",
         "creditName": "Points de contrôle du transit pétrolier mondial de l'EIA"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/hi.json
+++ b/src/locales/hi.json
@@ -2364,6 +2364,9 @@
         "sampleLabel": "AIS व्यवधान संकेत",
         "creditName": "EIA विश्व तेल पारगमन चोकपॉइंट"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/hr.json
+++ b/src/locales/hr.json
@@ -2548,6 +2548,9 @@
         "sampleLabel": "AIS signali smetnji",
         "creditName": "EIA World Oil Transit Chokepoints"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/hu.json
+++ b/src/locales/hu.json
@@ -2364,6 +2364,9 @@
         "sampleLabel": "AIS zavarási jelek",
         "creditName": "EIA World Oil Transit Chokepoints"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -2312,6 +2312,9 @@
         "sampleLabel": "Segnali di interruzione AIS",
         "creditName": "EIA Punti Critici del Transito Petrolifero Mondiale"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -2296,6 +2296,9 @@
         "sampleLabel": "AIS遮断信号",
         "creditName": "EIA World Oil Transit Chokepoints"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -2296,6 +2296,9 @@
         "sampleLabel": "AIS 중단 신호",
         "creditName": "EIA World Oil Transit Chokepoints"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -2084,6 +2084,9 @@
         "sampleLabel": "AIS-verstoringssignalen",
         "creditName": "EIA World Oil Transit Chokepoints"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -2328,6 +2328,9 @@
         "sampleLabel": "Sygnały zakłóceń AIS",
         "creditName": "EIA Światowe Punkty Krytyczne Transportu Ropy Naftowej"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -2100,6 +2100,9 @@
         "sampleLabel": "Sinais de perturbação AIS",
         "creditName": "Pontos de Trânsito de Petróleo Mundial da EIA"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -2312,6 +2312,9 @@
         "sampleLabel": "Semnale de întrerupere AIS",
         "creditName": "Puncte strâmte de tranzit petrolier mondial EIA"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -2328,6 +2328,9 @@
         "sampleLabel": "Сигналы нарушения AIS",
         "creditName": "EIA World Oil Transit Chokepoints"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -2084,6 +2084,9 @@
         "sampleLabel": "AIS-störningssignaler",
         "creditName": "EIA World Oil Transit Chokepoints"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/th.json
+++ b/src/locales/th.json
@@ -2296,6 +2296,9 @@
         "sampleLabel": "สัญญาณการหยุดชะงัก AIS",
         "creditName": "จุดคอขวดการขนส่งน้ำมันโลก EIA"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -2296,6 +2296,9 @@
         "sampleLabel": "AIS kesinti sinyalleri",
         "creditName": "EIA Dünya Petrol Transit Dar Boğazları"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -2296,6 +2296,9 @@
         "sampleLabel": "Tín hiệu gián đoạn AIS",
         "creditName": "Các điểm tắc nghẽn vận chuyển dầu toàn cầu của EIA"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -2296,6 +2296,9 @@
         "sampleLabel": "AIS 中断信号",
         "creditName": "EIA 世界石油运输瓶颈"
       }
+    },
+    "mobileNav": {
+      "panelCategories": "Panel categories"
     }
   },
   "popups": {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -23619,3 +23619,116 @@ body.map-width-resizing {
   align-items: center;
   margin-left: 6px;
 }
+
+/* ============ Mobile Category Nav + Mobile Banner Parity ============ */
+
+/* Sticky chip bar above the panels grid — mobile only. Mounted by
+ * PanelLayoutManager.setupMobilePanelNav(); hidden entirely on desktop
+ * so a resized-up viewport never shows it. Sticks to the top of the
+ * .main-content scrollport while the user scrolls panels. */
+.mobile-panel-nav {
+  display: none;
+}
+
+@media (max-width: 768px) {
+  .mobile-panel-nav {
+    display: flex;
+    flex-shrink: 0; /* .main-content is a column flexbox — don't get crushed */
+    gap: 6px;
+    position: sticky;
+    top: 0;
+    z-index: 60;
+    background: var(--bg);
+    border-bottom: 1px solid var(--border);
+    padding: 8px max(8px, env(safe-area-inset-right, 0px)) 8px max(8px, env(safe-area-inset-left, 0px));
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    touch-action: pan-x;
+  }
+
+  .mobile-panel-nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  .mobile-panel-nav-chip {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    min-height: 32px;
+    padding: 4px 14px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--surface);
+    color: var(--text-dim);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .mobile-panel-nav-chip.active {
+    /* --accent is #fff on dark / #111 on light — pair with --bg for contrast */
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--bg);
+    font-weight: 600;
+  }
+
+  /* Category filter: composes with Panel.toggle()'s `.hidden` — a panel
+   * renders only when both settings AND the active category allow it. */
+  .panels-grid .mobile-cat-hidden {
+    display: none !important;
+  }
+
+  /* Add-panel / Pro-widget CTAs only make sense in the unfiltered view. */
+  .panels-grid.mobile-cat-filtered .add-panel-block {
+    display: none;
+  }
+
+  /* Critical posture banner — compact mobile variant (was desktop-only). */
+  .critical-posture-banner {
+    padding: 8px 10px;
+    gap: 8px;
+  }
+
+  .critical-posture-banner .banner-content {
+    gap: 8px;
+  }
+
+  .critical-posture-banner .banner-headline {
+    font-size: 12px;
+  }
+
+  .critical-posture-banner .banner-stats {
+    display: none;
+  }
+
+  .critical-posture-banner .banner-view {
+    padding: 6px 10px;
+    font-size: 11px;
+    white-space: nowrap;
+  }
+
+  /* Breaking news alerts — let headlines wrap instead of ellipsizing into
+   * uselessness on narrow screens; source/time drops to its own line. */
+  .breaking-alert {
+    padding: 8px 10px;
+    gap: 8px;
+    font-size: 12px;
+  }
+
+  .breaking-alert-content {
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .breaking-alert-headline {
+    white-space: normal;
+  }
+
+  .breaking-alert-meta {
+    flex-basis: 100%;
+  }
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -12370,11 +12370,13 @@ a.prediction-link:hover {
     max-height: none !important;
   }
 
-  .main-content .map-section.collapsed .map-container,
-  .main-content .map-section.collapsed .map-resize-handle,
-  .main-content .map-section.collapsed .map-controls,
-  .main-content .map-section.collapsed .time-slider,
-  .main-content .map-section.collapsed .tv-exit-btn {
+  /* :not(.live-news-fullscreen): entering fullscreen from a collapsed map
+     must still show the map — fullscreen wins over collapse. */
+  .main-content .map-section.collapsed:not(.live-news-fullscreen) .map-container,
+  .main-content .map-section.collapsed:not(.live-news-fullscreen) .map-resize-handle,
+  .main-content .map-section.collapsed:not(.live-news-fullscreen) .map-controls,
+  .main-content .map-section.collapsed:not(.live-news-fullscreen) .time-slider,
+  .main-content .map-section.collapsed:not(.live-news-fullscreen) .tv-exit-btn {
     display: none;
   }
 
@@ -23699,6 +23701,21 @@ body.map-width-resizing {
 
   .panel-locked-desc {
     font-size: 12px;
+  }
+
+  /* Map fullscreen on mobile: the button shares .map-pin-btn with the
+   * desktop-only pin button, whose blanket display:none !important (see
+   * the collapsed-map block) hid fullscreen too. The CSS-class fullscreen
+   * (live-news-fullscreen, not the Fullscreen API) works on iOS Safari. */
+  .map-pin-btn#mapFullscreenBtn {
+    display: flex !important;
+    min-width: 44px;
+    min-height: 30px;
+  }
+
+  /* While fullscreen, collapsing would blank the screen — hide the toggle. */
+  .map-section.live-news-fullscreen .map-collapse-btn {
+    display: none;
   }
 
   /* Category filter: composes with Panel.toggle()'s `.hidden` — a panel

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -23718,6 +23718,20 @@ body.map-width-resizing {
     display: none;
   }
 
+  /* The mobile .map-section height (100dvh - 48px) outranks the generic
+   * .live-news-fullscreen height:auto by file order — restate it here so
+   * fullscreen truly reaches bottom:0 instead of leaving a 48px strip. */
+  .map-section.live-news-fullscreen {
+    height: auto !important;
+    min-height: 0 !important;
+    max-height: none !important;
+  }
+
+  /* Search FAB floats above the z-10000 fullscreen overlay — hide it. */
+  body.live-news-fullscreen-active .search-mobile-fab {
+    display: none;
+  }
+
   /* Category filter: composes with Panel.toggle()'s `.hidden` — a panel
    * renders only when both settings AND the active category allow it. */
   .panels-grid .mobile-cat-hidden {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -23786,6 +23786,15 @@ body.map-width-resizing {
     white-space: nowrap;
   }
 
+  /* Breaking news alerts — in-flow on mobile (BreakingNewsBanner mounts
+   * the container into the app flex column below the header), mirroring
+   * the critical posture banner: alerts push content down instead of
+   * covering the sticky chip nav / map header for their 30-60s lifetime. */
+  .breaking-news-container {
+    position: static;
+    flex-shrink: 0;
+  }
+
   /* Breaking news alerts — let headlines wrap instead of ellipsizing into
    * uselessness on narrow screens; source/time drops to its own line. */
   .breaking-alert {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -23647,7 +23647,9 @@ body.map-width-resizing {
     overflow-y: hidden;
     -webkit-overflow-scrolling: touch;
     scrollbar-width: none;
-    touch-action: pan-x;
+    /* pan-y too: the bar is sticky over the top of the scroller — a
+     * vertical swipe starting on it must still scroll .main-content. */
+    touch-action: pan-x pan-y;
   }
 
   .mobile-panel-nav::-webkit-scrollbar {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -23743,10 +23743,27 @@ body.map-width-resizing {
     display: none;
   }
 
-  /* Critical posture banner — compact mobile variant (was desktop-only). */
+  /* Critical posture banner — compact mobile variant (was desktop-only).
+   * In-flow (not fixed): a persistent fixed banner at top:50px sits over
+   * the sticky chip nav band (z 999 vs 60) and the map header buttons.
+   * The element is inserted right after .header in the flex column, so
+   * static positioning pushes content down naturally... */
   .critical-posture-banner {
+    position: static;
+    flex-shrink: 0; /* flex-column item — same crush risk as the chip nav */
     padding: 8px 10px;
     gap: 8px;
+    flex-wrap: wrap;
+  }
+
+  /* ...which also makes the desktop grid compensations dead gaps — the
+   * grid sits below the map + chip nav on mobile, not below the banner. */
+  body.has-critical-banner .panels-grid {
+    padding-top: 4px;
+  }
+
+  body.has-breaking-alert .panels-grid {
+    margin-top: 0;
   }
 
   .critical-posture-banner .banner-content {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -23676,6 +23676,31 @@ body.map-width-resizing {
     font-weight: 600;
   }
 
+  /* PRO chip — gold treatment matching the .panel-locked-cta aesthetic. */
+  .mobile-panel-nav-chip-pro {
+    border-color: #d4a843;
+    color: #d4a843;
+    font-weight: 600;
+  }
+
+  .mobile-panel-nav-chip-pro.active {
+    background: linear-gradient(135deg, #d4a843 0%, #b8902e 100%);
+    border-color: #d4a843;
+    color: #111;
+  }
+
+  /* Lock CTAs get touch-sized and prominent — in the single-column scroll
+   * the desktop-sized 6px button reads as decoration, not an action. */
+  .panel-locked-cta {
+    min-height: 44px;
+    padding: 10px 28px;
+    font-size: 12px;
+  }
+
+  .panel-locked-desc {
+    font-size: 12px;
+  }
+
   /* Category filter: composes with Panel.toggle()'s `.hidden` — a panel
    * renders only when both settings AND the active category allow it. */
   .panels-grid .mobile-cat-hidden {

--- a/tests/mobile-panel-nav-categories.test.mts
+++ b/tests/mobile-panel-nav-categories.test.mts
@@ -139,5 +139,7 @@ describe('mobile nav i18n contract', () => {
     }
     // The "all" chip both consumers prepend:
     assert.equal(typeof lookup('header.sourceRegionAll'), 'string');
+    // The nav's accessible name:
+    assert.equal(typeof lookup('components.mobileNav.panelCategories'), 'string');
   });
 });

--- a/tests/mobile-panel-nav-categories.test.mts
+++ b/tests/mobile-panel-nav-categories.test.mts
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { PANEL_CATEGORY_MAP, VARIANT_DEFAULTS, getVariantPanelCategories } from '../src/config/panels';
+import { PANEL_CATEGORY_MAP, VARIANT_DEFAULTS, getVariantPanelCategories, getProPanelKeys } from '../src/config/panels';
 import type { PanelConfig } from '../src/types';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -94,6 +94,36 @@ describe('getVariantPanelCategories', () => {
     const keys = getVariantPanelCategories(all, 'full').map((c) => c.key);
     const expected = Object.keys(PANEL_CATEGORY_MAP).filter((k) => keys.includes(k));
     assert.deepEqual(keys, expected);
+  });
+});
+
+describe('getProPanelKeys (mobile nav PRO chip)', () => {
+  // NOTE: runs on the web surface (no Tauri under tsx) — desktop-only
+  // premium fields (`_desktop && {...}` in panels.ts) are absent here, so
+  // assertions cover the web gating shape.
+  it('includes enabled premium panels, excludes free and disabled ones', () => {
+    const result = getProPanelKeys(settings({
+      'stock-analysis': true,   // premium: 'locked' on all surfaces
+      'chat-analyst': true,     // premium: 'locked' on all surfaces
+      'daily-market-brief': false, // premium but disabled
+      intel: true,              // free panel
+    }), 'full');
+    assert.deepEqual(result.sort(), ['chat-analyst', 'stock-analysis']);
+  });
+
+  it('drops unknown keys (custom widgets / MCP panels)', () => {
+    const result = getProPanelKeys(settings({ 'cw-abc123': true, 'mcp-panel-1': true }), 'full');
+    assert.deepEqual(result, []);
+  });
+
+  it('full-variant defaults surface a non-empty premium suite', () => {
+    const enabledDefaults = settings(
+      Object.fromEntries((VARIANT_DEFAULTS['full'] ?? []).map((k: string) => [k, true])),
+    );
+    const result = getProPanelKeys(enabledDefaults, 'full');
+    assert.ok(result.includes('stock-analysis'));
+    assert.ok(result.includes('chat-analyst'));
+    assert.ok(result.length >= 5, `expected a meaningful premium suite, got ${result.join(', ')}`);
   });
 });
 

--- a/tests/mobile-panel-nav-categories.test.mts
+++ b/tests/mobile-panel-nav-categories.test.mts
@@ -1,0 +1,113 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { PANEL_CATEGORY_MAP, VARIANT_DEFAULTS, getVariantPanelCategories } from '../src/config/panels';
+import type { PanelConfig } from '../src/types';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// getVariantPanelCategories feeds both the UnifiedSettings panel-tab filter
+// and the mobile category nav (MobilePanelNav). Regression target: the
+// mobile nav must only surface categories the user can actually browse —
+// variant-scoped and with at least one enabled panel.
+
+function settings(entries: Record<string, boolean>): Record<string, PanelConfig> {
+  return Object.fromEntries(
+    Object.entries(entries).map(([key, enabled]) => [key, { name: key, enabled }]),
+  );
+}
+
+describe('getVariantPanelCategories', () => {
+  it('drops categories with no enabled panel', () => {
+    const result = getVariantPanelCategories(settings({ cii: false, intel: false }), 'full');
+    assert.equal(result.length, 0);
+  });
+
+  it('includes a category once any of its panels is enabled', () => {
+    const result = getVariantPanelCategories(settings({ cii: true, intel: false }), 'full');
+    assert.deepEqual(result.map((c) => c.key), ['intelligence']);
+    assert.equal(result[0]!.labelKey, PANEL_CATEGORY_MAP['intelligence']!.labelKey);
+    assert.deepEqual(result[0]!.panelKeys, PANEL_CATEGORY_MAP['intelligence']!.panelKeys);
+  });
+
+  it('panels absent from settings never activate a category', () => {
+    // cii enabled=true but the category lookup goes through settings — a
+    // panel key that is missing entirely must not count as enabled.
+    const result = getVariantPanelCategories(settings({ 'not-a-real-panel': true }), 'full');
+    assert.equal(result.length, 0);
+  });
+
+  it('respects variant scoping (gulfMena is finance-only)', () => {
+    const enabled = settings({ 'gulf-economies': true });
+    assert.ok(PANEL_CATEGORY_MAP['gulfMena']!.variants?.includes('finance'), 'fixture assumption');
+    const forFull = getVariantPanelCategories(enabled, 'full');
+    const forFinance = getVariantPanelCategories(enabled, 'finance');
+    assert.ok(!forFull.some((c) => c.key === 'gulfMena'));
+    assert.ok(forFinance.some((c) => c.key === 'gulfMena'));
+  });
+
+  it('unscoped categories (core) are available to every variant', () => {
+    assert.equal(PANEL_CATEGORY_MAP['core']!.variants, undefined, 'core stays unscoped');
+    const enabled = settings({ 'live-news': true });
+    for (const variant of ['full', 'tech', 'finance', 'commodity', 'energy', 'happy']) {
+      const result = getVariantPanelCategories(enabled, variant);
+      assert.ok(
+        result.some((c) => c.key === 'core'),
+        `variant ${variant} should see the core category`,
+      );
+    }
+  });
+
+  // Chip-clutter guardrail: before the variants tags were populated, every
+  // variant surfaced 10-15 categories (incl. two distinct chips both labeled
+  // "Markets") because cross-variant panel keys lit up foreign categories.
+  // The mobile nav and the settings filter both depend on this curation.
+  it('variant defaults yield the curated category set, free of duplicate labels', () => {
+    const expected: Record<string, string[]> = {
+      full: ['core', 'intelligence', 'correlation', 'regionalNews', 'marketsFinance', 'topical', 'dataTracking'],
+      tech: ['core', 'techAi', 'startupsVc', 'securityPolicy', 'techMarkets'],
+      finance: ['core', 'finMarkets', 'fixedIncomeFx', 'finCommodities', 'cryptoDigital', 'centralBanksEcon', 'dealsInstitutional', 'gulfMena'],
+      commodity: ['core', 'commodityPrices', 'miningIndustry', 'commodityEcon'],
+      energy: ['core', 'marketsFinance', 'topical', 'dataTracking'],
+      happy: ['core', 'happyNews', 'happyPlanet'],
+    };
+    for (const [variant, expectedKeys] of Object.entries(expected)) {
+      const enabledDefaults = settings(
+        Object.fromEntries((VARIANT_DEFAULTS[variant] ?? []).map((k: string) => [k, true])),
+      );
+      const result = getVariantPanelCategories(enabledDefaults, variant);
+      assert.deepEqual(result.map((c) => c.key), expectedKeys, `variant ${variant}`);
+      const labels = result.map((c) => c.labelKey);
+      assert.equal(new Set(labels).size, labels.length, `duplicate category labels for ${variant}`);
+    }
+  });
+
+  it('preserves PANEL_CATEGORY_MAP declaration order', () => {
+    const all = settings(
+      Object.fromEntries(
+        Object.values(PANEL_CATEGORY_MAP).flatMap((def) => def.panelKeys.map((k) => [k, true])),
+      ),
+    );
+    const keys = getVariantPanelCategories(all, 'full').map((c) => c.key);
+    const expected = Object.keys(PANEL_CATEGORY_MAP).filter((k) => keys.includes(k));
+    assert.deepEqual(keys, expected);
+  });
+});
+
+describe('mobile nav i18n contract', () => {
+  it('every category labelKey resolves in en.json', () => {
+    const en = JSON.parse(readFileSync(resolve(__dirname, '../src/locales/en.json'), 'utf-8'));
+    const lookup = (path: string): unknown =>
+      path.split('.').reduce<unknown>((node, part) =>
+        node && typeof node === 'object' ? (node as Record<string, unknown>)[part] : undefined, en);
+
+    for (const [key, def] of Object.entries(PANEL_CATEGORY_MAP)) {
+      assert.equal(typeof lookup(def.labelKey), 'string', `missing en.json key ${def.labelKey} (category ${key})`);
+    }
+    // The "all" chip both consumers prepend:
+    assert.equal(typeof lookup('header.sourceRegionAll'), 'string');
+  });
+});


### PR DESCRIPTION
## Why

60% of visitors are on mobile, yet the mobile experience is a single endless scroll of ~40 panels with no navigation — value is buried, and two high-signal features (breaking news alerts, critical posture banner) were amputated on mobile entirely. This is round 1 of the mobile→desktop parity initiative.

## What

### 1. Mobile category navigation (`MobilePanelNav`)
A sticky, horizontally-scrollable chip bar above the panels grid (≤768px only) that filters the grid by panel category. Tapping **Intelligence** narrows 39 panels to the 8 relevant ones and auto-scrolls past the map; **All** restores everything. Built on the existing `PANEL_CATEGORY_MAP` + a new shared `getVariantPanelCategories()` helper that `UnifiedSettings` now reuses (DRY).

| Browse (All) | Filtered (Intelligence) |
|---|---|
| ![all](https://raw.githubusercontent.com/koala73/worldmonitor/assets/welcome-screenshots/mobile-nav-all.png) | ![intelligence](https://raw.githubusercontent.com/koala73/worldmonitor/assets/welcome-screenshots/mobile-nav-intelligence-v2.png) |

### 2. `PANEL_CATEGORY_MAP` variant curation
The `variants` field was unpopulated on most categories, so every variant lit up 10–15 categories — including **two distinct chips both labeled "Markets"** (techMarkets + finMarkets). Tagged each block per its design intent (the source comments already grouped them by variant); energy shares full's marketsFinance/topical/dataTracking since it has no dedicated block. Each variant now shows 4–8 curated categories. This also de-clutters the settings panel-tab filter, which shares the helper.

### 3. Breaking news + critical posture banners on mobile
Both were gated `if (!isMobile)`. Now enabled with compact mobile CSS (headlines wrap instead of ellipsizing into uselessness; stats hidden on the posture banner). The posture banner's **View Region** now expands a collapsed mobile map before flying to the region, so the action is actually visible.

![breaking](https://raw.githubusercontent.com/koala73/worldmonitor/assets/welcome-screenshots/mobile-breaking-alert.png)

### 4. PRO chip — the mobile conversion surface
A gold **⚡ PRO** chip (right after *All*) filters the grid to every premium-gated panel in one tap — Stock Analysis, Backtesting, Daily Market Brief, WM Analyst, Trade Policy, Latest Brief, Market Implications — each rendering its own unlock CTA. Previously these were scattered through a ~40-panel scroll where mobile users never saw them. Lock CTAs are also touch-sized (44px) on mobile now. The chip hides itself when no premium panel is enabled (e.g. happy variant), and `getProPanelKeys()` respects per-variant premium overrides.

![pro chip](https://raw.githubusercontent.com/koala73/worldmonitor/assets/welcome-screenshots/mobile-pro-chip.png)

### 5. Map fullscreen on mobile
The fullscreen button existed but shared `.map-pin-btn` with the desktop-only pin button, whose blanket mobile `display:none` hid it — the feature was built and unreachable. Now visible touch-sized on mobile; fullscreen wins over the collapsed-map state (entering fullscreen from a collapsed map shows the map), and the collapse toggle hides while fullscreen so it can't blank the overlay. Verified round-trip: expand/collapse × enter/exit.

![map fullscreen](https://raw.githubusercontent.com/koala73/worldmonitor/assets/welcome-screenshots/mobile-map-fullscreen.png)

## Verification

- Playwright at 390×844 against `vite dev`: chip bar renders curated chips (full variant), sticky engages at scroller top, Intelligence tap → 39→8 panels with correct keys + `add-panel` CTAs hidden, All → 39 restored, PRO tap → exactly the 7 premium panels with unlock CTAs, simulated `wm:breaking-news` event renders the mobile alert full-width with wrapped headline.
- Caught & fixed during browser verification: chip bar crushed to 17px (`.main-content` is a column flexbox → `flex-shrink: 0`), active chip white-on-white (`--accent` is `#fff` on dark theme → text uses `var(--bg)`).
- `npm run typecheck` (full), `npm run lint` + safe-html guard: clean.
- New `tests/mobile-panel-nav-categories.test.mts` (11 tests): `getProPanelKeys` premium/disabled/unknown-key handling, variant scoping, enabled-panel intersection, per-variant curated set + duplicate-label guardrail, declaration-order stability, en.json i18n contract for every category labelKey.
- Re-ran consumers of the touched config: `panel-config-guardrails` (12), `energy-variant-atlas-guard` (4), `panel-variant-config` + `widget-builder` + `country-deep-dive-notify-sub-action` (233) — all green.

## Notes for review

- `Panel.toggle()`'s `.hidden` and the nav's `.mobile-cat-hidden` compose (both must allow display); the filter class only exists inside the ≤768px media query, so widening the viewport restores the full grid with no JS.
- Custom widgets / MCP panels aren't categorized — they appear under **All** only.
- `MobileWarningModal` was found to be dead code (exported, never instantiated) — left untouched, candidate for removal in a follow-up.

Round 2 candidates (tracked): swipe between categories (TODO-067), map touch targets (TODO-066), tablet split-view (TODO-065). (PWA manifest turned out to already exist — vite-plugin-pwa injects it at build time.)

## Adversarial self-review (post-implementation)

A second adversarial pass over the cumulative diff surfaced 4 composition issues, all fixed and re-verified live:
- **Lazy-mount filter leak**: panels whose dynamic imports resolved after a chip was tapped appeared unfiltered (worst case: free panels inside the PRO view). `lazyPanel` now stamps the active filter on insertion. Verified: chip tapped during boot, 145 panels mounted over 9s, zero leaks.
- **Banner/nav stacking**: the (newly mobile-enabled) critical banner was `fixed top:50px z-999`, sitting on the sticky chip nav for its whole lifetime. It's in-flow on mobile now; the desktop `.panels-grid` padding/margin compensations are neutralized (they opened dead gaps mid-scroller).
- **Breaking alerts in-flow too** (P3 follow-up): the alert container had the same fixed-overlay overlap for its 30-60s lifetime — on mobile it now mounts into the app flex column below the header/posture banner; desktop keeps the fixed overlay. Verified: alert pushes content down by its own height, stuck nav sits flush below it.
- **Alert tap dead-end**: tapping a breaking alert whose target panel was filtered out silently no-oped (`scrollIntoView` on `display:none`). `scrollToPanel` now dispatches `wm:reveal-panel`; the nav clears the filter synchronously.
- **View Region with map disabled**: `revealMobileMap` no-ops instead of scrolling to an empty top.

Known accepted trade-offs: `isMobile` stays a boot-time constant (pre-existing pattern); nav `destroy()` leaves filter classes on grid panels (full-layout teardown makes this moot); on the desktop app at ≤768px width the PRO chip would include `premium:'enhanced'` panels (not just locked) — web behavior, the actual mobile audience, is exact.
