### PR TITLE
feat(api): per-tier API rate limits — Phase 1 (per-account burst + usage meter + safety ceiling)

### DIFF
--- a/convex/config/productCatalog.ts
+++ b/convex/config/productCatalog.ts
@@ -34,6 +34,19 @@ export type PlanFeatures = {
    * (fail-closed). Catalog entries below ALWAYS set the field explicitly.
    */
   mcpAccess?: boolean;
+  /**
+   * Per-account daily REST request allowance (the "included" number). Read by
+   * the per-account rate-limit layer (#3199): the daily usage meter counts but
+   * never rejects at this value; the hard safety ceiling is 10× this number.
+   * `-1` means unlimited (no daily meter/ceiling), mirroring `maxDashboards: -1`.
+   *
+   * Optional for the same reason as `mcpAccess`: legacy/cached entitlement rows
+   * predate it. But unlike `mcpAccess`, consumers treat `undefined` as
+   * **no daily limit (fail-OPEN)** — never punish a paying customer for a stale
+   * cache; the 15-min cache + Dodo webhook self-heal. Catalog entries below
+   * ALWAYS set the field explicitly.
+   */
+  apiDailyAllowance?: number;
 };
 
 export interface CatalogEntry {
@@ -60,6 +73,7 @@ const FREE_FEATURES: PlanFeatures = {
   maxDashboards: 3,
   apiAccess: false,
   apiRateLimit: 0,
+  apiDailyAllowance: 0,
   prioritySupport: false,
   exportFormats: ["csv"],
   mcpAccess: false,
@@ -70,6 +84,7 @@ const PRO_FEATURES: PlanFeatures = {
   maxDashboards: 10,
   apiAccess: false,
   apiRateLimit: 0,
+  apiDailyAllowance: 0,
   prioritySupport: false,
   exportFormats: ["csv", "pdf"],
   mcpAccess: true,
@@ -80,6 +95,7 @@ const API_STARTER_FEATURES: PlanFeatures = {
   maxDashboards: 25,
   apiAccess: true,
   apiRateLimit: 60,
+  apiDailyAllowance: 1000,
   prioritySupport: false,
   exportFormats: ["csv", "pdf", "json"],
   mcpAccess: true,
@@ -90,6 +106,7 @@ const API_BUSINESS_FEATURES: PlanFeatures = {
   maxDashboards: 100,
   apiAccess: true,
   apiRateLimit: 300,
+  apiDailyAllowance: 10000,
   prioritySupport: true,
   exportFormats: ["csv", "pdf", "json", "xlsx"],
   mcpAccess: true,
@@ -100,6 +117,7 @@ const ENTERPRISE_FEATURES: PlanFeatures = {
   maxDashboards: -1,
   apiAccess: true,
   apiRateLimit: 1000,
+  apiDailyAllowance: -1,
   prioritySupport: true,
   exportFormats: ["csv", "pdf", "json", "xlsx", "api-stream"],
   mcpAccess: true,
@@ -178,7 +196,8 @@ export const PRODUCT_CATALOG: Record<string, CatalogEntry> = {
     marketingFeatures: [
       "REST API access",
       "Real-time data streams",
-      "1,000 requests/day",
+      "60 requests/minute",
+      "1,000 requests/day included",
       "Webhook notifications",
       "Custom data exports",
     ],
@@ -211,7 +230,13 @@ export const PRODUCT_CATALOG: Record<string, CatalogEntry> = {
     billingPeriod: "monthly",
     tierGroup: "api_business",
     features: API_BUSINESS_FEATURES,
-    marketingFeatures: [],
+    marketingFeatures: [
+      "Everything in API Starter",
+      "300 requests/minute",
+      "10,000 requests/day included",
+      "Priority support",
+      "XLSX exports",
+    ],
     selfServe: false,
     highlighted: false,
     currentForCheckout: false,

--- a/convex/payments/cacheActions.ts
+++ b/convex/payments/cacheActions.ts
@@ -49,6 +49,9 @@ export const syncEntitlementCache = internalAction({
       // Optional — legacy entitlement rows pre-dating plan 2026-05-10-001
       // do not carry mcpAccess. Schema validator must accept their reads.
       mcpAccess: v.optional(v.boolean()),
+      // Optional — per-account daily REST allowance (#3199). Catalog-sourced
+      // writes set it; legacy rows omit it (rate-limit consumer fail-opens).
+      apiDailyAllowance: v.optional(v.number()),
     }),
     validUntil: v.number(),
   },

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -550,6 +550,12 @@ export default defineSchema({
       // the next subscription event; legacy rows return undefined and
       // every consumer treats undefined as "no MCP access" (fail-closed).
       mcpAccess: v.optional(v.boolean()),
+      // Optional — per-account daily REST allowance (#3199). Legacy rows
+      // predate it; the rate-limit consumer treats undefined as "no daily
+      // limit" (fail-OPEN). Catalog-sourced writes always set it, so this
+      // validator MUST accept it or the webhook's entitlement write is
+      // rejected (v.object is strict on extra keys).
+      apiDailyAllowance: v.optional(v.number()),
     }),
     validUntil: v.number(),
     // Optional complimentary-entitlement floor. When set and in the future,

--- a/docs/usage-rate-limits.mdx
+++ b/docs/usage-rate-limits.mdx
@@ -21,6 +21,21 @@ Applies to all `/api/*` routes that don't have a stricter override. Implemented 
 
 See [MCP](/mcp-server) for details.
 
+## Per-plan API rate limits
+
+Authenticated REST API keys (`wm_…`) are limited **per account**, not per IP — a key behind a shared egress IP is not throttled by other tenants' traffic, and all of an account's keys share one allowance.
+
+| Plan | Per-minute (burst) | Daily included | Beyond the daily allowance |
+|------|--------------------|----------------|----------------------------|
+| **API Starter** | **60** / 60 s | **1,000** / UTC day | metered — hard stop at 10,000 / day |
+| **API Business** | **300** / 60 s | **10,000** / UTC day | metered — hard stop at 100,000 / day |
+| **Enterprise** | **1,000** / 60 s | unlimited | — |
+
+- **Per-minute** is a hard burst limit — exceeding it returns 429 immediately.
+- **Daily included** is your plan's allowance; it resets at **00:00 UTC**. Requests beyond it are **metered, not rejected** — usage-based overage billing is rolling out. Until then a safety ceiling (10× the included allowance) caps runaway usage with a 429.
+- The daily allowance and ceiling are **per account** (shared across all of an account's keys), so issuing more keys does not raise your limit.
+- Need a higher limit? **Contact support** to raise your plan's allowance.
+
 ## OAuth endpoints
 
 | Endpoint | Limit | Window | Scope |
@@ -56,14 +71,20 @@ These mostly use the default public API limit. Cache headers vary by endpoint:
 
 ## Response when limited
 
-HTTP 429 with:
+HTTP 429 with the standard rate-limit headers so you can self-throttle:
 
 ```
+HTTP/1.1 429 Too Many Requests
+X-RateLimit-Limit: <limit>
+X-RateLimit-Remaining: 0
+X-RateLimit-Reset: <reset, ms since epoch>
 Retry-After: <seconds>
 Content-Type: application/json
 
 { "error": "Too many requests" }
 ```
+
+For a daily-ceiling 429 the `Retry-After` counts down to the next 00:00 UTC.
 
 ## Retry guidance
 

--- a/docs/usage-rate-limits.mdx
+++ b/docs/usage-rate-limits.mdx
@@ -33,7 +33,7 @@ Authenticated REST API keys (`wm_…`) are limited **per account**, not per IP �
 
 - **Per-minute** is a hard burst limit — exceeding it returns 429 immediately.
 - **Daily included** is your plan's allowance; it resets at **00:00 UTC**. Requests beyond it are **metered, not rejected** — usage-based overage billing is rolling out. Until then a safety ceiling (10× the included allowance) caps runaway usage with a 429.
-- The daily allowance and ceiling are **per account** (shared across all of an account's keys), so issuing more keys does not raise your limit.
+- The per-minute burst, daily allowance, and ceiling are all **per account** (shared across all of an account's `wm_…` keys), so issuing more keys does not raise your limit. (Operator-issued Enterprise keys are the exception — each is rate-limited independently.)
 - Need a higher limit? **Contact support** to raise your plan's allowance.
 
 ## OAuth endpoints

--- a/server/__tests__/entitlement-check.test.ts
+++ b/server/__tests__/entitlement-check.test.ts
@@ -26,6 +26,7 @@ import { getCachedJson } from "../_shared/redis";
 import {
   getRequiredTier,
   checkEntitlement,
+  getEntitlements,
 } from "../_shared/entitlement-check";
 
 // ---------------------------------------------------------------------------
@@ -245,5 +246,36 @@ describe("gateway entitlement check", () => {
       }
       vi.unstubAllGlobals();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #3199 U2 — apiDailyAllowance threads through to the resolved entitlement
+// ---------------------------------------------------------------------------
+
+describe("getEntitlements surfaces apiDailyAllowance (#3199 U2)", () => {
+  test("a fresh Starter cache row exposes apiDailyAllowance", async () => {
+    const fresh = makeEntitlements(2, "api_starter");
+    vi.mocked(getCachedJson).mockResolvedValueOnce({
+      ...fresh,
+      features: { ...fresh.features, apiDailyAllowance: 1000 },
+    } as never);
+
+    const result = await getEntitlements("user_starter");
+    expect(result?.features.apiDailyAllowance).toBe(1000);
+  });
+
+  test("a legacy cache row lacking apiDailyAllowance resolves to undefined (fail-open), no throw", async () => {
+    // makeEntitlements sets mcpAccess (boolean) so the row passes the
+    // staleness gate, but does NOT set apiDailyAllowance — the field is
+    // intentionally absent from the staleness gate so legacy rows are served
+    // from cache and the rate-limit consumer fail-opens on undefined.
+    vi.mocked(getCachedJson).mockResolvedValueOnce(
+      makeEntitlements(2, "api_starter") as never,
+    );
+
+    const result = await getEntitlements("user_legacy");
+    expect(result).not.toBeNull();
+    expect(result?.features.apiDailyAllowance).toBeUndefined();
   });
 });

--- a/server/__tests__/gateway-api-rate-limit.test.ts
+++ b/server/__tests__/gateway-api-rate-limit.test.ts
@@ -1,0 +1,170 @@
+// @vitest-environment node
+
+/**
+ * U4 (#3199) — gateway wiring for the per-account API rate-limit layer.
+ *
+ * The per-account burst/meter math is unit-tested in
+ * tests/api-key-rate-limit.test.mts; here we STUB that module (per the plan)
+ * and assert only the GATEWAY wiring at server/gateway.ts:1034 — the parts the
+ * reviewers flagged as defect-prone:
+ *   - eligibility via isUserApiKey (user keys carry NO keyCheck.kind)
+ *   - the per-IP bypass is ENFORCE-only (shadow keeps per-IP active)
+ *   - ordering + 429 shape
+ *   - downgraded / ineligible keys fall through to per-IP
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+
+// --- Stub the per-account module: control the burst/meter decisions ---------
+const checkBurst = vi.fn();
+const reserveDailyMeter = vi.fn();
+vi.mock("../_shared/api-key-rate-limit", () => ({
+  checkBurst: (...a: unknown[]) => checkBurst(...a),
+  reserveDailyMeter: (...a: unknown[]) => reserveDailyMeter(...a),
+  rateLimitHeaders: () => ({ "X-RateLimit-Limit": "60", "Retry-After": "30" }),
+  ENTERPRISE_API_RATE_LIMIT: 1000,
+  CEILING_MULTIPLIER: 10,
+}));
+
+// --- Stub the per-IP layer: spy whether checkRateLimit runs ------------------
+const checkRateLimit = vi.fn().mockResolvedValue(null);
+vi.mock("../_shared/rate-limit", () => ({
+  checkRateLimit: (...a: unknown[]) => checkRateLimit(...a),
+  checkEndpointRateLimit: vi.fn().mockResolvedValue(null),
+  hasEndpointRatePolicy: () => false,
+}));
+
+// --- Stub entitlement resolution: a Starter user, non-tier-gated route -------
+const STARTER = {
+  planKey: "api_starter",
+  features: {
+    tier: 2,
+    apiAccess: true,
+    apiRateLimit: 60,
+    apiDailyAllowance: 1000,
+    maxDashboards: 25,
+    prioritySupport: false,
+    exportFormats: ["csv"],
+    mcpAccess: true,
+  },
+  validUntil: Date.now() + 86_400_000,
+};
+let entitlement: typeof STARTER | { planKey: string; features: Record<string, unknown>; validUntil: number } | null = STARTER;
+vi.mock("../_shared/entitlement-check", () => ({
+  getRequiredTier: () => null, // not tier-gated
+  checkEntitlement: vi.fn().mockResolvedValue(null), // passes
+  getEntitlements: vi.fn(async () => entitlement),
+}));
+
+// --- Stub user-key validation: a valid wm_ key resolves to a userId ----------
+vi.mock("../_shared/user-api-key", () => ({
+  validateUserApiKey: vi.fn(async () => ({ userId: "acct_starter", keyId: "k1", name: "t" })),
+}));
+
+import { createDomainGateway } from "../gateway";
+
+function makeGateway() {
+  return createDomainGateway([
+    {
+      method: "GET",
+      path: "/api/news/v1/list-feed-digest",
+      handler: async () =>
+        new Response(JSON.stringify({ ok: true }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    },
+  ]);
+}
+
+function userKeyRequest() {
+  return new Request("https://www.worldmonitor.app/api/news/v1/list-feed-digest", {
+    method: "GET",
+    headers: { "X-Api-Key": "wm_test_starter_key" },
+  });
+}
+
+const ctx = { waitUntil: () => {} };
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  entitlement = STARTER;
+  checkBurst.mockReset().mockResolvedValue({ ok: true });
+  reserveDailyMeter.mockReset().mockResolvedValue({
+    count: 1,
+    overCeiling: false,
+    metered: true,
+    retryAfterSec: 100,
+    rollback: async () => {},
+  });
+  checkRateLimit.mockClear().mockResolvedValue(null);
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+});
+
+afterEach(() => {
+  for (const k of Object.keys(process.env)) if (!(k in ORIGINAL_ENV)) delete process.env[k];
+  Object.assign(process.env, ORIGINAL_ENV);
+});
+
+describe("#3199 U4 — gateway per-account rate-limit wiring", () => {
+  test("eligible Starter wm_ key engages the per-account layer (isUserApiKey discriminator)", async () => {
+    const res = await makeGateway()(userKeyRequest(), ctx);
+    expect(res.status).toBe(200);
+    // The block ran the burst check for the user key — proves eligibility keys
+    // on isUserApiKey, not keyCheck.kind (which is undefined for wm_ keys).
+    expect(checkBurst).toHaveBeenCalledWith(60, "acct_starter");
+  });
+
+  test("ENFORCE + burst trip → 429 and per-IP checkRateLimit is BYPASSED", async () => {
+    process.env.API_RATE_LIMIT_ENFORCE = "true";
+    checkBurst.mockResolvedValue({ ok: false, limit: 60, reset: Date.now() + 30_000 });
+
+    const res = await makeGateway()(userKeyRequest(), ctx);
+    expect(res.status).toBe(429);
+    expect(checkRateLimit).not.toHaveBeenCalled();
+  });
+
+  test("SHADOW + burst trip → served (200) and per-IP checkRateLimit STILL runs", async () => {
+    delete process.env.API_RATE_LIMIT_ENFORCE; // shadow (default)
+    checkBurst.mockResolvedValue({ ok: false, limit: 60, reset: Date.now() + 30_000 });
+
+    const res = await makeGateway()(userKeyRequest(), ctx);
+    expect(res.status).toBe(200);
+    expect(checkRateLimit).toHaveBeenCalledTimes(1); // protection retained in shadow
+  });
+
+  test("ENFORCE + over-ceiling → 429, meter rolled back, per-IP bypassed", async () => {
+    process.env.API_RATE_LIMIT_ENFORCE = "true";
+    const rollback = vi.fn(async () => {});
+    reserveDailyMeter.mockResolvedValue({
+      count: 10_001,
+      overCeiling: true,
+      metered: true,
+      retryAfterSec: 100,
+      rollback,
+    });
+
+    const res = await makeGateway()(userKeyRequest(), ctx);
+    expect(res.status).toBe(429);
+    expect(rollback).toHaveBeenCalledTimes(1);
+    expect(checkRateLimit).not.toHaveBeenCalled();
+  });
+
+  test("ENFORCE + within limits → served, per-IP bypassed", async () => {
+    process.env.API_RATE_LIMIT_ENFORCE = "true";
+    const res = await makeGateway()(userKeyRequest(), ctx);
+    expect(res.status).toBe(200);
+    expect(checkRateLimit).not.toHaveBeenCalled();
+  });
+
+  test("downgraded entitlement (apiAccess:false) → NOT eligible, per-IP runs, no burst check", async () => {
+    process.env.API_RATE_LIMIT_ENFORCE = "true";
+    entitlement = { planKey: "pro", features: { tier: 1, apiAccess: false, apiRateLimit: 0 }, validUntil: Date.now() + 86_400_000 };
+
+    const res = await makeGateway()(userKeyRequest(), ctx);
+    expect(res.status).toBe(200);
+    expect(checkBurst).not.toHaveBeenCalled(); // never slidingWindow(0)
+    expect(checkRateLimit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/server/_shared/api-key-rate-limit.ts
+++ b/server/_shared/api-key-rate-limit.ts
@@ -149,8 +149,11 @@ export async function reserveDailyMeter(opts: {
   const noop = async (): Promise<void> => {};
   const retryAfterSec = secondsUntilUtcMidnight(date);
 
-  // Unlimited allowance — never meter, never ceiling.
-  if (allowance < 0) {
+  // No daily limit: `-1` is unlimited (enterprise); `0` is a misconfiguration
+  // (positive burst but zero allowance) that we fail OPEN on rather than
+  // ceiling-429 every request (ceiling would be 0×10 = 0, so request #1 trips).
+  // Callers already gate eligibility on apiRateLimit > 0, so this is defensive.
+  if (allowance <= 0) {
     return { count: 0, overCeiling: false, metered: false, retryAfterSec, rollback: noop };
   }
 

--- a/server/_shared/api-key-rate-limit.ts
+++ b/server/_shared/api-key-rate-limit.ts
@@ -1,0 +1,217 @@
+// Per-account REST rate-limit layer for #3199 (Phase 1). Two limit types:
+//
+//   1. Per-minute burst  — infra/abuse protection. Hard limit; the gateway
+//      returns 429 on violation (in enforce mode). Value from the catalog
+//      `apiRateLimit` (user keys) or a hardcoded constant (enterprise).
+//   2. Daily usage meter — the commercial "included allowance". Counts every
+//      served request but NEVER rejects at the allowance. The only hard reject
+//      on this axis is a safety ceiling at CEILING_MULTIPLIER × allowance.
+//
+// This module is decision-only: it never builds a Response and never reads the
+// enforce flag — the gateway (the single chokepoint at server/gateway.ts:1034)
+// owns enforce-vs-shadow, per-IP bypass, and Response construction. That keeps
+// the burst/meter math unit-testable in isolation (inject the pipeline + date;
+// stub this module's decisions in the gateway-wiring test).
+//
+// Patterns cloned: api/mcp/quota.ts (INCR-first meter + DECR rollback),
+// api/_rate-limit.js (lazy Upstash singleton, NODE_TEST_CONTEXT retry skip,
+// X-RateLimit-* header shape), server/_shared/pro-mcp-token.ts UTC helpers.
+
+import { Ratelimit } from '@upstash/ratelimit';
+import { Redis } from '@upstash/redis';
+
+import { secondsUntilUtcMidnight } from './pro-mcp-token';
+
+/** Hardcoded per-minute burst for enterprise env keys — they carry no Convex
+ *  entitlement (gateway.ts:1006-1007 skips checkEntitlement), so this cannot
+ *  be sourced from `features.apiRateLimit`. Mirrors ENTERPRISE_FEATURES. */
+export const ENTERPRISE_API_RATE_LIMIT = 1000;
+
+/** Safety ceiling = this × the included daily allowance. The allowance itself
+ *  is metered (never rejects); the ceiling is pure runaway/cost protection. */
+export const CEILING_MULTIPLIER = 10;
+
+// Mirror REDIS_TEST_RETRY_OPTS in api/_rate-limit.js / server/_shared/rate-limit.ts:
+// skip the @upstash/redis retry backoff under the node test runner so
+// fail-open tests pointed at a fake host degrade immediately.
+const REDIS_TEST_RETRY_OPTS = process.env.NODE_TEST_CONTEXT ? { retry: false } : {};
+
+// One Redis client shared across every per-minute Ratelimit instance; one
+// Ratelimit per distinct numeric limit (60, 300, 1000) cached in the Map so two
+// Starter accounts share a limiter *config* but get separate buckets via the
+// per-account identifier passed to `.limit()`.
+let redisSingleton: Redis | null = null;
+const burstLimiters = new Map<number, Ratelimit>();
+
+function getRedis(): Redis | null {
+  if (redisSingleton) return redisSingleton;
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  redisSingleton = new Redis({ url, token, ...REDIS_TEST_RETRY_OPTS });
+  return redisSingleton;
+}
+
+/**
+ * The per-minute burst limiter for `perMinute` requests / 60s, cached by limit.
+ * Returns null when Upstash is not configured (caller fail-opens).
+ */
+export function getBurstLimiter(perMinute: number): Ratelimit | null {
+  const existing = burstLimiters.get(perMinute);
+  if (existing) return existing;
+  const redis = getRedis();
+  if (!redis) return null;
+  const limiter = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(perMinute, '60 s'),
+    prefix: 'rl:apikey:min',
+    analytics: false,
+  });
+  burstLimiters.set(perMinute, limiter);
+  return limiter;
+}
+
+export type BurstDecision =
+  | { ok: true }
+  | { ok: false; limit: number; reset: number };
+
+/**
+ * Evaluate the per-minute burst window for `identity`. Fail-OPEN: a missing
+ * Upstash config or any Redis error resolves to `{ ok: true }` so a paying
+ * customer is never 429'd for our outage (mirrors api/_rate-limit.js).
+ */
+export async function checkBurst(perMinute: number, identity: string): Promise<BurstDecision> {
+  const limiter = getBurstLimiter(perMinute);
+  if (!limiter) return { ok: true };
+  try {
+    const { success, limit, reset } = await limiter.limit(identity);
+    if (!success) return { ok: false, limit, reset };
+    return { ok: true };
+  } catch {
+    return { ok: true };
+  }
+}
+
+/** Plain (un-prefixed) daily-meter key — `runRedisPipeline` applies the
+ *  deployment/env prefix. UTC calendar day so the ceiling resets at midnight.
+ *  `date` is injectable for deterministic tests. */
+export function apiKeyDailyKey(userId: string, date?: Date): string {
+  if (!userId) return '';
+  const d = date ?? new Date();
+  const yyyy = d.getUTCFullYear();
+  const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(d.getUTCDate()).padStart(2, '0');
+  return `rl:apikey:day:${userId}:${yyyy}-${mm}-${dd}`;
+}
+
+/** 48h TTL: covers UTC-midnight rollover + an inspection window. Mirrors
+ *  PRO_DAILY_QUOTA_TTL_SECONDS. */
+export const API_DAILY_TTL_SECONDS = 172_800;
+
+/** Minimal pipeline contract — the subset of `runRedisPipeline` this module
+ *  needs. The gateway passes `(cmds) => runRedisPipeline(cmds)`; tests inject a
+ *  mock. Returns `[]` on failure (fail-open), never throws by contract. */
+export type RateLimitPipeline = (
+  commands: Array<Array<string | number>>,
+) => Promise<Array<{ result?: unknown }>>;
+
+export interface MeterResult {
+  /** Post-INCR count for this UTC day (0 when not metered). */
+  count: number;
+  /** True when count exceeded CEILING_MULTIPLIER × allowance. */
+  overCeiling: boolean;
+  /** False when Redis was unavailable (fail-open: serve uncounted). */
+  metered: boolean;
+  /** Seconds until UTC midnight — the ceiling 429 `Retry-After`. */
+  retryAfterSec: number;
+  /** Idempotent DECR rollback. The gateway calls this only when it actually
+   *  rejects (enforce + overCeiling); in shadow the request is served, so the
+   *  increment stands and reflects true demand. */
+  rollback: () => Promise<void>;
+}
+
+/**
+ * Increment the per-account daily meter and report whether the safety ceiling
+ * is now exceeded. INCR-first (atomic; no check-then-incr race), mirroring
+ * api/mcp/quota.ts::reserveQuota.
+ *
+ * - `allowance < 0` (unlimited, e.g. enterprise) → no Redis call; never metered.
+ * - Redis unavailable / pipeline failure → `metered:false`, `overCeiling:false`
+ *   (fail-open: the gateway serves uncounted).
+ */
+export async function reserveDailyMeter(opts: {
+  userId: string;
+  allowance: number;
+  pipeline: RateLimitPipeline;
+  date?: Date;
+}): Promise<MeterResult> {
+  const { userId, allowance, pipeline, date } = opts;
+  const noop = async (): Promise<void> => {};
+  const retryAfterSec = secondsUntilUtcMidnight(date);
+
+  // Unlimited allowance — never meter, never ceiling.
+  if (allowance < 0) {
+    return { count: 0, overCeiling: false, metered: false, retryAfterSec, rollback: noop };
+  }
+
+  const key = apiKeyDailyKey(userId, date);
+  if (!key) {
+    return { count: 0, overCeiling: false, metered: false, retryAfterSec, rollback: noop };
+  }
+
+  let pipeResult: Array<{ result?: unknown }> | null;
+  try {
+    pipeResult = await pipeline([
+      ['INCR', key],
+      ['EXPIRE', key, API_DAILY_TTL_SECONDS],
+    ]);
+  } catch {
+    pipeResult = null;
+  }
+
+  // Fail-open: couldn't meter → serve uncounted (never punish a paying
+  // customer for our Redis outage).
+  if (!pipeResult || !Array.isArray(pipeResult) || pipeResult.length === 0) {
+    return { count: 0, overCeiling: false, metered: false, retryAfterSec, rollback: noop };
+  }
+
+  const incrRaw = pipeResult[0]?.result;
+  const count = typeof incrRaw === 'number' ? incrRaw : Number(incrRaw);
+  if (!Number.isFinite(count) || count < 1) {
+    return { count: 0, overCeiling: false, metered: false, retryAfterSec, rollback: noop };
+  }
+
+  let rolledBack = false;
+  const rollback = async (): Promise<void> => {
+    if (rolledBack) return;
+    rolledBack = true;
+    try {
+      await pipeline([['DECR', key]]);
+    } catch {
+      // Best-effort: a failed DECR overshoots the meter by 1, the
+      // cost-protection-correct direction.
+    }
+  };
+
+  const ceiling = allowance * CEILING_MULTIPLIER;
+  return { count, overCeiling: count > ceiling, metered: true, retryAfterSec, rollback };
+}
+
+/**
+ * Standard rate-limit response headers. Mirrors api/_rate-limit.js:110-116 so
+ * customers get a uniform self-throttle contract across the per-IP and
+ * per-account limiters. The gateway merges these with corsHeaders.
+ */
+export function rateLimitHeaders(opts: {
+  limit: number;
+  remaining: number;
+  resetMs: number;
+  retryAfterSec: number;
+}): Record<string, string> {
+  return {
+    'X-RateLimit-Limit': String(opts.limit),
+    'X-RateLimit-Remaining': String(Math.max(0, opts.remaining)),
+    'X-RateLimit-Reset': String(opts.resetMs),
+    'Retry-After': String(Math.max(1, opts.retryAfterSec)),
+  };
+}

--- a/server/_shared/api-key-rate-limit.ts
+++ b/server/_shared/api-key-rate-limit.ts
@@ -31,11 +31,6 @@ export const ENTERPRISE_API_RATE_LIMIT = 1000;
  *  is metered (never rejects); the ceiling is pure runaway/cost protection. */
 export const CEILING_MULTIPLIER = 10;
 
-// Mirror REDIS_TEST_RETRY_OPTS in api/_rate-limit.js / server/_shared/rate-limit.ts:
-// skip the @upstash/redis retry backoff under the node test runner so
-// fail-open tests pointed at a fake host degrade immediately.
-const REDIS_TEST_RETRY_OPTS = process.env.NODE_TEST_CONTEXT ? { retry: false } : {};
-
 // One Redis client shared across every per-minute Ratelimit instance; one
 // Ratelimit per distinct numeric limit (60, 300, 1000) cached in the Map so two
 // Starter accounts share a limiter *config* but get separate buckets via the
@@ -48,7 +43,14 @@ function getRedis(): Redis | null {
   const url = process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
   if (!url || !token) return null;
-  redisSingleton = new Redis({ url, token, ...REDIS_TEST_RETRY_OPTS });
+  // Skip the @upstash/redis retry backoff under the node test runner so
+  // fail-open tests pointed at a fake host degrade immediately; production
+  // (env unset) keeps the resilient default. Mirrors api/_rate-limit.js.
+  // `retry: false` must stay a literal (not a spread) or it widens to
+  // `boolean` and fails tsconfig.api.json's RetryConfig type.
+  redisSingleton = process.env.NODE_TEST_CONTEXT
+    ? new Redis({ url, token, retry: false })
+    : new Redis({ url, token });
   return redisSingleton;
 }
 

--- a/server/_shared/api-key-rate-limit.ts
+++ b/server/_shared/api-key-rate-limit.ts
@@ -20,6 +20,7 @@
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 
+import { getKeyPrefix } from './redis';
 import { secondsUntilUtcMidnight } from './pro-mcp-token';
 
 /** Hardcoded per-minute burst for enterprise env keys — they carry no Convex
@@ -66,7 +67,10 @@ export function getBurstLimiter(perMinute: number): Ratelimit | null {
   const limiter = new Ratelimit({
     redis,
     limiter: Ratelimit.slidingWindow(perMinute, '60 s'),
-    prefix: 'rl:apikey:min',
+    // Env-scope the prefix exactly like the daily meter (runRedisPipeline's
+    // prefixKey) so a preview deployment sharing one Upstash database doesn't
+    // consume/pollute the production burst namespace. Empty in production.
+    prefix: `${getKeyPrefix()}rl:apikey:min`,
     analytics: false,
   });
   burstLimiters.set(perMinute, limiter);

--- a/server/_shared/entitlement-check.ts
+++ b/server/_shared/entitlement-check.ts
@@ -34,6 +34,15 @@ interface CachedEntitlements {
      * this on the next subscription event.
      */
     mcpAccess?: boolean;
+    /**
+     * Per-account daily REST allowance (#3199). The rate-limit layer meters
+     * but never rejects at this value; the hard ceiling is 10×. `-1` =
+     * unlimited. Unlike `mcpAccess`, consumers treat `undefined` as
+     * **no daily limit (fail-OPEN)** — a stale/legacy cache must not punish
+     * a paying customer. NOT added to the cache-staleness gate below for
+     * that reason (forcing a re-fetch would contradict fail-open).
+     */
+    apiDailyAllowance?: number;
   };
   validUntil: number;
 }

--- a/server/_shared/redis.ts
+++ b/server/_shared/redis.ts
@@ -37,7 +37,7 @@ function hasRemoteRedisConfig(): boolean {
  * Environment-based key prefix to avoid collisions when multiple deployments
  * share the same Upstash Redis instance (M-6 fix).
  */
-function getKeyPrefix(): string {
+export function getKeyPrefix(): string {
   const env = process.env.VERCEL_ENV; // 'production' | 'preview' | 'development'
   if (!env || env === 'production') return '';
   const sha = process.env.VERCEL_GIT_COMMIT_SHA?.slice(0, 8) || 'dev';

--- a/server/_shared/usage.ts
+++ b/server/_shared/usage.ts
@@ -72,7 +72,14 @@ export type RequestReason =
   | 'malformed_request'
   | 'unknown_route'
   | 'method_not_allowed'
-  | 'cors_error';
+  | 'cors_error'
+  // #3199 per-account API rate limit. `_429` = enforced reject; `_shadow` =
+  // would-have-rejected but served (shadow mode), threaded onto the single
+  // terminal success emit so the volume signal isn't double-counted.
+  | 'rl_min_429'
+  | 'rl_ceiling_429'
+  | 'rl_min_shadow'
+  | 'rl_ceiling_shadow';
 
 export interface RequestEvent {
   _time: string;

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -28,7 +28,15 @@ import {
   getInternalMcpVerifiedNonce,
   verifyInternalMcpRequest,
 } from './_shared/mcp-internal-hmac';
-import { buildUsageIdentity, type UsageIdentityInput } from './_shared/usage-identity';
+import { buildUsageIdentity, hashKeySync, type UsageIdentityInput } from './_shared/usage-identity';
+import { runRedisPipeline } from './_shared/redis';
+import {
+  checkBurst,
+  reserveDailyMeter,
+  rateLimitHeaders,
+  ENTERPRISE_API_RATE_LIMIT,
+  CEILING_MULTIPLIER,
+} from './_shared/api-key-rate-limit';
 import {
   deliverUsageEvents,
   buildRequestEvent,
@@ -522,8 +530,15 @@ export function createDomainGateway(
     const domain = (/^v\d+$/.test(_parts[2] ?? '') ? _parts[3] : _parts[2]) ?? '';
     const reqBytes = deriveReqBytes(request);
 
+    // #3199: in shadow mode a per-account limit that WOULD have triggered is
+    // recorded on the single terminal success emit (never a second event) so the
+    // volume signal Phase-2 pricing reuses isn't double-counted. Overrides only
+    // a successful terminal reason (status < 400); a real 4xx/5xx outcome wins.
+    let pendingShadowReason: RequestReason | null = null;
     function emitRequest(status: number, reason: RequestReason, cacheTier: UsageCacheTier | null, resBytes = 0): void {
       if (!ctx?.waitUntil) return;
+      const effectiveReason: RequestReason =
+        pendingShadowReason && status < 400 ? pendingShadowReason : reason;
       const identity = buildUsageIdentity(usage);
       // Single ctx.waitUntil() registered synchronously in the request phase.
       // The IIFE awaits ua_hash (SHA-256) then awaits delivery directly via
@@ -559,7 +574,7 @@ export function createDomainGateway(
             acceptLanguage: deriveAcceptLanguage(originalRequest),
             host: deriveHost(originalRequest),
             sentryTraceId: deriveSentryTraceId(originalRequest),
-            reason,
+            reason: effectiveReason,
           }),
         ]);
       })());
@@ -1043,7 +1058,95 @@ export function createDomainGateway(
         return endpointRlResponse;
       }
 
-      if (!hasEndpointRatePolicy(pathname)) {
+      // ── Per-account API rate limit (#3199) ──────────────────────────────
+      // Eligible authenticated keys — a valid user key (which carries NO
+      // keyCheck.kind, so `isUserApiKey` is the discriminator) or an enterprise
+      // env key — are governed by a per-account burst + daily meter + 10×
+      // safety ceiling instead of the global per-IP cap. In ENFORCE they bypass
+      // the per-IP fallback below; in SHADOW they only record telemetry and
+      // still fall through to per-IP, so protection never drops below today.
+      // Limits are NOT in scope here (checkEntitlement discards `features`), so
+      // user keys resolve getEntitlements explicitly (cached); enterprise keys
+      // carry no entitlement and use hardcoded limits.
+      let governedByApiKeyLayer = false;
+      if (keyCheck.valid && (isUserApiKey || isEnterpriseAuth)) {
+        const enforce = process.env.API_RATE_LIMIT_ENFORCE === 'true';
+        let perMinute = 0;
+        let allowance = -1;
+        let identity = '';
+        if (isEnterpriseAuth) {
+          perMinute = ENTERPRISE_API_RATE_LIMIT; // hardcoded — no entitlement row
+          allowance = -1; // unlimited daily / no ceiling
+          identity = wmKey ? hashKeySync(wmKey) : '';
+        } else if (sessionUserId) {
+          const ent = await getEntitlements(sessionUserId);
+          if (ent && ent.features.apiAccess && ent.features.apiRateLimit > 0) {
+            perMinute = ent.features.apiRateLimit;
+            // undefined ⇒ fail-open (no daily limit); -1 ⇒ unlimited.
+            allowance =
+              typeof ent.features.apiDailyAllowance === 'number'
+                ? ent.features.apiDailyAllowance
+                : -1;
+            identity = sessionUserId;
+          }
+          // else: downgraded / null entitlement ⇒ not eligible (perMinute = 0),
+          // falls through to the per-IP path — never a slidingWindow(0).
+        }
+
+        if (perMinute > 0 && identity) {
+          // 1. Per-minute burst (hard limit).
+          const burst = await checkBurst(perMinute, identity);
+          if (!burst.ok) {
+            if (enforce) {
+              const retryAfterSec = Math.max(1, Math.ceil((burst.reset - Date.now()) / 1000));
+              emitRequest(429, 'rl_min_429', null);
+              return new Response(JSON.stringify({ error: 'Too many requests' }), {
+                status: 429,
+                headers: {
+                  'Content-Type': 'application/json',
+                  'Cache-Control': 'no-store',
+                  ...rateLimitHeaders({ limit: burst.limit, remaining: 0, resetMs: burst.reset, retryAfterSec }),
+                  ...corsHeaders,
+                },
+              });
+            }
+            pendingShadowReason = 'rl_min_shadow';
+          } else if (allowance >= 0) {
+            // 2. Daily meter + 10× ceiling (skipped for unlimited allowance).
+            const meter = await reserveDailyMeter({
+              userId: identity,
+              allowance,
+              pipeline: (cmds) => runRedisPipeline(cmds),
+            });
+            if (meter.overCeiling) {
+              if (enforce) {
+                await meter.rollback();
+                emitRequest(429, 'rl_ceiling_429', null);
+                return new Response(JSON.stringify({ error: 'Daily request ceiling exceeded' }), {
+                  status: 429,
+                  headers: {
+                    'Content-Type': 'application/json',
+                    'Cache-Control': 'no-store',
+                    ...rateLimitHeaders({
+                      limit: allowance * CEILING_MULTIPLIER,
+                      remaining: 0,
+                      resetMs: Date.now() + meter.retryAfterSec * 1000,
+                      retryAfterSec: meter.retryAfterSec,
+                    }),
+                    ...corsHeaders,
+                  },
+                });
+              }
+              pendingShadowReason = 'rl_ceiling_shadow';
+            }
+          }
+          // Eligible + enforce + not rejected ⇒ the per-account layer governs
+          // this request; skip the per-IP fallback. In shadow, keep per-IP on.
+          if (enforce) governedByApiKeyLayer = true;
+        }
+      }
+
+      if (!governedByApiKeyLayer && !hasEndpointRatePolicy(pathname)) {
         const rateLimitResponse = await checkRateLimit(request, corsHeaders);
         if (rateLimitResponse) {
           const reason =

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -1077,6 +1077,12 @@ export function createDomainGateway(
         if (isEnterpriseAuth) {
           perMinute = ENTERPRISE_API_RATE_LIMIT; // hardcoded — no entitlement row
           allowance = -1; // unlimited daily / no ceiling
+          // Enterprise burst is keyed PER KEY (not per account) by design:
+          // these are operator-issued WORLDMONITOR_VALID_KEYS with no shared
+          // userId, and unlimited daily — so there's no quota to multiply by
+          // minting keys, and each operator key gets its own 1,000/min budget
+          // rather than contending for one shared bucket. (User keys below key
+          // on userId so a customer can't multiply their allowance.)
           identity = wmKey ? hashKeySync(wmKey) : '';
         } else if (sessionUserId) {
           const ent = await getEntitlements(sessionUserId);

--- a/tests/api-key-rate-limit.test.mts
+++ b/tests/api-key-rate-limit.test.mts
@@ -95,6 +95,14 @@ describe('#3199 U3 — reserveDailyMeter', () => {
     assert.equal(mock.commands.length, 0, 'no pipeline call for unlimited');
   });
 
+  it('allowance 0 (misconfig): fails open, never meters or ceilings (no brick)', async () => {
+    const mock = makePipeline(0);
+    const r = await reserveDailyMeter({ userId: 'u', allowance: 0, pipeline: mock.pipeline });
+    assert.equal(r.metered, false);
+    assert.equal(r.overCeiling, false);
+    assert.equal(mock.commands.length, 0, 'allowance 0 must not ceiling-429 request #1');
+  });
+
   it('fail-open when Redis returns empty (outage): metered:false, served', async () => {
     const downPipeline = async () => [];
     const r = await reserveDailyMeter({ userId: 'u', allowance: STARTER_ALLOWANCE, pipeline: downPipeline });

--- a/tests/api-key-rate-limit.test.mts
+++ b/tests/api-key-rate-limit.test.mts
@@ -1,0 +1,159 @@
+// U3 (#3199) — per-account rate-limit module. Pipeline + UTC math tested in
+// isolation with an injected mock pipeline + injected Date (no live Redis).
+// Per the plan, Upstash's sliding-window math is NOT re-tested here — only our
+// meter/ceiling logic and fail-open posture.
+//
+// Constants mirrored from the module so a prod drift fails by name rather than
+// silently (matches tests/mcp-quota-concurrent.test.mjs discipline).
+const STARTER_ALLOWANCE = 1000;
+const CEILING_MULTIPLIER = 10; // server/_shared/api-key-rate-limit.ts
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  apiKeyDailyKey,
+  reserveDailyMeter,
+  rateLimitHeaders,
+  checkBurst,
+  ENTERPRISE_API_RATE_LIMIT,
+} from '../server/_shared/api-key-rate-limit.ts';
+
+// A mock pipeline that simulates an INCR/DECR counter, recording every command.
+function makePipeline(initial = 0) {
+  let count = initial;
+  const commands: Array<Array<string | number>>[] = [];
+  const pipeline = async (cmds: Array<Array<string | number>>) => {
+    commands.push(cmds);
+    return cmds.map((cmd) => {
+      const verb = cmd[0];
+      if (verb === 'INCR') return { result: (count += 1) };
+      if (verb === 'DECR') return { result: (count -= 1) };
+      return { result: 1 }; // EXPIRE etc.
+    });
+  };
+  return {
+    pipeline,
+    commands,
+    current: () => count,
+  };
+}
+
+const D = (y: number, mo: number, d: number, h = 12) =>
+  new Date(Date.UTC(y, mo, d, h, 0, 0));
+
+describe('#3199 U3 — apiKeyDailyKey (UTC calendar day)', () => {
+  it('formats a plain (un-prefixed) UTC-day key', () => {
+    assert.equal(apiKeyDailyKey('user_1', D(2026, 5, 30)), 'rl:apikey:day:user_1:2026-06-30');
+  });
+
+  it('rolls over at UTC midnight, not before', () => {
+    assert.equal(apiKeyDailyKey('u', new Date(Date.UTC(2026, 5, 30, 23, 59, 59))).endsWith('2026-06-30'), true);
+    assert.equal(apiKeyDailyKey('u', new Date(Date.UTC(2026, 6, 1, 0, 0, 0))).endsWith('2026-07-01'), true);
+  });
+
+  it('returns empty for a missing userId', () => {
+    assert.equal(apiKeyDailyKey(''), '');
+  });
+});
+
+describe('#3199 U3 — reserveDailyMeter', () => {
+  it('under the ceiling: meters, does not flag, no rollback', async () => {
+    const mock = makePipeline(4999); // next INCR -> 5000, well under 10×1000
+    const r = await reserveDailyMeter({ userId: 'u', allowance: STARTER_ALLOWANCE, pipeline: mock.pipeline });
+    assert.equal(r.count, 5000);
+    assert.equal(r.overCeiling, false);
+    assert.equal(r.metered, true);
+    // INCR+EXPIRE issued, no DECR.
+    assert.equal(mock.commands.length, 1);
+  });
+
+  it('over the 10× ceiling: flags, and rollback() floors the counter', async () => {
+    const mock = makePipeline(STARTER_ALLOWANCE * CEILING_MULTIPLIER); // 10000 -> INCR 10001
+    const r = await reserveDailyMeter({ userId: 'u', allowance: STARTER_ALLOWANCE, pipeline: mock.pipeline });
+    assert.equal(r.count, 10001);
+    assert.equal(r.overCeiling, true);
+    await r.rollback();
+    assert.equal(mock.current(), 10000, 'rollback DECRs the over-ceiling increment');
+    // rollback is idempotent
+    await r.rollback();
+    assert.equal(mock.current(), 10000);
+  });
+
+  it('exactly at the ceiling is allowed (only strictly-over rejects)', async () => {
+    const mock = makePipeline(STARTER_ALLOWANCE * CEILING_MULTIPLIER - 1); // -> 10000
+    const r = await reserveDailyMeter({ userId: 'u', allowance: STARTER_ALLOWANCE, pipeline: mock.pipeline });
+    assert.equal(r.count, 10000);
+    assert.equal(r.overCeiling, false);
+  });
+
+  it('unlimited allowance (-1): never touches Redis, never ceilings', async () => {
+    const mock = makePipeline(999999);
+    const r = await reserveDailyMeter({ userId: 'ent', allowance: -1, pipeline: mock.pipeline });
+    assert.equal(r.metered, false);
+    assert.equal(r.overCeiling, false);
+    assert.equal(mock.commands.length, 0, 'no pipeline call for unlimited');
+  });
+
+  it('fail-open when Redis returns empty (outage): metered:false, served', async () => {
+    const downPipeline = async () => [];
+    const r = await reserveDailyMeter({ userId: 'u', allowance: STARTER_ALLOWANCE, pipeline: downPipeline });
+    assert.equal(r.metered, false);
+    assert.equal(r.overCeiling, false);
+  });
+
+  it('fail-open when the pipeline throws', async () => {
+    const throwingPipeline = async () => {
+      throw new Error('redis exploded');
+    };
+    const r = await reserveDailyMeter({ userId: 'u', allowance: STARTER_ALLOWANCE, pipeline: throwingPipeline });
+    assert.equal(r.metered, false);
+    assert.equal(r.overCeiling, false);
+  });
+
+  it('per-account: the metered key is the userId-scoped daily key', async () => {
+    const mock = makePipeline(0);
+    const date = D(2026, 5, 30);
+    await reserveDailyMeter({ userId: 'acct_42', allowance: STARTER_ALLOWANCE, pipeline: mock.pipeline, date });
+    const incrCmd = mock.commands[0][0];
+    assert.deepEqual(incrCmd, ['INCR', apiKeyDailyKey('acct_42', date)]);
+  });
+
+  it('retryAfterSec points at the next UTC midnight', async () => {
+    const date = new Date(Date.UTC(2026, 5, 30, 23, 0, 0)); // 1h before midnight
+    const r = await reserveDailyMeter({ userId: 'u', allowance: STARTER_ALLOWANCE, pipeline: makePipeline(0).pipeline, date });
+    assert.equal(r.retryAfterSec, 3600);
+  });
+});
+
+describe('#3199 U3 — burst limiter fail-open + headers', () => {
+  it('checkBurst fails open (ok:true) when Upstash is not configured', async () => {
+    const prevUrl = process.env.UPSTASH_REDIS_REST_URL;
+    const prevToken = process.env.UPSTASH_REDIS_REST_TOKEN;
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    try {
+      const r = await checkBurst(60, 'acct_1');
+      assert.deepEqual(r, { ok: true });
+    } finally {
+      if (prevUrl !== undefined) process.env.UPSTASH_REDIS_REST_URL = prevUrl;
+      if (prevToken !== undefined) process.env.UPSTASH_REDIS_REST_TOKEN = prevToken;
+    }
+  });
+
+  it('rateLimitHeaders emits the standard X-RateLimit-* + Retry-After set', () => {
+    const h = rateLimitHeaders({ limit: 60, remaining: 0, resetMs: 1_900_000_000_000, retryAfterSec: 42 });
+    assert.equal(h['X-RateLimit-Limit'], '60');
+    assert.equal(h['X-RateLimit-Remaining'], '0');
+    assert.equal(h['X-RateLimit-Reset'], '1900000000000');
+    assert.equal(h['Retry-After'], '42');
+  });
+
+  it('Retry-After floors at 1 second', () => {
+    assert.equal(rateLimitHeaders({ limit: 60, remaining: 0, resetMs: 0, retryAfterSec: 0 })['Retry-After'], '1');
+  });
+
+  it('enterprise per-minute constant matches the catalog (1000)', () => {
+    assert.equal(ENTERPRISE_API_RATE_LIMIT, 1000);
+  });
+});

--- a/tests/product-catalog-api-allowance.test.mts
+++ b/tests/product-catalog-api-allowance.test.mts
@@ -1,0 +1,64 @@
+// U1 (#3199) — apiDailyAllowance catalog field + Business marketing copy.
+// The per-account rate-limit layer reads features.apiDailyAllowance; these
+// values are the single source of truth for the included allowance and the
+// 10× safety ceiling, and feed the /pro marketing + docs/usage-rate-limits.mdx.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  getEntitlementFeatures,
+  PRODUCT_CATALOG,
+} from '../convex/config/productCatalog.ts';
+
+describe('#3199 U1 — apiDailyAllowance per tier', () => {
+  it('Starter includes 1,000/day', () => {
+    assert.equal(getEntitlementFeatures('api_starter').apiDailyAllowance, 1000);
+  });
+
+  it('Business includes 10,000/day', () => {
+    assert.equal(getEntitlementFeatures('api_business').apiDailyAllowance, 10000);
+  });
+
+  it('Enterprise is unlimited (-1)', () => {
+    assert.equal(getEntitlementFeatures('enterprise').apiDailyAllowance, -1);
+  });
+
+  it('Free and Pro have no API allowance (0 — they cannot mint wm_ keys)', () => {
+    assert.equal(getEntitlementFeatures('free').apiDailyAllowance, 0);
+    assert.equal(getEntitlementFeatures('pro_monthly').apiDailyAllowance, 0);
+  });
+
+  it('every catalog entry sets apiDailyAllowance explicitly (no undefined in source-of-truth rows)', () => {
+    for (const [planKey, entry] of Object.entries(PRODUCT_CATALOG)) {
+      assert.equal(
+        typeof entry.features.apiDailyAllowance,
+        'number',
+        `${planKey} must set apiDailyAllowance explicitly`,
+      );
+    }
+  });
+});
+
+describe('#3199 U1 — Business marketing differentiation', () => {
+  it('Business marketingFeatures is non-empty and advertises per-minute + per-day', () => {
+    const business = PRODUCT_CATALOG.api_business.marketingFeatures;
+    assert.ok(business.length > 0, 'Business must market its API allowance');
+    assert.ok(
+      business.some((f) => /requests?\/minute/i.test(f)),
+      'Business markets a per-minute burst',
+    );
+    assert.ok(
+      business.some((f) => /10,000 requests\/day/i.test(f)),
+      'Business markets its daily included allowance',
+    );
+  });
+
+  it('Starter daily copy reads "included" (allowance, not hard cap)', () => {
+    const starter = PRODUCT_CATALOG.api_starter.marketingFeatures;
+    assert.ok(
+      starter.some((f) => /1,000 requests\/day included/i.test(f)),
+      'Starter daily copy must say "included"',
+    );
+  });
+});


### PR DESCRIPTION
Closes #3199 (Phase 1). Phase 2 (overage billing) tracked in #4560.

## What

Wires a **per-account** REST rate-limit layer into the single gateway chokepoint, replacing the "advertised but unenforced" per-tier allowances. Two distinct limit types:

- **Per-minute burst** (infra/abuse) → **hard 429**, from `apiRateLimit` (Starter 60 / Business 300 / Enterprise 1,000 per 60s).
- **Daily usage meter** (commercial allowance) → **counts, never rejects at the allowance** (new `apiDailyAllowance`: 1,000 / 10,000 / unlimited).
- **Safety ceiling** at **10× allowance** → hard 429 (runaway protection; Enterprise none).

Eligible authenticated keys bypass the global per-IP limiter **in enforce mode only** (shadow keeps per-IP active, so protection never drops below today). Fail-open throughout. Ships **shadow-first** behind `API_RATE_LIMIT_ENFORCE` — merge is inert in prod until the flag flips.

This also fixes the latent contradiction where Enterprise's advertised 1,000/60s was unreachable behind the 600/60s per-IP cap, and gives Business real marketed differentiation (its `marketingFeatures` were empty).

## How (implementation units)

- **U1** `convex/config/productCatalog.ts` — `apiDailyAllowance` field + Business marketing copy.
- **U2** `convex/schema.ts`, `cacheActions.ts`, `entitlement-check.ts` — thread the field (optional; `undefined` ⇒ fail-open). Required so strict `v.object` accepts catalog-sourced webhook writes.
- **U3** `server/_shared/api-key-rate-limit.ts` (new) — decision-only module: cached `Map<number,Ratelimit>` burst + INCR-first daily meter w/ DECR rollback (clones `api/mcp/quota.ts`), UTC-day key, fail-open.
- **U4** `server/gateway.ts` — eligibility (`isUserApiKey`/`isEnterpriseAuth` — user keys carry no `keyCheck.kind`), explicit `getEntitlements` resolution, enforce-gated per-IP bypass, shadow reason threaded onto the single terminal `emitRequest` (no double-count), 4 new `RequestReason` values.
- **U5** `docs/usage-rate-limits.mdx` — per-plan table + full `X-RateLimit-*` headers; keeps the contact-support escalation line.

## Rollout

1. Merge → **shadow** (`API_RATE_LIMIT_ENFORCE` unset). Per-IP protection fully retained.
2. Audit `rl_*_shadow` telemetry; resolve plan OQ1–5 (10× justification, telemetry durability, "included" copy timing).
3. Flip `API_RATE_LIMIT_ENFORCE=true` → **enforce** (one env change, no redeploy).
4. Phase 2 (#4560): wire the meter to Dodo usage-based billing.

## Verification

- **157 tests** pass: U1 catalog (7), U2 entitlement threading (vitest), U3 module (16 — meter/ceiling/fail-open/UTC-rollover), U4 gateway wiring (6 vitest — enforce/shadow/bypass/downgrade matrix); 58 existing gateway+rate-limit tests still green.
- `tsc --noEmit`, `typecheck:api`, and biome lint all clean.
- Adversarial code review: **sound and shippable**, no blocking defects. One LOW finding fixed (`allowance:0` would have ceiling-429'd request #1 → now fails open). Informational notes carried to Phase 2: the meter counts 4xx (404/405/malformed) outcomes too, which the Phase-2 billing basis (plan OQ4) should exclude.

## Risk

Shadow-first + fail-open + per-IP retained in shadow = the merge cannot reduce protection or surprise a paying customer. The only behavioral change at merge is telemetry emission.

Plan: `docs/plans/2026-06-30-001-feat-per-tier-api-rate-limits-plan.md`

https://claude.ai/code/session_01SjVX3GyMBmC2XyFWCHogN1
