### PR TITLE
fix(news): avoid blocking categories on slow digest

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -1194,28 +1194,27 @@ export class DataLoaderManager implements AppModule {
       console.warn(`[News] Intel digest missing, using limited per-feed fallback (${fallbackIntelFeeds.length}/${enabledIntelSources.length} feeds)`);
     }
 
-    const intelResult = await Promise.allSettled([
-      fetchCategoryFeeds(fallbackIntelFeeds, { batchSize: this.perFeedFallbackBatchSize }),
-    ]);
-    if (intelResult[0]?.status === 'fulfilled') {
-      const intel = intelResult[0].value;
-      checkBatchForBreakingAlerts(intel);
-      this.renderNewsForCategory('intel', intel);
-      if (intelPanel && options.recordBaselineSample) {
-        try {
-          const baseline = await updateBaseline('news:intel', intel.length);
-          const deviation = calculateDeviation(intel.length, baseline);
-          intelPanel.setDeviation(deviation.zScore, deviation.percentChange, deviation.level);
-        } catch (e) { console.warn('[Baseline] news:intel write failed:', e); }
-      }
-      this.ctx.statusPanel?.updateFeed('Intel', { status: 'ok', itemCount: intel.length });
-      this.flashMapForNews(intel);
-      return intel;
+    let intel: NewsItem[];
+    try {
+      intel = await fetchCategoryFeeds(fallbackIntelFeeds, { batchSize: this.perFeedFallbackBatchSize });
+    } catch (e) {
+      delete this.ctx.newsByCategory['intel'];
+      console.error('[App] Intel feed failed:', e);
+      return [];
     }
 
-    delete this.ctx.newsByCategory['intel'];
-    console.error('[App] Intel feed failed:', intelResult[0]?.reason);
-    return [];
+    checkBatchForBreakingAlerts(intel);
+    this.renderNewsForCategory('intel', intel);
+    if (intelPanel && options.recordBaselineSample) {
+      try {
+        const baseline = await updateBaseline('news:intel', intel.length);
+        const deviation = calculateDeviation(intel.length, baseline);
+        intelPanel.setDeviation(deviation.zScore, deviation.percentChange, deviation.level);
+      } catch (e) { console.warn('[Baseline] news:intel write failed:', e); }
+    }
+    this.ctx.statusPanel?.updateFeed('Intel', { status: 'ok', itemCount: intel.length });
+    this.flashMapForNews(intel);
+    return intel;
   }
 
   async loadNews(): Promise<void> {

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -304,7 +304,7 @@ export class DataLoaderManager implements AppModule {
 
   private digestBreaker = { state: 'closed' as 'closed' | 'open' | 'half-open', failures: 0, cooldownUntil: 0 };
   private readonly digestRequestTimeoutMs = 8000;
-  private readonly digestFirstPaintGraceMs = 250;
+  private readonly digestFirstPaintGraceMs = 1500;
   private readonly digestBreakerCooldownMs = 5 * 60 * 1000;
   private readonly persistedDigestMaxAgeMs = 6 * 60 * 60 * 1000;
   private readonly perFeedFallbackCategoryFeedLimit = 3;
@@ -1229,6 +1229,7 @@ export class DataLoaderManager implements AppModule {
       console.warn('[News] Digest fetch failed before category load:', error);
       return null;
     });
+    const fallbackDigest = this.lastGoodDigest ?? await this.loadPersistedDigest();
 
     // Panel-driven, not variant-driven: load the active variant's preset
     // categories PLUS any extra categories required by enabled news panels the
@@ -1248,7 +1249,9 @@ export class DataLoaderManager implements AppModule {
         categories,
         categoryConcurrency,
         digestPromise,
+        fallbackDigest,
         digestGraceMs: this.digestFirstPaintGraceMs,
+        allowPendingPerFeedFallback: this.isPerFeedFallbackEnabled(),
         hasDigestCategory: (digest, key) => Boolean(digest.categories && key in digest.categories),
         loadCategory: ({ key, feeds, isCustom }, digest, options) => this.loadNewsCategory(key, feeds, digest, isCustom, options),
         loadIntel: SITE_VARIANT === 'full'

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -16,6 +16,11 @@ import {
   isPanelInVariantDefaults,
 } from '@/config';
 import { resolveNewsCategories, enabledNewsCategoryKeys } from '@/config/feed-resolution';
+import {
+  runNewsLoadPass,
+  type NewsCategoryLoadOptions,
+  type NewsIntelLoadOptions,
+} from '@/app/news-loader-sequencing';
 import { INTEL_HOTSPOTS, CONFLICT_ZONES } from '@/config/geo';
 import { tokenizeForMatch, matchKeyword } from '@/utils/keyword-match';
 import { withTimeout } from '@/utils/with-timeout';
@@ -299,6 +304,7 @@ export class DataLoaderManager implements AppModule {
 
   private digestBreaker = { state: 'closed' as 'closed' | 'open' | 'half-open', failures: 0, cooldownUntil: 0 };
   private readonly digestRequestTimeoutMs = 8000;
+  private readonly digestFirstPaintGraceMs = 250;
   private readonly digestBreakerCooldownMs = 5 * 60 * 1000;
   private readonly persistedDigestMaxAgeMs = 6 * 60 * 60 * 1000;
   private readonly perFeedFallbackCategoryFeedLimit = 3;
@@ -936,7 +942,13 @@ export class DataLoaderManager implements AppModule {
   // active variant's preset. The per-variant server digest never carries it,
   // so it skips the digest-availability gate and fetches its full feed set
   // directly client-side (the cost is borne only by users who customize).
-  private async loadNewsCategory(category: string, feeds: typeof FEEDS.politics, digest?: ListFeedDigestResponse | null, isCustom = false): Promise<NewsItem[]> {
+  private async loadNewsCategory(
+    category: string,
+    feeds: typeof FEEDS.politics,
+    digest?: ListFeedDigestResponse | null,
+    isCustom = false,
+    options: NewsCategoryLoadOptions = { allowDigestPendingFallback: false, recordBaselineSample: true },
+  ): Promise<NewsItem[]> {
     try {
       const panel = this.ctx.newsPanels[category];
 
@@ -974,7 +986,7 @@ export class DataLoaderManager implements AppModule {
           itemCount: items.length,
         });
 
-        if (panel) {
+        if (panel && options.recordBaselineSample) {
           try {
             const baseline = await updateBaseline(`news:${category}`, items.length);
             const deviation = calculateDeviation(items.length, baseline);
@@ -1041,7 +1053,7 @@ export class DataLoaderManager implements AppModule {
       // (every preset category fetching at once). It does NOT apply to custom
       // categories: those are NEVER in the digest by design — direct fetch is
       // their only path, and there are only a handful of them per user.
-      if (!isCustom && !this.isPerFeedFallbackEnabled()) {
+      if (!isCustom && !this.isPerFeedFallbackEnabled() && !options.allowDigestPendingFallback) {
         console.warn(`[News] Digest missing for "${category}", limited per-feed fallback disabled`);
         this.renderNewsForCategory(category, []);
         this.ctx.statusPanel?.updateFeed(category.charAt(0).toUpperCase() + category.slice(1), {
@@ -1058,6 +1070,8 @@ export class DataLoaderManager implements AppModule {
         : this.selectLimitedFeeds(enabledFeeds, this.perFeedFallbackCategoryFeedLimit);
       if (isCustom) {
         console.warn(`[News] Custom category "${category}" (not in variant preset), fetching ${fallbackFeeds.length} feeds directly`);
+      } else if (options.allowDigestPendingFallback) {
+        console.warn(`[News] Digest still pending for "${category}", using limited per-feed fallback (${fallbackFeeds.length}/${enabledFeeds.length} feeds)`);
       } else if (fallbackFeeds.length < enabledFeeds.length) {
         console.warn(`[News] Digest missing for "${category}", using limited per-feed fallback (${fallbackFeeds.length}/${enabledFeeds.length} feeds)`);
       } else {
@@ -1090,11 +1104,13 @@ export class DataLoaderManager implements AppModule {
           }
         }
 
-        try {
-          const baseline = await updateBaseline(`news:${category}`, items.length);
-          const deviation = calculateDeviation(items.length, baseline);
-          panel.setDeviation(deviation.zScore, deviation.percentChange, deviation.level);
-        } catch (e) { console.warn(`[Baseline] news:${category} write failed:`, e); }
+        if (options.recordBaselineSample) {
+          try {
+            const baseline = await updateBaseline(`news:${category}`, items.length);
+            const deviation = calculateDeviation(items.length, baseline);
+            panel.setDeviation(deviation.zScore, deviation.percentChange, deviation.level);
+          } catch (e) { console.warn(`[Baseline] news:${category} write failed:`, e); }
+        }
       }
 
       this.ctx.statusPanel?.updateFeed(category.charAt(0).toUpperCase() + category.slice(1), {
@@ -1115,14 +1131,105 @@ export class DataLoaderManager implements AppModule {
     }
   }
 
+  private async loadIntelNews(
+    digest: ListFeedDigestResponse | null,
+    allowDigestPendingFallback: boolean,
+    options: NewsIntelLoadOptions = { recordBaselineSample: true },
+  ): Promise<NewsItem[]> {
+    const enabledIntelSources = INTEL_SOURCES.filter(f => !this.ctx.disabledSources.has(f.name));
+    const enabledIntelNames = new Set(enabledIntelSources.map(f => f.name));
+    const intelPanel = this.ctx.newsPanels['intel'];
+    if (enabledIntelSources.length === 0) {
+      delete this.ctx.newsByCategory['intel'];
+      if (intelPanel) intelPanel.showError(t('common.allIntelSourcesDisabled'));
+      this.ctx.statusPanel?.updateFeed('Intel', { status: 'ok', itemCount: 0 });
+      return [];
+    }
+
+    if (digest?.categories && 'intel' in digest.categories) {
+      // Digest branch for intel
+      const intel = (digest.categories['intel']?.items ?? [])
+        .map(protoItemToNewsItem)
+        .filter(i => enabledIntelNames.has(i.source));
+      checkBatchForBreakingAlerts(intel);
+      this.renderNewsForCategory('intel', intel);
+      if (intelPanel && options.recordBaselineSample) {
+        try {
+          const baseline = await updateBaseline('news:intel', intel.length);
+          const deviation = calculateDeviation(intel.length, baseline);
+          intelPanel.setDeviation(deviation.zScore, deviation.percentChange, deviation.level);
+        } catch (e) { console.warn('[Baseline] news:intel write failed:', e); }
+      }
+      this.ctx.statusPanel?.updateFeed('Intel', { status: 'ok', itemCount: intel.length });
+      this.flashMapForNews(intel);
+      return intel;
+    }
+
+    const staleIntel = this.getStaleNewsItems('intel').filter(i => enabledIntelNames.has(i.source));
+    if (staleIntel.length > 0) {
+      console.warn(`[News] Intel digest missing, serving stale headlines (${staleIntel.length})`);
+      this.renderNewsForCategory('intel', staleIntel);
+      if (intelPanel && options.recordBaselineSample) {
+        try {
+          const baseline = await updateBaseline('news:intel', staleIntel.length);
+          const deviation = calculateDeviation(staleIntel.length, baseline);
+          intelPanel.setDeviation(deviation.zScore, deviation.percentChange, deviation.level);
+        } catch (e) { console.warn('[Baseline] news:intel write failed:', e); }
+      }
+      this.ctx.statusPanel?.updateFeed('Intel', { status: 'ok', itemCount: staleIntel.length });
+      return staleIntel;
+    }
+
+    if (!this.isPerFeedFallbackEnabled() && !allowDigestPendingFallback) {
+      console.warn('[News] Intel digest missing, limited per-feed fallback disabled');
+      delete this.ctx.newsByCategory['intel'];
+      this.ctx.statusPanel?.updateFeed('Intel', { status: 'error', errorMessage: 'Digest unavailable' });
+      return [];
+    }
+
+    const fallbackIntelFeeds = this.selectLimitedFeeds(enabledIntelSources, this.perFeedFallbackIntelFeedLimit);
+    if (allowDigestPendingFallback) {
+      console.warn(`[News] Intel digest still pending, using limited per-feed fallback (${fallbackIntelFeeds.length}/${enabledIntelSources.length} feeds)`);
+    } else if (fallbackIntelFeeds.length < enabledIntelSources.length) {
+      console.warn(`[News] Intel digest missing, using limited per-feed fallback (${fallbackIntelFeeds.length}/${enabledIntelSources.length} feeds)`);
+    }
+
+    const intelResult = await Promise.allSettled([
+      fetchCategoryFeeds(fallbackIntelFeeds, { batchSize: this.perFeedFallbackBatchSize }),
+    ]);
+    if (intelResult[0]?.status === 'fulfilled') {
+      const intel = intelResult[0].value;
+      checkBatchForBreakingAlerts(intel);
+      this.renderNewsForCategory('intel', intel);
+      if (intelPanel && options.recordBaselineSample) {
+        try {
+          const baseline = await updateBaseline('news:intel', intel.length);
+          const deviation = calculateDeviation(intel.length, baseline);
+          intelPanel.setDeviation(deviation.zScore, deviation.percentChange, deviation.level);
+        } catch (e) { console.warn('[Baseline] news:intel write failed:', e); }
+      }
+      this.ctx.statusPanel?.updateFeed('Intel', { status: 'ok', itemCount: intel.length });
+      this.flashMapForNews(intel);
+      return intel;
+    }
+
+    delete this.ctx.newsByCategory['intel'];
+    console.error('[App] Intel feed failed:', intelResult[0]?.reason);
+    return [];
+  }
+
   async loadNews(): Promise<void> {
     // Reset happy variant accumulator for fresh pipeline run
     if (SITE_VARIANT === 'happy') {
       this.ctx.happyAllItems = [];
     }
 
-    // Fire digest fetch early (non-blocking) — await before category loop
-    const digestPromise = this.tryFetchDigest();
+    // Fire digest fetch early, but do not let a slow digest stall the category
+    // first paint. Fast digests still take the optimized digest-backed path.
+    const digestPromise = this.tryFetchDigest().catch((error) => {
+      console.warn('[News] Digest fetch failed before category load:', error);
+      return null;
+    });
 
     // Panel-driven, not variant-driven: load the active variant's preset
     // categories PLUS any extra categories required by enabled news panels the
@@ -1135,109 +1242,45 @@ export class DataLoaderManager implements AppModule {
       enabledNewsCategoryKeys(this.ctx.newsPanels, this.ctx.panels, this.ctx.panelSettings),
     );
 
-    const digest = await digestPromise;
-
     const maxCategoryConcurrency = SITE_VARIANT === 'tech' ? 4 : 5;
     const categoryConcurrency = Math.max(1, Math.min(maxCategoryConcurrency, categories.length));
-    const categoryResults: PromiseSettledResult<NewsItem[]>[] = [];
-    for (let i = 0; i < categories.length; i += categoryConcurrency) {
-      const chunk = categories.slice(i, i + categoryConcurrency);
-      const chunkResults = await Promise.allSettled(
-        chunk.map(({ key, feeds, isCustom }) => this.loadNewsCategory(key, feeds, digest, isCustom))
-      );
-      categoryResults.push(...chunkResults);
-    }
+    const newsPass = await runNewsLoadPass(
+      {
+        categories,
+        categoryConcurrency,
+        digestPromise,
+        digestGraceMs: this.digestFirstPaintGraceMs,
+        hasDigestCategory: (digest, key) => Boolean(digest.categories && key in digest.categories),
+        loadCategory: ({ key, feeds, isCustom }, digest, options) => this.loadNewsCategory(key, feeds, digest, isCustom, options),
+        loadIntel: SITE_VARIANT === 'full'
+          ? (digest, allowDigestPendingFallback, options) => this.loadIntelNews(digest, allowDigestPendingFallback, options)
+          : undefined,
+        onCategoryError: (key, reason) => {
+          console.error(`[App] News category ${key ?? 'unknown'} failed:`, reason);
+        },
+        onDigestRefreshError: (key, reason) => {
+          console.error(`[App] Digest refresh for news category ${key ?? 'unknown'} failed:`, reason);
+        },
+      },
+    );
+    const { categoryItemsByKey, intelItems } = newsPass;
 
     const collectedNews: NewsItem[] = [];
-    categoryResults.forEach((result, idx) => {
-      if (result.status === 'fulfilled') {
-        const items = result.value;
-        // Tag items with content categories for happy variant
-        if (SITE_VARIANT === 'happy') {
-          for (const item of items) {
-            item.happyCategory = classifyNewsItem(item.source, item.title);
-          }
-          // Accumulate curated items for the positive news pipeline
-          this.ctx.happyAllItems = this.ctx.happyAllItems.concat(items);
+    for (const { key } of categories) {
+      const items = categoryItemsByKey.get(key) ?? [];
+      // Tag items with content categories for happy variant
+      if (SITE_VARIANT === 'happy') {
+        for (const item of items) {
+          item.happyCategory = classifyNewsItem(item.source, item.title);
         }
-        collectedNews.push(...items);
-      } else {
-        console.error(`[App] News category ${categories[idx]?.key} failed:`, result.reason);
+        // Accumulate curated items for the positive news pipeline
+        this.ctx.happyAllItems = this.ctx.happyAllItems.concat(items);
       }
-    });
+      collectedNews.push(...items);
+    }
 
     if (SITE_VARIANT === 'full') {
-      const enabledIntelSources = INTEL_SOURCES.filter(f => !this.ctx.disabledSources.has(f.name));
-      const enabledIntelNames = new Set(enabledIntelSources.map(f => f.name));
-      const intelPanel = this.ctx.newsPanels['intel'];
-      if (enabledIntelSources.length === 0) {
-        delete this.ctx.newsByCategory['intel'];
-        if (intelPanel) intelPanel.showError(t('common.allIntelSourcesDisabled'));
-        this.ctx.statusPanel?.updateFeed('Intel', { status: 'ok', itemCount: 0 });
-      } else if (digest?.categories && 'intel' in digest.categories) {
-        // Digest branch for intel
-        const intel = (digest.categories['intel']?.items ?? [])
-          .map(protoItemToNewsItem)
-          .filter(i => enabledIntelNames.has(i.source));
-        checkBatchForBreakingAlerts(intel);
-        this.renderNewsForCategory('intel', intel);
-        if (intelPanel) {
-          try {
-            const baseline = await updateBaseline('news:intel', intel.length);
-            const deviation = calculateDeviation(intel.length, baseline);
-            intelPanel.setDeviation(deviation.zScore, deviation.percentChange, deviation.level);
-          } catch (e) { console.warn('[Baseline] news:intel write failed:', e); }
-        }
-        this.ctx.statusPanel?.updateFeed('Intel', { status: 'ok', itemCount: intel.length });
-        collectedNews.push(...intel);
-        this.flashMapForNews(intel);
-      } else {
-        const staleIntel = this.getStaleNewsItems('intel').filter(i => enabledIntelNames.has(i.source));
-        if (staleIntel.length > 0) {
-          console.warn(`[News] Intel digest missing, serving stale headlines (${staleIntel.length})`);
-          this.renderNewsForCategory('intel', staleIntel);
-          if (intelPanel) {
-            try {
-              const baseline = await updateBaseline('news:intel', staleIntel.length);
-              const deviation = calculateDeviation(staleIntel.length, baseline);
-              intelPanel.setDeviation(deviation.zScore, deviation.percentChange, deviation.level);
-            } catch (e) { console.warn('[Baseline] news:intel write failed:', e); }
-          }
-          this.ctx.statusPanel?.updateFeed('Intel', { status: 'ok', itemCount: staleIntel.length });
-          collectedNews.push(...staleIntel);
-        } else if (!this.isPerFeedFallbackEnabled()) {
-          console.warn('[News] Intel digest missing, limited per-feed fallback disabled');
-          delete this.ctx.newsByCategory['intel'];
-          this.ctx.statusPanel?.updateFeed('Intel', { status: 'error', errorMessage: 'Digest unavailable' });
-        } else {
-          const fallbackIntelFeeds = this.selectLimitedFeeds(enabledIntelSources, this.perFeedFallbackIntelFeedLimit);
-          if (fallbackIntelFeeds.length < enabledIntelSources.length) {
-            console.warn(`[News] Intel digest missing, using limited per-feed fallback (${fallbackIntelFeeds.length}/${enabledIntelSources.length} feeds)`);
-          }
-
-          const intelResult = await Promise.allSettled([
-            fetchCategoryFeeds(fallbackIntelFeeds, { batchSize: this.perFeedFallbackBatchSize }),
-          ]);
-          if (intelResult[0]?.status === 'fulfilled') {
-            const intel = intelResult[0].value;
-            checkBatchForBreakingAlerts(intel);
-            this.renderNewsForCategory('intel', intel);
-            if (intelPanel) {
-              try {
-                const baseline = await updateBaseline('news:intel', intel.length);
-                const deviation = calculateDeviation(intel.length, baseline);
-                intelPanel.setDeviation(deviation.zScore, deviation.percentChange, deviation.level);
-              } catch (e) { console.warn('[Baseline] news:intel write failed:', e); }
-            }
-            this.ctx.statusPanel?.updateFeed('Intel', { status: 'ok', itemCount: intel.length });
-            collectedNews.push(...intel);
-            this.flashMapForNews(intel);
-          } else {
-            delete this.ctx.newsByCategory['intel'];
-            console.error('[App] Intel feed failed:', intelResult[0]?.reason);
-          }
-        }
-      }
+      collectedNews.push(...intelItems);
     }
 
     this.ctx.allNews = collectedNews;

--- a/src/app/news-loader-sequencing.ts
+++ b/src/app/news-loader-sequencing.ts
@@ -1,0 +1,178 @@
+export interface NewsDigestSnapshot<TDigest> {
+  digest: TDigest | null;
+  pending: boolean;
+}
+
+export interface NewsCategorySpec<TFeeds> {
+  key: string;
+  feeds: TFeeds;
+  isCustom?: boolean;
+}
+
+export interface NewsCategoryLoadOptions {
+  allowDigestPendingFallback: boolean;
+  recordBaselineSample: boolean;
+}
+
+export interface NewsIntelLoadOptions {
+  recordBaselineSample: boolean;
+}
+
+export interface NewsCategoryLoadResult<TItem> {
+  key: string;
+  items: TItem[];
+}
+
+export interface RunNewsLoadPassOptions<TFeeds, TDigest, TItem> {
+  categories: readonly NewsCategorySpec<TFeeds>[];
+  categoryConcurrency: number;
+  digestPromise: Promise<TDigest | null>;
+  digestGraceMs: number;
+  hasDigestCategory: (digest: TDigest, key: string) => boolean;
+  loadCategory: (
+    category: NewsCategorySpec<TFeeds>,
+    digest: TDigest | null,
+    options: NewsCategoryLoadOptions,
+  ) => Promise<TItem[]>;
+  loadIntel?: (
+    digest: TDigest | null,
+    allowDigestPendingFallback: boolean,
+    options: NewsIntelLoadOptions,
+  ) => Promise<TItem[]>;
+  onCategoryError?: (key: string | undefined, reason: unknown) => void;
+  onDigestRefreshError?: (key: string | undefined, reason: unknown) => void;
+}
+
+export interface RunNewsLoadPassResult<TDigest, TItem> {
+  categoryItemsByKey: Map<string, TItem[]>;
+  intelItems: TItem[];
+  initialDigest: NewsDigestSnapshot<TDigest>;
+  finalDigest: TDigest | null;
+}
+
+type Delay = (ms: number) => Promise<void>;
+
+const defaultDelay: Delay = (ms) => new Promise(resolve => {
+  setTimeout(resolve, Math.max(0, ms));
+});
+
+export async function resolveInitialNewsDigest<TDigest>(
+  digestPromise: Promise<TDigest | null>,
+  graceMs: number,
+  delay: Delay = defaultDelay,
+): Promise<NewsDigestSnapshot<TDigest>> {
+  let settled = false;
+  const trackedDigest = digestPromise.then(
+    value => {
+      settled = true;
+      return { status: 'fulfilled' as const, value };
+    },
+    reason => {
+      settled = true;
+      return { status: 'rejected' as const, reason };
+    },
+  );
+
+  const timeout = delay(graceMs).then(() => ({ status: 'timeout' as const }));
+  const first = await Promise.race([trackedDigest, timeout]);
+
+  if (first.status === 'rejected') {
+    throw first.reason;
+  }
+
+  if (first.status === 'fulfilled') {
+    return { digest: first.value, pending: false };
+  }
+
+  return { digest: null, pending: !settled };
+}
+
+export async function loadNewsCategoryBatches<TFeeds, TDigest, TItem>(
+  categories: readonly NewsCategorySpec<TFeeds>[],
+  categoryConcurrency: number,
+  digestSnapshot: NewsDigestSnapshot<TDigest>,
+  loadCategory: (
+    category: NewsCategorySpec<TFeeds>,
+    digest: TDigest | null,
+    options: NewsCategoryLoadOptions,
+  ) => Promise<TItem[]>,
+): Promise<Array<PromiseSettledResult<NewsCategoryLoadResult<TItem>>>> {
+  const concurrency = Math.max(1, Math.min(categoryConcurrency, Math.max(1, categories.length)));
+  const results: Array<PromiseSettledResult<NewsCategoryLoadResult<TItem>>> = [];
+  const allowDigestPendingFallback = digestSnapshot.pending && digestSnapshot.digest === null;
+  const recordBaselineSample = !allowDigestPendingFallback;
+
+  for (let i = 0; i < categories.length; i += concurrency) {
+    const chunk = categories.slice(i, i + concurrency);
+    const chunkResults = await Promise.allSettled(
+      chunk.map(async category => ({
+        key: category.key,
+        items: await loadCategory(category, digestSnapshot.digest, {
+          allowDigestPendingFallback,
+          recordBaselineSample,
+        }),
+      })),
+    );
+    results.push(...chunkResults);
+  }
+
+  return results;
+}
+
+export async function runNewsLoadPass<TFeeds, TDigest, TItem>(
+  options: RunNewsLoadPassOptions<TFeeds, TDigest, TItem>,
+): Promise<RunNewsLoadPassResult<TDigest, TItem>> {
+  const initialDigest = await resolveInitialNewsDigest(options.digestPromise, options.digestGraceMs);
+  const categoryResults = await loadNewsCategoryBatches(
+    options.categories,
+    options.categoryConcurrency,
+    initialDigest,
+    options.loadCategory,
+  );
+  const categoryItemsByKey = new Map<string, TItem[]>();
+  categoryResults.forEach((result, idx) => {
+    if (result.status === 'fulfilled') {
+      categoryItemsByKey.set(result.value.key, result.value.items);
+    } else {
+      options.onCategoryError?.(options.categories[idx]?.key, result.reason);
+    }
+  });
+
+  let intelItems = options.loadIntel
+    ? await options.loadIntel(
+      initialDigest.digest,
+      initialDigest.pending && initialDigest.digest === null,
+      { recordBaselineSample: !(initialDigest.pending && initialDigest.digest === null) },
+    )
+    : [];
+  let finalDigest = initialDigest.digest;
+
+  if (initialDigest.pending) {
+    finalDigest = await options.digestPromise;
+    if (finalDigest) {
+      const latestDigest = finalDigest;
+      const digestCategories = options.categories.filter(
+        ({ key, isCustom }) => !isCustom && options.hasDigestCategory(latestDigest, key),
+      );
+      const digestResults = await loadNewsCategoryBatches(
+        digestCategories,
+        options.categoryConcurrency,
+        { digest: latestDigest, pending: false },
+        options.loadCategory,
+      );
+      digestResults.forEach((result, idx) => {
+        if (result.status === 'fulfilled') {
+          categoryItemsByKey.set(result.value.key, result.value.items);
+        } else {
+          options.onDigestRefreshError?.(digestCategories[idx]?.key, result.reason);
+        }
+      });
+
+      if (options.loadIntel && options.hasDigestCategory(latestDigest, 'intel')) {
+        intelItems = await options.loadIntel(latestDigest, false, { recordBaselineSample: true });
+      }
+    }
+  }
+
+  return { categoryItemsByKey, intelItems, initialDigest, finalDigest };
+}

--- a/src/app/news-loader-sequencing.ts
+++ b/src/app/news-loader-sequencing.ts
@@ -77,7 +77,7 @@ export async function resolveInitialNewsDigest<TDigest>(
   const first = await Promise.race([trackedDigest, timeout]);
 
   if (first.status === 'rejected') {
-    throw first.reason;
+    return { digest: null, pending: false };
   }
 
   if (first.status === 'fulfilled') {
@@ -122,7 +122,8 @@ export async function loadNewsCategoryBatches<TFeeds, TDigest, TItem>(
 export async function runNewsLoadPass<TFeeds, TDigest, TItem>(
   options: RunNewsLoadPassOptions<TFeeds, TDigest, TItem>,
 ): Promise<RunNewsLoadPassResult<TDigest, TItem>> {
-  const initialDigest = await resolveInitialNewsDigest(options.digestPromise, options.digestGraceMs);
+  const digestPromise = options.digestPromise.catch(() => null);
+  const initialDigest = await resolveInitialNewsDigest(digestPromise, options.digestGraceMs);
   const categoryResults = await loadNewsCategoryBatches(
     options.categories,
     options.categoryConcurrency,
@@ -148,7 +149,7 @@ export async function runNewsLoadPass<TFeeds, TDigest, TItem>(
   let finalDigest = initialDigest.digest;
 
   if (initialDigest.pending) {
-    finalDigest = await options.digestPromise;
+    finalDigest = await digestPromise;
     if (finalDigest) {
       const latestDigest = finalDigest;
       const digestCategories = options.categories.filter(

--- a/src/app/news-loader-sequencing.ts
+++ b/src/app/news-loader-sequencing.ts
@@ -27,7 +27,9 @@ export interface RunNewsLoadPassOptions<TFeeds, TDigest, TItem> {
   categories: readonly NewsCategorySpec<TFeeds>[];
   categoryConcurrency: number;
   digestPromise: Promise<TDigest | null>;
+  fallbackDigest?: TDigest | null;
   digestGraceMs: number;
+  allowPendingPerFeedFallback?: boolean;
   hasDigestCategory: (digest: TDigest, key: string) => boolean;
   loadCategory: (
     category: NewsCategorySpec<TFeeds>,
@@ -60,31 +62,25 @@ export async function resolveInitialNewsDigest<TDigest>(
   digestPromise: Promise<TDigest | null>,
   graceMs: number,
   delay: Delay = defaultDelay,
+  fallbackDigest: TDigest | null = null,
 ): Promise<NewsDigestSnapshot<TDigest>> {
-  let settled = false;
   const trackedDigest = digestPromise.then(
-    value => {
-      settled = true;
-      return { status: 'fulfilled' as const, value };
-    },
-    reason => {
-      settled = true;
-      return { status: 'rejected' as const, reason };
-    },
+    value => ({ status: 'fulfilled' as const, value }),
+    reason => ({ status: 'rejected' as const, reason }),
   );
 
   const timeout = delay(graceMs).then(() => ({ status: 'timeout' as const }));
   const first = await Promise.race([trackedDigest, timeout]);
 
   if (first.status === 'rejected') {
-    return { digest: null, pending: false };
+    return { digest: fallbackDigest, pending: false };
   }
 
   if (first.status === 'fulfilled') {
-    return { digest: first.value, pending: false };
+    return { digest: first.value ?? fallbackDigest, pending: false };
   }
 
-  return { digest: null, pending: !settled };
+  return { digest: fallbackDigest, pending: true };
 }
 
 export async function loadNewsCategoryBatches<TFeeds, TDigest, TItem>(
@@ -96,11 +92,12 @@ export async function loadNewsCategoryBatches<TFeeds, TDigest, TItem>(
     digest: TDigest | null,
     options: NewsCategoryLoadOptions,
   ) => Promise<TItem[]>,
+  allowPendingPerFeedFallback = true,
 ): Promise<Array<PromiseSettledResult<NewsCategoryLoadResult<TItem>>>> {
   const concurrency = Math.max(1, Math.min(categoryConcurrency, Math.max(1, categories.length)));
   const results: Array<PromiseSettledResult<NewsCategoryLoadResult<TItem>>> = [];
-  const allowDigestPendingFallback = digestSnapshot.pending && digestSnapshot.digest === null;
-  const recordBaselineSample = !allowDigestPendingFallback;
+  const allowDigestPendingFallback = allowPendingPerFeedFallback && digestSnapshot.pending && digestSnapshot.digest === null;
+  const recordBaselineSample = !digestSnapshot.pending;
 
   for (let i = 0; i < categories.length; i += concurrency) {
     const chunk = categories.slice(i, i + concurrency);
@@ -123,12 +120,19 @@ export async function runNewsLoadPass<TFeeds, TDigest, TItem>(
   options: RunNewsLoadPassOptions<TFeeds, TDigest, TItem>,
 ): Promise<RunNewsLoadPassResult<TDigest, TItem>> {
   const digestPromise = options.digestPromise.catch(() => null);
-  const initialDigest = await resolveInitialNewsDigest(digestPromise, options.digestGraceMs);
+  const allowPendingPerFeedFallback = options.allowPendingPerFeedFallback ?? true;
+  const initialDigest = await resolveInitialNewsDigest(
+    digestPromise,
+    options.digestGraceMs,
+    undefined,
+    options.fallbackDigest ?? null,
+  );
   const categoryResults = await loadNewsCategoryBatches(
     options.categories,
     options.categoryConcurrency,
     initialDigest,
     options.loadCategory,
+    allowPendingPerFeedFallback,
   );
   const categoryItemsByKey = new Map<string, TItem[]>();
   categoryResults.forEach((result, idx) => {
@@ -142,8 +146,8 @@ export async function runNewsLoadPass<TFeeds, TDigest, TItem>(
   let intelItems = options.loadIntel
     ? await options.loadIntel(
       initialDigest.digest,
-      initialDigest.pending && initialDigest.digest === null,
-      { recordBaselineSample: !(initialDigest.pending && initialDigest.digest === null) },
+      allowPendingPerFeedFallback && initialDigest.pending && initialDigest.digest === null,
+      { recordBaselineSample: !initialDigest.pending },
     )
     : [];
   let finalDigest = initialDigest.digest;
@@ -160,6 +164,7 @@ export async function runNewsLoadPass<TFeeds, TDigest, TItem>(
         options.categoryConcurrency,
         { digest: latestDigest, pending: false },
         options.loadCategory,
+        allowPendingPerFeedFallback,
       );
       digestResults.forEach((result, idx) => {
         if (result.status === 'fulfilled') {

--- a/tests/feed-date-ranking-uses-effective.test.mts
+++ b/tests/feed-date-ranking-uses-effective.test.mts
@@ -92,7 +92,7 @@ const ALLOW_LIST: AllowEntry[] = [
   },
   {
     file: 'src/app/data-loader.ts',
-    line: 3382,
+    line: 3385,
     reason: 'Cache serialization step — wraps pubDate.getTime() into the persisted entry payload, not a comparator.',
   },
 ];

--- a/tests/feed-date-ranking-uses-effective.test.mts
+++ b/tests/feed-date-ranking-uses-effective.test.mts
@@ -92,7 +92,7 @@ const ALLOW_LIST: AllowEntry[] = [
   },
   {
     file: 'src/app/data-loader.ts',
-    line: 3340,
+    line: 3383,
     reason: 'Cache serialization step — wraps pubDate.getTime() into the persisted entry payload, not a comparator.',
   },
 ];

--- a/tests/feed-date-ranking-uses-effective.test.mts
+++ b/tests/feed-date-ranking-uses-effective.test.mts
@@ -92,7 +92,7 @@ const ALLOW_LIST: AllowEntry[] = [
   },
   {
     file: 'src/app/data-loader.ts',
-    line: 3383,
+    line: 3382,
     reason: 'Cache serialization step — wraps pubDate.getTime() into the persisted entry payload, not a comparator.',
   },
 ];

--- a/tests/news-loader-sequencing.test.mts
+++ b/tests/news-loader-sequencing.test.mts
@@ -125,6 +125,28 @@ describe('news loader digest sequencing', () => {
     );
   });
 
+  it('treats a rejected digest as unavailable rather than throwing', async () => {
+    const initialDigest = await resolveInitialNewsDigest<TestDigest>(
+      Promise.reject(new Error('digest unavailable')),
+      250,
+      neverDelay,
+    );
+
+    assert.deepEqual(initialDigest, { digest: null, pending: false });
+
+    await loadNewsCategoryBatches(
+      [{ key: 'politics', feeds: ['Reuters'] }],
+      1,
+      initialDigest,
+      async (_category, digestSnapshot, options) => {
+        assert.equal(digestSnapshot, null);
+        assert.equal(options.allowDigestPendingFallback, false);
+        assert.equal(options.recordBaselineSample, true);
+        return [];
+      },
+    );
+  });
+
   it('orchestrates slow-digest fallback, late digest refresh, and Intel refresh', async () => {
     const digest = deferred<TestDigest | null>();
     let digestSettled = false;
@@ -182,5 +204,52 @@ describe('news loader digest sequencing', () => {
     assert.deepEqual(result.intelItems, ['intel-digest']);
     assert.equal(result.initialDigest.pending, true);
     assert.deepEqual(result.finalDigest, { categories: { politics: {}, intel: {} } });
+  });
+
+  it('preserves fallback results when a pending digest resolves null', async () => {
+    const digest = deferred<TestDigest | null>();
+    const categoryStarted = deferred<void>();
+    const events: string[] = [];
+
+    const runPromise = runNewsLoadPass<string[], TestDigest, string>({
+      categories: [
+        { key: 'politics', feeds: ['Reuters'] },
+        { key: 'energy', feeds: ['Oil Monitor'] },
+      ],
+      categoryConcurrency: 2,
+      digestPromise: digest.promise,
+      digestGraceMs: 0,
+      hasDigestCategory: (digestSnapshot, key) => key in digestSnapshot.categories,
+      loadCategory: async (category, digestSnapshot, options) => {
+        events.push(`${category.key}:${digestSnapshot ? 'digest' : 'fallback'}:${options.allowDigestPendingFallback}`);
+        assert.equal(digestSnapshot, null);
+        assert.equal(options.allowDigestPendingFallback, true);
+        assert.equal(options.recordBaselineSample, false);
+        categoryStarted.resolve();
+        return [`${category.key}-fallback`];
+      },
+      loadIntel: async (digestSnapshot, allowDigestPendingFallback, options) => {
+        events.push(`intel:${digestSnapshot ? 'digest' : 'fallback'}:${allowDigestPendingFallback}`);
+        assert.equal(digestSnapshot, null);
+        assert.equal(allowDigestPendingFallback, true);
+        assert.equal(options.recordBaselineSample, false);
+        return ['intel-fallback'];
+      },
+    });
+
+    await categoryStarted.promise;
+    digest.resolve(null);
+    const result = await runPromise;
+
+    assert.deepEqual(events, [
+      'politics:fallback:true',
+      'energy:fallback:true',
+      'intel:fallback:true',
+    ]);
+    assert.deepEqual(result.categoryItemsByKey.get('politics'), ['politics-fallback']);
+    assert.deepEqual(result.categoryItemsByKey.get('energy'), ['energy-fallback']);
+    assert.deepEqual(result.intelItems, ['intel-fallback']);
+    assert.equal(result.initialDigest.pending, true);
+    assert.equal(result.finalDigest, null);
   });
 });

--- a/tests/news-loader-sequencing.test.mts
+++ b/tests/news-loader-sequencing.test.mts
@@ -9,6 +9,7 @@ import {
 
 interface TestDigest {
   categories: Record<string, unknown>;
+  label?: string;
 }
 
 function deferred<T>() {
@@ -147,6 +148,35 @@ describe('news loader digest sequencing', () => {
     );
   });
 
+  it('uses a fallback digest when the live digest rejects within the grace window', async () => {
+    const fallbackDigest: TestDigest = { label: 'cached', categories: { politics: {} } };
+    const initialDigest = await resolveInitialNewsDigest<TestDigest>(
+      Promise.reject(new Error('digest unavailable')),
+      250,
+      neverDelay,
+      fallbackDigest,
+    );
+
+    assert.deepEqual(initialDigest, { digest: fallbackDigest, pending: false });
+  });
+
+  it('does not bypass the per-feed fallback switch while a digest is pending', async () => {
+    const results = await loadNewsCategoryBatches(
+      [{ key: 'politics', feeds: ['Reuters'] }],
+      1,
+      { digest: null, pending: true },
+      async (_category, digestSnapshot, options) => {
+        assert.equal(digestSnapshot, null);
+        assert.equal(options.allowDigestPendingFallback, false);
+        assert.equal(options.recordBaselineSample, false);
+        return [];
+      },
+      false,
+    );
+
+    assert.equal(results[0]?.status, 'fulfilled');
+  });
+
   it('orchestrates slow-digest fallback, late digest refresh, and Intel refresh', async () => {
     const digest = deferred<TestDigest | null>();
     let digestSettled = false;
@@ -204,6 +234,60 @@ describe('news loader digest sequencing', () => {
     assert.deepEqual(result.intelItems, ['intel-digest']);
     assert.equal(result.initialDigest.pending, true);
     assert.deepEqual(result.finalDigest, { categories: { politics: {}, intel: {} } });
+  });
+
+  it('uses fallback digest during timeout and still refreshes when the live digest arrives', async () => {
+    const digest = deferred<TestDigest | null>();
+    const cachedDigest: TestDigest = { label: 'cached', categories: { politics: {}, intel: {} } };
+    const liveDigest: TestDigest = { label: 'live', categories: { politics: {}, intel: {} } };
+    const initialCategoryLoaded = deferred<void>();
+    const events: string[] = [];
+
+    const runPromise = runNewsLoadPass<string[], TestDigest, string>({
+      categories: [{ key: 'politics', feeds: ['Reuters'] }],
+      categoryConcurrency: 1,
+      digestPromise: digest.promise,
+      fallbackDigest: cachedDigest,
+      digestGraceMs: 0,
+      allowPendingPerFeedFallback: false,
+      hasDigestCategory: (digestSnapshot, key) => key in digestSnapshot.categories,
+      loadCategory: async (category, digestSnapshot, options) => {
+        events.push(`${category.key}:${digestSnapshot?.label ?? 'none'}:${options.allowDigestPendingFallback}:${options.recordBaselineSample}`);
+        assert.ok(digestSnapshot);
+        if (digestSnapshot.label === 'cached') {
+          assert.equal(options.allowDigestPendingFallback, false);
+          assert.equal(options.recordBaselineSample, false);
+          initialCategoryLoaded.resolve();
+        } else {
+          assert.equal(options.allowDigestPendingFallback, false);
+          assert.equal(options.recordBaselineSample, true);
+        }
+        return [`${category.key}-${digestSnapshot.label}`];
+      },
+      loadIntel: async (digestSnapshot, allowDigestPendingFallback, options) => {
+        events.push(`intel:${digestSnapshot?.label ?? 'none'}:${allowDigestPendingFallback}:${options.recordBaselineSample}`);
+        assert.ok(digestSnapshot);
+        assert.equal(allowDigestPendingFallback, false);
+        assert.equal(options.recordBaselineSample, digestSnapshot.label === 'live');
+        return [`intel-${digestSnapshot.label}`];
+      },
+    });
+
+    await initialCategoryLoaded.promise;
+    digest.resolve(liveDigest);
+    const result = await runPromise;
+
+    assert.deepEqual(events, [
+      'politics:cached:false:false',
+      'intel:cached:false:false',
+      'politics:live:false:true',
+      'intel:live:false:true',
+    ]);
+    assert.deepEqual(result.categoryItemsByKey.get('politics'), ['politics-live']);
+    assert.deepEqual(result.intelItems, ['intel-live']);
+    assert.equal(result.initialDigest.digest, cachedDigest);
+    assert.equal(result.initialDigest.pending, true);
+    assert.equal(result.finalDigest, liveDigest);
   });
 
   it('preserves fallback results when a pending digest resolves null', async () => {

--- a/tests/news-loader-sequencing.test.mts
+++ b/tests/news-loader-sequencing.test.mts
@@ -1,0 +1,186 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  loadNewsCategoryBatches,
+  resolveInitialNewsDigest,
+  runNewsLoadPass,
+  type NewsCategorySpec,
+} from '../src/app/news-loader-sequencing';
+
+interface TestDigest {
+  categories: Record<string, unknown>;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const neverDelay = () => new Promise<void>(() => {});
+
+describe('news loader digest sequencing', () => {
+  it('starts category work with pending-fallback permission before a slow digest settles', async () => {
+    const digest = deferred<TestDigest | null>();
+    let digestSettled = false;
+    const digestPromise = digest.promise.then(value => {
+      digestSettled = true;
+      return value;
+    });
+
+    const initialDigest = await resolveInitialNewsDigest(
+      digestPromise,
+      0,
+      async () => {},
+    );
+
+    assert.deepEqual(initialDigest, { digest: null, pending: true });
+
+    const categories: Array<NewsCategorySpec<string[]>> = [
+      { key: 'politics', feeds: ['Reuters'] },
+      { key: 'energy', feeds: ['Oil Monitor'] },
+    ];
+    const starts: string[] = [];
+    const results = await loadNewsCategoryBatches(
+      categories,
+      1,
+      initialDigest,
+      async (category, digestSnapshot, options) => {
+        starts.push(`${category.key}:${options.allowDigestPendingFallback}`);
+        assert.equal(digestSnapshot, null);
+        assert.equal(options.allowDigestPendingFallback, true);
+        assert.equal(options.recordBaselineSample, false);
+        assert.equal(digestSettled, false);
+        return [`${category.key}-item`];
+      },
+    );
+
+    assert.deepEqual(starts, ['politics:true', 'energy:true']);
+    assert.deepEqual(
+      results.map(result => result.status === 'fulfilled' ? result.value : result),
+      [
+        { key: 'politics', items: ['politics-item'] },
+        { key: 'energy', items: ['energy-item'] },
+      ],
+    );
+    assert.equal(digestSettled, false);
+
+    digest.resolve({ categories: {} });
+    await digestPromise;
+  });
+
+  it('preserves the fast digest path when the digest resolves within the first-paint grace', async () => {
+    const digest: TestDigest = { categories: { politics: {} } };
+    const initialDigest = await resolveInitialNewsDigest(
+      Promise.resolve(digest),
+      250,
+      neverDelay,
+    );
+
+    assert.equal(initialDigest.digest, digest);
+    assert.equal(initialDigest.pending, false);
+
+    const results = await loadNewsCategoryBatches(
+      [{ key: 'politics', feeds: ['Reuters'] }],
+      1,
+      initialDigest,
+      async (_category, digestSnapshot, options) => {
+        assert.equal(digestSnapshot, digest);
+        assert.equal(options.allowDigestPendingFallback, false);
+        assert.equal(options.recordBaselineSample, true);
+        return ['digest-item'];
+      },
+    );
+
+    assert.equal(results[0]?.status, 'fulfilled');
+    assert.deepEqual(
+      results[0]?.status === 'fulfilled' ? results[0].value : undefined,
+      { key: 'politics', items: ['digest-item'] },
+    );
+  });
+
+  it('treats a resolved null digest as unavailable rather than still pending', async () => {
+    const initialDigest = await resolveInitialNewsDigest<TestDigest>(
+      Promise.resolve(null),
+      250,
+      neverDelay,
+    );
+
+    assert.deepEqual(initialDigest, { digest: null, pending: false });
+
+    await loadNewsCategoryBatches(
+      [{ key: 'politics', feeds: ['Reuters'] }],
+      1,
+      initialDigest,
+      async (_category, digestSnapshot, options) => {
+        assert.equal(digestSnapshot, null);
+        assert.equal(options.allowDigestPendingFallback, false);
+        assert.equal(options.recordBaselineSample, true);
+        return [];
+      },
+    );
+  });
+
+  it('orchestrates slow-digest fallback, late digest refresh, and Intel refresh', async () => {
+    const digest = deferred<TestDigest | null>();
+    let digestSettled = false;
+    const digestPromise = digest.promise.then(value => {
+      digestSettled = true;
+      return value;
+    });
+    const categoryStarted = deferred<void>();
+    const releaseInitialCategory = deferred<void>();
+    const events: string[] = [];
+
+    const runPromise = runNewsLoadPass<string[], TestDigest, string>({
+      categories: [{ key: 'politics', feeds: ['Reuters'] }],
+      categoryConcurrency: 1,
+      digestPromise,
+      digestGraceMs: 0,
+      hasDigestCategory: (digestSnapshot, key) => key in digestSnapshot.categories,
+      loadCategory: async (category, digestSnapshot, options) => {
+        events.push(`${category.key}:${digestSnapshot ? 'digest' : 'fallback'}:${options.allowDigestPendingFallback}`);
+        if (!digestSnapshot) {
+          categoryStarted.resolve();
+          await releaseInitialCategory.promise;
+          assert.equal(options.allowDigestPendingFallback, true);
+          assert.equal(options.recordBaselineSample, false);
+          assert.equal(digestSettled, false);
+          return [`${category.key}-fallback`];
+        }
+        assert.equal(options.allowDigestPendingFallback, false);
+        assert.equal(options.recordBaselineSample, true);
+        return [`${category.key}-digest`];
+      },
+      loadIntel: async (digestSnapshot, allowDigestPendingFallback, options) => {
+        events.push(`intel:${digestSnapshot ? 'digest' : 'fallback'}:${allowDigestPendingFallback}`);
+        assert.equal(options.recordBaselineSample, Boolean(digestSnapshot));
+        return [digestSnapshot ? 'intel-digest' : 'intel-fallback'];
+      },
+    });
+
+    await categoryStarted.promise;
+    assert.equal(digestSettled, false);
+
+    releaseInitialCategory.resolve();
+    await Promise.resolve();
+    digest.resolve({ categories: { politics: {}, intel: {} } });
+
+    const result = await runPromise;
+
+    assert.deepEqual(events, [
+      'politics:fallback:true',
+      'intel:fallback:true',
+      'politics:digest:false',
+      'intel:digest:false',
+    ]);
+    assert.deepEqual(result.categoryItemsByKey.get('politics'), ['politics-digest']);
+    assert.deepEqual(result.intelItems, ['intel-digest']);
+    assert.equal(result.initialDigest.pending, true);
+    assert.deepEqual(result.finalDigest, { categories: { politics: {}, intel: {} } });
+  });
+});


### PR DESCRIPTION
## Summary

- Decouple news category loading from slow digest fetches with a bounded 1.5s first-paint digest snapshot.
- Consult last-good/persisted digest data before direct per-feed fallback, and keep honoring the `newsPerFeedFallback` kill switch while a digest is pending.
- Add focused sequencing tests for slow digest fallback, cached-digest timeout, fallback kill-switch behavior, fast digest preservation, resolved-null/rejected digest behavior, pending-null preservation, late digest refresh, and Intel refresh.

Closes #3538.

## Intent

The goal is to stop slow or degraded `/api/news/v1/list-feed-digest` responses from holding all news panels blank on first paint. The fix stays scoped to frontend news loader sequencing: it does not change the digest endpoint, feed registries, API/proto contracts, panel UI, or cache policy.

Accepted tradeoff: while a digest is pending, preset categories may use the existing capped per-feed fallback path only when ordinary digest-down fallback is enabled. Cached digest data is preferred before any direct per-feed fallback, and pending renders are baseline-suppressed so a later digest refresh does not double-count the same refresh cycle. The pending-then-null path now has explicit coverage to preserve the fallback results as final output.

## Validation Matrix

| Check | Status |
| --- | --- |
| `TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/news-loader-sequencing.test.mts tests/feed-date-ranking-uses-effective.test.mts tests/feed-resolution.test.mts tests/news-feed-key-parity.test.mts` | Pass, 35 tests |
| `node --test tests/digest-no-reclassify.test.mjs tests/feeds-client-server-parity.test.mjs` | Pass, 12 tests |
| `npm run typecheck` | Pass |
| `git diff --check` | Pass |
| Pre-push hook | Pass: typecheck, API typecheck, Convex typecheck, CJS syntax, Unicode safety, boundary lint, safe HTML, rate-limit policy, premium-fetch parity, edge bundle/tests, version sync, and changed test files |

Note: the first sandboxed `tsx` attempt failed with the known IPC `listen EPERM` issue, including with `TMPDIR=/tmp`; the same focused command passed outside the sandbox.

## Documentation

Not applicable. This changes frontend loader sequencing only, with no public API, proto, methodology, docs, or operator workflow change.

## Screenshots / UI Evidence

Not applicable. There is no visual copy/layout/style change; the user-visible timing behavior is covered by the focused behavioral sequencing test.

## Review Follow-Up

- Greptile P2: `resolveInitialNewsDigest` no longer rethrows digest rejection; `runNewsLoadPass` also normalizes late digest rejection to `null`.
- Greptile P2: added coverage for the `pending=true` then final digest `null` path, preserving fallback category and Intel results.
- Greptile P2: simplified the extracted Intel fallback from a single-item `Promise.allSettled` to direct `await`/`try-catch`.
- Follow-up review: raised first-paint grace from 250ms to 1.5s, uses the existing last-good/persisted digest before direct per-feed fallback, and no longer bypasses `newsPerFeedFallback` while the digest is pending.
- Follow-up review: timeout now always remains pending, so a digest that settles just after the timeout can still refresh the cached/fallback first paint.
- CI: re-pinned the feed-date guardrail allow-list after `data-loader.ts` line movement.

## Residual Findings

None.
