### PR TITLE
fix(user-prefs): rate-limit prefs writes

### DIFF
--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -20,6 +20,15 @@ import { captureSilentError } from './_sentry-edge.js';
 import { extractConvexErrorKind, isOpaqueConvexServerError, readConvexErrorNumber } from './_convex-error.js';
 import { ConvexHttpClient } from 'convex/browser';
 import { validateBearerToken } from '../server/auth-session';
+import {
+  RATE_LIMIT_DEGRADED_HEADERS,
+  checkScopedRateLimit,
+  type ScopedRateLimitResult,
+} from '../server/_shared/rate-limit';
+
+export const USER_PREFS_WRITE_RATE_SCOPE = '/api/user-prefs#write';
+export const USER_PREFS_WRITE_RATE_LIMIT = 30;
+export const USER_PREFS_WRITE_RATE_WINDOW = '60 s' as const;
 
 export default async function handler(
   req: Request,
@@ -145,6 +154,9 @@ export default async function handler(
     return jsonResponse({ error: 'MISSING_FIELDS' }, 400, cors);
   }
 
+  const rateLimitResponse = await checkUserPrefsWriteRateLimit(session.userId, cors);
+  if (rateLimitResponse) return rateLimitResponse;
+
   try {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result = (await client.mutation('userPreferences:setPreferences' as any, {
@@ -239,6 +251,56 @@ export default async function handler(
     }));
     return jsonResponse({ error: 'Failed to save preferences' }, 500, cors);
   }
+}
+
+
+async function checkUserPrefsWriteRateLimit(
+  userId: string,
+  cors: Record<string, string>,
+): Promise<Response | null> {
+  const scoped = await checkScopedRateLimit(
+    USER_PREFS_WRITE_RATE_SCOPE,
+    USER_PREFS_WRITE_RATE_LIMIT,
+    USER_PREFS_WRITE_RATE_WINDOW,
+    buildUserPrefsWriteRateLimitIdentifier(userId),
+  );
+  if (scoped.degraded) {
+    return userPrefsWriteRateLimitDegradedResponse(cors);
+  }
+  if (!scoped.allowed) {
+    return userPrefsWriteRateLimitExceededResponse(scoped, cors);
+  }
+  return null;
+}
+
+export function buildUserPrefsWriteRateLimitIdentifier(userId: string): string {
+  return 'user:' + userId;
+}
+
+export function userPrefsWriteRateLimitDegradedResponse(cors: Record<string, string>): Response {
+  return jsonResponse(
+    { error: 'RATE_LIMIT_DEGRADED' },
+    503,
+    { ...RATE_LIMIT_DEGRADED_HEADERS, ...cors },
+  );
+}
+
+export function userPrefsWriteRateLimitExceededResponse(
+  scoped: Pick<ScopedRateLimitResult, 'limit' | 'reset'>,
+  cors: Record<string, string>,
+): Response {
+  const retryAfter = Math.max(1, Math.ceil((scoped.reset - Date.now()) / 1000));
+  return jsonResponse(
+    { error: 'RATE_LIMITED' },
+    429,
+    {
+      'X-RateLimit-Limit': String(scoped.limit),
+      'X-RateLimit-Remaining': '0',
+      'X-RateLimit-Reset': String(scoped.reset),
+      'Retry-After': String(retryAfter),
+      ...cors,
+    },
+  );
 }
 
 

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -263,6 +263,11 @@ describe('rate-limit fail-closed call-site policy (#3531)', () => {
 describe('scoped rate-limit degraded call-site policy (#3531)', () => {
   const SCOPED_RATE_LIMIT_CALLERS = [
     {
+      path: 'api/user-prefs.ts',
+      expected: /if\s*\(\s*scoped\.degraded\s*\)\s*\{/,
+      reason: 'user-prefs writes hit Convex directly, so Redis degradation must fail closed locally',
+    },
+    {
       path: 'server/worldmonitor/leads/v1/register-interest.ts',
       expected: /if\s*\(\s*scoped\.degraded\s*\)\s*\{/,
       reason: 'desktop lead capture bypasses Turnstile, so Redis degradation must fail closed locally',

--- a/tests/user-prefs-sentry-context.test.mts
+++ b/tests/user-prefs-sentry-context.test.mts
@@ -1,6 +1,12 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildSentryContext } from '../api/user-prefs.ts';
+import {
+  USER_PREFS_WRITE_RATE_LIMIT,
+  buildSentryContext,
+  buildUserPrefsWriteRateLimitIdentifier,
+  userPrefsWriteRateLimitDegradedResponse,
+  userPrefsWriteRateLimitExceededResponse,
+} from '../api/user-prefs.ts';
 
 // ---------------------------------------------------------------------------
 // buildSentryContext — Sentry tag/extra/fingerprint shape for /api/user-prefs
@@ -240,5 +246,47 @@ describe('buildSentryContext — backwards-compat for non-CONFLICT callers', () 
     const ctx = buildSentryContext(err, err.message, baseOpts);
     assert.equal(typeof ctx.extra.messageHead, 'string');
     assert.match(ctx.extra.messageHead as string, /^quite a long/);
+  });
+});
+
+
+describe('user-prefs POST rate limit helpers (#4567)', () => {
+  it('keys the write budget by authenticated user, not variant', () => {
+    assert.equal(buildUserPrefsWriteRateLimitIdentifier('user_abc123'), 'user:user_abc123');
+  });
+
+  it('builds a fail-closed degraded response with retry guidance and CORS', async () => {
+    const res = userPrefsWriteRateLimitDegradedResponse({
+      'Access-Control-Allow-Origin': 'https://worldmonitor.app',
+    });
+
+    assert.equal(res.status, 503);
+    assert.equal(res.headers.get('X-RateLimit-Mode'), 'degraded');
+    assert.equal(res.headers.get('Retry-After'), '5');
+    assert.equal(res.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app');
+    const body = (await res.json()) as { error?: string };
+    assert.equal(body.error, 'RATE_LIMIT_DEGRADED');
+  });
+
+  it('builds a 429 throttle response with standard rate-limit headers', async () => {
+    const realNow = Date.now;
+    Date.now = () => 1_000;
+    try {
+      const res = userPrefsWriteRateLimitExceededResponse(
+        { limit: USER_PREFS_WRITE_RATE_LIMIT, reset: 11_000 },
+        { 'Access-Control-Allow-Origin': 'https://worldmonitor.app' },
+      );
+
+      assert.equal(res.status, 429);
+      assert.equal(res.headers.get('X-RateLimit-Limit'), String(USER_PREFS_WRITE_RATE_LIMIT));
+      assert.equal(res.headers.get('X-RateLimit-Remaining'), '0');
+      assert.equal(res.headers.get('X-RateLimit-Reset'), '11000');
+      assert.equal(res.headers.get('Retry-After'), '10');
+      assert.equal(res.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app');
+      const body = (await res.json()) as { error?: string };
+      assert.equal(body.error, 'RATE_LIMITED');
+    } finally {
+      Date.now = realNow;
+    }
   });
 });


### PR DESCRIPTION
## Summary

User prefs writes now hit a per-authenticated-user scoped throttle before the Convex mutation, so bot retry loops get stopped at the edge instead of pounding `userPreferences:setPreferences`.

The budget is variant-agnostic at 30 valid POST writes per minute per user, so a caller cannot cycle variants to dodge the cap. If the Redis limiter is unavailable, prefs writes fail closed with a short 503 + `Retry-After` and the standard degraded marker rather than silently bypassing the abuse gate.

Fixes #4567.

## Validation

- `./node_modules/.bin/tsx --test tests/user-prefs-sentry-context.test.mts tests/rate-limit.test.mts`
- `npm run typecheck:api`
- `./node_modules/.bin/biome check api/user-prefs.ts tests/rate-limit.test.mts tests/user-prefs-sentry-context.test.mts`
- `git diff --check`

## Post-Deploy Monitoring & Validation

- Window: first 24 hours after deploy; owner: WorldMonitor on-call / maintainer.
- Watch Sentry issue `7540529143` plus `api/user-prefs` events tagged `error_shape:convex_internal_error`, `convex_service_unavailable`, or `convex_worker_overloaded`. Healthy signal: no new concentrated retry-loop spikes from a small set of identities after deploy.
- Check Vercel / edge logs for `POST /api/user-prefs` status distribution. Healthy signal: abusive identities receive bounded `429 RATE_LIMITED`; ordinary users remain mostly `200` / `409`; `503 RATE_LIMIT_DEGRADED` is absent or brief.
- Watch rate-limit degraded logs/captures for `checkScopedRateLimit:/api/user-prefs#write`. Trigger: sustained degraded 503s or elevated legitimate-user 429s. Mitigation: verify Upstash env/health, adjust the write budget if normal clients are throttled, or rollback if valid prefs writes are broadly blocked.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5 Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
