### PR TITLE
fix(seed-forecasts): auth chokepoint warm-ping + unwrap envelope in loadTickerSet

### DIFF
--- a/scripts/_ticker-validation.mjs
+++ b/scripts/_ticker-validation.mjs
@@ -1,4 +1,6 @@
 // @ts-check
+import { unwrapEnvelope } from './_seed-envelope-source.mjs';
+
 /** @typedef {{ symbol: string, name?: string, display?: string }} StockSymbol */
 
 const STOCKS_BOOTSTRAP_KEY = 'market:stocks-bootstrap:v1';
@@ -19,10 +21,16 @@ export async function loadTickerSet(redisUrl, redisToken) {
     if (!resp.ok) return new Set();
     const data = await resp.json();
     if (!data?.result) return new Set();
+    // market:stocks-bootstrap:v1 is written in contract mode ({_seed, data}) by
+    // both seed-market-quotes.mjs (runSeed declareRecords) and the AIS relay
+    // (envelopeWrite). Reading `.quotes` off the raw parse returned undefined —
+    // the quotes live under `.data.quotes` — so this set was empty on every run
+    // (Railway log 2026-07-01). unwrapEnvelope strips _seed and passes legacy
+    // bare shapes through unchanged, so `.quotes` resolves for both.
     /** @type {{ quotes?: StockSymbol[] } | null} */
-    const parsed = (() => { try { return JSON.parse(data.result); } catch { return null; } })();
-    if (!Array.isArray(parsed?.quotes)) return new Set();
-    return new Set(parsed.quotes.map(s => s.symbol?.toUpperCase()).filter(Boolean));
+    const payload = unwrapEnvelope(data.result).data;
+    if (!Array.isArray(payload?.quotes)) return new Set();
+    return new Set(payload.quotes.map(s => s.symbol?.toUpperCase()).filter(Boolean));
   } catch {
     return new Set();
   }

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -673,13 +673,22 @@ function normalizeGpsJamming(raw) {
 async function warmPingChokepoints() {
   const baseUrl = process.env.WM_API_BASE_URL;
   if (!baseUrl) { console.log('  [Chokepoints] Warm-ping skipped (no WM_API_BASE_URL)'); return; }
+  // get-chokepoint-status is medium-tier gated. The gateway trusts a relay
+  // warm-ping ONLY when it carries WORLDMONITOR_RELAY_KEY in X-WorldMonitor-Key
+  // (server/gateway.ts isRelayWarmPingRequest); Origin alone is not enough, so
+  // without the key this 401s every run. Mirrors seed-service-statuses.mjs.
+  const relayKey = process.env.WORLDMONITOR_RELAY_KEY || '';
+  const headers = { 'User-Agent': CHROME_UA, Origin: 'https://worldmonitor.app' };
+  if (relayKey) headers['X-WorldMonitor-Key'] = relayKey;
   try {
     const resp = await fetch(`${baseUrl}/api/supply-chain/v1/get-chokepoint-status`, {
-      headers: { 'User-Agent': CHROME_UA, Origin: 'https://worldmonitor.app' },
+      headers,
       signal: AbortSignal.timeout(15_000),
     });
-    if (!resp.ok) console.warn(`  [Chokepoints] Warm-ping failed: HTTP ${resp.status}`);
-    else console.log('  [Chokepoints] Warm-ping OK');
+    if (!resp.ok) {
+      const keyNote = relayKey ? '' : ' (WORLDMONITOR_RELAY_KEY not set — Origin-only auth)';
+      console.warn(`  [Chokepoints] Warm-ping failed: HTTP ${resp.status}${keyNote}`);
+    } else console.log('  [Chokepoints] Warm-ping OK');
   } catch (err) { console.warn(`  [Chokepoints] Warm-ping error: ${err.message}`); }
 }
 

--- a/tests/forecasts-ticker-set-envelope-unwrap.test.mjs
+++ b/tests/forecasts-ticker-set-envelope-unwrap.test.mjs
@@ -1,0 +1,68 @@
+// loadTickerSet envelope unwrap — regression test.
+//
+// Production bug (Railway seed-forecasts log 2026-07-01): market:stocks-bootstrap:v1
+// is written in contract mode ({ _seed, data: { quotes } }) by BOTH
+// seed-market-quotes.mjs (runSeed declareRecords) and the AIS relay (envelopeWrite),
+// but loadTickerSet read `.quotes` off the raw parse — undefined inside an envelope.
+// Result: the MarketImplications live ticker set was empty on EVERY run
+// ("Redis ticker set empty — using static allowlist only"; 0/18 successful loads),
+// silently degrading card validation to the static allowlist.
+//
+// loadTickerSet now unwraps via unwrapEnvelope (legacy bare shapes pass through).
+// These tests pin the envelope + legacy shapes and the empty/missing/malformed paths.
+
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadTickerSet } from '../scripts/_ticker-validation.mjs';
+
+const realFetch = global.fetch;
+afterEach(() => { global.fetch = realFetch; });
+
+// Mirrors the Upstash REST /get response: { result: <stringified value> | null }.
+function stubRedisGet(result) {
+  global.fetch = async () => ({ ok: true, json: async () => ({ result }) });
+}
+
+function seedEnvelope(data) {
+  return { _seed: { fetchedAt: Date.now(), recordCount: 1, sourceVersion: 'test', schemaVersion: 1, state: 'OK' }, data };
+}
+
+const quotes = [
+  { symbol: 'nflx', name: 'Netflix' },
+  { symbol: 'WMT' },
+  { symbol: 'aapl' },
+];
+
+test('BUG REPRO + FIX: enveloped stocks-bootstrap populates the ticker set', async () => {
+  const raw = JSON.stringify(seedEnvelope({ quotes }));
+  // What the buggy loader did: JSON.parse, then read `.quotes` off the top level.
+  assert.equal(JSON.parse(raw).quotes, undefined, 'quotes live under .data.quotes — raw .quotes is undefined');
+  // The fixed loader unwraps the envelope and finds them (uppercased).
+  stubRedisGet(raw);
+  const set = await loadTickerSet('https://redis.example', 'tok');
+  assert.deepEqual([...set].sort(), ['AAPL', 'NFLX', 'WMT']);
+});
+
+test('legacy bare { quotes } shape still works (envelope passthrough)', async () => {
+  stubRedisGet(JSON.stringify({ quotes }));
+  const set = await loadTickerSet('https://redis.example', 'tok');
+  assert.deepEqual([...set].sort(), ['AAPL', 'NFLX', 'WMT']);
+});
+
+test('missing key returns an empty set', async () => {
+  stubRedisGet(null);
+  const set = await loadTickerSet('https://redis.example', 'tok');
+  assert.equal(set.size, 0);
+});
+
+test('malformed JSON returns an empty set (no throw)', async () => {
+  stubRedisGet('{not json');
+  const set = await loadTickerSet('https://redis.example', 'tok');
+  assert.equal(set.size, 0);
+});
+
+test('envelope with non-array quotes returns an empty set', async () => {
+  stubRedisGet(JSON.stringify(seedEnvelope({ quotes: 'nope' })));
+  const set = await loadTickerSet('https://redis.example', 'tok');
+  assert.equal(set.size, 0);
+});


### PR DESCRIPTION
## Summary

Two **deterministic** bugs surfaced by the hourly `seed-forecasts` Railway log — both fire on *every* run. (The run that actually `Failed gracefully` was a transient ~3-min Upstash Redis partition — infra, self-heals, no code change needed; OpenRouter kept succeeding while only the 7 Upstash REST IPs connect-timed-out. These two fixes are the *latent* bugs the log exposed.)

- **`warmPingChokepoints()` → HTTP 401 every run.** `/api/supply-chain/v1/get-chokepoint-status` is `medium`-tier gated **and** a relay warm-ping target (`RELAY_WARM_PING_PATHS`), so the gateway trusts it only when the request carries `X-WorldMonitor-Key === WORLDMONITOR_RELAY_KEY` (`isRelayWarmPingRequest`). The warm-ping sent no key. Now sends it (mirrors `seed-service-statuses.mjs` / `seed-infra.mjs`) and logs a clear note when the env var is missing.
  - ⚠️ **Operational dependency:** the 401 only disappears in production once `WORLDMONITOR_RELAY_KEY` is set on the **seed-forecasts Railway service** (same value as the Vercel gateway). Without it the new code logs `(WORLDMONITOR_RELAY_KEY not set — Origin-only auth)` and still 401s — the code is correct either way.

- **`loadTickerSet()` → empty set every run** → `[MarketImplications] Redis ticker set empty — using static allowlist only` (**0/18 successful loads** in the log), silently degrading MarketImplications card validation to the static allowlist. `market:stocks-bootstrap:v1` is contract/envelope-written (`{_seed, data:{quotes}}`) by **both** writers (`seed-market-quotes.mjs` runSeed `declareRecords`; AIS relay `envelopeWrite`), but `loadTickerSet` read `.quotes` off the raw parse — `undefined` inside an envelope. Now unwraps via `unwrapEnvelope` (matching `readInputKeys` in the same file); legacy bare shapes still pass through.

## Test plan

- [x] New `tests/forecasts-ticker-set-envelope-unwrap.test.mjs` (5 tests): envelope, legacy-bare, missing key, malformed JSON, non-array quotes — passing under `node --test` and `tsx`. Repro asserts `JSON.parse(raw).quotes === undefined` (old path) then proves the unwrap yields the symbols.
- [x] Full `/newpr` gate green: `typecheck`, `typecheck:api`, CJS syntax, `biome lint`, `test:data` (11946 pass; critical-css needed a `vite build`; one `withTimeout` was a concurrency flake — 8/8 isolated), edge-bundle (19 files), edge-functions test, `lint:md`, `version:check`.
- [ ] Post-merge: confirm Railway `seed-forecasts` logs `[Chokepoints] Warm-ping OK` and `[MarketImplications] Extended allowlist: N static + M live` (requires `WORLDMONITOR_RELAY_KEY` on the service).

https://claude.ai/code/session_01FuZaPRwKr6h31ZbHGvnwpQ