### PR TITLE
fix(checkout): failure banner rendered "undefined" on full-page return before i18n loaded

### DIFF
--- a/src/components/checkout-failure-banner.ts
+++ b/src/components/checkout-failure-banner.ts
@@ -63,7 +63,7 @@ export function showCheckoutFailureBanner(rawStatus: string): void {
   // attempt cleared, private-browsing storage, cross-device flow).
   // User can still dismiss and use the /pro pricing page normally.
   const retryButton = hasRetryTarget
-    ? `<button id="cf-retry-btn" style="background:#fff;color:#dc2626;border:none;border-radius:4px;padding:4px 12px;font-weight:600;font-size:12px;cursor:pointer;white-space:nowrap;">${t('components.checkoutFailureBanner.retry')}</button>`
+    ? `<button id="cf-retry-btn" style="background:#fff;color:#dc2626;border:none;border-radius:4px;padding:4px 12px;font-weight:600;font-size:12px;cursor:pointer;white-space:nowrap;">${t('components.checkoutFailureBanner.retry', { defaultValue: 'Try again' })}</button>`
     : '';
 
   setTrustedHtml(banner, trustedHtml(`
@@ -72,9 +72,9 @@ export function showCheckoutFailureBanner(rawStatus: string): void {
       <line x1="12" y1="8" x2="12" y2="12"/>
       <line x1="12" y1="16" x2="12.01" y2="16"/>
     </svg>
-    <span>${t('components.checkoutFailureBanner.message')}</span>
+    <span>${t('components.checkoutFailureBanner.message', { defaultValue: "Payment couldn't be completed. No charge was made." })}</span>
     ${retryButton}
-    <button id="cf-dismiss-btn" aria-label="${t('components.checkoutFailureBanner.dismiss')}" style="background:transparent;color:#fff;border:none;cursor:pointer;font-size:18px;padding:0 4px;line-height:1;">&times;</button>
+    <button id="cf-dismiss-btn" aria-label="${t('components.checkoutFailureBanner.dismiss', { defaultValue: 'Dismiss' })}" style="background:transparent;color:#fff;border:none;cursor:pointer;font-size:18px;padding:0 4px;line-height:1;">&times;</button>
   `, "legacy direct innerHTML migration"));
 
   document.body.appendChild(banner);
@@ -90,7 +90,7 @@ export function showCheckoutFailureBanner(rawStatus: string): void {
       if (retryBtn) {
         retryBtn.disabled = true;
         retryBtn.setAttribute('aria-busy', 'true');
-        retryBtn.textContent = t('components.checkoutFailureBanner.retrying');
+        retryBtn.textContent = t('components.checkoutFailureBanner.retrying', { defaultValue: 'Retrying…' });
       }
       let succeeded = false;
       try {
@@ -110,7 +110,7 @@ export function showCheckoutFailureBanner(rawStatus: string): void {
       } else if (retryBtn) {
         retryBtn.disabled = false;
         retryBtn.removeAttribute('aria-busy');
-        retryBtn.textContent = t('components.checkoutFailureBanner.retry');
+        retryBtn.textContent = t('components.checkoutFailureBanner.retry', { defaultValue: 'Try again' });
       }
     });
   }


### PR DESCRIPTION
## The bug (prod, post-#4454)

After the redirect-mode switch (#4449/#4454), a **failed** payment does a full-page redirect back to the dashboard. `panel-layout` renders the checkout-failure banner immediately during the **cold init** — before i18next's full bundle has loaded (i18n loads a shell subset first, then the full bundle async). So `t('components.checkoutFailureBanner.message')` returned `undefined` and the user saw a red **"undefined"** banner (confirmed on prod after a real declined 3DS payment).

The **success** banner is immune — its strings are hardcoded English (`checkout.ts:1221`), and it defers render via `waitForEntitlement`. Redirect mode is what made the immediate cold-load failure-banner path common (the old overlay never reloaded the page).

## Fix

Give every `t()` call in `checkout-failure-banner.ts` a `defaultValue` (English, matching `en.json`): `message`, `retry`, `retrying`, `dismiss`. The banner now renders correct English regardless of i18n readiness, and still picks up translations once the bundle loads. 5 lines, lint clean, no test asserted the raw key.

## Context

This is the only residual from the 3DS redirect work — which is **confirmed working end-to-end on prod**: 3DS now runs top-level (Stripe 3DS + bank ACS), success shows the proper green banner, and failures return to `/dashboard?wm_checkout=return`. Part of #4440.

Refs #4449 #4454