### PR TITLE
fix(self-host): repair docker self-host stack (relay build + Redis SSRF block)

### DIFF
--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -15,8 +15,12 @@ RUN apk add --no-cache curl
 WORKDIR /app
 
 # Install scripts/ runtime dependencies (telegram, ws, fast-xml-parser, etc.)
+# --omit=optional --ignore-scripts: skip native optional deps (bufferutil /
+# utf-8-validate) so node-gyp doesn't need Python/build tools in the Alpine
+# build stage. ws/telegram run fine on the pure-JS fallback. Mirrors the
+# main Dockerfile's stage-2 pattern.
 COPY scripts/package.json scripts/package-lock.json ./scripts/
-RUN npm ci --prefix scripts --omit=dev
+RUN npm ci --prefix scripts --omit=dev --omit=optional --ignore-scripts
 
 # Relay script and shared helpers
 COPY scripts/ais-relay.cjs ./scripts/ais-relay.cjs

--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -15,10 +15,12 @@ RUN apk add --no-cache curl
 WORKDIR /app
 
 # Install scripts/ runtime dependencies (telegram, ws, fast-xml-parser, etc.)
-# --omit=optional --ignore-scripts: skip native optional deps (bufferutil /
-# utf-8-validate) so node-gyp doesn't need Python/build tools in the Alpine
-# build stage. ws/telegram run fine on the pure-JS fallback. Mirrors the
-# main Dockerfile's stage-2 pattern.
+# --ignore-scripts is the critical part: native helper packages such as
+# bufferutil/utf-8-validate can still resolve through websocket, but their
+# node-gyp-build install scripts won't run, so Alpine doesn't need Python/build
+# tools. --omit=optional also skips packages that are only optional in this
+# tree. ws/telegram fall back to pure JS when native helpers are unavailable.
+# Mirrors the main Dockerfile's stage-2 pattern.
 COPY scripts/package.json scripts/package-lock.json ./scripts/
 RUN npm ci --prefix scripts --omit=dev --omit=optional --ignore-scripts
 

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1819,6 +1819,15 @@ export async function createLocalApiServer(options = {}) {
       const boundPort = typeof address === 'object' && address?.port ? address.port : context.port;
       context.port = boundPort;
       const extraAllowedPrivateOrigins = [];
+      // Self-hosted docker: UPSTASH_REDIS_REST_URL is an operator-configured
+      // internal endpoint (e.g. http://redis-rest:80 on a private RFC1918 docker
+      // network). Trust it the same way OLLAMA_API_URL / LLM_API_URL are trusted
+      // for fetch below — otherwise the SSRF guard blocks every Redis call and
+      // all /api/* responses return 503 REDIS_DOWN. No-op on desktop where the
+      // value is a public Upstash https origin (already passes the SSRF check).
+      if (process.env.UPSTASH_REDIS_REST_URL) {
+        try { extraAllowedPrivateOrigins.push(new URL(process.env.UPSTASH_REDIS_REST_URL).origin); } catch {}
+      }
       if (context.allowPrivateRemoteBase) {
         try { extraAllowedPrivateOrigins.push(new URL(context.remoteBase).origin); } catch {}
       }

--- a/src-tauri/sidecar/local-api-server.mjs
+++ b/src-tauri/sidecar/local-api-server.mjs
@@ -1819,14 +1819,23 @@ export async function createLocalApiServer(options = {}) {
       const boundPort = typeof address === 'object' && address?.port ? address.port : context.port;
       context.port = boundPort;
       const extraAllowedPrivateOrigins = [];
-      // Self-hosted docker: UPSTASH_REDIS_REST_URL is an operator-configured
-      // internal endpoint (e.g. http://redis-rest:80 on a private RFC1918 docker
-      // network). Trust it the same way OLLAMA_API_URL / LLM_API_URL are trusted
-      // for fetch below — otherwise the SSRF guard blocks every Redis call and
-      // all /api/* responses return 503 REDIS_DOWN. No-op on desktop where the
-      // value is a public Upstash https origin (already passes the SSRF check).
-      if (process.env.UPSTASH_REDIS_REST_URL) {
-        try { extraAllowedPrivateOrigins.push(new URL(process.env.UPSTASH_REDIS_REST_URL).origin); } catch {}
+      // Docker self-host ONLY: the Redis REST proxy (UPSTASH_REDIS_REST_URL)
+      // points at an internal private host (e.g. http://redis-rest:80 on a
+      // docker network). Without trusting it the SSRF guard blocks every Redis
+      // call and all /api/* return 503 REDIS_DOWN. Gated on mode === 'docker'
+      // so desktop/production startup never widens the SSRF boundary via env
+      // — the same containment as the cloudFallback=false docker policy above,
+      // and the programmatic allowPrivateFetchOrigins escape hatch stays
+      // env-free. On desktop UPSTASH_REDIS_REST_URL is a public Upstash https
+      // origin that already passes the SSRF check, so this path is docker-only.
+      if (context.mode === 'docker' && process.env.UPSTASH_REDIS_REST_URL) {
+        try {
+          extraAllowedPrivateOrigins.push(new URL(process.env.UPSTASH_REDIS_REST_URL).origin);
+        } catch (err) {
+          context.logger.warn(
+            `[local-api] UPSTASH_REDIS_REST_URL is not a valid URL; not added to the private-fetch allowlist (Redis calls will be SSRF-blocked): ${err.message}`,
+          );
+        }
       }
       if (context.allowPrivateRemoteBase) {
         try { extraAllowedPrivateOrigins.push(new URL(context.remoteBase).origin); } catch {}

--- a/src-tauri/sidecar/local-api-server.test.mjs
+++ b/src-tauri/sidecar/local-api-server.test.mjs
@@ -696,6 +696,76 @@ test('blocks handler global fetches to private network targets (#3549)', async (
   }
 });
 
+test('allows only Docker mode to fetch configured private Redis REST origin', async () => {
+  const originalRedisUrl = process.env.UPSTASH_REDIS_REST_URL;
+  const originalRedisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+  let upstreamHits = 0;
+
+  const upstream = createServer((_req, res) => {
+    upstreamHits += 1;
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end(JSON.stringify({ ok: true }));
+  });
+  const upstreamPort = await listen(upstream);
+  const redisOrigin = `http://127.0.0.1:${upstreamPort}`;
+
+  const localApi = await setupApiDir({
+    'redis-probe.js': `
+      export default async function handler() {
+        const upstream = await fetch(process.env.UPSTASH_REDIS_REST_URL + '/ping', {
+          headers: { Authorization: 'Bearer ' + process.env.UPSTASH_REDIS_REST_TOKEN },
+        });
+        const payload = await upstream.text();
+        return new Response(payload, {
+          status: upstream.status,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+    `,
+  });
+
+  async function runProbe(mode) {
+    const app = await createLocalApiServer({
+      port: 0,
+      apiDir: localApi.apiDir,
+      mode,
+      logger: { log() { }, warn() { }, error() { } },
+    });
+    const { port } = await app.start();
+    try {
+      return await authFetch(`http://127.0.0.1:${port}/api/redis-probe`);
+    } finally {
+      await app.close();
+    }
+  }
+
+  process.env.UPSTASH_REDIS_REST_URL = redisOrigin;
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+
+  try {
+    const dockerResponse = await runProbe('docker');
+    assert.equal(dockerResponse.status, 200);
+    assert.deepEqual(await dockerResponse.json(), { ok: true });
+    assert.equal(upstreamHits, 1);
+
+    const desktopResponse = await runProbe('desktop-sidecar');
+    assert.equal(desktopResponse.status, 502);
+    const desktopBody = await desktopResponse.json();
+    assert.equal(desktopBody.error, 'Local handler error');
+    assert.match(desktopBody.reason, /SSRF blocked/);
+    assert.equal(upstreamHits, 1);
+  } finally {
+    if (originalRedisUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+    else process.env.UPSTASH_REDIS_REST_URL = originalRedisUrl;
+    if (originalRedisToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    else process.env.UPSTASH_REDIS_REST_TOKEN = originalRedisToken;
+    await localApi.cleanup();
+    await new Promise((resolve, reject) => {
+      upstream.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
 test('blocks handler global fetches to non-global IPv4 special ranges', async () => {
   const originalHttpRequest = http.request;
   const blockedUrls = [


### PR DESCRIPTION
## Summary

The documented docker self-host flow (`SELF_HOSTING.md`) fails out of the box on a clean clone, in two independent places. Both are fixed here.

**1. `Dockerfile.relay` — relay image fails to build.**
`npm ci --prefix scripts --omit=dev` builds `ws`'s *optional* native dep `bufferutil` via `node-gyp`, which needs Python + a build toolchain absent from `node:22-alpine`:

```
npm error gyp ERR! find Python ... You need to install the latest version of Python.
The command '/bin/sh -c npm ci --prefix scripts --omit=dev' returned a non-zero code: 1
```

Fix: mirror the **main** `Dockerfile`'s stage-2 flags — `--omit=optional --ignore-scripts`. `ws`/`telegram` run fine on the pure-JS fallback.

**2. `local-api-server.mjs` — every `/api/*` returns `503 REDIS_DOWN`.**
The sidecar's SSRF guard blocks all private/RFC1918 fetch targets. Under docker self-host, `UPSTASH_REDIS_REST_URL` points at the internal `redis-rest` host (a private docker-network IP), so **every Redis call is blocked** and the whole API is dead — even though `redis-rest` itself is healthy. This path only triggers under docker self-host; on desktop `UPSTASH_REDIS_REST_URL` is a public Upstash `https` origin that already passes the SSRF check, so it was never exercised.

Fix (revised after review): **only when `mode === 'docker'`**, add the operator-configured `UPSTASH_REDIS_REST_URL` origin to the private-fetch allowlist. Gating on docker mode means desktop/production startup never widens the SSRF boundary via an env var — the programmatic `allowPrivateFetchOrigins` escape hatch stays env-free, exactly as its comment documents. This mirrors the existing `cloudFallback = false` docker-mode containment. URL parse failures are logged (`logger.warn`) instead of silently swallowed.

## Type of change

- [x] Bug fix
- [x] CI / Build / Infrastructure

## Affected areas

- [x] API endpoints (`/api/*`)
- [x] Other: docker self-host (the patched file `src-tauri/sidecar/local-api-server.mjs` is shared with the Tauri desktop sidecar; the Redis change is gated to `mode === 'docker'`, so desktop is unaffected)

## Verification (arm64 / Jetson Xavier)

- `docker compose build` — the relay image now builds successfully.
- `/api/health` **before**: `503 REDIS_DOWN` (Redis unreachable).
- `/api/health` **after**: `200`, `status: UNHEALTHY` — Redis is now reachable; UNHEALTHY only because seed scripts haven't been run yet (`earthquakes: EMPTY, records: 0`). The connection itself is restored.

## Checklist

- [x] No API keys or secrets committed
- [x] TypeScript compiles — N/A (SSRF-allowlist change in a sidecar `.mjs` + Dockerfile build flags; no `.ts` touched)
- [ ] Variant smoke tests — N/A (self-host infra fix, not a UI/variant change)

---

🤖 Developed with [Claude Code](https://claude.com/claude-code) on an arm64 Jetson self-host bring-up.
