### PR TITLE
fix(a11y): polish phase-23 controls (follow-up to #4412)

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -5255,7 +5255,7 @@ export class DeckGLMap {
               <span class="toggle-icon">${icon}</span>
               <span class="toggle-label">${label}${isLocked ? ' \uD83D\uDD12' : ''}${isEnhanced ? ' <span class="layer-pro-badge">PRO</span>' : ''}</span>
             </label>
-            <button type="button" class="layer-explain-btn${hasExplanation ? ' has-layer-explanation' : ''}" data-layer="${key}" aria-label="${explainLabel}" title="${explainLabel}">i</button>
+            <button type="button" class="layer-explain-btn${hasExplanation ? ' has-layer-explanation' : ''}" data-layer="${key}" aria-label="${explainLabel}">i</button>
           </div>`;
         }).join('')}
       </div>

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -5240,7 +5240,7 @@ export class DeckGLMap {
     setTrustedHtml(toggles, trustedHtml(`
       <div class="toggle-header">
         <span>${t('components.deckgl.layersTitle')}</span>
-        <button class="layer-help-btn" title="${t('components.deckgl.layerGuide')}" aria-label="${t('components.deckgl.layerGuide')}">?</button>
+        <button class="layer-help-btn" aria-label="${t('components.deckgl.layerGuide')}">?</button>
         <button class="toggle-collapse">&#9660;</button>
       </div>
       <input type="text" class="layer-search" placeholder="${t('components.deckgl.layerSearch')}" autocomplete="off" spellcheck="false" />

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -5178,6 +5178,9 @@ body.playback-mode .status-dot {
 }
 
 .layer-help-btn {
+  /* WCAG 2.5.8 / issue #3112: 48x48 hit area. margin:-12px 0 keeps the box
+     flush with its toggle-header siblings while ::before (inset:12px) renders
+     the visible 24px circle centred inside the 48px clickable target. */
   position: relative;
   width: 48px;
   height: 48px;
@@ -16417,6 +16420,9 @@ a.prediction-link:hover {
 
 .deckgl-time-slider .time-options {
   display: flex;
+  /* Wrap instead of overflowing the viewport: six 48px touch targets (issue
+     #3112) exceed the narrowest phone widths on a single row. */
+  flex-wrap: wrap;
   gap: 2px;
 }
 


### PR DESCRIPTION
## Summary

Small code-review follow-up to #4412 (merged) — three P3 a11y polish items surfaced by a multi-reviewer review of the merged result. #4412 merged before these could be pushed to its branch, so they land here against current `main`.

- **Drop the redundant `title` on the layer-help "?" button** (keep `aria-label`). #4412 added `aria-label="${t('components.deckgl.layerGuide')}"` but kept an identical `title=`, so some AT double-announce "Layer Guide". `aria-label` alone is the right accessible name for an icon button (matches the title-only sibling zoom buttons' single-source-of-name approach).
- **Wrap the time-range controls** (`.deckgl-time-slider .time-options { flex-wrap: wrap }`). #4412 enlarged the six time buttons to 48×48 touch targets; the slider is `position:absolute` with no width/wrap, so on the narrowest phones (~320px) the ~324px single row overflowed the viewport. Wrapping preserves the 48px targets and fits narrow widths.
- **Document the `.layer-help-btn` 48px-hit / 24px-visual `::before` pattern** so a future editor doesn't strip the load-bearing `margin:-12px 0`.

## Validation

- `node --test tests/a11y-issue-4373-invariants.test.mjs` — 17/17 pass
- `npx biome lint src/components/DeckGLMap.ts` — clean
- Pre-push hook (full changed-test suite + version sync) — pass

Refs #3112. Follow-up to #4412.