### PR TITLE
fix(worker): stop analysis-worker orphaning a rejected promise (Sentry V2/V6)

### DIFF
--- a/src/services/analysis-worker.ts
+++ b/src/services/analysis-worker.ts
@@ -36,6 +36,10 @@ class AnalysisWorkerManager {
   private pendingRequests: Map<string, PendingRequest<unknown>> = new Map();
   private requestIdCounter = 0;
   private isReady = false;
+  // Set true when worker construction throws synchronously (e.g. legacy
+  // browsers without module-worker support). Latches so we don't re-attempt
+  // construction on every call, and gates callers into graceful degradation.
+  private workerUnavailable = false;
   private readyPromise: Promise<void> | null = null;
   private readyResolve: (() => void) | null = null;
   private readyReject: ((error: Error) => void) | null = null;
@@ -47,7 +51,7 @@ class AnalysisWorkerManager {
    * Initialize the worker. Called lazily on first use.
    */
   private initWorker(): void {
-    if (this.worker) return;
+    if (this.worker || this.workerUnavailable) return;
 
     this.readyPromise = new Promise((resolve, reject) => {
       this.readyResolve = resolve;
@@ -67,8 +71,17 @@ class AnalysisWorkerManager {
     try {
       this.worker = new AnalysisWorker();
     } catch (error) {
+      // Legacy browsers without module-worker support (e.g. old smart-TV
+      // browsers) throw synchronously here. Do NOT reject readyPromise:
+      // cleanup() nulls readyPromise in this same synchronous tick, so
+      // waitForReady's `await this.readyPromise` would await `null` and the
+      // rejection would be orphaned into an unhandled promise rejection
+      // (WORLDMONITOR-V2/V6). Instead latch `workerUnavailable`, resolve the
+      // ready gate, and let clusterNews/analyzeCorrelations degrade to an
+      // empty result. Mirrors ml-worker's graceful `resolve(false)` path.
       console.error('[AnalysisWorker] Failed to create worker:', error);
-      this.readyReject?.(error instanceof Error ? error : new Error(String(error)));
+      this.workerUnavailable = true;
+      this.readyResolve?.();
       this.cleanup();
       return;
     }
@@ -202,6 +215,10 @@ class AnalysisWorkerManager {
    */
   async clusterNews(items: NewsItem[]): Promise<ClusteredEvent[]> {
     await this.waitForReady();
+    // Worker never came up (e.g. browser lacks module-worker support) — skip
+    // clustering rather than posting to a null worker. request() below derefs
+    // this.worker!, so guarding here keeps the degradation graceful.
+    if (!this.isReady) return [];
     return this.request<ClusteredEvent[]>(
       'cluster',
       { items, sourceTiers: SOURCE_TIERS },
@@ -220,6 +237,7 @@ class AnalysisWorkerManager {
     markets: MarketData[]
   ): Promise<CorrelationSignal[]> {
     await this.waitForReady();
+    if (!this.isReady) return [];
     return this.request<CorrelationSignal[]>(
       'correlation',
       {


### PR DESCRIPTION
## Summary

Fixes an **unhandled promise rejection** captured by Sentry (`WORLDMONITOR-V2` / `WORLDMONITOR-V6`) on legacy browsers that lack module-worker support (observed on **LG NetCast Smart TV**).

**Root cause:** In `AnalysisWorkerManager.initWorker()`, the worker-construction `catch` called `readyReject(error)` and then `cleanup()`. `cleanup()` nulls `this.readyPromise` **in the same synchronous tick**, so `waitForReady()`'s `await this.readyPromise` awaited `null` (which resolves) instead of the rejected promise. The rejection was orphaned → unhandled promise rejection → captured by Sentry with the construction error's stack (`new AnalysisWorker → initWorker → waitForReady → clusterNews → loadNews`). Separately, `clusterNews`/`analyzeCorrelations` then posted to a null worker.

**Fix** (mirrors the already-correct `ml-worker.ts` graceful `resolve(false)` pattern):
- Latch a `workerUnavailable` flag when construction throws (also short-circuits re-attempts).
- Resolve the ready gate instead of rejecting — no orphaned rejection.
- Guard `clusterNews` / `analyzeCorrelations` to return `[]` when the worker never came up, instead of dereferencing a null worker.
- Genuine runtime failures (ready timeout, `onerror`) still reject and surface — those paths `await` the promise *before* `cleanup()` nulls it, so they were never affected.

Clustering/correlation are non-critical enhancements; degrading to an empty result on unsupported browsers is the intended behavior (all three call sites already treat failure as "keep flat list / skip").

## Test plan

- [x] `npm run typecheck` + `typecheck:api` — pass
- [x] `npm run lint` (Biome + safe-html) — pass
- [x] `npm run test:data` — pass (dashboard-critical-css built-output tests green 8/8 after `VITE_VARIANT=full vite build`)
- [x] Edge bundle check (esbuild, 19 files) + `tests/edge-functions.test.mjs` (205/205) — pass
- [x] `lint:md`, `version:check` — pass
- [x] `VITE_VARIANT=full vite build` — change bundles cleanly

No worker-manager unit test exists in the repo, and the Vite `?worker` import isn't exercisable under the `tsx --test`/no-jsdom infra; verified via tsc + logic review against the known-good `ml-worker` sibling.

https://claude.ai/code/session_01WshrV8FyTKTUndRpogA9Yh