### PR TITLE
feat(api): enforce the sold daily cap + informative at-cap 429 (#4635 U4+U5)

### DIFF
--- a/server/__tests__/gateway-api-rate-limit.test.ts
+++ b/server/__tests__/gateway-api-rate-limit.test.ts
@@ -23,7 +23,6 @@ vi.mock("../_shared/api-key-rate-limit", () => ({
   reserveDailyMeter: (...a: unknown[]) => reserveDailyMeter(...a),
   rateLimitHeaders: () => ({ "X-RateLimit-Limit": "60", "Retry-After": "30" }),
   ENTERPRISE_API_RATE_LIMIT: 1000,
-  CEILING_MULTIPLIER: 10,
 }));
 
 // --- Stub the per-IP layer: spy whether checkRateLimit runs ------------------
@@ -93,7 +92,7 @@ beforeEach(() => {
   checkBurst.mockReset().mockResolvedValue({ ok: true });
   reserveDailyMeter.mockReset().mockResolvedValue({
     count: 1,
-    overCeiling: false,
+    overLimit: false,
     metered: true,
     retryAfterSec: 100,
     rollback: async () => {},
@@ -135,12 +134,12 @@ describe("#3199 U4 — gateway per-account rate-limit wiring", () => {
     expect(checkRateLimit).toHaveBeenCalledTimes(1); // protection retained in shadow
   });
 
-  test("ENFORCE + over-ceiling → 429, meter rolled back, per-IP bypassed", async () => {
+  test("ENFORCE + over daily limit → 429, meter rolled back, per-IP bypassed", async () => {
     process.env.API_RATE_LIMIT_ENFORCE = "true";
     const rollback = vi.fn(async () => {});
     reserveDailyMeter.mockResolvedValue({
       count: 10_001,
-      overCeiling: true,
+      overLimit: true,
       metered: true,
       retryAfterSec: 100,
       rollback,
@@ -150,6 +149,39 @@ describe("#3199 U4 — gateway per-account rate-limit wiring", () => {
     expect(res.status).toBe(429);
     expect(rollback).toHaveBeenCalledTimes(1);
     expect(checkRateLimit).not.toHaveBeenCalled();
+  });
+
+  test("#4635 U4 — ENFORCE burst 429 → informative body (plan, limit, limit_type, upgrade_url)", async () => {
+    process.env.API_RATE_LIMIT_ENFORCE = "true";
+    checkBurst.mockResolvedValue({ ok: false, limit: 60, reset: Date.now() + 30_000 });
+
+    const res = await makeGateway()(userKeyRequest(), ctx);
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      plan: "api_starter",
+      limit: 60,
+      limit_type: "per_minute",
+      upgrade_url: expect.any(String),
+    });
+    expect(typeof body.reset).toBe("string");
+  });
+
+  test("#4635 U4 — ENFORCE daily 429 → informative body names the sold limit + daily type", async () => {
+    process.env.API_RATE_LIMIT_ENFORCE = "true";
+    reserveDailyMeter.mockResolvedValue({
+      count: 1_001, overLimit: true, metered: true, retryAfterSec: 100, rollback: async () => {},
+    });
+
+    const res = await makeGateway()(userKeyRequest(), ctx);
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      plan: "api_starter",
+      limit: 1000,
+      limit_type: "daily",
+      upgrade_url: expect.any(String),
+    });
   });
 
   test("ENFORCE + within limits → served, per-IP bypassed", async () => {

--- a/server/__tests__/gateway-user-key-apiaccess.test.ts
+++ b/server/__tests__/gateway-user-key-apiaccess.test.ts
@@ -31,7 +31,6 @@ vi.mock("../_shared/api-key-rate-limit", () => ({
   reserveDailyMeter: (...a: unknown[]) => reserveDailyMeter(...a),
   rateLimitHeaders: () => ({ "X-RateLimit-Limit": "60", "Retry-After": "30" }),
   ENTERPRISE_API_RATE_LIMIT: 1000,
-  CEILING_MULTIPLIER: 10,
 }));
 
 // --- Stub the per-IP layer: spy whether checkRateLimit runs. -----------------
@@ -127,7 +126,7 @@ beforeEach(() => {
   clerkSession = null;
   checkBurst.mockReset().mockResolvedValue({ ok: true });
   reserveDailyMeter.mockReset().mockResolvedValue({
-    count: 1, overCeiling: false, metered: true, retryAfterSec: 100, rollback: async () => {},
+    count: 1, overLimit: false, metered: true, retryAfterSec: 100, rollback: async () => {},
   });
   checkRateLimit.mockClear().mockResolvedValue(null);
   getEntitlements.mockClear();

--- a/server/_shared/api-key-rate-limit.ts
+++ b/server/_shared/api-key-rate-limit.ts
@@ -3,9 +3,8 @@
 //   1. Per-minute burst  — infra/abuse protection. Hard limit; the gateway
 //      returns 429 on violation (in enforce mode). Value from the catalog
 //      `apiRateLimit` (user keys) or a hardcoded constant (enterprise).
-//   2. Daily usage meter — the commercial "included allowance". Counts every
-//      served request but NEVER rejects at the allowance. The only hard reject
-//      on this axis is a safety ceiling at CEILING_MULTIPLIER × allowance.
+//   2. Daily usage meter — the commercial "included allowance". Hard-rejects
+//      (429 in enforce mode) at the sold allowance (#4635; was a 10× ceiling).
 //
 // This module is decision-only: it never builds a Response and never reads the
 // enforce flag — the gateway (the single chokepoint at server/gateway.ts:1034)
@@ -28,9 +27,6 @@ import { secondsUntilUtcMidnight } from './pro-mcp-token';
  *  be sourced from `features.apiRateLimit`. Mirrors ENTERPRISE_FEATURES. */
 export const ENTERPRISE_API_RATE_LIMIT = 1000;
 
-/** Safety ceiling = this × the included daily allowance. The allowance itself
- *  is metered (never rejects); the ceiling is pure runaway/cost protection. */
-export const CEILING_MULTIPLIER = 10;
 
 // One Redis client shared across every per-minute Ratelimit instance; one
 // Ratelimit per distinct numeric limit (60, 300, 1000) cached in the Map so two
@@ -99,7 +95,7 @@ export async function checkBurst(perMinute: number, identity: string): Promise<B
 }
 
 /** Plain (un-prefixed) daily-meter key — `runRedisPipeline` applies the
- *  deployment/env prefix. UTC calendar day so the ceiling resets at midnight.
+ *  deployment/env prefix. UTC calendar day so the daily meter resets at midnight.
  *  `date` is injectable for deterministic tests. */
 export function apiKeyDailyKey(userId: string, date?: Date): string {
   if (!userId) return '';
@@ -124,25 +120,25 @@ export type RateLimitPipeline = (
 export interface MeterResult {
   /** Post-INCR count for this UTC day (0 when not metered). */
   count: number;
-  /** True when count exceeded CEILING_MULTIPLIER × allowance. */
-  overCeiling: boolean;
+  /** True when count exceeded the sold daily allowance. */
+  overLimit: boolean;
   /** False when Redis was unavailable (fail-open: serve uncounted). */
   metered: boolean;
-  /** Seconds until UTC midnight — the ceiling 429 `Retry-After`. */
+  /** Seconds until UTC midnight — the daily 429 `Retry-After`. */
   retryAfterSec: number;
   /** Idempotent DECR rollback. The gateway calls this only when it actually
-   *  rejects (enforce + overCeiling); in shadow the request is served, so the
+   *  rejects (enforce + overLimit); in shadow the request is served, so the
    *  increment stands and reflects true demand. */
   rollback: () => Promise<void>;
 }
 
 /**
- * Increment the per-account daily meter and report whether the safety ceiling
- * is now exceeded. INCR-first (atomic; no check-then-incr race), mirroring
+ * Increment the per-account daily meter and report whether the sold daily
+ * allowance is now exceeded. INCR-first (atomic; no check-then-incr race), mirroring
  * api/mcp/quota.ts::reserveQuota.
  *
  * - `allowance < 0` (unlimited, e.g. enterprise) → no Redis call; never metered.
- * - Redis unavailable / pipeline failure → `metered:false`, `overCeiling:false`
+ * - Redis unavailable / pipeline failure → `metered:false`, `overLimit:false`
  *   (fail-open: the gateway serves uncounted).
  */
 export async function reserveDailyMeter(opts: {
@@ -156,16 +152,17 @@ export async function reserveDailyMeter(opts: {
   const retryAfterSec = secondsUntilUtcMidnight(date);
 
   // No daily limit: `-1` is unlimited (enterprise); `0` is a misconfiguration
-  // (positive burst but zero allowance) that we fail OPEN on rather than
-  // ceiling-429 every request (ceiling would be 0×10 = 0, so request #1 trips).
+  // (positive burst but zero allowance) that we fail OPEN on rather than 429
+  // every request (a 0 allowance would reject request #1). This guard also keeps
+  // unlimited (-1) from ever reaching `count > allowance` (always-true otherwise).
   // Callers already gate eligibility on apiRateLimit > 0, so this is defensive.
   if (allowance <= 0) {
-    return { count: 0, overCeiling: false, metered: false, retryAfterSec, rollback: noop };
+    return { count: 0, overLimit: false, metered: false, retryAfterSec, rollback: noop };
   }
 
   const key = apiKeyDailyKey(userId, date);
   if (!key) {
-    return { count: 0, overCeiling: false, metered: false, retryAfterSec, rollback: noop };
+    return { count: 0, overLimit: false, metered: false, retryAfterSec, rollback: noop };
   }
 
   let pipeResult: Array<{ result?: unknown }> | null;
@@ -181,13 +178,13 @@ export async function reserveDailyMeter(opts: {
   // Fail-open: couldn't meter → serve uncounted (never punish a paying
   // customer for our Redis outage).
   if (!pipeResult || !Array.isArray(pipeResult) || pipeResult.length === 0) {
-    return { count: 0, overCeiling: false, metered: false, retryAfterSec, rollback: noop };
+    return { count: 0, overLimit: false, metered: false, retryAfterSec, rollback: noop };
   }
 
   const incrRaw = pipeResult[0]?.result;
   const count = typeof incrRaw === 'number' ? incrRaw : Number(incrRaw);
   if (!Number.isFinite(count) || count < 1) {
-    return { count: 0, overCeiling: false, metered: false, retryAfterSec, rollback: noop };
+    return { count: 0, overLimit: false, metered: false, retryAfterSec, rollback: noop };
   }
 
   let rolledBack = false;
@@ -202,8 +199,9 @@ export async function reserveDailyMeter(opts: {
     }
   };
 
-  const ceiling = allowance * CEILING_MULTIPLIER;
-  return { count, overCeiling: count > ceiling, metered: true, retryAfterSec, rollback };
+  // Enforce at the SOLD allowance (#4635): the customer's plan limit is the
+  // limit. (Was a 10× safety ceiling; dropped so the sold cap is authoritative.)
+  return { count, overLimit: count > allowance, metered: true, retryAfterSec, rollback };
 }
 
 /**

--- a/server/_shared/entitlement-check.ts
+++ b/server/_shared/entitlement-check.ts
@@ -35,8 +35,8 @@ export interface CachedEntitlements {
      */
     mcpAccess?: boolean;
     /**
-     * Per-account daily REST allowance (#3199). The rate-limit layer meters
-     * but never rejects at this value; the hard ceiling is 10×. `-1` =
+     * Per-account daily REST allowance (#3199). The rate-limit layer
+     * hard-rejects (in enforce mode) at this value (#4635). `-1` =
      * unlimited. Unlike `mcpAccess`, consumers treat `undefined` as
      * **no daily limit (fail-OPEN)** — a stale/legacy cache must not punish
      * a paying customer. NOT added to the cache-staleness gate below for

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -35,7 +35,6 @@ import {
   reserveDailyMeter,
   rateLimitHeaders,
   ENTERPRISE_API_RATE_LIMIT,
-  CEILING_MULTIPLIER,
 } from './_shared/api-key-rate-limit';
 import {
   deliverUsageEvents,
@@ -1188,8 +1187,8 @@ export function createDomainGateway(
       // ── Per-account API rate limit (#3199) ──────────────────────────────
       // Eligible authenticated keys — a valid user key (which carries NO
       // keyCheck.kind, so `isUserApiKey` is the discriminator) or an enterprise
-      // env key — are governed by a per-account burst + daily meter + 10×
-      // safety ceiling instead of the global per-IP cap. In ENFORCE they bypass
+      // env key — are governed by a per-account burst + daily meter (enforced
+      // at the sold allowance, #4635) instead of the global per-IP cap. In ENFORCE they bypass
       // the per-IP fallback below; in SHADOW they only record telemetry and
       // still fall through to per-IP, so protection never drops below today.
       // Limits are NOT in scope here (checkEntitlement discards `features`), so
@@ -1201,9 +1200,11 @@ export function createDomainGateway(
         let perMinute = 0;
         let allowance = -1;
         let identity = '';
+        let planKey = ''; // #4635 — hoisted for the informative 429 (ent is block-scoped below)
         if (isEnterpriseAuth) {
           perMinute = ENTERPRISE_API_RATE_LIMIT; // hardcoded — no entitlement row
           allowance = -1; // unlimited daily / no ceiling
+          planKey = 'enterprise'; // top tier — named in the 429, but no upgrade_url
           usage.tier = 3; // enterprise tier — no entitlement row to read it from
           // (plan_key defaults to 'enterprise' in buildUsageIdentity)
           // Enterprise burst is keyed PER KEY (not per account) by design:
@@ -1235,6 +1236,7 @@ export function createDomainGateway(
               typeof ent.features.apiDailyAllowance === 'number'
                 ? ent.features.apiDailyAllowance
                 : -1;
+            planKey = ent.planKey;
             identity = sessionUserId;
           }
           // else: downgraded / null entitlement ⇒ not eligible (perMinute = 0),
@@ -1242,13 +1244,23 @@ export function createDomainGateway(
         }
 
         if (perMinute > 0 && identity) {
+          // #4635 — informative 429 upgrade link; omitted for enterprise/top tier.
+          const upgradeUrl =
+            planKey && planKey !== 'enterprise' ? 'https://worldmonitor.app/' : undefined;
           // 1. Per-minute burst (hard limit).
           const burst = await checkBurst(perMinute, identity);
           if (!burst.ok) {
             if (enforce) {
               const retryAfterSec = Math.max(1, Math.ceil((burst.reset - Date.now()) / 1000));
               emitRequest(429, 'rl_min_429', null);
-              return new Response(JSON.stringify({ error: 'Too many requests' }), {
+              return new Response(JSON.stringify({
+                error: 'Too many requests',
+                plan: planKey || undefined,
+                limit: burst.limit,
+                limit_type: 'per_minute',
+                reset: new Date(burst.reset).toISOString(),
+                upgrade_url: upgradeUrl,
+              }), {
                 status: 429,
                 headers: {
                   'Content-Type': 'application/json',
@@ -1260,23 +1272,31 @@ export function createDomainGateway(
             }
             pendingShadowReason = 'rl_min_shadow';
           } else if (allowance >= 0) {
-            // 2. Daily meter + 10× ceiling (skipped for unlimited allowance).
+            // 2. Daily meter — hard-rejects at the sold allowance (#4635).
+            //    Skipped for unlimited (-1); reserveDailyMeter fail-opens on <=0.
             const meter = await reserveDailyMeter({
               userId: identity,
               allowance,
               pipeline: (cmds) => runRedisPipeline(cmds),
             });
-            if (meter.overCeiling) {
+            if (meter.overLimit) {
               if (enforce) {
                 await meter.rollback();
                 emitRequest(429, 'rl_ceiling_429', null);
-                return new Response(JSON.stringify({ error: 'Daily request ceiling exceeded' }), {
+                return new Response(JSON.stringify({
+                  error: 'Daily request limit reached',
+                  plan: planKey || undefined,
+                  limit: allowance,
+                  limit_type: 'daily',
+                  reset: new Date(Date.now() + meter.retryAfterSec * 1000).toISOString(),
+                  upgrade_url: upgradeUrl,
+                }), {
                   status: 429,
                   headers: {
                     'Content-Type': 'application/json',
                     'Cache-Control': 'no-store',
                     ...rateLimitHeaders({
-                      limit: allowance * CEILING_MULTIPLIER,
+                      limit: allowance,
                       remaining: 0,
                       resetMs: Date.now() + meter.retryAfterSec * 1000,
                       retryAfterSec: meter.retryAfterSec,

--- a/tests/api-key-rate-limit.test.mts
+++ b/tests/api-key-rate-limit.test.mts
@@ -6,7 +6,6 @@
 // Constants mirrored from the module so a prod drift fails by name rather than
 // silently (matches tests/mcp-quota-concurrent.test.mjs discipline).
 const STARTER_ALLOWANCE = 1000;
-const CEILING_MULTIPLIER = 10; // server/_shared/api-key-rate-limit.ts
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
@@ -58,40 +57,40 @@ describe('#3199 U3 — apiKeyDailyKey (UTC calendar day)', () => {
 });
 
 describe('#3199 U3 — reserveDailyMeter', () => {
-  it('under the ceiling: meters, does not flag, no rollback', async () => {
-    const mock = makePipeline(4999); // next INCR -> 5000, well under 10×1000
+  it('under the allowance: meters, does not flag, no rollback', async () => {
+    const mock = makePipeline(500); // next INCR -> 501, under the 1000 allowance
     const r = await reserveDailyMeter({ userId: 'u', allowance: STARTER_ALLOWANCE, pipeline: mock.pipeline });
-    assert.equal(r.count, 5000);
-    assert.equal(r.overCeiling, false);
+    assert.equal(r.count, 501);
+    assert.equal(r.overLimit, false);
     assert.equal(r.metered, true);
     // INCR+EXPIRE issued, no DECR.
     assert.equal(mock.commands.length, 1);
   });
 
-  it('over the 10× ceiling: flags, and rollback() floors the counter', async () => {
-    const mock = makePipeline(STARTER_ALLOWANCE * CEILING_MULTIPLIER); // 10000 -> INCR 10001
+  it('over the sold allowance: flags, and rollback() floors the counter', async () => {
+    const mock = makePipeline(STARTER_ALLOWANCE); // 1000 -> INCR 1001
     const r = await reserveDailyMeter({ userId: 'u', allowance: STARTER_ALLOWANCE, pipeline: mock.pipeline });
-    assert.equal(r.count, 10001);
-    assert.equal(r.overCeiling, true);
+    assert.equal(r.count, 1001);
+    assert.equal(r.overLimit, true);
     await r.rollback();
-    assert.equal(mock.current(), 10000, 'rollback DECRs the over-ceiling increment');
+    assert.equal(mock.current(), 1000, 'rollback DECRs the over-limit increment');
     // rollback is idempotent
     await r.rollback();
-    assert.equal(mock.current(), 10000);
+    assert.equal(mock.current(), 1000);
   });
 
-  it('exactly at the ceiling is allowed (only strictly-over rejects)', async () => {
-    const mock = makePipeline(STARTER_ALLOWANCE * CEILING_MULTIPLIER - 1); // -> 10000
+  it('exactly at the allowance is allowed (only strictly-over rejects)', async () => {
+    const mock = makePipeline(STARTER_ALLOWANCE - 1); // -> 1000
     const r = await reserveDailyMeter({ userId: 'u', allowance: STARTER_ALLOWANCE, pipeline: mock.pipeline });
-    assert.equal(r.count, 10000);
-    assert.equal(r.overCeiling, false);
+    assert.equal(r.count, 1000);
+    assert.equal(r.overLimit, false);
   });
 
-  it('unlimited allowance (-1): never touches Redis, never ceilings', async () => {
+  it('unlimited allowance (-1): never touches Redis, never over-limits', async () => {
     const mock = makePipeline(999999);
     const r = await reserveDailyMeter({ userId: 'ent', allowance: -1, pipeline: mock.pipeline });
     assert.equal(r.metered, false);
-    assert.equal(r.overCeiling, false);
+    assert.equal(r.overLimit, false);
     assert.equal(mock.commands.length, 0, 'no pipeline call for unlimited');
   });
 
@@ -99,7 +98,7 @@ describe('#3199 U3 — reserveDailyMeter', () => {
     const mock = makePipeline(0);
     const r = await reserveDailyMeter({ userId: 'u', allowance: 0, pipeline: mock.pipeline });
     assert.equal(r.metered, false);
-    assert.equal(r.overCeiling, false);
+    assert.equal(r.overLimit, false);
     assert.equal(mock.commands.length, 0, 'allowance 0 must not ceiling-429 request #1');
   });
 
@@ -107,7 +106,7 @@ describe('#3199 U3 — reserveDailyMeter', () => {
     const downPipeline = async () => [];
     const r = await reserveDailyMeter({ userId: 'u', allowance: STARTER_ALLOWANCE, pipeline: downPipeline });
     assert.equal(r.metered, false);
-    assert.equal(r.overCeiling, false);
+    assert.equal(r.overLimit, false);
   });
 
   it('fail-open when the pipeline throws', async () => {
@@ -116,7 +115,7 @@ describe('#3199 U3 — reserveDailyMeter', () => {
     };
     const r = await reserveDailyMeter({ userId: 'u', allowance: STARTER_ALLOWANCE, pipeline: throwingPipeline });
     assert.equal(r.metered, false);
-    assert.equal(r.overCeiling, false);
+    assert.equal(r.overLimit, false);
   });
 
   it('per-account: the metered key is the userId-scoped daily key', async () => {


### PR DESCRIPTION
The enforcement half of epic #4635 (U4 + U5), behind `API_RATE_LIMIT_ENFORCE` (shadow-safe until the flip). Independent of the notify/upgrade stack (#4648/#4665/#4672) — different files, off `main`.

**U5 — sold-cap daily enforcement:** `reserveDailyMeter` now flags at the SOLD allowance (Starter 1,000/day) instead of the 10× ceiling (`overLimit: count > allowance`). `CEILING_MULTIPLIER` removed; the `allowance <= 0` guard keeps Enterprise (`-1`) uncapped; the daily `X-RateLimit-Limit` header now advertises the sold cap. Per-minute burst unchanged (already enforced at 60/min).

**U4 — informative at-cap 429:** the burst + daily 429 bodies now carry `{ error, plan, limit, limit_type, reset, upgrade_url }` instead of a bare "Too many requests" / "Daily request ceiling exceeded". `planKey` hoisted at the 429 sites; enterprise (top tier) omits `upgrade_url`. Additive body contract; `X-RateLimit-*` header shape unchanged; telemetry reason strings (`rl_ceiling_*`) kept for dashboard/audit continuity.

Meter 16/16 + gateway 18/18 tests green; `typecheck:api` clean. Independent code review: no P0/P1/P2.

**Before the enforce flip:** `upgrade_url` is a placeholder (`https://worldmonitor.app/` → in-app settings → Upgrade); deep-link it if desired. Flip `API_RATE_LIMIT_ENFORCE=true` only after the notify/upgrade stack lands.

Plan: `docs/plans/2026-07-03-002-feat-api-enforcement-half-plan.md`. Epic #4635.

https://claude.ai/code/session_01SjVX3GyMBmC2XyFWCHogN1
