### PR TITLE
docs: fix dev server port in README (5173 → 3000)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ npm install
 npm run dev
 ```
 
-Open [localhost:5173](http://localhost:5173). The app runs with no environment variables.
+Open [localhost:3000](http://localhost:3000). The app runs with no environment variables.
 
 Feature-specific data sources may require credentials — for example, the flight-price command (`fly LON DXB`) needs `TRAVELPAYOUTS_API_TOKEN` to return live quotes; without it the command shows a "credentials required" message rather than synthetic data. See `.env.example` for the full list.
 


### PR DESCRIPTION
## Summary

- Corrects the Quick Start URL from `localhost:5173` (Vite default) to `localhost:3000` (the port configured in `vite.config.ts`)
- `CONTRIBUTING.md` already had the correct port — this brings the README in sync so new contributors aren't confused

## Test plan
- [ ] Run `npm run dev` and confirm the app opens at http://localhost:3000

🤖 Generated with [Claude Code](https://claude.com/claude-code)