### PR TITLE
perf(CLS): instrument field attribution reporting

### DIFF
--- a/src/bootstrap/cls-report.ts
+++ b/src/bootstrap/cls-report.ts
@@ -1,0 +1,76 @@
+/**
+ * Field CLS attribution reporting (#4580).
+ *
+ * `reportClsMetric` shapes one web-vitals CLS measurement (attribution build)
+ * into a Sentry event and routes it through `enqueueSentryCall` so it survives
+ * Sentry's deferred (~10s idle) init. Reporting the largest shift target/value
+ * lets field data name the real shifting element before we ship a layout fix.
+ *
+ * The `onCLS` registration that calls this lives behind the `web-vitals`
+ * dependency (see `registerClsReporting` doc at the bottom). This module keeps
+ * the reportable logic free of that import so it builds and is unit-tested
+ * without the package present.
+ */
+import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
+
+/** Structural subset of web-vitals' CLS attribution (kept local to avoid the dep). */
+export interface ClsAttributionLike {
+  largestShiftTarget?: string;
+  largestShiftValue?: number;
+  largestShiftTime?: number;
+  loadState?: string;
+}
+
+/** Structural subset of web-vitals' CLSMetricWithAttribution. */
+export interface ClsMetricLike {
+  value: number;
+  rating?: 'good' | 'needs-improvement' | 'poor';
+  attribution?: ClsAttributionLike;
+}
+
+const roundMs = (n: number | undefined): number | undefined =>
+  typeof n === 'number' && Number.isFinite(n) ? Math.round(n) : undefined;
+
+/**
+ * Report one field CLS measurement to Sentry. `enqueue` is injectable for tests;
+ * in production it defaults to the deferred-Sentry queue.
+ */
+export function reportClsMetric(
+  metric: ClsMetricLike,
+  enqueue: typeof enqueueSentryCall = enqueueSentryCall,
+): void {
+  // Volume trim: skip 'good' (<0.1) CLS and report needs-improvement / poor /
+  // unknown only, so field attribution stays focused on actionable shifts.
+  if (metric.rating === 'good') return;
+  const a = metric.attribution ?? {};
+  enqueue((s) => {
+    s.captureMessage('web-vital: CLS', {
+      level: 'info',
+      tags: {
+        webvital: 'cls',
+        'cls.rating': metric.rating ?? 'unknown',
+      },
+      extra: {
+        value: metric.value,
+        largestShiftTarget: a.largestShiftTarget ?? 'unknown',
+        largestShiftValue: a.largestShiftValue,
+        largestShiftTime: roundMs(a.largestShiftTime),
+        loadState: a.loadState,
+      },
+    });
+  });
+}
+
+/**
+ * Register the field CLS listener. Browser-only. Uses a dynamic import so
+ * `web-vitals` code-splits into its own chunk and so this module stays
+ * node-loadable for unit tests.
+ */
+export function registerClsReporting(): void {
+  if (typeof window === 'undefined') return;
+  void import('web-vitals/attribution')
+    .then(({ onCLS }) => {
+      onCLS((metric) => reportClsMetric(metric as unknown as ClsMetricLike));
+    })
+    .catch(() => { /* web-vitals chunk failed to load (adblock/CDN) - non-fatal */ });
+}

--- a/src/bootstrap/cls-report.ts
+++ b/src/bootstrap/cls-report.ts
@@ -62,7 +62,8 @@ export function reportClsMetric(
 /**
  * Register the field CLS listener. Browser-only. Uses a dynamic import so
  * `web-vitals` code-splits into its own chunk and so this module stays
- * node-loadable for unit tests.
+ * node-loadable for unit tests. Uses web-vitals' default lifecycle cadence
+ * (including bfcache/visibility reports), matching the INP reporter.
  */
 export function registerClsReporting(): void {
   if (typeof window === 'undefined') return;

--- a/src/bootstrap/cls-report.ts
+++ b/src/bootstrap/cls-report.ts
@@ -12,6 +12,7 @@
  * without the package present.
  */
 import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
+import { roundMs } from '@/bootstrap/web-vitals-utils';
 
 /** Structural subset of web-vitals' CLS attribution (kept local to avoid the dep). */
 export interface ClsAttributionLike {
@@ -27,9 +28,6 @@ export interface ClsMetricLike {
   rating?: 'good' | 'needs-improvement' | 'poor';
   attribution?: ClsAttributionLike;
 }
-
-const roundMs = (n: number | undefined): number | undefined =>
-  typeof n === 'number' && Number.isFinite(n) ? Math.round(n) : undefined;
 
 /**
  * Report one field CLS measurement to Sentry. `enqueue` is injectable for tests;

--- a/src/bootstrap/inp-report.ts
+++ b/src/bootstrap/inp-report.ts
@@ -15,6 +15,7 @@
  * without the package present.
  */
 import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
+import { roundMs } from '@/bootstrap/web-vitals-utils';
 
 /** Structural subset of web-vitals' INP attribution (kept local to avoid the dep). */
 export interface InpAttributionLike {
@@ -32,9 +33,6 @@ export interface InpMetricLike {
   rating?: 'good' | 'needs-improvement' | 'poor';
   attribution?: InpAttributionLike;
 }
-
-const roundMs = (n: number | undefined): number | undefined =>
-  typeof n === 'number' && Number.isFinite(n) ? Math.round(n) : undefined;
 
 /**
  * Report one field INP measurement to Sentry (R1, R2). `enqueue` is injectable

--- a/src/bootstrap/web-vitals-utils.ts
+++ b/src/bootstrap/web-vitals-utils.ts
@@ -1,0 +1,2 @@
+export const roundMs = (n: number | undefined): number | undefined =>
+  typeof n === 'number' && Number.isFinite(n) ? Math.round(n) : undefined;

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,7 @@ import './bootstrap/zod-csp';
 import { installLcpAttributionDebug } from '@/bootstrap/lcp-attribution';
 import { markLcpDebug } from '@/utils/lcp-debug';
 import { enqueueSentryCall, installPreInitErrorQueue, scheduleSentryInit } from '@/bootstrap/sentry-defer';
+import { registerClsReporting } from '@/bootstrap/cls-report';
 import { registerInpReporting } from '@/bootstrap/inp-report';
 import { initVercelAnalytics } from '@/bootstrap/secondary-startup';
 import { App } from './App';
@@ -43,6 +44,10 @@ scheduleSentryInit();
 // we can see which real interaction is slow and whether the cost is input delay,
 // processing, or presentation (#4537). web-vitals loads in its own post-paint chunk.
 registerInpReporting();
+
+// Report field CLS attribution to Sentry so field-only layout shifts can name
+// their largest shifting element before we scope the layout fix (#4580).
+registerClsReporting();
 
 // Suppress NotAllowedError from YouTube IFrame API's internal play() — browser autoplay policy,
 // not actionable. The YT IFrame API doesn't expose the play() promise so it leaks as unhandled.

--- a/tests/cls-report.test.mts
+++ b/tests/cls-report.test.mts
@@ -1,0 +1,69 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { registerClsReporting, reportClsMetric, type ClsMetricLike } from '@/bootstrap/cls-report';
+
+// Capture what reportClsMetric would send, by injecting a fake enqueue that
+// immediately invokes the closure with a fake Sentry namespace.
+function capture(metric: ClsMetricLike): { msg: string; ctx: any } {
+  let out: { msg: string; ctx: any } | null = null;
+  const fakeEnqueue = ((fn: (s: any) => void) => {
+    fn({ captureMessage: (msg: string, ctx: unknown) => { out = { msg, ctx }; } });
+  }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
+  reportClsMetric(metric, fakeEnqueue);
+  assert.ok(out, 'reportClsMetric must call enqueue exactly once');
+  return out!;
+}
+
+test('reportClsMetric drops good-rated CLS without enqueuing', () => {
+  let calls = 0;
+  const fakeEnqueue = ((fn: (s: any) => void) => {
+    calls += 1;
+    fn({ captureMessage: () => {} });
+  }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
+  reportClsMetric({ value: 0.04, rating: 'good', attribution: { largestShiftTarget: 'main' } }, fakeEnqueue);
+  assert.equal(calls, 0, 'good-rated (<0.1) CLS is not reported');
+});
+
+test('reportClsMetric reports CLS attribution for needs-improvement field shifts', () => {
+  const { msg, ctx } = capture({
+    value: 0.15321,
+    rating: 'needs-improvement',
+    attribution: {
+      largestShiftTarget: 'div.payment-failure-banner',
+      largestShiftValue: 0.1287,
+      largestShiftTime: 1842.6,
+      loadState: 'complete',
+    },
+  });
+  assert.equal(msg, 'web-vital: CLS');
+  assert.equal(ctx.tags.webvital, 'cls');
+  assert.equal(ctx.tags['cls.rating'], 'needs-improvement');
+  assert.equal(ctx.extra.value, 0.15321, 'CLS value keeps fractional precision');
+  assert.equal(ctx.extra.largestShiftTarget, 'div.payment-failure-banner');
+  assert.equal(ctx.extra.largestShiftValue, 0.1287);
+  assert.equal(ctx.extra.largestShiftTime, 1843, 'largest shift time rounded to ms');
+  assert.equal(ctx.extra.loadState, 'complete');
+});
+
+test('reportClsMetric tolerates poor-rated CLS with missing attribution', () => {
+  const { ctx } = capture({ value: 0.31, rating: 'poor' });
+  assert.equal(ctx.tags['cls.rating'], 'poor');
+  assert.equal(ctx.extra.value, 0.31);
+  assert.equal(ctx.extra.largestShiftTarget, 'unknown');
+  assert.equal(ctx.extra.largestShiftValue, undefined);
+  assert.equal(ctx.extra.largestShiftTime, undefined);
+});
+
+test('reportClsMetric still reports unknown/undefined-rated CLS conservatively', () => {
+  let calls = 0;
+  const fakeEnqueue = ((fn: (s: any) => void) => {
+    calls += 1;
+    fn({ captureMessage: () => {} });
+  }) as unknown as typeof import('@/bootstrap/sentry-defer').enqueueSentryCall;
+  reportClsMetric({ value: 0.17 }, fakeEnqueue);
+  assert.equal(calls, 1, 'unknown/undefined rating still reports; do not drop unknowns');
+});
+
+test('registerClsReporting returns without importing in non-browser contexts', () => {
+  assert.doesNotThrow(() => registerClsReporting());
+});

--- a/tests/cls-report.test.mts
+++ b/tests/cls-report.test.mts
@@ -52,6 +52,7 @@ test('reportClsMetric tolerates poor-rated CLS with missing attribution', () => 
   assert.equal(ctx.extra.largestShiftTarget, 'unknown');
   assert.equal(ctx.extra.largestShiftValue, undefined);
   assert.equal(ctx.extra.largestShiftTime, undefined);
+  assert.equal(ctx.extra.loadState, undefined);
 });
 
 test('reportClsMetric still reports unknown/undefined-rated CLS conservatively', () => {


### PR DESCRIPTION
## Summary

Field CLS attribution now reports the page's largest layout-shift target to Sentry for non-good CLS measurements, so the follow-up fix can be based on real mobile field data instead of guessing at banners, fonts, or async panel growth.

The reporter mirrors the existing INP path: it keeps `web-vitals/attribution` behind a dynamic import, routes through the deferred Sentry queue, skips good-rated CLS for volume control, and preserves fractional CLS values while rounding shift timing to milliseconds.

## Validation

- `./node_modules/.bin/tsx --test tests/cls-report.test.mts`
- `npm run typecheck`
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/tsx --test tests/dashboard-critical-css.test.mjs tests/cls-report.test.mts`
- `npm run lint` (passed; Biome reported existing warning-level findings outside this change)

`npm run test:data` was also run in the fresh worktree. It reported 11,948 passing tests and 2 failures because `dist/dashboard.html` did not exist for built-output CSS assertions; after producing the Vite build, the failing `tests/dashboard-critical-css.test.mjs` file passed together with the new CLS test.

## Post-Deploy Monitoring & Validation

- Query Sentry for `message:"web-vital: CLS"` or `webvital:cls`, grouped by URL and `extra.largestShiftTarget`.
- Watch `cls.rating`, `largestShiftTarget`, `largestShiftValue`, `largestShiftTime`, and `loadState` for `/` and `/dashboard` mobile traffic.
- Expected healthy signal: only needs-improvement/poor/unknown CLS events appear, most events carry a concrete `largestShiftTarget`, and event volume stays comparable to the existing INP volume-trimmed reporter.
- Failure signals: no CLS events after normal traffic, most targets are `unknown`, Sentry quota spikes, or Sentry capture errors around the new reporter.
- Rollback/mitigation: revert this PR or temporarily remove `registerClsReporting()` from boot if event volume or capture behavior is unhealthy.
- Validation window/owner: first 24-48 hours after deploy, WorldMonitor maintainer/on-call.

## Related

Related: #4580

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex GPT-5](https://img.shields.io/badge/Codex_GPT--5-000000)
