### PR TITLE
fix(security): bump blog-site astro to 6.4.7 (GHSA-2pvr-wf23-7pc7 Host header SSRF)

### DIFF
--- a/blog-site/package-lock.json
+++ b/blog-site/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.1",
-        "astro": "^6.4.2",
+        "astro": "^6.4.7",
         "gray-matter": "^4.0.3",
         "satori": "^0.25.0",
         "sharp": "^0.34.5"
@@ -1697,9 +1697,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.2.tgz",
-      "integrity": "sha512-8H89CH2dKL5SCU99OCqdU9BGjmPkSJqaPurywj5XMo7eMFGUFD3vsNhdEKnEh4mK4LgGje3/QDTTSIIGst0G0Q==",
+      "version": "6.4.7",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.4.7.tgz",
+      "integrity": "sha512-5vsXx0H52u23Jpshs9tM81D03Tb3Oh2Vt2Zo0bpqjXN+njkAWjFyGjTfmWJLAcrCQd9Q+iWB1eqfhR1sZJEaUA==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler": "^4.0.0",
@@ -1716,7 +1716,7 @@
         "clsx": "^2.1.1",
         "common-ancestor-path": "^2.0.0",
         "cookie": "^1.1.1",
-        "devalue": "^5.6.3",
+        "devalue": "^5.8.1",
         "diff": "^8.0.3",
         "dset": "^3.1.4",
         "es-module-lexer": "^2.0.0",

--- a/blog-site/package.json
+++ b/blog-site/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.1",
-    "astro": "^6.4.2",
+    "astro": "^6.4.7",
     "gray-matter": "^4.0.3",
     "satori": "^0.25.0",
     "sharp": "^0.34.5"


### PR DESCRIPTION
## Summary
Bumps the `blog-site` workspace's `astro` dependency from **6.4.2 → 6.4.7** to clear **GHSA-2pvr-wf23-7pc7** — *Astro: Host header SSRF in prerendered error page fetch* (**HIGH**, vulnerable `< 6.4.6`, first patched **6.4.6**).

## Why this is repo-wide, not a single PR's fault
The `audit-lockfile` matrix in `.github/workflows/security-audit.yml` runs `audit-production-dependencies.mjs` against the **committed lockfile** and queries npm's **live advisory database** at run time. When this advisory was published, every subsequent audit run started failing on the `blog-site` leg — the daily `main` cron *and* every open PR (it surfaced first on #4323, which never touched `blog-site`). `astro` is only present in the `blog-site` workspace, so no other matrix leg is affected.

It's a genuine, exploitable HIGH (Host-header SSRF in the deployed Astro blog's prerendered error page), so this **patches rather than baselines** the advisory.

## Change
- `blog-site/package.json`: `astro` `^6.4.2` → `^6.4.7`
- `blog-site/package-lock.json`: regenerated (`npm install astro@^6.4.6 --package-lock-only`); astro `6.4.2 → 6.4.7`

Astro-only — no other dependencies churned.

## Validation
```
$ node .github/scripts/audit-production-dependencies.mjs \
    --workspace blog-site \
    --package-json blog-site/package.json \
    --lockfile blog-site/package-lock.json
Production audit OK for blog-site/package-lock.json: 0 high+ advisories are baselined or absent.   (exit 0)
```
Full local pre-push battery (typecheck, API/Convex typecheck, lint suite, edge bundle, edge-function tests, md/mdx lint, version sync) passed.

> Note: a plain `npm install --package-lock-only` does **not** lift astro within the existing `^6.4.x` range — the upgrade target must be explicit (`astro@^6.4.6`).