### PR TITLE
fix(sentry): suppress first-party-framed chunk-load deploy-skew noise

### DIFF
--- a/src/bootstrap/sentry-defer.ts
+++ b/src/bootstrap/sentry-defer.ts
@@ -757,18 +757,37 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // (WORLDMONITOR-NJ).
       if (/Cannot read properties of undefined \(reading 'fetchToken'\)/.test(msg)
           && frames.some(f => /tryToReauthenticate/.test(f.function ?? ''))) return null;
+      // Dynamic-import chunk-load failures whose browser-emitted message names one of
+      // our own hashed `/assets/*.js` chunks. These FETCH-failure phrasings (Chrome
+      // `Failed to fetch dynamically imported module: <url>`, Firefox `error loading
+      // dynamically imported module: <url>`) are deploy-skew (a stale hashed filename
+      // 404s after a deploy) or a transient network blip — never a first-party logic
+      // bug: our compiled code can't synthesize the string, the URL is always one of
+      // our chunks, and the load itself failed (a chunk that fetches then throws during
+      // evaluation rejects with the underlying error, not this wrapper). Unlike the
+      // zero-frame variant below, the `import()` call site here is first-party
+      // (MapContainer.initDeck, lazy panel/video loaders), so the rejection rides a
+      // first-party frame and the `!hasFirstParty` gate misses it (WORLDMONITOR-TN: Map
+      // chunk, WORLDMONITOR-S1: hls chunk). Match the asset URL in the message instead
+      // of the stack.
+      if (/(?:Failed to fetch|error loading) dynamically imported module/i.test(msg)
+          && /\/assets\/[A-Za-z0-9_-]+\.js/.test(msg)) return null;
       // Stale-chunk-after-deploy: modulepreload / dynamic import failures arrive with no
       // stack trace because the browser fires them as synthetic TypeErrors at fetch time,
       // not at any first-party call site. The chunk-reload guard auto-reloads the page,
       // so the user is unaffected — but the Sentry event is still captured. Drop these
       // even when frames.length === 0 (WORLDMONITOR-Q / WORLDMONITOR-15). The phrases
       // are runtime-emitted only — our shipped code cannot synthesize them. Browser
-      // variants: Chrome/Edge `Failed to fetch dynamically imported module: <url>`,
-      // Safari `Importing a module script failed.`, Firefox `error loading dynamically
-      // imported module`.
+      // variants: Chrome/Edge `Failed to fetch dynamically imported module` (no URL /
+      // modulepreload), Safari `Importing a module script failed.`, Firefox `error
+      // loading dynamically imported module`. `Importing binding name '<x>' is not
+      // found.` (Safari) is the module-LINK counterpart: a chunk imports a named export
+      // a sibling chunk no longer provides after a deploy — a built bundle always links
+      // consistently, so at runtime this is version skew, never a code defect, and it
+      // throws at link time with zero first-party frames (WORLDMONITOR-TM).
       if (
         !hasFirstParty
-        && /(?:Failed to fetch|error loading) dynamically imported module|Importing a module script failed/i.test(msg)
+        && /(?:Failed to fetch|error loading) dynamically imported module|Importing a module script failed|Importing binding name '[^']*' is not found/i.test(msg)
       ) return null;
       // Zero-frame async-rejection patterns: AbortSignal.timeout() rejections
       // and DOMException(NotSupportedError) bubble up via

--- a/src/bootstrap/sentry-defer.ts
+++ b/src/bootstrap/sentry-defer.ts
@@ -762,16 +762,37 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // `Failed to fetch dynamically imported module: <url>`, Firefox `error loading
       // dynamically imported module: <url>`) are deploy-skew (a stale hashed filename
       // 404s after a deploy) or a transient network blip — never a first-party logic
-      // bug: our compiled code can't synthesize the string, the URL is always one of
-      // our chunks, and the load itself failed (a chunk that fetches then throws during
-      // evaluation rejects with the underlying error, not this wrapper). Unlike the
+      // bug: our compiled code can't synthesize the string, the URL is one of our
+      // owned hashed chunks, and the load itself failed (a chunk that fetches
+      // then throws during evaluation rejects with the underlying error, not
+      // this wrapper). Unlike the
       // zero-frame variant below, the `import()` call site here is first-party
       // (MapContainer.initDeck, lazy panel/video loaders), so the rejection rides a
       // first-party frame and the `!hasFirstParty` gate misses it (WORLDMONITOR-TN: Map
-      // chunk, WORLDMONITOR-S1: hls chunk). Match the asset URL in the message instead
-      // of the stack.
+      // chunk, WORLDMONITOR-S1: hls chunk). Match the owned, hashed asset URL in
+      // the message instead of the stack.
+      const dynamicImportAssetUrlMatch = msg.match(
+        /(?:https?:\/\/[^\s'")]+)?\/assets\/[A-Za-z0-9_-]+-[A-Za-z0-9_-]+\.js/i,
+      );
+      let isOwnedDynamicImportAssetUrl = false;
+      if (dynamicImportAssetUrlMatch) {
+        const assetUrl = dynamicImportAssetUrlMatch[0];
+        if (assetUrl.startsWith('/')) {
+          isOwnedDynamicImportAssetUrl = true;
+        } else {
+          try {
+            const host = new URL(assetUrl).hostname;
+            const currentHost = typeof location !== 'undefined' ? location.hostname : '';
+            isOwnedDynamicImportAssetUrl = host === 'worldmonitor.app'
+              || host.endsWith('.worldmonitor.app')
+              || (currentHost.endsWith('.vercel.app') && host === currentHost);
+          } catch {
+            isOwnedDynamicImportAssetUrl = false;
+          }
+        }
+      }
       if (/(?:Failed to fetch|error loading) dynamically imported module/i.test(msg)
-          && /\/assets\/[A-Za-z0-9_-]+\.js/.test(msg)) return null;
+          && isOwnedDynamicImportAssetUrl) return null;
       // Stale-chunk-after-deploy: modulepreload / dynamic import failures arrive with no
       // stack trace because the browser fires them as synthetic TypeErrors at fetch time,
       // not at any first-party call site. The chunk-reload guard auto-reloads the page,

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -236,27 +236,61 @@ describe('empty-stack network/timeout errors are NOT suppressed', () => {
 // (WORLDMONITOR-Q / WORLDMONITOR-15).
 
 describe('dynamic-module-import failures (stale chunk after deploy)', () => {
-  const dynamicImportErrors = [
+  // URL-bearing FETCH-failure phrasings whose message names one of our own
+  // hashed `/assets/*.js` chunks are deploy-skew / transient-network — never a
+  // first-party logic bug. The `import()` call site is ALWAYS first-party
+  // (MapContainer.initDeck, lazy panel/video loaders), so these ride a
+  // first-party frame; matching the asset URL suppresses them regardless of
+  // stack (WORLDMONITOR-TN: Map chunk, WORLDMONITOR-S1: hls chunk — both leaked
+  // because the old `!hasFirstParty`-only gate let first-party-framed ones
+  // through).
+  const assetUrlImportErrors = [
     'Failed to fetch dynamically imported module: https://worldmonitor.app/assets/panels-abc.js',
     'Failed to fetch dynamically imported module: https://www.worldmonitor.app/assets/index-DSkSc57y.js',
+    'error loading dynamically imported module: https://www.worldmonitor.app/assets/Map-eKJvyIxN.js',
+    'error loading dynamically imported module: https://www.worldmonitor.app/assets/hls-jw_vZdHi.js',
+  ];
+
+  for (const msg of assetUrlImportErrors) {
+    for (const [label, frames] of [
+      ['empty stack', []],
+      ['confirmed third-party stack', [extensionFrame()]],
+      ['first-party stack', [firstPartyFrame()]],
+    ]) {
+      it(`suppresses "${msg.slice(0, 55)}..." with ${label}`, () => {
+        const event = makeEvent(msg, 'TypeError', frames);
+        assert.equal(beforeSend(event), null, `asset-URL chunk-load failure should be suppressed regardless of stack (${label})`);
+      });
+    }
+  }
+
+  // No-URL phrasings (Safari `Importing a module script failed.`, bare Firefox
+  // `error loading dynamically imported module`, and the module-LINK export
+  // mismatch `Importing binding name '<x>' is not found.` — WORLDMONITOR-TM)
+  // throw at fetch/link time with no first-party call site, so they're gated on
+  // `!hasFirstParty`: suppressed with an empty or third-party stack, preserved
+  // when a genuine first-party frame is present.
+  const noUrlImportErrors = [
     'Importing a module script failed.',
     'TypeError: Importing a module script failed.',
     'error loading dynamically imported module',
+    "Importing binding name 'f' is not found.",
   ];
 
-  for (const msg of dynamicImportErrors) {
-    it(`suppresses "${msg.slice(0, 60)}..." with empty stack`, () => {
-      const event = makeEvent(msg, 'TypeError', []);
-      assert.equal(beforeSend(event), null, `"${msg}" with empty stack should be suppressed (chunk-reload guard handles it)`);
+  for (const msg of noUrlImportErrors) {
+    const type = msg.startsWith('Importing binding name') ? 'SyntaxError' : 'TypeError';
+    it(`suppresses "${msg.slice(0, 55)}..." with empty stack`, () => {
+      const event = makeEvent(msg, type, []);
+      assert.equal(beforeSend(event), null, `"${msg}" with empty stack should be suppressed (chunk-reload guard / deploy-skew)`);
     });
 
-    it(`suppresses "${msg.slice(0, 60)}..." with confirmed third-party stack`, () => {
-      const event = makeEvent(msg, 'TypeError', [extensionFrame()]);
+    it(`suppresses "${msg.slice(0, 55)}..." with confirmed third-party stack`, () => {
+      const event = makeEvent(msg, type, [extensionFrame()]);
       assert.equal(beforeSend(event), null);
     });
 
-    it(`lets through "${msg.slice(0, 60)}..." with first-party stack`, () => {
-      const event = makeEvent(msg, 'TypeError', [firstPartyFrame()]);
+    it(`lets through "${msg.slice(0, 55)}..." with first-party stack`, () => {
+      const event = makeEvent(msg, type, [firstPartyFrame()]);
       assert.ok(beforeSend(event) !== null, `"${msg}" with first-party stack should NOT be suppressed`);
     });
   }

--- a/tests/sentry-beforesend.test.mjs
+++ b/tests/sentry-beforesend.test.mjs
@@ -264,6 +264,24 @@ describe('dynamic-module-import failures (stale chunk after deploy)', () => {
     }
   }
 
+  it('lets through off-origin /assets dynamic-import failures even with first-party stack', () => {
+    const event = makeEvent(
+      'Failed to fetch dynamically imported module: https://cdn.example.com/assets/vendor-abc.js',
+      'TypeError',
+      [firstPartyFrame()],
+    );
+    assert.ok(beforeSend(event) !== null, 'off-origin asset URL must not be treated as WorldMonitor deploy skew');
+  });
+
+  it('lets through non-hashed /assets dynamic-import failures even on owned origins', () => {
+    const event = makeEvent(
+      'Failed to fetch dynamically imported module: https://worldmonitor.app/assets/runtime.js',
+      'TypeError',
+      [firstPartyFrame()],
+    );
+    assert.ok(beforeSend(event) !== null, 'non-hashed asset URL must not be treated as a stale Vite chunk');
+  });
+
   // No-URL phrasings (Safari `Importing a module script failed.`, bare Firefox
   // `error loading dynamically imported module`, and the module-LINK export
   // mismatch `Importing binding name '<x>' is not found.` — WORLDMONITOR-TM)


### PR DESCRIPTION
## Summary

Three browser Sentry issues were deploy-skew / chunk-load noise that leaked past the existing filters:

- **WORLDMONITOR-TN** / **WORLDMONITOR-S1** — `error loading dynamically imported module: /assets/Map-*.js` (and `/assets/hls-*.js`). The `import()` call site is **always** first-party (`MapContainer.initDeck`, lazy panel/video loaders), so a stale hashed-chunk 404 after a deploy rides a first-party frame and the existing `!hasFirstParty`-only gate never suppressed it. Both were caught and recovered at runtime (SVG fallback) — pure deploy-skew, not a logic bug.
- **WORLDMONITOR-TM** — `SyntaxError: Importing binding name 'f' is not found.` (Safari). A chunk importing a named export a sibling chunk no longer provides after a deploy — a built bundle always links consistently, so at runtime this is version skew, thrown at link time with zero first-party frames.

### Changes (`src/bootstrap/sentry-defer.ts`, `beforeSend`)

- **New asset-URL gate**: matches `(Failed to fetch|error loading) dynamically imported module` carrying a `/assets/*.js` URL and drops it **regardless of stack**. The phrase is browser-emitted only and the URL is always one of our own chunks, so a first-party frame on the rejection is structural (the awaiting call site), not diagnostic.
- **Extended zero-frame gate**: added `Importing binding name '<x>' is not found` (still gated on `!hasFirstParty`).

### Why the gates stay narrow (preserved signal)

Verified against counterexamples — these all still **surface**:
- real first-party logic bugs
- the chunk-eval TDZ shape (`ReferenceError: Cannot access 'X' before initialization` — the #4382 regression class)
- CDN dynamic imports (non-`/assets/` URLs)
- generic `SyntaxError: Unexpected token`

### Not touched (intentionally)

Two high-volume edge issues (**WORLDMONITOR-SR** 461ev, **WORLDMONITOR-RQ** 11ev) are Convex platform `InternalServerError`s on `/api/user-prefs`. The edge function **already** handles them — maps to `503` + `Retry-After` and captures at `level: warning` deliberately for observability. They're server-side (`runtime: edge`), so the browser `beforeSend` never sees them, and a filter would destroy the intended signal. The burst has gone quiet. All five issues were resolved in Sentry with `inNextRelease: true` (auto-reopen if they recur/escalate).

## Test plan

- [x] `npm run typecheck` + `typecheck:api`
- [x] `npm run lint` (Biome) + `lint:md`
- [x] `npm run test:data` — 11548 pass (the 2 build-gated `dashboard-critical-css` failures need a prior `vite build`; 8/8 after build — unrelated to this diff)
- [x] `node --test tests/sentry-beforesend.test.mjs` — 172/172 (added asset-URL vs no-URL cases + TN/S1/TM)
- [x] `node --test tests/edge-functions.test.mjs` — 204/204
- [x] edge-function esbuild bundle check, `version:check`
- [x] Regex validated against real production messages + false-positive guard

https://claude.ai/code/session_011R2coR6TBo56g25vs8a67F