### PR TITLE
perf(dashboard): defer critical app stylesheet

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,6 +105,8 @@ jobs:
           node-version: '22'
           cache: 'npm'
       - run: npm ci
+      - name: Build dashboard artifacts for built-output tests
+        run: VITE_VARIANT=full ./node_modules/.bin/vite build
       - run: npm run test:data
       - name: Edge function bundle check
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,8 +105,6 @@ jobs:
           node-version: '22'
           cache: 'npm'
       - run: npm ci
-      - name: Build dashboard artifacts for built-output tests
-        run: VITE_VARIANT=full ./node_modules/.bin/vite build
       - run: npm run test:data
       - name: Edge function bundle check
         run: |

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,16 @@ import { initVercelAnalytics } from '@/bootstrap/secondary-startup';
 import { App } from './App';
 import { installUtmInterceptor } from './utils/utm';
 
+function activateDeferredDashboardStyles(): void {
+  document
+    .querySelectorAll<HTMLLinkElement>('link[data-wm-deferred-style="dashboard"][media="print"]')
+    .forEach((link) => {
+      link.media = 'all';
+    });
+}
+
+activateDeferredDashboardStyles();
+
 // perf G — defer @sentry/browser off the critical path (#3994).
 // The eager `Sentry.init({...})` previously ran here cost ~1.96 s of pre-LCP
 // CPU. Install a lightweight error-buffering queue synchronously so any error

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,16 @@ import { initVercelAnalytics } from '@/bootstrap/secondary-startup';
 import { App } from './App';
 import { installUtmInterceptor } from './utils/utm';
 
+// Activate the deferred dashboard app stylesheet. The build
+// (deferDashboardStylesheetLinks in vite.config.ts) emits the large dashboard
+// CSS as <link media="print" data-wm-deferred-style="dashboard"> + a <noscript>
+// blocking copy, so it does not block first paint; flipping media to "all" here
+// applies it once main.js runs. The selector below MUST stay in lockstep with
+// the attribute/value the build writes (data-wm-deferred-style="dashboard" +
+// media="print"). No-JS users get the <noscript> fallback; if main.js fails to
+// execute (e.g. an /assets 404 after a redeploy) the wm-sw-nuke handler in
+// index.html reloads. Kept as the first body statement so it runs before the
+// rest of startup.
 function activateDeferredDashboardStyles(): void {
   document
     .querySelectorAll<HTMLLinkElement>('link[data-wm-deferred-style="dashboard"][media="print"]')

--- a/tests/dashboard-critical-css.test.mjs
+++ b/tests/dashboard-critical-css.test.mjs
@@ -148,6 +148,23 @@ function stylesheetHrefs(html) {
   return hrefs;
 }
 
+function stripNoscript(html) {
+  return html.replace(/<noscript\b[\s\S]*?<\/noscript>/gi, '');
+}
+
+function renderBlockingStylesheetHrefs(html) {
+  const hrefs = [];
+  for (const match of stripNoscript(html).matchAll(/<link\b[^>]*>/gi)) {
+    const attrs = linkAttributes(match[0]);
+    const rels = (attrs.get('rel') ?? '').toLowerCase().split(/\s+/);
+    const href = attrs.get('href');
+    const media = (attrs.get('media') ?? 'all').trim().toLowerCase();
+    if (!href?.endsWith('.css') || !rels.includes('stylesheet')) continue;
+    if (media === '' || media === 'all' || media === 'screen') hrefs.push(href);
+  }
+  return hrefs;
+}
+
 describe('dashboard critical CSS graph', () => {
   it('extracts stylesheet links regardless of link attribute order', () => {
     assert.deepEqual(
@@ -157,6 +174,17 @@ describe('dashboard critical CSS graph', () => {
         <link href="/assets/ignored.css" rel="preload">
       `),
       ['/assets/main.css', '/assets/settings.css'],
+    );
+  });
+
+  it('identifies only screen-blocking stylesheet links outside noscript fallbacks', () => {
+    assert.deepEqual(
+      renderBlockingStylesheetHrefs(`
+        <link rel="stylesheet" href="/assets/main.css">
+        <link rel="stylesheet" media="print" href="/assets/deferred.css">
+        <noscript><link rel="stylesheet" href="/assets/nojs.css"></noscript>
+      `),
+      ['/assets/main.css'],
     );
   });
 
@@ -299,6 +327,38 @@ describe('dashboard critical CSS graph', () => {
         standaloneSettingsSelectors.every((selector) => settingsCss.includes(selector)),
         true,
         'Built settings.html stylesheets should still include standalone settings selectors.',
+      );
+    }
+  });
+
+  it('keeps large dashboard CSS off the render-blocking stylesheet path', { skip: !existsSync(resolve(repoRoot, 'dist/dashboard.html')) }, () => {
+    const dashboardHtml = src('dist/dashboard.html');
+    const blockingHrefs = renderBlockingStylesheetHrefs(dashboardHtml);
+
+    assert.deepEqual(
+      blockingHrefs,
+      [],
+      `Built dashboard.html must not render-block on app CSS; found ${blockingHrefs.join(', ')}`,
+    );
+
+    const deferredHrefs = [];
+    for (const match of stripNoscript(dashboardHtml).matchAll(/<link\b[^>]*>/gi)) {
+      const attrs = linkAttributes(match[0]);
+      if (
+        attrs.get('data-wm-deferred-style') === 'dashboard' &&
+        attrs.get('media') === 'print' &&
+        attrs.get('href')?.endsWith('.css')
+      ) {
+        deferredHrefs.push(attrs.get('href'));
+      }
+    }
+    assert.ok(deferredHrefs.length > 0, 'Built dashboard.html should still request app CSS on a deferred stylesheet path.');
+
+    for (const href of deferredHrefs) {
+      assert.match(
+        dashboardHtml,
+        new RegExp(`<noscript><link\\b[^>]*rel=["']stylesheet["'][^>]*href=["']${href.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}["'][^>]*></noscript>`),
+        `Deferred dashboard stylesheet ${href} must keep a no-JS stylesheet fallback.`,
       );
     }
   });

--- a/tests/dashboard-critical-css.test.mjs
+++ b/tests/dashboard-critical-css.test.mjs
@@ -12,6 +12,15 @@ function src(relPath) {
   return readFileSync(resolve(repoRoot, relPath), 'utf8');
 }
 
+function builtSrc(relPath) {
+  const absPath = resolve(repoRoot, relPath);
+  assert.ok(
+    existsSync(absPath),
+    `${relPath} must exist before running built-output CSS assertions. Run VITE_VARIANT=full vite build first.`,
+  );
+  return readFileSync(absPath, 'utf8');
+}
+
 function toRepoPath(absPath) {
   return relative(repoRoot, absPath).replaceAll('\\', '/');
 }
@@ -158,9 +167,10 @@ function renderBlockingStylesheetHrefs(html) {
     const attrs = linkAttributes(match[0]);
     const rels = (attrs.get('rel') ?? '').toLowerCase().split(/\s+/);
     const href = attrs.get('href');
-    const media = (attrs.get('media') ?? 'all').trim().toLowerCase();
+    const rawMedia = attrs.get('media');
+    const media = rawMedia === undefined ? 'all' : rawMedia.trim().toLowerCase();
     if (!href?.endsWith('.css') || !rels.includes('stylesheet')) continue;
-    if (media === '' || media === 'all' || media === 'screen') hrefs.push(href);
+    if (media === 'all' || media === 'screen') hrefs.push(href);
   }
   return hrefs;
 }
@@ -181,10 +191,12 @@ describe('dashboard critical CSS graph', () => {
     assert.deepEqual(
       renderBlockingStylesheetHrefs(`
         <link rel="stylesheet" href="/assets/main.css">
+        <link rel="stylesheet" media="screen" href="/assets/screen.css">
         <link rel="stylesheet" media="print" href="/assets/deferred.css">
+        <link rel="stylesheet" media="" href="/assets/empty-media.css">
         <noscript><link rel="stylesheet" href="/assets/nojs.css"></noscript>
       `),
-      ['/assets/main.css'],
+      ['/assets/main.css', '/assets/screen.css'],
     );
   });
 
@@ -278,8 +290,8 @@ describe('dashboard critical CSS graph', () => {
     );
   });
 
-  it('does not link or merge the settings-only stylesheet into built dashboard.html', { skip: !existsSync(resolve(repoRoot, 'dist/dashboard.html')) }, () => {
-    const dashboardHtml = src('dist/dashboard.html');
+  it('does not link or merge the settings-only stylesheet into built dashboard.html', () => {
+    const dashboardHtml = builtSrc('dist/dashboard.html');
     const hrefs = stylesheetHrefs(dashboardHtml);
     const settingsStylesheets = hrefs.filter((href) =>
       /\/assets\/settings(?:-(?:persistence|window))?-[A-Za-z0-9_-]+\.css$/.test(href)
@@ -299,7 +311,7 @@ describe('dashboard critical CSS graph', () => {
       '.settings-titlebar',
     ];
     const dashboardCss = hrefs
-      .map((href) => src(`dist/${href.replace(/^\//, '')}`))
+      .map((href) => builtSrc(`dist/${href.replace(/^\//, '')}`))
       .join('\n');
     for (const selector of standaloneSettingsSelectors) {
       assert.equal(
@@ -315,13 +327,13 @@ describe('dashboard critical CSS graph', () => {
     );
 
     if (existsSync(resolve(repoRoot, 'dist/settings.html'))) {
-      const settingsHrefs = stylesheetHrefs(src('dist/settings.html'));
+      const settingsHrefs = stylesheetHrefs(builtSrc('dist/settings.html'));
       assert.ok(
         settingsHrefs.some((href) => /\/assets\/settings(?:-(?:persistence|window))?-[A-Za-z0-9_-]+\.css$/.test(href)),
         'Built settings.html should still link the settings-only stylesheet for the standalone settings window.',
       );
       const settingsCss = settingsHrefs
-        .map((href) => src(`dist/${href.replace(/^\//, '')}`))
+        .map((href) => builtSrc(`dist/${href.replace(/^\//, '')}`))
         .join('\n');
       assert.equal(
         standaloneSettingsSelectors.every((selector) => settingsCss.includes(selector)),
@@ -331,8 +343,8 @@ describe('dashboard critical CSS graph', () => {
     }
   });
 
-  it('keeps large dashboard CSS off the render-blocking stylesheet path', { skip: !existsSync(resolve(repoRoot, 'dist/dashboard.html')) }, () => {
-    const dashboardHtml = src('dist/dashboard.html');
+  it('keeps large dashboard CSS off the render-blocking stylesheet path', () => {
+    const dashboardHtml = builtSrc('dist/dashboard.html');
     const blockingHrefs = renderBlockingStylesheetHrefs(dashboardHtml);
 
     assert.deepEqual(

--- a/tests/dashboard-critical-css.test.mjs
+++ b/tests/dashboard-critical-css.test.mjs
@@ -366,11 +366,16 @@ describe('dashboard critical CSS graph', () => {
     }
     assert.ok(deferredHrefs.length > 0, 'Built dashboard.html should still request app CSS on a deferred stylesheet path.');
 
+    const noscriptLinkTags = [...dashboardHtml.matchAll(/<noscript>\s*(<link\b[^>]*>)\s*<\/noscript>/gi)].map((m) => m[1]);
     for (const href of deferredHrefs) {
-      assert.match(
-        dashboardHtml,
-        new RegExp(`<noscript><link\\b[^>]*rel=["']stylesheet["'][^>]*href=["']${href.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}["'][^>]*></noscript>`),
-        `Deferred dashboard stylesheet ${href} must keep a no-JS stylesheet fallback.`,
+      const hasFallback = noscriptLinkTags.some((tag) => {
+        const attrs = linkAttributes(tag);
+        const rels = (attrs.get('rel') ?? '').toLowerCase().split(/\s+/);
+        return attrs.get('href') === href && rels.includes('stylesheet');
+      });
+      assert.ok(
+        hasFallback,
+        `Deferred dashboard stylesheet ${href} must keep a no-JS stylesheet fallback (rel=stylesheet, any attribute order).`,
       );
     }
   });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -287,9 +287,20 @@ function dashboardHtmlOutputPlugin(): Plugin {
       const [bundleKey, dashboardHtml] = dashboardEntry;
       delete bundle[bundleKey];
       dashboardHtml.fileName = 'dashboard.html';
+      if (typeof dashboardHtml.source === 'string') {
+        dashboardHtml.source = deferDashboardStylesheetLinks(dashboardHtml.source);
+      }
       bundle['dashboard.html'] = dashboardHtml;
     },
   };
+}
+
+function deferDashboardStylesheetLinks(html: string): string {
+  return html.replace(/<link\b(?=[^>]*\brel=["']stylesheet["'])(?=[^>]*\bhref=["'][^"']+\.css["'])[^>]*>/gi, (tag) => {
+    if (/\bdata-wm-deferred-style=/.test(tag) || /\bmedia=/.test(tag)) return tag;
+    const deferredTag = tag.replace(/\s*\/?>$/, ' media="print" data-wm-deferred-style="dashboard">');
+    return `${deferredTag}\n    <noscript>${tag}</noscript>`;
+  });
 }
 
 function polymarketPlugin(): Plugin {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -310,6 +310,18 @@ function shouldDeferDashboardStylesheet(tag: string, bundle: OutputBundle): bool
   return sourceLength >= 100 * 1024;
 }
 
+// Rewrite large render-blocking dashboard <link rel=stylesheet> tags into a
+// deferred form (media="print" + data-wm-deferred-style="dashboard") plus a
+// <noscript> copy of the original blocking link, so the ~492KB app CSS no
+// longer blocks first paint. src/main.ts activateDeferredDashboardStyles()
+// flips media -> "all" at startup; the attribute name + values written here MUST
+// stay in lockstep with that runtime selector. Only assets >=100KB are deferred
+// (shouldDeferDashboardStylesheet) so small stylesheets stay blocking; links
+// that already set media= (an intentionally print/screen-scoped sheet) or are
+// already deferred are skipped. NOTE: during the defer window only the UNLAYERED
+// inline critical CSS in index.html applies (the bundle is @layer base), so any
+// future *unconditional* inline rule will beat the bundle (see PR #4346) — keep
+// inline rules scoped to a transient/closed state.
 function deferDashboardStylesheetLinks(html: string, bundle: OutputBundle): string {
   return html.replace(/<link\b(?=[^>]*\brel=["']stylesheet["'])(?=[^>]*\bhref=["'][^"']+\.css["'])[^>]*>/gi, (tag) => {
     if (/\bdata-wm-deferred-style=/.test(tag) || /\bmedia=/.test(tag)) return tag;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, loadEnv, type Plugin } from 'vite';
 import { VitePWA } from 'vite-plugin-pwa';
+import type { OutputBundle } from 'rollup';
 import { resolve, dirname, extname } from 'path';
 import { mkdir, readFile, writeFile } from 'fs/promises';
 import { brotliCompress } from 'zlib';
@@ -288,16 +289,31 @@ function dashboardHtmlOutputPlugin(): Plugin {
       delete bundle[bundleKey];
       dashboardHtml.fileName = 'dashboard.html';
       if (typeof dashboardHtml.source === 'string') {
-        dashboardHtml.source = deferDashboardStylesheetLinks(dashboardHtml.source);
+        dashboardHtml.source = deferDashboardStylesheetLinks(dashboardHtml.source, bundle);
       }
       bundle['dashboard.html'] = dashboardHtml;
     },
   };
 }
 
-function deferDashboardStylesheetLinks(html: string): string {
+function shouldDeferDashboardStylesheet(tag: string, bundle: OutputBundle): boolean {
+  const href = tag.match(/\bhref=["']([^"']+\.css)["']/i)?.[1];
+  if (!href) return false;
+
+  const bundleKey = href.replace(/^\//, '');
+  const asset = bundle[bundleKey];
+  if (!asset || asset.type !== 'asset') return false;
+
+  const sourceLength = typeof asset.source === 'string'
+    ? Buffer.byteLength(asset.source)
+    : asset.source.byteLength;
+  return sourceLength >= 100 * 1024;
+}
+
+function deferDashboardStylesheetLinks(html: string, bundle: OutputBundle): string {
   return html.replace(/<link\b(?=[^>]*\brel=["']stylesheet["'])(?=[^>]*\bhref=["'][^"']+\.css["'])[^>]*>/gi, (tag) => {
     if (/\bdata-wm-deferred-style=/.test(tag) || /\bmedia=/.test(tag)) return tag;
+    if (!shouldDeferDashboardStylesheet(tag, bundle)) return tag;
     const deferredTag = tag.replace(/\s*\/?>$/, ' media="print" data-wm-deferred-style="dashboard">');
     return `${deferredTag}\n    <noscript>${tag}</noscript>`;
   });


### PR DESCRIPTION
## Summary

The dashboard no longer waits on the ~492 kB generated app stylesheet before first paint. The built dashboard HTML now requests that CSS through a deferred stylesheet path, keeps a no-JS fallback, and activates the stylesheet at app startup without inline handlers or CSP changes.

This closes #4372's remaining render-blocking CSS path after #4385 removed the settings-only stylesheet. It does not try to shrink the CSS payload itself; a future split can still reduce transfer size, but the large stylesheet is no longer a screen-blocking stylesheet link in `dashboard.html`.

## Validation

| Check | Result |
|---|---|
| `node --test tests/dashboard-critical-css.test.mjs` | Passed, including the before/after regression for render-blocking dashboard CSS |
| `./node_modules/.bin/tsc` | Passed |
| `VITE_VARIANT=full vite build` | Passed; emitted `dashboard.html` uses `media="print" data-wm-deferred-style="dashboard"` plus a `<noscript>` fallback |
| `node --test tests/deploy-config.test.mjs` | Passed; CSP/deploy guardrails remain aligned |
| Local browser smoke via `vite preview` | Passed; deferred link became `media=all`, CSS applied, and mobile-width layout had no horizontal overflow |
| `git push -u origin HEAD` pre-push hook | Passed full local gate, including typecheck, API typecheck, changed test, edge tests, boundary/safe HTML/premium/rate-limit checks, and version sync |

## Notes

Local preview still logs expected production API CORS noise from `http://127.0.0.1:4174`; that was unrelated to the CSS-loading change.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
