### PR TITLE
fix: add missing env vars to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,15 +32,19 @@ services:
       LLM_API_KEY: "${LLM_API_KEY:-}"
       LLM_MODEL: "${LLM_MODEL:-}"
       GROQ_API_KEY: "${GROQ_API_KEY:-}"
+      OPENROUTER_API_KEY: "${OPENROUTER_API_KEY:-}"
       # Data source API keys (optional — features degrade gracefully)
       AISSTREAM_API_KEY: "${AISSTREAM_API_KEY:-}"
       FINNHUB_API_KEY: "${FINNHUB_API_KEY:-}"
       EIA_API_KEY: "${EIA_API_KEY:-}"
       FRED_API_KEY: "${FRED_API_KEY:-}"
+      ACLED_EMAIL: "${ACLED_EMAIL:-}"
+      ACLED_PASSWORD: "${ACLED_PASSWORD:-}"
       ACLED_ACCESS_TOKEN: "${ACLED_ACCESS_TOKEN:-}"
       NASA_FIRMS_API_KEY: "${NASA_FIRMS_API_KEY:-}"
       CLOUDFLARE_API_TOKEN: "${CLOUDFLARE_API_TOKEN:-}"
       AVIATIONSTACK_API: "${AVIATIONSTACK_API:-}"
+      TRAVELPAYOUTS_API_TOKEN: "${TRAVELPAYOUTS_API_TOKEN:-}"
     # Docker secrets (recommended for API keys — keeps them out of docker inspect).
     # Create secrets/ dir with one file per key, then uncomment below.
     # See SELF_HOSTING.md or docker-compose.override.yml for details.


### PR DESCRIPTION
## Summary

`docker-compose.yml` was missing three env vars that are documented in `.env.example` and actively read by the server. Self-hosters who set these in their `.env` file would find them silently ignored — the container never receives them.

| Variable | Used by | Was missing |
|---|---|---|
| `OPENROUTER_API_KEY` | `server/_shared/llm.ts`, `server/worldmonitor/news/v1/summarize-article.ts` | Yes |
| `ACLED_EMAIL` | `server/_shared/acled-auth.ts` (preferred OAuth flow) | Yes |
| `ACLED_PASSWORD` | `server/_shared/acled-auth.ts` (preferred OAuth flow) | Yes |
| `TRAVELPAYOUTS_API_TOKEN` | `server/worldmonitor/aviation/v1/search-flight-prices.ts` | Yes |

`ACLED_EMAIL` + `ACLED_PASSWORD` is the preferred auth method (OAuth with auto-refresh) over the static `ACLED_ACCESS_TOKEN` which expires every 24h.

## Test plan
- [ ] Set `OPENROUTER_API_KEY` in `.env`, run `docker compose up -d`, confirm the AI summarization picks up the key

🤖 Generated with [Claude Code](https://claude.com/claude-code)