### PR TITLE
fix(a11y): readable text on correlation score badges — #4421

### DIFF
--- a/src/components/CorrelationPanel.ts
+++ b/src/components/CorrelationPanel.ts
@@ -2,6 +2,7 @@ import { Panel } from './Panel';
 import { t } from '@/services/i18n';
 import type { ConvergenceCard, CorrelationDomain } from '@/services/correlation-engine';
 import { h, replaceChildren } from '@/utils/dom-utils';
+import { readableTextColor } from '@/utils/contrast';
 import { getHydratedData } from '@/services/bootstrap';
 
 let correlationBootstrap: Record<string, ConvergenceCard[]> | null | undefined;
@@ -12,9 +13,10 @@ function getCorrelationBootstrap(): Record<string, ConvergenceCard[]> | null {
   return correlationBootstrap;
 }
 
-// These are used as the score-badge BACKGROUND with white (#fff) text.
-// `low` darkened from #888888 → #6f6f6f so white text clears WCAG AA (4.5:1):
-// white-on-#888888 was 3.54, white-on-#6f6f6f is ~5.0. (See #4418.)
+// Score-badge BACKGROUND colors. Badge text color is chosen per-background via
+// readableTextColor() so it clears WCAG AA on each: white on the dark `low`
+// badge, dark text on the light/mid critical/high/medium hues (white was 3.41 /
+// 2.39 / 1.51 on those). `low` was also darkened #888888 → #6f6f6f. (#4418/#4421)
 const SCORE_COLORS = {
   critical: '#ff4444',
   high: '#ff8800',
@@ -113,7 +115,7 @@ export class CorrelationPanel extends Panel {
       style: 'display:flex;align-items:center;gap:6px;cursor:pointer;padding:8px;',
     },
       h('span', {
-        style: `display:inline-block;min-width:28px;text-align:center;padding:2px 6px;border-radius:10px;font-size:10px;font-weight:700;color:#fff;background:${scoreColor};`,
+        style: `display:inline-block;min-width:28px;text-align:center;padding:2px 6px;border-radius:10px;font-size:10px;font-weight:700;color:${readableTextColor(scoreColor)};background:${scoreColor};`,
       }, String(card.score)),
       h('span', {
         style: 'flex:1;font-size:11px;line-height:1.3;',

--- a/src/utils/contrast.ts
+++ b/src/utils/contrast.ts
@@ -22,9 +22,11 @@ export function contrastRatio(a: string, b: string): number {
 
 /**
  * Pick the higher-contrast foreground text color (white or near-black) for a
- * solid hex background, so badge/chip text clears WCAG AA. Returns whichever of
- * `#ffffff` / `#1a1a1a` has the greater contrast ratio against `bgHex` — e.g.
- * white on dark badges, dark on light/mid badges (yellow, orange).
+ * solid hex background. Returns whichever of `#ffffff` / `#1a1a1a` has the
+ * greater contrast ratio against `bgHex` — e.g. white on dark badges, dark on
+ * light/mid badges (yellow, orange). The four CorrelationPanel score-badge
+ * backgrounds clear WCAG AA with the chosen color; arbitrary mid-gray inputs
+ * may still need a different palette to reach 4.5:1.
  */
 export function readableTextColor(bgHex: string): '#ffffff' | '#1a1a1a' {
   return contrastRatio('#ffffff', bgHex) >= contrastRatio('#1a1a1a', bgHex)

--- a/src/utils/contrast.ts
+++ b/src/utils/contrast.ts
@@ -1,0 +1,33 @@
+/**
+ * WCAG relative luminance of a solid hex color (#rgb or #rrggbb, with or
+ * without the leading '#'). https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
+ */
+export function relativeLuminance(hex: string): number {
+  const h = hex.replace('#', '');
+  const full = h.length === 3 ? h.split('').map((c) => c + c).join('') : h;
+  const channel = (offset: number): number => {
+    const c = parseInt(full.slice(offset, offset + 2), 16) / 255;
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+  };
+  return 0.2126 * channel(0) + 0.7152 * channel(2) + 0.0722 * channel(4);
+}
+
+/** WCAG contrast ratio between two solid hex colors (1–21). */
+export function contrastRatio(a: string, b: string): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [hi, lo] = la >= lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/**
+ * Pick the higher-contrast foreground text color (white or near-black) for a
+ * solid hex background, so badge/chip text clears WCAG AA. Returns whichever of
+ * `#ffffff` / `#1a1a1a` has the greater contrast ratio against `bgHex` — e.g.
+ * white on dark badges, dark on light/mid badges (yellow, orange).
+ */
+export function readableTextColor(bgHex: string): '#ffffff' | '#1a1a1a' {
+  return contrastRatio('#ffffff', bgHex) >= contrastRatio('#1a1a1a', bgHex)
+    ? '#ffffff'
+    : '#1a1a1a';
+}

--- a/tests/contrast.test.mts
+++ b/tests/contrast.test.mts
@@ -1,0 +1,43 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { readableTextColor, contrastRatio, relativeLuminance } from '../src/utils/contrast.ts';
+
+describe('contrast util', () => {
+  it('computes WCAG contrast ratio at the extremes', () => {
+    assert.equal(Math.round(contrastRatio('#ffffff', '#000000')), 21);
+    assert.equal(contrastRatio('#ffffff', '#ffffff'), 1);
+  });
+
+  it('parses 3-digit and #-less hex', () => {
+    assert.equal(relativeLuminance('#fff'), relativeLuminance('#ffffff'));
+    assert.equal(relativeLuminance('000'), relativeLuminance('#000000'));
+  });
+
+  it('picks white text only when it clears AA, else dark — for every correlation score color', () => {
+    // The CorrelationPanel score-badge backgrounds (#4421 / #4418).
+    const cases: Array<[string, '#ffffff' | '#1a1a1a']> = [
+      ['#6f6f6f', '#ffffff'], // low (dark bg → white)
+      ['#ff4444', '#1a1a1a'], // critical (white was 3.41 → dark)
+      ['#ff8800', '#1a1a1a'], // high (white was 2.39 → dark)
+      ['#ffcc00', '#1a1a1a'], // medium (white was 1.51 → dark)
+    ];
+    for (const [bg, expected] of cases) {
+      const text = readableTextColor(bg);
+      assert.equal(text, expected, `${bg} should use ${expected}`);
+      // The chosen text color must actually clear WCAG AA (4.5:1) on that bg.
+      assert.ok(
+        contrastRatio(text, bg) >= 4.5,
+        `${text} on ${bg} must be >= 4.5:1 (got ${contrastRatio(text, bg).toFixed(2)})`,
+      );
+    }
+  });
+
+  it('always returns the higher-contrast of white/dark', () => {
+    for (const bg of ['#000000', '#ffffff', '#808080', '#123456', '#abcdef']) {
+      const text = readableTextColor(bg);
+      const other = text === '#ffffff' ? '#1a1a1a' : '#ffffff';
+      assert.ok(contrastRatio(text, bg) >= contrastRatio(other, bg));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #4421 — the remaining desktop `color-contrast` failures after #4419. The correlation score badge hard-coded white text (`color:#fff`) on a per-score background; white fails WCAG AA on the light/mid hues:

| Badge | bg | white (before) | now | ratio |
|---|---|---|---|---|
| medium | `#ffcc00` | 1.51 ✗ | dark `#1a1a1a` | **11.5** |
| high | `#ff8800` | 2.39 ✗ | dark `#1a1a1a` | **7.3** |
| critical | `#ff4444` | 3.41 ✗ | dark `#1a1a1a` | **5.1** |
| low | `#6f6f6f` | 5.0 ✓ | white (unchanged) | 5.0 |

## Approach
New pure util `src/utils/contrast.ts` — `readableTextColor(bg)` returns whichever of `#ffffff` / `#1a1a1a` has the higher WCAG contrast (plus `relativeLuminance`/`contrastRatio` helpers). CorrelationPanel uses it for the badge text color. Robust by construction (always picks the better option), and reusable for future badges/chips. Chosen over darkening the bgs because yellow `#ffcc00` can never carry white text.

## Verification
- [x] `tests/contrast.test.mts` (4/4): asserts the per-color pick **and** that each chosen color clears 4.5:1 (deterministic — not dependent on which cards render in a Lighthouse run)
- [x] tsc + typecheck:api clean; full `VITE_VARIANT=full` build 0 circular chunks
- [x] `test:data` 11,630 / 0; lint, lint:md, version green
- [ ] Post-deploy: confirm desktop Accessibility = 100 with a high/medium/critical correlation card rendered; no visual regression on the badges