### PR TITLE
fix(checkout): close Dodo overlay on destroy (follow-up to #4392)

### DIFF
--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -130,6 +130,14 @@ interface PendingCheckoutIntent {
  */
 const PENDING_INTENT_TTL_MS = 15 * 60 * 1000;
 
+// Overlay lifecycle state. The two init flags below have DIFFERENT reset
+// semantics — keep them distinct or the #4387 double-Initialize bug returns:
+//   - `initialized`: UI/overlay session lifecycle. RESET to false in
+//     destroyCheckoutOverlay() so a remount re-runs ensureCheckoutOverlayInitialized.
+//   - `dodoPaymentsInitialized` (below): SDK singleton guard. NEVER reset.
+//     DodoPayments.Initialize must run exactly once per page load (it registers
+//     a page-lifetime postMessage listener); the per-session event handler is
+//     swapped via `currentCheckoutEventHandler`, never by re-Initializing.
 let initialized = false;
 let checkoutOverlayGeneration = 0;
 let overlayInitPromise: Promise<void> | null = null;
@@ -228,8 +236,8 @@ async function ensureCheckoutOverlayInitialized(): Promise<void> {
     // onEvent callback forwards into this per-session handler. ONE session's
     // state must reset when a new overlay opens, so destroy/reopen replaces
     // the forwarded handler without registering a second SDK handler.
-    // `openCheckout` resets this flag via the exported `resetOverlaySessionState()`
-    // helper below.
+    // `openCheckout` resets these per-session flags by invoking the
+    // module-level `_resetOverlaySession` closure assigned just below.
     let successFired = false;
     let navigationFired = false;
     let watchdog: EntitlementWatchdog | null = null;
@@ -449,6 +457,16 @@ export function destroyCheckoutOverlay(): void {
   _resetOverlaySession?.();
   _resetOverlaySession = null;
   currentCheckoutEventHandler = null;
+  // Tear down the Dodo iframe itself. The SDK registers ONE page-lifetime
+  // message listener at Initialize and never removes it on close(); an iframe
+  // left mounted by a destroy-mid-checkout would otherwise (a) make the next
+  // openCheckout's Checkout.open() a silent no-op (the SDK ignores open() while
+  // an iframe already exists, so the reopened overlay never appears) and
+  // (b) emit a late terminal event from the orphaned iframe into the NEXT
+  // session's handler via the stable onEvent forwarder. The handler is nulled
+  // first so this teardown can't re-enter session cleanup — we intentionally
+  // preserve PENDING_CHECKOUT_KEY for auto-resume after a remount.
+  safeCloseOverlay();
   initialized = false;
   overlayInitPromise = null;
   onSuccessCallback = null;

--- a/tests/checkout-overlay-lifecycle.test.mts
+++ b/tests/checkout-overlay-lifecycle.test.mts
@@ -10,6 +10,8 @@ interface HarnessState {
   sentryBreadcrumbs: Array<{ message?: string }>;
   watchdogs: Array<{ stopCalls: number }>;
   storageWrites: string[];
+  closeCalls: number;
+  silentNoOpOpens: number;
 }
 
 declare global {
@@ -73,6 +75,8 @@ function resetHarness(): void {
     sentryBreadcrumbs: [],
     watchdogs: [],
     storageWrites: [],
+    closeCalls: 0,
+    silentNoOpOpens: 0,
   };
   installBrowserGlobals();
 }
@@ -88,15 +92,28 @@ const stubSources: Record<string, string> = {
     }
   `,
   'dodopayments-checkout': `
+    // Models the real SDK: Initialize registers ONE page-lifetime listener;
+    // open() is a silent no-op while an iframe is already mounted; close()
+    // tears the iframe down. A destroy that never calls close() therefore makes
+    // the next open() vanish — which is exactly what this harness can now catch.
+    let _overlayOpen = false;
     export const DodoPayments = {
       Initialize(options) {
         globalThis.__checkoutOverlayHarness.initializeCalls += 1;
         globalThis.__checkoutOverlayHarness.handlers.push(options.onEvent);
       },
       Checkout: {
-        isOpen: () => false,
-        close: () => {},
+        isOpen: () => _overlayOpen,
+        close: () => {
+          _overlayOpen = false;
+          globalThis.__checkoutOverlayHarness.closeCalls += 1;
+        },
         open(options) {
+          if (_overlayOpen) {
+            globalThis.__checkoutOverlayHarness.silentNoOpOpens += 1;
+            return;
+          }
+          _overlayOpen = true;
           globalThis.__checkoutOverlayHarness.openedUrls.push(options.checkoutUrl);
         },
       },
@@ -270,5 +287,50 @@ describe('checkout overlay lifecycle', () => {
 
     checkout.destroyCheckoutOverlay();
     assert.equal(harness.watchdogs[0].stopCalls, 1, 'destroy should stop the reopened session watchdog');
+  });
+
+  it('closes the overlay on destroy so a reopen is not a silent no-op', async () => {
+    resetHarness();
+    const checkout = await loadCheckoutModule();
+
+    await checkout.openCheckout('https://checkout.example/first');
+    checkout.destroyCheckoutOverlay();
+
+    const harness = globalThis.__checkoutOverlayHarness;
+    assert.equal(harness.closeCalls, 1, 'destroy must close the open Dodo overlay');
+
+    await checkout.openCheckout('https://checkout.example/second');
+    assert.equal(harness.silentNoOpOpens, 0, 'reopen must not be swallowed by an orphaned iframe');
+    assert.deepEqual(
+      harness.openedUrls,
+      ['https://checkout.example/first', 'https://checkout.example/second'],
+      'the reopened overlay must actually open',
+    );
+  });
+
+  it('silences events from a destroyed session before the overlay is reopened', async () => {
+    resetHarness();
+    const checkout = await loadCheckoutModule();
+
+    checkout.registerCheckoutSuccessCallback(() => {
+      globalThis.__checkoutOverlayHarness.successCalls += 1;
+    });
+    await checkout.openCheckout('https://checkout.example/first');
+    checkout.destroyCheckoutOverlay();
+
+    // A late terminal event arriving through the stable SDK forwarder after
+    // destroy (and before any reopen) must be a no-op — the per-session handler
+    // was nulled, so no success side effects or storage writes may fire.
+    const harness = globalThis.__checkoutOverlayHarness;
+    harness.handlers[0]({
+      event_type: 'checkout.status',
+      data: { message: { status: 'succeeded' } },
+    });
+    assert.equal(harness.successCalls, 0, 'a destroyed session must not run success side effects');
+    assert.equal(
+      harness.storageWrites.filter((key) => key === 'wm-post-checkout').length,
+      0,
+      'a destroyed session must not write the post-checkout marker',
+    );
   });
 });

--- a/tests/checkout-overlay-lifecycle.test.mts
+++ b/tests/checkout-overlay-lifecycle.test.mts
@@ -332,5 +332,20 @@ describe('checkout overlay lifecycle', () => {
       0,
       'a destroyed session must not write the post-checkout marker',
     );
+
+    // The headline cross-session hazard: a late checkout.redirect_requested from
+    // the destroyed session's orphaned iframe must NOT navigate — otherwise
+    // session A's redirect_to could hijack session B's tab.
+    const win = (globalThis as unknown as { window: { location: { href: string } } }).window;
+    const hrefBefore = win.location.href;
+    harness.handlers[0]({
+      event_type: 'checkout.redirect_requested',
+      data: { message: { redirect_to: 'https://attacker.example/stolen' } },
+    });
+    assert.equal(
+      win.location.href,
+      hrefBefore,
+      'a destroyed session must not navigate via a late redirect_requested',
+    );
   });
 });

--- a/tests/checkout-overlay-lifecycle.test.mts
+++ b/tests/checkout-overlay-lifecycle.test.mts
@@ -96,17 +96,29 @@ const stubSources: Record<string, string> = {
     // open() is a silent no-op while an iframe is already mounted; close()
     // tears the iframe down. A destroy that never calls close() therefore makes
     // the next open() vanish — which is exactly what this harness can now catch.
+    //
+    // close() also re-emits checkout.closed SYNCHRONOUSLY through the same onEvent
+    // forwarder, in the same call stack — mirroring the real SDK (fn b -> g('checkout.closed')
+    // -> config.onEvent). That synchronous re-entry is what makes destroyCheckoutOverlay's
+    // "null currentCheckoutEventHandler BEFORE safeCloseOverlay()" ordering load-bearing:
+    // reverse it and the re-entrant checkout.closed wipes the pending-intent.
     let _overlayOpen = false;
+    let _onEvent = null;
     export const DodoPayments = {
       Initialize(options) {
         globalThis.__checkoutOverlayHarness.initializeCalls += 1;
+        _onEvent = options.onEvent;
         globalThis.__checkoutOverlayHarness.handlers.push(options.onEvent);
       },
       Checkout: {
         isOpen: () => _overlayOpen,
         close: () => {
+          const wasOpen = _overlayOpen;
           _overlayOpen = false;
           globalThis.__checkoutOverlayHarness.closeCalls += 1;
+          if (wasOpen) {
+            _onEvent?.({ event_type: 'checkout.closed', data: { message: 'Checkout closed manually' } });
+          }
         },
         open(options) {
           if (_overlayOpen) {
@@ -346,6 +358,34 @@ describe('checkout overlay lifecycle', () => {
       win.location.href,
       hrefBefore,
       'a destroyed session must not navigate via a late redirect_requested',
+    );
+  });
+
+  it('preserves the pending-checkout intent across destroy (pins the null-handler-before-close ordering)', async () => {
+    resetHarness();
+    const checkout = await loadCheckoutModule();
+
+    await checkout.openCheckout('https://checkout.example/first');
+
+    // A saved auto-resume intent that an unmount-driven destroy must NOT wipe.
+    const pending = JSON.stringify({ productId: 'prod_1', savedByUserId: null, savedAt: 1 });
+    globalThis.sessionStorage.setItem('wm-pending-checkout', pending);
+
+    checkout.destroyCheckoutOverlay();
+
+    // The stub's close() re-emits checkout.closed synchronously through the stable
+    // forwarder, exactly as the real SDK does. destroyCheckoutOverlay nulls
+    // currentCheckoutEventHandler BEFORE calling safeCloseOverlay(), so that re-entrant
+    // checkout.closed lands on a null handler and the handler's
+    // `if (!successFired) clearPendingCheckoutIntent()` branch never runs — the intent
+    // survives for auto-resume after a remount. Reversing those two lines (close before
+    // null) routes checkout.closed into the still-live session handler and wipes the
+    // intent, failing this assertion. This is the property the other destroy tests do
+    // NOT pin, since they fire events manually after destroy has already returned.
+    assert.equal(
+      globalThis.sessionStorage.getItem('wm-pending-checkout'),
+      pending,
+      'destroy must preserve the pending-checkout intent (handler nulled before close)',
     );
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to #4392 (merged). That PR correctly fixed the double-`Initialize` / stacked-handler bug via the stable `onEvent` forwarder + per-session `currentCheckoutEventHandler`. A multi-reviewer code review of the merged result surfaced one residual in `destroyCheckoutOverlay`: **it stops the watchdog and nulls the per-session handler but never tears down the Dodo iframe.**

The DodoPayments SDK registers **one page-lifetime `postMessage` listener** at `Initialize` and never removes it on `close()`; `Checkout.open()` is a **silent no-op while an iframe is already mounted**. So a destroy that happens mid-checkout (e.g. layout unmount while the overlay is open) leaves the iframe live, which:

- makes the next `openCheckout`'s `Checkout.open()` a **silent no-op** — the reopened overlay never appears, yet `startCheckout` returns `true` (user clicks subscribe, nothing happens); and
- lets a **late terminal event** from the orphaned iframe route into the **next** session's handler via the stable forwarder (e.g. session A's `redirect_to` navigating session B's user — which also widens the blast radius of the pre-existing unvalidated `redirect_to` navigation).

Root cause is pre-existing (base `destroyCheckoutOverlay` was identical), but #4392's single-forwarder design changes the cross-session misrouting target (A→B), and a "harden overlay lifecycle" change is the right place to close it.

## Fix

`destroyCheckoutOverlay()` now calls `safeCloseOverlay()` — **after** nulling the handler so the teardown can't re-enter session cleanup (`PENDING_CHECKOUT_KEY` is preserved for auto-resume after a remount). `safeCloseOverlay()` only calls `Checkout.close()` when `isOpen()`, so a normal (already-closed) destroy is a no-op.

Also in this follow-up:
- **Document the two-flag invariant** at the declaration site (`initialized` resets on destroy; `dodoPaymentsInitialized` never does — re-`Initialize` is the #4387 bug).
- **Fix a misleading comment** that cited a non-existent exported `resetOverlaySessionState()` helper (the real mechanism is the module-level `_resetOverlaySession` closure).
- **Model the real SDK `open`/`close`/`isOpen` lifecycle** in `checkout-overlay-lifecycle.test.mts` and add two regression tests: close-on-destroy prevents a silent no-op reopen, and events from a destroyed session are silenced.

## Verification

- `npm run typecheck` — clean
- `tsx --test tests/checkout-overlay-lifecycle.test.mts tests/entitlement-watchdog.test.mts` — 14/14 pass
- **Revert-check:** removing `safeCloseOverlay()` from `destroyCheckoutOverlay` fails both the new close-on-destroy test and the existing "keeps one SDK handler" test (the second `open()` no-ops) — confirming the tests pin the fix.

Not in scope (reported, left as further follow-ups): extracting the watchdog's triple `isStale()` guard into a helper, and applying the singleton pattern to `pro-test/src/services/checkout.ts` (currently safe — no destroy/reopen there).