### PR TITLE
fix(sentry): suppress zero-frame SyntaxError 'Unexpected token <' deploy-skew noise

### DIFF
--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -630,6 +630,19 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
           // safety as the `Failed to fetch` / `signal timed out` blocks above
           // (WORLDMONITOR-RF).
           || /^(?:SyntaxError: )?Unexpected EOF$/.test(msg)
+          // `Unexpected token '<'` with zero captured frames = HTML served
+          // where JS was expected: a stale hashed chunk after a deploy (the
+          // SPA index.html fallback starts with `<!DOCTYPE html>`), or a
+          // captive-portal / proxy / ISP HTML interstitial intercepting a
+          // `<script>` / dynamic-import fetch. The `<` is dispositive — our
+          // already-parsed, build-time-validated first-party bundle cannot
+          // emit a parse error on its own source, and a genuine first-party
+          // SyntaxError carries a source-mapped .ts frame (hasFirstParty →
+          // preserved). The `hasAnyStack`-gated `Unexpected token/keyword`
+          // gate below misses this zero-frame variant. `(?:SyntaxError: )?`
+          // mirrors the EOF gate above: some engines embed the type in the
+          // `value` field (WORLDMONITOR-TY).
+          || /^(?:SyntaxError: )?Unexpected token '<'/.test(msg)
           // Firefox's wording for a failed `fetch()` — the engine-emitted
           // equivalent of Chrome's bare `Failed to fetch` (above) and Safari's
           // `Load failed`. Surfaces via `onunhandledrejection` with zero captured


### PR DESCRIPTION
## Summary

- Suppresses `SyntaxError: Unexpected token '<'` events that arrive with **zero captured frames** — the dispositive signature of HTML served where JS was expected.
- Root cause is never a first-party bug: a stale hashed chunk after a deploy (the SPA `index.html` fallback begins `<!DOCTYPE html>`), or a captive-portal / proxy / ISP HTML interstitial intercepting a `<script>` / dynamic-import fetch. Our already-parsed, build-validated bundle cannot emit a parse error on its own source, and a genuine first-party `SyntaxError` carries a source-mapped `.ts` frame (→ `hasFirstParty`, preserved).
- The two existing `Unexpected token` gates both require a frame (`hasAnyStack && !hasFirstParty`, or a maplibre/deck-stack vendor frame), so the **zero-frame** variant slipped through and surfaced as `WORLDMONITOR-TY`.
- Fix adds `/^(?:SyntaxError: )?Unexpected token '<'/` to the existing `!hasFirstParty` block in `beforeSend`, alongside its siblings (`Unexpected EOF`, bare `Failed to fetch`, `NetworkError`). Matched on `'<'` specifically so other `Unexpected token` variants stay with the existing `hasAnyStack` gate. `(?:SyntaxError: )?` mirrors the EOF gate (some engines embed the type in the `value` field).

Filter lives in `beforeSend` with `!hasFirstParty` stack-gating (not `ignoreErrors`) per the project's Sentry-noise policy: a message that *could* come from our own minified bundle must be stack-gated to avoid blinding us to real first-party bugs.

## Test plan

- [x] `npm run typecheck` + `typecheck:api`
- [x] `npm run lint` (biome) + `lint:md`
- [x] `npm run version:check`
- [x] CJS syntax check (`scripts/*.cjs`)
- [x] `npm run test:data` — 11790 pass / 0 fail / 6 skipped
- [x] Edge bundle check (19 fns) + `tests/edge-functions.test.mjs` (204 pass)
- [x] `VITE_VARIANT=full vite build` + `tests/dashboard-critical-css.test.mjs` (8 pass)
- [x] Regex unit-checked: matches `Unexpected token '<'` / `SyntaxError: Unexpected token '<'`; ignores `';'`, `'else'`
- [x] `WORLDMONITOR-TY` resolved in Sentry (`inNextRelease: true`) — auto-reopens if it recurs after deploy

https://claude.ai/code/session_01NKoxTiKkwFfcaW3nmHWQL7