### PR TITLE
feat(tooltips): add collapsible Historical Profile section for nuclear/conflict markers

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -4971,6 +4971,9 @@ export class DeckGLMap {
       const icao24 = (data as { icao24?: string }).icao24;
       if (icao24) this.popup.loadWingbitsLiveFlight(icao24);
     }
+    if (popupType === 'conflict') {
+      this.popup.loadConflictHistory(data as import('@/types').ConflictZone);
+    }
   }
 
   private async showWebcamClickPopup(webcam: WebcamEntry, x: number, y: number): Promise<void> {
@@ -6910,6 +6913,7 @@ export class DeckGLMap {
       const screenPos = this.projectToScreen(conflict.center[1], conflict.center[0]);
       const { x, y } = screenPos || this.getContainerCenter();
       this.popup.show({ type: 'conflict', data: conflict, x, y });
+      this.popup.loadConflictHistory(conflict);
     }
   }
 

--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -227,6 +227,7 @@ interface ConflictZoneMarker extends BaseMarker {
   parties: string[];
   casualties?: string;
   center: [number, number];
+  startDate?: string;
   peaceAgreements?: string[];
   totalFatalities?: string;
 }
@@ -1626,28 +1627,19 @@ export class GlobeMap {
         details.addEventListener('toggle', async () => {
           if (!details.open || loaded) return;
           loaded = true;
-          if (this.tooltipHideTimer) {
-            clearTimeout(this.tooltipHideTimer);
-            this.tooltipHideTimer = null;
-          }
+          // Auto-dismiss stays governed by hover: mouseenter already clears the
+          // hide timer while the cursor is over the tooltip, so don't permanently
+          // cancel it here — doing so left the tooltip stuck open forever.
           try {
-            const { fetchUcdpEvents } = await import('@/services/conflict');
+            const { fetchUcdpEvents, deriveConflictHistory } = await import('@/services/conflict');
             const resp = await fetchUcdpEvents();
             if (!el.isConnected || !content.isConnected) return;
-            const [cLon, cLat] = d.center;
-            const nearby = resp.data.filter(e => {
-              const dLat = e.latitude - cLat;
-              const dLon = e.longitude - cLon;
-              return Math.sqrt(dLat * dLat + dLon * dLon) < 3;
-            });
-            const totalDeaths = nearby.reduce((s, e) => s + (e.deaths_best ?? 0), 0);
-            const earliest = nearby.map(e => e.date_start).filter(Boolean).sort()[0];
-            const conflictSince = earliest ? earliest.substring(0, 4) : null;
+            const { conflictSince, recordedFatalities } = deriveConflictHistory(d, resp.data);
             const rows = [
               conflictSince ? `<div style="display:flex;justify-content:space-between;gap:8px;font-size:10px;margin:2px 0;"><span style="opacity:.5;">CONFLICT SINCE</span><span>${esc(conflictSince)}</span></div>` : '',
               d.peaceAgreements?.length ? `<div style="font-size:10px;margin:2px 0;"><span style="opacity:.5;display:block;margin-bottom:1px;">PEACE AGREEMENTS</span>${d.peaceAgreements.map(a => `<div style="opacity:.7;">· ${esc(a)}</div>`).join('')}</div>` : '',
-              totalDeaths > 0
-                ? `<div style="display:flex;justify-content:space-between;gap:8px;font-size:10px;margin:2px 0;"><span style="opacity:.5;">RECORDED FATALITIES</span><span>~${totalDeaths.toLocaleString()}</span></div>`
+              recordedFatalities > 0
+                ? `<div style="display:flex;justify-content:space-between;gap:8px;font-size:10px;margin:2px 0;"><span style="opacity:.5;">RECORDED FATALITIES</span><span>~${recordedFatalities.toLocaleString()}</span></div>`
                 : d.totalFatalities ? `<div style="display:flex;justify-content:space-between;gap:8px;font-size:10px;margin:2px 0;"><span style="opacity:.5;">TOTAL FATALITIES</span><span>${esc(d.totalFatalities)}</span></div>` : '',
             ].filter(Boolean).join('');
             setTrustedHtml(content, trustedHtml(rows || '<span style="opacity:.5;font-size:10px;">No UCDP data found.</span>', 'legacy direct innerHTML migration'));
@@ -2284,6 +2276,7 @@ export class GlobeMap {
       parties: z.parties ?? [],
       casualties: z.casualties,
       center: z.center,
+      startDate: z.startDate,
       peaceAgreements: z.peaceAgreements,
       totalFatalities: z.totalFatalities,
     }));

--- a/src/components/GlobeMap.ts
+++ b/src/components/GlobeMap.ts
@@ -226,6 +226,9 @@ interface ConflictZoneMarker extends BaseMarker {
   intensity: string;
   parties: string[];
   casualties?: string;
+  center: [number, number];
+  peaceAgreements?: string[];
+  totalFatalities?: string;
 }
 interface MilBaseMarker extends BaseMarker {
   _kind: 'milbase';
@@ -240,6 +243,10 @@ interface NuclearSiteMarker extends BaseMarker {
   name: string;
   type: string;
   status: string;
+  operationalSince?: string;
+  treaties?: string[];
+  iaeaStatus?: string;
+  keyEvents?: string[];
 }
 interface IrradiatorSiteMarker extends BaseMarker {
   _kind: 'irradiator';
@@ -1485,7 +1492,9 @@ export class GlobeMap {
       const ic = d.intensity === 'high' ? '#ff3030' : d.intensity === 'medium' ? '#ff8800' : '#ffcc00';
       html = `<span style="color:${ic};font-weight:bold;">⚔ ${esc(d.name)}</span>` +
              (d.parties.length ? `<br><span style="opacity:.7;">${d.parties.map(esc).join(', ')}</span>` : '') +
-             (d.casualties ? `<br><span style="opacity:.5;">Casualties: ${esc(d.casualties)}</span>` : '');
+             (d.casualties ? `<br><span style="opacity:.5;">Casualties: ${esc(d.casualties)}</span>` : '') +
+             `<details class="conflict-history-details" style="margin-top:6px;"><summary style="cursor:pointer;font-size:9px;opacity:.6;list-style:none;user-select:none;padding:2px 0;">📜 HISTORICAL PROFILE</summary>` +
+             `<div class="conflict-history-content" style="margin-top:4px;"><span style="opacity:.5;font-size:10px;">Loading…</span></div></details>`;
     } else if (d._kind === 'milbase') {
       html = `<span style="color:#4488ff;font-weight:bold;">🏛 ${esc(d.name)}</span>` +
              `<br><span style="opacity:.7;">${esc(d.type)}${d.country ? ' · ' + esc(d.country) : ''}</span>`;
@@ -1493,6 +1502,15 @@ export class GlobeMap {
       const nc = d.status === 'active' ? '#ffd700' : d.status === 'construction' ? '#ff8800' : '#888888';
       html = `<span style="color:${nc};font-weight:bold;">☢ ${esc(d.name)}</span>` +
              `<br><span style="opacity:.7;">${esc(d.type)} · ${esc(d.status)}</span>`;
+      if (d.operationalSince || d.treaties?.length || d.iaeaStatus || d.keyEvents?.length) {
+        html += `<details style="margin-top:6px;"><summary style="cursor:pointer;font-size:9px;opacity:.6;list-style:none;user-select:none;padding:2px 0;">📜 HISTORICAL PROFILE</summary>` +
+          `<div style="margin-top:4px;">` +
+          (d.operationalSince ? `<div style="display:flex;justify-content:space-between;gap:8px;font-size:10px;margin:2px 0;"><span style="opacity:.5;">OPERATIONAL SINCE</span><span>${esc(d.operationalSince)}</span></div>` : '') +
+          (d.treaties?.length ? `<div style="display:flex;justify-content:space-between;gap:8px;font-size:10px;margin:2px 0;"><span style="opacity:.5;">TREATIES</span><span>${d.treaties.map(esc).join(', ')}</span></div>` : '') +
+          (d.iaeaStatus ? `<div style="display:flex;justify-content:space-between;gap:8px;font-size:10px;margin:2px 0;"><span style="opacity:.5;">IAEA STATUS</span><span>${esc(d.iaeaStatus)}</span></div>` : '') +
+          (d.keyEvents?.length ? `<div style="font-size:10px;margin:4px 0 2px;"><span style="opacity:.5;display:block;margin-bottom:2px;">KEY EVENTS</span>${d.keyEvents.map(e => `<div style="opacity:.7;">· ${esc(e)}</div>`).join('')}</div>` : '') +
+          `</div></details>`;
+      }
     } else if (d._kind === 'irradiator') {
       html = `<span style="color:#ff8800;font-weight:bold;">⚠ Gamma Irradiator</span>` +
              `<br><span style="opacity:.7;">${esc(d.city)}, ${esc(d.country)}</span>`;
@@ -1596,9 +1614,51 @@ export class GlobeMap {
       html = '';
     }
     setTrustedHtml(el, trustedHtml(`<div style="padding-right:16px;position:relative;">${closeBtn}${html}</div>`, "legacy direct innerHTML migration"));
-    const wideKinds = new Set(['satellite', 'flightDelay', 'conflictZone', 'cableAdvisory']);
+    const wideKinds = new Set(['satellite', 'flightDelay', 'conflictZone', 'cableAdvisory', 'nuclearSite']);
     if (wideKinds.has(d._kind)) el.style.maxWidth = '300px';
     el.querySelector('button')?.addEventListener('click', () => this.hideTooltip());
+
+    if (d._kind === 'conflictZone') {
+      const details = el.querySelector<HTMLDetailsElement>('.conflict-history-details');
+      const content = el.querySelector('.conflict-history-content');
+      if (details && content) {
+        let loaded = false;
+        details.addEventListener('toggle', async () => {
+          if (!details.open || loaded) return;
+          loaded = true;
+          if (this.tooltipHideTimer) {
+            clearTimeout(this.tooltipHideTimer);
+            this.tooltipHideTimer = null;
+          }
+          try {
+            const { fetchUcdpEvents } = await import('@/services/conflict');
+            const resp = await fetchUcdpEvents();
+            if (!el.isConnected || !content.isConnected) return;
+            const [cLon, cLat] = d.center;
+            const nearby = resp.data.filter(e => {
+              const dLat = e.latitude - cLat;
+              const dLon = e.longitude - cLon;
+              return Math.sqrt(dLat * dLat + dLon * dLon) < 3;
+            });
+            const totalDeaths = nearby.reduce((s, e) => s + (e.deaths_best ?? 0), 0);
+            const earliest = nearby.map(e => e.date_start).filter(Boolean).sort()[0];
+            const conflictSince = earliest ? earliest.substring(0, 4) : null;
+            const rows = [
+              conflictSince ? `<div style="display:flex;justify-content:space-between;gap:8px;font-size:10px;margin:2px 0;"><span style="opacity:.5;">CONFLICT SINCE</span><span>${esc(conflictSince)}</span></div>` : '',
+              d.peaceAgreements?.length ? `<div style="font-size:10px;margin:2px 0;"><span style="opacity:.5;display:block;margin-bottom:1px;">PEACE AGREEMENTS</span>${d.peaceAgreements.map(a => `<div style="opacity:.7;">· ${esc(a)}</div>`).join('')}</div>` : '',
+              totalDeaths > 0
+                ? `<div style="display:flex;justify-content:space-between;gap:8px;font-size:10px;margin:2px 0;"><span style="opacity:.5;">RECORDED FATALITIES</span><span>~${totalDeaths.toLocaleString()}</span></div>`
+                : d.totalFatalities ? `<div style="display:flex;justify-content:space-between;gap:8px;font-size:10px;margin:2px 0;"><span style="opacity:.5;">TOTAL FATALITIES</span><span>${esc(d.totalFatalities)}</span></div>` : '',
+            ].filter(Boolean).join('');
+            setTrustedHtml(content, trustedHtml(rows || '<span style="opacity:.5;font-size:10px;">No UCDP data found.</span>', 'legacy direct innerHTML migration'));
+          } catch {
+            if (el.isConnected && content.isConnected) {
+              setTrustedHtml(content, trustedHtml('<span style="opacity:.5;font-size:10px;">Could not load history.</span>', 'legacy direct innerHTML migration'));
+            }
+          }
+        });
+      }
+    }
 
     if (d._kind === 'webcam') {
       const wrapper = el.firstElementChild!;
@@ -1713,7 +1773,7 @@ export class GlobeMap {
 
     this.tooltipEl = el;
     if (this.tooltipHideTimer) clearTimeout(this.tooltipHideTimer);
-    const richKinds = new Set(['satellite', 'flightDelay', 'cableAdvisory', 'conflictZone', 'spaceport', 'economic', 'datacenter', 'imageryScene', 'repairShip', 'aisDisruption']);
+    const richKinds = new Set(['satellite', 'flightDelay', 'cableAdvisory', 'conflictZone', 'nuclearSite', 'spaceport', 'economic', 'datacenter', 'imageryScene', 'repairShip', 'aisDisruption']);
     const hideDelay = d._kind === 'webcam' ? 8000 : d._kind === 'webcam-cluster' ? 12000 : richKinds.has(d._kind) ? 6000 : 3500;
     this.tooltipHideTimer = setTimeout(() => this.hideTooltip(), hideDelay);
 
@@ -2223,6 +2283,9 @@ export class GlobeMap {
       intensity: z.intensity ?? 'low',
       parties: z.parties ?? [],
       casualties: z.casualties,
+      center: z.center,
+      peaceAgreements: z.peaceAgreements,
+      totalFatalities: z.totalFatalities,
     }));
     this.flushMarkers();
   }
@@ -2260,6 +2323,10 @@ export class GlobeMap {
               name: f.name,
               type: f.type,
               status: f.status,
+              operationalSince: f.operationalSince,
+              treaties: f.treaties,
+              iaeaStatus: f.iaeaStatus,
+              keyEvents: f.keyEvents,
             }));
         }
         break;

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -1594,6 +1594,7 @@ export class MapComponent {
             x: e.clientX - rect.left,
             y: e.clientY - rect.top,
           });
+          this.popup.loadConflictHistory(zone);
         });
 
         this.overlays.appendChild(clickArea);
@@ -3644,6 +3645,7 @@ export class MapComponent {
       x: pos[0],
       y: pos[1],
     });
+    this.popup.loadConflictHistory(conflict);
   }
 
   public triggerBaseClick(id: string): void {

--- a/src/components/MapPopup.ts
+++ b/src/components/MapPopup.ts
@@ -828,6 +828,14 @@ export class MapPopup {
             </details>
           </div>
         ` : ''}
+        <div class="popup-section">
+          <details class="conflict-history-details">
+            <summary>📜 HISTORICAL PROFILE</summary>
+            <div class="conflict-history-content">
+              <div class="popup-loading">Loading…</div>
+            </div>
+          </details>
+        </div>
       </div>
     `;
   }
@@ -1083,6 +1091,72 @@ export class MapPopup {
         `, "legacy direct innerHTML migration"));
       }
     }
+  }
+
+  public loadConflictHistory(conflict: ConflictZone): void {
+    if (!this.popup) return;
+    const details = this.popup.querySelector<HTMLDetailsElement>('.conflict-history-details');
+    const content = this.popup.querySelector('.conflict-history-content');
+    if (!details || !content) return;
+
+    let loaded = false;
+
+    const onToggle = async () => {
+      if (!details.open || loaded) return;
+      loaded = true;
+
+      try {
+        const { fetchUcdpEvents } = await import('@/services/conflict');
+        const resp = await fetchUcdpEvents();
+
+        if (!this.popup || !content.isConnected) return;
+
+        const [cLon, cLat] = conflict.center;
+        const nearby = resp.data.filter(e => {
+          const dLat = e.latitude - cLat;
+          const dLon = e.longitude - cLon;
+          return Math.sqrt(dLat * dLat + dLon * dLon) < 3;
+        });
+
+        const totalDeaths = nearby.reduce((s, e) => s + (e.deaths_best ?? 0), 0);
+        const earliest = nearby
+          .map(e => e.date_start)
+          .filter(Boolean)
+          .sort()[0];
+        const conflictSince = earliest ? earliest.substring(0, 4) : null;
+
+        const rows = [
+          conflictSince
+            ? `<div class="popup-stat"><span class="stat-label">CONFLICT SINCE</span><span class="stat-value">${escapeHtml(conflictSince)}</span></div>`
+            : '',
+          conflict.peaceAgreements?.length
+            ? `<div class="popup-stat"><span class="stat-label">PEACE AGREEMENTS</span><span class="stat-value">${conflict.peaceAgreements.map(escapeHtml).join('<br>')}</span></div>`
+            : '',
+          totalDeaths > 0
+            ? `<div class="popup-stat"><span class="stat-label">RECORDED FATALITIES</span><span class="stat-value">~${totalDeaths.toLocaleString()}</span></div>`
+            : conflict.totalFatalities
+            ? `<div class="popup-stat"><span class="stat-label">TOTAL FATALITIES</span><span class="stat-value">${escapeHtml(conflict.totalFatalities)}</span></div>`
+            : '',
+        ].filter(Boolean).join('');
+
+        setTrustedHtml(
+          content,
+          trustedHtml(
+            rows || `<div class="popup-loading">No historical data available.</div>`,
+            'legacy direct innerHTML migration'
+          )
+        );
+      } catch {
+        if (content.isConnected) {
+          setTrustedHtml(
+            content,
+            trustedHtml(`<div class="popup-loading">Could not load history.</div>`, 'legacy direct innerHTML migration')
+          );
+        }
+      }
+    };
+
+    details.addEventListener('toggle', onToggle);
   }
 
   public async loadWingbitsLiveFlight(hexCode: string): Promise<void> {
@@ -1809,6 +1883,34 @@ ${isFeatureAvailable('wingbitsEnrichment') ? '<div class="wingbits-live-section"
           </div>
         </div>
         <p class="popup-description">${t('popups.nuclear.description')}</p>
+        ${(facility.operationalSince || facility.treaties?.length || facility.iaeaStatus || facility.keyEvents?.length) ? `
+        <div class="popup-section">
+          <details>
+            <summary>📜 HISTORICAL PROFILE</summary>
+            <div class="popup-section-content">
+              ${facility.operationalSince ? `
+              <div class="popup-stat">
+                <span class="stat-label">OPERATIONAL SINCE</span>
+                <span class="stat-value">${escapeHtml(facility.operationalSince)}</span>
+              </div>` : ''}
+              ${facility.treaties?.length ? `
+              <div class="popup-stat">
+                <span class="stat-label">TREATIES</span>
+                <span class="stat-value">${facility.treaties.map(escapeHtml).join(', ')}</span>
+              </div>` : ''}
+              ${facility.iaeaStatus ? `
+              <div class="popup-stat">
+                <span class="stat-label">IAEA STATUS</span>
+                <span class="stat-value">${escapeHtml(facility.iaeaStatus)}</span>
+              </div>` : ''}
+              ${facility.keyEvents?.length ? `
+              <div class="popup-stat">
+                <span class="stat-label">KEY EVENTS</span>
+                <span class="stat-value">${facility.keyEvents.map(escapeHtml).join('<br>')}</span>
+              </div>` : ''}
+            </div>
+          </details>
+        </div>` : ''}
       </div>
     `;
   }

--- a/src/components/MapPopup.ts
+++ b/src/components/MapPopup.ts
@@ -1106,24 +1106,12 @@ export class MapPopup {
       loaded = true;
 
       try {
-        const { fetchUcdpEvents } = await import('@/services/conflict');
+        const { fetchUcdpEvents, deriveConflictHistory } = await import('@/services/conflict');
         const resp = await fetchUcdpEvents();
 
         if (!this.popup || !content.isConnected) return;
 
-        const [cLon, cLat] = conflict.center;
-        const nearby = resp.data.filter(e => {
-          const dLat = e.latitude - cLat;
-          const dLon = e.longitude - cLon;
-          return Math.sqrt(dLat * dLat + dLon * dLon) < 3;
-        });
-
-        const totalDeaths = nearby.reduce((s, e) => s + (e.deaths_best ?? 0), 0);
-        const earliest = nearby
-          .map(e => e.date_start)
-          .filter(Boolean)
-          .sort((a, b) => a.localeCompare(b))[0];
-        const conflictSince = earliest ? earliest.substring(0, 4) : null;
+        const { conflictSince, recordedFatalities } = deriveConflictHistory(conflict, resp.data);
 
         const rows = [
           conflictSince
@@ -1132,8 +1120,8 @@ export class MapPopup {
           conflict.peaceAgreements?.length
             ? `<div class="popup-stat"><span class="stat-label">PEACE AGREEMENTS</span><span class="stat-value">${conflict.peaceAgreements.map(escapeHtml).join('<br>')}</span></div>`
             : '',
-          totalDeaths > 0
-            ? `<div class="popup-stat"><span class="stat-label">RECORDED FATALITIES</span><span class="stat-value">~${totalDeaths.toLocaleString()}</span></div>`
+          recordedFatalities > 0
+            ? `<div class="popup-stat"><span class="stat-label">RECORDED FATALITIES</span><span class="stat-value">~${recordedFatalities.toLocaleString()}</span></div>`
             : conflict.totalFatalities
             ? `<div class="popup-stat"><span class="stat-label">TOTAL FATALITIES</span><span class="stat-value">${escapeHtml(conflict.totalFatalities)}</span></div>`
             : '',

--- a/src/components/MapPopup.ts
+++ b/src/components/MapPopup.ts
@@ -1156,7 +1156,7 @@ export class MapPopup {
       }
     };
 
-    details.addEventListener('toggle', onToggle);
+    details.addEventListener('toggle', onToggle, { once: true });
   }
 
   public async loadWingbitsLiveFlight(hexCode: string): Promise<void> {

--- a/src/components/MapPopup.ts
+++ b/src/components/MapPopup.ts
@@ -1122,7 +1122,7 @@ export class MapPopup {
         const earliest = nearby
           .map(e => e.date_start)
           .filter(Boolean)
-          .sort()[0];
+          .sort((a, b) => a.localeCompare(b))[0];
         const conflictSince = earliest ? earliest.substring(0, 4) : null;
 
         const rows = [

--- a/src/config/geo.ts
+++ b/src/config/geo.ts
@@ -559,6 +559,8 @@ export const CONFLICT_ZONES: ConflictZone[] = [
     location: 'Eastern Ukraine (Donetsk, Luhansk)',
     description: 'Full-scale Russian invasion of Ukraine. Active frontlines in Donetsk, Luhansk, Zaporizhzhia, and Kherson oblasts. Heavy artillery, drone warfare, and trench combat.',
     keyDevelopments: ['Battle of Bakhmut', 'Kursk incursion', 'Black Sea drone strikes', 'Infrastructure attacks'],
+    peaceAgreements: ['Minsk I (2014, failed)', 'Minsk II (2015, failed)'],
+    totalFatalities: '500,000+',
   },
   {
     id: 'gaza',
@@ -574,6 +576,8 @@ export const CONFLICT_ZONES: ConflictZone[] = [
     location: 'Gaza Strip, Palestinian Territories',
     description: 'Israeli military operations in Gaza following October 7 attacks. Ground invasion, aerial bombardment. Humanitarian crisis. Regional escalation with Hezbollah.',
     keyDevelopments: ['Rafah ground operation', 'Humanitarian crisis', 'Hostage negotiations', 'Iran-backed attacks'],
+    peaceAgreements: ['Oslo Accords (1993, undermined)'],
+    totalFatalities: '40,000+',
   },
   {
     id: 'south_lebanon',
@@ -589,6 +593,8 @@ export const CONFLICT_ZONES: ConflictZone[] = [
     location: 'Southern Lebanon / Northern Israel',
     description: 'Cross-border artillery and rocket fire. Targeted assassinations. High risk of full-scale escalation.',
     keyDevelopments: ['Daily rocket fire', 'IDF airstrikes', 'Buffer zone evacuation', 'Litani River tensions'],
+    peaceAgreements: ['UNSC Resolution 1701 (2006)'],
+    totalFatalities: '1,500+',
   },
   {
     id: 'yemen_redsea',
@@ -640,6 +646,8 @@ export const CONFLICT_ZONES: ConflictZone[] = [
     location: 'Red Sea & Gulf of Aden, Yemen',
     description: 'Houthi maritime campaign against commercial shipping. US/UK airstrikes on Houthi targets. Ongoing blockade attempts.',
     keyDevelopments: ['Ship hijackings', 'US airstrikes', 'Cable cuts', 'Sinking of Rubymar'],
+    peaceAgreements: ['Stockholm Agreement (2018, partial)'],
+    totalFatalities: '150,000+ (Yemen Civil War)',
   },
   {
     id: 'sudan',
@@ -662,6 +670,7 @@ export const CONFLICT_ZONES: ConflictZone[] = [
     location: 'Sudan (nationwide)',
     description: 'Power struggle between SAF and RSF paramilitary has engulfed the entire country. RSF controls most of Darfur and Khartoum; SAF holds Port Sudan and eastern regions. World\'s largest displacement crisis. Famine conditions in multiple states.',
     keyDevelopments: ['Khartoum destruction', 'Darfur ethnic massacres', 'El Fasher siege', 'Wad Madani fall to RSF', 'Famine declared in North Darfur', 'SAF counter-offensives', 'Regional proxy involvement (UAE, Egypt)'],
+    totalFatalities: '150,000+',
   },
   {
     id: 'myanmar',
@@ -694,6 +703,8 @@ export const CONFLICT_ZONES: ConflictZone[] = [
     startDate: 'Jul 27, 1953',
     location: 'Korean Peninsula (MDL)',
     description: '250km-long, 4km-wide buffer zone along the Military Demarcation Line established by the 1953 Korean Armistice Agreement. Despite its name, one of the most heavily militarized borders in the world.',
+    peaceAgreements: ['Korean Armistice Agreement (Jul 27, 1953)'],
+    totalFatalities: '2,500,000+ (Korean War)',
     center: [127.27, 38.14],
     coords: [
       [126.0955, 37.7876],
@@ -3188,7 +3199,7 @@ export const NUCLEAR_FACILITIES: NuclearFacility[] = [
   // --- HU ---
   { id: 'paks', name: 'Paks Nuclear Power Plant', lat: 46.57, lon: 18.85, type: 'plant', status: 'active', operator: 'HU' },
   // --- IL ---
-  { id: 'negev', name: 'Negev Nuclear Research Center', lat: 31.0, lon: 35.15, type: 'weapons', status: 'active', operator: 'IL' },
+  { id: 'negev', name: 'Negev Nuclear Research Center', lat: 31.0, lon: 35.15, type: 'weapons', status: 'active', operator: 'IL', operationalSince: '1963', treaties: [], iaeaStatus: 'No IAEA access (non-NPT)', keyEvents: ['1986: Mordechai Vanunu revealed weapons program', '2020s: US intelligence reports suspected expansion'] },
   { id: 'soreq', name: 'Soreq Nuclear Research Center', lat: 31.9, lon: 34.7, type: 'research', status: 'active', operator: 'IL' },
   // --- IN ---
   { id: 'gorakhpur', name: 'Gorakhpur Nuclear Power Plant', lat: 29.45, lon: 75.68, type: 'plant', status: 'construction', operator: 'IN' },
@@ -3202,10 +3213,10 @@ export const NUCLEAR_FACILITIES: NuclearFacility[] = [
   { id: 'tarapur', name: 'Tarapur Atomic Power Station', lat: 19.83, lon: 72.66, type: 'plant', status: 'active', operator: 'IN' },
   { id: 'kalpakkam', name: 'Kalpakkam PFBR', lat: 12.56, lon: 80.17, type: 'plant', status: 'construction', operator: 'IN' },
   // --- IR ---
-  { id: 'arak', name: 'Arak Nuclear Complex', lat: 34.37, lon: 49.24, type: 'research', status: 'active', operator: 'IR' },
-  { id: 'bushehr', name: 'Bushehr Nuclear Power Plant', lat: 28.83, lon: 50.89, type: 'plant', status: 'active', operator: 'IR' },
-  { id: 'fordow', name: 'Fordow Uranium Enrichment Plant', lat: 34.89, lon: 51.0, type: 'enrichment', status: 'active', operator: 'IR' },
-  { id: 'natanz', name: 'Natanz nuclear facility', lat: 33.73, lon: 51.73, type: 'enrichment', status: 'active', operator: 'IR' },
+  { id: 'arak', name: 'Arak Nuclear Complex', lat: 34.37, lon: 49.24, type: 'research', status: 'active', operator: 'IR', operationalSince: '2006', treaties: ['NPT (1970)', 'JCPOA (2015)'], iaeaStatus: 'Limited access', keyEvents: ['2020: Reactor redesign per JCPOA', '2023: Heavy water production continued'] },
+  { id: 'bushehr', name: 'Bushehr Nuclear Power Plant', lat: 28.83, lon: 50.89, type: 'plant', status: 'active', operator: 'IR', operationalSince: '2011', treaties: ['NPT (1970)', 'JCPOA (2015)'], iaeaStatus: 'Limited access', keyEvents: ['2021: IAEA access restricted', '2022: JCPOA talks stalled'] },
+  { id: 'fordow', name: 'Fordow Uranium Enrichment Plant', lat: 34.89, lon: 51.0, type: 'enrichment', status: 'active', operator: 'IR', operationalSince: '2011', treaties: ['NPT (1970)', 'JCPOA (2015)'], iaeaStatus: 'Under safeguards', keyEvents: ['2019: Enrichment resumed post-JCPOA', '2023: 60% enrichment reported'] },
+  { id: 'natanz', name: 'Natanz nuclear facility', lat: 33.73, lon: 51.73, type: 'enrichment', status: 'active', operator: 'IR', operationalSince: '2003', treaties: ['NPT (1970)'], iaeaStatus: 'Inspections suspended', keyEvents: ['2021: Sabotage incident at centrifuge hall', '2023: Advanced IR-6 centrifuges installed'] },
   // --- IT ---
   { id: 'caorso', name: 'Caorso Nuclear Power Plant', lat: 45.07, lon: 9.87, type: 'plant', status: 'decommissioned', operator: 'IT' },
   { id: 'enrico_fermi', name: 'Enrico Fermi Nuclear Power Plant', lat: 45.18, lon: 8.28, type: 'plant', status: 'decommissioned', operator: 'IT' },
@@ -3214,7 +3225,7 @@ export const NUCLEAR_FACILITIES: NuclearFacility[] = [
   { id: 'latina', name: 'Latina Nuclear Power Plant', lat: 41.43, lon: 12.81, type: 'plant', status: 'decommissioned', operator: 'IT' },
   // --- JP ---
   { id: 'fugen', name: 'Fugen Nuclear Power Plant', lat: 35.75, lon: 136.02, type: 'plant', status: 'decommissioned', operator: 'JP' },
-  { id: 'fukushima_daiichi', name: 'Fukushima Daiichi Nuclear Power Plant', lat: 37.42, lon: 141.03, type: 'plant', status: 'decommissioned', operator: 'JP' },
+  { id: 'fukushima_daiichi', name: 'Fukushima Daiichi Nuclear Power Plant', lat: 37.42, lon: 141.03, type: 'plant', status: 'decommissioned', operator: 'JP', operationalSince: '1971', treaties: ['NPT (1970)'], iaeaStatus: 'Under decommissioning oversight', keyEvents: ['Mar 11, 2011: Tsunami-triggered meltdown (INES level 7)', '2023: ALPS treated water release approved by IAEA'] },
   { id: 'fukushima_daini', name: 'Fukushima Daini Nuclear Power Plant', lat: 37.32, lon: 141.02, type: 'plant', status: 'decommissioned', operator: 'JP' },
   { id: 'genkai', name: 'Genkai Nuclear Power Plant', lat: 33.52, lon: 129.84, type: 'plant', status: 'active', operator: 'JP' },
   { id: 'hamaoka', name: 'Hamaoka Nuclear Power Plant', lat: 34.62, lon: 138.14, type: 'plant', status: 'active', operator: 'JP' },
@@ -3236,9 +3247,9 @@ export const NUCLEAR_FACILITIES: NuclearFacility[] = [
   { id: 'oma', name: 'Ōma Nuclear Power Plant', lat: 41.51, lon: 140.91, type: 'plant', status: 'construction', operator: 'JP' },
   // --- KP ---
   { id: 'kumho', name: 'Kŭmho Nuclear Power Plant', lat: 40.1, lon: 128.34, type: 'plant', status: 'construction', operator: 'KP' },
-  { id: 'punggye_ri', name: 'Punggye-ri Nuclear Test Site', lat: 41.28, lon: 129.09, type: 'test-site', status: 'active', operator: 'KP' },
+  { id: 'punggye_ri', name: 'Punggye-ri Nuclear Test Site', lat: 41.28, lon: 129.09, type: 'test-site', status: 'active', operator: 'KP', treaties: ['NPT (withdrew 2003)'], iaeaStatus: 'No access', keyEvents: ['2006: 1st nuclear test', '2017: 6th nuclear test (est. 250kt)', '2018: Tunnels demolished (incomplete)'] },
   { id: 'taechon', name: 'Taechon nuclear facility', lat: 39.93, lon: 125.57, type: 'research', status: 'active', operator: 'KP' },
-  { id: 'yongbyon', name: 'Yongbyon Nuclear Scientific Research Center', lat: 39.8, lon: 125.75, type: 'weapons', status: 'active', operator: 'KP' },
+  { id: 'yongbyon', name: 'Yongbyon Nuclear Scientific Research Center', lat: 39.8, lon: 125.75, type: 'weapons', status: 'active', operator: 'KP', operationalSince: '1964', treaties: ['NPT (withdrew 2003)'], iaeaStatus: 'No access since 2009', keyEvents: ['2003: DPRK withdrew from NPT', '2017: 5MW reactor restart confirmed', '2021: IAEA reports reactor reactivated'] },
   // --- KR ---
   { id: 'hanbit', name: 'Hanbit Nuclear Power Plant', lat: 35.41, lon: 126.42, type: 'plant', status: 'active', operator: 'KR' },
   { id: 'hanul', name: 'Hanul Nuclear Power Plant', lat: 37.08, lon: 129.39, type: 'plant', status: 'active', operator: 'KR' },
@@ -3311,12 +3322,12 @@ export const NUCLEAR_FACILITIES: NuclearFacility[] = [
   { id: 'longmen', name: 'Longmen Nuclear Power Plant', lat: 25.04, lon: 121.92, type: 'plant', status: 'construction', operator: 'TW' },
   { id: 'maanshan', name: 'Maanshan Nuclear Power Plant', lat: 21.96, lon: 120.75, type: 'plant', status: 'active', operator: 'TW' },
   // --- UA ---
-  { id: 'chernobyl', name: 'Chernobyl Nuclear Power Plant', lat: 51.39, lon: 30.1, type: 'plant', status: 'decommissioned', operator: 'UA' },
+  { id: 'chernobyl', name: 'Chernobyl Nuclear Power Plant', lat: 51.39, lon: 30.1, type: 'plant', status: 'decommissioned', operator: 'UA', operationalSince: '1977', treaties: ['NPT (1994, via Soviet succession)'], iaeaStatus: 'Exclusion zone monitoring', keyEvents: ['Apr 26, 1986: Reactor 4 explosion (INES level 7)', '2000: Final reactor shutdown', 'Feb 2022: Briefly occupied by Russian forces'] },
   { id: 'khmelnytskyi', name: 'Khmelnytskyi Nuclear Power Plant', lat: 50.3, lon: 26.64, type: 'plant', status: 'active', operator: 'UA' },
   { id: 'main_storage_of_spent_nuclear_fuel', name: 'Main storage of spent nuclear fuel', lat: 51.27, lon: 30.22, type: 'research', status: 'decommissioned', operator: 'UA' },
   { id: 'rivne', name: 'Rivne Nuclear Power Plant', lat: 51.33, lon: 25.89, type: 'plant', status: 'active', operator: 'UA' },
   { id: 'south_ukraine', name: 'South Ukraine Nuclear Power Plant', lat: 47.82, lon: 31.22, type: 'plant', status: 'active', operator: 'UA' },
-  { id: 'zaporizhzhia', name: 'Zaporizhzhia Nuclear Power Plant', lat: 47.51, lon: 34.59, type: 'plant', status: 'contested', operator: 'UA' },
+  { id: 'zaporizhzhia', name: 'Zaporizhzhia Nuclear Power Plant', lat: 47.51, lon: 34.59, type: 'plant', status: 'contested', operator: 'UA', operationalSince: '1984', treaties: ['NPT (1994, Ukraine)'], iaeaStatus: 'IAEA monitoring mission active', keyEvents: ['Mar 4, 2022: Russian forces seized plant', 'Sep 2022: IAEA permanent monitoring mission established', '2023: Reactors in cold shutdown'] },
   // --- US ---
   { id: 'ames', name: 'Ames National Laboratory', lat: 42.03, lon: -93.65, type: 'research', status: 'active', operator: 'US' },
   { id: 'area', name: 'Area 2', lat: 37.14, lon: -116.07, type: 'test-site', status: 'decommissioned', operator: 'US' },

--- a/src/services/conflict/index.ts
+++ b/src/services/conflict/index.ts
@@ -402,6 +402,34 @@ export function deduplicateAgainstAcled(
   });
 }
 
+const CONFLICT_HISTORY_RADIUS_DEG = 3;
+
+/**
+ * Derive the figures shown in a conflict zone's "Historical Profile" popup.
+ *
+ * `conflictSince` is taken from the zone's static `startDate` — the UCDP feed is
+ * only a ~1-year trailing window (scripts/seed-ucdp-events.mjs), so its earliest
+ * event is NOT the conflict's inception and must not be used for "CONFLICT SINCE".
+ * `recordedFatalities` sums `deaths_best` for events within ~3° of the zone
+ * centre, applying a cos(latitude) correction so the radius is roughly isotropic
+ * in real distance (a raw degree radius is ~24% too narrow E–W at 40°N).
+ */
+export function deriveConflictHistory(
+  zone: { center: [number, number]; startDate?: string },
+  events: UcdpGeoEvent[],
+): { conflictSince: string | null; recordedFatalities: number } {
+  const [cLon, cLat] = zone.center;
+  const cosLat = Math.cos((cLat * Math.PI) / 180);
+  const recordedFatalities = events.reduce((sum, e) => {
+    const dLat = e.latitude - cLat;
+    const dLon = (e.longitude - cLon) * cosLat;
+    if (Math.sqrt(dLat * dLat + dLon * dLon) >= CONFLICT_HISTORY_RADIUS_DEG) return sum;
+    return sum + (e.deaths_best ?? 0);
+  }, 0);
+  const conflictSince = zone.startDate?.match(/\b(\d{4})\b/)?.[1] ?? null;
+  return { conflictSince, recordedFatalities };
+}
+
 export function groupByCountry(events: UcdpGeoEvent[]): Map<string, UcdpGeoEvent[]> {
   const map = new Map<string, UcdpGeoEvent[]>();
   for (const e of events) {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -16812,7 +16812,7 @@ a.prediction-link:hover {
   border-radius: 4px;
   font-size: 11px;
   color: var(--text);
-  max-width: 250px;
+  max-width: 300px;
   pointer-events: none;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -359,6 +359,8 @@ export interface ConflictZone {
   location?: string;
   description?: string;
   keyDevelopments?: string[];
+  peaceAgreements?: string[];
+  totalFatalities?: string;
 }
 
 
@@ -548,6 +550,10 @@ export interface NuclearFacility {
   type: NuclearFacilityType;
   status: 'active' | 'contested' | 'inactive' | 'decommissioned' | 'construction';
   operator?: string;  // Operating country
+  operationalSince?: string;
+  treaties?: string[];
+  iaeaStatus?: string;
+  keyEvents?: string[];
 }
 
 export interface GammaIrradiator {

--- a/tests/conflict-ucdp-date-window.test.mts
+++ b/tests/conflict-ucdp-date-window.test.mts
@@ -122,3 +122,40 @@ describe('frontend UCDP classification date guard', () => {
     }
   });
 });
+
+async function loadDeriveConflictHistory() {
+  const mod = (await loadUcdpDeriver()) as unknown as {
+    deriveConflictHistory: (
+      zone: { center: [number, number]; startDate?: string },
+      events: Array<{ latitude: number; longitude: number; deaths_best?: number }>,
+    ) => { conflictSince: string | null; recordedFatalities: number };
+  };
+  return mod.deriveConflictHistory;
+}
+
+describe('deriveConflictHistory', () => {
+  it('takes CONFLICT SINCE from the static startDate year, not the UCDP trailing window', async () => {
+    const deriveConflictHistory = await loadDeriveConflictHistory();
+    // UCDP feed is only a ~1yr trailing slice, so a 2026 event must NOT become "since".
+    const events = [{ latitude: 48.5, longitude: 31, deaths_best: 100, date_start: '2026-01-01' }];
+    const result = deriveConflictHistory({ center: [31, 48.5], startDate: 'Feb 24, 2022' }, events);
+    assert.equal(result.conflictSince, '2022');
+    assert.equal(result.recordedFatalities, 100);
+  });
+
+  it('returns null conflictSince when the zone has no startDate', async () => {
+    const deriveConflictHistory = await loadDeriveConflictHistory();
+    const result = deriveConflictHistory({ center: [31, 48.5] }, []);
+    assert.equal(result.conflictSince, null);
+    assert.equal(result.recordedFatalities, 0);
+  });
+
+  it('applies a cos(latitude) correction so the radius is isotropic in real distance', async () => {
+    const deriveConflictHistory = await loadDeriveConflictHistory();
+    // At 60°N, cos(lat)=0.5: an event 4° east is ~2° in real distance (inside the
+    // 3° radius) and MUST be counted. A raw degree filter would wrongly exclude it.
+    const events = [{ latitude: 60, longitude: 4, deaths_best: 50, date_start: '2024-01-01' }];
+    const result = deriveConflictHistory({ center: [0, 60], startDate: 'Jan 1, 2020' }, events);
+    assert.equal(result.recordedFatalities, 50);
+  });
+});


### PR DESCRIPTION
Closes #3840

- **Nuclear sites (pilot):** static historical enrichment — `operationalSince`, `treaties`, `iaeaStatus`, `keyEvents` fields added to the `NuclearFacility` type and populated for 9 key facilities (Bushehr, Natanz, Fordow, Arak, Yongbyon, Punggye-ri, Zaporizhzhia, Chernobyl, Fukushima Daiichi, Negev). Section renders immediately from in-memory data — no lazy fetch needed.
- **Conflict zones:** lazy-load on expand following the `loadHotspotGdeltContext` pattern. On first toggle, `fetchUcdpEvents()` is called, events within ~30ggregated to derive conflict start year and total fatalities. Falls back to static `totalFatalities` field if UCDP returns no nearby events. 6 zones enriched with `peaceAgreements` and `totalFatalities` (Ukraine, Gaza, South Lebanon, Yemen, Sudan, Korean DMZ).
- Both flat map (`DeckGLMap`, `Map`) and 3D glob

## Approach

Nuclear uses static `geo.ts` enrichment (no live IAEA service exists in the codebase). Conflict uses the existing `loadHotspotGdeltContext` lazy pattern — a `<details class="conflict-history-details">` placeholder is injected at render
time; a `toggle` event listener fires the UCDP fpand.

## Files changed

| File | Change |
|------|--------|
| `src/types/index.ts` | Added optional historic` and `ConflictZone` |
| `src/config/geo.ts` | Enriched 9 nuclear facilities and 6 conflict zones |
| `src/components/MapPopup.ts` | Added `<details>` in `renderNuclearPopup`; lazy placeholder in `renderConflictPopup`; new
`loadConflictHistory()` method |
| `src/components/DeckGLMap.ts` | Calls `loadConflictHistory` from click handler and `triggerConflictClick` |
| `src/components/Map.ts` | Calls `loadConflictHistory` from click listener and `triggerConflictClick` |
| `src/components/GlobeMap.ts` | Extended marker<details>`; conflict lazy toggle; `nuclearSite`added to `richKinds`/`wideKinds` |
| `src/styles/main.css` | `.deckgl-tooltip` max-width 250px → 300px |

## Test plan

- [ ] Enable Nuclear Sites layer → click Bushehr or Natanz → expand 📜 HISTORICAL PROFILE → verify fields render
- [ ] Click a nuclear site with no historical dan
- [ ] Enable Conflict Zones → click Ukraine or Gaza → expand section → confirm "Loading…" resolves into UCDP-derived data
- [ ] Switch to Globe view → repeat both checks
- [ ] `npm run typecheck` ✓
- [ ] `npm run lint` ✓
- [ ] `npm run build` (vite bundle) ✓

## Notes

The dataset in `geo.ts` covers the 9 most strategic facilities. Happy to extend coverage to additional sites in a follow-up if the maintainer wants to keep this PR focused.