### PR TITLE
docs(perf-G): note deferred-Sentry release-health tradeoff (follow-up to #4005)

### DIFF
--- a/src/bootstrap/sentry-defer.ts
+++ b/src/bootstrap/sentry-defer.ts
@@ -29,6 +29,20 @@
  * The init options block (the giant `ignoreErrors` regex array, `beforeSend`
  * suppression logic, allowlists) lives inside the dynamic-import callback so
  * it ships in the deferred sentry-*.js chunk, not the main entry.
+ *
+ * Release-health tradeoff: `browserSessionIntegration` (a Sentry default
+ * integration) calls `startSession()` + `captureSession()` synchronously
+ * inside `Sentry.init()`. Deferring init therefore delays the session
+ * (Sentry treats browser sessions as "akin to a page view") by up to the
+ * `requestIdleCallback` timeout, and users who leave before the deferred
+ * init fires get no session at all. Expect a one-time step-change in the
+ * Sentry release-health dashboard after this ships: lower total session
+ * volume and a shifted crash-free-session rate — a pre-init crash is still
+ * captured as an error via the queue above, but no session was ever started
+ * to attribute it to. This is inherent to deferral (a session cannot start
+ * without the SDK loaded) and is the accepted cost of the pre-LCP CPU
+ * savings. Vercel Analytics (`inject()` in `main.ts`) remains the primary
+ * traffic metric and is unaffected.
  */
 
 type SentryNs = typeof import('@sentry/browser');

--- a/src/bootstrap/sentry-defer.ts
+++ b/src/bootstrap/sentry-defer.ts
@@ -35,8 +35,8 @@
  * inside `Sentry.init()`. Deferring init therefore delays the session
  * (Sentry treats browser sessions as "akin to a page view") by up to the
  * `requestIdleCallback` timeout, and users who leave before the deferred
- * init fires get no session at all. Expect a one-time step-change in the
- * Sentry release-health dashboard after this ships: lower total session
+ * init fires get no session at all. This caused a one-time step-change in the
+ * Sentry release-health dashboard when first deployed: lower total session
  * volume and a shifted crash-free-session rate — a pre-init crash is still
  * captured as an error via the queue above, but no session was ever started
  * to attribute it to. This is inherent to deferral (a session cannot start


### PR DESCRIPTION
Follow-up to #4005 (`perf(G): defer Sentry init off the critical path`), which merged before the post-merge code review was actioned. This applies the one outstanding **P2** from that review and records the full findings below for the record.

## What

Adds a "Release-health tradeoff" note to the top-of-file doc comment in `src/bootstrap/sentry-defer.ts`. Comment-only change — no behavior change.

## Why (the P2)

`browserSessionIntegration` is a Sentry **default** integration; its `setupOnce()` calls `startSession()` + `captureSession()` **synchronously inside `Sentry.init()`** (`@sentry/browser@10.46.0` → `integrations/browsersession.js:28-29`). Sentry treats browser sessions as "akin to a page view."

Because #4005 defers `init()` via `requestIdleCallback({ timeout: 4000 })`:

- the session is started/sent up to ~4s late, and
- **users who leave before the deferred init fires get no session at all.**

Net effect on the Sentry release-health dashboard after #4005 shipped: a one-time **step-change** — lower total session volume and a shifted crash-free-session rate (a pre-init crash is still captured as an *error* via the pre-init queue, but no *session* was ever started to attribute it to).

This is **not a bug** — it's inherent to deferral (a session cannot start without the SDK loaded) and is the accepted cost of the pre-LCP CPU savings. The gap was simply **undocumented**, so this PR documents it. Vercel Analytics (`inject()` in `main.ts`) remains the primary traffic metric and is unaffected.

## Verification

- `npm run typecheck` — clean
- `node --test tests/sentry-beforesend.test.mjs` — 160/160 pass
- `tsx --test tests/sentry-defer-replay.test.mts` — 5/5 pass

---

## Full review findings for #4005 (post-merge)

Reviewed against the merged code + the `@sentry/browser@10.46.0` source.

**Overall: the #4005 implementation is sound.** Deferral preserves error coverage with no gaps and no double-capture, and the pre-init replay mirrors Sentry's `globalHandlers` faithfully. Both prior reviewer findings (Greptile P1/P2, owner P1) were already addressed in commit `abc739037` before merge.

### P0 — Critical
None.

### P1 — High
None outstanding. The owner's P1 (queued primitive/object/Event promise rejections must reproduce Sentry's `globalHandlers` event shape so existing `ignoreErrors` suppressors still match) was verified against the SDK source:
- primitive → `Non-Error promise rejection captured with value: …` (matches `_eventFromRejectionWithPrimitive`)
- plain object → `Object captured as promise rejection with keys: …` (matches `getNonErrorObjectExceptionValue`)
- Event → `Event \`Event\` (type=…) captured as promise rejection` (matches `eventFromPlainObject`)
- mechanism constants `auto.browser.global_handlers.on{error,unhandledrejection}` + `handled:false` match exactly, and `hint.mechanism` is honored downstream (`core/utils/prepareEvent.js` → `addExceptionMechanism`, `newMechanism` wins the merge).

### P2 — Medium
**Release-health session step-change — undocumented.** ← **fixed by this PR.**

### P3 — Low (not actioned; recorded for awareness)
1. Dead branch in `scheduleSentryInit`: `if (scheduled) return Promise.resolve();` is unreachable — `initPromise` is always set in the same synchronous block, so the earlier `if (initPromise)` guard already covers it. Harmless/defensive.
2. `extra.__serialized__` for the Event/plain-object replay diverges slightly from Sentry's `normalizeToSize` output (cosmetic metadata; does not affect grouping or `ignoreErrors`; Sentry normalizes `extra` anyway).
3. Synthetic onerror event for a thrown non-Error *object* (`throw {…}`) keys off `ev.message` rather than serializing the object the way Sentry would. Rare edge case (modern browsers populate `ev.error`).

### Verified solid (residual-risk notes)
- No coverage gap / no double-capture: buffering listeners attach before scheduling; drain + `teardownPreInitState()` run synchronously after `ns.init()`, so the window where both our listeners and Sentry's `globalHandlers` are attached carries zero async events.
- Failure path clean: `loadFailed` + teardown removes listeners, empties queues, no-ops `enqueueSentryCall`.
- No regression vs. old `main.ts` (old `Sentry.init()` also ran after the `App` import evaluated).
- `tracesSampleRate: 0.1` is not a loss — no `browserTracingIntegration` configured, so there were no pageload transactions to lose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
