### PR TITLE
fix(sentry): harden chat-analyst 5xx + filter Firefox fetch noise

### DIFF
--- a/api/chat-analyst.ts
+++ b/api/chat-analyst.ts
@@ -16,6 +16,8 @@ export const config = { runtime: 'edge', regions: ['iad1', 'lhr1', 'fra1', 'sfo1
 
 // @ts-expect-error — JS module, no declaration file
 import { getCorsHeaders } from './_cors.js';
+// @ts-expect-error — JS module, no declaration file
+import { captureSilentError } from './_sentry-edge.js';
 import { isCallerPremium } from '../server/_shared/premium-check';
 import { checkRateLimit } from '../server/_shared/rate-limit';
 import { assembleAnalystContext } from '../server/worldmonitor/intelligence/v1/chat-analyst-context';
@@ -85,95 +87,112 @@ export default async function handler(req: Request): Promise<Response> {
     return json({ error: 'Method not allowed' }, 405, corsHeaders);
   }
 
-  const isPremium = await isCallerPremium(req);
-  if (!isPremium) {
-    return json({ error: 'Pro subscription required' }, 403, corsHeaders);
-  }
-
-  // Streaming LLM endpoint — the rate-limit IS the abuse defence (each
-  // call hits a frontier model). This route doesn't go through gateway
-  // checkEndpointRateLimit, so opt into fail-closed explicitly: a Redis
-  // outage must not silently lift the budget. (#3531)
-  const rateLimitResponse = await checkRateLimit(req, corsHeaders, { failClosed: true });
-  if (rateLimitResponse) return rateLimitResponse;
-
-  let body: ChatAnalystRequestBody;
+  // Top-level error boundary. An edge function must never let an exception
+  // escape: an uncaught throw becomes an opaque Vercel platform 500 that — for
+  // the cross-origin api.worldmonitor.app caller — also drops our CORS headers,
+  // so the browser sees an opaque failure rather than a readable status. The
+  // pre-stream auth/entitlement lookups (isCallerPremium) are network-backed
+  // and, while individually fail-soft today, this route had NO server-side
+  // capture, so any 5xx surfaced only as the browser's `API 500` message with
+  // no stack (WORLDMONITOR-SV). Mirror the sibling premium edge route
+  // (api/latest-brief.ts): capture server-side for a real trace, and return a
+  // CORS-correct transient 503 the panel can render. 503 (not 403) so a
+  // transient dependency blip never misclassifies a paying Pro user as
+  // unsubscribed.
   try {
-    body = (await req.json()) as ChatAnalystRequestBody;
-  } catch {
-    return json({ error: 'Invalid JSON body' }, 400, corsHeaders);
+    const isPremium = await isCallerPremium(req);
+    if (!isPremium) {
+      return json({ error: 'Pro subscription required' }, 403, corsHeaders);
+    }
+
+    // Streaming LLM endpoint — the rate-limit IS the abuse defence (each
+    // call hits a frontier model). This route doesn't go through gateway
+    // checkEndpointRateLimit, so opt into fail-closed explicitly: a Redis
+    // outage must not silently lift the budget. (#3531)
+    const rateLimitResponse = await checkRateLimit(req, corsHeaders, { failClosed: true });
+    if (rateLimitResponse) return rateLimitResponse;
+
+    let body: ChatAnalystRequestBody;
+    try {
+      body = (await req.json()) as ChatAnalystRequestBody;
+    } catch {
+      return json({ error: 'Invalid JSON body' }, 400, corsHeaders);
+    }
+
+    const rawQuery = typeof body.query === 'string' ? body.query.trim().slice(0, MAX_QUERY_LEN) : '';
+    if (!rawQuery) return json({ error: 'query is required' }, 400, corsHeaders);
+
+    const query = sanitizeForPrompt(rawQuery);
+    if (!query) return json({ error: 'query is required' }, 400, corsHeaders);
+
+    // Validate domainFocus against the fixed domain set to prevent prompt injection
+    const rawDomain = typeof body.domainFocus === 'string' ? body.domainFocus.trim() : '';
+    const domainFocus = VALID_DOMAINS.has(rawDomain) ? rawDomain : 'all';
+
+    const geoContext = typeof body.geoContext === 'string'
+      ? body.geoContext.trim().toUpperCase().slice(0, MAX_GEO_LEN)
+      : undefined;
+
+    const rawHistory = Array.isArray(body.history) ? body.history : [];
+    const history: ChatMessage[] = rawHistory
+      .filter((m): m is ChatMessage => {
+        if (!m || typeof m !== 'object') return false;
+        const msg = m as Record<string, unknown>;
+        return (msg.role === 'user' || msg.role === 'assistant') && typeof msg.content === 'string';
+      })
+      .slice(-MAX_HISTORY_MESSAGES)
+      .map((m) => {
+        const sanitized = sanitizeForPrompt(m.content.slice(0, MAX_MESSAGE_CHARS)) ?? '';
+        return { role: m.role, content: sanitized };
+      })
+      .filter((m) => m.content.length > 0);
+
+    // Build retrieval query with current turn FIRST so its keywords fill the
+    // extraction cap before prior-turn terms. This ensures pivot words like
+    // "Germany" in "What about Germany?" are never crowded out by a long
+    // previous question. Prior turn backfills remaining slots for topic continuity.
+    const prevUserTurn = history.filter((m) => m.role === 'user').slice(-1)[0]?.content ?? '';
+    const retrievalQuery = prevUserTurn ? `${query} ${prevUserTurn}` : query;
+
+    const context = await assembleAnalystContext(geoContext, domainFocus, retrievalQuery);
+    const systemPrompt = buildAnalystSystemPrompt(context, domainFocus);
+
+    const messages = [
+      { role: 'system', content: systemPrompt },
+      ...history,
+      { role: 'user', content: query },
+    ];
+
+    const llmStream = callLlmReasoningStream({
+      messages,
+      maxTokens: 600,
+      temperature: 0.35,
+      timeoutMs: 25_000,
+      signal: req.signal,
+    });
+
+    // Always prepend a meta event so the client knows which sources are live
+    // and whether context is degraded — before the first token arrives.
+    // Optionally follows with an action event for visual/chart queries.
+    const stream = prependSseEvents(
+      [
+        { meta: { sources: context.activeSources, degraded: context.degraded } },
+        ...buildActionEvents(query).map((a) => ({ action: a })),
+      ],
+      llmStream,
+    );
+
+    return new Response(stream, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache, no-store',
+        'X-Accel-Buffering': 'no',
+        ...corsHeaders,
+      },
+    });
+  } catch (err) {
+    captureSilentError(err, { tags: { route: 'api/chat-analyst', step: 'pre-stream' } });
+    return json({ error: 'service_unavailable' }, 503, corsHeaders);
   }
-
-  const rawQuery = typeof body.query === 'string' ? body.query.trim().slice(0, MAX_QUERY_LEN) : '';
-  if (!rawQuery) return json({ error: 'query is required' }, 400, corsHeaders);
-
-  const query = sanitizeForPrompt(rawQuery);
-  if (!query) return json({ error: 'query is required' }, 400, corsHeaders);
-
-  // Validate domainFocus against the fixed domain set to prevent prompt injection
-  const rawDomain = typeof body.domainFocus === 'string' ? body.domainFocus.trim() : '';
-  const domainFocus = VALID_DOMAINS.has(rawDomain) ? rawDomain : 'all';
-
-  const geoContext = typeof body.geoContext === 'string'
-    ? body.geoContext.trim().toUpperCase().slice(0, MAX_GEO_LEN)
-    : undefined;
-
-  const rawHistory = Array.isArray(body.history) ? body.history : [];
-  const history: ChatMessage[] = rawHistory
-    .filter((m): m is ChatMessage => {
-      if (!m || typeof m !== 'object') return false;
-      const msg = m as Record<string, unknown>;
-      return (msg.role === 'user' || msg.role === 'assistant') && typeof msg.content === 'string';
-    })
-    .slice(-MAX_HISTORY_MESSAGES)
-    .map((m) => {
-      const sanitized = sanitizeForPrompt(m.content.slice(0, MAX_MESSAGE_CHARS)) ?? '';
-      return { role: m.role, content: sanitized };
-    })
-    .filter((m) => m.content.length > 0);
-
-  // Build retrieval query with current turn FIRST so its keywords fill the
-  // extraction cap before prior-turn terms. This ensures pivot words like
-  // "Germany" in "What about Germany?" are never crowded out by a long
-  // previous question. Prior turn backfills remaining slots for topic continuity.
-  const prevUserTurn = history.filter((m) => m.role === 'user').slice(-1)[0]?.content ?? '';
-  const retrievalQuery = prevUserTurn ? `${query} ${prevUserTurn}` : query;
-
-  const context = await assembleAnalystContext(geoContext, domainFocus, retrievalQuery);
-  const systemPrompt = buildAnalystSystemPrompt(context, domainFocus);
-
-  const messages = [
-    { role: 'system', content: systemPrompt },
-    ...history,
-    { role: 'user', content: query },
-  ];
-
-  const llmStream = callLlmReasoningStream({
-    messages,
-    maxTokens: 600,
-    temperature: 0.35,
-    timeoutMs: 25_000,
-    signal: req.signal,
-  });
-
-  // Always prepend a meta event so the client knows which sources are live
-  // and whether context is degraded — before the first token arrives.
-  // Optionally follows with an action event for visual/chart queries.
-  const stream = prependSseEvents(
-    [
-      { meta: { sources: context.activeSources, degraded: context.degraded } },
-      ...buildActionEvents(query).map((a) => ({ action: a })),
-    ],
-    llmStream,
-  );
-
-  return new Response(stream, {
-    status: 200,
-    headers: {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache, no-store',
-      'X-Accel-Buffering': 'no',
-      ...corsHeaders,
-    },
-  });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -586,6 +586,20 @@ Sentry.init({
         // safety as the `Failed to fetch` / `signal timed out` blocks above
         // (WORLDMONITOR-RF).
         || /^(?:SyntaxError: )?Unexpected EOF$/.test(msg)
+        // Firefox's wording for a failed `fetch()` — the engine-emitted
+        // equivalent of Chrome's bare `Failed to fetch` (above) and Safari's
+        // `Load failed`. Surfaces via `onunhandledrejection` with zero captured
+        // frames. Same provenance reasoning as the `Failed to fetch` gate
+        // (WORLDMONITOR-KM): a genuine first-party fetch failure keeps a
+        // source-mapped .ts frame on the awaiting site (hasFirstParty → NOT
+        // suppressed, preserved by the first-party-stack test), so a zero-frame
+        // rejection is a background / service-worker / extension / stale-pre-
+        // deploy-bundle fetch. The literal phrase is engine-emitted only — our
+        // shipped code never synthesizes it. This aligns the Firefox phrasing
+        // with the bare `Failed to fetch` handling; the earlier blanket
+        // "let NetworkError through" caution predated the KM provenance
+        // refinement (WORLDMONITOR-RK).
+        || /^(?:TypeError: )?NetworkError when attempting to fetch resource\.?$/.test(msg)
       )
     ) return null;
     if (hasAnyStack && !hasFirstParty && (

--- a/tests/chat-analyst.test.mts
+++ b/tests/chat-analyst.test.mts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
 
 import { buildAnalystSystemPrompt } from '../server/worldmonitor/intelligence/v1/chat-analyst-prompt.ts';
 import { buildActionEvents, VISUAL_INTENT_RE } from '../server/worldmonitor/intelligence/v1/chat-analyst-actions.ts';
@@ -586,5 +587,70 @@ describe('issue #3724 — prompt injection via headline context', () => {
       'system prompt must instruct the model to never treat context as instructions');
     assert.match(prompt, /disregard prior instructions|change role|switch persona/i,
       'system prompt must explicitly list role-change / instruction-override as attack patterns to ignore');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handler — edge wiring + pre-auth gates (WORLDMONITOR-SV)
+//
+// Importing the handler forces the full edge dependency graph to resolve
+// (a broken import path can't slip past `tsc` but WOULD fail at runtime on
+// Vercel — see brief-edge-route-smoke.test.mjs for the same rationale). The
+// OPTIONS / non-POST gates run before any network-backed call, so they are
+// deterministic without Redis/Convex/secrets.
+//
+// The top-level error boundary (try/catch → 503 service_unavailable +
+// captureSilentError) is defense-in-depth: every pre-stream dependency is
+// individually fail-soft today, so the catch cannot be black-box-triggered in
+// this suite (it has no Redis/Convex/Upstash mock — the same reason the sibling
+// route api/latest-brief.ts ships its boundary without a catch-trigger test).
+// This block at least guards that the route stays edge-wired and that the
+// boundary's source shape is present so a future refactor can't silently drop
+// it.
+// ---------------------------------------------------------------------------
+
+describe('api/chat-analyst handler — edge wiring + pre-auth gates', () => {
+  it('declares the edge runtime', async () => {
+    const mod = await import('../api/chat-analyst.ts');
+    assert.equal(typeof mod.default, 'function', 'handler must be a function');
+    assert.equal(mod.config?.runtime, 'edge', 'route must declare edge runtime');
+  });
+
+  it('returns 204 with CORS on OPTIONS preflight (no secrets / no Redis)', async () => {
+    const { default: handler } = await import('../api/chat-analyst.ts');
+    const req = new Request('https://api.worldmonitor.app/api/chat-analyst', {
+      method: 'OPTIONS',
+      headers: { origin: 'https://worldmonitor.app' },
+    });
+    const res = await handler(req);
+    assert.equal(res.status, 204);
+    assert.ok(res.headers.get('access-control-allow-methods')?.includes('POST'),
+      'preflight must advertise POST');
+  });
+
+  it('returns 405 on disallowed methods', async () => {
+    const { default: handler } = await import('../api/chat-analyst.ts');
+    const req = new Request('https://api.worldmonitor.app/api/chat-analyst', {
+      method: 'GET',
+      headers: { origin: 'https://worldmonitor.app' },
+    });
+    const res = await handler(req);
+    assert.equal(res.status, 405);
+  });
+
+  it('has a top-level error boundary that fails to a CORS-correct 503 (not an opaque platform 500)', () => {
+    // Source-shape guard. The boundary converts an uncaught pre-stream throw
+    // into a controlled, CORS-bearing 503 the panel can render and a server-
+    // side Sentry capture — the gap that left WORLDMONITOR-SV diagnosable only
+    // as the browser's `API 500` message. Locks the boundary in against a
+    // refactor that re-introduces an unguarded handler body.
+    const src = readFileSync(
+      new URL('../api/chat-analyst.ts', import.meta.url),
+      'utf-8',
+    );
+    assert.match(src, /captureSilentError\(err,\s*\{\s*tags:\s*\{\s*route:\s*'api\/chat-analyst'/,
+      'catch must capture server-side with a route tag');
+    assert.match(src, /json\(\{\s*error:\s*'service_unavailable'\s*\},\s*503,\s*corsHeaders\)/,
+      'catch must return a CORS-correct 503 service_unavailable');
   });
 });

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -157,8 +157,14 @@ describe('empty-stack network/timeout errors are NOT suppressed', () => {
   // stacks — that exact phrase is emitted only by the runtime on stale-chunk-after-
   // deploy, which the chunk-reload guard already auto-recovers. See the dedicated
   // suite below for that case (WORLDMONITOR-Q / WORLDMONITOR-15).
+  // Note: Firefox's `NetworkError when attempting to fetch resource.` USED to
+  // live here (preserved with empty stacks on a "could be our code" caution),
+  // but that predated the `Failed to fetch` provenance refinement. It now lives
+  // in the zero-frame suppression suite below — it is the engine-equivalent of
+  // Chrome's bare `Failed to fetch` and is suppressed the same way (zero frames
+  // → background/SW/extension; a real first-party failure keeps a .ts frame).
+  // WORLDMONITOR-RK / WORLDMONITOR-KM.
   const networkErrors = [
-    'TypeError: NetworkError when attempting to fetch resource.',
     'Could not connect to the server',
     'Operation timed out',
     'Invalid or unexpected token',
@@ -297,6 +303,15 @@ describe('zero-frame async-rejection patterns (timeout / DOMException / OOM / DO
     // is engine-emitted only.
     ['Unexpected EOF', 'SyntaxError'],
     ['SyntaxError: Unexpected EOF', 'SyntaxError'],
+    // Firefox's wording for a failed `fetch()` (WORLDMONITOR-RK) — the
+    // engine-equivalent of Chrome's bare `Failed to fetch` above. Zero frames
+    // via `onunhandledrejection` = background / service-worker / extension /
+    // stale-pre-deploy-bundle fetch. A genuine first-party fetch failure keeps
+    // a source-mapped .ts frame on the awaiting site (asserted "lets through"
+    // by the first-party-stack loop below). Both the bare and type-prefixed
+    // value shapes are matched.
+    ['NetworkError when attempting to fetch resource.', 'TypeError'],
+    ['TypeError: NetworkError when attempting to fetch resource.', 'TypeError'],
   ];
 
   for (const [msg, type] of zeroFrameErrors) {


### PR DESCRIPTION
## Summary

Two fixes from Sentry triage (both issues resolved as *next-release*):

- **WORLDMONITOR-SV** — `API 500: /api/chat-analyst`. This was the only premium edge route **lacking the top-level error boundary** its sibling `api/latest-brief.ts` already has. Every pre-stream dependency is individually fail-soft and `assembleAnalystContext` is `Promise.allSettled`-bulletproof, so the 500 was an *uncaught throw* → opaque Vercel platform 500 that **also drops CORS headers** for the cross-origin `api.worldmonitor.app` caller, leaving the failure diagnosable only as the browser's stackless `api_5xx` message. Added the convention: `try/catch` → `captureSilentError` (server-side trace) + CORS-correct **503 `service_unavailable`**. 503 (not 403) so a transient auth/entitlement-lookup blip never misclassifies a paying Pro user as unsubscribed.

- **WORLDMONITOR-RK** — `TypeError: NetworkError when attempting to fetch resource.` Firefox's wording for a failed `fetch()` — the engine-equivalent of Chrome's `Failed to fetch` / Safari's `Load failed`, which are already suppressed zero-frame in `beforeSend`. The Firefox phrasing was preserved by an earlier "could be our code" caution that predated the `Failed to fetch` provenance refinement (WORLDMONITOR-KM). Aligned them: suppress zero-frame in the `!hasFirstParty` block. A genuine first-party fetch failure keeps a source-mapped `.ts` frame and **still surfaces** (no observability blind spot).

## Why these are safe

- RK suppression is stack-gated (`beforeSend`, not `ignoreErrors`) — first-party frame ⇒ preserved.
- SV boundary mirrors the established `latest-brief.ts` pattern; whitespace-ignored diff confirms no business logic changed (the large line count is pure re-indent from the `try` wrap).

## Test plan

- [x] `npm run typecheck` + `npm run typecheck:api`
- [x] `npm run lint` (biome + safe-html) · CJS syntax · `npm run lint:md` · `npm run version:check`
- [x] `npm run test:data` (full suite, 204 pass / 0 fail)
- [x] edge bundle (`esbuild api/*.js`) + `tests/edge-functions.test.mjs`
- [x] `tests/sentry-beforesend.test.mjs` — RK case moved to `zeroFrameErrors` (empty/third-party → suppressed, first-party → preserved); 160/160
- [x] `tests/chat-analyst.test.mts` — new edge-wiring (OPTIONS→204, GET→405) + error-boundary source-shape guards; 66/66