### PR TITLE
perf: lazy-load post-paint service tail

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -949,7 +949,12 @@ export class App {
     });
 
     this.panelLayout = new PanelLayoutManager(this.state, {
-      openCountryStory: (code, name) => { void this.countryIntel.openCountryStory(code, name); },
+      openCountryStory: (code, name) => {
+        void this.countryIntel.openCountryStory(code, name).catch((err) => {
+          console.error('[CountryStory] Failed to open story:', err);
+          showToast('Country story failed to open. Please try again.');
+        });
+      },
       openCountryBrief: (code) => {
         const name = CountryIntelManager.resolveCountryName(code);
         void this.countryIntel.openCountryBriefByCode(code, name);

--- a/src/App.ts
+++ b/src/App.ts
@@ -957,7 +957,11 @@ export class App {
       },
       openCountryBrief: (code) => {
         const name = CountryIntelManager.resolveCountryName(code);
-        void this.countryIntel.openCountryBriefByCode(code, name);
+        void this.countryIntel.openCountryBriefByCode(code, name).catch((err) => {
+          console.error('[CountryBrief] Failed to open country brief:', err);
+          this.state.map?.setRenderPaused(false);
+          showToast('Country brief failed to open. Please try again.');
+        });
       },
       loadAllData: () => this.dataLoader.loadAllData(),
       updateMonitorResults: () => this.dataLoader.updateMonitorResults(),
@@ -1007,7 +1011,13 @@ export class App {
         }
 
         const manager = new SearchManager(this.state, {
-          openCountryBriefByCode: (code, country) => this.countryIntel.openCountryBriefByCode(code, country),
+          openCountryBriefByCode: (code, country) => {
+            void this.countryIntel.openCountryBriefByCode(code, country).catch((err) => {
+              console.error('[CountryBrief] Failed to open country brief:', err);
+              this.state.map?.setRenderPaused(false);
+              showToast('Country brief failed to open. Please try again.');
+            });
+          },
           enablePanel: (panelId) => this.eventHandlers.enablePanelById(panelId),
         });
         manager.init();
@@ -1801,8 +1811,12 @@ export class App {
         trackDeeplinkOpened('country', countryCode);
         const countryName = getCountryNameByCode(countryCode.toUpperCase()) || countryCode;
         setTimeout(() => {
-          this.countryIntel.openCountryBriefByCode(countryCode.toUpperCase(), countryName, {
+          void this.countryIntel.openCountryBriefByCode(countryCode.toUpperCase(), countryName, {
             maximize: true,
+          }).catch((err) => {
+            console.error('[CountryBrief] Failed to open country brief:', err);
+            this.state.map?.setRenderPaused(false);
+            showToast('Country brief failed to open. Please try again.');
           });
           this.eventHandlers.syncUrlState();
         }, DEEP_LINK_INITIAL_DELAY_MS);
@@ -1819,8 +1833,12 @@ export class App {
       trackDeeplinkOpened('country', deepLinkCountry);
       const cName = CountryIntelManager.resolveCountryName(deepLinkCountry);
       setTimeout(() => {
-        this.countryIntel.openCountryBriefByCode(deepLinkCountry, cName, {
+        void this.countryIntel.openCountryBriefByCode(deepLinkCountry, cName, {
           maximize: deepLinkExpanded,
+        }).catch((err) => {
+          console.error('[CountryBrief] Failed to open country brief:', err);
+          this.state.map?.setRenderPaused(false);
+          showToast('Country brief failed to open. Please try again.');
         });
         this.eventHandlers.syncUrlState();
       }, DEEP_LINK_INITIAL_DELAY_MS);

--- a/src/App.ts
+++ b/src/App.ts
@@ -949,7 +949,7 @@ export class App {
     });
 
     this.panelLayout = new PanelLayoutManager(this.state, {
-      openCountryStory: (code, name) => this.countryIntel.openCountryStory(code, name),
+      openCountryStory: (code, name) => { void this.countryIntel.openCountryStory(code, name); },
       openCountryBrief: (code) => {
         const name = CountryIntelManager.resolveCountryName(code);
         void this.countryIntel.openCountryBriefByCode(code, name);

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -1,5 +1,6 @@
 import type { AppContext, AppModule, CountryBriefSignals } from '@/app/app-context';
 import { getSignalAggregator } from '@/app/lazy-services';
+import type { CountrySignalCluster } from '@/services/signal-aggregator';
 import { getRpcBaseUrl } from '@/services/rpc-client';
 import { premiumFetch } from '@/services/premium-fetch';
 import { IS_EMBEDDED_PREVIEW } from '@/utils/embedded-preview';
@@ -1128,7 +1129,15 @@ export class CountryIntelManager implements AppModule {
   async getCountrySignals(code: string, country: string): Promise<CountryBriefSignals> {
     const countryLower = country.toLowerCase();
     const hasGeoShape = hasCountryGeometry(code) || !!CountryIntelManager.COUNTRY_BOUNDS[code];
-    const clusters = (await getSignalAggregator()).getCountryClusters();
+    // The signal-aggregator chunk is lazy-loaded; if it fails to load we still
+    // render the brief from the independent intelligence caches below rather
+    // than aborting the whole open. Only the cluster-derived counts degrade.
+    let clusters: CountrySignalCluster[] = [];
+    try {
+      clusters = (await getSignalAggregator()).getCountryClusters();
+    } catch (err) {
+      console.warn('[CountryBrief] signal clusters unavailable, degrading:', err);
+    }
     const countryCluster = clusters.find(c => c.country === code);
     const globalCluster = clusters.find(c => c.country === 'XX');
     const signalTypeCounts = {

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -274,12 +274,17 @@ export class CountryIntelManager implements AppModule {
   async openCountryBriefByCode(code: string, country: string, opts?: { maximize?: boolean }): Promise<void> {
     const token = ++this.briefRequestToken;
     let pageShown = false;
+    let showedLoading = false;
 
     try {
       if (!(await this.ensureCountryBriefPage())) return;
       if (token !== this.briefRequestToken || this.ctx.isDestroyed) return;
       const page = this.ctx.countryBriefPage;
       if (!page) return;
+      if (!this.hasVisibleRealCountryBrief() || page.getCode() !== code) {
+        page.showLoading();
+        showedLoading = true;
+      }
       this.ctx.map?.setRenderPaused(true);
       trackCountryBriefOpened(code);
 
@@ -721,16 +726,24 @@ export class CountryIntelManager implements AppModule {
       if (!pageShown) {
         const activePage = this.ctx.countryBriefPage;
         const activeCode = activePage?.getCode();
-        if (activePage?.isVisible() && (activeCode === '__loading__' || activeCode === '__error__')) activePage.hide();
-        this.ctx.map?.setRenderPaused(false);
+        if (showedLoading && activePage?.isVisible() && (activeCode === '__loading__' || activeCode === '__error__')) activePage.hide();
+        if (!this.hasVisibleRealCountryBrief()) this.ctx.map?.setRenderPaused(false);
         this.showToast('Country brief failed to open. Please try again.');
       }
     } finally {
-      if (!pageShown && token === this.briefRequestToken) {
+      if (!pageShown && token === this.briefRequestToken && !this.hasVisibleRealCountryBrief()) {
         this.ctx.map?.setRenderPaused(false);
       }
     }
   }
+
+  private hasVisibleRealCountryBrief(): boolean {
+    const page = this.ctx.countryBriefPage;
+    if (!page?.isVisible()) return false;
+    const activeCode = page.getCode();
+    return !!activeCode && activeCode !== '__loading__' && activeCode !== '__error__';
+  }
+
   private fetchProSections(code: string): void {
     // /pro live-preview iframe can't carry a Clerk session, so every pro
     // section call would 401. Skip the RPCs entirely so the embedded

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -84,7 +84,12 @@ type SignalAggregator = typeof import('@/services/signal-aggregator').signalAggr
 let signalAggregatorPromise: Promise<SignalAggregator> | null = null;
 
 function getSignalAggregator(): Promise<SignalAggregator> {
-  signalAggregatorPromise ??= import('@/services/signal-aggregator').then(module => module.signalAggregator);
+  signalAggregatorPromise ??= import('@/services/signal-aggregator')
+    .then(module => module.signalAggregator)
+    .catch((err) => {
+      signalAggregatorPromise = null;
+      throw err;
+    });
   return signalAggregatorPromise;
 }
 
@@ -185,7 +190,10 @@ export class CountryIntelManager implements AppModule {
     this.ctx.countryBriefPage = new CountryDeepDivePanel(this.ctx.map);
     this.ctx.countryBriefPage.setShareStoryHandler((code, name) => {
       this.ctx.countryBriefPage?.hide();
-      void this.openCountryStory(code, name);
+      void this.openCountryStory(code, name).catch((err) => {
+        console.error('[CountryStory] Failed to open story:', err);
+        this.showToast('Country story failed to open. Please try again.');
+      });
     });
     this.ctx.countryBriefPage.setExportImageHandler(async (code, name) => {
       try {

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -1,4 +1,5 @@
 import type { AppContext, AppModule, CountryBriefSignals } from '@/app/app-context';
+import { getSignalAggregator } from '@/app/lazy-services';
 import { getRpcBaseUrl } from '@/services/rpc-client';
 import { premiumFetch } from '@/services/premium-fetch';
 import { IS_EMBEDDED_PREVIEW } from '@/utils/embedded-preview';
@@ -80,19 +81,6 @@ type CountryIntelBriefResult = {
   cached?: boolean;
 };
 
-type SignalAggregator = typeof import('@/services/signal-aggregator').signalAggregator;
-let signalAggregatorPromise: Promise<SignalAggregator> | null = null;
-
-function getSignalAggregator(): Promise<SignalAggregator> {
-  signalAggregatorPromise ??= import('@/services/signal-aggregator')
-    .then(module => module.signalAggregator)
-    .catch((err) => {
-      signalAggregatorPromise = null;
-      throw err;
-    });
-  return signalAggregatorPromise;
-}
-
 export class CountryIntelManager implements AppModule {
   private ctx: AppContext;
   private briefRequestToken = 0;
@@ -121,7 +109,9 @@ export class CountryIntelManager implements AppModule {
       const name = page.getName() ?? code;
       if (!code || !name) return;
       if (this._fwDebounce) clearTimeout(this._fwDebounce);
-      this._fwDebounce = setTimeout(() => void this.openCountryBriefByCode(code, name), 400);
+      this._fwDebounce = setTimeout(() => {
+        void this.openCountryBriefByCode(code, name).catch((err) => this.handleCountryBriefOpenError(err));
+      }, 400);
     });
 
     this.lastHadPremium = hasPremiumAccess(getAuthState());
@@ -151,23 +141,43 @@ export class CountryIntelManager implements AppModule {
     this.authUnsubscribe = null;
   }
 
+  private handleCountryBriefOpenError(err: unknown): void {
+    console.error('[CountryBrief] Failed to open country brief:', err);
+    this.ctx.map?.setRenderPaused(false);
+    this.showToast('Country brief failed to open. Please try again.');
+  }
+
   private async setupCountryIntel(): Promise<void> {
     if (!this.ctx.map) return;
     this.ctx.map.onCountryClicked((countryClick) => {
       if (countryClick.code && countryClick.name) {
         trackCountrySelected(countryClick.code, countryClick.name, 'map');
-        void this.openCountryBriefByCode(countryClick.code, countryClick.name);
+        void this.openCountryBriefByCode(countryClick.code, countryClick.name)
+          .catch((err) => this.handleCountryBriefOpenError(err));
       } else {
-        void this.openCountryBrief(countryClick.lat, countryClick.lon);
+        void this.openCountryBrief(countryClick.lat, countryClick.lon)
+          .catch((err) => this.handleCountryBriefOpenError(err));
       }
     });
 
     this.ctx.map.onMapContextMenu((payload) => {
       const items = [];
       if (payload.countryCode && payload.countryName) {
-        items.push({ label: t('contextMenu.openCountryBrief'), action: () => void this.openCountryBriefByCode(payload.countryCode!, payload.countryName!) });
+        items.push({
+          label: t('contextMenu.openCountryBrief'),
+          action: () => {
+            void this.openCountryBriefByCode(payload.countryCode!, payload.countryName!)
+              .catch((err) => this.handleCountryBriefOpenError(err));
+          },
+        });
       } else {
-        items.push({ label: t('contextMenu.openCountryBrief'), action: () => void this.openCountryBrief(payload.lat, payload.lon) });
+        items.push({
+          label: t('contextMenu.openCountryBrief'),
+          action: () => {
+            void this.openCountryBrief(payload.lat, payload.lon)
+              .catch((err) => this.handleCountryBriefOpenError(err));
+          },
+        });
       }
       items.push({ label: t('contextMenu.copyCoordinates'), action: () => navigator.clipboard.writeText(`${payload.lat.toFixed(5)}, ${payload.lon.toFixed(5)}`).catch(() => {}) });
       showMapContextMenu(payload.screenX, payload.screenY, items);
@@ -178,10 +188,13 @@ export class CountryIntelManager implements AppModule {
     if (this.ctx.countryBriefPage) return true;
     if (!this.ctx.map || this.ctx.isDestroyed) return false;
     if (this.countryBriefPageLoading) return this.countryBriefPageLoading;
-    this.countryBriefPageLoading = this.createCountryBriefPage();
-    const ready = await this.countryBriefPageLoading;
-    this.countryBriefPageLoading = null;
-    return ready;
+    const loading = this.createCountryBriefPage();
+    this.countryBriefPageLoading = loading;
+    try {
+      return await loading;
+    } finally {
+      if (this.countryBriefPageLoading === loading) this.countryBriefPageLoading = null;
+    }
   }
 
   private async createCountryBriefPage(): Promise<boolean> {
@@ -258,427 +271,465 @@ export class CountryIntelManager implements AppModule {
   }
 
   async openCountryBriefByCode(code: string, country: string, opts?: { maximize?: boolean }): Promise<void> {
-    if (!(await this.ensureCountryBriefPage())) return;
-    const page = this.ctx.countryBriefPage;
-    if (!page) return;
-    this.ctx.map?.setRenderPaused(true);
-    trackCountryBriefOpened(code);
-
-    const canonicalName = TIER1_COUNTRIES[code] || CountryIntelManager.resolveCountryName(code);
-    if (canonicalName !== code) country = canonicalName;
-
-    const scoreCode = normalizeCiiCountryCode(code);
-    const score = getCachedCountryScore(scoreCode) ?? calculateCII().find((s) => s.code === scoreCode) ?? null;
-
-    const signals = await this.getCountrySignals(code, country);
-
-    page.show(country, code, score, signals);
-    this.ctx.map?.highlightCountry(code);
-    this.ctx.map?.fitCountry(code);
-
-    if (opts?.maximize) {
-      requestAnimationFrame(() => {
-        const panel = this.ctx.countryBriefPage;
-        if (panel?.isVisible() && panel.getCode() === code) {
-          panel.maximize?.();
-        }
-      });
-    }
-    page.updateSignalDetails?.(await this.buildSignalDetails(code));
-    page.updateMilitaryActivity?.(this.buildMilitarySummary(code, country));
-    page.updateEconomicIndicators?.(this.buildEconomicIndicators(code, score, null));
-
-    const marketClient = new MarketServiceClient(getRpcBaseUrl(), { fetch: (...args: Parameters<typeof globalThis.fetch>) => globalThis.fetch(...args) });
-    const stockPromise = marketClient.getCountryStockIndex({ countryCode: code })
-      .then((resp) => ({
-        available: resp.available,
-        code: resp.code,
-        symbol: resp.symbol,
-        indexName: resp.indexName,
-        price: String(resp.price),
-        weekChangePercent: String(resp.weekChangePercent),
-        currency: resp.currency,
-      }))
-      .catch(() => ({ available: false as const, code: '', symbol: '', indexName: '', price: '0', weekChangePercent: '0', currency: '' }));
-
-    let latestStock: CountryStockSnapshot | null = null;
-    let latestImf: ImfCountryBundle | null = null;
-
-    stockPromise.then((stock) => {
-      latestStock = stock;
-      if (this.ctx.countryBriefPage?.getCode() !== code) return;
-      this.ctx.countryBriefPage.updateStock(stock);
-      this.ctx.countryBriefPage.updateEconomicIndicators?.(this.buildEconomicIndicators(code, score, stock, latestImf));
-    });
-
-    // IMF WEO bundle (issue #3027): macro / growth / labor / external from
-    // the SDMX-3.0 seeded keys. Tolerant: missing data leaves card unchanged.
-    getImfCountryBundle(code).then((bundle) => {
-      latestImf = bundle;
-      if (this.ctx.countryBriefPage?.getCode() !== code) return;
-      this.ctx.countryBriefPage.updateEconomicIndicators?.(this.buildEconomicIndicators(code, score, latestStock, bundle));
-    }).catch(() => { /* non-fatal */ });
-
-    fetchCountryMarkets(country)
-      .then((markets) => {
-        if (this.ctx.countryBriefPage?.getCode() === code) this.ctx.countryBriefPage.updateMarkets(markets);
-      })
-      .catch(() => {
-        if (this.ctx.countryBriefPage?.getCode() === code) this.ctx.countryBriefPage.updateMarkets([]);
-      });
-
-    const searchTerms = CountryIntelManager.getCountrySearchTerms(country, code);
-    const otherCountryTerms = CountryIntelManager.getOtherCountryTerms(code);
-    const matchingNews = this.ctx.allNews.filter((n) => {
-      const t = n.title.toLowerCase();
-      return CountryIntelManager.firstMentionPosition(t, searchTerms) !== Infinity;
-    });
-    const filteredNews = matchingNews.filter((n) => {
-      const t = n.title.toLowerCase();
-      const ourPos = CountryIntelManager.firstMentionPosition(t, searchTerms);
-      const otherPos = CountryIntelManager.firstMentionPosition(t, otherCountryTerms);
-      return ourPos !== Infinity && (otherPos === Infinity || ourPos <= otherPos);
-    }).sort((a, b) => {
-      const severityDelta = this.newsSeverityRank(b) - this.newsSeverityRank(a);
-      if (severityDelta !== 0) return severityDelta;
-      return effectivePubDateMs(b) - effectivePubDateMs(a);
-    });
-    page.updateNews(filteredNews.slice(0, 10));
-
-    page.updateInfrastructure(code);
-    void Promise.all([
-      preloadMilitaryBases().catch(() => []),
-      preloadInfrastructureTables().catch(() => {}),
-    ])
-      .then(() => {
-        if (this.ctx.countryBriefPage?.getCode() === code) {
-          this.ctx.countryBriefPage.updateInfrastructure(code);
-          this.ctx.countryBriefPage.updateMilitaryActivity?.(this.buildMilitarySummary(code, country));
-        }
-      })
-      .catch(() => {});
-
-    const intelClient = new IntelligenceServiceClient(getRpcBaseUrl(), {
-      fetch: (...args: Parameters<typeof globalThis.fetch>) => globalThis.fetch(...args),
-    });
-    intelClient.getCountryFacts({ countryCode: code })
-      .then((facts) => {
-        if (this.ctx.countryBriefPage?.getCode() !== code) return;
-        this.ctx.countryBriefPage.updateCountryFacts?.({
-          headOfState: facts.headOfState,
-          headOfStateTitle: facts.headOfStateTitle,
-          wikipediaSummary: facts.wikipediaSummary,
-          wikipediaThumbnailUrl: facts.wikipediaThumbnailUrl,
-          population: Number(facts.population),
-          capital: facts.capital,
-          languages: facts.languages,
-          currencies: facts.currencies,
-          areaSqKm: facts.areaSqKm,
-          countryName: facts.countryName,
-        });
-      })
-      .catch(() => {
-        if (this.ctx.countryBriefPage?.getCode() !== code) return;
-        this.ctx.countryBriefPage.updateCountryFacts?.({
-          headOfState: '', headOfStateTitle: '', wikipediaSummary: '',
-          wikipediaThumbnailUrl: '', population: 0, capital: '',
-          languages: [], currencies: [], areaSqKm: 0, countryName: '',
-        });
-      });
-
-    intelClient.getCountryEnergyProfile({ countryCode: code })
-      .then((profile) => {
-        if (this.ctx.countryBriefPage?.getCode() !== code) return;
-        this.ctx.countryBriefPage.updateEnergyProfile?.({
-          mixAvailable: profile.mixAvailable,
-          mixYear: profile.mixYear,
-          coalShare: profile.coalShare,
-          gasShare: profile.gasShare,
-          oilShare: profile.oilShare,
-          nuclearShare: profile.nuclearShare,
-          renewShare: profile.renewShare,
-          windShare: profile.windShare,
-          solarShare: profile.solarShare,
-          hydroShare: profile.hydroShare,
-          importShare: profile.importShare,
-          gasStorageAvailable: profile.gasStorageAvailable,
-          gasStorageFillPct: profile.gasStorageFillPct,
-          gasStorageChange1d: profile.gasStorageChange1d,
-          gasStorageTrend: profile.gasStorageTrend,
-          gasStorageDate: profile.gasStorageDate,
-          electricityAvailable: profile.electricityAvailable,
-          electricityPriceMwh: profile.electricityPriceMwh,
-          electricitySource: profile.electricitySource,
-          electricityDate: profile.electricityDate,
-          jodiOilAvailable: profile.jodiOilAvailable,
-          jodiOilDataMonth: profile.jodiOilDataMonth,
-          gasolineDemandKbd: profile.gasolineDemandKbd,
-          gasolineImportsKbd: profile.gasolineImportsKbd,
-          dieselDemandKbd: profile.dieselDemandKbd,
-          dieselImportsKbd: profile.dieselImportsKbd,
-          jetDemandKbd: profile.jetDemandKbd,
-          jetImportsKbd: profile.jetImportsKbd,
-          lpgDemandKbd: profile.lpgDemandKbd,
-          lpgImportsKbd: profile.lpgImportsKbd,
-          crudeImportsKbd: profile.crudeImportsKbd,
-          jodiGasAvailable: profile.jodiGasAvailable,
-          jodiGasDataMonth: profile.jodiGasDataMonth,
-          gasTotalDemandTj: profile.gasTotalDemandTj,
-          gasLngImportsTj: profile.gasLngImportsTj,
-          gasPipeImportsTj: profile.gasPipeImportsTj,
-          gasLngShare: profile.gasLngShare,
-          ieaStocksAvailable: profile.ieaStocksAvailable,
-          ieaStocksDataMonth: profile.ieaStocksDataMonth,
-          ieaDaysOfCover: profile.ieaDaysOfCover,
-          ieaNetExporter: profile.ieaNetExporter,
-          ieaBelowObligation: profile.ieaBelowObligation,
-          emberFossilShare: profile.emberFossilShare,
-          emberRenewShare: profile.emberRenewShare,
-          emberNuclearShare: profile.emberNuclearShare,
-          emberCoalShare: profile.emberCoalShare,
-          emberGasShare: profile.emberGasShare,
-          emberDemandTwh: profile.emberDemandTwh,
-          emberDataMonth: profile.emberDataMonth,
-          emberAvailable: profile.emberAvailable,
-          sprRegime: profile.sprRegime,
-          sprCapacityMb: profile.sprCapacityMb,
-          sprOperator: profile.sprOperator,
-          sprIeaMember: profile.sprIeaMember,
-          sprStockholdingModel: profile.sprStockholdingModel,
-          sprNote: profile.sprNote,
-          sprSource: profile.sprSource,
-          sprAsOf: profile.sprAsOf,
-          sprAvailable: profile.sprAvailable,
-        });
-      })
-      .catch(() => {
-        if (this.ctx.countryBriefPage?.getCode() !== code) return;
-        this.ctx.countryBriefPage.updateEnergyProfile?.({
-          mixAvailable: false, mixYear: 0, coalShare: 0, gasShare: 0, oilShare: 0,
-          nuclearShare: 0, renewShare: 0, windShare: 0, solarShare: 0, hydroShare: 0,
-          importShare: 0, gasStorageAvailable: false, gasStorageFillPct: 0,
-          gasStorageChange1d: 0, gasStorageTrend: '', gasStorageDate: '', electricityAvailable: false,
-          electricityPriceMwh: 0, electricitySource: '', electricityDate: '',
-          jodiOilAvailable: false, jodiOilDataMonth: '', gasolineDemandKbd: 0,
-          gasolineImportsKbd: 0, dieselDemandKbd: 0, dieselImportsKbd: 0,
-          jetDemandKbd: 0, jetImportsKbd: 0, lpgDemandKbd: 0, lpgImportsKbd: 0,
-          crudeImportsKbd: 0, jodiGasAvailable: false, jodiGasDataMonth: '',
-          gasTotalDemandTj: 0, gasLngImportsTj: 0, gasPipeImportsTj: 0,
-          gasLngShare: 0, ieaStocksAvailable: false, ieaStocksDataMonth: '',
-          ieaDaysOfCover: 0, ieaNetExporter: false, ieaBelowObligation: false,
-          emberFossilShare: 0, emberRenewShare: 0, emberNuclearShare: 0,
-          emberCoalShare: 0, emberGasShare: 0, emberDemandTwh: 0,
-          emberDataMonth: '', emberAvailable: false,
-          sprRegime: 'unknown', sprCapacityMb: 0, sprOperator: '', sprIeaMember: false,
-          sprStockholdingModel: '', sprNote: '', sprSource: '', sprAsOf: '',
-          sprAvailable: false,
-        });
-      });
-
-    intelClient.getCountryPortActivity({ countryCode: code })
-      .then((activity) => {
-        if (this.ctx.countryBriefPage?.getCode() !== code) return;
-        this.ctx.countryBriefPage.updateMaritimeActivity?.({
-          available: activity.available,
-          ports: (activity.ports ?? []).map((p) => ({
-            portId: p.portId,
-            portName: p.portName,
-            lat: p.lat,
-            lon: p.lon,
-            tankerCalls30d: p.tankerCalls30d,
-            trendDeltaPct: p.trendDeltaPct,
-            importTankerDwt: p.importTankerDwt,
-            exportTankerDwt: p.exportTankerDwt,
-            anomalySignal: p.anomalySignal,
-          })),
-          fetchedAt: activity.fetchedAt,
-        });
-      })
-      .catch(() => {
-        if (this.ctx.countryBriefPage?.getCode() !== code) return;
-        this.ctx.countryBriefPage.updateMaritimeActivity?.({ available: false, ports: [], fetchedAt: '' });
-      });
-
-    // Fetch multi-sector exposure (all 10 seeded HS2 codes in parallel)
-    fetchMultiSectorExposure(code)
-      .then((sectors) => {
-        if (this.ctx.countryBriefPage?.getCode() !== code) return;
-        if (sectors.length === 0) {
-          this.ctx.countryBriefPage.updateTradeExposure?.(null);
-          if (hasPremiumAccess(getAuthState())) this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
-          return;
-        }
-        // Build a synthetic compat response from sector data (no extra fetch needed)
-        const top = sectors[0]!;
-        const syntheticResponse = {
-          iso2: code,
-          hs2: top.hs2,
-          exposures: sectors.slice(0, 3).map(s => ({
-            chokepointId: s.primaryChokepointId,
-            chokepointName: s.primaryChokepointName,
-            exposureScore: s.exposureScore,
-            coastSide: '',
-            shockSupported: s.hs2 === '27',
-          })),
-          primaryChokepointId: top.primaryChokepointId,
-          vulnerabilityIndex: top.vulnerabilityIndex,
-          fetchedAt: new Date().toISOString(),
-        };
-        this.ctx.countryBriefPage.updateTradeExposure?.(syntheticResponse, sectors);
-
-        // Trigger multi-sector cost shock calculator from the same primary chokepoint.
-        if (hasPremiumAccess(getAuthState()) && top.primaryChokepointId) {
-          fetchMultiSectorCostShock(code, top.primaryChokepointId, 30).then(multi => {
-            if (this.ctx.countryBriefPage?.getCode() !== code) return;
-            this.ctx.countryBriefPage.updateMultiSectorCostShock?.(multi);
-          }).catch(() => {
-            if (this.ctx.countryBriefPage?.getCode() === code) this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
-          });
-        } else if (hasPremiumAccess(getAuthState())) {
-          this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
-        }
-      })
-      .catch(() => {
-        if (this.ctx.countryBriefPage?.getCode() !== code) return;
-        this.ctx.countryBriefPage.updateTradeExposure?.(null);
-        if (hasPremiumAccess(getAuthState())) this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
-      });
-
-    if (hasPremiumAccess(getAuthState())) {
-      this.fetchProSections(code);
-    }
-
-    this.mountCountryTimeline(code, country);
+    const token = ++this.briefRequestToken;
+    let pageShown = false;
 
     try {
-      const context: Record<string, unknown> = {};
-      if (score) {
-        context.score = score.score;
-        context.level = score.level;
-        context.trend = score.trend;
-        context.components = score.components;
-        context.change24h = score.change24h;
-      }
-      Object.assign(context, signals);
+      if (!(await this.ensureCountryBriefPage())) return;
+      if (token !== this.briefRequestToken || this.ctx.isDestroyed) return;
+      const page = this.ctx.countryBriefPage;
+      if (!page) return;
+      this.ctx.map?.setRenderPaused(true);
+      trackCountryBriefOpened(code);
 
-      const aggregator = await getSignalAggregator();
-      const countryCluster = aggregator.getCountryClusters().find((c) => c.country === code);
-      if (countryCluster) {
-        context.convergenceScore = countryCluster.convergenceScore;
-        context.signalTypes = [...countryCluster.signalTypes];
-      }
+      const canonicalName = TIER1_COUNTRIES[code] || CountryIntelManager.resolveCountryName(code);
+      if (canonicalName !== code) country = canonicalName;
 
-      const convergences = aggregator.getRegionalConvergence()
-        .filter((r) => r.countries.includes(code));
-      if (convergences.length) {
-        context.regionalConvergence = convergences.map((r) => r.description);
-      }
+      const scoreCode = normalizeCiiCountryCode(code);
+      const score = getCachedCountryScore(scoreCode) ?? calculateCII().find((s) => s.code === scoreCode) ?? null;
 
-      if (this.ctx.intelligenceCache.advisories) {
-        const countryAdvisories = this.ctx.intelligenceCache.advisories.filter(a => a.country === code);
-        if (countryAdvisories.length > 0) {
-          context.travelAdvisories = countryAdvisories.map(a => ({ source: a.source, level: a.level, title: a.title }));
-        }
-      }
+      const signals = await this.getCountrySignals(code, country);
+      if (token !== this.briefRequestToken || this.ctx.isDestroyed || this.ctx.countryBriefPage !== page) return;
 
-      const groundingNews = filteredNews.slice(0, 15);
-      let briefSources = collectBriefSources(groundingNews, 6);
-      const headlines = groundingNews.map((n) => n.title);
-      if (headlines.length) context.headlines = headlines;
-      if (briefSources.length) context.briefSources = briefSources;
-      const briefHeadlines = (context.headlines as string[] | undefined) || [];
+      page.show(country, code, score, signals);
+      pageShown = true;
+      this.ctx.map?.highlightCountry(code);
+      this.ctx.map?.fitCountry(code);
 
-      const stockData = await stockPromise;
-      if (stockData.available) {
-        const pct = parseFloat(stockData.weekChangePercent);
-        context.stockIndex = `${stockData.indexName}: ${stockData.price} (${pct >= 0 ? '+' : ''}${stockData.weekChangePercent}% week)`;
-      }
-
-      let briefText = '';
-      let briefResult: CountryIntelBriefResult | null = null;
-      try {
-        let contextSnapshot = this.buildBriefContextSnapshot(country, code, score, signals, context);
-
-        if (isHeadlineMemoryEnabled() && mlWorker.isAvailable && mlWorker.isModelLoaded('embeddings') && briefHeadlines.length > 0) {
-          try {
-            const results = await mlWorker.vectorStoreSearch(briefHeadlines.slice(0, 3), 5, 0.3);
-            if (results.length > 0) {
-              const historical = results.map(r =>
-                `- ${r.text} (${new Date(r.pubDate).toISOString().slice(0, 10)})`
-              ).join('\n').slice(0, 350);
-              contextSnapshot = contextSnapshot.slice(0, 1800)
-                + `\n[BEGIN HISTORICAL DATA]\n${historical}\n[END HISTORICAL DATA]`;
-            }
-          } catch { /* RAG unavailable */ }
-        }
-
-        const countryFw = getActiveFrameworkForPanel('country-brief');
-        briefResult = await this.fetchCountryIntelBrief(code, contextSnapshot, countryFw?.systemPromptAppend ?? '');
-        briefText = briefResult.brief;
-        if (briefResult.sources.length > 0) {
-          briefSources = briefResult.sources;
-        }
-      } catch { /* server unreachable */ }
-
-      if (briefText) {
-        this.ctx.countryBriefPage?.updateBrief({
-          brief: briefText,
-          country,
-          code,
-          sources: briefSources,
-          generatedAt: briefResult?.generatedAt,
-          cached: briefResult?.cached,
+      if (opts?.maximize) {
+        requestAnimationFrame(() => {
+          const panel = this.ctx.countryBriefPage;
+          if (panel?.isVisible() && panel.getCode() === code) {
+            panel.maximize?.();
+          }
         });
-      } else {
-        let fallbackBrief = '';
-        const sumModelId = BETA_MODE ? 'summarization-beta' : 'summarization';
-        if (briefHeadlines.length >= 2 && mlWorker.isAvailable && mlWorker.isModelLoaded(sumModelId)) {
-          try {
-            const lang = getCurrentLanguage();
-            const prompt = lang === 'fr'
-              ? `Résumez la situation actuelle en ${country} à partir de ces titres : ${briefHeadlines.slice(0, 8).join('. ')}`
-              : `Summarize the current situation in ${country} based on these headlines: ${briefHeadlines.slice(0, 8).join('. ')}`;
+      }
+      try {
+        const signalDetails = await this.buildSignalDetails(code);
+        if (token === this.briefRequestToken && this.ctx.countryBriefPage?.getCode() === code) {
+          page.updateSignalDetails?.(signalDetails);
+        }
+      } catch (err) {
+        console.warn('[CountryBrief] signal details unavailable:', err);
+      }
+      if (token !== this.briefRequestToken || this.ctx.countryBriefPage?.getCode() !== code) return;
+      page.updateMilitaryActivity?.(this.buildMilitarySummary(code, country));
+      page.updateEconomicIndicators?.(this.buildEconomicIndicators(code, score, null));
 
-            const [summary] = await mlWorker.summarize([prompt], BETA_MODE ? 'summarization-beta' : undefined);
-            if (summary && summary.length > 20) fallbackBrief = summary;
-          } catch { /* T5 failed */ }
+      const marketClient = new MarketServiceClient(getRpcBaseUrl(), { fetch: (...args: Parameters<typeof globalThis.fetch>) => globalThis.fetch(...args) });
+      const stockPromise = marketClient.getCountryStockIndex({ countryCode: code })
+        .then((resp) => ({
+          available: resp.available,
+          code: resp.code,
+          symbol: resp.symbol,
+          indexName: resp.indexName,
+          price: String(resp.price),
+          weekChangePercent: String(resp.weekChangePercent),
+          currency: resp.currency,
+        }))
+        .catch(() => ({ available: false as const, code: '', symbol: '', indexName: '', price: '0', weekChangePercent: '0', currency: '' }));
+
+      let latestStock: CountryStockSnapshot | null = null;
+      let latestImf: ImfCountryBundle | null = null;
+
+      stockPromise.then((stock) => {
+        latestStock = stock;
+        if (this.ctx.countryBriefPage?.getCode() !== code) return;
+        this.ctx.countryBriefPage.updateStock(stock);
+        this.ctx.countryBriefPage.updateEconomicIndicators?.(this.buildEconomicIndicators(code, score, stock, latestImf));
+      });
+
+      // IMF WEO bundle (issue #3027): macro / growth / labor / external from
+      // the SDMX-3.0 seeded keys. Tolerant: missing data leaves card unchanged.
+      getImfCountryBundle(code).then((bundle) => {
+        latestImf = bundle;
+        if (this.ctx.countryBriefPage?.getCode() !== code) return;
+        this.ctx.countryBriefPage.updateEconomicIndicators?.(this.buildEconomicIndicators(code, score, latestStock, bundle));
+      }).catch(() => { /* non-fatal */ });
+
+      fetchCountryMarkets(country)
+        .then((markets) => {
+          if (this.ctx.countryBriefPage?.getCode() === code) this.ctx.countryBriefPage.updateMarkets(markets);
+        })
+        .catch(() => {
+          if (this.ctx.countryBriefPage?.getCode() === code) this.ctx.countryBriefPage.updateMarkets([]);
+        });
+
+      const searchTerms = CountryIntelManager.getCountrySearchTerms(country, code);
+      const otherCountryTerms = CountryIntelManager.getOtherCountryTerms(code);
+      const matchingNews = this.ctx.allNews.filter((n) => {
+        const t = n.title.toLowerCase();
+        return CountryIntelManager.firstMentionPosition(t, searchTerms) !== Infinity;
+      });
+      const filteredNews = matchingNews.filter((n) => {
+        const t = n.title.toLowerCase();
+        const ourPos = CountryIntelManager.firstMentionPosition(t, searchTerms);
+        const otherPos = CountryIntelManager.firstMentionPosition(t, otherCountryTerms);
+        return ourPos !== Infinity && (otherPos === Infinity || ourPos <= otherPos);
+      }).sort((a, b) => {
+        const severityDelta = this.newsSeverityRank(b) - this.newsSeverityRank(a);
+        if (severityDelta !== 0) return severityDelta;
+        return effectivePubDateMs(b) - effectivePubDateMs(a);
+      });
+      page.updateNews(filteredNews.slice(0, 10));
+
+      page.updateInfrastructure(code);
+      void Promise.all([
+        preloadMilitaryBases().catch(() => []),
+        preloadInfrastructureTables().catch(() => {}),
+      ])
+        .then(() => {
+          if (this.ctx.countryBriefPage?.getCode() === code) {
+            this.ctx.countryBriefPage.updateInfrastructure(code);
+            this.ctx.countryBriefPage.updateMilitaryActivity?.(this.buildMilitarySummary(code, country));
+          }
+        })
+        .catch(() => {});
+
+      const intelClient = new IntelligenceServiceClient(getRpcBaseUrl(), {
+        fetch: (...args: Parameters<typeof globalThis.fetch>) => globalThis.fetch(...args),
+      });
+      intelClient.getCountryFacts({ countryCode: code })
+        .then((facts) => {
+          if (this.ctx.countryBriefPage?.getCode() !== code) return;
+          this.ctx.countryBriefPage.updateCountryFacts?.({
+            headOfState: facts.headOfState,
+            headOfStateTitle: facts.headOfStateTitle,
+            wikipediaSummary: facts.wikipediaSummary,
+            wikipediaThumbnailUrl: facts.wikipediaThumbnailUrl,
+            population: Number(facts.population),
+            capital: facts.capital,
+            languages: facts.languages,
+            currencies: facts.currencies,
+            areaSqKm: facts.areaSqKm,
+            countryName: facts.countryName,
+          });
+        })
+        .catch(() => {
+          if (this.ctx.countryBriefPage?.getCode() !== code) return;
+          this.ctx.countryBriefPage.updateCountryFacts?.({
+            headOfState: '', headOfStateTitle: '', wikipediaSummary: '',
+            wikipediaThumbnailUrl: '', population: 0, capital: '',
+            languages: [], currencies: [], areaSqKm: 0, countryName: '',
+          });
+        });
+
+      intelClient.getCountryEnergyProfile({ countryCode: code })
+        .then((profile) => {
+          if (this.ctx.countryBriefPage?.getCode() !== code) return;
+          this.ctx.countryBriefPage.updateEnergyProfile?.({
+            mixAvailable: profile.mixAvailable,
+            mixYear: profile.mixYear,
+            coalShare: profile.coalShare,
+            gasShare: profile.gasShare,
+            oilShare: profile.oilShare,
+            nuclearShare: profile.nuclearShare,
+            renewShare: profile.renewShare,
+            windShare: profile.windShare,
+            solarShare: profile.solarShare,
+            hydroShare: profile.hydroShare,
+            importShare: profile.importShare,
+            gasStorageAvailable: profile.gasStorageAvailable,
+            gasStorageFillPct: profile.gasStorageFillPct,
+            gasStorageChange1d: profile.gasStorageChange1d,
+            gasStorageTrend: profile.gasStorageTrend,
+            gasStorageDate: profile.gasStorageDate,
+            electricityAvailable: profile.electricityAvailable,
+            electricityPriceMwh: profile.electricityPriceMwh,
+            electricitySource: profile.electricitySource,
+            electricityDate: profile.electricityDate,
+            jodiOilAvailable: profile.jodiOilAvailable,
+            jodiOilDataMonth: profile.jodiOilDataMonth,
+            gasolineDemandKbd: profile.gasolineDemandKbd,
+            gasolineImportsKbd: profile.gasolineImportsKbd,
+            dieselDemandKbd: profile.dieselDemandKbd,
+            dieselImportsKbd: profile.dieselImportsKbd,
+            jetDemandKbd: profile.jetDemandKbd,
+            jetImportsKbd: profile.jetImportsKbd,
+            lpgDemandKbd: profile.lpgDemandKbd,
+            lpgImportsKbd: profile.lpgImportsKbd,
+            crudeImportsKbd: profile.crudeImportsKbd,
+            jodiGasAvailable: profile.jodiGasAvailable,
+            jodiGasDataMonth: profile.jodiGasDataMonth,
+            gasTotalDemandTj: profile.gasTotalDemandTj,
+            gasLngImportsTj: profile.gasLngImportsTj,
+            gasPipeImportsTj: profile.gasPipeImportsTj,
+            gasLngShare: profile.gasLngShare,
+            ieaStocksAvailable: profile.ieaStocksAvailable,
+            ieaStocksDataMonth: profile.ieaStocksDataMonth,
+            ieaDaysOfCover: profile.ieaDaysOfCover,
+            ieaNetExporter: profile.ieaNetExporter,
+            ieaBelowObligation: profile.ieaBelowObligation,
+            emberFossilShare: profile.emberFossilShare,
+            emberRenewShare: profile.emberRenewShare,
+            emberNuclearShare: profile.emberNuclearShare,
+            emberCoalShare: profile.emberCoalShare,
+            emberGasShare: profile.emberGasShare,
+            emberDemandTwh: profile.emberDemandTwh,
+            emberDataMonth: profile.emberDataMonth,
+            emberAvailable: profile.emberAvailable,
+            sprRegime: profile.sprRegime,
+            sprCapacityMb: profile.sprCapacityMb,
+            sprOperator: profile.sprOperator,
+            sprIeaMember: profile.sprIeaMember,
+            sprStockholdingModel: profile.sprStockholdingModel,
+            sprNote: profile.sprNote,
+            sprSource: profile.sprSource,
+            sprAsOf: profile.sprAsOf,
+            sprAvailable: profile.sprAvailable,
+          });
+        })
+        .catch(() => {
+          if (this.ctx.countryBriefPage?.getCode() !== code) return;
+          this.ctx.countryBriefPage.updateEnergyProfile?.({
+            mixAvailable: false, mixYear: 0, coalShare: 0, gasShare: 0, oilShare: 0,
+            nuclearShare: 0, renewShare: 0, windShare: 0, solarShare: 0, hydroShare: 0,
+            importShare: 0, gasStorageAvailable: false, gasStorageFillPct: 0,
+            gasStorageChange1d: 0, gasStorageTrend: '', gasStorageDate: '', electricityAvailable: false,
+            electricityPriceMwh: 0, electricitySource: '', electricityDate: '',
+            jodiOilAvailable: false, jodiOilDataMonth: '', gasolineDemandKbd: 0,
+            gasolineImportsKbd: 0, dieselDemandKbd: 0, dieselImportsKbd: 0,
+            jetDemandKbd: 0, jetImportsKbd: 0, lpgDemandKbd: 0, lpgImportsKbd: 0,
+            crudeImportsKbd: 0, jodiGasAvailable: false, jodiGasDataMonth: '',
+            gasTotalDemandTj: 0, gasLngImportsTj: 0, gasPipeImportsTj: 0,
+            gasLngShare: 0, ieaStocksAvailable: false, ieaStocksDataMonth: '',
+            ieaDaysOfCover: 0, ieaNetExporter: false, ieaBelowObligation: false,
+            emberFossilShare: 0, emberRenewShare: 0, emberNuclearShare: 0,
+            emberCoalShare: 0, emberGasShare: 0, emberDemandTwh: 0,
+            emberDataMonth: '', emberAvailable: false,
+            sprRegime: 'unknown', sprCapacityMb: 0, sprOperator: '', sprIeaMember: false,
+            sprStockholdingModel: '', sprNote: '', sprSource: '', sprAsOf: '',
+            sprAvailable: false,
+          });
+        });
+
+      intelClient.getCountryPortActivity({ countryCode: code })
+        .then((activity) => {
+          if (this.ctx.countryBriefPage?.getCode() !== code) return;
+          this.ctx.countryBriefPage.updateMaritimeActivity?.({
+            available: activity.available,
+            ports: (activity.ports ?? []).map((p) => ({
+              portId: p.portId,
+              portName: p.portName,
+              lat: p.lat,
+              lon: p.lon,
+              tankerCalls30d: p.tankerCalls30d,
+              trendDeltaPct: p.trendDeltaPct,
+              importTankerDwt: p.importTankerDwt,
+              exportTankerDwt: p.exportTankerDwt,
+              anomalySignal: p.anomalySignal,
+            })),
+            fetchedAt: activity.fetchedAt,
+          });
+        })
+        .catch(() => {
+          if (this.ctx.countryBriefPage?.getCode() !== code) return;
+          this.ctx.countryBriefPage.updateMaritimeActivity?.({ available: false, ports: [], fetchedAt: '' });
+        });
+
+      // Fetch multi-sector exposure (all 10 seeded HS2 codes in parallel)
+      fetchMultiSectorExposure(code)
+        .then((sectors) => {
+          if (this.ctx.countryBriefPage?.getCode() !== code) return;
+          if (sectors.length === 0) {
+            this.ctx.countryBriefPage.updateTradeExposure?.(null);
+            if (hasPremiumAccess(getAuthState())) this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
+            return;
+          }
+          // Build a synthetic compat response from sector data (no extra fetch needed)
+          const top = sectors[0]!;
+          const syntheticResponse = {
+            iso2: code,
+            hs2: top.hs2,
+            exposures: sectors.slice(0, 3).map(s => ({
+              chokepointId: s.primaryChokepointId,
+              chokepointName: s.primaryChokepointName,
+              exposureScore: s.exposureScore,
+              coastSide: '',
+              shockSupported: s.hs2 === '27',
+            })),
+            primaryChokepointId: top.primaryChokepointId,
+            vulnerabilityIndex: top.vulnerabilityIndex,
+            fetchedAt: new Date().toISOString(),
+          };
+          this.ctx.countryBriefPage.updateTradeExposure?.(syntheticResponse, sectors);
+
+          // Trigger multi-sector cost shock calculator from the same primary chokepoint.
+          if (hasPremiumAccess(getAuthState()) && top.primaryChokepointId) {
+            fetchMultiSectorCostShock(code, top.primaryChokepointId, 30).then(multi => {
+              if (this.ctx.countryBriefPage?.getCode() !== code) return;
+              this.ctx.countryBriefPage.updateMultiSectorCostShock?.(multi);
+            }).catch(() => {
+              if (this.ctx.countryBriefPage?.getCode() === code) this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
+            });
+          } else if (hasPremiumAccess(getAuthState())) {
+            this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
+          }
+        })
+        .catch(() => {
+          if (this.ctx.countryBriefPage?.getCode() !== code) return;
+          this.ctx.countryBriefPage.updateTradeExposure?.(null);
+          if (hasPremiumAccess(getAuthState())) this.ctx.countryBriefPage.updateMultiSectorCostShock?.(null);
+        });
+
+      if (hasPremiumAccess(getAuthState())) {
+        this.fetchProSections(code);
+      }
+
+      this.mountCountryTimeline(code, country);
+
+      try {
+        const context: Record<string, unknown> = {};
+        if (score) {
+          context.score = score.score;
+          context.level = score.level;
+          context.trend = score.trend;
+          context.components = score.components;
+          context.change24h = score.change24h;
+        }
+        Object.assign(context, signals);
+
+        const aggregator = await getSignalAggregator();
+        if (token !== this.briefRequestToken || this.ctx.countryBriefPage?.getCode() !== code) return;
+        const countryCluster = aggregator.getCountryClusters().find((c) => c.country === code);
+        if (countryCluster) {
+          context.convergenceScore = countryCluster.convergenceScore;
+          context.signalTypes = [...countryCluster.signalTypes];
         }
 
-        if (fallbackBrief) {
-          this.ctx.countryBriefPage?.updateBrief({ brief: fallbackBrief, country, code, fallback: true, sources: briefSources });
-        } else {
-          const lines: string[] = [];
-          if (score) lines.push(t('countryBrief.fallback.instabilityIndex', { score: String(score.score), level: t(`countryBrief.levels.${score.level}`), trend: t(`countryBrief.trends.${score.trend}`) }));
-          if (signals.protests > 0) lines.push(t('countryBrief.fallback.protestsDetected', { count: String(signals.protests) }));
-          if (signals.militaryFlights > 0) lines.push(t('countryBrief.fallback.aircraftTracked', { count: String(signals.militaryFlights) }));
-          if (signals.militaryVessels > 0) lines.push(t('countryBrief.fallback.vesselsTracked', { count: String(signals.militaryVessels) }));
-          if (signals.activeStrikes > 0) lines.push(t('countryBrief.fallback.activeStrikes', { count: String(signals.activeStrikes) }));
-          if (signals.travelAdvisoryMaxLevel === 'do-not-travel') lines.push(`⚠️ Travel advisory: Do Not Travel (${signals.travelAdvisories} source${signals.travelAdvisories > 1 ? 's' : ''})`);
-          else if (signals.travelAdvisoryMaxLevel === 'reconsider') lines.push(`⚠️ Travel advisory: Reconsider Travel (${signals.travelAdvisories} source${signals.travelAdvisories > 1 ? 's' : ''})`);
-          if (signals.outages > 0) lines.push(t('countryBrief.fallback.internetOutages', { count: String(signals.outages) }));
-          if (signals.criticalNews > 0) lines.push(`🚨 Critical headlines in scope: ${signals.criticalNews}`);
-          if (signals.cyberThreats > 0) lines.push(`🛡️ Cyber threat indicators: ${signals.cyberThreats}`);
-          if (signals.aisDisruptions > 0) lines.push(`🚢 Maritime AIS disruptions: ${signals.aisDisruptions}`);
-          if (signals.satelliteFires > 0) lines.push(`🔥 Satellite fire detections: ${signals.satelliteFires}`);
-          if (signals.radiationAnomalies > 0) lines.push(`☢️ Radiation anomalies: ${signals.radiationAnomalies}`);
-          if (signals.temporalAnomalies > 0) lines.push(`⏱️ Temporal anomaly alerts: ${signals.temporalAnomalies}`);
-          if (signals.thermalEscalations > 0) lines.push(`🌡️ Thermal escalation clusters: ${signals.thermalEscalations}`);
-          if (signals.earthquakes > 0) lines.push(t('countryBrief.fallback.recentEarthquakes', { count: String(signals.earthquakes) }));
-          if (signals.orefHistory24h > 0) lines.push(`🚨 Sirens in past 24h: ${signals.orefHistory24h}`);
-          if (context.stockIndex) lines.push(t('countryBrief.fallback.stockIndex', { value: context.stockIndex }));
-          if (lines.length > 0) {
-            this.ctx.countryBriefPage?.updateBrief({ brief: lines.join('\n'), country, code, fallback: true });
-          } else {
-            this.ctx.countryBriefPage?.updateBrief({ brief: '', country, code, error: 'No AI service available. Configure GROQ_API_KEY in Settings for full briefs.' });
+        const convergences = aggregator.getRegionalConvergence()
+          .filter((r) => r.countries.includes(code));
+        if (convergences.length) {
+          context.regionalConvergence = convergences.map((r) => r.description);
+        }
+
+        if (this.ctx.intelligenceCache.advisories) {
+          const countryAdvisories = this.ctx.intelligenceCache.advisories.filter(a => a.country === code);
+          if (countryAdvisories.length > 0) {
+            context.travelAdvisories = countryAdvisories.map(a => ({ source: a.source, level: a.level, title: a.title }));
           }
         }
+
+        const groundingNews = filteredNews.slice(0, 15);
+        let briefSources = collectBriefSources(groundingNews, 6);
+        const headlines = groundingNews.map((n) => n.title);
+        if (headlines.length) context.headlines = headlines;
+        if (briefSources.length) context.briefSources = briefSources;
+        const briefHeadlines = (context.headlines as string[] | undefined) || [];
+
+        const stockData = await stockPromise;
+        if (token !== this.briefRequestToken || this.ctx.countryBriefPage?.getCode() !== code) return;
+        if (stockData.available) {
+          const pct = parseFloat(stockData.weekChangePercent);
+          context.stockIndex = `${stockData.indexName}: ${stockData.price} (${pct >= 0 ? '+' : ''}${stockData.weekChangePercent}% week)`;
+        }
+
+        let briefText = '';
+        let briefResult: CountryIntelBriefResult | null = null;
+        try {
+          let contextSnapshot = this.buildBriefContextSnapshot(country, code, score, signals, context);
+
+          if (isHeadlineMemoryEnabled() && mlWorker.isAvailable && mlWorker.isModelLoaded('embeddings') && briefHeadlines.length > 0) {
+            try {
+              const results = await mlWorker.vectorStoreSearch(briefHeadlines.slice(0, 3), 5, 0.3);
+              if (token !== this.briefRequestToken || this.ctx.countryBriefPage?.getCode() !== code) return;
+              if (results.length > 0) {
+                const historical = results.map(r =>
+                  `- ${r.text} (${new Date(r.pubDate).toISOString().slice(0, 10)})`
+                ).join('\n').slice(0, 350);
+                contextSnapshot = contextSnapshot.slice(0, 1800)
+                  + `\n[BEGIN HISTORICAL DATA]\n${historical}\n[END HISTORICAL DATA]`;
+              }
+            } catch { /* RAG unavailable */ }
+          }
+
+          const countryFw = getActiveFrameworkForPanel('country-brief');
+          briefResult = await this.fetchCountryIntelBrief(code, contextSnapshot, countryFw?.systemPromptAppend ?? '');
+          if (token !== this.briefRequestToken || this.ctx.countryBriefPage?.getCode() !== code) return;
+          briefText = briefResult.brief;
+          if (briefResult.sources.length > 0) {
+            briefSources = briefResult.sources;
+          }
+        } catch { /* server unreachable */ }
+
+        if (briefText) {
+          this.ctx.countryBriefPage?.updateBrief({
+            brief: briefText,
+            country,
+            code,
+            sources: briefSources,
+            generatedAt: briefResult?.generatedAt,
+            cached: briefResult?.cached,
+          });
+        } else {
+          let fallbackBrief = '';
+          const sumModelId = BETA_MODE ? 'summarization-beta' : 'summarization';
+          if (briefHeadlines.length >= 2 && mlWorker.isAvailable && mlWorker.isModelLoaded(sumModelId)) {
+            try {
+              const lang = getCurrentLanguage();
+              const prompt = lang === 'fr'
+                ? `Résumez la situation actuelle en ${country} à partir de ces titres : ${briefHeadlines.slice(0, 8).join('. ')}`
+                : `Summarize the current situation in ${country} based on these headlines: ${briefHeadlines.slice(0, 8).join('. ')}`;
+
+              const [summary] = await mlWorker.summarize([prompt], BETA_MODE ? 'summarization-beta' : undefined);
+              if (token !== this.briefRequestToken || this.ctx.countryBriefPage?.getCode() !== code) return;
+              if (summary && summary.length > 20) fallbackBrief = summary;
+            } catch { /* T5 failed */ }
+          }
+
+          if (fallbackBrief) {
+            this.ctx.countryBriefPage?.updateBrief({ brief: fallbackBrief, country, code, fallback: true, sources: briefSources });
+          } else {
+            const lines: string[] = [];
+            if (score) lines.push(t('countryBrief.fallback.instabilityIndex', { score: String(score.score), level: t(`countryBrief.levels.${score.level}`), trend: t(`countryBrief.trends.${score.trend}`) }));
+            if (signals.protests > 0) lines.push(t('countryBrief.fallback.protestsDetected', { count: String(signals.protests) }));
+            if (signals.militaryFlights > 0) lines.push(t('countryBrief.fallback.aircraftTracked', { count: String(signals.militaryFlights) }));
+            if (signals.militaryVessels > 0) lines.push(t('countryBrief.fallback.vesselsTracked', { count: String(signals.militaryVessels) }));
+            if (signals.activeStrikes > 0) lines.push(t('countryBrief.fallback.activeStrikes', { count: String(signals.activeStrikes) }));
+            if (signals.travelAdvisoryMaxLevel === 'do-not-travel') lines.push(`⚠️ Travel advisory: Do Not Travel (${signals.travelAdvisories} source${signals.travelAdvisories > 1 ? 's' : ''})`);
+            else if (signals.travelAdvisoryMaxLevel === 'reconsider') lines.push(`⚠️ Travel advisory: Reconsider Travel (${signals.travelAdvisories} source${signals.travelAdvisories > 1 ? 's' : ''})`);
+            if (signals.outages > 0) lines.push(t('countryBrief.fallback.internetOutages', { count: String(signals.outages) }));
+            if (signals.criticalNews > 0) lines.push(`🚨 Critical headlines in scope: ${signals.criticalNews}`);
+            if (signals.cyberThreats > 0) lines.push(`🛡️ Cyber threat indicators: ${signals.cyberThreats}`);
+            if (signals.aisDisruptions > 0) lines.push(`🚢 Maritime AIS disruptions: ${signals.aisDisruptions}`);
+            if (signals.satelliteFires > 0) lines.push(`🔥 Satellite fire detections: ${signals.satelliteFires}`);
+            if (signals.radiationAnomalies > 0) lines.push(`☢️ Radiation anomalies: ${signals.radiationAnomalies}`);
+            if (signals.temporalAnomalies > 0) lines.push(`⏱️ Temporal anomaly alerts: ${signals.temporalAnomalies}`);
+            if (signals.thermalEscalations > 0) lines.push(`🌡️ Thermal escalation clusters: ${signals.thermalEscalations}`);
+            if (signals.earthquakes > 0) lines.push(t('countryBrief.fallback.recentEarthquakes', { count: String(signals.earthquakes) }));
+            if (signals.orefHistory24h > 0) lines.push(`🚨 Sirens in past 24h: ${signals.orefHistory24h}`);
+            if (context.stockIndex) lines.push(t('countryBrief.fallback.stockIndex', { value: context.stockIndex }));
+            if (lines.length > 0) {
+              this.ctx.countryBriefPage?.updateBrief({ brief: lines.join('\n'), country, code, fallback: true });
+            } else {
+              this.ctx.countryBriefPage?.updateBrief({ brief: '', country, code, error: 'No AI service available. Configure GROQ_API_KEY in Settings for full briefs.' });
+            }
+          }
+        }
+      } catch (err) {
+        console.error('[CountryBrief] fetch error:', err);
+        if (token !== this.briefRequestToken || this.ctx.countryBriefPage?.getCode() !== code) return;
+        this.ctx.countryBriefPage?.updateBrief({ brief: '', country, code, error: 'Failed to generate brief' });
       }
     } catch (err) {
-      console.error('[CountryBrief] fetch error:', err);
-      this.ctx.countryBriefPage?.updateBrief({ brief: '', country, code, error: 'Failed to generate brief' });
+      if (token !== this.briefRequestToken) {
+        console.warn('[CountryBrief] Superseded country brief open failed after it was stale:', err);
+        return;
+      }
+      console.error('[CountryBrief] Failed to open country brief:', err);
+      if (!pageShown) {
+        const activePage = this.ctx.countryBriefPage;
+        const activeCode = activePage?.getCode();
+        if (activePage?.isVisible() && (activeCode === '__loading__' || activeCode === '__error__')) activePage.hide();
+        this.ctx.map?.setRenderPaused(false);
+        this.showToast('Country brief failed to open. Please try again.');
+      }
+    } finally {
+      if (!pageShown && token === this.briefRequestToken) {
+        this.ctx.map?.setRenderPaused(false);
+      }
     }
   }
-
   private fetchProSections(code: string): void {
     // /pro live-preview iframe can't carry a Clerk session, so every pro
     // section call would 401. Skip the RPCs entirely so the embedded
@@ -817,7 +868,9 @@ export class CountryIntelManager implements AppModule {
       .then((signals) => {
         if (page.isVisible() && page.getCode() === code) page.updateScore?.(score, signals);
       })
-      .catch(() => {});
+      .catch((err) => {
+        console.warn('[CountryBrief] refreshOpenBrief signal fetch failed:', err);
+      });
   }
 
   private async fetchCountryIntelBrief(code: string, contextSnapshot: string, framework = ''): Promise<CountryIntelBriefResult> {

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -22,7 +22,6 @@ import {
 } from '@/services/country-geometry';
 import { calculateCII, getCountryData, TIER1_COUNTRIES, type CountryScore } from '@/services/country-instability';
 import { getCachedCountryScore, normalizeCiiCountryCode } from '@/services/cached-risk-scores';
-import { signalAggregator } from '@/services/signal-aggregator';
 import { dataFreshness } from '@/services/data-freshness';
 import { fetchCountryMarkets } from '@/services/prediction';
 import { collectStoryData } from '@/services/story-data';
@@ -80,6 +79,14 @@ type CountryIntelBriefResult = {
   generatedAt?: string | number;
   cached?: boolean;
 };
+
+type SignalAggregator = typeof import('@/services/signal-aggregator').signalAggregator;
+let signalAggregatorPromise: Promise<SignalAggregator> | null = null;
+
+function getSignalAggregator(): Promise<SignalAggregator> {
+  signalAggregatorPromise ??= import('@/services/signal-aggregator').then(module => module.signalAggregator);
+  return signalAggregatorPromise;
+}
 
 export class CountryIntelManager implements AppModule {
   private ctx: AppContext;
@@ -178,13 +185,14 @@ export class CountryIntelManager implements AppModule {
     this.ctx.countryBriefPage = new CountryDeepDivePanel(this.ctx.map);
     this.ctx.countryBriefPage.setShareStoryHandler((code, name) => {
       this.ctx.countryBriefPage?.hide();
-      this.openCountryStory(code, name);
+      void this.openCountryStory(code, name);
     });
     this.ctx.countryBriefPage.setExportImageHandler(async (code, name) => {
       try {
-        const signals = this.getCountrySignals(code, name);
-        const cluster = signalAggregator.getCountryClusters().find(c => c.country === code);
-        const regional = signalAggregator.getRegionalConvergence().filter(r => r.countries.includes(code));
+        const aggregator = await getSignalAggregator();
+        const signals = await this.getCountrySignals(code, name);
+        const cluster = aggregator.getCountryClusters().find(c => c.country === code);
+        const regional = aggregator.getRegionalConvergence().filter(r => r.countries.includes(code));
         const convergence = cluster ? {
           score: cluster.convergenceScore,
           signalTypes: [...cluster.signalTypes],
@@ -254,7 +262,7 @@ export class CountryIntelManager implements AppModule {
     const scoreCode = normalizeCiiCountryCode(code);
     const score = getCachedCountryScore(scoreCode) ?? calculateCII().find((s) => s.code === scoreCode) ?? null;
 
-    const signals = this.getCountrySignals(code, country);
+    const signals = await this.getCountrySignals(code, country);
 
     page.show(country, code, score, signals);
     this.ctx.map?.highlightCountry(code);
@@ -268,7 +276,7 @@ export class CountryIntelManager implements AppModule {
         }
       });
     }
-    page.updateSignalDetails?.(this.buildSignalDetails(code));
+    page.updateSignalDetails?.(await this.buildSignalDetails(code));
     page.updateMilitaryActivity?.(this.buildMilitarySummary(code, country));
     page.updateEconomicIndicators?.(this.buildEconomicIndicators(code, score, null));
 
@@ -545,13 +553,14 @@ export class CountryIntelManager implements AppModule {
       }
       Object.assign(context, signals);
 
-      const countryCluster = signalAggregator.getCountryClusters().find((c) => c.country === code);
+      const aggregator = await getSignalAggregator();
+      const countryCluster = aggregator.getCountryClusters().find((c) => c.country === code);
       if (countryCluster) {
         context.convergenceScore = countryCluster.convergenceScore;
         context.signalTypes = [...countryCluster.signalTypes];
       }
 
-      const convergences = signalAggregator.getRegionalConvergence()
+      const convergences = aggregator.getRegionalConvergence()
         .filter((r) => r.countries.includes(code));
       if (convergences.length) {
         context.regionalConvergence = convergences.map((r) => r.description);
@@ -796,8 +805,11 @@ export class CountryIntelManager implements AppModule {
     const name = TIER1_COUNTRIES[code] ?? CountryIntelManager.resolveCountryName(code);
     const scoreCode = normalizeCiiCountryCode(code);
     const score = getCachedCountryScore(scoreCode) ?? calculateCII().find((s) => s.code === scoreCode) ?? null;
-    const signals = this.getCountrySignals(code, name);
-    page.updateScore?.(score, signals);
+    void this.getCountrySignals(code, name)
+      .then((signals) => {
+        if (page.isVisible() && page.getCode() === code) page.updateScore?.(score, signals);
+      })
+      .catch(() => {});
   }
 
   private async fetchCountryIntelBrief(code: string, contextSnapshot: string, framework = ''): Promise<CountryIntelBriefResult> {
@@ -1052,10 +1064,10 @@ export class CountryIntelManager implements AppModule {
     this.ctx.countryTimeline.render(events.filter(e => e.timestamp >= sevenDaysAgo));
   }
 
-  getCountrySignals(code: string, country: string): CountryBriefSignals {
+  async getCountrySignals(code: string, country: string): Promise<CountryBriefSignals> {
     const countryLower = country.toLowerCase();
     const hasGeoShape = hasCountryGeometry(code) || !!CountryIntelManager.COUNTRY_BOUNDS[code];
-    const clusters = signalAggregator.getCountryClusters();
+    const clusters = (await getSignalAggregator()).getCountryClusters();
     const countryCluster = clusters.find(c => c.country === code);
     const globalCluster = clusters.find(c => c.country === 'XX');
     const signalTypeCounts = {
@@ -1222,8 +1234,8 @@ export class CountryIntelManager implements AppModule {
     return 1;
   }
 
-  private buildSignalDetails(code: string): CountryDeepDiveSignalDetails {
-    const cluster = signalAggregator.getCountryClusters().find((entry) => entry.country === code);
+  private async buildSignalDetails(code: string): Promise<CountryDeepDiveSignalDetails> {
+    const cluster = (await getSignalAggregator()).getCountryClusters().find((entry) => entry.country === code);
     if (!cluster) {
       return { critical: 0, high: 0, medium: 0, low: 0, recentHigh: [] };
     }
@@ -1403,16 +1415,17 @@ export class CountryIntelManager implements AppModule {
     return 'low';
   }
 
-  openCountryStory(code: string, name: string): void {
+  async openCountryStory(code: string, name: string): Promise<void> {
     if (!dataFreshness.hasSufficientData() || this.ctx.latestClusters.length === 0) {
       this.showToast('Data still loading — try again in a moment');
       return;
     }
     const posturePanel = this.ctx.panels['strategic-posture'] as StrategicPosturePanel | undefined;
     const postures = posturePanel?.getPostures() || [];
-    const signals = this.getCountrySignals(code, name);
-    const cluster = signalAggregator.getCountryClusters().find(c => c.country === code);
-    const regional = signalAggregator.getRegionalConvergence().filter(r => r.countries.includes(code));
+    const aggregator = await getSignalAggregator();
+    const signals = await this.getCountrySignals(code, name);
+    const cluster = aggregator.getCountryClusters().find(c => c.country === code);
+    const regional = aggregator.getRegionalConvergence().filter(r => r.countries.includes(code));
     const convergence = cluster ? {
       score: cluster.convergenceScore,
       signalTypes: [...cluster.signalTypes],

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -25,8 +25,6 @@ import { INTEL_HOTSPOTS, CONFLICT_ZONES } from '@/config/geo';
 import { tokenizeForMatch, matchKeyword } from '@/utils/keyword-match';
 import { withTimeout } from '@/utils/with-timeout';
 import {
-  fetchCategoryFeeds,
-  getFeedFailures,
   fetchMultipleStocks,
   fetchCommodityQuotes,
   fetchSectors,
@@ -112,7 +110,6 @@ import { displayPubDateMs, effectivePubDateMs } from '@/services/feed-date';
 import { mlWorker } from '@/services/ml-worker';
 import { clusterNewsHybrid } from '@/services/clustering';
 import { ingestProtests, ingestFlights, ingestVessels, ingestEarthquakes, detectGeoConvergence, geoConvergenceToSignal } from '@/services/geo-convergence';
-import { signalAggregator } from '@/services/signal-aggregator';
 import { updateAndCheck, consumeServerAnomalies, fetchLiveAnomalies } from '@/services/temporal-baseline';
 import { fetchAllFires, flattenFires, computeRegionStats, toMapFires } from '@/services/wildfires';
 import type { TheaterPostureSummary } from '@/services/military-surge';
@@ -140,7 +137,6 @@ import { isDesktopRuntime, toApiUrl } from '@/services/runtime';
 import { getAiFlowSettings } from '@/services/ai-flow-settings';
 import { t, getCurrentLanguage } from '@/services/i18n';
 import { getHydratedData } from '@/services/bootstrap';
-import { ingestHeadlines } from '@/services/trending-keywords';
 import type { ListFeedDigestResponse } from '@/generated/client/worldmonitor/news/v1/service_client';
 import type { GetSectorSummaryResponse, ListMarketQuotesResponse, ListCommodityQuotesResponse } from '@/generated/client/worldmonitor/market/v1/service_client';
 import type {
@@ -191,14 +187,10 @@ import type { HappyContentCategory } from '@/services/positive-classifier';
 import { fetchKindnessData } from '@/services/kindness-data';
 import { getPersistentCache, setPersistentCache } from '@/services/persistent-cache';
 import { getActiveFrameworkForPanel, subscribeFrameworkChange } from '@/services/analysis-framework-store';
-import {
-  buildDailyMarketBrief,
-  cacheDailyMarketBrief,
-  getCachedDailyMarketBrief,
-  shouldRefreshDailyBrief,
-  type RegimeMacroContext,
-  type YieldCurveContext,
-  type SectorBriefContext,
+import type {
+  RegimeMacroContext,
+  YieldCurveContext,
+  SectorBriefContext,
 } from '@/services/daily-market-brief';
 import { fetchCachedRiskScores, getCachedScores, toCountryScore, type CachedRiskScores } from '@/services/cached-risk-scores';
 import type { ThreatLevel as ClientThreatLevel } from '@/types';
@@ -276,6 +268,36 @@ type HydrationTask = {
 };
 
 type HydrationTier = 1 | 2 | 3 | 4;
+type DailyMarketBriefModule = typeof import('@/services/daily-market-brief');
+type RssModule = Pick<typeof import('@/services/rss'), 'fetchCategoryFeeds' | 'getFeedFailures'>;
+type SignalAggregator = typeof import('@/services/signal-aggregator').signalAggregator;
+type TrendingHeadlineInput = import('@/services/trending-keywords').TrendingHeadlineInput;
+
+let dailyMarketBriefModulePromise: Promise<DailyMarketBriefModule> | null = null;
+let rssModulePromise: Promise<RssModule> | null = null;
+let signalAggregatorPromise: Promise<SignalAggregator> | null = null;
+let ingestHeadlinesPromise: Promise<(headlines: TrendingHeadlineInput[]) => void> | null = null;
+
+function getDailyMarketBriefModule(): Promise<DailyMarketBriefModule> {
+  dailyMarketBriefModulePromise ??= import('@/services/daily-market-brief');
+  return dailyMarketBriefModulePromise;
+}
+
+function getRssModule(): Promise<RssModule> {
+  rssModulePromise ??= import('@/services/rss');
+  return rssModulePromise;
+}
+
+function getSignalAggregator(): Promise<SignalAggregator> {
+  signalAggregatorPromise ??= import('@/services/signal-aggregator').then(module => module.signalAggregator);
+  return signalAggregatorPromise;
+}
+
+async function ingestTrendingHeadlines(headlines: TrendingHeadlineInput[]): Promise<void> {
+  ingestHeadlinesPromise ??= import('@/services/trending-keywords').then(module => module.ingestHeadlines);
+  const ingestHeadlines = await ingestHeadlinesPromise;
+  ingestHeadlines(headlines);
+}
 
 const HYDRATION_TIER_ONE = new Set(['news', 'markets', 'intelligence']);
 const HYDRATION_TIER_TWO = new Set([
@@ -803,7 +825,7 @@ export class DataLoaderManager implements AppModule {
 
     const bootstrapTemporal = consumeServerAnomalies();
     if (bootstrapTemporal.anomalies.length > 0 || bootstrapTemporal.trackedTypes.length > 0) {
-      signalAggregator.ingestTemporalAnomalies(bootstrapTemporal.anomalies, bootstrapTemporal.trackedTypes);
+      (await getSignalAggregator()).ingestTemporalAnomalies(bootstrapTemporal.anomalies, bootstrapTemporal.trackedTypes);
       ingestTemporalAnomaliesForCII(bootstrapTemporal.anomalies);
       this.refreshCiiAndBrief();
     } else {
@@ -813,7 +835,7 @@ export class DataLoaderManager implements AppModule {
 
   async refreshTemporalBaseline(): Promise<void> {
     const { anomalies, trackedTypes } = await fetchLiveAnomalies();
-    signalAggregator.ingestTemporalAnomalies(anomalies, trackedTypes);
+    (await getSignalAggregator()).ingestTemporalAnomalies(anomalies, trackedTypes);
     ingestTemporalAnomaliesForCII(anomalies);
     this.refreshCiiAndBrief();
   }
@@ -1108,7 +1130,8 @@ export class DataLoaderManager implements AppModule {
           .map(protoItemToNewsItem)
           .filter(i => enabledNames.has(i.source));
 
-        ingestHeadlines(items.map(i => ({ title: i.title, pubDate: i.pubDate, source: i.source, link: i.link })));
+        void ingestTrendingHeadlines(items.map(i => ({ title: i.title, pubDate: i.pubDate, source: i.source, link: i.link })))
+          .catch(() => {});
 
         // Skip client-side AI reclassification for digest items.
         // The server already ran enrichWithAiCache() which checks the same Redis keys
@@ -1216,6 +1239,7 @@ export class DataLoaderManager implements AppModule {
         console.warn(`[News] Digest missing for "${category}", using per-feed fallback (${fallbackFeeds.length} feeds)`);
       }
 
+      const { fetchCategoryFeeds, getFeedFailures } = await getRssModule();
       const items = await fetchCategoryFeeds(fallbackFeeds, {
         batchSize: this.perFeedFallbackBatchSize,
         onBatch: (partialItems) => {
@@ -1334,6 +1358,7 @@ export class DataLoaderManager implements AppModule {
 
     let intel: NewsItem[];
     try {
+      const { fetchCategoryFeeds } = await getRssModule();
       intel = await fetchCategoryFeeds(fallbackIntelFeeds, { batchSize: this.perFeedFallbackBatchSize });
     } catch (e) {
       delete this.ctx.newsByCategory['intel'];
@@ -1874,13 +1899,15 @@ export class DataLoaderManager implements AppModule {
     this.dailyBriefGeneration++;
     const gen = this.dailyBriefGeneration;
     this.ctx.inFlight.add('dailyMarketBrief');
+    let dailyMarketBrief: DailyMarketBriefModule | null = null;
     try {
       const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+      dailyMarketBrief = await getDailyMarketBriefModule();
       // Bound the IndexedDB cache read so a hung persistent-cache layer
       // can't keep the panel on its default Loading state forever — fall
       // through to "build from scratch" instead.
       const cached = await withTimeout(
-        getCachedDailyMarketBrief(timezone),
+        dailyMarketBrief.getCachedDailyMarketBrief(timezone),
         3_000,
         'daily-brief-cache-read',
       ).catch(() => null);
@@ -1889,7 +1916,7 @@ export class DataLoaderManager implements AppModule {
         this.callPanel('daily-market-brief', 'renderBrief', cached, 'cached');
       }
 
-      if (!force && cached && !shouldRefreshDailyBrief(cached, timezone)) {
+      if (!force && cached && !dailyMarketBrief.shouldRefreshDailyBrief(cached, timezone)) {
         return;
       }
 
@@ -1925,7 +1952,7 @@ export class DataLoaderManager implements AppModule {
       // resolves). On timeout the existing catch below serves the cached
       // version or shows an error, never letting the panel stay stuck.
       const brief = await withTimeout(
-        buildDailyMarketBrief({
+        dailyMarketBrief.buildDailyMarketBrief({
           markets: this.ctx.latestMarkets,
           newsByCategory: this.ctx.newsByCategory,
           timezone,
@@ -1953,7 +1980,7 @@ export class DataLoaderManager implements AppModule {
       }
 
       // Render first, persist after. The previous order `await
-      // cacheDailyMarketBrief(brief); render(brief)` meant a hung
+      // dailyMarketBrief.cacheDailyMarketBrief(brief); render(brief)` meant a hung
       // IndexedDB / Tauri-Store write blocked the panel from ever
       // displaying the finished brief — the build budget proved nothing
       // by itself. Now: user sees the brief immediately; the cache write
@@ -1962,7 +1989,7 @@ export class DataLoaderManager implements AppModule {
       // on Building forever."
       this.callPanel('daily-market-brief', 'renderBrief', brief, 'live');
       void withTimeout(
-        cacheDailyMarketBrief(brief),
+        dailyMarketBrief.cacheDailyMarketBrief(brief),
         5_000,
         'daily-brief-cache-write',
       ).catch((err) => {
@@ -1978,11 +2005,13 @@ export class DataLoaderManager implements AppModule {
       // state was. .catch(() => null) absorbs both the TimeoutError and
       // any persistent-cache read failure into the same null-result
       // branch that the existing showError fallback already handles.
-      const cached = await withTimeout(
-        getCachedDailyMarketBrief(timezone),
-        3_000,
-        'daily-brief-cache-read-recovery',
-      ).catch(() => null);
+      const cached = dailyMarketBrief
+        ? await withTimeout(
+          dailyMarketBrief.getCachedDailyMarketBrief(timezone),
+          3_000,
+          'daily-brief-cache-read-recovery',
+        ).catch(() => null)
+        : null;
       if (cached?.available) {
         this.callPanel('daily-market-brief', 'renderBrief', cached, 'cached');
         return;
@@ -2285,7 +2314,7 @@ export class DataLoaderManager implements AppModule {
         const outages = await fetchInternetOutages();
         this.ctx.intelligenceCache.outages = outages;
         ingestOutagesForCII(outages);
-        signalAggregator.ingestOutages(outages);
+        (await getSignalAggregator()).ingestOutages(outages);
         dataFreshness.recordUpdate('outages', outages.length);
         if (this.ctx.mapLayers.outages) {
           this.ctx.map?.setOutages(outages);
@@ -2313,7 +2342,7 @@ export class DataLoaderManager implements AppModule {
         this.ctx.intelligenceCache.protests = protestData;
         ingestProtests(protestData.events);
         ingestProtestsForCII(protestData.events);
-        signalAggregator.ingestProtests(protestData.events);
+        (await getSignalAggregator()).ingestProtests(protestData.events);
         const protestCount = protestData.sources.acled + protestData.sources.gdelt;
         if (protestCount > 0) dataFreshness.recordUpdate('acled', protestCount);
         if (protestData.sources.gdelt > 0) dataFreshness.recordUpdate('gdelt', protestData.sources.gdelt);
@@ -2393,15 +2422,15 @@ export class DataLoaderManager implements AppModule {
         ingestFlights(flightData.flights);
         ingestVessels(vesselData.vessels);
         ingestMilitaryForCII(flightData.flights, vesselData.vessels);
-        signalAggregator.ingestFlights(flightData.flights);
-        signalAggregator.ingestVessels(vesselData.vessels);
+        (await getSignalAggregator()).ingestFlights(flightData.flights);
+        (await getSignalAggregator()).ingestVessels(vesselData.vessels);
         dataFreshness.recordUpdate('opensky', flightData.flights.length);
         updateAndCheck([
           { type: 'military_flights', region: 'global', count: flightData.flights.length },
           { type: 'vessels', region: 'global', count: vesselData.vessels.length },
-        ]).then(anomalies => {
+        ]).then(async anomalies => {
           if (anomalies.length > 0) {
-            signalAggregator.ingestTemporalAnomalies(anomalies);
+            (await getSignalAggregator()).ingestTemporalAnomalies(anomalies);
             ingestTemporalAnomaliesForCII(anomalies);
             this.refreshCiiAndBrief();
           }
@@ -2595,7 +2624,7 @@ export class DataLoaderManager implements AppModule {
       this.ctx.map?.setOutages(outages);
       this.ctx.map?.setLayerReady('outages', outages.length > 0);
       ingestOutagesForCII(outages);
-      signalAggregator.ingestOutages(outages);
+      (await getSignalAggregator()).ingestOutages(outages);
       this.ctx.statusPanel?.updateFeed('NetBlocks', { status: 'ok', itemCount: outages.length });
       dataFreshness.recordUpdate('outages', outages.length);
       (this.ctx.panels['internet-disruptions'] as InternetDisruptionsPanel)?.setOutages(outages);
@@ -2656,7 +2685,7 @@ export class DataLoaderManager implements AppModule {
       this.ctx.map?.setIranEvents(events);
       this.ctx.map?.setLayerReady('iranAttacks', events.length > 0);
       const coerced = events.map(e => ({ ...e, timestamp: Number(e.timestamp) || 0 }));
-      signalAggregator.ingestConflictEvents(coerced);
+      (await getSignalAggregator()).ingestConflictEvents(coerced);
       ingestStrikesForCII(coerced);
       this.refreshCiiAndBrief();
     } catch {
@@ -2670,14 +2699,14 @@ export class DataLoaderManager implements AppModule {
       const aisStatus = getAisStatus();
       console.log('[Ships] Events:', { disruptions: disruptions.length, density: density.length, vessels: aisStatus.vessels });
       this.ctx.map?.setAisData(disruptions, density);
-      signalAggregator.ingestAisDisruptions(disruptions);
+      (await getSignalAggregator()).ingestAisDisruptions(disruptions);
       ingestAisDisruptionsForCII(disruptions);
       this.refreshCiiAndBrief();
       updateAndCheck([
         { type: 'ais_gaps', region: 'global', count: disruptions.length },
-      ]).then(anomalies => {
+      ]).then(async anomalies => {
         if (anomalies.length > 0) {
-          signalAggregator.ingestTemporalAnomalies(anomalies);
+          (await getSignalAggregator()).ingestTemporalAnomalies(anomalies);
           ingestTemporalAnomaliesForCII(anomalies);
           this.refreshCiiAndBrief();
         }
@@ -2789,7 +2818,7 @@ export class DataLoaderManager implements AppModule {
       this.ctx.map?.setLayerReady('protests', protestData.events.length > 0);
       ingestProtests(protestData.events);
       ingestProtestsForCII(protestData.events);
-      signalAggregator.ingestProtests(protestData.events);
+      (await getSignalAggregator()).ingestProtests(protestData.events);
       const protestCount = protestData.sources.acled + protestData.sources.gdelt;
       if (protestCount > 0) dataFreshness.recordUpdate('acled', protestCount);
       if (protestData.sources.gdelt > 0) dataFreshness.recordUpdate('gdelt', protestData.sources.gdelt);
@@ -2921,14 +2950,14 @@ export class DataLoaderManager implements AppModule {
       ingestFlights(flightData.flights);
       ingestVessels(vesselData.vessels);
       ingestMilitaryForCII(flightData.flights, vesselData.vessels);
-      signalAggregator.ingestFlights(flightData.flights);
-      signalAggregator.ingestVessels(vesselData.vessels);
+      (await getSignalAggregator()).ingestFlights(flightData.flights);
+      (await getSignalAggregator()).ingestVessels(vesselData.vessels);
       updateAndCheck([
         { type: 'military_flights', region: 'global', count: flightData.flights.length },
         { type: 'vessels', region: 'global', count: vesselData.vessels.length },
-      ]).then(anomalies => {
+      ]).then(async anomalies => {
         if (anomalies.length > 0) {
-          signalAggregator.ingestTemporalAnomalies(anomalies);
+          (await getSignalAggregator()).ingestTemporalAnomalies(anomalies);
           ingestTemporalAnomaliesForCII(anomalies);
           this.refreshCiiAndBrief();
         }
@@ -3374,7 +3403,7 @@ export class DataLoaderManager implements AppModule {
           acq_date: new Date(f.detectedAt).toISOString().slice(0, 10),
         }));
 
-        signalAggregator.ingestSatelliteFires(satelliteFires);
+        (await getSignalAggregator()).ingestSatelliteFires(satelliteFires);
         ingestSatelliteFiresForCII(satelliteFires);
         this.refreshCiiAndBrief();
 
@@ -3622,7 +3651,7 @@ export class DataLoaderManager implements AppModule {
       const result = await fetchSanctionsPressure();
       this.callPanel('sanctions-pressure', 'setData', result);
       this.ctx.intelligenceCache.sanctions = result;
-      signalAggregator.ingestSanctionsPressure(result.countries);
+      (await getSignalAggregator()).ingestSanctionsPressure(result.countries);
       ingestSanctionsForCII(result.countries);
       if (result.totalCount > 0) {
         dataFreshness.recordUpdate('sanctions_pressure', result.totalCount);
@@ -3663,7 +3692,7 @@ export class DataLoaderManager implements AppModule {
       const anomalies = result.observations.filter((observation) => observation.severity !== 'normal');
       this.callPanel('radiation-watch', 'setData', result);
       this.ctx.intelligenceCache.radiation = result;
-      signalAggregator.ingestRadiationObservations(result.observations);
+      (await getSignalAggregator()).ingestRadiationObservations(result.observations);
       this.ctx.map?.setRadiationObservations(anomalies);
       this.ctx.map?.setLayerReady('radiationWatch', anomalies.length > 0);
       if (result.observations.length > 0) {

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -321,11 +321,21 @@ async function drainTrendingSignalQueue(): Promise<ReturnType<DrainTrendingSigna
   }
 }
 
-async function runSignalAggregator(context: string, ingest: (aggregator: SignalAggregator) => void): Promise<void> {
+async function runSignalAggregator(
+  statusPanel: AppContext['statusPanel'] | undefined,
+  context: string,
+  ingest: (aggregator: SignalAggregator) => void,
+): Promise<void> {
   try {
     ingest(await getSignalAggregator());
+    statusPanel?.updateApi('Signal Aggregator', { status: 'ok', errorMessage: undefined });
   } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
     console.warn(`[SignalAggregator] ${context} skipped:`, err);
+    statusPanel?.updateApi('Signal Aggregator', {
+      status: 'error',
+      errorMessage: `${context}: ${errorMessage}`,
+    });
   }
 }
 
@@ -855,7 +865,7 @@ export class DataLoaderManager implements AppModule {
 
     const bootstrapTemporal = consumeServerAnomalies();
     if (bootstrapTemporal.anomalies.length > 0 || bootstrapTemporal.trackedTypes.length > 0) {
-      await runSignalAggregator('bootstrap temporal anomalies', (aggregator) => aggregator.ingestTemporalAnomalies(bootstrapTemporal.anomalies, bootstrapTemporal.trackedTypes));
+      await runSignalAggregator(this.ctx.statusPanel, 'bootstrap temporal anomalies', (aggregator) => aggregator.ingestTemporalAnomalies(bootstrapTemporal.anomalies, bootstrapTemporal.trackedTypes));
       ingestTemporalAnomaliesForCII(bootstrapTemporal.anomalies);
       this.refreshCiiAndBrief();
     } else {
@@ -865,7 +875,7 @@ export class DataLoaderManager implements AppModule {
 
   async refreshTemporalBaseline(): Promise<void> {
     const { anomalies, trackedTypes } = await fetchLiveAnomalies();
-    await runSignalAggregator('temporal baseline anomalies', (aggregator) => aggregator.ingestTemporalAnomalies(anomalies, trackedTypes));
+    await runSignalAggregator(this.ctx.statusPanel, 'temporal baseline anomalies', (aggregator) => aggregator.ingestTemporalAnomalies(anomalies, trackedTypes));
     ingestTemporalAnomaliesForCII(anomalies);
     this.refreshCiiAndBrief();
   }
@@ -2346,7 +2356,7 @@ export class DataLoaderManager implements AppModule {
         const outages = await fetchInternetOutages();
         this.ctx.intelligenceCache.outages = outages;
         ingestOutagesForCII(outages);
-        await runSignalAggregator('outages', (aggregator) => aggregator.ingestOutages(outages));
+        await runSignalAggregator(this.ctx.statusPanel, 'outages', (aggregator) => aggregator.ingestOutages(outages));
         dataFreshness.recordUpdate('outages', outages.length);
         if (this.ctx.mapLayers.outages) {
           this.ctx.map?.setOutages(outages);
@@ -2374,7 +2384,7 @@ export class DataLoaderManager implements AppModule {
         this.ctx.intelligenceCache.protests = protestData;
         ingestProtests(protestData.events);
         ingestProtestsForCII(protestData.events);
-        await runSignalAggregator('protests', (aggregator) => aggregator.ingestProtests(protestData.events));
+        await runSignalAggregator(this.ctx.statusPanel, 'protests', (aggregator) => aggregator.ingestProtests(protestData.events));
         const protestCount = protestData.sources.acled + protestData.sources.gdelt;
         if (protestCount > 0) dataFreshness.recordUpdate('acled', protestCount);
         if (protestData.sources.gdelt > 0) dataFreshness.recordUpdate('gdelt', protestData.sources.gdelt);
@@ -2454,7 +2464,7 @@ export class DataLoaderManager implements AppModule {
         ingestFlights(flightData.flights);
         ingestVessels(vesselData.vessels);
         ingestMilitaryForCII(flightData.flights, vesselData.vessels);
-        await runSignalAggregator('military tracks', (aggregator) => {
+        await runSignalAggregator(this.ctx.statusPanel, 'military tracks', (aggregator) => {
           aggregator.ingestFlights(flightData.flights);
           aggregator.ingestVessels(vesselData.vessels);
         });
@@ -2464,7 +2474,7 @@ export class DataLoaderManager implements AppModule {
           { type: 'vessels', region: 'global', count: vesselData.vessels.length },
         ]).then(async anomalies => {
           if (anomalies.length > 0) {
-            await runSignalAggregator('temporal anomalies', (aggregator) => aggregator.ingestTemporalAnomalies(anomalies));
+            await runSignalAggregator(this.ctx.statusPanel, 'temporal anomalies', (aggregator) => aggregator.ingestTemporalAnomalies(anomalies));
             ingestTemporalAnomaliesForCII(anomalies);
             this.refreshCiiAndBrief();
           }
@@ -2658,7 +2668,7 @@ export class DataLoaderManager implements AppModule {
       this.ctx.map?.setOutages(outages);
       this.ctx.map?.setLayerReady('outages', outages.length > 0);
       ingestOutagesForCII(outages);
-      await runSignalAggregator('outages', (aggregator) => aggregator.ingestOutages(outages));
+      await runSignalAggregator(this.ctx.statusPanel, 'outages', (aggregator) => aggregator.ingestOutages(outages));
       this.ctx.statusPanel?.updateFeed('NetBlocks', { status: 'ok', itemCount: outages.length });
       dataFreshness.recordUpdate('outages', outages.length);
       (this.ctx.panels['internet-disruptions'] as InternetDisruptionsPanel)?.setOutages(outages);
@@ -2719,7 +2729,7 @@ export class DataLoaderManager implements AppModule {
       this.ctx.map?.setIranEvents(events);
       this.ctx.map?.setLayerReady('iranAttacks', events.length > 0);
       const coerced = events.map(e => ({ ...e, timestamp: Number(e.timestamp) || 0 }));
-      await runSignalAggregator('iran conflict events', (aggregator) => aggregator.ingestConflictEvents(coerced));
+      await runSignalAggregator(this.ctx.statusPanel, 'iran conflict events', (aggregator) => aggregator.ingestConflictEvents(coerced));
       ingestStrikesForCII(coerced);
       this.refreshCiiAndBrief();
     } catch {
@@ -2733,14 +2743,14 @@ export class DataLoaderManager implements AppModule {
       const aisStatus = getAisStatus();
       console.log('[Ships] Events:', { disruptions: disruptions.length, density: density.length, vessels: aisStatus.vessels });
       this.ctx.map?.setAisData(disruptions, density);
-      await runSignalAggregator('AIS disruptions', (aggregator) => aggregator.ingestAisDisruptions(disruptions));
+      await runSignalAggregator(this.ctx.statusPanel, 'AIS disruptions', (aggregator) => aggregator.ingestAisDisruptions(disruptions));
       ingestAisDisruptionsForCII(disruptions);
       this.refreshCiiAndBrief();
       updateAndCheck([
         { type: 'ais_gaps', region: 'global', count: disruptions.length },
       ]).then(async anomalies => {
         if (anomalies.length > 0) {
-          await runSignalAggregator('temporal anomalies', (aggregator) => aggregator.ingestTemporalAnomalies(anomalies));
+          await runSignalAggregator(this.ctx.statusPanel, 'temporal anomalies', (aggregator) => aggregator.ingestTemporalAnomalies(anomalies));
           ingestTemporalAnomaliesForCII(anomalies);
           this.refreshCiiAndBrief();
         }
@@ -2852,7 +2862,7 @@ export class DataLoaderManager implements AppModule {
       this.ctx.map?.setLayerReady('protests', protestData.events.length > 0);
       ingestProtests(protestData.events);
       ingestProtestsForCII(protestData.events);
-      await runSignalAggregator('protests', (aggregator) => aggregator.ingestProtests(protestData.events));
+      await runSignalAggregator(this.ctx.statusPanel, 'protests', (aggregator) => aggregator.ingestProtests(protestData.events));
       const protestCount = protestData.sources.acled + protestData.sources.gdelt;
       if (protestCount > 0) dataFreshness.recordUpdate('acled', protestCount);
       if (protestData.sources.gdelt > 0) dataFreshness.recordUpdate('gdelt', protestData.sources.gdelt);
@@ -2984,7 +2994,7 @@ export class DataLoaderManager implements AppModule {
       ingestFlights(flightData.flights);
       ingestVessels(vesselData.vessels);
       ingestMilitaryForCII(flightData.flights, vesselData.vessels);
-      await runSignalAggregator('military tracks', (aggregator) => {
+      await runSignalAggregator(this.ctx.statusPanel, 'military tracks', (aggregator) => {
         aggregator.ingestFlights(flightData.flights);
         aggregator.ingestVessels(vesselData.vessels);
       });
@@ -2993,7 +3003,7 @@ export class DataLoaderManager implements AppModule {
         { type: 'vessels', region: 'global', count: vesselData.vessels.length },
       ]).then(async anomalies => {
         if (anomalies.length > 0) {
-          await runSignalAggregator('temporal anomalies', (aggregator) => aggregator.ingestTemporalAnomalies(anomalies));
+          await runSignalAggregator(this.ctx.statusPanel, 'temporal anomalies', (aggregator) => aggregator.ingestTemporalAnomalies(anomalies));
           ingestTemporalAnomaliesForCII(anomalies);
           this.refreshCiiAndBrief();
         }
@@ -3439,7 +3449,7 @@ export class DataLoaderManager implements AppModule {
           acq_date: new Date(f.detectedAt).toISOString().slice(0, 10),
         }));
 
-        await runSignalAggregator('satellite fires', (aggregator) => aggregator.ingestSatelliteFires(satelliteFires));
+        await runSignalAggregator(this.ctx.statusPanel, 'satellite fires', (aggregator) => aggregator.ingestSatelliteFires(satelliteFires));
         ingestSatelliteFiresForCII(satelliteFires);
         this.refreshCiiAndBrief();
 
@@ -3687,7 +3697,7 @@ export class DataLoaderManager implements AppModule {
       const result = await fetchSanctionsPressure();
       this.callPanel('sanctions-pressure', 'setData', result);
       this.ctx.intelligenceCache.sanctions = result;
-      await runSignalAggregator('sanctions pressure', (aggregator) => aggregator.ingestSanctionsPressure(result.countries));
+      await runSignalAggregator(this.ctx.statusPanel, 'sanctions pressure', (aggregator) => aggregator.ingestSanctionsPressure(result.countries));
       ingestSanctionsForCII(result.countries);
       if (result.totalCount > 0) {
         dataFreshness.recordUpdate('sanctions_pressure', result.totalCount);
@@ -3728,7 +3738,7 @@ export class DataLoaderManager implements AppModule {
       const anomalies = result.observations.filter((observation) => observation.severity !== 'normal');
       this.callPanel('radiation-watch', 'setData', result);
       this.ctx.intelligenceCache.radiation = result;
-      await runSignalAggregator('radiation observations', (aggregator) => aggregator.ingestRadiationObservations(result.observations));
+      await runSignalAggregator(this.ctx.statusPanel, 'radiation observations', (aggregator) => aggregator.ingestRadiationObservations(result.observations));
       this.ctx.map?.setRadiationObservations(anomalies);
       this.ctx.map?.setLayerReady('radiationWatch', anomalies.length > 0);
       if (result.observations.length > 0) {

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -279,22 +279,38 @@ let signalAggregatorPromise: Promise<SignalAggregator> | null = null;
 let ingestHeadlinesPromise: Promise<(headlines: TrendingHeadlineInput[]) => void> | null = null;
 
 function getDailyMarketBriefModule(): Promise<DailyMarketBriefModule> {
-  dailyMarketBriefModulePromise ??= import('@/services/daily-market-brief');
+  dailyMarketBriefModulePromise ??= import('@/services/daily-market-brief').catch((err) => {
+    dailyMarketBriefModulePromise = null;
+    throw err;
+  });
   return dailyMarketBriefModulePromise;
 }
 
 function getRssModule(): Promise<RssModule> {
-  rssModulePromise ??= import('@/services/rss');
+  rssModulePromise ??= import('@/services/rss').catch((err) => {
+    rssModulePromise = null;
+    throw err;
+  });
   return rssModulePromise;
 }
 
 function getSignalAggregator(): Promise<SignalAggregator> {
-  signalAggregatorPromise ??= import('@/services/signal-aggregator').then(module => module.signalAggregator);
+  signalAggregatorPromise ??= import('@/services/signal-aggregator')
+    .then(module => module.signalAggregator)
+    .catch((err) => {
+      signalAggregatorPromise = null;
+      throw err;
+    });
   return signalAggregatorPromise;
 }
 
 async function ingestTrendingHeadlines(headlines: TrendingHeadlineInput[]): Promise<void> {
-  ingestHeadlinesPromise ??= import('@/services/trending-keywords').then(module => module.ingestHeadlines);
+  ingestHeadlinesPromise ??= import('@/services/trending-keywords')
+    .then(module => module.ingestHeadlines)
+    .catch((err) => {
+      ingestHeadlinesPromise = null;
+      throw err;
+    });
   const ingestHeadlines = await ingestHeadlinesPromise;
   ingestHeadlines(headlines);
 }
@@ -2422,8 +2438,9 @@ export class DataLoaderManager implements AppModule {
         ingestFlights(flightData.flights);
         ingestVessels(vesselData.vessels);
         ingestMilitaryForCII(flightData.flights, vesselData.vessels);
-        (await getSignalAggregator()).ingestFlights(flightData.flights);
-        (await getSignalAggregator()).ingestVessels(vesselData.vessels);
+        const aggregator = await getSignalAggregator();
+        aggregator.ingestFlights(flightData.flights);
+        aggregator.ingestVessels(vesselData.vessels);
         dataFreshness.recordUpdate('opensky', flightData.flights.length);
         updateAndCheck([
           { type: 'military_flights', region: 'global', count: flightData.flights.length },
@@ -2950,8 +2967,9 @@ export class DataLoaderManager implements AppModule {
       ingestFlights(flightData.flights);
       ingestVessels(vesselData.vessels);
       ingestMilitaryForCII(flightData.flights, vesselData.vessels);
-      (await getSignalAggregator()).ingestFlights(flightData.flights);
-      (await getSignalAggregator()).ingestVessels(vesselData.vessels);
+      const aggregator = await getSignalAggregator();
+      aggregator.ingestFlights(flightData.flights);
+      aggregator.ingestVessels(vesselData.vessels);
       updateAndCheck([
         { type: 'military_flights', region: 'global', count: flightData.flights.length },
         { type: 'vessels', region: 'global', count: vesselData.vessels.length },

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -1,6 +1,7 @@
 import type { AppContext, AppModule } from '@/app/app-context';
 import { getRpcBaseUrl } from '@/services/rpc-client';
 import { enqueuePanelCall } from '@/app/pending-panel-data';
+import { getSignalAggregator, type SignalAggregator } from '@/app/lazy-services';
 import type { NewsItem, MapLayers, SocialUnrestEvent, MilitaryFlight } from '@/types';
 import type { MarketData } from '@/types';
 import type { TimeRange } from '@/components/MapContainer';
@@ -74,7 +75,6 @@ import {
   fetchBisData,
   fetchBlsData,
   fetchCyberThreats,
-  drainTrendingSignals,
   fetchTradeRestrictions,
   fetchTariffTrends,
   fetchTradeFlows,
@@ -270,13 +270,13 @@ type HydrationTask = {
 type HydrationTier = 1 | 2 | 3 | 4;
 type DailyMarketBriefModule = typeof import('@/services/daily-market-brief');
 type RssModule = Pick<typeof import('@/services/rss'), 'fetchCategoryFeeds' | 'getFeedFailures'>;
-type SignalAggregator = typeof import('@/services/signal-aggregator').signalAggregator;
 type TrendingHeadlineInput = import('@/services/trending-keywords').TrendingHeadlineInput;
+type DrainTrendingSignals = typeof import('@/services/trending-keywords').drainTrendingSignals;
 
 let dailyMarketBriefModulePromise: Promise<DailyMarketBriefModule> | null = null;
 let rssModulePromise: Promise<RssModule> | null = null;
-let signalAggregatorPromise: Promise<SignalAggregator> | null = null;
 let ingestHeadlinesPromise: Promise<(headlines: TrendingHeadlineInput[]) => void> | null = null;
+let drainTrendingSignalsPromise: Promise<DrainTrendingSignals> | null = null;
 
 function getDailyMarketBriefModule(): Promise<DailyMarketBriefModule> {
   dailyMarketBriefModulePromise ??= import('@/services/daily-market-brief').catch((err) => {
@@ -294,16 +294,6 @@ function getRssModule(): Promise<RssModule> {
   return rssModulePromise;
 }
 
-function getSignalAggregator(): Promise<SignalAggregator> {
-  signalAggregatorPromise ??= import('@/services/signal-aggregator')
-    .then(module => module.signalAggregator)
-    .catch((err) => {
-      signalAggregatorPromise = null;
-      throw err;
-    });
-  return signalAggregatorPromise;
-}
-
 async function ingestTrendingHeadlines(headlines: TrendingHeadlineInput[]): Promise<void> {
   ingestHeadlinesPromise ??= import('@/services/trending-keywords')
     .then(module => module.ingestHeadlines)
@@ -313,6 +303,30 @@ async function ingestTrendingHeadlines(headlines: TrendingHeadlineInput[]): Prom
     });
   const ingestHeadlines = await ingestHeadlinesPromise;
   ingestHeadlines(headlines);
+}
+
+async function drainTrendingSignalQueue(): Promise<ReturnType<DrainTrendingSignals>> {
+  try {
+    drainTrendingSignalsPromise ??= import('@/services/trending-keywords')
+      .then(module => module.drainTrendingSignals)
+      .catch((err) => {
+        drainTrendingSignalsPromise = null;
+        throw err;
+      });
+    const drainTrendingSignals = await drainTrendingSignalsPromise;
+    return drainTrendingSignals();
+  } catch (err) {
+    console.warn('[News] drainTrendingSignals failed (chunk load?):', err);
+    return [];
+  }
+}
+
+async function runSignalAggregator(context: string, ingest: (aggregator: SignalAggregator) => void): Promise<void> {
+  try {
+    ingest(await getSignalAggregator());
+  } catch (err) {
+    console.warn(`[SignalAggregator] ${context} skipped:`, err);
+  }
 }
 
 const HYDRATION_TIER_ONE = new Set(['news', 'markets', 'intelligence']);
@@ -841,7 +855,7 @@ export class DataLoaderManager implements AppModule {
 
     const bootstrapTemporal = consumeServerAnomalies();
     if (bootstrapTemporal.anomalies.length > 0 || bootstrapTemporal.trackedTypes.length > 0) {
-      (await getSignalAggregator()).ingestTemporalAnomalies(bootstrapTemporal.anomalies, bootstrapTemporal.trackedTypes);
+      await runSignalAggregator('bootstrap temporal anomalies', (aggregator) => aggregator.ingestTemporalAnomalies(bootstrapTemporal.anomalies, bootstrapTemporal.trackedTypes));
       ingestTemporalAnomaliesForCII(bootstrapTemporal.anomalies);
       this.refreshCiiAndBrief();
     } else {
@@ -851,7 +865,7 @@ export class DataLoaderManager implements AppModule {
 
   async refreshTemporalBaseline(): Promise<void> {
     const { anomalies, trackedTypes } = await fetchLiveAnomalies();
-    (await getSignalAggregator()).ingestTemporalAnomalies(anomalies, trackedTypes);
+    await runSignalAggregator('temporal baseline anomalies', (aggregator) => aggregator.ingestTemporalAnomalies(anomalies, trackedTypes));
     ingestTemporalAnomaliesForCII(anomalies);
     this.refreshCiiAndBrief();
   }
@@ -1147,7 +1161,9 @@ export class DataLoaderManager implements AppModule {
           .filter(i => enabledNames.has(i.source));
 
         void ingestTrendingHeadlines(items.map(i => ({ title: i.title, pubDate: i.pubDate, source: i.source, link: i.link })))
-          .catch(() => {});
+          .catch((err) => {
+            console.warn('[News] ingestTrendingHeadlines failed (chunk load?):', err);
+          });
 
         // Skip client-side AI reclassification for digest items.
         // The server already ran enrichWithAiCache() which checks the same Redis keys
@@ -2330,7 +2346,7 @@ export class DataLoaderManager implements AppModule {
         const outages = await fetchInternetOutages();
         this.ctx.intelligenceCache.outages = outages;
         ingestOutagesForCII(outages);
-        (await getSignalAggregator()).ingestOutages(outages);
+        await runSignalAggregator('outages', (aggregator) => aggregator.ingestOutages(outages));
         dataFreshness.recordUpdate('outages', outages.length);
         if (this.ctx.mapLayers.outages) {
           this.ctx.map?.setOutages(outages);
@@ -2358,7 +2374,7 @@ export class DataLoaderManager implements AppModule {
         this.ctx.intelligenceCache.protests = protestData;
         ingestProtests(protestData.events);
         ingestProtestsForCII(protestData.events);
-        (await getSignalAggregator()).ingestProtests(protestData.events);
+        await runSignalAggregator('protests', (aggregator) => aggregator.ingestProtests(protestData.events));
         const protestCount = protestData.sources.acled + protestData.sources.gdelt;
         if (protestCount > 0) dataFreshness.recordUpdate('acled', protestCount);
         if (protestData.sources.gdelt > 0) dataFreshness.recordUpdate('gdelt', protestData.sources.gdelt);
@@ -2438,16 +2454,17 @@ export class DataLoaderManager implements AppModule {
         ingestFlights(flightData.flights);
         ingestVessels(vesselData.vessels);
         ingestMilitaryForCII(flightData.flights, vesselData.vessels);
-        const aggregator = await getSignalAggregator();
-        aggregator.ingestFlights(flightData.flights);
-        aggregator.ingestVessels(vesselData.vessels);
+        await runSignalAggregator('military tracks', (aggregator) => {
+          aggregator.ingestFlights(flightData.flights);
+          aggregator.ingestVessels(vesselData.vessels);
+        });
         dataFreshness.recordUpdate('opensky', flightData.flights.length);
         updateAndCheck([
           { type: 'military_flights', region: 'global', count: flightData.flights.length },
           { type: 'vessels', region: 'global', count: vesselData.vessels.length },
         ]).then(async anomalies => {
           if (anomalies.length > 0) {
-            (await getSignalAggregator()).ingestTemporalAnomalies(anomalies);
+            await runSignalAggregator('temporal anomalies', (aggregator) => aggregator.ingestTemporalAnomalies(anomalies));
             ingestTemporalAnomaliesForCII(anomalies);
             this.refreshCiiAndBrief();
           }
@@ -2641,7 +2658,7 @@ export class DataLoaderManager implements AppModule {
       this.ctx.map?.setOutages(outages);
       this.ctx.map?.setLayerReady('outages', outages.length > 0);
       ingestOutagesForCII(outages);
-      (await getSignalAggregator()).ingestOutages(outages);
+      await runSignalAggregator('outages', (aggregator) => aggregator.ingestOutages(outages));
       this.ctx.statusPanel?.updateFeed('NetBlocks', { status: 'ok', itemCount: outages.length });
       dataFreshness.recordUpdate('outages', outages.length);
       (this.ctx.panels['internet-disruptions'] as InternetDisruptionsPanel)?.setOutages(outages);
@@ -2702,7 +2719,7 @@ export class DataLoaderManager implements AppModule {
       this.ctx.map?.setIranEvents(events);
       this.ctx.map?.setLayerReady('iranAttacks', events.length > 0);
       const coerced = events.map(e => ({ ...e, timestamp: Number(e.timestamp) || 0 }));
-      (await getSignalAggregator()).ingestConflictEvents(coerced);
+      await runSignalAggregator('iran conflict events', (aggregator) => aggregator.ingestConflictEvents(coerced));
       ingestStrikesForCII(coerced);
       this.refreshCiiAndBrief();
     } catch {
@@ -2716,14 +2733,14 @@ export class DataLoaderManager implements AppModule {
       const aisStatus = getAisStatus();
       console.log('[Ships] Events:', { disruptions: disruptions.length, density: density.length, vessels: aisStatus.vessels });
       this.ctx.map?.setAisData(disruptions, density);
-      (await getSignalAggregator()).ingestAisDisruptions(disruptions);
+      await runSignalAggregator('AIS disruptions', (aggregator) => aggregator.ingestAisDisruptions(disruptions));
       ingestAisDisruptionsForCII(disruptions);
       this.refreshCiiAndBrief();
       updateAndCheck([
         { type: 'ais_gaps', region: 'global', count: disruptions.length },
       ]).then(async anomalies => {
         if (anomalies.length > 0) {
-          (await getSignalAggregator()).ingestTemporalAnomalies(anomalies);
+          await runSignalAggregator('temporal anomalies', (aggregator) => aggregator.ingestTemporalAnomalies(anomalies));
           ingestTemporalAnomaliesForCII(anomalies);
           this.refreshCiiAndBrief();
         }
@@ -2835,7 +2852,7 @@ export class DataLoaderManager implements AppModule {
       this.ctx.map?.setLayerReady('protests', protestData.events.length > 0);
       ingestProtests(protestData.events);
       ingestProtestsForCII(protestData.events);
-      (await getSignalAggregator()).ingestProtests(protestData.events);
+      await runSignalAggregator('protests', (aggregator) => aggregator.ingestProtests(protestData.events));
       const protestCount = protestData.sources.acled + protestData.sources.gdelt;
       if (protestCount > 0) dataFreshness.recordUpdate('acled', protestCount);
       if (protestData.sources.gdelt > 0) dataFreshness.recordUpdate('gdelt', protestData.sources.gdelt);
@@ -2967,15 +2984,16 @@ export class DataLoaderManager implements AppModule {
       ingestFlights(flightData.flights);
       ingestVessels(vesselData.vessels);
       ingestMilitaryForCII(flightData.flights, vesselData.vessels);
-      const aggregator = await getSignalAggregator();
-      aggregator.ingestFlights(flightData.flights);
-      aggregator.ingestVessels(vesselData.vessels);
+      await runSignalAggregator('military tracks', (aggregator) => {
+        aggregator.ingestFlights(flightData.flights);
+        aggregator.ingestVessels(vesselData.vessels);
+      });
       updateAndCheck([
         { type: 'military_flights', region: 'global', count: flightData.flights.length },
         { type: 'vessels', region: 'global', count: vesselData.vessels.length },
       ]).then(async anomalies => {
         if (anomalies.length > 0) {
-          (await getSignalAggregator()).ingestTemporalAnomalies(anomalies);
+          await runSignalAggregator('temporal anomalies', (aggregator) => aggregator.ingestTemporalAnomalies(anomalies));
           ingestTemporalAnomaliesForCII(anomalies);
           this.refreshCiiAndBrief();
         }
@@ -3389,7 +3407,7 @@ export class DataLoaderManager implements AppModule {
         geoSignals = geoAlerts.map(geoConvergenceToSignal);
       }
 
-      const keywordSpikeSignals = drainTrendingSignals();
+      const keywordSpikeSignals = await drainTrendingSignalQueue();
       const allSignals = [...signals, ...geoSignals, ...keywordSpikeSignals];
       if (allSignals.length > 0) {
         addToSignalHistory(allSignals);
@@ -3421,7 +3439,7 @@ export class DataLoaderManager implements AppModule {
           acq_date: new Date(f.detectedAt).toISOString().slice(0, 10),
         }));
 
-        (await getSignalAggregator()).ingestSatelliteFires(satelliteFires);
+        await runSignalAggregator('satellite fires', (aggregator) => aggregator.ingestSatelliteFires(satelliteFires));
         ingestSatelliteFiresForCII(satelliteFires);
         this.refreshCiiAndBrief();
 
@@ -3669,7 +3687,7 @@ export class DataLoaderManager implements AppModule {
       const result = await fetchSanctionsPressure();
       this.callPanel('sanctions-pressure', 'setData', result);
       this.ctx.intelligenceCache.sanctions = result;
-      (await getSignalAggregator()).ingestSanctionsPressure(result.countries);
+      await runSignalAggregator('sanctions pressure', (aggregator) => aggregator.ingestSanctionsPressure(result.countries));
       ingestSanctionsForCII(result.countries);
       if (result.totalCount > 0) {
         dataFreshness.recordUpdate('sanctions_pressure', result.totalCount);
@@ -3710,7 +3728,7 @@ export class DataLoaderManager implements AppModule {
       const anomalies = result.observations.filter((observation) => observation.severity !== 'normal');
       this.callPanel('radiation-watch', 'setData', result);
       this.ctx.intelligenceCache.radiation = result;
-      (await getSignalAggregator()).ingestRadiationObservations(result.observations);
+      await runSignalAggregator('radiation observations', (aggregator) => aggregator.ingestRadiationObservations(result.observations));
       this.ctx.map?.setRadiationObservations(anomalies);
       this.ctx.map?.setLayerReady('radiationWatch', anomalies.length > 0);
       if (result.observations.length > 0) {

--- a/src/app/lazy-services.ts
+++ b/src/app/lazy-services.ts
@@ -1,0 +1,13 @@
+export type SignalAggregator = typeof import('@/services/signal-aggregator').signalAggregator;
+
+let signalAggregatorPromise: Promise<SignalAggregator> | null = null;
+
+export function getSignalAggregator(): Promise<SignalAggregator> {
+  signalAggregatorPromise ??= import('@/services/signal-aggregator')
+    .then(module => module.signalAggregator)
+    .catch((err) => {
+      signalAggregatorPromise = null;
+      throw err;
+    });
+  return signalAggregatorPromise;
+}

--- a/src/components/SignalModal.ts
+++ b/src/components/SignalModal.ts
@@ -1,12 +1,18 @@
 import type { CorrelationSignal } from '@/services/correlation';
 import type { UnifiedAlert } from '@/services/cross-module-integration';
-import { suppressTrendingTerm } from '@/services/trending-keywords';
 import { escapeHtml } from '@/utils/sanitize';
 import { getCSSColor } from '@/utils';
 import { getSignalContext, type SignalType } from '@/utils/analysis-constants';
 import { t } from '@/services/i18n';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 
+function suppressTrendingTermLazy(term: string): void {
+  void import('@/services/trending-keywords')
+    .then(module => module.suppressTrendingTerm(term))
+    .catch((err) => {
+      console.warn('[SignalModal] suppressTrendingTerm failed (chunk load?):', err);
+    });
+}
 
 export class SignalModal {
   private element: HTMLElement;
@@ -90,7 +96,7 @@ export class SignalModal {
       if (target.classList.contains('suppress-keyword-btn')) {
         const term = (target.dataset.term || '').trim();
         if (!term) return;
-        suppressTrendingTerm(term);
+        suppressTrendingTermLazy(term);
         this.currentSignals = this.currentSignals.filter(signal => {
           const signalTerm = (signal.data as Record<string, unknown>).term;
           return typeof signalTerm !== 'string' || signalTerm.toLowerCase() !== term.toLowerCase();

--- a/src/components/StatusPanel.ts
+++ b/src/components/StatusPanel.ts
@@ -15,6 +15,7 @@ export interface ApiStatus {
   name: string;
   status: StatusLevel;
   latency?: number;
+  errorMessage?: string;
 }
 
 // Allowlists for each variant
@@ -27,7 +28,7 @@ const TECH_FEEDS = new Set([
 ]);
 const TECH_APIS = new Set([
   'RSS Proxy', 'Finnhub', 'CoinGecko', 'Tech Events API', 'Service Status', 'Polymarket',
-  'Cyber Threats API'
+  'Cyber Threats API', 'Signal Aggregator'
 ]);
 
 const WORLD_FEEDS = new Set([
@@ -39,7 +40,7 @@ const WORLD_FEEDS = new Set([
 const WORLD_APIS = new Set([
   'RSS2JSON', 'Finnhub', 'CoinGecko', 'Polymarket', 'USGS', 'FRED',
   'AISStream', 'GDELT Doc', 'EIA', 'USASpending', 'PizzINT', 'FIRMS',
-  'Cyber Threats API', 'BIS', 'WTO', 'SupplyChain', 'OFAC'
+  'Cyber Threats API', 'BIS', 'WTO', 'SupplyChain', 'OFAC', 'Signal Aggregator'
 ]);
 
 import { t } from '../services/i18n';

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,5 +1,3 @@
-export * from './rss';
-export * from './trending-keywords';
 export * from './market';
 export * from './prediction';
 export * from './earthquakes';
@@ -43,7 +41,6 @@ export * from './radiation';
 export * from './breaking-news-alerts';
 export * from './sanctions-pressure';
 export * from './thermal-escalation';
-export * from './daily-market-brief';
 export * from './stock-analysis-history';
 export * from './stock-backtest';
 export * from './imagery';

--- a/tests/dashboard-eager-chunks.test.mjs
+++ b/tests/dashboard-eager-chunks.test.mjs
@@ -38,7 +38,7 @@ const DEFERRED_NPM_LIB_CHUNKS = ['satellite.es', 'confetti.module'];
 // it and fail this guard. correlation-engine gets its name from a manualChunks naming
 // rule (dir-index would otherwise emit an ambiguous `index-*.js`); story-renderer
 // (single file) names itself.
-const DEFERRED_SERVICE_CHUNKS = ['correlation-engine', 'story-renderer'];
+const DEFERRED_SERVICE_CHUNKS = ['correlation-engine', 'story-renderer', 'rss', 'trending-keywords', 'daily-market-brief', 'signal-aggregator'];
 const MILITARY_BASE_DIRECT_IMPORT_FORBIDDEN = [
   'src/app/country-intel.ts',
   'src/app/search-manager.ts',

--- a/tests/mainjs-eager-clients.test.mjs
+++ b/tests/mainjs-eager-clients.test.mjs
@@ -60,6 +60,13 @@ const DATA_LOADER_LAZY_PROMISE_SLOTS = [
 // Matches a direct eager assignment without crossing string-literal quotes.
 const EAGER_CONSTRUCTION = /^[^'"`\n]*=\s*new IntelligenceServiceClient\(/m;
 const LAZY_FACTORY = /createLazyClient\(\(\)\s*=>\s*new IntelligenceServiceClient\(/;
+// Counts every construction site and every lazy-wrapped one. EAGER_CONSTRUCTION
+// only catches the `<lhs> = new ...` assignment form; these catch the
+// non-assignment eager forms it misses (`export default new ...`, a standalone
+// `new ...().warmup()` call, an IIFE) by requiring construction count to equal
+// lazy-wrapped count — i.e. every construction must go through createLazyClient.
+const ANY_CONSTRUCTION = /new\s+IntelligenceServiceClient\s*\(/g;
+const LAZY_CONSTRUCTION = /createLazyClient\(\s*\(\)\s*=>\s*new\s+IntelligenceServiceClient\s*\(/g;
 
 function stripComments(src) {
   return src
@@ -178,6 +185,30 @@ describe('main.js eager diet — service clients are lazy-initialized', () => {
     assert.match(stripComments(eagerDeclaration), EAGER_CONSTRUCTION);
   });
 
+  it('construction-count check catches non-assignment eager forms EAGER_CONSTRUCTION misses', () => {
+    const countWrapped = (src) =>
+      (stripComments(src).match(LAZY_CONSTRUCTION) ?? []).length ===
+      (stripComments(src).match(ANY_CONSTRUCTION) ?? []).length;
+
+    // Bypasses that EAGER_CONSTRUCTION (assignment-only) does NOT catch:
+    assert.equal(countWrapped('export default new IntelligenceServiceClient(getRpcBaseUrl(), {})'), false);
+    assert.equal(countWrapped('new IntelligenceServiceClient(getRpcBaseUrl(), {}).warmup();'), false);
+    assert.equal(countWrapped('const c = (() => new IntelligenceServiceClient(x))();'), false);
+    // An eager construction added alongside a legit lazy factory must still fail:
+    assert.equal(
+      countWrapped(
+        'const client = createLazyClient(() => new IntelligenceServiceClient(getRpcBaseUrl(), {}));\n' +
+          'new IntelligenceServiceClient(getRpcBaseUrl(), {}).getCountryFacts();',
+      ),
+      false,
+    );
+    // A correctly lazy-wrapped sole construction passes:
+    assert.equal(
+      countWrapped('const client = createLazyClient(() => new IntelligenceServiceClient(getRpcBaseUrl(), {}));'),
+      true,
+    );
+  });
+
   it('detects dynamic imports without accepting comments or string literals', () => {
     assert.deepEqual(dynamicImportSpecifiers('const fixture = "import(\'@/services/rss\')";'), []);
     assert.deepEqual(dynamicImportSpecifiers('// import(\'@/services/rss\')\n'), []);
@@ -209,6 +240,20 @@ describe('main.js eager diet — service clients are lazy-initialized', () => {
         stripComments(source),
         EAGER_CONSTRUCTION,
         `${rel} must not assign "new IntelligenceServiceClient(...)" directly — that runs the constructor at boot`,
+      );
+    });
+
+    it(`${rel} wraps every IntelligenceServiceClient construction in createLazyClient`, () => {
+      const clean = stripComments(source);
+      const totalConstructions = (clean.match(ANY_CONSTRUCTION) ?? []).length;
+      const lazyConstructions = (clean.match(LAZY_CONSTRUCTION) ?? []).length;
+      assert.equal(
+        lazyConstructions,
+        totalConstructions,
+        `every "new IntelligenceServiceClient(...)" in ${rel} must be wrapped in createLazyClient(() => ...) ` +
+          `so the constructor never runs at boot — found ${totalConstructions} construction(s), ` +
+          `${lazyConstructions} lazy-wrapped (non-assignment forms like "export default new ...", ` +
+          `a standalone "new ...().warmup()", or an IIFE re-eagerise construction)`,
       );
     });
   }

--- a/tests/mainjs-eager-clients.test.mjs
+++ b/tests/mainjs-eager-clients.test.mjs
@@ -24,6 +24,22 @@ const EAGER_SERVICE_FILES = [
   'src/services/satellites.ts',
 ];
 
+const DATA_LOADER_DEFERRED_SERVICE_IMPORTS = [
+  '@/services/rss',
+  '@/services/signal-aggregator',
+  '@/services/trending-keywords',
+  '@/services/daily-market-brief',
+];
+
+const DATA_LOADER_DEFERRED_BARREL_EXPORTS = [
+  'fetchCategoryFeeds',
+  'getFeedFailures',
+];
+
+const COUNTRY_INTEL_DEFERRED_SERVICE_IMPORTS = [
+  '@/services/signal-aggregator',
+];
+
 // Matches a direct eager assignment without crossing string-literal quotes.
 const EAGER_CONSTRUCTION = /^[^'"`\n]*=\s*new IntelligenceServiceClient\(/m;
 const LAZY_FACTORY = /createLazyClient\(\(\)\s*=>\s*new IntelligenceServiceClient\(/;
@@ -32,6 +48,20 @@ function stripComments(src) {
   return src
     .replace(/\/\*[\s\S]*?\*\//g, '')
     .replace(/\/\/[^\n]*/g, '');
+}
+
+function valueImportSpecifiers(src) {
+  const specifiers = [];
+  const re = /\bimport\s+(?!type\b)[\s\S]*?\s+from\s+['"]([^'"]+)['"]/g;
+  let match;
+  while ((match = re.exec(src)) !== null) {
+    specifiers.push(match[1]);
+  }
+  return specifiers;
+}
+
+function servicesBarrelValueImportBlock(src) {
+  return src.match(/\bimport\s+\{([\s\S]*?)\}\s+from\s+['"]@\/services['"]/)?.[1] ?? '';
 }
 
 describe('main.js eager diet — service clients are lazy-initialized', () => {
@@ -77,4 +107,58 @@ describe('main.js eager diet — service clients are lazy-initialized', () => {
       );
     });
   }
+});
+
+describe('main.js eager diet — data-loader service tail is lazy-loaded', () => {
+  const source = readFileSync(resolve(repoRoot, 'src/app/data-loader.ts'), 'utf8');
+  const withoutComments = stripComments(source);
+
+  it('keeps post-paint service modules behind dynamic imports', () => {
+    const valueSpecifiers = valueImportSpecifiers(withoutComments);
+    const directOffenders = DATA_LOADER_DEFERRED_SERVICE_IMPORTS.filter((specifier) => valueSpecifiers.includes(specifier));
+    assert.deepEqual(
+      directOffenders,
+      [],
+      'data-loader must not statically import RSS/trending/signal/daily-brief services; load them through cached import() helpers after first paint',
+    );
+
+    for (const specifier of DATA_LOADER_DEFERRED_SERVICE_IMPORTS) {
+      assert.ok(
+        withoutComments.includes(`import('${specifier}')`),
+        `data-loader should lazy-load ${specifier} with import()`,
+      );
+    }
+  });
+
+  it('does not pull RSS fallback exports through the eager services barrel', () => {
+    const servicesImportBlock = servicesBarrelValueImportBlock(withoutComments);
+    const offenders = DATA_LOADER_DEFERRED_BARREL_EXPORTS.filter((name) => new RegExp(`\\b${name}\\b`).test(servicesImportBlock));
+    assert.deepEqual(
+      offenders,
+      [],
+      'RSS fallback exports pull rss.ts and its enrichment imports into the eager data-loader graph; use getRssModule() instead',
+    );
+  });
+});
+
+describe('main.js eager diet — country-intel service tail is lazy-loaded', () => {
+  const source = readFileSync(resolve(repoRoot, 'src/app/country-intel.ts'), 'utf8');
+  const withoutComments = stripComments(source);
+
+  it('keeps signal aggregation behind a dynamic import', () => {
+    const valueSpecifiers = valueImportSpecifiers(withoutComments);
+    const directOffenders = COUNTRY_INTEL_DEFERRED_SERVICE_IMPORTS.filter((specifier) => valueSpecifiers.includes(specifier));
+    assert.deepEqual(
+      directOffenders,
+      [],
+      'country-intel is part of the eager App graph; signal aggregation must load through import() on country-brief/story actions',
+    );
+
+    for (const specifier of COUNTRY_INTEL_DEFERRED_SERVICE_IMPORTS) {
+      assert.ok(
+        withoutComments.includes(`import('${specifier}')`),
+        `country-intel should lazy-load ${specifier} with import()`,
+      );
+    }
+  });
 });

--- a/tests/mainjs-eager-clients.test.mjs
+++ b/tests/mainjs-eager-clients.test.mjs
@@ -361,3 +361,44 @@ describe('main.js eager diet — country-intel uses the shared signal aggregatio
     );
   });
 });
+
+describe('main.js eager diet — review feedback guards', () => {
+  const dataLoaderSource = readFileSync(resolve(repoRoot, 'src/app/data-loader.ts'), 'utf8');
+  const countryIntelSource = readFileSync(resolve(repoRoot, 'src/app/country-intel.ts'), 'utf8');
+  const statusPanelSource = readFileSync(resolve(repoRoot, 'src/components/StatusPanel.ts'), 'utf8');
+  const dataLoaderWithoutComments = stripComments(dataLoaderSource);
+  const statusPanelWithoutComments = stripComments(statusPanelSource);
+
+  it('shows a loading brief before waiting on lazy country signals', () => {
+    const openStart = countryIntelSource.indexOf('async openCountryBriefByCode');
+    const loadingIndex = countryIntelSource.indexOf('page.showLoading();', openStart);
+    const signalsIndex = countryIntelSource.indexOf('const signals = await this.getCountrySignals(code, country);', openStart);
+    assert.ok(openStart >= 0, 'openCountryBriefByCode should exist');
+    assert.ok(loadingIndex > openStart, 'openCountryBriefByCode should show the loading shell');
+    assert.ok(signalsIndex > loadingIndex, 'openCountryBriefByCode should show loading before lazy signal aggregation');
+  });
+
+  it('keeps country signals resilient to signal-aggregator chunk failures', () => {
+    const signalsStart = countryIntelSource.indexOf('async getCountrySignals');
+    const signalsEnd = countryIntelSource.indexOf('const globalTemporalAnomalies', signalsStart);
+    const signalSetup = countryIntelSource.slice(signalsStart, signalsEnd);
+    assert.match(signalSetup, /let\s+clusters:\s+CountrySignalCluster\[\]\s*=\s*\[\];/);
+    assert.match(signalSetup, /try\s*\{[\s\S]*getSignalAggregator\(\)[\s\S]*\}\s*catch/);
+    assert.match(signalSetup, /signal clusters unavailable, degrading/);
+  });
+
+  it('surfaces signal-aggregator chunk failures in the status panel', () => {
+    assert.match(dataLoaderWithoutComments, /statusPanel\?\.updateApi\('Signal Aggregator',\s*\{\s*status:\s*'error'/);
+    assert.doesNotMatch(
+      dataLoaderWithoutComments,
+      /await\s+runSignalAggregator\(\s*['"]/,
+      'runSignalAggregator call sites should pass statusPanel so lazy chunk failures are visible to ops',
+    );
+  });
+
+  it('allows Signal Aggregator API status updates to be recorded', () => {
+    const signalAggregatorOccurrences = (statusPanelWithoutComments.match(/'Signal Aggregator'/g) ?? []).length;
+    assert.equal(signalAggregatorOccurrences, 2, 'Signal Aggregator should be allowlisted for tech and world variants');
+    assert.match(statusPanelWithoutComments, /interface\s+ApiStatus\s*\{[\s\S]*errorMessage\?:\s*string/);
+  });
+});

--- a/tests/mainjs-eager-clients.test.mjs
+++ b/tests/mainjs-eager-clients.test.mjs
@@ -40,6 +40,13 @@ const COUNTRY_INTEL_DEFERRED_SERVICE_IMPORTS = [
   '@/services/signal-aggregator',
 ];
 
+const DATA_LOADER_LAZY_PROMISE_SLOTS = [
+  'dailyMarketBriefModulePromise',
+  'rssModulePromise',
+  'signalAggregatorPromise',
+  'ingestHeadlinesPromise',
+];
+
 // Matches a direct eager assignment without crossing string-literal quotes.
 const EAGER_CONSTRUCTION = /^[^'"`\n]*=\s*new IntelligenceServiceClient\(/m;
 const LAZY_FACTORY = /createLazyClient\(\(\)\s*=>\s*new IntelligenceServiceClient\(/;
@@ -139,6 +146,15 @@ describe('main.js eager diet — data-loader service tail is lazy-loaded', () =>
       'RSS fallback exports pull rss.ts and its enrichment imports into the eager data-loader graph; use getRssModule() instead',
     );
   });
+
+  it('clears cached lazy-load promises on rejection so later calls can retry', () => {
+    for (const slot of DATA_LOADER_LAZY_PROMISE_SLOTS) {
+      assert.ok(
+        withoutComments.includes(`${slot} = null;`),
+        `${slot} should be reset in its import().catch() path`,
+      );
+    }
+  });
 });
 
 describe('main.js eager diet — country-intel service tail is lazy-loaded', () => {
@@ -160,5 +176,12 @@ describe('main.js eager diet — country-intel service tail is lazy-loaded', () 
         `country-intel should lazy-load ${specifier} with import()`,
       );
     }
+  });
+
+  it('clears the cached signal-aggregator promise on rejection so later country actions can retry', () => {
+    assert.ok(
+      withoutComments.includes('signalAggregatorPromise = null;'),
+      'country-intel signalAggregatorPromise should be reset in its import().catch() path',
+    );
   });
 });

--- a/tests/mainjs-eager-clients.test.mjs
+++ b/tests/mainjs-eager-clients.test.mjs
@@ -26,25 +26,35 @@ const EAGER_SERVICE_FILES = [
 
 const DATA_LOADER_DEFERRED_SERVICE_IMPORTS = [
   '@/services/rss',
-  '@/services/signal-aggregator',
   '@/services/trending-keywords',
   '@/services/daily-market-brief',
+];
+
+const SIGNAL_AGGREGATOR_DEFERRED_SERVICE_IMPORT = '@/services/signal-aggregator';
+
+const SERVICE_BARREL_DEFERRED_EXPORTS = [
+  './rss',
+  './trending-keywords',
+  './daily-market-brief',
 ];
 
 const DATA_LOADER_DEFERRED_BARREL_EXPORTS = [
   'fetchCategoryFeeds',
   'getFeedFailures',
+  'drainTrendingSignals',
+  'ingestHeadlines',
+  'buildDailyMarketBrief',
+  'cacheDailyMarketBrief',
+  'getCachedDailyMarketBrief',
+  'shouldRefreshDailyBrief',
 ];
 
-const COUNTRY_INTEL_DEFERRED_SERVICE_IMPORTS = [
-  '@/services/signal-aggregator',
-];
 
 const DATA_LOADER_LAZY_PROMISE_SLOTS = [
   'dailyMarketBriefModulePromise',
   'rssModulePromise',
-  'signalAggregatorPromise',
   'ingestHeadlinesPromise',
+  'drainTrendingSignalsPromise',
 ];
 
 // Matches a direct eager assignment without crossing string-literal quotes.
@@ -55,6 +65,87 @@ function stripComments(src) {
   return src
     .replace(/\/\*[\s\S]*?\*\//g, '')
     .replace(/\/\/[^\n]*/g, '');
+}
+
+function escapeRegExp(value) {
+  const special = '\\^$.*+?()[]{}|';
+  return [...value].map((ch) => special.includes(ch) ? '\\' + ch : ch).join('');
+}
+
+function skipQuoted(src, index, quote) {
+  let i = index + 1;
+  while (i < src.length) {
+    if (src[i] === '\\') {
+      i += 2;
+      continue;
+    }
+    if (src[i] === quote) return i + 1;
+    i++;
+  }
+  return src.length;
+}
+
+function dynamicImportSpecifiers(src) {
+  const specifiers = [];
+  let i = 0;
+  while (i < src.length) {
+    const ch = src[i];
+    const next = src[i + 1];
+
+    if (ch === '/' && next === '/') {
+      const end = src.indexOf('\n', i + 2);
+      i = end === -1 ? src.length : end + 1;
+      continue;
+    }
+    if (ch === '/' && next === '*') {
+      const end = src.indexOf('*/', i + 2);
+      i = end === -1 ? src.length : end + 2;
+      continue;
+    }
+    if (ch === "'" || ch === '"' || ch === '`') {
+      i = skipQuoted(src, i, ch);
+      continue;
+    }
+    if (src.startsWith('import', i) && !/[A-Za-z0-9_$]/.test(src[i - 1] ?? '') && !/[A-Za-z0-9_$]/.test(src[i + 6] ?? '')) {
+      if (/\btypeof\s*$/.test(src.slice(Math.max(0, i - 16), i))) {
+        i++;
+        continue;
+      }
+      let j = i + 6;
+      while (/\s/.test(src[j] ?? '')) j++;
+      if (src[j] !== '(') {
+        i++;
+        continue;
+      }
+      j++;
+      while (/\s/.test(src[j] ?? '')) j++;
+      const quote = src[j];
+      if (quote !== "'" && quote !== '"') {
+        i++;
+        continue;
+      }
+      j++;
+      let specifier = '';
+      while (j < src.length) {
+        if (src[j] === '\\') {
+          specifier += src[j + 1] ?? '';
+          j += 2;
+          continue;
+        }
+        if (src[j] === quote) {
+          specifiers.push(specifier);
+          i = j + 1;
+          break;
+        }
+        specifier += src[j];
+        j++;
+      }
+      if (j >= src.length) i = src.length;
+      continue;
+    }
+    i++;
+  }
+  return specifiers;
 }
 
 function valueImportSpecifiers(src) {
@@ -85,6 +176,13 @@ describe('main.js eager diet — service clients are lazy-initialized', () => {
   it('still flags direct eager client declarations', () => {
     const eagerDeclaration = 'const client: IntelligenceServiceClient = new IntelligenceServiceClient(getRpcBaseUrl(), {})';
     assert.match(stripComments(eagerDeclaration), EAGER_CONSTRUCTION);
+  });
+
+  it('detects dynamic imports without accepting comments or string literals', () => {
+    assert.deepEqual(dynamicImportSpecifiers('const fixture = "import(\'@/services/rss\')";'), []);
+    assert.deepEqual(dynamicImportSpecifiers('// import(\'@/services/rss\')\n'), []);
+    assert.deepEqual(dynamicImportSpecifiers("type Rss = typeof import('@/services/rss');"), []);
+    assert.deepEqual(dynamicImportSpecifiers("void import('@/services/rss')"), ['@/services/rss']);
   });
 
   for (const rel of EAGER_SERVICE_FILES) {
@@ -122,28 +220,41 @@ describe('main.js eager diet — data-loader service tail is lazy-loaded', () =>
 
   it('keeps post-paint service modules behind dynamic imports', () => {
     const valueSpecifiers = valueImportSpecifiers(withoutComments);
-    const directOffenders = DATA_LOADER_DEFERRED_SERVICE_IMPORTS.filter((specifier) => valueSpecifiers.includes(specifier));
+    const deferredSpecifiers = [...DATA_LOADER_DEFERRED_SERVICE_IMPORTS, SIGNAL_AGGREGATOR_DEFERRED_SERVICE_IMPORT];
+    const directOffenders = deferredSpecifiers.filter((specifier) => valueSpecifiers.includes(specifier));
     assert.deepEqual(
       directOffenders,
       [],
       'data-loader must not statically import RSS/trending/signal/daily-brief services; load them through cached import() helpers after first paint',
     );
 
+    const dynamicSpecifiers = dynamicImportSpecifiers(source);
     for (const specifier of DATA_LOADER_DEFERRED_SERVICE_IMPORTS) {
       assert.ok(
-        withoutComments.includes(`import('${specifier}')`),
-        `data-loader should lazy-load ${specifier} with import()`,
+        dynamicSpecifiers.includes(specifier),
+        'data-loader should lazy-load ' + specifier + ' with import()',
       );
     }
   });
 
-  it('does not pull RSS fallback exports through the eager services barrel', () => {
+  it('keeps deferred modules out of the eager services barrel', () => {
+    const barrel = stripComments(readFileSync(resolve(repoRoot, 'src/services/index.ts'), 'utf8'));
+    for (const specifier of SERVICE_BARREL_DEFERRED_EXPORTS) {
+      assert.doesNotMatch(
+        barrel,
+        new RegExp("export\\s+\\*\\s+from\\s+['\"]" + escapeRegExp(specifier) + "['\"]"),
+        '@/services must not value-re-export ' + specifier + '; eager barrel consumers would pull it into main',
+      );
+    }
+  });
+
+  it('does not pull deferred exports through the eager services barrel import', () => {
     const servicesImportBlock = servicesBarrelValueImportBlock(withoutComments);
     const offenders = DATA_LOADER_DEFERRED_BARREL_EXPORTS.filter((name) => new RegExp(`\\b${name}\\b`).test(servicesImportBlock));
     assert.deepEqual(
       offenders,
       [],
-      'RSS fallback exports pull rss.ts and its enrichment imports into the eager data-loader graph; use getRssModule() instead',
+      'RSS/trending/daily-brief exports pull deferred service modules into the eager data-loader graph; use cached import() helpers instead',
     );
   });
 
@@ -157,31 +268,51 @@ describe('main.js eager diet — data-loader service tail is lazy-loaded', () =>
   });
 });
 
-describe('main.js eager diet — country-intel service tail is lazy-loaded', () => {
+describe('main.js eager diet — eager UI keeps trending-keywords lazy', () => {
+  it('does not statically import trending-keywords from the signal modal', () => {
+    const source = readFileSync(resolve(repoRoot, 'src/components/SignalModal.ts'), 'utf8');
+    assert.ok(
+      !valueImportSpecifiers(stripComments(source)).includes('@/services/trending-keywords'),
+      'SignalModal is imported by App at boot; suppressTrendingTerm should load through import() on user action',
+    );
+    assert.ok(
+      dynamicImportSpecifiers(source).includes('@/services/trending-keywords'),
+      'SignalModal should lazy-load trending-keywords when suppressing a term',
+    );
+  });
+});
+
+describe('main.js eager diet — shared signal aggregation loader is lazy-loaded', () => {
+  const source = readFileSync(resolve(repoRoot, 'src/app/lazy-services.ts'), 'utf8');
+
+  it('keeps signal aggregation behind a dynamic import', () => {
+    assert.ok(
+      dynamicImportSpecifiers(source).includes(SIGNAL_AGGREGATOR_DEFERRED_SERVICE_IMPORT),
+      'lazy-services should lazy-load signal-aggregator with import()',
+    );
+  });
+
+  it('clears the cached signal-aggregator promise on rejection so later actions can retry', () => {
+    assert.ok(
+      stripComments(source).includes('signalAggregatorPromise = null;'),
+      'lazy-services signalAggregatorPromise should be reset in its import().catch() path',
+    );
+  });
+});
+
+describe('main.js eager diet — country-intel uses the shared signal aggregation loader', () => {
   const source = readFileSync(resolve(repoRoot, 'src/app/country-intel.ts'), 'utf8');
   const withoutComments = stripComments(source);
 
-  it('keeps signal aggregation behind a dynamic import', () => {
+  it('does not value-import signal aggregation directly', () => {
     const valueSpecifiers = valueImportSpecifiers(withoutComments);
-    const directOffenders = COUNTRY_INTEL_DEFERRED_SERVICE_IMPORTS.filter((specifier) => valueSpecifiers.includes(specifier));
-    assert.deepEqual(
-      directOffenders,
-      [],
-      'country-intel is part of the eager App graph; signal aggregation must load through import() on country-brief/story actions',
-    );
-
-    for (const specifier of COUNTRY_INTEL_DEFERRED_SERVICE_IMPORTS) {
-      assert.ok(
-        withoutComments.includes(`import('${specifier}')`),
-        `country-intel should lazy-load ${specifier} with import()`,
-      );
-    }
-  });
-
-  it('clears the cached signal-aggregator promise on rejection so later country actions can retry', () => {
     assert.ok(
-      withoutComments.includes('signalAggregatorPromise = null;'),
-      'country-intel signalAggregatorPromise should be reset in its import().catch() path',
+      !valueSpecifiers.includes(SIGNAL_AGGREGATOR_DEFERRED_SERVICE_IMPORT),
+      'country-intel is part of the eager App graph; signal aggregation must load through the shared lazy helper',
+    );
+    assert.ok(
+      valueSpecifiers.includes('@/app/lazy-services'),
+      'country-intel should use the shared lazy-services getSignalAggregator helper',
     );
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1193,6 +1193,21 @@ export default defineConfig(({ mode }) => {
             if (id.includes('/src/services/correlation-engine/')) {
               return 'correlation-engine';
             }
+            // Post-paint service tail split (#4487). These files are dynamic-imported
+            // from data-loader/country-intel/SignalModal; stable names let the
+            // dist guard prove they stay out of main rather than merely grepping src.
+            if (id.endsWith('/src/services/rss.ts')) {
+              return 'rss';
+            }
+            if (id.endsWith('/src/services/trending-keywords.ts')) {
+              return 'trending-keywords';
+            }
+            if (id.endsWith('/src/services/daily-market-brief.ts')) {
+              return 'daily-market-brief';
+            }
+            if (id.endsWith('/src/services/signal-aggregator.ts')) {
+              return 'signal-aggregator';
+            }
             // Co-locate the deck.gl renderer with the deck vendor chunk so
             // onlyExplicitManualChunks cannot split deck's transitive deps
             // across the DeckGLMap boundary (which formed a circular chunk →


### PR DESCRIPTION
Part of #4487 and #4486.

## Summary
- Lazy-load RSS fallback, trending headline ingestion, signal aggregation, and daily-market-brief modules from post-paint data-loader paths instead of eager imports.
- Lazy-load country-intel signal aggregation on country brief/story actions so the eager App graph no longer pulls signal-aggregator directly.
- Add source-level eager-diet guards for data-loader and country-intel service-tail imports.

## Reproduction
Before this patch, HEAD had eager value imports in src/app/data-loader.ts for fetchCategoryFeeds/getFeedFailures from the services barrel, signal-aggregator, trending-keywords, and daily-market-brief, plus eager signal-aggregator use in src/app/country-intel.ts. The new guard in tests/mainjs-eager-clients.test.mjs would fail on those imports.

## Verification
- PASS: node --test tests/mainjs-eager-clients.test.mjs
- PASS: node --test tests/bootstrap.test.mjs
- PASS: git diff --check
- BLOCKED: npm run typecheck. The isolated worktree had no node_modules, and npm run worktree:bootstrap:test-only failed with ENOSPC while unpacking dependencies. Partial node_modules from that failed install was removed to restore space.

## Notes
This does not close the #4487 field-CWV umbrella by itself. It lands one structural P0 lever toward reducing eager JS and protecting the boot graph from the post-paint enrichment tail.