### PR TITLE
feat(mcp): public discovery + JSON /api errors + server-card fields (orank Access gaps)

### DIFF
--- a/api/api-route-exceptions.json
+++ b/api/api-route-exceptions.json
@@ -328,6 +328,13 @@
       "removal_issue": null
     },
     {
+      "path": "api/not-found.ts",
+      "category": "ops-admin",
+      "reason": "Structured JSON 404 responder for unmatched /api/* paths (via a vercel.json rewrite). Fixed-shape error envelope for agents/scanners in place of Vercel's native text/plain NOT_FOUND; not a product API.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
       "path": "api/cache-purge.js",
       "category": "ops-admin",
       "reason": "Admin-gated cache invalidation endpoint. Internal operator action, not a product API.",

--- a/api/mcp/auth.ts
+++ b/api/mcp/auth.ts
@@ -5,6 +5,8 @@ import { resolveBearerToContext } from '../_oauth-token.js';
 // @ts-expect-error — JS module, no declaration file
 import { timingSafeIncludes } from '../_crypto.js';
 // @ts-expect-error — JS module, no declaration file
+import { getClientIp } from '../_client-ip.js';
+// @ts-expect-error — JS module, no declaration file
 import { captureSilentError } from '../_sentry-edge.js';
 // @ts-expect-error — JS module, no declaration file
 import { redisPipeline as rawRedisPipeline } from '../_upstash-json.js';
@@ -34,6 +36,11 @@ import type {
 
 let mcpRatelimit: Ratelimit | null = null;
 let mcpProMinRatelimit: Ratelimit | null = null;
+// Anonymous MCP discovery limiter (initialize / tools/list without credentials).
+// Keyed by client IP so a public discovery surface can't be hammered by an
+// unauthenticated caller. Separate prefix from the authed per-key/per-user
+// limiters above so anon traffic never shares a bucket with a real principal.
+let mcpAnonRatelimit: Ratelimit | null = null;
 
 function getMcpRatelimit(): Ratelimit | null {
   if (mcpRatelimit) return mcpRatelimit;
@@ -61,6 +68,20 @@ function getMcpProMinRatelimit(): Ratelimit | null {
     analytics: false,
   });
   return mcpProMinRatelimit;
+}
+
+function getMcpAnonRatelimit(): Ratelimit | null {
+  if (mcpAnonRatelimit) return mcpAnonRatelimit;
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (!url || !token) return null;
+  mcpAnonRatelimit = new Ratelimit({
+    redis: new Redis({ url, token, retry: false }),
+    limiter: Ratelimit.slidingWindow(60, '60 s'),
+    prefix: 'rl:mcp:anon',
+    analytics: false,
+  });
+  return mcpAnonRatelimit;
 }
 
 /**
@@ -255,6 +276,23 @@ export async function applyPerMinuteLimit(context: McpAuthContext, headers: Reco
   try {
     const { success } = await rl.limit(`pro-user:${context.userId}`);
     if (!success) return rpcError(null, -32029, 'Rate limit exceeded. Max 60 requests per minute per Pro user.', headers);
+  } catch { /* graceful degradation */ }
+  return null;
+}
+
+/** Per-IP rate limit for the UNAUTHENTICATED discovery path (initialize /
+ *  tools/list without credentials — the metadata surface agent scanners probe).
+ *  Keyed on the trusted client IP (cf-connecting-ip / x-real-ip; falls back to a
+ *  shared bucket so x-forwarded-for spoofing can't rotate identities). Fail-OPEN
+ *  on Upstash error, matching `applyPerMinuteLimit` — the discovery response is a
+ *  cheap in-memory payload, so availability beats strict enforcement here.
+ *  Returns null on success/skip, a Response on a real 60/min limit hit. */
+export async function applyAnonDiscoveryLimit(req: Request, headers: Record<string, string> = {}): Promise<Response | null> {
+  const rl = getMcpAnonRatelimit();
+  if (!rl) return null;
+  try {
+    const { success } = await rl.limit(`ip:${getClientIp(req)}`);
+    if (!success) return rpcError(null, -32029, 'Rate limit exceeded. Max 60 unauthenticated discovery requests per minute per IP.', headers);
   } catch { /* graceful degradation */ }
   return null;
 }

--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -6,6 +6,7 @@ import {
   PRODUCTION_DEPS,
   resolveAuthContext,
   runProPreChecks,
+  wwwAuthHeader,
 } from './auth';
 import {
   MCP_LOG_LEVELS,
@@ -46,6 +47,18 @@ const PUBLIC_MCP_METHODS: ReadonlySet<string> = new Set([
 function hasCredentials(req: Request): boolean {
   if ((req.headers.get('Authorization') ?? '').startsWith('Bearer ')) return true;
   return (req.headers.get('X-WorldMonitor-Key') ?? '') !== '';
+}
+
+// Spec-correct 401 for the fail-closed guards on data methods. These guards are
+// unreachable today (tools/call / resources/read are never PUBLIC_MCP_METHODS,
+// so `context` is always resolved), but if that invariant is ever broken this
+// fails closed with the SAME 401 + WWW-Authenticate shape resolveAuthContext
+// emits — not a soft 200 JSON-RPC error.
+function authRequiredResponse(id: unknown, resourceMetadataUrl: string, corsHeaders: Record<string, string>): Response {
+  return new Response(
+    JSON.stringify({ jsonrpc: '2.0', id: id ?? null, error: { code: -32001, message: 'Authentication required.' } }),
+    { status: 401, headers: withMcpNoStore({ 'Content-Type': 'application/json', 'WWW-Authenticate': wwwAuthHeader(resourceMetadataUrl), ...corsHeaders }) },
+  );
 }
 
 type StoredSseEvent = {
@@ -371,7 +384,7 @@ export async function mcpHandler(
     case 'tools/call':
       // context is always set here — tools/call is never a PUBLIC_MCP_METHOD.
       // The guard narrows the type and hard-fails closed if that ever changes.
-      if (!context) return rpcError(id, -32001, 'Authentication required.', corsHeaders);
+      if (!context) return authRequiredResponse(id, resourceMetadataUrl, corsHeaders);
       return maybeStreamJsonRpcResponse(req, await dispatchToolsCall(req, context, deps, body, corsHeaders, ctx));
     // Prompts are metadata-class — they ship a workflow template, not data.
     // Symmetric posture with `describe_tool`: quota-exempt (counting template
@@ -403,7 +416,7 @@ export async function mcpHandler(
       return maybeStreamJsonRpcResponse(req, rpcOk(id, { resources: RESOURCE_LIST_RESPONSE }, corsHeaders));
     case 'resources/read':
       // context is always set here — resources/read is never a PUBLIC_MCP_METHOD.
-      if (!context) return rpcError(id, -32001, 'Authentication required.', corsHeaders);
+      if (!context) return authRequiredResponse(id, resourceMetadataUrl, corsHeaders);
       return maybeStreamJsonRpcResponse(req, await buildResourceResponse(req, context, deps, body, corsHeaders, ctx));
     case 'logging/setLevel': {
       const level = (body.params as { level?: string } | null)?.level;

--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -1,6 +1,7 @@
 // @ts-expect-error — JS module, no declaration file
 import { getPublicCorsHeaders } from '../_cors.js';
 import {
+  applyAnonDiscoveryLimit,
   applyPerMinuteLimit,
   PRODUCTION_DEPS,
   resolveAuthContext,
@@ -19,7 +20,33 @@ import { TOOL_LIST_BYTES, TOOL_LIST_RESPONSE } from './registry/index';
 import { buildResourceResponse, RESOURCE_LIST_RESPONSE } from './resources/index';
 import { rpcError, rpcOk, withMcpNoStore } from './rpc';
 import { emitTelemetry, principalIdForLog } from './telemetry';
-import type { McpHandlerDeps } from './types';
+import type { McpAuthContext, McpHandlerDeps } from './types';
+
+// MCP methods servable WITHOUT authentication. These are the zero-data
+// discovery surface an agent (or an agent-readiness scanner) needs to learn
+// what this server is and what tools it exposes BEFORE authenticating —
+// exactly the metadata already published in the static server-card.json and
+// the public docs. Everything that returns DATA or spends quota
+// (`tools/call`, `resources/read`) — and the metadata methods the product
+// deliberately keeps gated (`prompts/list`, `resources/list`,
+// `logging/setLevel`) — still requires credentials. `notifications/initialized`
+// is the client's post-`initialize` handshake notification (carries no data);
+// leaving it public lets a strict MCP client complete the handshake before
+// calling `tools/list`.
+const PUBLIC_MCP_METHODS: ReadonlySet<string> = new Set([
+  'initialize',
+  'notifications/initialized',
+  'tools/list',
+]);
+
+// Mirror of resolveAuthContext's credential-header contract: does the request
+// PRESENT any credential? A public method with NO credentials is served
+// anonymously; a public method carrying a credential still has it validated
+// (a present-but-invalid key is rejected, never silently downgraded to anon).
+function hasCredentials(req: Request): boolean {
+  if ((req.headers.get('Authorization') ?? '').startsWith('Bearer ')) return true;
+  return (req.headers.get('X-WorldMonitor-Key') ?? '') !== '';
+}
 
 type StoredSseEvent = {
   id: string;
@@ -240,23 +267,24 @@ export async function mcpHandler(
   const requestHost = req.headers.get('host') ?? new URL(req.url).host;
   const resourceMetadataUrl = `https://${requestHost}/.well-known/oauth-protected-resource`;
 
-  const auth = await resolveAuthContext(req, deps, resourceMetadataUrl, corsHeaders);
-  if (!auth.ok) return auth.response;
-  const context = auth.context;
-
-  if (context.kind === 'pro') {
-    const proCheck = await runProPreChecks(context, deps, resourceMetadataUrl, corsHeaders, ctx);
-    if (proCheck) return proCheck;
-  }
-
-  const limited = await applyPerMinuteLimit(context, corsHeaders);
-  if (limited) return limited;
-
+  // GET is the SSE-replay path — it re-serves previously-streamed (Pro) tool
+  // result data, so it stays fully authenticated (never a discovery surface).
   if (req.method === 'GET') {
+    const auth = await resolveAuthContext(req, deps, resourceMetadataUrl, corsHeaders);
+    if (!auth.ok) return auth.response;
+    if (auth.context.kind === 'pro') {
+      const proCheck = await runProPreChecks(auth.context, deps, resourceMetadataUrl, corsHeaders, ctx);
+      if (proCheck) return proCheck;
+    }
+    const getLimited = await applyPerMinuteLimit(auth.context, corsHeaders);
+    if (getLimited) return getLimited;
     return handleSseReplay(req, corsHeaders);
   }
 
-  // Parse body
+  // Parse body BEFORE auth: the method decides whether credentials are required
+  // (public discovery methods are servable anonymously). Malformed/missing-method
+  // POSTs are a client error regardless of auth, so returning -32600 here (rather
+  // than 401-then-32600) leaks nothing.
   let body: { jsonrpc?: string; id?: unknown; method?: string; params?: unknown };
   try {
     body = await req.json();
@@ -270,6 +298,35 @@ export async function mcpHandler(
 
   const { id, method } = body;
 
+  // Auth gate. `context` is null only on the anonymous discovery path; every
+  // data/quota method below runs the full protected path and always sets it.
+  let context: McpAuthContext | null = null;
+  if (PUBLIC_MCP_METHODS.has(method)) {
+    if (hasCredentials(req)) {
+      // Credentials presented on a public method are still validated so a
+      // present-but-invalid key surfaces a 401 instead of a silent anon
+      // downgrade; a valid principal is attributed for telemetry + limits.
+      const auth = await resolveAuthContext(req, deps, resourceMetadataUrl, corsHeaders);
+      if (!auth.ok) return auth.response;
+      context = auth.context;
+      const limited = await applyPerMinuteLimit(context, corsHeaders);
+      if (limited) return limited;
+    } else {
+      const anonLimited = await applyAnonDiscoveryLimit(req, corsHeaders);
+      if (anonLimited) return anonLimited;
+    }
+  } else {
+    const auth = await resolveAuthContext(req, deps, resourceMetadataUrl, corsHeaders);
+    if (!auth.ok) return auth.response;
+    context = auth.context;
+    if (context.kind === 'pro') {
+      const proCheck = await runProPreChecks(context, deps, resourceMetadataUrl, corsHeaders, ctx);
+      if (proCheck) return proCheck;
+    }
+    const limited = await applyPerMinuteLimit(context, corsHeaders);
+    if (limited) return limited;
+  }
+
   // Dispatch
   switch (method) {
     case 'initialize': {
@@ -281,8 +338,8 @@ export async function mcpHandler(
       // fixed overhead). UA is sliced to 256 chars: a pathological 32 KB
       // custom UA would otherwise inflate every emitted line for that session.
       emitTelemetry('mcp.tools_list_emitted', {
-        auth_kind: context.kind,
-        user_id: principalIdForLog(context),
+        auth_kind: context?.kind ?? 'anon',
+        user_id: context ? principalIdForLog(context) : 'anon',
         tools_array_bytes: TOOL_LIST_BYTES,
         tool_count: TOOL_LIST_RESPONSE.length,
         client_user_agent: (req.headers.get('User-Agent') ?? '').slice(0, 256),
@@ -312,6 +369,9 @@ export async function mcpHandler(
     case 'tools/list':
       return maybeStreamJsonRpcResponse(req, rpcOk(id, { tools: TOOL_LIST_RESPONSE }, corsHeaders));
     case 'tools/call':
+      // context is always set here — tools/call is never a PUBLIC_MCP_METHOD.
+      // The guard narrows the type and hard-fails closed if that ever changes.
+      if (!context) return rpcError(id, -32001, 'Authentication required.', corsHeaders);
       return maybeStreamJsonRpcResponse(req, await dispatchToolsCall(req, context, deps, body, corsHeaders, ctx));
     // Prompts are metadata-class — they ship a workflow template, not data.
     // Symmetric posture with `describe_tool`: quota-exempt (counting template
@@ -342,6 +402,8 @@ export async function mcpHandler(
     case 'resources/list':
       return maybeStreamJsonRpcResponse(req, rpcOk(id, { resources: RESOURCE_LIST_RESPONSE }, corsHeaders));
     case 'resources/read':
+      // context is always set here — resources/read is never a PUBLIC_MCP_METHOD.
+      if (!context) return rpcError(id, -32001, 'Authentication required.', corsHeaders);
       return maybeStreamJsonRpcResponse(req, await buildResourceResponse(req, context, deps, body, corsHeaders, ctx));
     case 'logging/setLevel': {
       const level = (body.params as { level?: string } | null)?.level;

--- a/api/not-found.ts
+++ b/api/not-found.ts
@@ -1,0 +1,51 @@
+// Structured JSON 404 for unmatched `/api/*` paths.
+//
+// Vercel serves its native `text/plain` "NOT_FOUND" body for any `/api/...`
+// path that doesn't resolve to a function. Agents (and agent-readiness
+// scanners) can't parse an HTML/plain error page, so a `vercel.json` rewrite
+// funnels every otherwise-unmatched `/api/*` request here to return a
+// machine-readable JSON error with a code, a message, and a resolution hint.
+//
+// Filesystem precedence guarantees this only ever runs for paths with NO real
+// function: Vercel matches concrete + dynamic function routes before applying
+// `rewrites` (verified against production), so a live endpoint is never
+// shadowed by this catch-all.
+
+export const config = { runtime: 'edge' };
+
+// @ts-expect-error — JS module, no declaration file
+import { getPublicCorsHeaders } from './_cors.js';
+
+export default function handler(req: Request): Response {
+  const corsHeaders = getPublicCorsHeaders('GET, POST, OPTIONS');
+
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+
+  const pathname = (() => {
+    try {
+      return new URL(req.url).pathname;
+    } catch {
+      return req.url;
+    }
+  })();
+
+  const body = {
+    error: {
+      code: 'not_found',
+      message: `No API endpoint matches ${pathname}.`,
+      hint: 'Check the endpoint path against the OpenAPI spec at https://worldmonitor.app/openapi.yaml or the API reference at https://www.worldmonitor.app/docs/api-reference.',
+    },
+    documentation: 'https://www.worldmonitor.app/docs/api-reference',
+  };
+
+  return new Response(JSON.stringify(body), {
+    status: 404,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'no-store',
+      ...corsHeaders,
+    },
+  });
+}

--- a/api/not-found.ts
+++ b/api/not-found.ts
@@ -44,6 +44,9 @@ export default function handler(req: Request): Response {
     status: 404,
     headers: {
       'Content-Type': 'application/json; charset=utf-8',
+      // The body echoes the requested pathname (JSON-escaped, so no injection);
+      // nosniff stops a client from content-type-sniffing it to HTML anyway.
+      'X-Content-Type-Options': 'nosniff',
       'Cache-Control': 'no-store',
       ...corsHeaders,
     },

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -12,7 +12,7 @@
   "variantCount": 6,
   "componentTopLevelTsFiles": 159,
   "serviceTopLevelEntries": 193,
-  "apiEndpointEntries": 80,
+  "apiEndpointEntries": 81,
   "panelClasses": 104,
   "protoFiles": 276,
   "protoServices": 34,

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -54,6 +54,8 @@ The replay buffer is in-memory and bounded per edge instance. Treat `Last-Event-
 
 ## Authentication
 
+**Discovery is public.** `initialize`, `tools/list`, and the `notifications/initialized` handshake are servable **without credentials**, so any agent (or agent-readiness scanner) can connect to `https://worldmonitor.app/mcp`, read the server identity, and enumerate the full tool catalog before authenticating — the same metadata already published in the static [server card](https://worldmonitor.app/.well-known/mcp/server-card.json). Anonymous discovery is rate-limited to 60 requests/minute per client IP. Everything that returns data or spends quota (`tools/call`, `resources/read`) — and the gated metadata methods `prompts/list`, `resources/list`, and `logging/setLevel` — still requires one of the two auth modes below. A credential presented on a discovery method is still validated (a bad key returns `401`, never a silent anonymous downgrade).
+
 The MCP handler accepts two auth modes, in priority order:
 
 1. **OAuth 2.1 bearer** — `Authorization: Bearer <token>` where `<token>` was issued by `/api/oauth/token`. This is what Claude Desktop, claude.ai, Cursor, and MCP Inspector use automatically. Required for any client that hits MCP from a browser origin.

--- a/tests/api-not-found.test.mjs
+++ b/tests/api-not-found.test.mjs
@@ -1,0 +1,37 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import handler from '../api/not-found.ts';
+
+const URL_BASE = 'https://worldmonitor.app';
+
+describe('api/not-found.ts — structured JSON 404 for unmatched /api/* paths', () => {
+  it('returns a 404 application/json envelope with code, message, and a resolution hint', async () => {
+    const res = handler(new Request(`${URL_BASE}/api/does-not-exist`, { method: 'GET' }));
+    assert.equal(res.status, 404);
+    assert.match(res.headers.get('content-type') ?? '', /application\/json/);
+    const body = await res.json();
+    assert.equal(body.error?.code, 'not_found');
+    assert.ok(typeof body.error?.message === 'string' && body.error.message.length > 0, 'message must be present');
+    assert.ok(body.error.message.includes('/api/does-not-exist'), 'message must echo the requested path');
+    assert.ok(typeof body.error?.hint === 'string' && body.error.hint.length > 0, 'hint must be present');
+    assert.ok(typeof body.documentation === 'string', 'documentation URL must be present');
+  });
+
+  it('is CORS-enabled (agents / cross-origin scanners can read the error)', async () => {
+    const res = handler(new Request(`${URL_BASE}/api/x`, { method: 'GET' }));
+    assert.equal(res.headers.get('access-control-allow-origin'), '*');
+  });
+
+  it('answers an OPTIONS preflight with 204 + CORS', async () => {
+    const res = handler(new Request(`${URL_BASE}/api/x`, { method: 'OPTIONS' }));
+    assert.equal(res.status, 204);
+    assert.equal(res.headers.get('access-control-allow-origin'), '*');
+    assert.match(res.headers.get('access-control-allow-methods') ?? '', /POST/);
+  });
+
+  it('never caches (a 404 must not be served as a cached 200 for a later-added route)', async () => {
+    const res = handler(new Request(`${URL_BASE}/api/x`, { method: 'GET' }));
+    assert.match(res.headers.get('cache-control') ?? '', /no-store/);
+  });
+});

--- a/tests/api-not-found.test.mjs
+++ b/tests/api-not-found.test.mjs
@@ -10,6 +10,7 @@ describe('api/not-found.ts — structured JSON 404 for unmatched /api/* paths', 
     const res = handler(new Request(`${URL_BASE}/api/does-not-exist`, { method: 'GET' }));
     assert.equal(res.status, 404);
     assert.match(res.headers.get('content-type') ?? '', /application\/json/);
+    assert.equal(res.headers.get('x-content-type-options'), 'nosniff', 'reflected-path body must be nosniff');
     const body = await res.json();
     assert.equal(body.error?.code, 'not_found');
     assert.ok(typeof body.error?.message === 'string' && body.error.message.length > 0, 'message must be present');

--- a/tests/live-api-cache-auth-regression.test.mjs
+++ b/tests/live-api-cache-auth-regression.test.mjs
@@ -124,7 +124,7 @@ describe(`live API cache/auth regression sweep (${LIVE ? 'ENABLED' : 'SKIPPED - 
     assertNoSentinelLeak(fake.bodyText, 'premium RPC fake auth');
   });
 
-  it('MCP OPTIONS and unauthenticated POST are protocol-valid no-store responses', async () => {
+  it('MCP OPTIONS, public discovery, and gated data method are protocol-valid no-store responses', async () => {
     const options = await fetchText(`${WEB_BASE}/mcp`, {
       method: 'OPTIONS',
       headers: {
@@ -136,7 +136,9 @@ describe(`live API cache/auth regression sweep (${LIVE ? 'ENABLED' : 'SKIPPED - 
     assert.match(options.resp.headers.get('access-control-allow-methods') || '', /\bPOST\b/);
     assertNoStore(options.resp, 'MCP OPTIONS');
 
-    const post = await fetchText(`${WEB_BASE}/mcp`, {
+    // Discovery is public: unauthenticated `initialize` succeeds (200) and must
+    // still be no-store (the #4497 cached-200 hazard applies to any 200).
+    const discover = await fetchText(`${WEB_BASE}/mcp`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -153,9 +155,28 @@ describe(`live API cache/auth regression sweep (${LIVE ? 'ENABLED' : 'SKIPPED - 
         },
       }),
     });
+    assert.equal(discover.resp.status, 200, 'unauthenticated initialize is public discovery');
+    assertNoStore(discover.resp, 'MCP anonymous initialize');
+    assert.notEqual(cfCacheStatus(discover.resp).toUpperCase(), 'HIT', 'anonymous discovery 200 must not be a shared-cache HIT');
+
+    // A DATA/quota method stays gated: unauthenticated `tools/call` must be a
+    // no-store, dynamic 401 carrying the OAuth resource_metadata hint.
+    const post = await fetchText(`${WEB_BASE}/mcp`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'get_market_data', arguments: {} },
+      }),
+    });
     assert.equal(post.resp.status, 401);
     assert.match(post.resp.headers.get('www-authenticate') || '', /resource_metadata=/);
-    assertNoStore(post.resp, 'MCP unauthenticated POST');
+    assertNoStore(post.resp, 'MCP unauthenticated data method');
 
     const body = JSON.parse(post.bodyText);
     assert.equal(body.error?.code, -32001);

--- a/tests/mcp-capability-parity.test.mjs
+++ b/tests/mcp-capability-parity.test.mjs
@@ -234,6 +234,20 @@ describe('api/mcp.ts — capability parity (advertised AND non-empty)', () => {
     assert.match(notes, /Per-minute .* counts ALL methods/i, 'notes must distinguish per-minute from daily exemptions');
   });
 
+  // The card carries the identity fields BOTH top-level (for scanners that read
+  // the flat shape, e.g. ora.ai's mcp-server-card check) AND nested under
+  // serverInfo (the shape the handler + sibling tests read). Guard the two from
+  // drifting on the next version bump.
+  it('top-level server-card identity mirrors serverInfo (no drift)', () => {
+    const card = JSON.parse(
+      readFileSync(new URL('../public/.well-known/mcp/server-card.json', import.meta.url), 'utf8'),
+    );
+    assert.equal(card.name, card.serverInfo?.name, 'top-level name must mirror serverInfo.name');
+    assert.equal(card.version, card.serverInfo?.version, 'top-level version must mirror serverInfo.version');
+    assert.equal(card.description, card.serverInfo?.description, 'top-level description must mirror serverInfo.description');
+    assert.equal(card.serverUrl, card.transport?.endpoint, 'top-level serverUrl must mirror transport.endpoint');
+  });
+
 });
 
 describe('docs/mcp-server.mdx — API-key quota contract', () => {

--- a/tests/mcp-protocol-conformance.test.mjs
+++ b/tests/mcp-protocol-conformance.test.mjs
@@ -1,13 +1,14 @@
 // End-to-end MCP session lifecycle (in-process). Walks a single thread:
 //
-//   unauth → initialize → tools/list → describe_tool (quota-exempt)
+//   unauth tools/call (gated 401) → unauth initialize + tools/list (public 200)
+//   → initialize → tools/list → describe_tool (quota-exempt)
 //   → tools/call (pre-seeded near cap, success) → tools/call (cap exceeded)
 //   → re-initialize → tools/call (still cap exceeded)
 //
 // Asserts the JSON-RPC envelope at each hop, the `Mcp-Session-Id` response
-// header on `initialize`, the 401-vs-200 auth split, and that the Pro daily
-// quota counter is the load-bearing reservoir — neither `describe_tool` nor
-// re-`initialize` mutates it.
+// header on `initialize`, the auth split (discovery is public; tools/call is
+// gated), and that the Pro daily quota counter is the load-bearing reservoir —
+// neither `describe_tool` nor re-`initialize` mutates it.
 //
 // Why one `it()` for the whole sequence: the value here is the LIFECYCLE
 // thread, not any single envelope check (those are covered per-method in
@@ -95,10 +96,11 @@ describe('api/mcp.ts — protocol conformance lifecycle (in-process)', () => {
   });
 
   it('walks initialize → tools/list → describe_tool → tools/call × N → re-init → still-locked-out', async () => {
-    // Step 1 — unauthenticated POST is gated BEFORE the session starts.
-    // Asserts the 401 envelope (HTTP status, WWW-Authenticate Bearer realm,
-    // JSON-RPC code -32001) so a regression that drops the gate is caught
-    // at the very first hop.
+    // Step 1 — the auth wall is a DATA/quota method (tools/call). An
+    // unauthenticated tools/call is gated BEFORE the session touches any
+    // backend. Asserts the 401 envelope (HTTP status, WWW-Authenticate Bearer
+    // realm, JSON-RPC code -32001) so a regression that drops the gate is
+    // caught at the very first hop.
     //
     // Deps bundle is intentionally a thrower-stub: `resolveAuthContext` must
     // return 401 BEFORE consulting any dep — no Bearer header means no
@@ -117,24 +119,47 @@ describe('api/mcp.ts — protocol conformance lifecycle (in-process)', () => {
       getEntitlements: unreachable('getEntitlements'),
       redisPipeline: unreachable('redisPipeline'),
     };
+    const unauthReq = (body) => new Request(BASE_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
     const step1Res = await mcpHandler(
-      new Request(BASE_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          jsonrpc: '2.0', id: 1, method: 'initialize',
-          params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'lifecycle-test', version: '1.0' } },
-        }),
+      unauthReq({
+        jsonrpc: '2.0', id: 1, method: 'tools/call',
+        params: { name: 'get_market_data', arguments: {} },
       }),
       step1Deps,
     );
-    assert.equal(step1Res.status, 401, 'step 1 (unauth initialize): expected HTTP 401');
+    assert.equal(step1Res.status, 401, 'step 1 (unauth tools/call): expected HTTP 401');
     assert.ok(
       (step1Res.headers.get('www-authenticate') ?? '').includes('Bearer realm="worldmonitor"'),
-      'step 1 (unauth initialize): WWW-Authenticate Bearer realm missing',
+      'step 1 (unauth tools/call): WWW-Authenticate Bearer realm missing',
     );
     const step1Body = await step1Res.json();
-    assert.equal(step1Body.error?.code, -32001, 'step 1 (unauth initialize): JSON-RPC code must be -32001');
+    assert.equal(step1Body.error?.code, -32001, 'step 1 (unauth tools/call): JSON-RPC code must be -32001');
+
+    // Step 1b — discovery is PUBLIC. Unauthenticated initialize + tools/list
+    // succeed WITHOUT touching any dep (thrower-stub bundle stays untouched),
+    // proving the discovery surface bypasses the auth wall cleanly.
+    const step1bInit = await mcpHandler(
+      unauthReq({
+        jsonrpc: '2.0', id: '1b', method: 'initialize',
+        params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'lifecycle-test', version: '1.0' } },
+      }),
+      step1Deps,
+    );
+    assert.equal(step1bInit.status, 200, 'step 1b (unauth initialize): discovery must be public');
+    assert.ok(step1bInit.headers.get('mcp-session-id'), 'step 1b: anonymous initialize must still issue a session id');
+
+    const step1bList = await mcpHandler(
+      unauthReq({ jsonrpc: '2.0', id: '1c', method: 'tools/list', params: {} }),
+      step1Deps,
+    );
+    assert.equal(step1bList.status, 200, 'step 1b (unauth tools/list): discovery must be public');
+    const step1bListBody = await step1bList.json();
+    assert.ok(Array.isArray(step1bListBody.result?.tools) && step1bListBody.result.tools.length >= 3,
+      'step 1b: anonymous tools/list must expose the tool catalog');
 
     // Steps 2-4 share one Pro deps bundle with the counter at 0. `describe_tool`
     // is the metadata-exempt tool — using the same deps proves the counter

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -71,16 +71,65 @@ describe('api/mcp.ts — PRO MCP Server', () => {
 
   // --- Auth ---
 
-  it('returns HTTP 401 + WWW-Authenticate when no credentials provided', async () => {
+  // A DATA/quota method (tools/call) is the auth wall: unauthenticated → 401.
+  // Discovery methods (initialize / tools/list) are intentionally public — see
+  // the 'public discovery' block below — so they are NOT the probe here.
+  const protectedCallBody = (id = 1) => ({
+    jsonrpc: '2.0', id, method: 'tools/call',
+    params: { name: 'get_market_data', arguments: {} },
+  });
+
+  it('returns HTTP 401 + WWW-Authenticate when no credentials provided (protected method)', async () => {
     const req = new Request(BASE_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(initBody()),
+      body: JSON.stringify(protectedCallBody()),
     });
     const res = await handler(req);
     assert.equal(res.status, 401);
     assert.ok(res.headers.get('www-authenticate')?.includes('Bearer realm="worldmonitor"'), 'must include WWW-Authenticate header');
     assert.match(res.headers.get('cache-control') || '', /\bno-store\b/i);
+    const body = await res.json();
+    assert.equal(body.error?.code, -32001);
+  });
+
+  // --- Public discovery (initialize + tools/list are servable without creds) ---
+
+  it('initialize succeeds WITHOUT credentials (public discovery)', async () => {
+    const req = new Request(BASE_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(initBody(1)),
+    });
+    const res = await handler(req);
+    assert.equal(res.status, 200, 'unauthenticated initialize must be public');
+    const body = await res.json();
+    assert.equal(body.result?.protocolVersion, '2025-03-26');
+    assert.equal(body.result?.serverInfo?.name, 'worldmonitor');
+    assert.ok(res.headers.get('mcp-session-id'), 'Mcp-Session-Id must be issued on the anonymous handshake');
+    assertNoStore(res, 'anonymous initialize');
+  });
+
+  it('tools/list succeeds WITHOUT credentials (public discovery) and returns tools', async () => {
+    const req = new Request(BASE_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }),
+    });
+    const res = await handler(req);
+    assert.equal(res.status, 200, 'unauthenticated tools/list must be public');
+    const body = await res.json();
+    assert.ok(Array.isArray(body.result?.tools) && body.result.tools.length >= 3, 'must expose the tool catalog anonymously');
+  });
+
+  it('tools/call still requires credentials even though discovery is public', async () => {
+    const req = new Request(BASE_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(protectedCallBody(3)),
+    });
+    const res = await handler(req);
+    assert.equal(res.status, 401, 'tools/call is a data/quota method — must stay gated');
     const body = await res.json();
     assert.equal(body.error?.code, -32001);
   });
@@ -169,7 +218,7 @@ describe('api/mcp.ts — PRO MCP Server', () => {
     const unauthenticated = await handler(new Request(BASE_URL, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(initBody()),
+      body: JSON.stringify(protectedCallBody()),
     }));
     assert.equal(unauthenticated.status, 401);
     assertNoStore(unauthenticated, 'auth error');

--- a/vercel.json
+++ b/vercel.json
@@ -18,8 +18,10 @@
     { "source": "/oauth/authorize", "destination": "/api/oauth/authorize" },
     { "source": "/oauth/authorize-pro", "destination": "/api/oauth/authorize-pro" },
     { "source": "/.well-known/oauth-protected-resource", "destination": "/api/oauth-protected-resource" },
+    { "source": "/.well-known/mcp", "destination": "/.well-known/mcp/server-card.json" },
     { "source": "/embed", "destination": "/embed.html" },
     { "source": "/dashboard", "destination": "/dashboard.html" },
+    { "source": "/api/:path*", "destination": "/api/not-found" },
     { "source": "/((?!api|mcp|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)", "destination": "/dashboard.html" }
   ],
   "headers": [


### PR DESCRIPTION
## What & why

Raises worldmonitor.app's **agent-readiness** score ([ora.ai / orank](https://ora.ai/score/worldmonitor.app), currently **63/100 — C**) by closing the three flagged **Access-layer** gaps. The root causes were found by probing the live site + reading the scanner's per-check output, not guessed.

| orank check | before | root cause | fix |
|---|---|---|---|
| **MCP server / manifest** | 2/6 + ~14 "no MCP server detected" bonus checks | the edge MCP handler gated **every** method (even `initialize`/`tools/list`) behind a 401, so the unauthenticated scanner could never complete the Streamable-HTTP handshake | public discovery (below) |
| **JSON error responses** | 0/4 | unmatched `/api/*` paths returned Vercel's `text/plain` `NOT_FOUND`, so the scanner concluded "no JSON API surface" | structured JSON 404 responder |
| **WebMCP support** | 1/2 | `/mcp` 401'd anonymous `initialize`; `/.well-known/mcp` was a 404 | live public `/mcp` transport + `/.well-known/mcp` manifest |
| **MCP server-card.json** | 1/2 | `name`/`version`/`description` were nested under `serverInfo`; the check wants them top-level | added top-level fields |

## The changes

**1. Public MCP discovery** (`api/mcp/handler.ts`, `api/mcp/auth.ts`)
- `initialize`, `tools/list`, and the `notifications/initialized` handshake are now servable **without credentials**. Everything that returns data or spends quota (`tools/call`, `resources/read`) and the deliberately-gated metadata methods (`prompts/list`, `resources/list`, `logging/setLevel`) **still require auth**.
- A credential *presented* on a discovery method is still validated — a bad key returns `401`, never a silent anon downgrade.
- Anonymous discovery is rate-limited **60/min per client IP** (new `applyAnonDiscoveryLimit`, fail-open, keyed on the trusted `cf-connecting-ip`/`x-real-ip`).
- **No new data exposure:** the tool catalog (names, descriptions, input schemas) is already public via `server-card.json` + `/docs`; internal registry fields are stripped by `buildPublicTool` (asserted by existing tests).
- **Scope:** minimal discovery set chosen per review (`initialize` + `tools/list`); `prompts/list` + `resources/list` stay gated.

**2. Structured JSON 404 for `/api/*`** (`api/not-found.ts` + `vercel.json` rewrite + `api-route-exceptions.json`)
- A `/api/:path*` rewrite funnels unmatched API paths to a JSON envelope with `error.code` / `error.message` / `error.hint`.
- **Safe:** Vercel applies `rewrites` *after* the filesystem, so real functions are never shadowed. Verified against production (`/settings.html` serves its own file despite the SPA catch-all).

**3. server-card.json** — added top-level `name` / `version` / `description` / `serverUrl` (kept `serverInfo` for back-compat).

**Docs** — `docs/mcp-server.mdx` now documents the public-discovery surface.

## Testing
- Retargeted the auth-wall probes (`mcp.test.mjs`, `mcp-protocol-conformance`, `live-api-cache-auth-regression`) to a **protected** method and added explicit public-discovery coverage; new `tests/api-not-found.test.mjs`.
- Green locally: full MCP suite (**582**), edge-functions (**207**), gateway-HMAC (**39**), `tsc` (api + full), biome, sebuf-contract, rate-limit-policies, sentry-coverage, mdx-lint.

## Verify after deploy
Rescan once merged + deployed:
```
curl -X POST https://ora.ai/api/scan -H 'Content-Type: application/json' -d '{"url":"worldmonitor.app"}'
```
Preview note: confirm the `/api/:path*` rewrite on the Vercel preview returns JSON 404 for an unknown `/api/...` path and that real endpoints are unaffected.

## Deferred (follow-up if needed)
The WebMCP **homepage HTML** signal would need a `pro-test` rebuild (`public/pro/welcome.html`) + the pre-push freshness gate. The live `/mcp` transport + `/.well-known/mcp` manifest are the primary WebMCP fix; if the rescan shows `webmcp` still at 1/2, I'll add the homepage `<link>` in a focused follow-up.

https://claude.ai/code/session_011SE5TDpCY8J9o8o79vZ239