### PR TITLE
Add AviationStack monthly budget cap and freshness gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,6 +117,20 @@ AVIATIONSTACK_API=
 # Keep below 85 so freshness stays within the health staleness window.
 AVIATIONSTACK_MIN_REFRESH_MIN=55
 
+# AviationStack monthly call budget (optional, hard ceiling). Every paid call —
+# the seeder AND the request-time panel endpoints (flights, flight-status) —
+# increments one shared Redis counter and refuses to call upstream once its
+# ceiling is hit, so total spend can never exceed your plan.
+#   AVIATIONSTACK_MONTHLY_BUDGET  all calls stop here (default 130000)
+#   AVIATIONSTACK_REQUEST_BUDGET  request-time calls stop earlier (default
+#                                 85000); the gap reserves headroom for the
+#                                 curated seeder so panel traffic can't starve
+#                                 the map/health data.
+# Defaults sum under a 135000-call plan with margin. Set MONTHLY budget to 0 to
+# disable the cap.
+AVIATIONSTACK_MONTHLY_BUDGET=130000
+AVIATIONSTACK_REQUEST_BUDGET=85000
+
 # ICAO API (NOTAM airport closures — optional, MENA region)
 # Register at: https://applications.icao.int/
 ICAO_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -114,7 +114,7 @@ AVIATIONSTACK_API=
 # the minimum minutes between paid fetches: when last-good intl delay data is
 # younger than this, the seeder serves last-good and skips the fetch, capping
 # spend regardless of cron cadence. Default 55. Set 0 to fetch every tick.
-# Keep below 85 so freshness stays within the health staleness window.
+# Values above 60 are clamped so freshness stays within the health staleness window.
 AVIATIONSTACK_MIN_REFRESH_MIN=55
 
 # AviationStack monthly call budget (optional, hard ceiling). Every paid call —

--- a/.env.example
+++ b/.env.example
@@ -109,6 +109,14 @@ WAQI_API_KEY=
 # Register at: https://aviationstack.com/
 AVIATIONSTACK_API=
 
+# AviationStack quota guard (optional). The aviation seeder makes one paid
+# AviationStack call per monitored airport (~55) on every cron tick. This sets
+# the minimum minutes between paid fetches: when last-good intl delay data is
+# younger than this, the seeder serves last-good and skips the fetch, capping
+# spend regardless of cron cadence. Default 55. Set 0 to fetch every tick.
+# Keep below 85 so freshness stays within the health staleness window.
+AVIATIONSTACK_MIN_REFRESH_MIN=55
+
 # ICAO API (NOTAM airport closures — optional, MENA region)
 # Register at: https://applications.icao.int/
 ICAO_API_KEY=

--- a/api/seed-health.js
+++ b/api/seed-health.js
@@ -64,7 +64,7 @@ const SEED_DOMAINS = {
   'supply_chain:chokepoints': { key: 'seed-meta:supply_chain:chokepoints', intervalMin: 30 },
   'cable-health':             { key: 'seed-meta:cable-health',             intervalMin: 30 },
   'prediction:markets':       { key: 'seed-meta:prediction:markets',       intervalMin: 8 },
-  'aviation:intl':            { key: 'seed-meta:aviation:intl',            intervalMin: 15 },
+  'aviation:intl':            { key: 'seed-meta:aviation:intl',            intervalMin: 45 }, // intervalMin*2 = 90min staleness. seed-aviation's freshness gate (AVIATIONSTACK_MIN_REFRESH_MIN, default 55) lets fetchedAt age to ~55+cron between paid fetches; 90min matches the aviation:faa sibling + api/health.js intlDelays maxStaleMin:90. Was 15 (30min) and false-WARNed every cycle once the gate landed.
   'theater-posture':          { key: 'seed-meta:theater-posture',          intervalMin: 8 },
   'economic:worldbank-techreadiness': { key: 'seed-meta:economic:worldbank-techreadiness:v1', intervalMin: 5040 },
   'economic:worldbank-progress':      { key: 'seed-meta:economic:worldbank-progress:v1',     intervalMin: 5040 },

--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -1137,7 +1137,7 @@ async function runNewsSideCar() {
 // than being suppressed by the gate. Fail-open: any read error / missing meta /
 // non-numeric fetchedAt → false (fetch), so we never trade freshness for a
 // flaky Redis read.
-async function intlIsFresh() {
+export async function intlIsFresh() {
   if (INTL_MIN_REFRESH_MIN <= 0) return false;
   try {
     const meta = await readCanonicalValue(INTL_META_KEY);
@@ -1152,17 +1152,17 @@ async function intlIsFresh() {
 }
 
 // Monthly AviationStack budget backstop. Mirrors reserveAviationStackCalls() in
-// server/worldmonitor/aviation/v1/_shared.ts — SAME Redis key + env names so the
-// seeder and the request-time RPCs share one counter and one hard ceiling.
-// Keep the two in lockstep. 'seed' kind reserves against the full
-// AVIATIONSTACK_MONTHLY_BUDGET; request-time stops earlier (see _shared.ts),
-// reserving headroom for this curated feed.
-function avstackMonthlyBudget() {
+// server/worldmonitor/aviation/v1/_avstack-budget.ts — SAME Redis key + env
+// names so the seeder and the request-time RPCs share one counter and one hard
+// ceiling. Keep the two in lockstep. 'seed' kind reserves against the full
+// AVIATIONSTACK_MONTHLY_BUDGET; request-time stops earlier (see
+// _avstack-budget.ts), reserving headroom for this curated feed.
+export function avstackMonthlyBudget() {
   const raw = Number(process.env.AVIATIONSTACK_MONTHLY_BUDGET ?? 130_000);
   return Number.isFinite(raw) && raw >= 0 ? raw : 130_000;
 }
 
-async function reserveAviationStackBudget(count) {
+export async function reserveAviationStackBudget(count) {
   const cap = avstackMonthlyBudget();
   if (cap <= 0 || count <= 0) return true; // disabled
   const { url, token } = getRedisCredentials();
@@ -1206,7 +1206,17 @@ async function fetchIntl() {
     const why = result.skipped
       ? 'no AVIATIONSTACK_API key'
       : 'systemic fetch failure (failures > successes)';
-    throw new Error(`intl unpublishable: ${why}`);
+    // nonRetryable is load-bearing for the budget cap. Without it, runSeed's
+    // withRetry re-runs fetchIntl up to 4x on an unhealthy tick, and EACH run
+    // sweeps the FULL airport list again — so a degraded upstream costs up to
+    // 4x the paid AviationStack calls while the budget counter (reserved once
+    // in main()) only saw one batch, letting actual spend run past the ceiling
+    // exactly when the cap matters most. Tagging the error makes withRetry exit
+    // after one attempt, keeping actual calls bounded by the single
+    // reservation. We lose nothing: the seeder already re-runs every cron tick.
+    const err = new Error(`intl unpublishable: ${why}`);
+    err.nonRetryable = true;
+    throw err;
   }
   return result;
 }
@@ -1301,7 +1311,14 @@ async function main() {
   });
 }
 
-main().catch((err) => {
+// isMain guard so tests/agents can `import` the pure helpers (intlIsFresh,
+// reserveAviationStackBudget, declareRecords) without firing the side-cars +
+// runSeed on module load (which would touch Redis and process.exit). Matches
+// the repo convention (see scripts/seed-token-panels.mjs, seed-cyber-threats).
+// Railway still runs the seed via `node scripts/seed-aviation.mjs` because
+// argv[1] resolves to this file.
+const isMain = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/^.*[\\/]/, ''));
+if (isMain) main().catch((err) => {
   const cause = err.cause ? ` (cause: ${err.cause.message || err.cause.code || err.cause})` : '';
   console.error('FATAL:', (err.message || err) + cause);
   process.exit(1);

--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -64,11 +64,11 @@ const NOTAM_TTL     = 7_200;  // 2h
 const NEWS_TTL      = 2_400;  // 40min
 const BOOTSTRAP_TTL = 7_200;  // 2h — matches FAA/NOTAM; survives ~4 missed cron ticks
 
-function nonNegativeEnv(name, fallback) {
+function nonNegativeEnv(name, fallback, max = Number.POSITIVE_INFINITY) {
   const value = process.env[name]?.trim();
   if (!value) return fallback;
   const raw = Number(value);
-  return Number.isFinite(raw) && raw >= 0 ? raw : fallback;
+  return Number.isFinite(raw) && raw >= 0 ? Math.min(raw, max) : fallback;
 }
 
 // AviationStack quota guard. AviationStack is a PAID, per-airport API: one call
@@ -79,12 +79,13 @@ function nonNegativeEnv(name, fallback) {
 // SKIP the fetch entirely and just extend the last-good TTLs — turning the cron
 // cadence into an effective floor of INTL_MIN_REFRESH_MIN between paid fetches.
 //
-// Keep below runSeed's maxStaleMin (90) minus one cron interval so seed-meta
-// fetchedAt never ages into a false STALE_SEED: 55min default leaves headroom
-// even on a 30min cron (worst-case fetchedAt age ≈ 55+30 = 85 < 90). Set to 0
-// to disable the gate (fetch every tick, legacy behaviour). Override via
-// AVIATIONSTACK_MIN_REFRESH_MIN.
-const INTL_MIN_REFRESH_MIN = nonNegativeEnv('AVIATIONSTACK_MIN_REFRESH_MIN', 55);
+// Keep at or below runSeed's maxStaleMin (90) minus one 30min cron interval so
+// seed-meta fetchedAt never ages into a false STALE_SEED: 55min default leaves
+// headroom even on a 30min cron (worst-case fetchedAt age ≈ 55+30 = 85 < 90).
+// Set to 0 to disable the gate (fetch every tick, legacy behaviour). Override
+// via AVIATIONSTACK_MIN_REFRESH_MIN.
+const MAX_INTL_MIN_REFRESH_MIN = 60;
+const INTL_MIN_REFRESH_MIN = nonNegativeEnv('AVIATIONSTACK_MIN_REFRESH_MIN', 55, MAX_INTL_MIN_REFRESH_MIN);
 
 // health.js expects these exact meta keys (api/health.js:222,223,269)
 const INTL_META_KEY  = 'seed-meta:aviation:intl';
@@ -1188,13 +1189,24 @@ export async function reserveAviationStackBudget(count) {
     if (total > cap) {
       // Return the reservation so the counter reflects calls actually made.
       try {
-        await fetch(`${url}/pipeline`, {
+        const refundResp = await fetch(`${url}/pipeline`, {
           method: 'POST',
           headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
           body: JSON.stringify([['DECRBY', key, count]]),
           signal: AbortSignal.timeout(10_000),
         });
-      } catch {}
+        if (!refundResp.ok) {
+          console.warn(`[Aviation] AviationStack seed budget refund failed with HTTP ${refundResp.status}; counter may be inflated`);
+        } else {
+          const refundResults = await refundResp.json();
+          const refundedTotal = Number(refundResults?.[0]?.result);
+          if (!Number.isFinite(refundedTotal)) {
+            console.warn(`[Aviation] AviationStack seed budget refund returned no counter; counter may be inflated`);
+          }
+        }
+      } catch (err) {
+        console.warn(`[Aviation] AviationStack seed budget refund failed: ${err instanceof Error ? err.message : err}; counter may be inflated`);
+      }
       return false;
     }
     return true;

--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -64,6 +64,13 @@ const NOTAM_TTL     = 7_200;  // 2h
 const NEWS_TTL      = 2_400;  // 40min
 const BOOTSTRAP_TTL = 7_200;  // 2h — matches FAA/NOTAM; survives ~4 missed cron ticks
 
+function nonNegativeEnv(name, fallback) {
+  const value = process.env[name]?.trim();
+  if (!value) return fallback;
+  const raw = Number(value);
+  return Number.isFinite(raw) && raw >= 0 ? raw : fallback;
+}
+
 // AviationStack quota guard. AviationStack is a PAID, per-airport API: one call
 // per airport (~55 today) on EVERY cron tick, with no upstream batching. Intl
 // airport-delay data moves slowly (already cached 30min client-side, 3h Redis
@@ -77,10 +84,7 @@ const BOOTSTRAP_TTL = 7_200;  // 2h — matches FAA/NOTAM; survives ~4 missed cr
 // even on a 30min cron (worst-case fetchedAt age ≈ 55+30 = 85 < 90). Set to 0
 // to disable the gate (fetch every tick, legacy behaviour). Override via
 // AVIATIONSTACK_MIN_REFRESH_MIN.
-const INTL_MIN_REFRESH_MIN = (() => {
-  const raw = Number(process.env.AVIATIONSTACK_MIN_REFRESH_MIN ?? 55);
-  return Number.isFinite(raw) && raw >= 0 ? raw : 55;
-})();
+const INTL_MIN_REFRESH_MIN = nonNegativeEnv('AVIATIONSTACK_MIN_REFRESH_MIN', 55);
 
 // health.js expects these exact meta keys (api/health.js:222,223,269)
 const INTL_META_KEY  = 'seed-meta:aviation:intl';
@@ -1158,8 +1162,7 @@ export async function intlIsFresh() {
 // AVIATIONSTACK_MONTHLY_BUDGET; request-time stops earlier (see
 // _avstack-budget.ts), reserving headroom for this curated feed.
 export function avstackMonthlyBudget() {
-  const raw = Number(process.env.AVIATIONSTACK_MONTHLY_BUDGET ?? 130_000);
-  return Number.isFinite(raw) && raw >= 0 ? raw : 130_000;
+  return nonNegativeEnv('AVIATIONSTACK_MONTHLY_BUDGET', 130_000);
 }
 
 export async function reserveAviationStackBudget(count) {

--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -1151,6 +1151,55 @@ async function intlIsFresh() {
   }
 }
 
+// Monthly AviationStack budget backstop. Mirrors reserveAviationStackCalls() in
+// server/worldmonitor/aviation/v1/_shared.ts — SAME Redis key + env names so the
+// seeder and the request-time RPCs share one counter and one hard ceiling.
+// Keep the two in lockstep. 'seed' kind reserves against the full
+// AVIATIONSTACK_MONTHLY_BUDGET; request-time stops earlier (see _shared.ts),
+// reserving headroom for this curated feed.
+function avstackMonthlyBudget() {
+  const raw = Number(process.env.AVIATIONSTACK_MONTHLY_BUDGET ?? 130_000);
+  return Number.isFinite(raw) && raw >= 0 ? raw : 130_000;
+}
+
+async function reserveAviationStackBudget(count) {
+  const cap = avstackMonthlyBudget();
+  if (cap <= 0 || count <= 0) return true; // disabled
+  const { url, token } = getRedisCredentials();
+  if (!url || !token) return true; // fail-open (gate already bounds spend)
+  const now = new Date();
+  const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+  const key = `aviation:avstack:calls:${ym}`;
+  const ttl = 40 * 24 * 60 * 60; // 40d
+  try {
+    const resp = await fetch(`${url}/pipeline`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify([['INCRBY', key, count], ['EXPIRE', key, ttl]]),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!resp.ok) return true; // fail-open
+    const results = await resp.json();
+    const total = Number(results?.[0]?.result);
+    if (!Number.isFinite(total)) return true;
+    if (total > cap) {
+      // Return the reservation so the counter reflects calls actually made.
+      try {
+        await fetch(`${url}/pipeline`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify([['DECRBY', key, count]]),
+          signal: AbortSignal.timeout(10_000),
+        });
+      } catch {}
+      return false;
+    }
+    return true;
+  } catch {
+    return true; // fail-open
+  }
+}
+
 async function fetchIntl() {
   const result = await seedIntlDelays();
   if (!result.healthy || result.skipped) {
@@ -1219,6 +1268,22 @@ async function main() {
     console.log(
       `[Intl] SKIPPED AviationStack fetch — last publish < ${INTL_MIN_REFRESH_MIN}min old; ` +
       `saved ${AVIATIONSTACK_LIST.length} API call(s), extended TTLs on last-good.`,
+    );
+    process.exit(0);
+  }
+
+  // Monthly budget backstop — reserve this tick's batch (one call per airport)
+  // against the shared AviationStack counter. If we'd breach the monthly
+  // ceiling, skip the fetch and serve last-good, same as the freshness gate.
+  // Belt-and-braces: the freshness gate already bounds normal spend; this caps
+  // the worst case (misconfigured gate, traffic spike on the shared counter).
+  // Only reserve when a key is present — seedIntlDelays no-ops without one, so
+  // reserving would overcount calls that never happen.
+  if (process.env.AVIATIONSTACK_API && !(await reserveAviationStackBudget(AVIATIONSTACK_LIST.length))) {
+    await extendExistingTtl([INTL_KEY, INTL_META_KEY], INTL_TTL);
+    console.log(
+      `[Intl] SKIPPED AviationStack fetch — monthly budget (${avstackMonthlyBudget()}) reached; ` +
+      `extended TTLs on last-good.`,
     );
     process.exit(0);
   }

--- a/scripts/seed-aviation.mjs
+++ b/scripts/seed-aviation.mjs
@@ -36,6 +36,7 @@ import {
   acquireLockSafely,
   releaseLock,
   getRedisCredentials,
+  readCanonicalValue,
 } from './_seed-utils.mjs';
 import { unwrapEnvelope } from './_seed-envelope-source.mjs';
 
@@ -62,6 +63,24 @@ const FAA_TTL       = 7_200;  // 2h
 const NOTAM_TTL     = 7_200;  // 2h
 const NEWS_TTL      = 2_400;  // 40min
 const BOOTSTRAP_TTL = 7_200;  // 2h — matches FAA/NOTAM; survives ~4 missed cron ticks
+
+// AviationStack quota guard. AviationStack is a PAID, per-airport API: one call
+// per airport (~55 today) on EVERY cron tick, with no upstream batching. Intl
+// airport-delay data moves slowly (already cached 30min client-side, 3h Redis
+// TTL), so re-buying all 55 airports on a 10–30min cron burns quota for data we
+// already hold. When the last successful intl publish is younger than this, we
+// SKIP the fetch entirely and just extend the last-good TTLs — turning the cron
+// cadence into an effective floor of INTL_MIN_REFRESH_MIN between paid fetches.
+//
+// Keep below runSeed's maxStaleMin (90) minus one cron interval so seed-meta
+// fetchedAt never ages into a false STALE_SEED: 55min default leaves headroom
+// even on a 30min cron (worst-case fetchedAt age ≈ 55+30 = 85 < 90). Set to 0
+// to disable the gate (fetch every tick, legacy behaviour). Override via
+// AVIATIONSTACK_MIN_REFRESH_MIN.
+const INTL_MIN_REFRESH_MIN = (() => {
+  const raw = Number(process.env.AVIATIONSTACK_MIN_REFRESH_MIN ?? 55);
+  return Number.isFinite(raw) && raw >= 0 ? raw : 55;
+})();
 
 // health.js expects these exact meta keys (api/health.js:222,223,269)
 const INTL_META_KEY  = 'seed-meta:aviation:intl';
@@ -1110,6 +1129,28 @@ async function runNewsSideCar() {
 // last-good snapshot. FAA/NOTAM/news already ran via their side-cars and are
 // independent — an intl outage does NOT freeze their freshness.
 
+// Quota guard: returns true when the last successful intl publish is younger
+// than INTL_MIN_REFRESH_MIN, meaning we can serve last-good and skip the paid
+// AviationStack fetch this tick. Reads seed-meta:aviation:intl, whose fetchedAt
+// runSeed refreshes ONLY on a successful publish — the graceful-failure path
+// leaves it stale, so a real upstream outage still retries every tick rather
+// than being suppressed by the gate. Fail-open: any read error / missing meta /
+// non-numeric fetchedAt → false (fetch), so we never trade freshness for a
+// flaky Redis read.
+async function intlIsFresh() {
+  if (INTL_MIN_REFRESH_MIN <= 0) return false;
+  try {
+    const meta = await readCanonicalValue(INTL_META_KEY);
+    const fetchedAt = meta?.fetchedAt;
+    if (typeof fetchedAt !== 'number' || !Number.isFinite(fetchedAt)) return false;
+    const ageMin = (Date.now() - fetchedAt) / 60_000;
+    if (ageMin < 0) return false; // clock skew — treat as stale, fetch
+    return ageMin < INTL_MIN_REFRESH_MIN;
+  } catch {
+    return false;
+  }
+}
+
 async function fetchIntl() {
   const result = await seedIntlDelays();
   if (!result.healthy || result.skipped) {
@@ -1167,6 +1208,20 @@ async function main() {
   // Uses last-good intl from Redis; afterPublishIntl will overwrite with fresh
   // intl on success.
   await writeDelaysBootstrap();
+
+  // Quota guard — skip the paid AviationStack fetch when last-good intl is still
+  // fresh. Just extend the TTLs on the canonical key + its freshness meta so
+  // consumers and /api/health keep serving last-good, then exit clean. The
+  // FAA/NOTAM/news side-cars (free) and the bootstrap write above already ran,
+  // so the page-load aggregate is still refreshed this tick.
+  if (await intlIsFresh()) {
+    await extendExistingTtl([INTL_KEY, INTL_META_KEY], INTL_TTL);
+    console.log(
+      `[Intl] SKIPPED AviationStack fetch — last publish < ${INTL_MIN_REFRESH_MIN}min old; ` +
+      `saved ${AVIATIONSTACK_LIST.length} API call(s), extended TTLs on last-good.`,
+    );
+    process.exit(0);
+  }
 
   return runSeed('aviation', 'intl', INTL_KEY, fetchIntl, {
     validateFn: validate,

--- a/server/worldmonitor/aviation/v1/_avstack-budget.ts
+++ b/server/worldmonitor/aviation/v1/_avstack-budget.ts
@@ -32,7 +32,9 @@ function avstackBudgetKey(now = new Date()): string {
 const AVSTACK_BUDGET_TTL = 40 * 24 * 60 * 60; // 40d — outlives the month; next month uses a new key
 
 function intEnv(name: string, fallback: number): number {
-  const raw = Number(process.env[name]);
+  const value = process.env[name]?.trim();
+  if (!value) return fallback;
+  const raw = Number(value);
   return Number.isFinite(raw) && raw >= 0 ? raw : fallback;
 }
 

--- a/server/worldmonitor/aviation/v1/_avstack-budget.ts
+++ b/server/worldmonitor/aviation/v1/_avstack-budget.ts
@@ -1,0 +1,78 @@
+import { runRedisPipeline } from '../../../_shared/redis';
+
+// ---------- AviationStack monthly call budget ----------
+//
+// Hard ceiling on PAID AviationStack calls per calendar month, shared across
+// every call site (the request-time RPC layer + scripts/seed-aviation.mjs).
+// All callers INCRBY the same Redis counter `aviation:avstack:calls:<YYYY-MM>`
+// (UTC) and refuse to call upstream once their ceiling is reached, so total
+// spend can never exceed the plan no matter how much user traffic or how many
+// cron ticks arrive.
+//
+// Two ceilings against ONE counter so user-panel traffic can't starve the
+// curated seeder (the seeder feeds the map + health; request-time is a panel
+// nicety):
+//   - request-time calls stop at AVIATIONSTACK_REQUEST_BUDGET (default 85k)
+//   - all calls (incl. seeder) stop at AVIATIONSTACK_MONTHLY_BUDGET (default
+//     130k) — the gap reserves headroom for the seeder.
+// Defaults sum under a 135k plan with margin. Set MONTHLY budget to 0 to
+// disable the cap entirely (legacy behaviour).
+//
+// IMPORTANT: keep the key format + env names in lockstep with the duplicate
+// implementation in scripts/seed-aviation.mjs (the seeder is plain .mjs and
+// cannot import this module). In production both run unprefixed against the
+// same Upstash instance, so they share the counter; preview deploys are
+// key-prefixed and bill separately, which is fine.
+
+function avstackBudgetKey(now = new Date()): string {
+  const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
+  return `aviation:avstack:calls:${ym}`;
+}
+
+const AVSTACK_BUDGET_TTL = 40 * 24 * 60 * 60; // 40d — outlives the month; next month uses a new key
+
+function intEnv(name: string, fallback: number): number {
+  const raw = Number(process.env[name]);
+  return Number.isFinite(raw) && raw >= 0 ? raw : fallback;
+}
+
+/**
+ * Reserve `count` AviationStack calls against the monthly budget. Returns true
+ * if the caller may proceed with the upstream call(s), false if doing so would
+ * breach the ceiling for this `kind` (caller should serve last-good/empty).
+ *
+ * Fail-open: if Redis is unreachable we allow the call. The seeder — the bulk
+ * spender — is independently bounded by its freshness gate, and failing closed
+ * would blank the panel on every Redis blip. The 5k margin under a 135k plan
+ * absorbs the slack.
+ */
+export async function reserveAviationStackCalls(
+  count: number,
+  kind: 'request' | 'seed',
+): Promise<boolean> {
+  if (count <= 0) return true;
+  const hardCap = intEnv('AVIATIONSTACK_MONTHLY_BUDGET', 130_000);
+  if (hardCap <= 0) return true; // cap disabled
+  const ceiling = kind === 'seed'
+    ? hardCap
+    : Math.min(hardCap, intEnv('AVIATIONSTACK_REQUEST_BUDGET', 85_000));
+
+  const key = avstackBudgetKey();
+  try {
+    const res = await runRedisPipeline([
+      ['INCRBY', key, count],
+      ['EXPIRE', key, AVSTACK_BUDGET_TTL],
+    ]);
+    const total = Number(res?.[0]?.result);
+    if (!Number.isFinite(total)) return true; // redis unavailable → fail-open
+    if (total > ceiling) {
+      // Give the reservation back so the counter reflects calls actually made.
+      await runRedisPipeline([['DECRBY', key, count]]);
+      console.warn(`[Aviation] AviationStack ${kind} call blocked — monthly budget reached (${total - count}/${ceiling})`);
+      return false;
+    }
+    return true;
+  } catch {
+    return true; // fail-open
+  }
+}

--- a/server/worldmonitor/aviation/v1/_avstack-budget.ts
+++ b/server/worldmonitor/aviation/v1/_avstack-budget.ts
@@ -24,9 +24,13 @@ import { runRedisPipeline } from '../../../_shared/redis';
 // same Upstash instance, so they share the counter; preview deploys are
 // key-prefixed and bill separately, which is fine.
 
-function avstackBudgetKey(now = new Date()): string {
+export function aviationStackBudgetMonth(now = new Date()): string {
   const ym = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, '0')}`;
-  return `aviation:avstack:calls:${ym}`;
+  return ym;
+}
+
+function avstackBudgetKey(now = new Date()): string {
+  return `aviation:avstack:calls:${aviationStackBudgetMonth(now)}`;
 }
 
 const AVSTACK_BUDGET_TTL = 40 * 24 * 60 * 60; // 40d — outlives the month; next month uses a new key
@@ -69,7 +73,11 @@ export async function reserveAviationStackCalls(
     if (!Number.isFinite(total)) return true; // redis unavailable → fail-open
     if (total > ceiling) {
       // Give the reservation back so the counter reflects calls actually made.
-      await runRedisPipeline([['DECRBY', key, count]]);
+      const refund = await runRedisPipeline([['DECRBY', key, count]]);
+      const refundedTotal = Number(refund?.[0]?.result);
+      if (!Number.isFinite(refundedTotal)) {
+        console.warn(`[Aviation] AviationStack ${kind} budget refund failed for ${count} call(s); counter may be inflated`);
+      }
       console.warn(`[Aviation] AviationStack ${kind} call blocked — monthly budget reached (${total - count}/${ceiling})`);
       return false;
     }

--- a/server/worldmonitor/aviation/v1/get-flight-status.ts
+++ b/server/worldmonitor/aviation/v1/get-flight-status.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
 import { cachedFetchJson } from '../../../_shared/redis';
 import { getRelayBaseUrl, getRelayHeaders } from './_shared';
+import { reserveAviationStackCalls } from './_avstack-budget';
 
 const CACHE_TTL = 120; // 2 minutes
 
@@ -72,6 +73,12 @@ export async function getFlightStatus(
                 const relayBase = getRelayBaseUrl();
                 if (!relayBase) {
                     return { flights: [], source: 'no-relay' };
+                }
+
+                // Monthly quota guard — once the request-time budget is spent,
+                // serve empty (cached briefly) rather than calling upstream.
+                if (!(await reserveAviationStackCalls(1, 'request'))) {
+                    return { flights: [], source: 'budget' };
                 }
 
                 const params = new URLSearchParams({

--- a/server/worldmonitor/aviation/v1/get-flight-status.ts
+++ b/server/worldmonitor/aviation/v1/get-flight-status.ts
@@ -6,7 +6,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
 import { cachedFetchJson } from '../../../_shared/redis';
 import { getRelayBaseUrl, getRelayHeaders } from './_shared';
-import { reserveAviationStackCalls } from './_avstack-budget';
+import { aviationStackBudgetMonth, reserveAviationStackCalls } from './_avstack-budget';
 
 const CACHE_TTL = 120; // 2 minutes
 
@@ -60,7 +60,7 @@ export async function getFlightStatus(
         .replace(/^([A-Z]{2,3})0+(\d+)$/, '$1$2');
     const date = req.date || new Date().toISOString().slice(0, 10);
     const origin = req.origin?.toUpperCase() || '';
-    const cacheKey = `aviation:status:${flightNumber}:${date}:${origin}:v1`;
+    const cacheKey = `aviation:status:${flightNumber}:${date}:${origin}:v1:${aviationStackBudgetMonth()}`;
     const now = Date.now();
 
     if (!flightNumber || flightNumber.length > 10) {
@@ -88,16 +88,21 @@ export async function getFlightStatus(
                 });
                 if (origin) params.set('dep_iata', origin);
 
-                const resp = await fetch(`${relayBase}/aviationstack?${params}`, {
-                    headers: getRelayHeaders(),
-                    signal: AbortSignal.timeout(15_000),
-                });
-                if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-                const json = await resp.json() as { data?: AVSFlight[]; error?: { message?: string } };
-                if (json.error) throw new Error(json.error.message);
+                try {
+                    const resp = await fetch(`${relayBase}/aviationstack?${params}`, {
+                        headers: getRelayHeaders(),
+                        signal: AbortSignal.timeout(15_000),
+                    });
+                    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+                    const json = await resp.json() as { data?: AVSFlight[]; error?: { message?: string } };
+                    if (json.error) throw new Error(json.error.message);
 
-                const flights = (json.data ?? []).map(f => normalizeFlight(f, now));
-                return { flights, source: 'aviationstack' };
+                    const flights = (json.data ?? []).map(f => normalizeFlight(f, now));
+                    return { flights, source: 'aviationstack' };
+                } catch (err) {
+                    console.warn(`[Aviation] Flight status relay fetch failed for ${flightNumber}: ${err instanceof Error ? err.message : err}`);
+                    return { flights: [], source: 'error' };
+                }
             }
         );
 

--- a/server/worldmonitor/aviation/v1/list-airport-flights.ts
+++ b/server/worldmonitor/aviation/v1/list-airport-flights.ts
@@ -9,7 +9,7 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
 import { cachedFetchJson } from '../../../_shared/redis';
 import { getRelayBaseUrl, getRelayHeaders } from './_shared';
-import { reserveAviationStackCalls } from './_avstack-budget';
+import { aviationStackBudgetMonth, reserveAviationStackCalls } from './_avstack-budget';
 
 const CACHE_TTL = 300;
 // Always fetch a full page upstream and cache it once per airport+direction,
@@ -119,7 +119,7 @@ export async function listAirportFlights(
 
     // Cache key is limit-independent (see UPSTREAM_PAGE) — one upstream call
     // serves every limit for this airport+direction.
-    const cacheKey = `aviation:flights:${airport}:${direction}:v2`;
+    const cacheKey = `aviation:flights:${airport}:${direction}:v2:${aviationStackBudgetMonth()}`;
 
     try {
         const result = await cachedFetchJson<{ flights: FlightInstance[]; source: string }>(

--- a/server/worldmonitor/aviation/v1/list-airport-flights.ts
+++ b/server/worldmonitor/aviation/v1/list-airport-flights.ts
@@ -9,8 +9,16 @@ import type {
 } from '../../../../src/generated/server/worldmonitor/aviation/v1/service_server';
 import { cachedFetchJson } from '../../../_shared/redis';
 import { getRelayBaseUrl, getRelayHeaders } from './_shared';
+import { reserveAviationStackCalls } from './_avstack-budget';
 
 const CACHE_TTL = 300;
+// Always fetch a full page upstream and cache it once per airport+direction,
+// then slice to the caller's requested limit in memory. Threading req.limit
+// into the cache key (and the upstream query) meant limit 30 vs 31 vs 50 were
+// separate PAID AviationStack calls for identical data — a cache-key explosion
+// that multiplied spend. The page covers any limit ≤ 100.
+const UPSTREAM_PAGE = 100;
+const IATA_RE = /^[A-Z]{3}$/;
 
 interface AVSFlight {
     flight?: { iata?: string; icao?: string; codeshared?: { flight_iata?: string; airline_iata?: string }[] };
@@ -92,6 +100,8 @@ function normalizeFlights(flights: AVSFlight[], now: number): FlightInstance[] {
 //   'aviationstack' — live data from AviationStack via relay
 //   'none'          — relay not configured; flights = []
 //   'error'         — relay fetch failed; flights = []
+//   'invalid'       — malformed airport code; rejected before any paid call
+//   'budget'        — monthly AviationStack budget reached; serving empty
 export async function listAirportFlights(
     _ctx: ServerContext,
     req: ListAirportFlightsRequest,
@@ -99,8 +109,17 @@ export async function listAirportFlights(
     const airport = req.airport?.toUpperCase() || 'IST';
     const direction = req.direction || 'FLIGHT_DIRECTION_BOTH';
     const limit = Math.min(req.limit || 30, 100);
-    const cacheKey = `aviation:flights:${airport}:${direction}:${limit}:v1`;
     const now = Date.now();
+
+    // Reject malformed airport codes before they reach the paid API — bounds
+    // cache-key cardinality and blocks probing with arbitrary strings.
+    if (!IATA_RE.test(airport)) {
+        return { flights: [], totalAvailable: 0, source: 'invalid', updatedAt: now };
+    }
+
+    // Cache key is limit-independent (see UPSTREAM_PAGE) — one upstream call
+    // serves every limit for this airport+direction.
+    const cacheKey = `aviation:flights:${airport}:${direction}:v2`;
 
     try {
         const result = await cachedFetchJson<{ flights: FlightInstance[]; source: string }>(
@@ -110,10 +129,16 @@ export async function listAirportFlights(
                     return { flights: [], source: 'none' };
                 }
 
+                // Monthly quota guard — serve empty (cached briefly) instead of
+                // calling upstream once the request-time budget is exhausted.
+                if (!(await reserveAviationStackCalls(1, 'request'))) {
+                    return { flights: [], source: 'budget' };
+                }
+
                 const paramKey = direction === 'FLIGHT_DIRECTION_ARRIVAL' ? 'arr_iata' : 'dep_iata';
                 const params = new URLSearchParams({
                     [paramKey]: airport,
-                    limit: String(limit),
+                    limit: String(UPSTREAM_PAGE),
                 });
                 const url = `${relayBase}/aviationstack?${params}`;
 

--- a/tests/aviation-budget-cap.test.mjs
+++ b/tests/aviation-budget-cap.test.mjs
@@ -133,4 +133,130 @@ describe('aviation budget: call sites are wired to the cap', () => {
     // Same Redis key format as the server helper — they MUST share the counter.
     assert.match(src, /aviation:avstack:calls:\$\{ym\}/);
   });
+
+  it('server budget helper uses the same key format + UTC month math as the seeder', () => {
+    // Cross-file drift would split the counter and silently defeat the shared
+    // ceiling — pin both halves so a future edit to either fails the test.
+    const srv = read('server/worldmonitor/aviation/v1/_avstack-budget.ts');
+    assert.match(srv, /aviation:avstack:calls:/);
+    assert.match(srv, /getUTCFullYear\(\)/);
+    assert.match(srv, /getUTCMonth\(\)/);
+    const seeder = read('scripts/seed-aviation.mjs');
+    assert.match(seeder, /getUTCFullYear\(\)/);
+    assert.match(seeder, /getUTCMonth\(\)/);
+  });
+
+  it('seeder fetchIntl marks its throw nonRetryable so runSeed cannot 4x the paid sweep', () => {
+    // Regression guard for the retry-multiplier undercount: without this tag,
+    // withRetry re-runs the full airport sweep up to 4x on an unhealthy tick
+    // while the budget counter only saw one reserved batch.
+    const src = read('scripts/seed-aviation.mjs');
+    assert.match(src, /err\.nonRetryable = true/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// 3. Behavioural — seeder helpers (scripts/seed-aviation.mjs)
+// ────────────────────────────────────────────────────────────────────────────
+// The seeder's freshness gate is the PRIMARY normal-spend control and its
+// budget backstop is the hard ceiling on the biggest spender — both were
+// previously only regex-checked. Importing is safe: seed-aviation.mjs has an
+// isMain guard, so module load does not fire the seed run.
+
+describe('aviation budget: seeder helpers behave', () => {
+  let intlIsFresh, reserveAviationStackBudget;
+
+  before(async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'http://localhost:0';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+    delete process.env.LOCAL_API_MODE;
+    // Leave AVIATIONSTACK_MIN_REFRESH_MIN unset so the module loads the default
+    // 55-min gate (the const is captured at import time).
+    delete process.env.AVIATIONSTACK_MIN_REFRESH_MIN;
+    ({ intlIsFresh, reserveAviationStackBudget } = await import('../scripts/seed-aviation.mjs'));
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+    delete process.env.AVIATIONSTACK_MONTHLY_BUDGET;
+  });
+
+  // -- intlIsFresh: skip when last publish is younger than the gate --
+
+  function mockSeedMeta(metaValue) {
+    mock.method(globalThis, 'fetch', async (url) => {
+      // readCanonicalValue → redisGet → GET /get/<key>
+      if (String(url).includes('/get/')) {
+        return { ok: true, json: async () => ({ result: metaValue == null ? null : JSON.stringify(metaValue) }) };
+      }
+      return { ok: true, json: async () => [{ result: 1 }] };
+    });
+  }
+
+  it('returns true (skip the fetch) when last publish is younger than the gate', async () => {
+    mockSeedMeta({ fetchedAt: Date.now() - 10 * 60_000, recordCount: 4 });
+    assert.equal(await intlIsFresh(), true);
+  });
+
+  it('returns false (fetch) when last publish is older than the gate', async () => {
+    mockSeedMeta({ fetchedAt: Date.now() - 90 * 60_000, recordCount: 4 });
+    assert.equal(await intlIsFresh(), false);
+  });
+
+  it('returns false (fetch) when seed-meta is missing', async () => {
+    mockSeedMeta(null);
+    assert.equal(await intlIsFresh(), false);
+  });
+
+  it('returns false (fetch) on a non-numeric fetchedAt', async () => {
+    mockSeedMeta({ fetchedAt: 'not-a-number', recordCount: 4 });
+    assert.equal(await intlIsFresh(), false);
+  });
+
+  it('returns false (fetch) on a future fetchedAt (clock skew)', async () => {
+    mockSeedMeta({ fetchedAt: Date.now() + 60 * 60_000, recordCount: 4 });
+    assert.equal(await intlIsFresh(), false);
+  });
+
+  // -- reserveAviationStackBudget: hard ceiling, conservative counter --
+
+  function mockBudgetCounter() {
+    const state = { counter: 0 };
+    mock.method(globalThis, 'fetch', async (_url, opts) => {
+      const cmds = JSON.parse(opts.body);
+      const results = cmds.map((cmd) => {
+        const [verb, , n] = cmd;
+        if (verb === 'INCRBY') { state.counter += Number(n); return { result: state.counter }; }
+        if (verb === 'DECRBY') { state.counter -= Number(n); return { result: state.counter }; }
+        return { result: 1 };
+      });
+      return { ok: true, json: async () => results };
+    });
+    return state;
+  }
+
+  it('allows the seed batch under the hard cap, denies once it would breach, and refunds on deny', async () => {
+    process.env.AVIATIONSTACK_MONTHLY_BUDGET = '100';
+    const state = mockBudgetCounter();
+    // 50 + 50 = 100 (== cap, allowed since deny is total > cap).
+    assert.equal(await reserveAviationStackBudget(50), true);
+    assert.equal(await reserveAviationStackBudget(50), true);
+    assert.equal(state.counter, 100);
+    // Next batch would push to 150 > 100 → denied, and refunded back to the cap.
+    assert.equal(await reserveAviationStackBudget(50), false);
+    assert.equal(state.counter, 100);
+  });
+
+  it('treats a zero MONTHLY budget as disabled (always allow, no Redis I/O)', async () => {
+    process.env.AVIATIONSTACK_MONTHLY_BUDGET = '0';
+    const state = mockBudgetCounter();
+    assert.equal(await reserveAviationStackBudget(999), true);
+    assert.equal(state.counter, 0);
+  });
+
+  it('fails open when the budget pipeline throws', async () => {
+    process.env.AVIATIONSTACK_MONTHLY_BUDGET = '100';
+    mock.method(globalThis, 'fetch', async () => { throw new Error('ECONNREFUSED'); });
+    assert.equal(await reserveAviationStackBudget(50), true);
+  });
 });

--- a/tests/aviation-budget-cap.test.mjs
+++ b/tests/aviation-budget-cap.test.mjs
@@ -1,0 +1,136 @@
+/**
+ * Tests for the AviationStack monthly call budget — the hard ceiling that keeps
+ * total paid usage under the plan limit.
+ *
+ *   reserveAviationStackCalls()  server/worldmonitor/aviation/v1/_avstack-budget.ts
+ *   request-time wiring          list-airport-flights.ts, get-flight-status.ts
+ *   seeder backstop              scripts/seed-aviation.mjs
+ *
+ * Behavioural tests mock the Upstash pipeline so the shared counter is
+ * exercised end-to-end without network. Static tests pin the wiring + the
+ * limit cache-key quantization (a separate spend regression).
+ *
+ * Run with: npm run test:data -- --test-name-pattern="aviation budget"
+ */
+
+import { describe, it, before, beforeEach, afterEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+
+// ────────────────────────────────────────────────────────────────────────────
+// 1. Behavioural — shared counter enforces request + hard ceilings
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('aviation budget: reserveAviationStackCalls enforces ceilings', () => {
+  let reserveAviationStackCalls;
+  let counter; // simulated Redis INCRBY/DECRBY state
+
+  before(async () => {
+    process.env.UPSTASH_REDIS_REST_URL = 'http://localhost:0';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'test-token';
+    delete process.env.LOCAL_API_MODE;
+    ({ reserveAviationStackCalls } = await import(
+      '../server/worldmonitor/aviation/v1/_avstack-budget.ts'
+    ));
+  });
+
+  beforeEach(() => {
+    counter = 0;
+    mock.method(globalThis, 'fetch', async (_url, opts) => {
+      const cmds = JSON.parse(opts.body); // [[ 'INCRBY', key, n ], [ 'EXPIRE', ... ]]
+      const results = cmds.map((cmd) => {
+        const [verb, , n] = cmd;
+        if (verb === 'INCRBY') { counter += Number(n); return { result: counter }; }
+        if (verb === 'DECRBY') { counter -= Number(n); return { result: counter }; }
+        return { result: 1 }; // EXPIRE
+      });
+      return { ok: true, json: async () => results };
+    });
+  });
+
+  afterEach(() => {
+    mock.restoreAll();
+    delete process.env.AVIATIONSTACK_MONTHLY_BUDGET;
+    delete process.env.AVIATIONSTACK_REQUEST_BUDGET;
+  });
+
+  it('allows request-time calls up to AVIATIONSTACK_REQUEST_BUDGET, then denies', async () => {
+    process.env.AVIATIONSTACK_MONTHLY_BUDGET = '10';
+    process.env.AVIATIONSTACK_REQUEST_BUDGET = '5';
+
+    for (let i = 0; i < 5; i++) {
+      assert.equal(await reserveAviationStackCalls(1, 'request'), true, `call ${i + 1} should be allowed`);
+    }
+    // 6th request would exceed the request ceiling.
+    assert.equal(await reserveAviationStackCalls(1, 'request'), false);
+    // Denied reservation is returned — counter stays at the ceiling, not above.
+    assert.equal(counter, 5);
+  });
+
+  it('reserves headroom for the seeder above the request ceiling', async () => {
+    process.env.AVIATIONSTACK_MONTHLY_BUDGET = '10';
+    process.env.AVIATIONSTACK_REQUEST_BUDGET = '5';
+
+    // Burn the request budget.
+    for (let i = 0; i < 5; i++) await reserveAviationStackCalls(1, 'request');
+    assert.equal(await reserveAviationStackCalls(1, 'request'), false);
+
+    // Seeder can still use the reserved gap (5 → 10).
+    assert.equal(await reserveAviationStackCalls(3, 'seed'), true);
+    assert.equal(counter, 8);
+    // ...but not past the hard cap.
+    assert.equal(await reserveAviationStackCalls(3, 'seed'), false);
+    assert.equal(counter, 8);
+  });
+
+  it('treats a zero MONTHLY budget as disabled (always allow, no Redis I/O)', async () => {
+    process.env.AVIATIONSTACK_MONTHLY_BUDGET = '0';
+    const fetchMock = globalThis.fetch;
+    assert.equal(await reserveAviationStackCalls(999, 'request'), true);
+    assert.equal(await reserveAviationStackCalls(999, 'seed'), true);
+    assert.equal(fetchMock.mock.callCount(), 0, 'disabled cap must not touch Redis');
+  });
+
+  it('fails open when Redis is unreachable (never blanks the panel on a blip)', async () => {
+    process.env.AVIATIONSTACK_MONTHLY_BUDGET = '10';
+    mock.restoreAll();
+    mock.method(globalThis, 'fetch', async () => { throw new Error('ECONNREFUSED'); });
+    assert.equal(await reserveAviationStackCalls(1, 'request'), true);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// 2. Static — wiring + limit cache-key quantization
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('aviation budget: call sites are wired to the cap', () => {
+  const read = (p) => readFileSync(resolve(root, p), 'utf-8');
+
+  it('list-airport-flights reserves budget and quantizes the limit out of the cache key', () => {
+    const src = read('server/worldmonitor/aviation/v1/list-airport-flights.ts');
+    assert.match(src, /reserveAviationStackCalls\(1, 'request'\)/);
+    // Cache key must NOT vary by limit (was the spend-multiplying explosion).
+    assert.doesNotMatch(src, /aviation:flights:\$\{airport\}:\$\{direction\}:\$\{limit\}/);
+    assert.match(src, /aviation:flights:\$\{airport\}:\$\{direction\}:v2/);
+    // Upstream always fetches a fixed page, then slices in memory.
+    assert.match(src, /limit:\s*String\(UPSTREAM_PAGE\)/);
+    assert.match(src, /flights\.slice\(0, limit\)/);
+  });
+
+  it('get-flight-status reserves budget before the upstream call', () => {
+    const src = read('server/worldmonitor/aviation/v1/get-flight-status.ts');
+    assert.match(src, /reserveAviationStackCalls\(1, 'request'\)/);
+  });
+
+  it('seeder reserves its batch against the same shared counter + key', () => {
+    const src = read('scripts/seed-aviation.mjs');
+    assert.match(src, /reserveAviationStackBudget\(AVIATIONSTACK_LIST\.length\)/);
+    // Same Redis key format as the server helper — they MUST share the counter.
+    assert.match(src, /aviation:avstack:calls:\$\{ym\}/);
+  });
+});

--- a/tests/aviation-budget-cap.test.mjs
+++ b/tests/aviation-budget-cap.test.mjs
@@ -122,17 +122,21 @@ describe('aviation budget: call sites are wired to the cap', () => {
   it('list-airport-flights reserves budget and quantizes the limit out of the cache key', () => {
     const src = read('server/worldmonitor/aviation/v1/list-airport-flights.ts');
     assert.match(src, /reserveAviationStackCalls\(1, 'request'\)/);
+    assert.match(src, /aviationStackBudgetMonth\(\)/);
     // Cache key must NOT vary by limit (was the spend-multiplying explosion).
     assert.doesNotMatch(src, /aviation:flights:\$\{airport\}:\$\{direction\}:\$\{limit\}/);
-    assert.match(src, /aviation:flights:\$\{airport\}:\$\{direction\}:v2/);
+    assert.match(src, /aviation:flights:\$\{airport\}:\$\{direction\}:v2:\$\{aviationStackBudgetMonth\(\)\}/);
     // Upstream always fetches a fixed page, then slices in memory.
     assert.match(src, /limit:\s*String\(UPSTREAM_PAGE\)/);
     assert.match(src, /flights\.slice\(0, limit\)/);
   });
 
-  it('get-flight-status reserves budget before the upstream call', () => {
+  it('get-flight-status reserves budget before the upstream call and caches relay errors', () => {
     const src = read('server/worldmonitor/aviation/v1/get-flight-status.ts');
     assert.match(src, /reserveAviationStackCalls\(1, 'request'\)/);
+    assert.match(src, /aviation:status:\$\{flightNumber\}:\$\{date\}:\$\{origin\}:v1:\$\{aviationStackBudgetMonth\(\)\}/);
+    assert.match(src, /Flight status relay fetch failed/);
+    assert.match(src, /return \{ flights: \[\], source: 'error' \}/);
   });
 
   it('seeder reserves its batch against the same shared counter + key', () => {
@@ -152,6 +156,21 @@ describe('aviation budget: call sites are wired to the cap', () => {
     const seeder = read('scripts/seed-aviation.mjs');
     assert.match(seeder, /getUTCFullYear\(\)/);
     assert.match(seeder, /getUTCMonth\(\)/);
+  });
+
+  it('request cache keys include the UTC budget month so budget denials expire across month rollover', () => {
+    const srv = read('server/worldmonitor/aviation/v1/_avstack-budget.ts');
+    assert.match(srv, /export function aviationStackBudgetMonth/);
+    assert.match(srv, /getUTCFullYear\(\)/);
+    assert.match(srv, /getUTCMonth\(\)/);
+    assert.match(read('server/worldmonitor/aviation/v1/list-airport-flights.ts'), /aviationStackBudgetMonth\(\)/);
+    assert.match(read('server/worldmonitor/aviation/v1/get-flight-status.ts'), /aviationStackBudgetMonth\(\)/);
+  });
+
+  it('seeder freshness gate is clamped below the health staleness window', () => {
+    const src = read('scripts/seed-aviation.mjs');
+    assert.match(src, /const MAX_INTL_MIN_REFRESH_MIN = 60/);
+    assert.match(src, /AVIATIONSTACK_MIN_REFRESH_MIN', 55, MAX_INTL_MIN_REFRESH_MIN/);
   });
 
   it('seeder fetchIntl marks its throw nonRetryable so runSeed cannot 4x the paid sweep', () => {

--- a/tests/aviation-budget-cap.test.mjs
+++ b/tests/aviation-budget-cap.test.mjs
@@ -96,6 +96,14 @@ describe('aviation budget: reserveAviationStackCalls enforces ceilings', () => {
     assert.equal(fetchMock.mock.callCount(), 0, 'disabled cap must not touch Redis');
   });
 
+  it('treats blank budget env vars as unset defaults, not disabled', async () => {
+    process.env.AVIATIONSTACK_MONTHLY_BUDGET = ' ';
+    process.env.AVIATIONSTACK_REQUEST_BUDGET = '';
+
+    assert.equal(await reserveAviationStackCalls(1, 'request'), true);
+    assert.equal(counter, 1, 'blank budget env vars should still reserve against Redis');
+  });
+
   it('fails open when Redis is unreachable (never blanks the panel on a blip)', async () => {
     process.env.AVIATIONSTACK_MONTHLY_BUDGET = '10';
     mock.restoreAll();
@@ -252,6 +260,13 @@ describe('aviation budget: seeder helpers behave', () => {
     const state = mockBudgetCounter();
     assert.equal(await reserveAviationStackBudget(999), true);
     assert.equal(state.counter, 0);
+  });
+
+  it('treats a blank MONTHLY budget as unset default, not disabled', async () => {
+    process.env.AVIATIONSTACK_MONTHLY_BUDGET = ' ';
+    const state = mockBudgetCounter();
+    assert.equal(await reserveAviationStackBudget(50), true);
+    assert.equal(state.counter, 50, 'blank monthly budget should still reserve against Redis');
   });
 
   it('fails open when the budget pipeline throws', async () => {


### PR DESCRIPTION
## Summary

Implements a dual-layer quota control system for AviationStack API calls to prevent overspend:

1. **Monthly budget cap** — Hard ceiling shared across all call sites (request-time RPC + seeder) via a Redis counter. Two tiers: request-time calls stop at `AVIATIONSTACK_REQUEST_BUDGET` (default 85k), all calls stop at `AVIATIONSTACK_MONTHLY_BUDGET` (default 130k), reserving headroom for the curated seeder.

2. **Freshness gate** — Seeder skips paid fetches when last-good intl delay data is younger than `AVIATIONSTACK_MIN_REFRESH_MIN` (default 55 min), serving cached data instead. Bounds normal spend regardless of cron cadence.

3. **Retry safety** — Marks seeder errors as `nonRetryable` to prevent retry loops from multiplying paid calls (4x retries × full airport sweep = 4x budget burn for one degraded tick).

## Type of change

- [x] New feature
- [x] Refactor / code cleanup

## Affected areas

- [x] API endpoints (`/api/*`)
- [x] Other: AviationStack quota management, seeder optimization

## Changes

**New files:**
- `server/worldmonitor/aviation/v1/_avstack-budget.ts` — Request-time budget enforcement
- `tests/aviation-budget-cap.test.mjs` — Comprehensive behavioral + static tests (262 lines)

**Modified files:**
- `scripts/seed-aviation.mjs` — Added `intlIsFresh()` freshness gate, `reserveAviationStackBudget()` budget check, and `nonRetryable` error tagging
- `server/worldmonitor/aviation/v1/list-airport-flights.ts` — Integrated budget check, fixed cache-key explosion (limit-independent), added IATA validation
- `server/worldmonitor/aviation/v1/get-flight-status.ts` — Integrated budget check
- `.env.example` — Documented new env vars with defaults

## Key Design Decisions

- **Shared counter**: Both seeder and request-time use the same Redis key (`aviation:avstack:calls:<YYYY-MM>`) so they compete fairly for the monthly budget.
- **Fail-open**: Redis unavailability allows calls (seeder's freshness gate already bounds normal spend; 5k margin under 135k plan absorbs slack).
- **Limit-independent caching**: `list-airport-flights` now fetches a fixed 100-item page and slices in memory, eliminating the cache-key explosion where limit 30 vs 31 vs 50 were separate paid calls.
- **Retry safety**: `nonRetryable` flag prevents withRetry from re-running the full airport sweep up to 4x on a degraded tick.

## Test Plan

Added 262-line test suite covering:
- Budget enforcement (request vs seed ceilings, hard cap, refund on deny)
- Freshness gate (age checks, clock skew, missing metadata)
- Fail-open behavior (Redis unavailable)
- Static wiring checks (cache keys, env vars, retry safety)
- Seeder helpers (intlIsFresh, reserveAviationStackBudget)

Run with: `npm run test:data -- --test-name-pattern="aviation budget"`

## Checklist

- [x] Tested on worldmonitor.app variant
- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors

## Documentation Alignment Checklist

- [x] Redis keys enumerated: `aviation:avstack:calls:<YYYY-MM>`, `seed-meta:aviation:intl`
- [x] Env vars documented in `.env.example` with defaults and rationale
- [x] Seeder + request-time implementations kept in lockstep (comments reference each other)

https://claude.ai/code/session_01U3PiUWq58SAwotUDXiumdS