### PR TITLE
fix(security): bump scripts undici to 7.28.0 (GHSA-vmh5-mc38-953g)

### DIFF
--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -17,7 +17,7 @@
         "sax": "^1.6.0",
         "telegram": "^2.22.2",
         "tsx": "^4.21.0",
-        "undici": "^7.0.0",
+        "undici": "^7.28.0",
         "web-push": "^3.6.7",
         "ws": "^8.21.0",
         "yaml": "^2.8.3"
@@ -3983,9 +3983,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -19,13 +19,14 @@
     "sax": "^1.6.0",
     "telegram": "^2.22.2",
     "tsx": "^4.21.0",
-    "undici": "^7.0.0",
+    "undici": "^7.28.0",
     "web-push": "^3.6.7",
     "ws": "^8.21.0",
     "yaml": "^2.8.3"
   },
   "overrides": {
     "esbuild": "0.28.1",
+    "undici": "$undici",
     "ws": "$ws"
   },
   "engines": {


### PR DESCRIPTION
## Summary

Clears the repo-wide **`audit-lockfile (scripts)` / `security-audit`** failure that started blocking every PR (and `main`) when **GHSA-vmh5-mc38-953g** was published.

- `undici < 7.28.0` is vulnerable to a **TLS certificate validation bypass** via a dropped `requestTls` in the SOCKS5 `ProxyAgent` (high severity). The advisory landed in the live npm advisory DB after main's last green audit, so `npm audit --omit=dev` now flags it on any fresh run — the gate audits the **lockfiles**, not the diff, so it fails regardless of PR content.
- `scripts/package.json` pins `undici: "^7.0.0"`, which had resolved to **7.24.5** (inside the vulnerable `>=7.23.0 <7.28.0` range).

## Change

- Bump the direct dep to **`undici: "^7.28.0"`** (first patched 7.x).
- Add **`"undici": "$undici"`** to `scripts` `overrides`, forcing any future transitive copy to the direct, patched version — mirrors the existing `"ws": "$ws"` pin (#4322).
- Lockfile regenerated with `npm install --package-lock-only`; **only undici's `version`/`integrity` changed** (4 lines).

## Test plan

- [x] `node .github/scripts/audit-production-dependencies.mjs --workspace scripts --package-json scripts/package.json --lockfile scripts/package-lock.json` → **"0 high+ advisories"**, exit 0
- [x] Lockfile diff is undici-only (`undici` 7.24.5 → 7.28.0); no other packages touched
- [x] Minor bump within the already-declared `^7` range — no API break for the relay scripts

Unblocks the `security-audit` gate for the whole PR queue.