### PR TITLE
fix(sentry): suppress Baidu-TTS CSP noise + diagnose MCP brief 401

### DIFF
--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -279,7 +279,21 @@ export const RPC_TOOLS: ToolDef[] = [
         body: briefBody,
         signal: AbortSignal.timeout(22_000),
       });
-      if (!res.ok) throw new Error(`get-country-intel-brief HTTP ${res.status}`);
+      if (!res.ok) {
+        // Surface the gateway's error code in the thrown message so Sentry
+        // groups the failure by ROOT CAUSE, not just status. This is the only
+        // tool that appends its own `?context=` query param to the signed URL,
+        // so a residual internal-HMAC drift (canonicalisation / URL-length
+        // truncation in transit) surfaces as `invalid_internal_mcp_signature`,
+        // while an expired/free caller surfaces as `insufficient_entitlement`
+        // — previously indistinguishable from the bare `HTTP 401`
+        // (WORLDMONITOR-T8 — recurred after the 2026-06-12 ?rpc-echo fix). Body
+        // read is best-effort; a read failure must not mask the status.
+        const detail = await res.text().catch(() => '');
+        let code = '';
+        try { code = String((JSON.parse(detail) as { error?: unknown }).error ?? ''); } catch { code = detail.slice(0, 120); }
+        throw new Error(`get-country-intel-brief HTTP ${res.status}${code ? `: ${code}` : ''}`);
+      }
       const result = await res.json() as Record<string, unknown>;
       const resultSources = collectMcpBriefSources(Array.isArray(result.sources) ? result.sources as DigestItemForBrief[] : [], 6);
       return { ...result, sources: resultSources.length > 0 ? resultSources : sources };

--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -291,7 +291,12 @@ export const RPC_TOOLS: ToolDef[] = [
         // read is best-effort; a read failure must not mask the status.
         const detail = await res.text().catch(() => '');
         let code = '';
-        try { code = String((JSON.parse(detail) as { error?: unknown }).error ?? ''); } catch { code = detail.slice(0, 120); }
+        // `error` is a string today (e.g. `invalid_internal_mcp_signature`,
+        // `insufficient_entitlement`), but JSON.stringify any non-string shape so
+        // an object envelope renders readable JSON instead of `[object Object]`,
+        // which would defeat the whole point of surfacing the code. Bound BOTH
+        // shapes so the Sentry title can't bloat on a long body.
+        try { const e = (JSON.parse(detail) as { error?: unknown }).error ?? ''; code = (typeof e === 'string' ? e : JSON.stringify(e)).slice(0, 120); } catch { code = detail.slice(0, 120); }
         throw new Error(`get-country-intel-brief HTTP ${res.status}${code ? `: ${code}` : ''}`);
       }
       const result = await res.json() as Record<string, unknown>;

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,6 +77,23 @@ function shouldSuppressCspViolation(
       if (new URL(blockedURI).protocol === 'https:') return true;
     } catch { /* scheme-only values fall through */ }
   }
+  // Baidu read-aloud / TTS browser extensions (common in the Chinese market)
+  // inject an `<audio src="http://tts.baidu.com/text2audio?...&text=<selected
+  // text>">` element to speak page content when the user clicks/selects it. We
+  // never load tts.baidu.com (it appears nowhere in src) and our media-src
+  // allows only `'self' data: blob: https:`, so this http: load is third-party
+  // mixed-content the CSP correctly blocks — the audio never plays regardless of
+  // our code. UNLIKE the https: media-src rule above this is NOT protocol-gated
+  // on policy detection: it is host-pinned to an exact third-party hostname we
+  // provably never reference, so suppressing its http: block cannot mask a
+  // first-party mixed-content regression (we ship no http:// media). Parsed
+  // hostname match (not substring) so a `tts.baidu.com.evil.com` lookalike still
+  // surfaces (WORLDMONITOR-TW — map-popup description read-aloud, 1 user).
+  if (directive === 'media-src') {
+    try {
+      if (new URL(blockedURI).hostname === 'tts.baidu.com') return true;
+    } catch { /* scheme-only values fall through */ }
+  }
   // default-src + HTTP: mixed-content block on a fetch type we set no explicit
   // directive for — i.e. browser link-prefetch ("Preload pages" speculation) or
   // an extension article-prefetcher. News article links render as plain

--- a/tests/csp-filter.test.mjs
+++ b/tests/csp-filter.test.mjs
@@ -96,6 +96,26 @@ describe('CSP violation filter (shouldSuppressCspViolation)', () => {
     });
   });
 
+  describe('media-src tts.baidu.com extension injection — WORLDMONITOR-TW', () => {
+    // Baidu read-aloud / TTS extensions inject `<audio src="http://tts.baidu.com/
+    // text2audio?...&text=...">` to speak page content. http: mixed-content the
+    // CSP correctly blocks; we never load tts.baidu.com, so it is third-party
+    // noise. Host-pinned (not protocol-gated) — works even with cspMediaSrcAllowsHttps
+    // false because the http: block can never originate from our own bundle.
+    it('suppresses http: media-src for tts.baidu.com regardless of policy detection', () => {
+      assert.ok(suppress('enforce', 'media-src', 'http://tts.baidu.com/text2audio?lan=en&text=hello', '', false, null, false));
+      assert.ok(suppress('enforce', 'media-src', 'http://tts.baidu.com/text2audio?lan=en&text=hello', '', false, null, true));
+    });
+
+    it('does NOT suppress a tts.baidu.com.evil.com lookalike host', () => {
+      assert.ok(!suppress('enforce', 'media-src', 'http://tts.baidu.com.evil.com/text2audio?text=x', '', false, null, true));
+    });
+
+    it('does NOT suppress http: media-src for an unrelated host (real mixed-content)', () => {
+      assert.ok(!suppress('enforce', 'media-src', 'http://insecure.example.com/stream.m3u8', '', false, null, true));
+    });
+  });
+
   describe('default-src HTTP mixed-content suppression — WORLDMONITOR-S0', () => {
     // Browser link-prefetch / extension fetching a feed-supplied http article
     // URL; falls to the default-src fallback (no prefetch-src set). HTTPS-only


### PR DESCRIPTION
## Summary

Two fixes surfaced by a `/sentry-triage` sweep of the 7 unresolved issues.

- **WORLDMONITOR-TW** (CSP `media-src` blocked `http://tts.baidu.com/text2audio`): a Baidu read-aloud browser **extension** injects an `<audio>` element to speak a clicked map-popup description. `text2audio` is nowhere in our code and our `media-src` allows only `https:`, so this is pure third-party mixed-content noise. Host-pin `tts.baidu.com` in `shouldSuppressCspViolation`'s `media-src` gate — **parsed-hostname** match (a `tts.baidu.com.evil.com` lookalike still surfaces), and **not** protocol-gated since an `http:` block can never come from our own bundle. +3 `csp-filter` tests.
- **WORLDMONITOR-T8** (`get-country-intel-brief HTTP 401`, recurring after the 2026-06-12 `?rpc`-echo HMAC fix): this is the **only** MCP tool that appends its own `?context=` query to the signed URL, so a residual HMAC/URL-truncation drift (`invalid_internal_mcp_signature`) was indistinguishable from an expired/free caller (`insufficient_entitlement`) — the thrown error discarded the gateway body. Now capture the gateway error code in the thrown message so the **next occurrence self-classifies** in Sentry. Root-cause + fix options tracked in **#4503**.

### Triage outcome (all 7 issues)
- **Resolved in Sentry** (next release): TW (filtered here), TQ (intentional info telemetry — watchdog success counter-signal).
- **Code change here**: TW (CSP filter), T8 (diagnostic).
- **Filed as issues**: #4503 (T8 root-cause), #4504 (PD/TX Convex platform `Server Error` at error level).
- **Left as deliberate signals**: SR (Convex 500 already handled at warning+503/retry), TP (`Failed to fetch (api.worldmonitor.app)` — policy surfaces first-party-API transients on purpose).

Note: the error-filter config (`ignoreErrors`/`beforeSend`) now lives in `src/bootstrap/sentry-init.ts`; only the CSP-violation filter remains in `src/main.ts`.

## Test plan

- [x] `npm run typecheck` + `typecheck:api`
- [x] `npm run lint` (biome + safe-html) + `lint:md`
- [x] `npm run test:data` — 11793 pass / 0 fail (incl. the +3 new CSP-filter tests and MCP parity)
- [x] Edge bundle (esbuild, 19 fns) + edge-function tests (204) + `version:check`
- [x] `VITE_VARIANT=full vite build` green; `dashboard-critical-css` build-gated tests pass
- [ ] After deploy: confirm WORLDMONITOR-T8's next event carries the gateway error code; no new `tts.baidu.com` CSP events

https://claude.ai/code/session_017SVGMcbnXFEPK8hghKRrRN