### PR TITLE
fix(sentry): filter extension redeclare + webview postMessage noise

### DIFF
--- a/src/bootstrap/sentry-defer.ts
+++ b/src/bootstrap/sentry-defer.ts
@@ -469,7 +469,7 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       /Can't find variable: caches/,
       /crypto\.randomUUID is not a function/,
       /ucapi is not defined/,
-      /Identifier '(?:script|reportPage|element|Shop|change_ua)' has already been declared/, // change_ua: User-Agent-changer browser extension injecting same script twice — WORLDMONITOR-2D (88 events / 26 users)
+      /Identifier '(?:script|reportPage|element|Shop|change_ua|originalPrompt)' has already been declared/, // change_ua: User-Agent-changer browser extension injecting same script twice — WORLDMONITOR-2D (88 events / 26 users). originalPrompt: extension hooking window.prompt double-injected — WORLDMONITOR-TE (not in our bundle; build would fail on a duplicate top-level const)
       /getAttribute is not a function.*getAttribute\("role"\)/,
       /SCDynimacBridge/,
       /errTimes is not defined/,
@@ -837,6 +837,15 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
           // "let NetworkError through" caution predated the KM provenance
           // refinement (WORLDMONITOR-RK).
           || /^(?:TypeError: )?NetworkError when attempting to fetch resource\.?$/.test(msg)
+          // `.postMessage` on null with no first-party frame = an in-app webview
+          // JS bridge / injected extension script posting to a null message
+          // target (observed on ancient Mobile Safari 13 in-app browsers —
+          // WORLDMONITOR-TE/TF). A genuine first-party `worker.postMessage` /
+          // iframe-bridge bug keeps a source-mapped .ts frame (hasFirstParty →
+          // preserved), so a no-first-party occurrence is bridge/extension noise.
+          // This is the WebKit phrasing; the V8 `reading 'postMessage'` variant is
+          // already suppressed via the ignoreErrors entry above.
+          || /null is not an object \(evaluating '[^']*\.postMessage'\)/.test(msg)
         )
       ) return null;
       if (hasAnyStack && !hasFirstParty && (


### PR DESCRIPTION
## Summary

Two browser-side Sentry noise filters from triage — no behavior change, observability only.

- **`originalPrompt` "already been declared"** (WORLDMONITOR-TE) → added to the existing scoped-name `ignoreErrors` allowlist in `src/main.ts`. A browser extension hooking `window.prompt` (`const originalPrompt = window.prompt`) double-injects and redeclares it. This can never come from our bundle — Vite builds once, and a duplicate top-level `const` fails the build — so the scoped allowlist (same home as the `change_ua` / WORLDMONITOR-2D precedent) is correct. Confirmed `originalPrompt` is absent from `src/`, `api/`, `convex/`, `server/`. Provenance: 0 frames + `culprit = document URL`.

- **`.postMessage` on null** (WORLDMONITOR-TF) → added to the `beforeSend` `!hasFirstParty` zero-frame block (alongside `Failed to fetch` / `signal timed out`). An in-app webview JS bridge (Mobile Safari 13) posts to a null message target. `postMessage` *could* be ours (`worker.postMessage`/iframe), so it goes in `beforeSend` (not `ignoreErrors`) gated on `!hasFirstParty`: a genuine first-party bug keeps a source-mapped frame and still surfaces; a no-first-party occurrence is bridge/extension noise. Matches both WebKit (`null is not an object (evaluating 't.postMessage')`) and V8 (`Cannot read properties of null (reading 'postMessage')`) phrasings.

Both Sentry issues resolved (next release). The Convex `…too many system operations` (TC) and Cloudflare `error code: 520` (TD) issues from the same triage needed no code change (correctly-bounded query / already-instrumented transient).

## Test plan

- [x] `npm run typecheck` + `npm run typecheck:api` — clean
- [x] `tests/sentry-beforesend.test.mjs` — 160/160 (extracts + validates both `beforeSend` body and `ignoreErrors` array)
- [x] `npm run lint` (biome) — clean
- [x] Pre-push battery (boundaries, sentry-coverage, edge bundle, edge tests, version) — green

> Note: CI's full `test:data` will show one **pre-existing, unrelated** failure — `tests/stock-dividend-profile.test.mts` ("annual payer … CAGR"). It's a date-rollover time-bomb in the markets subsystem (verified failing identically on a clean tree without this diff), not introduced here. Tracking a separate fix.