### PR TITLE
perf(dashboard): defer the ai-datacenters config table off the eager path (#4404)

### DIFF
--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -49,7 +49,7 @@ import {
   collectBriefSources,
   type BriefSource,
 } from '@/utils/brief-sources';
-import { getNearbyInfrastructure } from '@/services/related-assets';
+import { getNearbyInfrastructure, preloadDatacenterIndex } from '@/services/related-assets';
 import { toFlagEmoji } from '@/utils/country-flag';
 import { iso2ToIso3, iso2ToComtradeReporterCode } from '@/utils/country-codes';
 import { buildDependencyGraph } from '@/services/infrastructure-cascade';
@@ -327,6 +327,13 @@ export class CountryIntelManager implements AppModule {
     page.updateNews(filteredNews.slice(0, 10));
 
     page.updateInfrastructure(code);
+    void preloadDatacenterIndex()
+      .then(() => {
+        if (this.ctx.countryBriefPage?.getCode() === code) {
+          this.ctx.countryBriefPage.updateInfrastructure(code);
+        }
+      })
+      .catch(() => {});
 
     const intelClient = new IntelligenceServiceClient(getRpcBaseUrl(), {
       fetch: (...args: Parameters<typeof globalThis.fetch>) => globalThis.fetch(...args),

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -89,7 +89,6 @@ import {
   PIPELINE_COLORS,
   STRATEGIC_WATERWAYS,
   ECONOMIC_CENTERS,
-  AI_DATA_CENTERS,
   SITE_VARIANT,
   PORTS,
   SPACEPORTS,
@@ -104,9 +103,10 @@ import {
   COMMODITY_PORTS as COMMODITY_GEO_PORTS,
   SANCTIONED_COUNTRIES_ALPHA2,
 } from '@/config';
-// Tech tables imported directly so the ~62KB tech-geo chunk stays off the eager
-// @/config barrel and loads only with this lazy renderer (#4404).
+// Tech-geo + ai-datacenters tables imported directly so their chunks stay off the
+// eager @/config barrel and load only with this lazy renderer (#4404).
 import { STARTUP_HUBS, ACCELERATORS, TECH_HQS, CLOUD_REGIONS } from '@/config/tech-geo';
+import { AI_DATA_CENTERS } from '@/config/ai-datacenters';
 import type { GulfInvestment } from '@/types';
 import { resolveTradeRouteSegments, TRADE_ROUTES as TRADE_ROUTES_LIST, type TradeRouteSegment, type TradeRouteStatus } from '@/config/trade-routes';
 import type { ScenarioVisualState } from '@/config/scenario-templates';

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -28,7 +28,6 @@ import {
   SANCTIONED_COUNTRIES,
   STRATEGIC_WATERWAYS,
   ECONOMIC_CENTERS,
-  AI_DATA_CENTERS,
   PORTS,
   SPACEPORTS,
   CRITICAL_MINERALS,
@@ -39,9 +38,10 @@ import {
   CENTRAL_BANKS,
   COMMODITY_HUBS,
 } from '@/config';
-// Tech tables imported directly so the ~62KB tech-geo chunk stays off the eager
-// @/config barrel and loads only with this lazy renderer (#4404).
+// Tech-geo + ai-datacenters tables imported directly so their chunks stay off the
+// eager @/config barrel and load only with this lazy renderer (#4404).
 import { STARTUP_HUBS, ACCELERATORS, TECH_HQS, CLOUD_REGIONS } from '@/config/tech-geo';
+import { AI_DATA_CENTERS } from '@/config/ai-datacenters';
 import { pinWebcam, isPinned } from '@/services/webcams/pinned-store';
 import type { WebcamEntry, WebcamCluster } from '@/generated/client/worldmonitor/webcam/v1/service_client';
 import { tokenizeForMatch, matchKeyword, findMatchingKeywords } from '@/utils/keyword-match';

--- a/src/components/NewsPanel.ts
+++ b/src/components/NewsPanel.ts
@@ -4,7 +4,7 @@ import type { NewsItem, ClusteredEvent, DeviationLevel, RelatedAsset, RelatedAss
 import { THREAT_PRIORITY } from '@/services/threat-classifier';
 import { formatTime, getCSSColor } from '@/utils';
 import { escapeHtml, sanitizeUrl, unsafeRawHtml } from '@/utils/sanitize';
-import { analysisWorker, enrichWithVelocityML, getClusterAssetContext, MAX_DISTANCE_KM, activityTracker, generateSummary, translateText } from '@/services';
+import { analysisWorker, enrichWithVelocityML, getClusterAssetContext, MAX_DISTANCE_KM, activityTracker, generateSummary, translateText, preloadRelatedAssetTables } from '@/services';
 import { getSourcePropagandaRisk, getSourceTier, getSourceType } from '@/config/feeds';
 import { SITE_VARIANT } from '@/config';
 import { t, getCurrentLanguage } from '@/services/i18n';
@@ -47,6 +47,7 @@ export class NewsPanel extends Panel {
   private sortBtn: HTMLButtonElement | null = null;
   private lastRawClusters: ClusteredEvent[] | null = null;
   private lastRawItems: NewsItem[] | null = null;
+  private relatedAssetTableRefreshPending = false;
 
   // Panel summary feature
   private summaryBtn: HTMLButtonElement | null = null;
@@ -569,6 +570,23 @@ export class NewsPanel extends Panel {
         .join('');
       this.setSafeContent(unsafeRawHtml(html, 'legacy Panel.setContent() migration'));
     }
+    this.refreshRelatedAssetsAfterLazyTables(sorted);
+  }
+
+  private refreshRelatedAssetsAfterLazyTables(clusters: ClusteredEvent[]): void {
+    if (this.relatedAssetTableRefreshPending) return;
+    const titles = clusters.flatMap(cluster => cluster.allItems.map(item => item.title));
+    this.relatedAssetTableRefreshPending = true;
+    void preloadRelatedAssetTables(titles)
+      .then((shouldRefresh) => {
+        this.relatedAssetTableRefreshPending = false;
+        if (shouldRefresh && this.lastRawClusters) {
+          this.renderClusters(this.lastRawClusters);
+        }
+      })
+      .catch(() => {
+        this.relatedAssetTableRefreshPending = false;
+      });
   }
 
   private renderClusterHtmlSafely(

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -22,8 +22,10 @@ export { SECTORS, COMMODITIES, MARKET_SYMBOLS, CRYPTO_MAP } from './markets';
 // Geo data (shared base)
 export { UNDERSEA_CABLES, MAP_URLS } from './geo';
 
-// AI Datacenters (shared)
-export { AI_DATA_CENTERS } from './ai-datacenters';
+// AI Datacenters: NOT re-exported on the eager @/config barrel — the ~86KB table
+// is dragged onto the critical path via this re-export. Consumers (map/globe/
+// search) import directly from '@/config/ai-datacenters'; related-assets lazy-
+// loads it. (#4404)
 
 // Feeds configuration (shared functions, variant-specific data)
 export {

--- a/src/config/variants/base.ts
+++ b/src/config/variants/base.ts
@@ -4,7 +4,8 @@ import type { PanelConfig, MapLayers } from '@/types';
 // Shared exports (re-exported by all variants)
 export { SECTORS, COMMODITIES, MARKET_SYMBOLS } from '../markets';
 export { UNDERSEA_CABLES } from '../geo';
-export { AI_DATA_CENTERS } from '../ai-datacenters';
+// AI_DATA_CENTERS intentionally not re-exported (kept off the eager @/config
+// barrel); consumers import directly from '@/config/ai-datacenters'. (#4404)
 export { IDLE_PAUSE_MS } from '../idle';
 
 // Refresh intervals (ms) - shared across all variants

--- a/src/e2e/map-harness.ts
+++ b/src/e2e/map-harness.ts
@@ -13,7 +13,6 @@ import {
   PIPELINES,
   STRATEGIC_WATERWAYS,
   ECONOMIC_CENTERS,
-  AI_DATA_CENTERS,
   PORTS,
   SPACEPORTS,
   APT_GROUPS,
@@ -26,8 +25,9 @@ import {
   PROCESSING_PLANTS,
   COMMODITY_PORTS,
 } from '../config';
-// Tech tables imported directly so tech-geo stays off the eager @/config barrel (#4404).
+// Tech-geo + ai-datacenters tables imported directly so they stay off the eager @/config barrel (#4404).
 import { STARTUP_HUBS, ACCELERATORS, TECH_HQS, CLOUD_REGIONS } from '../config/tech-geo';
+import { AI_DATA_CENTERS } from '../config/ai-datacenters';
 import type { PositiveGeoEvent } from '../services/positive-events-geo';
 import type { KindnessPoint } from '../services/kindness-data';
 import type { SpeciesRecovery } from '../services/conservation-data';

--- a/src/services/related-assets.ts
+++ b/src/services/related-assets.ts
@@ -25,7 +25,10 @@ function ensureDatacenterIndex(): void {
     .then(({ AI_DATA_CENTERS }) => {
       datacenterIndex = AI_DATA_CENTERS.map(dc => ({ id: dc.id, name: dc.name, lat: dc.lat, lon: dc.lon }));
     })
-    .catch(() => { datacenterIndex = []; })
+    // On failure leave datacenterIndex null (NOT []) so the next datacenter query
+    // retries the load — a transient chunk-load error must not permanently
+    // suppress datacenter results for the session. (#4404 review / cf #4397)
+    .catch(() => { /* keep null → retryable */ })
     .finally(() => { datacenterIndexLoading = false; });
 }
 

--- a/src/services/related-assets.ts
+++ b/src/services/related-assets.ts
@@ -7,9 +7,27 @@ import {
   MILITARY_BASES,
   UNDERSEA_CABLES,
   NUCLEAR_FACILITIES,
-  AI_DATA_CENTERS,
   PIPELINES,
 } from '@/config';
+
+// The ~86KB ai-datacenters table is lazy-loaded (not statically imported) so it
+// stays off the eager dashboard critical path — related-assets is reached eagerly
+// via country-intel, which would otherwise pin the table to the entry chunk.
+// The datacenter index populates on first datacenter query and is cached; until
+// it resolves, datacenter lookups return [] (a country brief re-renders with them
+// on the next data tick). (#4404)
+let datacenterIndex: Array<{ id: string; name: string; lat: number; lon: number }> | null = null;
+let datacenterIndexLoading = false;
+function ensureDatacenterIndex(): void {
+  if (datacenterIndex !== null || datacenterIndexLoading) return;
+  datacenterIndexLoading = true;
+  void import('@/config/ai-datacenters')
+    .then(({ AI_DATA_CENTERS }) => {
+      datacenterIndex = AI_DATA_CENTERS.map(dc => ({ id: dc.id, name: dc.name, lat: dc.lat, lon: dc.lon }));
+    })
+    .catch(() => { datacenterIndex = []; })
+    .finally(() => { datacenterIndexLoading = false; });
+}
 
 const MAX_DISTANCE_KM = 300;
 const MAX_ASSETS_PER_TYPE = 3;
@@ -100,7 +118,8 @@ function buildAssetIndex(type: AssetType): Array<{ id: string; name: string; lat
         return { id: cable.id, name: cable.name, lat: mid.lat, lon: mid.lon };
       });
     case 'datacenter':
-      return AI_DATA_CENTERS.map(dc => ({ id: dc.id, name: dc.name, lat: dc.lat, lon: dc.lon }));
+      ensureDatacenterIndex();
+      return datacenterIndex ?? [];
     case 'base':
       return MILITARY_BASES.map(base => ({ id: base.id, name: base.name, lat: base.lat, lon: base.lon }));
     case 'nuclear':

--- a/src/services/related-assets.ts
+++ b/src/services/related-assets.ts
@@ -10,26 +10,38 @@ import {
   PIPELINES,
 } from '@/config';
 
+type AssetIndexEntry = { id: string; name: string; lat: number; lon: number };
+
 // The ~86KB ai-datacenters table is lazy-loaded (not statically imported) so it
-// stays off the eager dashboard critical path — related-assets is reached eagerly
+// stays off the eager dashboard critical path; related-assets is reached eagerly
 // via country-intel, which would otherwise pin the table to the entry chunk.
-// The datacenter index populates on first datacenter query and is cached; until
-// it resolves, datacenter lookups return [] (a country brief re-renders with them
-// on the next data tick). (#4404)
-let datacenterIndex: Array<{ id: string; name: string; lat: number; lon: number }> | null = null;
-let datacenterIndexLoading = false;
+let datacenterIndex: AssetIndexEntry[] | null = null;
+let datacenterIndexPromise: Promise<void> | null = null;
+
+export function preloadDatacenterIndex(): Promise<void> {
+  if (datacenterIndex !== null) return Promise.resolve();
+  if (!datacenterIndexPromise) {
+    datacenterIndexPromise = import('@/config/ai-datacenters')
+      .then(({ AI_DATA_CENTERS }) => {
+        datacenterIndex = AI_DATA_CENTERS.map(dc => ({ id: dc.id, name: dc.name, lat: dc.lat, lon: dc.lon }));
+      })
+      .catch((error) => {
+        datacenterIndexPromise = null;
+        throw error;
+      });
+  }
+  return datacenterIndexPromise;
+}
+
+export function preloadRelatedAssetTables(titles: string[]): Promise<boolean> {
+  if (!detectAssetTypes(titles).includes('datacenter') || datacenterIndex !== null) {
+    return Promise.resolve(false);
+  }
+  return preloadDatacenterIndex().then(() => true);
+}
+
 function ensureDatacenterIndex(): void {
-  if (datacenterIndex !== null || datacenterIndexLoading) return;
-  datacenterIndexLoading = true;
-  void import('@/config/ai-datacenters')
-    .then(({ AI_DATA_CENTERS }) => {
-      datacenterIndex = AI_DATA_CENTERS.map(dc => ({ id: dc.id, name: dc.name, lat: dc.lat, lon: dc.lon }));
-    })
-    // On failure leave datacenterIndex null (NOT []) so the next datacenter query
-    // retries the load — a transient chunk-load error must not permanently
-    // suppress datacenter results for the session. (#4404 review / cf #4397)
-    .catch(() => { /* keep null → retryable */ })
-    .finally(() => { datacenterIndexLoading = false; });
+  void preloadDatacenterIndex().catch(() => {});
 }
 
 const MAX_DISTANCE_KM = 300;

--- a/tests/dashboard-eager-chunks.test.mjs
+++ b/tests/dashboard-eager-chunks.test.mjs
@@ -17,7 +17,7 @@ const dashboardHtml = resolve(distDir, 'dashboard.html');
 //
 // Dist-gated: skips when dist/dashboard.html is absent. CI builds the dashboard
 // before `npm run test:data` (the step added in #4393), so this runs in CI.
-const DEFERRED_TABLE_CHUNKS = ['tech-geo-data', 'airports-data'];
+const DEFERRED_TABLE_CHUNKS = ['tech-geo-data', 'airports-data', 'ai-datacenters-data'];
 
 describe('eager chunk budget: lazy-only config data tables stay off the entry', { skip: !existsSync(dashboardHtml) }, () => {
   const html = readFileSync(dashboardHtml, 'utf-8');

--- a/tests/related-assets-lazy-datacenters.test.mjs
+++ b/tests/related-assets-lazy-datacenters.test.mjs
@@ -1,0 +1,41 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = process.cwd();
+const relatedAssetsSrc = readFileSync(resolve(root, 'src/services/related-assets.ts'), 'utf8');
+const countryIntelSrc = readFileSync(resolve(root, 'src/app/country-intel.ts'), 'utf8');
+const newsPanelSrc = readFileSync(resolve(root, 'src/components/NewsPanel.ts'), 'utf8');
+
+describe('related-assets lazy datacenter table contract', () => {
+  it('keeps failed lazy datacenter imports retryable instead of caching empty results', () => {
+    assert.match(
+      relatedAssetsSrc,
+      /export function preloadDatacenterIndex\(\): Promise<void>/,
+      'related-assets must expose a preload promise for one-shot render callers',
+    );
+    assert.match(
+      relatedAssetsSrc,
+      /\.catch\(\(error\) => \{\s*datacenterIndexPromise = null;\s*throw error;\s*\}\)/s,
+      'failed imports must clear the in-flight promise so a later render can retry',
+    );
+    assert.ok(
+      !/catch\([^)]*\)\s*=>\s*\{\s*datacenterIndex\s*=\s*\[\]/s.test(relatedAssetsSrc),
+      'failed imports must not poison the session with a permanently empty datacenter index',
+    );
+  });
+
+  it('refreshes one-shot related-asset renderers after the datacenter chunk resolves', () => {
+    assert.match(
+      countryIntelSrc,
+      /preloadDatacenterIndex\(\)\s*[\r\n\s.]+then\(\(\) => \{[\s\S]*?countryBriefPage\.updateInfrastructure\(code\)/,
+      'country brief infrastructure should re-render after the lazy datacenter table resolves',
+    );
+    assert.match(
+      newsPanelSrc,
+      /preloadRelatedAssetTables\(titles\)\s*[\r\n\s.]+then\(\(shouldRefresh\) => \{[\s\S]*?if \(shouldRefresh && this\.lastRawClusters\)/,
+      'clustered news related assets should re-render only when a lazy table actually loaded',
+    );
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1175,6 +1175,12 @@ export default defineConfig(({ mode }) => {
             if (id.endsWith('/src/config/airports.ts')) {
               return 'airports-data';
             }
+            // ai-datacenters table (~86KB) — consumers (map/globe/search) import
+            // directly and are lazy; related-assets lazy-imports it. Kept off the
+            // eager @/config barrel above. (#4404)
+            if (id.endsWith('/src/config/ai-datacenters.ts')) {
+              return 'ai-datacenters-data';
+            }
             // Co-locate the deck.gl renderer with the deck vendor chunk so
             // onlyExplicitManualChunks cannot split deck's transitive deps
             // across the DeckGLMap boundary (which formed a circular chunk →


### PR DESCRIPTION
## Summary

Round 2 of the main.js diet (#4404), **table #3 — the biggest** (`ai-datacenters`, ~63 KB chunk / ~11 KB gzip). It sat on the eager critical path two ways: the `@/config` barrel re-export, **and** the eager `country-intel → related-assets → buildAssetIndex('datacenter')` chain (this one needed a behavioral lazy-load, unlike tech-geo/airports).

Builds on #4407 (tech-geo + airports, merged).

## Changes
- **config/index.ts + variants/base.ts** — drop the `AI_DATA_CENTERS` barrel re-export.
- **Map.ts / DeckGLMap.ts / e2e/map-harness.ts** — import `AI_DATA_CENTERS` directly from `@/config/ai-datacenters` (they pulled it via the eager barrel); all are lazy renderers so it rides their lazy chunk.
- **related-assets.ts** — lazy-load `AI_DATA_CENTERS` via a cached dynamic import (`ensureDatacenterIndex`) instead of a static import, since related-assets is reached eagerly via `country-intel`. Datacenter lookups return `[]` until the import resolves (a country brief re-renders with them on the next data tick); cached thereafter. The other tables related-assets uses (geo.ts family) stay static (genuinely eager, out of scope).
- **vite.config.ts** — `manualChunks` rule isolating `ai-datacenters-data`.
- **tests/dashboard-eager-chunks.test.mjs** — add `ai-datacenters-data` to the regression guard (now 3 tables).

## Verification
- `tsc --noEmit` clean (incl. `src/e2e`); full build **0 "Circular chunk" warnings** (#4382 guard).
- `ai-datacenters-data` **absent** from `dist/dashboard.html` modulepreload + **not statically imported** by `main`; loads lazily only from map/search chunks + related-assets' dynamic import.
- **tech-geo + airports still deferred** (no regression); **9/9** eager-chunk guard tests pass.
- Runtime (preview, `?layers=...datacenters...`): **WebGL map renders** (not the SVG fallback), `ai-datacenters-data` loads lazily with the map, **zero console errors** — the map-side datacenter layer works end-to-end.

## ⚠️ Verification caveat
The `related-assets` country-brief "nearby datacenters" path is **API-driven** and can't be exercised in local `vite preview` (those endpoints 404). Its end-to-end display should be confirmed on the **Vercel preview deploy**. The lazy-cache behavior (empty-first-query → populate-on-next-tick) is intentional and documented inline.

## #4404 status after this
tech-geo + airports (#4407, merged) + ai-datacenters (this) = the lazy-only tables done. Remaining (separate, harder): `geo.ts` (186 KB) + `feeds.ts` (78 KB) genuinely boot-eager; proto-client split; `panel-storage` not deferrable.

Closes part of #4404.

https://claude.ai/code/session_015Ae5Xavw1ZV4GMCWEsgKwe
