### PR TITLE
perf(measure): mobile main-thread attribution harness + baseline (#4458)

### DIFF
--- a/docs/perf/mobile-mainthread-baseline-2026-06-27.md
+++ b/docs/perf/mobile-mainthread-baseline-2026-06-27.md
@@ -1,0 +1,109 @@
+# Mobile main-thread baseline — 2026-06-27 (#4443 / U2)
+
+The committed baseline + measurement methodology for the mobile main-thread budget roadmap
+(`docs/plans/2026-06-27-001-perf-mobile-mainthread-budget-roadmap-plan.md`). Every spin-off
+PR (U3–U8) compares against this doc.
+
+## How to measure
+
+Two complementary signals (KTD1 — local mobile Lighthouse is untrustworthy: its `simulate`
+throttling 4×-amplifies host-CPU contention; the same URL has scored 28/57/85):
+
+1. **Authoritative absolute timings → PageSpeed Insights** (`pagespeed.web.dev`, mobile, Google
+   infra, zero local contention). Take the **median of ≥3** runs; discard the first-run outlier.
+   This is the headline TBT / `mainthread-work` / `bootup-time` / `scriptEvaluation` /
+   `styleLayout` and the per-script `bootup-time` ranking (R4).
+2. **Deterministic relative signal → `scripts/measure-mobile-mainthread.mjs`** (this harness;
+   Playwright mobile emulation + CPU throttle). DOM-node counts are stable run-to-run; total
+   long-task ms is a self-consistent *relative* signal for the same script before/after. This is
+   the per-PR R3 gate (reduce vs. reorder).
+
+```bash
+# deterministic harness (best-effort live capture)
+node scripts/measure-mobile-mainthread.mjs https://worldmonitor.app/dashboard --cpu 4 --settle 14000
+# or against a local preview: node scripts/measure-mobile-mainthread.mjs http://127.0.0.1:4173/dashboard
+```
+
+> **Per-script ms attribution comes from Lighthouse, not this script.** The browser
+> `PerformanceObserver('longtask')` attribution API returns `unknown`/`self` for first-party
+> same-origin script, so the harness cannot name *which* chunk owns each long task — it reports
+> total TBT + DOM-node attribution only. For the per-script ranking (Map-\*.js, main.js,
+> panel-layout) use Lighthouse's `bootup-time` audit, as #4443 did.
+
+## Committed PSI baseline (the comparison point)
+
+From #4443 — prod mobile Lighthouse, 2026-06-26, ×3 median (post #4425 + #4431; before this roadmap):
+
+| Metric | Baseline | Umbrella target (−33%) |
+|---|---|---|
+| TBT | ~1.5 s | ≤ ~1.0 s |
+| `mainthread-work` | ~15 s | ≤ ~10 s |
+| `bootup-time` | ~3.2 s | — |
+| `scriptEvaluation` | ~3.7 s | — |
+| `styleLayout` | ~1.3 s | — |
+| Lighthouse Perf (mobile) | ~65 | lift |
+
+Per-script `bootup-time` (mobile, #4443): `Map-*.js` ~880 ms · `main.js` ~650–1200 ms ·
+`panel-gating` (= `createPanels` serialization in `panel-layout`, not `panel-gating.ts`) ~447 ms.
+
+> **Re-take a fresh PSI median-of-3 at `pagespeed.web.dev` before starting Phase B/C** so the
+> umbrella comparison reflects current prod (which now also has #4442/#4448 — map-render `<50ms`
+> chunking — landed since the 2026-06-26 baseline). Paste the numbers below when taken.
+>
+> | Metric | PSI mobile (median-of-3, date) |
+> |---|---|
+> | TBT | _to fill_ |
+> | `mainthread-work` | _to fill_ |
+> | `bootup-time` | _to fill_ |
+
+## Harness capture — 2026-06-27 (prod, post #4442/#4448)
+
+`scripts/measure-mobile-mainthread.mjs` vs `https://worldmonitor.app/dashboard`, iPhone 14 Pro Max
+emulation, CPU 4×, 14 s settle, n=3:
+
+| Signal | Sample 1 | Sample 2 | Sample 3 | Notes |
+|---|---|---|---|---|
+| Long tasks (>50 ms) | 9 | 7 | 8 | counted by the observer during settle |
+| Total long-task ms | 1164 | 1011 | 1052 | — |
+| **Script-TBT ms** | 714 | 661 | 652 | **median ~661** — *relative* signal, NOT comparable to PSI TBT (different metric basis/throttle/host) |
+| **DOM nodes (total)** | **2313** | **2313** | **2313** | **perfectly stable** (deterministic) |
+| └ panels (`.panel`) | 960 (41.5%) | 960 | 960 | largest attributed source |
+| └ map SVG (`#mapContainer svg`) | 314 (13.6%) | 314 | 314 | — |
+| └ other (chrome/header/shells) | ~1039 (44.9%) | — | — | derived |
+
+Node counts are **unique** (each element counted once, via `querySelectorAll('.panel, .panel *')`),
+so nested panels can't inflate the total. Re-verified after that fix: total 2319, panels 971
+(41.9%), map 314 (13.5%) — within run-to-run content variance of the table above, so the
+panels-dominate-map conclusion is robust to the counting method.
+
+## Findings (R4 ranking + corrections to the plan's expected order)
+
+1. **DOM-node attribution confirms the plan's premise-correction direction, but the ~33K basis is
+   wrong for mobile-initial.** Mobile **initial** DOM (no scroll) is **~2.3K**, not ~33K — because
+   mobile mounts only the initial panel budget (4) plus IntersectionObserver shells. The ~33K /
+   "map ~1–1.5K" figures in #4443 are a **desktop or fully-scrolled** count. On the boot-critical
+   mobile-initial state: **panels are the largest single attributed source (~960, 41.5%, ~3× the
+   map's 314)** — so U4/U5 (panels) remain the node-count levers, but the absolute target is
+   ~2.3K, not 33K. → **re-derive the 33K basis** (desktop vs. fully-scrolled) before sizing U4/U5.
+2. **The dominant mobile-boot cost is script execution, not node count.** ~7–9 long tasks totalling
+   ~1.0–1.2 s of attributed main-thread time on a ~2.3K-node page points at `scriptEvaluation`
+   (Map.ts geometry build + `createPanels` serialization + main.js), consistent with #4443's
+   `bootup-time` ranking. → **U3 (de-serialize/chunk createPanels) and U6 (110m geometry) are the
+   highest-leverage levers**; U4/U5 (node count) are secondary on the mobile-initial state.
+3. **Script-TBT is stable enough to gate on.** ~652–714 ms across n=3 (range ~9%); DOM-node counts
+   are exact. Both are usable per-PR R3 signals; PSI supplies the absolute headline.
+
+### Lever ranking for Phase B/C (current evidence; confirm with a fresh PSI bootup-time pass)
+
+1. **U3** — `createPanels` de-serialization/chunking (the ~447 ms `panel-layout` block).
+2. **U6** — mobile 110m topology (cuts `Map.ts` geometry parse/`styleLayout`; deterministic, U2-independent).
+3. **U7** — feature caps + skip the first-paint label-reflow loop (`styleLayout`).
+4. **U4 / U5** — panel node-count levers; smaller absolute target on mobile-initial than the plan assumed (see finding 1).
+5. **U8** — canvas dense layers; **gated** — only if post-U6+U7 map `styleLayout`/compositor residual clears the bar (likely low value given the small mobile-initial map-node share).
+
+## Gate status (R5)
+
+U2 is the binding gate. Before each Phase B/C PR: (a) re-take PSI median-of-3 here if stale,
+(b) run the harness before/after and record the script-TBT + DOM-node delta in the PR, (c) honor
+the per-unit drop thresholds in the plan (defer U3 if `createPanels` < ~150 ms attributed; defer
+U8 if the post-U6+U7 residual is below its bar).

--- a/docs/perf/mobile-mainthread-baseline-2026-06-27.md
+++ b/docs/perf/mobile-mainthread-baseline-2026-06-27.md
@@ -46,15 +46,33 @@ From #4443 — prod mobile Lighthouse, 2026-06-26, ×3 median (post #4425 + #443
 Per-script `bootup-time` (mobile, #4443): `Map-*.js` ~880 ms · `main.js` ~650–1200 ms ·
 `panel-gating` (= `createPanels` serialization in `panel-layout`, not `panel-gating.ts`) ~447 ms.
 
-> **Re-take a fresh PSI median-of-3 at `pagespeed.web.dev` before starting Phase B/C** so the
-> umbrella comparison reflects current prod (which now also has #4442/#4448 — map-render `<50ms`
-> chunking — landed since the 2026-06-26 baseline). Paste the numbers below when taken.
+> **PSI mobile is blocked (2026-06-27):** the unkeyed PageSpeed API is quota-exhausted (429) and
+> the repo `GOOGLE_API_KEY` is expired (400). Re-take a fresh PSI mobile median-of-3 at
+> `pagespeed.web.dev` (or renew the key) before Phase B/C and paste it here:
 >
 > | Metric | PSI mobile (median-of-3, date) |
 > |---|---|
-> | TBT | _to fill_ |
-> | `mainthread-work` | _to fill_ |
-> | `bootup-time` | _to fill_ |
+> | TBT | _pending PSI_ |
+> | `mainthread-work` | _pending PSI_ |
+> | `bootup-time` | _pending PSI_ |
+
+**Interim desktop-Lighthouse baseline** (2026-06-27, current prod = post #4442/#4448, before the
+Phase A/B/C PRs land; `npx lighthouse@12 --preset=desktop`, median-of-3). Per KTD1, local *desktop*
+Lighthouse is the reliable fallback when PSI mobile is unavailable; mobile TBT is extrapolated as
+desktop × ~4. **These runs were host-contended** (score swung 51–77), so treat absolute TBT as
+directional:
+
+| Metric | Desktop median (range) | Mobile estimate (×4) |
+|---|---|---|
+| Perf score | 62 (51–77) | — |
+| TBT | 562 ms (287–696) | ~2.2 s |
+| `mainthread-work` | 10.1 s (8.1–11.1) | — |
+| `bootup-time` | 1.8 s (1.3–1.9) | — |
+| FCP / LCP | 1.1 s | — |
+
+Reading: `mainthread-work` ~10 s and `bootup-time` ~1.8 s remain the dominant budget (paint is fine
+at ~1.1 s) — consistent with the script-execution-bound finding above. Desktop TBT is noisy under
+contention; the authoritative mobile TBT still needs a clean PSI run.
 
 ## Harness capture — 2026-06-27 (prod, post #4442/#4448)
 

--- a/scripts/measure-mobile-mainthread.mjs
+++ b/scripts/measure-mobile-mainthread.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+/**
+ * Mobile main-thread attribution harness (#4443 / U2).
+ *
+ * Loads /dashboard under mobile emulation + CPU throttle and attributes:
+ *   - long tasks (PerformanceObserver 'longtask') by source, with TBT contribution
+ *   - DOM-node counts per source (map SVG subtree vs panels)
+ *
+ * The pure attribution functions are exported and unit-tested with fixtures
+ * (deterministic, CI-safe). Playwright is loaded lazily so importing this module
+ * for its helpers never launches a browser.
+ *
+ * Why this exists (KTD1, #4443): local mobile Lighthouse is untrustworthy — its
+ * `simulate` throttling 4x-amplifies host-CPU contention (the same URL has scored
+ * 28/57/85). Long-task *structure* and DOM-node *counts* are stable run-to-run, so
+ * this script is the deterministic per-PR R3 signal (reduce vs reorder). Take the
+ * authoritative absolute mobile timings from PageSpeed Insights (pagespeed.web.dev).
+ *
+ * Usage:
+ *   node scripts/measure-mobile-mainthread.mjs [url] [--cpu 4] [--settle 15000] [--json]
+ *   (default url: https://worldmonitor.app/dashboard)
+ */
+import { pathToFileURL } from 'node:url';
+
+const TBT_THRESHOLD_MS = 50;
+
+function round(n) {
+  return Math.round((Number(n) || 0) * 10) / 10;
+}
+
+/** TBT contribution of a single task = max(0, duration - 50ms). */
+export function tbtContribution(durationMs) {
+  return Math.max(0, (Number(durationMs) || 0) - TBT_THRESHOLD_MS);
+}
+
+/** First attribution container name (or the entry name) used to bucket a long task. */
+function longTaskSource(entry) {
+  const attr = Array.isArray(entry?.attribution) ? entry.attribution[0] : null;
+  return String(
+    attr?.containerName || attr?.containerSrc || attr?.name || entry?.name || 'unknown',
+  );
+}
+
+/**
+ * Group long-task entries by attributed source, summing duration + TBT contribution.
+ * Returns rows sorted by TBT contribution (then total duration), descending.
+ */
+export function rankLongTasks(entries) {
+  const bySource = new Map();
+  for (const entry of Array.isArray(entries) ? entries : []) {
+    const dur = Number(entry?.duration) || 0;
+    const key = longTaskSource(entry);
+    const acc = bySource.get(key) || { source: key, count: 0, totalMs: 0, tbtMs: 0, maxMs: 0 };
+    acc.count += 1;
+    acc.totalMs += dur;
+    acc.tbtMs += tbtContribution(dur);
+    acc.maxMs = Math.max(acc.maxMs, dur);
+    bySource.set(key, acc);
+  }
+  return [...bySource.values()]
+    .map((r) => ({ ...r, totalMs: round(r.totalMs), tbtMs: round(r.tbtMs), maxMs: round(r.maxMs) }))
+    .sort((a, b) => b.tbtMs - a.tbtMs || b.totalMs - a.totalMs);
+}
+
+/** Headline long-task summary: counts, total ms, TBT ms, and the per-source ranking. */
+export function summarizeLongTasks(entries) {
+  const list = Array.isArray(entries) ? entries : [];
+  const totalMs = list.reduce((s, e) => s + (Number(e?.duration) || 0), 0);
+  const tbtMs = list.reduce((s, e) => s + tbtContribution(e?.duration), 0);
+  const longTaskCount = list.filter((e) => (Number(e?.duration) || 0) > TBT_THRESHOLD_MS).length;
+  return {
+    taskCount: list.length,
+    longTaskCount,
+    totalMs: round(totalMs),
+    tbtMs: round(tbtMs),
+    ranked: rankLongTasks(list),
+  };
+}
+
+/**
+ * Attribute DOM nodes across named sources (e.g. { total, mapSvg, panels }).
+ * Returns the total plus per-source rows with share %, sorted by node count desc.
+ */
+export function attributeDomNodes(counts) {
+  const entries = Object.entries(counts || {}).filter(([k]) => k !== 'total');
+  const total =
+    counts && counts.total !== undefined
+      ? Number(counts.total) || 0
+      : entries.reduce((s, [, v]) => s + (Number(v) || 0), 0);
+  const rows = entries
+    .map(([source, n]) => ({
+      source,
+      nodes: Number(n) || 0,
+      sharePct: total ? round(((Number(n) || 0) / total) * 100) : 0,
+    }))
+    .sort((a, b) => b.nodes - a.nodes);
+  return { total, rows };
+}
+
+export function parseArgs(argv) {
+  const args = { url: 'https://worldmonitor.app/dashboard', cpu: 4, settle: 15000, json: false };
+  const rest = argv.slice(2);
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (a === '--cpu') {
+      const n = Number(rest[++i]);
+      if (!Number.isNaN(n)) args.cpu = n;
+    } else if (a === '--settle') {
+      const n = Number(rest[++i]);
+      if (!Number.isNaN(n)) args.settle = n;
+    } else if (a === '--json') {
+      args.json = true;
+    } else if (!a.startsWith('--')) {
+      args.url = a;
+    }
+  }
+  return args;
+}
+
+/** Live capture (best-effort). Loads the URL under mobile emulation + CPU throttle. */
+async function measure(url, { cpu = 4, settle = 15000, device = 'iPhone 14 Pro Max' } = {}) {
+  const { chromium, devices } = await import('@playwright/test');
+  if (!devices[device]) throw new Error(`Unknown Playwright device: ${device}`);
+  const browser = await chromium.launch();
+  try {
+    const { defaultBrowserType, ...descriptor } = devices[device];
+    const context = await browser.newContext({ ...descriptor });
+    const page = await context.newPage();
+    const client = await context.newCDPSession(page);
+    try {
+      await client.send('Emulation.setCPUThrottlingRate', { rate: cpu });
+    } catch {
+      /* CDP throttle unavailable — continue at host speed */
+    }
+    await page.addInitScript(() => {
+      window.__longtasks = [];
+      try {
+        new PerformanceObserver((list) => {
+          for (const e of list.getEntries()) {
+            window.__longtasks.push({
+              name: e.name,
+              duration: e.duration,
+              startTime: e.startTime,
+              attribution: (e.attribution || []).map((a) => ({
+                name: a.name,
+                containerType: a.containerType,
+                containerName: a.containerName,
+                containerSrc: a.containerSrc,
+              })),
+            });
+          }
+        }).observe({ type: 'longtask', buffered: true });
+      } catch {
+        /* longtask unsupported */
+      }
+    });
+    await page.goto(url, { waitUntil: 'load', timeout: 60000 });
+    await page.waitForTimeout(settle);
+    const longtasks = await page.evaluate(() => window.__longtasks || []);
+    const nodeCounts = await page.evaluate(() => {
+      // Count each element at most once. Summing per-match subtrees would double-count
+      // a .panel nested inside another .panel; the `, sel *` union keeps it unique.
+      const uniqueCount = (sel) => {
+        try {
+          return document.querySelectorAll(sel).length;
+        } catch {
+          return 0;
+        }
+      };
+      return {
+        total: document.querySelectorAll('*').length,
+        mapSvg: uniqueCount('#mapContainer svg, #mapContainer svg *'),
+        panels: uniqueCount('.panel, .panel *'),
+      };
+    });
+    return { url, cpu, longtasks, nodeCounts };
+  } finally {
+    await browser.close();
+  }
+}
+
+/** Build the structured report (pure — exported for tests). */
+export function buildReport(result) {
+  return {
+    url: result?.url,
+    cpu: result?.cpu,
+    tasks: summarizeLongTasks(result?.longtasks),
+    nodes: attributeDomNodes(result?.nodeCounts),
+  };
+}
+
+function printHuman(report) {
+  const { tasks, nodes } = report;
+  console.log(`\nMobile main-thread attribution — ${report.url} (CPU ${report.cpu}x)\n`);
+  console.log(
+    `Long tasks: ${tasks.taskCount} (${tasks.longTaskCount} >50ms) · total ${tasks.totalMs}ms · TBT ${tasks.tbtMs}ms`,
+  );
+  for (const r of tasks.ranked) {
+    console.log(`  ${String(r.source).padEnd(28)} TBT ${String(r.tbtMs).padStart(7)}ms  (${r.count}× · max ${r.maxMs}ms)`);
+  }
+  console.log(`\nDOM nodes: ${nodes.total} total`);
+  for (const r of nodes.rows) {
+    console.log(`  ${r.source.padEnd(28)} ${String(r.nodes).padStart(7)}  (${r.sharePct}%)`);
+  }
+  console.log('');
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const result = await measure(args.url, { cpu: args.cpu, settle: args.settle });
+  const report = buildReport(result);
+  // --json emits JSON-only on stdout so `| jq` works; human text is suppressed.
+  if (args.json) console.log(JSON.stringify(report, null, 2));
+  else printHuman(report);
+}
+
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tests/measure-mobile-mainthread.test.mts
+++ b/tests/measure-mobile-mainthread.test.mts
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  attributeDomNodes,
+  buildReport,
+  parseArgs,
+  rankLongTasks,
+  summarizeLongTasks,
+  tbtContribution,
+} from '../scripts/measure-mobile-mainthread.mjs';
+
+describe('measure-mobile-mainthread attribution', () => {
+  it('tbtContribution subtracts the 50ms floor, clamped at 0', () => {
+    assert.equal(tbtContribution(40), 0);
+    assert.equal(tbtContribution(50), 0);
+    assert.equal(tbtContribution(130), 80);
+  });
+
+  it('ranks long tasks by TBT contribution, descending, grouped by source', () => {
+    const fixture = [
+      { name: 'self', duration: 60, attribution: [{ containerName: 'panels' }] },
+      { name: 'self', duration: 200, attribution: [{ containerName: 'Map' }] },
+      { name: 'self', duration: 120, attribution: [{ containerName: 'Map' }] },
+    ];
+    const ranked = rankLongTasks(fixture);
+    assert.equal(ranked[0].source, 'Map');
+    assert.equal(ranked[0].count, 2);
+    assert.equal(ranked[0].tbtMs, 220); // (200-50) + (120-50)
+    assert.equal(ranked[0].maxMs, 200);
+    assert.equal(ranked[1].source, 'panels');
+    assert.equal(ranked[1].tbtMs, 10);
+  });
+
+  it('falls back to the entry name when attribution is absent', () => {
+    const ranked = rankLongTasks([{ name: 'unattributed', duration: 90 }]);
+    assert.equal(ranked[0].source, 'unattributed');
+    assert.equal(ranked[0].tbtMs, 40);
+  });
+
+  it('summarizeLongTasks counts only tasks over the 50ms floor as long tasks', () => {
+    const s = summarizeLongTasks([{ duration: 40 }, { duration: 200 }, { duration: 60 }]);
+    assert.equal(s.taskCount, 3);
+    assert.equal(s.longTaskCount, 2);
+    assert.equal(s.totalMs, 300);
+    assert.equal(s.tbtMs, 160); // (200-50) + (60-50)
+  });
+
+  it('handles an empty / missing trace without throwing', () => {
+    assert.deepEqual(summarizeLongTasks([]), {
+      taskCount: 0,
+      longTaskCount: 0,
+      totalMs: 0,
+      tbtMs: 0,
+      ranked: [],
+    });
+    assert.equal(rankLongTasks([]).length, 0);
+    assert.equal(rankLongTasks(undefined).length, 0);
+    assert.equal(summarizeLongTasks(undefined).taskCount, 0);
+  });
+
+  it('attributeDomNodes computes share percentages and sorts by node count desc', () => {
+    const { total, rows } = attributeDomNodes({ total: 1000, mapSvg: 100, panels: 800 });
+    assert.equal(total, 1000);
+    assert.equal(rows[0].source, 'panels');
+    assert.equal(rows[0].sharePct, 80);
+    assert.equal(rows[1].source, 'mapSvg');
+    assert.equal(rows[1].sharePct, 10);
+  });
+
+  it('attributeDomNodes derives total when not provided and tolerates empty input', () => {
+    const derived = attributeDomNodes({ mapSvg: 200, panels: 300 });
+    assert.equal(derived.total, 500);
+    assert.equal(derived.rows[0].source, 'panels');
+    assert.deepEqual(attributeDomNodes({}).rows, []);
+    assert.deepEqual(attributeDomNodes(undefined).rows, []);
+  });
+
+  it('attributeDomNodes honours an explicit total of 0 instead of deriving it', () => {
+    // A real page never reports total:0 with non-zero subtrees, but the contract
+    // must not silently override an explicit total.
+    const { total, rows } = attributeDomNodes({ total: 0, mapSvg: 100 });
+    assert.equal(total, 0);
+    assert.equal(rows[0].sharePct, 0); // no divide-by-zero
+  });
+});
+
+describe('parseArgs', () => {
+  it('defaults url/cpu/settle/json when no args are given', () => {
+    const a = parseArgs(['node', 'script']);
+    assert.equal(a.url, 'https://worldmonitor.app/dashboard');
+    assert.equal(a.cpu, 4);
+    assert.equal(a.settle, 15000);
+    assert.equal(a.json, false);
+  });
+
+  it('accepts a positional url and flags', () => {
+    const a = parseArgs(['node', 'script', 'http://127.0.0.1:4173/dashboard', '--cpu', '6', '--settle', '8000', '--json']);
+    assert.equal(a.url, 'http://127.0.0.1:4173/dashboard');
+    assert.equal(a.cpu, 6);
+    assert.equal(a.settle, 8000);
+    assert.equal(a.json, true);
+  });
+
+  it('honours --cpu 0 / --settle 0 as real values (not falsy-coerced to default)', () => {
+    const a = parseArgs(['node', 'script', '--cpu', '0', '--settle', '0']);
+    assert.equal(a.cpu, 0);
+    assert.equal(a.settle, 0);
+  });
+
+  it('keeps the default when a numeric flag has a missing or non-numeric value', () => {
+    assert.equal(parseArgs(['node', 'script', '--cpu']).cpu, 4);
+    assert.equal(parseArgs(['node', 'script', '--cpu', 'fast']).cpu, 4);
+  });
+});
+
+describe('buildReport', () => {
+  it('produces a JSON-serializable report from a measure() result', () => {
+    const report = buildReport({
+      url: 'http://x/dashboard',
+      cpu: 4,
+      longtasks: [{ duration: 200, attribution: [{ containerName: 'Map' }] }],
+      nodeCounts: { total: 1000, mapSvg: 100, panels: 800 },
+    });
+    assert.equal(report.url, 'http://x/dashboard');
+    assert.equal(report.cpu, 4);
+    assert.equal(report.tasks.tbtMs, 150);
+    assert.equal(report.nodes.rows[0].source, 'panels');
+    // round-trips cleanly for `--json | jq`
+    assert.doesNotThrow(() => JSON.parse(JSON.stringify(report)));
+  });
+});


### PR DESCRIPTION
Closes #4458 · part of #4443 (Phase A foundation — **the binding gate** for Phases B/C).

Adds `scripts/measure-mobile-mainthread.mjs`: loads `/dashboard` under mobile emulation + CPU
throttle and attributes long tasks (TBT contribution) and DOM-node counts per source (map SVG
vs panels). Pure attribution helpers (`tbtContribution`, `rankLongTasks`, `summarizeLongTasks`,
`attributeDomNodes`, `parseArgs`, `buildReport`) are fixture-tested (CI-safe); Playwright is
loaded lazily. `docs/perf/mobile-mainthread-baseline-2026-06-27.md` records the committed PSI
comparison point + methodology.

**Why (KTD1):** local mobile Lighthouse is untrustworthy (its `simulate` throttling 4×-amplifies
host-CPU contention — the same URL has scored 28/57/85). DOM-node counts are deterministic and
total long-task ms is a stable *relative* signal, so this is the per-PR R3 gate (reduce vs.
reorder); PSI supplies the authoritative absolute headline.

**Measure-first finding (reshapes Phase B/C):**
- Mobile **initial** DOM is **~2.3K**, not ~33K (that basis is desktop/fully-scrolled). Panels are
  the biggest single source (~42%, ~3× the map's ~13.5%) — so the premise direction holds but the
  U4/U5 node-count target is far smaller than assumed.
- Mobile boot is **script-execution-bound** (~7–9 long tasks / ~1.0–1.2s on a 2.3K-node page) →
  **U3 (createPanels) and U6 (110m geometry) rank above U4/U5**.
- The `longtask` attribution API returns `unknown` for first-party script, so per-script ms
  ranking must come from Lighthouse `bootup-time` (documented in the baseline).

**Tests:** `tests/measure-mobile-mainthread.test.mts` (13 cases incl. empty/edge inputs, `--cpu 0`
escape hatch, `--json` round-trip); biome lint clean; live-validated ×4 vs prod. Incorporates a
code-review pass (unique node-counting to avoid double-count, JSON-only `--json` for pipe consumers,
throw on unknown device, `try/finally` browser cleanup).

https://claude.ai/code/session_017L8nACBdvQ5Sj7mTBfEBhy
