### PR TITLE
fix(security): use timing-safe runtime secret checks

### DIFF
--- a/api/_crypto.js
+++ b/api/_crypto.js
@@ -45,3 +45,8 @@ export async function timingSafeIncludes(candidate, validKeys) {
   }
   return found;
 }
+
+export async function timingSafeEqualSecret(candidate, expected) {
+  if (!candidate || !expected) return false;
+  return timingSafeIncludes(candidate, [expected]);
+}

--- a/api/product-catalog.js
+++ b/api/product-catalog.js
@@ -15,6 +15,8 @@ export const config = { runtime: 'edge' };
 
 // @ts-expect-error — JS module
 import { getCorsHeaders } from './_cors.js';
+// @ts-expect-error — JS module
+import { timingSafeEqualSecret } from './_crypto.js';
 // @ts-expect-error — generated JS module
 import { FALLBACK_PRICES } from './_product-fallback-prices.js';
 // @ts-expect-error — JS module
@@ -235,7 +237,7 @@ export default async function handler(req) {
   // DELETE = purge cache (authenticated)
   if (req.method === 'DELETE') {
     const authHeader = req.headers.get('Authorization') ?? '';
-    if (!RELAY_SECRET || authHeader !== `Bearer ${RELAY_SECRET}`) {
+    if (!RELAY_SECRET || !(await timingSafeEqualSecret(authHeader, `Bearer ${RELAY_SECRET}`))) {
       return json({ error: 'Unauthorized' }, 401, cors);
     }
     await purgeCache();

--- a/api/product-catalog.test.mjs
+++ b/api/product-catalog.test.mjs
@@ -1,0 +1,60 @@
+import { strict as assert } from 'node:assert';
+import { afterEach, test } from 'node:test';
+
+const ORIGINAL_ENV = { ...process.env };
+
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in ORIGINAL_ENV)) delete process.env[key];
+  }
+  Object.assign(process.env, ORIGINAL_ENV);
+}
+
+async function importHandler({ relaySecret }) {
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (relaySecret == null) {
+    delete process.env.RELAY_SHARED_SECRET;
+  } else {
+    process.env.RELAY_SHARED_SECRET = relaySecret;
+  }
+  const mod = await import(`./product-catalog.js?test=${Date.now()}-${Math.random()}`);
+  return mod.default;
+}
+
+function deleteRequest(authHeader) {
+  const headers = new Headers();
+  if (authHeader != null) headers.set('Authorization', authHeader);
+  return new Request('https://api.worldmonitor.app/api/product-catalog', {
+    method: 'DELETE',
+    headers,
+  });
+}
+
+afterEach(() => {
+  restoreEnv();
+});
+
+test('DELETE purge accepts only the exact relay bearer secret', async () => {
+  const handler = await importHandler({ relaySecret: 'relay-secret-with-distinct-length' });
+
+  const accepted = await handler(deleteRequest('Bearer relay-secret-with-distinct-length'));
+  assert.equal(accepted.status, 200);
+  assert.deepEqual(await accepted.json(), { purged: true });
+
+  const prefixOnly = await handler(deleteRequest('Bearer relay-secret-with-distinct'));
+  assert.equal(prefixOnly.status, 401);
+
+  const longerMismatch = await handler(deleteRequest('Bearer relay-secret-with-distinct-length-extra'));
+  assert.equal(longerMismatch.status, 401);
+});
+
+test('DELETE purge fails closed when RELAY_SHARED_SECRET is missing', async () => {
+  const handler = await importHandler({ relaySecret: null });
+
+  const missingSecret = await handler(deleteRequest('Bearer '));
+  assert.equal(missingSecret.status, 401);
+
+  const noAuth = await handler(deleteRequest(null));
+  assert.equal(noAuth.status, 401);
+});

--- a/api/widget-agent.ts
+++ b/api/widget-agent.ts
@@ -19,21 +19,21 @@ export const config = { runtime: 'edge' };
 
 // @ts-expect-error — JS module, no declaration file
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+// @ts-expect-error — JS module, no declaration file
+import { timingSafeEqualSecret, timingSafeIncludes } from './_crypto.js';
 import { validateBearerToken } from '../server/auth-session';
 import { getEntitlements } from '../server/_shared/entitlement-check';
 
 const RELAY_BASE = 'https://proxy.worldmonitor.app';
 const WIDGET_AGENT_KEY = process.env.WIDGET_AGENT_KEY ?? '';
 const PRO_WIDGET_KEY = process.env.PRO_WIDGET_KEY ?? '';
-const WORLDMONITOR_VALID_KEY_SET = new Set(
-  (process.env.WORLDMONITOR_VALID_KEYS ?? '')
-    .split(',')
-    .map((v) => v.trim())
-    .filter(Boolean),
-);
+const WORLDMONITOR_VALID_KEYS = (process.env.WORLDMONITOR_VALID_KEYS ?? '')
+  .split(',')
+  .map((v) => v.trim())
+  .filter(Boolean);
 
-function hasValidWorldMonitorKey(key: string): boolean {
-  return Boolean(key) && WORLDMONITOR_VALID_KEY_SET.has(key);
+async function hasValidWorldMonitorKey(key: string): Promise<boolean> {
+  return timingSafeIncludes(key, WORLDMONITOR_VALID_KEYS);
 }
 
 function getCookie(req: Request, name: string): string {
@@ -88,7 +88,7 @@ export default async function handler(req: Request): Promise<Response> {
     headerWorldMonitorKey ||
     getCookie(req, 'wm-pro-key') ||
     getCookie(req, 'wm-widget-key');
-  if (hasValidWorldMonitorKey(worldMonitorKey)) {
+  if (await hasValidWorldMonitorKey(worldMonitorKey)) {
     isPro = true;
   } else {
     const authHeader = req.headers.get('Authorization');
@@ -146,8 +146,8 @@ export default async function handler(req: Request): Promise<Response> {
       // Legacy tester key path (wm-widget-key / wm-pro-key)
       const widgetKey = req.headers.get('X-Widget-Key') || getCookie(req, 'wm-widget-key');
       const proKey = req.headers.get('X-Pro-Key') || getCookie(req, 'wm-pro-key');
-      const hasWidgetKey = Boolean(WIDGET_AGENT_KEY && widgetKey === WIDGET_AGENT_KEY);
-      const hasProKey = Boolean(PRO_WIDGET_KEY && proKey === PRO_WIDGET_KEY);
+      const hasWidgetKey = await timingSafeEqualSecret(widgetKey, WIDGET_AGENT_KEY);
+      const hasProKey = await timingSafeEqualSecret(proKey, PRO_WIDGET_KEY);
       if (!hasWidgetKey && !hasProKey) {
         return json({ error: 'Forbidden' }, 403, corsHeaders);
       }

--- a/api/wm-session.js
+++ b/api/wm-session.js
@@ -4,6 +4,7 @@
 // short-lived HttpOnly cookies so they stop living in JS-readable storage.
 
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
+import { timingSafeEqualSecret, timingSafeIncludes } from './_crypto.js';
 import { checkRateLimit } from './_rate-limit.js';
 import { issueSessionToken } from './_session.js';
 
@@ -65,21 +66,21 @@ function envList(name) {
     .filter(Boolean);
 }
 
-function matchesEnvSecret(key, name) {
+async function matchesEnvSecret(key, name) {
   const secret = process.env[name] || '';
-  return Boolean(key && secret && key === secret);
+  return timingSafeEqualSecret(key, secret);
 }
 
-function isValidEnterpriseKey(key) {
-  return Boolean(key && envList('WORLDMONITOR_VALID_KEYS').includes(key));
+async function isValidEnterpriseKey(key) {
+  return timingSafeIncludes(key, envList('WORLDMONITOR_VALID_KEYS'));
 }
 
-function isValidWidgetKey(key) {
-  return matchesEnvSecret(key, 'WIDGET_AGENT_KEY') || isValidEnterpriseKey(key);
+async function isValidWidgetKey(key) {
+  return (await matchesEnvSecret(key, 'WIDGET_AGENT_KEY')) || await isValidEnterpriseKey(key);
 }
 
-function isValidProKey(key) {
-  return matchesEnvSecret(key, 'PRO_WIDGET_KEY') || isValidEnterpriseKey(key);
+async function isValidProKey(key) {
+  return (await matchesEnvSecret(key, 'PRO_WIDGET_KEY')) || await isValidEnterpriseKey(key);
 }
 
 async function readBody(req) {
@@ -128,8 +129,8 @@ export default async function handler(req) {
   const proKey = normalizeLegacyKey(body.proKey);
 
   if (
-    (submittedLegacyKey(body.widgetKey) && !isValidWidgetKey(widgetKey)) ||
-    (submittedLegacyKey(body.proKey) && !isValidProKey(proKey))
+    (submittedLegacyKey(body.widgetKey) && !(await isValidWidgetKey(widgetKey))) ||
+    (submittedLegacyKey(body.proKey) && !(await isValidProKey(proKey)))
   ) {
     return jsonResponse({ error: 'Invalid session key' }, 401, cors);
   }

--- a/api/wm-session.test.mjs
+++ b/api/wm-session.test.mjs
@@ -145,6 +145,60 @@ test('enterprise key can be exchanged into a short-lived HttpOnly pro cookie', a
   assert.match(cookies.join('\n'), /wm-pro-key=enterprise-secret;.*HttpOnly/);
 });
 
+test('legacy widget/pro secret checks reject prefix and length mismatches', async () => {
+  const previousWidget = process.env.WIDGET_AGENT_KEY;
+  const previousPro = process.env.PRO_WIDGET_KEY;
+  const previousEnterprise = process.env.WORLDMONITOR_VALID_KEYS;
+  process.env.WIDGET_AGENT_KEY = 'widget-secret-with-a-distinct-length';
+  process.env.PRO_WIDGET_KEY = 'pro-secret-with-a-longer-distinct-length';
+  process.env.WORLDMONITOR_VALID_KEYS = 'enterprise-short,enterprise-secret-with-a-longer-length';
+
+  try {
+    const accepted = await handler(new Request('https://api.worldmonitor.app/api/wm-session', {
+      method: 'POST',
+      headers: {
+        origin: 'https://worldmonitor.app',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        widgetKey: 'widget-secret-with-a-distinct-length',
+        proKey: 'enterprise-secret-with-a-longer-length',
+      }),
+    }));
+    assert.equal(accepted.status, 200);
+
+    const prefixOnly = await handler(new Request('https://api.worldmonitor.app/api/wm-session', {
+      method: 'POST',
+      headers: {
+        origin: 'https://worldmonitor.app',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        widgetKey: 'widget-secret-with-a-distinct',
+        proKey: 'enterprise-secret-with-a-longer',
+      }),
+    }));
+    assert.equal(prefixOnly.status, 401);
+
+    const differentLength = await handler(new Request('https://api.worldmonitor.app/api/wm-session', {
+      method: 'POST',
+      headers: {
+        origin: 'https://worldmonitor.app',
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        widgetKey: 'widget-secret-with-a-distinct-length-extra',
+        proKey: 'enterprise-short-extra',
+      }),
+    }));
+    assert.equal(differentLength.status, 401);
+  } finally {
+    process.env.WIDGET_AGENT_KEY = previousWidget;
+    process.env.PRO_WIDGET_KEY = previousPro;
+    process.env.WORLDMONITOR_VALID_KEYS = previousEnterprise;
+  }
+});
+
 test('invalid legacy keys are rejected and not persisted as HttpOnly cookies', async () => {
   const req = new Request('https://api.worldmonitor.app/api/wm-session', {
     method: 'POST',

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "dryrun:resilience": "node --import tsx/esm scripts/dry-run-resilience-rebalance.mjs",
     "test:feeds": "node scripts/validate-rss-feeds.mjs",
     "test:feeds:ci": "node scripts/validate-rss-feeds.mjs --ci",
-    "test:sidecar": "node --test src-tauri/sidecar/local-api-server.test.mjs api/_cors.test.mjs api/_session.test.mjs api/_api-key.test.mjs api/_user-api-key.test.mjs api/bootstrap-auth.test.mjs api/wm-session.test.mjs api/youtube/embed.test.mjs api/cyber-threats.test.mjs api/usni-fleet.test.mjs scripts/ais-relay-rss.test.cjs api/loaders-xml-wms-regression.test.mjs api/security/report.test.mjs",
+    "test:sidecar": "node --test src-tauri/sidecar/local-api-server.test.mjs api/_cors.test.mjs api/_session.test.mjs api/_api-key.test.mjs api/_user-api-key.test.mjs api/bootstrap-auth.test.mjs api/wm-session.test.mjs api/product-catalog.test.mjs api/youtube/embed.test.mjs api/cyber-threats.test.mjs api/usni-fleet.test.mjs scripts/ais-relay-rss.test.cjs api/loaders-xml-wms-regression.test.mjs api/security/report.test.mjs",
     "test:e2e:visual:full": "cross-env VITE_VARIANT=full playwright test -g \"matches golden screenshots per layer and zoom\"",
     "test:e2e:visual:tech": "cross-env VITE_VARIANT=tech playwright test -g \"matches golden screenshots per layer and zoom\"",
     "test:e2e:visual": "npm run test:e2e:visual:full && npm run test:e2e:visual:tech",

--- a/scripts/ais-relay.cjs
+++ b/scripts/ais-relay.cjs
@@ -10784,8 +10784,8 @@ function requireWidgetAgentAccess(req, res) {
 
   const providedKey = getWidgetAgentProvidedKey(req);
   const providedProKey = getWidgetAgentProvidedProKey(req);
-  const hasValidWidgetKey = status.widgetKeyConfigured && providedKey && providedKey === WIDGET_AGENT_KEY;
-  const hasValidProKey = status.proKeyConfigured && providedProKey && providedProKey === PRO_WIDGET_KEY;
+  const hasValidWidgetKey = Boolean(status.widgetKeyConfigured && providedKey && safeTokenEquals(providedKey, WIDGET_AGENT_KEY));
+  const hasValidProKey = Boolean(status.proKeyConfigured && providedProKey && safeTokenEquals(providedProKey, PRO_WIDGET_KEY));
   if (!hasValidWidgetKey && !hasValidProKey) {
     safeEnd(res, 403, { 'Content-Type': 'application/json' }, JSON.stringify({ ...status, error: 'Forbidden' }));
     return null;
@@ -10864,7 +10864,7 @@ async function handleWidgetAgentRequest(req, res) {
     }
     if (status.admittedAs !== 'pro') {
       const providedProKey = getWidgetAgentProvidedProKey(req);
-      if (!providedProKey || providedProKey !== PRO_WIDGET_KEY) {
+      if (!providedProKey || !safeTokenEquals(providedProKey, PRO_WIDGET_KEY)) {
         return safeEnd(res, 403, { 'Content-Type': 'application/json' }, JSON.stringify({ error: 'Forbidden' }));
       }
     }

--- a/server/_shared/premium-check.ts
+++ b/server/_shared/premium-check.ts
@@ -1,5 +1,7 @@
 // @ts-expect-error — JS module, no declaration file
 import { validateApiKey } from '../../api/_api-key.js';
+// @ts-expect-error — JS module, no declaration file
+import { timingSafeIncludes } from '../../api/_crypto.js';
 import { validateBearerToken } from '../auth-session';
 import { getEntitlements } from './entitlement-check';
 import {
@@ -74,7 +76,7 @@ export async function isCallerPremium(request: Request): Promise<boolean> {
   if (wmKey) {
     const validKeys = (process.env.WORLDMONITOR_VALID_KEYS ?? '')
       .split(',').map((k) => k.trim()).filter(Boolean);
-    if (validKeys.length > 0 && validKeys.includes(wmKey)) return true;
+    if (await timingSafeIncludes(wmKey, validKeys)) return true;
 
     // Check user-owned API keys (wm_ prefix) via Convex lookup.
     // Key existence alone is not sufficient — verify the owner's entitlement.

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -14,7 +14,7 @@ import { getCorsHeaders, isDisallowedOrigin, isAllowedOrigin } from './cors';
 // @ts-expect-error — JS module, no declaration file
 import { USER_API_KEY_GATEWAY_VALIDATION_ERROR, validateApiKey } from '../api/_api-key.js';
 // @ts-expect-error — JS module, no declaration file
-import { timingSafeIncludes } from '../api/_crypto.js';
+import { timingSafeEqualSecret } from '../api/_crypto.js';
 // @ts-expect-error — JS module, no declaration file
 import { captureSilentError } from '../api/_sentry-edge.js';
 import { mapErrorToResponse } from './error-mapper';
@@ -593,7 +593,7 @@ export function createDomainGateway(
     const rawWidgetKey = request.headers.get('x-widget-key') ?? null;
     const widgetAgentKey = process.env.WIDGET_AGENT_KEY ?? '';
     const validatedWidgetKey =
-      await timingSafeIncludes(rawWidgetKey ?? '', widgetAgentKey ? [widgetAgentKey] : []) ? rawWidgetKey : null;
+      await timingSafeEqualSecret(rawWidgetKey, widgetAgentKey) ? rawWidgetKey : null;
     const usage: UsageIdentityInput = {
       sessionUserId: null,
       isUserApiKey: false,

--- a/server/gateway.ts
+++ b/server/gateway.ts
@@ -14,6 +14,8 @@ import { getCorsHeaders, isDisallowedOrigin, isAllowedOrigin } from './cors';
 // @ts-expect-error — JS module, no declaration file
 import { USER_API_KEY_GATEWAY_VALIDATION_ERROR, validateApiKey } from '../api/_api-key.js';
 // @ts-expect-error — JS module, no declaration file
+import { timingSafeIncludes } from '../api/_crypto.js';
+// @ts-expect-error — JS module, no declaration file
 import { captureSilentError } from '../api/_sentry-edge.js';
 import { mapErrorToResponse } from './error-mapper';
 import { checkRateLimit, checkEndpointRateLimit, hasEndpointRatePolicy } from './_shared/rate-limit';
@@ -591,7 +593,7 @@ export function createDomainGateway(
     const rawWidgetKey = request.headers.get('x-widget-key') ?? null;
     const widgetAgentKey = process.env.WIDGET_AGENT_KEY ?? '';
     const validatedWidgetKey =
-      rawWidgetKey && widgetAgentKey && rawWidgetKey === widgetAgentKey ? rawWidgetKey : null;
+      await timingSafeIncludes(rawWidgetKey ?? '', widgetAgentKey ? [widgetAgentKey] : []) ? rawWidgetKey : null;
     const usage: UsageIdentityInput = {
       sessionUserId: null,
       isUserApiKey: false,

--- a/tests/gateway-internal-mcp.test.mjs
+++ b/tests/gateway-internal-mcp.test.mjs
@@ -18,6 +18,7 @@
 
 import { strict as assert } from 'node:assert';
 import { describe, it, beforeEach, afterEach } from 'node:test';
+import { readFile } from 'node:fs/promises';
 
 import { createDomainGateway } from '../server/gateway.ts';
 import {
@@ -714,6 +715,47 @@ describe('gateway internal-MCP — header injection defense', () => {
     });
     const result = await isCallerPremium(req);
     assert.equal(result, false, 'guessed-constant marker rejected by nonce check');
+  });
+
+  it('isCallerPremium enterprise key path accepts exact keys and rejects length mismatches', async () => {
+    process.env.WORLDMONITOR_VALID_KEYS = 'enterprise-short,enterprise-key-with-a-distinct-length';
+
+    const exact = new Request('https://api.worldmonitor.app/api/mcp-proxy', {
+      method: 'GET',
+      headers: { 'X-WorldMonitor-Key': 'enterprise-key-with-a-distinct-length' },
+    });
+    assert.equal(await isCallerPremium(exact), true);
+
+    const prefixOnly = new Request('https://api.worldmonitor.app/api/mcp-proxy', {
+      method: 'GET',
+      headers: { 'X-WorldMonitor-Key': 'enterprise-key-with-a-distinct' },
+    });
+    assert.equal(await isCallerPremium(prefixOnly), false);
+
+    const longerMismatch = new Request('https://api.worldmonitor.app/api/mcp-proxy', {
+      method: 'GET',
+      headers: { 'X-WorldMonitor-Key': 'enterprise-short-extra' },
+    });
+    assert.equal(await isCallerPremium(longerMismatch), false);
+  });
+
+  it('premium-check enterprise allowlist uses the timing-safe helper', async () => {
+    const source = await readFile(new URL('../server/_shared/premium-check.ts', import.meta.url), 'utf8');
+    assert.match(
+      source,
+      /import\s*\{[^}]*\btimingSafeIncludes\b[^}]*\}\s*from\s*['"]\.\.\/\.\.\/api\/_crypto\.js['"]/,
+      'premium-check must import the shared timingSafeIncludes helper',
+    );
+    assert.match(
+      source,
+      /await\s+timingSafeIncludes\s*\(\s*wmKey\s*,\s*validKeys\s*\)/,
+      'premium-check must validate enterprise keys with timingSafeIncludes',
+    );
+    assert.doesNotMatch(
+      source,
+      /validKeys\.includes\s*\(\s*wmKey\s*\)/,
+      'premium-check must not use Array.includes for enterprise key auth',
+    );
   });
 
   it('present-but-invalid HMAC + valid wm_ key: invalid path fails closed (does not chain to legacy)', async () => {

--- a/tests/widget-agent-auth.test.mts
+++ b/tests/widget-agent-auth.test.mts
@@ -166,4 +166,41 @@ describe('widget-agent unified tester key auth', () => {
     const body = await res.json() as { error: string };
     assert.equal(body.error, 'Forbidden');
   });
+
+  it('rejects prefix and length mismatches for browser and legacy tester keys', async () => {
+    const browserPrefix = await handler(new Request('https://www.worldmonitor.app/api/widget-agent', {
+      method: 'POST',
+      headers: {
+        Origin: 'https://www.worldmonitor.app',
+        'Content-Type': 'application/json',
+        'X-WorldMonitor-Key': 'browser-test',
+      },
+      body: JSON.stringify({ prompt: 'Build a widget', mode: 'create', tier: 'pro' }),
+    }));
+    assert.equal(browserPrefix.status, 403);
+
+    const proLonger = await handler(new Request('https://www.worldmonitor.app/api/widget-agent', {
+      method: 'POST',
+      headers: {
+        Origin: 'https://www.worldmonitor.app',
+        'Content-Type': 'application/json',
+        'X-Pro-Key': 'server-pro-key-extra',
+      },
+      body: JSON.stringify({ prompt: 'Build a widget', mode: 'create', tier: 'pro' }),
+    }));
+    assert.equal(proLonger.status, 403);
+
+    const widgetLonger = await handler(new Request('https://www.worldmonitor.app/api/widget-agent', {
+      method: 'POST',
+      headers: {
+        Origin: 'https://www.worldmonitor.app',
+        'Content-Type': 'application/json',
+        'X-Widget-Key': 'server-widget-key-extra',
+      },
+      body: JSON.stringify({ prompt: 'Build a widget', mode: 'create', tier: 'basic' }),
+    }));
+    assert.equal(widgetLonger.status, 403);
+
+    assert.equal(fetchMock.mock.calls.length, 0);
+  });
 });

--- a/tests/widget-builder.test.mjs
+++ b/tests/widget-builder.test.mjs
@@ -993,7 +993,7 @@ describe('PRO widget — relay auth and configuration', () => {
       'getWidgetAgentProvidedProKey function must be defined',
     );
     // The PRO key comparison is near the 403 rejection — find it directly
-    const keyCompareIdx = relay.indexOf('providedProKey !== PRO_WIDGET_KEY');
+    const keyCompareIdx = relay.indexOf('!safeTokenEquals(providedProKey, PRO_WIDGET_KEY)');
     assert.ok(keyCompareIdx !== -1, 'PRO key comparison must be present');
     const region = relay.slice(keyCompareIdx, keyCompareIdx + 200);
     assert.ok(region.includes('403'), 'Wrong PRO key must return 403');


### PR DESCRIPTION
## Summary

- Added `timingSafeEqualSecret()` on top of the existing hash-based `_crypto.js` timing-safe helper.
- Replaced remaining env-backed auth comparisons in `wm-session`, `product-catalog`, `premium-check`, `widget-agent`, `gateway`, and the Railway relay widget gate.
- Added focused negative coverage for prefix and length mismatches across the changed auth paths.

## Intent

Close #4680 by removing plain JavaScript equality, `Set.has()`, and `Array.includes()` checks for static bearer/API/widget secret material in runtime auth code.

Non-goals:
- No changes to ordinary non-secret collection membership checks.
- No UI, copy, API shape, or documentation changes.

## Validation Matrix

| Check | Status |
|---|---|
| `node --test api/wm-session.test.mjs api/product-catalog.test.mjs` | Pass |
| `TMPDIR=/tmp node --import tsx --test tests/gateway-internal-mcp.test.mjs` | Pass |
| `npm run test:sidecar` | Pass |
| `npm run typecheck:api` | Pass |
| `TMPDIR=/tmp node --import tsx --test tests/no-non-timing-safe-secret-compare.test.mts tests/mcp-proxy.test.mjs` | Pass |
| `TMPDIR=/tmp node --import tsx --test tests/widget-agent-auth.test.mts tests/widget-builder.test.mjs tests/gateway-internal-mcp.test.mjs` | Pass |
| `node --check scripts/ais-relay.cjs` | Pass |
| `npm run typecheck` | Pass |
| `./node_modules/.bin/biome check <touched files>` | Pass |
| `git diff --check` | Pass |
| Targeted runtime auth source scan | Pass; remaining hits are non-secret collection membership |

## Review Gates

- Baseline reviewer: pass, no findings.
- Code Review Expert: pass, no P0/P1/P2/P3 findings.
- Outcome Reviewer: pass, issue acceptance criteria satisfied.

## Documentation

Not applicable. This is an internal auth hardening change with focused regression coverage.

## Screenshots / UI Evidence

Not applicable. No UI behavior changed.

## Residual Findings

None.
