### PR TITLE
fix(sentry): ignore Greasemonkey gm_menus userscript noise

### DIFF
--- a/src/bootstrap/sentry-defer.ts
+++ b/src/bootstrap/sentry-defer.ts
@@ -406,6 +406,7 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       /evaluating '[^']*\.luma/,
       /translateNotifyError/,
       /GM_getValue/,
+      /gm_menus/, // WORLDMONITOR-TJ — Greasemonkey/Violentmonkey internal (GUID-keyed window['<uuid>'].gm_menus userscript-menu registry); never in our bundle, sibling of GM_getValue
       /^InvalidStateError:|The object is in an invalid state/,
       /Could not establish connection\. Receiving end does not exist/,
       /webkitCurrentPlaybackTargetIsWireless/,


### PR DESCRIPTION
## Summary

- Adds `/gm_menus/` to the Sentry `ignoreErrors` list in `src/bootstrap/sentry-defer.ts`, alongside the existing `/GM_getValue/` Greasemonkey entry.
- Suppresses **WORLDMONITOR-TJ**: `TypeError: undefined is not an object (evaluating 'window['<uuid>']['gm_menus']')`.
- `gm_menus` is the menu registry a Greasemonkey/Violentmonkey userscript manager stores under a GUID-keyed `window` property. On iOS Safari it throws when the page loads before that property is defined. The SDK captures it as a first-party-looking crash (frame = the page URL `/dashboard`, `global code`), so a message-based `ignoreErrors` entry is the correct suppression — the token can never originate from our own bundle.

This is the code half of a Sentry triage pass. The other two unresolved issues were handled out-of-band: `WORLDMONITOR-TH` (`Request timeout: /api/setIsSelect`) is already gated in `beforeSend` (the event came from a stale 2.6.5 bundle), and `WORLDMONITOR-TC` (Convex platform "too many system operations" timeout, `sdk.name=convex`) was suppressed via a Sentry inbound `filters:error_messages` glob since code filters are inert for Convex-forwarded events.

## Test plan

- [x] `npm run typecheck` + `npm run typecheck:api`
- [x] `npm run lint` (Biome)
- [x] `npm run test:data` (11437 tests, 0 fail)
- [x] esbuild bundle check over `api/*.js` (19 files)
- [x] `node --test tests/edge-functions.test.mjs`
- [x] `npm run lint:md`, `npm run version:check`, CJS syntax check