### PR TITLE
perf(dashboard): lower mobile eager-panel budget 4→3 (#4460)

### DIFF
--- a/src/app/panel-mount-deferral.ts
+++ b/src/app/panel-mount-deferral.ts
@@ -1,5 +1,9 @@
 export const INITIAL_PANEL_MOUNT_BUDGET_DESKTOP = 8;
-export const INITIAL_PANEL_MOUNT_BUDGET_MOBILE = 4;
+// Mobile mounts fewer panels eagerly; the rest get IntersectionObserver shells (700px
+// lookahead) and mount before they scroll into view. Lowered 4→3 to trim boot DOM /
+// main-thread work on mobile (#4460 / #4443 U4); the typically 1–2 above-the-fold panels
+// still mount eagerly, so no added skeleton flash.
+export const INITIAL_PANEL_MOUNT_BUDGET_MOBILE = 3;
 
 export interface PanelMountDeferralInput {
   enabled: boolean;

--- a/tests/panel-mount-deferral.test.mts
+++ b/tests/panel-mount-deferral.test.mts
@@ -73,11 +73,13 @@ afterEach(() => {
 describe('panel mount deferral', () => {
   it('uses a smaller initial real-panel budget on mobile', () => {
     assert.equal(getInitialPanelMountBudget(false), 8);
-    assert.equal(getInitialPanelMountBudget(true), 4);
+    assert.equal(getInitialPanelMountBudget(true), 3);
     assert.equal(shouldDeferInitialPanelMount({ enabled: false, mountedEnabledCount: 100, isMobile: false }), false);
     assert.equal(shouldDeferInitialPanelMount({ enabled: true, mountedEnabledCount: 7, isMobile: false }), false);
     assert.equal(shouldDeferInitialPanelMount({ enabled: true, mountedEnabledCount: 8, isMobile: false }), true);
-    assert.equal(shouldDeferInitialPanelMount({ enabled: true, mountedEnabledCount: 4, isMobile: true }), true);
+    // Mobile budget is 3: the first 3 enabled panels mount immediately; the 4th defers.
+    assert.equal(shouldDeferInitialPanelMount({ enabled: true, mountedEnabledCount: 2, isMobile: true }), false);
+    assert.equal(shouldDeferInitialPanelMount({ enabled: true, mountedEnabledCount: 3, isMobile: true }), true);
   });
 
   it('creates inert shells with panel identity but no startup controls', () => {


### PR DESCRIPTION
Closes #4460 · part of #4443 (Phase B — mobile DOM-node lever).

Lower `INITIAL_PANEL_MOUNT_BUDGET_MOBILE` **4 → 3** so one fewer panel mounts eagerly on
mobile boot. Everything beyond the budget already defers via the #4367 IntersectionObserver
shells (700px mobile lookahead) and mounts before scrolling into view, so **all panels stay
reachable** — this changes *initial* mount count, not availability. Desktop budget (8) unchanged.

**Why 3 (not 2):** the conservative end of the plan's range. The typically 1–2 above-the-fold
mobile panels still mount eagerly, so there's no added skeleton-flash; the formerly-4th panel
just routes through the same proven deferral path panels 5+ already use.

**Runtime-verified** (mobile dev, iPhone 14 Pro Max emulation): exactly **3 panels mount eagerly**,
**0 deferred shells stuck above the fold**, 0 page errors. Unit test pins the new boundary
(`getInitialPanelMountBudget(true) === 3`; defers at count ≥ 3, not at 2).

**Scope note / honesty:** this lever's value is modest — the clean-host re-measure (see #3106 /
#4443) showed mobile-initial DOM is ~2.3K (not the ~33K the umbrella assumed) and clean mobile TBT
is ~608ms, so the DOM-node gap is smaller than originally scoped. Held back as follow-ups pending a
clean PSI: the optional **mobile panel-exclusion gate** (needs product input on which panels),
shrinking the **deferred-shell skeleton**, and a more aggressive **budget=2** (risks a skeleton
flash when the map is collapsed and 2–3 panels sit above the fold).

https://claude.ai/code/session_017L8nACBdvQ5Sj7mTBfEBhy
