### PR TITLE
perf(INP/map): chunk the country deep-dive open sequence

### DIFF
--- a/src/app/country-intel.ts
+++ b/src/app/country-intel.ts
@@ -12,6 +12,7 @@ import type {
   CountryDeepDiveSignalDetails,
 } from '@/components/CountryBriefPanel';
 import { reverseGeocode } from '@/utils/reverse-geocode';
+import { yieldToMain } from '@/utils/after-paint';
 import { effectivePubDateMs } from '@/services/feed-date';
 import {
   getCountryAtCoordinates,
@@ -298,6 +299,13 @@ export class CountryIntelManager implements AppModule {
 
       page.show(country, code, score, signals);
       pageShown = true;
+      // Yield so the deep-dive panel paint lands before the map catch-up
+      // (highlightCountry deck rebuild + fitCountry fitBounds animation) — country
+      // click is the field #1 INP offender, presentation-delay-dominated (#4617).
+      // Re-check the staleness guard after the new async gap so a newer country
+      // open can't be painted over by this one.
+      await yieldToMain();
+      if (token !== this.briefRequestToken || this.ctx.isDestroyed || this.ctx.countryBriefPage !== page) return;
       this.ctx.map?.highlightCountry(code);
       this.ctx.map?.fitCountry(code);
 

--- a/tests/country-deep-dive-yield.test.mts
+++ b/tests/country-deep-dive-yield.test.mts
@@ -1,0 +1,44 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// No jsdom in the suite, so lock the country deep-dive yield (#4617) structurally:
+// openCountryBriefByCode must yield to the main thread AFTER the panel paint
+// (page.show) and BEFORE the map catch-up (highlightCountry / fitCountry), so the
+// deep-dive panel paint isn't blocked by the deck rebuild + fitBounds animation —
+// country click is the field #1 INP offender, presentation-delay-dominated. The
+// staleness guard (briefRequestToken) is re-checked after the new async gap so a
+// newer country open can't be painted over by this one.
+const src = readFileSync(
+  resolve(dirname(fileURLToPath(import.meta.url)), '../src/app/country-intel.ts'),
+  'utf8',
+);
+
+test('country-intel imports the shared yield primitive (#4617)', () => {
+  assert.match(src, /import \{[^}]*yieldToMain[^}]*\} from '@\/utils\/after-paint'/);
+});
+
+test('openCountryBriefByCode yields after the panel paint, before the map catch-up (#4617)', () => {
+  const showIdx = src.indexOf('page.show(country, code, score, signals)');
+  const yieldIdx = src.indexOf('await yieldToMain()', showIdx);
+  const highlightIdx = src.indexOf('highlightCountry(code)', showIdx);
+  const fitIdx = src.indexOf('fitCountry(code)', showIdx);
+  assert.ok(showIdx >= 0, 'page.show present');
+  assert.ok(yieldIdx > showIdx, 'yieldToMain runs after the panel paint');
+  assert.ok(highlightIdx > yieldIdx, 'map highlightCountry runs after the yield');
+  assert.ok(fitIdx > yieldIdx, 'map fitCountry runs after the yield');
+});
+
+test('openCountryBriefByCode re-checks the staleness guard after the new yield (#4617)', () => {
+  const showIdx = src.indexOf('page.show(country, code, score, signals)');
+  const yieldIdx = src.indexOf('await yieldToMain()', showIdx);
+  const highlightIdx = src.indexOf('highlightCountry(code)', yieldIdx);
+  const between = src.slice(yieldIdx, highlightIdx);
+  assert.match(
+    between,
+    /token !== this\.briefRequestToken/,
+    'briefRequestToken guard re-checked after the async yield, before the map catch-up',
+  );
+});


### PR DESCRIPTION
## Summary

Clicking a country on the map is the single worst interaction on `/dashboard` for real users — its INP is the field #1 offender at **728 ms p75** (CrUX `loadState=complete`, 2026-06-30, n=27), and the delay is presentation-bound: the deep-dive panel visually lags the click. The handler built and injected the full panel DOM, then rebuilt deck.gl layers and started a maplibre `fitBounds` camera animation all in one task, so the browser couldn't paint the panel until the map catch-up finished.

Now the panel paints first: the handler yields to the main thread right after the panel DOM is injected, then does the deck-layer rebuild + camera fit in a follow-up task. The interaction's *next paint* — the panel appearing — lands a frame sooner, which is exactly what INP measures.

## Field baseline

| Interaction | Metric | Before | Target |
|---|---|---|---|
| Country click (`#mapSvg path.country`) | INP p75 | 728 ms (field #1, presentation-dominated) | < 200 ms |

Post-fix movement is validated against field data, not a lab number (see below).

## Why now

`#4556` shipped INP instrumentation + the verified-safe handler chunks and **deferred** country deep-dive sequencing as measure-first, gated on U1 field data. That data is now in and names country click #1, so the gate is satisfied. The sibling deferred lever (panel-render chunking) stays deferred — field put `#panelTabsMount` at only 288 ms p75, so there is no real offender to chase there.

## Mechanism

The added `yieldToMain()` sits between the panel paint and the map catch-up, and re-checks the handler's existing `briefRequestToken` staleness guard after the new async gap — byte-identical to the guard already used earlier in the method. The token is bumped by every new open *and* by `onClose`, so a superseded open (newer country click, or the user closing the panel during the yield) returns before re-highlighting — no stale render, no orphaned map pause. As a side effect this removes a pre-existing possibility of the old country's highlight flashing under the new panel.

A structural test locks the ordering and the guard re-check (the suite has no jsdom, so it asserts on source text — the same approach as the `#4556` sanitize-yield tests).

## Testing

- 3/3 new structural tests pass (`tests/country-deep-dive-yield.test.mts`).
- `tsc --noEmit` — 0 errors (whole project). `biome lint` — clean.
- Independent adversarial correctness review confirmed all four race axes (stale-open, close-during-yield, map-pause leak, maximize/downstream paths) are closed. Verdict: ship it.
- Full `test:data` suite runs in CI (the worktree lacks local `node_modules`).

Fixes #4617. Related: #4537, #4487.

## Post-Deploy Monitoring & Validation

- **Watch:** field INP for `#mapSvg path.country` on `/dashboard` (baseline 728 ms p75). Sources: Sentry `webvital:inp` events (issue 7584575810 — `context` carries `interactionTarget` + input/processing/presentation sub-parts) and the CrUX `loadState=complete` re-pull (trigger `trig_01F7g1hAMwePWBHWKAzjDDfG`, ~07-03) plus the subsequent CrUX window.
- **Healthy signal:** country-click p75 trends toward < 200 ms; the presentation-delay share drops as the panel paint lands ahead of the map catch-up.
- **Failure signals:** INP flat or worse across a CrUX window; new Sentry errors in `openCountryBriefByCode` / country-intel (stale render, map stuck paused); reports of the wrong-country brief or a missing map fit/highlight on rapid clicks.
- **Rollback:** revert commit `0d21c9c42` — a self-contained 8-line change.
- **Window / owner:** the 07-03 re-pull + the post-deploy CrUX window; perf owner.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
