### PR TITLE
perf(mobile): decompose main-thread other

### DIFF
--- a/docs/perf/mobile-mainthread-baseline-2026-06-27.md
+++ b/docs/perf/mobile-mainthread-baseline-2026-06-27.md
@@ -13,10 +13,11 @@ throttling 4×-amplifies host-CPU contention; the same URL has scored 28/57/85):
    infra, zero local contention). Take the **median of ≥3** runs; discard the first-run outlier.
    This is the headline TBT / `mainthread-work` / `bootup-time` / `scriptEvaluation` /
    `styleLayout` and the per-script `bootup-time` ranking (R4).
-2. **Deterministic relative signal → `scripts/measure-mobile-mainthread.mjs`** (this harness;
-   Playwright mobile emulation + CPU throttle). DOM-node counts are stable run-to-run; total
-   long-task ms is a self-consistent *relative* signal for the same script before/after. This is
-   the per-PR R3 gate (reduce vs. reorder).
+2. **Deterministic relative decomposition → `scripts/measure-mobile-mainthread.mjs`** (this
+   harness; Playwright mobile emulation + CPU throttle). It now captures a Chrome DevTools trace
+   and aggregates renderer main-thread self-time by event name → category, itemizing the
+   Lighthouse "Other" bucket the same way the desktop harness did for #4539. It also retains the
+   long-task and DOM-node signals used by the original R3 gate (reduce vs. reorder).
 
 ```bash
 # deterministic harness (best-effort live capture)
@@ -24,11 +25,12 @@ node scripts/measure-mobile-mainthread.mjs https://worldmonitor.app/dashboard --
 # or against a local preview: node scripts/measure-mobile-mainthread.mjs http://127.0.0.1:4173/dashboard
 ```
 
-> **Per-script ms attribution comes from Lighthouse, not this script.** The browser
-> `PerformanceObserver('longtask')` attribution API returns `unknown`/`self` for first-party
-> same-origin script, so the harness cannot name *which* chunk owns each long task — it reports
-> total TBT + DOM-node attribution only. For the per-script ranking (Map-\*.js, main.js,
-> panel-layout) use Lighthouse's `bootup-time` audit, as #4443 did.
+> **Per-script chunk ownership still comes from Lighthouse, not this script.** The browser
+> `PerformanceObserver("longtask")` attribution API returns `unknown`/`self` for first-party
+> same-origin script, so the harness cannot name *which* chunk owns each long task. The local trace
+> path decomposes native main-thread event names/categories (`Layerize`, `RunTask`, layout, paint,
+> GC, etc.) and itemizes `Other`; for the per-script ranking (Map-*.js, main.js, panel-layout),
+> still use Lighthouse `bootup-time`, as #4443 did.
 
 ## Committed PSI baseline (the comparison point)
 
@@ -73,6 +75,52 @@ directional:
 Reading: `mainthread-work` ~10 s and `bootup-time` ~1.8 s remain the dominant budget (paint is fine
 at ~1.1 s) — consistent with the script-execution-bound finding above. Desktop TBT is noisy under
 contention; the authoritative mobile TBT still needs a clean PSI run.
+
+## Harness capture — 2026-07-03 (prod, mobile trace decomposition)
+
+Command:
+
+```bash
+node scripts/measure-mobile-mainthread.mjs https://worldmonitor.app/dashboard --cpu 4 --settle 14000 --json
+```
+
+First local capture, iPhone 14 Pro Max emulation, CPU 4×, 14 s settle. As above, treat absolute
+ms as host-contended lab values and use the relative split to decide what bucket to investigate.
+
+| Category | Share | Self-time |
+|---|---:|---:|
+| scripting | 50.7% | 7.52 s |
+| **other** | **31.9%** | **4.73 s** |
+| styleLayout | 12.1% | 1.80 s |
+| paintComposite | 4.8% | 0.71 s |
+| parseHTML | 0.4% | 0.05 s |
+| garbageCollection | 0.1% | 0.02 s |
+| main-thread self-time total | — | 14.82 s |
+| long tasks (>50 ms) / TBT | 63 / 10.74 s | — |
+
+A second same-command capture after the reuse cleanup was materially consistent: scripting 49.4%,
+`other` 31.7%, styleLayout 13.2%, `ThreadControllerImpl::RunTask` 9.7%,
+`SimpleWatcher::OnHandleReady` 7.0%, and `Layerize` 3.3%.
+
+### Mobile "Other" decomposed
+
+| "Other" component | Share | Self-time | What it suggests |
+|---|---:|---:|---|
+| `ThreadControllerImpl::RunTask` | 9.7% | 1.44 s | Scheduler task-runner self-time from running many renderer tasks. |
+| `SimpleWatcher::OnHandleReady` | 6.4% | 0.95 s | Chromium handle/socket readiness work; likely network or async plumbing around startup. |
+| `RunTask` | 3.7% | 0.55 s | More scheduler wrapper self-time. |
+| `Layerize` | 2.2% | 0.33 s | Compositor layerization; much smaller on mobile than desktop #4539. |
+| `v8.run` | 1.9% | 0.28 s | V8 native wrapper overhead; chunk ownership still comes from Lighthouse `bootup-time`. |
+| `IntersectionObserverController::computeIntersections` | 1.0% | 0.14 s | Panel mount / visibility observer work. |
+
+Findings from this run:
+
+1. The old mobile "Other" bucket is no longer a black box. In this current prod capture it is
+   **scheduler + Chromium watcher dominated**, not primarily compositor `Layerize` as on desktop.
+2. The largest total category is still **scripting** under CPU 4× (50.7% / 7.52 s). Use Lighthouse
+   `bootup-time` to map that to chunks; this harness maps native event categories and `Other`.
+3. DOM-node attribution remains close to the 2026-06-27 conclusion: panels 830 / 42.1%, map SVG
+   250 / 12.7%, total 1,971 nodes.
 
 ## Harness capture — 2026-06-27 (prod, post #4442/#4448)
 

--- a/scripts/measure-desktop-mainthread.mjs
+++ b/scripts/measure-desktop-mainthread.mjs
@@ -149,6 +149,16 @@ export function normalizeCompleteEvents(events) {
  * the top frame is a known limitation). Returns "pid:tid" or null when none found.
  */
 export function pickRendererMainThread(events) {
+  return selectRendererMainThreadEvents(events).mainThread;
+}
+
+/**
+ * Identify the busiest CrRendererMain and return its already-normalized complete
+ * events. This keeps report builders from normalizing the same trace twice:
+ * thread_name metadata must be read from raw events, but self-time needs complete
+ * events filtered to one properly-nested renderer thread.
+ */
+export function selectRendererMainThreadEvents(events) {
   const list = Array.isArray(events) ? events : [];
   const candidates = new Set();
   for (const e of list) {
@@ -156,11 +166,14 @@ export function pickRendererMainThread(events) {
       candidates.add(`${e.pid}:${e.tid}`);
     }
   }
-  if (candidates.size === 0) return null;
+  if (candidates.size === 0) return { mainThread: null, completeEvents: [] };
   const durByThread = new Map();
+  const eventsByThread = new Map();
   for (const e of normalizeCompleteEvents(list)) {
     const key = `${e.pid}:${e.tid}`;
     if (!candidates.has(key)) continue;
+    if (!eventsByThread.has(key)) eventsByThread.set(key, []);
+    eventsByThread.get(key).push(e);
     if (typeof e.dur === 'number') durByThread.set(key, (durByThread.get(key) || 0) + e.dur);
   }
   let best = null;
@@ -168,7 +181,7 @@ export function pickRendererMainThread(events) {
   for (const [key, d] of durByThread) {
     if (d > bestDur) { bestDur = d; best = key; }
   }
-  return best;
+  return { mainThread: best, completeEvents: best ? eventsByThread.get(best) || [] : [] };
 }
 
 /**
@@ -389,7 +402,7 @@ async function measure(url, { cpu = 1, settle = 15000 } = {}) {
 /** Build the structured report (pure — exported for tests). */
 export function buildReport(result) {
   const events = result?.trace?.traceEvents || (Array.isArray(result?.trace) ? result.trace : []);
-  const mainThread = pickRendererMainThread(events);
+  const { mainThread, completeEvents } = selectRendererMainThreadEvents(events);
   const longTasks = summarizeLongTasks(result?.longtasks);
   if (!mainThread) {
     // No CrRendererMain metadata - we cannot isolate one properly-nested thread.
@@ -407,8 +420,7 @@ export function buildReport(result) {
       warning: 'no CrRendererMain thread found in trace; not attributing',
     };
   }
-  const complete = normalizeCompleteEvents(events).filter((e) => `${e.pid}:${e.tid}` === mainThread);
-  const { byName } = computeSelfTimeByName(complete);
+  const { byName } = computeSelfTimeByName(completeEvents);
   return {
     url: result?.url,
     cpu: result?.cpu,

--- a/scripts/measure-desktop-mainthread.mjs
+++ b/scripts/measure-desktop-mainthread.mjs
@@ -276,7 +276,7 @@ export function parseArgs(argv) {
   return args;
 }
 
-const TRACE_CATEGORIES = [
+export const TRACE_CATEGORIES = [
   'devtools.timeline',
   'disabled-by-default-devtools.timeline',
   'disabled-by-default-devtools.timeline.frame',
@@ -288,7 +288,7 @@ const TRACE_CATEGORIES = [
 ];
 
 /** Read a CDP IO stream to completion, decoding base64 chunks when flagged. */
-async function readTraceStream(client, handle) {
+export async function readTraceStream(client, handle) {
   let data = '';
   let eof = false;
   while (!eof) {
@@ -300,18 +300,36 @@ async function readTraceStream(client, handle) {
   return data;
 }
 
-function waitForTraceComplete(client, timeoutMs = TRACE_COMPLETE_TIMEOUT_MS) {
+export function waitForTraceComplete(client, timeoutMs = TRACE_COMPLETE_TIMEOUT_MS, { signal } = {}) {
   return new Promise((resolve, reject) => {
     let timer;
-    const onComplete = (event) => {
+    let settled = false;
+    const cleanup = () => {
       clearTimeout(timer);
-      resolve(event);
+      if (typeof client.off === "function") client.off("Tracing.tracingComplete", onComplete);
+      signal?.removeEventListener?.("abort", onAbort);
     };
+    const settle = (fn, value) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      fn(value);
+    };
+    const onComplete = (event) => {
+      settle(resolve, event);
+    };
+    const onAbort = () => {
+      settle(reject, new Error("Cancelled waiting for Tracing.tracingComplete"));
+    };
+    if (signal?.aborted) {
+      reject(new Error("Cancelled waiting for Tracing.tracingComplete"));
+      return;
+    }
     timer = setTimeout(() => {
-      if (typeof client.off === 'function') client.off('Tracing.tracingComplete', onComplete);
-      reject(new Error(`Timed out waiting ${timeoutMs}ms for Tracing.tracingComplete`));
+      settle(reject, new Error(`Timed out waiting ${timeoutMs}ms for Tracing.tracingComplete`));
     }, timeoutMs);
-    client.once('Tracing.tracingComplete', onComplete);
+    client.once("Tracing.tracingComplete", onComplete);
+    signal?.addEventListener?.("abort", onAbort, { once: true });
   });
 }
 

--- a/scripts/measure-mobile-mainthread.mjs
+++ b/scripts/measure-mobile-mainthread.mjs
@@ -3,6 +3,7 @@
  * Mobile main-thread attribution harness (#4443 / U2).
  *
  * Loads /dashboard under mobile emulation + CPU throttle and attributes:
+ *   - Chrome trace renderer main-thread self-time by category + itemized Other events
  *   - long tasks (PerformanceObserver 'longtask') by source, with TBT contribution
  *   - DOM-node counts per source (map SVG subtree vs panels)
  *
@@ -21,6 +22,15 @@
  *   (default url: https://worldmonitor.app/dashboard)
  */
 import { pathToFileURL } from 'node:url';
+import {
+  buildDecomposition,
+  computeSelfTimeByName,
+  normalizeCompleteEvents,
+  pickRendererMainThread,
+  readTraceStream,
+  TRACE_CATEGORIES,
+  waitForTraceComplete,
+} from './measure-desktop-mainthread.mjs';
 
 const TBT_THRESHOLD_MS = 50;
 
@@ -187,8 +197,41 @@ async function measure(url, { cpu = 4, settle = 15000, device = 'iPhone 14 Pro M
         /* longtask unsupported */
       }
     });
+    let trace = null;
+    let traceWarning = "";
+    try {
+      await client.send("Tracing.start", {
+        transferMode: "ReturnAsStream",
+        traceConfig: { recordMode: "recordAsMuchAsPossible", includedCategories: TRACE_CATEGORIES },
+      });
+    } catch (err) {
+      traceWarning = "CDP tracing unavailable: " + (err?.message || String(err));
+    }
     await page.goto(url, { waitUntil: 'load', timeout: 60000 });
     await page.waitForTimeout(settle);
+    if (!traceWarning) {
+      try {
+        const traceAbort = new AbortController();
+        const completePromise = waitForTraceComplete(client, undefined, { signal: traceAbort.signal });
+        try {
+          await client.send("Tracing.end");
+        } catch (err) {
+          traceAbort.abort();
+          try {
+            await completePromise;
+          } catch {
+            /* expected when cancelling the trace-complete waiter */
+          }
+          throw err;
+        }
+        const { stream } = await completePromise;
+        if (!stream) throw new Error("Tracing completed without an IO stream");
+        const raw = await readTraceStream(client, stream);
+        trace = JSON.parse(raw);
+      } catch (err) {
+        traceWarning = "CDP trace capture failed: " + (err?.message || String(err));
+      }
+    }
     const longtasks = await page.evaluate(() => window.__longtasks || []);
     const lcpDebug = await page.evaluate(() => window.__wmLcpDebug?.getSnapshot?.() ?? null);
     const nodeCounts = await page.evaluate(() => {
@@ -207,7 +250,7 @@ async function measure(url, { cpu = 4, settle = 15000, device = 'iPhone 14 Pro M
         panels: uniqueCount('.panel, .panel *'),
       };
     });
-    return { url, cpu, longtasks, lcpDebug, nodeCounts };
+    return { url, cpu, trace, traceWarning, longtasks, lcpDebug, nodeCounts };
   } finally {
     await browser.close();
   }
@@ -215,9 +258,32 @@ async function measure(url, { cpu = 4, settle = 15000, device = 'iPhone 14 Pro M
 
 /** Build the structured report (pure — exported for tests). */
 export function buildReport(result) {
+  const events = result?.trace?.traceEvents || (Array.isArray(result?.trace) ? result.trace : []);
+  const mainThread = pickRendererMainThread(events);
+  const traceWarning = result?.traceWarning
+    || (mainThread ? "" : "no CrRendererMain thread found in trace; not attributing");
+  const traceReport = (() => {
+    if (traceWarning) {
+      return {
+        mainThread: null,
+        mainThreadMs: 0,
+        categories: [],
+        other: [],
+        warning: traceWarning,
+      };
+    }
+    const complete = normalizeCompleteEvents(events).filter((e) => e.pid + ":" + e.tid === mainThread);
+    const { byName } = computeSelfTimeByName(complete);
+    return {
+      mainThread,
+      ...buildDecomposition(byName),
+    };
+  })();
+
   return {
     url: result?.url,
     cpu: result?.cpu,
+    ...traceReport,
     lcp: summarizeLcpDebug(result?.lcpDebug),
     tasks: summarizeLongTasks(result?.longtasks),
     nodes: attributeDomNodes(result?.nodeCounts),
@@ -226,7 +292,24 @@ export function buildReport(result) {
 
 function printHuman(report) {
   const { lcp, tasks, nodes } = report;
-  console.log(`\nMobile main-thread attribution — ${report.url} (CPU ${report.cpu}x)\n`);
+  console.log("\nMobile main-thread attribution — " + report.url + " (CPU " + report.cpu + "x)\n");
+  console.log("Main-thread self-time total: " + report.mainThreadMs + "ms  (thread " + (report.mainThread || "unknown") + ")");
+  if (report.categories.length > 0) {
+    console.log("By category (share of attributed main-thread self-time):");
+    for (const c of report.categories) {
+      console.log("  " + c.category.padEnd(20) + " " + String(c.ms).padStart(9) + "ms  (" + c.pct + "%)");
+    }
+    console.log("\n\"Other\" decomposed (top events — this is the mobile #4443 black box):");
+    for (const o of report.other) {
+      console.log("  " + o.name.padEnd(36) + " " + String(o.ms).padStart(9) + "ms  (" + o.pct + "%)");
+    }
+    console.log("");
+  }
+  if (report.warning) {
+    console.log("Trace warning:");
+    console.log("  " + report.warning);
+    console.log("");
+  }
   if (lcp?.candidate) {
     const candidate = lcp.candidate;
     console.log(
@@ -254,7 +337,8 @@ function printHuman(report) {
   for (const r of nodes.rows) {
     console.log(`  ${r.source.padEnd(28)} ${String(r.nodes).padStart(7)}  (${r.sharePct}%)`);
   }
-  console.log('');
+  console.log("\nNote: absolute ms is host-contention-sensitive (#4486). Trust the RELATIVE");
+  console.log("shares here; take authoritative absolute mobile timings from PageSpeed/Calibre.\n");
 }
 
 async function main() {

--- a/scripts/measure-mobile-mainthread.mjs
+++ b/scripts/measure-mobile-mainthread.mjs
@@ -25,8 +25,7 @@ import { pathToFileURL } from 'node:url';
 import {
   buildDecomposition,
   computeSelfTimeByName,
-  normalizeCompleteEvents,
-  pickRendererMainThread,
+  selectRendererMainThreadEvents,
   readTraceStream,
   TRACE_CATEGORIES,
   waitForTraceComplete,
@@ -259,7 +258,7 @@ async function measure(url, { cpu = 4, settle = 15000, device = 'iPhone 14 Pro M
 /** Build the structured report (pure — exported for tests). */
 export function buildReport(result) {
   const events = result?.trace?.traceEvents || (Array.isArray(result?.trace) ? result.trace : []);
-  const mainThread = pickRendererMainThread(events);
+  const { mainThread, completeEvents } = selectRendererMainThreadEvents(events);
   const traceWarning = result?.traceWarning
     || (mainThread ? "" : "no CrRendererMain thread found in trace; not attributing");
   const traceReport = (() => {
@@ -272,8 +271,7 @@ export function buildReport(result) {
         warning: traceWarning,
       };
     }
-    const complete = normalizeCompleteEvents(events).filter((e) => e.pid + ":" + e.tid === mainThread);
-    const { byName } = computeSelfTimeByName(complete);
+    const { byName } = computeSelfTimeByName(completeEvents);
     return {
       mainThread,
       ...buildDecomposition(byName),

--- a/tests/measure-desktop-mainthread.test.mts
+++ b/tests/measure-desktop-mainthread.test.mts
@@ -8,6 +8,7 @@ import {
   categorize,
   buildDecomposition,
   buildReport,
+  waitForTraceComplete,
 } from '../scripts/measure-desktop-mainthread.mjs';
 
 // Deterministic fixture (CI-safe, no browser): a CrRendererMain thread (1:1) with
@@ -138,6 +139,26 @@ test('self-time handles ts-tie parent/child and adjacent siblings (guards the du
   assert.equal(byName.get('Layout'), 40, 'ts-tie child keeps its full duration');
   assert.equal(byName.get('Paint'), 60, 'adjacent sibling is not nested under Layout');
   assert.equal(total, 100);
+});
+
+test("waitForTraceComplete abort removes listener and rejects promptly (#4443)", async () => {
+  const listeners = new Set();
+  const client = {
+    once(name, callback) {
+      if (name === "Tracing.tracingComplete") listeners.add(callback);
+    },
+    off(name, callback) {
+      if (name === "Tracing.tracingComplete") listeners.delete(callback);
+    },
+  };
+  const controller = new AbortController();
+  const promise = waitForTraceComplete(client, 1000, { signal: controller.signal });
+
+  assert.equal(listeners.size, 1);
+  controller.abort();
+
+  await assert.rejects(promise, /Cancelled waiting for Tracing.tracingComplete/);
+  assert.equal(listeners.size, 0);
 });
 
 test('buildReport refuses to attribute when no CrRendererMain thread exists (#4539)', () => {

--- a/tests/measure-desktop-mainthread.test.mts
+++ b/tests/measure-desktop-mainthread.test.mts
@@ -4,6 +4,7 @@ import {
   categoryOf,
   normalizeCompleteEvents,
   pickRendererMainThread,
+  selectRendererMainThreadEvents,
   computeSelfTimeByName,
   categorize,
   buildDecomposition,
@@ -79,6 +80,19 @@ test('pickRendererMainThread picks the busiest CrRendererMain (#4539)', () => {
 
 test('pickRendererMainThread scores normalized B/E events and skips null entries (#4539)', () => {
   assert.equal(pickRendererMainThread(fixtureBeginEndTraceEvents()), '1:1');
+});
+
+test('selectRendererMainThreadEvents returns the selected normalized thread events (#4539)', () => {
+  const { mainThread, completeEvents } = selectRendererMainThreadEvents(fixtureBeginEndTraceEvents());
+
+  assert.equal(mainThread, '1:1');
+  assert.deepEqual(
+    completeEvents.map((event) => ({ name: event.name, dur: event.dur, thread: `${event.pid}:${event.tid}` })),
+    [
+      { name: 'Layout', dur: 150, thread: '1:1' },
+      { name: 'RunTask', dur: 500, thread: '1:1' },
+    ],
+  );
 });
 
 test('computeSelfTimeByName subtracts nested children from parents (#4539)', () => {

--- a/tests/measure-mobile-mainthread.test.mts
+++ b/tests/measure-mobile-mainthread.test.mts
@@ -164,4 +164,55 @@ describe('buildReport', () => {
     // round-trips cleanly for `--json | jq`
     assert.doesNotThrow(() => JSON.parse(JSON.stringify(report)));
   });
+
+  it("decomposes mobile trace self-time into categories and Other events (#4443)", () => {
+    const report = buildReport({
+      url: "http://x/dashboard",
+      cpu: 4,
+      trace: {
+        traceEvents: [
+          { ph: "M", name: "thread_name", pid: 7, tid: 11, args: { name: "CrRendererMain" } },
+          { ph: "M", name: "thread_name", pid: 7, tid: 12, args: { name: "CrRendererMain" } },
+          { ph: "X", name: "RunTask", pid: 7, tid: 11, ts: 0, dur: 1000 },
+          { ph: "X", name: "Layerize", pid: 7, tid: 11, ts: 100, dur: 500 },
+          { ph: "X", name: "FunctionCall", pid: 7, tid: 11, ts: 700, dur: 200 },
+          { ph: "X", name: "FunctionCall", pid: 7, tid: 12, ts: 0, dur: 50 },
+        ],
+      },
+      longtasks: [],
+      nodeCounts: { total: 1000, mapSvg: 100, panels: 800 },
+    });
+
+    assert.equal(report.mainThread, "7:11");
+    assert.equal(report.mainThreadMs, 1);
+    assert.deepEqual(report.categories.find((c) => c.category === "other"), {
+      category: "other",
+      ms: 0.8,
+      pct: 80,
+    });
+    assert.deepEqual(report.categories.find((c) => c.category === "scripting"), {
+      category: "scripting",
+      ms: 0.2,
+      pct: 20,
+    });
+    assert.deepEqual(report.other[0], { name: "Layerize", ms: 0.5, pct: 50 });
+    assert.deepEqual(report.other[1], { name: "RunTask", ms: 0.3, pct: 30 });
+    assert.equal(report.warning, undefined);
+  });
+
+  it("refuses trace attribution when CrRendererMain metadata is missing (#4443)", () => {
+    const report = buildReport({
+      url: "http://x/dashboard",
+      cpu: 4,
+      trace: { traceEvents: [{ ph: "X", name: "RunTask", pid: 1, tid: 1, ts: 0, dur: 1000 }] },
+      longtasks: [{ duration: 80 }],
+    });
+
+    assert.equal(report.mainThread, null);
+    assert.equal(report.mainThreadMs, 0);
+    assert.deepEqual(report.categories, []);
+    assert.deepEqual(report.other, []);
+    assert.match(report.warning, /no CrRendererMain/);
+    assert.equal(report.tasks.longTaskCount, 1);
+  });
 });


### PR DESCRIPTION
## Summary

The mobile perf harness can now explain the Lighthouse "Other" bucket instead of leaving the largest uncharacterized mobile slice anonymous. It captures a Chrome DevTools trace alongside the existing mobile LCP, long-task, and DOM snapshots, reuses the desktop trace decomposition helpers, and reports both category totals and itemized self-time contributors.

The first production captures show mobile Other is dominated by Chromium scheduler and watcher work, while scripting remains the biggest category under 4x CPU slowdown.

| Signal | Capture 1 | Capture 2 |
|---|---:|---:|
| Scripting | 50.7% / 7.52s | 49.4% |
| Other | 31.9% / 4.73s | 31.7% |
| Style/layout | 12.1% / 1.80s | 13.2% |
| ThreadControllerImpl::RunTask | 9.7% / 1.44s | 9.7% |
| SimpleWatcher::OnHandleReady | 6.4% / 0.95s | 7.0% |
| Layerize | 2.2% / 0.33s | 3.3% |

## Related

Related: #4443, #4539

## Validation

- `node --test tests/measure-desktop-mainthread.test.mts tests/measure-mobile-mainthread.test.mts`
- `node --check scripts/measure-desktop-mainthread.mjs && node --check scripts/measure-mobile-mainthread.mjs`
- `git diff --check`
- `node scripts/measure-mobile-mainthread.mjs https://worldmonitor.app/dashboard --cpu 4 --settle 14000 --json` twice against production

Not run: full lint/typecheck. `npm ci --ignore-scripts --cache /tmp/worldmonitor-npm-cache` was killed with exit 137 in this worktree, so validation stayed focused on the changed harness and tests.

## Post-Deploy Monitoring

No production runtime path changes. After merge, rerun the mobile harness against production; expected JSON has a non-null `mainThread`, populated `categories.other`, itemized `other.items`, and no trace warning. Treat a missing renderer main thread, empty trace categories, or `warning` output as a harness regression to fix or revert.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
