### PR TITLE
fix(prefs): rate-limit cloud preference writes

### DIFF
--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -20,6 +20,46 @@ import { captureSilentError } from './_sentry-edge.js';
 import { extractConvexErrorKind, isOpaqueConvexServerError, readConvexErrorNumber } from './_convex-error.js';
 import { ConvexHttpClient } from 'convex/browser';
 import { validateBearerToken } from '../server/auth-session';
+import { checkScopedRateLimit } from '../server/_shared/rate-limit';
+
+export const USER_PREFS_WRITE_RATE_SCOPE = 'user-prefs-write';
+export const USER_PREFS_WRITE_RATE_LIMIT = 30;
+export const USER_PREFS_WRITE_RATE_WINDOW = '60 s';
+
+type SessionValidator = typeof validateBearerToken;
+type ScopedRateLimiter = typeof checkScopedRateLimit;
+
+interface UserPrefsConvexClient {
+  setAuth(token: string): void;
+  query(name: unknown, args: Record<string, unknown>): Promise<unknown>;
+  mutation(name: unknown, args: Record<string, unknown>): Promise<unknown>;
+}
+
+interface UserPrefsDeps {
+  validateBearerToken: SessionValidator;
+  checkScopedRateLimit: ScopedRateLimiter;
+  createConvexClient: (
+    convexUrl: string,
+    options: ConstructorParameters<typeof ConvexHttpClient>[1],
+  ) => UserPrefsConvexClient;
+}
+
+function createDefaultUserPrefsDeps(): UserPrefsDeps {
+  return {
+    validateBearerToken,
+    checkScopedRateLimit,
+    createConvexClient: (convexUrl, options) =>
+      new ConvexHttpClient(convexUrl, options) as UserPrefsConvexClient,
+  };
+}
+
+let userPrefsDeps: UserPrefsDeps = createDefaultUserPrefsDeps();
+
+export function __setUserPrefsDepsForTests(overrides: Partial<UserPrefsDeps> | null): void {
+  userPrefsDeps = overrides
+    ? { ...createDefaultUserPrefsDeps(), ...overrides }
+    : createDefaultUserPrefsDeps();
+}
 
 export default async function handler(
   req: Request,
@@ -45,7 +85,7 @@ export default async function handler(
     return jsonResponse({ error: 'UNAUTHENTICATED' }, 401, cors);
   }
 
-  const session = await validateBearerToken(token);
+  const session = await userPrefsDeps.validateBearerToken(token);
   if (!session.valid || !session.userId) {
     return jsonResponse({ error: 'UNAUTHENTICATED' }, 401, cors);
   }
@@ -53,6 +93,36 @@ export default async function handler(
   const convexUrl = process.env.CONVEX_URL;
   if (!convexUrl) {
     return jsonResponse({ error: 'Service unavailable' }, 503, cors);
+  }
+
+  if (req.method === 'POST') {
+    const scoped = await userPrefsDeps.checkScopedRateLimit(
+      USER_PREFS_WRITE_RATE_SCOPE,
+      USER_PREFS_WRITE_RATE_LIMIT,
+      USER_PREFS_WRITE_RATE_WINDOW,
+      session.userId,
+    );
+    // Redis-degraded scoped limits intentionally fail open for prefs writes:
+    // the sync blob is low-stakes, while a limiter outage should not strand a
+    // legitimate user's local settings. checkScopedRateLimit logs Redis errors;
+    // this warning also surfaces missing-config fail-open windows.
+    if (scoped.degraded) {
+      console.warn('[user-prefs] POST write rate limit unavailable; failing open');
+    } else if (!scoped.allowed) {
+      const retryAfter = Math.max(1, Math.ceil((scoped.reset - Date.now()) / 1000));
+      console.warn('[user-prefs] POST write rate limit exceeded');
+      return jsonResponse(
+        { error: 'RATE_LIMITED' },
+        429,
+        {
+          ...cors,
+          'X-RateLimit-Limit': String(scoped.limit),
+          'X-RateLimit-Remaining': '0',
+          'X-RateLimit-Reset': String(scoped.reset),
+          'Retry-After': String(retryAfter),
+        },
+      );
+    }
   }
 
   // Bound the Convex round-trip below Vercel's 25s edge wall-clock so a
@@ -63,7 +133,7 @@ export default async function handler(
   // the JWKS verify above + response packaging below. Injected via the
   // public `fetch` constructor option (the `setFetchOptions` instance
   // method is marked `@internal` in convex's d.ts and not safe to depend on).
-  const client = new ConvexHttpClient(convexUrl, {
+  const client = userPrefsDeps.createConvexClient(convexUrl, {
     fetch: (input, init) =>
       fetch(input, { ...init, signal: init?.signal ?? AbortSignal.timeout(20_000) }),
   });

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -69,6 +69,15 @@ function logRateLimitDegraded(stage: string, err: unknown): void {
   });
 }
 
+const scopedMissingConfigStages = new Set<string>();
+
+function logScopedRateLimitMissingConfig(scope: string): void {
+  const stage = `checkScopedRateLimit:${scope}:missing-config`;
+  if (scopedMissingConfigStages.has(stage)) return;
+  scopedMissingConfigStages.add(stage);
+  logRateLimitDegraded(stage, new Error('UPSTASH_REDIS_REST_URL or UPSTASH_REDIS_REST_TOKEN missing'));
+}
+
 // Marker header set on every degraded (fail-closed) response so observability
 // can correlate "rate-limit unavailable" windows with downstream behaviour
 // without parsing the JSON body. Mirrored in api/_rate-limit.js.
@@ -326,7 +335,10 @@ export interface ScopedRateLimitResult {
  */
 export async function checkScopedRateLimit(scope: string, limit: number, window: Duration, identifier: string): Promise<ScopedRateLimitResult> {
   const rl = getScopedRatelimit(scope, limit, window);
-  if (!rl) return { allowed: true, limit, reset: 0, degraded: true };
+  if (!rl) {
+    logScopedRateLimitMissingConfig(scope);
+    return { allowed: true, limit, reset: 0, degraded: true };
+  }
   try {
     const result = await rl.limit(`${scope}:${identifier}`);
     return {

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -293,16 +293,18 @@ interface CloudPrefs {
 }
 
 /**
- * Typed 503 from the edge — Convex platform-level outage. Callers detect
+ * Typed temporary response from the edge. Callers detect
  * this via `instanceof ServiceUnavailableError` and back off using
  * `retryAfterSec` instead of treating it as a permanent error.
  */
 export class ServiceUnavailableError extends Error {
   retryAfterSec: number;
-  constructor(retryAfterSec: number) {
-    super(`service unavailable (retry after ${retryAfterSec}s)`);
+  status: number;
+  constructor(retryAfterSec: number, status = 503) {
+    super(`service temporarily unavailable (${status}; retry after ${retryAfterSec}s)`);
     this.name = 'ServiceUnavailableError';
     this.retryAfterSec = retryAfterSec;
+    this.status = status;
   }
 }
 
@@ -313,6 +315,10 @@ export class ServiceUnavailableError extends Error {
 const RETRY_AFTER_MIN_SEC = 1;
 const RETRY_AFTER_MAX_SEC = 60;
 const RETRY_AFTER_DEFAULT_SEC = 5;
+
+export function isTemporaryCloudPrefsStatus(status: number): boolean {
+  return status === 429 || status === 503;
+}
 
 /**
  * Parse the `Retry-After` header per RFC 7231: either delta-seconds or an
@@ -348,7 +354,7 @@ async function fetchCloudPrefs(token: string, variant: string): Promise<CloudPre
     headers: { Authorization: `Bearer ${token}` },
   });
   if (res.status === 401) return null;
-  if (res.status === 503) throw new ServiceUnavailableError(parseRetryAfterSeconds(res.headers));
+  if (isTemporaryCloudPrefsStatus(res.status)) throw new ServiceUnavailableError(parseRetryAfterSeconds(res.headers), res.status);
   if (!res.ok) throw new Error(`fetch prefs: ${res.status}`);
   return (await res.json()) as CloudPrefs | null;
 }
@@ -376,7 +382,7 @@ async function postCloudPrefs(
     const actualSyncVersion = typeof body.actualSyncVersion === 'number' ? body.actualSyncVersion : undefined;
     return { conflict: true, actualSyncVersion };
   }
-  if (res.status === 503) throw new ServiceUnavailableError(parseRetryAfterSeconds(res.headers));
+  if (isTemporaryCloudPrefsStatus(res.status)) throw new ServiceUnavailableError(parseRetryAfterSeconds(res.headers), res.status);
   if (!res.ok) throw new Error(`post prefs: ${res.status}`);
   return (await res.json()) as { syncVersion: number };
 }
@@ -495,7 +501,7 @@ export async function onSignIn(userId: string, variant: string): Promise<void> {
     Storage.prototype.setItem.call(localStorage, KEY_LAST_SIGNED_IN_AS, userId);
   } catch (err) {
     if (err instanceof ServiceUnavailableError) {
-      // Convex platform 503 — transient. Set 'pending' (not 'error') and
+      // Temporary edge response — transient. Set 'pending' (not 'error') and
       // re-attempt sign-in sync after the server-suggested delay. This is
       // the user-facing "transient outage shouldn't be permanent" fix
       // (PR #3479): without this branch the catch would fall through to
@@ -508,7 +514,7 @@ export async function onSignIn(userId: string, variant: string): Promise<void> {
       // attempt began). Without the guard, a 5s delayed retry from user A
       // could fire after sign-out (no token) or after user B signed in
       // (wrong token in cache).
-      console.warn(`[cloud-prefs] onSignIn 503; retrying in ${err.retryAfterSec}s`);
+      console.warn(`[cloud-prefs] onSignIn ${err.status}; retrying in ${err.retryAfterSec}s`);
       setState('pending');
       clearRetryTimer();
       _retryTimer = setTimeout(() => {
@@ -594,7 +600,7 @@ async function uploadNow(variant: string): Promise<void> {
     }
   } catch (err) {
     if (err instanceof ServiceUnavailableError) {
-      // Convex platform 503 — transient. Re-queue the upload after the
+      // Temporary edge response — transient. Re-queue the upload after the
       // server-suggested delay so the unsaved blob isn't lost. Setting
       // 'pending' state matches the existing schedulePrefUpload UX.
       //
@@ -603,7 +609,7 @@ async function uploadNow(variant: string): Promise<void> {
       // but the closure's captured `myGeneration` no longer matches, so
       // the retry aborts. Without this, the upload would re-fire against
       // a now-empty token cache or a different user's token.
-      console.warn(`[cloud-prefs] uploadNow 503; retrying in ${err.retryAfterSec}s`);
+      console.warn(`[cloud-prefs] uploadNow ${err.status}; retrying in ${err.retryAfterSec}s`);
       setState('pending');
       clearRetryTimer();
       _retryTimer = setTimeout(() => {

--- a/tests/cloud-prefs-retry-after.test.mjs
+++ b/tests/cloud-prefs-retry-after.test.mjs
@@ -20,11 +20,49 @@ const fnBody = constsBlock[0] + ';\n' + fnMatch[1].trim();
 // eslint-disable-next-line no-new-func
 const parseRetryAfterSeconds = new Function('headers', fnBody);
 
+const temporaryStatusMatch = src.match(/export function isTemporaryCloudPrefsStatus\(status: number\): boolean \{([\s\S]*?)\n\}/);
+assert.ok(temporaryStatusMatch, 'isTemporaryCloudPrefsStatus must exist in cloud-prefs-sync.ts');
+// eslint-disable-next-line no-new-func
+const isTemporaryCloudPrefsStatus = new Function('status', temporaryStatusMatch[1].trim());
+
+const postCloudPrefsBody = (() => {
+  const start = src.indexOf('async function postCloudPrefs');
+  assert.notEqual(start, -1, 'postCloudPrefs must exist in cloud-prefs-sync.ts');
+  const end = src.indexOf('// ── Core logic', start);
+  assert.notEqual(end, -1, 'postCloudPrefs should end before the core logic section');
+  return src.slice(start, end);
+})();
+
 const mkHeaders = (value) => {
   const h = new Headers();
   if (value !== undefined) h.set('Retry-After', value);
   return h;
 };
+
+describe('temporary cloud prefs statuses', () => {
+  it('treats 429 and 503 as retryable temporary failures', () => {
+    assert.equal(isTemporaryCloudPrefsStatus(429), true);
+    assert.equal(isTemporaryCloudPrefsStatus(503), true);
+  });
+
+  it('does not route auth, conflict, or generic server errors through the retry path', () => {
+    assert.equal(isTemporaryCloudPrefsStatus(401), false);
+    assert.equal(isTemporaryCloudPrefsStatus(409), false);
+    assert.equal(isTemporaryCloudPrefsStatus(500), false);
+  });
+
+  it('postCloudPrefs uses the temporary-status retry path before generic errors', () => {
+    assert.match(
+      postCloudPrefsBody,
+      /if \(isTemporaryCloudPrefsStatus\(res\.status\)\) throw new ServiceUnavailableError\(parseRetryAfterSeconds\(res\.headers\), res\.status\);/,
+      'POST 429 must throw ServiceUnavailableError so uploadNow honors Retry-After instead of stranding the write in error state',
+    );
+    assert.ok(
+      postCloudPrefsBody.includes("if (!res.ok) throw new Error(`post prefs: ${res.status}`);"),
+      'generic non-OK handling must remain after the temporary retry branch',
+    );
+  });
+});
 
 describe('parseRetryAfterSeconds', () => {
   describe('delta-seconds form', () => {

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -272,6 +272,11 @@ describe('scoped rate-limit degraded call-site policy (#3531)', () => {
       expected: /Redis-degraded scoped limits intentionally stay availability-first/,
       reason: 'MCP proxy is already premium-auth gated; scoped limit degradation is logged and remains availability-first',
     },
+    {
+      path: 'api/user-prefs.ts',
+      expected: /Redis-degraded scoped limits intentionally fail open for prefs writes/,
+      reason: 'cloud prefs writes are low-stakes, so Redis degradation should not block legitimate settings sync',
+    },
   ];
 
   it('keeps every checkScopedRateLimit caller audited for degraded handling', async () => {

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -216,15 +216,23 @@ describe('rate-limit fail-open / fail-closed posture (#3531 M9)', () => {
     assert.match(src, /fingerprint:\s*\['rate-limit',\s*'redis-error',\s*stage\]/);
   });
 
-  it('checkScopedRateLimit reports degraded when Upstash env is missing', async () => {
+  it('checkScopedRateLimit reports and captures degraded missing-config once per scope', async () => {
     delete process.env.UPSTASH_REDIS_REST_URL;
     delete process.env.UPSTASH_REDIS_REST_TOKEN;
     const mod = await importFreshRateLimitModule();
 
     const result = await mod.checkScopedRateLimit('test-scope', 5, '60 s', 'identifier');
+    const secondResult = await mod.checkScopedRateLimit('test-scope', 5, '60 s', 'identifier-2');
 
     assert.equal(result.allowed, true);
     assert.equal(result.degraded, true);
+    assert.equal(secondResult.allowed, true);
+    assert.equal(secondResult.degraded, true);
+    const missingConfigLogs = consoleErrors.filter((line) =>
+      line.includes('stage=checkScopedRateLimit:test-scope:missing-config'),
+    );
+    assert.equal(missingConfigLogs.length, 1, 'missing config should be observable without logging every request');
+    assert.match(missingConfigLogs[0], /UPSTASH_REDIS_REST_URL or UPSTASH_REDIS_REST_TOKEN missing/);
   });
 
   it('checkScopedRateLimit returns degraded:true on Redis error so callers can fail-closed locally', async () => {

--- a/tests/user-prefs-rate-limit.test.mts
+++ b/tests/user-prefs-rate-limit.test.mts
@@ -1,0 +1,177 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it, mock } from 'node:test';
+
+import handler, {
+  __setUserPrefsDepsForTests,
+  USER_PREFS_WRITE_RATE_LIMIT,
+  USER_PREFS_WRITE_RATE_SCOPE,
+  USER_PREFS_WRITE_RATE_WINDOW,
+} from '../api/user-prefs.ts';
+
+const originalConvexUrl = process.env.CONVEX_URL;
+const TEST_NOW = 1_700_000_000_000;
+const TEST_USER_ID = 'user_rate_limit_test';
+
+type RateLimitResult = {
+  allowed: boolean;
+  limit: number;
+  reset: number;
+  degraded: boolean;
+};
+
+type ClientCall =
+  | { kind: 'auth'; token: string }
+  | { kind: 'client'; url: string }
+  | { kind: 'setAuth'; token: string }
+  | { kind: 'query'; name: unknown; args: Record<string, unknown> }
+  | { kind: 'mutation'; name: unknown; args: Record<string, unknown> };
+
+function restoreEnv(): void {
+  if (originalConvexUrl === undefined) delete process.env.CONVEX_URL;
+  else process.env.CONVEX_URL = originalConvexUrl;
+}
+
+afterEach(() => {
+  __setUserPrefsDepsForTests(null);
+  mock.restoreAll();
+  restoreEnv();
+});
+
+function makePost(body: Record<string, unknown> = {
+  variant: 'full',
+  data: { theme: 'dark' },
+  expectedSyncVersion: 1,
+}): Request {
+  return new Request('https://worldmonitor.app/api/user-prefs', {
+    method: 'POST',
+    headers: {
+      Origin: 'https://worldmonitor.app',
+      Authorization: 'Bearer test-token',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function installDeps(rateLimitResult: RateLimitResult): {
+  calls: ClientCall[];
+  rateLimitCalls: Array<{ scope: string; limit: number; window: string; identifier: string }>;
+} {
+  const calls: ClientCall[] = [];
+  const rateLimitCalls: Array<{ scope: string; limit: number; window: string; identifier: string }> = [];
+
+  __setUserPrefsDepsForTests({
+    validateBearerToken: async (token: string) => {
+      calls.push({ kind: 'auth', token });
+      return { valid: true, userId: TEST_USER_ID };
+    },
+    checkScopedRateLimit: async (scope: string, limit: number, window: string, identifier: string) => {
+      rateLimitCalls.push({ scope, limit, window, identifier });
+      return rateLimitResult;
+    },
+    createConvexClient: (url: string) => {
+      calls.push({ kind: 'client', url });
+      return {
+        setAuth(token: string): void {
+          calls.push({ kind: 'setAuth', token });
+        },
+        async query(name: unknown, args: Record<string, unknown>): Promise<unknown> {
+          calls.push({ kind: 'query', name, args });
+          return null;
+        },
+        async mutation(name: unknown, args: Record<string, unknown>): Promise<unknown> {
+          calls.push({ kind: 'mutation', name, args });
+          return { ok: true, syncVersion: 7 };
+        },
+      };
+    },
+  });
+
+  return { calls, rateLimitCalls };
+}
+
+describe('user-prefs POST write rate limit', () => {
+  it('returns 429 + Retry-After without calling Convex when the identity is over budget', async () => {
+    process.env.CONVEX_URL = 'https://convex.test';
+    mock.method(Date, 'now', () => TEST_NOW);
+    const warnMock = mock.method(console, 'warn', () => {});
+    const { calls, rateLimitCalls } = installDeps({
+      allowed: false,
+      limit: USER_PREFS_WRITE_RATE_LIMIT,
+      reset: TEST_NOW + 30_000,
+      degraded: false,
+    });
+
+    const res = await handler(makePost());
+
+    assert.equal(res.status, 429);
+    assert.equal(res.headers.get('Retry-After'), '30');
+    assert.equal(res.headers.get('X-RateLimit-Limit'), String(USER_PREFS_WRITE_RATE_LIMIT));
+    assert.equal(res.headers.get('X-RateLimit-Remaining'), '0');
+    assert.equal(res.headers.get('X-RateLimit-Reset'), String(TEST_NOW + 30_000));
+    assert.deepEqual(await res.json(), { error: 'RATE_LIMITED' });
+    assert.deepEqual(rateLimitCalls, [{
+      scope: USER_PREFS_WRITE_RATE_SCOPE,
+      limit: USER_PREFS_WRITE_RATE_LIMIT,
+      window: USER_PREFS_WRITE_RATE_WINDOW,
+      identifier: TEST_USER_ID,
+    }]);
+    assert.equal(calls.some((call) => call.kind === 'client'), false, 'over-budget requests must not construct a Convex client');
+    assert.equal(calls.some((call) => call.kind === 'mutation'), false, 'over-budget requests must not reach Convex');
+    assert.equal(warnMock.mock.calls.length, 1);
+  });
+
+  it('passes an under-budget identity through to setPreferences', async () => {
+    process.env.CONVEX_URL = 'https://convex.test';
+    const { calls, rateLimitCalls } = installDeps({
+      allowed: true,
+      limit: USER_PREFS_WRITE_RATE_LIMIT,
+      reset: TEST_NOW + 60_000,
+      degraded: false,
+    });
+
+    const res = await handler(makePost({
+      variant: 'tech',
+      data: { theme: 'light' },
+      expectedSyncVersion: 2,
+      schemaVersion: 3,
+    }));
+
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { syncVersion: 7 });
+    assert.deepEqual(rateLimitCalls, [{
+      scope: USER_PREFS_WRITE_RATE_SCOPE,
+      limit: USER_PREFS_WRITE_RATE_LIMIT,
+      window: USER_PREFS_WRITE_RATE_WINDOW,
+      identifier: TEST_USER_ID,
+    }]);
+    const mutation = calls.find((call): call is Extract<ClientCall, { kind: 'mutation' }> => call.kind === 'mutation');
+    assert.ok(mutation, 'under-budget request should call setPreferences');
+    assert.equal(mutation.name, 'userPreferences:setPreferences');
+    assert.deepEqual(mutation.args, {
+      variant: 'tech',
+      data: { theme: 'light' },
+      expectedSyncVersion: 2,
+      schemaVersion: 3,
+    });
+  });
+
+  it('fails open when the scoped limiter is degraded', async () => {
+    process.env.CONVEX_URL = 'https://convex.test';
+    const warnMock = mock.method(console, 'warn', () => {});
+    const { calls } = installDeps({
+      allowed: true,
+      limit: USER_PREFS_WRITE_RATE_LIMIT,
+      reset: 0,
+      degraded: true,
+    });
+
+    const res = await handler(makePost());
+
+    assert.equal(res.status, 200);
+    assert.deepEqual(await res.json(), { syncVersion: 7 });
+    assert.ok(calls.some((call) => call.kind === 'mutation'), 'degraded limiter should fail open to Convex');
+    assert.equal(warnMock.mock.calls.length, 1);
+    assert.match(String(warnMock.mock.calls[0].arguments[0]), /rate limit unavailable; failing open/);
+  });
+});

--- a/tests/user-prefs-rate-limit.test.mts
+++ b/tests/user-prefs-rate-limit.test.mts
@@ -91,6 +91,29 @@ function installDeps(rateLimitResult: RateLimitResult): {
 }
 
 describe('user-prefs POST write rate limit', () => {
+  it('rejects invalid sessions before checking the scoped limiter', async () => {
+    const rateLimitCalls: Array<{ scope: string; limit: number; window: string; identifier: string }> = [];
+    let createdClient = false;
+
+    __setUserPrefsDepsForTests({
+      validateBearerToken: async () => ({ valid: false }),
+      checkScopedRateLimit: async (scope: string, limit: number, window: string, identifier: string) => {
+        rateLimitCalls.push({ scope, limit, window, identifier });
+        return { allowed: true, limit, reset: 0, degraded: false };
+      },
+      createConvexClient: () => {
+        createdClient = true;
+        throw new Error('Convex client should not be constructed for invalid sessions');
+      },
+    });
+
+    const res = await handler(makePost());
+
+    assert.equal(res.status, 401);
+    assert.deepEqual(await res.json(), { error: 'UNAUTHENTICATED' });
+    assert.deepEqual(rateLimitCalls, []);
+    assert.equal(createdClient, false);
+  });
   it('returns 429 + Retry-After without calling Convex when the identity is over budget', async () => {
     process.env.CONVEX_URL = 'https://convex.test';
     mock.method(Date, 'now', () => TEST_NOW);


### PR DESCRIPTION
## Summary

Authenticated cloud preference writes now have a per-user write budget, so a noisy client can no longer hammer `POST /api/user-prefs` all the way through to Convex. Over-budget callers receive `429` with `Retry-After` and rate-limit headers, while Redis limiter degradation logs and fails open so legitimate settings sync is not stranded during an infra blip.

The guard is keyed by the validated `session.userId`, uses the scoped `user-prefs-write` limiter at 30 writes/minute, and is covered by focused tests for over-budget, under-budget, and degraded-limiter paths.

Fixes #4569.

## Validation

- `./node_modules/.bin/tsx --test tests/user-prefs-rate-limit.test.mts tests/rate-limit.test.mts`
- `npm run typecheck:api`
- `npm run lint`
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/tsx --test tests/dashboard-critical-css.test.mjs`
- `npm run test:data` (12,098 pass, 0 fail, 6 skipped)

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
