### PR TITLE
fix(api): surface bbox diagnostics

### DIFF
--- a/api/_cors.js
+++ b/api/_cors.js
@@ -34,6 +34,10 @@ const EXPOSED_HEADERS = [
   'Mcp-Session-Id',
   'WWW-Authenticate',
   'Retry-After',
+  'X-WorldMonitor-Bbox',
+  'X-WorldMonitor-Bbox-Missing',
+  'X-WorldMonitor-Bbox-Invalid',
+  'X-Military-Bbox',
 ].join(', ');
 
 function isAllowedOrigin(origin) {

--- a/api/_cors.test.mjs
+++ b/api/_cors.test.mjs
@@ -55,5 +55,9 @@ test('CORS allow headers include MCP transport headers', () => {
     assert.match(exposed, /\bMcp-Session-Id\b/);
     assert.match(exposed, /\bWWW-Authenticate\b/);
     assert.match(exposed, /\bRetry-After\b/);
+    assert.match(exposed, /\bX-WorldMonitor-Bbox\b/);
+    assert.match(exposed, /\bX-WorldMonitor-Bbox-Missing\b/);
+    assert.match(exposed, /\bX-WorldMonitor-Bbox-Invalid\b/);
+    assert.match(exposed, /\bX-Military-Bbox\b/);
   }
 });

--- a/server/cors.ts
+++ b/server/cors.ts
@@ -46,6 +46,10 @@ const EXPOSED_HEADERS = [
   'Mcp-Session-Id',
   'WWW-Authenticate',
   'Retry-After',
+  'X-WorldMonitor-Bbox',
+  'X-WorldMonitor-Bbox-Missing',
+  'X-WorldMonitor-Bbox-Invalid',
+  'X-Military-Bbox',
 ].join(', ');
 
 export function isAllowedOrigin(origin: string): boolean {

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -388,16 +388,15 @@ const POST_TO_GET_MAX_ARRAY_VALUES_PER_KEY = 200;
 
 export const REQUIRED_BBOX_QUERY_PARAMS = ['sw_lat', 'sw_lon', 'ne_lat', 'ne_lon'] as const;
 
+// Issue #4595 is scoped to military RPCs whose handlers require bbox.
+// Other bbox-capable RPCs support lookup/global modes and must not emit this diagnostic.
 export const REQUIRED_BBOX_RPC_PATHS = [
-  '/api/aviation/v1/track-aircraft',
-  '/api/maritime/v1/get-vessel-snapshot',
   '/api/military/v1/list-military-bases',
   '/api/military/v1/list-military-flights',
-  '/api/unrest/v1/list-unrest-events',
-  '/api/wildfire/v1/list-fire-detections',
 ] as const;
 
 const REQUIRED_BBOX_RPC_PATH_SET = new Set<string>(REQUIRED_BBOX_RPC_PATHS);
+const MILITARY_BBOX_DIAGNOSTIC_PATH_SET = new Set<string>(REQUIRED_BBOX_RPC_PATHS);
 
 function isPostToGetCompatibleBodySize(headers: Headers): boolean {
   const rawContentLength = headers.get('Content-Length');
@@ -462,7 +461,7 @@ function attachRequiredBboxDiagnosticHeaders(
   headers.set('X-WorldMonitor-Bbox', diagnostic.status);
   if (diagnostic.missing.length > 0) headers.set('X-WorldMonitor-Bbox-Missing', diagnostic.missing.join(','));
   if (diagnostic.invalid.length > 0) headers.set('X-WorldMonitor-Bbox-Invalid', diagnostic.invalid.join(','));
-  if (pathname.startsWith('/api/military/')) {
+  if (MILITARY_BBOX_DIAGNOSTIC_PATH_SET.has(pathname)) {
     headers.set('X-Military-Bbox', diagnostic.status);
   }
 }

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -386,12 +386,85 @@ export type GatewayCtx = { waitUntil: (p: Promise<unknown>) => void };
 const POST_TO_GET_MAX_BODY_BYTES = 1_048_576;
 const POST_TO_GET_MAX_ARRAY_VALUES_PER_KEY = 200;
 
+export const REQUIRED_BBOX_QUERY_PARAMS = ['sw_lat', 'sw_lon', 'ne_lat', 'ne_lon'] as const;
+
+export const REQUIRED_BBOX_RPC_PATHS = [
+  '/api/aviation/v1/track-aircraft',
+  '/api/maritime/v1/get-vessel-snapshot',
+  '/api/military/v1/list-military-bases',
+  '/api/military/v1/list-military-flights',
+  '/api/unrest/v1/list-unrest-events',
+  '/api/wildfire/v1/list-fire-detections',
+] as const;
+
+const REQUIRED_BBOX_RPC_PATH_SET = new Set<string>(REQUIRED_BBOX_RPC_PATHS);
+
 function isPostToGetCompatibleBodySize(headers: Headers): boolean {
   const rawContentLength = headers.get('Content-Length');
   if (rawContentLength === null || !/^\d+$/.test(rawContentLength)) return false;
 
   const contentLength = Number(rawContentLength);
   return Number.isSafeInteger(contentLength) && contentLength < POST_TO_GET_MAX_BODY_BYTES;
+}
+
+function getRequiredBboxQueryProblems(searchParams: URLSearchParams): { missing: string[]; invalid: string[]; allZero: boolean } {
+  const missing: string[] = [];
+  const invalid: string[] = [];
+  const values: number[] = [];
+
+  for (const param of REQUIRED_BBOX_QUERY_PARAMS) {
+    const raw = searchParams.get(param);
+    if (raw == null || raw.trim() === '') {
+      missing.push(param);
+      continue;
+    }
+    const value = Number(raw);
+    if (!Number.isFinite(value)) {
+      invalid.push(param);
+      continue;
+    }
+    values.push(value);
+  }
+
+  return {
+    missing,
+    invalid,
+    allZero: missing.length === 0 && invalid.length === 0 && values.every((value) => value === 0),
+  };
+}
+
+type RequiredBboxDiagnostic = {
+  status: 'missing' | 'invalid';
+  missing: string[];
+  invalid: string[];
+};
+
+function getRequiredBboxDiagnostic(request: Request, pathname: string): RequiredBboxDiagnostic | null {
+  if (!REQUIRED_BBOX_RPC_PATH_SET.has(pathname)) return null;
+
+  const { searchParams } = new URL(request.url);
+  const { missing, invalid, allZero } = getRequiredBboxQueryProblems(searchParams);
+  if (missing.length === 0 && invalid.length === 0 && !allZero) return null;
+
+  return {
+    status: missing.length > 0 ? 'missing' : 'invalid',
+    missing,
+    invalid: allZero ? [...REQUIRED_BBOX_QUERY_PARAMS] : invalid,
+  };
+}
+
+function attachRequiredBboxDiagnosticHeaders(
+  headers: Headers,
+  pathname: string,
+  diagnostic: RequiredBboxDiagnostic | null,
+): void {
+  if (!diagnostic) return;
+  headers.set('X-WorldMonitor-Bbox', diagnostic.status);
+  if (diagnostic.missing.length > 0) headers.set('X-WorldMonitor-Bbox-Missing', diagnostic.missing.join(','));
+  if (diagnostic.invalid.length > 0) headers.set('X-WorldMonitor-Bbox-Invalid', diagnostic.invalid.join(','));
+  if (pathname.startsWith('/api/military/')) {
+    headers.set('X-Military-Bbox', diagnostic.status);
+  }
 }
 
 // `TRUSTED_USER_ID_HEADER` (a.k.a. `x-user-id`) is gateway-internal: the
@@ -1282,6 +1355,8 @@ export function createDomainGateway(
       });
     }
 
+    const requiredBboxDiagnostic = getRequiredBboxDiagnostic(request, pathname);
+
     // Execute handler with top-level error boundary.
     // Wrap in runWithUsageScope so deep fetch helpers (fetchJson,
     // cachedFetchJsonWithMeta) can attribute upstream calls to this customer
@@ -1320,6 +1395,7 @@ export function createDomainGateway(
         mergedHeaders.set(key, value);
       }
     }
+    attachRequiredBboxDiagnosticHeaders(mergedHeaders, pathname, requiredBboxDiagnostic);
 
     // For GET 200 responses: read body once for cache-header decisions + ETag
     let resolvedCacheTier: CacheTier | null = null;

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -407,14 +407,18 @@ function isPostToGetCompatibleBodySize(headers: Headers): boolean {
 }
 
 function getRequiredBboxQueryProblems(searchParams: URLSearchParams): { missing: string[]; invalid: string[]; allZero: boolean } {
-  const missing: string[] = [];
+  const absent: string[] = [];
   const invalid: string[] = [];
   const values: number[] = [];
 
   for (const param of REQUIRED_BBOX_QUERY_PARAMS) {
     const raw = searchParams.get(param);
-    if (raw == null || raw.trim() === '') {
-      missing.push(param);
+    if (raw == null) {
+      absent.push(param);
+      continue;
+    }
+    if (raw.trim() === '') {
+      invalid.push(param);
       continue;
     }
     const value = Number(raw);
@@ -425,10 +429,11 @@ function getRequiredBboxQueryProblems(searchParams: URLSearchParams): { missing:
     values.push(value);
   }
 
+  const missing = absent.length === REQUIRED_BBOX_QUERY_PARAMS.length ? [...REQUIRED_BBOX_QUERY_PARAMS] : [];
   return {
     missing,
     invalid,
-    allZero: missing.length === 0 && invalid.length === 0 && values.every((value) => value === 0),
+    allZero: absent.length === 0 && invalid.length === 0 && values.every((value) => value === 0),
   };
 }
 
@@ -462,6 +467,7 @@ function attachRequiredBboxDiagnosticHeaders(
   if (diagnostic.missing.length > 0) headers.set('X-WorldMonitor-Bbox-Missing', diagnostic.missing.join(','));
   if (diagnostic.invalid.length > 0) headers.set('X-WorldMonitor-Bbox-Invalid', diagnostic.invalid.join(','));
   if (MILITARY_BBOX_DIAGNOSTIC_PATH_SET.has(pathname)) {
+    // Issue #4595 explicitly requested the military alias; keep it as a stable consumer affordance.
     headers.set('X-Military-Bbox', diagnostic.status);
   }
 }

--- a/tests/gateway-required-bbox.test.mts
+++ b/tests/gateway-required-bbox.test.mts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { afterEach, describe, it } from 'node:test';
 
+import { MilitaryServiceClient } from '../src/generated/client/worldmonitor/military/v1/service_client.ts';
 import {
   createDomainGateway,
   REQUIRED_BBOX_QUERY_PARAMS,
@@ -78,6 +79,23 @@ function makeJsonPostRequest(path: string, bodyObject: Record<string, unknown>):
     },
     body,
   });
+}
+
+async function getGeneratedMilitaryFlightsPathAndQuery(req: Parameters<MilitaryServiceClient['listMilitaryFlights']>[0]): Promise<string> {
+  let requestedUrl = '';
+  const client = new MilitaryServiceClient('https://worldmonitor.app', {
+    fetch: async (input) => {
+      requestedUrl = String(input);
+      return new Response(JSON.stringify({ flights: [], clusters: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    },
+  });
+
+  await client.listMilitaryFlights(req);
+  const url = new URL(requestedUrl);
+  return url.pathname + url.search;
 }
 
 function assertNoBboxDiagnostic(res: Response): void {
@@ -194,21 +212,39 @@ describe('gateway required-bbox diagnostics', () => {
     assertBboxDiagnostic(res, 'invalid', { invalid: 'ne_lat', military: true });
   });
 
-  it('reports both missing and invalid fields for partial malformed bboxes', async () => {
+  it('reports invalid present fields without treating omitted zero corners as missing', async () => {
     const hits = new Map<string, number>();
     const handler = createBboxGateway(hits);
 
     const res = await handler(makeRequest(
-      '/api/military/v1/list-military-flights?sw_lat=0&ne_lat=abc',
+      '/api/military/v1/list-military-flights?ne_lat=abc&ne_lon=1',
     ));
 
     assert.equal(res.status, 200);
     assert.equal(hits.get('/api/military/v1/list-military-flights'), 1);
-    assertBboxDiagnostic(res, 'missing', {
-      missing: 'sw_lon,ne_lon',
-      invalid: 'ne_lat',
-      military: true,
+    assertBboxDiagnostic(res, 'invalid', { invalid: 'ne_lat', military: true });
+  });
+
+  it('does not flag the generated client shape for a zero-corner bbox', async () => {
+    const hits = new Map<string, number>();
+    const handler = createBboxGateway(hits);
+    const pathAndQuery = await getGeneratedMilitaryFlightsPathAndQuery({
+      pageSize: 100,
+      cursor: '',
+      neLat: 1,
+      neLon: 1,
+      swLat: 0,
+      swLon: 0,
+      operator: 'MILITARY_OPERATOR_UNSPECIFIED',
+      aircraftType: 'MILITARY_AIRCRAFT_TYPE_UNSPECIFIED',
     });
+
+    assert.equal(pathAndQuery, '/api/military/v1/list-military-flights?page_size=100&ne_lat=1&ne_lon=1');
+    const res = await handler(makeRequest(pathAndQuery));
+
+    assert.equal(res.status, 200);
+    assert.equal(hits.get('/api/military/v1/list-military-flights'), 1);
+    assertNoBboxDiagnostic(res);
   });
 
   it('reads the POST-to-GET converted request before deciding bbox diagnostics', async () => {

--- a/tests/gateway-required-bbox.test.mts
+++ b/tests/gateway-required-bbox.test.mts
@@ -12,17 +12,26 @@ import type { RouteDescriptor } from '../server/router.ts';
 const originalValidKeys = process.env.WORLDMONITOR_VALID_KEYS;
 const TEST_KEY = 'bbox-test-key';
 const REQUIRED_BBOX_QUERY = REQUIRED_BBOX_QUERY_PARAMS.join(',');
-const MARITIME_BBOX_PATH = '/api/maritime/v1/get-vessel-snapshot';
-const originalMaritimeRatePolicy = ENDPOINT_RATE_POLICIES[MARITIME_BBOX_PATH];
+const MARITIME_OPTIONAL_BBOX_PATH = '/api/maritime/v1/get-vessel-snapshot';
+const originalMaritimeRatePolicy = ENDPOINT_RATE_POLICIES[MARITIME_OPTIONAL_BBOX_PATH];
+
+const OPTIONAL_BBOX_RPC_PATHS = [
+  '/api/aviation/v1/track-aircraft',
+  '/api/maritime/v1/get-vessel-snapshot',
+  '/api/unrest/v1/list-unrest-events',
+  '/api/wildfire/v1/list-fire-detections',
+] as const;
 
 afterEach(() => {
   if (originalValidKeys == null) delete process.env.WORLDMONITOR_VALID_KEYS;
   else process.env.WORLDMONITOR_VALID_KEYS = originalValidKeys;
-  ENDPOINT_RATE_POLICIES[MARITIME_BBOX_PATH] = originalMaritimeRatePolicy;
+
+  if (originalMaritimeRatePolicy == null) delete ENDPOINT_RATE_POLICIES[MARITIME_OPTIONAL_BBOX_PATH];
+  else ENDPOINT_RATE_POLICIES[MARITIME_OPTIONAL_BBOX_PATH] = originalMaritimeRatePolicy;
 });
 
-function createBboxGateway(hits: Map<string, number>) {
-  const routes: RouteDescriptor[] = REQUIRED_BBOX_RPC_PATHS.map((path) => ({
+function createGatewayForPaths(hits: Map<string, number>, paths: readonly string[]) {
+  const routes: RouteDescriptor[] = paths.map((path) => ({
     method: 'GET',
     path,
     handler: async () => {
@@ -36,11 +45,15 @@ function createBboxGateway(hits: Map<string, number>) {
   return createDomainGateway(routes);
 }
 
+function createBboxGateway(hits: Map<string, number>) {
+  return createGatewayForPaths(hits, REQUIRED_BBOX_RPC_PATHS);
+}
+
 // The live tanker endpoint fails closed when Upstash is absent; remove only
 // this unit-test policy so the gateway header merge path is observable locally.
 function bypassMaritimeRateLimitForLocalGatewayTest(pathAndQuery: string): void {
-  if (!pathAndQuery.startsWith(MARITIME_BBOX_PATH)) return;
-  delete ENDPOINT_RATE_POLICIES[MARITIME_BBOX_PATH];
+  if (!pathAndQuery.startsWith(MARITIME_OPTIONAL_BBOX_PATH)) return;
+  delete ENDPOINT_RATE_POLICIES[MARITIME_OPTIONAL_BBOX_PATH];
 }
 
 function makeRequest(pathAndQuery: string): Request {
@@ -50,6 +63,28 @@ function makeRequest(pathAndQuery: string): Request {
     'https://worldmonitor.app' + pathAndQuery,
     { headers: { Origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': TEST_KEY } },
   );
+}
+
+function makeJsonPostRequest(path: string, bodyObject: Record<string, unknown>): Request {
+  process.env.WORLDMONITOR_VALID_KEYS = TEST_KEY;
+  const body = JSON.stringify(bodyObject);
+  return new Request('https://worldmonitor.app' + path, {
+    method: 'POST',
+    headers: {
+      Origin: 'https://worldmonitor.app',
+      'X-WorldMonitor-Key': TEST_KEY,
+      'Content-Type': 'application/json',
+      'Content-Length': String(new TextEncoder().encode(body).byteLength),
+    },
+    body,
+  });
+}
+
+function assertNoBboxDiagnostic(res: Response): void {
+  assert.equal(res.headers.get('X-WorldMonitor-Bbox'), null);
+  assert.equal(res.headers.get('X-WorldMonitor-Bbox-Missing'), null);
+  assert.equal(res.headers.get('X-WorldMonitor-Bbox-Invalid'), null);
+  assert.equal(res.headers.get('X-Military-Bbox'), null);
 }
 
 function assertBboxDiagnostic(
@@ -70,14 +105,10 @@ function assertBboxDiagnostic(
 }
 
 describe('gateway required-bbox diagnostics', () => {
-  it('tracks exactly the six issue-scoped bbox endpoints', () => {
+  it('tracks exactly the bbox-required military endpoints', () => {
     assert.deepEqual([...REQUIRED_BBOX_RPC_PATHS].sort(), [
-      '/api/aviation/v1/track-aircraft',
-      '/api/maritime/v1/get-vessel-snapshot',
       '/api/military/v1/list-military-bases',
       '/api/military/v1/list-military-flights',
-      '/api/unrest/v1/list-unrest-events',
-      '/api/wildfire/v1/list-fire-detections',
     ].sort());
   });
 
@@ -92,12 +123,37 @@ describe('gateway required-bbox diagnostics', () => {
       assert.equal(res.status, 200);
       assert.deepEqual(body, { ok: true });
       assert.equal(hits.get(path), 1, 'diagnostic mode must remain non-breaking and still call the handler');
-      assertBboxDiagnostic(res, 'missing', {
-        missing: REQUIRED_BBOX_QUERY,
-        military: path.startsWith('/api/military/'),
-      });
+      assertBboxDiagnostic(res, 'missing', { missing: REQUIRED_BBOX_QUERY, military: true });
     });
   }
+
+  it('does not diagnose optional-bbox endpoints that support no-bbox/global modes', async () => {
+    const hits = new Map<string, number>();
+    const handler = createGatewayForPaths(hits, OPTIONAL_BBOX_RPC_PATHS);
+
+    for (const path of OPTIONAL_BBOX_RPC_PATHS) {
+      const res = await handler(makeRequest(path));
+      const body = await res.json();
+
+      assert.equal(res.status, 200, path);
+      assert.deepEqual(body, { ok: true }, path);
+      assert.equal(hits.get(path), 1, path);
+      assertNoBboxDiagnostic(res);
+    }
+  });
+
+  it('does not add bbox diagnostics to unrelated API endpoints', async () => {
+    const hits = new Map<string, number>();
+    const handler = createGatewayForPaths(hits, ['/api/market/v1/list-market-quotes']);
+
+    const res = await handler(makeRequest('/api/market/v1/list-market-quotes?symbols=AAPL'));
+    const body = await res.json();
+
+    assert.equal(res.status, 200);
+    assert.deepEqual(body, { ok: true });
+    assert.equal(hits.get('/api/market/v1/list-market-quotes'), 1);
+    assertNoBboxDiagnostic(res);
+  });
 
   it('treats wrong bbox parameter names as missing snake_case params', async () => {
     const hits = new Map<string, number>();
@@ -130,12 +186,48 @@ describe('gateway required-bbox diagnostics', () => {
     const handler = createBboxGateway(hits);
 
     const res = await handler(makeRequest(
-      '/api/aviation/v1/track-aircraft?sw_lat=0&sw_lon=-1&ne_lat=abc&ne_lon=1',
+      '/api/military/v1/list-military-flights?sw_lat=0&sw_lon=-1&ne_lat=abc&ne_lon=1',
     ));
 
     assert.equal(res.status, 200);
-    assert.equal(hits.get('/api/aviation/v1/track-aircraft'), 1);
-    assertBboxDiagnostic(res, 'invalid', { invalid: 'ne_lat' });
+    assert.equal(hits.get('/api/military/v1/list-military-flights'), 1);
+    assertBboxDiagnostic(res, 'invalid', { invalid: 'ne_lat', military: true });
+  });
+
+  it('reports both missing and invalid fields for partial malformed bboxes', async () => {
+    const hits = new Map<string, number>();
+    const handler = createBboxGateway(hits);
+
+    const res = await handler(makeRequest(
+      '/api/military/v1/list-military-flights?sw_lat=0&ne_lat=abc',
+    ));
+
+    assert.equal(res.status, 200);
+    assert.equal(hits.get('/api/military/v1/list-military-flights'), 1);
+    assertBboxDiagnostic(res, 'missing', {
+      missing: 'sw_lon,ne_lon',
+      invalid: 'ne_lat',
+      military: true,
+    });
+  });
+
+  it('reads the POST-to-GET converted request before deciding bbox diagnostics', async () => {
+    const hits = new Map<string, number>();
+    const handler = createBboxGateway(hits);
+
+    const res = await handler(makeJsonPostRequest('/api/military/v1/list-military-flights', {
+      sw_lat: 0,
+      sw_lon: 0,
+      ne_lat: 1,
+      ne_lon: 1,
+      page_size: 100,
+    }));
+    const body = await res.json();
+
+    assert.equal(res.status, 200);
+    assert.deepEqual(body, { ok: true });
+    assert.equal(hits.get('/api/military/v1/list-military-flights'), 1);
+    assertNoBboxDiagnostic(res);
   });
 
   it('does not flag a legitimate bbox that touches the equator or prime meridian', async () => {
@@ -148,9 +240,6 @@ describe('gateway required-bbox diagnostics', () => {
 
     assert.equal(res.status, 200);
     assert.equal(hits.get('/api/military/v1/list-military-flights'), 1);
-    assert.equal(res.headers.get('X-WorldMonitor-Bbox'), null);
-    assert.equal(res.headers.get('X-WorldMonitor-Bbox-Missing'), null);
-    assert.equal(res.headers.get('X-WorldMonitor-Bbox-Invalid'), null);
-    assert.equal(res.headers.get('X-Military-Bbox'), null);
+    assertNoBboxDiagnostic(res);
   });
 });

--- a/tests/gateway-required-bbox.test.mts
+++ b/tests/gateway-required-bbox.test.mts
@@ -1,0 +1,156 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+
+import {
+  createDomainGateway,
+  REQUIRED_BBOX_QUERY_PARAMS,
+  REQUIRED_BBOX_RPC_PATHS,
+} from '../server/gateway.ts';
+import { ENDPOINT_RATE_POLICIES } from '../server/_shared/rate-limit.ts';
+import type { RouteDescriptor } from '../server/router.ts';
+
+const originalValidKeys = process.env.WORLDMONITOR_VALID_KEYS;
+const TEST_KEY = 'bbox-test-key';
+const REQUIRED_BBOX_QUERY = REQUIRED_BBOX_QUERY_PARAMS.join(',');
+const MARITIME_BBOX_PATH = '/api/maritime/v1/get-vessel-snapshot';
+const originalMaritimeRatePolicy = ENDPOINT_RATE_POLICIES[MARITIME_BBOX_PATH];
+
+afterEach(() => {
+  if (originalValidKeys == null) delete process.env.WORLDMONITOR_VALID_KEYS;
+  else process.env.WORLDMONITOR_VALID_KEYS = originalValidKeys;
+  ENDPOINT_RATE_POLICIES[MARITIME_BBOX_PATH] = originalMaritimeRatePolicy;
+});
+
+function createBboxGateway(hits: Map<string, number>) {
+  const routes: RouteDescriptor[] = REQUIRED_BBOX_RPC_PATHS.map((path) => ({
+    method: 'GET',
+    path,
+    handler: async () => {
+      hits.set(path, (hits.get(path) ?? 0) + 1);
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    },
+  }));
+  return createDomainGateway(routes);
+}
+
+// The live tanker endpoint fails closed when Upstash is absent; remove only
+// this unit-test policy so the gateway header merge path is observable locally.
+function bypassMaritimeRateLimitForLocalGatewayTest(pathAndQuery: string): void {
+  if (!pathAndQuery.startsWith(MARITIME_BBOX_PATH)) return;
+  delete ENDPOINT_RATE_POLICIES[MARITIME_BBOX_PATH];
+}
+
+function makeRequest(pathAndQuery: string): Request {
+  bypassMaritimeRateLimitForLocalGatewayTest(pathAndQuery);
+  process.env.WORLDMONITOR_VALID_KEYS = TEST_KEY;
+  return new Request(
+    'https://worldmonitor.app' + pathAndQuery,
+    { headers: { Origin: 'https://worldmonitor.app', 'X-WorldMonitor-Key': TEST_KEY } },
+  );
+}
+
+function assertBboxDiagnostic(
+  res: Response,
+  status: 'missing' | 'invalid',
+  options: { missing?: string; invalid?: string; military?: boolean } = {},
+): void {
+  assert.equal(res.headers.get('X-WorldMonitor-Bbox'), status);
+  assert.equal(res.headers.get('X-WorldMonitor-Bbox-Missing'), options.missing ?? null);
+  assert.equal(res.headers.get('X-WorldMonitor-Bbox-Invalid'), options.invalid ?? null);
+  const exposedHeaders = res.headers.get('Access-Control-Expose-Headers') ?? '';
+  assert.match(exposedHeaders, /X-WorldMonitor-Bbox/);
+  assert.match(exposedHeaders, /X-WorldMonitor-Bbox-Missing/);
+  assert.match(exposedHeaders, /X-WorldMonitor-Bbox-Invalid/);
+  assert.match(exposedHeaders, /X-Military-Bbox/);
+  if (options.military) assert.equal(res.headers.get('X-Military-Bbox'), status);
+  else assert.equal(res.headers.get('X-Military-Bbox'), null);
+}
+
+describe('gateway required-bbox diagnostics', () => {
+  it('tracks exactly the six issue-scoped bbox endpoints', () => {
+    assert.deepEqual([...REQUIRED_BBOX_RPC_PATHS].sort(), [
+      '/api/aviation/v1/track-aircraft',
+      '/api/maritime/v1/get-vessel-snapshot',
+      '/api/military/v1/list-military-bases',
+      '/api/military/v1/list-military-flights',
+      '/api/unrest/v1/list-unrest-events',
+      '/api/wildfire/v1/list-fire-detections',
+    ].sort());
+  });
+
+  for (const path of REQUIRED_BBOX_RPC_PATHS) {
+    it(path + ' adds a missing-bbox diagnostic header without changing handler status', async () => {
+      const hits = new Map<string, number>();
+      const handler = createBboxGateway(hits);
+
+      const res = await handler(makeRequest(path));
+      const body = await res.json();
+
+      assert.equal(res.status, 200);
+      assert.deepEqual(body, { ok: true });
+      assert.equal(hits.get(path), 1, 'diagnostic mode must remain non-breaking and still call the handler');
+      assertBboxDiagnostic(res, 'missing', {
+        missing: REQUIRED_BBOX_QUERY,
+        military: path.startsWith('/api/military/'),
+      });
+    });
+  }
+
+  it('treats wrong bbox parameter names as missing snake_case params', async () => {
+    const hits = new Map<string, number>();
+    const handler = createBboxGateway(hits);
+
+    const res = await handler(makeRequest(
+      '/api/military/v1/list-military-flights?north=1&south=0&east=1&west=0&bbox=0,0,1,1',
+    ));
+
+    assert.equal(res.status, 200);
+    assert.equal(hits.get('/api/military/v1/list-military-flights'), 1);
+    assertBboxDiagnostic(res, 'missing', { missing: REQUIRED_BBOX_QUERY, military: true });
+  });
+
+  it('marks an explicit all-zero bbox as invalid instead of silently accepting the generated default shape', async () => {
+    const hits = new Map<string, number>();
+    const handler = createBboxGateway(hits);
+
+    const res = await handler(makeRequest(
+      '/api/military/v1/list-military-bases?sw_lat=0&sw_lon=0&ne_lat=0&ne_lon=0',
+    ));
+
+    assert.equal(res.status, 200);
+    assert.equal(hits.get('/api/military/v1/list-military-bases'), 1);
+    assertBboxDiagnostic(res, 'invalid', { invalid: REQUIRED_BBOX_QUERY, military: true });
+  });
+
+  it('marks non-numeric bbox params as invalid', async () => {
+    const hits = new Map<string, number>();
+    const handler = createBboxGateway(hits);
+
+    const res = await handler(makeRequest(
+      '/api/aviation/v1/track-aircraft?sw_lat=0&sw_lon=-1&ne_lat=abc&ne_lon=1',
+    ));
+
+    assert.equal(res.status, 200);
+    assert.equal(hits.get('/api/aviation/v1/track-aircraft'), 1);
+    assertBboxDiagnostic(res, 'invalid', { invalid: 'ne_lat' });
+  });
+
+  it('does not flag a legitimate bbox that touches the equator or prime meridian', async () => {
+    const hits = new Map<string, number>();
+    const handler = createBboxGateway(hits);
+
+    const res = await handler(makeRequest(
+      '/api/military/v1/list-military-flights?sw_lat=0&sw_lon=0&ne_lat=1&ne_lon=1&page_size=100',
+    ));
+
+    assert.equal(res.status, 200);
+    assert.equal(hits.get('/api/military/v1/list-military-flights'), 1);
+    assert.equal(res.headers.get('X-WorldMonitor-Bbox'), null);
+    assert.equal(res.headers.get('X-WorldMonitor-Bbox-Missing'), null);
+    assert.equal(res.headers.get('X-WorldMonitor-Bbox-Invalid'), null);
+    assert.equal(res.headers.get('X-Military-Bbox'), null);
+  });
+});

--- a/workers/api-cors-preflight/index.test.mjs
+++ b/workers/api-cors-preflight/index.test.mjs
@@ -31,6 +31,7 @@ function makeRequest(method, url, headers = {}) {
 const CANONICAL_FALLBACK = 'https://worldmonitor.app';
 const KNOWN_GOOD = 'https://www.worldmonitor.app';
 const ACAH_EXPECTED = 'Content-Type, Authorization, X-WorldMonitor-Key, X-Api-Key, X-Widget-Key, X-Pro-Key, X-WorldMonitor-Desktop-Timestamp, X-WorldMonitor-Desktop-Signature';
+const ACEH_EXPECTED = 'Mcp-Session-Id, WWW-Authenticate, Retry-After, X-WorldMonitor-Bbox, X-WorldMonitor-Bbox-Missing, X-WorldMonitor-Bbox-Invalid, X-Military-Bbox';
 // Must be a superset of every method any api/* route advertises. Notably
 // includes DELETE for api/product-catalog.js — pinning this prevents the
 // regression that PR review caught (Worker omitted DELETE → product-catalog
@@ -100,6 +101,11 @@ test('buildCorsHeaders Access-Control-Allow-Headers matches api/_cors.js', () =>
   assert.equal(h['Access-Control-Allow-Headers'], ACAH_EXPECTED);
 });
 
+test('buildCorsHeaders Access-Control-Expose-Headers matches api/_cors.js', () => {
+  const h = buildCorsHeaders(KNOWN_GOOD);
+  assert.equal(h['Access-Control-Expose-Headers'], ACEH_EXPECTED);
+});
+
 // --- preflight short-circuit (the load-bearing branch) --------------------
 
 test('OPTIONS preflight returns 204 with Access-Control-Allow-Credentials: true', async () => {
@@ -114,6 +120,7 @@ test('OPTIONS preflight returns 204 with Access-Control-Allow-Credentials: true'
   assert.equal(resp.headers.get('access-control-allow-credentials'), 'true');
   assert.equal(resp.headers.get('access-control-allow-methods'), ACAM_EXPECTED);
   assert.equal(resp.headers.get('access-control-allow-headers'), ACAH_EXPECTED);
+  assert.equal(resp.headers.get('access-control-expose-headers'), ACEH_EXPECTED);
   assert.equal(resp.headers.get('vary'), 'Origin');
 });
 
@@ -194,6 +201,7 @@ test('GET response from origin has CORS headers stamped by the Worker', async ()
     assert.equal(resp.status, 200);
     assert.equal(resp.headers.get('access-control-allow-origin'), KNOWN_GOOD);
     assert.equal(resp.headers.get('access-control-allow-credentials'), 'true');
+    assert.equal(resp.headers.get('access-control-expose-headers'), ACEH_EXPECTED);
     assert.equal(resp.headers.get('content-type'), 'application/json');
   } finally {
     globalThis.fetch = original;

--- a/workers/api-cors-preflight/src/index.js
+++ b/workers/api-cors-preflight/src/index.js
@@ -37,6 +37,9 @@ const ALLOWED_ORIGIN_PATTERNS = [
 // Keep in sync with api/_cors.js#getCorsHeaders Access-Control-Allow-Headers.
 const ALLOW_HEADERS = 'Content-Type, Authorization, X-WorldMonitor-Key, X-Api-Key, X-Widget-Key, X-Pro-Key, X-WorldMonitor-Desktop-Timestamp, X-WorldMonitor-Desktop-Signature';
 
+// Keep in sync with api/_cors.js#getCorsHeaders Access-Control-Expose-Headers.
+const EXPOSE_HEADERS = 'Mcp-Session-Id, WWW-Authenticate, Retry-After, X-WorldMonitor-Bbox, X-WorldMonitor-Bbox-Missing, X-WorldMonitor-Bbox-Invalid, X-Military-Bbox';
+
 // Superset of every method any api/* route advertises. The Worker stamps ONE
 // fixed Allow-Methods on every preflight, so if a route handles DELETE but
 // Allow-Methods omits it, the browser rejects the preflight before the
@@ -101,6 +104,7 @@ export function buildCorsHeaders(origin) {
     'Access-Control-Allow-Credentials': 'true',
     'Access-Control-Allow-Methods': ALLOW_METHODS,
     'Access-Control-Allow-Headers': ALLOW_HEADERS,
+    'Access-Control-Expose-Headers': EXPOSE_HEADERS,
     'Access-Control-Max-Age': '3600',
     'Vary': 'Origin',
   };


### PR DESCRIPTION
## Summary
- Narrows bbox diagnostics to the two #4595 military endpoints that genuinely require bbox:
  - `/api/military/v1/list-military-bases`
  - `/api/military/v1/list-military-flights`
- Emits readable, non-breaking response headers when those required bbox params are absent/wrong-named, non-numeric, blank, or explicitly all-zero:
  - `X-WorldMonitor-Bbox: missing|invalid`
  - `X-WorldMonitor-Bbox-Missing`
  - `X-WorldMonitor-Bbox-Invalid`
  - `X-Military-Bbox`
- Treats `missing` as all four bbox params absent, so first-party generated clients that omit zero-valued corners do not get false-positive diagnostics.
- Explicitly verifies optional/global bbox endpoints do not get false-positive diagnostics.
- Exposes the diagnostic headers through the API/server CORS helpers and the Cloudflare `api-cors-preflight` worker.

Closes #4595.

## Intent
The intent is the issue's non-breaking fix: military callers no longer receive a bare empty/successful response when generated route coercion turns absent bbox params into zeroes. The PR deliberately does not add hard `400` enforcement; that remains a separate #4599 migration candidate.

The follow-up scope correction avoids labeling legitimate no-bbox traffic on `track-aircraft`, `get-vessel-snapshot`, `list-unrest-events`, and `list-fire-detections`, because those endpoints support lookup/global modes. The generated-client zero-corner correction avoids labeling valid military bboxes that touch the equator or prime meridian, because proto3 clients omit zero-valued numeric query params.

## Validation Matrix
| Check | Reason | Result |
|---|---|---|
| `./node_modules/.bin/tsx --test tests/gateway-required-bbox.test.mts` | Focused required-bbox diagnostics, optional-path negatives, generated-client zero-corner shape, POST-to-GET, invalid partials, zero-coordinate bbox | Pass: 12/12 |
| `node --test api/_cors.test.mjs` | API CORS helper exposed-header coverage | Pass: 4/4 |
| `node --test workers/api-cors-preflight/index.test.mjs` | Cloudflare worker CORS exposed-header parity | Pass: 20/20 |
| `npm run typecheck:api` | API/server typecheck plus Convex audit | Pass |
| `git diff --check` / `git diff --cached --check` | Whitespace/conflict hygiene | Pass |

## Review Gates
- Baseline reviewer: passed after narrowing diagnostics to required military paths, adding negative coverage for optional/global endpoints, and adding generated-client zero-corner coverage.
- Code Review Expert: passed; no open P0/P1/P2/P3 findings on the latest follow-up diff.
- Outcome reviewer: passed; current diff satisfies #4595's concrete military deliverable without false-positive diagnostics for optional/global traffic or generated-client zero-corner military bboxes.

## CI / Review Follow-Up
- Latest pushed head: `d3776f24059d02a679a362f0e62304014ec24965`.
- Required PR checks: pass, including `gate`, `unit`, `typecheck`, `biome`, `sidecar`, `convex-tests`, `variant-smoke-full`, `resilience-validation-smoke`, audits, and docs checks.
- Vercel preview: pass / deployed.
- Merge state: clean.
- Review threads: none.
- Greptile: no new comment for latest head `d3776f24059d02a679a362f0e62304014ec24965` after the bounded review window; the only Greptile comment is for the previous `af57e65` head and has no current actionable threads.

## Documentation
Not applicable. This is API diagnostic behavior only; no public docs were changed in this PR. Companion docs work is tracked separately in #4596.

## Screenshots / UI Evidence
Not applicable. No UI changes.

## Residual Findings
- Hard `400` enforcement is intentionally deferred/non-goal for this PR. Diagnostic headers satisfy #4595's non-breaking option A; route-wide hard failure should be handled as a separate migration under #4599 if desired.
- Optional/global bbox endpoint behavior is intentionally preserved and now negative-tested.
- Aviation `track-aircraft` optional lookup/callsign behavior remains a separate follow-up; aviation is intentionally not in this PR's required-bbox diagnostic set.
