### PR TITLE
feat(export): add country evidence bundles

### DIFF
--- a/docs/ai-intelligence.mdx
+++ b/docs/ai-intelligence.mdx
@@ -69,7 +69,7 @@ Clicking any country on the map opens a full-page intelligence dossier — a sin
 
 **Headline relevance filtering**: each country has an alias map (e.g., `US → ["united states", "american", "washington", "pentagon", "biden", "trump"]`). Headlines are filtered using a negative-match algorithm — if another country's alias appears earlier in the headline title than the target country's alias, the headline is excluded. This prevents cross-contamination (e.g., a headline about Venezuela mentioning "Washington sanctions" appearing in the US brief).
 
-**Export options**: briefs are exportable as JSON (structured data with all scores, signals, and headlines), CSV (flattened tabular format), or PNG image. A print button triggers the browser's native print dialog for PDF export.
+**Export options**: briefs are exportable as JSON (structured data with all scores, signals, and headlines), CSV (flattened tabular format), PNG image, or a portable evidence Markdown bundle with selected signals, cited source links when available, freshness notes, and provenance disclaimers. A print button triggers the browser's native print dialog for PDF export.
 
 ### Local-First Country Detection
 

--- a/docs/features.mdx
+++ b/docs/features.mdx
@@ -274,6 +274,7 @@ The full panel inventory lives in the app itself — Cmd+K surfaces what's avail
 ## Data Export
 
 - CSV and JSON export of current dashboard state
+- Country dossier evidence bundles as portable Markdown with source links and freshness notes where available
 - Historical playback from snapshots
 
 ---

--- a/src/components/CountryBriefPage.ts
+++ b/src/components/CountryBriefPage.ts
@@ -11,8 +11,8 @@ import type { CountryBriefPanel, CountryIntelData, StockIndexData } from '@/comp
 import { getNearbyInfrastructure, haversineDistanceKm } from '@/services/related-assets';
 import { PORTS } from '@/config/ports';
 import type { Port } from '@/types';
-import { exportCountryBriefJSON, exportCountryBriefCSV } from '@/utils/export';
-import type { CountryBriefExport } from '@/utils/export';
+import { exportCountryBriefJSON, exportCountryBriefCSV, exportCountryEvidenceMarkdown } from '@/utils/export';
+import type { CountryBriefExport, CountryEvidenceBundleInput } from '@/utils/export';
 import { ME_STRIKE_BOUNDS } from '@/services/country-geometry';
 import { toFlagEmoji } from '@/utils/country-flag';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
@@ -60,6 +60,8 @@ export class CountryBriefPage implements CountryBriefPanel {
   private currentScore: CountryScore | null = null;
   private currentSignals: CountryBriefSignals | null = null;
   private currentBrief: string | null = null;
+  private currentBriefGeneratedAt: string | null = null;
+  private currentBriefCached: boolean | null = null;
   private currentHeadlines: NewsItem[] = [];
   private onCloseCallback?: () => void;
   private onShareStory?: (code: string, name: string) => void;
@@ -133,7 +135,7 @@ export class CountryBriefPage implements CountryBriefPanel {
           }
         } else if (format === 'pdf') {
           this.exportPdf();
-        } else if (format === 'json' || format === 'csv') {
+        } else if (format === 'json' || format === 'csv' || format === 'evidence-md') {
           this.exportBrief(format);
         }
         const exportMenu = this.overlay.querySelector('.cb-export-menu');
@@ -375,6 +377,8 @@ export class CountryBriefPage implements CountryBriefPanel {
     this.currentScore = score;
     this.currentSignals = signals;
     this.currentBrief = null;
+    this.currentBriefGeneratedAt = null;
+    this.currentBriefCached = null;
     this.currentHeadlines = [];
     this.currentHeadlineCount = 0;
     const flag = this.countryFlag(code);
@@ -412,6 +416,7 @@ export class CountryBriefPage implements CountryBriefPanel {
                 <button class="cb-export-option" data-format="pdf">${t('common.exportPdf')}</button>
                 <button class="cb-export-option" data-format="json">${t('common.exportJson')}</button>
                 <button class="cb-export-option" data-format="csv">${t('common.exportCsv')}</button>
+                <button class="cb-export-option" data-format="evidence-md">Evidence Markdown</button>
               </div>
             </div>
             <button class="cb-close" aria-label="${t('components.newsPanel.close')}">×</button>
@@ -505,6 +510,8 @@ export class CountryBriefPage implements CountryBriefPanel {
     }
 
     this.currentBrief = data.brief;
+    this.currentBriefGeneratedAt = data.generatedAt ?? null;
+    this.currentBriefCached = data.cached === true;
     const formatted = this.formatBrief(data.brief, this.currentHeadlineCount);
     setTrustedHtml(section, trustedHtml(`
       <div class="cb-brief-text">${formatted}</div>
@@ -664,12 +671,15 @@ export class CountryBriefPage implements CountryBriefPanel {
     return formatIntelBrief(text, headlineCount > 0 ? { count: headlineCount, hrefPrefix: '#cb-news-' } : undefined);
   }
 
-  private exportBrief(format: 'json' | 'csv'): void {
+  private exportBrief(format: 'json' | 'csv' | 'evidence-md'): void {
     if (!this.currentCode || !this.currentName) return;
-    const data: CountryBriefExport = {
+    const exportedAt = new Date().toISOString();
+    const data: CountryBriefExport & CountryEvidenceBundleInput = {
       country: this.currentName,
       code: this.currentCode,
-      generatedAt: new Date().toISOString(),
+      context: 'Country dossier',
+      generatedAt: exportedAt,
+      exportedAt,
     };
     if (this.currentScore) {
       data.score = this.currentScore.score;
@@ -703,6 +713,8 @@ export class CountryBriefPage implements CountryBriefPanel {
       };
     }
     if (this.currentBrief) data.brief = this.currentBrief;
+    if (this.currentBriefGeneratedAt) data.briefGeneratedAt = this.currentBriefGeneratedAt;
+    if (this.currentBriefCached != null) data.briefCached = this.currentBriefCached;
     if (this.currentHeadlines.length > 0) {
       data.headlines = this.currentHeadlines.map(h => ({
         title: h.title,
@@ -711,7 +723,8 @@ export class CountryBriefPage implements CountryBriefPanel {
         pubDate: h.pubDate ? new Date(h.pubDate).toISOString() : undefined,
       }));
     }
-    if (format === 'json') exportCountryBriefJSON(data);
+    if (format === 'evidence-md') exportCountryEvidenceMarkdown(data);
+    else if (format === 'json') exportCountryBriefJSON(data);
     else exportCountryBriefCSV(data);
   }
 

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -44,6 +44,8 @@ import type { MapContainer } from './MapContainer';
 import { dedupeHeadlines } from './CountryDeepDivePanel-news-utils';
 import { renderFollowButton } from '@/utils/follow-button';
 import { renderNotifyCountryLink } from '@/utils/notify-country-link';
+import { exportCountryEvidenceMarkdown } from '@/utils/export';
+import type { CountryEvidenceBundleInput } from '@/utils/export';
 
 const DEPENDENCY_FLAG_LABELS: Record<string, { text: string; cls: string }> = {
   DEPENDENCY_FLAG_SINGLE_SOURCE_CRITICAL:   { text: 'Single Source',   cls: 'cdp-dep-critical' },
@@ -96,6 +98,12 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
   private closeButton: HTMLButtonElement;
   private currentCode: string | null = null;
   private currentName: string | null = null;
+  private currentScore: CountryScore | null = null;
+  private currentSignals: CountryBriefSignals | null = null;
+  private currentBrief: string | null = null;
+  private currentBriefGeneratedAt: string | null = null;
+  private currentBriefCached: boolean | null = null;
+  private currentHeadlines: NewsItem[] = [];
   private isMaximizedState = false;
   private onCloseCallback?: () => void;
   private onStateChangeCallback?: (state: { visible: boolean; maximized: boolean }) => void;
@@ -261,6 +269,13 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     this.abortController = new AbortController();
     this.currentCode = code;
     this.currentName = country;
+    this.currentScore = score;
+    this.currentSignals = signals;
+    this.currentBrief = null;
+    this.currentBriefGeneratedAt = null;
+    this.currentBriefCached = null;
+    this.currentHeadlines = [];
+    this.currentHeadlineCount = 0;
     this.economicIndicators = [];
     this.infrastructureByType.clear();
     this.renderSkeleton(country, code, score, signals);
@@ -280,6 +295,12 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     this.close();
     this.currentCode = null;
     this.currentName = null;
+    this.currentScore = null;
+    this.currentSignals = null;
+    this.currentBrief = null;
+    this.currentBriefGeneratedAt = null;
+    this.currentBriefCached = null;
+    this.currentHeadlines = [];
     this.onCloseCallback?.();
     this.onStateChangeCallback?.({ visible: false, maximized: false });
   }
@@ -337,6 +358,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
   public updateNews(headlines: NewsItem[]): void {
     if (!this.newsBody) return;
     this.newsBody.replaceChildren();
+    this.currentHeadlines = [];
 
     const compare = (a: NewsItem, b: NewsItem) => {
       const sa = SEVERITY_ORDER[this.toThreatLevel(a.threat?.level)];
@@ -352,6 +374,7 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
       .slice(0, 10);
 
     this.currentHeadlineCount = deduped.length;
+    this.currentHeadlines = deduped.map(({ item }) => item);
 
     if (deduped.length === 0) {
       this.newsBody.append(this.makeEmpty(t('countryBrief.noNews')));
@@ -2309,9 +2332,16 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     this.briefBody.replaceChildren();
 
     if (data.error || data.skipped || !data.brief) {
+      this.currentBrief = null;
+      this.currentBriefGeneratedAt = null;
+      this.currentBriefCached = null;
       this.briefBody.append(this.makeEmpty(data.error || data.reason || t('countryBrief.assessmentUnavailable')));
       return;
     }
+
+    this.currentBrief = data.brief;
+    this.currentBriefGeneratedAt = data.generatedAt ?? null;
+    this.currentBriefCached = data.cached === true;
 
     const summaryHtml = this.formatBrief(this.summarizeBrief(data.brief), 0);
     const text = this.el('div', 'cdp-assessment-text cdp-summary-only');
@@ -2424,7 +2454,13 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
         this.onExportImage(this.currentCode, this.currentName);
       }
     });
-    right.append(shareBtn, maxBtn, storyButton, exportButton);
+    const evidenceButton = this.el('button', 'cdp-action-btn cdp-evidence-export-btn', 'Evidence') as HTMLButtonElement;
+    evidenceButton.setAttribute('type', 'button');
+    evidenceButton.setAttribute('title', 'Export evidence bundle as Markdown');
+    evidenceButton.addEventListener('click', () => {
+      this.exportEvidenceBundle();
+    });
+    right.append(shareBtn, maxBtn, storyButton, exportButton, evidenceButton);
     header.append(left, right);
 
     const scoreCard = this.el('section', 'cdp-card cdp-score-card');
@@ -2916,6 +2952,67 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
 
   private formatBrief(text: string, headlineCount = 0): string {
     return formatIntelBrief(text, headlineCount > 0 ? { count: headlineCount, hrefPrefix: '#cdp-news-' } : undefined);
+  }
+
+  private exportEvidenceBundle(): void {
+    if (!this.currentCode || !this.currentName) return;
+    const exportedAt = new Date().toISOString();
+    const data: CountryEvidenceBundleInput = {
+      country: this.currentName,
+      code: this.currentCode,
+      context: 'Country dossier',
+      generatedAt: exportedAt,
+      exportedAt,
+    };
+
+    if (this.currentScore) {
+      data.score = this.currentScore.score;
+      data.level = this.currentScore.level;
+      data.trend = this.currentScore.trend;
+      data.components = this.currentScore.components;
+    }
+    if (this.currentSignals) {
+      data.signals = {
+        criticalNews: this.currentSignals.criticalNews,
+        protests: this.currentSignals.protests,
+        militaryFlights: this.currentSignals.militaryFlights,
+        militaryVessels: this.currentSignals.militaryVessels,
+        militaryFlightsInCountry: this.currentSignals.militaryFlightsInCountry,
+        militaryVesselsInCountry: this.currentSignals.militaryVesselsInCountry,
+        outages: this.currentSignals.outages,
+        aisDisruptions: this.currentSignals.aisDisruptions,
+        satelliteFires: this.currentSignals.satelliteFires,
+        radiationAnomalies: this.currentSignals.radiationAnomalies,
+        temporalAnomalies: this.currentSignals.temporalAnomalies,
+        cyberThreats: this.currentSignals.cyberThreats,
+        earthquakes: this.currentSignals.earthquakes,
+        displacementOutflow: this.currentSignals.displacementOutflow,
+        climateStress: this.currentSignals.climateStress,
+        conflictEvents: this.currentSignals.conflictEvents,
+        activeStrikes: this.currentSignals.activeStrikes,
+        orefSirens: this.currentSignals.orefSirens,
+        orefHistory24h: this.currentSignals.orefHistory24h,
+        aviationDisruptions: this.currentSignals.aviationDisruptions,
+        travelAdvisories: this.currentSignals.travelAdvisories,
+        travelAdvisoryMaxLevel: this.currentSignals.travelAdvisoryMaxLevel,
+        gpsJammingHexes: this.currentSignals.gpsJammingHexes,
+        thermalEscalations: this.currentSignals.thermalEscalations,
+        sanctionsDesignations: this.currentSignals.sanctionsDesignations,
+        sanctionsNewDesignations: this.currentSignals.sanctionsNewDesignations,
+      };
+    }
+    if (this.currentBrief) data.brief = this.currentBrief;
+    if (this.currentBriefGeneratedAt) data.briefGeneratedAt = this.currentBriefGeneratedAt;
+    if (this.currentBriefCached != null) data.briefCached = this.currentBriefCached;
+    if (this.currentHeadlines.length > 0) {
+      data.headlines = this.currentHeadlines.map((headline) => ({
+        title: headline.title,
+        source: headline.source,
+        link: headline.link,
+        pubDate: headline.pubDate ? new Date(headline.pubDate).toISOString() : undefined,
+      }));
+    }
+    exportCountryEvidenceMarkdown(data);
   }
 
   private summarizeBrief(brief: string): string {

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -291,6 +291,316 @@ export interface CountryBriefExport {
   generatedAt: string;
 }
 
+export interface CountryEvidenceSourceInput {
+  title?: string | null;
+  source?: string | null;
+  link?: string | null;
+  pubDate?: string | Date | null;
+}
+
+export interface CountryEvidenceBundleInput {
+  country: string;
+  code: string;
+  context?: string;
+  score?: number;
+  level?: string;
+  trend?: string;
+  components?: CountryBriefExport['components'];
+  signals?: Record<string, unknown>;
+  brief?: string;
+  headlines?: CountryEvidenceSourceInput[];
+  generatedAt?: string;
+  exportedAt?: string;
+  briefGeneratedAt?: string;
+  briefCached?: boolean;
+}
+
+export interface CountryEvidenceSignal {
+  label: string;
+  value: string;
+}
+
+export interface CountryEvidenceSource {
+  title: string;
+  publisher?: string;
+  url?: string;
+  publishedAt?: string;
+  freshness: string;
+  note?: string;
+}
+
+export interface CountryEvidenceBundle {
+  country: string;
+  code: string;
+  context: string;
+  exportedAt: string;
+  generatedAt?: string;
+  briefGeneratedAt?: string;
+  briefCacheStatus?: 'cached' | 'fresh';
+  score?: number;
+  level?: string;
+  trend?: string;
+  components?: CountryBriefExport['components'];
+  signals: CountryEvidenceSignal[];
+  brief?: string;
+  sources: CountryEvidenceSource[];
+  freshnessNotes: string[];
+  provenanceDisclaimer: string;
+}
+
+export const COUNTRY_EVIDENCE_PROVENANCE_DISCLAIMER =
+  'This WorldMonitor evidence bundle packages user-visible context and source metadata for analyst handoff. It is not a legal evidentiary record; verify source availability, timestamps, and claims before reuse.';
+
+const SIGNAL_LABELS: Record<string, string> = {
+  criticalNews: 'Critical news',
+  protests: 'Protests',
+  militaryFlights: 'Military flights nearby',
+  militaryVessels: 'Military vessels nearby',
+  militaryFlightsInCountry: 'Military flights inside borders',
+  militaryVesselsInCountry: 'Military vessels inside borders',
+  outages: 'Internet outages',
+  aisDisruptions: 'AIS disruptions',
+  satelliteFires: 'Satellite fires',
+  radiationAnomalies: 'Radiation anomalies',
+  temporalAnomalies: 'Temporal anomalies',
+  cyberThreats: 'Cyber threats',
+  earthquakes: 'Earthquakes',
+  displacementOutflow: 'Displacement outflow',
+  climateStress: 'Climate stress',
+  conflictEvents: 'Conflict events',
+  activeStrikes: 'Active strikes',
+  orefSirens: 'Active OREF sirens',
+  orefHistory24h: 'OREF sirens in 24h',
+  aviationDisruptions: 'Aviation disruptions',
+  travelAdvisories: 'Travel advisories',
+  travelAdvisoryMaxLevel: 'Maximum travel advisory',
+  gpsJammingHexes: 'GPS jamming zones',
+  thermalEscalations: 'Thermal escalations',
+  sanctionsDesignations: 'Sanctions designations',
+  sanctionsNewDesignations: 'New sanctions designations',
+};
+
+const SECRET_ASSIGNMENT_RE = /\b(api[_-]?key|token|secret|password|authorization|cookie|session)\b\s*[:=]\s*["']?[^"'\s,;]{6,}["']?/gi;
+const BEARER_RE = /\bBearer\s+[A-Za-z0-9._~+/=-]{12,}/g;
+const COMMON_SECRET_RE = /\b(?:sk|wm|ghp|github_pat)_[A-Za-z0-9_=-]{12,}\b/g;
+const EMAIL_RE = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const USER_ID_RE = /\buser_[A-Za-z0-9_-]{6,}\b/g;
+
+function sanitizeEvidenceText(value: unknown): string {
+  return String(value ?? '')
+    .replace(SECRET_ASSIGNMENT_RE, (_match, key) => `${key}=[redacted-secret]`)
+    .replace(BEARER_RE, 'Bearer [redacted-secret]')
+    .replace(COMMON_SECRET_RE, '[redacted-secret]')
+    .replace(EMAIL_RE, '[redacted-email]')
+    .replace(USER_ID_RE, '[redacted-user-id]')
+    .trim();
+}
+
+function normalizeEvidenceUrl(value: unknown): string | undefined {
+  const raw = String(value ?? '').trim();
+  if (!raw) return undefined;
+  try {
+    const parsed = new URL(raw);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return undefined;
+    return parsed.toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeIsoTimestamp(value: unknown): string | undefined {
+  if (!value) return undefined;
+  const date = value instanceof Date ? value : new Date(String(value));
+  const time = date.getTime();
+  return Number.isFinite(time) ? date.toISOString() : undefined;
+}
+
+function signalLabel(key: string): string {
+  return SIGNAL_LABELS[key] ?? key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b\w/g, (char) => char.toUpperCase());
+}
+
+function buildEvidenceSignals(signals: Record<string, unknown> | undefined): CountryEvidenceSignal[] {
+  if (!signals) return [];
+  return Object.entries(signals)
+    .filter(([, value]) => {
+      if (typeof value === 'number') return value > 0;
+      if (typeof value === 'string') return value.trim().length > 0;
+      return value != null && value !== false;
+    })
+    .map(([key, value]) => ({
+      label: signalLabel(key),
+      value: sanitizeEvidenceText(value),
+    }));
+}
+
+function freshnessForSource(publishedAt: string | undefined, exportedAt: string): string {
+  if (!publishedAt) return 'Published timestamp unavailable; freshness could not be computed.';
+  const published = new Date(publishedAt).getTime();
+  const exported = new Date(exportedAt).getTime();
+  if (!Number.isFinite(published) || !Number.isFinite(exported)) {
+    return 'Published timestamp unavailable; freshness could not be computed.';
+  }
+  const ageMs = Math.max(0, exported - published);
+  const ageHours = Math.floor(ageMs / 3_600_000);
+  if (ageHours < 48) return `${ageHours}h old at export.`;
+  return `${Math.floor(ageHours / 24)}d old at export.`;
+}
+
+function buildEvidenceSources(
+  headlines: CountryEvidenceSourceInput[] | undefined,
+  exportedAt: string,
+): CountryEvidenceSource[] {
+  return (headlines ?? [])
+    .map((headline, index) => {
+      const title = sanitizeEvidenceText(headline.title) || `Source ${index + 1} (title unavailable)`;
+      const publisher = sanitizeEvidenceText(headline.source) || undefined;
+      const url = normalizeEvidenceUrl(headline.link);
+      const publishedAt = normalizeIsoTimestamp(headline.pubDate);
+      const hadUnsafeOrMissingUrl = Boolean(headline.link) && !url;
+      return {
+        title,
+        publisher,
+        url,
+        publishedAt,
+        freshness: freshnessForSource(publishedAt, exportedAt),
+        note: url
+          ? undefined
+          : hadUnsafeOrMissingUrl
+            ? 'URL omitted because it was missing or unsafe.'
+            : 'URL unavailable; citation link was not provided.',
+      };
+    })
+    .filter((source) => source.title || source.publisher || source.url || source.publishedAt);
+}
+
+function buildFreshnessNotes(input: CountryEvidenceBundleInput, exportedAt: string): string[] {
+  const notes: string[] = [`Exported at ${exportedAt}.`];
+  const briefGeneratedAt = normalizeIsoTimestamp(input.briefGeneratedAt ?? input.generatedAt);
+  if (briefGeneratedAt) {
+    notes.push(`Brief generated at ${briefGeneratedAt}${input.briefCached === true ? ' from cache' : ''}.`);
+  } else {
+    notes.push('Brief generation timestamp unavailable.');
+  }
+  if (!input.headlines || input.headlines.length === 0) {
+    notes.push('No headline source list was available for this export.');
+  }
+  return notes;
+}
+
+function markdownListValue(value: string | number | undefined): string {
+  const clean = sanitizeEvidenceText(value);
+  return clean || 'Unavailable';
+}
+
+function escapeMarkdownLinkText(value: string): string {
+  return value.replace(/[[\]\\]/g, '\\$&');
+}
+
+export function buildCountryEvidenceBundle(input: CountryEvidenceBundleInput): CountryEvidenceBundle {
+  const exportedAt = normalizeIsoTimestamp(input.exportedAt) ?? new Date().toISOString();
+  const generatedAt = normalizeIsoTimestamp(input.generatedAt);
+  const briefGeneratedAt = normalizeIsoTimestamp(input.briefGeneratedAt ?? input.generatedAt);
+  const brief = sanitizeEvidenceText(input.brief);
+  return {
+    country: sanitizeEvidenceText(input.country),
+    code: sanitizeEvidenceText(input.code).toUpperCase(),
+    context: sanitizeEvidenceText(input.context) || 'Country dossier',
+    exportedAt,
+    generatedAt,
+    briefGeneratedAt,
+    briefCacheStatus: input.briefCached === true ? 'cached' : input.briefCached === false ? 'fresh' : undefined,
+    score: input.score,
+    level: sanitizeEvidenceText(input.level) || undefined,
+    trend: sanitizeEvidenceText(input.trend) || undefined,
+    components: input.components,
+    signals: buildEvidenceSignals(input.signals),
+    brief: brief || undefined,
+    sources: buildEvidenceSources(input.headlines, exportedAt),
+    freshnessNotes: buildFreshnessNotes(input, exportedAt),
+    provenanceDisclaimer: COUNTRY_EVIDENCE_PROVENANCE_DISCLAIMER,
+  };
+}
+
+export function renderCountryEvidenceMarkdown(bundle: CountryEvidenceBundle): string {
+  const lines: string[] = [];
+  lines.push(`# WorldMonitor Evidence Bundle: ${bundle.country} (${bundle.code})`);
+  lines.push('');
+  lines.push(`- Context: ${markdownListValue(bundle.context)}`);
+  lines.push(`- Exported at: ${markdownListValue(bundle.exportedAt)}`);
+  if (bundle.generatedAt) lines.push(`- Bundle generated at: ${markdownListValue(bundle.generatedAt)}`);
+  if (bundle.briefGeneratedAt) {
+    const cacheSuffix = bundle.briefCacheStatus ? ` (${bundle.briefCacheStatus})` : '';
+    lines.push(`- Brief generated at: ${markdownListValue(bundle.briefGeneratedAt)}${cacheSuffix}`);
+  }
+  lines.push('');
+
+  lines.push('## Risk Context');
+  if (bundle.score != null) {
+    lines.push(`- Instability score: ${bundle.score}/100`);
+    lines.push(`- Level: ${markdownListValue(bundle.level)}`);
+    lines.push(`- Trend: ${markdownListValue(bundle.trend)}`);
+  } else {
+    lines.push('- Instability score: unavailable in this dossier.');
+  }
+  if (bundle.components) {
+    lines.push(`- Components: unrest ${bundle.components.unrest}, conflict ${bundle.components.conflict}, security ${bundle.components.security}, information ${bundle.components.information}`);
+  }
+  lines.push('');
+
+  lines.push('## Selected Signals');
+  if (bundle.signals.length > 0) {
+    bundle.signals.forEach((signal) => {
+      lines.push(`- ${signal.label}: ${signal.value}`);
+    });
+  } else {
+    lines.push('- No active signal counts were available in this dossier.');
+  }
+  lines.push('');
+
+  if (bundle.brief) {
+    lines.push('## Intelligence Brief');
+    lines.push(bundle.brief);
+    lines.push('');
+  }
+
+  lines.push('## Sources');
+  if (bundle.sources.length > 0) {
+    bundle.sources.forEach((source, index) => {
+      const label = `${index + 1}. ${source.url ? `[${escapeMarkdownLinkText(source.title)}](${source.url})` : source.title}`;
+      lines.push(label);
+      lines.push(`   - Publisher: ${markdownListValue(source.publisher)}`);
+      lines.push(`   - Published at: ${markdownListValue(source.publishedAt)}`);
+      lines.push(`   - Freshness: ${source.freshness}`);
+      if (source.note) lines.push(`   - Note: ${source.note}`);
+    });
+  } else {
+    lines.push('- No source links were available for this export.');
+  }
+  lines.push('');
+
+  lines.push('## Freshness Notes');
+  bundle.freshnessNotes.forEach((note) => lines.push(`- ${note}`));
+  lines.push('');
+
+  lines.push('## Provenance Disclaimer');
+  lines.push(bundle.provenanceDisclaimer);
+  lines.push('');
+  return lines.join('\n');
+}
+
+export function exportCountryEvidenceMarkdown(data: CountryEvidenceBundleInput): void {
+  const bundle = buildCountryEvidenceBundle(data);
+  const timestamp = bundle.exportedAt.replace(/[:.]/g, '-');
+  downloadFile(
+    renderCountryEvidenceMarkdown(bundle),
+    `country-evidence-${bundle.code}-${timestamp}.md`,
+    'text/markdown;charset=utf-8',
+  );
+}
+
 export function exportCountryBriefJSON(data: CountryBriefExport): void {
   const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
   downloadFile(JSON.stringify(data, null, 2), `country-brief-${data.code}-${timestamp}.json`, 'application/json');

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -402,7 +402,7 @@ function normalizeEvidenceUrl(value: unknown): string | undefined {
   try {
     const parsed = new URL(raw);
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return undefined;
-    return parsed.toString();
+    return parsed.toString().replace(/[()]/g, (char) => char === '(' ? '%28' : '%29');
   } catch {
     return undefined;
   }
@@ -454,6 +454,12 @@ function buildEvidenceSources(
   exportedAt: string,
 ): CountryEvidenceSource[] {
   return (headlines ?? [])
+    .filter((headline) => Boolean(
+      sanitizeEvidenceText(headline.title)
+      || sanitizeEvidenceText(headline.source)
+      || normalizeEvidenceUrl(headline.link)
+      || normalizeIsoTimestamp(headline.pubDate),
+    ))
     .map((headline, index) => {
       const title = sanitizeEvidenceText(headline.title) || `Source ${index + 1} (title unavailable)`;
       const publisher = sanitizeEvidenceText(headline.source) || undefined;
@@ -472,8 +478,7 @@ function buildEvidenceSources(
             ? 'URL omitted because it was missing or unsafe.'
             : 'URL unavailable; citation link was not provided.',
       };
-    })
-    .filter((source) => source.title || source.publisher || source.url || source.publishedAt);
+    });
 }
 
 function buildFreshnessNotes(input: CountryEvidenceBundleInput, exportedAt: string): string[] {
@@ -497,6 +502,10 @@ function markdownListValue(value: string | number | undefined): string {
 
 function escapeMarkdownLinkText(value: string): string {
   return value.replace(/[[\]\\]/g, '\\$&');
+}
+
+function renderQuotedEvidenceBlock(value: string): string[] {
+  return value.split(/\r?\n/).map((line) => `> ${line}`);
 }
 
 export function buildCountryEvidenceBundle(input: CountryEvidenceBundleInput): CountryEvidenceBundle {
@@ -562,7 +571,8 @@ export function renderCountryEvidenceMarkdown(bundle: CountryEvidenceBundle): st
 
   if (bundle.brief) {
     lines.push('## Intelligence Brief');
-    lines.push(bundle.brief);
+    lines.push('');
+    lines.push(...renderQuotedEvidenceBlock(bundle.brief));
     lines.push('');
   }
 

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -380,17 +380,23 @@ const SIGNAL_LABELS: Record<string, string> = {
   sanctionsNewDesignations: 'New sanctions designations',
 };
 
-const SECRET_ASSIGNMENT_RE = /\b(api[_-]?key|token|secret|password|authorization|cookie|session)\b\s*[:=]\s*["']?[^"'\s,;]{6,}["']?/gi;
+const SECRET_ASSIGNMENT_RE = /\b((?:[a-z0-9]+[_-])*(?:api[_-]?key|access[_-]?key(?:[_-]?id)?|secret(?:[_-]?access[_-]?key)?|client[_-]?secret|token|password|authorization|cookie|session))\b\s*[:=]\s*["']?[^"'\s,;]{6,}["']?/gi;
 const BEARER_RE = /\bBearer\s+[A-Za-z0-9._~+/=-]{12,}/g;
-const COMMON_SECRET_RE = /\b(?:sk|wm|ghp|github_pat)_[A-Za-z0-9_=-]{12,}\b/g;
+const AWS_ACCESS_KEY_ID_RE = /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g;
+const AWS_SECRET_ACCESS_KEY_RE = /\b(?=[A-Za-z0-9/+=]{40}\b)(?=[A-Za-z0-9/+=]{0,39}[A-Z])(?=[A-Za-z0-9/+=]{0,39}[a-z])(?=[A-Za-z0-9/+=]{0,39}\d)[A-Za-z0-9/+=]{40}\b/g;
+const COMMON_SECRET_RE = /\b(?:sk[-_][A-Za-z0-9_-]{12,}|wm_[A-Za-z0-9_=-]{12,}|ghp_[A-Za-z0-9_=-]{12,}|github_pat_[A-Za-z0-9_=-]{12,}|AIza[A-Za-z0-9_-]{20,}|xox[abprsc]-[A-Za-z0-9-]{10,})\b/g;
+const JWT_RE = /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g;
 const EMAIL_RE = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
 const USER_ID_RE = /\buser_[A-Za-z0-9_-]{6,}\b/g;
 
 function sanitizeEvidenceText(value: unknown): string {
   return String(value ?? '')
-    .replace(SECRET_ASSIGNMENT_RE, (_match, key) => `${key}=[redacted-secret]`)
     .replace(BEARER_RE, 'Bearer [redacted-secret]')
+    .replace(SECRET_ASSIGNMENT_RE, (_match, key) => `${key}=[redacted-secret]`)
+    .replace(AWS_ACCESS_KEY_ID_RE, '[redacted-secret]')
+    .replace(AWS_SECRET_ACCESS_KEY_RE, '[redacted-secret]')
     .replace(COMMON_SECRET_RE, '[redacted-secret]')
+    .replace(JWT_RE, '[redacted-secret]')
     .replace(EMAIL_RE, '[redacted-email]')
     .replace(USER_ID_RE, '[redacted-user-id]')
     .trim();
@@ -504,6 +510,12 @@ function escapeMarkdownLinkText(value: string): string {
   return value.replace(/[[\]\\]/g, '\\$&');
 }
 
+function escapeMarkdownInline(value: string): string {
+  return sanitizeEvidenceText(value)
+    .replace(/\s+/g, ' ')
+    .replace(/([\\`*_{}\[\]()#+\-.!|<>])/g, '\\$1');
+}
+
 function renderQuotedEvidenceBlock(value: string): string[] {
   return value.split(/\r?\n/).map((line) => `> ${line}`);
 }
@@ -579,9 +591,12 @@ export function renderCountryEvidenceMarkdown(bundle: CountryEvidenceBundle): st
   lines.push('## Sources');
   if (bundle.sources.length > 0) {
     bundle.sources.forEach((source, index) => {
-      const label = `${index + 1}. ${source.url ? `[${escapeMarkdownLinkText(source.title)}](${source.url})` : source.title}`;
+      const title = source.url
+        ? `[${escapeMarkdownLinkText(source.title)}](${source.url})`
+        : escapeMarkdownInline(source.title);
+      const label = `${index + 1}. ${title}`;
       lines.push(label);
-      lines.push(`   - Publisher: ${markdownListValue(source.publisher)}`);
+      lines.push(`   - Publisher: ${escapeMarkdownInline(markdownListValue(source.publisher))}`);
       lines.push(`   - Published at: ${markdownListValue(source.publishedAt)}`);
       lines.push(`   - Freshness: ${source.freshness}`);
       if (source.note) lines.push(`   - Note: ${source.note}`);

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -388,6 +388,7 @@ const COMMON_SECRET_RE = /\b(?:sk[-_][A-Za-z0-9_-]{12,}|wm_[A-Za-z0-9_=-]{12,}|g
 const JWT_RE = /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g;
 const EMAIL_RE = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
 const USER_ID_RE = /\buser_[A-Za-z0-9_-]{6,}\b/g;
+const SECRET_URL_PARAM_NAME_RE = /(?:^|[_\-.])(?:api[_\-.]?key|access[_\-.]?key(?:[_\-.]?id)?|awsaccess[_\-.]?key(?:[_\-.]?id)?|secret(?:[_\-.]?access[_\-.]?key)?|client[_\-.]?secret|token|id[_\-.]?token|auth(?:orization)?|password|passwd|pwd|cookie|session|jwt|signature|sig|credential|key)(?:$|[_\-.])/i;
 
 function sanitizeEvidenceText(value: unknown): string {
   return String(value ?? '')
@@ -402,12 +403,43 @@ function sanitizeEvidenceText(value: unknown): string {
     .trim();
 }
 
+function isSensitiveUrlParamName(name: string): boolean {
+  const normalized = name
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toLowerCase();
+  return SECRET_URL_PARAM_NAME_RE.test(normalized);
+}
+
+function sanitizeEvidenceUrlSearchParams(parsed: URL): void {
+  if (!parsed.search) return;
+  const sanitized = new URLSearchParams();
+  let changed = false;
+  parsed.searchParams.forEach((value, key) => {
+    const sensitiveKey = isSensitiveUrlParamName(key);
+    const sanitizedValue = sensitiveKey ? '[redacted-secret]' : sanitizeEvidenceText(value);
+    if (sensitiveKey || sanitizedValue !== value) changed = true;
+    sanitized.append(key, sanitizedValue);
+  });
+  if (changed) parsed.search = sanitized.toString() ? `?${sanitized.toString()}` : '';
+}
+
+function sanitizeEvidenceUrlFragment(parsed: URL): void {
+  if (!parsed.hash) return;
+  const fragment = parsed.hash.slice(1);
+  const sanitized = sanitizeEvidenceText(fragment);
+  if (sanitized !== fragment) parsed.hash = sanitized;
+}
+
 function normalizeEvidenceUrl(value: unknown): string | undefined {
   const raw = String(value ?? '').trim();
   if (!raw) return undefined;
   try {
     const parsed = new URL(raw);
     if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return undefined;
+    if (parsed.username) parsed.username = '[redacted-user-id]';
+    if (parsed.password) parsed.password = '[redacted-secret]';
+    sanitizeEvidenceUrlSearchParams(parsed);
+    sanitizeEvidenceUrlFragment(parsed);
     return parsed.toString().replace(/[()]/g, (char) => char === '(' ? '%28' : '%29');
   } catch {
     return undefined;

--- a/src/utils/export.ts
+++ b/src/utils/export.ts
@@ -380,7 +380,7 @@ const SIGNAL_LABELS: Record<string, string> = {
   sanctionsNewDesignations: 'New sanctions designations',
 };
 
-const SECRET_ASSIGNMENT_RE = /\b((?:[a-z0-9]+[_-])*(?:api[_-]?key|access[_-]?key(?:[_-]?id)?|secret(?:[_-]?access[_-]?key)?|client[_-]?secret|token|password|authorization|cookie|session))\b\s*[:=]\s*["']?[^"'\s,;]{6,}["']?/gi;
+const SECRET_ASSIGNMENT_RE = /\b((?:[a-z0-9]+[_-])*(?:api[_-]?key|access[_-]?key(?:[_-]?id)?|secret(?:[_-]?access[_-]?key)?|client[_-]?secret|token|password|authorization|cookie|session))\b(\s*)([:=])(\s*)(["']?)([^"'\s,;]{6,})(["']?)/gi;
 const BEARER_RE = /\bBearer\s+[A-Za-z0-9._~+/=-]{12,}/g;
 const AWS_ACCESS_KEY_ID_RE = /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g;
 const AWS_SECRET_ACCESS_KEY_RE = /\b(?=[A-Za-z0-9/+=]{40}\b)(?=[A-Za-z0-9/+=]{0,39}[A-Z])(?=[A-Za-z0-9/+=]{0,39}[a-z])(?=[A-Za-z0-9/+=]{0,39}\d)[A-Za-z0-9/+=]{40}\b/g;
@@ -390,10 +390,41 @@ const EMAIL_RE = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
 const USER_ID_RE = /\buser_[A-Za-z0-9_-]{6,}\b/g;
 const SECRET_URL_PARAM_NAME_RE = /(?:^|[_\-.])(?:api[_\-.]?key|access[_\-.]?key(?:[_\-.]?id)?|awsaccess[_\-.]?key(?:[_\-.]?id)?|secret(?:[_\-.]?access[_\-.]?key)?|client[_\-.]?secret|token|id[_\-.]?token|auth(?:orization)?|password|passwd|pwd|cookie|session|jwt|signature|sig|credential|key)(?:$|[_\-.])/i;
 
+function regexMatches(pattern: RegExp, value: string): boolean {
+  pattern.lastIndex = 0;
+  const matches = pattern.test(value);
+  pattern.lastIndex = 0;
+  return matches;
+}
+
+function isSecretishAssignmentValue(value: string): boolean {
+  const clean = value.trim();
+  if (
+    regexMatches(AWS_ACCESS_KEY_ID_RE, clean)
+    || regexMatches(AWS_SECRET_ACCESS_KEY_RE, clean)
+    || regexMatches(COMMON_SECRET_RE, clean)
+    || regexMatches(JWT_RE, clean)
+  ) {
+    return true;
+  }
+
+  if (clean.length < 16 || !/[A-Za-z]/.test(clean) || !/\d/.test(clean)) return false;
+  const classes = [
+    /[a-z]/.test(clean),
+    /[A-Z]/.test(clean),
+    /\d/.test(clean),
+    /[-_=+/]/.test(clean),
+  ].filter(Boolean).length;
+  return classes >= 3 || clean.length >= 24;
+}
+
 function sanitizeEvidenceText(value: unknown): string {
   return String(value ?? '')
     .replace(BEARER_RE, 'Bearer [redacted-secret]')
-    .replace(SECRET_ASSIGNMENT_RE, (_match, key) => `${key}=[redacted-secret]`)
+    .replace(SECRET_ASSIGNMENT_RE, (match, key, beforeOperator, operator, afterOperator, openingQuote, secretValue, closingQuote) => {
+      if (operator === ':' && !isSecretishAssignmentValue(secretValue)) return match;
+      return `${key}${beforeOperator}${operator}${afterOperator}${openingQuote}[redacted-secret]${closingQuote}`;
+    })
     .replace(AWS_ACCESS_KEY_ID_RE, '[redacted-secret]')
     .replace(AWS_SECRET_ACCESS_KEY_RE, '[redacted-secret]')
     .replace(COMMON_SECRET_RE, '[redacted-secret]')

--- a/tests/country-evidence-bundle-export.test.mts
+++ b/tests/country-evidence-bundle-export.test.mts
@@ -127,15 +127,31 @@ describe('country evidence bundle export', () => {
 
   it('redacts secret-like values and private identifiers from rendered evidence', async () => {
     const { buildCountryEvidenceBundle, renderCountryEvidenceMarkdown } = await loadExportUtils();
+    const legacyOpenAiKey = ['sk', 'live', 'abc1234567890'].join('_');
+    const awsAccessKey = ['AK', 'IA', 'IOSFODNN7EXAMPLE'].join('');
+    const awsSecret = ['wJalrXUtnFEMI', '/K7MDENG+bPxRfiCY', 'EXAMPLEKEY'].join('');
+    const slackToken = ['xox', 'b-redacted-fixture-token'].join('');
+    const googleKey = ['AI', 'za', 'SyA1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p'].join('');
+    const openAiProjectKey = ['sk', 'proj', 'abc1234567890abcdefABCDEF', 'xyz1234567890'].join('-');
+    const jwt = [
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+      'eyJzdWIiOiIxMjM0NTY3ODkwIn0',
+      'SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+    ].join('.');
 
     const bundle = buildCountryEvidenceBundle({
       country: 'Testland',
       code: 'TL',
       exportedAt: '2026-06-10T12:00:00.000Z',
-      brief: 'Contact analyst@example.com with token=sk_live_abc1234567890 and user_abcdef123456.',
+      brief: [
+        `Contact analyst@example.com with token=${legacyOpenAiKey} and user_abcdef123456.`,
+        `AWS ${awsAccessKey} aws_secret_access_key=${awsSecret}`,
+        `Slack ${slackToken} Google ${googleKey} OpenAI ${openAiProjectKey}`,
+        `Authorization: Bearer ${jwt}`,
+      ].join('\n'),
       headlines: [{
         title: 'Report includes wm_0123456789abcdef0123456789abcdef01234567',
-        source: 'Desk user_abc12345',
+        source: `Desk user_abc12345 ${slackToken}`,
         link: 'https://example.com/private',
         pubDate: '2026-06-10T11:00:00.000Z',
       }],
@@ -143,12 +159,38 @@ describe('country evidence bundle export', () => {
     const markdown = renderCountryEvidenceMarkdown(bundle);
 
     assert.doesNotMatch(markdown, /analyst@example\.com/);
-    assert.doesNotMatch(markdown, /sk_live_abc1234567890/);
+    assert.doesNotMatch(markdown, new RegExp(legacyOpenAiKey));
     assert.doesNotMatch(markdown, /wm_0123456789abcdef0123456789abcdef01234567/);
     assert.doesNotMatch(markdown, /user_abcdef123456/);
+    assert.doesNotMatch(markdown, new RegExp(awsAccessKey));
+    assert.doesNotMatch(markdown, new RegExp(awsSecret.replace(/[+/]/g, '\\$&')));
+    assert.doesNotMatch(markdown, new RegExp(slackToken));
+    assert.doesNotMatch(markdown, new RegExp(googleKey));
+    assert.doesNotMatch(markdown, new RegExp(openAiProjectKey));
+    assert.doesNotMatch(markdown, /eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9/);
     assert.match(markdown, /\[redacted-email\]/);
     assert.match(markdown, /\[redacted-secret\]/);
     assert.match(markdown, /\[redacted-user-id\]/);
+  });
+
+  it('escapes unlinked source titles and publisher markdown inline text', async () => {
+    const { buildCountryEvidenceBundle, renderCountryEvidenceMarkdown } = await loadExportUtils();
+
+    const markdown = renderCountryEvidenceMarkdown(buildCountryEvidenceBundle({
+      country: 'Linkland',
+      code: 'LL',
+      exportedAt: '2026-06-10T12:00:00.000Z',
+      headlines: [{
+        title: 'Unlinked ](http://evil.com) title',
+        source: 'Publisher [spoof](http://evil.com)',
+        link: '',
+        pubDate: '2026-06-10T11:00:00.000Z',
+      }],
+    }));
+
+    assert.doesNotMatch(markdown, /\]\(http:\/\/evil\.com\)/);
+    assert.match(markdown, /Unlinked \\\]\\\(http:\/\/evil\\\.com\\\) title/);
+    assert.match(markdown, /Publisher: Publisher \\\[spoof\\\]\\\(http:\/\/evil\\\.com\\\)/);
   });
 
   it('renders Markdown with the expected handoff sections', async () => {

--- a/tests/country-evidence-bundle-export.test.mts
+++ b/tests/country-evidence-bundle-export.test.mts
@@ -171,6 +171,7 @@ describe('country evidence bundle export', () => {
     const slackToken = ['xox', 'b-redacted-fixture-token'].join('');
     const googleKey = ['AI', 'za', 'SyA1b2C3d4E5f6G7h8I9j0K1l2M3n4O5p'].join('');
     const openAiProjectKey = ['sk', 'proj', 'abc1234567890abcdefABCDEF', 'xyz1234567890'].join('-');
+    const colonOpenAiKey = ['sk', 'proj', 'colonredactionfixture1234567890', 'abcdef123456'].join('-');
     const jwt = [
       'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
       'eyJzdWIiOiIxMjM0NTY3ODkwIn0',
@@ -182,6 +183,8 @@ describe('country evidence bundle export', () => {
       code: 'TL',
       exportedAt: '2026-06-10T12:00:00.000Z',
       brief: [
+        'The session: closed-door talks remain underway.',
+        `api_key: ${colonOpenAiKey}`,
         `Contact analyst@example.com with token=${legacyOpenAiKey} and user_abcdef123456.`,
         `AWS ${awsAccessKey} aws_secret_access_key=${awsSecret}`,
         `Slack ${slackToken} Google ${googleKey} OpenAI ${openAiProjectKey}`,
@@ -196,8 +199,12 @@ describe('country evidence bundle export', () => {
     });
     const markdown = renderCountryEvidenceMarkdown(bundle);
 
+    assert.match(markdown, /The session: closed-door talks remain underway\./);
+    assert.match(markdown, /api_key: \[redacted-secret\]/);
+    assert.doesNotMatch(markdown, /session[:=]\s*\[redacted-secret\]/);
     assert.doesNotMatch(markdown, /analyst@example\.com/);
     assert.doesNotMatch(markdown, new RegExp(legacyOpenAiKey));
+    assert.doesNotMatch(markdown, new RegExp(colonOpenAiKey));
     assert.doesNotMatch(markdown, /wm_0123456789abcdef0123456789abcdef01234567/);
     assert.doesNotMatch(markdown, /user_abcdef123456/);
     assert.doesNotMatch(markdown, new RegExp(awsAccessKey));

--- a/tests/country-evidence-bundle-export.test.mts
+++ b/tests/country-evidence-bundle-export.test.mts
@@ -99,6 +99,44 @@ describe('country evidence bundle export', () => {
     assert.equal(bundle.provenanceDisclaimer, COUNTRY_EVIDENCE_PROVENANCE_DISCLAIMER);
   });
 
+  it('redacts secret-like URL credentials and query params while preserving benign citation params', async () => {
+    const { buildCountryEvidenceBundle, renderCountryEvidenceMarkdown } = await loadExportUtils();
+    const openAiProjectKey = ['sk', 'proj', 'urlredactionfixture1234567890', 'abcdef123456'].join('-');
+    const awsAccessKey = ['AK', 'IA', 'URLREDACTEXAMPLE'].join('');
+    const jwt = [
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+      'eyJ1cmwiOiJyZWRhY3Rpb24tZml4dHVyZSJ9',
+      'SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
+    ].join('.');
+
+    const bundle = buildCountryEvidenceBundle({
+      country: 'Testland',
+      code: 'TL',
+      exportedAt: '2026-06-10T12:00:00.000Z',
+      headlines: [{
+        title: 'Credentialed source URL',
+        source: 'Wire',
+        link: `https://analyst:${openAiProjectKey}@example.com/story(2026)?x=1&api_key=${openAiProjectKey}&token=plain-secret-value&ref=${awsAccessKey}#id_token=${jwt}`,
+        pubDate: '2026-06-10T11:00:00.000Z',
+      }],
+    });
+    const url = bundle.sources[0]?.url ?? '';
+    const markdown = renderCountryEvidenceMarkdown(bundle);
+
+    assert.match(url, /^https:\/\/%5Bredacted-user-id%5D:%5Bredacted-secret%5D@example\.com\/story%282026%29\?/);
+    assert.match(url, /[?&]x=1(?:&|#|$)/);
+    assert.match(url, /[?&]api_key=%5Bredacted-secret%5D(?:&|#|$)/);
+    assert.match(url, /[?&]token=%5Bredacted-secret%5D(?:&|#|$)/);
+    assert.match(url, /[?&]ref=%5Bredacted-secret%5D(?:&|#|$)/);
+    assert.match(url, /id_token=.*redacted-secret/);
+    assert.doesNotMatch(url, new RegExp(openAiProjectKey));
+    assert.doesNotMatch(url, new RegExp(awsAccessKey));
+    assert.doesNotMatch(url, /eyJhbGci/);
+    assert.doesNotMatch(markdown, new RegExp(openAiProjectKey));
+    assert.doesNotMatch(markdown, new RegExp(awsAccessKey));
+    assert.doesNotMatch(markdown, /eyJhbGci/);
+  });
+
   it('omits unsafe or missing citations without fabricating source metadata', async () => {
     const { buildCountryEvidenceBundle, renderCountryEvidenceMarkdown } = await loadExportUtils();
 

--- a/tests/country-evidence-bundle-export.test.mts
+++ b/tests/country-evidence-bundle-export.test.mts
@@ -1,0 +1,277 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+import { createCountryDeepDivePanelHarness } from './helpers/country-deep-dive-panel-harness.mjs';
+
+type ExportUtils = typeof import('../src/utils/export.ts');
+
+async function loadExportUtils(): Promise<ExportUtils> {
+  const tempDir = mkdtempSync(join(tmpdir(), 'wm-country-evidence-export-'));
+  const outfile = join(tempDir, 'export-utils.bundle.mjs');
+  const entry = resolve(process.cwd(), 'src/utils/export.ts');
+
+  const stubModules = new Map([
+    ['i18n-stub', `export function t(key) { return key; }`],
+    ['dom-utils-stub', `
+      export function trustedHtml(value) { return String(value ?? ''); }
+      export function setTrustedHtml(el, value) { el.innerHTML = String(value ?? ''); }
+    `],
+  ]);
+
+  const aliasMap = new Map([
+    ['@/services/i18n', 'i18n-stub'],
+    ['@/utils/dom-utils', 'dom-utils-stub'],
+  ]);
+
+  const plugin = {
+    name: 'country-evidence-export-test-stubs',
+    setup(buildApi: any) {
+      buildApi.onResolve({ filter: /.*/ }, (args) => {
+        const target = aliasMap.get(args.path);
+        return target ? { path: target, namespace: 'stub' } : null;
+      });
+      buildApi.onLoad({ filter: /.*/, namespace: 'stub' }, (args) => ({
+        contents: stubModules.get(args.path),
+        loader: 'js',
+      }));
+    },
+  };
+
+  const result = await build({
+    entryPoints: [entry],
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    target: 'es2020',
+    write: false,
+    plugins: [plugin],
+  });
+
+  writeFileSync(outfile, result.outputFiles[0].text, 'utf8');
+  const mod = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`);
+  rmSync(tempDir, { recursive: true, force: true });
+  return mod as ExportUtils;
+}
+
+describe('country evidence bundle export', () => {
+  it('builds a portable bundle with active signals, sources, freshness, and disclaimer', async () => {
+    const { buildCountryEvidenceBundle, COUNTRY_EVIDENCE_PROVENANCE_DISCLAIMER } = await loadExportUtils();
+
+    const bundle = buildCountryEvidenceBundle({
+      country: 'France',
+      code: 'fr',
+      context: 'Country dossier',
+      exportedAt: '2026-06-10T12:00:00.000Z',
+      briefGeneratedAt: '2026-06-10T11:55:00.000Z',
+      briefCached: false,
+      score: 38,
+      level: 'normal',
+      trend: 'stable',
+      components: { unrest: 8, conflict: 12, security: 9, information: 4 },
+      signals: {
+        criticalNews: 2,
+        protests: 0,
+        travelAdvisoryMaxLevel: 'reconsider',
+      },
+      brief: 'SITUATION NOW\n- Demonstrations remain localized.',
+      headlines: [{
+        title: 'Transport unions announce strikes',
+        source: 'Reuters',
+        link: 'https://example.com/story?x=1',
+        pubDate: '2026-06-10T06:00:00.000Z',
+      }],
+    });
+
+    assert.equal(bundle.country, 'France');
+    assert.equal(bundle.code, 'FR');
+    assert.equal(bundle.briefCacheStatus, 'fresh');
+    assert.deepEqual(bundle.signals, [
+      { label: 'Critical news', value: '2' },
+      { label: 'Maximum travel advisory', value: 'reconsider' },
+    ]);
+    assert.equal(bundle.sources[0]?.publisher, 'Reuters');
+    assert.equal(bundle.sources[0]?.url, 'https://example.com/story?x=1');
+    assert.equal(bundle.sources[0]?.freshness, '6h old at export.');
+    assert.equal(bundle.provenanceDisclaimer, COUNTRY_EVIDENCE_PROVENANCE_DISCLAIMER);
+  });
+
+  it('omits unsafe or missing citations without fabricating source metadata', async () => {
+    const { buildCountryEvidenceBundle, renderCountryEvidenceMarkdown } = await loadExportUtils();
+
+    const bundle = buildCountryEvidenceBundle({
+      country: 'Unknown',
+      code: 'xx',
+      exportedAt: '2026-06-10T12:00:00.000Z',
+      headlines: [
+        { title: '', source: '', link: '', pubDate: null },
+        { title: 'Unsafe link', source: null, link: 'javascript:alert(1)', pubDate: 'not-a-date' },
+      ],
+    });
+    const markdown = renderCountryEvidenceMarkdown(bundle);
+
+    assert.equal(bundle.sources[0]?.title, 'Source 1 (title unavailable)');
+    assert.equal(bundle.sources[0]?.publisher, undefined);
+    assert.equal(bundle.sources[0]?.url, undefined);
+    assert.equal(bundle.sources[0]?.note, 'URL unavailable; citation link was not provided.');
+    assert.equal(bundle.sources[1]?.url, undefined);
+    assert.equal(bundle.sources[1]?.note, 'URL omitted because it was missing or unsafe.');
+    assert.doesNotMatch(markdown, /javascript:alert/);
+    assert.match(markdown, /Publisher: Unavailable/);
+  });
+
+  it('redacts secret-like values and private identifiers from rendered evidence', async () => {
+    const { buildCountryEvidenceBundle, renderCountryEvidenceMarkdown } = await loadExportUtils();
+
+    const bundle = buildCountryEvidenceBundle({
+      country: 'Testland',
+      code: 'TL',
+      exportedAt: '2026-06-10T12:00:00.000Z',
+      brief: 'Contact analyst@example.com with token=sk_live_abc1234567890 and user_abcdef123456.',
+      headlines: [{
+        title: 'Report includes wm_0123456789abcdef0123456789abcdef01234567',
+        source: 'Desk user_abc12345',
+        link: 'https://example.com/private',
+        pubDate: '2026-06-10T11:00:00.000Z',
+      }],
+    });
+    const markdown = renderCountryEvidenceMarkdown(bundle);
+
+    assert.doesNotMatch(markdown, /analyst@example\.com/);
+    assert.doesNotMatch(markdown, /sk_live_abc1234567890/);
+    assert.doesNotMatch(markdown, /wm_0123456789abcdef0123456789abcdef01234567/);
+    assert.doesNotMatch(markdown, /user_abcdef123456/);
+    assert.match(markdown, /\[redacted-email\]/);
+    assert.match(markdown, /\[redacted-secret\]/);
+    assert.match(markdown, /\[redacted-user-id\]/);
+  });
+
+  it('renders Markdown with the expected handoff sections', async () => {
+    const { buildCountryEvidenceBundle, renderCountryEvidenceMarkdown } = await loadExportUtils();
+
+    const markdown = renderCountryEvidenceMarkdown(buildCountryEvidenceBundle({
+      country: 'Norway',
+      code: 'NO',
+      exportedAt: '2026-06-10T12:00:00.000Z',
+      score: 12,
+      level: 'low',
+      trend: 'stable',
+      headlines: [{
+        title: 'Grid operator updates alert level',
+        source: 'NVE',
+        link: 'https://example.org/nve',
+        pubDate: '2026-06-08T12:00:00.000Z',
+      }],
+    }));
+
+    assert.match(markdown, /^# WorldMonitor Evidence Bundle: Norway \(NO\)/);
+    assert.match(markdown, /## Risk Context/);
+    assert.match(markdown, /## Selected Signals/);
+    assert.match(markdown, /## Sources/);
+    assert.match(markdown, /\[Grid operator updates alert level\]\(https:\/\/example.org\/nve\)/);
+    assert.match(markdown, /Freshness: 2d old at export\./);
+    assert.match(markdown, /## Provenance Disclaimer/);
+  });
+
+  it('wires country brief export surfaces to the evidence Markdown exporter', () => {
+    const legacySource = readFileSync(resolve(process.cwd(), 'src/components/CountryBriefPage.ts'), 'utf8');
+    const dossierSource = readFileSync(resolve(process.cwd(), 'src/components/CountryDeepDivePanel.ts'), 'utf8');
+
+    assert.match(legacySource, /exportCountryEvidenceMarkdown/);
+    assert.match(legacySource, /data-format="evidence-md"/);
+    assert.match(legacySource, /format === 'json' \|\| format === 'csv' \|\| format === 'evidence-md'/);
+    assert.match(legacySource, /if \(format === 'evidence-md'\) exportCountryEvidenceMarkdown\(data\)/);
+    assert.match(legacySource, /data-format="json"/);
+    assert.match(legacySource, /data-format="csv"/);
+
+    assert.match(dossierSource, /exportCountryEvidenceMarkdown/);
+    assert.match(dossierSource, /cdp-evidence-export-btn/);
+    assert.match(dossierSource, /this\.exportEvidenceBundle\(\)/);
+    assert.match(dossierSource, /exportCountryEvidenceMarkdown\(data\)/);
+  });
+
+  it('passes the active dossier context to the evidence exporter when clicked', async () => {
+    const harness = await createCountryDeepDivePanelHarness();
+    try {
+      const panel = harness.createPanel();
+      panel.show('France', 'FR', {
+        code: 'FR',
+        name: 'France',
+        score: 38,
+        level: 'normal',
+        trend: 'stable',
+        change24h: 0,
+        components: { unrest: 8, conflict: 12, security: 9, information: 4 },
+        lastUpdated: null,
+      }, {
+        criticalNews: 2,
+        protests: 0,
+        militaryFlights: 1,
+        militaryVessels: 0,
+        militaryFlightsInCountry: 0,
+        militaryVesselsInCountry: 0,
+        outages: 0,
+        aisDisruptions: 0,
+        satelliteFires: 0,
+        radiationAnomalies: 0,
+        temporalAnomalies: 0,
+        cyberThreats: 0,
+        earthquakes: 0,
+        displacementOutflow: 0,
+        climateStress: 0,
+        conflictEvents: 0,
+        activeStrikes: 0,
+        orefSirens: 0,
+        orefHistory24h: 0,
+        aviationDisruptions: 0,
+        travelAdvisories: 1,
+        travelAdvisoryMaxLevel: 'exercise caution',
+        gpsJammingHexes: 0,
+        isTier1: true,
+        thermalEscalations: 0,
+        sanctionsDesignations: 0,
+        sanctionsNewDesignations: 0,
+      });
+      panel.updateBrief({
+        code: 'FR',
+        brief: 'SITUATION NOW\n- Demonstrations remain localized.',
+        generatedAt: '2026-06-10T11:55:00.000Z',
+        cached: true,
+      });
+      panel.updateNews([{
+        title: 'Transport unions announce strikes',
+        source: 'Reuters',
+        link: 'https://example.com/story',
+        pubDate: '2026-06-10T06:00:00.000Z',
+        threat: { level: 'medium' },
+      }]);
+      for (let attempt = 0; attempt < 25 && harness.getWidgets().length === 0; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+
+      const button = harness.getPanelRoot()?.querySelector('.cdp-evidence-export-btn') as HTMLButtonElement | null;
+      assert.ok(button, 'expected evidence export button');
+      button.dispatchEvent(new Event('click'));
+
+      const exports = harness.getEvidenceExports();
+      assert.equal(exports.length, 1);
+      assert.equal(exports[0].country, 'France');
+      assert.equal(exports[0].code, 'FR');
+      assert.equal(exports[0].context, 'Country dossier');
+      assert.equal(exports[0].score, 38);
+      assert.equal(exports[0].signals.criticalNews, 2);
+      assert.equal(exports[0].signals.militaryFlights, 1);
+      assert.equal(exports[0].brief, 'SITUATION NOW\n- Demonstrations remain localized.');
+      assert.equal(exports[0].briefGeneratedAt, '2026-06-10T11:55:00.000Z');
+      assert.equal(exports[0].briefCached, true);
+      assert.equal(exports[0].headlines[0].title, 'Transport unions announce strikes');
+      assert.equal(exports[0].headlines[0].source, 'Reuters');
+      assert.equal(exports[0].headlines[0].link, 'https://example.com/story');
+    } finally {
+      harness.cleanup();
+    }
+  });
+});

--- a/tests/country-evidence-bundle-export.test.mts
+++ b/tests/country-evidence-bundle-export.test.mts
@@ -108,12 +108,14 @@ describe('country evidence bundle export', () => {
       exportedAt: '2026-06-10T12:00:00.000Z',
       headlines: [
         { title: '', source: '', link: '', pubDate: null },
+        { title: 'Newswire note', source: '', link: '', pubDate: null },
         { title: 'Unsafe link', source: null, link: 'javascript:alert(1)', pubDate: 'not-a-date' },
       ],
     });
     const markdown = renderCountryEvidenceMarkdown(bundle);
 
-    assert.equal(bundle.sources[0]?.title, 'Source 1 (title unavailable)');
+    assert.equal(bundle.sources.length, 2);
+    assert.equal(bundle.sources[0]?.title, 'Newswire note');
     assert.equal(bundle.sources[0]?.publisher, undefined);
     assert.equal(bundle.sources[0]?.url, undefined);
     assert.equal(bundle.sources[0]?.note, 'URL unavailable; citation link was not provided.');
@@ -159,10 +161,11 @@ describe('country evidence bundle export', () => {
       score: 12,
       level: 'low',
       trend: 'stable',
+      brief: '## Spoofed Sources\n- This heading came from AI text.',
       headlines: [{
         title: 'Grid operator updates alert level',
         source: 'NVE',
-        link: 'https://example.org/nve',
+        link: 'https://example.org/report(2026)overview',
         pubDate: '2026-06-08T12:00:00.000Z',
       }],
     }));
@@ -170,8 +173,11 @@ describe('country evidence bundle export', () => {
     assert.match(markdown, /^# WorldMonitor Evidence Bundle: Norway \(NO\)/);
     assert.match(markdown, /## Risk Context/);
     assert.match(markdown, /## Selected Signals/);
+    assert.match(markdown, /## Intelligence Brief/);
+    assert.match(markdown, /> ## Spoofed Sources/);
+    assert.doesNotMatch(markdown, /\n## Spoofed Sources/);
     assert.match(markdown, /## Sources/);
-    assert.match(markdown, /\[Grid operator updates alert level\]\(https:\/\/example.org\/nve\)/);
+    assert.match(markdown, /\[Grid operator updates alert level\]\(https:\/\/example.org\/report%282026%29overview\)/);
     assert.match(markdown, /Freshness: 2d old at export\./);
     assert.match(markdown, /## Provenance Disclaimer/);
   });

--- a/tests/helpers/country-deep-dive-panel-harness.mjs
+++ b/tests/helpers/country-deep-dive-panel-harness.mjs
@@ -139,6 +139,12 @@ async function loadCountryDeepDivePanel(options = {}) {
       export function safeHtmlToString(value) { return String(value ?? ''); }
     `],
     ['intel-brief-stub', `export function formatIntelBrief(value) { return value; }`],
+    ['export-stub', `
+      const state = globalThis.__wmCountryDeepDiveTestState;
+      export function exportCountryEvidenceMarkdown(data) {
+        state.evidenceExports.push(data);
+      }
+    `],
     ['utils-stub', `
       export function getCSSColor() { return '#44ff88'; }
       export function createCircuitBreaker() { return { execute: (fn) => fn() }; }
@@ -206,6 +212,7 @@ async function loadCountryDeepDivePanel(options = {}) {
     ['@/services/related-assets', 'related-assets-stub'],
     ['@/utils/sanitize', 'sanitize-stub'],
     ['@/utils/format-intel-brief', 'intel-brief-stub'],
+    ['@/utils/export', 'export-stub'],
     ['@/utils', 'utils-stub'],
     ['@/utils/country-flag', 'country-flag-stub'],
     ['@/config/ports', 'ports-stub'],
@@ -272,7 +279,14 @@ export async function createCountryDeepDivePanelHarness(options = {}) {
     HTMLButtonElement: snapshotGlobal('HTMLButtonElement'),
   };
   const browserEnvironment = createBrowserEnvironment();
-  const state = { widgets: [], sentryBreadcrumbs: [], sentryExceptions: [], sentryMessages: [], sentryUser: undefined };
+  const state = {
+    widgets: [],
+    sentryBreadcrumbs: [],
+    sentryExceptions: [],
+    sentryMessages: [],
+    sentryUser: undefined,
+    evidenceExports: [],
+  };
 
   defineGlobal('document', browserEnvironment.document);
   defineGlobal('window', browserEnvironment.window);
@@ -334,6 +348,9 @@ export async function createCountryDeepDivePanelHarness(options = {}) {
     },
     getSentryExceptions() {
       return state.sentryExceptions;
+    },
+    getEvidenceExports() {
+      return state.evidenceExports;
     },
     cleanup,
   };


### PR DESCRIPTION
Closes #4272

## Summary
- Add a reusable country evidence bundle builder, Markdown renderer, and exporter with selected signals, source freshness, citation fallback notes, provenance disclaimer, and redaction of secret-like/private identifiers.
- Add Evidence Markdown export to the country brief export menu and to the active country dossier header.
- Update user-facing docs and add focused tests, including click-through UI wiring for the active dossier button.

## Validation
- npm run typecheck
- TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/country-evidence-bundle-export.test.mts
- TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/country-evidence-bundle-export.test.mts tests/resilience-country-brief.test.mjs tests/country-brief-i18n.test.mjs tests/brief-share-url.test.mts tests/brief-url.test.mjs tests/unrest-source-links.test.mts tests/deckgl-vessel-tooltip-provenance.test.mts tests/forecast-integrity-provenance.test.mjs
- ./node_modules/.bin/markdownlint-cli2 docs/ai-intelligence.mdx docs/features.mdx
- git diff --check and git diff --cached --check
- Browser sanity at http://127.0.0.1:3001/?c=FR: active dossier Evidence button found, no page errors
- Pre-push hook passed: typecheck, API typecheck, changed tests, edge tests, markdown and MDX lint, version sync