### PR TITLE
fix(docker): serve dashboard.html in the published frontend-only nginx image (follow-up to #4521)

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -36,7 +36,10 @@ http {
   server {
     listen 8080;
     root /usr/share/nginx/html;
-    index index.html;
+    # The Vite build renames the SPA entry index.html -> dashboard.html
+    # (dashboardHtmlOutputPlugin, non-desktop builds), matching the Vercel
+    # rewrite of the catch-all route to /dashboard.html. Keep nginx in sync.
+    index dashboard.html;
 
     # Static assets — immutable cache
     location /assets/ {
@@ -113,7 +116,7 @@ http {
       proxy_send_timeout 120s;
     }
 
-    # SPA fallback — all other routes serve index.html
+    # SPA fallback — all other routes serve dashboard.html (the renamed entry)
     location / {
       add_header X-Content-Type-Options "nosniff" always;
       add_header X-Frame-Options "SAMEORIGIN" always;
@@ -122,7 +125,7 @@ http {
       add_header Cache-Control "no-cache, no-store, must-revalidate";
       # Allow nested YouTube iframes to call requestStorageAccess().
       add_header Permissions-Policy "storage-access=(self \"https://www.youtube.com\" \"https://youtube.com\")";
-      try_files $uri $uri/ /index.html;
+      try_files $uri $uri/ /dashboard.html;
     }
   }
 }

--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -29,7 +29,10 @@ http {
     server_name _;
 
     root /usr/share/nginx/html;
-    index index.html;
+    # The Vite build renames the SPA entry index.html -> dashboard.html
+    # (dashboardHtmlOutputPlugin, non-desktop builds), matching the Vercel
+    # rewrite of the catch-all route to /dashboard.html. Keep nginx in sync.
+    index dashboard.html;
 
     location = /embed {
       include /etc/nginx/embed_security_headers.conf;
@@ -45,7 +48,7 @@ http {
 
     location / {
       include /etc/nginx/security_headers.conf;
-      try_files $uri $uri/ /index.html;
+      try_files $uri $uri/ /dashboard.html;
       add_header Cache-Control "no-cache, no-store, must-revalidate";
     }
 

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -948,6 +948,21 @@ describe('embeddable map route guardrails', () => {
     });
   }
 
+  it('both self-hosted nginx confs serve dashboard.html as the SPA entry', () => {
+    // dashboardHtmlOutputPlugin (vite.config.ts, !isDesktopBuild) renames the
+    // built SPA entry index.html -> dashboard.html for every web build, so dist/
+    // ships no index.html. BOTH self-hosted images must point the `index`
+    // directive and the SPA fallback at dashboard.html, or `/` 403s:
+    //   root Dockerfile   -> docker/nginx.conf          (docker-compose stack)
+    //   docker/Dockerfile -> docker/nginx.conf.template (published ghcr image)
+    for (const conf of ['docker/nginx.conf', 'docker/nginx.conf.template']) {
+      const src = readFileSync(resolve(__dirname, `../${conf}`), 'utf-8');
+      assert.match(src, /^\s*index dashboard\.html;/m, `${conf}: index directive must be dashboard.html`);
+      assert.match(src, /try_files \$uri \$uri\/ \/dashboard\.html;/, `${conf}: SPA fallback must serve /dashboard.html`);
+      assert.doesNotMatch(src, /try_files \$uri \$uri\/ \/index\.html;/, `${conf}: must not keep the broken /index.html SPA fallback`);
+    }
+  });
+
   it('keeps Docker embed routes on the locked-down embed security headers', () => {
     const nginxTemplate = readFileSync(resolve(__dirname, '../docker/nginx.conf.template'), 'utf-8');
     assert.match(nginxTemplate, /location = \/embed \{[\s\S]*?include \/etc\/nginx\/embed_security_headers\.conf;/);

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -948,21 +948,6 @@ describe('embeddable map route guardrails', () => {
     });
   }
 
-  it('both self-hosted nginx confs serve dashboard.html as the SPA entry', () => {
-    // dashboardHtmlOutputPlugin (vite.config.ts, !isDesktopBuild) renames the
-    // built SPA entry index.html -> dashboard.html for every web build, so dist/
-    // ships no index.html. BOTH self-hosted images must point the `index`
-    // directive and the SPA fallback at dashboard.html, or `/` 403s:
-    //   root Dockerfile   -> docker/nginx.conf          (docker-compose stack)
-    //   docker/Dockerfile -> docker/nginx.conf.template (published ghcr image)
-    for (const conf of ['docker/nginx.conf', 'docker/nginx.conf.template']) {
-      const src = readFileSync(resolve(__dirname, `../${conf}`), 'utf-8');
-      assert.match(src, /^\s*index dashboard\.html;/m, `${conf}: index directive must be dashboard.html`);
-      assert.match(src, /try_files \$uri \$uri\/ \/dashboard\.html;/, `${conf}: SPA fallback must serve /dashboard.html`);
-      assert.doesNotMatch(src, /try_files \$uri \$uri\/ \/index\.html;/, `${conf}: must not keep the broken /index.html SPA fallback`);
-    }
-  });
-
   it('keeps Docker embed routes on the locked-down embed security headers', () => {
     const nginxTemplate = readFileSync(resolve(__dirname, '../docker/nginx.conf.template'), 'utf-8');
     assert.match(nginxTemplate, /location = \/embed \{[\s\S]*?include \/etc\/nginx\/embed_security_headers\.conf;/);
@@ -987,6 +972,23 @@ describe('embeddable map route guardrails', () => {
 
     const dockerEmbedCsp = getNginxHeaderValueFrom('docker/nginx-embed-security-headers.conf', 'Content-Security-Policy');
     assert.equal(dockerEmbedCsp, getHeaderValueForSource('/embed', 'Content-Security-Policy'));
+  });
+});
+
+describe('self-hosted docker nginx SPA entry', () => {
+  it('both nginx confs serve dashboard.html as the SPA entry', () => {
+    // dashboardHtmlOutputPlugin (vite.config.ts, !isDesktopBuild) renames the
+    // built SPA entry index.html -> dashboard.html for every web build, so dist/
+    // ships no index.html. BOTH self-hosted images must point the `index`
+    // directive and the SPA fallback at dashboard.html, or `/` 403s:
+    //   root Dockerfile   -> docker/nginx.conf          (docker-compose stack)
+    //   docker/Dockerfile -> docker/nginx.conf.template (published ghcr image)
+    for (const conf of ['docker/nginx.conf', 'docker/nginx.conf.template']) {
+      const src = readFileSync(resolve(__dirname, `../${conf}`), 'utf-8');
+      assert.match(src, /^\s*index dashboard\.html;/m, `${conf}: index directive must be dashboard.html`);
+      assert.match(src, /try_files \$uri \$uri\/ \/dashboard\.html;/, `${conf}: SPA fallback must serve /dashboard.html`);
+      assert.doesNotMatch(src, /try_files \$uri \$uri\/ \/index\.html;/, `${conf}: must not keep the broken /index.html SPA fallback`);
+    }
   });
 });
 


### PR DESCRIPTION
## Problem

#4521 fixes the HTTP 403 on `/` for **one** of the two self-hosted images, but leaves the other — the **published** one — still broken.

- `docker-compose.yml` → root `Dockerfile` → `docker/nginx.conf` ✅ fixed by #4521.
- `.github/workflows/docker-publish.yml` → `docker/Dockerfile` → **`docker/nginx.conf.template`** → published as `ghcr.io/koala73/worldmonitor:latest`. ❌ still references `index.html`.

Both images run the same non-desktop `vite build`, and `dashboardHtmlOutputPlugin` (`vite.config.ts`, `!isDesktopBuild`) renames `index.html → dashboard.html` and deletes the original — so `dist/` has **no `index.html`**. The template's `index index.html;` (`:32`) and `try_files $uri $uri/ /index.html;` (`:48`) therefore point at a non-existent file, and `docker pull ghcr.io/koala73/worldmonitor:latest` still 403s on `/`.

## Fix

- `docker/nginx.conf.template`: point the `index` directive and the SPA fallback at `dashboard.html` (mirrors #4521 and `vercel.json`'s catch-all rewrite). Left `/pro/index.html` untouched — the Pro sub-app entry is not renamed.
- Add a `deploy-config.test.mjs` guard asserting **both** `docker/nginx.conf` and `docker/nginx.conf.template` serve `dashboard.html` as the SPA entry. Neither file was guarded before, so either could silently regress to the 403.

## Relationship to #4521

This branch is **stacked on #4521**, so this PR currently shows #4521's `docker/nginx.conf` commit plus this one. Merge #4521 first (contributor credit) — its `docker/nginx.conf` hunk then rebases away and this PR reduces to the template fix + cross-image guard test. Merging this alone also fully closes the bug.

## Verification

- `node --test tests/deploy-config.test.mjs` → 82/82 (incl. the new cross-image guard).
- Template brace balance OK; zero remaining bare `/index.html` SPA fallbacks; `/pro/index.html` entry preserved.

This was surfaced by a 3-agent adversarial review of #4521 (security / correctness / deployment-completeness), all converging on the published-image gap.

https://claude.ai/code/session_017aPxBRsHtUZUC5UWee9PuM