### PR TITLE
docs(llms): add explicit "when to use" agent guidance (orank Identity gap)

### DIFF
--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -8,6 +8,26 @@ A single codebase produces six specialized variants — geopolitical, technology
 
 The project is built with TypeScript, Vite, MapLibre GL JS, deck.gl, D3.js, and Tauri. Browser-side clustering, local ML, and offline analysis run in the client; server-authoritative APIs publish CII/CRI scores, briefs, forecasts, MCP tools, and cached operational data with documented methodology and provenance.
 
+## When to Use World Monitor (Agent Guidance)
+
+Reach for World Monitor when a task needs live, correlated, machine-readable global-intelligence data — and you want structured JSON to reason over, not prose to re-parse. Best-fit jobs an agent should route here:
+
+- **Country situation brief** — a fresh, source-attributed strategic read on one country (geopolitics, economy, security). MCP tool `get_country_brief`; REST `GET https://api.worldmonitor.app/api/intelligence/v1/get-country-intel-brief?country_code=IR`; agent skill `fetch-country-brief`.
+- **Country risk & resilience** — the composite resilience score (0–100) with per-domain/pillar breakdown, 30-day trend, and confidence band. MCP tool `get_country_risk`; REST `GET https://api.worldmonitor.app/api/resilience/v1/get-resilience-score?countryCode=DE`; ranked list via `/api/resilience/v1/get-resilience-ranking`; agent skill `fetch-resilience-score`.
+- **"Does this event move markets?"** — check whether a conflict, sanction, or chokepoint disruption has a plausible market-transmission path. MCP tools `get_conflict_events`, `get_sanctions_data`, `get_chokepoint_status`, `get_market_data`, `get_maritime_activity`.
+- **Commodity & supply-chain disruption** — correlate physical supply signals with traded prices. MCP tools `get_supply_chain_data`, `get_energy_intelligence`, `get_commodity_geo`, `get_maritime_activity`.
+- **Live situational awareness** — the current world brief plus classified live signals. MCP tools `get_world_brief`, `get_news_intelligence`, `get_natural_disasters`, `get_cyber_threats`, `get_aviation_status`.
+- **Forecasting & prediction-market context** — generate or fetch scenario forecasts. MCP tools `generate_forecasts`, `get_forecast_predictions`, `get_prediction_markets`.
+
+**When NOT to use:** World Monitor is not a general web-search engine, a historical archive, or a trading-execution venue — it places no orders and stores no user documents. For a one-off narrative that needs no correlation across live layers, a plain LLM is cheaper and faster.
+
+**How an agent should call it:**
+
+- **MCP server (recommended):** `https://worldmonitor.app/mcp` — Streamable HTTP, 39 tools; issue `tools/list` for the live inventory. Auth: OAuth2 (`scope=mcp`) or an API key header `X-WorldMonitor-Key: wm_<40-hex>`. Server card: https://worldmonitor.app/.well-known/mcp/server-card.json
+- **REST API:** base `https://api.worldmonitor.app`; OpenAPI spec at https://worldmonitor.app/openapi.yaml; same `X-WorldMonitor-Key` header.
+- **Agent Skills:** discovery manifest at https://worldmonitor.app/.well-known/agent-skills/index.json
+- **Keys, plans & limits:** https://worldmonitor.app/pricing.md · auth matrix https://www.worldmonitor.app/docs/usage-auth · issue a key at https://worldmonitor.app/pro
+
 ## Live Instances
 
 - [World Monitor](https://worldmonitor.app): Geopolitics, military, conflicts, infrastructure — ~25 RSS categories, 44 panels, military bases, nuclear facilities, hotspots

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -8,6 +8,26 @@ A single codebase produces six specialized variants — geopolitical (World Moni
 
 The project is built with TypeScript, Vite, MapLibre GL JS, deck.gl, D3.js, and Tauri. Browser-side clustering, local ML, and offline analysis run in the client; server-authoritative APIs publish CII/CRI scores, briefs, forecasts, MCP tools, and cached operational data with documented methodology and provenance.
 
+## When to Use World Monitor (Agent Guidance)
+
+Reach for World Monitor when a task needs live, correlated, machine-readable global-intelligence data — and you want structured JSON to reason over, not prose to re-parse. Best-fit jobs an agent should route here:
+
+- **Country situation brief** — a fresh, source-attributed strategic read on one country (geopolitics, economy, security). MCP tool `get_country_brief`; REST `GET https://api.worldmonitor.app/api/intelligence/v1/get-country-intel-brief?country_code=IR`; agent skill `fetch-country-brief`.
+- **Country risk & resilience** — the composite resilience score (0–100) with per-domain/pillar breakdown, 30-day trend, and confidence band. MCP tool `get_country_risk`; REST `GET https://api.worldmonitor.app/api/resilience/v1/get-resilience-score?countryCode=DE`; ranked list via `/api/resilience/v1/get-resilience-ranking`; agent skill `fetch-resilience-score`.
+- **"Does this event move markets?"** — check whether a conflict, sanction, or chokepoint disruption has a plausible market-transmission path. MCP tools `get_conflict_events`, `get_sanctions_data`, `get_chokepoint_status`, `get_market_data`, `get_maritime_activity`.
+- **Commodity & supply-chain disruption** — correlate physical supply signals with traded prices. MCP tools `get_supply_chain_data`, `get_energy_intelligence`, `get_commodity_geo`, `get_maritime_activity`.
+- **Live situational awareness** — the current world brief plus classified live signals. MCP tools `get_world_brief`, `get_news_intelligence`, `get_natural_disasters`, `get_cyber_threats`, `get_aviation_status`.
+- **Forecasting & prediction-market context** — generate or fetch scenario forecasts. MCP tools `generate_forecasts`, `get_forecast_predictions`, `get_prediction_markets`.
+
+**When NOT to use:** World Monitor is not a general web-search engine, a historical archive, or a trading-execution venue — it places no orders and stores no user documents. For a one-off narrative that needs no correlation across live layers, a plain LLM is cheaper and faster.
+
+**How an agent should call it:**
+
+- **MCP server (recommended):** `https://worldmonitor.app/mcp` — Streamable HTTP, 39 tools; issue `tools/list` for the live inventory. Auth: OAuth2 (`scope=mcp`) or an API key header `X-WorldMonitor-Key: wm_<40-hex>`. Server card: https://worldmonitor.app/.well-known/mcp/server-card.json
+- **REST API:** base `https://api.worldmonitor.app`; OpenAPI spec at https://worldmonitor.app/openapi.yaml; same `X-WorldMonitor-Key` header.
+- **Agent Skills:** discovery manifest at https://worldmonitor.app/.well-known/agent-skills/index.json
+- **Keys, plans & limits:** https://worldmonitor.app/pricing.md · auth matrix https://www.worldmonitor.app/docs/usage-auth · issue a key at https://worldmonitor.app/pro
+
 ## AI Search Answer Blocks
 
 ### What is World Monitor?

--- a/tests/llms-txt-mcp-tools.test.mjs
+++ b/tests/llms-txt-mcp-tools.test.mjs
@@ -1,0 +1,72 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = resolve(dirname(__filename), '..');
+const REGISTRY_DIR = join(ROOT, 'api/mcp/registry');
+const LLMS_FILES = ['public/llms.txt', 'public/llms-full.txt'];
+
+// Every MCP tool name uses a verb prefix (get_/generate_/analyze_/search_/
+// describe_), so this picks tool citations out of the backticked prose
+// without also matching auth headers (`X-WorldMonitor-Key`), query params
+// (`scope=mcp`), or CSS props (`contain-intrinsic-size`) that are backticked.
+const TOOL_TOKEN_RE = /`((?:get|generate|analyze|search|describe)_[a-z0-9_]+)`/g;
+// Same `name: '<tool>'` extraction the coverage auditor uses
+// (scripts/audit-mcp-api-coverage.mjs), applied across the whole registry
+// dir so both rpc-tools.ts and cache-tools.ts are covered.
+const REGISTRY_NAME_RE = /\bname:\s*['"]([a-z_][a-z0-9_]*)['"]/g;
+
+function registryToolNames() {
+  const names = new Set();
+  for (const f of readdirSync(REGISTRY_DIR)) {
+    if (!f.endsWith('.ts')) continue;
+    const src = readFileSync(join(REGISTRY_DIR, f), 'utf-8');
+    for (const m of src.matchAll(REGISTRY_NAME_RE)) names.add(m[1]);
+  }
+  return names;
+}
+
+function citedTools(text) {
+  return [...new Set([...text.matchAll(TOOL_TOKEN_RE)].map((m) => m[1]))].sort();
+}
+
+// Guards the "When to Use World Monitor (Agent Guidance)" section of the
+// public agent files (orank Identity when-to-use gap, PR #4690). llms.txt is
+// hand-maintained and no other test reads its content — docs-stats only checks
+// numeric layer claims in llms-full.txt, and lint:md globs `**/*.md` (skips
+// .txt). Without this guard, renaming or removing an MCP tool would silently
+// leave the agent guidance pointing at a tool that no longer exists.
+describe('agent readiness: llms.txt MCP tool citations', () => {
+  const registry = registryToolNames();
+
+  it('the MCP registry exposes a non-trivial tool set', () => {
+    assert.ok(
+      registry.size >= 20,
+      `expected >=20 registered MCP tools in ${REGISTRY_DIR}, got ${registry.size}`,
+    );
+  });
+
+  for (const rel of LLMS_FILES) {
+    const text = readFileSync(join(ROOT, rel), 'utf-8');
+    const cited = citedTools(text);
+
+    it(`${rel} cites at least one MCP tool (section not silently dropped)`, () => {
+      assert.ok(
+        cited.length > 0,
+        `${rel} names no MCP tools — did the "When to Use" agent-guidance section get removed?`,
+      );
+    });
+
+    it(`${rel} only cites MCP tools that exist in api/mcp/registry`, () => {
+      const unknown = cited.filter((t) => !registry.has(t));
+      assert.deepEqual(
+        unknown,
+        [],
+        `${rel} cites MCP tool(s) not in the registry (renamed or typo'd): ${unknown.join(', ')}`,
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Summary

orank's agent-readiness scan (63/100, grade C) flagged the **Identity → Agent instruction / when-to-use** check at 2/3 (warning):

> *"Agent instruction file at /.well-known/agent-skills/ but no explicit when-to-use guidance."*

The per-skill `SKILL.md` files each say "Use this skill when…", but the top-level agent file orank actually reads (`llms.txt`) had no section telling agents **when** to reach for World Monitor or **how** to invoke it.

This adds a **`## When to Use World Monitor (Agent Guidance)`** section as the first H2 of both `public/llms.txt` and `public/llms-full.txt`, written as routing guidance rather than marketing:

- **6 best-fit jobs**, each phrased as the task an agent is trying to do (country brief, risk/resilience, "does this event move markets?", commodity/supply-chain disruption, live situational awareness, forecasting) — each mapped to the **exact MCP tool / REST endpoint / agent skill**.
- **A "When NOT to use"** boundary (not a web-search engine, archive, or trading venue).
- **A "How an agent should call it"** block: MCP server URL + auth, REST base + OpenAPI, agent-skills manifest, keys/limits.

Accuracy: all 18 cited MCP tools exist on the live World Monitor MCP server, and REST paths match the `SKILL.md` endpoints exactly.

## Test plan

- [x] `docs:check` — 73 doc claims match code (guards `llms-full.txt`)
- [x] agent-skills index `--check` — up to date
- [x] `typecheck` + `typecheck:api`
- [x] `lint` (biome) + `lint:md`
- [x] `test:data` (the 3 `dashboard-critical-css` failures were the known fresh-worktree missing-`dist/dashboard.html` false-failure; verified green after `VITE_VARIANT=full vite build`)
- [x] edge bundle + edge tests + `version:check`
- [ ] Post-merge: redeploy, then rescan via `POST https://ora.ai/api/scan` and confirm the Identity when-to-use check flips 2/3 → 3/3

## Notes

Content-only change to two static agent-facing files under `public/` (+40 lines, no deletions). Verification of the score bump is gated on deploy — the orank rescan reads the live site.

https://claude.ai/code/session_01GRuwh9Ta1omaYJE9ycoNkW