### PR TITLE
feat(billing): self-serve Starter→Business API upgrade (#4634)

### DIFF
--- a/convex/__tests__/apiPlanLimitUsage.test.ts
+++ b/convex/__tests__/apiPlanLimitUsage.test.ts
@@ -173,6 +173,36 @@ describe("api plan-limit usage scanner", () => {
     expect(notices[0].blockedReason).toBeUndefined();
   });
 
+  test("an over-limit annual API Starter notice routes to contact_support, not a portal dead-end", async () => {
+    const t = convexTest(schema, modules);
+    await seedEntitlement(t, "user-annual", "api_starter_annual");
+
+    // api_starter_annual carries API_STARTER_FEATURES (planLimits: 1000/day), so it
+    // IS scanner-reachable. Its self-serve portal upgrade path to Business is
+    // unverified, so the CTA must be contact_support (never a billing_portal
+    // dead-end), matching the Settings button that renders only for 'api_starter'.
+    const summary = await t.action(usageFns.scanApiPlanLimitUsageInternal, {
+      now: NOW,
+      rows: [{
+        userId: "user-annual",
+        dimension: "api_daily_requests",
+        usage: 1_200,
+        source: "test",
+      }],
+    });
+
+    expect(summary.notified).toBe(1);
+    const notices = await t.run((ctx) => ctx.db.query("apiPlanLimitNotices").collect());
+    expect(notices).toHaveLength(1);
+    expect(notices[0]).toMatchObject({
+      planKey: "api_starter_annual",
+      state: "over_limit",
+      ctaKind: "contact_support",
+      blockedReason: "api_business_not_self_serve",
+      upgradeTargetPlanKey: "api_business",
+    });
+  });
+
   test("does not emit MCP minute notices without durable limiter-hit buckets", async () => {
     const t = convexTest(schema, modules);
     await seedEntitlement(t, "user-pro", "pro_monthly");

--- a/convex/__tests__/apiPlanLimitUsage.test.ts
+++ b/convex/__tests__/apiPlanLimitUsage.test.ts
@@ -139,7 +139,7 @@ describe("api plan-limit usage scanner", () => {
     expect(notices).toHaveLength(0);
   });
 
-  test("records over-limit API Starter notice and blocks readiness when Business is not self-serve", async () => {
+  test("records over-limit API Starter notice with a self-serve billing_portal CTA", async () => {
     const t = convexTest(schema, modules);
     await seedEntitlement(t, "user-api", "api_starter");
 
@@ -154,7 +154,10 @@ describe("api plan-limit usage scanner", () => {
     });
 
     expect(summary.notified).toBe(1);
-    expect(summary.blocked).toContainEqual({
+    // Self-serve upgrade is live (#4634): an over-cap Starter customer now gets a
+    // billing_portal CTA (→ the Dodo collection upgrade), so the notice is NOT
+    // recorded as blocked-for-no-self-serve-path.
+    expect(summary.blocked).not.toContainEqual({
       userId: "user-api",
       dimension: "api_daily_requests",
       reason: "api_business_not_self_serve",
@@ -164,10 +167,10 @@ describe("api plan-limit usage scanner", () => {
     expect(notices).toHaveLength(1);
     expect(notices[0]).toMatchObject({
       state: "over_limit",
-      ctaKind: "contact_support",
-      blockedReason: "api_business_not_self_serve",
+      ctaKind: "billing_portal",
       upgradeTargetPlanKey: "api_business",
     });
+    expect(notices[0].blockedReason).toBeUndefined();
   });
 
   test("does not emit MCP minute notices without durable limiter-hit buckets", async () => {

--- a/convex/__tests__/webhook.test.ts
+++ b/convex/__tests__/webhook.test.ts
@@ -344,6 +344,38 @@ describe("webhook processWebhookEvent", () => {
     );
   });
 
+  test("subscription.plan_changed api_starter -> api_business resolves the Business entitlement (#4634)", async () => {
+    const t = convexTest(schema, modules);
+
+    await seedProductPlan(t, "pdt_test_api_starter", "api_starter", "API Starter");
+    await seedProductPlan(t, "pdt_test_api_business", "api_business", "API Business");
+
+    // Active on Starter, then the Dodo collection upgrade fires plan_changed.
+    await processEvent(
+      t,
+      "wh_up_01",
+      "subscription.active",
+      makeSubscriptionPayload({ product_id: "pdt_test_api_starter" }),
+      BASE_TIMESTAMP,
+    );
+    await processEvent(
+      t,
+      "wh_up_02",
+      "subscription.plan_changed",
+      makeSubscriptionPayload({ product_id: "pdt_test_api_business" }),
+      BASE_TIMESTAMP + 1000,
+    );
+
+    const subs = await t.run((ctx) => ctx.db.query("subscriptions").collect());
+    expect(subs).toHaveLength(1);
+    expect(subs[0].planKey).toBe("api_business");
+
+    const entitlements = await t.run((ctx) => ctx.db.query("entitlements").collect());
+    expect(entitlements).toHaveLength(1);
+    expect(entitlements[0].planKey).toBe("api_business");
+    expect(entitlements[0].features).toMatchObject({ apiAccess: true, apiRateLimit: 300 });
+  });
+
   test("subscription.plan_changed updates product and entitlements", async () => {
     const t = convexTest(schema, modules);
 

--- a/convex/apiPlanLimitUsage.ts
+++ b/convex/apiPlanLimitUsage.ts
@@ -110,12 +110,16 @@ function dodoUpgradeNotice(planKey: string, dimension: PlanLimitDimension): Omit
   if (planKey === "api_starter" || planKey === "api_starter_annual") {
     const business = PRODUCT_CATALOG.api_business;
     // Gate billing_portal on a real self-serve plan-CHANGE surface, not on
-    // currentForCheckout ("purchasable at all"). The Dodo customer portal now
-    // surfaces the prorated Starter→Business change because both products share
-    // a collection with "Allow Subscription Updates" enabled (#4634); before that
-    // flag flipped, this fell through to contact_support. (annual is not scanner-
-    // reachable today — it has no planLimits — so only monthly Starter hits this.)
-    if (business?.canChangePlanSelfServe) {
+    // currentForCheckout ("purchasable at all"). The Dodo customer portal
+    // surfaces the prorated Starter→Business change only for MONTHLY api_starter:
+    // it shares a product collection with "Allow Subscription Updates" enabled
+    // (#4634). api_starter_annual DOES carry planLimits (API_STARTER_FEATURES),
+    // so it IS scanner-reachable — but its membership in that upgradeable
+    // collection is unverified, so routing it to the portal risks a dead-end
+    // (open portal, no upgrade path). Send annual to contact_support until that
+    // is confirmed. This also keeps parity with the Settings "Upgrade to
+    // Business" button, which renders only for exact 'api_starter'.
+    if (planKey === "api_starter" && business?.canChangePlanSelfServe) {
       return { upgradeTargetPlanKey: "api_business", ctaKind: "billing_portal" };
     }
     return {

--- a/convex/apiPlanLimitUsage.ts
+++ b/convex/apiPlanLimitUsage.ts
@@ -110,9 +110,11 @@ function dodoUpgradeNotice(planKey: string, dimension: PlanLimitDimension): Omit
   if (planKey === "api_starter" || planKey === "api_starter_annual") {
     const business = PRODUCT_CATALOG.api_business;
     // Gate billing_portal on a real self-serve plan-CHANGE surface, not on
-    // currentForCheckout ("purchasable at all"). The Dodo customer portal cannot
-    // change an existing customer's plan, so pointing "Upgrade to Business" there
-    // would dead-end; fall through to contact_support until that surface exists.
+    // currentForCheckout ("purchasable at all"). The Dodo customer portal now
+    // surfaces the prorated Starter→Business change because both products share
+    // a collection with "Allow Subscription Updates" enabled (#4634); before that
+    // flag flipped, this fell through to contact_support. (annual is not scanner-
+    // reachable today — it has no planLimits — so only monthly Starter hits this.)
     if (business?.canChangePlanSelfServe) {
       return { upgradeTargetPlanKey: "api_business", ctaKind: "billing_portal" };
     }

--- a/convex/config/productCatalog.ts
+++ b/convex/config/productCatalog.ts
@@ -322,9 +322,11 @@ export const PRODUCT_CATALOG: Record<string, CatalogEntry> = {
     selfServe: true,
     highlighted: false,
     currentForCheckout: true,
-    // No self-serve plan-CHANGE surface yet (change-plan is a distinct Dodo API,
-    // not the customer portal), so the upgrade CTA falls through to contact_support.
-    canChangePlanSelfServe: false,
+    // Self-serve plan change is live (#4634): api_starter + api_business share a
+    // Dodo product COLLECTION with "Allow Subscription Updates" enabled, so the
+    // customer portal surfaces the prorated Starter→Business upgrade. Flipping
+    // this promotes the plan-limit-notice CTA from contact_support → billing_portal.
+    canChangePlanSelfServe: true,
     publicVisible: true,
   },
 

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -133,6 +133,23 @@ export class UnifiedSettings {
         return;
       }
 
+      if (target.closest('.upgrade-to-business-btn')) {
+        // Self-serve Starter→Business upgrade (#4634): open the Dodo customer
+        // portal, which surfaces the prorated plan change via the product
+        // collection ("Allow Subscription Updates" enabled). Same hosted open
+        // path as Manage Billing — Dodo owns payment + 3DS + proration; a failed
+        // charge (prevent_change) leaves the customer on Starter.
+        const reservedWin = prereserveBillingPortalTab();
+        void openBillingPortal(reservedWin).then((result) => {
+          if (result.outcome === 'no-customer') {
+            showToast(
+              'Subscription is managed outside Dodo. Email support@worldmonitor.app for help.',
+            );
+          }
+        });
+        return;
+      }
+
       if (target.closest('.manage-billing-btn')) {
         // Pre-reserve the portal tab synchronously inside the click
         // handler so the popup blocker doesn't suppress the eventual
@@ -650,6 +667,7 @@ export class UnifiedSettings {
             <span style="color:${statusColor};font-weight:600;font-size:13px;">${escapeHtml(planName)}</span>
           </div>
           ${statusLine ? `<div class="upgrade-pro-status-line">${escapeHtml(statusLine)}</div>` : ''}
+          ${sub?.planKey === 'api_starter' ? `<button class="upgrade-to-business-btn" style="margin-right:8px;">Upgrade to Business</button>` : ''}
           <button class="manage-billing-btn">Manage Billing</button>
         </div>
       `;


### PR DESCRIPTION
Self-serve Starter→Business API upgrade (#4634) — U1+U2 of the #4635 lifecycle.

**Stacked on #4665** (base = `fix/api-plan-limit-notify-hardening`) — it needs #4648's `canChangePlanSelfServe` flag + notice CTA + notices service.

The Dodo product **collection** (api_starter + api_business, "Allow Subscription Updates" enabled) surfaces the prorated plan change in the customer portal, so the whole server side already exists (hosted portal via `getCustomerPortalUrl` + the `subscription.plan_changed` webhook). This PR just activates + surfaces it:
- flip `api_business.canChangePlanSelfServe` → true → the plan-limit-notice CTA becomes `billing_portal` (opens the portal → collection upgrade), replacing the `mailto:support` stopgap;
- add a standalone "Upgrade to Business" CTA in `UnifiedSettings` for `api_starter` subscribers (opens the same hosted portal);
- add the `api_starter → api_business` `plan_changed` webhook regression test (the handler already re-resolves the entitlement).

Dodo owns payment + 3DS + proration; payment-fail = **prevent_change** (a failed charge keeps the customer on Starter). Active subs are routed to the portal (`isEntitled` guard), never checkout — no double-charge. 35 convex tests + tsc green; independent code review found no P0/P1.

Plan: `docs/plans/2026-07-03-001-feat-self-serve-api-upgrade-plan.md`. Epic #4635.

https://claude.ai/code/session_01SjVX3GyMBmC2XyFWCHogN1
