### PR TITLE
fix(sentry): filter mainWorldSdk extension-global ReferenceError noise

### DIFF
--- a/src/bootstrap/sentry-defer.ts
+++ b/src/bootstrap/sentry-defer.ts
@@ -459,6 +459,7 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       /nmhCrx is not defined/,
       /\bcrusoe is not defined\b/, // WORLDMONITOR-R3 — injected userscript reference, anonymous-frames-only stack
       /\bvc_request_action is not defined\b/, // WORLDMONITOR-RB — Samsung Internet / Tizen smart-view-cast global injection
+      /\bmainWorldSdk is not defined\b/, // WORLDMONITOR-TG — browser extension SDK injected into the page main world references its global before define; not in our bundle (Edge 148/Windows, anonymous-frames-only stack)
       /navigationPerformanceLoggerJavascriptInterface/,
       /jQuery is not defined/,
       /illegal UTF-16 sequence/,

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -918,3 +918,31 @@ describe('SyntaxError via deck.gl/maplibre init path (WORLDMONITOR-SP)', () => {
       'non-SyntaxError with a map frame must not be swept up by the SP gate');
   });
 });
+
+// ─── WORLDMONITOR-TG: mainWorldSdk extension-global ReferenceError ─────────
+//
+// A browser-extension SDK injected into the page's main world references its
+// `mainWorldSdk` global before defining it (Edge 148 / Windows, anonymous-
+// frames-only stack). `mainWorldSdk` is nowhere in our bundle, so the message
+// can never originate from our own code — it goes in ignoreErrors alongside the
+// other named extension/webview globals (crusoe, vc_request_action, nmhCrx).
+describe('ignoreErrors — mainWorldSdk extension global (WORLDMONITOR-TG)', () => {
+  const PROD_MSG = 'mainWorldSdk is not defined';
+  const pattern = ignoreErrors.find(p => p instanceof RegExp && /mainWorldSdk/.test(p.source));
+
+  it('defines a mainWorldSdk ignore pattern', () => {
+    assert.ok(pattern, 'a /mainWorldSdk/ ignoreErrors pattern must exist');
+  });
+
+  it('suppresses the production "mainWorldSdk is not defined" message', () => {
+    assert.ok(isIgnored(PROD_MSG), `ignoreErrors must drop: ${PROD_MSG}`);
+  });
+
+  it('is scoped so a longer first-party identifier still surfaces', () => {
+    // The literal " is not defined" suffix must follow `mainWorldSdk` directly,
+    // so a real "mainWorldSdkLoader is not defined" bug from our own code is not
+    // swallowed by this pattern.
+    assert.ok(!isIgnored('mainWorldSdkLoader is not defined'),
+      'pattern must not swallow a longer identifier with the same prefix');
+  });
+});


### PR DESCRIPTION
## Summary

- **WORLDMONITOR-TG** — `ReferenceError: mainWorldSdk is not defined` (Edge 148 / Windows, 1 event / 1 user, anonymous-frames-only stack). A browser extension injects an SDK into the page's **main world** and references its `mainWorldSdk` global before defining it. The global is absent from our bundle (`grep -rn mainWorldSdk src/ api/` → 0 hits), so it can never originate from our own code.
- Added `/\bmainWorldSdk is not defined\b/` to the `ignoreErrors` named-extension-global allowlist in `src/bootstrap/sentry-defer.ts` (alongside `crusoe` / `vc_request_action` / `nmhCrx`) — **not** `beforeSend`, since the message is unambiguously third-party.
- Added a focused test block (3 cases): pattern exists, drops the production message, and a longer-prefix first-party identifier (`mainWorldSdkLoader is not defined`) still surfaces.

## Test plan

- [x] `npm run typecheck` + `npm run typecheck:api` — PASS
- [x] `npm run lint` (Biome) + `npm run lint:md` — PASS
- [x] `npm run test:data` — 11423/11429 pass, 0 fail (includes the 3 new TG cases)
- [x] Edge bundle check (`esbuild` over `api/*.js`) + `tests/edge-functions.test.mjs` — PASS
- [x] `npm run version:check` — PASS
- [x] Issue resolved in Sentry (`inNextRelease`), auto-reopens if it recurs post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)