### PR TITLE
perf(startup): lazy-load settings and checkout SDK

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Agent entry point for WorldMonitor. Read this first, then follow links for depth
 
 ## What This Project Is
 
-Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 155 top-level TypeScript component files, 80+ Vercel Edge API endpoint entries, a Tauri desktop app with Node.js sidecar, and a Railway relay service. Aggregates geopolitics, military, finance, climate, cyber, maritime, and aviation data across 35 freshness-tracked source groups.
+Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 157 top-level TypeScript component files, 80+ Vercel Edge API endpoint entries, a Tauri desktop app with Node.js sidecar, and a Railway relay service. Aggregates geopolitics, military, finance, climate, cyber, maritime, and aviation data across 35 freshness-tracked source groups.
 
 ## Repository Map
 
@@ -13,7 +13,7 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 155
 ├── src/                    # Browser SPA (TypeScript, class-based components)
 │   ├── app/                # App orchestration (data-loader, refresh-scheduler, panel-layout)
 │   ├── bootstrap/          # Startup/recovery (chunk reload, deferred Sentry, SW update)
-│   ├── components/         # 155 top-level TypeScript component files
+│   ├── components/         # 157 top-level TypeScript component files
 │   ├── config/             # Variant configs, panel/layer definitions, market symbols
 │   ├── services/           # Business logic (186 service modules and domain directories)
 │   ├── shared/             # Cross-cutting helpers (premium paths, registries, staleness)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Variants share all code but differ in default panels, map layers, and RSS feeds.
 
 | Directory | Purpose |
 |---|---|
-| `src/components/` | UI components — 155 top-level TypeScript component files |
+| `src/components/` | UI components — 157 top-level TypeScript component files |
 | `src/services/` | Data fetching modules — sebuf client wrappers, AI, signal analysis |
 | `src/config/` | Static data and variant configs (feeds, geo, military, pipelines, ports) |
 | `src/generated/` | Auto-generated sebuf client + server stubs (**do not edit by hand**) |

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -10,7 +10,7 @@
     "energy": 18
   },
   "variantCount": 6,
-  "componentTopLevelTsFiles": 155,
+  "componentTopLevelTsFiles": 157,
   "serviceTopLevelEntries": 186,
   "apiEndpointEntries": 80,
   "panelClasses": 104,

--- a/src/app/app-context.ts
+++ b/src/app/app-context.ts
@@ -8,6 +8,15 @@ import type { Earthquake } from '@/services/earthquakes';
 
 export type { CountryBriefSignals } from '@/types';
 
+export type UnifiedSettingsTabId = 'settings' | 'panels' | 'sources' | 'notifications' | 'api-keys' | 'mcp-clients';
+
+export interface UnifiedSettingsController {
+  open(tab?: UnifiedSettingsTabId): void;
+  refreshPanelToggles(): void;
+  getButton(): HTMLButtonElement;
+  destroy(): void;
+}
+
 export interface IntelligenceCache {
   flightDelays?: AirportDelayAlert[];
   thermalEscalation?: import('@/services/thermal-escalation').ThermalEscalationWatch;
@@ -59,7 +68,7 @@ export interface AppContext {
   breakingBanner: import('@/components/BreakingNewsBanner').BreakingNewsBanner | null;
   playbackControl: import('@/components').PlaybackControl | null;
   exportPanel: import('@/utils').ExportPanel | null;
-  unifiedSettings: import('@/components/UnifiedSettings').UnifiedSettings | null;
+  unifiedSettings: UnifiedSettingsController | null;
   pizzintIndicator: import('@/components').PizzIntIndicator | null;
   correlationEngine: import('@/services/correlation-engine').CorrelationEngine | null;
   llmStatusIndicator: import('@/components').LlmStatusIndicator | null;

--- a/src/app/app-context.ts
+++ b/src/app/app-context.ts
@@ -8,7 +8,8 @@ import type { Earthquake } from '@/services/earthquakes';
 
 export type { CountryBriefSignals } from '@/types';
 
-export type UnifiedSettingsTabId = 'settings' | 'panels' | 'sources' | 'notifications' | 'api-keys' | 'mcp-clients';
+import type { UnifiedSettingsTabId } from '@/components/settings-types';
+export type { UnifiedSettingsTabId };
 
 export interface UnifiedSettingsController {
   open(tab?: UnifiedSettingsTabId): void;

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -96,8 +96,7 @@ import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 import { escapeHtml } from '@/utils/sanitize';
 import { buildEmbedIframeSnippet, buildEmbedMapUrl, type EmbedVariant } from '@/embed/embed-url';
-
-const SETTINGS_GEAR_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>`;
+import { createSettingsButton } from '@/components/settings-button';
 
 type RealUnifiedSettings = import('@/components/UnifiedSettings').UnifiedSettings;
 
@@ -108,12 +107,7 @@ class LazyUnifiedSettings implements UnifiedSettingsController {
   private destroyed = false;
 
   constructor(private readonly config: UnifiedSettingsConfig) {
-    this.button = document.createElement('button');
-    this.button.className = 'unified-settings-btn';
-    this.button.id = 'unifiedSettingsBtn';
-    this.button.setAttribute('aria-label', t('header.settings'));
-    setTrustedHtml(this.button, trustedHtml(SETTINGS_GEAR_SVG, "legacy direct innerHTML migration"));
-    this.button.addEventListener('click', () => this.open());
+    this.button = createSettingsButton(() => this.open());
   }
 
   getButton(): HTMLButtonElement {
@@ -124,6 +118,9 @@ class LazyUnifiedSettings implements UnifiedSettingsController {
     void this.load().then((settings) => {
       if (!this.destroyed) settings.open(tab);
     }).catch((error) => {
+      // A rejection because the controller was torn down mid-load is a
+      // deliberate unmount, not a failure the user should be toasted about.
+      if (this.destroyed) return;
       console.warn('[settings] Failed to load settings window:', error);
       showToast(t('common.error'));
     });

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -1,4 +1,10 @@
-import type { AppContext, AppModule } from '@/app/app-context';
+import type {
+  AppContext,
+  AppModule,
+  UnifiedSettingsController,
+  UnifiedSettingsTabId,
+} from '@/app/app-context';
+import type { UnifiedSettingsConfig } from '@/components/UnifiedSettings';
 import type { AirlineIntelPanel } from '@/components/AirlineIntelPanel';
 import type { CustomWidgetPanel } from '@/components/CustomWidgetPanel';
 import { openWidgetChatModal } from '@/components/WidgetChatModal';
@@ -81,7 +87,6 @@ import { invokeTauri } from '@/services/tauri-bridge';
 import { getCachedGpsInterference } from '@/services/gps-interference';
 import { dataFreshness } from '@/services/data-freshness';
 import { mlWorker } from '@/services/ml-worker';
-import { UnifiedSettings } from '@/components/UnifiedSettings';
 import { WM_OPEN_NOTIFICATIONS_FOR_COUNTRY } from '@/utils/notify-country-link';
 import { AuthLauncher } from '@/components/AuthLauncher';
 import { AuthHeaderWidget } from '@/components/AuthHeaderWidget';
@@ -91,6 +96,73 @@ import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 import { escapeHtml } from '@/utils/sanitize';
 import { buildEmbedIframeSnippet, buildEmbedMapUrl, type EmbedVariant } from '@/embed/embed-url';
+
+const SETTINGS_GEAR_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>`;
+
+type RealUnifiedSettings = import('@/components/UnifiedSettings').UnifiedSettings;
+
+class LazyUnifiedSettings implements UnifiedSettingsController {
+  private readonly button: HTMLButtonElement;
+  private instance: RealUnifiedSettings | null = null;
+  private loadPromise: Promise<RealUnifiedSettings> | null = null;
+  private destroyed = false;
+
+  constructor(private readonly config: UnifiedSettingsConfig) {
+    this.button = document.createElement('button');
+    this.button.className = 'unified-settings-btn';
+    this.button.id = 'unifiedSettingsBtn';
+    this.button.setAttribute('aria-label', t('header.settings'));
+    setTrustedHtml(this.button, trustedHtml(SETTINGS_GEAR_SVG, "legacy direct innerHTML migration"));
+    this.button.addEventListener('click', () => this.open());
+  }
+
+  getButton(): HTMLButtonElement {
+    return this.button;
+  }
+
+  open(tab?: UnifiedSettingsTabId): void {
+    void this.load().then((settings) => {
+      if (!this.destroyed) settings.open(tab);
+    }).catch((error) => {
+      console.warn('[settings] Failed to load settings window:', error);
+      showToast(t('common.error'));
+    });
+  }
+
+  refreshPanelToggles(): void {
+    this.instance?.refreshPanelToggles();
+  }
+
+  destroy(): void {
+    this.destroyed = true;
+    this.instance?.destroy();
+    this.instance = null;
+  }
+
+  private load(): Promise<RealUnifiedSettings> {
+    if (this.destroyed) {
+      return Promise.reject(new Error('Settings controller destroyed'));
+    }
+    if (this.instance) return Promise.resolve(this.instance);
+    if (this.loadPromise) return this.loadPromise;
+
+    this.loadPromise = import('@/components/UnifiedSettings')
+      .then(({ UnifiedSettings }) => {
+        const settings = new UnifiedSettings(this.config);
+        if (this.destroyed) {
+          settings.destroy();
+          throw new Error('Settings controller destroyed during load');
+        }
+        this.instance = settings;
+        return settings;
+      })
+      .finally(() => {
+        this.loadPromise = null;
+      });
+
+    return this.loadPromise;
+  }
+}
 
 
 export interface EventHandlerCallbacks {
@@ -1578,7 +1650,7 @@ export class EventHandlerManager implements AppModule {
   }
 
   setupUnifiedSettings(): void {
-    this.ctx.unifiedSettings = new UnifiedSettings({
+    this.ctx.unifiedSettings = new LazyUnifiedSettings({
       getPanelSettings: () => this.ctx.panelSettings,
       savePanelSettings: (panels: Record<string, PanelConfig>) => {
         Object.entries(panels).forEach(([key, nextConfig]) => {

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -42,7 +42,7 @@ import { initEntitlementSubscription, destroyEntitlementSubscription, isEntitled
 import { initSubscriptionWatch, destroySubscriptionWatch } from '@/services/billing';
 import { initPaymentFailureBanner } from '@/components/payment-failure-banner';
 import { handleCheckoutReturn } from '@/services/checkout-return';
-import { initCheckoutOverlay, destroyCheckoutOverlay, showCheckoutSuccess, consumePostCheckoutFlag, clearCheckoutAttempt } from '@/services/checkout';
+import { registerCheckoutSuccessCallback, destroyCheckoutOverlay, showCheckoutSuccess, consumePostCheckoutFlag, clearCheckoutAttempt } from '@/services/checkout';
 import { showCheckoutFailureBanner } from '@/components/checkout-failure-banner';
 import { openMcpConnectModal } from '@/components/McpConnectModal';
 import { PanelTabBar } from '@/components/PanelTabBar';
@@ -250,7 +250,7 @@ export class PanelLayoutManager implements AppModule {
     // email lazily at fire-time (not at register-time) so a just-signed-
     // in buyer who completes checkout in the same session still sees
     // the receipt acknowledgement.
-    initCheckoutOverlay(() => showCheckoutSuccess({
+    registerCheckoutSuccessCallback(() => showCheckoutSuccess({
       waitForEntitlement: true,
       email: getAuthState().user?.email ?? null,
     }));

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -14,6 +14,8 @@ import {
 import { isProUser } from '@/services/widget-store';
 import { SITE_VARIANT } from '@/config/variant';
 import { t } from '@/services/i18n';
+import { createSettingsButton } from '@/components/settings-button';
+import type { UnifiedSettingsTabId } from '@/components/settings-types';
 import type { MapProvider } from '@/config/basemap';
 import { escapeHtml } from '@/utils/sanitize';
 import type { PanelConfig } from '@/types';
@@ -39,8 +41,6 @@ function showToast(msg: string): void {
   setTimeout(() => { el.classList.remove('visible'); setTimeout(() => el.remove(), 300); }, 4000);
 }
 
-const GEAR_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>`;
-
 export interface UnifiedSettingsConfig {
   getPanelSettings: () => Record<string, PanelConfig>;
   savePanelSettings: (panels: Record<string, PanelConfig>) => void;
@@ -54,7 +54,7 @@ export interface UnifiedSettingsConfig {
   onMapProviderChange?: (provider: MapProvider) => void;
 }
 
-type TabId = 'settings' | 'panels' | 'sources' | 'notifications' | 'api-keys' | 'mcp-clients';
+type TabId = UnifiedSettingsTabId;
 
 export class UnifiedSettings {
   private overlay: HTMLElement;
@@ -372,13 +372,7 @@ export class UnifiedSettings {
   }
 
   public getButton(): HTMLButtonElement {
-    const btn = document.createElement('button');
-    btn.className = 'unified-settings-btn';
-    btn.id = 'unifiedSettingsBtn';
-    btn.setAttribute('aria-label', t('header.settings'));
-    setTrustedHtml(btn, trustedHtml(GEAR_SVG, "legacy direct innerHTML migration"));
-    btn.addEventListener('click', () => this.open());
-    return btn;
+    return createSettingsButton(() => this.open());
   }
 
   public destroy(): void {

--- a/src/components/settings-button.ts
+++ b/src/components/settings-button.ts
@@ -1,0 +1,20 @@
+import { t } from '@/services/i18n';
+import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
+
+export const SETTINGS_GEAR_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>`;
+
+/**
+ * Build the settings gear button. Shared between the eager `LazyUnifiedSettings`
+ * proxy (event-handlers.ts) and the real `UnifiedSettings.getButton()` so the
+ * markup/ARIA/SVG stay in one place — the proxy needs the button without
+ * statically importing (and re-eagerizing) the UnifiedSettings chunk.
+ */
+export function createSettingsButton(onClick: () => void): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.className = 'unified-settings-btn';
+  btn.id = 'unifiedSettingsBtn';
+  btn.setAttribute('aria-label', t('header.settings'));
+  setTrustedHtml(btn, trustedHtml(SETTINGS_GEAR_SVG, 'legacy direct innerHTML migration'));
+  btn.addEventListener('click', onClick);
+  return btn;
+}

--- a/src/components/settings-types.ts
+++ b/src/components/settings-types.ts
@@ -1,0 +1,13 @@
+/**
+ * Canonical tab-id union for the settings modal. Lives in the components layer
+ * (a pure leaf type with no imports) so both the UnifiedSettings component and
+ * the app-context controller interface can share one declaration without a
+ * components -> app backward import.
+ */
+export type UnifiedSettingsTabId =
+  | 'settings'
+  | 'panels'
+  | 'sources'
+  | 'notifications'
+  | 'api-keys'
+  | 'mcp-clients';

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -193,9 +193,10 @@ function safeCloseOverlay(): void {
 
 /**
  * Register the checkout success callback. The Dodo overlay SDK itself is
- * initialized lazily on first checkout open so it stays off the startup path.
+ * initialized lazily on first checkout open (see ensureCheckoutOverlayInitialized)
+ * so it stays off the startup path — this call no longer initializes anything.
  */
-export function initCheckoutOverlay(onSuccess?: () => void): void {
+export function registerCheckoutSuccessCallback(onSuccess?: () => void): void {
   if (onSuccess) {
     onSuccessCallback = onSuccess;
   }
@@ -654,7 +655,7 @@ export async function openCheckout(checkoutUrl: string): Promise<void> {
   await ensureCheckoutOverlayInitialized();
   // Reset the per-session successFired flag so a prior session's
   // terminal state can't leak into this one. (The flag lives in a
-  // closure inside initCheckoutOverlay's event handler; this resets
+  // closure inside ensureCheckoutOverlayInitialized's event handler; this resets
   // it.)
   _resetOverlaySession?.();
 

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -207,7 +207,7 @@ async function ensureCheckoutOverlayInitialized(): Promise<void> {
 
   const generation = checkoutOverlayGeneration;
 
-  overlayInitPromise = (async () => {
+  const thisInitPromise = (async () => {
     const DodoPayments = await loadDodoPayments();
     if (generation !== checkoutOverlayGeneration) {
       throw new Error('Checkout overlay initialization cancelled');
@@ -412,10 +412,14 @@ async function ensureCheckoutOverlayInitialized(): Promise<void> {
     initialized = true;
   })();
 
+  overlayInitPromise = thisInitPromise;
+
   try {
-    await overlayInitPromise;
+    await thisInitPromise;
   } finally {
-    overlayInitPromise = null;
+    if (overlayInitPromise === thisInitPromise) {
+      overlayInitPromise = null;
+    }
   }
 }
 

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -12,7 +12,6 @@
  */
 
 import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
-import { DodoPayments } from 'dodopayments-checkout';
 import type { CheckoutEvent } from 'dodopayments-checkout';
 import { openBillingPortal, prereserveBillingPortalTab } from './billing';
 import { getCurrentClerkUser, getClerkToken, openSignIn } from './clerk';
@@ -132,10 +131,30 @@ interface PendingCheckoutIntent {
 const PENDING_INTENT_TTL_MS = 15 * 60 * 1000;
 
 let initialized = false;
+let checkoutOverlayGeneration = 0;
+let overlayInitPromise: Promise<void> | null = null;
+let dodoPayments: (typeof import('dodopayments-checkout'))['DodoPayments'] | null = null;
+let dodoPaymentsPromise: Promise<(typeof import('dodopayments-checkout'))['DodoPayments']> | null = null;
 let onSuccessCallback: (() => void) | null = null;
 let _resetOverlaySession: (() => void) | null = null;
 let _watchersInitialized = false;
 let _escapeHandler: ((e: KeyboardEvent) => void) | null = null;
+
+async function loadDodoPayments(): Promise<(typeof import('dodopayments-checkout'))['DodoPayments']> {
+  if (dodoPayments) return dodoPayments;
+  if (!dodoPaymentsPromise) {
+    dodoPaymentsPromise = import('dodopayments-checkout')
+      .then((mod) => {
+        dodoPayments = mod.DodoPayments;
+        return mod.DodoPayments;
+      })
+      .catch((error) => {
+        dodoPaymentsPromise = null;
+        throw error;
+      });
+  }
+  return dodoPaymentsPromise;
+}
 
 /**
  * Entitlement watchdog tuning (mirrors pro-test/src/services/checkout.ts).
@@ -164,8 +183,8 @@ const WATCHDOG_TIMEOUT_MS = 10 * 60 * 1000;
  */
 function safeCloseOverlay(): void {
   try {
-    if (DodoPayments.Checkout.isOpen?.()) {
-      DodoPayments.Checkout.close();
+    if (dodoPayments?.Checkout.isOpen?.()) {
+      dodoPayments.Checkout.close();
     }
   } catch {
     // Swallow — the overlay is already gone or the SDK is mid-teardown.
@@ -173,213 +192,231 @@ function safeCloseOverlay(): void {
 }
 
 /**
- * Initialize the Dodo overlay SDK. Idempotent -- second+ calls are no-ops.
- * Optionally accepts a success callback that fires when payment succeeds.
+ * Register the checkout success callback. The Dodo overlay SDK itself is
+ * initialized lazily on first checkout open so it stays off the startup path.
  */
 export function initCheckoutOverlay(onSuccess?: () => void): void {
-  if (initialized) return;
-
   if (onSuccess) {
     onSuccessCallback = onSuccess;
   }
+}
 
-  const env = import.meta.env.VITE_DODO_ENVIRONMENT;
+async function ensureCheckoutOverlayInitialized(): Promise<void> {
+  if (initialized) return;
+  if (overlayInitPromise) return overlayInitPromise;
 
-  // `successFired` must be scoped per-overlay-session, NOT module.
-  // Previously this was `let _successFired = false;` at module scope,
-  // which leaked state across sessions: if a user's success path ran
-  // and then a later `openCheckout` call re-entered the overlay, the
-  // stale `true` made the close handler skip the pending-intent clear,
-  // leaving PENDING_CHECKOUT_KEY populated for a silent auto-retry.
-  // DodoPayments.Initialize is idempotent (guarded by `initialized`),
-  // so there's only ever one onEvent closure — but ONE session's state
-  // must reset when a new overlay opens. `openCheckout` resets this
-  // flag via the exported `resetOverlaySessionState()` helper below.
-  let successFired = false;
-  let navigationFired = false;
-  let watchdog: EntitlementWatchdog | null = null;
+  const generation = checkoutOverlayGeneration;
 
-  const stopWatchdog = (): void => {
-    watchdog?.stop();
-    watchdog = null;
-  };
+  overlayInitPromise = (async () => {
+    const DodoPayments = await loadDodoPayments();
+    if (generation !== checkoutOverlayGeneration) {
+      throw new Error('Checkout overlay initialization cancelled');
+    }
 
-  _resetOverlaySession = () => {
-    successFired = false;
-    navigationFired = false;
-    stopWatchdog();
-  };
+    const env = import.meta.env.VITE_DODO_ENVIRONMENT;
 
-  // Shared terminal-success side effects (run ONCE per overlay session).
-  // Called from: `checkout.status=succeeded` (event path), the
-  // watchdog when entitlement flips to pro (fallback path), and the
-  // watchdog-free `checkout.redirect_requested` handler when it arrives
-  // before status (rare but possible per docs). The `successFired` flag
-  // makes subsequent callers no-op, preserving prior single-fire semantics.
-  //
-  // The entitlement watcher in panel-layout.ts owns the free→pro reload
-  // (REQUIRES_SKIP_INITIAL_SNAPSHOT_BEHAVIOR; see mirror marker in
-  // panel-layout.ts) — this block does NOT reload or navigate on its own.
-  const runTerminalSuccessSideEffects = (reason: 'event-status' | 'event-redirect' | 'watchdog'): void => {
-    if (successFired) return;
-    successFired = true;
-    stopWatchdog();
+    // `successFired` must be scoped per-overlay-session, NOT module.
+    // Previously this was `let _successFired = false;` at module scope,
+    // which leaked state across sessions: if a user's success path ran
+    // and then a later `openCheckout` call re-entered the overlay, the
+    // stale `true` made the close handler skip the pending-intent clear,
+    // leaving PENDING_CHECKOUT_KEY populated for a silent auto-retry.
+    // DodoPayments.Initialize is idempotent (guarded by `initialized`),
+    // so there's only ever one onEvent closure — but ONE session's state
+    // must reset when a new overlay opens. `openCheckout` resets this
+    // flag via the exported `resetOverlaySessionState()` helper below.
+    let successFired = false;
+    let navigationFired = false;
+    let watchdog: EntitlementWatchdog | null = null;
 
-    enqueueSentryCall((s) => s.addBreadcrumb({
-      category: 'checkout',
-      message: `terminal success (${reason})`,
-      level: 'info',
-      data: { reason },
-    }));
-    if (reason === 'watchdog') {
-      // Counter-signal so Dodo's wallet-return deadlock prevalence is
-      // measurable in Sentry. `info` level, not `error`, per
-      // feedback_sentry_level_expected_user_states.
-      enqueueSentryCall((s) => s.captureMessage('Dodo wallet-return deadlock — watchdog resolved', {
+    const stopWatchdog = (): void => {
+      watchdog?.stop();
+      watchdog = null;
+    };
+
+    _resetOverlaySession = () => {
+      successFired = false;
+      navigationFired = false;
+      stopWatchdog();
+    };
+
+    // Shared terminal-success side effects (run ONCE per overlay session).
+    // Called from: `checkout.status=succeeded` (event path), the
+    // watchdog when entitlement flips to pro (fallback path), and the
+    // watchdog-free `checkout.redirect_requested` handler when it arrives
+    // before status (rare but possible per docs). The `successFired` flag
+    // makes subsequent callers no-op, preserving prior single-fire semantics.
+    //
+    // The entitlement watcher in panel-layout.ts owns the free→pro reload
+    // (REQUIRES_SKIP_INITIAL_SNAPSHOT_BEHAVIOR; see mirror marker in
+    // panel-layout.ts) — this block does NOT reload or navigate on its own.
+    const runTerminalSuccessSideEffects = (reason: 'event-status' | 'event-redirect' | 'watchdog'): void => {
+      if (successFired) return;
+      successFired = true;
+      stopWatchdog();
+
+      enqueueSentryCall((s) => s.addBreadcrumb({
+        category: 'checkout',
+        message: `terminal success (${reason})`,
         level: 'info',
-        tags: { component: 'dodo-checkout', code: 'watchdog_resolved' },
+        data: { reason },
       }));
-    }
-
-    try {
-      onSuccessCallback?.();
-    } catch (err) {
-      console.error('[checkout] onSuccessCallback threw:', err);
-      enqueueSentryCall((s) => s.captureException(err, {
-        tags: { component: 'dodo-checkout', action: 'on-success' },
-      }));
-    }
-    // Terminal success: clear both keys. LAST_CHECKOUT_ATTEMPT_KEY
-    // is no longer needed (no retry context required); PENDING is
-    // cleared to avoid auto-opening the overlay on the reload.
-    clearCheckoutAttempt('success');
-    clearPendingCheckoutIntent();
-    // Session flag so the reloaded page seeds the entitlement transition
-    // detector as post-checkout — see comment block preserved from the
-    // original inlined handler below for the full rationale.
-    markPostCheckout();
-  };
-
-  const startWatchdog = (): void => {
-    if (watchdog !== null || successFired) return;
-    watchdog = createEntitlementWatchdog(
-      {
-        endpoint: '/api/me/entitlement',
-        intervalMs: WATCHDOG_INTERVAL_MS,
-        timeoutMs: WATCHDOG_TIMEOUT_MS,
-      },
-      {
-        getToken: getClerkToken,
-        fetch: (input, init) => fetch(input, init),
-        setInterval: (cb, ms) => window.setInterval(cb, ms),
-        clearInterval: (id) => window.clearInterval(id),
-        now: () => Date.now(),
-        onPro: () => {
-          runTerminalSuccessSideEffects('watchdog');
-          // Close the stuck overlay so the entitlement watcher's reload
-          // is not hidden behind Dodo's "payment successful" page.
-          safeCloseOverlay();
-        },
-      },
-    );
-    watchdog.start();
-  };
-
-  DodoPayments.Initialize({
-    mode: env === 'live_mode' ? 'live' : 'test',
-    displayType: 'overlay',
-    onEvent: (event: CheckoutEvent) => {
-      switch (event.event_type) {
-        case 'checkout.opened':
-          // Arm the watchdog at the earliest safe moment. HAR 2026-04-23
-          // confirms `checkout.opened` fires on both the happy path AND
-          // the wallet-return deadlock path; terminal events do not.
-          startWatchdog();
-          break;
-        case 'checkout.status': {
-          // Docs-documented shape is ONLY `event.data.message.status` —
-          // the prior top-level `event.data.status` read was a guess
-          // against an older SDK version and most likely never matched.
-          // (overlay-checkout.mdx / inline-checkout.mdx, SDK >= 0.109.2).
-          //
-          // Reload ownership: the entitlement watcher in panel-layout.ts
-          // is the SINGLE reload source (fires on free→pro transition).
-          // We no longer schedule a belt-and-braces setTimeout reload
-          // here — that competed with the watcher and made "still
-          // unlocking" UX impossible because the banner was guaranteed
-          // to be wiped at 3s regardless of webhook latency.
-          //
-          // REQUIRES_SKIP_INITIAL_SNAPSHOT_BEHAVIOR — the watcher's
-          // first-snapshot seeding depends on PR #3163 (merged
-          // 2026-04-18) having fixed the swallow-first-snapshot bug.
-          // If that PR is ever reverted or its behavior regresses,
-          // tests in tests/entitlement-transition.test.mts will fail
-          // (specifically "simulates the incident sequence" case); see
-          // the mirror marker in panel-layout.ts.
-          const rawData = event.data as Record<string, unknown> | undefined;
-          const status = (rawData?.message as Record<string, unknown> | undefined)?.status;
-          if (status === 'succeeded') {
-            runTerminalSuccessSideEffects('event-status');
-          }
-          break;
-        }
-        case 'checkout.closed':
-          // Only clear the auto-resume intent. Do NOT clear
-          // LAST_CHECKOUT_ATTEMPT_KEY here — Dodo can emit `closed` BEFORE
-          // the browser navigates to ?status=failed, and the failure
-          // banner on the next page needs the attempt record to populate
-          // the retry CTA. The attempt record will be cleared later by
-          // the terminal path that actually resolves (success, dismissed,
-          // duplicate, or the mount-time abandonment sweep).
-          stopWatchdog();
-          if (!successFired) {
-            clearPendingCheckoutIntent();
-          }
-          break;
-        case 'checkout.redirect_requested': {
-          // With `manualRedirect: true` (below), Dodo's SDK hands the
-          // final navigation to the merchant via this event. Dodo's own
-          // redirect path (manualRedirect:false) has been observed to
-          // fail on Safari with an orphaned about:blank tab; we follow
-          // the docs-prescribed handler instead.
-          // (overlay-checkout.mdx: "Redirect the customer manually".)
-          //
-          // On the happy path both `checkout.status=succeeded` and
-          // `checkout.redirect_requested` fire — status runs the
-          // markPostCheckout + cleanup side effects, redirect navigates
-          // away. When only redirect_requested fires (no prior status),
-          // we run the side effects here so the post-checkout flag is
-          // set before we navigate.
-          const redirectTo = (event.data?.message as Record<string, unknown> | undefined)?.redirect_to as string | undefined;
-          if (!successFired) runTerminalSuccessSideEffects('event-redirect');
-          if (redirectTo && !navigationFired) {
-            navigationFired = true;
-            window.location.href = redirectTo;
-          }
-          break;
-        }
-        case 'checkout.error':
-          console.error('[checkout] Overlay error:', event.data?.message);
-          enqueueSentryCall((s) => s.captureMessage(`Dodo checkout overlay error: ${event.data?.message || 'unknown'}`, { level: 'error', tags: { component: 'dodo-checkout' } }));
-          // Release the user if their overlay surfaces an error. The
-          // deadlock bug (payment-link 404 + render loop) never reaches
-          // this branch — it traps inside their iframe — but any error
-          // that DOES escape should not leave a broken overlay mounted.
-          stopWatchdog();
-          safeCloseOverlay();
-          break;
+      if (reason === 'watchdog') {
+        // Counter-signal so Dodo's wallet-return deadlock prevalence is
+        // measurable in Sentry. `info` level, not `error`, per
+        // feedback_sentry_level_expected_user_states.
+        enqueueSentryCall((s) => s.captureMessage('Dodo wallet-return deadlock — watchdog resolved', {
+          level: 'info',
+          tags: { component: 'dodo-checkout', code: 'watchdog_resolved' },
+        }));
       }
-    },
-  });
 
-  _escapeHandler = (e: KeyboardEvent) => {
-    if (e.key === 'Escape' && DodoPayments.Checkout.isOpen?.()) {
-      safeCloseOverlay();
-    }
-  };
-  window.addEventListener('keydown', _escapeHandler);
+      try {
+        onSuccessCallback?.();
+      } catch (err) {
+        console.error('[checkout] onSuccessCallback threw:', err);
+        enqueueSentryCall((s) => s.captureException(err, {
+          tags: { component: 'dodo-checkout', action: 'on-success' },
+        }));
+      }
+      // Terminal success: clear both keys. LAST_CHECKOUT_ATTEMPT_KEY
+      // is no longer needed (no retry context required); PENDING is
+      // cleared to avoid auto-opening the overlay on the reload.
+      clearCheckoutAttempt('success');
+      clearPendingCheckoutIntent();
+      // Session flag so the reloaded page seeds the entitlement transition
+      // detector as post-checkout — see comment block preserved from the
+      // original inlined handler below for the full rationale.
+      markPostCheckout();
+    };
 
-  initialized = true;
+    const startWatchdog = (): void => {
+      if (watchdog !== null || successFired) return;
+      watchdog = createEntitlementWatchdog(
+        {
+          endpoint: '/api/me/entitlement',
+          intervalMs: WATCHDOG_INTERVAL_MS,
+          timeoutMs: WATCHDOG_TIMEOUT_MS,
+        },
+        {
+          getToken: getClerkToken,
+          fetch: (input, init) => fetch(input, init),
+          setInterval: (cb, ms) => window.setInterval(cb, ms),
+          clearInterval: (id) => window.clearInterval(id),
+          now: () => Date.now(),
+          onPro: () => {
+            runTerminalSuccessSideEffects('watchdog');
+            // Close the stuck overlay so the entitlement watcher's reload
+            // is not hidden behind Dodo's "payment successful" page.
+            safeCloseOverlay();
+          },
+        },
+      );
+      watchdog.start();
+    };
+
+    DodoPayments.Initialize({
+      mode: env === 'live_mode' ? 'live' : 'test',
+      displayType: 'overlay',
+      onEvent: (event: CheckoutEvent) => {
+        switch (event.event_type) {
+          case 'checkout.opened':
+            // Arm the watchdog at the earliest safe moment. HAR 2026-04-23
+            // confirms `checkout.opened` fires on both the happy path AND
+            // the wallet-return deadlock path; terminal events do not.
+            startWatchdog();
+            break;
+          case 'checkout.status': {
+            // Docs-documented shape is ONLY `event.data.message.status` —
+            // the prior top-level `event.data.status` read was a guess
+            // against an older SDK version and most likely never matched.
+            // (overlay-checkout.mdx / inline-checkout.mdx, SDK >= 0.109.2).
+            //
+            // Reload ownership: the entitlement watcher in panel-layout.ts
+            // is the SINGLE reload source (fires on free→pro transition).
+            // We no longer schedule a belt-and-braces setTimeout reload
+            // here — that competed with the watcher and made "still
+            // unlocking" UX impossible because the banner was guaranteed
+            // to be wiped at 3s regardless of webhook latency.
+            //
+            // REQUIRES_SKIP_INITIAL_SNAPSHOT_BEHAVIOR — the watcher's
+            // first-snapshot seeding depends on PR #3163 (merged
+            // 2026-04-18) having fixed the swallow-first-snapshot bug.
+            // If that PR is ever reverted or its behavior regresses,
+            // tests in tests/entitlement-transition.test.mts will fail
+            // (specifically "simulates the incident sequence" case); see
+            // the mirror marker in panel-layout.ts.
+            const rawData = event.data as Record<string, unknown> | undefined;
+            const status = (rawData?.message as Record<string, unknown> | undefined)?.status;
+            if (status === 'succeeded') {
+              runTerminalSuccessSideEffects('event-status');
+            }
+            break;
+          }
+          case 'checkout.closed':
+            // Only clear the auto-resume intent. Do NOT clear
+            // LAST_CHECKOUT_ATTEMPT_KEY here — Dodo can emit `closed` BEFORE
+            // the browser navigates to ?status=failed, and the failure
+            // banner on the next page needs the attempt record to populate
+            // the retry CTA. The attempt record will be cleared later by
+            // the terminal path that actually resolves (success, dismissed,
+            // duplicate, or the mount-time abandonment sweep).
+            stopWatchdog();
+            if (!successFired) {
+              clearPendingCheckoutIntent();
+            }
+            break;
+          case 'checkout.redirect_requested': {
+            // With `manualRedirect: true` (below), Dodo's SDK hands the
+            // final navigation to the merchant via this event. Dodo's own
+            // redirect path (manualRedirect:false) has been observed to
+            // fail on Safari with an orphaned about:blank tab; we follow
+            // the docs-prescribed handler instead.
+            // (overlay-checkout.mdx: "Redirect the customer manually".)
+            //
+            // On the happy path both `checkout.status=succeeded` and
+            // `checkout.redirect_requested` fire — status runs the
+            // markPostCheckout + cleanup side effects, redirect navigates
+            // away. When only redirect_requested fires (no prior status),
+            // we run the side effects here so the post-checkout flag is
+            // set before we navigate.
+            const redirectTo = (event.data?.message as Record<string, unknown> | undefined)?.redirect_to as string | undefined;
+            if (!successFired) runTerminalSuccessSideEffects('event-redirect');
+            if (redirectTo && !navigationFired) {
+              navigationFired = true;
+              window.location.href = redirectTo;
+            }
+            break;
+          }
+          case 'checkout.error':
+            console.error('[checkout] Overlay error:', event.data?.message);
+            enqueueSentryCall((s) => s.captureMessage(`Dodo checkout overlay error: ${event.data?.message || 'unknown'}`, { level: 'error', tags: { component: 'dodo-checkout' } }));
+            // Release the user if their overlay surfaces an error. The
+            // deadlock bug (payment-link 404 + render loop) never reaches
+            // this branch — it traps inside their iframe — but any error
+            // that DOES escape should not leave a broken overlay mounted.
+            stopWatchdog();
+            safeCloseOverlay();
+            break;
+        }
+      },
+    });
+
+    _escapeHandler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && dodoPayments?.Checkout.isOpen?.()) {
+        safeCloseOverlay();
+      }
+    };
+    window.addEventListener('keydown', _escapeHandler);
+
+    initialized = true;
+  })();
+
+  try {
+    await overlayInitPromise;
+  } finally {
+    overlayInitPromise = null;
+  }
 }
 
 /**
@@ -387,6 +424,7 @@ export function initCheckoutOverlay(onSuccess?: () => void): void {
  * stored success callback so a new layout can register its own callback.
  */
 export function destroyCheckoutOverlay(): void {
+  checkoutOverlayGeneration += 1;
   // Stop any in-flight watchdog BEFORE we drop references. If the layout
   // unmounts mid-checkout, the watchdog's setInterval would otherwise
   // keep running inside the closed-over scope and, on entitlement flip,
@@ -397,6 +435,7 @@ export function destroyCheckoutOverlay(): void {
   _resetOverlaySession?.();
   _resetOverlaySession = null;
   initialized = false;
+  overlayInitPromise = null;
   onSuccessCallback = null;
   if (_escapeHandler) {
     window.removeEventListener('keydown', _escapeHandler);
@@ -607,15 +646,15 @@ export async function resumePendingCheckout(options?: {
  * Open the Dodo checkout overlay for a given checkout URL.
  * Lazily initializes the SDK if not already done.
  */
-export function openCheckout(checkoutUrl: string): void {
-  initCheckoutOverlay();
+export async function openCheckout(checkoutUrl: string): Promise<void> {
+  await ensureCheckoutOverlayInitialized();
   // Reset the per-session successFired flag so a prior session's
   // terminal state can't leak into this one. (The flag lives in a
   // closure inside initCheckoutOverlay's event handler; this resets
   // it.)
   _resetOverlaySession?.();
 
-  DodoPayments.Checkout.open({
+  dodoPayments!.Checkout.open({
     checkoutUrl,
     options: {
       manualRedirect: true,
@@ -812,7 +851,7 @@ export async function startCheckout(
 
     const result = await resp.json();
     if (result?.checkout_url) {
-      openCheckout(result.checkout_url);
+      await openCheckout(result.checkout_url);
       return true;
     }
     // 200 OK but no checkout_url is a server contract violation (the

--- a/tests/panel-cluster-chunks.test.mjs
+++ b/tests/panel-cluster-chunks.test.mjs
@@ -87,6 +87,14 @@ function hasSpreadOfArray(name, spreadName) {
   ));
 }
 
+function hasStringElement(name, value) {
+  const declaration = findVariableDeclaration(viteConfigAst, name);
+  assert.ok(declaration.initializer && ts.isAsExpression(declaration.initializer), `${name} must use "as const".`);
+  const expression = declaration.initializer.expression;
+  assert.ok(ts.isArrayLiteralExpression(expression), `${name} must be an array literal.`);
+  return expression.elements.some((element) => ts.isStringLiteral(element) && element.text === value);
+}
+
 function hasCall(ast, calleeName) {
   let found = false;
   function visit(node) {
@@ -288,7 +296,44 @@ function builtDashboardLazyPreloadOffenders() {
   const html = readFileSync(htmlPath, 'utf8');
   const preloadHrefs = [...html.matchAll(/<link\b[^>]*\brel=["']modulepreload["'][^>]*\bhref=["']([^"']+)["'][^>]*>/g)]
     .map((match) => match[1]);
-  return preloadHrefs.filter((href) => /\/assets\/(?:panels-[a-z]+|panel-support)-[A-Za-z0-9_-]+\.js$/.test(href));
+  return preloadHrefs.filter((href) => /\/assets\/(?:panels-[a-z]+|panel-support|UnifiedSettings|settings-window|checkout)-[A-Za-z0-9_-]+\.js$/.test(href));
+}
+
+function startupSecondaryFlowImportOffenders() {
+  const blockedSpecifiers = new Set([
+    '@/components/UnifiedSettings',
+  ]);
+  const offenders = [];
+  for (const filePath of startupModulePaths) {
+    const ast = astForPath(filePath);
+    const relativePath = filePath.slice(repoRoot.length + 1);
+    for (const statement of ast.statements) {
+      if (!ts.isImportDeclaration(statement)) continue;
+      const importClause = statement.importClause;
+      if (!importClause || importClause.isTypeOnly) continue;
+      const specifier = stringValue(statement.moduleSpecifier);
+      if (specifier && blockedSpecifiers.has(specifier)) {
+        offenders.push(`${relativePath}:${lineForPosition(ast, statement.getStart(ast))} imports ${specifier}`);
+      }
+    }
+  }
+  return offenders;
+}
+
+function checkoutSdkValueImportOffenders() {
+  const filePath = resolve(repoRoot, 'src/services/checkout.ts');
+  const ast = astForPath(filePath);
+  const offenders = [];
+  for (const statement of ast.statements) {
+    if (!ts.isImportDeclaration(statement)) continue;
+    const importClause = statement.importClause;
+    if (!importClause || importClause.isTypeOnly) continue;
+    const specifier = stringValue(statement.moduleSpecifier);
+    if (specifier === 'dodopayments-checkout') {
+      offenders.push(`src/services/checkout.ts:${lineForPosition(ast, statement.getStart(ast))} imports ${specifier}`);
+    }
+  }
+  return offenders;
 }
 
 describe('panel cluster chunk guardrails', () => {
@@ -387,6 +432,26 @@ describe('panel cluster chunk guardrails', () => {
       startupPanelValueImportOffenders(panelCluster),
       [],
       'Startup modules must use dynamic imports or type-only imports for panel chunks.',
+    );
+  });
+
+  it('keeps secondary settings and checkout chunks off the eager startup path', () => {
+    for (const chunkName of ['UnifiedSettings', 'settings-window', 'checkout']) {
+      assert.equal(
+        hasStringElement('LAZY_HTML_PRELOAD_CHUNKS', chunkName),
+        true,
+        `${chunkName} must stay in the HTML preload exclusion list.`,
+      );
+    }
+    assert.deepEqual(
+      startupSecondaryFlowImportOffenders(),
+      [],
+      'Startup modules must use dynamic imports for the UnifiedSettings modal.',
+    );
+    assert.deepEqual(
+      checkoutSdkValueImportOffenders(),
+      [],
+      'Checkout must dynamically import dodopayments-checkout so the SDK stays out of main.',
     );
   });
 });

--- a/tests/panel-cluster-chunks.test.mjs
+++ b/tests/panel-cluster-chunks.test.mjs
@@ -299,6 +299,20 @@ function builtDashboardLazyPreloadOffenders() {
   return preloadHrefs.filter((href) => /\/assets\/(?:panels-[a-z]+|panel-support|UnifiedSettings|settings-window|checkout)-[A-Za-z0-9_-]+\.js$/.test(href));
 }
 
+// When a build is present, confirm each secondary flow actually emitted its own
+// lazy chunk. Without this, builtDashboardLazyPreloadOffenders passes vacuously
+// if the split regresses and a module folds back into the eager entry (the
+// #4382 onlyExplicitManualChunks failure mode): a chunk that no longer exists
+// can never appear in the modulepreload list.
+function builtSecondaryLazyChunksMissing() {
+  const assetsDir = resolve(repoRoot, 'dist/assets');
+  if (!existsSync(assetsDir)) return null;
+  const files = readdirSync(assetsDir);
+  return ['UnifiedSettings', 'settings-window', 'checkout'].filter(
+    (name) => !files.some((file) => new RegExp(`^${name}-[A-Za-z0-9_-]+\\.js$`).test(file)),
+  );
+}
+
 function startupSecondaryFlowImportOffenders() {
   const blockedSpecifiers = new Set([
     '@/components/UnifiedSettings',
@@ -453,5 +467,13 @@ describe('panel cluster chunk guardrails', () => {
       [],
       'Checkout must dynamically import dodopayments-checkout so the SDK stays out of main.',
     );
+    const missingLazyChunks = builtSecondaryLazyChunksMissing();
+    if (missingLazyChunks) {
+      assert.deepEqual(
+        missingLazyChunks,
+        [],
+        `Secondary flows must build into their own lazy chunks (split regressed): ${missingLazyChunks.join(', ')}`,
+      );
+    }
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -58,7 +58,18 @@ type PanelManualChunkName = PanelChunkName | PanelSupportChunkName;
 //   - maplibre, deck-stack: heavy WebGL deps, only reachable via MapContainer
 //   - MapContainer: the dynamic-import target itself
 //   - panels-*: panel domain chunks; keep them out of the entry HTML preload
-const LAZY_HTML_PRELOAD_CHUNKS = ['maplibre', 'deck-stack', 'MapContainer', ...PANEL_CHUNK_NAMES, ...PANEL_SUPPORT_CHUNK_NAMES] as const;
+//   - UnifiedSettings, settings-window, checkout: secondary interaction flows;
+//     first paint only needs their header buttons and cheap event wiring
+const LAZY_HTML_PRELOAD_CHUNKS = [
+  'maplibre',
+  'deck-stack',
+  'MapContainer',
+  'UnifiedSettings',
+  'settings-window',
+  'checkout',
+  ...PANEL_CHUNK_NAMES,
+  ...PANEL_SUPPORT_CHUNK_NAMES,
+] as const;
 const LAZY_HTML_PRELOAD_RE = new RegExp(
   `/(${LAZY_HTML_PRELOAD_CHUNKS.join('|')})-[A-Za-z0-9_-]+\\.js$`,
 );


### PR DESCRIPTION
## Summary
- lazy-load the UnifiedSettings modal behind the existing synchronous header settings button
- lazy-load `dodopayments-checkout` only when checkout actually opens, while keeping return handling available at startup
- extend chunk guardrails so `UnifiedSettings`, `settings-window`, and `checkout` stay out of dashboard HTML modulepreloads and static SDK imports are rejected

Fixes #4379.

## Bundle Evidence
Baseline from untouched `origin/main` build:
- `main-2f4lmywj.js`: raw `1,210,647`, gzip `347,106`, brotli `275,047`
- `dashboard.html` modulepreloaded `checkout-B1Gi9C_A.js`

After this PR:
- `main-DYleJXjr.js`: raw `1,102,680`, gzip `319,563`, brotli `253,511`
- savings: raw `107,967`, gzip `27,543`, brotli `21,536` bytes
- new lazy chunks: `UnifiedSettings-JRNoEksZ.js` raw `112,132` / gzip `29,501`; `checkout-BjFFs30N.js` raw `19,429` / gzip `6,954`
- final `dashboard.html` modulepreload forbidden list is empty for `UnifiedSettings`, `settings-window`, `checkout`, `maplibre`, `deck-stack`, `MapContainer`, `panels-*`, and `panel-support`

## Validation
- `npm run typecheck`
- `npm run build:full`
- `node --import tsx --test tests/panel-cluster-chunks.test.mjs tests/checkout-report-error.test.mts tests/checkout-no-user-policy.test.mts tests/checkout-return-discriminant.test.mts tests/entitlement-transition.test.mts`
- `TMPDIR=/tmp npx playwright test e2e/prehydration-shell.spec.ts e2e/dashboard-cls.spec.ts e2e/header-cls.spec.ts e2e/map-harness.spec.ts -g "paints contentful|keeps desktop first-load|keeps mobile first-load|reserves stable|boots without deck assertions"`
- pre-push hook: src/API typechecks, boundary/safe-HTML/rate-limit/premium-fetch guards, changed test, edge tests, version check

## Review Notes
- scope stays on #4379; #4378 map-vendor lazy-load remains separate
- first settings modal open and first checkout open now pay their lazy chunk request, which is the intended tradeoff for reducing first-load parse/execute work
- DeckGL/WebGL #4384 guardrail remains intact; map harness boot passed without deck assertions or unhandled runtime errors