### PR TITLE
perf(INP/map): viewport-cull the country-choropleth layers (#4601)

### DIFF
--- a/src/components/DeckGLMap.ts
+++ b/src/components/DeckGLMap.ts
@@ -627,6 +627,12 @@ export class DeckGLMap {
   // returns the same FeatureCollection ref and Object.is short-circuits the
   // deck.gl re-tessellation (#4561 review P2).
   private conflictZoneContentKey: string | null = null;
+  // #4601: countries features + precomputed bounds, built once (cheap — no
+  // tessellation); the viewport cull filters this for the choropleth layers,
+  // mirroring conflictZoneBounded. Invalidated with countriesGeoJsonData.
+  private countriesBounded: BoundedFeature[] | null = null;
+  private culledCountriesGeoJson: GeoJSON.FeatureCollection | null = null;
+  private culledCountriesContentKey = '';
 
   // CII choropleth data
   private ciiScoresMap: Map<string, { score: number; level: string }> = new Map();
@@ -2741,6 +2747,43 @@ export class DeckGLMap {
   }
 
   /**
+   * Viewport-culled countries geojson for the choropleth layers (#4601). Mirrors the
+   * conflict-zone cull (#4561): build the bounded set once, cull to the current
+   * viewport, and content-key cache so an unchanged visible set reuses the FC ref
+   * (Object.is short-circuits the deck.gl re-tessellation). Re-culled on pan/zoom via
+   * updateLayers(). Cull-only — no RDP simplify, so country borders stay crisp; at
+   * world/low zoom every country is visible so the full ref is returned unchanged.
+   */
+  private getCulledCountriesGeoJson(): GeoJSON.FeatureCollection | null {
+    const data = this.countriesGeoJsonData;
+    if (!data) return null;
+    if (!this.countriesBounded) {
+      const bounded: BoundedFeature[] = [];
+      for (const feature of data.features) {
+        const bounds = geometryBounds(feature.geometry);
+        if (bounds) bounded.push({ bounds, feature });
+      }
+      this.countriesBounded = bounded;
+    }
+    const mapBounds = this.maplibreMap?.getBounds();
+    if (!mapBounds) return data; // pre-map-init: no viewport — render all (prior behavior)
+    const viewport: BBox = [
+      mapBounds.getWest(), mapBounds.getSouth(), mapBounds.getEast(), mapBounds.getNorth(),
+    ];
+    const indices = culledIndices(this.countriesBounded, viewport);
+    // All countries visible (world/low zoom) — return the full ref, no new FC alloc.
+    if (indices.length === this.countriesBounded.length) return data;
+    const contentKey = indices.join(',');
+    if (contentKey === this.culledCountriesContentKey && this.culledCountriesGeoJson) {
+      return this.culledCountriesGeoJson;
+    }
+    const features = indices.map((i) => this.countriesBounded![i]!.feature);
+    this.culledCountriesGeoJson = { type: 'FeatureCollection', features };
+    this.culledCountriesContentKey = contentKey;
+    return this.culledCountriesGeoJson;
+  }
+
+  /**
    * Two-phase heavy-layer data (#4558). On the immediate (deferHeavy) frame,
    * stage the freshly-computed data and render the previously-committed value
    * (or `empty` on first build) so the heavy deck.gl tessellation is deferred;
@@ -4418,7 +4461,7 @@ export class DeckGLMap {
     const scores = this.happinessScores;
     return new GeoJsonLayer({
       id: 'happiness-choropleth-layer',
-      data: this.countriesGeoJsonData,
+      data: this.getCulledCountriesGeoJson() ?? this.countriesGeoJsonData,
       filled: true,
       stroked: true,
       getFillColor: (feature: { properties?: Record<string, unknown> }) => {
@@ -4451,7 +4494,7 @@ export class DeckGLMap {
     const colors = CII_LEVEL_COLORS;
     return new GeoJsonLayer({
       id: 'cii-choropleth-layer',
-      data: this.countriesGeoJsonData,
+      data: this.getCulledCountriesGeoJson() ?? this.countriesGeoJsonData,
       filled: true,
       stroked: true,
       getFillColor: (feature: { properties?: Record<string, unknown> }) => {
@@ -4472,7 +4515,7 @@ export class DeckGLMap {
     const scores = this.resilienceScoresMap;
     return new GeoJsonLayer({
       id: 'resilience-choropleth-layer',
-      data: this.countriesGeoJsonData,
+      data: this.getCulledCountriesGeoJson() ?? this.countriesGeoJsonData,
       filled: true,
       stroked: true,
       getFillColor: (feature: { properties?: Record<string, unknown> }) => {
@@ -4492,7 +4535,7 @@ export class DeckGLMap {
     if (!this.countriesGeoJsonData) return null;
     return new GeoJsonLayer({
       id: 'sanctions-choropleth-layer',
-      data: this.countriesGeoJsonData,
+      data: this.getCulledCountriesGeoJson() ?? this.countriesGeoJsonData,
       filled: true,
       stroked: false,
       getFillColor: (feature: { properties?: Record<string, unknown> }) => {
@@ -4511,7 +4554,7 @@ export class DeckGLMap {
     if (!this.affectedIso2Set.size || !this.countriesGeoJsonData) return null;
     return new GeoJsonLayer({
       id: 'scenario-heat-layer',
-      data: this.countriesGeoJsonData,
+      data: this.getCulledCountriesGeoJson() ?? this.countriesGeoJsonData,
       stroked: false,
       filled: true,
       extruded: false,
@@ -7335,6 +7378,9 @@ export class DeckGLMap {
         this.conflictZoneGeoJson = null;
         this.conflictZoneBounded = null;
         this.conflictZoneContentKey = null;
+        this.countriesBounded = null;
+        this.culledCountriesGeoJson = null;
+        this.culledCountriesContentKey = '';
         this.maplibreMap.addSource('country-boundaries', {
           type: 'geojson',
           data: geojson,


### PR DESCRIPTION
## Summary

#4601 — the secondary unbounded-tessellation surface surfaced by the #4561 U3 audit. The 5 country choropleths (happiness / CII / resilience / sanctions / affected) rendered the **full** `countriesGeoJsonData`, tessellating every country polygon on build. This applies the proven #4561 conflict-zone cull to them.

## Measure-first (KTD4)
The issue required confirming a choropleth build is a real frame contributor before culling. Sentry INP field attribution shows **layer-toggle interactions** (which activate these overlays) *do* appear in the field data — a real but minor contributor (not the p75 driver, which is the map canvas). So the cull targets a confirmed secondary surface, exactly as scoped.

## Change
`getCulledCountriesGeoJson()` mirrors the conflict-zone cull: build the `BoundedFeature[]` once (cheap, no tessellation), cull to the current viewport via `culledIndices`, and content-key cache so an unchanged visible set reuses the FC ref (`Object.is` short-circuits deck.gl re-tessellation). **Cull-only** — no RDP simplify, so country borders stay crisp and no geometry is cloned/mutated. At world/low zoom every country is visible → the full ref is returned unchanged (**no-op at the default view**). Re-culls on pan/zoom via `buildLayers()`←`updateLayers()` — the same rebuild path the conflict-zone cull uses.

## Verification
- typecheck / biome / build green; reuses the #4561 `conflict-zone-cull` helpers (**23 pure-logic tests pass**).
- Re-cull-on-pan correctness confirmed in code (choropleth builders → `buildLayers` → `updateLayers` on `moveend`, reading live `getBounds()` each build).
- **Focused code-review: no blocking issues** — traced cache invalidation, the all-visible short-circuit (no stale serve), re-cull-on-pan, `renderWorldCopies:false` antimeridian safety, and shared-ref non-mutation; a correct mirror of the shipped #4561 pattern, safer (no simplify → no geometry mutation).
- INP delta is post-deploy field data (not unit-testable); correctness inherited from the proven, shipped #4561 cull.

Part of #4537 / #4487.

https://claude.ai/code/session_011htsYLErqJb922Qm9QLraN