### PR TITLE
fix(api): restrict bootstrap shared caching

### DIFF
--- a/api/bootstrap-auth.test.mjs
+++ b/api/bootstrap-auth.test.mjs
@@ -1,6 +1,7 @@
 import { strict as assert } from 'node:assert';
 import test from 'node:test';
 import handler from './bootstrap.js';
+import { issueSessionToken } from './_session.js';
 
 const ENTERPRISE_KEY = 'enterprise-bootstrap-test-key';
 const USER_KEY = 'wm_0123456789abcdef0123456789abcdef01234567';
@@ -22,6 +23,7 @@ async function withMockedBootstrapAuth({ entitlement, userKeyResponse = 'valid',
     'CONVEX_SERVER_SHARED_SECRET',
     'UPSTASH_REDIS_REST_URL',
     'UPSTASH_REDIS_REST_TOKEN',
+    'WM_SESSION_SECRET',
     'WORLDMONITOR_VALID_KEYS',
   ]);
   const originalFetch = globalThis.fetch;
@@ -31,6 +33,7 @@ async function withMockedBootstrapAuth({ entitlement, userKeyResponse = 'valid',
   process.env.CONVEX_SERVER_SHARED_SECRET = 'shared-secret';
   process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.test';
   process.env.UPSTASH_REDIS_REST_TOKEN = 'redis-token';
+  process.env.WM_SESSION_SECRET = 'test-secret-for-bootstrap-auth-cache-matrix';
   process.env.WORLDMONITOR_VALID_KEYS = ENTERPRISE_KEY;
 
   globalThis.fetch = async (input, init) => {
@@ -218,6 +221,17 @@ test('weather-only bootstrap with wm_ user key validates user auth before return
 test('allowed-Origin valid wm_ user key returns bootstrap data without shared cache headers', async () => {
   await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async () => {
     const resp = await handler(makeBootstrapRequestWithAllowedOrigin({ 'X-WorldMonitor-Key': USER_KEY }));
+
+    assert.equal(resp.status, 200);
+    assert.deepEqual(Object.keys(await resp.json()).sort(), ['data', 'missing']);
+    assertNonSharedCacheHeaders(resp);
+  });
+});
+
+test('session-authenticated bootstrap returns data without shared cache headers', async () => {
+  await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async () => {
+    const { token } = await issueSessionToken();
+    const resp = await handler(makeBootstrapRequestWithAllowedOrigin({ Cookie: `wm-session=${token}` }));
 
     assert.equal(resp.status, 200);
     assert.deepEqual(Object.keys(await resp.json()).sort(), ['data', 'missing']);

--- a/api/bootstrap-auth.test.mjs
+++ b/api/bootstrap-auth.test.mjs
@@ -239,6 +239,17 @@ test('session-authenticated bootstrap returns data without shared cache headers'
   });
 });
 
+test('session-authenticated weather-only bootstrap is not shared-cacheable', async () => {
+  await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async () => {
+    const { token } = await issueSessionToken();
+    const resp = await handler(makeWeatherBootstrapRequest({ Cookie: `wm-session=${token}` }));
+
+    assert.equal(resp.status, 200);
+    assert.deepEqual(Object.keys(await resp.json()).sort(), ['data', 'missing']);
+    assertNonSharedCacheHeaders(resp);
+  });
+});
+
 test('weather-only bootstrap with malformed wm_ header is rejected instead of anonymous bypass', async () => {
   await withMockedBootstrapAuth({ entitlement: activeApiEntitlement() }, async (calls) => {
     const resp = await handler(makeWeatherBootstrapRequest({ 'X-WorldMonitor-Key': 'wm_notcanonical' }));

--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -341,8 +341,7 @@ async function validateBootstrapAuth(req, cors) {
 }
 
 function successCacheHeaders(tier, authKind, cors) {
-  const isKeyAuth = authKind === 'enterprise' || authKind === 'user';
-  if (isKeyAuth) {
+  if (authKind !== 'public-weather') {
     return {
       ...cors,
       'Cache-Control': 'no-store',
@@ -388,11 +387,9 @@ export default async function handler(req) {
   try {
     cached = await getCachedJsonBatch(keys);
   } catch {
-    // Read auth.kind directly (not the output of successCacheHeaders) so a
-    // key-authenticated empty fallback always stays no-store and can never be
-    // shared-cached by a CDN to another caller.
-    const isKeyAuth = auth.kind === 'enterprise' || auth.kind === 'user';
-    const cacheControl = isKeyAuth ? 'no-store' : 'no-cache';
+    // Only the anonymous weather bootstrap may avoid no-store here; every
+    // other successful bootstrap response can carry session/key scoped data.
+    const cacheControl = auth.kind === 'public-weather' ? 'no-cache' : 'no-store';
     return jsonResponse({ data: {}, missing: names }, 200, { ...cors, 'Cache-Control': cacheControl });
   }
 

--- a/api/bootstrap.js
+++ b/api/bootstrap.js
@@ -227,6 +227,19 @@ export function isPublicWeatherBootstrapRequest(req) {
   return requested.length === 1 && requested[0] === 'weatherAlerts';
 }
 
+const BOOTSTRAP_CREDENTIAL_COOKIES = new Set(['wm-session', 'wm-pro-key', 'wm-widget-key']);
+
+function hasBootstrapCredentialCookie(req) {
+  const raw = req.headers.get('Cookie') || req.headers.get('cookie') || '';
+  if (!raw) return false;
+
+  for (const part of raw.split(';')) {
+    const name = part.trim().split('=', 1)[0];
+    if (BOOTSTRAP_CREDENTIAL_COOKIES.has(name)) return true;
+  }
+  return false;
+}
+
 const NEG_SENTINEL = '__WM_NEG__';
 
 async function getCachedJsonBatch(keys) {
@@ -268,7 +281,7 @@ function authFailure(body, status, cors, extraHeaders = {}) {
 
 async function validateBootstrapAuth(req, cors) {
   const headerKey = getHeaderApiKey(req);
-  if (!headerKey && isPublicWeatherBootstrapRequest(req)) {
+  if (!headerKey && !hasBootstrapCredentialCookie(req) && isPublicWeatherBootstrapRequest(req)) {
     return { ok: true, kind: 'public-weather' };
   }
 


### PR DESCRIPTION
## Summary

- Restricts successful `/api/bootstrap` shared caching to `auth.kind === "public-weather"` only.
- Keeps anonymous `GET /api/bootstrap?keys=weatherAlerts` cacheable while making session/user/enterprise bootstrap successes `no-store`.
- Adds a session-auth bootstrap regression test to the existing cache/auth matrix.

## Intent

Fixes #4495.

The remaining cache boundary after the bootstrap auth hardening was that non-key success kinds could still inherit public/CDN cache headers. This PR makes the shared-cache exception explicit and narrow: anonymous weather bootstrap only.

Non-goals:
- No changes to bootstrap key selection or payload shape.
- No UI changes.
- No changes to API-key validation semantics.

## Validation Matrix

| Check | Reason | Result |
| --- | --- | --- |
| `node --test api/bootstrap-auth.test.mjs api/bootstrap-cors.test.mjs api/_api-key.test.mjs` | Focused bootstrap/auth/session cache matrix | Pass: 47 tests |
| `TMPDIR=/tmp node --import tsx --test tests/embed-public-data-auth.test.mts` | Public/anonymous bootstrap exception guard | Pass: 3 tests |
| `npm run typecheck:api` | API typecheck and Convex call audit | Pass |
| `npm run test:sidecar` | Broader API/sidecar auth contract suite | Pass: 163 tests |
| `git diff --check` | Diff hygiene | Pass |
| `git push -u origin HEAD` pre-push hook | Repo pre-push gates including typecheck, API typecheck, boundary lint, safe HTML, rate-limit policy, premium-fetch parity, edge function bundle/tests, version sync | Pass |

## Review Gates

- Baseline reviewer: Pass. Found one fallback branch still using the old enterprise/user-only predicate; fixed before publish.
- Code Review Expert: Pass. SOLID, security, code-quality, and removal checklists reviewed against the final two-file diff; no remaining findings.
- Outcome reviewer: Pass. Final diff satisfies the issue acceptance criteria and validation rows are green.

## Documentation

Not applicable. This is an internal API response-header policy fix with regression coverage.

## Screenshots / UI Evidence

Not applicable. No user-visible UI changed.

## Residual Findings

None.
