### PR TITLE
fix(seed): retry air-quality Redis publish so a transient Upstash timeout doesn't fail the health bundle (#4631)

### DIFF
--- a/scripts/seed-health-air-quality.mjs
+++ b/scripts/seed-health-air-quality.mjs
@@ -479,6 +479,7 @@ async function redisPipeline(commands) {
     if (!response.ok) {
       const text = await response.text().catch(() => '');
       const error = new Error(`Redis pipeline failed: HTTP ${response.status} — ${text.slice(0, 200)}`);
+      error.httpStatus = response.status;
       if (PERMANENT_4XX_STATUSES.has(response.status)) {
         error.nonRetryable = true;
       } else if (response.status === 429) {

--- a/scripts/seed-health-air-quality.mjs
+++ b/scripts/seed-health-air-quality.mjs
@@ -8,6 +8,8 @@ import {
   getRedisCredentials,
   loadEnvFile,
   logSeedResult,
+  parseRetryAfterMs,
+  PERMANENT_4XX_STATUSES,
   releaseLock,
   verifySeedKey,
   withRetry,
@@ -461,17 +463,32 @@ export function buildMirrorWriteCommands(payload, ttlSeconds, fetchedAt = Date.n
 
 async function redisPipeline(commands) {
   const { url, token } = getRedisCredentials();
-  const response = await fetch(`${url}/pipeline`, {
-    method: 'POST',
-    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify(commands),
-    signal: AbortSignal.timeout(15_000),
-  });
-  if (!response.ok) {
-    const body = await response.text().catch(() => '');
-    throw new Error(`Redis pipeline failed: HTTP ${response.status} — ${body.slice(0, 200)}`);
-  }
-  return response.json();
+  const body = JSON.stringify(commands);
+  // Retry transient publish failures (Upstash timeouts, 5xx, network resets) so
+  // a single latency spike after a successful fetch doesn't fail the whole
+  // bundle — the fetch already retries, the publish did not. Mirrors
+  // redisCommand()'s tagging: permanent 4xx won't recover (fail fast), 429
+  // honours Retry-After, timeouts/5xx fall through to withRetry's backoff.
+  return withRetry(async () => {
+    const response = await fetch(`${url}/pipeline`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+      body,
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      const error = new Error(`Redis pipeline failed: HTTP ${response.status} — ${text.slice(0, 200)}`);
+      if (PERMANENT_4XX_STATUSES.has(response.status)) {
+        error.nonRetryable = true;
+      } else if (response.status === 429) {
+        const retryAfterMs = parseRetryAfterMs(response.headers.get('retry-after'));
+        if (retryAfterMs != null) error.retryAfterMs = retryAfterMs;
+      }
+      throw error;
+    }
+    return response.json();
+  }, 2, 1_000);
 }
 
 async function publishMirroredPayload(payload) {

--- a/tests/air-quality-seed.test.mjs
+++ b/tests/air-quality-seed.test.mjs
@@ -301,3 +301,95 @@ globalThis.fetch = async (url, init = {}) => {
     }
   });
 });
+
+describe('air quality redis publish resilience', () => {
+  it('retries a transient Redis publish timeout instead of failing the bundle', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'wm-air-quality-publish-'));
+    const preloadPath = join(tempDir, 'preload.mjs');
+    const redisUrl = 'https://fake-upstash.local';
+    writeFileSync(preloadPath, `
+// Collapse withRetry's exponential backoff sleeps so the retry path runs
+// without the wall-clock wait (see the graceful-failure test above for why this
+// is side-effect free in the spawned child).
+const __origSetTimeout = globalThis.setTimeout;
+globalThis.setTimeout = (fn, ms, ...rest) => __origSetTimeout(fn, typeof ms === 'number' && ms > 25 ? 0 : ms, ...rest);
+process.env.UPSTASH_REDIS_REST_URL = ${JSON.stringify(redisUrl)};
+process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+process.env.OPENAQ_API_KEY = 'fake-openaq-key';
+delete process.env.WAQI_API_KEY;
+
+let pipelineCalls = 0;
+globalThis.fetch = async (url, init = {}) => {
+  const href = String(url);
+  // OpenAQ fetch succeeds with a single fresh PM2.5 station so the seed reaches
+  // the publish step.
+  if (href.startsWith('https://api.openaq.org/v3/locations')) {
+    return new Response(JSON.stringify({
+      meta: { found: 1, limit: 1000 },
+      results: [{ id: 101, locality: 'Delhi', country: { code: 'IN' }, coordinates: { latitude: 28.61, longitude: 77.21 } }],
+    }), { status: 200 });
+  }
+  if (href.startsWith('https://api.openaq.org/v3/parameters/2/latest')) {
+    return new Response(JSON.stringify({
+      meta: { found: 1, limit: 1000 },
+      results: [{
+        locationsId: 101,
+        value: 82.4,
+        datetime: { utc: new Date(Date.now() - (10 * 60 * 1000)).toISOString() },
+        coordinates: { latitude: 28.61, longitude: 77.21 },
+        parameter: { name: 'pm25' },
+      }],
+    }), { status: 200 });
+  }
+  // The mirror publish: abort with a timeout on the first attempt (the exact
+  // failure that turned the bundle red), then succeed on the retry.
+  if (href === ${JSON.stringify(`${redisUrl}/pipeline`)}) {
+    pipelineCalls += 1;
+    if (pipelineCalls === 1) {
+      throw new Error('The operation was aborted due to timeout');
+    }
+    const commands = init.body ? JSON.parse(init.body) : [];
+    return new Response(JSON.stringify(commands.map(() => ({ result: 'OK' }))), { status: 200 });
+  }
+  // Lock acquire/release (single-command REST endpoint).
+  if (href === ${JSON.stringify(redisUrl)}) {
+    return new Response(JSON.stringify({ result: 'OK' }), { status: 200 });
+  }
+  // Verification read.
+  if (href.startsWith(${JSON.stringify(`${redisUrl}/get/`)})) {
+    return new Response(JSON.stringify({ result: JSON.stringify({ stations: [{}], fetchedAt: 1 }) }), { status: 200 });
+  }
+  return new Response(JSON.stringify({ result: null }), { status: 200 });
+};
+`);
+
+    try {
+      const scriptPath = fileURLToPath(new URL('../scripts/seed-health-air-quality.mjs', import.meta.url));
+      const result = await new Promise((resolve) => {
+        const child = spawn(process.execPath, ['--import', preloadPath, scriptPath], {
+          env: {
+            ...process.env,
+            UPSTASH_REDIS_REST_URL: redisUrl,
+            UPSTASH_REDIS_REST_TOKEN: 'fake-token',
+            OPENAQ_API_KEY: 'fake-openaq-key',
+            WAQI_API_KEY: '',
+          },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', (chunk) => { stdout += chunk; });
+        child.stderr.on('data', (chunk) => { stderr += chunk; });
+        child.on('close', (code) => resolve({ code, stdout, stderr }));
+      });
+
+      const combined = result.stdout + result.stderr;
+      assert.equal(result.code, 0);
+      assert.match(combined, /Retry 1\/2 in \d+ms: The operation was aborted due to timeout/);
+      assert.match(combined, /=== Done \(/);
+      assert.doesNotMatch(combined, /FATAL:/);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Closes #4631.

## Why

`seed-bundle-health` went red on the 2026-07-02 02:03 UTC run:

```
[Air-Quality] FATAL: The operation was aborted due to timeout
[Air-Quality] Failed after 74.1s: exit 1
[Bundle:health] section=Air-Quality status=FAILED elapsed=74.1s reason=exit 1
```

7 of the 8 runs in the same window were green. The OpenAQ **fetch** path is resilient — it retries (2+2) and, on exhaustion, exits **gracefully** (code 75 → `GRACEFUL_FAIL`). The **publish** path was not: `redisPipeline()` did a single `fetch` with `AbortSignal.timeout(15_000)` and **no retry**. After a slow-but-successful fetch, a transient Upstash latency spike throws *"operation aborted due to timeout"*, which propagates past the fetch handler to the top-level `main().catch` → `FATAL:` + `exit 1` → the bundle runner reports `FAILED` and the cron exits non-zero.

The `FATAL:`/`exit 1` signature (not `FETCH FAILED`/exit 75) confirms the abort came from the post-fetch publish.

## What

- Wrap `redisPipeline` in the shared `withRetry` (2 retries, exp backoff), mirroring `_seed-utils.mjs` `redisCommand()`'s error tagging:
  - `PERMANENT_4XX_STATUSES` → `nonRetryable` (fail fast on misconfig)
  - `429` → honour `Retry-After`
  - timeouts / 5xx / network resets → backoff and retry
- Hoist the ~1 MB body `JSON.stringify` out of the retry closure.
- Worst case ≈ 3 × 15s + 3s backoff ≈ 48s, well within the section's `timeoutMs: 600_000`.

## Test

New test in `tests/air-quality-seed.test.mjs` spawns the real seeder with a mocked transport: OpenAQ succeeds, the first `/pipeline` write aborts with a timeout. Asserts the seed **retries and exits 0**. Verified it fails with `exit 1` against the un-retried code, passes with the fix. Full air-quality suite (11 tests) green under both `node --test` and `tsx --test`; biome lint clean.

_Unrelated:_ `WAQI_API_KEY missing; skipping WAQI supplement` in the same logs is an optional-by-design source skip, not a failure.

https://claude.ai/code/session_015JDDQ3XmSyWE5sJz7DAqx2