### PR TITLE
docs: add missing TRAVELPAYOUTS_API_TOKEN to self-hosting guide

### DIFF
--- a/SELF_HOSTING.md
+++ b/SELF_HOSTING.md
@@ -73,7 +73,7 @@ services:
 
       # ✈️ Aviation
       AVIATIONSTACK_API: ""       # https://aviationstack.com (free tier)
-
+      TRAVELPAYOUTS_API_TOKEN: "" # https://travelpayouts.com (flight price search — optional)
       # 🚢 Maritime
       AISSTREAM_API_KEY: ""       # https://aisstream.io (free)
 


### PR DESCRIPTION
## Summary

`SELF_HOSTING.md`'s docker-compose API keys example was missing `TRAVELPAYOUTS_API_TOKEN`, which powers the `fly LON DXB` flight price command mentioned in `README.md`.

Without this key in their `docker-compose.override.yml`, self-hosters get a "credentials required" message when using the flight price feature and have no obvious path to fixing it from the self-hosting docs.

Added it under the Aviation section alongside `AVIATIONSTACK_API`.

## Source of truth
- `server/worldmonitor/aviation/v1/search-flight-prices.ts:48` reads `TRAVELPAYOUTS_API_TOKEN`
- `.env.example:118` documents the key
- `README.md:78` mentions the key by name

No code changes — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)