### PR TITLE
fix(seed/ecb): preserve €STR content-age on transient partial fetch fail

### DIFF
--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -183,9 +183,17 @@ All new services share these settings:
 |---|---|
 | **Service name** | `seed-bundle-ecb-eu` |
 | **Start command** | `node scripts/seed-bundle-ecb-eu.mjs` |
-| **Cron schedule** | `0 6 * * *` (daily 06:00 UTC) |
+| **Cron schedule** | `0 13 * * *` (daily 13:00 UTC) |
 | **Watch paths** | `scripts/**`, `shared/**` |
 | **Replaces** | 4 services (ecb-fx-rates, ecb-short-rates, yield-curve-eu, fsi-eu) |
+
+> **Why 13:00 UTC (not 06:00):** the daily ECB SDMX series (€STR, yield curve,
+> CISS) are rebuilt during ECB's early-morning refresh window. A `0 6 * * *`
+> run (08:00 CEST — exactly €STR's publication moment) intermittently hit that
+> window and got empty/incomplete datasets, so those three sections failed
+> gracefully (TTL extended, no data loss) while the bundle exited non-zero and
+> showed red on Railway. 13:00 UTC (15:00 CEST) clears €STR (08:00 CET), the
+> yield curve (~12:00 CET) and CISS morning publication. Changed 2026-07-01.
 | **Net savings** | 3 slots |
 | **Members** | ECB FX Rates (daily), ECB Short Rates (daily), Yield Curve EU (daily), FSI EU (daily) |
 

--- a/docs/railway-seed-consolidation-runbook.md
+++ b/docs/railway-seed-consolidation-runbook.md
@@ -186,6 +186,8 @@ All new services share these settings:
 | **Cron schedule** | `0 13 * * *` (daily 13:00 UTC) |
 | **Watch paths** | `scripts/**`, `shared/**` |
 | **Replaces** | 4 services (ecb-fx-rates, ecb-short-rates, yield-curve-eu, fsi-eu) |
+| **Net savings** | 3 slots |
+| **Members** | ECB FX Rates (daily), ECB Short Rates (daily), Yield Curve EU (daily), FSI EU (daily) |
 
 > **Why 13:00 UTC (not 06:00):** the daily ECB SDMX series (€STR, yield curve,
 > CISS) are rebuilt during ECB's early-morning refresh window. A `0 6 * * *`
@@ -194,8 +196,6 @@ All new services share these settings:
 > gracefully (TTL extended, no data loss) while the bundle exited non-zero and
 > showed red on Railway. 13:00 UTC (15:00 CEST) clears €STR (08:00 CET), the
 > yield curve (~12:00 CET) and CISS morning publication. Changed 2026-07-01.
-| **Net savings** | 3 slots |
-| **Members** | ECB FX Rates (daily), ECB Short Rates (daily), Yield Curve EU (daily), FSI EU (daily) |
 
 ### Bundle 2: seed-bundle-portwatch
 

--- a/scripts/seed-ecb-short-rates.mjs
+++ b/scripts/seed-ecb-short-rates.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { loadEnvFile, CHROME_UA, getRedisCredentials, withRetry, writeFreshnessMetadata, extendExistingTtl, acquireLockSafely, releaseLock, logSeedResult } from './_seed-utils.mjs';
+import { loadEnvFile, CHROME_UA, getRedisCredentials, withRetry, writeFreshnessMetadata, extendExistingTtl, acquireLockSafely, releaseLock, logSeedResult, readCanonicalValue } from './_seed-utils.mjs';
 import { tokensToContentMeta, DAY_MIN } from './_content-age-helpers.mjs';
 
 loadEnvFile(import.meta.url);
@@ -114,6 +114,30 @@ async function fetchEcbSeries(def) {
   return observations;
 }
 
+// ─── €STR content-age derivation (exported for unit tests) ─────────────────────
+//
+// The content-age contract tracks the €STR observation span so /api/health can
+// fire STALE_CONTENT if €STR freezes (issue #3845). €STR is fetched fresh each
+// run, but on a TRANSIENT fetch failure this seeder still publishes seed-meta
+// for the EURIBOR series that DID succeed (successCount > 0 → no throw). Nulling
+// the content age in that case flips ecbEstr AND all three ecbEuribor* health
+// checks (they share this one seed-meta record) to STALE_CONTENT on the FIRST
+// failed run — far more aggressive than the 10-day ESTR_MAX_CONTENT_AGE_MIN
+// budget, which is meant to fire only ~6 business days into a genuine freeze.
+//
+// So when the fresh fetch failed, derive the span from the LAST-GOOD €STR key
+// (whose TTL we extend on failure) instead. Freeze detection is preserved: if
+// €STR has genuinely been frozen for > budget days, the preserved key's newest
+// observation is already old enough to trip STALE_CONTENT; and if the key has
+// expired entirely (sustained outage) the read yields no observations → null
+// span → STALE_CONTENT. Fresh observations always win when present.
+export function deriveEstrContentMeta(freshObservations, preservedObservations, nowMs = Date.now()) {
+  const source = Array.isArray(freshObservations) && freshObservations.length > 0
+    ? freshObservations
+    : (Array.isArray(preservedObservations) ? preservedObservations : []);
+  return tokensToContentMeta(source.map((o) => o?.date), nowMs);
+}
+
 // ─── Write a single FRED-format key to Redis ───────────────────────────────────
 
 async function writeSeriesKey(redisUrl, redisToken, def, observations) {
@@ -191,9 +215,24 @@ async function main() {
   }
 
   // Content-age: report the €STR observation span so /api/health can fire
-  // STALE_CONTENT if the series freezes (issue #3845). estrObservations is
-  // null when the €STR fetch failed → newest/oldest null → STALE_CONTENT.
-  const estrSpan = tokensToContentMeta((estrObservations ?? []).map((o) => o?.date));
+  // STALE_CONTENT if the series freezes (issue #3845). When THIS run's €STR
+  // fetch failed, derive the span from the last-good €STR key (whose TTL we
+  // just extended) instead of nulling it — a single transient ECB blip must
+  // not flip ecbEstr + all EURIBOR checks to STALE_CONTENT. Freeze detection
+  // is preserved; see deriveEstrContentMeta.
+  let preservedEstrObs = null;
+  if (estrObservations == null) {
+    try {
+      const preserved = await readCanonicalValue(fredSeedKey('ESTR'));
+      preservedEstrObs = preserved?.series?.observations ?? null;
+      if (Array.isArray(preservedEstrObs) && preservedEstrObs.length > 0) {
+        console.log(`  €STR fetch failed — content-age from last-good key (${preservedEstrObs.length} obs, latest ${preservedEstrObs.at(-1)?.date})`);
+      }
+    } catch {
+      // best-effort: fall through to null span → STALE_CONTENT
+    }
+  }
+  const estrSpan = deriveEstrContentMeta(estrObservations, preservedEstrObs);
   const contentAge = {
     newestItemAt: estrSpan?.newestItemAt ?? null,
     oldestItemAt: estrSpan?.oldestItemAt ?? null,

--- a/tests/seed-ecb-short-rates-content-age.test.mjs
+++ b/tests/seed-ecb-short-rates-content-age.test.mjs
@@ -1,0 +1,75 @@
+// Regression guard for the €STR partial-failure content-age softening.
+//
+// Bug: seed-ecb-short-rates fetches 4 series (€STR daily + 3 EURIBOR monthly).
+// When the €STR fetch transiently fails but ≥1 EURIBOR succeeds, the seeder
+// still publishes seed-meta (successCount > 0 → no throw). The old code derived
+// the content-age span from the null `estrObservations`, nulling newest/oldest —
+// which flips ecbEstr AND all three ecbEuribor* /api/health checks (they read
+// the same seed-meta record) to STALE_CONTENT on the FIRST failed run. That is
+// far more aggressive than the 10-day budget, which exists to fire only ~6
+// business days into a GENUINE freeze (issue #3845).
+//
+// Fix: on €STR fetch failure, derive the span from the last-good €STR key
+// (whose TTL is extended on failure). These tests lock the pure derivation:
+// transient blip → keeps last-good span (no false stale); genuine freeze →
+// preserved dates are old enough to still trip stale; no data at all → null.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveEstrContentMeta } from '../scripts/seed-ecb-short-rates.mjs';
+import { DAY_MIN } from '../scripts/_content-age-helpers.mjs';
+
+const NOW = Date.parse('2026-07-01T12:00:00Z');
+const ESTR_BUDGET_MIN = 10 * DAY_MIN; // mirrors ESTR_MAX_CONTENT_AGE_MIN in the seeder
+const ts = (d) => Date.parse(`${d}T00:00:00Z`);
+const ageMin = (span) => (NOW - span.newestItemAt) / 60_000;
+
+test('fresh €STR observations win — span comes from this run, not the preserved key', () => {
+  const fresh = [{ date: '2026-06-29', value: 2.18 }, { date: '2026-06-30', value: 2.18 }];
+  const preserved = [{ date: '2026-06-01', value: 2.1 }]; // stale — must be ignored
+  const span = deriveEstrContentMeta(fresh, preserved, NOW);
+  assert.equal(span.newestItemAt, ts('2026-06-30'));
+  assert.equal(span.oldestItemAt, ts('2026-06-29'));
+});
+
+test('transient €STR fetch failure falls back to last-good key → NO false STALE_CONTENT', () => {
+  const preserved = [
+    { date: '2026-06-26', value: 2.18 },
+    { date: '2026-06-29', value: 2.18 },
+    { date: '2026-06-30', value: 2.18 },
+  ];
+  const span = deriveEstrContentMeta(null, preserved, NOW);
+  assert.notEqual(span, null, 'span must not be null on a transient blip with last-good data');
+  assert.equal(span.newestItemAt, ts('2026-06-30'));
+  // 1-day-old content is comfortably inside the 10-day budget → health stays OK.
+  assert.ok(ageMin(span) < ESTR_BUDGET_MIN, 'recent preserved data must read as fresh, not stale');
+});
+
+test('genuine €STR freeze still trips STALE_CONTENT — preserved dates are old enough', () => {
+  // €STR frozen ~30 days: fetch keeps failing, last-good key holds only old dates.
+  const preserved = [{ date: '2026-05-29', value: 2.1 }, { date: '2026-06-01', value: 2.1 }];
+  const span = deriveEstrContentMeta(null, preserved, NOW);
+  assert.notEqual(span, null);
+  assert.equal(span.newestItemAt, ts('2026-06-01'));
+  // Newest preserved observation is > budget old → /api/health flips STALE_CONTENT.
+  assert.ok(ageMin(span) > ESTR_BUDGET_MIN, 'a real freeze must still exceed the content-age budget');
+});
+
+test('no fresh AND no last-good data → null span → STALE_CONTENT (sustained outage)', () => {
+  assert.equal(deriveEstrContentMeta(null, null, NOW), null);
+  assert.equal(deriveEstrContentMeta(null, [], NOW), null);
+  assert.equal(deriveEstrContentMeta([], null, NOW), null);
+  assert.equal(deriveEstrContentMeta([], [], NOW), null);
+});
+
+test('empty fresh array is treated as "no fresh" and falls back to preserved', () => {
+  const preserved = [{ date: '2026-06-30', value: 2.18 }];
+  const span = deriveEstrContentMeta([], preserved, NOW);
+  assert.equal(span.newestItemAt, ts('2026-06-30'));
+});
+
+test('undatable preserved entries are skipped; a valid one still yields a span', () => {
+  const preserved = [{ value: 2.1 }, { date: null }, { date: '2026-06-30', value: 2.18 }];
+  const span = deriveEstrContentMeta(null, preserved, NOW);
+  assert.equal(span.newestItemAt, ts('2026-06-30'));
+});


### PR DESCRIPTION
## Summary

Fixes the `seed-bundle-ecb-eu` "failing" symptom traced from a 06:00-UTC cron run where the daily ECB SDMX series (€STR, yield-curve, CISS) transiently returned empty during ECB's morning refresh window. The code is not broken (all parsers verified against live ECB data); this addresses two follow-ups from that incident:

- **€STR partial-failure false `STALE_CONTENT` (code).** `seed-ecb-short-rates` fetches €STR (daily) + 3 EURIBOR (monthly). When €STR's fetch transiently fails but ≥1 EURIBOR succeeds, `successCount>0` so the seeder still publishes `seed-meta` — and the old code derived content-age from the null `estrObservations`, nulling `newest/oldestItemAt`. That flipped `ecbEstr` **and all three `ecbEuribor*`** `/api/health` checks (they share one `seed-meta` record) to `STALE_CONTENT` on the **first** failed run — far more aggressive than the 10-day budget, which is meant to fire ~6 business days into a genuine freeze (issue #3845).
  - Fix: on €STR fetch failure, derive the span from the **last-good €STR key** (whose TTL is already extended on failure) via `readCanonicalValue`, instead of nulling it. Freeze detection is preserved — stale preserved dates still trip `STALE_CONTENT`, and an expired/absent key → null span → `STALE_CONTENT`.
  - Extracted the pure derivation into exported `deriveEstrContentMeta(fresh, preserved, nowMs)` for unit testing.

- **Cron move 06:00 → 13:00 UTC (ops).** 06:00 UTC = 08:00 CEST collided with ECB's morning SDMX refresh window (and €STR's publication moment). 13:00 UTC (15:00 CEST) clears €STR (08:00 CET), the yield curve (~12:00 CET) and CISS morning publication. **The cron itself lives in the Railway dashboard and was already updated there** (via CLI); this PR only syncs the runbook doc to match, with a rationale note.

## Test plan

- [x] New unit tests: `tests/seed-ecb-short-rates-content-age.test.mjs` (6 cases) — fresh wins; transient blip keeps last-good span (no false stale); genuine freeze still trips stale; no-data → null.
- [x] `npm run typecheck` / `typecheck:api` — pass
- [x] `npm run lint` (biome) — pass
- [x] `npm run lint:md` — pass (runbook doc)
- [x] `npm run version:check` — pass
- [x] edge-function esbuild bundle check (19 files) + `tests/edge-functions.test.mjs` — pass
- [x] `npm run test:data` — 14052 pass, my 6 new tests pass. The 9 failures are **pre-existing and unrelated to this diff**: 2 `dashboard-critical-css` built-output tests that require `VITE_VARIANT=full vite build` first (asserted message), plus a `relay-auth` relay-spawn 15s timeout — all in files/modules this PR does not touch.

Claude-Session: https://claude.ai/code/session_01GZy23sxphXQYgGGYv8ygYP