### PR TITLE
perf(map): split provider-specific WebGL vendor bytes

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -2547,7 +2547,7 @@ export class DataLoaderManager implements AppModule {
           }
           ingestGpsJammingForCII(data.hexes);
           if (this.ctx.mapLayers.gpsJamming) {
-            this.ctx.map?.setGpsJamming(data.hexes);
+            await this.ctx.map?.setGpsJamming(data.hexes);
             this.ctx.map?.setLayerReady('gpsJamming', data.hexes.length > 0);
           }
           this.ctx.statusPanel?.updateFeed('GPS Jam', { status: 'ok', itemCount: data.hexes.length });

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -8,7 +8,7 @@ import type { Layer, LayersList, PickingInfo } from '@deck.gl/core';
 import { GeoJsonLayer, ScatterplotLayer, PathLayer, IconLayer, TextLayer, PolygonLayer } from '@deck.gl/layers';
 import maplibregl from 'maplibre-gl';
 import type { StyleSpecification } from 'maplibre-gl';
-import { FALLBACK_DARK_STYLE, FALLBACK_LIGHT_STYLE, getMapProvider, getMapTheme, isLightMapTheme, type MapProvider } from '@/config/basemap';
+import { FALLBACK_DARK_STYLE, FALLBACK_LIGHT_STYLE, getMapProvider, getMapTheme, isLightMapTheme } from '@/config/basemap';
 import { getStyleForProvider } from '@/config/basemap-styles';
 import Supercluster from 'supercluster';
 import type {
@@ -695,8 +695,10 @@ export class DeckGLMap {
   private renderPaused = false;
   private renderPending = false;
   private webglLost = false;
+  private destroyed = false;
   private usedFallbackStyle = false;
   private readonly chrome: boolean;
+  private initPromise: Promise<void> = Promise.resolve();
   private styleLoadTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private tileMonitorGeneration = 0;
 
@@ -793,7 +795,7 @@ export class DeckGLMap {
     };
     window.addEventListener('map-theme-changed', this.handleMapThemeChange);
 
-    void this.initMapLibre();
+    this.initPromise = this.initMapLibre();
 
     if (this.chrome) {
       this.createControls();
@@ -937,6 +939,18 @@ export class DeckGLMap {
     this.container.appendChild(wrapper);
   }
 
+  /**
+   * Resolves once the initial MapLibre construction has settled (success, or a
+   * guarded teardown that bailed before constructing the map). Rejects if map
+   * construction throws (e.g. a WebGL init failure), letting
+   * MapContainer.createDeckGLMap fall back to the SVG renderer — the failure
+   * path that the fire-and-forget `void this.initMapLibre()` would otherwise
+   * swallow into an unhandled rejection + blank map.
+   */
+  public whenReady(): Promise<void> {
+    return this.initPromise;
+  }
+
   private async initMapLibre(): Promise<void> {
     if (maplibregl.getRTLTextPluginStatus() === 'unavailable') {
       maplibregl.setRTLTextPlugin(
@@ -946,6 +960,11 @@ export class DeckGLMap {
     }
 
     const { mapTheme: initialMapTheme, style: primaryStyle } = await this.resolveInitialBasemapStyle();
+    // The component can be torn down (renderer switch) while the style import
+    // above is in flight; bail before constructing a MapLibre map that destroy()
+    // can no longer reach — it would orphan a live WebGL context, its listeners
+    // and the 10s styleLoadTimeoutId.
+    if (this.destroyed) return;
 
     const preset = VIEW_PRESETS[this.state.view];
     if (!isHappyVariant && typeof primaryStyle === 'string' && !primaryStyle.includes('pmtiles')) {
@@ -1181,11 +1200,10 @@ export class DeckGLMap {
     }
   }
 
-  private async resolveInitialBasemapStyle(): Promise<{ provider: MapProvider; mapTheme: string; style: StyleSpecification | string }> {
+  private async resolveInitialBasemapStyle(): Promise<{ mapTheme: string; style: StyleSpecification | string }> {
     if (isHappyVariant) {
       const mapTheme = getCurrentTheme();
       return {
-        provider: 'openfreemap',
         mapTheme,
         style: mapTheme === 'light' ? HAPPY_LIGHT_STYLE : HAPPY_DARK_STYLE,
       };
@@ -1198,7 +1216,7 @@ export class DeckGLMap {
       const currentProvider = getMapProvider();
       const currentMapTheme = getMapTheme(currentProvider);
       if (provider === currentProvider && mapTheme === currentMapTheme) {
-        return { provider, mapTheme, style };
+        return { mapTheme, style };
       }
     }
 
@@ -1206,7 +1224,6 @@ export class DeckGLMap {
     const mapTheme = getMapTheme(provider);
     console.warn('[DeckGLMap] Map provider changed repeatedly during startup; using latest provider state');
     return {
-      provider,
       mapTheme,
       style: provider === 'carto'
         ? await getStyleForProvider(provider, mapTheme)
@@ -7436,6 +7453,7 @@ export class DeckGLMap {
   }
 
   public destroy(): void {
+    this.destroyed = true;
     this.stopTradeAnimation();
     this.activeFlightTrails.clear();
     this.clearTrailsBtn = null;

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -7,8 +7,9 @@ import { MapboxOverlay } from '@deck.gl/mapbox';
 import type { Layer, LayersList, PickingInfo } from '@deck.gl/core';
 import { GeoJsonLayer, ScatterplotLayer, PathLayer, IconLayer, TextLayer, PolygonLayer } from '@deck.gl/layers';
 import maplibregl from 'maplibre-gl';
-import { FALLBACK_DARK_STYLE, FALLBACK_LIGHT_STYLE, getMapProvider, getMapTheme, isLightMapTheme } from '@/config/basemap';
-import { registerPMTilesProtocol, getStyleForProvider } from '@/config/basemap-styles';
+import type { StyleSpecification } from 'maplibre-gl';
+import { FALLBACK_DARK_STYLE, FALLBACK_LIGHT_STYLE, getMapProvider, getMapTheme, isLightMapTheme, type MapProvider } from '@/config/basemap';
+import { getStyleForProvider } from '@/config/basemap-styles';
 import Supercluster from 'supercluster';
 import type {
   MapLayers,
@@ -54,7 +55,6 @@ import type { Earthquake } from '@/services/earthquakes';
 import type { ClimateAnomaly } from '@/services/climate';
 import type { RadiationObservation } from '@/services/radiation';
 import { ArcLayer } from '@deck.gl/layers';
-import { cellToBoundary } from 'h3-js';
 import type { WeatherAlert } from '@/services/weather';
 import { escapeHtml } from '@/utils/sanitize';
 import {
@@ -570,6 +570,7 @@ export class DeckGLMap {
   private ucdpEvents: UcdpGeoEvent[] = [];
   private displacementFlows: DisplacementFlow[] = [];
   private gpsJammingHexes: GpsJamHexWithPolygon[] = [];
+  private gpsJammingLoadSeq = 0;
   private climateAnomalies: ClimateAnomaly[] = [];
   private radiationObservations: RadiationObservation[] = [];
   private diseaseOutbreaks: DiseaseOutbreakItem[] = [];
@@ -728,6 +729,7 @@ export class DeckGLMap {
   // setTiles back-to-back. Idempotent today but wasteful.
   private radarIdlePending = false;
   private readonly startupTime = Date.now();
+  private basemapSwitchSeq = 0;
   private lastCableHighlightSignature = '';
   private lastCableHealthSignature = '';
   private lastPipelineHighlightSignature = '';
@@ -775,7 +777,7 @@ export class DeckGLMap {
 
     this.handleThemeChange = () => {
       if (isHappyVariant) {
-        this.switchBasemap();
+        void this.switchBasemap();
         return;
       }
       const provider = getMapProvider();
@@ -787,19 +789,11 @@ export class DeckGLMap {
     window.addEventListener('theme-changed', this.handleThemeChange);
 
     this.handleMapThemeChange = () => {
-      this.switchBasemap();
+      void this.switchBasemap();
     };
     window.addEventListener('map-theme-changed', this.handleMapThemeChange);
 
-    this.initMapLibre();
-
-    this.maplibreMap?.on('load', () => {
-      localizeMapLabels(this.maplibreMap);
-      this.initDeck();
-      this.loadCountryBoundaries();
-      this.fetchServerBases();
-      this.render();
-    });
+    void this.initMapLibre();
 
     if (this.chrome) {
       this.createControls();
@@ -943,7 +937,7 @@ export class DeckGLMap {
     this.container.appendChild(wrapper);
   }
 
-  private initMapLibre(): void {
+  private async initMapLibre(): Promise<void> {
     if (maplibregl.getRTLTextPluginStatus() === 'unavailable') {
       maplibregl.setRTLTextPlugin(
         '/mapbox-gl-rtl-text.min.js',
@@ -951,14 +945,9 @@ export class DeckGLMap {
       );
     }
 
-    const initialProvider = isHappyVariant ? 'openfreemap' as const : getMapProvider();
-    if (initialProvider === 'pmtiles' || initialProvider === 'auto') registerPMTilesProtocol();
+    const { mapTheme: initialMapTheme, style: primaryStyle } = await this.resolveInitialBasemapStyle();
 
     const preset = VIEW_PRESETS[this.state.view];
-    const initialMapTheme = getMapTheme(initialProvider);
-    const primaryStyle = isHappyVariant
-      ? (getCurrentTheme() === 'light' ? HAPPY_LIGHT_STYLE : HAPPY_DARK_STYLE)
-      : getStyleForProvider(initialProvider, initialMapTheme);
     if (!isHappyVariant && typeof primaryStyle === 'string' && !primaryStyle.includes('pmtiles')) {
       this.usedFallbackStyle = true;
       const attr = this.container.querySelector('.map-attribution');
@@ -1029,6 +1018,14 @@ export class DeckGLMap {
         this.render();
       });
     };
+
+    this.maplibreMap.on('load', () => {
+      localizeMapLabels(this.maplibreMap);
+      this.initDeck();
+      this.loadCountryBoundaries();
+      this.fetchServerBases();
+      this.render();
+    });
 
     let tileLoadOk = false;
     let tileErrorCount = 0;
@@ -1181,6 +1178,28 @@ export class DeckGLMap {
       }
     } else {
       this.savedTopLat = null;
+    }
+  }
+
+  private async resolveInitialBasemapStyle(): Promise<{ provider: MapProvider; mapTheme: string; style: StyleSpecification | string }> {
+    if (isHappyVariant) {
+      const mapTheme = getCurrentTheme();
+      return {
+        provider: 'openfreemap',
+        mapTheme,
+        style: mapTheme === 'light' ? HAPPY_LIGHT_STYLE : HAPPY_DARK_STYLE,
+      };
+    }
+
+    while (true) {
+      const provider = getMapProvider();
+      const mapTheme = getMapTheme(provider);
+      const style = await getStyleForProvider(provider, mapTheme);
+      const currentProvider = getMapProvider();
+      const currentMapTheme = getMapTheme(currentProvider);
+      if (provider === currentProvider && mapTheme === currentMapTheme) {
+        return { provider, mapTheme, style };
+      }
     }
   }
 
@@ -6458,14 +6477,31 @@ export class DeckGLMap {
     this.render();
   }
 
-  public setGpsJamming(hexes: GpsJamHex[]): void {
-    // Precompute each hex boundary once per data refresh (every ~5 min) instead
-    // of calling cellToBoundary per hex on every buildLayers()/render (#4396).
-    this.gpsJammingHexes = hexes.map(h => ({
-      ...h,
-      polygon: cellToBoundary(h.h3, true) as [number, number][],
-    }));
-    this.render();
+  public async setGpsJamming(hexes: GpsJamHex[]): Promise<void> {
+    const seq = ++this.gpsJammingLoadSeq;
+    if (hexes.length === 0) {
+      this.gpsJammingHexes = [];
+      this.render();
+      return;
+    }
+
+    try {
+      const { cellToBoundary } = await import('h3-js');
+      if (seq !== this.gpsJammingLoadSeq) return;
+      // Precompute each hex boundary once per data refresh (every ~5 min)
+      // instead of calling cellToBoundary per hex on every buildLayers()/render.
+      this.gpsJammingHexes = hexes.map(h => ({
+        ...h,
+        polygon: cellToBoundary(h.h3, true) as [number, number][],
+      }));
+      this.render();
+    } catch (err) {
+      if (seq !== this.gpsJammingLoadSeq) return;
+      this.gpsJammingHexes = [];
+      this.render();
+      console.warn('[DeckGLMap] failed to prepare GPS jamming polygons:', (err as Error)?.message);
+      throw err;
+    }
   }
 
   public setDiseaseOutbreaks(outbreaks: DiseaseOutbreakItem[]): void {
@@ -7278,19 +7314,22 @@ export class DeckGLMap {
     this.countryPulseRaf = requestAnimationFrame(step);
   }
 
-  private switchBasemap(): void {
-    if (!this.maplibreMap) return;
+  private async switchBasemap(): Promise<void> {
+    const map = this.maplibreMap;
+    if (!map) return;
+    const seq = ++this.basemapSwitchSeq;
     const provider = getMapProvider();
     const mapTheme = getMapTheme(provider);
     const style = isHappyVariant
       ? (getCurrentTheme() === 'light' ? HAPPY_LIGHT_STYLE : HAPPY_DARK_STYLE)
       : (this.usedFallbackStyle && provider === 'auto')
         ? (isLightMapTheme(mapTheme) ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE)
-        : getStyleForProvider(provider, mapTheme);
+        : await getStyleForProvider(provider, mapTheme);
+    if (this.maplibreMap !== map || seq !== this.basemapSwitchSeq) return;
     if (this.countryPulseRaf) { cancelAnimationFrame(this.countryPulseRaf); this.countryPulseRaf = null; }
     this.countryGeoJsonLoaded = false;
-    this.maplibreMap.setStyle(style, { diff: false });
-    this.maplibreMap.once('style.load', () => {
+    map.setStyle(style, { diff: false });
+    map.once('style.load', () => {
       localizeMapLabels(this.maplibreMap);
       this.loadCountryBoundaries();
       if (this.radarActive) this.applyRadarLayer();
@@ -7364,11 +7403,10 @@ export class DeckGLMap {
   }
 
   public reloadBasemap(): void {
+    this.basemapSwitchSeq++;
     if (!this.maplibreMap) return;
-    const provider = getMapProvider();
-    if (provider === 'pmtiles' || provider === 'auto') registerPMTilesProtocol();
     this.usedFallbackStyle = false;
-    this.switchBasemap();
+    void this.switchBasemap();
   }
 
   private updateCountryLayerPaint(theme: 'dark' | 'light'): void {

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -1191,7 +1191,7 @@ export class DeckGLMap {
       };
     }
 
-    while (true) {
+    for (let attempt = 0; attempt < 10; attempt++) {
       const provider = getMapProvider();
       const mapTheme = getMapTheme(provider);
       const style = await getStyleForProvider(provider, mapTheme);
@@ -1201,6 +1201,17 @@ export class DeckGLMap {
         return { provider, mapTheme, style };
       }
     }
+
+    const provider = getMapProvider();
+    const mapTheme = getMapTheme(provider);
+    console.warn('[DeckGLMap] Map provider changed repeatedly during startup; using latest provider state');
+    return {
+      provider,
+      mapTheme,
+      style: provider === 'carto'
+        ? await getStyleForProvider(provider, mapTheme)
+        : (isLightMapTheme(mapTheme) ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE),
+    };
   }
 
   public resize(): void {

--- a/src/components/MapContainer.ts
+++ b/src/components/MapContainer.ts
@@ -602,7 +602,7 @@ export class MapContainer {
     if (this.cachedDisplacementFlows) this.setDisplacementFlows(this.cachedDisplacementFlows);
     if (this.cachedClimateAnomalies) this.setClimateAnomalies(this.cachedClimateAnomalies);
     if (this.cachedRadiationObservations) this.setRadiationObservations(this.cachedRadiationObservations);
-    if (this.cachedGpsJamming) this.setGpsJamming(this.cachedGpsJamming);
+    if (this.cachedGpsJamming) void this.setGpsJamming(this.cachedGpsJamming);
     if (this.cachedSatellites) this.setSatellites(this.cachedSatellites);
     if (this.cachedDiseaseOutbreaks) this.setDiseaseOutbreaks(this.cachedDiseaseOutbreaks);
     if (this.cachedCyberThreats) this.setCyberThreats(this.cachedCyberThreats);
@@ -954,11 +954,11 @@ export class MapContainer {
     }
   }
 
-  public setGpsJamming(hexes: GpsJamHex[]): void {
+  public async setGpsJamming(hexes: GpsJamHex[]): Promise<void> {
     this.cachedGpsJamming = hexes;
     if (this.useGlobe) { this.globeMap?.setGpsJamming(hexes); return; }
     if (this.useDeckGL) {
-      this.deckGLMap?.setGpsJamming(hexes);
+      await this.deckGLMap?.setGpsJamming(hexes);
     }
   }
 

--- a/src/components/MapContainer.ts
+++ b/src/components/MapContainer.ts
@@ -498,9 +498,18 @@ export class MapContainer {
         view: this.initialState.view as DeckMapView,
       }, { chrome: this.chrome });
       this.rehydrateActiveMap();
+      // DeckGLMap defers MapLibre construction behind an async init. Await it so
+      // a WebGL/map-construction throw still reaches this catch and degrades to
+      // SVG, instead of becoming an unhandled rejection behind a blank map.
+      await this.deckGLMap.whenReady();
+      if (!this.isCurrentRendererInit(token)) return;
     } catch (error) {
       if (!this.isCurrentRendererInit(token)) return;
       console.warn('[MapContainer] DeckGL initialization failed, falling back to SVG map', error);
+      // Tear down the half-built deck map so its listeners, timers and WebGL
+      // context do not leak; initSvgMap then nulls the reference and flips
+      // useDeckGL off.
+      this.deckGLMap?.destroy();
       await this.initSvgMap('[MapContainer] Initializing SVG map (DeckGL fallback mode)', token);
     }
   }

--- a/src/components/MapContainer.ts
+++ b/src/components/MapContainer.ts
@@ -602,7 +602,11 @@ export class MapContainer {
     if (this.cachedDisplacementFlows) this.setDisplacementFlows(this.cachedDisplacementFlows);
     if (this.cachedClimateAnomalies) this.setClimateAnomalies(this.cachedClimateAnomalies);
     if (this.cachedRadiationObservations) this.setRadiationObservations(this.cachedRadiationObservations);
-    if (this.cachedGpsJamming) void this.setGpsJamming(this.cachedGpsJamming);
+    if (this.cachedGpsJamming) {
+      void this.setGpsJamming(this.cachedGpsJamming).catch(err => {
+        console.warn('[MapContainer] GPS jamming re-init failed:', (err as Error)?.message);
+      });
+    }
     if (this.cachedSatellites) this.setSatellites(this.cachedSatellites);
     if (this.cachedDiseaseOutbreaks) this.setDiseaseOutbreaks(this.cachedDiseaseOutbreaks);
     if (this.cachedCyberThreats) this.setCyberThreats(this.cachedCyberThreats);

--- a/src/config/basemap-styles.ts
+++ b/src/config/basemap-styles.ts
@@ -1,11 +1,11 @@
-// maplibre-, pmtiles-, @protomaps/basemaps-using parts of basemap.ts.
+// maplibre-using parts of basemap.ts.
 // Split out so `preferences-content.ts` (which only needs the preference
 // getters/setters) does NOT pull maplibre into the main bundle. Only
 // imported by `DeckGLMap.ts`, which is itself dynamically imported when
-// the map panel mounts — so maplibre + deck.gl now load lazily.
-import { Protocol } from 'pmtiles';
+// the map panel mounts — so maplibre + deck.gl now load lazily. PMTiles and
+// Protomaps stay behind provider-specific dynamic imports below so CARTO /
+// OpenFreeMap users do not download the self-hosted basemap stack.
 import maplibregl from 'maplibre-gl';
-import { layers, namedFlavor } from '@protomaps/basemaps';
 import type { StyleSpecification } from 'maplibre-gl';
 import {
   R2_BASE,
@@ -19,16 +19,28 @@ import {
 } from '@/config/basemap';
 
 let registered = false;
+let registerPromise: Promise<void> | null = null;
 
-export function registerPMTilesProtocol(): void {
+export async function registerPMTilesProtocol(): Promise<void> {
   if (registered) return;
-  registered = true;
-  const protocol = new Protocol();
-  maplibregl.addProtocol('pmtiles', protocol.tile);
+  registerPromise ??= (async () => {
+    try {
+      const { Protocol } = await import('pmtiles');
+      if (registered) return;
+      const protocol = new Protocol();
+      maplibregl.addProtocol('pmtiles', protocol.tile);
+      registered = true;
+    } catch (err) {
+      registerPromise = null;
+      throw err;
+    }
+  })();
+  await registerPromise;
 }
 
-export function buildPMTilesStyle(flavor: PMTilesTheme): StyleSpecification | null {
+export async function buildPMTilesStyle(flavor: PMTilesTheme): Promise<StyleSpecification | null> {
   if (!hasPMTilesUrl) return null;
+  const { layers, namedFlavor } = await import('@protomaps/basemaps');
   const spriteName = ['light', 'white'].includes(flavor) ? 'light' : 'dark';
   return {
     version: 8,
@@ -55,11 +67,23 @@ const CARTO_STYLES: Record<string, string> = {
   'positron': CARTO_POSITRON,
 };
 
-export function getStyleForProvider(provider: MapProvider, mapTheme: string): StyleSpecification | string {
+async function tryBuildRegisteredPMTilesStyle(flavor: PMTilesTheme): Promise<StyleSpecification | null> {
+  try {
+    const style = await buildPMTilesStyle(flavor);
+    if (!style) return null;
+    await registerPMTilesProtocol();
+    return style;
+  } catch (err) {
+    console.warn('[basemap] PMTiles style unavailable, using fallback:', (err as Error)?.message);
+    return null;
+  }
+}
+
+export async function getStyleForProvider(provider: MapProvider, mapTheme: string): Promise<StyleSpecification | string> {
   const lightFallback = isLightMapTheme(mapTheme);
   switch (provider) {
     case 'pmtiles': {
-      const style = buildPMTilesStyle(asPMTilesTheme(mapTheme));
+      const style = await tryBuildRegisteredPMTilesStyle(asPMTilesTheme(mapTheme));
       if (style) return style;
       return lightFallback ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE;
     }
@@ -68,7 +92,7 @@ export function getStyleForProvider(provider: MapProvider, mapTheme: string): St
     case 'carto':
       return CARTO_STYLES[mapTheme] ?? CARTO_DARK;
     default: {
-      const pmtiles = buildPMTilesStyle(asPMTilesTheme(mapTheme));
+      const pmtiles = await tryBuildRegisteredPMTilesStyle(asPMTilesTheme(mapTheme));
       return pmtiles ?? (lightFallback ? FALLBACK_LIGHT_STYLE : FALLBACK_DARK_STYLE);
     }
   }

--- a/tests/map-renderer-deferral.test.mjs
+++ b/tests/map-renderer-deferral.test.mjs
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync } from 'node:fs';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
@@ -181,6 +181,56 @@ describe('map renderer deferral boundary', () => {
       /if\s*\([^{]*id\.includes\('\/@protomaps\/basemaps\/'\)[^{]*\)\s*\{\s*return 'maplibre'/,
       'MapLibre manual chunk must not include Protomaps basemap code',
     );
+  });
+
+  // Real bundle-output guard. The static import-graph and vite.config text checks
+  // above cannot prove the split actually happened: staticValueImportGraph does not
+  // follow @/-aliased imports into basemap-styles.ts (where pmtiles/@protomaps/basemaps
+  // live), and a config-text regex says nothing about the emitted bundle. When a build
+  // is present, assert the split survived in dist — the #4382 onlyExplicitManualChunks
+  // fold-back stays green in source-level tests and only surfaces in the real output.
+  it('emits provider-specific WebGL vendor chunks that stay lazy in the real build', () => {
+    const assetsDir = resolve(root, 'dist/assets');
+    if (!existsSync(assetsDir)) return; // no build present — runs meaningfully post-build (CI)
+
+    const assets = readdirSync(assetsDir);
+    const findChunk = (name) => assets.find((file) => new RegExp(`^${name}-[A-Za-z0-9_-]+\\.js$`).test(file));
+
+    const maplibre = findChunk('maplibre');
+    const deckStack = findChunk('deck-stack');
+    const protomaps = findChunk('protomaps');
+    const h3 = findChunk('h3-js');
+
+    // Fold-back guard: if pmtiles/@protomaps/basemaps or h3-js regress back into the
+    // shared vendor chunks, their dedicated chunks disappear (the #4382 failure mode).
+    assert.ok(maplibre, 'maplibre vendor chunk must be emitted');
+    assert.ok(deckStack, 'deck-stack vendor chunk must be emitted');
+    assert.ok(protomaps, 'protomaps (pmtiles + @protomaps/basemaps) chunk must be emitted');
+    assert.ok(h3, 'h3-js chunk must be emitted');
+
+    // The whole point of the split: the maplibre chunk must not reference the
+    // provider-specific chunks at all (neither static nor dynamic).
+    const maplibreSrc = readFileSync(resolve(assetsDir, maplibre), 'utf-8');
+    assert.doesNotMatch(maplibreSrc, /protomaps-[A-Za-z0-9_-]+\.js/, 'maplibre chunk must not reference the protomaps chunk');
+    assert.doesNotMatch(maplibreSrc, /h3-js-[A-Za-z0-9_-]+\.js/, 'maplibre chunk must not reference the h3-js chunk');
+
+    // deck-stack may reach h3-js, but only via dynamic import() so it stays lazy —
+    // never a static `import"./h3-js-…"` / `from"./h3-js-…"`.
+    const deckStackSrc = readFileSync(resolve(assetsDir, deckStack), 'utf-8');
+    assert.doesNotMatch(
+      deckStackSrc,
+      /(?:import|from)\s*["']\.\/h3-js-[A-Za-z0-9_-]+\.js["']/,
+      'deck-stack must load h3-js lazily (dynamic import), never as a static import',
+    );
+
+    // None of the WebGL chunks may be modulepreloaded by the dashboard entry HTML.
+    const dashboard = resolve(root, 'dist/dashboard.html');
+    if (existsSync(dashboard)) {
+      const html = readFileSync(dashboard, 'utf-8');
+      const preloads = [...html.matchAll(/<link\b[^>]*\brel=["']modulepreload["'][^>]*\bhref=["']([^"']+)["'][^>]*>/g)].map((match) => match[1]);
+      const offenders = preloads.filter((href) => /\/assets\/(?:maplibre|deck-stack|protomaps|h3-js)-[A-Za-z0-9_-]+\.js$/.test(href));
+      assert.deepEqual(offenders, [], `WebGL vendor chunks must not be modulepreloaded by dashboard.html: ${offenders.join(', ')}`);
+    }
   });
 
   it('caches renderer data calls that can arrive before the deferred renderer exists', () => {

--- a/tests/map-renderer-deferral.test.mjs
+++ b/tests/map-renderer-deferral.test.mjs
@@ -150,14 +150,37 @@ describe('map renderer deferral boundary', () => {
       '@deck.gl/aggregation-layers',
       '@deck.gl/geo-layers',
       '@deck.gl/extensions',
+      'pmtiles',
+      '@protomaps/basemaps',
+      'h3-js',
     ];
 
     for (const specifier of forbidden) {
       assert.ok(
         !imports.has(specifier),
-        `DeckGLMap import graph must avoid static optional deck package ${specifier}`,
+        `DeckGLMap import graph must avoid static optional WebGL package ${specifier}`,
       );
     }
+  });
+
+  it('keeps provider-specific PMTiles deps out of the emitted MapLibre manual chunk', () => {
+    const viteConfig = readFileSync(resolve(root, 'vite.config.ts'), 'utf-8');
+
+    assert.match(
+      viteConfig,
+      /id\.includes\('\/pmtiles\/'\)[\s\S]*id\.includes\('\/@protomaps\/basemaps\/'\)[\s\S]*return 'protomaps'/,
+      'PMTiles and Protomaps must share a provider-specific lazy chunk',
+    );
+    assert.doesNotMatch(
+      viteConfig,
+      /if\s*\([^{]*id\.includes\('\/pmtiles\/'\)[^{]*\)\s*\{\s*return 'maplibre'/,
+      'MapLibre manual chunk must not include PMTiles provider code',
+    );
+    assert.doesNotMatch(
+      viteConfig,
+      /if\s*\([^{]*id\.includes\('\/@protomaps\/basemaps\/'\)[^{]*\)\s*\{\s*return 'maplibre'/,
+      'MapLibre manual chunk must not include Protomaps basemap code',
+    );
   });
 
   it('caches renderer data calls that can arrive before the deferred renderer exists', () => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -56,7 +56,7 @@ type PanelManualChunkName = PanelChunkName | PanelSupportChunkName;
 // (filter regex is built from this list). Keeping them tied prevents the
 // silent-breakage failure mode where renaming a chunk in `manualChunks`
 // re-eagerises the WebGL stack without any build-time error.
-//   - maplibre, deck-stack: heavy WebGL deps, only reachable via MapContainer
+//   - maplibre, deck-stack, protomaps: heavy WebGL deps, only reachable via MapContainer
 //   - MapContainer: the dynamic-import target itself
 //   - panels-*: panel domain chunks; keep them out of the entry HTML preload
 //   - UnifiedSettings, settings-window, checkout: secondary interaction flows;
@@ -64,6 +64,8 @@ type PanelManualChunkName = PanelChunkName | PanelSupportChunkName;
 const LAZY_HTML_PRELOAD_CHUNKS = [
   'maplibre',
   'deck-stack',
+  'protomaps',
+  'h3-js',
   'MapContainer',
   'UnifiedSettings',
   'settings-window',
@@ -1125,15 +1127,20 @@ export default defineConfig(({ mode }) => {
               // (top of file). The resolveDependencies filter relies on this string
               // identity; renaming here without updating the constant silently
               // re-eagerises the WebGL stack into the entry HTML's modulepreload list.
-              if (id.includes('/maplibre-gl/') || id.includes('/pmtiles/') || id.includes('/@protomaps/basemaps/')) {
+              if (id.includes('/maplibre-gl/')) {
                 return 'maplibre';
+              }
+              if (id.includes('/pmtiles/') || id.includes('/@protomaps/basemaps/')) {
+                return 'protomaps';
+              }
+              if (id.includes('/h3-js/')) {
+                return 'h3-js';
               }
               if (
                 id.includes('/@deck.gl/')
                 || id.includes('/@luma.gl/')
                 || id.includes('/@loaders.gl/')
                 || id.includes('/@math.gl/')
-                || id.includes('/h3-js/')
               ) {
                 return 'deck-stack';
               }


### PR DESCRIPTION
## Summary

Default desktop map users now download less WebGL vendor code after the demand gate fires. PMTiles/Protomaps no longer ride inside the base MapLibre chunk for CARTO/OpenFreeMap sessions, and H3 polygon code only loads when GPS jamming data needs it.

This also keeps the async map paths honest: provider changes made during initial style resolution are rechecked before MapLibre is constructed, stale basemap switches are discarded, PMTiles split-chunk failures fall back to OpenFreeMap instead of leaving a blank map, and GPS jamming readiness waits for lazy H3 polygon preparation.

Closes koala73/worldmonitor#4394.

## Measurements

| Asset | Before | After |
| --- | ---: | ---: |
| `maplibre` | 1,106,936 raw / 243,065 br | 1,048,679 raw / 231,274 br |
| `deck-stack` | 936,971 raw / 220,419 br | 750,446 raw / 173,360 br |
| `h3-js` | bundled into `deck-stack` | 195,415 raw / 48,461 br, lazy |
| `protomaps` | bundled into `maplibre` | 18,571 raw / 6,560 br, provider-specific |

`dashboard.html` still has zero modulepreloads for `maplibre`, `deck-stack`, `h3-js`, `protomaps`, `MapContainer`, or `GlobeMap`. A PMTiles-enabled build with `VITE_PMTILES_URL=https://example.com/world.pmtiles` also keeps PMTiles/Protomaps out of the emitted `maplibre` chunk; the provider-specific `protomaps` chunk is 56,946 raw / 12,136 br in that build.

## Validation

- `npm run typecheck`
- `./node_modules/.bin/tsx --test tests/map-renderer-deferral.test.mjs tests/map-trade-trip-position.test.mjs`
- `npm run build`
- `VITE_PMTILES_URL=https://example.com/world.pmtiles ./node_modules/.bin/vite build --outDir /tmp/wm-4394-pmtiles-final --emptyOutDir`
- Direct `dist/assets` scans for chunk sizes and PMTiles/Protomaps implementation identifiers in `maplibre-*`
- Pre-push hook: app/API typechecks, boundary/safe HTML/rate-limit/premium-fetch guards, changed tests, edge function tests, version sync

Headless Chromium in this environment exposes no WebGL2, so the browser smoke can only confirm correct SVG fallback and lazy resource behavior here. A GPU-backed browser should still be used for final live DeckGL canvas proof.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
