### PR TITLE
feat: make Vite dev server port configurable via DEV_PORT

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,10 @@
 
 # ------ Local dev server ------
 
-# Port for the Vite dev server (`npm run dev`). Defaults to 3000 when unset.
-# Config-time only (read in vite.config.ts) — intentionally NOT VITE_-prefixed
-# so it is never injected into the client bundle.
+# Port for the main Vite dev server (`npm run dev`). Defaults to 3000 when unset,
+# or when the value is not an integer in 1–65535. (The pro-test dev server keeps its
+# own fixed port.) Config-time only (read in vite.config.ts) — intentionally NOT
+# VITE_-prefixed so it is never injected into the client bundle.
 # DEV_PORT=3000
 
 

--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,9 @@
 # ------ Local dev server ------
 
 # Port for the Vite dev server (`npm run dev`). Defaults to 3000 when unset.
-# VITE_DEV_PORT=3000
+# Config-time only (read in vite.config.ts) — intentionally NOT VITE_-prefixed
+# so it is never injected into the client bundle.
+# DEV_PORT=3000
 
 
 # ------ AI Summarization (Vercel) ------

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,12 @@
 # ============================================
 
 
+# ------ Local dev server ------
+
+# Port for the Vite dev server (`npm run dev`). Defaults to 3000 when unset.
+# VITE_DEV_PORT=3000
+
+
 # ------ AI Summarization (Vercel) ------
 
 # Groq API (primary — 14,400 req/day on free tier)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ npm run build:happy
 npm run build:energy
 ```
 
-The dev server runs at `http://localhost:3000`. Run `make help` to see all available make targets.
+The dev server runs at `http://localhost:3000` (override the port with `DEV_PORT` in `.env.local`). Run `make help` to see all available make targets.
 
 ### Environment Variables (Optional)
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ npm install
 npm run dev
 ```
 
-Open [localhost:3000](http://localhost:3000). The app runs with no environment variables.
+Open [localhost:3000](http://localhost:3000) (override the port with `DEV_PORT` in `.env.local`). The app runs with no environment variables.
 
 Feature-specific data sources may require credentials — for example, the flight-price command (`fly LON DXB`) needs `TRAVELPAYOUTS_API_TOKEN` to return live quotes; without it the command shows a "credentials required" message rather than synthetic data. See `.env.example` for the full list.
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1261,7 +1261,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
-      port: Number(env.VITE_DEV_PORT) || 3000,
+      port: env.VITE_DEV_PORT ? (Number(env.VITE_DEV_PORT) || 3000) : 3000,
       open: !isE2E,
       hmr: isE2E ? false : undefined,
       watch: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1261,7 +1261,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
-      port: 3000,
+      port: Number(env.VITE_DEV_PORT) || 3000,
       open: !isE2E,
       hmr: isE2E ? false : undefined,
       watch: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1261,7 +1261,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
-      port: env.VITE_DEV_PORT ? (Number(env.VITE_DEV_PORT) || 3000) : 3000,
+      port: Number(env.DEV_PORT) || 3000,
       open: !isE2E,
       hmr: isE2E ? false : undefined,
       watch: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -880,6 +880,15 @@ export default defineConfig(({ mode }) => {
   // available to the dev server plugins and server-side handlers.
   Object.assign(process.env, env);
 
+  // Dev-server port: DEV_PORT overrides the 3000 default. Reject non-integer or
+  // out-of-range values (fall back to 3000) so a typo can't crash Vite's listen()
+  // with ERR_SOCKET_BAD_PORT. Not VITE_-prefixed, so it never reaches the client bundle.
+  const parsedDevPort = Number(env.DEV_PORT);
+  const devPort =
+    Number.isInteger(parsedDevPort) && parsedDevPort >= 1 && parsedDevPort <= 65535
+      ? parsedDevPort
+      : 3000;
+
   const isE2E = process.env.VITE_E2E === '1';
   const isDesktopBuild = process.env.VITE_DESKTOP_RUNTIME === '1';
   const activeVariant = process.env.VITE_VARIANT || 'full';
@@ -1261,7 +1270,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
-      port: Number(env.DEV_PORT) || 3000,
+      port: devPort,
       open: !isE2E,
       hmr: isE2E ? false : undefined,
       watch: {


### PR DESCRIPTION
## Summary

Makes the Vite dev server port `.env`-driven instead of hardcoded, so contributors can run on a different port without editing tracked source or passing `--port` on every invocation.

Previously `vite.config.ts` pinned the dev server to `3000`. The config already loads env vars via `loadEnv(mode, process.cwd(), '')`, so this reads an optional `DEV_PORT` and falls back to `3000` when it is unset or invalid — existing setups are unaffected.

`DEV_PORT` is intentionally **not** `VITE_`-prefixed: it is read only at config time in `vite.config.ts`, so it is never injected into the client bundle.

## Changes

- `vite.config.ts` — dev-server `port` now resolves from `DEV_PORT`, validated to an integer in `1–65535` (falls back to `3000` otherwise).
- `.env.example` — documents `DEV_PORT` under a "Local dev server" section.
- `CONTRIBUTING.md`, `README.md` — note the `DEV_PORT` override where contributors set up the dev server.

## Technical details

- Reuses the existing `loadEnv` call (empty prefix), so no new env plumbing is introduced.
- Invalid values — unset, non-numeric, `0`/negative, non-integer, or out of range (`> 65535`) — fall back to `3000`, so a typo can't crash Vite's `listen()` with `ERR_SOCKET_BAD_PORT`.
- `strictPort` is intentionally left unset, preserving Vite's auto-increment behaviour when the chosen port is occupied.

## Acceptance criteria

- [x] `DEV_PORT` in `.env` controls the dev server port
- [x] Falls back to `3000` when unset or invalid
- [x] `.env.example` documents the new variable

Closes #4641

---
_Maintainer follow-up (koala73): added integer/range validation for `DEV_PORT` and documented the override in CONTRIBUTING.md / README.md._
