### PR TITLE
fix(perf): stabilize dashboard LCP critical path

### DIFF
--- a/docs/perf/dashboard-lcp-critical-payload-2026-06-28.md
+++ b/docs/perf/dashboard-lcp-critical-payload-2026-06-28.md
@@ -1,0 +1,79 @@
+# Dashboard LCP Critical Payload Evidence - 2026-06-28
+
+## Scope
+
+Issue: https://github.com/koala73/worldmonitor/issues/4489
+
+This note records the first implementation slice for the dashboard LCP critical-payload plan:
+
+- Add opt-in final-LCP attribution for `/dashboard`.
+- Mark startup gates that can delay shell replacement, map readiness, country geometry, slow bootstrap, first data fan-out, and feed digest timing.
+- Move non-LCP country geometry and the slow-tier checkpoint out of the awaited visible-data fan-out path.
+
+## Local Changes
+
+- `src/bootstrap/lcp-attribution.ts` exposes `window.__wmLcpDebug` only when `?wm_lcp_debug=1`, `sessionStorage.wm_lcp_debug=1`, `localStorage.wm_lcp_debug=1`, or the matching hyphenated storage key is set. Storage-blocked contexts are handled without throwing during top-level boot.
+- LCP snapshots include element tag/id/class/closest marker, capped text, redacted resource URL, viewport, DPR, variant, theme, visibility state, and pre-LCP resource groups.
+- `src/utils/lcp-debug.ts` provides the shared mark helper so services can mark resource timing without importing from `src/bootstrap/`.
+- `src/main.ts` installs the observer before `new App('app')`.
+- `src/App.ts`, `src/app/panel-layout.ts`, `src/components/MapContainer.ts`, and `src/services/country-geometry.ts` add `performance.mark()` checkpoints for boot, layout, map, slow tier, country geometry, actual geometry fetch, and initial data fan-out.
+- `src/app/data-loader.ts` marks `/api/news/v1/list-feed-digest` start, ready, and error timing so U4 can prove whether the digest competes before final LCP.
+- `src/App.ts` starts the slow-tier wait as a background checkpoint and starts `preloadCountryGeometry()` only after initial visible data fan-out completes. Correlation and country-learning now wait on that background geometry work instead of blocking the first data fan-out.
+- `src/app/data-loader.ts` replays cached geometry-sensitive CII inputs after deferred country geometry is ready, preserving country attribution without reintroducing a pre-fanout await.
+- `scripts/measure-mobile-mainthread.mjs` enables LCP debug during browser measurement and includes the LCP candidate/context/resource groups in the JSON and human reports.
+
+## Verification Run
+
+Focused attribution/bootstrap pass:
+
+```bash
+npx --yes tsx --test tests/lcp-attribution.test.mts tests/lcp-attribution-contract.test.mjs tests/bootstrap.test.mjs
+git diff --check
+```
+
+Result: 65 focused tests passed. `git diff --check` reported no whitespace errors. The bootstrap guard now enforces that slow-tier and country-geometry waits stay off the visible data fan-out path, post-geometry CII replay remains wired, and the LCP contract guard includes actual country-geometry fetch plus feed-digest timing marks.
+
+Wider focused guard pass:
+
+```bash
+npx --yes tsx --test tests/secondary-startup.test.mts tests/map-mobile-topology.test.mts tests/map-deferred-overlays.test.mts tests/news-loader-sequencing.test.mts tests/lcp-attribution.test.mts tests/lcp-attribution-contract.test.mjs tests/bootstrap.test.mjs tests/measure-mobile-mainthread.test.mts
+```
+
+Result: 97 tests passed. Passing coverage included bootstrap, LCP attribution, secondary startup, deferred Umami, mobile topology, map deferred-overlay guards, news digest sequencing, and deterministic mobile measurement report shaping.
+
+Previously attempted broader static/source guard:
+
+```bash
+npx --yes tsx --test tests/dashboard-critical-css.test.mjs tests/panel-cluster-chunks.test.mjs tests/dashboard-eager-chunks.test.mjs tests/secondary-startup.test.mts tests/map-renderer-deferral.test.mjs tests/map-mobile-topology.test.mts tests/map-deferred-overlays.test.mts tests/lcp-attribution.test.mts tests/lcp-attribution-contract.test.mjs tests/bootstrap.test.mjs
+```
+
+Result: 73 tests passed, 3 test files failed before running assertions because they import the local `typescript` package and this checkout has no `node_modules`: `tests/dashboard-critical-css.test.mjs`, `tests/map-renderer-deferral.test.mjs`, and `tests/panel-cluster-chunks.test.mjs`.
+
+Blocked in this environment:
+
+```bash
+npm run typecheck
+npx playwright test e2e/dashboard-lcp-attribution.spec.ts
+npx playwright test e2e/prehydration-shell.spec.ts
+```
+
+Reason: the checkout has no `node_modules`. `npm run typecheck` fails with `tsc: not found`. `npx playwright test e2e/dashboard-lcp-attribution.spec.ts` fails before running assertions because `playwright.config.ts` imports repo-local `@playwright/test`. Full `npm install`, slim `npm install --ignore-scripts --omit=optional --no-audit --no-fund`, and a local TypeScript-only install attempt all failed with `ENOSPC` while extracting dependencies. Incomplete `node_modules` directories were removed after each failed attempt. Current filesystem free space is about 295 MB, so dependency restoration is not possible in this checkout without freeing disk.
+
+## Follow-Up Evidence Needed
+
+After dependencies are available, run:
+
+```bash
+npm run typecheck
+npx playwright test e2e/prehydration-shell.spec.ts e2e/dashboard-lcp-attribution.spec.ts
+node scripts/measure-mobile-mainthread.mjs <local-or-preview-dashboard-url> --cpu 4 --settle 15000 --json
+```
+
+Then capture a dashboard run with `?wm_lcp_debug=1` on mobile and desktop and record:
+
+- final LCP candidate selector and closest marker;
+- whether the shell candidate is superseded after hydration;
+- pre-LCP resource groups for entry JS/CSS, map topology, country geometry, bootstrap, and feed digest;
+- whether `/api/news/v1/list-feed-digest` appears before final LCP and needs a U4 scheduling change.
+
+Field validation still requires PageSpeed Insights median-of-3 after deploy and a delayed CrUX follow-up because field data uses a rolling window.

--- a/e2e/dashboard-lcp-attribution.spec.ts
+++ b/e2e/dashboard-lcp-attribution.spec.ts
@@ -1,0 +1,139 @@
+import { devices, expect, test, type Page } from '@playwright/test';
+
+const { defaultBrowserType: mobileDefaultBrowserType, ...mobileDevice } = devices['iPhone 14 Pro Max'];
+void mobileDefaultBrowserType;
+
+type LcpDebugContext = {
+  devicePixelRatio: number;
+  theme: string;
+  variant: string;
+  viewport: { height: number; width: number };
+  visibilityState: string;
+};
+
+type LcpDebugSnapshot = {
+  context: LcpDebugContext;
+  entries: Array<{
+    context: LcpDebugContext;
+    element: {
+      closest: string;
+      selector: string;
+      tagName: string;
+      text: string;
+    } | null;
+    resources: Array<{ category: string; count: number; transferSize: number }>;
+    size: number;
+    startTime: number;
+    url: string;
+  }>;
+  marks: Array<{ name: string; startTime: number }>;
+  resources: Array<{ category: string; count: number; transferSize: number }>;
+};
+
+declare global {
+  interface Window {
+    __wmLcpDebug?: {
+      enabled: true;
+      getSnapshot: () => LcpDebugSnapshot;
+    };
+  }
+}
+
+const installLcpDebug = async (page: Page): Promise<void> => {
+  await page.addInitScript(() => {
+    localStorage.setItem('wm_lcp_debug', '1');
+    localStorage.setItem('wm-layer-warning-dismissed', 'true');
+    localStorage.setItem('wm-pro-banner-launched-dismissed', String(Date.now()));
+    localStorage.setItem('worldmonitor-mission-preset-dismissed-v1', '1');
+  });
+};
+
+const CORE_MARKS = [
+  'wm:lcp-debug:installed',
+  'wm:boot:app-construct',
+  'wm:boot:app-init-start',
+  'wm:layout:render-start',
+  'wm:layout:shell-replaced',
+  'wm:map:shell-shown',
+];
+
+const expectLcpDebug = async (page: Page): Promise<LcpDebugSnapshot> => {
+  await expect.poll(async () => page.evaluate(() => Boolean(window.__wmLcpDebug?.enabled)), {
+    message: 'LCP debug should install when explicitly enabled',
+  }).toBe(true);
+
+  await expect(page.locator('.header')).toBeVisible({ timeout: 30000 });
+  await expect.poll(async () => page.evaluate(() => window.__wmLcpDebug?.getSnapshot().entries.length ?? 0), {
+    message: 'LCP debug should capture at least one LCP entry',
+    timeout: 10000,
+  }).toBeGreaterThan(0);
+  await expect.poll(async () => page.evaluate((expectedMarks) => {
+    const marks = new Set(window.__wmLcpDebug?.getSnapshot().marks.map((mark) => mark.name) ?? []);
+    return expectedMarks.every((mark) => marks.has(mark));
+  }, CORE_MARKS), {
+    message: 'LCP debug should capture post-hydration boot and map marks',
+    timeout: 30000,
+  }).toBe(true);
+
+  return page.evaluate(() => window.__wmLcpDebug!.getSnapshot());
+};
+
+const expectCoreMarks = (snapshot: LcpDebugSnapshot): void => {
+  const marks = new Set(snapshot.marks.map((mark) => mark.name));
+  for (const mark of CORE_MARKS) expect(marks).toContain(mark);
+};
+
+const expectContext = (snapshot: LcpDebugSnapshot): void => {
+  expect(snapshot.context.viewport.width).toBeGreaterThan(0);
+  expect(snapshot.context.viewport.height).toBeGreaterThan(0);
+  expect(snapshot.context.devicePixelRatio).toBeGreaterThan(0);
+  expect(snapshot.context.visibilityState).toBeTruthy();
+};
+
+test.describe('dashboard LCP attribution debug', () => {
+  test.beforeEach(async ({ page }) => {
+    await installLcpDebug(page);
+  });
+
+  test('captures final LCP candidate and boot marks on desktop', async ({ page }) => {
+    await page.goto('/dashboard?wm_lcp_debug=1', { waitUntil: 'domcontentloaded' });
+    const snapshot = await expectLcpDebug(page);
+    const latest = snapshot.entries.at(-1);
+
+    expectCoreMarks(snapshot);
+    expectContext(snapshot);
+    expect(latest).toBeTruthy();
+    expect(latest!.startTime).toBeGreaterThanOrEqual(0);
+    expect(latest!.size).toBeGreaterThan(0);
+    expect(latest!.element?.selector || latest!.url).toBeTruthy();
+    expect(latest!.context.viewport.width).toBeGreaterThan(0);
+    expect(latest!.url).not.toContain('wms_');
+    expect(latest!.url).not.toContain('token=');
+  });
+});
+
+test.describe('dashboard LCP attribution debug on mobile', () => {
+  test.use({
+    ...mobileDevice,
+    viewport: { width: 360, height: 780 },
+    deviceScaleFactor: 2.625,
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await installLcpDebug(page);
+  });
+
+  test('captures final LCP candidate and boot marks on mobile', async ({ page }) => {
+    await page.goto('/dashboard?wm_lcp_debug=1', { waitUntil: 'domcontentloaded' });
+    const snapshot = await expectLcpDebug(page);
+    const latest = snapshot.entries.at(-1);
+
+    expectCoreMarks(snapshot);
+    expectContext(snapshot);
+    expect(latest).toBeTruthy();
+    expect(latest!.startTime).toBeGreaterThanOrEqual(0);
+    expect(latest!.size).toBeGreaterThan(0);
+    expect(latest!.element?.selector || latest!.url).toBeTruthy();
+    expect(latest!.context.viewport.width).toBeGreaterThan(0);
+  });
+});

--- a/scripts/measure-mobile-mainthread.mjs
+++ b/scripts/measure-mobile-mainthread.mjs
@@ -81,6 +81,34 @@ export function summarizeLongTasks(entries) {
  * Attribute DOM nodes across named sources (e.g. { total, mapSvg, panels }).
  * Returns the total plus per-source rows with share %, sorted by node count desc.
  */
+function summarizeLcpResources(resources) {
+  return (Array.isArray(resources) ? resources : []).map((resource) => ({
+    category: String(resource?.category || 'unknown'),
+    count: Number(resource?.count) || 0,
+    encodedBodySize: round(resource?.encodedBodySize),
+    transferSize: round(resource?.transferSize),
+  }));
+}
+
+/** Summarize the opt-in window.__wmLcpDebug snapshot captured by the app. */
+export function summarizeLcpDebug(snapshot) {
+  const entries = Array.isArray(snapshot?.entries) ? snapshot.entries : [];
+  const latest = entries.at(-1) || null;
+  return {
+    candidate: latest ? {
+      closest: latest.element?.closest || '',
+      selector: latest.element?.selector || '',
+      size: Number(latest.size) || 0,
+      startTime: round(latest.startTime),
+      tagName: latest.element?.tagName || '',
+      url: latest.url || '',
+    } : null,
+    context: snapshot?.context ?? latest?.context ?? null,
+    entryCount: entries.length,
+    resources: summarizeLcpResources(latest?.resources ?? snapshot?.resources),
+  };
+}
+
 export function attributeDomNodes(counts) {
   const entries = Object.entries(counts || {}).filter(([k]) => k !== 'total');
   const total =
@@ -133,6 +161,11 @@ async function measure(url, { cpu = 4, settle = 15000, device = 'iPhone 14 Pro M
       /* CDP throttle unavailable — continue at host speed */
     }
     await page.addInitScript(() => {
+      try {
+        localStorage.setItem('wm_lcp_debug', '1');
+      } catch {
+        /* storage unavailable */
+      }
       window.__longtasks = [];
       try {
         new PerformanceObserver((list) => {
@@ -157,6 +190,7 @@ async function measure(url, { cpu = 4, settle = 15000, device = 'iPhone 14 Pro M
     await page.goto(url, { waitUntil: 'load', timeout: 60000 });
     await page.waitForTimeout(settle);
     const longtasks = await page.evaluate(() => window.__longtasks || []);
+    const lcpDebug = await page.evaluate(() => window.__wmLcpDebug?.getSnapshot?.() ?? null);
     const nodeCounts = await page.evaluate(() => {
       // Count each element at most once. Summing per-match subtrees would double-count
       // a .panel nested inside another .panel; the `, sel *` union keeps it unique.
@@ -173,7 +207,7 @@ async function measure(url, { cpu = 4, settle = 15000, device = 'iPhone 14 Pro M
         panels: uniqueCount('.panel, .panel *'),
       };
     });
-    return { url, cpu, longtasks, nodeCounts };
+    return { url, cpu, longtasks, lcpDebug, nodeCounts };
   } finally {
     await browser.close();
   }
@@ -184,6 +218,7 @@ export function buildReport(result) {
   return {
     url: result?.url,
     cpu: result?.cpu,
+    lcp: summarizeLcpDebug(result?.lcpDebug),
     tasks: summarizeLongTasks(result?.longtasks),
     nodes: attributeDomNodes(result?.nodeCounts),
   };

--- a/src/App.ts
+++ b/src/App.ts
@@ -42,6 +42,7 @@ import { SignalModal } from '@/components/SignalModal';
 import { IntelligenceGapBadge } from '@/components/IntelligenceGapBadge';
 import { BreakingNewsBanner } from '@/components/BreakingNewsBanner';
 import { initBreakingNewsAlerts, destroyBreakingNewsAlerts } from '@/services/breaking-news-alerts';
+import { markLcpDebug } from '@/utils/lcp-debug';
 import type { ServiceStatusPanel } from '@/components/ServiceStatusPanel';
 import type { StablecoinPanel } from '@/components/StablecoinPanel';
 import type { EnergyCrisisPanel } from '@/components/EnergyCrisisPanel';
@@ -1077,6 +1078,40 @@ export class App {
     }
   }
 
+  private async waitForSlowBootstrapCheckpoint(): Promise<void> {
+    markLcpDebug('wm:data:slow-tier-wait-start');
+    try {
+      const settled = await waitForBootstrapSlowTier(isDesktopRuntime() ? 8_500 : 3_500);
+      markLcpDebug('wm:data:slow-tier-wait-end', { settled });
+      if (this.state.isDestroyed) return;
+      this.bootstrapHydrationState = getBootstrapHydrationState();
+      this.updateConnectivityUi();
+    } catch {
+      markLcpDebug('wm:data:slow-tier-wait-error');
+    }
+  }
+
+  private async preloadCountryGeometryForPostLcpWork(): Promise<void> {
+    markLcpDebug('wm:data:country-geometry-start');
+    try {
+      await preloadCountryGeometry();
+      markLcpDebug('wm:data:country-geometry-ready');
+    } catch {
+      markLcpDebug('wm:data:country-geometry-error');
+    }
+  }
+
+  private startPostLcpIntelligence(countryGeometryReady: Promise<void>): void {
+    void countryGeometryReady.finally(() => {
+      if (this.state.isDestroyed) return;
+      this.dataLoader.refreshGeometryDependentCiiAfterCountryGeometry();
+      // Correlation and country-learning use precision geometry/name matching,
+      // but they are post-initial-data work and should not hold the LCP path.
+      void this.loadInitialCorrelationEngine();
+      startLearning();
+    });
+  }
+
   private async loadInitialCorrelationEngine(): Promise<void> {
     try {
       const {
@@ -1108,6 +1143,7 @@ export class App {
 
   public async init(): Promise<void> {
     const initStart = performance.now();
+    markLcpDebug('wm:boot:app-init-start');
 
     // WebMCP — register synchronously before any init awaits so agent
     // scanners (isitagentready.com, in-browser agents) find the tools on
@@ -1141,6 +1177,7 @@ export class App {
     startFlightHistoryCleanup();
     startVesselHistoryCleanup();
     await initI18n();
+    markLcpDebug('wm:boot:i18n-ready');
     initDeferredDashboardFonts();
     // Localize the static index.html shell — <title>, meta description, and
     // sr-only <h1> are baked in English so search crawlers see something
@@ -1226,6 +1263,7 @@ export class App {
     // Wait for sidecar readiness on desktop so bootstrap hits a live server
     if (isDesktopRuntime()) {
       await waitForSidecarReady(3000);
+      markLcpDebug('wm:boot:sidecar-ready');
     }
 
     // Anonymous browser session token (issue #3541). Server's validateApiKey
@@ -1237,6 +1275,7 @@ export class App {
     if (!isDesktopRuntime()) {
       installWmSessionFetchInterceptor();
       await ensureWmSession();
+      markLcpDebug('wm:boot:session-ready');
     }
 
     // Hydrate in-memory cache from bootstrap endpoint. Awaits only the fast tier; the slow
@@ -1247,6 +1286,7 @@ export class App {
       this.bootstrapHydrationState = getBootstrapHydrationState();
       this.updateConnectivityUi();
     });
+    markLcpDebug('wm:boot:fast-bootstrap-ready');
     this.bootstrapHydrationState = getBootstrapHydrationState();
 
     // Verify OAuth OTT and hydrate auth session BEFORE any UI subscribes to auth state
@@ -1368,7 +1408,9 @@ export class App {
     // Phase 1: Layout (creates map + panels — they'll find hydrated data).
     // init() is async so the dynamic MapContainer import can resolve before
     // downstream code (e.g. mobileGeoCoords→state.map.setCenter) reads ctx.map.
+    markLcpDebug('wm:layout:init-start');
     await this.panelLayout.init();
+    markLcpDebug('wm:layout:init-complete');
     this.eventHandlers.setupSearchControls();
     showProBanner(this.state.container);
     this.updateConnectivityUi();
@@ -1475,11 +1517,8 @@ export class App {
 
     // Phase 6: Data loading
     this.dataLoader.syncDataFreshnessWithLayers();
-    await preloadCountryGeometry();
-    await waitForBootstrapSlowTier(isDesktopRuntime() ? 8_500 : 3_500);
+    const slowTierReady = this.waitForSlowBootstrapCheckpoint();
     if (this.state.isDestroyed) return;
-    this.bootstrapHydrationState = getBootstrapHydrationState();
-    this.updateConnectivityUi();
     // Prime panel-specific data concurrently with bulk loading.
     // primeVisiblePanelData owns ETF, Stablecoins, Gulf Economies, etc. that
     // are NOT part of loadAllData. Running them in parallel prevents those
@@ -1492,23 +1531,23 @@ export class App {
     // panels currently above the fold. IntersectionObserver wiring in
     // panel-layout.ts plus handleViewportPrime above re-trigger
     // loadAllData() as below-fold panels enter the viewport. (#3990)
+    markLcpDebug('wm:data:initial-fanout-start');
     await Promise.all([
       this.dataLoader.loadAllData(),
       this.primeVisiblePanelData(),
     ]);
+    markLcpDebug('wm:data:initial-fanout-complete');
+    const countryGeometryReady = this.preloadCountryGeometryForPostLcpWork();
+    void slowTierReady;
 
     // If bootstrap was served from cache but live data just loaded, promote the status indicator
     markBootstrapAsLive();
     this.bootstrapHydrationState = getBootstrapHydrationState();
     this.updateConnectivityUi();
 
-    // Initial correlation engine run — construct + register adapters + run here,
-    // inside a dynamic import, so the engine graph loads off the eager boot path
-    // (#4486). state.correlationEngine settles asynchronously; the refresh scheduler
-    // and export getter that read it already null-guard.
-    void this.loadInitialCorrelationEngine();
-
-    startLearning();
+    // Initial correlation engine run is post-LCP background work. Wait for
+    // precision country geometry there instead of before visible data fan-out.
+    this.startPostLcpIntelligence(countryGeometryReady);
 
     // Hide unconfigured layers after first data load
     if (!isAisConfigured()) {

--- a/src/app/app-context.ts
+++ b/src/app/app-context.ts
@@ -1,6 +1,7 @@
 import type { InternetOutage, SocialUnrestEvent, MilitaryFlight, MilitaryFlightCluster, MilitaryVessel, MilitaryVesselCluster, USNIFleetReport, PanelConfig, MapLayers, NewsItem, MarketData, ClusteredEvent, CyberThreat, Monitor } from '@/types';
 import type { AirportDelayAlert, PositionSample } from '@/services/aviation';
 import type { IranEvent } from '@/generated/client/worldmonitor/conflict/v1/service_client';
+import type { ConflictEvent } from '@/services/conflict';
 import type { SanctionsPressureResult } from '@/services/sanctions-pressure';
 import type { RadiationWatchResult } from '@/services/radiation';
 import type { SecurityAdvisory } from '@/services/security-advisories';
@@ -19,6 +20,7 @@ export interface UnifiedSettingsController {
 }
 
 export interface IntelligenceCache {
+  conflicts?: ConflictEvent[];
   flightDelays?: AirportDelayAlert[];
   thermalEscalation?: import('@/services/thermal-escalation').ThermalEscalationWatch;
   aircraftPositions?: PositionSample[];

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -1,6 +1,7 @@
 import type { AppContext, AppModule } from '@/app/app-context';
 import { getRpcBaseUrl } from '@/services/rpc-client';
 import { enqueuePanelCall } from '@/app/pending-panel-data';
+import { markLcpDebug } from '@/utils/lcp-debug';
 import type { NewsItem, MapLayers, SocialUnrestEvent, MilitaryFlight } from '@/types';
 import type { MarketData } from '@/types';
 import type { TimeRange } from '@/components/MapContainer';
@@ -504,6 +505,67 @@ export class DataLoaderManager implements AppModule {
     this.refreshCiiAndBrief(false);
   }
 
+  public refreshGeometryDependentCiiAfterCountryGeometry(): void {
+    markLcpDebug('wm:data:country-geometry-replay-start');
+    const cache = this.ctx.intelligenceCache;
+    let replayed = 0;
+
+    if (cache.protests || cache.conflicts || cache.military || cache.iranEvents) {
+      resetHotspotActivity();
+    }
+    if (cache.protests) {
+      ingestProtestsForCII(cache.protests.events);
+      replayed += 1;
+    }
+    if (cache.conflicts) {
+      ingestConflictsForCII(cache.conflicts);
+      replayed += 1;
+    }
+    if (cache.military) {
+      ingestMilitaryForCII(cache.military.flights, cache.military.vessels);
+      replayed += 1;
+    }
+    if (cache.iranEvents) {
+      const coerced = cache.iranEvents.map(e => ({ ...e, timestamp: Number(e.timestamp) || 0 }));
+      ingestStrikesForCII(coerced);
+      replayed += 1;
+    }
+    if (cache.earthquakes) {
+      ingestEarthquakesForCII(cache.earthquakes);
+      replayed += 1;
+    }
+    if (cache.flightDelays) {
+      const severe = cache.flightDelays.filter(d => d.severity === 'major' || d.severity === 'severe' || d.delayType === 'closure');
+      if (severe.length > 0) {
+        ingestAviationForCII(severe);
+        replayed += 1;
+      }
+    }
+    if (cache.outages) {
+      ingestOutagesForCII(cache.outages);
+      replayed += 1;
+    }
+    if (cache.orefAlerts) {
+      ingestOrefForCII(cache.orefAlerts.alertCount, cache.orefAlerts.historyCount24h);
+      replayed += 1;
+    }
+    if (cache.advisories) {
+      ingestAdvisoriesForCII(cache.advisories);
+      replayed += 1;
+    }
+    if (cache.sanctions) {
+      ingestSanctionsForCII(cache.sanctions.countries);
+      replayed += 1;
+    }
+    if (this.ctx.cyberThreatsCache) {
+      ingestCyberThreatsForCII(this.ctx.cyberThreatsCache);
+      replayed += 1;
+    }
+
+    markLcpDebug('wm:data:country-geometry-replay-ready', { replayed });
+    if (replayed > 0) this.refreshCiiAndBrief(false);
+  }
+
   private async tryFetchDigest(): Promise<ListFeedDigestResponse | null> {
     const now = Date.now();
 
@@ -515,6 +577,7 @@ export class DataLoaderManager implements AppModule {
     }
 
     try {
+      markLcpDebug('wm:data:feed-digest-start');
       const resp = await fetch(
         toApiUrl(`/api/news/v1/list-feed-digest?variant=${SITE_VARIANT}&lang=${getCurrentLanguage()}`),
         { cache: 'no-cache', signal: AbortSignal.timeout(this.digestRequestTimeoutMs) },
@@ -522,12 +585,14 @@ export class DataLoaderManager implements AppModule {
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
       const data = await resp.json() as ListFeedDigestResponse;
       const catCount = Object.keys(data.categories ?? {}).length;
+      markLcpDebug('wm:data:feed-digest-ready', { categories: catCount });
       console.info(`[News] Digest fetched: ${catCount} categories`);
       this.lastGoodDigest = data;
       this.persistDigest(data);
       this.digestBreaker = { state: 'closed', failures: 0, cooldownUntil: 0 };
       return data;
     } catch (e) {
+      markLcpDebug('wm:data:feed-digest-error');
       console.warn('[News] Digest fetch failed, using fallback:', e);
       this.digestBreaker.failures++;
       if (this.digestBreaker.failures >= 2) {
@@ -2340,6 +2405,7 @@ export class DataLoaderManager implements AppModule {
     tasks.push((async () => {
       try {
         const conflictData = await fetchConflictEvents();
+        this.ctx.intelligenceCache.conflicts = conflictData.events;
         ingestConflictsForCII(conflictData.events);
         if (conflictData.count > 0) dataFreshness.recordUpdate('acled_conflict', conflictData.count);
       } catch (error) {

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -63,6 +63,7 @@ import type { McpPanelSpec } from '@/services/mcp-store';
 import { getAuthState, subscribeAuthState } from '@/services/auth-state';
 import type { AuthSession } from '@/services/auth-state';
 import { PanelGateReason, getPanelGateReason, hasPremiumAccess } from '@/services/panel-gating';
+import { markLcpDebug } from '@/utils/lcp-debug';
 import type { Panel } from '@/components/Panel';
 import type { SupplyChainPanel } from '@/components/SupplyChainPanel';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
@@ -454,7 +455,9 @@ export class PanelLayoutManager implements AppModule {
   async renderLayout(): Promise<void> {
     const isGlobeMode = getStoredMapModePreference() === 'globe';
 
+    markLcpDebug('wm:layout:render-start');
     document.documentElement.classList.add('wm-layout-hydrated');
+    markLcpDebug('wm:layout:shell-replaced');
     setTrustedHtml(this.ctx.container, trustedHtml(`
       ${this.ctx.isDesktopApp ? '<div class="tauri-titlebar" data-tauri-drag-region></div>' : ''}
       <a href="#main" class="skip-link">Skip to main content</a>
@@ -2122,6 +2125,7 @@ export class PanelLayoutManager implements AppModule {
     // the isDestroyed guard below also stops a destroyed manager from building a map.
     const { MapContainer } = await mapModulePromise;
     if (this.ctx.isDestroyed) return;
+    markLcpDebug('wm:map:container-construct');
     this.ctx.map = new MapContainer(mapContainer, {
       zoom: this.ctx.isMobile ? 2.5 : 1.0,
       pan: { x: 0, y: 0 },
@@ -2142,6 +2146,7 @@ export class PanelLayoutManager implements AppModule {
 
     this.ctx.map.initEscalationGetters();
     this.ctx.currentTimeRange = this.ctx.map.getTimeRange();
+    markLcpDebug('wm:map:container-ready');
 
     this.ctx.map.onTimeRangeChanged((range) => {
       this.ctx.currentTimeRange = range;

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -1220,7 +1220,8 @@ export class PanelLayoutManager implements AppModule {
     }
     const existing = this.deferredPanelMounts.get(key);
     existing?.observer?.disconnect();
-    if (existing?.retryTimer !== null) clearTimeout(existing.retryTimer);
+    const retryTimer = existing?.retryTimer ?? null;
+    if (retryTimer !== null) clearTimeout(retryTimer);
     if (existing?.placeholder && existing.placeholder !== placeholder) {
       existing.placeholder.remove();
     }

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -130,6 +130,7 @@ interface DeferredPanelMount {
   panel: Panel | null;
   placeholder: HTMLElement | null;
   observer: IntersectionObserver | null;
+  retryTimer: ReturnType<typeof setTimeout> | null;
   mounted: boolean;
   loading: Promise<void> | null;
 }
@@ -340,6 +341,7 @@ export class PanelLayoutManager implements AppModule {
     this.panelDragCleanupHandlers = [];
     for (const deferred of this.deferredPanelMounts.values()) {
       deferred.observer?.disconnect();
+      if (deferred.retryTimer !== null) clearTimeout(deferred.retryTimer);
     }
     this.deferredPanelMounts.clear();
     this.lazyPanelRegistrations.clear();
@@ -1215,6 +1217,7 @@ export class PanelLayoutManager implements AppModule {
     }
     const existing = this.deferredPanelMounts.get(key);
     existing?.observer?.disconnect();
+    if (existing?.retryTimer !== null) clearTimeout(existing.retryTimer);
     if (existing?.placeholder && existing.placeholder !== placeholder) {
       existing.placeholder.remove();
     }
@@ -1222,6 +1225,7 @@ export class PanelLayoutManager implements AppModule {
       panel,
       placeholder,
       observer: null,
+      retryTimer: null,
       mounted: false,
       loading: null,
     };
@@ -1234,6 +1238,10 @@ export class PanelLayoutManager implements AppModule {
   private observeDeferredPanelShell(key: string, deferred: DeferredPanelMount): void {
     const { placeholder } = deferred;
     if (!placeholder) return;
+    if (deferred.retryTimer !== null) {
+      clearTimeout(deferred.retryTimer);
+      deferred.retryTimer = null;
+    }
     if (typeof window === 'undefined' || typeof IntersectionObserver === 'undefined') {
       const ric = typeof window !== 'undefined'
         ? (window as unknown as { requestIdleCallback?: (cb: () => void) => number }).requestIdleCallback
@@ -1266,20 +1274,33 @@ export class PanelLayoutManager implements AppModule {
     const grid = this.getPanelMountGrid(key);
     if (!grid && !deferred.placeholder?.parentNode) return false;
 
+    if (deferred.retryTimer !== null) {
+      clearTimeout(deferred.retryTimer);
+      deferred.retryTimer = null;
+    }
     deferred.observer?.disconnect();
     deferred.observer = null;
     const targetGrid = grid ?? (deferred.placeholder!.parentNode as HTMLElement);
     const finish = (panel: Panel | null): void => {
-      if (!panel || this.ctx.isDestroyed) return;
       const current = this.deferredPanelMounts.get(key);
       if (current !== deferred || deferred.mounted) return;
+      deferred.loading = null;
+      if (!panel || this.ctx.isDestroyed) {
+        if (!this.ctx.isDestroyed && this.lazyPanelRegistrations.has(key) && deferred.placeholder?.parentNode) {
+          deferred.retryTimer = setTimeout(() => {
+            if (this.deferredPanelMounts.get(key) !== deferred || deferred.mounted) return;
+            deferred.retryTimer = null;
+            this.observeDeferredPanelShell(key, deferred);
+          }, 1000);
+        }
+        return;
+      }
       const placeholder = deferred.placeholder;
       if (this.mountPanelElement(targetGrid, key, panel, placeholder)) {
         this.afterPanelMounted(key, panel);
       }
       deferred.mounted = true;
       deferred.placeholder = null;
-      deferred.loading = null;
       this.deferredPanelMounts.delete(key);
     };
 

--- a/src/app/panel-mount-deferral.ts
+++ b/src/app/panel-mount-deferral.ts
@@ -1,3 +1,9 @@
+import {
+  loadPanelCollapsed,
+  loadPanelColSpans,
+  loadPanelSpans,
+} from '@/utils/panel-storage';
+
 export const INITIAL_PANEL_MOUNT_BUDGET_DESKTOP = 8;
 // Mobile mounts fewer panels eagerly; the rest get IntersectionObserver shells (700px
 // lookahead) and mount before they scroll into view. Lowered 4→3 to trim boot DOM /
@@ -10,6 +16,59 @@ export interface PanelMountDeferralInput {
   mountedEnabledCount: number;
   isMobile: boolean;
 }
+
+export interface PanelFootprint {
+  rowSpan?: number;
+  colSpan?: number;
+  wide?: boolean;
+}
+
+export interface PanelReservation extends Required<PanelFootprint> {
+  rowSpanSource: 'default' | 'saved' | 'none';
+  colSpanSource: 'default' | 'saved' | 'none';
+  collapsed: boolean;
+}
+
+export interface PanelReservationInput {
+  defaultFootprints?: Readonly<Record<string, PanelFootprint>>;
+  savedRowSpans?: Readonly<Record<string, number>>;
+  savedColSpans?: Readonly<Record<string, number>>;
+  savedCollapsed?: Readonly<Record<string, boolean>>;
+}
+
+const MIN_ROW_SPAN = 1;
+const MAX_ROW_SPAN = 4;
+const MIN_COL_SPAN = 1;
+const MAX_COL_SPAN = 3;
+const DYNAMIC_PANEL_DEFAULT_FOOTPRINT: PanelFootprint = Object.freeze({ rowSpan: 2 });
+
+export const DEFAULT_PANEL_FOOTPRINTS: Readonly<Record<string, PanelFootprint>> = Object.freeze({
+  'chat-analyst': { rowSpan: 2 },
+  'consumer-prices': { rowSpan: 2 },
+  cii: { rowSpan: 2 },
+  displacement: { rowSpan: 2 },
+  economic: { rowSpan: 2 },
+  'energy-complex': { rowSpan: 2 },
+  'energy-crisis': { rowSpan: 2 },
+  'energy-disruptions': { rowSpan: 2 },
+  'fuel-shortages': { rowSpan: 2 },
+  'gdelt-intel': { rowSpan: 2 },
+  'internet-disruptions': { rowSpan: 2 },
+  'live-news': { rowSpan: 2, colSpan: 2, wide: true },
+  'live-webcams': { rowSpan: 2, colSpan: 2, wide: true },
+  'oil-inventories': { rowSpan: 2 },
+  'pipeline-status': { rowSpan: 2 },
+  'sanctions-pressure': { rowSpan: 2 },
+  'security-advisories': { rowSpan: 2 },
+  'storage-facility-map': { rowSpan: 2 },
+  'strategic-posture': { rowSpan: 2 },
+  'supply-chain': { rowSpan: 2 },
+  'telegram-intel': { rowSpan: 2 },
+  'threat-timeline': { rowSpan: 2 },
+  'trade-policy': { rowSpan: 2 },
+  'ucdp-events': { rowSpan: 2 },
+  'windy-webcams': { rowSpan: 2, colSpan: 2, wide: true },
+});
 
 const CONTROL_SELECTOR = [
   'button',
@@ -24,6 +83,68 @@ const CONTROL_SELECTOR = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(',');
 
+function validIntegerInRange(value: unknown, min: number, max: number): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= min && value <= max;
+}
+
+export function getDefaultPanelFootprint(
+  panelId: string,
+  defaultFootprints: Readonly<Record<string, PanelFootprint>> = DEFAULT_PANEL_FOOTPRINTS,
+): PanelFootprint {
+  const staticFootprint = defaultFootprints[panelId];
+  if (staticFootprint) return staticFootprint;
+  if (panelId.startsWith('cw-') || panelId.startsWith('mcp-')) return DYNAMIC_PANEL_DEFAULT_FOOTPRINT;
+  return {};
+}
+
+export function derivePanelReservation(panelId: string, input: PanelReservationInput = {}): PanelReservation {
+  const defaultFootprint = getDefaultPanelFootprint(panelId, input.defaultFootprints);
+  const savedRowSpans = input.savedRowSpans ?? loadPanelSpans();
+  const savedColSpans = input.savedColSpans ?? loadPanelColSpans();
+  const savedCollapsed = input.savedCollapsed ?? loadPanelCollapsed();
+  const savedRowSpan = savedRowSpans[panelId];
+  const savedColSpan = savedColSpans[panelId];
+  const defaultRowSpan = validIntegerInRange(defaultFootprint.rowSpan, MIN_ROW_SPAN, MAX_ROW_SPAN)
+    ? defaultFootprint.rowSpan
+    : MIN_ROW_SPAN;
+  const defaultColSpan = validIntegerInRange(defaultFootprint.colSpan, MIN_COL_SPAN, MAX_COL_SPAN)
+    ? defaultFootprint.colSpan
+    : (defaultFootprint.wide ? 2 : MIN_COL_SPAN);
+  const hasSavedRowSpan = validIntegerInRange(savedRowSpan, MIN_ROW_SPAN, MAX_ROW_SPAN);
+  const hasSavedColSpan = validIntegerInRange(savedColSpan, MIN_COL_SPAN, MAX_COL_SPAN);
+
+  return {
+    rowSpan: hasSavedRowSpan ? savedRowSpan : defaultRowSpan,
+    colSpan: hasSavedColSpan ? savedColSpan : defaultColSpan,
+    wide: defaultFootprint.wide === true,
+    rowSpanSource: hasSavedRowSpan ? 'saved' : (defaultRowSpan > 1 ? 'default' : 'none'),
+    colSpanSource: hasSavedColSpan ? 'saved' : (defaultColSpan > 1 ? 'default' : 'none'),
+    collapsed: savedCollapsed[panelId] === true,
+  };
+}
+
+function applyPanelReservation(shell: HTMLElement, reservation: PanelReservation): void {
+  if (reservation.wide) {
+    shell.classList.add('panel-wide');
+  }
+
+  if (reservation.rowSpanSource === 'saved') {
+    shell.classList.add(`span-${reservation.rowSpan}`, 'resized');
+  } else if (reservation.rowSpanSource === 'default' && !reservation.wide) {
+    shell.classList.add(`span-${reservation.rowSpan}`);
+  }
+
+  if (reservation.colSpanSource === 'saved') {
+    shell.classList.add(`col-span-${reservation.colSpan}`);
+  } else if (reservation.colSpanSource === 'default' && !reservation.wide) {
+    shell.classList.add(`col-span-${reservation.colSpan}`);
+  }
+
+  if (reservation.collapsed) {
+    shell.classList.add('panel-collapsed');
+  }
+}
+
 export function getInitialPanelMountBudget(isMobile: boolean): number {
   return isMobile ? INITIAL_PANEL_MOUNT_BUDGET_MOBILE : INITIAL_PANEL_MOUNT_BUDGET_DESKTOP;
 }
@@ -36,12 +157,17 @@ export function shouldDeferInitialPanelMount({
   return enabled && mountedEnabledCount >= getInitialPanelMountBudget(isMobile);
 }
 
-export function createDeferredPanelShell(panelId: string, title: string): HTMLElement {
+export function createDeferredPanelShell(
+  panelId: string,
+  title: string,
+  reservationInput: PanelReservationInput = {},
+): HTMLElement {
   const shell = document.createElement('div');
   shell.className = 'panel panel-deferred-shell';
   shell.dataset.panel = panelId;
   shell.dataset.deferredPanel = 'true';
   shell.setAttribute('aria-hidden', 'true');
+  applyPanelReservation(shell, derivePanelReservation(panelId, reservationInput));
 
   const header = document.createElement('div');
   header.className = 'panel-header panel-deferred-header';
@@ -57,6 +183,9 @@ export function createDeferredPanelShell(panelId: string, title: string): HTMLEl
 
   const content = document.createElement('div');
   content.className = 'panel-content panel-deferred-content';
+  if (shell.classList.contains('panel-collapsed')) {
+    content.style.display = 'none';
+  }
   for (let index = 0; index < 3; index++) {
     const line = document.createElement('span');
     line.className = 'panel-deferred-skeleton';

--- a/src/bootstrap/lcp-attribution.ts
+++ b/src/bootstrap/lcp-attribution.ts
@@ -1,4 +1,4 @@
-import { markLcpDebug, type LcpDebugDetail, type LcpMarkSnapshot } from '@/utils/lcp-debug';
+import { markLcpDebug, type LcpMarkSnapshot } from '@/utils/lcp-debug';
 
 type LcpElementSnapshot = {
   className: string;
@@ -133,7 +133,8 @@ function sanitizeResourceUrl(raw: string | undefined): string {
     const query = url.search ? '?[redacted]' : '';
     return `${url.origin}${url.pathname}${query}`;
   } catch {
-    return raw.split('?')[0].slice(0, 200);
+    const [withoutQuery = raw] = raw.split('?');
+    return withoutQuery.slice(0, 200);
   }
 }
 

--- a/src/bootstrap/lcp-attribution.ts
+++ b/src/bootstrap/lcp-attribution.ts
@@ -1,0 +1,342 @@
+import { markLcpDebug, type LcpDebugDetail, type LcpMarkSnapshot } from '@/utils/lcp-debug';
+
+type LcpElementSnapshot = {
+  className: string;
+  closest: string;
+  id: string;
+  selector: string;
+  tagName: string;
+  text: string;
+};
+
+type LcpResourceGroup = {
+  category: string;
+  count: number;
+  encodedBodySize: number;
+  transferSize: number;
+  largest?: {
+    duration: number;
+    initiatorType: string;
+    name: string;
+    startTime: number;
+    transferSize: number;
+  };
+};
+
+type LcpContextSnapshot = {
+  devicePixelRatio: number;
+  theme: string;
+  variant: string;
+  viewport: {
+    height: number;
+    width: number;
+  };
+  visibilityState: string;
+};
+
+type LcpEntrySnapshot = {
+  context: LcpContextSnapshot;
+  element: LcpElementSnapshot | null;
+  loadTime: number;
+  renderTime: number;
+  resources: LcpResourceGroup[];
+  size: number;
+  startTime: number;
+  url: string;
+};
+
+
+export type WmLcpDebugState = {
+  enabled: true;
+  entries: LcpEntrySnapshot[];
+  getSnapshot: () => {
+    context: LcpContextSnapshot;
+    entries: LcpEntrySnapshot[];
+    marks: LcpMarkSnapshot[];
+    resources: LcpResourceGroup[];
+  };
+  marks: LcpMarkSnapshot[];
+  observerInstalled: boolean;
+};
+
+declare global {
+  interface Window {
+    __wmLcpDebug?: WmLcpDebugState;
+  }
+}
+
+const DEBUG_QUERY_PARAM = 'wm_lcp_debug';
+const DEBUG_STORAGE_KEYS = ['wm_lcp_debug', 'wm-lcp-debug'];
+const MAX_ENTRIES = 20;
+const MAX_RESOURCE_GROUPS = 12;
+const MAX_TEXT_LENGTH = 140;
+
+type LcpPerformanceEntry = PerformanceEntry & {
+  element?: Element;
+  loadTime?: number;
+  renderTime?: number;
+  size?: number;
+  url?: string;
+};
+
+function capText(value: string, maxLength = MAX_TEXT_LENGTH): string {
+  return value.replace(/\s+/g, ' ').trim().slice(0, maxLength);
+}
+
+function getWindowStorage(kind: 'localStorage' | 'sessionStorage'): Storage | undefined {
+  if (typeof window === 'undefined') return undefined;
+  try {
+    return window[kind];
+  } catch {
+    return undefined;
+  }
+}
+
+function getStorageFlag(storage: Storage | undefined, key: string): string | null {
+  try {
+    return storage?.getItem(key) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function isTruthyDebugFlag(value: string | null): boolean {
+  return value === '1' || value === 'true' || value === 'yes';
+}
+
+function isLcpDebugEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    const params = new URL(window.location.href).searchParams;
+    if (isTruthyDebugFlag(params.get(DEBUG_QUERY_PARAM))) return true;
+  } catch {
+    // Ignore URL parsing failures in unusual embedded runtimes.
+  }
+
+  const sessionStorage = getWindowStorage('sessionStorage');
+  const localStorage = getWindowStorage('localStorage');
+  for (const key of DEBUG_STORAGE_KEYS) {
+    if (
+      isTruthyDebugFlag(getStorageFlag(sessionStorage, key))
+      || isTruthyDebugFlag(getStorageFlag(localStorage, key))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function sanitizeResourceUrl(raw: string | undefined): string {
+  if (!raw) return '';
+  try {
+    const url = new URL(raw, typeof window !== 'undefined' ? window.location.href : 'https://worldmonitor.app/');
+    const query = url.search ? '?[redacted]' : '';
+    return `${url.origin}${url.pathname}${query}`;
+  } catch {
+    return raw.split('?')[0].slice(0, 200);
+  }
+}
+
+function getClassName(element: Element): string {
+  const className = element.className;
+  if (typeof className === 'string') return className;
+  if (className && typeof className === 'object' && 'baseVal' in className) {
+    return String((className as SVGAnimatedString).baseVal ?? '');
+  }
+  return '';
+}
+
+function escapeClassName(name: string): string {
+  if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+    return CSS.escape(name);
+  }
+  return name.replace(/[^a-zA-Z0-9_-]/g, (char) => `\\${char}`);
+}
+
+function buildSelector(element: Element): string {
+  const tag = element.tagName.toLowerCase();
+  const id = element.id ? `#${element.id}` : '';
+  const classes = getClassName(element)
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 4)
+    .map((name) => `.${escapeClassName(name)}`)
+    .join('');
+  return `${tag}${id}${classes}`.slice(0, 180);
+}
+
+function closestAttributionLabel(element: Element): string {
+  const panel = element.closest<HTMLElement>('[data-panel-id]');
+  if (panel?.dataset.panelId) return `panel:${panel.dataset.panelId}`;
+  if (element.closest('[data-shell-lcp]')) return 'shell-lcp';
+  if (element.closest('.skeleton-shell')) return 'shell';
+  if (element.closest('#mapContainer')) return 'map-container';
+  if (element.closest('#mapSection')) return 'map-section';
+  if (element.closest('.map-renderer-shell')) return 'map-renderer-shell';
+  if (element.closest('.panel')) return 'panel';
+  return '';
+}
+
+function snapshotElement(element: Element | undefined): LcpElementSnapshot | null {
+  if (!element) return null;
+  return {
+    className: capText(getClassName(element), 240),
+    closest: closestAttributionLabel(element),
+    id: element.id,
+    selector: buildSelector(element),
+    tagName: element.tagName.toLowerCase(),
+    text: capText(element.textContent ?? ''),
+  };
+}
+
+function classifyCriticalResource(name: string, initiatorType: string): string {
+  const lower = name.toLowerCase();
+  if (lower.includes('/api/bootstrap')) return 'bootstrap';
+  if (lower.includes('/api/news/v1/list-feed-digest')) return 'feed-digest';
+  if (lower.includes('/data/countries.geojson')) return 'country-geometry';
+  if (lower.includes('/data/countries-50m.json') || lower.includes('/data/countries-110m.json')) return 'map-topology';
+  if (
+    lower.includes('mapcontainer')
+    || lower.includes('deckglmap')
+    || lower.includes('globemap')
+    || lower.includes('maplibre')
+    || lower.includes('deck-stack')
+    || lower.includes('protomaps')
+  ) {
+    return 'map-chunk';
+  }
+  if (lower.includes('sentry') || lower.includes('clerk') || lower.includes('vercel') || lower.includes('analytics')) {
+    return 'secondary-startup';
+  }
+  if (initiatorType === 'script' || lower.endsWith('.js')) return 'script';
+  if (initiatorType === 'css' || lower.endsWith('.css')) return 'style';
+  if (lower.includes('/api/')) return 'api';
+  if (lower.includes('/assets/') || lower.includes('/data/')) return 'static';
+  return 'other';
+}
+
+function summarizeCriticalResources(upToStartTime = Number.POSITIVE_INFINITY): LcpResourceGroup[] {
+  if (typeof performance === 'undefined' || typeof performance.getEntriesByType !== 'function') return [];
+  const resources = performance.getEntriesByType('resource') as PerformanceResourceTiming[];
+  const groups = new Map<string, LcpResourceGroup>();
+
+  for (const resource of resources) {
+    if (resource.startTime > upToStartTime + 1) continue;
+    const category = classifyCriticalResource(resource.name, resource.initiatorType);
+    if (category === 'other') continue;
+    const group = groups.get(category) ?? {
+      category,
+      count: 0,
+      encodedBodySize: 0,
+      transferSize: 0,
+    };
+    const transferSize = Math.max(0, resource.transferSize || 0);
+    group.count += 1;
+    group.encodedBodySize += Math.max(0, resource.encodedBodySize || 0);
+    group.transferSize += transferSize;
+    if (!group.largest || transferSize > group.largest.transferSize) {
+      group.largest = {
+        duration: Math.round(resource.duration),
+        initiatorType: resource.initiatorType,
+        name: sanitizeResourceUrl(resource.name),
+        startTime: Math.round(resource.startTime),
+        transferSize,
+      };
+    }
+    groups.set(category, group);
+  }
+
+  return Array.from(groups.values())
+    .sort((a, b) => b.transferSize - a.transferSize || b.encodedBodySize - a.encodedBodySize || a.category.localeCompare(b.category))
+    .slice(0, MAX_RESOURCE_GROUPS);
+}
+
+function snapshotContext(): LcpContextSnapshot {
+  const root = typeof document !== 'undefined' ? document.documentElement : null;
+  return {
+    devicePixelRatio: Math.round((typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1) * 100) / 100,
+    theme: root?.dataset.theme ?? '',
+    variant: root?.dataset.variant ?? '',
+    viewport: {
+      height: Math.round(typeof window !== 'undefined' ? window.innerHeight || root?.clientHeight || 0 : root?.clientHeight || 0),
+      width: Math.round(typeof window !== 'undefined' ? window.innerWidth || root?.clientWidth || 0 : root?.clientWidth || 0),
+    },
+    visibilityState: typeof document !== 'undefined' ? document.visibilityState : '',
+  };
+}
+
+function getOrCreateDebugState(): WmLcpDebugState {
+  const existing = window.__wmLcpDebug;
+  if (existing?.enabled) return existing;
+
+  const state: WmLcpDebugState = {
+    enabled: true,
+    entries: [],
+    getSnapshot: () => ({
+      context: snapshotContext(),
+      entries: state.entries.slice(),
+      marks: state.marks.slice(),
+      resources: summarizeCriticalResources(),
+    }),
+    marks: [],
+    observerInstalled: false,
+  };
+  window.__wmLcpDebug = state;
+  return state;
+}
+
+function pushCapped<T>(items: T[], item: T, cap: number): void {
+  items.push(item);
+  if (items.length > cap) items.splice(0, items.length - cap);
+}
+
+function recordLcpEntry(entry: LcpPerformanceEntry): void {
+  const state = window.__wmLcpDebug;
+  if (!state?.enabled) return;
+  pushCapped(state.entries, {
+    context: snapshotContext(),
+    element: snapshotElement(entry.element),
+    loadTime: Math.round(entry.loadTime ?? 0),
+    renderTime: Math.round(entry.renderTime ?? 0),
+    resources: summarizeCriticalResources(entry.startTime),
+    size: Math.round(entry.size ?? 0),
+    startTime: Math.round(entry.startTime),
+    url: sanitizeResourceUrl(entry.url),
+  }, MAX_ENTRIES);
+}
+
+export function installLcpAttributionDebug(): void {
+  if (typeof window === 'undefined' || !isLcpDebugEnabled()) return;
+  const state = getOrCreateDebugState();
+  if (state.observerInstalled) return;
+  state.observerInstalled = true;
+
+  try {
+    const observer = new PerformanceObserver((list) => {
+      for (const entry of list.getEntries()) {
+        recordLcpEntry(entry as LcpPerformanceEntry);
+      }
+    });
+    observer.observe({ type: 'largest-contentful-paint', buffered: true });
+  } catch {
+    markLcpDebug('wm:lcp-debug:observer-unavailable');
+  }
+
+  document.addEventListener('visibilitychange', () => {
+    markLcpDebug(`wm:visibility:${document.visibilityState}`);
+  }, { passive: true });
+  window.addEventListener('pagehide', () => {
+    markLcpDebug('wm:pagehide');
+  }, { passive: true });
+
+  markLcpDebug('wm:lcp-debug:installed');
+}
+
+export const __testing__ = {
+  capText,
+  classifyCriticalResource,
+  isLcpDebugEnabled,
+  isTruthyDebugFlag,
+  sanitizeResourceUrl,
+  snapshotContext,
+};

--- a/src/components/CustomWidgetPanel.ts
+++ b/src/components/CustomWidgetPanel.ts
@@ -14,6 +14,7 @@ export class CustomWidgetPanel extends Panel {
       title: spec.title,
       closable: true,
       className: 'custom-widget-panel',
+      defaultRowSpan: 2,
     });
     this.spec = spec;
     this.addHeaderButtons();

--- a/src/components/MapContainer.ts
+++ b/src/components/MapContainer.ts
@@ -5,6 +5,7 @@
  * Supports an optional 3D globe mode (globe.gl) selectable from Settings.
  */
 import { isMobileDevice } from '@/utils';
+import { markLcpDebug } from '@/utils/lcp-debug';
 import type { MapComponent } from './Map';
 import type { DeckGLMap, DeckMapView, CountryClickPayload } from './DeckGLMap';
 import type { GlobeMap } from './GlobeMap';
@@ -275,6 +276,7 @@ export class MapContainer {
   }
 
   private showRendererShell(kind: RendererKind): void {
+    markLcpDebug('wm:map:shell-shown', { kind });
     this.container.classList.remove('deckgl-mode', 'globe-mode', 'svg-mode');
     this.container.classList.add('map-renderer-shell');
     this.container.dataset.mapRendererPending = kind;
@@ -370,6 +372,7 @@ export class MapContainer {
       };
 
       const finish = (): void => {
+        markLcpDebug('wm:map:renderer-demand', { kind: 'deck' });
         settle(true);
       };
 
@@ -446,6 +449,7 @@ export class MapContainer {
 
   private async initSvgMap(logMessage: string, token: number): Promise<void> {
     console.log(logMessage);
+    markLcpDebug('wm:map:svg-init-start');
     this.useDeckGL = false;
     this.deckGLMap = null;
     this.sanitizeNonDeckLayers();
@@ -456,11 +460,13 @@ export class MapContainer {
     // clear partial WebGL nodes before creating the SVG fallback.
     this.svgMap = new MapComponent(this.container, this.initialState, { chrome: this.chrome, isMobile: this.isMobile });
     this.rehydrateActiveMap();
+    markLcpDebug('wm:map:svg-ready');
   }
 
   private async createGlobeMap(rendererToken: number): Promise<void> {
     const globeToken = ++this.globeInitToken;
     try {
+      markLcpDebug('wm:map:globe-init-start');
       const { GlobeMap } = await import('./GlobeMap');
       if (!this.isCurrentRendererInit(rendererToken)) return;
       this.prepareRendererDom('globe-mode');
@@ -469,6 +475,7 @@ export class MapContainer {
         chrome: this.chrome,
       });
       this.rehydrateActiveMap();
+      markLcpDebug('wm:map:globe-ready');
     } catch (error) {
       this.handleGlobeInitFailure(globeToken, error);
     }
@@ -489,6 +496,7 @@ export class MapContainer {
   private async createDeckGLMap(token: number): Promise<void> {
     console.log('[MapContainer] Initializing deck.gl map (desktop mode)');
     try {
+      markLcpDebug('wm:map:deck-init-start');
       await loadMapLibreCss();
       const { DeckGLMap } = await import('./DeckGLMap');
       if (!this.isCurrentRendererInit(token)) return;
@@ -503,6 +511,7 @@ export class MapContainer {
       // SVG, instead of becoming an unhandled rejection behind a blank map.
       await this.deckGLMap.whenReady();
       if (!this.isCurrentRendererInit(token)) return;
+      markLcpDebug('wm:map:deck-ready');
     } catch (error) {
       if (!this.isCurrentRendererInit(token)) return;
       console.warn('[MapContainer] DeckGL initialization failed, falling back to SVG map', error);
@@ -523,6 +532,7 @@ export class MapContainer {
     // the tab becomes visible — the lightweight shell is shown until then.
     await afterFirstPaint();
     if (!this.isCurrentRendererInit(token)) return;
+    markLcpDebug('wm:map:after-first-paint');
 
     if (this.useGlobe) {
       console.log('[MapContainer] Initializing 3D globe (globe.gl mode)');

--- a/src/components/McpDataPanel.ts
+++ b/src/components/McpDataPanel.ts
@@ -29,6 +29,7 @@ export class McpDataPanel extends Panel {
       title: spec.title,
       closable: true,
       className: 'mcp-data-panel',
+      defaultRowSpan: 2,
     });
     this.spec = spec;
     this.addHeaderButtons();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,8 @@
 import './styles/base-layer.css';
 import './styles/happy-theme.css';
 import './bootstrap/zod-csp';
+import { installLcpAttributionDebug } from '@/bootstrap/lcp-attribution';
+import { markLcpDebug } from '@/utils/lcp-debug';
 import { enqueueSentryCall, installPreInitErrorQueue, scheduleSentryInit } from '@/bootstrap/sentry-defer';
 import { initVercelAnalytics } from '@/bootstrap/secondary-startup';
 import { App } from './App';
@@ -25,6 +27,7 @@ function activateDeferredDashboardStyles(): void {
 }
 
 activateDeferredDashboardStyles();
+installLcpAttributionDebug();
 
 // perf G — defer @sentry/browser off the critical path (#3994).
 // The eager `Sentry.init({...})` previously ran here cost ~1.96 s of pre-LCP
@@ -366,6 +369,7 @@ if (urlParams.get('settings') === '1') {
   );
 } else {
   installUtmInterceptor();
+  markLcpDebug('wm:boot:app-construct');
   const app = new App('app');
   app
     .init()

--- a/src/services/country-geometry.ts
+++ b/src/services/country-geometry.ts
@@ -1,4 +1,5 @@
 import type { FeatureCollection, Geometry, GeoJsonProperties, Position } from 'geojson';
+import { markLcpDebug } from '@/utils/lcp-debug';
 
 interface IndexedCountryGeometry {
   code: string;
@@ -251,6 +252,7 @@ async function ensureLoaded(): Promise<void> {
   loadPromise = (async () => {
     if (typeof fetch !== 'function') return;
 
+    markLcpDebug('wm:data:country-geometry-fetch-start');
     try {
       const response = await fetch(COUNTRY_GEOJSON_URL);
       if (!response.ok) {
@@ -264,6 +266,7 @@ async function ensureLoaded(): Promise<void> {
 
       loadedGeoJson = data;
       rebuildCountryIndex(data);
+      markLcpDebug('wm:data:country-geometry-fetch-ready', { features: data.features.length });
 
       // Apply optional higher-resolution boundary overrides (sourced from Natural Earth)
       try {
@@ -280,6 +283,7 @@ async function ensureLoaded(): Promise<void> {
         // Overrides optional; ignore fetch/parse errors
       }
     } catch (err) {
+      markLcpDebug('wm:data:country-geometry-fetch-error');
       console.warn('[country-geometry] Failed to load countries.geojson:', err);
     }
   })();

--- a/src/utils/lcp-debug.ts
+++ b/src/utils/lcp-debug.ts
@@ -1,0 +1,36 @@
+export type LcpDebugDetail = Record<string, string | number | boolean | null | undefined>;
+
+export type LcpMarkSnapshot = {
+  detail?: LcpDebugDetail;
+  name: string;
+  startTime: number;
+};
+
+const MAX_MARKS = 120;
+
+type LcpDebugMarkTarget = {
+  enabled?: boolean;
+  marks?: LcpMarkSnapshot[];
+};
+
+export function markLcpDebug(name: string, detail?: LcpDebugDetail): void {
+  if (typeof performance !== 'undefined' && typeof performance.mark === 'function') {
+    try {
+      performance.mark(name);
+    } catch {
+      // A malformed mark name should never break dashboard startup.
+    }
+  }
+
+  if (typeof window === 'undefined') return;
+  const state = (window as unknown as { __wmLcpDebug?: LcpDebugMarkTarget }).__wmLcpDebug;
+  if (!state?.enabled || !Array.isArray(state.marks)) return;
+  state.marks.push({
+    detail,
+    name,
+    startTime: Math.round(typeof performance !== 'undefined' && typeof performance.now === 'function'
+      ? performance.now()
+      : Date.now()),
+  });
+  if (state.marks.length > MAX_MARKS) state.marks.splice(0, state.marks.length - MAX_MARKS);
+}

--- a/tests/bootstrap.test.mjs
+++ b/tests/bootstrap.test.mjs
@@ -285,13 +285,21 @@ describe('App bootstrap slow-tier lifecycle', () => {
     assert.ok(appSrc.includes('cancelBootstrapSlowTier();'), 'App.destroy() should cancel pending slow bootstrap work');
   });
 
-  it('waits for the slow-tier checkpoint before visible data fan-out', () => {
-    const preloadIndex = appSrc.indexOf('await preloadCountryGeometry();');
-    const waitIndex = appSrc.indexOf('await waitForBootstrapSlowTier');
-    const fanoutIndex = appSrc.indexOf('this.dataLoader.loadAllData()', waitIndex);
-    assert.ok(preloadIndex >= 0, 'Missing preloadCountryGeometry checkpoint');
-    assert.ok(waitIndex > preloadIndex, 'slow-tier wait should run after non-render-blocking geometry preload');
-    assert.ok(fanoutIndex > waitIndex, 'visible data fan-out should wait for slow bootstrap settle/timeout');
+  it('keeps slow-tier and country geometry waits off visible data fan-out (#4489)', () => {
+    const phase6Start = appSrc.indexOf('// Phase 6: Data loading');
+    const phase6End = appSrc.indexOf('// If bootstrap was served from cache', phase6Start);
+    const phase6 = appSrc.slice(phase6Start, phase6End);
+    const slowStartIndex = phase6.indexOf('const slowTierReady = this.waitForSlowBootstrapCheckpoint();');
+    const fanoutIndex = phase6.indexOf('this.dataLoader.loadAllData()');
+    const countryGeometryIndex = phase6.indexOf('const countryGeometryReady = this.preloadCountryGeometryForPostLcpWork();');
+
+    assert.ok(phase6Start >= 0 && phase6End > phase6Start, 'Missing Phase 6 data loading block');
+    assert.ok(slowStartIndex >= 0, 'slow-tier checkpoint should still start in the background');
+    assert.ok(fanoutIndex > slowStartIndex, 'visible data fan-out should start after kicking off slow-tier checkpoint');
+    assert.ok(countryGeometryIndex > fanoutIndex, 'country geometry preload should start after initial visible data fan-out');
+    assert.ok(phase6.includes('void slowTierReady;'), 'slow-tier checkpoint should not be awaited before fan-out');
+    assert.ok(appSrc.includes('this.startPostLcpIntelligence(countryGeometryReady);'), 'post-LCP intelligence should wait on background geometry');
+    assert.ok(appSrc.includes('this.dataLoader.refreshGeometryDependentCiiAfterCountryGeometry();'), 'post-geometry replay should restore CII country attribution without blocking fan-out');
   });
 });
 

--- a/tests/lcp-attribution-contract.test.mjs
+++ b/tests/lcp-attribution-contract.test.mjs
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+
+const repoRoot = resolve(new URL('..', import.meta.url).pathname);
+const readSrc = (path) => readFileSync(join(repoRoot, path), 'utf8');
+
+describe('LCP attribution debug contract', () => {
+  it('installs the attribution observer before App construction', () => {
+    const src = readSrc('src/main.ts');
+    const installIndex = src.indexOf('installLcpAttributionDebug();');
+    const appIndex = src.indexOf('new App(');
+
+    assert.ok(installIndex >= 0, 'main.ts must install LCP attribution debug');
+    assert.ok(appIndex >= 0, 'main.ts must construct App');
+    assert.ok(installIndex < appIndex, 'LCP attribution debug must install before App construction');
+  });
+
+  it('marks the boot gates that can delay final LCP', () => {
+    const appSrc = readSrc('src/App.ts');
+    for (const mark of [
+      'wm:boot:app-init-start',
+      'wm:boot:i18n-ready',
+      'wm:boot:session-ready',
+      'wm:boot:fast-bootstrap-ready',
+      'wm:layout:init-start',
+      'wm:layout:init-complete',
+      'wm:data:country-geometry-start',
+      'wm:data:country-geometry-ready',
+      'wm:data:slow-tier-wait-start',
+      'wm:data:slow-tier-wait-end',
+      'wm:data:initial-fanout-start',
+      'wm:data:initial-fanout-complete',
+    ]) {
+      assert.ok(appSrc.includes(`markLcpDebug('${mark}'`), `missing App LCP mark ${mark}`);
+    }
+  });
+
+  it('marks shell replacement and map renderer phases', () => {
+    const layoutSrc = readSrc('src/app/panel-layout.ts');
+    const mapContainerSrc = readSrc('src/components/MapContainer.ts');
+
+    assert.ok(layoutSrc.includes("markLcpDebug('wm:layout:render-start'"));
+    assert.ok(layoutSrc.includes("markLcpDebug('wm:layout:shell-replaced'"));
+    assert.ok(layoutSrc.includes("markLcpDebug('wm:map:container-construct'"));
+    assert.ok(layoutSrc.includes("markLcpDebug('wm:map:container-ready'"));
+
+    for (const mark of [
+      'wm:map:shell-shown',
+      'wm:map:after-first-paint',
+      'wm:map:renderer-demand',
+      'wm:map:svg-init-start',
+      'wm:map:svg-ready',
+      'wm:map:deck-init-start',
+      'wm:map:deck-ready',
+      'wm:map:globe-init-start',
+      'wm:map:globe-ready',
+    ]) {
+      assert.ok(mapContainerSrc.includes(`markLcpDebug('${mark}'`), `missing MapContainer LCP mark ${mark}`);
+    }
+  });
+
+  it('marks actual country geometry fetch and post-geometry replay timing', () => {
+    const countryGeometrySrc = readSrc('src/services/country-geometry.ts');
+    const dataLoaderSrc = readSrc('src/app/data-loader.ts');
+    assert.ok(countryGeometrySrc.includes("markLcpDebug('wm:data:country-geometry-fetch-start'"));
+    assert.ok(countryGeometrySrc.includes("markLcpDebug('wm:data:country-geometry-fetch-ready'"));
+    assert.ok(countryGeometrySrc.includes("markLcpDebug('wm:data:country-geometry-fetch-error'"));
+    assert.ok(dataLoaderSrc.includes("markLcpDebug('wm:data:country-geometry-replay-start'"));
+    assert.ok(dataLoaderSrc.includes("markLcpDebug('wm:data:country-geometry-replay-ready'"));
+  });
+
+  it('marks feed digest request timing for U4 evidence', () => {
+    const dataLoaderSrc = readSrc('src/app/data-loader.ts');
+    assert.ok(dataLoaderSrc.includes("markLcpDebug('wm:data:feed-digest-start'"));
+    assert.ok(dataLoaderSrc.includes("markLcpDebug('wm:data:feed-digest-ready'"));
+    assert.ok(dataLoaderSrc.includes("markLcpDebug('wm:data:feed-digest-error'"));
+  });
+});

--- a/tests/lcp-attribution.test.mts
+++ b/tests/lcp-attribution.test.mts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { __testing__ } from '../src/bootstrap/lcp-attribution';
+
+describe('lcp attribution helpers', () => {
+  it('recognizes explicit debug flags only', () => {
+    assert.equal(__testing__.isTruthyDebugFlag('1'), true);
+    assert.equal(__testing__.isTruthyDebugFlag('true'), true);
+    assert.equal(__testing__.isTruthyDebugFlag('yes'), true);
+    assert.equal(__testing__.isTruthyDebugFlag('0'), false);
+    assert.equal(__testing__.isTruthyDebugFlag(null), false);
+  });
+
+  it('does not throw when browser storage getters are blocked', () => {
+    const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        location: { href: 'https://worldmonitor.app/dashboard' },
+        get sessionStorage() { throw new Error('storage blocked'); },
+        get localStorage() { throw new Error('storage blocked'); },
+      },
+    });
+    try {
+      assert.equal(__testing__.isLcpDebugEnabled(), false);
+    } finally {
+      if (windowDescriptor) Object.defineProperty(globalThis, 'window', windowDescriptor);
+      else delete (globalThis as typeof globalThis & { window?: unknown }).window;
+    }
+  });
+
+  it('captures viewport, DPR, variant, theme, and visibility context', () => {
+    const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'document');
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: {
+        devicePixelRatio: 2.625,
+        innerHeight: 780,
+        innerWidth: 360,
+      },
+    });
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: {
+        documentElement: {
+          clientHeight: 640,
+          clientWidth: 320,
+          dataset: { theme: 'light', variant: 'tech' },
+        },
+        visibilityState: 'hidden',
+      },
+    });
+    try {
+      assert.deepEqual(__testing__.snapshotContext(), {
+        devicePixelRatio: 2.63,
+        theme: 'light',
+        variant: 'tech',
+        viewport: { height: 780, width: 360 },
+        visibilityState: 'hidden',
+      });
+    } finally {
+      if (windowDescriptor) Object.defineProperty(globalThis, 'window', windowDescriptor);
+      else delete (globalThis as typeof globalThis & { window?: unknown }).window;
+      if (documentDescriptor) Object.defineProperty(globalThis, 'document', documentDescriptor);
+      else delete (globalThis as typeof globalThis & { document?: unknown }).document;
+    }
+  });
+
+  it('redacts query strings from resource URLs', () => {
+    assert.equal(
+      __testing__.sanitizeResourceUrl('https://api.worldmonitor.app/api/bootstrap?tier=fast&wms=secret#frag'),
+      'https://api.worldmonitor.app/api/bootstrap?[redacted]',
+    );
+    assert.equal(
+      __testing__.sanitizeResourceUrl('https://worldmonitor.app/data/countries-110m.json'),
+      'https://worldmonitor.app/data/countries-110m.json',
+    );
+  });
+
+  it('classifies resources that may compete before LCP', () => {
+    assert.equal(__testing__.classifyCriticalResource('/api/bootstrap?tier=fast', 'fetch'), 'bootstrap');
+    assert.equal(__testing__.classifyCriticalResource('/api/news/v1/list-feed-digest?lang=en', 'fetch'), 'feed-digest');
+    assert.equal(__testing__.classifyCriticalResource('/data/countries.geojson', 'fetch'), 'country-geometry');
+    assert.equal(__testing__.classifyCriticalResource('/data/countries-50m.json', 'fetch'), 'map-topology');
+    assert.equal(__testing__.classifyCriticalResource('/assets/MapContainer-abc.js', 'script'), 'map-chunk');
+    assert.equal(__testing__.classifyCriticalResource('/assets/sentry-abc.js', 'script'), 'secondary-startup');
+    assert.equal(__testing__.classifyCriticalResource('/assets/index-abc.css', 'css'), 'style');
+  });
+
+  it('caps text snippets for debug evidence', () => {
+    assert.equal(__testing__.capText('  hello   world  ', 20), 'hello world');
+    assert.equal(__testing__.capText('x'.repeat(200), 10), 'xxxxxxxxxx');
+  });
+});

--- a/tests/measure-mobile-mainthread.test.mts
+++ b/tests/measure-mobile-mainthread.test.mts
@@ -6,6 +6,7 @@ import {
   buildReport,
   parseArgs,
   rankLongTasks,
+  summarizeLcpDebug,
   summarizeLongTasks,
   tbtContribution,
 } from '../scripts/measure-mobile-mainthread.mjs';
@@ -57,6 +58,38 @@ describe('measure-mobile-mainthread attribution', () => {
     assert.equal(rankLongTasks([]).length, 0);
     assert.equal(rankLongTasks(undefined).length, 0);
     assert.equal(summarizeLongTasks(undefined).taskCount, 0);
+  });
+
+
+  it('summarizes LCP debug candidate and resource groups', () => {
+    const summary = summarizeLcpDebug({
+      context: { viewport: { width: 360, height: 780 }, devicePixelRatio: 2.63, variant: 'tech', theme: 'dark', visibilityState: 'visible' },
+      entries: [{
+        context: { viewport: { width: 360, height: 780 }, devicePixelRatio: 2.63, variant: 'tech', theme: 'dark', visibilityState: 'visible' },
+        element: { closest: 'map-container', selector: 'section#mapSection', tagName: 'section' },
+        resources: [
+          { category: 'map-topology', count: 1, encodedBodySize: 1000.4, transferSize: 1200.6 },
+          { category: 'feed-digest', count: 1, encodedBodySize: 800, transferSize: 900 },
+        ],
+        size: 12345,
+        startTime: 987.65,
+        url: '',
+      }],
+      resources: [],
+    });
+    assert.equal(summary.entryCount, 1);
+    assert.equal(summary.candidate?.closest, 'map-container');
+    assert.equal(summary.candidate?.startTime, 987.7);
+    assert.equal(summary.resources[0].category, 'map-topology');
+    assert.equal(summary.resources[0].transferSize, 1200.6);
+    assert.equal(summary.context?.variant, 'tech');
+  });
+
+  it('summarizes missing LCP debug data without throwing', () => {
+    const summary = summarizeLcpDebug(null);
+    assert.equal(summary.candidate, null);
+    assert.equal(summary.entryCount, 0);
+    assert.deepEqual(summary.resources, []);
   });
 
   it('attributeDomNodes computes share percentages and sorts by node count desc', () => {
@@ -120,10 +153,12 @@ describe('buildReport', () => {
       url: 'http://x/dashboard',
       cpu: 4,
       longtasks: [{ duration: 200, attribution: [{ containerName: 'Map' }] }],
+      lcpDebug: { entries: [{ element: { closest: 'shell-lcp' }, resources: [], size: 100, startTime: 500 }], resources: [] },
       nodeCounts: { total: 1000, mapSvg: 100, panels: 800 },
     });
     assert.equal(report.url, 'http://x/dashboard');
     assert.equal(report.cpu, 4);
+    assert.equal(report.lcp.candidate?.closest, 'shell-lcp');
     assert.equal(report.tasks.tbtMs, 150);
     assert.equal(report.nodes.rows[0].source, 'panels');
     // round-trips cleanly for `--json | jq`

--- a/tests/panel-mount-deferral.test.mts
+++ b/tests/panel-mount-deferral.test.mts
@@ -3,8 +3,11 @@ import { readFile } from 'node:fs/promises';
 import { afterEach, describe, it } from 'node:test';
 
 import {
+  DEFAULT_PANEL_FOOTPRINTS,
   countInteractiveControls,
   createDeferredPanelShell,
+  derivePanelReservation,
+  getDefaultPanelFootprint,
   getInitialPanelMountBudget,
   shouldDeferInitialPanelMount,
 } from '../src/app/panel-mount-deferral';
@@ -94,6 +97,113 @@ describe('panel mount deferral', () => {
     assert.equal(countInteractiveControls(shell), 0);
   });
 
+  it('keeps the static reservation map in sync with constructor-sized panels', () => {
+    assert.deepEqual(Object.keys(DEFAULT_PANEL_FOOTPRINTS).sort(), [
+      'chat-analyst',
+      'cii',
+      'consumer-prices',
+      'displacement',
+      'economic',
+      'energy-complex',
+      'energy-crisis',
+      'energy-disruptions',
+      'fuel-shortages',
+      'gdelt-intel',
+      'internet-disruptions',
+      'live-news',
+      'live-webcams',
+      'oil-inventories',
+      'pipeline-status',
+      'sanctions-pressure',
+      'security-advisories',
+      'storage-facility-map',
+      'strategic-posture',
+      'supply-chain',
+      'telegram-intel',
+      'threat-timeline',
+      'trade-policy',
+      'ucdp-events',
+      'windy-webcams',
+    ].sort());
+  });
+
+  it('derives natural, saved, and dynamic panel reservations without importing panel bundles', () => {
+    assert.deepEqual(derivePanelReservation('cii', {
+      savedRowSpans: {},
+      savedColSpans: {},
+      savedCollapsed: {},
+    }), {
+      rowSpan: 2,
+      colSpan: 1,
+      wide: false,
+      rowSpanSource: 'default',
+      colSpanSource: 'none',
+      collapsed: false,
+    });
+
+    assert.deepEqual(derivePanelReservation('strategic-risk', {
+      savedRowSpans: {},
+      savedColSpans: {},
+      savedCollapsed: {},
+    }), {
+      rowSpan: 1,
+      colSpan: 1,
+      wide: false,
+      rowSpanSource: 'none',
+      colSpanSource: 'none',
+      collapsed: false,
+    });
+
+    assert.deepEqual(getDefaultPanelFootprint('cw-alpha'), { rowSpan: 2 });
+    assert.deepEqual(getDefaultPanelFootprint('mcp-alpha'), { rowSpan: 2 });
+  });
+
+  it('applies saved span, width, and collapsed reservations to deferred shells', () => {
+    const document = installDom();
+    const shell = createDeferredPanelShell('strategic-risk', 'Strategic Risk Overview', {
+      savedRowSpans: { 'strategic-risk': 3 },
+      savedColSpans: { 'strategic-risk': 2 },
+      savedCollapsed: { 'strategic-risk': true },
+    });
+    document.body.appendChild(shell);
+
+    assert.equal(shell.classList.contains('span-3'), true);
+    assert.equal(shell.classList.contains('resized'), true);
+    assert.equal(shell.classList.contains('col-span-2'), true);
+    assert.equal(shell.classList.contains('panel-collapsed'), true);
+    assert.equal((shell.querySelector('.panel-content') as HTMLElement | null)?.style.display, 'none');
+  });
+
+  it('reserves wide and dynamic deferred shells using their real-panel footprints', () => {
+    const document = installDom();
+    const wideShell = createDeferredPanelShell('live-news', 'Live News', {
+      savedRowSpans: {},
+      savedColSpans: {},
+      savedCollapsed: {},
+    });
+    const widgetShell = createDeferredPanelShell('cw-alpha', 'Custom Widget', {
+      savedRowSpans: {},
+      savedColSpans: {},
+      savedCollapsed: {},
+    });
+    document.body.appendChild(wideShell);
+    document.body.appendChild(widgetShell);
+
+    assert.equal(wideShell.classList.contains('panel-wide'), true);
+    assert.equal(wideShell.classList.contains('span-2'), false);
+    assert.equal(widgetShell.classList.contains('span-2'), true);
+  });
+
+  it('keeps dynamic panel real constructors aligned with shell reservations', async () => {
+    const [customWidgetSource, mcpDataSource] = await Promise.all([
+      readFile(new URL('../src/components/CustomWidgetPanel.ts', import.meta.url), 'utf8'),
+      readFile(new URL('../src/components/McpDataPanel.ts', import.meta.url), 'utf8'),
+    ]);
+
+    assert.match(customWidgetSource, /defaultRowSpan:\s*2,/, 'CustomWidgetPanel must match the cw-* shell reservation');
+    assert.match(mcpDataSource, /defaultRowSpan:\s*2,/, 'McpDataPanel must match the mcp-* shell reservation');
+  });
+
   it('materially reduces initial DOM and control count for below-budget panels', () => {
     const fullDocument = installDom();
     for (let index = 0; index < 12; index++) {
@@ -133,6 +243,35 @@ describe('panel mount deferral', () => {
       source,
       /if\s*\(!mountedFromDeferred\)\s*\{\s*panel\?\.toggle\(config\.enabled\);\s*\}/,
       'applyPanelSettings must skip its own toggle when mountDeferredPanel already toggled',
+    );
+  });
+
+  it('keeps deferred lazy shells retryable after a failed lazy import', async () => {
+    const source = await readFile(new URL('../src/app/panel-layout.ts', import.meta.url), 'utf8');
+    const mountDeferredPanel = source.match(/private\s+mountDeferredPanel[\s\S]*?\n  private mountLazyPanel/);
+    const destroyMethod = source.match(/destroy\(\):\s*void[\s\S]*?this\.deferredPanelMounts\.clear\(\);/);
+
+    assert.ok(mountDeferredPanel, 'mountDeferredPanel method not found');
+    assert.match(
+      mountDeferredPanel[0],
+      /deferred\.loading = null;[\s\S]*?if\s*\(!panel \|\| this\.ctx\.isDestroyed\)/,
+      'failed deferred lazy loads must clear the in-flight deferred.loading guard',
+    );
+    assert.match(
+      mountDeferredPanel[0],
+      /this\.lazyPanelRegistrations\.has\(key\)[\s\S]*?deferred\.placeholder\?\.parentNode[\s\S]*?this\.observeDeferredPanelShell\(key, deferred\)/,
+      'failed deferred lazy loads must keep the inert shell and re-arm observation for retry',
+    );
+    assert.match(
+      mountDeferredPanel[0],
+      /this\.deferredPanelMounts\.delete\(key\);/,
+      'deferred entries should only be deleted after the real panel successfully replaces the shell',
+    );
+    assert.ok(destroyMethod, 'destroy method cleanup not found');
+    assert.match(
+      destroyMethod[0],
+      /clearTimeout\(deferred\.retryTimer\);/,
+      'destroy must clear deferred retry timers as well as observers',
     );
   });
 


### PR DESCRIPTION
## Summary
Dashboard startup now exposes the final LCP candidate and the work that happened before it for koala73/worldmonitor#4489, while moving two non-visible waits off the first visible data fan-out path. Reviewers can turn on `?wm_lcp_debug=1` to see the candidate element, dashboard attribution label, sanitized resource groups, viewport/device context, and boot/layout/map/data marks. The branch also keeps deferred panel shells at their eventual footprints so lazy panels do not add layout movement while the dashboard is being measured.

## What Changed
- Opt-in `window.__wmLcpDebug` installs before `new App('app')` and records buffered LCP entries, closest dashboard labels, redacted URLs, resource groups, and capped `performance.mark()` checkpoints.
- Slow-tier bootstrap wait now runs in the background; precision country geometry starts after initial visible data fan-out, then cached CII inputs replay once geometry is ready so country attribution is preserved.
- Map, layout, feed-digest, country-geometry, and renderer phases now mark the same timeline that `scripts/measure-mobile-mainthread.mjs` reports as JSON.
- Deferred panel shells reserve configured, saved, collapsed, custom widget, and MCP footprints before lazy bundles mount, with retryable lazy-import failure behavior.

## Validation
| Check | Result |
|---|---|
| `npm run typecheck` | Passed |
| `npm run typecheck:api` | Passed |
| `npx tsc --noEmit -p convex/tsconfig.json` | Passed |
| `npx --yes tsx --test tests/panel-mount-deferral.test.mts tests/lcp-attribution.test.mts tests/lcp-attribution-contract.test.mjs tests/bootstrap.test.mjs tests/measure-mobile-mainthread.test.mts` | 76 tests passed |
| `npx playwright test e2e/prehydration-shell.spec.ts e2e/dashboard-lcp-attribution.spec.ts` | 5 tests passed |
| `VITE_VARIANT=full ./node_modules/.bin/vite build` | Passed |
| `npm run test:data` | 11,814 passed, 0 failed, 6 skipped |
| `npm run lint:md` | Passed |
| `node scripts/docs-stats.mjs --check` | Passed |
| GitHub PR checks | Typecheck, Test, Lint Code, Lint, Security Audit, Vercel, and aggregate gate are green on `bd811d4c87b39f376d3126dfc508c5b4482fc409` |

## Follow-Up Evidence
PageSpeed median-of-3 and CrUX follow-up should happen after deploy because field data rolls over time. The debug hooks and measurement script are now in place for that capture.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
