### PR TITLE
fix(panel): cache panel storage maps

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -33,6 +33,7 @@ import { mlWorker } from '@/services/ml-worker';
 import { getAiFlowSettings, subscribeAiFlowChange, isHeadlineMemoryEnabled } from '@/services/ai-flow-settings';
 import { startLearning } from '@/services/country-instability';
 import { loadFromStorage, parseMapUrlState, saveToStorage, isMobileDevice } from '@/utils';
+import { clearPanelSpans, invalidatePanelStorageCacheForKeys } from '@/utils/panel-storage';
 import type { ParsedMapUrlState } from '@/utils';
 import { SignalModal, IntelligenceGapBadge, BreakingNewsBanner } from '@/components';
 import { initBreakingNewsAlerts, destroyBreakingNewsAlerts } from '@/services/breaking-news-alerts';
@@ -194,6 +195,7 @@ export class App {
     if (keys.length === 0) return;
 
     const keySet = new Set(keys);
+    invalidatePanelStorageCacheForKeys(keys);
 
     if (keySet.has(STORAGE_KEYS.panels)) {
       this.state.panelSettings = loadFromStorage<Record<string, PanelConfig>>(
@@ -784,7 +786,7 @@ export class App {
         localStorage.removeItem(PANEL_ORDER_KEY);
         localStorage.removeItem(PANEL_ORDER_KEY + '-bottom');
         localStorage.removeItem(PANEL_ORDER_KEY + '-bottom-set');
-        localStorage.removeItem(PANEL_SPANS_KEY);
+        clearPanelSpans();
         console.log('[App] Applied layout reset migration (v2.5): cleared panel order/spans');
       }
       localStorage.setItem(LAYOUT_RESET_MIGRATION_KEY, 'done');

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -28,6 +28,7 @@ import {
   setTheme,
   showToast,
 } from '@/utils';
+import { clearPanelColSpans, clearPanelSpans } from '@/utils/panel-storage';
 import {
   IDLE_PAUSE_MS,
   DEFAULT_MAP_LAYERS,
@@ -1514,8 +1515,8 @@ export class EventHandlerManager implements AppModule {
       getAllSourceNames: () => this.getAllSourceNames(),
       getLocalizedPanelName: (key: string, fallback: string) => this.getLocalizedPanelName(key, fallback),
       resetLayout: () => {
-        localStorage.removeItem(this.ctx.PANEL_SPANS_KEY);
-        localStorage.removeItem('worldmonitor-panel-col-spans');
+        clearPanelSpans();
+        clearPanelColSpans();
         localStorage.removeItem(this.ctx.PANEL_ORDER_KEY);
         localStorage.removeItem(this.ctx.PANEL_ORDER_KEY + '-bottom');
         localStorage.removeItem(this.ctx.PANEL_ORDER_KEY + '-bottom-set');

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -7,6 +7,16 @@ import { trackPanelResized } from '@/services/analytics';
 import { getAiFlowSettings } from '@/services/ai-flow-settings';
 import { getSecretState } from '@/services/runtime-config';
 import { PanelGateReason } from '@/services/panel-gating';
+import {
+  clearPanelColSpan,
+  clearPanelSpan,
+  loadPanelCollapsed,
+  loadPanelColSpans,
+  loadPanelSpans,
+  savePanelCollapsed,
+  savePanelColSpan,
+  savePanelSpan,
+} from '@/utils/panel-storage';
 
 export type PanelSeverity = 'critical' | 'high' | 'medium' | 'low' | 'none';
 
@@ -27,78 +37,9 @@ const lockSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" 
 
 const upgradeSvg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="16 12 12 8 8 12"/><line x1="12" y1="16" x2="12" y2="8"/></svg>`;
 
-const PANEL_SPANS_KEY = 'worldmonitor-panel-spans';
-
-function loadPanelSpans(): Record<string, number> {
-  try {
-    const stored = localStorage.getItem(PANEL_SPANS_KEY);
-    return stored ? JSON.parse(stored) : {};
-  } catch {
-    return {};
-  }
-}
-
-function savePanelSpan(panelId: string, span: number): void {
-  const spans = loadPanelSpans();
-  spans[panelId] = span;
-  localStorage.setItem(PANEL_SPANS_KEY, JSON.stringify(spans));
-}
-
-const PANEL_COL_SPANS_KEY = 'worldmonitor-panel-col-spans';
 const ROW_RESIZE_STEP_PX = 80;
 const COL_RESIZE_STEP_PX = 80;
 const PANELS_GRID_MIN_TRACK_PX = 280;
-
-function loadPanelColSpans(): Record<string, number> {
-  try {
-    const stored = localStorage.getItem(PANEL_COL_SPANS_KEY);
-    return stored ? JSON.parse(stored) : {};
-  } catch {
-    return {};
-  }
-}
-
-function savePanelColSpan(panelId: string, span: number): void {
-  const spans = loadPanelColSpans();
-  spans[panelId] = span;
-  localStorage.setItem(PANEL_COL_SPANS_KEY, JSON.stringify(spans));
-}
-
-const PANEL_COLLAPSED_KEY = 'worldmonitor-panel-collapsed';
-
-function loadPanelCollapsed(): Record<string, boolean> {
-  try {
-    const stored = localStorage.getItem(PANEL_COLLAPSED_KEY);
-    return stored ? JSON.parse(stored) : {};
-  } catch {
-    return {};
-  }
-}
-
-function savePanelCollapsed(panelId: string, collapsed: boolean): void {
-  const map = loadPanelCollapsed();
-  if (collapsed) {
-    map[panelId] = true;
-  } else {
-    delete map[panelId];
-  }
-  if (Object.keys(map).length === 0) {
-    localStorage.removeItem(PANEL_COLLAPSED_KEY);
-  } else {
-    localStorage.setItem(PANEL_COLLAPSED_KEY, JSON.stringify(map));
-  }
-}
-
-function clearPanelColSpan(panelId: string): void {
-  const spans = loadPanelColSpans();
-  if (!(panelId in spans)) return;
-  delete spans[panelId];
-  if (Object.keys(spans).length === 0) {
-    localStorage.removeItem(PANEL_COL_SPANS_KEY);
-    return;
-  }
-  localStorage.setItem(PANEL_COL_SPANS_KEY, JSON.stringify(spans));
-}
 
 function getDefaultColSpan(element: HTMLElement): number {
   return element.classList.contains('panel-wide') ? 2 : 1;
@@ -1201,9 +1142,7 @@ export class Panel {
    */
   public resetHeight(): void {
     this.element.classList.remove('resized', 'span-1', 'span-2', 'span-3', 'span-4');
-    const spans = loadPanelSpans();
-    delete spans[this.panelId];
-    localStorage.setItem(PANEL_SPANS_KEY, JSON.stringify(spans));
+    clearPanelSpan(this.panelId);
   }
 
   public resetWidth(): void {

--- a/src/services/mcp-store.ts
+++ b/src/services/mcp-store.ts
@@ -1,8 +1,7 @@
 import { loadFromStorage, saveToStorage } from '@/utils';
+import { clearPanelColSpanEntry, clearPanelSpanEntry } from '@/utils/panel-storage';
 
 const STORAGE_KEY = 'wm-mcp-panels';
-const PANEL_SPANS_KEY = 'worldmonitor-panel-spans';
-const PANEL_COL_SPANS_KEY = 'worldmonitor-panel-col-spans';
 const MAX_PANELS = 10;
 
 export interface McpPreset {
@@ -276,25 +275,10 @@ export function saveMcpPanel(spec: McpPanelSpec): void {
 export function deleteMcpPanel(id: string): void {
   const updated = loadMcpPanels().filter(p => p.id !== id);
   saveToStorage(STORAGE_KEY, updated);
-  cleanSpanEntry(PANEL_SPANS_KEY, id);
-  cleanSpanEntry(PANEL_COL_SPANS_KEY, id);
+  clearPanelSpanEntry(id);
+  clearPanelColSpanEntry(id);
 }
 
 export function getMcpPanel(id: string): McpPanelSpec | null {
   return loadMcpPanels().find(p => p.id === id) ?? null;
-}
-
-function cleanSpanEntry(storageKey: string, panelId: string): void {
-  try {
-    const raw = localStorage.getItem(storageKey);
-    if (!raw) return;
-    const spans = JSON.parse(raw) as Record<string, number>;
-    if (!(panelId in spans)) return;
-    delete spans[panelId];
-    if (Object.keys(spans).length === 0) {
-      localStorage.removeItem(storageKey);
-    } else {
-      localStorage.setItem(storageKey, JSON.stringify(spans));
-    }
-  } catch { /* ignore */ }
 }

--- a/src/services/widget-store.ts
+++ b/src/services/widget-store.ts
@@ -1,4 +1,5 @@
 import { loadFromStorage, saveToStorage } from '@/utils';
+import { clearPanelColSpanEntry, clearPanelSpanEntry } from '@/utils/panel-storage';
 import { sanitizeWidgetHtml } from '@/utils/widget-sanitizer';
 import { getAuthState } from '@/services/auth-state';
 import { isEntitled } from '@/services/entitlements';
@@ -9,8 +10,6 @@ import {
 } from '@/services/browser-key-session';
 
 const STORAGE_KEY = 'wm-custom-widgets';
-const PANEL_SPANS_KEY = 'worldmonitor-panel-spans';
-const PANEL_COL_SPANS_KEY = 'worldmonitor-panel-col-spans';
 const MAX_WIDGETS = 10;
 const MAX_HISTORY = 10;
 const MAX_HTML_CHARS = 50_000;
@@ -41,8 +40,8 @@ export function loadWidgets(): CustomWidgetSpec[] {
       const proHtml = localStorage.getItem(proHtmlKey(w.id));
       if (!proHtml) {
         // HTML missing — drop widget and clean up spans
-        cleanSpanEntry(PANEL_SPANS_KEY, w.id);
-        cleanSpanEntry(PANEL_COL_SPANS_KEY, w.id);
+        clearPanelSpanEntry(w.id);
+        clearPanelColSpanEntry(w.id);
         continue;
       }
       result.push({ ...w, tier, html: proHtml });
@@ -94,8 +93,8 @@ export function deleteWidget(id: string): void {
   const updated = loadFromStorage<CustomWidgetSpec[]>(STORAGE_KEY, []).filter(w => w.id !== id);
   saveToStorage(STORAGE_KEY, updated);
   try { localStorage.removeItem(proHtmlKey(id)); } catch { /* ignore */ }
-  cleanSpanEntry(PANEL_SPANS_KEY, id);
-  cleanSpanEntry(PANEL_COL_SPANS_KEY, id);
+  clearPanelSpanEntry(id);
+  clearPanelColSpanEntry(id);
 }
 
 export function getWidget(id: string): CustomWidgetSpec | null {
@@ -190,21 +189,4 @@ export function isProUser(): boolean {
 export function getProWidgetKey(): string {
   migrateLegacyKeyStorage();
   return '';
-}
-
-function cleanSpanEntry(storageKey: string, panelId: string): void {
-  try {
-    const raw = localStorage.getItem(storageKey);
-    if (!raw) return;
-    const spans = JSON.parse(raw) as Record<string, number>;
-    if (!(panelId in spans)) return;
-    delete spans[panelId];
-    if (Object.keys(spans).length === 0) {
-      localStorage.removeItem(storageKey);
-    } else {
-      localStorage.setItem(storageKey, JSON.stringify(spans));
-    }
-  } catch {
-    // ignore
-  }
 }

--- a/src/utils/panel-storage.ts
+++ b/src/utils/panel-storage.ts
@@ -1,0 +1,132 @@
+export const PANEL_SPANS_KEY = 'worldmonitor-panel-spans';
+export const PANEL_COL_SPANS_KEY = 'worldmonitor-panel-col-spans';
+export const PANEL_COLLAPSED_KEY = 'worldmonitor-panel-collapsed';
+
+let panelSpansCache: Record<string, number> | null = null;
+let panelColSpansCache: Record<string, number> | null = null;
+let panelCollapsedCache: Record<string, boolean> | null = null;
+
+function readStorageMap<T>(key: string): Record<string, T> {
+  try {
+    const stored = localStorage.getItem(key);
+    if (!stored) return {};
+    const parsed = JSON.parse(stored);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, T>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeStorageMap<T>(key: string, map: Record<string, T>): void {
+  localStorage.setItem(key, JSON.stringify(map));
+}
+
+function removeStorageMap(key: string): void {
+  localStorage.removeItem(key);
+}
+
+export function loadPanelSpans(): Readonly<Record<string, number>> {
+  panelSpansCache ??= readStorageMap<number>(PANEL_SPANS_KEY);
+  return panelSpansCache;
+}
+
+export function savePanelSpan(panelId: string, span: number): void {
+  const next = { ...loadPanelSpans(), [panelId]: span };
+  writeStorageMap(PANEL_SPANS_KEY, next);
+  panelSpansCache = next;
+}
+
+export function clearPanelSpan(panelId: string, options: { removeWhenEmpty?: boolean } = {}): void {
+  const spans = loadPanelSpans();
+  if (!(panelId in spans)) return;
+  const next = { ...spans };
+  delete next[panelId];
+  if (options.removeWhenEmpty && Object.keys(next).length === 0) {
+    removeStorageMap(PANEL_SPANS_KEY);
+    panelSpansCache = next;
+    return;
+  }
+  writeStorageMap(PANEL_SPANS_KEY, next);
+  panelSpansCache = next;
+}
+
+export function clearPanelSpans(): void {
+  removeStorageMap(PANEL_SPANS_KEY);
+  panelSpansCache = {};
+}
+
+export function loadPanelColSpans(): Readonly<Record<string, number>> {
+  panelColSpansCache ??= readStorageMap<number>(PANEL_COL_SPANS_KEY);
+  return panelColSpansCache;
+}
+
+export function savePanelColSpan(panelId: string, span: number): void {
+  const next = { ...loadPanelColSpans(), [panelId]: span };
+  writeStorageMap(PANEL_COL_SPANS_KEY, next);
+  panelColSpansCache = next;
+}
+
+export function clearPanelColSpan(panelId: string, options: { removeWhenEmpty?: boolean } = { removeWhenEmpty: true }): void {
+  const spans = loadPanelColSpans();
+  if (!(panelId in spans)) return;
+  const next = { ...spans };
+  delete next[panelId];
+  if (options.removeWhenEmpty && Object.keys(next).length === 0) {
+    removeStorageMap(PANEL_COL_SPANS_KEY);
+    panelColSpansCache = next;
+    return;
+  }
+  writeStorageMap(PANEL_COL_SPANS_KEY, next);
+  panelColSpansCache = next;
+}
+
+export function clearPanelColSpans(): void {
+  removeStorageMap(PANEL_COL_SPANS_KEY);
+  panelColSpansCache = {};
+}
+
+export function loadPanelCollapsed(): Readonly<Record<string, boolean>> {
+  panelCollapsedCache ??= readStorageMap<boolean>(PANEL_COLLAPSED_KEY);
+  return panelCollapsedCache;
+}
+
+export function savePanelCollapsed(panelId: string, collapsed: boolean): void {
+  const next = { ...loadPanelCollapsed() };
+  if (collapsed) {
+    next[panelId] = true;
+  } else {
+    delete next[panelId];
+  }
+  if (Object.keys(next).length === 0) {
+    removeStorageMap(PANEL_COLLAPSED_KEY);
+  } else {
+    writeStorageMap(PANEL_COLLAPSED_KEY, next);
+  }
+  panelCollapsedCache = next;
+}
+
+export function clearPanelSpanEntry(panelId: string): void {
+  try {
+    clearPanelSpan(panelId, { removeWhenEmpty: true });
+  } catch {
+    // Ignore corrupt or unavailable storage, matching the previous cleanup path.
+  }
+}
+
+export function clearPanelColSpanEntry(panelId: string): void {
+  try {
+    clearPanelColSpan(panelId, { removeWhenEmpty: true });
+  } catch {
+    // Ignore corrupt or unavailable storage, matching the previous cleanup path.
+  }
+}
+
+export function invalidatePanelStorageCacheForKeys(keys: Iterable<string>): void {
+  for (const key of keys) {
+    if (key === PANEL_SPANS_KEY) panelSpansCache = null;
+    else if (key === PANEL_COL_SPANS_KEY) panelColSpansCache = null;
+    else if (key === PANEL_COLLAPSED_KEY) panelCollapsedCache = null;
+  }
+}

--- a/src/utils/panel-storage.ts
+++ b/src/utils/panel-storage.ts
@@ -5,6 +5,20 @@ export const PANEL_COLLAPSED_KEY = 'worldmonitor-panel-collapsed';
 let panelSpansCache: Record<string, number> | null = null;
 let panelColSpansCache: Record<string, number> | null = null;
 let panelCollapsedCache: Record<string, boolean> | null = null;
+let storageInvalidationListenerInstalled = false;
+
+function ensurePanelStorageCacheInvalidationListener(): void {
+  if (storageInvalidationListenerInstalled) return;
+  if (typeof window === 'undefined' || typeof window.addEventListener !== 'function') return;
+  window.addEventListener('storage', (event: StorageEvent) => {
+    if (event.key === null) {
+      invalidatePanelStorageCacheForKeys([PANEL_SPANS_KEY, PANEL_COL_SPANS_KEY, PANEL_COLLAPSED_KEY]);
+      return;
+    }
+    invalidatePanelStorageCacheForKeys([event.key]);
+  });
+  storageInvalidationListenerInstalled = true;
+}
 
 function readStorageMap<T>(key: string): Record<string, T> {
   try {
@@ -28,17 +42,22 @@ function removeStorageMap(key: string): void {
 }
 
 export function loadPanelSpans(): Readonly<Record<string, number>> {
+  ensurePanelStorageCacheInvalidationListener();
   panelSpansCache ??= readStorageMap<number>(PANEL_SPANS_KEY);
   return panelSpansCache;
 }
 
 export function savePanelSpan(panelId: string, span: number): void {
+  ensurePanelStorageCacheInvalidationListener();
   const next = { ...loadPanelSpans(), [panelId]: span };
   writeStorageMap(PANEL_SPANS_KEY, next);
   panelSpansCache = next;
 }
 
+// resetHeight historically persisted an empty aggregate map instead of removing
+// the row-span key, so the default keeps that exact behavior for callers.
 export function clearPanelSpan(panelId: string, options: { removeWhenEmpty?: boolean } = {}): void {
+  ensurePanelStorageCacheInvalidationListener();
   const spans = loadPanelSpans();
   if (!(panelId in spans)) return;
   const next = { ...spans };
@@ -53,22 +72,28 @@ export function clearPanelSpan(panelId: string, options: { removeWhenEmpty?: boo
 }
 
 export function clearPanelSpans(): void {
+  ensurePanelStorageCacheInvalidationListener();
   removeStorageMap(PANEL_SPANS_KEY);
   panelSpansCache = {};
 }
 
 export function loadPanelColSpans(): Readonly<Record<string, number>> {
+  ensurePanelStorageCacheInvalidationListener();
   panelColSpansCache ??= readStorageMap<number>(PANEL_COL_SPANS_KEY);
   return panelColSpansCache;
 }
 
 export function savePanelColSpan(panelId: string, span: number): void {
+  ensurePanelStorageCacheInvalidationListener();
   const next = { ...loadPanelColSpans(), [panelId]: span };
   writeStorageMap(PANEL_COL_SPANS_KEY, next);
   panelColSpansCache = next;
 }
 
+// Column-span cleanup historically removed the aggregate key when the last
+// entry disappeared, unlike row-span reset. Keep that legacy default explicit.
 export function clearPanelColSpan(panelId: string, options: { removeWhenEmpty?: boolean } = { removeWhenEmpty: true }): void {
+  ensurePanelStorageCacheInvalidationListener();
   const spans = loadPanelColSpans();
   if (!(panelId in spans)) return;
   const next = { ...spans };
@@ -83,16 +108,19 @@ export function clearPanelColSpan(panelId: string, options: { removeWhenEmpty?: 
 }
 
 export function clearPanelColSpans(): void {
+  ensurePanelStorageCacheInvalidationListener();
   removeStorageMap(PANEL_COL_SPANS_KEY);
   panelColSpansCache = {};
 }
 
 export function loadPanelCollapsed(): Readonly<Record<string, boolean>> {
+  ensurePanelStorageCacheInvalidationListener();
   panelCollapsedCache ??= readStorageMap<boolean>(PANEL_COLLAPSED_KEY);
   return panelCollapsedCache;
 }
 
 export function savePanelCollapsed(panelId: string, collapsed: boolean): void {
+  ensurePanelStorageCacheInvalidationListener();
   const next = { ...loadPanelCollapsed() };
   if (collapsed) {
     next[panelId] = true;

--- a/src/utils/panel-storage.ts
+++ b/src/utils/panel-storage.ts
@@ -2,9 +2,9 @@ export const PANEL_SPANS_KEY = 'worldmonitor-panel-spans';
 export const PANEL_COL_SPANS_KEY = 'worldmonitor-panel-col-spans';
 export const PANEL_COLLAPSED_KEY = 'worldmonitor-panel-collapsed';
 
-let panelSpansCache: Record<string, number> | null = null;
-let panelColSpansCache: Record<string, number> | null = null;
-let panelCollapsedCache: Record<string, boolean> | null = null;
+let panelSpansCache: Readonly<Record<string, number>> | null = null;
+let panelColSpansCache: Readonly<Record<string, number>> | null = null;
+let panelCollapsedCache: Readonly<Record<string, boolean>> | null = null;
 let storageInvalidationListenerInstalled = false;
 
 function ensurePanelStorageCacheInvalidationListener(): void {
@@ -33,6 +33,10 @@ function readStorageMap<T>(key: string): Record<string, T> {
   }
 }
 
+function freezeStorageMap<T>(map: Record<string, T>): Readonly<Record<string, T>> {
+  return Object.freeze(map);
+}
+
 function writeStorageMap<T>(key: string, map: Record<string, T>): void {
   localStorage.setItem(key, JSON.stringify(map));
 }
@@ -43,7 +47,7 @@ function removeStorageMap(key: string): void {
 
 export function loadPanelSpans(): Readonly<Record<string, number>> {
   ensurePanelStorageCacheInvalidationListener();
-  panelSpansCache ??= readStorageMap<number>(PANEL_SPANS_KEY);
+  panelSpansCache ??= freezeStorageMap(readStorageMap<number>(PANEL_SPANS_KEY));
   return panelSpansCache;
 }
 
@@ -51,7 +55,7 @@ export function savePanelSpan(panelId: string, span: number): void {
   ensurePanelStorageCacheInvalidationListener();
   const next = { ...loadPanelSpans(), [panelId]: span };
   writeStorageMap(PANEL_SPANS_KEY, next);
-  panelSpansCache = next;
+  panelSpansCache = freezeStorageMap(next);
 }
 
 // resetHeight historically persisted an empty aggregate map instead of removing
@@ -64,22 +68,22 @@ export function clearPanelSpan(panelId: string, options: { removeWhenEmpty?: boo
   delete next[panelId];
   if (options.removeWhenEmpty && Object.keys(next).length === 0) {
     removeStorageMap(PANEL_SPANS_KEY);
-    panelSpansCache = next;
+    panelSpansCache = freezeStorageMap(next);
     return;
   }
   writeStorageMap(PANEL_SPANS_KEY, next);
-  panelSpansCache = next;
+  panelSpansCache = freezeStorageMap(next);
 }
 
 export function clearPanelSpans(): void {
   ensurePanelStorageCacheInvalidationListener();
   removeStorageMap(PANEL_SPANS_KEY);
-  panelSpansCache = {};
+  panelSpansCache = freezeStorageMap({});
 }
 
 export function loadPanelColSpans(): Readonly<Record<string, number>> {
   ensurePanelStorageCacheInvalidationListener();
-  panelColSpansCache ??= readStorageMap<number>(PANEL_COL_SPANS_KEY);
+  panelColSpansCache ??= freezeStorageMap(readStorageMap<number>(PANEL_COL_SPANS_KEY));
   return panelColSpansCache;
 }
 
@@ -87,35 +91,35 @@ export function savePanelColSpan(panelId: string, span: number): void {
   ensurePanelStorageCacheInvalidationListener();
   const next = { ...loadPanelColSpans(), [panelId]: span };
   writeStorageMap(PANEL_COL_SPANS_KEY, next);
-  panelColSpansCache = next;
+  panelColSpansCache = freezeStorageMap(next);
 }
 
 // Column-span cleanup historically removed the aggregate key when the last
 // entry disappeared, unlike row-span reset. Keep that legacy default explicit.
-export function clearPanelColSpan(panelId: string, options: { removeWhenEmpty?: boolean } = { removeWhenEmpty: true }): void {
+export function clearPanelColSpan(panelId: string, { removeWhenEmpty = true }: { removeWhenEmpty?: boolean } = {}): void {
   ensurePanelStorageCacheInvalidationListener();
   const spans = loadPanelColSpans();
   if (!(panelId in spans)) return;
   const next = { ...spans };
   delete next[panelId];
-  if (options.removeWhenEmpty && Object.keys(next).length === 0) {
+  if (removeWhenEmpty && Object.keys(next).length === 0) {
     removeStorageMap(PANEL_COL_SPANS_KEY);
-    panelColSpansCache = next;
+    panelColSpansCache = freezeStorageMap(next);
     return;
   }
   writeStorageMap(PANEL_COL_SPANS_KEY, next);
-  panelColSpansCache = next;
+  panelColSpansCache = freezeStorageMap(next);
 }
 
 export function clearPanelColSpans(): void {
   ensurePanelStorageCacheInvalidationListener();
   removeStorageMap(PANEL_COL_SPANS_KEY);
-  panelColSpansCache = {};
+  panelColSpansCache = freezeStorageMap({});
 }
 
 export function loadPanelCollapsed(): Readonly<Record<string, boolean>> {
   ensurePanelStorageCacheInvalidationListener();
-  panelCollapsedCache ??= readStorageMap<boolean>(PANEL_COLLAPSED_KEY);
+  panelCollapsedCache ??= freezeStorageMap(readStorageMap<boolean>(PANEL_COLLAPSED_KEY));
   return panelCollapsedCache;
 }
 
@@ -132,7 +136,7 @@ export function savePanelCollapsed(panelId: string, collapsed: boolean): void {
   } else {
     writeStorageMap(PANEL_COLLAPSED_KEY, next);
   }
-  panelCollapsedCache = next;
+  panelCollapsedCache = freezeStorageMap(next);
 }
 
 export function clearPanelSpanEntry(panelId: string): void {

--- a/src/utils/settings-persistence.ts
+++ b/src/utils/settings-persistence.ts
@@ -12,6 +12,7 @@ export interface ImportResult {
 }
 
 import { CLOUD_SYNC_KEYS } from './sync-keys';
+import { invalidatePanelStorageCacheForKeys } from './panel-storage';
 
 const MAX_IMPORT_SIZE_BYTES = 5 * 1024 * 1024;
 
@@ -87,12 +88,15 @@ export function importSettings(file: File): Promise<ImportResult> {
         }
 
         let keysImported = 0;
+        const importedKeys: string[] = [];
         for (const [key, value] of Object.entries(parsed.data)) {
           if (isSettingsKey(key) && typeof value === 'string') {
             localStorage.setItem(key, value);
             keysImported++;
+            importedKeys.push(key);
           }
         }
+        invalidatePanelStorageCacheForKeys(importedKeys);
 
         resolve({ success: true, keysImported });
       } catch (err) {

--- a/tests/helpers/minimal-panel-harness.mjs
+++ b/tests/helpers/minimal-panel-harness.mjs
@@ -67,8 +67,14 @@ async function loadMinimalPanel() {
       static MARKER_CLASS = 'minimal-test-wrapper';
       static INPUT_CLASS = 'minimal-test-input';
 
-      constructor() {
-        super({ id: 'minimal-test', title: 'Minimal Test' });
+      constructor(options = {}) {
+        super({
+          id: options.id ?? 'minimal-test',
+          title: options.title ?? 'Minimal Test',
+          collapsible: options.collapsible,
+          defaultRowSpan: options.defaultRowSpan,
+          className: options.className,
+        });
         constructorRunCount += 1;
         // Build UI ONCE — no buildUI() method, no override of unlockPanel.
         // This mirrors DeductionPanel's shape (src/components/DeductionPanel.ts:30-77).
@@ -204,7 +210,9 @@ export async function createMinimalPanelHarness() {
 
   return {
     document: browserEnvironment.document,
-    createPanel: () => new MinimalConstructorOnlyPanel(),
+    window: browserEnvironment.window,
+    localStorage: browserEnvironment.localStorage,
+    createPanel: (options) => new MinimalConstructorOnlyPanel(options),
     getConstructorRunCount,
     resetConstructorRunCount,
     cleanup() {

--- a/tests/panel-storage-cache.test.mts
+++ b/tests/panel-storage-cache.test.mts
@@ -1,0 +1,172 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { createMinimalPanelHarness } from './helpers/minimal-panel-harness.mjs';
+import {
+  invalidatePanelStorageCacheForKeys,
+  loadPanelSpans,
+  PANEL_COL_SPANS_KEY,
+  PANEL_COLLAPSED_KEY,
+  PANEL_SPANS_KEY,
+} from '../src/utils/panel-storage';
+
+const PANEL_COUNT = 86;
+
+function wrapGetItemCounter(storage: Storage) {
+  const originalGetItem = storage.getItem.bind(storage);
+  const counts = new Map<string, number>();
+  storage.getItem = ((key: string) => {
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+    return originalGetItem(key);
+  }) as Storage['getItem'];
+
+  return {
+    count(key: string): number {
+      return counts.get(key) ?? 0;
+    },
+  };
+}
+
+async function withHarness<T>(callback: (harness: Awaited<ReturnType<typeof createMinimalPanelHarness>>) => T | Promise<T>): Promise<T> {
+  const harness = await createMinimalPanelHarness();
+  try {
+    return await callback(harness);
+  } finally {
+    harness.cleanup();
+  }
+}
+
+function click(element: Element): void {
+  element.dispatchEvent(new Event('click', { bubbles: true, cancelable: true }));
+}
+
+describe('Panel storage cache', () => {
+  it('reads each aggregate storage map once across repeated Panel construction', async () => {
+    await withHarness((harness) => {
+      const spanMap = Object.fromEntries(Array.from({ length: PANEL_COUNT }, (_, index) => [`panel-${index}`, 2]));
+      const colSpanMap = Object.fromEntries(Array.from({ length: PANEL_COUNT }, (_, index) => [`panel-${index}`, 2]));
+      const collapsedMap = Object.fromEntries(Array.from({ length: PANEL_COUNT }, (_, index) => [`panel-${index}`, true]));
+      harness.localStorage.setItem(PANEL_SPANS_KEY, JSON.stringify(spanMap));
+      harness.localStorage.setItem(PANEL_COL_SPANS_KEY, JSON.stringify(colSpanMap));
+      harness.localStorage.setItem(PANEL_COLLAPSED_KEY, JSON.stringify(collapsedMap));
+
+      const counter = wrapGetItemCounter(harness.localStorage);
+
+      for (let index = 0; index < PANEL_COUNT; index++) {
+        const panel = harness.createPanel({ id: `panel-${index}`, collapsible: true });
+        const root = panel.getElement();
+        assert.equal(root.classList.contains('panel-collapsed'), true);
+        assert.equal(root.classList.contains('span-2'), true);
+        assert.equal(root.classList.contains('col-span-2'), true);
+      }
+
+      assert.equal(counter.count(PANEL_COLLAPSED_KEY), 1);
+      assert.equal(counter.count(PANEL_SPANS_KEY), 1);
+      assert.equal(counter.count(PANEL_COL_SPANS_KEY), 1);
+    });
+  });
+
+  it('hydrates persisted collapsed, row-span, and column-span state', async () => {
+    await withHarness((harness) => {
+      harness.localStorage.setItem(PANEL_SPANS_KEY, JSON.stringify({ hydrate: 3 }));
+      harness.localStorage.setItem(PANEL_COL_SPANS_KEY, JSON.stringify({ hydrate: 2 }));
+      harness.localStorage.setItem(PANEL_COLLAPSED_KEY, JSON.stringify({ hydrate: true }));
+
+      const panel = harness.createPanel({ id: 'hydrate', collapsible: true });
+      const root = panel.getElement();
+      const collapseButton = root.querySelector('.panel-collapse-btn');
+
+      assert.equal(root.classList.contains('panel-collapsed'), true);
+      assert.equal(panel.content.style.display, 'none');
+      assert.equal(collapseButton?.getAttribute('aria-expanded'), 'false');
+      assert.equal(root.classList.contains('span-3'), true);
+      assert.equal(root.classList.contains('col-span-2'), true);
+    });
+  });
+
+  it('keeps the warmed cache fresh after collapse and reset mutations', async () => {
+    await withHarness((harness) => {
+      harness.localStorage.setItem(PANEL_SPANS_KEY, JSON.stringify({ mutable: 4 }));
+      harness.localStorage.setItem(PANEL_COL_SPANS_KEY, JSON.stringify({ mutable: 2 }));
+      harness.localStorage.setItem(PANEL_COLLAPSED_KEY, JSON.stringify({ mutable: true }));
+
+      const panel = harness.createPanel({ id: 'mutable', collapsible: true });
+      const root = panel.getElement();
+      assert.equal(root.classList.contains('panel-collapsed'), true);
+      assert.equal(root.classList.contains('span-4'), true);
+      assert.equal(root.classList.contains('col-span-2'), true);
+
+      const collapseButton = root.querySelector('.panel-collapse-btn');
+      assert.ok(collapseButton, 'collapse button is rendered for collapsible panel');
+      click(collapseButton);
+      assert.equal(harness.localStorage.getItem(PANEL_COLLAPSED_KEY), null);
+
+      panel.resetHeight();
+      assert.equal(harness.localStorage.getItem(PANEL_SPANS_KEY), '{}');
+
+      panel.resetWidth();
+      assert.equal(harness.localStorage.getItem(PANEL_COL_SPANS_KEY), null);
+
+      const laterPanel = harness.createPanel({ id: 'mutable', collapsible: true });
+      const laterRoot = laterPanel.getElement();
+      assert.equal(laterRoot.classList.contains('panel-collapsed'), false);
+      assert.equal(laterRoot.classList.contains('span-4'), false);
+      assert.equal(laterRoot.classList.contains('col-span-2'), false);
+    });
+  });
+
+  it('bounds reads and falls back safely for corrupt or throwing storage', async () => {
+    await withHarness((harness) => {
+      harness.localStorage.setItem(PANEL_SPANS_KEY, '{bad json');
+      harness.localStorage.setItem(PANEL_COL_SPANS_KEY, '[]');
+      harness.localStorage.setItem(PANEL_COLLAPSED_KEY, '{bad json');
+      const counter = wrapGetItemCounter(harness.localStorage);
+
+      for (let index = 0; index < 3; index++) {
+        const panel = harness.createPanel({ id: `corrupt-${index}`, collapsible: true });
+        const root = panel.getElement();
+        assert.equal(root.classList.contains('panel-collapsed'), false);
+        assert.equal(root.classList.contains('span-2'), false);
+        assert.equal(root.classList.contains('col-span-2'), false);
+      }
+
+      assert.equal(counter.count(PANEL_COLLAPSED_KEY), 1);
+      assert.equal(counter.count(PANEL_SPANS_KEY), 1);
+      assert.equal(counter.count(PANEL_COL_SPANS_KEY), 1);
+    });
+
+    await withHarness((harness) => {
+      const originalGetItem = harness.localStorage.getItem.bind(harness.localStorage);
+      const counts = new Map<string, number>();
+      harness.localStorage.getItem = ((key: string) => {
+        if ([PANEL_SPANS_KEY, PANEL_COL_SPANS_KEY, PANEL_COLLAPSED_KEY].includes(key)) {
+          counts.set(key, (counts.get(key) ?? 0) + 1);
+          throw new Error('storage unavailable');
+        }
+        return originalGetItem(key);
+      }) as Storage['getItem'];
+
+      for (let index = 0; index < 3; index++) {
+        assert.doesNotThrow(() => harness.createPanel({ id: `throwing-${index}`, collapsible: true }));
+      }
+
+      assert.equal(counts.get(PANEL_COLLAPSED_KEY), 1);
+      assert.equal(counts.get(PANEL_SPANS_KEY), 1);
+      assert.equal(counts.get(PANEL_COL_SPANS_KEY), 1);
+    });
+  });
+
+  it('invalidates cached panel maps after direct storage replacement', async () => {
+    await withHarness((harness) => {
+      invalidatePanelStorageCacheForKeys([PANEL_SPANS_KEY, PANEL_COL_SPANS_KEY, PANEL_COLLAPSED_KEY]);
+      harness.localStorage.setItem(PANEL_SPANS_KEY, JSON.stringify({ imported: 1 }));
+      assert.equal(loadPanelSpans().imported, 1);
+
+      harness.localStorage.setItem(PANEL_SPANS_KEY, JSON.stringify({ imported: 3 }));
+      assert.equal(loadPanelSpans().imported, 1, 'cache stays warm until the writer reports replacement');
+
+      invalidatePanelStorageCacheForKeys([PANEL_SPANS_KEY]);
+      assert.equal(loadPanelSpans().imported, 3);
+    });
+  });
+});

--- a/tests/panel-storage-cache.test.mts
+++ b/tests/panel-storage-cache.test.mts
@@ -3,7 +3,9 @@ import { describe, it } from 'node:test';
 
 import { createMinimalPanelHarness } from './helpers/minimal-panel-harness.mjs';
 import {
+  clearPanelColSpan,
   invalidatePanelStorageCacheForKeys,
+  loadPanelColSpans,
   loadPanelSpans,
   PANEL_COL_SPANS_KEY,
   PANEL_COLLAPSED_KEY,
@@ -11,6 +13,10 @@ import {
 } from '../src/utils/panel-storage';
 
 const PANEL_COUNT = 86;
+
+function invalidateAllPanelStorageCaches(): void {
+  invalidatePanelStorageCacheForKeys([PANEL_SPANS_KEY, PANEL_COL_SPANS_KEY, PANEL_COLLAPSED_KEY]);
+}
 
 function wrapGetItemCounter(storage: Storage) {
   const originalGetItem = storage.getItem.bind(storage);
@@ -157,6 +163,7 @@ describe('Panel storage cache', () => {
   });
 
   it('invalidates warmed maps when another tab changes panel storage', () => {
+    invalidateAllPanelStorageCaches();
     const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
     const originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
     const values = new Map<string, string>();
@@ -210,9 +217,38 @@ describe('Panel storage cache', () => {
     }
   });
 
+  it('returns frozen cached maps so callers cannot mutate tab-wide storage state', async () => {
+    await withHarness((harness) => {
+      invalidateAllPanelStorageCaches();
+      harness.localStorage.setItem(PANEL_SPANS_KEY, JSON.stringify({ immutable: 2 }));
+
+      const spans = loadPanelSpans();
+      assert.equal(Object.isFrozen(spans), true);
+      assert.throws(() => {
+        (spans as Record<string, number>).poisoned = 5;
+      }, TypeError);
+
+      assert.equal(loadPanelSpans().poisoned, undefined);
+      assert.equal(loadPanelSpans().immutable, 2);
+    });
+  });
+
+  it('keeps column-span removeWhenEmpty default when options object is empty', async () => {
+    await withHarness((harness) => {
+      invalidateAllPanelStorageCaches();
+      harness.localStorage.setItem(PANEL_COL_SPANS_KEY, JSON.stringify({ compact: 2 }));
+
+      assert.equal(loadPanelColSpans().compact, 2);
+      clearPanelColSpan('compact', {});
+
+      assert.equal(harness.localStorage.getItem(PANEL_COL_SPANS_KEY), null);
+      assert.equal(Object.keys(loadPanelColSpans()).length, 0);
+    });
+  });
+
   it('invalidates cached panel maps after direct storage replacement', async () => {
     await withHarness((harness) => {
-      invalidatePanelStorageCacheForKeys([PANEL_SPANS_KEY, PANEL_COL_SPANS_KEY, PANEL_COLLAPSED_KEY]);
+      invalidateAllPanelStorageCaches();
       harness.localStorage.setItem(PANEL_SPANS_KEY, JSON.stringify({ imported: 1 }));
       assert.equal(loadPanelSpans().imported, 1);
 

--- a/tests/panel-storage-cache.test.mts
+++ b/tests/panel-storage-cache.test.mts
@@ -156,6 +156,60 @@ describe('Panel storage cache', () => {
     });
   });
 
+  it('invalidates warmed maps when another tab changes panel storage', () => {
+    const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+    const values = new Map<string, string>();
+    let storageListener: ((event: Event & { key: string | null }) => void) | null = null;
+
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      writable: true,
+      value: {
+        addEventListener(type: string, listener: EventListener) {
+          if (type === 'storage') {
+            storageListener = listener as (event: Event & { key: string | null }) => void;
+          }
+        },
+      },
+    });
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      writable: true,
+      value: {
+        getItem(key: string) {
+          return values.get(key) ?? null;
+        },
+        setItem(key: string, value: string) {
+          values.set(key, String(value));
+        },
+        removeItem(key: string) {
+          values.delete(key);
+        },
+      },
+    });
+
+    try {
+      values.set(PANEL_SPANS_KEY, JSON.stringify({ crossTab: 1 }));
+      assert.equal(loadPanelSpans().crossTab, 1);
+      assert.ok(storageListener, 'panel storage installs a storage-event invalidation listener');
+
+      values.set(PANEL_SPANS_KEY, JSON.stringify({ crossTab: 3 }));
+      assert.equal(loadPanelSpans().crossTab, 1, 'cache remains warm before the cross-tab event');
+
+      const event = new Event('storage') as Event & { key: string | null };
+      Object.defineProperty(event, 'key', { value: PANEL_SPANS_KEY });
+      storageListener(event);
+
+      assert.equal(loadPanelSpans().crossTab, 3, 'storage event invalidates the warmed map');
+    } finally {
+      if (originalWindow) Object.defineProperty(globalThis, 'window', originalWindow);
+      else delete (globalThis as { window?: unknown }).window;
+      if (originalLocalStorage) Object.defineProperty(globalThis, 'localStorage', originalLocalStorage);
+      else delete (globalThis as { localStorage?: unknown }).localStorage;
+    }
+  });
+
   it('invalidates cached panel maps after direct storage replacement', async () => {
     await withHarness((harness) => {
       invalidatePanelStorageCacheForKeys([PANEL_SPANS_KEY, PANEL_COL_SPANS_KEY, PANEL_COLLAPSED_KEY]);

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -342,15 +342,15 @@ describe('widget-store — constants and logic', () => {
 
   it('deleteWidget cleans worldmonitor-panel-spans (aggregate map)', () => {
     assert.ok(
-      store.includes("'worldmonitor-panel-spans'"),
-      "deleteWidget must clean 'worldmonitor-panel-spans'",
+      store.includes('clearPanelSpanEntry(id)'),
+      'deleteWidget must clean row-span entries through the shared panel storage helper',
     );
   });
 
   it('deleteWidget cleans worldmonitor-panel-col-spans (aggregate map)', () => {
     assert.ok(
-      store.includes("'worldmonitor-panel-col-spans'"),
-      "deleteWidget must clean 'worldmonitor-panel-col-spans'",
+      store.includes('clearPanelColSpanEntry(id)'),
+      'deleteWidget must clean column-span entries through the shared panel storage helper',
     );
   });
 


### PR DESCRIPTION
## Summary

- Add a shared cached panel-storage helper for row spans, column spans, and collapsed state.
- Route `Panel` construction and existing cleanup/reset/direct-replacement paths through the helper so cold init reads each aggregate map once while cache freshness stays correct.
- Add behavioral coverage for constructor read counts, persisted hydration, mutation freshness, corrupt/throwing storage fallback, and explicit cache invalidation.
- Address Greptile follow-up by invalidating warmed caches on cross-tab `storage` events and documenting the intentional row-vs-column cleanup asymmetry.

## Intent

Fixes #3536 by removing redundant synchronous `localStorage.getItem` + `JSON.parse` work from `Panel` cold construction without changing storage keys, JSON formats, panel layout behavior, or variant behavior.

Accepted tradeoffs:
- Use a module-local cache for the three existing aggregate maps rather than adding new constructor options across the panel fleet.
- Keep row-span reset and column-span cleanup semantics aligned with the previous behavior.
- Invalidate the cache after cloud/settings direct replacement writes instead of redesigning those flows.

Non-goals:
- No panel layout refactor.
- No persistence format migration.
- No user-visible UI changes.

## Validation Matrix

| Check | Status | Evidence |
| --- | --- | --- |
| Focused panel storage cache behavior | Pass | `TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/panel-storage-cache.test.mts` |
| Adjacent panel/widget/cloud guards | Pass | `TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/panel-unlock-restore.test.mts tests/widget-builder.test.mjs tests/cloud-prefs-panel-sync-guard.test.mjs` |
| Frontend typecheck | Pass | `npm run typecheck` |
| Diff hygiene | Pass | `git diff --check` |
| Pre-push hook | Pass | ran on both pushes; required local gates passed |

Note: `tsx` was run outside the sandbox because the sandboxed command failed before tests executed with `listen EPERM` on the tsx IPC pipe.

## Documentation

Not applicable. This is an internal performance fix; documented storage keys/formats and user-visible panel behavior are unchanged.

## Screenshots / UI Evidence

Not applicable. No visual UI change.

## Residual Findings

None.

## Review Follow-up

Greptile posted two comments on the first head. The cross-tab cache staleness issue was fixed in `b8829b0a8` with a `storage` event invalidation listener and regression test. The intentional `clearPanelSpan` / `clearPanelColSpan` empty-map asymmetry was documented in code to preserve legacy behavior.
