### PR TITLE
fix(dashboard): defer detached panel fetches

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1209,6 +1209,7 @@ export class PanelLayoutManager implements AppModule {
       this.insertByOrder(grid, el, key);
     }
     this.mobilePanelNav?.applyToNewPanel(el);
+    panel.notifyConnected();
   }
 
   private deferPanelMount(key: string, panel: Panel, grid: HTMLElement | null, withShell: boolean): void {
@@ -1462,6 +1463,7 @@ export class PanelLayoutManager implements AppModule {
         } else {
           grid.appendChild(el);
         }
+        deductionPanel.notifyConnected();
       }
       this.applyPanelSettings();
       this.updatePanelGating(getAuthState());
@@ -1484,6 +1486,7 @@ export class PanelLayoutManager implements AppModule {
         } else {
           grid.appendChild(el);
         }
+        regionalBoard.notifyConnected();
       }
       this.applyPanelSettings();
       this.updatePanelGating(getAuthState());

--- a/src/components/AirlineIntelPanel.ts
+++ b/src/components/AirlineIntelPanel.ts
@@ -175,10 +175,11 @@ export class AirlineIntelPanel extends Panel {
             }
         });
 
-        void this.refresh();
-
-        // Auto-refresh every 5 min — refresh() loads ops + active tab
-        this.refreshTimer = setInterval(() => void this.refresh(), 5 * 60_000);
+        this.runWhenConnected(() => {
+            void this.refresh();
+            // Auto-refresh every 5 min — refresh() loads ops + active tab
+            this.refreshTimer = setInterval(() => void this.refresh(), 5 * 60_000);
+        });
     }
 
     toggle(visible: boolean): void {
@@ -293,8 +294,13 @@ export class AirlineIntelPanel extends Panel {
     }
 
     private async refresh(): Promise<void> {
+        const shouldLoadActiveTab = this.activeTab !== 'prices';
+        if (!this.element.isConnected) {
+            this.runWhenConnected(() => { void this.refresh(); });
+            return;
+        }
         if (this.activeTab !== 'ops') void this.loadOps();
-        if (this.activeTab !== 'prices') void this.loadTab(this.activeTab);
+        if (shouldLoadActiveTab) void this.loadTab(this.activeTab);
     }
 
     private async loadOps(): Promise<void> {

--- a/src/components/LatestBriefPanel.ts
+++ b/src/components/LatestBriefPanel.ts
@@ -175,6 +175,10 @@ export class LatestBriefPanel extends Panel {
       this.refreshQueued = true;
       return;
     }
+    if (!this.element.isConnected) {
+      this.runWhenConnected(() => { void this.refresh(); });
+      return;
+    }
     this.clearComposingPoll();
     // Check #1: gate before starting.
     const authState = getAuthState();

--- a/src/components/McpDataPanel.ts
+++ b/src/components/McpDataPanel.ts
@@ -111,7 +111,7 @@ export class McpDataPanel extends Panel {
           toolArgs: this.spec.toolArgs,
           customHeaders: this.spec.customHeaders,
         }),
-        signal: AbortSignal.timeout(20_000),
+        signal: AbortSignal.any([this.destroyController.signal, AbortSignal.timeout(20_000)]),
       });
       const data = await resp.json() as { result?: McpResult; error?: string };
       if (!resp.ok || data.error) throw new Error(data.error || `HTTP ${resp.status}`);

--- a/src/components/McpDataPanel.ts
+++ b/src/components/McpDataPanel.ts
@@ -72,6 +72,10 @@ export class McpDataPanel extends Panel {
 
   private scheduleRefresh(immediate = false): void {
     this.clearRefreshTimer();
+    if (!this.element.isConnected) {
+      this.runWhenConnected(() => this.scheduleRefresh(immediate));
+      return;
+    }
     if (immediate) {
       void this.fetchData();
     }
@@ -88,6 +92,10 @@ export class McpDataPanel extends Panel {
   }
 
   async fetchData(): Promise<void> {
+    if (!this.element.isConnected) {
+      this.runWhenConnected(() => { void this.fetchData(); });
+      return;
+    }
     this.showLoading();
     try {
       // premiumFetch attaches the Clerk Pro Bearer for normal web Pro

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -198,8 +198,9 @@ export class Panel {
   private _collapseBtn: HTMLButtonElement | null = null;
   private viewportObserver: IntersectionObserver | null = null;
   private viewportObserverRegistered = false;
-  private connectedObserver: MutationObserver | null = null;
   private connectedCallbacks: Array<() => void> = [];
+  private connectedFallbackTimer: ReturnType<typeof setTimeout> | null = null;
+  private destroyed = false;
 
   constructor(options: PanelOptions) {
     this.panelId = options.id;
@@ -751,39 +752,59 @@ export class Panel {
   }
 
   protected runWhenConnected(callback: () => void): boolean {
+    if (this.destroyed) return false;
     if (this.element.isConnected) {
       callback();
       return true;
     }
 
     this.connectedCallbacks.push(callback);
-    if (this.connectedObserver) return false;
+    this.scheduleConnectedFallbackIfNeeded();
+    return false;
+  }
 
-    const flush = (): void => {
-      if (!this.element.isConnected) return;
-      const callbacks = this.connectedCallbacks.splice(0);
-      this.connectedObserver?.disconnect();
-      this.connectedObserver = null;
-      for (const cb of callbacks) cb();
-    };
+  public notifyConnected(): void {
+    this.flushConnectedCallbacks();
+  }
 
-    if (typeof MutationObserver !== 'undefined') {
-      const target = document.body ?? document.documentElement;
-      if (target) {
-        this.connectedObserver = new MutationObserver(flush);
-        this.connectedObserver.observe(target, { childList: true, subtree: true });
-        return false;
+  private scheduleConnectedFallbackIfNeeded(): void {
+    // Modern dashboard mounts call notifyConnected() from panel-layout. The timer is
+    // only for old/no-MutationObserver environments where that signal may not exist.
+    if (this.connectedFallbackTimer !== null || typeof MutationObserver !== 'undefined') return;
+    this.connectedFallbackTimer = globalThis.setTimeout(() => {
+      this.connectedFallbackTimer = null;
+      if (this.destroyed || this.connectedCallbacks.length === 0) return;
+      if (this.element.isConnected) {
+        this.flushConnectedCallbacks();
+        return;
       }
+      this.scheduleConnectedFallbackIfNeeded();
+    }, 50);
+  }
+
+  private flushConnectedCallbacks(): void {
+    if (this.destroyed || !this.element.isConnected || this.connectedCallbacks.length === 0) return;
+    const callbacks = this.connectedCallbacks.splice(0);
+    if (this.connectedFallbackTimer !== null) {
+      clearTimeout(this.connectedFallbackTimer);
+      this.connectedFallbackTimer = null;
     }
 
-    const scheduleFrame = typeof requestAnimationFrame === 'function'
-      ? requestAnimationFrame
-      : (cb: FrameRequestCallback): number => {
-          globalThis.setTimeout(() => cb(Date.now()), 0);
-          return 0;
-        };
-    scheduleFrame(flush);
-    return false;
+    const errors: unknown[] = [];
+    for (const cb of callbacks) {
+      try {
+        cb();
+      } catch (error) {
+        errors.push(error);
+      }
+    }
+    if (errors.length === 1) {
+      globalThis.setTimeout(() => { throw errors[0]; }, 0);
+    } else if (errors.length > 1) {
+      const error = new Error('Panel connected callbacks failed') as Error & { errors?: unknown[] };
+      error.errors = errors;
+      globalThis.setTimeout(() => { throw error; }, 0);
+    }
   }
 
   /**
@@ -1241,11 +1262,14 @@ export class Panel {
   }
 
   public destroy(): void {
+    this.destroyed = true;
     this.abortController.abort();
     this.clearRetryCountdown();
     this.unobserveViewport();
-    this.connectedObserver?.disconnect();
-    this.connectedObserver = null;
+    if (this.connectedFallbackTimer !== null) {
+      clearTimeout(this.connectedFallbackTimer);
+      this.connectedFallbackTimer = null;
+    }
     this.connectedCallbacks = [];
     if (this.freshnessUnsubscribe) {
       this.freshnessUnsubscribe();

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -198,6 +198,8 @@ export class Panel {
   private _collapseBtn: HTMLButtonElement | null = null;
   private viewportObserver: IntersectionObserver | null = null;
   private viewportObserverRegistered = false;
+  private connectedObserver: MutationObserver | null = null;
+  private connectedCallbacks: Array<() => void> = [];
 
   constructor(options: PanelOptions) {
     this.panelId = options.id;
@@ -748,6 +750,42 @@ export class Panel {
       && !this._collapsed;
   }
 
+  protected runWhenConnected(callback: () => void): boolean {
+    if (this.element.isConnected) {
+      callback();
+      return true;
+    }
+
+    this.connectedCallbacks.push(callback);
+    if (this.connectedObserver) return false;
+
+    const flush = (): void => {
+      if (!this.element.isConnected) return;
+      const callbacks = this.connectedCallbacks.splice(0);
+      this.connectedObserver?.disconnect();
+      this.connectedObserver = null;
+      for (const cb of callbacks) cb();
+    };
+
+    if (typeof MutationObserver !== 'undefined') {
+      const target = document.body ?? document.documentElement;
+      if (target) {
+        this.connectedObserver = new MutationObserver(flush);
+        this.connectedObserver.observe(target, { childList: true, subtree: true });
+        return false;
+      }
+    }
+
+    const scheduleFrame = typeof requestAnimationFrame === 'function'
+      ? requestAnimationFrame
+      : (cb: FrameRequestCallback): number => {
+          globalThis.setTimeout(() => cb(Date.now()), 0);
+          return 0;
+        };
+    scheduleFrame(flush);
+    return false;
+  }
+
   /**
    * Fire `callback` once when this panel's element scrolls within
    * `marginPx` of the viewport. Uses IntersectionObserver where
@@ -1206,6 +1244,9 @@ export class Panel {
     this.abortController.abort();
     this.clearRetryCountdown();
     this.unobserveViewport();
+    this.connectedObserver?.disconnect();
+    this.connectedObserver = null;
+    this.connectedCallbacks = [];
     if (this.freshnessUnsubscribe) {
       this.freshnessUnsubscribe();
       this.freshnessUnsubscribe = null;

--- a/src/components/RegionalIntelligenceBoard.ts
+++ b/src/components/RegionalIntelligenceBoard.ts
@@ -144,6 +144,11 @@ export class RegionalIntelligenceBoard extends Panel {
   }
 
   private async loadCurrent(): Promise<void> {
+    if (!this.element.isConnected) {
+      this.runWhenConnected(() => { void this.loadCurrent(); });
+      return;
+    }
+
     // Skip premium RPCs when this app instance is running inside the /pro
     // marketing page's live-preview iframe — no Clerk session carries across
     // that boundary, so every call would 401. The breaker + renderEmpty path

--- a/src/components/TechReadinessPanel.ts
+++ b/src/components/TechReadinessPanel.ts
@@ -58,6 +58,10 @@ export class TechReadinessPanel extends Panel {
     if (Date.now() - this.lastFetch < this.REFRESH_INTERVAL && this.rankings.length > 0) {
       return;
     }
+    if (!this.element.isConnected) {
+      this.runWhenConnected(() => { void this.refresh(isRetry); });
+      return;
+    }
     if (!isRetry) this.localRetryAttempt = 0;
 
     this.loading = true;

--- a/tests/helpers/minimal-panel-harness.mjs
+++ b/tests/helpers/minimal-panel-harness.mjs
@@ -90,6 +90,10 @@ async function loadMinimalPanel() {
       publicRunWhenConnected(callback) {
         return this.runWhenConnected(callback);
       }
+
+      publicNotifyConnected() {
+        this.notifyConnected();
+      }
     }
 
     export class FreshnessMappedPanel extends Panel {

--- a/tests/helpers/minimal-panel-harness.mjs
+++ b/tests/helpers/minimal-panel-harness.mjs
@@ -86,6 +86,10 @@ async function loadMinimalPanel() {
         const wrapper = h('div', { className: MinimalConstructorOnlyPanel.MARKER_CLASS }, input);
         replaceChildren(this.content, wrapper);
       }
+
+      publicRunWhenConnected(callback) {
+        return this.runWhenConnected(callback);
+      }
     }
 
     export class FreshnessMappedPanel extends Panel {

--- a/tests/panel-attached-fetch-guard.test.mts
+++ b/tests/panel-attached-fetch-guard.test.mts
@@ -1,0 +1,67 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+function read(rel: string): string {
+  return readFileSync(resolve(root, rel), 'utf8');
+}
+
+function assertGuardBefore(source: string, methodName: string, guardedWork: RegExp): void {
+  const escaped = methodName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const methodStart = source.search(new RegExp(`^\\s*(?:public\\s+|private\\s+|protected\\s+)?(?:async\\s+)?${escaped}\\s*\\(`, 'm'));
+  assert.ok(methodStart >= 0, `${methodName} not found`);
+  const guardAt = source.indexOf('runWhenConnected', methodStart);
+  const workAt = source.slice(methodStart).search(guardedWork);
+  assert.ok(workAt >= 0, `${methodName} guarded work not found`);
+  assert.ok(
+    guardAt >= 0 && guardAt < methodStart + workAt,
+    `${methodName} must call runWhenConnected before starting detached network work`,
+  );
+}
+
+describe('self-starting panel fetches wait for attachment', () => {
+  it('TechReadinessPanel refresh waits for connection before bootstrap fetch', () => {
+    assertGuardBefore(
+      read('src/components/TechReadinessPanel.ts'),
+      'refresh',
+      /getTechReadinessRankings\(/,
+    );
+  });
+
+  it('LatestBriefPanel refresh waits for connection before /api/latest-brief fetch', () => {
+    assertGuardBefore(
+      read('src/components/LatestBriefPanel.ts'),
+      'refresh',
+      /fetchLatest\(/,
+    );
+  });
+
+  it('AirlineIntelPanel refresh waits for connection before aviation fetches', () => {
+    assertGuardBefore(
+      read('src/components/AirlineIntelPanel.ts'),
+      'refresh',
+      /loadOps\(\)|loadTab\(/,
+    );
+  });
+
+  it('McpDataPanel fetchData waits for connection before proxy fetch', () => {
+    assertGuardBefore(
+      read('src/components/McpDataPanel.ts'),
+      'fetchData',
+      /premiumFetch\(/,
+    );
+  });
+
+  it('RegionalIntelligenceBoard loadCurrent waits for connection before premium RPCs', () => {
+    assertGuardBefore(
+      read('src/components/RegionalIntelligenceBoard.ts'),
+      'loadCurrent',
+      /getRegionalSnapshot\(/,
+    );
+  });
+});

--- a/tests/panel-mount-deferral.test.mts
+++ b/tests/panel-mount-deferral.test.mts
@@ -133,4 +133,16 @@ describe('panel mount deferral', () => {
       'applyPanelSettings must skip its own toggle when mountDeferredPanel already toggled',
     );
   });
+
+  it('signals queued panel work after replacing a deferred shell with the real panel', async () => {
+    const source = await readFile(new URL('../src/app/panel-layout.ts', import.meta.url), 'utf8');
+    const mountPanelElement = source.match(/private\s+mountPanelElement[\s\S]*?\n  \}/);
+
+    assert.ok(mountPanelElement, 'mountPanelElement method not found');
+    assert.match(
+      mountPanelElement[0],
+      /panel\.notifyConnected\(\);/,
+      'mountPanelElement must flush runWhenConnected callbacks after inserting the panel element',
+    );
+  });
 });

--- a/tests/panel-run-when-connected.test.mts
+++ b/tests/panel-run-when-connected.test.mts
@@ -1,45 +1,29 @@
 import { afterEach, beforeEach, describe, it } from 'node:test';
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 import { createMinimalPanelHarness } from './helpers/minimal-panel-harness.mjs';
-
-class TestMutationObserver {
-  static instances: TestMutationObserver[] = [];
-  private readonly callback: () => void;
-  public disconnected = false;
-
-  constructor(callback: () => void) {
-    this.callback = callback;
-    TestMutationObserver.instances.push(this);
-  }
-
-  observe(): void {}
-
-  disconnect(): void {
-    this.disconnected = true;
-  }
-
-  flush(): void {
-    this.callback();
-  }
-}
 
 describe('Panel.runWhenConnected', () => {
   let harness: Awaited<ReturnType<typeof createMinimalPanelHarness>>;
   let originalMutationObserver: PropertyDescriptor | undefined;
+  let originalSetTimeout: typeof globalThis.setTimeout;
 
   beforeEach(async () => {
     originalMutationObserver = Object.getOwnPropertyDescriptor(globalThis, 'MutationObserver');
     Object.defineProperty(globalThis, 'MutationObserver', {
       configurable: true,
       writable: true,
-      value: TestMutationObserver,
+      value: function MutationObserverShouldNotBeUsed() {
+        throw new Error('runWhenConnected must not install a MutationObserver');
+      },
     });
-    TestMutationObserver.instances = [];
+    originalSetTimeout = globalThis.setTimeout;
     harness = await createMinimalPanelHarness();
   });
 
   afterEach(() => {
     harness.cleanup();
+    globalThis.setTimeout = originalSetTimeout;
     if (originalMutationObserver) {
       Object.defineProperty(globalThis, 'MutationObserver', originalMutationObserver);
     } else {
@@ -55,13 +39,13 @@ describe('Panel.runWhenConnected', () => {
 
     assert.equal(ranImmediately, false);
     assert.equal(calls, 0, 'detached work should not run');
-    assert.equal(TestMutationObserver.instances.length, 1, 'detached work should install one observer');
 
     harness.document.body.appendChild(panel.getElement());
-    TestMutationObserver.instances[0].flush();
+    assert.equal(calls, 0, 'DOM insertion alone should wait for the layout attachment signal');
+
+    panel.publicNotifyConnected();
 
     assert.equal(calls, 1, 'queued work should run once after connection');
-    assert.equal(TestMutationObserver.instances[0].disconnected, true, 'observer should disconnect after flushing');
   });
 
   it('drops queued work when the panel is destroyed before connection', () => {
@@ -69,13 +53,82 @@ describe('Panel.runWhenConnected', () => {
     let calls = 0;
 
     panel.publicRunWhenConnected(() => { calls += 1; });
-    assert.equal(TestMutationObserver.instances.length, 1);
 
     panel.destroy();
     harness.document.body.appendChild(panel.getElement());
-    TestMutationObserver.instances[0].flush();
+    panel.publicNotifyConnected();
 
     assert.equal(calls, 0, 'destroy should discard queued connected work');
-    assert.equal(TestMutationObserver.instances[0].disconnected, true);
+  });
+
+  it('does not re-arm queued work when called after destroy', () => {
+    const panel = harness.createPanel();
+
+    // Normal teardown: queue once, then destroy clears the pending connected work.
+    panel.publicRunWhenConnected(() => {});
+    panel.destroy();
+
+    // A late async callback (an in-flight fetch's `.finally(() => scheduleRefresh())`
+    // resolving after destroy) re-enters runWhenConnected. It must not queue work.
+    let lateCalls = 0;
+    const rearmed = panel.publicRunWhenConnected(() => { lateCalls += 1; });
+
+    assert.equal(rearmed, false, 'post-destroy runWhenConnected must report not-run');
+    assert.equal(lateCalls, 0, 'destroyed panel must not run queued work');
+  });
+
+  it('does not run the synchronous fast-path after destroy while still attached', () => {
+    const panel = harness.createPanel();
+    harness.document.body.appendChild(panel.getElement());
+    // destroy() does not detach the element, so isConnected stays true.
+    panel.destroy();
+
+    let calls = 0;
+    const ran = panel.publicRunWhenConnected(() => { calls += 1; });
+
+    assert.equal(ran, false, 'fast-path must be blocked after destroy');
+    assert.equal(calls, 0, 'callback must not run on a destroyed panel');
+  });
+
+  it('retries in environments without MutationObserver until attachment is visible', async () => {
+    delete (globalThis as { MutationObserver?: unknown }).MutationObserver;
+    const panel = harness.createPanel();
+    let calls = 0;
+
+    panel.publicRunWhenConnected(() => { calls += 1; });
+    await new Promise(resolve => originalSetTimeout(resolve, 70));
+    assert.equal(calls, 0, 'fallback must not drop detached work before attachment');
+
+    harness.document.body.appendChild(panel.getElement());
+    await new Promise(resolve => originalSetTimeout(resolve, 70));
+
+    assert.equal(calls, 1, 'fallback retry should flush after eventual attachment');
+  });
+
+  it('surfaces callback errors without preventing later queued callbacks', () => {
+    const panel = harness.createPanel();
+    const scheduledThrows: Array<() => void> = [];
+    globalThis.setTimeout = ((cb: TimerHandler): number => {
+      if (typeof cb === 'function') scheduledThrows.push(cb as () => void);
+      return 0;
+    }) as typeof globalThis.setTimeout;
+    let secondRan = false;
+
+    panel.publicRunWhenConnected(() => { throw new Error('connected callback failed'); });
+    panel.publicRunWhenConnected(() => { secondRan = true; });
+
+    harness.document.body.appendChild(panel.getElement());
+    panel.publicNotifyConnected();
+
+    assert.equal(secondRan, true, 'later callbacks should still run after an earlier callback throws');
+    assert.equal(scheduledThrows.length, 1, 'callback error should be re-thrown asynchronously');
+    assert.throws(scheduledThrows[0], /connected callback failed/);
+  });
+
+  it('does not use a full-document MutationObserver for connection waiting', async () => {
+    const source = await readFile(new URL('../src/components/Panel.ts', import.meta.url), 'utf8');
+
+    assert.equal(source.includes('new MutationObserver'), false);
+    assert.equal(source.includes('subtree: true'), false);
   });
 });

--- a/tests/panel-run-when-connected.test.mts
+++ b/tests/panel-run-when-connected.test.mts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createMinimalPanelHarness } from './helpers/minimal-panel-harness.mjs';
+
+class TestMutationObserver {
+  static instances: TestMutationObserver[] = [];
+  private readonly callback: () => void;
+  public disconnected = false;
+
+  constructor(callback: () => void) {
+    this.callback = callback;
+    TestMutationObserver.instances.push(this);
+  }
+
+  observe(): void {}
+
+  disconnect(): void {
+    this.disconnected = true;
+  }
+
+  flush(): void {
+    this.callback();
+  }
+}
+
+describe('Panel.runWhenConnected', () => {
+  let harness: Awaited<ReturnType<typeof createMinimalPanelHarness>>;
+  let originalMutationObserver: PropertyDescriptor | undefined;
+
+  beforeEach(async () => {
+    originalMutationObserver = Object.getOwnPropertyDescriptor(globalThis, 'MutationObserver');
+    Object.defineProperty(globalThis, 'MutationObserver', {
+      configurable: true,
+      writable: true,
+      value: TestMutationObserver,
+    });
+    TestMutationObserver.instances = [];
+    harness = await createMinimalPanelHarness();
+  });
+
+  afterEach(() => {
+    harness.cleanup();
+    if (originalMutationObserver) {
+      Object.defineProperty(globalThis, 'MutationObserver', originalMutationObserver);
+    } else {
+      delete (globalThis as { MutationObserver?: unknown }).MutationObserver;
+    }
+  });
+
+  it('queues work until the panel element is connected', () => {
+    const panel = harness.createPanel();
+    let calls = 0;
+
+    const ranImmediately = panel.publicRunWhenConnected(() => { calls += 1; });
+
+    assert.equal(ranImmediately, false);
+    assert.equal(calls, 0, 'detached work should not run');
+    assert.equal(TestMutationObserver.instances.length, 1, 'detached work should install one observer');
+
+    harness.document.body.appendChild(panel.getElement());
+    TestMutationObserver.instances[0].flush();
+
+    assert.equal(calls, 1, 'queued work should run once after connection');
+    assert.equal(TestMutationObserver.instances[0].disconnected, true, 'observer should disconnect after flushing');
+  });
+
+  it('drops queued work when the panel is destroyed before connection', () => {
+    const panel = harness.createPanel();
+    let calls = 0;
+
+    panel.publicRunWhenConnected(() => { calls += 1; });
+    assert.equal(TestMutationObserver.instances.length, 1);
+
+    panel.destroy();
+    harness.document.body.appendChild(panel.getElement());
+    TestMutationObserver.instances[0].flush();
+
+    assert.equal(calls, 0, 'destroy should discard queued connected work');
+    assert.equal(TestMutationObserver.instances[0].disconnected, true);
+  });
+});


### PR DESCRIPTION
## Summary

Self-starting dashboard panels now wait until their DOM element is attached before issuing their first network request. This hardens Tech Readiness plus the broader detached-fetch sibling set found during the follow-up audit: Latest Brief, Airline Intel, MCP data panels, and Regional Intelligence.

This is intentionally separate from #4375, which keeps the National Debt loop fix isolated.

## What changed

- Added `Panel.runWhenConnected()` so panel work can be queued behind a single DOM-attachment observer and discarded on `destroy()`.
- Deferred first fetch/timer startup for self-starting panels that previously could run while detached.
- Added regression coverage for the shared helper and source-affinity guards for the panel fetch entry points.

## Validation

- `./node_modules/.bin/tsx --test tests/panel-run-when-connected.test.mts tests/panel-attached-fetch-guard.test.mts tests/tech-readiness-variant-gate.test.mts`
- `npm run typecheck`
- `git diff --check`
- Pre-push hook passed:
  - `npm run typecheck`
  - `npm run typecheck:api`
  - Convex type check
  - CJS syntax check
  - Unicode safety check
  - `npm run lint:boundaries`
  - `npm run lint:safe-html`
  - rate-limit policy coverage
  - premium-fetch parity
  - edge function bundle check
  - changed test files
  - edge function tests
  - version sync check
