### PR TITLE
fix(live-media): let explicitly-played feeds coexist instead of one global stream

### DIFF
--- a/e2e/live-media-intent.spec.ts
+++ b/e2e/live-media-intent.spec.ts
@@ -77,7 +77,7 @@ async function setPanelEnabledViaStoredSettings(page: Page, panelId: string, ena
 }
 
 test.describe('live media intent gating', () => {
-  test('keeps live media transports idle until click, then keeps one active stream', async ({ page }) => {
+  test('keeps live media transports idle until click, then lets played feeds coexist as a wall', async ({ page }) => {
     await installCleanLiveMediaPrefs(page);
     const mediaRequests: string[] = [];
     page.on('request', (request) => {
@@ -100,9 +100,15 @@ test.describe('live media intent gating', () => {
     await liveNews.getByRole('button', { name: /play live feed/i }).click();
     await expect.poll(() => liveNewsTransportCount(page), { timeout: 30_000 }).toBe(1);
 
+    // Playing a webcam tile must NOT stop Live News — explicitly played feeds coexist.
     await webcams.locator('.webcam-preview-tile').first().getByRole('button', { name: /^play$/i }).click();
     await expect.poll(() => webcamTransportCount(page), { timeout: 30_000 }).toBe(1);
-    await expect.poll(() => liveNewsTransportCount(page), { timeout: 30_000 }).toBe(0);
+    await expect.poll(() => liveNewsTransportCount(page), { timeout: 5_000 }).toBe(1);
+
+    // Playing a second tile builds the wall — both webcams run alongside Live News.
+    await webcams.locator('.webcam-preview-tile').first().getByRole('button', { name: /^play$/i }).click();
+    await expect.poll(() => webcamTransportCount(page), { timeout: 30_000 }).toBe(2);
+    await expect.poll(() => liveNewsTransportCount(page), { timeout: 5_000 }).toBe(1);
   });
 
   test('renders stored single webcam mode as a preview before play intent', async ({ page }) => {
@@ -231,7 +237,8 @@ test.describe('live media intent gating', () => {
 
     await liveNews.scrollIntoViewIfNeeded();
     await expect.poll(() => liveNewsTransportCount(page), { timeout: 30_000 }).toBe(1);
-    await expect.poll(() => webcamTransportCount(page), { timeout: 30_000 }).toBe(1);
+    // Always-on grid auto-starts the whole wall, so more than one webcam can be live.
+    await expect.poll(() => webcamTransportCount(page), { timeout: 30_000 }).toBeGreaterThanOrEqual(1);
 
     await page.evaluate(() => {
       Object.defineProperty(Document.prototype, 'hidden', { configurable: true, get: () => true });
@@ -245,10 +252,10 @@ test.describe('live media intent gating', () => {
       document.dispatchEvent(new Event('visibilitychange'));
     });
     await expect.poll(() => liveNewsTransportCount(page), { timeout: 30_000 }).toBe(1);
-    await expect.poll(() => webcamTransportCount(page), { timeout: 30_000 }).toBe(1);
+    await expect.poll(() => webcamTransportCount(page), { timeout: 30_000 }).toBeGreaterThanOrEqual(1);
   });
 
-  test('turning always-on off restores one active live stream', async ({ page }) => {
+  test('turning always-on off keeps already-playing feeds running', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 220 });
     await installAlwaysOnLiveMediaPrefs(page);
 
@@ -258,7 +265,7 @@ test.describe('live media intent gating', () => {
 
     await liveNews.scrollIntoViewIfNeeded();
     await expect.poll(() => liveNewsTransportCount(page), { timeout: 30_000 }).toBe(1);
-    await expect.poll(() => webcamTransportCount(page), { timeout: 30_000 }).toBe(1);
+    await expect.poll(() => webcamTransportCount(page), { timeout: 30_000 }).toBeGreaterThanOrEqual(1);
 
     await page.evaluate(() => {
       localStorage.setItem('wm-live-streams-always-on', 'false');
@@ -266,11 +273,10 @@ test.describe('live media intent gating', () => {
         detail: { alwaysOn: false },
       }));
     });
-    await expect.poll(async () => {
-      const liveNewsCount = await liveNewsTransportCount(page);
-      const webcamCount = await webcamTransportCount(page);
-      return liveNewsCount + webcamCount;
-    }, { timeout: 10_000 }).toBe(1);
+    // Leaving always-on must NOT collapse the wall — feeds already playing stay (eco-idle pauses later).
+    await page.waitForTimeout(1500);
+    expect(await liveNewsTransportCount(page)).toBe(1);
+    expect(await webcamTransportCount(page)).toBeGreaterThanOrEqual(1);
   });
 
   test('always-on live news restarts after disable and re-enable through stored settings', async ({ page }) => {

--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -7,7 +7,7 @@ import { IDLE_PAUSE_MS, STORAGE_KEYS, SITE_VARIANT } from '@/config';
 import { escapeHtml, sanitizeUrl } from '@/utils/sanitize';
 
 import { getStreamQuality } from '@/services/ai-flow-settings';
-import { enforceExclusiveLiveMediaPlayback, getActiveLiveMedia, releaseLiveMediaPlayback, requestLiveMediaPlayback, stopLiveMediaPlayback, type LiveMediaStopReason } from '@/services/live-media-controller';
+import { getActiveLiveMedia, releaseLiveMediaPlayback, requestLiveMediaPlayback, stopLiveMediaPlayback, type LiveMediaStopReason } from '@/services/live-media-controller';
 import { getLiveStreamsAlwaysOn, subscribeLiveStreamsSettingsChange } from '@/services/live-stream-settings';
 import { track } from '@/services/analytics';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
@@ -436,14 +436,13 @@ export class LiveNewsPanel extends Panel {
       this.applyIdleMode();
       if (wasAlwaysOn && !alwaysOn) {
         // Cancel any pending lazy-init so leaving always-on cannot auto-start playback without intent.
+        // Anything already playing keeps running — feeds coexist; eco-idle (re-armed below) will pause it.
         if (this.lazyObserver) { this.lazyObserver.disconnect(); this.lazyObserver = null; }
         if (this.idleCallbackId !== null) {
           if ('cancelIdleCallback' in window) (window as any).cancelIdleCallback(this.idleCallbackId);
           else clearTimeout(this.idleCallbackId as ReturnType<typeof setTimeout>);
           this.idleCallbackId = null;
         }
-        // Deterministically keep Live News when leaving always-on (stable priority over webcams).
-        enforceExclusiveLiveMediaPlayback('live-news');
       }
       if (alwaysOn && !this.deferredInit && this.isPanelVisible()) {
         this.startAlwaysOnPlaybackIfVisible();
@@ -541,7 +540,6 @@ export class LiveNewsPanel extends Panel {
       streamId,
       () => this.startPlaybackForActiveChannel(),
       (reason) => this.stopPlaybackFromController(reason),
-      { exclusive: !this.alwaysOn },
     );
   }
 

--- a/src/components/LiveWebcamsPanel.ts
+++ b/src/components/LiveWebcamsPanel.ts
@@ -292,9 +292,9 @@ export class LiveWebcamsPanel extends Panel {
     this.toolbar?.querySelectorAll('.webcam-view-btn').forEach(btn => {
       (btn as HTMLElement).classList.toggle('active', (btn as HTMLElement).dataset.mode === mode);
     });
-    this.render();
-    if (this.alwaysOn && this.isVisible && !document.hidden) {
-      this.startAlwaysOnPlayback();
+    // In always-on, let startAlwaysOnPlayback own the render so the wall isn't built then immediately rebuilt.
+    if (!this.startAlwaysOnPlayback()) {
+      this.render();
     }
   }
 
@@ -420,8 +420,9 @@ export class LiveWebcamsPanel extends Panel {
       rect.left < window.innerWidth;
   }
 
-  private startAlwaysOnPlayback(): void {
-    if (!this.alwaysOn || document.hidden || !this.element.isConnected || !this.isVisible) return;
+  /** Ensure the always-on feed(s) are in the active set. Returns true if it rendered (so callers don't double-render). */
+  private startAlwaysOnPlayback(): boolean {
+    if (!this.alwaysOn || document.hidden || !this.element.isConnected || !this.isVisible) return false;
     // In grid view auto-start the whole wall; single view auto-starts only the selected feed.
     const feeds = (this.viewMode === 'grid' && !this.forceSingleView) ? this.gridFeeds : [this.activeFeed];
     let added = false;
@@ -431,9 +432,10 @@ export class LiveWebcamsPanel extends Panel {
         added = true;
       }
     }
-    if (!added) return;
+    if (!added) return false;
     this.isIdle = false;
     this.render();
+    return true;
   }
 
   /** Stop and forget every active tile without rebuilding the shell. */
@@ -723,8 +725,8 @@ export class LiveWebcamsPanel extends Panel {
         const wasVisible = this.isVisible;
         this.isVisible = entries.some(e => e.isIntersecting);
         if (this.isVisible && !wasVisible && !this.isIdle) {
-          this.render();
-          if (this.alwaysOn) this.startAlwaysOnPlayback();
+          // startAlwaysOnPlayback renders the wall when always-on; otherwise render the previews once.
+          if (!this.startAlwaysOnPlayback()) this.render();
         } else if (!this.isVisible && wasVisible) {
           this.teardownPlayback('scroll-away');
         }

--- a/src/components/LiveWebcamsPanel.ts
+++ b/src/components/LiveWebcamsPanel.ts
@@ -6,7 +6,7 @@ import { t } from '../services/i18n';
 import { track, trackWebcamSelected, trackWebcamRegionFiltered } from '@/services/analytics';
 import { getStreamQuality, subscribeStreamQualityChange } from '@/services/ai-flow-settings';
 import { isMobileDevice, loadFromStorage, saveToStorage } from '@/utils';
-import { enforceExclusiveLiveMediaPlayback, releaseLiveMediaPlayback, requestLiveMediaPlayback, stopLiveMediaPlayback, type LiveMediaStopReason } from '@/services/live-media-controller';
+import { type LiveMediaStopReason } from '@/services/live-media-controller';
 import { getLiveStreamsAlwaysOn, subscribeLiveStreamsSettingsChange } from '@/services/live-stream-settings';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 
@@ -103,7 +103,9 @@ export class LiveWebcamsPanel extends Panel {
   private toolbar: HTMLElement | null = null;
   private iframes: HTMLIFrameElement[] = [];
   private iframeTrackers = new Map<HTMLIFrameElement, WebcamIframeTracker>();
-  private activeIframeFeedId: string | null = null;
+  // Feeds the user has explicitly started. The grid is a "wall" — multiple tiles play at once;
+  // single view keeps one. Tiles coexist and are only torn down by scroll-away/hidden/idle/close.
+  private activeIframeFeedIds = new Set<string>();
   private observer: IntersectionObserver | null = null;
   private isVisible = false;
   // Stream lifecycle
@@ -114,7 +116,7 @@ export class LiveWebcamsPanel extends Panel {
   private isIdle = false;
   private alwaysOn = getLiveStreamsAlwaysOn();
   private unsubscribeStreamSettings: (() => void) | null = null;
-  private resumeFeedAfterIdleId: string | null = null;
+  private resumeFeedAfterIdleIds: string[] = [];
 
   // UI
   private fullscreenBtn: HTMLButtonElement | null = null;
@@ -138,15 +140,11 @@ export class LiveWebcamsPanel extends Panel {
     this.setupIdleDetection();
     subscribeStreamQualityChange(() => this.render());
     this.unsubscribeStreamSettings = subscribeLiveStreamsSettingsChange((alwaysOn) => {
-      const wasAlwaysOn = this.alwaysOn;
       this.alwaysOn = alwaysOn;
       this.applyIdleMode();
-      if (wasAlwaysOn && !alwaysOn) {
-        // Deterministically keep Live News when leaving always-on (stable priority over webcams).
-        enforceExclusiveLiveMediaPlayback('live-news');
-      }
-      if (alwaysOn && this.isVisible && !document.hidden && !this.activeIframeFeedId) {
-        this.requestPlayback(this.activeFeed, 'settings');
+      // Leaving always-on keeps whatever is playing; eco-idle (re-armed by applyIdleMode) pauses it later.
+      if (alwaysOn && this.isVisible && !document.hidden) {
+        this.startAlwaysOnPlayback();
       }
     });
     this.boundEmbedMessageHandler = (e) => this.handleEmbedMessage(e);
@@ -272,11 +270,11 @@ export class LiveWebcamsPanel extends Panel {
     this.toolbar?.querySelectorAll('.webcam-region-btn').forEach(btn => {
       (btn as HTMLElement).classList.toggle('active', (btn as HTMLElement).dataset.region === filter);
     });
+    // Region change swaps the entire feed set — stop the current wall and start fresh from previews.
+    this.clearActivePlayback();
     const feeds = this.filteredFeeds;
     if (feeds.length > 0 && !feeds.includes(this.activeFeed)) {
-      stopLiveMediaPlayback('live-webcams', 'replaced');
       this.activeFeed = feeds[0]!;
-      this.activeIframeFeedId = null;
     }
     this.savePrefs();
     this.render();
@@ -286,15 +284,18 @@ export class LiveWebcamsPanel extends Panel {
     if (this.forceSingleView && mode === 'grid') return;
     if (mode === this.viewMode) return;
     this.viewMode = mode;
-    if (mode === 'grid' && this.activeIframeFeedId && !this.gridFeeds.some(feed => feed.id === this.activeIframeFeedId)) {
-      stopLiveMediaPlayback('live-webcams', 'replaced');
-      this.activeIframeFeedId = null;
-    }
+    // Switching layout resets the wall to the selected feed; the user rebuilds it by clicking tiles.
+    const keepActive = this.activeIframeFeedIds.has(this.activeFeed.id);
+    this.activeIframeFeedIds.clear();
+    if (keepActive) this.activeIframeFeedIds.add(this.activeFeed.id);
     this.savePrefs();
     this.toolbar?.querySelectorAll('.webcam-view-btn').forEach(btn => {
       (btn as HTMLElement).classList.toggle('active', (btn as HTMLElement).dataset.mode === mode);
     });
     this.render();
+    if (this.alwaysOn && this.isVisible && !document.hidden) {
+      this.startAlwaysOnPlayback();
+    }
   }
 
   private buildEmbedUrl(videoId: string): string {
@@ -372,25 +373,40 @@ export class LiveWebcamsPanel extends Panel {
     tracker.timeout = setTimeout(() => this.markIframeBlocked(iframe), this.EMBED_READY_TIMEOUT_MS);
   }
 
-  private requestPlayback(feed: WebcamFeed, source: 'grid' | 'single' | 'settings'): void {
+  private playFeed(feed: WebcamFeed, source: 'grid' | 'single' | 'settings'): void {
     if (source !== 'settings') {
       trackWebcamSelected(feed.id, feed.city, source);
     }
-    requestLiveMediaPlayback(
-      'live-webcams',
-      feed.id,
-      () => this.startPlayback(feed),
-      (reason) => this.stopPlaybackFromController(reason),
-      { exclusive: !this.alwaysOn },
-    );
+    this.activeFeed = feed;
+    this.isIdle = false;
+    const alreadyActive = this.activeIframeFeedIds.has(feed.id);
+    this.activeIframeFeedIds.add(feed.id);
+    this.savePrefs();
+    if (!this.isVisible || document.hidden) return;
+    // Grid is a wall: swap just the clicked tile into a live iframe so sibling streams keep playing.
+    if (this.viewMode === 'grid' && !this.forceSingleView && !alreadyActive && this.activateGridCell(feed)) {
+      return;
+    }
+    this.render();
   }
 
-  private startPlayback(feed: WebcamFeed): void {
-    this.activeFeed = feed;
-    this.activeIframeFeedId = feed.id;
-    this.isIdle = false;
-    this.savePrefs();
-    if (this.isVisible) this.render();
+  /** Swap a single grid preview tile into a live iframe in place, leaving sibling streams untouched. */
+  private activateGridCell(feed: WebcamFeed): boolean {
+    const grid = this.content.querySelector('.webcam-grid');
+    if (!grid) return false;
+    const preview = grid.querySelector<HTMLElement>(`.webcam-preview-tile[data-feed-id="${CSS.escape(feed.id)}"]`);
+    const cell = preview?.closest('.webcam-cell') as HTMLElement | null;
+    if (!cell) return false;
+    setTrustedHtml(cell, trustedHtml('', "legacy direct innerHTML migration"));
+    const iframe = this.createIframe(feed);
+    cell.appendChild(iframe);
+    this.iframes.push(iframe);
+    this.trackIframe(iframe, feed, cell);
+    const label = document.createElement('div');
+    label.className = 'webcam-cell-label';
+    setTrustedHtml(label, trustedHtml(`<span class="webcam-live-dot"></span><span class="webcam-city">${escapeHtml(feed.city.toUpperCase())}</span>`, "legacy direct innerHTML migration"));
+    cell.appendChild(label);
+    return true;
   }
 
   private isPanelVisible(): boolean {
@@ -404,15 +420,31 @@ export class LiveWebcamsPanel extends Panel {
       rect.left < window.innerWidth;
   }
 
-  private startAlwaysOnPlaybackIfVisible(): void {
-    if (!this.alwaysOn || document.hidden || !this.element.isConnected || !this.isVisible || this.activeIframeFeedId) return;
-    this.requestPlayback(this.activeFeed, 'settings');
+  private startAlwaysOnPlayback(): void {
+    if (!this.alwaysOn || document.hidden || !this.element.isConnected || !this.isVisible) return;
+    // In grid view auto-start the whole wall; single view auto-starts only the selected feed.
+    const feeds = (this.viewMode === 'grid' && !this.forceSingleView) ? this.gridFeeds : [this.activeFeed];
+    let added = false;
+    for (const feed of feeds) {
+      if (!this.activeIframeFeedIds.has(feed.id)) {
+        this.activeIframeFeedIds.add(feed.id);
+        added = true;
+      }
+    }
+    if (!added) return;
+    this.isIdle = false;
+    this.render();
   }
 
-  private stopPlaybackFromController(reason: LiveMediaStopReason): void {
-    this.resumeFeedAfterIdleId = reason === 'idle' ? this.activeIframeFeedId : null;
-    this.activeIframeFeedId = null;
+  /** Stop and forget every active tile without rebuilding the shell. */
+  private clearActivePlayback(): void {
+    this.activeIframeFeedIds.clear();
     this.destroyIframes();
+  }
+
+  private teardownPlayback(reason: LiveMediaStopReason): void {
+    this.resumeFeedAfterIdleIds = reason === 'idle' ? Array.from(this.activeIframeFeedIds) : [];
+    this.clearActivePlayback();
     // Don't rebuild DOM for a backgrounded tab; the visibility handler re-renders on return.
     if (this.isVisible && !this.isIdle && this.element.isConnected && !document.hidden) {
       this.render();
@@ -446,10 +478,10 @@ export class LiveWebcamsPanel extends Panel {
     playBtn.textContent = t('components.webcams.play') || 'Play';
     playBtn.addEventListener('click', (e) => {
       e.stopPropagation();
-      this.requestPlayback(feed, source);
+      this.playFeed(feed, source);
     });
 
-    preview.addEventListener('click', () => this.requestPlayback(feed, source));
+    preview.addEventListener('click', () => this.playFeed(feed, source));
     preview.append(status, title, meta, playBtn);
     container.appendChild(preview);
   }
@@ -598,7 +630,7 @@ export class LiveWebcamsPanel extends Panel {
       const cell = document.createElement('div');
       cell.className = 'webcam-cell';
 
-      if (this.activeIframeFeedId === feed.id) {
+      if (this.activeIframeFeedIds.has(feed.id)) {
         const iframe = this.createIframe(feed);
         cell.appendChild(iframe);
         this.iframes.push(iframe);
@@ -625,7 +657,7 @@ export class LiveWebcamsPanel extends Panel {
     const wrapper = document.createElement('div');
     wrapper.className = 'webcam-single';
 
-    if (this.activeIframeFeedId === this.activeFeed.id) {
+    if (this.activeIframeFeedIds.has(this.activeFeed.id)) {
       const iframe = this.createIframe(this.activeFeed);
       wrapper.appendChild(iframe);
       this.iframes.push(iframe);
@@ -651,17 +683,16 @@ export class LiveWebcamsPanel extends Panel {
       btn.textContent = feed.city;
       btn.addEventListener('click', () => {
         if (feed.id === this.activeFeed.id) return;
-        if (this.activeIframeFeedId) {
-          stopLiveMediaPlayback('live-webcams', 'replaced');
-        }
+        // Single view shows one feed at a time — switching keeps playing if a stream was active.
+        const wasPlaying = this.activeIframeFeedIds.size > 0;
+        this.activeIframeFeedIds.clear();
         this.activeFeed = feed;
-        this.activeIframeFeedId = null;
         this.savePrefs();
-        if (this.alwaysOn && this.isVisible && !document.hidden) {
-          this.requestPlayback(feed, 'settings');
-          return;
+        if ((this.alwaysOn || wasPlaying) && this.isVisible && !document.hidden) {
+          this.playFeed(feed, 'single');
+        } else {
+          this.render();
         }
-        this.render();
       });
       switcher.appendChild(btn);
     });
@@ -692,13 +723,10 @@ export class LiveWebcamsPanel extends Panel {
         const wasVisible = this.isVisible;
         this.isVisible = entries.some(e => e.isIntersecting);
         if (this.isVisible && !wasVisible && !this.isIdle) {
-          if (this.alwaysOn && !this.activeIframeFeedId) {
-            this.requestPlayback(this.activeFeed, 'settings');
-          } else {
-            this.render();
-          }
+          this.render();
+          if (this.alwaysOn) this.startAlwaysOnPlayback();
         } else if (!this.isVisible && wasVisible) {
-          stopLiveMediaPlayback('live-webcams', 'scroll-away');
+          this.teardownPlayback('scroll-away');
         }
       },
       { threshold: 0.1 }
@@ -718,11 +746,11 @@ export class LiveWebcamsPanel extends Panel {
         });
         this.idleDetectionEnabled = false;
       }
-      this.resumeFeedAfterIdleId = null;
+      this.resumeFeedAfterIdleIds = [];
       if (this.isIdle && !document.hidden) {
         this.isIdle = false;
       }
-      this.startAlwaysOnPlaybackIfVisible();
+      this.startAlwaysOnPlayback();
       return;
     }
 
@@ -742,7 +770,7 @@ export class LiveWebcamsPanel extends Panel {
       if (document.hidden) {
         // Tear down live media when the tab is hidden; the preview shell can resume on return.
         if (this.idleTimeout) clearTimeout(this.idleTimeout);
-        stopLiveMediaPlayback('live-webcams', 'hidden');
+        this.teardownPlayback('hidden');
         return;
       }
 
@@ -763,20 +791,19 @@ export class LiveWebcamsPanel extends Panel {
       if (this.isIdle) {
         this.isIdle = false;
         if (this.isVisible) {
-          const resumeFeed = this.resumeFeedAfterIdleId
-            ? WEBCAM_FEEDS.find(feed => feed.id === this.resumeFeedAfterIdleId)
-            : null;
-          this.resumeFeedAfterIdleId = null;
-          if (resumeFeed) {
-            this.requestPlayback(resumeFeed, 'settings');
-          } else {
-            this.render();
+          // Restore the whole wall that was paused for idle.
+          const resumeIds = this.resumeFeedAfterIdleIds;
+          this.resumeFeedAfterIdleIds = [];
+          for (const id of resumeIds) {
+            if (WEBCAM_FEEDS.some(feed => feed.id === id)) this.activeIframeFeedIds.add(id);
           }
+          this.render();
         }
       }
       this.idleTimeout = setTimeout(() => {
+        // Set isIdle before teardown so teardownPlayback skips its re-render; the placeholder is written below.
         this.isIdle = true;
-        stopLiveMediaPlayback('live-webcams', 'idle');
+        this.teardownPlayback('idle');
         setTrustedHtml(this.content, trustedHtml(`<div class="webcam-placeholder">${escapeHtml(t('components.webcams.pausedIdle'))}</div>`, "legacy direct innerHTML migration"));
       }, ECO_IDLE_PAUSE_MS);
     };
@@ -791,11 +818,9 @@ export class LiveWebcamsPanel extends Panel {
   }
 
   public stopLiveMediaForClose(): void {
-    this.resumeFeedAfterIdleId = null;
+    this.resumeFeedAfterIdleIds = [];
     if (this.idleTimeout) { clearTimeout(this.idleTimeout); this.idleTimeout = null; }
-    stopLiveMediaPlayback('live-webcams', 'destroyed');
-    this.activeIframeFeedId = null;
-    this.destroyIframes();
+    this.clearActivePlayback();
     if (this.isVisible && !this.isIdle && this.element.isConnected) {
       this.render();
     }
@@ -804,14 +829,13 @@ export class LiveWebcamsPanel extends Panel {
   public resumeLiveMediaForShow(): void {
     if (!this.alwaysOn || document.hidden) return;
     this.isVisible = this.isVisible || this.isPanelVisible();
-    this.startAlwaysOnPlaybackIfVisible();
+    this.startAlwaysOnPlayback();
   }
 
   public destroy(): void {
     // Disconnect the IntersectionObserver FIRST so a scroll-driven callback can't
     // re-render / re-create iframes (with leaked ready-timeouts) mid-teardown.
     this.observer?.disconnect();
-    releaseLiveMediaPlayback('live-webcams');
     if (this.idleTimeout) {
       clearTimeout(this.idleTimeout);
       this.idleTimeout = null;

--- a/src/services/live-media-controller.ts
+++ b/src/services/live-media-controller.ts
@@ -5,16 +5,16 @@ export interface ActiveLiveMediaSnapshot {
   streamId: string;
 }
 
-interface LiveMediaPlaybackOptions {
-  exclusive?: boolean;
-}
-
 interface ActiveLiveMedia {
   panelId: string;
   streamId: string;
   stop: (reason: LiveMediaStopReason) => void;
 }
 
+// One entry per panel. A panel that owns a single player (Live News) registers here so
+// switching its stream replaces the previous one. Panels do NOT evict each other: explicitly
+// played feeds coexist (the dashboard "wall"), gated only by user intent. Multi-stream panels
+// (the webcam grid) track their own active set and stay out of this map.
 const activeLiveMedia = new Map<string, ActiveLiveMedia>();
 
 function stopActiveEntry(entry: ActiveLiveMedia, reason: LiveMediaStopReason): void {
@@ -27,23 +27,12 @@ export function requestLiveMediaPlayback(
   streamId: string,
   start: () => void,
   stop: (reason: LiveMediaStopReason) => void,
-  options: LiveMediaPlaybackOptions = {},
 ): void {
-  const exclusive = options.exclusive ?? true;
   const currentPanel = activeLiveMedia.get(panelId);
   if (currentPanel && currentPanel.streamId !== streamId) {
     stopActiveEntry(currentPanel, 'replaced');
   }
 
-  if (exclusive) {
-    for (const entry of Array.from(activeLiveMedia.values())) {
-      if (entry.panelId !== panelId) {
-        stopActiveEntry(entry, 'replaced');
-      }
-    }
-  }
-
-  activeLiveMedia.delete(panelId);
   activeLiveMedia.set(panelId, { panelId, streamId, stop });
   start();
 }
@@ -59,20 +48,6 @@ export function releaseLiveMediaPlayback(panelId: string, streamId?: string): vo
   if (!current) return;
   if (streamId && current.streamId !== streamId) return;
   activeLiveMedia.delete(panelId);
-}
-
-export function enforceExclusiveLiveMediaPlayback(preferredPanelId?: string): void {
-  const entries = Array.from(activeLiveMedia.values());
-  const latestEntry = entries[entries.length - 1];
-  const keepPanelId = preferredPanelId && activeLiveMedia.has(preferredPanelId)
-    ? preferredPanelId
-    : latestEntry?.panelId;
-  if (!keepPanelId) return;
-
-  for (const entry of entries) {
-    if (entry.panelId === keepPanelId) continue;
-    stopActiveEntry(entry, 'replaced');
-  }
 }
 
 export function getActiveLiveMedia(panelId?: string): ActiveLiveMediaSnapshot | null {

--- a/tests/live-media-controller.test.mts
+++ b/tests/live-media-controller.test.mts
@@ -2,7 +2,6 @@ import { afterEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
-  enforceExclusiveLiveMediaPlayback,
   getActiveLiveMedia,
   releaseLiveMediaPlayback,
   requestLiveMediaPlayback,
@@ -15,7 +14,7 @@ describe('live media controller', () => {
     stopLiveMediaPlayback('live-webcams', 'destroyed');
   });
 
-  it('starts one stream and stops the previous stream when another begins', () => {
+  it('lets different panels play at the same time (no cross-panel eviction)', () => {
     const events: string[] = [];
 
     requestLiveMediaPlayback(
@@ -24,12 +23,6 @@ describe('live media controller', () => {
       () => events.push('start:live-news:bbc-news'),
       (reason) => events.push(`stop:live-news:${reason}`),
     );
-
-    assert.deepEqual(getActiveLiveMedia(), {
-      panelId: 'live-news',
-      streamId: 'bbc-news',
-    });
-
     requestLiveMediaPlayback(
       'live-webcams',
       'jerusalem',
@@ -37,18 +30,49 @@ describe('live media controller', () => {
       (reason) => events.push(`stop:live-webcams:${reason}`),
     );
 
+    // Starting webcams must NOT stop live-news — explicitly played feeds coexist.
     assert.deepEqual(events, [
       'start:live-news:bbc-news',
-      'stop:live-news:replaced',
       'start:live-webcams:jerusalem',
     ]);
-    assert.deepEqual(getActiveLiveMedia(), {
+    assert.deepEqual(getActiveLiveMedia('live-news'), {
+      panelId: 'live-news',
+      streamId: 'bbc-news',
+    });
+    assert.deepEqual(getActiveLiveMedia('live-webcams'), {
       panelId: 'live-webcams',
       streamId: 'jerusalem',
     });
   });
 
-  it('stops only the active panel and releases without firing stop callbacks', () => {
+  it('replaces the previous stream within the same panel (single-player switch)', () => {
+    const events: string[] = [];
+
+    requestLiveMediaPlayback(
+      'live-news',
+      'bbc-news',
+      () => events.push('start:live-news:bbc-news'),
+      (reason) => events.push(`stop:live-news:${reason}`),
+    );
+    requestLiveMediaPlayback(
+      'live-news',
+      'sky-news',
+      () => events.push('start:live-news:sky-news'),
+      (reason) => events.push(`stop:live-news:${reason}`),
+    );
+
+    assert.deepEqual(events, [
+      'start:live-news:bbc-news',
+      'stop:live-news:replaced',
+      'start:live-news:sky-news',
+    ]);
+    assert.deepEqual(getActiveLiveMedia('live-news'), {
+      panelId: 'live-news',
+      streamId: 'sky-news',
+    });
+  });
+
+  it('stops only the targeted panel and releases without firing stop callbacks', () => {
     const events: string[] = [];
 
     requestLiveMediaPlayback(
@@ -57,136 +81,48 @@ describe('live media controller', () => {
       () => events.push('start:live-news:sky-news'),
       (reason) => events.push(`stop:live-news:${reason}`),
     );
+    requestLiveMediaPlayback(
+      'live-webcams',
+      'jerusalem',
+      () => events.push('start:live-webcams:jerusalem'),
+      (reason) => events.push(`stop:live-webcams:${reason}`),
+    );
 
     stopLiveMediaPlayback('live-webcams', 'user-paused');
-    assert.deepEqual(getActiveLiveMedia(), {
+    assert.equal(getActiveLiveMedia('live-webcams'), null);
+    assert.deepEqual(getActiveLiveMedia('live-news'), {
       panelId: 'live-news',
       streamId: 'sky-news',
     });
-    assert.deepEqual(events, ['start:live-news:sky-news']);
+    assert.deepEqual(events, [
+      'start:live-news:sky-news',
+      'start:live-webcams:jerusalem',
+      'stop:live-webcams:user-paused',
+    ]);
 
     releaseLiveMediaPlayback('live-news', 'sky-news');
-    assert.equal(getActiveLiveMedia(), null);
-    assert.deepEqual(events, ['start:live-news:sky-news']);
-  });
-
-  it('can opt out of cross-panel replacement for always-on playback', () => {
-    const events: string[] = [];
-
-    requestLiveMediaPlayback(
-      'live-news',
-      'bloomberg',
-      () => events.push('start:live-news:bloomberg'),
-      (reason) => events.push(`stop:live-news:${reason}`),
-      { exclusive: false },
-    );
-    requestLiveMediaPlayback(
-      'live-webcams',
-      'jerusalem',
-      () => events.push('start:live-webcams:jerusalem'),
-      (reason) => events.push(`stop:live-webcams:${reason}`),
-      { exclusive: false },
-    );
-
-    assert.deepEqual(getActiveLiveMedia('live-news'), {
-      panelId: 'live-news',
-      streamId: 'bloomberg',
-    });
-    assert.deepEqual(getActiveLiveMedia('live-webcams'), {
-      panelId: 'live-webcams',
-      streamId: 'jerusalem',
-    });
-    assert.deepEqual(events, [
-      'start:live-news:bloomberg',
-      'start:live-webcams:jerusalem',
-    ]);
-  });
-
-  it('keeps the preferred panel (live-news) after always-on is disabled, regardless of insertion order', () => {
-    const events: string[] = [];
-
-    // Webcams registered FIRST, news SECOND. Without a preference the no-arg form
-    // keeps the last-inserted entry (webcams). The panels pass 'live-news', so the
-    // surviving stream is deterministic instead of insertion-order dependent.
-    requestLiveMediaPlayback(
-      'live-webcams',
-      'jerusalem',
-      () => events.push('start:live-webcams:jerusalem'),
-      (reason) => events.push(`stop:live-webcams:${reason}`),
-      { exclusive: false },
-    );
-    requestLiveMediaPlayback(
-      'live-news',
-      'bloomberg',
-      () => events.push('start:live-news:bloomberg'),
-      (reason) => events.push(`stop:live-news:${reason}`),
-      { exclusive: false },
-    );
-
-    enforceExclusiveLiveMediaPlayback('live-news');
-
-    assert.deepEqual(getActiveLiveMedia('live-news'), {
-      panelId: 'live-news',
-      streamId: 'bloomberg',
-    });
-    assert.equal(getActiveLiveMedia('live-webcams'), null);
-    assert.deepEqual(events, [
-      'start:live-webcams:jerusalem',
-      'start:live-news:bloomberg',
-      'stop:live-webcams:replaced',
-    ]);
-  });
-
-  it('falls back to keeping the latest stream when the preferred panel is not active', () => {
-    const events: string[] = [];
-
-    requestLiveMediaPlayback(
-      'live-webcams',
-      'jerusalem',
-      () => events.push('start:live-webcams:jerusalem'),
-      (reason) => events.push(`stop:live-webcams:${reason}`),
-      { exclusive: false },
-    );
-
-    // 'live-news' is not active, so the preference is ignored and webcams survives.
-    enforceExclusiveLiveMediaPlayback('live-news');
-
-    assert.deepEqual(getActiveLiveMedia('live-webcams'), {
-      panelId: 'live-webcams',
-      streamId: 'jerusalem',
-    });
-    assert.deepEqual(events, ['start:live-webcams:jerusalem']);
-  });
-
-  it('keeps the most recently requested stream after always-on mode is disabled', () => {
-    const events: string[] = [];
-
-    requestLiveMediaPlayback(
-      'live-news',
-      'bloomberg',
-      () => events.push('start:live-news:bloomberg'),
-      (reason) => events.push(`stop:live-news:${reason}`),
-      { exclusive: false },
-    );
-    requestLiveMediaPlayback(
-      'live-webcams',
-      'jerusalem',
-      () => events.push('start:live-webcams:jerusalem'),
-      (reason) => events.push(`stop:live-webcams:${reason}`),
-      { exclusive: false },
-    );
-
-    enforceExclusiveLiveMediaPlayback();
-
     assert.equal(getActiveLiveMedia('live-news'), null);
-    assert.deepEqual(getActiveLiveMedia('live-webcams'), {
-      panelId: 'live-webcams',
-      streamId: 'jerusalem',
-    });
     assert.deepEqual(events, [
-      'start:live-news:bloomberg',
+      'start:live-news:sky-news',
       'start:live-webcams:jerusalem',
-      'stop:live-news:replaced',
+      'stop:live-webcams:user-paused',
     ]);
+  });
+
+  it('release is a no-op when the streamId does not match the active stream', () => {
+    const events: string[] = [];
+
+    requestLiveMediaPlayback(
+      'live-news',
+      'bloomberg',
+      () => events.push('start:live-news:bloomberg'),
+      (reason) => events.push(`stop:live-news:${reason}`),
+    );
+
+    releaseLiveMediaPlayback('live-news', 'sky-news');
+    assert.deepEqual(getActiveLiveMedia('live-news'), {
+      panelId: 'live-news',
+      streamId: 'bloomberg',
+    });
   });
 });


### PR DESCRIPTION
## Problem

PR #4341 (issue #4334) gated live media on user intent — correct — but in doing so collapsed the dashboard to a **single active stream**: clicking **Play** on a webcam tile tore down every other feed *and* Live News, and the webcam grid (previously a multi-camera **wall**, up to 4 live tiles) could only ever show one live cam in any mode.

That contradicts the intent. The gate should only **defer** media load until the user clicks; once clicked, each played feed should run **alongside** the others.

### Root cause (two compounding mechanisms)
1. **Webcam grid lost its wall.** Pre-#4341 `renderGrid()` created a live `<iframe>` for *every* tile. Post-#4341 the panel tracked a single `activeIframeFeedId`, so only one tile could be live; clicking another *replaced* it.
2. **Cross-panel exclusivity.** `requestLiveMediaPlayback` defaulted to `exclusive: true` (`!alwaysOn`), so any Play also evicted the *other* panel — webcam Play killed Live News and vice-versa.

Both were locked in by the new tests (e2e title *"…keeps one active stream"*; controller test *"stops the previous stream when another begins"*; webcam-play asserted `liveNews → 0`).

## Fix (full-wall model)

The gate stays (0 iframes on load); after intent, explicitly-played feeds coexist.

- **`live-media-controller.ts`** — removed cross-panel exclusivity + `enforceExclusiveLiveMediaPlayback`. Panels no longer evict each other. Kept the per-panel same-stream replace (Live News relies on it for channel switching — it's a single player).
- **`LiveWebcamsPanel.ts`** — `activeIframeFeedId: string|null` → `activeIframeFeedIds: Set<string>`. Each tile's Play now surgically swaps just that grid cell into a live iframe (`activateGridCell`), leaving sibling streams playing. Scroll-away / hidden-tab / idle / panel-close still tear down the whole wall, and idle-resume restores it. Always-on auto-starts the full grid wall on visibility; single view and mobile `forceSingleView` stay one-at-a-time.
- **`LiveNewsPanel.ts`** — stopped requesting exclusive playback; leaving always-on no longer collapses other feeds (eco-idle pauses them later instead). Live News internals otherwise untouched.

## Tests

- Rewrote `tests/live-media-controller.test.mts` for coexistence + same-panel replace.
- Rewrote `e2e/live-media-intent.spec.ts`: the gating test now asserts **Live News + 2 webcam tiles run simultaneously** as a wall, and that leaving always-on keeps already-playing feeds running.

## Validation — all green

- `tsc --noEmit` ✅ · Biome lint ✅ · safe-html ✅
- controller unit 4/4 ✅ · live-news-hls 49/49 ✅ · **Playwright e2e 9/9** ✅

https://claude.ai/code/session_016ycJg3miJiDfzw6JHGtAvX