### PR TITLE
fix(badge): tear down findings modal on destroy

### DIFF
--- a/src/components/IntelligenceGapBadge.ts
+++ b/src/components/IntelligenceGapBadge.ts
@@ -67,6 +67,8 @@ export class IntelligenceFindingsBadge {
   private popupEnabled: boolean;
   private contextMenu: HTMLElement | null = null;
   private contextMenuDismissListener: (() => void) | null = null;
+  private findingsModalOverlay: HTMLElement | null = null;
+  private findingsModalEscListener: ((e: KeyboardEvent) => void) | null = null;
   private updateEpoch = 0;
   private destroyed = false;
 
@@ -545,10 +547,10 @@ export class IntelligenceFindingsBadge {
       </div>
     `, "legacy direct innerHTML migration"));
 
-    const closeOverlay = () => {
-      overlay.remove();
-      document.removeEventListener('keydown', onEsc);
-    };
+    // Replace any modal already open so we never leak more than one overlay
+    // or its document-level Esc listener.
+    this.dismissFindingsModal();
+    const closeOverlay = () => this.dismissFindingsModal();
     const onEsc = (e: KeyboardEvent) => {
       if (e.key === 'Escape') closeOverlay();
     };
@@ -559,6 +561,8 @@ export class IntelligenceFindingsBadge {
       }
     });
     document.addEventListener('keydown', onEsc);
+    this.findingsModalOverlay = overlay;
+    this.findingsModalEscListener = onEsc;
 
     // Handle clicking individual items
     overlay.querySelectorAll('.findings-modal-item').forEach(item => {
@@ -581,6 +585,17 @@ export class IntelligenceFindingsBadge {
     document.body.appendChild(overlay);
   }
 
+  private dismissFindingsModal(): void {
+    if (this.findingsModalEscListener) {
+      document.removeEventListener('keydown', this.findingsModalEscListener);
+      this.findingsModalEscListener = null;
+    }
+    if (this.findingsModalOverlay) {
+      this.findingsModalOverlay.remove();
+      this.findingsModalOverlay = null;
+    }
+  }
+
   public destroy(): void {
     this.destroyed = true;
     this.updateEpoch++;
@@ -591,6 +606,7 @@ export class IntelligenceFindingsBadge {
       cancelAnimationFrame(this.pendingUpdateFrame);
     }
     this.dismissContextMenu();
+    this.dismissFindingsModal();
     document.removeEventListener('wm:intelligence-updated', this.boundUpdate);
     document.removeEventListener('click', this.boundCloseDropdown);
     this.badge.remove();

--- a/tests/intelligence-gap-badge-polling.test.mts
+++ b/tests/intelligence-gap-badge-polling.test.mts
@@ -24,10 +24,18 @@ describe('IntelligenceGapBadge teardown', () => {
   });
 
   it('dismissFindingsModal removes the document keydown listener and the overlay', () => {
+    const idx = src.indexOf('private dismissFindingsModal(): void');
+    assert.notEqual(idx, -1, 'dismissFindingsModal() must exist');
+    const body = src.slice(idx, idx + 400);
     assert.match(
-      src,
-      /private dismissFindingsModal\(\): void \{[\s\S]*?removeEventListener\('keydown', this\.findingsModalEscListener\)[\s\S]*?this\.findingsModalOverlay\.remove\(\)[\s\S]*?\}/,
-      'dismissFindingsModal must tear down both the keydown listener and the overlay element',
+      body,
+      /removeEventListener\(\s*'keydown'\s*,\s*this\.findingsModalEscListener\b/,
+      'dismissFindingsModal must remove the document keydown (Esc) listener',
+    );
+    assert.match(
+      body,
+      /this\.findingsModalOverlay\??\.remove\(\)/,
+      'dismissFindingsModal must remove the overlay element',
     );
   });
 

--- a/tests/intelligence-gap-badge-polling.test.mts
+++ b/tests/intelligence-gap-badge-polling.test.mts
@@ -16,3 +16,23 @@ describe('IntelligenceGapBadge polling', () => {
     );
   });
 });
+
+describe('IntelligenceGapBadge teardown', () => {
+  it('tracks the findings modal overlay and its Esc listener on the instance', () => {
+    assert.match(src, /this\.findingsModalOverlay = overlay;/, 'showAllFindings must store the overlay on the instance');
+    assert.match(src, /this\.findingsModalEscListener = onEsc;/, 'showAllFindings must store the Esc listener on the instance');
+  });
+
+  it('dismissFindingsModal removes the document keydown listener and the overlay', () => {
+    assert.match(
+      src,
+      /private dismissFindingsModal\(\): void \{[\s\S]*?removeEventListener\('keydown', this\.findingsModalEscListener\)[\s\S]*?this\.findingsModalOverlay\.remove\(\)[\s\S]*?\}/,
+      'dismissFindingsModal must tear down both the keydown listener and the overlay element',
+    );
+  });
+
+  it('destroy tears down an open findings modal so it cannot outlive the badge', () => {
+    const destroyBody = src.slice(src.indexOf('public destroy(): void'));
+    assert.match(destroyBody, /this\.dismissFindingsModal\(\);/, 'destroy() must dismiss the findings modal');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a pre-existing DOM/listener leak in `IntelligenceGapBadge` surfaced during review of #4540 (out of scope there, deferred to this follow-up).

`showAllFindings()` appended a modal overlay to `document.body` and registered a document-level `keydown` (Esc) listener, neither tracked on the instance. If the modal was open when the badge was destroyed — e.g. a same-document re-init (HMR/SPA/tests) while the user had it open — the overlay stayed in the DOM and the listener leaked.

The fix tracks the open overlay and its Esc listener as instance fields, adds a `dismissFindingsModal()` helper, and calls it from `destroy()`. Opening a new modal now also dismisses any prior one, so at most one overlay/listener can exist at a time (mirrors the existing `dismissContextMenu()` pattern).

## Type of change

- [x] Bug fix

## Affected areas

- [x] Other: Desktop intelligence findings badge (`IntelligenceGapBadge`)

## Checklist

- [x] No API keys or secrets committed
- [x] TypeScript compiles without errors (`npm run typecheck`)
- [x] Added a source-contract regression test (`tests/intelligence-gap-badge-polling.test.mts`) asserting the modal + Esc listener are tracked and torn down in `destroy()`

## Documentation Alignment Checklist

N/A — no documentation, methodology, or API/MCP contract claims are changed.

## Verification

- `./node_modules/.bin/tsx --test tests/intelligence-gap-badge-polling.test.mts` (4 pass, 0 fail)
- `npm run typecheck` (exit 0)
- `biome lint` on changed files (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018KFRYrvELKcThapVubLfPY)_