### PR TITLE
fix(seo): serve Content-Signal as an HTTP header, not a robots.txt directive (#4471)

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,8 +1,9 @@
 # World Monitor - protect API routes from crawlers
 
-# AI content-usage preferences (contentsignals.org draft RFC).
-# Origin-wide directive, NOT scoped under User-agent per the spec.
-Content-Signal: ai-train=no, search=yes, ai-input=yes
+# AI content-usage preferences (contentsignals.org draft RFC) are served as the
+# origin-wide `Content-Signal` HTTP response header (see vercel.json), NOT as a
+# robots.txt body directive — Lighthouse's robots.txt validator rejects unknown
+# directives and would drop the SEO score (#4471). Do not re-add it here.
 
 User-agent: *
 Allow: /

--- a/vercel.json
+++ b/vercel.json
@@ -81,6 +81,7 @@
     {
       "source": "/((?!docs|embed|embed\\.html).*)",
       "headers": [
+        { "key": "Content-Signal", "value": "ai-train=no, search=yes, ai-input=yes" },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },


### PR DESCRIPTION
Closes #4471.

Lighthouse's `robots-txt` audit rejects the unknown `Content-Signal` directive
(contentsignals.org AI-usage **draft RFC**) and flags `robots.txt` invalid, dropping
**Lighthouse SEO 100 → 92 on both desktop and mobile** (surfaced re-measuring #3106 on 2026-06-27).

**Fix:** move the AI-usage signal from the `robots.txt` body to an **origin-wide HTTP response
header** — the draft RFC supports header placement, so the signal is preserved while `robots.txt`
stays Lighthouse-valid (SEO back to 100).

- `public/robots.txt` — drop the `Content-Signal:` directive (+ replace with a `#` comment so it isn't re-added; Lighthouse ignores comment lines).
- `vercel.json` — add `{ "key": "Content-Signal", "value": "ai-train=no, search=yes, ai-input=yes" }` to the existing origin-wide content-headers block (`/((?!docs|embed|embed\.html).*)`, alongside the other security headers).

`blog-site/public/robots.txt` checked — it does not carry the directive, no change needed.

**Takes effect on deploy.** Post-deploy acceptance (per #4471):
- `curl -I https://www.worldmonitor.app/` shows the `Content-Signal` response header.
- `https://www.worldmonitor.app/robots.txt` no longer contains the directive.
- Lighthouse SEO = 100 (desktop + mobile); the `robots-txt` audit passes.

Validated locally: `vercel.json` is valid JSON; `robots.txt` retains User-agent/Allow/Disallow/Sitemap and carries no non-comment `Content-Signal` line.

https://claude.ai/code/session_017L8nACBdvQ5Sj7mTBfEBhy
