### PR TITLE
fix: render header dropdown panels above the content grid

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -323,6 +323,12 @@ canvas,
   border-bottom: 1px solid var(--border);
   height: 40px;
   flex-shrink: 0;
+  /* Lift the header's stacking context above the content grid so its
+     dropdown panels (Intelligence Findings, Pentagon Pizza, etc.) are not
+     occluded by .panels-grid (z-index: 1) or .map-controls (z-index: 500).
+     Kept below .search-overlay (2000) and modals so they still cover the header. */
+  position: relative;
+  z-index: 600;
 }
 
 /* -- Tauri desktop: separate title bar for traffic lights -- */


### PR DESCRIPTION
## Summary

The **Intelligence Findings** and **Pentagon Pizza Index** header dropdowns opened beneath the top toolbar but rendered *behind* the map controls and the side feed panels (INTEL FEED / LIVE NEWS / LIVE WEBCAMS), leaving them partly unreadable and unclickable.

## Root cause

`.header` is a stacking context sitting at the root `auto/0` level, while the content grid below it is `position: relative; z-index: 1` (`.panels-grid`) and `.map-controls` is `z-index: 500`. The entire header branch therefore paints *below* those, and the dropdowns are trapped in the header's band — **no z-index on the dropdowns themselves can lift them out**.

`.mission-preset-popover` avoids this only because it is portaled to `document.body`; the two affected dropdowns live inside the header.

## Fix

Give `.header` its own positive stacking context so its whole subtree — every current and future header dropdown — paints above the content grid:

```css
.header {
  position: relative;
  z-index: 600;
}
```

`600` clears `.panels-grid` (1) and `.map-controls` (500) while staying below `.search-overlay` (2000) and the modal tiers (3000-10000+), so overlays still cover the header.

## Verification

Verified in the running app via `elementFromPoint` sampling of the open dropdown:

| State | Dropdown points rendered on top |
| --- | --- |
| Original CSS | 5 / 25 (occluded by `.panels-grid`, map canvas) |
| Dropdown `z-index` alone bumped to 5000 | 5 / 25 (no change — proves per-component z-index is insufficient) |
| **This fix (header lifted)** | **25 / 25 (fully on top)** |

Confirmed visually: the Intelligence Findings panel now renders entirely above the LIVE NEWS panel and map. The Pentagon Pizza panel mounts in the same `.header`, so the same fix covers it.

## Follow-up (separate, see #4643)

Introduce z-index tokens (`--z-header`, `--z-popover`, `--z-modal`, ...) — values currently sprawl from 1 to 100000 with no scale, which is what let this regress.

Closes #4643