### PR TITLE
test(api): add live cache auth regression sweep

### DIFF
--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -28,7 +28,10 @@ type StoredSseEvent = {
 };
 
 const SSE_CONTENT_TYPE = 'text/event-stream; charset=utf-8';
-const MCP_CACHE_CONTROL = 'no-store, no-cache, no-transform';
+// no-store forbids storage outright; no-cache is vacuous alongside it (RFC 9111
+// §5.2) so it is omitted. no-transform is load-bearing for SSE framing. This also
+// matches the sibling no-store work in api/mcp/rpc.ts (#4502).
+const MCP_CACHE_CONTROL = 'no-store, no-transform';
 const MAX_SSE_SESSIONS = 500;
 const MAX_SSE_STREAMS_PER_SESSION = 25;
 const mcpSseStreamsBySession = new Map<string, Map<string, StoredSseEvent[]>>();
@@ -37,7 +40,6 @@ function getMcpCorsHeaders(methods = 'POST, GET, OPTIONS'): Record<string, strin
   return {
     ...getPublicCorsHeaders(methods),
     'Cache-Control': MCP_CACHE_CONTROL,
-    Pragma: 'no-cache',
   };
 }
 
@@ -132,7 +134,6 @@ function sseHeadersFrom(headers: Headers): Headers {
   const out = new Headers(headers);
   out.set('Content-Type', SSE_CONTENT_TYPE);
   out.set('Cache-Control', MCP_CACHE_CONTROL);
-  out.set('Pragma', 'no-cache');
   return out;
 }
 

--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -28,9 +28,18 @@ type StoredSseEvent = {
 };
 
 const SSE_CONTENT_TYPE = 'text/event-stream; charset=utf-8';
+const MCP_CACHE_CONTROL = 'no-store, no-cache, no-transform';
 const MAX_SSE_SESSIONS = 500;
 const MAX_SSE_STREAMS_PER_SESSION = 25;
 const mcpSseStreamsBySession = new Map<string, Map<string, StoredSseEvent[]>>();
+
+function getMcpCorsHeaders(methods = 'POST, GET, OPTIONS'): Record<string, string> {
+  return {
+    ...getPublicCorsHeaders(methods),
+    'Cache-Control': MCP_CACHE_CONTROL,
+    Pragma: 'no-cache',
+  };
+}
 
 function clientAcceptsSse(req: Request): boolean {
   const accept = req.headers.get('accept') ?? '';
@@ -122,7 +131,8 @@ function replayEventsAfter(sessionId: string, lastEventId: string): StoredSseEve
 function sseHeadersFrom(headers: Headers): Headers {
   const out = new Headers(headers);
   out.set('Content-Type', SSE_CONTENT_TYPE);
-  out.set('Cache-Control', 'no-cache, no-transform');
+  out.set('Cache-Control', MCP_CACHE_CONTROL);
+  out.set('Pragma', 'no-cache');
   return out;
 }
 
@@ -187,7 +197,7 @@ function handleSseReplay(req: Request, corsHeaders: Record<string, string>): Res
 
   return new Response(createSseStream(events), {
     status: 200,
-    headers: { 'Content-Type': SSE_CONTENT_TYPE, 'Cache-Control': 'no-cache, no-transform', ...corsHeaders },
+    headers: { 'Content-Type': SSE_CONTENT_TYPE, ...corsHeaders },
   });
 }
 
@@ -200,7 +210,7 @@ export async function mcpHandler(
   ctx?: { waitUntil: (p: Promise<unknown>) => void },
 ): Promise<Response> {
   // MCP is a public API endpoint secured by API key — allow all origins (claude.ai, Claude Desktop, custom agents)
-  const corsHeaders = getPublicCorsHeaders('POST, GET, OPTIONS');
+  const corsHeaders = getMcpCorsHeaders();
 
   if (req.method === 'OPTIONS') {
     return new Response(null, { status: 204, headers: corsHeaders });

--- a/tests/live-api-cache-auth-regression.test.mjs
+++ b/tests/live-api-cache-auth-regression.test.mjs
@@ -1,0 +1,161 @@
+/**
+ * Live API cache/auth regression sweep for issue #4497.
+ *
+ * This intentionally probes production cache/auth behavior and is skipped unless
+ * LIVE_API_CACHE_TESTS=1 is set. It validates the Cloudflare/Vercel rule
+ * assumptions from the 2026-06-28 incident follow-up:
+ *   - fake auth must never receive a cached 200
+ *   - auth errors must be no-store and dynamic
+ *   - anonymous public surfaces remain cacheable
+ *   - MCP auth/protocol surfaces remain functional and no-store
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+const LIVE = process.env.LIVE_API_CACHE_TESTS === '1';
+const API_BASE = stripTrailingSlash(process.env.WM_LIVE_API_BASE_URL || 'https://api.worldmonitor.app');
+const WEB_BASE = stripTrailingSlash(process.env.WM_LIVE_WEB_BASE_URL || 'https://worldmonitor.app');
+const FAKE_WM_KEY = 'wm_0000000000000000000000000000000000000000';
+const USER_AGENT = 'WorldMonitor-Live-Cache-Auth-Sweep/1.0';
+
+function stripTrailingSlash(value) {
+  return value.replace(/\/+$/, '');
+}
+
+function cacheControl(resp) {
+  return resp.headers.get('cache-control') || '';
+}
+
+function cfCacheStatus(resp) {
+  return resp.headers.get('cf-cache-status') || '';
+}
+
+function assertNoStore(resp, name) {
+  assert.match(cacheControl(resp), /\bno-store\b/i, `${name}: Cache-Control must include no-store`);
+  assert.equal(resp.headers.get('cdn-cache-control'), null, `${name}: CDN-Cache-Control must not be present`);
+}
+
+function assertNoSentinelLeak(bodyText, name) {
+  assert.doesNotMatch(bodyText, /gateway validation|Convex|keyHash/i, `${name}: leaked internal auth sentinel/detail`);
+}
+
+function assertNotCached200(resp, name) {
+  assert.notEqual(resp.status, 200, `${name}: fake auth must not receive a 200`);
+  assert.notEqual(cfCacheStatus(resp).toUpperCase(), 'HIT', `${name}: fake auth response must not be a Cloudflare HIT`);
+}
+
+function assertPublicCacheable(resp, name) {
+  assert.equal(resp.status, 200, `${name}: anonymous public request should succeed`);
+  assert.match(cacheControl(resp), /\bpublic\b/i, `${name}: anonymous public request should remain public-cacheable`);
+}
+
+async function fetchText(pathOrUrl, init = {}) {
+  const headers = new Headers(init.headers || {});
+  headers.set('User-Agent', USER_AGENT);
+  const resp = await fetch(pathOrUrl, { ...init, headers });
+  const bodyText = await resp.text();
+  return { resp, bodyText };
+}
+
+describe(`live API cache/auth regression sweep (${LIVE ? 'ENABLED' : 'SKIPPED - set LIVE_API_CACHE_TESTS=1'})`, { skip: !LIVE }, () => {
+  it('documents the Cloudflare rule assumptions being validated', () => {
+    console.info([
+      'Cloudflare/API cache assumptions under test:',
+      'fake-auth responses are dynamic no-store and never cached 200s;',
+      'anonymous public REST/RPC responses remain public-cacheable;',
+      'MCP auth/protocol responses are no-store;',
+      'OAuth metadata remains discoverable and cacheable.',
+    ].join(' '));
+    assert.equal(LIVE, true);
+  });
+
+  it('bootstrap rejects fake auth as dynamic no-store while anonymous weather stays cacheable', async () => {
+    const fake = await fetchText(`${API_BASE}/api/bootstrap?keys=weatherAlerts`, {
+      headers: { 'X-WorldMonitor-Key': FAKE_WM_KEY },
+    });
+    assert.equal(fake.resp.status, 401);
+    assertNoStore(fake.resp, 'bootstrap fake auth');
+    assertNotCached200(fake.resp, 'bootstrap fake auth');
+    assertNoSentinelLeak(fake.bodyText, 'bootstrap fake auth');
+
+    const anon = await fetchText(`${API_BASE}/api/bootstrap?keys=weatherAlerts`);
+    assertPublicCacheable(anon.resp, 'bootstrap anonymous weather');
+    assert.match(anon.bodyText, /"data"\s*:/, 'bootstrap anonymous weather: expected data envelope');
+  });
+
+  it('generated RPCs reject fake auth as dynamic no-store while public no-auth RPCs stay cacheable', async () => {
+    const fake = await fetchText(`${API_BASE}/api/market/v1/list-market-quotes?symbols=AAPL`, {
+      headers: { 'X-WorldMonitor-Key': FAKE_WM_KEY },
+    });
+    assert.equal(fake.resp.status, 401);
+    assertNoStore(fake.resp, 'generated RPC fake auth');
+    assertNotCached200(fake.resp, 'generated RPC fake auth');
+    assertNoSentinelLeak(fake.bodyText, 'generated RPC fake auth');
+
+    const publicRpc = await fetchText(`${API_BASE}/api/conflict/v1/list-acled-events`);
+    assertPublicCacheable(publicRpc.resp, 'public no-auth RPC');
+    assert.match(publicRpc.bodyText, /"events"\s*:/, 'public no-auth RPC: expected events payload');
+  });
+
+  it('premium RPC fake auth fails closed without shared cache headers', async () => {
+    const fake = await fetchText(`${API_BASE}/api/market/v1/analyze-stock?symbol=AAPL`, {
+      headers: { 'X-WorldMonitor-Key': FAKE_WM_KEY },
+    });
+    assert.equal(fake.resp.status, 401);
+    assertNoStore(fake.resp, 'premium RPC fake auth');
+    assertNotCached200(fake.resp, 'premium RPC fake auth');
+    assertNoSentinelLeak(fake.bodyText, 'premium RPC fake auth');
+  });
+
+  it('MCP OPTIONS and unauthenticated POST are protocol-valid no-store responses', async () => {
+    const options = await fetchText(`${WEB_BASE}/mcp`, {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://claude.ai',
+        'Access-Control-Request-Method': 'POST',
+      },
+    });
+    assert.equal(options.resp.status, 204);
+    assert.match(options.resp.headers.get('access-control-allow-methods') || '', /\bPOST\b/);
+    assertNoStore(options.resp, 'MCP OPTIONS');
+
+    const post = await fetchText(`${WEB_BASE}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'worldmonitor-live-sweep', version: '1.0' },
+        },
+      }),
+    });
+    assert.equal(post.resp.status, 401);
+    assert.match(post.resp.headers.get('www-authenticate') || '', /resource_metadata=/);
+    assertNoStore(post.resp, 'MCP unauthenticated POST');
+
+    const body = JSON.parse(post.bodyText);
+    assert.equal(body.error?.code, -32001);
+  });
+
+  it('OAuth metadata remains discoverable and cacheable', async () => {
+    const protectedResource = await fetchText(`${WEB_BASE}/.well-known/oauth-protected-resource`);
+    assertPublicCacheable(protectedResource.resp, 'OAuth protected-resource metadata');
+    const resourceBody = JSON.parse(protectedResource.bodyText);
+    assert.equal(resourceBody.resource, WEB_BASE);
+    assert.ok(Array.isArray(resourceBody.authorization_servers));
+
+    const authServer = await fetchText(`${API_BASE}/.well-known/oauth-authorization-server`);
+    assertPublicCacheable(authServer.resp, 'OAuth authorization-server metadata');
+    const authBody = JSON.parse(authServer.bodyText);
+    assert.equal(authBody.issuer, API_BASE);
+    assert.equal(authBody.token_endpoint, `${API_BASE}/oauth/token`);
+  });
+});

--- a/tests/live-api-cache-auth-regression.test.mjs
+++ b/tests/live-api-cache-auth-regression.test.mjs
@@ -18,6 +18,12 @@ const API_BASE = stripTrailingSlash(process.env.WM_LIVE_API_BASE_URL || 'https:/
 const WEB_BASE = stripTrailingSlash(process.env.WM_LIVE_WEB_BASE_URL || 'https://worldmonitor.app');
 const FAKE_WM_KEY = 'wm_0000000000000000000000000000000000000000';
 const USER_AGENT = 'WorldMonitor-Live-Cache-Auth-Sweep/1.0';
+const LIVE_API_CACHE_TIMEOUT_MS = positiveIntegerFromEnv(process.env.LIVE_API_CACHE_TIMEOUT_MS, 15_000);
+
+function positiveIntegerFromEnv(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
 
 function stripTrailingSlash(value) {
   return value.replace(/\/+$/, '');
@@ -33,7 +39,11 @@ function cfCacheStatus(resp) {
 
 function assertNoStore(resp, name) {
   assert.match(cacheControl(resp), /\bno-store\b/i, `${name}: Cache-Control must include no-store`);
-  assert.equal(resp.headers.get('cdn-cache-control'), null, `${name}: CDN-Cache-Control must not be present`);
+  const cdnCacheControl = resp.headers.get('cdn-cache-control') || '';
+  if (cdnCacheControl) {
+    assert.match(cdnCacheControl, /\bno-store\b/i, `${name}: CDN-Cache-Control must be absent or no-store`);
+    assert.doesNotMatch(cdnCacheControl, /\bpublic\b|\bs-maxage\b/i, `${name}: CDN-Cache-Control must not be shared-cacheable`);
+  }
 }
 
 function assertNoSentinelLeak(bodyText, name) {
@@ -53,7 +63,11 @@ function assertPublicCacheable(resp, name) {
 async function fetchText(pathOrUrl, init = {}) {
   const headers = new Headers(init.headers || {});
   headers.set('User-Agent', USER_AGENT);
-  const resp = await fetch(pathOrUrl, { ...init, headers });
+  const timeoutSignal = AbortSignal.timeout(LIVE_API_CACHE_TIMEOUT_MS);
+  const signal = init.signal && typeof AbortSignal.any === 'function'
+    ? AbortSignal.any([init.signal, timeoutSignal])
+    : init.signal || timeoutSignal;
+  const resp = await fetch(pathOrUrl, { ...init, headers, signal });
   const bodyText = await resp.text();
   return { resp, bodyText };
 }

--- a/tests/live-api-cache-auth-regression.test.mjs
+++ b/tests/live-api-cache-auth-regression.test.mjs
@@ -51,7 +51,9 @@ function assertNoSentinelLeak(bodyText, name) {
 }
 
 function assertNotCached200(resp, name) {
-  assert.notEqual(resp.status, 200, `${name}: fake auth must not receive a 200`);
+  // The HTTP status is asserted explicitly at each call site (401); the only
+  // meaningful guard here is that the rejection was not served from a shared
+  // cache HIT (the #4497 failure mode).
   assert.notEqual(cfCacheStatus(resp).toUpperCase(), 'HIT', `${name}: fake auth response must not be a Cloudflare HIT`);
 }
 
@@ -171,5 +173,33 @@ describe(`live API cache/auth regression sweep (${LIVE ? 'ENABLED' : 'SKIPPED - 
     const authBody = JSON.parse(authServer.bodyText);
     assert.equal(authBody.issuer, API_BASE);
     assert.equal(authBody.token_endpoint, `${API_BASE}/oauth/token`);
+  });
+
+  // The #4497 incident class is a CACHED 200 of private/authenticated data — the
+  // negative (401) cases above cannot catch it. With a real MCP-authorized key
+  // (WM_LIVE_TEST_KEY, never committed), assert an authenticated 200 MCP response
+  // is no-store and not served from a shared-cache HIT. Skipped unless the key is set.
+  it('authenticated MCP 200 is no-store and never a shared-cache HIT', { skip: !process.env.WM_LIVE_TEST_KEY }, async () => {
+    const post = await fetchText(`${WEB_BASE}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        'X-WorldMonitor-Key': process.env.WM_LIVE_TEST_KEY,
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2025-03-26',
+          capabilities: {},
+          clientInfo: { name: 'worldmonitor-live-sweep', version: '1.0' },
+        },
+      }),
+    });
+    assert.equal(post.resp.status, 200, 'authenticated MCP initialize should succeed (WM_LIVE_TEST_KEY must be a valid MCP-authorized key)');
+    assertNoStore(post.resp, 'authenticated MCP 200');
+    assert.notEqual(cfCacheStatus(post.resp).toUpperCase(), 'HIT', 'authenticated MCP 200 must not be a shared-cache HIT');
   });
 });

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -76,6 +76,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     const res = await handler(req);
     assert.equal(res.status, 401);
     assert.ok(res.headers.get('www-authenticate')?.includes('Bearer realm="worldmonitor"'), 'must include WWW-Authenticate header');
+    assert.match(res.headers.get('cache-control') || '', /\bno-store\b/i);
     const body = await res.json();
     assert.equal(body.error?.code, -32001);
   });
@@ -98,6 +99,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     const res = await handler(req);
     assert.equal(res.status, 204);
     assert.ok(res.headers.get('access-control-allow-methods'));
+    assert.match(res.headers.get('cache-control') || '', /\bno-store\b/i);
   });
 
   it('initialize returns protocol version and Mcp-Session-Id header', async () => {

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -113,6 +113,24 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assert.ok(res.headers.get('mcp-session-id'), 'Mcp-Session-Id header must be present');
   });
 
+  it('bakes Cache-Control: no-store into JSON-RPC success and SSE-upgraded responses', async () => {
+    // getMcpCorsHeaders() threads no-store into every branch; assert the positive
+    // 200 paths (the #4497 incident class is a CACHED 200), not just the 401/204
+    // negative paths the other two assertions cover.
+    const json = await handler(makeReq('POST', initBody(50)));
+    assert.equal(json.status, 200);
+    assert.match(json.headers.get('cache-control') || '', /\bno-store\b/i, 'JSON-RPC 200 success must be no-store');
+
+    // Accept: text/event-stream upgrades the 200 to SSE; it must keep no-transform
+    // (framing) AND carry no-store (payload), and preserve Mcp-Session-Id.
+    const sse = await handler(makeReq('POST', initBody(51), { Accept: 'text/event-stream' }));
+    assert.equal(sse.status, 200);
+    assert.match(sse.headers.get('content-type') || '', /text\/event-stream/, 'must upgrade to an SSE stream');
+    assert.equal(sse.headers.get('cache-control'), 'no-store, no-transform', 'SSE success must be no-store + no-transform');
+    assert.ok(sse.headers.get('mcp-session-id'), 'Mcp-Session-Id must survive the SSE envelope');
+    await sse.body?.cancel();
+  });
+
   it('notifications/initialized returns 202 with no body', async () => {
     const req = makeReq('POST', { jsonrpc: '2.0', method: 'notifications/initialized', params: {} });
     const res = await handler(req);


### PR DESCRIPTION
## Summary

WorldMonitor now has an opt-in live production sweep for the cache/auth incident class from koala73/worldmonitor#4497. The sweep validates fake-auth 401/no-store behavior, anonymous public cacheability, premium fail-closed behavior, MCP protocol/cache posture, and OAuth metadata discovery without requiring committed secrets.

MCP responses also now set explicit `no-store, no-cache, no-transform` headers, so Vercel/Cloudflare cannot fall back to a public revalidation default on OPTIONS, auth failures, JSON-RPC responses, or SSE replay responses.

## Validation

- `TMPDIR=/private/tmp ./node_modules/.bin/tsx --test tests/mcp.test.mjs tests/live-api-cache-auth-regression.test.mjs` passes locally; the live sweep is skipped unless `LIVE_API_CACHE_TESTS=1`.
- `npm run typecheck:api` passes.
- `git diff --check` passes.
- `LIVE_API_CACHE_TESTS=1 TMPDIR=/private/tmp ./node_modules/.bin/tsx --test tests/live-api-cache-auth-regression.test.mjs` reproduces the current deployed MCP issue: 5/6 live checks pass, and MCP OPTIONS fails because production still returns `Cache-Control: public, max-age=0, must-revalidate` instead of `no-store`.
- Push hook passed typecheck, API typecheck, Convex type check, CJS syntax check, Unicode safety, boundary lint, safe HTML, Sentry coverage, rate-limit policy coverage, premium-fetch parity, edge bundle check, changed tests, edge function tests, and version sync.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
