### PR TITLE
perf(map): defer-data INP groundwork — timing + commit nucleus (#4558)

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -152,6 +152,7 @@ import { pinWebcam, isPinned } from '@/services/webcams/pinned-store';
 import type { WebcamEntry, WebcamCluster } from '@/generated/client/worldmonitor/webcam/v1/service_client';
 import { fetchWebcamImage } from '@/services/webcams';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
+import { summarizeRenderTiming, formatRenderTiming } from '@/components/map/render-timing';
 import {
   createCountryClickGestureTracker,
   finishCountryClickGesture,
@@ -5747,13 +5748,20 @@ export class DeckGLMap {
   private updateLayers(): void {
     if (this.renderPaused || this.webglLost || !this.maplibreMap) return;
     const startTime = performance.now();
+    let jsBuild = 0;
+    let layerCount = 0;
     try {
-      this.deckOverlay?.setProps({ layers: this.buildLayers() });
+      const buildStart = performance.now();
+      const built = this.buildLayers();
+      jsBuild = performance.now() - buildStart;
+      layerCount = built.length;
+      this.deckOverlay?.setProps({ layers: built });
     } catch { /* map may be mid-teardown (null.getProjection) */ }
     this.maplibreMap.triggerRepaint();
-    const elapsed = performance.now() - startTime;
-    if (import.meta.env.DEV && elapsed > 16) {
-      console.warn(`[DeckGLMap] updateLayers took ${elapsed.toFixed(2)}ms (>16ms budget)`);
+    if (import.meta.env.DEV) {
+      // Attribute a slow frame to our JS build vs deck.gl's commit (#4558).
+      const summary = summarizeRenderTiming({ total: performance.now() - startTime, jsBuild, layerCount });
+      if (summary.overBudget) console.warn(formatRenderTiming(summary));
     }
     this.updateZoomHints();
   }

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -5757,12 +5757,14 @@ export class DeckGLMap {
       layerCount = built.length;
       this.deckOverlay?.setProps({ layers: built });
     } catch { /* map may be mid-teardown (null.getProjection) */ }
-    this.maplibreMap.triggerRepaint();
     if (import.meta.env.DEV) {
       // Attribute a slow frame to our JS build vs deck.gl's commit (#4558).
+      // Sample total BEFORE triggerRepaint() so the deckCommit bucket isolates
+      // setProps tessellation and doesn't absorb the repaint-schedule cost.
       const summary = summarizeRenderTiming({ total: performance.now() - startTime, jsBuild, layerCount });
       if (summary.overBudget) console.warn(formatRenderTiming(summary));
     }
+    this.maplibreMap.triggerRepaint();
     this.updateZoomHints();
   }
 

--- a/src/components/map/deferred-layer-commit.ts
+++ b/src/components/map/deferred-layer-commit.ts
@@ -52,8 +52,11 @@ export class DeferredHeavyCommit<T> {
   stage(key: string, data: T): void {
     this.pending.set(key, data);
     if (this.equals(data, this.committed.get(key))) {
-      // No real change for this key; don't schedule on its account.
+      // No real change for this key; don't schedule on its account. If this
+      // empties the pending set, drop any flush a prior stage() scheduled so
+      // hasPending() doesn't report a flush that would commit nothing.
       this.pending.delete(key);
+      if (this.pending.size === 0) this.clearHandle();
       return;
     }
     this.scheduleFlush();

--- a/src/components/map/deferred-layer-commit.ts
+++ b/src/components/map/deferred-layer-commit.ts
@@ -1,0 +1,116 @@
+/**
+ * Two-phase heavy-layer data commit for DeckGLMap (#4558 / #4537).
+ *
+ * The interaction-attributed render frame must not synchronously tessellate a
+ * heavy deck.gl layer (conflict-zone GeoJson, Supercluster cluster layers). This
+ * gate models the *scheduling and per-layer data state* of a two-phase commit,
+ * deliberately free of any DOM/deck.gl/WebGL dependency so it is unit-testable
+ * under `tsx --test`:
+ *
+ *   - Phase 1 (immediate): the render builds each heavy layer with its
+ *     PREVIOUSLY-committed data via `present(key)` — so an already-visible layer
+ *     never blanks (R2 no-flicker); a first build has no previous data and shows
+ *     empty for one frame (R3, stable id, acceptable since it was not visible).
+ *   - Phase 2 (deferred): a coalesced, teardown-guarded flush moves staged data
+ *     to committed and calls `onCommit(changedKeys)`, which the owner uses to run
+ *     a second render carrying the real heavy data — off the interaction frame.
+ *
+ * The owner (DeckGLMap) wires `schedule` to `yieldToMain`, `isAlive` to the
+ * `!renderPaused && !webglLost && maplibreMap` guard, and `onCommit` to a
+ * deferred `updateLayers`. This module owns none of that — only the state machine.
+ */
+
+export interface DeferredCommitDeps<T> {
+  /**
+   * Schedule the deferred flush to run later (e.g. `yieldToMain`/`setTimeout(0)`).
+   * Returns a cancel handle so a superseding stage can coalesce.
+   */
+  schedule: (run: () => void) => () => void;
+  /** True while the map can still receive a commit (not paused/destroyed/WebGL-lost). */
+  isAlive: () => boolean;
+  /** Called on the deferred flush with the heavy-layer keys whose data changed. */
+  onCommit: (changedKeys: string[]) => void;
+  /** Equality used to decide whether staged data differs from committed (default `Object.is`). */
+  equals?: (a: T | undefined, b: T | undefined) => boolean;
+}
+
+export class DeferredHeavyCommit<T> {
+  private readonly committed = new Map<string, T>();
+  private readonly pending = new Map<string, T>();
+  private cancelHandle: (() => void) | null = null;
+  private readonly equals: (a: T | undefined, b: T | undefined) => boolean;
+
+  constructor(private readonly deps: DeferredCommitDeps<T>) {
+    this.equals = deps.equals ?? ((a, b) => Object.is(a, b));
+  }
+
+  /**
+   * Stage a heavy layer's newly-available data. If it differs from what is
+   * currently committed, schedule a coalesced deferred flush. A burst of stage()
+   * calls before the flush runs collapses to a single flush.
+   */
+  stage(key: string, data: T): void {
+    this.pending.set(key, data);
+    if (this.equals(data, this.committed.get(key))) {
+      // No real change for this key; don't schedule on its account.
+      this.pending.delete(key);
+      return;
+    }
+    this.scheduleFlush();
+  }
+
+  /** Data to present for `key` on the immediate (Phase 1) render: the last committed value, or undefined on first build. */
+  present(key: string): T | undefined {
+    return this.committed.get(key);
+  }
+
+  /** Whether a deferred flush is currently scheduled. */
+  hasPending(): boolean {
+    return this.cancelHandle !== null;
+  }
+
+  /** Keys currently staged but not yet committed (for assertions/diagnostics). */
+  pendingKeys(): string[] {
+    return [...this.pending.keys()];
+  }
+
+  /**
+   * Run any scheduled flush immediately. Honors the teardown guard: if the map
+   * is no longer alive, the flush is dropped without committing (R4).
+   */
+  flushNow(): void {
+    this.clearHandle();
+    if (this.pending.size === 0) return;
+    if (!this.deps.isAlive()) {
+      // Teardown between schedule and flush — drop staged data, commit nothing.
+      this.pending.clear();
+      return;
+    }
+    const changed: string[] = [];
+    for (const [key, data] of this.pending) {
+      if (!this.equals(data, this.committed.get(key))) changed.push(key);
+      this.committed.set(key, data);
+    }
+    this.pending.clear();
+    if (changed.length > 0) this.deps.onCommit(changed);
+  }
+
+  /** Drop any scheduled flush and staged data without committing (teardown/destroy). */
+  cancel(): void {
+    this.clearHandle();
+    this.pending.clear();
+  }
+
+  private scheduleFlush(): void {
+    // Coalesce: cancel a prior scheduled flush and reschedule one.
+    this.clearHandle();
+    this.cancelHandle = this.deps.schedule(() => this.flushNow());
+  }
+
+  private clearHandle(): void {
+    if (this.cancelHandle) {
+      this.cancelHandle();
+      this.cancelHandle = null;
+    }
+  }
+}

--- a/src/components/map/render-timing.ts
+++ b/src/components/map/render-timing.ts
@@ -1,0 +1,70 @@
+/**
+ * DEV-only render-frame timing attribution for DeckGLMap (#4558 / #4537).
+ *
+ * Pure, dependency-free so it is unit-testable under `tsx --test` without a
+ * DOM/WebGL context. `DeckGLMap.updateLayers()` feeds it the measured parts of a
+ * render frame; `summarizeRenderTiming` splits the cost into the JS-build bucket
+ * (our `buildLayers()` — layer construction + any Supercluster index rebuild that
+ * fires inside it) vs the deck.gl commit bucket (tessellation + attribute
+ * generation inside `setProps`). That distinction is the core #4558 question: is
+ * a slow frame our synchronous JS or deck.gl's intrinsic tessellation?
+ */
+
+/** The 16ms single-frame budget the existing DEV warning checks against. */
+export const FRAME_BUDGET_MS = 16;
+
+export interface RenderTimingParts {
+  /** Total wall-clock for the render frame (performance.now delta). */
+  total: number;
+  /** Time spent in `buildLayers()` (layer construction + in-build Supercluster rebuilds). */
+  jsBuild?: number;
+  /** Number of deck.gl layers committed this frame. */
+  layerCount?: number;
+  /** Heavy layers whose data changed this frame (e.g. conflict-zones, clusters). */
+  changedHeavyLayers?: string[];
+}
+
+export interface RenderTimingSummary {
+  total: number;
+  /** Our synchronous JS cost (`buildLayers`). */
+  jsBuild: number;
+  /** Remainder attributed to the deck.gl commit (tessellation + attributes). */
+  deckCommit: number;
+  layerCount: number;
+  changedHeavyLayers: string[];
+  /** True when the frame exceeded the single-frame budget. */
+  overBudget: boolean;
+}
+
+const clampNonNegative = (n: number | undefined): number =>
+  typeof n === 'number' && Number.isFinite(n) && n > 0 ? n : 0;
+
+/**
+ * Split a measured render frame into attributable buckets. `deckCommit` is the
+ * remainder after the JS build, floored at 0 so a noisy measurement (build
+ * slightly exceeding total) never reports a negative bucket.
+ */
+export function summarizeRenderTiming(parts: RenderTimingParts): RenderTimingSummary {
+  const total = clampNonNegative(parts.total);
+  const jsBuild = Math.min(total, clampNonNegative(parts.jsBuild));
+  return {
+    total,
+    jsBuild,
+    deckCommit: Math.max(0, total - jsBuild),
+    layerCount: clampNonNegative(parts.layerCount),
+    changedHeavyLayers: parts.changedHeavyLayers ? [...parts.changedHeavyLayers] : [],
+    overBudget: total > FRAME_BUDGET_MS,
+  };
+}
+
+/** Compact one-line DEV log string for a slow frame. */
+export function formatRenderTiming(summary: RenderTimingSummary): string {
+  const heavy = summary.changedHeavyLayers.length
+    ? ` changed=[${summary.changedHeavyLayers.join(',')}]`
+    : '';
+  return (
+    `[DeckGLMap] render ${summary.total.toFixed(1)}ms ` +
+    `(jsBuild ${summary.jsBuild.toFixed(1)} / ` +
+    `deck ${summary.deckCommit.toFixed(1)}) layers=${summary.layerCount}${heavy}`
+  );
+}

--- a/tests/deckgl-deferred-commit.test.mts
+++ b/tests/deckgl-deferred-commit.test.mts
@@ -1,0 +1,160 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { DeferredHeavyCommit } from '../src/components/map/deferred-layer-commit.ts';
+
+/** Controllable scheduler: captures the queued flush so the test fires it deterministically. */
+function makeScheduler() {
+  let queued: (() => void) | null = null;
+  let scheduleCount = 0;
+  let cancelCount = 0;
+  return {
+    schedule: (run: () => void) => {
+      queued = run;
+      scheduleCount += 1;
+      return () => {
+        cancelCount += 1;
+        queued = null;
+      };
+    },
+    fire: () => {
+      const r = queued;
+      queued = null;
+      r?.();
+    },
+    get pending() {
+      return queued !== null;
+    },
+    get scheduleCount() {
+      return scheduleCount;
+    },
+    get cancelCount() {
+      return cancelCount;
+    },
+  };
+}
+
+describe('DeferredHeavyCommit (#4558 U2 nucleus)', () => {
+  it('coalesces a burst of stages into one deferred flush', () => {
+    const sched = makeScheduler();
+    const commits: string[][] = [];
+    const gate = new DeferredHeavyCommit<number[]>({
+      schedule: sched.schedule,
+      isAlive: () => true,
+      onCommit: (k) => commits.push(k),
+    });
+
+    gate.stage('conflict', [1]);
+    gate.stage('protests', [2]);
+    gate.stage('conflict', [1, 1]); // supersede
+    // Coalesced: prior schedules cancelled, one live flush.
+    assert.ok(gate.hasPending());
+    assert.equal(sched.cancelCount, sched.scheduleCount - 1);
+
+    sched.fire();
+    assert.equal(commits.length, 1);
+    assert.deepEqual(commits[0]!.sort(), ['conflict', 'protests']);
+    assert.ok(!gate.hasPending());
+  });
+
+  it('present() returns previously-committed data (R2 no-flicker), undefined on first build (R3)', () => {
+    const sched = makeScheduler();
+    const gate = new DeferredHeavyCommit<string>({
+      schedule: sched.schedule,
+      isAlive: () => true,
+      onCommit: () => {},
+    });
+
+    // First build: nothing committed yet -> present is undefined (layer shows empty one frame).
+    assert.equal(gate.present('conflict'), undefined);
+
+    gate.stage('conflict', 'A');
+    // Phase 1 of the NEXT render still shows nothing until the deferred flush commits.
+    assert.equal(gate.present('conflict'), undefined);
+    sched.fire();
+    assert.equal(gate.present('conflict'), 'A');
+
+    // A later data change: Phase 1 keeps showing the OLD committed value (no blank).
+    gate.stage('conflict', 'B');
+    assert.equal(gate.present('conflict'), 'A');
+    sched.fire();
+    assert.equal(gate.present('conflict'), 'B');
+  });
+
+  it('drops the flush without committing when the map is torn down (R4)', () => {
+    const sched = makeScheduler();
+    let alive = true;
+    const commits: string[][] = [];
+    const gate = new DeferredHeavyCommit<number>({
+      schedule: sched.schedule,
+      isAlive: () => alive,
+      onCommit: (k) => commits.push(k),
+    });
+
+    gate.stage('conflict', 1);
+    alive = false; // teardown between schedule and flush
+    sched.fire();
+
+    assert.equal(commits.length, 0, 'no commit after teardown');
+    assert.equal(gate.present('conflict'), undefined, 'nothing committed');
+    assert.ok(!gate.hasPending());
+  });
+
+  it('does not schedule when staged data equals committed data', () => {
+    const sched = makeScheduler();
+    const gate = new DeferredHeavyCommit<string>({
+      schedule: sched.schedule,
+      isAlive: () => true,
+      onCommit: () => {},
+      equals: (a, b) => a === b,
+    });
+
+    gate.stage('conflict', 'A');
+    sched.fire();
+    const after = sched.scheduleCount;
+
+    gate.stage('conflict', 'A'); // identical -> no-op
+    assert.equal(sched.scheduleCount, after, 'no new flush scheduled');
+    assert.ok(!gate.hasPending());
+    assert.deepEqual(gate.pendingKeys(), []);
+  });
+
+  it('onCommit reports only the keys whose data actually changed', () => {
+    const sched = makeScheduler();
+    const commits: string[][] = [];
+    const gate = new DeferredHeavyCommit<number>({
+      schedule: sched.schedule,
+      isAlive: () => true,
+      onCommit: (k) => commits.push([...k].sort()),
+      equals: (a, b) => a === b,
+    });
+
+    gate.stage('conflict', 1);
+    gate.stage('protests', 2);
+    sched.fire();
+    assert.deepEqual(commits[0], ['conflict', 'protests']);
+
+    gate.stage('conflict', 1); // unchanged -> filtered before schedule
+    gate.stage('protests', 9); // changed
+    sched.fire();
+    assert.deepEqual(commits[1], ['protests']);
+  });
+
+  it('cancel() drops staged data and any scheduled flush', () => {
+    const sched = makeScheduler();
+    const commits: string[][] = [];
+    const gate = new DeferredHeavyCommit<number>({
+      schedule: sched.schedule,
+      isAlive: () => true,
+      onCommit: (k) => commits.push(k),
+    });
+
+    gate.stage('conflict', 1);
+    assert.ok(gate.hasPending());
+    gate.cancel();
+    assert.ok(!gate.hasPending());
+    assert.deepEqual(gate.pendingKeys(), []);
+    sched.fire(); // nothing queued
+    assert.equal(commits.length, 0);
+  });
+});

--- a/tests/deckgl-deferred-commit.test.mts
+++ b/tests/deckgl-deferred-commit.test.mts
@@ -157,4 +157,53 @@ describe('DeferredHeavyCommit (#4558 U2 nucleus)', () => {
     sched.fire(); // nothing queued
     assert.equal(commits.length, 0);
   });
+
+  it('clears the scheduled flush when the only pending key reverts to its committed value', () => {
+    const sched = makeScheduler();
+    const commits: string[][] = [];
+    const gate = new DeferredHeavyCommit<string>({
+      schedule: sched.schedule,
+      isAlive: () => true,
+      onCommit: (k) => commits.push(k),
+      equals: (a, b) => a === b,
+    });
+
+    gate.stage('conflict', 'A');
+    sched.fire();
+    assert.deepEqual(commits[0], ['conflict']);
+    const cancelsBefore = sched.cancelCount;
+
+    // Real change schedules a flush, then revert it before the flush runs.
+    gate.stage('conflict', 'B');
+    assert.ok(gate.hasPending());
+    gate.stage('conflict', 'A'); // back to committed -> pending empties
+
+    assert.ok(!gate.hasPending(), 'no stale flush once nothing is pending');
+    assert.deepEqual(gate.pendingKeys(), []);
+    assert.equal(sched.pending, false, 'scheduler queue drained');
+    assert.equal(sched.cancelCount, cancelsBefore + 1, 'prior schedule cancelled');
+
+    sched.fire(); // nothing queued -> no extra commit
+    assert.equal(commits.length, 1, 'reverted change commits nothing');
+  });
+
+  it('keeps the scheduled flush when one of several pending keys reverts', () => {
+    const sched = makeScheduler();
+    const commits: string[][] = [];
+    const gate = new DeferredHeavyCommit<string>({
+      schedule: sched.schedule,
+      isAlive: () => true,
+      onCommit: (k) => commits.push([...k].sort()),
+      equals: (a, b) => a === b,
+    });
+
+    gate.stage('conflict', 'A'); // committed empty -> stays pending
+    gate.stage('protests', 'B');
+    gate.stage('conflict', undefined as unknown as string); // committed.get is undefined -> reverts conflict only
+
+    assert.ok(gate.hasPending(), 'flush stays scheduled while protests is pending');
+    assert.deepEqual(gate.pendingKeys(), ['protests']);
+    sched.fire();
+    assert.deepEqual(commits[0], ['protests']);
+  });
 });

--- a/tests/deckgl-render-timing.test.mts
+++ b/tests/deckgl-render-timing.test.mts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  summarizeRenderTiming,
+  formatRenderTiming,
+  FRAME_BUDGET_MS,
+} from '../src/components/map/render-timing.ts';
+
+describe('summarizeRenderTiming (#4558 U1)', () => {
+  it('splits a heavy frame into jsBuild vs deck buckets (happy path)', () => {
+    const s = summarizeRenderTiming({
+      total: 7935,
+      jsBuild: 5200,
+      layerCount: 18,
+      changedHeavyLayers: ['conflict-zones-layer', 'protest-clusters'],
+    });
+    assert.equal(s.total, 7935);
+    assert.equal(s.jsBuild, 5200);
+    assert.equal(s.deckCommit, 7935 - 5200);
+    assert.equal(s.layerCount, 18);
+    assert.deepEqual(s.changedHeavyLayers, ['conflict-zones-layer', 'protest-clusters']);
+    assert.equal(s.overBudget, true);
+  });
+
+  it('returns a zero summary for empty/zero parts without NaN (edge case)', () => {
+    const s = summarizeRenderTiming({ total: 0 });
+    assert.equal(s.total, 0);
+    assert.equal(s.jsBuild, 0);
+    assert.equal(s.deckCommit, 0);
+    assert.equal(s.layerCount, 0);
+    assert.deepEqual(s.changedHeavyLayers, []);
+    assert.equal(s.overBudget, false);
+    assert.ok(!Number.isNaN(s.deckCommit));
+  });
+
+  it('floors deckCommit at 0 when a noisy rebuild measurement exceeds total', () => {
+    const s = summarizeRenderTiming({ total: 100, jsBuild: 140 });
+    // rebuild is clamped to total; deckCommit never goes negative
+    assert.equal(s.jsBuild, 100);
+    assert.equal(s.deckCommit, 0);
+  });
+
+  it('ignores negative / non-finite inputs', () => {
+    const s = summarizeRenderTiming({
+      total: -5,
+      jsBuild: Number.NaN,
+      layerCount: -3,
+    });
+    assert.equal(s.total, 0);
+    assert.equal(s.jsBuild, 0);
+    assert.equal(s.deckCommit, 0);
+    assert.equal(s.layerCount, 0);
+  });
+
+  it('marks frames over the 16ms budget and copies the heavy-layer list defensively', () => {
+    const input = ['conflict-zones-layer'];
+    const s = summarizeRenderTiming({ total: FRAME_BUDGET_MS + 1, changedHeavyLayers: input });
+    assert.equal(s.overBudget, true);
+    input.push('mutated');
+    assert.deepEqual(s.changedHeavyLayers, ['conflict-zones-layer']); // not aliased
+  });
+
+  it('formatRenderTiming renders a compact one-line summary', () => {
+    const line = formatRenderTiming(
+      summarizeRenderTiming({ total: 1200.4, jsBuild: 800, layerCount: 12, changedHeavyLayers: ['x'] }),
+    );
+    assert.match(line, /render 1200\.4ms/);
+    assert.match(line, /jsBuild 800\.0/);
+    assert.match(line, /deck 400\.4/);
+    assert.match(line, /layers=12/);
+    assert.match(line, /changed=\[x\]/);
+  });
+});


### PR DESCRIPTION
## Summary

Groundwork for #4558 (cut map-interaction INP — the warm field-INP cost is presentation-bound, dominated by intermittent multi-second deck.gl render frames). This PR lands the **headless-safe, fully-tested** parts of the plan; the production render-path wiring is browser-gated and left as a checklist (this is a **draft**).

**Landed:**
- **U1 — DEV render-frame timing attribution** (`src/components/map/render-timing.ts`). Splits a slow `updateLayers` frame into `jsBuild` (our `buildLayers`) vs `deckCommit` (deck.gl tessellation inside `setProps`) so the fix's before/after is measurable. DEV-gated only — no production behavior change.
- **U2 nucleus — `DeferredHeavyCommit` state machine** (`src/components/map/deferred-layer-commit.ts`). The DOM-free scheduling + per-layer data logic for the two-phase commit: `present()` returns previously-committed data (R2 no-flicker), a burst of `stage()` coalesces to one deferred flush (KTD3), and the flush drops without committing on teardown (R4). Plan's Execution note calls for this to be extracted and tested first, before any wiring.
- 12 new unit tests (`tests/deckgl-render-timing.test.mts`, `tests/deckgl-deferred-commit.test.mts`), DOM-free (`tsx --test`, no jsdom).

**Why the approach:** the map is deck.gl declarative `interleaved` mode; splitting the layer list across `setProps` (the original issue's suggestion) would flicker + re-tessellate + violate the stable-id invariant the ghost sentinels protect. This defers heavy-layer *data* (stable layer IDs throughout) instead. Full rationale in the issue and its mechanism comment.

## Remaining (browser-gated — not in this PR)

- [ ] **Wire `DeferredHeavyCommit` into `DeckGLMap.updateLayers`/`buildLayers`** — thread it through the heavy layers (conflict GeoJson + the 4 Supercluster cluster layers + bases clusters) and the `layerCache`; move the Supercluster index rebuild into the deferred flush (KTD4).
- [ ] **In-browser verification (R2/R4/race):** enabling conflict zones / a clustered layer paints immediately, heavy layer fills one frame later with no blink of already-visible layers; rapid toggle bursts + teardown leave the map correct; no swallowed interleaved-race warnings.
- [ ] **Resolve the implementation-time unknown:** deck.gl 9.2 empty→real `data` swap on a stable-id layer (expected in-place update; fallback `visible:false` for phase 1).
- [ ] **U3 — lab before/after** using the U1 DEV breakdown (median ≥3 runs); attach the table.

These need a browser session; they were intentionally not done headlessly to avoid blind-refactoring the production render path.

## Test plan

- [x] `typecheck`, `typecheck:api` — pass
- [x] `lint` (biome + safe-html) — pass
- [x] cjs syntax · `version:check` · `lint:md` — pass
- [x] edge-function tests (205/205) + edge bundles (19/19) — pass
- [x] `test:data` — 11865/11873; the **2 failures are the pre-existing `dashboard-critical-css` built-output tests**, which require a `VITE_VARIANT=full vite build` first. The build is itself blocked in this worktree by a stale parent `node_modules` missing `@fontsource` (env issue, not this diff) — CI installs + builds and passes them. This diff touches zero CSS/HTML/build/font files. Both new test suites pass.

Follow-up: #4561 (cap/cluster feature counts — the only path to a bounded <50ms frame). Part of #4537 / #4487.

https://claude.ai/code/session_011htsYLErqJb922Qm9QLraN