### PR TITLE
perf(header): reserve async header controls

### DIFF
--- a/e2e/header-cls.spec.ts
+++ b/e2e/header-cls.spec.ts
@@ -1,0 +1,171 @@
+import { expect, test } from '@playwright/test';
+import { assertSignedOutAuthHydrationKeepsHeaderStable, HEADER_AUTH_SLOT_WIDTH } from './header-reservation';
+
+declare global {
+  interface Window {
+    __wmHeaderClsEntries?: Array<{
+      value: number;
+      hadRecentInput: boolean;
+      sourceSelectors: string[];
+      sourceDetails: Array<{
+        selector: string;
+        previousRect?: DOMRectInit;
+        currentRect?: DOMRectInit;
+      }>;
+    }>;
+  }
+}
+
+test.describe('header CLS reservations', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('wm-layer-warning-dismissed', 'true');
+      localStorage.setItem('wm-pro-banner-launched-dismissed', String(Date.now()));
+      localStorage.setItem('worldmonitor-mission-preset-dismissed-v1', '1');
+      window.__wmHeaderClsEntries = [];
+      const selectorFor = (node: Node | null): string => {
+        if (!(node instanceof Element)) return '';
+        if (node.id) return `#${node.id}`;
+        if (node.classList.length > 0) return `.${Array.from(node.classList).join('.')}`;
+        return node.tagName.toLowerCase();
+      };
+      try {
+        const observer = new PerformanceObserver((list) => {
+          for (const entry of list.getEntries() as PerformanceEntry[]) {
+            const layoutShift = entry as PerformanceEntry & {
+              value?: number;
+              hadRecentInput?: boolean;
+              sources?: Array<{ node?: Node; previousRect?: DOMRectReadOnly; currentRect?: DOMRectReadOnly }>;
+            };
+            window.__wmHeaderClsEntries?.push({
+              value: layoutShift.value ?? 0,
+              hadRecentInput: Boolean(layoutShift.hadRecentInput),
+              sourceSelectors: (layoutShift.sources ?? []).map((source) => selectorFor(source.node ?? null)),
+              sourceDetails: (layoutShift.sources ?? []).map((source) => ({
+                selector: selectorFor(source.node ?? null),
+                previousRect: source.previousRect ? {
+                  x: source.previousRect.x,
+                  y: source.previousRect.y,
+                  width: source.previousRect.width,
+                  height: source.previousRect.height,
+                } : undefined,
+                currentRect: source.currentRect ? {
+                  x: source.currentRect.x,
+                  y: source.currentRect.y,
+                  width: source.currentRect.width,
+                  height: source.currentRect.height,
+                } : undefined,
+              })),
+            });
+          }
+        });
+        observer.observe({ type: 'layout-shift', buffered: true });
+      } catch {
+        // Older engines without layout-shift support still exercise computed styles below.
+      }
+    });
+  });
+
+  test('reserves stable space for async header mounts without shifting the header', async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error.message));
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await page.locator('.header').waitFor();
+    await page.locator('.unified-settings-btn').waitFor({ timeout: 20000 });
+    await page.locator('.intel-findings-badge').waitFor({ timeout: 20000 });
+    await page.evaluate(() => new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    }));
+
+    const beforeHydration = await page.locator('.header').boundingBox();
+    expect(beforeHydration).not.toBeNull();
+    await page.evaluate(() => {
+      window.__wmHeaderClsEntries = [];
+    });
+
+    const styles = await page.evaluate(() => {
+      const header = document.querySelector<HTMLElement>('.header');
+      const missionMount = document.getElementById('missionPresetMount');
+      const settingsMount = document.getElementById('unifiedSettingsMount');
+      const authMount = document.getElementById('authWidgetMount');
+      if (!header || !missionMount || !settingsMount || !authMount) {
+        throw new Error('missing header reservation elements');
+      }
+
+      const headerStyle = getComputedStyle(header);
+      const missionStyle = getComputedStyle(missionMount);
+      const settingsStyle = getComputedStyle(settingsMount);
+      const authStyle = getComputedStyle(authMount);
+
+      return {
+        headerContain: headerStyle.contain,
+        missionDisplay: missionStyle.display,
+        missionMinWidth: missionStyle.minWidth,
+        missionMinHeight: missionStyle.minHeight,
+        missionWidth: missionMount.getBoundingClientRect().width,
+        missionHeight: missionMount.getBoundingClientRect().height,
+        settingsDisplay: settingsStyle.display,
+        settingsMinWidth: settingsStyle.minWidth,
+        settingsMinHeight: settingsStyle.minHeight,
+        settingsWidth: settingsMount.getBoundingClientRect().width,
+        settingsHeight: settingsMount.getBoundingClientRect().height,
+        authDisplay: authStyle.display,
+        authMinWidth: authStyle.minWidth,
+        authMinHeight: authStyle.minHeight,
+        authWidth: authMount.getBoundingClientRect().width,
+        authHeight: authMount.getBoundingClientRect().height,
+      };
+    });
+
+    expect(styles.headerContain.split(' ')).toContain('layout');
+    expect(styles.missionDisplay).toMatch(/^(inline-)?flex$/);
+    expect(styles.missionMinWidth).toBe('86px');
+    expect(styles.missionMinHeight).toBe('24px');
+    expect(styles.missionWidth).toBeGreaterThanOrEqual(86);
+    expect(styles.missionHeight).toBeGreaterThanOrEqual(24);
+    expect(styles.settingsDisplay).toMatch(/^(inline-)?flex$/);
+    expect(styles.settingsMinWidth).toBe('28px');
+    expect(styles.settingsMinHeight).toBe('28px');
+    expect(styles.settingsWidth).toBeGreaterThanOrEqual(28);
+    expect(styles.settingsHeight).toBeGreaterThanOrEqual(28);
+    expect(styles.authDisplay).toMatch(/^(inline-)?flex$/);
+    expect(styles.authMinWidth).toBe(`${HEADER_AUTH_SLOT_WIDTH}px`);
+    expect(styles.authMinHeight).toBe('32px');
+    expect(styles.authWidth).toBeGreaterThanOrEqual(HEADER_AUTH_SLOT_WIDTH);
+    expect(styles.authHeight).toBeGreaterThanOrEqual(32);
+
+    await assertSignedOutAuthHydrationKeepsHeaderStable(page);
+    await page.evaluate(() => new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    }));
+
+    const afterHydration = await page.locator('.header').boundingBox();
+    expect(afterHydration).not.toBeNull();
+    expect(Math.abs((afterHydration?.height ?? 0) - (beforeHydration?.height ?? 0))).toBeLessThanOrEqual(1);
+
+    const cls = await page.evaluate(() => {
+      const entries = (window.__wmHeaderClsEntries ?? []).filter((entry) => !entry.hadRecentInput);
+      const total = entries.reduce((sum, entry) => sum + entry.value, 0);
+      const headerEntries = entries.filter((entry) => entry.sourceSelectors.some((selector) => (
+          selector === '.header'
+          || selector === '#missionPresetMount'
+          || selector === '#unifiedSettingsMount'
+          || selector === '#authWidgetMount'
+          || selector.startsWith('.header-')
+          || selector.includes('mission-preset')
+          || selector.includes('auth-')
+          || selector.includes('unified-settings')
+        )));
+      const header = headerEntries.reduce((sum, entry) => sum + entry.value, 0);
+      return { total, header, headerEntries };
+    });
+
+    expect(cls.header, JSON.stringify(cls.headerEntries)).toBeLessThanOrEqual(0.001);
+    expect(cls.total).toBeLessThan(0.05);
+
+    await page.locator('.unified-settings-btn').click();
+    await expect(page.locator('#unifiedSettingsModal.active')).toBeVisible();
+    expect(pageErrors.filter((message) => message.toLowerCase().includes('auth'))).toHaveLength(0);
+  });
+});

--- a/e2e/header-reservation.ts
+++ b/e2e/header-reservation.ts
@@ -1,0 +1,110 @@
+import { expect, type Page } from '@playwright/test';
+
+export const HEADER_AUTH_SLOT_WIDTH = 200;
+
+type Box = {
+  height: number;
+  width: number;
+  x: number;
+  y: number;
+};
+
+const waitForLayoutFrame = async (page: Page): Promise<void> => {
+  await page.evaluate(() => new Promise<void>((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+  }));
+};
+
+const expectBoxesToMatch = (actual: Box, expected: Box, message: string): void => {
+  expect(Math.abs(actual.x - expected.x), `${message} x`).toBeLessThanOrEqual(1);
+  expect(Math.abs(actual.y - expected.y), `${message} y`).toBeLessThanOrEqual(1);
+  expect(Math.abs(actual.width - expected.width), `${message} width`).toBeLessThanOrEqual(1);
+  expect(Math.abs(actual.height - expected.height), `${message} height`).toBeLessThanOrEqual(1);
+};
+
+export const assertSignedOutAuthHydrationKeepsHeaderStable = async (page: Page): Promise<void> => {
+  await page.locator('.header').waitFor();
+  const result = await page.evaluate(() => {
+    const header = document.querySelector<HTMLElement>('.header');
+    const authMount = document.getElementById('authWidgetMount');
+    if (!header || !authMount) {
+      throw new Error('missing header auth reservation elements');
+    }
+
+    const rectOf = (element: Element): Box => {
+      const rect = element.getBoundingClientRect();
+      return {
+        height: rect.height,
+        width: rect.width,
+        x: rect.x,
+        y: rect.y,
+      };
+    };
+
+    const beforeHeaderBox = rectOf(header);
+    const beforeAuthMountBox = rectOf(authMount);
+    const pendingSkeletonCount = authMount.querySelectorAll('.auth-header-skeleton').length;
+
+    const widget = document.createElement('div');
+    widget.className = 'auth-header-widget';
+
+    const signInButton = document.createElement('button');
+    signInButton.className = 'auth-signin-btn';
+    signInButton.type = 'button';
+    signInButton.textContent = 'Sign In';
+    widget.appendChild(signInButton);
+
+    const signUpButton = document.createElement('button');
+    signUpButton.className = 'auth-signup-link';
+    signUpButton.type = 'button';
+    signUpButton.textContent = 'Create account';
+    widget.appendChild(signUpButton);
+
+    authMount.replaceChildren(widget);
+
+    return {
+      beforeAuthMountBox,
+      beforeHeaderBox,
+      pendingSkeletonCount,
+    };
+  });
+
+  await waitForLayoutFrame(page);
+
+  const hydrated = await page.evaluate(() => {
+    const header = document.querySelector<HTMLElement>('.header');
+    const authMount = document.getElementById('authWidgetMount');
+    const widget = authMount?.querySelector<HTMLElement>('.auth-header-widget');
+    if (!header || !authMount || !widget) {
+      throw new Error('missing hydrated header auth elements');
+    }
+
+    const rectOf = (element: Element): Box => {
+      const rect = element.getBoundingClientRect();
+      return {
+        height: rect.height,
+        width: rect.width,
+        x: rect.x,
+        y: rect.y,
+      };
+    };
+
+    return {
+      afterAuthMountBox: rectOf(authMount),
+      afterHeaderBox: rectOf(header),
+      hydratedWidgetBox: rectOf(widget),
+      authMountMinWidth: getComputedStyle(authMount).minWidth,
+    };
+  });
+
+  expect(hydrated.authMountMinWidth).toBe(`${HEADER_AUTH_SLOT_WIDTH}px`);
+  expect(result.beforeAuthMountBox.width).toBeGreaterThanOrEqual(HEADER_AUTH_SLOT_WIDTH);
+  expect(hydrated.afterAuthMountBox.width).toBeGreaterThanOrEqual(HEADER_AUTH_SLOT_WIDTH);
+  expect(hydrated.hydratedWidgetBox.width).toBeGreaterThan(180);
+  expect(hydrated.hydratedWidgetBox.width).toBeLessThanOrEqual(HEADER_AUTH_SLOT_WIDTH + 1);
+  if (result.pendingSkeletonCount > 0) {
+    expect(result.pendingSkeletonCount).toBe(2);
+  }
+  expectBoxesToMatch(hydrated.afterAuthMountBox, result.beforeAuthMountBox, 'auth mount');
+  expectBoxesToMatch(hydrated.afterHeaderBox, result.beforeHeaderBox, 'header');
+};

--- a/e2e/variant-live-smoke.spec.ts
+++ b/e2e/variant-live-smoke.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Request } from '@playwright/test';
+import { assertSignedOutAuthHydrationKeepsHeaderStable } from './header-reservation';
 import { PREMIUM_RPC_PATHS } from '../src/shared/premium-paths';
 
 type VariantName = 'full' | 'tech' | 'finance' | 'commodity' | 'energy' | 'happy';
@@ -173,6 +174,7 @@ test.describe('variant live reliability smoke', () => {
       .toBeGreaterThan(1);
 
     await page.waitForTimeout(10_000);
+    await assertSignedOutAuthHydrationKeepsHeaderStable(page);
 
     const panelDiagnostics = await page.evaluate((ids) => {
       const expected = new Set(ids);

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -580,7 +580,7 @@ export class PanelLayoutManager implements AppModule {
           ${this.ctx.isDesktopApp ? '' : `<button class="fullscreen-btn" id="fullscreenBtn" title="${t('header.fullscreen')}">⛶</button>`}
           ${SITE_VARIANT === 'happy' ? `<button class="tv-mode-btn" id="tvModeBtn" title="TV Mode (Shift+T)"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2" ry="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg></button>` : ''}
           <span id="unifiedSettingsMount"></span>
-          <span id="authWidgetMount" class="auth-widget-mount" style="display:inline-flex;align-items:center;min-width:148px;min-height:32px"></span>
+          <span id="authWidgetMount" class="auth-widget-mount"></span>
         </div>
       </div>
       <div class="mobile-menu-overlay" id="mobileMenuOverlay"></div>

--- a/src/components/AuthHeaderWidget.ts
+++ b/src/components/AuthHeaderWidget.ts
@@ -19,7 +19,7 @@ export class AuthHeaderWidget {
 
     this.unsubscribeAuth = subscribeAuthState((state: AuthSession) => {
       if (state.isPending) {
-        setTrustedHtml(this.container, trustedHtml('', "legacy direct innerHTML migration"));
+        this.renderPending();
         return;
       }
       this.render(state);
@@ -42,6 +42,8 @@ export class AuthHeaderWidget {
   private render(state: AuthSession): void {
     this.unmountUserButton?.();
     this.unmountUserButton = null;
+    this.container.classList.remove('auth-header-widget-pending');
+    this.container.removeAttribute('aria-busy');
     setTrustedHtml(this.container, trustedHtml('', "legacy direct innerHTML migration"));
 
     if (!state.user) {
@@ -49,6 +51,24 @@ export class AuthHeaderWidget {
       return;
     }
     this.renderSignedIn();
+  }
+
+  private renderPending(): void {
+    this.unmountUserButton?.();
+    this.unmountUserButton = null;
+    this.container.classList.add('auth-header-widget-pending');
+    this.container.setAttribute('aria-busy', 'true');
+    setTrustedHtml(this.container, trustedHtml('', "legacy direct innerHTML migration"));
+
+    const signInSkeleton = document.createElement('span');
+    signInSkeleton.className = 'auth-header-skeleton auth-header-skeleton-signin';
+    signInSkeleton.setAttribute('aria-hidden', 'true');
+    this.container.appendChild(signInSkeleton);
+
+    const signUpSkeleton = document.createElement('span');
+    signUpSkeleton.className = 'auth-header-skeleton auth-header-skeleton-signup';
+    signUpSkeleton.setAttribute('aria-hidden', 'true');
+    this.container.appendChild(signUpSkeleton);
   }
 
   private renderSignedOut(): void {

--- a/src/styles/base-layer.css
+++ b/src/styles/base-layer.css
@@ -6,6 +6,7 @@
  * See: https://developer.mozilla.org/en-US/docs/Web/CSS/@layer
  */
 @import url('./main.css') layer(base);
+@import url('./header.css') layer(base);
 @import url('./country-deep-dive.css') layer(base);
 @import url('./map-context-menu.css') layer(base);
 @import url('./supply-chain-panel.css') layer(base);

--- a/src/styles/header.css
+++ b/src/styles/header.css
@@ -1,0 +1,83 @@
+.header {
+  contain: layout;
+}
+
+.header-right {
+  --header-auth-slot-width: 200px;
+  --header-findings-slot-width: 72px;
+
+  padding-left: calc(var(--header-findings-slot-width) + 12px);
+  position: relative;
+}
+
+.header-right > .intel-findings-badge {
+  box-sizing: border-box;
+  justify-content: center;
+  left: 0;
+  position: absolute;
+  top: 50%;
+  translate: 0 -50%;
+  width: var(--header-findings-slot-width);
+}
+
+#missionPresetMount,
+#unifiedSettingsMount,
+#authWidgetMount {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+}
+
+#missionPresetMount,
+#unifiedSettingsMount {
+  contain: layout;
+}
+
+#missionPresetMount {
+  min-width: 86px;
+  min-height: 24px;
+}
+
+#unifiedSettingsMount {
+  min-width: 28px;
+  min-height: 28px;
+}
+
+#authWidgetMount {
+  min-width: var(--header-auth-slot-width);
+  min-height: 32px;
+}
+
+.auth-header-widget-pending {
+  width: var(--header-auth-slot-width);
+}
+
+.auth-header-skeleton {
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--text) 7%, transparent),
+      color-mix(in srgb, var(--text) 13%, transparent),
+      color-mix(in srgb, var(--text) 7%, transparent)
+    );
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  border-radius: 6px;
+  display: block;
+  height: 32px;
+  pointer-events: none;
+}
+
+.auth-header-skeleton-signin {
+  flex: 0 0 72px;
+}
+
+.auth-header-skeleton-signup {
+  flex: 0 0 120px;
+}
+
+#missionPresetMount:empty,
+#unifiedSettingsMount:empty,
+#authWidgetMount:empty {
+  visibility: hidden;
+}


### PR DESCRIPTION
## Summary
- Adds a loaded header stylesheet for layout containment and stable async mount reservations.
- Reserves mission, settings, findings, and auth header slots so hydrated controls do not push the header rail.
- Renders a 200px pending auth skeleton that matches the signed-out "Sign In" + "Create account" footprint.
- Adds a shared Playwright auth hydration guard that verifies pre/post signed-out auth bounding boxes stay equal, including in `variant-live-smoke`.

Closes #3989.
Parent: #3987.

## Validation
- npx biome lint src/components/AuthHeaderWidget.ts src/styles/header.css e2e/header-reservation.ts e2e/header-cls.spec.ts e2e/variant-live-smoke.spec.ts
- git diff --check HEAD -- src/components/AuthHeaderWidget.ts src/styles/header.css e2e/header-reservation.ts e2e/header-cls.spec.ts e2e/variant-live-smoke.spec.ts
- TMPDIR=/tmp npx playwright test e2e/header-cls.spec.ts --repeat-each=3
- TMPDIR=/tmp npx playwright test e2e/variant-live-smoke.spec.ts
- npm run typecheck
- git push pre-push suite passed: typecheck, API typecheck, Convex type check, CJS syntax, Unicode safety, boundaries, safe HTML, rate-limit policies, premium-fetch parity, edge bundle/tests, version sync
- In-app browser computed styles: header contain=layout; mission 86x24, settings 28x28, auth 200x32
- Visual smoke captured locally: /private/tmp/worldmonitor-issue-3987-header-desktop.png and /private/tmp/worldmonitor-issue-3987-header-mobile.png

## Non-gating Notes
- TMPDIR=/tmp npx playwright test e2e/auth-ui.spec.ts currently times out waiting for local .auth-signin-btn; failure snapshot showed settings rendered while the auth mount remained pending locally. The focused CLS guard now simulates signed-out auth hydration with the project's real button classes while local Clerk remains unavailable.
- Preview Clerk popover verification was attempted from automation, but the Vercel preview redirects to Vercel SSO with HTTP 401 and no local Vercel protection bypass secret is available. As a mitigation, `#authWidgetMount` no longer applies `contain: layout`, so the auth mount itself does not create a containing block for Clerk UI.
