### PR TITLE
perf(desktop/#4630): CDP LayerTree audit tool + Layerize named cause

### DIFF
--- a/docs/perf/desktop-mainthread-baseline-2026-07-02.md
+++ b/docs/perf/desktop-mainthread-baseline-2026-07-02.md
@@ -119,6 +119,10 @@ Measured with the new `scripts/measure-composited-layers.mjs` (CDP `LayerTree`) 
 | `div.nuclear-marker.construction` | 10 |
 | base-markers / structural / doc | ~20 |
 
+> Note: this capture predated the `describeNodeCap` skipped-node bucket. Treat the `(detached)` row as
+> "unresolved owner" evidence until rerun with the current harness; the total layer count and compositing
+> reasons remain the stable signals.
+
 Compositing reasons (frequency across the 517 layers):
 
 | Reason | Layers |

--- a/docs/perf/desktop-mainthread-baseline-2026-07-02.md
+++ b/docs/perf/desktop-mainthread-baseline-2026-07-02.md
@@ -101,3 +101,43 @@ Re-run both harness invocations before/after any compositing-layer change and re
 `Layerize` self-time share delta in the PR. Take the authoritative absolute desktop `mainthread-work`
 from a clean PSI/Calibre run — this harness supplies the **relative** decomposition, not the headline
 absolute (KTD1). The `styleLayout` share is the #4536 gate; the `Layerize` share is the new one.
+
+## Composited layers (#4630) — named cause, 2026-07-03
+
+Measured with the new `scripts/measure-composited-layers.mjs` (CDP `LayerTree`) against prod
+`/dashboard`, CPU 1×, 9s settle:
+
+**517 composited layers** (430 draw content). Top owners by layer count:
+
+| Owner selector | Layers |
+|---|---:|
+| `div.nuclear-marker.active` | 226 |
+| `(detached)` | 113 |
+| `div.earthquake-marker` | 66 |
+| `div.nuclear-marker.decommissioned` | 43 |
+| `div.hotspot` + `div.hotspot-marker.high` | 37 |
+| `div.nuclear-marker.construction` | 10 |
+| base-markers / structural / doc | ~20 |
+
+Compositing reasons (frequency across the 517 layers):
+
+| Reason | Layers |
+|---|---:|
+| **Has an active accelerated opacity animation or transition** | **385** |
+| Overlaps other composited content | 115 |
+| Has an active accelerated transform animation or transition | 20 |
+| Scrollable overflow using accelerated scrolling | 13 |
+| `will-change` hint (transform + opacity) | **4** |
+
+**Named cause:** the dominant `Layerize` driver is **infinite `opacity` pulse animations on hundreds
+of map markers** — `.nuclear-marker.active` (`animation: nuclear-pulse …infinite`, 226×),
+`.earthquake-marker` (`quake-pulse …infinite`, 66×), `.nuclear-marker.contested` (`nuclear-alert
+…infinite`). Each infinite opacity animation is a hard compositing trigger that holds a permanent
+per-marker layer; the 115 "overlaps composited content" layers are the cascade this forces on
+neighbouring markers. The `will-change` CSS-audit candidates (`.virtual-item`, `.panel-content`,
+`.widget-chat-footer`) contribute only **4** layers combined — negligible. This **refutes** the pre-
+measurement CSS-audit hypothesis (the #4630 U2 named-cause gate working as designed) and retargets the
+fix at the marker-animation layer explosion, which is a UX/design decision (shared root with #4545 —
+too many simultaneously-active markers). Lever options: time-box the pulse (animate only
+recently-changed markers, then settle → release the layer), cap the count of simultaneously-pulsing
+markers by severity/viewport, or gate pulsing by marker density.

--- a/scripts/measure-composited-layers.mjs
+++ b/scripts/measure-composited-layers.mjs
@@ -1,0 +1,248 @@
+#!/usr/bin/env node
+/**
+ * Composited-layer audit harness (#4630 / #4487) — the layer-tree companion to
+ * scripts/measure-desktop-mainthread.mjs (#4539).
+ *
+ * The desktop main-thread harness surfaced that Blink `Layerize` (compositor
+ * layerization) is ~27.6% / ~3s of desktop /dashboard's main thread — the single
+ * largest component of the #4539 "Other" bucket. `Layerize` cost scales with the
+ * NUMBER of composited layers and how often the layer tree is rebuilt, but the
+ * trace share is noisy under host contention and cannot name WHICH DOM nodes own
+ * the layers. This tool answers that: it enables the CDP `LayerTree` domain,
+ * loads a URL, and reports the composited-layer count, the top owning selectors,
+ * and the compositing reasons — the deterministic evidence (#4630 R1) that makes
+ * a demotion targeted and its effect legible (N fewer layers).
+ *
+ * Philosophy mirrors the desktop harness (KTD1/#4486): trust the layer COUNT
+ * (deterministic) as the leading indicator; the `Layerize` trace share is the
+ * goal metric, measured separately. The pure aggregation functions are exported
+ * and unit-tested with fixtures (deterministic, CI-safe); Playwright is imported
+ * lazily so importing this module for its helpers never launches a browser.
+ *
+ * Usage:
+ *   node scripts/measure-composited-layers.mjs [url] [--cpu 1] [--settle 15000] [--json]
+ *   (default url: https://www.worldmonitor.app/dashboard; run against a local
+ *    `vite preview` build for in-session before/after per #4630 KTD3)
+ */
+import { pathToFileURL } from 'node:url';
+
+const DESCRIBE_NODE_CAP = 400;
+
+export function parseArgs(argv) {
+  const args = { url: 'https://www.worldmonitor.app/dashboard', cpu: 1, settle: 15000, json: false };
+  const rest = argv.slice(2);
+  for (let i = 0; i < rest.length; i++) {
+    const a = rest[i];
+    if (a === '--cpu') {
+      const n = Number(rest[++i]);
+      if (!Number.isNaN(n)) args.cpu = n;
+    } else if (a === '--settle') {
+      const n = Number(rest[++i]);
+      if (!Number.isNaN(n)) args.settle = n;
+    } else if (a === '--json') {
+      args.json = true;
+    } else if (!a.startsWith('--')) {
+      args.url = a;
+    }
+  }
+  return args;
+}
+
+/**
+ * Pick the current layer tree from a sequence of `LayerTree.layerTreeDidChange`
+ * snapshots. The last event carrying a defined `layers` array is the live tree;
+ * events without a `layers` field are no-ops and ignored, so repeated changes do
+ * not double-count and only the final composited-layer set is measured.
+ */
+export function latestSnapshot(snapshots) {
+  let last = [];
+  for (const s of Array.isArray(snapshots) ? snapshots : []) {
+    if (Array.isArray(s?.layers)) last = s.layers;
+  }
+  return last;
+}
+
+/** Flat CDP attribute array [name,val,name,val,…] -> { id, className }. */
+export function parseAttributes(attrs) {
+  const out = {};
+  const list = Array.isArray(attrs) ? attrs : [];
+  for (let i = 0; i + 1 < list.length; i += 2) out[list[i]] = list[i + 1];
+  return { id: out.id || '', className: out.class || '' };
+}
+
+/**
+ * Compact CSS-ish selector for a layer's owning DOM node (from
+ * `DOM.describeNode`): `tag#id` when an id exists, else `tag.class1.class2`
+ * (first two classes), else the bare tag. Unknown nodes yield '(unknown)'.
+ */
+export function selectorForNode(node) {
+  if (!node || !node.nodeName) return '(unknown)';
+  const tag = String(node.nodeName).toLowerCase();
+  const { id, className } = parseAttributes(node.attributes);
+  if (id) return `${tag}#${id}`;
+  const cls = String(className).trim().split(/\s+/).filter(Boolean).slice(0, 2).join('.');
+  return cls ? `${tag}.${cls}` : tag;
+}
+
+/**
+ * Attribute each layer to a selector. A layer with a resolvable backend node
+ * gets its selector; one whose node failed to resolve is '(detached)'; one with
+ * no backend node at all is '(structural)' (compositor root/scroll layer). Every
+ * layer is kept — nothing is dropped — so the count stays honest.
+ */
+export function attributeLayers(layers, nodes) {
+  return (Array.isArray(layers) ? layers : []).map((l) => {
+    const hasNode = l?.backendNodeId != null;
+    const node = hasNode ? nodes?.[l.backendNodeId] : null;
+    const selector = node ? selectorForNode(node) : hasNode ? '(detached)' : '(structural)';
+    return { layerId: l?.layerId, selector, width: l?.width, height: l?.height, paintCount: l?.paintCount };
+  });
+}
+
+/** Group attributed layers by selector, descending by layer count. */
+export function groupBySelector(attributed) {
+  const counts = new Map();
+  for (const a of Array.isArray(attributed) ? attributed : []) {
+    counts.set(a.selector, (counts.get(a.selector) || 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([selector, count]) => ({ selector, count }))
+    .sort((a, b) => b.count - a.count || a.selector.localeCompare(b.selector));
+}
+
+/** Aggregate compositing reasons across all layers, descending by frequency. */
+export function summarizeReasons(reasons) {
+  const counts = new Map();
+  for (const list of Object.values(reasons || {})) {
+    for (const r of Array.isArray(list) ? list : []) counts.set(r, (counts.get(r) || 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([reason, count]) => ({ reason, count }))
+    .sort((a, b) => b.count - a.count || a.reason.localeCompare(b.reason));
+}
+
+/** Build the structured report (pure — exported for tests). */
+export function buildLayerReport(result) {
+  const layers = Array.isArray(result?.layers) ? result.layers : [];
+  if (result?.warning) {
+    return {
+      url: result?.url,
+      cpu: result?.cpu,
+      layerCount: 0,
+      contentLayerCount: 0,
+      owners: [],
+      reasons: [],
+      warning: result.warning,
+    };
+  }
+  const attributed = attributeLayers(layers, result?.nodes);
+  return {
+    url: result?.url,
+    cpu: result?.cpu,
+    layerCount: layers.length,
+    contentLayerCount: layers.filter((l) => l?.drawsContent).length,
+    owners: groupBySelector(attributed).slice(0, 25),
+    reasons: summarizeReasons(result?.reasons).slice(0, 20),
+  };
+}
+
+/** Live capture (best-effort). Loads the URL and snapshots the composited layer tree via CDP `LayerTree`. */
+async function measure(url, { cpu = 1, settle = 15000 } = {}) {
+  const { chromium } = await import('@playwright/test');
+  const browser = await chromium.launch();
+  try {
+    const context = await browser.newContext({
+      viewport: { width: 1350, height: 940 },
+      deviceScaleFactor: 1,
+      isMobile: false,
+    });
+    const page = await context.newPage();
+    const client = await context.newCDPSession(page);
+    if (cpu > 1) {
+      try {
+        await client.send('Emulation.setCPUThrottlingRate', { rate: cpu });
+      } catch {
+        /* CDP throttle unavailable — continue at host speed */
+      }
+    }
+    const snapshots = [];
+    client.on('LayerTree.layerTreeDidChange', (e) => snapshots.push(e));
+    try {
+      await client.send('DOM.enable');
+      await client.send('LayerTree.enable');
+    } catch (err) {
+      return { url, cpu, layers: [], nodes: {}, reasons: {}, warning: `CDP LayerTree unavailable: ${err?.message || err}` };
+    }
+    await page.goto(url, { waitUntil: 'load', timeout: 60000 });
+    await page.waitForTimeout(settle);
+
+    const layers = latestSnapshot(snapshots);
+    const nodes = {};
+    const reasons = {};
+    let described = 0;
+    for (const layer of layers) {
+      if (layer.backendNodeId != null && nodes[layer.backendNodeId] === undefined && described < DESCRIBE_NODE_CAP) {
+        described++;
+        try {
+          const { node } = await client.send('DOM.describeNode', { backendNodeId: layer.backendNodeId });
+          nodes[layer.backendNodeId] = { nodeName: node?.nodeName, attributes: node?.attributes || [] };
+        } catch {
+          nodes[layer.backendNodeId] = null;
+        }
+      }
+      try {
+        const r = await client.send('LayerTree.compositingReasons', { layerId: layer.layerId });
+        reasons[layer.layerId] = r?.compositingReasons?.length ? r.compositingReasons : r?.compositingReasonIds || [];
+      } catch {
+        reasons[layer.layerId] = [];
+      }
+    }
+    const slim = layers.map((l) => ({
+      layerId: l.layerId,
+      backendNodeId: l.backendNodeId,
+      width: l.width,
+      height: l.height,
+      paintCount: l.paintCount,
+      drawsContent: l.drawsContent,
+    }));
+    return { url, cpu, layers: slim, nodes, reasons };
+  } finally {
+    await browser.close();
+  }
+}
+
+function printHuman(report) {
+  console.log(`\nComposited-layer audit — ${report.url} (CPU ${report.cpu}x)\n`);
+  if (report.warning) {
+    console.log('Warning:');
+    console.log('  ' + report.warning + '\n');
+    return;
+  }
+  console.log(`Composited layers: ${report.layerCount}  (${report.contentLayerCount} draw content)\n`);
+  console.log('Top owners (layers per selector — over-promotion shows up here):');
+  for (const o of report.owners) {
+    console.log(`  ${String(o.count).padStart(4)}  ${o.selector}`);
+  }
+  console.log('\nCompositing reasons (frequency across layers):');
+  for (const r of report.reasons) {
+    console.log(`  ${String(r.count).padStart(4)}  ${r.reason}`);
+  }
+  console.log('\nNote: the layer COUNT is the deterministic signal (#4630 KTD4). Pair with the');
+  console.log('`Layerize` self-time share from measure-desktop-mainthread.mjs for the outcome.\n');
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  const result = await measure(args.url, { cpu: args.cpu, settle: args.settle });
+  const report = buildLayerReport(result);
+  if (args.json) console.log(JSON.stringify(report, null, 2));
+  else printHuman(report);
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/scripts/measure-composited-layers.mjs
+++ b/scripts/measure-composited-layers.mjs
@@ -27,6 +27,16 @@
 import { pathToFileURL } from 'node:url';
 
 const DESCRIBE_NODE_CAP = 400;
+const DESCRIBE_NODE_CAP_SKIPPED_SELECTOR = '(describe-cap-skipped)';
+const CAP_SKIPPED_NODE = Object.freeze({ skippedByDescribeNodeCap: true });
+
+function parsePositiveNumberFlag(name, raw) {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(`${name} must be a finite positive number`);
+  }
+  return n;
+}
 
 export function parseArgs(argv) {
   const args = { url: 'https://www.worldmonitor.app/dashboard', cpu: 1, settle: 15000, json: false };
@@ -34,11 +44,9 @@ export function parseArgs(argv) {
   for (let i = 0; i < rest.length; i++) {
     const a = rest[i];
     if (a === '--cpu') {
-      const n = Number(rest[++i]);
-      if (!Number.isNaN(n)) args.cpu = n;
+      args.cpu = parsePositiveNumberFlag('--cpu', rest[++i]);
     } else if (a === '--settle') {
-      const n = Number(rest[++i]);
-      if (!Number.isNaN(n)) args.settle = n;
+      args.settle = parsePositiveNumberFlag('--settle', rest[++i]);
     } else if (a === '--json') {
       args.json = true;
     } else if (!a.startsWith('--')) {
@@ -87,6 +95,7 @@ export function selectorForNode(node) {
 /**
  * Attribute each layer to a selector. A layer with a resolvable backend node
  * gets its selector; one whose node failed to resolve is '(detached)'; one with
+ * a node skipped by the describe cap is '(describe-cap-skipped)'; one with
  * no backend node at all is '(structural)' (compositor root/scroll layer). Every
  * layer is kept — nothing is dropped — so the count stays honest.
  */
@@ -94,7 +103,13 @@ export function attributeLayers(layers, nodes) {
   return (Array.isArray(layers) ? layers : []).map((l) => {
     const hasNode = l?.backendNodeId != null;
     const node = hasNode ? nodes?.[l.backendNodeId] : null;
-    const selector = node ? selectorForNode(node) : hasNode ? '(detached)' : '(structural)';
+    const selector = !hasNode
+      ? '(structural)'
+      : node?.skippedByDescribeNodeCap
+        ? DESCRIBE_NODE_CAP_SKIPPED_SELECTOR
+        : node
+          ? selectorForNode(node)
+          : '(detached)';
     return { layerId: l?.layerId, selector, width: l?.width, height: l?.height, paintCount: l?.paintCount };
   });
 }
@@ -136,6 +151,7 @@ export function buildLayerReport(result) {
     };
   }
   const attributed = attributeLayers(layers, result?.nodes);
+  const describeNodeSkippedCount = attributed.filter((a) => a.selector === DESCRIBE_NODE_CAP_SKIPPED_SELECTOR).length;
   return {
     url: result?.url,
     cpu: result?.cpu,
@@ -143,6 +159,13 @@ export function buildLayerReport(result) {
     contentLayerCount: layers.filter((l) => l?.drawsContent).length,
     owners: groupBySelector(attributed).slice(0, 25),
     reasons: summarizeReasons(result?.reasons).slice(0, 20),
+    ...(describeNodeSkippedCount > 0
+      ? {
+          describeNodeCap: DESCRIBE_NODE_CAP,
+          describeNodeSkippedCount,
+          warning: `DOM.describeNode cap reached; ${describeNodeSkippedCount} layers are bucketed as ${DESCRIBE_NODE_CAP_SKIPPED_SELECTOR}`,
+        }
+      : {}),
   };
 }
 
@@ -181,13 +204,17 @@ async function measure(url, { cpu = 1, settle = 15000 } = {}) {
     const reasons = {};
     let described = 0;
     for (const layer of layers) {
-      if (layer.backendNodeId != null && nodes[layer.backendNodeId] === undefined && described < DESCRIBE_NODE_CAP) {
-        described++;
-        try {
-          const { node } = await client.send('DOM.describeNode', { backendNodeId: layer.backendNodeId });
-          nodes[layer.backendNodeId] = { nodeName: node?.nodeName, attributes: node?.attributes || [] };
-        } catch {
-          nodes[layer.backendNodeId] = null;
+      if (layer.backendNodeId != null && nodes[layer.backendNodeId] === undefined) {
+        if (described < DESCRIBE_NODE_CAP) {
+          described++;
+          try {
+            const { node } = await client.send('DOM.describeNode', { backendNodeId: layer.backendNodeId });
+            nodes[layer.backendNodeId] = { nodeName: node?.nodeName, attributes: node?.attributes || [] };
+          } catch {
+            nodes[layer.backendNodeId] = null;
+          }
+        } else {
+          nodes[layer.backendNodeId] = CAP_SKIPPED_NODE;
         }
       }
       try {
@@ -213,12 +240,13 @@ async function measure(url, { cpu = 1, settle = 15000 } = {}) {
 
 function printHuman(report) {
   console.log(`\nComposited-layer audit — ${report.url} (CPU ${report.cpu}x)\n`);
-  if (report.warning) {
+  if (report.warning && report.layerCount === 0) {
     console.log('Warning:');
     console.log('  ' + report.warning + '\n');
     return;
   }
   console.log(`Composited layers: ${report.layerCount}  (${report.contentLayerCount} draw content)\n`);
+  if (report.warning) console.log(`Warning: ${report.warning}\n`);
   console.log('Top owners (layers per selector — over-promotion shows up here):');
   for (const o of report.owners) {
     console.log(`  ${String(o.count).padStart(4)}  ${o.selector}`);

--- a/tests/measure-composited-layers.test.mts
+++ b/tests/measure-composited-layers.test.mts
@@ -1,0 +1,143 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  parseArgs,
+  latestSnapshot,
+  parseAttributes,
+  selectorForNode,
+  attributeLayers,
+  groupBySelector,
+  summarizeReasons,
+  buildLayerReport,
+} from '../scripts/measure-composited-layers.mjs';
+
+// Deterministic fixtures (CI-safe, no browser). A `result` mirrors what measure()
+// returns: composited `layers` (some tied to DOM nodes via backendNodeId), the
+// resolved `nodes` map (CDP DOM.describeNode shape: nodeName + flat attribute
+// array), and per-layer compositing `reasons`.
+function fixtureResult() {
+  return {
+    url: 'http://x/dashboard',
+    cpu: 1,
+    layers: [
+      // three .virtual-item rows — the over-promotion signal (#4630)
+      { layerId: '1', backendNodeId: 10, width: 200, height: 40, paintCount: 1, drawsContent: true },
+      { layerId: '2', backendNodeId: 11, width: 200, height: 40, paintCount: 1, drawsContent: true },
+      { layerId: '3', backendNodeId: 12, width: 200, height: 40, paintCount: 1, drawsContent: true },
+      // the unavoidable map canvas
+      { layerId: '4', backendNodeId: 20, width: 1350, height: 700, paintCount: 3, drawsContent: true },
+      // a structural compositor layer (no owning node)
+      { layerId: '5', width: 1350, height: 940, paintCount: 0, drawsContent: false },
+      // a layer whose node failed to resolve (detached between snapshot and describe)
+      { layerId: '6', backendNodeId: 99, width: 10, height: 10, paintCount: 1, drawsContent: true },
+    ],
+    nodes: {
+      10: { nodeName: 'DIV', attributes: ['class', 'virtual-item'] },
+      11: { nodeName: 'DIV', attributes: ['class', 'virtual-item'] },
+      12: { nodeName: 'DIV', attributes: ['class', 'virtual-item'] },
+      20: { nodeName: 'CANVAS', attributes: ['class', 'maplibregl-canvas', 'id', 'map'] },
+      99: null,
+    },
+    reasons: {
+      '1': ['willChangeTransform'],
+      '2': ['willChangeTransform'],
+      '3': ['willChangeTransform'],
+      '4': ['canvas'],
+      '5': ['root'],
+      '6': ['willChangeTransform'],
+    },
+  };
+}
+
+test('parseArgs reads url + flags with sane defaults', () => {
+  assert.deepEqual(parseArgs(['node', 's.mjs']).url, 'https://www.worldmonitor.app/dashboard');
+  const a = parseArgs(['node', 's.mjs', 'http://127.0.0.1:4173/dashboard', '--cpu', '4', '--json']);
+  assert.equal(a.url, 'http://127.0.0.1:4173/dashboard');
+  assert.equal(a.cpu, 4);
+  assert.equal(a.json, true);
+});
+
+test('parseAttributes turns the flat CDP attribute array into {id, className}', () => {
+  assert.deepEqual(parseAttributes(['class', 'virtual-item', 'id', 'foo']), { id: 'foo', className: 'virtual-item' });
+  assert.deepEqual(parseAttributes([]), { id: '', className: '' });
+  assert.deepEqual(parseAttributes(undefined), { id: '', className: '' });
+});
+
+test('selectorForNode prefers id, else first two classes, else tag; unknown is safe', () => {
+  assert.equal(selectorForNode({ nodeName: 'DIV', attributes: ['id', 'panelsGrid'] }), 'div#panelsGrid');
+  assert.equal(selectorForNode({ nodeName: 'DIV', attributes: ['class', 'a b c'] }), 'div.a.b');
+  assert.equal(selectorForNode({ nodeName: 'SPAN', attributes: [] }), 'span');
+  assert.equal(selectorForNode(null), '(unknown)');
+});
+
+test('happy path: buildLayerReport counts layers and ranks owners by layer count (#4630 R1)', () => {
+  const report = buildLayerReport(fixtureResult());
+  assert.equal(report.layerCount, 6);
+  assert.equal(report.contentLayerCount, 5); // the structural layer draws no content
+  // .virtual-item is the top owner (3 layers) — the over-promotion signal
+  assert.deepEqual(report.owners[0], { selector: 'div.virtual-item', count: 3 });
+  // every layer is attributed to some bucket; nothing dropped
+  const totalAttributed = report.owners.reduce((s, o) => s + o.count, 0);
+  assert.equal(totalAttributed, 6);
+  // compositing reasons aggregate across layers, willChangeTransform dominant
+  assert.deepEqual(report.reasons[0], { reason: 'willChangeTransform', count: 4 });
+});
+
+test('groupBySelector attributes structural + detached layers to their own buckets, never dropping', () => {
+  const attributed = attributeLayers(fixtureResult().layers, fixtureResult().nodes);
+  const owners = groupBySelector(attributed);
+  const byName = Object.fromEntries(owners.map((o) => [o.selector, o.count]));
+  assert.equal(byName['div.virtual-item'], 3);
+  assert.equal(byName['canvas#map'], 1); // id wins over class
+  assert.equal(byName['(structural)'], 1); // no backendNodeId
+  assert.equal(byName['(detached)'], 1); // backendNodeId present but node null
+});
+
+test('edge: only the two unavoidable map canvases → count 2, no excess owner', () => {
+  const result = {
+    url: 'http://x/dashboard',
+    cpu: 1,
+    layers: [
+      { layerId: '1', backendNodeId: 20, width: 1350, height: 700, paintCount: 3, drawsContent: true },
+      { layerId: '2', backendNodeId: 21, width: 1350, height: 700, paintCount: 3, drawsContent: true },
+    ],
+    nodes: {
+      20: { nodeName: 'CANVAS', attributes: ['class', 'maplibregl-canvas'] },
+      21: { nodeName: 'CANVAS', attributes: ['class', 'deckgl-canvas'] },
+    },
+    reasons: { '1': ['canvas'], '2': ['canvas'] },
+  };
+  const report = buildLayerReport(result);
+  assert.equal(report.layerCount, 2);
+  assert.ok(report.owners.every((o) => o.count === 1)); // no single selector over-promotes
+});
+
+test('edge: repeated layerTreeDidChange events → only the latest snapshot is counted', () => {
+  const snapshots = [
+    { layers: [{ layerId: '1' }, { layerId: '2' }] },
+    {}, // a no-op change event (no layers field) — ignored
+    { layers: [{ layerId: '1' }, { layerId: '2' }, { layerId: '3' }] },
+  ];
+  assert.equal(latestSnapshot(snapshots).length, 3);
+  assert.equal(latestSnapshot([]).length, 0);
+  assert.equal(latestSnapshot(undefined).length, 0);
+});
+
+test('error: LayerTree unavailable → warning report, count 0, non-fatal', () => {
+  const report = buildLayerReport({ url: 'http://x/dashboard', cpu: 1, warning: 'CDP LayerTree unavailable: boom' });
+  assert.equal(report.layerCount, 0);
+  assert.equal(report.contentLayerCount, 0);
+  assert.deepEqual(report.owners, []);
+  assert.deepEqual(report.reasons, []);
+  assert.match(report.warning, /LayerTree unavailable/);
+});
+
+test('--json report round-trips through JSON.parse(JSON.stringify(report))', () => {
+  const report = buildLayerReport(fixtureResult());
+  assert.doesNotThrow(() => JSON.parse(JSON.stringify(report)));
+});
+
+test('summarizeReasons is empty-safe', () => {
+  assert.deepEqual(summarizeReasons({}), []);
+  assert.deepEqual(summarizeReasons(undefined), []);
+});

--- a/tests/measure-composited-layers.test.mts
+++ b/tests/measure-composited-layers.test.mts
@@ -57,6 +57,15 @@ test('parseArgs reads url + flags with sane defaults', () => {
   assert.equal(a.json, true);
 });
 
+test('parseArgs rejects non-positive, non-finite, and missing numeric flags', () => {
+  for (const value of ['0', '-1', 'Infinity']) {
+    assert.throws(() => parseArgs(['node', 's.mjs', '--cpu', value]), /--cpu must be a finite positive number/);
+    assert.throws(() => parseArgs(['node', 's.mjs', '--settle', value]), /--settle must be a finite positive number/);
+  }
+  assert.throws(() => parseArgs(['node', 's.mjs', '--cpu']), /--cpu must be a finite positive number/);
+  assert.throws(() => parseArgs(['node', 's.mjs', '--settle']), /--settle must be a finite positive number/);
+});
+
 test('parseAttributes turns the flat CDP attribute array into {id, className}', () => {
   assert.deepEqual(parseAttributes(['class', 'virtual-item', 'id', 'foo']), { id: 'foo', className: 'virtual-item' });
   assert.deepEqual(parseAttributes([]), { id: '', className: '' });
@@ -91,6 +100,32 @@ test('groupBySelector attributes structural + detached layers to their own bucke
   assert.equal(byName['canvas#map'], 1); // id wins over class
   assert.equal(byName['(structural)'], 1); // no backendNodeId
   assert.equal(byName['(detached)'], 1); // backendNodeId present but node null
+});
+
+test('cap-skipped nodes are reported separately from detached nodes', () => {
+  const result = {
+    url: 'http://x/dashboard',
+    cpu: 1,
+    layers: [
+      { layerId: '1', backendNodeId: 10, width: 20, height: 20, paintCount: 1, drawsContent: true },
+      { layerId: '2', backendNodeId: 99, width: 20, height: 20, paintCount: 1, drawsContent: true },
+      { layerId: '3', backendNodeId: 100, width: 20, height: 20, paintCount: 1, drawsContent: true },
+    ],
+    nodes: {
+      10: { nodeName: 'DIV', attributes: ['class', 'known-owner'] },
+      99: null,
+      100: { skippedByDescribeNodeCap: true },
+    },
+    reasons: {},
+  };
+  const report = buildLayerReport(result);
+  const byName = Object.fromEntries(report.owners.map((o) => [o.selector, o.count]));
+  assert.equal(byName['div.known-owner'], 1);
+  assert.equal(byName['(detached)'], 1);
+  assert.equal(byName['(describe-cap-skipped)'], 1);
+  assert.equal(report.describeNodeCap, 400);
+  assert.equal(report.describeNodeSkippedCount, 1);
+  assert.match(report.warning, /DOM\.describeNode cap reached/);
 });
 
 test('edge: only the two unavoidable map canvases → count 2, no excess owner', () => {


### PR DESCRIPTION
## Summary

Investigation half of #4630 (desktop `Layerize` = 27.6% / ~3s of the #4539 "Other" bucket). Builds the missing composited-layer measurement tool and uses it to name the real cause — which **corrected the pre-measurement CSS hypothesis**.

**U1 — `scripts/measure-composited-layers.mjs`** (+ 10 browser-free unit tests): a CDP `LayerTree` audit harness, sibling to `measure-desktop-mainthread.mjs`. Enables the `LayerTree` domain, counts composited layers, and attributes them to owning selectors + compositing reasons. Exported pure aggregation functions; Playwright imported lazily.

**U2 — named cause** (`docs/perf/desktop-mainthread-baseline-2026-07-02.md`): prod `/dashboard` has **517 composited layers**, and **385 come from "active accelerated opacity animation"** — infinite marker opacity pulses (`nuclear-pulse` 226×, `quake-pulse` 66×, `nuclear-alert`). The `will-change` CSS-audit candidates (`.virtual-item`, `.panel-content`, `.widget-chat-footer`) contribute only **4** layers combined — negligible. Each infinite marker pulse is a hard compositing trigger holding a permanent per-marker layer.

This satisfies the issue's R1 ("a named cause backed by a composited-layer count") and de-risks the fix by pointing it at the right target.

## The fix is deferred (follow-up)

The measurement revealed the fix is **systemic** — ~30 map-marker types share the infinite-opacity-pulse design language, so the `Layerize` reduction is a map-wide "time-box the pulse" change (animate briefly on appearance, settle to static → release the layer) that needs its own local before/after measurement loop and a visual pass. Tracked as a follow-up; not rushed into this PR.

## Test plan
- `npx tsx --test tests/measure-composited-layers.test.mts` — 10/10 pass (happy path, multi-owner ranking, structural/detached buckets, latest-snapshot dedup, LayerTree-unavailable warning, JSON round-trip).
- Tool smoke-tested against prod `/dashboard` (517 layers, ranked owners + reasons).
- Biome lint clean.

Closes #4630 partially (investigation / R1); fix tracked as follow-up.

https://claude.ai/code/session_011htsYLErqJb922Qm9QLraN