### PR TITLE
fix(build): co-locate DeckGLMap into deck-stack chunk — restore WebGL map (P0 regression from #4382)

### DIFF
--- a/tests/panel-cluster-chunks.test.mjs
+++ b/tests/panel-cluster-chunks.test.mjs
@@ -335,7 +335,7 @@ describe('panel cluster chunk guardrails', () => {
     assert.equal(
       hasTrueProperty(viteConfigAst, 'onlyExplicitManualChunks'),
       true,
-      'Rollup must keep manual chunk dependencies explicit so app-shared modules do not make main import panel chunks.',
+      'Rollup must keep manual chunk dependencies explicit so app-shared modules do not make main import panel chunks. (DeckGLMap is co-located into the deck-stack chunk to avoid the circular-chunk TDZ this flag otherwise caused on the WebGL map.)',
     );
   });
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1054,6 +1054,14 @@ export default defineConfig(({ mode }) => {
           mcpGrant: resolve(__dirname, 'mcp-grant.html'),
         },
         output: {
+          // onlyExplicitManualChunks keeps the panel clusters from forming
+          // cross-chunk cycles. Its side effect: a manual chunk's unmatched
+          // static deps get pulled into the importer chunk — which created a
+          // circular DeckGLMap -> deck-stack -> DeckGLMap chunk (runtime TDZ
+          // "Cannot access 'X' before initialization" that crashed the WebGL map
+          // into the SVG fallback). Fixed by co-locating the DeckGLMap renderer
+          // into the 'deck-stack' chunk below so deck deps never split across the
+          // DeckGLMap boundary.
           onlyExplicitManualChunks: true,
           manualChunks(id) {
             if (id.includes('node_modules')) {
@@ -1096,6 +1104,13 @@ export default defineConfig(({ mode }) => {
                 // lets Workbox keep the large auth SDK out of precache.
                 return 'clerk';
               }
+            }
+            // Co-locate the deck.gl renderer with the deck vendor chunk so
+            // onlyExplicitManualChunks cannot split deck's transitive deps
+            // across the DeckGLMap boundary (which formed a circular chunk →
+            // runtime TDZ that crashed the WebGL map into the SVG fallback).
+            if (id.endsWith('/src/components/DeckGLMap.ts')) {
+              return 'deck-stack';
             }
             if (id.includes('/src/components/') && id.endsWith('.ts')) {
               const panelChunk = panelChunkForComponentId(id);


### PR DESCRIPTION
## P0 — the WebGL map is crashing to the old SVG map for all users

After #4382 merged, the dashboard renders the old d3/SVG flat map instead of the WebGL map. Confirmed live in Chrome:

```
[MapContainer] DeckGL initialization failed, falling back to SVG map
ReferenceError: Cannot access 'Hn' before initialization  @ deck-stack-*.js
```

### Root cause
#4382 added `output.onlyExplicitManualChunks: true` — which is **load-bearing** for the panel-cluster split (without it the panel chunks form cycles). But its side effect pulls a manual chunk's unmatched static deps into the importer chunk. `DeckGLMap.ts` imports deck.gl, so deck's deps got pulled back across the `DeckGLMap` boundary, forming a **circular `DeckGLMap → deck-stack → DeckGLMap` chunk**. At runtime that's a TDZ that throws on deck.gl init → SVG fallback.

The vite build already printed the warning: `Circular chunk: DeckGLMap -> deck-stack -> DeckGLMap. Consider disabling "output.onlyExplicitManualChunks"`. (Disabling the flag is *not* the fix — it regresses the panels back to circular chunks.)

### Fix
Co-locate the `DeckGLMap` renderer into the deck vendor chunk so deck's deps can never split across the boundary — keeping the flag for the panel split:

```ts
if (id.endsWith('/src/components/DeckGLMap.ts')) {
  return 'deck-stack';
}
```

### Verification
- **Build:** zero circular chunks (deck *and* panel); `DeckGLMap` merges into `deck-stack` (no separate chunk); all 7 panel cluster chunks stay lazy and out of the eager modulepreload.
- **Runtime** (vite preview + Chrome): `mapMode: deckgl-mode`, deck.gl initializes, maplibre WebGL canvas renders, **no deck error** in console.
- **Tests:** `tests/panel-cluster-chunks.test.mjs` — 5/5 pass.

No behavior change beyond chunk assignment; the panel-split wins from #4382 are fully preserved.

https://claude.ai/code/session_015Ae5Xavw1ZV4GMCWEsgKwe