### PR TITLE
test(telemetry): guard plan_key attribution on served user-key requests (#4613)

### DIFF
--- a/tests/usage-telemetry-emission.test.mts
+++ b/tests/usage-telemetry-emission.test.mts
@@ -419,6 +419,70 @@ describe('gateway telemetry payload — bearer identity propagation', () => {
     assert.equal(ev.reason, 'tier_403');
   });
 
+  it('records plan_key on a SERVED (200) user API-key request on a non-tier-gated route (#4613)', async () => {
+    // #4613: the served keyed path attributes plan_key via the #3199 per-account
+    // rate-limit block's recordUsageEntitlement — a DIFFERENT call site than the
+    // tier-gate rejection path (asserted above) or the clerk_jwt success path.
+    // Without this guard, a regression there emits plan_key=null on the paid API
+    // surface, silently breaking the per-plan usage / limit-abuse audit (#4572).
+    process.env.USAGE_TELEMETRY = '1';
+    process.env.AXIOM_API_TOKEN = 'test-token';
+    process.env.CONVEX_SITE_URL = 'https://convex.test';
+    process.env.CONVEX_SERVER_SHARED_SECRET = 'test-shared-secret';
+
+    const starterEntitlements = {
+      planKey: 'api_starter',
+      features: {
+        tier: 2,
+        apiAccess: true,
+        apiRateLimit: 1000,
+        maxDashboards: 25,
+        prioritySupport: false,
+        exportFormats: ['csv'],
+        mcpAccess: true,
+      },
+      validUntil: Date.now() + 60_000,
+    };
+    const spy = installAxiomFetchSpy(ORIGINAL_FETCH, {
+      apiKeyValidationResponse: { userId: 'user_active_api_key', keyId: 'key_active', name: 'Active key' },
+      entitlementsResponse: starterEntitlements,
+    });
+
+    // list-cyber-threats: a plain keyed RPC — not tier-gated, not premium, not
+    // public-no-auth — so the served path runs through the per-account block
+    // where user-key plan_key attribution happens.
+    const handler = createDomainGateway([
+      {
+        method: 'GET',
+        path: '/api/cyber/v1/list-cyber-threats',
+        handler: async () => new Response('{"ok":true}', { status: 200 }),
+      },
+    ]);
+
+    const recorder = makeRecordingCtx();
+    const res = await handler(
+      new Request('https://worldmonitor.app/api/cyber/v1/list-cyber-threats', {
+        headers: {
+          Origin: 'https://worldmonitor.app',
+          'X-Api-Key': 'wm_test_active_key',
+        },
+      }),
+      recorder.ctx,
+    );
+    assert.equal(res.status, 200, 'active user API key should be served on a non-tier-gated route');
+
+    await recorder.settled;
+    spy.restore();
+
+    assert.equal(spy.events.length, 1);
+    const ev = spy.events[0]!;
+    assert.equal(ev.auth_kind, 'user_api_key');
+    assert.equal(ev.customer_id, 'user_active_api_key');
+    assert.equal(ev.tier, 2);
+    assert.equal(ev.plan_key, 'api_starter', 'served user-key request must attribute plan_key (#4613)');
+    assert.equal(ev.reason, 'ok');
+  });
+
   it('still emits with auth_kind=anon when the bearer is invalid', async () => {
     process.env.USAGE_TELEMETRY = '1';
     process.env.AXIOM_API_TOKEN = 'test-token';


### PR DESCRIPTION
Closes #4613.

## TL;DR
The #4613 **runtime bug was already fixed** — `#4572`'s plan_key attribution deployed to prod at **~2026-07-01 09:00 UTC**. This PR adds the **regression guard that was missing**, so it can't silently break again.

## Why the issue looked bigger than it was
#4613 was filed off a 30-day Axiom window showing ~65k `user_api_key` served events with `plan_key=None`. On closer inspection that window was **~97% pre-deployment**: `plan_key` was null for 100% of June, then flips to 100% populated at the 09:00 UTC July-1 deploy. **Last 6h: 374 served user-key events, all `plan_key='api_starter'`, zero nulls.** So there is no live attribution gap to fix.

## The real gap: test coverage
`recordUsageEntitlement` populates `plan_key` from three call sites. Existing tests cover two:
- `buildUsageIdentity` unit tests (#4572).
- user-key **rejected** by the tier gate (403) → asserts `plan_key`.
- clerk_jwt **served** (200) on a tier-gated route → asserts `tier`.

Nothing asserted a user-key request **served (200) on a non-tier-gated route** — the path that attributes via the `#3199` per-account rate-limit block. That's the exact codepath #4613 was about; a regression there emits `plan_key=null` on the paid API surface and no test would catch it.

## Change
Adds one test (`tests/usage-telemetry-emission.test.mts`): an active `api_starter` wm_ key served on `list-cyber-threats` (a plain keyed RPC — the #1 route in the audit) must emit `auth_kind=user_api_key`, `tier=2`, `plan_key='api_starter'`, `reason='ok'`.

Test-only, no runtime change. `tsx --test` for that file: 11 pass.

https://claude.ai/code/session_01YG8rgjvzmeYwHsjCtniCnU
