### PR TITLE
fix(leads): allow anonymous submit-contact/register-interest through gateway

### DIFF
--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -330,6 +330,17 @@ import { PREMIUM_RPC_PATHS } from '../src/shared/premium-paths';
 
 export const PUBLIC_NO_AUTH_RPC_PATHS = new Set<string>([
   '/api/resilience/v1/get-runtime-manifest',
+  // Lead-capture RPCs serve ANONYMOUS prospects by definition: the /pro
+  // marketing page contact form and the waitlist/desktop signup both POST
+  // without a wms_ session or API key (see pro-test/src/App.tsx onSubmit and
+  // src/services/runtime.ts isKeyFreeApiTarget). A freely-mintable anonymous
+  // session token would add zero abuse protection here — the real gates live
+  // in the handlers: server-side Turnstile (fails closed in production),
+  // honeypot, free-email-domain rejection, per-IP endpoint rate limits
+  // (server/_shared/rate-limit.ts: 3/h and 5/h), and the Convex per-email
+  // throttle. Pinned by tests/leads-gateway-public.test.mts.
+  '/api/leads/v1/submit-contact',
+  '/api/leads/v1/register-interest',
 ]);
 
 // Cacheable, non-premium RPC endpoints the Railway relay periodically warm-pings

--- a/tests/leads-gateway-public.test.mts
+++ b/tests/leads-gateway-public.test.mts
@@ -1,0 +1,87 @@
+/**
+ * Gateway-level regression tests for LeadsService public access.
+ *
+ * Regression: the enterprise contact form on the /pro marketing page POSTs
+ * to /api/leads/v1/submit-contact with NO credentials (no wms_ session, no
+ * API key) — by design, since the audience is anonymous prospects. The
+ * gateway 401'd these requests because the leads paths were missing from
+ * PUBLIC_NO_AUTH_RPC_PATHS, so the handler's own anti-abuse stack
+ * (server-side Turnstile, honeypot, free-email rejection, per-IP and
+ * per-email rate limits) never ran. Same class of breakage for
+ * register-interest, which the desktop runtime deliberately calls key-free
+ * (src/services/runtime.ts isKeyFreeApiTarget).
+ */
+
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+import { installRedis } from './helpers/fake-upstash-redis.mts';
+
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  Object.keys(process.env).forEach((k) => {
+    if (!(k in originalEnv)) delete process.env[k];
+  });
+  Object.assign(process.env, originalEnv);
+});
+
+async function loadLeadsGateway() {
+  const [{ createDomainGateway, PUBLIC_NO_AUTH_RPC_PATHS, serverOptions }, generated, { leadsHandler }, { PREMIUM_RPC_PATHS }] = await Promise.all([
+    import('../server/gateway.ts'),
+    import('../src/generated/server/worldmonitor/leads/v1/service_server.ts'),
+    import('../server/worldmonitor/leads/v1/handler.ts'),
+    import('../src/shared/premium-paths.ts'),
+  ]);
+  delete process.env.WORLDMONITOR_VALID_KEYS;
+  // The endpoint rate limiter fails closed (503) when Redis is unconfigured;
+  // install the fake so the request reaches the handler like in production.
+  installRedis({});
+  return {
+    PUBLIC_NO_AUTH_RPC_PATHS,
+    PREMIUM_RPC_PATHS,
+    gateway: createDomainGateway(generated.createLeadsServiceRoutes(leadsHandler, serverOptions)),
+  };
+}
+
+describe('leads gateway public access', () => {
+  it('declares both leads RPCs public-no-auth and non-premium', async () => {
+    const { PUBLIC_NO_AUTH_RPC_PATHS, PREMIUM_RPC_PATHS } = await loadLeadsGateway();
+    assert.equal(PUBLIC_NO_AUTH_RPC_PATHS.has('/api/leads/v1/submit-contact'), true);
+    assert.equal(PUBLIC_NO_AUTH_RPC_PATHS.has('/api/leads/v1/register-interest'), true);
+    assert.equal(PREMIUM_RPC_PATHS.has('/api/leads/v1/submit-contact'), false);
+    assert.equal(PREMIUM_RPC_PATHS.has('/api/leads/v1/register-interest'), false);
+  });
+
+  it('accepts an anonymous submit-contact POST (no API key, no session token)', async () => {
+    const { gateway } = await loadLeadsGateway();
+
+    // Honeypot-filled body: the handler short-circuits to a silent success
+    // without touching Turnstile/Convex/Resend, so this exercises ONLY the
+    // gateway auth pipeline — exactly the layer that regressed.
+    const res = await gateway(new Request('https://api.worldmonitor.app/api/leads/v1/submit-contact', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'https://worldmonitor.app',
+      },
+      body: JSON.stringify({
+        email: 'lead@example-corp.com',
+        name: 'Lead',
+        organization: 'ExampleCorp',
+        phone: '+1 555 123 4567',
+        message: 'hello',
+        source: 'enterprise-contact',
+        website: 'http://honeypot-filled.example',
+        turnstileToken: '',
+      }),
+    }));
+
+    assert.notEqual(res.status, 401, 'gateway must not 401 anonymous contact submissions');
+    assert.equal(res.status, 200);
+    const body = await res.json() as { status?: string };
+    assert.equal(body.status, 'sent');
+  });
+});

--- a/tests/leads-gateway-public.test.mts
+++ b/tests/leads-gateway-public.test.mts
@@ -84,4 +84,30 @@ describe('leads gateway public access', () => {
     const body = await res.json() as { status?: string };
     assert.equal(body.status, 'sent');
   });
+
+  it('accepts an anonymous register-interest POST (no API key, no session token)', async () => {
+    const { gateway } = await loadLeadsGateway();
+
+    // Same honeypot short-circuit as submit-contact: registerInterest returns
+    // a silent success before Turnstile/desktop-HMAC/Convex, isolating the
+    // gateway auth layer for the waitlist path too.
+    const res = await gateway(new Request('https://api.worldmonitor.app/api/leads/v1/register-interest', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Origin: 'https://worldmonitor.app',
+      },
+      body: JSON.stringify({
+        email: 'lead@example-corp.com',
+        source: 'pro-waitlist',
+        website: 'http://honeypot-filled.example',
+        turnstileToken: '',
+      }),
+    }));
+
+    assert.notEqual(res.status, 401, 'gateway must not 401 anonymous waitlist signups');
+    assert.equal(res.status, 200);
+    const body = await res.json() as { status?: string };
+    assert.equal(body.status, 'registered');
+  });
 });

--- a/tests/resilience-runtime-manifest.test.mts
+++ b/tests/resilience-runtime-manifest.test.mts
@@ -248,7 +248,11 @@ describe('resilience runtime manifest gateway auth', () => {
     delete process.env.WORLDMONITOR_VALID_KEYS;
     process.env.RESILIENCE_PILLAR_COMBINE_ENABLED = 'true';
 
-    assert.deepEqual([...PUBLIC_NO_AUTH_RPC_PATHS], ['/api/resilience/v1/get-runtime-manifest']);
+    assert.deepEqual([...PUBLIC_NO_AUTH_RPC_PATHS], [
+      '/api/resilience/v1/get-runtime-manifest',
+      '/api/leads/v1/submit-contact',
+      '/api/leads/v1/register-interest',
+    ]);
     assert.equal(PREMIUM_RPC_PATHS.has('/api/resilience/v1/get-runtime-manifest'), false);
 
     const gateway = createDomainGateway(generated.createResilienceServiceRoutes(resilienceHandler, serverOptions));


### PR DESCRIPTION
## Problem

The enterprise contact form on the /pro marketing page is broken in production: every submission fails with

```
POST https://api.worldmonitor.app/api/leads/v1/submit-contact → 401 (Unauthorized)
```

and the user sees "Failed to send. Please email enterprise@worldmonitor.app" — i.e. we are dropping inbound enterprise leads.

## Root cause

The form POSTs with **no credentials** (no `wms_` session, no API key) — correct by design, since the audience is anonymous prospects. But `/api/leads/v1/submit-contact` was never added to the gateway's `PUBLIC_NO_AUTH_RPC_PATHS`, so `validateApiKey` returns `API key required` and the gateway 401s **before the handler runs**. The handler's entire anti-abuse stack — server-side Turnstile (fails closed in production), honeypot, free-email-domain rejection, 3/h-per-IP rate limit, Convex per-email throttle — never executes.

`register-interest` has the same break: the desktop runtime deliberately calls it key-free (`src/services/runtime.ts isKeyFreeApiTarget`), and it carries the same Turnstile + scoped-rate-limit + desktop-HMAC defenses in the handler.

This is a code↔contract regression, not a design change: `docs/api-platform.mdx` describes submit-contact as "Public enterprise contact form. Turnstile-verified, rate-limited per IP", `docs/usage-rate-limits.mdx` lists both endpoints as "Per IP + Turnstile", and the OpenAPI spec declares no security requirement on either.

## Fix

Add both leads RPCs to `PUBLIC_NO_AUTH_RPC_PATHS`. Security is unchanged in practice: an anonymous `wms_` session token is freely mintable by any caller of `/api/wm-session`, so requiring one added zero abuse protection on top of Turnstile. Everything downstream of the auth check still runs for these paths — entitlement check (unrestricted tier), endpoint IP rate limit (verified empirically: it 503'd the new test until fake Redis was installed), and all handler-level gates.

## Tests

- **New** `tests/leads-gateway-public.test.mts` — written first and confirmed failing with 401 (exact production repro), green after the fix:
  - pins both leads paths as public-no-auth and non-premium
  - drives an anonymous POST through the real `createDomainGateway` pipeline; the honeypot-filled body makes the handler short-circuit so the test exercises only the gateway auth layer that regressed
- Updated the exact-set assertion in `tests/resilience-runtime-manifest.test.mts`
- `npm run test:data`: 11,303 pass / 0 fail · full `npm run typecheck` clean