### PR TITLE
test(railway): harden no-escape bundle scan for comments + nested bundles

### DIFF
--- a/tests/scripts-railway-nixpacks-no-escape-import.test.mts
+++ b/tests/scripts-railway-nixpacks-no-escape-import.test.mts
@@ -75,17 +75,28 @@ function collectRelativeImports(filePath: string): string[] {
   return out;
 }
 
-function stripLineComments(src: string): string {
+// Conservative JS comment stripper (same pattern as
+// tests/news-feed-key-parity.test.mts): drop block comments, then line
+// comments anchored at a line start or after whitespace so in-string `//`
+// (e.g. `https://`) survives. Keeps a `script:` literal in a block, trailing,
+// or full-line comment from registering as a real child seeder.
+function stripComments(src: string): string {
   return src
-    .split('\n')
-    .filter((line) => !line.trimStart().startsWith('//'))
-    .join('\n');
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|\s)\/\/[^\n]*/g, '$1');
 }
 
 function collectBundleSectionScripts(filePath: string): string[] {
-  if (!BUNDLE_ENTRY_FILES.has(filePath)) return [];
+  const raw = readFileSync(filePath, 'utf8');
+  // `script:` section entries are the _bundle-runner orchestrator shape. Scan
+  // registry entry points AND any nested orchestrator reached in the BFS (a
+  // bundle that spawns a sub-bundle), but skip unrelated files so a stray
+  // `script: 'x.mjs'` literal elsewhere can't fake an escape.
+  if (!BUNDLE_ENTRY_FILES.has(filePath) && !raw.includes('_bundle-runner')) {
+    return [];
+  }
 
-  const src = stripLineComments(readFileSync(filePath, 'utf8'));
+  const src = stripComments(raw);
   const out: string[] = [];
   let m: RegExpExecArray | null;
   BUNDLE_SECTION_SCRIPT_RE.lastIndex = 0;

--- a/tests/scripts-railway-nixpacks-no-escape-import.test.mts
+++ b/tests/scripts-railway-nixpacks-no-escape-import.test.mts
@@ -87,16 +87,17 @@ function stripComments(src: string): string {
 }
 
 function collectBundleSectionScripts(filePath: string): string[] {
-  const raw = readFileSync(filePath, 'utf8');
-  // `script:` section entries are the _bundle-runner orchestrator shape. Scan
-  // registry entry points AND any nested orchestrator reached in the BFS (a
-  // bundle that spawns a sub-bundle), but skip unrelated files so a stray
-  // `script: 'x.mjs'` literal elsewhere can't fake an escape.
-  if (!BUNDLE_ENTRY_FILES.has(filePath) && !raw.includes('_bundle-runner')) {
+  // Strip comments first so the gate and the extraction agree on the same
+  // source: `script:` section entries are the _bundle-runner orchestrator
+  // shape, so scan registry entry points AND any nested orchestrator reached
+  // in the BFS (a bundle that spawns a sub-bundle), but skip unrelated files
+  // (and files that mention `_bundle-runner` only in a comment) so a stray
+  // `script: 'x.mjs'` literal can't fake an escape.
+  const src = stripComments(readFileSync(filePath, 'utf8'));
+  if (!BUNDLE_ENTRY_FILES.has(filePath) && !src.includes('_bundle-runner')) {
     return [];
   }
 
-  const src = stripComments(raw);
   const out: string[] = [];
   let m: RegExpExecArray | null;
   BUNDLE_SECTION_SCRIPT_RE.lastIndex = 0;


### PR DESCRIPTION
## Summary

Follow-up hardening to the `_bundle-runner` section scan added in #4515. The merged version closed the original review findings; this tightens two residual robustness gaps in `tests/scripts-railway-nixpacks-no-escape-import.test.mts` (no behavior change on the current tree — all entries still pass).

1. **Comment-awareness** — `stripLineComments` only dropped *full-line* `//` comments, so a `script: 'x.mjs'` literal inside a `/* … */` block comment or a *trailing* `// …` comment could still register as a real child seeder (a false-positive escape). Replaced with the repo-standard `stripComments` (same pattern as `tests/news-feed-key-parity.test.mts`): strips block comments, then line comments anchored at a line start or after whitespace so in-string `//` (e.g. `https://`) survives.

2. **Nested bundles** — scanning was gated to `BUNDLE_ENTRY_FILES` (top-level registry entries only), so a bundle that spawns a *sub-bundle* via `script:` would not have the sub-bundle's own children scanned (silent under-coverage). Widened the gate to `BUNDLE_ENTRY_FILES.has(filePath) || raw.includes('_bundle-runner')` — a strict superset that also follows any nested orchestrator reached in the BFS. No entry bundle nests today, so this is purely future-proofing.

## Validation

- `node --test tests/scripts-railway-nixpacks-no-escape-import.test.mts` (20 entries) + full affected set (`railway-services-registry-coverage`, `edge-functions`, `resilience-static-seed`) — 283/283 pass.
- Bug-reintroduction guard: flipping `seed-resilience-static.mjs` back to `../shared/` still fails the `seed-bundle-resilience.mjs` entry with the expected escape — guard remains genuine.
- Verified both hardenings against the real functions with throwaway fixtures: a file with block/trailing/full-line `script:` comment literals extracts only the real entry; a non-registry nested bundle's child is now scanned; an unrelated file with a stray `script:` literal is still skipped.
- `tsc --noEmit --strict` clean; `git diff --check` clean.

https://claude.ai/code/session_01DDdLVt4TfiQUkcPpjzT3CM