### PR TITLE
fix(dashboard): collapse empty wide-map drop zone

### DIFF
--- a/e2e/dashboard-wide-layout.spec.ts
+++ b/e2e/dashboard-wide-layout.spec.ts
@@ -45,7 +45,7 @@ async function readWideLayoutMetrics(page: Page) {
 
 test.describe('dashboard wide display layout', () => {
   test('empty map drop zone does not consume the map column and stays collapsed after resize', async ({ page }) => {
-    test.setTimeout(150_000);
+    test.setTimeout(60_000);
 
     await setupDashboard(page, { width: 2537, height: 1270 });
     const initial = await readWideLayoutMetrics(page);
@@ -56,11 +56,10 @@ test.describe('dashboard wide display layout', () => {
     expect(initial.mapHeight).toBeGreaterThan(initial.sectionHeight * 0.85);
 
     await page.setViewportSize({ width: 1920, height: 1080 });
-    await expect.poll(() => readWideLayoutMetrics(page)).toMatchObject({
-      bottomChildren: 0,
-    });
+    await expect.poll(async () => (await readWideLayoutMetrics(page)).bottomHeight).toBeLessThanOrEqual(4);
     const resized = await readWideLayoutMetrics(page);
 
+    expect(resized.bottomChildren).toBe(0);
     expect(resized.scrollWidth).toBeLessThanOrEqual(resized.viewportWidth + 1);
     expect(resized.bottomHeight).toBeLessThanOrEqual(4);
     expect(resized.mapHeight).toBeGreaterThan(resized.sectionHeight * 0.85);

--- a/e2e/dashboard-wide-layout.spec.ts
+++ b/e2e/dashboard-wide-layout.spec.ts
@@ -1,5 +1,14 @@
 import { expect, test, type Page } from '@playwright/test';
 
+interface WideLayoutMetrics {
+  viewportWidth: number;
+  scrollWidth: number;
+  sectionHeight: number;
+  mapHeight: number;
+  bottomHeight: number;
+  bottomChildren: number;
+}
+
 async function installLocalOnlyNetwork(page: Page): Promise<void> {
   await page.route(/^https?:\/\/(?!(127\.0\.0\.1:4173|localhost:4173)(?:\/|$)).*/i, (route) => {
     return route.abort('blockedbyclient');
@@ -15,11 +24,11 @@ async function setupDashboard(page: Page, viewport: { width: number; height: num
   });
   await installLocalOnlyNetwork(page);
 
-  await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
   await page.waitForFunction(() => document.documentElement.dataset.wmEventHandlersReady === 'true');
 }
 
-async function readWideLayoutMetrics(page: Page) {
+async function readWideLayoutMetrics(page: Page): Promise<WideLayoutMetrics> {
   return page.evaluate(() => {
     const mapSection = document.getElementById('mapSection');
     const mapContainer = document.getElementById('mapContainer');
@@ -43,9 +52,39 @@ async function readWideLayoutMetrics(page: Page) {
   });
 }
 
+function hasDragActiveClass(page: Page): Promise<boolean> {
+  return page.evaluate(() => document.body.classList.contains('panel-drag-active'));
+}
+
+function emptyPlaceholderOpacity(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const grid = document.getElementById('mapBottomGrid');
+    if (!grid) return 0;
+    return parseFloat(getComputedStyle(grid, '::after').opacity || '0');
+  });
+}
+
+// Begins a panel drag past DRAG_THRESHOLD (8px) without releasing the mouse, so callers
+// can assert mid-drag state. The cursor stays in the top-of-grid region, well away from
+// the below-map drop zone, so a subsequent mouse.up() does not populate the bottom grid.
+async function beginPanelDragInUpperGrid(page: Page): Promise<void> {
+  const header = page.locator('#panelsGrid > .panel[data-panel]:not(.hidden) > .panel-header').first();
+  await expect(header).toBeVisible();
+  const box = await header.boundingBox();
+  expect(box, 'first panel header should have a rendered bounding box').not.toBeNull();
+  const startX = box!.x + Math.min(48, box!.width / 2);
+  const startY = box!.y + box!.height / 2;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  // Cross the 8px threshold, then settle a few pixels away — staying in the upper grid.
+  await page.mouse.move(startX + 12, startY + 12, { steps: 3 });
+  await page.mouse.move(startX + 16, startY + 16, { steps: 3 });
+}
+
 test.describe('dashboard wide display layout', () => {
   test('empty map drop zone does not consume the map column and stays collapsed after resize', async ({ page }) => {
-    test.setTimeout(60_000);
+    test.setTimeout(30_000);
 
     await setupDashboard(page, { width: 2537, height: 1270 });
     const initial = await readWideLayoutMetrics(page);
@@ -53,15 +92,72 @@ test.describe('dashboard wide display layout', () => {
     expect(initial.bottomChildren).toBe(0);
     expect(initial.scrollWidth).toBeLessThanOrEqual(initial.viewportWidth + 1);
     expect(initial.bottomHeight).toBeLessThanOrEqual(4);
+    expect(initial.sectionHeight).toBeGreaterThan(100);
     expect(initial.mapHeight).toBeGreaterThan(initial.sectionHeight * 0.85);
 
     await page.setViewportSize({ width: 1920, height: 1080 });
-    await expect.poll(async () => (await readWideLayoutMetrics(page)).bottomHeight).toBeLessThanOrEqual(4);
+    await expect
+      .poll(async () => (await readWideLayoutMetrics(page)).bottomHeight, { timeout: 2_000, intervals: [50, 100, 200] })
+      .toBeLessThanOrEqual(4);
     const resized = await readWideLayoutMetrics(page);
 
     expect(resized.bottomChildren).toBe(0);
     expect(resized.scrollWidth).toBeLessThanOrEqual(resized.viewportWidth + 1);
     expect(resized.bottomHeight).toBeLessThanOrEqual(4);
+    expect(resized.sectionHeight).toBeGreaterThan(100);
     expect(resized.mapHeight).toBeGreaterThan(resized.sectionHeight * 0.85);
+  });
+
+  test('empty drop zone re-expands during an active drag and collapses again after release', async ({ page }) => {
+    test.setTimeout(30_000);
+
+    await setupDashboard(page, { width: 2537, height: 1270 });
+
+    // Baseline: empty + collapsed.
+    await expect
+      .poll(async () => (await readWideLayoutMetrics(page)).bottomHeight, { timeout: 2_000, intervals: [50, 100, 200] })
+      .toBeLessThanOrEqual(4);
+    expect((await readWideLayoutMetrics(page)).bottomChildren).toBe(0);
+
+    await beginPanelDragInUpperGrid(page);
+
+    // panel-drag-active reveals the 120px drop target and its placeholder while still empty.
+    await expect.poll(() => hasDragActiveClass(page)).toBe(true);
+    await expect
+      .poll(async () => (await readWideLayoutMetrics(page)).bottomHeight, { timeout: 2_000, intervals: [50, 100, 200] })
+      .toBeGreaterThanOrEqual(100);
+    expect(await emptyPlaceholderOpacity(page)).toBeGreaterThan(0);
+    expect((await readWideLayoutMetrics(page)).bottomChildren).toBe(0);
+
+    // Release in the upper grid (no drop into the bottom zone) -> class clears, zone re-collapses.
+    await page.mouse.up();
+    await expect.poll(() => hasDragActiveClass(page)).toBe(false);
+    await expect
+      .poll(async () => (await readWideLayoutMetrics(page)).bottomHeight, { timeout: 2_000, intervals: [50, 100, 200] })
+      .toBeLessThanOrEqual(4);
+    expect((await readWideLayoutMetrics(page)).bottomChildren).toBe(0);
+  });
+
+  test('Escape during a drag clears panel-drag-active and re-collapses the empty drop zone', async ({ page }) => {
+    test.setTimeout(30_000);
+
+    await setupDashboard(page, { width: 2537, height: 1270 });
+
+    await beginPanelDragInUpperGrid(page);
+    await expect.poll(() => hasDragActiveClass(page)).toBe(true);
+    await expect
+      .poll(async () => (await readWideLayoutMetrics(page)).bottomHeight, { timeout: 2_000, intervals: [50, 100, 200] })
+      .toBeGreaterThanOrEqual(100);
+
+    await page.keyboard.press('Escape');
+
+    await expect.poll(() => hasDragActiveClass(page)).toBe(false);
+    await expect
+      .poll(async () => (await readWideLayoutMetrics(page)).bottomHeight, { timeout: 2_000, intervals: [50, 100, 200] })
+      .toBeLessThanOrEqual(4);
+    expect((await readWideLayoutMetrics(page)).bottomChildren).toBe(0);
+
+    // Release the still-held button; drag state was already torn down by Escape.
+    await page.mouse.up();
   });
 });

--- a/e2e/dashboard-wide-layout.spec.ts
+++ b/e2e/dashboard-wide-layout.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test, type Page } from '@playwright/test';
+
+async function installLocalOnlyNetwork(page: Page): Promise<void> {
+  await page.route(/^https?:\/\/(?!(127\.0\.0\.1:4173|localhost:4173)(?:\/|$)).*/i, (route) => {
+    return route.abort('blockedbyclient');
+  });
+}
+
+async function setupDashboard(page: Page, viewport: { width: number; height: number }): Promise<void> {
+  await page.setViewportSize(viewport);
+  await page.addInitScript(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    localStorage.setItem('worldmonitor-variant', 'full');
+  });
+  await installLocalOnlyNetwork(page);
+
+  await page.goto('/dashboard', { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(() => document.documentElement.dataset.wmEventHandlersReady === 'true');
+}
+
+async function readWideLayoutMetrics(page: Page) {
+  return page.evaluate(() => {
+    const mapSection = document.getElementById('mapSection');
+    const mapContainer = document.getElementById('mapContainer');
+    const bottomGrid = document.getElementById('mapBottomGrid');
+    if (!mapSection || !mapContainer || !bottomGrid) {
+      throw new Error('Dashboard map layout nodes were not rendered');
+    }
+
+    const mapRect = mapContainer.getBoundingClientRect();
+    const bottomRect = bottomGrid.getBoundingClientRect();
+    const sectionRect = mapSection.getBoundingClientRect();
+
+    return {
+      viewportWidth: window.innerWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+      sectionHeight: sectionRect.height,
+      mapHeight: mapRect.height,
+      bottomHeight: bottomRect.height,
+      bottomChildren: bottomGrid.children.length,
+    };
+  });
+}
+
+test.describe('dashboard wide display layout', () => {
+  test('empty map drop zone does not consume the map column and stays collapsed after resize', async ({ page }) => {
+    test.setTimeout(150_000);
+
+    await setupDashboard(page, { width: 2537, height: 1270 });
+    const initial = await readWideLayoutMetrics(page);
+
+    expect(initial.bottomChildren).toBe(0);
+    expect(initial.scrollWidth).toBeLessThanOrEqual(initial.viewportWidth + 1);
+    expect(initial.bottomHeight).toBeLessThanOrEqual(4);
+    expect(initial.mapHeight).toBeGreaterThan(initial.sectionHeight * 0.85);
+
+    await page.setViewportSize({ width: 1920, height: 1080 });
+    await expect.poll(() => readWideLayoutMetrics(page)).toMatchObject({
+      bottomChildren: 0,
+    });
+    const resized = await readWideLayoutMetrics(page);
+
+    expect(resized.scrollWidth).toBeLessThanOrEqual(resized.viewportWidth + 1);
+    expect(resized.bottomHeight).toBeLessThanOrEqual(4);
+    expect(resized.mapHeight).toBeGreaterThan(resized.sectionHeight * 0.85);
+  });
+});

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -2712,8 +2712,7 @@ export class PanelLayoutManager implements AppModule {
         const dropPos = findDropPosition(lastX, lastY);
         const moved = dropPos ? commitDrop(dropPos, lastX, lastY) : false;
         
-        // Clean up drag visualization
-        document.body.classList.remove('panel-drag-active');
+        // Clean up drag visualization (panel-drag-active is cleared unconditionally below)
         el.classList.remove('dragging-source');
         if (ghostEl) {
           ghostEl.style.opacity = '0';

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -2638,6 +2638,7 @@ export class PanelLayoutManager implements AppModule {
         dragStarted = true;
         
         // Initialize drag visualization
+        document.body.classList.add('panel-drag-active');
         el.classList.add('dragging-source');
         originalParent = el.parentElement as HTMLElement;
         originalIndex = Array.from(originalParent.children).indexOf(el);
@@ -2647,6 +2648,7 @@ export class PanelLayoutManager implements AppModule {
         onKeyDown = (e: KeyboardEvent) => {
           if (e.key === 'Escape') {
             // Cancel drag and restore original position
+            document.body.classList.remove('panel-drag-active');
             el.classList.remove('dragging-source');
             if (ghostEl) {
               ghostEl.style.opacity = '0';
@@ -2711,6 +2713,7 @@ export class PanelLayoutManager implements AppModule {
         const moved = dropPos ? commitDrop(dropPos, lastX, lastY) : false;
         
         // Clean up drag visualization
+        document.body.classList.remove('panel-drag-active');
         el.classList.remove('dragging-source');
         if (ghostEl) {
           ghostEl.style.opacity = '0';
@@ -2740,6 +2743,7 @@ export class PanelLayoutManager implements AppModule {
         }
       }
       dragStarted = false;
+      document.body.classList.remove('panel-drag-active');
       originalRect = null;
       if (onKeyDown) {
         document.removeEventListener('keydown', onKeyDown);
@@ -2767,6 +2771,7 @@ export class PanelLayoutManager implements AppModule {
       if (dropIndicator) dropIndicator.remove();
       isDragging = false;
       dragStarted = false;
+      document.body.classList.remove('panel-drag-active');
       originalRect = null;
       el.classList.remove('dragging-source');
     });

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -2215,7 +2215,7 @@
   flex: 0 0 0;
   min-height: 0;
   padding: 0;
-  border-top: 0;
+  border-top: none;
   overflow: hidden;
 }
 

--- a/src/styles/panels.css
+++ b/src/styles/panels.css
@@ -2211,6 +2211,22 @@
   z-index: 5;
 }
 
+.map-bottom-grid:empty {
+  flex: 0 0 0;
+  min-height: 0;
+  padding: 0;
+  border-top: 0;
+  overflow: hidden;
+}
+
+body.panel-drag-active .map-bottom-grid:empty {
+  flex: 0 0 120px;
+  min-height: 120px;
+  padding: 12px;
+  border-top: 1px solid var(--border);
+  overflow-y: auto;
+}
+
 /* Base state for placeholder */
 .map-bottom-grid::after {
   content: 'Drop panels here to move them below the map';
@@ -2233,6 +2249,14 @@
   opacity: 0.4;
   pointer-events: none;
   transition: opacity 0.2s;
+}
+
+.map-bottom-grid:empty::after {
+  opacity: 0;
+}
+
+body.panel-drag-active .map-bottom-grid:empty::after {
+  opacity: 0.4;
 }
 
 /* Hide placeholder if there are panels */


### PR DESCRIPTION
Fixes #4344

## Summary
- collapse the empty ultra-wide map bottom grid so it no longer consumes half the map column
- restore the below-map drop target only while a panel drag is active
- add a focused Playwright regression for the 2537x1270 dashboard layout and resize behavior

## Failure / Root Cause
At the reporter-size viewport, the empty "Drop panels here" area measured 520px tall because `.map-bottom-grid` kept `flex: 1` even when empty, splitting the wide map column with the actual map container.

## Validation
- Before fix: `npx playwright test e2e/dashboard-wide-layout.spec.ts` failed with `bottomHeight = 520px` where the regression expected the empty bottom grid to collapse
- After fix: `npx playwright test e2e/dashboard-wide-layout.spec.ts`
- `npm run typecheck`
- `git diff --check HEAD~1..HEAD`
- Pre-push hook passed: typecheck, API typecheck, Convex typecheck, CJS syntax, Unicode safety, architectural boundaries, safe HTML, rate-limit policy coverage, premium-fetch parity, edge function bundle/tests, version sync