### PR TITLE
docs(mcp): clarify REST coverage discovery

### DIFF
--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -37,35 +37,28 @@ Open any group in the sidebar to browse its operations.
 
 ## MCP equivalents
 
-If you've been using the [MCP server](/mcp-server) and want REST equivalents, the relationship isn't always 1:1. Most MCP tools fall into one of three buckets:
+If you're moving between REST and the [MCP server](/mcp-server), treat them as related but distinct catalogs. REST coverage is defined by OpenAPI. MCP coverage is narrower: an endpoint is **MCP-exposed** only when the exact `METHOD /api/...` path is declared in a tool's registry `_apiPaths` entry.
 
-**Bundled cache-reads** — the MCP tool reads multiple Redis keys in one call. There's no single REST RPC that returns the same envelope; instead, REST exposes the underlying domains as fine-grained operations you can mix-and-match. Examples: `get_market_data` (bundles equity / commodity / crypto / sectors / ETF flows / Gulf / fear-greed) → see `list-market-quotes`, `list-commodity-quotes`, `list-crypto-quotes`, `get-sector-summary`, `list-etf-flows`, `list-gulf-quotes`, `get-fear-greed-index` in MarketService. Same shape for `get_economic_data`, `get_country_macro` (IMF WEO macro), and `get_eu_*`.
+Use the [MCP API coverage table](/mcp-server#api-coverage) as the human-facing reverse lookup. It maps each MCP tool to the REST endpoints it explicitly serves. If a REST route is not in that table, it is REST-only as an API equivalence, even if a cache-backed MCP tool returns similar domain data.
 
-**1:1 RPC tools** — the MCP tool wraps a single REST RPC:
+Common shapes:
 
-| MCP tool | REST endpoint |
+- **Declared REST-backed tools** — the tool's registry names one or more exact REST paths, such as `get_market_data` covering market quote and sector endpoints.
+- **Bundled cache reads** — the tool reads one or more pre-seeded Redis keys and may not have a single REST equivalent, such as `get_country_macro`, the EU macro tools, `get_aviation_status`, and `get_cyber_threats`.
+- **Live/composite tools** — the tool fans out, filters geographically, or invokes LLM analysis; use the coverage table for the exact REST paths it claims.
+
+Important non-equivalences:
+
+| REST endpoint | MCP status |
 |---|---|
-| `get_conflict_events` | `/api/conflict/v1/list-acled-events` (also `list-ucdp-events`, `list-iran-events`) |
-| `get_news_intelligence` | `/api/news/v1/list-feed-digest`, `/api/news/v1/summarize-article` |
-| `get_natural_disasters` | `/api/natural/v1/list-natural-events` |
-| `get_military_posture` | `/api/military/v1/list-military-flights`, `/api/military/v1/get-theater-posture` |
-| `get_cyber_threats` | `/api/cyber/v1/list-cyber-threats` |
-| `get_prediction_markets` | `/api/prediction/v1/list-prediction-markets` |
-| `get_sanctions_data` | `/api/sanctions/v1/list-sanctions-pressure`, `/api/sanctions/v1/lookup-sanction-entity` |
-| `get_climate_data` | `/api/climate/v1/list-climate-anomalies`, `/api/climate/v1/get-co2-monitoring`, `/api/climate/v1/get-ocean-ice-data`, `/api/climate/v1/list-air-quality-data`, … |
-| `get_infrastructure_status` | `/api/infrastructure/v1/list-internet-outages`, `/api/infrastructure/v1/list-service-statuses` |
-| `get_supply_chain_data` | `/api/supply-chain/v1/get-shipping-stress`, `/api/supply-chain/v1/get-chokepoint-status`, `/api/supply-chain/v1/get-critical-minerals`, … |
-| `get_positive_events` | `/api/positive-events/v1/list-positive-geo-events` |
-| `get_radiation_data` | `/api/radiation/v1/list-radiation-observations` |
-| `get_research_signals` | `/api/research/v1/list-arxiv-papers`, `/api/research/v1/list-trending-repos`, `/api/research/v1/list-hackernews-items`, `/api/research/v1/list-tech-events` |
-| `get_forecast_predictions` | `/api/forecast/v1/get-forecasts` |
-| `get_maritime_activity` | `/api/maritime/v1/get-vessel-snapshot` |
-| `get_aviation_status` | `/api/aviation/v1/list-airport-delays`, `/api/aviation/v1/track-aircraft`, `/api/aviation/v1/get-flight-status` |
-| `search_flights` / `search_flight_prices_by_date` | `/api/aviation/v1/search-google-flights`, `/api/aviation/v1/search-google-dates` |
+| `GET /api/conflict/v1/list-acled-events` | REST-only. `get_conflict_events` covers `list-iran-events`, `list-ucdp-events`, and `list-unrest-events`, not ACLED. |
+| `GET /api/cyber/v1/list-cyber-threats` | REST-only for now. `get_cyber_threats` is a cache-backed MCP tool with no declared REST path. |
+| `GET /api/infrastructure/v1/list-service-statuses` | REST-only. `get_infrastructure_status` declares `list-internet-outages` only. |
+| `GET /api/supply-chain/v1/get-critical-minerals` | REST-only. `get_supply_chain_data` declares shipping stress and customs revenue only. |
+| `GET /api/research/v1/list-arxiv-papers`, `GET /api/research/v1/list-trending-repos`, `GET /api/research/v1/list-hackernews-items` | REST-only. `get_research_signals` declares `list-tech-events` only. |
+| `GET /api/aviation/v1/list-airport-delays`, `GET /api/aviation/v1/get-flight-status` | REST-only. MCP aviation coverage is via `get_airspace`, flight-search tools, and cache-backed `get_aviation_status`, not these routes. |
 
-**Composite / LLM tools** — `get_world_brief`, `get_country_brief`, `get_country_risk`, `get_airspace`, `analyze_situation`, `generate_forecasts` fan out to multiple REST RPCs and apply LLM synthesis or geographic filtering. There's no single REST equivalent — call the underlying RPCs and combine client-side.
-
-Always cross-check against [the bundled OpenAPI spec](https://www.worldmonitor.app/openapi.yaml) — that's the source of truth for path names, parameters, and response shapes.
+Always cross-check against [the bundled OpenAPI spec](https://www.worldmonitor.app/openapi.yaml) for REST path names, parameters, and response shapes, and against [MCP API coverage](/mcp-server#api-coverage) for MCP exposure.
 
 ## Platform endpoints
 

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -274,7 +274,16 @@ For per-tool parameters, freshness budgets, timeouts, and concrete `curl` exampl
 
 ## API coverage
 
-Most MCP tools wrap one or more REST/RPC endpoints from the [API Reference](/api-reference). The table below maps each covered tool to the API paths it serves — useful when you know the API endpoint you want and need to find the corresponding MCP tool, or vice versa. A handful of tools don't appear in this table because they don't expose a 1:1 public OpenAPI operation — see the trailing note below the table for the categories, and the [MCP Tools Reference](/mcp-tools-reference) for the complete 39-tool set.
+An API endpoint is **MCP-exposed** only when the exact `METHOD /api/...` path is declared in a tool's registry `_apiPaths` entry. The table below is the human-facing rendering of those declarations from `api/mcp/registry/cache-tools.ts` and `api/mcp/registry/rpc-tools.ts`; it is narrower than the public OpenAPI catalog.
+
+A REST route can exist in OpenAPI and still be REST-only. The parity test keeps that distinction explicit: every public OpenAPI operation must either appear in `_apiPaths` or be listed in `tests/mcp-api-parity.test.mjs` with a categorized exclusion reason.
+
+Reverse lookup workflow:
+
+1. Copy the exact method and path from the OpenAPI page, for example `GET /api/research/v1/list-tech-events`.
+2. Search this table. If the route appears, call the listed MCP tool.
+3. If it does not appear, the REST route is not exposed through MCP as an API-equivalent path. A cache-only MCP tool may still return related domain data, but it is not claiming that REST route.
+4. For code-level verification, search `_apiPaths` in `api/mcp/registry/cache-tools.ts` and `api/mcp/registry/rpc-tools.ts`; the parity test explains intentional REST-only exclusions.
 
 | MCP tool | API endpoints served |
 |----------|---------------------|
@@ -309,17 +318,22 @@ Most MCP tools wrap one or more REST/RPC endpoints from the [API Reference](/api
 | `search_flights` | `GET /api/aviation/v1/search-google-flights` |
 | `search_flight_prices_by_date` | `GET /api/aviation/v1/search-google-dates` |
 
-A handful of tools have no entry above because they don't map 1:1 to a public OpenAPI operation. They still return live data via `tools/call`; they fall into three categories:
+Tools with no declared API paths still return data via `tools/call`, but they should not be read as REST equivalents:
 
 - **Cache-backed bootstrap aggregates** — read Redis keys seeded directly by Railway crons (e.g. `get_aviation_status`, `get_cyber_threats`, `get_country_macro`, the three EU Eurostat tools).
 - **Static in-memory registries** — filter a constant bundled with the MCP server's edge binary, no upstream call at all (e.g. `get_commodity_geo`).
 - **Live tools without a public OpenAPI row** — runtime proxies an HTTP call whose method drifts from the public spec, where a sibling tool already covers the spec-declared method (e.g. `generate_forecasts` POSTs `/api/forecast/v1/get-forecasts` while `get_forecast_predictions` owns the GET).
 
-See the [Tool catalog](#tool-catalog) above for the complete list of 39 tools, or the [MCP Tools Reference](/mcp-tools-reference) for per-tool details.
+Common REST-only exclusions in `tests/mcp-api-parity.test.mjs`:
 
-<Tip>
-**Reverse lookup** — if you know the API path you want, search this table with Cmd/Ctrl+F. The same data is also queryable via the running server's `tools/list` response, where each tool description names its domain.
-</Tip>
+- **Mutating endpoints** — writes, queues, webhooks, cache refreshes, or persistent side effects. Example: `GET /api/aviation/v1/list-airport-delays` is intentionally REST-only even though `get_aviation_status` exposes a cache-backed airport-delay snapshot.
+- **Fetch-on-miss endpoints** — may call paid or rate-limited upstreams when cache is cold. Examples: `GET /api/conflict/v1/list-acled-events`, `GET /api/infrastructure/v1/list-service-statuses`, and `GET /api/supply-chain/v1/get-critical-minerals`.
+- **High-cardinality lookups** — arbitrary identifiers are not enumerable or cache-bundle friendly. Example: `GET /api/aviation/v1/get-flight-status`.
+- **LLM-cost endpoints** — direct LLM passthroughs or fetch-on-miss paths with per-call model cost stay out of open MCP exposure unless wrapped by a purpose-built tool.
+- **Deferred future tools** — pure reads whose cache keys are not yet exposed by an MCP bundle. Example: `GET /api/cyber/v1/list-cyber-threats` is slated for a future expanded-domain tool rather than claimed by today's cache-backed `get_cyber_threats`.
+- **Manual mapping** — parameterized cache keys or inline Redis/Convex handlers need human triage. Examples: `GET /api/research/v1/list-arxiv-papers`, `GET /api/research/v1/list-trending-repos`, and `GET /api/research/v1/list-hackernews-items`; `get_research_signals` declares only `GET /api/research/v1/list-tech-events`.
+
+See the [Tool catalog](#tool-catalog) above for the complete list of 39 tools, or the [MCP Tools Reference](/mcp-tools-reference) for per-tool details.
 
 ## Prompts and resources
 

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -326,7 +326,7 @@ Tools with no declared API paths still return data via `tools/call`, but they sh
 
 Common REST-only exclusions in `tests/mcp-api-parity.test.mjs`:
 
-- **Mutating endpoints** — writes, queues, webhooks, cache refreshes, or persistent side effects. Example: `GET /api/aviation/v1/list-airport-delays` is intentionally REST-only even though `get_aviation_status` exposes a cache-backed airport-delay snapshot.
+- **Mutating endpoints** — writes, queues, webhooks, cache refreshes, or persistent side effects. Example: `GET /api/aviation/v1/list-airport-delays` is intentionally REST-only because the GET handler refreshes/persists airport-delay cache state; `get_aviation_status` exposes the already-seeded cache-backed snapshot instead.
 - **Fetch-on-miss endpoints** — may call paid or rate-limited upstreams when cache is cold. Examples: `GET /api/conflict/v1/list-acled-events`, `GET /api/infrastructure/v1/list-service-statuses`, and `GET /api/supply-chain/v1/get-critical-minerals`.
 - **High-cardinality lookups** — arbitrary identifiers are not enumerable or cache-bundle friendly. Example: `GET /api/aviation/v1/get-flight-status`.
 - **LLM-cost endpoints** — direct LLM passthroughs or fetch-on-miss paths with per-call model cost stay out of open MCP exposure unless wrapped by a purpose-built tool.

--- a/docs/mcp-tools-reference.mdx
+++ b/docs/mcp-tools-reference.mdx
@@ -27,7 +27,7 @@ If you've completed the OAuth flow instead, replace `-H "X-WorldMonitor-Key: $WM
 
 ## Discovering tools
 
-Before diving into the per-tool reference, two affordances make discovery cheaper than reading this page top-to-bottom.
+Before diving into the per-tool reference, two affordances make discovery cheaper than reading this page top-to-bottom. If you are starting from a REST route instead of a tool name, use the [API coverage table](/mcp-server#api-coverage); per-tool **API endpoints** lines mean exact `_apiPaths` declarations, while `none directly` means the tool returns data without claiming an equivalent REST route.
 
 ### `describe_tool` — full uncompressed definition on demand
 


### PR DESCRIPTION
## Summary
MCP/API docs now distinguish exact MCP-exposed REST paths from broader REST-only API coverage. Readers starting from a REST route get a reverse lookup path through the MCP coverage table, and the docs no longer imply that cache-backed domain tools cover endpoints that are intentionally excluded from MCP parity.

The stale equivalence examples called out in the audit are now labeled REST-only where appropriate: ACLED, cyber threats, infrastructure service statuses, critical minerals, arXiv/trending/Hacker News feeds, airport delays, and flight status.

## Validation
- `git diff --check`
- `npm run docs:check`
- Compared the MCP coverage table against registry `_apiPaths`; all 30 tools with declared REST paths matched.

## Post-Deploy Monitoring & Validation
No additional operational monitoring required. This is documentation-only and does not change runtime code, API behavior, or MCP tool registration.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
