### PR TITLE
fix(cf-waf): exempt /mcp from Bot Fight Mode and AI-bot blocking (#4348)

### DIFF
--- a/.github/workflows/deploy-cf-waf.yml
+++ b/.github/workflows/deploy-cf-waf.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: jq empty deploy/cloudflare/waf-mcp-bot-exempt.json && echo OK
       - env: {CLOUDFLARE_API_TOKEN: dry, CLOUDFLARE_ZONE_ID: dry, DRY_RUN: "1"}
-        run: bash deploy/cloudflare/apply-waf-rules.sh 2>&1 || true
+        run: bash deploy/cloudflare/apply-waf-rules.sh
   apply:
     needs: dry-run
     runs-on: ubuntu-latest
@@ -35,5 +35,7 @@ jobs:
       - run: |
           S=$(curl -s -o /tmp/b.txt -w "%{http_code}" -H "User-Agent: mcp-client/1.0" https://worldmonitor.app/mcp)
           echo "HTTP $S"; head -c 200 /tmp/b.txt
-          [[ "$S" == "403" ]] && grep -qi "cloudflare\|ray id" /tmp/b.txt && { echo FAIL; exit 1; }
-          echo "OK"
+          if [[ "$S" != "200" && "$S" != "401" && "$S" != "405" ]]; then
+            echo "FAIL: unexpected status $S — /mcp may still be blocked"; exit 1
+          fi
+          echo "OK — /mcp reachable (HTTP $S)"

--- a/.github/workflows/deploy-cf-waf.yml
+++ b/.github/workflows/deploy-cf-waf.yml
@@ -1,0 +1,39 @@
+name: Deploy Cloudflare WAF Rules
+on:
+  push:
+    branches: [main]
+    paths:
+      - deploy/cloudflare/**
+      - .github/workflows/deploy-cf-waf.yml
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  dry-run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: jq empty deploy/cloudflare/waf-mcp-bot-exempt.json && echo OK
+      - env: {CLOUDFLARE_API_TOKEN: dry, CLOUDFLARE_ZONE_ID: dry, DRY_RUN: "1"}
+        run: bash deploy/cloudflare/apply-waf-rules.sh 2>&1 || true
+  apply:
+    needs: dry-run
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - run: sudo apt-get install -y jq
+      - env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
+        run: bash deploy/cloudflare/apply-waf-rules.sh
+  verify:
+    needs: apply
+    runs-on: ubuntu-latest
+    steps:
+      - run: sleep 30
+      - run: |
+          S=$(curl -s -o /tmp/b.txt -w "%{http_code}" -H "User-Agent: mcp-client/1.0" https://worldmonitor.app/mcp)
+          echo "HTTP $S"; head -c 200 /tmp/b.txt
+          [[ "$S" == "403" ]] && grep -qi "cloudflare\|ray id" /tmp/b.txt && { echo FAIL; exit 1; }
+          echo "OK"

--- a/deploy/cloudflare/apply-waf-rules.sh
+++ b/deploy/cloudflare/apply-waf-rules.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Exempts /mcp from Cloudflare Bot Fight Mode. Fixes issue #4348.
+# Usage: CLOUDFLARE_API_TOKEN=<token> CLOUDFLARE_ZONE_ID=<zone_id> ./apply-waf-rules.sh
+set -euo pipefail
+: "${CLOUDFLARE_API_TOKEN:?required}"
+: "${CLOUDFLARE_ZONE_ID:?required}"
+DRY_RUN="${DRY_RUN:-0}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RULE_FILE="${SCRIPT_DIR}/waf-mcp-bot-exempt.json"
+PHASE="http_request_firewall_custom"
+CF_API="https://api.cloudflare.com/client/v4"
+DESC="Skip Bot Fight Mode for /mcp — allow MCP client connections (issue #4348)"
+log() { echo "[waf] $*" >&2; }
+die() { echo "[waf] ERROR: $*" >&2; exit 1; }
+command -v curl &>/dev/null || die "curl required"
+command -v jq   &>/dev/null || die "jq required"
+NEW_RULE="$(jq .rules[0] "$RULE_FILE")"
+RESP="$(curl -sf -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" -H "Content-Type: application/json" "${CF_API}/zones/${CLOUDFLARE_ZONE_ID}/rulesets/phases/${PHASE}/entrypoint" || echo "{}")"
+if echo "$RESP" | jq -e .success &>/dev/null; then
+  CURRENT="$(echo "$RESP" | jq ".result.rules // []")"
+else
+  CURRENT="[]"; log "No existing ruleset."
+fi
+FILTERED="$(echo "$CURRENT" | jq --arg d "$DESC" "[.[] | select(.description != \$d)]")"
+MERGED="$(jq -n --argjson n "$NEW_RULE" --argjson r "$FILTERED" "[\$n] + \$r")"
+PAYLOAD="$(jq -n --argjson rules "$MERGED" "{description:\"WAF rules worldmonitor.app\",rules:\$rules}")"
+[[ "$DRY_RUN" == "1" ]] && { echo "$PAYLOAD" | jq .; exit 0; }
+log "Applying..."
+APPLY="$(curl -sf -X PUT -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" -H "Content-Type: application/json" --data "$PAYLOAD" "${CF_API}/zones/${CLOUDFLARE_ZONE_ID}/rulesets/phases/${PHASE}/entrypoint")"
+echo "$APPLY" | jq -e .success &>/dev/null && log "? Done." || { echo "$APPLY" | jq . >&2; die "Failed."; }

--- a/deploy/cloudflare/apply-waf-rules.sh
+++ b/deploy/cloudflare/apply-waf-rules.sh
@@ -9,12 +9,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 RULE_FILE="${SCRIPT_DIR}/waf-mcp-bot-exempt.json"
 PHASE="http_request_firewall_custom"
 CF_API="https://api.cloudflare.com/client/v4"
-DESC="Skip Bot Fight Mode for /mcp — allow MCP client connections (issue #4348)"
 log() { echo "[waf] $*" >&2; }
 die() { echo "[waf] ERROR: $*" >&2; exit 1; }
 command -v curl &>/dev/null || die "curl required"
 command -v jq   &>/dev/null || die "jq required"
 NEW_RULE="$(jq .rules[0] "$RULE_FILE")"
+DESC="$(echo "$NEW_RULE" | jq -r .description)"
+log "Rule: $DESC"
 RESP="$(curl -sf -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" -H "Content-Type: application/json" "${CF_API}/zones/${CLOUDFLARE_ZONE_ID}/rulesets/phases/${PHASE}/entrypoint" || echo "{}")"
 if echo "$RESP" | jq -e .success &>/dev/null; then
   CURRENT="$(echo "$RESP" | jq ".result.rules // []")"
@@ -27,4 +28,4 @@ PAYLOAD="$(jq -n --argjson rules "$MERGED" "{description:\"WAF rules worldmonito
 [[ "$DRY_RUN" == "1" ]] && { echo "$PAYLOAD" | jq .; exit 0; }
 log "Applying..."
 APPLY="$(curl -sf -X PUT -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" -H "Content-Type: application/json" --data "$PAYLOAD" "${CF_API}/zones/${CLOUDFLARE_ZONE_ID}/rulesets/phases/${PHASE}/entrypoint")"
-echo "$APPLY" | jq -e .success &>/dev/null && log "? Done." || { echo "$APPLY" | jq . >&2; die "Failed."; }
+echo "$APPLY" | jq -e .success &>/dev/null && log "Done." || { echo "$APPLY" | jq . >&2; die "Failed."; }

--- a/deploy/cloudflare/waf-mcp-bot-exempt.json
+++ b/deploy/cloudflare/waf-mcp-bot-exempt.json
@@ -7,8 +7,7 @@
       "expression": "(http.request.uri.path eq \"/mcp\" or starts_with(http.request.uri.path, \"/mcp/\"))",
       "action": "skip",
       "action_parameters": {
-        "products": ["botFight", "bic"],
-        "ruleset": "current"
+        "products": ["botFight", "bic"]
       },
       "enabled": true
     }

--- a/deploy/cloudflare/waf-mcp-bot-exempt.json
+++ b/deploy/cloudflare/waf-mcp-bot-exempt.json
@@ -1,0 +1,16 @@
+{
+  "_comment": "Cloudflare WAF Custom Rule — exempt /mcp from Bot Fight Mode.",
+  "_issue": "https://github.com/koala73/worldmonitor/issues/4348",
+  "rules": [
+    {
+      "description": "Skip Bot Fight Mode for /mcp — allow MCP client connections (issue #4348)",
+      "expression": "(http.request.uri.path eq \"/mcp\" or starts_with(http.request.uri.path, \"/mcp/\"))",
+      "action": "skip",
+      "action_parameters": {
+        "products": ["botFight", "bic"],
+        "ruleset": "current"
+      },
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
Closes #4348

## Summary
Cloudflare's "Block AI training bots" toggle and Bot Fight Mode classify
MCP clients (Claude Desktop, Cursor, MCP Inspector) as bots their
User-Agents don't match browser fingerprints. Requests to /mcp receive
a 403 or JS Challenge instead of the MCP protocol response, breaking
the handshake entirely.

Bot Fight Mode fires at the network layer before Workers and Vercel.
No handler-side fix exists. A WAF Custom Rule with action=skip scoped
to /mcp is the only remedy.

## Type of change
- [x] CI / Build / Infrastructure

## Affected areas
- [x] API endpoints (`/api/*`)

## Checklist
- [x] No API keys or secrets committed

## Documentation Alignment Checklist
N/A