### PR TITLE
perf(map): cap mobile overlay density

### DIFF
--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -115,6 +115,8 @@ interface WorldTopology extends Topology {
 }
 
 export class MapComponent {
+  private static readonly MOBILE_MIN_EARTHQUAKE_MAGNITUDE = 5;
+  private static readonly MOBILE_MAX_IRAN_EVENTS = 50;
   private static readonly LAYER_ZOOM_THRESHOLDS: Partial<
     Record<keyof MapLayers, { minZoom: number; showLabels?: number }>
   > = {
@@ -206,6 +208,7 @@ export class MapComponent {
   private destroyed = false;
   // Mobile loads the lighter 110m country topology (U6); passed in from MapContainer.
   private readonly isMobile: boolean;
+  private mobileLabelVisibilityArmed = true;
 
   constructor(container: HTMLElement, initialState: MapState, options: MapComponentOptions = {}) {
     this.container = container;
@@ -213,6 +216,7 @@ export class MapComponent {
     this.hotspots = [...INTEL_HOTSPOTS];
     const chrome = options.chrome ?? true;
     this.isMobile = options.isMobile ?? false;
+    this.mobileLabelVisibilityArmed = !this.isMobile;
 
     this.wrapper = document.createElement('div');
     this.wrapper.className = 'map-wrapper';
@@ -850,6 +854,12 @@ export class MapComponent {
       );
     };
 
+    // Resume mobile label-overlap measurement on the first direct map interaction.
+    this.container.addEventListener('pointerdown', (e) => {
+      if (shouldIgnoreInteractionStart(e.target)) return;
+      this.resumeMobileLabelVisibility();
+    });
+
     // Wheel zoom with smooth delta
     this.container.addEventListener(
       'wheel',
@@ -922,6 +932,7 @@ export class MapComponent {
 
     this.container.addEventListener('touchstart', (e) => {
       if (shouldIgnoreInteractionStart(e.target)) return;
+      this.resumeMobileLabelVisibility();
       cancelAnimationFrame(inertiaRaf);
       const touch1 = e.touches[0];
       const touch2 = e.touches[1];
@@ -1667,7 +1678,10 @@ export class MapComponent {
 
     // Iran events (severity-colored circles matching DeckGL layer)
     if (this.state.layers.iranAttacks && this.iranEvents.length > 0) {
-      this.iranEvents.forEach((ev) => {
+      const iranEventsForRender = this.isMobile
+        ? this.iranEvents.slice(0, MapComponent.MOBILE_MAX_IRAN_EVENTS)
+        : this.iranEvents;
+      iranEventsForRender.forEach((ev) => {
         const pos = projection([ev.longitude, ev.latitude]);
         if (!pos || !Number.isFinite(pos[0]) || !Number.isFinite(pos[1])) return;
 
@@ -1770,9 +1784,12 @@ export class MapComponent {
       const filteredQuakes = this.state.timeRange === 'all'
         ? this.earthquakes
         : this.earthquakes.filter((eq) => eq.occurredAt >= Date.now() - this.getTimeRangeMs());
-      console.log('[Map] After time filter:', filteredQuakes.length, 'earthquakes. TimeRange:', this.state.timeRange);
+      const quakesForRender = this.isMobile
+        ? filteredQuakes.filter((eq) => eq.magnitude >= MapComponent.MOBILE_MIN_EARTHQUAKE_MAGNITUDE)
+        : filteredQuakes;
+      console.log('[Map] After time/mobile filter:', quakesForRender.length, 'earthquakes. TimeRange:', this.state.timeRange);
       let rendered = 0;
-      filteredQuakes.forEach((eq) => {
+      quakesForRender.forEach((eq) => {
         const pos = projection([eq.location?.longitude ?? 0, eq.location?.latitude ?? 0]);
         if (!pos) {
           console.log('[Map] Earthquake position null for:', eq.place, eq.location?.longitude, eq.location?.latitude);
@@ -3901,9 +3918,19 @@ export class MapComponent {
     this.wrapper.style.setProperty('--zoom', String(zoom));
 
     // Smart label hiding based on zoom level and overlap
-    this.updateLabelVisibility(zoom);
+    if (this.shouldUpdateLabelVisibility()) this.updateLabelVisibility(zoom);
     this.updateZoomLayerVisibility();
     this.emitStateChange();
+  }
+
+  private shouldUpdateLabelVisibility(): boolean {
+    return !this.isMobile || this.mobileLabelVisibilityArmed;
+  }
+
+  private resumeMobileLabelVisibility(): void {
+    if (!this.isMobile || this.mobileLabelVisibilityArmed) return;
+    this.mobileLabelVisibilityArmed = true;
+    this.updateLabelVisibility(this.state.zoom);
   }
 
   private updateZoomLayerVisibility(): void {

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -208,7 +208,10 @@ export class MapComponent {
   private destroyed = false;
   // Mobile loads the lighter 110m country topology (U6); passed in from MapContainer.
   private readonly isMobile: boolean;
-  private mobileLabelVisibilityArmed = true;
+  // Desktop measures label overlap from the start; mobile defers until the first
+  // interaction. The effective value is set in the constructor (= !this.isMobile);
+  // false here documents the mobile-off default.
+  private mobileLabelVisibilityArmed = false;
   // All container/document interaction listeners are registered with this signal so
   // destroy() can remove them in one shot. The container node is reused across
   // renderer switches (MapContainer keeps one element and rebuilds MapComponent on it),

--- a/src/components/Map.ts
+++ b/src/components/Map.ts
@@ -209,6 +209,11 @@ export class MapComponent {
   // Mobile loads the lighter 110m country topology (U6); passed in from MapContainer.
   private readonly isMobile: boolean;
   private mobileLabelVisibilityArmed = true;
+  // All container/document interaction listeners are registered with this signal so
+  // destroy() can remove them in one shot. The container node is reused across
+  // renderer switches (MapContainer keeps one element and rebuilds MapComponent on it),
+  // so listeners left attached would retain every destroyed instance forever.
+  private readonly listenerAbort = new AbortController();
 
   constructor(container: HTMLElement, initialState: MapState, options: MapComponentOptions = {}) {
     this.container = container;
@@ -333,6 +338,7 @@ export class MapComponent {
 
   public destroy(): void {
     this.destroyed = true;
+    this.listenerAbort.abort();
     window.removeEventListener('theme-changed', this.handleThemeChange);
     document.removeEventListener('visibilitychange', this.boundVisibilityHandler);
     if (this.resizeObserver) {
@@ -840,6 +846,7 @@ export class MapComponent {
   }
 
   private setupZoomHandlers(): void {
+    const signal = this.listenerAbort.signal;
     let isDragging = false;
     let lastPos = { x: 0, y: 0 };
     let lastTouchDist = 0;
@@ -855,10 +862,14 @@ export class MapComponent {
     };
 
     // Resume mobile label-overlap measurement on the first direct map interaction.
-    this.container.addEventListener('pointerdown', (e) => {
-      if (shouldIgnoreInteractionStart(e.target)) return;
-      this.resumeMobileLabelVisibility();
-    });
+    // Mobile-only: on desktop the flag is always armed, so this would only ever
+    // early-return inside resumeMobileLabelVisibility().
+    if (this.isMobile) {
+      this.container.addEventListener('pointerdown', (e) => {
+        if (shouldIgnoreInteractionStart(e.target)) return;
+        this.resumeMobileLabelVisibility();
+      }, { signal });
+    }
 
     // Wheel zoom with smooth delta
     this.container.addEventListener(
@@ -886,7 +897,7 @@ export class MapComponent {
         }
         this.applyTransform();
       },
-      { passive: false }
+      { passive: false, signal }
     );
 
     // Mouse drag for panning
@@ -898,7 +909,7 @@ export class MapComponent {
         startCountryClickGesture(countryClickGesture, { x: e.clientX, y: e.clientY });
         this.container.style.cursor = 'grabbing';
       }
-    });
+    }, { signal });
 
     document.addEventListener('mousemove', (e) => {
       if (!isDragging) return;
@@ -913,7 +924,7 @@ export class MapComponent {
 
       lastPos = { x: e.clientX, y: e.clientY };
       this.applyTransform();
-    });
+    }, { signal });
 
     document.addEventListener('mouseup', () => {
       if (isDragging) {
@@ -921,7 +932,7 @@ export class MapComponent {
         finishCountryClickGesture(countryClickGesture);
         this.container.style.cursor = 'grab';
       }
-    });
+    }, { signal });
 
     let touchStartPos = { x: 0, y: 0 };
     let touchDragActive = false;
@@ -956,7 +967,7 @@ export class MapComponent {
         touchHistory.length = 0;
         touchHistory.push({ x: touch1.clientX, y: touch1.clientY, t: performance.now() });
       }
-    }, { passive: false });
+    }, { passive: false, signal });
 
     this.container.addEventListener('touchmove', (e) => {
       const touch1 = e.touches[0];
@@ -1007,7 +1018,7 @@ export class MapComponent {
 
         this.applyTransform();
       }
-    }, { passive: false });
+    }, { passive: false, signal });
 
     this.container.addEventListener('touchend', () => {
       if (touchDragActive && touchHistory.length >= 2) {
@@ -1036,7 +1047,7 @@ export class MapComponent {
       touchDragActive = false;
       lastTouchDist = 0;
       touchHistory.length = 0;
-    });
+    }, { signal });
 
     this.container.addEventListener('click', (e) => {
       if (!this.onCountryClick) return;
@@ -1061,7 +1072,7 @@ export class MapComponent {
       if (hit) {
         this.onCountryClick({ lat, lon, code: hit.code, name: hit.name });
       }
-    });
+    }, { signal });
 
     this.container.style.cursor = 'grab';
   }
@@ -3669,11 +3680,15 @@ export class MapComponent {
   public zoomIn(): void {
     this.state.zoom = Math.min(this.state.zoom + 0.5, 10);
     this.applyTransform();
+    // The on-screen +/- controls are excluded by shouldIgnoreInteractionStart, so a
+    // mobile user zooming only via buttons would never arm label thinning otherwise.
+    this.resumeMobileLabelVisibility();
   }
 
   public zoomOut(): void {
     this.state.zoom = Math.max(this.state.zoom - 0.5, 1);
     this.applyTransform();
+    this.resumeMobileLabelVisibility();
   }
 
   public reset(): void {
@@ -3685,6 +3700,7 @@ export class MapComponent {
     } else {
       this.applyTransform();
     }
+    this.resumeMobileLabelVisibility();
   }
 
   public triggerHotspotClick(id: string): void {

--- a/tests/map-mobile-feature-caps.test.mjs
+++ b/tests/map-mobile-feature-caps.test.mjs
@@ -63,7 +63,7 @@ describe('mobile SVG map feature caps and label reflow skip (#4463 / U7)', () =>
   });
 
   it('keeps label overlap measurement disabled on mobile until the first direct map interaction', () => {
-    assert.match(mapSrc, /private mobileLabelVisibilityArmed = true/);
+    assert.match(mapSrc, /private mobileLabelVisibilityArmed = false/);
     assert.match(mapSrc, /this\.mobileLabelVisibilityArmed = !this\.isMobile/);
     assert.match(
       mapSrc,

--- a/tests/map-mobile-feature-caps.test.mjs
+++ b/tests/map-mobile-feature-caps.test.mjs
@@ -1,0 +1,100 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const mapSrc = readFileSync(resolve(root, 'src/components/Map.ts'), 'utf-8');
+
+function sliceBetween(start, end) {
+  const startIdx = mapSrc.indexOf(start);
+  const endIdx = mapSrc.indexOf(end, startIdx + start.length);
+  assert.ok(startIdx >= 0, `missing start marker: ${start}`);
+  assert.ok(endIdx > startIdx, `missing end marker after ${start}: ${end}`);
+  return mapSrc.slice(startIdx, endIdx);
+}
+
+describe('mobile SVG map feature caps and label reflow skip (#4463 / U7)', () => {
+  it('declares the signed-off mobile caps as named constants', () => {
+    assert.match(mapSrc, /private static readonly MOBILE_MIN_EARTHQUAKE_MAGNITUDE = 5/);
+    assert.match(mapSrc, /private static readonly MOBILE_MAX_IRAN_EVENTS = 50/);
+  });
+
+  it('applies the mobile M5.0 earthquake cutoff after the time-range filter and before marker DOM creation', () => {
+    const block = sliceBetween('// Earthquakes (magnitude-based sizing)', '// Economic Centers');
+
+    const timeFilterIdx = block.indexOf('const filteredQuakes =');
+    const mobileFilterIdx = block.indexOf('const quakesForRender = this.isMobile');
+    const markerLoopIdx = block.indexOf('quakesForRender.forEach((eq) => {');
+    const markerDomIdx = block.indexOf("document.createElement('div')");
+
+    assert.ok(timeFilterIdx >= 0, 'earthquake time-range filter should exist');
+    assert.ok(mobileFilterIdx > timeFilterIdx, 'mobile cutoff should run after the time-range filter');
+    assert.ok(markerLoopIdx > mobileFilterIdx, 'marker loop should use the capped render list');
+    assert.ok(markerDomIdx > markerLoopIdx, 'mobile cutoff should run before marker DOM creation');
+    assert.match(
+      block,
+      /filteredQuakes\.filter\(\(eq\) => eq\.magnitude >= MapComponent\.MOBILE_MIN_EARTHQUAKE_MAGNITUDE\)/,
+      'mobile path must filter earthquakes at the named M5.0 threshold',
+    );
+    assert.match(block, /: filteredQuakes;/, 'desktop path must keep the full time-range-filtered list');
+  });
+
+  it('applies the mobile Iran event cap before projection and marker DOM creation', () => {
+    const block = sliceBetween('// Iran events (severity-colored circles matching DeckGL layer)', '// Hotspots');
+
+    const capIdx = block.indexOf('const iranEventsForRender = this.isMobile');
+    const loopIdx = block.indexOf('iranEventsForRender.forEach((ev) => {');
+    const projectionIdx = block.indexOf('const pos = projection([ev.longitude, ev.latitude])');
+    const markerDomIdx = block.indexOf("document.createElement('div')");
+
+    assert.ok(capIdx >= 0, 'Iran render list should be capped on mobile');
+    assert.ok(loopIdx > capIdx, 'Iran marker loop should use the capped render list');
+    assert.ok(projectionIdx > loopIdx, 'Iran cap should run before per-event projection');
+    assert.ok(markerDomIdx > projectionIdx, 'Iran cap should run before marker DOM creation');
+    assert.match(
+      block,
+      /this\.iranEvents\.slice\(0, MapComponent\.MOBILE_MAX_IRAN_EVENTS\)/,
+      'mobile path must cap Iran events at the named 50-event threshold',
+    );
+    assert.match(block, /: this\.iranEvents;/, 'desktop path must keep the full Iran event list');
+  });
+
+  it('keeps label overlap measurement disabled on mobile until the first direct map interaction', () => {
+    assert.match(mapSrc, /private mobileLabelVisibilityArmed = true/);
+    assert.match(mapSrc, /this\.mobileLabelVisibilityArmed = !this\.isMobile/);
+    assert.match(
+      mapSrc,
+      /private shouldUpdateLabelVisibility\(\): boolean \{\s*return !this\.isMobile \|\| this\.mobileLabelVisibilityArmed;\s*\}/,
+      'desktop should keep label measurement enabled while mobile waits for the resume trigger',
+    );
+
+    const applyBlock = sliceBetween('private applyTransform(): void {', 'private shouldUpdateLabelVisibility(): boolean');
+    const guardIdx = applyBlock.indexOf('if (this.shouldUpdateLabelVisibility()) this.updateLabelVisibility(zoom);');
+    const zoomVisibilityIdx = applyBlock.indexOf('this.updateZoomLayerVisibility();');
+    const emitIdx = applyBlock.indexOf('this.emitStateChange();');
+    assert.ok(guardIdx >= 0, 'applyTransform should guard label visibility measurement');
+    assert.ok(zoomVisibilityIdx > guardIdx, 'zoom-layer visibility should still run after the label guard');
+    assert.ok(emitIdx > zoomVisibilityIdx, 'state emission should still run after the label guard');
+  });
+
+  it('resumes mobile label measurement once from valid pointer or touch starts', () => {
+    assert.match(
+      mapSrc,
+      /addEventListener\('pointerdown', \(e\) => \{\s*if \(shouldIgnoreInteractionStart\(e\.target\)\) return;\s*this\.resumeMobileLabelVisibility\(\);\s*\}\)/,
+      'pointerdown should resume label visibility only for direct map interactions',
+    );
+    assert.match(
+      mapSrc,
+      /addEventListener\('touchstart', \(e\) => \{\s*if \(shouldIgnoreInteractionStart\(e\.target\)\) return;\s*this\.resumeMobileLabelVisibility\(\);/,
+      'touchstart should resume label visibility only for direct map interactions',
+    );
+    assert.match(
+      mapSrc,
+      /private resumeMobileLabelVisibility\(\): void \{\s*if \(!this\.isMobile \|\| this\.mobileLabelVisibilityArmed\) return;\s*this\.mobileLabelVisibilityArmed = true;\s*this\.updateLabelVisibility\(this\.state\.zoom\);\s*\}/,
+      'resume should be mobile-only, idempotent, and run one immediate label pass',
+    );
+  });
+});

--- a/tests/map-mobile-feature-caps.test.mjs
+++ b/tests/map-mobile-feature-caps.test.mjs
@@ -83,7 +83,7 @@ describe('mobile SVG map feature caps and label reflow skip (#4463 / U7)', () =>
   it('resumes mobile label measurement once from valid pointer or touch starts', () => {
     assert.match(
       mapSrc,
-      /addEventListener\('pointerdown', \(e\) => \{\s*if \(shouldIgnoreInteractionStart\(e\.target\)\) return;\s*this\.resumeMobileLabelVisibility\(\);\s*\}\)/,
+      /addEventListener\('pointerdown', \(e\) => \{\s*if \(shouldIgnoreInteractionStart\(e\.target\)\) return;\s*this\.resumeMobileLabelVisibility\(\);\s*\}, \{ signal \}\)/,
       'pointerdown should resume label visibility only for direct map interactions',
     );
     assert.match(


### PR DESCRIPTION
## Summary

Mobile SVG maps now avoid the densest U7 first-paint work without changing desktop density. On mobile, sub-M5.0 earthquakes stay out of marker rendering, Iran event markers stop at the first 50 events in the existing order, and label-overlap measurement waits until the first direct map interaction before resuming normally.

Closes koala73/worldmonitor#4463.

## Validation

- `./node_modules/.bin/tsx --test tests/map-mobile-feature-caps.test.mjs`
- `./node_modules/.bin/tsx --test tests/map-mobile-feature-caps.test.mjs tests/map-deferred-overlays.test.mts tests/map-renderer-deferral.test.mjs tests/map-mobile-topology.test.mts`
- `npm run typecheck`
- `env VITE_VARIANT=full ./node_modules/.bin/vite build`
- `npm run test:data` after the Vite build: 11,891 tests, 11,885 pass, 0 fail, 6 skipped
- `npm run lint`

`ce-code-review` was not run because this Codex harness exposes subagents only when the user explicitly asks for subagent delegation. I performed a manual diff review against the plan requirements and found no actionable issues.

## Performance Evidence

Local fallback harness, not authoritative PSI: `node scripts/measure-mobile-mainthread.mjs http://127.0.0.1:4173/dashboard?wm_lcp_debug=1 --cpu 4 --settle 15000 --json`, iPhone 14 Pro Max emulation, n=3, 2026-06-30.

| Sample | Long tasks | Script-TBT ms | Total DOM nodes | Map SVG nodes | LCP ms |
|---|---:|---:|---:|---:|---:|
| 1 | 31 | 15,891 | 1,572 | 238 | 2,252 |
| 2 | 35 | 19,317 | 1,391 | 61 | 10,440 |
| 3 | 29 | 15,519 | 1,572 | 238 | 1,936 |

Median local DOM signal: 1,572 total nodes and 238 map SVG nodes. The local long-task/TBT samples were host-contended and should be treated only as relative fallback evidence, per `docs/perf/mobile-mainthread-baseline-2026-06-27.md`. PSI mobile median-of-3 still needs to be retaken after deploy for the headline `styleLayout`, TBT, and main-thread comparison.

## Post-Deploy Monitoring & Validation

- Validation window: first production deploy plus 24 hours.
- Owner: PR author / next deploy watcher.
- Log searches: Sentry and browser console events containing `Map`, `updateLabelVisibility`, `earthquake-marker`, `iran-event-marker`, `TypeError`, or `getBoundingClientRect` on `/dashboard` mobile sessions.
- Metrics to watch: PageSpeed Insights mobile median-of-3 for `/dashboard`; Lighthouse `styleLayout`, TBT, `mainthread-work`, and `bootup-time`; Web Vitals / INP if available; Sentry frontend error rate for map interactions.
- Healthy signals: mobile map renders M5.0+ earthquakes and capped Iran events; labels resume after the first pan/touch; no new map interaction errors; PSI `styleLayout` and TBT do not regress versus the U2 baseline.
- Failure signals and rollback trigger: mobile map markers missing signed-off M5.0+ events, labels never recovering after interaction, new frontend error spike tied to map rendering, or PSI/Lighthouse showing a clear main-thread regression. Roll back this commit or disable the mobile caps while preserving the desktop path.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
