### PR TITLE
perf(map): defer mobile SVG-map dynamic overlays off the first-paint path (#4429)

### DIFF
--- a/e2e/mobile-map-popup.spec.ts
+++ b/e2e/mobile-map-popup.spec.ts
@@ -20,6 +20,12 @@ type HarnessWindow = Window & {
   };
   __mobileMapIntegrationHarness?: {
     ready: boolean;
+    pendingDeferredCallbacks: number;
+    flushDeferredCallbacks: () => void;
+    destroyMap: () => void;
+    getDynamicLayerChildCount: () => number;
+    getInitialDynamicRendered: () => boolean;
+    getWrapperTransform: () => string;
     getPopupRect: () => {
       left: number;
       top: number;
@@ -265,6 +271,53 @@ test.describe('Mobile SVG popup integration path', () => {
     await popup.locator('.popup-close').first().tap();
     await expect(page.locator('.map-popup')).toHaveCount(0);
 
+    expect(pageErrors).toEqual([]);
+  });
+
+  test('defers overlays while preserving transform and guarding destroy', async ({ page }) => {
+    const pageErrors: string[] = [];
+    page.on('pageerror', (error) => pageErrors.push(error.message));
+
+    await page.goto('/tests/mobile-map-integration-harness.html?defer-control=1');
+
+    await expect
+      .poll(async () => {
+        return await page.evaluate(() => document.querySelectorAll('.country').length);
+      }, { timeout: 30000 })
+      .toBeGreaterThan(0);
+
+    await expect
+      .poll(async () => {
+        return await page.evaluate(() => {
+          const w = window as HarnessWindow;
+          return w.__mobileMapIntegrationHarness?.pendingDeferredCallbacks ?? 0;
+        });
+      }, { timeout: 10000 })
+      .toBeGreaterThan(0);
+
+    const transformBeforeFlush = await page.evaluate(() => {
+      const w = window as HarnessWindow;
+      return w.__mobileMapIntegrationHarness?.getWrapperTransform() ?? '';
+    });
+    expect(transformBeforeFlush).toContain('scale(2.7)');
+
+    const dynamicBeforeFlush = await page.evaluate(() => {
+      const w = window as HarnessWindow;
+      return w.__mobileMapIntegrationHarness?.getDynamicLayerChildCount() ?? -1;
+    });
+    expect(dynamicBeforeFlush).toBe(0);
+
+    await page.evaluate(() => {
+      const w = window as HarnessWindow;
+      w.__mobileMapIntegrationHarness?.destroyMap();
+      w.__mobileMapIntegrationHarness?.flushDeferredCallbacks();
+    });
+
+    const initialDynamicRendered = await page.evaluate(() => {
+      const w = window as HarnessWindow;
+      return w.__mobileMapIntegrationHarness?.getInitialDynamicRendered() ?? true;
+    });
+    expect(initialDynamicRendered).toBe(false);
     expect(pageErrors).toEqual([]);
   });
 });

--- a/src/bootstrap/secondary-startup.ts
+++ b/src/bootstrap/secondary-startup.ts
@@ -1,46 +1,7 @@
-type IdleCallback = () => void;
-type RequestIdleCallback = (cb: IdleCallback, opts?: { timeout: number }) => number;
+import { scheduleAfterFirstPaint } from '@/utils/after-paint';
 
 let vercelAnalyticsScheduled = false;
 let dashboardFontsScheduled = false;
-
-/**
- * Run non-critical startup work after the first paint and browser load event,
- * then yield to requestIdleCallback when the browser supports it.
- */
-export function scheduleAfterFirstPaint(task: () => void, timeoutMs = 3000): void {
-  if (typeof window === 'undefined' || typeof document === 'undefined') return;
-
-  let ran = false;
-  const runOnce = (): void => {
-    if (ran) return;
-    ran = true;
-    task();
-  };
-
-  const scheduleIdle = (): void => {
-    const ric = (window as unknown as { requestIdleCallback?: RequestIdleCallback }).requestIdleCallback;
-    if (typeof ric === 'function') {
-      ric(runOnce, { timeout: timeoutMs });
-      return;
-    }
-    setTimeout(runOnce, 0);
-  };
-
-  const afterPaint = (): void => {
-    if (typeof window.requestAnimationFrame === 'function') {
-      window.requestAnimationFrame(() => window.requestAnimationFrame(scheduleIdle));
-      return;
-    }
-    scheduleIdle();
-  };
-
-  if (document.readyState === 'complete') {
-    afterPaint();
-  } else {
-    window.addEventListener('load', afterPaint, { once: true });
-  }
-}
 
 export interface DashboardFontContext {
   variant?: string | null;
@@ -131,4 +92,3 @@ export function initVercelAnalytics(): void {
       });
   }, 3000);
 }
-

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -196,6 +196,9 @@ export class MapComponent {
   // SVG renderer and its synchronous overlay build was the #1 boot-scripting cost (~1.3s).
   private initialDynamicRendered = false;
   private initialDynamicScheduled = false;
+  // Set in destroy(); guards render() (incl. the deferred first-paint callback and the
+  // resize/visibility rAF callbacks) from running on a torn-down instance.
+  private destroyed = false;
 
   constructor(container: HTMLElement, initialState: MapState, options: MapComponentOptions = {}) {
     this.container = container;
@@ -297,6 +300,7 @@ export class MapComponent {
   }
 
   public destroy(): void {
+    this.destroyed = true;
     window.removeEventListener('theme-changed', this.handleThemeChange);
     document.removeEventListener('visibilitychange', this.boundVisibilityHandler);
     if (this.resizeObserver) {
@@ -1073,6 +1077,7 @@ export class MapComponent {
   }
 
   public render(): void {
+    if (this.destroyed) return;
     const now = performance.now();
     if (now - this.lastRenderTime < this.MIN_RENDER_INTERVAL_MS) {
       this.scheduleRender();

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -15,7 +15,7 @@ import type { WeatherAlert } from '@/services/weather';
 import type { RadiationObservation } from '@/services/radiation';
 import { getSeverityColor } from '@/services/weather';
 import { startSmartPollLoop, type SmartPollLoopHandle } from '@/services/smart-poll-loop';
-import { scheduleAfterFirstPaint } from '@/bootstrap/secondary-startup';
+import { scheduleAfterFirstPaint } from '@/utils/after-paint';
 import {
   INTEL_HOTSPOTS,
   CONFLICT_ZONES,
@@ -1175,10 +1175,12 @@ export class MapComponent {
       if (!this.initialDynamicScheduled) {
         this.initialDynamicScheduled = true;
         scheduleAfterFirstPaint(() => {
+          if (this.destroyed) return;
           this.initialDynamicRendered = true;
           this.render();
         });
       }
+      this.applyTransform();
       return;
     }
 

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -15,6 +15,7 @@ import type { WeatherAlert } from '@/services/weather';
 import type { RadiationObservation } from '@/services/radiation';
 import { getSeverityColor } from '@/services/weather';
 import { startSmartPollLoop, type SmartPollLoopHandle } from '@/services/smart-poll-loop';
+import { scheduleAfterFirstPaint } from '@/bootstrap/secondary-startup';
 import {
   INTEL_HOTSPOTS,
   CONFLICT_ZONES,
@@ -190,6 +191,11 @@ export class MapComponent {
   private lastRenderTime = 0;
   private readonly MIN_RENDER_INTERVAL_MS = 100;
   private healthCheckLoop: SmartPollLoopHandle | null = null;
+  // First render paints the base map (countries) synchronously for LCP, then defers the
+  // heavy dynamic-overlay pass off the first-paint critical path (#4429). Mobile uses this
+  // SVG renderer and its synchronous overlay build was the #1 boot-scripting cost (~1.3s).
+  private initialDynamicRendered = false;
+  private initialDynamicScheduled = false;
 
   constructor(container: HTMLElement, initialState: MapState, options: MapComponentOptions = {}) {
     this.container = container;
@@ -1153,6 +1159,22 @@ export class MapComponent {
       // Countries
       this.renderCountries(this.baseLayerGroup, basePath);
       this.baseRendered = true;
+    }
+
+    // Defer the first dynamic-overlay pass off the first-paint critical path. The base map
+    // (countries) above is enough for LCP; the dynamic layer below (cables/pipelines/
+    // conflicts/AIS/cluster markers/overlays) is the heavy synchronous cost (#4429 — ~1.3s
+    // of mobile boot scripting, the #1 mobile-TBT contributor since mobile uses this SVG
+    // renderer). After first paint, render fully so interactions update overlays immediately.
+    if (!this.initialDynamicRendered) {
+      if (!this.initialDynamicScheduled) {
+        this.initialDynamicScheduled = true;
+        scheduleAfterFirstPaint(() => {
+          this.initialDynamicRendered = true;
+          this.render();
+        });
+      }
+      return;
     }
 
     // Always rebuild dynamic layer - use native DOM clear for reliability

--- a/src/e2e/mobile-map-integration-harness.ts
+++ b/src/e2e/mobile-map-integration-harness.ts
@@ -4,6 +4,12 @@ import { initI18n } from '../services/i18n';
 
 type MobileMapIntegrationHarness = {
   ready: boolean;
+  pendingDeferredCallbacks: number;
+  flushDeferredCallbacks: () => void;
+  destroyMap: () => void;
+  getDynamicLayerChildCount: () => number;
+  getInitialDynamicRendered: () => boolean;
+  getWrapperTransform: () => string;
   getPopupRect: () => {
     left: number;
     top: number;
@@ -25,6 +31,15 @@ declare global {
 const app = document.getElementById('app');
 if (!app) {
   throw new Error('Missing #app container for mobile map integration harness');
+}
+
+const controlDeferredCallbacks = new URLSearchParams(window.location.search).get('defer-control') === '1';
+const deferredCallbacks: IdleRequestCallback[] = [];
+if (controlDeferredCallbacks) {
+  window.requestIdleCallback = ((callback: IdleRequestCallback) => {
+    deferredCallbacks.push(callback);
+    return deferredCallbacks.length;
+  }) as typeof window.requestIdleCallback;
 }
 
 document.body.style.margin = '0';
@@ -214,6 +229,27 @@ window.__mobileMapIntegrationHarness = {
   get ready() {
     return ready;
   },
+  get pendingDeferredCallbacks() {
+    return deferredCallbacks.length;
+  },
+  flushDeferredCallbacks: () => {
+    const callbacks = deferredCallbacks.splice(0);
+    callbacks.forEach((callback) => {
+      callback({
+        didTimeout: false,
+        timeRemaining: () => 50,
+      });
+    });
+  },
+  destroyMap: () => {
+    map.destroy();
+  },
+  getDynamicLayerChildCount: () =>
+    document.querySelector('.map-dynamic')?.childElementCount ?? 0,
+  getInitialDynamicRendered: () =>
+    Boolean((map as unknown as { initialDynamicRendered?: boolean }).initialDynamicRendered),
+  getWrapperTransform: () =>
+    (document.querySelector('.map-wrapper') as HTMLElement | null)?.style.transform ?? '',
   getPopupRect: () => {
     const element = document.querySelector('.map-popup') as HTMLElement | null;
     if (!element) return null;

--- a/src/services/analytics.ts
+++ b/src/services/analytics.ts
@@ -5,7 +5,7 @@
  * arrives are kept in a small bounded queue and replayed on script load.
  */
 
-import { scheduleAfterFirstPaint } from '@/bootstrap/secondary-startup';
+import { scheduleAfterFirstPaint } from '@/utils/after-paint';
 import { subscribeAuthState, type AuthSession } from './auth-state';
 import { onSubscriptionChange, type SubscriptionInfo } from './billing';
 import { getClerkUserCreatedAt } from './clerk';

--- a/src/utils/after-paint.ts
+++ b/src/utils/after-paint.ts
@@ -1,0 +1,39 @@
+type IdleCallback = () => void;
+type RequestIdleCallback = (cb: IdleCallback, opts?: { timeout: number }) => number;
+
+/**
+ * Run non-critical work after first paint and browser load, then yield to idle time when available.
+ */
+export function scheduleAfterFirstPaint(task: () => void, timeoutMs = 3000): void {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return;
+
+  let ran = false;
+  const runOnce = (): void => {
+    if (ran) return;
+    ran = true;
+    task();
+  };
+
+  const scheduleIdle = (): void => {
+    const ric = (window as unknown as { requestIdleCallback?: RequestIdleCallback }).requestIdleCallback;
+    if (typeof ric === 'function') {
+      ric(runOnce, { timeout: timeoutMs });
+      return;
+    }
+    setTimeout(runOnce, 0);
+  };
+
+  const afterPaint = (): void => {
+    if (typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(() => window.requestAnimationFrame(scheduleIdle));
+      return;
+    }
+    scheduleIdle();
+  };
+
+  if (document.readyState === 'complete') {
+    afterPaint();
+  } else {
+    window.addEventListener('load', afterPaint, { once: true });
+  }
+}

--- a/tests/map-deferred-overlays.test.mts
+++ b/tests/map-deferred-overlays.test.mts
@@ -17,7 +17,7 @@ describe('mobile SVG map: defer dynamic overlays off first paint (#4429)', () =>
   it('imports the first-paint scheduler and declares the one-time flags', () => {
     assert.match(
       mapSrc,
-      /import \{ scheduleAfterFirstPaint \} from '@\/bootstrap\/secondary-startup'/,
+      /import \{ scheduleAfterFirstPaint \} from '@\/utils\/after-paint'/,
       'Map.ts must import scheduleAfterFirstPaint for the deferral',
     );
     assert.match(mapSrc, /private initialDynamicRendered = false/);
@@ -51,6 +51,19 @@ describe('mobile SVG map: defer dynamic overlays off first paint (#4429)', () =>
       mapSrc,
       /public render\(\): void \{\s*\n\s*if \(this\.destroyed\) return;/,
       'render() must early-return when destroyed so the deferred first-paint callback cannot run on a torn-down instance',
+    );
+    assert.match(
+      mapSrc,
+      /scheduleAfterFirstPaint\(\(\) => \{\s*\n\s*if \(this\.destroyed\) return;\s*\n\s*this\.initialDynamicRendered = true;/,
+      'the deferred callback must not mutate render state after destroy()',
+    );
+  });
+
+  it('applies the current map transform before returning from the first-paint gate', () => {
+    assert.match(
+      mapSrc,
+      /if \(!this\.initialDynamicRendered\) \{[\s\S]*?scheduleAfterFirstPaint\(\(\) => \{[\s\S]*?if \(this\.destroyed\) return;[\s\S]*?this\.render\(\);[\s\S]*?\}\);\s*\n\s*\}\s*\n\s*this\.applyTransform\(\);\s*\n\s*return;\s*\n\s*\}/,
+      'applyTransform must run immediately before the first-paint gate returns',
     );
   });
 

--- a/tests/map-deferred-overlays.test.mts
+++ b/tests/map-deferred-overlays.test.mts
@@ -1,0 +1,59 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Structural guard for the mobile SVG-map first-paint deferral (#4429). The full
+// MapComponent is not instantiated in unit tests (heavy d3/topojson/canvas/DOM) — the
+// repo verifies Map.ts behavior via source-structure assertions (see
+// globe-default-map-mode.test.mts). Runtime/perf verification is the prod mobile
+// Lighthouse re-read (Map-*.js boot scripting vs the ~1277 ms baseline).
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const mapSrc = readFileSync(resolve(root, 'src/components/Map.ts'), 'utf-8');
+
+describe('mobile SVG map: defer dynamic overlays off first paint (#4429)', () => {
+  it('imports the first-paint scheduler and declares the one-time flags', () => {
+    assert.match(
+      mapSrc,
+      /import \{ scheduleAfterFirstPaint \} from '@\/bootstrap\/secondary-startup'/,
+      'Map.ts must import scheduleAfterFirstPaint for the deferral',
+    );
+    assert.match(mapSrc, /private initialDynamicRendered = false/);
+    assert.match(mapSrc, /private initialDynamicScheduled = false/);
+  });
+
+  it('gates the dynamic-overlay pass behind the first-paint defer with a single schedule + early return', () => {
+    // The gate: on first render, schedule once and return before the dynamic block.
+    assert.match(
+      mapSrc,
+      /if \(!this\.initialDynamicRendered\) \{[\s\S]*?if \(!this\.initialDynamicScheduled\) \{[\s\S]*?this\.initialDynamicScheduled = true;[\s\S]*?scheduleAfterFirstPaint\(\(\) => \{[\s\S]*?this\.initialDynamicRendered = true;[\s\S]*?this\.render\(\);[\s\S]*?\}\);[\s\S]*?\}[\s\S]*?return;[\s\S]*?\}/,
+      'render() must schedule the dynamic pass once via scheduleAfterFirstPaint and return on first render',
+    );
+  });
+
+  it('keeps the base layer (countries) synchronous — rendered BEFORE the defer gate (LCP-critical)', () => {
+    const baseIdx = mapSrc.indexOf('this.renderCountries(this.baseLayerGroup');
+    const gateIdx = mapSrc.indexOf('if (!this.initialDynamicRendered)');
+    assert.ok(baseIdx > 0, 'renderCountries must exist in render()');
+    assert.ok(gateIdx > 0, 'the defer gate must exist');
+    assert.ok(
+      baseIdx < gateIdx,
+      'renderCountries (base/LCP) must run before the dynamic-defer gate',
+    );
+  });
+
+  it('defers the heavy dynamic layers — they run AFTER the gate', () => {
+    const gateIdx = mapSrc.indexOf('if (!this.initialDynamicRendered)');
+    for (const marker of [
+      'this.renderClusterLayer(projection)',
+      'this.renderOverlays(projection)',
+      'this.renderCables(projection)',
+    ]) {
+      const idx = mapSrc.indexOf(marker);
+      assert.ok(idx > 0, `${marker} must exist`);
+      assert.ok(idx > gateIdx, `${marker} must run after the defer gate (deferred off first paint)`);
+    }
+  });
+});

--- a/tests/map-deferred-overlays.test.mts
+++ b/tests/map-deferred-overlays.test.mts
@@ -44,6 +44,16 @@ describe('mobile SVG map: defer dynamic overlays off first paint (#4429)', () =>
     );
   });
 
+  it('guards render() against running on a destroyed instance (deferred callback safety)', () => {
+    assert.match(mapSrc, /private destroyed = false/);
+    assert.match(mapSrc, /public destroy\(\): void \{\s*\n\s*this\.destroyed = true;/);
+    assert.match(
+      mapSrc,
+      /public render\(\): void \{\s*\n\s*if \(this\.destroyed\) return;/,
+      'render() must early-return when destroyed so the deferred first-paint callback cannot run on a torn-down instance',
+    );
+  });
+
   it('defers the heavy dynamic layers — they run AFTER the gate', () => {
     const gateIdx = mapSrc.indexOf('if (!this.initialDynamicRendered)');
     for (const marker of [

--- a/tests/secondary-startup.test.mts
+++ b/tests/secondary-startup.test.mts
@@ -4,7 +4,8 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { dashboardFontFamilies, scheduleAfterFirstPaint } from '../src/bootstrap/secondary-startup.ts';
+import { dashboardFontFamilies } from '../src/bootstrap/secondary-startup.ts';
+import { scheduleAfterFirstPaint } from '../src/utils/after-paint.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');


### PR DESCRIPTION
Closes #4429.

## Summary

On mobile the dashboard renders the D3/SVG `MapComponent` (`src/components/Map.ts`), not deck.gl/maplibre (desktop). Its first render built the base map **and all dynamic overlays synchronously** — measured as **~1277 ms of boot scripting, the #1 mobile-TBT contributor** (prod mobile Lighthouse ×3, 2026-06-25: Perf 67, TBT ~1691 ms, LCP fine at 1.3 s; `scriptEvaluation` 3705 ms ≫ `styleLayout` 1320 ms).

This gates the dynamic-overlay pass behind a one-time flag + the existing `scheduleAfterFirstPaint`:
- **Base map (countries/grid/graticule) still paints synchronously** → no LCP regression.
- **Dynamic layer** (cables/pipelines/conflicts/AIS + always-on cluster markers + overlays) is **deferred off the first-paint critical path**.
- **After first paint, `render()` runs the full pipeline** → zoom/pan/layer-toggle/theme interactions update overlays immediately (no deferred-overlay lag).

The change maps onto `render()`'s existing base-vs-dynamic seam — 22 lines, runtime-scheduling only (no chunk-graph change).

## Why this (and not #4410)

Build-verified + measured this session: #4410's data-table defers (feeds/bases/proto) are ~49 ms each — noise vs the 1277 ms map cost. #4425 already banked the big eager-JS win (zod/satellite/confetti, −29.5 KB brotli). #4410/#3944 closed. The byte-attribution lesson: **rank eager-JS work by measured boot-scripting ms, not chunk byte size** (the feeds catalog is 19 KB brotli but only 49 ms).

## Risk

- Mobile/fallback SVG `MapComponent` only; desktop `DeckGLMap`/`GlobeMap` unchanged.
- Low blast radius: worst case (if base/topojson dominated the 1277 ms) it's a smaller win, not a regression. Flags guard against stuck overlays (`scheduleAfterFirstPaint` has a 3 s timeout fallback; next interaction render recovers).
- This is the mobile-primary renderer → verify on a real mobile viewport post-merge.

## Test plan

- [x] `npm run typecheck` + `typecheck:api`
- [x] `npm run lint` (biome) + `lint:md` + `version:check` + CJS syntax + edge esbuild bundle
- [x] `node --test tests/edge-functions.test.mjs`
- [x] `npm run test:data` — 11650 pass / 0 fail
- [x] `VITE_VARIANT=full` build — **0 circular chunks**; Map chunk unchanged (~88 KB, no bootstrap bloat); still lazy (off eager modulepreload)
- [x] New `tests/map-deferred-overlays.test.mts` — structural guard (base before gate, overlays after; scheduler imported)
- [ ] **Post-merge:** prod mobile Lighthouse re-read — `Map-*.js` boot scripting vs the 1277 ms baseline (the meaningful perf verification; local mobile Lighthouse is CPU-contention noise)