### PR TITLE
Fix seed forecast review follow-ups

### DIFF
--- a/scripts/seed-forecasts.mjs
+++ b/scripts/seed-forecasts.mjs
@@ -14139,6 +14139,19 @@ function resolveForecastLlmProviders(options = {}) {
   return providers.length > 0 ? providers : FORECAST_LLM_PROVIDERS;
 }
 
+function moveForecastLlmProviderToBack(options = {}, providerName = '') {
+  if (!providerName) return options;
+  const requestedOrder = Array.isArray(options.providerOrder) && options.providerOrder.length > 0
+    ? options.providerOrder
+    : FORECAST_LLM_PROVIDERS.map(provider => provider.name);
+  const providerOrder = [...new Set(requestedOrder.filter(name => FORECAST_LLM_PROVIDER_NAMES.has(name)))];
+  if (providerOrder.length < 2 || !providerOrder.includes(providerName)) return options;
+  return {
+    ...options,
+    providerOrder: [...providerOrder.filter(name => name !== providerName), providerName],
+  };
+}
+
 function summarizeForecastLlmOptions(options = {}) {
   return {
     providerOrder: Array.isArray(options.providerOrder) ? options.providerOrder : [],
@@ -14517,7 +14530,11 @@ async function redisSet(url, token, key, data, ttlSeconds) {
     await withRetry(async () => {
       const resp = await fetch(url, {
         method: 'POST',
-        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'User-Agent': CHROME_UA,
+        },
         body: JSON.stringify(['SET', key, JSON.stringify(data), 'EX', ttlSeconds]),
         signal: AbortSignal.timeout(10_000),
       });
@@ -14787,9 +14804,10 @@ const SCENARIO_LLM_VALIDATION_RETRIES = 1;
 
 async function resolveScenarioLlmResult(scenarioOnly, scenarioLlmOptions, maxValidationRetries = SCENARIO_LLM_VALIDATION_RETRIES) {
   let last = { result: null, parsed: null, raw: null, valid: [], validCases: [] };
+  let callOptions = { ...scenarioLlmOptions, stage: 'scenario' };
   for (let attempt = 0; attempt <= maxValidationRetries; attempt++) {
     if (attempt > 0) console.log(`  [LLM:scenario] validation retry ${attempt + 1}/${maxValidationRetries + 1} (prior attempt validated to 0)`);
-    const result = await callForecastLLM(SCENARIO_SYSTEM_PROMPT, buildUserPrompt(scenarioOnly), { ...scenarioLlmOptions, stage: 'scenario' });
+    const result = await callForecastLLM(SCENARIO_SYSTEM_PROMPT, buildUserPrompt(scenarioOnly), callOptions);
     if (!result) break; // provider failure / budget exhausted — keep the last (possibly empty) result
     const parsed = extractStructuredLlmPayload(result.text);
     const raw = parsed.items;
@@ -14797,6 +14815,7 @@ async function resolveScenarioLlmResult(scenarioOnly, scenarioLlmOptions, maxVal
     const validCases = validateCaseNarratives(raw, scenarioOnly);
     last = { result, parsed, raw, valid, validCases };
     if (valid.length > 0 || validCases.length > 0) break;
+    callOptions = moveForecastLlmProviderToBack(callOptions, result.provider);
   }
   return last;
 }

--- a/tests/forecast-seed-resilience.test.mjs
+++ b/tests/forecast-seed-resilience.test.mjs
@@ -11,6 +11,7 @@ import {
   __setForecastLlmTransportForTests,
   __setForecastLlmRunDeadlineForTests,
 } from '../scripts/seed-forecasts.mjs';
+import { CHROME_UA } from '../scripts/_seed-utils.mjs';
 
 const REAL_FETCH = globalThis.fetch;
 
@@ -56,6 +57,16 @@ describe('redisSet cache-write retry', () => {
     globalThis.fetch = async () => { calls += 1; return calls === 1 ? { ok: false, status: 503 } : { ok: true }; };
     await __redisSetForTests('http://redis', 'tok', 'k', { a: 1 }, 600);
     assert.equal(calls, 2, '5xx is retryable');
+  });
+
+  it('sends the standard User-Agent header on cache writes', async () => {
+    let seenHeaders = null;
+    globalThis.fetch = async (_url, init) => {
+      seenHeaders = init.headers;
+      return { ok: true };
+    };
+    await __redisSetForTests('http://redis', 'tok', 'k', { a: 1 }, 600);
+    assert.equal(seenHeaders?.['User-Agent'], CHROME_UA);
   });
 });
 
@@ -130,5 +141,41 @@ describe('resolveScenarioLlmResult validation retry', () => {
     const out = await resolveScenarioLlmResult(predictions, {});
     assert.equal(calls, 1, 'valid first response => no retry');
     assert.equal(out.validCases.length, 1);
+  });
+
+  it('tries a fallback provider after the primary validates to zero narratives', async () => {
+    const oldGroqKey = process.env.GROQ_API_KEY;
+    const oldOpenRouterKey = process.env.OPENROUTER_API_KEY;
+    process.env.GROQ_API_KEY = 'groq-key';
+    process.env.OPENROUTER_API_KEY = 'openrouter-key';
+    const providers = [];
+    try {
+      __setForecastLlmTransportForTests({
+        fetch: async (url) => {
+          const provider = url.includes('groq.com') ? 'groq' : 'openrouter';
+          providers.push(provider);
+          return {
+            ok: true,
+            json: async () => ({
+              model: `${provider}-model`,
+              choices: [{
+                message: {
+                  content: provider === 'groq'
+                    ? 'The provider returned a semantically empty JSON payload: []'
+                    : validCasePayload,
+                },
+              }],
+            }),
+          };
+        },
+      });
+      const out = await resolveScenarioLlmResult(predictions, { providerOrder: ['groq', 'openrouter'], retryDelayMs: 1 });
+      assert.deepEqual(providers, ['groq', 'openrouter']);
+      assert.equal(out.result.provider, 'openrouter');
+      assert.equal(out.validCases.length, 1);
+    } finally {
+      if (oldGroqKey === undefined) delete process.env.GROQ_API_KEY; else process.env.GROQ_API_KEY = oldGroqKey;
+      if (oldOpenRouterKey === undefined) delete process.env.OPENROUTER_API_KEY; else process.env.OPENROUTER_API_KEY = oldOpenRouterKey;
+    }
   });
 });


### PR DESCRIPTION
## What Changed

Before, `redisSet()` cache writes skipped the repo-standard `User-Agent`, and a scenario validation retry could immediately ask the same provider again after a parseable-but-empty response, blocking a healthy fallback provider.

Now, Redis cache writes include `CHROME_UA`, and scenario validation retries move the provider that produced zero valid narratives to the back of the order so fallback providers get the next chance.

## Validation

- `./node_modules/.bin/tsx --test tests/forecast-seed-resilience.test.mjs` (11 tests passed)
- `git diff --check`

Follow-up to the merged #4659 review P2s.

Generated with [Compound Engineering](https://compound.engineering)
