### PR TITLE
fix(mcp): keep country brief context out of signed URL

### DIFF
--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -238,7 +238,7 @@ export const RPC_TOOLS: ToolDef[] = [
       // Fetch current geopolitical headlines to ground the LLM (budget: 2 s — cached endpoint).
       // Without context the model hallucinates events — real headlines anchor it.
       // 2 s + 22 s brief = 24 s worst-case; 6 s margin before the 30 s Edge kill.
-      let contextParam = '';
+      let contextSnapshot = '';
       let sources: McpBriefSource[] = [];
       try {
         const digestUrl = `${base}/api/news/v1/list-feed-digest?variant=full&lang=en`;
@@ -263,15 +263,19 @@ export const RPC_TOOLS: ToolDef[] = [
           const sourceLines = sources.length > 0 ? ['Brief source articles:', ...briefSourceContextLines(sources)] : [];
           const headlineLines = groundingItems.map(item => item.title ?? '').filter(Boolean);
           const contextLines = [...sourceLines, 'Headlines:', ...headlineLines].join('\n');
-          if (contextLines.trim()) contextParam = encodeURIComponent(contextLines.slice(0, 4000));
+          if (contextLines.trim()) contextSnapshot = contextLines.slice(0, 4000);
         }
       } catch { /* proceed without context — better than failing */ }
 
-      const briefUrl = contextParam
-        ? `${base}/api/intelligence/v1/get-country-intel-brief?context=${contextParam}`
-        : `${base}/api/intelligence/v1/get-country-intel-brief`;
-
-      const briefBody = JSON.stringify({ country_code: countryCode, framework: String(params.framework ?? '') });
+      const briefUrl = `${base}/api/intelligence/v1/get-country-intel-brief`;
+      // Keep grounding context out of the signed URL; the gateway's POST-to-GET
+      // compatibility path promotes scalar JSON body fields for this GET handler.
+      const briefPayload: { country_code: string; framework: string; context?: string } = {
+        country_code: countryCode,
+        framework: String(params.framework ?? ''),
+      };
+      if (contextSnapshot) briefPayload.context = contextSnapshot;
+      const briefBody = JSON.stringify(briefPayload);
       const briefAuth = await buildAuthHeaders(context, 'POST', briefUrl, briefBody);
       const res = await fetch(briefUrl, {
         method: 'POST',
@@ -279,7 +283,17 @@ export const RPC_TOOLS: ToolDef[] = [
         body: briefBody,
         signal: AbortSignal.timeout(22_000),
       });
-      if (!res.ok) throw new Error(`get-country-intel-brief HTTP ${res.status}`);
+      if (!res.ok) {
+        const detail = await res.text().catch(() => '');
+        let code = '';
+        try {
+          const parsed = JSON.parse(detail) as { error?: unknown };
+          code = typeof parsed.error === 'string' ? parsed.error : '';
+        } catch {
+          code = detail.slice(0, 120);
+        }
+        throw new Error(`get-country-intel-brief HTTP ${res.status}${code ? `: ${code}` : ''}`);
+      }
       const result = await res.json() as Record<string, unknown>;
       const resultSources = collectMcpBriefSources(Array.isArray(result.sources) ? result.sources as DigestItemForBrief[] : [], 6);
       return { ...result, sources: resultSources.length > 0 ? resultSources : sources };

--- a/api/mcp/registry/rpc-tools.ts
+++ b/api/mcp/registry/rpc-tools.ts
@@ -290,7 +290,7 @@ export const RPC_TOOLS: ToolDef[] = [
           const parsed = JSON.parse(detail) as { error?: unknown };
           code = typeof parsed.error === 'string' ? parsed.error : '';
         } catch {
-          code = detail.slice(0, 120);
+          code = detail.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 120);
         }
         throw new Error(`get-country-intel-brief HTTP ${res.status}${code ? `: ${code}` : ''}`);
       }

--- a/server/worldmonitor/intelligence/v1/get-country-intel-brief.ts
+++ b/server/worldmonitor/intelligence/v1/get-country-intel-brief.ts
@@ -97,6 +97,8 @@ export async function getCountryIntelBrief(
   let lang = 'en';
   try {
     const url = new URL(ctx.request.url);
+    // MCP sends `context` in the signed POST body; the gateway promotes scalar
+    // body fields into query params before this generated GET handler runs.
     const rawContextSnapshot = (url.searchParams.get('context') || '').trim().slice(0, 4000);
     sources = parseCountryBriefSources(rawContextSnapshot);
     contextSnapshot = sanitizeForPrompt(rawContextSnapshot);

--- a/tests/mcp-news-auth-docs-contract.test.mjs
+++ b/tests/mcp-news-auth-docs-contract.test.mjs
@@ -21,7 +21,7 @@ function rpcTool(name) {
   return tool;
 }
 
-async function captureRpcFetches(toolName, params) {
+async function captureRpcFetches(toolName, params, opts = {}) {
   const calls = [];
   let result;
   globalThis.fetch = async (input, init = {}) => {
@@ -35,6 +35,13 @@ async function captureRpcFetches(toolName, params) {
         categories: {
           world: {
             items: [
+              ...(opts.longCountryHeadline ? [{
+                title: `United States ${'%'.repeat(3900)}`,
+                source: 'Long Wire',
+                link: 'https://example.com/long-context',
+                publishedAt: '2026-06-07T00:00:00.000Z',
+                snippet: 'Large context headline used to prove the signed URL stays short.',
+              }] : []),
               {
                 title: 'United States headline used for MCP grounding',
                 source: 'Example Wire',
@@ -122,9 +129,24 @@ describe('MCP news/auth public contract', () => {
     assert.deepEqual(countryResult.sources, worldResult.sources);
     const countryBriefCall = countryCalls.find((call) => new URL(call.url).pathname === '/api/intelligence/v1/get-country-intel-brief');
     assert.ok(countryBriefCall, 'get_country_brief should call country brief endpoint');
-    const context = new URL(countryBriefCall.url).searchParams.get('context') || '';
-    assert.match(decodeURIComponent(context), /Source \[1\]: \{"title":"United States headline used for MCP grounding","source":"Example Wire","url":"https:\/\/example\.com\/world-grounding","publishedAt":"2026-06-07T00:00:00.000Z"\}/);
-    assert.doesNotMatch(decodeURIComponent(context), /russia-house/);
+    const context = JSON.parse(String(countryBriefCall.init.body)).context || '';
+    assert.match(context, /Source \[1\]: \{"title":"United States headline used for MCP grounding","source":"Example Wire","url":"https:\/\/example\.com\/world-grounding","publishedAt":"2026-06-07T00:00:00.000Z"\}/);
+    assert.doesNotMatch(context, /russia-house/);
+  });
+
+  it('get_country_brief keeps large grounding context out of the signed URL', async () => {
+    const { calls } = await captureRpcFetches('get_country_brief', { country_code: 'US' }, { longCountryHeadline: true });
+    const countryBriefCall = calls.find((call) => new URL(call.url).pathname === '/api/intelligence/v1/get-country-intel-brief');
+    assert.ok(countryBriefCall, 'get_country_brief should call country brief endpoint');
+
+    const url = new URL(countryBriefCall.url);
+    assert.equal(url.searchParams.has('context'), false, 'grounding context must not travel in the signed URL query');
+    assert.ok(countryBriefCall.url.length < 512, `signed URL should stay short, got ${countryBriefCall.url.length} chars`);
+
+    const body = JSON.parse(String(countryBriefCall.init.body));
+    assert.equal(body.country_code, 'US');
+    assert.match(body.context, /Brief source articles:/);
+    assert.ok(body.context.length >= 3900, `expected large body context, got ${body.context.length} chars`);
   });
 
   it('RPC brief output schemas expose structured sources', () => {

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -2775,6 +2775,95 @@ describe('api/mcp.ts — U7 Pro-path', () => {
     assert.equal(await verifyInternalMcpRequest(tamperedReq, HMAC_SECRET), null, 'same signature must not verify if context is moved back into the URL');
   });
 
+  it('edge: Pro get_country_brief surfaces gateway error detail for Sentry grouping', async () => {
+    const scenarios = [
+      {
+        name: 'structured HMAC 401',
+        expectedLog: 'warn',
+        makeResponse: () => new Response(
+          JSON.stringify({ error: 'invalid_internal_mcp_signature' }),
+          { status: 401, headers: { 'Content-Type': 'application/json' } },
+        ),
+        assertMessage: (message) => {
+          assert.equal(message, 'get-country-intel-brief HTTP 401: invalid_internal_mcp_signature');
+        },
+      },
+      {
+        name: 'HTML CDN 503',
+        expectedLog: 'error',
+        makeResponse: () => new Response(
+          '<!DOCTYPE html><html><head><title>Bad Gateway</title></head><body>Cloudflare outage</body></html>',
+          { status: 503, headers: { 'Content-Type': 'text/html' } },
+        ),
+        assertMessage: (message) => {
+          assert.equal(message, 'get-country-intel-brief HTTP 503: Bad Gateway Cloudflare outage');
+          assert.doesNotMatch(message, /<[^>]*>/, 'HTML tags must not leak into the Sentry/log title');
+        },
+      },
+      {
+        name: 'unreadable body 503',
+        expectedLog: 'error',
+        makeResponse: () => ({ ok: false, status: 503, text: async () => { throw new Error('body locked'); } }),
+        assertMessage: (message) => {
+          assert.equal(message, 'get-country-intel-brief HTTP 503');
+        },
+      },
+    ];
+
+    for (const scenario of scenarios) {
+      const { deps } = makeProDeps();
+      const warnCalls = [];
+      const errorCalls = [];
+      const origWarn = console.warn;
+      const origError = console.error;
+      console.warn = (...args) => { warnCalls.push(args); };
+      console.error = (...args) => { errorCalls.push(args); };
+      try {
+        globalThis.fetch = async (url) => {
+          const { pathname } = new URL(String(url));
+          if (pathname === '/api/news/v1/list-feed-digest') {
+            return new Response(JSON.stringify({
+              categories: {
+                world: {
+                  items: [{
+                    title: 'Iran headline for failing country brief',
+                    source: 'Context Wire',
+                    link: 'https://example.com/iran-failure',
+                    publishedAt: '2026-06-07T00:00:00.000Z',
+                    snippet: 'Iran context item used before the brief endpoint fails.',
+                  }],
+                },
+              },
+            }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+          }
+          if (pathname === '/api/intelligence/v1/get-country-intel-brief') {
+            return scenario.makeResponse();
+          }
+          return new Response('', { status: 200 });
+        };
+
+        const res = await mcpHandler(proReq('POST', callBody('get_country_brief', {
+          country_code: 'IR',
+          framework: 'PMESII-PT',
+        })), deps);
+        assert.equal(res.status, 200, `${scenario.name}: JSON-RPC tool errors stay HTTP 200`);
+        const rpc = await res.json();
+        assert.equal(rpc.error?.code, -32603, `${scenario.name}: tool failure should be a JSON-RPC internal error`);
+
+        const expectedCalls = scenario.expectedLog === 'warn' ? warnCalls : errorCalls;
+        const unexpectedCalls = scenario.expectedLog === 'warn' ? errorCalls : warnCalls;
+        const mcpLogs = expectedCalls.filter((args) => args[0] === '[mcp] tool execution error:');
+        assert.equal(mcpLogs.length, 1, `${scenario.name}: expected one MCP execution log`);
+        assert.equal(unexpectedCalls.some((args) => args[0] === '[mcp] tool execution error:'), false, `${scenario.name}: wrong console severity`);
+        const loggedError = mcpLogs[0][1];
+        scenario.assertMessage(loggedError instanceof Error ? loggedError.message : String(loggedError));
+      } finally {
+        console.warn = origWarn;
+        console.error = origError;
+      }
+    }
+  });
+
   it('edge: cache-only tool for Pro user goes through INCR/DECR path (counts toward 50/day)', async () => {
     const { deps, pipe } = makeProDeps();
     process.env.UPSTASH_REDIS_REST_URL = 'https://stub.upstash';

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -2694,6 +2694,87 @@ describe('api/mcp.ts — U7 Pro-path', () => {
     assert.match(sig, /^\d{10}\.[A-Za-z0-9_-]+$/, 'signature must be <ts>.<base64url-sig>');
   });
 
+  it('edge: Pro get_country_brief signs a short URL and sends grounding context in the POST body', async () => {
+    const { deps } = makeProDeps();
+    const captured = [];
+    globalThis.fetch = async (url, init = {}) => {
+      const call = {
+        url: String(url),
+        method: init.method || 'GET',
+        headers: new Headers(init.headers),
+        body: typeof init.body === 'string' ? init.body : '',
+      };
+      captured.push(call);
+      const { pathname } = new URL(call.url);
+
+      if (pathname === '/api/news/v1/list-feed-digest') {
+        const items = Array.from({ length: 15 }, (_, index) => ({
+          title: `Iran ${index} ${'%'.repeat(300)}`,
+          source: 'Context Wire',
+          link: `https://example.com/iran-${index}`,
+          publishedAt: '2026-06-07T00:00:00.000Z',
+          snippet: 'Long Iran grounding item used to keep the MCP signed URL below proxy limits.',
+        }));
+        return new Response(JSON.stringify({ categories: { world: { items } } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      if (pathname === '/api/intelligence/v1/get-country-intel-brief') {
+        return new Response(JSON.stringify({ brief: 'Grounded country brief.' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      throw new Error(`Unexpected fetch URL: ${call.url}`);
+    };
+
+    const res = await mcpHandler(proReq('POST', callBody('get_country_brief', {
+      country_code: 'IR',
+      framework: 'PMESII-PT',
+    })), deps);
+    assert.equal(res.status, 200);
+    const rpc = await res.json();
+    assert.ok(rpc.result?.content, 'tool call must return content');
+
+    const countryCall = captured.find((call) => new URL(call.url).pathname === '/api/intelligence/v1/get-country-intel-brief');
+    assert.ok(countryCall, 'country brief fetch must run');
+    const countryUrl = new URL(countryCall.url);
+    assert.equal(countryUrl.searchParams.has('context'), false, 'context must not be signed in the URL query');
+    assert.ok(countryCall.url.length < 200, `signed URL should stay short, got ${countryCall.url.length} chars`);
+
+    const body = JSON.parse(countryCall.body);
+    assert.equal(body.country_code, 'IR');
+    assert.equal(body.framework, 'PMESII-PT');
+    assert.match(body.context, /Brief source articles:/);
+    assert.match(body.context, /Headlines:/);
+    assert.match(body.context, /Iran/);
+    assert.ok(body.context.length > 1000, `expected large grounding context, got ${body.context.length} chars`);
+    assert.ok(body.context.length <= 4000, `grounding context should be bounded to 4000 chars, got ${body.context.length}`);
+
+    assert.ok(countryCall.headers.get('x-wm-mcp-internal'), 'X-WM-MCP-Internal must be set');
+    assert.equal(countryCall.headers.get('x-wm-mcp-user-id'), PRO_USER_ID);
+    assert.equal(countryCall.headers.get('x-worldmonitor-key'), null, 'X-WorldMonitor-Key must NOT be set for Pro');
+
+    const { verifyInternalMcpRequest } = await import(`../server/_shared/mcp-internal-hmac.ts?t=${Date.now()}`);
+    const signedReq = new Request(countryCall.url, {
+      method: 'POST',
+      headers: countryCall.headers,
+      body: countryCall.body,
+    });
+    assert.ok(await verifyInternalMcpRequest(signedReq, HMAC_SECRET), 'signature must verify for the short URL plus context body');
+
+    const tamperedUrl = `${countryCall.url}?context=${encodeURIComponent(body.context)}`;
+    const tamperedReq = new Request(tamperedUrl, {
+      method: 'POST',
+      headers: countryCall.headers,
+      body: countryCall.body,
+    });
+    assert.equal(await verifyInternalMcpRequest(tamperedReq, HMAC_SECRET), null, 'same signature must not verify if context is moved back into the URL');
+  });
+
   it('edge: cache-only tool for Pro user goes through INCR/DECR path (counts toward 50/day)', async () => {
     const { deps, pipe } = makeProDeps();
     process.env.UPSTASH_REDIS_REST_URL = 'https://stub.upstash';


### PR DESCRIPTION
## Summary

Pro/OAuth `get_country_brief` no longer signs its grounding context in the URL, so large country brief requests avoid proxy/CDN request-line truncation that could invalidate the downstream HMAC. The tool now signs a short `/api/intelligence/v1/get-country-intel-brief` URL and sends the bounded grounding context in the existing JSON POST body, which the gateway already promotes after internal-MCP verification. If this endpoint still returns a non-2xx response, the thrown error now includes the gateway error code so Sentry can distinguish `invalid_internal_mcp_signature` from entitlement failures.

Fixes koala73/worldmonitor#4503.

## Validation

- `git diff --check`
- `node --check tests/mcp.test.mjs`
- `node --check tests/mcp-news-auth-docs-contract.test.mjs`
- Attempted `node --test tests/mcp-news-auth-docs-contract.test.mjs`; blocked before assertions because plain Node cannot resolve this repo's extensionless TypeScript imports.
- Attempted `npm ci --ignore-scripts --cache /tmp/worldmonitor-npm-cache` and `npm ci --ignore-scripts --omit=optional --no-audit --cache /tmp/worldmonitor-npm-cache`; both failed with `ENOSPC: no space left on device`, so the `tsx --test` suites could not be run locally in this worktree.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
