### PR TITLE
perf(dashboard): defer zod, satellite.js & canvas-confetti off eager main.js (−29.5 KB brotli)

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -905,7 +905,7 @@ export class DataLoaderManager implements AppModule {
     this.stopSatellitePropagation();
     const data = await fetchSatelliteTLEs();
     if (!data || data.length === 0) return;
-    this.cachedSatRecs = initSatRecs(data);
+    this.cachedSatRecs = await initSatRecs(data);
     const positions = propagatePositions(this.cachedSatRecs);
     this.ctx.map?.setSatellites(positions);
     this.satellitePropagationCleanup = startPropagationLoop(this.cachedSatRecs, (pos) => {

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -905,7 +905,14 @@ export class DataLoaderManager implements AppModule {
     this.stopSatellitePropagation();
     const data = await fetchSatelliteTLEs();
     if (!data || data.length === 0) return;
-    this.cachedSatRecs = await initSatRecs(data);
+    try {
+      this.cachedSatRecs = await initSatRecs(data);
+    } catch (err) {
+      console.error('[satellites] failed to initialize satellite propagation', err);
+      this.cachedSatRecs = [];
+      this.ctx.map?.setSatellites([]);
+      return;
+    }
     const positions = propagatePositions(this.cachedSatRecs);
     this.ctx.map?.setSatellites(positions);
     this.satellitePropagationCleanup = startPropagationLoop(this.cachedSatRecs, (pos) => {

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1,5 +1,4 @@
 import type { AppContext, AppModule } from '@/app/app-context';
-import { applyAgentBusAction } from '@/app/agent-bus-applier';
 import { normalizeExclusiveChoropleths } from '@/components/resilience-choropleth-utils';
 import { replayPendingCalls, clearAllPendingCalls } from '@/app/pending-panel-data';
 import {
@@ -1633,7 +1632,13 @@ export class PanelLayoutManager implements AppModule {
     // reactively by updatePanelGating() via auth state subscription (all in WEB_PREMIUM_PANELS).
 
     this.lazyPanel('chat-analyst', () =>
-      import('@/components/ChatAnalystPanel').then(m => {
+      // agent-bus-applier (and its zod-backed shared/agent-bus-actions schemas, ~69KB)
+      // is only reachable through this lazy panel's action handler — co-load it here so
+      // it ships in the chat-analyst chunk instead of the eager main entry.
+      Promise.all([
+        import('@/components/ChatAnalystPanel'),
+        import('@/app/agent-bus-applier'),
+      ]).then(([m, { applyAgentBusAction }]) => {
         const panel = new m.ChatAnalystPanel();
         panel.setDashboardActionHandler((action) => applyAgentBusAction(this.ctx, action, {
           getPanelConfig: (panelId) => getEffectivePanelConfig(panelId, SITE_VARIANT),

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1633,19 +1633,23 @@ export class PanelLayoutManager implements AppModule {
 
     this.lazyPanel('chat-analyst', () =>
       // agent-bus-applier (and its zod-backed shared/agent-bus-actions schemas, ~69KB)
-      // is only reachable through this lazy panel's action handler — co-load it here so
-      // it ships in the chat-analyst chunk instead of the eager main entry.
-      Promise.all([
-        import('@/components/ChatAnalystPanel'),
-        import('@/app/agent-bus-applier'),
-      ]).then(([m, { applyAgentBusAction }]) => {
+      // is only reachable through this lazy panel's action handler. Start loading it
+      // here so it stays off the eager main entry, but do not make plain chat depend
+      // on the optional dashboard-control chunk being available.
+      import('@/components/ChatAnalystPanel').then(m => {
         const panel = new m.ChatAnalystPanel();
-        panel.setDashboardActionHandler((action) => applyAgentBusAction(this.ctx, action, {
-          getPanelConfig: (panelId) => getEffectivePanelConfig(panelId, SITE_VARIANT),
-          isPanelAllowed: (panelId, config) => isPanelEntitled(panelId, config, hasPremiumAccess(getAuthState())),
-          hasPremiumAccess: () => hasPremiumAccess(getAuthState()),
-          applyLayerChange: this.callbacks.applyMapLayerChange,
-        }));
+        void import('@/app/agent-bus-applier')
+          .then(({ applyAgentBusAction }) => {
+            panel.setDashboardActionHandler((action) => applyAgentBusAction(this.ctx, action, {
+              getPanelConfig: (panelId) => getEffectivePanelConfig(panelId, SITE_VARIANT),
+              isPanelAllowed: (panelId, config) => isPanelEntitled(panelId, config, hasPremiumAccess(getAuthState())),
+              hasPremiumAccess: () => hasPremiumAccess(getAuthState()),
+              applyLayerChange: this.callbacks.applyMapLayerChange,
+            }));
+          })
+          .catch((err) => {
+            console.error('[panel] failed to lazy-load "chat-analyst" dashboard action handler', err);
+          });
         return panel;
       }),
     );

--- a/src/services/celebration.ts
+++ b/src/services/celebration.ts
@@ -11,7 +11,25 @@
  * Respects prefers-reduced-motion: no animations when that media query matches.
  */
 
-import confetti from 'canvas-confetti';
+// canvas-confetti (~10KB) is only needed when a positive milestone actually fires —
+// never at boot. Lazy-load + cache it on first celebration so it ships off the eager
+// main entry. Bursts are fire-and-forget, so a one-tick load delay is imperceptible.
+type ConfettiFn = typeof import('canvas-confetti');
+type ConfettiOptions = Parameters<ConfettiFn>[0];
+let confettiPromise: Promise<ConfettiFn> | null = null;
+function loadConfetti(): Promise<ConfettiFn> {
+  if (!confettiPromise) {
+    confettiPromise = import('canvas-confetti')
+      // canvas-confetti is `export =`; the runtime namespace wraps it under .default
+      // (esbuild/Vite CJS interop), while the type is the function itself.
+      .then((m) => ((m as { default?: ConfettiFn }).default ?? m) as ConfettiFn)
+      .catch((err) => { confettiPromise = null; throw err; });
+  }
+  return confettiPromise;
+}
+function fireConfetti(options: ConfettiOptions): void {
+  void loadConfetti().then((confetti) => { confetti(options); }).catch(() => { /* best-effort */ });
+}
 
 // ---- Types ----
 
@@ -46,7 +64,7 @@ export function celebrate(type: 'milestone' | 'record' = 'milestone'): void {
   if (REDUCED_MOTION) return;
 
   if (type === 'milestone') {
-    void confetti({
+    fireConfetti({
       particleCount: 40,
       spread: 60,
       origin: { y: 0.7 },
@@ -55,7 +73,7 @@ export function celebrate(type: 'milestone' | 'record' = 'milestone'): void {
     });
   } else {
     // 'record' -- double burst for extra emphasis
-    void confetti({
+    fireConfetti({
       particleCount: 80,
       spread: 90,
       origin: { y: 0.6 },
@@ -63,7 +81,7 @@ export function celebrate(type: 'milestone' | 'record' = 'milestone'): void {
       disableForReducedMotion: true,
     });
     setTimeout(() => {
-      void confetti({
+      fireConfetti({
         particleCount: 80,
         spread: 90,
         origin: { y: 0.6 },

--- a/src/services/satellites.ts
+++ b/src/services/satellites.ts
@@ -13,8 +13,23 @@
 
 import { getRpcBaseUrl } from '@/services/rpc-client';
 import { IntelligenceServiceClient } from '@/generated/client/worldmonitor/intelligence/v1/service_client';
-import { twoline2satrec, propagate, eciToGeodetic, gstime, degreesLong, degreesLat } from 'satellite.js';
 import type { SatRec } from 'satellite.js';
+
+// satellite.js (~20KB) is only needed once the satellite layer fetches TLEs — never at
+// boot. Lazy-load + cache the module so it ships off the eager main entry. initSatRecs
+// (async) resolves the lib before propagatePositions (sync) runs in the loop.
+type SatelliteLib = typeof import('satellite.js');
+let satLib: SatelliteLib | null = null;
+let satLibPromise: Promise<SatelliteLib> | null = null;
+async function ensureSatelliteLib(): Promise<SatelliteLib> {
+  if (satLib) return satLib;
+  if (!satLibPromise) {
+    satLibPromise = import('satellite.js')
+      .then((m) => { satLib = m; return m; })
+      .catch((err) => { satLibPromise = null; throw err; });
+  }
+  return satLibPromise;
+}
 
 const intelligenceClient = new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
 
@@ -92,7 +107,8 @@ export async function fetchSatelliteTLEs(): Promise<SatelliteTLE[] | null> {
   }
 }
 
-export function initSatRecs(tles: SatelliteTLE[]): SatRecEntry[] {
+export async function initSatRecs(tles: SatelliteTLE[]): Promise<SatRecEntry[]> {
+  const { twoline2satrec } = await ensureSatelliteLib();
   const entries: SatRecEntry[] = [];
   for (const tle of tles) {
     try {
@@ -107,6 +123,10 @@ export function initSatRecs(tles: SatelliteTLE[]): SatRecEntry[] {
 }
 
 export function propagatePositions(satRecs: SatRecEntry[], date?: Date): SatellitePosition[] {
+  // satellite.js is loaded by initSatRecs before any propagation runs; if it has not
+  // resolved yet (propagatePositions called before init), yield no positions this tick.
+  if (!satLib) return [];
+  const { gstime, propagate, eciToGeodetic, degreesLat, degreesLong } = satLib;
   const now = date || new Date();
   const gmst = gstime(now);
   const positions: SatellitePosition[] = [];

--- a/tests/dashboard-eager-chunks.test.mjs
+++ b/tests/dashboard-eager-chunks.test.mjs
@@ -31,6 +31,61 @@ const DEFERRED_AGENT_BUS_CHUNKS = ['agent-bus-actions'];
 // Re-adding a static `import` of either would re-eagerise it into main and fail this.
 const DEFERRED_NPM_LIB_CHUNKS = ['satellite.es', 'confetti.module'];
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function loadDashboardBuild() {
+  const html = readFileSync(dashboardHtml, 'utf-8');
+  const assetsDir = resolve(distDir, 'assets');
+  const assets = existsSync(assetsDir) ? readdirSync(assetsDir) : [];
+  const mainFile = assets.find((f) => /^main-[A-Za-z0-9_-]+\.js$/.test(f));
+  const mainJs = mainFile ? readFileSync(resolve(assetsDir, mainFile), 'utf-8') : '';
+  const modulepreloadHrefs = [...html.matchAll(/<link\b[^>]*>/g)]
+    .map((match) => match[0])
+    .filter((tag) => /\brel=["']modulepreload["']/.test(tag))
+    .map((tag) => tag.match(/\bhref=["']([^"']+)["']/)?.[1])
+    .filter(Boolean);
+  return { html, assets, mainFile, mainJs, modulepreloadHrefs };
+}
+
+function hasModulepreloadForChunk(modulepreloadHrefs, chunk) {
+  const escaped = escapeRegExp(chunk);
+  const hrefRe = new RegExp(`(?:^|/)assets/${escaped}-[A-Za-z0-9_-]+\\.js$`);
+  return modulepreloadHrefs.some((href) => hrefRe.test(href));
+}
+
+function registerDeferredChunkAssertions(chunks, options) {
+  const { assets, mainFile, mainJs, modulepreloadHrefs } = loadDashboardBuild();
+
+  for (const chunk of chunks) {
+    const escaped = escapeRegExp(chunk);
+
+    it(`${chunk}: built as its own isolated chunk`, () => {
+      assert.ok(
+        assets.some((f) => f.startsWith(`${chunk}-`) && f.endsWith('.js')),
+        options.missingMessage(chunk),
+      );
+    });
+
+    it(`${chunk}: absent from dashboard.html modulepreload`, () => {
+      assert.ok(
+        !hasModulepreloadForChunk(modulepreloadHrefs, chunk),
+        options.preloadMessage(chunk),
+      );
+    });
+
+    it(`${chunk}: not statically imported by the main entry chunk`, () => {
+      assert.ok(mainFile, 'main-*.js entry chunk should exist in dist/assets');
+      const staticImportRe = new RegExp(`(?:from|import)"\\./${escaped}-[A-Za-z0-9_-]+\\.js"`);
+      assert.ok(
+        !staticImportRe.test(mainJs),
+        `${chunk} must not be statically imported by ${mainFile} (dynamic preload-manifest references are fine)`,
+      );
+    });
+  }
+}
+
 describe('eager chunk budget: lazy-only config data tables stay off the entry', { skip: !existsSync(dashboardHtml) }, () => {
   const html = readFileSync(dashboardHtml, 'utf-8');
   const assetsDir = resolve(distDir, 'assets');
@@ -103,70 +158,15 @@ describe('eager chunk budget: Sentry stays behind the deferred scheduler', { ski
 });
 
 describe('eager chunk budget: opt-in npm libs stay off the entry', { skip: !existsSync(dashboardHtml) }, () => {
-  const html = readFileSync(dashboardHtml, 'utf-8');
-  const assetsDir = resolve(distDir, 'assets');
-  const assets = existsSync(assetsDir) ? readdirSync(assetsDir) : [];
-  const mainFile = assets.find((f) => /^main-[A-Za-z0-9_-]+\.js$/.test(f));
-  const mainJs = mainFile ? readFileSync(resolve(assetsDir, mainFile), 'utf-8') : '';
-
-  for (const chunk of DEFERRED_NPM_LIB_CHUNKS) {
-    const escaped = chunk.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    it(`${chunk}: built as its own isolated chunk`, () => {
-      assert.ok(
-        assets.some((f) => f.startsWith(`${chunk}-`) && f.endsWith('.js')),
-        `${chunk}-*.js chunk should exist — if missing, the lib was inlined into another chunk by a static import`,
-      );
-    });
-
-    it(`${chunk}: absent from dashboard.html modulepreload`, () => {
-      const modulepreloadRe = new RegExp(`<link\\b[^>]+rel=["']modulepreload["'][^>]+href=["']/assets/${escaped}-[A-Za-z0-9_-]+\\.js["']`);
-      assert.ok(
-        !modulepreloadRe.test(html),
-        `${chunk} must not be eagerly modulepreloaded — it loads on demand`,
-      );
-    });
-
-    it(`${chunk}: not statically imported by the main entry chunk`, () => {
-      assert.ok(mainFile, 'main-*.js entry chunk should exist in dist/assets');
-      const staticImportRe = new RegExp(`(?:from|import)"\\./${escaped}-[A-Za-z0-9_-]+\\.js"`);
-      assert.ok(
-        !staticImportRe.test(mainJs),
-        `${chunk} must not be statically imported by ${mainFile} (dynamic preload-manifest references are fine)`,
-      );
-    });
-  }
+  registerDeferredChunkAssertions(DEFERRED_NPM_LIB_CHUNKS, {
+    missingMessage: (chunk) => `${chunk}-*.js chunk should exist — if missing, the lib was inlined into another chunk by a static import`,
+    preloadMessage: (chunk) => `${chunk} must not be eagerly modulepreloaded — it loads on demand`,
+  });
 });
 
 describe('eager chunk budget: agent-bus + zod stay behind the lazy chat-analyst panel', { skip: !existsSync(dashboardHtml) }, () => {
-  const html = readFileSync(dashboardHtml, 'utf-8');
-  const assetsDir = resolve(distDir, 'assets');
-  const assets = existsSync(assetsDir) ? readdirSync(assetsDir) : [];
-  const mainFile = assets.find((f) => /^main-[A-Za-z0-9_-]+\.js$/.test(f));
-  const mainJs = mainFile ? readFileSync(resolve(assetsDir, mainFile), 'utf-8') : '';
-
-  for (const chunk of DEFERRED_AGENT_BUS_CHUNKS) {
-    it(`${chunk}: built as its own isolated chunk (not inlined into main)`, () => {
-      assert.ok(
-        assets.some((f) => f.startsWith(`${chunk}-`) && f.endsWith('.js')),
-        `${chunk}-*.js chunk should exist — if it was inlined into main, a static import re-eagerised agent-bus-applier (and zod)`,
-      );
-    });
-
-    it(`${chunk}: absent from dashboard.html modulepreload`, () => {
-      const modulepreloadRe = new RegExp(`<link\\b[^>]+rel=["']modulepreload["'][^>]+href=["']/assets/${chunk}-[A-Za-z0-9_-]+\\.js["']`);
-      assert.ok(
-        !modulepreloadRe.test(html),
-        `${chunk} must not be eagerly modulepreloaded — agent-bus loads through the lazy chat-analyst panel`,
-      );
-    });
-
-    it(`${chunk}: not statically imported by the main entry chunk`, () => {
-      assert.ok(mainFile, 'main-*.js entry chunk should exist in dist/assets');
-      const staticImportRe = new RegExp(`(?:from|import)"\\./${chunk}-[A-Za-z0-9_-]+\\.js"`);
-      assert.ok(
-        !staticImportRe.test(mainJs),
-        `${chunk} must not be statically imported by ${mainFile} (dynamic preload-manifest references are fine)`,
-      );
-    });
-  }
+  registerDeferredChunkAssertions(DEFERRED_AGENT_BUS_CHUNKS, {
+    missingMessage: (chunk) => `${chunk}-*.js chunk should exist — if it was inlined into main, a static import re-eagerised agent-bus-applier (and zod)`,
+    preloadMessage: (chunk) => `${chunk} must not be eagerly modulepreloaded — agent-bus loads through the lazy chat-analyst panel`,
+  });
 });

--- a/tests/dashboard-eager-chunks.test.mjs
+++ b/tests/dashboard-eager-chunks.test.mjs
@@ -19,6 +19,17 @@ const dashboardHtml = resolve(distDir, 'dashboard.html');
 // before `npm run test:data` (the step added in #4393), so this runs in CI.
 const DEFERRED_TABLE_CHUNKS = ['tech-geo-data', 'airports-data', 'ai-datacenters-data', 'geo-map-data'];
 const DEFERRED_SENTRY_CHUNKS = ['sentry-init', 'sentry'];
+// agent-bus-applier + shared/agent-bus-actions pull in zod (~69KB raw). They are
+// only reachable through the lazy chat-analyst panel's action handler, so they
+// must ship in the chat-analyst graph (agent-bus-actions chunk), NOT eager main.
+// Re-adding a static `import { applyAgentBusAction }` to panel-layout would inline
+// the subtree (and zod) into main — collapsing this chunk and failing the guard.
+const DEFERRED_AGENT_BUS_CHUNKS = ['agent-bus-actions'];
+// npm libs only needed by opt-in/non-boot features, lazy-loaded off the eager entry:
+//   satellite.es  — satellite.js, loaded by the satellite layer (ensureSatelliteLib)
+//   confetti.module — canvas-confetti, loaded on the first milestone celebration
+// Re-adding a static `import` of either would re-eagerise it into main and fail this.
+const DEFERRED_NPM_LIB_CHUNKS = ['satellite.es', 'confetti.module'];
 
 describe('eager chunk budget: lazy-only config data tables stay off the entry', { skip: !existsSync(dashboardHtml) }, () => {
   const html = readFileSync(dashboardHtml, 'utf-8');
@@ -77,6 +88,75 @@ describe('eager chunk budget: Sentry stays behind the deferred scheduler', { ski
       assert.ok(
         !modulepreloadRe.test(html),
         `${chunk} must not be eagerly modulepreloaded in dashboard.html — Sentry must load through the deferred scheduler`,
+      );
+    });
+
+    it(`${chunk}: not statically imported by the main entry chunk`, () => {
+      assert.ok(mainFile, 'main-*.js entry chunk should exist in dist/assets');
+      const staticImportRe = new RegExp(`(?:from|import)"\\./${chunk}-[A-Za-z0-9_-]+\\.js"`);
+      assert.ok(
+        !staticImportRe.test(mainJs),
+        `${chunk} must not be statically imported by ${mainFile} (dynamic preload-manifest references are fine)`,
+      );
+    });
+  }
+});
+
+describe('eager chunk budget: opt-in npm libs stay off the entry', { skip: !existsSync(dashboardHtml) }, () => {
+  const html = readFileSync(dashboardHtml, 'utf-8');
+  const assetsDir = resolve(distDir, 'assets');
+  const assets = existsSync(assetsDir) ? readdirSync(assetsDir) : [];
+  const mainFile = assets.find((f) => /^main-[A-Za-z0-9_-]+\.js$/.test(f));
+  const mainJs = mainFile ? readFileSync(resolve(assetsDir, mainFile), 'utf-8') : '';
+
+  for (const chunk of DEFERRED_NPM_LIB_CHUNKS) {
+    const escaped = chunk.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    it(`${chunk}: built as its own isolated chunk`, () => {
+      assert.ok(
+        assets.some((f) => f.startsWith(`${chunk}-`) && f.endsWith('.js')),
+        `${chunk}-*.js chunk should exist — if missing, the lib was inlined into another chunk by a static import`,
+      );
+    });
+
+    it(`${chunk}: absent from dashboard.html modulepreload`, () => {
+      const modulepreloadRe = new RegExp(`<link\\b[^>]+rel=["']modulepreload["'][^>]+href=["']/assets/${escaped}-[A-Za-z0-9_-]+\\.js["']`);
+      assert.ok(
+        !modulepreloadRe.test(html),
+        `${chunk} must not be eagerly modulepreloaded — it loads on demand`,
+      );
+    });
+
+    it(`${chunk}: not statically imported by the main entry chunk`, () => {
+      assert.ok(mainFile, 'main-*.js entry chunk should exist in dist/assets');
+      const staticImportRe = new RegExp(`(?:from|import)"\\./${escaped}-[A-Za-z0-9_-]+\\.js"`);
+      assert.ok(
+        !staticImportRe.test(mainJs),
+        `${chunk} must not be statically imported by ${mainFile} (dynamic preload-manifest references are fine)`,
+      );
+    });
+  }
+});
+
+describe('eager chunk budget: agent-bus + zod stay behind the lazy chat-analyst panel', { skip: !existsSync(dashboardHtml) }, () => {
+  const html = readFileSync(dashboardHtml, 'utf-8');
+  const assetsDir = resolve(distDir, 'assets');
+  const assets = existsSync(assetsDir) ? readdirSync(assetsDir) : [];
+  const mainFile = assets.find((f) => /^main-[A-Za-z0-9_-]+\.js$/.test(f));
+  const mainJs = mainFile ? readFileSync(resolve(assetsDir, mainFile), 'utf-8') : '';
+
+  for (const chunk of DEFERRED_AGENT_BUS_CHUNKS) {
+    it(`${chunk}: built as its own isolated chunk (not inlined into main)`, () => {
+      assert.ok(
+        assets.some((f) => f.startsWith(`${chunk}-`) && f.endsWith('.js')),
+        `${chunk}-*.js chunk should exist — if it was inlined into main, a static import re-eagerised agent-bus-applier (and zod)`,
+      );
+    });
+
+    it(`${chunk}: absent from dashboard.html modulepreload`, () => {
+      const modulepreloadRe = new RegExp(`<link\\b[^>]+rel=["']modulepreload["'][^>]+href=["']/assets/${chunk}-[A-Za-z0-9_-]+\\.js["']`);
+      assert.ok(
+        !modulepreloadRe.test(html),
+        `${chunk} must not be eagerly modulepreloaded — agent-bus loads through the lazy chat-analyst panel`,
       );
     });
 

--- a/tests/load-all-data-scheduling.test.mts
+++ b/tests/load-all-data-scheduling.test.mts
@@ -112,6 +112,7 @@ function findTasksSliceCalls(node: ts.Node): string[] {
 describe('loadAllData scheduler', () => {
   const loadAllDataMethod = findMethod(DATA_LOADER_SOURCE, 'loadAllData');
   const runLoadAllDataMethod = findMethod(DATA_LOADER_SOURCE, 'runLoadAllData');
+  const loadSatellitesMethod = findMethod(DATA_LOADER_SOURCE, 'loadSatellites');
 
   it('does not add a blanket inter-batch startup delay', () => {
     const batchIdentifiers = findBlockedBatchIdentifiers(runLoadAllDataMethod);
@@ -142,6 +143,30 @@ describe('loadAllData scheduler', () => {
     assert.match(text, /this\.loadAllDataRerunRequested\s*=\s*true/);
     assert.match(text, /this\.loadAllDataQueuedForceAll\s*=\s*this\.loadAllDataQueuedForceAll\s*\|\|\s*forceAll/);
     assert.match(text, /return\s+this\.loadAllDataPromise/);
+  });
+
+  it('keeps satellite.js chunk failures local to the satellite layer', () => {
+    const text = loadSatellitesMethod.getText(DATA_LOADER_SOURCE);
+    assert.match(
+      text,
+      /try\s*\{[\s\S]*?this\.cachedSatRecs\s*=\s*await\s+initSatRecs\(data\);[\s\S]*?\}\s*catch\s*\(err\)\s*\{/,
+      'loadSatellites must catch lazy satellite.js import/init failures locally',
+    );
+    assert.match(
+      text,
+      /this\.cachedSatRecs\s*=\s*\[\];/,
+      'failed satellite initialization should clear cached satellite records',
+    );
+    assert.match(
+      text,
+      /this\.ctx\.map\?\.setSatellites\(\[\]\);/,
+      'failed satellite initialization should clear the rendered satellite layer',
+    );
+    assert.match(
+      text,
+      /return;/,
+      'failed satellite initialization should return without starting propagation',
+    );
   });
 });
 

--- a/tests/panel-layout-dynamic-import-guard.test.mts
+++ b/tests/panel-layout-dynamic-import-guard.test.mts
@@ -177,6 +177,40 @@ function assertSharedImportPanelGuard(source: string) {
   );
 }
 
+function assertChatAnalystLoadsWithoutAgentBusApplier(source: string) {
+  const registrationStart = source.indexOf("this.lazyPanel('chat-analyst'");
+  assert.notEqual(registrationStart, -1, 'chat-analyst lazy panel registration not found');
+  const registrationEnd = source.indexOf("this.lazyPanel('forecast'", registrationStart);
+  assert.ok(registrationEnd > registrationStart, 'chat-analyst lazy panel registration boundary not found');
+  const registration = source.slice(registrationStart, registrationEnd);
+
+  assert.match(
+    registration,
+    /import\('@\/components\/ChatAnalystPanel'\)\.then\(m => \{/,
+    'chat-analyst panel component should load independently',
+  );
+  assert.doesNotMatch(
+    registration,
+    /Promise\.all\(\s*\[[\s\S]*?@\/components\/ChatAnalystPanel[\s\S]*?@\/app\/agent-bus-applier/,
+    'chat-analyst must not couple panel mounting to agent-bus-applier through Promise.all',
+  );
+  assert.match(
+    registration,
+    /const panel = new m\.ChatAnalystPanel\(\);[\s\S]*?void import\('@\/app\/agent-bus-applier'\)/,
+    'chat-analyst should create the panel before loading the optional dashboard action handler',
+  );
+  assert.match(
+    registration,
+    /\.catch\(\(err\) => \{[\s\S]*?failed to lazy-load "chat-analyst" dashboard action handler/,
+    'agent-bus-applier lazy-load failure should be logged without rejecting the panel loader',
+  );
+  assert.match(
+    registration,
+    /return panel;/,
+    'chat-analyst loader should return the panel even while the optional action handler is loading',
+  );
+}
+
 const SPLIT_RISK_PANEL_IMPORTS: Array<[string, string, string]> = [
   ['pipeline-status', '@/components/PipelineStatusPanel', 'PipelineStatusPanel'],
   ['storage-facility-map', '@/components/StorageFacilityMapPanel', 'StorageFacilityMapPanel'],
@@ -210,6 +244,11 @@ describe('panel-layout lazy dynamic-import guard (WORLDMONITOR-R4)', () => {
       assertLazyPanelRegistration(source, panelKey, modulePath, exportName);
     }
     assertLazyLoaderHandlesFailedImports(source);
+  });
+
+  it('chat analyst mounts even if the dashboard action handler chunk fails', async () => {
+    const source = await readFile(filePath, 'utf8');
+    assertChatAnalystLoadsWithoutAgentBusApplier(source);
   });
 
   it('token-aware brace walker skips strings/templates/comments', () => {


### PR DESCRIPTION
## Summary

`main.js` (the eager dashboard entry chunk) was parsing/executing three npm payloads at boot that are only needed by opt-in or non-boot features. Build-verified attribution of `main.js` (via sourcemap decode) found these as the top deferrable contributors:

| Lib | Why eager (before) | Fix | Now in lazy chunk |
|---|---|---|---|
| **zod** (~69 KB raw) | `panel-layout.ts` *statically* imported `agent-bus-applier`, but `applyAgentBusAction` is only called **inside the already-lazy `chat-analyst` panel callback** | co-locate the import into that callback | `agent-bus-actions-*.js` |
| **satellite.js** (~20 KB) | `satellites.ts` statically imported it; reached eagerly via `data-loader` | lazy-load + cache via `ensureSatelliteLib()`; `initSatRecs()` is now `async` and resolves the lib before the sync `propagatePositions()` loop | `satellite.es-*.js` |
| **canvas-confetti** (~10 KB) | `celebration.ts` statically imported it; reached via `data-loader` | lazy-load on the first milestone burst (fire-and-forget) | `confetti.module-*.js` |

### Verified impact (`VITE_VARIANT=full` build)

- `main.js`: **999.3 → 892.0 KB raw (−107 KB)**, **233.0 → 203.4 KB brotli (−29.5 KB)**
- **0 circular chunks** (guards against the #4382 TDZ hazard)
- All three chunks confirmed **absent from the `dashboard.html` modulepreload** set and **not statically imported by `main`**
- Reduces eager main-thread parse/execute → directly targets the dashboard's remaining Total-Blocking-Time lever

This is the boot-service-defer follow-up after #4410's proto-client/bases approach was build-verified as ~15 KB brotli for far higher risk (see #4410 comment). These three are cleanly isolated, behavior-preserving deferrals.

## Test plan

- [x] `npm run typecheck` + `typecheck:api`
- [x] `npm run lint` (biome) + `lint:md`
- [x] `npm run version:check`
- [x] CJS syntax check (`scripts/*.cjs`) + edge-function esbuild bundle check
- [x] `node --test tests/edge-functions.test.mjs`
- [x] `npm run test:data` — 11639 pass / 0 fail
- [x] `tests/dashboard-eager-chunks.test.mjs` extended (+6 guards) — locks `agent-bus-actions`, `satellite.es`, `confetti.module` off the eager entry; re-adding a static import fails the guard
- [x] `agent-bus-applier` / `agent-bus-actions` / `panel-layout-dynamic-import-guard` behavior tests still green