### PR TITLE
fix(checkout): return Dodo 3DS flows to dashboard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 157
 │   ├── bootstrap/          # Startup/recovery (chunk reload, deferred Sentry, SW update)
 │   ├── components/         # 157 top-level TypeScript component files
 │   ├── config/             # Variant configs, panel/layer definitions, market symbols
-│   ├── services/           # Business logic (186 service modules and domain directories)
+│   ├── services/           # Business logic (187 service modules and domain directories)
 │   ├── shared/             # Cross-cutting helpers (premium paths, registries, staleness)
 │   ├── embed/              # Embeddable widget loader
 │   ├── styles/             # Global CSS (layers, themes, panel styles)

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -11,7 +11,7 @@
   },
   "variantCount": 6,
   "componentTopLevelTsFiles": 157,
-  "serviceTopLevelEntries": 186,
+  "serviceTopLevelEntries": 187,
   "apiEndpointEntries": 80,
   "panelClasses": 104,
   "protoFiles": 276,

--- a/src/services/checkout-return-url.ts
+++ b/src/services/checkout-return-url.ts
@@ -1,6 +1,13 @@
 const DASHBOARD_PATH = '/dashboard';
-const CHECKOUT_RETURN_PARAM = 'wm_checkout';
-const CHECKOUT_RETURN_MARKER = 'return';
+
+/**
+ * Single source of truth for the dashboard checkout-return marker.
+ * The parser in `checkout-return.ts` imports these so the producer and
+ * consumer can never drift on the param/value (a rename here is a
+ * compile-time break there, not a silently-broken 3DS return).
+ */
+export const CHECKOUT_RETURN_PARAM = 'wm_checkout';
+export const CHECKOUT_RETURN_MARKER = 'return';
 
 export function buildDashboardCheckoutReturnUrl(origin: string): string {
   const url = new URL(DASHBOARD_PATH, origin);

--- a/src/services/checkout-return-url.ts
+++ b/src/services/checkout-return-url.ts
@@ -1,0 +1,9 @@
+const DASHBOARD_PATH = '/dashboard';
+const CHECKOUT_RETURN_PARAM = 'wm_checkout';
+const CHECKOUT_RETURN_MARKER = 'return';
+
+export function buildDashboardCheckoutReturnUrl(origin: string): string {
+  const url = new URL(DASHBOARD_PATH, origin);
+  url.searchParams.set(CHECKOUT_RETURN_PARAM, CHECKOUT_RETURN_MARKER);
+  return url.toString();
+}

--- a/src/services/checkout-return.ts
+++ b/src/services/checkout-return.ts
@@ -1,7 +1,7 @@
 /**
  * Post-checkout redirect detection and URL cleanup.
  *
- * Three success signals land on the dashboard after a purchase:
+ * Four checkout signals land on the dashboard after a purchase:
  *
  *   1. Dodo full-page redirect: `?subscription_id=...&status=active`
  *      (historical path; Dodo-owned URL shape)
@@ -14,6 +14,11 @@
  *      itself doesn't write any URL params. The marker is a WorldMonitor-
  *      namespaced param (not `?success=`) to avoid collision with
  *      unrelated query strings and to make the origin intent-explicit.
+ *   4. Dashboard full-page return bridge: `?wm_checkout=return` — set
+ *      as the merchant return URL for Dodo sessions so 3DS returns land
+ *      on the dashboard route instead of `/`, which is now the public
+ *      welcome page. This marker only triggers the post-checkout
+ *      reconciliation path when a local checkout attempt exists.
  *
  * This module inspects those params, cleans them from the URL, and
  * returns a discriminated union so callers can branch on success vs
@@ -22,6 +27,8 @@
  * payments — a Dodo return with status=failed looked identical to "no
  * checkout here, render normal dashboard."
  */
+
+import { loadCheckoutAttempt } from './checkout-attempt';
 
 export type CheckoutReturnResult =
   | { kind: 'none' }
@@ -34,6 +41,7 @@ const FAILED_STATUSES = new Set(['failed', 'declined', 'cancelled', 'canceled'])
 /** WorldMonitor-namespaced marker written by /pro overlay-success. */
 const WM_MARKER_PARAM = 'wm_checkout';
 const WM_MARKER_SUCCESS = 'success';
+const WM_MARKER_RETURN = 'return';
 
 /**
  * Inspect current URL for Dodo return params. If found, cleans them
@@ -54,6 +62,7 @@ export function handleCheckoutReturn(): CheckoutReturnResult {
   const hasDodoParams = Boolean(subscriptionId || paymentId);
   const hasAnyWmMarker = wmMarker !== null;
   const hasWmSuccess = wmMarker === WM_MARKER_SUCCESS;
+  const hasWmReturn = wmMarker === WM_MARKER_RETURN;
 
   // Early return when nothing checkout-related is present. Note we
   // enter cleanup below when ANY wm_checkout value is present (even
@@ -98,6 +107,9 @@ export function handleCheckoutReturn(): CheckoutReturnResult {
     if (FAILED_STATUSES.has(status)) return { kind: 'failed', rawStatus: status };
   }
   if (hasWmSuccess) return { kind: 'success' };
+  if (!hasDodoParams && hasWmReturn && !status && loadCheckoutAttempt()) {
+    return { kind: 'success' };
+  }
   if (hasDodoParams && status) return { kind: 'failed', rawStatus: status };
   return { kind: 'none' };
 }

--- a/src/services/checkout-return.ts
+++ b/src/services/checkout-return.ts
@@ -29,6 +29,7 @@
  */
 
 import { loadCheckoutAttempt } from './checkout-attempt';
+import { CHECKOUT_RETURN_PARAM, CHECKOUT_RETURN_MARKER } from './checkout-return-url';
 
 export type CheckoutReturnResult =
   | { kind: 'none' }
@@ -38,10 +39,13 @@ export type CheckoutReturnResult =
 const SUCCESS_STATUSES = new Set(['active', 'succeeded']);
 const FAILED_STATUSES = new Set(['failed', 'declined', 'cancelled', 'canceled']);
 
-/** WorldMonitor-namespaced marker written by /pro overlay-success. */
-const WM_MARKER_PARAM = 'wm_checkout';
+/**
+ * Marker param/values share `checkout-return-url.ts` as the single
+ * source of truth (`CHECKOUT_RETURN_PARAM` / `CHECKOUT_RETURN_MARKER`).
+ * `WM_MARKER_SUCCESS` is the only value owned solely by this consumer —
+ * the /pro overlay-success bridge that no producer module writes.
+ */
 const WM_MARKER_SUCCESS = 'success';
-const WM_MARKER_RETURN = 'return';
 
 /**
  * Inspect current URL for Dodo return params. If found, cleans them
@@ -57,12 +61,12 @@ export function handleCheckoutReturn(): CheckoutReturnResult {
   const subscriptionId = params.get('subscription_id');
   const paymentId = params.get('payment_id');
   const status = params.get('status') ?? '';
-  const wmMarker = params.get(WM_MARKER_PARAM);
+  const wmMarker = params.get(CHECKOUT_RETURN_PARAM);
 
   const hasDodoParams = Boolean(subscriptionId || paymentId);
   const hasAnyWmMarker = wmMarker !== null;
   const hasWmSuccess = wmMarker === WM_MARKER_SUCCESS;
-  const hasWmReturn = wmMarker === WM_MARKER_RETURN;
+  const hasWmReturn = wmMarker === CHECKOUT_RETURN_MARKER;
 
   // Early return when nothing checkout-related is present. Note we
   // enter cleanup below when ANY wm_checkout value is present (even
@@ -83,7 +87,7 @@ export function handleCheckoutReturn(): CheckoutReturnResult {
     'status',
     'email',
     'license_key',
-    WM_MARKER_PARAM,
+    CHECKOUT_RETURN_PARAM,
   ];
   for (const key of paramsToRemove) {
     params.delete(key);

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -42,6 +42,7 @@ import { loadActiveReferral } from './referral-capture';
 import { showDuplicateSubscriptionDialog } from './checkout-duplicate-dialog';
 import { resolvePlanDisplayName } from './checkout-plan-names';
 import { createEntitlementWatchdog, type EntitlementWatchdog } from './entitlement-watchdog';
+import { buildDashboardCheckoutReturnUrl } from './checkout-return-url';
 
 export {
   EXTENDED_UNLOCK_TIMEOUT_MS,
@@ -808,7 +809,7 @@ export async function startCheckout(
       headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
       body: JSON.stringify({
         productId,
-        returnUrl: window.location.origin,
+        returnUrl: buildDashboardCheckoutReturnUrl(window.location.origin),
         discountCode: options?.discountCode,
         referralCode: effectiveReferral,
       }),

--- a/tests/checkout-overlay-lifecycle.test.mts
+++ b/tests/checkout-overlay-lifecycle.test.mts
@@ -10,6 +10,7 @@ interface HarnessState {
   sentryBreadcrumbs: Array<{ message?: string }>;
   watchdogs: Array<{ stopCalls: number }>;
   storageWrites: string[];
+  fetchBodies: unknown[];
   closeCalls: number;
   silentNoOpOpens: number;
 }
@@ -64,6 +65,18 @@ function installBrowserGlobals(): void {
       history: { replaceState: () => {} },
     },
   });
+  Object.defineProperty(globalThis, 'fetch', {
+    configurable: true,
+    value: async (_input: string, init?: RequestInit) => {
+      const body = typeof init?.body === 'string' ? JSON.parse(init.body) : init?.body;
+      globalThis.__checkoutOverlayHarness.fetchBodies.push(body);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ checkout_url: 'https://checkout.example/session' }),
+      };
+    },
+  });
 }
 
 function resetHarness(): void {
@@ -75,6 +88,7 @@ function resetHarness(): void {
     sentryBreadcrumbs: [],
     watchdogs: [],
     storageWrites: [],
+    fetchBodies: [],
     closeCalls: 0,
     silentNoOpOpens: 0,
   };
@@ -214,6 +228,7 @@ const checkoutHarnessPlugin: Plugin = {
 async function loadCheckoutModule(): Promise<{
   registerCheckoutSuccessCallback: (onSuccess?: () => void) => void;
   openCheckout: (checkoutUrl: string) => Promise<void>;
+  startCheckout: (productId: string) => Promise<boolean>;
   destroyCheckoutOverlay: () => void;
 }> {
   const result = await build({
@@ -223,6 +238,7 @@ async function loadCheckoutModule(): Promise<{
         export {
           registerCheckoutSuccessCallback,
           openCheckout,
+          startCheckout,
           destroyCheckoutOverlay,
         } from './src/services/checkout.ts';
       `,
@@ -245,6 +261,21 @@ async function loadCheckoutModule(): Promise<{
 }
 
 describe('checkout overlay lifecycle', () => {
+  it('sends Dodo full-page returns back to the dashboard checkout-return handler', async () => {
+    resetHarness();
+    const checkout = await loadCheckoutModule();
+
+    assert.equal(await checkout.startCheckout('prod_monthly'), true);
+
+    const harness = globalThis.__checkoutOverlayHarness;
+    assert.equal(harness.fetchBodies.length, 1);
+    assert.deepEqual(harness.fetchBodies[0], {
+      productId: 'prod_monthly',
+      returnUrl: 'https://worldmonitor.app/dashboard?wm_checkout=return',
+    });
+    assert.deepEqual(harness.openedUrls, ['https://checkout.example/session']);
+  });
+
   it('keeps one SDK handler while refreshing per-session side effects after destroy+reopen', async () => {
     resetHarness();
     const checkout = await loadCheckoutModule();

--- a/tests/checkout-return-discriminant.test.mts
+++ b/tests/checkout-return-discriminant.test.mts
@@ -14,8 +14,31 @@ interface MutableHistory {
   replaceState: (state: unknown, unused: string, url?: string | URL | null) => void;
 }
 
+class MemoryStorage {
+  private readonly store = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+const LAST_CHECKOUT_ATTEMPT_KEY = 'wm-last-checkout-attempt';
+
 let _loc: MutableLocation;
 let _history: MutableHistory;
+let _sessionStorage: MemoryStorage;
 
 function setUrl(href: string): void {
   const url = new URL(href);
@@ -27,6 +50,7 @@ function setUrl(href: string): void {
 
 before(() => {
   _loc = { href: BASE_URL, pathname: '/', search: '', hash: '' };
+  _sessionStorage = new MemoryStorage();
   _history = {
     replaceState: (_state, _unused, url) => {
       if (url !== undefined && url !== null) setUrl(new URL(String(url), _loc.href).toString());
@@ -36,15 +60,22 @@ before(() => {
     configurable: true,
     value: { location: _loc, history: _history },
   });
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    configurable: true,
+    value: _sessionStorage,
+  });
 });
 
 after(() => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (globalThis as any).window;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (globalThis as any).sessionStorage;
 });
 
 beforeEach(() => {
   setUrl(BASE_URL);
+  _sessionStorage.clear();
 });
 
 const { handleCheckoutReturn } = await import('../src/services/checkout-return.ts');
@@ -136,6 +167,54 @@ describe('handleCheckoutReturn — /pro overlay-success marker (?wm_checkout=)',
     // richer information and should be honored.
     setUrl(`${BASE_URL}?subscription_id=sub_X&status=active&wm_checkout=success`);
     assert.deepEqual(handleCheckoutReturn(), { kind: 'success' });
+  });
+
+  it('Dodo success status wins over the dashboard return marker used by 3DS redirects', () => {
+    setUrl(`${BASE_URL}?wm_checkout=return&subscription_id=sub_X&status=active`);
+    assert.deepEqual(handleCheckoutReturn(), { kind: 'success' });
+    assert.equal(_loc.href, BASE_URL);
+  });
+
+  it('Dodo failure status wins over the dashboard return marker used by 3DS redirects', () => {
+    setUrl(`${BASE_URL}?wm_checkout=return&payment_id=pay_X&status=failed`);
+    assert.deepEqual(handleCheckoutReturn(), { kind: 'failed', rawStatus: 'failed' });
+    assert.equal(_loc.href, BASE_URL);
+  });
+
+  it('uses wm_checkout=return alone only when there is a saved checkout attempt', () => {
+    _sessionStorage.setItem(
+      LAST_CHECKOUT_ATTEMPT_KEY,
+      JSON.stringify({ productId: 'prod_monthly', startedAt: Date.now() }),
+    );
+    setUrl(`${BASE_URL}?wm_checkout=return`);
+    assert.deepEqual(handleCheckoutReturn(), { kind: 'success' });
+    assert.equal(_loc.href, BASE_URL);
+  });
+
+  it('strips wm_checkout=return alone without a saved attempt but does not trigger success', () => {
+    setUrl(`${BASE_URL}?wm_checkout=return`);
+    assert.deepEqual(handleCheckoutReturn(), { kind: 'none' });
+    assert.equal(_loc.href, BASE_URL);
+  });
+
+  it('does not honor status with wm_checkout=return unless Dodo IDs are present', () => {
+    _sessionStorage.setItem(
+      LAST_CHECKOUT_ATTEMPT_KEY,
+      JSON.stringify({ productId: 'prod_monthly', startedAt: Date.now() }),
+    );
+    setUrl(`${BASE_URL}?wm_checkout=return&status=active`);
+    assert.deepEqual(handleCheckoutReturn(), { kind: 'none' });
+    assert.equal(_loc.href, BASE_URL);
+  });
+
+  it('does not treat Dodo IDs without status as success via wm_checkout=return', () => {
+    _sessionStorage.setItem(
+      LAST_CHECKOUT_ATTEMPT_KEY,
+      JSON.stringify({ productId: 'prod_monthly', startedAt: Date.now() }),
+    );
+    setUrl(`${BASE_URL}?wm_checkout=return&subscription_id=sub_X`);
+    assert.deepEqual(handleCheckoutReturn(), { kind: 'none' });
+    assert.equal(_loc.href, BASE_URL);
   });
 
   it('Dodo failure status wins over wm_checkout=success (surface actual failure)', () => {

--- a/tests/checkout-return-url.test.mts
+++ b/tests/checkout-return-url.test.mts
@@ -1,0 +1,20 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildDashboardCheckoutReturnUrl } from '../src/services/checkout-return-url.ts';
+
+describe('buildDashboardCheckoutReturnUrl', () => {
+  it('routes Dodo full-page returns to the dashboard instead of the root welcome page', () => {
+    assert.equal(
+      buildDashboardCheckoutReturnUrl('https://worldmonitor.app'),
+      'https://worldmonitor.app/dashboard?wm_checkout=return',
+    );
+  });
+
+  it('preserves the active origin so preview and variant hosts return to their own dashboard', () => {
+    assert.equal(
+      buildDashboardCheckoutReturnUrl('https://tech.worldmonitor.app'),
+      'https://tech.worldmonitor.app/dashboard?wm_checkout=return',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- send dashboard-origin Dodo checkout sessions back to `/dashboard?wm_checkout=return` instead of bare origin `/`
- teach checkout return handling to reconcile the dashboard return marker when a saved checkout attempt exists, while keeping marker-only spoof URLs without an attempt as no-ops
- add focused coverage for the checkout session POST body, Dodo success/failure return params, marker-only gated returns, and return URL construction

Closes #4434.

## Validation

- `./node_modules/.bin/tsx --test tests/checkout-return-url.test.mts tests/checkout-return-discriminant.test.mts tests/checkout-overlay-lifecycle.test.mts`
- `npm run typecheck`
- `node --test tests/deploy-config.test.mjs`
- `git diff --check`
- pre-push hook: typecheck, API typecheck, Convex audit, boundary lint, safe HTML, Sentry/rate-limit/premium-fetch checks, edge bundle/test checks, version sync

## Review Notes

- Adversarial review flagged marker-only `/dashboard?wm_checkout=return` as a possible gap.
- Addressed by gating marker-only reconciliation on the existing `wm-last-checkout-attempt` session record, and by explicitly testing the no-attempt/no-Dodo-ID spoof cases.
