### PR TITLE
fix(seed-trade-flows): pin lagged Comtrade period + best-effort Russia/Iran to stop exit-75 crash

### DIFF
--- a/scripts/seed-trade-flows.mjs
+++ b/scripts/seed-trade-flows.mjs
@@ -17,22 +17,48 @@ const ANOMALY_THRESHOLD = 0.30; // 30% YoY change
 // (e.g., wrong reporterCode → HTTP 200 with count:0 for every commodity).
 // Global coverage floor — overall populated/total must be ≥ this.
 const MIN_COVERAGE_RATIO = 0.70;
-// Per-reporter coverage floor — each reporter must have ≥ this fraction of
-// its commodities populated. Prevents the "India/Taiwan flatlines entirely"
-// failure mode: with 6 reporters × 5 commodities, losing one full reporter
-// is only 5/30 missing (83% global coverage → passes MIN_COVERAGE_RATIO),
-// but 0/5 per-reporter coverage for the dead one blocks publish here.
+// Per-reporter coverage floor — each REQUIRED reporter must have ≥ this fraction
+// of its commodities populated. Prevents the "India/Taiwan flatlines entirely"
+// failure mode: losing one full required reporter passes the global ratio but
+// its 0/5 per-reporter coverage blocks publish here.
 const MIN_PER_REPORTER_RATIO = 0.40; // at least 2 of 5 commodities per reporter
 
-// Strategic reporters: US, China, Russia, Iran, India, Taiwan
+// Strategic reporters: US, China, Russia, Iran, India, Taiwan.
+// `required: false` reporters are best-effort: still fetched and published when
+// they return data, but excluded from BOTH coverage floors. Russia (suspended
+// UN Comtrade reporting post-2022) and Iran (sporadic) return 0 as reporters for
+// every recent year, so gating on them makes the publish gate unsatisfiable and
+// exit-75-crashes the seed on every run regardless of period.
 const REPORTERS = [
   { code: '842', name: 'USA' },
   { code: '156', name: 'China' },
-  { code: '643', name: 'Russia' },
-  { code: '364', name: 'Iran' },
+  { code: '643', name: 'Russia', required: false },
+  { code: '364', name: 'Iran', required: false },
   { code: '699', name: 'India' },
   { code: '490', name: 'Taiwan' },
 ];
+
+// Comtrade annual data lags. The preview endpoint accepts a SINGLE period and,
+// when given NONE, defaults to the most-recent year present GLOBALLY — currently
+// the fastest reporter (US) is a full year ahead of everyone else, so that
+// default flatlines every other reporter and trips the coverage gate. (Multiple
+// comma-separated periods return HTTP 400 on this endpoint.) Pin an explicit,
+// uniform year instead: (y-2) is ~2 years old, so it is reliably final for all
+// strategic reporters. (Single-year data means yoyChange stays 0 here, same as
+// the pre-fix implicit-latest behavior — restoring true YoY needs a second call.)
+export function recentPeriod(now = new Date(), lag = 2) {
+  return String(now.getUTCFullYear() - lag);
+}
+
+// Candidate periods, freshest first. fetchAllFlows tries (y-2) and, only if its
+// coverage gate fails, falls back to (y-3). This survives the year boundary:
+// on Jan 1, (y-2) rolls to a fresher year the slower required reporters may not
+// have filed yet — without the fallback the seed would exit-75-crash for weeks
+// until they catch up. (y-3) is guaranteed-final and keeps the snapshot fresh
+// enough (annual trade data is inherently ~2yr lagged).
+export function candidatePeriods(now = new Date()) {
+  return [recentPeriod(now, 2), recentPeriod(now, 3)];
+}
 
 // Strategic HS commodity codes
 const COMMODITIES = [
@@ -54,11 +80,12 @@ export function isTransientComtrade(status) {
 let _retrySleep = sleep;
 export function __setSleepForTests(fn) { _retrySleep = typeof fn === 'function' ? fn : sleep; }
 
-export async function fetchFlows(reporter, commodity) {
+export async function fetchFlows(reporter, commodity, period = recentPeriod()) {
   const url = new URL(`${COMTRADE_BASE}/preview/C/A/HS`);
   url.searchParams.set('reporterCode', reporter.code);
   url.searchParams.set('cmdCode', commodity.code);
   url.searchParams.set('flowCode', 'X,M'); // exports + imports
+  url.searchParams.set('period', period); // explicit lagged year; see recentPeriod()
 
   async function once() {
     return fetch(url.toString(), {
@@ -139,7 +166,9 @@ export async function fetchFlows(reporter, commodity) {
   return flows;
 }
 
-async function fetchAllFlows() {
+// Fetch every (reporter × commodity) pair for one annual `period`.
+// `pace` is the inter-request delay (injectable so tests skip the real 3s waits).
+async function fetchFlowsForPeriod(period, pace) {
   const allFlows = [];
   const perKeyFlows = {};
 
@@ -149,12 +178,12 @@ async function fetchAllFlows() {
       const commodity = COMMODITIES[ci];
       const label = `${reporter.name}/${commodity.desc}`;
 
-      if (ri > 0 || ci > 0) await sleep(INTER_REQUEST_DELAY_MS);
-      console.log(`  Fetching ${label}...`);
+      if (ri > 0 || ci > 0) await pace(INTER_REQUEST_DELAY_MS);
+      console.log(`  Fetching ${label} (period ${period})...`);
 
       let flows = [];
       try {
-        flows = await fetchFlows(reporter, commodity);
+        flows = await fetchFlows(reporter, commodity, period);
         console.log(`    ${flows.length} records`);
       } catch (err) {
         console.warn(`    ${label}: failed (${err.message})`);
@@ -166,16 +195,37 @@ async function fetchAllFlows() {
     }
   }
 
-  const gate = checkCoverage(perKeyFlows, REPORTERS, COMMODITIES);
-  console.log(`  Coverage: ${gate.populated}/${gate.total} (${(gate.globalRatio * 100).toFixed(0)}%) reporter×commodity pairs populated`);
-  for (const r of gate.perReporter) {
-    if (r.ratio < MIN_PER_REPORTER_RATIO) {
-      console.warn(`    ${r.reporter} reporter ${r.code}: ${r.populated}/${r.total} (${(r.ratio * 100).toFixed(0)}%) — below per-reporter floor ${MIN_PER_REPORTER_RATIO}`);
+  return { allFlows, perKeyFlows };
+}
+
+export async function fetchAllFlows(opts = {}) {
+  const periods = opts.periods ?? candidatePeriods();
+  const pace = opts.pace ?? sleep;
+
+  let lastGate = null;
+  for (let pi = 0; pi < periods.length; pi++) {
+    const period = periods[pi];
+    if (pi > 0) console.log(`  Prior period failed coverage — falling back to period ${period}...`);
+
+    const { allFlows, perKeyFlows } = await fetchFlowsForPeriod(period, pace);
+
+    const gate = checkCoverage(perKeyFlows, REPORTERS, COMMODITIES);
+    lastGate = gate;
+    console.log(`  Coverage (period ${period}): ${gate.populated}/${gate.total} (${(gate.globalRatio * 100).toFixed(0)}%) required reporter×commodity pairs populated`);
+    for (const r of gate.perReporter) {
+      if (!r.required) {
+        console.log(`    ${r.reporter} reporter ${r.code}: ${r.populated}/${r.total} (best-effort, not gated)`);
+      } else if (r.ratio < MIN_PER_REPORTER_RATIO) {
+        console.warn(`    ${r.reporter} reporter ${r.code}: ${r.populated}/${r.total} (${(r.ratio * 100).toFixed(0)}%) — below per-reporter floor ${MIN_PER_REPORTER_RATIO}`);
+      }
+    }
+
+    if (gate.ok) {
+      return { flows: allFlows, perKeyFlows, fetchedAt: new Date().toISOString(), period };
     }
   }
-  if (!gate.ok) throw new Error(gate.reason);
 
-  return { flows: allFlows, perKeyFlows, fetchedAt: new Date().toISOString() };
+  throw new Error(lastGate?.reason ?? 'no candidate period produced sufficient coverage');
 }
 
 /**
@@ -189,19 +239,34 @@ async function fetchAllFlows() {
  * a global-only gate.
  */
 export function checkCoverage(perKeyFlows, reporters, commodities) {
-  const total = reporters.length * commodities.length;
-  const populated = Object.values(perKeyFlows).filter((v) => (v.flows?.length ?? 0) > 0).length;
-  const globalRatio = total > 0 ? populated / total : 0;
+  const commTotal = commodities.length;
 
+  // Full breakdown (for logging). `required` defaults to true, so callers that
+  // pass plain { code, name } reporters keep the original all-reporters gate.
   const perReporter = reporters.map((r) => {
     const pop = commodities.filter((c) => (perKeyFlows[`${KEY_PREFIX}:${r.code}:${c.code}`]?.flows?.length ?? 0) > 0).length;
-    return { reporter: r.name, code: r.code, populated: pop, total: commodities.length, ratio: commodities.length > 0 ? pop / commodities.length : 0 };
+    return {
+      reporter: r.name,
+      code: r.code,
+      populated: pop,
+      total: commTotal,
+      ratio: commTotal > 0 ? pop / commTotal : 0,
+      required: r.required !== false,
+    };
   });
+
+  // Both floors apply to REQUIRED reporters only. Best-effort reporters
+  // (required:false) are still fetched and published when they return data,
+  // but never block publish — see the REPORTERS note on Russia/Iran.
+  const gated = perReporter.filter((r) => r.required);
+  const total = gated.length * commTotal;
+  const populated = gated.reduce((n, r) => n + r.populated, 0);
+  const globalRatio = total > 0 ? populated / total : 0;
 
   if (globalRatio < MIN_COVERAGE_RATIO) {
     return { ok: false, populated, total, globalRatio, perReporter, reason: `coverage ${populated}/${total} below global floor ${MIN_COVERAGE_RATIO}; refusing to publish partial snapshot` };
   }
-  const dead = perReporter.find((r) => r.ratio < MIN_PER_REPORTER_RATIO);
+  const dead = gated.find((r) => r.ratio < MIN_PER_REPORTER_RATIO);
   if (dead) {
     return { ok: false, populated, total, globalRatio, perReporter, reason: `reporter ${dead.reporter} (${dead.code}) only ${dead.populated}/${dead.total} commodities — below per-reporter floor ${MIN_PER_REPORTER_RATIO}; refusing to publish snapshot with a flatlined reporter` };
   }

--- a/scripts/seed-trade-flows.mjs
+++ b/scripts/seed-trade-flows.mjs
@@ -205,7 +205,15 @@ export async function fetchAllFlows(opts = {}) {
   let lastGate = null;
   for (let pi = 0; pi < periods.length; pi++) {
     const period = periods[pi];
-    if (pi > 0) console.log(`  Prior period failed coverage — falling back to period ${period}...`);
+    if (pi > 0) {
+      console.log(`  Prior period failed coverage — falling back to period ${period}...`);
+      // Keep the inter-request gap across the pass boundary: the fresh
+      // fetchFlowsForPeriod loop skips its delay on the first pair (ri=ci=0),
+      // so without this the first fallback call fires immediately after the
+      // prior pass's last response — right when the rate-limited preview
+      // endpoint is most likely to return a transient 5xx.
+      await pace(INTER_REQUEST_DELAY_MS);
+    }
 
     const { allFlows, perKeyFlows } = await fetchFlowsForPeriod(period, pace);
 

--- a/tests/seed-trade-flows-period-gate.test.mjs
+++ b/tests/seed-trade-flows-period-gate.test.mjs
@@ -1,0 +1,163 @@
+// Regression test for seed-trade-flows CRASHED-on-Railway incident (2026-07-02).
+//
+// Root cause (verified live against comtradeapi.un.org):
+//   1. fetchFlows pinned NO `period`, so the Comtrade preview endpoint defaulted
+//      to the single most-recent annual year present globally (2025). Only the
+//      USA had filed 2025 annual HS data; China/India/Taiwan/Russia/Iran all
+//      returned {count:0,data:[]}. Coverage collapsed to 5/30 (17%), the publish
+//      gate refused the partial snapshot, and runSeed exited 75
+//      (GRACEFUL_FETCH_FAILURE_EXIT_CODE) → Railway paints any non-zero exit CRASHED.
+//   2. Russia (643) and Iran (364) return 0 for every recent year — they have
+//      largely stopped reporting to UN Comtrade as reporters (Russia suspended
+//      post-2022, Iran sporadic). Behind the 40% hard per-reporter floor they
+//      make the gate structurally unsatisfiable regardless of period.
+//
+// Fix contract pinned here:
+//   - fetchFlows requests an explicit lagged period window (recentPeriods()).
+//   - checkCoverage treats reporters with `required:false` as best-effort:
+//     still fetched/published if present, but excluded from both coverage floors.
+
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  fetchFlows,
+  fetchAllFlows,
+  checkCoverage,
+  KEY_PREFIX,
+  __setSleepForTests,
+} from '../scripts/seed-trade-flows.mjs';
+
+const ORIGINAL_FETCH = globalThis.fetch;
+let fetchCalls;
+
+beforeEach(() => {
+  fetchCalls = [];
+  __setSleepForTests(async () => {});
+  globalThis.fetch = async (url) => {
+    fetchCalls.push(String(url));
+    return new Response(
+      JSON.stringify({ data: [{ period: 2024, flowCode: 'X', primaryValue: 1, partnerCode: '000' }] }),
+      { status: 200 },
+    );
+  };
+});
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH;
+  __setSleepForTests();
+});
+
+// --- Defect 1: no explicit period → endpoint defaults to bleeding-edge year ---
+test('fetchFlows pins an explicit lagged period (not the bleeding-edge default)', async () => {
+  await fetchFlows({ code: '156', name: 'China' }, { code: '2709', desc: 'Crude' });
+  const url = fetchCalls[0];
+  assert.match(
+    url,
+    /[?&]period=/,
+    'request must pin an explicit period so the endpoint does not default to the latest global year (which only the fastest reporter has filed)',
+  );
+  const lagYear = String(new Date().getUTCFullYear() - 2);
+  assert.ok(url.includes(lagYear), `period window should include the newest safely-published year (${lagYear}); got: ${url}`);
+});
+
+// --- Defect 2: structurally-absent reporters must not block publish ---
+const REQUIRED_FOUR = [
+  { code: '842', name: 'USA' },
+  { code: '156', name: 'China' },
+  { code: '699', name: 'India' },
+  { code: '490', name: 'Taiwan' },
+];
+const BEST_EFFORT = [
+  { code: '643', name: 'Russia', required: false },
+  { code: '364', name: 'Iran', required: false },
+];
+const GATE_REPORTERS = [...REQUIRED_FOUR, ...BEST_EFFORT];
+const GATE_COMMODITIES = [
+  { code: '2709', desc: 'Crude' }, { code: '7108', desc: 'Gold' },
+  { code: '8542', desc: 'Semis' }, { code: '9301', desc: 'Arms' }, { code: '2711', desc: 'LNG' },
+];
+
+function buildPerKey(reporters, commodities, isPopulated) {
+  const out = {};
+  for (const r of reporters) {
+    for (const c of commodities) {
+      const key = `${KEY_PREFIX}:${r.code}:${c.code}`;
+      out[key] = { flows: isPopulated(r, c) ? [{ year: 2024 }, { year: 2023 }] : [], fetchedAt: 't' };
+    }
+  }
+  return out;
+}
+
+test('checkCoverage: publishes when the four required reporters are full and only Russia/Iran are empty', () => {
+  // Fast four fully populated (20/20), Russia+Iran flatlined (0/10).
+  const perKey = buildPerKey(GATE_REPORTERS, GATE_COMMODITIES, (r) => r.required !== false);
+  const res = checkCoverage(perKey, GATE_REPORTERS, GATE_COMMODITIES);
+  assert.equal(res.ok, true, `expected publish to proceed when only best-effort reporters are empty; got reason: ${res.reason}`);
+});
+
+test('checkCoverage: still blocks when a REQUIRED reporter flatlines', () => {
+  // India (required) empty; everyone else (incl. best-effort) populated.
+  const perKey = buildPerKey(GATE_REPORTERS, GATE_COMMODITIES, (r) => r.code !== '699');
+  const res = checkCoverage(perKey, GATE_REPORTERS, GATE_COMMODITIES);
+  assert.equal(res.ok, false, 'a required reporter flatlining must still block publish');
+  assert.match(res.reason, /India/);
+});
+
+// --- recentPeriod / candidatePeriods pure helpers ---
+// The preview endpoint accepts only a SINGLE period (comma-separated → HTTP 400),
+// so we pin the newest reliably-final year (current UTC year − 2).
+test('recentPeriod returns the newest safely-final year (y-2) as a single period', async () => {
+  const mod = await import('../scripts/seed-trade-flows.mjs');
+  assert.equal(typeof mod.recentPeriod, 'function', 'recentPeriod must be exported');
+  assert.equal(mod.recentPeriod(new Date('2026-07-02T00:00:00Z')), '2024');
+  assert.equal(mod.recentPeriod(new Date('2027-03-15T00:00:00Z')), '2025');
+});
+
+test('candidatePeriods returns [y-2, y-3] freshest-first', async () => {
+  const mod = await import('../scripts/seed-trade-flows.mjs');
+  assert.deepEqual(mod.candidatePeriods(new Date('2026-07-02T00:00:00Z')), ['2024', '2023']);
+  assert.deepEqual(mod.candidatePeriods(new Date('2027-01-01T00:00:00Z')), ['2025', '2024']);
+});
+
+// --- Year-boundary fallback: y-2 unfiled → fall back to y-3 (P2) ---
+// Returns populated flows only for the `populatedPeriod`; every other period is
+// an empty (but HTTP-200) snapshot — the exact "reporters haven't filed y-2 yet"
+// shape that made the endpoint flatline.
+function installPeriodKeyedFetch(populatedPeriod) {
+  fetchCalls = [];
+  globalThis.fetch = async (url) => {
+    const s = String(url);
+    fetchCalls.push(s);
+    const period = new URL(s).searchParams.get('period');
+    const body = period === populatedPeriod
+      ? { data: [{ period: Number(period), flowCode: 'X', primaryValue: 100, partnerCode: '000' }] }
+      : { data: [] };
+    return new Response(JSON.stringify(body), { status: 200 });
+  };
+}
+
+test('fetchAllFlows falls back to the older period when the newer one fails coverage', async () => {
+  installPeriodKeyedFetch('2023'); // y-2 (2024) empty, y-3 (2023) populated
+  const res = await fetchAllFlows({ periods: ['2024', '2023'], pace: async () => {} });
+  assert.equal(res.period, '2023', 'should publish using the fallback period');
+  assert.ok(res.flows.length > 0, 'fallback period supplies the flows');
+  assert.ok(fetchCalls.some((u) => u.includes('period=2024')), 'tried the fresher period first');
+  assert.ok(fetchCalls.some((u) => u.includes('period=2023')), 'fell back to the older period');
+});
+
+test('fetchAllFlows uses the newest period and skips fallback when coverage passes', async () => {
+  installPeriodKeyedFetch('2024'); // y-2 (2024) populated
+  const res = await fetchAllFlows({ periods: ['2024', '2023'], pace: async () => {} });
+  assert.equal(res.period, '2024');
+  assert.ok(fetchCalls.length > 0);
+  assert.ok(fetchCalls.every((u) => u.includes('period=2024')), 'must not fetch the fallback period once coverage passes');
+});
+
+test('fetchAllFlows throws (→ graceful exit 75) when no candidate period has coverage', async () => {
+  installPeriodKeyedFetch('9999'); // no candidate populated
+  await assert.rejects(
+    () => fetchAllFlows({ periods: ['2024', '2023'], pace: async () => {} }),
+    /below (global floor|per-reporter)/,
+  );
+});

--- a/tests/seed-trade-flows-period-gate.test.mjs
+++ b/tests/seed-trade-flows-period-gate.test.mjs
@@ -13,7 +13,7 @@
 //      make the gate structurally unsatisfiable regardless of period.
 //
 // Fix contract pinned here:
-//   - fetchFlows requests an explicit lagged period window (recentPeriods()).
+//   - fetchFlows requests an explicit lagged period (recentPeriod()).
 //   - checkCoverage treats reporters with `required:false` as best-effort:
 //     still fetched/published if present, but excluded from both coverage floors.
 


### PR DESCRIPTION
## Problem
Railway service `seed-trade-flows` shows **CRASHED**. It actually exits **75** (`GRACEFUL_FETCH_FAILURE_EXIT_CODE`, `=== Failed gracefully ===`) — Railway paints any non-zero exit red — but the underlying snapshot genuinely stopped refreshing. The coverage gate rejected the snapshot at `5/30 (17%)`.

Root cause (verified live against `comtradeapi.un.org/public/v1/preview/C/A/HS`), two independent defects:

1. **No `period`** → the preview endpoint defaults to the latest year present *globally* (2025); only the US has filed 2025 annual HS data, flatlining every other reporter. The endpoint accepts only a **single** period (`period=2023,2024` → **HTTP 400**) and returns one year per call.
2. **Russia (643) + Iran (364)** return 0 as reporters for every recent year (Russia suspended UN Comtrade post-2022, Iran sporadic) → the 40% per-reporter floor is structurally unsatisfiable.

## Fix
- **`recentPeriod(now, lag=2)`** pins an explicit lagged year; **`candidatePeriods()` = `[y-2, y-3]`**. `fetchAllFlows` tries `y-2` and, only if its coverage gate fails, **falls back to `y-3`** — this survives the year boundary, where on Jan 1 `y-2` rolls to a fresher year the slower reporters may not have filed yet (without the fallback the seed would re-crash for weeks).
- **Russia/Iran tagged `required:false`** — best-effort: still fetched and published when they report, but excluded from both coverage floors. `checkCoverage` applies both floors to required reporters only (backward-compatible: `required` defaults to `true`, so existing callers/tests are unchanged).

Single-year data means the `isAnomaly`/YoY feature (#2045) stays inert, as it already was pre-fix — restoring real YoY is a tracked follow-up (the fallback already fetches a second year on demand).

## Verification
- **Unit** (`tests/seed-trade-flows-period-gate.test.mjs`, 8 tests): explicit-period pin, required-only gate, `y-2 → y-3` fallback, no-fallback-when-fresh-passes, throws-when-no-period-covers, `recentPeriod`/`candidatePeriods`. Existing `seed-comtrade-5xx-retry.test.mjs` (22) unchanged → **30/30 green**.
- **Live end-to-end**: `period 2025 → 5/20 (25%), fails → falls back to 2024 → 18/20 (90%), publishes` (`PASS = true`). Steady-state daily run uses `y-2` in a single ~90s pass; fallback only pays a second pass at year boundaries.

Closes #4646
