### PR TITLE
fix(mcp): pro HMAC 401s from Vercel rpc query injection + tool fixes

### DIFF
--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -513,15 +513,25 @@ export const RPC_TOOLS: ToolDef[] = [
       const bbox = COUNTRY_BBOXES[code];
       if (!bbox) return { error: `Unknown country code: ${code}. Use ISO 3166-1 alpha-2 (e.g. "AE", "SA", "JP").` };
       const [sw_lat, sw_lon, ne_lat, ne_lon] = bbox;
-      const bboxQ = `sw_lat=${sw_lat}&sw_lon=${sw_lon}&ne_lat=${ne_lat}&ne_lon=${ne_lon}`;
-      const url = `${base}/api/maritime/v1/get-vessel-snapshot?${bboxQ}`;
+      // Deliberately NO bbox on the inner fetch: the handler rejects any bbox
+      // dimension >10° (BboxValidationError → HTTP 400), and 67 of the 167
+      // COUNTRY_BBOXES exceed that (US, JP, AU, BR, …) — WORLDMONITOR-T8.
+      // The relay's density/disruption sets are global regardless of bbox
+      // (bbox only scopes tanker/candidate reports, which this tool never
+      // requests), so we take the cached global snapshot and filter to the
+      // country bbox here using each item's coordinates.
+      const url = `${base}/api/maritime/v1/get-vessel-snapshot`;
       const auth = await buildAuthHeaders(context, 'GET', url, null);
 
+      // Wire shape is the generated sebuf JSON — camelCase field names with
+      // nested `location` (the previous snake_case reads matched nothing, so
+      // density_zones was permanently empty).
+      type VesselLoc = { latitude?: number; longitude?: number };
       type VesselResp = {
         snapshot?: {
-          snapshot_at?: number;
-          density_zones?: { name: string; intensity: number; ships_per_day: number; delta_pct: number; note: string }[];
-          disruptions?: { name: string; type: string; severity: string; dark_ships: number; vessel_count: number; region: string; description: string }[];
+          snapshotAt?: number;
+          densityZones?: { name?: string; location?: VesselLoc; intensity?: number; shipsPerDay?: number; deltaPct?: number; note?: string }[];
+          disruptions?: { name?: string; type?: string; severity?: string; location?: VesselLoc; darkShips?: number; vesselCount?: number; region?: string; description?: string }[];
         };
       };
 
@@ -529,23 +539,44 @@ export const RPC_TOOLS: ToolDef[] = [
         headers: { ...auth, 'User-Agent': 'worldmonitor-mcp-edge/1.0' },
         signal: AbortSignal.timeout(8_000),
       });
-      if (!res.ok) throw new Error(`get-vessel-snapshot HTTP ${res.status}`);
+      if (!res.ok) {
+        const detail = (await res.text().catch(() => '')).slice(0, 200);
+        throw new Error(`get-vessel-snapshot HTTP ${res.status}${detail ? ` — ${detail}` : ''}`);
+      }
       const data = await res.json() as VesselResp;
       const snap = data.snapshot ?? {};
+
+      // 3° pad: maritime zones sit offshore, outside land bboxes (e.g. the
+      // Strait of Hormuz at 26.6N/56.3E vs AE's ne corner at 26.06/56.38).
+      // (0,0) is the handler's default for missing coordinates → exclude.
+      const PAD_DEG = 3;
+      const inCountryBbox = (loc?: VesselLoc): boolean => {
+        const lat = loc?.latitude ?? 0;
+        const lon = loc?.longitude ?? 0;
+        if (lat === 0 && lon === 0) return false;
+        if (lat < sw_lat - PAD_DEG || lat > ne_lat + PAD_DEG) return false;
+        const lo = sw_lon - PAD_DEG;
+        const hi = ne_lon + PAD_DEG;
+        // Antimeridian-wrapped boxes (sw_lon > ne_lon) match the complement range.
+        return sw_lon <= ne_lon ? lon >= lo && lon <= hi : lon >= lo || lon <= hi;
+      };
+
+      const zones = (snap.densityZones ?? []).filter(z => inCountryBbox(z.location));
+      const disruptions = (snap.disruptions ?? []).filter(d => inCountryBbox(d.location));
 
       return {
         country_code: code,
         bounding_box: { sw_lat, sw_lon, ne_lat, ne_lon },
-        snapshot_at: snap.snapshot_at ? new Date(snap.snapshot_at).toISOString() : new Date().toISOString(),
-        total_zones: (snap.density_zones ?? []).length,
-        total_disruptions: (snap.disruptions ?? []).length,
-        density_zones: (snap.density_zones ?? []).map(z => ({
-          name: z.name, intensity: z.intensity, ships_per_day: z.ships_per_day,
-          delta_pct: z.delta_pct, ...(z.note ? { note: z.note } : {}),
+        snapshot_at: snap.snapshotAt ? new Date(snap.snapshotAt).toISOString() : new Date().toISOString(),
+        total_zones: zones.length,
+        total_disruptions: disruptions.length,
+        density_zones: zones.map(z => ({
+          name: z.name, intensity: z.intensity, ships_per_day: z.shipsPerDay,
+          delta_pct: z.deltaPct, ...(z.note ? { note: z.note } : {}),
         })),
-        disruptions: (snap.disruptions ?? []).map(d => ({
+        disruptions: disruptions.map(d => ({
           name: d.name, type: d.type, severity: d.severity,
-          dark_ships: d.dark_ships, vessel_count: d.vessel_count,
+          dark_ships: d.darkShips, vessel_count: d.vesselCount,
           region: d.region, description: d.description,
         })),
       };

--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -556,9 +556,20 @@ export const RPC_TOOLS: ToolDef[] = [
         if (lat === 0 && lon === 0) return false;
         if (lat < sw_lat - PAD_DEG || lat > ne_lat + PAD_DEG) return false;
         const lo = sw_lon - PAD_DEG;
-        const hi = ne_lon + PAD_DEG;
-        // Antimeridian-wrapped boxes (sw_lon > ne_lon) match the complement range.
-        return sw_lon <= ne_lon ? lon >= lo && lon <= hi : lon >= lo || lon <= hi;
+        // Source boxes stored wrapped (sw_lon > ne_lon) span the dateline;
+        // unwrap to a monotonic interval before reasoning about the pad.
+        const hi = (sw_lon > ne_lon ? ne_lon + 360 : ne_lon) + PAD_DEG;
+        // Pad widened the interval to the full circle — AQ and RU are stored
+        // as -180..180 spans, so every longitude matches.
+        if (hi - lo >= 360) return true;
+        // The pad itself can push a ±180-adjacent box past the dateline
+        // (FJ ne_lon=180 → hi=183; NZ 178.29 → 181.29): points just across
+        // it (e.g. -179) must still match, so renormalize the overflowing
+        // end into [-180,180] and compare on the wrapped complement.
+        const wraps = lo < -180 || hi > 180;
+        const loN = lo < -180 ? lo + 360 : lo;
+        const hiN = hi > 180 ? hi - 360 : hi;
+        return wraps ? lon >= loN || lon <= hiN : lon >= loN && lon <= hiN;
       };
 
       const zones = (snap.densityZones ?? []).filter(z => inCountryBbox(z.location));

--- a/server/_shared/mcp-internal-hmac.ts
+++ b/server/_shared/mcp-internal-hmac.ts
@@ -399,6 +399,27 @@ export async function verifyInternalMcpRequest(
     return null;
   }
 
+  // Vercel's filesystem router serves every gateway domain through a dynamic
+  // route file (api/<domain>/v1/[rpc].ts) and injects the matched segment into
+  // the function's request URL as a query parameter (?rpc=<segment>) — see
+  // "named parameters are automatically passed through in the query string"
+  // in Vercel's routing docs. The signer (api/mcp/auth.ts buildAuthHeaders)
+  // signs the OUTBOUND url, which never carries that param, so hashing the
+  // inbound query verbatim 401s EVERY legitimate Pro tool fetch
+  // (WORLDMONITOR-R1 / WORLDMONITOR-T8 — deterministic since U7 shipped,
+  // confirmed live: signing WITH the injected param verifies, without fails).
+  // Strip `rpc` entries ONLY when every value exactly equals the final path
+  // segment — i.e. only the router-injected echo. A caller-appended
+  // ?rpc=<anything-else> still participates in the hash and breaks the
+  // signature, so this is not a bypass vector: stripping the exact echo is
+  // semantically identical to the router not having injected it.
+  const pathSegments = url.pathname.split('/').filter(Boolean);
+  const lastSegment = pathSegments[pathSegments.length - 1] ?? '';
+  const rpcParams = url.searchParams.getAll('rpc');
+  if (rpcParams.length > 0 && rpcParams.every((v) => v === lastSegment)) {
+    url.searchParams.delete('rpc');
+  }
+
   // Body must be cloned BEFORE reading so the downstream handler can still
   // read it — Web Fetch API contract: a body can only be consumed once on
   // any given Request/Response.

--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -298,11 +298,20 @@ export function getClerk(): ClerkInstance | null {
   return clerkInstance;
 }
 
+// Chinese in-app browsers (WeChat/Weibo/QQ/UC/Baidu) routinely block or
+// time out script loads from Cloudflare-fronted third-party hosts like
+// clerk.worldmonitor.app — a `clerk-load-failed` there is environmental
+// (Great-Firewall-class), not actionable, and not a Clerk-CDN-outage
+// signal (WORLDMONITOR-T7). A real CDN outage still alarms via every
+// other browser, so the load-failure capture keeps its value.
+const CN_INAPP_BROWSER_RE = /MicroMessenger|Weibo|QQBrowser|UCBrowser|baiduboxapp/i;
+
 // Report a Clerk UI-open failure as a single handled Sentry event. Lazy
 // import keeps @sentry/browser off this module's static graph (clerk.ts is
 // imported by Node test files where the browser SDK is unwanted) and makes
 // telemetry strictly best-effort — it must never throw into a click handler.
 function captureClerkSurfaceFailure(action: string, err: unknown, reason: string): void {
+  if (reason === 'clerk-load-failed' && typeof navigator !== 'undefined' && CN_INAPP_BROWSER_RE.test(navigator.userAgent)) return;
   void import('@sentry/browser')
     .then((Sentry) => {
       Sentry.captureException(err instanceof Error ? err : new Error(String(err)), {

--- a/tests/gateway-internal-mcp.test.mjs
+++ b/tests/gateway-internal-mcp.test.mjs
@@ -381,15 +381,13 @@ describe('gateway internal-MCP HMAC verify — happy paths', () => {
     assert.deepEqual(await res.json(), { error: 'invalid_internal_mcp_signature' });
   });
 
-  it('signer that legitimately included rpc=<last-segment> in the signed URL still verifies', async () => {
+  it('rpc=<last-segment> in the SIGNED URL fails verification — rpc is a reserved routing param', async () => {
     // Both sides carry the param: verifier strips it from the inbound hash,
-    // and the signer's canonical string included it — they would diverge if
-    // the signer-side URL ever grows a real rpc param. Pin the SAFE direction:
-    // the inbound request carries the same single echo entry the router would
-    // inject, so stripping reproduces the signed (param-less) string only when
-    // the signer ALSO omitted it. Here the signer included it, so verification
-    // must fail — documenting that `rpc` is a RESERVED routing param that
-    // outbound tool URLs must never use.
+    // but the signer's canonical string included it, so the hashes diverge
+    // and verification MUST fail (401). This pins the contract that `rpc`
+    // is a RESERVED routing param outbound tool URLs must never use — if a
+    // future endpoint legitimately needs a query param named rpc, the
+    // signer and verifier have to agree on new handling first.
     const handler = makeGateway();
     const url = 'https://api.worldmonitor.app/api/news/v1/list-feed-digest?rpc=list-feed-digest';
     const signed = await signInternalMcpRequest({ method: 'GET', url, body: null, userId: PRO_USER_ID, secret: HMAC_SECRET });

--- a/tests/gateway-internal-mcp.test.mjs
+++ b/tests/gateway-internal-mcp.test.mjs
@@ -320,6 +320,89 @@ describe('gateway internal-MCP HMAC verify — happy paths', () => {
     const res = await handler(req);
     assert.equal(res.status, 200, 'GET with empty body verified ok');
   });
+
+  // -------------------------------------------------------------------------
+  // Vercel dynamic-route query injection (WORLDMONITOR-R1 / WORLDMONITOR-T8).
+  //
+  // In production every gateway domain is served by api/<domain>/v1/[rpc].ts;
+  // Vercel's filesystem router injects the matched segment into the function's
+  // request URL as ?rpc=<segment>. The signer never sees that param, so the
+  // verifier must strip the exact router echo before hashing — confirmed live:
+  // signing WITHOUT the param 401'd (invalid_internal_mcp_signature) while
+  // signing WITH it passed signature verify. These tests feed the verifier the
+  // REAL production request shape, which the original suite never did.
+  // -------------------------------------------------------------------------
+  it('Vercel-injected ?rpc=<last-segment> on the inbound URL still verifies (signer never saw it)', async () => {
+    const handler = makeGateway();
+    const signedUrl = 'https://api.worldmonitor.app/api/news/v1/list-feed-digest?lang=en';
+    const inboundUrl = 'https://api.worldmonitor.app/api/news/v1/list-feed-digest?lang=en&rpc=list-feed-digest';
+    const signed = await signInternalMcpRequest({ method: 'GET', url: signedUrl, body: null, userId: PRO_USER_ID, secret: HMAC_SECRET });
+    const req = new Request(inboundUrl, {
+      method: 'GET',
+      headers: {
+        [INTERNAL_MCP_SIG_HEADER]: signed.signature,
+        [INTERNAL_MCP_USER_ID_HEADER]: signed.userId,
+      },
+    });
+    const res = await handler(req);
+    assert.equal(res.status, 200, 'router-injected rpc param MUST be stripped before hashing');
+  });
+
+  it('Vercel-injected ?rpc=<last-segment> with NO other query params still verifies', async () => {
+    const handler = makeGateway();
+    const signedUrl = 'https://api.worldmonitor.app/api/news/v1/list-feed-digest';
+    const inboundUrl = 'https://api.worldmonitor.app/api/news/v1/list-feed-digest?rpc=list-feed-digest';
+    const signed = await signInternalMcpRequest({ method: 'GET', url: signedUrl, body: null, userId: PRO_USER_ID, secret: HMAC_SECRET });
+    const req = new Request(inboundUrl, {
+      method: 'GET',
+      headers: {
+        [INTERNAL_MCP_SIG_HEADER]: signed.signature,
+        [INTERNAL_MCP_USER_ID_HEADER]: signed.userId,
+      },
+    });
+    const res = await handler(req);
+    assert.equal(res.status, 200, 'router-injected rpc as the only param MUST be stripped');
+  });
+
+  it('caller-appended ?rpc with a value ≠ last path segment still breaks the signature → 401', async () => {
+    const handler = makeGateway();
+    const signedUrl = 'https://api.worldmonitor.app/api/news/v1/list-feed-digest';
+    const inboundUrl = 'https://api.worldmonitor.app/api/news/v1/list-feed-digest?rpc=evil-other-route';
+    const signed = await signInternalMcpRequest({ method: 'GET', url: signedUrl, body: null, userId: PRO_USER_ID, secret: HMAC_SECRET });
+    const req = new Request(inboundUrl, {
+      method: 'GET',
+      headers: {
+        [INTERNAL_MCP_SIG_HEADER]: signed.signature,
+        [INTERNAL_MCP_USER_ID_HEADER]: signed.userId,
+      },
+    });
+    const res = await handler(req);
+    assert.equal(res.status, 401, 'non-echo rpc values MUST stay in the hash');
+    assert.deepEqual(await res.json(), { error: 'invalid_internal_mcp_signature' });
+  });
+
+  it('signer that legitimately included rpc=<last-segment> in the signed URL still verifies', async () => {
+    // Both sides carry the param: verifier strips it from the inbound hash,
+    // and the signer's canonical string included it — they would diverge if
+    // the signer-side URL ever grows a real rpc param. Pin the SAFE direction:
+    // the inbound request carries the same single echo entry the router would
+    // inject, so stripping reproduces the signed (param-less) string only when
+    // the signer ALSO omitted it. Here the signer included it, so verification
+    // must fail — documenting that `rpc` is a RESERVED routing param that
+    // outbound tool URLs must never use.
+    const handler = makeGateway();
+    const url = 'https://api.worldmonitor.app/api/news/v1/list-feed-digest?rpc=list-feed-digest';
+    const signed = await signInternalMcpRequest({ method: 'GET', url, body: null, userId: PRO_USER_ID, secret: HMAC_SECRET });
+    const req = new Request(url, {
+      method: 'GET',
+      headers: {
+        [INTERNAL_MCP_SIG_HEADER]: signed.signature,
+        [INTERNAL_MCP_USER_ID_HEADER]: signed.userId,
+      },
+    });
+    const res = await handler(req);
+    assert.equal(res.status, 401, 'rpc is reserved for the router; signer URLs must not carry it');
+  });
 });
 
 // ===========================================================================

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -2163,16 +2163,28 @@ describe('api/mcp.ts — PRO MCP Server', () => {
   // --- get_maritime_activity ---
 
   it('get_maritime_activity returns zones and disruptions for valid country code', async () => {
+    // Fixture mirrors the REAL wire shape of the generated sebuf handler:
+    // camelCase keys + nested `location` objects. The original fixture used
+    // snake_case (which the wire never produces), so the tool's misread of
+    // density_zones/snapshot_at passed the suite while returning total_zones=0
+    // in production — WORLDMONITOR-T8. Items outside the AE bbox (+3° pad)
+    // must be filtered out tool-side; the inner fetch must carry NO bbox
+    // query (the handler 400s any dimension >10°, and 67 COUNTRY_BBOXES
+    // exceed that).
+    let innerUrl = null;
     globalThis.fetch = async (url) => {
       if (url.toString().includes('/api/maritime/v1/get-vessel-snapshot')) {
+        innerUrl = url.toString();
         return new Response(JSON.stringify({
           snapshot: {
-            snapshot_at: 1711620000000,
-            density_zones: [
-              { name: 'Strait of Hormuz', intensity: 82, ships_per_day: 45, delta_pct: 3.2, note: '' },
+            snapshotAt: 1711620000000,
+            densityZones: [
+              { name: 'Strait of Hormuz', location: { latitude: 26.6, longitude: 56.3 }, intensity: 82, shipsPerDay: 45, deltaPct: 3.2, note: '' },
+              { name: 'Zone 50,4 North Sea', location: { latitude: 51, longitude: 5 }, intensity: 1, shipsPerDay: 114240, deltaPct: 0, note: 'High traffic area' },
             ],
             disruptions: [
-              { name: 'Gulf AIS Gap', type: 'AIS_DISRUPTION_TYPE_GAP_SPIKE', severity: 'AIS_DISRUPTION_SEVERITY_ELEVATED', dark_ships: 3, vessel_count: 12, region: 'Persian Gulf', description: 'Elevated dark-ship activity' },
+              { name: 'Gulf AIS Gap', type: 'AIS_DISRUPTION_TYPE_GAP_SPIKE', severity: 'AIS_DISRUPTION_SEVERITY_ELEVATED', location: { latitude: 25.5, longitude: 54.0 }, darkShips: 3, vesselCount: 12, region: 'Persian Gulf', description: 'Elevated dark-ship activity' },
+              { name: 'Taiwan Strait', type: 'AIS_DISRUPTION_TYPE_CHOKEPOINT_CONGESTION', severity: 'AIS_DISRUPTION_SEVERITY_LOW', location: { latitude: 24.5, longitude: 119.5 }, darkShips: 0, vesselCount: 17, region: 'Taiwan Strait', description: 'Congestion' },
             ],
           },
         }), { status: 200, headers: { 'Content-Type': 'application/json' } });
@@ -2188,11 +2200,42 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     const body = await res.json();
     const data = JSON.parse(body.result.content[0].text);
     assert.equal(data.country_code, 'AE');
-    assert.equal(data.total_zones, 1);
-    assert.equal(data.total_disruptions, 1);
+    assert.ok(innerUrl !== null, 'inner vessel-snapshot fetch must happen');
+    assert.ok(!/sw_lat|ne_lat/.test(innerUrl), 'inner fetch must NOT send a bbox (handler caps at 10°/side)');
+    assert.equal(data.total_zones, 1, 'North Sea zone must be filtered out of AE results');
+    assert.equal(data.total_disruptions, 1, 'Taiwan Strait must be filtered out of AE results');
     assert.equal(data.density_zones[0].name, 'Strait of Hormuz');
+    assert.equal(data.density_zones[0].ships_per_day, 45, 'camelCase wire field must map to snake_case output');
     assert.equal(data.disruptions[0].dark_ships, 3);
+    assert.equal(data.snapshot_at, new Date(1711620000000).toISOString(), 'snapshotAt wire field must populate snapshot_at');
     assert.ok(data.bounding_box?.sw_lat !== undefined, 'bounding_box must be present');
+  });
+
+  it('get_maritime_activity works for countries whose bbox exceeds the 10° handler cap (e.g. JP)', async () => {
+    globalThis.fetch = async (url) => {
+      if (url.toString().includes('/api/maritime/v1/get-vessel-snapshot')) {
+        return new Response(JSON.stringify({
+          snapshot: {
+            snapshotAt: 1711620000000,
+            densityZones: [
+              { name: 'Tokyo Bay', location: { latitude: 35.4, longitude: 139.8 }, intensity: 60, shipsPerDay: 500, deltaPct: 1, note: '' },
+            ],
+            disruptions: [],
+          },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return originalFetch(url);
+    };
+
+    const res = await handler(makeReq('POST', {
+      jsonrpc: '2.0', id: 22, method: 'tools/call',
+      params: { name: 'get_maritime_activity', arguments: { country_code: 'JP' } },
+    }));
+    const body = await res.json();
+    assert.equal(body.error, undefined, 'JP (14°×16° bbox) must not error');
+    const data = JSON.parse(body.result.content[0].text);
+    assert.equal(data.total_zones, 1);
+    assert.equal(data.density_zones[0].name, 'Tokyo Bay');
   });
 
   it('get_maritime_activity returns error for unknown country code', async () => {

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -2211,6 +2211,65 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.ok(data.bounding_box?.sw_lat !== undefined, 'bounding_box must be present');
   });
 
+  it('get_maritime_activity keeps dateline-adjacent results when the pad crosses ±180 (FJ)', async () => {
+    // FJ bbox is [-18.25, 177.34, -16.15, 180]: the +3° pad pushes the east
+    // edge to 183, so a point at -179 sits just across the dateline and MUST
+    // match (it is 1-4° away), while a genuinely distant Pacific point must
+    // not. The original filter only treated sw_lon > ne_lon as wrapped and
+    // silently dropped the -179 point.
+    globalThis.fetch = async (url) => {
+      if (url.toString().includes('/api/maritime/v1/get-vessel-snapshot')) {
+        return new Response(JSON.stringify({
+          snapshot: {
+            snapshotAt: 1711620000000,
+            densityZones: [
+              { name: 'Across the dateline', location: { latitude: -17.5, longitude: -179 }, intensity: 10, shipsPerDay: 20, deltaPct: 0, note: '' },
+              { name: 'West of Fiji in-box', location: { latitude: -17.0, longitude: 178.0 }, intensity: 5, shipsPerDay: 10, deltaPct: 0, note: '' },
+              { name: 'Far Pacific', location: { latitude: -17.5, longitude: -150 }, intensity: 3, shipsPerDay: 5, deltaPct: 0, note: '' },
+            ],
+            disruptions: [],
+          },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return originalFetch(url);
+    };
+
+    const res = await handler(makeReq('POST', {
+      jsonrpc: '2.0', id: 23, method: 'tools/call',
+      params: { name: 'get_maritime_activity', arguments: { country_code: 'FJ' } },
+    }));
+    const body = await res.json();
+    const data = JSON.parse(body.result.content[0].text);
+    const names = data.density_zones.map((z) => z.name).sort();
+    assert.deepEqual(names, ['Across the dateline', 'West of Fiji in-box'], 'dateline-adjacent point must match; far-Pacific point must not');
+  });
+
+  it('get_maritime_activity matches every longitude for full-span bboxes (AQ stored as -180..180)', async () => {
+    globalThis.fetch = async (url) => {
+      if (url.toString().includes('/api/maritime/v1/get-vessel-snapshot')) {
+        return new Response(JSON.stringify({
+          snapshot: {
+            snapshotAt: 1711620000000,
+            densityZones: [
+              { name: 'Drake Passage', location: { latitude: -65, longitude: -62 }, intensity: 4, shipsPerDay: 8, deltaPct: 0, note: '' },
+              { name: 'Ross Sea', location: { latitude: -75, longitude: 175 }, intensity: 1, shipsPerDay: 1, deltaPct: 0, note: '' },
+            ],
+            disruptions: [],
+          },
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      return originalFetch(url);
+    };
+
+    const res = await handler(makeReq('POST', {
+      jsonrpc: '2.0', id: 24, method: 'tools/call',
+      params: { name: 'get_maritime_activity', arguments: { country_code: 'AQ' } },
+    }));
+    const body = await res.json();
+    const data = JSON.parse(body.result.content[0].text);
+    assert.equal(data.total_zones, 2, 'a full-circle longitude span must not collapse under pad normalization');
+  });
+
   it('get_maritime_activity works for countries whose bbox exceeds the 10° handler cap (e.g. JP)', async () => {
     globalThis.fetch = async (url) => {
       if (url.toString().includes('/api/maritime/v1/get-vessel-snapshot')) {


### PR DESCRIPTION
## Summary

Sentry triage (`/sentry-triage`) traced WORLDMONITOR-T8 (`get-vessel-snapshot HTTP 401`) to a month-old systemic bug, plus two latent bugs in the same tool and one noise source.

- **Every Pro-context MCP tool inner fetch has 401'd since the pro HMAC path shipped (2026-05-11).** Gateway domains are served by Vercel dynamic route files (`api/<domain>/v1/[rpc].ts`), and Vercel's filesystem router injects the matched segment into the function's request URL as `?rpc=<segment>`. `verifyInternalMcpRequest` hashed that query verbatim; the signer (`api/mcp/auth.ts`) never saw the param → `invalid_internal_mcp_signature` on 100% of Pro inner fetches (WORLDMONITOR-R1, 173 events misread as "transient HMAC drift", + T8). env-key callers authenticate via header, not URL signature, which is why key-based testing never saw it. **Fix:** the verifier strips `rpc` entries only when every value equals the final path segment — the exact router echo. `?rpc=<anything-else>` still breaks the signature (not a bypass vector); `rpc` is now a reserved routing param, test-pinned.
- **`get_maritime_activity` returned HTTP 400 for 67 of 167 countries** (JP/US/AU/BR…): it sent the raw country bbox but the handler rejects any dimension >10°. The relay's density/disruption sets are global regardless of bbox, so the tool now fetches the global snapshot and filters tool-side by item coordinates (country bbox + 3° offshore pad, antimeridian-aware).
- **`density_zones` was permanently empty** even on success: the tool read snake_case (`density_zones`/`snapshot_at`) off the camelCase sebuf wire (`densityZones`/`snapshotAt`). Disruptions were also unfiltered (Taiwan Strait returned for AE). Both fixed; non-ok inner responses now include a body snippet in the thrown error for diagnosability.
- **Clerk `clerk-load-failed` captures from CN in-app browsers** (WeChat/Weibo/QQ/UC/Baidu) are skipped — Great-Firewall-class environmental noise (WORLDMONITOR-T7). A real Clerk CDN outage still alarms via every other browser.

### Live confirmation of the HMAC root cause
Differential probe against production with the prod secret and a fake userId: signing the URL exactly as the edge signs → `{"error":"invalid_internal_mcp_signature"}`; signing with `rpc=<segment>` appended → signature **passes** (rejects at entitlement). Deterministic, both directions.

### Why tests missed all three
The HMAC suite signed and verified the same URL (never the production request shape), and the maritime fixture invented a snake_case wire the endpoint never produces. New tests pin the real shapes.

## Test plan
- [x] `npm run typecheck` + `npm run typecheck:api`
- [x] `npm run lint` + `lint:md` + CJS syntax + edge bundle check + `version:check`
- [x] `npm run test:data` (full suite, 47s)
- [x] New: verifier accepts Vercel-injected `?rpc=<segment>` (with and without other params); rejects `?rpc=<other>`; rejects signer-side `rpc` (reserved param)
- [x] New: maritime tool sends no bbox, maps camelCase wire, filters out-of-bbox items, JP (14°×16°) no longer errors
- [x] Live: env-key MCP call to `get_maritime_activity(AE)` returns data end-to-end
- [ ] Post-deploy: re-run differential probe — sign-without-rpc should now pass the signature layer; Sentry R1/T8 are `inNextRelease` and will auto-reopen on recurrence