### PR TITLE
fix(csp): suppress stale Google font reports

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -176,7 +176,7 @@ function shouldSuppressCspViolation(
   if (directive === 'font-src') {
     try {
       const url = new URL(blockedURI);
-      if (url.protocol === 'https:' && url.hostname === 'fonts.gstatic.com' && /^\/s\/.+\.woff2(?:$|\?)/.test(url.pathname + url.search)) return true;
+      if (url.protocol === 'https:' && url.hostname === 'fonts.gstatic.com' && /^\/s\/.+\.woff2$/.test(url.pathname)) return true;
     } catch { /* scheme-only values fall through */ }
   }
   // YouTube live stream manifests.

--- a/src/main.ts
+++ b/src/main.ts
@@ -169,6 +169,16 @@ function shouldSuppressCspViolation(
   if (/manifest\.webmanifest$/.test(blockedURI)) return true;
   // Third-party injectors: Google Translate, Facebook Pixel.
   if (/gstatic\.com\/_\/translate/.test(blockedURI) || /facebook\.net/.test(blockedURI)) return true;
+  // Google Fonts font files from stale or injected stylesheets. The dashboard now
+  // self-hosts its own fonts and the deploy/config tests keep Google Fonts out of
+  // dashboard CSP/source surfaces; if a user's browser still tries
+  // fonts.gstatic.com/s/*.woff2, the strict font-src block is expected noise.
+  if (directive === 'font-src') {
+    try {
+      const url = new URL(blockedURI);
+      if (url.protocol === 'https:' && url.hostname === 'fonts.gstatic.com' && /^\/s\/.+\.woff2(?:$|\?)/.test(url.pathname + url.search)) return true;
+    } catch { /* scheme-only values fall through */ }
+  }
   // YouTube live stream manifests.
   if (/googlevideo\.com|youtube\.com\/generate_204/.test(blockedURI)) return true;
   // Corporate/school content filter injections.

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -197,6 +197,14 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       assert.ok(suppress('enforce', 'font-src', 'https://fonts.gstatic.com/s/mulish/v18/1Ptvg83HX_SGhgqk2wotcqA.woff2', '', false));
     });
 
+    it('suppresses Google Fonts font files with query params', () => {
+      assert.ok(suppress('enforce', 'font-src', 'https://fonts.gstatic.com/s/mulish/v18/1Ptvg83HX_SGhgqk2wotcqA.woff2?display=swap', '', false));
+    });
+
+    it('does NOT suppress non-woff2 Google Fonts paths with woff2 query values', () => {
+      assert.ok(!suppress('enforce', 'font-src', 'https://fonts.gstatic.com/s/mulish/v18/font.woff?kit=abc.woff2', '', false));
+    });
+
     it('does NOT suppress arbitrary third-party font-src hosts', () => {
       assert.ok(!suppress('enforce', 'font-src', 'https://fonts.evil.example/s/mulish/v18/font.woff2', '', false));
     });

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -193,6 +193,18 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       assert.ok(suppress('enforce', 'connect-src', 'https://translate.gstatic.com/_/translate_http', '', false));
     });
 
+    it('suppresses Google Fonts font files from stale or injected stylesheets', () => {
+      assert.ok(suppress('enforce', 'font-src', 'https://fonts.gstatic.com/s/mulish/v18/1Ptvg83HX_SGhgqk2wotcqA.woff2', '', false));
+    });
+
+    it('does NOT suppress arbitrary third-party font-src hosts', () => {
+      assert.ok(!suppress('enforce', 'font-src', 'https://fonts.evil.example/s/mulish/v18/font.woff2', '', false));
+    });
+
+    it('does NOT suppress Google Fonts under unrelated directives', () => {
+      assert.ok(!suppress('enforce', 'script-src', 'https://fonts.gstatic.com/s/mulish/v18/1Ptvg83HX_SGhgqk2wotcqA.woff2', '', false));
+    });
+
     it('suppresses Facebook Pixel', () => {
       assert.ok(suppress('enforce', 'connect-src', 'https://connect.facebook.net/en_US/fbevents.js', '', false));
     });


### PR DESCRIPTION
## Summary
- suppress expected dashboard CSP reports for stale/injected Google Fonts woff2 loads
- keep the dashboard font CSP strict; this does not re-allow Google Fonts
- add regression coverage so arbitrary font hosts and unrelated directives still report

## Verification
- ./node_modules/.bin/tsx --test tests/csp-filter.test.mjs
- npm run typecheck
- git diff --check
- pre-push hook: typecheck, API typecheck, changed tests, edge function tests