### PR TITLE
docs(api): expose aviation and intelligence endpoints

### DIFF
--- a/docs/ai-intelligence.mdx
+++ b/docs/ai-intelligence.mdx
@@ -143,6 +143,14 @@ Every news item passes through a three-stage classification pipeline:
 
 This hybrid approach means the UI is never blocked waiting for AI — users see keyword results instantly, with ML and LLM refinements arriving within seconds and persisting for all subsequent visitors. Each classification carries its `source` tag (`keyword`, `ml`, or `llm`) so downstream consumers can weight confidence accordingly.
 
+### Backed by endpoints
+
+| Surface | Endpoint | Notes |
+|---|---|---|
+| Event classification | `GET /api/intelligence/v1/classify-event` | Direct REST RPC used by the generated client; server results are cached by headline hash. |
+| Country factual context | `GET /api/intelligence/v1/get-country-facts` | RestCountries / Wikipedia context for country-brief and dossier workflows. |
+| Summary cache lookup | `GET /api/news/v1/summarize-article-cache` | CDN-cacheable lookup for deterministic summary keys; generation remains `POST /api/news/v1/summarize-article`. |
+
 ## Alerts
 
 ### Breaking News Alert Pipeline

--- a/docs/country-instability-index.mdx
+++ b/docs/country-instability-index.mdx
@@ -137,6 +137,15 @@ minutes against the same RPC. That keeps the server-side risk-score cache warm
 for bootstrap and health monitoring while preserving the RPC handler as the
 scoring source of truth.
 
+### Backed by endpoints
+
+| Related input | Endpoint | Notes |
+|---|---|---|
+| CII / Strategic Risk scores | `GET /api/intelligence/v1/get-risk-scores` | Server-side scoring source of truth, warmed by the relay loop. |
+| Country humanitarian summary | `GET /api/conflict/v1/get-humanitarian-summary` | HAPI/HDX country overview for conflict-context workflows. |
+| Batch humanitarian summaries | `POST /api/conflict/v1/get-humanitarian-summary-batch` | Batch lookup for multiple countries; POST because the request carries a country list. |
+| Population exposure | `GET /api/displacement/v1/get-population-exposure` | Country population data or radius-based exposure estimate used by humanitarian and map workflows. |
+
 ## Trend Detection
 
 The server publishes `dynamicScore` as a signed movement delta in the range

--- a/docs/maritime-intelligence.mdx
+++ b/docs/maritime-intelligence.mdx
@@ -51,6 +51,13 @@ The system monitors for AIS gaps, vessels that stop transmitting their position.
 
 Vessels reappearing after gaps are flagged for the duration of the session.
 
+## Backed by endpoints
+
+| Surface | Endpoint | Notes |
+|---|---|---|
+| Vessel snapshot | `GET /api/maritime/v1/get-vessel-snapshot` | Civilian AIS point-in-time view for traffic and disruption context. |
+| Navigational warnings | `GET /api/maritime/v1/list-navigational-warnings` | NGA maritime safety warnings used by chokepoint and undersea-cable awareness. |
+
 ## WebSocket Architecture
 
 AIS data flows through a WebSocket relay for real-time updates without polling:

--- a/docs/maritime-intelligence.mdx
+++ b/docs/maritime-intelligence.mdx
@@ -51,7 +51,7 @@ The system monitors for AIS gaps, vessels that stop transmitting their position.
 
 Vessels reappearing after gaps are flagged for the duration of the session.
 
-## Backed by endpoints
+### Backed by endpoints
 
 | Surface | Endpoint | Notes |
 |---|---|---|

--- a/docs/orbital-surveillance.mdx
+++ b/docs/orbital-surveillance.mdx
@@ -116,6 +116,13 @@ Client-side fetch uses a circuit breaker: 3 consecutive failures trigger a 10-mi
 - `api/health.js` checks `intelligence:satellites:tle:v1` as a standalone key
 - Seed metadata checked with `maxStaleMin: 180` (3h — survives 1 missed cycle)
 
+### Backed by endpoints
+
+| Surface | Endpoint | Notes |
+|---|---|---|
+| Satellite TLE mirror | `GET /api/intelligence/v1/list-satellites` | Generated IntelligenceService RPC reading `intelligence:satellites:tle:v1`; the current renderer still uses the legacy `api/satellites.js` path listed below. |
+| SAR / optical scene search | `GET /api/imagery/v1/search-imagery` | STAC-backed Sentinel search by `bbox`, `datetime`, `source`, and `limit`, cached per snapped query. |
+
 ---
 
 ## Files

--- a/docs/panels/airline-intel.mdx
+++ b/docs/panels/airline-intel.mdx
@@ -29,14 +29,25 @@ Panel id is `airline-intel`; canonical component is `src/components/AirlineIntel
 
 ## Data sources
 
-Eight RPCs back the six tabs via `@/services/aviation`:
+The panel uses `@/services/aviation`, which wraps the generated
+`AviationServiceClient`. Flight-delay alerts can arrive through bootstrap
+hydration first; the tab-specific calls below are direct REST RPCs.
 
-- `fetchAirportOpsSummary`, `fetchAirportFlights`, `fetchCarrierOps`
-- `fetchAircraftPositions`, `fetchFlightStatus`
-- `fetchAviationNews`
-- `fetchGoogleFlights`, `fetchGoogleDates`
+### Backed by endpoints
 
-All are backed by the **Aviation service** (`/api/aviation/v1/*`) — see the API reference below.
+| Capability | Endpoint | Panel path |
+|---|---|---|
+| Airport delay alerts | `GET /api/aviation/v1/list-airport-delays` | Bootstrap-backed disruption layer and service fallback. |
+| Airport ops summaries | `GET /api/aviation/v1/get-airport-ops-summary` | `ops` tab for watched airports. |
+| Airport flight instances | `GET /api/aviation/v1/list-airport-flights` | `flights` tab for one watched airport. |
+| Carrier delay / cancellation rollups | `GET /api/aviation/v1/get-carrier-ops` | `airlines` tab for watched airports. |
+| Specific flight status | `GET /api/aviation/v1/get-flight-status` | `tracking` tab lookup. |
+| Aircraft position tracking | `GET /api/aviation/v1/track-aircraft` | `tracking` tab and civil-airspace map workflows. |
+| YouTube live stream metadata | `GET /api/aviation/v1/get-youtube-live-stream-info` | Service RPC for aviation live-stream metadata; not part of the six-tab auto-refresh loop. |
+| Legacy flight price quotes | `GET /api/aviation/v1/search-flight-prices` | Direct quote search path with provider/degraded-state metadata. |
+| Aviation news | `GET /api/aviation/v1/list-aviation-news` | `news` tab. |
+| Google Flights itinerary search | `GET /api/aviation/v1/search-google-flights` | `prices` tab explicit search. |
+| Google Flights date grid | `GET /api/aviation/v1/search-google-dates` | `prices` tab cheapest-date grid. |
 
 ## Refresh cadence
 
@@ -52,5 +63,5 @@ Three distinct refresh paths in `src/components/AirlineIntelPanel.ts`:
 
 ## API reference
 
-- [Aviation service](/api/AviationService.openapi.yaml) — 11 RPCs: airport delays, ops summary, airport flights, carrier ops, flight status, aircraft tracking, aviation news, Google Flights search / date grid.
+- [Aviation service](/api/AviationService.openapi.yaml) — generated OpenAPI for the 11 RPCs above.
 - Related map layer: [Military & Civilian Flight Tracking](/military-tracking) for the live flights overlay that the `tracking` tab complements.

--- a/docs/panels/consumer-prices.mdx
+++ b/docs/panels/consumer-prices.mdx
@@ -34,17 +34,20 @@ Panel id is `consumer-prices`; canonical component is `src/components/ConsumerPr
 
 ## Data sources
 
-Five RPCs back the five tabs:
+Five tab RPCs plus one sparkline RPC back the panel:
 
-| Tab | RPC |
+| Surface | RPC |
 |---|---|
 | Overview | `GET /api/consumer-prices/v1/get-consumer-price-overview` |
+| Overview sparkline | `GET /api/consumer-prices/v1/get-consumer-price-basket-series` |
 | Categories | `GET /api/consumer-prices/v1/list-consumer-price-categories` |
 | Movers | `GET /api/consumer-prices/v1/list-consumer-price-movers` |
 | Spread | `GET /api/consumer-prices/v1/list-retailer-price-spreads` |
 | Health | `GET /api/consumer-prices/v1/get-consumer-price-freshness` |
 
-There is also a `get-consumer-price-basket-series` RPC used internally for the sparkline data. Upstream data is scraped from retailer price feeds and aggregated per market.
+Upstream data is scraped from retailer price feeds by the companion
+`consumer-prices-core` service and published as Redis snapshots per market and
+basket.
 
 ## Refresh cadence
 

--- a/docs/panels/news-feeds.mdx
+++ b/docs/panels/news-feeds.mdx
@@ -133,6 +133,17 @@ All free. Stream configuration lives in `src/config/variants/happy.ts`.
 - **Cmd+K discoverability** — each panel is searchable by its title and category.
 - **Free by default** — none of the news-feed panels are PRO-gated.
 
+## Backed by endpoints
+
+| Feed family | Endpoint | Notes |
+|---|---|---|
+| Digest feed | `GET /api/news/v1/list-feed-digest` | Pre-aggregated RSS digest by site variant. |
+| Summary cache lookup | `GET /api/news/v1/summarize-article-cache` | Cache-only GET for deterministic article-summary keys; use `POST /api/news/v1/summarize-article` to generate. |
+| arXiv papers | `GET /api/research/v1/list-arxiv-papers` | ResearchService academic-paper feed. |
+| Trending repos | `GET /api/research/v1/list-trending-repos` | ResearchService GitHub trending feed. |
+| Hacker News items | `GET /api/research/v1/list-hackernews-items` | ResearchService Hacker News feed. |
+| Giving activity | `GET /api/giving/v1/get-giving-summary` | Global personal-giving and philanthropy summary used by happy-variant giving surfaces. |
+
 ## Related
 
 - [Signal Intelligence](/signal-intelligence) — structural overview of how news feeds are classified, deduplicated, and ranked.

--- a/docs/panels/news-feeds.mdx
+++ b/docs/panels/news-feeds.mdx
@@ -133,7 +133,7 @@ All free. Stream configuration lives in `src/config/variants/happy.ts`.
 - **Cmd+K discoverability** — each panel is searchable by its title and category.
 - **Free by default** — none of the news-feed panels are PRO-gated.
 
-## Backed by endpoints
+### Backed by endpoints
 
 | Feed family | Endpoint | Notes |
 |---|---|---|

--- a/docs/panels/oref-sirens.mdx
+++ b/docs/panels/oref-sirens.mdx
@@ -36,7 +36,7 @@ Panel id is `oref-sirens`; canonical component is `src/components/OrefSirensPane
 
 | Surface | Endpoint | Notes |
 |---|---|---|
-| Panel relay path | `/api/oref-alerts` | Current browser path for active sirens and history. |
+| Panel relay path | `GET /api/oref-alerts` | Current browser path for active sirens and history. |
 | Generated service RPC | `GET /api/intelligence/v1/list-oref-alerts` | `mode=MODE_HISTORY` serves Redis history; live mode tries the relay and falls back to cached counts. |
 
 ## Refresh cadence

--- a/docs/panels/oref-sirens.mdx
+++ b/docs/panels/oref-sirens.mdx
@@ -32,6 +32,13 @@ Panel id is `oref-sirens`; canonical component is `src/components/OrefSirensPane
 - `fetchOrefHistory()` in `@/services/oref-alerts` — backed by `/api/oref-alerts` (a Railway relay that mirrors the OREF feed; documented under [Proxies](/api-proxies)).
 - Live sirens are delivered separately via the same relay; the panel's `setData()` path accepts an `OrefAlertsResponse` with the `configured` flag + active alert list.
 
+### Backed by endpoints
+
+| Surface | Endpoint | Notes |
+|---|---|---|
+| Panel relay path | `/api/oref-alerts` | Current browser path for active sirens and history. |
+| Generated service RPC | `GET /api/intelligence/v1/list-oref-alerts` | `mode=MODE_HISTORY` serves Redis history; live mode tries the relay and falls back to cached counts. |
+
 ## Refresh cadence
 
 Real-time for active sirens. History is client-cached for 3 minutes to damp re-fetch on re-render.

--- a/docs/panels/telegram-intel.mdx
+++ b/docs/panels/telegram-intel.mdx
@@ -29,7 +29,7 @@ Panel id is `telegram-intel`; canonical component is `src/components/TelegramInt
 
 | Surface | Endpoint | Notes |
 |---|---|---|
-| Panel relay path | `/api/telegram-feed` | Current browser path for the topic-tabbed feed. |
+| Panel relay path | `GET /api/telegram-feed` | Current browser path for the topic-tabbed feed. |
 | Generated service RPC | `GET /api/intelligence/v1/list-telegram-feed` | Direct IntelligenceService RPC with `topic`, `channel`, and `limit` query parameters; fetches the same Railway relay. |
 
 ## Refresh cadence

--- a/docs/panels/telegram-intel.mdx
+++ b/docs/panels/telegram-intel.mdx
@@ -25,6 +25,13 @@ Panel id is `telegram-intel`; canonical component is `src/components/TelegramInt
 
 - `@/services/telegram-intel` — backed by `/api/telegram-feed` which proxies to a Railway relay that pulls the curated channel set. Channel coverage is curated rather than user-configurable.
 
+### Backed by endpoints
+
+| Surface | Endpoint | Notes |
+|---|---|---|
+| Panel relay path | `/api/telegram-feed` | Current browser path for the topic-tabbed feed. |
+| Generated service RPC | `GET /api/intelligence/v1/list-telegram-feed` | Direct IntelligenceService RPC with `topic`, `channel`, and `limit` query parameters; fetches the same Railway relay. |
+
 ## Refresh cadence
 
 Driven by the relay's poll cycle; the panel reads on mount and on relevant external refresh triggers.

--- a/docs/signal-intelligence.mdx
+++ b/docs/signal-intelligence.mdx
@@ -447,3 +447,12 @@ Convergence Zones: Baltic Sea (military_flight + military_vessel),
 Active Signal Types: 5 of 5
 Total Signals: 47
 ```
+
+## Backed by endpoints
+
+| Signal family | Endpoint | Notes |
+|---|---|---|
+| Company enrichment | `GET /api/intelligence/v1/get-company-enrichment` | Aggregates GitHub, SEC, Hacker News, and inferred stack context for one company. |
+| Company activity signals | `GET /api/intelligence/v1/list-company-signals` | Funding, hiring, expansion, executive, and open-source activity cards. |
+| GDELT topic timeline | `GET /api/intelligence/v1/get-gdelt-topic-timeline` | Tone and volume timeline for an intelligence topic. |
+| Market-implication cards | `GET /api/intelligence/v1/list-market-implications` | AI-generated implication cards from live world state; documented here to avoid duplicating market-domain panel ownership. |

--- a/docs/signal-intelligence.mdx
+++ b/docs/signal-intelligence.mdx
@@ -448,7 +448,7 @@ Active Signal Types: 5 of 5
 Total Signals: 47
 ```
 
-## Backed by endpoints
+### Backed by endpoints
 
 | Signal family | Endpoint | Notes |
 |---|---|---|

--- a/docs/strategic-risk.mdx
+++ b/docs/strategic-risk.mdx
@@ -171,6 +171,17 @@ Each pair shows:
 
 This provides context for the activity levels. A spike at Pentagon locations during a rising China-Taiwan tension score carries different weight than during a quiet period.
 
+### Backed by endpoints
+
+| Surface | Endpoint | Notes |
+|---|---|---|
+| Pentagon Pizza Index + GDELT pairs | `GET /api/intelligence/v1/get-pizzint-status` | Reads the seeded PizzINT cache; `include_gdelt=true` includes tension pairs. |
+| GPS/GNSS interference | `GET /api/intelligence/v1/list-gps-interference` | Reads normalized GPSJam Redis keys, with optional `region` filtering. |
+| OREF alerts for CII context | `GET /api/intelligence/v1/list-oref-alerts` | Direct RPC for live or history OREF data; see [Israel Sirens](/panels/oref-sirens) for the panel relay path. |
+| Security advisories | `GET /api/intelligence/v1/list-security-advisories` | Redis-backed advisory feed used by CII boosts and floors. |
+| Country energy profile | `GET /api/intelligence/v1/get-country-energy-profile` | Country-level energy context for country deep dives and strategic risk analysis. |
+| Energy shock scenario | `GET /api/intelligence/v1/compute-energy-shock` | On-demand country + chokepoint product supply shock. |
+
 ## Related Assets
 
 News clusters are automatically enriched with nearby critical infrastructure. When a story mentions a geographic region, the system identifies relevant assets within 600km, providing immediate operational context.


### PR DESCRIPTION
## Summary

Human-facing docs now list the exact REST RPC paths for AviationService, IntelligenceService, and the remaining long-tail endpoint surfaces, so readers can discover these APIs without jumping straight to generated OpenAPI files. The notes call out direct service RPCs separately from bootstrap, relay, and cache paths where the panel wiring still uses those routes today.

## What changed

- Added a complete Airline Intelligence endpoint table covering all 11 AviationService RPCs.
- Added IntelligenceService discovery tables across the strategic risk, AI intelligence, signal intelligence, OREF, Telegram, and orbital docs.
- Placed long-tail endpoint references in their natural owner pages for consumer prices, humanitarian/displacement, imagery, maritime warnings, news summary cache, research feeds, and giving activity.

## Validation

- Verified endpoint methods and paths against proto/generated service contracts.
- Ran a local coverage check confirming 36/36 requested endpoint strings are present in changed human docs.
- Ran `git diff --check`.
- Ran `npm run docs:check`.

## Post-Deploy Monitoring & Validation

No additional operational monitoring required. This is a docs-only change; validate the deploy by confirming the docs build succeeds and spot-opening the changed endpoint tables in the published docs.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
