### PR TITLE
fix(sentry): suppress extension Object.apply fetch-hook noise (WORLDMONITOR-TZ)

### DIFF
--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -457,11 +457,16 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // a monkeypatched-`window.fetch` frame on the stack — a genuine API outage
       // (host-suffixed `Failed to fetch (<host>)`, handled above) and any
       // non-extension user are unaffected. The function match is anchored to
-      // exactly `window.fetch` / `fetch` (not a loose `/fetch/`) so an extension
+      // exactly `window.fetch` / `fetch` or the `Function.prototype.apply`
+      // trampoline (`Object.apply` / `apply`) an extension's hook.js uses to
+      // re-invoke the original fetch — NOT a loose `/fetch/` — so an extension
       // frame named `fetchContent` / `prefetch` does NOT swallow a real bare
-      // `Failed to fetch` from our own code (WORLDMONITOR-SG).
+      // `Failed to fetch` from our own code (WORLDMONITOR-SG). The `apply`
+      // trampoline variant is WORLDMONITOR-TZ: a wallet extension's
+      // `injected/hook.js` wraps `window.fetch` and the leaked rejection frame
+      // surfaces as `Object.apply`, not `window.fetch`.
       if (/^(?:TypeError: )?Failed to fetch$/.test(msg)
-          && frames.some(f => /^(?:chrome|moz|safari(?:-web)?)-extension:\/\//.test(f.filename ?? '') && /^(?:window\.)?fetch$/i.test(f.function ?? ''))) {
+          && frames.some(f => /^(?:chrome|moz|safari(?:-web)?)-extension:\/\//.test(f.filename ?? '') && /^(?:(?:window|Object)\.)?(?:fetch|apply)$/i.test(f.function ?? ''))) {
         return null;
       }
       // Suppress Sentry SDK DOM breadcrumb null-access on document.activeElement/contains.


### PR DESCRIPTION
## Summary
- Browser Sentry was reporting a bare `TypeError: Failed to fetch` (WORLDMONITOR-TZ) that originates from a wallet extension's `injected/hook.js` monkeypatching `window.fetch` and re-invoking the original via `Function.prototype.apply`. A transient network blip rejects the underlying fetch and the extension's orphan promise leaks to `onunhandledrejection`.
- The existing extension-monkeypatch gate (WORLDMONITOR-SG) only matched an extension frame whose function is `window.fetch`/`fetch`. This variant reports the leaked frame's function as `Object.apply`, so it slipped through and surfaced as noise (first-party frames present → the generic `!hasFirstParty` gate can't catch it either).
- Broaden the function anchor on the extension frame to also accept the `Object.apply` / `apply` trampoline, kept tight (`^(?:(?:window|Object)\.)?(?:fetch|apply)$`) so `fetchContent` / `prefetch` / `applyMiddleware` still surface a real first-party `Failed to fetch`.
- The `chrome|moz|safari-extension://` filename match remains the load-bearing safety: the gate only fires when an actual extension frame is on the stack of a bare `Failed to fetch`.

Surfaced during a Sentry triage pass. T8 (country-brief 401, fixed by #4508), PD/TX (Convex opaque 5xx, addressed by #4507) were resolved in Sentry; SR (Convex `InternalServerError`) left open as intentional volume telemetry.

## Test plan
- [x] `npm run typecheck` / `typecheck:api`
- [x] `npm run lint` (biome) + `lint:md`
- [x] `npm run version:check`
- [x] `VITE_VARIANT=full vite build` + `npm run test:data` (11764/11764 after build artifact present)
- [x] Edge function bundle check + `tests/edge-functions.test.mjs` (204/204)
- [x] Regex match/no-match verified: matches `window.fetch`, `fetch`, `Object.apply`, `apply`; rejects `fetchContent`, `prefetch`, `applyMiddleware`, `doApply`

https://claude.ai/code/session_01DDdLVt4TfiQUkcPpjzT3CM