### PR TITLE
perf(seed-forecasts): harden LLM + cache-write resilience

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -14042,7 +14042,10 @@ const FORECAST_LLM_PROVIDERS = [
   { name: 'openrouter', envKey: 'OPENROUTER_API_KEY', apiUrl: 'https://openrouter.ai/api/v1/chat/completions', model: 'google/gemini-2.5-flash', timeout: 25_000 },
 ];
 const FORECAST_LLM_PROVIDER_NAMES = new Set(FORECAST_LLM_PROVIDERS.map(provider => provider.name));
-const FORECAST_LLM_PROVIDER_MAX_RETRIES = 2;
+// 3 retries (=4 attempts/provider): during an OpenRouter slowdown 2 retries all timed
+// out and market_implications wrote an error seed-meta. Bounded by the per-stage /
+// per-run LLM budgets below, so extra attempts can't blow the 180s seed lock.
+const FORECAST_LLM_PROVIDER_MAX_RETRIES = 3;
 const FORECAST_LLM_RETRY_BASE_MS = 1_000;
 const FORECAST_LLM_RETRY_AFTER_MAX_MS = 10_000;
 // The forecast seed lock is 180s; leave headroom for non-LLM work and cleanup.
@@ -14370,6 +14373,10 @@ async function __callForecastLlmForTests(systemPrompt, userPrompt, options = {})
   return await callForecastLLM(systemPrompt, userPrompt, options);
 }
 
+async function __redisSetForTests(url, token, key, data, ttlSeconds) {
+  return await redisSet(url, token, key, data, ttlSeconds);
+}
+
 function getForecastLlmRetryAfterMs(resp) {
   const retryAfterMs = parseRetryAfterMs(getResponseHeader(resp?.headers, 'Retry-After'));
   return retryAfterMs == null ? null : Math.min(retryAfterMs, FORECAST_LLM_RETRY_AFTER_MAX_MS);
@@ -14501,12 +14508,25 @@ async function callForecastLLM(systemPrompt, userPrompt, options = {}) {
 async function redisSet(url, token, key, data, ttlSeconds) {
   if (_testRedisStore) { _testRedisStore[key] = JSON.parse(JSON.stringify(data)); return; }
   try {
-    await fetch(url, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-      body: JSON.stringify(['SET', key, JSON.stringify(data), 'EX', ttlSeconds]),
-      signal: AbortSignal.timeout(5_000),
-    });
+    // Best-effort cache write. The 10s timeout addresses the root cause (the observed
+    // write needed >5s — "[Redis] Cache write failed for intelligence:market-
+    // implications:v1: aborted due to timeout"); a single retry catches a transient
+    // drop. Kept to ONE retry (not 2) because redisSet is a shared helper called from
+    // ~10 sites incl. a Promise.all batch, none budget-aware — this bounds worst-case
+    // tail latency to ~20s. 4xx stays non-retryable so withRetry bails in ~10ms.
+    await withRetry(async () => {
+      const resp = await fetch(url, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify(['SET', key, JSON.stringify(data), 'EX', ttlSeconds]),
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (!resp.ok) {
+        const err = new Error(`HTTP ${resp.status}`);
+        err.nonRetryable = !isRetryableHttpStatus(resp.status);
+        throw err;
+      }
+    }, 1, 500);
   } catch (err) { console.warn(`  [Redis] Cache write failed for ${key}: ${err.message}`); }
 }
 
@@ -14757,6 +14777,29 @@ async function recoverScenarioNarratives(predictions, llmOptions = {}, stage = '
   };
 }
 
+// Bounded re-call of the scenario LLM when a complete-but-plausible response still
+// validates to zero scenarios AND zero case narratives (logged as llm_scenario
+// failureReason="validation_failed" → scenarios=0). withRetry only re-tries transport
+// failures, not a 200 that parses to nothing, so this validation-aware retry lives
+// here. Bounded by the run budget: callForecastLLM returns null once the budget is
+// exhausted, which ends the loop.
+const SCENARIO_LLM_VALIDATION_RETRIES = 1;
+
+async function resolveScenarioLlmResult(scenarioOnly, scenarioLlmOptions, maxValidationRetries = SCENARIO_LLM_VALIDATION_RETRIES) {
+  let last = { result: null, parsed: null, raw: null, valid: [], validCases: [] };
+  for (let attempt = 0; attempt <= maxValidationRetries; attempt++) {
+    const result = await callForecastLLM(SCENARIO_SYSTEM_PROMPT, buildUserPrompt(scenarioOnly), { ...scenarioLlmOptions, stage: 'scenario' });
+    if (!result) break; // provider failure / budget exhausted — keep the last (possibly empty) result
+    const parsed = extractStructuredLlmPayload(result.text);
+    const raw = parsed.items;
+    const valid = validateScenarios(raw, scenarioOnly);
+    const validCases = validateCaseNarratives(raw, scenarioOnly);
+    last = { result, parsed, raw, valid, validCases };
+    if (valid.length > 0 || validCases.length > 0) break;
+  }
+  return last;
+}
+
 async function enrichScenariosWithLLM(predictions) {
   if (predictions.length === 0) return null;
   const { url, token } = getRedisCredentials();
@@ -14983,12 +15026,8 @@ async function enrichScenariosWithLLM(predictions) {
       console.log('  [LLM:scenario] cache miss');
       const t0 = Date.now();
       console.log('  [LLM:scenario] invoking provider');
-      const result = await callForecastLLM(SCENARIO_SYSTEM_PROMPT, buildUserPrompt(scenarioOnly), { ...scenarioLlmOptions, stage: 'scenario' });
+      const { result, parsed, raw, valid, validCases } = await resolveScenarioLlmResult(scenarioOnly, scenarioLlmOptions);
       if (result) {
-        const parsed = extractStructuredLlmPayload(result.text);
-        const raw = parsed.items;
-        const valid = validateScenarios(raw, scenarioOnly);
-        const validCases = validateCaseNarratives(raw, scenarioOnly);
         enrichmentMeta.scenario.source = 'live';
         enrichmentMeta.scenario.provider = result.provider;
         enrichmentMeta.scenario.model = result.model;
@@ -17511,6 +17550,7 @@ export {
   parseForecastProviderOrder,
   getForecastLlmCallOptions,
   resolveForecastLlmProviders,
+  resolveScenarioLlmResult,
   buildFallbackScenario,
   buildFallbackBaseCase,
   buildFallbackEscalatoryCase,
@@ -17637,6 +17677,7 @@ export {
   readImpactPromptLearnedSection,
   clearImpactPromptLearnedSection,
   __callForecastLlmForTests,
+  __redisSetForTests,
   __setForecastLlmCallOverrideForTests,
   __setForecastLlmTransportForTests,
   __setForecastLlmRunDeadlineForTests,

--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -14788,6 +14788,7 @@ const SCENARIO_LLM_VALIDATION_RETRIES = 1;
 async function resolveScenarioLlmResult(scenarioOnly, scenarioLlmOptions, maxValidationRetries = SCENARIO_LLM_VALIDATION_RETRIES) {
   let last = { result: null, parsed: null, raw: null, valid: [], validCases: [] };
   for (let attempt = 0; attempt <= maxValidationRetries; attempt++) {
+    if (attempt > 0) console.log(`  [LLM:scenario] validation retry ${attempt + 1}/${maxValidationRetries + 1} (prior attempt validated to 0)`);
     const result = await callForecastLLM(SCENARIO_SYSTEM_PROMPT, buildUserPrompt(scenarioOnly), { ...scenarioLlmOptions, stage: 'scenario' });
     if (!result) break; // provider failure / budget exhausted — keep the last (possibly empty) result
     const parsed = extractStructuredLlmPayload(result.text);

--- a/tests/forecast-detectors.test.mjs
+++ b/tests/forecast-detectors.test.mjs
@@ -1438,7 +1438,7 @@ describe('forecast llm overrides', () => {
 
     const result = await __callForecastLlmForTests('system', 'user', { stage: 'scenario', retryDelayMs: 0 });
 
-    assert.deepEqual(providers, ['groq', 'groq', 'groq', 'openrouter']);
+    assert.deepEqual(providers, ['groq', 'groq', 'groq', 'groq', 'openrouter']);
     assert.deepEqual(result, {
       text: 'OpenRouter fallback succeeded with enough narrative content.',
       model: 'openrouter/gemini-test',

--- a/tests/forecast-seed-resilience.test.mjs
+++ b/tests/forecast-seed-resilience.test.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, it } from 'node:test';
+
+import {
+  makePrediction,
+  resolveScenarioLlmResult,
+  __redisSetForTests,
+  __setRedisStoreForTests,
+  __callForecastLlmForTests,
+  __setForecastLlmCallOverrideForTests,
+  __setForecastLlmTransportForTests,
+  __setForecastLlmRunDeadlineForTests,
+} from '../scripts/seed-forecasts.mjs';
+
+const REAL_FETCH = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = REAL_FETCH;
+  __setRedisStoreForTests(null);
+  __setForecastLlmCallOverrideForTests(null);
+  __setForecastLlmTransportForTests(null);
+  __setForecastLlmRunDeadlineForTests(null);
+});
+
+// ---- redisSet best-effort cache write now retries transient failures ----
+describe('redisSet cache-write retry', () => {
+  beforeEach(() => __setRedisStoreForTests(null)); // force the real fetch path
+
+  it('retries a transient timeout and succeeds on the 2nd attempt', async () => {
+    let calls = 0;
+    globalThis.fetch = async () => {
+      calls += 1;
+      if (calls === 1) throw Object.assign(new Error('The operation was aborted due to timeout'), { name: 'TimeoutError' });
+      return { ok: true };
+    };
+    await __redisSetForTests('http://redis', 'tok', 'intelligence:market-implications:v1', { a: 1 }, 600);
+    assert.equal(calls, 2, 'should retry once then succeed');
+  });
+
+  it('swallows the error after exhausting retries (best-effort) — 1 + 1 retry', async () => {
+    let calls = 0;
+    globalThis.fetch = async () => { calls += 1; throw new Error('ECONNRESET'); };
+    await assert.doesNotReject(() => __redisSetForTests('http://redis', 'tok', 'k', { a: 1 }, 600));
+    assert.equal(calls, 2, 'withRetry(1) => 2 total attempts');
+  });
+
+  it('does not retry a non-retryable 4xx', async () => {
+    let calls = 0;
+    globalThis.fetch = async () => { calls += 1; return { ok: false, status: 400 }; };
+    await __redisSetForTests('http://redis', 'tok', 'k', { a: 1 }, 600);
+    assert.equal(calls, 1, '4xx is nonRetryable → bail immediately');
+  });
+
+  it('retries a 503 then succeeds', async () => {
+    let calls = 0;
+    globalThis.fetch = async () => { calls += 1; return calls === 1 ? { ok: false, status: 503 } : { ok: true }; };
+    await __redisSetForTests('http://redis', 'tok', 'k', { a: 1 }, 600);
+    assert.equal(calls, 2, '5xx is retryable');
+  });
+});
+
+// ---- LLM provider retry budget bumped 2 -> 3 (=4 attempts) ----
+describe('forecast LLM provider retries', () => {
+  const OLD_KEY = process.env.OPENROUTER_API_KEY;
+  beforeEach(() => { process.env.OPENROUTER_API_KEY = 'test-key'; });
+  afterEach(() => { if (OLD_KEY === undefined) delete process.env.OPENROUTER_API_KEY; else process.env.OPENROUTER_API_KEY = OLD_KEY; });
+
+  it('survives 3 consecutive transport failures then succeeds (proves maxRetries>=3)', async () => {
+    let calls = 0;
+    __setForecastLlmTransportForTests({
+      fetch: async () => {
+        calls += 1;
+        if (calls <= 3) throw Object.assign(new Error('fetch failed'), { cause: { code: 'ETIMEDOUT' } });
+        return { ok: true, json: async () => ({ choices: [{ message: { content: 'A valid forecast LLM response over twenty chars.' } }], model: 'test-model' }) };
+      },
+    });
+    const res = await __callForecastLlmForTests('sys', 'user', { providerOrder: ['openrouter'], stage: 'default', retryDelayMs: 1 });
+    assert.ok(res && res.text, 'should succeed on the 4th attempt');
+    assert.equal(calls, 4, '1 initial + 3 retries');
+  });
+
+  it('gives up after 4 attempts when the provider never recovers', async () => {
+    let calls = 0;
+    __setForecastLlmTransportForTests({ fetch: async () => { calls += 1; throw new Error('fetch failed'); } });
+    const res = await __callForecastLlmForTests('sys', 'user', { providerOrder: ['openrouter'], stage: 'default', retryDelayMs: 1 });
+    assert.equal(res, null, 'exhausted provider returns null');
+    assert.equal(calls, 4, '1 initial + 3 retries');
+  });
+});
+
+// ---- scenario stage re-calls the LLM once on a validation_failed (0 scenarios) ----
+describe('resolveScenarioLlmResult validation retry', () => {
+  const predictions = [
+    makePrediction('conflict', 'Middle East', 'Escalation risk: Iran', 0.7, 0.6, '7d', [{ type: 'cii', value: 'Iran CII 85', weight: 0.4 }]),
+  ];
+  const validCasePayload = JSON.stringify([{ index: 0, baseCase: 'This is a base case narrative well over twenty characters long.' }]);
+
+  it('retries once when the first response validates to zero, then accepts the valid one', async () => {
+    let calls = 0;
+    __setForecastLlmCallOverrideForTests(async () => {
+      calls += 1;
+      return { text: calls === 1 ? '[]' : validCasePayload, model: 'm', provider: 'p' };
+    });
+    const out = await resolveScenarioLlmResult(predictions, {});
+    assert.equal(calls, 2, 'empty first response triggers exactly one retry');
+    assert.ok(out.result, 'returns a usable result');
+    assert.equal(out.validCases.length, 1, 'second response validated');
+  });
+
+  it('stops after the bounded retry when every response is empty (returns last)', async () => {
+    let calls = 0;
+    __setForecastLlmCallOverrideForTests(async () => { calls += 1; return { text: '[]', model: 'm', provider: 'p' }; });
+    const out = await resolveScenarioLlmResult(predictions, {});
+    assert.equal(calls, 2, 'default 1 retry => 2 total attempts, no infinite loop');
+    assert.ok(out.result, 'still returns the last (empty) LLM result for downstream logging');
+    assert.equal(out.valid.length + out.validCases.length, 0);
+  });
+
+  it('does not retry when the first response is already valid', async () => {
+    let calls = 0;
+    __setForecastLlmCallOverrideForTests(async () => { calls += 1; return { text: validCasePayload, model: 'm', provider: 'p' }; });
+    const out = await resolveScenarioLlmResult(predictions, {});
+    assert.equal(calls, 1, 'valid first response => no retry');
+    assert.equal(out.validCases.length, 1);
+  });
+});

--- a/tests/forecast-seed-resilience.test.mjs
+++ b/tests/forecast-seed-resilience.test.mjs
@@ -95,16 +95,24 @@ describe('resolveScenarioLlmResult validation retry', () => {
   ];
   const validCasePayload = JSON.stringify([{ index: 0, baseCase: 'This is a base case narrative well over twenty characters long.' }]);
 
-  it('retries once when the first response validates to zero, then accepts the valid one', async () => {
+  it('retries once when the first response validates to zero, then accepts the valid one (and logs the retry)', async () => {
     let calls = 0;
-    __setForecastLlmCallOverrideForTests(async () => {
-      calls += 1;
-      return { text: calls === 1 ? '[]' : validCasePayload, model: 'm', provider: 'p' };
-    });
-    const out = await resolveScenarioLlmResult(predictions, {});
-    assert.equal(calls, 2, 'empty first response triggers exactly one retry');
-    assert.ok(out.result, 'returns a usable result');
-    assert.equal(out.validCases.length, 1, 'second response validated');
+    const logs = [];
+    const origLog = console.log;
+    console.log = (...a) => logs.push(a.join(' '));
+    try {
+      __setForecastLlmCallOverrideForTests(async () => {
+        calls += 1;
+        return { text: calls === 1 ? '[]' : validCasePayload, model: 'm', provider: 'p' };
+      });
+      const out = await resolveScenarioLlmResult(predictions, {});
+      assert.equal(calls, 2, 'empty first response triggers exactly one retry');
+      assert.ok(out.result, 'returns a usable result');
+      assert.equal(out.validCases.length, 1, 'second response validated');
+    } finally {
+      console.log = origLog;
+    }
+    assert.ok(logs.some((l) => l.includes('validation retry')), 'emits a log line when the retry fires');
   });
 
   it('stops after the bounded retry when every response is empty (returns last)', async () => {


### PR DESCRIPTION
## Summary

Found via a past-day Railway log review of `seed-forecasts` / `seed-earthquakes` / `seed-bundle-market-backup`. Only seed-forecasts had real issues (the other two are healthy — they already have `runSeed`'s 3-retry+graceful — and are untouched).

- **LLM retries 2→3** (`FORECAST_LLM_PROVIDER_MAX_RETRIES`): an OpenRouter timeout storm exhausted the 2 retries and made `market_implications` write an error seed-meta. Bounded by the existing per-stage (120s) / per-run (150s) LLM budgets, so it can't blow the 180s seed lock.
- **`redisSet` retry + timeout**: the best-effort cache write timed out (`intelligence:market-implications:v1: aborted due to timeout`) with no retry. Now 5s→10s timeout (the write needed >5s) + 1 retry. Kept to **one** retry because `redisSet` is a shared helper (~10 call sites incl. a `Promise.all` batch, none budget-aware) — bounds worst-case tail latency to ~20s.
- **`resolveScenarioLlmResult`**: the scenario stage logged `validation_failed → 0 scenarios` because `withRetry` only retries transport failures, not a 200 that validates to nothing. Adds a bounded 1× re-call at the scenario call site.

### Deferred (not in this PR)
Root cause of the storm degradation is a **config pin**: `FORECAST_LLM_PROVIDER_ORDER=openrouter` excludes the already-keyed groq fallback. Setting it to `openrouter,groq` (zero code) is the highest-leverage fix; these code changes harden the path regardless.

## Test plan
- [x] `tests/forecast-seed-resilience.test.mjs` — 9 new tests (redisSet retry paths, LLM 2→3 retry lock, scenario validation-retry)
- [x] Updated the groq-exhaustion assertion in `forecast-detectors.test.mjs` for the retry bump
- [x] typecheck · typecheck:api · biome · lint:md · version:check · cjs syntax · edge-functions (206) · edge bundle — all pass
- [x] test:data scoped to all 11 `seed-forecasts.mjs` importers + forecast suites — **692 pass**

https://claude.ai/code/session_01XmZMvAViUHicwZwyEL4QnC