### PR TITLE
perf(dashboard): defer lazy-only config data tables off the eager path — tech-geo + airports (#4404)

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -208,7 +208,9 @@ import { fetchDiseaseOutbreaks } from '@/services/disease-outbreaks';
 import { fetchSocialVelocity } from '@/services/social-velocity';
 import { fetchShippingStress } from '@/services/supply-chain';
 import { getTopActiveGeoHubs } from '@/services/geo-activity';
-import { getTopActiveHubs } from '@/services/tech-activity';
+// getTopActiveHubs is lazy-imported at its call sites (applyTechHubActivities) so
+// the tech-activity → tech-hub-index → ~62KB tech-geo chain stays off the eager
+// dashboard critical path (#4404).
 import type { GeoHubsPanel } from '@/components/GeoHubsPanel';
 import type { TechHubsPanel } from '@/components/TechHubsPanel';
 
@@ -1436,8 +1438,7 @@ export class DataLoaderManager implements AppModule {
 
       (this.ctx.panels['geo-hubs'] as GeoHubsPanel | undefined)
         ?.setActivities(getTopActiveGeoHubs(this.ctx.latestClusters));
-      (this.ctx.panels['tech-hubs'] as TechHubsPanel | undefined)
-        ?.setActivities(getTopActiveHubs(this.ctx.latestClusters));
+      this.applyTechHubActivities();
 
       const geoLocated = this.ctx.latestClusters
         .filter((c): c is typeof c & { lat: number; lon: number } => c.lat != null && c.lon != null)
@@ -3292,6 +3293,19 @@ export class DataLoaderManager implements AppModule {
     monitorPanel?.renderResults(this.ctx.allNews);
   }
 
+  // Lazy-load the tech-activity service (→ tech-hub-index → the ~62KB tech-geo
+  // table) only when the lazy tech-hubs panel is mounted, so the table stays off
+  // the eager dashboard critical path. Non-critical panel data — degrade silently
+  // on load failure. (#4404)
+  private applyTechHubActivities(): void {
+    const techHubsPanel = this.ctx.panels['tech-hubs'] as TechHubsPanel | undefined;
+    if (!techHubsPanel) return;
+    const clusters = this.ctx.latestClusters;
+    void import('@/services/tech-activity')
+      .then(({ getTopActiveHubs }) => techHubsPanel.setActivities(getTopActiveHubs(clusters)))
+      .catch(() => { /* non-critical */ });
+  }
+
   async runCorrelationAnalysis(): Promise<void> {
     try {
       if (this.ctx.latestClusters.length === 0 && this.ctx.allNews.length > 0) {
@@ -3306,8 +3320,7 @@ export class DataLoaderManager implements AppModule {
         this.refreshCiiAndBrief();
         (this.ctx.panels['geo-hubs'] as GeoHubsPanel | undefined)
           ?.setActivities(getTopActiveGeoHubs(this.ctx.latestClusters));
-        (this.ctx.panels['tech-hubs'] as TechHubsPanel | undefined)
-          ?.setActivities(getTopActiveHubs(this.ctx.latestClusters));
+        this.applyTechHubActivities();
       }
 
       const signals = await analysisWorker.analyzeCorrelations(

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -91,10 +91,6 @@ import {
   ECONOMIC_CENTERS,
   AI_DATA_CENTERS,
   SITE_VARIANT,
-  STARTUP_HUBS,
-  ACCELERATORS,
-  TECH_HQS,
-  CLOUD_REGIONS,
   PORTS,
   SPACEPORTS,
   CRITICAL_MINERALS,
@@ -108,6 +104,9 @@ import {
   COMMODITY_PORTS as COMMODITY_GEO_PORTS,
   SANCTIONED_COUNTRIES_ALPHA2,
 } from '@/config';
+// Tech tables imported directly so the ~62KB tech-geo chunk stays off the eager
+// @/config barrel and loads only with this lazy renderer (#4404).
+import { STARTUP_HUBS, ACCELERATORS, TECH_HQS, CLOUD_REGIONS } from '@/config/tech-geo';
 import type { GulfInvestment } from '@/types';
 import { resolveTradeRouteSegments, TRADE_ROUTES as TRADE_ROUTES_LIST, type TradeRouteSegment, type TradeRouteStatus } from '@/config/trade-routes';
 import type { ScenarioVisualState } from '@/config/scenario-templates';

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -33,17 +33,15 @@ import {
   SPACEPORTS,
   CRITICAL_MINERALS,
   SITE_VARIANT,
-  // Tech variant data
-  STARTUP_HUBS,
-  ACCELERATORS,
-  TECH_HQS,
-  CLOUD_REGIONS,
   // Finance variant data
   STOCK_EXCHANGES,
   FINANCIAL_CENTERS,
   CENTRAL_BANKS,
   COMMODITY_HUBS,
 } from '@/config';
+// Tech tables imported directly so the ~62KB tech-geo chunk stays off the eager
+// @/config barrel and loads only with this lazy renderer (#4404).
+import { STARTUP_HUBS, ACCELERATORS, TECH_HQS, CLOUD_REGIONS } from '@/config/tech-geo';
 import { pinWebcam, isPinned } from '@/services/webcams/pinned-store';
 import type { WebcamEntry, WebcamCluster } from '@/generated/client/worldmonitor/webcam/v1/service_client';
 import { tokenizeForMatch, matchKeyword, findMatchingKeywords } from '@/utils/keyword-match';

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -94,7 +94,9 @@ export { APT_GROUPS } from './apt-groups';
 export { GAMMA_IRRADIATORS } from './irradiators';
 export { PIPELINES, PIPELINE_COLORS } from './pipelines';
 export { PORTS } from './ports';
-export { MONITORED_AIRPORTS, FAA_AIRPORTS } from './airports';
+// MONITORED_AIRPORTS/FAA_AIRPORTS are NOT re-exported on the eager @/config
+// barrel — that pulls the airports table onto the critical path. The only
+// consumer (AviationCommandBar, lazy) imports directly from '@/config/airports'. (#4404)
 export {
   ENTITY_REGISTRY,
   getEntityById,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -113,11 +113,11 @@ export {
   getUpcomingDeadlines,
   getRecentActions,
 } from './ai-regulations';
+// Value re-exports of the tech-geo tables are intentionally NOT on the eager
+// @/config barrel — they pull the ~62KB tech-geo chunk onto the dashboard
+// critical path. Every consumer (search/map/globe/tech-hub services) imports
+// directly from '@/config/tech-geo'. Type re-exports are erased, no edge. (#4404)
 export {
-  STARTUP_HUBS,
-  ACCELERATORS,
-  TECH_HQS,
-  CLOUD_REGIONS,
   type StartupHub,
   type Accelerator,
   type TechHQ,

--- a/src/config/variants/full.ts
+++ b/src/config/variants/full.ts
@@ -12,7 +12,8 @@ export * from '../irradiators';
 export * from '../pipelines';
 export * from '../ports';
 export * from '../military';
-export * from '../airports';
+// airports intentionally not re-exported here — keeps the airports table off the
+// eager variant/@/config barrel; AviationCommandBar imports it directly. (#4404)
 export * from '../entities';
 
 // Panel configuration for geopolitical analysis

--- a/src/e2e/map-harness.ts
+++ b/src/e2e/map-harness.ts
@@ -14,10 +14,6 @@ import {
   STRATEGIC_WATERWAYS,
   ECONOMIC_CENTERS,
   AI_DATA_CENTERS,
-  STARTUP_HUBS,
-  ACCELERATORS,
-  TECH_HQS,
-  CLOUD_REGIONS,
   PORTS,
   SPACEPORTS,
   APT_GROUPS,
@@ -30,6 +26,8 @@ import {
   PROCESSING_PLANTS,
   COMMODITY_PORTS,
 } from '../config';
+// Tech tables imported directly so tech-geo stays off the eager @/config barrel (#4404).
+import { STARTUP_HUBS, ACCELERATORS, TECH_HQS, CLOUD_REGIONS } from '../config/tech-geo';
 import type { PositiveGeoEvent } from '../services/positive-events-geo';
 import type { KindnessPoint } from '../services/kindness-data';
 import type { SpeciesRecovery } from '../services/conservation-data';

--- a/tests/dashboard-eager-chunks.test.mjs
+++ b/tests/dashboard-eager-chunks.test.mjs
@@ -23,7 +23,7 @@ describe('eager chunk budget: lazy-only config data tables stay off the entry', 
   const html = readFileSync(dashboardHtml, 'utf-8');
   const assetsDir = resolve(distDir, 'assets');
   const assets = existsSync(assetsDir) ? readdirSync(assetsDir) : [];
-  const mainFile = assets.find((f) => /^main-[A-Za-z0-9_]+\.js$/.test(f));
+  const mainFile = assets.find((f) => /^main-[A-Za-z0-9_-]+\.js$/.test(f));
   const mainJs = mainFile ? readFileSync(resolve(assetsDir, mainFile), 'utf-8') : '';
 
   for (const chunk of DEFERRED_TABLE_CHUNKS) {
@@ -47,7 +47,7 @@ describe('eager chunk budget: lazy-only config data tables stay off the entry', 
       // The bare filename also appears in Vite's dynamic-import preload manifest
       // (`"assets/<chunk>-hash.js"` inside an array) — that's expected for a lazy
       // chunk and must NOT fail the guard, so match the static-import form only.
-      const staticImportRe = new RegExp(`(?:from|import)"\\./${chunk}-[A-Za-z0-9_]+\\.js"`);
+      const staticImportRe = new RegExp(`(?:from|import)"\\./${chunk}-[A-Za-z0-9_-]+\\.js"`);
       assert.ok(
         !staticImportRe.test(mainJs),
         `${chunk} must not be statically imported by ${mainFile} (dynamic preload-manifest references are fine)`,

--- a/tests/dashboard-eager-chunks.test.mjs
+++ b/tests/dashboard-eager-chunks.test.mjs
@@ -17,7 +17,7 @@ const dashboardHtml = resolve(distDir, 'dashboard.html');
 //
 // Dist-gated: skips when dist/dashboard.html is absent. CI builds the dashboard
 // before `npm run test:data` (the step added in #4393), so this runs in CI.
-const DEFERRED_TABLE_CHUNKS = ['tech-geo-data'];
+const DEFERRED_TABLE_CHUNKS = ['tech-geo-data', 'airports-data'];
 
 describe('eager chunk budget: lazy-only config data tables stay off the entry', { skip: !existsSync(dashboardHtml) }, () => {
   const html = readFileSync(dashboardHtml, 'utf-8');

--- a/tests/dashboard-eager-chunks.test.mjs
+++ b/tests/dashboard-eager-chunks.test.mjs
@@ -1,0 +1,57 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const distDir = resolve(repoRoot, 'dist');
+const dashboardHtml = resolve(distDir, 'dashboard.html');
+
+// Large static config DATA TABLES intentionally kept OFF the eager dashboard
+// critical path (#4404 — main.js diet round 2). Each must (a) build as its own
+// chunk and (b) NOT appear in dashboard.html modulepreload or be statically
+// imported by the main entry chunk. A re-added @/config barrel value re-export
+// or a new eager consumer would re-eagerise the table and fail this guard.
+//
+// Dist-gated: skips when dist/dashboard.html is absent. CI builds the dashboard
+// before `npm run test:data` (the step added in #4393), so this runs in CI.
+const DEFERRED_TABLE_CHUNKS = ['tech-geo-data'];
+
+describe('eager chunk budget: lazy-only config data tables stay off the entry', { skip: !existsSync(dashboardHtml) }, () => {
+  const html = readFileSync(dashboardHtml, 'utf-8');
+  const assetsDir = resolve(distDir, 'assets');
+  const assets = existsSync(assetsDir) ? readdirSync(assetsDir) : [];
+  const mainFile = assets.find((f) => /^main-[A-Za-z0-9_]+\.js$/.test(f));
+  const mainJs = mainFile ? readFileSync(resolve(assetsDir, mainFile), 'utf-8') : '';
+
+  for (const chunk of DEFERRED_TABLE_CHUNKS) {
+    it(`${chunk}: built as its own isolated chunk`, () => {
+      assert.ok(
+        assets.some((f) => f.startsWith(`${chunk}-`) && f.endsWith('.js')),
+        `${chunk}-*.js chunk should exist (manualChunks rule present)`,
+      );
+    });
+
+    it(`${chunk}: absent from dashboard.html modulepreload`, () => {
+      assert.ok(
+        !html.includes(chunk),
+        `${chunk} must not be eagerly modulepreloaded in dashboard.html — a barrel value re-export or eager consumer re-eagerised it`,
+      );
+    });
+
+    it(`${chunk}: not statically imported by the main entry chunk`, () => {
+      assert.ok(mainFile, 'main-*.js entry chunk should exist in dist/assets');
+      // A STATIC import is `from"./<chunk>-hash.js"` / `import"./<chunk>-hash.js"`.
+      // The bare filename also appears in Vite's dynamic-import preload manifest
+      // (`"assets/<chunk>-hash.js"` inside an array) — that's expected for a lazy
+      // chunk and must NOT fail the guard, so match the static-import form only.
+      const staticImportRe = new RegExp(`(?:from|import)"\\./${chunk}-[A-Za-z0-9_]+\\.js"`);
+      assert.ok(
+        !staticImportRe.test(mainJs),
+        `${chunk} must not be statically imported by ${mainFile} (dynamic preload-manifest references are fine)`,
+      );
+    });
+  }
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1162,6 +1162,14 @@ export default defineConfig(({ mode }) => {
                 return 'clerk';
               }
             }
+            // Large static config DATA TABLE (~62KB) with only lazy consumers
+            // (search/map/globe/tech-hub services). Isolating it keeps it off the
+            // eager entry now that the @/config barrel no longer re-exports its
+            // values and data-loader lazy-loads the tech-activity chain. Pure
+            // data (type-only imports) → no unmatched-static-dep circular risk. (#4404)
+            if (id.endsWith('/src/config/tech-geo.ts')) {
+              return 'tech-geo-data';
+            }
             // Co-locate the deck.gl renderer with the deck vendor chunk so
             // onlyExplicitManualChunks cannot split deck's transitive deps
             // across the DeckGLMap boundary (which formed a circular chunk →

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1170,6 +1170,11 @@ export default defineConfig(({ mode }) => {
             if (id.endsWith('/src/config/tech-geo.ts')) {
               return 'tech-geo-data';
             }
+            // airports table (~14KB) — only consumer is the lazy AviationCommandBar
+            // (imports directly); kept off the eager @/config barrel above. (#4404)
+            if (id.endsWith('/src/config/airports.ts')) {
+              return 'airports-data';
+            }
             // Co-locate the deck.gl renderer with the deck vendor chunk so
             // onlyExplicitManualChunks cannot split deck's transitive deps
             // across the DeckGLMap boundary (which formed a circular chunk →


### PR DESCRIPTION
## Summary

Round 2 of the `main.js` diet (#4404), **first data table**. The ~62 KB `tech-geo` config table (`STARTUP_HUBS`/`ACCELERATORS`/`TECH_HQS`/`CLOUD_REGIONS`) sat on the eager dashboard critical path even though every consumer is lazy (search / map / globe / tech-hubs panel). The audit (see #4404) showed it was dragged eager by the `@/config` barrel value re-export **and** by `data-loader → tech-activity → tech-hub-index` running in the data-load cycle — a `manualChunks` rule alone is a no-op.

## Recipe (all parts required — build-proven)
- **config/index.ts** — drop the `tech-geo` **value** re-export from the eager `@/config` barrel (keep type re-exports; erased, no runtime edge).
- **Map.ts / DeckGLMap.ts / e2e/map-harness.ts** — import the tech-geo values directly from `@/config/tech-geo` (they pulled them via the eager barrel).
- **data-loader.ts** — lazy-load `tech-activity` in a new `applyTechHubActivities()` helper, guarded on the lazy `tech-hubs` panel being mounted, so the `tech-activity → tech-hub-index → tech-geo` chain no longer runs at boot. Degrades silently on load failure (non-critical panel data).
- **vite.config.ts** — `manualChunks` rule isolating `tech-geo` into its own `tech-geo-data` chunk.
- **tests/dashboard-eager-chunks.test.mjs** — dist-gated regression guard: asserts `tech-geo-data` stays out of `dashboard.html` modulepreload and is not statically imported by `main` (extensible to the remaining tables).

## Bundle impact (VITE_VARIANT=full)
| Asset | Before | After |
| --- | ---: | ---: |
| `main-*.js` raw | 1,021.7 KB | **996.4 KB** |
| `main-*.js` gzip | 300.2 KB | **293.7 KB** |
| `tech-geo-data` | (eager, in main's graph) | **51 KB raw / 11 KB gzip, lazy** |

## Verification
- `tsc --noEmit` clean (incl. `src/e2e`); full build has **0 "Circular chunk" warnings** (#4382 guard).
- `tech-geo-data` **absent** from `dist/dashboard.html` modulepreload and **not statically imported** by `main` (only lazy chunks: deck-stack/Map/MapContainer/search-manager/tech-activity).
- Runtime (preview): **WebGL map renders** (`maplibre` canvas, not the SVG fallback), **zero console errors**, `tech-geo` loads on demand with the map.
- 3/3 new regression tests + 7/7 `map-renderer-deferral` tests pass.

## Scope
First of the lazy-only tables in #4404. The same recipe extends to `airports` (14 KB) and `ai-datacenters` (86 KB, needs the `country-intel → related-assets` lazy-load); `geo.ts`/`feeds.ts` are genuinely boot-eager (separate issue); `panel-storage` is not deferrable.

Fixes part of #4404.

https://claude.ai/code/session_015Ae5Xavw1ZV4GMCWEsgKwe
