### PR TITLE
docs: fix stale counts in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Agent entry point for WorldMonitor. Read this first, then follow links for depth
 
 ## What This Project Is
 
-Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 86 panel components, 60+ Vercel Edge API endpoints, a Tauri desktop app with Node.js sidecar, and a Railway relay service. Aggregates 30+ external data sources (geopolitics, military, finance, climate, cyber, maritime, aviation).
+Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 154 panel components, 80+ Vercel Edge API endpoints, a Tauri desktop app with Node.js sidecar, and a Railway relay service. Aggregates 65+ external data sources (geopolitics, military, finance, climate, cyber, maritime, aviation).
 
 ## Repository Map
 
@@ -14,7 +14,7 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 86 
 │   ├── app/                # App orchestration (data-loader, refresh-scheduler, panel-layout)
 │   ├── components/         # 86 UI panels + map components (Panel subclasses)
 │   ├── config/             # Variant configs, panel/layer definitions, market symbols
-│   ├── services/           # Business logic (120+ service files, organized by domain)
+│   ├── services/           # Business logic (184+ service files, organized by domain)
 │   ├── types/              # TypeScript type definitions
 │   ├── utils/              # Shared utilities (circuit-breaker, theme, URL state, DOM)
 │   ├── workers/            # Web Workers (analysis, ML/ONNX, vector DB)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 154
 .
 ├── src/                    # Browser SPA (TypeScript, class-based components)
 │   ├── app/                # App orchestration (data-loader, refresh-scheduler, panel-layout)
-│   ├── components/         # 86 UI panels + map components (Panel subclasses)
+│   ├── components/         # 154 UI panels + map components (Panel subclasses)
 │   ├── config/             # Variant configs, panel/layer definitions, market symbols
 │   ├── services/           # Business logic (184+ service files, organized by domain)
 │   ├── types/              # TypeScript type definitions


### PR DESCRIPTION
## Summary

Four numbers in `AGENTS.md` were out of date:

| Field | Was | Now | Source of truth |
|---|---|---|---|
| Panel components | 86 | 154 | `ls src/components/*.ts \| wc -l` |
| Vercel Edge API endpoints | 60+ | 80+ | `ls api/ \| grep -v '^_\|\.test\.\|\.d\.ts\|\.json' \| wc -l` |
| External data sources | 30+ | 65+ | matches README.md |
| Service files | 120+ | 184+ | `ls src/services/ \| wc -l` |

No code changes — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)