### PR TITLE
perf(INP/telemetry): report only needs-improvement+poor INP to Sentry (#4565)

### DIFF
--- a/src/bootstrap/inp-report.ts
+++ b/src/bootstrap/inp-report.ts
@@ -44,6 +44,10 @@ export function reportInpMetric(
   metric: InpMetricLike,
   enqueue: typeof enqueueSentryCall = enqueueSentryCall,
 ): void {
+  // Volume trim (#4565): skip 'good' (<200ms) INP — ~70% of field events, low
+  // diagnostic value. Report needs-improvement / poor / unknown only, so the
+  // actionable worst-case signal still lands while Sentry event volume drops ~70%.
+  if (metric.rating === 'good') return;
   const a = metric.attribution ?? {};
   enqueue((s) => {
     s.captureMessage('web-vital: INP', {

--- a/tests/inp-report.test.mts
+++ b/tests/inp-report.test.mts
@@ -55,3 +55,29 @@ test('reportInpMetric routes through the injected enqueue exactly once (R2 deleg
   reportInpMetric({ value: 100 }, fakeEnqueue);
   assert.equal(calls, 1, 'delegates to enqueueSentryCall (which buffers until Sentry init)');
 });
+
+test('reportInpMetric drops good-rated INP without enqueuing (#4565)', () => {
+  let calls = 0;
+  const fakeEnqueue = ((fn: (s: any) => void) => {
+    calls += 1;
+    fn({ captureMessage: () => {} });
+  }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
+  reportInpMetric({ value: 120, rating: 'good', attribution: { interactionTarget: 'x' } }, fakeEnqueue);
+  assert.equal(calls, 0, 'good-rated (<200ms) INP is not reported');
+});
+
+test('reportInpMetric still reports poor-rated INP (#4565)', () => {
+  const { ctx } = capture({ value: 900, rating: 'poor', attribution: { interactionTarget: 'canvas' } });
+  assert.equal(ctx.tags['inp.rating'], 'poor');
+  assert.equal(ctx.extra.value, 900);
+});
+
+test('reportInpMetric still reports unknown/undefined-rated INP (conservative) (#4565)', () => {
+  let calls = 0;
+  const fakeEnqueue = ((fn: (s: any) => void) => {
+    calls += 1;
+    fn({ captureMessage: () => {} });
+  }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
+  reportInpMetric({ value: 250 }, fakeEnqueue); // no rating field
+  assert.equal(calls, 1, 'unknown/undefined rating still reports — do not drop unknowns');
+});


### PR DESCRIPTION
## Summary

Trims the field INP telemetry shipped in #4556: `reportInpMetric` now **skips `good`-rated INP** (<200ms) and reports only `needs-improvement`, `poor`, and `unknown`.

**Why:** a Sentry review showed `web-vital: INP` info events are the project's **#1 event source** — ~1 per page lifecycle on dashboard traffic ≈ **~16k/day (~500k/month)** info-level `captureMessage` events against the Sentry quota, dwarfing real errors. ~70% of those are `good` and carry little diagnostic value. Dropping them cuts ~70% of the volume while keeping every event we'd act on. The collection still works exactly as #4556 designed (once per page lifecycle, full attribution) — this is a pure volume/cost trim.

**Trade-off (recorded in #4565):** Sentry no longer shows the `good` bucket, so the full INP distribution / good-rate isn't visible from Sentry alone — that baseline remains available from CrUX / web.dev field data. We only lose the per-interaction `good` attribution, which we don't act on.

## Changes
- `src/bootstrap/inp-report.ts`: early-return when `metric.rating === 'good'`. No change to payload or once-per-lifecycle behavior; `unknown`/undefined ratings still report (don't drop unknowns).
- `tests/inp-report.test.mts`: +3 cases — `good` not enqueued; `poor` reported; `unknown` reported. 6/6 pass.

## Test plan
- [x] `tests/inp-report.test.mts` 6/6 (`tsx --test`)
- [x] `tsc --noEmit` 0 · biome clean
- [x] No new component files → docs-stats unaffected

Closes #4565. Part of #4537 / #4487.

https://claude.ai/code/session_011htsYLErqJb922Qm9QLraN