### PR TITLE
fix(security): bump dompurify to 3.4.11 (XSS / prototype pollution in HTML sanitizer)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "d3": "^7.9.0",
         "deck.gl": "^9.2.11",
         "dodopayments-checkout": "^1.8.0",
-        "dompurify": "^3.4.0",
+        "dompurify": "^3.4.11",
         "fast-xml-parser": "^5.8.0",
         "globe.gl": "^2.45.0",
         "hls.js": "^1.6.15",
@@ -12576,9 +12576,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
-      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "d3": "^7.9.0",
     "deck.gl": "^9.2.11",
     "dodopayments-checkout": "^1.8.0",
-    "dompurify": "^3.4.0",
+    "dompurify": "^3.4.11",
     "fast-xml-parser": "^5.8.0",
     "globe.gl": "^2.45.0",
     "hls.js": "^1.6.15",


### PR DESCRIPTION
## Summary

`dompurify@3.4.1` is our **runtime HTML sanitizer for untrusted external content** — RSS/news feed HTML and AI-generated output — used via `DOMPurify.sanitize()` in:

- [`src/utils/widget-sanitizer.ts`](src/utils/widget-sanitizer.ts)
- [`src/components/DeductionPanel.ts`](src/components/DeductionPanel.ts)
- [`src/components/ChatAnalystPanel.ts`](src/components/ChatAnalystPanel.ts)

Snyk flags **7 advisories** against this version — XSS, prototype pollution, and trust-boundary violations:

| Advisory | Type | Fixed in |
|---|---|---|
| CVE-2026-49978 / SNYK-JS-DOMPURIFY-17342528 | Cross-site Scripting | 3.4.7 / 3.4.8 |
| CVE-2026-49458 / SNYK-JS-DOMPURIFY-17344516 | Trust Boundary Violation | 3.4.6 / 3.4.7 |
| CVE-2026-49459 | Prototype Pollution | 3.4.6 |
| SNYK-JS-DOMPURIFY-17344549 | Cross-site Scripting | 3.4.8 |
| SNYK-JS-DOMPURIFY-17375136 | Improper Initialization | 3.4.11 |

This one matters more than its "medium" label suggests: it's the sanitizer sitting **directly in the untrusted-content render path** that `SECURITY.md` relies on ("External content (RSS feeds, news) is sanitized before rendering"). A bypass here is exactly the XSS vector that sanitizer exists to close. (Snyk marks it `isRuntime:false`, which is wrong for a bundled client lib — it ships in the browser bundle.)

## Fix

Bump to **3.4.11** — the highest fixed version, same `3.x` major, no API change. `--package-lock-only` update; diff is `package.json` + `package-lock.json` only.

## Type of change
- [x] Bug fix (security)

## Verification

3.4.11 ≥ every listed fixed version (3.4.6–3.4.11), so all 7 advisories clear. No API surface change within the 3.x line; the existing `DOMPurify.addHook(...)` / `DOMPurify.sanitize(html, PURIFY_CONFIG)` usage is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)