### PR TITLE
fix(seed-fuel-prices): retry transient 5xx on publish-gating sources

### DIFF
--- a/scripts/seed-fuel-prices.mjs
+++ b/scripts/seed-fuel-prices.mjs
@@ -254,7 +254,7 @@ async function fetchMexico() {
   }
 }
 
-export async function fetchUS_EIA() {
+export async function fetchUS_EIA({ baseDelayMs } = {}) {
   try {
     const apiKey = process.env.EIA_API_KEY || '';
     if (!apiKey) {
@@ -272,7 +272,7 @@ export async function fetchUS_EIA() {
       });
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
       return r;
-    });
+    }, { baseDelayMs });
     const data = await resp.json();
     const rows = data?.response?.data;
     if (!Array.isArray(rows) || rows.length === 0) return [];

--- a/scripts/seed-fuel-prices.mjs
+++ b/scripts/seed-fuel-prices.mjs
@@ -17,8 +17,10 @@ if (_proxyAuth) {
 
 async function sleep(ms) { return new Promise(r => setTimeout(r, ms)); }
 
-// Retry wrapper: 3 attempts, 1.5s/3s/4.5s backoff. Use for all upstream calls.
-async function withFuelRetry(label, fn, { tries = 3 } = {}) {
+// Retry wrapper: 3 attempts, 1.5s/3s backoff. Use for all upstream calls so a
+// single transient 5xx/network blip on a publish-gating source (US/GB/MY/EU)
+// doesn't reject the whole weekly snapshot. baseDelayMs is injectable for tests.
+export async function withFuelRetry(label, fn, { tries = 3, baseDelayMs = 1500 } = {}) {
   let lastErr;
   for (let i = 1; i <= tries; i++) {
     try {
@@ -26,7 +28,7 @@ async function withFuelRetry(label, fn, { tries = 3 } = {}) {
     } catch (err) {
       lastErr = err;
       if (i < tries) {
-        const delay = 1500 * i;
+        const delay = baseDelayMs * i;
         console.warn(`  [${label}] attempt ${i}/${tries} failed (${err.message}) — retry in ${delay}ms`);
         await sleep(delay);
       }
@@ -142,11 +144,16 @@ function isSaneUsd(usdPrice) {
 async function fetchMalaysia() {
   try {
     const url = 'https://api.data.gov.my/data-catalogue?id=fuelprice&limit=20&sort=-date';
-    const resp = await globalThis.fetch(url, {
-      headers: { 'User-Agent': CHROME_UA },
-      signal: AbortSignal.timeout(20000),
+    // MY is a critical + untolerated source — retry transient errors so one blip
+    // doesn't reject the whole publish.
+    const resp = await withFuelRetry('MY', async () => {
+      const r = await globalThis.fetch(url, {
+        headers: { 'User-Agent': CHROME_UA },
+        signal: AbortSignal.timeout(20000),
+      });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      return r;
     });
-    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
     const data = await resp.json();
     if (!Array.isArray(data) || data.length === 0) return [];
     const row = data.find(r => r.series_type === 'level') ?? data[0];
@@ -247,7 +254,7 @@ async function fetchMexico() {
   }
 }
 
-async function fetchUS_EIA() {
+export async function fetchUS_EIA() {
   try {
     const apiKey = process.env.EIA_API_KEY || '';
     if (!apiKey) {
@@ -256,11 +263,16 @@ async function fetchUS_EIA() {
     }
     const url = `https://api.eia.gov/v2/petroleum/pri/gnd/data/?api_key=${apiKey}&data[]=value&facets[series][]=EMM_EPMR_PTE_NUS_DPG&facets[series][]=EMD_EPD2DXL0_PTE_NUS_DPG&sort[0][column]=period&sort[0][direction]=desc&length=4`;
     console.log(`  [US] Fetching EIA: ${url.replace(/api_key=[^&]+/, 'api_key=***')}`);
-    const resp = await globalThis.fetch(url, {
-      headers: { 'User-Agent': CHROME_UA },
-      signal: AbortSignal.timeout(20000),
+    // EIA's gateway intermittently 502s. US is a critical + untolerated source,
+    // so a single unretried blip rejects the whole publish — retry transient errors.
+    const resp = await withFuelRetry('US', async () => {
+      const r = await globalThis.fetch(url, {
+        headers: { 'User-Agent': CHROME_UA },
+        signal: AbortSignal.timeout(20000),
+      });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      return r;
     });
-    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
     const data = await resp.json();
     const rows = data?.response?.data;
     if (!Array.isArray(rows) || rows.length === 0) return [];
@@ -318,11 +330,16 @@ function parseEUPrice(raw) {
 async function fetchEU_CSV() {
   try {
     console.log(`  [EU] Fetching XLSX from EC document store`);
-    const resp = await globalThis.fetch(EU_XLSX_URL, {
-      headers: { 'User-Agent': CHROME_UA },
-      signal: AbortSignal.timeout(60000),
+    // EU-CSV supplies 27 of the ≥30 countries the publish gate requires, so a
+    // transient failure here also rejects the whole snapshot — retry it.
+    const resp = await withFuelRetry('EU', async () => {
+      const r = await globalThis.fetch(EU_XLSX_URL, {
+        headers: { 'User-Agent': CHROME_UA },
+        signal: AbortSignal.timeout(60000),
+      });
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      return r;
     });
-    if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
 
     const buf = Buffer.from(await resp.arrayBuffer());
     const workbook = new ExcelJS.Workbook();
@@ -556,18 +573,26 @@ async function fetchUK_DESNZ() {
   // URL changes weekly; discover via Content API.
   try {
     console.log('  [GB] Discovering DESNZ CSV URL...');
-    const apiResp = await globalThis.fetch('https://www.gov.uk/api/content/government/statistics/weekly-road-fuel-prices', {
-      headers: { 'User-Agent': CHROME_UA }, signal: AbortSignal.timeout(15000),
+    // GB is a critical + untolerated source — retry both the discovery call and
+    // the CSV fetch so one transient blip doesn't reject the whole publish.
+    const apiResp = await withFuelRetry('GB-api', async () => {
+      const r = await globalThis.fetch('https://www.gov.uk/api/content/government/statistics/weekly-road-fuel-prices', {
+        headers: { 'User-Agent': CHROME_UA }, signal: AbortSignal.timeout(15000),
+      });
+      if (!r.ok) throw new Error(`Content API HTTP ${r.status}`);
+      return r;
     });
-    if (!apiResp.ok) throw new Error(`Content API HTTP ${apiResp.status}`);
     const apiData = await apiResp.json();
     const csvAttach = apiData?.details?.attachments?.find(a => a.content_type?.includes('csv') && a.title?.includes('2018'));
     if (!csvAttach?.url) throw new Error('CSV attachment not found in Content API');
 
-    const csvResp = await globalThis.fetch(csvAttach.url, {
-      headers: { 'User-Agent': CHROME_UA }, signal: AbortSignal.timeout(20000),
+    const csvResp = await withFuelRetry('GB-csv', async () => {
+      const r = await globalThis.fetch(csvAttach.url, {
+        headers: { 'User-Agent': CHROME_UA }, signal: AbortSignal.timeout(20000),
+      });
+      if (!r.ok) throw new Error(`CSV HTTP ${r.status}`);
+      return r;
     });
-    if (!csvResp.ok) throw new Error(`CSV HTTP ${csvResp.status}`);
     const lines = (await csvResp.text()).split('\n').filter(l => l.trim());
     // Header: Date,ULSP Pump price pence/litre,ULSD Pump price pence/litre,...
     const dataLines = lines.slice(1).filter(l => l.split(',').length >= 3);

--- a/tests/seed-fuel-prices.test.mjs
+++ b/tests/seed-fuel-prices.test.mjs
@@ -48,7 +48,9 @@ test('fetchUS_EIA recovers from a transient 502 instead of failing the critical 
     }), { status: 200, headers: { 'Content-Type': 'application/json' } });
   };
   try {
-    const out = await fetchUS_EIA();
+    // baseDelayMs: 0 threads through to withFuelRetry so the retry is instant
+    // (no 1.5s real sleep) — the seam's whole point.
+    const out = await fetchUS_EIA({ baseDelayMs: 0 });
     assert.ok(calls >= 2, 'should have retried after the 502');
     assert.equal(out.length, 1);
     assert.equal(out[0].code, 'US');

--- a/tests/seed-fuel-prices.test.mjs
+++ b/tests/seed-fuel-prices.test.mjs
@@ -1,6 +1,64 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { parseCREStationPrices, validateFuel } from '../scripts/seed-fuel-prices.mjs';
+import { parseCREStationPrices, validateFuel, withFuelRetry, fetchUS_EIA } from '../scripts/seed-fuel-prices.mjs';
+
+test('withFuelRetry returns the first success without retrying', async () => {
+  let calls = 0;
+  const r = await withFuelRetry('T', async () => { calls++; return 'ok'; }, { baseDelayMs: 0 });
+  assert.equal(r, 'ok');
+  assert.equal(calls, 1);
+});
+
+test('withFuelRetry retries transient failures then succeeds', async () => {
+  let calls = 0;
+  const r = await withFuelRetry('T', async () => {
+    calls++;
+    if (calls < 3) throw new Error('boom');
+    return 'ok';
+  }, { baseDelayMs: 0 });
+  assert.equal(r, 'ok');
+  assert.equal(calls, 3);
+});
+
+test('withFuelRetry throws the last error after exhausting tries', async () => {
+  let calls = 0;
+  await assert.rejects(
+    withFuelRetry('T', async () => { calls++; throw new Error(`fail-${calls}`); }, { tries: 3, baseDelayMs: 0 }),
+    /fail-3/,
+  );
+  assert.equal(calls, 3);
+});
+
+// Regression: prod log 2026-06-23 showed a single `[US] fetchUS_EIA error: HTTP 502`
+// rejecting the ENTIRE multi-source publish (US is critical + untolerated), because
+// fetchUS_EIA did a bare fetch with no retry. A transient 502 must be retried.
+test('fetchUS_EIA recovers from a transient 502 instead of failing the critical source', async () => {
+  const origFetch = globalThis.fetch;
+  const origKey = process.env.EIA_API_KEY;
+  process.env.EIA_API_KEY = 'test-key';
+  let calls = 0;
+  globalThis.fetch = async () => {
+    calls++;
+    if (calls === 1) return new Response('bad gateway', { status: 502 });
+    return new Response(JSON.stringify({
+      response: { data: [
+        { series: 'EMM_EPMR_PTE_NUS_DPG', value: 3.10, period: '2026-06-16' },
+        { series: 'EMD_EPD2DXL0_PTE_NUS_DPG', value: 3.60, period: '2026-06-16' },
+      ] },
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+  };
+  try {
+    const out = await fetchUS_EIA();
+    assert.ok(calls >= 2, 'should have retried after the 502');
+    assert.equal(out.length, 1);
+    assert.equal(out[0].code, 'US');
+    assert.ok(out[0].gasoline.usdPrice > 0, 'US gasoline price should be present after recovery');
+  } finally {
+    globalThis.fetch = origFetch;
+    if (origKey === undefined) delete process.env.EIA_API_KEY;
+    else process.env.EIA_API_KEY = origKey;
+  }
+});
 
 test('parseCREStationPrices extracts regular + diesel per-station prices from CRE XML', () => {
   const xml = `<?xml version="1.0" encoding="utf-8"?>


### PR DESCRIPTION
## Summary
- **Bug:** a single `HTTP 502` from the EIA gateway (prod log 2026-06-23) rejected the *entire* weekly fuel-prices snapshot. `fetchUS_EIA` did a bare `fetch` with **no retry**, and US is a critical + untolerated source, so `validateFuel` returned false → `validation failed (empty data)` → seed-meta never refreshed (heading toward `STALE_SEED`), even though 31 countries + GB/MY were healthy. The `withFuelRetry` helper already existed but was only wired to Mexico/Brazil.
- **Fix:** wrap all four publish-gating sources — **US, MY, EU, and GB** (both the DESNZ discovery call and the CSV fetch) — in `withFuelRetry` so a transient 5xx/network blip retries (3 attempts, 1.5s/3s backoff) instead of nuking the publish.
- **Latency is bounded:** the 7 sources run concurrently via `Promise.allSettled`, so added wall-time is bounded by the slowest source's backoff (~4.5s for the common fast-fail 502), not the sum. `seed-fuel-prices` is a standalone Railway cron container (not a bundle member), so there is no per-seed `timeoutMs` wrapper to trip.
- Added a `baseDelayMs` seam to `withFuelRetry` for instant tests; exported `withFuelRetry` + `fetchUS_EIA`.
- NZ's `<html>` failure in the same log is the known Incapsula bot-wall (already in `TOLERATED_FAILURES`, tracked separately) — it does not gate publish on its own.

## Test plan
- [x] Reproduction test: `fetch` returns `502`-then-`200` → `fetchUS_EIA` recovers and returns US (confirmed **failing** before the fix, passing after).
- [x] `withFuelRetry` contract tests: first-success (no retry), retry-then-succeed, exhaust-tries-then-throw.
- [x] `node --test tests/seed-fuel-prices.test.mjs` → 18/18 pass.
- [x] Full `/newpr` gate: typecheck, typecheck:api, CJS syntax, Biome lint, `test:data` (all seed tests green; the only 2 fails were unrelated timing flakes that pass in isolation), edge-function esbuild bundle, edge-function tests, markdown lint, version:check — all pass.

Claude-Session: https://claude.ai/code/session_016Jk7w1sYSzyNd5AwRuTzsY