### PR TITLE
fix(panels): restore Live News video panel shadowed by CANONICAL_FEEDS loop (regression #4382)

### DIFF
--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1469,6 +1469,14 @@ export class PanelLayoutManager implements AppModule {
     for (const key of Object.keys(CANONICAL_FEEDS)) {
       if (this.ctx.newsPanels[key]) continue;
       if (!Array.isArray((CANONICAL_FEEDS as Record<string, unknown>)[key])) continue;
+      // 'live-news' is the dedicated LiveNewsPanel (24/7 video) key, registered
+      // lazily below — NOT a generic RSS feed panel. CANONICAL_FEEDS['live-news']
+      // exists only to feed the energy variant's headlines; if we let it spawn a
+      // NewsPanel here it registers first and lazyPanel()'s dedup guard then
+      // blocks the real video panel (regression #4382 → "LIVE NEWS / No items in
+      // the last 7 days" on the live dashboard). Skip it so the video panel owns
+      // the key on every variant (happy has no 'live-news' panel at all).
+      if (key === 'live-news') continue;
       const panelKey = COLLIDING_NEWS_PANEL_KEYS.has(key) && !this.ctx.newsPanels[key] ? `${key}-news` : key;
       if (this.ctx.panels[panelKey]) continue;
       // Gate on panelKey, NOT key. When `key` collided with a non-news data

--- a/tests/live-news-panel-guard.test.mts
+++ b/tests/live-news-panel-guard.test.mts
@@ -136,3 +136,49 @@ describe('LiveNewsPanel instantiation guard', () => {
     );
   });
 });
+
+// ---------------------------------------------------------------------------
+// 5. 'live-news' must NOT be shadowed by a generic RSS NewsPanel
+//    Regression: #4382 (perf: split panel chunks by domain) flipped the
+//    live-news video panel from an EAGER assignment (ctx.panels['live-news'] =
+//    new LiveNewsPanel(), set BEFORE the CANONICAL_FEEDS loop) to a LAZY
+//    registration AFTER the loop, and swapped the collision guard from the
+//    dynamic `this.ctx.panels[key]` to a static `COLLIDING_NEWS_PANEL_KEYS`
+//    set that omits 'live-news'. Result: the loop creates a generic NewsPanel
+//    for the 'live-news' key (fed by CANONICAL_FEEDS['live-news'], the energy
+//    headlines block), which registers first and — via lazyPanel's dedup
+//    guard — BLOCKS the real LiveNewsPanel video registration. The live site
+//    rendered "LIVE NEWS … No items in the last 7 days" instead of the 24/7
+//    video streams. The loop must exclude 'live-news' so the dedicated video
+//    panel owns the key.
+// ---------------------------------------------------------------------------
+
+describe("live-news must not be shadowed by a generic NewsPanel (regression #4382)", () => {
+  it("CANONICAL_FEEDS defines a 'live-news' key (the latent landmine)", () => {
+    const feeds = src('src/config/feeds.ts');
+    assert.match(
+      feeds,
+      /['"]live-news['"]\s*:/,
+      "expected a 'live-news' entry in feeds.ts (energy headlines) — this is what lets the CANONICAL_FEEDS loop spawn a NewsPanel that shadows the video panel",
+    );
+  });
+
+  it("CANONICAL_FEEDS loop in panel-layout.ts must NOT create a generic NewsPanel for 'live-news'", () => {
+    const layout = src('src/app/panel-layout.ts');
+    const loopStart = layout.indexOf('for (const key of Object.keys(CANONICAL_FEEDS))');
+    assert.ok(loopStart !== -1, 'CANONICAL_FEEDS key loop not found in panel-layout.ts');
+    const createCall = layout.indexOf('createNewsPanelWithLabel(panelKey', loopStart);
+    assert.ok(createCall !== -1, 'createNewsPanelWithLabel call not found inside the loop');
+    const loopRegion = layout.slice(loopStart, createCall + 200);
+
+    const skipsLiveNews = /key\s*===\s*['"]live-news['"]/.test(loopRegion);
+    const collidesLiveNews = /COLLIDING_NEWS_PANEL_KEYS\s*=\s*new Set\(\[[^\]]*['"]live-news['"]/.test(layout);
+
+    assert.ok(
+      skipsLiveNews || collidesLiveNews,
+      "panel-layout.ts must exclude 'live-news' from the CANONICAL_FEEDS NewsPanel loop " +
+        "(it is the dedicated LiveNewsPanel video key). Without this, the generic NewsPanel " +
+        "shadows the video panel and lazyPanel's dedup guard blocks the real one (regression #4382).",
+    );
+  });
+});


### PR DESCRIPTION
## What users saw

On the live dashboard (`worldmonitor.app`), the flagship **LIVE NEWS** panel rendered the empty news state — a green `● LIVE` badge over **"No items in the last 7 days"** — instead of the 24/7 video streams (Bloomberg / Sky / DW / CNN …).

## Root cause — registration-order regression from #4382

`live-news` is overloaded: it is the dedicated `LiveNewsPanel` (video) key **and** a `CANONICAL_FEEDS['live-news']` entry (the energy-headlines RSS block, defined in `ENERGY_FEEDS`).

`#4382 (perf: split panel chunks by domain)` made two changes that together broke it:

1. The video panel went from an **eager** assignment set *before* the `CANONICAL_FEEDS` news-panel loop —
   `this.ctx.panels['live-news'] = new LiveNewsPanel()` — to a **lazy** registration *after* the loop.
2. The loop's collision guard changed from the dynamic `this.ctx.panels[key]` to the static
   `COLLIDING_NEWS_PANEL_KEYS` set (`markets` / `crypto` / `economic`), which **omits `live-news`**.

Net effect: at loop time `ctx.panels['live-news']` is no longer set, and `live-news` isn't in the static set, so the loop creates a **generic `NewsPanel`** for it. That registration lands first, and `lazyPanel()`'s dedup guard (`if (this.ctx.panels[key] || this.lazyPanelRegistrations.has(key)) return;`) then **blocks the real video panel**. The RSS feed has no items inside the 7-day window → `renderFilteredEmpty("No items in the last 7 days")` (which still sets the `LIVE` data badge).

## Fix

Skip `live-news` in the `CANONICAL_FEEDS` loop so the dedicated video panel owns the key on every variant. This restores **pre-#4382 behavior exactly**:

- Every variant except `happy` has non-empty default channels (`getDefaultLiveChannels()` → `FULL_LIVE_CHANNELS`/`TECH_LIVE_CHANNELS`), so `live-news` was always the video panel.
- `happy` has no `live-news` panel at all (`HAPPY_PANELS` doesn't define it).

So no variant legitimately wants a generic RSS panel under this key.

## Tests

- Added a regression guard to `tests/live-news-panel-guard.test.mts` (fails on the regressed code, passes after the fix).
- `tsc --noEmit` clean; adjacent suites green (`feed-resolution`, `news-feed-key-parity`, `panel-layout-dynamic-import-guard`, `panel-variant-config` — 36 tests).

https://claude.ai/code/session_01EdPTDeKmCTLD2mqWrxB8kc