### PR TITLE
feat(analyst): add in-app dashboard control v1

### DIFF
--- a/api/chat-analyst.ts
+++ b/api/chat-analyst.ts
@@ -6,7 +6,7 @@
  *
  * Returns text/event-stream SSE:
  *   data: {"meta":{"sources":["Brief","Risk",...],"degraded":false}}  — always first event
- *   data: {"action":{"type":"suggest-widget","label":"...","prefill":"..."}}  — optional, visual queries only
+ *   data: {"action":{"type":"open_panel"|"set_view"|"...","label":"..."}}  — optional, schema-validated in-app actions
  *   data: {"delta":"..."}    — one per content token
  *   data: {"done":true}      — terminal event
  *   data: {"error":"..."}    — on auth/llm failure

--- a/docs/panels/chat-analyst.mdx
+++ b/docs/panels/chat-analyst.mdx
@@ -13,6 +13,7 @@ Panel-level controls:
 
 - **Quick action buttons** at the top of the panel — `Situation` (world brief), `Markets`, `Conflicts`, `Forecasts`, `Risk`. Clicking runs a pre-built query.
 - **Domain selector** — `All` / `Geo` / `Market` / `Military` (+ more). Scopes which caches the analyst draws from.
+- **Dashboard control** — an opt-in `Control dashboard` toggle with a `Pause` control. When enabled, schema-validated Analyst action events can focus an already-live panel, move the map view, or toggle permitted map layers. When off or paused, the answer still streams but dashboard actions are skipped.
 - **Composer** — free-form text input; Enter to send.
 
 Panel id is `chat-analyst`; canonical component is `src/components/ChatAnalystPanel.ts`. Title "WM Analyst" per `src/config/panels.ts:52`.
@@ -27,6 +28,12 @@ Panel id is `chat-analyst`; canonical component is `src/components/ChatAnalystPa
 The panel POSTs to `/api/chat-analyst` (edge function backed by `api/chat-analyst.ts`) via `premiumFetch()`, which injects the caller's credentials (`WORLDMONITOR_API_KEY` on desktop, Clerk bearer + PRO in the browser). The edge function composes context from the intelligence, conflict, markets, forecasts, and risk caches (scoped to the selected domain), streams tokens back, and the panel renders incrementally.
 
 No separate `/chat-analyst/v1/*` RPC surface — this is a first-class edge endpoint, not a proto-generated RPC.
+
+## Dashboard control actions
+
+Dashboard control v1 is in-app and in-process only. `/api/chat-analyst` may stream validated action events alongside the answer, and `src/app/agent-bus-applier.ts` is the only client write boundary that mutates panels or the map. The applier enforces entitlement checks, live panel existence, map availability, variant-allowed layers, renderer executability, and premium layer gating before applying any action.
+
+External MCP write tools, Convex action queues, and cross-user command delivery are not exposed in this version.
 
 ## Refresh cadence
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,8 @@
         "uqr": "^0.1.2",
         "ws": "^8.19.0",
         "yaml": "^2.8.3",
-        "youtubei.js": "^16.0.1"
+        "youtubei.js": "^16.0.1",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.7",
@@ -23691,7 +23692,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -170,7 +170,8 @@
     "uqr": "^0.1.2",
     "ws": "^8.19.0",
     "yaml": "^2.8.3",
-    "youtubei.js": "^16.0.1"
+    "youtubei.js": "^16.0.1",
+    "zod": "^4.3.6"
   },
   "overrides": {
     "fast-xml-parser": "^5.8.0",

--- a/server/worldmonitor/intelligence/v1/chat-analyst-actions.ts
+++ b/server/worldmonitor/intelligence/v1/chat-analyst-actions.ts
@@ -30,7 +30,7 @@ const PANEL_INTENTS: PanelIntent[] = [
 
 const VIEW_INTENTS = [
   { view: 'global', label: 'Show global map', pattern: /\b(global|world(?:wide)?)\b/i },
-  { view: 'america', label: 'Show Americas', pattern: /\b(america|americas|united\s+states|u\.s\.|us)\b/i },
+  { view: 'america', label: 'Show Americas', pattern: /\b[Aa]mericas?\b|\b[Uu]nited\s+[Ss]tates\b|\b[Uu][Ss][Aa]\b|\bUS\b|\b[Uu]\.[Ss]\.?(?![A-Za-z])/ },
   { view: 'mena', label: 'Show MENA', pattern: /\b(mena|middle\s+east|north\s+africa|gulf)\b/i },
   { view: 'eu', label: 'Show Europe', pattern: /\b(europe|european\s+union|eu)\b/i },
   { view: 'asia', label: 'Show Asia', pattern: /\b(asia|indo-?pacific|china|taiwan|korea|japan)\b/i },

--- a/server/worldmonitor/intelligence/v1/chat-analyst-actions.ts
+++ b/server/worldmonitor/intelligence/v1/chat-analyst-actions.ts
@@ -3,11 +3,7 @@
  * Exported for unit testing; consumed by api/chat-analyst.ts.
  */
 
-export interface AnalystActionEvent {
-  type: string;
-  label: string;
-  prefill: string;
-}
+import { parseAgentBusAction, type AgentBusAction } from '../../../../shared/agent-bus-actions';
 
 // Matches compound visual keywords to avoid false-positives on bare nouns
 // (e.g. "UN Charter", "GDP", "chart a course"). Requires visual-specific
@@ -15,7 +11,74 @@ export interface AnalystActionEvent {
 export const VISUAL_INTENT_RE =
   /\b(chart(\s+\w+)?\s+(prices?|data|rates?|trends?|performance|comparison|history)|graph(\s+\w+)?\s+(prices?|data|rates?|trends?|performance)|plot(\s+\w+)?\s+(prices?|data|rates?|trends?|performance)|visuali[sz]e|(show|give|get|make|build)\s+(me\s+)?(a\s+)?(chart|graph|plot|dashboard|trend|visualization)|create\s+a\s+(chart|graph|dashboard|visualization)|price\s+(history|over\s+time|comparison|trend|chart)|compare\s+(prices?|rates?|data|performance)|dashboard|candlestick)\b/i;
 
-export function buildActionEvents(query: string): AnalystActionEvent[] {
-  if (!VISUAL_INTENT_RE.test(query)) return [];
-  return [{ type: 'suggest-widget', label: 'Create chart widget', prefill: query }];
+interface PanelIntent {
+  panelId: string;
+  label: string;
+  pattern: RegExp;
+}
+
+const OPEN_PANEL_RE = /\b(open|show|focus|pull\s+up|go\s+to|bring\s+up)\b/i;
+
+const PANEL_INTENTS: PanelIntent[] = [
+  { panelId: 'strategic-risk', label: 'Open Strategic Risk', pattern: /\b(strategic\s+risk|risk\s+panel)\b/i },
+  { panelId: 'forecast', label: 'Open Forecasts', pattern: /\b(forecasts?|prediction\s+markets?|outlook)\b/i },
+  { panelId: 'cii', label: 'Open CII', pattern: /\b(cii|country\s+instability|instability\s+index)\b/i },
+  { panelId: 'markets', label: 'Open Markets', pattern: /\b(markets?|commodit(?:y|ies)|macro|finance)\b/i },
+  { panelId: 'deduction', label: 'Open Deduction', pattern: /\b(deduction|reasoning|hypothesis)\b/i },
+  { panelId: 'regional-intelligence', label: 'Open Regional Intelligence', pattern: /\b(regional\s+intelligence|regional\s+brief)\b/i },
+];
+
+const VIEW_INTENTS = [
+  { view: 'global', label: 'Show global map', pattern: /\b(global|world(?:wide)?)\b/i },
+  { view: 'america', label: 'Show Americas', pattern: /\b(america|americas|united\s+states|u\.s\.|us)\b/i },
+  { view: 'mena', label: 'Show MENA', pattern: /\b(mena|middle\s+east|north\s+africa|gulf)\b/i },
+  { view: 'eu', label: 'Show Europe', pattern: /\b(europe|european\s+union|eu)\b/i },
+  { view: 'asia', label: 'Show Asia', pattern: /\b(asia|indo-?pacific|china|taiwan|korea|japan)\b/i },
+  { view: 'latam', label: 'Show Latin America', pattern: /\b(latam|latin\s+america|south\s+america)\b/i },
+  { view: 'africa', label: 'Show Africa', pattern: /\b(africa|sub-?saharan)\b/i },
+  { view: 'oceania', label: 'Show Oceania', pattern: /\b(oceania|australia|new\s+zealand|pacific)\b/i },
+] as const;
+
+const MAP_VIEW_RE = /\b(show|fly|zoom|pan|move|focus|center)\b.*\b(map|view|globe|region|area)\b|\b(map|view|globe)\b.*\b(show|fly|zoom|pan|move|focus|center)\b/i;
+
+function validatedAction(input: unknown): AgentBusAction | null {
+  const parsed = parseAgentBusAction(input);
+  return parsed.ok ? parsed.action : null;
+}
+
+function buildOpenPanelAction(query: string): AgentBusAction | null {
+  if (!OPEN_PANEL_RE.test(query)) return null;
+  const intent = PANEL_INTENTS.find((candidate) => candidate.pattern.test(query));
+  if (!intent) return null;
+  return validatedAction({
+    type: 'open_panel',
+    label: intent.label,
+    panelId: intent.panelId,
+    reason: 'Analyst inferred an explicit panel focus request.',
+  });
+}
+
+function buildSetViewAction(query: string): AgentBusAction | null {
+  if (!MAP_VIEW_RE.test(query)) return null;
+  const intent = VIEW_INTENTS.find((candidate) => candidate.pattern.test(query));
+  if (!intent) return null;
+  return validatedAction({
+    type: 'set_view',
+    label: intent.label,
+    view: intent.view,
+    reason: 'Analyst inferred an explicit map view request.',
+  });
+}
+
+function buildSuggestWidgetAction(query: string): AgentBusAction | null {
+  if (!VISUAL_INTENT_RE.test(query)) return null;
+  return validatedAction({ type: 'suggest-widget', label: 'Create chart widget', prefill: query });
+}
+
+export function buildActionEvents(query: string): AgentBusAction[] {
+  return [
+    buildOpenPanelAction(query),
+    buildSetViewAction(query),
+    buildSuggestWidgetAction(query),
+  ].filter((action): action is AgentBusAction => action !== null);
 }

--- a/shared/agent-bus-actions.ts
+++ b/shared/agent-bus-actions.ts
@@ -1,0 +1,95 @@
+import { z } from 'zod';
+
+export const AGENT_BUS_ACTION_TYPES = [
+  'suggest-widget',
+  'open_panel',
+  'set_view',
+  'set_layers',
+] as const;
+
+const labelSchema = z.string().trim().min(1).max(96).optional();
+const reasonSchema = z.string().trim().min(1).max(240).optional();
+const mapViewSchema = z.enum(['global', 'america', 'mena', 'eu', 'asia', 'latam', 'africa', 'oceania']);
+
+export const suggestWidgetActionSchema = z.object({
+  type: z.literal('suggest-widget'),
+  label: labelSchema.default('Create chart widget'),
+  prefill: z.string().trim().min(1).max(500),
+}).strict();
+
+export const openPanelActionSchema = z.object({
+  type: z.literal('open_panel'),
+  label: labelSchema,
+  panelId: z.string().trim().min(1).max(96).regex(/^[a-z0-9][a-z0-9@_-]*$/),
+  reason: reasonSchema,
+}).strict();
+
+export const setViewActionSchema = z.object({
+  type: z.literal('set_view'),
+  label: labelSchema,
+  view: mapViewSchema.optional(),
+  lat: z.number().finite().min(-90).max(90).optional(),
+  lon: z.number().finite().min(-180).max(180).optional(),
+  zoom: z.number().finite().min(1).max(10).optional(),
+  reason: reasonSchema,
+}).strict().superRefine((action, ctx) => {
+  const hasCoordinatePair = action.lat != null && action.lon != null;
+  if (!action.view && !hasCoordinatePair) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'set_view requires either a named view or a lat/lon pair',
+      path: ['view'],
+    });
+  }
+  if ((action.lat == null) !== (action.lon == null)) {
+    ctx.addIssue({
+      code: 'custom',
+      message: 'set_view lat and lon must be provided together',
+      path: action.lat == null ? ['lat'] : ['lon'],
+    });
+  }
+});
+
+export const setLayersActionSchema = z.object({
+  type: z.literal('set_layers'),
+  label: labelSchema,
+  layers: z.record(z.string().trim().min(1).max(80), z.boolean())
+    .refine((layers) => Object.keys(layers).length > 0, 'set_layers requires at least one layer'),
+  reason: reasonSchema,
+}).strict();
+
+export const agentBusActionSchema = z.discriminatedUnion('type', [
+  suggestWidgetActionSchema,
+  openPanelActionSchema,
+  setViewActionSchema,
+  setLayersActionSchema,
+]);
+
+export type SuggestWidgetAction = z.infer<typeof suggestWidgetActionSchema>;
+export type OpenPanelAction = z.infer<typeof openPanelActionSchema>;
+export type SetViewAction = z.infer<typeof setViewActionSchema>;
+export type SetLayersAction = z.infer<typeof setLayersActionSchema>;
+export type AgentBusAction = z.infer<typeof agentBusActionSchema>;
+export type DashboardControlAction = Exclude<AgentBusAction, SuggestWidgetAction>;
+export type DashboardControlActionType = DashboardControlAction['type'];
+export type AgentBusActionParseResult =
+  | { ok: true; action: AgentBusAction }
+  | { ok: false; issues: string[] };
+
+export function parseAgentBusAction(input: unknown): AgentBusActionParseResult {
+  const parsed = agentBusActionSchema.safeParse(input);
+  if (parsed.success) {
+    return { ok: true, action: parsed.data };
+  }
+  return {
+    ok: false,
+    issues: parsed.error.issues.map((issue) => {
+      const path = issue.path.length > 0 ? `${issue.path.join('.')}: ` : '';
+      return `${path}${issue.message}`;
+    }),
+  };
+}
+
+export function isDashboardControlAction(action: AgentBusAction): action is DashboardControlAction {
+  return action.type !== 'suggest-widget';
+}

--- a/src/App.ts
+++ b/src/App.ts
@@ -932,6 +932,7 @@ export class App {
       loadAllData: () => this.dataLoader.loadAllData(),
       updateMonitorResults: () => this.dataLoader.updateMonitorResults(),
       loadSecurityAdvisories: () => this.dataLoader.loadSecurityAdvisories(),
+      applyMapLayerChange: (layer, enabled, source) => this.eventHandlers.applyMapLayerChange(layer, enabled, source),
     });
 
     this.eventHandlers = new EventHandlerManager(this.state, {

--- a/src/app/agent-bus-applier.ts
+++ b/src/app/agent-bus-applier.ts
@@ -1,0 +1,233 @@
+import { SITE_VARIANT } from '@/config/variant';
+import { normalizeExclusiveChoropleths } from '@/components/resilience-choropleth-utils';
+import { getAllowedLayerKeys, isLayerExecutable, LAYER_REGISTRY, type MapRenderer, type MapVariant } from '@/config/map-layer-definitions';
+import type { AppContext } from './app-context';
+import type { MapLayers, PanelConfig } from '@/types';
+import {
+  isDashboardControlAction,
+  parseAgentBusAction,
+  type AgentBusAction,
+  type DashboardControlAction,
+  type DashboardControlActionType,
+} from '../../shared/agent-bus-actions';
+
+export type AgentBusApplyStatus = 'applied' | 'denied' | 'invalid' | 'skipped';
+
+export interface AgentBusApplyTargetResult {
+  target: string;
+  status: AgentBusApplyStatus;
+  reason?: string;
+}
+
+export interface AgentBusApplyResult {
+  ok: boolean;
+  status: AgentBusApplyStatus;
+  actionType?: DashboardControlActionType;
+  label?: string;
+  reason?: string;
+  message: string;
+  targets: AgentBusApplyTargetResult[];
+}
+
+export interface AgentBusApplierOptions {
+  getPanelConfig?: (panelId: string) => PanelConfig;
+  isPanelAllowed?: (panelId: string, config: PanelConfig) => boolean;
+  hasPremiumAccess?: () => boolean;
+  getRenderer?: (ctx: AppContext) => MapRenderer;
+}
+
+const DEFAULT_LAYER_RESULT: AgentBusApplyTargetResult[] = [];
+const MAP_VARIANTS = new Set<MapVariant>(['full', 'tech', 'finance', 'happy', 'commodity', 'energy']);
+
+function denied(message: string, reason: string, targets = DEFAULT_LAYER_RESULT, action?: DashboardControlAction): AgentBusApplyResult {
+  return {
+    ok: false,
+    status: 'denied',
+    actionType: action?.type,
+    label: action?.label,
+    reason,
+    message,
+    targets,
+  };
+}
+
+function invalid(issues: string[]): AgentBusApplyResult {
+  return {
+    ok: false,
+    status: 'invalid',
+    reason: 'invalid_action',
+    message: issues.join('; ') || 'Invalid dashboard action.',
+    targets: [],
+  };
+}
+
+function applied(action: DashboardControlAction, message: string, targets: AgentBusApplyTargetResult[]): AgentBusApplyResult {
+  return {
+    ok: true,
+    status: 'applied',
+    actionType: action.type,
+    label: action.label,
+    message,
+    targets,
+  };
+}
+
+function defaultPanelAllowed(panelId: string, config: PanelConfig): boolean {
+  void panelId;
+  return !config.premium;
+}
+
+function getPanelConfig(panelId: string, options: AgentBusApplierOptions): PanelConfig {
+  return options.getPanelConfig?.(panelId) ?? { name: panelId, enabled: true };
+}
+
+function isPanelAllowed(panelId: string, config: PanelConfig, options: AgentBusApplierOptions): boolean {
+  return options.isPanelAllowed?.(panelId, config) ?? defaultPanelAllowed(panelId, config);
+}
+
+function premiumAccess(options: AgentBusApplierOptions): boolean {
+  return options.hasPremiumAccess?.() ?? false;
+}
+
+function currentRenderer(ctx: AppContext, options: AgentBusApplierOptions): MapRenderer {
+  if (options.getRenderer) return options.getRenderer(ctx);
+  return ctx.map?.isGlobeMode?.() ? 'globe' : 'flat';
+}
+
+function currentMapVariant(): MapVariant {
+  return MAP_VARIANTS.has(SITE_VARIANT as MapVariant) ? SITE_VARIANT as MapVariant : 'full';
+}
+
+function isMapLayerKey(key: string): key is keyof MapLayers {
+  return Object.prototype.hasOwnProperty.call(LAYER_REGISTRY, key);
+}
+
+function applyOpenPanel(ctx: AppContext, action: Extract<AgentBusAction, { type: 'open_panel' }>, options: AgentBusApplierOptions): AgentBusApplyResult {
+  const panel = ctx.panels[action.panelId];
+  if (!panel) {
+    return denied(`Panel is not available: ${action.panelId}.`, 'panel_not_live', [], action);
+  }
+
+  const config = ctx.panelSettings[action.panelId] ?? getPanelConfig(action.panelId, options);
+  if (!isPanelAllowed(action.panelId, config, options)) {
+    return denied(`Panel is not available on this plan: ${config.name || action.panelId}.`, 'panel_not_entitled', [
+      { target: action.panelId, status: 'denied', reason: 'panel_not_entitled' },
+    ], action);
+  }
+
+  panel.show();
+  const element = panel.getElement();
+  if (typeof element.scrollIntoView === 'function') {
+    element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }
+  return applied(action, `Opened ${config.name || action.panelId}.`, [
+    { target: action.panelId, status: 'applied' },
+  ]);
+}
+
+function applySetView(ctx: AppContext, action: Extract<AgentBusAction, { type: 'set_view' }>): AgentBusApplyResult {
+  if (!ctx.map) {
+    return denied('Map is not available.', 'map_unavailable', [], action);
+  }
+
+  if (action.lat != null && action.lon != null) {
+    ctx.map.setCenter(action.lat, action.lon, action.zoom);
+    return applied(action, 'Moved the map.', [
+      { target: `${action.lat},${action.lon}`, status: 'applied' },
+    ]);
+  }
+
+  if (action.view) {
+    ctx.map.setView(action.view, action.zoom);
+    return applied(action, `Moved the map to ${action.view}.`, [
+      { target: action.view, status: 'applied' },
+    ]);
+  }
+
+  return invalid(['set_view requires either a named view or a lat/lon pair']);
+}
+
+function applySetLayers(ctx: AppContext, action: Extract<AgentBusAction, { type: 'set_layers' }>, options: AgentBusApplierOptions): AgentBusApplyResult {
+  if (!ctx.map) {
+    return denied('Map is not available.', 'map_unavailable', [], action);
+  }
+
+  const allowed = getAllowedLayerKeys(currentMapVariant());
+  const renderer = currentRenderer(ctx, options);
+  const isDeckGLActive = Boolean(ctx.map.isDeckGLActive?.());
+  const isPremium = premiumAccess(options);
+  const nextLayers = { ...ctx.mapLayers };
+  const targets: AgentBusApplyTargetResult[] = [];
+  let changed = false;
+
+  for (const [rawKey, enabled] of Object.entries(action.layers)) {
+    if (!isMapLayerKey(rawKey)) {
+      targets.push({ target: rawKey, status: 'denied', reason: 'unknown_layer' });
+      continue;
+    }
+    if (!Object.prototype.hasOwnProperty.call(ctx.mapLayers, rawKey)) {
+      targets.push({ target: rawKey, status: 'denied', reason: 'layer_not_live' });
+      continue;
+    }
+    if (!allowed.has(rawKey)) {
+      targets.push({ target: rawKey, status: 'denied', reason: 'variant_disallowed' });
+      continue;
+    }
+
+    const definition = LAYER_REGISTRY[rawKey];
+    if (definition.premium && !isPremium) {
+      targets.push({ target: rawKey, status: 'denied', reason: 'layer_not_entitled' });
+      continue;
+    }
+    if (rawKey === 'resilienceScore' && !isDeckGLActive) {
+      targets.push({ target: rawKey, status: 'denied', reason: 'layer_not_executable' });
+      continue;
+    }
+    if (!isLayerExecutable(rawKey, renderer, isDeckGLActive)) {
+      targets.push({ target: rawKey, status: 'denied', reason: 'layer_not_executable' });
+      continue;
+    }
+
+    nextLayers[rawKey] = enabled;
+    targets.push({ target: rawKey, status: 'applied' });
+    changed = true;
+  }
+
+  if (!changed) {
+    return denied('No requested layers can be applied.', 'no_allowed_layers', targets, action);
+  }
+
+  const normalized = normalizeExclusiveChoropleths(nextLayers, ctx.mapLayers);
+  ctx.mapLayers = normalized;
+  ctx.map.setLayers(normalized);
+  return applied(action, 'Updated map layers.', targets);
+}
+
+export function applyAgentBusAction(
+  ctx: AppContext,
+  input: unknown,
+  options: AgentBusApplierOptions = {},
+): AgentBusApplyResult {
+  const parsed = parseAgentBusAction(input);
+  if (!parsed.ok) return invalid(parsed.issues);
+  if (!isDashboardControlAction(parsed.action)) {
+    return {
+      ok: false,
+      status: 'skipped',
+      actionType: undefined,
+      label: parsed.action.label,
+      reason: 'not_dashboard_control',
+      message: 'Action is handled outside the dashboard control applier.',
+      targets: [],
+    };
+  }
+
+  switch (parsed.action.type) {
+    case 'open_panel':
+      return applyOpenPanel(ctx, parsed.action, options);
+    case 'set_view':
+      return applySetView(ctx, parsed.action);
+    case 'set_layers':
+      return applySetLayers(ctx, parsed.action, options);
+  }
+}

--- a/src/app/agent-bus-applier.ts
+++ b/src/app/agent-bus-applier.ts
@@ -34,6 +34,7 @@ export interface AgentBusApplierOptions {
   isPanelAllowed?: (panelId: string, config: PanelConfig) => boolean;
   hasPremiumAccess?: () => boolean;
   getRenderer?: (ctx: AppContext) => MapRenderer;
+  applyLayerChange?: (layer: keyof MapLayers, enabled: boolean, source: 'programmatic') => void;
 }
 
 const DEFAULT_LAYER_RESULT: AgentBusApplyTargetResult[] = [];
@@ -198,8 +199,27 @@ function applySetLayers(ctx: AppContext, action: Extract<AgentBusAction, { type:
   }
 
   const normalized = normalizeExclusiveChoropleths(nextLayers, ctx.mapLayers);
+  const changedLayers = (Object.keys(normalized) as Array<keyof MapLayers>)
+    .filter((layer) => (normalized[layer] === true) !== (ctx.mapLayers[layer] === true));
+  if (changedLayers.length === 0) {
+    return applied(action, 'Map layers already match.', targets);
+  }
+  if (!options.applyLayerChange) {
+    return denied(
+      'Layer controls are unavailable.',
+      'layer_change_unavailable',
+      targets.map((target) => target.status === 'applied'
+        ? { ...target, status: 'denied', reason: 'layer_change_unavailable' }
+        : target),
+      action,
+    );
+  }
+
   ctx.mapLayers = normalized;
   ctx.map.setLayers(normalized);
+  for (const layer of changedLayers) {
+    options.applyLayerChange(layer, normalized[layer] === true, 'programmatic');
+  }
   return applied(action, 'Updated map layers.', targets);
 }
 

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -757,6 +757,43 @@ export class EventHandlerManager implements AppModule {
     this.debouncedUrlSync();
   }
 
+  applyMapLayerChange(layer: keyof MapLayers, enabled: boolean, source: 'user' | 'programmatic'): void {
+    console.log(`[App.onLayerChange] ${layer}: ${enabled} (${source})`);
+    trackMapLayerToggle(layer, enabled, source);
+    this.ctx.mapLayers[layer] = enabled;
+    saveToStorage(STORAGE_KEYS.mapLayers, this.ctx.mapLayers);
+    this.syncUrlState();
+
+    const sourceIds = LAYER_TO_SOURCE[layer];
+    if (sourceIds) {
+      for (const sourceId of sourceIds) {
+        dataFreshness.setEnabled(sourceId, enabled);
+      }
+    }
+
+    if (layer === 'ais') {
+      if (enabled) {
+        this.ctx.map?.setLayerLoading('ais', true);
+        initAisStream();
+        this.callbacks.waitForAisData();
+      } else {
+        disconnectAisStream();
+      }
+      return;
+    }
+
+    if (layer === 'flights') {
+      const airlineIntel = this.ctx.panels['airline-intel'] as AirlineIntelPanel | undefined;
+      airlineIntel?.setLiveMode(enabled);
+    }
+
+    if (enabled) {
+      this.callbacks.loadDataForLayer(layer);
+    } else {
+      this.callbacks.stopLayerActivity?.(layer);
+    }
+  }
+
   getShareUrl(): string | null {
     if (!this.ctx.map) return null;
     const state = this.ctx.map.getState();
@@ -1256,40 +1293,7 @@ export class EventHandlerManager implements AppModule {
 
   setupMapLayerHandlers(): void {
     this.ctx.map?.setOnLayerChange((layer, enabled, source) => {
-      console.log(`[App.onLayerChange] ${layer}: ${enabled} (${source})`);
-      trackMapLayerToggle(layer, enabled, source);
-      this.ctx.mapLayers[layer] = enabled;
-      saveToStorage(STORAGE_KEYS.mapLayers, this.ctx.mapLayers);
-      this.syncUrlState();
-
-      const sourceIds = LAYER_TO_SOURCE[layer];
-      if (sourceIds) {
-        for (const sourceId of sourceIds) {
-          dataFreshness.setEnabled(sourceId, enabled);
-        }
-      }
-
-      if (layer === 'ais') {
-        if (enabled) {
-          this.ctx.map?.setLayerLoading('ais', true);
-          initAisStream();
-          this.callbacks.waitForAisData();
-        } else {
-          disconnectAisStream();
-        }
-        return;
-      }
-
-      if (layer === 'flights') {
-        const airlineIntel = this.ctx.panels['airline-intel'] as AirlineIntelPanel | undefined;
-        airlineIntel?.setLiveMode(enabled);
-      }
-
-      if (enabled) {
-        this.callbacks.loadDataForLayer(layer);
-      } else {
-        this.callbacks.stopLayerActivity?.(layer as keyof MapLayers);
-      }
+      this.applyMapLayerChange(layer, enabled, source);
     });
 
     // Forward live aircraft positions from map to AirlineIntelPanel + cache + search index

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1,4 +1,5 @@
 import type { AppContext, AppModule } from '@/app/app-context';
+import { applyAgentBusAction } from '@/app/agent-bus-applier';
 import { normalizeExclusiveChoropleths } from '@/components/resilience-choropleth-utils';
 import { replayPendingCalls, clearAllPendingCalls } from '@/app/pending-panel-data';
 import { getAlertsNearLocation } from '@/services/geo-convergence';
@@ -99,6 +100,8 @@ import {
   ALL_PANELS,
   VARIANT_DEFAULTS,
   isPanelInVariantDefaults,
+  getEffectivePanelConfig,
+  isPanelEntitled,
 } from '@/config';
 import { resolveNewsCategories, enabledNewsCategoryKeys } from '@/config/feed-resolution';
 import { BETA_MODE } from '@/config/beta';
@@ -1198,7 +1201,15 @@ export class PanelLayoutManager implements AppModule {
     // reactively by updatePanelGating() via auth state subscription (all in WEB_PREMIUM_PANELS).
 
     this.lazyPanel('chat-analyst', () =>
-      import('@/components/ChatAnalystPanel').then(m => new m.ChatAnalystPanel()),
+      import('@/components/ChatAnalystPanel').then(m => {
+        const panel = new m.ChatAnalystPanel();
+        panel.setDashboardActionHandler((action) => applyAgentBusAction(this.ctx, action, {
+          getPanelConfig: (panelId) => getEffectivePanelConfig(panelId, SITE_VARIANT),
+          isPanelAllowed: (panelId, config) => isPanelEntitled(panelId, config, hasPremiumAccess(getAuthState())),
+          hasPremiumAccess: () => hasPremiumAccess(getAuthState()),
+        }));
+        return panel;
+      }),
     );
 
     this.lazyPanel('forecast', () =>

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -4,7 +4,7 @@ import { normalizeExclusiveChoropleths } from '@/components/resilience-choroplet
 import { replayPendingCalls, clearAllPendingCalls } from '@/app/pending-panel-data';
 import { getAlertsNearLocation } from '@/services/geo-convergence';
 import { effectivePubDateMs } from '@/services/feed-date';
-import type { ClusteredEvent } from '@/types';
+import type { ClusteredEvent, MapLayers } from '@/types';
 import type { RelatedAsset } from '@/types';
 import type { TheaterPostureSummary } from '@/services/military-surge';
 import {
@@ -182,6 +182,7 @@ export interface PanelLayoutManagerCallbacks {
   loadAllData: () => Promise<void>;
   updateMonitorResults: () => void;
   loadSecurityAdvisories?: () => Promise<void>;
+  applyMapLayerChange?: (layer: keyof MapLayers, enabled: boolean, source: 'programmatic') => void;
 }
 
 export class PanelLayoutManager implements AppModule {
@@ -1207,6 +1208,7 @@ export class PanelLayoutManager implements AppModule {
           getPanelConfig: (panelId) => getEffectivePanelConfig(panelId, SITE_VARIANT),
           isPanelAllowed: (panelId, config) => isPanelEntitled(panelId, config, hasPremiumAccess(getAuthState())),
           hasPremiumAccess: () => hasPremiumAccess(getAuthState()),
+          applyLayerChange: this.callbacks.applyMapLayerChange,
         }));
         return panel;
       }),

--- a/src/components/ChatAnalystPanel.ts
+++ b/src/components/ChatAnalystPanel.ts
@@ -415,8 +415,8 @@ export class ChatAnalystPanel extends Panel {
       result = this.dashboardActionHandler(action);
     }
 
-    if (result.ok && result.actionType) {
-      trackAnalystControlAction(result.actionType, result.status);
+    if (result.actionType) {
+      trackAnalystControlAction(result.actionType, result.status, result.reason);
     }
     this.renderDashboardControlStatus(bubble, result, action);
   }

--- a/src/components/ChatAnalystPanel.ts
+++ b/src/components/ChatAnalystPanel.ts
@@ -4,10 +4,18 @@ import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import { postProcessAnalystHtml } from '@/utils/analyst-markdown';
 import { premiumFetch } from '@/services/premium-fetch';
+import { trackAnalystControlAction } from '@/services/analytics';
 import { h, replaceChildren, setTrustedHtml, trustedHtml, type TrustedHtml } from '@/utils/dom-utils';
+import {
+  isDashboardControlAction,
+  parseAgentBusAction,
+  type AgentBusAction,
+  type DashboardControlAction,
+} from '../../shared/agent-bus-actions';
 
 const API_URL = '/api/chat-analyst';
 const MAX_HISTORY = 20;
+const DASHBOARD_CONTROL_STORAGE_KEY = 'wm-analyst-dashboard-control-enabled';
 
 interface QuickAction {
   label: string;
@@ -41,11 +49,19 @@ interface MetaEvent {
   degraded: boolean;
 }
 
-interface ActionEvent {
-  type: string;
-  label: string;
-  prefill?: string;
+type DashboardControlStatus = 'applied' | 'denied' | 'invalid' | 'skipped';
+
+interface DashboardControlResult {
+  ok: boolean;
+  status: DashboardControlStatus;
+  actionType?: DashboardControlAction['type'];
+  label?: string;
+  reason?: string;
+  message: string;
+  targets: Array<{ target: string; status: DashboardControlStatus; reason?: string }>;
 }
+
+type DashboardActionHandler = (action: DashboardControlAction) => DashboardControlResult;
 
 // Narrow allowlist: text formatting + tables only. No img/a/iframe so
 // prompt-injected or hallucinated URLs cannot trigger third-party requests.
@@ -66,13 +82,33 @@ function renderMarkdown(raw: string): TrustedHtml {
   );
 }
 
+function loadDashboardControlEnabled(): boolean {
+  try {
+    return globalThis.localStorage?.getItem(DASHBOARD_CONTROL_STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function saveDashboardControlEnabled(enabled: boolean): void {
+  try {
+    globalThis.localStorage?.setItem(DASHBOARD_CONTROL_STORAGE_KEY, enabled ? 'true' : 'false');
+  } catch { /* storage unavailable */ }
+}
+
 export class ChatAnalystPanel extends Panel {
   private history: ChatMessage[] = [];
   private domainFocus = 'all';
   private streamAbort: AbortController | null = null;
   private isStreaming = false;
+  private dashboardActionHandler: DashboardActionHandler | null = null;
+  private dashboardControlEnabled = loadDashboardControlEnabled();
+  private dashboardControlPaused = false;
   private messagesEl!: HTMLElement;
   private inputEl: HTMLTextAreaElement | null = null;
+  private controlToggleEl: HTMLInputElement | null = null;
+  private controlStatusEl: HTMLElement | null = null;
+  private controlPauseBtn: HTMLButtonElement | null = null;
   private contentDelegationAttached = false;
 
   constructor() {
@@ -84,6 +120,10 @@ export class ChatAnalystPanel extends Panel {
       infoTooltip: t('components.chatAnalyst.infoTooltip'),
     });
     this.buildUI();
+  }
+
+  public setDashboardActionHandler(handler: DashboardActionHandler): void {
+    this.dashboardActionHandler = handler;
   }
 
   private buildUI(): void {
@@ -98,6 +138,8 @@ export class ChatAnalystPanel extends Panel {
       }, d.label);
       chipBar.appendChild(chip);
     }
+
+    const controlBar = this.createDashboardControlBar();
 
     // Messages container
     const messages = h('div', { className: 'chat-analyst-messages' });
@@ -131,6 +173,7 @@ export class ChatAnalystPanel extends Panel {
     inputRow.appendChild(sendBtn);
 
     wrapper.appendChild(chipBar);
+    wrapper.appendChild(controlBar);
     wrapper.appendChild(messages);
     wrapper.appendChild(quickBar);
     wrapper.appendChild(inputRow);
@@ -138,7 +181,35 @@ export class ChatAnalystPanel extends Panel {
     replaceChildren(this.content, wrapper);
 
     this.showWelcome();
+    this.updateDashboardControlUi();
     this.attachListeners();
+  }
+
+  private createDashboardControlBar(): HTMLElement {
+    const bar = h('div', { className: 'chat-analyst-control-bar' });
+    const label = h('label', { className: 'chat-control-toggle-label' });
+    const toggle = document.createElement('input');
+    toggle.type = 'checkbox';
+    toggle.className = 'chat-control-toggle';
+    toggle.dataset.controlToggle = 'dashboard';
+    this.controlToggleEl = toggle;
+    label.appendChild(toggle);
+    label.appendChild(document.createTextNode('Control dashboard'));
+
+    const status = h('span', { className: 'chat-control-status' });
+    this.controlStatusEl = status;
+
+    const pauseBtn = h('button', {
+      className: 'chat-control-pause',
+      dataset: { action: 'toggle-control-pause' },
+      type: 'button',
+    }, 'Pause') as HTMLButtonElement;
+    this.controlPauseBtn = pauseBtn;
+
+    bar.appendChild(label);
+    bar.appendChild(status);
+    bar.appendChild(pauseBtn);
+    return bar;
   }
 
   private attachListeners(): void {
@@ -171,6 +242,14 @@ export class ChatAnalystPanel extends Panel {
         if (a === 'send') this.sendFromInput();
         else if (a === 'clear') this.clear();
         else if (a === 'export') this.exportChat();
+        else if (a === 'toggle-control-pause') this.toggleDashboardControlPause();
+      }
+    });
+
+    this.content.addEventListener('change', (e) => {
+      const target = e.target as HTMLInputElement | null;
+      if (target?.dataset?.controlToggle === 'dashboard') {
+        this.setDashboardControlEnabled(Boolean(target.checked));
       }
     });
 
@@ -182,6 +261,35 @@ export class ChatAnalystPanel extends Panel {
         this.sendFromInput();
       }
     });
+  }
+
+  private setDashboardControlEnabled(enabled: boolean): void {
+    this.dashboardControlEnabled = enabled;
+    if (!enabled) this.dashboardControlPaused = false;
+    saveDashboardControlEnabled(enabled);
+    this.updateDashboardControlUi();
+  }
+
+  private toggleDashboardControlPause(): void {
+    if (!this.dashboardControlEnabled) return;
+    this.dashboardControlPaused = !this.dashboardControlPaused;
+    this.updateDashboardControlUi();
+  }
+
+  private updateDashboardControlUi(): void {
+    if (this.controlToggleEl) this.controlToggleEl.checked = this.dashboardControlEnabled;
+    if (this.controlStatusEl) {
+      this.controlStatusEl.textContent = this.dashboardControlEnabled
+        ? (this.dashboardControlPaused ? 'Paused' : 'Active')
+        : 'Off';
+      this.controlStatusEl.dataset.state = this.dashboardControlEnabled
+        ? (this.dashboardControlPaused ? 'paused' : 'active')
+        : 'off';
+    }
+    if (this.controlPauseBtn) {
+      this.controlPauseBtn.disabled = !this.dashboardControlEnabled;
+      this.controlPauseBtn.textContent = this.dashboardControlPaused ? 'Resume' : 'Pause';
+    }
   }
 
   private setDomain(domain: string): void {
@@ -261,17 +369,81 @@ export class ChatAnalystPanel extends Panel {
     if (body) bubble.insertBefore(chipsRow, body);
   }
 
-  private renderActionChip(bubble: HTMLElement, action: ActionEvent): void {
-    if (action.type !== 'suggest-widget') return;
+  private renderActionChip(bubble: HTMLElement, action: unknown): void {
+    const parsed = parseAgentBusAction(action);
+    if (!parsed.ok) {
+      this.renderDashboardControlStatus(bubble, {
+        ok: false,
+        status: 'invalid',
+        reason: 'invalid_action',
+        message: 'Analyst sent an invalid dashboard action.',
+        targets: [],
+      });
+      return;
+    }
+
+    const parsedAction = parsed.action;
+    if (isDashboardControlAction(parsedAction)) {
+      this.renderDashboardControlAction(bubble, parsedAction);
+      return;
+    }
+    if (parsedAction.type !== 'suggest-widget') return;
+
     const chip = document.createElement('button');
     chip.className = 'chat-action-chip';
-    chip.textContent = `${action.label} →`;
+    chip.textContent = `${parsedAction.label} →`;
     chip.addEventListener('click', () => {
       this.element.dispatchEvent(new CustomEvent('wm:open-widget-creator', {
         bubbles: true,
-        detail: { initialMessage: action.prefill ?? '' },
+        detail: { initialMessage: parsedAction.prefill },
       }));
     });
+    const body = bubble.querySelector('.chat-msg-body');
+    if (body) bubble.insertBefore(chip, body);
+    else bubble.appendChild(chip);
+  }
+
+  private renderDashboardControlAction(bubble: HTMLElement, action: DashboardControlAction): void {
+    let result: DashboardControlResult;
+    if (!this.dashboardControlEnabled) {
+      result = this.skippedDashboardAction(action, 'control_disabled', 'Dashboard control is off.');
+    } else if (this.dashboardControlPaused) {
+      result = this.skippedDashboardAction(action, 'control_paused', 'Dashboard control is paused.');
+    } else if (!this.dashboardActionHandler) {
+      result = this.skippedDashboardAction(action, 'context_unavailable', 'Dashboard context is unavailable.');
+    } else {
+      result = this.dashboardActionHandler(action);
+    }
+
+    if (result.ok && result.actionType) {
+      trackAnalystControlAction(result.actionType, result.status);
+    }
+    this.renderDashboardControlStatus(bubble, result, action);
+  }
+
+  private skippedDashboardAction(action: DashboardControlAction, reason: string, message: string): DashboardControlResult {
+    return {
+      ok: false,
+      status: 'skipped',
+      actionType: action.type,
+      label: action.label,
+      reason,
+      message,
+      targets: [],
+    };
+  }
+
+  private renderDashboardControlStatus(
+    bubble: HTMLElement,
+    result: DashboardControlResult,
+    action?: AgentBusAction,
+  ): void {
+    const chip = document.createElement('span');
+    chip.className = `chat-action-chip chat-action-chip--control chat-action-chip--${result.ok ? 'applied' : result.status}`;
+    chip.textContent = result.ok
+      ? `Applied: ${result.label ?? action?.type ?? 'dashboard action'}`
+      : `${result.label ?? action?.type ?? 'Dashboard action'} not applied`;
+    chip.title = result.message;
     const body = bubble.querySelector('.chat-msg-body');
     if (body) bubble.insertBefore(chip, body);
     else bubble.appendChild(chip);
@@ -402,7 +574,7 @@ export class ChatAnalystPanel extends Panel {
             done?: boolean;
             error?: string;
             meta?: MetaEvent;
-            action?: ActionEvent;
+            action?: unknown;
           };
           if (payload.error) {
             this.finalizeStreamingBubble(bodyEl, '⚠ Analyst unavailable. Try again shortly.', false);

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -46,6 +46,8 @@ const EVENTS = {
   'widget-ai-open': true,
   'widget-ai-generate': true,
   'widget-ai-success': true,
+  // WM Analyst dashboard control
+  'analyst-control-action': true,
   // MCP
   'mcp-connect-attempt': true,
   'mcp-connect-success': true,
@@ -194,6 +196,14 @@ export function trackSignIn(method: string): void {
 
 export function trackSignUp(method: string): void {
   track('sign-up', { method });
+}
+
+export function trackAnalystControlAction(actionType: string, status: string, reason?: string): void {
+  track('analyst-control-action', {
+    actionType,
+    status,
+    ...(reason ? { reason } : {}),
+  });
 }
 
 /**

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -22557,6 +22557,67 @@ body.map-width-resizing {
   border-color: var(--accent);
   color: var(--bg);
 }
+.chat-analyst-control-bar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-height: 24px;
+  padding: 4px 6px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--panel-inner-bg, rgba(255,255,255,0.03)) 80%, transparent);
+}
+.chat-control-toggle-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+}
+.chat-control-toggle {
+  width: 13px;
+  height: 13px;
+  margin: 0;
+  accent-color: var(--accent);
+}
+.chat-control-status {
+  min-width: 42px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.chat-control-status[data-state="active"] {
+  color: var(--green, #22c55e);
+}
+.chat-control-status[data-state="paused"] {
+  color: var(--yellow, #eab308);
+}
+.chat-control-pause {
+  margin-left: auto;
+  min-width: 50px;
+  height: 22px;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-dim);
+  font-size: 10px;
+  cursor: pointer;
+}
+.chat-control-pause:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.chat-control-pause:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
 .chat-analyst-messages {
   flex: 1;
   overflow-y: auto;
@@ -22748,6 +22809,24 @@ body.map-width-resizing {
 }
 .chat-action-chip:hover {
   background: color-mix(in srgb, var(--accent) 22%, transparent);
+}
+.chat-action-chip--control {
+  cursor: default;
+}
+.chat-action-chip--control:hover {
+  background: color-mix(in srgb, var(--accent) 12%, transparent);
+}
+.chat-action-chip--applied {
+  color: var(--green, #22c55e);
+  border-color: color-mix(in srgb, var(--green, #22c55e) 35%, transparent);
+  background: color-mix(in srgb, var(--green, #22c55e) 10%, transparent);
+}
+.chat-action-chip--denied,
+.chat-action-chip--invalid,
+.chat-action-chip--skipped {
+  color: var(--yellow, #eab308);
+  border-color: color-mix(in srgb, var(--yellow, #eab308) 35%, transparent);
+  background: color-mix(in srgb, var(--yellow, #eab308) 10%, transparent);
 }
 
 /* ── Payment / Upgrade UI ── */

--- a/tests/agent-bus-actions.test.mts
+++ b/tests/agent-bus-actions.test.mts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  AGENT_BUS_ACTION_TYPES,
+  parseAgentBusAction,
+} from '../shared/agent-bus-actions.ts';
+
+describe('agent bus action schema', () => {
+  it('parses v1 dashboard control actions', () => {
+    assert.deepEqual([...AGENT_BUS_ACTION_TYPES], [
+      'suggest-widget',
+      'open_panel',
+      'set_view',
+      'set_layers',
+    ]);
+
+    const openPanel = parseAgentBusAction({
+      type: 'open_panel',
+      label: 'Open Strategic Risk',
+      panelId: 'strategic-risk',
+    });
+    assert.equal(openPanel.ok, true);
+    if (openPanel.ok) {
+      assert.equal(openPanel.action.type, 'open_panel');
+      assert.equal(openPanel.action.panelId, 'strategic-risk');
+    }
+
+    const setView = parseAgentBusAction({
+      type: 'set_view',
+      view: 'mena',
+      zoom: 3,
+    });
+    assert.equal(setView.ok, true);
+
+    const setLayers = parseAgentBusAction({
+      type: 'set_layers',
+      layers: { conflicts: true, weather: false },
+    });
+    assert.equal(setLayers.ok, true);
+  });
+
+  it('keeps legacy suggest-widget compatible', () => {
+    const parsed = parseAgentBusAction({
+      type: 'suggest-widget',
+      prefill: 'chart oil prices',
+    });
+    assert.equal(parsed.ok, true);
+    if (parsed.ok) {
+      assert.equal(parsed.action.type, 'suggest-widget');
+      assert.equal(parsed.action.label, 'Create chart widget');
+      assert.equal(parsed.action.prefill, 'chart oil prices');
+    }
+  });
+
+  it('rejects malformed, unknown, or overbroad actions', () => {
+    const unknown = parseAgentBusAction({ type: 'delete_everything' });
+    assert.equal(unknown.ok, false);
+
+    const extraField = parseAgentBusAction({
+      type: 'open_panel',
+      panelId: 'forecast',
+      persist: true,
+    });
+    assert.equal(extraField.ok, false);
+
+    const badPanelId = parseAgentBusAction({
+      type: 'open_panel',
+      panelId: '../forecast',
+    });
+    assert.equal(badPanelId.ok, false);
+  });
+
+  it('bounds map view targets', () => {
+    assert.equal(parseAgentBusAction({ type: 'set_view', view: 'eu', zoom: 4 }).ok, true);
+    assert.equal(parseAgentBusAction({ type: 'set_view', lat: 34.5, lon: 39.0, zoom: 5 }).ok, true);
+    assert.equal(parseAgentBusAction({ type: 'set_view', lat: 34.5 }).ok, false);
+    assert.equal(parseAgentBusAction({ type: 'set_view', view: 'moon' }).ok, false);
+    assert.equal(parseAgentBusAction({ type: 'set_view', lat: 120, lon: 39.0 }).ok, false);
+    assert.equal(parseAgentBusAction({ type: 'set_view', lat: 34.5, lon: 39.0, zoom: 99 }).ok, false);
+  });
+
+  it('requires explicit layer changes', () => {
+    assert.equal(parseAgentBusAction({ type: 'set_layers', layers: { conflicts: true } }).ok, true);
+    assert.equal(parseAgentBusAction({ type: 'set_layers', layers: {} }).ok, false);
+    assert.equal(parseAgentBusAction({ type: 'set_layers', layers: { conflicts: 'true' } }).ok, false);
+  });
+});

--- a/tests/agent-bus-applier.test.mts
+++ b/tests/agent-bus-applier.test.mts
@@ -1,0 +1,199 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { applyAgentBusAction } from '../src/app/agent-bus-applier.ts';
+import type { AppContext } from '../src/app/app-context.ts';
+import type { MapLayers, PanelConfig } from '../src/types/index.ts';
+
+function makePanel() {
+  let showCalls = 0;
+  let scrollCalls = 0;
+  const element = {
+    scrollIntoView: () => { scrollCalls += 1; },
+  } as unknown as HTMLElement;
+  return {
+    panel: {
+      show: () => { showCalls += 1; },
+      getElement: () => element,
+    },
+    get showCalls() { return showCalls; },
+    get scrollCalls() { return scrollCalls; },
+  };
+}
+
+function makeCtx(overrides: Partial<AppContext> = {}): AppContext {
+  const setCenterCalls: Array<[number, number, number | undefined]> = [];
+  const setViewCalls: Array<[string, number | undefined]> = [];
+  const setLayersCalls: MapLayers[] = [];
+  const mapLayers = {
+    conflicts: false,
+    weather: false,
+    ciiChoropleth: false,
+    resilienceScore: false,
+    storageFacilities: false,
+  } as unknown as MapLayers;
+  return {
+    panels: {},
+    panelSettings: {},
+    mapLayers,
+    map: {
+      setCenter: (lat: number, lon: number, zoom?: number) => { setCenterCalls.push([lat, lon, zoom]); },
+      setView: (view: string, zoom?: number) => { setViewCalls.push([view, zoom]); },
+      setLayers: (layers: MapLayers) => { setLayersCalls.push(layers); },
+      isDeckGLActive: () => false,
+      isGlobeMode: () => false,
+      _calls: { setCenterCalls, setViewCalls, setLayersCalls },
+    },
+    ...overrides,
+  } as unknown as AppContext;
+}
+
+const entitled = {
+  getPanelConfig: (panelId: string): PanelConfig => ({ name: panelId, enabled: true }),
+  isPanelAllowed: () => true,
+  hasPremiumAccess: () => false,
+};
+
+describe('agent bus applier', () => {
+  it('opens only live, entitled panels', () => {
+    const panel = makePanel();
+    const ctx = makeCtx({
+      panels: { forecast: panel.panel as never },
+      panelSettings: { forecast: { name: 'Forecasts', enabled: false, premium: 'locked' } },
+    });
+    const result = applyAgentBusAction(ctx, { type: 'open_panel', panelId: 'forecast' }, entitled);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.status, 'applied');
+    assert.equal(panel.showCalls, 1);
+    assert.equal(panel.scrollCalls, 1);
+    assert.equal(ctx.panelSettings.forecast.enabled, false, 'open_panel must not persistently enable settings');
+  });
+
+  it('rejects unknown or lazy-not-live panels before mutation', () => {
+    const ctx = makeCtx({
+      panels: {},
+      panelSettings: { forecast: { name: 'Forecasts', enabled: true } },
+    });
+    const result = applyAgentBusAction(ctx, { type: 'open_panel', panelId: 'forecast' }, entitled);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'panel_not_live');
+  });
+
+  it('enforces premium panel entitlement in the applier', () => {
+    const panel = makePanel();
+    const ctx = makeCtx({
+      panels: { forecast: panel.panel as never },
+      panelSettings: { forecast: { name: 'Forecasts', enabled: true, premium: 'locked' } },
+    });
+    const result = applyAgentBusAction(ctx, { type: 'open_panel', panelId: 'forecast' }, {
+      ...entitled,
+      isPanelAllowed: () => false,
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'panel_not_entitled');
+    assert.equal(panel.showCalls, 0);
+  });
+
+  it('moves the map only after action validation', () => {
+    const ctx = makeCtx();
+    const result = applyAgentBusAction(ctx, { type: 'set_view', view: 'mena', zoom: 4 }, entitled);
+    const mapCalls = (ctx.map as never as { _calls: { setViewCalls: Array<[string, number | undefined]> } })._calls;
+
+    assert.equal(result.ok, true);
+    assert.deepEqual(mapCalls.setViewCalls, [['mena', 4]]);
+    assert.equal(applyAgentBusAction(ctx, { type: 'set_view', lat: 91, lon: 0 }, entitled).status, 'invalid');
+  });
+
+  it('treats missing map as a denied no-op', () => {
+    const ctx = makeCtx({ map: null });
+    const result = applyAgentBusAction(ctx, { type: 'set_view', view: 'eu' }, entitled);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'map_unavailable');
+  });
+
+  it('filters layers by live state, entitlement, variant, and renderer executability', () => {
+    const ctx = makeCtx();
+    const result = applyAgentBusAction(ctx, {
+      type: 'set_layers',
+      layers: {
+        conflicts: true,
+        resilienceScore: true,
+        storageFacilities: true,
+        notARealLayer: true,
+      },
+    }, entitled);
+    const mapCalls = (ctx.map as never as { _calls: { setLayersCalls: MapLayers[] } })._calls;
+
+    assert.equal(result.ok, true);
+    assert.equal(ctx.mapLayers.conflicts, true);
+    assert.equal(ctx.mapLayers.resilienceScore, false);
+    assert.equal(ctx.mapLayers.storageFacilities, false);
+    assert.equal(mapCalls.setLayersCalls.length, 1);
+    assert.deepEqual(
+      result.targets.map((target) => [target.target, target.status, target.reason ?? '']),
+      [
+        ['conflicts', 'applied', ''],
+        ['resilienceScore', 'denied', 'layer_not_entitled'],
+        ['storageFacilities', 'denied', 'layer_not_executable'],
+        ['notARealLayer', 'denied', 'unknown_layer'],
+      ],
+    );
+  });
+
+  it('does not partially mutate when every requested layer is denied', () => {
+    const ctx = makeCtx();
+    const before = ctx.mapLayers;
+    const result = applyAgentBusAction(ctx, {
+      type: 'set_layers',
+      layers: { resilienceScore: true },
+    }, entitled);
+    const mapCalls = (ctx.map as never as { _calls: { setLayersCalls: MapLayers[] } })._calls;
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'no_allowed_layers');
+    assert.equal(ctx.mapLayers, before);
+    assert.equal(ctx.mapLayers.resilienceScore, false);
+    assert.equal(mapCalls.setLayersCalls.length, 0);
+  });
+
+  it('rejects resilienceScore outside DeckGL even for premium users', () => {
+    const ctx = makeCtx();
+    const result = applyAgentBusAction(ctx, {
+      type: 'set_layers',
+      layers: { resilienceScore: true },
+    }, { ...entitled, hasPremiumAccess: () => true });
+    const mapCalls = (ctx.map as never as { _calls: { setLayersCalls: MapLayers[] } })._calls;
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'no_allowed_layers');
+    assert.equal(result.targets[0]?.reason, 'layer_not_executable');
+    assert.equal(ctx.mapLayers.resilienceScore, false);
+    assert.equal(mapCalls.setLayersCalls.length, 0);
+  });
+
+  it('normalizes mutually exclusive choropleth layers before applying', () => {
+    const ctx = makeCtx({
+      map: {
+        setCenter: () => {},
+        setView: () => {},
+        setLayers: () => {},
+        isDeckGLActive: () => true,
+        isGlobeMode: () => false,
+      } as never,
+    });
+    ctx.mapLayers.ciiChoropleth = true;
+
+    const result = applyAgentBusAction(ctx, {
+      type: 'set_layers',
+      layers: { resilienceScore: true },
+    }, { ...entitled, hasPremiumAccess: () => true });
+
+    assert.equal(result.ok, true);
+    assert.equal(ctx.mapLayers.resilienceScore, true);
+    assert.equal(ctx.mapLayers.ciiChoropleth, false);
+  });
+});

--- a/tests/agent-bus-applier.test.mts
+++ b/tests/agent-bus-applier.test.mts
@@ -52,6 +52,7 @@ const entitled = {
   getPanelConfig: (panelId: string): PanelConfig => ({ name: panelId, enabled: true }),
   isPanelAllowed: () => true,
   hasPremiumAccess: () => false,
+  applyLayerChange: () => {},
 };
 
 describe('agent bus applier', () => {
@@ -144,6 +145,26 @@ describe('agent bus applier', () => {
     );
   });
 
+  it('denies layer updates when the normal layer-change side effects are unavailable', () => {
+    const ctx = makeCtx();
+    const result = applyAgentBusAction(ctx, {
+      type: 'set_layers',
+      layers: { conflicts: true },
+    }, {
+      getPanelConfig: entitled.getPanelConfig,
+      isPanelAllowed: entitled.isPanelAllowed,
+      hasPremiumAccess: entitled.hasPremiumAccess,
+    });
+    const mapCalls = (ctx.map as never as { _calls: { setLayersCalls: MapLayers[] } })._calls;
+
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, 'layer_change_unavailable');
+    assert.equal(result.targets[0]?.status, 'denied');
+    assert.equal(result.targets[0]?.reason, 'layer_change_unavailable');
+    assert.equal(ctx.mapLayers.conflicts, false);
+    assert.equal(mapCalls.setLayersCalls.length, 0);
+  });
+
   it('does not partially mutate when every requested layer is denied', () => {
     const ctx = makeCtx();
     const before = ctx.mapLayers;
@@ -176,6 +197,7 @@ describe('agent bus applier', () => {
   });
 
   it('normalizes mutually exclusive choropleth layers before applying', () => {
+    const layerChanges: Array<[keyof MapLayers, boolean, 'programmatic']> = [];
     const ctx = makeCtx({
       map: {
         setCenter: () => {},
@@ -190,10 +212,18 @@ describe('agent bus applier', () => {
     const result = applyAgentBusAction(ctx, {
       type: 'set_layers',
       layers: { resilienceScore: true },
-    }, { ...entitled, hasPremiumAccess: () => true });
+    }, {
+      ...entitled,
+      hasPremiumAccess: () => true,
+      applyLayerChange: (layer, enabled, source) => { layerChanges.push([layer, enabled, source]); },
+    });
 
     assert.equal(result.ok, true);
     assert.equal(ctx.mapLayers.resilienceScore, true);
     assert.equal(ctx.mapLayers.ciiChoropleth, false);
+    assert.deepEqual(layerChanges, [
+      ['ciiChoropleth', false, 'programmatic'],
+      ['resilienceScore', true, 'programmatic'],
+    ]);
   });
 });

--- a/tests/chat-analyst-panel-control.test.mts
+++ b/tests/chat-analyst-panel-control.test.mts
@@ -97,14 +97,16 @@ describe('ChatAnalystPanel — dashboard control actions', () => {
     });
 
     assert.equal(globals.__wmAppliedAnalystActions.length, 0);
-    assert.equal(globals.__wmAnalystControlTelemetry.length, 0);
+    assert.deepEqual(globals.__wmAnalystControlTelemetry, [
+      { actionType: 'open_panel', status: 'skipped', reason: 'control_disabled' },
+    ]);
     assert.ok(bubble.querySelector('.chat-action-chip--skipped'), 'skipped chip rendered');
   });
 
-  it('applies and tracks streamed actions only while enabled and unpaused', async () => {
+  it('applies actions only while enabled and unpaused while tracking all outcomes', async () => {
     const globals = globalThis as typeof globalThis & {
       __wmAppliedAnalystActions?: Array<{ action: { type: string } }>;
-      __wmAnalystControlTelemetry?: Array<{ actionType: string; status: string }>;
+      __wmAnalystControlTelemetry?: Array<{ actionType: string; status: string; reason?: string }>;
     };
     globals.__wmAppliedAnalystActions = [];
     globals.__wmAnalystControlTelemetry = [];
@@ -144,7 +146,40 @@ describe('ChatAnalystPanel — dashboard control actions', () => {
     });
 
     assert.equal(globals.__wmAppliedAnalystActions.length, 1, 'paused action must not call applier');
-    assert.equal(globals.__wmAnalystControlTelemetry.length, 1, 'paused action must not emit adoption telemetry');
+    assert.deepEqual(globals.__wmAnalystControlTelemetry, [
+      { actionType: 'open_panel', status: 'applied' },
+      { actionType: 'set_view', status: 'skipped', reason: 'control_paused' },
+    ]);
     assert.ok(pausedBubble.querySelector('.chat-action-chip--skipped'), 'paused chip rendered');
+  });
+
+  it('tracks denied handler results with reason context', async () => {
+    const globals = globalThis as typeof globalThis & {
+      __wmAnalystControlTelemetry?: Array<{ actionType: string; status: string; reason?: string }>;
+    };
+    globals.__wmAnalystControlTelemetry = [];
+
+    const panel = harness.createPanel();
+    panel.setDashboardActionHandler((action: { type: string }) => ({
+      ok: false,
+      status: 'denied',
+      actionType: action.type,
+      label: 'Denied',
+      reason: 'panel_not_entitled',
+      message: 'denied by test handler',
+      targets: [{ target: action.type, status: 'denied', reason: 'panel_not_entitled' }],
+    }));
+    (panel as never as { setDashboardControlEnabled: (enabled: boolean) => void }).setDashboardControlEnabled(true);
+
+    const bubble = await feedAction(panel, {
+      type: 'open_panel',
+      label: 'Open Forecasts',
+      panelId: 'forecast',
+    });
+
+    assert.deepEqual(globals.__wmAnalystControlTelemetry, [
+      { actionType: 'open_panel', status: 'denied', reason: 'panel_not_entitled' },
+    ]);
+    assert.ok(bubble.querySelector('.chat-action-chip--denied'), 'denied chip rendered');
   });
 });

--- a/tests/chat-analyst-panel-control.test.mts
+++ b/tests/chat-analyst-panel-control.test.mts
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import { after, afterEach, describe, it } from 'node:test';
+
+import { createChatAnalystPanelHarness } from './helpers/chat-analyst-panel-harness.mjs';
+
+const harness = await createChatAnalystPanelHarness();
+
+after(() => {
+  harness.cleanup();
+});
+
+afterEach(() => {
+  const globals = globalThis as typeof globalThis & {
+    __wmAppliedAnalystActions?: unknown[];
+    __wmAnalystControlTelemetry?: unknown[];
+  };
+  globals.__wmAppliedAnalystActions = [];
+  globals.__wmAnalystControlTelemetry = [];
+  globalThis.localStorage?.clear?.();
+});
+
+function sseReader(events: unknown[]): ReadableStreamDefaultReader<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const event of events) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n`));
+      }
+      controller.close();
+    },
+  }).getReader();
+}
+
+async function feedAction(panel: unknown, action: unknown): Promise<HTMLElement> {
+  const panelAny = panel as {
+    appendStreamingBubble: () => { bubble: HTMLElement; body: HTMLElement };
+    readStream: (
+      reader: ReadableStreamDefaultReader<Uint8Array>,
+      bubble: HTMLElement,
+      body: HTMLElement,
+      onToken: (text: string) => void,
+    ) => Promise<string>;
+  };
+  const { bubble, body } = panelAny.appendStreamingBubble();
+  const status = await panelAny.readStream(
+    sseReader([{ action }, { delta: 'Answer continues.' }, { done: true }]),
+    bubble,
+    body,
+    () => {},
+  );
+  assert.equal(status, 'done');
+  assert.ok(body.textContent?.includes('Answer continues.'), 'text stream should continue after action');
+  return bubble;
+}
+
+describe('ChatAnalystPanel — dashboard control actions', () => {
+  it('renders the opt-in and pause control state', () => {
+    const panel = harness.createPanel();
+    const root = panel.getElement();
+
+    assert.ok(root.querySelector('.chat-analyst-control-bar'), 'control bar present');
+    assert.equal(root.querySelector('.chat-control-status')?.textContent, 'Off');
+
+    (panel as never as { setDashboardControlEnabled: (enabled: boolean) => void }).setDashboardControlEnabled(true);
+    assert.equal(globalThis.localStorage?.getItem('wm-analyst-dashboard-control-enabled'), 'true');
+    assert.equal(root.querySelector('.chat-control-status')?.textContent, 'Active');
+
+    (panel as never as { toggleDashboardControlPause: () => void }).toggleDashboardControlPause();
+    assert.equal(root.querySelector('.chat-control-status')?.textContent, 'Paused');
+    assert.equal(root.querySelector('.chat-control-pause')?.textContent, 'Resume');
+  });
+
+  it('does not apply streamed actions while dashboard control is off', async () => {
+    const globals = globalThis as typeof globalThis & {
+      __wmAppliedAnalystActions?: unknown[];
+      __wmAnalystControlTelemetry?: unknown[];
+    };
+    globals.__wmAppliedAnalystActions = [];
+    globals.__wmAnalystControlTelemetry = [];
+
+    const panel = harness.createPanel();
+    panel.setDashboardActionHandler((action: { type: string }) => {
+      globals.__wmAppliedAnalystActions?.push({ action });
+      return {
+        ok: true,
+        status: 'applied',
+        actionType: action.type,
+        label: 'Applied',
+        message: 'applied by test handler',
+        targets: [{ target: action.type, status: 'applied' }],
+      };
+    });
+    const bubble = await feedAction(panel, {
+      type: 'open_panel',
+      label: 'Open Forecasts',
+      panelId: 'forecast',
+    });
+
+    assert.equal(globals.__wmAppliedAnalystActions.length, 0);
+    assert.equal(globals.__wmAnalystControlTelemetry.length, 0);
+    assert.ok(bubble.querySelector('.chat-action-chip--skipped'), 'skipped chip rendered');
+  });
+
+  it('applies and tracks streamed actions only while enabled and unpaused', async () => {
+    const globals = globalThis as typeof globalThis & {
+      __wmAppliedAnalystActions?: Array<{ action: { type: string } }>;
+      __wmAnalystControlTelemetry?: Array<{ actionType: string; status: string }>;
+    };
+    globals.__wmAppliedAnalystActions = [];
+    globals.__wmAnalystControlTelemetry = [];
+
+    const panel = harness.createPanel();
+    panel.setDashboardActionHandler((action: { type: string }) => {
+      globals.__wmAppliedAnalystActions?.push({ action });
+      return {
+        ok: true,
+        status: 'applied',
+        actionType: action.type,
+        label: 'Applied',
+        message: 'applied by test handler',
+        targets: [{ target: action.type, status: 'applied' }],
+      };
+    });
+    (panel as never as { setDashboardControlEnabled: (enabled: boolean) => void }).setDashboardControlEnabled(true);
+
+    const appliedBubble = await feedAction(panel, {
+      type: 'open_panel',
+      label: 'Open Forecasts',
+      panelId: 'forecast',
+    });
+
+    assert.equal(globals.__wmAppliedAnalystActions.length, 1);
+    assert.equal(globals.__wmAppliedAnalystActions[0]?.action.type, 'open_panel');
+    assert.deepEqual(globals.__wmAnalystControlTelemetry, [
+      { actionType: 'open_panel', status: 'applied' },
+    ]);
+    assert.ok(appliedBubble.querySelector('.chat-action-chip--applied'), 'applied chip rendered');
+
+    (panel as never as { toggleDashboardControlPause: () => void }).toggleDashboardControlPause();
+    const pausedBubble = await feedAction(panel, {
+      type: 'set_view',
+      label: 'Show MENA',
+      view: 'mena',
+    });
+
+    assert.equal(globals.__wmAppliedAnalystActions.length, 1, 'paused action must not call applier');
+    assert.equal(globals.__wmAnalystControlTelemetry.length, 1, 'paused action must not emit adoption telemetry');
+    assert.ok(pausedBubble.querySelector('.chat-action-chip--skipped'), 'paused chip rendered');
+  });
+});

--- a/tests/chat-analyst.test.mts
+++ b/tests/chat-analyst.test.mts
@@ -304,6 +304,31 @@ describe('buildActionEvents — visual intent detection', () => {
     }
   });
 
+  it('does not treat lowercase us as an Americas map intent', () => {
+    const events = buildActionEvents('Show us the Middle East on the map');
+    assert.equal(events.length, 1);
+    assert.equal(events[0]?.type, 'set_view');
+    if (events[0]?.type === 'set_view') {
+      assert.equal(events[0].view, 'mena');
+    }
+  });
+
+  it('still accepts unambiguous US map intents', () => {
+    const events = buildActionEvents('Zoom the map to US');
+    assert.equal(events.length, 1);
+    assert.equal(events[0]?.type, 'set_view');
+    if (events[0]?.type === 'set_view') {
+      assert.equal(events[0].view, 'america');
+    }
+
+    const dottedEvents = buildActionEvents('Center the U.S. map');
+    assert.equal(dottedEvents.length, 1);
+    assert.equal(dottedEvents[0]?.type, 'set_view');
+    if (dottedEvents[0]?.type === 'set_view') {
+      assert.equal(dottedEvents[0].view, 'america');
+    }
+  });
+
   it('returns empty for non-visual market summary query', () => {
     assert.deepEqual(buildActionEvents('Key market moves, macro signals, and commodity moves today'), []);
   });

--- a/tests/chat-analyst.test.mts
+++ b/tests/chat-analyst.test.mts
@@ -286,6 +286,24 @@ describe('buildActionEvents — visual intent detection', () => {
     assert.deepEqual(buildActionEvents("What is happening in Ukraine?"), []);
   });
 
+  it('returns open_panel action for explicit panel focus query', () => {
+    const events = buildActionEvents('Open the Strategic Risk panel');
+    assert.equal(events.length, 1);
+    assert.equal(events[0]?.type, 'open_panel');
+    if (events[0]?.type === 'open_panel') {
+      assert.equal(events[0].panelId, 'strategic-risk');
+    }
+  });
+
+  it('returns set_view action for explicit map view query', () => {
+    const events = buildActionEvents('Zoom the map to the Middle East');
+    assert.equal(events.length, 1);
+    assert.equal(events[0]?.type, 'set_view');
+    if (events[0]?.type === 'set_view') {
+      assert.equal(events[0].view, 'mena');
+    }
+  });
+
   it('returns empty for non-visual market summary query', () => {
     assert.deepEqual(buildActionEvents('Key market moves, macro signals, and commodity moves today'), []);
   });

--- a/tests/helpers/chat-analyst-panel-harness.mjs
+++ b/tests/helpers/chat-analyst-panel-harness.mjs
@@ -55,6 +55,9 @@ async function loadChatAnalystPanel() {
     `],
     ['analytics-stub', `
       export function trackPanelResized() {}
+      export function trackAnalystControlAction(actionType, status) {
+        globalThis.__wmAnalystControlTelemetry?.push({ actionType, status });
+      }
     `],
     ['ai-flow-settings-stub', `
       export function getAiFlowSettings() { return { badgeAnimation: false }; }

--- a/tests/helpers/chat-analyst-panel-harness.mjs
+++ b/tests/helpers/chat-analyst-panel-harness.mjs
@@ -55,8 +55,12 @@ async function loadChatAnalystPanel() {
     `],
     ['analytics-stub', `
       export function trackPanelResized() {}
-      export function trackAnalystControlAction(actionType, status) {
-        globalThis.__wmAnalystControlTelemetry?.push({ actionType, status });
+      export function trackAnalystControlAction(actionType, status, reason) {
+        globalThis.__wmAnalystControlTelemetry?.push({
+          actionType,
+          status,
+          ...(reason ? { reason } : {}),
+        });
       }
     `],
     ['ai-flow-settings-stub', `


### PR DESCRIPTION
## Summary

- Adds a shared zod-backed Analyst action contract plus an in-process dashboard applier for `open_panel`, `set_view`, and permitted `set_layers`.
- Wires WM Analyst SSE action events into an opt-in/pause control UI, with live app-context handling injected from `panel-layout`.
- Enforces premium/panel/layer/map/renderer gates in the applier, not in prompt instructions, and tracks applied actions without logging prompt text.
- Documents v1 as in-app only and keeps external MCP/Convex write paths out of scope.

Refs #3949

## Validation

- `./node_modules/.bin/tsx --test tests/agent-bus-actions.test.mts tests/agent-bus-applier.test.mts tests/chat-analyst.test.mts tests/chat-analyst-panel-control.test.mts tests/chat-analyst-panel-unlock.test.mts`
- `./node_modules/.bin/tsx --test tests/map-layer-executable.test.mts tests/resilience-map-layer.test.mts tests/panel-config-guardrails.test.mjs`
- `npm run lint:boundaries`
- `npm run typecheck`
- `npm run typecheck:api`
- `npm run docs:check`
- `npm run lint:md`
- `npm run lint:mintlify-slugs`
- `git diff --check`
- Pre-push hook passed, including typecheck, API typecheck, Convex typecheck, CJS syntax, Unicode safety, boundaries, safe HTML, Sentry coverage, rate-limit policies, premium-fetch parity, edge bundle/function tests, markdown/MDX lint, pro-test bundle freshness, and version sync.

## Residual / Phase 2

- No external MCP write tool, Convex action bus, cross-user command delivery, browser subscription path, OAuth quota changes, proto changes, or public write API are included here.
- Server-side action emission is intentionally deterministic and narrow for v1. Broader verbs and model/tool-driven action proposals should build on the shared schema and applier after demand is proven.
