### PR TITLE
perf(boot): defer correlation-engine + story-renderer off the eager graph (Phase A, #4486)

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -122,13 +122,9 @@ import {
   resumePendingCheckout,
 } from '@/services/checkout';
 import { captureReferralFromUrl } from '@/services/referral-capture';
-import {
-  CorrelationEngine,
-  militaryAdapter,
-  escalationAdapter,
-  economicAdapter,
-  disasterAdapter,
-} from '@/services/correlation-engine';
+// CorrelationEngine + its 4 adapters are dynamic-imported at the post-loadAllData
+// run site (#4486) so the engine bytes stay off the eager boot graph. The TYPE is
+// referenced via the inline `import(...)` type in app-context.ts (erased at build).
 import type { CorrelationPanel } from '@/components/CorrelationPanel';
 
 const CYBER_LAYER_ENABLED = import.meta.env.VITE_ENABLE_CYBER_LAYER === 'true';
@@ -1378,13 +1374,8 @@ export class App {
     this.eventHandlers.setupExportPanel();
     this.eventHandlers.setupSearchControls();
 
-    // Correlation engine
-    const correlationEngine = new CorrelationEngine();
-    correlationEngine.registerAdapter(militaryAdapter);
-    correlationEngine.registerAdapter(escalationAdapter);
-    correlationEngine.registerAdapter(economicAdapter);
-    correlationEngine.registerAdapter(disasterAdapter);
-    this.state.correlationEngine = correlationEngine;
+    // Correlation engine is constructed lazily at its post-loadAllData run site
+    // (Phase 6 below) so its bytes + adapters stay off the eager boot graph (#4486).
     this.eventHandlers.setupUnifiedSettings();
     this.eventHandlers.setupAuthWidget();
     // Capture any ?ref= / ?wm_referral= from the URL into localStorage
@@ -1465,15 +1456,27 @@ export class App {
     this.bootstrapHydrationState = getBootstrapHydrationState();
     this.updateConnectivityUi();
 
-    // Initial correlation engine run
-    if (this.state.correlationEngine) {
-      void this.state.correlationEngine.run(this.state).then(() => {
-        for (const domain of ['military', 'escalation', 'economic', 'disaster'] as const) {
-          const panel = this.state.panels[`${domain}-correlation`] as CorrelationPanel | undefined;
-          panel?.updateCards(this.state.correlationEngine!.getCards(domain));
-        }
-      });
-    }
+    // Initial correlation engine run — construct + register adapters + run here,
+    // inside a dynamic import, so the engine graph loads off the eager boot path
+    // (#4486). state.correlationEngine settles asynchronously; the refresh scheduler
+    // and export getter that read it already null-guard.
+    void import('@/services/correlation-engine').then(
+      ({ CorrelationEngine, militaryAdapter, escalationAdapter, economicAdapter, disasterAdapter }) => {
+        if (this.state.isDestroyed) return;
+        const engine = new CorrelationEngine();
+        engine.registerAdapter(militaryAdapter);
+        engine.registerAdapter(escalationAdapter);
+        engine.registerAdapter(economicAdapter);
+        engine.registerAdapter(disasterAdapter);
+        this.state.correlationEngine = engine;
+        return engine.run(this.state).then(() => {
+          for (const domain of ['military', 'escalation', 'economic', 'disaster'] as const) {
+            const panel = this.state.panels[`${domain}-correlation`] as CorrelationPanel | undefined;
+            panel?.updateCards(engine.getCards(domain));
+          }
+        });
+      },
+    );
 
     startLearning();
 

--- a/src/App.ts
+++ b/src/App.ts
@@ -1070,6 +1070,35 @@ export class App {
     }
   }
 
+  private async loadInitialCorrelationEngine(): Promise<void> {
+    try {
+      const {
+        CorrelationEngine,
+        militaryAdapter,
+        escalationAdapter,
+        economicAdapter,
+        disasterAdapter,
+      } = await import('@/services/correlation-engine');
+
+      if (this.state.isDestroyed) return;
+      const engine = new CorrelationEngine();
+      engine.registerAdapter(militaryAdapter);
+      engine.registerAdapter(escalationAdapter);
+      engine.registerAdapter(economicAdapter);
+      engine.registerAdapter(disasterAdapter);
+      this.state.correlationEngine = engine;
+
+      await engine.run(this.state);
+      if (this.state.isDestroyed) return;
+      for (const domain of ['military', 'escalation', 'economic', 'disaster'] as const) {
+        const panel = this.state.panels[`${domain}-correlation`] as CorrelationPanel | undefined;
+        panel?.updateCards(engine.getCards(domain));
+      }
+    } catch (error) {
+      console.warn('[CorrelationEngine] Initial lazy load/run failed:', error);
+    }
+  }
+
   public async init(): Promise<void> {
     const initStart = performance.now();
 
@@ -1460,23 +1489,7 @@ export class App {
     // inside a dynamic import, so the engine graph loads off the eager boot path
     // (#4486). state.correlationEngine settles asynchronously; the refresh scheduler
     // and export getter that read it already null-guard.
-    void import('@/services/correlation-engine').then(
-      ({ CorrelationEngine, militaryAdapter, escalationAdapter, economicAdapter, disasterAdapter }) => {
-        if (this.state.isDestroyed) return;
-        const engine = new CorrelationEngine();
-        engine.registerAdapter(militaryAdapter);
-        engine.registerAdapter(escalationAdapter);
-        engine.registerAdapter(economicAdapter);
-        engine.registerAdapter(disasterAdapter);
-        this.state.correlationEngine = engine;
-        return engine.run(this.state).then(() => {
-          for (const domain of ['military', 'escalation', 'economic', 'disaster'] as const) {
-            const panel = this.state.panels[`${domain}-correlation`] as CorrelationPanel | undefined;
-            panel?.updateCards(engine.getCards(domain));
-          }
-        });
-      },
-    );
+    void this.loadInitialCorrelationEngine();
 
     startLearning();
 

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -26,7 +26,9 @@ import { signalAggregator } from '@/services/signal-aggregator';
 import { dataFreshness } from '@/services/data-freshness';
 import { fetchCountryMarkets } from '@/services/prediction';
 import { collectStoryData } from '@/services/story-data';
-import { renderStoryToCanvas } from '@/services/story-renderer';
+// renderStoryToCanvas is dynamic-imported at its call site (#4486) so story-renderer
+// stays off the eager boot graph; this is one of its two eager edges (the other is
+// StoryModal). The export runs on user interaction (post-paint), already async.
 import { openStoryModal } from '@/components/StoryModal';
 import { MarketServiceClient } from '@/generated/client/worldmonitor/market/v1/service_client';
 import { IntelligenceServiceClient } from '@/generated/client/worldmonitor/intelligence/v1/service_client';
@@ -191,6 +193,7 @@ export class CountryIntelManager implements AppModule {
         const posturePanel = this.ctx.panels['strategic-posture'] as StrategicPosturePanel | undefined;
         const postures = posturePanel?.getPostures() || [];
         const data = collectStoryData(code, name, this.ctx.latestClusters, postures, this.ctx.latestPredictions, signals, convergence);
+        const { renderStoryToCanvas } = await import('@/services/story-renderer');
         const canvas = await renderStoryToCanvas(data);
         const dataUrl = canvas.toDataURL('image/png');
         const a = document.createElement('a');

--- a/src/components/StoryModal.ts
+++ b/src/components/StoryModal.ts
@@ -1,5 +1,7 @@
 import type { StoryData } from '@/services/story-data';
-import { renderStoryToCanvas } from '@/services/story-renderer';
+// renderStoryToCanvas is dynamic-imported at its call site (#4486) so story-renderer
+// stays off the eager boot graph; this is the second of its two eager edges (the
+// other is country-intel). renderAndDisplay runs on story-modal open (interaction).
 import { generateStoryDeepLink, getShareUrls, shareTexts } from '@/services/story-share';
 import { t } from '@/services/i18n';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
@@ -84,6 +86,7 @@ export function openStoryModal(data: StoryData): void {
 }
 
 async function renderAndDisplay(data: StoryData): Promise<void> {
+  const { renderStoryToCanvas } = await import('@/services/story-renderer');
   const canvas = await renderStoryToCanvas(data);
   currentDataUrl = canvas.toDataURL('image/png');
 

--- a/tests/dashboard-eager-chunks.test.mjs
+++ b/tests/dashboard-eager-chunks.test.mjs
@@ -227,3 +227,31 @@ describe('eager chunk budget: post-paint enrichment services stay off the entry'
     preloadMessage: (chunk) => `${chunk} must not be eagerly modulepreloaded — it loads post-first-paint on demand`,
   });
 });
+
+describe('correlation-engine lazy boot failure handling', () => {
+  it('keeps the dynamic import locally handled', () => {
+    const src = readFileSync(resolve(repoRoot, 'src/App.ts'), 'utf-8');
+    const methodStart = src.indexOf('private async loadInitialCorrelationEngine(): Promise<void>');
+    assert.notEqual(methodStart, -1, 'App should isolate correlation-engine lazy boot in loadInitialCorrelationEngine');
+    const methodEnd = src.indexOf('public async init(): Promise<void>', methodStart);
+    assert.notEqual(methodEnd, -1, 'loadInitialCorrelationEngine should be declared before init()');
+    const method = src.slice(methodStart, methodEnd);
+
+    assert.ok(
+      method.includes("await import('@/services/correlation-engine')"),
+      'correlation-engine should still load through a dynamic import',
+    );
+    assert.ok(
+      method.includes('} catch (error) {'),
+      'correlation-engine lazy boot should catch chunk-load/run failures locally',
+    );
+    assert.ok(
+      method.includes("console.warn('[CorrelationEngine] Initial lazy load/run failed:', error);"),
+      'correlation-engine lazy boot failures should be logged for diagnosis',
+    );
+    assert.ok(
+      !src.includes("void import('@/services/correlation-engine').then("),
+      'correlation-engine lazy boot must not use an unhandled void import().then() chain',
+    );
+  });
+});

--- a/tests/dashboard-eager-chunks.test.mjs
+++ b/tests/dashboard-eager-chunks.test.mjs
@@ -30,6 +30,15 @@ const DEFERRED_AGENT_BUS_CHUNKS = ['agent-bus-actions'];
 //   confetti.module — canvas-confetti, loaded on the first milestone celebration
 // Re-adding a static `import` of either would re-eagerise it into main and fail this.
 const DEFERRED_NPM_LIB_CHUNKS = ['satellite.es', 'confetti.module'];
+// Enrichment SERVICE tail deferred off the eager boot graph (#4486 — service-graph
+// split, Phase A). Each runs only AFTER first paint — correlation-engine.run() is
+// post-loadAllData fire-and-forget; story-renderer fires on story-modal open — so its
+// bytes belong in a lazy chunk, NOT eager main. A re-added static import (App.ts for
+// correlation-engine; country-intel/StoryModal for story-renderer) would re-eagerise
+// it and fail this guard. correlation-engine gets its name from a manualChunks naming
+// rule (dir-index would otherwise emit an ambiguous `index-*.js`); story-renderer
+// (single file) names itself.
+const DEFERRED_SERVICE_CHUNKS = ['correlation-engine', 'story-renderer'];
 const MILITARY_BASE_DIRECT_IMPORT_FORBIDDEN = [
   'src/app/country-intel.ts',
   'src/app/search-manager.ts',
@@ -209,5 +218,12 @@ describe('eager chunk budget: agent-bus + zod stay behind the lazy chat-analyst 
   registerDeferredChunkAssertions(DEFERRED_AGENT_BUS_CHUNKS, {
     missingMessage: (chunk) => `${chunk}-*.js chunk should exist — if it was inlined into main, a static import re-eagerised agent-bus-applier (and zod)`,
     preloadMessage: (chunk) => `${chunk} must not be eagerly modulepreloaded — agent-bus loads through the lazy chat-analyst panel`,
+  });
+});
+
+describe('eager chunk budget: post-paint enrichment services stay off the entry', { skip: !existsSync(dashboardHtml) }, () => {
+  registerDeferredChunkAssertions(DEFERRED_SERVICE_CHUNKS, {
+    missingMessage: (chunk) => `${chunk}-*.js chunk should exist — if missing, a static import inlined the service into the entry (correlation-engine: App.ts; story-renderer: country-intel/StoryModal)`,
+    preloadMessage: (chunk) => `${chunk} must not be eagerly modulepreloaded — it loads post-first-paint on demand`,
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1185,6 +1185,14 @@ export default defineConfig(({ mode }) => {
             if (id.endsWith('/src/config/military-bases.ts') || id.endsWith('/src/config/bases-expanded.ts')) {
               return 'military-bases-data';
             }
+            // Correlation engine (engine + 4 adapters) is dynamic-imported at its
+            // post-loadAllData run site in App.ts (#4486), so it already forms a lazy
+            // chunk; this rule only gives that chunk a STABLE name — the dir-index
+            // would otherwise emit an ambiguous `index-*.js` the eager-chunk guard
+            // can't pin. Naming only; the deferral is the call-site import().
+            if (id.includes('/src/services/correlation-engine/')) {
+              return 'correlation-engine';
+            }
             // Co-locate the deck.gl renderer with the deck vendor chunk so
             // onlyExplicitManualChunks cannot split deck's transitive deps
             // across the DeckGLMap boundary (which formed a circular chunk →


### PR DESCRIPTION
## Phase A — defer correlation-engine + story-renderer off the eager boot graph

Part of #4487 (Core Web Vitals field fix). Phase A of the service-graph boot split **#4486**.

The eager `main.js` pulls a ~150 KB enrichment service tail it only invokes *after* first paint. This PR defers the two **genuinely-clean** services (neither re-exported by the `@/services` barrel) via call-site dynamic `import()`:

- **correlation-engine** (`src/App.ts`) — the `new CorrelationEngine()` + 4 `registerAdapter()` + `.run()` move into `import('@/services/correlation-engine').then(...)` at the existing post-`loadAllData` fire-and-forget run site. `state.correlationEngine` now settles asynchronously; all three readers (run path, 5-min refresh scheduler, export getter) already null-guard, so no new guard code. The `.then` is `isDestroyed`-guarded. A `manualChunks` *naming* rule gives the chunk a stable name — the dir-index would otherwise emit an ambiguous `index-*.js` the guard can't pin (naming only; the deferral is the call-site `import()`).
- **story-renderer** — both eager edges converted to `await import()`: `country-intel`'s direct render **and** `StoryModal`'s render (the second edge a call-site-only swap would miss). Both fire on story-modal interaction (post-paint).

### Result
~28.7 KB raw / ~10.4 KB gzip off eager `main.js` into lazy chunks:
- `correlation-engine-*.js` — 17.9 KB (6.7 KB gz)
- `story-renderer-*.js` — 10.8 KB (3.7 KB gz)

(correlation-engine's win is the exclusive logic; the shared generated-client / premiumFetch / panel-gating stay eager, as scoped.)

### Verification
- **Eager-chunk guard** extended (`DEFERRED_SERVICE_CHUNKS`): both chunks build isolated, stay out of `dashboard.html` modulepreload, and are **not statically imported by main** (the binding proof).
- `test:data` full suite **11778/11778** pass · **tsc** 0 errors · `vite build` clean (no circular-chunk warning).
- Adversarial code review: **clean, no blocking issues** — verified the no-cycle claim against the real `dist/` build; the construct-moved-later is **not** a regression (`setupRefreshIntervals` already sits after `loadAllData`, so both old and new code skip it on a `loadAllData` throw, and every reader null-guards).

### Field-gated stop
Phase A is byte-light by design — it proves the mechanism + guard discipline on the lowest-risk units. **Measure CrUX LCP/INP after deploy before committing to Phase B** (the barrel-pinned bytes: infra-cascade + daily-brief + economic, #4486). The structurally-pinned tail (military-vessels, cross-module-integration, generated-client split) is tracked in #4492 / #4493.

https://claude.ai/code/session_017L8nACBdvQ5Sj7mTBfEBhy