### PR TITLE
perf(map): wire conflict-zone layer through two-phase deferred commit (#4558)

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -153,6 +153,7 @@ import type { WebcamEntry, WebcamCluster } from '@/generated/client/worldmonitor
 import { fetchWebcamImage } from '@/services/webcams';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 import { summarizeRenderTiming, formatRenderTiming } from '@/components/map/render-timing';
+import { DeferredHeavyCommit } from '@/components/map/deferred-layer-commit';
 import {
   createCountryClickGestureTracker,
   finishCountryClickGesture,
@@ -705,6 +706,19 @@ export class DeckGLMap {
   private renderPaused = false;
   private renderPending = false;
   private webglLost = false;
+  /** Stable empty GeoJSON for the immediate (pre-defer) frame of a heavy layer (#4558). */
+  private readonly emptyHeavyData: GeoJSON.FeatureCollection = { type: 'FeatureCollection', features: [] };
+  /**
+   * Two-phase heavy-layer commit (#4558). On the interaction-attributed frame
+   * heavy layers render their previously-committed (or empty) data; the real
+   * data is committed on a deferred (yielded) frame so the deck.gl tessellation
+   * lands off the measured frame. The gate skips the defer when data is unchanged.
+   */
+  private readonly heavyGate = new DeferredHeavyCommit<unknown>({
+    schedule: (fn) => { const id = setTimeout(fn, 0); return () => clearTimeout(id); },
+    isAlive: () => !this.renderPaused && !this.webglLost && !!this.maplibreMap,
+    onCommit: () => this.updateLayers(true),
+  });
   private destroyed = false;
   private usedFallbackStyle = false;
   private readonly chrome: boolean;
@@ -1720,7 +1734,7 @@ export class DeckGLMap {
     return zoom >= threshold.minZoom;
   }
 
-  private buildLayers(): LayersList {
+  private buildLayers(deferHeavy = false): LayersList {
     const startTime = performance.now();
     // Refresh theme-aware overlay colors on each rebuild
     COLORS = getOverlayColors();
@@ -1831,9 +1845,12 @@ export class DeckGLMap {
       this.layerCache.delete('live-tankers-layer');
     }
 
-    // Conflict zones layer
+    // Conflict zones layer — heavy GeoJson tessellation routed through the
+    // two-phase commit so it lands off the interaction frame (#4558).
     if (mapLayers.conflicts) {
-      layers.push(this.createConflictZonesLayer());
+      layers.push(this.createConflictZonesLayer(
+        this.resolveHeavyData('conflict', () => this.buildConflictZoneGeoJson(), deferHeavy, this.emptyHeavyData),
+      ));
     }
 
 
@@ -2636,14 +2653,30 @@ export class DeckGLMap {
     return this.conflictZoneGeoJson;
   }
 
-  private createConflictZonesLayer(): GeoJsonLayer {
+  /**
+   * Two-phase heavy-layer data (#4558). On the immediate (deferHeavy) frame,
+   * stage the freshly-computed data and render the previously-committed value
+   * (or `empty` on first build) so the heavy deck.gl tessellation is deferred;
+   * the gate's deferred pass (deferHeavy=false) renders the committed real data.
+   * Unchanged data short-circuits in the gate (no extra frame).
+   */
+  private resolveHeavyData<T>(key: string, compute: () => T, deferHeavy: boolean, empty: T): T {
+    const real = compute();
+    if (deferHeavy) {
+      this.heavyGate.stage(key, real);
+      return (this.heavyGate.present(key) as T | undefined) ?? empty;
+    }
+    return (this.heavyGate.present(key) as T | undefined) ?? real;
+  }
+
+  private createConflictZonesLayer(data: GeoJSON.FeatureCollection): GeoJsonLayer {
     const cacheKey = this.countriesGeoJsonData
       ? 'conflict-zones-layer-country-geometry'
       : 'conflict-zones-layer';
 
     const layer = new GeoJsonLayer({
       id: cacheKey,
-      data: this.buildConflictZoneGeoJson(),
+      data,
       filled: true,
       stroked: true,
       getFillColor: () => COLORS.conflict,
@@ -5745,14 +5778,16 @@ export class DeckGLMap {
     }
   }
 
-  private updateLayers(): void {
+  private updateLayers(deferred = false): void {
     if (this.renderPaused || this.webglLost || !this.maplibreMap) return;
     const startTime = performance.now();
     let jsBuild = 0;
     let layerCount = 0;
     try {
       const buildStart = performance.now();
-      const built = this.buildLayers();
+      // Immediate pass defers heavy data (deferHeavy=true); the gate's deferred
+      // pass (deferred=true) commits the real heavy data (#4558).
+      const built = this.buildLayers(!deferred);
       jsBuild = performance.now() - buildStart;
       layerCount = built.length;
       this.deckOverlay?.setProps({ layers: built });

--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -795,15 +795,13 @@ export class DeckGLMap {
     this.debouncedRebuildLayers = debounce(() => {
       if (this.renderPaused || this.webglLost || !this.maplibreMap) return;
       this.maplibreMap.resize();
-      try { this.deckOverlay?.setProps({ layers: this.buildLayers() }); } catch { /* map mid-teardown */ }
-      this.maplibreMap.triggerRepaint();
+      this.updateLayers();
     }, 150);
     this.debouncedFetchBases = debounce(() => this.fetchServerBases(), 300);
     this.debouncedFetchAircraft = debounce(() => this.fetchViewportAircraft(), 500);
     this.rafUpdateLayers = rafSchedule(() => {
       if (this.renderPaused || this.webglLost || !this.maplibreMap) return;
-      try { this.deckOverlay?.setProps({ layers: this.buildLayers() }); } catch { /* map mid-teardown */ }
-      this.maplibreMap?.triggerRepaint();
+      this.updateLayers();
     });
 
     this.setupDOM();
@@ -1153,7 +1151,7 @@ export class DeckGLMap {
 
     this.deckOverlay = new MapboxOverlay({
       interleaved: true,
-      layers: this.buildLayers(),
+      layers: this.buildLayers(true),
       getTooltip: (info: PickingInfo) => this.getTooltip(info),
       onClick: (info: PickingInfo) => this.handleClick(info),
       pickingRadius: 10,
@@ -1166,7 +1164,7 @@ export class DeckGLMap {
         if (error.message.includes('satellite-imagery-layer')) {
           this.satelliteImageryLayerFailed = true;
           console.warn('[DeckGLMap] Satellite imagery layer failed (likely Intel GPU driver incompatibility) — rebuilding layer stack without it');
-          try { this.deckOverlay?.setProps({ layers: this.buildLayers() }); } catch { /* map mid-teardown */ }
+          this.updateLayers();
         }
       },
     });
@@ -2661,12 +2659,12 @@ export class DeckGLMap {
    * Unchanged data short-circuits in the gate (no extra frame).
    */
   private resolveHeavyData<T>(key: string, compute: () => T, deferHeavy: boolean, empty: T): T {
-    const real = compute();
     if (deferHeavy) {
+      const real = compute();
       this.heavyGate.stage(key, real);
       return (this.heavyGate.present(key) as T | undefined) ?? empty;
     }
-    return (this.heavyGate.present(key) as T | undefined) ?? real;
+    return (this.heavyGate.present(key) as T | undefined) ?? compute();
   }
 
   private createConflictZonesLayer(data: GeoJSON.FeatureCollection): GeoJsonLayer {
@@ -7562,6 +7560,7 @@ export class DeckGLMap {
     this.debouncedFetchBases.cancel();
     this.debouncedFetchAircraft.cancel();
     this.rafUpdateLayers.cancel();
+    this.heavyGate.cancel();
 
     if (this.renderRafId !== null) {
       cancelAnimationFrame(this.renderRafId);


### PR DESCRIPTION
## Summary

Wires the **conflict-zone GeoJsonLayer** — the primary unbounded deck.gl tessellation and the #1 warm-INP cost per the field ranking (#4537) — through the `DeferredHeavyCommit` two-phase gate landed in #4562. This is the production render-path integration the nucleus PR left as a browser-gated checklist.

**Mechanism:** `updateLayers(deferred=false)` → `buildLayers(deferHeavy=true)` renders the heavy layer with its **previously-committed (or empty) data** and stages the real data in the gate; the gate yields (`setTimeout 0`) and its `onCommit` fires `updateLayers(true)` → `buildLayers(deferHeavy=false)` with the **real data**, so the tessellation lands off the interaction-attributed frame. Unchanged data short-circuits in the gate (no extra frame, no flicker); already-visible layers keep their prior data across phase 1 (no blink); stable layer IDs throughout (no list-split).

## Verified in-browser ✅
Dev server, `/dashboard?layers=conflicts`: map renders fully (continents, borders, deck.gl WEBGL overlay), the **conflict-zones layer commits via the deferred path** (legend present, data renders), **no flicker**, and **no deck.gl/render console errors** (only expected local data-fetch failures). The plan's load-bearing unknown — deck.gl 9.2's empty→real `data` swap on a stable-id `GeoJsonLayer` — is confirmed to be an **in-place attribute update** (no teardown/flicker), so no `visible:false` fallback needed.

- [x] `tsc --noEmit` 0 · biome clean
- [x] nucleus tests (`deckgl-deferred-commit`, `deckgl-render-timing`) 14/14
- [x] in-browser: map + conflict layer render correctly, no errors

## Scope / follow-ups (this PR = conflict zones only)
- **Other heavy layers** (the 4 Supercluster cluster layers + bases cluster) can adopt the same `resolveHeavyData` helper — **lower priority**: they're already clustered + viewport-culled (`getClusters(bbox,zoom)`, `MAX_CLUSTER_LEAVES=200`), so their per-frame cost is already bounded. Tracked under #4561 (the bound-the-frame follow-up).
- **U3 lab before/after** via the U1 DEV breakdown (median ≥3 runs, world + regional zoom) — attach once measured.

Part of #4558 / #4537 / #4487. Follows #4562 (nucleus).

https://claude.ai/code/session_011htsYLErqJb922Qm9QLraN