### PR TITLE
fix(a11y): tablist child role, contrast, region label, landmarks, tap targets (#4373)

### DIFF
--- a/e2e/a11y-landmarks-tablist.spec.ts
+++ b/e2e/a11y-landmarks-tablist.spec.ts
@@ -1,0 +1,108 @@
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * Real-DOM regression coverage for the issue #4373 accessibility fixes that
+ * the source-invariant unit test (tests/a11y-issue-4373-invariants.test.mjs)
+ * can only assert structurally:
+ *   - aria-required-children: the dashboard tablist owns ONLY role="tab"
+ *     children; the "+" add button is a sibling in the bar, not in the tablist.
+ *   - bypass: a single <main id="main"> landmark exists and a skip link is the
+ *     first focusable element, moving focus to <main> when activated.
+ *   - select-name: #regionSelect exposes an accessible name.
+ *
+ * Runs against the Vite dev server (default `full` variant) on :4173.
+ */
+
+async function loadDashboard(page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await page.waitForFunction(
+    () => document.documentElement.dataset.wmEventHandlersReady === 'true',
+    undefined,
+    { timeout: 60_000 },
+  );
+  await page.locator('[role="tablist"]').first().waitFor({ timeout: 30_000 });
+}
+
+test.describe('a11y #4373 — landmarks, tablist ownership, labelled region select', () => {
+  test('tablist owns only role="tab" children; add button is outside it', async ({ page }) => {
+    await loadDashboard(page);
+
+    // The dashboard tab strip exposes exactly one tablist, on the inner
+    // .dashboard-tablist element (NOT the .dashboard-tabs-bar). Other unrelated
+    // components (settings, route explorer) may render their own tablists, so
+    // this is scoped to the dashboard tab bar rather than the whole document.
+    await expect(page.locator('.dashboard-tablist[role="tablist"]')).toHaveCount(1);
+    await expect(page.locator('.dashboard-tabs-bar[role="tablist"]')).toHaveCount(0);
+
+    // The tablist owns at least one tab and NO add button.
+    await expect(page.locator('.dashboard-tablist [role="tab"]')).not.toHaveCount(0);
+    await expect(page.locator('.dashboard-tablist .dashboard-tab-add')).toHaveCount(0);
+
+    // The add button exists as a sibling of the tablist, inside the bar.
+    await expect(page.locator('.dashboard-tabs-bar > .dashboard-tab-add')).toHaveCount(1);
+
+    // Every direct child of the tablist resolves to a role="tab" (via the
+    // generic .dashboard-tab wrapper) — i.e. no stray non-tab owned roles at
+    // the top level. This is the exact shape axe aria-required-children checks.
+    const nonTabTopChildren = await page.evaluate(() => {
+      const tablist = document.querySelector('.dashboard-tablist[role="tablist"]');
+      if (!tablist) return ['NO_TABLIST'];
+      return Array.from(tablist.children)
+        .filter((c) => !c.querySelector('[role="tab"]') && c.getAttribute('role') !== 'tab')
+        .map((c) => c.className);
+    });
+    expect(nonTabTopChildren).toEqual([]);
+  });
+
+  test('single <main id="main"> landmark wraps the dashboard content', async ({ page }) => {
+    await loadDashboard(page);
+    const main = page.locator('main#main.main-content');
+    await expect(main).toHaveCount(1);
+    // The panels grid (tabpanel) lives inside the landmark.
+    await expect(main.locator('#panelsGrid')).toHaveCount(1);
+  });
+
+  test('skip link is the first focusable element and moves focus to <main>', async ({ page }) => {
+    await loadDashboard(page);
+    await page.locator('#panelsGrid .panel').first().waitFor({ timeout: 30_000 });
+
+    const skip = page.locator('a.skip-link');
+    await expect(skip).toHaveCount(1);
+    await expect(skip).toHaveAttribute('href', '#main');
+
+    // The skip link is the FIRST tabbable element in document order, so a
+    // keyboard user reaches it on the first Tab. Checked structurally (DOM
+    // order) rather than by driving Tab, because the app manages focus during
+    // hydration and that would race a live keypress.
+    const skipTabIndex = await page.evaluate(() => {
+      const sel = 'a[href], button, input, select, textarea, [tabindex]';
+      const tabbable = Array.from(document.querySelectorAll(sel)).filter((el) => {
+        if (el.closest('[inert]')) return false;
+        if ((el as HTMLElement).hasAttribute('disabled')) return false;
+        const ti = el.getAttribute('tabindex');
+        if (ti !== null && Number(ti) < 0) return false;
+        const cs = getComputedStyle(el as HTMLElement);
+        return cs.display !== 'none' && cs.visibility !== 'hidden';
+      });
+      return tabbable.indexOf(document.querySelector('a.skip-link') as Element);
+    });
+    expect(skipTabIndex).toBe(0);
+
+    // Activating the skip link moves focus to the <main> landmark. Enter on a
+    // focused <a> fires a native click, so exercising the click handler is the
+    // same code path; done in one synchronous step to be deterministic.
+    const focusedAfterActivate = await page.evaluate(() => {
+      (document.querySelector('a.skip-link') as HTMLElement).click();
+      return document.activeElement?.id ?? '';
+    });
+    expect(focusedAfterActivate).toBe('main');
+  });
+
+  test('#regionSelect exposes an accessible name', async ({ page }) => {
+    await loadDashboard(page);
+    const region = page.locator('#regionSelect');
+    await expect(region).toHaveCount(1);
+    const label = await region.getAttribute('aria-label');
+    expect(label && label.trim().length).toBeTruthy();
+  });
+});

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -517,6 +517,7 @@ export class PanelLayoutManager implements AppModule {
     document.documentElement.classList.add('wm-layout-hydrated');
     setTrustedHtml(this.ctx.container, trustedHtml(`
       ${this.ctx.isDesktopApp ? '<div class="tauri-titlebar" data-tauri-drag-region></div>' : ''}
+      <a href="#main" class="skip-link">Skip to main content</a>
       <div id="proBannerSlot" class="pro-banner-slot" aria-live="polite"></div>
       <div class="header">
         <div class="header-left">
@@ -599,7 +600,7 @@ export class PanelLayoutManager implements AppModule {
             <span>${t('header.live')}</span>
           </div>
           <div class="region-selector">
-            <select id="regionSelect" class="region-select">
+            <select id="regionSelect" class="region-select" aria-label="${t('header.selectRegion')}">
               <option value="global">${t('components.deckgl.views.global')}</option>
               <option value="america">${t('components.deckgl.views.americas')}</option>
               <option value="mena">${t('components.deckgl.views.mena')}</option>
@@ -705,7 +706,7 @@ export class PanelLayoutManager implements AppModule {
       ).join('')}
       </div>
       <div class="dashboard-tabs-mount" id="panelTabsMount"></div>
-      <div class="main-content${this.ctx.isDesktopApp ? ' desktop-grid' : ''}">
+      <main id="main" tabindex="-1" class="main-content${this.ctx.isDesktopApp ? ' desktop-grid' : ''}">
         <div class="map-section" id="mapSection">
           <div class="panel-header">
             <div class="panel-header-left">
@@ -735,7 +736,7 @@ export class PanelLayoutManager implements AppModule {
         <div class="map-width-resize-handle" id="mapWidthResizeHandle"></div>
         <div class="panels-grid" id="panelsGrid" role="tabpanel"></div>
         <button class="search-mobile-fab" id="searchMobileFab" aria-label="Search">\u{1F50D}</button>
-      </div>
+      </main>
       <footer class="site-footer">
         <div class="site-footer-brand">
           <img src="/favico/favicon-32x32.png" alt="" width="28" height="28" class="site-footer-icon" />
@@ -757,6 +758,19 @@ export class PanelLayoutManager implements AppModule {
         <span class="site-footer-copy">&copy; ${new Date().getFullYear()} World Monitor</span>
       </footer>
     `, "legacy direct innerHTML migration"));
+
+    // Skip link: explicitly move focus to <main> on activation. Native
+    // fragment focus on a tabindex="-1" target is inconsistent across
+    // browsers, so drive it directly to guarantee keyboard users land in the
+    // main content (WCAG 2.4.1).
+    this.ctx.container.querySelector('.skip-link')?.addEventListener('click', (e) => {
+      e.preventDefault();
+      const main = document.getElementById('main');
+      if (main) {
+        main.focus();
+        main.scrollIntoView({ block: 'start' });
+      }
+    });
 
     await this.createPanels();
 

--- a/src/components/PanelTabBar.ts
+++ b/src/components/PanelTabBar.ts
@@ -18,6 +18,7 @@ export interface PanelTabBarCallbacks {
  */
 export class PanelTabBar {
   private element: HTMLElement;
+  private tablistEl: HTMLElement;
   private getState: () => TabsState;
   private callbacks: PanelTabBarCallbacks;
 
@@ -26,17 +27,24 @@ export class PanelTabBar {
     this.callbacks = callbacks;
     this.element = document.createElement('div');
     this.element.className = 'dashboard-tabs-bar';
-    this.element.setAttribute('role', 'tablist');
-    this.element.setAttribute('aria-label', t('dashboardTabs.ariaLabel'));
-    this.element.addEventListener('keydown', (e) => this.handleKeyDown(e));
 
-    // Delegate dblclick at the container (attached ONCE, survives re-renders).
+    // ARIA: a role="tablist" may only own role="tab"/"presentation" children.
+    // The trailing "+" button is an action, not a tab, so the tablist is an
+    // inner element holding ONLY the tabs and the add button sits beside it in
+    // the bar (see render()). This clears the aria-required-children violation.
+    this.tablistEl = document.createElement('div');
+    this.tablistEl.className = 'dashboard-tablist';
+    this.tablistEl.setAttribute('role', 'tablist');
+    this.tablistEl.setAttribute('aria-label', t('dashboardTabs.ariaLabel'));
+    this.tablistEl.addEventListener('keydown', (e) => this.handleKeyDown(e));
+
+    // Delegate dblclick at the tablist (attached ONCE, survives re-renders).
     // A per-label listener breaks for inactive tabs: the first click switches
     // tabs → render() → replaceChildren() swaps out the label node, so the two
     // clicks land on different elements and the browser dispatches dblclick on
     // their common ancestor (this container) rather than the new label.
     // Resolving the tab from the DOM here makes rename work on any tab.
-    this.element.addEventListener('dblclick', (e) => {
+    this.tablistEl.addEventListener('dblclick', (e) => {
       const target = e.target as HTMLElement;
       if (target.closest('.dashboard-tab-close')) return; // don't rename on delete dblclick
       const tabEl = (target.closest('.dashboard-tab') ??
@@ -64,10 +72,10 @@ export class PanelTabBar {
   }
 
   private render(): void {
-    this.element.replaceChildren();
+    this.tablistEl.replaceChildren();
     const { tabs, activeTabId } = this.getState();
     for (const tab of tabs) {
-      this.element.appendChild(this.renderTab(tab, tab.id === activeTabId, tabs.length > 1));
+      this.tablistEl.appendChild(this.renderTab(tab, tab.id === activeTabId, tabs.length > 1));
     }
     this.updateControlledPanel(activeTabId);
     const addBtn = document.createElement('button');
@@ -76,7 +84,8 @@ export class PanelTabBar {
     addBtn.setAttribute('aria-label', t('dashboardTabs.addTab'));
     addBtn.textContent = '+';
     addBtn.addEventListener('click', () => this.callbacks.onAdd());
-    this.element.appendChild(addBtn);
+    // The tablist owns only tabs; the add button is a sibling in the bar.
+    this.element.replaceChildren(this.tablistEl, addBtn);
   }
 
   private renderTab(tab: PanelTab, isActive: boolean, canDelete: boolean): HTMLElement {

--- a/src/components/PizzIntIndicator.ts
+++ b/src/components/PizzIntIndicator.ts
@@ -79,7 +79,9 @@ export class PizzIntIndicator {
     const color = DEFCON_COLORS[this.status.defconLevel] || '#888';
     defconEl.textContent = t('components.pizzint.defcon', { level: String(this.status.defconLevel) });
     defconEl.style.background = color;
-    defconEl.style.color = this.status.defconLevel <= 3 ? '#000' : '#fff';
+    // Black on every DEFCON hue clears WCAG AA 4.5:1 (green #2d8a6e→4.97:1,
+    // blue #00aaff→8.2:1); white failed on levels 4–5 (4.22:1 / 2.56:1).
+    defconEl.style.color = '#000';
 
     scoreEl.textContent = `${this.status.aggregateActivity}%`;
     labelEl.textContent = this.getDefconLabel(this.status.defconLevel);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -110,6 +110,10 @@
 
   /* Legacy color aliases (used by existing var() references) */
   --red: #ff4444;
+  /* Darker red for white-text "active/live" pills: #fff on --red is only
+     3.4:1, on --red-strong it clears WCAG AA (≈5:1). Theme-independent (the
+     pill is red in both themes). */
+  --red-strong: #d62b2b;
   --green: #44ff88;
   --yellow: #ffaa00;
 }
@@ -271,6 +275,43 @@ canvas,
   left: 0;
   right: 0;
   bottom: 0;
+}
+
+/* Keyboard bypass affordance (WCAG 2.4.1). Off-screen until focused, then
+   slides in over the header so a keyboard user can jump straight to <main>. */
+.skip-link {
+  position: fixed;
+  top: 8px;
+  left: 8px;
+  z-index: 100000;
+  padding: 10px 16px;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--green);
+  border-radius: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  text-decoration: none;
+  opacity: 0;
+  transform: translateY(-150%);
+  pointer-events: none;
+  transition: transform 0.15s ease, opacity 0.15s ease;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+  outline: 2px solid var(--green);
+  outline-offset: 2px;
+}
+
+/* The skip-link moves focus to <main> (tabindex="-1"). Suppress the
+   full-width focus ring on the container itself; the next Tab lands on a
+   real control with its own visible focus. */
+#main.main-content:focus {
+  outline: none;
 }
 
 .header {
@@ -1540,8 +1581,10 @@ canvas,
 .site-footer-copy {
   font-family: var(--font-mono, monospace);
   font-size: 10px;
+  /* No opacity: 0.6 fade — it dropped --text-dim (#888) to an effective
+     #5a5a5a on the #141414 footer (2.67:1). At full strength #888 clears
+     4.5:1 (≈5.2:1) for WCAG AA, matching the footer nav links. */
   color: var(--text-dim);
-  opacity: 0.6;
 }
 
 @media (max-width: 768px) {
@@ -2406,8 +2449,8 @@ body.panel-resize-active iframe {
 }
 
 .live-channel-btn.active {
-  background: var(--red);
-  border-color: var(--red);
+  background: var(--red-strong);
+  border-color: var(--red-strong);
   color: white;
 }
 
@@ -3387,14 +3430,14 @@ body.live-news-fullscreen-active .panels-grid > *:not(.live-news-fullscreen) {
 }
 
 .webcam-region-btn.active {
-  background: var(--red);
-  border-color: var(--red);
+  background: var(--red-strong);
+  border-color: var(--red-strong);
   color: white;
 }
 
 .webcam-view-btn.active {
-  background: var(--red);
-  border-color: var(--red);
+  background: var(--red-strong);
+  border-color: var(--red-strong);
   color: white;
 }
 
@@ -3594,8 +3637,8 @@ body.live-news-fullscreen-active .panels-grid > *:not(.live-news-fullscreen) {
 }
 
 .webcam-feed-btn.active {
-  background: var(--red);
-  border-color: var(--red);
+  background: var(--red-strong);
+  border-color: var(--red-strong);
   color: white;
 }
 
@@ -5134,8 +5177,9 @@ body.playback-mode .status-dot {
 }
 
 .layer-help-btn {
-  width: 20px;
-  height: 20px;
+  /* WCAG 2.5.8: ≥24×24 hit area (was 20×20). */
+  width: 24px;
+  height: 24px;
   padding: 0;
   background: var(--bg);
   border: 1px solid var(--border);
@@ -16371,6 +16415,13 @@ a.prediction-link:hover {
   font-size: 10px;
   cursor: pointer;
   transition: all 0.2s ease;
+  /* WCAG 2.5.8: ≥24×24 hit area (was ~36×23.5). */
+  box-sizing: border-box;
+  min-width: 24px;
+  min-height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .deckgl-time-slider .time-btn:hover {
@@ -17867,7 +17918,7 @@ a.prediction-link:hover {
 }
 
 .focal-point-urgency.critical {
-  background: var(--red);
+  background: var(--red-strong);
   color: white;
 }
 
@@ -24976,6 +25027,15 @@ body.map-width-resizing {
   min-height: 36px;
   overflow-x: auto;
   scrollbar-width: thin;
+}
+
+/* Inner tablist holds only the tabs; the "+" add button is a sibling in the
+   bar so the tablist owns no non-tab children (ARIA aria-required-children). */
+.dashboard-tablist {
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  flex-shrink: 0;
 }
 
 .dashboard-tab {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3170,8 +3170,10 @@ body.panel-resize-active iframe {
 
 .live-media-shell .offline-retry:hover,
 .webcam-preview-play:hover {
-  background: var(--red);
-  border-color: var(--red);
+  /* White (#fff, from the base rule) on --red is 3.41:1; --red-strong clears
+     AA (≈5:1). axe doesn't audit :hover, but this is the same defect class. */
+  background: var(--red-strong);
+  border-color: var(--red-strong);
 }
 
 .live-media-shell .offline-retry:focus-visible,

--- a/tests/a11y-issue-4373-invariants.test.mjs
+++ b/tests/a11y-issue-4373-invariants.test.mjs
@@ -181,6 +181,8 @@ describe('color-contrast — live/webcam active pills', () => {
       '.webcam-view-btn.active',
       '.webcam-feed-btn.active',
       '.focal-point-urgency.critical',
+      // hover state: the base rule sets white text, this swaps to a red bg
+      '.webcam-preview-play:hover',
     ]) {
       const block = css.match(
         new RegExp(`${sel.replace(/[.]/g, '\\.')}\\s*\\{([^}]*)\\}`),
@@ -198,7 +200,9 @@ describe('color-contrast — live/webcam active pills', () => {
     const offenders = [];
     for (const m of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
       const body = m[2].replace(/\/\*[\s\S]*?\*\//g, '');
-      const whiteText = /color:\s*(white|#fff(f{0,3})?)\b/i.test(body);
+      const whiteText =
+        /color:\s*(white|#fff(f{0,3})?)\b/i.test(body) ||
+        /color:\s*rgb\(\s*255\s*,\s*255\s*,\s*255\s*\)/i.test(body);
       const redBg = /background(-color)?:\s*var\(--red\)\s*;/.test(body);
       if (whiteText && redBg) offenders.push(m[1].trim().slice(0, 60));
     }

--- a/tests/a11y-issue-4373-invariants.test.mjs
+++ b/tests/a11y-issue-4373-invariants.test.mjs
@@ -148,6 +148,25 @@ describe('color-contrast — footer copyright', () => {
     assert.ok(contrastRatio(fg, bg) >= 4.5,
       `footer copy ${fg} on ${bg} must clear 4.5:1`);
   });
+
+  it('.site-footer-copy also clears AA in light theme', () => {
+    // cssToken() returns the first (dark/:root) value, so the light theme is
+    // unguarded otherwise — and #6b6b6b on #fff is only ~4.84:1, close enough
+    // that a token tweak could silently regress it.
+    const lightBlock = [...css.matchAll(/\[data-theme="light"\][^{]*\{([^}]*)\}/g)]
+      .map((m) => m[1])
+      .find((b) => /--text-dim:/.test(b) && /--surface:/.test(b));
+    assert.ok(lightBlock, 'light theme token block must define --text-dim and --surface');
+    const lightToken = (name) => {
+      const m = lightBlock.match(new RegExp(`--${name}:\\s*(#[0-9a-fA-F]{3,8})`));
+      assert.ok(m, `light theme --${name} must be a hex value`);
+      return m[1];
+    };
+    const fg = lightToken('text-dim');
+    const bg = lightToken('surface');
+    assert.ok(contrastRatio(fg, bg) >= 4.5,
+      `light-theme footer copy ${fg} on ${bg} must clear 4.5:1`);
+  });
 });
 
 // --- 5. DEFCON badge contrast ----------------------------------------------

--- a/tests/a11y-issue-4373-invariants.test.mjs
+++ b/tests/a11y-issue-4373-invariants.test.mjs
@@ -1,0 +1,226 @@
+/**
+ * Regression guard for the accessibility fixes in issue #4373:
+ *   - aria-required-children: the "+" add button must NOT be a child of the
+ *     role="tablist" element (PanelTabBar).
+ *   - color-contrast: footer copyright, DEFCON badge, and live/webcam "active"
+ *     pills must clear WCAG AA 4.5:1.
+ *   - select-name: #regionSelect must carry an aria-label.
+ *   - bypass: a <main> landmark and a skip link must exist.
+ *   - target-size: map time-range buttons and the layer-help "?" button must
+ *     present a >=24x24 hit area.
+ *
+ * These are source-invariant assertions (the components render via
+ * createElement / inline HTML strings with no DOM in the Node test runner,
+ * the same shape as notifications-settings-ui-invariants.test.mjs) plus real
+ * WCAG contrast math computed from the actual source values, so the contrast
+ * guards fail if someone regresses a color rather than just a string.
+ *
+ * Run: node --test tests/a11y-issue-4373-invariants.test.mjs
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const read = (...p) => readFileSync(resolve(__dirname, '..', ...p), 'utf-8');
+
+const css = read('src', 'styles', 'main.css');
+const tabBar = read('src', 'components', 'PanelTabBar.ts');
+const pizzint = read('src', 'components', 'PizzIntIndicator.ts');
+const panelLayout = read('src', 'app', 'panel-layout.ts');
+
+// --- WCAG contrast helpers -------------------------------------------------
+
+function hexToRgb(hex) {
+  const m = hex.replace('#', '').trim();
+  const full = m.length === 3 ? m.split('').map((c) => c + c).join('') : m;
+  return [0, 2, 4].map((i) => parseInt(full.slice(i, i + 2), 16));
+}
+
+function relativeLuminance(hex) {
+  const [r, g, b] = hexToRgb(hex).map((v) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function contrastRatio(a, b) {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// Extract a `--token: #value;` from the :root block of main.css.
+function cssToken(name) {
+  const m = css.match(new RegExp(`--${name}:\\s*(#[0-9a-fA-F]{3,8})`));
+  assert.ok(m, `--${name} token must be defined in main.css`);
+  return m[1];
+}
+
+// Self-check the contrast math against the issue's reported figures.
+describe('WCAG contrast helper sanity', () => {
+  it('reproduces the issue figures (within rounding)', () => {
+    assert.ok(Math.abs(contrastRatio('#5a5a5a', '#141414') - 2.67) < 0.1);
+    assert.ok(Math.abs(contrastRatio('#ffffff', '#2d8a6e') - 4.22) < 0.1);
+    assert.ok(Math.abs(contrastRatio('#ffffff', '#ff4444') - 3.41) < 0.1);
+  });
+});
+
+// --- 1. tablist child role (aria-required-children) ------------------------
+
+describe('PanelTabBar — add button is not a tablist child', () => {
+  it('role="tablist" lives on the inner tablist element, not the bar', () => {
+    assert.match(tabBar, /tablistEl\.setAttribute\('role',\s*'tablist'\)/);
+    assert.doesNotMatch(
+      tabBar,
+      /this\.element\.setAttribute\('role',\s*'tablist'\)/,
+      'the bar (this.element) must not be the tablist — the add button is its child',
+    );
+  });
+
+  it('the add button is a sibling of the tablist in the bar', () => {
+    // render() appends tabs to the tablist and re-parents [tablist, addBtn]
+    // onto the bar, so the tablist owns only role="tab" children.
+    assert.match(tabBar, /this\.tablistEl\.appendChild\(this\.renderTab\(/);
+    assert.match(tabBar, /this\.element\.replaceChildren\(this\.tablistEl,\s*addBtn\)/);
+  });
+});
+
+// --- 2. select-name --------------------------------------------------------
+
+describe('select-name — #regionSelect is labelled', () => {
+  it('regionSelect carries an aria-label', () => {
+    const line = panelLayout
+      .split('\n')
+      .find((l) => l.includes('id="regionSelect"'));
+    assert.ok(line, '#regionSelect must exist');
+    assert.match(line, /aria-label=/, '#regionSelect must have an aria-label');
+  });
+});
+
+// --- 3. bypass: <main> landmark + skip link --------------------------------
+
+describe('bypass — landmark and skip link', () => {
+  it('renders a <main id="main"> landmark wrapping the dashboard content', () => {
+    assert.match(panelLayout, /<main id="main"[^>]*class="main-content/);
+    assert.match(panelLayout, /<\/main>/);
+  });
+
+  it('renders a skip link targeting #main as the first focusable element', () => {
+    assert.match(panelLayout, /<a href="#main" class="skip-link">/);
+    const skipIdx = panelLayout.indexOf('class="skip-link"');
+    const headerIdx = panelLayout.indexOf('class="header"');
+    assert.ok(skipIdx > 0 && headerIdx > 0 && skipIdx < headerIdx,
+      'skip link must appear before the header in source order');
+  });
+
+  it('defines visually-hidden-until-focus skip-link CSS', () => {
+    assert.match(css, /\.skip-link\s*\{[^}]*position:\s*fixed/);
+    assert.match(css, /\.skip-link:focus[^{]*\{[^}]*transform:\s*translateY\(0\)/);
+  });
+
+  it('wires a skip-link click handler that focuses <main> (native fragment focus is unreliable)', () => {
+    const handlerIdx = panelLayout.indexOf("querySelector('.skip-link')?.addEventListener('click'");
+    assert.ok(handlerIdx > 0, 'skip-link click handler must be wired in renderLayout');
+    // The handler must move focus to #main.
+    const after = panelLayout.slice(handlerIdx, handlerIdx + 320);
+    assert.match(after, /getElementById\('main'\)/);
+    assert.match(after, /\.focus\(\)/);
+  });
+});
+
+// --- 4. footer copyright contrast ------------------------------------------
+
+describe('color-contrast — footer copyright', () => {
+  it('.site-footer-copy no longer fades --text-dim below AA', () => {
+    const block = css.match(/\.site-footer-copy\s*\{([^}]*)\}/);
+    assert.ok(block, '.site-footer-copy rule must exist');
+    const body = block[1].replace(/\/\*[\s\S]*?\*\//g, ''); // drop comments
+    assert.doesNotMatch(body, /opacity:/,
+      'the opacity fade dropped contrast to 2.67:1 — it must be gone');
+    const fg = cssToken('text-dim');
+    const bg = cssToken('surface');
+    assert.ok(contrastRatio(fg, bg) >= 4.5,
+      `footer copy ${fg} on ${bg} must clear 4.5:1`);
+  });
+});
+
+// --- 5. DEFCON badge contrast ----------------------------------------------
+
+describe('color-contrast — DEFCON badge', () => {
+  it('badge text is black, which clears AA on every DEFCON hue', () => {
+    assert.match(pizzint, /defconEl\.style\.color\s*=\s*'#000'/);
+    assert.doesNotMatch(pizzint, /defconEl\.style\.color\s*=\s*[^\n]*'#fff'/,
+      'white text failed on DEFCON 4 (blue) and 5 (green)');
+    const colors = pizzint.match(/DEFCON_COLORS[^}]*}/)[0];
+    for (const hex of colors.match(/#[0-9a-fA-F]{6}/g)) {
+      assert.ok(contrastRatio('#000000', hex) >= 4.5,
+        `black on DEFCON color ${hex} must clear 4.5:1`);
+    }
+  });
+});
+
+// --- 6. live / webcam "active" pill contrast -------------------------------
+
+describe('color-contrast — live/webcam active pills', () => {
+  it('--red-strong clears AA with white text', () => {
+    const red = cssToken('red-strong');
+    assert.ok(contrastRatio('#ffffff', red) >= 4.5,
+      `white on ${red} must clear 4.5:1`);
+  });
+
+  it('the known active/critical pills use --red-strong, not the failing --red', () => {
+    for (const sel of [
+      '.live-channel-btn.active',
+      '.webcam-region-btn.active',
+      '.webcam-view-btn.active',
+      '.webcam-feed-btn.active',
+      '.focal-point-urgency.critical',
+    ]) {
+      const block = css.match(
+        new RegExp(`${sel.replace(/[.]/g, '\\.')}\\s*\\{([^}]*)\\}`),
+      );
+      assert.ok(block, `${sel} rule must exist`);
+      assert.match(block[1], /background:\s*var\(--red-strong\)/,
+        `${sel} must use --red-strong`);
+    }
+  });
+
+  it('NO rule pairs white text with the failing 3.4:1 var(--red) background', () => {
+    // Comprehensive sweep: any rule whose own body sets both a white-ish
+    // foreground and `background: var(--red)` is a 3.41:1 color-contrast fail.
+    // Every such pill must move to --red-strong (≈5:1).
+    const offenders = [];
+    for (const m of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+      const body = m[2].replace(/\/\*[\s\S]*?\*\//g, '');
+      const whiteText = /color:\s*(white|#fff(f{0,3})?)\b/i.test(body);
+      const redBg = /background(-color)?:\s*var\(--red\)\s*;/.test(body);
+      if (whiteText && redBg) offenders.push(m[1].trim().slice(0, 60));
+    }
+    assert.deepEqual(offenders, [],
+      `white-on-var(--red) (3.41:1) rules must use --red-strong: ${offenders.join(' | ')}`);
+  });
+});
+
+// --- 7. tap target sizes ----------------------------------------------------
+
+describe('target-size — small map controls', () => {
+  it('time-range buttons present a >=24px hit area', () => {
+    const block = css.match(/\.deckgl-time-slider \.time-btn\s*\{([^}]*)\}/);
+    assert.ok(block, '.deckgl-time-slider .time-btn rule must exist');
+    assert.match(block[1], /min-height:\s*24px/);
+    assert.match(block[1], /min-width:\s*24px/);
+  });
+
+  it('layer-help "?" button is 24x24', () => {
+    const block = css.match(/\.layer-help-btn\s*\{([^}]*)\}/);
+    assert.ok(block, '.layer-help-btn rule must exist');
+    assert.match(block[1], /width:\s*24px/);
+    assert.match(block[1], /height:\s*24px/);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the concrete axe/Lighthouse accessibility failures in #4373 (a11y scores 0.84 desktop / 0.91 mobile). Cheap, high-confidence, independent of the perf work.

Every contrast fix was computed from the actual source values, and the tablist + landmark fixes were validated against **real axe-core 4.10.2** in a browser (not just reasoning).

## Fixes

| Failure | Fix |
|---|---|
| **`aria-required-children`** (critical) — the `[role=tablist]` bar owned a non-tab `<button class="dashboard-tab-add">` | Tabs now live in an inner `.dashboard-tablist[role=tablist]`; the `+` button is a sibling in the bar. Verified the default single-tab dashboard **passes** axe. |
| **`color-contrast`** — footer `© World Monitor` 2.67:1 | Removed the `opacity:0.6` fade → `--text-dim` (#888) on #141414 = **5.2:1**. |
| **`color-contrast`** — DEFCON badge (#fff/#2d8a6e = 4.22:1) | Badge text → black; all five DEFCON hues clear 4.5:1 (worst green = 4.97:1; white also failed level-4 blue at 2.56:1). |
| **`color-contrast`** — live/webcam pills (#fff/#ff4444 = 3.41:1) | New `--red-strong` (#d62b2b, **4.95:1** with white) applied to every white-on-`var(--red)` active/critical/hover pill (`.live-channel-btn.active`, `.webcam-region-btn.active`, `.webcam-view-btn.active`, `.webcam-feed-btn.active`, `.focal-point-urgency.critical`, and the `.offline-retry`/`.webcam-preview-play` `:hover` state). A stylesheet-wide sweep confirms **zero** white-on-`var(--red)` pairings remain. |
| **`select-name`** (critical) — `#regionSelect` unlabeled | `aria-label` via the existing `header.selectRegion` key. |
| **`bypass`** — no skip link / landmark | `<main id="main">` landmark + a focus-revealed skip link. |
| **`target-size`** — 36×23.5 / 20×20 controls | Map time-range buttons and the layer-help `?` button → **≥24×24**. |

### Notes
- **Skip link:** wired an explicit click handler that focuses `<main>` — native fragment focus on a `tabindex="-1"` target proved unreliable in-browser during hydration.
- **DEFCON / pills** use black-text or a darker-red token rather than enlarging text, since these are <18px.

## Tests
- `tests/a11y-issue-4373-invariants.test.mjs` — source invariants **plus real WCAG-contrast math** from the source hex values, including a sweep asserting **zero** remaining white-on-`var(--red)` rules.
- `e2e/a11y-landmarks-tablist.spec.ts` — real-DOM: tablist owns only `role=tab` (add button outside), single `<main>` landmark, skip link is first-tabbable and moves focus to `<main>`, `#regionSelect` has an accessible name.

Local: `tsc --noEmit`, biome, safe-HTML, `docs:check`, the new unit suite, the new e2e spec (4/4), and the related panel/layout/i18n suites all pass.

## Known follow-up (not in this PR)
With **2+ dashboard tabs**, the per-tab close buttons re-introduce `aria-required-children` — axe recurses through the generic `.dashboard-tab` wrapper and flags the grandchild `<button>`. This is **pre-existing** (the old structure had it too) and outside the single-tab state Lighthouse audited. The naive shield (`role=tab` on the wrapper) trades it for a `nested-interactive` violation (both confirmed via real axe), so a proper closeable-tab redesign (e.g. `Delete`-to-close + `aria-hidden` decoration) is left as a separate scoped change rather than half-fixed here.

Closes #4373

https://claude.ai/code/session_01Qjv6LNXsGbYXMs4FF24o22
