### PR TITLE
docs: guard agent and contributor stats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Agent entry point for WorldMonitor. Read this first, then follow links for depth
 
 ## What This Project Is
 
-Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 86 panel components, 60+ Vercel Edge API endpoints, a Tauri desktop app with Node.js sidecar, and a Railway relay service. Aggregates 30+ external data sources (geopolitics, military, finance, climate, cyber, maritime, aviation).
+Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 154 top-level TypeScript component files, 80+ Vercel Edge API endpoint entries, a Tauri desktop app with Node.js sidecar, and a Railway relay service. Aggregates geopolitics, military, finance, climate, cyber, maritime, and aviation data across 35 freshness-tracked source groups.
 
 ## Repository Map
 
@@ -12,9 +12,9 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 86 
 .
 ├── src/                    # Browser SPA (TypeScript, class-based components)
 │   ├── app/                # App orchestration (data-loader, refresh-scheduler, panel-layout)
-│   ├── components/         # 86 UI panels + map components (Panel subclasses)
+│   ├── components/         # 154 top-level TypeScript component files
 │   ├── config/             # Variant configs, panel/layer definitions, market symbols
-│   ├── services/           # Business logic (120+ service files, organized by domain)
+│   ├── services/           # Business logic (184 service modules and domain directories)
 │   ├── types/              # TypeScript type definitions
 │   ├── utils/              # Shared utilities (circuit-breaker, theme, URL state, DOM)
 │   ├── workers/            # Web Workers (analysis, ML/ONNX, vector DB)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ World Monitor is a real-time OSINT dashboard built with **Vanilla TypeScript** (
 | **TypeScript** | All code — frontend, edge functions, and handlers |
 | **Vite** | Build tool and dev server |
 | **Sebuf** | Proto-first HTTP RPC framework for typed API contracts |
-| **Protobuf / Buf** | Service and message definitions across 22 domains |
+| **Protobuf / Buf** | Service and message definitions across 35 domains |
 | **MapLibre GL** | Base map rendering (tiles, globe mode, camera) |
 | **deck.gl** | WebGL overlay layers (scatterplot, geojson, arcs, heatmaps) |
 | **d3** | Charts, sparklines, and data visualization |
@@ -40,13 +40,16 @@ World Monitor is a real-time OSINT dashboard built with **Vanilla TypeScript** (
 
 ### Variant System
 
-The codebase produces three app variants from the same source, each targeting a different audience:
+The codebase produces 6 app variants from the same source, each targeting a different audience or use case:
 
 | Variant | Command | Focus |
 |---|---|---|
 | `full` | `npm run dev` | Geopolitics, military, conflicts, infrastructure |
 | `tech` | `npm run dev:tech` | Startups, AI/ML, cloud, cybersecurity |
 | `finance` | `npm run dev:finance` | Markets, trading, central banks, commodities |
+| `commodity` | `npm run dev:commodity` | Commodities, mining, energy markets |
+| `happy` | `npm run dev:happy` | Positive news and constructive signals |
+| `energy` | `npm run dev:energy` | Energy security, chokepoints, oil/gas |
 
 Variants share all code but differ in default panels, map layers, and RSS feeds. Variant configs live in `src/config/variants/`.
 
@@ -54,14 +57,14 @@ Variants share all code but differ in default panels, map layers, and RSS feeds.
 
 | Directory | Purpose |
 |---|---|
-| `src/components/` | UI components — Panel subclasses, map, modals (~50 panels) |
+| `src/components/` | UI components — 154 top-level TypeScript component files |
 | `src/services/` | Data fetching modules — sebuf client wrappers, AI, signal analysis |
 | `src/config/` | Static data and variant configs (feeds, geo, military, pipelines, ports) |
 | `src/generated/` | Auto-generated sebuf client + server stubs (**do not edit by hand**) |
 | `src/types/` | TypeScript type definitions |
-| `src/locales/` | i18n JSON files (14 languages) |
+| `src/locales/` | i18n JSON files (24 languages) |
 | `src/workers/` | Web Workers for analysis |
-| `server/` | Sebuf handler implementations for all 17 domain services |
+| `server/` | Sebuf handler implementations for all 34 server handler domains |
 | `api/` | Vercel Edge Functions (sebuf gateway + legacy endpoints) |
 | `proto/` | Protobuf service and message definitions |
 | `data/` | Static JSON datasets |
@@ -95,18 +98,24 @@ npm run dev
 # Start other variants
 npm run dev:tech
 npm run dev:finance
+npm run dev:commodity
+npm run dev:happy
+npm run dev:energy
 
 # Run type checking
 npm run typecheck
 
 # Run tests
 npm run test:data          # Data integrity tests
-npm run test:e2e           # Playwright end-to-end tests
+npm run test:e2e:full      # Playwright end-to-end tests (full variant)
 
 # Production build (per variant)
 npm run build              # full
 npm run build:tech
 npm run build:finance
+npm run build:commodity
+npm run build:happy
+npm run build:energy
 ```
 
 The dev server runs at `http://localhost:3000`. Run `make help` to see all available make targets.
@@ -123,7 +132,7 @@ See [API Dependencies](docs/DOCUMENTATION.md#api-dependencies) for the full list
 
 - **Bug fixes** — found something broken? Fix it!
 - **New data layers** — add new geospatial data sources to the map
-- **RSS feeds** — expand our 100+ feed collection with quality sources
+- **RSS feeds** — expand our 500+ feed collection with quality sources
 - **UI/UX improvements** — make the dashboard more intuitive
 - **Performance optimizations** — faster loading, better caching
 - **Documentation** — improve docs, add examples, fix typos

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ npm install
 npm run dev
 ```
 
-Open [localhost:5173](http://localhost:5173). The app runs with no environment variables.
+Open [localhost:3000](http://localhost:3000). The app runs with no environment variables.
 
 Feature-specific data sources may require credentials — for example, the flight-price command (`fly LON DXB`) needs `TRAVELPAYOUTS_API_TOKEN` to return live quotes; without it the command shows a "credentials required" message rather than synthetic data. See `.env.example` for the full list.
 

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -9,6 +9,10 @@
     "commodity": 18,
     "energy": 18
   },
+  "variantCount": 6,
+  "componentTopLevelTsFiles": 154,
+  "serviceTopLevelEntries": 184,
+  "apiEndpointEntries": 80,
   "protoFiles": 276,
   "protoServices": 34,
   "protoDomainFolders": 35,

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -24,6 +24,7 @@ const dirsIn = (p) =>
   readdirSync(join(ROOT, p), { withFileTypes: true }).filter((e) => e.isDirectory()).map((e) => e.name);
 const filesIn = (p) =>
   readdirSync(join(ROOT, p), { withFileTypes: true }).filter((e) => e.isFile()).map((e) => e.name);
+const entriesIn = (p) => readdirSync(join(ROOT, p), { withFileTypes: true }).map((e) => e.name);
 
 function walk(rel, out = []) {
   for (const e of readdirSync(join(ROOT, rel), { withFileTypes: true })) {
@@ -45,6 +46,14 @@ function computeStats() {
   for (const m of variantBlock.matchAll(/(\w+):\s*\[([^\]]*)\]/g)) {
     variantLayers[m[1]] = (m[2].match(/'[^']+'/g) || []).length;
   }
+  const variantCount = Object.keys(variantLayers).length;
+
+  // ---- Root app directories used by AGENTS.md and CONTRIBUTING.md ----
+  const componentTopLevelTsFiles = filesIn('src/components').filter((f) => f.endsWith('.ts')).length;
+  const serviceTopLevelEntries = entriesIn('src/services').length;
+  const apiEndpointEntries = entriesIn('api').filter(
+    (f) => !f.startsWith('_') && !/\.test\./.test(f) && !/\.d\.ts$/.test(f) && !/\.json$/.test(f),
+  ).length;
 
   // ---- Protos & services (proto/**) ----
   const protoFiles = walk('proto').filter((f) => f.endsWith('.proto'));
@@ -124,6 +133,10 @@ function computeStats() {
     _generated: 'scripts/docs-stats.mjs — do not edit by hand; run `npm run docs:stats`',
     layerDefinitions,
     variantLayers,
+    variantCount,
+    componentTopLevelTsFiles,
+    serviceTopLevelEntries,
+    apiEndpointEntries,
     protoFiles: protoFiles.length,
     protoServices,
     protoDomainFolders,
@@ -160,6 +173,19 @@ function claims(s) {
     { file: 'README.md', re: /(\d+)\+\s+curated news feeds/, value: s.feedDefinitions, min: true },
     { file: 'README.md', re: /(\d+)\s+stock exchanges/, value: s.stockExchangeCount },
     { file: 'docs/overview.mdx', re: /(\d+)\+\s+curated news feeds/, value: s.feedDefinitions, min: true },
+
+    // ---- Root contributor/agent docs ----
+    { file: 'AGENTS.md', re: /with (\d+)\s+top-level TypeScript component files/, value: s.componentTopLevelTsFiles },
+    { file: 'AGENTS.md', re: /(\d+)\+\s+Vercel Edge API endpoint entries/, value: s.apiEndpointEntries, min: true },
+    { file: 'AGENTS.md', re: /(\d+)\s+freshness-tracked source groups/, value: s.freshnessSources },
+    { file: 'AGENTS.md', re: /components\/\s+# (\d+)\s+top-level TypeScript component files/, value: s.componentTopLevelTsFiles },
+    { file: 'AGENTS.md', re: /services\/\s+# Business logic \((\d+)\s+service modules and domain directories\)/, value: s.serviceTopLevelEntries },
+    { file: 'CONTRIBUTING.md', re: /Service and message definitions across (\d+)\s+domains/, value: s.protoDomainFolders },
+    { file: 'CONTRIBUTING.md', re: /produces (\d+)\s+app variants/, value: s.variantCount },
+    { file: 'CONTRIBUTING.md', re: /UI components — (\d+)\s+top-level TypeScript component files/, value: s.componentTopLevelTsFiles },
+    { file: 'CONTRIBUTING.md', re: /i18n JSON files \((\d+)\s+languages\)/, value: s.locales },
+    { file: 'CONTRIBUTING.md', re: /Sebuf handler implementations for all (\d+)\s+server handler domains/, value: s.serverDomains },
+    { file: 'CONTRIBUTING.md', re: /expand our (\d+)\+\s+feed collection/, value: s.feedDefinitions, min: true },
 
     { file: 'docs/architecture.mdx', re: /(\d+)\s+service domains, and (?:\d+)\s+map layers/, value: s.protoServices },
     { file: 'docs/architecture.mdx', re: /(\d+)\s+map layers\./, value: s.layerDefinitions },


### PR DESCRIPTION
## Summary
- extend docs-stats with machine-counted AGENTS.md and CONTRIBUTING.md claims
- refresh AGENTS, CONTRIBUTING, and README counts/commands so this supersedes #4317 and #4315
- regenerate docs/generated/stats.json with the new root-doc metrics

## Checks
- npm run docs:check
- npm run lint:md
- git diff --check HEAD~1 HEAD
- pre-push hook: typecheck, API typecheck, boundary checks, safe HTML, rate-limit policies, premium-fetch parity, edge bundle check, markdown lint, version sync