### PR TITLE
fix(prefs): enforce cloud preference write limits

### DIFF
--- a/api/_convex-error.js
+++ b/api/_convex-error.js
@@ -144,6 +144,7 @@ export function extractConvexErrorKind(err, msg) {
   // through to the unknown/500 path.
   if (isOpaqueConvexServerError(msg)) return 'SERVICE_UNAVAILABLE';
   if (msg.includes('CONFLICT')) return 'CONFLICT';
+  if (msg.includes('RATE_LIMITED')) return 'RATE_LIMITED';
   if (msg.includes('BLOB_TOO_LARGE')) return 'BLOB_TOO_LARGE';
   if (msg.includes('UNAUTHENTICATED')) return 'UNAUTHENTICATED';
   return null;

--- a/api/_cors.js
+++ b/api/_cors.js
@@ -34,6 +34,9 @@ const EXPOSED_HEADERS = [
   'Mcp-Session-Id',
   'WWW-Authenticate',
   'Retry-After',
+  'X-RateLimit-Limit',
+  'X-RateLimit-Remaining',
+  'X-RateLimit-Reset',
 ].join(', ');
 
 function isAllowedOrigin(origin) {

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -63,6 +63,27 @@ export function __setUserPrefsDepsForTests(overrides: Partial<UserPrefsDeps> | n
     : createDefaultUserPrefsDeps();
 }
 
+type SetPreferencesResult =
+  | { ok: true; syncVersion: number }
+  | { ok: false; reason: 'CONFLICT'; actualSyncVersion: number }
+  | { ok: false; reason: 'BLOB_TOO_LARGE'; size: number; max: number }
+  | { ok: false; reason: 'RATE_LIMITED'; limit: number; reset: number };
+
+function rateLimitHeaders(
+  cors: Record<string, string>,
+  limit: number,
+  reset: number,
+): Record<string, string> {
+  const retryAfter = Math.max(1, Math.ceil((reset - Date.now()) / 1000));
+  return {
+    ...cors,
+    'X-RateLimit-Limit': String(limit),
+    'X-RateLimit-Remaining': '0',
+    'X-RateLimit-Reset': String(reset),
+    'Retry-After': String(retryAfter),
+  };
+}
+
 export default async function handler(
   req: Request,
   ctx?: { waitUntil: (p: Promise<unknown>) => void },
@@ -224,20 +245,22 @@ export default async function handler(
       data: body.data,
       expectedSyncVersion: body.expectedSyncVersion,
       schemaVersion: typeof body.schemaVersion === 'number' ? body.schemaVersion : undefined,
-    })) as
-      | { ok: true; syncVersion: number }
-      | { ok: false; reason: 'CONFLICT'; actualSyncVersion: number };
-    // PR 3 (post-launch-stabilization): setPreferences now returns a
-    // discriminated result for CONFLICT instead of throwing. Wire shape
-    // to the client (HTTP 409 with actualSyncVersion) is unchanged. The
-    // change silences the dozens-per-day "Uncaught ConvexError" log surface
-    // in Convex Insights, which was just the intentional CAS guard. We no
-    // longer captureSilentError on CONFLICT either — PR 1.B's Sentry
-    // attribution served its purpose during the soak window (we used
-    // it to verify the stuck-bundle storm decayed) and is no longer
-    // needed now that CONFLICT is a normal return shape.
+    })) as SetPreferencesResult;
+    // Expected write denials return as a discriminated result so Convex can
+    // commit limiter bookkeeping and duplicate-counter cleanup. Wire shape to
+    // clients stays the same as the older thrown ConvexError paths below.
     if (result.ok === false) {
-      // Discriminated union narrows to the CONFLICT variant here.
+      if (result.reason === 'BLOB_TOO_LARGE') {
+        return jsonResponse({ error: 'BLOB_TOO_LARGE' }, 400, cors);
+      }
+      if (result.reason === 'RATE_LIMITED') {
+        console.warn('[user-prefs] POST convex write rate limit exceeded');
+        return jsonResponse(
+          { error: 'RATE_LIMITED' },
+          429,
+          rateLimitHeaders(cors, result.limit, result.reset),
+        );
+      }
       return jsonResponse(
         { error: 'CONFLICT', actualSyncVersion: result.actualSyncVersion },
         409,
@@ -271,17 +294,11 @@ export default async function handler(
     if (kind === 'RATE_LIMITED') {
       const limit = readConvexErrorNumber(err, 'limit') ?? USER_PREFS_WRITE_RATE_LIMIT;
       const reset = readConvexErrorNumber(err, 'reset') ?? Date.now() + 60_000;
-      const retryAfter = Math.max(1, Math.ceil((reset - Date.now()) / 1000));
+      console.warn('[user-prefs] POST convex write rate limit exceeded');
       return jsonResponse(
         { error: 'RATE_LIMITED' },
         429,
-        {
-          ...cors,
-          'X-RateLimit-Limit': String(limit),
-          'X-RateLimit-Remaining': '0',
-          'X-RateLimit-Reset': String(reset),
-          'Retry-After': String(retryAfter),
-        },
+        rateLimitHeaders(cors, limit, reset),
       );
     }
     if (kind === 'UNAUTHENTICATED') {

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -23,6 +23,8 @@ import { validateBearerToken } from '../server/auth-session';
 import { checkScopedRateLimit } from '../server/_shared/rate-limit';
 
 export const USER_PREFS_WRITE_RATE_SCOPE = 'user-prefs-write';
+// Keep in lockstep with convex/constants.ts; tests/user-prefs-rate-limit.test.mts
+// guards the duplicated Edge/Convex rate-limit contract from drifting.
 export const USER_PREFS_WRITE_RATE_LIMIT = 30;
 export const USER_PREFS_WRITE_RATE_WINDOW = '60 s';
 

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -266,6 +266,22 @@ export default async function handler(
     if (kind === 'BLOB_TOO_LARGE') {
       return jsonResponse({ error: 'BLOB_TOO_LARGE' }, 400, cors);
     }
+    if (kind === 'RATE_LIMITED') {
+      const limit = readConvexErrorNumber(err, 'limit') ?? USER_PREFS_WRITE_RATE_LIMIT;
+      const reset = readConvexErrorNumber(err, 'reset') ?? Date.now() + 60_000;
+      const retryAfter = Math.max(1, Math.ceil((reset - Date.now()) / 1000));
+      return jsonResponse(
+        { error: 'RATE_LIMITED' },
+        429,
+        {
+          ...cors,
+          'X-RateLimit-Limit': String(limit),
+          'X-RateLimit-Remaining': '0',
+          'X-RateLimit-Reset': String(reset),
+          'Retry-After': String(retryAfter),
+        },
+      );
+    }
     if (kind === 'UNAUTHENTICATED') {
       // See GET branch above — UNAUTHENTICATED here means Clerk-vs-Convex
       // auth drift (token already passed validateBearerToken). Capture

--- a/convex/__tests__/http.test.ts
+++ b/convex/__tests__/http.test.ts
@@ -1,0 +1,83 @@
+import { convexTest } from "convex-test";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import schema from "../schema";
+import {
+  USER_PREFS_WRITE_RATE_LIMIT,
+  USER_PREFS_WRITE_RATE_WINDOW_MS,
+} from "../constants";
+
+const modules = import.meta.glob("../**/*.ts");
+
+const TEST_NOW = 1_700_000_000_000;
+const TEST_WINDOW_START = Math.floor(TEST_NOW / USER_PREFS_WRITE_RATE_WINDOW_MS) * USER_PREFS_WRITE_RATE_WINDOW_MS;
+const TEST_RESET = TEST_WINDOW_START + USER_PREFS_WRITE_RATE_WINDOW_MS;
+const USER = {
+  subject: "user-prefs-http-rate",
+  tokenIdentifier: "clerk|user-prefs-http-rate",
+};
+
+function makePost(expectedSyncVersion: number): RequestInit {
+  return {
+    method: "POST",
+    headers: {
+      Origin: "https://worldmonitor.app",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      variant: "full",
+      data: { theme: `theme-${expectedSyncVersion}` },
+      expectedSyncVersion,
+      schemaVersion: 1,
+    }),
+  };
+}
+
+function expectExposedRateLimitHeaders(headers: Headers) {
+  const exposed = headers.get("Access-Control-Expose-Headers") ?? "";
+  expect(exposed).toContain("Retry-After");
+  expect(exposed).toContain("X-RateLimit-Limit");
+  expect(exposed).toContain("X-RateLimit-Remaining");
+  expect(exposed).toContain("X-RateLimit-Reset");
+}
+
+describe("/api/user-prefs Convex HTTP action", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("preflight exposes retry and rate-limit headers", async () => {
+    const t = convexTest(schema, modules);
+
+    const res = await t.fetch("/api/user-prefs", {
+      method: "OPTIONS",
+      headers: { Origin: "https://worldmonitor.app" },
+    });
+
+    expect(res.status).toBe(204);
+    expectExposedRateLimitHeaders(res.headers);
+  });
+
+  test("maps mutation RATE_LIMITED errors to 429 with retry guidance", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(TEST_NOW);
+    const t = convexTest(schema, modules);
+    const authed = t.withIdentity(USER);
+
+    for (let i = 0; i < USER_PREFS_WRITE_RATE_LIMIT; i++) {
+      const res = await authed.fetch("/api/user-prefs", makePost(i));
+      expect(res.status).toBe(200);
+    }
+
+    const res = await authed.fetch(
+      "/api/user-prefs",
+      makePost(USER_PREFS_WRITE_RATE_LIMIT),
+    );
+
+    expect(res.status).toBe(429);
+    expect(await res.json()).toEqual({ error: "RATE_LIMITED" });
+    expect(res.headers.get("Retry-After")).toBe(String(Math.ceil((TEST_RESET - TEST_NOW) / 1000)));
+    expect(res.headers.get("X-RateLimit-Limit")).toBe(String(USER_PREFS_WRITE_RATE_LIMIT));
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("0");
+    expect(res.headers.get("X-RateLimit-Reset")).toBe(String(TEST_RESET));
+    expectExposedRateLimitHeaders(res.headers);
+  });
+});

--- a/convex/__tests__/userPreferences.test.ts
+++ b/convex/__tests__/userPreferences.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import schema from "../schema";
 import { api } from "../_generated/api";
 import {
+  MAX_PREFS_BLOB_SIZE,
   USER_PREFS_WRITE_RATE_LIMIT,
   USER_PREFS_WRITE_RATE_WINDOW_MS,
 } from "../constants";
@@ -41,18 +42,9 @@ async function writePref(
 }
 
 async function expectRateLimited(promise: Promise<unknown>, reset = TEST_RESET) {
-  let caught: unknown;
-  try {
-    await promise;
-  } catch (err) {
-    caught = err;
-  }
-
-  const data = (caught as { data?: unknown } | undefined)?.data;
-  const parsed = typeof data === "string" ? JSON.parse(data) : data;
-
-  expect(parsed).toEqual({
-    kind: "RATE_LIMITED",
+  await expect(promise).resolves.toEqual({
+    ok: false,
+    reason: "RATE_LIMITED",
     limit: USER_PREFS_WRITE_RATE_LIMIT,
     reset,
   });
@@ -154,6 +146,68 @@ describe("userPreferences.setPreferences write rate limit", () => {
       count: 4,
       updatedAt: TEST_NOW,
     });
+  });
+
+  test("consolidates duplicate counter rows even when the request is rate limited", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(TEST_NOW);
+    const t = makeT();
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("userPreferenceWriteRateLimits", {
+        userId: USER_A.subject,
+        windowStart: TEST_WINDOW_START,
+        count: 10,
+        updatedAt: TEST_NOW - 20,
+      });
+      await ctx.db.insert("userPreferenceWriteRateLimits", {
+        userId: USER_A.subject,
+        windowStart: TEST_WINDOW_START,
+        count: USER_PREFS_WRITE_RATE_LIMIT - 10,
+        updatedAt: TEST_NOW - 10,
+      });
+    });
+
+    await expectRateLimited(writePref(t, USER_A, 0));
+
+    const rows = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("userPreferenceWriteRateLimits")
+        .withIndex("by_user_window", (q) =>
+          q.eq("userId", USER_A.subject).eq("windowStart", TEST_WINDOW_START),
+        )
+        .collect();
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      userId: USER_A.subject,
+      windowStart: TEST_WINDOW_START,
+      count: USER_PREFS_WRITE_RATE_LIMIT,
+      updatedAt: TEST_NOW,
+    });
+  });
+
+  test("oversized write attempts consume the direct Convex write budget", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(TEST_NOW);
+    const t = makeT();
+    const data = { payload: "x".repeat(MAX_PREFS_BLOB_SIZE) };
+
+    for (let i = 0; i < USER_PREFS_WRITE_RATE_LIMIT; i++) {
+      await expect(
+        t.withIdentity(USER_A).mutation(api.userPreferences.setPreferences, {
+          variant: "full",
+          data,
+          expectedSyncVersion: 0,
+          schemaVersion: 1,
+        }),
+      ).resolves.toMatchObject({
+        ok: false,
+        reason: "BLOB_TOO_LARGE",
+        max: MAX_PREFS_BLOB_SIZE,
+      });
+    }
+
+    await expectRateLimited(writePref(t, USER_A, 0));
   });
 
   test("rate limit wins before stale-version CONFLICT checks", async () => {

--- a/convex/__tests__/userPreferences.test.ts
+++ b/convex/__tests__/userPreferences.test.ts
@@ -2,8 +2,16 @@ import { convexTest } from "convex-test";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import schema from "../schema";
 import { api } from "../_generated/api";
+import {
+  USER_PREFS_WRITE_RATE_LIMIT,
+  USER_PREFS_WRITE_RATE_WINDOW_MS,
+} from "../constants";
 
 const modules = import.meta.glob("../**/*.ts");
+
+const TEST_NOW = 1_700_000_000_000;
+const TEST_WINDOW_START = Math.floor(TEST_NOW / USER_PREFS_WRITE_RATE_WINDOW_MS) * USER_PREFS_WRITE_RATE_WINDOW_MS;
+const TEST_RESET = TEST_WINDOW_START + USER_PREFS_WRITE_RATE_WINDOW_MS;
 
 const USER_A = {
   subject: "user-prefs-rate-a",
@@ -32,21 +40,39 @@ async function writePref(
   });
 }
 
+async function expectRateLimited(promise: Promise<unknown>, reset = TEST_RESET) {
+  let caught: unknown;
+  try {
+    await promise;
+  } catch (err) {
+    caught = err;
+  }
+
+  const data = (caught as { data?: unknown } | undefined)?.data;
+  const parsed = typeof data === "string" ? JSON.parse(data) : data;
+
+  expect(parsed).toEqual({
+    kind: "RATE_LIMITED",
+    limit: USER_PREFS_WRITE_RATE_LIMIT,
+    reset,
+  });
+}
+
 describe("userPreferences.setPreferences write rate limit", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
   test("caps direct Convex writes per authenticated user and fixed window", async () => {
-    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    vi.spyOn(Date, "now").mockReturnValue(TEST_NOW);
     const t = makeT();
 
-    for (let i = 0; i < 30; i++) {
+    for (let i = 0; i < USER_PREFS_WRITE_RATE_LIMIT; i++) {
       const result = await writePref(t, USER_A, i);
       expect(result).toEqual({ ok: true, syncVersion: i + 1 });
     }
 
-    await expect(writePref(t, USER_A, 30)).rejects.toThrow(/RATE_LIMITED|rate/i);
+    await expectRateLimited(writePref(t, USER_A, USER_PREFS_WRITE_RATE_LIMIT));
 
     const row = await t.run(async (ctx) => {
       return await ctx.db
@@ -56,31 +82,88 @@ describe("userPreferences.setPreferences write rate limit", () => {
         )
         .unique();
     });
-    expect(row?.syncVersion).toBe(30);
+    expect(row?.syncVersion).toBe(USER_PREFS_WRITE_RATE_LIMIT);
   });
 
   test("uses separate buckets per authenticated user", async () => {
-    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    vi.spyOn(Date, "now").mockReturnValue(TEST_NOW);
     const t = makeT();
 
-    for (let i = 0; i < 30; i++) {
+    for (let i = 0; i < USER_PREFS_WRITE_RATE_LIMIT; i++) {
       await writePref(t, USER_A, i);
     }
-    await expect(writePref(t, USER_A, 30)).rejects.toThrow(/RATE_LIMITED|rate/i);
+    await expectRateLimited(writePref(t, USER_A, USER_PREFS_WRITE_RATE_LIMIT));
 
     await expect(writePref(t, USER_B, 0)).resolves.toEqual({ ok: true, syncVersion: 1 });
   });
 
   test("resets the write budget when the fixed window advances", async () => {
-    const now = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    const now = vi.spyOn(Date, "now").mockReturnValue(TEST_NOW);
     const t = makeT();
 
-    for (let i = 0; i < 30; i++) {
+    for (let i = 0; i < USER_PREFS_WRITE_RATE_LIMIT; i++) {
       await writePref(t, USER_A, i);
     }
-    await expect(writePref(t, USER_A, 30)).rejects.toThrow(/RATE_LIMITED|rate/i);
+    await expectRateLimited(writePref(t, USER_A, USER_PREFS_WRITE_RATE_LIMIT));
 
-    now.mockReturnValue(1_700_000_060_000);
-    await expect(writePref(t, USER_A, 30)).resolves.toEqual({ ok: true, syncVersion: 31 });
+    now.mockReturnValue(TEST_RESET);
+    await expect(writePref(t, USER_A, USER_PREFS_WRITE_RATE_LIMIT)).resolves.toEqual({
+      ok: true,
+      syncVersion: USER_PREFS_WRITE_RATE_LIMIT + 1,
+    });
+  });
+
+  test("consolidates duplicate counter rows left by concurrent first writes", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(TEST_NOW);
+    const t = makeT();
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("userPreferenceWriteRateLimits", {
+        userId: USER_A.subject,
+        windowStart: TEST_WINDOW_START,
+        count: 1,
+        updatedAt: TEST_NOW - 20,
+      });
+      await ctx.db.insert("userPreferenceWriteRateLimits", {
+        userId: USER_A.subject,
+        windowStart: TEST_WINDOW_START,
+        count: 2,
+        updatedAt: TEST_NOW - 10,
+      });
+      await ctx.db.insert("userPreferenceWriteRateLimits", {
+        userId: USER_A.subject,
+        windowStart: TEST_WINDOW_START - USER_PREFS_WRITE_RATE_WINDOW_MS,
+        count: 99,
+        updatedAt: TEST_NOW - USER_PREFS_WRITE_RATE_WINDOW_MS,
+      });
+    });
+
+    await expect(writePref(t, USER_A, 0)).resolves.toEqual({ ok: true, syncVersion: 1 });
+
+    const rows = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("userPreferenceWriteRateLimits")
+        .withIndex("by_user_window", (q) => q.eq("userId", USER_A.subject))
+        .collect();
+    });
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      userId: USER_A.subject,
+      windowStart: TEST_WINDOW_START,
+      count: 4,
+      updatedAt: TEST_NOW,
+    });
+  });
+
+  test("rate limit wins before stale-version CONFLICT checks", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(TEST_NOW);
+    const t = makeT();
+
+    for (let i = 0; i < USER_PREFS_WRITE_RATE_LIMIT; i++) {
+      await writePref(t, USER_A, i);
+    }
+
+    await expectRateLimited(writePref(t, USER_A, 0));
   });
 });

--- a/convex/__tests__/userPreferences.test.ts
+++ b/convex/__tests__/userPreferences.test.ts
@@ -1,0 +1,86 @@
+import { convexTest } from "convex-test";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import schema from "../schema";
+import { api } from "../_generated/api";
+
+const modules = import.meta.glob("../**/*.ts");
+
+const USER_A = {
+  subject: "user-prefs-rate-a",
+  tokenIdentifier: "clerk|user-prefs-rate-a",
+};
+
+const USER_B = {
+  subject: "user-prefs-rate-b",
+  tokenIdentifier: "clerk|user-prefs-rate-b",
+};
+
+function makeT() {
+  return convexTest(schema, modules);
+}
+
+async function writePref(
+  t: ReturnType<typeof convexTest>,
+  user: typeof USER_A,
+  expectedSyncVersion: number,
+) {
+  return await t.withIdentity(user).mutation(api.userPreferences.setPreferences, {
+    variant: "full",
+    data: { theme: `theme-${expectedSyncVersion}` },
+    expectedSyncVersion,
+    schemaVersion: 1,
+  });
+}
+
+describe("userPreferences.setPreferences write rate limit", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("caps direct Convex writes per authenticated user and fixed window", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    const t = makeT();
+
+    for (let i = 0; i < 30; i++) {
+      const result = await writePref(t, USER_A, i);
+      expect(result).toEqual({ ok: true, syncVersion: i + 1 });
+    }
+
+    await expect(writePref(t, USER_A, 30)).rejects.toThrow(/RATE_LIMITED|rate/i);
+
+    const row = await t.run(async (ctx) => {
+      return await ctx.db
+        .query("userPreferences")
+        .withIndex("by_user_variant", (q) =>
+          q.eq("userId", USER_A.subject).eq("variant", "full"),
+        )
+        .unique();
+    });
+    expect(row?.syncVersion).toBe(30);
+  });
+
+  test("uses separate buckets per authenticated user", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    const t = makeT();
+
+    for (let i = 0; i < 30; i++) {
+      await writePref(t, USER_A, i);
+    }
+    await expect(writePref(t, USER_A, 30)).rejects.toThrow(/RATE_LIMITED|rate/i);
+
+    await expect(writePref(t, USER_B, 0)).resolves.toEqual({ ok: true, syncVersion: 1 });
+  });
+
+  test("resets the write budget when the fixed window advances", async () => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000);
+    const t = makeT();
+
+    for (let i = 0; i < 30; i++) {
+      await writePref(t, USER_A, i);
+    }
+    await expect(writePref(t, USER_A, 30)).rejects.toThrow(/RATE_LIMITED|rate/i);
+
+    now.mockReturnValue(1_700_000_060_000);
+    await expect(writePref(t, USER_A, 30)).resolves.toEqual({ ok: true, syncVersion: 31 });
+  });
+});

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -32,6 +32,12 @@ export const CURRENT_PREFS_SCHEMA_VERSION = 1;
 
 export const MAX_PREFS_BLOB_SIZE = 65536;
 
+// Cloud preference writes are low-latency but public to authenticated Convex
+// clients. Keep the authoritative guard inside the mutation so direct
+// *.convex.site callers cannot bypass the Vercel edge limiter.
+export const USER_PREFS_WRITE_RATE_LIMIT = 30;
+export const USER_PREFS_WRITE_RATE_WINDOW_MS = 60 * 1000;
+
 // Followed-countries (watchlist primitive) constants. See
 // docs/plans/2026-05-02-001-feat-followed-countries-watchlist-primitive-plan.md
 // (U12) for context. These three constants are consumed by the

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -34,7 +34,12 @@ export const MAX_PREFS_BLOB_SIZE = 65536;
 
 // Cloud preference writes are low-latency but public to authenticated Convex
 // clients. Keep the authoritative guard inside the mutation so direct
-// *.convex.site callers cannot bypass the Vercel edge limiter.
+// *.convex.site callers cannot bypass the Vercel edge limiter. Keep these
+// values in lockstep with api/user-prefs.ts; tests/user-prefs-rate-limit.test.mts
+// guards the duplicated Edge/Convex constants from drifting. Unlike the
+// Redis-backed Vercel pre-gate, this mutation-local backstop intentionally
+// fails closed if its own counter storage fails: failing open here would
+// reopen the direct-Convex bypass this guard exists to close.
 export const USER_PREFS_WRITE_RATE_LIMIT = 30;
 export const USER_PREFS_WRITE_RATE_WINDOW_MS = 60 * 1000;
 

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -99,6 +99,20 @@ function readConvexErrorNumber(err: unknown, field: string): number | null {
   return typeof value === "number" ? value : null;
 }
 
+type SetPreferencesResult =
+  | { ok: true; syncVersion: number }
+  | { ok: false; reason: "CONFLICT"; actualSyncVersion: number }
+  | { ok: false; reason: "BLOB_TOO_LARGE"; size: number; max: number }
+  | { ok: false; reason: "RATE_LIMITED"; limit: number; reset: number };
+
+function setRateLimitResponseHeaders(headers: Headers, limit: number, reset: number): void {
+  const retryAfter = Math.max(1, Math.ceil((reset - Date.now()) / 1000));
+  headers.set("X-RateLimit-Limit", String(limit));
+  headers.set("X-RateLimit-Remaining", "0");
+  headers.set("X-RateLimit-Reset", String(reset));
+  headers.set("Retry-After", String(retryAfter));
+}
+
 const http = httpRouter();
 
 http.route({
@@ -205,15 +219,24 @@ http.route({
           expectedSyncVersion: body.expectedSyncVersion,
           schemaVersion: body.schemaVersion,
         },
-      )) as
-        | { ok: true; syncVersion: number }
-        | { ok: false; reason: "CONFLICT"; actualSyncVersion: number };
-      // PR 3 (post-launch-stabilization): setPreferences now returns a
-      // discriminated result for CONFLICT instead of throwing. Mirror the
-      // wire shape from api/user-prefs.ts (Vercel) so clients see the same
-      // 409 + actualSyncVersion regardless of which `/api/user-prefs` host
-      // they hit.
+      )) as SetPreferencesResult;
+      // Expected write denials return as a discriminated result so Convex can
+      // commit limiter bookkeeping and duplicate-counter cleanup. Mirror the
+      // wire shape from api/user-prefs.ts (Vercel) regardless of host.
       if (result.ok === false) {
+        if (result.reason === "BLOB_TOO_LARGE") {
+          return new Response(JSON.stringify({ error: "BLOB_TOO_LARGE" }), {
+            status: 400,
+            headers,
+          });
+        }
+        if (result.reason === "RATE_LIMITED") {
+          setRateLimitResponseHeaders(headers, result.limit, result.reset);
+          return new Response(JSON.stringify({ error: "RATE_LIMITED" }), {
+            status: 429,
+            headers,
+          });
+        }
         return new Response(
           JSON.stringify({
             error: "CONFLICT",
@@ -248,11 +271,7 @@ http.route({
       if (code === "RATE_LIMITED" || msg.includes("RATE_LIMITED")) {
         const limit = readConvexErrorNumber(err, "limit") ?? USER_PREFS_WRITE_RATE_LIMIT;
         const reset = readConvexErrorNumber(err, "reset") ?? Date.now() + 60_000;
-        const retryAfter = Math.max(1, Math.ceil((reset - Date.now()) / 1000));
-        headers.set("X-RateLimit-Limit", String(limit));
-        headers.set("X-RateLimit-Remaining", "0");
-        headers.set("X-RateLimit-Reset", String(reset));
-        headers.set("Retry-After", String(retryAfter));
+        setRateLimitResponseHeaders(headers, limit, reset);
         return new Response(JSON.stringify({ error: "RATE_LIMITED" }), {
           status: 429,
           headers,

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -3,6 +3,7 @@ import { httpAction } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { webhookHandler } from "./payments/webhookHandlers";
 import { resendWebhookHandler } from "./resendWebhookHandler";
+import { USER_PREFS_WRITE_RATE_LIMIT } from "./constants";
 
 const TRUSTED = [
   "https://worldmonitor.app",
@@ -62,25 +63,32 @@ async function timingSafeEqualStrings(a: string, b: string): Promise<boolean> {
  *   - `throw new ConvexError("PRO_REQUIRED")`  → data = '"PRO_REQUIRED"' → "PRO_REQUIRED"
  *   - `throw new ConvexError({code: "X", ...})` → data = '{"code":"X",…}'  → "X"
  */
-function extractConvexErrorCode(err: unknown): string | null {
+function parseConvexErrorData(err: unknown): unknown {
   const raw = (err as { data?: unknown } | undefined)?.data;
-  if (typeof raw !== "string") {
-    if (raw && typeof raw === "object" && "code" in (raw as Record<string, unknown>)) {
-      return String((raw as Record<string, unknown>).code);
-    }
-    return null;
-  }
+  if (typeof raw !== "string") return raw ?? null;
   try {
-    const parsed = JSON.parse(raw);
-    if (typeof parsed === "string") return parsed;
-    if (parsed && typeof parsed === "object" && "code" in parsed) {
-      return String((parsed as Record<string, unknown>).code);
-    }
-    return null;
+    return JSON.parse(raw);
   } catch {
-    // Not JSON — treat the raw string as the code itself.
     return raw;
   }
+}
+
+function extractConvexErrorCode(err: unknown): string | null {
+  const parsed = parseConvexErrorData(err);
+  if (typeof parsed === "string") return parsed;
+  if (parsed && typeof parsed === "object") {
+    const data = parsed as Record<string, unknown>;
+    const code = data.code ?? data.kind;
+    if (typeof code === "string") return code;
+  }
+  return null;
+}
+
+function readConvexErrorNumber(err: unknown, field: string): number | null {
+  const parsed = parseConvexErrorData(err);
+  if (!parsed || typeof parsed !== "object") return null;
+  const value = (parsed as Record<string, unknown>)[field];
+  return typeof value === "number" ? value : null;
 }
 
 const http = httpRouter();
@@ -212,19 +220,33 @@ http.route({
       );
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
+      const code = extractConvexErrorCode(err);
       // Defensive: keep CONFLICT-throw fallback for the deploy-ordering
       // window where this http action may run against an older Convex
       // deployment that still throws. Once both layers have soaked, this
       // branch is unreachable and can be removed.
-      if (msg.includes("CONFLICT")) {
+      if (code === "CONFLICT" || msg.includes("CONFLICT")) {
         return new Response(JSON.stringify({ error: "CONFLICT" }), {
           status: 409,
           headers,
         });
       }
-      if (msg.includes("BLOB_TOO_LARGE")) {
+      if (code === "BLOB_TOO_LARGE" || msg.includes("BLOB_TOO_LARGE")) {
         return new Response(JSON.stringify({ error: "BLOB_TOO_LARGE" }), {
           status: 400,
+          headers,
+        });
+      }
+      if (code === "RATE_LIMITED" || msg.includes("RATE_LIMITED")) {
+        const limit = readConvexErrorNumber(err, "limit") ?? USER_PREFS_WRITE_RATE_LIMIT;
+        const reset = readConvexErrorNumber(err, "reset") ?? Date.now() + 60_000;
+        const retryAfter = Math.max(1, Math.ceil((reset - Date.now()) / 1000));
+        headers.set("X-RateLimit-Limit", String(limit));
+        headers.set("X-RateLimit-Remaining", "0");
+        headers.set("X-RateLimit-Reset", String(reset));
+        headers.set("Retry-After", String(retryAfter));
+        return new Response(JSON.stringify({ error: "RATE_LIMITED" }), {
+          status: 429,
           headers,
         });
       }

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -11,6 +11,13 @@ const TRUSTED = [
   "http://localhost:3000",
 ];
 
+const EXPOSED_HEADERS = [
+  "Retry-After",
+  "X-RateLimit-Limit",
+  "X-RateLimit-Remaining",
+  "X-RateLimit-Reset",
+].join(", ");
+
 function matchOrigin(origin: string, pattern: string): boolean {
   if (pattern.startsWith("*.")) {
     return origin.endsWith(pattern.slice(1));
@@ -30,6 +37,7 @@ function corsHeaders(origin: string | null): Headers {
     headers.set("Access-Control-Allow-Origin", allowed);
     headers.set("Access-Control-Allow-Methods", "POST, OPTIONS");
     headers.set("Access-Control-Allow-Headers", "Content-Type, Authorization");
+    headers.set("Access-Control-Expose-Headers", EXPOSED_HEADERS);
     headers.set("Access-Control-Max-Age", "86400");
   }
   return headers;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -42,9 +42,7 @@ export default defineSchema({
     windowStart: v.number(),
     count: v.number(),
     updatedAt: v.number(),
-  })
-    .index("by_user_window", ["userId", "windowStart"])
-    .index("by_updatedAt", ["updatedAt"]),
+  }).index("by_user_window", ["userId", "windowStart"]),
 
   notificationChannels: defineTable(
     v.union(

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -37,6 +37,15 @@ export default defineSchema({
     syncVersion: v.number(),
   }).index("by_user_variant", ["userId", "variant"]),
 
+  userPreferenceWriteRateLimits: defineTable({
+    userId: v.string(),
+    windowStart: v.number(),
+    count: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_user_window", ["userId", "windowStart"])
+    .index("by_updatedAt", ["updatedAt"]),
+
   notificationChannels: defineTable(
     v.union(
       v.object({

--- a/convex/userPreferences.ts
+++ b/convex/userPreferences.ts
@@ -1,6 +1,11 @@
 import { ConvexError, v } from "convex/values";
-import { internalQuery, mutation, query } from "./_generated/server";
-import { CURRENT_PREFS_SCHEMA_VERSION, MAX_PREFS_BLOB_SIZE } from "./constants";
+import { internalQuery, mutation, query, type MutationCtx } from "./_generated/server";
+import {
+  CURRENT_PREFS_SCHEMA_VERSION,
+  MAX_PREFS_BLOB_SIZE,
+  USER_PREFS_WRITE_RATE_LIMIT,
+  USER_PREFS_WRITE_RATE_WINDOW_MS,
+} from "./constants";
 
 export const getPreferencesByUserId = internalQuery({
   args: { userId: v.string(), variant: v.string() },
@@ -45,6 +50,58 @@ export type SetPreferencesResult =
   | { ok: true; syncVersion: number }
   | { ok: false; reason: "CONFLICT"; actualSyncVersion: number };
 
+async function checkUserPrefsWriteRateLimit(ctx: MutationCtx, userId: string): Promise<void> {
+  const now = Date.now();
+  const windowStart = Math.floor(now / USER_PREFS_WRITE_RATE_WINDOW_MS) * USER_PREFS_WRITE_RATE_WINDOW_MS;
+  const reset = windowStart + USER_PREFS_WRITE_RATE_WINDOW_MS;
+  const rows = await ctx.db
+    .query("userPreferenceWriteRateLimits")
+    .withIndex("by_user_window", (q) => q.eq("userId", userId))
+    .collect();
+  const currentRows = rows.filter((row) => row.windowStart === windowStart);
+  const count = currentRows.reduce((sum, row) => sum + row.count, 0);
+
+  if (count >= USER_PREFS_WRITE_RATE_LIMIT) {
+    throw new ConvexError({
+      kind: "RATE_LIMITED",
+      limit: USER_PREFS_WRITE_RATE_LIMIT,
+      reset,
+    });
+  }
+
+  let retainedId: (typeof rows)[number]["_id"] | null = null;
+
+  if (currentRows.length > 0) {
+    const current = currentRows[0]!;
+    retainedId = current._id;
+    await ctx.db.patch(current._id, {
+      count: count + 1,
+      updatedAt: now,
+    });
+  } else {
+    const reusable = rows[0];
+    if (reusable) {
+      retainedId = reusable._id;
+      await ctx.db.patch(reusable._id, {
+        windowStart,
+        count: 1,
+        updatedAt: now,
+      });
+    } else {
+      retainedId = await ctx.db.insert("userPreferenceWriteRateLimits", {
+        userId,
+        windowStart,
+        count: 1,
+        updatedAt: now,
+      });
+    }
+  }
+
+  for (const row of rows) {
+    if (row._id !== retainedId) await ctx.db.delete(row._id);
+  }
+}
+
 export const setPreferences = mutation({
   args: {
     variant: v.string(),
@@ -61,6 +118,8 @@ export const setPreferences = mutation({
     // string-data wire-strip bug.)
     if (!identity) throw new ConvexError({ kind: "UNAUTHENTICATED" });
     const userId = identity.subject;
+
+    await checkUserPrefsWriteRateLimit(ctx, userId);
 
     const blobSize = JSON.stringify(args.data).length;
     if (blobSize > MAX_PREFS_BLOB_SIZE) {

--- a/convex/userPreferences.ts
+++ b/convex/userPreferences.ts
@@ -119,6 +119,10 @@ export const setPreferences = mutation({
     if (!identity) throw new ConvexError({ kind: "UNAUTHENTICATED" });
     const userId = identity.subject;
 
+    // Run before the CAS read so stale expectedSyncVersion requests cannot
+    // bypass the authoritative direct-Convex backstop by intentionally
+    // returning CONFLICT forever. CONFLICT retries count as write attempts;
+    // the limit is sized for that worst-case retry profile.
     await checkUserPrefsWriteRateLimit(ctx, userId);
 
     const blobSize = JSON.stringify(args.data).length;

--- a/convex/userPreferences.ts
+++ b/convex/userPreferences.ts
@@ -42,64 +42,81 @@ export const getPreferences = query({
  * exposed through `api/user-prefs.ts` (HTTP 409 with `actualSyncVersion`)
  * is unchanged — clients see the same response.
  *
- * `BLOB_TOO_LARGE` and `UNAUTHENTICATED` remain THROWS because they are
- * rare and we DO want them visible in Sentry as errors. CONFLICT is
- * dozens-per-day expected behavior, not an error.
+ * Expected write denials return instead of throwing so limiter accounting and
+ * duplicate-row cleanup persist in Convex. `UNAUTHENTICATED` remains a throw
+ * because it is auth drift / bad input rather than a metered write attempt.
  */
 export type SetPreferencesResult =
   | { ok: true; syncVersion: number }
-  | { ok: false; reason: "CONFLICT"; actualSyncVersion: number };
+  | { ok: false; reason: "CONFLICT"; actualSyncVersion: number }
+  | { ok: false; reason: "BLOB_TOO_LARGE"; size: number; max: number }
+  | { ok: false; reason: "RATE_LIMITED"; limit: number; reset: number };
 
-async function checkUserPrefsWriteRateLimit(ctx: MutationCtx, userId: string): Promise<void> {
+type UserPrefsWriteRateLimitResult =
+  | { ok: true }
+  | { ok: false; reason: "RATE_LIMITED"; limit: number; reset: number };
+
+const RATE_LIMIT_COUNTER_SCAN_LIMIT = USER_PREFS_WRITE_RATE_LIMIT + 1;
+const RATE_LIMIT_STALE_CLEANUP_LIMIT = 5;
+
+async function checkUserPrefsWriteRateLimit(
+  ctx: MutationCtx,
+  userId: string,
+): Promise<UserPrefsWriteRateLimitResult> {
   const now = Date.now();
   const windowStart = Math.floor(now / USER_PREFS_WRITE_RATE_WINDOW_MS) * USER_PREFS_WRITE_RATE_WINDOW_MS;
   const reset = windowStart + USER_PREFS_WRITE_RATE_WINDOW_MS;
-  const rows = await ctx.db
+  const currentRows = await ctx.db
     .query("userPreferenceWriteRateLimits")
-    .withIndex("by_user_window", (q) => q.eq("userId", userId))
-    .collect();
-  const currentRows = rows.filter((row) => row.windowStart === windowStart);
+    .withIndex("by_user_window", (q) =>
+      q.eq("userId", userId).eq("windowStart", windowStart),
+    )
+    .take(RATE_LIMIT_COUNTER_SCAN_LIMIT);
   const count = currentRows.reduce((sum, row) => sum + row.count, 0);
+  const retained = currentRows[0] ?? null;
 
-  if (count >= USER_PREFS_WRITE_RATE_LIMIT) {
-    throw new ConvexError({
-      kind: "RATE_LIMITED",
-      limit: USER_PREFS_WRITE_RATE_LIMIT,
-      reset,
-    });
+  for (const row of currentRows.slice(1)) {
+    await ctx.db.delete(row._id);
   }
 
-  let retainedId: (typeof rows)[number]["_id"] | null = null;
+  if (count >= USER_PREFS_WRITE_RATE_LIMIT) {
+    if (retained && retained.count !== count) {
+      await ctx.db.patch(retained._id, {
+        count,
+        updatedAt: now,
+      });
+    }
+    return {
+      ok: false,
+      reason: "RATE_LIMITED",
+      limit: USER_PREFS_WRITE_RATE_LIMIT,
+      reset,
+    };
+  }
 
-  if (currentRows.length > 0) {
-    const current = currentRows[0]!;
-    retainedId = current._id;
-    await ctx.db.patch(current._id, {
+  if (retained) {
+    await ctx.db.patch(retained._id, {
       count: count + 1,
       updatedAt: now,
     });
   } else {
-    const reusable = rows[0];
-    if (reusable) {
-      retainedId = reusable._id;
-      await ctx.db.patch(reusable._id, {
-        windowStart,
-        count: 1,
-        updatedAt: now,
-      });
-    } else {
-      retainedId = await ctx.db.insert("userPreferenceWriteRateLimits", {
-        userId,
-        windowStart,
-        count: 1,
-        updatedAt: now,
-      });
-    }
+    await ctx.db.insert("userPreferenceWriteRateLimits", {
+      userId,
+      windowStart,
+      count: 1,
+      updatedAt: now,
+    });
   }
 
-  for (const row of rows) {
-    if (row._id !== retainedId) await ctx.db.delete(row._id);
+  const staleRows = await ctx.db
+    .query("userPreferenceWriteRateLimits")
+    .withIndex("by_user_window", (q) => q.eq("userId", userId))
+    .take(RATE_LIMIT_STALE_CLEANUP_LIMIT);
+  for (const row of staleRows) {
+    if (row.windowStart !== windowStart) await ctx.db.delete(row._id);
   }
+
+  return { ok: true };
 }
 
 export const setPreferences = mutation({
@@ -111,8 +128,8 @@ export const setPreferences = mutation({
   },
   handler: async (ctx, args): Promise<SetPreferencesResult> => {
     const identity = await ctx.auth.getUserIdentity();
-    // BLOB_TOO_LARGE and UNAUTHENTICATED throw as structured ConvexErrors —
-    // they are rare error conditions we want surfaced in Sentry. Convex's
+    // UNAUTHENTICATED throws as a structured ConvexError because it is rare
+    // auth drift / bad input we want surfaced in Sentry. Convex's
     // wire format propagates `errorData` for object payloads so the edge
     // handler routes via `err.data.kind`. (PR #3466 fixed the original
     // string-data wire-strip bug.)
@@ -123,15 +140,17 @@ export const setPreferences = mutation({
     // bypass the authoritative direct-Convex backstop by intentionally
     // returning CONFLICT forever. CONFLICT retries count as write attempts;
     // the limit is sized for that worst-case retry profile.
-    await checkUserPrefsWriteRateLimit(ctx, userId);
+    const rateLimit = await checkUserPrefsWriteRateLimit(ctx, userId);
+    if (!rateLimit.ok) return rateLimit;
 
     const blobSize = JSON.stringify(args.data).length;
     if (blobSize > MAX_PREFS_BLOB_SIZE) {
-      throw new ConvexError({
-        kind: "BLOB_TOO_LARGE",
+      return {
+        ok: false,
+        reason: "BLOB_TOO_LARGE",
         size: blobSize,
         max: MAX_PREFS_BLOB_SIZE,
-      });
+      };
     }
 
     const existing = await ctx.db

--- a/src/utils/cloud-prefs-flush.ts
+++ b/src/utils/cloud-prefs-flush.ts
@@ -1,0 +1,31 @@
+export interface ObservableCloudPrefsFlushSuccessOptions {
+  syncVersion: unknown;
+  myGeneration: number;
+  getAuthGeneration: () => number;
+  getSyncVersion: () => number;
+  setSyncVersion: (syncVersion: number) => void;
+  clearSettledDirtyKeys: () => void;
+  setLastSyncAt: (timestampMs: number) => void;
+  isIdle: () => boolean;
+  setSynced: () => void;
+  now?: () => number;
+}
+
+/**
+ * Apply an observable keepalive flush response after a tab is hidden.
+ * Real unloads usually do not run this path; tab switches do, and the echoed
+ * syncVersion must be adopted so the next alive-tab save does not hit 409.
+ */
+export function applyObservableCloudPrefsFlushSuccess(
+  opts: ObservableCloudPrefsFlushSuccessOptions,
+): boolean {
+  if (typeof opts.syncVersion !== 'number') return false;
+  if (opts.getAuthGeneration() !== opts.myGeneration) return false;
+  if (opts.syncVersion <= opts.getSyncVersion()) return false;
+
+  opts.setSyncVersion(opts.syncVersion);
+  opts.clearSettledDirtyKeys();
+  opts.setLastSyncAt((opts.now ?? Date.now)());
+  if (opts.isIdle()) opts.setSynced();
+  return true;
+}

--- a/src/utils/cloud-prefs-retry.ts
+++ b/src/utils/cloud-prefs-retry.ts
@@ -1,0 +1,58 @@
+const RETRY_AFTER_MIN_SEC = 1;
+const RETRY_AFTER_MAX_SEC = 60;
+const RETRY_AFTER_DEFAULT_SEC = 5;
+
+export function isTemporaryCloudPrefsStatus(status: number): boolean {
+  return status === 429 || status === 503;
+}
+
+/**
+ * Parse the `Retry-After` header per RFC 7231: either delta-seconds or an
+ * HTTP-date. Returns a clamped number of seconds, with the configured
+ * default for missing/malformed values.
+ */
+export function parseRetryAfterSeconds(headers: Headers): number {
+  const raw = headers.get('Retry-After');
+  if (!raw) return RETRY_AFTER_DEFAULT_SEC;
+  const trimmed = raw.trim();
+  if (/^\d+$/.test(trimmed)) {
+    const n = Number(trimmed);
+    if (!Number.isFinite(n)) return RETRY_AFTER_DEFAULT_SEC;
+    return Math.min(Math.max(n, RETRY_AFTER_MIN_SEC), RETRY_AFTER_MAX_SEC);
+  }
+  if (!/\b\d{4}\b/.test(trimmed) || !trimmed.includes(':')) return RETRY_AFTER_DEFAULT_SEC;
+  const t = Date.parse(trimmed);
+  if (!Number.isFinite(t)) return RETRY_AFTER_DEFAULT_SEC;
+  const delta = Math.round((t - Date.now()) / 1000);
+  return Math.min(Math.max(delta, RETRY_AFTER_MIN_SEC), RETRY_AFTER_MAX_SEC);
+}
+
+export interface TemporaryCloudPrefsRetryOptions {
+  status: number;
+  headers: Headers;
+  myGeneration: number;
+  getAuthGeneration: () => number;
+  setPending: () => void;
+  clearRetryTimer: () => void;
+  setRetryTimer: (timer: ReturnType<typeof setTimeout> | null) => void;
+  uploadNow: () => void | Promise<void>;
+  setTimeoutFn?: typeof setTimeout;
+}
+
+export function rearmTemporaryCloudPrefsRetry(opts: TemporaryCloudPrefsRetryOptions): boolean {
+  if (!isTemporaryCloudPrefsStatus(opts.status)) return false;
+
+  const retryAfterSec = parseRetryAfterSeconds(opts.headers);
+  if (opts.getAuthGeneration() !== opts.myGeneration) return true;
+
+  opts.setPending();
+  opts.clearRetryTimer();
+  const setTimeoutFn = opts.setTimeoutFn ?? setTimeout;
+  const timer = setTimeoutFn(() => {
+    opts.setRetryTimer(null);
+    if (opts.getAuthGeneration() !== opts.myGeneration) return;
+    void opts.uploadNow();
+  }, retryAfterSec * 1000);
+  opts.setRetryTimer(timer);
+  return true;
+}

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -730,10 +730,24 @@ export function install(variant: string): void {
       // the new version when the response is observable (true unloads never
       // get here; the next boot's onSignIn GET heals those instead).
       //
-      // Non-2xx (409/5xx): change nothing — keeping the stale version and
-      // the dirty keys is what routes the next upload through the
-      // conflict-merge path, which is the correct recovery.
-      if (!res.ok) return;
+      // Non-2xx: 409 keeps the stale version and dirty keys so the next
+      // upload resolves through the conflict-merge path. Temporary 429/5xx
+      // responses are observable during tab switches, so re-arm the normal
+      // retry machinery instead of stranding the final save.
+      if (!res.ok) {
+        if (isTemporaryCloudPrefsStatus(res.status)) {
+          const retryAfterSec = parseRetryAfterSeconds(res.headers);
+          if (_authGeneration !== myGeneration) return;
+          setState('pending');
+          clearRetryTimer();
+          _retryTimer = setTimeout(() => {
+            _retryTimer = null;
+            if (_authGeneration !== myGeneration) return;
+            void uploadNow(_currentVariant);
+          }, retryAfterSec * 1000);
+        }
+        return;
+      }
       const body = (await res.json().catch(() => null)) as { syncVersion?: number } | null;
       if (typeof body?.syncVersion !== 'number') return;
       // Auth generation: a sign-out or user switch while the flush was in

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -27,6 +27,7 @@ import {
   parseRetryAfterSeconds,
   rearmTemporaryCloudPrefsRetry,
 } from './cloud-prefs-retry';
+import { applyObservableCloudPrefsFlushSuccess } from './cloud-prefs-flush';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
 
 export { isTemporaryCloudPrefsStatus, parseRetryAfterSeconds } from './cloud-prefs-retry';
@@ -714,22 +715,23 @@ export function install(variant: string): void {
         return;
       }
       const body = (await res.json().catch(() => null)) as { syncVersion?: number } | null;
-      if (typeof body?.syncVersion !== 'number') return;
-      // Auth generation: a sign-out or user switch while the flush was in
-      // flight already cleared/replaced sync state — don't resurrect a
-      // version marker for the previous session.
-      if (_authGeneration !== myGeneration) return;
-      // Monotonic: a slow flush response must not regress the version past
-      // a newer upload (or conflict-merge) that completed meanwhile.
-      if (body.syncVersion <= getSyncVersion()) return;
-      setSyncVersion(body.syncVersion);
-      clearSettledDirtyKeys(blob);
-      Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
-      // Only claim 'synced' when no newer edit re-armed the debounce AND no
-      // uploadNow is mid-flight (the debounce callback nulls the timer
-      // synchronously before uploadNow's async work, so the timer alone
-      // can't distinguish "idle" from "upload in progress").
-      if (_debounceTimer === null && _uploadsInFlight === 0) setState('synced');
+      applyObservableCloudPrefsFlushSuccess({
+        syncVersion: body?.syncVersion,
+        myGeneration,
+        getAuthGeneration: () => _authGeneration,
+        getSyncVersion,
+        setSyncVersion,
+        clearSettledDirtyKeys: () => clearSettledDirtyKeys(blob),
+        setLastSyncAt: (timestampMs) => {
+          Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(timestampMs));
+        },
+        // Only claim 'synced' when no newer edit re-armed the debounce AND no
+        // uploadNow is mid-flight (the debounce callback nulls the timer
+        // synchronously before uploadNow's async work, so the timer alone
+        // can't distinguish "idle" from "upload in progress").
+        isIdle: () => _debounceTimer === null && _uploadsInFlight === 0,
+        setSynced: () => setState('synced'),
+      });
     }).catch(() => { /* best-effort on unload */ });
   };
 

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -22,7 +22,14 @@ import {
   mergeCloudWithLocalDirty,
   settledDirtyKeys,
 } from './cloud-prefs-migrations';
+import {
+  isTemporaryCloudPrefsStatus,
+  parseRetryAfterSeconds,
+  rearmTemporaryCloudPrefsRetry,
+} from './cloud-prefs-retry';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
+
+export { isTemporaryCloudPrefsStatus, parseRetryAfterSeconds } from './cloud-prefs-retry';
 
 
 const ENABLED = import.meta.env.VITE_CLOUD_PREFS_ENABLED === 'true';
@@ -306,47 +313,6 @@ export class ServiceUnavailableError extends Error {
     this.retryAfterSec = retryAfterSec;
     this.status = status;
   }
-}
-
-// Bounds on the Retry-After value we'll honor. Lower bound prevents a
-// retry storm if the server sends 0 or a malformed value; upper bound
-// caps the delay so a misconfigured/extreme header doesn't strand sync
-// for minutes.
-const RETRY_AFTER_MIN_SEC = 1;
-const RETRY_AFTER_MAX_SEC = 60;
-const RETRY_AFTER_DEFAULT_SEC = 5;
-
-export function isTemporaryCloudPrefsStatus(status: number): boolean {
-  return status === 429 || status === 503;
-}
-
-/**
- * Parse the `Retry-After` header per RFC 7231: either delta-seconds or an
- * HTTP-date. Returns a clamped number of seconds, with the configured
- * default for missing/malformed values. Exported for testability.
- */
-export function parseRetryAfterSeconds(headers: Headers): number {
-  const raw = headers.get('Retry-After');
-  if (!raw) return RETRY_AFTER_DEFAULT_SEC;
-  const trimmed = raw.trim();
-  // delta-seconds form: digits only.
-  if (/^\d+$/.test(trimmed)) {
-    const n = Number(trimmed);
-    if (!Number.isFinite(n)) return RETRY_AFTER_DEFAULT_SEC;
-    return Math.min(Math.max(n, RETRY_AFTER_MIN_SEC), RETRY_AFTER_MAX_SEC);
-  }
-  // HTTP-date form: parse and convert to delta-seconds from now.
-  // `Date.parse` is permissive — `Date.parse("-5")` parses as year -5 BCE,
-  // and other garbage strings can produce finite timestamps that then
-  // clamp to RETRY_AFTER_MIN_SEC, retrying in 1s instead of the safer
-  // default. Require the input to look like a real HTTP-date (must
-  // contain both a 4-digit year and a `:` time separator) so non-date
-  // garbage falls into the default-seconds branch instead.
-  if (!/\b\d{4}\b/.test(trimmed) || !trimmed.includes(':')) return RETRY_AFTER_DEFAULT_SEC;
-  const t = Date.parse(trimmed);
-  if (!Number.isFinite(t)) return RETRY_AFTER_DEFAULT_SEC;
-  const delta = Math.round((t - Date.now()) / 1000);
-  return Math.min(Math.max(delta, RETRY_AFTER_MIN_SEC), RETRY_AFTER_MAX_SEC);
 }
 
 async function fetchCloudPrefs(token: string, variant: string): Promise<CloudPrefs | null> {
@@ -735,17 +701,16 @@ export function install(variant: string): void {
       // responses are observable during tab switches, so re-arm the normal
       // retry machinery instead of stranding the final save.
       if (!res.ok) {
-        if (isTemporaryCloudPrefsStatus(res.status)) {
-          const retryAfterSec = parseRetryAfterSeconds(res.headers);
-          if (_authGeneration !== myGeneration) return;
-          setState('pending');
-          clearRetryTimer();
-          _retryTimer = setTimeout(() => {
-            _retryTimer = null;
-            if (_authGeneration !== myGeneration) return;
-            void uploadNow(_currentVariant);
-          }, retryAfterSec * 1000);
-        }
+        rearmTemporaryCloudPrefsRetry({
+          status: res.status,
+          headers: res.headers,
+          myGeneration,
+          getAuthGeneration: () => _authGeneration,
+          setPending: () => setState('pending'),
+          clearRetryTimer,
+          setRetryTimer: (timer) => { _retryTimer = timer; },
+          uploadNow: () => uploadNow(_currentVariant),
+        });
         return;
       }
       const body = (await res.json().catch(() => null)) as { syncVersion?: number } | null;

--- a/tests/cloud-prefs-flush-success.test.mts
+++ b/tests/cloud-prefs-flush-success.test.mts
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { applyObservableCloudPrefsFlushSuccess } from '../src/utils/cloud-prefs-flush.ts';
+
+describe('applyObservableCloudPrefsFlushSuccess', () => {
+  it('adopts a newer syncVersion, settles posted dirty keys, records last sync, and marks idle state synced', () => {
+    const calls: string[] = [];
+
+    const applied = applyObservableCloudPrefsFlushSuccess({
+      syncVersion: 8,
+      myGeneration: 3,
+      getAuthGeneration: () => 3,
+      getSyncVersion: () => 7,
+      setSyncVersion: (syncVersion) => { calls.push(`version:${syncVersion}`); },
+      clearSettledDirtyKeys: () => { calls.push('clear-dirty'); },
+      setLastSyncAt: (timestampMs) => { calls.push(`last-sync:${timestampMs}`); },
+      isIdle: () => true,
+      setSynced: () => { calls.push('synced'); },
+      now: () => 1_700_000_000_000,
+    });
+
+    assert.equal(applied, true);
+    assert.deepEqual(calls, [
+      'version:8',
+      'clear-dirty',
+      'last-sync:1700000000000',
+      'synced',
+    ]);
+  });
+
+  it('does not resurrect sync state after the auth generation changes', () => {
+    let touched = false;
+
+    const applied = applyObservableCloudPrefsFlushSuccess({
+      syncVersion: 8,
+      myGeneration: 3,
+      getAuthGeneration: () => 4,
+      getSyncVersion: () => 7,
+      setSyncVersion: () => { touched = true; },
+      clearSettledDirtyKeys: () => { touched = true; },
+      setLastSyncAt: () => { touched = true; },
+      isIdle: () => true,
+      setSynced: () => { touched = true; },
+    });
+
+    assert.equal(applied, false);
+    assert.equal(touched, false);
+  });
+
+  it('does not regress local syncVersion when a newer upload completed first', () => {
+    let touched = false;
+
+    const applied = applyObservableCloudPrefsFlushSuccess({
+      syncVersion: 8,
+      myGeneration: 3,
+      getAuthGeneration: () => 3,
+      getSyncVersion: () => 9,
+      setSyncVersion: () => { touched = true; },
+      clearSettledDirtyKeys: () => { touched = true; },
+      setLastSyncAt: () => { touched = true; },
+      isIdle: () => true,
+      setSynced: () => { touched = true; },
+    });
+
+    assert.equal(applied, false);
+    assert.equal(touched, false);
+  });
+
+  it('does not claim synced while another upload is active', () => {
+    const calls: string[] = [];
+
+    const applied = applyObservableCloudPrefsFlushSuccess({
+      syncVersion: 8,
+      myGeneration: 3,
+      getAuthGeneration: () => 3,
+      getSyncVersion: () => 7,
+      setSyncVersion: (syncVersion) => { calls.push(`version:${syncVersion}`); },
+      clearSettledDirtyKeys: () => { calls.push('clear-dirty'); },
+      setLastSyncAt: (timestampMs) => { calls.push(`last-sync:${timestampMs}`); },
+      isIdle: () => false,
+      setSynced: () => { calls.push('synced'); },
+      now: () => 1_700_000_000_000,
+    });
+
+    assert.equal(applied, true);
+    assert.deepEqual(calls, [
+      'version:8',
+      'clear-dirty',
+      'last-sync:1700000000000',
+    ]);
+  });
+
+  it('ignores malformed response bodies', () => {
+    let touched = false;
+
+    const applied = applyObservableCloudPrefsFlushSuccess({
+      syncVersion: '8',
+      myGeneration: 3,
+      getAuthGeneration: () => 3,
+      getSyncVersion: () => 7,
+      setSyncVersion: () => { touched = true; },
+      clearSettledDirtyKeys: () => { touched = true; },
+      setLastSyncAt: () => { touched = true; },
+      isIdle: () => true,
+      setSynced: () => { touched = true; },
+    });
+
+    assert.equal(applied, false);
+    assert.equal(touched, false);
+  });
+});

--- a/tests/cloud-prefs-flush-version-guard.test.mjs
+++ b/tests/cloud-prefs-flush-version-guard.test.mjs
@@ -34,13 +34,8 @@ describe('cloud prefs flush version guardrails', () => {
     );
     assert.match(
       flushBody,
-      /setSyncVersion\(body\.syncVersion\)/,
-      'flushOnUnload must persist the new syncVersion on a 200',
-    );
-    assert.match(
-      flushBody,
-      /clearSettledDirtyKeys\(blob\)/,
-      'flushOnUnload must settle the dirty keys it durably uploaded',
+      /applyObservableCloudPrefsFlushSuccess\([\s\S]*syncVersion: body\?\.syncVersion,[\s\S]*setSyncVersion,[\s\S]*clearSettledDirtyKeys: \(\) => clearSettledDirtyKeys\(blob\)/,
+      'flushOnUnload must route successful observable responses through the behavior-tested flush helper',
     );
   });
 
@@ -52,12 +47,12 @@ describe('cloud prefs flush version guardrails', () => {
     );
     assert.match(
       flushBody,
-      /if \(_authGeneration !== myGeneration\) return;/,
+      /getAuthGeneration: \(\) => _authGeneration/,
       'flushOnUnload must not resurrect sync state after sign-out/user switch',
     );
     assert.match(
       flushBody,
-      /if \(body\.syncVersion <= getSyncVersion\(\)\) return;/,
+      /getSyncVersion,/,
       'flushOnUnload must never regress the version past a newer upload',
     );
   });
@@ -69,7 +64,7 @@ describe('cloud prefs flush version guardrails', () => {
     // 'synced' during an active upload (Greptile P2 on PR #4267).
     assert.match(
       flushBody,
-      /if \(_debounceTimer === null && _uploadsInFlight === 0\) setState\('synced'\);/,
+      /isIdle: \(\) => _debounceTimer === null && _uploadsInFlight === 0,[\s\S]*setSynced: \(\) => setState\('synced'\)/,
       'flushOnUnload must not claim synced while a debounce is armed or an upload is in flight',
     );
     const uploadNowBody = (() => {

--- a/tests/cloud-prefs-flush-version-guard.test.mjs
+++ b/tests/cloud-prefs-flush-version-guard.test.mjs
@@ -29,7 +29,7 @@ describe('cloud prefs flush version guardrails', () => {
     );
     assert.match(
       flushBody,
-      /if \(isTemporaryCloudPrefsStatus\(res\.status\)\) \{[\s\S]*parseRetryAfterSeconds\(res\.headers\)[\s\S]*void uploadNow\(_currentVariant\);[\s\S]*\}\s*return;/,
+      /rearmTemporaryCloudPrefsRetry\([\s\S]*status: res.status,[\s\S]*setRetryTimer:[\s\S]*uploadNow:[\s\S]*return;/,
       'flushOnUnload must requeue observable 429/503 keepalive failures instead of stranding the final save',
     );
     assert.match(

--- a/tests/cloud-prefs-flush-version-guard.test.mjs
+++ b/tests/cloud-prefs-flush-version-guard.test.mjs
@@ -29,8 +29,8 @@ describe('cloud prefs flush version guardrails', () => {
     );
     assert.match(
       flushBody,
-      /if \(!res\.ok\) return;/,
-      'flushOnUnload must leave local state untouched on 409/5xx so conflict-merge recovers',
+      /if \(isTemporaryCloudPrefsStatus\(res\.status\)\) \{[\s\S]*parseRetryAfterSeconds\(res\.headers\)[\s\S]*void uploadNow\(_currentVariant\);[\s\S]*\}\s*return;/,
+      'flushOnUnload must requeue observable 429/503 keepalive failures instead of stranding the final save',
     );
     assert.match(
       flushBody,

--- a/tests/cloud-prefs-rearm-retry.test.mts
+++ b/tests/cloud-prefs-rearm-retry.test.mts
@@ -1,0 +1,95 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { rearmTemporaryCloudPrefsRetry } from '../src/utils/cloud-prefs-retry.ts';
+
+function headersWithRetryAfter(value: string): Headers {
+  const headers = new Headers();
+  headers.set('Retry-After', value);
+  return headers;
+}
+
+describe('rearmTemporaryCloudPrefsRetry', () => {
+  it('schedules a pending upload retry using Retry-After seconds', () => {
+    let generation = 7;
+    let pendingCount = 0;
+    let clearCount = 0;
+    let uploadCount = 0;
+    let scheduledCallback: (() => void) | null = null;
+    let scheduledDelay = 0;
+    const timer = { id: 1 } as unknown as ReturnType<typeof setTimeout>;
+    const timers: Array<ReturnType<typeof setTimeout> | null> = [];
+
+    const handled = rearmTemporaryCloudPrefsRetry({
+      status: 429,
+      headers: headersWithRetryAfter('12'),
+      myGeneration: 7,
+      getAuthGeneration: () => generation,
+      setPending: () => { pendingCount += 1; },
+      clearRetryTimer: () => { clearCount += 1; },
+      setRetryTimer: (nextTimer) => { timers.push(nextTimer); },
+      uploadNow: () => { uploadCount += 1; },
+      setTimeoutFn: (callback: () => void, delay: number) => {
+        scheduledCallback = callback;
+        scheduledDelay = delay;
+        return timer;
+      },
+    });
+
+    assert.equal(handled, true);
+    assert.equal(pendingCount, 1);
+    assert.equal(clearCount, 1);
+    assert.equal(scheduledDelay, 12_000);
+    assert.deepEqual(timers, [timer]);
+
+    assert.ok(scheduledCallback, 'retry callback should be scheduled');
+    scheduledCallback();
+
+    assert.deepEqual(timers, [timer, null]);
+    assert.equal(uploadCount, 1);
+
+    generation = 8;
+    scheduledCallback();
+    assert.equal(uploadCount, 1, 'stale retry callbacks must not upload after auth changes');
+  });
+
+  it('treats stale generations as handled without scheduling a retry', () => {
+    let touched = false;
+
+    const handled = rearmTemporaryCloudPrefsRetry({
+      status: 503,
+      headers: headersWithRetryAfter('5'),
+      myGeneration: 1,
+      getAuthGeneration: () => 2,
+      setPending: () => { touched = true; },
+      clearRetryTimer: () => { touched = true; },
+      setRetryTimer: () => { touched = true; },
+      uploadNow: () => { touched = true; },
+      setTimeoutFn: (() => {
+        touched = true;
+        return undefined as unknown as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout,
+    });
+
+    assert.equal(handled, true);
+    assert.equal(touched, false);
+  });
+
+  it('ignores non-temporary statuses', () => {
+    let touched = false;
+
+    const handled = rearmTemporaryCloudPrefsRetry({
+      status: 409,
+      headers: headersWithRetryAfter('5'),
+      myGeneration: 1,
+      getAuthGeneration: () => 1,
+      setPending: () => { touched = true; },
+      clearRetryTimer: () => { touched = true; },
+      setRetryTimer: () => { touched = true; },
+      uploadNow: () => { touched = true; },
+    });
+
+    assert.equal(handled, false);
+    assert.equal(touched, false);
+  });
+});

--- a/tests/cloud-prefs-retry-after.test.mjs
+++ b/tests/cloud-prefs-retry-after.test.mjs
@@ -3,27 +3,10 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { isTemporaryCloudPrefsStatus, parseRetryAfterSeconds } from '../src/utils/cloud-prefs-retry.ts';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-
-// Extract `parseRetryAfterSeconds` from src/utils/cloud-prefs-sync.ts and
-// run it standalone. The full module imports browser-only globals; this
-// test focuses on the pure-function piece. Same regex+Function pattern the
-// other src-extraction tests use (csp-filter, sentry-beforesend).
 const src = readFileSync(resolve(__dirname, '../src/utils/cloud-prefs-sync.ts'), 'utf-8');
-const constsBlock = src.match(/const RETRY_AFTER_MIN_SEC[\s\S]*?const RETRY_AFTER_DEFAULT_SEC[^\n]+/);
-assert.ok(constsBlock, 'RETRY_AFTER_* constants must exist in cloud-prefs-sync.ts');
-const fnMatch = src.match(/export function parseRetryAfterSeconds\(headers: Headers\): number \{([\s\S]*?)\n\}/);
-assert.ok(fnMatch, 'parseRetryAfterSeconds must exist in cloud-prefs-sync.ts');
-
-const fnBody = constsBlock[0] + ';\n' + fnMatch[1].trim();
-// eslint-disable-next-line no-new-func
-const parseRetryAfterSeconds = new Function('headers', fnBody);
-
-const temporaryStatusMatch = src.match(/export function isTemporaryCloudPrefsStatus\(status: number\): boolean \{([\s\S]*?)\n\}/);
-assert.ok(temporaryStatusMatch, 'isTemporaryCloudPrefsStatus must exist in cloud-prefs-sync.ts');
-// eslint-disable-next-line no-new-func
-const isTemporaryCloudPrefsStatus = new Function('status', temporaryStatusMatch[1].trim());
 
 const postCloudPrefsBody = (() => {
   const start = src.indexOf('async function postCloudPrefs');
@@ -121,25 +104,15 @@ describe('parseRetryAfterSeconds', () => {
     });
 
     it('returns default for empty string', () => {
-      // Empty header is treated as absent by Headers.set, but the regex
-      // won't match either — defensive double-check.
       assert.equal(parseRetryAfterSeconds(mkHeaders('')), 5);
     });
 
     it('returns default for negative-number form (not a valid delta-seconds)', () => {
-      // RFC delta-seconds is digits-only; "-5" would parse via Number()
-      // but our `^\d+$` regex correctly rejects it. The HTTP-date branch
-      // is then gated on a 4-digit year + a `:` separator, so "-5" can't
-      // sneak through as Date.parse("-5") returning year -5 BCE.
       assert.equal(parseRetryAfterSeconds(mkHeaders('-5')), 5);
     });
 
     it('returns default for a date-shaped string lacking a time component', () => {
-      // Defensive: "2025-01-01" would Date.parse() as midnight Jan 1.
-      // The colon-required gate excludes it, falling into default rather
-      // than letting Date.parse interpret a date-only string and clamp
-      // to MIN/MAX based on now's distance from Jan 1.
-      assert.equal(parseRetryAfterSeconds(mkHeaders('2025-01-01')), 5);
+      assert.equal(parseRetryAfterSeconds(mkHeaders('2026-01-01')), 5);
     });
   });
 });

--- a/tests/user-prefs-rate-limit.test.mts
+++ b/tests/user-prefs-rate-limit.test.mts
@@ -197,4 +197,42 @@ describe('user-prefs POST write rate limit', () => {
     assert.equal(warnMock.mock.calls.length, 1);
     assert.match(String(warnMock.mock.calls[0].arguments[0]), /rate limit unavailable; failing open/);
   });
+
+  it('maps Convex-side RATE_LIMITED to 429 with retry guidance', async () => {
+    process.env.CONVEX_URL = 'https://convex.test';
+    mock.method(Date, 'now', () => TEST_NOW);
+    const reset = TEST_NOW + 12_000;
+
+    __setUserPrefsDepsForTests({
+      validateBearerToken: async () => ({ valid: true, userId: TEST_USER_ID }),
+      checkScopedRateLimit: async () => ({
+        allowed: true,
+        limit: USER_PREFS_WRITE_RATE_LIMIT,
+        reset,
+        degraded: false,
+      }),
+      createConvexClient: () => ({
+        setAuth(): void {},
+        async query(): Promise<unknown> {
+          return null;
+        },
+        async mutation(): Promise<unknown> {
+          const err = new Error('ConvexError: RATE_LIMITED') as Error & {
+            data?: Record<string, unknown>;
+          };
+          err.data = { kind: 'RATE_LIMITED', limit: USER_PREFS_WRITE_RATE_LIMIT, reset };
+          throw err;
+        },
+      }),
+    });
+
+    const res = await handler(makePost());
+
+    assert.equal(res.status, 429);
+    assert.equal(res.headers.get('Retry-After'), '12');
+    assert.equal(res.headers.get('X-RateLimit-Limit'), String(USER_PREFS_WRITE_RATE_LIMIT));
+    assert.equal(res.headers.get('X-RateLimit-Remaining'), '0');
+    assert.equal(res.headers.get('X-RateLimit-Reset'), String(reset));
+    assert.deepEqual(await res.json(), { error: 'RATE_LIMITED' });
+  });
 });

--- a/tests/user-prefs-rate-limit.test.mts
+++ b/tests/user-prefs-rate-limit.test.mts
@@ -7,6 +7,10 @@ import handler, {
   USER_PREFS_WRITE_RATE_SCOPE,
   USER_PREFS_WRITE_RATE_WINDOW,
 } from '../api/user-prefs.ts';
+import {
+  USER_PREFS_WRITE_RATE_LIMIT as CONVEX_USER_PREFS_WRITE_RATE_LIMIT,
+  USER_PREFS_WRITE_RATE_WINDOW_MS,
+} from '../convex/constants.ts';
 
 const originalConvexUrl = process.env.CONVEX_URL;
 const TEST_NOW = 1_700_000_000_000;
@@ -25,6 +29,14 @@ type ClientCall =
   | { kind: 'setAuth'; token: string }
   | { kind: 'query'; name: unknown; args: Record<string, unknown> }
   | { kind: 'mutation'; name: unknown; args: Record<string, unknown> };
+
+function expectExposedRateLimitHeaders(headers: Headers): void {
+  const exposed = headers.get('Access-Control-Expose-Headers') ?? '';
+  assert.match(exposed, /Retry-After/);
+  assert.match(exposed, /X-RateLimit-Limit/);
+  assert.match(exposed, /X-RateLimit-Remaining/);
+  assert.match(exposed, /X-RateLimit-Reset/);
+}
 
 function restoreEnv(): void {
   if (originalConvexUrl === undefined) delete process.env.CONVEX_URL;
@@ -91,6 +103,11 @@ function installDeps(rateLimitResult: RateLimitResult): {
 }
 
 describe('user-prefs POST write rate limit', () => {
+  it('keeps the Edge and Convex write limit contracts in lockstep', () => {
+    assert.equal(USER_PREFS_WRITE_RATE_LIMIT, CONVEX_USER_PREFS_WRITE_RATE_LIMIT);
+    assert.equal(USER_PREFS_WRITE_RATE_WINDOW, String(USER_PREFS_WRITE_RATE_WINDOW_MS / 1000) + ' s');
+  });
+
   it('rejects invalid sessions before checking the scoped limiter', async () => {
     const rateLimitCalls: Array<{ scope: string; limit: number; window: string; identifier: string }> = [];
     let createdClient = false;
@@ -114,6 +131,7 @@ describe('user-prefs POST write rate limit', () => {
     assert.deepEqual(rateLimitCalls, []);
     assert.equal(createdClient, false);
   });
+
   it('returns 429 + Retry-After without calling Convex when the identity is over budget', async () => {
     process.env.CONVEX_URL = 'https://convex.test';
     mock.method(Date, 'now', () => TEST_NOW);
@@ -132,6 +150,7 @@ describe('user-prefs POST write rate limit', () => {
     assert.equal(res.headers.get('X-RateLimit-Limit'), String(USER_PREFS_WRITE_RATE_LIMIT));
     assert.equal(res.headers.get('X-RateLimit-Remaining'), '0');
     assert.equal(res.headers.get('X-RateLimit-Reset'), String(TEST_NOW + 30_000));
+    expectExposedRateLimitHeaders(res.headers);
     assert.deepEqual(await res.json(), { error: 'RATE_LIMITED' });
     assert.deepEqual(rateLimitCalls, [{
       scope: USER_PREFS_WRITE_RATE_SCOPE,
@@ -233,6 +252,7 @@ describe('user-prefs POST write rate limit', () => {
     assert.equal(res.headers.get('X-RateLimit-Limit'), String(USER_PREFS_WRITE_RATE_LIMIT));
     assert.equal(res.headers.get('X-RateLimit-Remaining'), '0');
     assert.equal(res.headers.get('X-RateLimit-Reset'), String(reset));
+    expectExposedRateLimitHeaders(res.headers);
     assert.deepEqual(await res.json(), { error: 'RATE_LIMITED' });
   });
 });

--- a/tests/user-prefs-rate-limit.test.mts
+++ b/tests/user-prefs-rate-limit.test.mts
@@ -220,6 +220,7 @@ describe('user-prefs POST write rate limit', () => {
   it('maps Convex-side RATE_LIMITED to 429 with retry guidance', async () => {
     process.env.CONVEX_URL = 'https://convex.test';
     mock.method(Date, 'now', () => TEST_NOW);
+    const warnMock = mock.method(console, 'warn', () => {});
     const reset = TEST_NOW + 12_000;
 
     __setUserPrefsDepsForTests({
@@ -254,5 +255,83 @@ describe('user-prefs POST write rate limit', () => {
     assert.equal(res.headers.get('X-RateLimit-Reset'), String(reset));
     expectExposedRateLimitHeaders(res.headers);
     assert.deepEqual(await res.json(), { error: 'RATE_LIMITED' });
+    assert.equal(warnMock.mock.calls.length, 1);
+    assert.match(String(warnMock.mock.calls[0].arguments[0]), /convex write rate limit exceeded/);
+  });
+
+  it('maps returned Convex-side RATE_LIMITED to 429 with retry guidance and a warning', async () => {
+    process.env.CONVEX_URL = 'https://convex.test';
+    mock.method(Date, 'now', () => TEST_NOW);
+    const warnMock = mock.method(console, 'warn', () => {});
+    const reset = TEST_NOW + 12_000;
+
+    __setUserPrefsDepsForTests({
+      validateBearerToken: async () => ({ valid: true, userId: TEST_USER_ID }),
+      checkScopedRateLimit: async () => ({
+        allowed: true,
+        limit: USER_PREFS_WRITE_RATE_LIMIT,
+        reset,
+        degraded: false,
+      }),
+      createConvexClient: () => ({
+        setAuth(): void {},
+        async query(): Promise<unknown> {
+          return null;
+        },
+        async mutation(): Promise<unknown> {
+          return {
+            ok: false,
+            reason: 'RATE_LIMITED',
+            limit: USER_PREFS_WRITE_RATE_LIMIT,
+            reset,
+          };
+        },
+      }),
+    });
+
+    const res = await handler(makePost());
+
+    assert.equal(res.status, 429);
+    assert.equal(res.headers.get('Retry-After'), '12');
+    assert.equal(res.headers.get('X-RateLimit-Limit'), String(USER_PREFS_WRITE_RATE_LIMIT));
+    assert.equal(res.headers.get('X-RateLimit-Remaining'), '0');
+    assert.equal(res.headers.get('X-RateLimit-Reset'), String(reset));
+    expectExposedRateLimitHeaders(res.headers);
+    assert.deepEqual(await res.json(), { error: 'RATE_LIMITED' });
+    assert.equal(warnMock.mock.calls.length, 1);
+    assert.match(String(warnMock.mock.calls[0].arguments[0]), /convex write rate limit exceeded/);
+  });
+
+  it('maps returned Convex-side BLOB_TOO_LARGE to 400', async () => {
+    process.env.CONVEX_URL = 'https://convex.test';
+
+    __setUserPrefsDepsForTests({
+      validateBearerToken: async () => ({ valid: true, userId: TEST_USER_ID }),
+      checkScopedRateLimit: async () => ({
+        allowed: true,
+        limit: USER_PREFS_WRITE_RATE_LIMIT,
+        reset: TEST_NOW + 60_000,
+        degraded: false,
+      }),
+      createConvexClient: () => ({
+        setAuth(): void {},
+        async query(): Promise<unknown> {
+          return null;
+        },
+        async mutation(): Promise<unknown> {
+          return {
+            ok: false,
+            reason: 'BLOB_TOO_LARGE',
+            size: 123,
+            max: 100,
+          };
+        },
+      }),
+    });
+
+    const res = await handler(makePost());
+
+    assert.equal(res.status, 400);
+    assert.deepEqual(await res.json(), { error: 'BLOB_TOO_LARGE' });
   });
 });


### PR DESCRIPTION
## Summary
Cloud preference writes are now metered at the Convex mutation boundary, so authenticated callers that bypass Vercel and hit the public Convex HTTP surface cannot write preferences unbounded. Both `/api/user-prefs` entry points now return the same 429 contract with `Retry-After`, and visible tab-switch keepalive failures re-enter the normal retry path instead of silently losing the final pending save.

This keeps #4588's deliberate Vercel fail-open behavior for Redis limiter outages while adding the authoritative server-side guard where every write must pass.

## Validation
- `npm run test:convex -- convex/__tests__/userPreferences.test.ts`
- `./node_modules/.bin/tsx --test tests/user-prefs-rate-limit.test.mts tests/cloud-prefs-flush-version-guard.test.mjs tests/user-prefs-convex-error.test.mjs`
- `/home/elie/github/worldmonitor/node_modules/.bin/tsx --test tests/cloud-prefs-retry-after.test.mjs`
- `npm run typecheck:api`
- `npm run typecheck`
- `git diff --check`

Local `npm ci` could not complete because the filesystem was full, so focused tests were run using the existing shared dependency install.

## Post-Deploy Monitoring & Validation
- Watch edge logs for `[user-prefs] POST write rate limit exceeded`, `[user-prefs] POST write rate limit unavailable; failing open`, and `RATE_LIMITED` responses from both Vercel and Convex `/api/user-prefs` paths.
- Track 429 volume on `/api/user-prefs` by user/session; healthy signal is low, isolated 429s with matching `Retry-After` headers and no sustained retry storm.
- Track cloud preference sync error states and Sentry buckets for `SERVICE_UNAVAILABLE`, `RATE_LIMITED`, and stuck 409 conflict loops; healthy signal is no increase in final-save loss or repeated conflict retries after tab/page hide.
- Roll back or disable the Convex mutation limiter if legitimate users show broad 429s below expected usage, if the rate-limit table grows unexpectedly, or if unload retries create elevated write volume.
- Validation window: first 24 hours after deploy, owner: on-call/release owner.

## Related
Related: #4620, #4588

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
