### PR TITLE
fix(discovery): add RFC 9727 item enumeration to api-catalog

### DIFF
--- a/docs/agent-discovery.mdx
+++ b/docs/agent-discovery.mdx
@@ -53,9 +53,10 @@ The header-discoverable static assets (`.well-known/*`, `/openapi.yaml`) serve `
 ### Codegen a REST client for every service
 
 ```bash
-# 1. Discover the bundled OpenAPI URL
+# 1. Discover the bundled OpenAPI URL (linkset[0] enumerates every API via
+#    RFC 9727 `item` links; select the REST API context object by anchor)
 curl -s https://worldmonitor.app/.well-known/api-catalog \
-  | jq -r '.linkset[0]."service-desc"[0].href'
+  | jq -r '.linkset[] | select(.anchor == "https://api.worldmonitor.app/")."service-desc"[0].href'
 # → https://www.worldmonitor.app/openapi.yaml
 
 # 2. Generate clients

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -1,6 +1,26 @@
 {
   "linkset": [
     {
+      "anchor": "https://worldmonitor.app/.well-known/api-catalog",
+      "item": [
+        {
+          "href": "https://api.worldmonitor.app/",
+          "title": "World Monitor REST API",
+          "type": "application/vnd.oai.openapi"
+        },
+        {
+          "href": "https://worldmonitor.app/mcp",
+          "title": "World Monitor MCP server",
+          "type": "application/json"
+        },
+        {
+          "href": "https://worldmonitor.app/",
+          "title": "World Monitor agent skills",
+          "type": "application/json"
+        }
+      ]
+    },
+    {
       "anchor": "https://api.worldmonitor.app/",
       "service-desc": [
         {

--- a/public/.well-known/api-catalog
+++ b/public/.well-known/api-catalog
@@ -5,18 +5,15 @@
       "item": [
         {
           "href": "https://api.worldmonitor.app/",
-          "title": "World Monitor REST API",
-          "type": "application/vnd.oai.openapi"
+          "title": "World Monitor REST API"
         },
         {
           "href": "https://worldmonitor.app/mcp",
-          "title": "World Monitor MCP server",
-          "type": "application/json"
+          "title": "World Monitor MCP server"
         },
         {
           "href": "https://worldmonitor.app/",
-          "title": "World Monitor agent skills",
-          "type": "application/json"
+          "title": "World Monitor agent skills"
         }
       ]
     },

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -1102,19 +1102,42 @@ describe('brief magazine CSP override', () => {
 //   (2) variant build scripts dropping the `npm run build:openapi`
 //       prefix and silently shipping web bundles without the spec;
 //   (3) the openapi source under docs/ being deleted without a
-//       matching removal of the build step.
+//       matching removal of the build step;
+//   (4) linkset[0] losing its RFC 9727 `item` enumeration (agent
+//       crawlers read the catalog anchor's item links to find every API).
 describe('agent readiness: api-catalog + openapi build', () => {
   const apiCatalog = JSON.parse(
     readFileSync(resolve(__dirname, '../public/.well-known/api-catalog'), 'utf-8')
   );
   const pkg = JSON.parse(readFileSync(resolve(__dirname, '../package.json'), 'utf-8'));
 
-  it('api anchor is first and points at the api host root', () => {
-    assert.equal(apiCatalog.linkset[0].anchor, 'https://api.worldmonitor.app/');
+  const catalogEntry = apiCatalog.linkset[0];
+  const apiEntry = apiCatalog.linkset.find((entry) => entry.anchor === 'https://api.worldmonitor.app/');
+
+  it('linkset[0] is the catalog anchor and enumerates each API via RFC 9727 item links', () => {
+    assert.equal(catalogEntry.anchor, 'https://worldmonitor.app/.well-known/api-catalog');
+    assert.ok(Array.isArray(catalogEntry.item), 'linkset[0] must carry an "item" array (RFC 9727 §4)');
+    assert.ok(catalogEntry.item.length > 0, 'linkset[0].item must enumerate at least one API');
+    // Each item MUST resolve to a linkset context object that describes that API.
+    const anchors = new Set(apiCatalog.linkset.map((entry) => entry.anchor));
+    for (const item of catalogEntry.item) {
+      assert.ok(item.href, 'each item entry must carry an href');
+      assert.ok(
+        anchors.has(item.href),
+        `item href ${item.href} must match a linkset context anchor`
+      );
+    }
+    const itemHrefs = catalogEntry.item.map((i) => i.href);
+    assert.ok(itemHrefs.includes('https://api.worldmonitor.app/'), 'item list must enumerate the REST API host root');
+    assert.ok(itemHrefs.includes('https://worldmonitor.app/mcp'), 'item list must enumerate the MCP server');
+  });
+
+  it('the api host root has its own context object', () => {
+    assert.ok(apiEntry, 'linkset must contain a context object anchored at https://api.worldmonitor.app/');
   });
 
   it('status href points at /api/health (SPA lives at /health — would 200 HTML and look healthy)', () => {
-    const statusHref = apiCatalog.linkset[0].status[0].href;
+    const statusHref = apiEntry.status[0].href;
     assert.ok(
       statusHref.startsWith('https://api.worldmonitor.app'),
       `status href must be on api.worldmonitor.app, got: ${statusHref}`
@@ -1126,7 +1149,7 @@ describe('agent readiness: api-catalog + openapi build', () => {
   });
 
   it('service-desc points at /openapi.yaml with the OpenAPI media type', () => {
-    const serviceDesc = apiCatalog.linkset[0]['service-desc'][0];
+    const serviceDesc = apiEntry['service-desc'][0];
     assert.ok(
       serviceDesc.href.endsWith('/openapi.yaml'),
       `service-desc href must end with /openapi.yaml, got: ${serviceDesc.href}`

--- a/vercel.json
+++ b/vercel.json
@@ -50,7 +50,7 @@
     {
       "source": "/.well-known/api-catalog",
       "headers": [
-        { "key": "Content-Type", "value": "application/linkset+json" },
+        { "key": "Content-Type", "value": "application/linkset+json;profile=\"https://www.rfc-editor.org/info/rfc9727\"" },
         { "key": "Access-Control-Allow-Origin", "value": "*" },
         { "key": "Cache-Control", "value": "public, max-age=3600" }
       ]


### PR DESCRIPTION
## Summary

orank's RFC 9727 **Access** check flagged **"api-catalog linkset[0] has no 'item' entries"** (Access 68/91, overall 63/100 grade C). Production `/.well-known/api-catalog` had `linkset[0]` jump straight to the REST API context object, so agent crawlers (and the scanner) couldn't enumerate the member APIs.

- **Restructured to the canonical RFC 9727 shape**: `linkset[0]` is now the catalog-resource anchor (`.../.well-known/api-catalog`) carrying an `item` array that enumerates each API — REST (`api.worldmonitor.app`), MCP (`/mcp`), and agent-skills. Each `item.href` resolves to its own `service-desc` / `service-doc` / `status` context object (Appendix A.1 pattern), so nothing else moved.
- **Content-Type**: added `profile="https://www.rfc-editor.org/info/rfc9727"` per RFC 9727 §4.1.
- **Guardrails**: updated `deploy-config` tests to locate the API context by anchor (not positionally) and to assert `linkset[0]` keeps a non-empty, fully-resolvable `item` list; updated the `agent-discovery.mdx` jq example that relied on positional `linkset[0]`.

## Test plan

- [x] `npm run typecheck` + `typecheck:api`
- [x] `npm run lint` (biome) + `lint:md`
- [x] `npm run test:data` — 12529/12531 pass; the 2 failures were the known fresh-worktree `dashboard-critical-css` built-output tests, which PASS (8/8) after `VITE_VARIANT=full vite build`
- [x] edge-function esbuild bundle + `edge-functions` tests
- [x] pre-push hook green (npm ci + typecheck ×2 + convex tsc + boundary/safe-html/sentry/rate-limit/premium-fetch lints + changed `deploy-config` test + mdx lint + version check)
- [ ] **After deploy**: rescan `POST https://ora.ai/api/scan {"url":"worldmonitor.app"}` — Access api-catalog check should go 1/2 → 2/2 (Access 68→69/91, overall 63→64/100). The scanner hits the live domain, so it only reflects the fix once merged + deployed.

https://claude.ai/code/session_01KmfumZk7HVidLsU49vmESH