### PR TITLE
fix(telemetry): attribute API-key usage events to tier + plan_key (#4572)

### DIFF
--- a/server/__tests__/gateway-api-rate-limit.test.ts
+++ b/server/__tests__/gateway-api-rate-limit.test.ts
@@ -53,6 +53,7 @@ let entitlement: typeof STARTER | { planKey: string; features: Record<string, un
 vi.mock("../_shared/entitlement-check", () => ({
   getRequiredTier: () => null, // not tier-gated
   checkEntitlement: vi.fn().mockResolvedValue(null), // passes
+  checkEntitlementDetailed: vi.fn().mockResolvedValue({ response: null, entitlements: null }), // passes
   getEntitlements: vi.fn(async () => entitlement),
 }));
 

--- a/server/__tests__/usage-identity.test.ts
+++ b/server/__tests__/usage-identity.test.ts
@@ -20,9 +20,32 @@ function baseInput(overrides: Partial<UsageIdentityInput> = {}): UsageIdentityIn
     clerkOrgId: null,
     userApiKeyCustomerRef: null,
     tier: null,
+    planKey: null,
     ...overrides,
   };
 }
+
+describe('buildUsageIdentity — plan_key attribution (#4572)', () => {
+  test('user_api_key carries the resolved planKey', () => {
+    const ident = buildUsageIdentity(baseInput({
+      isUserApiKey: true,
+      sessionUserId: 'u',
+      tier: 2,
+      planKey: 'api_business',
+    }));
+    expect(ident.plan_key).toBe('api_business');
+  });
+
+  test('enterprise_api_key defaults plan_key to "enterprise" when none supplied', () => {
+    const ident = buildUsageIdentity(baseInput({ enterpriseApiKey: 'wm_ent_x', tier: 3 }));
+    expect(ident.auth_kind).toBe('enterprise_api_key');
+    expect(ident.plan_key).toBe('enterprise');
+  });
+
+  test('anon has null plan_key', () => {
+    expect(buildUsageIdentity(baseInput()).plan_key).toBeNull();
+  });
+});
 
 describe('buildUsageIdentity — auth_kind branches', () => {
   test('user_api_key takes precedence over every other signal', () => {

--- a/server/_shared/entitlement-check.ts
+++ b/server/_shared/entitlement-check.ts
@@ -17,7 +17,7 @@ import { getCachedJson, setCachedJson } from './redis';
 // Types
 // ---------------------------------------------------------------------------
 
-interface CachedEntitlements {
+export interface CachedEntitlements {
   planKey: string;
   features: {
     tier: number;
@@ -45,6 +45,11 @@ interface CachedEntitlements {
     apiDailyAllowance?: number;
   };
   validUntil: number;
+}
+
+export interface EntitlementCheckResult {
+  response: Response | null;
+  entitlements: CachedEntitlements | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -220,44 +225,67 @@ export async function checkEntitlement(
   pathname: string,
   corsHeaders: Record<string, string>,
 ): Promise<Response | null> {
+  const result = await checkEntitlementDetailed(userId, pathname, corsHeaders);
+  return result.response;
+}
+
+/**
+ * Same authorization decision as checkEntitlement(), plus the resolved
+ * entitlement row when one was available. Gateway telemetry uses this so
+ * allow/deny events reflect the exact plan/tier that drove the decision.
+ */
+export async function checkEntitlementDetailed(
+  userId: string | null,
+  pathname: string,
+  corsHeaders: Record<string, string>,
+): Promise<EntitlementCheckResult> {
   const requiredTier = getRequiredTier(pathname);
   if (requiredTier === null) {
     // Unrestricted endpoint -- no check needed
-    return null;
+    return { response: null, entitlements: null };
   }
 
   if (!userId) {
-    return new Response(
-      JSON.stringify({ error: 'Authentication required', requiredTier }),
-      { status: 403, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
-    );
+    return {
+      response: new Response(
+        JSON.stringify({ error: 'Authentication required', requiredTier }),
+        { status: 403, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      ),
+      entitlements: null,
+    };
   }
 
   const ent = await getEntitlements(userId);
   if (!ent) {
     // Fail-closed: unable to verify entitlements -> block the request
-    return new Response(
-      JSON.stringify({ error: 'Unable to verify entitlements', requiredTier }),
-      { status: 403, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
-    );
+    return {
+      response: new Response(
+        JSON.stringify({ error: 'Unable to verify entitlements', requiredTier }),
+        { status: 403, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+      ),
+      entitlements: null,
+    };
   }
 
   if (ent.features.tier >= requiredTier) {
     // User has sufficient tier -- allow
-    return null;
+    return { response: null, entitlements: ent };
   }
 
   // User lacks required tier -- return 403
-  return new Response(
-    JSON.stringify({
-      error: 'Upgrade required',
-      requiredTier,
-      currentTier: ent.features.tier,
-      planKey: ent.planKey,
-    }),
-    {
-      status: 403,
-      headers: { 'Content-Type': 'application/json', ...corsHeaders },
-    },
-  );
+  return {
+    response: new Response(
+      JSON.stringify({
+        error: 'Upgrade required',
+        requiredTier,
+        currentTier: ent.features.tier,
+        planKey: ent.planKey,
+      }),
+      {
+        status: 403,
+        headers: { 'Content-Type': 'application/json', ...corsHeaders },
+      },
+    ),
+    entitlements: ent,
+  };
 }

--- a/server/_shared/usage-identity.ts
+++ b/server/_shared/usage-identity.ts
@@ -20,6 +20,7 @@ export interface UsageIdentity {
   principal_id: string | null;
   customer_id: string | null;
   tier: number;
+  plan_key: string | null;
 }
 
 export interface UsageIdentityInput {
@@ -30,6 +31,9 @@ export interface UsageIdentityInput {
   clerkOrgId: string | null;
   userApiKeyCustomerRef: string | null;
   tier: number | null;
+  // #4572 — entitlement planKey (api_starter / api_business / …) when the
+  // gateway resolved one; null otherwise. 'enterprise' for env keys.
+  planKey: string | null;
 }
 
 // Static enterprise-key → customer map. Explicit so attribution is reviewable in code,
@@ -48,6 +52,7 @@ export function buildUsageIdentity(input: UsageIdentityInput): UsageIdentity {
       principal_id: input.sessionUserId,
       customer_id: input.userApiKeyCustomerRef ?? input.sessionUserId,
       tier,
+      plan_key: input.planKey,
     };
   }
 
@@ -57,6 +62,7 @@ export function buildUsageIdentity(input: UsageIdentityInput): UsageIdentity {
       principal_id: input.sessionUserId,
       customer_id: input.clerkOrgId ?? input.sessionUserId,
       tier,
+      plan_key: input.planKey,
     };
   }
 
@@ -67,6 +73,7 @@ export function buildUsageIdentity(input: UsageIdentityInput): UsageIdentity {
       principal_id: hashKeySync(input.enterpriseApiKey),
       customer_id: customer,
       tier,
+      plan_key: input.planKey ?? 'enterprise',
     };
   }
 
@@ -76,6 +83,7 @@ export function buildUsageIdentity(input: UsageIdentityInput): UsageIdentity {
       principal_id: hashKeySync(input.widgetKey),
       customer_id: input.widgetKey,
       tier,
+      plan_key: null,
     };
   }
 
@@ -84,6 +92,7 @@ export function buildUsageIdentity(input: UsageIdentityInput): UsageIdentity {
     principal_id: null,
     customer_id: null,
     tier: 0,
+    plan_key: null,
   };
 }
 

--- a/server/_shared/usage.ts
+++ b/server/_shared/usage.ts
@@ -96,6 +96,11 @@ export interface RequestEvent {
   principal_id: string | null;
   auth_kind: AuthKind;
   tier: number;
+  // #4572 — API plan attribution. planKey of the caller's entitlement
+  // (api_starter / api_business / enterprise / …) or null. Distinguishes
+  // Starter from Business (both tier 2) so the limit-abuse audit can compare
+  // each request to the customer's actual cap without an external lookup.
+  plan_key: string | null;
   country: string | null;
   ip_city: string | null;
   ip_region: string | null;
@@ -147,6 +152,7 @@ export function buildRequestEvent(p: {
   principalId: string | null;
   authKind: AuthKind;
   tier: number;
+  planKey: string | null;
   country: string | null;
   ipCity: string | null;
   ipRegion: string | null;
@@ -178,6 +184,7 @@ export function buildRequestEvent(p: {
     principal_id: p.principalId,
     auth_kind: p.authKind,
     tier: p.tier,
+    plan_key: p.planKey,
     country: p.country,
     ip_city: p.ipCity,
     ip_region: p.ipRegion,

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -522,6 +522,7 @@ export function createDomainGateway(
       clerkOrgId: null,
       userApiKeyCustomerRef: null,
       tier: null,
+      planKey: null,
     };
     // Domain segment for telemetry. Path layouts:
     //   /api/<domain>/v1/<rpc>          → parts[2] = domain
@@ -560,6 +561,7 @@ export function createDomainGateway(
             principalId: identity.principal_id,
             authKind: identity.auth_kind,
             tier: identity.tier,
+            planKey: identity.plan_key,
             country: deriveCountry(originalRequest),
             ipCity: deriveIpCity(originalRequest),
             ipRegion: deriveIpRegion(originalRequest),
@@ -1077,6 +1079,8 @@ export function createDomainGateway(
         if (isEnterpriseAuth) {
           perMinute = ENTERPRISE_API_RATE_LIMIT; // hardcoded — no entitlement row
           allowance = -1; // unlimited daily / no ceiling
+          usage.tier = 3; // enterprise tier — no entitlement row to read it from
+          // (plan_key defaults to 'enterprise' in buildUsageIdentity)
           // Enterprise burst is keyed PER KEY (not per account) by design:
           // these are operator-issued WORLDMONITOR_VALID_KEYS with no shared
           // userId, and unlimited daily — so there's no quota to multiply by
@@ -1086,6 +1090,13 @@ export function createDomainGateway(
           identity = wmKey ? hashKeySync(wmKey) : '';
         } else if (sessionUserId) {
           const ent = await getEntitlements(sessionUserId);
+          if (ent) {
+            // #4572 — attribute the usage event to the caller's real tier +
+            // plan (recorded even for downgraded keys), so the limit-abuse
+            // audit can compare each request to the customer's actual cap.
+            usage.tier = ent.features.tier;
+            usage.planKey = ent.planKey;
+          }
           if (ent && ent.features.apiAccess && ent.features.apiRateLimit > 0) {
             perMinute = ent.features.apiRateLimit;
             // undefined ⇒ fail-open (no daily limit); -1 ⇒ unlimited.

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -18,7 +18,7 @@ import { captureSilentError } from '../api/_sentry-edge.js';
 import { mapErrorToResponse } from './error-mapper';
 import { checkRateLimit, checkEndpointRateLimit, hasEndpointRatePolicy } from './_shared/rate-limit';
 import { drainResponseHeaders } from './_shared/response-headers';
-import { checkEntitlement, getRequiredTier, getEntitlements } from './_shared/entitlement-check';
+import { checkEntitlementDetailed, getRequiredTier, getEntitlements, type CachedEntitlements } from './_shared/entitlement-check';
 import { resolveClerkSession } from './_shared/auth-session';
 import {
   INTERNAL_MCP_SIG_HEADER,
@@ -524,6 +524,11 @@ export function createDomainGateway(
       tier: null,
       planKey: null,
     };
+    function recordUsageEntitlement(ent: CachedEntitlements | null): void {
+      if (!ent) return;
+      usage.tier = typeof ent.features.tier === 'number' ? ent.features.tier : 0;
+      usage.planKey = ent.planKey;
+    }
     // Domain segment for telemetry. Path layouts:
     //   /api/<domain>/v1/<rpc>          → parts[2] = domain
     //   /api/v2/<domain>/<rpc>          → parts[2] = "v2", parts[3] = domain
@@ -852,9 +857,7 @@ export function createDomainGateway(
       if (bodyBytes !== null) rebuildInit.body = bodyBytes;
       request = new Request(request.url, rebuildInit);
       usage.sessionUserId = verified.userId;
-      if (typeof ent.features.tier === 'number') {
-        usage.tier = ent.features.tier;
-      }
+      recordUsageEntitlement(ent);
       internalMcpVerified = true;
     }
 
@@ -948,7 +951,7 @@ export function createDomainGateway(
     // Admin keys (WORLDMONITOR_VALID_KEYS) bypass this since they are operator-issued.
     if (isUserApiKey && needsLegacyProBearerGate && sessionUserId) {
       const ent = await getEntitlements(sessionUserId);
-      if (ent) usage.tier = typeof ent.features.tier === 'number' ? ent.features.tier : 0;
+      recordUsageEntitlement(ent);
       if (!ent || !ent.features.apiAccess) {
         emitRequest(403, 'tier_403', null);
         return createGatewayAuthErrorResponse(403, 'API access subscription required', corsHeaders);
@@ -992,7 +995,7 @@ export function createDomainGateway(
           let allowed = session.role === 'pro';
           if (!allowed && session.userId) {
             const ent = await getEntitlements(session.userId);
-            if (ent) usage.tier = typeof ent.features.tier === 'number' ? ent.features.tier : 0;
+            recordUsageEntitlement(ent);
             allowed = !!ent && ent.features.tier >= 1 && ent.validUntil >= Date.now();
           }
           if (!allowed) {
@@ -1022,7 +1025,9 @@ export function createDomainGateway(
     // through the MCP edge's whitelisted tool set.
     const isEnterpriseAuth = keyCheck.valid && wmKey && !isUserApiKey && keyCheck.kind === 'enterprise';
     if (!isEnterpriseAuth && !internalMcpVerified && !seedRefreshVerified && !relayWarmPingVerified) {
-      const entitlementResponse = await checkEntitlement(sessionUserId, pathname, corsHeaders);
+      const entitlementCheck = await checkEntitlementDetailed(sessionUserId, pathname, corsHeaders);
+      recordUsageEntitlement(entitlementCheck.entitlements);
+      const entitlementResponse = entitlementCheck.response;
       if (entitlementResponse) {
         const entReason: RequestReason =
           entitlementResponse.status === 401 ? 'auth_401'
@@ -1032,13 +1037,6 @@ export function createDomainGateway(
         return entitlementResponse.status === 401 || entitlementResponse.status === 403
           ? markAuthErrorNoStore(entitlementResponse)
           : entitlementResponse;
-      }
-      // Allowed → record the resolved tier for telemetry. getEntitlements has
-      // its own Redis cache + in-flight coalescing, so the second lookup here
-      // does not double the cost when checkEntitlement already fetched.
-      if (isTierGated && sessionUserId && usage.tier === null) {
-        const ent = await getEntitlements(sessionUserId);
-        if (ent) usage.tier = typeof ent.features.tier === 'number' ? ent.features.tier : 0;
       }
     }
 
@@ -1094,8 +1092,7 @@ export function createDomainGateway(
             // #4572 — attribute the usage event to the caller's real tier +
             // plan (recorded even for downgraded keys), so the limit-abuse
             // audit can compare each request to the customer's actual cap.
-            usage.tier = ent.features.tier;
-            usage.planKey = ent.planKey;
+            recordUsageEntitlement(ent);
           }
           if (ent && ent.features.apiAccess && ent.features.apiRateLimit > 0) {
             perMinute = ent.features.apiRateLimit;

--- a/tests/usage-telemetry-emission.test.mts
+++ b/tests/usage-telemetry-emission.test.mts
@@ -36,6 +36,7 @@ interface CapturedEvent {
   customer_id: string | null;
   auth_kind: string;
   tier: number;
+  plan_key: string | null;
   reason: string;
 }
 
@@ -62,7 +63,7 @@ function makeRecordingCtx(): { ctx: GatewayCtx; settled: Promise<void> } {
 
 function installAxiomFetchSpy(
   originalFetch: typeof fetch,
-  opts: { entitlementsResponse?: unknown } = {},
+  opts: { entitlementsResponse?: unknown; apiKeyValidationResponse?: unknown } = {},
 ): {
   events: CapturedEvent[];
   restore: () => void;
@@ -74,6 +75,12 @@ function installAxiomFetchSpy(
       const body = init?.body ? JSON.parse(init.body as string) as CapturedEvent[] : [];
       for (const ev of body) events.push(ev);
       return new Response('{}', { status: 200 });
+    }
+    if (url.includes('/api/internal-validate-api-key')) {
+      return new Response(JSON.stringify(opts.apiKeyValidationResponse ?? null), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
     }
     if (url.includes('/api/internal-entitlements')) {
       return new Response(JSON.stringify(opts.entitlementsResponse ?? null), {
@@ -90,6 +97,8 @@ const ORIGINAL_FETCH = globalThis.fetch;
 const ORIGINAL_USAGE_FLAG = process.env.USAGE_TELEMETRY;
 const ORIGINAL_AXIOM_TOKEN = process.env.AXIOM_API_TOKEN;
 const ORIGINAL_VALID_KEYS = process.env.WORLDMONITOR_VALID_KEYS;
+const ORIGINAL_CONVEX_SITE_URL = process.env.CONVEX_SITE_URL;
+const ORIGINAL_CONVEX_SHARED_SECRET = process.env.CONVEX_SERVER_SHARED_SECRET;
 
 afterEach(() => {
   globalThis.fetch = ORIGINAL_FETCH;
@@ -99,6 +108,10 @@ afterEach(() => {
   else process.env.AXIOM_API_TOKEN = ORIGINAL_AXIOM_TOKEN;
   if (ORIGINAL_VALID_KEYS == null) delete process.env.WORLDMONITOR_VALID_KEYS;
   else process.env.WORLDMONITOR_VALID_KEYS = ORIGINAL_VALID_KEYS;
+  if (ORIGINAL_CONVEX_SITE_URL == null) delete process.env.CONVEX_SITE_URL;
+  else process.env.CONVEX_SITE_URL = ORIGINAL_CONVEX_SITE_URL;
+  if (ORIGINAL_CONVEX_SHARED_SECRET == null) delete process.env.CONVEX_SERVER_SHARED_SECRET;
+  else process.env.CONVEX_SERVER_SHARED_SECRET = ORIGINAL_CONVEX_SHARED_SECRET;
 });
 
 describe('gateway telemetry payload — domain extraction', () => {
@@ -348,6 +361,62 @@ describe('gateway telemetry payload — bearer identity propagation', () => {
     assert.equal(ev.auth_kind, 'clerk_jwt');
     assert.equal(ev.domain, 'market');
     assert.equal(ev.route, '/api/market/v1/analyze-stock');
+  });
+
+  it('records plan_key for user API-key requests rejected by entitlement gate', async () => {
+    process.env.USAGE_TELEMETRY = '1';
+    process.env.AXIOM_API_TOKEN = 'test-token';
+    process.env.CONVEX_SITE_URL = 'https://convex.test';
+    process.env.CONVEX_SERVER_SHARED_SECRET = 'test-shared-secret';
+
+    const freeEntitlements = {
+      planKey: 'free',
+      features: {
+        tier: 0,
+        apiAccess: false,
+        apiRateLimit: 0,
+        maxDashboards: 3,
+        prioritySupport: false,
+        exportFormats: ['csv'],
+        mcpAccess: false,
+      },
+      validUntil: Date.now() + 60_000,
+    };
+    const spy = installAxiomFetchSpy(ORIGINAL_FETCH, {
+      apiKeyValidationResponse: { userId: 'user_free_api_key', keyId: 'key_free', name: 'Free key' },
+      entitlementsResponse: freeEntitlements,
+    });
+
+    const handler = createDomainGateway([
+      {
+        method: 'GET',
+        path: '/api/market/v1/analyze-stock',
+        handler: async () => new Response('{"ok":true}', { status: 200 }),
+      },
+    ]);
+
+    const recorder = makeRecordingCtx();
+    const res = await handler(
+      new Request('https://worldmonitor.app/api/market/v1/analyze-stock?symbol=AAPL', {
+        headers: {
+          Origin: 'https://worldmonitor.app',
+          'X-Api-Key': 'wm_test_free_key',
+        },
+      }),
+      recorder.ctx,
+    );
+    assert.equal(res.status, 403, 'free user API key should fail the tier-gated endpoint');
+
+    await recorder.settled;
+    spy.restore();
+
+    assert.equal(spy.events.length, 1);
+    const ev = spy.events[0]!;
+    assert.equal(ev.auth_kind, 'user_api_key');
+    assert.equal(ev.customer_id, 'user_free_api_key');
+    assert.equal(ev.tier, 0);
+    assert.equal(ev.plan_key, 'free');
+    assert.equal(ev.reason, 'tier_403');
   });
 
   it('still emits with auth_kind=anon when the bearer is invalid', async () => {


### PR DESCRIPTION
Closes #4572. Follow-up to #3199 / #4563, surfaced while running the shadow-mode limit-abuse audit.

## Problem

The audit against Axiom `wm_api_usage` couldn't attribute an API-key request to its plan/caps:
- `usage.tier` was only set on tier-gated routes, so API-key traffic on public routes emitted **`tier: 0`** (56,988 `user_api_key` events at tier 0 vs 9,452 at tier 2 — the field was unreliable, even though every `user_api_key` holder is paid tier 2+).
- Starter and Business are **both `tier: 2`**, so even with tier fixed they're indistinguishable — the audit needed an external Convex/Dodo lookup per customer.

## Fix

In the #3199 gateway rate-limit block (where `getEntitlements(sessionUserId)` is already resolved):
- Set `usage.tier = ent.features.tier` + `usage.planKey = ent.planKey` (recorded even for downgraded keys); enterprise env keys → `tier 3` / `plan_key 'enterprise'`.
- Thread a new **`plan_key`** field through `UsageIdentity` → `RequestEvent` → `buildRequestEvent`, mirroring `auth_kind`/`customer_id`.

Additive optional field — no Axiom schema migration. The audit can now group by `customer_id` + `plan_key` and compare each customer's peak rpm/day to *their* cap with zero external lookups.

## Verification

- 39 vitest tests pass (3 new `buildUsageIdentity` `plan_key` cases + existing gateway-wiring + entitlement suites unchanged).
- `tsc --noEmit`, `typecheck:api`, biome lint all clean.
- Diff is 50 insertions, purely additive — gateway edits only set telemetry fields; no change to rate-limiting decisions, eligibility, or responses.

## Risk

Telemetry-only. Worst case a field is null on some path (handled — `plan_key` is nullable). No request-flow impact.

https://claude.ai/code/session_01SjVX3GyMBmC2XyFWCHogN1
