### PR TITLE
fix(security): bump protobufjs 7.6.2 → 7.6.4 (CVE-2026-54269)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5939,12 +5939,6 @@
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
@@ -18422,9 +18416,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.2.tgz",
-      "integrity": "sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -18434,7 +18428,6 @@
         "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",


### PR DESCRIPTION
## Summary

`protobufjs@7.6.2` is flagged by Snyk for **CVE-2026-54269** (Improper Check for Unusual or Exceptional Conditions, medium), fixed in `7.6.3`.

It's **transitive** — pulled only via `onnxruntime-web` (the ONNX ML worker), which already declares `protobufjs@^7.2.4`. So a plain `npm update protobufjs --package-lock-only` resolves it to **7.6.4** with:

- no direct dependency added,
- no `package.json` change,
- and `@protobufjs/inquire` dropped from the tree (7.6.4 no longer depends on it).

Net diff: **+3 / −10 in `package-lock.json` only**.

## Reachability / priority

Honest framing: this is **housekeeping**, not urgent. `protobufjs` here only runs inside the ML inference worker (`onnxruntime-web`) processing model artifacts — not a path that takes arbitrary attacker-controlled protobuf input. But the fix is a clean, zero-risk lockfile bump, so there's no reason to carry the advisory.

## Type of change
- [x] Bug fix (security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)