### PR TITLE
fix(checkout): P0 — handle checkout.link_expired so the overlay can't freeze (#4435)

### DIFF
--- a/src/services/checkout-errors.ts
+++ b/src/services/checkout-errors.ts
@@ -17,6 +17,7 @@
 export type CheckoutErrorCode =
   | 'unauthorized'
   | 'session_expired'
+  | 'link_expired'
   | 'duplicate_subscription'
   | 'invalid_product'
   | 'service_unavailable'
@@ -35,6 +36,7 @@ export interface CheckoutError {
 const USER_COPY: Record<CheckoutErrorCode, string> = {
   unauthorized: 'Please sign in to continue your purchase.',
   session_expired: 'Your session expired. Sign in again to continue.',
+  link_expired: 'Your payment link expired. Please start checkout again.',
   duplicate_subscription: "You already have an active subscription. Let's open the billing portal instead.",
   invalid_product: "That product isn't available. Please refresh and try again.",
   service_unavailable: 'Checkout is temporarily unavailable. Please try again in a moment.',
@@ -44,6 +46,7 @@ const USER_COPY: Record<CheckoutErrorCode, string> = {
 const RETRYABLE: Record<CheckoutErrorCode, boolean> = {
   unauthorized: true,        // after sign-in
   session_expired: true,     // after sign-in
+  link_expired: true,        // re-initiate checkout (link, not session, expired)
   duplicate_subscription: false,
   invalid_product: false,
   service_unavailable: true,
@@ -122,12 +125,13 @@ export function classifyThrownCheckoutError(caught: unknown): CheckoutError {
 }
 
 /**
- * Classify a synthetic "no Clerk session" or "no token" condition.
- * These don't correspond to an HTTP response, but should still flow
- * through the taxonomy so the toast copy stays consistent.
+ * Classify a synthetic checkout condition that has no HTTP response —
+ * a missing Clerk session/token (`unauthorized` / `session_expired`) or
+ * a Dodo `checkout.link_expired` overlay event. These still flow through
+ * the taxonomy so the toast copy and retryability stay consistent.
  */
 export function classifySyntheticCheckoutError(
-  kind: 'unauthorized' | 'session_expired',
+  kind: 'unauthorized' | 'session_expired' | 'link_expired',
 ): CheckoutError {
   return {
     code: kind,

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -16,7 +16,7 @@ import type { CheckoutEvent } from 'dodopayments-checkout';
 import { openBillingPortal, prereserveBillingPortalTab } from './billing';
 import { getCurrentClerkUser, getClerkToken, openSignIn } from './clerk';
 import { subscribeAuthState } from './auth-state';
-import { saveCheckoutAttempt, clearCheckoutAttempt } from './checkout-attempt';
+import { saveCheckoutAttempt, loadCheckoutAttempt, clearCheckoutAttempt } from './checkout-attempt';
 import {
   classifyHttpCheckoutError,
   classifySyntheticCheckoutError,
@@ -409,6 +409,43 @@ async function ensureCheckoutOverlayInitialized(): Promise<void> {
           stopWatchdog();
           safeCloseOverlay();
           break;
+        case 'checkout.link_expired': {
+          // Dodo's SDK emits this when the checkout session / payment link
+          // expires mid-flow but does NOT self-close the iframe — leaving the
+          // customer stranded on a frozen "Processing… / Payment Link Expires
+          // in 00:00" overlay (the literal incident symptom). The `error`
+          // branch above never fires for this because the SDK models expiry as
+          // its own event, not an error. Tear the frozen iframe down, then
+          // surface an actionable "payment link expired — retry" toast through
+          // the same error taxonomy startCheckout failures use.
+          //
+          // We deliberately do NOT clear LAST_CHECKOUT_ATTEMPT_KEY: the saved
+          // attempt is the retry context (a re-initiated checkout / the
+          // failure-retry banner re-opens the exact product), mirroring
+          // checkout.closed's "preserve the attempt for retry" rule.
+          //
+          // safeCloseOverlay() re-emits checkout.closed synchronously through
+          // this same handler (stopWatchdog + clearPendingCheckoutIntent, both
+          // idempotent), so the error-surface calls below intentionally run
+          // AFTER it — do not reorder them above safeCloseOverlay().
+          stopWatchdog();
+          safeCloseOverlay();
+          // If the session already resolved to success, the iframe we just
+          // tore down was a stale post-success overlay (checkout.status=
+          // succeeded does not close it). Surfacing the expiry toast there
+          // would tell a paid user to "start checkout again" — a duplicate-
+          // payment nudge. Gate the user-facing surface on !successFired,
+          // mirroring checkout.closed / checkout.redirect_requested; the
+          // teardown above still runs so the overlay never stays frozen.
+          if (successFired) break;
+          const error = classifySyntheticCheckoutError('link_expired');
+          reportCheckoutError(error, {
+            productId: loadCheckoutAttempt()?.productId ?? 'unknown',
+            action: 'link-expired',
+          });
+          renderCheckoutErrorSurface(error, false);
+          break;
+        }
       }
     };
 
@@ -937,6 +974,9 @@ type SentryLevel = 'error' | 'info';
 const INFO_LEVEL_CODES: ReadonlySet<CheckoutErrorCode> = new Set([
   'unauthorized',
   'session_expired',
+  // Expected user state: an abandoned-then-reopened payment link aged out.
+  // Observable in Sentry (funnel drop-off) but should not trigger alerts.
+  'link_expired',
 ]);
 
 function reportCheckoutError(

--- a/src/services/checkout.ts
+++ b/src/services/checkout.ts
@@ -424,11 +424,13 @@ async function ensureCheckoutOverlayInitialized(): Promise<void> {
           // failure-retry banner re-opens the exact product), mirroring
           // checkout.closed's "preserve the attempt for retry" rule.
           //
-          // safeCloseOverlay() re-emits checkout.closed synchronously through
-          // this same handler (stopWatchdog + clearPendingCheckoutIntent, both
-          // idempotent), so the error-surface calls below intentionally run
-          // AFTER it — do not reorder them above safeCloseOverlay().
+          // Clear the dead auto-resume intent directly. Do not depend on
+          // Checkout.close() re-emitting checkout.closed: current SDK versions
+          // do that synchronously, but this state transition is ours to own.
+          // LAST_CHECKOUT_ATTEMPT_KEY is intentionally preserved above for the
+          // retry CTA.
           stopWatchdog();
+          clearPendingCheckoutIntent();
           safeCloseOverlay();
           // If the session already resolved to success, the iframe we just
           // tore down was a stale post-success overlay (checkout.status=

--- a/tests/checkout-error-classification.test.mts
+++ b/tests/checkout-error-classification.test.mts
@@ -150,6 +150,16 @@ describe('classifySyntheticCheckoutError', () => {
     assert.equal(err.retryable, true);
   });
 
+  it('maps link_expired to retryable link_expired code with retry-oriented copy', () => {
+    const err = classifySyntheticCheckoutError('link_expired');
+    assert.equal(err.code, 'link_expired');
+    assert.equal(err.retryable, true);
+    // Distinct from session_expired: the user is signed in — the payment
+    // LINK aged out, so the copy points to re-initiating checkout, not re-auth.
+    assert.equal(err.userMessage, 'Your payment link expired. Please start checkout again.');
+    assert.ok(!/sign in/i.test(err.userMessage), 'link_expired must not tell the user to sign in');
+  });
+
   it('does not include serverMessage for synthetic errors (no server involved)', () => {
     const err = classifySyntheticCheckoutError('unauthorized');
     assert.equal(err.serverMessage, undefined);

--- a/tests/checkout-overlay-lifecycle.test.mts
+++ b/tests/checkout-overlay-lifecycle.test.mts
@@ -13,6 +13,8 @@ interface HarnessState {
   fetchBodies: unknown[];
   closeCalls: number;
   silentNoOpOpens: number;
+  errorToasts: string[];
+  attemptClears: string[];
 }
 
 declare global {
@@ -91,6 +93,8 @@ function resetHarness(): void {
     fetchBodies: [],
     closeCalls: 0,
     silentNoOpOpens: 0,
+    errorToasts: [],
+    attemptClears: [],
   };
   installBrowserGlobals();
 }
@@ -160,7 +164,7 @@ const stubSources: Record<string, string> = {
   './checkout-attempt': `
     export const saveCheckoutAttempt = () => {};
     export const loadCheckoutAttempt = () => null;
-    export const clearCheckoutAttempt = () => {};
+    export const clearCheckoutAttempt = (reason) => globalThis.__checkoutOverlayHarness.attemptClears.push(reason);
   `,
   './checkout-errors': `
     export const classifyHttpCheckoutError = () => ({ code: 'service_unavailable', userMessage: 'unavailable', retryable: true });
@@ -170,7 +174,7 @@ const stubSources: Record<string, string> = {
     export const snapshotUpstreamResponse = () => ({});
   `,
   './checkout-error-toast': `
-    export const showCheckoutErrorToast = () => {};
+    export const showCheckoutErrorToast = (message) => globalThis.__checkoutOverlayHarness.errorToasts.push(message);
   `,
   './checkout-no-user-policy': `
     export const decideNoUserPathOutcome = () => ({ kind: 'inline-signin', persist: true });
@@ -417,6 +421,76 @@ describe('checkout overlay lifecycle', () => {
       globalThis.sessionStorage.getItem('wm-pending-checkout'),
       pending,
       'destroy must preserve the pending-checkout intent (handler nulled before close)',
+    );
+  });
+
+  it('closes the frozen overlay and surfaces a retry on checkout.link_expired', async () => {
+    resetHarness();
+    const checkout = await loadCheckoutModule();
+
+    // Open the overlay so the SDK is in the "iframe mounted" state. The real
+    // bug: Dodo emits checkout.link_expired but does NOT self-close the iframe,
+    // stranding the user on a frozen "Processing… / Expires in 00:00" overlay.
+    await checkout.openCheckout('https://checkout.example/session');
+
+    const harness = globalThis.__checkoutOverlayHarness;
+    // Reproduce the production state: checkout.opened arms the watchdog, and a
+    // pending auto-resume intent is saved. link_expired must stop the running
+    // watchdog (no zombie timer) and the re-entrant checkout.closed must clear
+    // the dead-link auto-resume intent while preserving the retry attempt.
+    harness.handlers[0]({ event_type: 'checkout.opened', data: {} });
+    assert.equal(harness.watchdogs.length, 1, 'checkout.opened must arm the watchdog');
+    globalThis.sessionStorage.setItem('wm-pending-checkout', JSON.stringify({ productId: 'prod_1' }));
+
+    harness.handlers[0]({ event_type: 'checkout.link_expired', data: {} });
+
+    // (a) the frozen iframe is torn down so the user is no longer stranded.
+    assert.equal(harness.closeCalls, 1, 'link_expired must close the frozen overlay');
+    // (b) an actionable retry surface is shown via the error taxonomy toast
+    //     (stub maps userMessage to the code, so the toast carries 'link_expired').
+    assert.deepEqual(
+      harness.errorToasts,
+      ['link_expired'],
+      'link_expired must surface a retry toast via the error taxonomy',
+    );
+    // (c) retry context is preserved — the attempt is NOT cleared as a terminal
+    //     state, so a re-initiated checkout still has the product to re-open.
+    assert.deepEqual(
+      harness.attemptClears,
+      [],
+      'link_expired must preserve the saved checkout attempt for retry',
+    );
+    // (d) the running watchdog is stopped — a leaked timer would keep polling
+    //     entitlement against a dead session.
+    assert.equal(harness.watchdogs[0].stopCalls, 1, 'link_expired must stop the running watchdog');
+    // (e) the re-entrant checkout.closed cleared the dead-link auto-resume intent.
+    assert.equal(
+      globalThis.sessionStorage.getItem('wm-pending-checkout'),
+      null,
+      'link_expired must clear the pending auto-resume intent for the expired link',
+    );
+  });
+
+  it('does not show an expiry toast when checkout.link_expired arrives after success', async () => {
+    resetHarness();
+    const checkout = await loadCheckoutModule();
+
+    await checkout.openCheckout('https://checkout.example/session');
+
+    const harness = globalThis.__checkoutOverlayHarness;
+    harness.handlers[0]({ event_type: 'checkout.opened', data: {} });
+    // The payment succeeds; checkout.status=succeeded does NOT close the iframe,
+    // so a late link_expired can still arrive while the success overlay is up.
+    harness.handlers[0]({ event_type: 'checkout.status', data: { message: { status: 'succeeded' } } });
+    harness.handlers[0]({ event_type: 'checkout.link_expired', data: {} });
+
+    // The frozen iframe is still torn down...
+    assert.equal(harness.closeCalls, 1, 'post-success link_expired must still close the overlay');
+    // ...but a paid user is NOT told to "start checkout again" (duplicate-payment nudge).
+    assert.deepEqual(
+      harness.errorToasts,
+      [],
+      'link_expired after success must not surface an expiry retry toast',
     );
   });
 });

--- a/tests/checkout-overlay-lifecycle.test.mts
+++ b/tests/checkout-overlay-lifecycle.test.mts
@@ -15,6 +15,7 @@ interface HarnessState {
   silentNoOpOpens: number;
   errorToasts: string[];
   attemptClears: string[];
+  suppressCloseEvent: boolean;
 }
 
 declare global {
@@ -95,6 +96,7 @@ function resetHarness(): void {
     silentNoOpOpens: 0,
     errorToasts: [],
     attemptClears: [],
+    suppressCloseEvent: false,
   };
   installBrowserGlobals();
 }
@@ -134,7 +136,7 @@ const stubSources: Record<string, string> = {
           const wasOpen = _overlayOpen;
           _overlayOpen = false;
           globalThis.__checkoutOverlayHarness.closeCalls += 1;
-          if (wasOpen) {
+          if (wasOpen && !globalThis.__checkoutOverlayHarness.suppressCloseEvent) {
             _onEvent?.({ event_type: 'checkout.closed', data: { message: 'Checkout closed manually' } });
           }
         },
@@ -436,11 +438,15 @@ describe('checkout overlay lifecycle', () => {
     const harness = globalThis.__checkoutOverlayHarness;
     // Reproduce the production state: checkout.opened arms the watchdog, and a
     // pending auto-resume intent is saved. link_expired must stop the running
-    // watchdog (no zombie timer) and the re-entrant checkout.closed must clear
-    // the dead-link auto-resume intent while preserving the retry attempt.
+    // watchdog (no zombie timer) and clear the dead-link auto-resume intent
+    // directly while preserving the retry attempt.
     harness.handlers[0]({ event_type: 'checkout.opened', data: {} });
     assert.equal(harness.watchdogs.length, 1, 'checkout.opened must arm the watchdog');
     globalThis.sessionStorage.setItem('wm-pending-checkout', JSON.stringify({ productId: 'prod_1' }));
+    // The merchant code must own the state cleanup. Current Dodo SDK versions
+    // synchronously re-emit checkout.closed from Checkout.close(), but
+    // link_expired recovery should not depend on that SDK lifecycle detail.
+    harness.suppressCloseEvent = true;
 
     harness.handlers[0]({ event_type: 'checkout.link_expired', data: {} });
 
@@ -463,11 +469,11 @@ describe('checkout overlay lifecycle', () => {
     // (d) the running watchdog is stopped — a leaked timer would keep polling
     //     entitlement against a dead session.
     assert.equal(harness.watchdogs[0].stopCalls, 1, 'link_expired must stop the running watchdog');
-    // (e) the re-entrant checkout.closed cleared the dead-link auto-resume intent.
+    // (e) the link_expired branch itself cleared the dead-link auto-resume intent.
     assert.equal(
       globalThis.sessionStorage.getItem('wm-pending-checkout'),
       null,
-      'link_expired must clear the pending auto-resume intent for the expired link',
+      'link_expired must clear the pending auto-resume intent without relying on checkout.closed',
     );
   });
 

--- a/tests/checkout-report-error.test.mts
+++ b/tests/checkout-report-error.test.mts
@@ -42,6 +42,12 @@ describe('shouldSkipSentryForAction', () => {
     assert.equal(shouldSkipSentryForAction('missing-checkout-url'), false);
   });
 
+  it('does NOT skip Sentry for link-expired (overlay link-expiry — track volume)', () => {
+    // Emits at info level (INFO_LEVEL_CODES) so the abandoned-link funnel is
+    // observable without alerting. It must still be captured, never skipped.
+    assert.equal(shouldSkipSentryForAction('link-expired'), false);
+  });
+
   it('does NOT skip Sentry for exception (unhandled throw inside startCheckout)', () => {
     assert.equal(shouldSkipSentryForAction('exception'), false);
   });
@@ -88,7 +94,7 @@ describe('reportCheckoutError call sites in src/services/checkout.ts', () => {
     // this assertion forces an accompanying policy decision.
     assert.deepEqual(
       [...knownActions].sort(),
-      ['exception', 'http-error', 'missing-checkout-url', 'no-token', 'no-user'].sort(),
+      ['exception', 'http-error', 'link-expired', 'missing-checkout-url', 'no-token', 'no-user'].sort(),
     );
   });
 


### PR DESCRIPTION
## Summary

Fixes the P0 where a customer is stranded on a frozen **"Processing… / Payment Link Expires in 00:00"** Dodo overlay (the literal #4435 incident symptom).

Dodo's SDK emits `checkout.link_expired` when a session/payment link expires mid-flow but does **not** self-close the iframe. The dashboard overlay handler (`src/services/checkout.ts`) switched on `opened/status/closed/redirect_requested/error` but had **no `checkout.link_expired` case**, so the frozen overlay had no client-side escape.

- Add a `case 'checkout.link_expired'` that **tears down the frozen iframe** (`safeCloseOverlay`) and surfaces an actionable **"payment link expired — start checkout again"** toast via the existing error taxonomy.
- **Preserve `LAST_CHECKOUT_ATTEMPT_KEY`** (no `clearCheckoutAttempt`) so a re-initiated checkout keeps the product context — mirrors the `checkout.closed` convention.
- New `link_expired` error code reports to Sentry at **info level** (`INFO_LEVEL_CODES`) — an abandoned-then-reopened link is an expected user state, observable for volume without alerting.

### Key decision: `!successFired` guard
`checkout.status=succeeded` runs terminal side effects but does **not** close the iframe, so the success overlay stays mounted. A late `link_expired` would otherwise tell a **paid** user to "start checkout again" — a duplicate-payment nudge (the exact #4440 failure class). The user-facing toast is therefore gated on `!successFired`, mirroring `checkout.closed` / `checkout.redirect_requested`; the iframe teardown still runs unconditionally so the overlay never stays frozen.

## Scope (important)
This closes the **UI symptom** (frozen overlay → actionable retry). It does **not** resolve the upstream 3DS-success path: the hang's root cause is Permissions-Policy blocking nested fraud-detection iframes inside Dodo's sandbox; the structural fix is `displayType:'redirect'` (**#4449**). The retry toast fires, but a re-attempt may hit the same wall until #4449 lands. Independently mergeable.

## Validation
- `npx tsx --test tests/checkout-overlay-lifecycle.test.mts tests/checkout-error-classification.test.mts tests/checkout-report-error.test.mts` — all pass; full `tests/checkout-*.test.mts` = 112 pass.
- `npm run typecheck` clean · `npm run lint:boundaries` clean · `npm run lint:safe-html` clean.
- **Test-first** (issue-mandated): the lifecycle stub arms the watchdog (`checkout.opened`), emits `checkout.link_expired`, and asserts the overlay closes + the watchdog stops + the retry toast shows + the attempt is preserved + the dead-link pending intent is cleared. A second test pins that a **post-success** `link_expired` shows no toast. Revert-check: without the case the overlay stays open (test fails).
- Reviewed via multi-agent code review (8 reviewers + adversarial); the `!successFired` guard and the watchdog-arming test assertion came out of that review and are applied here.

## Post-Deploy Monitoring & Validation
- **Sentry:** watch `tags.code = link_expired` / `action = link-expired` (info level) under `component: dodo-checkout`. Expected healthy signal: occurrences appear with `level: info` (never `error`), each correlated with an overlay that closed. Failure signal: a spike, or any `link_expired` paired with a same-session `terminal success` breadcrumb (would indicate the `!successFired` guard is being bypassed → investigate).
- **User-facing:** confirm in prod that an expired link now shows the inline "payment link expired" toast and the overlay is dismissed (no more frozen "00:00"). Cross-check support reports of stuck overlays drop to zero.
- **Rollback trigger:** if `link_expired` handling correlates with a rise in duplicate subscriptions/payments, revert this commit (single, isolated) and fall back to the prior behavior while #4449 is prioritized.
- **Window/owner:** 48h post-deploy, checkout owner.

## Known follow-ups (not blocking)
- **#4452** — `pro-test/src/services/checkout.ts:243`: the `/pro` marketing variant's `checkout.link_expired` handler is **log-only** (no close/toast), so `/pro` users can still be stranded on expiry. Filed as a separate follow-up (pro-test has no error taxonomy; use a guarded `Checkout.close()` + a vanilla toast).

Closes #4435. Part of the DodoPayments 3DS stuck-payments incident epic #4440.

---
🤖 Compound-engineered with Claude Code (Opus 4.8) via `/ce-work`.
https://claude.ai/code/session_017L8nACBdvQ5Sj7mTBfEBhy

