### PR TITLE
fix(docker): serve dashboard.html as SPA entry in self-hosted nginx

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -36,7 +36,10 @@ http {
   server {
     listen 8080;
     root /usr/share/nginx/html;
-    index index.html;
+    # The Vite build renames the SPA entry index.html -> dashboard.html
+    # (dashboardHtmlOutputPlugin, non-desktop builds), matching the Vercel
+    # rewrite of the catch-all route to /dashboard.html. Keep nginx in sync.
+    index dashboard.html;
 
     # Static assets — immutable cache
     location /assets/ {
@@ -113,7 +116,7 @@ http {
       proxy_send_timeout 120s;
     }
 
-    # SPA fallback — all other routes serve index.html
+    # SPA fallback — all other routes serve dashboard.html (the renamed entry)
     location / {
       add_header X-Content-Type-Options "nosniff" always;
       add_header X-Frame-Options "SAMEORIGIN" always;
@@ -122,7 +125,7 @@ http {
       add_header Cache-Control "no-cache, no-store, must-revalidate";
       # Allow nested YouTube iframes to call requestStorageAccess().
       add_header Permissions-Policy "storage-access=(self \"https://www.youtube.com\" \"https://youtube.com\")";
-      try_files $uri $uri/ /index.html;
+      try_files $uri $uri/ /dashboard.html;
     }
   }
 }


### PR DESCRIPTION
## Problem

A freshly built self-hosted Docker image returns **HTTP 403** on `/`:

```
[error] directory index of "/usr/share/nginx/html/" is forbidden
"GET / HTTP/1.1" 403
```

The Vite build renames the SPA entry `index.html` → `dashboard.html` (`dashboardHtmlOutputPlugin` in `vite.config.ts`, applied to all non-desktop builds), and `vercel.json` rewrites the catch-all route to `/dashboard.html`. But `docker/nginx.conf` still referenced `index.html` for both the `index` directive and the SPA `try_files` fallback. Since `dist/` ships `dashboard.html` and no `index.html`, nginx falls through to a directory listing and returns 403, leaving the self-hosted dashboard unreachable at `/`.

## Fix

Point the self-hosted nginx config at `dashboard.html`, matching the build output and the existing Vercel routing. No other behavior changes; the API proxy, embed, and asset locations are untouched.

## Testing

On a clean `docker compose up -d --build`:

- `GET /` → **200** (serves the dashboard) — was 403
- `GET /dashboard.html` → **200**
- `GET /api/health` → **200**

🤖 Generated with [Claude Code](https://claude.com/claude-code)