### PR TITLE
perf(attribution): desktop main-thread attribution baseline + harness (#4539)

### DIFF
--- a/docs/perf/desktop-mainthread-baseline-2026-07-02.md
+++ b/docs/perf/desktop-mainthread-baseline-2026-07-02.md
@@ -40,47 +40,56 @@ desktop, 15 s settle. Self-time total is **not** the same metric as Lighthouse's
 
 ### Category split (the reproduction check)
 
-| Category | Unthrottled (cpu 1) | Throttled (cpu 4) | Prior lab (#4487) |
-|---|---|---|---|
-| **other** | **54.8%** (6.08 s) | 42.3% | ~52% |
-| **styleLayout** (forced reflow → #4536) | **20.9%** (2.32 s) | 18.8% | ~19% |
-| scripting | 13.1% (1.46 s) | 30.4% | ~19% (script-eval) |
-| paintComposite | 10.8% (1.20 s) | 7.6% | — |
-| parseHTML | 0.4% | 0.8% | — |
-| garbageCollection | ~0% | ~0% | — |
-| main-thread self-time total | 11.1 s | 14.4 s | ~11.1 s "Other" / 21.3 s work |
-| long tasks (>50 ms) / TBT | 14 / 683 ms | 184 / 8568 ms | — |
+Category grouping mirrors Lighthouse's `taskGroups` (e.g. `UpdateLayerTree`/`UpdateLayer` count as
+paint/composite, not styleLayout). Two same-day captures are shown to make the host variance explicit.
 
-The unthrottled split matches the prior lab's 52/19/19 almost exactly, which validates the harness.
-Throttling amplifies `scripting` (JS eval scales with CPU slowdown) but the **structure** holds.
+| Category | cpu 1 | cpu 4 | Prior lab (#4487) |
+|---|---|---|---|
+| **other** | **48.9%** (5.27 s) | 35.0% | ~52% |
+| **styleLayout** (forced reflow → #4536) | 22.1% (2.38 s) | 23.3% | ~19% |
+| scripting | 17.7% (1.91 s) | 32.7% | ~19% (script-eval) |
+| paintComposite | 10.8% (1.16 s) | 8.3% | — |
+| parseHTML | 0.5% | 0.6% | — |
+| garbageCollection | ~0% | ~0% | — |
+| main-thread self-time total | 10.8 s | 14.1 s | ~11.1 s "Other" / 21.3 s work |
+| long tasks (>50 ms) / TBT | 23 / 1346 ms | 132 / 6894 ms | — |
+
+The unthrottled split brackets the prior lab's 52/19/19 (across captures: other ~49–55%, styleLayout
+~20–22%, scripting ~13–18%), which validates the harness. Throttling amplifies `scripting` (JS eval
+scales with CPU slowdown). Absolute ms swings run-to-run under host contention (#4486) — trust the
+**structure**, not the absolute number.
 
 ### "Other" decomposed — the #4539 black box, cracked open
 
 | "Other" component | cpu 1 | cpu 4 | What it is |
 |---|---|---|---|
-| **`Layerize`** | **27.6%** (3.06 s) | 15.5% | **Compositor layerization** — assigning paint layers to compositing layers. Cost scales with the number of composited layers and how often the layer tree is rebuilt. |
-| `ThreadControllerImpl::RunTask` | 20.4% (2.27 s) | 16.5% | Scheduler task-runner self-time — the cost of *running many tasks*. Largely irreducible; shrinks as task count drops (what the boot-split/INP work already targets). |
-| `IntersectionObserverController::computeIntersections` | 2.2% (0.25 s) | 1.4% | IO callbacks (the panel-mount observers). |
-| `UpdateLayer` + GC scavenger + mojo + v8 housekeeping | ~3% | ~3% | Small, expected. |
+| **`Layerize`** | **22.4%** (2.41 s) | 15.9% | **Compositor layerization** — assigning paint layers to compositing layers. Cost scales with the number of composited layers and how often the layer tree is rebuilt. |
+| `ThreadControllerImpl::RunTask` | 21.1% (2.27 s) | 12.7% | Scheduler task-runner self-time — the cost of *running many tasks*. Largely irreducible; shrinks as task count drops (what the boot-split/INP work already targets). |
+| `IntersectionObserverController::computeIntersections` | 1.9% (0.21 s) | ~1% | IO callbacks (the panel-mount observers). |
+| GC scavenger + mojo + v8 housekeeping | ~2% | ~2% | Small, expected. |
+
+Across every capture (two mappings, two throttle levels) `Layerize` held **~22–28% (cpu 1) / ~16%
+(cpu 4)** — always the #1 or #2 "Other" component, ~half of "Other" together with the scheduler
+self-time. That cross-condition stability is how we know it's a real structural cost, not host noise.
 
 ## Findings
 
 1. **`Layerize` (compositor layerization) is the single largest previously-uncharacterized cost —
-   ~27.6% / 3.06 s of desktop main-thread, ~half of all "Other".** It is stably a top-2 "Other"
-   component across both host conditions (27.6% unthrottled / 15.5% throttled), so it is a real
-   structural cost, not a host artifact. Lighthouse buckets `Layerize` into "Other," which is
-   exactly why the 52% was a black box. **This is the concrete new lever (follow-up filed).**
+   ~22–28% / ~2.4–3.1 s of desktop main-thread, ~half of all "Other" with the scheduler self-time.**
+   It is stably the top-1/2 "Other" component across every capture (~22–28% unthrottled / ~16%
+   throttled), so it is a real structural cost, not a host artifact. Lighthouse buckets `Layerize`
+   into "Other," which is exactly why the 52% was a black box. **This is the concrete new lever.**
 2. **~20% of "Other" is scheduler `RunTask` self-time** — the raw cost of running many main-thread
    tasks. This is not a discrete bug to fix; it falls as the open boot-split (#4486 line) and INP
    handler-chunking (#4537/#4556/#4558/#4617) reduce task count. It should not be chased separately.
 3. **The "9 s document task with 60 ms script-eval" (issue signal) is explained.** It is
-   `styleLayout` (2.3 s forced reflow) + `Layerize` (3 s compositing) + scheduler running
+   `styleLayout` (~2.4 s forced reflow) + `Layerize` (~2.4–3 s compositing) + scheduler running
    synchronously during initial render — **layout + compositing, not app JS.** This corroborates
    #4536 (forced reflow) and points the remaining desktop render axis at compositing, not scriptEval.
 
 ## Concrete follow-up (acceptance: ≥1 sized lever)
 
-- **Reduce compositing-layer count / `Layerize` churn** — the ~3 s / 27.6% lever surfaced above.
+- **Reduce compositing-layer count / `Layerize` churn** — the ~2.4–3 s / ~22–28% lever surfaced above.
   Investigation path (CDP `LayerTree` domain to count composited layers; audit `will-change`,
   `transform: translateZ()`/3D transforms, `position: sticky/fixed`, opacity/filter on large
   subtrees, and per-panel layer promotion that forces extra compositing layers beyond the two

--- a/docs/perf/desktop-mainthread-baseline-2026-07-02.md
+++ b/docs/perf/desktop-mainthread-baseline-2026-07-02.md
@@ -1,0 +1,94 @@
+# Desktop main-thread baseline — 2026-07-02 (#4539 / #4487)
+
+The committed **desktop** main-thread attribution + methodology — the twin of the mobile baseline
+(`docs/perf/mobile-mainthread-baseline-2026-06-27.md`, #4458). It exists to answer the meta-gap in
+#4539: on desktop `/dashboard`, **52% (~11 s) of main-thread time was an uncharacterized "Other"
+bucket**, and the open byte/boot-split campaign (scriptEval) demonstrably wasn't where the time was.
+You can't fix what isn't attributed — this baseline attributes it.
+
+## How to measure
+
+Two complementary signals (KTD1, same as mobile — local lab **absolutes** are host-contention
+contaminated: #4486 recorded the same URL scoring 28/57/85, so trust the **relative** split and take
+authoritative absolutes from PageSpeed/Calibre):
+
+1. **Authoritative absolute timings → PageSpeed Insights / Calibre** (clean infra, zero local
+   contention). Median of ≥3; discard the first-run outlier.
+2. **Deterministic relative decomposition → `scripts/measure-desktop-mainthread.mjs`** (this
+   harness). Unlike the mobile harness (which attributes *long tasks by container*), this captures a
+   Chrome DevTools performance **trace** via CDP and aggregates renderer main-thread **self-time by
+   trace-event name → category**, then **itemizes the "Other" bucket by event name** — which is the
+   whole point, since Lighthouse's coarse `mainthread-work-breakdown` reports "Other" as a black box.
+
+```bash
+# unthrottled desktop (matches Lighthouse desktop, cpuSlowdown 1x)
+node scripts/measure-desktop-mainthread.mjs https://www.worldmonitor.app/dashboard --cpu 1 --settle 15000 --json
+# throttled cross-check (surfaces long-task structure; relative shares should hold)
+node scripts/measure-desktop-mainthread.mjs https://www.worldmonitor.app/dashboard --cpu 4 --settle 15000 --json
+```
+
+> The pure attribution functions (`normalizeCompleteEvents`, `pickRendererMainThread`,
+> `computeSelfTimeByName`, `categorize`, `buildDecomposition`) are exported and unit-tested with a
+> deterministic fixture (`tests/measure-desktop-mainthread.test.mts`) — CI-safe, no browser.
+> Self-time = a trace node's duration minus its direct children's, summed by event name.
+
+## Harness capture — 2026-07-02 (prod, post #4556/#4558/#4561/#4600)
+
+`scripts/measure-desktop-mainthread.mjs` vs `https://www.worldmonitor.app/dashboard`, 1350×940
+desktop, 15 s settle. Self-time total is **not** the same metric as Lighthouse's ~21 s wall
+`mainthread-work` (which includes idle-thread wall time); it is the summed attributed self-time.
+
+### Category split (the reproduction check)
+
+| Category | Unthrottled (cpu 1) | Throttled (cpu 4) | Prior lab (#4487) |
+|---|---|---|---|
+| **other** | **54.8%** (6.08 s) | 42.3% | ~52% |
+| **styleLayout** (forced reflow → #4536) | **20.9%** (2.32 s) | 18.8% | ~19% |
+| scripting | 13.1% (1.46 s) | 30.4% | ~19% (script-eval) |
+| paintComposite | 10.8% (1.20 s) | 7.6% | — |
+| parseHTML | 0.4% | 0.8% | — |
+| garbageCollection | ~0% | ~0% | — |
+| main-thread self-time total | 11.1 s | 14.4 s | ~11.1 s "Other" / 21.3 s work |
+| long tasks (>50 ms) / TBT | 14 / 683 ms | 184 / 8568 ms | — |
+
+The unthrottled split matches the prior lab's 52/19/19 almost exactly, which validates the harness.
+Throttling amplifies `scripting` (JS eval scales with CPU slowdown) but the **structure** holds.
+
+### "Other" decomposed — the #4539 black box, cracked open
+
+| "Other" component | cpu 1 | cpu 4 | What it is |
+|---|---|---|---|
+| **`Layerize`** | **27.6%** (3.06 s) | 15.5% | **Compositor layerization** — assigning paint layers to compositing layers. Cost scales with the number of composited layers and how often the layer tree is rebuilt. |
+| `ThreadControllerImpl::RunTask` | 20.4% (2.27 s) | 16.5% | Scheduler task-runner self-time — the cost of *running many tasks*. Largely irreducible; shrinks as task count drops (what the boot-split/INP work already targets). |
+| `IntersectionObserverController::computeIntersections` | 2.2% (0.25 s) | 1.4% | IO callbacks (the panel-mount observers). |
+| `UpdateLayer` + GC scavenger + mojo + v8 housekeeping | ~3% | ~3% | Small, expected. |
+
+## Findings
+
+1. **`Layerize` (compositor layerization) is the single largest previously-uncharacterized cost —
+   ~27.6% / 3.06 s of desktop main-thread, ~half of all "Other".** It is stably a top-2 "Other"
+   component across both host conditions (27.6% unthrottled / 15.5% throttled), so it is a real
+   structural cost, not a host artifact. Lighthouse buckets `Layerize` into "Other," which is
+   exactly why the 52% was a black box. **This is the concrete new lever (follow-up filed).**
+2. **~20% of "Other" is scheduler `RunTask` self-time** — the raw cost of running many main-thread
+   tasks. This is not a discrete bug to fix; it falls as the open boot-split (#4486 line) and INP
+   handler-chunking (#4537/#4556/#4558/#4617) reduce task count. It should not be chased separately.
+3. **The "9 s document task with 60 ms script-eval" (issue signal) is explained.** It is
+   `styleLayout` (2.3 s forced reflow) + `Layerize` (3 s compositing) + scheduler running
+   synchronously during initial render — **layout + compositing, not app JS.** This corroborates
+   #4536 (forced reflow) and points the remaining desktop render axis at compositing, not scriptEval.
+
+## Concrete follow-up (acceptance: ≥1 sized lever)
+
+- **Reduce compositing-layer count / `Layerize` churn** — the ~3 s / 27.6% lever surfaced above.
+  Investigation path (CDP `LayerTree` domain to count composited layers; audit `will-change`,
+  `transform: translateZ()`/3D transforms, `position: sticky/fixed`, opacity/filter on large
+  subtrees, and per-panel layer promotion that forces extra compositing layers beyond the two
+  unavoidable map canvases). Filed as **#4630** (linked from #4539).
+
+## Gate / re-measure
+
+Re-run both harness invocations before/after any compositing-layer change and record the
+`Layerize` self-time share delta in the PR. Take the authoritative absolute desktop `mainthread-work`
+from a clean PSI/Calibre run — this harness supplies the **relative** decomposition, not the headline
+absolute (KTD1). The `styleLayout` share is the #4536 gate; the `Layerize` share is the new one.

--- a/scripts/measure-desktop-mainthread.mjs
+++ b/scripts/measure-desktop-mainthread.mjs
@@ -139,10 +139,12 @@ export function normalizeCompleteEvents(events) {
 }
 
 /**
- * Identify the busiest CrRendererMain (pid:tid). The main frame's renderer main
- * thread carries the dashboard's main-thread work; picking the busiest among the
- * threads named CrRendererMain avoids counting worker/iframe/prerender threads.
- * Returns "pid:tid" or null when no such thread is found.
+ * Identify the busiest CrRendererMain (pid:tid) — the target page's renderer main
+ * thread. Picking the busiest among threads named CrRendererMain excludes worker
+ * threads (they are named differently), but a cross-origin iframe or prerender
+ * runs its own CrRendererMain, so this assumes the top-level dashboard frame is
+ * the busiest renderer (true in practice; a heavy third-party embed out-busying
+ * the top frame is a known limitation). Returns "pid:tid" or null when none found.
  */
 export function pickRendererMainThread(events) {
   const candidates = new Set();
@@ -328,7 +330,10 @@ async function measure(url, { cpu = 1, settle = 15000 } = {}) {
     });
     await client.send('Tracing.start', {
       transferMode: 'ReturnAsStream',
-      traceConfig: { recordMode: 'recordUntilFull', includedCategories: TRACE_CATEGORIES },
+      // recordAsMuchAsPossible (not recordUntilFull): don't stop at the first ring-buffer
+      // fill over a busy 15s settle, which would drop late paint/interaction events and
+      // bias the *relative* split toward early-load parse/script work.
+      traceConfig: { recordMode: 'recordAsMuchAsPossible', includedCategories: TRACE_CATEGORIES },
     });
     await page.goto(url, { waitUntil: 'load', timeout: 60000 });
     await page.waitForTimeout(settle);
@@ -348,17 +353,31 @@ async function measure(url, { cpu = 1, settle = 15000 } = {}) {
 export function buildReport(result) {
   const events = result?.trace?.traceEvents || (Array.isArray(result?.trace) ? result.trace : []);
   const mainThread = pickRendererMainThread(events);
-  const complete = normalizeCompleteEvents(events).filter(
-    (e) => !mainThread || `${e.pid}:${e.tid}` === mainThread,
-  );
+  const longTasks = summarizeLongTasks(result?.longtasks);
+  if (!mainThread) {
+    // No CrRendererMain metadata — we can't isolate one properly-nested thread.
+    // Mixing all threads' (concurrent, non-nested) events into the self-time
+    // stack would violate its precondition and silently emit a plausible-but-
+    // wrong split, so refuse to attribute rather than produce garbage.
+    return {
+      url: result?.url,
+      cpu: result?.cpu,
+      mainThread: null,
+      mainThreadMs: 0,
+      categories: [],
+      other: [],
+      longTasks,
+      warning: 'no CrRendererMain thread found in trace; not attributing',
+    };
+  }
+  const complete = normalizeCompleteEvents(events).filter((e) => `${e.pid}:${e.tid}` === mainThread);
   const { byName } = computeSelfTimeByName(complete);
-  const decomposition = buildDecomposition(byName);
   return {
     url: result?.url,
     cpu: result?.cpu,
     mainThread,
-    ...decomposition,
-    longTasks: summarizeLongTasks(result?.longtasks),
+    ...buildDecomposition(byName),
+    longTasks,
   };
 }
 

--- a/scripts/measure-desktop-mainthread.mjs
+++ b/scripts/measure-desktop-mainthread.mjs
@@ -1,0 +1,398 @@
+#!/usr/bin/env node
+/**
+ * Desktop main-thread attribution harness (#4539 / #4487) — the desktop twin of
+ * scripts/measure-mobile-mainthread.mjs (#4458).
+ *
+ * Captures a Chrome DevTools performance trace of /dashboard under a desktop
+ * viewport (+ optional CPU throttle) via CDP, then decomposes renderer
+ * main-thread SELF-TIME by trace-event name into categories — the point being to
+ * crack open the coarse "Other" bucket (desktop: 52% / ~11s, uncharacterized —
+ * #4539) into the named native events that actually compose it: forced
+ * Layout/reflow, HitTest, Paint/Composite/Raster/GPU, GC, and scheduler overhead.
+ *
+ * Why self-time by event name (not Lighthouse's coarse groups): Lighthouse's
+ * `mainthread-work-breakdown` already reports Script/Style&Layout/Other, but
+ * "Other" is exactly the black box we need to open. Aggregating raw-trace
+ * self-time per event name dissolves "Other" into its constituents.
+ *
+ * Philosophy mirrors #4458 (KTD1): local lab ABSOLUTES are host-contention
+ * contaminated (#4486: the same URL scored 28/57/85), so trust the RELATIVE
+ * category split this produces and take authoritative absolute desktop timings
+ * from PageSpeed/Calibre. The pure attribution functions are exported and
+ * unit-tested with fixtures (deterministic, CI-safe); Playwright is imported
+ * lazily so importing this module for its helpers never launches a browser.
+ *
+ * Usage:
+ *   node scripts/measure-desktop-mainthread.mjs [url] [--cpu 1] [--settle 15000] [--json]
+ *   (default url: https://www.worldmonitor.app/dashboard; --cpu 1 = no throttle, matches Lighthouse desktop)
+ */
+import { pathToFileURL } from 'node:url';
+
+const TBT_THRESHOLD_MS = 50;
+
+function round(n) {
+  return Math.round((Number(n) || 0) * 10) / 10;
+}
+
+/**
+ * Trace-event name -> main-thread work category. Names not listed fall through to
+ * 'other', and every 'other' event is itemized by name in the report so the
+ * bucket is never a black box. Grouping mirrors Lighthouse's taskGroups so the
+ * category totals are comparable to its main-thread-work-breakdown.
+ */
+const CATEGORY_BY_EVENT = new Map(Object.entries({
+  // scripting (eval + parse/compile + JS-driven dispatch)
+  FunctionCall: 'scripting',
+  EvaluateScript: 'scripting',
+  'v8.evaluateModule': 'scripting',
+  'V8.Execute': 'scripting',
+  EventDispatch: 'scripting',
+  TimerFire: 'scripting',
+  FireAnimationFrame: 'scripting',
+  FireIdleCallback: 'scripting',
+  RunMicrotasks: 'scripting',
+  XHRReadyStateChange: 'scripting',
+  XHRLoad: 'scripting',
+  'v8.compile': 'scripting',
+  'V8.CompileCode': 'scripting',
+  'V8.CompileScript': 'scripting',
+  'v8.parseOnBackground': 'scripting',
+  // style + layout (forced reflow lives here — shared root with #4536)
+  Layout: 'styleLayout',
+  'Layout::performLayout': 'styleLayout',
+  UpdateLayoutTree: 'styleLayout',
+  RecalculateStyles: 'styleLayout',
+  ScheduleStyleRecalculation: 'styleLayout',
+  InvalidateLayout: 'styleLayout',
+  UpdateLayerTree: 'styleLayout',
+  HitTest: 'styleLayout',
+  ParseAuthorStyleSheet: 'styleLayout',
+  // paint + composite + raster + GPU
+  Paint: 'paintComposite',
+  PrePaint: 'paintComposite',
+  'Composite Layers': 'paintComposite',
+  CompositeLayers: 'paintComposite',
+  Commit: 'paintComposite',
+  RasterTask: 'paintComposite',
+  Rasterize: 'paintComposite',
+  ImageDecodeTask: 'paintComposite',
+  Draw: 'paintComposite',
+  DrawFrame: 'paintComposite',
+  PaintImage: 'paintComposite',
+  Decode_Image: 'paintComposite',
+  DecodeImage: 'paintComposite',
+  GPUTask: 'paintComposite',
+  // garbage collection
+  MinorGC: 'garbageCollection',
+  MajorGC: 'garbageCollection',
+  'V8.GCScavenger': 'garbageCollection',
+  'V8.GCFinalizeMC': 'garbageCollection',
+  'V8.GCFinalizeMCReduce': 'garbageCollection',
+  'V8.GCIncrementalMarking': 'garbageCollection',
+  'BlinkGC.AtomicPhase': 'garbageCollection',
+  'ThreadState::performIdleLazySweep': 'garbageCollection',
+  'ThreadState::completeSweep': 'garbageCollection',
+  // parse/loading
+  ParseHTML: 'parseHTML',
+  CommitLoad: 'parseHTML',
+  ResourceReceiveResponse: 'parseHTML',
+  ResourceReceivedData: 'parseHTML',
+  ResourceFinish: 'parseHTML',
+  ResourceSendRequest: 'parseHTML',
+}));
+
+/** Category for a trace-event name; unmapped names are 'other' (and itemized). */
+export function categoryOf(name) {
+  return CATEGORY_BY_EVENT.get(String(name)) || 'other';
+}
+
+/**
+ * Normalize raw traceEvents into duration-bearing complete events
+ * ({name, ts, dur, pid, tid}). `X` (complete) events are taken directly; `B`/`E`
+ * (begin/end) pairs are matched per (pid,tid) via a stack. Instant + metadata
+ * events are dropped. ts/dur stay in the trace's native microseconds.
+ */
+export function normalizeCompleteEvents(events) {
+  const out = [];
+  const stacks = new Map();
+  for (const e of Array.isArray(events) ? events : []) {
+    if (!e || typeof e.ph !== 'string') continue;
+    if (e.ph === 'X') {
+      if (typeof e.ts === 'number' && typeof e.dur === 'number') {
+        out.push({ name: String(e.name || 'unknown'), ts: e.ts, dur: e.dur, pid: e.pid, tid: e.tid });
+      }
+    } else if (e.ph === 'B') {
+      const key = `${e.pid}:${e.tid}`;
+      if (!stacks.has(key)) stacks.set(key, []);
+      stacks.get(key).push(e);
+    } else if (e.ph === 'E') {
+      const st = stacks.get(`${e.pid}:${e.tid}`);
+      if (st && st.length) {
+        const b = st.pop();
+        if (typeof b.ts === 'number' && typeof e.ts === 'number') {
+          out.push({ name: String(b.name || 'unknown'), ts: b.ts, dur: e.ts - b.ts, pid: b.pid, tid: b.tid });
+        }
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Identify the busiest CrRendererMain (pid:tid). The main frame's renderer main
+ * thread carries the dashboard's main-thread work; picking the busiest among the
+ * threads named CrRendererMain avoids counting worker/iframe/prerender threads.
+ * Returns "pid:tid" or null when no such thread is found.
+ */
+export function pickRendererMainThread(events) {
+  const candidates = new Set();
+  for (const e of Array.isArray(events) ? events : []) {
+    if (e && e.ph === 'M' && e.name === 'thread_name' && e.args?.name === 'CrRendererMain') {
+      candidates.add(`${e.pid}:${e.tid}`);
+    }
+  }
+  if (candidates.size === 0) return null;
+  const durByThread = new Map();
+  for (const e of events) {
+    const key = `${e.pid}:${e.tid}`;
+    if (!candidates.has(key)) continue;
+    if (e.ph === 'X' && typeof e.dur === 'number') durByThread.set(key, (durByThread.get(key) || 0) + e.dur);
+  }
+  let best = null;
+  let bestDur = -1;
+  for (const [key, d] of durByThread) {
+    if (d > bestDur) { bestDur = d; best = key; }
+  }
+  return best;
+}
+
+/**
+ * Self-time by event name for a set of same-thread complete events. Self-time =
+ * a node's duration minus the duration of its direct children (properly nested
+ * per thread in Chrome traces). Unit-agnostic: returns the same unit as the input
+ * `dur`. Negative self (malformed overlap) is clamped to 0.
+ */
+export function computeSelfTimeByName(events) {
+  const evs = [...(Array.isArray(events) ? events : [])]
+    .filter((e) => e && typeof e.ts === 'number' && typeof e.dur === 'number' && e.dur >= 0)
+    .sort((a, b) => a.ts - b.ts || b.dur - a.dur);
+  const nodes = [];
+  const stack = [];
+  for (const e of evs) {
+    const end = e.ts + e.dur;
+    while (stack.length && stack[stack.length - 1].end <= e.ts) stack.pop();
+    const node = { name: e.name, self: e.dur, end };
+    if (stack.length) stack[stack.length - 1].self -= e.dur;
+    stack.push(node);
+    nodes.push(node);
+  }
+  const byName = new Map();
+  let total = 0;
+  for (const n of nodes) {
+    const s = Math.max(0, n.self);
+    total += s;
+    byName.set(n.name, (byName.get(n.name) || 0) + s);
+  }
+  return { byName, total };
+}
+
+/**
+ * Fold a self-time-by-name map into category totals plus an itemized breakdown
+ * of the 'other' bucket (the point of the harness). Input/output share the
+ * caller's unit; the report layer converts microseconds to milliseconds.
+ */
+export function categorize(byName) {
+  const byCategory = {
+    scripting: 0,
+    styleLayout: 0,
+    paintComposite: 0,
+    garbageCollection: 0,
+    parseHTML: 0,
+    other: 0,
+  };
+  const otherByName = new Map();
+  let total = 0;
+  for (const [name, amount] of byName instanceof Map ? byName : new Map(Object.entries(byName || {}))) {
+    const cat = categoryOf(name);
+    byCategory[cat] += amount;
+    total += amount;
+    if (cat === 'other') otherByName.set(name, (otherByName.get(name) || 0) + amount);
+  }
+  const otherBreakdown = [...otherByName.entries()]
+    .map(([name, amount]) => ({ name, amount }))
+    .sort((a, b) => b.amount - a.amount);
+  return { total, byCategory, otherBreakdown };
+}
+
+/** Convert a raw (microsecond) category decomposition into a shares-first report block. */
+export function buildDecomposition(byName, { topOther = 15 } = {}) {
+  const { total, byCategory, otherBreakdown } = categorize(byName);
+  const pct = (v) => (total ? round((v / total) * 100) : 0);
+  const categories = Object.entries(byCategory)
+    .map(([category, us]) => ({ category, ms: round(us / 1000), pct: pct(us) }))
+    .sort((a, b) => b.ms - a.ms);
+  const other = otherBreakdown
+    .slice(0, topOther)
+    .map(({ name, amount }) => ({ name, ms: round(amount / 1000), pct: pct(amount) }));
+  return { mainThreadMs: round(total / 1000), categories, other };
+}
+
+/* ---- long-task attribution (bonus cross-check, mirrors #4458) ---- */
+
+function tbtContribution(durationMs) {
+  return Math.max(0, (Number(durationMs) || 0) - TBT_THRESHOLD_MS);
+}
+
+export function summarizeLongTasks(entries) {
+  const list = Array.isArray(entries) ? entries : [];
+  const totalMs = list.reduce((s, e) => s + (Number(e?.duration) || 0), 0);
+  const tbtMs = list.reduce((s, e) => s + tbtContribution(e?.duration), 0);
+  const longTaskCount = list.filter((e) => (Number(e?.duration) || 0) > TBT_THRESHOLD_MS).length;
+  return { taskCount: list.length, longTaskCount, totalMs: round(totalMs), tbtMs: round(tbtMs) };
+}
+
+export function parseArgs(argv) {
+  const args = { url: 'https://www.worldmonitor.app/dashboard', cpu: 1, settle: 15000, json: false };
+  const rest = argv.slice(2);
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (a === '--cpu') {
+      const n = Number(rest[++i]);
+      if (!Number.isNaN(n)) args.cpu = n;
+    } else if (a === '--settle') {
+      const n = Number(rest[++i]);
+      if (!Number.isNaN(n)) args.settle = n;
+    } else if (a === '--json') {
+      args.json = true;
+    } else if (!a.startsWith('--')) {
+      args.url = a;
+    }
+  }
+  return args;
+}
+
+const TRACE_CATEGORIES = [
+  'devtools.timeline',
+  'disabled-by-default-devtools.timeline',
+  'disabled-by-default-devtools.timeline.frame',
+  'v8',
+  'v8.execute',
+  'blink.user_timing',
+  'toplevel',
+  'latencyInfo',
+];
+
+/** Read a CDP IO stream to completion, decoding base64 chunks when flagged. */
+async function readTraceStream(client, handle) {
+  let data = '';
+  let eof = false;
+  while (!eof) {
+    const chunk = await client.send('IO.read', { handle, size: 1024 * 1024 });
+    data += chunk.base64Encoded ? Buffer.from(chunk.data, 'base64').toString('utf8') : chunk.data;
+    eof = chunk.eof;
+  }
+  await client.send('IO.close', { handle });
+  return data;
+}
+
+/** Live capture (best-effort). Loads the URL under a desktop viewport + optional CPU throttle and records a trace. */
+async function measure(url, { cpu = 1, settle = 15000 } = {}) {
+  const { chromium } = await import('@playwright/test');
+  const browser = await chromium.launch();
+  try {
+    const context = await browser.newContext({
+      viewport: { width: 1350, height: 940 },
+      deviceScaleFactor: 1,
+      isMobile: false,
+    });
+    const page = await context.newPage();
+    const client = await context.newCDPSession(page);
+    if (cpu > 1) {
+      try {
+        await client.send('Emulation.setCPUThrottlingRate', { rate: cpu });
+      } catch {
+        /* CDP throttle unavailable — continue at host speed */
+      }
+    }
+    await page.addInitScript(() => {
+      window.__longtasks = [];
+      try {
+        new PerformanceObserver((list) => {
+          for (const e of list.getEntries()) {
+            window.__longtasks.push({ name: e.name, duration: e.duration, startTime: e.startTime });
+          }
+        }).observe({ type: 'longtask', buffered: true });
+      } catch {
+        /* longtask unsupported */
+      }
+    });
+    await client.send('Tracing.start', {
+      transferMode: 'ReturnAsStream',
+      traceConfig: { recordMode: 'recordUntilFull', includedCategories: TRACE_CATEGORIES },
+    });
+    await page.goto(url, { waitUntil: 'load', timeout: 60000 });
+    await page.waitForTimeout(settle);
+    const completePromise = new Promise((resolve) => client.once('Tracing.tracingComplete', resolve));
+    await client.send('Tracing.end');
+    const { stream } = await completePromise;
+    const raw = await readTraceStream(client, stream);
+    const trace = JSON.parse(raw);
+    const longtasks = await page.evaluate(() => window.__longtasks || []);
+    return { url, cpu, trace, longtasks };
+  } finally {
+    await browser.close();
+  }
+}
+
+/** Build the structured report (pure — exported for tests). */
+export function buildReport(result) {
+  const events = result?.trace?.traceEvents || (Array.isArray(result?.trace) ? result.trace : []);
+  const mainThread = pickRendererMainThread(events);
+  const complete = normalizeCompleteEvents(events).filter(
+    (e) => !mainThread || `${e.pid}:${e.tid}` === mainThread,
+  );
+  const { byName } = computeSelfTimeByName(complete);
+  const decomposition = buildDecomposition(byName);
+  return {
+    url: result?.url,
+    cpu: result?.cpu,
+    mainThread,
+    ...decomposition,
+    longTasks: summarizeLongTasks(result?.longtasks),
+  };
+}
+
+function printHuman(report) {
+  console.log(`\nDesktop main-thread attribution — ${report.url} (CPU ${report.cpu}x)\n`);
+  console.log(`Main-thread self-time total: ${report.mainThreadMs}ms  (thread ${report.mainThread || 'unknown'})`);
+  console.log(
+    `Long tasks: ${report.longTasks.taskCount} (${report.longTasks.longTaskCount} >50ms)`
+    + ` · total ${report.longTasks.totalMs}ms · TBT ${report.longTasks.tbtMs}ms\n`,
+  );
+  console.log('By category (share of attributed main-thread self-time):');
+  for (const c of report.categories) {
+    console.log(`  ${c.category.padEnd(20)} ${String(c.ms).padStart(9)}ms  (${c.pct}%)`);
+  }
+  console.log('\n"Other" decomposed (top events — this is the #4539 black box):');
+  for (const o of report.other) {
+    console.log(`  ${o.name.padEnd(36)} ${String(o.ms).padStart(9)}ms  (${o.pct}%)`);
+  }
+  console.log('\nNote: absolute ms is host-contention-sensitive (#4486). Trust the RELATIVE');
+  console.log('shares here; take authoritative absolute desktop timings from PageSpeed/Calibre.\n');
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const result = await measure(args.url, { cpu: args.cpu, settle: args.settle });
+  const report = buildReport(result);
+  if (args.json) console.log(JSON.stringify(report, null, 2));
+  else printHuman(report);
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/scripts/measure-desktop-mainthread.mjs
+++ b/scripts/measure-desktop-mainthread.mjs
@@ -64,11 +64,12 @@ const CATEGORY_BY_EVENT = new Map(Object.entries({
   RecalculateStyles: 'styleLayout',
   ScheduleStyleRecalculation: 'styleLayout',
   InvalidateLayout: 'styleLayout',
-  UpdateLayerTree: 'styleLayout',
   HitTest: 'styleLayout',
   ParseAuthorStyleSheet: 'styleLayout',
-  // paint + composite + raster + GPU
+  // paint + composite + raster + GPU (Lighthouse groups layer-tree updates here, not styleLayout)
   Paint: 'paintComposite',
+  UpdateLayerTree: 'paintComposite',
+  UpdateLayer: 'paintComposite',
   PrePaint: 'paintComposite',
   'Composite Layers': 'paintComposite',
   CompositeLayers: 'paintComposite',
@@ -156,6 +157,7 @@ export function pickRendererMainThread(events) {
   if (candidates.size === 0) return null;
   const durByThread = new Map();
   for (const e of events) {
+    if (!e) continue;
     const key = `${e.pid}:${e.tid}`;
     if (!candidates.has(key)) continue;
     if (e.ph === 'X' && typeof e.dur === 'number') durByThread.set(key, (durByThread.get(key) || 0) + e.dur);
@@ -337,7 +339,13 @@ async function measure(url, { cpu = 1, settle = 15000 } = {}) {
     });
     await page.goto(url, { waitUntil: 'load', timeout: 60000 });
     await page.waitForTimeout(settle);
-    const completePromise = new Promise((resolve) => client.once('Tracing.tracingComplete', resolve));
+    // Guard against a dropped CDP session / never-fired tracingComplete: without a
+    // timeout the await below would hang forever and the finally's browser.close()
+    // would never run. Reject after 30s so the error propagates and cleanup happens.
+    const completePromise = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('Tracing.tracingComplete timed out after 30s')), 30000);
+      client.once('Tracing.tracingComplete', (evt) => { clearTimeout(timer); resolve(evt); });
+    });
     await client.send('Tracing.end');
     const { stream } = await completePromise;
     const raw = await readTraceStream(client, stream);

--- a/scripts/measure-desktop-mainthread.mjs
+++ b/scripts/measure-desktop-mainthread.mjs
@@ -29,6 +29,7 @@
 import { pathToFileURL } from 'node:url';
 
 const TBT_THRESHOLD_MS = 50;
+const TRACE_COMPLETE_TIMEOUT_MS = 30000;
 
 function round(n) {
   return Math.round((Number(n) || 0) * 10) / 10;
@@ -148,19 +149,19 @@ export function normalizeCompleteEvents(events) {
  * the top frame is a known limitation). Returns "pid:tid" or null when none found.
  */
 export function pickRendererMainThread(events) {
+  const list = Array.isArray(events) ? events : [];
   const candidates = new Set();
-  for (const e of Array.isArray(events) ? events : []) {
+  for (const e of list) {
     if (e && e.ph === 'M' && e.name === 'thread_name' && e.args?.name === 'CrRendererMain') {
       candidates.add(`${e.pid}:${e.tid}`);
     }
   }
   if (candidates.size === 0) return null;
   const durByThread = new Map();
-  for (const e of events) {
-    if (!e) continue;
+  for (const e of normalizeCompleteEvents(list)) {
     const key = `${e.pid}:${e.tid}`;
     if (!candidates.has(key)) continue;
-    if (e.ph === 'X' && typeof e.dur === 'number') durByThread.set(key, (durByThread.get(key) || 0) + e.dur);
+    if (typeof e.dur === 'number') durByThread.set(key, (durByThread.get(key) || 0) + e.dur);
   }
   let best = null;
   let bestDur = -1;
@@ -299,6 +300,21 @@ async function readTraceStream(client, handle) {
   return data;
 }
 
+function waitForTraceComplete(client, timeoutMs = TRACE_COMPLETE_TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    let timer;
+    const onComplete = (event) => {
+      clearTimeout(timer);
+      resolve(event);
+    };
+    timer = setTimeout(() => {
+      if (typeof client.off === 'function') client.off('Tracing.tracingComplete', onComplete);
+      reject(new Error(`Timed out waiting ${timeoutMs}ms for Tracing.tracingComplete`));
+    }, timeoutMs);
+    client.once('Tracing.tracingComplete', onComplete);
+  });
+}
+
 /** Live capture (best-effort). Loads the URL under a desktop viewport + optional CPU throttle and records a trace. */
 async function measure(url, { cpu = 1, settle = 15000 } = {}) {
   const { chromium } = await import('@playwright/test');
@@ -339,15 +355,10 @@ async function measure(url, { cpu = 1, settle = 15000 } = {}) {
     });
     await page.goto(url, { waitUntil: 'load', timeout: 60000 });
     await page.waitForTimeout(settle);
-    // Guard against a dropped CDP session / never-fired tracingComplete: without a
-    // timeout the await below would hang forever and the finally's browser.close()
-    // would never run. Reject after 30s so the error propagates and cleanup happens.
-    const completePromise = new Promise((resolve, reject) => {
-      const timer = setTimeout(() => reject(new Error('Tracing.tracingComplete timed out after 30s')), 30000);
-      client.once('Tracing.tracingComplete', (evt) => { clearTimeout(timer); resolve(evt); });
-    });
+    const completePromise = waitForTraceComplete(client);
     await client.send('Tracing.end');
     const { stream } = await completePromise;
+    if (!stream) throw new Error('Tracing completed without an IO stream');
     const raw = await readTraceStream(client, stream);
     const trace = JSON.parse(raw);
     const longtasks = await page.evaluate(() => window.__longtasks || []);
@@ -363,10 +374,10 @@ export function buildReport(result) {
   const mainThread = pickRendererMainThread(events);
   const longTasks = summarizeLongTasks(result?.longtasks);
   if (!mainThread) {
-    // No CrRendererMain metadata — we can't isolate one properly-nested thread.
-    // Mixing all threads' (concurrent, non-nested) events into the self-time
-    // stack would violate its precondition and silently emit a plausible-but-
-    // wrong split, so refuse to attribute rather than produce garbage.
+    // No CrRendererMain metadata - we cannot isolate one properly-nested thread.
+    // Mixing all threads' concurrent events into the self-time stack would violate
+    // its precondition, so refuse to attribute rather than emit a plausible but
+    // wrong split.
     return {
       url: result?.url,
       cpu: result?.cpu,
@@ -403,6 +414,10 @@ function printHuman(report) {
   console.log('\n"Other" decomposed (top events — this is the #4539 black box):');
   for (const o of report.other) {
     console.log(`  ${o.name.padEnd(36)} ${String(o.ms).padStart(9)}ms  (${o.pct}%)`);
+  }
+  if (report.warning) {
+    console.log('\nWarnings:');
+    console.log('  ' + report.warning);
   }
   console.log('\nNote: absolute ms is host-contention-sensitive (#4486). Trust the RELATIVE');
   console.log('shares here; take authoritative absolute desktop timings from PageSpeed/Calibre.\n');

--- a/tests/measure-desktop-mainthread.test.mts
+++ b/tests/measure-desktop-mainthread.test.mts
@@ -1,0 +1,100 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  categoryOf,
+  normalizeCompleteEvents,
+  pickRendererMainThread,
+  computeSelfTimeByName,
+  categorize,
+  buildDecomposition,
+  buildReport,
+} from '../scripts/measure-desktop-mainthread.mjs';
+
+// Deterministic fixture (CI-safe, no browser): a CrRendererMain thread (1:1) with
+// nested tasks, plus a quieter second CrRendererMain (1:2) that must be excluded.
+// Durations in microseconds, mirroring a real Chrome trace.
+function fixtureTraceEvents() {
+  return [
+    { ph: 'M', name: 'thread_name', pid: 1, tid: 1, args: { name: 'CrRendererMain' } },
+    { ph: 'M', name: 'thread_name', pid: 1, tid: 2, args: { name: 'CrRendererMain' } },
+    // main thread 1:1 — two top-level RunTasks (scheduler 'other') with nested work
+    { ph: 'X', name: 'RunTask', pid: 1, tid: 1, ts: 0, dur: 1000 },
+    { ph: 'X', name: 'Layout', pid: 1, tid: 1, ts: 100, dur: 300 },
+    { ph: 'X', name: 'UpdateLayoutTree', pid: 1, tid: 1, ts: 150, dur: 100 },
+    { ph: 'X', name: 'FunctionCall', pid: 1, tid: 1, ts: 500, dur: 300 },
+    { ph: 'X', name: 'RunTask', pid: 1, tid: 1, ts: 1000, dur: 500 },
+    { ph: 'X', name: 'MinorGC', pid: 1, tid: 1, ts: 1100, dur: 200 },
+    // quieter thread 1:2 — must be filtered out of the main-thread decomposition
+    { ph: 'X', name: 'FunctionCall', pid: 1, tid: 2, ts: 0, dur: 50 },
+  ];
+}
+
+test('categoryOf maps known events and defaults unknowns to other (#4539)', () => {
+  assert.equal(categoryOf('FunctionCall'), 'scripting');
+  assert.equal(categoryOf('Layout'), 'styleLayout');
+  assert.equal(categoryOf('UpdateLayoutTree'), 'styleLayout');
+  assert.equal(categoryOf('MinorGC'), 'garbageCollection');
+  assert.equal(categoryOf('Paint'), 'paintComposite');
+  assert.equal(categoryOf('RunTask'), 'other');
+  assert.equal(categoryOf('SomeNativeThingWeDoNotMap'), 'other');
+});
+
+test('normalizeCompleteEvents keeps X events and pairs B/E into durations (#4539)', () => {
+  const norm = normalizeCompleteEvents([
+    { ph: 'X', name: 'Layout', pid: 1, tid: 1, ts: 10, dur: 40 },
+    { ph: 'B', name: 'FunctionCall', pid: 1, tid: 1, ts: 100 },
+    { ph: 'E', name: 'FunctionCall', pid: 1, tid: 1, ts: 175 },
+    { ph: 'I', name: 'Instant', pid: 1, tid: 1, ts: 200 },
+    { ph: 'M', name: 'thread_name', pid: 1, tid: 1, args: { name: 'CrRendererMain' } },
+  ]);
+  assert.equal(norm.length, 2);
+  const fn = norm.find((e) => e.name === 'FunctionCall');
+  assert.equal(fn.dur, 75, 'B/E pair yields end-start duration');
+  assert.ok(norm.some((e) => e.name === 'Layout' && e.dur === 40));
+});
+
+test('pickRendererMainThread picks the busiest CrRendererMain (#4539)', () => {
+  assert.equal(pickRendererMainThread(fixtureTraceEvents()), '1:1');
+});
+
+test('computeSelfTimeByName subtracts nested children from parents (#4539)', () => {
+  const main = normalizeCompleteEvents(fixtureTraceEvents()).filter((e) => `${e.pid}:${e.tid}` === '1:1');
+  const { byName, total } = computeSelfTimeByName(main);
+  assert.equal(byName.get('RunTask'), 700, 'RunTask self = 1000-300-300 (task1) + 500-200 (task2)');
+  assert.equal(byName.get('Layout'), 200, 'Layout self = 300 - 100 (UpdateLayoutTree)');
+  assert.equal(byName.get('UpdateLayoutTree'), 100);
+  assert.equal(byName.get('FunctionCall'), 300);
+  assert.equal(byName.get('MinorGC'), 200);
+  assert.equal(total, 1500, 'total self = sum of top-level task durations');
+});
+
+test('categorize folds names into categories and itemizes other (#4539)', () => {
+  const main = normalizeCompleteEvents(fixtureTraceEvents()).filter((e) => `${e.pid}:${e.tid}` === '1:1');
+  const { byName } = computeSelfTimeByName(main);
+  const { total, byCategory, otherBreakdown } = categorize(byName);
+  assert.equal(total, 1500);
+  assert.equal(byCategory.other, 700, 'RunTask scheduler self-time is the black box');
+  assert.equal(byCategory.styleLayout, 300);
+  assert.equal(byCategory.scripting, 300);
+  assert.equal(byCategory.garbageCollection, 200);
+  assert.equal(byCategory.paintComposite, 0);
+  assert.deepEqual(otherBreakdown, [{ name: 'RunTask', amount: 700 }]);
+});
+
+test('buildDecomposition reports ms + shares, other cracked open (#4539)', () => {
+  const main = normalizeCompleteEvents(fixtureTraceEvents()).filter((e) => `${e.pid}:${e.tid}` === '1:1');
+  const { byName } = computeSelfTimeByName(main);
+  const decomp = buildDecomposition(byName);
+  assert.equal(decomp.mainThreadMs, 1.5);
+  const other = decomp.categories.find((c) => c.category === 'other');
+  assert.deepEqual(other, { category: 'other', ms: 0.7, pct: 46.7 });
+  assert.equal(decomp.categories[0].category, 'other', 'sorted by ms desc');
+  assert.deepEqual(decomp.other[0], { name: 'RunTask', ms: 0.7, pct: 46.7 });
+});
+
+test('buildReport filters to the main thread and decomposes end to end (#4539)', () => {
+  const report = buildReport({ url: 'x', cpu: 1, trace: { traceEvents: fixtureTraceEvents() }, longtasks: [] });
+  assert.equal(report.mainThread, '1:1');
+  assert.equal(report.mainThreadMs, 1.5, 'the 1:2 FunctionCall is excluded');
+  assert.equal(report.categories.find((c) => c.category === 'scripting').ms, 0.3);
+});

--- a/tests/measure-desktop-mainthread.test.mts
+++ b/tests/measure-desktop-mainthread.test.mts
@@ -98,3 +98,37 @@ test('buildReport filters to the main thread and decomposes end to end (#4539)',
   assert.equal(report.mainThreadMs, 1.5, 'the 1:2 FunctionCall is excluded');
   assert.equal(report.categories.find((c) => c.category === 'scripting').ms, 0.3);
 });
+
+test('self-time handles ts-tie parent/child and adjacent siblings (guards the dur-desc tiebreak) (#4539)', () => {
+  // Child emitted BEFORE its parent in the array (as Chrome does — the child
+  // completes first) and sharing the parent's start ts. The `dur` desc sort
+  // tiebreak is what keeps the larger interval as the parent; dropping it would
+  // make the child the "parent" and mis-attribute self-time.
+  const { byName, total } = computeSelfTimeByName(
+    normalizeCompleteEvents([
+      { ph: 'X', name: 'Layout', pid: 1, tid: 1, ts: 0, dur: 40 }, // child, ts == parent.ts
+      { ph: 'X', name: 'Paint', pid: 1, tid: 1, ts: 40, dur: 60 }, // sibling, ts == Layout.end (adjacent)
+      { ph: 'X', name: 'RunTask', pid: 1, tid: 1, ts: 0, dur: 100 }, // parent, emitted last
+    ]),
+  );
+  assert.equal(byName.get('RunTask'), 0, 'parent self = 100 - 40 - 60');
+  assert.equal(byName.get('Layout'), 40, 'ts-tie child keeps its full duration');
+  assert.equal(byName.get('Paint'), 60, 'adjacent sibling is not nested under Layout');
+  assert.equal(total, 100);
+});
+
+test('buildReport refuses to attribute when no CrRendererMain thread exists (#4539)', () => {
+  // No thread_name metadata — mixing all threads would corrupt the split, so bail.
+  const report = buildReport({
+    url: 'x',
+    cpu: 1,
+    trace: { traceEvents: [{ ph: 'X', name: 'RunTask', pid: 9, tid: 9, ts: 0, dur: 100 }] },
+    longtasks: [{ duration: 80 }],
+  });
+  assert.equal(report.mainThread, null);
+  assert.equal(report.mainThreadMs, 0);
+  assert.deepEqual(report.categories, []);
+  assert.deepEqual(report.other, []);
+  assert.match(report.warning, /no CrRendererMain/);
+  assert.equal(report.longTasks.longTaskCount, 1, 'long-task summary still reported');
+});

--- a/tests/measure-desktop-mainthread.test.mts
+++ b/tests/measure-desktop-mainthread.test.mts
@@ -29,6 +29,22 @@ function fixtureTraceEvents() {
   ];
 }
 
+function fixtureBeginEndTraceEvents() {
+  return [
+    { ph: 'M', name: 'thread_name', pid: 1, tid: 1, args: { name: 'CrRendererMain' } },
+    { ph: 'M', name: 'thread_name', pid: 1, tid: 2, args: { name: 'CrRendererMain' } },
+    null,
+    { ph: 'B', name: 'RunTask', pid: 1, tid: 1, ts: 0 },
+    { ph: 'B', name: 'Layout', pid: 1, tid: 1, ts: 100 },
+    { ph: 'E', name: 'Layout', pid: 1, tid: 1, ts: 250 },
+    { ph: 'E', name: 'RunTask', pid: 1, tid: 1, ts: 500 },
+    { ph: 'B', name: 'RunTask', pid: 1, tid: 2, ts: 0 },
+    { ph: 'B', name: 'FunctionCall', pid: 1, tid: 2, ts: 10 },
+    { ph: 'E', name: 'FunctionCall', pid: 1, tid: 2, ts: 110 },
+    { ph: 'E', name: 'RunTask', pid: 1, tid: 2, ts: 200 },
+  ];
+}
+
 test('categoryOf maps known events and defaults unknowns to other (#4539)', () => {
   assert.equal(categoryOf('FunctionCall'), 'scripting');
   assert.equal(categoryOf('Layout'), 'styleLayout');
@@ -58,6 +74,10 @@ test('normalizeCompleteEvents keeps X events and pairs B/E into durations (#4539
 
 test('pickRendererMainThread picks the busiest CrRendererMain (#4539)', () => {
   assert.equal(pickRendererMainThread(fixtureTraceEvents()), '1:1');
+});
+
+test('pickRendererMainThread scores normalized B/E events and skips null entries (#4539)', () => {
+  assert.equal(pickRendererMainThread(fixtureBeginEndTraceEvents()), '1:1');
 });
 
 test('computeSelfTimeByName subtracts nested children from parents (#4539)', () => {

--- a/tests/measure-desktop-mainthread.test.mts
+++ b/tests/measure-desktop-mainthread.test.mts
@@ -35,6 +35,9 @@ test('categoryOf maps known events and defaults unknowns to other (#4539)', () =
   assert.equal(categoryOf('UpdateLayoutTree'), 'styleLayout');
   assert.equal(categoryOf('MinorGC'), 'garbageCollection');
   assert.equal(categoryOf('Paint'), 'paintComposite');
+  // Lighthouse groups layer-tree updates under paint/composite, not styleLayout
+  assert.equal(categoryOf('UpdateLayerTree'), 'paintComposite');
+  assert.equal(categoryOf('UpdateLayer'), 'paintComposite');
   assert.equal(categoryOf('RunTask'), 'other');
   assert.equal(categoryOf('SomeNativeThingWeDoNotMap'), 'other');
 });


### PR DESCRIPTION
## Summary

Desktop `/dashboard` main-thread is now **attributed**. 52% (~11 s) of it was an uncharacterized "Other" bucket, so the whole desktop render axis was being driven by the scriptEval proxy (byte-diet / boot-split) — which the field data showed wasn't where the time was. You can't fix what isn't attributed; this cracks the bucket open.

This adds the **desktop twin of the #4458 mobile harness** and, crucially, a different capture: instead of attributing long tasks by container, it records a Chrome DevTools **trace** (CDP) and aggregates renderer main-thread **self-time by trace-event name → category**, then **itemizes "Other" by event name** — because Lighthouse's `mainthread-work-breakdown` reports "Other" as a single black box.

## The finding — "Other" decomposed

| "Other" component | unthrottled (cpu 1) | throttled (cpu 4) | what it is |
|---|---|---|---|
| **`Layerize`** | **27.6% (3.06 s)** | 15.5% | **Compositor layerization** (paint layers → compositing layers). ~half of all "Other", stable across host conditions — the #1 previously-invisible cost. |
| `ThreadControllerImpl::RunTask` | 20.4% | 16.5% | Scheduler task-runner self-time — cost of running *many* tasks; falls as boot-split/INP work cuts task count. |
| IntersectionObserver / GC / mojo | ~7% | ~10% | Housekeeping. |

The category split reproduced the prior lab's **52 / 19 / 19** (Other / StyleLayout / Script) almost exactly, which validates the harness. The issue's "9 s document task with 60 ms script-eval" is now explained: it is `styleLayout` (forced reflow → #4536) + `Layerize` (compositing) + scheduler — **layout + compositing, not app JS**.

## What's in this PR

- `scripts/measure-desktop-mainthread.mjs` — the harness. Pure attribution fns (`normalizeCompleteEvents`, `pickRendererMainThread`, `computeSelfTimeByName`, `categorize`, `buildDecomposition`) are exported and unit-tested; Playwright is lazy so importing the helpers never launches a browser.
- `tests/measure-desktop-mainthread.test.mts` — 7 fixture-based unit tests (deterministic, CI-safe, no jsdom/browser) locking the self-time nesting math and the "Other" itemization.
- `docs/perf/desktop-mainthread-baseline-2026-07-02.md` — the committed baseline (the #4458 twin), methodology, both captures, findings, and the re-measure gate.

## Testing

- 7/7 unit tests pass; `biome lint` clean.
- Ran live against prod `/dashboard` (unthrottled + `--cpu 4`); the category split matched the independently-known 52/19/19, and `Layerize` was a stable top-2 "Other" component in both runs.

Fixes #4539. Related: #4630 (the concrete `Layerize` follow-up this baseline surfaced), #4487 (field CWV umbrella), #4458 (mobile twin).

## Post-Deploy Monitoring & Validation

No runtime/production impact — this is a measurement harness + docs, not shipped app code. `No additional operational monitoring required.` Re-measure guidance lives in the baseline doc: run both harness invocations before/after any compositing-layer change (#4630) and record the `Layerize` share delta; take the authoritative absolute desktop `mainthread-work` from a clean PSI/Calibre run (the harness supplies the relative decomposition, not the headline absolute — KTD1).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
