### PR TITLE
perf(boot): defer the 410KB slow-tier bootstrap off the first-paint critical path (LCP, #4488)

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1207,8 +1207,13 @@ export class App {
       await ensureWmSession();
     }
 
-    // Hydrate in-memory cache from bootstrap endpoint (before panels construct and fetch)
-    await fetchBootstrapData();
+    // Hydrate in-memory cache from bootstrap endpoint. Awaits only the fast tier; the slow
+    // tier loads in the background (off the first-paint critical path, #4488) and calls back
+    // when it lands so the connectivity indicator re-snapshots (no reactive emitter exists).
+    await fetchBootstrapData(() => {
+      this.bootstrapHydrationState = getBootstrapHydrationState();
+      this.updateConnectivityUi();
+    });
     this.bootstrapHydrationState = getBootstrapHydrationState();
 
     // Verify OAuth OTT and hydrate auth session BEFORE any UI subscribes to auth state

--- a/src/App.ts
+++ b/src/App.ts
@@ -85,7 +85,14 @@ import { initDeferredDashboardFonts } from '@/bootstrap/secondary-startup';
 
 import { computeDefaultDisabledSources, getLocaleBoostedSources, getTotalFeedCount, FEEDS, INTEL_SOURCES } from '@/config/feeds';
 import { selectSourcesUnderCap, findFullyDisabledCategories } from '@/services/source-cap';
-import { fetchBootstrapData, getBootstrapHydrationState, markBootstrapAsLive, type BootstrapHydrationState } from '@/services/bootstrap';
+import {
+  cancelBootstrapSlowTier,
+  fetchBootstrapData,
+  getBootstrapHydrationState,
+  markBootstrapAsLive,
+  waitForBootstrapSlowTier,
+  type BootstrapHydrationState,
+} from '@/services/bootstrap';
 import { ensureWmSession, installWmSessionFetchInterceptor } from '@/services/wm-session';
 import { describeFreshness } from '@/services/persistent-cache';
 import { DesktopUpdater } from '@/app/desktop-updater';
@@ -1211,6 +1218,7 @@ export class App {
     // tier loads in the background (off the first-paint critical path, #4488) and calls back
     // when it lands so the connectivity indicator re-snapshots (no reactive emitter exists).
     await fetchBootstrapData(() => {
+      if (this.state.isDestroyed) return;
       this.bootstrapHydrationState = getBootstrapHydrationState();
       this.updateConnectivityUi();
     });
@@ -1448,6 +1456,10 @@ export class App {
     // Phase 6: Data loading
     this.dataLoader.syncDataFreshnessWithLayers();
     await preloadCountryGeometry();
+    await waitForBootstrapSlowTier(isDesktopRuntime() ? 8_500 : 3_500);
+    if (this.state.isDestroyed) return;
+    this.bootstrapHydrationState = getBootstrapHydrationState();
+    this.updateConnectivityUi();
     // Prime panel-specific data concurrently with bulk loading.
     // primeVisiblePanelData owns ETF, Stablecoins, Gulf Economies, etc. that
     // are NOT part of loadAllData. Running them in parallel prevents those
@@ -1625,6 +1637,7 @@ export class App {
 
   public destroy(): void {
     this.state.isDestroyed = true;
+    cancelBootstrapSlowTier();
     window.removeEventListener('scroll', this.handleViewportPrime);
     window.removeEventListener('resize', this.handleViewportPrime);
     window.removeEventListener('online', this.handleConnectivityChange);

--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -4,6 +4,7 @@ import { isDesktopRuntime, toApiUrl } from '@/services/runtime';
 const hydrationCache = new Map<string, unknown>();
 const BOOTSTRAP_CACHE_PREFIX = 'bootstrap:tier:';
 const BOOTSTRAP_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+type CommitGuard = () => boolean;
 
 export type BootstrapDataSource = 'live' | 'cached' | 'mixed' | 'none';
 
@@ -28,6 +29,9 @@ let lastHydrationState: BootstrapHydrationState = {
     slow: { ...EMPTY_TIER_STATE },
   },
 };
+let bootstrapGeneration = 0;
+let activeSlowCtrl: AbortController | null = null;
+let slowTierSettled: Promise<void> | null = null;
 
 export function getHydratedData(key: string): unknown | undefined {
   const val = hydrationCache.get(key);
@@ -62,7 +66,8 @@ export function getBootstrapHydrationState(): BootstrapHydrationState {
   };
 }
 
-function populateCache(data: Record<string, unknown>): void {
+function populateCache(data: Record<string, unknown>, shouldCommit: CommitGuard): void {
+  if (!shouldCommit()) return;
   for (const [k, v] of Object.entries(data)) {
     if (v !== null && v !== undefined) {
       hydrationCache.set(k, v);
@@ -93,11 +98,15 @@ function combineHydrationSources(states: BootstrapTierHydrationState[]): Bootstr
   return 'mixed';
 }
 
-async function fetchTier(tier: 'fast' | 'slow', signal: AbortSignal): Promise<BootstrapTierHydrationState> {
+async function fetchTier(
+  tier: 'fast' | 'slow',
+  signal: AbortSignal,
+  shouldCommit: CommitGuard = () => true,
+): Promise<BootstrapTierHydrationState> {
   if (typeof navigator !== 'undefined' && navigator.onLine === false) {
     const cached = await readCachedTier(tier, true); // age gate skipped: any snapshot beats blank offline
     if (cached) {
-      populateCache(cached.data);
+      populateCache(cached.data, shouldCommit);
       return { source: 'cached', updatedAt: cached.updatedAt };
     }
     return { ...EMPTY_TIER_STATE };
@@ -123,7 +132,7 @@ async function fetchTier(tier: 'fast' | 'slow', signal: AbortSignal): Promise<Bo
   if (Object.keys(liveData).length === 0) {
     const cached = await readCachedTier(tier);
     if (cached) {
-      populateCache(cached.data);
+      populateCache(cached.data, shouldCommit);
       return { source: 'cached', updatedAt: cached.updatedAt };
     }
     return { ...EMPTY_TIER_STATE };
@@ -149,26 +158,135 @@ async function fetchTier(tier: 'fast' | 'slow', signal: AbortSignal): Promise<Bo
     }
   }
 
-  populateCache(mergedData);
-  void setPersistentCache(getTierCacheKey(tier), mergedData, saveUpdatedAt).catch(() => {});
+  populateCache(mergedData, shouldCommit);
+  if (shouldCommit()) {
+    void setPersistentCache(getTierCacheKey(tier), mergedData, saveUpdatedAt).catch(() => {});
+  }
   return tierState;
+}
+
+function scheduleAfterNextPaint(fn: () => void): () => void {
+  let cancelled = false;
+  let started = false;
+  let rafId: number | null = null;
+  let postPaintTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  let fallbackTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  const run = (): void => {
+    if (cancelled || started) return;
+    started = true;
+    if (rafId !== null && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(rafId);
+    if (postPaintTimeoutId !== null) clearTimeout(postPaintTimeoutId);
+    if (fallbackTimeoutId !== null) clearTimeout(fallbackTimeoutId);
+    fn();
+  };
+
+  if (typeof requestAnimationFrame === 'function') {
+    rafId = requestAnimationFrame(() => {
+      postPaintTimeoutId = setTimeout(run, 0);
+    });
+    fallbackTimeoutId = setTimeout(run, 250);
+    return () => {
+      cancelled = true;
+      if (rafId !== null && typeof cancelAnimationFrame === 'function') cancelAnimationFrame(rafId);
+      if (postPaintTimeoutId !== null) clearTimeout(postPaintTimeoutId);
+      if (fallbackTimeoutId !== null) clearTimeout(fallbackTimeoutId);
+    };
+  }
+
+  postPaintTimeoutId = setTimeout(run, 0);
+  return () => {
+    cancelled = true;
+    if (postPaintTimeoutId !== null) clearTimeout(postPaintTimeoutId);
+  };
+}
+
+function scheduleSlowTierFetch(generation: number, onSlowSettled?: () => void): Promise<void> {
+  const desktop = isDesktopRuntime();
+  const isCurrentGeneration = (): boolean => generation === bootstrapGeneration;
+
+  return new Promise<void>((resolve) => {
+    const cancelScheduledStart = scheduleAfterNextPaint(() => {
+      if (!isCurrentGeneration()) {
+        resolve();
+        return;
+      }
+
+      const slowCtrl = new AbortController();
+      activeSlowCtrl = slowCtrl;
+      const slowTimeout = setTimeout(() => slowCtrl.abort(), desktop ? 8_000 : 3_000);
+
+      void fetchTier('slow', slowCtrl.signal, isCurrentGeneration)
+        .then((slowState) => {
+          if (!isCurrentGeneration()) return;
+          lastHydrationState = {
+            source: combineHydrationSources([lastHydrationState.tiers.fast, slowState]),
+            tiers: { fast: lastHydrationState.tiers.fast, slow: slowState },
+          };
+        })
+        .catch(() => {
+          // Background failure: leave the slow keys un-hydrated; consumers refetch on demand.
+        })
+        .finally(() => {
+          clearTimeout(slowTimeout);
+          if (activeSlowCtrl === slowCtrl) activeSlowCtrl = null;
+          if (isCurrentGeneration()) onSlowSettled?.();
+          resolve();
+        });
+    });
+
+    if (!isCurrentGeneration()) {
+      cancelScheduledStart();
+      resolve();
+    }
+  });
+}
+
+export async function waitForBootstrapSlowTier(timeoutMs = 0): Promise<boolean> {
+  const pending = slowTierSettled;
+  if (!pending) return true;
+  if (timeoutMs <= 0) {
+    await pending;
+    return true;
+  }
+
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const timedOut = Symbol('timedOut');
+  const result = await Promise.race([
+    pending.then(() => true),
+    new Promise<typeof timedOut>((resolve) => {
+      timeoutId = setTimeout(() => resolve(timedOut), timeoutMs);
+    }),
+  ]);
+  if (timeoutId !== null) clearTimeout(timeoutId);
+  return result !== timedOut;
+}
+
+export function cancelBootstrapSlowTier(): void {
+  bootstrapGeneration += 1;
+  activeSlowCtrl?.abort();
+  activeSlowCtrl = null;
+  slowTierSettled = null;
 }
 
 /**
  * Hydrate the in-memory cache from the bootstrap endpoint.
  *
- * The boot awaits ONLY the small fast tier — the ~410 KB slow tier is fetched in the
- * BACKGROUND so it no longer blocks first paint (#4488; it was the largest item on the
- * boot critical path and a primary driver of the field LCP failure). Slow-tier consumers
- * read `getHydratedData()` and fall back to an on-demand fetch when a key is absent, so
- * deferring the slow batch only shifts more reads onto that existing fallback — no
- * consumer depends on slow hydration being present at boot.
+ * The boot awaits ONLY the small fast tier, commits that state, then schedules the
+ * ~410 KB slow tier after the next paint (#4488). A later app checkpoint can wait for
+ * the slow tier before visible slow-key consumers start fallback RPCs, but the payload
+ * stays off the first-paint critical path.
  *
  * `onSlowSettled` lets the caller (App.ts) re-snapshot the hydration state and refresh
  * the connectivity indicator when the background slow tier lands — `getBootstrapHydrationState`
  * is read via a one-shot snapshot, with no reactive emitter, so a passive update is invisible.
  */
 export async function fetchBootstrapData(onSlowSettled?: () => void): Promise<void> {
+  const generation = ++bootstrapGeneration;
+  const isCurrentGeneration = (): boolean => generation === bootstrapGeneration;
+
+  activeSlowCtrl?.abort();
+  activeSlowCtrl = null;
+  slowTierSettled = null;
   hydrationCache.clear();
   lastHydrationState = {
     source: 'none',
@@ -179,7 +297,6 @@ export async function fetchBootstrapData(onSlowSettled?: () => void): Promise<vo
   };
 
   const fastCtrl = new AbortController();
-  const slowCtrl = new AbortController();
   const desktop = isDesktopRuntime();
   // Tier abort budgets:
   // - Fast tier (~10 keys, small payload) keeps an aggressive 1.2 s browser cap; it already meets that budget.
@@ -191,29 +308,9 @@ export async function fetchBootstrapData(onSlowSettled?: () => void): Promise<vo
   //   data once available; do not move this without evidence.
   // - Desktop budgets (5 s / 8 s) are unchanged — different network and dependency-loading constraints.
   const fastTimeout = setTimeout(() => fastCtrl.abort(), desktop ? 5_000 : 1_200);
-  const slowTimeout = setTimeout(() => slowCtrl.abort(), desktop ? 8_000 : 3_000);
-
-  // Background slow tier: owns its OWN timeout cleanup (NOT the fast `finally` below) so the
-  // 3 s/8 s abort survives this function returning after the fast tier. Both updates do a
-  // read-merge-write of `lastHydrationState` (single-threaded microtasks, so no torn state),
-  // so they compose regardless of which tier resolves first.
-  void fetchTier('slow', slowCtrl.signal)
-    .then((slowState) => {
-      lastHydrationState = {
-        source: combineHydrationSources([lastHydrationState.tiers.fast, slowState]),
-        tiers: { fast: lastHydrationState.tiers.fast, slow: slowState },
-      };
-    })
-    .catch(() => {
-      // Background failure: leave the slow keys un-hydrated; consumers refetch on demand.
-    })
-    .finally(() => {
-      clearTimeout(slowTimeout);
-      onSlowSettled?.();
-    });
-
   try {
-    const fastState = await fetchTier('fast', fastCtrl.signal);
+    const fastState = await fetchTier('fast', fastCtrl.signal, isCurrentGeneration);
+    if (!isCurrentGeneration()) return;
     lastHydrationState = {
       source: combineHydrationSources([fastState, lastHydrationState.tiers.slow]),
       tiers: { fast: fastState, slow: lastHydrationState.tiers.slow },
@@ -221,4 +318,24 @@ export async function fetchBootstrapData(onSlowSettled?: () => void): Promise<vo
   } finally {
     clearTimeout(fastTimeout);
   }
+
+  if (!isCurrentGeneration()) return;
+  slowTierSettled = scheduleSlowTierFetch(generation, onSlowSettled);
 }
+
+export const __testing__ = {
+  resetBootstrapForTests(): void {
+    cancelBootstrapSlowTier();
+    hydrationCache.clear();
+    lastHydrationState = {
+      source: 'none',
+      tiers: {
+        fast: { ...EMPTY_TIER_STATE },
+        slow: { ...EMPTY_TIER_STATE },
+      },
+    };
+  },
+  getBootstrapGeneration(): number {
+    return bootstrapGeneration;
+  },
+};

--- a/src/services/bootstrap.ts
+++ b/src/services/bootstrap.ts
@@ -154,7 +154,21 @@ async function fetchTier(tier: 'fast' | 'slow', signal: AbortSignal): Promise<Bo
   return tierState;
 }
 
-export async function fetchBootstrapData(): Promise<void> {
+/**
+ * Hydrate the in-memory cache from the bootstrap endpoint.
+ *
+ * The boot awaits ONLY the small fast tier — the ~410 KB slow tier is fetched in the
+ * BACKGROUND so it no longer blocks first paint (#4488; it was the largest item on the
+ * boot critical path and a primary driver of the field LCP failure). Slow-tier consumers
+ * read `getHydratedData()` and fall back to an on-demand fetch when a key is absent, so
+ * deferring the slow batch only shifts more reads onto that existing fallback — no
+ * consumer depends on slow hydration being present at boot.
+ *
+ * `onSlowSettled` lets the caller (App.ts) re-snapshot the hydration state and refresh
+ * the connectivity indicator when the background slow tier lands — `getBootstrapHydrationState`
+ * is read via a one-shot snapshot, with no reactive emitter, so a passive update is invisible.
+ */
+export async function fetchBootstrapData(onSlowSettled?: () => void): Promise<void> {
   hydrationCache.clear();
   lastHydrationState = {
     source: 'none',
@@ -179,21 +193,32 @@ export async function fetchBootstrapData(): Promise<void> {
   const fastTimeout = setTimeout(() => fastCtrl.abort(), desktop ? 5_000 : 1_200);
   const slowTimeout = setTimeout(() => slowCtrl.abort(), desktop ? 8_000 : 3_000);
 
-  try {
-    const [slowState, fastState] = await Promise.all([
-      fetchTier('slow', slowCtrl.signal),
-      fetchTier('fast', fastCtrl.signal),
-    ]);
+  // Background slow tier: owns its OWN timeout cleanup (NOT the fast `finally` below) so the
+  // 3 s/8 s abort survives this function returning after the fast tier. Both updates do a
+  // read-merge-write of `lastHydrationState` (single-threaded microtasks, so no torn state),
+  // so they compose regardless of which tier resolves first.
+  void fetchTier('slow', slowCtrl.signal)
+    .then((slowState) => {
+      lastHydrationState = {
+        source: combineHydrationSources([lastHydrationState.tiers.fast, slowState]),
+        tiers: { fast: lastHydrationState.tiers.fast, slow: slowState },
+      };
+    })
+    .catch(() => {
+      // Background failure: leave the slow keys un-hydrated; consumers refetch on demand.
+    })
+    .finally(() => {
+      clearTimeout(slowTimeout);
+      onSlowSettled?.();
+    });
 
+  try {
+    const fastState = await fetchTier('fast', fastCtrl.signal);
     lastHydrationState = {
-      source: combineHydrationSources([fastState, slowState]),
-      tiers: {
-        fast: fastState,
-        slow: slowState,
-      },
+      source: combineHydrationSources([fastState, lastHydrationState.tiers.slow]),
+      tiers: { fast: fastState, slow: lastHydrationState.tiers.slow },
     };
   } finally {
     clearTimeout(fastTimeout);
-    clearTimeout(slowTimeout);
   }
 }

--- a/tests/bootstrap-runtime.test.mts
+++ b/tests/bootstrap-runtime.test.mts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  __testing__ as bootstrapTesting,
+  fetchBootstrapData,
+  getBootstrapHydrationState,
+  getHydratedData,
+  waitForBootstrapSlowTier,
+} from '../src/services/bootstrap';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: unknown) => void;
+};
+
+type FetchRequest = {
+  url: string;
+  signal: AbortSignal | null;
+  deferred: Deferred<Response>;
+};
+
+const originalFetch = globalThis.fetch;
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function jsonResponse(data: Record<string, unknown>): Response {
+  return new Response(JSON.stringify({ data }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function tick(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function installFetchStub(): FetchRequest[] {
+  const requests: FetchRequest[] = [];
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const request: FetchRequest = {
+      url: String(input),
+      signal: init?.signal ?? null,
+      deferred: deferred<Response>(),
+    };
+    requests.push(request);
+    return request.deferred.promise;
+  }) as typeof fetch;
+  return requests;
+}
+
+function tierRequests(requests: FetchRequest[], tier: 'fast' | 'slow'): FetchRequest[] {
+  return requests.filter((request) => request.url.includes(`tier=${tier}`));
+}
+
+describe('Frontend bootstrap runtime behavior', () => {
+  beforeEach(() => {
+    bootstrapTesting.resetBootstrapForTests();
+  });
+
+  afterEach(() => {
+    bootstrapTesting.resetBootstrapForTests();
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns after the fast tier and starts the slow tier only after fast state is committed', async () => {
+    const requests = installFetchStub();
+    let callbackState = getBootstrapHydrationState();
+
+    const boot = fetchBootstrapData(() => {
+      callbackState = getBootstrapHydrationState();
+    });
+
+    await tick();
+    assert.equal(tierRequests(requests, 'fast').length, 1, 'fast tier should start immediately');
+    assert.equal(tierRequests(requests, 'slow').length, 0, 'slow tier must wait for fast commit');
+
+    tierRequests(requests, 'fast')[0]!.deferred.resolve(jsonResponse({ fastKey: 'fast-value' }));
+    await boot;
+
+    assert.equal(getHydratedData('fastKey'), 'fast-value');
+    assert.equal(tierRequests(requests, 'slow').length, 0, 'slow tier should be scheduled after boot returns');
+
+    await tick();
+    assert.equal(tierRequests(requests, 'slow').length, 1, 'slow tier should start after the deferred checkpoint');
+
+    tierRequests(requests, 'slow')[0]!.deferred.resolve(jsonResponse({ slowKey: 'slow-value' }));
+    assert.equal(await waitForBootstrapSlowTier(100), true);
+
+    assert.equal(callbackState.tiers.slow.source, 'live', 'callback should observe updated slow state');
+    assert.equal(getHydratedData('slowKey'), 'slow-value');
+  });
+
+  it('ignores a stale slow-tier completion from an earlier bootstrap generation', async () => {
+    const requests = installFetchStub();
+    const callbacks: string[] = [];
+
+    const firstBoot = fetchBootstrapData(() => callbacks.push('first'));
+    await tick();
+    tierRequests(requests, 'fast')[0]!.deferred.resolve(jsonResponse({ firstFast: true }));
+    await firstBoot;
+    await tick();
+    const firstSlow = tierRequests(requests, 'slow')[0]!;
+
+    const secondBoot = fetchBootstrapData(() => callbacks.push('second'));
+    assert.equal(firstSlow.signal?.aborted, true, 'new bootstrap should abort the old slow fetch');
+    await tick();
+    tierRequests(requests, 'fast')[1]!.deferred.resolve(jsonResponse({ secondFast: true }));
+    await secondBoot;
+    await tick();
+
+    tierRequests(requests, 'slow')[1]!.deferred.resolve(jsonResponse({ currentSlow: 'current' }));
+    assert.equal(await waitForBootstrapSlowTier(100), true);
+
+    firstSlow.deferred.resolve(jsonResponse({ staleSlow: 'stale' }));
+    await tick();
+
+    assert.deepEqual(callbacks, ['second']);
+    assert.equal(getHydratedData('currentSlow'), 'current');
+    assert.equal(getHydratedData('staleSlow'), undefined);
+  });
+
+  it('swallows slow-tier failures and still settles the background checkpoint', async () => {
+    const requests = installFetchStub();
+    let callbackCount = 0;
+
+    const boot = fetchBootstrapData(() => {
+      callbackCount += 1;
+    });
+    await tick();
+    tierRequests(requests, 'fast')[0]!.deferred.resolve(jsonResponse({ fastKey: true }));
+    await boot;
+    await tick();
+
+    tierRequests(requests, 'slow')[0]!.deferred.reject(new Error('slow tier failed'));
+    assert.equal(await waitForBootstrapSlowTier(100), true);
+
+    assert.equal(callbackCount, 1);
+    assert.equal(getBootstrapHydrationState().tiers.slow.source, 'none');
+  });
+});

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -250,10 +250,19 @@ describe('Frontend hydration (src/services/bootstrap.ts)', () => {
     assert.ok(src.includes('catch'), 'Missing error handling — panels should fall through to individual calls');
   });
 
-  it('fetches both tiers in parallel', () => {
-    assert.ok(src.includes('Promise.all'), 'Missing Promise.all for parallel tier fetches');
+  it('awaits only the fast tier; backgrounds the slow tier (#4488 — slow off the boot critical path)', () => {
     assert.ok(src.includes("'slow'"), 'Missing slow tier fetch');
     assert.ok(src.includes("'fast'"), 'Missing fast tier fetch');
+    // The ~410KB slow tier must NOT block first paint: the boot must not await both tiers
+    // together. A regression to `await Promise.all([fetchTier('slow'), fetchTier('fast')])`
+    // re-introduces the LCP-blocking boot this deferral removed.
+    assert.ok(
+      !/await\s+Promise\.all\(\s*\[\s*fetchTier\('slow'/.test(src),
+      'slow tier must not be awaited via Promise.all — background it so it stays off the first-paint critical path',
+    );
+    // Slow tier is fired un-awaited (void); the boot awaits only the fast tier.
+    assert.ok(/void\s+fetchTier\('slow'/.test(src), "slow tier should be fired un-awaited: void fetchTier('slow', …)");
+    assert.ok(/await\s+fetchTier\('fast'/.test(src), "boot should await the fast tier: await fetchTier('fast', …)");
   });
 });
 
@@ -274,6 +283,12 @@ describe('Panel hydration consumers', () => {
   }
 });
 
+// The slow tier is fetched in the BACKGROUND (off the boot critical path, #4488), so any
+// slow-tier consumer that read its hydration WITHOUT an on-demand fetch fallback would break
+// (empty panel). This guard enforces the greppable half — every bootstrap key (incl. all
+// SLOW_KEYS) has a getHydratedData consumer or is allow-listed below. The fetch-on-absence
+// half is a manual audit (a getHydratedData call alone can't prove the adjacent RPC is the
+// fallback); the #4488 audit confirmed every slow-key consumer is hydrated-else-fetch.
 describe('Bootstrap key hydration coverage', () => {
   it('every bootstrap key has a getHydratedData consumer in src/', () => {
     const bootstrapSrc = readFileSync(join(root, 'api', 'bootstrap.js'), 'utf-8');

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -232,7 +232,7 @@ describe('Frontend hydration (src/services/bootstrap.ts)', () => {
       .map((m) => parseInt(m[1].replace(/_/g, ''), 10))
       .filter((n) => n === 1200 || n === 3000);
     assert.deepEqual(
-      timeouts,
+      timeouts.toSorted((a, b) => a - b),
       [1200, 3000],
       `Expected web bootstrap timeouts (fast=1200, slow=3000) — slow tier was bumped from 1.8s to 3.0s to avoid hydration-cascade aborts`,
     );
@@ -260,9 +260,38 @@ describe('Frontend hydration (src/services/bootstrap.ts)', () => {
       !/await\s+Promise\.all\(\s*\[\s*fetchTier\('slow'/.test(src),
       'slow tier must not be awaited via Promise.all — background it so it stays off the first-paint critical path',
     );
-    // Slow tier is fired un-awaited (void); the boot awaits only the fast tier.
-    assert.ok(/void\s+fetchTier\('slow'/.test(src), "slow tier should be fired un-awaited: void fetchTier('slow', …)");
+    // Slow tier is scheduled only after the fast state is committed.
+    assert.ok(src.includes('scheduleSlowTierFetch'), 'slow tier should be scheduled through the deferred slow-tier helper');
+    assert.ok(src.includes('slowTierSettled = scheduleSlowTierFetch'), 'fetchBootstrapData should expose the background slow-tier checkpoint');
     assert.ok(/await\s+fetchTier\('fast'/.test(src), "boot should await the fast tier: await fetchTier('fast', …)");
+  });
+
+  it('guards stale slow-tier generations before committing cache or hydration state', () => {
+    assert.ok(src.includes('bootstrapGeneration'), 'Missing bootstrap generation guard');
+    assert.ok(src.includes('isCurrentGeneration'), 'Missing current-generation predicate');
+    assert.ok(src.includes('fetchTier(') && src.includes('shouldCommit'), 'fetchTier should receive a commit guard');
+  });
+});
+
+describe('App bootstrap slow-tier lifecycle', () => {
+  const appSrc = readFileSync(join(root, 'src', 'App.ts'), 'utf-8');
+
+  it('does not update connectivity UI from a slow callback after destroy', () => {
+    assert.match(
+      appSrc,
+      /fetchBootstrapData\(\(\) => \{\s*if \(this\.state\.isDestroyed\) return;\s*this\.bootstrapHydrationState = getBootstrapHydrationState\(\);\s*this\.updateConnectivityUi\(\);/s,
+      'slow-tier callback should bail out after App.destroy()',
+    );
+    assert.ok(appSrc.includes('cancelBootstrapSlowTier();'), 'App.destroy() should cancel pending slow bootstrap work');
+  });
+
+  it('waits for the slow-tier checkpoint before visible data fan-out', () => {
+    const preloadIndex = appSrc.indexOf('await preloadCountryGeometry();');
+    const waitIndex = appSrc.indexOf('await waitForBootstrapSlowTier');
+    const fanoutIndex = appSrc.indexOf('this.dataLoader.loadAllData()', waitIndex);
+    assert.ok(preloadIndex >= 0, 'Missing preloadCountryGeometry checkpoint');
+    assert.ok(waitIndex > preloadIndex, 'slow-tier wait should run after non-render-blocking geometry preload');
+    assert.ok(fanoutIndex > waitIndex, 'visible data fan-out should wait for slow bootstrap settle/timeout');
   });
 });
 


### PR DESCRIPTION
## Defer the slow-tier bootstrap off the first-paint critical path

Part of #4487 (CWV fix). **Closes #4488.** The P0 lever for the worst field metric — CrUX mobile **LCP 4.8s** 🔴.

`fetchBootstrapData` awaited **both** tiers via `Promise.all`, and `App.ts` awaits it before panels construct — so the ~410 KB `bootstrap?tier=slow` fetch (up to a 3 s mobile abort) blocked first paint. The slow tier is ~80 secondary/enrichment keys, none first-paint-critical.

### Change
- **`bootstrap.ts`** — await only the fast tier (~10 keys, 1.2 s cap); fire the slow batch **un-awaited** so it loads in the background and populates the hydration cache when it lands. The slow timeout is cleared inside the slow path's own `.finally` (not the shared `finally`) so the 3 s/8 s abort survives the function's early return.
- **`App.ts`** — pass an `onSlowSettled` callback so the connectivity indicator re-snapshots when slow lands (`getBootstrapHydrationState` has no reactive emitter; its sole reader is `updateConnectivityUi`).
- **`bootstrap.test.mjs`** — replace the old "both tiers in parallel"/`Promise.all` assertion with the deferral contract (`void` slow, `await` fast, no blocking `Promise.all`); document the deferral-safety requirement on the existing coverage guard.

### Why it's safe
`getHydratedData` is consume-once and slow-tier consumers already use "hydrated-else-fetch" — deferring the batch only shifts more reads onto that existing fallback. A doc-review audit sample-verified the slow-key consumers (ETFFlows, pizzint, euGasStorage, eurostat all RPC-fallback; no-consumer keys fetch on their own paths); `enforceFreeTierLimits` reads only storage; only `App.ts` calls `fetchBootstrapData`. **No no-fallback boot consumer exists.** Does **not** touch the free-tier cap path — the lowest-risk CWV lever.

### Verification
- `tsc --noEmit` clean · `bootstrap.test.mjs` 36/36 · build clean.
- Headless boot smoke (built dist): dashboard renders, **0 unhandled rejections**, no TDZ/bootstrap/hydration console errors (only expected no-backend 404s).
- **Field gate:** re-read CrUX LCP/FCP for `/dashboard` after deploy (the binding acceptance — recorded on #4488/#4487).

Plan: `docs/plans/2026-06-28-003-fix-slow-bootstrap-defer-lcp-plan.md`.

https://claude.ai/code/session_017L8nACBdvQ5Sj7mTBfEBhy