### PR TITLE
perf(pwa): narrow service worker precache scope

### DIFF
--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -148,9 +148,11 @@ describe('deploy/cache configuration guardrails', () => {
   });
 
   it('keeps off-page public assets out of the PWA precache', () => {
-    const globIgnoresSource = viteConfigSource.match(/globIgnores:\s*\[([\s\S]*?)\]/)?.[1] ?? '';
     const assertGlobIgnore = (pattern) => {
-      assert.match(globIgnoresSource, new RegExp(`'${escapeRegExp(pattern)}'`));
+      assert.match(
+        viteConfigSource,
+        new RegExp(`globIgnores:\\s*\\[[\\s\\S]*'${escapeRegExp(pattern)}'[\\s\\S]*\\]`)
+      );
     };
 
     assert.match(viteConfigSource, /includeManifestIcons:\s*false/);

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -147,6 +147,18 @@ describe('deploy/cache configuration guardrails', () => {
     assert.doesNotMatch(viteConfigSource, /globPatterns:\s*\['\*\*\/\*\.\{js,css,html/);
   });
 
+  it('keeps off-page public assets out of the PWA precache', () => {
+    const globIgnoresSource = viteConfigSource.match(/globIgnores:\s*\[([\s\S]*?)\]/)?.[1] ?? '';
+    const assertGlobIgnore = (pattern) => {
+      assert.match(globIgnoresSource, new RegExp(`'${escapeRegExp(pattern)}'`));
+    };
+
+    assert.match(viteConfigSource, /includeManifestIcons:\s*false/);
+    assertGlobIgnore('pro/**');
+    assertGlobIgnore('favico/**');
+    assertGlobIgnore('textures/**');
+  });
+
   it('keeps the lazy Clerk SDK out of the PWA precache', () => {
     assert.match(viteConfigSource, /globIgnores:\s*\[[^\]]*'\*\*\/clerk-\*\.js'[^\]]*\]/s);
     assert.match(

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -156,6 +156,10 @@ describe('deploy/cache configuration guardrails', () => {
     };
 
     assert.match(viteConfigSource, /includeManifestIcons:\s*false/);
+    assert.doesNotMatch(
+      viteConfigSource,
+      /globIgnores:[\s\S]*'assets\/\*\*'/
+    );
     assertGlobIgnore('pro/**');
     assertGlobIgnore('favico/**');
     assertGlobIgnore('textures/**');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -934,6 +934,10 @@ export default defineConfig(({ mode }) => {
           'favico/apple-touch-icon.png',
           'favico/favicon-32x32.png',
         ],
+        // Manifest install icons stay advertised in manifest.webmanifest, but
+        // they are fetched on demand instead of forced into first-visit SW
+        // precache with the rest of the dashboard shell.
+        includeManifestIcons: false,
 
         manifest: {
           name: `${activeMeta.siteName} - ${activeMeta.subject}`,
@@ -955,7 +959,18 @@ export default defineConfig(({ mode }) => {
 
         workbox: {
           globPatterns: ['**/*.{js,css,ico,png,svg,woff2}'],
-          globIgnores: ['**/ml*.js', '**/onnx*.wasm', '**/locale-*.js', '**/clerk-*.js'],
+          globIgnores: [
+            '**/ml*.js',
+            '**/onnx*.wasm',
+            '**/locale-*.js',
+            '**/clerk-*.js',
+            // Keep off-page/static-heavy public assets out of the dashboard's
+            // first-visit precache. The small root favicons above remain
+            // explicit includeAssets entries.
+            'pro/**',
+            'favico/**',
+            'textures/**',
+          ],
           // globe.gl + three.js grows main bundle past the 2 MiB default limit
           maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
           navigateFallback: null,


### PR DESCRIPTION
## Summary
The dashboard service worker no longer treats off-page public assets as first-visit critical path. Pro landing bundles/locales, every favicon variant/social image, and globe textures are excluded from the Workbox glob; the shell still explicitly precaches the three small root favicons it already listed.

## Measurement

| Check | Result |
|---|---:|
| Emitted SW precache | 280 entries / 11,460.38 KiB |
| `pro/**` excluded from precache | 29 files / 4,157.05 KiB |
| `favico/**` excluded except explicit root favicons | 42 files / 1,387.27 KiB |
| `textures/**` excluded from precache | 2 files / 1,303.08 KiB |
| Total generated files kept out of first-visit precache | 73 files / 6,847.39 KiB |

## Verification
- `./node_modules/.bin/tsx --test tests/deploy-config.test.mjs`
- `npm run build`
- Parsed `dist/sw.js`: `pro` 0 entries, `textures` 0 entries, `og-image` 0 entries, `favico` only `apple-touch-icon.png`, `favicon-32x32.png`, and `favicon.ico`.

## Post-Deploy Monitoring & Validation
- Validation window: first 24 hours after deploy; owner: @koala73.
- Check a cold `/dashboard` load with an empty profile and search the request waterfall/Cache Storage for `/pro/assets/`, `/textures/`, `/favico/.*/og-image`, and `android-chrome-512x512`; expected healthy signal is zero service-worker-initiated precache fetches for those groups.
- Watch mobile dashboard FCP/LCP and SW install duration in field/lab captures; expected signal is stable or lower first-visit contention compared with the issue capture.
- Failure signals: missing visible favicons, PWA install icon regressions, globe texture fetch failures when the map/globe actually mounts, or SW install errors. Rollback trigger: revert this Workbox config change if any of those regressions reproduce on production.

Fixes #4578.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
