### PR TITLE
perf(boot): dynamic-import renewable-energy-data off the boot bundle (#4571)

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -176,7 +176,9 @@ import { classifyNewsItem } from '@/services/positive-classifier';
 import { fetchGivingSummary } from '@/services/giving';
 import { fetchProgressData } from '@/services/progress-data';
 import { fetchConservationWins } from '@/services/conservation-data';
-import { fetchRenewableEnergyData, fetchEnergyCapacity } from '@/services/renewable-energy-data';
+// #4571: renewable-energy-data (+ its transitive economic edge) dynamic-imported
+// inside loadRenewableData so it doesn't parse/execute at boot — the renewable
+// panel is below-fold and its load is viewport-gated (shouldLoad('renewable')).
 import { checkMilestones } from '@/services/celebration';
 import { fetchHappinessScores } from '@/services/happiness-data';
 import { fetchRenewableInstallations } from '@/services/renewable-installations';
@@ -3767,6 +3769,7 @@ export class DataLoaderManager implements AppModule {
   }
 
   private async loadRenewableData(): Promise<void> {
+    const { fetchRenewableEnergyData, fetchEnergyCapacity } = await import('@/services/renewable-energy-data');
     const data = await fetchRenewableEnergyData();
     this.callPanel('renewable', 'setData', data);
     if (SITE_VARIANT === 'happy' && data?.globalPercentage) {


### PR DESCRIPTION
## Summary

First measured increment of the #4571 main.js boot-bundle diet: defers `renewable-energy-data` (and its transitive economic-facade edge) off the eager `main.js` chunk. It was statically imported by `data-loader.ts`, parsing/executing at boot even though the renewable panel is below-fold and its load is viewport-gated (`shouldLoad('renewable')`). Moved the import into `loadRenewableData` so it only loads when that panel is near-viewport; `runGuarded` keeps a chunk-load failure non-fatal.

**Verified** by sourcemap byte-attribution: `renewable-energy-data` left the eager `main.js` chunk (about -4KB). Behavior-preserving import-timing refactor (same fetchers, same gate) — `tsc --noEmit` clean.

## Finding — the plan's mechanism is insufficient for the bulk of the boot weight

Attempting the same conversion on `economic` (34.9KB, the plan's lead target) did NOT shed it, proven by the measure-gate: converting all 10 of its data-loader edges to dynamic imports left `main.js` unchanged. Root cause (documented on #4571): `src/services/index.ts` does `export * from './economic'` and `economic/index.ts` runs `new EconomicServiceClient(...)` at module load — a side-effectful module reached via `export *` can't be tree-shaken while any eager module imports the barrel. So the fetcher-dynamic-import approach only sheds directly-imported services (like this one). Economic/market/the tail need the service clients made lazy (a bigger pattern-wide refactor constrained by #3242) — a separate ce-plan. This PR lands the one clean win the current approach yields.

## Test plan
- `tsc --noEmit` clean; build succeeds; byte-attribution confirms the module left the eager chunk.
- Behavior-preserving (no new test — same data loads via the same gate).

Part of #4571 / #4487.

https://claude.ai/code/session_011htsYLErqJb922Qm9QLraN