### PR TITLE
fix: keep free global map accessible

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -128,6 +128,7 @@ import {
 import type { CorrelationPanel } from '@/components/CorrelationPanel';
 
 const CYBER_LAYER_ENABLED = import.meta.env.VITE_ENABLE_CYBER_LAYER === 'true';
+const FREE_MAP_PANEL_ACCESS_KEY = 'worldmonitor-free-map-panel-access-v1';
 
 export type { CountryBriefSignals } from '@/app/app-context';
 
@@ -1442,7 +1443,6 @@ export class App {
     // already short-circuited pro users.
     let panelSettings = loadFromStorage<Record<string, PanelConfig>>(STORAGE_KEYS.panels, {});
     let panelsChanged = false;
-    const FREE_MAP_PANEL_ACCESS_KEY = 'worldmonitor-free-map-panel-access-v1';
     if (!localStorage.getItem(FREE_MAP_PANEL_ACCESS_KEY)) {
       const restoredPanels = restoreFreeMapPanelAccess(panelSettings);
       if (panelSettings.map?.enabled !== restoredPanels.map?.enabled) {

--- a/src/App.ts
+++ b/src/App.ts
@@ -12,6 +12,7 @@ import {
   VARIANT_DEFAULTS,
   getEffectivePanelConfig,
   enforceFreePanelLimit,
+  restoreFreeMapPanelAccess,
   FREE_MAX_PANELS,
   FREE_MAX_SOURCES,
 } from '@/config';
@@ -1439,9 +1440,18 @@ export class App {
     // the dashboard-tab add/switch/load paths stay in lockstep (same cw-* and
     // count rules). isPro is false here — the isProUser() early-return above
     // already short-circuited pro users.
-    const panelSettings = loadFromStorage<Record<string, PanelConfig>>(STORAGE_KEYS.panels, {});
-    const clampedPanels = enforceFreePanelLimit(panelSettings, false);
+    let panelSettings = loadFromStorage<Record<string, PanelConfig>>(STORAGE_KEYS.panels, {});
     let panelsChanged = false;
+    const FREE_MAP_PANEL_ACCESS_KEY = 'worldmonitor-free-map-panel-access-v1';
+    if (!localStorage.getItem(FREE_MAP_PANEL_ACCESS_KEY)) {
+      const restoredPanels = restoreFreeMapPanelAccess(panelSettings);
+      if (panelSettings.map?.enabled !== restoredPanels.map?.enabled) {
+        panelSettings = restoredPanels;
+        panelsChanged = true;
+      }
+      localStorage.setItem(FREE_MAP_PANEL_ACCESS_KEY, 'done');
+    }
+    const clampedPanels = enforceFreePanelLimit(panelSettings, false);
     for (const key of Object.keys(panelSettings)) {
       if (panelSettings[key]?.enabled !== clampedPanels[key]?.enabled) {
         panelsChanged = true;
@@ -1450,6 +1460,7 @@ export class App {
     }
     if (panelsChanged) {
       saveToStorage(STORAGE_KEYS.panels, clampedPanels);
+      this.state.panelSettings = clampedPanels;
       console.log(`[App] Free tier: enforced ${FREE_MAX_PANELS}-panel limit (disabled over-cap / cw-* panels)`);
     }
 

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -3,7 +3,12 @@ import type { AirlineIntelPanel } from '@/components/AirlineIntelPanel';
 import type { CustomWidgetPanel } from '@/components/CustomWidgetPanel';
 import { openWidgetChatModal } from '@/components/WidgetChatModal';
 import { deleteWidget, getWidget, saveWidget, isProUser } from '@/services/widget-store';
-import { FREE_MAX_PANELS, FREE_MAX_SOURCES } from '@/config/panels';
+import {
+  FREE_MAX_PANELS,
+  FREE_MAX_SOURCES,
+  countFreePanelCapUsage,
+  isFreePanelCapCounted,
+} from '@/config/panels';
 import type { McpDataPanel } from '@/components/McpDataPanel';
 import { openMcpConnectModal } from '@/components/McpConnectModal';
 import { deleteMcpPanel, getMcpPanel, saveMcpPanel } from '@/services/mcp-store';
@@ -184,8 +189,8 @@ export class EventHandlerManager implements AppModule {
     const config = this.ctx.panelSettings[panelId];
     if (!config) return false;
     if (config.enabled) return true;
-    if (!isProUser()) {
-      const enabledCount = Object.entries(this.ctx.panelSettings).filter(([k, p]) => p.enabled && !k.startsWith('cw-')).length;
+    if (!isProUser() && isFreePanelCapCounted(panelId)) {
+      const enabledCount = countFreePanelCapUsage(this.ctx.panelSettings);
       if (enabledCount >= FREE_MAX_PANELS) {
         // Tell the user why nothing happened instead of failing silently.
         // (Undo-restore can't reach this branch — closing a panel frees a

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -1,6 +1,16 @@
 import '@/styles/settings-window.css';
 import { CANONICAL_FEEDS, INTEL_SOURCES, SOURCE_REGION_MAP } from '@/config/feeds';
-import { PANEL_CATEGORY_MAP, ALL_PANELS, VARIANT_DEFAULTS, getEffectivePanelConfig, getVariantPanelCategories, isPanelEntitled, FREE_MAX_PANELS } from '@/config/panels';
+import {
+  PANEL_CATEGORY_MAP,
+  ALL_PANELS,
+  VARIANT_DEFAULTS,
+  getEffectivePanelConfig,
+  getVariantPanelCategories,
+  isPanelEntitled,
+  FREE_MAX_PANELS,
+  countFreePanelCapUsage,
+  isFreePanelCapCounted,
+} from '@/config/panels';
 import { isProUser } from '@/services/widget-store';
 import { SITE_VARIANT } from '@/config/variant';
 import { t } from '@/services/i18n';
@@ -780,8 +790,8 @@ export class UnifiedSettings {
     // collapse to getEffectivePanelConfig's disabled synthetic fallback.
     const resolvedPanel = ALL_PANELS[key] ? getEffectivePanelConfig(key, SITE_VARIANT) : panel;
     if (!panel.enabled && !isPanelEntitled(key, resolvedPanel, isProUser())) return;
-    if (!panel.enabled && !isProUser()) {
-      const enabledCount = Object.entries(this.draftPanelSettings).filter(([k, p]) => p.enabled && !k.startsWith('cw-')).length;
+    if (!panel.enabled && !isProUser() && isFreePanelCapCounted(key)) {
+      const enabledCount = countFreePanelCapUsage(this.draftPanelSettings);
       if (enabledCount >= FREE_MAX_PANELS) {
         showToast(t('modals.settingsWindow.freePanelLimit', { max: String(FREE_MAX_PANELS) }));
         return;

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -51,6 +51,9 @@ export {
   isPanelInVariantDefaults,
   isPanelEntitled,
   enforceFreePanelLimit,
+  countFreePanelCapUsage,
+  isFreePanelCapCounted,
+  restoreFreeMapPanelAccess,
   FREE_MAX_PANELS,
   FREE_MAX_SOURCES,
 } from './panels';

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -1185,6 +1185,31 @@ export function isPanelInVariantDefaults(key: string): boolean {
 export const FREE_MAX_PANELS = 40;
 export const FREE_MAX_SOURCES = 80;
 
+export function isFreePanelCapCounted(key: string): boolean {
+  return key !== 'map' && !key.startsWith('cw-');
+}
+
+export function countFreePanelCapUsage(panelSettings: Record<string, PanelConfig>): number {
+  return Object.entries(panelSettings).filter(([key, panel]) =>
+    panel.enabled && isFreePanelCapCounted(key)
+  ).length;
+}
+
+export function restoreFreeMapPanelAccess(
+  panelSettings: Record<string, PanelConfig>,
+): Record<string, PanelConfig> {
+  const next: Record<string, PanelConfig> = {};
+  for (const [key, config] of Object.entries(panelSettings)) {
+    next[key] = { ...config };
+  }
+
+  if (next.map?.enabled === false && countFreePanelCapUsage(next) >= FREE_MAX_PANELS) {
+    next.map = { ...next.map, enabled: true };
+  }
+
+  return next;
+}
+
 /**
  * Returns true if the current user is entitled to enable/view this panel.
  * Mirrors the entitlement checks in panel-layout.ts (single source of truth).
@@ -1211,7 +1236,8 @@ export function isPanelEntitled(key: string, config: PanelConfig, isPro = false)
  * Returns a NEW map; the input is never mutated. Pro users get the same
  * panel eligibility, but still receive a copied map. For free users: cw-*
  * custom-widget panels are a pro
- * feature and are always disabled, then among the remaining enabled panels
+ * feature and are always disabled. The map is free baseline infrastructure
+ * and never consumes a capped panel slot. Among the remaining enabled panels
  * the lowest-priority ones past FREE_MAX_PANELS are disabled (priority asc,
  * key tiebreak — identical ordering to App.enforceFreeTierLimits).
  *
@@ -1237,7 +1263,7 @@ export function enforceFreePanelLimit(
   }
 
   const enabledKeys = Object.entries(next)
-    .filter(([k, v]) => v.enabled && !k.startsWith('cw-'))
+    .filter(([k, v]) => v.enabled && isFreePanelCapCounted(k))
     .sort(([ka, a], [kb, b]) => (a.priority ?? 99) - (b.priority ?? 99) || ka.localeCompare(kb))
     .map(([k]) => k);
 

--- a/src/config/panels.ts
+++ b/src/config/panels.ts
@@ -1203,7 +1203,7 @@ export function restoreFreeMapPanelAccess(
     next[key] = { ...config };
   }
 
-  if (next.map?.enabled === false && countFreePanelCapUsage(next) >= FREE_MAX_PANELS) {
+  if (next.map?.enabled === false && countFreePanelCapUsage(next) > FREE_MAX_PANELS) {
     next.map = { ...next.map, enabled: true };
   }
 

--- a/src/settings-window.ts
+++ b/src/settings-window.ts
@@ -3,7 +3,17 @@
  * Loaded when the app is opened with ?settings=1 (e.g. from the main window's Settings button).
  */
 import type { PanelConfig } from '@/types';
-import { DEFAULT_PANELS, STORAGE_KEYS, ALL_PANELS, VARIANT_DEFAULTS, getEffectivePanelConfig, isPanelEntitled, FREE_MAX_PANELS } from '@/config';
+import {
+  DEFAULT_PANELS,
+  STORAGE_KEYS,
+  ALL_PANELS,
+  VARIANT_DEFAULTS,
+  getEffectivePanelConfig,
+  isPanelEntitled,
+  FREE_MAX_PANELS,
+  countFreePanelCapUsage,
+  isFreePanelCapCounted,
+} from '@/config';
 import { isProUser } from '@/services/widget-store';
 import { SITE_VARIANT } from '@/config/variant';
 import { loadFromStorage, saveToStorage } from '@/utils';
@@ -80,8 +90,8 @@ export function initSettingsWindow(): void {
             // not collapse to getEffectivePanelConfig's disabled synthetic fallback.
             const resolvedConfig = ALL_PANELS[panelKey] ? getEffectivePanelConfig(panelKey, SITE_VARIANT) : config;
             if (!config.enabled && !isPanelEntitled(panelKey, resolvedConfig, isProUser())) return;
-            if (!config.enabled && !isProUser()) {
-              const enabledCount = Object.entries(panelSettings).filter(([k, p]) => p.enabled && !k.startsWith('cw-')).length;
+            if (!config.enabled && !isProUser() && isFreePanelCapCounted(panelKey)) {
+              const enabledCount = countFreePanelCapUsage(panelSettings);
               if (enabledCount >= FREE_MAX_PANELS) return;
             }
             config.enabled = !config.enabled;

--- a/tests/panel-variant-config.test.mts
+++ b/tests/panel-variant-config.test.mts
@@ -4,7 +4,14 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { getEffectivePanelConfig } from '../src/config/panels.ts';
+import {
+  FREE_MAX_PANELS,
+  VARIANT_DEFAULTS,
+  countFreePanelCapUsage,
+  enforceFreePanelLimit,
+  getEffectivePanelConfig,
+  restoreFreeMapPanelAccess,
+} from '../src/config/panels.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
@@ -61,6 +68,42 @@ describe('variant panel config resolution', () => {
     assert.equal(financeMap.name, 'Global Markets Map');
     assert.equal(financeMap.enabled, true);
     assert.equal(financeMap.priority, 1);
+  });
+
+  it('keeps the global map available when free-tier defaults are clamped', () => {
+    const fullDefaults = Object.fromEntries(
+      VARIANT_DEFAULTS.full.map((key) => [key, { ...getEffectivePanelConfig(key, 'full') }]),
+    );
+
+    const clamped = enforceFreePanelLimit(fullDefaults, false);
+
+    assert.equal(clamped.map?.enabled, true);
+    assert.equal(countFreePanelCapUsage(clamped), FREE_MAX_PANELS);
+  });
+
+  it('restores stale cap-filled free layouts where the old cap disabled the map', () => {
+    const fullDefaults = Object.fromEntries(
+      VARIANT_DEFAULTS.full.map((key) => [key, { ...getEffectivePanelConfig(key, 'full') }]),
+    );
+    const stale = enforceFreePanelLimit(fullDefaults, false);
+    stale.map = { ...stale.map!, enabled: false };
+
+    const restored = restoreFreeMapPanelAccess(stale);
+
+    assert.equal(stale.map.enabled, false);
+    assert.equal(restored.map?.enabled, true);
+    assert.equal(countFreePanelCapUsage(restored), FREE_MAX_PANELS);
+  });
+
+  it('does not force-enable a manually hidden map when the free layout is under cap', () => {
+    const underCap = {
+      map: { ...getEffectivePanelConfig('map', 'full'), enabled: false },
+      'live-news': getEffectivePanelConfig('live-news', 'full'),
+    };
+
+    const restored = restoreFreeMapPanelAccess(underCap);
+
+    assert.equal(restored.map?.enabled, false);
   });
 
   it('does not use the canonical registry directly for entitlement or pro badge metadata', () => {

--- a/tests/panel-variant-config.test.mts
+++ b/tests/panel-variant-config.test.mts
@@ -10,6 +10,7 @@ import {
   countFreePanelCapUsage,
   enforceFreePanelLimit,
   getEffectivePanelConfig,
+  isFreePanelCapCounted,
   restoreFreeMapPanelAccess,
 } from '../src/config/panels.ts';
 
@@ -81,18 +82,36 @@ describe('variant panel config resolution', () => {
     assert.equal(countFreePanelCapUsage(clamped), FREE_MAX_PANELS);
   });
 
-  it('restores stale cap-filled free layouts where the old cap disabled the map', () => {
+  it('restores stale over-cap free layouts where the cap disabled the map', () => {
     const fullDefaults = Object.fromEntries(
       VARIANT_DEFAULTS.full.map((key) => [key, { ...getEffectivePanelConfig(key, 'full') }]),
     );
     const stale = enforceFreePanelLimit(fullDefaults, false);
     stale.map = { ...stale.map!, enabled: false };
+    const disabledCapPanel = Object.entries(fullDefaults).find(([key, panel]) =>
+      isFreePanelCapCounted(key) && panel.enabled && !stale[key]?.enabled
+    );
+    assert.ok(disabledCapPanel, 'fixture should include a disabled over-cap panel');
+    stale[disabledCapPanel[0]] = { ...disabledCapPanel[1], enabled: true };
 
     const restored = restoreFreeMapPanelAccess(stale);
 
     assert.equal(stale.map.enabled, false);
     assert.equal(restored.map?.enabled, true);
-    assert.equal(countFreePanelCapUsage(restored), FREE_MAX_PANELS);
+    assert.equal(countFreePanelCapUsage(restored), FREE_MAX_PANELS + 1);
+  });
+
+  it('does not force-enable a manually hidden map when the free layout is exactly at cap', () => {
+    const fullDefaults = Object.fromEntries(
+      VARIANT_DEFAULTS.full.map((key) => [key, { ...getEffectivePanelConfig(key, 'full') }]),
+    );
+    const atCap = enforceFreePanelLimit(fullDefaults, false);
+    atCap.map = { ...atCap.map!, enabled: false };
+
+    const restored = restoreFreeMapPanelAccess(atCap);
+
+    assert.equal(countFreePanelCapUsage(atCap), FREE_MAX_PANELS);
+    assert.equal(restored.map?.enabled, false);
   });
 
   it('does not force-enable a manually hidden map when the free layout is under cap', () => {


### PR DESCRIPTION
## Summary
- Keep Global Situation available to logged-out/free users by excluding the map from the free panel cap.
- Centralize free panel cap counting so settings, standalone settings, and restore paths use the same rules.
- Add a one-time stale-layout restoration for anonymous/free browsers where the old cap had already disabled the map.

## Root cause
The free-tier cap counted the map like a regular panel. In full default layouts the cap could disable Global Situation, and previously saved anonymous layouts could stay stuck with the map off.

## Validation
- npm run typecheck
- npm run typecheck:api
- ./node_modules/.bin/tsx --test tests/panel-variant-config.test.mts
- Pre-push hook: boundary lint, safe HTML guard, rate-limit policy lint, premium-fetch parity, edge bundle check, changed tests, edge function tests, version check