### PR TITLE
fix(ci): stop deploy-gate overflowing ARG_MAX with check-run JSON

### DIFF
--- a/.github/workflows/deploy-gate.yml
+++ b/.github/workflows/deploy-gate.yml
@@ -25,8 +25,13 @@ jobs:
           required='["changes","docs-stats","unit","sidecar","convex-tests","variant-smoke-full","resilience-validation-smoke","digest-image","typecheck","biome","security-audit"]'
 
           # Poll check-runs for this SHA and find the latest result for each required job.
+          # Project to just the three fields the gate logic reads. A SHA can
+          # accumulate dozens of full check-run objects across re-runs; passing
+          # the un-projected JSON to python3 via the RUNS_JSON env var overflowed
+          # Linux's 128KB-per-arg/env limit (MAX_ARG_STRLEN) once it crossed
+          # ~131KB, failing the gate with "Argument list too long" (exit 126).
           runs=$(gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" \
-            --jq ".check_runs | map(select(.name as \$name | $required | index(\$name)))")
+            --jq ".check_runs | map(select(.name as \$name | $required | index(\$name)) | {name, conclusion, completed_at})")
 
           status=$(RUNS_JSON="$runs" REQUIRED_JOBS="$required" python3 -c "
           import json


### PR DESCRIPTION
## Summary

The **Deploy Gate** workflow started failing intermittently with:

```
/usr/bin/python3: Argument list too long
Error: Process completed with exit code 126.
```

**Cause:** the gate passes the filtered check-runs JSON to an inline `python3 -c` via the `RUNS_JSON` environment variable, keeping the **full** check-run objects. As a SHA accumulates re-runs the payload grows; at 44 check-runs it was **~133 KB**, crossing Linux's per-arg/env limit **`MAX_ARG_STRLEN = 131072` (128 KB)**. `execve` then rejects the command → exit 126 → the gate can't post its commit status → merges stay blocked. It's intermittent because early runs (fewer check-runs) stayed under 128 KB.

**Fix:** the gate logic only reads `name`, `conclusion`, and `completed_at`, so project the jq to `{name, conclusion, completed_at}`. Payload drops from ~133 KB to **~1.3 KB** — permanently clear of the limit (bounded by the existing `per_page=100` cap → ≤ ~9 KB worst case).

```diff
- --jq ".check_runs | map(select(.name as \$name | $required | index(\$name)))"
+ --jq ".check_runs | map(select(.name as \$name | $required | index(\$name)) | {name, conclusion, completed_at})"
```

## Test plan

- [x] Replayed the exact gate pipeline against the SHA that failed (`0e55ef813`): projected `RUNS_JSON` = **1256 bytes** (was 133,587)
- [x] Gate logic still yields the correct verdict — all 11 required gates `success`, `pending=`/`failed=` empty → status **success**
- [x] `deploy-gate.yml` parses as valid YAML
- [x] No behavior change beyond the payload size — same fields, same comparison, same output