### PR TITLE
fix(a11y): clear desktop color-contrast (panel-count + correlation badge) — #4418

### DIFF
--- a/src/components/CorrelationPanel.ts
+++ b/src/components/CorrelationPanel.ts
@@ -12,11 +12,14 @@ function getCorrelationBootstrap(): Record<string, ConvergenceCard[]> | null {
   return correlationBootstrap;
 }
 
+// These are used as the score-badge BACKGROUND with white (#fff) text.
+// `low` darkened from #888888 → #6f6f6f so white text clears WCAG AA (4.5:1):
+// white-on-#888888 was 3.54, white-on-#6f6f6f is ~5.0. (See #4418.)
 const SCORE_COLORS = {
   critical: '#ff4444',
   high: '#ff8800',
   medium: '#ffcc00',
-  low: '#888888',
+  low: '#6f6f6f',
 };
 
 const TREND_ICONS: Record<string, { symbol: string; color: string }> = {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1962,7 +1962,7 @@ body.panel-resize-active iframe {
   0% {
     transform: scale(1);
     background: var(--border);
-    color: var(--text-dim);
+    color: var(--text-secondary);
   }
 
   40% {
@@ -1974,7 +1974,7 @@ body.panel-resize-active iframe {
   100% {
     transform: scale(1);
     background: var(--border);
-    color: var(--text-dim);
+    color: var(--text-secondary);
   }
 }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1945,7 +1945,9 @@ body.panel-resize-active iframe {
 
 .panel-count {
   font-size: 10px;
-  color: var(--text-dim);
+  /* --text-dim (#888) on --border fails WCAG AA (4.04:1 on #2a2a2a / 3.6:1 light);
+     --text-secondary is tuned per-theme and clears 4.5:1 on every theme's --border. */
+  color: var(--text-secondary);
   background: var(--border);
   padding: 2px 6px;
   border-radius: 2px;


### PR DESCRIPTION
## Summary

Closes the only remaining desktop Accessibility failure → **97 → 100** (mobile already 100). Two WCAG-AA `color-contrast` fixes from the audit:

- **`.panel-count`** badge: `var(--text-dim)` (#888) on `var(--border)` was 4.04:1 (dark) / 3.6:1 (light). Now `var(--text-secondary)` — **theme-tuned**, clears 4.5:1 on every theme's `--border` (dark 8.9, light 8.5, happy light & dark both pass). No hardcoded per-theme values → robust across dark/light/happy/variants.
- **CorrelationPanel score badge**: `SCORE_COLORS.low` `#888888 → #6f6f6f` so the white badge text clears AA (3.54 → ~5.0). `low` is *only* the badge background (verified); the trend-arrow `#888` is a different context and left unchanged.

## Verification
- [x] Local Lighthouse desktop **Accessibility = 100, `color-contrast` PASS**
- [x] tsc + typecheck:api clean; full `VITE_VARIANT=full` build 0 circular chunks
- [x] `test:data` 11,617 / 0; lint, lint:md, version green
- [x] No tests referenced the changed values
- [ ] Post-deploy: confirm desktop a11y 100 on prod; no visual regression on panel-count badges / correlation cards

## Out of scope (follow-up)
The other correlation score-badge colors (critical `#ff4444` / high `#ff8800` / medium `#ffcc00`) also fail white-text contrast, but weren't surfaced by the audit (no critical/high/medium cards rendered). They need per-color text or darker backgrounds (yellow especially needs dark text) — a small badge-contrast follow-up, separate from this audited fix.