### PR TITLE
fix(sentry): rss-proxy bad-URL 500s + Perplexity font CSP noise

### DIFF
--- a/api/rss-proxy.js
+++ b/api/rss-proxy.js
@@ -91,9 +91,19 @@ export default async function handler(req, ctx) {
     return jsonResponse({ error: 'Missing url parameter' }, 400, corsHeaders);
   }
 
+  // A malformed `url` param is a client error, not a server fault. Parse it up
+  // front and return 400 WITHOUT a Sentry capture — otherwise `new URL()` throws
+  // "Invalid URL string." inside the try below, which the catch reports as an
+  // error-level exception and answers with a 502 (WORLDMONITOR-TT: 21 events from
+  // malformed/double-encoded feed params).
+  let parsedUrl;
   try {
-    const parsedUrl = new URL(feedUrl);
+    parsedUrl = new URL(feedUrl);
+  } catch {
+    return jsonResponse({ error: 'Invalid url parameter' }, 400, corsHeaders);
+  }
 
+  try {
     // Security: Check if domain is allowed (normalize www prefix)
     const hostname = parsedUrl.hostname;
     if (!isAllowedDomain(hostname)) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -177,6 +177,13 @@ function shouldSuppressCspViolation(
     try {
       const url = new URL(blockedURI);
       if (url.protocol === 'https:' && url.hostname === 'fonts.gstatic.com' && /^\/s\/.+\.woff2$/.test(url.pathname)) return true;
+      // Perplexity's Comet browser / extension injects its own UI webfont
+      // (frontend-cdn.perplexity.ai/_agi_assets/fonts/*.woff2) into every page.
+      // We never load it; the block is the overlay's font failing regardless of
+      // our code. Allowlisted by exact host like gstatic above — NOT a blanket
+      // third-party suppression, so an unexpected font injection from any other
+      // host still surfaces (WORLDMONITOR-TR: 1065 events / 83 users).
+      if (url.protocol === 'https:' && url.hostname === 'frontend-cdn.perplexity.ai' && /\.woff2?$/.test(url.pathname)) return true;
     } catch { /* scheme-only values fall through */ }
   }
   // YouTube live stream manifests.

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -209,6 +209,16 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
       assert.ok(!suppress('enforce', 'font-src', 'https://fonts.evil.example/s/mulish/v18/font.woff2', '', false));
     });
 
+    it('suppresses Perplexity Comet overlay webfont injection (WORLDMONITOR-TR)', () => {
+      assert.ok(suppress('enforce', 'font-src', 'https://frontend-cdn.perplexity.ai/_agi_assets/fonts/FKGroteskNeue.woff2', '', false));
+      assert.ok(suppress('enforce', 'font-src', 'https://frontend-cdn.perplexity.ai/_agi_assets/fonts/FKGroteskNeue.woff', '', false));
+    });
+
+    it('does NOT suppress a perplexity.ai lookalike host or non-font path', () => {
+      assert.ok(!suppress('enforce', 'font-src', 'https://frontend-cdn.perplexity.ai.evil.com/x.woff2', '', false));
+      assert.ok(!suppress('enforce', 'font-src', 'https://frontend-cdn.perplexity.ai/_agi_assets/app.js', '', false));
+    });
+
     it('does NOT suppress Google Fonts under unrelated directives', () => {
       assert.ok(!suppress('enforce', 'script-src', 'https://fonts.gstatic.com/s/mulish/v18/1Ptvg83HX_SGhgqk2wotcqA.woff2', '', false));
     });


### PR DESCRIPTION
## Summary

Triage of the production Sentry unresolved queue — two issues fixed, four verified as intentional/already-handled and deliberately left to surface.

**Fixed (both marked resolved in Sentry, `inNextRelease`):**
- **WORLDMONITOR-TT** (21 ev / 6 users) — `api/rss-proxy.js` fed a malformed `url` query param into `new URL()`, throwing `Invalid URL string.` inside the fetch `try`; the catch reported it as an **error-level** exception and answered **502**. A malformed client param is a client error: parse it up front and return **400** with no Sentry capture.
- **WORLDMONITOR-TR** (1065 ev / 83 users) — Perplexity's Comet browser/extension injects its own UI webfont (`frontend-cdn.perplexity.ai/_agi_assets/fonts/*.woff2`) into every page; `font-src 'self' data:` blocks it and the CSP reporter forwarded the noise. Allowlisted that **exact host** in `shouldSuppressCspViolation`, mirroring the existing `fonts.gstatic.com` rule — an exact-host allowlist, **not** a blanket third-party suppression, so unexpected font injection from any other host still surfaces.

**Deliberately NOT changed** (verified intentional or already-handled — existing tests/code prove the intent):
- **SR** — Convex `InternalServerError` already maps to 503 + Retry-After at `warning` level (intentional upstream-500 observability).
- **TS** — zero-frame `SyntaxError` is intentionally surfaced as a stale-bundle/deploy signal (an existing `csp`/`beforeSend` test asserts it).
- **TQ** — Dodo deadlock watchdog `captureMessage` is intentional self-heal telemetry.

> Operational note (no code change): **SR** is a recurring upstream Convex `InternalServerError` (464 ev / 21 users) — gracefully degraded, but worth checking Convex health.

## Test plan
- [x] `npm run typecheck` + `typecheck:api`
- [x] `npm run lint` (biome)
- [x] `csp-filter` + `sentry-beforesend` tests — 255/255 (+4 new `font-src` cases: Perplexity suppress, lookalike-host reject, non-font-path reject)
- [x] `test:data` — 11630/11638 (the 2 failures are `dashboard-critical-css` build-output tests requiring `VITE_VARIANT=full vite build`; unrelated, fail on clean `main` too)
- [x] edge-function esbuild bundles + `edge-functions.test.mjs`
- [x] `version:check`, markdown lint

https://claude.ai/code/session_01SfU43TAhhi8VSE5geCdCjT