### PR TITLE
fix: retry panel col-span clamp after grid layout

### DIFF
--- a/src/app/panel-mount-deferral.ts
+++ b/src/app/panel-mount-deferral.ts
@@ -3,6 +3,7 @@ import {
   MAX_PANEL_ROW_SPAN,
   getExplicitColSpanClass,
   getMaxColSpan,
+  isPanelGridColumnCountReady,
   setColSpanClass,
 } from '@/utils/panel-grid';
 
@@ -142,15 +143,13 @@ export function createDeferredPanelShell(
  * direction until the real panel mounts).
  */
 export function reconcileDeferredPanelShellColSpan(shell: HTMLElement, attempts = 3): void {
-  const currentSpan = getExplicitColSpanClass(shell);
-  if (currentSpan === undefined) return;
-
   const tryReconcile = (remaining: number): void => {
-    if (!shell.isConnected || !shell.parentElement) {
-      if (remaining <= 0) return;
-      if (typeof requestAnimationFrame === 'function') {
-        requestAnimationFrame(() => tryReconcile(remaining - 1));
-      }
+    const currentSpan = getExplicitColSpanClass(shell);
+    if (currentSpan === undefined) return;
+
+    if (!shell.isConnected || !shell.parentElement || !isPanelGridColumnCountReady(shell)) {
+      if (remaining <= 0 || typeof requestAnimationFrame !== 'function') return;
+      requestAnimationFrame(() => tryReconcile(remaining - 1));
       return;
     }
     const maxSpan = getMaxColSpan(shell);

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -24,6 +24,7 @@ import {
   clearColSpanClass,
   getExplicitColSpanClass,
   getMaxColSpan,
+  isPanelGridColumnCountReady,
   setColSpanClass,
 } from '@/utils/panel-grid';
 
@@ -326,8 +327,11 @@ export class Panel {
     }
 
     const tryReconcile = (remaining: number) => {
-      if (!this.element.isConnected || !this.element.parentElement) {
-        if (remaining <= 0) return;
+      if (!this.element.isConnected || !this.element.parentElement || !isPanelGridColumnCountReady(this.element)) {
+        if (remaining <= 0) {
+          this.colSpanReconcileRaf = null;
+          return;
+        }
         this.colSpanReconcileRaf = requestAnimationFrame(() => tryReconcile(remaining - 1));
         return;
       }

--- a/src/utils/panel-grid.ts
+++ b/src/utils/panel-grid.ts
@@ -17,14 +17,43 @@ export const MAX_PANEL_ROW_SPAN = 4;
 /** Maximum column span supported by the CSS (`.panel.col-span-1` … `.col-span-3`). */
 export const MAX_PANEL_COL_SPAN = 3;
 
+function getPanelGrid(element: HTMLElement): HTMLElement | null {
+  return (element.closest('.panels-grid') || element.closest('.map-bottom-grid')) as HTMLElement | null;
+}
+
+function getPanelGridWidth(grid: HTMLElement): number {
+  const width = grid.getBoundingClientRect().width;
+  return Number.isFinite(width) ? width : 0;
+}
+
+/**
+ * Whether the owning grid's column count can be trusted right now. CSS
+ * `repeat(auto-fill/auto-fit, ...)` templates need a rendered width before
+ * they can be converted into a column count; a connected grid can briefly
+ * report width 0 during synchronous insertion/layout.
+ */
+export function isPanelGridColumnCountReady(element: HTMLElement): boolean {
+  const grid = getPanelGrid(element);
+  if (!grid || typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') return true;
+
+  const style = window.getComputedStyle(grid);
+  const template = style.gridTemplateColumns;
+  if (!template || template === 'none' || !template.includes('repeat(')) return true;
+  if (/repeat\(\s*\d+\s*,/i.test(template)) return true;
+  if (/repeat\(\s*auto-(fill|fit)\s*,/i.test(template)) {
+    return getPanelGridWidth(grid) > 0;
+  }
+  return true;
+}
+
 /**
  * Best-effort count of the rendered columns of the grid that owns `element`.
  * Falls back to {@link MAX_PANEL_COL_SPAN} when the grid or its computed style
  * is unavailable (e.g. server-side render).
  */
 export function getGridColumnCount(element: HTMLElement): number {
-  const grid = (element.closest('.panels-grid') || element.closest('.map-bottom-grid')) as HTMLElement | null;
-  if (!grid || typeof window === 'undefined') return MAX_PANEL_COL_SPAN;
+  const grid = getPanelGrid(element);
+  if (!grid || typeof window === 'undefined' || typeof window.getComputedStyle !== 'function') return MAX_PANEL_COL_SPAN;
   const style = window.getComputedStyle(grid);
   const template = style.gridTemplateColumns;
   if (!template || template === 'none') return MAX_PANEL_COL_SPAN;
@@ -40,10 +69,11 @@ export function getGridColumnCount(element: HTMLElement): number {
     const autoRepeatMatch = template.match(/repeat\(\s*auto-(fill|fit)\s*,/i);
     if (autoRepeatMatch) {
       const gap = Number.parseFloat(style.columnGap || '0') || 0;
-      const width = grid.getBoundingClientRect().width;
+      const width = getPanelGridWidth(grid);
       if (width > 0) {
         return Math.max(1, Math.floor((width + gap) / (PANELS_GRID_MIN_TRACK_PX + gap)));
       }
+      return MAX_PANEL_COL_SPAN;
     }
   }
 

--- a/tests/panel-config-guardrails.test.mjs
+++ b/tests/panel-config-guardrails.test.mjs
@@ -11,6 +11,7 @@ const commandsSrc = readFileSync(resolve(__dirname, '../src/config/commands.ts')
 
 const VARIANT_FILES = ['full', 'tech', 'finance', 'commodity', 'energy', 'happy'];
 const PANEL_WIDE_CLASS_RE = /className:\s*['"][^'"]*\bpanel-wide\b/;
+const COMPONENT_SOURCE_RE = /\.tsx?$/;
 
 // Depth-aware extraction of the TOP-LEVEL keys of a `const X_PANELS = { ... }`
 // object literal — i.e. the panel ids, not nested config keys like
@@ -191,6 +192,19 @@ function findMatchingBrace(src, openIndex) {
   return -1;
 }
 
+function staticStringLiteralValue(rawValue) {
+  const value = rawValue.trim();
+  if (value.length < 2) return null;
+  const quote = value[0];
+  if ((quote === '\'' || quote === '"') && value.endsWith(quote)) {
+    return value.slice(1, -1);
+  }
+  if (quote === '`' && value.endsWith('`') && !value.includes('${')) {
+    return value.slice(1, -1);
+  }
+  return null;
+}
+
 function superObjectBodies(src) {
   const bodies = [];
   let searchIndex = 0;
@@ -218,12 +232,22 @@ function naturalDeferredPanelFootprints() {
   const componentsDir = resolve(__dirname, '../src/components');
   const footprints = new Map();
   for (const file of readdirSync(componentsDir)) {
-    if (!file.endsWith('.ts')) continue;
+    if (!COMPONENT_SOURCE_RE.test(file) || file.endsWith('.d.ts')) continue;
     const src = readFileSync(resolve(componentsDir, file), 'utf-8');
     for (const body of superObjectBodies(src)) {
       const id = body.match(/id:\s*['"]([^'"]+)['"]/);
       if (!id) continue;
-      const panelWide = PANEL_WIDE_CLASS_RE.test(body);
+      const classNameRaw = body.match(/className:\s*([^,\n}]+)/);
+      let panelWide = false;
+      let unverifiableClassName = null;
+      if (classNameRaw) {
+        const classNameValue = staticStringLiteralValue(classNameRaw[1]);
+        if (classNameValue === null) {
+          unverifiableClassName = classNameRaw[1].trim();
+        } else {
+          panelWide = /\bpanel-wide\b/.test(classNameValue);
+        }
+      }
 
       // Capture the raw defaultRowSpan value so a non-literal (variable or
       // expression) is reported as unverifiable rather than silently dropped —
@@ -237,8 +261,8 @@ function naturalDeferredPanelFootprints() {
         else if (value !== '1') unverifiableRowSpan = value;
       }
 
-      if (!rowSpan && !panelWide && !unverifiableRowSpan) continue;
-      footprints.set(id[1], { file, rowSpan, panelWide, unverifiableRowSpan });
+      if (!rowSpan && !panelWide && !unverifiableRowSpan && !unverifiableClassName) continue;
+      footprints.set(id[1], { file, rowSpan, panelWide, unverifiableRowSpan, unverifiableClassName });
     }
   }
   return footprints;
@@ -353,6 +377,14 @@ describe('panel-config guardrails', () => {
           panelId + ' (' + footprint.file + ') has a non-literal defaultRowSpan "' +
             footprint.unverifiableRowSpan + '" this guard cannot verify; inline a literal 2-4 ' +
             'or extend naturalDeferredPanelFootprints to resolve it',
+        );
+        continue;
+      }
+      if (footprint.unverifiableClassName) {
+        mismatches.push(
+          panelId + ' (' + footprint.file + ') has a non-literal className "' +
+            footprint.unverifiableClassName + '" this guard cannot verify for panel-wide; ' +
+            'inline a static className or extend naturalDeferredPanelFootprints to resolve it',
         );
         continue;
       }
@@ -653,6 +685,17 @@ describe('panel-config guardrails', () => {
     assert.ok(rowSpanRaw, 'expected a defaultRowSpan match');
     const value = rowSpanRaw[1].trim();
     assert.ok(!/^[2-4]$/.test(value) && value !== '1', 'value should be treated as unverifiable');
+  });
+
+  it('includes TSX sources and flags non-literal className as unverifiable', () => {
+    assert.equal(COMPONENT_SOURCE_RE.test('FuturePanel.tsx'), true);
+
+    const src = "super({ id: 'mystery-wide', className: panelClassName });";
+    const bodies = superObjectBodies(src);
+    const body = bodies[0] ?? '';
+    const classNameRaw = body.match(/className:\s*([^,\n}]+)/);
+    assert.ok(classNameRaw, 'expected a className match');
+    assert.equal(staticStringLiteralValue(classNameRaw[1]), null);
   });
 });
 

--- a/tests/panel-mount-deferral.test.mts
+++ b/tests/panel-mount-deferral.test.mts
@@ -182,6 +182,48 @@ describe('panel mount deferral', () => {
     assert.equal(shell.classList.contains('col-span-2'), true);
   });
 
+  it('waits for a measurable connected grid before clamping saved shell column spans', () => {
+    const document = installDom();
+    const grid = document.createElement('div');
+    grid.className = 'panels-grid';
+    let gridWidth = 0;
+    Object.defineProperty(grid, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ width: gridWidth, height: 0, top: 0, left: 0, right: gridWidth, bottom: 0, x: 0, y: 0, toJSON: () => ({}) }),
+    });
+    (globalThis.window as unknown as { getComputedStyle: () => { gridTemplateColumns: string; columnGap: string } }).getComputedStyle = () => ({
+      gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+      columnGap: '0',
+    });
+
+    const frames: Array<() => void> = [];
+    (globalThis as unknown as { requestAnimationFrame: (cb: () => void) => number }).requestAnimationFrame = (cb) => {
+      frames.push(cb);
+      return frames.length;
+    };
+
+    try {
+      const shell = createDeferredPanelShell(
+        'live-webcams',
+        'Live Webcams',
+        getDeferredPanelShellFootprint({ panelId: 'live-webcams', savedColSpans: { 'live-webcams': 3 } }),
+      );
+      grid.appendChild(shell);
+      document.body.appendChild(grid);
+
+      reconcileDeferredPanelShellColSpan(shell);
+      assert.equal(shell.classList.contains('col-span-3'), true);
+      assert.equal(frames.length, 1);
+
+      gridWidth = 560;
+      frames.shift()?.();
+      assert.equal(shell.classList.contains('col-span-3'), false);
+      assert.equal(shell.classList.contains('col-span-2'), true);
+    } finally {
+      delete (globalThis as { requestAnimationFrame?: unknown }).requestAnimationFrame;
+    }
+  });
+
   it('defers col-span reconciliation until the shell is connected, then clamps', () => {
     const document = installDom();
     const grid = document.createElement('div');

--- a/tests/panel-storage-cache.test.mts
+++ b/tests/panel-storage-cache.test.mts
@@ -90,6 +90,50 @@ describe('Panel storage cache', () => {
     });
   });
 
+  it('retries saved column-span reconciliation until the connected grid has width', async () => {
+    await withHarness((harness) => {
+      invalidateAllPanelStorageCaches();
+      harness.localStorage.setItem(PANEL_COL_SPANS_KEY, JSON.stringify({ delayed: 3 }));
+
+      const grid = harness.document.createElement('div');
+      grid.className = 'panels-grid';
+      let gridWidth = 0;
+      Object.defineProperty(grid, 'getBoundingClientRect', {
+        configurable: true,
+        value: () => ({ width: gridWidth, height: 0, top: 0, left: 0, right: gridWidth, bottom: 0, x: 0, y: 0, toJSON: () => ({}) }),
+      });
+      harness.window.getComputedStyle = () => ({
+        display: '',
+        visibility: '',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(280px, 1fr))',
+        columnGap: '0',
+      });
+
+      const frames: Array<() => void> = [];
+      globalThis.requestAnimationFrame = ((callback: () => void) => {
+        frames.push(callback);
+        return frames.length;
+      }) as typeof requestAnimationFrame;
+      globalThis.cancelAnimationFrame = (() => {}) as typeof cancelAnimationFrame;
+
+      const panel = harness.createPanel({ id: 'delayed' });
+      const root = panel.getElement();
+      assert.equal(root.classList.contains('col-span-3'), true);
+      assert.equal(frames.length, 1);
+
+      grid.appendChild(root);
+      harness.document.body.appendChild(grid);
+      frames.shift()?.();
+      assert.equal(root.classList.contains('col-span-3'), true);
+      assert.equal(frames.length, 1);
+
+      gridWidth = 560;
+      frames.shift()?.();
+      assert.equal(root.classList.contains('col-span-3'), false);
+      assert.equal(root.classList.contains('col-span-2'), true);
+    });
+  });
+
   it('keeps the warmed cache fresh after collapse and reset mutations', async () => {
     await withHarness((harness) => {
       harness.localStorage.setItem(PANEL_SPANS_KEY, JSON.stringify({ mutable: 4 }));


### PR DESCRIPTION
## Summary
Returning users with a saved 3-column panel span no longer get a deferred shell that briefly overflows an auto-fill grid before the real panel clamps down. Shared grid span logic now treats `repeat(auto-fill/auto-fit, ...)` with `width: 0` as not laid out yet, so both shells and real panels retry on rAF until the grid can report a reliable column count.

The deferred footprint guardrail also now scans `.tsx` component sources and fails on non-literal constructor `className` values that could hide future `panel-wide` footprint drift.

## Validation
- Reproduced before fix: `./node_modules/.bin/tsx --test tests/panel-mount-deferral.test.mts tests/panel-storage-cache.test.mts` failed in the new connected-width-zero shell and real-panel cases (`0 !== 1`, no retry scheduled).
- `./node_modules/.bin/tsx --test tests/panel-mount-deferral.test.mts tests/panel-storage-cache.test.mts`
- `./node_modules/.bin/tsx --test tests/panel-config-guardrails.test.mjs`
- `npm run typecheck`
- `git diff --check`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
