### PR TITLE
feat(trust): explain high-adoption map layers

### DIFF
--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -392,6 +392,8 @@ All 56 map layer toggle definitions — icon, localization key, fallback display
 
 A `def()` factory function reduces per-entry boilerplate. Variant-specific layer ordering (`VARIANT_LAYER_ORDER`) defines the display sequence for each of the six dashboard variants without duplicating the definitions themselves. Adding a new map layer requires a single registry entry — both the flat map and 3D globe derive their toggle panels from this catalog automatically.
 
+The same registry also carries the v1 layer-explanation catalog for high-adoption layers. Each curated explanation records purpose, provider/source, freshness expectations, confidence notes, limitations, related panels/actions, and grounding paths; unsupported layers intentionally fall back to a generic card so the UI never implies a fabricated freshness or confidence value.
+
 ---
 
 ## Bandwidth & Caching

--- a/docs/architecture.mdx
+++ b/docs/architecture.mdx
@@ -235,11 +235,11 @@ The `SmartPollLoop` is the core refresh orchestration primitive used by all data
 | `seed-market-quotes` | Yahoo Finance (staggered batches) | 5 min | `market:stocks-bootstrap:v1` |
 | `seed-commodity-quotes` | Yahoo Finance (WTI, Brent, metals) | 5 min | `market:commodities-bootstrap:v1` |
 | `seed-crypto-quotes` | CoinGecko (BTC, ETH, SOL, XRP+) | 5 min | `market:crypto:v1` |
-| `seed-cyber-threats` | Feodo, URLhaus, C2Intel, OTX, AbuseIPDB | 10 min | `cyber:threats-bootstrap:v2` |
+| `seed-cyber-threats` | Feodo, URLhaus, C2Intel, OTX, AbuseIPDB | 2 hours | `cyber:threats-bootstrap:v2` |
 | `seed-internet-outages` | Cloudflare Radar | 5 min | `infra:outages:v1` |
 | `seed-fire-detections` | NASA FIRMS VIIRS | 10 min | `wildfire:fires:v1` |
 | `seed-climate-anomalies` | Open-Meteo ERA5 | 15 min | `climate:anomalies:v2` |
-| `seed-natural-events` | USGS + GDACS + NASA EONET | 10 min | `natural:events:v1` |
+| `seed-natural-events` | USGS + GDACS + NASA EONET | 2 hours | `natural:events:v1` |
 | `seed-airport-delays` | FAA + AviationStack + ICAO NOTAM | 10 min | `aviation:delays-bootstrap:v1` |
 | `seed-insights` | Groq LLM world brief + top stories | 10 min | `news:insights:v1` |
 | `seed-prediction-markets` | Polymarket Gamma API | 10 min | `prediction:markets-bootstrap:v1` |

--- a/docs/features.mdx
+++ b/docs/features.mdx
@@ -637,6 +637,7 @@ These models run entirely in the browser via Web Workers, providing intelligence
 - **Click markers** - Show detailed popup with full context
 - **Hover markers** - Show tooltip with summary information
 - **Layer toggles** - Show/hide data layers
+- **Layer explanations** - Open compact cards from the layer picker to see a layer's purpose, source/provider, freshness expectation, confidence notes, limitations, and related panels
 
 ### Map Marker Design
 

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -119,9 +119,9 @@ import {
   bindLayerSearch,
   getLayerExplanation,
   hasCuratedLayerExplanation,
-  type LayerExplanation,
   type MapVariant,
 } from '@/config/map-layer-definitions';
+import { renderLayerExplanationCard } from '@/utils/layer-explanation-card';
 import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import { onEntitlementChange } from '@/services/entitlements';
 import { hasPremiumAccess } from '@/services/panel-gating';
@@ -5220,54 +5220,6 @@ export class DeckGLMap {
     });
   }
 
-  private renderLayerExplanationCard(layerLabel: string, explanation: LayerExplanation): string {
-    const list = (items: string[]): string => items.map(item => `<li>${escapeHtml(item)}</li>`).join('');
-    const related = explanation.related.length > 0
-      ? explanation.related.map(item => `<span>${escapeHtml(item)}</span>`).join('')
-      : '<span>Layer guide</span>';
-    const evidence = explanation.evidence.length > 0
-      ? `<div class="layer-explanation-grounding"><span>Grounded in</span>${explanation.evidence.map(item => `<code>${escapeHtml(item)}</code>`).join('')}</div>`
-      : '';
-    const coverageLabel = explanation.coverage === 'curated' ? 'Curated v1' : 'Fallback';
-
-    return `
-      <div class="layer-explanation-header">
-        <div>
-          <span class="layer-explanation-kicker">${escapeHtml(explanation.category)}</span>
-          <strong>${escapeHtml(layerLabel)}</strong>
-        </div>
-        <button class="layer-explanation-close" aria-label="Close">×</button>
-      </div>
-      <div class="layer-explanation-content">
-        <div class="layer-explanation-status ${explanation.coverage}">${coverageLabel}</div>
-        <p class="layer-explanation-purpose">${escapeHtml(explanation.purpose)}</p>
-        <div class="layer-explanation-grid">
-          <section>
-            <span>Source</span>
-            <p>${escapeHtml(explanation.source)}</p>
-          </section>
-          <section>
-            <span>Freshness</span>
-            <p>${escapeHtml(explanation.freshness)}</p>
-          </section>
-          <section>
-            <span>Confidence</span>
-            <p>${escapeHtml(explanation.confidence)}</p>
-          </section>
-        </div>
-        <div class="layer-explanation-section">
-          <span>Limitations</span>
-          <ul>${list(explanation.limitations)}</ul>
-        </div>
-        <div class="layer-explanation-section">
-          <span>Related</span>
-          <div class="layer-explanation-related">${related}</div>
-        </div>
-        ${evidence}
-      </div>
-    `;
-  }
-
   private showLayerExplanation(layer: keyof MapLayers): void {
     const existing = this.container.querySelector('.layer-explanation-popup') as HTMLElement | null;
     if (existing?.dataset.layer === layer) {
@@ -5276,6 +5228,7 @@ export class DeckGLMap {
       return;
     }
     existing?.remove();
+    this.container.querySelector('.layer-help-popup')?.remove();
     this.container.querySelectorAll('.layer-explain-btn.active').forEach(btn => btn.classList.remove('active'));
 
     const def = getLayersForVariant((SITE_VARIANT || 'full') as MapVariant, 'flat').find(item => item.key === layer);
@@ -5285,7 +5238,7 @@ export class DeckGLMap {
     popup.className = 'layer-explanation-popup';
     popup.dataset.layer = layer;
     setTrustedHtml(popup, trustedHtml(
-      this.renderLayerExplanationCard(layerLabel, explanation),
+      renderLayerExplanationCard(layerLabel, explanation),
       "static layer explanation metadata",
     ));
 
@@ -5306,6 +5259,8 @@ export class DeckGLMap {
       existing.remove();
       return;
     }
+    this.container.querySelector('.layer-explanation-popup')?.remove();
+    this.container.querySelectorAll('.layer-explain-btn.active').forEach(btn => btn.classList.remove('active'));
 
     const popup = document.createElement('div');
     popup.className = 'layer-help-popup';

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -113,7 +113,15 @@ import {
 import type { GulfInvestment } from '@/types';
 import { resolveTradeRouteSegments, TRADE_ROUTES as TRADE_ROUTES_LIST, type TradeRouteSegment, type TradeRouteStatus } from '@/config/trade-routes';
 import type { ScenarioVisualState } from '@/config/scenario-templates';
-import { getLayersForVariant, resolveLayerLabel, bindLayerSearch, type MapVariant } from '@/config/map-layer-definitions';
+import {
+  getLayersForVariant,
+  resolveLayerLabel,
+  bindLayerSearch,
+  getLayerExplanation,
+  hasCuratedLayerExplanation,
+  type LayerExplanation,
+  type MapVariant,
+} from '@/config/map-layer-definitions';
 import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import { onEntitlementChange } from '@/services/entitlements';
 import { hasPremiumAccess } from '@/services/panel-gating';
@@ -5076,6 +5084,8 @@ export class DeckGLMap {
       label: resolveLayerLabel(def, t),
       icon: def.icon,
       premium: def.premium,
+      explainLabel: escapeHtml(`Explain ${resolveLayerLabel(def, t)} layer`),
+      hasExplanation: hasCuratedLayerExplanation(def.key),
     }));
 
     setTrustedHtml(toggles, trustedHtml(`
@@ -5086,15 +5096,18 @@ export class DeckGLMap {
       </div>
       <input type="text" class="layer-search" placeholder="${t('components.deckgl.layerSearch')}" autocomplete="off" spellcheck="false" />
       <div class="toggle-list" style="max-height: 32vh; overflow-y: auto; scrollbar-width: thin;">
-        ${layerConfig.map(({ key, label, icon, premium }) => {
+        ${layerConfig.map(({ key, label, icon, premium, explainLabel, hasExplanation }) => {
           const isLocked = premium === 'locked' && !premiumUnlocked;
           const isEnhanced = premium === 'enhanced' && !premiumUnlocked;
           return `
-          <label class="layer-toggle${isLocked ? ' layer-toggle-locked' : ''}" data-layer="${key}">
-            <input type="checkbox" ${this.state.layers[key as keyof MapLayers] ? 'checked' : ''}${isLocked ? ' disabled' : ''}>
-            <span class="toggle-icon">${icon}</span>
-            <span class="toggle-label">${label}${isLocked ? ' \uD83D\uDD12' : ''}${isEnhanced ? ' <span class="layer-pro-badge">PRO</span>' : ''}</span>
-          </label>`;
+          <div class="layer-toggle-row" data-layer="${key}">
+            <label class="layer-toggle${isLocked ? ' layer-toggle-locked' : ''}" data-layer="${key}">
+              <input type="checkbox" ${this.state.layers[key as keyof MapLayers] ? 'checked' : ''}${isLocked ? ' disabled' : ''}>
+              <span class="toggle-icon">${icon}</span>
+              <span class="toggle-label">${label}${isLocked ? ' \uD83D\uDD12' : ''}${isEnhanced ? ' <span class="layer-pro-badge">PRO</span>' : ''}</span>
+            </label>
+            <button type="button" class="layer-explain-btn${hasExplanation ? ' has-layer-explanation' : ''}" data-layer="${key}" aria-label="${explainLabel}" title="${explainLabel}">i</button>
+          </div>`;
         }).join('')}
       </div>
     `, "legacy direct innerHTML migration"));
@@ -5171,6 +5184,15 @@ export class DeckGLMap {
     });
     this.enforceLayerLimit();
 
+    toggles.querySelectorAll('.layer-explain-btn').forEach(button => {
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const layer = (button as HTMLElement).getAttribute('data-layer') as keyof MapLayers | null;
+        if (layer) this.showLayerExplanation(layer);
+      });
+    });
+
     // Help button
     const helpBtn = toggles.querySelector('.layer-help-btn');
     helpBtn?.addEventListener('click', () => this.showLayerHelp());
@@ -5196,6 +5218,85 @@ export class DeckGLMap {
       if (searchEl) searchEl.style.display = toggleList?.classList.contains('collapsed') ? 'none' : '';
       if (collapseBtn) setTrustedHtml(collapseBtn, trustedHtml(toggleList?.classList.contains('collapsed') ? '&#9654;' : '&#9660;', "legacy direct innerHTML migration"));
     });
+  }
+
+  private renderLayerExplanationCard(layerLabel: string, explanation: LayerExplanation): string {
+    const list = (items: string[]): string => items.map(item => `<li>${escapeHtml(item)}</li>`).join('');
+    const related = explanation.related.length > 0
+      ? explanation.related.map(item => `<span>${escapeHtml(item)}</span>`).join('')
+      : '<span>Layer guide</span>';
+    const evidence = explanation.evidence.length > 0
+      ? `<div class="layer-explanation-grounding"><span>Grounded in</span>${explanation.evidence.map(item => `<code>${escapeHtml(item)}</code>`).join('')}</div>`
+      : '';
+    const coverageLabel = explanation.coverage === 'curated' ? 'Curated v1' : 'Fallback';
+
+    return `
+      <div class="layer-explanation-header">
+        <div>
+          <span class="layer-explanation-kicker">${escapeHtml(explanation.category)}</span>
+          <strong>${escapeHtml(layerLabel)}</strong>
+        </div>
+        <button class="layer-explanation-close" aria-label="Close">×</button>
+      </div>
+      <div class="layer-explanation-content">
+        <div class="layer-explanation-status ${explanation.coverage}">${coverageLabel}</div>
+        <p class="layer-explanation-purpose">${escapeHtml(explanation.purpose)}</p>
+        <div class="layer-explanation-grid">
+          <section>
+            <span>Source</span>
+            <p>${escapeHtml(explanation.source)}</p>
+          </section>
+          <section>
+            <span>Freshness</span>
+            <p>${escapeHtml(explanation.freshness)}</p>
+          </section>
+          <section>
+            <span>Confidence</span>
+            <p>${escapeHtml(explanation.confidence)}</p>
+          </section>
+        </div>
+        <div class="layer-explanation-section">
+          <span>Limitations</span>
+          <ul>${list(explanation.limitations)}</ul>
+        </div>
+        <div class="layer-explanation-section">
+          <span>Related</span>
+          <div class="layer-explanation-related">${related}</div>
+        </div>
+        ${evidence}
+      </div>
+    `;
+  }
+
+  private showLayerExplanation(layer: keyof MapLayers): void {
+    const existing = this.container.querySelector('.layer-explanation-popup') as HTMLElement | null;
+    if (existing?.dataset.layer === layer) {
+      existing.remove();
+      this.container.querySelector(`.layer-explain-btn[data-layer="${layer}"]`)?.classList.remove('active');
+      return;
+    }
+    existing?.remove();
+    this.container.querySelectorAll('.layer-explain-btn.active').forEach(btn => btn.classList.remove('active'));
+
+    const def = getLayersForVariant((SITE_VARIANT || 'full') as MapVariant, 'flat').find(item => item.key === layer);
+    const layerLabel = def ? resolveLayerLabel(def, t) : String(layer);
+    const explanation = getLayerExplanation(layer);
+    const popup = document.createElement('div');
+    popup.className = 'layer-explanation-popup';
+    popup.dataset.layer = layer;
+    setTrustedHtml(popup, trustedHtml(
+      this.renderLayerExplanationCard(layerLabel, explanation),
+      "static layer explanation metadata",
+    ));
+
+    const closePopup = (): void => {
+      popup.remove();
+      this.container.querySelector(`.layer-explain-btn[data-layer="${layer}"]`)?.classList.remove('active');
+    };
+
+    popup.querySelector('.layer-explanation-close')?.addEventListener('click', closePopup);
+    this.container.appendChild(popup);
+    this.container.querySelector(`.layer-explain-btn[data-layer="${layer}"]`)?.classList.add('active');
   }
 
   /** Show layer help popup explaining each layer */
@@ -6632,7 +6733,11 @@ export class DeckGLMap {
     const togglesEl = this.container.querySelector('.deckgl-layer-toggles');
     if (!togglesEl) return;
     const activeCount = Array.from(togglesEl.querySelectorAll<HTMLInputElement>('.layer-toggle input'))
-      .filter(i => (i.closest('.layer-toggle') as HTMLElement)?.style.display !== 'none')
+      .filter(i => {
+        const toggle = i.closest('.layer-toggle') as HTMLElement | null;
+        const row = i.closest('.layer-toggle-row') as HTMLElement | null;
+        return toggle?.style.display !== 'none' && row?.style.display !== 'none';
+      })
       .filter(i => i.checked).length;
     const increasing = activeCount > this.lastActiveLayerCount;
     this.lastActiveLayerCount = activeCount;
@@ -6648,7 +6753,9 @@ export class DeckGLMap {
   public hideLayerToggle(layer: keyof MapLayers): void {
     const toggle = this.container.querySelector(`.layer-toggle[data-layer="${layer}"]`);
     if (toggle) {
-      (toggle as HTMLElement).style.display = 'none';
+      const row = toggle.closest('.layer-toggle-row') as HTMLElement | null;
+      const target = (row ?? toggle) as HTMLElement;
+      target.style.display = 'none';
       toggle.setAttribute('data-layer-hidden', '');
     }
   }

--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -22,7 +22,15 @@ import { PIPELINES } from '@/config/pipelines';
 import { t } from '@/services/i18n';
 import { SITE_VARIANT } from '@/config/variant';
 import { getGlobeRenderScale, resolveGlobePixelRatio, resolvePerformanceProfile, subscribeGlobeRenderScaleChange, getGlobeTexture, GLOBE_TEXTURE_URLS, subscribeGlobeTextureChange, getGlobeVisualPreset, subscribeGlobeVisualPresetChange, type GlobeRenderScale, type GlobePerformanceProfile, type GlobeVisualPreset } from '@/services/globe-render-settings';
-import { getLayersForVariant, resolveLayerLabel, bindLayerSearch, type MapVariant } from '@/config/map-layer-definitions';
+import {
+  getLayerExplanation,
+  getLayersForVariant,
+  hasCuratedLayerExplanation,
+  resolveLayerLabel,
+  bindLayerSearch,
+  type LayerExplanation,
+  type MapVariant,
+} from '@/config/map-layer-definitions';
 import { getSecretState } from '@/services/runtime-config';
 import { resolveTradeRouteSegments, type TradeRouteSegment } from '@/config/trade-routes';
 import { GAMMA_IRRADIATORS } from '@/config/irradiators';
@@ -1840,12 +1848,17 @@ export class GlobeMap {
         ${layers.map(({ key, label, icon, premium }) => {
           const isLocked = premium === 'locked' && !_wmKey;
           const isEnhanced = premium === 'enhanced' && !_wmKey;
+          const explainLabel = escapeHtml(`Explain ${label} layer`);
+          const hasExplanation = hasCuratedLayerExplanation(key);
           return `
-          <label class="layer-toggle${isLocked ? ' layer-toggle-locked' : ''}" data-layer="${key}">
-            <input type="checkbox" ${this.layers[key] ? 'checked' : ''}${isLocked ? ' disabled' : ''}>
-            <span class="toggle-icon">${icon}</span>
-            <span class="toggle-label">${label}${isLocked ? ' \uD83D\uDD12' : ''}${isEnhanced ? ' <span class="layer-pro-badge">PRO</span>' : ''}</span>
-          </label>`;
+          <div class="layer-toggle-row" data-layer="${key}">
+            <label class="layer-toggle${isLocked ? ' layer-toggle-locked' : ''}" data-layer="${key}">
+              <input type="checkbox" ${this.layers[key] ? 'checked' : ''}${isLocked ? ' disabled' : ''}>
+              <span class="toggle-icon">${icon}</span>
+              <span class="toggle-label">${label}${isLocked ? ' \uD83D\uDD12' : ''}${isEnhanced ? ' <span class="layer-pro-badge">PRO</span>' : ''}</span>
+            </label>
+            <button type="button" class="layer-explain-btn${hasExplanation ? ' has-layer-explanation' : ''}" data-layer="${key}" aria-label="${explainLabel}" title="${explainLabel}">i</button>
+          </div>`;
         }).join('')}
       </div>`, "legacy direct innerHTML migration"));
     const authorBadge = document.createElement('div');
@@ -1869,6 +1882,15 @@ export class GlobeMap {
             if (modeRow) modeRow.style.display = checked ? '' : 'none';
           }
         }
+      });
+    });
+
+    el.querySelectorAll('.layer-explain-btn').forEach(button => {
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        const layer = (button as HTMLElement).getAttribute('data-layer') as keyof MapLayers | null;
+        if (layer) this.showLayerExplanation(layer);
       });
     });
 
@@ -1924,6 +1946,84 @@ export class GlobeMap {
     }, { passive: false });
 
     this.layerTogglesEl = el;
+  }
+
+  private renderLayerExplanationCard(layerLabel: string, explanation: LayerExplanation): string {
+    const list = (items: string[]): string => items.map(item => `<li>${escapeHtml(item)}</li>`).join('');
+    const related = explanation.related.length > 0
+      ? explanation.related.map(item => `<span>${escapeHtml(item)}</span>`).join('')
+      : '<span>Layer guide</span>';
+    const evidence = explanation.evidence.length > 0
+      ? `<div class="layer-explanation-grounding"><span>Grounded in</span>${explanation.evidence.map(item => `<code>${escapeHtml(item)}</code>`).join('')}</div>`
+      : '';
+    const coverageLabel = explanation.coverage === 'curated' ? 'Curated v1' : 'Fallback';
+
+    return `
+      <div class="layer-explanation-header">
+        <div>
+          <span class="layer-explanation-kicker">${escapeHtml(explanation.category)}</span>
+          <strong>${escapeHtml(layerLabel)}</strong>
+        </div>
+        <button class="layer-explanation-close" aria-label="Close">×</button>
+      </div>
+      <div class="layer-explanation-content">
+        <div class="layer-explanation-status ${explanation.coverage}">${coverageLabel}</div>
+        <p class="layer-explanation-purpose">${escapeHtml(explanation.purpose)}</p>
+        <div class="layer-explanation-grid">
+          <section>
+            <span>Source</span>
+            <p>${escapeHtml(explanation.source)}</p>
+          </section>
+          <section>
+            <span>Freshness</span>
+            <p>${escapeHtml(explanation.freshness)}</p>
+          </section>
+          <section>
+            <span>Confidence</span>
+            <p>${escapeHtml(explanation.confidence)}</p>
+          </section>
+        </div>
+        <div class="layer-explanation-section">
+          <span>Limitations</span>
+          <ul>${list(explanation.limitations)}</ul>
+        </div>
+        <div class="layer-explanation-section">
+          <span>Related</span>
+          <div class="layer-explanation-related">${related}</div>
+        </div>
+        ${evidence}
+      </div>
+    `;
+  }
+
+  private showLayerExplanation(layer: keyof MapLayers): void {
+    const existing = this.container.querySelector('.layer-explanation-popup') as HTMLElement | null;
+    if (existing?.dataset.layer === layer) {
+      existing.remove();
+      this.container.querySelector(`.layer-explain-btn[data-layer="${layer}"]`)?.classList.remove('active');
+      return;
+    }
+    existing?.remove();
+    this.container.querySelectorAll('.layer-explain-btn.active').forEach(btn => btn.classList.remove('active'));
+
+    const def = getLayersForVariant((SITE_VARIANT || 'full') as MapVariant, 'globe').find(item => item.key === layer);
+    const layerLabel = def ? resolveLayerLabel(def, t) : String(layer);
+    const popup = document.createElement('div');
+    popup.className = 'layer-explanation-popup';
+    popup.dataset.layer = layer;
+    setTrustedHtml(popup, trustedHtml(
+      this.renderLayerExplanationCard(layerLabel, getLayerExplanation(layer)),
+      "static layer explanation metadata",
+    ));
+
+    const closePopup = (): void => {
+      popup.remove();
+      this.container.querySelector(`.layer-explain-btn[data-layer="${layer}"]`)?.classList.remove('active');
+    };
+
+    popup.querySelector('.layer-explanation-close')?.addEventListener('click', closePopup);
+    this.container.appendChild(popup);
+    this.container.querySelector(`.layer-explain-btn[data-layer="${layer}"]`)?.classList.add('active');
   }
 
   // ─── Flush all current data to globe ──────────────────────────────────────
@@ -2746,7 +2846,9 @@ export class GlobeMap {
   }
   public setOnTimeRangeChange(_cb: any): void {}
   public hideLayerToggle(layer: keyof MapLayers): void {
-    this.layerTogglesEl?.querySelector(`.layer-toggle[data-layer="${layer}"]`)?.remove();
+    const toggle = this.layerTogglesEl?.querySelector(`.layer-toggle[data-layer="${layer}"]`);
+    toggle?.closest('.layer-toggle-row')?.remove();
+    toggle?.remove();
   }
   public setLayerLoading(layer: keyof MapLayers, loading: boolean): void {
     this.layerTogglesEl?.querySelector(`.layer-toggle[data-layer="${layer}"]`)?.classList.toggle('loading', loading);

--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -28,9 +28,9 @@ import {
   hasCuratedLayerExplanation,
   resolveLayerLabel,
   bindLayerSearch,
-  type LayerExplanation,
   type MapVariant,
 } from '@/config/map-layer-definitions';
+import { renderLayerExplanationCard } from '@/utils/layer-explanation-card';
 import { getSecretState } from '@/services/runtime-config';
 import { resolveTradeRouteSegments, type TradeRouteSegment } from '@/config/trade-routes';
 import { GAMMA_IRRADIATORS } from '@/config/irradiators';
@@ -1948,54 +1948,6 @@ export class GlobeMap {
     this.layerTogglesEl = el;
   }
 
-  private renderLayerExplanationCard(layerLabel: string, explanation: LayerExplanation): string {
-    const list = (items: string[]): string => items.map(item => `<li>${escapeHtml(item)}</li>`).join('');
-    const related = explanation.related.length > 0
-      ? explanation.related.map(item => `<span>${escapeHtml(item)}</span>`).join('')
-      : '<span>Layer guide</span>';
-    const evidence = explanation.evidence.length > 0
-      ? `<div class="layer-explanation-grounding"><span>Grounded in</span>${explanation.evidence.map(item => `<code>${escapeHtml(item)}</code>`).join('')}</div>`
-      : '';
-    const coverageLabel = explanation.coverage === 'curated' ? 'Curated v1' : 'Fallback';
-
-    return `
-      <div class="layer-explanation-header">
-        <div>
-          <span class="layer-explanation-kicker">${escapeHtml(explanation.category)}</span>
-          <strong>${escapeHtml(layerLabel)}</strong>
-        </div>
-        <button class="layer-explanation-close" aria-label="Close">×</button>
-      </div>
-      <div class="layer-explanation-content">
-        <div class="layer-explanation-status ${explanation.coverage}">${coverageLabel}</div>
-        <p class="layer-explanation-purpose">${escapeHtml(explanation.purpose)}</p>
-        <div class="layer-explanation-grid">
-          <section>
-            <span>Source</span>
-            <p>${escapeHtml(explanation.source)}</p>
-          </section>
-          <section>
-            <span>Freshness</span>
-            <p>${escapeHtml(explanation.freshness)}</p>
-          </section>
-          <section>
-            <span>Confidence</span>
-            <p>${escapeHtml(explanation.confidence)}</p>
-          </section>
-        </div>
-        <div class="layer-explanation-section">
-          <span>Limitations</span>
-          <ul>${list(explanation.limitations)}</ul>
-        </div>
-        <div class="layer-explanation-section">
-          <span>Related</span>
-          <div class="layer-explanation-related">${related}</div>
-        </div>
-        ${evidence}
-      </div>
-    `;
-  }
-
   private showLayerExplanation(layer: keyof MapLayers): void {
     const existing = this.container.querySelector('.layer-explanation-popup') as HTMLElement | null;
     if (existing?.dataset.layer === layer) {
@@ -2012,7 +1964,7 @@ export class GlobeMap {
     popup.className = 'layer-explanation-popup';
     popup.dataset.layer = layer;
     setTrustedHtml(popup, trustedHtml(
-      this.renderLayerExplanationCard(layerLabel, getLayerExplanation(layer)),
+      renderLayerExplanationCard(layerLabel, getLayerExplanation(layer)),
       "static layer explanation metadata",
     ));
 

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -64,6 +64,14 @@ import type { CountryClickPayload } from './DeckGLMap';
 import { t } from '@/services/i18n';
 import type { ScenarioVisualState } from '@/config/scenario-templates';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
+import {
+  getLayerExplanation,
+  getLayersForVariant,
+  hasCuratedLayerExplanation,
+  resolveLayerLabel,
+  type LayerExplanation,
+  type MapVariant,
+} from '@/config/map-layer-definitions';
 
 
 export type TimeRange = '1h' | '6h' | '24h' | '48h' | '7d' | 'all';
@@ -375,6 +383,11 @@ export class MapComponent {
 
 
 
+  private getLayerControlLabel(layer: keyof MapLayers): string {
+    const def = getLayersForVariant((SITE_VARIANT || 'full') as MapVariant, 'flat').find(item => item.key === layer);
+    return def ? resolveLayerLabel(def, t) : String(layer);
+  }
+
   private createLayerToggles(): HTMLElement {
     const toggles = document.createElement('div');
     toggles.className = 'layer-toggles';
@@ -434,43 +447,6 @@ export class MapComponent {
                  : SITE_VARIANT === 'happy' ? happyLayers
                  : SITE_VARIANT === 'energy' ? energyLayers
                  : fullLayers;
-    const layerLabelKeys: Partial<Record<keyof MapLayers, string>> = {
-      hotspots: 'components.deckgl.layers.intelHotspots',
-      conflicts: 'components.deckgl.layers.conflictZones',
-      bases: 'components.deckgl.layers.militaryBases',
-      nuclear: 'components.deckgl.layers.nuclearSites',
-      irradiators: 'components.deckgl.layers.gammaIrradiators',
-      military: 'components.deckgl.layers.militaryActivity',
-      cables: 'components.deckgl.layers.underseaCables',
-      pipelines: 'components.deckgl.layers.pipelines',
-      outages: 'components.deckgl.layers.internetOutages',
-      datacenters: 'components.deckgl.layers.aiDataCenters',
-      ais: 'components.deckgl.layers.shipTraffic',
-      flights: 'components.deckgl.layers.flightDelays',
-      natural: 'components.deckgl.layers.naturalEvents',
-      weather: 'components.deckgl.layers.weatherAlerts',
-      economic: 'components.deckgl.layers.economicCenters',
-      waterways: 'components.deckgl.layers.strategicWaterways',
-      startupHubs: 'components.deckgl.layers.startupHubs',
-      cloudRegions: 'components.deckgl.layers.cloudRegions',
-      accelerators: 'components.deckgl.layers.accelerators',
-      techHQs: 'components.deckgl.layers.techHQs',
-      techEvents: 'components.deckgl.layers.techEvents',
-      stockExchanges: 'components.deckgl.layers.stockExchanges',
-      financialCenters: 'components.deckgl.layers.financialCenters',
-      centralBanks: 'components.deckgl.layers.centralBanks',
-      commodityHubs: 'components.deckgl.layers.commodityHubs',
-      gulfInvestments: 'components.deckgl.layers.gulfInvestments',
-      iranAttacks: 'components.deckgl.layers.iranAttacks',
-      gpsJamming: 'components.deckgl.layers.gpsJamming',
-      ciiChoropleth: 'components.deckgl.layers.ciiChoropleth',
-    };
-    const getLayerLabel = (layer: keyof MapLayers): string => {
-      if (layer === 'sanctions') return t('components.deckgl.layerHelp.labels.sanctions');
-      const key = layerLabelKeys[layer];
-      return key ? t(key) : layer;
-    };
-
     const MAX_SVG_LAYERS = 9;
     const enforceLayerLimit = () => {
       const allBtns = Array.from(toggles.querySelectorAll<HTMLButtonElement>('.layer-toggle'));
@@ -496,15 +472,37 @@ export class MapComponent {
     };
 
     layers.forEach((layer) => {
+      const layerLabel = this.getLayerControlLabel(layer);
+      const explainLabel = `Explain ${layerLabel} layer`;
+      const row = document.createElement('div');
+      row.className = 'layer-toggle-row';
+      row.dataset.layer = layer;
+
       const btn = document.createElement('button');
       btn.className = `layer-toggle ${this.state.layers[layer] ? 'active' : ''}`;
       btn.dataset.layer = layer;
-      btn.textContent = getLayerLabel(layer);
+      btn.textContent = layerLabel;
       btn.addEventListener('click', () => {
         this.toggleLayer(layer);
         enforceLayerLimit();
       });
-      toggles.appendChild(btn);
+      row.appendChild(btn);
+
+      const explainBtn = document.createElement('button');
+      explainBtn.type = 'button';
+      explainBtn.className = `layer-explain-btn ${hasCuratedLayerExplanation(layer) ? 'has-layer-explanation' : ''}`;
+      explainBtn.dataset.layer = layer;
+      explainBtn.textContent = 'i';
+      explainBtn.title = explainLabel;
+      explainBtn.setAttribute('aria-label', explainLabel);
+      explainBtn.addEventListener('click', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        this.showLayerExplanation(layer);
+      });
+      row.appendChild(explainBtn);
+
+      toggles.appendChild(row);
     });
 
     // Add help button
@@ -520,12 +518,105 @@ export class MapComponent {
     return toggles;
   }
 
+  private renderLayerExplanationCard(layerLabel: string, explanation: LayerExplanation): string {
+    const list = (items: string[]): string => items.map(item => `<li>${escapeHtml(item)}</li>`).join('');
+    const related = explanation.related.length > 0
+      ? explanation.related.map(item => `<span>${escapeHtml(item)}</span>`).join('')
+      : '<span>Layer guide</span>';
+    const evidence = explanation.evidence.length > 0
+      ? `<div class="layer-explanation-grounding"><span>Grounded in</span>${explanation.evidence.map(item => `<code>${escapeHtml(item)}</code>`).join('')}</div>`
+      : '';
+    const coverageLabel = explanation.coverage === 'curated' ? 'Curated v1' : 'Fallback';
+
+    return `
+      <div class="layer-explanation-header">
+        <div>
+          <span class="layer-explanation-kicker">${escapeHtml(explanation.category)}</span>
+          <strong>${escapeHtml(layerLabel)}</strong>
+        </div>
+        <button class="layer-explanation-close" aria-label="Close">×</button>
+      </div>
+      <div class="layer-explanation-content">
+        <div class="layer-explanation-status ${explanation.coverage}">${coverageLabel}</div>
+        <p class="layer-explanation-purpose">${escapeHtml(explanation.purpose)}</p>
+        <div class="layer-explanation-grid">
+          <section>
+            <span>Source</span>
+            <p>${escapeHtml(explanation.source)}</p>
+          </section>
+          <section>
+            <span>Freshness</span>
+            <p>${escapeHtml(explanation.freshness)}</p>
+          </section>
+          <section>
+            <span>Confidence</span>
+            <p>${escapeHtml(explanation.confidence)}</p>
+          </section>
+        </div>
+        <div class="layer-explanation-section">
+          <span>Limitations</span>
+          <ul>${list(explanation.limitations)}</ul>
+        </div>
+        <div class="layer-explanation-section">
+          <span>Related</span>
+          <div class="layer-explanation-related">${related}</div>
+        </div>
+        ${evidence}
+      </div>
+    `;
+  }
+
+  private showLayerExplanation(layer: keyof MapLayers): void {
+    const existing = this.container.querySelector('.layer-explanation-popup') as HTMLElement | null;
+    if (existing?.dataset.layer === layer) {
+      existing.remove();
+      this.container.querySelector(`.layer-explain-btn[data-layer="${layer}"]`)?.classList.remove('active');
+      return;
+    }
+    existing?.remove();
+    this.container.querySelector('.layer-help-popup')?.remove();
+    this.container.querySelectorAll('.layer-explain-btn.active').forEach(btn => btn.classList.remove('active'));
+
+    const popup = document.createElement('div');
+    popup.className = 'layer-explanation-popup';
+    popup.dataset.layer = layer;
+    setTrustedHtml(popup, trustedHtml(
+      this.renderLayerExplanationCard(this.getLayerControlLabel(layer), getLayerExplanation(layer)),
+      "static layer explanation metadata",
+    ));
+
+    const closePopup = (): void => {
+      popup.remove();
+      this.container.querySelector(`.layer-explain-btn[data-layer="${layer}"]`)?.classList.remove('active');
+    };
+
+    popup.querySelector('.layer-explanation-close')?.addEventListener('click', closePopup);
+    const content = popup.querySelector('.layer-explanation-content');
+    content?.addEventListener('wheel', (e) => e.stopPropagation(), { passive: false });
+    content?.addEventListener('touchmove', (e) => e.stopPropagation(), { passive: false });
+
+    setTimeout(() => {
+      const closeHandler = (e: MouseEvent) => {
+        if (!popup.contains(e.target as Node)) {
+          closePopup();
+          document.removeEventListener('click', closeHandler);
+        }
+      };
+      document.addEventListener('click', closeHandler);
+    }, 100);
+
+    this.container.appendChild(popup);
+    this.container.querySelector(`.layer-explain-btn[data-layer="${layer}"]`)?.classList.add('active');
+  }
+
   private showLayerHelp(): void {
     const existing = this.container.querySelector('.layer-help-popup');
     if (existing) {
       existing.remove();
       return;
     }
+    this.container.querySelector('.layer-explanation-popup')?.remove();
+    this.container.querySelectorAll('.layer-explain-btn.active').forEach(btn => btn.classList.remove('active'));
 
     const popup = document.createElement('div');
     popup.className = 'layer-help-popup';

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -385,6 +385,8 @@ export class MapComponent {
 
 
   private getLayerControlLabel(layer: keyof MapLayers): string {
+    if (layer === 'sanctions') return t('components.deckgl.layerHelp.labels.sanctions');
+
     const def = getLayersForVariant((SITE_VARIANT || 'full') as MapVariant, 'flat').find(item => item.key === layer);
     return def ? resolveLayerLabel(def, t) : String(layer);
   }

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -69,9 +69,9 @@ import {
   getLayersForVariant,
   hasCuratedLayerExplanation,
   resolveLayerLabel,
-  type LayerExplanation,
   type MapVariant,
 } from '@/config/map-layer-definitions';
+import { renderLayerExplanationCard } from '@/utils/layer-explanation-card';
 
 
 export type TimeRange = '1h' | '6h' | '24h' | '48h' | '7d' | 'all';
@@ -126,6 +126,7 @@ export class MapComponent {
   private clusterCanvas: HTMLCanvasElement;
   private clusterGl: WebGLRenderingContext | null = null;
   private state: MapState;
+  private layerExplanationOutsideClickHandler: ((event: MouseEvent) => void) | null = null;
   private worldData: WorldTopology | null = null;
   private countryFeatures: Feature<Geometry>[] | null = null;
   private isResizing = false;
@@ -518,56 +519,15 @@ export class MapComponent {
     return toggles;
   }
 
-  private renderLayerExplanationCard(layerLabel: string, explanation: LayerExplanation): string {
-    const list = (items: string[]): string => items.map(item => `<li>${escapeHtml(item)}</li>`).join('');
-    const related = explanation.related.length > 0
-      ? explanation.related.map(item => `<span>${escapeHtml(item)}</span>`).join('')
-      : '<span>Layer guide</span>';
-    const evidence = explanation.evidence.length > 0
-      ? `<div class="layer-explanation-grounding"><span>Grounded in</span>${explanation.evidence.map(item => `<code>${escapeHtml(item)}</code>`).join('')}</div>`
-      : '';
-    const coverageLabel = explanation.coverage === 'curated' ? 'Curated v1' : 'Fallback';
-
-    return `
-      <div class="layer-explanation-header">
-        <div>
-          <span class="layer-explanation-kicker">${escapeHtml(explanation.category)}</span>
-          <strong>${escapeHtml(layerLabel)}</strong>
-        </div>
-        <button class="layer-explanation-close" aria-label="Close">×</button>
-      </div>
-      <div class="layer-explanation-content">
-        <div class="layer-explanation-status ${explanation.coverage}">${coverageLabel}</div>
-        <p class="layer-explanation-purpose">${escapeHtml(explanation.purpose)}</p>
-        <div class="layer-explanation-grid">
-          <section>
-            <span>Source</span>
-            <p>${escapeHtml(explanation.source)}</p>
-          </section>
-          <section>
-            <span>Freshness</span>
-            <p>${escapeHtml(explanation.freshness)}</p>
-          </section>
-          <section>
-            <span>Confidence</span>
-            <p>${escapeHtml(explanation.confidence)}</p>
-          </section>
-        </div>
-        <div class="layer-explanation-section">
-          <span>Limitations</span>
-          <ul>${list(explanation.limitations)}</ul>
-        </div>
-        <div class="layer-explanation-section">
-          <span>Related</span>
-          <div class="layer-explanation-related">${related}</div>
-        </div>
-        ${evidence}
-      </div>
-    `;
+  private clearLayerExplanationOutsideClickHandler(): void {
+    if (!this.layerExplanationOutsideClickHandler) return;
+    document.removeEventListener('click', this.layerExplanationOutsideClickHandler);
+    this.layerExplanationOutsideClickHandler = null;
   }
 
   private showLayerExplanation(layer: keyof MapLayers): void {
     const existing = this.container.querySelector('.layer-explanation-popup') as HTMLElement | null;
+    this.clearLayerExplanationOutsideClickHandler();
     if (existing?.dataset.layer === layer) {
       existing.remove();
       this.container.querySelector(`.layer-explain-btn[data-layer="${layer}"]`)?.classList.remove('active');
@@ -581,11 +541,12 @@ export class MapComponent {
     popup.className = 'layer-explanation-popup';
     popup.dataset.layer = layer;
     setTrustedHtml(popup, trustedHtml(
-      this.renderLayerExplanationCard(this.getLayerControlLabel(layer), getLayerExplanation(layer)),
+      renderLayerExplanationCard(this.getLayerControlLabel(layer), getLayerExplanation(layer)),
       "static layer explanation metadata",
     ));
 
     const closePopup = (): void => {
+      this.clearLayerExplanationOutsideClickHandler();
       popup.remove();
       this.container.querySelector(`.layer-explain-btn[data-layer="${layer}"]`)?.classList.remove('active');
     };
@@ -599,9 +560,9 @@ export class MapComponent {
       const closeHandler = (e: MouseEvent) => {
         if (!popup.contains(e.target as Node)) {
           closePopup();
-          document.removeEventListener('click', closeHandler);
         }
       };
+      this.layerExplanationOutsideClickHandler = closeHandler;
       document.addEventListener('click', closeHandler);
     }, 100);
 
@@ -616,6 +577,7 @@ export class MapComponent {
       return;
     }
     this.container.querySelector('.layer-explanation-popup')?.remove();
+    this.clearLayerExplanationOutsideClickHandler();
     this.container.querySelectorAll('.layer-explain-btn.active').forEach(btn => btn.classList.remove('active'));
 
     const popup = document.createElement('div');

--- a/src/config/map-layer-definitions.ts
+++ b/src/config/map-layer-definitions.ts
@@ -171,7 +171,7 @@ export const LAYER_EXPLANATIONS: Partial<Record<keyof MapLayers, LayerExplanatio
     category: 'Country Risk',
     purpose: 'Colors countries by the current Country Instability Index score for broad strategic-risk triage.',
     source: 'WorldMonitor CII scoring service using conflict, unrest, advisories, cyber, AIS, aviation, natural-event, and news signals.',
-    freshness: 'Risk-score cache is designed for near-real-time refresh; seed-meta and health.riskScores expose whether coverage is live, stale, partial, or degraded.',
+    freshness: 'Risk-score cache is warm-pinged every 8 minutes; seed-meta and health.riskScores expose live, stale, partial, or degraded state against a 30-minute freshness budget.',
     confidence: 'Composite model signal, not an official country rating or probability forecast.',
     limitations: [
       'Sparse or degraded source families can reduce confidence even when a country still has a score.',
@@ -216,7 +216,7 @@ export const LAYER_EXPLANATIONS: Partial<Record<keyof MapLayers, LayerExplanatio
     category: 'Maritime',
     purpose: 'Shows vessel density and AIS disruption signals around strategic waters and chokepoints.',
     source: 'AISStream relay snapshots, WorldMonitor maritime service, and chokepoint disruption classifiers.',
-    freshness: 'AIS snapshots are documented at about 10 seconds when the relay is connected; the layer is disabled or stale when relay credentials/connectivity are unavailable.',
+    freshness: 'AIS relay snapshots are rebuilt every 5 seconds by default; the server may cache the base density snapshot for 5 minutes, and the layer is disabled or stale when relay credentials/connectivity are unavailable.',
     confidence: 'Useful for maritime anomaly screening, but AIS is self-reported and vessels can go dark.',
     limitations: [
       'Terrestrial AIS coverage is uneven, with weaker Middle East, Asia, and open-ocean visibility documented.',
@@ -231,7 +231,7 @@ export const LAYER_EXPLANATIONS: Partial<Record<keyof MapLayers, LayerExplanatio
     category: 'Maritime',
     purpose: 'Marks strategic waterways and chokepoints so disruption signals can be interpreted against fixed maritime geography.',
     source: 'WorldMonitor strategic-waterways registry with supply-chain chokepoint status overlays from AIS, NGA warnings, and PortWatch-derived feeds.',
-    freshness: 'Waterway locations are static; live chokepoint status is refreshed by the supply-chain cache/warm-ping path when available.',
+    freshness: 'Waterway locations are static; live chokepoint status is warm-pinged every 30 minutes and transit summaries refresh every 10 minutes when the relay/PortWatch path is healthy.',
     confidence: 'High for fixed geography; live disruption confidence depends on the companion AIS, NGA, and PortWatch feeds.',
     limitations: [
       'A visible chokepoint marker does not mean there is an active disruption.',
@@ -246,7 +246,7 @@ export const LAYER_EXPLANATIONS: Partial<Record<keyof MapLayers, LayerExplanatio
     category: 'Maritime',
     purpose: 'Draws major container, energy, and bulk routes through strategic chokepoints for disruption-path reasoning.',
     source: 'WorldMonitor trade-route registry plus supply-chain chokepoint status and transit summaries.',
-    freshness: 'Route geometry is static. Chokepoint status and transit summaries refresh independently through supply-chain caches and relay warm-pings.',
+    freshness: 'Route geometry is static. Chokepoint status is warm-pinged every 30 minutes and transit summaries refresh every 10 minutes through supply-chain caches and relay paths.',
     confidence: 'Good for route-level exposure context; not a ship-level routing feed.',
     limitations: [
       'Routes are modeled corridors and may not match a specific voyage plan.',
@@ -276,7 +276,7 @@ export const LAYER_EXPLANATIONS: Partial<Record<keyof MapLayers, LayerExplanatio
     category: 'News / Hotspots',
     purpose: 'Highlights monitored geopolitical hotspots and raises their level when related news and escalation signals converge.',
     source: 'WorldMonitor hotspot registry, RSS/GDELT news intelligence, hotspot escalation scoring, military activity, and CII context.',
-    freshness: 'Hotspot locations are curated/static. News feeds are freshness-tracked separately; RSS/GDELT cache expectations are documented around 5-10 minutes, with some GDELT intelligence seeds hourly.',
+    freshness: 'Hotspot locations are curated/static. News feeds are freshness-tracked separately; live-news RSS cache expectations are around 5 minutes, while GDELT intelligence has longer seeded/cache budgets.',
     confidence: 'Useful as a triage cue, not a citation-grade claim without opening the underlying news and country context.',
     limitations: [
       'News volume and keyword matching can overrepresent highly covered regions.',

--- a/src/config/map-layer-definitions.ts
+++ b/src/config/map-layer-definitions.ts
@@ -24,6 +24,21 @@ export interface LayerDefinition {
   deckGLOnly?: boolean;
 }
 
+export type LayerExplanationCoverage = 'curated' | 'fallback';
+
+export interface LayerExplanation {
+  key: keyof MapLayers;
+  coverage: LayerExplanationCoverage;
+  category: string;
+  purpose: string;
+  source: string;
+  freshness: string;
+  confidence: string;
+  limitations: string[];
+  related: string[];
+  evidence: string[];
+}
+
 const def = (
   key: keyof MapLayers,
   icon: string,
@@ -104,6 +119,172 @@ export const LAYER_REGISTRY: Record<keyof MapLayers, LayerDefinition> = {
   storageFacilities:        def('storageFacilities',        '&#127959;', 'storageFacilities',        'Storage Facilities', ['flat'], undefined, true),
   fuelShortages:            def('fuelShortages',            '&#9881;',   'fuelShortages',            'Fuel Shortages', ['flat'], undefined, true),
   liveTankers:              def('liveTankers',              '&#128674;', 'liveTankers',              'Live Tanker Positions', ['flat'], undefined, true),
+};
+
+export const V1_LAYER_EXPLANATION_KEYS = [
+  'conflicts',
+  'ucdpEvents',
+  'ciiChoropleth',
+  'natural',
+  'flights',
+  'ais',
+  'waterways',
+  'tradeRoutes',
+  'cyberThreats',
+  'hotspots',
+] as const satisfies readonly (keyof MapLayers)[];
+
+export const LAYER_EXPLANATIONS: Partial<Record<keyof MapLayers, LayerExplanation>> = {
+  conflicts: {
+    key: 'conflicts',
+    coverage: 'curated',
+    category: 'Conflict',
+    purpose: 'Shows curated conflict zones and geopolitical boundary overlays so analysts can orient live signals against known theaters.',
+    source: 'WorldMonitor conflict-zone registry, UCDP/ACLED conflict context, and documented boundary metadata such as the Korean DMZ.',
+    freshness: 'Base zones are curated/static. Dynamic conflict-event inputs are tracked separately through ACLED/UCDP feeds and health signals.',
+    confidence: 'Good for geographic orientation; not a real-time incident confirmation by itself.',
+    limitations: [
+      'Static zones can lag fast tactical changes.',
+      'Some conflict evidence appears in UCDP Events, CII, or related panels rather than as a conflict-zone polygon.',
+    ],
+    related: ['UCDP Events', 'CII panel', 'Strategic Risk', 'Country brief'],
+    evidence: ['docs/data-sources.mdx', 'docs/architecture.mdx', 'src/config/geo.ts'],
+  },
+  ucdpEvents: {
+    key: 'ucdpEvents',
+    coverage: 'curated',
+    category: 'Conflict',
+    purpose: 'Plots event-level armed conflict records with country, actors, date, and fatality ranges.',
+    source: 'Uppsala Conflict Data Program GED API via the conflict service and UCDP event seed.',
+    freshness: 'Seeded every 6 hours when the UCDP seed is healthy.',
+    confidence: 'Higher editorial consistency than raw breaking feeds, but intentionally lagging and not a live battlefield feed.',
+    limitations: [
+      'Annual/research-grade release cadence can miss very recent events.',
+      'Fatality ranges are estimates and should be interpreted as ranges, not exact counts.',
+    ],
+    related: ['UCDP Events panel', 'CII conflict component', 'Country timeline'],
+    evidence: ['docs/architecture.mdx', 'src/services/conflict/index.ts', 'scripts/seed-ucdp-events.mjs'],
+  },
+  ciiChoropleth: {
+    key: 'ciiChoropleth',
+    coverage: 'curated',
+    category: 'Country Risk',
+    purpose: 'Colors countries by the current Country Instability Index score for broad strategic-risk triage.',
+    source: 'WorldMonitor CII scoring service using conflict, unrest, advisories, cyber, AIS, aviation, natural-event, and news signals.',
+    freshness: 'Risk-score cache is designed for near-real-time refresh; seed-meta and health.riskScores expose whether coverage is live, stale, partial, or degraded.',
+    confidence: 'Composite model signal, not an official country rating or probability forecast.',
+    limitations: [
+      'Sparse or degraded source families can reduce confidence even when a country still has a score.',
+      'Country-level color can hide subnational variation and should be checked against panels before citation.',
+    ],
+    related: ['CII panel', 'Strategic Risk panel', 'Data freshness status', 'Country brief'],
+    evidence: ['docs/strategic-risk.mdx', 'docs/architecture.mdx', 'src/services/cached-risk-scores.ts'],
+  },
+  natural: {
+    key: 'natural',
+    coverage: 'curated',
+    category: 'Natural Disasters',
+    purpose: 'Shows earthquakes, severe disaster alerts, and active Earth-observation events for situational awareness.',
+    source: 'USGS earthquakes, GDACS alerts, and NASA EONET events merged into the natural events service.',
+    freshness: 'Natural events are seeded every 10 minutes; USGS earthquake expectations are documented at roughly 5-minute source cadence.',
+    confidence: 'Strong for detected public disaster signals; confidence varies by hazard type and upstream reporting latency.',
+    limitations: [
+      'Low-severity GDACS alerts are filtered out to keep the map readable.',
+      'EONET wildfires are freshness-filtered, so older open events may not appear as active map points.',
+    ],
+    related: ['Natural Events layer popups', 'Weather Alerts', 'Country brief natural signals'],
+    evidence: ['docs/data-sources.mdx', 'docs/architecture.mdx', 'server/worldmonitor/natural/v1/list-natural-events.ts'],
+  },
+  flights: {
+    key: 'flights',
+    coverage: 'curated',
+    category: 'Aviation',
+    purpose: 'Highlights airport disruption, closures, NOTAM-derived airspace issues, and live aircraft positions when tracking is available.',
+    source: 'FAA ASWS, AviationStack, ICAO NOTAMs, OpenSky/Wingbits aircraft tracking, and the aviation service.',
+    freshness: 'Airport disruption seeds run on a 10-minute cadence; the aviation panel also refreshes operational views on a 5-minute polling cycle.',
+    confidence: 'Best for disruption triage; individual live aircraft coverage depends on ADS-B availability and configured providers.',
+    limitations: [
+      'AviationStack-backed simulated demo data can appear when an API key is absent.',
+      'Live aircraft positions can be delayed or absent where ADS-B coverage is weak or blocked.',
+    ],
+    related: ['Airline Intel panel', 'Aviation command bar', 'Country brief aviation signals'],
+    evidence: ['docs/data-sources.mdx', 'docs/architecture.mdx', 'src/services/aviation/index.ts', 'scripts/seed-aviation.mjs'],
+  },
+  ais: {
+    key: 'ais',
+    coverage: 'curated',
+    category: 'Maritime',
+    purpose: 'Shows vessel density and AIS disruption signals around strategic waters and chokepoints.',
+    source: 'AISStream relay snapshots, WorldMonitor maritime service, and chokepoint disruption classifiers.',
+    freshness: 'AIS snapshots are documented at about 10 seconds when the relay is connected; the layer is disabled or stale when relay credentials/connectivity are unavailable.',
+    confidence: 'Useful for maritime anomaly screening, but AIS is self-reported and vessels can go dark.',
+    limitations: [
+      'Terrestrial AIS coverage is uneven, with weaker Middle East, Asia, and open-ocean visibility documented.',
+      'Dark shipping is inferred from gaps and congestion patterns, not direct proof of intent.',
+    ],
+    related: ['Supply Chain panel', 'Chokepoint strip', 'Military vessels', 'Country brief AIS signals'],
+    evidence: ['docs/features.mdx', 'docs/architecture.mdx', 'src/services/maritime/index.ts', 'scripts/ais-relay.cjs'],
+  },
+  waterways: {
+    key: 'waterways',
+    coverage: 'curated',
+    category: 'Maritime',
+    purpose: 'Marks strategic waterways and chokepoints so disruption signals can be interpreted against fixed maritime geography.',
+    source: 'WorldMonitor strategic-waterways registry with supply-chain chokepoint status overlays from AIS, NGA warnings, and PortWatch-derived feeds.',
+    freshness: 'Waterway locations are static; live chokepoint status is refreshed by the supply-chain cache/warm-ping path when available.',
+    confidence: 'High for fixed geography; live disruption confidence depends on the companion AIS, NGA, and PortWatch feeds.',
+    limitations: [
+      'A visible chokepoint marker does not mean there is an active disruption.',
+      'Area geofences and modeled routes can simplify complex traffic patterns.',
+    ],
+    related: ['Supply Chain panel', 'Trade Routes layer', 'Route Explorer', 'Scenario Engine'],
+    evidence: ['docs/architecture.mdx', 'docs/data-sources.mdx', 'src/config/geo.ts', 'server/worldmonitor/supply-chain/v1/get-chokepoint-status.ts'],
+  },
+  tradeRoutes: {
+    key: 'tradeRoutes',
+    coverage: 'curated',
+    category: 'Maritime',
+    purpose: 'Draws major container, energy, and bulk routes through strategic chokepoints for disruption-path reasoning.',
+    source: 'WorldMonitor trade-route registry plus supply-chain chokepoint status and transit summaries.',
+    freshness: 'Route geometry is static. Chokepoint status and transit summaries refresh independently through supply-chain caches and relay warm-pings.',
+    confidence: 'Good for route-level exposure context; not a ship-level routing feed.',
+    limitations: [
+      'Routes are modeled corridors and may not match a specific voyage plan.',
+      'Disruption overlays depend on current chokepoint and AIS health.',
+    ],
+    related: ['Supply Chain panel', 'Route Explorer', 'Scenario Engine', 'Waterways layer'],
+    evidence: ['docs/data-sources.mdx', 'docs/architecture.mdx', 'src/config/trade-routes.ts', 'src/services/supply-chain/index.ts'],
+  },
+  cyberThreats: {
+    key: 'cyberThreats',
+    coverage: 'curated',
+    category: 'Cyber',
+    purpose: 'Maps geo-enriched indicators of compromise such as C2 servers, malware hosts, phishing, malicious URLs, and ransomware infrastructure.',
+    source: 'abuse.ch Feodo Tracker and URLhaus, C2IntelFeeds, AlienVault OTX, AbuseIPDB, ransomware.live, and IP geolocation enrichment.',
+    freshness: 'Cyber threat seeds run every 10 minutes; displayed IOCs use a 14-day rolling window and are capped for map performance.',
+    confidence: 'Good for infrastructure visibility, but attribution and IP geolocation can be noisy.',
+    limitations: [
+      'IP geolocation can point to hosting infrastructure rather than an operator or victim.',
+      'Feed availability, API keys, and per-feed abuse reports can bias coverage.',
+    ],
+    related: ['Cyber Threats map popups', 'CII cyber supplemental boost', 'Data freshness status'],
+    evidence: ['docs/data-sources.mdx', 'docs/architecture.mdx', 'scripts/seed-cyber-threats.mjs', 'server/worldmonitor/cyber/v1/list-cyber-threats.ts'],
+  },
+  hotspots: {
+    key: 'hotspots',
+    coverage: 'curated',
+    category: 'News / Hotspots',
+    purpose: 'Highlights monitored geopolitical hotspots and raises their level when related news and escalation signals converge.',
+    source: 'WorldMonitor hotspot registry, RSS/GDELT news intelligence, hotspot escalation scoring, military activity, and CII context.',
+    freshness: 'Hotspot locations are curated/static. News feeds are freshness-tracked separately; RSS/GDELT cache expectations are documented around 5-10 minutes, with some GDELT intelligence seeds hourly.',
+    confidence: 'Useful as a triage cue, not a citation-grade claim without opening the underlying news and country context.',
+    limitations: [
+      'News volume and keyword matching can overrepresent highly covered regions.',
+      'Low-profile events may be missed when RSS/GDELT coverage is sparse or delayed.',
+    ],
+    related: ['Live News panel', 'Strategic Risk panel', 'Country brief', 'Hotspot popups'],
+    evidence: ['docs/data-sources.mdx', 'docs/architecture.mdx', 'src/config/geo.ts', 'src/services/hotspot-escalation.ts'],
+  },
 };
 
 const VARIANT_LAYER_ORDER: Record<MapVariant, Array<keyof MapLayers>> = {
@@ -276,6 +457,31 @@ export function resolveLayerLabel(def: LayerDefinition, tFn?: (key: string) => s
   return def.fallbackLabel;
 }
 
+export function hasCuratedLayerExplanation(layerKey: keyof MapLayers): boolean {
+  return LAYER_EXPLANATIONS[layerKey]?.coverage === 'curated';
+}
+
+export function getLayerExplanation(layerKey: keyof MapLayers): LayerExplanation {
+  const curated = LAYER_EXPLANATIONS[layerKey];
+  if (curated) return curated;
+
+  return {
+    key: layerKey,
+    coverage: 'fallback',
+    category: 'Layer',
+    purpose: 'This layer can be toggled on the map, but a curated source and confidence card has not been added yet.',
+    source: 'Not curated in the v1 layer-explainability set.',
+    freshness: 'No layer-level freshness contract is declared here. Check the visible panel badges, popups, or data freshness status when available.',
+    confidence: 'Unknown until source-specific metadata is added.',
+    limitations: [
+      'The lack of a curated card does not mean the layer is unsupported.',
+      'Use layer popups and related panels for source-specific context.',
+    ],
+    related: ['Layer guide'],
+    evidence: [],
+  };
+}
+
 export function bindLayerSearch(container: HTMLElement): void {
   const searchInput = container.querySelector('.layer-search') as HTMLInputElement | null;
   if (!searchInput) return;
@@ -290,11 +496,13 @@ export function bindLayerSearch(container: HTMLElement): void {
     container.querySelectorAll('.layer-toggle').forEach(label => {
       const el = label as HTMLElement;
       if (el.hasAttribute('data-layer-hidden')) return;
-      if (!q) { el.style.display = ''; return; }
+      const row = el.closest('.layer-toggle-row') as HTMLElement | null;
+      const displayTarget = row ?? el;
+      if (!q) { displayTarget.style.display = ''; return; }
       const key = label.getAttribute('data-layer') || '';
       const text = label.textContent?.toLowerCase() || '';
       const match = text.includes(q) || key.toLowerCase().includes(q) || synonymHits.has(key);
-      el.style.display = match ? '' : 'none';
+      displayTarget.style.display = match ? '' : 'none';
     });
   });
 }

--- a/src/config/map-layer-definitions.ts
+++ b/src/config/map-layer-definitions.ts
@@ -186,7 +186,7 @@ export const LAYER_EXPLANATIONS: Partial<Record<keyof MapLayers, LayerExplanatio
     category: 'Natural Disasters',
     purpose: 'Shows earthquakes, severe disaster alerts, and active Earth-observation events for situational awareness.',
     source: 'USGS earthquakes, GDACS alerts, and NASA EONET events merged into the natural events service.',
-    freshness: 'Natural events are seeded every 10 minutes; USGS earthquake expectations are documented at roughly 5-minute source cadence.',
+    freshness: 'Natural events are seeded every 2 hours; USGS earthquake expectations are documented at roughly 5-minute source cadence.',
     confidence: 'Strong for detected public disaster signals; confidence varies by hazard type and upstream reporting latency.',
     limitations: [
       'Low-severity GDACS alerts are filtered out to keep the map readable.',
@@ -201,7 +201,7 @@ export const LAYER_EXPLANATIONS: Partial<Record<keyof MapLayers, LayerExplanatio
     category: 'Aviation',
     purpose: 'Highlights airport disruption, closures, NOTAM-derived airspace issues, and live aircraft positions when tracking is available.',
     source: 'FAA ASWS, AviationStack, ICAO NOTAMs, OpenSky/Wingbits aircraft tracking, and the aviation service.',
-    freshness: 'Airport disruption seeds run on a 10-minute cadence; the aviation panel also refreshes operational views on a 5-minute polling cycle.',
+    freshness: 'Airport disruption seeds run on a 30-minute cadence; the aviation panel also refreshes operational views on a 5-minute polling cycle.',
     confidence: 'Best for disruption triage; individual live aircraft coverage depends on ADS-B availability and configured providers.',
     limitations: [
       'AviationStack-backed simulated demo data can appear when an API key is absent.',
@@ -260,8 +260,8 @@ export const LAYER_EXPLANATIONS: Partial<Record<keyof MapLayers, LayerExplanatio
     coverage: 'curated',
     category: 'Cyber',
     purpose: 'Maps geo-enriched indicators of compromise such as C2 servers, malware hosts, phishing, malicious URLs, and ransomware infrastructure.',
-    source: 'abuse.ch Feodo Tracker and URLhaus, C2IntelFeeds, AlienVault OTX, AbuseIPDB, ransomware.live, and IP geolocation enrichment.',
-    freshness: 'Cyber threat seeds run every 10 minutes; displayed IOCs use a 14-day rolling window and are capped for map performance.',
+    source: 'abuse.ch Feodo Tracker and URLhaus, C2IntelFeeds, AlienVault OTX, AbuseIPDB, ransomware.live RSS/news feed, and IP geolocation enrichment.',
+    freshness: 'Cyber threat seeds run every 2 hours; displayed IOCs use a 14-day rolling window and are capped for map performance.',
     confidence: 'Good for infrastructure visibility, but attribution and IP geolocation can be noisy.',
     limitations: [
       'IP geolocation can point to hosting infrastructure rather than an operator or victim.',

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4407,6 +4407,13 @@ body.playback-mode .status-dot {
   max-width: 300px;
 }
 
+.layer-toggles:not(.deckgl-layer-toggles) .layer-toggle-row {
+  display: flex;
+  align-items: stretch;
+  gap: 2px;
+  min-width: 0;
+}
+
 .layer-toggles:not(.deckgl-layer-toggles) .layer-toggle {
   padding: 3px 8px;
   background: var(--bg);
@@ -4418,6 +4425,11 @@ body.playback-mode .status-dot {
   text-transform: uppercase;
   position: relative;
   transition: color 0.2s ease, border-color 0.2s ease, opacity 0.2s ease;
+}
+
+.layer-toggles:not(.deckgl-layer-toggles) .layer-toggle-row .layer-toggle {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .layer-toggles:not(.deckgl-layer-toggles) .layer-toggle.active {
@@ -4445,6 +4457,35 @@ body.playback-mode .status-dot {
   animation: layer-loading 0.8s ease-in-out infinite;
   border-color: var(--yellow);
   color: var(--yellow);
+}
+
+.layer-toggles:not(.deckgl-layer-toggles) .layer-explain-btn {
+  width: 18px;
+  min-width: 18px;
+  padding: 0;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  color: var(--text-dim);
+  font-family: inherit;
+  font-size: 9px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.layer-toggles:not(.deckgl-layer-toggles) .layer-explain-btn.has-layer-explanation {
+  color: var(--accent);
+  border-color: rgba(0, 212, 255, 0.45);
+}
+
+.layer-toggles:not(.deckgl-layer-toggles) .layer-explain-btn:hover,
+.layer-toggles:not(.deckgl-layer-toggles) .layer-explain-btn:focus-visible,
+.layer-toggles:not(.deckgl-layer-toggles) .layer-explain-btn.active {
+  color: var(--green);
+  border-color: var(--green);
+  background: var(--overlay-subtle);
+  outline: none;
 }
 
 @keyframes layer-loading {
@@ -15669,6 +15710,13 @@ a.prediction-link:hover {
   display: none;
 }
 
+.deckgl-layer-toggles .layer-toggle-row {
+  display: flex;
+  align-items: stretch;
+  gap: 4px;
+  min-width: 0;
+}
+
 .deckgl-layer-toggles .layer-search {
   width: calc(100% - 16px);
   margin: 4px 8px;
@@ -15693,6 +15741,8 @@ a.prediction-link:hover {
   display: flex;
   align-items: center;
   gap: 6px;
+  flex: 1 1 auto;
+  min-width: 0;
   padding: 5px 8px;
   cursor: pointer;
   border-radius: 3px;
@@ -15797,6 +15847,212 @@ a.prediction-link:hover {
 
 .deckgl-layer-toggles .layer-toggle.has-data {
   border-color: rgba(68, 255, 136, 0.2);
+}
+
+.deckgl-layer-toggles .layer-explain-btn {
+  width: 22px;
+  min-width: 22px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: var(--bg);
+  color: var(--text-dim);
+  font-family: inherit;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.deckgl-layer-toggles .layer-explain-btn.has-layer-explanation {
+  color: var(--accent);
+  border-color: rgba(0, 212, 255, 0.45);
+}
+
+.deckgl-layer-toggles .layer-explain-btn:hover,
+.deckgl-layer-toggles .layer-explain-btn:focus-visible,
+.deckgl-layer-toggles .layer-explain-btn.active {
+  color: var(--green);
+  border-color: var(--green);
+  background: var(--overlay-subtle);
+  outline: none;
+}
+
+.layer-explanation-popup {
+  position: absolute;
+  bottom: 10px;
+  left: 282px;
+  width: min(380px, calc(100vw - 310px));
+  max-height: min(70vh, 640px);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  z-index: 210;
+  overflow: hidden;
+  box-shadow: 0 8px 32px var(--shadow-color);
+}
+
+.layer-explanation-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+}
+
+.layer-explanation-header strong {
+  display: block;
+  margin-top: 2px;
+  color: var(--text);
+  font-size: 13px;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+
+.layer-explanation-kicker {
+  display: block;
+  color: var(--accent);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+}
+
+.layer-explanation-close {
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.layer-explanation-close:hover,
+.layer-explanation-close:focus-visible {
+  color: var(--accent);
+  outline: none;
+}
+
+.layer-explanation-content {
+  max-height: calc(min(70vh, 640px) - 48px);
+  overflow-y: auto;
+  padding: 10px 12px 12px;
+}
+
+.layer-explanation-status {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  margin-bottom: 8px;
+  padding: 2px 6px;
+  border: 1px solid rgba(68, 255, 136, 0.35);
+  border-radius: 3px;
+  color: var(--green);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+}
+
+.layer-explanation-status.fallback {
+  border-color: rgba(255, 193, 7, 0.35);
+  color: var(--yellow);
+}
+
+.layer-explanation-purpose {
+  margin: 0 0 10px;
+  color: var(--text);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.layer-explanation-grid {
+  display: grid;
+  gap: 8px;
+}
+
+.layer-explanation-grid section,
+.layer-explanation-section {
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.layer-explanation-grid span,
+.layer-explanation-section > span,
+.layer-explanation-grounding > span {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--accent);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+}
+
+.layer-explanation-grid p {
+  margin: 0;
+  color: var(--text-dim);
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.layer-explanation-section {
+  margin-top: 8px;
+}
+
+.layer-explanation-section ul {
+  margin: 0;
+  padding-left: 16px;
+}
+
+.layer-explanation-section li {
+  margin: 3px 0;
+  color: var(--text-dim);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.layer-explanation-related {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.layer-explanation-related span {
+  padding: 2px 6px;
+  border: 1px solid rgba(0, 212, 255, 0.28);
+  border-radius: 3px;
+  color: var(--text);
+  font-size: 10px;
+}
+
+.layer-explanation-grounding {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 8px;
+  color: var(--text-dim);
+}
+
+.layer-explanation-grounding > span {
+  flex-basis: 100%;
+  margin-bottom: 0;
+}
+
+.layer-explanation-grounding code {
+  padding: 2px 5px;
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  color: var(--text-dim);
+  font-size: 9px;
 }
 
 /* Pro early-access banner */
@@ -16246,6 +16502,11 @@ a.prediction-link:hover {
     max-width: 180px;
   }
 
+  .layer-explanation-popup {
+    left: 202px;
+    width: min(360px, calc(100vw - 230px));
+  }
+
   .deckgl-legend {
     padding: 4px 10px;
     gap: 8px;
@@ -16259,6 +16520,14 @@ a.prediction-link:hover {
 
 /* Mobile: prevent horizontal overflow from deck.gl legend */
 @media (max-width: 520px) {
+  .layer-explanation-popup {
+    right: 10px;
+    bottom: 96px;
+    left: 10px;
+    width: auto;
+    max-height: 60vh;
+  }
+
   .deckgl-legend {
     left: 8px;
     right: 8px;

--- a/src/utils/layer-explanation-card.ts
+++ b/src/utils/layer-explanation-card.ts
@@ -1,0 +1,50 @@
+import type { LayerExplanation } from '@/config/map-layer-definitions';
+import { escapeHtml } from '@/utils/sanitize';
+
+export function renderLayerExplanationCard(layerLabel: string, explanation: LayerExplanation): string {
+  const list = (items: string[]): string => items.map(item => `<li>${escapeHtml(item)}</li>`).join('');
+  const related = explanation.related.length > 0
+    ? explanation.related.map(item => `<span>${escapeHtml(item)}</span>`).join('')
+    : '<span>Layer guide</span>';
+  const evidence = explanation.evidence.length > 0
+    ? `<div class="layer-explanation-grounding"><span>Grounded in</span>${explanation.evidence.map(item => `<code>${escapeHtml(item)}</code>`).join('')}</div>`
+    : '';
+  const coverageLabel = explanation.coverage === 'curated' ? 'Curated v1' : 'Fallback';
+
+  return `
+    <div class="layer-explanation-header">
+      <div>
+        <span class="layer-explanation-kicker">${escapeHtml(explanation.category)}</span>
+        <strong>${escapeHtml(layerLabel)}</strong>
+      </div>
+      <button class="layer-explanation-close" aria-label="Close">×</button>
+    </div>
+    <div class="layer-explanation-content">
+      <div class="layer-explanation-status ${explanation.coverage}">${coverageLabel}</div>
+      <p class="layer-explanation-purpose">${escapeHtml(explanation.purpose)}</p>
+      <div class="layer-explanation-grid">
+        <section>
+          <span>Source</span>
+          <p>${escapeHtml(explanation.source)}</p>
+        </section>
+        <section>
+          <span>Freshness</span>
+          <p>${escapeHtml(explanation.freshness)}</p>
+        </section>
+        <section>
+          <span>Confidence</span>
+          <p>${escapeHtml(explanation.confidence)}</p>
+        </section>
+      </div>
+      <div class="layer-explanation-section">
+        <span>Limitations</span>
+        <ul>${list(explanation.limitations)}</ul>
+      </div>
+      <div class="layer-explanation-section">
+        <span>Related</span>
+        <div class="layer-explanation-related">${related}</div>
+      </div>
+      ${evidence}
+    </div>
+  `;
+}

--- a/tests/layer-explanations.test.mts
+++ b/tests/layer-explanations.test.mts
@@ -1,0 +1,112 @@
+import { strict as assert } from 'node:assert';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, test } from 'node:test';
+import {
+  getLayerExplanation,
+  hasCuratedLayerExplanation,
+  LAYER_EXPLANATIONS,
+  LAYER_REGISTRY,
+  V1_LAYER_EXPLANATION_KEYS,
+} from '../src/config/map-layer-definitions';
+
+const root = resolve(import.meta.dirname, '..');
+
+describe('layer explanation metadata', () => {
+  test('v1 high-adoption layers have curated structured cards', () => {
+    const expected = new Set([
+      'conflicts',
+      'ucdpEvents',
+      'ciiChoropleth',
+      'natural',
+      'flights',
+      'ais',
+      'waterways',
+      'tradeRoutes',
+      'cyberThreats',
+      'hotspots',
+    ]);
+
+    assert.deepEqual(new Set(V1_LAYER_EXPLANATION_KEYS), expected);
+
+    for (const key of V1_LAYER_EXPLANATION_KEYS) {
+      assert.ok(LAYER_REGISTRY[key], `${key} must be a registered layer`);
+      assert.equal(hasCuratedLayerExplanation(key), true, `${key} must have curated metadata`);
+
+      const explanation = getLayerExplanation(key);
+      assert.equal(explanation.coverage, 'curated', `${key} must not use fallback metadata`);
+      assert.equal(explanation.key, key);
+      assert.ok(explanation.category.trim(), `${key} category is required`);
+      assert.ok(explanation.purpose.trim(), `${key} purpose is required`);
+      assert.ok(explanation.source.trim(), `${key} source/provider text is required`);
+      assert.ok(explanation.freshness.trim(), `${key} freshness text is required`);
+      assert.ok(explanation.confidence.trim(), `${key} confidence text is required`);
+      assert.ok(explanation.limitations.length > 0, `${key} limitations are required`);
+      assert.ok(explanation.related.length > 0, `${key} related panels/actions are required`);
+      assert.ok(explanation.evidence.length > 0, `${key} evidence paths are required`);
+
+      for (const evidencePath of explanation.evidence) {
+        assert.equal(
+          existsSync(resolve(root, evidencePath)),
+          true,
+          `${key} evidence path does not exist: ${evidencePath}`,
+        );
+      }
+    }
+  });
+
+  test('unsupported layers degrade to fallback metadata without fabricating freshness', () => {
+    const explanation = getLayerExplanation('dayNight');
+
+    assert.equal(explanation.coverage, 'fallback');
+    assert.equal(explanation.key, 'dayNight');
+    assert.equal(hasCuratedLayerExplanation('dayNight'), false);
+    assert.match(explanation.source, /Not curated/i);
+    assert.match(explanation.freshness, /No layer-level freshness contract/i);
+    assert.match(explanation.confidence, /Unknown/i);
+    assert.deepEqual(explanation.evidence, []);
+  });
+
+  test('curated explanations are not accidentally added outside the declared v1 set', () => {
+    const declared = new Set<string>(V1_LAYER_EXPLANATION_KEYS);
+    const curated = Object.entries(LAYER_EXPLANATIONS)
+      .filter(([, explanation]) => explanation?.coverage === 'curated')
+      .map(([key]) => key);
+
+    assert.deepEqual(new Set(curated), declared);
+  });
+});
+
+describe('map layer explanation control wiring', () => {
+  const componentSources = new Map([
+    ['SVG map', readFileSync(resolve(root, 'src/components/Map.ts'), 'utf8')],
+    ['DeckGL map', readFileSync(resolve(root, 'src/components/DeckGLMap.ts'), 'utf8')],
+    ['Globe map', readFileSync(resolve(root, 'src/components/GlobeMap.ts'), 'utf8')],
+  ]);
+
+  test('layer pickers render an explanation button for each layer row', () => {
+    for (const [name, source] of componentSources) {
+      assert.match(source, /layer-toggle-row/, `${name} must keep the layer and explanation controls grouped`);
+      assert.match(source, /layer-explain-btn/, `${name} must render explanation buttons`);
+      assert.match(source, /aria-label/, `${name} explanation buttons must be screen-reader labeled`);
+      assert.match(source, /hasCuratedLayerExplanation/, `${name} must distinguish curated coverage`);
+    }
+  });
+
+  test('info button opens the structured explanation card without toggling the layer', () => {
+    for (const [name, source] of componentSources) {
+      assert.match(source, /event\.preventDefault\(\)/, `${name} must not submit or trigger parent controls`);
+      assert.match(source, /event\.stopPropagation\(\)/, `${name} must not toggle the layer when opening help`);
+      assert.match(source, /this\.showLayerExplanation\(layer\)/, `${name} must open the explanation card`);
+      assert.match(source, /getLayerExplanation\(layer\)/, `${name} must use the shared explanation catalog`);
+    }
+  });
+
+  test('explanation card exposes source, freshness, confidence, limitations, and related sections', () => {
+    for (const [name, source] of componentSources) {
+      for (const label of ['Source', 'Freshness', 'Confidence', 'Limitations', 'Related']) {
+        assert.match(source, new RegExp(`>${label}<`), `${name} missing card section: ${label}`);
+      }
+    }
+  });
+});

--- a/tests/layer-explanations.test.mts
+++ b/tests/layer-explanations.test.mts
@@ -67,6 +67,28 @@ describe('layer explanation metadata', () => {
     assert.deepEqual(explanation.evidence, []);
   });
 
+  test('curated freshness text uses seed cadence rather than gateway cache TTLs', () => {
+    const natural = getLayerExplanation('natural');
+    const flights = getLayerExplanation('flights');
+    const cyberThreats = getLayerExplanation('cyberThreats');
+
+    assert.match(natural.freshness, /seeded every 2 hours/i);
+    assert.doesNotMatch(natural.freshness, /10 minutes/i);
+
+    assert.match(flights.freshness, /30-minute cadence/i);
+    assert.doesNotMatch(flights.freshness, /10-minute cadence/i);
+
+    assert.match(cyberThreats.freshness, /every 2 hours/i);
+    assert.doesNotMatch(cyberThreats.freshness, /every 10 minutes/i);
+  });
+
+  test('cyber source text distinguishes ransomware.live news from geo-enriched IOCs', () => {
+    const cyberThreats = getLayerExplanation('cyberThreats');
+
+    assert.match(cyberThreats.source, /ransomware\.live RSS\/news feed/i);
+    assert.match(cyberThreats.source, /IP geolocation enrichment/i);
+  });
+
   test('curated explanations are not accidentally added outside the declared v1 set', () => {
     const declared = new Set<string>(V1_LAYER_EXPLANATION_KEYS);
     const curated = Object.entries(LAYER_EXPLANATIONS)
@@ -123,5 +145,12 @@ describe('map layer explanation control wiring', () => {
     assert.match(source, /layerExplanationOutsideClickHandler/);
     assert.match(source, /clearLayerExplanationOutsideClickHandler\(\)/);
     assert.match(source, /document\.removeEventListener\('click', this\.layerExplanationOutsideClickHandler\)/);
+  });
+
+  test('SVG map preserves the localized sanctions label path', () => {
+    const source = componentSources.get('SVG map');
+    assert.ok(source);
+    assert.match(source, /layer === 'sanctions'/);
+    assert.match(source, /components\.deckgl\.layerHelp\.labels\.sanctions/);
   });
 });

--- a/tests/layer-explanations.test.mts
+++ b/tests/layer-explanations.test.mts
@@ -83,6 +83,7 @@ describe('map layer explanation control wiring', () => {
     ['DeckGL map', readFileSync(resolve(root, 'src/components/DeckGLMap.ts'), 'utf8')],
     ['Globe map', readFileSync(resolve(root, 'src/components/GlobeMap.ts'), 'utf8')],
   ]);
+  const rendererSource = readFileSync(resolve(root, 'src/utils/layer-explanation-card.ts'), 'utf8');
 
   test('layer pickers render an explanation button for each layer row', () => {
     for (const [name, source] of componentSources) {
@@ -99,14 +100,28 @@ describe('map layer explanation control wiring', () => {
       assert.match(source, /event\.stopPropagation\(\)/, `${name} must not toggle the layer when opening help`);
       assert.match(source, /this\.showLayerExplanation\(layer\)/, `${name} must open the explanation card`);
       assert.match(source, /getLayerExplanation\(layer\)/, `${name} must use the shared explanation catalog`);
+      assert.match(source, /renderLayerExplanationCard/, `${name} must use the shared explanation renderer`);
     }
   });
 
   test('explanation card exposes source, freshness, confidence, limitations, and related sections', () => {
-    for (const [name, source] of componentSources) {
-      for (const label of ['Source', 'Freshness', 'Confidence', 'Limitations', 'Related']) {
-        assert.match(source, new RegExp(`>${label}<`), `${name} missing card section: ${label}`);
-      }
+    for (const label of ['Source', 'Freshness', 'Confidence', 'Limitations', 'Related']) {
+      assert.match(rendererSource, new RegExp(`>${label}<`), `missing shared card section: ${label}`);
     }
+  });
+
+  test('DeckGL help and explanation popups dismiss each other', () => {
+    const source = componentSources.get('DeckGL map');
+    assert.ok(source);
+    assert.match(source, /querySelector\('\.layer-help-popup'\)\?\.remove\(\)/);
+    assert.match(source, /querySelector\('\.layer-explanation-popup'\)\?\.remove\(\)/);
+  });
+
+  test('SVG map clears stale outside-click listeners when explanation popups close or switch', () => {
+    const source = componentSources.get('SVG map');
+    assert.ok(source);
+    assert.match(source, /layerExplanationOutsideClickHandler/);
+    assert.match(source, /clearLayerExplanationOutsideClickHandler\(\)/);
+    assert.match(source, /document\.removeEventListener\('click', this\.layerExplanationOutsideClickHandler\)/);
   });
 });

--- a/tests/layer-explanations.test.mts
+++ b/tests/layer-explanations.test.mts
@@ -9,8 +9,104 @@ import {
   LAYER_REGISTRY,
   V1_LAYER_EXPLANATION_KEYS,
 } from '../src/config/map-layer-definitions';
+import { renderLayerExplanationCard } from '../src/utils/layer-explanation-card';
 
 const root = resolve(import.meta.dirname, '..');
+const relaySource = readFileSync(resolve(root, 'scripts/ais-relay.cjs'), 'utf8');
+const healthSource = readFileSync(resolve(root, 'api/health.js'), 'utf8');
+
+function evalNumberExpression(expression: string): number {
+  const cleaned = expression.replace(/_/g, '');
+  assert.match(cleaned, /^[0-9\s()+*/.-]+$/, `unsafe numeric expression: ${expression}`);
+  const value = Function(`"use strict"; return (${cleaned});`)();
+  assert.equal(typeof value, 'number', `expression did not evaluate to a number: ${expression}`);
+  assert.ok(Number.isFinite(value), `expression did not evaluate to a finite number: ${expression}`);
+  return value;
+}
+
+function readSource(path: string): string {
+  return readFileSync(resolve(root, path), 'utf8');
+}
+
+function constNumber(path: string, name: string): number {
+  const source = readSource(path);
+  const match = source.match(new RegExp(`const\\s+${name}\\s*=\\s*([^;\\n]+);`));
+  assert.ok(match, `${path} must define ${name}`);
+  return evalNumberExpression(match[1]);
+}
+
+function relayConstMinutes(name: string): number {
+  const match = relaySource.match(new RegExp(`const\\s+${name}\\s*=\\s*([^;\\n]+);`));
+  assert.ok(match, `scripts/ais-relay.cjs must define ${name}`);
+  return evalNumberExpression(match[1]) / 60_000;
+}
+
+function relayFunctionConstNumber(functionName: string, name: string): number {
+  const start = relaySource.indexOf(`async function ${functionName}(`);
+  assert.notEqual(start, -1, `scripts/ais-relay.cjs must define ${functionName}()`);
+  const nextFunction = relaySource.indexOf('\nasync function ', start + 1);
+  const body = relaySource.slice(start, nextFunction === -1 ? undefined : nextFunction);
+  const match = body.match(new RegExp(`const\\s+${name}\\s*=\\s*([^;\\n]+);`));
+  assert.ok(match, `scripts/ais-relay.cjs ${functionName}() must define ${name}`);
+  return evalNumberExpression(match[1]);
+}
+
+function cyberRollingWindowMinutes(): number {
+  return relayFunctionConstNumber('seedCyberThreats', 'days') * 24 * 60;
+}
+
+function relayEnvDefaultMinutes(name: string): number {
+  const match = relaySource.match(new RegExp(`const\\s+${name}\\s*=\\s*Math\\.max\\([^|]+\\|\\|\\s*([0-9_]+)\\)\\)`));
+  assert.ok(match, `scripts/ais-relay.cjs must define numeric env default for ${name}`);
+  return evalNumberExpression(match[1]) / 60_000;
+}
+
+function aviationBreakerCacheMinutes(name: string): number {
+  const source = readSource('src/services/aviation/index.ts');
+  const match = source.match(new RegExp(`const\\s+${name}\\s*=\\s*createCircuitBreaker<[^>]+>\\(\\{[^}]*cacheTtlMs:\\s*([^,}\\n]+)`));
+  assert.ok(match, `src/services/aviation/index.ts must define ${name}.cacheTtlMs`);
+  return evalNumberExpression(match[1]) / 60_000;
+}
+
+function maxStaleMin(path: string, seedDomain: string): number {
+  const source = readSource(path);
+  const match = source.match(new RegExp(`runSeed\\(\\s*['"][^'"]+['"]\\s*,\\s*['"]${seedDomain}['"][\\s\\S]*?maxStaleMin:\\s*([^,\\n}]+)`));
+  assert.ok(match, `${path} must pass maxStaleMin for ${seedDomain}`);
+  return evalNumberExpression(match[1]);
+}
+
+function healthMaxStale(entry: string): number {
+  const match = healthSource.match(new RegExp(`${entry}:\\s*\\{[^}]*maxStaleMin:\\s*([^,}\\n]+)`));
+  assert.ok(match, `api/health.js must declare SEED_META.${entry}.maxStaleMin`);
+  return evalNumberExpression(match[1]);
+}
+
+function renderedFreshnessText(layerKey: keyof typeof LAYER_REGISTRY): string {
+  const html = renderLayerExplanationCard('Layer', getLayerExplanation(layerKey));
+  const match = html.match(/<span>Freshness<\/span>\s*<p>([\s\S]*?)<\/p>/);
+  assert.ok(match, `${layerKey} card must render a Freshness section`);
+  return match[1].replace(/<[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+}
+
+function durationMinutes(text: string, pattern: RegExp): number {
+  const match = text.match(pattern);
+  assert.ok(match, `duration pattern ${pattern} did not match: ${text}`);
+  const amount = Number(match[1]);
+  const unit = match[2].toLowerCase();
+  if (unit.startsWith('second')) return amount / 60;
+  if (unit.startsWith('minute')) return amount;
+  if (unit.startsWith('hour')) return amount * 60;
+  if (unit.startsWith('day')) return amount * 24 * 60;
+  throw new Error(`Unsupported duration unit: ${unit}`);
+}
+
+function assertDuration(text: string, pattern: RegExp, expectedMinutes: number, label: string): void {
+  assert.equal(
+    durationMinutes(text, pattern),
+    expectedMinutes,
+    `${label} must match authoritative freshness/cadence source`,
+  );
+}
 
 describe('layer explanation metadata', () => {
   test('v1 high-adoption layers have curated structured cards', () => {
@@ -67,19 +163,60 @@ describe('layer explanation metadata', () => {
     assert.deepEqual(explanation.evidence, []);
   });
 
-  test('curated freshness text uses seed cadence rather than gateway cache TTLs', () => {
-    const natural = getLayerExplanation('natural');
-    const flights = getLayerExplanation('flights');
-    const cyberThreats = getLayerExplanation('cyberThreats');
+  test('curated freshness text is a data contract against seeder and runtime cadence sources', () => {
+    const naturalCadenceMin = maxStaleMin('scripts/seed-natural-events.mjs', 'events') / 3;
+    const naturalTtlMin = constNumber('scripts/seed-natural-events.mjs', 'CACHE_TTL') / 60;
+    assert.equal(naturalTtlMin, naturalCadenceMin * 6, 'natural TTL must keep the documented 6x cadence buffer');
+    assertDuration(renderedFreshnessText('natural'), /every\s+([0-9]+)\s+(hour)s?/i, naturalCadenceMin, 'natural event seed cadence');
 
-    assert.match(natural.freshness, /seeded every 2 hours/i);
-    assert.doesNotMatch(natural.freshness, /10 minutes/i);
+    const aviationCadenceMin = maxStaleMin('scripts/seed-aviation.mjs', 'intl') / 3;
+    assertDuration(renderedFreshnessText('flights'), /([0-9]+)-\s*(minute)\s+cadence/i, aviationCadenceMin, 'aviation disruption seed cadence');
+    assertDuration(
+      renderedFreshnessText('flights'),
+      /([0-9]+)-\s*(minute)\s+polling cycle/i,
+      aviationBreakerCacheMinutes('breakerFlights'),
+      'aviation panel polling cycle',
+    );
 
-    assert.match(flights.freshness, /30-minute cadence/i);
-    assert.doesNotMatch(flights.freshness, /10-minute cadence/i);
+    assertDuration(renderedFreshnessText('ucdpEvents'), /every\s+([0-9]+)\s+(hour)s?/i, relayConstMinutes('UCDP_POLL_INTERVAL_MS'), 'UCDP relay seed cadence');
+    assert.equal(healthMaxStale('ucdpEvents'), relayConstMinutes('UCDP_POLL_INTERVAL_MS') + 60, 'UCDP health budget should be cadence plus one hour grace');
 
-    assert.match(cyberThreats.freshness, /every 2 hours/i);
-    assert.doesNotMatch(cyberThreats.freshness, /every 10 minutes/i);
+    assertDuration(renderedFreshnessText('cyberThreats'), /every\s+([0-9]+)\s+(hour)s?/i, relayConstMinutes('CYBER_SEED_INTERVAL_MS'), 'cyber relay seed cadence');
+    assertDuration(renderedFreshnessText('cyberThreats'), /([0-9]+)-\s*(day)\s+rolling window/i, cyberRollingWindowMinutes(), 'cyber IOC rolling window');
+    assert.equal(healthMaxStale('cyberThreats'), relayConstMinutes('CYBER_SEED_INTERVAL_MS') * 2, 'cyber health budget should stay 2x relay cadence');
+
+    assertDuration(renderedFreshnessText('ciiChoropleth'), /every\s+([0-9]+)\s+(minute)s?/i, relayConstMinutes('CII_WARM_PING_INTERVAL_MS'), 'CII warm-ping cadence');
+    assertDuration(renderedFreshnessText('ciiChoropleth'), /([0-9]+)-\s*(minute)\s+freshness budget/i, healthMaxStale('riskScores'), 'CII health freshness budget');
+
+    assertDuration(renderedFreshnessText('ais'), /every\s+([0-9]+)\s+(second)s?/i, relayEnvDefaultMinutes('SNAPSHOT_INTERVAL_MS'), 'AIS relay snapshot cadence');
+    assertDuration(
+      renderedFreshnessText('ais'),
+      /([0-9]+)\s+(minute)s?/i,
+      constNumber('server/worldmonitor/maritime/v1/get-vessel-snapshot.ts', 'SNAPSHOT_CACHE_TTL_BASE_MS') / 60_000,
+      'AIS base snapshot server cache',
+    );
+
+    for (const layer of ['waterways', 'tradeRoutes'] as const) {
+      const text = renderedFreshnessText(layer);
+      assertDuration(text, /every\s+([0-9]+)\s+(minute)s?/i, relayConstMinutes('CHOKEPOINT_WARM_PING_INTERVAL_MS'), `${layer} chokepoint warm-ping cadence`);
+      assertDuration(text, /refresh\s+every\s+([0-9]+)\s+(minute)s?/i, relayConstMinutes('TRANSIT_SUMMARY_INTERVAL_MS'), `${layer} transit-summary cadence`);
+    }
+
+    assertDuration(
+      renderedFreshnessText('hotspots'),
+      /around\s+([0-9]+)\s+(minute)s?/i,
+      constNumber('src/services/live-news.ts', 'CACHE_TTL') / 60_000,
+      'hotspot live-news RSS cache',
+    );
+  });
+
+  test('freshness contract assertions fail on stale copied cadence values', () => {
+    const staleNaturalText = renderedFreshnessText('natural').replace('2 hours', '12 hours');
+
+    assert.throws(
+      () => assertDuration(staleNaturalText, /every\s+([0-9]+)\s+(hour)s?/i, maxStaleMin('scripts/seed-natural-events.mjs', 'events') / 3, 'natural event seed cadence'),
+      /natural event seed cadence must match authoritative freshness\/cadence source/,
+    );
   });
 
   test('cyber source text distinguishes ransomware.live news from geo-enriched IOCs', () => {


### PR DESCRIPTION
## Summary

Fixes #4271.

- Adds a structured v1 layer-explanation catalog for high-adoption map layers: conflict zones, UCDP events, CII/strategic risk, natural events, aviation, AIS, waterways/chokepoints, trade routes, cyber threats, and news/hotspots.
- Adds compact info buttons to SVG fallback, DeckGL, and 3D globe layer pickers so users can open source, freshness, confidence, limitation, related-action, and grounding cards from the map controls.
- Adds a fallback explanation card for unsupported layers that explicitly avoids fabricated source freshness or confidence.
- Documents the new layer-explanation registry contract in the docs.

## Intent

New and non-expert users need help interpreting powerful map layers without leaving the map. This keeps the first version scoped to the highest-adoption/trust-sensitive layers and stores the metadata in the shared layer registry so it is testable and reusable.

## Validation Matrix

| Check | Result |
| --- | --- |
| `node --import tsx --test tests/layer-explanations.test.mts` | Pass |
| `node --import tsx --test tests/map-layer-executable.test.mts tests/resilience-map-layer.test.mts` | Pass |
| `node --test tests/variant-layer-guardrail.test.mjs` | Pass |
| `./node_modules/.bin/markdownlint-cli2 docs/features.mdx docs/architecture.mdx` | Pass |
| `git diff --check` | Pass |
| `npm run typecheck` | Pass |
| Browser sanity: `npm run dev -- --host 127.0.0.1` plus Playwright click test | Pass; SVG controls rendered 21 info buttons, Conflict Zones opened a curated card, and Sanctions opened the fallback card |
| Pre-push hook | Pass; included src/API typechecks, changed tests, edge-function tests, markdown/MDX lint, boundary/safe-HTML checks, and version sync |

## Documentation

- `docs/features.mdx` notes layer explanations under map controls.
- `docs/architecture.mdx` describes the v1 catalog and fallback behavior.

## Residual Findings

- Browser sanity was non-credentialed; local dev emitted expected feed/CORS/provider warnings, but the explanation UI rendered and interacted correctly.
- Full coverage for all map layers is intentionally out of scope for v1; unsupported layers use the generic fallback card.
