### PR TITLE
docs: add missing dev:energy variant and ACLED OAuth credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ npm run dev:tech       # tech.worldmonitor.app
 npm run dev:finance    # finance.worldmonitor.app
 npm run dev:commodity  # commodity.worldmonitor.app
 npm run dev:happy      # happy.worldmonitor.app
+npm run dev:energy     # energy.worldmonitor.app
 ```
 
 See the **[self-hosting guide](https://www.worldmonitor.app/docs/getting-started)** for deployment options (Vercel, Docker, static).

--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -66,7 +66,9 @@ services:
       EIA_API_KEY: ""             # https://www.eia.gov/opendata/ (free)
 
       # ⚔️ Conflict & Unrest
-      ACLED_ACCESS_TOKEN: ""      # https://acleddata.com (free for researchers)
+      ACLED_EMAIL: ""             # https://acleddata.com (free for researchers)
+      ACLED_PASSWORD: ""          # OAuth flow — tokens auto-refresh (preferred over ACLED_ACCESS_TOKEN)
+      ACLED_ACCESS_TOKEN: ""      # Alternative: static token (expires every 24h)
 
       # 🛰️ Earth Observation
       NASA_FIRMS_API_KEY: ""      # REQUIRED for seed-fire-detections.mjs — https://firms.modaps.eosdis.nasa.gov (free)


### PR DESCRIPTION
## Summary

Two small documentation gaps:

**1. `README.md` — missing `dev:energy` in Quick Start**

The variant-specific dev commands list had 4 of 5 non-default variants. `npm run dev:energy` was missing.

**2. `SELF_HOSTING.md` — ACLED section only showed the static token**

The docker-compose API keys example only listed `ACLED_ACCESS_TOKEN`, but `server/_shared/acled-auth.ts` documents that `ACLED_EMAIL` + `ACLED_PASSWORD` is the **preferred** method (OAuth with auto-refresh). The static token expires every 24 hours, which causes data gaps in self-hosted deployments. Added both options with a note about which is preferred.

No code changes — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)