### PR TITLE
fix(market): classify annual dividend payers as Annual between payments

### DIFF
--- a/server/worldmonitor/market/v1/analyze-stock.ts
+++ b/server/worldmonitor/market/v1/analyze-stock.ts
@@ -339,6 +339,28 @@ export async function fetchDividendProfile(symbol: string, currentPrice: number)
         const byInterval = paymentsPerYearFromInterval(entries);
         paymentsPerYear = byInterval > 0 ? byInterval : recentDivs.length;
       }
+    } else {
+      // recentDivs.length === 0: no payment in the trailing 365 days. This is
+      // EITHER a suspended program OR a low-frequency payer (annual / semi-
+      // annual) observed BETWEEN scheduled payments — its last payment fell
+      // just outside the 365-day window and the next one is still pending.
+      // Distinguish the two by recency relative to the payer's OWN historical
+      // cadence: a last payment within ~1.5x its median interval is between
+      // payments, not suspended. Quarterly/monthly payers with a >365-day gap
+      // have skipped many payments, so they blow past 1.5x their (much
+      // shorter) interval and correctly stay '' (see the suspended-program
+      // test). Without this, annual payers collapse to '' for the weeks each
+      // year after their payment anniversary — the trailing-year window is
+      // empty even though the program is healthy.
+      const byInterval = paymentsPerYearFromInterval(entries);
+      if (byInterval > 0) {
+        const expectedGapDays = 365.25 / byInterval;
+        const daysSinceLast =
+          (now / 1000 - (entries[entries.length - 1]!.date ?? 0)) / (24 * 3600);
+        if (daysSinceLast <= expectedGapDays * 1.5) {
+          paymentsPerYear = byInterval;
+        }
+      }
     }
 
     const latestEntry = entries[entries.length - 1]!;

--- a/server/worldmonitor/market/v1/analyze-stock.ts
+++ b/server/worldmonitor/market/v1/analyze-stock.ts
@@ -299,12 +299,18 @@ export async function fetchDividendProfile(symbol: string, currentPrice: number)
     const now = Date.now();
     const oneYearAgo = now - 365.25 * 24 * 3600 * 1000;
     const recentDivs = entries.filter((d) => (d.date ?? 0) * 1000 >= oneYearAgo);
-    const trailingAnnual = recentDivs.reduce((sum, d) => sum + (d.amount ?? 0), 0);
-    const dividendYield = currentPrice > 0 ? (trailingAnnual / currentPrice) * 100 : 0;
-    // Suppress frequency entirely when there is no active dividend program:
-    // no payment in the trailing year means dividendYield/trailingAnnualRate
-    // are both 0, and emitting a 'Quarterly' badge derived from suspended
-    // history would contradict the accompanying zeros in the UI.
+    // `let`, not `const`: the recent=0 branch below backfills these from the
+    // INDICATED annual rate when it detects an active low-frequency payer that
+    // is merely between scheduled payments (last payment just outside the
+    // trailing-365-day window). Without that, an annual payer past its
+    // anniversary would read "Annual / $0 rate / 0% yield".
+    let trailingAnnual = recentDivs.reduce((sum, d) => sum + (d.amount ?? 0), 0);
+    let dividendYield = currentPrice > 0 ? (trailingAnnual / currentPrice) * 100 : 0;
+    // Suppress frequency entirely when the program is genuinely suspended: no
+    // payment in the trailing year AND the last payment too old to be a
+    // between-payments gap (see the recent=0 branch). Then dividendYield/
+    // trailingAnnualRate stay 0, and emitting a frequency badge derived from
+    // stale history would contradict the accompanying zeros in the UI.
     // Frequency reconciliation:
     //   recent=0          → program suspended, leave frequency empty
     //   recent >= 3       → trust interval (robust to calendar-boundary drift)
@@ -359,6 +365,21 @@ export async function fetchDividendProfile(symbol: string, currentPrice: number)
           (now / 1000 - (entries[entries.length - 1]!.date ?? 0)) / (24 * 3600);
         if (daysSinceLast <= expectedGapDays * 1.5) {
           paymentsPerYear = byInterval;
+          // The trailing-12-month window is empty for this between-payments
+          // payer, so trailingAnnual/dividendYield computed above are both 0.
+          // Backfill them with the INDICATED annual rate — the most recent
+          // regular payment(s) annualized — so the badge, rate, and yield are
+          // mutually coherent instead of "Annual / $0 / 0%". Genuinely
+          // suspended payers never reach here (paymentsPerYear stays 0), so
+          // their zeros are preserved.
+          const indicatedPayments = Math.max(1, Math.round(paymentsPerYear));
+          const indicatedAnnual = entries
+            .slice(-indicatedPayments)
+            .reduce((sum, e) => sum + (e.amount ?? 0), 0);
+          if (indicatedAnnual > 0) {
+            trailingAnnual = indicatedAnnual;
+            dividendYield = currentPrice > 0 ? (indicatedAnnual / currentPrice) * 100 : 0;
+          }
         }
       }
     }

--- a/tests/stock-dividend-profile.test.mts
+++ b/tests/stock-dividend-profile.test.mts
@@ -118,16 +118,25 @@ describe('fetchDividendProfile', () => {
     );
   });
 
-  it('produces a non-zero CAGR for an annual payer with several full calendar years', async () => {
-    // Annual payer = 1 distinct month per year. The pre-fix CAGR gate
-    // required 10 distinct months per year, so annual payers always
-    // collapsed to 0. Post-fix we only care about calendar position.
-    const currentYear = new Date().getFullYear();
+  it('classifies an annual payer between scheduled payments (last payment just past the 1-year mark)', async () => {
+    // Regression for the anniversary-boundary bug: an annual payer whose most
+    // recent payment fell just OUTSIDE the trailing-365-day window — i.e. the
+    // next annual payment is still a few weeks away — must read as 'Annual',
+    // not collapse to '' as if the program were suspended, and must still
+    // produce a positive CAGR across its full prior calendar years.
+    //
+    // Anchored to `now` (last payment 380 days ago) so the recent=0 path is
+    // exercised DETERMINISTICALLY on every run. The previous calendar-year
+    // anchoring made this assertion depend on where today's date sat relative
+    // to a fixed prior-June payment, so it began failing once the real date
+    // rolled >365 days past that synthetic payment.
+    const nowSec = Math.floor(Date.now() / 1000);
+    const DAY = 24 * 3600;
     const divs: Record<string, { amount: number; date: number }> = {};
-    for (let yearIndex = 0; yearIndex < 5; yearIndex++) {
-      const year = currentYear - 5 + yearIndex;
-      const amount = 2.0 + yearIndex * 0.25;
-      const ts = Math.floor(Date.UTC(year, 5, 15) / 1000);
+    for (let k = 0; k < 5; k++) {
+      // newest payment 380d ago (just past the 365d window), then yearly back
+      const ts = nowSec - (380 + k * 365) * DAY;
+      const amount = 2.0 + (4 - k) * 0.25; // newest highest -> positive CAGR
       divs[String(ts)] = { amount, date: ts };
     }
     globalThis.fetch = (async () => {

--- a/tests/stock-dividend-profile.test.mts
+++ b/tests/stock-dividend-profile.test.mts
@@ -148,6 +148,17 @@ describe('fetchDividendProfile', () => {
       profile.dividendCagr > 0,
       `annual payer should have non-zero CAGR; got ${profile.dividendCagr}`,
     );
+    // Coherence: an 'Annual' badge must not ship alongside a $0 rate / 0% yield.
+    // The trailing-12-month window is empty here, so rate/yield must be
+    // backfilled from the indicated annual rate (the most recent payment).
+    assert.ok(
+      profile.trailingAnnualDividendRate > 0,
+      `Annual badge must carry a non-zero rate; got ${profile.trailingAnnualDividendRate}`,
+    );
+    assert.ok(
+      profile.dividendYield > 0,
+      `Annual badge must carry a non-zero yield; got ${profile.dividendYield}`,
+    );
   });
 
   it('identifies monthly frequency', async () => {


### PR DESCRIPTION
## Summary

Fixes a real product bug **and** the CI-breaking date-rollover test flake it exposed.

**The bug** — `fetchDividendProfile` (`server/worldmonitor/market/v1/analyze-stock.ts`) derived dividend *frequency* only from payments inside the trailing **365 days** (`recentDivs`). An **annual** payer observed just past its payment anniversary — last payment 366+ days ago, next one still pending — has an empty trailing-year window, so `paymentsPerYear` stayed `0` and `inferDividendFrequency(0)` returned `''`. Result: a healthy annual-dividend stock reads as **"suspended" (no frequency)** for the weeks each year between the 365-day mark and its next payment.

**The fix** — add a `recentDivs.length === 0` fallback that classifies by the payer's **own historical median interval**, but only when the last payment is within **~1.5× that interval** (between payments, not skipped):
- Annual payer ~380 days out (1.5× ≈ 548d) → classified `Annual`. ✅
- Quarterly/monthly payer silent >365 days blows past 1.5× its much shorter interval → stays `''`. The suspended-program path is **unchanged** and still asserted by `emits empty frequency when the dividend program has been suspended`. ✅

**The flake** — `tests/stock-dividend-profile.test.mts`'s annual-payer case anchored its synthetic dividends to fixed prior-calendar-year dates (`currentYear - N`, June 15). Once the real clock rolled >365 days past that synthetic June payment, the trailing-year window emptied and the assertion flipped `'' !== 'Annual'`. Re-anchored to `now` (last payment 380d ago) so the `recent=0` path runs **deterministically on every date**, and renamed to reflect what it actually covers.

## Test plan

- [x] `tests/stock-dividend-profile.test.mts` — 17/17 (was 16/17; the previously-failing case now passes, suspended-program case still emits `''`)
- [x] `npm run typecheck` + `npm run typecheck:api` — clean
- [x] Pre-push battery (server handler tests, boundaries, sentry-coverage, edge bundle, version) — green

## Note / follow-up

The sibling **quarterly** CAGR test (`produces a non-zero CAGR for a quarterly payer with several full calendar years`) uses the same fixed-calendar-year anchoring and shares the latent flaw — it would flake mid-Oct→Dec each year (when its last synthetic Q4 payment ages past 365 days). It's not failing today and has a tight CAGR-band (`8–10%`) assertion tied to its exact construction, so I left it untouched here to keep this PR surgical; worth a follow-up to re-anchor it to `now` the same way.