### PR TITLE
fix(export): gate evidence bundles to Pro users

### DIFF
--- a/src/components/CountryBriefPage.ts
+++ b/src/components/CountryBriefPage.ts
@@ -1,7 +1,7 @@
 import { escapeHtml, sanitizeUrl } from '@/utils/sanitize';
 import { formatIntelBrief } from '@/utils/format-intel-brief';
 import { t } from '@/services/i18n';
-import { getCSSColor } from '@/utils';
+import { getCSSColor, showToast } from '@/utils';
 import type { CountryScore } from '@/services/country-instability';
 import type { NewsItem } from '@/types';
 import type { PredictionMarket } from '@/services/prediction';
@@ -16,6 +16,9 @@ import type { CountryBriefExport, CountryEvidenceBundleInput } from '@/utils/exp
 import { ME_STRIKE_BOUNDS } from '@/services/country-geometry';
 import { toFlagEmoji } from '@/utils/country-flag';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
+import { getAuthState } from '@/services/auth-state';
+import { hasPremiumAccess } from '@/services/panel-gating';
+import { trackGateHit } from '@/services/analytics';
 
 
 type BriefAssetType = AssetType | 'port';
@@ -673,6 +676,7 @@ export class CountryBriefPage implements CountryBriefPanel {
 
   private exportBrief(format: 'json' | 'csv' | 'evidence-md'): void {
     if (!this.currentCode || !this.currentName) return;
+    if (format === 'evidence-md' && !this.canExportEvidenceBundle()) return;
     const exportedAt = new Date().toISOString();
     const data: CountryBriefExport & CountryEvidenceBundleInput = {
       country: this.currentName,
@@ -726,6 +730,13 @@ export class CountryBriefPage implements CountryBriefPanel {
     if (format === 'evidence-md') exportCountryEvidenceMarkdown(data);
     else if (format === 'json') exportCountryBriefJSON(data);
     else exportCountryBriefCSV(data);
+  }
+
+  private canExportEvidenceBundle(): boolean {
+    if (hasPremiumAccess(getAuthState())) return true;
+    trackGateHit('evidence-export');
+    showToast('Evidence export is available on Pro.');
+    return false;
   }
 
   private exportPdf(): void {

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -9,7 +9,7 @@ import type { AssetType, NewsItem, RelatedAsset } from '@/types';
 import { sanitizeUrl, escapeHtml } from '@/utils/sanitize';
 import { computeAlternativeSuppliers, type ChokepointScoreMap, type EnrichedExporter } from '@/utils/supplier-route-risk';
 import { formatIntelBrief } from '@/utils/format-intel-brief';
-import { getCSSColor } from '@/utils';
+import { getCSSColor, showToast } from '@/utils';
 import { toFlagEmoji } from '@/utils/country-flag';
 import { PORTS } from '@/config/ports';
 import { getChokepointRoutes } from '@/config/trade-routes';
@@ -2456,8 +2456,13 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
     });
     const evidenceButton = this.el('button', 'cdp-action-btn cdp-evidence-export-btn', 'Evidence') as HTMLButtonElement;
     evidenceButton.setAttribute('type', 'button');
-    evidenceButton.setAttribute('title', 'Export evidence bundle as Markdown');
+    evidenceButton.setAttribute('title', 'Export evidence bundle as Markdown (PRO)');
     evidenceButton.addEventListener('click', () => {
+      if (!hasPremiumAccess(getAuthState())) {
+        trackGateHit('evidence-export');
+        showToast('Evidence export is available on Pro.');
+        return;
+      }
       this.exportEvidenceBundle();
     });
     right.append(shareBtn, maxBtn, storyButton, exportButton, evidenceButton);

--- a/tests/country-evidence-bundle-export.test.mts
+++ b/tests/country-evidence-bundle-export.test.mts
@@ -6,8 +6,10 @@ import { join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { build } from 'esbuild';
 import { createCountryDeepDivePanelHarness } from './helpers/country-deep-dive-panel-harness.mjs';
+import { createBrowserEnvironment } from './helpers/runtime-config-panel-harness.mjs';
 
 type ExportUtils = typeof import('../src/utils/export.ts');
+type GlobalSnapshot = { exists: boolean; value: unknown };
 
 async function loadExportUtils(): Promise<ExportUtils> {
   const tempDir = mkdtempSync(join(tmpdir(), 'wm-country-evidence-export-'));
@@ -55,6 +57,283 @@ async function loadExportUtils(): Promise<ExportUtils> {
   const mod = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`);
   rmSync(tempDir, { recursive: true, force: true });
   return mod as ExportUtils;
+}
+
+function snapshotGlobal(name: string): GlobalSnapshot {
+  return {
+    exists: Object.prototype.hasOwnProperty.call(globalThis, name),
+    value: (globalThis as Record<string, unknown>)[name],
+  };
+}
+
+function restoreGlobal(name: string, snapshot: GlobalSnapshot): void {
+  if (snapshot.exists) {
+    Object.defineProperty(globalThis, name, {
+      configurable: true,
+      writable: true,
+      value: snapshot.value,
+    });
+    return;
+  }
+  delete (globalThis as Record<string, unknown>)[name];
+}
+
+function defineGlobal(name: string, value: unknown): void {
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}
+
+function zeroCountryBriefSignals() {
+  return {
+    criticalNews: 0,
+    protests: 0,
+    militaryFlights: 0,
+    militaryVessels: 0,
+    militaryFlightsInCountry: 0,
+    militaryVesselsInCountry: 0,
+    outages: 0,
+    aisDisruptions: 0,
+    satelliteFires: 0,
+    radiationAnomalies: 0,
+    temporalAnomalies: 0,
+    cyberThreats: 0,
+    earthquakes: 0,
+    displacementOutflow: 0,
+    climateStress: 0,
+    conflictEvents: 0,
+    activeStrikes: 0,
+    orefSirens: 0,
+    orefHistory24h: 0,
+    aviationDisruptions: 0,
+    travelAdvisories: 0,
+    travelAdvisoryMaxLevel: null,
+    gpsJammingHexes: 0,
+    isTier1: true,
+    thermalEscalations: 0,
+    sanctionsDesignations: 0,
+    sanctionsNewDesignations: 0,
+  };
+}
+
+async function loadCountryBriefPage(options: { premiumAccess?: boolean } = {}) {
+  const premiumAccess = options.premiumAccess === true;
+  const tempDir = mkdtempSync(join(tmpdir(), 'wm-country-brief-page-'));
+  const outfile = join(tempDir, 'CountryBriefPage.bundle.mjs');
+  const entry = resolve(process.cwd(), 'src/components/CountryBriefPage.ts');
+
+  const stubModules = new Map([
+    ['sanitize-stub', `
+      export function escapeHtml(value) { return String(value ?? ''); }
+      export function sanitizeUrl(value) { return value ?? ''; }
+    `],
+    ['intel-brief-stub', `export function formatIntelBrief(value) { return value; }`],
+    ['i18n-stub', `
+      export function t(key, params) {
+        if (params && typeof params.count === 'number') return key + ':' + params.count;
+        return key;
+      }
+    `],
+    ['utils-stub', `
+      export function getCSSColor() { return '#44ff88'; }
+      export function showToast(message) {
+        globalThis.__wmCountryBriefPageTestState.toasts.push(message);
+      }
+    `],
+    ['related-assets-stub', `
+      export function getNearbyInfrastructure() { return []; }
+      export function haversineDistanceKm() { return 0; }
+    `],
+    ['ports-stub', `export const PORTS = [];`],
+    ['export-stub', `
+      const state = globalThis.__wmCountryBriefPageTestState;
+      export function exportCountryBriefJSON(data) { state.jsonExports.push(data); }
+      export function exportCountryBriefCSV(data) { state.csvExports.push(data); }
+      export function exportCountryEvidenceMarkdown(data) { state.evidenceExports.push(data); }
+    `],
+    ['country-geometry-stub', `export const ME_STRIKE_BOUNDS = {};`],
+    ['country-flag-stub', `export function toFlagEmoji(code, fallback = ':world:') { return code ? ':' + code + ':' : fallback; }`],
+    ['dom-utils-stub', `
+      function setAttributes(el, attrText) {
+        for (const match of attrText.matchAll(/([A-Za-z0-9_-]+)="([^"]*)"/g)) {
+          el.setAttribute(match[1], match[2]);
+        }
+      }
+
+      function textFromHtml(html) {
+        return String(html ?? '').replace(/<[^>]+>/g, '').trim();
+      }
+
+      function materializeCountryBriefExportControls(root, html) {
+        if (!String(html).includes('cb-export-option')) return;
+        const page = document.createElement('div');
+        page.className = 'country-brief-page';
+        const menu = document.createElement('div');
+        menu.className = 'cb-export-menu hidden';
+        for (const match of String(html).matchAll(/<button\\s+([^>]*class="[^"]*cb-export-option[^"]*"[^>]*)>([\\s\\S]*?)<\\/button>/g)) {
+          const button = document.createElement('button');
+          setAttributes(button, match[1]);
+          button.textContent = textFromHtml(match[2]);
+          menu.appendChild(button);
+        }
+        page.appendChild(menu);
+        root.appendChild(page);
+      }
+
+      export function trustedHtml(value) { return String(value ?? ''); }
+
+      export function setTrustedHtml(el, value) {
+        const html = String(value ?? '');
+        el.innerHTML = html;
+        materializeCountryBriefExportControls(el, html);
+      }
+    `],
+    ['auth-state-stub', `export function getAuthState() { return { user: null }; }`],
+    ['panel-gating-stub', `export function hasPremiumAccess() { return ${premiumAccess ? 'true' : 'false'}; }`],
+    ['analytics-stub', `
+      export function trackGateHit(feature) {
+        globalThis.__wmCountryBriefPageTestState.gateHits.push(feature);
+      }
+    `],
+  ]);
+
+  const aliasMap = new Map([
+    ['@/utils/sanitize', 'sanitize-stub'],
+    ['@/utils/format-intel-brief', 'intel-brief-stub'],
+    ['@/services/i18n', 'i18n-stub'],
+    ['@/utils', 'utils-stub'],
+    ['@/services/related-assets', 'related-assets-stub'],
+    ['@/config/ports', 'ports-stub'],
+    ['@/utils/export', 'export-stub'],
+    ['@/services/country-geometry', 'country-geometry-stub'],
+    ['@/utils/country-flag', 'country-flag-stub'],
+    ['@/utils/dom-utils', 'dom-utils-stub'],
+    ['@/services/auth-state', 'auth-state-stub'],
+    ['@/services/panel-gating', 'panel-gating-stub'],
+    ['@/services/analytics', 'analytics-stub'],
+  ]);
+
+  const plugin = {
+    name: 'country-brief-page-test-stubs',
+    setup(buildApi: any) {
+      buildApi.onResolve({ filter: /.*/ }, (args: any) => {
+        const target = aliasMap.get(args.path);
+        return target ? { path: target, namespace: 'stub' } : null;
+      });
+      buildApi.onLoad({ filter: /.*/, namespace: 'stub' }, (args: any) => ({
+        contents: stubModules.get(args.path),
+        loader: 'js',
+      }));
+    },
+  };
+
+  const result = await build({
+    entryPoints: [entry],
+    bundle: true,
+    format: 'esm',
+    platform: 'browser',
+    target: 'es2020',
+    write: false,
+    plugins: [plugin],
+  });
+
+  writeFileSync(outfile, result.outputFiles[0].text, 'utf8');
+  const mod = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`);
+  return {
+    CountryBriefPage: mod.CountryBriefPage,
+    cleanupBundle() {
+      rmSync(tempDir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function createCountryBriefPageHarness(options: { premiumAccess?: boolean } = {}) {
+  const originalGlobals = {
+    document: snapshotGlobal('document'),
+    window: snapshotGlobal('window'),
+    localStorage: snapshotGlobal('localStorage'),
+    requestAnimationFrame: snapshotGlobal('requestAnimationFrame'),
+    cancelAnimationFrame: snapshotGlobal('cancelAnimationFrame'),
+    navigator: snapshotGlobal('navigator'),
+    HTMLElement: snapshotGlobal('HTMLElement'),
+    HTMLButtonElement: snapshotGlobal('HTMLButtonElement'),
+  };
+  const browserEnvironment = createBrowserEnvironment();
+  const state = {
+    evidenceExports: [] as Array<Record<string, unknown>>,
+    jsonExports: [] as Array<Record<string, unknown>>,
+    csvExports: [] as Array<Record<string, unknown>>,
+    gateHits: [] as string[],
+    toasts: [] as string[],
+  };
+
+  defineGlobal('document', browserEnvironment.document);
+  defineGlobal('window', browserEnvironment.window);
+  defineGlobal('localStorage', browserEnvironment.localStorage);
+  defineGlobal('requestAnimationFrame', browserEnvironment.requestAnimationFrame);
+  defineGlobal('cancelAnimationFrame', browserEnvironment.cancelAnimationFrame);
+  defineGlobal('navigator', browserEnvironment.window.navigator);
+  defineGlobal('HTMLElement', browserEnvironment.HTMLElement);
+  defineGlobal('HTMLButtonElement', browserEnvironment.HTMLButtonElement);
+  defineGlobal('__wmCountryBriefPageTestState', state);
+
+  let CountryBriefPage;
+  let cleanupBundle: (() => void) | undefined;
+  try {
+    ({ CountryBriefPage, cleanupBundle } = await loadCountryBriefPage(options));
+  } catch (error) {
+    delete (globalThis as Record<string, unknown>).__wmCountryBriefPageTestState;
+    restoreGlobal('document', originalGlobals.document);
+    restoreGlobal('window', originalGlobals.window);
+    restoreGlobal('localStorage', originalGlobals.localStorage);
+    restoreGlobal('requestAnimationFrame', originalGlobals.requestAnimationFrame);
+    restoreGlobal('cancelAnimationFrame', originalGlobals.cancelAnimationFrame);
+    restoreGlobal('navigator', originalGlobals.navigator);
+    restoreGlobal('HTMLElement', originalGlobals.HTMLElement);
+    restoreGlobal('HTMLButtonElement', originalGlobals.HTMLButtonElement);
+    throw error;
+  }
+
+  function cleanup() {
+    cleanupBundle?.();
+    delete (globalThis as Record<string, unknown>).__wmCountryBriefPageTestState;
+    restoreGlobal('document', originalGlobals.document);
+    restoreGlobal('window', originalGlobals.window);
+    restoreGlobal('localStorage', originalGlobals.localStorage);
+    restoreGlobal('requestAnimationFrame', originalGlobals.requestAnimationFrame);
+    restoreGlobal('cancelAnimationFrame', originalGlobals.cancelAnimationFrame);
+    restoreGlobal('navigator', originalGlobals.navigator);
+    restoreGlobal('HTMLElement', originalGlobals.HTMLElement);
+    restoreGlobal('HTMLButtonElement', originalGlobals.HTMLButtonElement);
+  }
+
+  return {
+    createPage() {
+      return new CountryBriefPage();
+    },
+    document: browserEnvironment.document,
+    getOverlay() {
+      return browserEnvironment.document.querySelector('.country-brief-overlay') as HTMLElement | null;
+    },
+    getEvidenceExports() {
+      return state.evidenceExports;
+    },
+    getGateHits() {
+      return state.gateHits;
+    },
+    getToasts() {
+      return state.toasts;
+    },
+    cleanup,
+  };
+}
+
+function dispatchDelegatedClick(delegateRoot: HTMLElement, target: HTMLElement): void {
+  const event = new Event('click', { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'target', { value: target });
+  delegateRoot.dispatchEvent(event);
 }
 
 describe('country evidence bundle export', () => {
@@ -288,6 +567,27 @@ describe('country evidence bundle export', () => {
     assert.match(dossierSource, /trackGateHit\('evidence-export'\)/);
     assert.match(dossierSource, /this\.exportEvidenceBundle\(\)/);
     assert.match(dossierSource, /exportCountryEvidenceMarkdown\(data\)/);
+  });
+
+  it('blocks country brief evidence export for free users', async () => {
+    const harness = await createCountryBriefPageHarness({ premiumAccess: false });
+    try {
+      const page = harness.createPage();
+      page.show('France', 'FR', null, zeroCountryBriefSignals());
+
+      const overlay = harness.getOverlay();
+      assert.ok(overlay, 'expected country brief overlay');
+      const button = overlay.querySelector('[data-format="evidence-md"]') as HTMLElement | null;
+      assert.ok(button, 'expected evidence export option');
+
+      dispatchDelegatedClick(overlay, button);
+
+      assert.equal(harness.getEvidenceExports().length, 0);
+      assert.deepEqual(harness.getGateHits(), ['evidence-export']);
+      assert.deepEqual(harness.getToasts(), ['Evidence export is available on Pro.']);
+    } finally {
+      harness.cleanup();
+    }
   });
 
   it('passes the active dossier context to the evidence exporter for Pro users when clicked', async () => {

--- a/tests/country-evidence-bundle-export.test.mts
+++ b/tests/country-evidence-bundle-export.test.mts
@@ -276,18 +276,22 @@ describe('country evidence bundle export', () => {
     assert.match(legacySource, /exportCountryEvidenceMarkdown/);
     assert.match(legacySource, /data-format="evidence-md"/);
     assert.match(legacySource, /format === 'json' \|\| format === 'csv' \|\| format === 'evidence-md'/);
+    assert.match(legacySource, /if \(format === 'evidence-md' && !this\.canExportEvidenceBundle\(\)\) return;/);
     assert.match(legacySource, /if \(format === 'evidence-md'\) exportCountryEvidenceMarkdown\(data\)/);
     assert.match(legacySource, /data-format="json"/);
     assert.match(legacySource, /data-format="csv"/);
+    assert.match(legacySource, /trackGateHit\('evidence-export'\)/);
 
     assert.match(dossierSource, /exportCountryEvidenceMarkdown/);
     assert.match(dossierSource, /cdp-evidence-export-btn/);
+    assert.match(dossierSource, /if \(!hasPremiumAccess\(getAuthState\(\)\)\)/);
+    assert.match(dossierSource, /trackGateHit\('evidence-export'\)/);
     assert.match(dossierSource, /this\.exportEvidenceBundle\(\)/);
     assert.match(dossierSource, /exportCountryEvidenceMarkdown\(data\)/);
   });
 
-  it('passes the active dossier context to the evidence exporter when clicked', async () => {
-    const harness = await createCountryDeepDivePanelHarness();
+  it('passes the active dossier context to the evidence exporter for Pro users when clicked', async () => {
+    const harness = await createCountryDeepDivePanelHarness({ premiumAccess: true });
     try {
       const panel = harness.createPanel();
       panel.show('France', 'FR', {
@@ -363,6 +367,55 @@ describe('country evidence bundle export', () => {
       assert.equal(exports[0].headlines[0].title, 'Transport unions announce strikes');
       assert.equal(exports[0].headlines[0].source, 'Reuters');
       assert.equal(exports[0].headlines[0].link, 'https://example.com/story');
+    } finally {
+      harness.cleanup();
+    }
+  });
+
+  it('blocks active dossier evidence export for free users', async () => {
+    const harness = await createCountryDeepDivePanelHarness({ premiumAccess: false });
+    try {
+      const panel = harness.createPanel();
+      panel.show('France', 'FR', null, {
+        criticalNews: 0,
+        protests: 0,
+        militaryFlights: 0,
+        militaryVessels: 0,
+        militaryFlightsInCountry: 0,
+        militaryVesselsInCountry: 0,
+        outages: 0,
+        aisDisruptions: 0,
+        satelliteFires: 0,
+        radiationAnomalies: 0,
+        temporalAnomalies: 0,
+        cyberThreats: 0,
+        earthquakes: 0,
+        displacementOutflow: 0,
+        climateStress: 0,
+        conflictEvents: 0,
+        activeStrikes: 0,
+        orefSirens: 0,
+        orefHistory24h: 0,
+        aviationDisruptions: 0,
+        travelAdvisories: 0,
+        travelAdvisoryMaxLevel: null,
+        gpsJammingHexes: 0,
+        isTier1: true,
+        thermalEscalations: 0,
+        sanctionsDesignations: 0,
+        sanctionsNewDesignations: 0,
+      });
+      for (let attempt = 0; attempt < 25 && harness.getWidgets().length === 0; attempt += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+
+      const button = harness.getPanelRoot()?.querySelector('.cdp-evidence-export-btn') as HTMLButtonElement | null;
+      assert.ok(button, 'expected evidence export button');
+      button.dispatchEvent(new Event('click'));
+
+      assert.equal(harness.getEvidenceExports().length, 0);
+      assert.deepEqual(harness.getGateHits(), ['evidence-export']);
+      assert.deepEqual(harness.getToasts(), ['Evidence export is available on Pro.']);
     } finally {
       harness.cleanup();
     }

--- a/tests/helpers/country-deep-dive-panel-harness.mjs
+++ b/tests/helpers/country-deep-dive-panel-harness.mjs
@@ -38,6 +38,7 @@ function defineGlobal(name, value) {
 
 async function loadCountryDeepDivePanel(options = {}) {
   const resilienceWidgetMode = options.resilienceWidgetMode ?? 'success';
+  const premiumAccess = options.premiumAccess === true;
   const tempDir = mkdtempSync(join(tmpdir(), 'wm-country-deep-dive-'));
   const outfile = join(tempDir, 'CountryDeepDivePanel.bundle.mjs');
   const resilienceWidgetStub = resilienceWidgetMode === 'import-reject'
@@ -147,6 +148,7 @@ async function loadCountryDeepDivePanel(options = {}) {
     `],
     ['utils-stub', `
       export function getCSSColor() { return '#44ff88'; }
+      export function showToast(msg) { globalThis.__wmCountryDeepDiveTestState.toasts.push(msg); }
       export function createCircuitBreaker() { return { execute: (fn) => fn() }; }
       export function loadFromStorage() { return null; }
       export function saveToStorage() {}
@@ -155,7 +157,7 @@ async function loadCountryDeepDivePanel(options = {}) {
     ['ports-stub', `export const PORTS = [];`],
     ['trade-routes-stub', `export function getChokepointRoutes() { return []; } export const TRADE_ROUTES = [];`],
     ['geo-stub', `export const STRATEGIC_WATERWAYS = [];`],
-    ['analytics-stub', `export function trackGateHit() {}`],
+    ['analytics-stub', `export function trackGateHit(feature) { globalThis.__wmCountryDeepDiveTestState.gateHits.push(feature); }`],
     ['chokepoint-registry-stub', `export const CHOKEPOINT_REGISTRY = [];`],
     ['supplier-route-risk-stub', `
       export function computeAlternativeSuppliers(exporters) {
@@ -181,7 +183,7 @@ async function loadCountryDeepDivePanel(options = {}) {
       export class IntelligenceServiceClient {}
     `],
     ['panel-gating-stub', `
-      export function hasPremiumAccess() { return false; }
+      export function hasPremiumAccess() { return ${premiumAccess ? 'true' : 'false'}; }
       export function getPanelGateReason() { return 'none'; }
     `],
     ['auth-state-stub', `
@@ -286,6 +288,8 @@ export async function createCountryDeepDivePanelHarness(options = {}) {
     sentryMessages: [],
     sentryUser: undefined,
     evidenceExports: [],
+    gateHits: [],
+    toasts: [],
   };
 
   defineGlobal('document', browserEnvironment.document);
@@ -351,6 +355,12 @@ export async function createCountryDeepDivePanelHarness(options = {}) {
     },
     getEvidenceExports() {
       return state.evidenceExports;
+    },
+    getGateHits() {
+      return state.gateHits;
+    },
+    getToasts() {
+      return state.toasts;
     },
     cleanup,
   };


### PR DESCRIPTION
Follow-up to #4283 after the evidence bundle PR merged while the Pro-only export gate was being applied.

Summary:
- Gate Evidence Markdown export from country briefs and country dossiers behind hasPremiumAccess.
- Track free-tier attempts as evidence-export gate hits and show a Pro-only toast.
- Extend evidence export tests so Pro users can export and free users cannot.

Validation:
- TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/country-evidence-bundle-export.test.mts
- TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/sector-route-explorer.test.mjs
- npm run typecheck
- git push pre-push hook