### PR TITLE
perf(map): extract yieldToMain into shared after-paint util (#4457)

### DIFF
--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -15,7 +15,7 @@ import type { WeatherAlert } from '@/services/weather';
 import type { RadiationObservation } from '@/services/radiation';
 import { getSeverityColor } from '@/services/weather';
 import { startSmartPollLoop, type SmartPollLoopHandle } from '@/services/smart-poll-loop';
-import { scheduleAfterFirstPaint } from '@/utils/after-paint';
+import { scheduleAfterFirstPaint, yieldToMain } from '@/utils/after-paint';
 import {
   INTEL_HOTSPOTS,
   CONFLICT_ZONES,
@@ -111,12 +111,6 @@ interface WorldTopology extends Topology {
   objects: {
     countries: GeometryCollection;
   };
-}
-
-// Yield to the main thread (ends the current task) so a long render can be split into
-// sub-50ms tasks — lowers TBT, which deferral alone does not (#4442).
-function yieldToMain(): Promise<void> {
-  return new Promise((resolve) => { setTimeout(resolve, 0); });
 }
 
 export class MapComponent {

--- a/src/utils/after-paint.ts
+++ b/src/utils/after-paint.ts
@@ -37,3 +37,11 @@ export function scheduleAfterFirstPaint(task: () => void, timeoutMs = 3000): voi
     window.addEventListener('load', afterPaint, { once: true });
   }
 }
+
+/**
+ * Yield to the main thread (ends the current task) so a long render can be split into
+ * sub-50ms tasks — lowers TBT, which deferral alone does not (#4442).
+ */
+export function yieldToMain(): Promise<void> {
+  return new Promise((resolve) => { setTimeout(resolve, 0); });
+}

--- a/tests/yield-to-main.test.mts
+++ b/tests/yield-to-main.test.mts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { yieldToMain } from '../src/utils/after-paint.ts';
+
+describe('yieldToMain', () => {
+  it('returns a Promise', () => {
+    const p = yieldToMain();
+    assert.ok(p instanceof Promise);
+    return p;
+  });
+
+  it('yields to the macrotask queue (resolves after an earlier-queued timer)', async () => {
+    const order: string[] = [];
+    setTimeout(() => order.push('earlier-timer'), 0);
+    await yieldToMain();
+    order.push('after-yield');
+    // A microtask-based yield would resolve before the earlier setTimeout(0) fired.
+    // yieldToMain is a macrotask (setTimeout(0)), so the earlier timer runs first.
+    assert.deepEqual(order, ['earlier-timer', 'after-yield']);
+  });
+
+  it('can be awaited repeatedly in order', async () => {
+    const order: number[] = [];
+    await yieldToMain();
+    order.push(1);
+    await yieldToMain();
+    order.push(2);
+    assert.deepEqual(order, [1, 2]);
+  });
+});


### PR DESCRIPTION
Closes #4457 · part of #4443 (Phase A foundation).

Lifts the module-private `yieldToMain` out of `src/components/Map.ts` into
`src/utils/after-paint.ts` (exported, imported directly — mirroring the existing
`scheduleAfterFirstPaint` convention) so the upcoming `createPanels` chunking (U3) and
any future chunked render can reuse the `<50ms` yield primitive.

Pure verbatim move — the implementation (`setTimeout(0)` macrotask yield) is byte-for-byte
identical; `Map.ts`'s Map-specific re-entrancy token guard stays in `Map.ts`.

**Tests:** `npm run typecheck` clean; `tests/yield-to-main.test.mts` (resolves on a macrotask,
returns a Promise, repeatable); biome lint clean. No bundle-chunk risk — `after-paint.ts` was
already imported by `Map.ts`; `secondary-startup.ts`/`analytics.ts` only import
`scheduleAfterFirstPaint`, so the new export adds no import surface.

https://claude.ai/code/session_017L8nACBdvQ5Sj7mTBfEBhy
