### PR TITLE
fix(notifications): make Country-scope chips show selected state + removal (#3632 regression)

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -25608,6 +25608,58 @@ body.map-width-resizing {
   background: rgba(255, 255, 255, 0.11);
 }
 
+/* Country-scope chip picker (alertRules.countries). Toggle-cloud: every chip
+   is a button; the selected (-on) state must be visually distinct or removal
+   looks like a no-op. */
+.us-notif-country-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.us-notif-country-chip {
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  cursor: pointer;
+  border: 1px solid var(--settings-border-strong);
+  background: transparent;
+  color: var(--settings-text-secondary);
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.us-notif-country-chip:hover {
+  background: var(--overlay-subtle);
+  color: var(--settings-text);
+  border-color: var(--settings-text-secondary);
+}
+
+.us-notif-country-chip-on {
+  background: rgba(52, 211, 153, 0.12);
+  border-color: rgba(52, 211, 153, 0.4);
+  color: var(--settings-green);
+}
+
+.us-notif-country-chip-on:hover {
+  background: rgba(52, 211, 153, 0.2);
+  color: var(--settings-green);
+}
+
+.us-notif-country-chip-x {
+  font-size: 13px;
+  line-height: 1;
+  opacity: 0.65;
+}
+
+.us-notif-country-chip-on:hover .us-notif-country-chip-x {
+  opacity: 1;
+}
+
 .us-notif-slack-wrap {
   width: 100%;
   display: flex;

--- a/src/utils/country-chip-picker.ts
+++ b/src/utils/country-chip-picker.ts
@@ -99,14 +99,17 @@ export function mountCountryChipPicker(
 
     const chipRow = COMMON_COUNTRIES.map(({ code, name }) => {
       const on = selectedSet.has(code);
-      return `<button type="button" class="us-notif-country-chip${on ? ' us-notif-country-chip-on' : ''}" data-code="${code}" aria-pressed="${on ? 'true' : 'false'}" title="${name}">${toFlagEmoji(code)} ${code}</button>`;
+      // Selected chips carry a ✕ so removal is discoverable (clicking anywhere
+      // on the chip toggles it off via the delegated handler). Decorative
+      // (aria-hidden) — screen readers get the toggle state from aria-pressed.
+      return `<button type="button" class="us-notif-country-chip${on ? ' us-notif-country-chip-on' : ''}" data-code="${code}" aria-pressed="${on ? 'true' : 'false'}" title="${on ? `Remove ${name}` : `Add ${name}`}">${toFlagEmoji(code)} ${code}${on ? ' <span class="us-notif-country-chip-x" aria-hidden="true">×</span>' : ''}</button>`;
     }).join('');
 
     // Custom-added codes that aren't in COMMON_COUNTRIES — render them so the
-    // user can deselect.
+    // user can deselect. Always selected, so always show the ✕ remove glyph.
     const extras = value.filter(code => !COMMON_COUNTRIES.some(c => c.code === code));
     const extraChips = extras.map(code =>
-      `<button type="button" class="us-notif-country-chip us-notif-country-chip-on" data-code="${code}" aria-pressed="true" title="${code}">${toFlagEmoji(code)} ${code}</button>`,
+      `<button type="button" class="us-notif-country-chip us-notif-country-chip-on" data-code="${code}" aria-pressed="true" title="Remove ${code}">${toFlagEmoji(code)} ${code} <span class="us-notif-country-chip-x" aria-hidden="true">×</span></button>`,
     ).join('');
 
     setTrustedHtml(root, trustedHtml(`

--- a/tests/notifications-settings-country-picker.test.mts
+++ b/tests/notifications-settings-country-picker.test.mts
@@ -596,3 +596,67 @@ describe('mountCountryChipPicker', () => {
     assert.equal(emitted, false);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Regression — selected-chip removal affordance (visible ✕ + selected-state CSS)
+//
+// Field report: a Pro user could not remove default country chips — "chips do
+// not show an X and clicking them does not remove them." Root cause was purely
+// presentational: the toggle worked (see tests above), but the `-on` state had
+// NO CSS (a selected chip looked identical to an unselected one, so toggling
+// off appeared to do nothing) and there was no ✕ affordance. Guard both so the
+// widget can never regress back to an invisible selected state.
+// ---------------------------------------------------------------------------
+
+describe('country picker — removal affordance (regression)', () => {
+  it('selected chips render a ✕ remove glyph; unselected chips do not', () => {
+    const selected = makeFakeElement() as unknown as HTMLElement;
+    mountCountryChipPicker(selected, { initial: ['US'] });
+    assert.match(
+      selected.innerHTML,
+      /data-code="US"[\s\S]*?us-notif-country-chip-x/,
+      'a selected chip must render the ✕ remove affordance',
+    );
+
+    const empty = makeFakeElement() as unknown as HTMLElement;
+    mountCountryChipPicker(empty, { initial: [] });
+    assert.doesNotMatch(
+      empty.innerHTML,
+      /us-notif-country-chip-x/,
+      'no ✕ affordance should render when nothing is selected',
+    );
+  });
+
+  it('custom (non-common) selected codes also render the ✕ remove glyph', () => {
+    // RO is not in COMMON_COUNTRIES — it renders as an "extra" chip.
+    const root = makeFakeElement() as unknown as HTMLElement;
+    mountCountryChipPicker(root, { initial: ['RO'] });
+    assert.match(
+      root.innerHTML,
+      /data-code="RO"[\s\S]*?us-notif-country-chip-x/,
+      'a custom selected chip must render the ✕ remove affordance',
+    );
+  });
+
+  it('main.css defines a visible selected (-on) state — the missing rule that caused the bug', () => {
+    const css = readFileSync(
+      resolve(__dirname, '..', 'src', 'styles', 'main.css'),
+      'utf-8',
+    );
+    assert.match(
+      css,
+      /\.us-notif-country-chip\s*\{/,
+      'main.css must define a base .us-notif-country-chip rule',
+    );
+    assert.match(
+      css,
+      /\.us-notif-country-chip-on\s*\{/,
+      'main.css must define a distinct .us-notif-country-chip-on selected state',
+    );
+    assert.match(
+      css,
+      /\.us-notif-country-chip-x\s*\{/,
+      'main.css must style the ✕ remove glyph',
+    );
+  });
+});

--- a/tests/notifications-settings-country-picker.test.mts
+++ b/tests/notifications-settings-country-picker.test.mts
@@ -457,6 +457,19 @@ function makeFakeElement(): FakeElement {
   return el;
 }
 
+function chipMarkup(html: string, code: string): string {
+  const match = html.match(new RegExp('<button[^>]*data-code="' + code + '"[^>]*>[\\s\\S]*?<\\/button>'));
+  assert.ok(match, `expected ${code} chip markup`);
+  return match[0];
+}
+
+function cssRuleBody(css: string, selector: string): string {
+  const selectorPattern = selector.replace(/\./g, '\\.');
+  const match = css.match(new RegExp(selectorPattern + '\\s*\\{([\\s\\S]*?)\\}'));
+  assert.ok(match, `expected ${selector} CSS rule`);
+  return match[1];
+}
+
 describe('mountCountryChipPicker', () => {
   it('renders chips for the initial selection', () => {
     const root = makeFakeElement() as unknown as HTMLElement;
@@ -612,19 +625,79 @@ describe('country picker — removal affordance (regression)', () => {
   it('selected chips render a ✕ remove glyph; unselected chips do not', () => {
     const selected = makeFakeElement() as unknown as HTMLElement;
     mountCountryChipPicker(selected, { initial: ['US'] });
+    const selectedUs = chipMarkup(selected.innerHTML, 'US');
     assert.match(
-      selected.innerHTML,
-      /data-code="US"[\s\S]*?us-notif-country-chip-x/,
+      selectedUs,
+      /us-notif-country-chip-on/,
+      'a selected chip must render the selected-state class',
+    );
+    assert.match(
+      selectedUs,
+      /us-notif-country-chip-x/,
       'a selected chip must render the ✕ remove affordance',
+    );
+    assert.match(
+      selectedUs,
+      /title="Remove United States"/,
+      'a selected common chip must expose remove tooltip copy',
     );
 
     const empty = makeFakeElement() as unknown as HTMLElement;
     mountCountryChipPicker(empty, { initial: [] });
+    const unselectedUs = chipMarkup(empty.innerHTML, 'US');
     assert.doesNotMatch(
-      empty.innerHTML,
+      unselectedUs,
+      /us-notif-country-chip-on/,
+      'an unselected chip must not render the selected-state class',
+    );
+    assert.doesNotMatch(
+      unselectedUs,
       /us-notif-country-chip-x/,
       'no ✕ affordance should render when nothing is selected',
     );
+    assert.match(
+      unselectedUs,
+      /title="Add United States"/,
+      'an unselected common chip must expose add tooltip copy',
+    );
+  });
+
+  it('clicking a selected chip visibly returns it to the unselected state', () => {
+    const root = makeFakeElement() as unknown as HTMLElement;
+    const picker = mountCountryChipPicker(root, { initial: ['US'] });
+    const fakeChip = {
+      dataset: { code: 'US' },
+      closest(sel: string) {
+        return sel === '.us-notif-country-chip' ? this : null;
+      },
+      matches(_sel: string) { return false; },
+    };
+
+    root.dispatchEvent({ type: 'click', target: fakeChip });
+
+    const usChip = chipMarkup(root.innerHTML, 'US');
+    assert.deepEqual(picker.getValue(), []);
+    assert.match(
+      usChip,
+      /aria-pressed="false"/,
+      'removing a selected chip must update its pressed state',
+    );
+    assert.doesNotMatch(
+      usChip,
+      /us-notif-country-chip-on/,
+      'removing a selected chip must clear the selected-state class',
+    );
+    assert.doesNotMatch(
+      usChip,
+      /us-notif-country-chip-x/,
+      'removing a selected chip must clear the ✕ affordance',
+    );
+    assert.match(
+      usChip,
+      /title="Add United States"/,
+      'removing a selected chip must restore add tooltip copy',
+    );
+    picker.destroy();
   });
 
   it('custom (non-common) selected codes also render the ✕ remove glyph', () => {
@@ -643,15 +716,23 @@ describe('country picker — removal affordance (regression)', () => {
       resolve(__dirname, '..', 'src', 'styles', 'main.css'),
       'utf-8',
     );
+    const baseRule = cssRuleBody(css, '.us-notif-country-chip');
+    const selectedRule = cssRuleBody(css, '.us-notif-country-chip-on');
+    assert.match(baseRule, /background:\s*transparent;/, 'base chip must render as unselected');
     assert.match(
-      css,
-      /\.us-notif-country-chip\s*\{/,
-      'main.css must define a base .us-notif-country-chip rule',
+      selectedRule,
+      /background:\s*rgba\(52,\s*211,\s*153,\s*0\.12\);/,
+      'selected chip must have a visible selected background',
     );
     assert.match(
-      css,
-      /\.us-notif-country-chip-on\s*\{/,
-      'main.css must define a distinct .us-notif-country-chip-on selected state',
+      selectedRule,
+      /border-color:\s*rgba\(52,\s*211,\s*153,\s*0\.4\);/,
+      'selected chip must have a visible selected border',
+    );
+    assert.match(
+      selectedRule,
+      /color:\s*var\(--settings-green\);/,
+      'selected chip must have a visible selected text color',
     );
     assert.match(
       css,


### PR DESCRIPTION
## Summary

Fixes a user-reported bug in **Notification Settings → Country scope**: *"I cannot remove the default country codes… the chips do not show an X and clicking them does not remove them."*

**Root cause — missing CSS, not a logic bug.** The country-scope chip picker (`src/utils/country-chip-picker.ts`, mounted in `notifications-settings.ts`) shipped in #3632 with class names `us-notif-country-chip` / `us-notif-country-chip-on` that were **never given any CSS** (`git log -S` in `src/styles` confirms the rule was never written; only the unrelated `us-notif-ch-btn` is styled). As a result:

- Selected chips looked **identical** to unselected ones (the `-on` state had no highlight).
- Toggling a chip **off produced no visible change** — it stays in the fixed 20-country cloud → "clicking does nothing."
- There was **no ✕** affordance.

The underlying toggle logic worked and persisted to Convex the whole time (see existing unit tests) — the widget was simply invisible to interaction.

The pre-selected "default" countries are the user's **followed/watchlist** countries, auto-seeded on a brand-new alert rule.

## Changes

- **`src/styles/main.css`** — add the missing chip CSS: pill base, hover, and a distinct green selected (`-on`) state reusing the established `us-notif-ch-on` convention (`--settings-green`), plus the ✕ glyph style.
- **`src/utils/country-chip-picker.ts`** — render a decorative `✕` + a "Remove …" tooltip on selected chips. No handler change (the whole chip stays the toggle target via `closest('.us-notif-country-chip')`).
- **`tests/notifications-settings-country-picker.test.mts`** — 3 regression guards, including one asserting `main.css` defines the `-on` selected-state rule (the rule whose absence caused this).

Verified visually against the real chip markup + resolved settings theme vars: before = indistinguishable grey buttons with no ✕; after = selected countries are green pills with a ✕, and click-to-remove clears the highlight immediately.

> Note (not in scope): `RO` is not in the 20-country seed cloud (`UA` is). It's still addable via the "Add code" input, where it renders as a removable chip. Happy to add `RO`/expand the seed list as a follow-up if desired.

## Test plan

- [x] `npm run typecheck` / `typecheck:api` — pass
- [x] `npm run lint` (biome + safe-html guard) — pass
- [x] `VITE_VARIANT=full vite build` — pass
- [x] `npm run test:data` — **12678 tests, 0 fail** (incl. 3 new regression tests)
- [x] edge-fn esbuild bundle check + `tests/edge-functions.test.mjs` — pass
- [x] `npm run lint:md` / `version:check` — pass

https://claude.ai/code/session_019zAm1xKtQPkCVUsST8xf2R