### PR TITLE
Require full PortWatch country coverage for healthy port activity

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -327,7 +327,7 @@ const SEED_META = {
   theaterPosture:   { key: 'seed-meta:theater-posture',         maxStaleMin: 60 },
   correlationCards: { key: 'seed-meta:correlation:cards',       maxStaleMin: 30 }, // 5min cron (seed-bundle-derived-signals); 30min = 6× interval. Was 15 (3× = gold-standard floor) — overnight UptimeRobot flips when bundle jitter spaced two consecutive runs ~9-10min apart, producing 15-19min gaps that tripped STALE_SEED briefly. See WM 2026-05-10 health:failure-log.
   portwatch:           { key: 'seed-meta:supply_chain:portwatch',            maxStaleMin: 720 },
-  portwatchPortActivity: { key: 'seed-meta:supply_chain:portwatch-ports',   maxStaleMin: 2160 }, // 12h cron; 2160min = 36h = 3x interval
+  portwatchPortActivity: { key: 'seed-meta:supply_chain:portwatch-ports',   maxStaleMin: 2160, minRecordCount: 174 }, // 12h cron; 36h = 3x interval; #3613 requires full 174-country coverage before OK.
   corridorrisk:        { key: 'seed-meta:supply_chain:corridorrisk',         maxStaleMin: 120 },
   chokepointTransits:  { key: 'seed-meta:supply_chain:chokepoint_transits',  maxStaleMin: 30 }, // relay every 10min; 30min = 3x interval,
   transitSummaries:    { key: 'seed-meta:supply_chain:transit-summaries',    maxStaleMin: 30 }, // relay every 10min; 30min = 3x interval,

--- a/api/mcp/freshness.ts
+++ b/api/mcp/freshness.ts
@@ -1,5 +1,14 @@
 import type { FreshnessCheck } from './types';
 
+function parseFiniteRecordCount(raw: unknown): number | null {
+  if (typeof raw === 'number') return Number.isFinite(raw) ? raw : null;
+  if (typeof raw === 'string' && raw.trim() !== '') {
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
 export function evaluateFreshness(checks: FreshnessCheck[], metas: unknown[], now = Date.now()): { cached_at: string | null; stale: boolean } {
   let stale = false;
   let oldestFetchedAt = Number.POSITIVE_INFINITY;
@@ -21,6 +30,13 @@ export function evaluateFreshness(checks: FreshnessCheck[], metas: unknown[], no
     hasAnyValidMeta = true;
     oldestFetchedAt = Math.min(oldestFetchedAt, fetchedAt);
     stale ||= (now - fetchedAt) / 60_000 > check.maxStaleMin;
+
+    if (check.minRecordCount != null) {
+      const recordCount = meta && typeof meta === 'object' && 'recordCount' in meta
+        ? parseFiniteRecordCount((meta as { recordCount: unknown }).recordCount)
+        : null;
+      stale ||= recordCount == null || recordCount < check.minRecordCount;
+    }
   }
 
   return {

--- a/api/mcp/registry/cache-tools.ts
+++ b/api/mcp/registry/cache-tools.ts
@@ -1606,7 +1606,7 @@ export const CACHE_TOOLS: ToolDef[] = [
     _freshnessChecks: [
       { key: 'seed-meta:supply_chain:transit-summaries',   maxStaleMin: 30 },             // 10-min relay; 30min = 3× interval
       { key: 'seed-meta:supply_chain:chokepoint_transits', maxStaleMin: 30 },             // 10-min relay; 30min = 3× interval
-      { key: 'seed-meta:supply_chain:portwatch-ports',     maxStaleMin: 2160 },           // 12h cron; 36h = 3× interval
+      { key: 'seed-meta:supply_chain:portwatch-ports',     maxStaleMin: 2160, minRecordCount: 174 }, // 12h cron; 36h = 3× interval; #3613 requires full country coverage
       { key: 'seed-meta:energy:chokepoint-baselines',      maxStaleMin: 60 * 24 * 400 },  // ~400d static registry
       { key: 'seed-meta:portwatch:chokepoints-ref',        maxStaleMin: 60 * 24 * 14 },   // weekly cron; 14d = 2× interval
       { key: 'seed-meta:energy:chokepoint-flows',          maxStaleMin: 720 },            // 6h cron; 12h = 2× interval

--- a/api/mcp/types.ts
+++ b/api/mcp/types.ts
@@ -97,6 +97,7 @@ export interface BaseToolDef {
 export interface FreshnessCheck {
   key: string;
   maxStaleMin: number;
+  minRecordCount?: number;
 }
 
 // Cache-read tool: reads one or more Redis keys and returns them with staleness info.

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -322,6 +322,7 @@ export default async function handler(req) {
 
     if (!meta) {
       seeds[domain] = { status: 'missing', fetchedAt: null, recordCount: null, stale: true };
+      if (cfg.minRecordCount != null) seeds[domain].minRecordCount = cfg.minRecordCount;
       missingCount++;
       continue;
     }

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -111,7 +111,7 @@ const SEED_DOMAINS = {
   'economic:fatf-listing':     { key: 'seed-meta:economic:fatf-listing',     intervalMin: 30240 }, // FATF plenary 3×/year; intervalMin = health.js maxStaleMin / 2 (60480 / 2)
   'product-catalog':          { key: 'seed-meta:product-catalog',          intervalMin: 360 }, // relay loop every 6h; intervalMin = health.js maxStaleMin / 3 (1080 / 3)
   'portwatch:chokepoints-ref': { key: 'seed-meta:portwatch:chokepoints-ref', intervalMin: 10080 }, // seed-bundle-portwatch runs this at WEEK cadence; intervalMin*2 = 14d matches api/health.js SEED_META.portwatchChokepointsRef
-  'supply_chain:portwatch-ports': { key: 'seed-meta:supply_chain:portwatch-ports', intervalMin: 720 }, // 12h cron (0 */12 * * *); intervalMin = maxStaleMin / 3 (2160 / 3)
+  'supply_chain:portwatch-ports': { key: 'seed-meta:supply_chain:portwatch-ports', intervalMin: 720, minRecordCount: 174 }, // 12h cron (0 */12 * * *); intervalMin = maxStaleMin / 3 (2160 / 3); #3613 requires 174-country coverage before OK.
   'energy:chokepoint-flows': { key: 'seed-meta:energy:chokepoint-flows', intervalMin: 360 }, // 6h relay loop; intervalMin = maxStaleMin / 2 (720 / 2)
   'energy:eia-petroleum':   { key: 'seed-meta:energy:eia-petroleum',   intervalMin: 1440 }, // daily bundle cron; intervalMin*3 = health.js maxStaleMin (4320)
   'energy:spine':                 { key: 'seed-meta:energy:spine',                 intervalMin: 1440 }, // daily cron (0 6 * * *); intervalMin = maxStaleMin / 2 (2880 / 2)
@@ -138,6 +138,15 @@ function parseJsonValue(raw) {
   } catch {
     return null;
   }
+}
+
+function parseFiniteRecordCount(raw) {
+  if (typeof raw === 'number') return Number.isFinite(raw) ? raw : null;
+  if (typeof raw === 'string' && raw.trim() !== '') {
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
 }
 
 function isEnabledEnv(name, defaultValue) {
@@ -318,6 +327,8 @@ export default async function handler(req) {
     }
 
     const ageMs = now - (meta.fetchedAt || 0);
+    const recordCount = parseFiniteRecordCount(meta.recordCount);
+    const coveragePartial = cfg.minRecordCount != null && (recordCount == null || recordCount < cfg.minRecordCount);
     const isError = meta.status === 'error';
     const probe = evaluateDataProbe(cfg.dataProbe, probeMap.get(domain));
     const sourceMismatch = Boolean(
@@ -326,7 +337,7 @@ export default async function handler(req) {
       meta.sourceVersion !== '' &&
       meta.sourceVersion !== cfg.dataProbe.sourceVersion
     );
-    const stale = ageMs > maxStalenessMs || isError || sourceMismatch || probe?.ok === false;
+    const stale = ageMs > maxStalenessMs || coveragePartial || isError || sourceMismatch || probe?.ok === false;
     if (stale) staleCount++;
 
     seeds[domain] = {
@@ -336,15 +347,18 @@ export default async function handler(req) {
           ? 'source_version_mismatch'
           : probe?.ok === false
             ? probe.status
-            : stale
+            : coveragePartial
+              ? 'coverage_partial'
+              : stale
               ? 'stale'
               : 'ok',
       fetchedAt: meta.fetchedAt,
-      recordCount: meta.recordCount ?? null,
+      recordCount: recordCount ?? meta.recordCount ?? null,
       sourceVersion: meta.sourceVersion || null,
       ageMinutes: Math.round(ageMs / 60000),
       stale,
     };
+    if (cfg.minRecordCount != null) seeds[domain].minRecordCount = cfg.minRecordCount;
     if (probe) seeds[domain].dataProbe = probe;
   }
 

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -76,7 +76,7 @@ Keys are grouped into three tiers that determine alert severity:
 | `OK_CASCADE` | Green | Key empty but a sibling in the cascade group has data (e.g., theater posture fallback chain) |
 | `STALE_SEED` | Warn | Data present but `seed-meta` age exceeds `maxStaleMin` |
 | `STALE_CONTENT` | Warn | Seeder is fresh but the upstream content stopped advancing (frozen feed); counted in `summary.staleContent` |
-| `COVERAGE_PARTIAL` | Warn | Record count is below the key's declared `minRecordCount` (e.g. 10/13 chokepoints) |
+| `COVERAGE_PARTIAL` | Warn | Record count is below the key's declared `minRecordCount` (e.g. 10/13 chokepoints or 139/174 PortWatch port-activity countries) |
 | `SEED_ERROR` | Warn | `seed-meta` reports `status: "error"` from the last seed run |
 | `REDIS_PARTIAL` | Warn | A single per-command Redis error on this key's STRLEN/GET (not a full outage) |
 | `EMPTY_ON_DEMAND` | Warn | On-demand key has no data yet (expected until first request); counted in `summary.onDemandWarn` |
@@ -99,6 +99,12 @@ feed, matching the CII v8 scorer. When those feeds are reachable but quiet,
 `riskScores` can still report
 `COVERAGE_PARTIAL`; underlying feed freshness is tracked by the source-specific
 health entries where those feeds publish seed metadata.
+
+`portwatchPortActivity` also uses `minRecordCount`. A fresh
+`seed-meta:supply_chain:portwatch-ports` record below 174 countries reports
+`COVERAGE_PARTIAL` instead of `OK`; partial runs may still refresh per-country
+PortWatch cache entries, but the canonical country list and healthy seed-meta
+signal do not advance until full 174-country coverage returns.
 
 ### Staleness Thresholds (maxStaleMin)
 
@@ -145,7 +151,7 @@ Focused endpoint for seed loop freshness. Checks only `seed-meta:*` keys without
 | HTTP Status | Overall Status | Meaning |
 |-------------|---------------|---------|
 | `200` | `healthy` | All seed loops reporting on time |
-| `200` | `warning` | Some seeds stale (age > 2x interval) |
+| `200` | `warning` | Some seeds stale (age > 2x interval) or below a declared coverage floor |
 | `200` | `degraded` | Some seeds missing entirely |
 | `401` | - | Invalid or missing API key |
 | `503` | - | Redis unavailable |
@@ -172,6 +178,15 @@ Focused endpoint for seed loop freshness. Checks only `seed-meta:*` keys without
       "sourceVersion": null,
       "ageMinutes": 140,
       "stale": true
+    },
+    "supply_chain:portwatch-ports": {
+      "status": "coverage_partial",
+      "fetchedAt": 1710158100000,
+      "recordCount": 139,
+      "minRecordCount": 174,
+      "sourceVersion": null,
+      "ageMinutes": 5,
+      "stale": true
     }
   }
 }
@@ -179,7 +194,7 @@ Focused endpoint for seed loop freshness. Checks only `seed-meta:*` keys without
 
 ### Staleness Logic
 
-A seed is considered stale when its age exceeds **2x the configured interval**. This accounts for normal jitter in cron/relay timing.
+A seed is considered stale when its age exceeds **2x the configured interval**. This accounts for normal jitter in cron/relay timing. Seeds with an explicit `minRecordCount` also report `coverage_partial` and `stale: true` until their coverage floor is met.
 
 | Domain | Interval (min) | Stale After (min) |
 |--------|---------------|-------------------|

--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -23,6 +23,11 @@ const LOCK_DOMAIN = 'supply_chain:portwatch-ports';
 // 60 min — covers the widest realistic run of this standalone service.
 const LOCK_TTL_MS = 60 * 60 * 1000;
 const TTL = 259_200; // 3 days — 6× the 12h cron interval
+// PortWatch currently has 174 ISO2-mapped countries with port references.
+// This is the issue #3613 completion target: a run below this count can
+// contribute per-country cache rotation, but must not advance the canonical
+// list or seed-meta as if coverage had recovered.
+export const PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES = 174;
 // Coverage gate for per-country WRITES. Lowered to 5 on 2026-05-18 (was
 // 50 → 25 → 20) so partial-success runs (6-10/30) can persist their fresh
 // per-country payloads to Redis. Below this floor, NOTHING is written.
@@ -56,10 +61,11 @@ const MIN_VALID_COUNTRIES = 5;
 // 5-entry canonical list (3% coverage published as "healthy"). With
 // this gate, the canonical only advances when coverage is meaningful.
 //
-// 50 chosen as a hold-over target — matches the historical pre-incident
-// gate. Bump to 100 / 174 as cache-rotation accumulates and the
-// expected steady-state coverage grows.
-const MIN_CANONICAL_PUBLISH = 50;
+// 174 chosen as the explicit #3613 recovery target. Anything below this
+// remains a partial recovery run: per-country writes may rotate in, but the
+// public canonical list + operator seed-meta stay on the prior version so
+// /api/health cannot report partial coverage as OK.
+const MIN_CANONICAL_PUBLISH = PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES;
 
 const EP3_BASE =
   'https://services9.arcgis.com/weJ1QsnbMYJlCHdG/arcgis/rest/services/Daily_Ports_Data/FeatureServer/0/query';
@@ -1175,7 +1181,12 @@ export async function fetchAll(progress, { signal } = {}) {
 }
 
 export function validateFn(data) {
-  return data && Array.isArray(data.countries) && data.countries.length >= MIN_VALID_COUNTRIES;
+  return !!(data && Array.isArray(data.countries) && data.countries.length >= MIN_VALID_COUNTRIES);
+}
+
+export function shouldAdvanceCanonical(countryCount, floor = MIN_CANONICAL_PUBLISH) {
+  const count = Number(countryCount);
+  return Number.isFinite(count) && count >= floor;
 }
 
 async function main() {
@@ -1311,7 +1322,7 @@ async function main() {
     // accumulates), but CANONICAL + META only advance when total coverage
     // crosses MIN_CANONICAL_PUBLISH — protects consumers from seeing a
     // 5-country canonical published as "healthy" during recovery.
-    const canonicalAdvances = countryData.size >= MIN_CANONICAL_PUBLISH;
+    const canonicalAdvances = shouldAdvanceCanonical(countryData.size);
     const metaPayload = { fetchedAt: Date.now(), recordCount: countryData.size };
 
     const commands = [];

--- a/scripts/seed-portwatch-port-activity.mjs
+++ b/scripts/seed-portwatch-port-activity.mjs
@@ -24,9 +24,10 @@ const LOCK_DOMAIN = 'supply_chain:portwatch-ports';
 const LOCK_TTL_MS = 60 * 60 * 1000;
 const TTL = 259_200; // 3 days — 6× the 12h cron interval
 // PortWatch currently has 174 ISO2-mapped countries with port references.
-// This is the issue #3613 completion target: a run below this count can
-// contribute per-country cache rotation, but must not advance the canonical
-// list or seed-meta as if coverage had recovered.
+// This is the issue #3613 health target. Runs below this count must stay
+// non-green in /api/health and /api/seed-health, but they still need to
+// advance seed-meta/canonical when they meet the recovery publish floor below
+// so fetchedAt does not freeze and incremental coverage gains reach consumers.
 export const PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES = 174;
 // Coverage gate for per-country WRITES. Lowered to 5 on 2026-05-18 (was
 // 50 → 25 → 20) so partial-success runs (6-10/30) can persist their fresh
@@ -36,10 +37,10 @@ export const PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES = 174;
 // writes through (so the cache-fresh rotation accumulates), but a
 // SEPARATE higher threshold gates the CANONICAL list + seed-meta advance.
 // This decoupling addresses Greptile PR #3760 P1: lowering this gate
-// alone would have let a 5-country run REPLACE the 174-country canonical
-// snapshot, exposing consumers to a 3% coverage canonical published as
-// fresh. Now the canonical stays at the prior version until coverage
-// genuinely recovers (see MIN_CANONICAL_PUBLISH).
+// alone would have let a 5-country run REPLACE the prior canonical snapshot,
+// exposing consumers to a 3% coverage canonical published as fresh. Now the
+// canonical stays at the prior version until coverage reaches the recovery
+// publish floor (see MIN_CANONICAL_PUBLISH).
 //
 // Floor at 5 matches MIN_FRESH_FETCH_FOR_CAP_BYPASS (the silent-loss
 // safety): cap-mode bypass still requires 5 fresh upstream contacts,
@@ -49,23 +50,23 @@ export const PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES = 174;
 // then 30 / 50 as upstream stabilises. Target review: 2026-05-25.
 const MIN_VALID_COUNTRIES = 5;
 // Minimum total countryData.size required to ADVANCE the canonical list
-// + seed-meta (the operator-facing healthy signal). Below this, the
+// + seed-meta (the operator-facing freshness signal). Below this, the
 // per-country fresh writes still go through (cache rotation accumulates),
 // but CANONICAL_KEY + META_KEY are extendExistingTtl-only — keeping the
-// prior 174-country list and the prior fetchedAt visible to consumers,
-// and keeping the operator-facing WARNING visible.
+// prior canonical list and prior fetchedAt visible to consumers.
 //
 // Greptile PR #3760 P1: addresses the failure mode where a 5-country
 // fresh-fetched run with no usable stale-served cache could pass
 // validateFn, earn the cap-mode bypass, advance seed-meta with a
-// 5-entry canonical list (3% coverage published as "healthy"). With
+// 5-entry canonical list (3% coverage published as fresh). With
 // this gate, the canonical only advances when coverage is meaningful.
 //
-// 174 chosen as the explicit #3613 recovery target. Anything below this
-// remains a partial recovery run: per-country writes may rotate in, but the
-// public canonical list + operator seed-meta stay on the prior version so
-// /api/health cannot report partial coverage as OK.
-const MIN_CANONICAL_PUBLISH = PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES;
+// Keep this below the 174-country health target. /api/health and
+// /api/seed-health use PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES to report
+// partial recovery as non-green; this lower publish floor keeps cap-mode
+// recovery from freezing seed-meta fetchedAt or hiding incremental canonical
+// coverage improvements while still blocking tiny 5-country publishes.
+const MIN_CANONICAL_PUBLISH = 50;
 
 const EP3_BASE =
   'https://services9.arcgis.com/weJ1QsnbMYJlCHdG/arcgis/rest/services/Daily_Ports_Data/FeatureServer/0/query';
@@ -1321,7 +1322,7 @@ async function main() {
     // advance. Per-country writes always go through (cache-fresh rotation
     // accumulates), but CANONICAL + META only advance when total coverage
     // crosses MIN_CANONICAL_PUBLISH — protects consumers from seeing a
-    // 5-country canonical published as "healthy" during recovery.
+    // 5-country canonical published as fresh during recovery.
     const canonicalAdvances = shouldAdvanceCanonical(countryData.size);
     const metaPayload = { fetchedAt: Date.now(), recordCount: countryData.size };
 
@@ -1335,24 +1336,24 @@ async function main() {
     } else {
       // Per-country fresh data persists, but canonical list + seed-meta
       // stay at the prior version. extendExistingTtl preserves the
-      // operator-facing WARNING — consumers reading CANONICAL see the
-      // prior 174-country list with their existing data (mostly stale
-      // for not-yet-rotated entries, fresh for the ones we just wrote).
+      // operator-facing state stable — consumers reading CANONICAL see the
+      // prior canonical list with their existing data (mostly stale for
+      // not-yet-rotated entries, fresh for the ones we just wrote).
       //
       // Greptile PR #3760 round 3 P1: prevCountryKeys MUST be extended
       // here too, mirroring the COVERAGE GATE / DEGRADATION GUARD
       // failure paths. Without it, untouched countries' per-country
       // payloads (TTL=3d) can expire during a multi-day partial
       // recovery while the canonical list still references them —
-      // contradicting the "consumers see the prior 174-country list
-      // with their existing data" claim. The keys we DO write in
+      // contradicting the "consumers see the prior canonical list with
+      // their existing data" claim. The keys we DO write in
       // `commands` below get their own SET ... EX TTL, so this only
       // affects the un-refreshed entries from the prior list.
       await extendExistingTtl([CANONICAL_KEY, META_KEY, ...prevCountryKeys], TTL).catch(() => {});
       console.warn(
         `  PARTIAL PERSIST: ${countryData.size}/${MIN_CANONICAL_PUBLISH} below canonical-publish floor — ` +
         `${countryData.size} per-country payload(s) written (cache rotation accumulates), ` +
-        `canonical + seed-meta + prior per-country keys preserved (operator WARNING remains visible).`,
+        `canonical + seed-meta + prior per-country keys preserved.`,
       );
     }
 

--- a/tests/health-classify.test.mjs
+++ b/tests/health-classify.test.mjs
@@ -99,6 +99,19 @@ test('classifyKey: riskScores partial realtime family coverage → COVERAGE_PART
   assert.equal(STATUS_COUNTS[entry.status], 'warn');
 });
 
+test('classifyKey: portwatchPortActivity below 174 countries → COVERAGE_PARTIAL', () => {
+  const entry = classifyKey('portwatchPortActivity', STANDALONE_KEYS.portwatchPortActivity, { allowOnDemand: true },
+    makeCtx({
+      strens: { [STANDALONE_KEYS.portwatchPortActivity]: 1234 },
+      metaValues: { 'seed-meta:supply_chain:portwatch-ports': seedMeta({ recordCount: 139 }) },
+    }));
+
+  assert.equal(entry.status, 'COVERAGE_PARTIAL');
+  assert.equal(entry.records, 139);
+  assert.equal(entry.minRecordCount, 174);
+  assert.equal(STATUS_COUNTS[entry.status], 'warn');
+});
+
 test('classifyKey: socialVelocity error seed-meta → SEED_ERROR while data is preserved', () => {
   const entry = classifyKey('socialVelocity', BOOTSTRAP_KEYS.socialVelocity, { allowOnDemand: false },
     makeCtx({

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -267,6 +267,32 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.equal(freshness.cached_at, new Date(now - 24 * 60 * 60_000).toISOString());
   });
 
+  it('evaluateFreshness marks below-floor recordCount stale even when fetchedAt is fresh', () => {
+    const now = Date.UTC(2026, 5, 11, 12, 0, 0);
+    const freshness = evaluateFreshness(
+      [
+        { key: 'seed-meta:supply_chain:portwatch-ports', maxStaleMin: 2160, minRecordCount: 174 },
+      ],
+      [
+        { fetchedAt: now - 12 * 60 * 60_000, recordCount: 139 },
+      ],
+      now,
+    );
+
+    assert.equal(freshness.stale, true);
+    assert.equal(freshness.cached_at, new Date(now - 12 * 60 * 60_000).toISOString());
+  });
+
+  it('get_chokepoint_status declares the PortWatch 174-country freshness floor', async () => {
+    const { CACHE_TOOLS } = await import(`../api/mcp/registry/cache-tools.ts?t=${Date.now()}`);
+    const tool = CACHE_TOOLS.find((candidate) => candidate.name === 'get_chokepoint_status');
+    const portwatchFreshness = tool?._freshnessChecks?.find(
+      (check) => check.key === 'seed-meta:supply_chain:portwatch-ports',
+    );
+
+    assert.equal(portwatchFreshness?.minRecordCount, 174);
+  });
+
   // --- Rate limiting ---
 
   it('returns JSON-RPC -32029 when rate limited', async () => {

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -180,13 +180,13 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     assert.match(src, /ArcGIS degraded — \$\{_invalidParamsErrorCount\}/);
   });
 
-  it('canonical/seed-meta advance only when coverage >= MIN_CANONICAL_PUBLISH (Greptile PR #3760 P1)', () => {
+  it('canonical/seed-meta advance at the recovery publish floor, below the 174 health target', () => {
     // Gate=5 lets per-country writes through (cache rotation accumulates)
     // but CANONICAL_KEY + META_KEY require a higher coverage floor before
     // they advance — protects consumers from a 5-country canonical
-    // published as "healthy" during a recovery from full outage.
+    // published as fresh during a recovery from full outage.
     assert.match(src, /export const PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES\s*=\s*174/);
-    assert.match(src, /const MIN_CANONICAL_PUBLISH\s*=\s*PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES/);
+    assert.match(src, /const MIN_CANONICAL_PUBLISH\s*=\s*50/);
     // The gate is evaluated and used to conditionally write canonical/meta:
     assert.match(src, /const canonicalAdvances = shouldAdvanceCanonical\(countryData\.size\)/);
     assert.match(src, /if\s*\(canonicalAdvances\)\s*\{[\s\S]{0,300}SET',\s*CANONICAL_KEY/);
@@ -923,10 +923,12 @@ describe('validateFn', () => {
     assert.equal(validateFn(null), false);
   });
 
-  it('advances canonical and seed-meta only at the 174-country recovery target', () => {
+  it('keeps the 174-country target as a health floor, not the publish cursor', () => {
     assert.equal(PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES, 174);
-    assert.equal(shouldAdvanceCanonical(139), false);
-    assert.equal(shouldAdvanceCanonical(173), false);
+    assert.equal(shouldAdvanceCanonical(49), false);
+    assert.equal(shouldAdvanceCanonical(50), true);
+    assert.equal(shouldAdvanceCanonical(139), true);
+    assert.equal(shouldAdvanceCanonical(173), true);
     assert.equal(shouldAdvanceCanonical(174), true);
     assert.equal(shouldAdvanceCanonical(175), true);
   });

--- a/tests/portwatch-port-activity-seed.test.mjs
+++ b/tests/portwatch-port-activity-seed.test.mjs
@@ -185,9 +185,10 @@ describe('seed-portwatch-port-activity.mjs exports', () => {
     // but CANONICAL_KEY + META_KEY require a higher coverage floor before
     // they advance — protects consumers from a 5-country canonical
     // published as "healthy" during a recovery from full outage.
-    assert.match(src, /const MIN_CANONICAL_PUBLISH\s*=\s*50/);
+    assert.match(src, /export const PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES\s*=\s*174/);
+    assert.match(src, /const MIN_CANONICAL_PUBLISH\s*=\s*PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES/);
     // The gate is evaluated and used to conditionally write canonical/meta:
-    assert.match(src, /const canonicalAdvances = countryData\.size\s*>=\s*MIN_CANONICAL_PUBLISH/);
+    assert.match(src, /const canonicalAdvances = shouldAdvanceCanonical\(countryData\.size\)/);
     assert.match(src, /if\s*\(canonicalAdvances\)\s*\{[\s\S]{0,300}SET',\s*CANONICAL_KEY/);
     // Below the floor, extendExistingTtl preserves canonical + meta +
     // prior per-country keys, and a PARTIAL PERSIST log line surfaces
@@ -896,22 +897,38 @@ describe('proxyFetch signal propagation (runtime)', () => {
 });
 
 describe('validateFn', () => {
-  it('returns true when countries array has >= 50 entries', () => {
-    const data = { countries: Array.from({ length: 80 }, (_, i) => `C${i}`), fetchedAt: new Date().toISOString() };
-    const valid = data && Array.isArray(data.countries) && data.countries.length >= 50;
-    assert.equal(valid, true);
+  let validateFn;
+  let shouldAdvanceCanonical;
+  let PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES;
+
+  before(async () => {
+    ({
+      validateFn,
+      shouldAdvanceCanonical,
+      PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES,
+    } = await import('../scripts/seed-portwatch-port-activity.mjs'));
   });
 
-  it('returns false when countries array has < 50 entries', () => {
-    const data = { countries: ['US', 'SA'], fetchedAt: new Date().toISOString() };
-    const valid = data && Array.isArray(data.countries) && data.countries.length >= 50;
-    assert.equal(valid, false);
+  it('keeps the per-country write gate permissive so partial recovery can accumulate', () => {
+    const data = { countries: Array.from({ length: 5 }, (_, i) => `C${i}`), fetchedAt: new Date().toISOString() };
+    assert.equal(validateFn(data), true);
+  });
+
+  it('returns false below the per-country write gate', () => {
+    const data = { countries: ['US', 'SA', 'GB', 'JP'], fetchedAt: new Date().toISOString() };
+    assert.equal(validateFn(data), false);
   });
 
   it('returns false for null data', () => {
-    const data = null;
-    const valid = !!(data && Array.isArray(data.countries) && data.countries.length >= 50);
-    assert.equal(valid, false);
+    assert.equal(validateFn(null), false);
+  });
+
+  it('advances canonical and seed-meta only at the 174-country recovery target', () => {
+    assert.equal(PORTWATCH_PORT_ACTIVITY_TARGET_COUNTRIES, 174);
+    assert.equal(shouldAdvanceCanonical(139), false);
+    assert.equal(shouldAdvanceCanonical(173), false);
+    assert.equal(shouldAdvanceCanonical(174), true);
+    assert.equal(shouldAdvanceCanonical(175), true);
   });
 });
 

--- a/tests/seed-health-portwatch-port-activity.test.mjs
+++ b/tests/seed-health-portwatch-port-activity.test.mjs
@@ -38,13 +38,14 @@ after(() => {
   }
 });
 
-function installSeedHealthPipelineMock(portwatchRecordCount) {
+function installSeedHealthPipelineMock(portwatchRecordCount, { missingPortwatchMeta = false } = {}) {
   globalThis.fetch = async (_url, init) => {
     const commands = JSON.parse(init.body);
     const results = commands.map((command) => {
       const [op, key] = command;
       assert.equal(op, 'GET');
       if (key === PORTWATCH_META_KEY) {
+        if (missingPortwatchMeta) return { result: null };
         return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: portwatchRecordCount }) };
       }
       if (key === RESILIENCE_INTERVAL_PROBE_KEY) {
@@ -99,6 +100,20 @@ test('seed-health treats missing PortWatch recordCount as coverage_partial', asy
   assert.equal(res.status, 200);
   assert.equal(body.overall, 'warning');
   assert.equal(entry.status, 'coverage_partial');
+  assert.equal(entry.stale, true);
+  assert.equal(entry.recordCount, null);
+  assert.equal(entry.minRecordCount, 174);
+});
+
+test('seed-health includes PortWatch minRecordCount when seed-meta is missing', async () => {
+  installSeedHealthPipelineMock(undefined, { missingPortwatchMeta: true });
+
+  const { res, body } = await readSeedHealth();
+  const entry = body.seeds['supply_chain:portwatch-ports'];
+
+  assert.equal(res.status, 503);
+  assert.equal(body.overall, 'degraded');
+  assert.equal(entry.status, 'missing');
   assert.equal(entry.stale, true);
   assert.equal(entry.recordCount, null);
   assert.equal(entry.minRecordCount, 174);

--- a/tests/seed-health-portwatch-port-activity.test.mjs
+++ b/tests/seed-health-portwatch-port-activity.test.mjs
@@ -1,0 +1,119 @@
+import { after, before, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+const originalFetch = globalThis.fetch;
+const originalEnv = {
+  UPSTASH_REDIS_REST_URL: process.env.UPSTASH_REDIS_REST_URL,
+  UPSTASH_REDIS_REST_TOKEN: process.env.UPSTASH_REDIS_REST_TOKEN,
+  WORLDMONITOR_VALID_KEYS: process.env.WORLDMONITOR_VALID_KEYS,
+  RESILIENCE_PILLAR_COMBINE_ENABLED: process.env.RESILIENCE_PILLAR_COMBINE_ENABLED,
+  RESILIENCE_SCHEMA_V2_ENABLED: process.env.RESILIENCE_SCHEMA_V2_ENABLED,
+};
+
+process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+process.env.WORLDMONITOR_VALID_KEYS = 'test-key';
+process.env.RESILIENCE_PILLAR_COMBINE_ENABLED = 'true';
+process.env.RESILIENCE_SCHEMA_V2_ENABLED = 'true';
+
+const { default: handler } = await import('../api/seed-health.js');
+
+const PORTWATCH_META_KEY = 'seed-meta:supply_chain:portwatch-ports';
+const RESILIENCE_INTERVAL_PROBE_KEY = 'resilience:intervals:v9:US';
+const RESILIENCE_INTERVAL_METHODOLOGY = 'weight-perturbation-sensitivity-v3';
+
+before(() => {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.example.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+  process.env.WORLDMONITOR_VALID_KEYS = 'test-key';
+  process.env.RESILIENCE_PILLAR_COMBINE_ENABLED = 'true';
+  process.env.RESILIENCE_SCHEMA_V2_ENABLED = 'true';
+});
+
+after(() => {
+  globalThis.fetch = originalFetch;
+  for (const [key, value] of Object.entries(originalEnv)) {
+    if (value == null) delete process.env[key];
+    else process.env[key] = value;
+  }
+});
+
+function installSeedHealthPipelineMock(portwatchRecordCount) {
+  globalThis.fetch = async (_url, init) => {
+    const commands = JSON.parse(init.body);
+    const results = commands.map((command) => {
+      const [op, key] = command;
+      assert.equal(op, 'GET');
+      if (key === PORTWATCH_META_KEY) {
+        return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: portwatchRecordCount }) };
+      }
+      if (key === RESILIENCE_INTERVAL_PROBE_KEY) {
+        return {
+          result: JSON.stringify({
+            p05: 65.2,
+            p95: 72.8,
+            _formula: 'pc',
+            methodology: RESILIENCE_INTERVAL_METHODOLOGY,
+            computedAt: '2026-06-11T12:00:00.000Z',
+          }),
+        };
+      }
+      return { result: JSON.stringify({ fetchedAt: Date.now(), recordCount: 1 }) };
+    });
+    return new Response(JSON.stringify(results), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  };
+}
+
+async function readSeedHealth() {
+  const req = new Request('https://api.worldmonitor.app/api/seed-health', {
+    headers: { 'X-WorldMonitor-Key': 'test-key' },
+  });
+  const res = await handler(req);
+  const body = await res.json();
+  return { res, body };
+}
+
+test('seed-health flags fresh PortWatch port activity below 174 countries as coverage_partial', async () => {
+  installSeedHealthPipelineMock(139);
+
+  const { res, body } = await readSeedHealth();
+  const entry = body.seeds['supply_chain:portwatch-ports'];
+
+  assert.equal(res.status, 200);
+  assert.equal(body.overall, 'warning');
+  assert.equal(entry.status, 'coverage_partial');
+  assert.equal(entry.stale, true);
+  assert.equal(entry.recordCount, 139);
+  assert.equal(entry.minRecordCount, 174);
+});
+
+test('seed-health treats missing PortWatch recordCount as coverage_partial', async () => {
+  installSeedHealthPipelineMock(undefined);
+
+  const { res, body } = await readSeedHealth();
+  const entry = body.seeds['supply_chain:portwatch-ports'];
+
+  assert.equal(res.status, 200);
+  assert.equal(body.overall, 'warning');
+  assert.equal(entry.status, 'coverage_partial');
+  assert.equal(entry.stale, true);
+  assert.equal(entry.recordCount, null);
+  assert.equal(entry.minRecordCount, 174);
+});
+
+test('seed-health keeps PortWatch port activity OK at the 174-country recovery floor', async () => {
+  installSeedHealthPipelineMock(174);
+
+  const { res, body } = await readSeedHealth();
+  const entry = body.seeds['supply_chain:portwatch-ports'];
+
+  assert.equal(res.status, 200);
+  assert.equal(body.overall, 'healthy');
+  assert.equal(entry.status, 'ok');
+  assert.equal(entry.stale, false);
+  assert.equal(entry.recordCount, 174);
+  assert.equal(entry.minRecordCount, 174);
+});


### PR DESCRIPTION
## Summary
- keep PortWatch port-activity health/API/MCP status non-green until the explicit 174-country target is met
- keep the seeder canonical/seed-meta publish cursor moving at the 50-country recovery floor so partial runs like 139/174 refresh `fetchedAt` and incremental coverage gains reach consumers
- make `/api/health`, `/api/seed-health`, and MCP `get_chokepoint_status` treat PortWatch port-activity `recordCount` below 174 as partial or stale instead of healthy
- add focused tests and health endpoint docs for the new coverage-floor behavior

## Validation
- `node --test tests/portwatch-port-activity-seed.test.mjs tests/health-classify.test.mjs tests/seed-health-portwatch-port-activity.test.mjs`
- `node --test tests/portwatch-port-activity-seed.test.mjs`
- `node --test tests/seed-health-portwatch-port-activity.test.mjs tests/seed-health-resilience-intervals.test.mjs tests/seed-health-risk-scores.test.mjs`
- `node --import tsx --test tests/mcp.test.mjs --test-name-pattern "evaluateFreshness|PortWatch 174-country"`
- `node --test tests/health-content-age.test.mjs tests/health-redis-down-status.test.mjs tests/seed-health-resilience-intervals.test.mjs tests/seed-health-risk-scores.test.mjs`
- `npm run typecheck:api`
- `git diff --check`
- `git push` pre-push hook passed: full typecheck, API typecheck, Convex typecheck, CJS syntax, Unicode safety, boundaries, safe HTML, Sentry coverage, rate-limit policies, premium-fetch parity, edge bundle check, seed tests, changed tests, edge function tests, markdown lint, MDX lint, proto freshness skip, version check

## Operational note
Live production before this patch, checked on 2026-06-11, reported `portwatchPortActivity.status=OK` with `records=139`. This PR fixes the partial-but-green contract while preserving cap-mode recovery: 139/174 will refresh seed-meta and remain `COVERAGE_PARTIAL` instead of becoming falsely stale after the 36h budget. It does not by itself prove issue closure. Keep #3613 open until production shows the issue DoD: 3 consecutive cron runs at 174/174, average runtime below 540s, and the named heavy countries present.

Refs #3613
