### PR TITLE
perf(CLS): self-correcting contain-intrinsic-size on deferred panels (#4580)

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2381,7 +2381,12 @@ body.panel-resize-active iframe {
   min-width: 0;
   user-select: none;
   content-visibility: auto;
+  /* #4580: field CLS attribution shows #panelsGrid + deferred panels re-shifting as
+     they scroll in/out of view. `auto <fallback>` makes the browser remember each
+     element's last rendered size, so re-entry reserves the real height instead of the
+     fallback and doesn't shift. The plain line stays first as the pre-Chrome-111 fallback. */
   contain-intrinsic-size: 260px;
+  contain-intrinsic-size: auto 260px;
 }
 
 .panel-deferred-shell {
@@ -2389,19 +2394,23 @@ body.panel-resize-active iframe {
   pointer-events: none;
   content-visibility: auto;
   contain-intrinsic-size: var(--dashboard-panel-row-min, 260px);
+  contain-intrinsic-size: auto var(--dashboard-panel-row-min, 260px);
 }
 
 .panel-deferred-shell.panel-wide,
 .panel-deferred-shell.span-2 {
   contain-intrinsic-size: var(--dashboard-first-grid-reservation, 400px);
+  contain-intrinsic-size: auto var(--dashboard-first-grid-reservation, 400px);
 }
 
 .panel-deferred-shell.span-3 {
   contain-intrinsic-size: 600px;
+  contain-intrinsic-size: auto 600px;
 }
 
 .panel-deferred-shell.span-4 {
   contain-intrinsic-size: 800px;
+  contain-intrinsic-size: auto 800px;
 }
 
 .panel-deferred-shell.panel-collapsed .panel-deferred-content {
@@ -13359,6 +13368,7 @@ a.prediction-link:hover {
   .panel-deferred-shell.span-3,
   .panel-deferred-shell.span-4 {
     contain-intrinsic-size: 250px;
+    contain-intrinsic-size: auto 250px; /* #4580: remember rendered size on mobile too */
   }
 
   .panel-deferred-shell.panel-collapsed,


### PR DESCRIPTION
## Summary

Data-driven CLS fix for #4580. The `onCLS` field-attribution instrumentation (shipped in #4585) collected **7,067 events / 2,671 users** over 2 days, and aggregating `largestShiftTarget` names the culprit unambiguously:

| Shift target | freq | median CLS |
|---|---|---|
| `#panelsGrid` | 27× | **0.36** |
| `.panel.panel-deferred-shell.span-2` | 8× | 0.24 |
| `.panel.span-2` | 7× | 0.14 |
| `#country-deep-dive-panel` | 4× | 0.83 (rare) |

## Root cause
`grid-auto-rows: minmax(200px, max)` grows each panel's row to its content height, while the `content-visibility: auto` panels/shells reserve a **fixed** `contain-intrinsic-size` fallback (200px desktop / 250px flat on mobile). So every time a panel scrolls out of view and back, it re-reserves the fallback and re-shifts `#panelsGrid` — the dominant session-CLS driver.

## Fix
Add `contain-intrinsic-size: auto <fallback>` to `.panel-content` and every `.panel-deferred-shell` span variant (incl. the mobile block). The `auto` keyword makes the browser **remember each element's last rendered size**, so scroll re-entry reserves the real height instead of the fallback — no re-shift.

**Progressive enhancement:** the plain `contain-intrinsic-size: <len>` line stays first as the pre-Chrome-111 fallback; the `auto` line overrides it only in supporting browsers. No regression on older browsers.

## Verification
- Build green; the built CSS carries both declarations (fallback + `auto`).
- CLS is **not unit-testable** — the delta is post-deploy field data (CrUX/Sentry over days), same cadence as the instrumentation. The `onCLS` reporter (#4585) will show whether `#panelsGrid` drops.

## Not in scope (follow-ups noted on #4580)
- `#country-deep-dive-panel` (median 0.83, rare) — a distinct opening-shift.
- First-hydration shell→panel delta where the fallback under-reserves (needs per-panel height tuning, browser-verified).

Part of #4580 / #4487.

https://claude.ai/code/session_011htsYLErqJb922Qm9QLraN