### PR TITLE
fix(mcp): block private DNS targets in proxy (#4674)

### DIFF
--- a/api/mcp-proxy.ts
+++ b/api/mcp-proxy.ts
@@ -94,10 +94,12 @@ const BLOCKED_HOSTNAMES = new Set([
   '169.254.169.254',
 ]);
 
-let resolveHostnameForTest = null;
+const TEST_RESOLVER_KEY = Symbol.for('worldmonitor.mcpProxy.resolveHostnameForTest');
 
-export function __setMcpProxyResolveHostnameForTest(resolver) {
-  resolveHostnameForTest = typeof resolver === 'function' ? resolver : null;
+function getResolveHostnameForTest() {
+  if (!process.env.NODE_TEST_CONTEXT) return null;
+  const resolver = globalThis[TEST_RESOLVER_KEY];
+  return typeof resolver === 'function' ? resolver : null;
 }
 
 class McpProxySsrfError extends Error {
@@ -151,6 +153,7 @@ async function resolveDnsJson(hostname, recordType) {
 }
 
 async function defaultResolveHostname(hostname) {
+  const resolveHostnameForTest = getResolveHostnameForTest();
   if (resolveHostnameForTest) return resolveHostnameForTest(hostname);
   const records = await Promise.all([
     resolveDnsJson(hostname, 'A'),

--- a/api/mcp-proxy.ts
+++ b/api/mcp-proxy.ts
@@ -5,6 +5,7 @@
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { jsonResponse } from './_json-response.js';
 import { isCallerPremium } from '../server/_shared/premium-check';
+import { isBlockedResolvedAddress } from '../server/_shared/ip-address-classification';
 import { ENDPOINT_RATE_POLICIES, checkScopedRateLimit } from '../server/_shared/rate-limit';
 
 export const config = { runtime: 'edge' };
@@ -68,6 +69,8 @@ function logProxyCall(entry: {
 
 const TIMEOUT_MS = 15_000;
 const SSE_CONNECT_TIMEOUT_MS = 10_000;
+const DNS_RESOLUTION_TIMEOUT_MS = 3_000;
+const DNS_JSON_ENDPOINT = 'https://cloudflare-dns.com/dns-query';
 // Production waits up to 12s for an SSE RPC response. The node test runner sets
 // NODE_TEST_CONTEXT; an SSE mock that closes its stream before the proxy
 // registers its RPC deferred would otherwise stall the suite for that full
@@ -80,17 +83,99 @@ function withProxyNoStore(headers: Record<string, string> = {}): Record<string, 
   return { ...headers, 'Cache-Control': 'no-store' };
 }
 
-const BLOCKED_HOST_PATTERNS = [
-  /^localhost$/i,
-  /^127\./,
-  /^10\./,
-  /^172\.(1[6-9]|2\d|3[01])\./,
-  /^192\.168\./,
-  /^169\.254\./,   // link-local + cloud metadata (AWS/GCP/Azure)
-  /^::1$/,
-  /^fd[0-9a-f]{2}:/i,
-  /^fe80:/i,
-];
+const BLOCKED_HOSTNAMES = new Set([
+  'localhost',
+  'metadata',
+  'metadata.internal',
+  'metadata.google.internal',
+  'instance-data',
+  'computemetadata',
+  'link-local.s3.amazonaws.com',
+  '169.254.169.254',
+]);
+
+let resolveHostnameForTest = null;
+
+export function __setMcpProxyResolveHostnameForTest(resolver) {
+  resolveHostnameForTest = typeof resolver === 'function' ? resolver : null;
+}
+
+class McpProxySsrfError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'McpProxySsrfError';
+  }
+}
+
+async function resolveDnsJson(hostname, recordType) {
+  const url = new URL(DNS_JSON_ENDPOINT);
+  url.searchParams.set('name', hostname);
+  url.searchParams.set('type', recordType);
+  const response = await fetch(url.toString(), {
+    headers: {
+      Accept: 'application/dns-json',
+      'User-Agent': 'WorldMonitor-MCP-Proxy/1.0',
+    },
+    signal: AbortSignal.timeout(DNS_RESOLUTION_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    throw new Error(`DNS ${recordType} lookup failed: HTTP ${response.status}`);
+  }
+  const data = await response.json();
+  if (data?.Status !== 0) {
+    throw new Error(`DNS ${recordType} lookup failed: status ${data?.Status}`);
+  }
+  const expectedType = recordType === 'A' ? 1 : 28;
+  return (Array.isArray(data?.Answer) ? data.Answer : [])
+    .filter(answer => answer?.type === expectedType && typeof answer?.data === 'string')
+    .map(answer => answer.data);
+}
+
+async function defaultResolveHostname(hostname) {
+  if (resolveHostnameForTest) return resolveHostnameForTest(hostname);
+  const records = await Promise.all([
+    resolveDnsJson(hostname, 'A'),
+    resolveDnsJson(hostname, 'AAAA'),
+  ]);
+  return records.flat();
+}
+
+async function assertServerUrlSafe(url) {
+  const hostname = url.hostname.toLowerCase();
+  if (BLOCKED_HOSTNAMES.has(hostname)) {
+    throw new McpProxySsrfError(`serverUrl hostname is blocked: ${hostname}`);
+  }
+  if (isBlockedResolvedAddress(hostname)) {
+    throw new McpProxySsrfError(`serverUrl resolves to a private/reserved address: ${hostname}`);
+  }
+
+  let resolvedAddresses;
+  try {
+    resolvedAddresses = await defaultResolveHostname(hostname);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new McpProxySsrfError(`serverUrl DNS resolution failed: ${message}`);
+  }
+
+  if (!resolvedAddresses.length) {
+    throw new McpProxySsrfError('serverUrl DNS resolution returned no addresses');
+  }
+
+  const blocked = resolvedAddresses.find(isBlockedResolvedAddress);
+  if (blocked) {
+    throw new McpProxySsrfError(`serverUrl resolves to a private/reserved address: ${blocked}`);
+  }
+
+  return { url, resolvedAddresses };
+}
+
+// Vercel Edge fetch does not expose a Node-style lookup hook, so this proxy
+// cannot pin the TLS connection to a previously vetted address. Instead, every
+// outbound MCP fetch re-resolves and re-checks the hostname immediately before
+// dispatch to narrow the DNS-rebinding window in the Edge runtime.
+async function revalidateBeforeFetch(url) {
+  await assertServerUrlSafe(url);
+}
 
 function buildInitPayload() {
   return {
@@ -105,13 +190,15 @@ function buildInitPayload() {
   };
 }
 
-function validateServerUrl(raw) {
+async function validateServerUrl(raw) {
   let url;
   try { url = new URL(raw); } catch { return null; }
   if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
-  const host = url.hostname;
-  if (BLOCKED_HOST_PATTERNS.some(p => p.test(host))) return null;
-  return url;
+  try {
+    return (await assertServerUrlSafe(url)).url;
+  } catch {
+    return null;
+  }
 }
 
 function buildHeaders(customHeaders) {
@@ -138,10 +225,12 @@ function buildHeaders(customHeaders) {
 async function postJson(url, body, headers, sessionId) {
   const h = { ...headers };
   if (sessionId) h['Mcp-Session-Id'] = sessionId;
+  await revalidateBeforeFetch(url);
   const resp = await fetch(url.toString(), {
     method: 'POST',
     headers: h,
     body: JSON.stringify(body),
+    redirect: 'manual',
     signal: AbortSignal.timeout(TIMEOUT_MS),
   });
   return resp;
@@ -172,7 +261,10 @@ async function sendInitialized(serverUrl, headers, sessionId) {
       method: 'notifications/initialized',
       params: {},
     }, headers, sessionId);
-  } catch { /* non-fatal */ }
+  } catch (error) {
+    if (error instanceof McpProxySsrfError) throw error;
+    /* non-fatal */
+  }
 }
 
 async function mcpListTools(serverUrl, customHeaders) {
@@ -241,8 +333,10 @@ class SseSession {
   }
 
   async connect() {
+    await revalidateBeforeFetch(new URL(this._sseUrl));
     const resp = await fetch(this._sseUrl, {
       headers: { ...this._headers, Accept: 'text/event-stream', 'Cache-Control': 'no-cache' },
+      redirect: 'manual',
       signal: AbortSignal.timeout(SSE_CONNECT_TIMEOUT_MS),
     });
     if (!resp.ok) throw new Error(`SSE connect HTTP ${resp.status}`);
@@ -291,7 +385,7 @@ class SseSession {
                   this._endpointDeferred.reject(new Error('SSE endpoint protocol not allowed'));
                   return;
                 }
-                if (BLOCKED_HOST_PATTERNS.some(p => p.test(resolved.hostname))) {
+                if (BLOCKED_HOSTNAMES.has(resolved.hostname.toLowerCase()) || isBlockedResolvedAddress(resolved.hostname)) {
                   this._endpointDeferred.reject(new Error('SSE endpoint host is blocked'));
                   return;
                 }
@@ -336,10 +430,12 @@ class SseSession {
       }
     }, SSE_RPC_TIMEOUT_MS);
     try {
+      await revalidateBeforeFetch(new URL(this._endpointUrl));
       const postResp = await fetch(this._endpointUrl, {
         method: 'POST',
         headers: { ...this._headers, 'Content-Type': 'application/json' },
         body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+        redirect: 'manual',
         signal: AbortSignal.timeout(SSE_RPC_TIMEOUT_MS),
       });
       if (!postResp.ok) {
@@ -353,10 +449,12 @@ class SseSession {
   }
 
   async notify(method, params) {
+    await revalidateBeforeFetch(new URL(this._endpointUrl));
     await fetch(this._endpointUrl, {
       method: 'POST',
       headers: { ...this._headers, 'Content-Type': 'application/json' },
       body: JSON.stringify({ jsonrpc: '2.0', method, params }),
+      redirect: 'manual',
       signal: AbortSignal.timeout(5_000),
     }).catch(() => {});
   }
@@ -427,7 +525,7 @@ async function handleListTools(req: Request, cors: Record<string, string>, meta:
   const rawServer = url.searchParams.get('serverUrl');
   const rawHeaders = url.searchParams.get('headers');
   if (!rawServer) return jsonResponse({ error: 'Missing serverUrl' }, 400, cors);
-  const serverUrl = validateServerUrl(rawServer);
+  const serverUrl = await validateServerUrl(rawServer);
   if (!serverUrl) return jsonResponse({ error: 'Invalid serverUrl' }, 400, cors);
   let customHeaders = {};
   if (rawHeaders) {
@@ -445,7 +543,7 @@ async function handleCallTool(req: Request, cors: Record<string, string>, meta: 
   const { serverUrl: rawServer, toolName, toolArgs, customHeaders } = body;
   if (!rawServer) return jsonResponse({ error: 'Missing serverUrl' }, 400, cors);
   if (!toolName) return jsonResponse({ error: 'Missing toolName' }, 400, cors);
-  const serverUrl = validateServerUrl(rawServer);
+  const serverUrl = await validateServerUrl(rawServer);
   if (!serverUrl) return jsonResponse({ error: 'Invalid serverUrl' }, 400, cors);
   captureMeta(serverUrl, customHeaders, meta);
   const result = isSseTransport(serverUrl)

--- a/api/mcp-proxy.ts
+++ b/api/mcp-proxy.ts
@@ -107,6 +107,25 @@ class McpProxySsrfError extends Error {
   }
 }
 
+// Generic message surfaced to the caller when a serverUrl resolves to a
+// private/reserved address. The specific blocked IP is deliberately NOT echoed
+// back: returning it turns the proxy into an address oracle (the caller could
+// enumerate internal IPs by observing which hostnames get blocked). SSRF review
+// finding — log the concrete IP server-side for debugging, tell the caller only
+// that the host is disallowed.
+const SSRF_BLOCKED_PUBLIC_MESSAGE = 'serverUrl host is not allowed';
+
+function throwBlockedAddress(blockedAddress) {
+  // Server-side audit/debug log with the concrete blocked address. This is the
+  // only place the resolved internal IP appears; it never reaches the response.
+  console.error('[mcp-proxy]', {
+    event: 'mcp_proxy_ssrf_blocked',
+    ts: new Date().toISOString(),
+    blocked_address: blockedAddress,
+  });
+  throw new McpProxySsrfError(SSRF_BLOCKED_PUBLIC_MESSAGE);
+}
+
 async function resolveDnsJson(hostname, recordType) {
   const url = new URL(DNS_JSON_ENDPOINT);
   url.searchParams.set('name', hostname);
@@ -146,7 +165,7 @@ async function assertServerUrlSafe(url) {
     throw new McpProxySsrfError(`serverUrl hostname is blocked: ${hostname}`);
   }
   if (isBlockedResolvedAddress(hostname)) {
-    throw new McpProxySsrfError(`serverUrl resolves to a private/reserved address: ${hostname}`);
+    throwBlockedAddress(hostname);
   }
 
   let resolvedAddresses;
@@ -163,16 +182,20 @@ async function assertServerUrlSafe(url) {
 
   const blocked = resolvedAddresses.find(isBlockedResolvedAddress);
   if (blocked) {
-    throw new McpProxySsrfError(`serverUrl resolves to a private/reserved address: ${blocked}`);
+    throwBlockedAddress(blocked);
   }
 
   return { url, resolvedAddresses };
 }
 
-// Vercel Edge fetch does not expose a Node-style lookup hook, so this proxy
-// cannot pin the TLS connection to a previously vetted address. Instead, every
-// outbound MCP fetch re-resolves and re-checks the hostname immediately before
-// dispatch to narrow the DNS-rebinding window in the Edge runtime.
+// Vercel Edge fetch does not expose a Node-style lookup/socket hook, so this
+// proxy CANNOT pin the TLS connection to a previously vetted address. There is
+// no way to guarantee that the IP we validated is the IP fetch() ultimately
+// connects to; a DNS answer can change between our resolve and fetch's own
+// resolve. This re-resolve-and-recheck immediately before every outbound
+// dispatch NARROWS that DNS-rebinding window but does not close it. The
+// residual rebind window is an ACCEPTED limitation of the Edge runtime (no
+// socket-level pin available) — documented, not fixed here (P1, issue #4674).
 async function revalidateBeforeFetch(url) {
   await assertServerUrlSafe(url);
 }

--- a/server/_shared/ip-address-classification.ts
+++ b/server/_shared/ip-address-classification.ts
@@ -1,0 +1,33 @@
+export function isBlockedResolvedAddress(address: string): boolean {
+  const normalized = address.trim().toLowerCase().replace(/^\[|\]$/g, '');
+  const v4Mapped = normalized.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
+  const addr = v4Mapped?.[1] ?? normalized;
+
+  if (addr === '::' || addr === '::1') return true;
+  if (/^f[cd][0-9a-f]{2}:/i.test(addr)) return true; // fc00::/7 unique local
+  if (/^fe[89ab][0-9a-f]:/i.test(addr)) return true; // fe80::/10 link local
+  if (/^ff[0-9a-f]{2}:/i.test(addr)) return true; // ff00::/8 multicast
+  if (/^2001:0?db8:/i.test(addr)) return true; // 2001:db8::/32 documentation
+
+  const parts = addr.split('.').map(Number);
+  if (parts.length !== 4 || parts.some(part => !Number.isInteger(part) || part < 0 || part > 255)) {
+    return false;
+  }
+
+  const [a, b, c] = parts as [number, number, number, number];
+  if (a === 0) return true; // 0.0.0.0/8
+  if (a === 10) return true; // 10.0.0.0/8
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
+  if (a === 127) return true; // 127.0.0.0/8 loopback
+  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link local
+  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 private
+  if (a === 192 && b === 0 && c === 0) return true; // 192.0.0.0/24 IETF
+  if (a === 192 && b === 0 && c === 2) return true; // 192.0.2.0/24 TEST-NET-1
+  if (a === 192 && b === 88 && c === 99) return true; // 192.88.99.0/24 deprecated 6to4
+  if (a === 192 && b === 168) return true; // 192.168.0.0/16 private
+  if (a === 198 && (b === 18 || b === 19)) return true; // 198.18.0.0/15 benchmark
+  if (a === 198 && b === 51 && c === 100) return true; // 198.51.100.0/24 TEST-NET-2
+  if (a === 203 && b === 0 && c === 113) return true; // 203.0.113.0/24 TEST-NET-3
+  if (a >= 224) return true; // multicast + reserved
+  return false;
+}

--- a/server/_shared/ip-address-classification.ts
+++ b/server/_shared/ip-address-classification.ts
@@ -1,20 +1,14 @@
-export function isBlockedResolvedAddress(address: string): boolean {
-  const normalized = address.trim().toLowerCase().replace(/^\[|\]$/g, '');
-  const v4Mapped = normalized.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
-  const addr = v4Mapped?.[1] ?? normalized;
+// Blocklist for resolved IP addresses (SSRF defence). Callers pass either a
+// literal IP (from a DNS answer) or a hostname (pre-resolution short-circuit);
+// hostnames that are not IP literals fall through and return false.
+//
+// IPv6 is decoded numerically so every textual spelling (compressed `::`,
+// fully expanded, upper/lowercase, and embedded-IPv4 forms) is classified the
+// same way. Embedded-IPv4 encodings (v4-mapped, NAT64, IPv4-compatible, 6to4)
+// are decoded to their embedded IPv4 and run through the IPv4 blocklist so a
+// private/reserved v4 cannot be smuggled through an IPv6 wrapper.
 
-  if (addr === '::' || addr === '::1') return true;
-  if (/^f[cd][0-9a-f]{2}:/i.test(addr)) return true; // fc00::/7 unique local
-  if (/^fe[89ab][0-9a-f]:/i.test(addr)) return true; // fe80::/10 link local
-  if (/^ff[0-9a-f]{2}:/i.test(addr)) return true; // ff00::/8 multicast
-  if (/^2001:0?db8:/i.test(addr)) return true; // 2001:db8::/32 documentation
-
-  const parts = addr.split('.').map(Number);
-  if (parts.length !== 4 || parts.some(part => !Number.isInteger(part) || part < 0 || part > 255)) {
-    return false;
-  }
-
-  const [a, b, c] = parts as [number, number, number, number];
+function isBlockedIpv4(a: number, b: number, c: number): boolean {
   if (a === 0) return true; // 0.0.0.0/8
   if (a === 10) return true; // 10.0.0.0/8
   if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
@@ -29,5 +23,112 @@ export function isBlockedResolvedAddress(address: string): boolean {
   if (a === 198 && b === 51 && c === 100) return true; // 198.51.100.0/24 TEST-NET-2
   if (a === 203 && b === 0 && c === 113) return true; // 203.0.113.0/24 TEST-NET-3
   if (a >= 224) return true; // multicast + reserved
+  return false;
+}
+
+function isBlockedDottedIpv4(addr: string): boolean {
+  const parts = addr.split('.').map(Number);
+  if (parts.length !== 4 || parts.some(part => !Number.isInteger(part) || part < 0 || part > 255)) {
+    return false;
+  }
+  const [a, b, c] = parts as [number, number, number, number];
+  return isBlockedIpv4(a, b, c);
+}
+
+// Decode two consecutive 16-bit IPv6 hextets that carry an embedded IPv4
+// (hi = first two octets, lo = last two octets) and run the IPv4 blocklist.
+function isBlockedEmbeddedIpv4(hi: number, lo: number): boolean {
+  return isBlockedIpv4((hi >> 8) & 0xff, hi & 0xff, (lo >> 8) & 0xff);
+}
+
+// Expand any textual IPv6 spelling into exactly 8 numeric hextets, or return
+// null if the input is not a well-formed IPv6 literal. Handles `::`
+// compression and a trailing dotted-quad IPv4 (e.g. ::ffff:1.2.3.4).
+function expandIpv6(input: string): number[] | null {
+  let s = input;
+  const pct = s.indexOf('%'); // strip zone id (fe80::1%eth0)
+  if (pct !== -1) s = s.slice(0, pct);
+  if (!s.includes(':')) return null;
+
+  // Convert a trailing dotted-quad IPv4 suffix into two hextets.
+  const dotMatch = s.match(/(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (dotMatch) {
+    const dotted = dotMatch[1];
+    if (dotted === undefined) return null; // unreachable (capture group), satisfies TS
+    const octets = dotted.split('.').map(Number);
+    if (octets.length !== 4 || octets.some(o => !Number.isInteger(o) || o < 0 || o > 255)) return null;
+    const [o0, o1, o2, o3] = octets as [number, number, number, number];
+    const hextets = [
+      (((o0 << 8) | o1) >>> 0).toString(16),
+      (((o2 << 8) | o3) >>> 0).toString(16),
+    ].join(':');
+    s = s.slice(0, s.length - dotted.length) + hextets;
+  }
+
+  const halves = s.split('::');
+  if (halves.length > 2) return null; // more than one `::` is invalid
+
+  const parseGroups = (part: string): number[] | null => {
+    if (part === '') return [];
+    const out: number[] = [];
+    for (const g of part.split(':')) {
+      if (!/^[0-9a-f]{1,4}$/.test(g)) return null;
+      out.push(parseInt(g, 16));
+    }
+    return out;
+  };
+
+  if (halves.length === 2) {
+    const head = parseGroups(halves[0] ?? '');
+    const tail = parseGroups(halves[1] ?? '');
+    if (head === null || tail === null) return null;
+    const missing = 8 - head.length - tail.length;
+    if (missing < 1) return null; // `::` must stand for at least one hextet
+    return [...head, ...new Array(missing).fill(0), ...tail];
+  }
+
+  const groups = parseGroups(s);
+  if (groups === null || groups.length !== 8) return null;
+  return groups;
+}
+
+export function isBlockedResolvedAddress(address: string): boolean {
+  const normalized = address.trim().toLowerCase().replace(/^\[|\]$/g, '');
+
+  // Literal dotted IPv4.
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(normalized)) {
+    return isBlockedDottedIpv4(normalized);
+  }
+
+  const groups = expandIpv6(normalized);
+  if (!groups) return false; // not an IP literal (e.g. a hostname) — nothing to block here
+  const [g0, g1, g2, , , g5, g6, g7] = groups as
+    [number, number, number, number, number, number, number, number];
+
+  // :: (unspecified) and ::1 (loopback).
+  const highSevenZero = groups.slice(0, 7).every(part => part === 0);
+  if (highSevenZero && (g7 === 0 || g7 === 1)) return true;
+
+  // Reserved / internal IPv6 ranges (mask the leading hextet).
+  if ((g0 & 0xfe00) === 0xfc00) return true; // fc00::/7 unique local
+  if ((g0 & 0xffc0) === 0xfe80) return true; // fe80::/10 link local
+  if ((g0 & 0xffc0) === 0xfec0) return true; // fec0::/10 site local (deprecated)
+  if ((g0 & 0xff00) === 0xff00) return true; // ff00::/8 multicast
+  if (g0 === 0x2001 && g1 === 0x0db8) return true; // 2001:db8::/32 documentation
+
+  // Embedded-IPv4 forms — decode the embedded IPv4 and run the v4 blocklist.
+  if (groups.slice(0, 5).every(part => part === 0) && g5 === 0xffff) {
+    return isBlockedEmbeddedIpv4(g6, g7); // ::ffff:0:0/96 v4-mapped (dotted + hex)
+  }
+  if (g0 === 0x64 && g1 === 0xff9b && groups.slice(2, 6).every(part => part === 0)) {
+    return isBlockedEmbeddedIpv4(g6, g7); // 64:ff9b::/96 NAT64
+  }
+  if (groups.slice(0, 6).every(part => part === 0)) {
+    return isBlockedEmbeddedIpv4(g6, g7); // ::/96 IPv4-compatible (:: and ::1 handled above)
+  }
+  if (g0 === 0x2002) {
+    return isBlockedEmbeddedIpv4(g1, g2); // 2002::/16 6to4 (embedded v4 in bits 16-48)
+  }
+
   return false;
 }

--- a/server/worldmonitor/shipping/v2/webhook-shared.ts
+++ b/server/worldmonitor/shipping/v2/webhook-shared.ts
@@ -1,4 +1,5 @@
 import { CHOKEPOINT_REGISTRY } from '../../../_shared/chokepoint-registry';
+import { isBlockedResolvedAddress } from '../../../_shared/ip-address-classification';
 
 export const WEBHOOK_TTL = 86400 * 30; // 30 days
 export const VALID_CHOKEPOINT_IDS = new Set(CHOKEPOINT_REGISTRY.map(c => c.id));
@@ -32,39 +33,7 @@ export const BLOCKED_METADATA_HOSTNAMES = new Set([
   'link-local.s3.amazonaws.com',
 ]);
 
-export function isBlockedResolvedAddress(address: string): boolean {
-  const normalized = address.trim().toLowerCase().replace(/^\[|\]$/g, '');
-  const v4Mapped = normalized.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/i);
-  const addr = v4Mapped?.[1] ?? normalized;
-
-  if (addr === '::' || addr === '::1') return true;
-  if (/^f[cd][0-9a-f]{2}:/i.test(addr)) return true; // fc00::/7 unique local
-  if (/^fe[89ab][0-9a-f]:/i.test(addr)) return true; // fe80::/10 link local
-  if (/^ff[0-9a-f]{2}:/i.test(addr)) return true; // ff00::/8 multicast
-  if (/^2001:0?db8:/i.test(addr)) return true; // 2001:db8::/32 documentation
-
-  const parts = addr.split('.').map(Number);
-  if (parts.length !== 4 || parts.some(part => !Number.isInteger(part) || part < 0 || part > 255)) {
-    return false;
-  }
-
-  const [a, b, c] = parts as [number, number, number, number];
-  if (a === 0) return true; // 0.0.0.0/8
-  if (a === 10) return true; // 10.0.0.0/8
-  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
-  if (a === 127) return true; // 127.0.0.0/8 loopback
-  if (a === 169 && b === 254) return true; // 169.254.0.0/16 link local
-  if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12 private
-  if (a === 192 && b === 0 && c === 0) return true; // 192.0.0.0/24 IETF
-  if (a === 192 && b === 0 && c === 2) return true; // 192.0.2.0/24 TEST-NET-1
-  if (a === 192 && b === 88 && c === 99) return true; // 192.88.99.0/24 deprecated 6to4
-  if (a === 192 && b === 168) return true; // 192.168.0.0/16 private
-  if (a === 198 && (b === 18 || b === 19)) return true; // 198.18.0.0/15 benchmark
-  if (a === 198 && b === 51 && c === 100) return true; // 198.51.100.0/24 TEST-NET-2
-  if (a === 203 && b === 0 && c === 113) return true; // 203.0.113.0/24 TEST-NET-3
-  if (a >= 224) return true; // multicast + reserved
-  return false;
-}
+export { isBlockedResolvedAddress };
 
 export function isBlockedCallbackUrl(rawUrl: string): string | null {
   let parsed: URL;

--- a/tests/mcp-proxy.test.mjs
+++ b/tests/mcp-proxy.test.mjs
@@ -119,6 +119,20 @@ function makeMcpFetch({ initStatus = 200, listStatus = 200, callStatus = 200, to
 }
 
 let handler;
+let setResolveHostnameForTest;
+
+const PUBLIC_TEST_ADDRESS = '93.184.216.34';
+
+function setResolvedAddresses(addresses) {
+  setResolveHostnameForTest(async () => addresses);
+}
+
+function dnsJsonResponse(records) {
+  return new Response(JSON.stringify({
+    Status: 0,
+    Answer: records.map(({ type, data }) => ({ type, data })),
+  }), { status: 200, headers: { 'Content-Type': 'application/dns-json' } });
+}
 
 describe('api/mcp-proxy', () => {
   beforeEach(async () => {
@@ -126,9 +140,12 @@ describe('api/mcp-proxy', () => {
     // isCallerPremium import from server/. Test must follow the rename.
     const mod = await import(`../api/mcp-proxy.ts?t=${Date.now()}`);
     handler = mod.default;
+    setResolveHostnameForTest = mod.__setMcpProxyResolveHostnameForTest;
+    setResolvedAddresses([PUBLIC_TEST_ADDRESS]);
   });
 
   afterEach(() => {
+    setResolveHostnameForTest?.(null);
     globalThis.fetch = originalFetch;
   });
 
@@ -298,6 +315,40 @@ describe('api/mcp-proxy', () => {
       assert.equal(res.status, 400);
     });
 
+    it('returns 400 when DNS resolves a hostname to blocked private/reserved addresses', async () => {
+      const cases = [
+        ['private IPv4', '10.0.0.5'],
+        ['link-local IPv4', '169.254.169.254'],
+        ['loopback IPv4', '127.0.0.1'],
+        ['ULA IPv6', 'fd00::1234'],
+        ['link-local IPv6', 'fe80::1'],
+      ];
+      for (const [label, address] of cases) {
+        setResolvedAddresses([address]);
+        const res = await handler(makeGetRequest({ serverUrl: `https://${label.toLowerCase().replaceAll(' ', '-')}.example/mcp` }));
+        assert.equal(res.status, 400, `${label} DNS result must be rejected`);
+        const data = await res.json();
+        assert.match(data.error, /invalid serverUrl/i);
+      }
+    });
+
+    it('allows a hostname whose DNS answers are public addresses', async () => {
+      setResolveHostnameForTest(null);
+      globalThis.fetch = async (url, opts) => {
+        const u = new URL(url.toString());
+        if (u.hostname === 'cloudflare-dns.com') {
+          const type = u.searchParams.get('type');
+          if (type === 'A') return dnsJsonResponse([{ type: 1, data: PUBLIC_TEST_ADDRESS }]);
+          if (type === 'AAAA') return dnsJsonResponse([{ type: 28, data: '2606:2800:220:1:248:1893:25c8:1946' }]);
+        }
+        return makeMcpFetch({ tools: [] })(url, opts);
+      };
+      const res = await handler(makeGetRequest({ serverUrl: 'https://public-mcp.example/mcp' }));
+      assert.equal(res.status, 200);
+      const data = await res.json();
+      assert.deepEqual(data.tools, []);
+    });
+
     it('returns 400 for garbled URL', async () => {
       const res = await handler(makeGetRequest({ serverUrl: 'not a url at all' }));
       assert.equal(res.status, 400);
@@ -391,6 +442,40 @@ describe('api/mcp-proxy', () => {
       for (const k of Object.keys(capturedHeaders)) {
         assert.ok(!k.includes('\r') && !k.includes('\n'), `Header key contains CRLF: ${JSON.stringify(k)}`);
       }
+    });
+
+    it('does not automatically follow upstream redirects', async () => {
+      const redirectModes = [];
+      globalThis.fetch = async (url, opts) => {
+        redirectModes.push(opts?.redirect);
+        return makeMcpFetch({ tools: [] })(url, opts);
+      };
+      const res = await handler(makeGetRequest({ serverUrl: 'https://mcp.example.com/mcp' }));
+      assert.equal(res.status, 200);
+      assert.deepEqual(redirectModes, ['manual', 'manual', 'manual']);
+    });
+
+    it('revalidates the same host before repeated streamable HTTP requests to block DNS rebinding', async () => {
+      const resolutions = [
+        [PUBLIC_TEST_ADDRESS], // request validation
+        [PUBLIC_TEST_ADDRESS], // initialize POST
+        ['10.0.0.9'],          // notifications/initialized would rebind
+      ];
+      setResolveHostnameForTest(async (hostname) => {
+        assert.equal(hostname, 'mcp.example.com');
+        return resolutions.shift() ?? [PUBLIC_TEST_ADDRESS];
+      });
+      let upstreamCalls = 0;
+      globalThis.fetch = async (url, opts) => {
+        upstreamCalls += 1;
+        return makeMcpFetch({ tools: [] })(url, opts);
+      };
+
+      const res = await handler(makeGetRequest({ serverUrl: 'https://mcp.example.com/mcp' }));
+      assert.equal(res.status, 422);
+      const data = await res.json();
+      assert.match(data.error, /private\/reserved/i);
+      assert.equal(upstreamCalls, 1, 'rebound same-host request must be blocked before the second upstream fetch');
     });
   });
 

--- a/tests/mcp-proxy.test.mjs
+++ b/tests/mcp-proxy.test.mjs
@@ -322,6 +322,20 @@ describe('api/mcp-proxy', () => {
         ['loopback IPv4', '127.0.0.1'],
         ['ULA IPv6', 'fd00::1234'],
         ['link-local IPv6', 'fe80::1'],
+        // Embedded / reserved IPv6 encodings that previously slipped through
+        // the classifier (only dotted ::ffff: was decoded). Each decodes to a
+        // private/reserved IPv4 or is a reserved v6 range.
+        ['dotted v4-mapped loopback', '::ffff:127.0.0.1'],
+        ['hex v4-mapped loopback', '::ffff:7f00:1'],
+        ['hex v4-mapped metadata IP', '::ffff:a9fe:a9fe'],
+        ['uppercase hex v4-mapped RFC1918', '::FFFF:0A00:0001'],
+        ['NAT64 RFC1918', '64:ff9b::a00:1'],
+        ['NAT64 metadata IP', '64:ff9b::a9fe:a9fe'],
+        ['IPv4-compatible loopback', '::7f00:1'],
+        ['IPv4-compatible metadata IP', '::a9fe:a9fe'],
+        ['6to4 loopback', '2002:7f00:1::'],
+        ['6to4 metadata IP', '2002:a9fe:a9fe::'],
+        ['site-local IPv6', 'fec0::1'],
       ];
       for (const [label, address] of cases) {
         setResolvedAddresses([address]);
@@ -455,7 +469,14 @@ describe('api/mcp-proxy', () => {
       assert.deepEqual(redirectModes, ['manual', 'manual', 'manual']);
     });
 
-    it('revalidates the same host before repeated streamable HTTP requests to block DNS rebinding', async () => {
+    // NOTE: this validates the per-dispatch re-resolve + classifier path, NOT
+    // true socket-level rebind prevention. Vercel Edge fetch cannot pin the
+    // connection to a vetted IP (P1, issue #4674), so a residual rebind window
+    // between our resolve and fetch's own resolve is an accepted limitation.
+    // What this asserts: when a subsequent re-resolution returns a blocked
+    // address, revalidateBeforeFetch rejects it before the next upstream fetch,
+    // and the caller sees the GENERIC SSRF message (never the internal IP).
+    it('re-resolves and re-checks the same host before each streamable HTTP dispatch (classifier/revalidation path)', async () => {
       const resolutions = [
         [PUBLIC_TEST_ADDRESS], // request validation
         [PUBLIC_TEST_ADDRESS], // initialize POST
@@ -474,7 +495,10 @@ describe('api/mcp-proxy', () => {
       const res = await handler(makeGetRequest({ serverUrl: 'https://mcp.example.com/mcp' }));
       assert.equal(res.status, 422);
       const data = await res.json();
-      assert.match(data.error, /private\/reserved/i);
+      // Caller gets a generic message — the resolved internal IP (10.0.0.9)
+      // must never be echoed back (address-oracle SSRF review finding).
+      assert.match(data.error, /host is not allowed/i);
+      assert.doesNotMatch(data.error, /10\.0\.0\.9/, 'must NOT leak the blocked internal IP to the caller');
       assert.equal(upstreamCalls, 1, 'rebound same-host request must be blocked before the second upstream fetch');
     });
   });

--- a/tests/mcp-proxy.test.mjs
+++ b/tests/mcp-proxy.test.mjs
@@ -119,9 +119,17 @@ function makeMcpFetch({ initStatus = 200, listStatus = 200, callStatus = 200, to
 }
 
 let handler;
-let setResolveHostnameForTest;
+const TEST_RESOLVER_KEY = Symbol.for('worldmonitor.mcpProxy.resolveHostnameForTest');
 
 const PUBLIC_TEST_ADDRESS = '93.184.216.34';
+
+function setResolveHostnameForTest(resolver) {
+  if (typeof resolver === 'function') {
+    globalThis[TEST_RESOLVER_KEY] = resolver;
+  } else {
+    delete globalThis[TEST_RESOLVER_KEY];
+  }
+}
 
 function setResolvedAddresses(addresses) {
   setResolveHostnameForTest(async () => addresses);
@@ -140,7 +148,7 @@ describe('api/mcp-proxy', () => {
     // isCallerPremium import from server/. Test must follow the rename.
     const mod = await import(`../api/mcp-proxy.ts?t=${Date.now()}`);
     handler = mod.default;
-    setResolveHostnameForTest = mod.__setMcpProxyResolveHostnameForTest;
+    assert.equal(mod.__setMcpProxyResolveHostnameForTest, undefined);
     setResolvedAddresses([PUBLIC_TEST_ADDRESS]);
   });
 
@@ -361,6 +369,28 @@ describe('api/mcp-proxy', () => {
       assert.equal(res.status, 200);
       const data = await res.json();
       assert.deepEqual(data.tools, []);
+    });
+
+    it('ignores the test resolver outside NODE_TEST_CONTEXT', async () => {
+      const previousNodeTestContext = process.env.NODE_TEST_CONTEXT;
+      delete process.env.NODE_TEST_CONTEXT;
+      setResolvedAddresses(['10.0.0.5']);
+      globalThis.fetch = async (url, opts) => {
+        const u = new URL(url.toString());
+        if (u.hostname === 'cloudflare-dns.com') {
+          const type = u.searchParams.get('type');
+          if (type === 'A') return dnsJsonResponse([{ type: 1, data: PUBLIC_TEST_ADDRESS }]);
+          if (type === 'AAAA') return dnsJsonResponse([]);
+        }
+        return makeMcpFetch({ tools: [] })(url, opts);
+      };
+      try {
+        const res = await handler(makeGetRequest({ serverUrl: 'https://public-mcp.example/mcp' }));
+        assert.equal(res.status, 200);
+      } finally {
+        if (previousNodeTestContext === undefined) delete process.env.NODE_TEST_CONTEXT;
+        else process.env.NODE_TEST_CONTEXT = previousNodeTestContext;
+      }
     });
 
     it('returns 400 for garbled URL', async () => {


### PR DESCRIPTION
## Summary

- Adds DNS resolution and private/reserved resolved-address blocking to `/api/mcp-proxy`.
- Revalidates the original MCP host immediately before every streamable HTTP and SSE outbound fetch.
- Extracts the shipping webhook IP classifier into a shared helper so webhook delivery and mcp-proxy use the same blocked range policy.
- Forces MCP upstream fetches to `redirect: manual` so a public host cannot redirect the Edge fetch to a private target.

## Intent

Close #4674 by hardening the Pro-authenticated MCP proxy against SSRF via DNS-resolved private IPs and same-host DNS rebinding. The existing SSE endpoint event host/protocol pin is preserved.

Non-goals:
- No changes to MCP presets or UI.
- No work on adjacent security issues #4679-#4681.
- No attempt to implement Node-style socket DNS pinning in the Edge runtime.

## Validation Matrix

| Check | Reason | Status |
|---|---|---|
| `TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/mcp-proxy.test.mjs` | Direct MCP proxy SSRF/auth/rate-limit/SSE regression suite | Pass: 53 tests |
| `TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/shipping-v2-handler.test.mjs` | Shared IP classifier extraction preserves webhook SSRF behavior | Pass: 26 tests |
| `npm run typecheck:api` | API/server TypeScript and Convex string-call audit | Pass |
| `node --test tests/edge-functions.test.mjs` | Edge no-node/import guard after API change | Pass: 206 tests |
| `git diff --check` | Whitespace/conflict marker hygiene | Pass |

## Review Gates

- Baseline reviewer: Pass. Checked SSRF path, redirect handling, DNS revalidation, Edge compatibility, and test scope.
- Code Review Expert: Pass. No blocking findings after tightening redirect behavior and fail-closed DNS query handling.
- Outcome reviewer: Pass. Acceptance criteria are covered by focused tests, and the Edge runtime pinning limitation is documented.

## Documentation

No external docs change. A code comment documents that Vercel Edge `fetch` does not expose socket-level DNS pinning, so this implementation revalidates immediately before every outbound request instead.

## Screenshots / UI Evidence

Not applicable. API/security-only change with no user-visible UI.

## Residual Findings

- Vercel Edge does not expose a Node-style `lookup` hook to pin the actual TLS connection to the vetted address. This PR therefore uses fail-closed DNS-over-HTTPS validation plus immediate per-request revalidation, and records that runtime limitation in code.