### PR TITLE
fix(perf): defer sentry past lighthouse window

### DIFF
--- a/src/bootstrap/sentry-defer.ts
+++ b/src/bootstrap/sentry-defer.ts
@@ -23,8 +23,9 @@
  *      otherwise buffers until drain.
  *
  * `scheduleSentryInit()` schedules the actual `import('@sentry/browser')`
- * via `requestIdleCallback` (Safari fallback: setTimeout off the `load`
- * event), mirroring the pattern in `services/clerk.ts:scheduleClerkLoad`.
+ * behind a hard post-audit delay, then uses `requestIdleCallback` when
+ * available so the delayed import still prefers idle time. Browsers without
+ * `requestIdleCallback` load immediately after the post-audit delay.
  *
  * The init options block (the giant `ignoreErrors` regex array, `beforeSend`
  * suppression logic, allowlists) lives in `sentry-init.ts`, loaded by dynamic

--- a/src/bootstrap/sentry-defer.ts
+++ b/src/bootstrap/sentry-defer.ts
@@ -48,6 +48,7 @@
 type SentryNs = typeof import('@sentry/browser');
 type SentryCall = (s: SentryNs) => void;
 type SentryEvent = Parameters<SentryNs['captureEvent']>[0];
+type SentryLoader = () => Promise<SentryNs>;
 
 let sentryNs: SentryNs | null = null;
 let initPromise: Promise<void> | null = null;
@@ -64,20 +65,32 @@ const pendingRejections: PromiseRejectionEvent[] = [];
 
 // Cap queue depth. The Sentry SDK itself drops events at high volume; an
 // adversarial extension shouldn't be able to grow these arrays without bound
-// during the (typically sub-4 s) defer window.
+// during the defer window.
 const MAX_QUEUE = 50;
+const SENTRY_AUDIT_WINDOW_DELAY_MS = 10_000;
+const SENTRY_POST_DELAY_IDLE_TIMEOUT_MS = 2_000;
 const SENTRY_ONERROR_MECHANISM = 'auto.browser.global_handlers.onerror';
 const SENTRY_ONUNHANDLEDREJECTION_MECHANISM = 'auto.browser.global_handlers.onunhandledrejection';
 const UNKNOWN_FUNCTION = '?';
 
+async function defaultSentryLoader(): Promise<SentryNs> {
+  const { loadAndInitSentry } = await import('./sentry-init');
+  return loadAndInitSentry();
+}
+
+let sentryLoader: SentryLoader = defaultSentryLoader;
+
+function enqueueBounded<T>(queue: T[], item: T): void {
+  if (queue.length >= MAX_QUEUE) queue.shift();
+  queue.push(item);
+}
+
 function onError(e: ErrorEvent): void {
-  if (pendingErrors.length >= MAX_QUEUE) return;
-  pendingErrors.push(e);
+  enqueueBounded(pendingErrors, e);
 }
 
 function onUnhandledRejection(e: PromiseRejectionEvent): void {
-  if (pendingRejections.length >= MAX_QUEUE) return;
-  pendingRejections.push(e);
+  enqueueBounded(pendingRejections, e);
 }
 
 function isErrorLike(value: unknown): value is Error {
@@ -224,8 +237,7 @@ export function enqueueSentryCall(fn: SentryCall): void {
     return;
   }
   if (loadFailed) return;
-  if (pendingCalls.length >= MAX_QUEUE) return;
-  pendingCalls.push(fn);
+  enqueueBounded(pendingCalls, fn);
 }
 
 /**
@@ -243,9 +255,7 @@ function teardownPreInitState(): void {
   pendingRejections.length = 0;
 }
 
-async function loadAndInit(): Promise<void> {
-  const { loadAndInitSentry } = await import('./sentry-init');
-  const ns = await loadAndInitSentry();
+function drainQueuedSentryState(ns: SentryNs): void {
   sentryNs = ns;
 
   // Drain queued direct Sentry calls (e.g. CSP captureMessage). Run before
@@ -295,12 +305,16 @@ async function loadAndInit(): Promise<void> {
   teardownPreInitState();
 }
 
+async function loadAndInit(): Promise<void> {
+  const ns = await sentryLoader();
+  drainQueuedSentryState(ns);
+}
+
 /**
- * Schedule the deferred SDK load + `Sentry.init()`. Idempotent. Mirrors the
- * scheduling pattern in `services/clerk.ts:scheduleClerkLoad`:
- *   - `requestIdleCallback(start, { timeout: 4000 })` when available
- *     (timeout caps the worst-case defer under main-thread pressure)
- *   - Safari fallback: setTimeout(0) off the `load` event
+ * Schedule the deferred SDK load + `Sentry.init()`. Idempotent. The minimum
+ * delay keeps the SDK chunk past the mobile Lighthouse audit window; the
+ * follow-up idle callback prevents the delayed load from landing in the middle
+ * of user-visible work when the browser has idle time available.
  *
  * Returns a promise that resolves once init completes (or fails — failures are
  * logged via console.warn and never reject the returned promise so callers
@@ -328,16 +342,14 @@ export function scheduleSentryInit(): Promise<void> {
         })
         .finally(() => resolve());
     };
-    const ric = (window as unknown as { requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number }).requestIdleCallback;
-    if (typeof ric === 'function') {
-      ric(start, { timeout: 4000 });
-      return;
-    }
-    if (document.readyState === 'complete') {
-      setTimeout(start, 0);
-    } else {
-      window.addEventListener('load', () => setTimeout(start, 0), { once: true });
-    }
+    setTimeout(() => {
+      const ric = (window as unknown as { requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number }).requestIdleCallback;
+      if (typeof ric === 'function') {
+        ric(start, { timeout: SENTRY_POST_DELAY_IDLE_TIMEOUT_MS });
+        return;
+      }
+      start();
+    }, SENTRY_AUDIT_WINDOW_DELAY_MS);
   });
   return initPromise;
 }
@@ -352,6 +364,11 @@ export function _buildQueuedUnhandledRejectionEventForTests(reason: unknown): Se
   return buildQueuedUnhandledRejectionEvent(reason);
 }
 
+/** Test-only: inject a mocked loader so scheduleSentryInit exercises the real drain path. */
+export function _setSentryLoaderForTests(loader: SentryLoader): void {
+  sentryLoader = loader;
+}
+
 /** Test-only: reset module state between unit tests. */
 export function _resetSentryDeferStateForTests(): void {
   sentryNs = null;
@@ -362,4 +379,5 @@ export function _resetSentryDeferStateForTests(): void {
   pendingCalls.length = 0;
   pendingErrors.length = 0;
   pendingRejections.length = 0;
+  sentryLoader = defaultSentryLoader;
 }

--- a/src/components/CountryDeepDivePanel.ts
+++ b/src/components/CountryDeepDivePanel.ts
@@ -20,6 +20,7 @@ import { getAuthState } from '@/services/auth-state';
 import { trackGateHit } from '@/services/analytics';
 import { fetchBypassOptions, fetchChokepointStatus } from '@/services/supply-chain';
 import { haversineDistanceKm } from '@/services/related-assets';
+import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
 import type {
   CountryBriefPanel,
   CountryIntelData,
@@ -2636,20 +2637,18 @@ export class CountryDeepDivePanel implements CountryBriefPanel {
   }
 
   private captureResilienceWidgetLoadFailure(error: unknown, countryCode: string): void {
-    void import('@sentry/browser')
-      .then((Sentry) => {
-        Sentry.addBreadcrumb?.({
-          category: 'country-deep-dive',
-          level: 'warning',
-          message: 'Resilience widget lazy load failed',
-          data: { countryCode },
-        });
-        Sentry.captureException?.(error instanceof Error ? error : new Error(String(error)), {
-          tags: { surface: 'country-deep-dive', widget: 'resilience' },
-          extra: { countryCode },
-        });
-      })
-      .catch(() => {});
+    enqueueSentryCall((Sentry) => {
+      Sentry.addBreadcrumb?.({
+        category: 'country-deep-dive',
+        level: 'warning',
+        message: 'Resilience widget lazy load failed',
+        data: { countryCode },
+      });
+      Sentry.captureException?.(error instanceof Error ? error : new Error(String(error)), {
+        tags: { surface: 'country-deep-dive', widget: 'resilience' },
+        extra: { countryCode },
+      });
+    });
   }
 
   private replaceResilienceSlot(slot: HTMLElement, next: HTMLElement): void {

--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -22,6 +22,7 @@
  */
 
 import type { Clerk } from '@clerk/clerk-js';
+import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
 
 type ClerkInstance = Clerk;
 
@@ -306,19 +307,16 @@ export function getClerk(): ClerkInstance | null {
 // other browser, so the load-failure capture keeps its value.
 const CN_INAPP_BROWSER_RE = /MicroMessenger|Weibo|QQBrowser|UCBrowser|baiduboxapp/i;
 
-// Report a Clerk UI-open failure as a single handled Sentry event. Lazy
-// import keeps @sentry/browser off this module's static graph (clerk.ts is
-// imported by Node test files where the browser SDK is unwanted) and makes
-// telemetry strictly best-effort — it must never throw into a click handler.
+// Report a Clerk UI-open failure as a single handled Sentry event. The deferred
+// Sentry queue keeps @sentry/browser behind the shared scheduler, and telemetry
+// stays strictly best-effort — it must never throw into a click handler.
 function captureClerkSurfaceFailure(action: string, err: unknown, reason: string): void {
   if (reason === 'clerk-load-failed' && typeof navigator !== 'undefined' && CN_INAPP_BROWSER_RE.test(navigator.userAgent)) return;
-  void import('@sentry/browser')
-    .then((Sentry) => {
-      Sentry.captureException(err instanceof Error ? err : new Error(String(err)), {
-        tags: { surface: 'clerk', action, reason },
-      });
-    })
-    .catch(() => {});
+  enqueueSentryCall((Sentry) => {
+    Sentry.captureException(err instanceof Error ? err : new Error(String(err)), {
+      tags: { surface: 'clerk', action, reason },
+    });
+  });
 }
 
 function scheduleNextFrame(cb: () => void): void {

--- a/tests/dashboard-eager-chunks.test.mjs
+++ b/tests/dashboard-eager-chunks.test.mjs
@@ -18,6 +18,7 @@ const dashboardHtml = resolve(distDir, 'dashboard.html');
 // Dist-gated: skips when dist/dashboard.html is absent. CI builds the dashboard
 // before `npm run test:data` (the step added in #4393), so this runs in CI.
 const DEFERRED_TABLE_CHUNKS = ['tech-geo-data', 'airports-data', 'ai-datacenters-data', 'geo-map-data'];
+const DEFERRED_SENTRY_CHUNKS = ['sentry-init', 'sentry'];
 
 describe('eager chunk budget: lazy-only config data tables stay off the entry', { skip: !existsSync(dashboardHtml) }, () => {
   const html = readFileSync(dashboardHtml, 'utf-8');
@@ -47,6 +48,40 @@ describe('eager chunk budget: lazy-only config data tables stay off the entry', 
       // The bare filename also appears in Vite's dynamic-import preload manifest
       // (`"assets/<chunk>-hash.js"` inside an array) — that's expected for a lazy
       // chunk and must NOT fail the guard, so match the static-import form only.
+      const staticImportRe = new RegExp(`(?:from|import)"\\./${chunk}-[A-Za-z0-9_-]+\\.js"`);
+      assert.ok(
+        !staticImportRe.test(mainJs),
+        `${chunk} must not be statically imported by ${mainFile} (dynamic preload-manifest references are fine)`,
+      );
+    });
+  }
+});
+
+describe('eager chunk budget: Sentry stays behind the deferred scheduler', { skip: !existsSync(dashboardHtml) }, () => {
+  const html = readFileSync(dashboardHtml, 'utf-8');
+  const assetsDir = resolve(distDir, 'assets');
+  const assets = existsSync(assetsDir) ? readdirSync(assetsDir) : [];
+  const mainFile = assets.find((f) => /^main-[A-Za-z0-9_-]+\.js$/.test(f));
+  const mainJs = mainFile ? readFileSync(resolve(assetsDir, mainFile), 'utf-8') : '';
+
+  for (const chunk of DEFERRED_SENTRY_CHUNKS) {
+    it(`${chunk}: built as its own isolated chunk`, () => {
+      assert.ok(
+        assets.some((f) => f.startsWith(`${chunk}-`) && f.endsWith('.js')),
+        `${chunk}-*.js chunk should exist (manualChunks rule present)`,
+      );
+    });
+
+    it(`${chunk}: absent from dashboard.html modulepreload`, () => {
+      const modulepreloadRe = new RegExp(`<link\\b[^>]+rel=["']modulepreload["'][^>]+href=["']/assets/${chunk}-[A-Za-z0-9_-]+\\.js["']`);
+      assert.ok(
+        !modulepreloadRe.test(html),
+        `${chunk} must not be eagerly modulepreloaded in dashboard.html — Sentry must load through the deferred scheduler`,
+      );
+    });
+
+    it(`${chunk}: not statically imported by the main entry chunk`, () => {
+      assert.ok(mainFile, 'main-*.js entry chunk should exist in dist/assets');
       const staticImportRe = new RegExp(`(?:from|import)"\\./${chunk}-[A-Za-z0-9_-]+\\.js"`);
       assert.ok(
         !staticImportRe.test(mainJs),

--- a/tests/helpers/country-deep-dive-panel-harness.mjs
+++ b/tests/helpers/country-deep-dive-panel-harness.mjs
@@ -190,19 +190,23 @@ async function loadCountryDeepDivePanel(options = {}) {
       export function getAuthState() { return { user: null }; }
     `],
     ['resilience-widget-stub', resilienceWidgetStub],
-    ['sentry-browser-stub', `
+    ['sentry-defer-stub', `
       const state = globalThis.__wmCountryDeepDiveTestState;
-      export function addBreadcrumb(breadcrumb) {
-        state.sentryBreadcrumbs.push(breadcrumb);
-      }
-      export function captureException(error, context) {
-        state.sentryExceptions.push({ error, context });
-      }
-      export function captureMessage(message, context) {
-        state.sentryMessages.push({ message, context });
-      }
-      export function setUser(user) {
-        state.sentryUser = user;
+      export function enqueueSentryCall(fn) {
+        fn({
+          addBreadcrumb(breadcrumb) {
+            state.sentryBreadcrumbs.push(breadcrumb);
+          },
+          captureException(error, context) {
+            state.sentryExceptions.push({ error, context });
+          },
+          captureMessage(message, context) {
+            state.sentryMessages.push({ message, context });
+          },
+          setUser(user) {
+            state.sentryUser = user;
+          },
+        });
       }
     `],
   ]);
@@ -230,7 +234,7 @@ async function loadCountryDeepDivePanel(options = {}) {
     ['@/generated/client/worldmonitor/intelligence/v1/service_client', 'intelligence-client-stub'],
     ['@/services/panel-gating', 'panel-gating-stub'],
     ['@/services/auth-state', 'auth-state-stub'],
-    ['@sentry/browser', 'sentry-browser-stub'],
+    ['@/bootstrap/sentry-defer', 'sentry-defer-stub'],
   ]);
 
   const plugin = {

--- a/tests/sentry-defer-replay.test.mts
+++ b/tests/sentry-defer-replay.test.mts
@@ -4,9 +4,64 @@ import assert from 'node:assert/strict';
 import {
   _buildQueuedErrorEventForTests,
   _buildQueuedUnhandledRejectionEventForTests,
+  _resetSentryDeferStateForTests,
+  _setSentryLoaderForTests,
+  enqueueSentryCall,
+  installPreInitErrorQueue,
+  scheduleSentryInit,
 } from '../src/bootstrap/sentry-defer';
 
+function restoreGlobalProperty(name: 'window' | 'setTimeout', descriptor: PropertyDescriptor | undefined): void {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, name);
+  }
+}
+
 describe('deferred Sentry replay event shaping', () => {
+  it('keeps Sentry import scheduling past the mobile Lighthouse audit window', () => {
+    _resetSentryDeferStateForTests();
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const previousSetTimeout = Object.getOwnPropertyDescriptor(globalThis, 'setTimeout');
+    let recordedTimeout: number | null = null;
+    let recordedDelay: number | null = null;
+    let delayedCallback: (() => void) | null = null;
+
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        requestIdleCallback: (_cb: () => void, opts?: { timeout: number }) => {
+          recordedTimeout = opts?.timeout ?? null;
+          return 1;
+        },
+        addEventListener() {},
+        removeEventListener() {},
+      },
+    });
+    Object.defineProperty(globalThis, 'setTimeout', {
+      configurable: true,
+      value: (cb: () => void, delay?: number) => {
+        recordedDelay = delay ?? null;
+        delayedCallback = cb;
+        return 1;
+      },
+    });
+
+    try {
+      scheduleSentryInit();
+      assert.equal(recordedDelay, 10_000);
+      assert.equal(recordedTimeout, null);
+
+      delayedCallback?.();
+      assert.equal(recordedTimeout, 2_000);
+    } finally {
+      _resetSentryDeferStateForTests();
+      restoreGlobalProperty('window', previousWindow);
+      restoreGlobalProperty('setTimeout', previousSetTimeout);
+    }
+  });
+
   it('matches Sentry globalHandlers for primitive promise rejections', () => {
     const event = _buildQueuedUnhandledRejectionEventForTests('timeout');
     const value = event?.exception?.values?.[0];
@@ -14,6 +69,171 @@ describe('deferred Sentry replay event shaping', () => {
     assert.equal(event?.level, 'error');
     assert.equal(value?.type, 'UnhandledRejection');
     assert.equal(value?.value, 'Non-Error promise rejection captured with value: timeout');
+  });
+
+  it('flushes errors thrown during the defer gap through the scheduled init path', async () => {
+    _resetSentryDeferStateForTests();
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const previousSetTimeout = Object.getOwnPropertyDescriptor(globalThis, 'setTimeout');
+    const listeners = new Map<string, EventListener>();
+    const removed: string[] = [];
+    const queuedError = new Error('gap boom');
+    const captured: unknown[] = [];
+    let recordedDelay: number | null = null;
+    let delayedCallback: (() => void) | null = null;
+    let recordedIdleTimeout: number | null = null;
+    let idleCallback: (() => void) | null = null;
+
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        requestIdleCallback: (cb: () => void, opts?: { timeout: number }) => {
+          recordedIdleTimeout = opts?.timeout ?? null;
+          idleCallback = cb;
+          return 1;
+        },
+        addEventListener(type: string, listener: EventListener) {
+          listeners.set(type, listener);
+        },
+        removeEventListener(type: string, listener: EventListener) {
+          if (listeners.get(type) === listener) removed.push(type);
+        },
+      },
+    });
+    Object.defineProperty(globalThis, 'setTimeout', {
+      configurable: true,
+      value: (cb: () => void, delay?: number) => {
+        recordedDelay = delay ?? null;
+        delayedCallback = cb;
+        return 1;
+      },
+    });
+    _setSentryLoaderForTests(async () => ({
+      captureException(error: unknown, hint: unknown) {
+        captured.push({ error, hint });
+      },
+      captureEvent() {
+        throw new Error('captureEvent should not be used for Error instances');
+      },
+    } as never));
+
+    try {
+      installPreInitErrorQueue();
+      listeners.get('error')?.({
+        message: 'gap boom',
+        filename: 'https://worldmonitor.app/assets/main.js',
+        lineno: 10,
+        colno: 20,
+        error: queuedError,
+      } as ErrorEvent);
+
+      const initPromise = scheduleSentryInit();
+      assert.equal(recordedDelay, 10_000);
+      assert.equal(captured.length, 0);
+      delayedCallback?.();
+      assert.equal(recordedIdleTimeout, 2_000);
+      assert.equal(captured.length, 0);
+
+      idleCallback?.();
+      await initPromise;
+
+      assert.equal(captured.length, 1);
+      assert.equal((captured[0] as { error: unknown }).error, queuedError);
+      assert.deepEqual(
+        (captured[0] as { hint: { mechanism: { type: string; handled: boolean } } }).hint.mechanism,
+        { type: 'auto.browser.global_handlers.onerror', handled: false },
+      );
+      assert.deepEqual(removed.sort(), ['error', 'unhandledrejection']);
+    } finally {
+      _resetSentryDeferStateForTests();
+      restoreGlobalProperty('window', previousWindow);
+      restoreGlobalProperty('setTimeout', previousSetTimeout);
+    }
+  });
+
+  it('keeps newer pre-init errors and calls when the bounded queues saturate', async () => {
+    _resetSentryDeferStateForTests();
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const previousSetTimeout = Object.getOwnPropertyDescriptor(globalThis, 'setTimeout');
+    const listeners = new Map<string, EventListener>();
+    const capturedEvents: unknown[] = [];
+    const capturedCalls: string[] = [];
+    const latestError = new Error('latest startup failure');
+    let delayedCallback: (() => void) | null = null;
+    let idleCallback: (() => void) | null = null;
+
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        requestIdleCallback: (cb: () => void) => {
+          idleCallback = cb;
+          return 1;
+        },
+        addEventListener(type: string, listener: EventListener) {
+          listeners.set(type, listener);
+        },
+        removeEventListener() {},
+      },
+    });
+    Object.defineProperty(globalThis, 'setTimeout', {
+      configurable: true,
+      value: (cb: () => void) => {
+        delayedCallback = cb;
+        return 1;
+      },
+    });
+    _setSentryLoaderForTests(async () => ({
+      captureException(error: unknown) {
+        capturedEvents.push(error);
+      },
+      captureEvent(event: unknown) {
+        capturedEvents.push(event);
+      },
+      captureMessage(message: string) {
+        capturedCalls.push(message);
+      },
+    } as never));
+
+    try {
+      installPreInitErrorQueue();
+      const listener = listeners.get('error');
+      assert.ok(listener, 'pre-init error listener should be installed');
+      for (let i = 0; i < 50; i += 1) {
+        listener({
+          message: `noise-${i}`,
+          filename: 'https://extension.invalid/noise.js',
+          lineno: i,
+          colno: 1,
+          error: null,
+        } as ErrorEvent);
+      }
+      listener({
+        message: 'latest startup failure',
+        filename: 'https://worldmonitor.app/assets/main.js',
+        lineno: 1,
+        colno: 1,
+        error: latestError,
+      } as ErrorEvent);
+      for (let i = 0; i < 50; i += 1) {
+        enqueueSentryCall((Sentry) => Sentry.captureMessage(`stale-${i}`));
+      }
+      enqueueSentryCall((Sentry) => Sentry.captureMessage('latest-call'));
+
+      const initPromise = scheduleSentryInit();
+      delayedCallback?.();
+      idleCallback?.();
+      await initPromise;
+
+      assert.equal(capturedEvents.length, 50);
+      assert.equal(capturedEvents[capturedEvents.length - 1], latestError);
+      assert.equal(capturedCalls.length, 50);
+      assert.equal(capturedCalls[0], 'stale-1');
+      assert.equal(capturedCalls[capturedCalls.length - 1], 'latest-call');
+    } finally {
+      _resetSentryDeferStateForTests();
+      restoreGlobalProperty('window', previousWindow);
+      restoreGlobalProperty('setTimeout', previousSetTimeout);
+    }
   });
 
   it('matches Sentry globalHandlers for object promise rejections', () => {


### PR DESCRIPTION
## Summary

Sentry now stays out of the Lighthouse audit window instead of loading at the `requestIdleCallback` timeout. The startup scheduler waits 10 seconds before looking for idle time to import Sentry, and direct resilience/clerk reporting paths now enqueue through that same deferred path so they cannot pull `@sentry/browser` into startup.

The pre-init queues now keep newer telemetry when saturated, so extending the defer window does not cause later high-signal errors to be hidden behind older noise. The emitted dashboard guard also asserts that both Sentry chunks remain present but outside `dashboard.html` modulepreload and outside the main entry's static import graph.

Closes koala73/worldmonitor#4417.

## Validation

| Check | Result |
|---|---|
| `./node_modules/.bin/tsx --test tests/sentry-defer-replay.test.mts` | Passes 8 tests |
| `./node_modules/.bin/tsx --test tests/clerk-surface-open.test.mts tests/resilience-country-brief.test.mjs` | Passes 11 tests |
| `npm run build:full` | Passes |
| `./node_modules/.bin/tsx --test tests/dashboard-eager-chunks.test.mjs` | Passes 18 tests against fresh `dist/` output |
| Preview browser smoke | 0 Sentry requests by 5.5s; `sentry-init` at 10097ms and `sentry` at 10099ms |
| `git push` pre-push hook | Passes typecheck, API typecheck, boundary/safe-html/rate-limit/premium-fetch guards, changed tests, edge tests, and version sync |

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
