### PR TITLE
docs: document military infrastructure webcam endpoints

### DIFF
--- a/docs/infrastructure-cascade.mdx
+++ b/docs/infrastructure-cascade.mdx
@@ -73,7 +73,7 @@ Alternative Routes: SEA-ME-WE 6 (11%), 2Africa (8%), Falcon (8%)
 
 The dashboard monitors real-time cable operations and advisories from official maritime warning systems, providing early warning of potential connectivity disruptions.
 
-### Backed by endpoint
+### Backed by endpoints
 
 | Method | Route | What it feeds |
 |--------|-------|---------------|

--- a/docs/infrastructure-cascade.mdx
+++ b/docs/infrastructure-cascade.mdx
@@ -73,6 +73,12 @@ Alternative Routes: SEA-ME-WE 6 (11%), 2Africa (8%), Falcon (8%)
 
 The dashboard monitors real-time cable operations and advisories from official maritime warning systems, providing early warning of potential connectivity disruptions.
 
+### Backed by endpoint
+
+| Method | Route | What it feeds |
+|--------|-------|---------------|
+| `GET` | `/api/infrastructure/v1/get-cable-health` | Cable health map/tooltips and cascade context. `fetchCableHealth()` calls this RPC when the cable layer is active, keeps a 1-minute local cache, and the server response is backed by Redis plus NGA warning analysis. |
+
 ### Data Sources
 
 | Source | Coverage | Data Type |

--- a/docs/military-tracking.mdx
+++ b/docs/military-tracking.mdx
@@ -15,7 +15,7 @@ The frontend uses generated MilitaryService clients for fresh or scoped reads, w
 | Method | Route | What it feeds |
 |--------|-------|---------------|
 | `GET` | `/api/military/v1/list-military-flights` | Military aircraft map layer, surge inputs, and country-risk signals; the frontend calls it by bounding box through the generated client and the handler serves Redis/relay-backed data. |
-| `GET` | `/api/military/v1/get-theater-posture` | AI Strategic Posture cards; `fetchCachedTheaterPosture()` reads bootstrap `theaterPosture` first, then falls back to this cached RPC. |
+| `GET` | `/api/military/v1/get-theater-posture` | AI Strategic Posture cards; `fetchCachedTheaterPosture()` checks bootstrap `theaterPosture`, circuit-breaker cache, and IndexedDB before falling through to this RPC. |
 | `GET` | `/api/military/v1/get-aircraft-details` | Single-aircraft Wingbits enrichment for map popups and aircraft detail lookups. |
 | `POST` | `/api/military/v1/get-aircraft-details-batch` | Batched Wingbits enrichment for visible military aircraft; the browser keeps a local cache so repeat views do not refetch the same ICAO24 records. |
 | `GET` | `/api/military/v1/get-wingbits-status` | Wingbits configuration check used before enabling enrichment-dependent UI. |

--- a/docs/military-tracking.mdx
+++ b/docs/military-tracking.mdx
@@ -8,6 +8,22 @@ WorldMonitor provides specialized tracking of military vessels and aircraft, ide
 The system defines **10 active conflict zones** (Iran, Strait of Hormuz, Ukraine, Gaza, South Lebanon, Red Sea, Sudan, Myanmar, Korean DMZ, Pakistan-Afghanistan Border) and **4 military command hotspots** (INDO-PACIFIC, CENTCOM, EUCOM, ARCTIC). Different subsystems group these into theater lists tailored to their specific analysis, so theater counts vary by context throughout this page.
 </Note>
 
+## Backed by endpoints
+
+The frontend uses generated MilitaryService clients for fresh or scoped reads, while some panels first consume bootstrap or circuit-breaker caches. These are the public REST RPC routes behind the military map layers, posture cards, aircraft enrichment, USNI fleet view, and defense R&D tile.
+
+| Method | Route | What it feeds |
+|--------|-------|---------------|
+| `GET` | `/api/military/v1/list-military-flights` | Military aircraft map layer, surge inputs, and country-risk signals; the frontend calls it by bounding box through the generated client and the handler serves Redis/relay-backed data. |
+| `GET` | `/api/military/v1/get-theater-posture` | AI Strategic Posture cards; `fetchCachedTheaterPosture()` reads bootstrap `theaterPosture` first, then falls back to this cached RPC. |
+| `GET` | `/api/military/v1/get-aircraft-details` | Single-aircraft Wingbits enrichment for map popups and aircraft detail lookups. |
+| `POST` | `/api/military/v1/get-aircraft-details-batch` | Batched Wingbits enrichment for visible military aircraft; the browser keeps a local cache so repeat views do not refetch the same ICAO24 records. |
+| `GET` | `/api/military/v1/get-wingbits-status` | Wingbits configuration check used before enabling enrichment-dependent UI. |
+| `GET` | `/api/military/v1/get-wingbits-live-flight` | On-demand Wingbits ECS live-position lookup for a selected aircraft. |
+| `GET` | `/api/military/v1/get-usni-fleet-report` | Parsed USNI Fleet Tracker report used for naval order-of-battle enrichment and weekly fleet context. |
+| `GET` | `/api/military/v1/list-military-bases` | Military bases map layer; viewport, zoom, type, kind, and country filters are clustered server-side. |
+| `GET` | `/api/military/v1/list-defense-patents` | Defense Patents panel and R&D signal tile, with CPC, assignee, and result-limit filters. |
+
 ## Military Vessel Identification
 
 Vessels are identified as military through multiple methods:

--- a/docs/panels/indicators-and-signals.mdx
+++ b/docs/panels/indicators-and-signals.mdx
@@ -101,6 +101,24 @@ These panels visualise cross-domain correlation over a rolling window — useful
 | `live-webcams` | Live Webcams | See [Webcam layer](/webcam-layer) for the map-layer equivalent. |
 | `windy-webcams` | Windy Live Webcam | Windy.com-backed webcam. |
 
+## Infrastructure-backed endpoints
+
+The compact infrastructure tiles use the generated InfrastructureService client. `internet-disruptions`, DDoS summaries, traffic anomalies, `service-status`, and server-computed temporal anomalies read bootstrap data first when available, then call the REST RPC when bootstrap data is absent, filtered, or stale. Utility routes such as IP geolocation, reverse geocoding, bootstrap cache reads, and baseline writes are data-plane routes rather than standalone tiles.
+
+| Method | Route | What it feeds |
+|--------|-------|---------------|
+| `GET` | `/api/infrastructure/v1/list-internet-outages` | Internet Disruptions map/tile data from Cloudflare Radar; `fetchInternetOutages()` uses bootstrap `outages` first, then this RPC. |
+| `GET` | `/api/infrastructure/v1/list-service-statuses` | Service Status tile; `fetchServiceStatuses()` uses bootstrap `serviceStatuses` first, then this RPC with optional status filtering. |
+| `GET` | `/api/infrastructure/v1/get-cable-health` | Cable layer and infrastructure cascade context; see [Infrastructure Cascade Analysis](/infrastructure-cascade) for the cable-specific workflow. |
+| `GET` | `/api/infrastructure/v1/get-temporal-baseline` | Client-side temporal anomaly checks for metrics such as military flights, vessels, protests, AIS gaps, and satellite fires. |
+| `GET` | `/api/infrastructure/v1/list-temporal-anomalies` | Server-computed temporal anomalies for news and satellite fires; bootstrap `temporalAnomalies` is consumed first, then `fetchLiveAnomalies()` can call this route. |
+| `GET` | `/api/infrastructure/v1/list-internet-ddos-attacks` | DDoS attack summaries from Cloudflare Radar; `fetchDdosAttacks()` uses bootstrap `ddosAttacks` first, then this RPC. |
+| `GET` | `/api/infrastructure/v1/list-internet-traffic-anomalies` | Traffic anomaly events from Cloudflare Radar; bootstrap `trafficAnomalies` is used for the unfiltered view, while country-filtered reads call this RPC. |
+| `GET` | `/api/infrastructure/v1/get-ip-geo` | Caller IP geolocation utility for infrastructure-aware experiences; no panel hydrates from it directly. |
+| `GET` | `/api/infrastructure/v1/reverse-geocode` | Coordinate-to-place lookup utility for API consumers and v1 callers; some UI paths still use the legacy thin `/api/reverse-geocode` helper. |
+| `GET` | `/api/infrastructure/v1/get-bootstrap-data` | Batch cache read RPC for selected bootstrap/cache keys; complements the top-level bootstrap hydration path. |
+| `POST` | `/api/infrastructure/v1/record-baseline-snapshot` | Background baseline update used by temporal anomaly tracking; it writes observations and does not render a visible tile by itself. |
+
 ## Shared behaviour
 
 - All panels above are **free** unless noted otherwise — none are `premium: 'locked'` in `src/config/panels.ts`.

--- a/docs/panels/strategic-posture.mdx
+++ b/docs/panels/strategic-posture.mdx
@@ -30,6 +30,15 @@ Panel id is `strategic-posture`; canonical component is `src/components/Strategi
 - **Military vessels**: live positions via `@/services/military-vessels` (the same feed that drives the military map layer).
 - **Surge recalculation**: `recalcPostureWithVessels()` in `@/services/military-surge` blends cached baseline with today's vessel positions to produce the displayed `TheaterPostureSummary`.
 
+## Backed by endpoints
+
+The panel does not call every military route directly. It reads bootstrap/cache posture data first, then uses the generated MilitaryService client only when the local posture cache needs a fresh server value.
+
+| Method | Route | What it feeds |
+|--------|-------|---------------|
+| `GET` | `/api/military/v1/get-theater-posture` | Primary posture RPC for the card list. The browser checks bootstrap `theaterPosture`, circuit-breaker cache, and IndexedDB before falling through to this route. |
+| `GET` | `/api/military/v1/list-military-flights` | Source feed for aircraft-driven posture and surge calculations upstream of the cached posture payload; the panel normally consumes the computed posture output rather than refetching flights itself. |
+
 ## Refresh cadence
 
 The panel is not on a polling timer — it fetches on mount and re-renders on relevant external triggers. The underlying posture seed refreshes on the military cron; live vessel positions refresh with the AIS relay.

--- a/docs/webcam-layer.mdx
+++ b/docs/webcam-layer.mdx
@@ -74,6 +74,15 @@ Runtime:
   User pins webcam → localStorage → PinnedWebcamsPanel (2x2 iframe grid)
 ```
 
+### Backed by endpoints
+
+The webcam layer does not hydrate marker or preview data from the bootstrap payload. Viewport reads are direct WebcamService RPC calls against the seeded Redis geo index, and preview/player URLs are fetched only after a user interacts with a marker.
+
+| Method | Route | What it feeds |
+|--------|-------|---------------|
+| `GET` | `/api/webcam/v1/list-webcams` | Map webcam markers and clusters for the current viewport; the handler reads seeded Redis geo/metadata keys and caches clustered viewport responses. |
+| `GET` | `/api/webcam/v1/get-webcam-image` | Tooltip preview images and Windy player URLs for a selected camera; the handler calls Windy on demand and caches each webcam image lookup for 5 minutes. |
+
 ### Server-side clustering
 
 The `listWebcams` handler performs server-side spatial clustering based on zoom level. At low zoom, nearby cameras are grouped into cluster markers showing a count. At higher zoom, individual markers appear. This keeps the map performant even when thousands of cameras are in view.


### PR DESCRIPTION
## Summary

Human-facing docs now expose the REST RPC routes behind MilitaryService, InfrastructureService, and WebcamService, so readers can connect dashboard keys and panels to their API endpoints without opening generated OpenAPI specs. The new tables also clarify which frontend paths hydrate from bootstrap/cache first and which call generated RPC clients directly.

## What changed

- Military tracking docs now cover all MilitaryService routes, including flights, theater posture, Wingbits enrichment, USNI fleet reports, bases, and defense patents.
- Infrastructure signal docs now cover all InfrastructureService routes, including outages, service status, cable health, temporal baselines/anomalies, DDoS, traffic anomalies, geocoding, bootstrap cache reads, and baseline writes.
- Webcam docs now cover both WebcamService routes and call out the direct RPC flow through Redis-backed viewport clustering and on-demand Windy image lookups.

## Validation

- `git diff --check`
- `npm run docs:check`
- `npm run lint:mintlify-slugs`

## Post-Deploy Monitoring & Validation

No additional operational monitoring required: this is a docs-only change and does not alter runtime code, APIs, seeders, or deployment configuration. After the docs preview/deploy is available, validate that the updated pages render the endpoint tables and internal docs links successfully; rollback trigger is a docs build failure or broken rendered MDX on the changed pages.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
