### PR TITLE
docs: fix stale domain count in SECURITY.md and sebuf version in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ npm run typecheck:api    # Typecheck API layer separately
 npm run test:data        # Run unit/integration tests
 npm run test:sidecar     # Run sidecar + API handler tests
 npm run test:e2e         # Run all Playwright E2E tests
-make generate            # Regenerate proto stubs + per-service & unified OpenAPI specs (requires buf + sebuf v0.11.0 plugins)
+make generate            # Regenerate proto stubs + per-service & unified OpenAPI specs (requires buf + sebuf v0.11.1 plugins)
 npm run worktree:bootstrap          # Fresh worktree: link local env files + npm ci with tmp cache
 npm run worktree:bootstrap:test-only # Fresh docs/test worktree: same, but npm ci --ignore-scripts
 npm run worktree:env                # Link ignored local env files only

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,7 +52,7 @@ World Monitor is a client-side intelligence dashboard that aggregates publicly a
 
 ### Edge Functions & Sebuf Handlers
 
-- All 35 domain APIs are served through Sebuf (a Proto-first RPC framework) via Vercel Edge Functions
+- All 34 domain APIs are served through Sebuf (a Proto-first RPC framework) via Vercel Edge Functions
 - Edge functions and handlers should validate/sanitize all input
 - CORS headers are configured per-function
 - Rate limiting and circuit breakers protect against abuse

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -52,7 +52,7 @@ World Monitor is a client-side intelligence dashboard that aggregates publicly a
 
 ### Edge Functions & Sebuf Handlers
 
-- All 17 domain APIs are served through Sebuf (a Proto-first RPC framework) via Vercel Edge Functions
+- All 35 domain APIs are served through Sebuf (a Proto-first RPC framework) via Vercel Edge Functions
 - Edge functions and handlers should validate/sanitize all input
 - CORS headers are configured per-function
 - Rate limiting and circuit breakers protect against abuse

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,19 +32,15 @@ services:
       LLM_API_KEY: "${LLM_API_KEY:-}"
       LLM_MODEL: "${LLM_MODEL:-}"
       GROQ_API_KEY: "${GROQ_API_KEY:-}"
-      OPENROUTER_API_KEY: "${OPENROUTER_API_KEY:-}"
       # Data source API keys (optional — features degrade gracefully)
       AISSTREAM_API_KEY: "${AISSTREAM_API_KEY:-}"
       FINNHUB_API_KEY: "${FINNHUB_API_KEY:-}"
       EIA_API_KEY: "${EIA_API_KEY:-}"
       FRED_API_KEY: "${FRED_API_KEY:-}"
-      ACLED_EMAIL: "${ACLED_EMAIL:-}"
-      ACLED_PASSWORD: "${ACLED_PASSWORD:-}"
       ACLED_ACCESS_TOKEN: "${ACLED_ACCESS_TOKEN:-}"
       NASA_FIRMS_API_KEY: "${NASA_FIRMS_API_KEY:-}"
       CLOUDFLARE_API_TOKEN: "${CLOUDFLARE_API_TOKEN:-}"
       AVIATIONSTACK_API: "${AVIATIONSTACK_API:-}"
-      TRAVELPAYOUTS_API_TOKEN: "${TRAVELPAYOUTS_API_TOKEN:-}"
     # Docker secrets (recommended for API keys — keeps them out of docker inspect).
     # Create secrets/ dir with one file per key, then uncomment below.
     # See SELF_HOSTING.md or docker-compose.override.yml for details.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,15 +32,19 @@ services:
       LLM_API_KEY: "${LLM_API_KEY:-}"
       LLM_MODEL: "${LLM_MODEL:-}"
       GROQ_API_KEY: "${GROQ_API_KEY:-}"
+      OPENROUTER_API_KEY: "${OPENROUTER_API_KEY:-}"
       # Data source API keys (optional — features degrade gracefully)
       AISSTREAM_API_KEY: "${AISSTREAM_API_KEY:-}"
       FINNHUB_API_KEY: "${FINNHUB_API_KEY:-}"
       EIA_API_KEY: "${EIA_API_KEY:-}"
       FRED_API_KEY: "${FRED_API_KEY:-}"
+      ACLED_EMAIL: "${ACLED_EMAIL:-}"
+      ACLED_PASSWORD: "${ACLED_PASSWORD:-}"
       ACLED_ACCESS_TOKEN: "${ACLED_ACCESS_TOKEN:-}"
       NASA_FIRMS_API_KEY: "${NASA_FIRMS_API_KEY:-}"
       CLOUDFLARE_API_TOKEN: "${CLOUDFLARE_API_TOKEN:-}"
       AVIATIONSTACK_API: "${AVIATIONSTACK_API:-}"
+      TRAVELPAYOUTS_API_TOKEN: "${TRAVELPAYOUTS_API_TOKEN:-}"
     # Docker secrets (recommended for API keys — keeps them out of docker inspect).
     # Create secrets/ dir with one file per key, then uncomment below.
     # See SELF_HOSTING.md or docker-compose.override.yml for details.

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -50,5 +50,6 @@
     "3": 30
   },
   "leaderNames": 16,
-  "populationPriorityCountries": 20
+  "populationPriorityCountries": 20,
+  "sebufVersion": "v0.11.1"
 }

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -26,6 +26,12 @@ const filesIn = (p) =>
   readdirSync(join(ROOT, p), { withFileTypes: true }).filter((e) => e.isFile()).map((e) => e.name);
 const entriesIn = (p) => readdirSync(join(ROOT, p), { withFileTypes: true }).map((e) => e.name);
 
+function makefileVar(text, name) {
+  const match = text.match(new RegExp(`^${name}\\s*:=\\s*(\\S+)`, 'm'));
+  if (!match) throw new Error(`docs-stats: could not find ${name} in Makefile`);
+  return match[1];
+}
+
 function walk(rel, out = []) {
   for (const e of readdirSync(join(ROOT, rel), { withFileTypes: true })) {
     const child = `${rel}/${e.name}`;
@@ -36,6 +42,8 @@ function walk(rel, out = []) {
 }
 
 function computeStats() {
+  const makefile = read('Makefile');
+
   // ---- Map layers (src/config/map-layer-definitions.ts) ----
   const mld = read('src/config/map-layer-definitions.ts');
   const registryBlock = mld.slice(mld.indexOf('LAYER_REGISTRY'), mld.indexOf('VARIANT_LAYER_ORDER'));
@@ -155,6 +163,7 @@ function computeStats() {
     telegramFullTierCounts,
     leaderNames,
     populationPriorityCountries,
+    sebufVersion: makefileVar(makefile, 'SEBUF_VERSION'),
   };
 }
 
@@ -180,11 +189,13 @@ function claims(s) {
     { file: 'AGENTS.md', re: /(\d+)\s+freshness-tracked source groups/, value: s.freshnessSources },
     { file: 'AGENTS.md', re: /components\/\s+# (\d+)\s+top-level TypeScript component files/, value: s.componentTopLevelTsFiles },
     { file: 'AGENTS.md', re: /services\/\s+# Business logic \((\d+)\s+service modules and domain directories\)/, value: s.serviceTopLevelEntries },
+    { file: 'AGENTS.md', re: /requires buf \+ sebuf (v\d+\.\d+\.\d+) plugins/, value: s.sebufVersion },
     { file: 'CONTRIBUTING.md', re: /Service and message definitions across (\d+)\s+domains/, value: s.protoDomainFolders },
     { file: 'CONTRIBUTING.md', re: /produces (\d+)\s+app variants/, value: s.variantCount },
     { file: 'CONTRIBUTING.md', re: /UI components — (\d+)\s+top-level TypeScript component files/, value: s.componentTopLevelTsFiles },
     { file: 'CONTRIBUTING.md', re: /i18n JSON files \((\d+)\s+languages\)/, value: s.locales },
     { file: 'CONTRIBUTING.md', re: /Sebuf handler implementations for all (\d+)\s+server handler domains/, value: s.serverDomains },
+    { file: 'CONTRIBUTING.md', re: /currently \*\*(v\d+\.\d+\.\d+)\*\*/, value: s.sebufVersion },
     { file: 'CONTRIBUTING.md', re: /expand our (\d+)\+\s+feed collection/, value: s.feedDefinitions, min: true },
 
     { file: 'docs/architecture.mdx', re: /(\d+)\s+service domains, and (?:\d+)\s+map layers/, value: s.protoServices },
@@ -225,6 +236,7 @@ function claims(s) {
     { file: 'docs/data-sources.mdx', re: /\*\*Tier 1\*\* \| (\d+)\s+\|/, value: s.telegramFullTierCounts['1'] },
     { file: 'docs/data-sources.mdx', re: /\*\*Tier 2\*\* \| (\d+)\s+\|/, value: s.telegramFullTierCounts['2'] },
     { file: 'docs/data-sources.mdx', re: /\*\*Tier 3\*\* \| (\d+)\s+\|/, value: s.telegramFullTierCounts['3'] },
+    { file: 'SECURITY.md', re: /All (\d+)\s+domain APIs are served through Sebuf/, value: s.serverDomains },
     { file: 'docs/algorithms.mdx', re: /local (\d+)-country priority population table/, value: s.populationPriorityCountries },
     { file: 'docs/algorithms.mdx', re: /and (\d+)\s+tracked world-leader names/, value: s.leaderNames },
 
@@ -281,8 +293,8 @@ function main() {
       failures.push(`${c.file}: claim pattern ${c.re} not found (expected ${c.value})`);
       continue;
     }
-    const found = Number(m[1]);
-    const ok = c.min ? found <= c.value : found === c.value;
+    const found = typeof c.value === 'number' ? Number(m[1]) : m[1];
+    const ok = c.min ? Number(found) <= c.value : found === c.value;
     if (!ok) {
       failures.push(
         `${c.file}: doc says ${found}, code says ${c.value}${c.min ? ' (floor)' : ''} — pattern ${c.re}`,

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -183,7 +183,7 @@ function claims(s) {
     { file: 'README.md', re: /(\d+)\s+stock exchanges/, value: s.stockExchangeCount },
     { file: 'docs/overview.mdx', re: /(\d+)\+\s+curated news feeds/, value: s.feedDefinitions, min: true },
 
-    // ---- Root contributor/agent docs ----
+    // ---- Root contributor/agent/security docs ----
     { file: 'AGENTS.md', re: /with (\d+)\s+top-level TypeScript component files/, value: s.componentTopLevelTsFiles },
     { file: 'AGENTS.md', re: /(\d+)\+\s+Vercel Edge API endpoint entries/, value: s.apiEndpointEntries, min: true },
     { file: 'AGENTS.md', re: /(\d+)\s+freshness-tracked source groups/, value: s.freshnessSources },
@@ -197,6 +197,7 @@ function claims(s) {
     { file: 'CONTRIBUTING.md', re: /Sebuf handler implementations for all (\d+)\s+server handler domains/, value: s.serverDomains },
     { file: 'CONTRIBUTING.md', re: /currently \*\*(v\d+\.\d+\.\d+)\*\*/, value: s.sebufVersion },
     { file: 'CONTRIBUTING.md', re: /expand our (\d+)\+\s+feed collection/, value: s.feedDefinitions, min: true },
+    { file: 'SECURITY.md', re: /All (\d+)\s+domain APIs are served through Sebuf/, value: s.serverDomains },
 
     { file: 'docs/architecture.mdx', re: /(\d+)\s+service domains, and (?:\d+)\s+map layers/, value: s.protoServices },
     { file: 'docs/architecture.mdx', re: /(\d+)\s+map layers\./, value: s.layerDefinitions },
@@ -236,7 +237,6 @@ function claims(s) {
     { file: 'docs/data-sources.mdx', re: /\*\*Tier 1\*\* \| (\d+)\s+\|/, value: s.telegramFullTierCounts['1'] },
     { file: 'docs/data-sources.mdx', re: /\*\*Tier 2\*\* \| (\d+)\s+\|/, value: s.telegramFullTierCounts['2'] },
     { file: 'docs/data-sources.mdx', re: /\*\*Tier 3\*\* \| (\d+)\s+\|/, value: s.telegramFullTierCounts['3'] },
-    { file: 'SECURITY.md', re: /All (\d+)\s+domain APIs are served through Sebuf/, value: s.serverDomains },
     { file: 'docs/algorithms.mdx', re: /local (\d+)-country priority population table/, value: s.populationPriorityCountries },
     { file: 'docs/algorithms.mdx', re: /and (\d+)\s+tracked world-leader names/, value: s.leaderNames },
 
@@ -293,8 +293,12 @@ function main() {
       failures.push(`${c.file}: claim pattern ${c.re} not found (expected ${c.value})`);
       continue;
     }
+    if (c.min && typeof c.value !== 'number') {
+      failures.push(`${c.file}: min claims must use numeric expected values — pattern ${c.re}`);
+      continue;
+    }
     const found = typeof c.value === 'number' ? Number(m[1]) : m[1];
-    const ok = c.min ? Number(found) <= c.value : found === c.value;
+    const ok = c.min ? found <= c.value : found === c.value;
     if (!ok) {
       failures.push(
         `${c.file}: doc says ${found}, code says ${c.value}${c.min ? ' (floor)' : ''} — pattern ${c.re}`,


### PR DESCRIPTION
## Summary

Fix stale contributor/security documentation claims and add docs-stats coverage so the same drift is caught by CI next time.

| File | Was | Now | Source of truth |
| --- | --- | --- | --- |
| `SECURITY.md:55` | "All 17 domain APIs" | "All 34 domain APIs" | `server/worldmonitor/*` handler directories via `scripts/docs-stats.mjs` |
| `AGENTS.md:61` | `sebuf v0.11.0 plugins` | `sebuf v0.11.1 plugins` | `SEBUF_VERSION := v0.11.1` in `Makefile` |
| `scripts/docs-stats.mjs` / `docs/generated/stats.json` | SECURITY domain count and sebuf version claims unchecked | both claims are registered in `docs:check` | `npm run docs:check` |

The unrelated `docker-compose.yml` environment-variable edits were removed so this PR stays scoped to documentation and docs-stat guardrails.

## Verification

- `npm run docs:stats`
- `npm run docs:check`
