### PR TITLE
fix(notifications): stop unhandled 401 rejections on settings save

### DIFF
--- a/src/services/notifications-settings.ts
+++ b/src/services/notifications-settings.ts
@@ -430,6 +430,17 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
       let qhDebounceTimer: ReturnType<typeof setTimeout> | null = null;
       let digestDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
+      // Fire-and-forget settings writes MUST NOT surface as unhandled promise
+      // rejections. A debounced auto-save that 401s (expired Clerk session) or
+      // hits a transient network error is expected and non-fatal — swallow it
+      // here so it never reaches window.onunhandledrejection (WORLDMONITOR-SN).
+      // Logged for local debugging only; the setting simply isn't persisted.
+      function fireForgetSave(p: Promise<unknown>, label: string): void {
+        void p.catch((err) => {
+          console.warn(`[notifications] ${label} failed (not saved):`, err);
+        });
+      }
+
       function reloadNotifSection(): void {
         const loadingEl = container.querySelector<HTMLElement>('#usNotifLoading');
         const contentEl = container.querySelector<HTMLElement>('#usNotifContent');
@@ -544,10 +555,10 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
       // getCurrentAlertRuleFormState so `countries` flows through every time.
       function saveCurrentAlertRule(): void {
         const state = getCurrentAlertRuleFormState();
-        void saveAlertRules({
+        fireForgetSave(saveAlertRules({
           variant: SITE_VARIANT,
           ...state,
-        });
+        }), 'save alert rules');
       }
 
       reloadNotifSection();
@@ -556,11 +567,11 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
         const state = getCurrentAlertRuleFormState();
         // Augment channels with the newly connected one (set semantics).
         const channels = [...new Set([...state.channels, newChannel])];
-        void saveAlertRules({
+        fireForgetSave(saveAlertRules({
           variant: SITE_VARIANT,
           ...state,
           channels,
-        });
+        }), 'save alert rules');
       }
 
       signal.addEventListener('abort', () => {
@@ -586,7 +597,7 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
           const endEl = container.querySelector<HTMLSelectElement>('#usQhEnd');
           const tzEl = container.querySelector<HTMLSelectElement>('#usSharedTimezone');
           const overrideEl = container.querySelector<HTMLSelectElement>('#usQhOverride');
-          void setQuietHours({
+          fireForgetSave(setQuietHours({
             variant: SITE_VARIANT,
             quietHoursEnabled: enabledEl?.checked ?? false,
             quietHoursStart: startEl ? Number(startEl.value) : 22,
@@ -594,7 +605,7 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
             quietHoursTimezone: tzEl?.value || detectedTz,
             quietHoursOverride: (overrideEl?.value ?? 'critical_only') as QuietHoursOverride,
             countries: countryPicker ? countryPicker.getValue() : undefined,
-          });
+          }), 'save quiet hours');
         }, 800);
       };
 
@@ -604,13 +615,13 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
           const modeEl = container.querySelector<HTMLSelectElement>('#usDigestMode');
           const hourEl = container.querySelector<HTMLSelectElement>('#usDigestHour');
           const tzEl = container.querySelector<HTMLSelectElement>('#usSharedTimezone');
-          void setDigestSettings({
+          fireForgetSave(setDigestSettings({
             variant: SITE_VARIANT,
             digestMode: (modeEl?.value ?? 'realtime') as DigestMode,
             digestHour: hourEl ? Number(hourEl.value) : 8,
             digestTimezone: tzEl?.value || detectedTz,
             countries: countryPicker ? countryPicker.getValue() : undefined,
-          });
+          }), 'save digest settings');
         }, 800);
       };
 
@@ -730,11 +741,11 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
             // reads from the DOM, which has already been updated by the time
             // the debounce fires, but explicit override avoids any race).
             const state = getCurrentAlertRuleFormState();
-            void saveAlertRules({
+            fireForgetSave(saveAlertRules({
               variant: SITE_VARIANT,
               ...state,
               aiDigestEnabled: target.checked,
-            });
+            }), 'save alert rules');
           }, 500);
           return;
         }
@@ -743,10 +754,10 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
           alertRuleDebounceTimer = setTimeout(() => {
             // Source from the centralized helper so `countries` flows through.
             const state = getCurrentAlertRuleFormState();
-            void saveAlertRules({
+            fireForgetSave(saveAlertRules({
               variant: SITE_VARIANT,
               ...state,
-            });
+            }), 'save alert rules');
           }, 1000);
         }
       }, { signal });


### PR DESCRIPTION
## Summary

- Debounced notification-settings auto-saves (`saveAlertRules` / `setQuietHours` / `setDigestSettings`) were fired detached with `void` and **no `.catch`**. On an expired Clerk session (401) or a transient network error, the rejected promise reached `window.onunhandledrejection` and surfaced in Sentry as an unhandled error — **WORLDMONITOR-SN** (`save alert rules: 401`).
- Repro path from the Sentry breadcrumb: toggling a notification **country chip** (Russia) with a stale session → 401 → unhandled rejection.
- Routed all six fire-and-forget writes through a small `fireForgetSave(promise, label)` helper that swallows and `console.warn`s the rejection (matching this file's existing load-error handling at the `getChannelsData().catch(...)` site). Expected auth/transient failures no longer crash the global handler; the setting simply isn't persisted.
- Sentry issue resolved with `inNextRelease: true` so it auto-reopens if it recurs post-deploy.

No behavior change on the happy path — only rejection handling on the fire-and-forget writes.

## Test plan

- [x] `typecheck` + `typecheck:api` — PASS
- [x] `lint` (biome + safe-html) — 0 errors
- [x] `test:data` — **12,669 pass / 0 fail / 6 skip** across all 686 files (run in 3 batches to avoid the worktree single-process OOM; `dist/` built first for the ~11 built-output tests)
- [x] Directly-relevant suites (`notifications-settings-*`, `notification-channels-countries-contract`, `country-picker`, quiet-hours/digest rollout flags) — **73/73 pass**
- [x] Edge bundle check (19 fns) + `lint:md` + `version:check` — PASS

https://claude.ai/code/session_011KAmdsDJDYgDSCxycDhTtR