### PR TITLE
perf(boot): lazy-load Widget/Mcp/Story modals off the FCP critical path (#4571)

### DIFF
--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -27,10 +27,10 @@ import { getCachedCountryScore, normalizeCiiCountryCode } from '@/services/cache
 import { dataFreshness } from '@/services/data-freshness';
 import { fetchCountryMarkets } from '@/services/prediction';
 import { collectStoryData } from '@/services/story-data';
-// renderStoryToCanvas is dynamic-imported at its call site (#4486) so story-renderer
-// stays off the eager boot graph; this is one of its two eager edges (the other is
-// StoryModal). The export runs on user interaction (post-paint), already async.
-import { openStoryModal } from '@/components/StoryModal';
+// StoryModal — and the story-renderer it statically pulls in — is lazy-imported at
+// its call site (below) so it stays off the eager boot graph. renderStoryToCanvas was
+// already made dynamic in #4486; #4571 closes the remaining StoryModal eager edge.
+// The modal opens on user interaction (post-paint), so the import() latency is hidden.
 
 import { hasPremiumAccess } from '@/services/panel-gating';
 import { getAuthState, subscribeAuthState } from '@/services/auth-state';
@@ -1512,7 +1512,7 @@ export class CountryIntelManager implements AppModule {
       regionalDescriptions: regional.map(r => r.description),
     } : null;
     const data = collectStoryData(code, name, this.ctx.latestClusters, postures, this.ctx.latestPredictions, signals, convergence);
-    openStoryModal(data);
+    void import('@/components/StoryModal').then((m) => m.openStoryModal(data));
   }
 
   showToast(msg: string): void {

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -27,10 +27,11 @@ import { getCachedCountryScore, normalizeCiiCountryCode } from '@/services/cache
 import { dataFreshness } from '@/services/data-freshness';
 import { fetchCountryMarkets } from '@/services/prediction';
 import { collectStoryData } from '@/services/story-data';
-// StoryModal — and the story-renderer it statically pulls in — is lazy-imported at
-// its call site (below) so it stays off the eager boot graph. renderStoryToCanvas was
-// already made dynamic in #4486; #4571 closes the remaining StoryModal eager edge.
-// The modal opens on user interaction (post-paint), so the import() latency is hidden.
+// StoryModal is lazy-imported at its call site (below), and its render path
+// lazy-imports story-renderer, so both stay off the eager boot graph.
+// renderStoryToCanvas was already made dynamic in #4486; #4571 closes the
+// remaining StoryModal eager edge. The modal opens on user interaction
+// (post-paint), so the import() latency is hidden.
 
 import { hasPremiumAccess } from '@/services/panel-gating';
 import { getAuthState, subscribeAuthState } from '@/services/auth-state';

--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -1512,7 +1512,10 @@ export class CountryIntelManager implements AppModule {
       regionalDescriptions: regional.map(r => r.description),
     } : null;
     const data = collectStoryData(code, name, this.ctx.latestClusters, postures, this.ctx.latestPredictions, signals, convergence);
-    void import('@/components/StoryModal').then((m) => m.openStoryModal(data));
+    // await (not void) so a chunk-load failure rejects openCountryStory's promise and
+    // reaches the caller's existing .catch() toast handler (country-intel.ts:205).
+    const { openStoryModal } = await import('@/components/StoryModal');
+    openStoryModal(data);
   }
 
   showToast(msg: string): void {

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -583,7 +583,7 @@ export class EventHandlerManager implements AppModule {
           saveWidget(updated);
           (this.ctx.panels[updated.id] as CustomWidgetPanel | undefined)?.updateSpec(updated);
         },
-      }));
+      })).catch((err) => console.error('[widget-chat] failed to lazy-load WidgetChatModal', err));
     }) as EventListener;
     this.ctx.container.addEventListener('wm:widget-modify', this.boundWidgetModifyHandler);
 
@@ -596,7 +596,7 @@ export class EventHandlerManager implements AppModule {
           saveMcpPanel(updated);
           (this.ctx.panels[updated.id] as McpDataPanel | undefined)?.updateSpec(updated);
         },
-      }));
+      })).catch((err) => console.error('[mcp-connect] failed to lazy-load McpConnectModal', err));
     }) as EventListener);
 
     // undo via Ctrl/Cmd+Z

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -7,7 +7,6 @@ import type {
 import type { UnifiedSettingsConfig } from '@/components/UnifiedSettings';
 import type { AirlineIntelPanel } from '@/components/AirlineIntelPanel';
 import type { CustomWidgetPanel } from '@/components/CustomWidgetPanel';
-import { openWidgetChatModal } from '@/components/WidgetChatModal';
 import { deleteWidget, getWidget, saveWidget, isProUser } from '@/services/widget-store';
 import {
   FREE_MAX_PANELS,
@@ -16,7 +15,6 @@ import {
   isFreePanelCapCounted,
 } from '@/config/panels';
 import type { McpDataPanel } from '@/components/McpDataPanel';
-import { openMcpConnectModal } from '@/components/McpConnectModal';
 import { deleteMcpPanel, getMcpPanel, saveMcpPanel } from '@/services/mcp-store';
 import type { PanelConfig, MapLayers, MilitaryFlight } from '@/types';
 import type { MapView } from '@/components/MapContainer';
@@ -578,27 +576,27 @@ export class EventHandlerManager implements AppModule {
     this.boundWidgetModifyHandler = ((e: CustomEvent<{ widgetId: string }>) => {
       const spec = getWidget(e.detail.widgetId);
       if (!spec) return;
-      openWidgetChatModal({
+      void import('@/components/WidgetChatModal').then((m) => m.openWidgetChatModal({
         mode: 'modify',
         existingSpec: spec,
         onComplete: (updated) => {
           saveWidget(updated);
           (this.ctx.panels[updated.id] as CustomWidgetPanel | undefined)?.updateSpec(updated);
         },
-      });
+      }));
     }) as EventListener;
     this.ctx.container.addEventListener('wm:widget-modify', this.boundWidgetModifyHandler);
 
     this.ctx.container.addEventListener('wm:mcp-configure', ((e: CustomEvent<{ panelId: string }>) => {
       const spec = getMcpPanel(e.detail.panelId);
       if (!spec) return;
-      openMcpConnectModal({
+      void import('@/components/McpConnectModal').then((m) => m.openMcpConnectModal({
         existingSpec: spec,
         onComplete: (updated) => {
           saveMcpPanel(updated);
           (this.ctx.panels[updated.id] as McpDataPanel | undefined)?.updateSpec(updated);
         },
-      });
+      }));
     }) as EventListener);
 
     // undo via Ctrl/Cmd+Z

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -42,7 +42,6 @@ import { t } from '@/services/i18n';
 import { getCurrentTheme } from '@/utils';
 import { trackCriticalBannerAction } from '@/services/analytics';
 import { getStoredMapModePreference } from '@/services/map-mode-preference';
-import { openWidgetChatModal } from '@/components/WidgetChatModal';
 import { loadWidgets, saveWidget, isProUser } from '@/services/widget-store';
 import type { CustomWidgetSpec } from '@/services/widget-store';
 import { initEntitlementSubscription, destroyEntitlementSubscription, isEntitled, hasTier, getEntitlementState, onEntitlementChange, shouldReloadOnEntitlementChange } from '@/services/entitlements';
@@ -51,7 +50,6 @@ import { initPaymentFailureBanner } from '@/components/payment-failure-banner';
 import { handleCheckoutReturn } from '@/services/checkout-return';
 import { registerCheckoutSuccessCallback, destroyCheckoutOverlay, showCheckoutSuccess, consumePostCheckoutFlag, clearCheckoutAttempt } from '@/services/checkout';
 import { showCheckoutFailureBanner } from '@/components/checkout-failure-banner';
-import { openMcpConnectModal } from '@/components/McpConnectModal';
 import { PanelTabBar } from '@/components/PanelTabBar';
 import {
   loadTabsState,
@@ -401,12 +399,12 @@ export class PanelLayoutManager implements AppModule {
 
     // Handle analyst action chip "Create chart widget →" click
     this.boundWidgetCreatorHandler = ((e: CustomEvent<{ initialMessage?: string }>) => {
-      openWidgetChatModal({
+      void import('@/components/WidgetChatModal').then((m) => m.openWidgetChatModal({
         mode: 'create',
         tier: 'pro',
         initialMessage: e.detail.initialMessage,
         onComplete: (spec) => this.addCustomWidget(spec),
-      });
+      }));
     }) as EventListener;
     this.ctx.container.addEventListener('wm:open-widget-creator', this.boundWidgetCreatorHandler);
   }
@@ -2177,11 +2175,11 @@ export class PanelLayoutManager implements AppModule {
     proBlock.appendChild(proLabel);
     proBlock.appendChild(proBadge);
     proBlock.addEventListener('click', () => {
-      openWidgetChatModal({
+      void import('@/components/WidgetChatModal').then((m) => m.openWidgetChatModal({
         mode: 'create',
         tier: 'pro',
         onComplete: (spec) => this.addCustomWidget(spec),
-      });
+      }));
     });
     panelsGrid.appendChild(proBlock);
 
@@ -2201,9 +2199,9 @@ export class PanelLayoutManager implements AppModule {
     mcpBlock.appendChild(mcpLabel);
     mcpBlock.appendChild(mcpBadge);
     mcpBlock.addEventListener('click', () => {
-      openMcpConnectModal({
+      void import('@/components/McpConnectModal').then((m) => m.openMcpConnectModal({
         onComplete: (spec) => this.addMcpPanel(spec),
-      });
+      }));
     });
     panelsGrid.appendChild(mcpBlock);
 

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -404,7 +404,7 @@ export class PanelLayoutManager implements AppModule {
         tier: 'pro',
         initialMessage: e.detail.initialMessage,
         onComplete: (spec) => this.addCustomWidget(spec),
-      }));
+      })).catch((err) => console.error('[widget-chat] failed to lazy-load WidgetChatModal', err));
     }) as EventListener;
     this.ctx.container.addEventListener('wm:open-widget-creator', this.boundWidgetCreatorHandler);
   }
@@ -2179,7 +2179,7 @@ export class PanelLayoutManager implements AppModule {
         mode: 'create',
         tier: 'pro',
         onComplete: (spec) => this.addCustomWidget(spec),
-      }));
+      })).catch((err) => console.error('[widget-chat] failed to lazy-load WidgetChatModal', err));
     });
     panelsGrid.appendChild(proBlock);
 
@@ -2201,7 +2201,7 @@ export class PanelLayoutManager implements AppModule {
     mcpBlock.addEventListener('click', () => {
       void import('@/components/McpConnectModal').then((m) => m.openMcpConnectModal({
         onComplete: (spec) => this.addMcpPanel(spec),
-      }));
+      })).catch((err) => console.error('[mcp-connect] failed to lazy-load McpConnectModal', err));
     });
     panelsGrid.appendChild(mcpBlock);
 


### PR DESCRIPTION
## Summary

Field FCP is WorldMonitor's worst Core Web Vital (6.6s mobile, Lighthouse). Per the verified diagnosis in #4571, nothing paints until `main.js` plus the panel-layout boot fan-out it triggers finishes executing — so the cleanest incremental lever is evicting interaction-only code from the first-paint critical path.

The **WidgetChat, McpConnect, and Story modals** were statically imported by the boot-core orchestration (`event-handlers.ts`, `panel-layout.ts`, `country-intel.ts`), so their code rode in `main.js` and executed before first paint even though they only open on user interaction (create/modify widget, connect MCP panel, open country story). This converts their **6 call sites** to lazy `import('@/components/X').then((m) => m.openX(...))` at the handler — matching the repo's dominant lazy-load convention (`void import().then()`).

Bonus: this closes the **last eager edge into `story-renderer`** — the #4486 loose end documented in `country-intel.ts` (StoryModal statically pulled story-renderer onto the boot graph). It now ships in the StoryModal chunk.

## Impact (sourcemap byte-attribution)

| | before | after |
|---|---|---|
| `main.js` raw | 748,733 B | 716,872 B (**−31.9 KB**) |
| `main.js` brotli | ~174.9 KB | **164.9 KB (−10 KB on the FCP critical path)** |

New demand-loaded chunks (brotli): `WidgetChatModal` 3.3 KB · `McpConnectModal` 3.4 KB · `StoryModal` 3.5 KB. Byte-attribution confirms the trio **and story-renderer are fully absent** from `main.js` after the change. No circular-chunk / TDZ warnings.

## Why these three (and not export.ts / SignalModal)

`utils/export.ts` is pulled via the `@/utils` barrel (tangled — untangling risks dragging unrelated code) and `SignalModal` is boot-constructed (`new SignalModal()` held in state, needs lazy-init). Both are deliberately deferred to a follow-up to keep this diff clean and mechanical. Tracked under #4571.

## Test plan

- [x] `npm run typecheck` — clean (also proves each dynamic `import()` resolves to the named export)
- [x] `npm run lint` (biome + safe-html) — clean
- [x] `npm run test:data` — 12094 pass / 0 fail
- [x] `npm run version:check` — OK
- [x] Full-variant build (`VITE_VARIANT=full`) — trio split into own chunks, main.js shrank, no circular/TDZ warnings
- [ ] Runtime: modals still open on interaction (mechanical conversion + identical option objects; typecheck-verified resolution)

Closes the modal-cluster lever of #4571.

https://claude.ai/code/session_011htsYLErqJb922Qm9QLraN