### PR TITLE
perf(attribution): desktop main-thread baseline — decompose the 'Other' bucket (#4539)

### DIFF
--- a/docs/perf/desktop-mainthread-baseline-2026-07-02.md
+++ b/docs/perf/desktop-mainthread-baseline-2026-07-02.md
@@ -1,0 +1,66 @@
+# Desktop main-thread baseline — 2026-07-02 (#4539)
+
+The committed desktop main-thread attribution for the render axis (`#4487`). The desktop sibling of
+`docs/perf/mobile-mainthread-baseline-2026-06-27.md` (#4443). Its point: **decompose the
+uncharacterized "Other" bucket** (52% of desktop main-thread per #4539) so the render axis is driven
+by evidence, not the scriptEval proxy.
+
+## How to measure
+
+Two signals, same contamination discipline as mobile (**KTD3 / #4486** — the local lab host 4×-amplifies
+CPU contention; the same URL scores 28/57/85, so **absolute times are indicative, not authoritative —
+trust the proportions + structure**, both stable run-to-run):
+
+1. **Attribution → `scripts/measure-desktop-mainthread.mjs`** (this harness — Playwright desktop
+   viewport + a CDP `devtools.timeline` trace). It reports long-task-by-source (reused from the mobile
+   harness) **and** decomposes the main-thread trace by event name — including breaking open "Other".
+   Self-time subtracts nested children, so a `RunTask` containing a `Layout` isn't double-counted.
+2. **Authoritative absolutes → PSI-desktop / a clean host.** As on mobile, take absolute TBT /
+   `mainthread-work` from a zero-contention host, not this lab.
+
+```bash
+node scripts/measure-desktop-mainthread.mjs https://worldmonitor.app/dashboard --cpu 1 --settle 12000 --json
+# --cpu 4 for a throttled pass; the proportions hold across throttle levels.
+```
+
+## Captured baseline (2026-07-02, `/dashboard`, unthrottled fast host — proportions authoritative)
+
+Main-thread self-time total: **8,579 ms** (this run; the host is fast + unthrottled, so absolutes are
+far below the #4539 lab figure of 21.3 s — **the proportions are the signal**, and they match the
+issue's Lighthouse split: "Other" ~47% here vs ~52% there).
+
+| Category | ms | % | Owner / note |
+|---|---|---|---|
+| **Other** (decomposed below) | 4,056 | **47.3%** | the #4539 black box — now opened |
+| **Style & Layout** | 2,485 | **29.0%** | forced-reflow — **owned by #4536** |
+| Rendering (paint/composite/raster) | 1,713 | 20.0% | — |
+| Script Evaluation | 269 | 3.1% | **confirms scriptEval is NOT the desktop cost** |
+| Parse | 54 | 0.6% | — |
+| Garbage Collection | 2 | 0.0% | — |
+
+### "Other" decomposed by event (the deliverable)
+
+| Event | ms | % of main-thread | Actionable? |
+|---|---|---|---|
+| **`RunTask`** (top-level task self-time) | 3,122 | **36.4%** | This is the "~9 s document task" #4539 described — browser task-scheduling / native work *not* attributed to any named child. Not app JS. Reducing it = fewer/smaller top-level tasks (yield/batch) — overlaps **#4537 INP**. |
+| `HandlePostMessage` | 296 | 3.5% | worker/message-channel traffic — audit volume |
+| **`IntersectionObserverController::computeIntersections`** | 173 | 2.0% | **cleanest new lever** — the viewport/lazy-load observers recompute intersections on scroll/layout; likely over-observing |
+| `UpdateLayer` | 110 | 1.3% | compositor layer churn |
+| `v8.evaluateModule` | 86 | 1.0% | module eval (ties to the #4571 bundle work) |
+| `FireIdleCallback` / `TimerFire` | ~72 | 0.8% | deferred work firing |
+| `HitTest`, `EventDispatch`, GC-scavenger | ~90 | ~1.0% | small; not levers |
+
+## Findings → follow-ups (the #4539 acceptance)
+
+1. **The desktop render axis is real and script-eval is not it** (3.1%). The cost is `RunTask`
+   self-time (36%) + Style&Layout (29%) + Rendering (20%). The open scriptEval/bytes campaign is not
+   where the time is — **confirmed by attribution**, as the issue predicted.
+2. **`RunTask` self-time (36%) is the "9 s document task"** — top-level task overhead, browser-internal.
+   The lever is fewer/smaller synchronous top-level tasks (yield-to-main / batching), which is the
+   **#4537 INP** axis; cross-linked rather than a new lever here.
+3. **Style & Layout (29%)** → **#4536** (forced reflow) already owns it; no duplicate filed.
+4. **`IntersectionObserverController::computeIntersections` (2%)** is the cleanest *new* actionable
+   sub-bucket → **filed as a sized follow-up** (audit the viewport/lazy observers for over-firing).
+
+> Re-run on a clean host (or PSI-desktop) for authoritative absolute ms before sizing a fix by
+> absolute time; the proportions above are stable and sufficient to pick the lever.

--- a/scripts/measure-desktop-mainthread.mjs
+++ b/scripts/measure-desktop-mainthread.mjs
@@ -184,10 +184,11 @@ async function measure(url, { cpu = 1, settle = 15000 } = {}) {
       }
     });
     // Category-filtered tracing keeps the payload reviewable while retaining the
-    // devtools.timeline events decomposeTraceEvents classifies.
+    // devtools.timeline events decomposeTraceEvents classifies. Default
+    // transferMode (ReportEvents) delivers events via Tracing.dataCollected —
+    // must NOT be ReturnAsStream, which delivers via an IO stream handle instead.
     await client.send('Tracing.start', {
       traceConfig: { includedCategories: ['devtools.timeline', 'disabled-by-default-devtools.timeline', '__metadata'] },
-      transferMode: 'ReturnAsStream',
     });
     await page.goto(url, { waitUntil: 'load', timeout: 60000 });
     await page.waitForTimeout(settle);

--- a/scripts/measure-desktop-mainthread.mjs
+++ b/scripts/measure-desktop-mainthread.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+/**
+ * Desktop main-thread attribution harness (#4539 / U1+U2).
+ *
+ * Loads /dashboard under desktop emulation and attributes:
+ *   - long tasks (PerformanceObserver 'longtask') by source — reuses the mobile
+ *     harness's pure functions (#4443).
+ *   - the main-thread trace, decomposed by event name, so the opaque Lighthouse
+ *     "Other" bucket is broken open (Layout / HitTest / EventDispatch / GC /
+ *     native RunTask document work) — the #4539 gap.
+ *
+ * The pure attribution/decomposition functions are exported and unit-tested with
+ * fixtures (deterministic, CI-safe). Playwright is loaded lazily so importing this
+ * module for its helpers never launches a browser.
+ *
+ * Why (KTD3, #4486): the desktop lab host is contention-contaminated (the same
+ * URL scores 28/57/85). Trust the *relative decomposition* (proportions) + the
+ * long-task structure — both stable run-to-run. Take absolute desktop timings
+ * from a clean host (PSI-desktop / a clean machine), not the lab.
+ *
+ * Usage:
+ *   node scripts/measure-desktop-mainthread.mjs [url] [--cpu 1] [--settle 15000] [--json]
+ *   (default url: https://worldmonitor.app/dashboard)
+ */
+import { pathToFileURL } from 'node:url';
+import { summarizeLongTasks } from './measure-mobile-mainthread.mjs';
+
+function round(n) {
+  return Math.round((Number(n) || 0) * 10) / 10;
+}
+
+// Map DevTools trace event names to the Lighthouse mainthread-work-breakdown
+// groups. Any name NOT here falls into "other" — which is exactly the bucket
+// #4539 needs opened, so "other" keeps its per-name breakdown.
+const CATEGORY_BY_NAME = {
+  // Script evaluation
+  FunctionCall: 'scriptEval', EvaluateScript: 'scriptEval', 'v8.compile': 'scriptEval',
+  'v8.run': 'scriptEval', RunMicrotasks: 'scriptEval', V8Execute: 'scriptEval',
+  // Style & Layout
+  Layout: 'styleLayout', UpdateLayoutTree: 'styleLayout', UpdateLayerTree: 'styleLayout',
+  InvalidateLayout: 'styleLayout', ScheduleStyleRecalculation: 'styleLayout',
+  RecalculateStyles: 'styleLayout',
+  // Rendering / paint
+  Paint: 'rendering', PrePaint: 'rendering', Layerize: 'rendering', PaintImage: 'rendering',
+  CompositeLayers: 'rendering', 'Composite Layers': 'rendering', RasterTask: 'rendering',
+  Commit: 'rendering',
+  // Garbage collection
+  MinorGC: 'gc', MajorGC: 'gc', 'V8.GCScavenger': 'gc', 'V8.GCFinalizeMC': 'gc',
+  'V8.GCIncrementalMarking': 'gc',
+  // Parse
+  ParseHTML: 'parse', ParseAuthorStyleSheet: 'parse',
+};
+
+/** The renderer main-thread tid, from the trace's `thread_name` metadata (CrRendererMain). */
+export function findMainThreadTid(traceEvents) {
+  for (const e of Array.isArray(traceEvents) ? traceEvents : []) {
+    if (e?.ph === 'M' && e?.name === 'thread_name' && e?.args?.name === 'CrRendererMain') {
+      return e.tid;
+    }
+  }
+  return null;
+}
+
+/**
+ * Self-time per complete ('X') event on the main thread. Self-time = duration
+ * minus the duration of directly-nested children, so a RunTask containing a
+ * Layout isn't double-counted. Returns a Map(event -> selfMs). Pure.
+ */
+export function computeSelfTimes(events) {
+  const list = (Array.isArray(events) ? events : [])
+    .filter((e) => e && e.ph === 'X' && typeof e.ts === 'number' && typeof e.dur === 'number');
+  // Parents sort before their children: earlier ts first, and for equal ts the
+  // longer (containing) event first.
+  const sorted = list.slice().sort((a, b) => a.ts - b.ts || b.dur - a.dur);
+  const self = new Map();
+  const stack = [];
+  for (const e of sorted) {
+    self.set(e, e.dur);
+    while (stack.length && stack[stack.length - 1].ts + stack[stack.length - 1].dur <= e.ts) {
+      stack.pop();
+    }
+    const parent = stack[stack.length - 1];
+    if (parent) self.set(parent, self.get(parent) - e.dur);
+    stack.push(e);
+  }
+  return self;
+}
+
+/**
+ * Decompose main-thread trace events into the Lighthouse category groups, with
+ * the residual "other" bucket broken out by event name (the #4539 deliverable).
+ * `mainThreadTid` defaults to the CrRendererMain thread found in the trace.
+ * Durations are microseconds in the trace → reported as ms. Pure.
+ */
+export function decomposeTraceEvents(traceEvents, opts = {}) {
+  const events = Array.isArray(traceEvents) ? traceEvents : [];
+  const tid = opts.mainThreadTid ?? findMainThreadTid(events);
+  const mainEvents = tid == null ? events : events.filter((e) => e?.tid === tid);
+  const self = computeSelfTimes(mainEvents);
+
+  const byCategory = { scriptEval: 0, styleLayout: 0, rendering: 0, gc: 0, parse: 0, other: 0 };
+  const otherByName = new Map();
+  let totalUs = 0;
+  for (const [event, selfUs] of self.entries()) {
+    if (!(selfUs > 0)) continue;
+    totalUs += selfUs;
+    const category = CATEGORY_BY_NAME[event.name] || 'other';
+    byCategory[category] += selfUs;
+    if (category === 'other') {
+      otherByName.set(event.name, (otherByName.get(event.name) || 0) + selfUs);
+    }
+  }
+
+  const usToMs = (us) => round(us / 1000);
+  const pct = (us) => (totalUs ? round((us / totalUs) * 100) : 0);
+  const totalMs = usToMs(totalUs);
+  return {
+    totalMs,
+    byCategory: Object.fromEntries(
+      Object.entries(byCategory).map(([k, us]) => [k, { ms: usToMs(us), pct: pct(us) }]),
+    ),
+    // The "Other" decomposition, ranked — the sub-buckets #4539 wants surfaced.
+    otherBreakdown: [...otherByName.entries()]
+      .map(([name, us]) => ({ name, ms: usToMs(us), pct: pct(us) }))
+      .sort((a, b) => b.ms - a.ms),
+  };
+}
+
+export function parseArgs(argv) {
+  const args = { url: 'https://worldmonitor.app/dashboard', cpu: 1, settle: 15000, json: false };
+  const rest = argv.slice(2);
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (a === '--cpu') {
+      const n = Number(rest[++i]);
+      if (!Number.isNaN(n)) args.cpu = n;
+    } else if (a === '--settle') {
+      const n = Number(rest[++i]);
+      if (!Number.isNaN(n)) args.settle = n;
+    } else if (a === '--json') {
+      args.json = true;
+    } else if (!a.startsWith('--')) {
+      args.url = a;
+    }
+  }
+  return args;
+}
+
+/** Live capture (best-effort). Desktop viewport; captures longtasks + a CDP trace. */
+async function measure(url, { cpu = 1, settle = 15000 } = {}) {
+  const { chromium } = await import('@playwright/test');
+  const browser = await chromium.launch();
+  try {
+    const context = await browser.newContext({ viewport: { width: 1440, height: 900 } });
+    const page = await context.newPage();
+    const client = await context.newCDPSession(page);
+    if (cpu > 1) {
+      try {
+        await client.send('Emulation.setCPUThrottlingRate', { rate: cpu });
+      } catch {
+        /* CDP throttle unavailable — continue at host speed */
+      }
+    }
+    await page.addInitScript(() => {
+      window.__longtasks = [];
+      try {
+        new PerformanceObserver((list) => {
+          for (const e of list.getEntries()) {
+            window.__longtasks.push({
+              name: e.name,
+              duration: e.duration,
+              startTime: e.startTime,
+              attribution: (e.attribution || []).map((a) => ({
+                name: a.name,
+                containerType: a.containerType,
+                containerName: a.containerName,
+                containerSrc: a.containerSrc,
+              })),
+            });
+          }
+        }).observe({ type: 'longtask', buffered: true });
+      } catch {
+        /* longtask unsupported */
+      }
+    });
+    // Category-filtered tracing keeps the payload reviewable while retaining the
+    // devtools.timeline events decomposeTraceEvents classifies.
+    await client.send('Tracing.start', {
+      traceConfig: { includedCategories: ['devtools.timeline', 'disabled-by-default-devtools.timeline', '__metadata'] },
+      transferMode: 'ReturnAsStream',
+    });
+    await page.goto(url, { waitUntil: 'load', timeout: 60000 });
+    await page.waitForTimeout(settle);
+    const traceEvents = await collectTrace(client);
+    const longtasks = await page.evaluate(() => window.__longtasks || []);
+    return { url, cpu, longtasks, traceEvents };
+  } finally {
+    await browser.close();
+  }
+}
+
+/** Drain the CDP tracing stream into a traceEvents array. */
+async function collectTrace(client) {
+  const events = [];
+  const done = new Promise((resolve) => {
+    client.on('Tracing.dataCollected', (payload) => {
+      if (Array.isArray(payload?.value)) events.push(...payload.value);
+    });
+    client.on('Tracing.tracingComplete', () => resolve());
+  });
+  await client.send('Tracing.end');
+  await done;
+  return events;
+}
+
+/** Build the structured report (pure — exported for tests). */
+export function buildReport(result) {
+  return {
+    url: result?.url,
+    cpu: result?.cpu,
+    tasks: summarizeLongTasks(result?.longtasks),
+    mainThread: decomposeTraceEvents(result?.traceEvents),
+  };
+}
+
+function printHuman(report) {
+  const { tasks, mainThread } = report;
+  console.log(`\nDesktop main-thread attribution — ${report.url} (CPU ${report.cpu}x)\n`);
+  console.log(
+    `Long tasks: ${tasks.taskCount} (${tasks.longTaskCount} >50ms) · total ${tasks.totalMs}ms · TBT ${tasks.tbtMs}ms`,
+  );
+  for (const r of tasks.ranked) {
+    console.log(`  ${String(r.source).padEnd(28)} TBT ${String(r.tbtMs).padStart(7)}ms  (${r.count}× · max ${r.maxMs}ms)`);
+  }
+  console.log(`\nMain-thread by category (${mainThread.totalMs}ms total, proportions are the stable signal):`);
+  for (const [cat, v] of Object.entries(mainThread.byCategory)) {
+    console.log(`  ${cat.padEnd(14)} ${String(v.ms).padStart(8)}ms  (${v.pct}%)`);
+  }
+  console.log('\n"Other" decomposed by event (the #4539 black box):');
+  for (const r of mainThread.otherBreakdown.slice(0, 12)) {
+    console.log(`  ${String(r.name).padEnd(26)} ${String(r.ms).padStart(8)}ms  (${r.pct}%)`);
+  }
+  console.log('');
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const result = await measure(args.url, { cpu: args.cpu, settle: args.settle });
+  const report = buildReport(result);
+  if (args.json) console.log(JSON.stringify(report, null, 2));
+  else printHuman(report);
+}
+
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/tests/measure-desktop-mainthread.test.mts
+++ b/tests/measure-desktop-mainthread.test.mts
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import {
+  buildReport,
+  computeSelfTimes,
+  decomposeTraceEvents,
+  findMainThreadTid,
+  parseArgs,
+} from '../scripts/measure-desktop-mainthread.mjs';
+
+// A settled main-thread task: RunTask(100ms) containing Layout(30) + HitTest(10)
+// + FunctionCall(20). Durations are microseconds (trace units). A RasterTask on a
+// different thread must be excluded once the main-thread tid is resolved.
+const TRACE = [
+  { ph: 'M', name: 'thread_name', tid: 1, args: { name: 'CrRendererMain' } },
+  { ph: 'M', name: 'thread_name', tid: 2, args: { name: 'Compositor' } },
+  { ph: 'X', name: 'RunTask', tid: 1, ts: 1_000, dur: 100_000 },
+  { ph: 'X', name: 'Layout', tid: 1, ts: 1_000, dur: 30_000 },
+  { ph: 'X', name: 'HitTest', tid: 1, ts: 31_000, dur: 10_000 },
+  { ph: 'X', name: 'FunctionCall', tid: 1, ts: 41_000, dur: 20_000 },
+  { ph: 'X', name: 'RasterTask', tid: 2, ts: 1_000, dur: 500_000 },
+];
+
+describe('findMainThreadTid (#4539 U2)', () => {
+  it('resolves CrRendererMain from thread_name metadata; null when absent', () => {
+    assert.equal(findMainThreadTid(TRACE), 1);
+    assert.equal(findMainThreadTid([{ ph: 'M', name: 'thread_name', tid: 9, args: { name: 'Other' } }]), null);
+    assert.equal(findMainThreadTid(null), null);
+  });
+});
+
+describe('computeSelfTimes (#4539 U2)', () => {
+  it('subtracts nested children so no time is double-counted', () => {
+    const self = computeSelfTimes(TRACE.filter((e) => e.tid === 1 && e.ph === 'X'));
+    const byName = new Map([...self.entries()].map(([e, us]) => [e.name, us]));
+    assert.equal(byName.get('RunTask'), 40_000, 'RunTask self = 100 - (30+10+20)');
+    assert.equal(byName.get('Layout'), 30_000);
+    assert.equal(byName.get('HitTest'), 10_000);
+    assert.equal(byName.get('FunctionCall'), 20_000);
+    // Self-times sum to the top-level task duration (no over-count).
+    assert.equal([...self.values()].reduce((a, b) => a + b, 0), 100_000);
+  });
+
+  it('ignores instant/duration-less and non-complete events', () => {
+    const self = computeSelfTimes([
+      { ph: 'X', name: 'A', ts: 0, dur: 10 },
+      { ph: 'B', name: 'begin', ts: 0 }, // not a complete event
+      { ph: 'X', name: 'NoTs', dur: 5 }, // missing ts
+    ]);
+    assert.equal(self.size, 1);
+  });
+});
+
+describe('decomposeTraceEvents (#4539 U2)', () => {
+  it('categorizes by name and opens the Other bucket by event, main-thread only', () => {
+    const d = decomposeTraceEvents(TRACE);
+    assert.equal(d.totalMs, 100, 'RasterTask on the compositor thread is excluded');
+    assert.equal(d.byCategory.styleLayout.ms, 30);
+    assert.equal(d.byCategory.scriptEval.ms, 20);
+    assert.equal(d.byCategory.other.ms, 50, 'RunTask(40) + HitTest(10)');
+    // proportions sum to ~100%
+    const pctSum = Object.values(d.byCategory).reduce((s, v) => s + v.pct, 0);
+    assert.ok(Math.abs(pctSum - 100) < 0.5, `category proportions ~100% (got ${pctSum})`);
+    // the "Other" black box is decomposed by event, ranked
+    assert.deepEqual(d.otherBreakdown.map((r) => r.name), ['RunTask', 'HitTest']);
+    assert.equal(d.otherBreakdown[0].ms, 40);
+  });
+
+  it('an unmapped event name lands in Other (never silently dropped)', () => {
+    const d = decomposeTraceEvents([
+      { ph: 'M', name: 'thread_name', tid: 1, args: { name: 'CrRendererMain' } },
+      { ph: 'X', name: 'SomeFutureEvent', tid: 1, ts: 0, dur: 5_000 },
+    ]);
+    assert.equal(d.byCategory.other.ms, 5);
+    assert.equal(d.otherBreakdown[0].name, 'SomeFutureEvent');
+  });
+
+  it('empty/invalid trace yields a zeroed decomposition without throwing', () => {
+    const d = decomposeTraceEvents([]);
+    assert.equal(d.totalMs, 0);
+    assert.deepEqual(d.otherBreakdown, []);
+    assert.equal(d.byCategory.other.pct, 0);
+  });
+});
+
+describe('parseArgs (#4539 U1)', () => {
+  it('desktop defaults (cpu 1, /dashboard) and overrides', () => {
+    assert.deepEqual(parseArgs(['node', 's']), {
+      url: 'https://worldmonitor.app/dashboard', cpu: 1, settle: 15000, json: false,
+    });
+    const a = parseArgs(['node', 's', 'https://x.test/p', '--cpu', '4', '--settle', '9000', '--json']);
+    assert.equal(a.url, 'https://x.test/p');
+    assert.equal(a.cpu, 4);
+    assert.equal(a.settle, 9000);
+    assert.equal(a.json, true);
+  });
+});
+
+describe('buildReport (#4539 U1+U2)', () => {
+  it('combines long-task attribution with the main-thread decomposition', () => {
+    const report = buildReport({
+      url: 'https://x.test/dashboard',
+      cpu: 1,
+      longtasks: [{ name: 'self', duration: 120, attribution: [{ containerName: 'panels' }] }],
+      traceEvents: TRACE,
+    });
+    assert.equal(report.url, 'https://x.test/dashboard');
+    assert.equal(report.tasks.taskCount, 1);
+    assert.equal(report.tasks.tbtMs, 70); // 120 - 50
+    assert.equal(report.mainThread.byCategory.other.ms, 50);
+  });
+});
+
+describe('module import safety (#4539 KTD1)', () => {
+  it('importing the module for its helpers launched no browser (this test ran)', () => {
+    // If the top-level import had launched Playwright, this file would hang/fail
+    // before reaching here. Reaching this assertion proves the invokedDirectly guard.
+    assert.equal(typeof decomposeTraceEvents, 'function');
+  });
+});


### PR DESCRIPTION
## Summary

Closes the #4539 meta-gap: 52% of desktop main-thread was uncharacterized "Other". This adds the **desktop main-thread attribution harness** (sibling of the #4458 mobile one) and — the capability the mobile harness lacked — **decomposes the opaque "Other" bucket from raw CDP trace events**, commits a desktop baseline, and files a sized follow-up.

## What the attribution found (the deliverable)

A real `/dashboard` capture, decomposed (proportions are the stable signal per #4486; absolutes are from a fast unthrottled host, hence below the lab's 21.3s):

| Category | % of main-thread |
|---|---|
| **Other** | **47.3%** (matches the issue's ~52%) |
| Style & Layout | 29.0% (→ **#4536** forced-reflow) |
| Rendering | 20.0% |
| **Script Evaluation** | **3.1%** — script-eval is NOT the desktop cost, as #4539 predicted |

**"Other" decomposed:** dominated by **`RunTask` self-time (36.4%)** — the "~9s document task" = browser task-scheduling/native overhead, *not* app JS (→ **#4537** yield-to-main). The cleanest *new* actionable sub-bucket is **`IntersectionObserver::computeIntersections` (2%)** → filed **#4637**.

## Units
- **U1+U2** — `scripts/measure-desktop-mainthread.mjs` (reuses the mobile long-task fns; adds `decomposeTraceEvents` with self-time computation that subtracts nested children so a `RunTask` containing a `Layout` isn't double-counted) + `tests/measure-desktop-mainthread.test.mts` (9 fixture cases, CI-safe: Playwright lazy-imported, no browser in CI).
- **U3** — committed baseline `docs/perf/desktop-mainthread-baseline-2026-07-02.md`; follow-up **#4637**. Running the harness for real caught + fixed a live trace-capture bug (`Tracing.start` `ReturnAsStream` vs the `dataCollected` collector — mutually exclusive).

## Test plan
- `tsx --test tests/measure-desktop-mainthread.test.mts` — 9 pass (self-time no-double-count, "Other" decomposition, category mapping, main-thread-tid filter, import-safety).
- `tsc --noEmit` clean; biome clean.
- Real `/dashboard` capture populated the baseline; re-run on a clean host for authoritative absolutes (noted in the doc).

Closes #4539. Part of #4487.

https://claude.ai/code/session_011htsYLErqJb922Qm9QLraN