### PR TITLE
fix(mcp): enforce no-store on MCP responses

### DIFF
--- a/api/mcp-proxy.ts
+++ b/api/mcp-proxy.ts
@@ -76,6 +76,10 @@ const SSE_CONNECT_TIMEOUT_MS = 10_000;
 const SSE_RPC_TIMEOUT_MS = process.env.NODE_TEST_CONTEXT ? 200 : 12_000;
 const MCP_PROTOCOL_VERSION = '2025-03-26';
 
+function withProxyNoStore(headers: Record<string, string> = {}): Record<string, string> {
+  return { ...headers, 'Cache-Control': 'no-store' };
+}
+
 const BLOCKED_HOST_PATTERNS = [
   /^localhost$/i,
   /^127\./,
@@ -452,9 +456,9 @@ async function handleCallTool(req: Request, cors: Record<string, string>, meta: 
 
 export default async function handler(req) {
   if (isDisallowedOrigin(req))
-    return new Response('Forbidden', { status: 403 });
+    return new Response('Forbidden', { status: 403, headers: withProxyNoStore() });
 
-  const cors = getCorsHeaders(req, 'GET, POST, OPTIONS');
+  const cors = withProxyNoStore(getCorsHeaders(req, 'GET, POST, OPTIONS'));
   if (req.method === 'OPTIONS')
     return new Response(null, { status: 204, headers: cors });
 

--- a/api/mcp-proxy.ts
+++ b/api/mcp-proxy.ts
@@ -451,7 +451,7 @@ async function handleCallTool(req: Request, cors: Record<string, string>, meta: 
   const result = isSseTransport(serverUrl)
     ? await mcpCallToolSse(serverUrl, toolName, toolArgs || {}, customHeaders || {})
     : await mcpCallTool(serverUrl, toolName, toolArgs || {}, customHeaders || {});
-  return jsonResponse({ result }, 200, { ...cors, 'Cache-Control': 'no-store' });
+  return jsonResponse({ result }, 200, cors);
 }
 
 export default async function handler(req) {
@@ -519,14 +519,14 @@ export default async function handler(req) {
       }),
       {
         status: 429,
-        headers: {
+        headers: withProxyNoStore({
           'Content-Type': 'application/json',
           'X-RateLimit-Limit': String(scoped.limit),
           'X-RateLimit-Remaining': '0',
           'X-RateLimit-Reset': String(scoped.reset),
           'Retry-After': String(retryAfter),
           ...cors,
-        },
+        }),
       },
     );
   }

--- a/api/mcp/auth.ts
+++ b/api/mcp/auth.ts
@@ -14,7 +14,7 @@ import {
   signInternalMcpRequest,
 } from '../../server/_shared/mcp-internal-hmac';
 import { validateProMcpTokenOrNull } from '../../server/_shared/pro-mcp-token';
-import { rpcError } from './rpc';
+import { rpcError, withMcpNoStore } from './rpc';
 import type {
   AuthResolution,
   AuthResolutionRejected,
@@ -140,7 +140,7 @@ export async function resolveAuthContext(
         ok: false,
         response: new Response(
           JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32603, message: 'Auth service temporarily unavailable. Try again.' } }),
-          { status: 503, headers: { 'Content-Type': 'application/json', 'Retry-After': '5', ...corsHeaders } },
+          { status: 503, headers: withMcpNoStore({ 'Content-Type': 'application/json', 'Retry-After': '5', ...corsHeaders }) },
         ),
       };
     }
@@ -149,7 +149,7 @@ export async function resolveAuthContext(
         ok: false,
         response: new Response(
           JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'Invalid or expired OAuth token. Re-authenticate via /oauth/token.' } }),
-          { status: 401, headers: { 'Content-Type': 'application/json', 'WWW-Authenticate': wwwAuthHeader(resourceMetadataUrl, 'invalid_token'), ...corsHeaders } },
+          { status: 401, headers: withMcpNoStore({ 'Content-Type': 'application/json', 'WWW-Authenticate': wwwAuthHeader(resourceMetadataUrl, 'invalid_token'), ...corsHeaders }) },
         ),
       };
     }
@@ -162,7 +162,7 @@ export async function resolveAuthContext(
       ok: false,
       response: new Response(
         JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'Authentication required. Use OAuth (/oauth/token) or pass your API key via X-WorldMonitor-Key header.' } }),
-        { status: 401, headers: { 'Content-Type': 'application/json', 'WWW-Authenticate': wwwAuthHeader(resourceMetadataUrl), ...corsHeaders } },
+        { status: 401, headers: withMcpNoStore({ 'Content-Type': 'application/json', 'WWW-Authenticate': wwwAuthHeader(resourceMetadataUrl), ...corsHeaders }) },
       ),
     };
   }
@@ -172,7 +172,7 @@ export async function resolveAuthContext(
       ok: false,
       response: new Response(
         JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'Invalid API key' } }),
-        { status: 401, headers: { 'Content-Type': 'application/json', 'WWW-Authenticate': wwwAuthHeader(resourceMetadataUrl, 'invalid_token'), ...corsHeaders } },
+        { status: 401, headers: withMcpNoStore({ 'Content-Type': 'application/json', 'WWW-Authenticate': wwwAuthHeader(resourceMetadataUrl, 'invalid_token'), ...corsHeaders }) },
       ),
     };
   }
@@ -202,7 +202,7 @@ export async function runProPreChecks(
     });
     return new Response(
       JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32603, message: 'Service temporarily unavailable, retry in a moment.' } }),
-      { status: 503, headers: { 'Content-Type': 'application/json', 'Retry-After': '5', ...corsHeaders } },
+      { status: 503, headers: withMcpNoStore({ 'Content-Type': 'application/json', 'Retry-After': '5', ...corsHeaders }) },
     );
   }
 
@@ -210,7 +210,7 @@ export async function runProPreChecks(
   if (!validation || validation.userId !== context.userId) {
     return new Response(
       JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'MCP authorization revoked. Re-authorize at https://worldmonitor.app/mcp-grant.' } }),
-      { status: 401, headers: { 'Content-Type': 'application/json', 'WWW-Authenticate': wwwAuthHeader(resourceMetadataUrl, 'invalid_token'), ...corsHeaders } },
+      { status: 401, headers: withMcpNoStore({ 'Content-Type': 'application/json', 'WWW-Authenticate': wwwAuthHeader(resourceMetadataUrl, 'invalid_token'), ...corsHeaders }) },
     );
   }
 
@@ -222,7 +222,7 @@ export async function runProPreChecks(
     captureSilentError(err, { tags: { route: 'api/mcp', step: 'pro-entitlement-recheck' }, ctx });
     return new Response(
       JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'Subscription not active.' } }),
-      { status: 401, headers: { 'Content-Type': 'application/json', 'WWW-Authenticate': wwwAuthHeader(resourceMetadataUrl, 'invalid_token'), ...corsHeaders } },
+      { status: 401, headers: withMcpNoStore({ 'Content-Type': 'application/json', 'WWW-Authenticate': wwwAuthHeader(resourceMetadataUrl, 'invalid_token'), ...corsHeaders }) },
     );
   }
   const tier = ent?.features?.tier ?? 0;
@@ -231,7 +231,7 @@ export async function runProPreChecks(
   if (!ent || tier < 1 || !mcpAccess || validUntil < Date.now()) {
     return new Response(
       JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32001, message: 'Subscription not active.' } }),
-      { status: 401, headers: { 'Content-Type': 'application/json', 'WWW-Authenticate': wwwAuthHeader(resourceMetadataUrl, 'invalid_token'), ...corsHeaders } },
+      { status: 401, headers: withMcpNoStore({ 'Content-Type': 'application/json', 'WWW-Authenticate': wwwAuthHeader(resourceMetadataUrl, 'invalid_token'), ...corsHeaders }) },
     );
   }
   return null;

--- a/api/mcp/dispatch.ts
+++ b/api/mcp/dispatch.ts
@@ -11,7 +11,7 @@ import { evaluateFreshness } from './freshness';
 import { applyJmespath } from './jmespath';
 import { reserveQuota } from './quota';
 import { TOOL_REGISTRY } from './registry/index';
-import { rpcError, rpcOk } from './rpc';
+import { rpcError, rpcOk, withMcpNoStore } from './rpc';
 import {
   emitTelemetry,
   principalIdForLog,
@@ -133,13 +133,13 @@ export async function dispatchToolsCall(
       if (reservation.reason === 'cap-exceeded') {
         return new Response(
           JSON.stringify({ jsonrpc: '2.0', id, error: { code: -32029, message: `Daily MCP quota exceeded (${PRO_DAILY_QUOTA_LIMIT}/day). Resets at next UTC midnight.` } }),
-          { status: 429, headers: { 'Content-Type': 'application/json', 'Retry-After': String(secondsUntilUtcMidnight()), ...corsHeaders } },
+          { status: 429, headers: withMcpNoStore({ 'Content-Type': 'application/json', 'Retry-After': String(secondsUntilUtcMidnight()), ...corsHeaders }) },
         );
       }
       // Hard-cap correctness: NEVER dispatch on reservation failure.
       return new Response(
         JSON.stringify({ jsonrpc: '2.0', id, error: { code: -32603, message: 'Service temporarily unavailable, retry in a moment.' } }),
-        { status: 503, headers: { 'Content-Type': 'application/json', 'Retry-After': '5', ...corsHeaders } },
+        { status: 503, headers: withMcpNoStore({ 'Content-Type': 'application/json', 'Retry-After': '5', ...corsHeaders }) },
       );
     }
     proRollback = reservation.rollback;

--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -122,7 +122,10 @@ function replayEventsAfter(sessionId: string, lastEventId: string): StoredSseEve
 function sseHeadersFrom(headers: Headers): Headers {
   const out = new Headers(headers);
   out.set('Content-Type', SSE_CONTENT_TYPE);
-  out.set('Cache-Control', 'no-cache, no-transform');
+  // no-store forbids storing the (sensitive Pro tool-result) payload, matching the
+  // no-store the JSON branches carry; no-transform stays load-bearing for SSE (it
+  // blocks proxy gzip/buffering that would corrupt the event-stream framing).
+  out.set('Cache-Control', 'no-store, no-transform');
   return out;
 }
 
@@ -187,7 +190,9 @@ function handleSseReplay(req: Request, corsHeaders: Record<string, string>): Res
 
   return new Response(createSseStream(events), {
     status: 200,
-    headers: { 'Content-Type': SSE_CONTENT_TYPE, 'Cache-Control': 'no-cache, no-transform', ...corsHeaders },
+    // no-store, no-transform: the replay carries previously-streamed tool-result
+    // data; no-store forbids caching it, no-transform preserves SSE framing.
+    headers: { 'Content-Type': SSE_CONTENT_TYPE, 'Cache-Control': 'no-store, no-transform', ...corsHeaders },
   });
 }
 

--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -17,7 +17,7 @@ import { dispatchToolsCall } from './dispatch';
 import { buildPromptResponse, PROMPT_LIST_RESPONSE } from './prompts/index';
 import { TOOL_LIST_BYTES, TOOL_LIST_RESPONSE } from './registry/index';
 import { buildResourceResponse, RESOURCE_LIST_RESPONSE } from './resources/index';
-import { rpcError, rpcOk } from './rpc';
+import { rpcError, rpcOk, withMcpNoStore } from './rpc';
 import { emitTelemetry, principalIdForLog } from './telemetry';
 import type { McpHandlerDeps } from './types';
 
@@ -152,13 +152,13 @@ function handleSseReplay(req: Request, corsHeaders: Record<string, string>): Res
   if (!clientAcceptsSse(req)) {
     return new Response(
       JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32600, message: 'SSE replay requires Accept: text/event-stream' } }),
-      { status: 406, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      { status: 406, headers: withMcpNoStore({ 'Content-Type': 'application/json', ...corsHeaders }) },
     );
   }
   if (!lastEventId) {
     return new Response(
       JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32600, message: 'Missing Last-Event-ID for SSE replay' } }),
-      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      { status: 400, headers: withMcpNoStore({ 'Content-Type': 'application/json', ...corsHeaders }) },
     );
   }
 
@@ -166,7 +166,7 @@ function handleSseReplay(req: Request, corsHeaders: Record<string, string>): Res
   if (!sessionId) {
     return new Response(
       JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32600, message: 'Missing Mcp-Session-Id for SSE replay' } }),
-      { status: 400, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      { status: 400, headers: withMcpNoStore({ 'Content-Type': 'application/json', ...corsHeaders }) },
     );
   }
 
@@ -181,7 +181,7 @@ function handleSseReplay(req: Request, corsHeaders: Record<string, string>): Res
           message: 'SSE replay cursor not found for this session; the stream may have expired or the reconnect may have reached a different server instance',
         },
       }),
-      { status: 404, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      { status: 404, headers: withMcpNoStore({ 'Content-Type': 'application/json', ...corsHeaders }) },
     );
   }
 
@@ -203,20 +203,20 @@ export async function mcpHandler(
   const corsHeaders = getPublicCorsHeaders('POST, GET, OPTIONS');
 
   if (req.method === 'OPTIONS') {
-    return new Response(null, { status: 204, headers: corsHeaders });
+    return new Response(null, { status: 204, headers: withMcpNoStore(corsHeaders) });
   }
   if (req.method === 'HEAD') {
-    return new Response(null, { status: 200, headers: { 'Content-Type': 'application/json', ...corsHeaders } });
+    return new Response(null, { status: 200, headers: withMcpNoStore({ 'Content-Type': 'application/json', ...corsHeaders }) });
   }
 
   // Origin validation: allow claude.ai/claude.com web clients; allow absent origin (desktop/CLI)
   const origin = req.headers.get('Origin');
   if (origin && origin !== 'https://claude.ai' && origin !== 'https://claude.com') {
-    return new Response('Forbidden', { status: 403, headers: corsHeaders });
+    return new Response('Forbidden', { status: 403, headers: withMcpNoStore(corsHeaders) });
   }
 
   if (req.method !== 'POST' && req.method !== 'GET') {
-    return new Response(null, { status: 405, headers: { Allow: 'POST, GET, HEAD, OPTIONS', ...corsHeaders } });
+    return new Response(null, { status: 405, headers: withMcpNoStore({ Allow: 'POST, GET, HEAD, OPTIONS', ...corsHeaders }) });
   }
 
   // Host-derived resource_metadata pointer matches api/oauth-protected-resource.ts.
@@ -289,7 +289,7 @@ export async function mcpHandler(
       }, { 'Mcp-Session-Id': sessionId, ...corsHeaders }));
     }
     case 'notifications/initialized':
-      return new Response(null, { status: 202, headers: corsHeaders });
+      return new Response(null, { status: 202, headers: withMcpNoStore(corsHeaders) });
     case 'ping':
       return maybeStreamJsonRpcResponse(req, rpcOk(id, {}, corsHeaders));
     case 'tools/list':

--- a/api/mcp/resources/index.ts
+++ b/api/mcp/resources/index.ts
@@ -34,7 +34,7 @@
 import type { McpAuthContext, McpHandlerDeps, McpResourceDef } from '../types';
 import { dispatchToolsCall } from '../dispatch';
 import { evaluateFreshness } from '../freshness';
-import { rpcError, rpcOk } from '../rpc';
+import { rpcError, rpcOk, withMcpNoStore } from '../rpc';
 // @ts-expect-error — JS module, no declaration file
 import { readJsonFromUpstash } from '../../_upstash-json.js';
 import { CHOKEPOINT_SLUGS } from './slugs';
@@ -258,7 +258,7 @@ export async function buildResourceResponse(
     // Without this, a correctly-implemented client back-off would retry
     // immediately on resources/read while waiting correctly on tools/call
     // — directly contradicting the auth-symmetry contract.
-    const errorHeaders: Record<string, string> = { 'Content-Type': 'application/json', ...corsHeaders };
+    const errorHeaders: Record<string, string> = withMcpNoStore({ 'Content-Type': 'application/json', ...corsHeaders });
     const retryAfter = dispatched.headers.get('Retry-After');
     if (retryAfter !== null) errorHeaders['Retry-After'] = retryAfter;
     return new Response(

--- a/api/mcp/rpc.ts
+++ b/api/mcp/rpc.ts
@@ -4,10 +4,14 @@ import { jsonResponse } from '../_json-response.js';
 // ---------------------------------------------------------------------------
 // JSON-RPC helpers
 // ---------------------------------------------------------------------------
+export function withMcpNoStore(extraHeaders: Record<string, string> = {}): Record<string, string> {
+  return { ...extraHeaders, 'Cache-Control': 'no-store' };
+}
+
 export function rpcOk(id: unknown, result: unknown, extraHeaders: Record<string, string> = {}): Response {
-  return jsonResponse({ jsonrpc: '2.0', id: id ?? null, result }, 200, extraHeaders);
+  return jsonResponse({ jsonrpc: '2.0', id: id ?? null, result }, 200, withMcpNoStore(extraHeaders));
 }
 
 export function rpcError(id: unknown, code: number, message: string, extraHeaders: Record<string, string> = {}): Response {
-  return jsonResponse({ jsonrpc: '2.0', id: id ?? null, error: { code, message } }, 200, extraHeaders);
+  return jsonResponse({ jsonrpc: '2.0', id: id ?? null, error: { code, message } }, 200, withMcpNoStore(extraHeaders));
 }

--- a/tests/mcp-proxy.test.mjs
+++ b/tests/mcp-proxy.test.mjs
@@ -88,6 +88,10 @@ function makeOptionsRequest(origin = 'https://worldmonitor.app') {
   });
 }
 
+function assertNoStore(res, label) {
+  assert.equal(res.headers.get('Cache-Control'), 'no-store', `${label} must include Cache-Control: no-store`);
+}
+
 // Minimal MCP server stub — returns valid JSON-RPC responses
 function makeMcpFetch({ initStatus = 200, listStatus = 200, callStatus = 200, tools = [], callResult = { content: [] } } = {}) {
   return async (_url, opts) => {
@@ -134,6 +138,7 @@ describe('api/mcp-proxy', () => {
     it('returns 401 when no X-WorldMonitor-Key is provided', async () => {
       const res = await handler(makeGetRequest({ serverUrl: 'https://mcp.example.com/mcp' }, 'https://worldmonitor.app', { authed: false }));
       assert.equal(res.status, 401);
+      assertNoStore(res, 'GET auth error');
     });
 
     it('returns 401 for curl-style request (no Origin, no key) — the #3723 bypass', async () => {
@@ -149,11 +154,13 @@ describe('api/mcp-proxy', () => {
     it('returns 401 for POST without key', async () => {
       const res = await handler(makePostRequest({ serverUrl: 'https://mcp.example.com/mcp', toolName: 'search' }, 'https://worldmonitor.app', { authed: false }));
       assert.equal(res.status, 401);
+      assertNoStore(res, 'POST auth error');
     });
 
     it('still returns 204 for OPTIONS preflight without key (preflights must not require auth)', async () => {
       const res = await handler(makeOptionsRequest());
       assert.equal(res.status, 204);
+      assertNoStore(res, 'OPTIONS preflight');
     });
 
     // wms_ session tokens are anonymous and freely mintable by any caller
@@ -215,11 +222,13 @@ describe('api/mcp-proxy', () => {
     it('returns 403 for disallowed origin', async () => {
       const res = await handler(makeGetRequest({ serverUrl: 'https://mcp.example.com/mcp' }, 'https://evil.com'));
       assert.equal(res.status, 403);
+      assertNoStore(res, 'disallowed origin');
     });
 
     it('returns 204 for OPTIONS preflight', async () => {
       const res = await handler(makeOptionsRequest());
       assert.equal(res.status, 204);
+      assertNoStore(res, 'OPTIONS preflight');
     });
 
     it('returns 405 for DELETE', async () => {
@@ -228,6 +237,7 @@ describe('api/mcp-proxy', () => {
         headers: { origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': ENTERPRISE_KEY },
       }));
       assert.equal(res.status, 405);
+      assertNoStore(res, 'DELETE method guard');
     });
 
     it('returns 405 for PUT', async () => {
@@ -246,6 +256,7 @@ describe('api/mcp-proxy', () => {
     it('returns 400 when serverUrl is missing', async () => {
       const res = await handler(makeGetRequest());
       assert.equal(res.status, 400);
+      assertNoStore(res, 'GET validation error');
       const data = await res.json();
       assert.match(data.error, /serverUrl/i);
     });
@@ -297,6 +308,7 @@ describe('api/mcp-proxy', () => {
       globalThis.fetch = makeMcpFetch({ tools: sampleTools });
       const res = await handler(makeGetRequest({ serverUrl: 'https://mcp.example.com/mcp' }));
       assert.equal(res.status, 200);
+      assertNoStore(res, 'GET list success');
       const data = await res.json();
       assert.ok(Array.isArray(data.tools));
       assert.equal(data.tools.length, 1);
@@ -315,6 +327,7 @@ describe('api/mcp-proxy', () => {
       globalThis.fetch = makeMcpFetch({ initStatus: 401 });
       const res = await handler(makeGetRequest({ serverUrl: 'https://mcp.example.com/mcp' }));
       assert.equal(res.status, 422);
+      assertNoStore(res, 'GET upstream error');
     });
 
     it('returns 422 when upstream returns JSON-RPC error', async () => {
@@ -387,6 +400,7 @@ describe('api/mcp-proxy', () => {
     it('returns 400 when serverUrl is missing', async () => {
       const res = await handler(makePostRequest({ toolName: 'search' }));
       assert.equal(res.status, 400);
+      assertNoStore(res, 'POST validation error');
       const data = await res.json();
       assert.match(data.error, /serverUrl/i);
     });
@@ -655,6 +669,7 @@ describe('api/mcp-proxy', () => {
         { extra: { 'cf-connecting-ip': ip } },
       ));
       assert.equal(res.status, 429, 'must return HTTP 429 on rate-limit hit');
+      assertNoStore(res, 'rate-limit error');
       assert.ok(res.headers.get('Retry-After'), 'must include Retry-After header');
       assert.ok(Number(res.headers.get('Retry-After')) >= 1, 'Retry-After must be >= 1s');
       const body = await res.json();

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -177,6 +177,24 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     assertNoStore(invalidMethod, 'JSON-RPC error');
   });
 
+  it('SSE-upgraded success carries no-store, no-transform and preserves the session id', async () => {
+    // Accept: text/event-stream makes maybeStreamJsonRpcResponse upgrade the 200
+    // initialize reply to an SSE stream. The streamed reply (which carries the
+    // tool/resource result data on tools/call) must keep no-transform for framing
+    // AND now carry no-store so the payload is not cached, and still expose the
+    // Mcp-Session-Id through the SSE envelope.
+    const res = await handler(makeReq('POST', initBody(40), { Accept: 'text/event-stream' }));
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get('Content-Type') ?? '', /text\/event-stream/, 'must upgrade to an SSE stream');
+    assert.equal(
+      res.headers.get('Cache-Control'),
+      'no-store, no-transform',
+      'SSE success must be no-store (payload not cached) + no-transform (SSE framing preserved)',
+    );
+    assert.ok(res.headers.get('mcp-session-id'), 'Mcp-Session-Id must survive the SSE envelope');
+    await res.body?.cancel();
+  });
+
   // --- logging/setLevel ---
 
   it('logging/setLevel with valid level returns success', async () => {

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -37,6 +37,10 @@ function initBody(id = 1) {
   };
 }
 
+function assertNoStore(res, label) {
+  assert.equal(res.headers.get('Cache-Control'), 'no-store', `${label} must include Cache-Control: no-store`);
+}
+
 let handler;
 let evaluateFreshness;
 
@@ -132,6 +136,45 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     const res = await handler(req);
     const body = await res.json();
     assert.equal(body.error?.code, -32600);
+  });
+
+  it('sets Cache-Control: no-store on representative MCP success and error responses', async () => {
+    const preflight = await handler(new Request(BASE_URL, {
+      method: 'OPTIONS',
+      headers: { origin: 'https://claude.ai' },
+    }));
+    assert.equal(preflight.status, 204);
+    assertNoStore(preflight, 'OPTIONS preflight');
+
+    const unauthenticated = await handler(new Request(BASE_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(initBody()),
+    }));
+    assert.equal(unauthenticated.status, 401);
+    assertNoStore(unauthenticated, 'auth error');
+
+    const initialized = await handler(makeReq('POST', initBody(20)));
+    assert.equal(initialized.status, 200);
+    assertNoStore(initialized, 'initialize success');
+    assert.ok(initialized.headers.get('Mcp-Session-Id'), 'Mcp-Session-Id header must still be present');
+
+    const acknowledged = await handler(makeReq('POST', {
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+      params: {},
+    }));
+    assert.equal(acknowledged.status, 202);
+    assertNoStore(acknowledged, 'notification acknowledgement');
+
+    const invalidMethod = await handler(makeReq('POST', {
+      jsonrpc: '2.0',
+      id: 21,
+      method: 'nonexistent/method',
+      params: {},
+    }));
+    assert.equal(invalidMethod.status, 200);
+    assertNoStore(invalidMethod, 'JSON-RPC error');
   });
 
   // --- logging/setLevel ---


### PR DESCRIPTION
## Summary
MCP and MCP proxy responses now consistently send `Cache-Control: no-store` across representative JSON-RPC, auth, validation, quota, and proxy list/call branches. Before this fix, only some helper-driven or POST success paths carried the header, leaving preflight, auth, GET/list, validation, and rate-limit responses without the defensive cache directive.

This keeps MCP payload shapes, CORS headers, OAuth challenge metadata, `Retry-After`, and SSE streaming behavior intact while making JSON and empty response branches cache-defensive by default.

Closes koala73/worldmonitor#4496.

## Verification
- Red before fix: `./node_modules/.bin/tsx --test tests/mcp.test.mjs tests/mcp-proxy.test.mjs` failed 12 new no-store assertions across MCP and proxy branches.
- `./node_modules/.bin/tsx --test tests/mcp.test.mjs tests/mcp-proxy.test.mjs` passed, 168/168.
- `./node_modules/.bin/tsx --test tests/mcp-resources.test.mjs tests/mcp-protocol-conformance.test.mjs` passed, 25/25.
- `npm run typecheck:api` passed.
- `git diff --check` passed.
- Pre-push hook on `git push -u origin HEAD` passed full typecheck, API typecheck, Convex typecheck, CJS syntax, Unicode, boundary, safe HTML, Sentry coverage, rate-limit policy, premium-fetch parity, edge bundle, changed tests, edge function tests, and version sync.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)