### PR TITLE
fix(security): require fail-closed policies for expensive routes

### DIFF
--- a/scripts/enforce-rate-limit-policies.mjs
+++ b/scripts/enforce-rate-limit-policies.mjs
@@ -20,11 +20,21 @@
  * to this audit. Without this branch, /api/mcp-proxy would silently slip
  * through future endpoint-coverage checks even though it has a live limit.
  *
- * Also validates two decision registries exported from rate-limit.ts:
+ * Also validates three decision registries exported from rate-limit.ts:
  *   - FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED: expensive/sensitive routes
  *     that must have an endpoint policy so Redis degradation fails closed.
  *   - GLOBAL_RATE_LIMIT_FALLBACK_READ_ROUTES: deliberately read-only gateway
  *     routes that are allowed to inherit the global fail-open fallback.
+ *   - RATE_LIMIT_MUTATION_FALLBACK_EXEMPT: NON-GET routes deliberately allowed
+ *     to inherit the fail-open fallback (each with a justification).
+ *
+ * #4676 (systemic guardrail): enumerate EVERY non-GET (post/put/patch/delete)
+ * route from the generated OpenAPI metadata and require each to be either
+ * covered by ENDPOINT_RATE_POLICIES or explicitly listed in
+ * RATE_LIMIT_MUTATION_FALLBACK_EXEMPT. Previously the audit only checked
+ * registry internal consistency, so an expensive/mutation route omitted from
+ * every registry would pass CI and silently fail OPEN on a Redis outage. New
+ * non-GET routes now have to be triaged into one bucket or the other.
  */
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
@@ -54,6 +64,11 @@ async function extractRateLimitPolicyModule() {
   if (!mod.GLOBAL_RATE_LIMIT_FALLBACK_READ_ROUTES || typeof mod.GLOBAL_RATE_LIMIT_FALLBACK_READ_ROUTES !== 'object') {
     throw new Error(
       `${RATE_LIMIT_SRC} no longer exports GLOBAL_RATE_LIMIT_FALLBACK_READ_ROUTES — accepted fail-open read routes need an auditable registry (#4676).`,
+    );
+  }
+  if (!mod.RATE_LIMIT_MUTATION_FALLBACK_EXEMPT || typeof mod.RATE_LIMIT_MUTATION_FALLBACK_EXEMPT !== 'object') {
+    throw new Error(
+      `${RATE_LIMIT_SRC} no longer exports RATE_LIMIT_MUTATION_FALLBACK_EXEMPT — non-GET routes that deliberately keep the fail-open fallback need an auditable exemption registry (#4676).`,
     );
   }
   return mod;
@@ -121,6 +136,7 @@ async function main() {
   const keys = Object.keys(rateLimitPolicyModule.ENDPOINT_RATE_POLICIES);
   const failClosedRequired = Object.keys(rateLimitPolicyModule.FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED);
   const globalFallbackReadRoutes = Object.keys(rateLimitPolicyModule.GLOBAL_RATE_LIMIT_FALLBACK_READ_ROUTES);
+  const mutationFallbackExempt = Object.keys(rateLimitPolicyModule.RATE_LIMIT_MUTATION_FALLBACK_EXEMPT);
   const gatewayRoutes = extractRoutesFromOpenApi();
   const edgeRoutes = extractEdgeFunctionRoutes();
   const gatewayRoutePaths = new Set(gatewayRoutes.keys());
@@ -187,8 +203,60 @@ async function main() {
     process.exit(1);
   }
 
+  // --- Systemic coverage: every non-GET route must be triaged (#4676) ---
+  // Build the set of generated non-GET (post/put/patch/delete) gateway routes.
+  const nonGetRoutes = [];
+  for (const [route, methods] of gatewayRoutes) {
+    const hasMutation = [...methods].some((m) => m !== 'get');
+    if (hasMutation) nonGetRoutes.push(route);
+  }
+  nonGetRoutes.sort();
+  const keySet = new Set(keys);
+  const exemptSet = new Set(mutationFallbackExempt);
+
+  // First: hygiene on the exemption registry itself so it can't rot into a
+  // rubber stamp. Every entry must (a) name a real generated non-GET gateway
+  // route and (b) not also carry an endpoint policy (redundant + contradictory).
+  const exemptNotNonGet = mutationFallbackExempt.filter((k) => !nonGetRoutes.includes(k));
+  const exemptWithPolicy = mutationFallbackExempt.filter((k) => keySet.has(k));
+  if (exemptNotNonGet.length > 0 || exemptWithPolicy.length > 0) {
+    console.error('✗ RATE_LIMIT_MUTATION_FALLBACK_EXEMPT contains invalid entries:\n');
+    if (exemptNotNonGet.length > 0) {
+      console.error('  Entries that are not generated non-GET (post/put/patch/delete) gateway routes:');
+      for (const key of exemptNotNonGet) console.error(`    - ${key}`);
+      console.error('  (A read-only route belongs in GLOBAL_RATE_LIMIT_FALLBACK_READ_ROUTES, and');
+      console.error('   a renamed/removed route should be dropped from the exemption set.)');
+    }
+    if (exemptWithPolicy.length > 0) {
+      console.error('  Entries that already have an ENDPOINT_RATE_POLICIES policy (remove the exemption):');
+      for (const key of exemptWithPolicy) console.error(`    - ${key}`);
+    }
+    console.error('');
+    process.exit(1);
+  }
+
+  // Then: the core guardrail — no non-GET route may be silently uncovered.
+  const uncoveredNonGet = nonGetRoutes.filter((r) => !keySet.has(r) && !exemptSet.has(r));
+  if (uncoveredNonGet.length > 0) {
+    console.error('✗ non-GET route(s) are neither rate-limited nor explicitly exempt:\n');
+    for (const key of uncoveredNonGet) {
+      const methods = [...gatewayRoutes.get(key)].filter((m) => m !== 'get').sort();
+      console.error(`  - ${key} [${methods.join(',')}]`);
+    }
+    console.error('\nEvery generated post/put/patch/delete route can mutate state or spend on');
+    console.error('external providers/LLMs, so it must NOT silently inherit the availability-first');
+    console.error('global fallback on a Redis outage. Triage each route above into exactly one of:\n');
+    console.error('  (a) ENDPOINT_RATE_POLICIES + FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED');
+    console.error('      (server/_shared/rate-limit.ts) — the route is expensive / provider-backed /');
+    console.error('      mutation-like and should return 503 when the limiter is unavailable, OR');
+    console.error('  (b) RATE_LIMIT_MUTATION_FALLBACK_EXEMPT (server/_shared/rate-limit.ts) — the');
+    console.error('      route is safe to fail open (add a justification comment/reason explaining');
+    console.error('      why: e.g. read-only despite POST, Redis-only write, already auth-gated).\n');
+    process.exit(1);
+  }
+
   console.log(
-    `✓ rate-limit policies clean: ${keys.length} policies validated against ${gatewayRoutes.size} gateway routes + ${edgeRoutes.size} edge-function exceptions; ${failClosedRequired.length} fail-closed requirements and ${globalFallbackReadRoutes.length} global-fallback read decisions audited.`,
+    `✓ rate-limit policies clean: ${keys.length} policies validated against ${gatewayRoutes.size} gateway routes + ${edgeRoutes.size} edge-function exceptions; ${failClosedRequired.length} fail-closed requirements, ${globalFallbackReadRoutes.length} global-fallback read decisions, and ${nonGetRoutes.length} non-GET routes (${mutationFallbackExempt.length} explicitly exempt) audited.`,
   );
 }
 

--- a/scripts/enforce-rate-limit-policies.mjs
+++ b/scripts/enforce-rate-limit-policies.mjs
@@ -19,6 +19,12 @@
  * enforce it in-handler via `checkScopedRateLimit` without becoming invisible
  * to this audit. Without this branch, /api/mcp-proxy would silently slip
  * through future endpoint-coverage checks even though it has a live limit.
+ *
+ * Also validates two decision registries exported from rate-limit.ts:
+ *   - FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED: expensive/sensitive routes
+ *     that must have an endpoint policy so Redis degradation fails closed.
+ *   - GLOBAL_RATE_LIMIT_FALLBACK_READ_ROUTES: deliberately read-only gateway
+ *     routes that are allowed to inherit the global fail-open fallback.
  */
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
@@ -30,7 +36,7 @@ const OPENAPI_DIR = join(ROOT, 'docs/api');
 const RATE_LIMIT_SRC = join(ROOT, 'server/_shared/rate-limit.ts');
 const API_EXCEPTIONS = join(ROOT, 'api/api-route-exceptions.json');
 
-async function extractPolicyKeys() {
+async function extractRateLimitPolicyModule() {
   // Dynamic import via the file URL — works under tsx (the shebang) which
   // transparently transpiles TS. Importing the live object means any reformat
   // of the source literal can never desync the lint from the runtime.
@@ -40,7 +46,17 @@ async function extractPolicyKeys() {
       `${RATE_LIMIT_SRC} no longer exports ENDPOINT_RATE_POLICIES — the lint relies on it (#3278).`,
     );
   }
-  return Object.keys(mod.ENDPOINT_RATE_POLICIES);
+  if (!mod.FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED || typeof mod.FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED !== 'object') {
+    throw new Error(
+      `${RATE_LIMIT_SRC} no longer exports FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED — expensive routes need an auditable fail-closed registry (#4676).`,
+    );
+  }
+  if (!mod.GLOBAL_RATE_LIMIT_FALLBACK_READ_ROUTES || typeof mod.GLOBAL_RATE_LIMIT_FALLBACK_READ_ROUTES !== 'object') {
+    throw new Error(
+      `${RATE_LIMIT_SRC} no longer exports GLOBAL_RATE_LIMIT_FALLBACK_READ_ROUTES — accepted fail-open read routes need an auditable registry (#4676).`,
+    );
+  }
+  return mod;
 }
 
 function extractRoutesFromOpenApi() {
@@ -49,14 +65,22 @@ function extractRoutesFromOpenApi() {
   // indent, so any YAML formatter change (2-space indent, flow style, line
   // folding) would silently drop routes and let policy-drift slip through
   // (#3287 greptile nit 3).
-  const routes = new Set();
+  const routes = new Map();
   const files = readdirSync(OPENAPI_DIR).filter((f) => f.endsWith('.openapi.yaml'));
   for (const file of files) {
     const doc = parseYaml(readFileSync(join(OPENAPI_DIR, file), 'utf8'));
     const paths = doc?.paths;
     if (!paths || typeof paths !== 'object') continue;
-    for (const route of Object.keys(paths)) {
-      if (route.startsWith('/api/')) routes.add(route);
+    for (const [route, operations] of Object.entries(paths)) {
+      if (!route.startsWith('/api/') || !operations || typeof operations !== 'object') continue;
+      routes.set(
+        route,
+        new Set(
+          Object.keys(operations)
+            .map((method) => method.toLowerCase())
+            .filter((method) => ['get', 'post', 'put', 'patch', 'delete'].includes(method)),
+        ),
+      );
     }
   }
   return routes;
@@ -93,10 +117,14 @@ function extractEdgeFunctionRoutes() {
 }
 
 async function main() {
-  const keys = await extractPolicyKeys();
+  const rateLimitPolicyModule = await extractRateLimitPolicyModule();
+  const keys = Object.keys(rateLimitPolicyModule.ENDPOINT_RATE_POLICIES);
+  const failClosedRequired = Object.keys(rateLimitPolicyModule.FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED);
+  const globalFallbackReadRoutes = Object.keys(rateLimitPolicyModule.GLOBAL_RATE_LIMIT_FALLBACK_READ_ROUTES);
   const gatewayRoutes = extractRoutesFromOpenApi();
   const edgeRoutes = extractEdgeFunctionRoutes();
-  const missing = keys.filter((k) => !gatewayRoutes.has(k) && !edgeRoutes.has(k));
+  const gatewayRoutePaths = new Set(gatewayRoutes.keys());
+  const missing = keys.filter((k) => !gatewayRoutePaths.has(k) && !edgeRoutes.has(k));
 
   if (missing.length > 0) {
     console.error('✗ ENDPOINT_RATE_POLICIES key(s) do not match any gateway route OR edge-function exception:\n');
@@ -119,8 +147,47 @@ async function main() {
     process.exit(1);
   }
 
+  const requiredWithoutPolicy = failClosedRequired.filter((k) => !keys.includes(k));
+  if (requiredWithoutPolicy.length > 0) {
+    console.error('✗ fail-closed endpoint(s) are missing ENDPOINT_RATE_POLICIES entries:\n');
+    for (const key of requiredWithoutPolicy) {
+      console.error(`  - ${key}`);
+    }
+    console.error('\nRoutes listed in FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED perform expensive,');
+    console.error('provider-backed, mutation-like, checkout, lead-capture, live, or otherwise');
+    console.error('sensitive work. They must declare endpoint-specific policies so Redis');
+    console.error('missing/degraded windows return 503 instead of inheriting the global fail-open fallback.\n');
+    process.exit(1);
+  }
+
+  const fallbackWithPolicy = globalFallbackReadRoutes.filter((k) => keys.includes(k));
+  const fallbackMissingRoute = globalFallbackReadRoutes.filter((k) => !gatewayRoutePaths.has(k));
+  const fallbackNonGet = globalFallbackReadRoutes.filter((k) => {
+    const methods = gatewayRoutes.get(k);
+    return !methods || methods.size !== 1 || !methods.has('get');
+  });
+  if (fallbackWithPolicy.length > 0 || fallbackMissingRoute.length > 0 || fallbackNonGet.length > 0) {
+    console.error('✗ GLOBAL_RATE_LIMIT_FALLBACK_READ_ROUTES contains invalid route decisions:\n');
+    if (fallbackWithPolicy.length > 0) {
+      console.error('  Routes that already have endpoint-specific policies:');
+      for (const key of fallbackWithPolicy) console.error(`    - ${key}`);
+    }
+    if (fallbackMissingRoute.length > 0) {
+      console.error('  Routes that do not appear in generated OpenAPI gateway specs:');
+      for (const key of fallbackMissingRoute) console.error(`    - ${key}`);
+    }
+    if (fallbackNonGet.length > 0) {
+      console.error('  Routes that are not generated GET-only/read endpoints:');
+      for (const key of fallbackNonGet) console.error(`    - ${key}`);
+    }
+    console.error('\nOnly low-cost read-only gateway routes may document acceptance of the');
+    console.error('availability-first global fallback. Expensive or mutation-like routes belong');
+    console.error('in ENDPOINT_RATE_POLICIES and FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED.\n');
+    process.exit(1);
+  }
+
   console.log(
-    `✓ rate-limit policies clean: ${keys.length} policies validated against ${gatewayRoutes.size} gateway routes + ${edgeRoutes.size} edge-function exceptions.`,
+    `✓ rate-limit policies clean: ${keys.length} policies validated against ${gatewayRoutes.size} gateway routes + ${edgeRoutes.size} edge-function exceptions; ${failClosedRequired.length} fail-closed requirements and ${globalFallbackReadRoutes.length} global-fallback read decisions audited.`,
   );
 }
 

--- a/scripts/enforce-rate-limit-policies.mjs
+++ b/scripts/enforce-rate-limit-policies.mjs
@@ -45,6 +45,8 @@ const ROOT = new URL('..', import.meta.url).pathname;
 const OPENAPI_DIR = join(ROOT, 'docs/api');
 const RATE_LIMIT_SRC = join(ROOT, 'server/_shared/rate-limit.ts');
 const API_EXCEPTIONS = join(ROOT, 'api/api-route-exceptions.json');
+const RUNTIME_RATE_LIMIT_DIRS = ['server', 'api'].map((dir) => join(ROOT, dir));
+const RUNTIME_SOURCE_EXTENSIONS = new Set(['.js', '.cjs', '.mjs', '.ts', '.tsx']);
 
 async function extractRateLimitPolicyModule() {
   // Dynamic import via the file URL — works under tsx (the shebang) which
@@ -129,6 +131,50 @@ function extractEdgeFunctionRoutes() {
     routes.add(urlPath);
   }
   return routes;
+}
+
+function listRuntimeSourceFiles(dir, files = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === '.next' || entry.name === 'dist') continue;
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      listRuntimeSourceFiles(fullPath, files);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    const dot = entry.name.lastIndexOf('.');
+    const ext = dot === -1 ? '' : entry.name.slice(dot);
+    if (RUNTIME_SOURCE_EXTENSIONS.has(ext)) files.push(fullPath);
+  }
+  return files;
+}
+
+function toRepoRelativePath(pathname) {
+  return pathname.slice(ROOT.length).replace(/^\/+/, '');
+}
+
+function findEndpointRateLimitFailOpenOptOuts() {
+  // The endpoint limiter is the guardrail for routes listed in
+  // FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED. Its helper still exposes an
+  // escape hatch for tests/backcompat, but production runtime callers must not
+  // pass `{ failClosed: false }` and silently nullify the registry.
+  const findings = [];
+  const callWithFailOpenOptOut =
+    /checkEndpointRateLimit\s*\([\s\S]*?\{[\s\S]*?failClosed\s*:\s*false[\s\S]*?\}\s*\)/g;
+
+  for (const dir of RUNTIME_RATE_LIMIT_DIRS) {
+    for (const file of listRuntimeSourceFiles(dir)) {
+      if (file === RATE_LIMIT_SRC) continue;
+      const src = readFileSync(file, 'utf8');
+      if (!src.includes('checkEndpointRateLimit') || !src.includes('failClosed')) continue;
+      for (const match of src.matchAll(callWithFailOpenOptOut)) {
+        const line = src.slice(0, match.index).split('\n').length;
+        findings.push(`${toRepoRelativePath(file)}:${line}`);
+      }
+    }
+  }
+
+  return findings;
 }
 
 async function main() {
@@ -252,6 +298,20 @@ async function main() {
     console.error('  (b) RATE_LIMIT_MUTATION_FALLBACK_EXEMPT (server/_shared/rate-limit.ts) — the');
     console.error('      route is safe to fail open (add a justification comment/reason explaining');
     console.error('      why: e.g. read-only despite POST, Redis-only write, already auth-gated).\n');
+    process.exit(1);
+  }
+
+  const endpointFailOpenOptOuts = findEndpointRateLimitFailOpenOptOuts();
+  if (endpointFailOpenOptOuts.length > 0) {
+    console.error('✗ production runtime caller(s) opt out of fail-closed endpoint rate limiting:\n');
+    for (const location of endpointFailOpenOptOuts) {
+      console.error(`  - ${location}`);
+    }
+    console.error('\nRoutes in FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED rely on');
+    console.error('checkEndpointRateLimit defaulting to fail closed when Redis is unavailable.');
+    console.error('Do not pass { failClosed: false } from server/ or api/ runtime code;');
+    console.error('move genuinely safe non-GET routes to RATE_LIMIT_MUTATION_FALLBACK_EXEMPT');
+    console.error('or documented read routes to GLOBAL_RATE_LIMIT_FALLBACK_READ_ROUTES instead.\n');
     process.exit(1);
   }
 

--- a/scripts/enforce-rate-limit-policies.mjs
+++ b/scripts/enforce-rate-limit-policies.mjs
@@ -163,6 +163,7 @@ async function main() {
   const fallbackWithPolicy = globalFallbackReadRoutes.filter((k) => keys.includes(k));
   const fallbackMissingRoute = globalFallbackReadRoutes.filter((k) => !gatewayRoutePaths.has(k));
   const fallbackNonGet = globalFallbackReadRoutes.filter((k) => {
+    if (!gatewayRoutePaths.has(k)) return false;
     const methods = gatewayRoutes.get(k);
     return !methods || methods.size !== 1 || !methods.has('get');
   });

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -190,6 +190,21 @@ export const ENDPOINT_RATE_POLICIES: Record<string, EndpointRatePolicy> = {
   '/api/news/v1/summarize-article': { limit: 60, window: '60 s' },
   '/api/news/v1/summarize-article-cache': { limit: 3000, window: '60 s' },
   '/api/intelligence/v1/classify-event': { limit: 600, window: '60 s' },
+  // LLM-backed situational deduction (imports callLlmReasoning) can drive
+  // provider spend on cache misses, so it must fail closed on Redis outage
+  // rather than inherit the global fail-open fallback. Mirror the sibling
+  // classify-event budget (same limit/window) — both are AI-backed Intelligence
+  // RPCs. (#4676)
+  '/api/intelligence/v1/deduct-situation': { limit: 600, window: '60 s' },
+  // Batch humanitarian-summary fans out to the external HAPI (humdata) provider
+  // on cache miss — up to 25 countries per request, 5 concurrent upstream
+  // fetches. Batch aircraft-details fans out to the external Wingbits provider —
+  // up to 10 ICAO24 lookups per request. Both proxy external providers, so keep
+  // them at the same 30/min budget as the other provider-proxy routes
+  // (sanctions lookup / resilience ranking); conservative because a single
+  // request already amplifies into many upstream calls. (#4676)
+  '/api/conflict/v1/get-humanitarian-summary-batch': { limit: 30, window: '60 s' },
+  '/api/military/v1/get-aircraft-details-batch': { limit: 30, window: '60 s' },
   // Legacy /api/sanctions-entity-search rate limit was 30/min per IP. Preserve
   // that budget now that LookupSanctionEntity proxies OpenSanctions live.
   '/api/sanctions/v1/lookup-sanction-entity': { limit: 30, window: '60 s' },
@@ -240,6 +255,15 @@ export const FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED: Record<string, RateLimit
   '/api/intelligence/v1/classify-event': {
     reason: 'AI classification performs expensive provider-backed analysis.',
   },
+  '/api/intelligence/v1/deduct-situation': {
+    reason: 'LLM-backed situational deduction can drive provider spend on cache misses.',
+  },
+  '/api/conflict/v1/get-humanitarian-summary-batch': {
+    reason: 'Batch summary fans out to the external HAPI (humdata) provider on cache miss.',
+  },
+  '/api/military/v1/get-aircraft-details-batch': {
+    reason: 'Batch enrichment fans out to the external Wingbits provider on cache miss.',
+  },
   '/api/sanctions/v1/lookup-sanction-entity': {
     reason: 'Live sanctions lookup proxies an external provider.',
   },
@@ -270,6 +294,30 @@ export const FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED: Record<string, RateLimit
 export const GLOBAL_RATE_LIMIT_FALLBACK_READ_ROUTES: Record<string, RateLimitPolicyDecision> = {
   '/api/aviation/v1/list-airport-delays': {
     reason: 'Read-only cache-backed airport delay listing; availability-first fallback is acceptable.',
+  },
+};
+
+// Explicit allow-list of NON-GET (post/put/patch/delete) gateway routes that are
+// permitted to inherit the global availability-first fallback during a Redis
+// outage instead of declaring an ENDPOINT_RATE_POLICIES entry. The audit
+// scripts/enforce-rate-limit-policies.mjs fails CI if any generated non-GET
+// route is neither in ENDPOINT_RATE_POLICIES nor listed here — so a newly added
+// expensive/mutation route can no longer silently fail open. Every entry MUST
+// carry a justification for why fail-open is safe for that route. When a route
+// becomes provider-backed / spend-bearing, move it to ENDPOINT_RATE_POLICIES +
+// FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED instead of keeping it here. (#4676)
+export const RATE_LIMIT_MUTATION_FALLBACK_EXEMPT: Record<string, RateLimitPolicyDecision> = {
+  '/api/economic/v1/get-fred-series-batch': {
+    reason:
+      'Read-only despite POST shape: reads seeded FRED data from the Redis seed cache only; all external FRED API calls happen in the Railway seed job, so a cache miss never fans out to an external provider.',
+  },
+  '/api/infrastructure/v1/record-baseline-snapshot': {
+    reason:
+      'Redis-only write (setCachedJson) with no external provider or LLM call; if Redis is degraded the write itself cannot land, so the fail-open fallback carries no spend/abuse risk.',
+  },
+  '/api/v2/shipping/webhooks': {
+    reason:
+      'Webhook registration is API-key authenticated (validateApiKey) and premium-gated before any work, so unauthenticated abuse is already blocked; the handler only writes to Redis, with no external provider or LLM spend.',
   },
 };
 

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -183,6 +183,11 @@ interface EndpointRatePolicy {
 // using checkEndpointRateLimit / hasEndpointRatePolicy below — the export is
 // for tooling, not new runtime callers.
 export const ENDPOINT_RATE_POLICIES: Record<string, EndpointRatePolicy> = {
+  // LLM-backed article summarization can trigger provider spend on cache
+  // misses, so it must not inherit the global fail-open fallback when Redis is
+  // unavailable. Keep this lower than general read traffic until #4675 makes a
+  // product-level entitlement decision.
+  '/api/news/v1/summarize-article': { limit: 60, window: '60 s' },
   '/api/news/v1/summarize-article-cache': { limit: 3000, window: '60 s' },
   '/api/intelligence/v1/classify-event': { limit: 600, window: '60 s' },
   // Legacy /api/sanctions-entity-search rate limit was 30/min per IP. Preserve
@@ -219,6 +224,53 @@ export const ENDPOINT_RATE_POLICIES: Record<string, EndpointRatePolicy> = {
   // resolves edge-function paths via api/api-route-exceptions.json instead
   // of the OpenAPI specs.
   '/api/mcp-proxy': { limit: 30, window: '60 s' },
+};
+
+interface RateLimitPolicyDecision {
+  reason: string;
+}
+
+// Repo-native guardrail for routes where the rate-limit is part of the abuse
+// defence. scripts/enforce-rate-limit-policies.mjs fails if any route listed
+// here can drift back to the gateway's availability-first global fallback.
+export const FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED: Record<string, RateLimitPolicyDecision> = {
+  '/api/news/v1/summarize-article': {
+    reason: 'LLM-backed summarization can drive provider spend on cache misses.',
+  },
+  '/api/intelligence/v1/classify-event': {
+    reason: 'AI classification performs expensive provider-backed analysis.',
+  },
+  '/api/sanctions/v1/lookup-sanction-entity': {
+    reason: 'Live sanctions lookup proxies an external provider.',
+  },
+  '/api/leads/v1/submit-contact': {
+    reason: 'Lead capture writes to Convex and sends email.',
+  },
+  '/api/leads/v1/register-interest': {
+    reason: 'Lead capture writes to Convex and sends email.',
+  },
+  '/api/scenario/v1/run-scenario': {
+    reason: 'Scenario runs are mutation-like jobs with a historical 10/min cap.',
+  },
+  '/api/forecast/v1/trigger-simulation': {
+    reason: 'Forecast simulation trigger starts expensive backend work.',
+  },
+  '/api/maritime/v1/get-vessel-snapshot': {
+    reason: 'Live vessel snapshots can generate high-frequency upstream load.',
+  },
+  '/api/resilience/v1/get-resilience-ranking': {
+    reason: 'Cold/stale cache paths can synchronously warm the full country table.',
+  },
+};
+
+// Explicit examples of read-only gateway routes where the global per-IP
+// fallback remains acceptable during Redis degradation. New expensive/provider
+// routes should not be added here; add them to ENDPOINT_RATE_POLICIES and
+// FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED instead.
+export const GLOBAL_RATE_LIMIT_FALLBACK_READ_ROUTES: Record<string, RateLimitPolicyDecision> = {
+  '/api/aviation/v1/list-airport-delays': {
+    reason: 'Read-only cache-backed airport delay listing; availability-first fallback is acceptable.',
+  },
 };
 
 const endpointLimiters = new Map<string, Ratelimit>();

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -223,6 +223,38 @@ describe('rate-limit fail-open / fail-closed posture (#3531 M9)', () => {
     );
   });
 
+  it('deduct-situation is an explicit fail-closed endpoint policy route (#4676)', async () => {
+    // LLM-backed situational deduction (imports callLlmReasoning) must fail
+    // closed on a Redis outage rather than inherit the availability-first
+    // global fallback — mirrors summarize-article / classify-event. Regression
+    // guard for the #4676 finding where it was absent from both registries.
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    const mod = await importFreshRateLimitModule();
+    const pathname = '/api/intelligence/v1/deduct-situation';
+
+    assert.deepEqual(ENDPOINT_RATE_POLICIES[pathname], { limit: 600, window: '60 s' });
+    assert.ok(
+      pathname in FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED,
+      'LLM-backed deduct-situation must stay in the fail-closed requirement registry',
+    );
+
+    const res = await mod.checkEndpointRateLimit(
+      makeRequest({ 'cf-connecting-ip': '203.0.113.7' }),
+      pathname,
+      { 'Access-Control-Allow-Origin': 'https://worldmonitor.app' },
+    );
+
+    assert.ok(res, 'expected deduct-situation endpoint policy to fail closed without Redis config');
+    assert.equal(res.status, 503);
+    assert.equal(res.headers.get('X-RateLimit-Mode'), 'degraded');
+    assert.equal(
+      res.headers.get('Access-Control-Allow-Origin'),
+      'https://worldmonitor.app',
+      'CORS headers should be propagated on the degraded response',
+    );
+  });
+
   it('checkEndpointRateLimit keeps unrecognised paths unguarded even with fail-closed defaults', async () => {
     delete process.env.UPSTASH_REDIS_REST_URL;
     delete process.env.UPSTASH_REDIS_REST_TOKEN;

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -11,6 +11,9 @@ import assert from 'node:assert/strict';
 import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import {
+  ENDPOINT_RATE_POLICIES,
+  FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED,
+  GLOBAL_RATE_LIMIT_FALLBACK_READ_ROUTES,
   RATE_LIMIT_DEGRADED_HEADERS,
   UNKNOWN_CLIENT_IP,
   checkEndpointRateLimit,
@@ -192,6 +195,34 @@ describe('rate-limit fail-open / fail-closed posture (#3531 M9)', () => {
     assert.equal(res.headers.get('X-RateLimit-Mode'), 'degraded');
   });
 
+  it('summarize-article is an explicit fail-closed endpoint policy route', async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    const mod = await importFreshRateLimitModule();
+    const pathname = '/api/news/v1/summarize-article';
+
+    assert.deepEqual(ENDPOINT_RATE_POLICIES[pathname], { limit: 60, window: '60 s' });
+    assert.ok(
+      pathname in FAIL_CLOSED_ENDPOINT_RATE_POLICY_REQUIRED,
+      'LLM-backed summarize-article must stay in the fail-closed requirement registry',
+    );
+
+    const res = await mod.checkEndpointRateLimit(
+      makeRequest({ 'cf-connecting-ip': '203.0.113.7' }),
+      pathname,
+      { 'Access-Control-Allow-Origin': 'https://worldmonitor.app' },
+    );
+
+    assert.ok(res, 'expected summarize-article endpoint policy to fail closed without Redis config');
+    assert.equal(res.status, 503);
+    assert.equal(res.headers.get('X-RateLimit-Mode'), 'degraded');
+    assert.equal(
+      res.headers.get('Access-Control-Allow-Origin'),
+      'https://worldmonitor.app',
+      'CORS headers should be propagated on the degraded response',
+    );
+  });
+
   it('checkEndpointRateLimit keeps unrecognised paths unguarded even with fail-closed defaults', async () => {
     delete process.env.UPSTASH_REDIS_REST_URL;
     delete process.env.UPSTASH_REDIS_REST_TOKEN;
@@ -204,6 +235,29 @@ describe('rate-limit fail-open / fail-closed posture (#3531 M9)', () => {
     );
 
     assert.equal(res, null);
+  });
+
+  it('documented read-only global fallback routes remain fail-open when Redis config is missing', async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    const mod = await importFreshRateLimitModule();
+    const pathname = '/api/aviation/v1/list-airport-delays';
+
+    assert.ok(
+      pathname in GLOBAL_RATE_LIMIT_FALLBACK_READ_ROUTES,
+      'the intentionally fail-open read route must be documented in the global fallback registry',
+    );
+    assert.equal(mod.hasEndpointRatePolicy(pathname), false);
+
+    const endpointRes = await mod.checkEndpointRateLimit(
+      makeRequest({ 'cf-connecting-ip': '203.0.113.7' }),
+      pathname,
+      {},
+    );
+    const globalRes = await mod.checkRateLimit(makeRequest({ 'cf-connecting-ip': '203.0.113.7' }), {});
+
+    assert.equal(endpointRes, null, 'no endpoint policy should be applied to the documented read route');
+    assert.equal(globalRes, null, 'global fallback keeps read traffic fail-open without Redis config');
   });
 
   it('server rate-limit degraded logs are also sent through Sentry capture', async () => {


### PR DESCRIPTION
## Summary

- Add `/api/news/v1/summarize-article` to `ENDPOINT_RATE_POLICIES` so Redis-missing/degraded windows fail closed instead of inheriting the global fail-open fallback.
- Add an auditable fail-closed endpoint requirement registry plus an explicit read-only global-fallback registry in `server/_shared/rate-limit.ts`.
- Extend `scripts/enforce-rate-limit-policies.mjs` to validate policy keys, fail-closed requirements, and GET-only global-fallback read decisions against generated OpenAPI route metadata.
- Cover both degraded behaviors in `tests/rate-limit.test.mts`.

## Intent

Issue #4676 is the systemic guardrail. The goal is to prevent expensive/provider-backed or mutation-like routes from accidentally relying on the broad availability-first global limiter.

Non-goal: the product-level anonymous summarize-article spend decision remains in #4675.

## Validation Matrix

| Check | Reason | Result |
| --- | --- | --- |
| `TMPDIR=/tmp npm run lint:rate-limit-policies` | Proves policy keys are live routes, fail-closed-required routes have endpoint policies, and documented global fallback routes are GET-only read endpoints | Pass: 11 policies, 9 fail-closed requirements, 1 global-fallback read decision audited |
| `TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/rate-limit.test.mts` | Proves summarize-article fails closed without Redis config and a documented read route remains fail-open through the global fallback | Pass: 21 tests |
| `npm run typecheck:api` | Typechecks shared server/script surface | Pass |
| `git diff --check` | Whitespace/conflict marker check | Pass |

Note: the first sandboxed `npm run lint:rate-limit-policies` attempt failed before assertions with `listen EPERM` from `tsx` IPC; the same command passed with `TMPDIR=/tmp` in the broader local execution context.

## Review Gates

- Baseline reviewer: pass; diff is scoped to the rate-limit registry, audit script, and focused tests.
- Code Review Expert: pass; no P0/P1/P2/P3 findings.
- Outcome reviewer: pass; acceptance criteria for #4676 are covered, with #4675 left as a separate sibling issue.

## Documentation

Not applicable; this is a security/control-plane guardrail and test/audit update.

## Screenshots / UI Evidence

Not applicable; no UI changes.

## Residual Findings

- #4675 still owns the anonymous/basic-session summarize-article entitlement or product-policy decision.
