### PR TITLE
docs(api): expose endpoint discovery for economy services

### DIFF
--- a/docs/finance-data.mdx
+++ b/docs/finance-data.mdx
@@ -34,10 +34,10 @@ These tables are the human-facing route map for finance, market, macro, energy, 
 | DeFi tokens | `GET /api/market/v1/list-defi-tokens` | DeFi token tile; bootstrap-first via `defiTokens`. |
 | AI tokens | `GET /api/market/v1/list-ai-tokens` | AI token tile; bootstrap-first via `aiTokens`. |
 | Other tokens | `GET /api/market/v1/list-other-tokens` | Alt / trending token tile; bootstrap-first via `otherTokens`. |
-| Fear & Greed | `GET /api/market/v1/get-fear-greed-index` | Fear & Greed panel plus US KCFSI portion of Financial Stress. |
+| Fear & Greed | `GET /api/market/v1/get-fear-greed-index` | Fear & Greed panel plus US KCFSI portion of Financial Stress; bootstrap-first via `fearGreedIndex`. |
 | Earnings calendar | `GET /api/market/v1/list-earnings-calendar` | Earnings Calendar tile. |
 | COT positioning | `GET /api/market/v1/get-cot-positioning` | COT Positioning tile and gold positioning context. |
-| Insider transactions | `GET /api/market/v1/get-insider-transactions` | Insider section in locked Premium Stock Analysis. |
+| PRO insider transactions | `GET /api/market/v1/get-insider-transactions` | Insider Activity section in the locked Premium Stock Analysis surface. |
 | Market breadth history | `GET /api/market/v1/get-market-breadth-history` | Market Breadth panel; bootstrap-first via `breadthHistory`. |
 | Gold intelligence | `GET /api/market/v1/get-gold-intelligence` | Gold Intelligence panel direct REST fetch. |
 | Hyperliquid flow | `GET /api/market/v1/get-hyperliquid-flow` | 24/7 Positioning panel; bootstrap-first via `hyperliquidFlow`. |

--- a/docs/finance-data.mdx
+++ b/docs/finance-data.mdx
@@ -10,6 +10,70 @@ For the premium stock-analysis product layer, see:
 
 ---
 
+## Endpoint Discovery
+
+These tables are the human-facing route map for finance, market, macro, energy, and commodity surfaces. Full request and response schemas remain in the generated OpenAPI pages; methods and routes below are verified against `proto/worldmonitor/market/v1/service.proto` and `proto/worldmonitor/economic/v1/service.proto`. Unless noted, routes are generated sebuf REST RPCs under the service base path and may be bootstrap-hydrated before the live RPC fallback runs.
+
+### MarketService routes
+
+| Service area | Method + route | Feeds |
+|---|---|---|
+| Market quotes | `GET /api/market/v1/list-market-quotes` | Markets panel, customizable watchlist, equity / index quotes. |
+| Crypto quotes | `GET /api/market/v1/list-crypto-quotes` | Crypto panel defaults; bootstrap-first via `cryptoQuotes`. |
+| Commodity quotes | `GET /api/market/v1/list-commodity-quotes` | Commodities, Energy Risk Brent tile, gold / crude watchlists; bootstrap-first via `commodityQuotes`. |
+| Sector summary | `GET /api/market/v1/get-sector-summary` | Sector heatmap and valuation context; bootstrap-first via `sectors`. |
+| Stablecoin markets | `GET /api/market/v1/list-stablecoin-markets` | Stablecoin peg-health panel; bootstrap-first via `stablecoinMarkets`. |
+| ETF flows | `GET /api/market/v1/list-etf-flows` | BTC spot ETF tracker; bootstrap-first via `etfFlows`. |
+| Country stock index | `GET /api/market/v1/get-country-stock-index` | Country Brief stock-index card for a selected country. |
+| Gulf quotes | `GET /api/market/v1/list-gulf-quotes` | Gulf Economies panel; bootstrap-first via `gulfQuotes`. |
+| Premium stock analysis | `GET /api/market/v1/analyze-stock` | PRO stock-analysis card with technicals, headlines, targets, and AI synthesis. |
+| Stock analysis history | `GET /api/market/v1/get-stock-analysis-history` | PRO cached/shared premium analysis ledger. |
+| Stock backtest | `GET /api/market/v1/backtest-stock` | PRO on-demand replay of a stock-analysis signal. |
+| Stored stock backtests | `GET /api/market/v1/list-stored-stock-backtests` | PRO Premium Backtesting panel stored snapshots. |
+| Crypto sectors | `GET /api/market/v1/list-crypto-sectors` | Crypto heatmap sector averages; bootstrap-first via `cryptoSectors`. |
+| DeFi tokens | `GET /api/market/v1/list-defi-tokens` | DeFi token tile; bootstrap-first via `defiTokens`. |
+| AI tokens | `GET /api/market/v1/list-ai-tokens` | AI token tile; bootstrap-first via `aiTokens`. |
+| Other tokens | `GET /api/market/v1/list-other-tokens` | Alt / trending token tile; bootstrap-first via `otherTokens`. |
+| Fear & Greed | `GET /api/market/v1/get-fear-greed-index` | Fear & Greed panel plus US KCFSI portion of Financial Stress. |
+| Earnings calendar | `GET /api/market/v1/list-earnings-calendar` | Earnings Calendar tile. |
+| COT positioning | `GET /api/market/v1/get-cot-positioning` | COT Positioning tile and gold positioning context. |
+| Insider transactions | `GET /api/market/v1/get-insider-transactions` | Insider section in locked Premium Stock Analysis. |
+| Market breadth history | `GET /api/market/v1/get-market-breadth-history` | Market Breadth panel; bootstrap-first via `breadthHistory`. |
+| Gold intelligence | `GET /api/market/v1/get-gold-intelligence` | Gold Intelligence panel direct REST fetch. |
+| Hyperliquid flow | `GET /api/market/v1/get-hyperliquid-flow` | 24/7 Positioning panel; bootstrap-first via `hyperliquidFlow`. |
+
+### EconomicService routes
+
+| Service area | Method + route | Feeds |
+|---|---|---|
+| FRED single series | `GET /api/economic/v1/get-fred-series` | Single-series fallback for FRED-derived macro data. |
+| World Bank indicators | `GET /api/economic/v1/list-world-bank-indicators` | World Bank country indicators and tech-readiness data. |
+| Energy prices | `GET /api/economic/v1/get-energy-prices` | Oil & Energy analytics for WTI, Brent, production, and inventory metrics. |
+| Macro signals | `GET /api/economic/v1/get-macro-signals` | Market Radar / Macro Signals panel; bootstrap-first via `macroSignals`. |
+| Energy capacity | `GET /api/economic/v1/get-energy-capacity` | Installed solar, wind, and coal capacity timeseries. |
+| BIS policy rates | `GET /api/economic/v1/get-bis-policy-rates` | Economic panel BIS policy-rate table; bootstrap-first via `bisPolicy`. |
+| BIS exchange rates | `GET /api/economic/v1/get-bis-exchange-rates` | BIS real effective exchange-rate table; bootstrap-first via `bisExchange`. |
+| BIS credit | `GET /api/economic/v1/get-bis-credit` | BIS credit-to-GDP rankings; bootstrap-first via `bisCredit`. |
+| FRED batch | `POST /api/economic/v1/get-fred-series-batch` | Macro tiles and FRED dashboard series in one call. |
+| Grocery basket prices | `GET /api/economic/v1/list-grocery-basket-prices` | Grocery Index panel; bootstrap-first via `groceryBasket`. |
+| Big Mac prices | `GET /api/economic/v1/list-bigmac-prices` | Big Mac Index panel; bootstrap-first via `bigmac`. |
+| National debt | `GET /api/economic/v1/get-national-debt` | PRO Global Debt Clock panel; bootstrap-first via `nationalDebt`. |
+| Fuel prices | `GET /api/economic/v1/list-fuel-prices` | Fuel Prices panel; bootstrap-first via `fuelPrices`. |
+| BLS series | `GET /api/economic/v1/get-bls-series` | BLS-only payroll and Employment Cost Index series. |
+| Economic calendar | `GET /api/economic/v1/get-economic-calendar` | Economic Calendar tile. |
+| Crude inventories | `GET /api/economic/v1/get-crude-inventories` | Weekly EIA crude stockpile panel data; bootstrap-first via `crudeInventories`. |
+| Natural gas storage | `GET /api/economic/v1/get-nat-gas-storage` | Weekly EIA US working gas storage; bootstrap-first via `natGasStorage`. |
+| ECB FX rates | `GET /api/economic/v1/get-ecb-fx-rates` | ECB EUR reference-rate table; bootstrap-first via `ecbFxRates`. |
+| Eurostat country data | `GET /api/economic/v1/get-eurostat-country-data` | Macro tiles for EU CPI, unemployment, and GDP growth; bootstrap-first via `eurostatCountryData`. |
+| EU gas storage | `GET /api/economic/v1/get-eu-gas-storage` | Global Energy Risk Overview and Oil Inventories EU gas tile; bootstrap-first via `euGasStorage`. |
+| EU yield curve | `GET /api/economic/v1/get-eu-yield-curve` | Yield Curve panel. |
+| EU FSI | `GET /api/economic/v1/get-eu-fsi` | EU half of the Financial Stress panel; bootstrap-first via `euFsi`. |
+| Economic stress | `GET /api/economic/v1/get-economic-stress` | Economic Stress signal loaded by the data loader; bootstrap-first via `economicStress`. |
+| FAO food price index | `GET /api/economic/v1/get-fao-food-price-index` | FAO Food Price Index panel; bootstrap-first via `faoFoodPriceIndex`. |
+| Oil stocks analysis | `GET /api/economic/v1/get-oil-stocks-analysis` | IEA oil days-of-cover ranking in Oil Inventories; bootstrap-first via `oilStocksAnalysis`. |
+| Oil inventories composite | `GET /api/economic/v1/get-oil-inventories` | Oil Inventories panel direct REST fetch combining crude, SPR, gas storage, EU gas, IEA stocks, and refinery context. |
+| Energy crisis policies | `GET /api/economic/v1/get-energy-crisis-policies` | Energy Crisis Tracker; bootstrap-first via `energyCrisisPolicies`. |
+
 ## Market Monitoring
 
 ### Customizable Market Watchlist
@@ -130,7 +194,7 @@ Data is fetched through three dedicated BIS RPCs (`GetBisPolicyRates`, `GetBisEx
 
 ### WTO Trade Policy Intelligence
 
-The Trade Policy panel provides real-time visibility into global trade restrictions, tariffs, and barriers — critical for tracking economic warfare, sanctions impact, and supply chain disruption risk. Four data views are available:
+The Trade Policy panel provides real-time visibility into global trade restrictions, tariffs, and barriers — critical for tracking economic warfare, sanctions impact, and supply chain disruption risk. Six data views are available:
 
 | Tab | Data Source | Content |
 | --- | --- | --- |
@@ -139,8 +203,9 @@ The Trade Policy panel provides real-time visibility into global trade restricti
 | **Flows** | WTO trade statistics | Bilateral trade flow volumes with year-over-year change indicators |
 | **Barriers** | WTO SPS/TBT notifications | Sanitary, phytosanitary, and technical barriers to trade with status tracking |
 | **Revenue** | US Treasury Monthly Treasury Statement | Monthly US customs duties revenue with fiscal-year-to-date totals and year-over-year comparison |
+| **Comtrade** | UN Comtrade | Strategic commodity flow search with anomaly detection |
 
-The `trade/v1` proto service defines five RPCs. The four WTO RPCs each have their own circuit breaker (30-minute cache TTL) and `upstreamUnavailable` signaling for graceful degradation when WTO endpoints are temporarily unreachable. The fifth RPC (`GetCustomsRevenue`) serves US Treasury customs duties data from a Railway seed (free API, no key required). The panel is available on FULL and FINANCE variants. WTO data feeds into the data freshness tracker as `wto_trade`, and Treasury revenue as `treasury_revenue`, with intelligence gap warnings when either feed goes stale.
+The `trade/v1` proto service defines six RPCs. The WTO-backed restrictions, tariffs, flows, and barriers RPCs each have their own circuit breaker (30-minute cache TTL) and `upstreamUnavailable` signaling for graceful degradation when WTO endpoints are temporarily unreachable. `GetCustomsRevenue` serves US Treasury customs duties data from a Railway seed (free API, no key required), and `ListComtradeFlows` serves UN Comtrade strategic commodity flows. The panel is available on full/geopolitical, finance, and commodity variants. WTO data feeds into the data freshness tracker as `wto_trade`, and Treasury revenue as `treasury_revenue`, with intelligence gap warnings when either feed goes stale. For exact method, route, and gating notes, see [Trade Policy](/panels/trade-policy).
 
 The Revenue tab is particularly relevant during periods of active trade policy changes. US customs duties revenue spiked from approximately $7B/month (pre-2025) to $27-31B/month following the 2025-2026 tariff escalation. WTO annual tariff data lags by approximately one year, so the monthly Treasury revenue data provides near-real-time visibility into the actual fiscal impact of tariff policy. The Revenue tab shows a fiscal-year-to-date summary with a year-over-year comparison using matched fiscal month counts (e.g., FY2026 Oct-Feb vs FY2025 Oct-Feb), along with a monthly table highlighting months where revenue exceeds twice the prior-year monthly average. On desktop without a WTO API key, the Revenue tab is still accessible since Treasury data requires no authentication.
 
@@ -158,6 +223,6 @@ The Supply Chain panel provides real-time visibility into global logistics risk 
 
 **Critical Minerals tab** — applies the **Herfindahl-Hirschman Index (HHI)** to 2024 global production data for minerals critical to technology and defense manufacturing — lithium, cobalt, rare earths, gallium, germanium, and others. The HHI quantifies supply concentration risk: a market dominated by a single producer scores near 10,000, while a perfectly distributed market scores near 0. Each mineral displays the top 3 producing countries with market share percentages, flagging single-country dependencies that represent strategic vulnerability (e.g., China's dominance in rare earth processing). This tab uses static production data, cached for 24 hours with no external API dependency.
 
-The panel is available on the FULL (World Monitor) variant and integrates with the infrastructure cascade model — when a chokepoint disruption coincides with high mineral concentration risk for affected trade routes, the combined signal feeds into convergence detection.
+The panel is available on the full/geopolitical, finance, and commodity variants and integrates with the infrastructure cascade model — when a chokepoint disruption coincides with high mineral concentration risk for affected trade routes, the combined signal feeds into convergence detection.
 
 See also [Maritime Intelligence](/maritime-intelligence) for vessel tracking and dark ship detection.

--- a/docs/panels/energy-crisis.mdx
+++ b/docs/panels/energy-crisis.mdx
@@ -25,8 +25,11 @@ Panel id is `energy-crisis`; canonical component is `src/components/EnergyCrisis
 
 ## Data sources
 
-- `EconomicServiceClient.getEnergyCrisisPolicies()` via the generated Economic service client.
-- Panel prefers the hydrated bootstrap payload first (`getHydratedData()`) and falls back to a fresh RPC call — the standard WorldMonitor "one bootstrap, no duplicate fetch" pattern.
+The panel prefers the hydrated bootstrap payload first (`energyCrisisPolicies`) and falls back to a generated Economic service RPC.
+
+| Method + route | Feeds |
+|---|---|
+| `GET /api/economic/v1/get-energy-crisis-policies` | IEA 2026 Energy Crisis Policy Response Tracker policies, optionally filtered by country or category. |
 
 Upstream source per the in-panel info tooltip: **IEA 2026 Energy Crisis Policy Response Tracker**. Tracks measures across ~60 countries with nearly 200 policy entries.
 

--- a/docs/panels/fsi.mdx
+++ b/docs/panels/fsi.mdx
@@ -27,11 +27,12 @@ Panel id is `fsi`; canonical component is `src/components/FSIPanel.ts`. Title fr
 
 ## Data sources
 
-The panel uses the generated RPC clients directly:
+The panel uses generated RPC clients directly and prefers bootstrap-hydrated values before fresh calls.
 
-- **Market service** (`MarketServiceClient`) — KCFSI series.
-- **Economic service** (`EconomicServiceClient.getEuFsi()`) — EU FSI (`GetEuFsiResponse`).
-- **Bootstrap-hydrated data** — the panel prefers `getHydratedData(...)` first and falls back to fresh RPC calls (the standard hydration pattern).
+| Reading | Method + route | Feeds |
+|---|---|---|
+| US KCFSI | `GET /api/market/v1/get-fear-greed-index` | KCFSI value and market-stress inputs from the Fear & Greed payload; bootstrap-first via `fearGreedIndex`. |
+| EU FSI | `GET /api/economic/v1/get-eu-fsi` | ECB CISS `SS_CIN` latest value and history; bootstrap-first via `euFsi`. |
 
 Upstream KCFSI data is from the Federal Reserve Bank of Kansas City; EU FSI is
 from the ECB CISS `SS_CIN` daily series, the live successor to the legacy

--- a/docs/panels/hormuz-tracker.mdx
+++ b/docs/panels/hormuz-tracker.mdx
@@ -24,9 +24,15 @@ Panel id is `hormuz-tracker`; canonical component is `src/components/HormuzPanel
 
 ## Data sources
 
-`fetchHormuzTracker()` in `@/services/hormuz-tracker` — backed by the Railway AIS relay that tallies AIS vessel transits through the Strait. The seeder produces both live tanker counts and weekly flow deltas; disruption events surface through the status field.
+`fetchHormuzTracker()` in `@/services/hormuz-tracker` is backed by the Railway AIS relay that tallies AIS vessel transits through the Strait. The seeder produces both live tanker counts and weekly flow deltas; disruption events surface through the status field.
 
-For the public HTTP surface see `/api/supply-chain/hormuz-tracker` under [Proxies](/api-proxies).
+This panel uses a legacy/special platform proxy rather than a generated `SupplyChainService` RPC:
+
+| Method + route | Feeds |
+|---|---|
+| `GET /api/supply-chain/hormuz-tracker` | Real-time Hormuz status, tanker transit series, weekly flow deltas, and disruption events. |
+
+For the proxy catalog entry, see [Proxies](/api-proxies). For generated chokepoint and lane-risk RPCs, see [Supply Chain](/panels/supply-chain) and [Route Explorer](/route-explorer).
 
 ## Refresh cadence
 

--- a/docs/panels/stock-analysis.mdx
+++ b/docs/panels/stock-analysis.mdx
@@ -28,11 +28,13 @@ Panel id is `stock-analysis`; canonical component is `src/components/StockAnalys
 
 ## Data sources
 
-All fields come from the generated `MarketServiceClient`:
+All fields come from generated `MarketServiceClient` routes. The panel is locked, and the premium stock-analysis calls use `premiumFetch`; the insider-enrichment route is rendered only inside this locked surface.
 
-- `analyst_consensus`, `price_targets`, `upgrade_downgrades` — Market service RPCs.
-- Insider transactions — `@/services/insider-transactions` wrapper, bound via `setInsiderData()`.
-- Price + sparkline — Market service quote/series RPCs.
+| Method + route | Feeds |
+|---|---|
+| `GET /api/market/v1/analyze-stock` | Per-symbol analysis card: current price, sparkline, technical signal, thesis, targets, ratings, headlines, and AI synthesis. |
+| `GET /api/market/v1/get-stock-analysis-history` | Cached/shared previous analyses so the panel can render stored snapshots before recomputing stale symbols. |
+| `GET /api/market/v1/get-insider-transactions` | Insider Activity section attached after the analysis card renders. |
 
 ## Refresh cadence
 
@@ -44,5 +46,5 @@ Analyses are on-demand; no polling. The panel caches previous analyses in `Stock
 
 ## API reference
 
-- [Markets service](/api/MarketService.openapi.yaml) — analyst consensus, price targets, upgrades/downgrades, quote RPCs.
+- [Markets service](/api/MarketService.openapi.yaml) — schemas and parameters for `analyze-stock`, `get-stock-analysis-history`, and `get-insider-transactions`.
 - Related: [Premium Backtesting](/panels/stock-backtest) — the backtest side of the same dataset.

--- a/docs/panels/stock-backtest.mdx
+++ b/docs/panels/stock-backtest.mdx
@@ -20,7 +20,12 @@ Panel id is `stock-backtest`; canonical component is `src/components/StockBackte
 
 ## Data sources
 
-Backtests are produced by a Railway cron that replays previous analysis signals against historical price series. Results are stored in the premium-stock store and fetched via `@/services/stock-backtest`. The panel consumes `StockBacktestResult[]` through `renderBacktests(items, source)`.
+Backtests are produced by a Railway cron that replays previous analysis signals against historical price series. Results are stored in the premium-stock store and fetched via `@/services/stock-backtest`; stale or missing stored rows can be recomputed on demand.
+
+| Method + route | Feeds |
+|---|---|
+| `GET /api/market/v1/list-stored-stock-backtests` | Stored premium backtest snapshots rendered first when fresh. |
+| `GET /api/market/v1/backtest-stock` | On-demand per-symbol backtest recomputation for missing or stale rows. |
 
 ## Refresh cadence
 
@@ -32,5 +37,5 @@ Backtest results update with the premium-stock cron. Freshness is signalled by t
 
 ## API reference
 
-- [Markets service](/api/MarketService.openapi.yaml) — underlying price-series and stock-analysis RPCs.
+- [Markets service](/api/MarketService.openapi.yaml) — schemas and parameters for `list-stored-stock-backtests` and `backtest-stock`.
 - Related: [Premium Stock Analysis](/panels/stock-analysis) — per-ticker deep dive that seeds the backtest input.

--- a/docs/panels/supply-chain.mdx
+++ b/docs/panels/supply-chain.mdx
@@ -24,7 +24,39 @@ Panel id is `supply-chain`; canonical component is `src/components/SupplyChainPa
 
 ## Data sources
 
-Reads the cached supply-chain dataset (composite stress, carrier list, minerals, scenario templates). The Scenario Engine triggers call `POST /api/scenario/v1/run-scenario` and poll `GET /api/scenario/v1/get-scenario-status` — see [Scenarios API](/api-scenarios) for the HTTP contract.
+The panel and adjacent supply-chain workflows mix generated sebuf REST RPCs, bootstrap/shared-store first paint, and special platform routes. The main Supply Chain panel reads cached bootstrap payloads for composite stress, chokepoints, shipping rates, and minerals when available, then refreshes through the generated `SupplyChainService` RPCs.
+
+| Surface | Method + route | Feeds |
+|---|---|---|
+| Shipping stress header and carrier rows | `GET /api/supply-chain/v1/get-shipping-stress` | Composite stress score plus carrier / ETF / index rows; bootstrap-first via `shippingStress`. |
+| Shipping rates | `GET /api/supply-chain/v1/get-shipping-rates` | FRED freight indices and spike detection; bootstrap-first via `shippingRates`. |
+| Chokepoint cards and strip | `GET /api/supply-chain/v1/get-chokepoint-status` | Current chokepoint status, warnings, AIS disruption counts, and compact transit summaries; bootstrap-first via `chokepoints`. |
+| Expanded chokepoint card | `GET /api/supply-chain/v1/get-chokepoint-history` | Lazy transit-count history for one chokepoint. |
+| Critical minerals rows | `GET /api/supply-chain/v1/get-critical-minerals` | Mineral concentration, HHI, top producers, and risk rating; bootstrap-first via `minerals`. |
+| Country exposure | `GET /api/supply-chain/v1/get-country-chokepoint-index` | PRO country + HS2 exposure scores used by Country Brief and route-risk surfaces. |
+| Bypass corridors | `GET /api/supply-chain/v1/get-bypass-options` | PRO ranked maritime and land bypass options for a chokepoint / cargo type. |
+| Country cost shock | `GET /api/supply-chain/v1/get-country-cost-shock` | PRO cost-shock and war-risk estimates for a country + chokepoint + HS2 slice. |
+| Country import basket | `GET /api/supply-chain/v1/get-country-products` | PRO seeded bilateral-HS4 import basket for country drill-downs. |
+| Multi-sector shock | `GET /api/supply-chain/v1/get-multi-sector-cost-shock` | PRO sector-level cost-shock estimates over a closure window. |
+| Sector dependency | `GET /api/supply-chain/v1/get-sector-dependency` | PRO dependency flags, primary exporter share, and primary chokepoint exposure. |
+| Route Explorer lane | `GET /api/supply-chain/v1/get-route-explorer-lane` | PRO primary route geometry, chokepoint exposures, bypass geometry, war-risk tier, and disruption score. |
+| Route Explorer impact | `GET /api/supply-chain/v1/get-route-impact` | PRO country-impact metrics for selected lane + HS2 commodity. |
+| Pipeline registry | `GET /api/supply-chain/v1/list-pipelines` | Pipeline Status panel and Energy Atlas PathLayer; bootstrap/shared-store first, RPC refresh after render. |
+| Pipeline drawer | `GET /api/supply-chain/v1/get-pipeline-detail` | Lazy evidence bundle and revision log for one pipeline. |
+| Storage registry | `GET /api/supply-chain/v1/list-storage-facilities` | Strategic Storage Atlas and Energy Atlas ScatterplotLayer; bootstrap/shared-store first, RPC refresh after render. |
+| Storage drawer | `GET /api/supply-chain/v1/get-storage-facility-detail` | Lazy evidence bundle and revision log for one storage facility. |
+| Fuel shortage registry | `GET /api/supply-chain/v1/list-fuel-shortages` | Fuel-shortage alert panel and energy-intelligence summaries. |
+| Fuel shortage drawer | `GET /api/supply-chain/v1/get-fuel-shortage-detail` | Lazy citation timeline and evidence bundle for one shortage. |
+| Energy disruptions | `GET /api/supply-chain/v1/list-energy-disruptions` | Energy Disruptions panel, Pipeline / Storage drawer timelines, and active-disruption count in Global Energy Risk Overview. |
+
+Special platform routes used from this surface:
+
+| Surface | Method + route | Feeds |
+|---|---|---|
+| Scenario activation | `POST /api/scenario/v1/run-scenario` | PRO Scenario Engine trigger buttons dispatch a template id and parameters. |
+| Scenario status | `GET /api/scenario/v1/get-scenario-status` | Scenario Engine polling paints the active-scenario banner after worker completion. |
+
+See [Scenarios API](/api-scenarios) for the full async job contract.
 
 ## Refresh cadence
 

--- a/docs/panels/trade-policy.mdx
+++ b/docs/panels/trade-policy.mdx
@@ -29,9 +29,16 @@ Panel id is `trade-policy`; canonical component is `src/components/TradePolicyPa
 
 ## Data sources
 
-Six response shapes from `@/services/trade`, each backed by the Trade service:
+Six response shapes from `@/services/trade`, each backed by a generated sebuf REST RPC in `TradeService`. The panel shell is free; tariff trends and Comtrade calls use `premiumFetch` because those two paths are premium transport paths, while restrictions, flows, barriers, and customs revenue use the public client. Customs revenue also checks the bootstrap cache key `customsRevenue` before falling back to the RPC.
 
-- `GetTradeRestrictionsResponse` / `GetTariffTrendsResponse` / `GetTradeFlowsResponse` / `GetTradeBarriersResponse` / `GetCustomsRevenueResponse` / `ListComtradeFlowsResponse`.
+| Tab | Method + route | Feeds |
+|---|---|---|
+| `restrictions` | `GET /api/trade/v1/get-trade-restrictions` | WTO restrictions list with country filters and upstream-unavailable state. |
+| `tariffs` | `GET /api/trade/v1/get-tariff-trends` | Premium tariff-rate timeseries between reporting and partner countries. |
+| `flows` | `GET /api/trade/v1/get-trade-flows` | Bilateral merchandise trade-flow rows and year-over-year context. |
+| `barriers` | `GET /api/trade/v1/get-trade-barriers` | SPS/TBT barrier notifications filtered by country or measure type. |
+| `revenue` | `GET /api/trade/v1/get-customs-revenue` | US Treasury customs duties revenue; bootstrap-first via `customsRevenue`. |
+| `comtrade` | `GET /api/trade/v1/list-comtrade-flows` | Premium UN Comtrade strategic commodity flow search with anomaly flags. |
 
 The `revenue` tab's US-Treasury feed is particularly sensitive — see the changelog entry for "US Treasury customs revenue in Trade Policy panel" (`#1663`).
 
@@ -41,8 +48,8 @@ Per-tab fetches on mount and on tab switch; no polling. Upstream seeders run on 
 
 ## Tier & gating
 
-**Free.** No `premium` flag in variant registrations. Trade service RPCs are public.
+**Panel shell is free.** No `premium` flag in variant registrations. The generated REST service is mixed: restrictions, flows, barriers, and customs revenue are public; `get-tariff-trends` and `list-comtrade-flows` are premium RPC paths and degrade to empty data without an entitled session or API key.
 
 ## API reference
 
-- [Trade service](/api/TradeService.openapi.yaml) — full OpenAPI for all six tab-backing RPCs.
+- [Trade service](/api/TradeService.openapi.yaml) — full schemas and query parameters for the six tab-backing RPCs.

--- a/docs/route-explorer.mdx
+++ b/docs/route-explorer.mdx
@@ -87,9 +87,14 @@ The gate path is implemented by `renderFreeGate()` in `src/components/RouteExplo
 
 ## Data behind Route Explorer
 
-- **Route graph** — `/api/supply-chain/v1/get-route-explorer-lane` (generated from `proto/worldmonitor/supply_chain/v1/`). Returns primary route id, chokepoint exposures, bypass corridors, war-risk tier, and disruption score.
-- **Country impact** — `/api/supply-chain/v1/get-route-impact` for the Impact tab.
-- **Chokepoint status** — live dry-bulk congestion, AIS density, dark-ship events, and recent incident feeds.
+Route Explorer calls generated sebuf REST RPCs from `SupplyChainService`. Both lane and impact calls are PRO paths; free users can open the workflow, but fetch-time gating replaces numeric results with the upgrade card. The route-intelligence vendor path is wrapped server-side by `get-route-explorer-lane`; browser code should use the generated REST routes below.
+
+| Workflow area | Method + route | Feeds |
+|---|---|---|
+| Current / Alternatives / Land tabs | `GET /api/supply-chain/v1/get-route-explorer-lane` | Primary route id, route geometry, chokepoint exposures, bypass options with geometry, war-risk tier, and disruption score. |
+| Impact tab | `GET /api/supply-chain/v1/get-route-impact` | Lane value, primary exporter share, strategic products, resilience score, dependency flags, and Comtrade source state. |
+| Public chokepoint context | `GET /api/supply-chain/v1/get-chokepoint-status` | Current chokepoint status, AIS disruption counts, and recent incident context shown elsewhere on the map. |
+| Chokepoint history drill-down | `GET /api/supply-chain/v1/get-chokepoint-history` | Lazy transit-count history for an expanded chokepoint card. |
 
 For the API-level contract, see the [Supply Chain](/api/SupplyChainService.openapi.yaml) and [Shipping v2](/api-shipping-v2) reference pages. For the underlying maritime layer on the map, see [Maritime Intelligence](/maritime-intelligence).
 


### PR DESCRIPTION
## Summary

Human docs now expose exact REST endpoints for Economic, Market, Trade, and SupplyChain panel surfaces without forcing readers into generated OpenAPI. The route tables call out when data is bootstrap-backed, premium-gated, or served through legacy/special platform paths, which makes panel docs useful for implementation discovery and support triage.

- Added a finance endpoint discovery map covering all EconomicService and MarketService operations.
- Added panel-local method + route tables for Trade Policy, Supply Chain, Route Explorer, Hormuz, Energy Crisis, Financial Stress, Stock Analysis, and Stock Backtest.
- Corrected stale availability and gating wording for Trade Policy and Supply Chain variants, including tariff/Comtrade premium paths.

## Validation

- `git diff --check`
- Proto route coverage script: all Economic, Market, Trade, and SupplyChain routes are mentioned in changed human docs.
- `npm run docs:check`
- `npm run lint:mintlify-slugs`
- Not run: `npm run lint:md` because this isolated worktree has no `node_modules`; the focused docs checks above passed.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is a docs-only change; after deployment, spot-check the Mintlify-rendered `/finance-data`, `/panels/trade-policy`, `/panels/supply-chain`, and `/route-explorer` pages for table wrapping and route readability.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
