### PR TITLE
perf: split panel chunks by domain

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1281,7 +1281,7 @@ export class App {
     // Phase 3: UI setup methods
     this.eventHandlers.startHeaderClock();
     this.eventHandlers.setupPlaybackControl();
-    await this.eventHandlers.setupStatusPanel();
+    this.eventHandlers.setupStatusPanel();
     this.eventHandlers.setupPizzIntIndicator();
     this.eventHandlers.setupLlmStatusIndicator();
     this.eventHandlers.setupExportPanel();

--- a/src/App.ts
+++ b/src/App.ts
@@ -38,7 +38,9 @@ import { startLearning } from '@/services/country-instability';
 import { loadFromStorage, parseMapUrlState, saveToStorage, isMobileDevice } from '@/utils';
 import { clearPanelSpans, invalidatePanelStorageCacheForKeys } from '@/utils/panel-storage';
 import type { ParsedMapUrlState } from '@/utils';
-import { SignalModal, IntelligenceGapBadge, BreakingNewsBanner } from '@/components';
+import { SignalModal } from '@/components/SignalModal';
+import { IntelligenceGapBadge } from '@/components/IntelligenceGapBadge';
+import { BreakingNewsBanner } from '@/components/BreakingNewsBanner';
 import { initBreakingNewsAlerts, destroyBreakingNewsAlerts } from '@/services/breaking-news-alerts';
 import type { ServiceStatusPanel } from '@/components/ServiceStatusPanel';
 import type { StablecoinPanel } from '@/components/StablecoinPanel';
@@ -1279,7 +1281,7 @@ export class App {
     // Phase 3: UI setup methods
     this.eventHandlers.startHeaderClock();
     this.eventHandlers.setupPlaybackControl();
-    this.eventHandlers.setupStatusPanel();
+    await this.eventHandlers.setupStatusPanel();
     this.eventHandlers.setupPizzIntIndicator();
     this.eventHandlers.setupLlmStatusIndicator();
     this.eventHandlers.setupExportPanel();
@@ -1321,7 +1323,7 @@ export class App {
     // Phase 4: SearchManager, MapLayerHandlers, CountryIntel
     this.searchManager.init();
     this.eventHandlers.setupMapLayerHandlers();
-    this.countryIntel.init();
+    await this.countryIntel.init();
     // Unblock any WebMCP tool invocations that arrived during startup.
     this.resolveUiReady();
 

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -9,7 +9,6 @@ import type {
   CountryDeepDiveMilitarySummary,
   CountryDeepDiveSignalDetails,
 } from '@/components/CountryBriefPanel';
-import { CountryDeepDivePanel } from '@/components/CountryDeepDivePanel';
 import { reverseGeocode } from '@/utils/reverse-geocode';
 import { effectivePubDateMs } from '@/services/feed-date';
 import {
@@ -93,13 +92,14 @@ export class CountryIntelManager implements AppModule {
   // don't re-hammer fetchProSections.
   private authUnsubscribe: (() => void) | null = null;
   private lastHadPremium = false;
+  private countryBriefPageLoading: Promise<boolean> | null = null;
 
   constructor(ctx: AppContext) {
     this.ctx = ctx;
   }
 
-  init(): void {
-    this.setupCountryIntel();
+  async init(): Promise<void> {
+    await this.setupCountryIntel();
     this.frameworkUnsubscribe = subscribeFrameworkChange('country-brief', () => {
       const page = this.ctx.countryBriefPage;
       if (!page?.isVisible()) return;
@@ -130,14 +130,49 @@ export class CountryIntelManager implements AppModule {
     this.ctx.countryTimeline?.destroy();
     this.ctx.countryTimeline = null;
     this.ctx.countryBriefPage = null;
+    this.countryBriefPageLoading = null;
     this.frameworkUnsubscribe?.();
     this.frameworkUnsubscribe = null;
     this.authUnsubscribe?.();
     this.authUnsubscribe = null;
   }
 
-  private setupCountryIntel(): void {
+  private async setupCountryIntel(): Promise<void> {
     if (!this.ctx.map) return;
+    this.ctx.map.onCountryClicked((countryClick) => {
+      if (countryClick.code && countryClick.name) {
+        trackCountrySelected(countryClick.code, countryClick.name, 'map');
+        void this.openCountryBriefByCode(countryClick.code, countryClick.name);
+      } else {
+        void this.openCountryBrief(countryClick.lat, countryClick.lon);
+      }
+    });
+
+    this.ctx.map.onMapContextMenu((payload) => {
+      const items = [];
+      if (payload.countryCode && payload.countryName) {
+        items.push({ label: t('contextMenu.openCountryBrief'), action: () => void this.openCountryBriefByCode(payload.countryCode!, payload.countryName!) });
+      } else {
+        items.push({ label: t('contextMenu.openCountryBrief'), action: () => void this.openCountryBrief(payload.lat, payload.lon) });
+      }
+      items.push({ label: t('contextMenu.copyCoordinates'), action: () => navigator.clipboard.writeText(`${payload.lat.toFixed(5)}, ${payload.lon.toFixed(5)}`).catch(() => {}) });
+      showMapContextMenu(payload.screenX, payload.screenY, items);
+    });
+  }
+
+  private async ensureCountryBriefPage(): Promise<boolean> {
+    if (this.ctx.countryBriefPage) return true;
+    if (!this.ctx.map || this.ctx.isDestroyed) return false;
+    if (this.countryBriefPageLoading) return this.countryBriefPageLoading;
+    this.countryBriefPageLoading = this.createCountryBriefPage();
+    const ready = await this.countryBriefPageLoading;
+    this.countryBriefPageLoading = null;
+    return ready;
+  }
+
+  private async createCountryBriefPage(): Promise<boolean> {
+    const { CountryDeepDivePanel } = await import('@/components/CountryDeepDivePanel');
+    if (this.ctx.isDestroyed || !this.ctx.map) return false;
     this.ctx.countryBriefPage = new CountryDeepDivePanel(this.ctx.map);
     this.ctx.countryBriefPage.setShareStoryHandler((code, name) => {
       this.ctx.countryBriefPage?.hide();
@@ -167,26 +202,6 @@ export class CountryIntelManager implements AppModule {
       }
     });
 
-    this.ctx.map.onCountryClicked(async (countryClick) => {
-      if (countryClick.code && countryClick.name) {
-        trackCountrySelected(countryClick.code, countryClick.name, 'map');
-        this.openCountryBriefByCode(countryClick.code, countryClick.name);
-      } else {
-        this.openCountryBrief(countryClick.lat, countryClick.lon);
-      }
-    });
-
-    this.ctx.map.onMapContextMenu((payload) => {
-      const items = [];
-      if (payload.countryCode && payload.countryName) {
-        items.push({ label: t('contextMenu.openCountryBrief'), action: () => this.openCountryBriefByCode(payload.countryCode!, payload.countryName!) });
-      } else {
-        items.push({ label: t('contextMenu.openCountryBrief'), action: () => this.openCountryBrief(payload.lat, payload.lon) });
-      }
-      items.push({ label: t('contextMenu.copyCoordinates'), action: () => navigator.clipboard.writeText(`${payload.lat.toFixed(5)}, ${payload.lon.toFixed(5)}`).catch(() => {}) });
-      showMapContextMenu(payload.screenX, payload.screenY, items);
-    });
-
     this.ctx.countryBriefPage.onClose(() => {
       this.briefRequestToken++;
       this.ctx.map?.clearCountryHighlight();
@@ -194,34 +209,39 @@ export class CountryIntelManager implements AppModule {
       this.ctx.countryTimeline?.destroy();
       this.ctx.countryTimeline = null;
     });
+    return true;
   }
 
   async openCountryBrief(lat: number, lon: number): Promise<void> {
-    if (!this.ctx.countryBriefPage) return;
+    if (!(await this.ensureCountryBriefPage())) return;
+    const page = this.ctx.countryBriefPage;
+    if (!page) return;
     const token = ++this.briefRequestToken;
-    this.ctx.countryBriefPage.showLoading();
+    page.showLoading();
     this.ctx.map?.setRenderPaused(true);
 
     const localGeo = getCountryAtCoordinates(lat, lon);
     if (localGeo) {
       if (token !== this.briefRequestToken) return;
-      this.openCountryBriefByCode(localGeo.code, localGeo.name);
+      await this.openCountryBriefByCode(localGeo.code, localGeo.name);
       return;
     }
 
     const geo = await reverseGeocode(lat, lon);
     if (token !== this.briefRequestToken) return;
     if (!geo) {
-      this.ctx.countryBriefPage.hide();
+      page.hide();
       this.ctx.map?.setRenderPaused(false);
       return;
     }
 
-    this.openCountryBriefByCode(geo.code, geo.country);
+    await this.openCountryBriefByCode(geo.code, geo.country);
   }
 
   async openCountryBriefByCode(code: string, country: string, opts?: { maximize?: boolean }): Promise<void> {
-    if (!this.ctx.countryBriefPage) return;
+    if (!(await this.ensureCountryBriefPage())) return;
+    const page = this.ctx.countryBriefPage;
+    if (!page) return;
     this.ctx.map?.setRenderPaused(true);
     trackCountryBriefOpened(code);
 
@@ -233,7 +253,7 @@ export class CountryIntelManager implements AppModule {
 
     const signals = this.getCountrySignals(code, country);
 
-    this.ctx.countryBriefPage.show(country, code, score, signals);
+    page.show(country, code, score, signals);
     this.ctx.map?.highlightCountry(code);
     this.ctx.map?.fitCountry(code);
 
@@ -245,9 +265,9 @@ export class CountryIntelManager implements AppModule {
         }
       });
     }
-    this.ctx.countryBriefPage.updateSignalDetails?.(this.buildSignalDetails(code));
-    this.ctx.countryBriefPage.updateMilitaryActivity?.(this.buildMilitarySummary(code, country));
-    this.ctx.countryBriefPage.updateEconomicIndicators?.(this.buildEconomicIndicators(code, score, null));
+    page.updateSignalDetails?.(this.buildSignalDetails(code));
+    page.updateMilitaryActivity?.(this.buildMilitarySummary(code, country));
+    page.updateEconomicIndicators?.(this.buildEconomicIndicators(code, score, null));
 
     const marketClient = new MarketServiceClient(getRpcBaseUrl(), { fetch: (...args: Parameters<typeof globalThis.fetch>) => globalThis.fetch(...args) });
     const stockPromise = marketClient.getCountryStockIndex({ countryCode: code })
@@ -304,9 +324,9 @@ export class CountryIntelManager implements AppModule {
       if (severityDelta !== 0) return severityDelta;
       return effectivePubDateMs(b) - effectivePubDateMs(a);
     });
-    this.ctx.countryBriefPage.updateNews(filteredNews.slice(0, 10));
+    page.updateNews(filteredNews.slice(0, 10));
 
-    this.ctx.countryBriefPage.updateInfrastructure(code);
+    page.updateInfrastructure(code);
 
     const intelClient = new IntelligenceServiceClient(getRpcBaseUrl(), {
       fetch: (...args: Parameters<typeof globalThis.fetch>) => globalThis.fetch(...args),

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -3,7 +3,7 @@ import { getRpcBaseUrl } from '@/services/rpc-client';
 import { enqueuePanelCall } from '@/app/pending-panel-data';
 import type { NewsItem, MapLayers, SocialUnrestEvent } from '@/types';
 import type { MarketData } from '@/types';
-import type { TimeRange } from '@/components';
+import type { TimeRange } from '@/components/MapContainer';
 import {
   FEEDS,
   CANONICAL_FEEDS,
@@ -143,40 +143,39 @@ import { getHydratedData } from '@/services/bootstrap';
 import { ingestHeadlines } from '@/services/trending-keywords';
 import type { ListFeedDigestResponse } from '@/generated/client/worldmonitor/news/v1/service_client';
 import type { GetSectorSummaryResponse, ListMarketQuotesResponse, ListCommodityQuotesResponse } from '@/generated/client/worldmonitor/market/v1/service_client';
-import type { SectorValuation } from '@/components/MarketPanel';
+import type {
+  AiTokensPanel,
+  CommoditiesPanel,
+  CryptoHeatmapPanel,
+  CryptoPanel,
+  DefiTokensPanel,
+  HeatmapPanel,
+  MarketPanel,
+  OtherTokensPanel,
+  SectorValuation,
+} from '@/components/MarketPanel';
 import { mountCommunityWidget } from '@/components/CommunityWidget';
 import { ResearchServiceClient } from '@/generated/client/worldmonitor/research/v1/service_client';
-import {
-  MarketPanel,
-  StockAnalysisPanel,
-  StockBacktestPanel,
-  HeatmapPanel,
-  CommoditiesPanel,
-  CryptoPanel,
-  CryptoHeatmapPanel,
-  DefiTokensPanel,
-  AiTokensPanel,
-  OtherTokensPanel,
-  PredictionPanel,
-  MonitorPanel,
-  InsightsPanel,
-  ThreatTimelinePanel,
-  CIIPanel,
-  InternetDisruptionsPanel,
-  StrategicPosturePanel,
-  EconomicPanel,
-  EnergyComplexPanel,
-  TechReadinessPanel,
-  UcdpEventsPanel,
-  TradePolicyPanel,
-  SupplyChainPanel,
-  DiseaseOutbreaksPanel,
-  SocialVelocityPanel,
-  WsbTickerScannerPanel,
-  AAIISentimentPanel,
-  MarketBreadthPanel,
-} from '@/components';
-import { SatelliteFiresPanel } from '@/components/SatelliteFiresPanel';
+import type { StockAnalysisPanel } from '@/components/StockAnalysisPanel';
+import type { StockBacktestPanel } from '@/components/StockBacktestPanel';
+import type { PredictionPanel } from '@/components/PredictionPanel';
+import type { MonitorPanel } from '@/components/MonitorPanel';
+import type { InsightsPanel } from '@/components/InsightsPanel';
+import type { ThreatTimelinePanel } from '@/components/ThreatTimelinePanel';
+import type { InternetDisruptionsPanel } from '@/components/InternetDisruptionsPanel';
+import type { StrategicPosturePanel } from '@/components/StrategicPosturePanel';
+import type { EconomicPanel } from '@/components/EconomicPanel';
+import type { EnergyComplexPanel } from '@/components/EnergyComplexPanel';
+import type { TechReadinessPanel } from '@/components/TechReadinessPanel';
+import type { UcdpEventsPanel } from '@/components/UcdpEventsPanel';
+import type { TradePolicyPanel } from '@/components/TradePolicyPanel';
+import type { SupplyChainPanel } from '@/components/SupplyChainPanel';
+import type { DiseaseOutbreaksPanel } from '@/components/DiseaseOutbreaksPanel';
+import type { SocialVelocityPanel } from '@/components/SocialVelocityPanel';
+import type { WsbTickerScannerPanel } from '@/components/WsbTickerScannerPanel';
+import type { AAIISentimentPanel } from '@/components/AAIISentimentPanel';
+import type { MarketBreadthPanel } from '@/components/MarketBreadthPanel';
+import type { SatelliteFiresPanel } from '@/components/SatelliteFiresPanel';
 import { classifyNewsItem } from '@/services/positive-classifier';
 import { fetchGivingSummary } from '@/services/giving';
 import { fetchProgressData } from '@/services/progress-data';
@@ -480,7 +479,7 @@ export class DataLoaderManager implements AppModule {
 
   private renderCachedCiiScores(cached: CachedRiskScores): void {
     this.cachedRiskScores = cached;
-    (this.ctx.panels['cii'] as CIIPanel)?.renderFromCached(cached);
+    this.callPanel('cii', 'renderFromCached', cached);
     this.applyCiiScoresToMap(cached.cii.map(toCountryScore));
   }
 
@@ -493,7 +492,7 @@ export class DataLoaderManager implements AppModule {
     }
 
     const shouldUseLocalFallback = forceLocal || !this.cachedRiskScores;
-    (this.ctx.panels['cii'] as CIIPanel)?.refresh(shouldUseLocalFallback);
+    this.callPanel('cii', 'refresh', shouldUseLocalFallback);
     this.callbacks.refreshOpenCountryBrief();
     const scores = calculateCII();
     this.applyCiiScoresToMap(scores);
@@ -1369,7 +1368,7 @@ export class DataLoaderManager implements AppModule {
     const categories = resolveNewsCategories(
       FEEDS,
       CANONICAL_FEEDS,
-      enabledNewsCategoryKeys(this.ctx.newsPanels, this.ctx.panels, this.ctx.panelSettings),
+      enabledNewsCategoryKeys(this.ctx.newsPanels, this.ctx.panels, this.ctx.panelSettings, Object.keys(CANONICAL_FEEDS)),
     );
 
     const maxCategoryConcurrency = SITE_VARIANT === 'tech' ? 4 : 5;

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -13,17 +13,14 @@ import type { McpDataPanel } from '@/components/McpDataPanel';
 import { openMcpConnectModal } from '@/components/McpConnectModal';
 import { deleteMcpPanel, getMcpPanel, saveMcpPanel } from '@/services/mcp-store';
 import type { PanelConfig, MapLayers, MilitaryFlight } from '@/types';
-import type { MapView } from '@/components';
+import type { MapView } from '@/components/MapContainer';
 import type { PositionSample } from '@/services/aviation';
 import type { ClusteredEvent } from '@/types';
 import type { DashboardSnapshot } from '@/services/storage';
-import {
-  PlaybackControl,
-  StatusPanel,
-  PizzIntIndicator,
-  LlmStatusIndicator,
-  PredictionPanel,
-} from '@/components';
+import { PlaybackControl } from '@/components/PlaybackControl';
+import { PizzIntIndicator } from '@/components/PizzIntIndicator';
+import { LlmStatusIndicator } from '@/components/LlmStatusIndicator';
+import type { PredictionPanel } from '@/components/PredictionPanel';
 import {
   buildMapUrl,
   debounce,
@@ -1510,7 +1507,9 @@ export class EventHandlerManager implements AppModule {
     this.clockIntervalId = setInterval(tick, 1000);
   }
 
-  setupStatusPanel(): void {
+  async setupStatusPanel(): Promise<void> {
+    const { StatusPanel } = await import('@/components/StatusPanel');
+    if (this.ctx.isDestroyed) return;
     this.ctx.statusPanel = new StatusPanel();
   }
 
@@ -2073,7 +2072,7 @@ export class EventHandlerManager implements AppModule {
     const sources = new Set<string>();
     // Preset feeds + sources from any custom news panels the user added, so
     // the source manager stays in sync with what loadNews() actually fetches.
-    const categories = resolveNewsCategories(FEEDS, CANONICAL_FEEDS, enabledNewsCategoryKeys(this.ctx.newsPanels, this.ctx.panels, this.ctx.panelSettings));
+    const categories = resolveNewsCategories(FEEDS, CANONICAL_FEEDS, enabledNewsCategoryKeys(this.ctx.newsPanels, this.ctx.panels, this.ctx.panelSettings, Object.keys(CANONICAL_FEEDS)));
     categories.forEach(({ feeds }) => feeds.forEach(f => sources.add(f.name)));
     INTEL_SOURCES.forEach(f => sources.add(f.name));
     return Array.from(sources).sort((a, b) => a.localeCompare(b));

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -1507,10 +1507,15 @@ export class EventHandlerManager implements AppModule {
     this.clockIntervalId = setInterval(tick, 1000);
   }
 
-  async setupStatusPanel(): Promise<void> {
-    const { StatusPanel } = await import('@/components/StatusPanel');
-    if (this.ctx.isDestroyed) return;
-    this.ctx.statusPanel = new StatusPanel();
+  setupStatusPanel(): void {
+    void import('@/components/StatusPanel')
+      .then(({ StatusPanel }) => {
+        if (this.ctx.isDestroyed) return;
+        this.ctx.statusPanel = new StatusPanel();
+      })
+      .catch((err) => {
+        console.error('[status-panel] failed to lazy-load StatusPanel', err);
+      });
   }
 
   setupPizzIntIndicator(): void {

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -134,6 +134,8 @@ interface LazyPanelRegistration {
   loading: Promise<Panel | null> | null;
 }
 
+type PanelConstructor<T extends Panel> = new (...args: unknown[]) => T;
+
 type HydrationSchedulePhase = 'visible' | 'near';
 
 export class PanelLayoutManager implements AppModule {
@@ -1394,11 +1396,21 @@ export class PanelLayoutManager implements AppModule {
     this.lazyPanel('oil-inventories', () => import('@/components/OilInventoriesPanel').then(m => new m.OilInventoriesPanel()));
     this.lazyPanel('energy-crisis', () => import('@/components/EnergyCrisisPanel').then(m => new m.EnergyCrisisPanel()));
     this.lazyPanel('chokepoint-strip', () => import('@/components/ChokepointStripPanel').then(m => new m.ChokepointStripPanel()));
-    this.lazyPanel('pipeline-status', () => import('@/components/PipelineStatusPanel').then(m => new m.PipelineStatusPanel()));
-    this.lazyPanel('storage-facility-map', () => import('@/components/StorageFacilityMapPanel').then(m => new m.StorageFacilityMapPanel()));
-    this.lazyPanel('fuel-shortages', () => import('@/components/FuelShortagePanel').then(m => new m.FuelShortagePanel()));
-    this.lazyPanel('energy-disruptions', () => import('@/components/EnergyDisruptionsPanel').then(m => new m.EnergyDisruptionsPanel()));
-    this.lazyPanel('energy-risk-overview', () => import('@/components/EnergyRiskOverviewPanel').then(m => new m.EnergyRiskOverviewPanel()));
+    this.lazyPanel('pipeline-status', () =>
+      this.importPanel('pipeline-status', () => import('@/components/PipelineStatusPanel'), 'PipelineStatusPanel', (PipelineStatusPanel) => new PipelineStatusPanel()),
+    );
+    this.lazyPanel('storage-facility-map', () =>
+      this.importPanel('storage-facility-map', () => import('@/components/StorageFacilityMapPanel'), 'StorageFacilityMapPanel', (StorageFacilityMapPanel) => new StorageFacilityMapPanel()),
+    );
+    this.lazyPanel('fuel-shortages', () =>
+      this.importPanel('fuel-shortages', () => import('@/components/FuelShortagePanel'), 'FuelShortagePanel', (FuelShortagePanel) => new FuelShortagePanel()),
+    );
+    this.lazyPanel('energy-disruptions', () =>
+      this.importPanel('energy-disruptions', () => import('@/components/EnergyDisruptionsPanel'), 'EnergyDisruptionsPanel', (EnergyDisruptionsPanel) => new EnergyDisruptionsPanel()),
+    );
+    this.lazyPanel('energy-risk-overview', () =>
+      this.importPanel('energy-risk-overview', () => import('@/components/EnergyRiskOverviewPanel'), 'EnergyRiskOverviewPanel', (EnergyRiskOverviewPanel) => new EnergyRiskOverviewPanel()),
+    );
     this.lazyPanel('polymarket', () => import('@/components/PredictionPanel').then(m => new m.PredictionPanel()));
 
     this.createNewsPanel('gov', 'panels.gov');
@@ -1474,10 +1486,20 @@ export class PanelLayoutManager implements AppModule {
     this.lazyPanel('gdelt-intel', () => import('@/components/GdeltIntelPanel').then(m => new m.GdeltIntelPanel()));
 
     this.lazyPanel('deduction', () =>
-      import('@/components/DeductionPanel').then(({ DeductionPanel }) => new DeductionPanel(() => this.ctx.allNews)),
+      this.importPanel(
+        'deduction',
+        () => import('@/components/DeductionPanel'),
+        'DeductionPanel',
+        (DeductionPanel) => new DeductionPanel(() => this.ctx.allNews),
+      ),
     );
     this.lazyPanel('regional-intelligence', () =>
-      import('@/components/RegionalIntelligenceBoard').then(({ RegionalIntelligenceBoard }) => new RegionalIntelligenceBoard()),
+      this.importPanel(
+        'regional-intelligence',
+        () => import('@/components/RegionalIntelligenceBoard'),
+        'RegionalIntelligenceBoard',
+        (RegionalIntelligenceBoard) => new RegionalIntelligenceBoard(),
+      ),
     );
 
     this.lazyPanel('cii', () => import('@/components/CIIPanel').then(m => {
@@ -1529,7 +1551,6 @@ export class PanelLayoutManager implements AppModule {
     this.lazyPanel('strategic-posture', () => import('@/components/StrategicPosturePanel').then(m => {
       const strategicPosturePanel = new m.StrategicPosturePanel(() => this.ctx.allNews);
       strategicPosturePanel.setLocationClickHandler((lat, lon) => {
-        console.log('[App] StrategicPosture handler called:', { lat, lon, hasMap: !!this.ctx.map });
         this.ctx.map?.setCenter(lat, lon, 4);
       });
       return strategicPosturePanel;
@@ -1654,12 +1675,24 @@ export class PanelLayoutManager implements AppModule {
       }),
     );
 
-    this.lazyPanel('gulf-economies', () => import('@/components/GulfEconomiesPanel').then(m => new m.GulfEconomiesPanel()));
-    this.lazyPanel('grocery-basket', () => import('@/components/GroceryBasketPanel').then(m => new m.GroceryBasketPanel()));
-    this.lazyPanel('bigmac', () => import('@/components/BigMacPanel').then(m => new m.BigMacPanel()));
-    this.lazyPanel('fuel-prices', () => import('@/components/FuelPricesPanel').then(m => new m.FuelPricesPanel()));
-    this.lazyPanel('fao-food-price-index', () => import('@/components/FaoFoodPriceIndexPanel').then(m => new m.FaoFoodPriceIndexPanel()));
-    this.lazyPanel('climate-news', () => import('@/components/ClimateNewsPanel').then(m => new m.ClimateNewsPanel()));
+    this.lazyPanel('gulf-economies', () =>
+      this.importPanel('gulf-economies', () => import('@/components/GulfEconomiesPanel'), 'GulfEconomiesPanel', (GulfEconomiesPanel) => new GulfEconomiesPanel()),
+    );
+    this.lazyPanel('grocery-basket', () =>
+      this.importPanel('grocery-basket', () => import('@/components/GroceryBasketPanel'), 'GroceryBasketPanel', (GroceryBasketPanel) => new GroceryBasketPanel()),
+    );
+    this.lazyPanel('bigmac', () =>
+      this.importPanel('bigmac', () => import('@/components/BigMacPanel'), 'BigMacPanel', (BigMacPanel) => new BigMacPanel()),
+    );
+    this.lazyPanel('fuel-prices', () =>
+      this.importPanel('fuel-prices', () => import('@/components/FuelPricesPanel'), 'FuelPricesPanel', (FuelPricesPanel) => new FuelPricesPanel()),
+    );
+    this.lazyPanel('fao-food-price-index', () =>
+      this.importPanel('fao-food-price-index', () => import('@/components/FaoFoodPriceIndexPanel'), 'FaoFoodPriceIndexPanel', (FaoFoodPriceIndexPanel) => new FaoFoodPriceIndexPanel()),
+    );
+    this.lazyPanel('climate-news', () =>
+      this.importPanel('climate-news', () => import('@/components/ClimateNewsPanel'), 'ClimateNewsPanel', (ClimateNewsPanel) => new ClimateNewsPanel()),
+    );
 
     this.lazyPanel('live-news', () =>
       import('@/components/LiveNewsPanel').then((m) => {
@@ -1671,7 +1704,14 @@ export class PanelLayoutManager implements AppModule {
     this.lazyPanel('live-webcams', () => import('@/components/LiveWebcamsPanel').then(m => new m.LiveWebcamsPanel()));
     this.lazyPanel('windy-webcams', () => import('@/components/PinnedWebcamsPanel').then(m => new m.PinnedWebcamsPanel()));
 
-    this.lazyPanel('events', () => import('@/components/TechEventsPanel').then(m => new m.TechEventsPanel('events', () => this.ctx.allNews)));
+    this.lazyPanel('events', () =>
+      this.importPanel(
+        'events',
+        () => import('@/components/TechEventsPanel'),
+        'TechEventsPanel',
+        (TechEventsPanel) => new TechEventsPanel('events', () => this.ctx.allNews),
+      ),
+    );
     this.lazyPanel('internet-disruptions', () => import('@/components/InternetDisruptionsPanel').then(m => new m.InternetDisruptionsPanel()));
     this.lazyPanel('service-status', () => import('@/components/ServiceStatusPanel').then(m => new m.ServiceStatusPanel()));
 
@@ -1722,7 +1762,9 @@ export class PanelLayoutManager implements AppModule {
       import('@/components/RegulationPanel').then(m => new m.RegulationPanel('ai-regulation')),
     );
 
-    this.lazyPanel('macro-signals', () => import('@/components/MacroSignalsPanel').then(m => new m.MacroSignalsPanel()));
+    this.lazyPanel('macro-signals', () =>
+      this.importPanel('macro-signals', () => import('@/components/MacroSignalsPanel'), 'MacroSignalsPanel', (MacroSignalsPanel) => new MacroSignalsPanel()),
+    );
     this.lazyPanel('fear-greed', () => import('@/components/FearGreedPanel').then(m => new m.FearGreedPanel()));
     this.lazyPanel('aaii-sentiment', () => import('@/components/AAIISentimentPanel').then(m => new m.AAIISentimentPanel()));
     this.lazyPanel('market-breadth', () => import('@/components/MarketBreadthPanel').then(m => new m.MarketBreadthPanel()));
@@ -1836,7 +1878,12 @@ export class PanelLayoutManager implements AppModule {
       }
       const capturedSpec = spec;
       this.lazyPanel(spec.id, () =>
-        import('@/components/CustomWidgetPanel').then(m => new m.CustomWidgetPanel(capturedSpec)),
+        this.importPanel(
+          spec.id,
+          () => import('@/components/CustomWidgetPanel'),
+          'CustomWidgetPanel',
+          (CustomWidgetPanel) => new CustomWidgetPanel(capturedSpec),
+        ),
       );
     }
 
@@ -1846,7 +1893,12 @@ export class PanelLayoutManager implements AppModule {
       }
       const capturedSpec = spec;
       this.lazyPanel(spec.id, () =>
-        import('@/components/McpDataPanel').then(m => new m.McpDataPanel(capturedSpec)),
+        this.importPanel(
+          spec.id,
+          () => import('@/components/McpDataPanel'),
+          'McpDataPanel',
+          (McpDataPanel) => new McpDataPanel(capturedSpec),
+        ),
       );
     }
 
@@ -2180,28 +2232,37 @@ export class PanelLayoutManager implements AppModule {
     }
   }
 
+  private addDynamicPanel(key: string, panel: Panel): void {
+    this.ctx.panels[key] = panel;
+    const el = panel.getElement();
+    this.makeDraggable(el, key);
+    const grid = document.getElementById('panelsGrid');
+    if (grid) {
+      const addBlock = grid.querySelector('.add-panel-block');
+      if (addBlock) {
+        grid.insertBefore(el, addBlock);
+      } else {
+        grid.appendChild(el);
+      }
+      this.mobilePanelNav?.applyToNewPanel(el);
+      panel.notifyConnected();
+      this.afterPanelMounted(key, panel);
+    }
+    this.savePanelOrder();
+    this.applyPanelSettings();
+  }
+
   addCustomWidget(spec: CustomWidgetSpec): void {
     saveWidget(spec);
     this.ctx.panelSettings[spec.id] = { name: spec.title, enabled: true, priority: 3 };
     saveToStorage(STORAGE_KEYS.panels, this.ctx.panelSettings);
-    import('@/components/CustomWidgetPanel').then((m) => {
-      const panel = new m.CustomWidgetPanel(spec);
-      this.ctx.panels[spec.id] = panel;
-      const el = panel.getElement();
-      this.makeDraggable(el, spec.id);
-      const grid = document.getElementById('panelsGrid');
-      if (grid) {
-        const addBlock = grid.querySelector('.add-panel-block');
-        if (addBlock) {
-          grid.insertBefore(el, addBlock);
-        } else {
-          grid.appendChild(el);
-        }
-      }
-      this.savePanelOrder();
-      this.applyPanelSettings();
-    }).catch((err) => {
-      console.error(`[panel] failed to lazy-load "${spec.id}"`, err);
+    void this.importPanel(
+      spec.id,
+      () => import('@/components/CustomWidgetPanel'),
+      'CustomWidgetPanel',
+      (CustomWidgetPanel) => new CustomWidgetPanel(spec),
+    ).then((panel) => {
+      if (panel) this.addDynamicPanel(spec.id, panel);
     });
   }
 
@@ -2209,24 +2270,13 @@ export class PanelLayoutManager implements AppModule {
     saveMcpPanel(spec);
     this.ctx.panelSettings[spec.id] = { name: spec.title, enabled: true, priority: 3 };
     saveToStorage(STORAGE_KEYS.panels, this.ctx.panelSettings);
-    import('@/components/McpDataPanel').then((m) => {
-      const panel = new m.McpDataPanel(spec);
-      this.ctx.panels[spec.id] = panel;
-      const el = panel.getElement();
-      this.makeDraggable(el, spec.id);
-      const grid = document.getElementById('panelsGrid');
-      if (grid) {
-        const addBlock = grid.querySelector('.add-panel-block');
-        if (addBlock) {
-          grid.insertBefore(el, addBlock);
-        } else {
-          grid.appendChild(el);
-        }
-      }
-      this.savePanelOrder();
-      this.applyPanelSettings();
-    }).catch((err) => {
-      console.error(`[panel] failed to lazy-load "${spec.id}"`, err);
+    void this.importPanel(
+      spec.id,
+      () => import('@/components/McpDataPanel'),
+      'McpDataPanel',
+      (McpDataPanel) => new McpDataPanel(spec),
+    ).then((panel) => {
+      if (panel) this.addDynamicPanel(spec.id, panel);
     });
   }
 
@@ -2513,7 +2563,26 @@ export class PanelLayoutManager implements AppModule {
     }
   }
 
-  private lazyPanel<T extends { getElement(): HTMLElement }>(
+  private importPanel<T extends Panel, K extends string>(
+    key: string,
+    importer: () => Promise<Record<K, unknown>>,
+    exportName: K,
+    createPanel: (PanelClass: PanelConstructor<T>) => T,
+  ): Promise<T | null> {
+    return importer().then((module) => {
+      const PanelClass = module[exportName];
+      if (typeof PanelClass !== 'function') {
+        console.error(`[panel] ${exportName} export unavailable for "${key}"`);
+        return null;
+      }
+      return createPanel(PanelClass as PanelConstructor<T>);
+    }, (err) => {
+      console.error(`[panel] failed to lazy-load "${key}"`, err);
+      return null;
+    });
+  }
+
+  private lazyPanel<T extends Panel>(
     key: string,
     loader: () => Promise<T | null>,
     setup?: (panel: T) => void,
@@ -2527,7 +2596,7 @@ export class PanelLayoutManager implements AppModule {
         if (this.ctx.isDestroyed) return null;
         const panel = await loader();
         if (!panel) return null;
-        const basePanel = panel as unknown as Panel;
+        const basePanel = panel;
         if (this.ctx.isDestroyed) {
           basePanel.destroy?.();
           return null;

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -11,90 +11,9 @@ import { effectivePubDateMs } from '@/services/feed-date';
 import type { ClusteredEvent, MapLayers, PanelConfig } from '@/types';
 import type { RelatedAsset } from '@/types';
 import type { TheaterPostureSummary } from '@/services/military-surge';
-import {
-  NewsPanel,
-  MarketPanel,
-  StockAnalysisPanel,
-  StockBacktestPanel,
-  HeatmapPanel,
-  CommoditiesPanel,
-  CryptoPanel,
-  CryptoHeatmapPanel,
-  DefiTokensPanel,
-  AiTokensPanel,
-  OtherTokensPanel,
-  PredictionPanel,
-  MonitorPanel,
-  LatestBriefPanel,
-  EconomicPanel,
-  ConsumerPricesPanel,
-  EnergyComplexPanel,
-  OilInventoriesPanel,
-  GdeltIntelPanel,
-  LiveNewsPanel,
-  getDefaultLiveChannels,
-  loadChannelsFromStorage,
-  LiveWebcamsPanel,
-  PinnedWebcamsPanel,
-  CIIPanel,
-  CascadePanel,
-  StrategicRiskPanel,
-  StrategicPosturePanel,
-  TechEventsPanel,
-  ServiceStatusPanel,
-  InternetDisruptionsPanel,
-  RuntimeConfigPanel,
-  InsightsPanel,
-  ThreatTimelinePanel,
-  MacroSignalsPanel,
-  FearGreedPanel,
-  MarketBreadthPanel,
-  ETFFlowsPanel,
-  StablecoinPanel,
-  UcdpEventsPanel,
-  InvestmentsPanel,
-  TradePolicyPanel,
-  SupplyChainPanel,
-  SanctionsPressurePanel,
-  GulfEconomiesPanel,
-  GroceryBasketPanel,
-  BigMacPanel,
-  FuelPricesPanel,
-  FaoFoodPriceIndexPanel,
-  ClimateNewsPanel,
-  WorldClockPanel,
-  AirlineIntelPanel,
-  AviationCommandBar,
-  MilitaryCorrelationPanel,
-  EscalationCorrelationPanel,
-  EconomicCorrelationPanel,
-  DisasterCorrelationPanel,
-  DefensePatentsPanel,
-  HormuzPanel,
-  ChokepointStripPanel,
-  PipelineStatusPanel,
-  StorageFacilityMapPanel,
-  FuelShortagePanel,
-  EnergyDisruptionsPanel,
-  EnergyRiskOverviewPanel,
-  MacroTilesPanel,
-  FSIPanel,
-  YieldCurvePanel,
-  EarningsCalendarPanel,
-  EconomicCalendarPanel,
-  CotPositioningPanel,
-  LiquidityShiftsPanel,
-  PositioningPanel,
-  GoldIntelligencePanel,
-  DiseaseOutbreaksPanel,
-  SocialVelocityPanel,
-  WsbTickerScannerPanel,
-  AAIISentimentPanel,
-  EnergyCrisisPanel,
-  MobilePanelNav,
-} from '@/components';
-import { SatelliteFiresPanel } from '@/components/SatelliteFiresPanel';
-import { focusInvestmentOnMap } from '@/services/investments-focus';
+import type { NewsPanel } from '@/components/NewsPanel';
+import type { AviationCommandBar } from '@/components/AviationCommandBar';
+import { MobilePanelNav } from '@/components/MobilePanelNav';
 import { debounce, saveToStorage } from '@/utils';
 import { escapeHtml } from '@/utils/sanitize';
 import {
@@ -116,7 +35,6 @@ import { t } from '@/services/i18n';
 import { getCurrentTheme } from '@/utils';
 import { trackCriticalBannerAction } from '@/services/analytics';
 import { getStoredMapModePreference } from '@/services/map-mode-preference';
-import { CustomWidgetPanel } from '@/components/CustomWidgetPanel';
 import { openWidgetChatModal } from '@/components/WidgetChatModal';
 import { loadWidgets, saveWidget, isProUser } from '@/services/widget-store';
 import type { CustomWidgetSpec } from '@/services/widget-store';
@@ -126,7 +44,6 @@ import { initPaymentFailureBanner } from '@/components/payment-failure-banner';
 import { handleCheckoutReturn } from '@/services/checkout-return';
 import { initCheckoutOverlay, destroyCheckoutOverlay, showCheckoutSuccess, consumePostCheckoutFlag, clearCheckoutAttempt } from '@/services/checkout';
 import { showCheckoutFailureBanner } from '@/components/checkout-failure-banner';
-import { McpDataPanel } from '@/components/McpDataPanel';
 import { openMcpConnectModal } from '@/components/McpConnectModal';
 import { PanelTabBar } from '@/components/PanelTabBar';
 import {
@@ -193,6 +110,8 @@ const WEB_CLERK_PRO_ONLY_PANELS = new Set([
   'latest-brief',
 ]);
 
+const COLLIDING_NEWS_PANEL_KEYS = new Set(['markets', 'crypto', 'economic']);
+
 export interface PanelLayoutManagerCallbacks {
   openCountryStory: (code: string, name: string) => void;
   openCountryBrief: (code: string) => void;
@@ -203,10 +122,16 @@ export interface PanelLayoutManagerCallbacks {
 }
 
 interface DeferredPanelMount {
-  panel: Panel;
+  panel: Panel | null;
   placeholder: HTMLElement | null;
   observer: IntersectionObserver | null;
   mounted: boolean;
+  loading: Promise<void> | null;
+}
+
+interface LazyPanelRegistration {
+  load: () => Promise<Panel | null>;
+  loading: Promise<Panel | null> | null;
 }
 
 type HydrationSchedulePhase = 'visible' | 'near';
@@ -216,6 +141,8 @@ export class PanelLayoutManager implements AppModule {
   private callbacks: PanelLayoutManagerCallbacks;
   private panelDragCleanupHandlers: Array<() => void> = [];
   private deferredPanelMounts: Map<string, DeferredPanelMount> = new Map();
+  private lazyPanelRegistrations: Map<string, LazyPanelRegistration> = new Map();
+  private observedHydrationPanels = new WeakSet<Panel>();
   private initiallyMountedEnabledPanelCount = 0;
   private resolvedPanelOrder: string[] = [];
   private bottomSetMemory: Set<string> = new Set();
@@ -406,6 +333,7 @@ export class PanelLayoutManager implements AppModule {
       deferred.observer?.disconnect();
     }
     this.deferredPanelMounts.clear();
+    this.lazyPanelRegistrations.clear();
     this.initiallyMountedEnabledPanelCount = 0;
     this.cancelScheduledLoadAllIdle();
     if (this.scheduledLoadAllRaf !== null) {
@@ -1134,19 +1062,29 @@ export class PanelLayoutManager implements AppModule {
    */
   mountLiveNewsIfReady(): void {
     if (this.ctx.panels['live-news']) return;
-    if (getDefaultLiveChannels().length === 0 && loadChannelsFromStorage().length === 0) return;
-    const panel = new LiveNewsPanel();
-    this.ctx.panels['live-news'] = panel;
-    const el = panel.getElement();
-    this.makeDraggable(el, 'live-news');
     const grid = document.getElementById('panelsGrid');
-    if (grid) {
-      const addBlock = grid.querySelector('.add-panel-block');
-      if (addBlock) grid.insertBefore(el, addBlock);
-      else grid.appendChild(el);
+    if (this.lazyPanelRegistrations.has('live-news') && grid) {
+      this.mountLazyPanel('live-news', grid);
+      return;
     }
-    this.applyPanelSettings();
-    panel.observeNearViewport(() => this.scheduleLoadAllData(), 200);
+    import('@/components/LiveNewsPanel').then((m) => {
+      if (this.ctx.isDestroyed) return;
+      if (this.ctx.panels['live-news']) return;
+      if (m.getDefaultLiveChannels().length === 0 && m.loadChannelsFromStorage().length === 0) return;
+      const panel = new m.LiveNewsPanel();
+      this.ctx.panels['live-news'] = panel;
+      const el = panel.getElement();
+      this.makeDraggable(el, 'live-news');
+      if (grid) {
+        const addBlock = grid.querySelector('.add-panel-block');
+        if (addBlock) grid.insertBefore(el, addBlock);
+        else grid.appendChild(el);
+      }
+      this.applyPanelSettings();
+      this.afterPanelMounted('live-news', panel);
+    }).catch((err) => {
+      console.error('[panel] failed to lazy-load "live-news"', err);
+    });
   }
 
   private shouldCreatePanel(key: string): boolean {
@@ -1157,14 +1095,35 @@ export class PanelLayoutManager implements AppModule {
     centralbanks: t('components.centralBankWatch.infoTooltip'),
   };
 
-  private createNewsPanel(key: string, labelKey: string): NewsPanel | null {
-    if (!this.shouldCreatePanel(key)) return null;
-    const panel = new NewsPanel(key, t(labelKey), PanelLayoutManager.NEWS_PANEL_TOOLTIPS[key]);
-    this.attachRelatedAssetHandlers(panel);
-    panel.setRiskScoreGetter(PanelLayoutManager.computeEventRisk);
-    this.ctx.newsPanels[key] = panel;
-    this.ctx.panels[key] = panel;
-    return panel;
+  private createNewsPanel(key: string, labelKey: string): void {
+    this.createNewsPanelWithLabel(key, t(labelKey), PanelLayoutManager.NEWS_PANEL_TOOLTIPS[key], key);
+  }
+
+  private createNewsPanelWithLabel(
+    panelKey: string,
+    label: string,
+    tooltip?: string,
+    categoryKey = panelKey,
+  ): void {
+    if (!this.shouldCreatePanel(panelKey)) return;
+    this.lazyPanel(panelKey, () =>
+      import('@/components/NewsPanel').then((m) => {
+        const panel = new m.NewsPanel(panelKey, label, tooltip);
+        this.attachRelatedAssetHandlers(panel);
+        panel.setRiskScoreGetter(PanelLayoutManager.computeEventRisk);
+        this.ctx.newsPanels[categoryKey] = panel;
+        const existingItems = this.ctx.newsByCategory[categoryKey];
+        if (existingItems?.length) {
+          const filteredItems = this.filterItemsByTimeRange(existingItems);
+          if (filteredItems.length === 0) {
+            panel.renderFilteredEmpty(`No items in ${this.getTimeRangeLabel()}`);
+          } else {
+            panel.renderNews(filteredItems);
+          }
+        }
+        return panel;
+      }),
+    );
   }
 
   // 0-100 event risk score: 0.40×severity + 0.30×geoConvergence + 0.30×CII
@@ -1183,13 +1142,6 @@ export class PanelLayoutManager implements AppModule {
     return Math.round(0.57 * severity + 0.43 * geoScore);
   }
 
-  private createPanel<T extends import('@/components/Panel').Panel>(key: string, factory: () => T): T | null {
-    if (!this.shouldCreatePanel(key)) return null;
-    const panel = factory();
-    this.ctx.panels[key] = panel;
-    return panel;
-  }
-
   private shouldMountPanelImmediately(key: string): boolean {
     const config = this.ctx.panelSettings[key];
     if (!config?.enabled) return false;
@@ -1206,16 +1158,32 @@ export class PanelLayoutManager implements AppModule {
 
   private insertInitialPanel(grid: HTMLElement, key: string, panel: Panel): void {
     if (this.shouldMountPanelImmediately(key)) {
-      this.mountPanelElement(grid, key, panel);
+      if (this.mountPanelElement(grid, key, panel)) {
+        this.afterPanelMounted(key, panel);
+      }
       return;
     }
 
     this.deferPanelMount(key, panel, grid, this.ctx.panelSettings[key]?.enabled === true);
   }
 
-  private mountPanelElement(grid: HTMLElement, key: string, panel: Panel, placeholder?: HTMLElement | null): void {
+  private insertInitialPanelByKey(grid: HTMLElement, key: string): void {
+    const panel = this.ctx.panels[key];
+    if (panel && !panel.getElement().parentElement) {
+      this.insertInitialPanel(grid, key, panel);
+      return;
+    }
+    if (panel || !this.lazyPanelRegistrations.has(key)) return;
+    if (this.shouldMountPanelImmediately(key)) {
+      this.mountLazyPanel(key, grid);
+      return;
+    }
+    this.deferPanelMount(key, null, grid, this.ctx.panelSettings[key]?.enabled === true);
+  }
+
+  private mountPanelElement(grid: HTMLElement, key: string, panel: Panel, placeholder?: HTMLElement | null): boolean {
     const el = panel.getElement();
-    if (el.parentElement) return;
+    if (el.parentElement) return false;
     this.makeDraggable(el, key);
     if (placeholder?.parentNode) {
       placeholder.parentNode.replaceChild(el, placeholder);
@@ -1224,9 +1192,10 @@ export class PanelLayoutManager implements AppModule {
     }
     this.mobilePanelNav?.applyToNewPanel(el);
     panel.notifyConnected();
+    return true;
   }
 
-  private deferPanelMount(key: string, panel: Panel, grid: HTMLElement | null, withShell: boolean): void {
+  private deferPanelMount(key: string, panel: Panel | null, grid: HTMLElement | null, withShell: boolean): void {
     const placeholder = withShell && grid
       ? createDeferredPanelShell(key, this.ctx.panelSettings[key]?.name ?? key)
       : null;
@@ -1244,6 +1213,7 @@ export class PanelLayoutManager implements AppModule {
       placeholder,
       observer: null,
       mounted: false,
+      loading: null,
     };
     this.deferredPanelMounts.set(key, deferred);
     if (placeholder) {
@@ -1282,24 +1252,68 @@ export class PanelLayoutManager implements AppModule {
 
   private mountDeferredPanel(key: string): boolean {
     const deferred = this.deferredPanelMounts.get(key);
-    if (!deferred || deferred.mounted) return false;
+    if (!deferred || deferred.mounted || deferred.loading) return false;
     const grid = this.getPanelMountGrid(key);
     if (!grid && !deferred.placeholder?.parentNode) return false;
 
     deferred.observer?.disconnect();
-    const panel = deferred.panel;
-    const placeholder = deferred.placeholder;
-    this.mountPanelElement(grid ?? (placeholder!.parentNode as HTMLElement), key, panel, placeholder);
-    deferred.mounted = true;
-    deferred.placeholder = null;
     deferred.observer = null;
-    this.deferredPanelMounts.delete(key);
+    const targetGrid = grid ?? (deferred.placeholder!.parentNode as HTMLElement);
+    const finish = (panel: Panel | null): void => {
+      if (!panel || this.ctx.isDestroyed) return;
+      const current = this.deferredPanelMounts.get(key);
+      if (current !== deferred || deferred.mounted) return;
+      const placeholder = deferred.placeholder;
+      if (this.mountPanelElement(targetGrid, key, panel, placeholder)) {
+        this.afterPanelMounted(key, panel);
+      }
+      deferred.mounted = true;
+      deferred.placeholder = null;
+      deferred.loading = null;
+      this.deferredPanelMounts.delete(key);
+    };
 
+    if (deferred.panel) {
+      finish(deferred.panel);
+      return true;
+    }
+    deferred.loading = this.loadRegisteredPanel(key).then(finish);
+    return true;
+  }
+
+  private mountLazyPanel(key: string, grid: HTMLElement, placeholder?: HTMLElement | null): void {
+    void this.loadRegisteredPanel(key).then((panel) => {
+      if (!panel || this.ctx.isDestroyed) return;
+      const targetGrid = placeholder?.parentNode ? (placeholder.parentNode as HTMLElement) : grid;
+      if (this.mountPanelElement(targetGrid, key, panel, placeholder)) {
+        this.afterPanelMounted(key, panel);
+      }
+    });
+  }
+
+  private observePanelForHydration(panel: Panel): void {
+    if (this.observedHydrationPanels.has(panel)) return;
+    this.observedHydrationPanels.add(panel);
+    panel.observeNearViewport(() => {
+      if (typeof window === 'undefined') {
+        this.scheduleLoadAllData('near');
+        return;
+      }
+      const rect = panel.getElement?.().getBoundingClientRect();
+      const phase: HydrationSchedulePhase = rect && rect.top < window.innerHeight && rect.bottom > 0 ? 'visible' : 'near';
+      this.scheduleLoadAllData(phase);
+    }, 200);
+  }
+
+  private afterPanelMounted(key: string, panel: Panel): void {
     const config = this.ctx.panelSettings[key];
     if (config) panel.toggle(config.enabled);
-    panel.observeNearViewport(() => this.scheduleLoadAllData(), 200);
-    if (config?.enabled) this.scheduleLoadAllData();
-    return true;
+    this.observePanelForHydration(panel);
+    if (config?.enabled) {
+      const rect = typeof window !== 'undefined' ? panel.getElement().getBoundingClientRect() : null;
+      const phase: HydrationSchedulePhase = rect && rect.top < window.innerHeight && rect.bottom > 0 ? 'visible' : 'near';
+      this.scheduleLoadAllData(phase);
+    }
   }
 
   private getPanelElementForOrdering(key: string): HTMLElement | null {
@@ -1353,45 +1367,48 @@ export class PanelLayoutManager implements AppModule {
     this.createNewsPanel('tech', 'panels.tech');
     this.createNewsPanel('finance', 'panels.finance');
 
-    this.createPanel('heatmap', () => new HeatmapPanel());
-    this.createPanel('markets', () => new MarketPanel());
-    this.createPanel('stock-analysis', () => new StockAnalysisPanel());
-    this.createPanel('stock-backtest', () => new StockBacktestPanel());
+    this.lazyPanel('heatmap', () => import('@/components/MarketPanel').then(m => new m.HeatmapPanel()));
+    this.lazyPanel('markets', () => import('@/components/MarketPanel').then(m => new m.MarketPanel()));
+    this.lazyPanel('stock-analysis', () => import('@/components/StockAnalysisPanel').then(m => new m.StockAnalysisPanel()));
+    this.lazyPanel('stock-backtest', () => import('@/components/StockBacktestPanel').then(m => new m.StockBacktestPanel()));
     // Web premium gating for stock-analysis and stock-backtest is handled
     // reactively by updatePanelGating() via auth state subscription.
 
-    const monitorPanel = this.createPanel('monitors', () => new MonitorPanel(this.ctx.monitors));
-    monitorPanel?.onChanged((monitors) => {
-      this.ctx.monitors = monitors;
-      saveToStorage(STORAGE_KEYS.monitors, monitors);
-      this.callbacks.updateMonitorResults();
-    });
+    this.lazyPanel('monitors', () => import('@/components/MonitorPanel').then(m => {
+      const monitorPanel = new m.MonitorPanel(this.ctx.monitors);
+      monitorPanel.onChanged((monitors) => {
+        this.ctx.monitors = monitors;
+        saveToStorage(STORAGE_KEYS.monitors, monitors);
+        this.callbacks.updateMonitorResults();
+      });
+      return monitorPanel;
+    }));
 
     // Latest Brief — reads /api/latest-brief and opens the hosted
     // magazine on click. Self-fetching (no data-loader integration);
     // PRO gating handled by the base Panel class via premium: 'locked'.
-    this.createPanel('latest-brief', () => new LatestBriefPanel());
+    this.lazyPanel('latest-brief', () => import('@/components/LatestBriefPanel').then(m => new m.LatestBriefPanel()));
 
-    this.createPanel('commodities', () => new CommoditiesPanel());
-    this.createPanel('energy-complex', () => new EnergyComplexPanel());
-    this.createPanel('oil-inventories', () => new OilInventoriesPanel());
-    this.createPanel('energy-crisis', () => new EnergyCrisisPanel());
-    this.createPanel('chokepoint-strip', () => new ChokepointStripPanel());
-    this.createPanel('pipeline-status', () => new PipelineStatusPanel());
-    this.createPanel('storage-facility-map', () => new StorageFacilityMapPanel());
-    this.createPanel('fuel-shortages', () => new FuelShortagePanel());
-    this.createPanel('energy-disruptions', () => new EnergyDisruptionsPanel());
-    this.createPanel('energy-risk-overview', () => new EnergyRiskOverviewPanel());
-    this.createPanel('polymarket', () => new PredictionPanel());
+    this.lazyPanel('commodities', () => import('@/components/MarketPanel').then(m => new m.CommoditiesPanel()));
+    this.lazyPanel('energy-complex', () => import('@/components/EnergyComplexPanel').then(m => new m.EnergyComplexPanel()));
+    this.lazyPanel('oil-inventories', () => import('@/components/OilInventoriesPanel').then(m => new m.OilInventoriesPanel()));
+    this.lazyPanel('energy-crisis', () => import('@/components/EnergyCrisisPanel').then(m => new m.EnergyCrisisPanel()));
+    this.lazyPanel('chokepoint-strip', () => import('@/components/ChokepointStripPanel').then(m => new m.ChokepointStripPanel()));
+    this.lazyPanel('pipeline-status', () => import('@/components/PipelineStatusPanel').then(m => new m.PipelineStatusPanel()));
+    this.lazyPanel('storage-facility-map', () => import('@/components/StorageFacilityMapPanel').then(m => new m.StorageFacilityMapPanel()));
+    this.lazyPanel('fuel-shortages', () => import('@/components/FuelShortagePanel').then(m => new m.FuelShortagePanel()));
+    this.lazyPanel('energy-disruptions', () => import('@/components/EnergyDisruptionsPanel').then(m => new m.EnergyDisruptionsPanel()));
+    this.lazyPanel('energy-risk-overview', () => import('@/components/EnergyRiskOverviewPanel').then(m => new m.EnergyRiskOverviewPanel()));
+    this.lazyPanel('polymarket', () => import('@/components/PredictionPanel').then(m => new m.PredictionPanel()));
 
     this.createNewsPanel('gov', 'panels.gov');
     this.createNewsPanel('intel', 'panels.intel');
 
-    this.createPanel('crypto', () => new CryptoPanel());
-    this.createPanel('crypto-heatmap', () => new CryptoHeatmapPanel());
-    this.createPanel('defi-tokens', () => new DefiTokensPanel());
-    this.createPanel('ai-tokens', () => new AiTokensPanel());
-    this.createPanel('other-tokens', () => new OtherTokensPanel());
+    this.lazyPanel('crypto', () => import('@/components/MarketPanel').then(m => new m.CryptoPanel()));
+    this.lazyPanel('crypto-heatmap', () => import('@/components/MarketPanel').then(m => new m.CryptoHeatmapPanel()));
+    this.lazyPanel('defi-tokens', () => import('@/components/MarketPanel').then(m => new m.DefiTokensPanel()));
+    this.lazyPanel('ai-tokens', () => import('@/components/MarketPanel').then(m => new m.AiTokensPanel()));
+    this.lazyPanel('other-tokens', () => import('@/components/MarketPanel').then(m => new m.OtherTokensPanel()));
     this.createNewsPanel('middleeast', 'panels.middleeast');
     this.createNewsPanel('layoffs', 'panels.layoffs');
     this.createNewsPanel('ai', 'panels.ai');
@@ -1410,13 +1427,13 @@ export class PanelLayoutManager implements AppModule {
     this.createNewsPanel('github', 'panels.github');
     this.createNewsPanel('ipo', 'panels.ipo');
     this.createNewsPanel('thinktanks', 'panels.thinktanks');
-    this.createPanel('economic', () => new EconomicPanel());
-    this.createPanel('consumer-prices', () => new ConsumerPricesPanel());
+    this.lazyPanel('economic', () => import('@/components/EconomicPanel').then(m => new m.EconomicPanel()));
+    this.lazyPanel('consumer-prices', () => import('@/components/ConsumerPricesPanel').then(m => new m.ConsumerPricesPanel()));
 
-    this.createPanel('trade-policy', () => new TradePolicyPanel());
-    this.createPanel('sanctions-pressure', () => new SanctionsPressurePanel());
-    const supplyChainPanel = this.createPanel('supply-chain', () => new SupplyChainPanel());
-    if (supplyChainPanel) {
+    this.lazyPanel('trade-policy', () => import('@/components/TradePolicyPanel').then(m => new m.TradePolicyPanel()));
+    this.lazyPanel('sanctions-pressure', () => import('@/components/SanctionsPressurePanel').then(m => new m.SanctionsPressurePanel()));
+    this.lazyPanel('supply-chain', () => import('@/components/SupplyChainPanel').then(m => {
+      const supplyChainPanel = new m.SupplyChainPanel();
       supplyChainPanel.setOnScenarioActivate((id, result) => {
         this.ctx.map?.activateScenario(id, result);
       });
@@ -1424,7 +1441,8 @@ export class PanelLayoutManager implements AppModule {
         this.ctx.map?.deactivateScenario();
       });
       this.ctx.map?.setSupplyChainPanel(supplyChainPanel);
-    }
+      return supplyChainPanel;
+    }));
 
     this.createNewsPanel('africa', 'panels.africa');
     this.createNewsPanel('latam', 'panels.latam');
@@ -1439,7 +1457,7 @@ export class PanelLayoutManager implements AppModule {
     for (const key of Object.keys(CANONICAL_FEEDS)) {
       if (this.ctx.newsPanels[key]) continue;
       if (!Array.isArray((CANONICAL_FEEDS as Record<string, unknown>)[key])) continue;
-      const panelKey = this.ctx.panels[key] && !this.ctx.newsPanels[key] ? `${key}-news` : key;
+      const panelKey = COLLIDING_NEWS_PANEL_KEYS.has(key) && !this.ctx.newsPanels[key] ? `${key}-news` : key;
       if (this.ctx.panels[panelKey]) continue;
       // Gate on panelKey, NOT key. When `key` collided with a non-news data
       // panel (panelKey became `${key}-news` — e.g. `markets`/`crypto`/`economic`
@@ -1450,128 +1468,84 @@ export class PanelLayoutManager implements AppModule {
       if (!panelConfig) continue;
       const label = panelConfig.name ?? key.charAt(0).toUpperCase() + key.slice(1);
       const tooltip = PanelLayoutManager.NEWS_PANEL_TOOLTIPS[panelKey] ?? PanelLayoutManager.NEWS_PANEL_TOOLTIPS[key];
-      const panel = new NewsPanel(panelKey, label, tooltip);
-      this.attachRelatedAssetHandlers(panel);
-      panel.setRiskScoreGetter(PanelLayoutManager.computeEventRisk);
-      this.ctx.newsPanels[key] = panel;
-      this.ctx.panels[panelKey] = panel;
+      this.createNewsPanelWithLabel(panelKey, label, tooltip, key);
     }
 
-    this.createPanel('gdelt-intel', () => new GdeltIntelPanel());
+    this.lazyPanel('gdelt-intel', () => import('@/components/GdeltIntelPanel').then(m => new m.GdeltIntelPanel()));
 
-    // Two-arg `.then(onFulfilled, onRejected)` so the rejection handler ONLY catches
-    // the dynamic-import promise itself (already suppressed in main.ts beforeSend) and
-    // does NOT swallow synchronous throws from the callback body (panel construction,
-    // makeDraggable, etc.) — those must continue to surface in Sentry as real bugs.
-    import('@/components/DeductionPanel').then(({ DeductionPanel }) => {
-      if (typeof DeductionPanel !== 'function') return;
-      const deductionPanel = new DeductionPanel(() => this.ctx.allNews);
-      this.ctx.panels['deduction'] = deductionPanel;
-      const el = deductionPanel.getElement();
-      this.makeDraggable(el, 'deduction');
-      const grid = document.getElementById('panelsGrid');
-      if (grid) {
-        const gdeltEl = this.ctx.panels['gdelt-intel']?.getElement();
-        if (gdeltEl?.parentNode === grid && gdeltEl.nextSibling) {
-          grid.insertBefore(el, gdeltEl.nextSibling);
-        } else {
-          grid.appendChild(el);
-        }
-        deductionPanel.notifyConnected();
-      }
-      this.applyPanelSettings();
-      this.updatePanelGating(getAuthState());
-    }, () => undefined);
+    this.lazyPanel('deduction', () =>
+      import('@/components/DeductionPanel').then(({ DeductionPanel }) => new DeductionPanel(() => this.ctx.allNews)),
+    );
+    this.lazyPanel('regional-intelligence', () =>
+      import('@/components/RegionalIntelligenceBoard').then(({ RegionalIntelligenceBoard }) => new RegionalIntelligenceBoard()),
+    );
 
-    // Guard against named-export resolving to undefined (Safari ESM cache / proxy truncation
-    // edge case, WORLDMONITOR-R4): `new undefined` surfaced as
-    // `TypeError: undefined is not a constructor (evaluating 'new m')` from this exact line.
-    import('@/components/RegionalIntelligenceBoard').then(({ RegionalIntelligenceBoard }) => {
-      if (typeof RegionalIntelligenceBoard !== 'function') return;
-      const regionalBoard = new RegionalIntelligenceBoard();
-      this.ctx.panels['regional-intelligence'] = regionalBoard;
-      const el = regionalBoard.getElement();
-      this.makeDraggable(el, 'regional-intelligence');
-      const grid = document.getElementById('panelsGrid');
-      if (grid) {
-        const deductionEl = this.ctx.panels['deduction']?.getElement();
-        if (deductionEl?.parentNode === grid && deductionEl.nextSibling) {
-          grid.insertBefore(el, deductionEl.nextSibling);
-        } else {
-          grid.appendChild(el);
-        }
-        regionalBoard.notifyConnected();
-      }
-      this.applyPanelSettings();
-      this.updatePanelGating(getAuthState());
-    }, () => undefined);
-
-    if (this.shouldCreatePanel('cii')) {
-      const ciiPanel = new CIIPanel();
+    this.lazyPanel('cii', () => import('@/components/CIIPanel').then(m => {
+      const ciiPanel = new m.CIIPanel();
       ciiPanel.setShareStoryHandler((code, name) => {
         this.callbacks.openCountryStory(code, name);
       });
       ciiPanel.setCountryClickHandler((code) => {
         this.callbacks.openCountryBrief(code);
       });
-      this.ctx.panels['cii'] = ciiPanel;
-    }
+      return ciiPanel;
+    }));
 
-    this.createPanel('cascade', () => new CascadePanel());
-    this.createPanel('satellite-fires', () => new SatelliteFiresPanel());
+    this.lazyPanel('cascade', () => import('@/components/CascadePanel').then(m => new m.CascadePanel()));
+    this.lazyPanel('satellite-fires', () => import('@/components/SatelliteFiresPanel').then(m => new m.SatelliteFiresPanel()));
 
-    this.createPanel('defense-patents', () => new DefensePatentsPanel());
+    this.lazyPanel('defense-patents', () => import('@/components/DefensePatentsPanel').then(m => new m.DefensePatentsPanel()));
 
     // Correlation engine panels
-    if (this.shouldCreatePanel('military-correlation')) {
-      const p = new MilitaryCorrelationPanel();
+    this.lazyPanel('military-correlation', () => import('@/components/MilitaryCorrelationPanel').then(m => {
+      const p = new m.MilitaryCorrelationPanel();
       p.setMapNavigateHandler((lat, lon) => { this.ctx.map?.setCenter(lat, lon, 6); });
-      this.ctx.panels['military-correlation'] = p;
-    }
-    if (this.shouldCreatePanel('escalation-correlation')) {
-      const p = new EscalationCorrelationPanel();
+      return p;
+    }));
+    this.lazyPanel('escalation-correlation', () => import('@/components/EscalationCorrelationPanel').then(m => {
+      const p = new m.EscalationCorrelationPanel();
       p.setMapNavigateHandler((lat, lon) => { this.ctx.map?.setCenter(lat, lon, 4); });
-      this.ctx.panels['escalation-correlation'] = p;
-    }
-    if (this.shouldCreatePanel('economic-correlation')) {
-      const p = new EconomicCorrelationPanel();
+      return p;
+    }));
+    this.lazyPanel('economic-correlation', () => import('@/components/EconomicCorrelationPanel').then(m => {
+      const p = new m.EconomicCorrelationPanel();
       p.setMapNavigateHandler((lat, lon) => { this.ctx.map?.setCenter(lat, lon, 4); });
-      this.ctx.panels['economic-correlation'] = p;
-    }
-    if (this.shouldCreatePanel('disaster-correlation')) {
-      const p = new DisasterCorrelationPanel();
+      return p;
+    }));
+    this.lazyPanel('disaster-correlation', () => import('@/components/DisasterCorrelationPanel').then(m => {
+      const p = new m.DisasterCorrelationPanel();
       p.setMapNavigateHandler((lat, lon) => { this.ctx.map?.setCenter(lat, lon, 5); });
-      this.ctx.panels['disaster-correlation'] = p;
-    }
+      return p;
+    }));
 
-    if (this.shouldCreatePanel('strategic-risk')) {
-      const strategicRiskPanel = new StrategicRiskPanel();
+    this.lazyPanel('strategic-risk', () => import('@/components/StrategicRiskPanel').then(m => {
+      const strategicRiskPanel = new m.StrategicRiskPanel();
       strategicRiskPanel.setLocationClickHandler((lat, lon) => {
         this.ctx.map?.setCenter(lat, lon, 4);
       });
-      this.ctx.panels['strategic-risk'] = strategicRiskPanel;
-    }
+      return strategicRiskPanel;
+    }));
 
-    if (this.shouldCreatePanel('strategic-posture')) {
-      const strategicPosturePanel = new StrategicPosturePanel(() => this.ctx.allNews);
+    this.lazyPanel('strategic-posture', () => import('@/components/StrategicPosturePanel').then(m => {
+      const strategicPosturePanel = new m.StrategicPosturePanel(() => this.ctx.allNews);
       strategicPosturePanel.setLocationClickHandler((lat, lon) => {
         console.log('[App] StrategicPosture handler called:', { lat, lon, hasMap: !!this.ctx.map });
         this.ctx.map?.setCenter(lat, lon, 4);
       });
-      this.ctx.panels['strategic-posture'] = strategicPosturePanel;
-    }
+      return strategicPosturePanel;
+    }));
 
-    if (this.shouldCreatePanel('ucdp-events')) {
-      const ucdpEventsPanel = new UcdpEventsPanel();
+    this.lazyPanel('ucdp-events', () => import('@/components/UcdpEventsPanel').then(m => {
+      const ucdpEventsPanel = new m.UcdpEventsPanel();
       ucdpEventsPanel.setEventClickHandler((lat, lon) => {
         this.ctx.map?.setCenter(lat, lon, 5);
       });
-      this.ctx.panels['ucdp-events'] = ucdpEventsPanel;
-    }
+      return ucdpEventsPanel;
+    }));
 
-    this.createPanel('disease-outbreaks', () => new DiseaseOutbreaksPanel());
-    this.createPanel('social-velocity', () => new SocialVelocityPanel());
-    this.createPanel('wsb-ticker-scanner', () => new WsbTickerScannerPanel());
+    this.lazyPanel('disease-outbreaks', () => import('@/components/DiseaseOutbreaksPanel').then(m => new m.DiseaseOutbreaksPanel()));
+    this.lazyPanel('social-velocity', () => import('@/components/SocialVelocityPanel').then(m => new m.SocialVelocityPanel()));
+    this.lazyPanel('wsb-ticker-scanner', () => import('@/components/WsbTickerScannerPanel').then(m => new m.WsbTickerScannerPanel()));
 
     this.lazyPanel('displacement', () =>
       import('@/components/DisplacementPanel').then(m => {
@@ -1660,62 +1634,46 @@ export class PanelLayoutManager implements AppModule {
       _lockPanels ? [t('premium.features.telegramIntel1'), t('premium.features.telegramIntel2')] : undefined,
     );
 
-    if (this.shouldCreatePanel('gcc-investments')) {
-      const investmentsPanel = new InvestmentsPanel((inv) => {
-        focusInvestmentOnMap(this.ctx.map, this.ctx.mapLayers, inv.lat, inv.lon);
-      });
-      this.ctx.panels['gcc-investments'] = investmentsPanel;
-    }
+    this.lazyPanel('gcc-investments', () =>
+      import('@/components/InvestmentsPanel').then(async (m) => {
+        const { focusInvestmentOnMap } = await import('@/services/investments-focus');
+        return new m.InvestmentsPanel((inv) => {
+          focusInvestmentOnMap(this.ctx.map, this.ctx.mapLayers, inv.lat, inv.lon);
+        });
+      }),
+    );
 
-    if (this.shouldCreatePanel('world-clock')) {
-      this.ctx.panels['world-clock'] = new WorldClockPanel();
-    }
+    this.lazyPanel('world-clock', () => import('@/components/WorldClockPanel').then(m => new m.WorldClockPanel()));
 
-    if (this.shouldCreatePanel('airline-intel')) {
-      this.ctx.panels['airline-intel'] = new AirlineIntelPanel();
-      this.aviationCommandBar = new AviationCommandBar();
-    }
+    this.lazyPanel('airline-intel', () =>
+      import('@/components/AirlineIntelPanel').then(async (m) => {
+        const { AviationCommandBar } = await import('@/components/AviationCommandBar');
+        const panel = new m.AirlineIntelPanel();
+        this.aviationCommandBar = new AviationCommandBar();
+        return panel;
+      }),
+    );
 
-    if (this.shouldCreatePanel('gulf-economies') && !this.ctx.panels['gulf-economies']) {
-      this.ctx.panels['gulf-economies'] = new GulfEconomiesPanel();
-    }
+    this.lazyPanel('gulf-economies', () => import('@/components/GulfEconomiesPanel').then(m => new m.GulfEconomiesPanel()));
+    this.lazyPanel('grocery-basket', () => import('@/components/GroceryBasketPanel').then(m => new m.GroceryBasketPanel()));
+    this.lazyPanel('bigmac', () => import('@/components/BigMacPanel').then(m => new m.BigMacPanel()));
+    this.lazyPanel('fuel-prices', () => import('@/components/FuelPricesPanel').then(m => new m.FuelPricesPanel()));
+    this.lazyPanel('fao-food-price-index', () => import('@/components/FaoFoodPriceIndexPanel').then(m => new m.FaoFoodPriceIndexPanel()));
+    this.lazyPanel('climate-news', () => import('@/components/ClimateNewsPanel').then(m => new m.ClimateNewsPanel()));
 
-    if (this.shouldCreatePanel('grocery-basket') && !this.ctx.panels['grocery-basket']) {
-      this.ctx.panels['grocery-basket'] = new GroceryBasketPanel();
-    }
+    this.lazyPanel('live-news', () =>
+      import('@/components/LiveNewsPanel').then((m) => {
+        if (m.getDefaultLiveChannels().length === 0 && m.loadChannelsFromStorage().length === 0) return null;
+        return new m.LiveNewsPanel();
+      }),
+    );
 
-    if (this.shouldCreatePanel('bigmac') && !this.ctx.panels['bigmac']) {
-      this.ctx.panels['bigmac'] = new BigMacPanel();
-    }
+    this.lazyPanel('live-webcams', () => import('@/components/LiveWebcamsPanel').then(m => new m.LiveWebcamsPanel()));
+    this.lazyPanel('windy-webcams', () => import('@/components/PinnedWebcamsPanel').then(m => new m.PinnedWebcamsPanel()));
 
-    if (this.shouldCreatePanel('fuel-prices') && !this.ctx.panels['fuel-prices']) {
-      this.ctx.panels['fuel-prices'] = new FuelPricesPanel();
-    }
-
-    if (this.shouldCreatePanel('fao-food-price-index') && !this.ctx.panels['fao-food-price-index']) {
-      this.ctx.panels['fao-food-price-index'] = new FaoFoodPriceIndexPanel();
-    }
-
-    if (this.shouldCreatePanel('climate-news') && !this.ctx.panels['climate-news']) {
-      this.ctx.panels['climate-news'] = new ClimateNewsPanel();
-    }
-
-    if (this.shouldCreatePanel('live-news') &&
-        (getDefaultLiveChannels().length > 0 || loadChannelsFromStorage().length > 0)) {
-      this.ctx.panels['live-news'] = new LiveNewsPanel();
-    }
-
-    if (this.shouldCreatePanel('live-webcams')) {
-      this.ctx.panels['live-webcams'] = new LiveWebcamsPanel();
-    }
-
-    if (this.shouldCreatePanel('windy-webcams')) {
-      this.ctx.panels['windy-webcams'] = new PinnedWebcamsPanel();
-    }
-
-    this.createPanel('events', () => new TechEventsPanel('events', () => this.ctx.allNews));
-    this.createPanel('internet-disruptions', () => new InternetDisruptionsPanel());
-    this.createPanel('service-status', () => new ServiceStatusPanel());
+    this.lazyPanel('events', () => import('@/components/TechEventsPanel').then(m => new m.TechEventsPanel('events', () => this.ctx.allNews)));
+    this.lazyPanel('internet-disruptions', () => import('@/components/InternetDisruptionsPanel').then(m => new m.InternetDisruptionsPanel()));
+    this.lazyPanel('service-status', () => import('@/components/ServiceStatusPanel').then(m => new m.ServiceStatusPanel()));
 
     this.lazyPanel('tech-readiness', () =>
       import('@/components/TechReadinessPanel').then(m => {
@@ -1764,31 +1722,30 @@ export class PanelLayoutManager implements AppModule {
       import('@/components/RegulationPanel').then(m => new m.RegulationPanel('ai-regulation')),
     );
 
-    this.createPanel('macro-signals', () => new MacroSignalsPanel());
-    this.createPanel('fear-greed', () => new FearGreedPanel());
-    this.createPanel('aaii-sentiment', () => new AAIISentimentPanel());
-    this.createPanel('market-breadth', () => new MarketBreadthPanel());
-    this.createPanel('macro-tiles', () => new MacroTilesPanel());
-    this.createPanel('fsi', () => new FSIPanel());
-    this.createPanel('yield-curve', () => new YieldCurvePanel());
-    this.createPanel('earnings-calendar', () => new EarningsCalendarPanel());
-    this.createPanel('economic-calendar', () => new EconomicCalendarPanel());
-    this.createPanel('cot-positioning', () => new CotPositioningPanel());
-    this.createPanel('liquidity-shifts', () => new LiquidityShiftsPanel());
-    this.createPanel('positioning-247', () => new PositioningPanel());
-    this.createPanel('gold-intelligence', () => new GoldIntelligencePanel());
-    this.createPanel('hormuz-tracker', () => new HormuzPanel());
-    this.createPanel('etf-flows', () => new ETFFlowsPanel());
-    this.createPanel('stablecoins', () => new StablecoinPanel());
+    this.lazyPanel('macro-signals', () => import('@/components/MacroSignalsPanel').then(m => new m.MacroSignalsPanel()));
+    this.lazyPanel('fear-greed', () => import('@/components/FearGreedPanel').then(m => new m.FearGreedPanel()));
+    this.lazyPanel('aaii-sentiment', () => import('@/components/AAIISentimentPanel').then(m => new m.AAIISentimentPanel()));
+    this.lazyPanel('market-breadth', () => import('@/components/MarketBreadthPanel').then(m => new m.MarketBreadthPanel()));
+    this.lazyPanel('macro-tiles', () => import('@/components/MacroTilesPanel').then(m => new m.MacroTilesPanel()));
+    this.lazyPanel('fsi', () => import('@/components/FSIPanel').then(m => new m.FSIPanel()));
+    this.lazyPanel('yield-curve', () => import('@/components/YieldCurvePanel').then(m => new m.YieldCurvePanel()));
+    this.lazyPanel('earnings-calendar', () => import('@/components/EarningsCalendarPanel').then(m => new m.EarningsCalendarPanel()));
+    this.lazyPanel('economic-calendar', () => import('@/components/EconomicCalendarPanel').then(m => new m.EconomicCalendarPanel()));
+    this.lazyPanel('cot-positioning', () => import('@/components/CotPositioningPanel').then(m => new m.CotPositioningPanel()));
+    this.lazyPanel('liquidity-shifts', () => import('@/components/LiquidityShiftsPanel').then(m => new m.LiquidityShiftsPanel()));
+    this.lazyPanel('positioning-247', () => import('@/components/PositioningPanel').then(m => new m.PositioningPanel()));
+    this.lazyPanel('gold-intelligence', () => import('@/components/GoldIntelligencePanel').then(m => new m.GoldIntelligencePanel()));
+    this.lazyPanel('hormuz-tracker', () => import('@/components/HormuzPanel').then(m => new m.HormuzPanel()));
+    this.lazyPanel('etf-flows', () => import('@/components/ETFFlowsPanel').then(m => new m.ETFFlowsPanel()));
+    this.lazyPanel('stablecoins', () => import('@/components/StablecoinPanel').then(m => new m.StablecoinPanel()));
 
     if (this.ctx.isDesktopApp) {
-      const runtimeConfigPanel = new RuntimeConfigPanel({ mode: 'alert' });
-      this.ctx.panels['runtime-config'] = runtimeConfigPanel;
+      this.lazyPanel('runtime-config', () => import('@/components/RuntimeConfigPanel').then(m => new m.RuntimeConfigPanel({ mode: 'alert' })));
     }
 
-    this.createPanel('insights', () => new InsightsPanel());
+    this.lazyPanel('insights', () => import('@/components/InsightsPanel').then(m => new m.InsightsPanel()));
     if (isPanelInVariantDefaults('threat-timeline')) {
-      this.createPanel('threat-timeline', () => new ThreatTimelinePanel());
+      this.lazyPanel('threat-timeline', () => import('@/components/ThreatTimelinePanel').then(m => new m.ThreatTimelinePanel()));
     }
 
     // Global Giving panel (all variants)
@@ -1874,19 +1831,23 @@ export class PanelLayoutManager implements AppModule {
 
     // Always load custom widgets — Pro gating is handled reactively by auth state.
     for (const spec of loadWidgets()) {
-      const panel = new CustomWidgetPanel(spec);
-      this.ctx.panels[spec.id] = panel;
       if (!this.ctx.panelSettings[spec.id]) {
         this.ctx.panelSettings[spec.id] = { name: spec.title, enabled: true, priority: 3 };
       }
+      const capturedSpec = spec;
+      this.lazyPanel(spec.id, () =>
+        import('@/components/CustomWidgetPanel').then(m => new m.CustomWidgetPanel(capturedSpec)),
+      );
     }
 
     for (const spec of loadMcpPanels()) {
-      const panel = new McpDataPanel(spec);
-      this.ctx.panels[spec.id] = panel;
       if (!this.ctx.panelSettings[spec.id]) {
         this.ctx.panelSettings[spec.id] = { name: spec.title, enabled: true, priority: 3 };
       }
+      const capturedSpec = spec;
+      this.lazyPanel(spec.id, () =>
+        import('@/components/McpDataPanel').then(m => new m.McpDataPanel(capturedSpec)),
+      );
     }
 
     const variantOrder = (VARIANT_DEFAULTS[SITE_VARIANT] ?? VARIANT_DEFAULTS['full'] ?? []).filter(k => k !== 'map');
@@ -1962,10 +1923,7 @@ export class PanelLayoutManager implements AppModule {
       : [];
 
     sidebarOrder.forEach((key: string) => {
-      const panel = this.ctx.panels[key];
-      if (panel && !panel.getElement().parentElement) {
-        this.insertInitialPanel(panelsGrid, key, panel);
-      }
+      this.insertInitialPanelByKey(panelsGrid, key);
     });
 
     // "+" Add Panel block at the end of the grid
@@ -2062,10 +2020,7 @@ export class PanelLayoutManager implements AppModule {
     const bottomGrid = document.getElementById('mapBottomGrid');
     if (bottomGrid) {
       bottomOrder.forEach(key => {
-        const panel = this.ctx.panels[key];
-        if (panel && !panel.getElement().parentElement) {
-          this.insertInitialPanel(bottomGrid, key, panel);
-        }
+        this.insertInitialPanelByKey(bottomGrid, key);
       });
     }
 
@@ -2140,16 +2095,7 @@ export class PanelLayoutManager implements AppModule {
 
   private observePanelsForViewport(): void {
     for (const panel of Object.values(this.ctx.panels)) {
-      const observable = panel as { observeNearViewport?: (cb: () => void, marginPx?: number) => void };
-      observable.observeNearViewport?.(() => {
-        if (typeof window === 'undefined') {
-          this.scheduleLoadAllData('near');
-          return;
-        }
-        const rect = panel.getElement?.().getBoundingClientRect();
-        const phase: HydrationSchedulePhase = rect && rect.top < window.innerHeight && rect.bottom > 0 ? 'visible' : 'near';
-        this.scheduleLoadAllData(phase);
-      }, 200);
+      this.observePanelForHydration(panel);
     }
   }
 
@@ -2166,7 +2112,7 @@ export class PanelLayoutManager implements AppModule {
     });
   }
 
-  private filterItemsByTimeRange(items: import('@/types').NewsItem[], range: import('@/components').TimeRange = this.ctx.currentTimeRange): import('@/types').NewsItem[] {
+  private filterItemsByTimeRange(items: import('@/types').NewsItem[], range: import('@/components/MapContainer').TimeRange = this.ctx.currentTimeRange): import('@/types').NewsItem[] {
     if (range === 'all') return items;
     const ranges: Record<string, number> = {
       '1h': 60 * 60 * 1000, '6h': 6 * 60 * 60 * 1000,
@@ -2236,44 +2182,52 @@ export class PanelLayoutManager implements AppModule {
 
   addCustomWidget(spec: CustomWidgetSpec): void {
     saveWidget(spec);
-    const panel = new CustomWidgetPanel(spec);
-    this.ctx.panels[spec.id] = panel;
     this.ctx.panelSettings[spec.id] = { name: spec.title, enabled: true, priority: 3 };
     saveToStorage(STORAGE_KEYS.panels, this.ctx.panelSettings);
-    const el = panel.getElement();
-    this.makeDraggable(el, spec.id);
-    const grid = document.getElementById('panelsGrid');
-    if (grid) {
-      const addBlock = grid.querySelector('.add-panel-block');
-      if (addBlock) {
-        grid.insertBefore(el, addBlock);
-      } else {
-        grid.appendChild(el);
+    import('@/components/CustomWidgetPanel').then((m) => {
+      const panel = new m.CustomWidgetPanel(spec);
+      this.ctx.panels[spec.id] = panel;
+      const el = panel.getElement();
+      this.makeDraggable(el, spec.id);
+      const grid = document.getElementById('panelsGrid');
+      if (grid) {
+        const addBlock = grid.querySelector('.add-panel-block');
+        if (addBlock) {
+          grid.insertBefore(el, addBlock);
+        } else {
+          grid.appendChild(el);
+        }
       }
-    }
-    this.savePanelOrder();
-    this.applyPanelSettings();
+      this.savePanelOrder();
+      this.applyPanelSettings();
+    }).catch((err) => {
+      console.error(`[panel] failed to lazy-load "${spec.id}"`, err);
+    });
   }
 
   addMcpPanel(spec: McpPanelSpec): void {
     saveMcpPanel(spec);
-    const panel = new McpDataPanel(spec);
-    this.ctx.panels[spec.id] = panel;
     this.ctx.panelSettings[spec.id] = { name: spec.title, enabled: true, priority: 3 };
     saveToStorage(STORAGE_KEYS.panels, this.ctx.panelSettings);
-    const el = panel.getElement();
-    this.makeDraggable(el, spec.id);
-    const grid = document.getElementById('panelsGrid');
-    if (grid) {
-      const addBlock = grid.querySelector('.add-panel-block');
-      if (addBlock) {
-        grid.insertBefore(el, addBlock);
-      } else {
-        grid.appendChild(el);
+    import('@/components/McpDataPanel').then((m) => {
+      const panel = new m.McpDataPanel(spec);
+      this.ctx.panels[spec.id] = panel;
+      const el = panel.getElement();
+      this.makeDraggable(el, spec.id);
+      const grid = document.getElementById('panelsGrid');
+      if (grid) {
+        const addBlock = grid.querySelector('.add-panel-block');
+        if (addBlock) {
+          grid.insertBefore(el, addBlock);
+        } else {
+          grid.appendChild(el);
+        }
       }
-    }
-    this.savePanelOrder();
-    this.applyPanelSettings();
+      this.savePanelOrder();
+      this.applyPanelSettings();
+    }).catch((err) => {
+      console.error(`[panel] failed to lazy-load "${spec.id}"`, err);
+    });
   }
 
   private getSavedPanelOrder(): string[] {
@@ -2561,46 +2515,63 @@ export class PanelLayoutManager implements AppModule {
 
   private lazyPanel<T extends { getElement(): HTMLElement }>(
     key: string,
-    loader: () => Promise<T>,
+    loader: () => Promise<T | null>,
     setup?: (panel: T) => void,
     lockedFeatures?: string[],
   ): void {
     if (!this.shouldCreatePanel(key)) return;
-    loader().then(async (panel) => {
-      this.ctx.panels[key] = panel as unknown as import('@/components/Panel').Panel;
-      if (lockedFeatures) {
-        (panel as unknown as import('@/components/Panel').Panel).showLocked(lockedFeatures);
-      } else {
-        // Re-apply auth gating for panels that loaded after the initial auth state fire
-        this.updatePanelGating(getAuthState());
-        await replayPendingCalls(key, panel);
-        if (setup) setup(panel);
-      }
-      // applyPanelSettings() already ran at startup before this lazy promise resolved.
-      // If the user had this panel disabled, it must be hidden immediately after insertion
-      // or it reappears until the next applyPanelSettings() call.
-      const savedConfig = this.ctx.panelSettings[key];
-      if (savedConfig && !savedConfig.enabled) {
-        this.deferPanelMount(key, panel as unknown as Panel, this.getPanelMountGrid(key), false);
-        this.ctx.panels[key]?.hide();
-        return;
-      }
-
-      const grid = this.getPanelMountGrid(key);
-      if (!grid) return;
-      if (shouldDeferInitialPanelMount({
-        enabled: savedConfig?.enabled === true,
-        mountedEnabledCount: this.initiallyMountedEnabledPanelCount,
-        isMobile: this.ctx.isMobile,
-      })) {
-        this.deferPanelMount(key, panel as unknown as Panel, grid, true);
-        return;
-      }
-      if (savedConfig?.enabled === true) this.initiallyMountedEnabledPanelCount += 1;
-      this.mountPanelElement(grid, key, panel as unknown as Panel);
-    }).catch((err) => {
-      console.error(`[panel] failed to lazy-load "${key}"`, err);
+    if (this.ctx.panels[key] || this.lazyPanelRegistrations.has(key)) return;
+    this.lazyPanelRegistrations.set(key, {
+      loading: null,
+      load: async () => {
+        if (this.ctx.isDestroyed) return null;
+        const panel = await loader();
+        if (!panel) return null;
+        const basePanel = panel as unknown as Panel;
+        if (this.ctx.isDestroyed) {
+          basePanel.destroy?.();
+          return null;
+        }
+        this.ctx.panels[key] = basePanel;
+        if (lockedFeatures) {
+          basePanel.showLocked(lockedFeatures);
+        } else {
+          // Re-apply auth gating for panels that load after the initial auth state fire.
+          this.updatePanelGating(getAuthState());
+          await replayPendingCalls(key, panel);
+          if (this.ctx.isDestroyed) {
+            basePanel.destroy?.();
+            return null;
+          }
+          if (setup) setup(panel);
+        }
+        return basePanel;
+      },
     });
+  }
+
+  private async loadRegisteredPanel(key: string): Promise<Panel | null> {
+    const existing = this.ctx.panels[key];
+    if (existing) return existing;
+    const registration = this.lazyPanelRegistrations.get(key);
+    if (!registration) return null;
+    if (!registration.loading) {
+      registration.loading = registration.load()
+        .then((panel) => {
+          if (panel) {
+            this.lazyPanelRegistrations.delete(key);
+          } else {
+            registration.loading = null;
+          }
+          return panel;
+        })
+        .catch((err) => {
+          registration.loading = null;
+          console.error(`[panel] failed to lazy-load "${key}"`, err);
+          return null;
+        });
+    }
+    return registration.loading;
   }
 
   private makeDraggable(el: HTMLElement, key: string): void {
@@ -3004,7 +2975,7 @@ export class PanelLayoutManager implements AppModule {
     const sources = new Set<string>();
     // Preset feeds + sources from any custom news panels the user added, so
     // the source manager stays in sync with what loadNews() actually fetches.
-    const categories = resolveNewsCategories(FEEDS, CANONICAL_FEEDS, enabledNewsCategoryKeys(this.ctx.newsPanels, this.ctx.panels, this.ctx.panelSettings));
+    const categories = resolveNewsCategories(FEEDS, CANONICAL_FEEDS, enabledNewsCategoryKeys(this.ctx.newsPanels, this.ctx.panels, this.ctx.panelSettings, Object.keys(CANONICAL_FEEDS)));
     categories.forEach(({ feeds }) => feeds.forEach(f => sources.add(f.name)));
     INTEL_SOURCES.forEach(f => sources.add(f.name));
     return Array.from(sources).sort((a, b) => a.localeCompare(b));

--- a/src/app/search-manager.ts
+++ b/src/app/search-manager.ts
@@ -1,10 +1,10 @@
 import type { AppContext, AppModule } from '@/app/app-context';
 import type { SearchResult } from '@/components/SearchModal';
 import type { NewsItem, MapLayers } from '@/types';
-import type { MapView } from '@/components';
+import type { MapView, TimeRange } from '@/components/MapContainer';
 import type { Command } from '@/config/commands';
-import { SearchModal } from '@/components';
-import { CIIPanel } from '@/components';
+import { SearchModal } from '@/components/SearchModal';
+import type { CIIPanel } from '@/components/CIIPanel';
 import { SITE_VARIANT, STORAGE_KEYS, ALL_PANELS, getEffectivePanelConfig, isPanelEntitled } from '@/config';
 import { getAllowedLayerKeys, isLayerExecutable } from '@/config/map-layer-definitions';
 import type { MapRenderer } from '@/config/map-layer-definitions';
@@ -598,7 +598,7 @@ export class SearchManager implements AppModule {
         break;
 
       case 'time':
-        this.ctx.map?.setTimeRange(action as import('@/components').TimeRange);
+        this.ctx.map?.setTimeRange(action as TimeRange);
         break;
 
       case 'country': {

--- a/src/components/BigMacPanel.ts
+++ b/src/components/BigMacPanel.ts
@@ -2,11 +2,11 @@ import { Panel } from './Panel';
 import { t } from '@/services/i18n';
 import { escapeHtml, unsafeRawHtml } from '@/utils/sanitize';
 import { getHydratedData } from '@/services/bootstrap';
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl, rpcFetch } from '@/services/rpc-client';
 import { EconomicServiceClient } from '@/generated/client/worldmonitor/economic/v1/service_client';
 import type { ListBigMacPricesResponse } from '@/generated/client/worldmonitor/economic/v1/service_client';
 
-const client = new EconomicServiceClient(getRpcBaseUrl(), { fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args) });
+const getEconomicClient = createLazyClient(() => new EconomicServiceClient(getRpcBaseUrl(), { fetch: rpcFetch }));
 
 export class BigMacPanel extends Panel {
   constructor() {
@@ -19,13 +19,13 @@ export class BigMacPanel extends Panel {
       if (hydrated?.countries?.length) {
         if (!this.element?.isConnected) return;
         this.renderIndex(hydrated);
-        void client.listBigMacPrices({}).then(data => {
+        void getEconomicClient().listBigMacPrices({}).then(data => {
           if (!this.element?.isConnected || !data.countries?.length) return;
           this.renderIndex(data);
         }).catch(() => {});
         return;
       }
-      const data = await client.listBigMacPrices({});
+      const data = await getEconomicClient().listBigMacPrices({});
       if (!this.element?.isConnected) return;
       this.renderIndex(data);
     } catch (err) {

--- a/src/components/ClimateNewsPanel.ts
+++ b/src/components/ClimateNewsPanel.ts
@@ -2,11 +2,11 @@ import { Panel } from './Panel';
 import { t } from '@/services/i18n';
 import { joinSafeHtml, safeHtml, safeUrlAttr, type SafeHtml } from '@/utils/sanitize';
 import { getHydratedData } from '@/services/bootstrap';
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl, rpcFetch } from '@/services/rpc-client';
 import { ClimateServiceClient } from '@/generated/client/worldmonitor/climate/v1/service_client';
 import type { ListClimateNewsResponse, ClimateNewsItem } from '@/generated/client/worldmonitor/climate/v1/service_client';
 
-const client = new ClimateServiceClient(getRpcBaseUrl(), { fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args) });
+const getClimateClient = createLazyClient(() => new ClimateServiceClient(getRpcBaseUrl(), { fetch: rpcFetch }));
 
 function formatTimeAgo(epochMs: number): string {
   const diffMs = Date.now() - epochMs;
@@ -52,13 +52,13 @@ export class ClimateNewsPanel extends Panel {
       if (hydrated?.items?.length) {
         if (!this.element?.isConnected) return;
         this.renderNewsList(hydrated);
-        void client.listClimateNews({}).then(data => {
+        void getClimateClient().listClimateNews({}).then(data => {
           if (!this.element?.isConnected || !data.items?.length) return;
           this.renderNewsList(data);
         }).catch(() => {});
         return;
       }
-      const data = await client.listClimateNews({});
+      const data = await getClimateClient().listClimateNews({});
       if (!this.element?.isConnected) return;
       this.renderNewsList(data);
     } catch (err) {

--- a/src/components/DeductionPanel.ts
+++ b/src/components/DeductionPanel.ts
@@ -1,5 +1,5 @@
 import { Panel } from './Panel';
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl } from '@/services/rpc-client';
 import { premiumFetch } from '@/services/premium-fetch';
 import { IntelligenceServiceClient } from '@/generated/client/worldmonitor/intelligence/v1/service_client';
 import { h, replaceChildren, setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
@@ -13,7 +13,7 @@ import { FrameworkSelector } from './FrameworkSelector';
 import { extractDeductionProbability } from './deduction-probability';
 
 // deduct-situation + list-market-implications are premium-gated.
-const client = new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: premiumFetch });
+const getIntelligenceClient = createLazyClient(() => new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: premiumFetch }));
 
 const COOLDOWN_MS = 5_000;
 
@@ -250,7 +250,7 @@ export class DeductionPanel extends Panel {
         );
 
         try {
-            const resp = await client.deductSituation({
+            const resp = await getIntelligenceClient().deductSituation({
                 query,
                 geoContext,
                 framework: fw?.systemPromptAppend ?? '',

--- a/src/components/EnergyDisruptionsPanel.ts
+++ b/src/components/EnergyDisruptionsPanel.ts
@@ -1,6 +1,6 @@
 import { Panel } from './Panel';
 import { escapeHtml, unsafeRawHtml } from '@/utils/sanitize';
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl, rpcFetch } from '@/services/rpc-client';
 import { attributionFooterHtml, ATTRIBUTION_FOOTER_CSS } from '@/utils/attribution-footer';
 import { SupplyChainServiceClient } from '@/generated/client/worldmonitor/supply_chain/v1/service_client';
 import type {
@@ -14,9 +14,9 @@ import {
   type DisruptionStatus,
 } from '@/shared/disruption-timeline';
 
-const client = new SupplyChainServiceClient(getRpcBaseUrl(), {
-  fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args),
-});
+const getSupplyChainClient = createLazyClient(() => new SupplyChainServiceClient(getRpcBaseUrl(), {
+  fetch: rpcFetch,
+}));
 
 // One glyph per event type so readers can scan the timeline by nature of
 // disruption. Kept terse — the type string itself is shown next to the glyph.
@@ -127,7 +127,7 @@ export class EnergyDisruptionsPanel extends Panel {
 
   public async fetchData(): Promise<void> {
     try {
-      const live = await client.listEnergyDisruptions({
+      const live = await getSupplyChainClient().listEnergyDisruptions({
         assetId: '',
         assetType: '',
         ongoingOnly: false,

--- a/src/components/EnergyRiskOverviewPanel.ts
+++ b/src/components/EnergyRiskOverviewPanel.ts
@@ -20,16 +20,16 @@
 
 import { Panel } from './Panel';
 import { escapeHtml, unsafeRawHtml } from '@/utils/sanitize';
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl, rpcFetch } from '@/services/rpc-client';
 import { fetchHormuzTracker, type HormuzTrackerData } from '@/services/hormuz-tracker';
 import { getEuGasStorageData } from '@/services/economic';
 import { fetchCommodityQuotes } from '@/services/market';
 import { SupplyChainServiceClient } from '@/generated/client/worldmonitor/supply_chain/v1/service_client';
 import { buildOverviewState, type OverviewState } from './_energy-risk-overview-state';
 
-const supplyChain = new SupplyChainServiceClient(getRpcBaseUrl(), {
-  fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args),
-});
+const getSupplyChainClient = createLazyClient(() => new SupplyChainServiceClient(getRpcBaseUrl(), {
+  fetch: rpcFetch,
+}));
 
 const BRENT_SYMBOL = 'BZ=F';
 const BRENT_META = [{ symbol: BRENT_SYMBOL, name: 'Brent Crude', display: 'BRENT' }];
@@ -111,7 +111,7 @@ export class EnergyRiskOverviewPanel extends Panel {
       // a Greptile P2 finding (over-fetch); buildOverviewState's count
       // calculation handles either response (the redundant client-side
       // filter remains as defense-in-depth in the state builder).
-      supplyChain.listEnergyDisruptions({ assetId: '', assetType: '', ongoingOnly: true }),
+      getSupplyChainClient().listEnergyDisruptions({ assetId: '', assetType: '', ongoingOnly: true }),
     ]);
     this.state = buildOverviewState(hormuz, euGas, brent, disruptions, Date.now());
 

--- a/src/components/FaoFoodPriceIndexPanel.ts
+++ b/src/components/FaoFoodPriceIndexPanel.ts
@@ -2,11 +2,11 @@ import { Panel } from './Panel';
 import { t } from '@/services/i18n';
 import { escapeHtml, unsafeRawHtml } from '@/utils/sanitize';
 import { getHydratedData } from '@/services/bootstrap';
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl, rpcFetch } from '@/services/rpc-client';
 import { EconomicServiceClient } from '@/generated/client/worldmonitor/economic/v1/service_client';
 import type { GetFaoFoodPriceIndexResponse, FaoFoodPricePoint } from '@/generated/client/worldmonitor/economic/v1/service_client';
 
-const client = new EconomicServiceClient(getRpcBaseUrl(), { fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args) });
+const getEconomicClient = createLazyClient(() => new EconomicServiceClient(getRpcBaseUrl(), { fetch: rpcFetch }));
 
 const SVG_W = 480;
 const SVG_H = 140;
@@ -106,13 +106,13 @@ export class FaoFoodPriceIndexPanel extends Panel {
       if (hydrated?.points?.length) {
         if (!this.element?.isConnected) return;
         this.renderChart(hydrated);
-        void client.getFaoFoodPriceIndex({}).then(data => {
+        void getEconomicClient().getFaoFoodPriceIndex({}).then(data => {
           if (!this.element?.isConnected || !data.points?.length) return;
           this.renderChart(data);
         }).catch(() => {});
         return;
       }
-      const data = await client.getFaoFoodPriceIndex({});
+      const data = await getEconomicClient().getFaoFoodPriceIndex({});
       if (!this.element?.isConnected) return;
       this.renderChart(data);
     } catch (err) {

--- a/src/components/FuelPricesPanel.ts
+++ b/src/components/FuelPricesPanel.ts
@@ -2,11 +2,11 @@ import { Panel } from './Panel';
 import { t } from '@/services/i18n';
 import { escapeHtml, unsafeRawHtml } from '@/utils/sanitize';
 import { getHydratedData } from '@/services/bootstrap';
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl, rpcFetch } from '@/services/rpc-client';
 import { EconomicServiceClient } from '@/generated/client/worldmonitor/economic/v1/service_client';
 import type { ListFuelPricesResponse } from '@/generated/client/worldmonitor/economic/v1/service_client';
 
-const client = new EconomicServiceClient(getRpcBaseUrl(), { fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args) });
+const getEconomicClient = createLazyClient(() => new EconomicServiceClient(getRpcBaseUrl(), { fetch: rpcFetch }));
 
 export class FuelPricesPanel extends Panel {
   constructor() {
@@ -19,13 +19,13 @@ export class FuelPricesPanel extends Panel {
       if (hydrated?.countries?.length) {
         if (!this.element?.isConnected) return;
         this.renderIndex(hydrated);
-        void client.listFuelPrices({}).then(data => {
+        void getEconomicClient().listFuelPrices({}).then(data => {
           if (!this.element?.isConnected || !data.countries?.length) return;
           this.renderIndex(data);
         }).catch(() => {});
         return;
       }
-      const data = await client.listFuelPrices({});
+      const data = await getEconomicClient().listFuelPrices({});
       if (!this.element?.isConnected) return;
       this.renderIndex(data);
     } catch (err) {

--- a/src/components/FuelShortagePanel.ts
+++ b/src/components/FuelShortagePanel.ts
@@ -1,6 +1,6 @@
 import { Panel } from './Panel';
 import { escapeHtml, sanitizeUrl, unsafeRawHtml } from '@/utils/sanitize';
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl, rpcFetch } from '@/services/rpc-client';
 import { attributionFooterHtml, ATTRIBUTION_FOOTER_CSS } from '@/utils/attribution-footer';
 import { SupplyChainServiceClient } from '@/generated/client/worldmonitor/supply_chain/v1/service_client';
 import type {
@@ -19,9 +19,9 @@ import {
   type RawFuelShortageRegistry,
 } from '@/shared/fuel-shortage-registry-store';
 
-const client = new SupplyChainServiceClient(getRpcBaseUrl(), {
-  fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args),
-});
+const getSupplyChainClient = createLazyClient(() => new SupplyChainServiceClient(getRpcBaseUrl(), {
+  fetch: rpcFetch,
+}));
 
 const SEVERITY_COLOR: Record<string, string> = {
   confirmed: '#e74c3c',
@@ -161,7 +161,7 @@ export class FuelShortagePanel extends Panel {
       if (hydrated) {
         this.data = hydrated;
         this.render();
-        void client.listFuelShortages({ country: '', product: '', severity: '' }).then(live => {
+        void getSupplyChainClient().listFuelShortages({ country: '', product: '', severity: '' }).then(live => {
           if (!this.element?.isConnected || !live?.shortages?.length) return;
           this.data = live;
           this.render();
@@ -176,7 +176,7 @@ export class FuelShortagePanel extends Panel {
         return;
       }
 
-      const live = await client.listFuelShortages({ country: '', product: '', severity: '' });
+      const live = await getSupplyChainClient().listFuelShortages({ country: '', product: '', severity: '' });
       if (!this.element?.isConnected) return;
       if (live.upstreamUnavailable || !live.shortages?.length) {
         this.showError('Fuel shortage registry unavailable', () => void this.fetchData());
@@ -203,7 +203,7 @@ export class FuelShortagePanel extends Panel {
     this.detailLoading = true;
     this.render();
     try {
-      const d = await client.getFuelShortageDetail({ shortageId });
+      const d = await getSupplyChainClient().getFuelShortageDetail({ shortageId });
       if (!this.element?.isConnected || this.selectedId !== shortageId) return;
       this.detail = d;
       this.detailLoading = false;

--- a/src/components/GroceryBasketPanel.ts
+++ b/src/components/GroceryBasketPanel.ts
@@ -2,11 +2,11 @@ import { Panel } from './Panel';
 import { t } from '@/services/i18n';
 import { escapeHtml, unsafeRawHtml } from '@/utils/sanitize';
 import { getHydratedData } from '@/services/bootstrap';
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl, rpcFetch } from '@/services/rpc-client';
 import { EconomicServiceClient } from '@/generated/client/worldmonitor/economic/v1/service_client';
 import type { ListGroceryBasketPricesResponse } from '@/generated/client/worldmonitor/economic/v1/service_client';
 
-const client = new EconomicServiceClient(getRpcBaseUrl(), { fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args) });
+const getEconomicClient = createLazyClient(() => new EconomicServiceClient(getRpcBaseUrl(), { fetch: rpcFetch }));
 
 export class GroceryBasketPanel extends Panel {
   constructor() {
@@ -19,13 +19,13 @@ export class GroceryBasketPanel extends Panel {
       if (hydrated?.countries?.length) {
         if (!this.element?.isConnected) return;
         this.renderBasket(hydrated);
-        void client.listGroceryBasketPrices({}).then(data => {
+        void getEconomicClient().listGroceryBasketPrices({}).then(data => {
           if (!this.element?.isConnected || !data.countries?.length) return;
           this.renderBasket(data);
         }).catch(() => {});
         return;
       }
-      const data = await client.listGroceryBasketPrices({});
+      const data = await getEconomicClient().listGroceryBasketPrices({});
       if (!this.element?.isConnected) return;
       this.renderBasket(data);
     } catch (err) {

--- a/src/components/GulfEconomiesPanel.ts
+++ b/src/components/GulfEconomiesPanel.ts
@@ -1,5 +1,5 @@
 import { Panel } from './Panel';
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl, rpcFetch } from '@/services/rpc-client';
 import { t } from '@/services/i18n';
 import { escapeHtml, unsafeRawHtml } from '@/utils/sanitize';
 import { formatPrice, formatChange, getChangeClass } from '@/utils';
@@ -8,7 +8,7 @@ import { MarketServiceClient } from '@/generated/client/worldmonitor/market/v1/s
 import type { ListGulfQuotesResponse, GulfQuote } from '@/generated/client/worldmonitor/market/v1/service_client';
 import { getHydratedData } from '@/services/bootstrap';
 
-const client = new MarketServiceClient(getRpcBaseUrl(), { fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args) });
+const getMarketClient = createLazyClient(() => new MarketServiceClient(getRpcBaseUrl(), { fetch: rpcFetch }));
 
 function renderSection(title: string, quotes: GulfQuote[]): string {
   if (quotes.length === 0) return '';
@@ -39,13 +39,13 @@ export class GulfEconomiesPanel extends Panel {
       if (hydrated?.quotes?.length) {
         if (!this.element?.isConnected) return;
         this.renderGulf(hydrated);
-        void client.listGulfQuotes({}).then(data => {
+        void getMarketClient().listGulfQuotes({}).then(data => {
           if (!this.element?.isConnected || !data.quotes?.length) return;
           this.renderGulf(data);
         }).catch(() => {});
         return;
       }
-      const data = await client.listGulfQuotes({});
+      const data = await getMarketClient().listGulfQuotes({});
       if (!this.element?.isConnected) return;
       this.renderGulf(data);
     } catch (err) {

--- a/src/components/MacroSignalsPanel.ts
+++ b/src/components/MacroSignalsPanel.ts
@@ -1,5 +1,5 @@
 import { Panel } from './Panel';
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl, rpcFetch } from '@/services/rpc-client';
 import { escapeHtml, unsafeRawHtml } from '@/utils/sanitize';
 import { t } from '@/services/i18n';
 import { EconomicServiceClient } from '@/generated/client/worldmonitor/economic/v1/service_client';
@@ -24,7 +24,7 @@ interface MacroSignalData {
   unavailable?: boolean;
 }
 
-const economicClient = new EconomicServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
+const getEconomicClient = createLazyClient(() => new EconomicServiceClient(getRpcBaseUrl(), { fetch: rpcFetch }));
 
 /** Map proto response (optional fields = undefined) to MacroSignalData (null for absent values). */
 function mapProtoToData(r: GetMacroSignalsResponse): MacroSignalData {
@@ -153,7 +153,7 @@ export class MacroSignalsPanel extends Panel {
 
   private async refreshFromRpc(): Promise<boolean> {
     try {
-      const res = await economicClient.getMacroSignals({});
+      const res = await getEconomicClient().getMacroSignals({});
       if (!this.element?.isConnected) return false;
       this.data = mapProtoToData(res);
       this.error = null;

--- a/src/components/PipelineStatusPanel.ts
+++ b/src/components/PipelineStatusPanel.ts
@@ -1,6 +1,6 @@
 import { Panel } from './Panel';
 import { escapeHtml, sanitizeUrl, unsafeRawHtml } from '@/utils/sanitize';
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl, rpcFetch } from '@/services/rpc-client';
 import { attributionFooterHtml, ATTRIBUTION_FOOTER_CSS } from '@/utils/attribution-footer';
 import { SupplyChainServiceClient } from '@/generated/client/worldmonitor/supply_chain/v1/service_client';
 import type {
@@ -22,9 +22,9 @@ import {
   type RawPipelineRegistry,
 } from '@/shared/pipeline-registry-store';
 
-const client = new SupplyChainServiceClient(getRpcBaseUrl(), {
-  fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args),
-});
+const getSupplyChainClient = createLazyClient(() => new SupplyChainServiceClient(getRpcBaseUrl(), {
+  fetch: rpcFetch,
+}));
 
 // Shape of the raw Redis registry hydrated by bootstrap. This mirrors
 // scripts/data/pipelines-{gas,oil}.json verbatim — the seeder does NOT
@@ -224,7 +224,7 @@ export class PipelineStatusPanel extends Panel {
         // classifierVersion + updatedAt into the shared store so the map's
         // next re-render uses the newer stamps too — prevents map/panel
         // drift during rollouts.
-        void client.listPipelines({ commodityType: '' }).then(live => {
+        void getSupplyChainClient().listPipelines({ commodityType: '' }).then(live => {
           if (!this.element?.isConnected || !live?.pipelines?.length) return;
           this.data = live;
           this.render();
@@ -242,7 +242,7 @@ export class PipelineStatusPanel extends Panel {
         return;
       }
 
-      const live = await client.listPipelines({ commodityType: '' });
+      const live = await getSupplyChainClient().listPipelines({ commodityType: '' });
       if (!this.element?.isConnected) return;
       if (live.upstreamUnavailable || !live.pipelines?.length) {
         this.showError('Pipeline registry unavailable', () => void this.fetchData());
@@ -272,8 +272,8 @@ export class PipelineStatusPanel extends Panel {
     this.render();
     try {
       const [d, events] = await Promise.all([
-        client.getPipelineDetail({ pipelineId }),
-        client.listEnergyDisruptions({ assetId: pipelineId, assetType: 'pipeline', ongoingOnly: false }),
+        getSupplyChainClient().getPipelineDetail({ pipelineId }),
+        getSupplyChainClient().listEnergyDisruptions({ assetId: pipelineId, assetType: 'pipeline', ongoingOnly: false }),
       ]);
       if (!this.element?.isConnected || this.selectedId !== pipelineId) return;
       this.detail = d;

--- a/src/components/RegionalIntelligenceBoard.ts
+++ b/src/components/RegionalIntelligenceBoard.ts
@@ -1,5 +1,5 @@
 import { Panel } from './Panel';
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl } from '@/services/rpc-client';
 import { premiumFetch } from '@/services/premium-fetch';
 import { IS_EMBEDDED_PREVIEW } from '@/utils/embedded-preview';
 import { hasPremiumAccess } from '@/services/panel-gating';
@@ -13,7 +13,7 @@ import { BOARD_REGIONS, DEFAULT_REGION_ID, buildBoardHtml, buildRegimeHistoryBlo
 // get-regional-snapshot + get-regime-history + get-regional-brief are
 // premium-gated. Plain globalThis.fetch skips Clerk/tester/api-key injection
 // and returns 401 for pro users — premiumFetch is the correct fetcher here.
-const client = new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: premiumFetch });
+const getIntelligenceClient = createLazyClient(() => new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: premiumFetch }));
 
 /**
  * RegionalIntelligenceBoard — premium panel rendering a canonical
@@ -186,7 +186,7 @@ export class RegionalIntelligenceBoard extends Panel {
     let actualRegion = myRegion;
     let fallbackFrom: string | null = null;
     try {
-      const resp = await client.getRegionalSnapshot({ regionId: myRegion });
+      const resp = await getIntelligenceClient().getRegionalSnapshot({ regionId: myRegion });
       if (!isLatestSequence(mySequence, this.latestSequence)) return;
       snapshot = resp.snapshot;
     } catch (err) {
@@ -219,7 +219,7 @@ export class RegionalIntelligenceBoard extends Panel {
         };
         const timer = setTimeout(() => settle(null), FALLBACK_TIMEOUT_MS);
         for (const id of fallbackIds) {
-          client.getRegionalSnapshot({ regionId: id })
+          getIntelligenceClient().getRegionalSnapshot({ regionId: id })
             .then(resp => {
               if (resp.snapshot?.regionId) {
                 clearTimeout(timer);
@@ -262,8 +262,8 @@ export class RegionalIntelligenceBoard extends Panel {
 
     // Phase 2: fire history + brief RPCs in background. Use actualRegion so
     // the enrichments match the rendered snapshot when we fell back.
-    const historyPromise = client.getRegimeHistory({ regionId: actualRegion, limit: 20 }).catch(() => null);
-    const briefPromise = client.getRegionalBrief({ regionId: actualRegion }).catch(() => null);
+    const historyPromise = getIntelligenceClient().getRegimeHistory({ regionId: actualRegion, limit: 20 }).catch(() => null);
+    const briefPromise = getIntelligenceClient().getRegionalBrief({ regionId: actualRegion }).catch(() => null);
 
     Promise.allSettled([historyPromise, briefPromise]).then(([hResult, bResult]) => {
       if (!isLatestSequence(mySequence, this.latestSequence)) return;

--- a/src/components/StorageFacilityMapPanel.ts
+++ b/src/components/StorageFacilityMapPanel.ts
@@ -1,6 +1,6 @@
 import { Panel } from './Panel';
 import { escapeHtml, sanitizeUrl, unsafeRawHtml } from '@/utils/sanitize';
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl, rpcFetch } from '@/services/rpc-client';
 import { attributionFooterHtml, ATTRIBUTION_FOOTER_CSS } from '@/utils/attribution-footer';
 import { SupplyChainServiceClient } from '@/generated/client/worldmonitor/supply_chain/v1/service_client';
 import type {
@@ -18,9 +18,9 @@ import {
   type RawStorageFacilityRegistry,
 } from '@/shared/storage-facility-registry-store';
 
-const client = new SupplyChainServiceClient(getRpcBaseUrl(), {
-  fetch: (...args: Parameters<typeof fetch>) => globalThis.fetch(...args),
-});
+const getSupplyChainClient = createLazyClient(() => new SupplyChainServiceClient(getRpcBaseUrl(), {
+  fetch: rpcFetch,
+}));
 
 const BADGE_COLOR: Record<string, string> = {
   operational: '#2ecc71',
@@ -212,7 +212,7 @@ export class StorageFacilityMapPanel extends Panel {
         // Background RPC refresh for post-deploy classifier-version bumps.
         // When it lands, mirror the fresh shape into the store so the
         // map's next re-render uses the newer stamps too.
-        void client.listStorageFacilities({ facilityType: '' }).then(live => {
+        void getSupplyChainClient().listStorageFacilities({ facilityType: '' }).then(live => {
           if (!this.element?.isConnected || !live?.facilities?.length) return;
           this.data = live;
           this.render();
@@ -227,7 +227,7 @@ export class StorageFacilityMapPanel extends Panel {
         return;
       }
 
-      const live = await client.listStorageFacilities({ facilityType: '' });
+      const live = await getSupplyChainClient().listStorageFacilities({ facilityType: '' });
       if (!this.element?.isConnected) return;
       if (live.upstreamUnavailable || !live.facilities?.length) {
         this.showError('Storage registry unavailable', () => void this.fetchData());
@@ -256,8 +256,8 @@ export class StorageFacilityMapPanel extends Panel {
     this.render();
     try {
       const [d, events] = await Promise.all([
-        client.getStorageFacilityDetail({ facilityId }),
-        client.listEnergyDisruptions({ assetId: facilityId, assetType: 'storage', ongoingOnly: false }),
+        getSupplyChainClient().getStorageFacilityDetail({ facilityId }),
+        getSupplyChainClient().listEnergyDisruptions({ assetId: facilityId, assetType: 'storage', ongoingOnly: false }),
       ]);
       if (!this.element?.isConnected || this.selectedId !== facilityId) return;
       this.detail = d;

--- a/src/components/TechEventsPanel.ts
+++ b/src/components/TechEventsPanel.ts
@@ -1,5 +1,5 @@
 import { Panel } from './Panel';
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl, rpcFetch } from '@/services/rpc-client';
 import { t } from '@/services/i18n';
 import { sanitizeUrl } from '@/utils/sanitize';
 import { h, replaceChildren } from '@/utils/dom-utils';
@@ -12,7 +12,7 @@ import { getHydratedData } from '@/services/bootstrap';
 
 type ViewMode = 'upcoming' | 'conferences' | 'earnings' | 'all';
 
-const researchClient = new ResearchServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
+const getResearchClient = createLazyClient(() => new ResearchServiceClient(getRpcBaseUrl(), { fetch: rpcFetch }));
 
 export class TechEventsPanel extends Panel {
   private viewMode: ViewMode = 'upcoming';
@@ -44,7 +44,7 @@ export class TechEventsPanel extends Panel {
     // Fallback: single RPC call — listTechEvents reads from Redis seed,
     // retrying on empty returns the same stale result each time.
     try {
-      const data = await researchClient.listTechEvents({
+      const data = await getResearchClient().listTechEvents({
         type: '',
         mappable: false,
         days: 180,

--- a/src/config/feed-resolution.ts
+++ b/src/config/feed-resolution.ts
@@ -123,12 +123,18 @@ export function enabledNewsCategoryKeys(
   newsPanels: Record<string, unknown>,
   panels: Record<string, unknown>,
   panelSettings: Record<string, { enabled?: boolean } | undefined>,
+  configuredCategoryKeys: Iterable<string> = [],
 ): string[] {
-  const result: string[] = [];
+  const result = new Set<string>();
   for (const [key, newsPanel] of Object.entries(newsPanels)) {
     const collided = panels[key] !== undefined && panels[key] !== newsPanel;
     const panelKey = collided ? `${key}-news` : key;
-    if (panelSettings[panelKey]?.enabled === true) result.push(key);
+    if (panelSettings[panelKey]?.enabled === true) result.add(key);
   }
-  return result;
+  for (const key of configuredCategoryKeys) {
+    if (panelSettings[key]?.enabled === true || panelSettings[`${key}-news`]?.enabled === true) {
+      result.add(key);
+    }
+  }
+  return [...result];
 }

--- a/src/config/feed-resolution.ts
+++ b/src/config/feed-resolution.ts
@@ -134,13 +134,7 @@ export function enabledNewsCategoryKeys(
     if (panelSettings[panelKey]?.enabled === true) result.add(key);
   }
   for (const key of configuredCategoryKeys) {
-    const remappedPanelKey = `${key}-news`;
-    const settingsKey = (
-      COLLIDING_NEWS_CATEGORY_KEYS.has(key)
-      || panelSettings[remappedPanelKey] !== undefined
-    )
-      ? remappedPanelKey
-      : key;
+    const settingsKey = COLLIDING_NEWS_CATEGORY_KEYS.has(key) ? `${key}-news` : key;
     if (panelSettings[settingsKey]?.enabled === true) {
       result.add(key);
     }

--- a/src/config/feed-resolution.ts
+++ b/src/config/feed-resolution.ts
@@ -60,6 +60,8 @@ export interface ResolvedCategory {
   isCustom: boolean;
 }
 
+const COLLIDING_NEWS_CATEGORY_KEYS = new Set(['markets', 'crypto', 'economic']);
+
 /**
  * Resolve every news category that should be loaded for the current session:
  * the active variant's preset categories, PLUS any extra categories required
@@ -132,7 +134,14 @@ export function enabledNewsCategoryKeys(
     if (panelSettings[panelKey]?.enabled === true) result.add(key);
   }
   for (const key of configuredCategoryKeys) {
-    if (panelSettings[key]?.enabled === true || panelSettings[`${key}-news`]?.enabled === true) {
+    const remappedPanelKey = `${key}-news`;
+    const settingsKey = (
+      COLLIDING_NEWS_CATEGORY_KEYS.has(key)
+      || panelSettings[remappedPanelKey] !== undefined
+    )
+      ? remappedPanelKey
+      : key;
+    if (panelSettings[settingsKey]?.enabled === true) {
       result.add(key);
     }
   }

--- a/src/services/rpc-client.ts
+++ b/src/services/rpc-client.ts
@@ -5,3 +5,15 @@ export function getRpcBaseUrl(): string {
   // latest sidecar port per request instead of freezing a stale module-load port.
   return getConfiguredWebApiBaseUrl() || '';
 }
+
+export function rpcFetch(...args: Parameters<typeof fetch>): ReturnType<typeof fetch> {
+  return globalThis.fetch(...args);
+}
+
+export function createLazyClient<T>(factory: () => T): () => T {
+  let client: T | undefined;
+  return () => {
+    client ??= factory();
+    return client;
+  };
+}

--- a/tests/feed-resolution.test.mts
+++ b/tests/feed-resolution.test.mts
@@ -171,6 +171,16 @@ describe('enabledNewsCategoryKeys', () => {
     );
   });
 
+  test('configured colliding categories ignore enabled data panels before lazy news panels register', () => {
+    assert.deepStrictEqual(
+      enabledNewsCategoryKeys({}, {}, {
+        markets: { enabled: true },
+        'markets-news': { enabled: false },
+      }, ['markets']),
+      [],
+    );
+  });
+
   // Collision case: `markets` key is occupied by a non-news DATA panel, so the
   // news panel registered under `markets-news`. Enablement must be read from
   // panelSettings['markets-news'] — NOT panelSettings['markets'] (the data panel).

--- a/tests/feed-resolution.test.mts
+++ b/tests/feed-resolution.test.mts
@@ -160,6 +160,17 @@ describe('enabledNewsCategoryKeys', () => {
     );
   });
 
+  test('includes enabled configured categories before lazy news panels register', () => {
+    assert.deepStrictEqual(
+      enabledNewsCategoryKeys({}, {}, {
+        startups: { enabled: true },
+        'markets-news': { enabled: true },
+        markets: { enabled: true },
+      }, ['startups', 'markets']),
+      ['startups', 'markets'],
+    );
+  });
+
   // Collision case: `markets` key is occupied by a non-news DATA panel, so the
   // news panel registered under `markets-news`. Enablement must be read from
   // panelSettings['markets-news'] — NOT panelSettings['markets'] (the data panel).

--- a/tests/feed-resolution.test.mts
+++ b/tests/feed-resolution.test.mts
@@ -181,6 +181,20 @@ describe('enabledNewsCategoryKeys', () => {
     );
   });
 
+  test('configured non-colliding categories ignore stale disabled ${key}-news settings', () => {
+    assert.deepStrictEqual(
+      enabledNewsCategoryKeys({}, {}, {
+        commodities: { enabled: true },
+        'commodities-news': { enabled: false },
+        climate: { enabled: true },
+        'climate-news': { enabled: false },
+        mining: { enabled: true },
+        'mining-news': { enabled: false },
+      }, ['commodities', 'climate', 'mining']),
+      ['commodities', 'climate', 'mining'],
+    );
+  });
+
   // Collision case: `markets` key is occupied by a non-news DATA panel, so the
   // news panel registered under `markets-news`. Enablement must be read from
   // panelSettings['markets-news'] — NOT panelSettings['markets'] (the data panel).

--- a/tests/frontend-cii-source-of-truth.test.mts
+++ b/tests/frontend-cii-source-of-truth.test.mts
@@ -184,7 +184,7 @@ describe('frontend CII source of truth', () => {
     assert.match(refreshBody, /const cached = this\.getAuthoritativeCachedRiskScores\(forceLocal\);/);
     assert.match(refreshBody, /if \(cached\) \{[\s\S]*this\.renderCachedCiiScores\(cached\);[\s\S]*return;[\s\S]*\}/);
     assert.match(refreshBody, /const shouldUseLocalFallback = forceLocal \|\| !this\.cachedRiskScores;/);
-    assert.match(refreshBody, /\(this\.ctx\.panels\['cii'\] as CIIPanel\)\?\.refresh\(shouldUseLocalFallback\);/);
+    assert.match(refreshBody, /this\.callPanel\('cii', 'refresh', shouldUseLocalFallback\);/);
     assert.match(refreshBody, /const scores = calculateCII\(\);[\s\S]*this\.applyCiiScoresToMap\(scores\);/);
 
     assert.match(eventHandlersSrc, /refreshCiiAfterFocalPointsReady\?: \(\) => void;/);

--- a/tests/live-news-panel-guard.test.mts
+++ b/tests/live-news-panel-guard.test.mts
@@ -75,7 +75,7 @@ describe('LiveNewsPanel instantiation guard', () => {
 
   it('panel-layout.ts live-news guard checks getDefaultLiveChannels()', () => {
     const layout = src('src/app/panel-layout.ts');
-    const guardBlock = layout.match(/shouldCreatePanel\('live-news'\)[^}]*getDefaultLiveChannels\(\)\.length/s);
+    const guardBlock = layout.match(/this\.lazyPanel\('live-news'[\s\S]*?getDefaultLiveChannels\(\)\.length === 0[\s\S]*?return null;/s);
     assert.ok(
       guardBlock,
       "panel-layout.ts must guard 'live-news' with getDefaultLiveChannels().length > 0",
@@ -84,7 +84,7 @@ describe('LiveNewsPanel instantiation guard', () => {
 
   it('panel-layout.ts live-news guard also checks loadChannelsFromStorage()', () => {
     const layout = src('src/app/panel-layout.ts');
-    const guardBlock = layout.match(/shouldCreatePanel\('live-news'\)[^}]*loadChannelsFromStorage\(\)\.length/s);
+    const guardBlock = layout.match(/this\.lazyPanel\('live-news'[\s\S]*?loadChannelsFromStorage\(\)\.length === 0[\s\S]*?return null;/s);
     assert.ok(
       guardBlock,
       "panel-layout.ts must also check loadChannelsFromStorage().length > 0 so users with saved channels can use the panel on happy variant",

--- a/tests/load-all-data-scheduling.test.mts
+++ b/tests/load-all-data-scheduling.test.mts
@@ -148,6 +148,7 @@ describe('loadAllData scheduler', () => {
 describe('viewport hydration scheduler lifecycle', () => {
   const destroyMethod = findMethod(PANEL_LAYOUT_SOURCE, 'destroy');
   const observeMethod = findMethod(PANEL_LAYOUT_SOURCE, 'observePanelsForViewport');
+  const observePanelMethod = findMethod(PANEL_LAYOUT_SOURCE, 'observePanelForHydration');
 
   it('cancels pending idle hydration during teardown', () => {
     assert.match(
@@ -158,7 +159,12 @@ describe('viewport hydration scheduler lifecycle', () => {
   });
 
   it('keeps the no-window viewport fallback before reading window.innerHeight', () => {
-    const text = observeMethod.getText(PANEL_LAYOUT_SOURCE);
+    assert.match(
+      observeMethod.getText(PANEL_LAYOUT_SOURCE),
+      /this\.observePanelForHydration\(panel\);/,
+      'observePanelsForViewport should delegate per-panel viewport handling to observePanelForHydration',
+    );
+    const text = observePanelMethod.getText(PANEL_LAYOUT_SOURCE);
     const guardIndex = text.indexOf("typeof window === 'undefined'");
     const innerHeightIndex = text.indexOf('window.innerHeight');
     assert.ok(guardIndex >= 0, 'observer should preserve an explicit no-window guard');

--- a/tests/mission-presets.test.mts
+++ b/tests/mission-presets.test.mts
@@ -356,6 +356,14 @@ async function loadEventHandlerManager(): Promise<EventHandlerManagerCtor> {
       export function saveToStorage(key, value) {
         try { localStorage.setItem(key, JSON.stringify(value)); } catch {}
       }
+      export function loadFromStorage(key, fallback) {
+        try {
+          const raw = localStorage.getItem(key);
+          return raw == null ? fallback : JSON.parse(raw);
+        } catch {
+          return fallback;
+        }
+      }
       export function rssProxyUrl(url) { return url; }
       export function getCSSColor(_name, fallback) { return fallback || '#000000'; }
       export class ExportPanel {}
@@ -367,10 +375,44 @@ async function loadEventHandlerManager(): Promise<EventHandlerManagerCtor> {
       }
     `],
     ['@/utils/dom-utils', `
+      export function h(tagName, props, ...children) {
+        const el = document.createElement(tagName);
+        if (props && typeof props === 'object') {
+          for (const [key, value] of Object.entries(props)) {
+            if (key === 'className') el.className = String(value);
+            else if (key.startsWith('on') && typeof value === 'function') el.addEventListener(key.slice(2).toLowerCase(), value);
+            else if (value !== false && value != null) el.setAttribute(key, String(value));
+          }
+        }
+        for (const child of children.flat()) {
+          if (child == null) continue;
+          if (typeof child === 'string') {
+            const text = document.createElement('span');
+            text.textContent = child;
+            el.appendChild(text);
+          } else {
+            el.appendChild(child);
+          }
+        }
+        return el;
+      }
+      export function replaceChildren(el, ...children) {
+        el.innerHTML = '';
+        for (const child of children.flat()) {
+          if (child == null) continue;
+          if (typeof child === 'string') {
+            const text = document.createElement('span');
+            text.textContent = child;
+            el.appendChild(text);
+          } else {
+            el.appendChild(child);
+          }
+        }
+      }
       export function trustedHtml(html) { return String(html); }
       export function setTrustedHtml(el, html) { el.innerHTML = String(html); }
     `],
-    ['@/utils/sanitize', 'export function escapeHtml(value) { return String(value); }'],
+    ['@/utils/sanitize', 'export function escapeHtml(value) { return String(value); } export function safeHtmlToString(value) { return String(value); }'],
     ['@/services/analytics', `
       const push = (name, args) => {
         globalThis.__missionAnalytics = globalThis.__missionAnalytics || [];
@@ -385,6 +427,7 @@ async function loadEventHandlerManager(): Promise<EventHandlerManagerCtor> {
       export function trackPanelToggled(...args) { push('trackPanelToggled', args); }
       export function trackDownloadClicked(...args) { push('trackDownloadClicked', args); }
       export function trackGateHit(...args) { push('trackGateHit', args); }
+      export function trackPanelResized(...args) { push('trackPanelResized', args); }
     `],
     ['@/services', `
       export async function saveSnapshot() {}
@@ -424,6 +467,10 @@ async function loadEventHandlerManager(): Promise<EventHandlerManagerCtor> {
       export class LlmStatusIndicator {}
       export class PredictionPanel { renderPredictions(){} }
     `],
+    ['@/components/PlaybackControl', 'export class PlaybackControl { onSnapshot(){} getElement(){ return document.createElement("div"); } }'],
+    ['@/components/StatusPanel', 'export class StatusPanel {}'],
+    ['@/components/PizzIntIndicator', 'export class PizzIntIndicator { getElement(){ return document.createElement("div"); } update(){} }'],
+    ['@/components/LlmStatusIndicator', 'export class LlmStatusIndicator { getElement(){ return document.createElement("div"); } update(){} }'],
     ['@/components/CustomWidgetPanel', 'export class CustomWidgetPanel { constructor(spec){ this.spec = spec; } getElement(){ return document.createElement("div"); } }'],
     ['@/components/WidgetChatModal', 'export function openWidgetChatModal(){}'],
     ['@/components/McpDataPanel', 'export class McpDataPanel { constructor(spec){ this.spec = spec; } getElement(){ return document.createElement("div"); } }'],

--- a/tests/panel-cluster-chunks.test.mjs
+++ b/tests/panel-cluster-chunks.test.mjs
@@ -1,0 +1,337 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as ts from 'typescript';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const componentDir = resolve(repoRoot, 'src/components');
+const startupModulePaths = [
+  'src/App.ts',
+  'src/app/country-intel.ts',
+  'src/app/data-loader.ts',
+  'src/app/event-handlers.ts',
+  'src/app/panel-layout.ts',
+  'src/app/search-manager.ts',
+].map((path) => resolve(repoRoot, path));
+const viteConfigPath = resolve(repoRoot, 'vite.config.ts');
+const viteConfigSource = readFileSync(viteConfigPath, 'utf8');
+const viteConfigAst = ts.createSourceFile(
+  viteConfigPath,
+  viteConfigSource,
+  ts.ScriptTarget.Latest,
+  true,
+  ts.ScriptKind.TS,
+);
+
+function findVariableDeclaration(ast, name) {
+  let found = null;
+  for (const statement of ast.statements) {
+    if (!ts.isVariableStatement(statement)) continue;
+    for (const declaration of statement.declarationList.declarations) {
+      if (ts.isIdentifier(declaration.name) && declaration.name.text === name) {
+        found = declaration;
+      }
+    }
+  }
+  assert.ok(found, `Could not locate ${name}.`);
+  return found;
+}
+
+function stringValue(node) {
+  return ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node) ? node.text : null;
+}
+
+function propertyNameText(name) {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) return name.text;
+  return null;
+}
+
+function extractStringArray(name) {
+  const declaration = findVariableDeclaration(viteConfigAst, name);
+  assert.ok(declaration.initializer && ts.isAsExpression(declaration.initializer), `${name} must use "as const".`);
+  const expression = declaration.initializer.expression;
+  assert.ok(ts.isArrayLiteralExpression(expression), `${name} must be an array literal.`);
+  return expression.elements.map((element) => {
+    assert.ok(ts.isStringLiteral(element), `${name} must contain only string literals.`);
+    return element.text;
+  });
+}
+
+function extractObjectMap(name) {
+  const declaration = findVariableDeclaration(viteConfigAst, name);
+  assert.ok(declaration.initializer && ts.isObjectLiteralExpression(declaration.initializer), `${name} must be an object literal.`);
+  const entries = new Map();
+  for (const property of declaration.initializer.properties) {
+    assert.ok(ts.isPropertyAssignment(property), `${name} must only contain property assignments.`);
+    const key = propertyNameText(property.name);
+    const value = stringValue(property.initializer);
+    assert.ok(key, `${name} has an unsupported property key.`);
+    assert.ok(value, `${name}.${key} must be a string literal.`);
+    entries.set(key, value);
+  }
+  return entries;
+}
+
+function hasSpreadOfArray(name, spreadName) {
+  const declaration = findVariableDeclaration(viteConfigAst, name);
+  assert.ok(declaration.initializer && ts.isAsExpression(declaration.initializer), `${name} must use "as const".`);
+  const expression = declaration.initializer.expression;
+  assert.ok(ts.isArrayLiteralExpression(expression), `${name} must be an array literal.`);
+  return expression.elements.some((element) => (
+    ts.isSpreadElement(element)
+    && ts.isIdentifier(element.expression)
+    && element.expression.text === spreadName
+  ));
+}
+
+function hasCall(ast, calleeName) {
+  let found = false;
+  function visit(node) {
+    if (
+      ts.isCallExpression(node)
+      && ts.isIdentifier(node.expression)
+      && node.expression.text === calleeName
+    ) {
+      found = true;
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(ast);
+  return found;
+}
+
+function hasTrueProperty(ast, propertyName) {
+  let found = false;
+  function visit(node) {
+    if (
+      ts.isPropertyAssignment(node)
+      && propertyNameText(node.name) === propertyName
+      && node.initializer.kind === ts.SyntaxKind.TrueKeyword
+    ) {
+      found = true;
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(ast);
+  return found;
+}
+
+function returnedStringLiterals(ast) {
+  const values = [];
+  function visit(node) {
+    if (ts.isReturnStatement(node) && node.expression) {
+      const value = stringValue(node.expression);
+      if (value) values.push(value);
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(ast);
+  return values;
+}
+
+function panelKeyForFile(fileName) {
+  const baseName = fileName.replace(/\.ts$/, '');
+  if (baseName === 'Panel') return null;
+  if (baseName === 'CountryBriefPage' || baseName === 'RegionalIntelligenceBoard') return baseName;
+  if (baseName.endsWith('Panel')) return baseName.slice(0, -'Panel'.length);
+  return null;
+}
+
+function sourceFileForComponent(fileName) {
+  const filePath = resolve(componentDir, fileName);
+  return ts.createSourceFile(
+    filePath,
+    readFileSync(filePath, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+}
+
+function isGeneratedServiceClientNew(node) {
+  return (
+    ts.isNewExpression(node)
+    && ts.isIdentifier(node.expression)
+    && /ServiceClient$/.test(node.expression.text)
+  );
+}
+
+function lineForPosition(sourceFile, pos) {
+  return sourceFile.getLineAndCharacterOfPosition(pos).line + 1;
+}
+
+function topLevelGeneratedClientOffenders(fileName) {
+  const ast = sourceFileForComponent(fileName);
+  const offenders = [];
+  for (const statement of ast.statements) {
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (declaration.initializer && isGeneratedServiceClientNew(declaration.initializer)) {
+          offenders.push(`${fileName}:${lineForPosition(ast, declaration.initializer.getStart(ast))}`);
+        }
+      }
+    }
+    if (ts.isClassDeclaration(statement)) {
+      for (const member of statement.members) {
+        const isStatic = member.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.StaticKeyword);
+        if (
+          isStatic
+          && ts.isPropertyDeclaration(member)
+          && member.initializer
+          && isGeneratedServiceClientNew(member.initializer)
+        ) {
+          offenders.push(`${fileName}:${lineForPosition(ast, member.initializer.getStart(ast))}`);
+        }
+      }
+    }
+  }
+  return offenders;
+}
+
+function astForPath(filePath) {
+  return ts.createSourceFile(
+    filePath,
+    readFileSync(filePath, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+}
+
+function panelKeyForSpecifier(specifier) {
+  if (!specifier.startsWith('@/components/')) return null;
+  const baseName = specifier.slice('@/components/'.length).split('/').pop();
+  if (!baseName) return null;
+  return panelKeyForFile(`${baseName}.ts`);
+}
+
+function startupPanelValueImportOffenders(panelCluster) {
+  const offenders = [];
+  for (const filePath of startupModulePaths) {
+    const ast = astForPath(filePath);
+    const relativePath = filePath.slice(repoRoot.length + 1);
+    for (const statement of ast.statements) {
+      if (!ts.isImportDeclaration(statement)) continue;
+      const importClause = statement.importClause;
+      if (!importClause || importClause.isTypeOnly) continue;
+      const specifier = stringValue(statement.moduleSpecifier);
+      if (!specifier) continue;
+      if (specifier === '@/components') {
+        offenders.push(`${relativePath}:${lineForPosition(ast, statement.getStart(ast))} imports the component barrel`);
+        continue;
+      }
+      const panelKey = panelKeyForSpecifier(specifier);
+      if (panelKey && panelCluster.has(panelKey)) {
+        offenders.push(`${relativePath}:${lineForPosition(ast, statement.getStart(ast))} imports ${specifier}`);
+      }
+    }
+  }
+  return offenders;
+}
+
+function builtDashboardLazyPreloadOffenders() {
+  const htmlPath = resolve(repoRoot, 'dist/dashboard.html');
+  if (!existsSync(htmlPath)) return null;
+  const html = readFileSync(htmlPath, 'utf8');
+  const preloadHrefs = [...html.matchAll(/<link\b[^>]*\brel=["']modulepreload["'][^>]*\bhref=["']([^"']+)["'][^>]*>/g)]
+    .map((match) => match[1]);
+  return preloadHrefs.filter((href) => /\/assets\/(?:panels-[a-z]+|panel-support)-[A-Za-z0-9_-]+\.js$/.test(href));
+}
+
+describe('panel cluster chunk guardrails', () => {
+  it('keeps all panel component files assigned to documented domain chunks', () => {
+    const panelCluster = extractObjectMap('PANEL_CLUSTER');
+    const panelSupportCluster = extractObjectMap('PANEL_SUPPORT_CLUSTER');
+    const panelChunkNames = new Set([
+      ...extractStringArray('PANEL_CHUNK_NAMES'),
+      ...extractStringArray('PANEL_SUPPORT_CHUNK_NAMES'),
+    ]);
+    const panelFiles = readdirSync(componentDir)
+      .filter(file => file.endsWith('.ts'))
+      .map(file => ({ file, key: panelKeyForFile(file) }))
+      .filter(({ key }) => key !== null);
+
+    const missing = panelFiles
+      .filter(({ key }) => !panelCluster.has(key) && !panelSupportCluster.has(key))
+      .map(({ file, key }) => `${file} (${key})`);
+    assert.deepEqual(missing, [], 'Every panel component file must be assigned in PANEL_CLUSTER or PANEL_SUPPORT_CLUSTER.');
+
+    const configuredKeys = [...panelCluster.keys(), ...panelSupportCluster.keys()];
+    const stale = configuredKeys
+      .filter(key => key !== 'CountryBriefPage' && key !== 'RegionalIntelligenceBoard')
+      .filter(key => !existsSync(resolve(componentDir, `${key}Panel.ts`)));
+    assert.deepEqual(stale, [], 'Panel chunk maps contain entries for missing panel files.');
+
+    const invalidChunks = [...panelCluster.entries(), ...panelSupportCluster.entries()]
+      .filter(([, chunk]) => !panelChunkNames.has(chunk))
+      .map(([key, chunk]) => `${key}: ${chunk}`);
+    assert.deepEqual(invalidChunks, [], 'Panel chunk maps must only use documented chunk-name entries.');
+  });
+
+  it('routes panel modules through PANEL_CLUSTER instead of a monolithic panels chunk', () => {
+    assert.equal(
+      hasCall(viteConfigAst, 'panelChunkForComponentId'),
+      true,
+      'manualChunks must classify panel files through panelChunkForComponentId().',
+    );
+    assert.equal(
+      returnedStringLiterals(viteConfigAst).includes('panels'),
+      false,
+      'manualChunks must not return the old monolithic panels chunk.',
+    );
+    assert.equal(
+      hasTrueProperty(viteConfigAst, 'onlyExplicitManualChunks'),
+      true,
+      'Rollup must keep manual chunk dependencies explicit so app-shared modules do not make main import panel chunks.',
+    );
+  });
+
+  it('keeps panel domain chunks out of entry HTML modulepreloads', () => {
+    assert.equal(
+      hasSpreadOfArray('LAZY_HTML_PRELOAD_CHUNKS', 'PANEL_CHUNK_NAMES'),
+      true,
+      'PANEL_CHUNK_NAMES must feed the HTML preload exclusion list.',
+    );
+    assert.equal(
+      hasSpreadOfArray('LAZY_HTML_PRELOAD_CHUNKS', 'PANEL_SUPPORT_CHUNK_NAMES'),
+      true,
+      'PANEL_SUPPORT_CHUNK_NAMES must feed the HTML preload exclusion list.',
+    );
+    const builtOffenders = builtDashboardLazyPreloadOffenders();
+    if (builtOffenders) {
+      assert.deepEqual(
+        builtOffenders,
+        [],
+        'Built dashboard.html must not modulepreload panel domain/support chunks.',
+      );
+    }
+  });
+
+  it('keeps generated service clients lazy in component modules', () => {
+    const offenders = readdirSync(componentDir)
+      .filter(file => file.endsWith('.ts'))
+      .flatMap(topLevelGeneratedClientOffenders);
+
+    assert.deepEqual(
+      offenders,
+      [],
+      'Generated ServiceClient instances in component modules must be created through lazy getters, not at module evaluation.',
+    );
+  });
+
+  it('keeps startup modules from value-importing clustered panel chunks', () => {
+    const panelCluster = new Map([
+      ...extractObjectMap('PANEL_CLUSTER'),
+      ...extractObjectMap('PANEL_SUPPORT_CLUSTER'),
+    ]);
+
+    assert.deepEqual(
+      startupPanelValueImportOffenders(panelCluster),
+      [],
+      'Startup modules must use dynamic imports or type-only imports for panel chunks.',
+    );
+  });
+});

--- a/tests/panel-cluster-chunks.test.mjs
+++ b/tests/panel-cluster-chunks.test.mjs
@@ -119,6 +119,56 @@ function hasTrueProperty(ast, propertyName) {
   return found;
 }
 
+function hasLazyHtmlModulePreloadFilter(ast) {
+  let found = false;
+  function visit(node) {
+    if (
+      ts.isPropertyAssignment(node)
+      && propertyNameText(node.name) === 'resolveDependencies'
+      && (ts.isArrowFunction(node.initializer) || ts.isFunctionExpression(node.initializer))
+    ) {
+      let hasHtmlHostGuard = false;
+      let hasDepsFilter = false;
+      let hasLazyChunkTest = false;
+      function inspect(bodyNode) {
+        if (
+          ts.isBinaryExpression(bodyNode)
+          && ts.isIdentifier(bodyNode.left)
+          && bodyNode.left.text === 'hostType'
+          && bodyNode.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsEqualsToken
+          && stringValue(bodyNode.right) === 'html'
+        ) {
+          hasHtmlHostGuard = true;
+        }
+        if (
+          ts.isCallExpression(bodyNode)
+          && ts.isPropertyAccessExpression(bodyNode.expression)
+          && bodyNode.expression.name.text === 'filter'
+          && ts.isIdentifier(bodyNode.expression.expression)
+          && bodyNode.expression.expression.text === 'deps'
+        ) {
+          hasDepsFilter = true;
+        }
+        if (
+          ts.isCallExpression(bodyNode)
+          && ts.isPropertyAccessExpression(bodyNode.expression)
+          && bodyNode.expression.name.text === 'test'
+          && ts.isIdentifier(bodyNode.expression.expression)
+          && bodyNode.expression.expression.text === 'LAZY_HTML_PRELOAD_RE'
+        ) {
+          hasLazyChunkTest = true;
+        }
+        ts.forEachChild(bodyNode, inspect);
+      }
+      inspect(node.initializer.body);
+      if (hasHtmlHostGuard && hasDepsFilter && hasLazyChunkTest) found = true;
+    }
+    ts.forEachChild(node, visit);
+  }
+  visit(ast);
+  return found;
+}
+
 function returnedStringLiterals(ast) {
   const values = [];
   function visit(node) {
@@ -300,8 +350,13 @@ describe('panel cluster chunk guardrails', () => {
       true,
       'PANEL_SUPPORT_CHUNK_NAMES must feed the HTML preload exclusion list.',
     );
+    assert.equal(
+      hasLazyHtmlModulePreloadFilter(viteConfigAst),
+      true,
+      'modulePreload.resolveDependencies must filter HTML deps through LAZY_HTML_PRELOAD_RE so panel chunks stay out of eager entry preloads even when this test runs without dist/.',
+    );
     const builtOffenders = builtDashboardLazyPreloadOffenders();
-    if (builtOffenders) {
+    if (builtOffenders !== null) {
       assert.deepEqual(
         builtOffenders,
         [],

--- a/tests/panel-config-guardrails.test.mjs
+++ b/tests/panel-config-guardrails.test.mjs
@@ -152,7 +152,7 @@ describe('panel-config guardrails', () => {
   it('reapplies panel settings after mounting the async deduction panel', () => {
     assert.match(
       panelLayoutSrc,
-      /this\.lazyPanel\('deduction',\s*\(\)\s*=>\s*\n?\s*import\('@\/components\/DeductionPanel'\)[\s\S]*?new DeductionPanel\(\(\) => this\.ctx\.allNews\)/,
+      /this\.lazyPanel\('deduction',\s*\(\)\s*=>\s*\n?\s*this\.importPanel\([\s\S]*?'@\/components\/DeductionPanel'[\s\S]*?new DeductionPanel\(\(\) => this\.ctx\.allNews\)/,
       'expected DeductionPanel to be registered through the lazy panel loader',
     );
 
@@ -175,6 +175,39 @@ describe('panel-config guardrails', () => {
       /panel\.toggle\(config\.enabled\);/,
       'lazy-mounted panels must replay the saved enabled/hidden state after insertion',
     );
+  });
+
+  it('runs dynamic custom and MCP panels through the mounted-panel hydration path', () => {
+    const helperStart = panelLayoutSrc.indexOf('private addDynamicPanel(');
+    assert.notEqual(helperStart, -1, 'expected addDynamicPanel helper in panel-layout.ts');
+    const helperEnd = panelLayoutSrc.indexOf('addCustomWidget(spec:', helperStart);
+    assert.ok(helperEnd > helperStart, 'expected addDynamicPanel helper boundary in panel-layout.ts');
+    const addDynamicPanel = panelLayoutSrc.slice(helperStart, helperEnd);
+    assert.match(
+      addDynamicPanel,
+      /this\.afterPanelMounted\(key, panel\);/,
+      'custom and MCP panels added after startup must run afterPanelMounted so initial hydration can be scheduled',
+    );
+
+    for (const methodName of ['addCustomWidget', 'addMcpPanel']) {
+      const methodStart = panelLayoutSrc.indexOf(`${methodName}(spec:`);
+      assert.notEqual(methodStart, -1, `expected ${methodName} method in panel-layout.ts`);
+      const methodEnd = methodName === 'addCustomWidget'
+        ? panelLayoutSrc.indexOf('addMcpPanel(spec:', methodStart)
+        : panelLayoutSrc.indexOf('private getSavedPanelOrder', methodStart);
+      assert.ok(methodEnd > methodStart, `expected ${methodName} method boundary in panel-layout.ts`);
+      const method = panelLayoutSrc.slice(methodStart, methodEnd);
+      assert.match(
+        method,
+        /this\.importPanel\(/,
+        `${methodName} must use the shared guarded import path`,
+      );
+      assert.match(
+        method,
+        /this\.addDynamicPanel\(spec\.id, panel\);/,
+        `${methodName} must insert through addDynamicPanel() so notifyConnected/afterPanelMounted run`,
+      );
+    }
   });
 
   it('every API-key-entitled premium panel is in WEB_PREMIUM_PANELS (anon lock-CTA invariant)', () => {

--- a/tests/panel-config-guardrails.test.mjs
+++ b/tests/panel-config-guardrails.test.mjs
@@ -150,15 +150,30 @@ describe('panel-config guardrails', () => {
   });
 
   it('reapplies panel settings after mounting the async deduction panel', () => {
-    const deductionMount = panelLayoutSrc.match(
-      /import\('@\/components\/DeductionPanel'\)\.then\(\(\{ DeductionPanel \}\) => \{([\s\S]*?)\n\s*\}\);/
+    assert.match(
+      panelLayoutSrc,
+      /this\.lazyPanel\('deduction',\s*\(\)\s*=>\s*\n?\s*import\('@\/components\/DeductionPanel'\)[\s\S]*?new DeductionPanel\(\(\) => this\.ctx\.allNews\)/,
+      'expected DeductionPanel to be registered through the lazy panel loader',
     );
 
-    assert.ok(deductionMount, 'expected async DeductionPanel mount block in panel-layout.ts');
+    const mountLazyPanel = panelLayoutSrc.match(
+      /private mountLazyPanel\([\s\S]*?\n\s*\}/
+    );
+    assert.ok(mountLazyPanel, 'expected mountLazyPanel helper in panel-layout.ts');
     assert.match(
-      deductionMount[1],
-      /this\.applyPanelSettings\(\);/,
-      'async DeductionPanel mount must replay saved panel settings after insertion',
+      mountLazyPanel[0],
+      /this\.afterPanelMounted\(key, panel\);/,
+      'lazy panel mounts must run afterPanelMounted so saved settings and hydration replay apply',
+    );
+
+    const afterPanelMounted = panelLayoutSrc.match(
+      /private afterPanelMounted\([\s\S]*?\n\s*\}/
+    );
+    assert.ok(afterPanelMounted, 'expected afterPanelMounted helper in panel-layout.ts');
+    assert.match(
+      afterPanelMounted[0],
+      /panel\.toggle\(config\.enabled\);/,
+      'lazy-mounted panels must replay the saved enabled/hidden state after insertion',
     );
   });
 

--- a/tests/panel-layout-dynamic-import-guard.test.mts
+++ b/tests/panel-layout-dynamic-import-guard.test.mts
@@ -2,15 +2,10 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
 
-// Regression coverage for WORLDMONITOR-R4: dynamic `import(...).then(({ Foo }) => new Foo(...))`
-// must guard against the destructured named export resolving to `undefined`, AND must pass an
-// onRejected handler as the SECOND argument to `.then(...)` so the import-promise rejection is
-// suppressed without swallowing synchronous throws from inside the .then() callback body
-// (panel construction, getElement, makeDraggable, etc.) — those must keep surfacing in Sentry.
-//
-// The two call sites at src/app/panel-layout.ts:1041 (DeductionPanel) and :1059
-// (RegionalIntelligenceBoard) are the only ones in the file that use the destructure-and-
-// construct pattern; any sibling that adopts the same shape should add the same guards.
+// Regression coverage for WORLDMONITOR-R4 adapted to the lazy panel registry:
+// DeductionPanel and RegionalIntelligenceBoard must stay demand-loaded through
+// `lazyPanel(...)`, and the shared lazy loader must treat failed chunk loads as
+// recoverable instead of letting an absent/offline async panel crash startup.
 
 // Note: we deliberately do NOT strip comments via a naive regex before grepping —
 // panel-layout.ts contains regex literals like `/\/\*.../` that would defeat a naive
@@ -118,17 +113,56 @@ function assertGuardedDynamicImport(source: string, modulePath: string, exportNa
   );
 }
 
-describe('panel-layout dynamic-import guard (WORLDMONITOR-R4)', () => {
+function assertLazyPanelRegistration(
+  source: string,
+  panelKey: string,
+  modulePath: string,
+  exportName: string,
+) {
+  const registration = new RegExp(
+    `this\\.lazyPanel\\(['"]${panelKey}['"],\\s*\\(\\)\\s*=>\\s*\\n?\\s*import\\(['"]${modulePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"]\\)[\\s\\S]*?new\\s+${exportName}\\(`,
+  );
+  assert.match(source, registration, `${exportName} must be registered through lazyPanel(${panelKey})`);
+  assert.doesNotMatch(
+    source,
+    new RegExp(`^import\\s+\\{[^}]*${exportName}[^}]*\\}\\s+from\\s+['"]${modulePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"]`, 'm'),
+    `${exportName} must not be eagerly imported into panel-layout.ts`,
+  );
+}
+
+function assertLazyLoaderHandlesFailedImports(source: string) {
+  const loadRegisteredPanel = source.match(/private async loadRegisteredPanel\([\s\S]*?\n\s*private makeDraggable/);
+  assert.ok(loadRegisteredPanel, 'loadRegisteredPanel helper not found');
+  assert.match(
+    loadRegisteredPanel[0],
+    /registration\.loading = registration\.load\(\)[\s\S]*?\.catch\(\(err\) => \{/,
+    'lazy panel chunk failures must be caught by the shared loader',
+  );
+  assert.match(
+    loadRegisteredPanel[0],
+    /registration\.loading = null;/,
+    'failed lazy panel loads must reset the in-flight promise so the panel can retry',
+  );
+  assert.match(
+    loadRegisteredPanel[0],
+    /return null;/,
+    'failed lazy panel loads must resolve to null instead of crashing startup',
+  );
+}
+
+describe('panel-layout lazy dynamic-import guard (WORLDMONITOR-R4)', () => {
   const filePath = new URL('../src/app/panel-layout.ts', import.meta.url);
 
-  it('RegionalIntelligenceBoard import has typeof guard + onRejected arg', async () => {
+  it('RegionalIntelligenceBoard is demand-loaded through lazyPanel', async () => {
     const source = await readFile(filePath, 'utf8');
-    assertGuardedDynamicImport(source, '@/components/RegionalIntelligenceBoard', 'RegionalIntelligenceBoard');
+    assertLazyPanelRegistration(source, 'regional-intelligence', '@/components/RegionalIntelligenceBoard', 'RegionalIntelligenceBoard');
+    assertLazyLoaderHandlesFailedImports(source);
   });
 
-  it('DeductionPanel import has typeof guard + onRejected arg', async () => {
+  it('DeductionPanel is demand-loaded through lazyPanel', async () => {
     const source = await readFile(filePath, 'utf8');
-    assertGuardedDynamicImport(source, '@/components/DeductionPanel', 'DeductionPanel');
+    assertLazyPanelRegistration(source, 'deduction', '@/components/DeductionPanel', 'DeductionPanel');
+    assertLazyLoaderHandlesFailedImports(source);
   });
 
   it('token-aware brace walker skips strings/templates/comments', () => {

--- a/tests/panel-layout-dynamic-import-guard.test.mts
+++ b/tests/panel-layout-dynamic-import-guard.test.mts
@@ -3,9 +3,10 @@ import { readFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
 
 // Regression coverage for WORLDMONITOR-R4 adapted to the lazy panel registry:
-// DeductionPanel and RegionalIntelligenceBoard must stay demand-loaded through
-// `lazyPanel(...)`, and the shared lazy loader must treat failed chunk loads as
-// recoverable instead of letting an absent/offline async panel crash startup.
+// split-risk panels must stay demand-loaded through `lazyPanel(...)`, and their
+// dynamic imports must route through the Safari-safe importPanel helper. The
+// shared lazy loader must also treat failed chunk loads as recoverable instead of
+// letting an absent/offline async panel crash startup.
 
 // Note: we deliberately do NOT strip comments via a naive regex before grepping —
 // panel-layout.ts contains regex literals like `/\/\*.../` that would defeat a naive
@@ -120,9 +121,9 @@ function assertLazyPanelRegistration(
   exportName: string,
 ) {
   const registration = new RegExp(
-    `this\\.lazyPanel\\(['"]${panelKey}['"],\\s*\\(\\)\\s*=>\\s*\\n?\\s*import\\(['"]${modulePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"]\\)[\\s\\S]*?new\\s+${exportName}\\(`,
+    `this\\.lazyPanel\\(['"]${panelKey}['"],\\s*\\(\\)\\s*=>\\s*(?:\\n\\s*)?this\\.importPanel\\(\\s*['"]${panelKey}['"],\\s*\\(\\)\\s*=>\\s*import\\(['"]${modulePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"]\\),\\s*['"]${exportName}['"]`,
   );
-  assert.match(source, registration, `${exportName} must be registered through lazyPanel(${panelKey})`);
+  assert.match(source, registration, `${exportName} must be registered through lazyPanel(${panelKey}) and importPanel()`);
   assert.doesNotMatch(
     source,
     new RegExp(`^import\\s+\\{[^}]*${exportName}[^}]*\\}\\s+from\\s+['"]${modulePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"]`, 'm'),
@@ -150,18 +151,64 @@ function assertLazyLoaderHandlesFailedImports(source: string) {
   );
 }
 
+function assertSharedImportPanelGuard(source: string) {
+  const callback = findCallbackBody(source, /return\s+importer\(\)\.then\(\(module\)\s*=>\s*\{/);
+  assert.ok(callback, 'importPanel helper must call importer().then(onFulfilled, onRejected)');
+  assert.match(
+    callback.body,
+    /const PanelClass = module\[exportName\];/,
+    'importPanel helper must read the requested named export dynamically.',
+  );
+  assert.match(
+    callback.body,
+    /typeof\s+PanelClass\s*!==?\s*['"]function['"]/,
+    'importPanel helper must verify the named export is a constructor function before using it.',
+  );
+  const tail = source.slice(callback.afterIdx, callback.afterIdx + 200);
+  assert.match(
+    tail,
+    /^\s*,\s*\([^)]*\)\s*=>/,
+    'importPanel helper must use two-arg .then(onFulfilled, onRejected), not .then(...).catch(...).',
+  );
+  assert.doesNotMatch(
+    tail,
+    /^\s*\)\s*\.catch\(/,
+    'importPanel helper must not use .then(...).catch(...) for import failures.',
+  );
+}
+
+const SPLIT_RISK_PANEL_IMPORTS: Array<[string, string, string]> = [
+  ['pipeline-status', '@/components/PipelineStatusPanel', 'PipelineStatusPanel'],
+  ['storage-facility-map', '@/components/StorageFacilityMapPanel', 'StorageFacilityMapPanel'],
+  ['fuel-shortages', '@/components/FuelShortagePanel', 'FuelShortagePanel'],
+  ['energy-disruptions', '@/components/EnergyDisruptionsPanel', 'EnergyDisruptionsPanel'],
+  ['energy-risk-overview', '@/components/EnergyRiskOverviewPanel', 'EnergyRiskOverviewPanel'],
+  ['deduction', '@/components/DeductionPanel', 'DeductionPanel'],
+  ['regional-intelligence', '@/components/RegionalIntelligenceBoard', 'RegionalIntelligenceBoard'],
+  ['gulf-economies', '@/components/GulfEconomiesPanel', 'GulfEconomiesPanel'],
+  ['grocery-basket', '@/components/GroceryBasketPanel', 'GroceryBasketPanel'],
+  ['bigmac', '@/components/BigMacPanel', 'BigMacPanel'],
+  ['fuel-prices', '@/components/FuelPricesPanel', 'FuelPricesPanel'],
+  ['fao-food-price-index', '@/components/FaoFoodPriceIndexPanel', 'FaoFoodPriceIndexPanel'],
+  ['climate-news', '@/components/ClimateNewsPanel', 'ClimateNewsPanel'],
+  ['events', '@/components/TechEventsPanel', 'TechEventsPanel'],
+  ['macro-signals', '@/components/MacroSignalsPanel', 'MacroSignalsPanel'],
+];
+
 describe('panel-layout lazy dynamic-import guard (WORLDMONITOR-R4)', () => {
   const filePath = new URL('../src/app/panel-layout.ts', import.meta.url);
 
-  it('RegionalIntelligenceBoard is demand-loaded through lazyPanel', async () => {
+  it('shared importPanel helper uses Safari-safe dynamic import guards', async () => {
     const source = await readFile(filePath, 'utf8');
-    assertLazyPanelRegistration(source, 'regional-intelligence', '@/components/RegionalIntelligenceBoard', 'RegionalIntelligenceBoard');
+    assertSharedImportPanelGuard(source);
     assertLazyLoaderHandlesFailedImports(source);
   });
 
-  it('DeductionPanel is demand-loaded through lazyPanel', async () => {
+  it('split-risk panels are demand-loaded through the guarded helper', async () => {
     const source = await readFile(filePath, 'utf8');
-    assertLazyPanelRegistration(source, 'deduction', '@/components/DeductionPanel', 'DeductionPanel');
+    for (const [panelKey, modulePath, exportName] of SPLIT_RISK_PANEL_IMPORTS) {
+      assertLazyPanelRegistration(source, panelKey, modulePath, exportName);
+    }
     assertLazyLoaderHandlesFailedImports(source);
   });
 

--- a/tests/product-catalog-freshness.test.mjs
+++ b/tests/product-catalog-freshness.test.mjs
@@ -160,6 +160,7 @@ describe('Product ID guard', () => {
     const result = execSync(
       `grep -rn 'pdt_' --include='*.ts' --include='*.tsx' --include='*.mjs' --include='*.js' . ` +
       `| grep -v node_modules ` +
+      `| grep -v './dist/' ` +
       `| grep -v '.claude/worktrees/' ` +
       `| grep -v 'convex/_generated/' ` +
       `| grep -v 'convex/config/productCatalog' ` +

--- a/tests/threat-timeline-panel.test.mts
+++ b/tests/threat-timeline-panel.test.mts
@@ -458,7 +458,7 @@ describe('ThreatTimelinePanel registration', () => {
 
     assert.match(panelsSrc, /'threat-timeline':\s*\{\s*name:\s*'Threat Timeline'/);
     assert.match(panelsSrc, /intelligence:\s*\{[\s\S]*panelKeys:\s*\[[^\]]*'threat-timeline'/);
-    assert.match(layoutSrc, /isPanelInVariantDefaults\('threat-timeline'\)[\s\S]*createPanel\('threat-timeline',\s*\(\)\s*=>\s*new ThreatTimelinePanel\(\)\)/);
+    assert.match(layoutSrc, /isPanelInVariantDefaults\('threat-timeline'\)[\s\S]*lazyPanel\('threat-timeline',\s*\(\)\s*=>\s*import\('@\/components\/ThreatTimelinePanel'\)\.then\(m\s*=>\s*new m\.ThreatTimelinePanel\(\)\)\)/);
     assert.match(dataLoaderSrc, /isPanelInVariantDefaults\('threat-timeline'\)[\s\S]*panels\['threat-timeline'\]\s+as ThreatTimelinePanel/);
     assert.match(commandsSrc, /id:\s*'panel:threat-timeline'[\s\S]*keywords:\s*\[[^\]]*'threat trend'/);
   });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,20 @@ if (CLERK_JS_VERSION.split('.')[0] !== '6') {
   throw new Error(`[vite] @clerk/clerk-js major is ${CLERK_JS_VERSION.split('.')[0]}, expected 6 — update CLERK_UI_VERSION in src/services/clerk.ts to the paired @clerk/ui major, then bump this guard.`);
 }
 
+const PANEL_CHUNK_NAMES = [
+  'panels-markets',
+  'panels-energy',
+  'panels-defense',
+  'panels-news',
+  'panels-economy',
+  'panels-intel',
+  'panels-risk',
+] as const;
+type PanelChunkName = typeof PANEL_CHUNK_NAMES[number];
+const PANEL_SUPPORT_CHUNK_NAMES = ['panel-support'] as const;
+type PanelSupportChunkName = typeof PANEL_SUPPORT_CHUNK_NAMES[number];
+type PanelManualChunkName = PanelChunkName | PanelSupportChunkName;
+
 // Single source of truth for chunk names that must NOT be hoisted into the
 // entry HTML's modulepreload list. Used by both `manualChunks` (return values
 // must literally match these strings) and `modulePreload.resolveDependencies`
@@ -43,7 +57,8 @@ if (CLERK_JS_VERSION.split('.')[0] !== '6') {
 // re-eagerises the WebGL stack without any build-time error.
 //   - maplibre, deck-stack: heavy WebGL deps, only reachable via MapContainer
 //   - MapContainer: the dynamic-import target itself
-const LAZY_HTML_PRELOAD_CHUNKS = ['maplibre', 'deck-stack', 'MapContainer'] as const;
+//   - panels-*: panel domain chunks; keep them out of the entry HTML preload
+const LAZY_HTML_PRELOAD_CHUNKS = ['maplibre', 'deck-stack', 'MapContainer', ...PANEL_CHUNK_NAMES, ...PANEL_SUPPORT_CHUNK_NAMES] as const;
 const LAZY_HTML_PRELOAD_RE = new RegExp(
   `/(${LAZY_HTML_PRELOAD_CHUNKS.join('|')})-[A-Za-z0-9_-]+\\.js$`,
 );
@@ -51,8 +66,9 @@ const LAZY_HTML_PRELOAD_RE = new RegExp(
 // Panel-cluster manualChunks map. Splits the previously monolithic ~2.3MB
 // `panels` chunk into per-domain chunks so cache invalidation is local to
 // the cluster a panel lives in and per-variant builds can prune unused
-// clusters. Unmapped panels fall through to a generic `panels` chunk.
-const PANEL_CLUSTER: Record<string, string> = {
+// clusters. New panel files must be assigned here before the build can split
+// them; otherwise they would silently fall back into an eager catch-all chunk.
+const PANEL_CLUSTER: Record<string, PanelChunkName> = {
   // Markets / equities / crypto positioning
   AAIISentiment: 'panels-markets', CotPositioning: 'panels-markets',
   ETFFlows: 'panels-markets', EarningsCalendar: 'panels-markets',
@@ -94,7 +110,8 @@ const PANEL_CLUSTER: Record<string, string> = {
   // in this cluster — splitting them across clusters caused TDZ on init.
   ChatAnalyst: 'panels-intel', CII: 'panels-intel',
   Cascade: 'panels-intel', Correlation: 'panels-intel',
-  CountryBrief: 'panels-intel', CountryDeepDive: 'panels-intel',
+  CountryBrief: 'panels-intel', CountryBriefPage: 'panels-intel',
+  CountryDeepDive: 'panels-intel',
   CrossSourceSignals: 'panels-intel', CustomWidget: 'panels-intel',
   Deduction: 'panels-intel',
   DisasterCorrelation: 'panels-intel',
@@ -106,6 +123,7 @@ const PANEL_CLUSTER: Record<string, string> = {
   LiveWebcams: 'panels-intel', McpData: 'panels-intel',
   Monitor: 'panels-intel', PinnedWebcams: 'panels-intel',
   Prediction: 'panels-intel', ProgressCharts: 'panels-intel',
+  RegionalIntelligenceBoard: 'panels-intel',
   Regulation: 'panels-intel',
   // Disasters / climate / connectivity / society
   ClimateAnomaly: 'panels-risk', Counters: 'panels-risk',
@@ -116,10 +134,34 @@ const PANEL_CLUSTER: Record<string, string> = {
   RuntimeConfig: 'panels-risk', SatelliteFires: 'panels-risk',
   SecurityAdvisories: 'panels-risk', ServiceStatus: 'panels-risk',
   SocialVelocity: 'panels-risk', SpeciesComeback: 'panels-risk',
-  Status: 'panels-risk', TechEvents: 'panels-risk',
+  TechEvents: 'panels-risk',
+  ThreatTimeline: 'panels-risk',
   TechHubs: 'panels-risk', TechReadiness: 'panels-risk',
   WorldClock: 'panels-risk',
 };
+
+const PANEL_SUPPORT_CLUSTER: Record<string, PanelSupportChunkName> = {
+  Status: 'panel-support',
+};
+
+function panelKeyForComponentId(id: string): string | null {
+  if (!id.includes('/src/components/') || !id.endsWith('.ts')) return null;
+  const match = id.match(/\/([^/]+)\.ts$/);
+  if (!match) return null;
+  const fileBase = match[1];
+  if (fileBase === 'Panel') return null;
+  if (fileBase === 'CountryBriefPage' || fileBase === 'RegionalIntelligenceBoard') return fileBase;
+  if (fileBase.endsWith('Panel')) return fileBase.slice(0, -'Panel'.length);
+  return null;
+}
+
+function panelChunkForComponentId(id: string): PanelManualChunkName | null {
+  const panelKey = panelKeyForComponentId(id);
+  if (!panelKey) return null;
+  const chunkName = PANEL_SUPPORT_CLUSTER[panelKey] ?? PANEL_CLUSTER[panelKey];
+  if (chunkName) return chunkName;
+  throw new Error(`[manualChunks] Unassigned panel component ${panelKey}. Add it to PANEL_CLUSTER or PANEL_SUPPORT_CLUSTER in vite.config.ts.`);
+}
 
 function brotliPrecompressPlugin(): Plugin {
   return {
@@ -1012,6 +1054,7 @@ export default defineConfig(({ mode }) => {
           mcpGrant: resolve(__dirname, 'mcp-grant.html'),
         },
         output: {
+          onlyExplicitManualChunks: true,
           manualChunks(id) {
             if (id.includes('node_modules')) {
               if (id.includes('/@xenova/transformers/')) {
@@ -1045,7 +1088,7 @@ export default defineConfig(({ mode }) => {
               if (id.includes('/i18next')) {
                 return 'i18n';
               }
-              if (id.includes('/@sentry/')) {
+              if (id.includes('/@sentry/') || id.includes('/@sentry-internal/')) {
                 return 'sentry';
               }
               if (id.includes('/@clerk/clerk-js/')) {
@@ -1054,12 +1097,9 @@ export default defineConfig(({ mode }) => {
                 return 'clerk';
               }
             }
-            if (id.includes('/src/components/') && id.endsWith('Panel.ts')) {
-              // Cluster split (PANEL_CLUSTER) is staged but disabled: it exposes
-              // a systemic TDZ in panels with top-level `new XxxServiceClient(...)`
-              // singletons (~20+ panels). They each need lazy-init refactors
-              // before the cluster split can ship. See ce-doc-review followup.
-              return 'panels';
+            if (id.includes('/src/components/') && id.endsWith('.ts')) {
+              const panelChunk = panelChunkForComponentId(id);
+              if (panelChunk) return panelChunk;
             }
             // Give lazy-loaded locale chunks a recognizable prefix so the
             // service worker can exclude them from precache (en.json is


### PR DESCRIPTION
## Summary

Fixes #4371.

- Enables the existing `PANEL_CLUSTER` split so panel modules build into per-domain chunks instead of one eager `panels-*` bundle.
- Converts top-level generated service-client construction in the affected panel modules to lazy first-use clients.
- Removes startup value imports of clustered panels and replaces them with type-only imports, direct non-panel imports, or dynamic panel factories.
- Adds lazy panel replay/guardrails so data that arrives before a deferred panel mounts is applied when the panel chunk loads.
- Adds source and build-output guards for panel chunk assignment, lazy service clients, startup imports, and entry HTML modulepreloads.

## Intent

#4381 made the shell contentful before hydration, but left the first-wave panel payload intact. This PR focuses on the next bottleneck: splitting the previous ~2.54 MB `panels-*` eager chunk into domain chunks without reintroducing the TDZ crashes that blocked the earlier split.

I reviewed draft PR #3946 as a required decision point. I did not reuse it because it was an older draft for #3944 with conflicts/failing checks and stale assumptions against current `origin/main` after #4381. This branch starts fresh from current `main` while adapting the durable approach: lazy service clients plus documented panel domain chunks.

## Validation Matrix

| Gate | Result |
| --- | --- |
| `npm run worktree:bootstrap` | Passed |
| Current-main baseline `npm run build:full` | Passed; baseline `panels-DXgUQe1q.js` was 2,541,859 decoded / 671,155 gzip and modulepreloaded by `dashboard.html` |
| `node --test tests/panel-cluster-chunks.test.mjs tests/feed-resolution.test.mts` | Passed, 19 tests |
| `npx tsx --test --test-concurrency=16 tests/mission-presets.test.mts tests/product-catalog-freshness.test.mjs tests/panel-config-guardrails.test.mjs tests/panel-layout-dynamic-import-guard.test.mts tests/threat-timeline-panel.test.mts` | Passed, 57 tests |
| `npx tsx --test --test-concurrency=16 tests/frontend-cii-source-of-truth.test.mts tests/live-news-panel-guard.test.mts tests/load-all-data-scheduling.test.mts` | Passed, 24 tests |
| `npm run typecheck` | Passed |
| `npm run build:full` | Passed |
| `npm run test:data` | Passed, 11,526 passing / 0 failing / 6 skipped |
| `git diff --check` | Passed |
| Browser smoke via `npm run preview -- --host 127.0.0.1 --port 4172` | Passed; 234 panel elements, all seven panel clusters dynamically imported, no TDZ/ReferenceError/page errors |
| Pre-push hook | Passed: typecheck, API typecheck, Convex audit, boundaries, safe HTML, rate-limit policy, premium-fetch parity, edge bundle/tests, changed tests, version check |

Final built chunks:

| Asset | Decoded | Gzip |
| --- | ---: | ---: |
| `main-Bhhdo0cL.js` | 1,210,181 | 346,931 |
| `Panel-4kdyZ6ZX.js` | 31,721 | 7,914 |
| `panel-support-BwGUOgTA.js` | 2,789 | 1,261 |
| `panels-defense-DTj2y-BO.js` | 73,741 | 18,017 |
| `panels-economy-DL53tGCX.js` | 133,053 | 33,720 |
| `panels-energy-B4mBai0f.js` | 94,724 | 23,239 |
| `panels-intel-DzJbWByQ.js` | 241,525 | 65,980 |
| `panels-markets-DsIk7GaP.js` | 139,130 | 33,549 |
| `panels-news-qEVHNlJe.js` | 103,143 | 27,833 |
| `panels-risk-DbmiqzOf.js` | 111,710 | 28,232 |

Entry HTML checks:

- `dashboard.html` panel/support modulepreloads: `0`
- `main-Bhhdo0cL.js` static panel/support imports: `0`

## Review Gates

- Bundle graph adversary: passed. Panel/support chunks are not entry HTML modulepreloaded, and `main` has no static panel/support imports.
- TDZ/runtime adversary: passed. Generated service clients are lazy, Sentry internals stay grouped with Sentry, and all panel clusters booted in browser smoke without TDZ/ReferenceError.
- Panel behavior adversary: passed. Deferred panels replay queued data calls, CII/live-news/custom-news paths have focused guards, and premium fetch behavior is preserved.
- Test-quality adversary: passed. Guardrails parse TypeScript/Vite source with AST checks and inspect built output when `dist/` exists.
- Scope/maintainability adversary: passed. Scope stays on #4371 panel splitting, TDZ lazy clients, preload guardrails, and runtime replay.

## Documentation

No user-facing docs changed. The durable contract is encoded in `vite.config.ts` comments and `tests/panel-cluster-chunks.test.mjs`.

## Screenshots / UI Evidence

No intentional UI change. I captured a local browser smoke screenshot while verifying startup, but the evidence for this PR is bundle/runtime: all panel domain chunks dynamically import successfully, no TDZ/ReferenceError/page errors, and the entry HTML no longer modulepreloads panel/support chunks.

## Residual Findings

- `main` is larger after making manual chunks explicit. That keeps app-shared dependencies from dragging panel chunks back into the entry graph, but the remaining `main` diet belongs to follow-up #4379.
- This PR intentionally does not address CSS payload #4372 or WebGL vendor payload #4378.
