### PR TITLE
perf(services): barrel-surgery tail batch 1 — shed research/cyber/cable-activity (#4649)

### DIFF
--- a/src/app/data-loader.ts
+++ b/src/app/data-loader.ts
@@ -38,7 +38,6 @@ import {
   fetchAisSignals,
   getAisStatus,
   isAisConfigured,
-  fetchCableActivity,
   fetchCableHealth,
   fetchProtestEvents,
   getProtestStatus,
@@ -52,7 +51,6 @@ import {
   fetchGdeltTensions,
   fetchNaturalEvents,
   fetchRecentAwards,
-  fetchCyberThreats,
   fetchSanctionsPressure,
   fetchRadiationWatch,
 } from '@/services';
@@ -2803,6 +2801,7 @@ export class DataLoaderManager implements AppModule {
     }
 
     try {
+      const { fetchCyberThreats } = await import('@/services/cyber');
       const threats = await fetchCyberThreats({ limit: 500, days: 14 });
       this.ctx.cyberThreatsCache = threats;
       this.ctx.map?.setCyberThreats(threats);
@@ -2912,6 +2911,7 @@ export class DataLoaderManager implements AppModule {
 
   async loadCableActivity(): Promise<void> {
     try {
+      const { fetchCableActivity } = await import('@/services/cable-activity');
       const activity = await fetchCableActivity();
       this.ctx.map?.setCableActivity(activity.advisories, activity.repairShips);
       const itemCount = activity.advisories.length + activity.repairShips.length;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -12,13 +12,13 @@ export * from './weather';
 // keeps it un-tree-shakeable in eager main.js. Its consumers import it directly
 // (`@/services/economic`) or dynamically (data-loader), so it tree-shakes out.
 export * from './infrastructure';
-export * from './cyber';
+// cyber: not re-exported (#4649) — eager service client; kept tree-shakeable out of main.js
 export * from './maritime';
-export * from './cable-activity';
+// cable-activity: not re-exported (#4649) — eager service client; kept tree-shakeable out of main.js
 export * from './cable-health';
 export * from './conflict';
 export * from './displacement';
-export * from './research';
+// research: not re-exported (#4649) — eager service client; kept tree-shakeable out of main.js
 export * from './wildfires';
 export * from './climate';
 export * from './unrest';

--- a/tests/services-barrel-eager-guard.test.mts
+++ b/tests/services-barrel-eager-guard.test.mts
@@ -11,7 +11,10 @@ import { describe, it } from 'node:test';
 // regardless of whether the service's fetchers are dynamic-imported. That is the
 // exact regression #4571 removed (~150KB of service code off boot). This guard trips
 // if a deferred service is re-added to the barrel.
-const DEFERRED = ['economic', 'market', 'aviation', 'trade', 'supply-chain'];
+const DEFERRED = ['economic', 'market', 'aviation', 'trade', 'supply-chain', 'cyber', 'cable-activity', 'research'];
+// research is barrel-only (no data-loader consumer) — export*-guarded but not data-loader-guarded.
+const BARREL_ONLY = new Set(['research']);
+const DATA_LOADER_DEFERRED = DEFERRED.filter((s) => !BARREL_ONLY.has(s));
 
 const src = readFileSync(new URL('../src/services/index.ts', import.meta.url), 'utf8');
 const dataLoaderSrc = readFileSync(new URL('../src/app/data-loader.ts', import.meta.url), 'utf8');
@@ -37,7 +40,7 @@ describe('@/services barrel keeps side-effectful services tree-shakeable (#4571 
 });
 
 describe('data-loader keeps deferred service fetchers behind dynamic imports (#4571)', () => {
-  for (const svc of DEFERRED) {
+  for (const svc of DATA_LOADER_DEFERRED) {
     it(`does not statically import @/services/${svc}`, () => {
       const staticValueImportRe = new RegExp(`import\\s+(?!type\\b)[\\s\\S]*?from\\s*['"]@/services/${svc}['"]`);
       assert.ok(
@@ -47,7 +50,7 @@ describe('data-loader keeps deferred service fetchers behind dynamic imports (#4
     });
   }
 
-  for (const svc of DEFERRED) {
+  for (const svc of DATA_LOADER_DEFERRED) {
     it(`has an explicit dynamic import for @/services/${svc}`, () => {
       const dynamicImportRe = new RegExp(`import\\(\\s*['"]@/services/${svc}['"]\\s*\\)`);
       assert.ok(

--- a/tests/services-barrel-eager-guard.test.mts
+++ b/tests/services-barrel-eager-guard.test.mts
@@ -12,7 +12,8 @@ import { describe, it } from 'node:test';
 // exact regression #4571 removed (~150KB of service code off boot). This guard trips
 // if a deferred service is re-added to the barrel.
 const DEFERRED = ['economic', 'market', 'aviation', 'trade', 'supply-chain', 'cyber', 'cable-activity', 'research'];
-// research is barrel-only (no data-loader consumer) — export*-guarded but not data-loader-guarded.
+// research is barrel-only (no data-loader consumer) — export*-guarded and static-import guarded,
+// but it does not need a dynamic-import assertion until data-loader actually consumes it.
 const BARREL_ONLY = new Set(['research']);
 const DATA_LOADER_DEFERRED = DEFERRED.filter((s) => !BARREL_ONLY.has(s));
 
@@ -40,7 +41,7 @@ describe('@/services barrel keeps side-effectful services tree-shakeable (#4571 
 });
 
 describe('data-loader keeps deferred service fetchers behind dynamic imports (#4571)', () => {
-  for (const svc of DATA_LOADER_DEFERRED) {
+  for (const svc of DEFERRED) {
     it(`does not statically import @/services/${svc}`, () => {
       const staticValueImportRe = new RegExp(`import\\s+(?!type\\b)[\\s\\S]*?from\\s*['"]@/services/${svc}['"]`);
       assert.ok(


### PR DESCRIPTION
## Summary

First batch of the #4649 tail follow-up, applying the proven #4640 barrel-surgery recipe. Sheds 3 cleanly-deferrable side-effectful services off eager `main.js`:

| Service | eager main.js bytes | Mechanism |
|---|---|---|
| research | **0** | barrel-only — drop `export *` (no data-loader consumer) |
| cyber | **0** | drop `export *` + dynamic-import in `loadCyberThreats` |
| cable-activity | **0** | drop `export *` + dynamic-import in `loadCableActivity` |

`main.js`: 674.6KB → **671.1KB**. Guard extended to 8 deferred services (22 tests). typecheck / biome / build green.

The guard now distinguishes `BARREL_ONLY` services (research — export*-guarded but has no data-loader edge) from data-loader-deferred ones.

## Scope finding (corrects #4649's premise)
The "~20-service tail" is **not** all cheap barrel-surgery. Diagnosing consumer graphs: most tail services (**conflict, climate, radiation, earthquakes, displacement, weather, eonet, sanctions-pressure, prediction, military-flights, maritime**) are imported **eagerly by the map components** (DeckGLMap/GlobeMap/Map/MapContainer), app-context, or another service — barrel surgery alone won't shed them; they need the heavier **lazy-init** treatment (KTD2 from the #4571 plan). The realistic *cheap* barrel-surgery set is ~5 services: research/cyber/cable-activity (this PR) + usni-fleet/pizzint (next batch).

This keeps the shed honest and measure-gated rather than force-deferring integrated services (which wouldn't shed and would risk the map boot graph).

Part of #4649 / #4571 / #4487.

https://claude.ai/code/session_011htsYLErqJb922Qm9QLraN