### PR TITLE
Fix map country selection after drag

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -613,6 +613,28 @@ export class DeckGLMap {
   private readonly refreshCountryDragSuppression = (): void => {
     refreshCountryClickDragSuppression(this.countryClickGesture);
   };
+  private attachMapLibreInteractionHandlers(): void {
+    if (!this.maplibreMap) return;
+    const canvas = this.maplibreMap.getCanvas();
+    canvas.addEventListener('contextmenu', this.handleContextMenu);
+    canvas.addEventListener('pointerdown', this.handleCountryClickPointerDown);
+    canvas.addEventListener('pointermove', this.handleCountryClickPointerMove);
+    canvas.addEventListener('pointerup', this.handleCountryClickPointerEnd);
+    canvas.addEventListener('pointercancel', this.handleCountryClickPointerEnd);
+    this.maplibreMap.on('dragstart', this.markCountryDragGesture);
+    this.maplibreMap.on('dragend', this.refreshCountryDragSuppression);
+  }
+  private detachMapLibreInteractionHandlers(): void {
+    if (!this.maplibreMap) return;
+    const canvas = this.maplibreMap.getCanvas();
+    this.maplibreMap.off('dragstart', this.markCountryDragGesture);
+    this.maplibreMap.off('dragend', this.refreshCountryDragSuppression);
+    canvas.removeEventListener('contextmenu', this.handleContextMenu);
+    canvas.removeEventListener('pointerdown', this.handleCountryClickPointerDown);
+    canvas.removeEventListener('pointermove', this.handleCountryClickPointerMove);
+    canvas.removeEventListener('pointerup', this.handleCountryClickPointerEnd);
+    canvas.removeEventListener('pointercancel', this.handleCountryClickPointerEnd);
+  }
   private readonly handleContextMenu = (e: MouseEvent): void => {
     e.preventDefault();
     if (!this.onMapContextMenu || !this.maplibreMap) return;
@@ -943,6 +965,7 @@ export class DeckGLMap {
       console.warn(`[DeckGLMap] Primary basemap failed, recreating with fallback: ${fallback}`);
       const attr = this.container.querySelector('.map-attribution');
       if (attr) setTrustedHtml(attr, trustedHtml('© <a href="https://openfreemap.org" target="_blank" rel="noopener">OpenFreeMap</a> © <a href="https://www.openstreetmap.org/copyright" target="_blank" rel="noopener">OpenStreetMap</a>', "legacy direct innerHTML migration"));
+      this.detachMapLibreInteractionHandlers();
       this.maplibreMap?.remove();
       const fallbackEl = document.getElementById('deckgl-basemap');
       if (!fallbackEl) return;
@@ -965,6 +988,7 @@ export class DeckGLMap {
           : {}),
       });
       this.maplibreMap.on('load', () => {
+        this.attachMapLibreInteractionHandlers();
         localizeMapLabels(this.maplibreMap);
         this.initDeck();
         this.loadCountryBoundaries();
@@ -1036,13 +1060,7 @@ export class DeckGLMap {
       }
     });
 
-    this.maplibreMap.getCanvas().addEventListener('contextmenu', this.handleContextMenu);
-    this.maplibreMap.getCanvas().addEventListener('pointerdown', this.handleCountryClickPointerDown);
-    this.maplibreMap.getCanvas().addEventListener('pointermove', this.handleCountryClickPointerMove);
-    this.maplibreMap.getCanvas().addEventListener('pointerup', this.handleCountryClickPointerEnd);
-    this.maplibreMap.getCanvas().addEventListener('pointercancel', this.handleCountryClickPointerEnd);
-    this.maplibreMap.on('dragstart', this.markCountryDragGesture);
-    this.maplibreMap.on('dragend', this.refreshCountryDragSuppression);
+    this.attachMapLibreInteractionHandlers();
   }
 
   private initDeck(): void {
@@ -7368,13 +7386,7 @@ export class DeckGLMap {
 
     this.deckOverlay?.finalize();
     this.deckOverlay = null;
-    this.maplibreMap?.off('dragstart', this.markCountryDragGesture);
-    this.maplibreMap?.off('dragend', this.refreshCountryDragSuppression);
-    this.maplibreMap?.getCanvas().removeEventListener('contextmenu', this.handleContextMenu);
-    this.maplibreMap?.getCanvas().removeEventListener('pointerdown', this.handleCountryClickPointerDown);
-    this.maplibreMap?.getCanvas().removeEventListener('pointermove', this.handleCountryClickPointerMove);
-    this.maplibreMap?.getCanvas().removeEventListener('pointerup', this.handleCountryClickPointerEnd);
-    this.maplibreMap?.getCanvas().removeEventListener('pointercancel', this.handleCountryClickPointerEnd);
+    this.detachMapLibreInteractionHandlers();
     this.maplibreMap?.remove();
     this.maplibreMap = null;
     setTrustedHtml(this.container, trustedHtml('', "legacy direct innerHTML migration"));

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -161,6 +161,15 @@ import { pinWebcam, isPinned } from '@/services/webcams/pinned-store';
 import type { WebcamEntry, WebcamCluster } from '@/generated/client/worldmonitor/webcam/v1/service_client';
 import { fetchWebcamImage } from '@/services/webcams';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
+import {
+  createCountryClickGestureTracker,
+  finishCountryClickGesture,
+  markCountryClickDrag,
+  shouldSuppressCountryClick,
+  startCountryClickGesture,
+  updateCountryClickGestureDrag,
+  type CountryClickGestureTracker,
+} from './map-interaction-guard';
 
 
 export type TimeRange = '1h' | '6h' | '24h' | '48h' | '7d' | 'all';
@@ -584,6 +593,22 @@ export class DeckGLMap {
   private onTimeRangeChange?: (range: TimeRange) => void;
   private onCountryClick?: (country: CountryClickPayload) => void;
   private onMapContextMenu?: (payload: { lat: number; lon: number; screenX: number; screenY: number; countryCode?: string; countryName?: string }) => void;
+  private readonly countryClickGesture: CountryClickGestureTracker = createCountryClickGestureTracker();
+  private readonly handleCountryClickPointerDown = (e: PointerEvent): void => {
+    if (e.pointerType === 'mouse' && e.button !== 0) return;
+    if (e.isPrimary === false) return;
+    startCountryClickGesture(this.countryClickGesture, { x: e.clientX, y: e.clientY });
+  };
+  private readonly handleCountryClickPointerMove = (e: PointerEvent): void => {
+    if (e.isPrimary === false) return;
+    updateCountryClickGestureDrag(this.countryClickGesture, { x: e.clientX, y: e.clientY });
+  };
+  private readonly handleCountryClickPointerEnd = (): void => {
+    finishCountryClickGesture(this.countryClickGesture);
+  };
+  private readonly markCountryDragGesture = (): void => {
+    markCountryClickDrag(this.countryClickGesture);
+  };
   private readonly handleContextMenu = (e: MouseEvent): void => {
     e.preventDefault();
     if (!this.onMapContextMenu || !this.maplibreMap) return;
@@ -1008,6 +1033,12 @@ export class DeckGLMap {
     });
 
     this.maplibreMap.getCanvas().addEventListener('contextmenu', this.handleContextMenu);
+    this.maplibreMap.getCanvas().addEventListener('pointerdown', this.handleCountryClickPointerDown);
+    this.maplibreMap.getCanvas().addEventListener('pointermove', this.handleCountryClickPointerMove);
+    this.maplibreMap.getCanvas().addEventListener('pointerup', this.handleCountryClickPointerEnd);
+    this.maplibreMap.getCanvas().addEventListener('pointercancel', this.handleCountryClickPointerEnd);
+    this.maplibreMap.on('dragstart', this.markCountryDragGesture);
+    this.maplibreMap.on('dragend', this.markCountryDragGesture);
   }
 
   private initDeck(): void {
@@ -4623,6 +4654,7 @@ export class DeckGLMap {
     const isChoropleth = info.layer?.id ? DeckGLMap.CHOROPLETH_LAYER_IDS.has(info.layer.id) : false;
     if (!info.object || isChoropleth) {
       if (info.coordinate && this.onCountryClick) {
+        if (this.shouldSuppressCountryClickAfterDrag()) return;
         const [lon, lat] = info.coordinate as [number, number];
         let country: { code: string; name: string } | null = null;
         if (isChoropleth && info.object?.properties) {
@@ -6959,6 +6991,10 @@ export class DeckGLMap {
 
   // --- Country click + highlight ---
 
+  private shouldSuppressCountryClickAfterDrag(): boolean {
+    return shouldSuppressCountryClick(this.countryClickGesture);
+  }
+
   public setOnCountryClick(cb: (country: CountryClickPayload) => void): void {
     this.onCountryClick = cb;
   }
@@ -7328,7 +7364,13 @@ export class DeckGLMap {
 
     this.deckOverlay?.finalize();
     this.deckOverlay = null;
+    this.maplibreMap?.off('dragstart', this.markCountryDragGesture);
+    this.maplibreMap?.off('dragend', this.markCountryDragGesture);
     this.maplibreMap?.getCanvas().removeEventListener('contextmenu', this.handleContextMenu);
+    this.maplibreMap?.getCanvas().removeEventListener('pointerdown', this.handleCountryClickPointerDown);
+    this.maplibreMap?.getCanvas().removeEventListener('pointermove', this.handleCountryClickPointerMove);
+    this.maplibreMap?.getCanvas().removeEventListener('pointerup', this.handleCountryClickPointerEnd);
+    this.maplibreMap?.getCanvas().removeEventListener('pointercancel', this.handleCountryClickPointerEnd);
     this.maplibreMap?.remove();
     this.maplibreMap = null;
     setTrustedHtml(this.container, trustedHtml('', "legacy direct innerHTML migration"));

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -165,6 +165,7 @@ import {
   createCountryClickGestureTracker,
   finishCountryClickGesture,
   markCountryClickDrag,
+  refreshCountryClickDragSuppression,
   shouldSuppressCountryClick,
   startCountryClickGesture,
   updateCountryClickGestureDrag,
@@ -609,6 +610,9 @@ export class DeckGLMap {
   private readonly markCountryDragGesture = (): void => {
     markCountryClickDrag(this.countryClickGesture);
   };
+  private readonly refreshCountryDragSuppression = (): void => {
+    refreshCountryClickDragSuppression(this.countryClickGesture);
+  };
   private readonly handleContextMenu = (e: MouseEvent): void => {
     e.preventDefault();
     if (!this.onMapContextMenu || !this.maplibreMap) return;
@@ -1038,7 +1042,7 @@ export class DeckGLMap {
     this.maplibreMap.getCanvas().addEventListener('pointerup', this.handleCountryClickPointerEnd);
     this.maplibreMap.getCanvas().addEventListener('pointercancel', this.handleCountryClickPointerEnd);
     this.maplibreMap.on('dragstart', this.markCountryDragGesture);
-    this.maplibreMap.on('dragend', this.markCountryDragGesture);
+    this.maplibreMap.on('dragend', this.refreshCountryDragSuppression);
   }
 
   private initDeck(): void {
@@ -7365,7 +7369,7 @@ export class DeckGLMap {
     this.deckOverlay?.finalize();
     this.deckOverlay = null;
     this.maplibreMap?.off('dragstart', this.markCountryDragGesture);
-    this.maplibreMap?.off('dragend', this.markCountryDragGesture);
+    this.maplibreMap?.off('dragend', this.refreshCountryDragSuppression);
     this.maplibreMap?.getCanvas().removeEventListener('contextmenu', this.handleContextMenu);
     this.maplibreMap?.getCanvas().removeEventListener('pointerdown', this.handleCountryClickPointerDown);
     this.maplibreMap?.getCanvas().removeEventListener('pointermove', this.handleCountryClickPointerMove);

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -72,6 +72,13 @@ import {
   type MapVariant,
 } from '@/config/map-layer-definitions';
 import { renderLayerExplanationCard } from '@/utils/layer-explanation-card';
+import {
+  createCountryClickGestureTracker,
+  finishCountryClickGesture,
+  shouldSuppressCountryClick,
+  startCountryClickGesture,
+  updateCountryClickGestureDrag,
+} from './map-interaction-guard';
 
 
 export type TimeRange = '1h' | '6h' | '24h' | '48h' | '7d' | 'all';
@@ -794,6 +801,7 @@ export class MapComponent {
     let lastPos = { x: 0, y: 0 };
     let lastTouchDist = 0;
     let lastTouchCenter = { x: 0, y: 0 };
+    const countryClickGesture = createCountryClickGestureTracker();
     const shouldIgnoreInteractionStart = (target: EventTarget | null): boolean => {
       if (!(target instanceof Element)) return false;
       return Boolean(
@@ -838,6 +846,7 @@ export class MapComponent {
       if (e.button === 0) { // Left click
         isDragging = true;
         lastPos = { x: e.clientX, y: e.clientY };
+        startCountryClickGesture(countryClickGesture, { x: e.clientX, y: e.clientY });
         this.container.style.cursor = 'grabbing';
       }
     });
@@ -847,6 +856,7 @@ export class MapComponent {
 
       const dx = e.clientX - lastPos.x;
       const dy = e.clientY - lastPos.y;
+      updateCountryClickGestureDrag(countryClickGesture, { x: e.clientX, y: e.clientY });
 
       const panSpeed = 1 / this.state.zoom;
       this.state.pan.x += dx * panSpeed;
@@ -859,6 +869,7 @@ export class MapComponent {
     document.addEventListener('mouseup', () => {
       if (isDragging) {
         isDragging = false;
+        finishCountryClickGesture(countryClickGesture);
         this.container.style.cursor = 'grab';
       }
     });
@@ -980,6 +991,7 @@ export class MapComponent {
     this.container.addEventListener('click', (e) => {
       if (!this.onCountryClick) return;
       if (performance.now() - lastDragEndTime < 300) return;
+      if (shouldSuppressCountryClick(countryClickGesture)) return;
       const containerRect = this.container.getBoundingClientRect();
       const zoom = this.state.zoom;
       const width = this.container.clientWidth;

--- a/src/components/map-interaction-guard.ts
+++ b/src/components/map-interaction-guard.ts
@@ -32,6 +32,8 @@ export function startCountryClickGesture(
 ): void {
   tracker.pointerStart = point;
   tracker.dragged = false;
+  // Preserve suppressNextClick across rapid gesture restarts so a quick
+  // click immediately after a drag still consumes the prior drag window.
 }
 
 export function markCountryClickDrag(
@@ -39,6 +41,13 @@ export function markCountryClickDrag(
   nowMs = currentNowMs(),
 ): void {
   tracker.dragged = true;
+  refreshCountryClickDragSuppression(tracker, nowMs);
+}
+
+export function refreshCountryClickDragSuppression(
+  tracker: CountryClickGestureTracker,
+  nowMs = currentNowMs(),
+): void {
   tracker.suppressNextClick = true;
   tracker.lastDragAtMs = nowMs;
 }
@@ -72,6 +81,8 @@ export function shouldSuppressCountryClick(
   nowMs = currentNowMs(),
 ): boolean {
   if (!tracker.suppressNextClick) return false;
+  // This check is intentionally single-use: call once per click event so a
+  // drag can suppress at most the synthetic click that follows it.
   tracker.suppressNextClick = false;
   return nowMs - tracker.lastDragAtMs <= COUNTRY_CLICK_DRAG_SUPPRESSION_MS;
 }

--- a/src/components/map-interaction-guard.ts
+++ b/src/components/map-interaction-guard.ts
@@ -1,0 +1,77 @@
+export interface ScreenPoint {
+  x: number;
+  y: number;
+}
+
+export interface CountryClickGestureTracker {
+  pointerStart: ScreenPoint | null;
+  dragged: boolean;
+  suppressNextClick: boolean;
+  lastDragAtMs: number;
+}
+
+export const COUNTRY_CLICK_DRAG_THRESHOLD_PX = 6;
+export const COUNTRY_CLICK_DRAG_SUPPRESSION_MS = 250;
+
+function currentNowMs(): number {
+  return typeof performance !== 'undefined' ? performance.now() : Date.now();
+}
+
+export function createCountryClickGestureTracker(): CountryClickGestureTracker {
+  return {
+    pointerStart: null,
+    dragged: false,
+    suppressNextClick: false,
+    lastDragAtMs: 0,
+  };
+}
+
+export function startCountryClickGesture(
+  tracker: CountryClickGestureTracker,
+  point: ScreenPoint,
+): void {
+  tracker.pointerStart = point;
+  tracker.dragged = false;
+}
+
+export function markCountryClickDrag(
+  tracker: CountryClickGestureTracker,
+  nowMs = currentNowMs(),
+): void {
+  tracker.dragged = true;
+  tracker.suppressNextClick = true;
+  tracker.lastDragAtMs = nowMs;
+}
+
+export function updateCountryClickGestureDrag(
+  tracker: CountryClickGestureTracker,
+  point: ScreenPoint,
+  nowMs = currentNowMs(),
+): boolean {
+  if (!tracker.pointerStart) return false;
+  const dx = point.x - tracker.pointerStart.x;
+  const dy = point.y - tracker.pointerStart.y;
+  if ((dx * dx + dy * dy) <= COUNTRY_CLICK_DRAG_THRESHOLD_PX * COUNTRY_CLICK_DRAG_THRESHOLD_PX) {
+    return false;
+  }
+  markCountryClickDrag(tracker, nowMs);
+  return true;
+}
+
+export function finishCountryClickGesture(
+  tracker: CountryClickGestureTracker,
+  nowMs = currentNowMs(),
+): void {
+  if (tracker.dragged) markCountryClickDrag(tracker, nowMs);
+  tracker.pointerStart = null;
+  tracker.dragged = false;
+}
+
+export function shouldSuppressCountryClick(
+  tracker: CountryClickGestureTracker,
+  nowMs = currentNowMs(),
+): boolean {
+  if (!tracker.suppressNextClick) return false;
+  tracker.suppressNextClick = false;
+  return nowMs - tracker.lastDragAtMs <= COUNTRY_CLICK_DRAG_SUPPRESSION_MS;
+}

--- a/tests/map-country-drag-click.test.mjs
+++ b/tests/map-country-drag-click.test.mjs
@@ -1,5 +1,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   COUNTRY_CLICK_DRAG_SUPPRESSION_MS,
   COUNTRY_CLICK_DRAG_THRESHOLD_PX,
@@ -11,6 +14,9 @@ import {
   startCountryClickGesture,
   updateCountryClickGestureDrag,
 } from '../src/components/map-interaction-guard.ts';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const deckGLMapSrc = readFileSync(join(root, 'src', 'components', 'DeckGLMap.ts'), 'utf-8');
 
 describe('map country drag/click guard', () => {
   it('keeps sub-threshold pointer jitter as an intentional country click', () => {
@@ -71,5 +77,26 @@ describe('map country drag/click guard', () => {
     assert.equal(tracker.pointerStart, null);
     assert.equal(tracker.dragged, false);
     assert.equal(shouldSuppressCountryClick(tracker, 26), true);
+  });
+
+  it('reattaches DeckGL country click handlers after MapLibre fallback recreation', () => {
+    const attachMatch = deckGLMapSrc.match(
+      /private attachMapLibreInteractionHandlers\(\): void \{[\s\S]*?^\s{2}\}/m,
+    );
+    assert.ok(attachMatch, 'DeckGLMap should centralize MapLibre interaction listener attachment');
+    assert.match(attachMatch[0], /addEventListener\('pointerdown', this\.handleCountryClickPointerDown\)/);
+    assert.match(attachMatch[0], /addEventListener\('pointermove', this\.handleCountryClickPointerMove\)/);
+    assert.match(attachMatch[0], /on\('dragstart', this\.markCountryDragGesture\)/);
+    assert.match(attachMatch[0], /on\('dragend', this\.refreshCountryDragSuppression\)/);
+
+    const fallbackMatch = deckGLMapSrc.match(
+      /const recreateWithFallback = \(\) => \{[\s\S]*?this\.maplibreMap\.on\('load', \(\) => \{[\s\S]*?^\s{6}\}\);/m,
+    );
+    assert.ok(fallbackMatch, 'DeckGLMap should keep a MapLibre fallback recreation path');
+    assert.match(
+      fallbackMatch[0],
+      /this\.attachMapLibreInteractionHandlers\(\);[\s\S]*localizeMapLabels\(this\.maplibreMap\);/,
+      'fallback load handler must reattach country click handlers before continuing map initialization',
+    );
   });
 });

--- a/tests/map-country-drag-click.test.mjs
+++ b/tests/map-country-drag-click.test.mjs
@@ -1,0 +1,51 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  COUNTRY_CLICK_DRAG_SUPPRESSION_MS,
+  COUNTRY_CLICK_DRAG_THRESHOLD_PX,
+  createCountryClickGestureTracker,
+  finishCountryClickGesture,
+  markCountryClickDrag,
+  shouldSuppressCountryClick,
+  startCountryClickGesture,
+  updateCountryClickGestureDrag,
+} from '../src/components/map-interaction-guard.ts';
+
+describe('map country drag/click guard', () => {
+  it('keeps sub-threshold pointer jitter as an intentional country click', () => {
+    const tracker = createCountryClickGestureTracker();
+    startCountryClickGesture(tracker, { x: 100, y: 100 });
+
+    assert.equal(
+      updateCountryClickGestureDrag(tracker, { x: 100 + COUNTRY_CLICK_DRAG_THRESHOLD_PX - 1, y: 100 }, 10),
+      false,
+    );
+
+    finishCountryClickGesture(tracker, 20);
+    assert.equal(shouldSuppressCountryClick(tracker, 21), false);
+  });
+
+  it('suppresses exactly one country click after a real drag gesture', () => {
+    const tracker = createCountryClickGestureTracker();
+    startCountryClickGesture(tracker, { x: 100, y: 100 });
+
+    assert.equal(
+      updateCountryClickGestureDrag(tracker, { x: 100 + COUNTRY_CLICK_DRAG_THRESHOLD_PX + 1, y: 100 }, 10),
+      true,
+    );
+    finishCountryClickGesture(tracker, 20);
+
+    assert.equal(shouldSuppressCountryClick(tracker, 21), true);
+    assert.equal(shouldSuppressCountryClick(tracker, 22), false);
+  });
+
+  it('does not suppress a later intentional country click after the drag window expires', () => {
+    const tracker = createCountryClickGestureTracker();
+    markCountryClickDrag(tracker, 100);
+
+    assert.equal(
+      shouldSuppressCountryClick(tracker, 100 + COUNTRY_CLICK_DRAG_SUPPRESSION_MS + 1),
+      false,
+    );
+  });
+});

--- a/tests/map-country-drag-click.test.mjs
+++ b/tests/map-country-drag-click.test.mjs
@@ -6,6 +6,7 @@ import {
   createCountryClickGestureTracker,
   finishCountryClickGesture,
   markCountryClickDrag,
+  refreshCountryClickDragSuppression,
   shouldSuppressCountryClick,
   startCountryClickGesture,
   updateCountryClickGestureDrag,
@@ -47,5 +48,28 @@ describe('map country drag/click guard', () => {
       shouldSuppressCountryClick(tracker, 100 + COUNTRY_CLICK_DRAG_SUPPRESSION_MS + 1),
       false,
     );
+  });
+
+  it('preserves suppression across a rapid gesture restart after a drag', () => {
+    const tracker = createCountryClickGestureTracker();
+    markCountryClickDrag(tracker, 100);
+
+    startCountryClickGesture(tracker, { x: 25, y: 25 });
+    finishCountryClickGesture(tracker, 110);
+
+    assert.equal(shouldSuppressCountryClick(tracker, 111), true);
+  });
+
+  it('refreshes dragend suppression without leaving stale dragged state', () => {
+    const tracker = createCountryClickGestureTracker();
+    startCountryClickGesture(tracker, { x: 100, y: 100 });
+    updateCountryClickGestureDrag(tracker, { x: 100 + COUNTRY_CLICK_DRAG_THRESHOLD_PX + 1, y: 100 }, 10);
+    finishCountryClickGesture(tracker, 20);
+
+    refreshCountryClickDragSuppression(tracker, 25);
+
+    assert.equal(tracker.pointerStart, null);
+    assert.equal(tracker.dragged, false);
+    assert.equal(shouldSuppressCountryClick(tracker, 26), true);
   });
 });


### PR DESCRIPTION
## Summary
- Reproduced the still-live drag-selection failure on clean `origin/main` even though the reporter later said the broader update was reversed: a map drag opened CountryDeepDive and added `country=ML` to the URL in the local Chromium/SVG fallback path.
- Add a shared country click gesture guard that treats movement over a small threshold as a drag and suppresses only the synthetic country click that follows it.
- Wire the guard into both the SVG map fallback and the DeckGL/MapLibre canvas path while preserving intentional click-to-country behavior.

Fixes #4237

## Intent
This stays scoped to the validated first-impression blocker: drag/pan gestures should not select countries. I did not change zoom range, border styling, map layers, data loading, or country panel behavior because I could not isolate those as current regressions on clean `origin/main`.

## Validation
- `TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/map-country-drag-click.test.mjs`
- `TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/deckgl-layer-state-aliasing.test.mjs tests/deckgl-interleaved-race-filter.test.mjs tests/route-drawing-layers.test.mjs tests/sector-route-explorer.test.mjs tests/url-sync-initial.test.mts`
- `TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/map-fullscreen-resize.test.mjs tests/map-locale.test.mts tests/map-layer-executable.test.mts`
- `npm run typecheck`
- `git diff --check`
- Pre-push hook on `git push -u origin HEAD`, including src/API typecheck, boundary checks, changed test files, edge function tests, and version sync.
- Clean baseline UI repro: origin/main at `7849101d3e370333a4e8e7a9d7c7f6d5a9e758b4` on port 5179; drag opened CountryDeepDive and URL had `country=ML`.
- Patched UI check: branch on port 5180; same drag left CountryDeepDive closed and URL had no `country`, then an intentional country click still opened a country.

## Residual Risk
- Firefox/Windows 11 validation is still manual-blocked locally because the Playwright Firefox executable is not installed in this environment. The generic interaction path was validated through local Playwright/Chromium.
- Headless Chromium used the SVG fallback renderer locally, so DeckGL/MapLibre coverage is via the shared guard, focused unit regression, typecheck, and source-affinity tests rather than a rendered Firefox/Windows DeckGL session.