### PR TITLE
perf(map): chunk first-paint dynamic-overlay render into yielded <50ms tasks (#4442)

### DIFF
--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -113,6 +113,12 @@ interface WorldTopology extends Topology {
   };
 }
 
+// Yield to the main thread (ends the current task) so a long render can be split into
+// sub-50ms tasks — lowers TBT, which deferral alone does not (#4442).
+function yieldToMain(): Promise<void> {
+  return new Promise((resolve) => { setTimeout(resolve, 0); });
+}
+
 export class MapComponent {
   private static readonly LAYER_ZOOM_THRESHOLDS: Partial<
     Record<keyof MapLayers, { minZoom: number; showLabels?: number }>
@@ -196,6 +202,9 @@ export class MapComponent {
   // SVG renderer and its synchronous overlay build was the #1 boot-scripting cost (~1.3s).
   private initialDynamicRendered = false;
   private initialDynamicScheduled = false;
+  // Bumped on every dynamic-layer build; lets the chunked first-paint pass bail mid-yield
+  // when a newer (synchronous) render has superseded it (#4442 re-entrancy guard).
+  private dynamicRenderToken = 0;
   // Set in destroy(); guards render() (incl. the deferred first-paint callback and the
   // resize/visibility rAF callbacks) from running on a torn-down instance.
   private destroyed = false;
@@ -1174,50 +1183,18 @@ export class MapComponent {
     if (!this.initialDynamicRendered) {
       if (!this.initialDynamicScheduled) {
         this.initialDynamicScheduled = true;
-        scheduleAfterFirstPaint(() => {
-          if (this.destroyed) return;
-          this.initialDynamicRendered = true;
-          this.render();
-        });
+        // First paint: build the dynamic layers off the critical path AND chunked into
+        // sub-50ms tasks (#4442), so the overlay build is neither blocking nor one long task.
+        scheduleAfterFirstPaint(() => { void this.renderInitialDynamicPass(); });
       }
       this.applyTransform();
       return;
     }
 
-    // Always rebuild dynamic layer - use native DOM clear for reliability
-    const dynamicNode = this.dynamicLayerGroup.node()!;
-    while (dynamicNode.firstChild) dynamicNode.removeChild(dynamicNode.firstChild);
-    // Create overlays-svg group for SVG-based overlays (military tracks, etc.)
-    this.dynamicLayerGroup.append('g').attr('class', 'overlays-svg');
-
-    // Setup projection for dynamic elements
-    const projection = this.getProjection(width, height);
-
-    // Update country fills (sanctions toggle without rebuilding geometry)
-    this.updateCountryFills();
-
-    // Render dynamic map layers
-    if (this.state.layers.cables) {
-      this.renderCables(projection);
-    }
-
-    if (this.state.layers.pipelines) {
-      this.renderPipelines(projection);
-    }
-
-    if (this.state.layers.conflicts) {
-      this.renderConflicts(projection);
-    }
-
-    if (this.state.layers.ais) {
-      this.renderAisDensity(projection);
-    }
-
-    // GPU-accelerated cluster markers (LOD)
-    this.renderClusterLayer(projection);
-
-    // Overlays
-    this.renderOverlays(projection);
+    // Steady state (post first-paint): build the dynamic layers synchronously so interactions
+    // (zoom/pan/toggle/theme) update overlays immediately. renderDynamicLayers takes no await
+    // when chunk=false, so this runs to completion before returning.
+    void this.renderDynamicLayers(width, height);
 
     // POST-RENDER VERIFICATION: Ensure base layer actually rendered
     // This catches silent failures where d3 operations didn't stick
@@ -1233,6 +1210,52 @@ export class MapComponent {
     }
 
     this.applyTransform();
+  }
+
+  // Builds the dynamic overlay layers (cables/pipelines/conflicts/AIS/cluster/overlays).
+  // When `chunk` is true, yields between layers so the build runs as several sub-50ms tasks
+  // instead of one long task (#4442). Steady-state callers pass chunk=false → no await is
+  // reached, so it runs synchronously. The re-entrancy token lets a chunked pass bail once a
+  // newer render (which bumps the token and rebuilds) has superseded it.
+  private async renderDynamicLayers(width: number, height: number, chunk = false): Promise<void> {
+    const dynamicGroup = this.dynamicLayerGroup;
+    const dynamicNode = dynamicGroup?.node();
+    if (!dynamicGroup || !dynamicNode) return;
+    const token = ++this.dynamicRenderToken;
+
+    // Rebuild dynamic layer - native DOM clear for reliability
+    while (dynamicNode.firstChild) dynamicNode.removeChild(dynamicNode.firstChild);
+    dynamicGroup.append('g').attr('class', 'overlays-svg');
+
+    const projection = this.getProjection(width, height);
+    // Update country fills (sanctions toggle without rebuilding geometry)
+    this.updateCountryFills();
+
+    const steps: Array<() => void> = [];
+    if (this.state.layers.cables) steps.push(() => this.renderCables(projection));
+    if (this.state.layers.pipelines) steps.push(() => this.renderPipelines(projection));
+    if (this.state.layers.conflicts) steps.push(() => this.renderConflicts(projection));
+    if (this.state.layers.ais) steps.push(() => this.renderAisDensity(projection));
+    steps.push(() => this.renderClusterLayer(projection));
+    steps.push(() => this.renderOverlays(projection));
+
+    for (const step of steps) {
+      if (chunk && (this.destroyed || token !== this.dynamicRenderToken)) return;
+      step();
+      if (chunk) await yieldToMain();
+    }
+  }
+
+  // First-paint dynamic pass: the base map is already painted, so build the overlays chunked
+  // (off the critical path + split into sub-50ms tasks). Steady-state renders run synchronously.
+  private async renderInitialDynamicPass(): Promise<void> {
+    if (this.destroyed || !this.svg) return;
+    this.initialDynamicRendered = true;
+    const width = this.container.clientWidth;
+    const height = this.container.clientHeight;
+    if (width === 0 || height === 0) return; // next real render handles it
+    await this.renderDynamicLayers(width, height, true);
+    if (!this.destroyed) this.applyTransform();
   }
 
   private renderGrid(

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -1239,10 +1239,10 @@ export class MapComponent {
     steps.push(() => this.renderClusterLayer(projection));
     steps.push(() => this.renderOverlays(projection));
 
-    for (const step of steps) {
+    for (let i = 0; i < steps.length; i++) {
       if (chunk && (this.destroyed || token !== this.dynamicRenderToken)) return;
-      step();
-      if (chunk) await yieldToMain();
+      steps[i]?.();
+      if (chunk && i < steps.length - 1) await yieldToMain();
     }
   }
 

--- a/tests/map-deferred-overlays.test.mts
+++ b/tests/map-deferred-overlays.test.mts
@@ -40,8 +40,8 @@ describe('mobile SVG map: defer + chunk dynamic overlays off first paint (#4429/
     assert.match(mapSrc, /private async renderDynamicLayers\(width: number, height: number, chunk = false\): Promise<void>/);
     assert.match(
       mapSrc,
-      /if \(chunk && \(this\.destroyed \|\| token !== this\.dynamicRenderToken\)\) return;[\s\S]*?step\(\);[\s\S]*?if \(chunk\) await yieldToMain\(\);/,
-      'the layer loop must yield between steps when chunking and bail on token mismatch / destroy',
+      /for \(let i = 0; i < steps\.length; i\+\+\) \{[\s\S]*?if \(chunk && \(this\.destroyed \|\| token !== this\.dynamicRenderToken\)\) return;[\s\S]*?steps\[i\]\?\.\(\);[\s\S]*?if \(chunk && i < steps\.length - 1\) await yieldToMain\(\);/,
+      'the layer loop must yield between steps when chunking, skip the final yield, and bail on token mismatch / destroy',
     );
   });
 

--- a/tests/map-deferred-overlays.test.mts
+++ b/tests/map-deferred-overlays.test.mts
@@ -4,79 +4,65 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-// Structural guard for the mobile SVG-map first-paint deferral (#4429). The full
-// MapComponent is not instantiated in unit tests (heavy d3/topojson/canvas/DOM) — the
-// repo verifies Map.ts behavior via source-structure assertions (see
-// globe-default-map-mode.test.mts). Runtime/perf verification is the prod mobile
-// Lighthouse re-read (Map-*.js boot scripting vs the ~1277 ms baseline).
+// Structural guard for the mobile SVG-map first-paint deferral (#4429) + chunking (#4442).
+// The full MapComponent is not instantiated in unit tests (heavy d3/topojson/canvas/DOM) —
+// the repo verifies Map.ts behavior via source-structure assertions (see
+// globe-default-map-mode.test.mts). Runtime/perf verification is the prod mobile Lighthouse
+// re-read (Map-*.js boot scripting + TBT vs the ~1277 ms / ~1.5 s baselines).
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = resolve(__dirname, '..');
 const mapSrc = readFileSync(resolve(root, 'src/components/Map.ts'), 'utf-8');
 
-describe('mobile SVG map: defer dynamic overlays off first paint (#4429)', () => {
-  it('imports the first-paint scheduler and declares the one-time flags', () => {
-    assert.match(
-      mapSrc,
-      /import \{ scheduleAfterFirstPaint \} from '@\/utils\/after-paint'/,
-      'Map.ts must import scheduleAfterFirstPaint for the deferral',
-    );
+describe('mobile SVG map: defer + chunk dynamic overlays off first paint (#4429/#4442)', () => {
+  it('declares the one-time + re-entrancy-token flags', () => {
     assert.match(mapSrc, /private initialDynamicRendered = false/);
     assert.match(mapSrc, /private initialDynamicScheduled = false/);
+    assert.match(mapSrc, /private dynamicRenderToken = 0/, 'needs the re-entrancy token for the chunked pass');
   });
 
-  it('gates the dynamic-overlay pass behind the first-paint defer with a single schedule + early return', () => {
-    // The gate: on first render, schedule once and return before the dynamic block.
+  it('gates the first dynamic pass behind scheduleAfterFirstPaint → renderInitialDynamicPass with an early return', () => {
     assert.match(
       mapSrc,
-      /if \(!this\.initialDynamicRendered\) \{[\s\S]*?if \(!this\.initialDynamicScheduled\) \{[\s\S]*?this\.initialDynamicScheduled = true;[\s\S]*?scheduleAfterFirstPaint\(\(\) => \{[\s\S]*?this\.initialDynamicRendered = true;[\s\S]*?this\.render\(\);[\s\S]*?\}\);[\s\S]*?\}[\s\S]*?return;[\s\S]*?\}/,
-      'render() must schedule the dynamic pass once via scheduleAfterFirstPaint and return on first render',
+      /if \(!this\.initialDynamicRendered\) \{[\s\S]*?if \(!this\.initialDynamicScheduled\) \{[\s\S]*?this\.initialDynamicScheduled = true;[\s\S]*?scheduleAfterFirstPaint\(\(\) => \{ void this\.renderInitialDynamicPass\(\); \}\);[\s\S]*?\}[\s\S]*?return;[\s\S]*?\}/,
+      'render() must schedule renderInitialDynamicPass once and return on first render',
+    );
+  });
+
+  it('first-paint pass builds the dynamic layers CHUNKED (off critical path, sub-50ms tasks)', () => {
+    assert.match(
+      mapSrc,
+      /private async renderInitialDynamicPass\(\): Promise<void> \{[\s\S]*?this\.initialDynamicRendered = true;[\s\S]*?await this\.renderDynamicLayers\(width, height, true\);/,
+      'renderInitialDynamicPass must set the flag and await the chunked renderDynamicLayers',
+    );
+  });
+
+  it('renderDynamicLayers yields between layers when chunking and bails when superseded', () => {
+    assert.match(mapSrc, /private async renderDynamicLayers\(width: number, height: number, chunk = false\): Promise<void>/);
+    assert.match(
+      mapSrc,
+      /if \(chunk && \(this\.destroyed \|\| token !== this\.dynamicRenderToken\)\) return;[\s\S]*?step\(\);[\s\S]*?if \(chunk\) await yieldToMain\(\);/,
+      'the layer loop must yield between steps when chunking and bail on token mismatch / destroy',
+    );
+  });
+
+  it('steady-state render() builds the dynamic layers synchronously (no chunking on interactions)', () => {
+    assert.match(
+      mapSrc,
+      /Steady state[\s\S]*?void this\.renderDynamicLayers\(width, height\);/,
+      'post-first-paint render() must call renderDynamicLayers without the chunk flag (synchronous)',
     );
   });
 
   it('keeps the base layer (countries) synchronous — rendered BEFORE the defer gate (LCP-critical)', () => {
     const baseIdx = mapSrc.indexOf('this.renderCountries(this.baseLayerGroup');
     const gateIdx = mapSrc.indexOf('if (!this.initialDynamicRendered)');
-    assert.ok(baseIdx > 0, 'renderCountries must exist in render()');
-    assert.ok(gateIdx > 0, 'the defer gate must exist');
-    assert.ok(
-      baseIdx < gateIdx,
-      'renderCountries (base/LCP) must run before the dynamic-defer gate',
-    );
+    assert.ok(baseIdx > 0 && gateIdx > 0);
+    assert.ok(baseIdx < gateIdx, 'renderCountries (base/LCP) must run before the dynamic-defer gate');
   });
 
-  it('guards render() against running on a destroyed instance (deferred callback safety)', () => {
+  it('guards render() and the deferred pass against running on a destroyed instance', () => {
     assert.match(mapSrc, /private destroyed = false/);
-    assert.match(mapSrc, /public destroy\(\): void \{\s*\n\s*this\.destroyed = true;/);
-    assert.match(
-      mapSrc,
-      /public render\(\): void \{\s*\n\s*if \(this\.destroyed\) return;/,
-      'render() must early-return when destroyed so the deferred first-paint callback cannot run on a torn-down instance',
-    );
-    assert.match(
-      mapSrc,
-      /scheduleAfterFirstPaint\(\(\) => \{\s*\n\s*if \(this\.destroyed\) return;\s*\n\s*this\.initialDynamicRendered = true;/,
-      'the deferred callback must not mutate render state after destroy()',
-    );
-  });
-
-  it('applies the current map transform before returning from the first-paint gate', () => {
-    assert.match(
-      mapSrc,
-      /if \(!this\.initialDynamicRendered\) \{[\s\S]*?scheduleAfterFirstPaint\(\(\) => \{[\s\S]*?if \(this\.destroyed\) return;[\s\S]*?this\.render\(\);[\s\S]*?\}\);\s*\n\s*\}\s*\n\s*this\.applyTransform\(\);\s*\n\s*return;\s*\n\s*\}/,
-      'applyTransform must run immediately before the first-paint gate returns',
-    );
-  });
-
-  it('defers the heavy dynamic layers — they run AFTER the gate', () => {
-    const gateIdx = mapSrc.indexOf('if (!this.initialDynamicRendered)');
-    for (const marker of [
-      'this.renderClusterLayer(projection)',
-      'this.renderOverlays(projection)',
-      'this.renderCables(projection)',
-    ]) {
-      const idx = mapSrc.indexOf(marker);
-      assert.ok(idx > 0, `${marker} must exist`);
-      assert.ok(idx > gateIdx, `${marker} must run after the defer gate (deferred off first paint)`);
-    }
+    assert.match(mapSrc, /public render\(\): void \{\s*\n\s*if \(this\.destroyed\) return;/);
+    assert.match(mapSrc, /private async renderInitialDynamicPass\(\): Promise<void> \{\s*\n\s*if \(this\.destroyed \|\| !this\.svg\) return;/);
   });
 });


### PR DESCRIPTION
Closes #4442.

## Summary

#4431 deferred the mobile SVG-map overlay render off first paint, but prod validation showed it cut perceived-load (`Map-*.js` boot scripting 1277 → ~880 ms) **without moving mobile Perf/TBT** — because `scheduleAfterFirstPaint` *reorders* the render off the critical path but it still ran as **one long task** inside the TBT window. TBT = Σ(task − 50 ms) over tasks > 50 ms, so a single relocated long task doesn't lower it.

This **chunks** the first-paint dynamic-overlay build so each layer is a short task:
- Extract the dynamic-layer sequence into `renderDynamicLayers(width, height, chunk)`.
- The first-paint pass (`renderInitialDynamicPass`, via `scheduleAfterFirstPaint`) runs it with `chunk=true` — **yielding to the main thread between layers**.
- Steady-state `render()` calls it with `chunk=false` → no `await` is reached → runs **synchronously**, so zoom/pan/toggle/theme interactions are unchanged.
- A `dynamicRenderToken` lets a chunked pass **bail when a newer render supersedes it** (re-entrancy); the `destroyed` guard covers teardown mid-yield.

## Scope (bounded — not overengineered)

Only the deferred first pass yields. `renderOverlays` stays one step; if prod shows it alone exceeds 50 ms, chunk *inside it* as a follow-up. No async rewrite of every layer.

## Risk

Mobile/fallback SVG `MapComponent` only (desktop `DeckGLMap`/`GlobeMap` untouched). Runtime-scheduling change, no chunk-graph impact. Mobile-primary renderer → verify on a real mobile viewport post-merge.

## Test plan

- [x] `npm run typecheck` + `typecheck:api`
- [x] `npm run lint` + `lint:md` + `version:check` + CJS syntax + edge esbuild bundle
- [x] `node --test tests/edge-functions.test.mjs`
- [x] `npm run test:data` — 11663 pass / 0 fail
- [x] `VITE_VARIANT=full` build — **0 circular chunks**; Map chunk ~89 KB, still lazy (off eager modulepreload)
- [x] `tests/map-deferred-overlays.test.mts` extended (7 structural assertions: gate, chunked first pass, yield + re-entrancy bail, synchronous steady-state, base-before-gate, destroyed guards)
- [ ] **Post-merge:** prod mobile Lighthouse — `Map-*.js` long-task count / TBT vs the ~880 ms / ~1.5 s baseline (the meaningful perf check; local mobile Lighthouse is CPU-contention noise)