### PR TITLE
fix(INP/ux): non-blocking confirm on Settings close (#4559)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Agent entry point for WorldMonitor. Read this first, then follow links for depth
 
 ## What This Project Is
 
-Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 157 top-level TypeScript component files, 80+ Vercel Edge API endpoint entries, a Tauri desktop app with Node.js sidecar, and a Railway relay service. Aggregates geopolitics, military, finance, climate, cyber, maritime, and aviation data across 35 freshness-tracked source groups.
+Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 159 top-level TypeScript component files, 80+ Vercel Edge API endpoint entries, a Tauri desktop app with Node.js sidecar, and a Railway relay service. Aggregates geopolitics, military, finance, climate, cyber, maritime, and aviation data across 35 freshness-tracked source groups.
 
 ## Repository Map
 
@@ -13,7 +13,7 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 157
 ├── src/                    # Browser SPA (TypeScript, class-based components)
 │   ├── app/                # App orchestration (data-loader, refresh-scheduler, panel-layout)
 │   ├── bootstrap/          # Startup/recovery (chunk reload, deferred Sentry, SW update)
-│   ├── components/         # 157 top-level TypeScript component files
+│   ├── components/         # 159 top-level TypeScript component files
 │   ├── config/             # Variant configs, panel/layer definitions, market symbols
 │   ├── services/           # Business logic (193 service modules and domain directories)
 │   ├── shared/             # Cross-cutting helpers (premium paths, registries, staleness)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Variants share all code but differ in default panels, map layers, and RSS feeds.
 
 | Directory | Purpose |
 |---|---|
-| `src/components/` | UI components — 157 top-level TypeScript component files |
+| `src/components/` | UI components — 159 top-level TypeScript component files |
 | `src/services/` | Data fetching modules — sebuf client wrappers, AI, signal analysis |
 | `src/config/` | Static data and variant configs (feeds, geo, military, pipelines, ports) |
 | `src/generated/` | Auto-generated sebuf client + server stubs (**do not edit by hand**) |

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -10,7 +10,7 @@
     "energy": 18
   },
   "variantCount": 6,
-  "componentTopLevelTsFiles": 157,
+  "componentTopLevelTsFiles": 159,
   "serviceTopLevelEntries": 193,
   "apiEndpointEntries": 80,
   "panelClasses": 104,

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -14,6 +14,7 @@ import { isProUser } from '@/services/widget-store';
 import { SITE_VARIANT } from '@/config/variant';
 import { t } from '@/services/i18n';
 import { createSettingsButton } from '@/components/settings-button';
+import { confirmDialog } from '@/components/confirm-dialog';
 import type { UnifiedSettingsTabId } from '@/components/settings-types';
 import type { MapProvider } from '@/config/basemap';
 import { escapeHtml } from '@/utils/sanitize';
@@ -70,6 +71,7 @@ export class UnifiedSettings {
   private draftPanelSettings: Record<string, PanelConfig> = {};
   private panelsJustSaved = false;
   private savedTimeout: ReturnType<typeof setTimeout> | null = null;
+  private confirmingClose = false;
   private apiKeys: ApiKeyInfo[] = [];
   private apiKeysLoading = false;
   private apiKeysError = '';
@@ -346,7 +348,22 @@ export class UnifiedSettings {
   }
 
   public close(): void {
-    if (this.hasPendingPanelChanges() && !confirm(t('header.unsavedChanges'))) return;
+    // Unsaved panel changes → confirm before tearing down. The confirm is a
+    // non-blocking in-app dialog (#4559): close() stays synchronous (8 callers)
+    // and defers teardown to the user's choice instead of a blocking confirm().
+    if (this.hasPendingPanelChanges()) {
+      if (this.confirmingClose) return; // a confirm is already on screen
+      this.confirmingClose = true;
+      void confirmDialog({ message: t('header.unsavedChanges') }).then((discard) => {
+        this.confirmingClose = false;
+        if (discard) this.teardownSettings();
+      });
+      return;
+    }
+    this.teardownSettings();
+  }
+
+  private teardownSettings(): void {
     this.overlay.classList.remove('active');
     this.prefsCleanup?.();
     this.prefsCleanup = null;

--- a/src/components/confirm-dialog-labels.ts
+++ b/src/components/confirm-dialog-labels.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure label resolution for the confirm dialog (#4559).
+ *
+ * Kept in its own module with ZERO imports so it is unit-testable under
+ * `tsx --test` — importing `confirm-dialog.ts` directly pulls in `@/services/i18n`
+ * (which uses Vite's `import.meta.glob` and crashes outside the Vite build).
+ */
+
+export interface ConfirmDialogOptions {
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+}
+
+export interface ResolvedConfirmLabels {
+  message: string;
+  confirmLabel: string;
+  cancelLabel: string;
+}
+
+/** Fill in default labels for missing/blank ones; pass the message through verbatim. */
+export function resolveConfirmLabels(
+  opts: ConfirmDialogOptions,
+  fallback: { confirm: string; cancel: string },
+): ResolvedConfirmLabels {
+  const pick = (v: string | undefined, d: string): string => (v && v.trim() ? v : d);
+  return {
+    message: opts.message,
+    confirmLabel: pick(opts.confirmLabel, fallback.confirm),
+    cancelLabel: pick(opts.cancelLabel, fallback.cancel),
+  };
+}

--- a/src/components/confirm-dialog.ts
+++ b/src/components/confirm-dialog.ts
@@ -11,6 +11,7 @@
  */
 import { t } from '@/services/i18n';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
+import { escapeHtml } from '@/utils/sanitize';
 import { type ConfirmDialogOptions, resolveConfirmLabels } from '@/components/confirm-dialog-labels';
 
 export type { ConfirmDialogOptions, ResolvedConfirmLabels } from '@/components/confirm-dialog-labels';
@@ -45,19 +46,23 @@ export function confirmDialog(opts: ConfirmDialogOptions): Promise<boolean> {
     overlay.className = 'confirm-dialog-overlay';
     overlay.setAttribute('role', 'dialog');
     overlay.setAttribute('aria-modal', 'true');
+    // Single-instance (guarded below), so the fixed message id is unique.
+    overlay.setAttribute('aria-labelledby', 'confirm-dialog-message');
     setTrustedHtml(
       overlay,
       trustedHtml(
+        // Every interpolated value is escaped so the reusable API is XSS-safe by
+        // default even if a caller passes user-controlled `message`.
         `
       <div class="confirm-dialog">
-        <p class="confirm-dialog-message">${labels.message}</p>
+        <p id="confirm-dialog-message" class="confirm-dialog-message">${escapeHtml(labels.message)}</p>
         <div class="confirm-dialog-actions">
-          <button type="button" class="confirm-dialog-btn confirm-dialog-cancel">${labels.cancelLabel}</button>
-          <button type="button" class="confirm-dialog-btn confirm-dialog-confirm">${labels.confirmLabel}</button>
+          <button type="button" class="confirm-dialog-btn confirm-dialog-cancel">${escapeHtml(labels.cancelLabel)}</button>
+          <button type="button" class="confirm-dialog-btn confirm-dialog-confirm">${escapeHtml(labels.confirmLabel)}</button>
         </div>
       </div>
     `,
-        'static i18n confirm dialog content',
+        'confirm dialog skeleton; all interpolated values escaped via escapeHtml',
       ),
     );
 
@@ -66,6 +71,26 @@ export function confirmDialog(opts: ConfirmDialogOptions): Promise<boolean> {
       if (e.key === 'Escape') {
         e.stopPropagation();
         settle(false);
+        return;
+      }
+      if (e.key === 'Tab') {
+        // Minimal focus trap: keep Tab / Shift+Tab cycling within the dialog
+        // buttons so focus can't reach the settings modal behind the overlay.
+        const buttons = [...overlay.querySelectorAll<HTMLElement>('.confirm-dialog-btn')];
+        if (buttons.length === 0) return;
+        const first = buttons[0]!;
+        const last = buttons[buttons.length - 1]!;
+        const active = document.activeElement;
+        if (!buttons.includes(active as HTMLElement)) {
+          e.preventDefault();
+          first.focus();
+        } else if (e.shiftKey && active === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && active === last) {
+          e.preventDefault();
+          first.focus();
+        }
       }
     };
     const settle = (value: boolean): void => {

--- a/src/components/confirm-dialog.ts
+++ b/src/components/confirm-dialog.ts
@@ -1,0 +1,93 @@
+/**
+ * Non-blocking confirm dialog (#4559).
+ *
+ * Replaces native `confirm()` — which blocks the main thread and inflates INP
+ * processingDuration with human dwell time — with an in-app overlay that resolves
+ * a Promise. Mirrors the construction of `src/components/MobileWarningModal.ts`
+ * (overlay + `setTrustedHtml`/`trustedHtml`, `.active` class for the CSS
+ * transition) and is reusable by any call site.
+ *
+ * Resolves `true` on confirm; `false` on cancel, Escape, or backdrop click.
+ */
+import { t } from '@/services/i18n';
+import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
+import { type ConfirmDialogOptions, resolveConfirmLabels } from '@/components/confirm-dialog-labels';
+
+export type { ConfirmDialogOptions, ResolvedConfirmLabels } from '@/components/confirm-dialog-labels';
+export { resolveConfirmLabels } from '@/components/confirm-dialog-labels';
+
+let activeOverlay: HTMLElement | null = null;
+
+/** Whether a confirm dialog is currently on screen (callers can avoid re-opening). */
+export function isConfirmDialogOpen(): boolean {
+  return activeOverlay !== null;
+}
+
+/**
+ * Show a non-blocking confirm dialog. Single-instance: a call made while one is
+ * already open resolves `false` immediately rather than stacking overlays.
+ */
+export function confirmDialog(opts: ConfirmDialogOptions): Promise<boolean> {
+  if (activeOverlay) return Promise.resolve(false);
+
+  const labels = resolveConfirmLabels(opts, {
+    // Cancel reuses the covered common.cancel key; the affirmative defaults to a
+    // literal (no t() key) — a translated `common.discard` would have to be added
+    // to every locale file (locale-completeness gate), deferred as a follow-up.
+    // Callers needing a translated affirmative pass `confirmLabel` explicitly.
+    confirm: 'Discard',
+    cancel: t('common.cancel'),
+  });
+
+  return new Promise<boolean>((resolve) => {
+    const overlay = document.createElement('div');
+    activeOverlay = overlay;
+    overlay.className = 'confirm-dialog-overlay';
+    overlay.setAttribute('role', 'dialog');
+    overlay.setAttribute('aria-modal', 'true');
+    setTrustedHtml(
+      overlay,
+      trustedHtml(
+        `
+      <div class="confirm-dialog">
+        <p class="confirm-dialog-message">${labels.message}</p>
+        <div class="confirm-dialog-actions">
+          <button type="button" class="confirm-dialog-btn confirm-dialog-cancel">${labels.cancelLabel}</button>
+          <button type="button" class="confirm-dialog-btn confirm-dialog-confirm">${labels.confirmLabel}</button>
+        </div>
+      </div>
+    `,
+        'static i18n confirm dialog content',
+      ),
+    );
+
+    let settled = false;
+    const onKeydown = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        settle(false);
+      }
+    };
+    const settle = (value: boolean): void => {
+      if (settled) return;
+      settled = true;
+      document.removeEventListener('keydown', onKeydown, true);
+      overlay.remove();
+      if (activeOverlay === overlay) activeOverlay = null;
+      resolve(value);
+    };
+
+    overlay.querySelector('.confirm-dialog-confirm')?.addEventListener('click', () => settle(true));
+    overlay.querySelector('.confirm-dialog-cancel')?.addEventListener('click', () => settle(false));
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) settle(false);
+    });
+    document.addEventListener('keydown', onKeydown, true);
+
+    document.body.appendChild(overlay);
+    requestAnimationFrame(() => {
+      overlay.classList.add('active');
+      (overlay.querySelector('.confirm-dialog-confirm') as HTMLElement | null)?.focus();
+    });
+  });
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -12506,6 +12506,67 @@ a.prediction-link:hover {
   display: flex;
 }
 
+/* Non-blocking confirm dialog (#4559) — replaces native confirm(). Sits above
+   the settings modal; mirrors the mobile-warning overlay tokens. */
+.confirm-dialog-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--overlay-scrim, rgb(0 0 0 / 50%));
+  backdrop-filter: blur(2px);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 4000;
+  padding: 20px;
+}
+
+.confirm-dialog-overlay.active {
+  display: flex;
+}
+
+.confirm-dialog {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  max-width: 360px;
+  width: 100%;
+  box-shadow: 0 8px 32px var(--shadow-color);
+  animation: mobile-warning-appear 0.2s ease-out;
+}
+
+.confirm-dialog-message {
+  margin: 0;
+  padding: 20px;
+  color: var(--text);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.confirm-dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+  padding: 12px 20px 16px;
+  border-top: 1px solid var(--border);
+}
+
+.confirm-dialog-btn {
+  padding: 8px 16px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--darken-medium);
+  color: var(--text);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.confirm-dialog-confirm {
+  background: var(--danger, #d64545);
+  border-color: var(--danger, #d64545);
+  color: #fff;
+}
+
 .mobile-warning-modal {
   background: var(--surface);
   border: 1px solid var(--border);

--- a/tests/confirm-dialog.test.mts
+++ b/tests/confirm-dialog.test.mts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { resolveConfirmLabels } from '../src/components/confirm-dialog-labels.ts';
+
+const FALLBACK = { confirm: 'Discard', cancel: 'Cancel' };
+
+describe('resolveConfirmLabels (#4559 U1)', () => {
+  it('uses provided labels when present (happy path)', () => {
+    const r = resolveConfirmLabels(
+      { message: 'Drop changes?', confirmLabel: 'Drop', cancelLabel: 'Keep' },
+      FALLBACK,
+    );
+    assert.deepEqual(r, { message: 'Drop changes?', confirmLabel: 'Drop', cancelLabel: 'Keep' });
+  });
+
+  it('falls back to defaults when labels are omitted', () => {
+    const r = resolveConfirmLabels({ message: 'Discard them?' }, FALLBACK);
+    assert.equal(r.message, 'Discard them?');
+    assert.equal(r.confirmLabel, 'Discard');
+    assert.equal(r.cancelLabel, 'Cancel');
+  });
+
+  it('treats blank/whitespace labels as missing (edge case)', () => {
+    const r = resolveConfirmLabels({ message: 'x', confirmLabel: '', cancelLabel: '   ' }, FALLBACK);
+    assert.equal(r.confirmLabel, 'Discard');
+    assert.equal(r.cancelLabel, 'Cancel');
+  });
+
+  it('passes the message through verbatim', () => {
+    const r = resolveConfirmLabels({ message: 'You have unsaved panel changes. Discard them?' }, FALLBACK);
+    assert.equal(r.message, 'You have unsaved panel changes. Discard them?');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the field-INP regression in #4559: closing the Settings modal with unsaved panel changes called native `confirm()`, which **blocks the main thread** — the dialog-open dwell was logged as INP `processingDuration` (field web-vitals: 2832ms / 1568ms "poor", processing-dominated). Replaced with a **non-blocking in-app confirm dialog**, preserving the guard behavior.

**U1 — reusable confirm dialog** (`src/components/confirm-dialog.ts`)
- `confirmDialog(opts): Promise<boolean>` overlay — resolves `true` on confirm, `false` on cancel / Escape / backdrop click; single-instance (no stacked overlays); focuses the confirm button; removes itself from the DOM on resolve.
- Mirrors `MobileWarningModal` construction (`setTrustedHtml`/`trustedHtml`) + the overlay CSS tokens (`src/styles/main.css`, z-index above the settings modal).
- Pure label resolution extracted to a **zero-import** module (`confirm-dialog-labels.ts`) so it's unit-testable under `tsx --test` — the DOM/i18n-coupled component imports `@/services/i18n` (Vite `import.meta.glob`) and isn't import-renderable. 4 unit tests.

**U2 — wire into `UnifiedSettings.close()`** (`src/components/UnifiedSettings.ts`)
- `close()` **stays synchronous** (8 callers unchanged): on pending changes it opens the non-blocking confirm and **defers teardown** to the result; native `confirm()` removed. Teardown extracted to `teardownSettings()`. Guard against a second dialog on repeated `close()` (Escape spam).
- Behavior preserved: Discard → teardown; Cancel → Settings stays open with changes; no pending → immediate close.

## ⚠️ Browser verification pending (not done — headless session)

The dialog's rendered behavior needs a browser before merge (the DOM/overlay isn't unit-testable under `tsx --test`, by design — see plan). Manual checklist:
- [ ] Toggle a panel (pending change) → Escape / close button shows the in-app confirm; page does **not** freeze.
- [ ] Discard closes Settings; Cancel keeps it open with the toggle intact; no-pending close is immediate.
- [ ] Escape + backdrop click cancel; confirm button focused; no overlay left in the DOM; no console errors.
- [ ] Overlay renders above the settings modal at desktop + mobile widths.

## Test plan

- [x] `tsc --noEmit` clean
- [x] biome + safe-html guard clean
- [x] `tests/confirm-dialog.test.mts` (label resolution) 4/4
- [x] `test:data` 11902/11910 — the 2 failures are the pre-existing `dashboard-critical-css` built-output tests (build-gated by the worktree's stale `node_modules` missing `@fontsource`; unrelated, CI builds + passes them). No new failures from this change.
- [x] code-check: no `confirm(`/`alert(`/`prompt(` remains in `close()`

## Notes / follow-ups

- The "Discard" affirmative label is an English literal default (Cancel is translated via `common.cancel`). A translated `common.discard` would require adding the key to all ~28 locale files (locale-completeness gate) — deferred as a small follow-up to keep this change scoped. Callers can pass `confirmLabel` explicitly.
- Out of scope (tracked separately): the 2 destructive key-revoke confirms (`UnifiedSettings.ts:1058`/`:1275`) and the rename `prompt()` (`preferences-content.ts:648`).

Part of #4537 / #4487.

https://claude.ai/code/session_011htsYLErqJb922Qm9QLraN