### PR TITLE
fix(observability): drop injected main-world script noise (WORLDMONITOR-V8)

### DIFF
--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -433,28 +433,36 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // Suppress parentNode.insertBefore from injected/inline scripts (iOS WKWebView, Apple Mail)
       // Also covers [native code] frames (no filename) produced by WKWebView's forEach wrapper
       if (/parentNode\.insertBefore/.test(msg) && frames.every(f => !f.filename || f.filename === '<anonymous>' || f.filename === '[native code]' || /^blob:/.test(f.filename) || /^https?:\/\/[^/]+\/?$/.test(f.filename))) return null;
-      // Suppress TypeErrors whose ONLY source frames are the page document URL
-      // itself (a relative path like `/dashboard` or the full `https://<host>/dashboard`).
-      // Scripts injected into the page's MAIN world — WKUserScript content
-      // scripts on Firefox iOS / other in-app WebViews, bookmarklets — are
-      // attributed by WebKit to the document URL (line 1, minified fns `o`/`s`/`Or`,
-      // with native `insertBefore`/`forEach` frames), not to a distinct script URL.
-      // Our own shipped code never runs from the document URL: the app entry is a
-      // hashed `/assets/*.js` module chunk (flagged first-party by firstPartyFile),
-      // so a TypeError with zero first-party frames whose non-infra frames are all
-      // the document URL cannot originate in our bundle. The `frames.every(...)`
-      // injected-script gate above misses this because the `[native code]`
-      // insertBefore/forEach frames break its predicate and its page-URL matcher
-      // only accepts bare origins, not document paths (WORLDMONITOR-V8: Firefox iOS
-      // 152, `undefined is not an object (evaluating 's[e]')`, insertBefore in a
-      // promiseReactionJob — 6 events / 1 user).
-      const isPageDocumentFrame = (filename: string) =>
+      // Suppress TypeErrors whose ONLY source frames are non-script URLs — the
+      // page document URL itself (a relative path like `/dashboard` or the full
+      // `https://<host>/dashboard`) or any external resource served without a
+      // recognized script extension. Scripts injected into the page's MAIN world
+      // — WKUserScript content scripts on Firefox iOS / other in-app WebViews,
+      // bookmarklets — are attributed by WebKit to the document URL (line 1,
+      // minified fns `o`/`s`/`Or`, with native `insertBefore`/`forEach` frames),
+      // not to a distinct `.js` script URL. Our own shipped code never runs from
+      // such a URL: the app entry is a hashed `/assets/*.js` module chunk (flagged
+      // first-party by firstPartyFile), so a TypeError with zero first-party
+      // frames whose non-infra frames are all non-script URLs cannot originate in
+      // our bundle. The `frames.every(...)` injected-script gate above misses this
+      // because the `[native code]` insertBefore/forEach frames break its
+      // predicate and its page-URL matcher only accepts bare origins, not document
+      // paths (WORLDMONITOR-V8: Firefox iOS 152, `undefined is not an object
+      // (evaluating 's[e]')`, insertBefore in a promiseReactionJob — 6 events / 1
+      // user).
+      //
+      // `isNonScriptUrlFrame` is intentionally broader than "page document": the
+      // `https?://` branch also matches extensionless third-party script URLs
+      // (e.g. `https://js.stripe.com/v3/`). That is still correct to suppress here
+      // — the `!hasFirstParty` guard already proves zero first-party involvement,
+      // so a same-shaped error from a third-party host is equally unactionable.
+      const isNonScriptUrlFrame = (filename: string) =>
         !/\.(?:m|c)?[jt]sx?(?:[?#]|$)/.test(filename)
         && (/^\/(?!\/)/.test(filename) || /^https?:\/\//.test(filename));
       if ((excType === 'TypeError' || /^TypeError:/.test(msg))
           && !hasFirstParty
           && nonInfraFrames.length > 0
-          && nonInfraFrames.every(f => isPageDocumentFrame(f.filename ?? ''))) return null;
+          && nonInfraFrames.every(f => isNonScriptUrlFrame(f.filename ?? ''))) return null;
       // Suppress NotFoundError: insertBefore with no usable stack (Chrome 146+ extension DOM interference — stack shows minified bundle but no line/function)
       if (excType === 'NotFoundError' && /insertBefore/.test(msg) && frames.every(f => !f.lineno && !f.function)) return null;
       // Suppress Sentry breadcrumb DOM-measuring crashes (element.offsetWidth on detached DOM)

--- a/src/bootstrap/sentry-init.ts
+++ b/src/bootstrap/sentry-init.ts
@@ -433,6 +433,28 @@ function buildSentryInitOptions(): Parameters<SentryNs['init']>[0] {
       // Suppress parentNode.insertBefore from injected/inline scripts (iOS WKWebView, Apple Mail)
       // Also covers [native code] frames (no filename) produced by WKWebView's forEach wrapper
       if (/parentNode\.insertBefore/.test(msg) && frames.every(f => !f.filename || f.filename === '<anonymous>' || f.filename === '[native code]' || /^blob:/.test(f.filename) || /^https?:\/\/[^/]+\/?$/.test(f.filename))) return null;
+      // Suppress TypeErrors whose ONLY source frames are the page document URL
+      // itself (a relative path like `/dashboard` or the full `https://<host>/dashboard`).
+      // Scripts injected into the page's MAIN world — WKUserScript content
+      // scripts on Firefox iOS / other in-app WebViews, bookmarklets — are
+      // attributed by WebKit to the document URL (line 1, minified fns `o`/`s`/`Or`,
+      // with native `insertBefore`/`forEach` frames), not to a distinct script URL.
+      // Our own shipped code never runs from the document URL: the app entry is a
+      // hashed `/assets/*.js` module chunk (flagged first-party by firstPartyFile),
+      // so a TypeError with zero first-party frames whose non-infra frames are all
+      // the document URL cannot originate in our bundle. The `frames.every(...)`
+      // injected-script gate above misses this because the `[native code]`
+      // insertBefore/forEach frames break its predicate and its page-URL matcher
+      // only accepts bare origins, not document paths (WORLDMONITOR-V8: Firefox iOS
+      // 152, `undefined is not an object (evaluating 's[e]')`, insertBefore in a
+      // promiseReactionJob — 6 events / 1 user).
+      const isPageDocumentFrame = (filename: string) =>
+        !/\.(?:m|c)?[jt]sx?(?:[?#]|$)/.test(filename)
+        && (/^\/(?!\/)/.test(filename) || /^https?:\/\//.test(filename));
+      if ((excType === 'TypeError' || /^TypeError:/.test(msg))
+          && !hasFirstParty
+          && nonInfraFrames.length > 0
+          && nonInfraFrames.every(f => isPageDocumentFrame(f.filename ?? ''))) return null;
       // Suppress NotFoundError: insertBefore with no usable stack (Chrome 146+ extension DOM interference — stack shows minified bundle but no line/function)
       if (excType === 'NotFoundError' && /insertBefore/.test(msg) && frames.every(f => !f.lineno && !f.function)) return null;
       // Suppress Sentry breadcrumb DOM-measuring crashes (element.offsetWidth on detached DOM)


### PR DESCRIPTION
## Summary
- Suppresses an `error`-level Sentry `TypeError: undefined is not an object (evaluating 's[e]')` (WORLDMONITOR-V8) that is **not our code**: a script injected into the page's main world (Firefox iOS `WKUserScript` content script / in-app WebViews, bookmarklets). WebKit attributes such frames to the **document URL** (`/dashboard:1`, minified fns `o`/`s`/`Or`) plus native `insertBefore`/`forEach` — 6 events / 1 user, fr-FR.
- Our shipped app only ever runs from hashed `/assets/*.js` module chunks (flagged first-party by `firstPartyFile`), so a `TypeError` with **zero first-party frames** whose non-infra frames are all the page document URL cannot originate in our bundle.
- Adds a `beforeSend` gate stack-gated on `!hasFirstParty`. Kept **out of `ignoreErrors`** because `evaluating 's[e]'` is a generic minified access our own bundle can emit; the `!hasFirstParty` gate preserves any real `/assets/*.js` crash.

### Why the existing gate missed it
The `frames.every(...)` injected-script gate has two blind spots for this shape:
1. `frames.every(...)` runs over **all** frames → the `[native code]` `insertBefore`/`forEach` frames break its predicate.
2. Its page-URL matcher `/^https?:\/\/[^/]+\/?$/` only accepts **bare origins**, not document paths like `/dashboard`.

The new gate uses `nonInfraFrames` (already strips `[native code]`/`<anonymous>`/sentry) and matches document-URL frames (relative path or full URL, not a `.js`/`.ts` script file).

## Test plan
- [x] `npm run typecheck` / `typecheck:api` — PASS
- [x] `npm run lint` (biome) + CJS syntax — PASS
- [x] `npm run test:data` — 12387/12395 pass (the 2 initial failures were the env-only `dashboard-critical-css` built-output tests; green after `VITE_VARIANT=full vite build` → `dashboard-critical-css.test.mjs` 8/8)
- [x] Edge bundle check + `tests/edge-functions.test.mjs` (206/206) — PASS
- [x] `npm run lint:md` / `version:check` — PASS
- [x] Node simulation of the gate: real V8 event (relative + full-URL variants) → **suppressed**; genuine `/assets/index-*.js` crash → **preserved**; vendor-only (maplibre) + external `<script src>.js` → **not swallowed** by this gate.

WORLDMONITOR-V8 marked resolved in Sentry (`inNextRelease`).

https://claude.ai/code/session_01UAhechRSqSxftk8tGYc1rd