### PR TITLE
test(map): follow aliased deckgl import graph

### DIFF
--- a/tests/map-renderer-deferral.test.mjs
+++ b/tests/map-renderer-deferral.test.mjs
@@ -66,42 +66,37 @@ function tsconfigPathMappings() {
   ));
 }
 
-const pathMappings = tsconfigPathMappings();
+let cachedPathMappings = null;
+
+function pathMappings() {
+  cachedPathMappings ??= tsconfigPathMappings();
+  return cachedPathMappings;
+}
+
+function matchPathPattern(specifier, pattern) {
+  const wildcardIndex = pattern.indexOf('*');
+  if (wildcardIndex === -1) {
+    return specifier === pattern ? '' : null;
+  }
+
+  const prefix = pattern.slice(0, wildcardIndex);
+  const suffix = pattern.slice(wildcardIndex + 1);
+  if (!specifier.startsWith(prefix) || !specifier.endsWith(suffix)) return null;
+
+  return specifier.slice(prefix.length, specifier.length - suffix.length);
+}
 
 function resolvePathMappedSource(specifier) {
   let matchedPath = false;
-  for (const { pattern, target } of pathMappings) {
-    const wildcardIndex = pattern.indexOf('*');
-    if (wildcardIndex === -1) {
-      if (specifier !== pattern) continue;
-      matchedPath = true;
-      const resolved = sourcePathCandidate(resolve(root, target));
-      if (resolved) return resolved;
-      continue;
-    }
-
-    const prefix = pattern.slice(0, wildcardIndex);
-    const suffix = pattern.slice(wildcardIndex + 1);
-    if (!specifier.startsWith(prefix) || !specifier.endsWith(suffix)) continue;
-
+  for (const { pattern, target } of pathMappings()) {
+    const matched = matchPathPattern(specifier, pattern);
+    if (matched === null) continue;
     matchedPath = true;
-    const matched = specifier.slice(prefix.length, specifier.length - suffix.length);
     const targetBase = target.replace('*', matched);
     const resolved = sourcePathCandidate(resolve(root, targetBase));
-    if (resolved) return resolved;
+    if (resolved) return { matched: true, fileName: resolved };
   }
-  if (matchedPath) return null;
-  return null;
-}
-
-function matchesTsconfigPath(specifier) {
-  return pathMappings.some(({ pattern }) => {
-    const wildcardIndex = pattern.indexOf('*');
-    if (wildcardIndex === -1) return specifier === pattern;
-    const prefix = pattern.slice(0, wildcardIndex);
-    const suffix = pattern.slice(wildcardIndex + 1);
-    return specifier.startsWith(prefix) && specifier.endsWith(suffix);
-  });
+  return { matched: matchedPath, fileName: null };
 }
 
 function resolveInRepoSpecifier(fromFileName, specifier) {
@@ -115,7 +110,7 @@ function resolveInRepoSpecifier(fromFileName, specifier) {
   }
 
   const resolved = resolvePathMappedSource(specifier);
-  if (resolved || !matchesTsconfigPath(specifier)) return resolved;
+  if (resolved.fileName || !resolved.matched) return resolved.fileName;
 
   assert.fail(`Static path alias import ${specifier} from ${rootRelative(fromFileName)} must resolve to a real file`);
 }

--- a/tests/map-renderer-deferral.test.mjs
+++ b/tests/map-renderer-deferral.test.mjs
@@ -1,12 +1,17 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, extname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import ts from 'typescript';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
+const sourceExtensions = new Set(['.ts', '.tsx', '.mts', '.js', '.mjs']);
+
+function rootRelative(fileName) {
+  return relative(root, fileName) || '.';
+}
 
 function parseSource(relPath) {
   const fileName = resolve(root, relPath);
@@ -30,9 +35,7 @@ function staticValueImports(sourceFile) {
   return specifiers;
 }
 
-function resolveRelativeSource(fromFileName, specifier) {
-  if (!specifier.startsWith('.')) return null;
-  const base = resolve(dirname(fromFileName), specifier);
+function sourcePathCandidate(base) {
   const candidates = [
     base,
     `${base}.ts`,
@@ -45,7 +48,76 @@ function resolveRelativeSource(fromFileName, specifier) {
     resolve(base, 'index.js'),
     resolve(base, 'index.mjs'),
   ];
-  return candidates.find((candidate) => existsSync(candidate)) ?? null;
+  return candidates.find((candidate) => existsSync(candidate) && statSync(candidate).isFile()) ?? null;
+}
+
+function isSourceFile(fileName) {
+  return sourceExtensions.has(extname(fileName));
+}
+
+function tsconfigPathMappings() {
+  const configPath = resolve(root, 'tsconfig.json');
+  const source = readFileSync(configPath, 'utf-8');
+  const parsed = ts.parseConfigFileTextToJson(configPath, source);
+  assert.ifError(parsed.error ? new Error(ts.flattenDiagnosticMessageText(parsed.error.messageText, '\n')) : null);
+  const paths = parsed.config?.compilerOptions?.paths ?? {};
+  return Object.entries(paths).flatMap(([pattern, targets]) => (
+    (Array.isArray(targets) ? targets : []).map((target) => ({ pattern, target }))
+  ));
+}
+
+const pathMappings = tsconfigPathMappings();
+
+function resolvePathMappedSource(specifier) {
+  let matchedPath = false;
+  for (const { pattern, target } of pathMappings) {
+    const wildcardIndex = pattern.indexOf('*');
+    if (wildcardIndex === -1) {
+      if (specifier !== pattern) continue;
+      matchedPath = true;
+      const resolved = sourcePathCandidate(resolve(root, target));
+      if (resolved) return resolved;
+      continue;
+    }
+
+    const prefix = pattern.slice(0, wildcardIndex);
+    const suffix = pattern.slice(wildcardIndex + 1);
+    if (!specifier.startsWith(prefix) || !specifier.endsWith(suffix)) continue;
+
+    matchedPath = true;
+    const matched = specifier.slice(prefix.length, specifier.length - suffix.length);
+    const targetBase = target.replace('*', matched);
+    const resolved = sourcePathCandidate(resolve(root, targetBase));
+    if (resolved) return resolved;
+  }
+  if (matchedPath) return null;
+  return null;
+}
+
+function matchesTsconfigPath(specifier) {
+  return pathMappings.some(({ pattern }) => {
+    const wildcardIndex = pattern.indexOf('*');
+    if (wildcardIndex === -1) return specifier === pattern;
+    const prefix = pattern.slice(0, wildcardIndex);
+    const suffix = pattern.slice(wildcardIndex + 1);
+    return specifier.startsWith(prefix) && specifier.endsWith(suffix);
+  });
+}
+
+function resolveInRepoSpecifier(fromFileName, specifier) {
+  if (specifier.startsWith('.')) {
+    const resolved = sourcePathCandidate(resolve(dirname(fromFileName), specifier));
+    assert.ok(
+      resolved,
+      `Static import ${specifier} from ${rootRelative(fromFileName)} must resolve to a real file`,
+    );
+    return resolved;
+  }
+
+  const resolved = resolvePathMappedSource(specifier);
+  if (resolved || !matchesTsconfigPath(specifier)) return resolved;
+
+  assert.fail(`Static path alias import ${specifier} from ${rootRelative(fromFileName)} must resolve to a real file`);
 }
 
 function staticValueImportGraph(entryRelPath) {
@@ -60,8 +132,8 @@ function staticValueImportGraph(entryRelPath) {
 
     for (const specifier of staticValueImports(sourceFile)) {
       imports.add(specifier);
-      const resolved = resolveRelativeSource(sourceFile.fileName, specifier);
-      if (resolved) visit(resolved);
+      const resolved = resolveInRepoSpecifier(sourceFile.fileName, specifier);
+      if (resolved && isSourceFile(resolved)) visit(resolved);
     }
   };
 
@@ -161,6 +233,30 @@ describe('map renderer deferral boundary', () => {
         `DeckGLMap import graph must avoid static optional WebGL package ${specifier}`,
       );
     }
+  });
+
+  it('walks tsconfig path aliases in the DeckGLMap static import graph', () => {
+    const imports = staticValueImportGraph('src/components/DeckGLMap.ts');
+
+    assert.ok(
+      imports.has('@/services/bootstrap'),
+      'DeckGLMap graph should traverse @/-aliased transitive imports, not only direct relative imports',
+    );
+    assert.ok(
+      imports.has('./feeds'),
+      'DeckGLMap graph should resolve @/config and traverse its relative re-export edges',
+    );
+  });
+
+  it('fails loudly when an in-repo static import edge cannot be resolved', () => {
+    assert.throws(
+      () => resolveInRepoSpecifier(resolve(root, 'src/components/DeckGLMap.ts'), '@/missing/deckgl-test-fixture'),
+      /must resolve to a real file/,
+    );
+    assert.throws(
+      () => resolveInRepoSpecifier(resolve(root, 'src/components/DeckGLMap.ts'), './missing-deckgl-test-fixture'),
+      /must resolve to a real file/,
+    );
   });
 
   it('keeps provider-specific PMTiles deps out of the emitted MapLibre manual chunk', () => {


### PR DESCRIPTION
## Summary

- Teach the map renderer deferral import-graph test to resolve `@/*` aliases from `tsconfig.json`.
- Make in-repo static import edges fail loudly when a relative or matched alias specifier cannot resolve.
- Add regression assertions proving the DeckGLMap graph now follows aliased transitive imports and `@/config` barrel re-export edges.

## Intent

Fixes #4399. The goal is to make the deck.gl optional-package guard cover the realistic `@/`-aliased re-entry path instead of only scanning `DeckGLMap.ts` plus a few relative siblings.

Non-goals: no production renderer changes, no bundle strategy changes, no UI changes.

## Validation Matrix

| Check | Reason | Result |
|---|---|---|
| `node --test tests/map-renderer-deferral.test.mjs` | Focused regression guard for map renderer deferral and import graph traversal | Pass: 9/9 tests |
| `git diff --check` | Whitespace/conflict sanity before publish | Pass |

## Review Gates

- Baseline Reviewer: Pass. New tests use stable import specifiers and real source edges, with no line-number or snapshot-only assertions.
- Code Review Expert: Pass. Required checklist review completed; one robustness note was fixed before publish by using TypeScript's tsconfig parser and by trying all matching path targets before failing.
- Outcome Reviewer: Pass. The diff satisfies the issue contract: alias traversal is covered, missing in-repo edges fail, and dynamic PMTiles/Protomaps imports remain outside the static value graph.

## Documentation

Not applicable. Test-only hardening of an existing regression guard.

## Screenshots / UI Evidence

Not applicable. No user-visible UI change.

## Residual Findings

None.
