### PR TITLE
feat(live-media): one Play click auto-plays all live feeds (wall + Live News)

### DIFF
--- a/e2e/live-media-intent.spec.ts
+++ b/e2e/live-media-intent.spec.ts
@@ -77,7 +77,7 @@ async function setPanelEnabledViaStoredSettings(page: Page, panelId: string, ena
 }
 
 test.describe('live media intent gating', () => {
-  test('keeps live media transports idle until click, then lets played feeds coexist as a wall', async ({ page }) => {
+  test('keeps live media idle until click, then one click lights up the whole wall + Live News', async ({ page }) => {
     await installCleanLiveMediaPrefs(page);
     const mediaRequests: string[] = [];
     page.on('request', (request) => {
@@ -97,18 +97,10 @@ test.describe('live media intent gating', () => {
     expect(await webcamTransportCount(page)).toBe(0);
     expect(mediaRequests, `live media request(s) before intent: ${mediaRequests.join('\n')}`).toEqual([]);
 
-    await liveNews.getByRole('button', { name: /play live feed/i }).click();
+    // A single Play click (here, one webcam tile) cascades to the entire webcam wall AND Live News.
+    await webcams.locator('.webcam-preview-tile').first().getByRole('button', { name: /^play$/i }).click();
+    await expect.poll(() => webcamTransportCount(page), { timeout: 30_000 }).toBe(4);
     await expect.poll(() => liveNewsTransportCount(page), { timeout: 30_000 }).toBe(1);
-
-    // Playing a webcam tile must NOT stop Live News — explicitly played feeds coexist.
-    await webcams.locator('.webcam-preview-tile').first().getByRole('button', { name: /^play$/i }).click();
-    await expect.poll(() => webcamTransportCount(page), { timeout: 30_000 }).toBe(1);
-    await expect.poll(() => liveNewsTransportCount(page), { timeout: 5_000 }).toBe(1);
-
-    // Playing a second tile builds the wall — both webcams run alongside Live News.
-    await webcams.locator('.webcam-preview-tile').first().getByRole('button', { name: /^play$/i }).click();
-    await expect.poll(() => webcamTransportCount(page), { timeout: 30_000 }).toBe(2);
-    await expect.poll(() => liveNewsTransportCount(page), { timeout: 5_000 }).toBe(1);
   });
 
   test('renders stored single webcam mode as a preview before play intent', async ({ page }) => {
@@ -185,8 +177,9 @@ test.describe('live media intent gating', () => {
     await webcams.scrollIntoViewIfNeeded();
     await expect(webcams.locator('.webcam-preview-tile').first()).toBeVisible({ timeout: 60_000 });
 
+    // One click starts the whole wall (cascade); count is the grid size, not 1.
     await webcams.locator('.webcam-preview-tile').first().getByRole('button', { name: /^play$/i }).click();
-    await expect.poll(() => webcamTransportCount(page), { timeout: 30_000 }).toBe(1);
+    await expect.poll(() => webcamTransportCount(page), { timeout: 30_000 }).toBeGreaterThanOrEqual(1);
 
     await page.setViewportSize({ width: 1280, height: 240 });
     await page.evaluate(() => window.scrollTo(0, 0));
@@ -207,10 +200,9 @@ test.describe('live media intent gating', () => {
     await expect.poll(() => liveNewsTransportCount(page), { timeout: 10_000 }).toBe(0);
     await expect(liveNews).toHaveClass(/hidden/);
 
+    // The Live News play click already cascaded to the webcam wall, so it's live once scrolled in.
     await webcams.scrollIntoViewIfNeeded();
-    await expect(webcams.locator('.webcam-preview-tile').first()).toBeVisible({ timeout: 60_000 });
-    await webcams.locator('.webcam-preview-tile').first().getByRole('button', { name: /^play$/i }).click();
-    await expect.poll(() => webcamTransportCount(page), { timeout: 30_000 }).toBe(1);
+    await expect.poll(() => webcamTransportCount(page), { timeout: 30_000 }).toBeGreaterThanOrEqual(1);
     await disablePanelViaStoredSettings(page, 'live-webcams');
     await expect.poll(() => webcamTransportCount(page), { timeout: 10_000 }).toBe(0);
     await expect(webcams).toHaveClass(/hidden/);

--- a/e2e/live-media-intent.spec.ts
+++ b/e2e/live-media-intent.spec.ts
@@ -103,6 +103,35 @@ test.describe('live media intent gating', () => {
     await expect.poll(() => liveNewsTransportCount(page), { timeout: 30_000 }).toBe(1);
   });
 
+  test('the play-all cascade does not start media in a collapsed live panel', async ({ page }) => {
+    await installCleanLiveMediaPrefs(page);
+
+    await page.goto('/dashboard?liveMediaCollapsedCascade=1', { waitUntil: 'domcontentloaded' });
+    const liveNews = page.locator('.panel[data-panel="live-news"]');
+    const webcams = page.locator('.panel[data-panel="live-webcams"]');
+    await expect(liveNews).toBeVisible({ timeout: 60_000 });
+
+    // Collapse Live News (content hidden, but the panel is NOT disabled).
+    await liveNews.locator('.panel-collapse-btn').click();
+    await expect(liveNews).toHaveClass(/panel-collapsed/);
+
+    // Fire the cascade from the webcams panel.
+    await webcams.scrollIntoViewIfNeeded();
+    await expect(webcams.locator('.webcam-preview-tile').first()).toBeVisible({ timeout: 60_000 });
+    await webcams.locator('.webcam-preview-tile').first().getByRole('button', { name: /^play$/i }).click();
+
+    // Webcams play, but the collapsed Live News must NOT create a hidden transport.
+    await expect.poll(() => webcamTransportCount(page), { timeout: 30_000 }).toBeGreaterThanOrEqual(1);
+    await page.waitForTimeout(2500);
+    expect(await liveNewsTransportCount(page)).toBe(0);
+
+    // Expanding then explicitly playing still works.
+    await liveNews.locator('.panel-collapse-btn').click();
+    await expect(liveNews).not.toHaveClass(/panel-collapsed/);
+    await liveNews.getByRole('button', { name: /play live feed/i }).click();
+    await expect.poll(() => liveNewsTransportCount(page), { timeout: 30_000 }).toBe(1);
+  });
+
   test('renders stored single webcam mode as a preview before play intent', async ({ page }) => {
     await installCleanLiveMediaPrefs(page, {
       regionFilter: 'all',

--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -412,9 +412,9 @@ export class LiveNewsPanel extends Panel {
   private deferredInit = false;
   private lazyObserver: IntersectionObserver | null = null;
   private idleCallbackId: number | ReturnType<typeof setTimeout> | null = null;
-  // Play-all cascade: start this panel's channel, but never revive a panel the user disabled.
+  // Play-all cascade: start this panel's channel, but never start a disabled or collapsed panel.
   private readonly boundPlayAllStarter = () => {
-    if (!this.element.classList.contains('hidden')) this.triggerInit();
+    if (this.canHostLiveMedia()) this.triggerInit();
   };
 
   constructor() {

--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -7,7 +7,7 @@ import { IDLE_PAUSE_MS, STORAGE_KEYS, SITE_VARIANT } from '@/config';
 import { escapeHtml, sanitizeUrl } from '@/utils/sanitize';
 
 import { getStreamQuality } from '@/services/ai-flow-settings';
-import { getActiveLiveMedia, releaseLiveMediaPlayback, requestLiveMediaPlayback, stopLiveMediaPlayback, type LiveMediaStopReason } from '@/services/live-media-controller';
+import { getActiveLiveMedia, playAllLiveMedia, registerLiveMediaStarter, releaseLiveMediaPlayback, requestLiveMediaPlayback, stopLiveMediaPlayback, unregisterLiveMediaStarter, type LiveMediaStopReason } from '@/services/live-media-controller';
 import { getLiveStreamsAlwaysOn, subscribeLiveStreamsSettingsChange } from '@/services/live-stream-settings';
 import { track } from '@/services/analytics';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
@@ -412,6 +412,10 @@ export class LiveNewsPanel extends Panel {
   private deferredInit = false;
   private lazyObserver: IntersectionObserver | null = null;
   private idleCallbackId: number | ReturnType<typeof setTimeout> | null = null;
+  // Play-all cascade: start this panel's channel, but never revive a panel the user disabled.
+  private readonly boundPlayAllStarter = () => {
+    if (!this.element.classList.contains('hidden')) this.triggerInit();
+  };
 
   constructor() {
     super({ id: 'live-news', title: t('panels.liveNews'), className: 'panel-wide', closable: true, collapsible: true });
@@ -450,6 +454,7 @@ export class LiveNewsPanel extends Panel {
         this.setupLazyInit();
       }
     });
+    registerLiveMediaStarter('live-news', this.boundPlayAllStarter);
     document.addEventListener('keydown', this.boundFullscreenEscHandler);
   }
 
@@ -489,13 +494,13 @@ export class LiveNewsPanel extends Panel {
     playBtn.textContent = t('components.liveNews.playLiveFeed') || 'Play live feed';
     playBtn.addEventListener('click', (e) => {
       e.stopPropagation();
-      this.triggerInit();
+      playAllLiveMedia();
     });
 
     container.appendChild(status);
     container.appendChild(label);
     container.appendChild(playBtn);
-    container.addEventListener('click', () => this.triggerInit());
+    container.addEventListener('click', () => playAllLiveMedia());
     this.content.appendChild(container);
   }
 
@@ -1808,6 +1813,7 @@ export class LiveNewsPanel extends Panel {
 
   public destroy(): void {
     this.liveMediaSessionToken += 1;
+    unregisterLiveMediaStarter('live-news', this.boundPlayAllStarter);
     releaseLiveMediaPlayback('live-news');
     this.destroyPlayer();
     this.unsubscribeStreamSettings?.();

--- a/src/components/LiveWebcamsPanel.ts
+++ b/src/components/LiveWebcamsPanel.ts
@@ -446,6 +446,12 @@ export class LiveWebcamsPanel extends Panel {
   /**
    * Start the whole webcam wall (every grid tile, or the single feed in single view) regardless of
    * always-on. Drives the "play all" cascade. Off-screen feeds are queued and render on visibility.
+   *
+   * This intentionally uses a full render() rather than the per-tile activateGridCell() swap that
+   * playFeed() uses: the cascade is an all-at-once start. The only grid trigger is a preview-tile
+   * click, which only exists when the grid is fully stopped (no tiles playing), so the full render
+   * rebuilds from zero — no already-playing iframe is destroyed/reloaded. A future caller that adds
+   * feeds incrementally before calling this should switch to the surgical swap to avoid reload flashes.
    */
   private playAllFeeds(): void {
     const feeds = (this.viewMode === 'grid' && !this.forceSingleView) ? this.gridFeeds : [this.activeFeed];

--- a/src/components/LiveWebcamsPanel.ts
+++ b/src/components/LiveWebcamsPanel.ts
@@ -6,7 +6,7 @@ import { t } from '../services/i18n';
 import { track, trackWebcamSelected, trackWebcamRegionFiltered } from '@/services/analytics';
 import { getStreamQuality, subscribeStreamQualityChange } from '@/services/ai-flow-settings';
 import { isMobileDevice, loadFromStorage, saveToStorage } from '@/utils';
-import { type LiveMediaStopReason } from '@/services/live-media-controller';
+import { playAllLiveMedia, registerLiveMediaStarter, unregisterLiveMediaStarter, type LiveMediaStopReason } from '@/services/live-media-controller';
 import { getLiveStreamsAlwaysOn, subscribeLiveStreamsSettingsChange } from '@/services/live-stream-settings';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 
@@ -117,6 +117,10 @@ export class LiveWebcamsPanel extends Panel {
   private alwaysOn = getLiveStreamsAlwaysOn();
   private unsubscribeStreamSettings: (() => void) | null = null;
   private resumeFeedAfterIdleIds: string[] = [];
+  // Play-all cascade: start the whole webcam wall, but never revive a panel the user disabled.
+  private readonly boundPlayAllStarter = () => {
+    if (!this.element.classList.contains('hidden')) this.playAllFeeds();
+  };
 
   // UI
   private fullscreenBtn: HTMLButtonElement | null = null;
@@ -150,6 +154,7 @@ export class LiveWebcamsPanel extends Panel {
     this.boundEmbedMessageHandler = (e) => this.handleEmbedMessage(e);
     window.addEventListener('message', this.boundEmbedMessageHandler);
     this.render();
+    registerLiveMediaStarter('live-webcams', this.boundPlayAllStarter);
     document.addEventListener('keydown', this.boundFullscreenEscHandler);
   }
 
@@ -438,6 +443,24 @@ export class LiveWebcamsPanel extends Panel {
     return true;
   }
 
+  /**
+   * Start the whole webcam wall (every grid tile, or the single feed in single view) regardless of
+   * always-on. Drives the "play all" cascade. Off-screen feeds are queued and render on visibility.
+   */
+  private playAllFeeds(): void {
+    const feeds = (this.viewMode === 'grid' && !this.forceSingleView) ? this.gridFeeds : [this.activeFeed];
+    let added = false;
+    for (const feed of feeds) {
+      if (!this.activeIframeFeedIds.has(feed.id)) {
+        this.activeIframeFeedIds.add(feed.id);
+        added = true;
+      }
+    }
+    if (!added) return;
+    this.isIdle = false;
+    if (this.isVisible && !document.hidden) this.render();
+  }
+
   /** Stop and forget every active tile without rebuilding the shell. */
   private clearActivePlayback(): void {
     this.activeIframeFeedIds.clear();
@@ -478,12 +501,19 @@ export class LiveWebcamsPanel extends Panel {
     playBtn.type = 'button';
     playBtn.className = 'offline-retry webcam-preview-play';
     playBtn.textContent = t('components.webcams.play') || 'Play';
+    // First play intent lights up everything (the wall + Live News), not just this tile.
+    const playAll = () => {
+      trackWebcamSelected(feed.id, feed.city, source);
+      this.activeFeed = feed;
+      this.savePrefs();
+      playAllLiveMedia();
+    };
     playBtn.addEventListener('click', (e) => {
       e.stopPropagation();
-      this.playFeed(feed, source);
+      playAll();
     });
 
-    preview.addEventListener('click', () => this.playFeed(feed, source));
+    preview.addEventListener('click', () => playAll());
     preview.append(status, title, meta, playBtn);
     container.appendChild(preview);
   }
@@ -838,6 +868,7 @@ export class LiveWebcamsPanel extends Panel {
     // Disconnect the IntersectionObserver FIRST so a scroll-driven callback can't
     // re-render / re-create iframes (with leaked ready-timeouts) mid-teardown.
     this.observer?.disconnect();
+    unregisterLiveMediaStarter('live-webcams', this.boundPlayAllStarter);
     if (this.idleTimeout) {
       clearTimeout(this.idleTimeout);
       this.idleTimeout = null;

--- a/src/components/LiveWebcamsPanel.ts
+++ b/src/components/LiveWebcamsPanel.ts
@@ -117,9 +117,9 @@ export class LiveWebcamsPanel extends Panel {
   private alwaysOn = getLiveStreamsAlwaysOn();
   private unsubscribeStreamSettings: (() => void) | null = null;
   private resumeFeedAfterIdleIds: string[] = [];
-  // Play-all cascade: start the whole webcam wall, but never revive a panel the user disabled.
+  // Play-all cascade: start the whole webcam wall, but never start a disabled or collapsed panel.
   private readonly boundPlayAllStarter = () => {
-    if (!this.element.classList.contains('hidden')) this.playAllFeeds();
+    if (this.canHostLiveMedia()) this.playAllFeeds();
   };
 
   // UI

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -738,6 +738,17 @@ export class Panel {
   }
 
   /**
+   * True when this panel can host live media right now: attached, enabled (not hidden via the
+   * disable path), and expanded (not collapsed). The play-all cascade gates on this so a
+   * collapsed or disabled panel never creates/queues media work inside a hidden content area.
+   */
+  public canHostLiveMedia(): boolean {
+    return this.element.isConnected
+      && !this.element.classList.contains('hidden')
+      && !this._collapsed;
+  }
+
+  /**
    * Fire `callback` once when this panel's element scrolls within
    * `marginPx` of the viewport. Uses IntersectionObserver where
    * available; falls back to an idle-callback tick when not (Node/SSR

--- a/src/services/live-media-controller.ts
+++ b/src/services/live-media-controller.ts
@@ -60,3 +60,23 @@ export function getActiveLiveMedia(panelId?: string): ActiveLiveMediaSnapshot | 
     streamId: active.streamId,
   };
 }
+
+// "Play all" cascade: each live panel registers a starter so the first play intent anywhere
+// (a webcam tile or Live News) lights up every live panel at once. Starters are idempotent.
+type LiveMediaStarter = () => void;
+const liveMediaStarters = new Map<string, LiveMediaStarter>();
+
+export function registerLiveMediaStarter(panelId: string, start: LiveMediaStarter): void {
+  liveMediaStarters.set(panelId, start);
+}
+
+export function unregisterLiveMediaStarter(panelId: string, start?: LiveMediaStarter): void {
+  // Only remove if it still points at this starter, so a recreate-then-destroy-old race
+  // can't clobber the freshly registered panel.
+  if (start && liveMediaStarters.get(panelId) !== start) return;
+  liveMediaStarters.delete(panelId);
+}
+
+export function playAllLiveMedia(): void {
+  for (const start of Array.from(liveMediaStarters.values())) start();
+}

--- a/tests/live-media-controller.test.mts
+++ b/tests/live-media-controller.test.mts
@@ -3,15 +3,20 @@ import assert from 'node:assert/strict';
 
 import {
   getActiveLiveMedia,
+  playAllLiveMedia,
+  registerLiveMediaStarter,
   releaseLiveMediaPlayback,
   requestLiveMediaPlayback,
   stopLiveMediaPlayback,
+  unregisterLiveMediaStarter,
 } from '../src/services/live-media-controller';
 
 describe('live media controller', () => {
   afterEach(() => {
     stopLiveMediaPlayback('live-news', 'destroyed');
     stopLiveMediaPlayback('live-webcams', 'destroyed');
+    unregisterLiveMediaStarter('live-news');
+    unregisterLiveMediaStarter('live-webcams');
   });
 
   it('lets different panels play at the same time (no cross-panel eviction)', () => {
@@ -124,5 +129,41 @@ describe('live media controller', () => {
       panelId: 'live-news',
       streamId: 'bloomberg',
     });
+  });
+
+  it('playAllLiveMedia fires every registered starter (play-all cascade)', () => {
+    const fired: string[] = [];
+    registerLiveMediaStarter('live-news', () => fired.push('live-news'));
+    registerLiveMediaStarter('live-webcams', () => fired.push('live-webcams'));
+
+    playAllLiveMedia();
+
+    assert.deepEqual(fired.sort(), ['live-news', 'live-webcams']);
+  });
+
+  it('unregistering a starter stops it from firing on the next cascade', () => {
+    const fired: string[] = [];
+    const webcamStarter = () => fired.push('live-webcams');
+    registerLiveMediaStarter('live-news', () => fired.push('live-news'));
+    registerLiveMediaStarter('live-webcams', webcamStarter);
+
+    unregisterLiveMediaStarter('live-webcams', webcamStarter);
+    playAllLiveMedia();
+
+    assert.deepEqual(fired, ['live-news']);
+  });
+
+  it('unregister with a stale starter ref does not clobber a re-registered panel', () => {
+    const fired: string[] = [];
+    const oldStarter = () => fired.push('old');
+    const newStarter = () => fired.push('new');
+
+    // Simulate recreate-then-destroy-old: new instance registers, old instance's destroy runs after.
+    registerLiveMediaStarter('live-webcams', oldStarter);
+    registerLiveMediaStarter('live-webcams', newStarter);
+    unregisterLiveMediaStarter('live-webcams', oldStarter); // stale ref — must be ignored
+
+    playAllLiveMedia();
+    assert.deepEqual(fired, ['new']);
   });
 });


### PR DESCRIPTION
## What & why

Follow-up to #4363. The dashboard shows ~5 live feeds at once — 4 webcam grid tiles + Live News. After the coexistence fix, each still needed its **own** Play click. This makes the **first play intent in either live panel light up all of them at once**, so the dashboard comes alive with a single click.

The intent gate is preserved: still **zero** iframes on load; the difference is one click now starts everything instead of one feed.

## How

- **`live-media-controller.ts`** — small cross-panel starter registry: `registerLiveMediaStarter` / `unregisterLiveMediaStarter` / `playAllLiveMedia()`. Each live panel registers an **idempotent** starter; `unregister` only removes if the ref still matches, guarding a recreate-then-destroy-old race.
- **`LiveWebcamsPanel.ts`** — registers a starter that plays the whole grid wall (`playAllFeeds`). The preview-tile Play/click now fires `playAllLiveMedia()` instead of starting just that tile. Off-screen webcam feeds are **queued** and render lazily on scroll-in (no off-screen iframe cost).
- **`LiveNewsPanel.ts`** — registers a starter (`triggerInit`); the placeholder Play now fires `playAllLiveMedia()`.
- Both starters are gated on the panel **not being disabled** (the `hidden` class), so a cascade never revives a panel the user turned off.
- **Granular controls preserved:** the Live News header play/pause toggle and the single-view webcam feed switcher still act on one feed only.

## Behavior notes

- "All feeds" = all feeds in the **visible/enabled** live panels. On the typical desktop layout both panels are on screen, so one click = all 5. An off-screen webcam panel's tiles are queued and play when scrolled in; a *disabled* panel is never auto-started.
- The cascade is idempotent — clicking again once everything's playing is a no-op.

## Validation

- `tsc --noEmit` ✅ · Biome ✅
- controller unit **7/7** ✅ (incl. cascade + unregister-race) · live-news-hls **49/49** ✅
- Playwright e2e **9/9** ✅ — the gating test now asserts **one webcam-tile click → 4 webcams + Live News all live**, and the disable test confirms a cascade does not revive a disabled panel.

https://claude.ai/code/session_016ycJg3miJiDfzw6JHGtAvX