### PR TITLE
fix(supply-chain): pin Docker and action refs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "docker"
+    directory: "/consumer-prices-core"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/convex-deploy.yml
+++ b/.github/workflows/convex-deploy.yml
@@ -38,7 +38,7 @@ jobs:
     outputs:
       convex: ${{ steps.diff.outputs.convex }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           # Need both BEFORE and AFTER commits locally so `git diff` can name
           # the changed files authoritatively. `fetch-depth: 0` (full history)
@@ -90,8 +90,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -29,8 +29,8 @@ jobs:
       run:
         working-directory: workers/api-cors-preflight
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
       - name: Install
@@ -46,8 +46,8 @@ jobs:
       run:
         working-directory: workers/api-cors-preflight
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
       - name: Install
@@ -63,8 +63,8 @@ jobs:
     needs: deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
       - name: Wait for Worker propagation

--- a/.github/workflows/feed-validation.yml
+++ b/.github/workflows/feed-validation.yml
@@ -45,8 +45,8 @@ jobs:
     # headroom while avoiding stuck-runner alerts on real outages.
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/lint-code.yml
+++ b/.github/workflows/lint-code.yml
@@ -34,8 +34,8 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'npm'
@@ -54,8 +54,8 @@ jobs:
   mintlify-slugs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
       - run: node scripts/enforce-mintlify-reserved-slugs.mjs

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -45,8 +45,8 @@ jobs:
             package_json: docker/runtime-package.json
             lockfile: docker/runtime-package-lock.json
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
       - name: Audit ${{ matrix.lockfile }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,8 +75,8 @@ jobs:
     # Pure Node builtins — no npm install required.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
       - name: stats.json is tracked and current
@@ -99,8 +99,8 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'npm'
@@ -136,8 +136,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'npm'
@@ -150,8 +150,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'npm'
@@ -167,8 +167,8 @@ jobs:
     # page-error, and expected-panel invariants.
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'npm'
@@ -182,8 +182,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'npm'
@@ -201,7 +201,7 @@ jobs:
     # remains the load-bearing gate; this job is the integration smoke.
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Build digest-notifications image (smoke)
         # No push, no tag publish. Catches cross-directory-import breakage
         # before it reaches main. Pairs with the BFS import test in

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # =============================================================================
 
 # ── Stage 1: Builder ─────────────────────────────────────────────────────────
-FROM node:22-alpine AS builder
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS builder
 
 WORKDIR /app
 
@@ -28,7 +28,7 @@ RUN node docker/build-handlers.mjs
 RUN npx tsc && npx vite build
 
 # ── Stage 2: Runtime dependencies ───────────────────────────────────────────
-FROM node:22-alpine AS runtime-deps
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS runtime-deps
 
 WORKDIR /app
 
@@ -42,7 +42,7 @@ COPY docker/runtime-package-lock.json ./package-lock.json
 RUN npm ci --omit=dev --omit=optional --ignore-scripts
 
 # ── Stage 3: Runtime ─────────────────────────────────────────────────────────
-FROM node:22-alpine AS final
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS final
 
 # nginx + supervisord
 RUN apk add --no-cache nginx supervisor gettext && \

--- a/Dockerfile.digest-notifications
+++ b/Dockerfile.digest-notifications
@@ -28,7 +28,7 @@
 #   AI_DIGEST_ENABLED=0           (kill switch for AI summary LLM call)
 # =============================================================================
 
-FROM node:22-alpine
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
 
 WORKDIR /app
 

--- a/Dockerfile.relay
+++ b/Dockerfile.relay
@@ -7,7 +7,7 @@
 # Set AISSTREAM_API_KEY in docker-compose.yml or Railway env.
 # =============================================================================
 
-FROM node:22-alpine
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
 
 # curl required by OREF polling (Node.js JA3 fingerprint blocked by Akamai; curl passes)
 RUN apk add --no-cache curl

--- a/Dockerfile.seed-bundle-portwatch-port-activity
+++ b/Dockerfile.seed-bundle-portwatch-port-activity
@@ -8,14 +8,14 @@
 # rationale.
 #
 # Runtime deps this image needs:
-#   - node:22-alpine (ESM, AbortSignal.any, fetch)
+#   - Node 22 Alpine (digest-pinned below; ESM, AbortSignal.any, fetch)
 #   - scripts/ tree (seeder + _seed-utils + _proxy-utils + _country-resolver
 #     + _bundle-runner + proxy helpers)
 #   - shared/ (country mappings that _country-resolver depends on)
 #   - .nvmrc? (not needed; node version baked into the base image)
 # =============================================================================
 
-FROM node:22-alpine
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
 
 WORKDIR /app
 

--- a/Dockerfile.seed-bundle-resilience-validation
+++ b/Dockerfile.seed-bundle-resilience-validation
@@ -11,7 +11,7 @@
 # is tsx (to register the ESM loader for .ts imports).
 # =============================================================================
 
-FROM node:22-alpine
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
 
 WORKDIR /app
 

--- a/consumer-prices-core/Dockerfile
+++ b/consumer-prices-core/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim AS base
+FROM node:20-slim@sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0 AS base
 WORKDIR /app
 
 # Install Playwright dependencies. Tolerate transient Ubuntu mirror failures

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@
 # Multi-stage build for the World Monitor web app (frontend only).
 
 # Stage 1: Build the frontend with TypeScript + Vite.
-FROM node:22-alpine AS builder
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2 AS builder
 
 WORKDIR /app
 
@@ -26,7 +26,7 @@ RUN npm run build
 
 
 # Stage 2: Serve the built assets from nginx.
-FROM nginx:alpine AS runtime
+FROM nginx:alpine@sha256:54f2a904c251d5a34adf545a72d32515a15e08418dae0266e23be2e18c66fefa AS runtime
 
 WORKDIR /usr/share/nginx/html
 

--- a/docker/Dockerfile.redis-rest
+++ b/docker/Dockerfile.redis-rest
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:22-alpine@sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2
 WORKDIR /app
 RUN npm init -y && npm install redis@4
 COPY redis-rest-proxy.mjs .

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -123,6 +123,13 @@ function collectPackageLockfiles(): string[] {
     .sort();
 }
 
+function collectDockerfiles(): string[] {
+  return execFileSync('git', ['ls-files', '*Dockerfile*'], { cwd: root, encoding: 'utf8' })
+    .split('\n')
+    .filter((file) => /(^|\/)Dockerfile(\.|$)/.test(file))
+    .sort();
+}
+
 function securityAuditMatrixLockfiles(): string[] {
   return Array.from(securityAuditWorkflow.matchAll(/^\s+lockfile:\s+(.+)$/gm), ([, value]) =>
     value.trim().replace(/^['"]|['"]$/g, ''),
@@ -252,5 +259,75 @@ describe('CI workflow coverage', () => {
         `security-audit.yml must cover ${lockfile}`,
       );
     }
+  });
+
+  it('keeps Docker base images pinned to immutable digests', () => {
+    const failures: string[] = [];
+
+    for (const dockerfile of collectDockerfiles()) {
+      const aliases = new Set<string>();
+      const source = readFileSync(resolve(root, dockerfile), 'utf8');
+      const lines = source.split('\n');
+
+      lines.forEach((line, index) => {
+        const match = line.match(/^FROM\s+(.+)$/i);
+        if (!match) return;
+
+        const parts = match[1].trim().split(/\s+/);
+        while (parts[0]?.startsWith('--')) {
+          parts.shift();
+        }
+
+        const image = parts[0];
+        const asIndex = parts.findIndex((part) => part.toUpperCase() === 'AS');
+        const alias = asIndex >= 0 ? parts[asIndex + 1] : undefined;
+        const isKnownStage = image ? aliases.has(image) : false;
+        if (alias) {
+          aliases.add(alias);
+        }
+
+        if (!image || image === 'scratch' || isKnownStage) return;
+
+        if (!image.includes('@sha256:')) {
+          failures.push(`${dockerfile}:${index + 1} ${line.trim()}`);
+        }
+      });
+    }
+
+    assert.deepEqual(
+      failures,
+      [],
+      `Docker FROM images must be pinned with @sha256 digests:\n${failures.join('\n')}`,
+    );
+  });
+
+  it('keeps GitHub Actions external uses pinned to commit SHAs', () => {
+    const failures: string[] = [];
+    const workflowFiles = readdirSync(workflowsDir)
+      .filter((name) => name.endsWith('.yml') || name.endsWith('.yaml'))
+      .sort();
+
+    for (const workflowFile of workflowFiles) {
+      const source = readFileSync(resolve(workflowsDir, workflowFile), 'utf8');
+      const lines = source.split('\n');
+
+      lines.forEach((line, index) => {
+        const match = line.match(/^\s*uses:\s*([^@\s#]+)@([^\s#]+)/);
+        if (!match) return;
+
+        const [, action, ref] = match;
+        if (action.startsWith('./') || action.startsWith('docker://')) return;
+
+        if (!/^[0-9a-f]{40}$/i.test(ref)) {
+          failures.push(`${workflowFile}:${index + 1} ${line.trim()}`);
+        }
+      });
+    }
+
+    assert.deepEqual(
+      failures,
+      [],
+      `GitHub Actions uses refs must be 40-character commit SHAs:\n${failures.join('\n')}`,
+    );
   });
 });

--- a/tests/ci-workflow-coverage.test.mts
+++ b/tests/ci-workflow-coverage.test.mts
@@ -288,7 +288,7 @@ describe('CI workflow coverage', () => {
 
         if (!image || image === 'scratch' || isKnownStage) return;
 
-        if (!image.includes('@sha256:')) {
+        if (!/@sha256:[0-9a-f]{64}$/i.test(image)) {
           failures.push(`${dockerfile}:${index + 1} ${line.trim()}`);
         }
       });
@@ -297,7 +297,7 @@ describe('CI workflow coverage', () => {
     assert.deepEqual(
       failures,
       [],
-      `Docker FROM images must be pinned with @sha256 digests:\n${failures.join('\n')}`,
+      `Docker FROM images must be pinned with full @sha256:<64 hex> digests:\n${failures.join('\n')}`,
     );
   });
 

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -499,7 +499,7 @@ describe('docker runtime dependency guardrails', () => {
   const runtimeLock = JSON.parse(readFileSync(resolve(__dirname, '../docker/runtime-package-lock.json'), 'utf-8'));
 
   it('installs runtime node_modules from a minimal dependency stage', () => {
-    assert.match(dockerfileSource, /FROM node:22-alpine AS runtime-deps/);
+    assert.match(dockerfileSource, /^FROM\s+node:22-alpine@sha256:[a-f0-9]{64}\s+AS\s+runtime-deps$/m);
     assert.match(dockerfileSource, /npm ci --omit=dev --omit=optional --ignore-scripts/);
     assert.match(dockerfileSource, /COPY --from=runtime-deps \/app\/node_modules \.\/node_modules/);
     assert.doesNotMatch(dockerfileSource, /npm prune --omit=dev/);


### PR DESCRIPTION
## Summary

- Pin all tracked Dockerfile base images to immutable Docker Hub index digests.
- Replace remaining `actions/checkout@v4` and `actions/setup-node@v4` workflow refs with resolved commit SHAs plus `# v4` comments.
- Add weekly Dependabot coverage for GitHub Actions and Docker image updates.
- Extend CI workflow coverage tests to reject future mutable Docker base refs and non-SHA external GitHub Actions refs.

## Intent

Fixes #3552.

This is scoped to supply-chain pinning only: no app runtime code, endpoint behavior, UI, or deployment semantics are changed.

Pin evidence:

- `node:22-alpine` -> `sha256:16e22a550f3863206a3f701448c45f7912c6896a62de43add43bb9c86130c3e2`
- `node:20-slim` -> `sha256:2cf067cfed83d5ea958367df9f966191a942351a2df77d6f0193e162b5febfc0`
- `nginx:alpine` -> `sha256:54f2a904c251d5a34adf545a72d32515a15e08418dae0266e23be2e18c66fefa`
- `actions/checkout@v4` -> `34e114876b0b11c390a56381ad16ebd13914f8d5`
- `actions/setup-node@v4` -> `49933ea5288caeca8642d1e84afbd3f7d6820020`

## Validation Matrix

| Check | Status | Evidence |
|---|---:|---|
| Mutable ref inventory | Pass | `rg -n "^FROM\\s+[^\\s@]+:[^\\s@]+(\\s|$)|uses:\\s*[^\\s#]+@v[0-9]+\\b" ...` returned no matches |
| Focused guard | Pass | `TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/ci-workflow-coverage.test.mts` passed 9/9 |
| Typecheck | Pass | `npm run typecheck` |
| Targeted lint | Pass | `./node_modules/.bin/biome lint tests/ci-workflow-coverage.test.mts` |
| Full lint sample | Pass | `npm run lint` exited 0; existing unrelated warnings were informational |
| Diff hygiene | Pass | `git diff --check` |
| Pre-push hook | Pass | Typecheck, API typecheck, Convex check, CJS syntax, Unicode safety, boundaries, safe HTML, rate-limit policy, premium-fetch, resilience tests, changed test files, and version sync passed |

## Review Gates

- Baseline reviewer: Pass; fixed one parser robustness issue for `FROM existing-stage AS new-alias`.
- Code Review Expert: Pass; no blocking findings.
- Outcome reviewer: Pass; issue contract is satisfied and no broader runtime behavior is changed.

## Documentation

No user-facing docs changed. Dependabot config is added so pinned Docker and GitHub Actions refs can be updated by reviewed PRs.

## Screenshots / UI Evidence

Not applicable. This is workflow and Docker supply-chain configuration only.

## Residual Findings

None.