### PR TITLE
fix(seeders): package resilience static WGI keys

### DIFF
--- a/scripts/seed-resilience-static.mjs
+++ b/scripts/seed-resilience-static.mjs
@@ -19,7 +19,7 @@ import {
   resolveIso2,
 } from './_country-resolver.mjs';
 import { isInRankableUniverse } from './shared/rankable-universe.mjs';
-import wgiIndicatorKeys from '../shared/wgi-indicator-keys.json' with { type: 'json' };
+import wgiIndicatorKeys from './shared/wgi-indicator-keys.json' with { type: 'json' };
 
 export { createCountryResolvers, resolveIso2 } from './_country-resolver.mjs';
 

--- a/scripts/shared/wgi-indicator-keys.json
+++ b/scripts/shared/wgi-indicator-keys.json
@@ -1,0 +1,8 @@
+[
+  "VA.EST",
+  "PV.EST",
+  "GE.EST",
+  "RQ.EST",
+  "RL.EST",
+  "CC.EST"
+]

--- a/tests/edge-functions.test.mjs
+++ b/tests/edge-functions.test.mjs
@@ -58,13 +58,8 @@ describe('scripts/shared/ stays in sync with shared/', () => {
     // by the audit script under scripts/. Must stay byte-identical.
     'url-classifier.js',
   ]);
-  const rootSharedOnlyFiles = new Set([
-    // Resilience .mjs scripts import this directly from ../shared/. Keeping a
-    // scripts/shared copy would reintroduce the WGI scorer/seeder drift risk.
-    'wgi-indicator-keys.json',
-  ]);
   const sharedFiles = readdirSync(sharedDir).filter(
-    (f) => !rootSharedOnlyFiles.has(f) && (f.endsWith('.json') || f.endsWith('.cjs') || explicitMirroredFiles.has(f)),
+    (f) => f.endsWith('.json') || f.endsWith('.cjs') || explicitMirroredFiles.has(f),
   );
   for (const file of sharedFiles) {
     it(`scripts/shared/${file} matches shared/${file}`, () => {

--- a/tests/scripts-railway-nixpacks-no-escape-import.test.mts
+++ b/tests/scripts-railway-nixpacks-no-escape-import.test.mts
@@ -15,8 +15,9 @@
  * Dockerfile.digest-notifications header for the cherry-pick alternative
  * we explicitly do NOT use for these three.)
  *
- * Approach: BFS from each entry script, follow relative imports, assert no
- * resolved path escapes `scripts/`. Skips bare-package and `node:*` imports.
+ * Approach: BFS from each entry script, follow relative imports and
+ * _bundle-runner section script references, assert no resolved path escapes
+ * `scripts/`. Skips bare-package and `node:*` imports.
  *
  * Companion to the header comment in
  * `scripts/_simulation-queue-constants.mjs`.
@@ -38,41 +39,45 @@ const scriptsDir = resolve(repoRoot, 'scripts');
 // companion test tests/railway-services-registry-coverage.test.mts fails
 // if any Dockerfile.* or runbook entry references a script that isn't
 // in the registry — that's how drift is caught.
-interface RailwayServiceEntry {
-  entry: string;
-  deployMode: 'nixpacks-root-scripts' | 'dockerfile';
-  dockerfile?: string;
-  service: string;
-  documentedAt: string;
-}
-
 const registry = JSON.parse(
   readFileSync(resolve(repoRoot, 'scripts/railway-services.json'), 'utf8'),
-) as RailwayServiceEntry[];
+);
 
 const ENTRY_POINTS = registry
   .filter((r) => r.deployMode === 'nixpacks-root-scripts')
   .map((r) => r.entry);
 
 const IMPORT_RE = /(?:^|[\s;])(?:import\b[\s\S]*?\bfrom|import|export\b[\s\S]*?\bfrom)\s+['"]([^'"]+)['"]/gm;
+const BUNDLE_SECTION_SCRIPT_RE = /\bscript\s*:\s*['"]([^'"]+\.(?:mjs|cjs|js))['"]/gm;
 
-function isRelative(spec: string): boolean {
+function isRelative(spec) {
   return spec.startsWith('./') || spec.startsWith('../');
 }
 
-function collectRelativeImports(filePath: string): string[] {
+function collectRelativeImports(filePath) {
   const src = readFileSync(filePath, 'utf8');
-  const out: string[] = [];
-  let m: RegExpExecArray | null;
+  const out = [];
+  let m;
   IMPORT_RE.lastIndex = 0;
   while ((m = IMPORT_RE.exec(src)) !== null) {
-    const spec = m[1]!;
+    const spec = m[1];
     if (isRelative(spec)) out.push(spec);
   }
   return out;
 }
 
-function escapesScriptsDir(absResolved: string): boolean {
+function collectBundleSectionScripts(filePath) {
+  const src = readFileSync(filePath, 'utf8');
+  const out = [];
+  let m;
+  BUNDLE_SECTION_SCRIPT_RE.lastIndex = 0;
+  while ((m = BUNDLE_SECTION_SCRIPT_RE.exec(src)) !== null) {
+    out.push(m[1]);
+  }
+  return out;
+}
+
+function escapesScriptsDir(absResolved) {
   const rel = relative(scriptsDir, absResolved);
   return rel.startsWith('..') || resolve(rel) === absResolved;
 }
@@ -80,20 +85,20 @@ function escapesScriptsDir(absResolved: string): boolean {
 describe('scripts/ Railway nixpacks packaging — no escape imports', () => {
   for (const entry of ENTRY_POINTS) {
     it(`entry ${entry} and its transitive scripts/ deps never import outside scripts/`, () => {
-      const visited = new Set<string>();
-      const queue: string[] = [resolve(repoRoot, entry)];
-      const violations: Array<{ from: string; spec: string; resolved: string }> = [];
+      const visited = new Set();
+      const queue = [resolve(repoRoot, entry)];
+      const violations = [];
 
       while (queue.length > 0) {
-        const file = queue.shift()!;
+        const file = queue.shift();
         if (visited.has(file)) continue;
         visited.add(file);
 
-        let imports: string[];
+        let imports;
         try {
           imports = collectRelativeImports(file);
         } catch (err) {
-          assert.fail(`Could not read ${file}: ${(err as Error).message}`);
+          assert.fail(`Could not read ${file}: ${err instanceof Error ? err.message : String(err)}`);
         }
 
         for (const spec of imports) {
@@ -112,6 +117,19 @@ describe('scripts/ Railway nixpacks packaging — no escape imports', () => {
           if (/\.(mjs|cjs|js)$/.test(resolved)) {
             queue.push(resolved);
           }
+        }
+
+        for (const spec of collectBundleSectionScripts(file)) {
+          const resolved = resolve(dirname(file), spec);
+          if (escapesScriptsDir(resolved)) {
+            violations.push({
+              from: relative(repoRoot, file),
+              spec,
+              resolved: relative(repoRoot, resolved),
+            });
+            continue;
+          }
+          queue.push(resolved);
         }
       }
 

--- a/tests/scripts-railway-nixpacks-no-escape-import.test.mts
+++ b/tests/scripts-railway-nixpacks-no-escape-import.test.mts
@@ -39,45 +39,63 @@ const scriptsDir = resolve(repoRoot, 'scripts');
 // companion test tests/railway-services-registry-coverage.test.mts fails
 // if any Dockerfile.* or runbook entry references a script that isn't
 // in the registry — that's how drift is caught.
+interface RailwayServiceEntry {
+  entry: string;
+  deployMode: 'nixpacks-root-scripts' | 'dockerfile';
+  dockerfile?: string;
+  service: string;
+  documentedAt: string;
+}
+
 const registry = JSON.parse(
   readFileSync(resolve(repoRoot, 'scripts/railway-services.json'), 'utf8'),
-);
+) as RailwayServiceEntry[];
 
 const ENTRY_POINTS = registry
   .filter((r) => r.deployMode === 'nixpacks-root-scripts')
   .map((r) => r.entry);
+const BUNDLE_ENTRY_FILES = new Set(ENTRY_POINTS.map((entry) => resolve(repoRoot, entry)));
 
 const IMPORT_RE = /(?:^|[\s;])(?:import\b[\s\S]*?\bfrom|import|export\b[\s\S]*?\bfrom)\s+['"]([^'"]+)['"]/gm;
 const BUNDLE_SECTION_SCRIPT_RE = /\bscript\s*:\s*['"]([^'"]+\.(?:mjs|cjs|js))['"]/gm;
 
-function isRelative(spec) {
+function isRelative(spec: string): boolean {
   return spec.startsWith('./') || spec.startsWith('../');
 }
 
-function collectRelativeImports(filePath) {
+function collectRelativeImports(filePath: string): string[] {
   const src = readFileSync(filePath, 'utf8');
-  const out = [];
-  let m;
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
   IMPORT_RE.lastIndex = 0;
   while ((m = IMPORT_RE.exec(src)) !== null) {
-    const spec = m[1];
+    const spec = m[1]!;
     if (isRelative(spec)) out.push(spec);
   }
   return out;
 }
 
-function collectBundleSectionScripts(filePath) {
-  const src = readFileSync(filePath, 'utf8');
-  const out = [];
-  let m;
+function stripLineComments(src: string): string {
+  return src
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('//'))
+    .join('\n');
+}
+
+function collectBundleSectionScripts(filePath: string): string[] {
+  if (!BUNDLE_ENTRY_FILES.has(filePath)) return [];
+
+  const src = stripLineComments(readFileSync(filePath, 'utf8'));
+  const out: string[] = [];
+  let m: RegExpExecArray | null;
   BUNDLE_SECTION_SCRIPT_RE.lastIndex = 0;
   while ((m = BUNDLE_SECTION_SCRIPT_RE.exec(src)) !== null) {
-    out.push(m[1]);
+    out.push(m[1]!);
   }
   return out;
 }
 
-function escapesScriptsDir(absResolved) {
+function escapesScriptsDir(absResolved: string): boolean {
   const rel = relative(scriptsDir, absResolved);
   return rel.startsWith('..') || resolve(rel) === absResolved;
 }
@@ -85,20 +103,20 @@ function escapesScriptsDir(absResolved) {
 describe('scripts/ Railway nixpacks packaging — no escape imports', () => {
   for (const entry of ENTRY_POINTS) {
     it(`entry ${entry} and its transitive scripts/ deps never import outside scripts/`, () => {
-      const visited = new Set();
-      const queue = [resolve(repoRoot, entry)];
-      const violations = [];
+      const visited = new Set<string>();
+      const queue: string[] = [resolve(repoRoot, entry)];
+      const violations: Array<{ from: string; spec: string; resolved: string }> = [];
 
       while (queue.length > 0) {
-        const file = queue.shift();
+        const file = queue.shift()!;
         if (visited.has(file)) continue;
         visited.add(file);
 
-        let imports;
+        let imports: string[];
         try {
           imports = collectRelativeImports(file);
         } catch (err) {
-          assert.fail(`Could not read ${file}: ${err instanceof Error ? err.message : String(err)}`);
+          assert.fail(`Could not read ${file}: ${(err as Error).message}`);
         }
 
         for (const spec of imports) {
@@ -120,7 +138,7 @@ describe('scripts/ Railway nixpacks packaging — no escape imports', () => {
         }
 
         for (const spec of collectBundleSectionScripts(file)) {
-          const resolved = resolve(dirname(file), spec);
+          const resolved = resolve(scriptsDir, spec);
           if (escapesScriptsDir(resolved)) {
             violations.push({
               from: relative(repoRoot, file),


### PR DESCRIPTION
## Summary

Railway’s resilience bundle can now start its static seeder in scripts-only containers; the WGI key list resolves inside `/app` instead of escaping to missing `/shared`.

The fix mirrors the canonical WGI indicator list into `scripts/shared` with parity coverage so scorer/seeder key drift is caught. The Railway no-escape regression now follows `_bundle-runner` child script entries, so spawned seeders like `seed-resilience-static.mjs` are checked instead of only top-level bundle files.

## Validation

- Reproduced the scripts-only import failure before the fix (`ERR_MODULE_NOT_FOUND file:///tmp/shared/wgi-indicator-keys.json`) and verified the same fixture imports successfully after the fix.
- `node --test tests/scripts-railway-nixpacks-no-escape-import.test.mts`
- `node --test tests/edge-functions.test.mjs`
- `node --test tests/resilience-static-seed.test.mjs`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
