### PR TITLE
perf(main.js): lazy-init the 5 module-scope IntelligenceServiceClients (U1, #4477)

### DIFF
--- a/src/services/gdelt-intel.ts
+++ b/src/services/gdelt-intel.ts
@@ -1,5 +1,5 @@
 import type { Hotspot } from '@/types';
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl } from '@/services/rpc-client';
 import { t } from '@/services/i18n';
 import {
   IntelligenceServiceClient,
@@ -133,7 +133,7 @@ export function getIntelTopics(): IntelTopic[] {
 
 // ---- Sebuf client ----
 
-const client = new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
+const getClient = createLazyClient(() => new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) }));
 const gdeltBreaker = createCircuitBreaker<SearchGdeltDocumentsResponse>({ name: 'GDELT Intelligence', cacheTtlMs: 10 * 60 * 1000, persistCache: true });
 const positiveGdeltBreaker = createCircuitBreaker<SearchGdeltDocumentsResponse>({ name: 'GDELT Positive', cacheTtlMs: 10 * 60 * 1000, persistCache: true });
 
@@ -149,7 +149,7 @@ export async function fetchTopicTimeline(topicId: string): Promise<TopicTimeline
   if (cached && Date.now() - cached.timestamp < CACHE_TTL) return cached.data;
 
   try {
-    const resp = await client.getGdeltTopicTimeline({ topic: topicId });
+    const resp = await getClient().getGdeltTopicTimeline({ topic: topicId });
     if (resp.error || (resp.tone.length === 0 && resp.vol.length === 0)) return null;
     const data: TopicTimeline = { tone: resp.tone, vol: resp.vol, fetchedAt: resp.fetchedAt };
     timelineCache.set(topicId, { data, timestamp: Date.now() });
@@ -185,7 +185,7 @@ export async function fetchGdeltArticles(
   }
 
   const resp = await gdeltBreaker.execute(async () => {
-    return client.searchGdeltDocuments({
+    return getClient().searchGdeltDocuments({
       query,
       maxRecords: maxrecords,
       timespan,
@@ -309,7 +309,7 @@ export async function fetchPositiveGdeltArticles(
   }
 
   const resp = await positiveGdeltBreaker.execute(async () => {
-    return client.searchGdeltDocuments({
+    return getClient().searchGdeltDocuments({
       query,
       maxRecords: maxrecords,
       timespan,

--- a/src/services/pizzint.ts
+++ b/src/services/pizzint.ts
@@ -1,5 +1,5 @@
 import type { PizzIntStatus, PizzIntLocation, PizzIntDefconLevel, GdeltTensionPair } from '@/types';
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl } from '@/services/rpc-client';
 import { createCircuitBreaker } from '@/utils';
 import { getHydratedData } from '@/services/bootstrap';
 import { t } from '@/services/i18n';
@@ -13,7 +13,7 @@ import {
 
 // ---- Sebuf client ----
 
-const client = new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
+const getClient = createLazyClient(() => new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) }));
 
 // ---- Circuit breakers ----
 
@@ -120,7 +120,7 @@ export async function fetchPizzIntStatus(): Promise<PizzIntStatus> {
   if (hydrated?.pizzint) return toStatus(hydrated.pizzint);
 
   return pizzintBreaker.execute(async () => {
-    const resp: GetPizzintStatusResponse = await client.getPizzintStatus({ includeGdelt: false });
+    const resp: GetPizzintStatusResponse = await getClient().getPizzintStatus({ includeGdelt: false });
     if (!resp.pizzint) throw new Error('No PizzINT data');
     return toStatus(resp.pizzint);
   }, defaultStatus);
@@ -128,7 +128,7 @@ export async function fetchPizzIntStatus(): Promise<PizzIntStatus> {
 
 export async function fetchGdeltTensions(): Promise<GdeltTensionPair[]> {
   return gdeltBreaker.execute(async () => {
-    const resp: GetPizzintStatusResponse = await client.getPizzintStatus({ includeGdelt: true });
+    const resp: GetPizzintStatusResponse = await getClient().getPizzintStatus({ includeGdelt: true });
     return resp.tensionPairs.map(toTensionPair);
   }, []);
 }

--- a/src/services/satellites.ts
+++ b/src/services/satellites.ts
@@ -11,7 +11,7 @@
 // - Historical Pass Log: which sats passed over a location in the last 24h
 //   (useful for identifying imaging windows after events)
 
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl } from '@/services/rpc-client';
 import { IntelligenceServiceClient } from '@/generated/client/worldmonitor/intelligence/v1/service_client';
 import type { SatRec } from 'satellite.js';
 
@@ -31,7 +31,7 @@ async function ensureSatelliteLib(): Promise<SatelliteLib> {
   return satLibPromise;
 }
 
-const intelligenceClient = new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
+const getIntelligenceClient = createLazyClient(() => new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) }));
 
 export interface SatelliteTLE {
   noradId: string;
@@ -79,7 +79,7 @@ export async function fetchSatelliteTLEs(): Promise<SatelliteTLE[] | null> {
     const timeoutId = setTimeout(() => controller.abort(), 20_000);
     let resp;
     try {
-      resp = await intelligenceClient.listSatellites({ country: '' }, { signal: controller.signal });
+      resp = await getIntelligenceClient().listSatellites({ country: '' }, { signal: controller.signal });
     } finally {
       clearTimeout(timeoutId);
     }

--- a/src/services/security-advisories.ts
+++ b/src/services/security-advisories.ts
@@ -1,4 +1,4 @@
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl } from '@/services/rpc-client';
 import { getHydratedData } from '@/services/bootstrap';
 import { dataFreshness } from './data-freshness';
 import {
@@ -22,7 +22,7 @@ export interface SecurityAdvisoriesFetchResult {
   cachedAt?: string;
 }
 
-const client = new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
+const getClient = createLazyClient(() => new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) }));
 
 function normalizeAdvisories(
   raw: ListSecurityAdvisoriesResponse | { advisories: Array<{ title: string; link: string; pubDate: string; source: string; sourceCountry: string; level: string; country: string }>; byCountry: Record<string, string> },
@@ -59,7 +59,7 @@ export async function loadAdvisoriesFromServer(): Promise<SecurityAdvisoriesFetc
   }
 
   try {
-    const resp = await client.listSecurityAdvisories({});
+    const resp = await getClient().listSecurityAdvisories({});
     const advisories = normalizeAdvisories(resp);
     cachedResult = advisories;
     lastFetch = now;

--- a/src/services/social-velocity.ts
+++ b/src/services/social-velocity.ts
@@ -1,4 +1,4 @@
-import { getRpcBaseUrl } from '@/services/rpc-client';
+import { createLazyClient, getRpcBaseUrl } from '@/services/rpc-client';
 import {
   IntelligenceServiceClient,
   type GetSocialVelocityResponse,
@@ -8,7 +8,7 @@ import { getHydratedData } from '@/services/bootstrap';
 
 export type { GetSocialVelocityResponse, SocialVelocityPost };
 
-const client = new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) });
+const getClient = createLazyClient(() => new IntelligenceServiceClient(getRpcBaseUrl(), { fetch: (...args) => globalThis.fetch(...args) }));
 
 const emptyVelocity: GetSocialVelocityResponse = { posts: [], fetchedAt: 0 };
 
@@ -17,7 +17,7 @@ export async function fetchSocialVelocity(): Promise<GetSocialVelocityResponse> 
   if (hydrated?.posts?.length) return hydrated;
 
   try {
-    return await client.getSocialVelocity({});
+    return await getClient().getSocialVelocity({});
   } catch {
     return emptyVelocity;
   }

--- a/tests/mainjs-eager-clients.test.mjs
+++ b/tests/mainjs-eager-clients.test.mjs
@@ -1,0 +1,61 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+
+// The five service modules below are statically imported by the eager boot
+// graph (via @/app/data-loader). Their IntelligenceServiceClient MUST be
+// constructed lazily (createLazyClient) so its constructor + getRpcBaseUrl()
+// do NOT run at module eval on every dashboard boot (#4477 / #4410). A
+// regression that reintroduces a module-scope `const x = new
+// IntelligenceServiceClient(...)` re-eagerises construction and fails here.
+//
+// This is a SOURCE guard (greps src/), so it runs without a dist build —
+// unlike the dist-gated chunk guards in dashboard-eager-chunks.test.mjs.
+const EAGER_SERVICE_FILES = [
+  'src/services/gdelt-intel.ts',
+  'src/services/security-advisories.ts',
+  'src/services/social-velocity.ts',
+  'src/services/pizzint.ts',
+  'src/services/satellites.ts',
+];
+
+// Matches an eager module/function-scope assignment `… = new IntelligenceServiceClient(`.
+// The lazy factory form `createLazyClient(() => new IntelligenceServiceClient(` does NOT
+// match: the char before `new` there is `>` (from `=>`), not `=` + whitespace.
+const EAGER_CONSTRUCTION = /=\s*new IntelligenceServiceClient\(/;
+const LAZY_FACTORY = /createLazyClient\(\(\)\s*=>\s*new IntelligenceServiceClient\(/;
+
+describe('main.js eager diet — service clients are lazy-initialized', () => {
+  for (const rel of EAGER_SERVICE_FILES) {
+    const source = readFileSync(resolve(repoRoot, rel), 'utf8');
+
+    it(`${rel} imports createLazyClient from rpc-client`, () => {
+      assert.match(
+        source,
+        /import\s*\{[^}]*\bcreateLazyClient\b[^}]*\}\s*from\s*'@\/services\/rpc-client'/,
+        `${rel} must import createLazyClient from @/services/rpc-client`,
+      );
+    });
+
+    it(`${rel} constructs IntelligenceServiceClient via createLazyClient`, () => {
+      assert.match(
+        source,
+        LAZY_FACTORY,
+        `${rel} must wrap "new IntelligenceServiceClient(...)" in createLazyClient(() => ...)`,
+      );
+    });
+
+    it(`${rel} has no module-scope eager "new IntelligenceServiceClient"`, () => {
+      assert.doesNotMatch(
+        source,
+        EAGER_CONSTRUCTION,
+        `${rel} must not assign "new IntelligenceServiceClient(...)" directly — that runs the constructor at boot`,
+      );
+    });
+  }
+});

--- a/tests/mainjs-eager-clients.test.mjs
+++ b/tests/mainjs-eager-clients.test.mjs
@@ -24,13 +24,32 @@ const EAGER_SERVICE_FILES = [
   'src/services/satellites.ts',
 ];
 
-// Matches an eager module/function-scope assignment `… = new IntelligenceServiceClient(`.
-// The lazy factory form `createLazyClient(() => new IntelligenceServiceClient(` does NOT
-// match: the char before `new` there is `>` (from `=>`), not `=` + whitespace.
-const EAGER_CONSTRUCTION = /=\s*new IntelligenceServiceClient\(/;
+// Matches a direct eager assignment without crossing string-literal quotes.
+const EAGER_CONSTRUCTION = /^[^'"`\n]*=\s*new IntelligenceServiceClient\(/m;
 const LAZY_FACTORY = /createLazyClient\(\(\)\s*=>\s*new IntelligenceServiceClient\(/;
 
+function stripComments(src) {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/[^\n]*/g, '');
+}
+
 describe('main.js eager diet — service clients are lazy-initialized', () => {
+  it('does not flag line-commented examples of the eager pattern', () => {
+    const commentedExample = '// was: const client = new IntelligenceServiceClient(getRpcBaseUrl(), {})';
+    assert.doesNotMatch(stripComments(commentedExample), EAGER_CONSTRUCTION);
+  });
+
+  it('does not flag string-literal examples of the eager pattern', () => {
+    const stringExample = 'const example = "was: = new IntelligenceServiceClient(getRpcBaseUrl(), {})";';
+    assert.doesNotMatch(stripComments(stringExample), EAGER_CONSTRUCTION);
+  });
+
+  it('still flags direct eager client declarations', () => {
+    const eagerDeclaration = 'const client: IntelligenceServiceClient = new IntelligenceServiceClient(getRpcBaseUrl(), {})';
+    assert.match(stripComments(eagerDeclaration), EAGER_CONSTRUCTION);
+  });
+
   for (const rel of EAGER_SERVICE_FILES) {
     const source = readFileSync(resolve(repoRoot, rel), 'utf8');
 
@@ -52,7 +71,7 @@ describe('main.js eager diet — service clients are lazy-initialized', () => {
 
     it(`${rel} has no module-scope eager "new IntelligenceServiceClient"`, () => {
       assert.doesNotMatch(
-        source,
+        stripComments(source),
         EAGER_CONSTRUCTION,
         `${rel} must not assign "new IntelligenceServiceClient(...)" directly — that runs the constructor at boot`,
       );


### PR DESCRIPTION
## U1 — lazy-init the 5 module-scope IntelligenceServiceClients

Part of #4476 (main.js eager diet). Closes #4477.

`gdelt-intel`, `security-advisories`, `social-velocity`, `pizzint`, `satellites` constructed `IntelligenceServiceClient` at **module scope** → the constructor + `getRpcBaseUrl()` ran at import on every dashboard boot (these are statically pulled by `@/app/data-loader`). Each now uses the existing `createLazyClient()` accessor: construction defers to first use, and the RPC base URL resolves at first call (matching `RegionalIntelligenceBoard`/`DeductionPanel`). Call sites are already async — **no behavior change**.

### Why
Eager `main.js` scriptEval is the #1 boot lever (~660ms mobile / ~155ms desktop, LH 13.2.0, 2026-06-27). Honest scoping: the constructor is cheap, so this is primarily a **correctness/consistency** fix (URL resolves at first call, not frozen at import) with ~nil byte impact — the byte wins are U2/U3 (config deferral, #4478/#4479). U1 ships the safe pattern + the regression guard.

### Verification
- New source guard `tests/mainjs-eager-clients.test.mjs` (15/15) — asserts no module-scope `new IntelligenceServiceClient`, all 5 use `createLazyClient`.
- `tsc --noEmit` clean.
- Service behavior tests green: `gdelt-fetch`, `hapi-gdelt-circuit-breakers`, `security-advisory-source-contract` (54/54 incl. the new guard).

https://claude.ai/code/session_017L8nACBdvQ5Sj7mTBfEBhy