### PR TITLE
fix(security): enforce active apiAccess on all keyed wm_ API-key routes (#4611)

### DIFF
--- a/server/__tests__/entitlement-check.test.ts
+++ b/server/__tests__/entitlement-check.test.ts
@@ -233,6 +233,8 @@ describe("gateway entitlement check", () => {
           }),
         }),
       );
+      const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+      expect(init.signal).toBeInstanceOf(AbortSignal);
     } finally {
       if (originalSiteUrl === undefined) {
         delete process.env.CONVEX_SITE_URL;

--- a/server/__tests__/gateway-api-rate-limit.test.ts
+++ b/server/__tests__/gateway-api-rate-limit.test.ts
@@ -159,13 +159,16 @@ describe("#3199 U4 — gateway per-account rate-limit wiring", () => {
     expect(checkRateLimit).not.toHaveBeenCalled();
   });
 
-  test("downgraded entitlement (apiAccess:false) → NOT eligible, per-IP runs, no burst check", async () => {
+  test("downgraded entitlement (apiAccess:false) → 403 (#4611), rejected before the rate-limit block", async () => {
     process.env.API_RATE_LIMIT_ENFORCE = "true";
     entitlement = { planKey: "pro", features: { tier: 1, apiAccess: false, apiRateLimit: 0 }, validUntil: Date.now() + 86_400_000 };
 
     const res = await makeGateway()(userKeyRequest(), ctx);
-    expect(res.status).toBe(200);
-    expect(checkBurst).not.toHaveBeenCalled(); // never slidingWindow(0)
-    expect(checkRateLimit).toHaveBeenCalledTimes(1);
+    // #4611: a wm_ key whose owner lost apiAccess is rejected outright, not
+    // silently downgraded to the per-IP path. The apiAccess gate runs BEFORE
+    // the #3199 per-account rate-limit block, so neither limiter is consulted.
+    expect(res.status).toBe(403);
+    expect(checkBurst).not.toHaveBeenCalled();
+    expect(checkRateLimit).not.toHaveBeenCalled();
   });
 });

--- a/server/__tests__/gateway-user-key-apiaccess.test.ts
+++ b/server/__tests__/gateway-user-key-apiaccess.test.ts
@@ -43,8 +43,8 @@ vi.mock("../_shared/rate-limit", () => ({
 }));
 
 // --- Stub entitlement resolution. getEntitlements returns whatever the
-//     current test set; getRequiredTier=null keeps routes non-tier-gated so
-//     PREMIUM_RPC_PATHS membership alone drives the legacy premium path. ------
+//     current test sets. getRequiredTier defaults to null so most routes stay
+//     non-tier-gated; individual tests can opt into ENDPOINT_ENTITLEMENTS. -----
 const ACTIVE = {
   planKey: "api_starter",
   features: {
@@ -61,9 +61,11 @@ const ACTIVE = {
 };
 type Ent = { planKey: string; features: Record<string, unknown>; validUntil: number } | null;
 let entitlement: Ent = ACTIVE;
-const getEntitlements = vi.fn(async () => entitlement);
+const requiredTiers = new Map<string, number>();
+const entitlementsByUser = new Map<string, Ent>();
+const getEntitlements = vi.fn(async (userId: string) => entitlementsByUser.get(userId) ?? entitlement);
 vi.mock("../_shared/entitlement-check", () => ({
-  getRequiredTier: () => null, // not tier-gated
+  getRequiredTier: (pathname: string) => requiredTiers.get(pathname) ?? null,
   checkEntitlement: vi.fn().mockResolvedValue(null),
   checkEntitlementDetailed: vi.fn().mockResolvedValue({ response: null, entitlements: null }),
   getEntitlements: (...a: unknown[]) => getEntitlements(...a),
@@ -73,6 +75,14 @@ vi.mock("../_shared/entitlement-check", () => ({
 const validateUserApiKey = vi.fn(async () => ({ userId: "acct_lapsed", keyId: "k1", name: "t" }));
 vi.mock("../_shared/user-api-key", () => ({
   validateUserApiKey: (...a: unknown[]) => validateUserApiKey(...a),
+}));
+
+// --- Stub Clerk session resolution for mixed bearer + wm_ requests. ----------
+type MockClerkSession = { userId: string; orgId: string | null } | null;
+let clerkSession: MockClerkSession = null;
+const resolveClerkSession = vi.fn(async () => clerkSession);
+vi.mock("../_shared/auth-session", () => ({
+  resolveClerkSession: (...a: unknown[]) => resolveClerkSession(...a),
 }));
 
 import { createDomainGateway } from "../gateway";
@@ -96,11 +106,15 @@ function makeGateway() {
   ]);
 }
 
-function keyReq(path: string, method = "GET", key = "wm_lapsed_customer_key") {
-  return new Request(`https://www.worldmonitor.app${path}`, {
-    method,
-    headers: { "X-Api-Key": key },
-  });
+function keyReq(
+  path: string,
+  method = "GET",
+  key = "wm_lapsed_customer_key",
+  extraHeaders: Record<string, string> = {},
+) {
+  const headers = new Headers(extraHeaders);
+  headers.set("X-Api-Key", key);
+  return new Request(`https://www.worldmonitor.app${path}`, { method, headers });
 }
 
 const ctx = { waitUntil: () => {} };
@@ -108,12 +122,16 @@ const ORIGINAL_ENV = { ...process.env };
 
 beforeEach(() => {
   entitlement = ACTIVE;
+  requiredTiers.clear();
+  entitlementsByUser.clear();
+  clerkSession = null;
   checkBurst.mockReset().mockResolvedValue({ ok: true });
   reserveDailyMeter.mockReset().mockResolvedValue({
     count: 1, overCeiling: false, metered: true, retryAfterSec: 100, rollback: async () => {},
   });
   checkRateLimit.mockClear().mockResolvedValue(null);
   getEntitlements.mockClear();
+  resolveClerkSession.mockClear();
   validateUserApiKey.mockClear().mockResolvedValue({ userId: "acct_lapsed", keyId: "k1", name: "t" });
   delete process.env.UPSTASH_REDIS_REST_URL;
   delete process.env.UPSTASH_REDIS_REST_TOKEN;
@@ -155,6 +173,27 @@ describe("#4611 — expired wm_ key rejected on all route classes", () => {
     entitlement = DOWNGRADED;
     const res = await makeGateway()(keyReq(PREMIUM_PATH, "POST"), ctx);
     expect(res.status).toBe(403);
+  });
+
+  test("tier-gated route: mixed bearer + downgraded wm_ key checks the wm_ owner", async () => {
+    requiredTiers.set(PREMIUM_PATH, 1);
+    clerkSession = { userId: "acct_active_session", orgId: "org_1" };
+    entitlementsByUser.set("acct_active_session", ACTIVE);
+    entitlementsByUser.set("acct_lapsed", DOWNGRADED);
+
+    const res = await makeGateway()(
+      keyReq(PREMIUM_PATH, "POST", "wm_lapsed_customer_key", {
+        Authorization: "Bearer valid-clerk-session",
+      }),
+      ctx,
+    );
+
+    expect(res.status).toBe(403);
+    expect(resolveClerkSession).toHaveBeenCalledTimes(1);
+    expect(validateUserApiKey).toHaveBeenCalledWith("wm_lapsed_customer_key");
+    expect(getEntitlements).toHaveBeenCalledWith("acct_lapsed");
+    expect(checkBurst).not.toHaveBeenCalled();
+    expect(checkRateLimit).not.toHaveBeenCalled();
   });
 
   // --- apiAccess:true but validUntil in the past (lapsed) → 403 -------------

--- a/server/__tests__/gateway-user-key-apiaccess.test.ts
+++ b/server/__tests__/gateway-user-key-apiaccess.test.ts
@@ -1,0 +1,207 @@
+// @vitest-environment node
+
+/**
+ * #4611 — cancelled / downgraded customers must NOT keep programmatic API
+ * access via an un-revoked `wm_` key.
+ *
+ * The pre-existing `apiAccess` gate only fired on PREMIUM_RPC_PATHS, so an
+ * expired key still served the whole keyed RPC surface (the API Starter product
+ * leaked past churn). These tests assert the generalized gate added at
+ * server/gateway.ts, scoped to `isUserApiKey` (the wm_ key is the authenticating
+ * credential), which is the actual paid surface:
+ *   - regular non-tier-gated keyed RPC and PREMIUM_RPC_PATHS: a wm_ key whose
+ *     owner lacks ACTIVE apiAccess (downgraded or past validUntil) → 403,
+ *     BEFORE the #3199 rate-limit block; active keys unaffected.
+ *   - transient/unresolvable entitlement (getEntitlements null) → fail-OPEN
+ *     (served), so a Convex/cache blip never 403s active subscribers.
+ *   - PUBLIC_NO_AUTH_RPC_PATHS serve free data to everyone: the wm_ key is NOT
+ *     re-validated there (no unauthenticated Convex-lookup amplification, no
+ *     gating the anonymous lead forms) — served as anonymous.
+ *   - enterprise operator keys (kind 'enterprise') are exempt.
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+
+// --- Stub the per-account rate-limit module (never reached for an expired key,
+//     but keep real Redis out of the picture for the allowed-key paths). ------
+const checkBurst = vi.fn();
+const reserveDailyMeter = vi.fn();
+vi.mock("../_shared/api-key-rate-limit", () => ({
+  checkBurst: (...a: unknown[]) => checkBurst(...a),
+  reserveDailyMeter: (...a: unknown[]) => reserveDailyMeter(...a),
+  rateLimitHeaders: () => ({ "X-RateLimit-Limit": "60", "Retry-After": "30" }),
+  ENTERPRISE_API_RATE_LIMIT: 1000,
+  CEILING_MULTIPLIER: 10,
+}));
+
+// --- Stub the per-IP layer: spy whether checkRateLimit runs. -----------------
+const checkRateLimit = vi.fn().mockResolvedValue(null);
+vi.mock("../_shared/rate-limit", () => ({
+  checkRateLimit: (...a: unknown[]) => checkRateLimit(...a),
+  checkEndpointRateLimit: vi.fn().mockResolvedValue(null),
+  hasEndpointRatePolicy: () => false,
+}));
+
+// --- Stub entitlement resolution. getEntitlements returns whatever the
+//     current test set; getRequiredTier=null keeps routes non-tier-gated so
+//     PREMIUM_RPC_PATHS membership alone drives the legacy premium path. ------
+const ACTIVE = {
+  planKey: "api_starter",
+  features: {
+    tier: 2,
+    apiAccess: true,
+    apiRateLimit: 60,
+    apiDailyAllowance: 1000,
+    maxDashboards: 25,
+    prioritySupport: false,
+    exportFormats: ["csv"],
+    mcpAccess: true,
+  },
+  validUntil: Date.now() + 86_400_000,
+};
+type Ent = { planKey: string; features: Record<string, unknown>; validUntil: number } | null;
+let entitlement: Ent = ACTIVE;
+const getEntitlements = vi.fn(async () => entitlement);
+vi.mock("../_shared/entitlement-check", () => ({
+  getRequiredTier: () => null, // not tier-gated
+  checkEntitlement: vi.fn().mockResolvedValue(null),
+  checkEntitlementDetailed: vi.fn().mockResolvedValue({ response: null, entitlements: null }),
+  getEntitlements: (...a: unknown[]) => getEntitlements(...a),
+}));
+
+// --- Stub user-key validation: a valid wm_ key resolves to a userId. ---------
+const validateUserApiKey = vi.fn(async () => ({ userId: "acct_lapsed", keyId: "k1", name: "t" }));
+vi.mock("../_shared/user-api-key", () => ({
+  validateUserApiKey: (...a: unknown[]) => validateUserApiKey(...a),
+}));
+
+import { createDomainGateway } from "../gateway";
+
+const REGULAR_PATH = "/api/news/v1/list-feed-digest";
+const PUBLIC_NO_AUTH_PATH = "/api/conflict/v1/list-acled-events"; // in PUBLIC_NO_AUTH_RPC_PATHS
+const PREMIUM_PATH = "/api/market/v1/analyze-stock"; // in PREMIUM_RPC_PATHS
+
+function ok() {
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeGateway() {
+  return createDomainGateway([
+    { method: "GET", path: REGULAR_PATH, handler: async () => ok() },
+    { method: "GET", path: PUBLIC_NO_AUTH_PATH, handler: async () => ok() },
+    { method: "POST", path: PREMIUM_PATH, handler: async () => ok() },
+  ]);
+}
+
+function keyReq(path: string, method = "GET", key = "wm_lapsed_customer_key") {
+  return new Request(`https://www.worldmonitor.app${path}`, {
+    method,
+    headers: { "X-Api-Key": key },
+  });
+}
+
+const ctx = { waitUntil: () => {} };
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  entitlement = ACTIVE;
+  checkBurst.mockReset().mockResolvedValue({ ok: true });
+  reserveDailyMeter.mockReset().mockResolvedValue({
+    count: 1, overCeiling: false, metered: true, retryAfterSec: 100, rollback: async () => {},
+  });
+  checkRateLimit.mockClear().mockResolvedValue(null);
+  getEntitlements.mockClear();
+  validateUserApiKey.mockClear().mockResolvedValue({ userId: "acct_lapsed", keyId: "k1", name: "t" });
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  delete process.env.WORLDMONITOR_VALID_KEYS;
+});
+
+afterEach(() => {
+  for (const k of Object.keys(process.env)) if (!(k in ORIGINAL_ENV)) delete process.env[k];
+  Object.assign(process.env, ORIGINAL_ENV);
+});
+
+describe("#4611 — expired wm_ key rejected on all route classes", () => {
+  // --- apiAccess:false (downgraded) → 403 everywhere ------------------------
+  const DOWNGRADED: Ent = { planKey: "pro", features: { tier: 1, apiAccess: false, apiRateLimit: 0 }, validUntil: Date.now() + 86_400_000 };
+
+  test("regular RPC: downgraded key → 403, rejected before the rate-limit block", async () => {
+    entitlement = DOWNGRADED;
+    const res = await makeGateway()(keyReq(REGULAR_PATH), ctx);
+    expect(res.status).toBe(403);
+    // Gate runs before #3199 — neither the per-account nor per-IP limiter fires.
+    expect(checkBurst).not.toHaveBeenCalled();
+    expect(checkRateLimit).not.toHaveBeenCalled();
+  });
+
+  test("PUBLIC_NO_AUTH route: wm_ key NOT re-validated (no Convex amplification) — served as anonymous", async () => {
+    entitlement = DOWNGRADED;
+    const res = await makeGateway()(keyReq(PUBLIC_NO_AUTH_PATH), ctx);
+    // Public-no-auth serves free data to everyone; the wm_ key is not the
+    // authenticator, so the gate does NOT resolve it. This is deliberate: it
+    // avoids an unauthenticated Convex-lookup amplification vector (a rotating
+    // fake wm_ key per anonymous request) and keeps the intentionally-anonymous
+    // lead-capture forms open. Public data is not the paid product.
+    expect(res.status).toBe(200);
+    expect(validateUserApiKey).not.toHaveBeenCalled();
+    expect(getEntitlements).not.toHaveBeenCalled();
+  });
+
+  test("PREMIUM route: downgraded key → 403 (parity preserved)", async () => {
+    entitlement = DOWNGRADED;
+    const res = await makeGateway()(keyReq(PREMIUM_PATH, "POST"), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  // --- apiAccess:true but validUntil in the past (lapsed) → 403 -------------
+  test("expired entitlement (apiAccess:true, validUntil < now) → 403", async () => {
+    entitlement = { planKey: "api_starter", features: { tier: 2, apiAccess: true, apiRateLimit: 60 }, validUntil: Date.now() - 1_000 };
+    const res = await makeGateway()(keyReq(REGULAR_PATH), ctx);
+    expect(res.status).toBe(403);
+  });
+
+  test("null entitlement (transient Convex/cache failure) → 200 fail-open, active customers not locked out", async () => {
+    entitlement = null;
+    const res = await makeGateway()(keyReq(REGULAR_PATH), ctx);
+    // Fail-OPEN: an unresolvable entitlement is "unknown", not "denied", so a
+    // backend blip never 403s active subscribers fleet-wide. The systematic
+    // churn leak is still closed on the warm path, where the downgraded
+    // entitlement resolves and 403s (the downgraded/expired tests above).
+    expect(res.status).toBe(200);
+  });
+
+  // --- active subscription unaffected --------------------------------------
+  test("active apiAccess key → served on regular RPC", async () => {
+    entitlement = ACTIVE;
+    const res = await makeGateway()(keyReq(REGULAR_PATH), ctx);
+    expect(res.status).toBe(200);
+  });
+
+  test("active apiAccess key → served on PUBLIC_NO_AUTH route (key not re-validated)", async () => {
+    entitlement = ACTIVE;
+    const res = await makeGateway()(keyReq(PUBLIC_NO_AUTH_PATH), ctx);
+    expect(res.status).toBe(200);
+    expect(validateUserApiKey).not.toHaveBeenCalled();
+  });
+
+  test("re-subscribe restores the SAME key (no revocation) — active again → 200", async () => {
+    entitlement = DOWNGRADED;
+    expect((await makeGateway()(keyReq(REGULAR_PATH), ctx)).status).toBe(403);
+    entitlement = ACTIVE; // subscription restored, same un-revoked key
+    expect((await makeGateway()(keyReq(REGULAR_PATH), ctx)).status).toBe(200);
+  });
+
+  // --- enterprise operator keys are exempt ---------------------------------
+  test("enterprise wm_-prefixed operator key is NOT gated (no entitlement row)", async () => {
+    process.env.WORLDMONITOR_VALID_KEYS = "wm_enterprise_legacy_relay";
+    entitlement = DOWNGRADED; // would 403 a user key — must be ignored here
+    const res = await makeGateway()(keyReq(REGULAR_PATH, "GET", "wm_enterprise_legacy_relay"), ctx);
+    expect(res.status).toBe(200);
+    // The apiAccess gate must not resolve an entitlement for an enterprise key.
+    expect(getEntitlements).not.toHaveBeenCalled();
+  });
+});

--- a/server/_shared/entitlement-check.ts
+++ b/server/_shared/entitlement-check.ts
@@ -179,6 +179,7 @@ async function _getEntitlementsImpl(userId: string): Promise<CachedEntitlements 
         'x-convex-shared-secret': convexSharedSecret,
       },
       body: JSON.stringify({ userId }),
+      signal: AbortSignal.timeout(3_000),
     });
     if (!response.ok) return null;
     const result = await response.json() as CachedEntitlements | null;

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -902,16 +902,13 @@ export function createDomainGateway(
           forceKey: (isTierGated && !sessionUserId) || needsLegacyProBearerGate,
         })) as { valid: boolean; required: boolean; error?: string; kind?: 'enterprise' | 'session' | 'user' });
 
-    // Clerk session is itself proof of authentication (validated at line 410).
-    // validateApiKey is strict-no-trust-of-headers per #3541 and would 401 every
-    // Clerk-authenticated user who hasn't also minted a wms_ session token.
-    // Override: tier-gated routes with a resolved sessionUserId pass this layer.
-    if (isTierGated && sessionUserId && keyCheck.required && !keyCheck.valid) {
-      keyCheck = { valid: true, required: false };
-    }
-
     // User-owned API keys (wm_ prefix): when the static WORLDMONITOR_VALID_KEYS
     // check fails, try async Convex-backed validation for user-issued keys.
+    //
+    // Run this before the Clerk-session override below. A request can carry both
+    // a valid bearer session and an X-Api-Key wm_ header; when that happens, the
+    // wm_ key is still an explicit authenticating credential and its owner must
+    // pass the #4611 apiAccess gate.
     let isUserApiKey = false;
     const wmKey =
       request.headers.get('X-WorldMonitor-Key') ??
@@ -930,12 +927,19 @@ export function createDomainGateway(
         // userId argument directly (see checkEntitlement(sessionUserId, …))
         // so it no longer depends on this header — the header is now for
         // handler consumption + the internal-MCP `isCallerPremium` path.
-        if (!sessionUserId) {
-          sessionUserId = userKeyResult.userId;
-          usage.sessionUserId = sessionUserId;
-          request = withAuthenticatedUserId(request, sessionUserId);
-        }
+        sessionUserId = userKeyResult.userId;
+        usage.sessionUserId = sessionUserId;
+        usage.clerkOrgId = null;
+        request = withAuthenticatedUserId(request, sessionUserId);
       }
+    }
+
+    // Clerk session is itself proof of authentication (validated at line 410).
+    // validateApiKey is strict-no-trust-of-headers per #3541 and would 401 every
+    // Clerk-authenticated user who hasn't also minted a wms_ session token.
+    // Override: tier-gated routes with a resolved sessionUserId pass this layer.
+    if (isTierGated && sessionUserId && keyCheck.required && !keyCheck.valid) {
+      keyCheck = { valid: true, required: false };
     }
 
     // Enterprise API key (WORLDMONITOR_VALID_KEYS): require kind === 'enterprise'.
@@ -958,7 +962,7 @@ export function createDomainGateway(
     // resolved entitlement is reused there to avoid a second lookup.
     //
     // Scoped to isUserApiKey: the wm_ key IS the authenticating credential
-    // (isUserApiKey ⇒ sessionUserId is the resolved key owner, set at :933).
+    // (isUserApiKey ⇒ sessionUserId is the resolved key owner, set above).
     // This intentionally does NOT re-validate wm_ keys on any other route class:
     //   - Enterprise operator keys (kind 'enterprise', incl. legacy wm_-prefixed
     //     relay keys) never set isUserApiKey and carry no user entitlement row.

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -947,14 +947,51 @@ export function createDomainGateway(
       usage.enterpriseApiKey = wmKey;
     }
 
-    // User API keys on PREMIUM_RPC_PATHS need verified pro-tier entitlement.
-    // Admin keys (WORLDMONITOR_VALID_KEYS) bypass this since they are operator-issued.
-    if (isUserApiKey && needsLegacyProBearerGate && sessionUserId) {
-      const ent = await getEntitlements(sessionUserId);
-      recordUsageEntitlement(ent);
-      if (!ent || !ent.features.apiAccess) {
+    // ── Active-subscription gate for user API keys (#4611) ──────────────────
+    // A wm_ user key that authenticated this request must map to an owner with
+    // ACTIVE apiAccess on EVERY keyed route — not just PREMIUM_RPC_PATHS. A
+    // cancelled/downgraded customer keeps a valid (un-revoked) key that still
+    // resolves to their userId, so without a route-wide gate the key keeps
+    // serving the whole paid programmatic surface for free: the API Starter
+    // product leaks past churn. Runs BEFORE the #3199 per-account rate-limit
+    // block so an expired key is rejected outright, never metered — and the
+    // resolved entitlement is reused there to avoid a second lookup.
+    //
+    // Scoped to isUserApiKey: the wm_ key IS the authenticating credential
+    // (isUserApiKey ⇒ sessionUserId is the resolved key owner, set at :933).
+    // This intentionally does NOT re-validate wm_ keys on any other route class:
+    //   - Enterprise operator keys (kind 'enterprise', incl. legacy wm_-prefixed
+    //     relay keys) never set isUserApiKey and carry no user entitlement row.
+    //   - Verified internal paths (MCP / seed-refresh / relay warm-ping) never
+    //     set isUserApiKey.
+    //   - PUBLIC_NO_AUTH_RPC_PATHS serve free data to everyone; the key is not
+    //     the authenticator there. Re-validating an arbitrary header key on that
+    //     anonymous surface would add an unauthenticated Convex-lookup
+    //     amplification vector (a rotating fake wm_ key per request defeats the
+    //     negative cache, ahead of any rate limit) for no revenue gain — public
+    //     data is not the paid product — and would wrongly gate the
+    //     intentionally-anonymous lead-capture forms.
+    let userKeyEntitlement: CachedEntitlements | null | undefined;
+    if (isUserApiKey && sessionUserId) {
+      userKeyEntitlement = await getEntitlements(sessionUserId);
+      recordUsageEntitlement(userKeyEntitlement);
+      // Fail-OPEN on an unresolved entitlement (null ⇒ transient Convex/cache
+      // failure, indistinguishable from "no row"): mirrors the #3199 block below
+      // and avoids 403-ing an ACTIVE subscriber fleet-wide during a backend
+      // blip. Reject only on an AFFIRMATIVELY inactive/expired entitlement — the
+      // systematic churn case (#4611), always resolvable under normal operation
+      // (the warm 15-min entitlement cache closes the leak; an outage degrades
+      // to prior behavior rather than denying paying customers).
+      if (
+        userKeyEntitlement &&
+        (!userKeyEntitlement.features.apiAccess || userKeyEntitlement.validUntil < Date.now())
+      ) {
         emitRequest(403, 'tier_403', null);
-        return createGatewayAuthErrorResponse(403, 'API access subscription required', corsHeaders);
+        return createGatewayAuthErrorResponse(
+          403,
+          'API access requires an active subscription',
+          corsHeaders,
+        );
       }
     }
 
@@ -1087,7 +1124,14 @@ export function createDomainGateway(
           // on userId so a customer can't multiply their allowance.)
           identity = wmKey ? hashKeySync(wmKey) : '';
         } else if (sessionUserId) {
-          const ent = await getEntitlements(sessionUserId);
+          // Reuse the entitlement the #4611 gate above already resolved for this
+          // same user key (undefined ⇒ the gate didn't run, e.g. a Clerk-session
+          // caller with no wm_ key — resolve it now). Avoids a duplicate lookup
+          // on the hot active-key path.
+          const ent =
+            userKeyEntitlement !== undefined
+              ? userKeyEntitlement
+              : await getEntitlements(sessionUserId);
           if (ent) {
             // #4572 — attribute the usage event to the caller's real tier +
             // plan (recorded even for downgraded keys), so the limit-abuse


### PR DESCRIPTION
Closes #4611.

## Problem
Cancelled/downgraded API-Starter customers kept full programmatic access via their un-revoked `wm_` key. `validateUserApiKey` checks key existence only (never the owner's subscription), and the `apiAccess` gate was scoped to `PREMIUM_RPC_PATHS` — so the entire *keyed* RPC surface was served to lapsed keys.

## Fix
A route-wide active-subscription gate in `server/gateway.ts`, scoped to `isUserApiKey` (the `wm_` key is the authenticating credential ⇒ `sessionUserId` is the resolved owner):

- Resolve the owner's entitlement once and **403 before** the #3199 per-account rate-limit block when the entitlement is **affirmatively** inactive/expired (`!apiAccess || validUntil < now`).
- The resolved entitlement is **reused** by the rate-limit block (no duplicate lookup).
- **Fail-open** on an unresolved entitlement (transient Convex/cache `null`) so a backend blip never 403s active subscribers fleet-wide.
- **Public-no-auth routes are intentionally not re-validated**: they serve free data to everyone, so a lapsed key there leaks no product; re-validating arbitrary keys on that anonymous surface would add an **unauthenticated Convex-lookup amplification vector** (a rotating fake `wm_` key per request defeats the negative cache, ahead of any rate limit).

## Data (verified against prod, 30d)
- **Real leak: 3 downgraded accounts** (`plan: free`, `apiAccess: false`, keys never revoked) served ~4,086 requests — **~96% on keyed/paid routes** (`get-fear-greed-index`, `get-resilience-ranking` [premium], `list-market-quotes`, `get-cot-positioning`, `get-macro-signals`, `get-vessel-snapshot`, …). **All now 403'd.** The only public route hit was `list-acled-events` (166 reqs, free data).
- The larger `plan_key=None` served volume (~65k) is **active paying `api_starter` customers** with a telemetry-attribution gap — the fix correctly keeps serving them.

## Acceptance criteria (#4611)
- [x] Inactive `wm_` key → 403 on all **keyed** routes (regular + premium + tier-gated). *Deliberate scope decision: public-no-auth routes serve as anonymous — free data, and to avoid the amplification vector above (see thread).*
- [x] Active `apiAccess` owner unaffected (fail-open on transient null protects them further).
- [x] Re-subscribing restores the same key (no revocation).
- [x] Enforced **before** the per-account rate-limit eligibility check.

## Tests
- New `server/__tests__/gateway-user-key-apiaccess.test.ts` — downgraded/expired/null(fail-open)/active/re-subscribe/enterprise-exempt/public-not-revalidated.
- Updated `gateway-api-rate-limit.test.ts` (the case that codified the bug now asserts 403).
- Full vitest 501 pass · tsx gateway/auth 92 pass · `tsc` (default + api) clean.

## Reviewed
Multi-persona review (correctness/security/adversarial) + independent cross-model (Codex) pass. Findings resolved: fail-closed→active-customer-403 (fixed via fail-open), public-route amplification (fixed via isUserApiKey scoping), redundant `getEntitlements` (fixed via reuse), leads/verified-path over-gating (mooted by scoping).

## Noted (not in this PR)
Active `api_starter` customers emit `plan_key=None` on keyed routes (~60k of ~65k such reqs/30d) — a telemetry-attribution gap that leaves #4572 incomplete. Tracked in **#4613**.

https://claude.ai/code/session_01YG8rgjvzmeYwHsjCtniCnU
