### PR TITLE
perf(boot): lazy-load export and signal modal chunks

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -37,7 +37,6 @@ import { startLearning } from '@/services/country-instability';
 import { loadFromStorage, parseMapUrlState, saveToStorage, isMobileDevice, showToast } from '@/utils';
 import { clearPanelSpans, invalidatePanelStorageCacheForKeys } from '@/utils/panel-storage';
 import type { ParsedMapUrlState } from '@/utils';
-import { SignalModal } from '@/components/SignalModal';
 import { BreakingNewsBanner } from '@/components/BreakingNewsBanner';
 import { initBreakingNewsAlerts, destroyBreakingNewsAlerts } from '@/services/breaking-news-alerts';
 import { markLcpDebug } from '@/utils/lcp-debug';
@@ -135,6 +134,7 @@ import type { CorrelationPanel } from '@/components/CorrelationPanel';
 
 const CYBER_LAYER_ENABLED = import.meta.env.VITE_ENABLE_CYBER_LAYER === 'true';
 const FREE_MAP_PANEL_ACCESS_KEY = 'worldmonitor-free-map-panel-access-v1';
+type SignalModalInstance = import('@/components/SignalModal').SignalModal;
 
 export type { CountryBriefSignals } from '@/app/app-context';
 
@@ -149,6 +149,7 @@ export class App {
   private eventHandlers: EventHandlerManager;
   private searchManager: SearchManager | null = null;
   private searchManagerLoad: Promise<SearchManager> | null = null;
+  private signalModalLoad: Promise<SignalModalInstance> | null = null;
   // Monotonic epoch: every openSearch() call supersedes earlier in-flight ones.
   // searchToggleDesiredOpen accumulates the net intent of rapid Cmd+K presses
   // while the lazy chunk loads (XOR: odd → open, even → cancel). (#4403 review)
@@ -903,6 +904,7 @@ export class App {
       seenGeoAlerts: new Set(),
       monitors,
       signalModal: null,
+      ensureSignalModal: () => this.ensureSignalModal(),
       statusPanel: null,
       searchModal: null,
       findingsBadge: null,
@@ -997,6 +999,30 @@ export class App {
       this.refreshScheduler,
       this.eventHandlers,
     ];
+  }
+
+  private ensureSignalModal(): Promise<SignalModalInstance> {
+    if (this.state.signalModal) return Promise.resolve(this.state.signalModal);
+    if (this.signalModalLoad) return this.signalModalLoad;
+
+    this.signalModalLoad = import('@/components/SignalModal')
+      .then(({ SignalModal }) => {
+        if (this.state.isDestroyed) {
+          throw new Error('App destroyed before signal modal loaded');
+        }
+        const signalModal = new SignalModal();
+        signalModal.setLocationClickHandler((lat, lon) => {
+          this.state.map?.setCenter(lat, lon, 4);
+        });
+        this.state.signalModal = signalModal;
+        return signalModal;
+      })
+      .catch((err) => {
+        this.signalModalLoad = null;
+        throw err;
+      });
+
+    return this.signalModalLoad;
   }
 
   private ensureSearchManager(): Promise<SearchManager> {
@@ -1450,10 +1476,6 @@ export class App {
     }
 
     // Phase 2: Shared UI components
-    this.state.signalModal = new SignalModal();
-    this.state.signalModal.setLocationClickHandler((lat, lon) => {
-      this.state.map?.setCenter(lat, lon, 4);
-    });
     if (!this.state.isMobile) {
       void this.initFindingsBadge();
     }
@@ -1770,12 +1792,24 @@ export class App {
       this.state.findingsBadge.setOnSignalClick((signal) => {
         if (this.state.countryBriefPage?.isVisible()) return;
         if (localStorage.getItem('wm-settings-open') === '1') return;
-        this.state.signalModal?.showSignal(signal);
+        void this.state.ensureSignalModal()
+          .then((signalModal) => {
+            if (!this.state.isDestroyed) signalModal.showSignal(signal);
+          })
+          .catch((err) => {
+            console.warn('[SignalModal] Failed to show signal:', err);
+          });
       });
       this.state.findingsBadge.setOnAlertClick((alert) => {
         if (this.state.countryBriefPage?.isVisible()) return;
         if (localStorage.getItem('wm-settings-open') === '1') return;
-        this.state.signalModal?.showAlert(alert);
+        void this.state.ensureSignalModal()
+          .then((signalModal) => {
+            if (!this.state.isDestroyed) signalModal.showAlert(alert);
+          })
+          .catch((err) => {
+            console.warn('[SignalModal] Failed to show alert:', err);
+          });
       });
     } catch (error) {
       console.warn('[IntelligenceGapBadge] Lazy init failed:', error);

--- a/src/app/app-context.ts
+++ b/src/app/app-context.ts
@@ -84,13 +84,14 @@ export interface AppContext {
   seenGeoAlerts: Set<string>;
   monitors: Monitor[];
 
-  signalModal: import('@/components').SignalModal | null;
+  signalModal: import('@/components/SignalModal').SignalModal | null;
+  ensureSignalModal: () => Promise<import('@/components/SignalModal').SignalModal>;
   statusPanel: import('@/components').StatusPanel | null;
   searchModal: import('@/components').SearchModal | null;
   findingsBadge: import('@/components').IntelligenceGapBadge | null;
   breakingBanner: import('@/components/BreakingNewsBanner').BreakingNewsBanner | null;
   playbackControl: import('@/components').PlaybackControl | null;
-  exportPanel: import('@/utils').ExportPanel | null;
+  exportPanel: import('@/utils/export').ExportPanel | null;
   unifiedSettings: UnifiedSettingsController | null;
   pizzintIndicator: import('@/components').PizzIntIndicator | null;
   correlationEngine: import('@/services/correlation-engine').CorrelationEngine | null;

--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -118,6 +118,7 @@ import { fetchGpsInterference } from '@/services/gps-interference';
 import { fetchSatelliteTLEs, initSatRecs, propagatePositions, startPropagationLoop } from '@/services/satellites';
 import type { SatRecEntry } from '@/services/satellites';
 import { dataFreshness, type DataSourceId } from '@/services/data-freshness';
+import type { CorrelationSignal } from '@/services/correlation';
 import { fetchConflictEvents, fetchUcdpClassifications, fetchHapiSummary, fetchUcdpEvents, deduplicateAgainstAcled, fetchIranEvents } from '@/services/conflict';
 import { fetchUnhcrPopulation } from '@/services/displacement';
 import { fetchClimateAnomalies } from '@/services/climate';
@@ -714,6 +715,16 @@ export class DataLoaderManager implements AppModule {
 
   private shouldShowIntelligenceNotifications(): boolean {
     return !this.ctx.isMobile && !!this.ctx.findingsBadge?.isPopupEnabled();
+  }
+
+  private showSignalNotification(signals: CorrelationSignal[], context: string): void {
+    void this.ctx.ensureSignalModal()
+      .then((signalModal) => {
+        if (!this.ctx.isDestroyed) signalModal.show(signals);
+      })
+      .catch((err) => {
+        console.warn(`[SignalModal] ${context} notification skipped:`, err);
+      });
   }
 
   private isPanelNearViewport(panelId: string, marginPx = 400): boolean {
@@ -3136,13 +3147,13 @@ export class DataLoaderManager implements AppModule {
       if (surgeAlerts.length > 0) {
         const surgeSignals = surgeAlerts.map(surgeAlertToSignal);
         addToSignalHistory(surgeSignals);
-        if (this.shouldShowIntelligenceNotifications()) this.ctx.signalModal?.show(surgeSignals);
+        if (this.shouldShowIntelligenceNotifications()) this.showSignalNotification(surgeSignals, 'Military surge');
       }
       const foreignAlerts = detectForeignMilitaryPresence(flights);
       if (foreignAlerts.length > 0) {
         const foreignSignals = foreignAlerts.map(foreignPresenceToSignal);
         addToSignalHistory(foreignSignals);
-        if (this.shouldShowIntelligenceNotifications()) this.ctx.signalModal?.show(foreignSignals);
+        if (this.shouldShowIntelligenceNotifications()) this.showSignalNotification(foreignSignals, 'Foreign presence');
       }
     } catch (error) {
       console.warn('[Intelligence] Military surge analysis skipped:', error);
@@ -3512,7 +3523,7 @@ export class DataLoaderManager implements AppModule {
       const allSignals = [...signals, ...geoSignals, ...keywordSpikeSignals];
       if (allSignals.length > 0) {
         addToSignalHistory(allSignals);
-        if (this.shouldShowIntelligenceNotifications()) this.ctx.signalModal?.show(allSignals);
+        if (this.shouldShowIntelligenceNotifications()) this.showSignalNotification(allSignals, 'Correlation');
       }
     } catch (error) {
       console.error('[App] Correlation analysis failed:', error);

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -29,7 +29,6 @@ import {
   buildMapUrl,
   debounce,
   saveToStorage,
-  ExportPanel,
   getCurrentTheme,
   setTheme,
   showToast,
@@ -211,6 +210,7 @@ export class EventHandlerManager implements AppModule {
   private missionPresetPopover: HTMLElement | null = null;
   private missionDataRefreshTimer: number | null = null;
   private proGateUnsubscribers: Array<() => void> = [];
+  private exportPanelLoad: Promise<NonNullable<AppContext['exportPanel']>> | null = null;
   private closedPanelStack: string[] = []; // max-items: 20
   private idleTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private snapshotIntervalId: ReturnType<typeof setInterval> | null = null;
@@ -1628,8 +1628,7 @@ export class EventHandlerManager implements AppModule {
   }
 
   setupExportPanel(): void {
-    // Always create — show/hide reactively via auth state subscription below.
-    this.ctx.exportPanel = new ExportPanel(() => {
+    const getExportData = () => {
       const allCards = this.ctx.correlationEngine?.getAllCards() ?? [];
       const disabledCount = this.ctx.disabledSources.size;
       return {
@@ -1651,19 +1650,61 @@ export class EventHandlerManager implements AppModule {
         convergenceCards: allCards.map(({ assessment: _a, ...card }) => card),
         monitors: this.ctx.monitors.length > 0 ? this.ctx.monitors : undefined,
       };
-    });
-
-    const el = this.ctx.exportPanel.getElement();
-    const headerRight = this.ctx.container.querySelector('.header-right');
-    if (headerRight) {
-      headerRight.insertBefore(el, headerRight.firstChild);
-    }
-
-    const applyProGate = (isPro: boolean, initial = false) => {
-      el.style.display = isPro ? '' : 'none';
-      if (initial && !isPro) trackGateHit('export');
     };
-    applyProGate(getAuthState().user?.role === 'pro', true);
+
+    const attachExportPanel = (panel: NonNullable<AppContext['exportPanel']>): void => {
+      const el = panel.getElement();
+      if (el.parentElement) return;
+      const headerRight = this.ctx.container.querySelector('.header-right');
+      if (headerRight) {
+        headerRight.insertBefore(el, headerRight.firstChild);
+      }
+    };
+
+    const ensureExportPanel = (): Promise<NonNullable<AppContext['exportPanel']>> => {
+      if (this.ctx.exportPanel) {
+        attachExportPanel(this.ctx.exportPanel);
+        return Promise.resolve(this.ctx.exportPanel);
+      }
+      if (this.exportPanelLoad) return this.exportPanelLoad;
+
+      this.exportPanelLoad = import('@/utils/export')
+        .then(({ ExportPanel }) => {
+          if (this.ctx.isDestroyed) {
+            throw new Error('EventHandlerManager destroyed before export panel loaded');
+          }
+          const panel = new ExportPanel(getExportData);
+          this.ctx.exportPanel = panel;
+          attachExportPanel(panel);
+          return panel;
+        })
+        .catch((err) => {
+          this.exportPanelLoad = null;
+          throw err;
+        });
+
+      return this.exportPanelLoad;
+    };
+
+    let currentIsPro = getAuthState().user?.role === 'pro';
+    const applyProGate = (isPro: boolean, initial = false) => {
+      currentIsPro = isPro;
+      if (!isPro) {
+        const el = this.ctx.exportPanel?.getElement();
+        if (el) el.style.display = 'none';
+        if (initial) trackGateHit('export');
+        return;
+      }
+
+      void ensureExportPanel()
+        .then((panel) => {
+          panel.getElement().style.display = currentIsPro ? '' : 'none';
+        })
+        .catch((err) => {
+          console.warn('[export-panel] Failed to lazy-load ExportPanel:', err);
+        });
+    };
+    applyProGate(currentIsPro, true);
     this.proGateUnsubscribers.push(subscribeAuthState(state => applyProGate(state.user?.role === 'pro')));
   }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -179,7 +179,6 @@ export function shuffle<T>(arr: T[]): T[] {
 }
 
 export { proxyUrl, fetchWithProxy, rssProxyUrl } from './proxy';
-export { exportToJSON, exportToCSV, ExportPanel } from './export';
 export { buildMapUrl, parseMapUrlState } from './urlState';
 export { withTimeout, TimeoutError } from './with-timeout';
 export type { ParsedMapUrlState } from './urlState';

--- a/tests/mainjs-eager-clients.test.mjs
+++ b/tests/mainjs-eager-clients.test.mjs
@@ -180,8 +180,8 @@ function servicesBarrelValueImportBlock(src) {
 }
 
 function valueImportBlock(src, specifier) {
-  const re = new RegExp(`\\bimport\\s+\\{([\\s\\S]*?)\\}\\s+from\\s+['"]${escapeRegExp(specifier)}['"]`);
-  return src.match(re)?.[1] ?? '';
+  const re = new RegExp(`\\bimport\\s+\\{([\\s\\S]*?)\\}\\s+from\\s+['"]${escapeRegExp(specifier)}['"]`, 'g');
+  return [...src.matchAll(re)].map((match) => match[1]).join('\n');
 }
 
 describe('main.js eager diet — service clients are lazy-initialized', () => {
@@ -346,6 +346,15 @@ describe('main.js eager diet — export panel is interaction-loaded', () => {
   const eventHandlersSource = readFileSync(resolve(repoRoot, 'src/app/event-handlers.ts'), 'utf8');
   const eventHandlersWithoutComments = stripComments(eventHandlersSource);
   const utilsIndexSource = readFileSync(resolve(repoRoot, 'src/utils/index.ts'), 'utf8');
+
+  it('checks every import block from the same specifier', () => {
+    const source = [
+      'import { buildMapUrl } from "@/utils";',
+      'import { ExportPanel } from "@/utils";',
+    ].join('\n');
+
+    assert.match(valueImportBlock(source, '@/utils'), /\bExportPanel\b/);
+  });
 
   it('does not import ExportPanel through the eager utils barrel', () => {
     assert.doesNotMatch(

--- a/tests/mainjs-eager-clients.test.mjs
+++ b/tests/mainjs-eager-clients.test.mjs
@@ -34,6 +34,8 @@ const SIGNAL_AGGREGATOR_DEFERRED_SERVICE_IMPORT = '@/services/signal-aggregator'
 const MILITARY_VESSELS_DEFERRED_SERVICE_IMPORT = '@/services/military-vessels';
 const CROSS_MODULE_DEFERRED_SERVICE_IMPORT = '@/services/cross-module-integration';
 const INTELLIGENCE_GAP_BADGE_DEFERRED_IMPORT = '@/components/IntelligenceGapBadge';
+const EXPORT_PANEL_DEFERRED_IMPORT = '@/utils/export';
+const SIGNAL_MODAL_DEFERRED_IMPORT = '@/components/SignalModal';
 
 const SERVICE_BARREL_DEFERRED_EXPORTS = [
   './rss',
@@ -175,6 +177,11 @@ function valueImportSpecifiers(src) {
 
 function servicesBarrelValueImportBlock(src) {
   return src.match(/\bimport\s+\{([\s\S]*?)\}\s+from\s+['"]@\/services['"]/)?.[1] ?? '';
+}
+
+function valueImportBlock(src, specifier) {
+  const re = new RegExp(`\\bimport\\s+\\{([\\s\\S]*?)\\}\\s+from\\s+['"]${escapeRegExp(specifier)}['"]`);
+  return src.match(re)?.[1] ?? '';
 }
 
 describe('main.js eager diet — service clients are lazy-initialized', () => {
@@ -331,6 +338,66 @@ describe('main.js eager diet — eager UI keeps trending-keywords lazy', () => {
     assert.ok(
       dynamicImportSpecifiers(source).includes('@/services/trending-keywords'),
       'SignalModal should lazy-load trending-keywords when suppressing a term',
+    );
+  });
+});
+
+describe('main.js eager diet — export panel is interaction-loaded', () => {
+  const eventHandlersSource = readFileSync(resolve(repoRoot, 'src/app/event-handlers.ts'), 'utf8');
+  const eventHandlersWithoutComments = stripComments(eventHandlersSource);
+  const utilsIndexSource = readFileSync(resolve(repoRoot, 'src/utils/index.ts'), 'utf8');
+
+  it('does not import ExportPanel through the eager utils barrel', () => {
+    assert.doesNotMatch(
+      valueImportBlock(eventHandlersWithoutComments, '@/utils'),
+      /\bExportPanel\b/,
+      'event-handlers should not import ExportPanel from @/utils; it pulls export.ts into main.js',
+    );
+  });
+
+  it('keeps ExportPanel behind a dynamic import and resets failed loads', () => {
+    assert.ok(
+      dynamicImportSpecifiers(eventHandlersSource).includes(EXPORT_PANEL_DEFERRED_IMPORT),
+      'event-handlers should lazy-load ExportPanel with import("@/utils/export")',
+    );
+    assert.ok(
+      eventHandlersWithoutComments.includes('exportPanelLoad = null;'),
+      'event-handlers should reset exportPanelLoad on chunk-load failure so later Pro gates can retry',
+    );
+  });
+
+  it('does not re-export export.ts from the eager utils barrel', () => {
+    assert.doesNotMatch(
+      stripComments(utilsIndexSource),
+      /from\s+['"]\.\/export['"]/,
+      'src/utils/index.ts should not re-export ./export into every @/utils importer',
+    );
+  });
+});
+
+describe('main.js eager diet — signal modal is interaction-loaded', () => {
+  const appSource = readFileSync(resolve(repoRoot, 'src/App.ts'), 'utf8');
+  const appWithoutComments = stripComments(appSource);
+
+  it('does not statically import SignalModal into App boot', () => {
+    assert.ok(
+      !valueImportSpecifiers(appWithoutComments).includes(SIGNAL_MODAL_DEFERRED_IMPORT),
+      'App should not statically import SignalModal; first show should lazy-load it',
+    );
+  });
+
+  it('keeps SignalModal behind a dynamic import and resets failed loads', () => {
+    assert.ok(
+      appWithoutComments.includes("this.signalModalLoad = import('@/components/SignalModal')"),
+      'App should lazy-load SignalModal with import("@/components/SignalModal")',
+    );
+    assert.ok(
+      appWithoutComments.includes('signalModalLoad = null;'),
+      'App should reset signalModalLoad on chunk-load failure so later notifications can retry',
+    );
+    assert.ok(
+      !appWithoutComments.includes('this.state.signalModal = new SignalModal();'),
+      'App should not construct SignalModal during boot',
     );
   });
 });


### PR DESCRIPTION
## Summary

Export and signal modal UI no longer sit on the first-paint JavaScript path. Free sessions skip the export bundle entirely, Pro sessions load it through a retryable dynamic import when the header gate needs to show it, and SignalModal loads only on the first intelligence notification or finding interaction.

The eager-diet guard now pins both deferrals so future `@/utils` barrel imports or boot-time SignalModal construction fail in `tests/mainjs-eager-clients.test.mjs`.

Fixes #4577

## Validation

- `node --test tests/mainjs-eager-clients.test.mjs` (44 tests pass)
- `npm run typecheck`
- `npm run lint` (passes; existing Biome warnings still print)
- `env VITE_VARIANT=full node_modules/.bin/vite build --sourcemap`
- Sourcemap assertion: `src/utils/export.ts` and `src/components/SignalModal.ts` are absent from `main-CE65jj-c.js.map`; build emitted `export-CgHsOcvZ.js` and `SignalModal-toe9JRLq.js` chunks
- `./node_modules/.bin/tsx --test tests/dashboard-critical-css.test.mjs` (8 tests pass)
- `npm run test:data` final rerun (12,100 pass, 0 fail, 6 skipped)
- `git diff --check`

## Post-Deploy Monitoring & Validation

- Window/owner: first 24 hours after deploy, WorldMonitor maintainer on-call for web performance.
- Log and Sentry searches: `ChunkLoadError`, `Failed to lazy-load ExportPanel`, `Failed to show signal`, `assets/export`, `assets/SignalModal`.
- Metrics to watch: dashboard main JS transfer size and FCP/LCP, frontend error rate, asset 404 rate for `export-*.js` and `SignalModal-*.js`, Pro export control smoke, and intelligence finding click-to-modal smoke.
- Healthy signals: no chunk-load or asset-404 spike, Pro users see the export control after auth settles, finding/alert clicks open SignalModal, and main JS gzip stays at or below the current ~205.9 kB build baseline.
- Failure signals and rollback: rising chunk-load errors, missing Pro export controls, or modal interactions failing after deploy; revert this PR or temporarily reintroduce the eager import path as mitigation.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
