### PR TITLE
fix(security): reject replayed internal MCP HMAC requests

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/user/worldmonitor/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/user/worldmonitor/node_modules

--- a/server/_shared/mcp-internal-hmac.ts
+++ b/server/_shared/mcp-internal-hmac.ts
@@ -17,7 +17,7 @@
  * `/api/news/v1/list-feed-digest?lang=en` cannot be replayed against
  * `/api/intelligence/v1/deduct-situation` (Codex round-2 review finding).
  *
- *   payload   = `${ts}:${method}:${pathname}:${queryHash}:${bodyHash}:${userId}`
+ *   payload   = `${ts}:${method}:${pathname}:${queryHash}:${bodyHash}:${userId}:${nonce}`
  *   queryHash = SHA-256(canonicalQueryString(URL))
  *   bodyHash  = SHA-256(bodyBytes)        // SHA-256("") for GET / no body
  *   sig       = HMAC-SHA-256(secret, payload)
@@ -38,6 +38,9 @@ export const INTERNAL_MCP_SIG_HEADER = 'X-WM-MCP-Internal';
 
 /** Header carrying the userId the signature claims to represent. */
 export const INTERNAL_MCP_USER_ID_HEADER = 'X-WM-MCP-User-Id';
+
+/** Header carrying the one-shot request nonce bound into the HMAC payload. */
+export const INTERNAL_MCP_NONCE_HEADER = 'X-WM-MCP-Nonce';
 
 /** Trusted markers set by the gateway AFTER successful verify. Downstream
  *  handlers (`isCallerPremium`) read these — never the inbound headers.
@@ -75,6 +78,10 @@ export function getInternalMcpVerifiedNonce(): string {
 /** Timestamp window (seconds) for replay defense. Default per plan: 30s.
  *  Loosen via env if production observes clock skew. */
 export const INTERNAL_MCP_TIMESTAMP_WINDOW_SECONDS = 30;
+
+/** Replay-cache TTL. Slightly longer than the accepted timestamp window so
+ * duplicate signatures are rejected for the whole freshness interval. */
+export const INTERNAL_MCP_REPLAY_CACHE_TTL_SECONDS = INTERNAL_MCP_TIMESTAMP_WINDOW_SECONDS + 5;
 
 // ---------------------------------------------------------------------------
 // Canonicalisation primitives — exported so U8's verifier produces byte-
@@ -153,8 +160,9 @@ export function buildHmacPayload(args: {
   queryHash: string;
   bodyHash: string;
   userId: string;
+  nonce: string;
 }): string {
-  return `${args.ts}:${args.method.toUpperCase()}:${args.pathname}:${args.queryHash}:${args.bodyHash}:${args.userId}`;
+  return `${args.ts}:${args.method.toUpperCase()}:${args.pathname}:${args.queryHash}:${args.bodyHash}:${args.userId}:${args.nonce}`;
 }
 
 // ---------------------------------------------------------------------------
@@ -195,8 +203,21 @@ export interface SignedInternalMcpHeaders {
   signature: string;
   /** UserId the signature claims; sent as `X-WM-MCP-User-Id`. */
   userId: string;
+  /** One-shot nonce bound into the signature payload. */
+  nonce: string;
   /** Unix-seconds timestamp embedded in the signature payload. */
   ts: number;
+}
+
+function makeInternalMcpNonce(): string {
+  if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function isValidInternalMcpNonce(nonce: string): boolean {
+  return /^[A-Za-z0-9_-]{16,128}$/.test(nonce);
 }
 
 /**
@@ -214,6 +235,8 @@ export interface SignedInternalMcpHeaders {
  * @param userId  The Pro userId being attributed to this request.
  * @param secret  `MCP_INTERNAL_HMAC_SECRET`. The function does NOT read env
  *                directly — caller passes it explicitly so tests can inject.
+ * @param nonce   Optional test injection. Production callers get a fresh
+ *                random UUID per signed request.
  * @param now     Override Unix-seconds (test injection); defaults to `Date.now()/1000`.
  */
 export async function signInternalMcpRequest(args: {
@@ -222,10 +245,13 @@ export async function signInternalMcpRequest(args: {
   body?: BodyInit | null | undefined;
   userId: string;
   secret: string;
+  nonce?: string;
   now?: number;
 }): Promise<SignedInternalMcpHeaders> {
   if (!args.userId) throw new Error('signInternalMcpRequest: userId is required');
   if (!args.secret) throw new Error('signInternalMcpRequest: secret is required');
+  const nonce = args.nonce ?? makeInternalMcpNonce();
+  if (!isValidInternalMcpNonce(nonce)) throw new Error('signInternalMcpRequest: nonce must be 16-128 URL-safe characters');
 
   const url = args.url instanceof URL ? args.url : new URL(args.url);
   const ts = Math.floor(args.now ?? Date.now() / 1000);
@@ -238,9 +264,10 @@ export async function signInternalMcpRequest(args: {
     queryHash,
     bodyHash,
     userId: args.userId,
+    nonce,
   });
   const sig = await hmacSha256Base64Url(args.secret, payload);
-  return { signature: `${ts}.${sig}`, userId: args.userId, ts };
+  return { signature: `${ts}.${sig}`, userId: args.userId, nonce, ts };
 }
 
 /**
@@ -295,6 +322,7 @@ export function buildInternalMcpHeaders(signed: SignedInternalMcpHeaders): Recor
   return {
     [INTERNAL_MCP_SIG_HEADER]: signed.signature,
     [INTERNAL_MCP_USER_ID_HEADER]: signed.userId,
+    [INTERNAL_MCP_NONCE_HEADER]: signed.nonce,
   };
 }
 
@@ -310,6 +338,8 @@ export function buildInternalMcpHeaders(signed: SignedInternalMcpHeaders): Recor
 export interface VerifiedInternalMcpRequest {
   /** UserId carried by the verified `X-WM-MCP-User-Id` header. */
   userId: string;
+  /** One-shot nonce carried by `X-WM-MCP-Nonce` and bound into the HMAC. */
+  nonce: string;
 }
 
 /**
@@ -354,16 +384,17 @@ function parseSignatureHeader(value: string | null): { ts: number; sigB64u: stri
 /**
  * Verify an inbound internal-MCP request signed by U7's sign helpers.
  *
- * Reads `X-WM-MCP-Internal` (`<ts>.<base64url-sig>`) and `X-WM-MCP-User-Id`
- * from the request. Re-canonicalises the inbound request the SAME way the
- * signer did — exporting/importing canonicalQueryString, sha256Hex,
- * buildHmacPayload from this module is the single-source-of-truth invariant.
+ * Reads `X-WM-MCP-Internal` (`<ts>.<base64url-sig>`), `X-WM-MCP-User-Id`,
+ * and `X-WM-MCP-Nonce` from the request. Re-canonicalises the inbound request
+ * the SAME way the signer did — exporting/importing canonicalQueryString,
+ * sha256Hex, buildHmacPayload from this module is the single-source-of-truth
+ * invariant.
  *
  * Body handling: `req.clone().bytes()` reads the body as raw bytes; cloning
  * preserves the original body for the downstream handler. Body-less requests
  * (GET) hash to SHA-256("") consistently between sign and verify.
  *
- * Returns `{userId}` on success, `null` on ANY verification failure
+ * Returns `{userId, nonce}` on success, `null` on ANY verification failure
  * (missing headers, malformed signature, timestamp out of window, signature
  * mismatch). The gateway treats null as 401 `invalid_internal_mcp_signature`
  * and MUST NOT fall through to other auth paths.
@@ -383,7 +414,8 @@ export async function verifyInternalMcpRequest(
 
   const sigHeader = req.headers.get(INTERNAL_MCP_SIG_HEADER);
   const userId = req.headers.get(INTERNAL_MCP_USER_ID_HEADER);
-  if (!sigHeader || !userId) return null;
+  const nonce = req.headers.get(INTERNAL_MCP_NONCE_HEADER);
+  if (!sigHeader || !userId || !nonce || !isValidInternalMcpNonce(nonce)) return null;
 
   const parsed = parseSignatureHeader(sigHeader);
   if (!parsed) return null;
@@ -444,10 +476,11 @@ export async function verifyInternalMcpRequest(
     queryHash,
     bodyHash,
     userId,
+    nonce,
   });
   const expectedSig = await hmacSha256Base64Url(secret, expectedPayload);
 
   const ok = await timingSafeStringEqual(expectedSig, sigB64u);
   if (!ok) return null;
-  return { userId };
+  return { userId, nonce };
 }

--- a/server/_shared/mcp-internal-hmac.ts
+++ b/server/_shared/mcp-internal-hmac.ts
@@ -79,9 +79,16 @@ export function getInternalMcpVerifiedNonce(): string {
  *  Loosen via env if production observes clock skew. */
 export const INTERNAL_MCP_TIMESTAMP_WINDOW_SECONDS = 30;
 
-/** Replay-cache TTL. Slightly longer than the accepted timestamp window so
- * duplicate signatures are rejected for the whole freshness interval. */
-export const INTERNAL_MCP_REPLAY_CACHE_TTL_SECONDS = INTERNAL_MCP_TIMESTAMP_WINDOW_SECONDS + 5;
+/** Replay-cache TTL. The verify timestamp check is SYMMETRIC — a signature
+ * is accepted whenever `Math.abs(nowSec - ts) <= WINDOW`, i.e. across a full
+ * `2 * WINDOW` span (up to WINDOW seconds "in the past" and WINDOW seconds
+ * "in the future" relative to the gateway clock). The nonce entry MUST
+ * outlive that entire acceptance span regardless of clock-skew direction:
+ * if the signer's clock leads the gateway's, a nonce cached at first sight
+ * could otherwise expire while the same signature is still inside the
+ * acceptance window, reopening the replay. So the TTL must be at least
+ * `2 * WINDOW`; the small margin absorbs Redis EX rounding / propagation. */
+export const INTERNAL_MCP_REPLAY_CACHE_TTL_SECONDS = 2 * INTERNAL_MCP_TIMESTAMP_WINDOW_SECONDS + 5;
 
 // ---------------------------------------------------------------------------
 // Canonicalisation primitives — exported so U8's verifier produces byte-

--- a/server/_shared/usage.ts
+++ b/server/_shared/usage.ts
@@ -70,6 +70,10 @@ export type RequestReason =
   // Distinct from auth_401 so telemetry separates malformed requests
   // from auth failures.
   | 'malformed_request'
+  // Fail-closed rejection when the internal-MCP replay-nonce cache (Redis)
+  // is unavailable so an atomic claim can't be made. Distinct from auth_401
+  // so a Redis outage is not conflated with genuine signature/auth failures.
+  | 'replay_cache_unavailable'
   | 'unknown_route'
   | 'method_not_allowed'
   | 'cors_error'

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -23,9 +23,12 @@ import { resolveClerkSession } from './_shared/auth-session';
 import {
   INTERNAL_MCP_SIG_HEADER,
   INTERNAL_MCP_USER_ID_HEADER,
+  INTERNAL_MCP_NONCE_HEADER,
   INTERNAL_MCP_VERIFIED_HEADER,
   TRUSTED_USER_ID_HEADER,
+  INTERNAL_MCP_REPLAY_CACHE_TTL_SECONDS,
   getInternalMcpVerifiedNonce,
+  sha256Hex,
   verifyInternalMcpRequest,
 } from './_shared/mcp-internal-hmac';
 import { buildUsageIdentity, hashKeySync, type UsageIdentityInput } from './_shared/usage-identity';
@@ -79,6 +82,18 @@ export const serverOptions: ServerOptions = { onError: mapErrorToResponse };
  * F8 (U7+U8 review pass).
  */
 const MAX_INTERNAL_MCP_BODY = 256 * 1024;
+
+type InternalMcpReplayClaim = 'fresh' | 'replay' | 'unavailable';
+
+async function claimInternalMcpReplayNonce(userId: string, nonce: string): Promise<InternalMcpReplayClaim> {
+  const digest = await sha256Hex(`${userId}:${nonce}`);
+  const key = `internal-mcp-replay:v1:${digest}`;
+  const result = await runRedisPipeline([
+    ['SET', key, '1', 'EX', INTERNAL_MCP_REPLAY_CACHE_TTL_SECONDS, 'NX'],
+  ]);
+  if (result.length === 0) return 'unavailable';
+  return result[0]?.result === 'OK' ? 'fresh' : 'replay';
+}
 
 // --- Edge cache tier definitions ---
 // NOTE: This map is shared across all domain bundles (~3KB). Kept centralised for
@@ -878,6 +893,23 @@ export function createDomainGateway(
           { status: 401, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
         );
       }
+      const replayClaim = await claimInternalMcpReplayNonce(verified.userId, verified.nonce);
+      if (replayClaim === 'unavailable') {
+        // Fail closed: without an atomic replay-cache claim, a valid captured
+        // signature could be reused throughout the timestamp window.
+        emitRequest(503, 'auth_401', null);
+        return new Response(
+          JSON.stringify({ error: 'internal_mcp_replay_cache_unavailable' }),
+          { status: 503, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+        );
+      }
+      if (replayClaim === 'replay') {
+        emitRequest(401, 'auth_401', null);
+        return new Response(
+          JSON.stringify({ error: 'invalid_internal_mcp_signature' }),
+          { status: 401, headers: { 'Content-Type': 'application/json', ...corsHeaders } },
+        );
+      }
       // Entitlement re-check at the gateway: the MCP edge already verifies
       // tier ≥ 1 + mcpAccess + validUntil before signing the outbound
       // fetch (api/mcp.ts). This second check defends against (a) the
@@ -929,6 +961,7 @@ export function createDomainGateway(
       const trusted = new Headers(request.headers);
       trusted.delete(INTERNAL_MCP_SIG_HEADER);
       trusted.delete(INTERNAL_MCP_USER_ID_HEADER);
+      trusted.delete(INTERNAL_MCP_NONCE_HEADER);
       trusted.set(INTERNAL_MCP_VERIFIED_HEADER, getInternalMcpVerifiedNonce());
       trusted.set(TRUSTED_USER_ID_HEADER, verified.userId);
       const rebuildInit: RequestInit = { method: request.method, headers: trusted };

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -92,7 +92,9 @@ async function claimInternalMcpReplayNonce(userId: string, nonce: string): Promi
     ['SET', key, '1', 'EX', INTERNAL_MCP_REPLAY_CACHE_TTL_SECONDS, 'NX'],
   ]);
   if (result.length === 0) return 'unavailable';
-  return result[0]?.result === 'OK' ? 'fresh' : 'replay';
+  const claim = result[0] as { result?: unknown; error?: unknown } | undefined;
+  if (claim?.error) return 'unavailable';
+  return claim?.result === 'OK' ? 'fresh' : 'replay';
 }
 
 // --- Edge cache tier definitions ---

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -899,7 +899,7 @@ export function createDomainGateway(
       if (replayClaim === 'unavailable') {
         // Fail closed: without an atomic replay-cache claim, a valid captured
         // signature could be reused throughout the timestamp window.
-        emitRequest(503, 'auth_401', null);
+        emitRequest(503, 'replay_cache_unavailable', null);
         return new Response(
           JSON.stringify({ error: 'internal_mcp_replay_cache_unavailable' }),
           { status: 503, headers: { 'Content-Type': 'application/json', ...corsHeaders } },

--- a/tests/gateway-internal-mcp.test.mjs
+++ b/tests/gateway-internal-mcp.test.mjs
@@ -112,6 +112,7 @@ function entitlementForUser(userId) {
 function installFetchStub(opts = {}) {
   const overrideEntitlement = opts.entitlement;
   const replayCacheUnavailable = opts.replayCacheUnavailable === true;
+  const replayCacheCommandError = opts.replayCacheCommandError === true;
   globalThis.fetch = async (input, init) => {
     const url = typeof input === 'string' ? input : input?.url;
     if (typeof url === 'string' && url.includes('redis.test/get/')) {
@@ -130,6 +131,7 @@ function installFetchStub(opts = {}) {
       const commands = JSON.parse(String(init?.body ?? '[]'));
       const results = commands.map((cmd) => {
         if (cmd?.[0] === 'SET' && cmd?.[3] === 'EX' && cmd?.[5] === 'NX') {
+          if (replayCacheCommandError) return { error: 'WRONGTYPE Operation against a key holding the wrong kind of value' };
           const key = String(cmd[1]);
           if (replayCacheKeys.has(key)) return { result: null };
           replayCacheKeys.add(key);
@@ -343,6 +345,16 @@ describe('gateway internal-MCP HMAC verify — happy paths', () => {
     assert.equal(res.status, 503, 'replay-cache outage must fail closed');
     assert.deepEqual(await res.json(), { error: 'internal_mcp_replay_cache_unavailable' });
     assert.equal(lastHandlerRequest, null, 'handler must not run when replay cache cannot claim the nonce');
+  });
+
+  it('valid HMAC fails closed when Redis returns a command-level replay-cache error', async () => {
+    installFetchStub({ replayCacheCommandError: true });
+    const handler = makeGateway();
+    const req = await buildSignedRequest();
+    const res = await handler(req);
+    assert.equal(res.status, 503, 'Redis command-level errors must be cache-unavailable, not replay');
+    assert.deepEqual(await res.json(), { error: 'internal_mcp_replay_cache_unavailable' });
+    assert.equal(lastHandlerRequest, null, 'handler must not run when Redis cannot atomically claim the nonce');
   });
 
   it('isCallerPremium returns true for a verified-marker request from tier-1 mcpAccess user', async () => {

--- a/tests/gateway-internal-mcp.test.mjs
+++ b/tests/gateway-internal-mcp.test.mjs
@@ -29,6 +29,8 @@ import {
   INTERNAL_MCP_NONCE_HEADER,
   INTERNAL_MCP_VERIFIED_HEADER,
   TRUSTED_USER_ID_HEADER,
+  INTERNAL_MCP_TIMESTAMP_WINDOW_SECONDS,
+  INTERNAL_MCP_REPLAY_CACHE_TTL_SECONDS,
 } from '../server/_shared/mcp-internal-hmac.ts';
 import { isCallerPremium } from '../server/_shared/premium-check.ts';
 
@@ -50,7 +52,9 @@ const ORIGINAL_ENV = { ...process.env };
 // to the handler so tests can assert what propagated through.
 // ---------------------------------------------------------------------------
 let lastHandlerRequest = null;
-let replayCacheKeys = new Set();
+// Map<key, expiryMs> — models Redis EX-based expiry so tests can exercise
+// TTL-vs-acceptance-window interactions, not just presence/absence.
+let replayCacheKeys = new Map();
 
 function makeGateway() {
   return createDomainGateway([
@@ -133,8 +137,13 @@ function installFetchStub(opts = {}) {
         if (cmd?.[0] === 'SET' && cmd?.[3] === 'EX' && cmd?.[5] === 'NX') {
           if (replayCacheCommandError) return { error: 'WRONGTYPE Operation against a key holding the wrong kind of value' };
           const key = String(cmd[1]);
-          if (replayCacheKeys.has(key)) return { result: null };
-          replayCacheKeys.add(key);
+          const ttlSeconds = Number(cmd[4]);
+          const nowMs = Date.now();
+          const existingExpiry = replayCacheKeys.get(key);
+          // Honor Redis EX expiry: a key past its TTL is treated as absent, so
+          // a claim after expiry succeeds exactly as production Redis would.
+          if (existingExpiry !== undefined && existingExpiry > nowMs) return { result: null };
+          replayCacheKeys.set(key, nowMs + ttlSeconds * 1000);
           return { result: 'OK' };
         }
         return { result: 0 };
@@ -174,7 +183,7 @@ function disableRedisForLegacyGatewayCheck() {
 
 beforeEach(() => {
   lastHandlerRequest = null;
-  replayCacheKeys = new Set();
+  replayCacheKeys = new Map();
   process.env.MCP_INTERNAL_HMAC_SECRET = HMAC_SECRET;
   process.env.CONVEX_SITE_URL = CONVEX_SITE;
   process.env.CONVEX_SERVER_SHARED_SECRET = CONVEX_SECRET;
@@ -324,6 +333,61 @@ describe('gateway internal-MCP HMAC verify — happy paths', () => {
     assert.equal(replay.status, 401, 'duplicate signed nonce must be rejected within the timestamp window');
     assert.deepEqual(await replay.json(), { error: 'invalid_internal_mcp_signature' });
     assert.equal(lastHandlerRequest, null, 'replay must not reach the handler or trusted-marker path');
+  });
+
+  it('replay inside the symmetric acceptance span but past the old short TTL is still rejected', async () => {
+    // Regression for the P2 finding. The verify timestamp check is SYMMETRIC
+    // (|nowSec - ts| <= WINDOW), so a signature stays acceptable across a full
+    // 2*WINDOW span. The old TTL (WINDOW + 5 = 35s) could expire the nonce
+    // while the signature was still fresh when the signer's clock LEADS the
+    // gateway's, reopening the replay. The TTL must cover the whole 2*WINDOW
+    // acceptance span (now 2*WINDOW + 5 = 65s).
+    assert.ok(
+      INTERNAL_MCP_REPLAY_CACHE_TTL_SECONDS >= 2 * INTERNAL_MCP_TIMESTAMP_WINDOW_SECONDS,
+      'replay-cache TTL must cover the full 2*WINDOW symmetric acceptance span',
+    );
+
+    const WINDOW = INTERNAL_MCP_TIMESTAMP_WINDOW_SECONDS;
+    const handler = makeGateway();
+    const url = 'https://api.worldmonitor.app/api/news/v1/summarize-article';
+    const body = JSON.stringify({ provider: 'auto', mode: 'brief' });
+    const tsSec = 1_800_000_000; // fixed signer timestamp (unix seconds)
+    const signed = await signInternalMcpRequest({
+      method: 'POST',
+      url,
+      body,
+      userId: PRO_USER_ID,
+      secret: HMAC_SECRET,
+      now: tsSec,
+      nonce: 'replay_nonce_skew_4681',
+    });
+    const headers = {
+      'Content-Type': 'application/json',
+      [INTERNAL_MCP_SIG_HEADER]: signed.signature,
+      [INTERNAL_MCP_USER_ID_HEADER]: signed.userId,
+      [INTERNAL_MCP_NONCE_HEADER]: signed.nonce,
+    };
+
+    const realDateNow = Date.now;
+    try {
+      // Signer clock leads the gateway by WINDOW seconds: first sighting sits
+      // at the earliest edge of the acceptance window; the nonce is cached here.
+      Date.now = () => (tsSec - WINDOW) * 1000;
+      const first = await handler(new Request(url, { method: 'POST', headers, body }));
+      assert.equal(first.status, 200, `first request at acceptance-window start should pass, body=${await first.clone().text()}`);
+
+      // Replay arrives 2*WINDOW seconds later — the latest edge of the SAME
+      // acceptance window. That is past the old (WINDOW + 5) TTL, but the
+      // signature is still fresh, so the nonce MUST still be cached → 401.
+      lastHandlerRequest = null;
+      Date.now = () => (tsSec + WINDOW) * 1000;
+      const replay = await handler(new Request(url, { method: 'POST', headers, body }));
+      assert.equal(replay.status, 401, 'replay inside the acceptance span but past the old short TTL must still be rejected');
+      assert.deepEqual(await replay.json(), { error: 'invalid_internal_mcp_signature' });
+      assert.equal(lastHandlerRequest, null, 'replay must not reach the handler');
+    } finally {
+      Date.now = realDateNow;
+    }
   });
 
   it('same request shape with unique signed nonces continues to succeed', async () => {

--- a/tests/gateway-internal-mcp.test.mjs
+++ b/tests/gateway-internal-mcp.test.mjs
@@ -11,9 +11,10 @@
  * side share canonicalisation primitives, so any drift between the two
  * surfaces immediately as a 401 here.
  *
- * Convex `getEntitlements` is stubbed by intercepting globalThis.fetch
- * for `${CONVEX_SITE_URL}/api/internal-entitlements`. Upstash is left
- * unset so the rate limiter / entitlement cache paths are no-ops.
+ * Convex `getEntitlements` and the internal-MCP replay cache are stubbed by
+ * intercepting globalThis.fetch. The replay cache stub implements Redis
+ * `SET ... EX ... NX` semantics so same-nonce replays exercise the production
+ * gateway decision point.
  */
 
 import { strict as assert } from 'node:assert';
@@ -25,6 +26,7 @@ import {
   getInternalMcpVerifiedNonce,
   INTERNAL_MCP_SIG_HEADER,
   INTERNAL_MCP_USER_ID_HEADER,
+  INTERNAL_MCP_NONCE_HEADER,
   INTERNAL_MCP_VERIFIED_HEADER,
   TRUSTED_USER_ID_HEADER,
 } from '../server/_shared/mcp-internal-hmac.ts';
@@ -48,6 +50,7 @@ const ORIGINAL_ENV = { ...process.env };
 // to the handler so tests can assert what propagated through.
 // ---------------------------------------------------------------------------
 let lastHandlerRequest = null;
+let replayCacheKeys = new Set();
 
 function makeGateway() {
   return createDomainGateway([
@@ -108,8 +111,43 @@ function entitlementForUser(userId) {
 
 function installFetchStub(opts = {}) {
   const overrideEntitlement = opts.entitlement;
+  const replayCacheUnavailable = opts.replayCacheUnavailable === true;
   globalThis.fetch = async (input, init) => {
     const url = typeof input === 'string' ? input : input?.url;
+    if (typeof url === 'string' && url.includes('redis.test/get/')) {
+      return new Response(JSON.stringify({ result: undefined }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (typeof url === 'string' && url.includes('redis.test/pipeline')) {
+      if (replayCacheUnavailable) {
+        return new Response(JSON.stringify([{ error: 'redis unavailable' }]), {
+          status: 503,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      const commands = JSON.parse(String(init?.body ?? '[]'));
+      const results = commands.map((cmd) => {
+        if (cmd?.[0] === 'SET' && cmd?.[3] === 'EX' && cmd?.[5] === 'NX') {
+          const key = String(cmd[1]);
+          if (replayCacheKeys.has(key)) return { result: null };
+          replayCacheKeys.add(key);
+          return { result: 'OK' };
+        }
+        return { result: 0 };
+      });
+      return new Response(JSON.stringify(results), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    if (typeof url === 'string' && url === 'https://redis.test/') {
+      return new Response(JSON.stringify({ result: 'OK' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
     if (typeof url === 'string' && url.includes('/api/internal-entitlements')) {
       const body = JSON.parse(init?.body ?? '{}');
       const ent = overrideEntitlement ? overrideEntitlement(body.userId) : entitlementForUser(body.userId);
@@ -127,14 +165,19 @@ function resetEnv() {
   Object.assign(process.env, ORIGINAL_ENV);
 }
 
+function disableRedisForLegacyGatewayCheck() {
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+}
+
 beforeEach(() => {
   lastHandlerRequest = null;
+  replayCacheKeys = new Set();
   process.env.MCP_INTERNAL_HMAC_SECRET = HMAC_SECRET;
   process.env.CONVEX_SITE_URL = CONVEX_SITE;
   process.env.CONVEX_SERVER_SHARED_SECRET = CONVEX_SECRET;
-  // Disable Upstash so rate-limit / cache paths are no-ops.
-  delete process.env.UPSTASH_REDIS_REST_URL;
-  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'redis-test-token';
   // The gateway's envelope expects WORLDMONITOR_VALID_KEYS to exist for the
   // legacy wm_ key path tests.
   process.env.WORLDMONITOR_VALID_KEYS = 'wm_test_key_123';
@@ -165,6 +208,7 @@ async function buildSignedRequest({
       'Content-Type': 'application/json',
       [INTERNAL_MCP_SIG_HEADER]: signed.signature,
       [INTERNAL_MCP_USER_ID_HEADER]: signed.userId,
+      [INTERNAL_MCP_NONCE_HEADER]: signed.nonce,
       ...extraHeaders,
     },
     body: method === 'GET' ? undefined : body,
@@ -251,6 +295,56 @@ describe('gateway internal-MCP HMAC verify — happy paths', () => {
     );
   });
 
+  it('same signed internal-MCP request succeeds once, then replay is rejected before handler trust', async () => {
+    const handler = makeGateway();
+    const url = 'https://api.worldmonitor.app/api/news/v1/summarize-article';
+    const body = JSON.stringify({ provider: 'auto', mode: 'brief' });
+    const signed = await signInternalMcpRequest({
+      method: 'POST',
+      url,
+      body,
+      userId: PRO_USER_ID,
+      secret: HMAC_SECRET,
+      nonce: 'replay_nonce_4681',
+    });
+    const headers = {
+      'Content-Type': 'application/json',
+      [INTERNAL_MCP_SIG_HEADER]: signed.signature,
+      [INTERNAL_MCP_USER_ID_HEADER]: signed.userId,
+      [INTERNAL_MCP_NONCE_HEADER]: signed.nonce,
+    };
+
+    const first = await handler(new Request(url, { method: 'POST', headers, body }));
+    assert.equal(first.status, 200, `first signed request should pass, body=${await first.clone().text()}`);
+
+    lastHandlerRequest = null;
+    const replay = await handler(new Request(url, { method: 'POST', headers, body }));
+    assert.equal(replay.status, 401, 'duplicate signed nonce must be rejected within the timestamp window');
+    assert.deepEqual(await replay.json(), { error: 'invalid_internal_mcp_signature' });
+    assert.equal(lastHandlerRequest, null, 'replay must not reach the handler or trusted-marker path');
+  });
+
+  it('same request shape with unique signed nonces continues to succeed', async () => {
+    const handler = makeGateway();
+    const first = await buildSignedRequest();
+    const firstRes = await handler(first);
+    assert.equal(firstRes.status, 200, `first unique nonce should pass, body=${await firstRes.clone().text()}`);
+
+    const second = await buildSignedRequest();
+    const secondRes = await handler(second);
+    assert.equal(secondRes.status, 200, `second unique nonce should pass, body=${await secondRes.clone().text()}`);
+  });
+
+  it('valid HMAC fails closed when the replay cache is unavailable', async () => {
+    installFetchStub({ replayCacheUnavailable: true });
+    const handler = makeGateway();
+    const req = await buildSignedRequest();
+    const res = await handler(req);
+    assert.equal(res.status, 503, 'replay-cache outage must fail closed');
+    assert.deepEqual(await res.json(), { error: 'internal_mcp_replay_cache_unavailable' });
+    assert.equal(lastHandlerRequest, null, 'handler must not run when replay cache cannot claim the nonce');
+  });
+
   it('isCallerPremium returns true for a verified-marker request from tier-1 mcpAccess user', async () => {
     // Synthesize the post-gateway request shape: trusted markers set,
     // no inbound HMAC headers (gateway already consumed them).
@@ -300,6 +394,7 @@ describe('gateway internal-MCP HMAC verify — happy paths', () => {
       headers: {
         [INTERNAL_MCP_SIG_HEADER]: signed.signature,
         [INTERNAL_MCP_USER_ID_HEADER]: signed.userId,
+        [INTERNAL_MCP_NONCE_HEADER]: signed.nonce,
       },
     });
     const res = await handler(req);
@@ -315,6 +410,7 @@ describe('gateway internal-MCP HMAC verify — happy paths', () => {
       headers: {
         [INTERNAL_MCP_SIG_HEADER]: signed.signature,
         [INTERNAL_MCP_USER_ID_HEADER]: signed.userId,
+        [INTERNAL_MCP_NONCE_HEADER]: signed.nonce,
       },
     });
     const res = await handler(req);
@@ -342,6 +438,7 @@ describe('gateway internal-MCP HMAC verify — happy paths', () => {
       headers: {
         [INTERNAL_MCP_SIG_HEADER]: signed.signature,
         [INTERNAL_MCP_USER_ID_HEADER]: signed.userId,
+        [INTERNAL_MCP_NONCE_HEADER]: signed.nonce,
       },
     });
     const res = await handler(req);
@@ -358,6 +455,7 @@ describe('gateway internal-MCP HMAC verify — happy paths', () => {
       headers: {
         [INTERNAL_MCP_SIG_HEADER]: signed.signature,
         [INTERNAL_MCP_USER_ID_HEADER]: signed.userId,
+        [INTERNAL_MCP_NONCE_HEADER]: signed.nonce,
       },
     });
     const res = await handler(req);
@@ -374,6 +472,7 @@ describe('gateway internal-MCP HMAC verify — happy paths', () => {
       headers: {
         [INTERNAL_MCP_SIG_HEADER]: signed.signature,
         [INTERNAL_MCP_USER_ID_HEADER]: signed.userId,
+        [INTERNAL_MCP_NONCE_HEADER]: signed.nonce,
       },
     });
     const res = await handler(req);
@@ -396,6 +495,7 @@ describe('gateway internal-MCP HMAC verify — happy paths', () => {
       headers: {
         [INTERNAL_MCP_SIG_HEADER]: signed.signature,
         [INTERNAL_MCP_USER_ID_HEADER]: signed.userId,
+        [INTERNAL_MCP_NONCE_HEADER]: signed.nonce,
       },
     });
     const res = await handler(req);
@@ -457,6 +557,7 @@ describe('gateway internal-MCP HMAC verify — error paths', () => {
         'Content-Type': 'application/json',
         [INTERNAL_MCP_SIG_HEADER]: signed.signature,
         [INTERNAL_MCP_USER_ID_HEADER]: signed.userId,
+        [INTERNAL_MCP_NONCE_HEADER]: signed.nonce,
       },
       body,
     });
@@ -475,6 +576,7 @@ describe('gateway internal-MCP HMAC verify — error paths', () => {
         'Content-Type': 'application/json',
         [INTERNAL_MCP_SIG_HEADER]: signed.signature,
         [INTERNAL_MCP_USER_ID_HEADER]: signed.userId,
+        [INTERNAL_MCP_NONCE_HEADER]: signed.nonce,
       },
       body: JSON.stringify({ x: 1 }),
     });
@@ -494,6 +596,7 @@ describe('gateway internal-MCP HMAC verify — error paths', () => {
         'Content-Type': 'application/json',
         [INTERNAL_MCP_SIG_HEADER]: signed.signature,
         [INTERNAL_MCP_USER_ID_HEADER]: signed.userId,
+        [INTERNAL_MCP_NONCE_HEADER]: signed.nonce,
       },
       body: tampered,
     });
@@ -605,6 +708,7 @@ describe('gateway internal-MCP HMAC verify — error paths', () => {
   it('legacy wm_ caller (no internal-MCP headers) → unaffected by missing MCP_INTERNAL_HMAC_SECRET', async () => {
     delete process.env.MCP_PRO_GRANT_HMAC_SECRET;
     delete process.env.MCP_INTERNAL_HMAC_SECRET;
+    disableRedisForLegacyGatewayCheck();
     const handler = makeGateway();
     // wm_-key flow: send a valid WORLDMONITOR_VALID_KEYS key on a non-tier-gated route.
     // Use list-feed-digest which is public-ish but in routes table.
@@ -627,6 +731,7 @@ describe('gateway internal-MCP HMAC verify — error paths', () => {
 // ===========================================================================
 describe('gateway internal-MCP — header injection defense', () => {
   it('client-injected x-wm-mcp-internal-verified is stripped before any logic', async () => {
+    disableRedisForLegacyGatewayCheck();
     const handler = makeGateway();
     // External attacker sends a guessed marker value (constant '1', the
     // pre-nonce design) with a hopeful spoof of x-user-id.
@@ -659,6 +764,7 @@ describe('gateway internal-MCP — header injection defense', () => {
   });
 
   it('attacker who somehow guesses the per-process nonce ALSO gets stripped at gateway entry', async () => {
+    disableRedisForLegacyGatewayCheck();
     const handler = makeGateway();
     const req = new Request('https://api.worldmonitor.app/api/news/v1/list-feed-digest', {
       method: 'GET',
@@ -727,6 +833,7 @@ describe('gateway internal-MCP — header injection defense', () => {
         'X-WorldMonitor-Key': 'wm_test_key_123',
         [INTERNAL_MCP_SIG_HEADER]: signed.signature,
         [INTERNAL_MCP_USER_ID_HEADER]: signed.userId,
+        [INTERNAL_MCP_NONCE_HEADER]: signed.nonce,
       },
     });
     const res = await handler(req);
@@ -741,6 +848,7 @@ describe('gateway internal-MCP — header injection defense', () => {
 // ===========================================================================
 describe('gateway internal-MCP — legacy unaffected', () => {
   it('no internal-MCP headers at all → legacy validateApiKey path runs (request reaches handler when key is valid)', async () => {
+    disableRedisForLegacyGatewayCheck();
     const handler = makeGateway();
     const req = new Request('https://api.worldmonitor.app/api/news/v1/list-feed-digest', {
       method: 'GET',
@@ -803,6 +911,11 @@ describe('gateway internal-MCP — F7: HMAC headers stripped before handler sees
       null,
       'F7: inbound HMAC userId header MUST be stripped before handler',
     );
+    assert.equal(
+      lastHandlerRequest.headers.get(INTERNAL_MCP_NONCE_HEADER),
+      null,
+      'F7: inbound HMAC nonce header MUST be stripped before handler',
+    );
     // Trusted markers MUST still be present — those are the gateway's
     // outbound contract for downstream isCallerPremium checks.
     assert.equal(
@@ -839,6 +952,7 @@ describe('gateway internal-MCP — F8: body size cap', () => {
         'Content-Length': String(4 * 1024 * 1024), // 4MB — well over the cap
         [INTERNAL_MCP_SIG_HEADER]: signed.signature,
         [INTERNAL_MCP_USER_ID_HEADER]: signed.userId,
+        [INTERNAL_MCP_NONCE_HEADER]: signed.nonce,
       },
       body,
     });

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -2943,6 +2943,7 @@ describe('api/mcp.ts — U7 Pro-path', () => {
       queryHash: await sha256Hex(canonicalQueryString(replayUrl)),
       bodyHash: await sha256Hex(JSON.stringify({ query: 'attacker' })),
       userId: PRO_USER_ID,
+      nonce: signed.nonce,
     });
     const replayExpected = await hmacSha256Base64Url(HMAC_SECRET, replayPayload);
     const replayActual = signed.signature.split('.')[1];


### PR DESCRIPTION
## Summary

- Bind internal MCP HMAC signatures to a fresh `X-WM-MCP-Nonce` value.
- Claim verified nonces through Redis `SET ... EX ... NX` before the gateway marks a request as internal-MCP verified.
- Fail closed when the replay cache is unavailable, and strip the nonce header before downstream handlers run.

## Intent

Issue #4681 identified that a captured valid `X-WM-MCP-Internal` signature could be replayed against the exact same request within the 30-second timestamp window. This keeps the existing timestamp, method, path, query, body, and userId binding, and adds one-shot nonce enforcement at the gateway trust boundary.

Non-goals: no UI changes, public API auth changes, billing changes, or unrelated security hardening.

## Validation Matrix

| Check | Reason | Status |
| --- | --- | --- |
| `TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/gateway-internal-mcp.test.mjs` | Proves first use succeeds, same signed request replay fails, unique nonce requests continue, cache outage fails closed | Pass |
| `TMPDIR=/tmp ./node_modules/.bin/tsx --test --test-name-pattern "signed header for\|signInternalMcpRequest" tests/mcp.test.mjs` | Source-affinity coverage for changed HMAC payload/sign helper | Pass |
| `npm run typecheck:api` | API/server TypeScript check for gateway and HMAC helper | Pass |
| `git diff --check` | Whitespace/conflict-marker hygiene | Pass |
| Pre-push hook | Full repo guardrails: typecheck, API typecheck, boundaries, safe HTML, rate-limit policy, premium-fetch, bundle/server tests, changed tests, version checks | Pass |

## Review Gates

- Baseline reviewer: pass.
- Code Review Expert: pass after one JSDoc drift fix.
- Outcome reviewer: pass; acceptance criteria are covered by behavior tests.

## Documentation

No external docs required. The gateway code documents the fail-closed replay-cache-unavailable decision inline.

## Screenshots / UI Evidence

Not applicable; no UI changes.

## Residual Findings

None.
