### PR TITLE
fix(security): compare Resend webhook signatures safely

### DIFF
--- a/convex/__tests__/resendWebhookHandler.test.ts
+++ b/convex/__tests__/resendWebhookHandler.test.ts
@@ -1,0 +1,156 @@
+import { convexTest } from "convex-test";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import schema from "../schema";
+
+const modules = import.meta.glob("../**/*.ts");
+
+const TEST_NOW_SECONDS = 1_700_000_000;
+const TEST_NOW_MS = TEST_NOW_SECONDS * 1000;
+const SECRET_BYTES = new Uint8Array([
+  0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+  0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+  0x10, 0x21, 0x32, 0x43, 0x54, 0x65, 0x76, 0x87,
+  0x98, 0xa9, 0xba, 0xcb, 0xdc, 0xed, 0xfe, 0x0f,
+]);
+const RESEND_WEBHOOK_SECRET = `whsec_${btoa(String.fromCharCode(...SECRET_BYTES))}`;
+
+function makePayload(): string {
+  return JSON.stringify({
+    type: "email.opened",
+    created_at: "2023-11-14T22:13:20.000Z",
+    data: { email_id: "email_test_resend_signature" },
+  });
+}
+
+async function signPayload(
+  payload: string,
+  {
+    messageId = "msg_test_resend_signature",
+    timestamp = String(TEST_NOW_SECONDS),
+  }: { messageId?: string; timestamp?: string } = {},
+): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    SECRET_BYTES,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const toSign = `${messageId}.${timestamp}.${payload}`;
+  const sig = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(toSign),
+  );
+  return btoa(String.fromCharCode(...new Uint8Array(sig)));
+}
+
+function replaceFirstBase64Char(value: string): string {
+  return `${value[0] === "A" ? "B" : "A"}${value.slice(1)}`;
+}
+
+async function postResendWebhook(
+  svixSignature: string | undefined,
+  {
+    payload = makePayload(),
+    messageId = "msg_test_resend_signature",
+    timestamp = String(TEST_NOW_SECONDS),
+  }: { payload?: string; messageId?: string; timestamp?: string } = {},
+) {
+  const t = convexTest(schema, modules);
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "svix-id": messageId,
+    "svix-timestamp": timestamp,
+  };
+  if (svixSignature !== undefined) {
+    headers["svix-signature"] = svixSignature;
+  }
+
+  return await t.fetch("/resend-webhook", {
+    method: "POST",
+    headers,
+    body: payload,
+  });
+}
+
+describe("Resend webhook signature verification (#4678)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.RESEND_WEBHOOK_SECRET;
+  });
+
+  test("accepts a valid Svix/Resend signature", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(TEST_NOW_MS);
+    process.env.RESEND_WEBHOOK_SECRET = RESEND_WEBHOOK_SECRET;
+    const payload = makePayload();
+    const signature = await signPayload(payload);
+
+    const res = await postResendWebhook(`v1,${signature}`, { payload });
+
+    expect(res.status).toBe(200);
+  });
+
+  test("rejects an invalid same-length signature", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(TEST_NOW_MS);
+    process.env.RESEND_WEBHOOK_SECRET = RESEND_WEBHOOK_SECRET;
+    const payload = makePayload();
+    const signature = await signPayload(payload);
+    const invalidSignature = replaceFirstBase64Char(signature);
+
+    const res = await postResendWebhook(`v1,${invalidSignature}`, { payload });
+
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe("Invalid signature");
+  });
+
+  test("rejects an invalid different-length signature", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(TEST_NOW_MS);
+    process.env.RESEND_WEBHOOK_SECRET = RESEND_WEBHOOK_SECRET;
+    const payload = makePayload();
+    const signature = await signPayload(payload);
+
+    const res = await postResendWebhook(`v1,${signature.slice(0, -4)}`, {
+      payload,
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe("Invalid signature");
+  });
+
+  test("rejects malformed or missing signature headers", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(TEST_NOW_MS);
+    process.env.RESEND_WEBHOOK_SECRET = RESEND_WEBHOOK_SECRET;
+    const payload = makePayload();
+    const signature = await signPayload(payload);
+
+    const malformed = await postResendWebhook("not-a-pair v1,");
+    const extraFields = await postResendWebhook(`v1,${signature},extra`, {
+      payload,
+    });
+    const missing = await postResendWebhook(undefined);
+
+    expect(malformed.status).toBe(401);
+    expect(await malformed.text()).toBe("Invalid signature");
+    expect(extraFields.status).toBe(401);
+    expect(await extraFields.text()).toBe("Invalid signature");
+    expect(missing.status).toBe(401);
+    expect(await missing.text()).toBe("Invalid signature");
+  });
+
+  test("rejects stale timestamps", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(TEST_NOW_MS);
+    process.env.RESEND_WEBHOOK_SECRET = RESEND_WEBHOOK_SECRET;
+    const payload = makePayload();
+    const staleTimestamp = String(TEST_NOW_SECONDS - 301);
+    const signature = await signPayload(payload, { timestamp: staleTimestamp });
+
+    const res = await postResendWebhook(`v1,${signature}`, {
+      payload,
+      timestamp: staleTimestamp,
+    });
+
+    expect(res.status).toBe(401);
+    expect(await res.text()).toBe("Invalid signature");
+  });
+});

--- a/convex/resendWebhookHandler.ts
+++ b/convex/resendWebhookHandler.ts
@@ -8,6 +8,24 @@ const BROADCAST_TRACKED_SET: ReadonlySet<string> = new Set(
   BROADCAST_TRACKED_EVENT_TYPES,
 );
 
+async function timingSafeEqualStrings(a: string, b: string): Promise<boolean> {
+  const enc = new TextEncoder();
+  const keyMaterial = await crypto.subtle.generateKey(
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const [sigA, sigB] = await Promise.all([
+    crypto.subtle.sign("HMAC", keyMaterial, enc.encode(a)),
+    crypto.subtle.sign("HMAC", keyMaterial, enc.encode(b)),
+  ]);
+  const aArr = new Uint8Array(sigA);
+  const bArr = new Uint8Array(sigB);
+  let diff = 0;
+  for (let i = 0; i < aArr.length; i++) diff |= aArr[i]! ^ bArr[i]!;
+  return diff === 0;
+}
+
 async function verifySignature(
   payload: string,
   headers: Headers,
@@ -43,10 +61,14 @@ async function verifySignature(
   const expected = btoa(String.fromCharCode(...new Uint8Array(sig)));
 
   const signatures = signature.split(" ");
-  return signatures.some((s) => {
-    const [, val] = s.split(",");
-    return val === expected;
-  });
+  for (const s of signatures) {
+    const parts = s.split(",");
+    if (parts.length !== 2) continue;
+    const [version, val] = parts;
+    if (version !== "v1" || !val) continue;
+    if (await timingSafeEqualStrings(val, expected)) return true;
+  }
+  return false;
 }
 
 export const resendWebhookHandler = httpAction(async (ctx, request) => {


### PR DESCRIPTION
## Summary

- Replaces the Resend/Svix webhook signature `val === expected` check with a Convex-safe HMAC-wrapped timing-safe comparison.
- Rejects malformed signature fragments before comparison, including missing values and extra comma fields.
- Adds route-level Convex regression tests for valid, invalid same-length, invalid different-length, malformed/missing, and stale timestamp cases.

## Intent

Issue #4678 identifies `convex/resendWebhookHandler.ts` as the remaining Resend webhook auth outlier: the endpoint computes the expected HMAC correctly, but authenticates candidate signatures with plain JavaScript string equality. This PR keeps the existing raw-body/timestamp behavior and narrows the fix to the public Resend webhook authentication boundary.

Non-goals: no changes to broadcast metric idempotency, suppression writes, Dodo webhook verification, routing, or UI.

## Validation Matrix

| Check | Reason | Result |
| --- | --- | --- |
| `./node_modules/.bin/vitest run --config vitest.config.mts convex/__tests__/resendWebhookHandler.test.ts` | Focused Resend webhook auth regression coverage | Pass: 1 file / 5 tests |
| `./node_modules/.bin/vitest run --config vitest.config.mts convex/__tests__/http.test.ts convex/__tests__/telegramWebhook.test.ts convex/__tests__/resendWebhookHandler.test.ts` | Neighboring Convex HTTP/auth route affinity | Pass: 3 files / 11 tests |
| `npm run test:convex` | Full Convex module graph regression coverage | Pass: 32 files / 517 tests |
| `npm run typecheck:api` | API/Convex audit affinity | Pass: `audit-convex-string-calls` clean |
| `npm run typecheck` | Repo-wide TypeScript check | Pass |
| `git diff --cached --check` | Staged diff whitespace hygiene | Pass |
| pre-push hook | Repo guard bundle before publication | Pass: typecheck, API typecheck, Convex type check, CJS syntax, Unicode, boundaries, safe HTML, Sentry coverage, rate-limit policies, premium-fetch parity, edge bundle, version sync |

## Review Gates

- Baseline reviewer: Pass. Tightened malformed `v1,<sig>,extra` parsing before final validation.
- Code Review Expert: Pass. Checked SOLID, security/reliability, code quality, and removal-plan prompts; no P0/P1/P2/P3 findings.
- Outcome reviewer: Pass. Acceptance criteria are covered by route-level behavior tests; no residual findings.

## Documentation

Not applicable. This is internal webhook-auth hardening with unchanged external behavior and no docs-facing contract change.

## Screenshots / UI Evidence

Not applicable. No user-visible UI changed.

## Residual Findings

None.
