### PR TITLE
fix(bundle): flag graceful seed failures

### DIFF
--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -27,6 +27,22 @@
 
 Each "bundle" is a single Railway cron service that replaces N individual services. The bundle script spawns each member seed sequentially via `child_process.execFile`, checking Redis `seed-meta:` timestamps to skip seeds that ran recently. Original seed scripts are unchanged.
 
+**Graceful fetch failures:** `runSeed` now treats transient upstream fetch
+failures as non-zero graceful failures after extending the last-good Redis TTL.
+This applies to bundled members and standalone `runSeed` cron seeders: Railway
+may mark that cron run failed, but `/api/health` and seed-contract probes still
+read the preserved `seed-meta:` freshness. Alerting should either tolerate these
+transient cron failures or key sustained data-health pages off those freshness
+checks. Bundle member logs use `status=GRACEFUL_FAIL`; external log consumers
+that match only `status=FAILED` should include `GRACEFUL_FAIL`. The bundle
+summary still reports these under `failed:N`, so use per-section status when
+distinguishing graceful upstream outages from hard failures.
+
+**Standalone follow-up:** `scripts/seed-military-flights.mjs` and
+`scripts/seed-service-statuses.mjs` still have manual graceful failure paths
+that exit `0`. Track those separately if the standalone graceful-failure
+contract needs to be made fully uniform beyond shared `runSeed` users.
+
 **Per-bundle migration:**
 
 1. Delete ONE old member first (to free a slot under the 100 limit)

--- a/scripts/_bundle-runner.mjs
+++ b/scripts/_bundle-runner.mjs
@@ -24,7 +24,7 @@
 import { spawn } from 'node:child_process';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { loadEnvFile } from './_seed-utils.mjs';
+import { GRACEFUL_FETCH_FAILURE_EXIT_CODE, loadEnvFile } from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -180,6 +180,13 @@ function spawnSeed(scriptPath, { timeoutMs, label, bundleStartedAtMs }) {
         settle({ elapsed, ok: false, reason: `timeout after ${Math.round(timeoutMs / 1000)}s (signal ${signal || 'SIGTERM'})`, alreadyLogged: true });
       } else if (code === 0) {
         settle({ elapsed, ok: true, seedComplete: lastSeedComplete });
+      } else if (code === GRACEFUL_FETCH_FAILURE_EXIT_CODE) {
+        settle({
+          elapsed,
+          ok: false,
+          status: 'GRACEFUL_FAIL',
+          reason: `graceful fetch failure (exit ${GRACEFUL_FETCH_FAILURE_EXIT_CODE})`,
+        });
       } else {
         settle({ elapsed, ok: false, reason: `exit ${code ?? 'null'}${signal ? ` (signal ${signal})` : ''}` });
       }
@@ -284,7 +291,8 @@ export async function runBundle(label, sections, opts = {}) {
       // appear before those stderr lines when consumers concatenate
       // stdout+stderr, breaking tests (and log readers) that rely on
       // signal-escalation ordering.
-      console.error(`[Bundle:${label}] section=${section.label} status=FAILED elapsed=${result.elapsed}s reason=${(result.reason || 'unknown').replace(/\s+/g, ' ')}`);
+      const status = result.status || 'FAILED';
+      console.error(`[Bundle:${label}] section=${section.label} status=${status} elapsed=${result.elapsed}s reason=${(result.reason || 'unknown').replace(/\s+/g, ' ')}`);
       failed++;
     }
   }

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -460,6 +460,11 @@ export async function readCanonicalEnvelopeMeta(canonicalKey) {
 // fetches like seed-imf-* WEO bundles).
 export const PERMANENT_4XX_STATUSES = new Set([400, 401, 403, 404, 410, 422, 451]);
 
+// sysexits.h EX_TEMPFAIL: fetch failed, last-good TTL was extended, and the
+// bundle runner should retry/report non-OK without treating the seeder as a
+// generic crash.
+export const GRACEFUL_FETCH_FAILURE_EXIT_CODE = 75;
+
 // Cap upstream Retry-After hints so a stuck/abusive header can't park the
 // bundle past its section timeoutMs. Mirrors _yahoo-fetch.mjs convention.
 const MAX_RETRY_AFTER_MS = 60_000;
@@ -1314,8 +1319,8 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     // releases at most once for a given runId, and EXPIRE pipelines on
     // existing keys are safely re-runnable — so a race between the
     // catch path and the handler converges on the correct end state.
-    // process.exit(0) below terminates before any pending SIGTERM can
-    // fire on the success path of cleanup.
+    // process.exit below terminates before any pending SIGTERM can fire
+    // on the success path of cleanup.
     await releaseLock(`${domain}:${resource}`, runId);
     const durationMs = Date.now() - startMs;
     const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
@@ -1327,7 +1332,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     await extendExistingTtl(keys, ttl);
 
     console.log(`\n=== Failed gracefully (${Math.round(durationMs)}ms) ===`);
-    process.exit(0);
+    process.exit(GRACEFUL_FETCH_FAILURE_EXIT_CODE);
   }
   // Transition to publish phase — handler stays installed but switches
   // behavior via the phase tracker.

--- a/scripts/seed-health-air-quality.mjs
+++ b/scripts/seed-health-air-quality.mjs
@@ -4,6 +4,7 @@ import {
   acquireLockSafely,
   CHROME_UA,
   extendExistingTtl,
+  GRACEFUL_FETCH_FAILURE_EXIT_CODE,
   getRedisCredentials,
   loadEnvFile,
   logSeedResult,
@@ -549,7 +550,7 @@ async function main() {
       process.exit(1);
     }
     console.log(`\n=== Failed gracefully (${Math.round(durationMs)}ms) ===`);
-    process.exit(0);
+    process.exit(GRACEFUL_FETCH_FAILURE_EXIT_CODE);
   }
 
   if (!validateAirQualityPayload(payload)) {

--- a/tests/air-quality-seed.test.mjs
+++ b/tests/air-quality-seed.test.mjs
@@ -1,5 +1,10 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
   buildOpenAqHeaders,
@@ -15,6 +20,7 @@ import {
   OPENAQ_META_KEY,
   mergeAirQualityStations,
 } from '../scripts/seed-health-air-quality.mjs';
+import { GRACEFUL_FETCH_FAILURE_EXIT_CODE } from '../scripts/_seed-utils.mjs';
 
 describe('air quality AQI helpers', () => {
   it('maps PM2.5 concentrations onto EPA AQI breakpoints', () => {
@@ -227,5 +233,63 @@ describe('air quality payload assembly', () => {
     assert.equal(commands[1][4], '3600');
     assert.match(String(commands[2][2]), /"recordCount":1/);
     assert.match(String(commands[3][2]), /"sourceVersion":"source-v1"/);
+  });
+});
+
+describe('air quality main graceful failure behavior', () => {
+  it('exits with graceful-failure code after fetch failure and TTL extension', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'wm-air-quality-fail-'));
+    const preloadPath = join(tempDir, 'preload.mjs');
+    const redisUrl = 'https://fake-upstash.local';
+    writeFileSync(preloadPath, `
+process.env.UPSTASH_REDIS_REST_URL = ${JSON.stringify(redisUrl)};
+process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+process.env.OPENAQ_API_KEY = 'fake-openaq-key';
+delete process.env.WAQI_API_KEY;
+
+globalThis.fetch = async (url, init = {}) => {
+  const href = String(url);
+  if (href === ${JSON.stringify(redisUrl)}) {
+    return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+  }
+  if (href === ${JSON.stringify(`${redisUrl}/pipeline`)}) {
+    const commands = init.body ? JSON.parse(init.body) : [];
+    return new Response(JSON.stringify(commands.map(() => ({ result: 1 }))), { status: 200 });
+  }
+  if (href.startsWith('https://api.openaq.org/')) {
+    throw new Error('forced OpenAQ outage');
+  }
+  return new Response(JSON.stringify({ result: null }), { status: 200 });
+};
+`);
+
+    try {
+      const scriptPath = fileURLToPath(new URL('../scripts/seed-health-air-quality.mjs', import.meta.url));
+      const result = await new Promise((resolve) => {
+        const child = spawn(process.execPath, ['--import', preloadPath, scriptPath], {
+          env: {
+            ...process.env,
+            UPSTASH_REDIS_REST_URL: redisUrl,
+            UPSTASH_REDIS_REST_TOKEN: 'fake-token',
+            OPENAQ_API_KEY: 'fake-openaq-key',
+            WAQI_API_KEY: '',
+          },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', (chunk) => { stdout += chunk; });
+        child.stderr.on('data', (chunk) => { stderr += chunk; });
+        child.on('close', (code) => resolve({ code, stdout, stderr }));
+      });
+
+      const combined = result.stdout + result.stderr;
+      assert.equal(result.code, GRACEFUL_FETCH_FAILURE_EXIT_CODE);
+      assert.match(combined, /FETCH FAILED: forced OpenAQ outage/);
+      assert.match(combined, /Extended TTL on 4 key\(s\)/);
+      assert.match(combined, /=== Failed gracefully \(/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/bundle-runner.test.mjs
+++ b/tests/bundle-runner.test.mjs
@@ -9,6 +9,7 @@ import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
 import { writeFileSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
+import { GRACEFUL_FETCH_FAILURE_EXIT_CODE } from '../scripts/_seed-utils.mjs';
 
 const SCRIPTS_DIR = new URL('../scripts/', import.meta.url).pathname;
 
@@ -141,6 +142,47 @@ test('non-zero exit without timeout reports exit code', async () => {
     const combined = stdout + stderr;
     assert.match(combined, /\[FAIL\] boom/);
     assert.match(combined, /Failed after .*s: exit 2/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('graceful fetch failure exit reports a distinct non-OK bundle status', async () => {
+  const cleanup = writeFixture(
+    '_bundle-fixture-graceful-fail.mjs',
+    `console.error('FETCH FAILED: upstream unavailable');\nconsole.log('=== Failed gracefully (42ms) ===');\nprocess.exit(${GRACEFUL_FETCH_FAILURE_EXIT_CODE});\n`,
+  );
+  try {
+    const { code, stdout, stderr } = await runBundleWith([
+      { label: 'GRACEFUL', script: '_bundle-fixture-graceful-fail.mjs', intervalMs: 1, timeoutMs: 5000 },
+    ]);
+    const combined = stdout + stderr;
+    assert.equal(code, 1, 'graceful fetch failure must make the bundle non-zero');
+    assert.match(combined, /\[GRACEFUL\] FETCH FAILED: upstream unavailable/);
+    assert.match(combined, new RegExp(`Failed after .*s: graceful fetch failure \\(exit ${GRACEFUL_FETCH_FAILURE_EXIT_CODE}\\)`));
+    assert.match(combined, new RegExp(`\\[Bundle:test\\] section=GRACEFUL status=GRACEFUL_FAIL .*reason=graceful fetch failure \\(exit ${GRACEFUL_FETCH_FAILURE_EXIT_CODE}\\)`));
+    assert.match(stdout, /\[Bundle:test\] Finished .* ran:0 skipped:0 deferred:0 failed:1/);
+    assert.doesNotMatch(combined, /\[Bundle:test\] section=GRACEFUL status=OK/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('lock-skip-like exit zero remains OK even without seed_complete', async () => {
+  const cleanup = writeFixture(
+    '_bundle-fixture-lock-skip.mjs',
+    `console.log('SKIPPED: another seed run in progress');\nprocess.exit(0);\n`,
+  );
+  try {
+    const { code, stdout, stderr } = await runBundleWith([
+      { label: 'LOCK_SKIP', script: '_bundle-fixture-lock-skip.mjs', intervalMs: 1, timeoutMs: 5000 },
+    ]);
+    const combined = stdout + stderr;
+    assert.equal(code, 0, 'lock-skip exit zero must remain a successful bundle outcome');
+    assert.match(combined, /\[LOCK_SKIP\] SKIPPED: another seed run in progress/);
+    assert.match(combined, /\[Bundle:test\] section=LOCK_SKIP status=OK elapsed=/);
+    assert.match(stdout, /\[Bundle:test\] Finished .* ran:1 skipped:0 deferred:0 failed:0/);
+    assert.doesNotMatch(combined, /GRACEFUL_FAIL/);
   } finally {
     cleanup();
   }

--- a/tests/seed-utils-empty-data-failure.test.mjs
+++ b/tests/seed-utils-empty-data-failure.test.mjs
@@ -8,7 +8,7 @@
 import { test, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { runSeed } from '../scripts/_seed-utils.mjs';
+import { GRACEFUL_FETCH_FAILURE_EXIT_CODE, runSeed } from '../scripts/_seed-utils.mjs';
 
 const ORIGINAL_FETCH = globalThis.fetch;
 const ORIGINAL_EXIT = process.exit;
@@ -64,10 +64,49 @@ function countMetaSets(resourceSuffix) {
 async function runWithExitTrap(fn) {
   try {
     await fn();
+    return null;
   } catch (err) {
     if (!String(err.message).startsWith('__test_exit__:')) throw err;
+    return err.exitCode;
   }
 }
+
+function expireKeys() {
+  return recordedCalls
+    .filter(c => Array.isArray(c.body) && Array.isArray(c.body[0]))
+    .flatMap(c => c.body)
+    .filter(cmd => Array.isArray(cmd) && cmd[0] === 'EXPIRE')
+    .map(cmd => cmd[1]);
+}
+
+test('fetch failure extends existing TTL and exits with graceful-failure code', async () => {
+  const exitCode = await runWithExitTrap(() =>
+    runSeed('test', 'fetch-fail', 'test:fetch-fail:v1', async () => {
+      const err = new Error('upstream unavailable');
+      err.nonRetryable = true;
+      throw err;
+    }, {
+      validateFn: (d) => Boolean(d),
+      ttlSeconds: 3600,
+      extraKeys: [{ key: 'test:fetch-fail:extra' }],
+    }),
+  );
+
+  assert.equal(
+    exitCode,
+    GRACEFUL_FETCH_FAILURE_EXIT_CODE,
+    'fetch failure should use the reserved graceful-failure exit code so bundle logs do not report OK',
+  );
+  assert.deepEqual(
+    new Set(expireKeys()),
+    new Set(['test:fetch-fail:v1', 'seed-meta:test:fetch-fail', 'test:fetch-fail:extra']),
+    'fetch failure should still preserve last-good data by extending canonical, seed-meta, and extra-key TTLs',
+  );
+  assert.equal(
+    countMetaSets('fetch-fail'), 0,
+    'fetch failure must not write fresh seed-meta while reporting graceful failure',
+  );
+});
 
 test('validation failure with emptyDataIsFailure:true does NOT refresh seed-meta', async () => {
   await runWithExitTrap(() =>


### PR DESCRIPTION
## Summary

- Reserve `GRACEFUL_FETCH_FAILURE_EXIT_CODE` (`75`) for seed fetch failures that preserved last-good cache TTLs.
- Map that exit code in `_bundle-runner.mjs` to `status=GRACEFUL_FAIL`, count it as failed, and keep ordinary exit `0` paths OK.
- Apply the same graceful-failure exit code to the bundled Air Quality manual seeder path.
- Document the Railway/operator blast radius: bundled members and standalone `runSeed` cron seeders now surface transient upstream outages as non-zero graceful failures while preserving last-good freshness.

Closes #3526.

## Intent

The issue goal is observability honesty: a seeder that fails to fetch but extends last-good TTLs should not appear as `status=OK records=` in bundle logs. The accepted operational tradeoff is that Railway cron runs can now show failures for transient upstream outages; the data path remains last-good via TTL preservation and `seed-meta:` freshness checks. Lock-skip, contract RETRY, quiet-period validation skip, and other intentional exit-zero paths remain OK. This does not parse child stdout or infer failure from missing `seed_complete`; the parent-child contract is the reserved exit code.

## Validation Matrix

| Check | Status | Evidence |
| --- | --- | --- |
| Bundle runner graceful failure and lock-skip behavior | PASS | `node --test tests/bundle-runner.test.mjs` |
| `runSeed` fetch failure TTL preservation and exit code | PASS | `node --test tests/seed-utils-empty-data-failure.test.mjs` |
| Strict-empty, SIGTERM cleanup, and Air Quality touched paths | PASS | `node --test tests/seed-utils-empty-data-failure.test.mjs tests/seed-empty-data-is-failure.test.mjs tests/seed-utils-sigterm-cleanup.test.mjs tests/air-quality-seed.test.mjs` |
| TypeScript source | PASS | `npm run typecheck` |
| API TypeScript/audit | PASS | `npm run typecheck:api` |
| Publish/pre-push hook | PASS | `git push -u origin HEAD` passed repo hook, including changed tests, boundary/safe-html/rate-limit/premium-fetch/edge bundle/version checks |
| Follow-up docs/pre-push hook | PASS | `git push` for `a6d9993b9` passed repo hook, including typecheck, API typecheck, changed tests, full markdown lint, and version sync |
| Runbook markdown lint | PASS | `./node_modules/.bin/markdownlint-cli2 docs/railway-seed-consolidation-runbook.md` |
| Diff hygiene | PASS | `git diff --check` |
| Manual graceful-path inventory | PASS | Air Quality is bundled and fixed; `seed-military-flights.mjs` and `seed-service-statuses.mjs` have manual graceful exits but are not referenced by `scripts/seed-bundle*.mjs` |

## Documentation

Updated `docs/railway-seed-consolidation-runbook.md` with the graceful fetch failure contract:

- `runSeed` graceful fetch failures now exit non-zero after TTL preservation for bundled members and standalone cron seeders.
- Alerting should tolerate transient cron-failure noise or key sustained pages off `/api/health` and seed-contract freshness checks.
- External log consumers matching `status=FAILED` should include `status=GRACEFUL_FAIL`.
- Bundle summaries still fold graceful and hard failures into `failed:N`, so per-section status is the distinguishing signal.

## Screenshots / UI Evidence

Not applicable. This is a backend/script observability fix with no rendered UI.

## Residual Findings

- Deferred standalone uniformity follow-up: `scripts/seed-military-flights.mjs` and `scripts/seed-service-statuses.mjs` still have manual graceful failure paths that exit `0`. They are not bundle members, so they are out of scope for issue #3526, but the runbook now records them as a follow-up if the standalone graceful-failure contract should become fully uniform.
