### PR TITLE
fix(api): make gateway auth responses cache-safe

### DIFF
--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -12,7 +12,7 @@
 import { createRouter, type RouteDescriptor } from './router';
 import { getCorsHeaders, isDisallowedOrigin, isAllowedOrigin } from './cors';
 // @ts-expect-error — JS module, no declaration file
-import { validateApiKey } from '../api/_api-key.js';
+import { USER_API_KEY_GATEWAY_VALIDATION_ERROR, validateApiKey } from '../api/_api-key.js';
 // @ts-expect-error — JS module, no declaration file
 import { captureSilentError } from '../api/_sentry-edge.js';
 import { mapErrorToResponse } from './error-mapper';
@@ -377,7 +377,6 @@ export type GatewayCtx = { waitUntil: (p: Promise<unknown>) => void };
 
 const POST_TO_GET_MAX_BODY_BYTES = 1_048_576;
 const POST_TO_GET_MAX_ARRAY_VALUES_PER_KEY = 200;
-const USER_API_KEY_GATEWAY_VALIDATION_ERROR = 'User API key requires gateway validation';
 
 function isPostToGetCompatibleBodySize(headers: Headers): boolean {
   const rawContentLength = headers.get('Content-Length');
@@ -1205,6 +1204,8 @@ export function createDomainGateway(
         // bypassing auth entirely.
         const reqOrigin = request.headers.get('origin') || '';
         const cdnCache = !isPremium && !hasCredentialedNonPublicGet && isAllowedOrigin(reqOrigin) ? TIER_CDN_CACHE[tier] : null;
+        mergedHeaders.delete('CDN-Cache-Control');
+        mergedHeaders.delete('Vercel-CDN-Cache-Control');
         if (cdnCache) mergedHeaders.set('CDN-Cache-Control', cdnCache);
         mergedHeaders.set('X-Cache-Tier', tier);
 

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -377,6 +377,7 @@ export type GatewayCtx = { waitUntil: (p: Promise<unknown>) => void };
 
 const POST_TO_GET_MAX_BODY_BYTES = 1_048_576;
 const POST_TO_GET_MAX_ARRAY_VALUES_PER_KEY = 200;
+const USER_API_KEY_GATEWAY_VALIDATION_ERROR = 'User API key requires gateway validation';
 
 function isPostToGetCompatibleBodySize(headers: Headers): boolean {
   const rawContentLength = headers.get('Content-Length');
@@ -409,6 +410,42 @@ function withAuthenticatedUserId(request: Request, userId: string): Request {
   const headers = new Headers(request.headers);
   headers.set(TRUSTED_USER_ID_HEADER, userId);
   return cloneRequestWithHeaders(request, headers);
+}
+
+function normalizeAuthError(error: string | undefined): string {
+  if (!error || error === USER_API_KEY_GATEWAY_VALIDATION_ERROR) return 'Invalid API key';
+  return error;
+}
+
+function createGatewayAuthErrorResponse(
+  status: 401 | 403,
+  error: string | undefined,
+  corsHeaders: Record<string, string>,
+): Response {
+  return new Response(JSON.stringify({ error: normalizeAuthError(error) }), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+      ...corsHeaders,
+    },
+  });
+}
+
+function markAuthErrorNoStore(response: Response): Response {
+  response.headers.set('Cache-Control', 'no-store');
+  response.headers.delete('CDN-Cache-Control');
+  response.headers.delete('Vercel-CDN-Cache-Control');
+  return response;
+}
+
+function hasCredentialBearingHeader(request: Request): boolean {
+  return Boolean(
+    request.headers.get('Authorization') ||
+    request.headers.get('X-WorldMonitor-Key') ||
+    request.headers.get('X-Api-Key') ||
+    request.headers.get('Cookie'),
+  );
 }
 
 async function isResilienceRankingSeedRefreshRequest(request: Request, pathname: string): Promise<boolean> {
@@ -898,10 +935,7 @@ export function createDomainGateway(
       if (ent) usage.tier = typeof ent.features.tier === 'number' ? ent.features.tier : 0;
       if (!ent || !ent.features.apiAccess) {
         emitRequest(403, 'tier_403', null);
-        return new Response(JSON.stringify({ error: 'API access subscription required' }), {
-          status: 403,
-          headers: { 'Content-Type': 'application/json', ...corsHeaders },
-        });
+        return createGatewayAuthErrorResponse(403, 'API access subscription required', corsHeaders);
       }
     }
 
@@ -913,10 +947,7 @@ export function createDomainGateway(
           const session = await validateBearerToken(authHeader.slice(7));
           if (!session.valid) {
             emitRequest(401, 'auth_401', null);
-            return new Response(JSON.stringify({ error: 'Invalid or expired session' }), {
-              status: 401,
-              headers: { 'Content-Type': 'application/json', ...corsHeaders },
-            });
+            return createGatewayAuthErrorResponse(401, 'Invalid or expired session', corsHeaders);
           }
           // Capture identity for telemetry — legacy bearer auth bypasses the
           // earlier resolveClerkSession() block (only runs for tier-gated routes),
@@ -950,25 +981,16 @@ export function createDomainGateway(
           }
           if (!allowed) {
             emitRequest(403, 'tier_403', null);
-            return new Response(JSON.stringify({ error: 'Pro subscription required' }), {
-              status: 403,
-              headers: { 'Content-Type': 'application/json', ...corsHeaders },
-            });
+            return createGatewayAuthErrorResponse(403, 'Pro subscription required', corsHeaders);
           }
           // Valid pro session (Clerk role OR Dodo entitlement) — fall through to route handling.
         } else {
           emitRequest(401, 'auth_401', null);
-          return new Response(JSON.stringify({ error: keyCheck.error }), {
-            status: 401,
-            headers: { 'Content-Type': 'application/json', ...corsHeaders },
-          });
+          return createGatewayAuthErrorResponse(401, keyCheck.error, corsHeaders);
         }
       } else {
         emitRequest(401, 'auth_401', null);
-        return new Response(JSON.stringify({ error: keyCheck.error }), {
-          status: 401,
-          headers: { 'Content-Type': 'application/json', ...corsHeaders },
-        });
+        return createGatewayAuthErrorResponse(401, keyCheck.error, corsHeaders);
       }
     }
 
@@ -991,7 +1013,9 @@ export function createDomainGateway(
           : entitlementResponse.status === 403 ? 'tier_403'
           : 'ok';
         emitRequest(entitlementResponse.status, entReason, null);
-        return entitlementResponse;
+        return entitlementResponse.status === 401 || entitlementResponse.status === 403
+          ? markAuthErrorNoStore(entitlementResponse)
+          : entitlementResponse;
       }
       // Allowed → record the resolved tier for telemetry. getEntitlements has
       // its own Redis cache + in-flight coalescing, so the second lookup here
@@ -1169,7 +1193,8 @@ export function createDomainGateway(
         const rpcName = pathname.split('/').pop() ?? '';
         const envOverride = process.env[`CACHE_TIER_OVERRIDE_${rpcName.replace(/-/g, '_').toUpperCase()}`] as CacheTier | undefined;
         const isPremium = PREMIUM_RPC_PATHS.has(pathname) || getRequiredTier(pathname) !== null;
-        const tier = isPremium ? 'slow-browser' as CacheTier
+        const hasCredentialedNonPublicGet = !isPublicNoAuthRpc && hasCredentialBearingHeader(request);
+        const tier = isPremium || hasCredentialedNonPublicGet ? 'slow-browser' as CacheTier
           : (envOverride && envOverride in TIER_HEADERS ? envOverride : null) ?? RPC_CACHE_TIER[pathname] ?? 'medium';
         resolvedCacheTier = tier;
         mergedHeaders.set('Cache-Control', TIER_HEADERS[tier]);
@@ -1179,7 +1204,7 @@ export function createDomainGateway(
         // 200 from a trusted-origin browser request could be served to a no-origin scraper,
         // bypassing auth entirely.
         const reqOrigin = request.headers.get('origin') || '';
-        const cdnCache = !isPremium && isAllowedOrigin(reqOrigin) ? TIER_CDN_CACHE[tier] : null;
+        const cdnCache = !isPremium && !hasCredentialedNonPublicGet && isAllowedOrigin(reqOrigin) ? TIER_CDN_CACHE[tier] : null;
         if (cdnCache) mergedHeaders.set('CDN-Cache-Control', cdnCache);
         mergedHeaders.set('X-Cache-Tier', tier);
 

--- a/tests/gateway-cdn-origin-policy.test.mts
+++ b/tests/gateway-cdn-origin-policy.test.mts
@@ -34,6 +34,11 @@ function createHandler() {
     },
     {
       method: 'GET',
+      path: '/api/conflict/v1/list-acled-events',
+      handler: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    },
+    {
+      method: 'GET',
       path: '/api/market/v1/analyze-stock',
       handler: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
     },
@@ -47,42 +52,47 @@ async function requestPublicRoute(origin: string) {
   }));
 }
 
+function assertNoSharedCacheHeaders(res: Response) {
+  assert.equal(res.headers.get('CDN-Cache-Control'), null);
+  assert.doesNotMatch(res.headers.get('Cache-Control') ?? '', /\bpublic\b|\bs-maxage=/i);
+}
+
 describe('gateway CDN origin policy', () => {
-  it('keeps per-origin CORS and enables CDN caching for worldmonitor.app', async () => {
+  it('keeps per-origin CORS without shared CDN caching for session-bearing worldmonitor.app GETs', async () => {
     const res = await requestPublicRoute('https://worldmonitor.app');
     assert.equal(res.status, 200);
     assert.equal(res.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app');
     assert.equal(res.headers.get('Vary'), 'Origin');
-    assert.match(res.headers.get('CDN-Cache-Control') ?? '', /s-maxage=/);
+    assertNoSharedCacheHeaders(res);
   });
 
-  it('keeps per-origin CORS and enables CDN caching for production subdomains', async () => {
+  it('keeps per-origin CORS without shared CDN caching for session-bearing production subdomain GETs', async () => {
     const res = await requestPublicRoute('https://tech.worldmonitor.app');
     assert.equal(res.status, 200);
     assert.equal(res.headers.get('Access-Control-Allow-Origin'), 'https://tech.worldmonitor.app');
     assert.equal(res.headers.get('Vary'), 'Origin');
-    assert.match(res.headers.get('CDN-Cache-Control') ?? '', /s-maxage=/);
+    assertNoSharedCacheHeaders(res);
   });
 
-  it('enables CDN caching for preview origins', async () => {
+  it('avoids shared CDN caching for session-bearing preview origin GETs', async () => {
     const origin = 'https://worldmonitor-git-feature-eliewm.vercel.app';
     const res = await requestPublicRoute(origin);
     assert.equal(res.status, 200);
     assert.equal(res.headers.get('Access-Control-Allow-Origin'), origin);
     assert.equal(res.headers.get('Vary'), 'Origin');
-    assert.match(res.headers.get('CDN-Cache-Control') ?? '', /s-maxage=/);
+    assertNoSharedCacheHeaders(res);
   });
 
-  it('enables CDN caching for localhost origins', async () => {
+  it('avoids shared CDN caching for session-bearing localhost GETs', async () => {
     const origin = 'http://127.0.0.1:5173';
     const res = await requestPublicRoute(origin);
     assert.equal(res.status, 200);
     assert.equal(res.headers.get('Access-Control-Allow-Origin'), origin);
     assert.equal(res.headers.get('Vary'), 'Origin');
-    assert.match(res.headers.get('CDN-Cache-Control') ?? '', /s-maxage=/);
+    assertNoSharedCacheHeaders(res);
   });
 
-  it('enables CDN caching for Tauri origins', async () => {
+  it('avoids shared CDN caching for enterprise-key Tauri GETs', async () => {
     const origin = 'tauri://localhost';
     process.env.WORLDMONITOR_VALID_KEYS = 'real-key-123';
     const handler = createHandler();
@@ -91,6 +101,18 @@ describe('gateway CDN origin policy', () => {
         Origin: origin,
         'X-WorldMonitor-Key': 'real-key-123',
       },
+    }));
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), origin);
+    assert.equal(res.headers.get('Vary'), 'Origin');
+    assertNoSharedCacheHeaders(res);
+  });
+
+  it('preserves CDN caching for explicit anonymous public no-auth GETs', async () => {
+    const origin = 'https://worldmonitor.app';
+    const handler = createHandler();
+    const res = await handler(new Request('https://worldmonitor.app/api/conflict/v1/list-acled-events', {
+      headers: { Origin: origin },
     }));
     assert.equal(res.status, 200);
     assert.equal(res.headers.get('Access-Control-Allow-Origin'), origin);
@@ -114,6 +136,7 @@ describe('gateway CDN origin policy', () => {
       headers: { Origin: 'https://worldmonitor.app' },
     }));
     assert.equal(noCreds.status, 401);
+    assert.equal(noCreds.headers.get('Cache-Control'), 'no-store');
 
     const withKey = await handler(new Request('https://worldmonitor.app/api/market/v1/analyze-stock?symbol=AAPL', {
       headers: {
@@ -125,5 +148,39 @@ describe('gateway CDN origin policy', () => {
     assert.equal(withKey.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app');
     assert.equal(withKey.headers.get('Vary'), 'Origin');
     assert.equal(withKey.headers.get('CDN-Cache-Control'), null, 'premium endpoints must NOT have CDN caching');
+  });
+
+  it('normalizes invalid wm_ gateway-validation sentinel to non-cacheable invalid key response', async () => {
+    const handler = createHandler();
+    const res = await handler(new Request('https://worldmonitor.app/api/market/v1/list-market-quotes?symbols=AAPL', {
+      headers: {
+        Origin: 'https://worldmonitor.app',
+        'X-WorldMonitor-Key': 'wm_revoked_or_unknown_key',
+      },
+    }));
+    const body = await res.json();
+
+    assert.equal(res.status, 401);
+    assert.equal(res.headers.get('Cache-Control'), 'no-store');
+    assert.equal(res.headers.get('CDN-Cache-Control'), null);
+    assert.equal(body.error, 'Invalid API key');
+    assert.doesNotMatch(JSON.stringify(body), /gateway validation|Convex|keyHash/i);
+  });
+
+  it('normalizes invalid wm_ gateway-validation sentinel on premium RPCs', async () => {
+    const handler = createHandler();
+    const res = await handler(new Request('https://worldmonitor.app/api/market/v1/analyze-stock?symbol=AAPL', {
+      headers: {
+        Origin: 'https://worldmonitor.app',
+        'X-WorldMonitor-Key': 'wm_revoked_or_unknown_key',
+      },
+    }));
+    const body = await res.json();
+
+    assert.equal(res.status, 401);
+    assert.equal(res.headers.get('Cache-Control'), 'no-store');
+    assert.equal(res.headers.get('CDN-Cache-Control'), null);
+    assert.equal(body.error, 'Invalid API key');
+    assert.doesNotMatch(JSON.stringify(body), /gateway validation|Convex|keyHash/i);
   });
 });

--- a/tests/gateway-cdn-origin-policy.test.mts
+++ b/tests/gateway-cdn-origin-policy.test.mts
@@ -25,12 +25,15 @@ afterEach(() => {
   process.env.WM_SESSION_SECRET = 'test-secret-must-be-at-least-32-chars-long-xxx';
 });
 
-function createHandler() {
+function createHandler(options: { handlerCdnCacheHeader?: string } = {}) {
   return createDomainGateway([
     {
       method: 'GET',
       path: '/api/market/v1/list-market-quotes',
-      handler: async () => new Response(JSON.stringify({ ok: true }), { status: 200 }),
+      handler: async () => new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: options.handlerCdnCacheHeader ? { 'CDN-Cache-Control': options.handlerCdnCacheHeader } : undefined,
+      }),
     },
     {
       method: 'GET',
@@ -118,6 +121,18 @@ describe('gateway CDN origin policy', () => {
     assert.equal(res.headers.get('Access-Control-Allow-Origin'), origin);
     assert.equal(res.headers.get('Vary'), 'Origin');
     assert.match(res.headers.get('CDN-Cache-Control') ?? '', /s-maxage=/);
+  });
+
+  it('strips handler-supplied shared CDN headers on credential-bearing GETs', async () => {
+    const handler = createHandler({
+      handlerCdnCacheHeader: 'public, s-maxage=9999, stale-while-revalidate=9999',
+    });
+    const res = await handler(new Request('https://worldmonitor.app/api/market/v1/list-market-quotes?symbols=AAPL', {
+      headers: { Origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': sessionToken },
+    }));
+
+    assert.equal(res.status, 200);
+    assertNoSharedCacheHeaders(res);
   });
 
   it('still blocks disallowed origins before route handling', async () => {


### PR DESCRIPTION
## Summary

Gateway auth failures now return generic, non-cacheable 401/403 responses instead of exposing the user-key gateway-validation sentinel or omitting cache directives. Credential-bearing successful GETs on non-public RPCs keep browser-only cache posture and no longer emit shared CDN cache headers, while explicit anonymous public no-auth RPCs remain CDN-cacheable.

Closes #4494.

## Verification

- Before fix: `env TMPDIR=/private/tmp npx tsx --test tests/gateway-cdn-origin-policy.test.mts` failed 8 assertions on shared CDN headers and missing `Cache-Control: no-store`.
- `env TMPDIR=/private/tmp npx tsx --test tests/gateway-cdn-origin-policy.test.mts`
- `env TMPDIR=/private/tmp npx tsx --test api/bootstrap-auth.test.mjs tests/embed-public-data-auth.test.mts`
- `npm run typecheck`
- `npm run typecheck:api`
- `git diff --check`
- Pre-push hook passed, including server handler tests, changed gateway test file, boundary checks, edge bundle check, and version sync.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
