### PR TITLE
fix(seed): recover Unity cable — replace dead 'unityeac-pacific' slug

### DIFF
--- a/scripts/seed-submarine-cables.mjs
+++ b/scripts/seed-submarine-cables.mjs
@@ -10,7 +10,12 @@ const CACHE_TTL = 7 * 24 * 3600; // 7 days — cable infra changes slowly
 
 // Strategic cable list — TeleGeography slugs organized by region.
 // Find slugs at: https://www.submarinecablemap.com/api/v3/cable/all.json
-const CABLE_REGIONS = [
+// NOTE: TeleGeography renames/splits slugs over time (e.g. the combined
+// "Unity/EAC-Pacific" was split into 'unity' + 'eac-c2c'). A stale slug returns
+// HTTP 200 with the SPA's HTML shell (not JSON); per-cable fetches tolerate this
+// (see fetchSubmarineCables), but it silently drops the cable — verify slugs
+// against cable/all.json when the fetched count drifts below the region total.
+export const CABLE_REGIONS = [
   {
     label: 'TRANS-ATLANTIC',
     ids: [
@@ -24,7 +29,7 @@ const CABLE_REGIONS = [
     ids: [
       'faster', 'southern-cross-cable-network-sccn', 'curie',
       'trans-pacific-express-tpe-cable-system', 'new-cross-pacific-ncp-cable-system',
-      'pacific-light-cable-network-plcn', 'jupiter', 'unityeac-pacific',
+      'pacific-light-cable-network-plcn', 'jupiter', 'unity',
       'pacific-crossing-1-pc-1', 'topaz', 'echo', 'southern-cross-next', 'hawaiki',
     ],
   },

--- a/src/config/geo-map.ts
+++ b/src/config/geo-map.ts
@@ -357,8 +357,8 @@ export const UNDERSEA_CABLES: UnderseaCable[] = [
     ],
   },
   {
-    id: 'unityeac_pacific',
-    name: 'Unity/EAC-Pacific',
+    id: 'unity',
+    name: 'Unity',
     points: [[140, 35], [141.3, 34.9], [160.2, 41.4], [-118.4, 33.8], [-129.6, 37.9], [-180, 44.7]],
     major: true,
     rfsYear: 2010,

--- a/tests/seed-submarine-cables.test.mjs
+++ b/tests/seed-submarine-cables.test.mjs
@@ -2,6 +2,7 @@ import { describe, it, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  CABLE_REGIONS,
   declareRecords,
   fetchSubmarineCables,
   validate,
@@ -65,6 +66,33 @@ function installSubmarineCableFetchMock({ malformedDetail }) {
 
   return { detailIds };
 }
+
+describe('seed-submarine-cables strategic slug list', () => {
+  const allIds = CABLE_REGIONS.flatMap(r => r.ids);
+
+  it('has no duplicate slugs across regions', () => {
+    const seen = new Set();
+    const dupes = [];
+    for (const id of allIds) {
+      if (seen.has(id)) dupes.push(id);
+      seen.add(id);
+    }
+    assert.deepEqual(dupes, [], `duplicate cable slug(s): ${dupes.join(', ')}`);
+  });
+
+  it('uses only well-formed lowercase-kebab slugs', () => {
+    const bad = allIds.filter(id => !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(id));
+    assert.deepEqual(bad, [], `malformed cable slug(s): ${bad.join(', ')}`);
+  });
+
+  it('drops the dead unityeac-pacific slug in favour of unity', () => {
+    // TeleGeography split the combined "Unity/EAC-Pacific" cable; the old slug
+    // now 404s to an HTML SPA shell (the <!DOCTYPE parse failure that broke the
+    // static-ref bundle before #4516 tolerated per-cable fetch failures).
+    assert.equal(allIds.includes('unityeac-pacific'), false, 'unityeac-pacific is a dead slug');
+    assert.equal(allIds.includes('unity'), true, 'unity is the live replacement slug');
+  });
+});
 
 describe('seed-submarine-cables detail fetch resilience', () => {
   it('skips a malformed individual detail response when the validation floor still passes', async () => {

--- a/tests/seed-submarine-cables.test.mjs
+++ b/tests/seed-submarine-cables.test.mjs
@@ -87,8 +87,9 @@ describe('seed-submarine-cables strategic slug list', () => {
 
   it('drops the dead unityeac-pacific slug in favour of unity', () => {
     // TeleGeography split the combined "Unity/EAC-Pacific" cable; the old slug
-    // now 404s to an HTML SPA shell (the <!DOCTYPE parse failure that broke the
-    // static-ref bundle before #4516 tolerated per-cable fetch failures).
+    // now returns HTTP 200 with the SPA's HTML shell (not a 404) — the <!DOCTYPE
+    // parse failure that broke the static-ref bundle before #4516 tolerated
+    // per-cable fetch failures.
     assert.equal(allIds.includes('unityeac-pacific'), false, 'unityeac-pacific is a dead slug');
     assert.equal(allIds.includes('unity'), true, 'unity is the live replacement slug');
   });


### PR DESCRIPTION
## Summary

`seed-bundle-static-ref` → `Submarine-Cables` was failing with `Unexpected token '<', "<!DOCTYPE "... is not valid JSON`.

- **Root cause:** `unityeac-pacific` is a dead TeleGeography slug. The combined "Unity/EAC-Pacific" cable was split upstream into `unity` + `eac-c2c`; the old slug now returns **HTTP 200 with the site's HTML SPA shell** (not JSON), so `JSON.parse` throws on `<!DOCTYPE`.
- **Impact:** Pre-#4516 this failed the **entire** static-ref bundle, and because the 7-day cache had already expired, the submarine-cable keys went missing (`2 key(s) expired — manual re-seed required`). #4516 made per-cable fetches tolerant, but the dead slug still silently dropped the cable and ate into the 90% (77/86) fetch floor — leaving us one vendor rename away from failing again.
- **Fix:** point the seeder at `unity` → restores the full **86/86** fetch. Verified live: valid JSON, route geometry present in `cable-geo.json`, JP↔US landing points, Google/KDDI/Telstra owners, RFS 2010.
- Reconcile the static `UNDERSEA_CABLES` baseline (the documented fallback mirror of the seeded ids) to `id: 'unity'` / `name: 'Unity'` so live + fallback data agree on one id. Referenced nowhere else in the repo.
- Add a regression suite guarding slug uniqueness, kebab-case format, and the specific `unityeac-pacific`→`unity` rename so it can't reappear.

## Test plan

- [x] `fetchSubmarineCables()` against the live API → **86/86**, `validate()` true, `unity` present with route + landing points
- [x] `tests/seed-submarine-cables.test.mjs` — 5/5 pass (incl. 3 new slug-list guards)
- [x] `npm run typecheck` + `npm run typecheck:api` — pass
- [x] `npm run lint` + `npm run lint:md` — pass
- [x] `test:data` full suite — **12,097 pass, 0 fail** (split into two processes to dodge the worktree's single-process OOM)
- [x] edge-function bundle check (19 fns) + `tests/edge-functions.test.mjs` (205/205) — pass
- [ ] **Post-merge:** manual re-seed of `seed-submarine-cables.mjs` on Railway to refresh the (expired) keys immediately rather than waiting for the weekly cron

https://claude.ai/code/session_015oes5hWj45xnxGDrcFEENL