### PR TITLE
fix(notifications): harden webhook SSRF guard (#4677)

### DIFF
--- a/api/_notification-webhook-ssrf.ts
+++ b/api/_notification-webhook-ssrf.ts
@@ -1,0 +1,91 @@
+const BLOCKED_METADATA_HOSTNAMES = new Set([
+  'localhost',
+  '169.254.169.254',
+  'metadata.google.internal',
+  'metadata.internal',
+  'instance-data',
+  'metadata',
+  'computemetadata',
+  'link-local.s3.amazonaws.com',
+]);
+
+function ipv4Parts(value: string): [number, number, number, number] | null {
+  const parts = value.split('.');
+  if (parts.length !== 4) return null;
+  const nums = parts.map(part => Number(part));
+  if (nums.some(part => !Number.isInteger(part) || part < 0 || part > 255)) {
+    return null;
+  }
+  return nums as [number, number, number, number];
+}
+
+function ipv4FromMappedIpv6(value: string): string | null {
+  const dotted = value.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  const dottedAddress = dotted?.[1];
+  if (dottedAddress && ipv4Parts(dottedAddress)) return dottedAddress;
+
+  const hex = value.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
+  if (!hex) return null;
+  const hi = Number.parseInt(hex[1]!, 16);
+  const lo = Number.parseInt(hex[2]!, 16);
+  if (!Number.isInteger(hi) || !Number.isInteger(lo) || hi < 0 || hi > 0xffff || lo < 0 || lo > 0xffff) {
+    return null;
+  }
+  return `${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`;
+}
+
+export function isBlockedNotificationResolvedAddress(address: string): boolean {
+  const normalized = address.trim().toLowerCase().replace(/^\[|\]$/g, '');
+  const mappedIpv4 = ipv4FromMappedIpv6(normalized);
+  const addr = mappedIpv4 ?? normalized;
+
+  if (addr === '::' || addr === '::1') return true;
+  if (/^f[cd][0-9a-f]{2}:/i.test(addr)) return true;
+  if (/^fe[89ab][0-9a-f]:/i.test(addr)) return true;
+  if (/^ff[0-9a-f]{2}:/i.test(addr)) return true;
+  if (/^2001:0?db8:/i.test(addr)) return true;
+
+  const parts = ipv4Parts(addr);
+  if (!parts) return false;
+
+  const [a, b, c] = parts;
+  if (a === 0) return true;
+  if (a === 10) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  if (a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 0 && c === 0) return true;
+  if (a === 192 && b === 0 && c === 2) return true;
+  if (a === 192 && b === 88 && c === 99) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 198 && (b === 18 || b === 19)) return true;
+  if (a === 198 && b === 51 && c === 100) return true;
+  if (a === 203 && b === 0 && c === 113) return true;
+  if (a >= 224) return true;
+  return false;
+}
+
+export function blockedNotificationWebhookUrlReason(rawUrl: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return 'Webhook URL is not a valid URL';
+  }
+
+  if (parsed.protocol !== 'https:') {
+    return 'Webhook URL must use HTTPS';
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (BLOCKED_METADATA_HOSTNAMES.has(hostname)) {
+    return 'Webhook URL must not point to a metadata endpoint';
+  }
+
+  if (isBlockedNotificationResolvedAddress(hostname)) {
+    return 'Webhook URL must not point to a private/local address';
+  }
+
+  return null;
+}

--- a/api/_notification-webhook-ssrf.ts
+++ b/api/_notification-webhook-ssrf.ts
@@ -34,14 +34,97 @@ function ipv4FromMappedIpv6(value: string): string | null {
   return `${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`;
 }
 
+// Parse an IPv6 literal (compressed or expanded, any case, optional trailing
+// dotted IPv4) into exactly eight 16-bit hextets, or null when it is not a
+// syntactically valid IPv6 address.
+function ipv6ToHextets(value: string): number[] | null {
+  if (typeof value !== 'string' || !value.includes(':')) return null;
+  if ((value.match(/::/g) || []).length > 1) return null;
+
+  const parseSide = (side: string): number[] | null => {
+    if (side === '') return [];
+    const tokens = side.split(':');
+    const hextets: number[] = [];
+    for (let i = 0; i < tokens.length; i += 1) {
+      const token = tokens[i]!;
+      if (token.includes('.')) {
+        if (i !== tokens.length - 1) return null;
+        const parts = ipv4Parts(token);
+        if (!parts) return null;
+        hextets.push((parts[0] << 8) | parts[1]);
+        hextets.push((parts[2] << 8) | parts[3]);
+      } else {
+        if (!/^[0-9a-f]{1,4}$/i.test(token)) return null;
+        hextets.push(Number.parseInt(token, 16));
+      }
+    }
+    return hextets;
+  };
+
+  const compressionIndex = value.indexOf('::');
+  if (compressionIndex === -1) {
+    const groups = parseSide(value);
+    if (!groups || groups.length !== 8) return null;
+    return groups;
+  }
+
+  const head = parseSide(value.slice(0, compressionIndex));
+  const tail = parseSide(value.slice(compressionIndex + 2));
+  if (!head || !tail) return null;
+  const missing = 8 - head.length - tail.length;
+  if (missing < 1) return null;
+  return [...head, ...new Array(missing).fill(0), ...tail];
+}
+
+// When the IPv6 address embeds an IPv4 (NAT64 64:ff9b::/96, IPv4-compatible
+// ::/96, 6to4 2002::/16, or IPv4-mapped ::ffff:0:0/96), return the embedded
+// IPv4 in dotted form so it can be run through the IPv4 blocklist. Otherwise
+// null.
+function embeddedIpv4FromIpv6(hextets: number[]): string | null {
+  const [h0, h1, h2, h3, h4, h5, h6, h7] = hextets as [
+    number, number, number, number, number, number, number, number,
+  ];
+  const toDotted = (hi: number, lo: number): string =>
+    `${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`;
+
+  // IPv4-mapped ::ffff:0:0/96 (covers both ::ffff:1.2.3.4 and ::ffff:hhhh:hhhh)
+  if (h0 === 0 && h1 === 0 && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0xffff) {
+    return toDotted(h6, h7);
+  }
+  // NAT64 64:ff9b::/96
+  if (h0 === 0x0064 && h1 === 0xff9b && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0) {
+    return toDotted(h6, h7);
+  }
+  // 6to4 2002::/16 — the 32 bits after 2002: are the embedded IPv4
+  if (h0 === 0x2002) {
+    return toDotted(h1, h2);
+  }
+  // IPv4-compatible ::/96 (::a.b.c.d / ::hhhh:hhhh); :: and ::1 fall through to
+  // the a===0 rule below, which blocks them either way.
+  if (h0 === 0 && h1 === 0 && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0) {
+    return toDotted(h6, h7);
+  }
+  return null;
+}
+
+function ipv4FromIpv6(value: string): string | null {
+  const hextets = ipv6ToHextets(value);
+  if (hextets) {
+    const embedded = embeddedIpv4FromIpv6(hextets);
+    if (embedded) return embedded;
+  }
+  return ipv4FromMappedIpv6(value);
+}
+
 export function isBlockedNotificationResolvedAddress(address: string): boolean {
   const normalized = address.trim().toLowerCase().replace(/^\[|\]$/g, '');
-  const mappedIpv4 = ipv4FromMappedIpv6(normalized);
+  const mappedIpv4 = ipv4FromIpv6(normalized);
   const addr = mappedIpv4 ?? normalized;
 
   if (addr === '::' || addr === '::1') return true;
   if (/^f[cd][0-9a-f]{2}:/i.test(addr)) return true;
   if (/^fe[89ab][0-9a-f]:/i.test(addr)) return true;
+  if (/^fe[c-f][0-9a-f]:/i.test(addr)) return true;
   if (/^ff[0-9a-f]{2}:/i.test(addr)) return true;
   if (/^2001:0?db8:/i.test(addr)) return true;
 

--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -15,6 +15,7 @@ export const config = { runtime: 'edge' };
 import { getCorsHeaders } from './_cors.js';
 // @ts-expect-error — JS module, no declaration file
 import { captureEdgeException, captureSilentError } from './_sentry-edge.js';
+import { blockedNotificationWebhookUrlReason } from './_notification-webhook-ssrf';
 import { validateBearerToken } from '../server/auth-session';
 import { getEntitlements } from '../server/_shared/entitlement-check';
 
@@ -251,16 +252,9 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
         if (!channelType) return json({ error: 'channelType required' }, 400, corsHeaders);
 
         if (channelType === 'webhook' && webhookEnvelope) {
-          try {
-            const parsed = new URL(webhookEnvelope);
-            if (parsed.protocol !== 'https:') {
-              return json({ error: 'Webhook URL must use HTTPS' }, 400, corsHeaders);
-            }
-            if (/^(localhost|127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|::1|0\.0\.0\.0)/.test(parsed.hostname)) {
-              return json({ error: 'Webhook URL must not point to a private/local address' }, 400, corsHeaders);
-            }
-          } catch {
-            return json({ error: 'Invalid webhook URL' }, 400, corsHeaders);
+          const blockedReason = blockedNotificationWebhookUrlReason(webhookEnvelope);
+          if (blockedReason) {
+            return json({ error: blockedReason }, 400, corsHeaders);
           }
         }
 

--- a/scripts/lib/notification-webhook-ssrf.cjs
+++ b/scripts/lib/notification-webhook-ssrf.cjs
@@ -15,6 +15,7 @@ const BLOCKED_METADATA_HOSTNAMES = new Set([
 ]);
 
 const WEBHOOK_DELIVERY_TIMEOUT_MS = 10_000;
+const MAX_WEBHOOK_RESPONSE_BYTES = 1024 * 1024;
 
 class NotificationWebhookSsrfError extends Error {
   constructor(message) {
@@ -154,6 +155,14 @@ async function postJsonWithPinnedAddress(url, body, headers, resolvedAddresses) 
   const family = pinnedAddress.includes(':') ? 6 : 4;
 
   return new Promise((resolve, reject) => {
+    let settled = false;
+    let hardDeadline;
+    const settle = (fn, value) => {
+      if (settled) return;
+      settled = true;
+      if (hardDeadline) clearTimeout(hardDeadline);
+      fn(value);
+    };
     const req = https.request({
       hostname: url.hostname,
       port: url.port || 443,
@@ -167,21 +176,33 @@ async function postJsonWithPinnedAddress(url, body, headers, resolvedAddresses) 
       lookup: (_hostname, _options, callback) => callback(null, pinnedAddress, family),
     }, (res) => {
       const chunks = [];
-      res.on('error', reject);
-      res.on('data', chunk => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+      let totalBytes = 0;
+      res.on('error', error => settle(reject, error));
+      res.on('data', chunk => {
+        const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+        totalBytes += buffer.length;
+        if (totalBytes > MAX_WEBHOOK_RESPONSE_BYTES) {
+          req.destroy(new Error('webhook response too large'));
+          return;
+        }
+        chunks.push(buffer);
+      });
       res.on('end', () => {
         const responseHeaders = new Headers();
         for (const [key, value] of Object.entries(res.headers)) {
           if (!value) continue;
           responseHeaders.set(key, Array.isArray(value) ? value.join(', ') : value);
         }
-        resolve(responseFromNode(res.statusCode, res.statusMessage, responseHeaders, Buffer.concat(chunks)));
+        settle(resolve, responseFromNode(res.statusCode, res.statusMessage, responseHeaders, Buffer.concat(chunks)));
       });
     });
-    req.on('error', reject);
+    req.on('error', error => settle(reject, error));
     req.setTimeout(WEBHOOK_DELIVERY_TIMEOUT_MS, () => {
       req.destroy(new Error('webhook delivery timed out'));
     });
+    hardDeadline = setTimeout(() => {
+      req.destroy(new Error('webhook delivery timed out'));
+    }, WEBHOOK_DELIVERY_TIMEOUT_MS);
     req.write(body);
     req.end();
   });

--- a/scripts/lib/notification-webhook-ssrf.cjs
+++ b/scripts/lib/notification-webhook-ssrf.cjs
@@ -1,0 +1,196 @@
+'use strict';
+
+const dns = require('node:dns').promises;
+const https = require('node:https');
+
+const BLOCKED_METADATA_HOSTNAMES = new Set([
+  'localhost',
+  '169.254.169.254',
+  'metadata.google.internal',
+  'metadata.internal',
+  'instance-data',
+  'metadata',
+  'computemetadata',
+  'link-local.s3.amazonaws.com',
+]);
+
+const WEBHOOK_DELIVERY_TIMEOUT_MS = 10_000;
+
+class NotificationWebhookSsrfError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'NotificationWebhookSsrfError';
+  }
+}
+
+function ipv4Parts(value) {
+  const parts = String(value).split('.');
+  if (parts.length !== 4) return null;
+  const nums = parts.map(part => Number(part));
+  if (nums.some(part => !Number.isInteger(part) || part < 0 || part > 255)) {
+    return null;
+  }
+  return nums;
+}
+
+function ipv4FromMappedIpv6(value) {
+  const dotted = value.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  if (dotted && ipv4Parts(dotted[1])) return dotted[1];
+
+  const hex = value.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
+  if (!hex) return null;
+  const hi = Number.parseInt(hex[1], 16);
+  const lo = Number.parseInt(hex[2], 16);
+  if (!Number.isInteger(hi) || !Number.isInteger(lo) || hi < 0 || hi > 0xffff || lo < 0 || lo > 0xffff) {
+    return null;
+  }
+  return `${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`;
+}
+
+function isBlockedResolvedAddress(address) {
+  const normalized = String(address).trim().toLowerCase().replace(/^\[|\]$/g, '');
+  const mappedIpv4 = ipv4FromMappedIpv6(normalized);
+  const addr = mappedIpv4 || normalized;
+
+  if (addr === '::' || addr === '::1') return true;
+  if (/^f[cd][0-9a-f]{2}:/i.test(addr)) return true;
+  if (/^fe[89ab][0-9a-f]:/i.test(addr)) return true;
+  if (/^ff[0-9a-f]{2}:/i.test(addr)) return true;
+  if (/^2001:0?db8:/i.test(addr)) return true;
+
+  const parts = ipv4Parts(addr);
+  if (!parts) return false;
+
+  const [a, b, c] = parts;
+  if (a === 0) return true;
+  if (a === 10) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  if (a === 127) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 0 && c === 0) return true;
+  if (a === 192 && b === 0 && c === 2) return true;
+  if (a === 192 && b === 88 && c === 99) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 198 && (b === 18 || b === 19)) return true;
+  if (a === 198 && b === 51 && c === 100) return true;
+  if (a === 203 && b === 0 && c === 113) return true;
+  if (a >= 224) return true;
+  return false;
+}
+
+function blockedNotificationWebhookUrlReason(rawUrl) {
+  let parsed;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return 'Webhook URL is not a valid URL';
+  }
+
+  if (parsed.protocol !== 'https:') {
+    return 'Webhook URL must use HTTPS';
+  }
+
+  const hostname = parsed.hostname.toLowerCase();
+  if (BLOCKED_METADATA_HOSTNAMES.has(hostname)) {
+    return 'Webhook URL must not point to a metadata endpoint';
+  }
+
+  if (isBlockedResolvedAddress(hostname)) {
+    return 'Webhook URL must not point to a private/local address';
+  }
+
+  return null;
+}
+
+async function defaultResolveHostname(hostname) {
+  const records = await dns.lookup(hostname, { all: true, verbatim: true });
+  return records.map(record => record.address);
+}
+
+async function assertNotificationWebhookDeliveryUrlSafe(rawUrl, resolveHostname = defaultResolveHostname) {
+  const urlError = blockedNotificationWebhookUrlReason(rawUrl);
+  if (urlError) {
+    throw new NotificationWebhookSsrfError(urlError);
+  }
+
+  const url = new URL(rawUrl);
+  let resolvedAddresses;
+  try {
+    resolvedAddresses = await resolveHostname(url.hostname);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new NotificationWebhookSsrfError(`Webhook URL DNS resolution failed: ${message}`);
+  }
+
+  if (!resolvedAddresses.length) {
+    throw new NotificationWebhookSsrfError('Webhook URL DNS resolution returned no addresses');
+  }
+
+  const blocked = resolvedAddresses.find(isBlockedResolvedAddress);
+  if (blocked) {
+    throw new NotificationWebhookSsrfError(`Webhook URL resolves to a private/reserved address: ${blocked}`);
+  }
+
+  return { url, resolvedAddresses };
+}
+
+function responseFromNode(statusCode, statusMessage, headers, body) {
+  return new Response(new Uint8Array(body), {
+    status: statusCode || 502,
+    statusText: statusMessage,
+    headers,
+  });
+}
+
+async function postJsonWithPinnedAddress(url, body, headers, resolvedAddresses) {
+  const pinnedAddress = resolvedAddresses.find(address => address.includes('.')) || resolvedAddresses[0];
+  if (!pinnedAddress) {
+    throw new NotificationWebhookSsrfError('Webhook URL DNS resolution returned no addresses');
+  }
+  if (isBlockedResolvedAddress(pinnedAddress)) {
+    throw new NotificationWebhookSsrfError(`Webhook URL resolves to a private/reserved address: ${pinnedAddress}`);
+  }
+  const family = pinnedAddress.includes(':') ? 6 : 4;
+
+  return new Promise((resolve, reject) => {
+    const req = https.request({
+      hostname: url.hostname,
+      port: url.port || 443,
+      path: `${url.pathname}${url.search}`,
+      method: 'POST',
+      headers: {
+        ...headers,
+        'content-length': String(Buffer.byteLength(body)),
+      },
+      family,
+      lookup: (_hostname, _options, callback) => callback(null, pinnedAddress, family),
+    }, (res) => {
+      const chunks = [];
+      res.on('error', reject);
+      res.on('data', chunk => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+      res.on('end', () => {
+        const responseHeaders = new Headers();
+        for (const [key, value] of Object.entries(res.headers)) {
+          if (!value) continue;
+          responseHeaders.set(key, Array.isArray(value) ? value.join(', ') : value);
+        }
+        resolve(responseFromNode(res.statusCode, res.statusMessage, responseHeaders, Buffer.concat(chunks)));
+      });
+    });
+    req.on('error', reject);
+    req.setTimeout(WEBHOOK_DELIVERY_TIMEOUT_MS, () => {
+      req.destroy(new Error('webhook delivery timed out'));
+    });
+    req.write(body);
+    req.end();
+  });
+}
+
+module.exports = {
+  NotificationWebhookSsrfError,
+  assertNotificationWebhookDeliveryUrlSafe,
+  blockedNotificationWebhookUrlReason,
+  isBlockedResolvedAddress,
+  postJsonWithPinnedAddress,
+};

--- a/scripts/lib/notification-webhook-ssrf.cjs
+++ b/scripts/lib/notification-webhook-ssrf.cjs
@@ -48,14 +48,94 @@ function ipv4FromMappedIpv6(value) {
   return `${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`;
 }
 
+// Parse an IPv6 literal (compressed or expanded, any case, optional trailing
+// dotted IPv4) into exactly eight 16-bit hextets, or null when it is not a
+// syntactically valid IPv6 address.
+function ipv6ToHextets(value) {
+  if (typeof value !== 'string' || !value.includes(':')) return null;
+  if ((value.match(/::/g) || []).length > 1) return null;
+
+  const parseSide = (side) => {
+    if (side === '') return [];
+    const tokens = side.split(':');
+    const hextets = [];
+    for (let i = 0; i < tokens.length; i += 1) {
+      const token = tokens[i];
+      if (token.includes('.')) {
+        if (i !== tokens.length - 1) return null;
+        const parts = ipv4Parts(token);
+        if (!parts) return null;
+        hextets.push((parts[0] << 8) | parts[1]);
+        hextets.push((parts[2] << 8) | parts[3]);
+      } else {
+        if (!/^[0-9a-f]{1,4}$/i.test(token)) return null;
+        hextets.push(Number.parseInt(token, 16));
+      }
+    }
+    return hextets;
+  };
+
+  const compressionIndex = value.indexOf('::');
+  if (compressionIndex === -1) {
+    const groups = parseSide(value);
+    if (!groups || groups.length !== 8) return null;
+    return groups;
+  }
+
+  const head = parseSide(value.slice(0, compressionIndex));
+  const tail = parseSide(value.slice(compressionIndex + 2));
+  if (!head || !tail) return null;
+  const missing = 8 - head.length - tail.length;
+  if (missing < 1) return null;
+  return [...head, ...new Array(missing).fill(0), ...tail];
+}
+
+// When the IPv6 address embeds an IPv4 (NAT64 64:ff9b::/96, IPv4-compatible
+// ::/96, 6to4 2002::/16, or IPv4-mapped ::ffff:0:0/96), return the embedded
+// IPv4 in dotted form so it can be run through the IPv4 blocklist. Otherwise
+// null.
+function embeddedIpv4FromIpv6(hextets) {
+  const [h0, h1, h2, h3, h4, h5, h6, h7] = hextets;
+  const toDotted = (hi, lo) => `${hi >> 8}.${hi & 0xff}.${lo >> 8}.${lo & 0xff}`;
+
+  // IPv4-mapped ::ffff:0:0/96 (covers both ::ffff:1.2.3.4 and ::ffff:hhhh:hhhh)
+  if (h0 === 0 && h1 === 0 && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0xffff) {
+    return toDotted(h6, h7);
+  }
+  // NAT64 64:ff9b::/96
+  if (h0 === 0x0064 && h1 === 0xff9b && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0) {
+    return toDotted(h6, h7);
+  }
+  // 6to4 2002::/16 — the 32 bits after 2002: are the embedded IPv4
+  if (h0 === 0x2002) {
+    return toDotted(h1, h2);
+  }
+  // IPv4-compatible ::/96 (::a.b.c.d / ::hhhh:hhhh); :: and ::1 fall through to
+  // the a===0 rule below, which blocks them either way.
+  if (h0 === 0 && h1 === 0 && h2 === 0 && h3 === 0 && h4 === 0 && h5 === 0) {
+    return toDotted(h6, h7);
+  }
+  return null;
+}
+
+function ipv4FromIpv6(value) {
+  const hextets = ipv6ToHextets(value);
+  if (hextets) {
+    const embedded = embeddedIpv4FromIpv6(hextets);
+    if (embedded) return embedded;
+  }
+  return ipv4FromMappedIpv6(value);
+}
+
 function isBlockedResolvedAddress(address) {
   const normalized = String(address).trim().toLowerCase().replace(/^\[|\]$/g, '');
-  const mappedIpv4 = ipv4FromMappedIpv6(normalized);
+  const mappedIpv4 = ipv4FromIpv6(normalized);
   const addr = mappedIpv4 || normalized;
 
   if (addr === '::' || addr === '::1') return true;
   if (/^f[cd][0-9a-f]{2}:/i.test(addr)) return true;
   if (/^fe[89ab][0-9a-f]:/i.test(addr)) return true;
+  if (/^fe[c-f][0-9a-f]:/i.test(addr)) return true;
   if (/^ff[0-9a-f]{2}:/i.test(addr)) return true;
   if (/^2001:0?db8:/i.test(addr)) return true;
 

--- a/scripts/notification-relay.cjs
+++ b/scripts/notification-relay.cjs
@@ -5,6 +5,11 @@ const dns = require('node:dns').promises;
 const { ConvexHttpClient } = require('convex/browser');
 const { Resend } = require('resend');
 const { decrypt } = require('./lib/crypto.cjs');
+const {
+  assertNotificationWebhookDeliveryUrlSafe,
+  isBlockedResolvedAddress,
+  postJsonWithPinnedAddress,
+} = require('./lib/notification-webhook-ssrf.cjs');
 const { callLLM } = require('./lib/llm-chain.cjs');
 const { fetchUserPreferences, extractUserContext, formatUserProfile } = require('./lib/user-context.cjs');
 const { countryNameToIso2 } = require('./shared/country-name-to-iso2.cjs');
@@ -161,7 +166,7 @@ async function isUserPro(userId) {
 // ── Private IP guard ─────────────────────────────────────────────────────────
 
 function isPrivateIP(ip) {
-  return /^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|127\.|::1|fc|fd)/.test(ip);
+  return isBlockedResolvedAddress(ip);
 }
 
 // ── Quiet hours ───────────────────────────────────────────────────────────────
@@ -486,28 +491,12 @@ async function sendWebhook(userId, webhookEnvelope, event) {
     return false;
   }
 
-  let parsed;
+  let safeUrl;
+  let resolvedAddresses;
   try {
-    parsed = new URL(url);
-  } catch {
-    console.warn(`[relay] Webhook invalid URL for ${userId}`);
-    await deactivateChannel(userId, 'webhook');
-    return false;
-  }
-
-  if (parsed.protocol !== 'https:') {
-    console.warn(`[relay] Webhook rejected non-HTTPS for ${userId}`);
-    return false;
-  }
-
-  try {
-    const addrs = await dns.resolve4(parsed.hostname);
-    if (addrs.some(isPrivateIP)) {
-      console.warn(`[relay] Webhook SSRF blocked (private IP) for ${userId}`);
-      return false;
-    }
+    ({ url: safeUrl, resolvedAddresses } = await assertNotificationWebhookDeliveryUrlSafe(url));
   } catch (err) {
-    console.warn(`[relay] Webhook DNS resolve failed for ${userId}:`, err.message);
+    console.warn(`[relay] Webhook URL rejected for ${userId}:`, err.message);
     return false;
   }
 
@@ -527,12 +516,12 @@ async function sendWebhook(userId, webhookEnvelope, event) {
   });
 
   try {
-    const resp = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'User-Agent': 'worldmonitor-relay/1.0' },
-      body: payload,
-      signal: AbortSignal.timeout(10000),
-    });
+    const resp = await postJsonWithPinnedAddress(
+      safeUrl,
+      payload,
+      { 'Content-Type': 'application/json', 'User-Agent': 'worldmonitor-relay/1.0' },
+      resolvedAddresses,
+    );
     if (resp.status === 404 || resp.status === 410 || resp.status === 403) {
       console.warn(`[relay] Webhook ${resp.status} for ${userId} — deactivating`);
       await deactivateChannel(userId, 'webhook');

--- a/scripts/seed-digest-notifications.mjs
+++ b/scripts/seed-digest-notifications.mjs
@@ -26,6 +26,11 @@ import {
 const require = createRequire(import.meta.url);
 const DIGEST_DIPLOMACY_DATA = require('../shared/diplomacy-keywords.json');
 const { decrypt } = require('./lib/crypto.cjs');
+const {
+  assertNotificationWebhookDeliveryUrlSafe,
+  isBlockedResolvedAddress,
+  postJsonWithPinnedAddress,
+} = require('./lib/notification-webhook-ssrf.cjs');
 const { callLLM } = require('./lib/llm-chain.cjs');
 const { fetchUserPreferences, extractUserContext, formatUserProfile } = require('./lib/user-context.cjs');
 const { fetchFollowedCountries } = require('./lib/followed-countries-fetch.cjs');
@@ -1221,7 +1226,7 @@ async function deactivateChannel(userId, channelType) {
 }
 
 function isPrivateIP(ip) {
-  return /^(10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|127\.|::1|fc|fd)/.test(ip);
+  return isBlockedResolvedAddress(ip);
 }
 
 // ── Send functions ────────────────────────────────────────────────────────────
@@ -1445,21 +1450,12 @@ async function sendWebhook(userId, webhookEnvelope, stories, aiSummary) {
     console.warn(`[digest] Webhook decrypt failed for ${userId}:`, err.message);
     return false;
   }
-  let parsed;
-  try { parsed = new URL(url); } catch {
-    console.warn(`[digest] Webhook invalid URL for ${userId}`);
-    await deactivateChannel(userId, 'webhook');
-    return false;
-  }
-  if (parsed.protocol !== 'https:') {
-    console.warn(`[digest] Webhook rejected non-HTTPS for ${userId}`);
-    return false;
-  }
+  let safeUrl;
+  let resolvedAddresses;
   try {
-    const addrs = await dns.resolve4(parsed.hostname);
-    if (addrs.some(isPrivateIP)) { console.warn(`[digest] Webhook SSRF blocked for ${userId}`); return false; }
-  } catch {
-    console.warn(`[digest] Webhook DNS resolve failed for ${userId}`);
+    ({ url: safeUrl, resolvedAddresses } = await assertNotificationWebhookDeliveryUrlSafe(url));
+  } catch (err) {
+    console.warn(`[digest] Webhook URL rejected for ${userId}:`, err.message);
     return false;
   }
   const payload = JSON.stringify({
@@ -1470,12 +1466,12 @@ async function sendWebhook(userId, webhookEnvelope, stories, aiSummary) {
     storyCount: stories.length,
   });
   try {
-    const resp = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'User-Agent': 'worldmonitor-digest/1.0' },
-      body: payload,
-      signal: AbortSignal.timeout(10000),
-    });
+    const resp = await postJsonWithPinnedAddress(
+      safeUrl,
+      payload,
+      { 'Content-Type': 'application/json', 'User-Agent': 'worldmonitor-digest/1.0' },
+      resolvedAddresses,
+    );
     if (resp.status === 404 || resp.status === 410 || resp.status === 403) {
       console.warn(`[digest] Webhook ${resp.status} for ${userId} — deactivating`);
       await deactivateChannel(userId, 'webhook');

--- a/tests/notification-webhook-ssrf.test.mts
+++ b/tests/notification-webhook-ssrf.test.mts
@@ -1,0 +1,106 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  blockedNotificationWebhookUrlReason,
+  isBlockedNotificationResolvedAddress,
+} from '../api/_notification-webhook-ssrf';
+
+const require = createRequire(import.meta.url);
+const scriptSsrf = require('../scripts/lib/notification-webhook-ssrf.cjs') as {
+  assertNotificationWebhookDeliveryUrlSafe: (
+    rawUrl: string,
+    resolveHostname?: (hostname: string) => Promise<string[]>,
+  ) => Promise<{ url: URL; resolvedAddresses: string[] }>;
+  blockedNotificationWebhookUrlReason: (rawUrl: string) => string | null;
+  isBlockedResolvedAddress: (address: string) => boolean;
+};
+
+const blockedUrls = [
+  'https://localhost/hook',
+  'https://2130706433/hook',
+  'https://0x7f000001/hook',
+  'https://0177.0.0.1/hook',
+  'https://169.254.169.254/latest/meta-data',
+  'https://100.64.0.1/hook',
+  'https://192.0.2.10/hook',
+  'https://198.51.100.10/hook',
+  'https://203.0.113.10/hook',
+  'https://metadata.google.internal/computeMetadata/v1/',
+  'https://[::ffff:169.254.169.254]/hook',
+  'https://[::ffff:7f00:1]/hook',
+  'https://[::ffff:a9fe:a9fe]/hook',
+  'https://[fe80::1]/hook',
+  'https://[2001:db8::1]/hook',
+];
+
+describe('notification webhook SSRF guard', () => {
+  test('registration rejects literal private, link-local, reserved, metadata, and IPv4-mapped addresses', () => {
+    for (const url of blockedUrls) {
+      assert.ok(blockedNotificationWebhookUrlReason(url), `api helper must block ${url}`);
+      assert.ok(scriptSsrf.blockedNotificationWebhookUrlReason(url), `script helper must block ${url}`);
+    }
+    assert.equal(blockedNotificationWebhookUrlReason('https://example.com/hook'), null);
+    assert.equal(scriptSsrf.blockedNotificationWebhookUrlReason('https://example.com/hook'), null);
+  });
+
+  test('address classifier blocks DNS-resolved private and reserved ranges with parity', () => {
+    const blockedAddresses = [
+      '169.254.169.254',
+      '100.64.12.34',
+      '0.1.2.3',
+      '192.0.0.5',
+      '198.18.0.1',
+      '224.0.0.1',
+      '::ffff:169.254.169.254',
+      '::ffff:a9fe:a9fe',
+      'fe80::1',
+      'fc00::1',
+      'ff02::1',
+      '2001:db8::1234',
+    ];
+    for (const address of blockedAddresses) {
+      assert.equal(isBlockedNotificationResolvedAddress(address), true, `api helper must block ${address}`);
+      assert.equal(scriptSsrf.isBlockedResolvedAddress(address), true, `script helper must block ${address}`);
+    }
+    for (const address of ['93.184.216.34', '2606:2800:220:1:248:1893:25c8:1946']) {
+      assert.equal(isBlockedNotificationResolvedAddress(address), false, `api helper must allow ${address}`);
+      assert.equal(scriptSsrf.isBlockedResolvedAddress(address), false, `script helper must allow ${address}`);
+    }
+  });
+
+  test('delivery rejects DNS rebinding to link-local and reserved addresses', async () => {
+    await assert.rejects(
+      () => scriptSsrf.assertNotificationWebhookDeliveryUrlSafe(
+        'https://webhook.example.test/hook',
+        async () => ['169.254.169.254'],
+      ),
+      /private\/reserved address/,
+    );
+    await assert.rejects(
+      () => scriptSsrf.assertNotificationWebhookDeliveryUrlSafe(
+        'https://webhook.example.test/hook',
+        async () => ['::ffff:a9fe:a9fe'],
+      ),
+      /private\/reserved address/,
+    );
+
+    await assert.doesNotReject(async () => {
+      const result = await scriptSsrf.assertNotificationWebhookDeliveryUrlSafe(
+        'https://webhook.example.test/hook',
+        async () => ['93.184.216.34'],
+      );
+      assert.deepEqual(result.resolvedAddresses, ['93.184.216.34']);
+    });
+  });
+
+  test('realtime and digest arbitrary webhook senders use pinned delivery helper', () => {
+    for (const relPath of ['scripts/notification-relay.cjs', 'scripts/seed-digest-notifications.mjs']) {
+      const source = readFileSync(resolve(process.cwd(), relPath), 'utf8');
+      assert.match(source, /assertNotificationWebhookDeliveryUrlSafe/);
+      assert.match(source, /postJsonWithPinnedAddress/);
+    }
+  });
+});

--- a/tests/notification-webhook-ssrf.test.mts
+++ b/tests/notification-webhook-ssrf.test.mts
@@ -34,6 +34,17 @@ const blockedUrls = [
   'https://[::ffff:a9fe:a9fe]/hook',
   'https://[fe80::1]/hook',
   'https://[2001:db8::1]/hook',
+  // NAT64 64:ff9b::/96 embedding an internal IPv4
+  'https://[64:ff9b::a9fe:a9fe]/hook',
+  'https://[64:ff9b::7f00:1]/hook',
+  // 6to4 2002::/16 embedding an internal IPv4
+  'https://[2002:7f00:1::]/hook',
+  'https://[2002:a9fe:a9fe::]/hook',
+  // IPv4-compatible ::/96 embedding an internal IPv4
+  'https://[::7f00:1]/hook',
+  'https://[::a9fe:a9fe]/hook',
+  // fec0::/10 deprecated site-local
+  'https://[fec0::1]/hook',
 ];
 
 describe('notification webhook SSRF guard', () => {
@@ -56,6 +67,25 @@ describe('notification webhook SSRF guard', () => {
       '224.0.0.1',
       '::ffff:169.254.169.254',
       '::ffff:a9fe:a9fe',
+      // IPv4-mapped hex form (::ffff:hhhh:hhhh) embedding loopback
+      '::ffff:7f00:1',
+      '::FFFF:7F00:1',
+      // NAT64 64:ff9b::/96 → trailing 32 bits are the embedded IPv4
+      '64:ff9b::a9fe:a9fe',
+      '64:ff9b::7f00:1',
+      '0064:ff9b:0000:0000:0000:0000:a9fe:a9fe',
+      // 6to4 2002::/16 → the 32 bits after 2002: are the embedded IPv4
+      '2002:7f00:1::',
+      '2002:a9fe:a9fe::',
+      '2002:0a00:0001::',
+      // IPv4-compatible ::/96 (::a.b.c.d and ::hhhh:hhhh)
+      '::7f00:1',
+      '::127.0.0.1',
+      '::a9fe:a9fe',
+      '::169.254.169.254',
+      // fec0::/10 deprecated site-local (not caught by the fe80::/10 regex)
+      'fec0::1',
+      'feff::1',
       'fe80::1',
       'fc00::1',
       'ff02::1',
@@ -65,7 +95,14 @@ describe('notification webhook SSRF guard', () => {
       assert.equal(isBlockedNotificationResolvedAddress(address), true, `api helper must block ${address}`);
       assert.equal(scriptSsrf.isBlockedResolvedAddress(address), true, `script helper must block ${address}`);
     }
-    for (const address of ['93.184.216.34', '2606:2800:220:1:248:1893:25c8:1946']) {
+    for (const address of [
+      '93.184.216.34',
+      '2606:2800:220:1:248:1893:25c8:1946',
+      // 6to4 wrapping a public IPv4 (93.184.216.34) must still be allowed
+      '2002:5db8:d822::',
+      // NAT64 wrapping a public IPv4 (93.184.216.34) must still be allowed
+      '64:ff9b::5db8:d822',
+    ]) {
       assert.equal(isBlockedNotificationResolvedAddress(address), false, `api helper must allow ${address}`);
       assert.equal(scriptSsrf.isBlockedResolvedAddress(address), false, `script helper must allow ${address}`);
     }

--- a/tests/notification-webhook-ssrf.test.mts
+++ b/tests/notification-webhook-ssrf.test.mts
@@ -103,4 +103,12 @@ describe('notification webhook SSRF guard', () => {
       assert.match(source, /postJsonWithPinnedAddress/);
     }
   });
+
+  test('pinned delivery helper keeps hard timeout and response body caps', () => {
+    const source = readFileSync(resolve(process.cwd(), 'scripts/lib/notification-webhook-ssrf.cjs'), 'utf8');
+    assert.match(source, /MAX_WEBHOOK_RESPONSE_BYTES/);
+    assert.match(source, /totalBytes > MAX_WEBHOOK_RESPONSE_BYTES/);
+    assert.match(source, /hardDeadline = setTimeout/);
+    assert.match(source, /clearTimeout\(hardDeadline\)/);
+  });
 });


### PR DESCRIPTION
## Summary

- Adds a notification webhook SSRF guard shared by registration and relay delivery coverage.
- Blocks link-local, private, CGNAT, documentation, multicast/reserved, metadata-hostname, and IPv4-mapped variants before storing arbitrary webhook URLs.
- Pins realtime and digest arbitrary webhook delivery to the DNS address that passed validation, closing the resolve-then-fetch TOCTOU gap.

## Intent

Issue #4677 identified that user-configured `channelType: "webhook"` URLs could miss link-local/reserved literals at registration and DNS-rebind between delivery validation and `fetch()`.

Non-goals:

- No Slack/Discord URL contract changes; those channels remain constrained by their existing service URL regexes.
- No Convex schema or UI changes.

## Validation Matrix

| Check | Reason | Result |
|---|---|---|
| Live issue/open PR preflight with `gh-axi` | Avoid duplicate work and verify current contract | Pass: #4677 open; adjacent #4648/#4665 do not cover this SSRF surface |
| `TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/notification-webhook-ssrf.test.mts` | Focused SSRF negative coverage | Pass: 4/4 |
| `npm run typecheck:api` | Edge/API helper typecheck and Convex call audit | Pass |
| `node --check scripts/lib/notification-webhook-ssrf.cjs` | New Node helper syntax | Pass |
| `node --check scripts/notification-relay.cjs` | Realtime relay syntax | Pass |
| `node --check scripts/seed-digest-notifications.mjs` | Digest relay syntax | Pass |
| `node --test tests/edge-functions.test.mjs` | Edge runtime guardrails | Pass: 206/206 |
| `git diff --check` | Whitespace/conflict marker check | Pass |
| Pre-push hook | Repo standard local gate | Pass: typecheck, API typecheck, Convex typecheck, CJS syntax, Unicode, boundaries, safe HTML, Sentry coverage, rate-limit policy, premium-fetch parity, changed test, edge tests, version check |

## Review Gates

- Baseline reviewer: found and fixed missing `localhost` coverage in the extracted helper before publish.
- Code Review Expert: SOLID, removal, security, and code-quality checklists loaded; no open P0/P1/P2/P3 findings after the localhost fix.
- Outcome reviewer: issue acceptance maps to implementation and validation; signed off for publish.

## Documentation

Not applicable. This hardens an existing security boundary without changing public webhook payload shape or UI behavior.

## Screenshots / UI Evidence

Not applicable. No UI changes.

## Residual Findings

None.
