### PR TITLE
fix(payments): persist pending/3DS payment webhook states (#4436)

### DIFF
--- a/convex/__tests__/webhook.test.ts
+++ b/convex/__tests__/webhook.test.ts
@@ -37,7 +37,6 @@ function makePaymentPayload(
     | "payment.succeeded"
     | "payment.failed"
     | "payment.processing"
-    | "payment.requires_customer_action"
     | "payment.cancelled",
   overrides: Record<string, unknown> = {},
 ) {
@@ -435,22 +434,22 @@ describe("webhook processWebhookEvent", () => {
     expect(paymentEvents[0].status).toBe("failed");
   });
 
-  // #4436 — non-terminal/abandoned payment states (3DS/SCA) must be persisted
-  // so the app has a pending-payment signal for duplicate-prevention (#4438)
-  // and reconciliation (#4439). Before the fix these hit the `default` branch
-  // and were silently dropped (no paymentEvents row).
+  // #4436 — Dodo delivers the 3DS/SCA-pending state as a `payment.processing`
+  // event whose payload `data.status` (IntentStatus) is `requires_customer_action`
+  // (`payment.requires_customer_action` is NOT a Dodo event type). Before the
+  // fix `payment.processing` hit the `default` branch and was silently dropped,
+  // so the app had no pending-payment signal for duplicate-prevention (#4438) /
+  // reconciliation (#4439).
   test.each([
-    ["payment.processing", "processing"],
-    ["payment.requires_customer_action", "requires_customer_action"],
-    ["payment.cancelled", "cancelled"],
+    ["requires_customer_action", "requires_customer_action"],
+    ["processing", "processing"],
   ] as const)(
-    "%s persists a paymentEvents row with status %s",
-    async (eventType, expectedStatus) => {
+    "payment.processing with data.status=%s persists status %s",
+    async (payloadStatus, expectedStatus) => {
       const t = convexTest(schema, modules);
 
-      const payload = makePaymentPayload(eventType);
-      const webhookId = `wh_${eventType.replace(/\./g, "_")}`;
-      await processEvent(t, webhookId, eventType, payload, BASE_TIMESTAMP);
+      const payload = makePaymentPayload("payment.processing", { status: payloadStatus });
+      await processEvent(t, `wh_proc_${expectedStatus}`, "payment.processing", payload, BASE_TIMESTAMP);
 
       const paymentEvents = await t.run(async (ctx) =>
         ctx.db.query("paymentEvents").collect(),
@@ -462,17 +461,30 @@ describe("webhook processWebhookEvent", () => {
     },
   );
 
+  test("payment.cancelled persists a cancelled paymentEvents row", async () => {
+    const t = convexTest(schema, modules);
+
+    const payload = makePaymentPayload("payment.cancelled");
+    await processEvent(t, "wh_pay_cancelled", "payment.cancelled", payload, BASE_TIMESTAMP);
+
+    const paymentEvents = await t.run(async (ctx) =>
+      ctx.db.query("paymentEvents").collect(),
+    );
+    expect(paymentEvents).toHaveLength(1);
+    expect(paymentEvents[0].status).toBe("cancelled");
+  });
+
   // #4436 correction (validated): dedup is by webhookId ONLY. A later DISTINCT
   // transition (new webhookId, same payment_id) must still process — it is not
-  // blocked by the earlier requires_customer_action webhook being recorded.
-  test("requires_customer_action then a distinct succeeded webhook both persist", async () => {
+  // blocked by the earlier 3DS-pending webhook being recorded.
+  test("3DS-pending (payment.processing) then a distinct succeeded webhook both persist", async () => {
     const t = convexTest(schema, modules);
 
     await processEvent(
       t,
       "wh_3ds_pending",
-      "payment.requires_customer_action",
-      makePaymentPayload("payment.requires_customer_action"),
+      "payment.processing",
+      makePaymentPayload("payment.processing", { status: "requires_customer_action" }),
       BASE_TIMESTAMP,
     );
     await processEvent(

--- a/convex/__tests__/webhook.test.ts
+++ b/convex/__tests__/webhook.test.ts
@@ -33,7 +33,12 @@ function makeSubscriptionPayload(overrides: Record<string, unknown> = {}) {
 }
 
 function makePaymentPayload(
-  eventType: "payment.succeeded" | "payment.failed",
+  eventType:
+    | "payment.succeeded"
+    | "payment.failed"
+    | "payment.processing"
+    | "payment.requires_customer_action"
+    | "payment.cancelled",
   overrides: Record<string, unknown> = {},
 ) {
   return {
@@ -428,6 +433,71 @@ describe("webhook processWebhookEvent", () => {
     });
     expect(paymentEvents).toHaveLength(1);
     expect(paymentEvents[0].status).toBe("failed");
+  });
+
+  // #4436 — non-terminal/abandoned payment states (3DS/SCA) must be persisted
+  // so the app has a pending-payment signal for duplicate-prevention (#4438)
+  // and reconciliation (#4439). Before the fix these hit the `default` branch
+  // and were silently dropped (no paymentEvents row).
+  test.each([
+    ["payment.processing", "processing"],
+    ["payment.requires_customer_action", "requires_customer_action"],
+    ["payment.cancelled", "cancelled"],
+  ] as const)(
+    "%s persists a paymentEvents row with status %s",
+    async (eventType, expectedStatus) => {
+      const t = convexTest(schema, modules);
+
+      const payload = makePaymentPayload(eventType);
+      const webhookId = `wh_${eventType.replace(/\./g, "_")}`;
+      await processEvent(t, webhookId, eventType, payload, BASE_TIMESTAMP);
+
+      const paymentEvents = await t.run(async (ctx) =>
+        ctx.db.query("paymentEvents").collect(),
+      );
+      expect(paymentEvents).toHaveLength(1);
+      expect(paymentEvents[0].status).toBe(expectedStatus);
+      expect(paymentEvents[0].type).toBe("charge");
+      expect(paymentEvents[0].dodoPaymentId).toBe("pay_test_001");
+    },
+  );
+
+  // #4436 correction (validated): dedup is by webhookId ONLY. A later DISTINCT
+  // transition (new webhookId, same payment_id) must still process — it is not
+  // blocked by the earlier requires_customer_action webhook being recorded.
+  test("requires_customer_action then a distinct succeeded webhook both persist", async () => {
+    const t = convexTest(schema, modules);
+
+    await processEvent(
+      t,
+      "wh_3ds_pending",
+      "payment.requires_customer_action",
+      makePaymentPayload("payment.requires_customer_action"),
+      BASE_TIMESTAMP,
+    );
+    await processEvent(
+      t,
+      "wh_3ds_succeeded",
+      "payment.succeeded",
+      makePaymentPayload("payment.succeeded"),
+      BASE_TIMESTAMP + 5000,
+    );
+
+    const paymentEvents = await t.run(async (ctx) =>
+      ctx.db
+        .query("paymentEvents")
+        .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", "pay_test_001"))
+        .collect(),
+    );
+    expect(paymentEvents.map((e) => e.status).sort()).toEqual([
+      "requires_customer_action",
+      "succeeded",
+    ]);
+
+    const webhookEvents = await t.run(async (ctx) =>
+      ctx.db.query("webhookEvents").collect(),
+    );
+    expect(webhookEvents).toHaveLength(2);
   });
 
   test("duplicate webhook-id is deduplicated", async () => {

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -47,6 +47,22 @@ interface DodoPaymentData {
   metadata?: Record<string, string>;
 }
 
+// Maps Dodo payment/refund webhook event types to our `paymentEvents.status`
+// (schema.ts `paymentEventStatus`). Keys are the exact events routed to
+// handlePaymentOrRefundEvent in webhookMutations.ts. `processing` /
+// `requires_customer_action` are non-terminal (3DS/SCA in flight) — persisting
+// them is the pending-payment signal (#4436). Dispute events use a separate
+// handler and are not listed here.
+const PAYMENT_EVENT_STATUS: Record<string, "succeeded" | "failed" | "processing" | "requires_customer_action" | "cancelled"> = {
+  "payment.succeeded": "succeeded",
+  "payment.failed": "failed",
+  "payment.processing": "processing",
+  "payment.requires_customer_action": "requires_customer_action",
+  "payment.cancelled": "cancelled",
+  "refund.succeeded": "succeeded",
+  "refund.failed": "failed",
+};
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -896,7 +912,13 @@ export async function handlePaymentOrRefundEvent(
   );
 
   const type = eventType.startsWith("refund.") ? "refund" : "charge";
-  const status = eventType.endsWith(".succeeded") ? "succeeded" : "failed";
+  // Map the Dodo event to our paymentEvents status. Non-terminal payment
+  // states (processing, requires_customer_action / 3DS-SCA) are persisted so
+  // the app has a pending-payment signal for duplicate-prevention (#4438) and
+  // reconciliation (#4439); `cancelled` is terminal-but-uncharged. The prior
+  // binary `endsWith(".succeeded") ? … : "failed"` mislabeled every one of
+  // these as a failed charge. Refund events only ever succeed/fail.
+  const status = PAYMENT_EVENT_STATUS[eventType] ?? "failed";
 
   await ctx.db.insert("paymentEvents", {
     userId,

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -52,10 +52,14 @@ interface DodoPaymentData {
 }
 
 // The payment/refund webhook event types we route to handlePaymentOrRefundEvent
-// — a mirror of the case group in webhookMutations.ts. Typed as a closed union
-// so the exhaustive switch below fails to COMPILE if a routed event is added
-// without a status mapping (no silent fallback that could re-introduce a
-// mislabel).
+// — kept in sync with the case group in webhookMutations.ts. Two drift guards,
+// with DIFFERENT enforcement (the call site casts `eventType as
+// RoutedPaymentEvent`, so cross-file drift is not type-checked):
+//   • Intra-file: omit a `case` for a union member below and the `never`
+//     default fails to COMPILE — this file's exhaustiveness guarantee.
+//   • Cross-file: a NEW webhookMutations.ts case not added to this union is NOT
+//     a compile error (the cast launders it); it is caught at RUNTIME by the
+//     `never`-default throw — loud, never a silent succeeded/failed mislabel.
 //
 // IMPORTANT: `payment.requires_customer_action` is NOT a Dodo webhook event
 // type. Dodo's payment event types are succeeded | failed | processing |

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -45,23 +45,70 @@ interface DodoPaymentData {
   currency?: string;
   subscription_id?: string;
   metadata?: Record<string, string>;
+  // Dodo's payment IntentStatus (succeeded | failed | cancelled | processing |
+  // requires_customer_action | …). On `payment.processing` this is where the
+  // 3DS/SCA-pending state is surfaced. See derivePaymentEventStatus.
+  status?: string;
 }
 
-// Maps Dodo payment/refund webhook event types to our `paymentEvents.status`
-// (schema.ts `paymentEventStatus`). Keys are the exact events routed to
-// handlePaymentOrRefundEvent in webhookMutations.ts. `processing` /
-// `requires_customer_action` are non-terminal (3DS/SCA in flight) — persisting
-// them is the pending-payment signal (#4436). Dispute events use a separate
-// handler and are not listed here.
-const PAYMENT_EVENT_STATUS: Record<string, "succeeded" | "failed" | "processing" | "requires_customer_action" | "cancelled"> = {
-  "payment.succeeded": "succeeded",
-  "payment.failed": "failed",
-  "payment.processing": "processing",
-  "payment.requires_customer_action": "requires_customer_action",
-  "payment.cancelled": "cancelled",
-  "refund.succeeded": "succeeded",
-  "refund.failed": "failed",
-};
+// The payment/refund webhook event types we route to handlePaymentOrRefundEvent
+// — a mirror of the case group in webhookMutations.ts. Typed as a closed union
+// so the exhaustive switch below fails to COMPILE if a routed event is added
+// without a status mapping (no silent fallback that could re-introduce a
+// mislabel).
+//
+// IMPORTANT: `payment.requires_customer_action` is NOT a Dodo webhook event
+// type. Dodo's payment event types are succeeded | failed | processing |
+// cancelled (SDK `WebhookEventType`); the 3DS/SCA-pending state is delivered as
+// a `payment.processing` event whose payload `data.status` (IntentStatus) is
+// `requires_customer_action`.
+type RoutedPaymentEvent =
+  | "payment.succeeded"
+  | "payment.failed"
+  | "payment.processing"
+  | "payment.cancelled"
+  | "refund.succeeded"
+  | "refund.failed";
+
+type PaymentEventStatusValue =
+  | "succeeded"
+  | "failed"
+  | "processing"
+  | "requires_customer_action"
+  | "cancelled";
+
+// Derives the persisted `paymentEvents.status` from the event type and, for the
+// non-terminal `payment.processing` event, the payload IntentStatus — that is
+// where Dodo surfaces the 3DS/SCA-pending `requires_customer_action` state
+// (#4436). Throws on an unrouted event rather than silently mislabeling it.
+function derivePaymentEventStatus(
+  eventType: RoutedPaymentEvent,
+  data: DodoPaymentData,
+): PaymentEventStatusValue {
+  switch (eventType) {
+    case "payment.succeeded":
+    case "refund.succeeded":
+      return "succeeded";
+    case "payment.failed":
+    case "refund.failed":
+      return "failed";
+    case "payment.cancelled":
+      return "cancelled";
+    case "payment.processing":
+      // Plain in-flight vs. 3DS/SCA-pending. Other non-terminal IntentStatus
+      // values (requires_payment_method, etc.) collapse to `processing` — never
+      // to a terminal succeeded/failed.
+      return data.status === "requires_customer_action"
+        ? "requires_customer_action"
+        : "processing";
+    default: {
+      const _exhaustive: never = eventType;
+      throw new Error(
+        `[webhook] derivePaymentEventStatus: unrouted event ${String(_exhaustive)}`,
+      );
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -912,13 +959,14 @@ export async function handlePaymentOrRefundEvent(
   );
 
   const type = eventType.startsWith("refund.") ? "refund" : "charge";
-  // Map the Dodo event to our paymentEvents status. Non-terminal payment
-  // states (processing, requires_customer_action / 3DS-SCA) are persisted so
-  // the app has a pending-payment signal for duplicate-prevention (#4438) and
-  // reconciliation (#4439); `cancelled` is terminal-but-uncharged. The prior
-  // binary `endsWith(".succeeded") ? … : "failed"` mislabeled every one of
-  // these as a failed charge. Refund events only ever succeed/fail.
-  const status = PAYMENT_EVENT_STATUS[eventType] ?? "failed";
+  // Non-terminal payment states (processing, requires_customer_action / 3DS-SCA)
+  // are persisted so the app has a pending-payment signal for duplicate-
+  // prevention (#4438) and reconciliation (#4439); `cancelled` is terminal-but-
+  // uncharged. The prior binary `endsWith(".succeeded") ? … : "failed"`
+  // mislabeled every one of these as a failed charge. The cast is safe: every
+  // caller is gated by the webhook switch's routed-event cases, and an
+  // unexpected value throws (loudly) in derivePaymentEventStatus.
+  const status = derivePaymentEventStatus(eventType as RoutedPaymentEvent, data);
 
   await ctx.db.insert("paymentEvents", {
     userId,

--- a/convex/payments/webhookMutations.ts
+++ b/convex/payments/webhookMutations.ts
@@ -104,6 +104,14 @@ export const processWebhookEvent = internalMutation({
         break;
       case "payment.succeeded":
       case "payment.failed":
+      // Non-terminal/abandoned payment states (3DS/SCA). Persisting them gives
+      // the app a pending-payment signal for duplicate-prevention (#4438) and
+      // reconciliation (#4439); previously they fell through to `default` and
+      // were silently dropped while the payment sat in "requires_customer_action"
+      // on Dodo's dashboard. See convex/payments/subscriptionHelpers.ts.
+      case "payment.processing":
+      case "payment.requires_customer_action":
+      case "payment.cancelled":
       case "refund.succeeded":
       case "refund.failed":
         await handlePaymentOrRefundEvent(ctx, data, args.eventType, args.timestamp);

--- a/convex/payments/webhookMutations.ts
+++ b/convex/payments/webhookMutations.ts
@@ -104,13 +104,15 @@ export const processWebhookEvent = internalMutation({
         break;
       case "payment.succeeded":
       case "payment.failed":
-      // Non-terminal/abandoned payment states (3DS/SCA). Persisting them gives
-      // the app a pending-payment signal for duplicate-prevention (#4438) and
-      // reconciliation (#4439); previously they fell through to `default` and
-      // were silently dropped while the payment sat in "requires_customer_action"
-      // on Dodo's dashboard. See convex/payments/subscriptionHelpers.ts.
+      // `payment.processing` is Dodo's only non-terminal payment event; its
+      // payload `data.status` carries the 3DS/SCA-pending `requires_customer_action`
+      // state. `payment.cancelled` is terminal-but-uncharged. Persisting these
+      // gives the app a pending-payment signal for duplicate-prevention (#4438)
+      // and reconciliation (#4439); previously they fell through to `default`
+      // and were dropped while the payment sat in "Requires customer action" on
+      // Dodo's dashboard. (`payment.requires_customer_action` is NOT a Dodo event
+      // type — see derivePaymentEventStatus in subscriptionHelpers.ts.)
       case "payment.processing":
-      case "payment.requires_customer_action":
       case "payment.cancelled":
       case "refund.succeeded":
       case "refund.failed":

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -10,10 +10,17 @@ const subscriptionStatus = v.union(
   v.literal("expired"),
 );
 
-// Payment event status enum — covers charge outcomes and dispute lifecycle
+// Payment event status enum — covers charge outcomes and dispute lifecycle.
+// `processing` / `requires_customer_action` are NON-terminal states (3DS/SCA
+// in flight); persisting them gives the app a pending-payment signal for
+// duplicate-prevention (#4438) and reconciliation (#4439). `cancelled` is a
+// terminal-but-uncharged outcome. See convex/payments/webhookMutations.ts.
 const paymentEventStatus = v.union(
   v.literal("succeeded"),
   v.literal("failed"),
+  v.literal("processing"),
+  v.literal("requires_customer_action"),
+  v.literal("cancelled"),
   v.literal("dispute_opened"),
   v.literal("dispute_won"),
   v.literal("dispute_lost"),


### PR DESCRIPTION
## What

Persist Dodo's non-terminal / abandoned payment webhook states so a payment stuck in 3DS/SCA is no longer invisible to us.

`payment.processing`, `payment.requires_customer_action`, and `payment.cancelled` previously fell through the webhook dispatcher's `default` branch and were silently dropped — so a payment sitting in **"Requires customer action"** on Dodo's dashboard left no record on our side. That's the core blindness behind the [stuck-payments incident](https://github.com/koala73/worldmonitor/issues/4440): with no pending-payment signal we can neither prevent duplicate retries (#4438) nor reconcile/recover the stuck payment (#4439).

## Changes

- **`convex/schema.ts`** — extend `paymentEventStatus` with `processing` / `requires_customer_action` / `cancelled`. Union-widening only: existing rows keep valid values, and no consumer switches exhaustively on status (the one reader, `billing.ts` anon-claim, just reassigns `userId`).
- **`convex/payments/subscriptionHelpers.ts`** — route via an explicit `PAYMENT_EVENT_STATUS` event→status map, replacing the binary `endsWith(".succeeded") ? … : "failed"` derivation that mislabeled every non-succeeded charge as `failed`.
- **`convex/payments/webhookMutations.ts`** — add the three events to the `handlePaymentOrRefundEvent` case group so they persist a `paymentEvents` row instead of hitting `default`.

## Scope note

This is **not** an idempotency-corruption fix. Dedup is strictly by `webhookId` (`webhookMutations.ts:36`), so later distinct transitions were never blocked — the harm was the **lost pending-payment signal**. The optional "stop labeling truly-unhandled events as `processed`" cleanup from #4436 is intentionally left out to keep this migration focused.

## Tests (test-first)

- Each new event persists a `paymentEvents` row with the correct status + `type: charge`.
- A `requires_customer_action` → `succeeded` sequence with **distinct `webhookId`s** persists **both** rows — proving dedup is by `webhookId` and later transitions still process.
- Wrote red first (4 failing), then green. Full suite: **462 convex tests pass**, `tsc -p convex` clean.

## Deploy

Convex schema migration (additive union widening) — backward-compatible, no data backfill.

Part of #4440. Sibling P0 #4434 (return_url) is independent (frontend) and ships separately.

Closes #4436