### PR TITLE
docs: sweep missing dirs, gate panelClasses count in CI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,16 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 155
 .
 ├── src/                    # Browser SPA (TypeScript, class-based components)
 │   ├── app/                # App orchestration (data-loader, refresh-scheduler, panel-layout)
+│   ├── bootstrap/          # Startup/recovery (chunk reload, deferred Sentry, SW update)
 │   ├── components/         # 155 top-level TypeScript component files
 │   ├── config/             # Variant configs, panel/layer definitions, market symbols
 │   ├── services/           # Business logic (186 service modules and domain directories)
+│   ├── shared/             # Cross-cutting helpers (premium paths, registries, staleness)
+│   ├── embed/              # Embeddable widget loader
+│   ├── styles/             # Global CSS (layers, themes, panel styles)
+│   ├── shims/              # Runtime shims (child-process for sidecar)
+│   ├── data/               # Static JSON datasets (conservation, renewable, happiness)
+│   ├── e2e/                # Map test harnesses (consumed by Playwright specs)
 │   ├── types/              # TypeScript type definitions
 │   ├── utils/              # Shared utilities (circuit-breaker, theme, URL state, DOM)
 │   ├── workers/            # Web Workers (analysis, ML/ONNX, vector DB)
@@ -35,14 +42,19 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 155
 │   ├── buf.yaml            # Buf configuration
 │   └── worldmonitor/       # Service definitions with HTTP annotations
 ├── shared/                 # Cross-platform data (JSON configs for markets, RSS domains)
+├── data/                   # Static data (telegram channels, OREF translations, gamma irradiators)
+├── public/                 # Static assets served as-is (favicons, textures, .well-known, llms.txt)
 ├── scripts/                # Seed scripts, build helpers, data fetchers
 ├── src-tauri/              # Tauri desktop shell (Rust + Node.js sidecar)
 │   └── sidecar/            # Node.js sidecar API server
+├── consumer-prices-core/   # Consumer-price scrapers (Playwright, per-country baskets; Railway/Docker)
+├── workers/                # Cloudflare Workers (edge CORS preflight for api.worldmonitor.app)
 ├── tests/                  # Unit/integration tests (node:test runner)
 ├── e2e/                    # Playwright E2E specs
+├── pro-test/               # Standalone Pro QA app (separate package)
 ├── docs/                   # Mintlify documentation site
 ├── docker/                 # Docker build for Railway services
-├── deploy/                 # Deployment configs
+├── deploy/                 # Deployment configs (nginx)
 └── blog-site/              # Static blog (built into public/blog/)
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 155
 │   ├── buf.yaml            # Buf configuration
 │   └── worldmonitor/       # Service definitions with HTTP annotations
 ├── shared/                 # Cross-platform data (JSON configs for markets, RSS domains)
-├── data/                   # Static data (telegram channels, OREF translations, gamma irradiators)
+├── data/                   # Static data (telegram channels, OREF threat translations, gamma irradiators)
 ├── public/                 # Static assets served as-is (favicons, textures, .well-known, llms.txt)
 ├── scripts/                # Seed scripts, build helpers, data fetchers
 ├── src-tauri/              # Tauri desktop shell (Rust + Node.js sidecar)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,7 +17,7 @@ World Monitor is a real-time global intelligence dashboard built as a TypeScript
 │                        Browser / Desktop                        │
 │  ┌──────────┐  ┌──────────┐  ┌────────────┐  ┌──────────────┐  │
 │  │ DeckGLMap│  │ GlobeMap │  │  Panels    │  │  Workers     │  │
-│  │(deck.gl) │  │(globe.gl)│  │(86 classes)│  │(ML, analysis)│  │
+│  │(deck.gl) │  │(globe.gl)│  │(Panel base)│  │(ML, analysis)│  │
 │  └────┬─────┘  └────┬─────┘  └─────┬──────┘  └──────────────┘  │
 │       └──────────────┴──────────────┘                           │
 │                         │ fetch /api/*                          │
@@ -58,14 +58,16 @@ World Monitor is a real-time global intelligence dashboard built as a TypeScript
 | Service | Platform | Role |
 |---------|----------|------|
 | SPA + Edge Functions | Vercel | Static files, API endpoints, middleware (bot filtering, social OG) |
+| CORS Preflight Worker | Cloudflare | Edge CORS for `api.worldmonitor.app` — short-circuits OPTIONS, stamps CORS headers on responses |
 | AIS Relay | Railway | WebSocket proxy (AIS stream), seed loops (market, aviation, GPSJAM, risk scores, UCDP, positive events), RSS proxy, OREF polling |
+| Consumer Prices | Railway | Containerized price scrapers (Playwright, per-country baskets) + Redis publisher for the consumer-prices dataset |
 | Redis | Upstash | Cache layer with stampede protection, seed-meta freshness tracking, rate limiting |
 | Convex | Convex Cloud | Contact form submissions, waitlist registrations |
 | Documentation | Mintlify | Public docs, proxied through Vercel at `/docs` |
 | Desktop App | Tauri 2.x | macOS (ARM64, x64), Windows (x64), Linux (x64, ARM64) with bundled Node.js sidecar |
 | Container Image | GHCR | Multi-arch Docker image (nginx serving built SPA, proxies API to upstream) |
 
-**Source files**: `vercel.json`, `docker/Dockerfile`, `scripts/ais-relay.cjs`, `convex/schema.ts`, `src-tauri/tauri.conf.json`
+**Source files**: `vercel.json`, `docker/Dockerfile`, `scripts/ais-relay.cjs`, `consumer-prices-core/Dockerfile`, `workers/api-cors-preflight/wrangler.toml`, `convex/schema.ts`, `src-tauri/tauri.conf.json`
 
 ---
 
@@ -88,7 +90,7 @@ World Monitor is a real-time global intelligence dashboard built as a TypeScript
 
 ### Component Model
 
-All panels extend the `Panel` base class. Panels render via `setContent(html)` (debounced 150ms) and use event delegation on a stable `this.content` element. Panels support resizable row/col spans persisted to localStorage.
+All panels extend the `Panel` base class (104 classes across `src/components`). Panels render via `setContent(html)` (debounced 150ms) and use event delegation on a stable `this.content` element. Panels support resizable row/col spans persisted to localStorage.
 
 ### Dual Map System
 
@@ -380,16 +382,19 @@ Runs before every `git push`:
 ```
 .
 ├── api/                    Vercel Edge Functions (self-contained JS)
-│   ├── _*.js               Shared helpers (CORS, rate-limit, API key, relay)
+│   ├── _*.js               Shared helpers (CORS, rate-limit, API key, relay, Sentry, session)
 │   └── <domain>/           Domain endpoints (aviation/, climate/, conflict/, ...)
 ├── blog-site/              Static blog (built into public/blog/)
+├── consumer-prices-core/   Consumer-price collection service (Playwright scrapers, per-country baskets; Railway/Docker)
 ├── convex/                 Convex backend (contact form, waitlist)
-├── data/                   Static data files (conservation, renewable, happiness)
-├── deploy/                 Deployment configs
+├── data/                   Static data (telegram channels, OREF threat translations, gamma irradiators)
+├── deploy/                 Deployment configs (nginx)
 ├── docker/                 Dockerfile + nginx config for Railway
 ├── docs/                   Mintlify documentation site
 ├── e2e/                    Playwright E2E specs
+├── pro-test/               Standalone Pro QA app (separate package)
 ├── proto/                  Protobuf service definitions (sebuf framework)
+├── public/                 Static assets served as-is (favicons, textures, .well-known agent-skills/MCP, llms.txt)
 ├── scripts/                Seed scripts, build helpers, relay service
 ├── server/                 Server-side code (bundled into Edge Functions)
 │   ├── _shared/            Redis, rate-limit, LLM, caching utilities
@@ -399,16 +404,23 @@ Runs before every `git push`:
 ├── shared/                 Cross-platform JSON configs (markets, RSS domains)
 ├── src/                    Browser SPA (TypeScript)
 │   ├── app/                App orchestration managers
-│   ├── bootstrap/          Chunk reload recovery
+│   ├── bootstrap/          Startup/recovery (chunk reload, deferred Sentry, SW update)
 │   ├── components/         Panel subclasses + map components
 │   ├── config/             Variant, panel, layer, market configurations
+│   ├── data/               Static JSON datasets (conservation, renewable, happiness)
+│   ├── e2e/                Map test harnesses (consumed by Playwright specs)
+│   ├── embed/              Embeddable widget loader
 │   ├── generated/          Proto-generated client/server stubs (DO NOT EDIT)
 │   ├── locales/            i18n translation files
 │   ├── services/           Business logic organized by domain
+│   ├── shared/             Cross-cutting helpers (premium paths, registries, staleness)
+│   ├── shims/              Runtime shims (child-process for sidecar)
+│   ├── styles/             Global CSS (layers, themes, panel styles)
 │   ├── types/              TypeScript type definitions
 │   ├── utils/              Shared utilities (circuit-breaker, theme, URL state)
 │   └── workers/            Web Workers (analysis, ML, vector DB)
 ├── src-tauri/              Tauri desktop shell (Rust)
 │   └── sidecar/            Node.js sidecar API server
-└── tests/                  Unit/integration tests (node:test)
+├── tests/                  Unit/integration tests (node:test)
+└── workers/                Cloudflare Workers (edge CORS preflight for api.worldmonitor.app)
 ```

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -13,6 +13,7 @@
   "componentTopLevelTsFiles": 155,
   "serviceTopLevelEntries": 186,
   "apiEndpointEntries": 80,
+  "panelClasses": 104,
   "protoFiles": 276,
   "protoServices": 34,
   "protoDomainFolders": 35,

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -65,7 +65,7 @@ function computeStats() {
 
   // ---- Panel subclasses across src/components (ARCHITECTURE.md system diagram) ----
   const panelClasses = walk('src/components')
-    .filter((f) => f.endsWith('.ts'))
+    .filter((f) => f.endsWith('.ts') && !f.endsWith('.d.ts'))
     .reduce((n, f) => n + (read(f).match(/class\s+\w+\s+extends\s+Panel\b/g) || []).length, 0);
 
   // ---- Protos & services (proto/**) ----

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -63,6 +63,11 @@ function computeStats() {
     (f) => !f.startsWith('_') && !/\.test\./.test(f) && !/\.d\.ts$/.test(f) && !/\.json$/.test(f),
   ).length;
 
+  // ---- Panel subclasses across src/components (ARCHITECTURE.md system diagram) ----
+  const panelClasses = walk('src/components')
+    .filter((f) => f.endsWith('.ts'))
+    .reduce((n, f) => n + (read(f).match(/class\s+\w+\s+extends\s+Panel\b/g) || []).length, 0);
+
   // ---- Protos & services (proto/**) ----
   const protoFiles = walk('proto').filter((f) => f.endsWith('.proto'));
   const protoServices = protoFiles
@@ -145,6 +150,7 @@ function computeStats() {
     componentTopLevelTsFiles,
     serviceTopLevelEntries,
     apiEndpointEntries,
+    panelClasses,
     protoFiles: protoFiles.length,
     protoServices,
     protoDomainFolders,
@@ -190,6 +196,8 @@ function claims(s) {
     { file: 'AGENTS.md', re: /components\/\s+# (\d+)\s+top-level TypeScript component files/, value: s.componentTopLevelTsFiles },
     { file: 'AGENTS.md', re: /services\/\s+# Business logic \((\d+)\s+service modules and domain directories\)/, value: s.serviceTopLevelEntries },
     { file: 'AGENTS.md', re: /requires buf \+ sebuf (v\d+\.\d+\.\d+) plugins/, value: s.sebufVersion },
+
+    { file: 'ARCHITECTURE.md', re: /base class \((\d+)\s+classes\b/, value: s.panelClasses },
     { file: 'CONTRIBUTING.md', re: /Service and message definitions across (\d+)\s+domains/, value: s.protoDomainFolders },
     { file: 'CONTRIBUTING.md', re: /produces (\d+)\s+app variants/, value: s.variantCount },
     { file: 'CONTRIBUTING.md', re: /UI components — (\d+)\s+top-level TypeScript component files/, value: s.componentTopLevelTsFiles },


### PR DESCRIPTION
## Summary

- **AGENTS.md + ARCHITECTURE.md directory maps were stale** — both missed several real top-level directories (`consumer-prices-core/`, `workers/`, `public/`, `data/`, `pro-test/`) and `src/` subdirectories (`bootstrap/`, `shared/`, `embed/`, `styles/`, `shims/`, `data/`, `e2e/`). Also had `src/data/`'s contents described under the top-level `data/` entry (wrong dataset).
- **ARCHITECTURE.md `(86 classes)` annotation was stale and unregistered** — changed ASCII box interior to qualitative `(Panel base)` (same 12-char width) and placed the CI-gated count `(104 classes)` in §3 prose instead.
- **ARCHITECTURE.md deployment table** — added the two deployed-but-undocumented services: Cloudflare CORS Preflight Worker (`workers/api-cors-preflight/`) and Consumer Prices Railway service (`consumer-prices-core/`).
- **`scripts/docs-stats.mjs`** — added `panelClasses` stat (`class X extends Panel` across `src/components/**/*.ts`) and a `claims()` entry so the count is CI-gated and drift-proof going forward.

## Test plan

- [ ] `node scripts/docs-stats.mjs --check` → "71 doc claims match code" (all pass, including new `panelClasses` claim)
- [ ] `npm run lint:md` → 0 errors
- [ ] `npm run typecheck` → clean
- [ ] All pre-push hooks passed (full suite ran on push)

