### PR TITLE
fix(test): assert openapi.json service-desc on apiEntry, not catalog anchor

### DIFF
--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -1162,7 +1162,11 @@ describe('agent readiness: api-catalog + openapi build', () => {
     // through a JSON parser; YAML input trips them ("found but failed to
     // parse"). The JSON mirror is a second service-desc so those scanners
     // have a parseable spec. YAML stays at [0] (human-readable canonical).
-    const jsonDesc = apiCatalog.linkset[0]['service-desc'][1];
+    // Read from apiEntry (the api.worldmonitor.app context object), not
+    // linkset[0] — since #4691 added the RFC 9727 catalog anchor, linkset[0]
+    // is the catalog itself (item enumeration, no service-desc). The sibling
+    // /openapi.yaml assertion above already uses apiEntry for the same reason.
+    const jsonDesc = apiEntry['service-desc'][1];
     assert.ok(jsonDesc, 'api anchor must have a second service-desc entry (JSON mirror)');
     assert.ok(
       jsonDesc.href.endsWith('/openapi.json'),


### PR DESCRIPTION
## Summary

**`main` is currently red** — the `unit` job fails on the last several commits, which also blocks the CI of **every open PR** (CI merges each PR with `main`).

Root cause is an interaction between two recently-merged PRs:
- **#4691** added the RFC 9727 `item` enumeration to `public/.well-known/api-catalog`, making `linkset[0]` the **catalog anchor** (it has an `item` array and no `service-desc`).
- **#4696** then added a test — *"also advertises a JSON service-desc at /openapi.json"* — that reads `apiCatalog.linkset[0]['service-desc'][1]`. Since `linkset[0]` no longer has `service-desc`, this throws `TypeError: Cannot read properties of undefined (reading '1')`.

The fix reads from **`apiEntry`** (the `https://api.worldmonitor.app/` context object), which is already defined one line above and is what the sibling `/openapi.yaml` assertion uses. `apiEntry['service-desc'][1]` is the JSON mirror (`href` ends `/openapi.json`, `type: application/json`), so all three assertions pass.

Test-only change — no `api-catalog` or product change.

## Test plan

- [x] `tests/deploy-config.test.mjs` → "agent readiness: api-catalog + openapi build" suite: **11/11 pass** (was 1 failing).
- [x] Whole `deploy-config.test.mjs` file: **87/87 pass**.
- [x] Verified `apiEntry['service-desc'][1]` against the committed `public/.well-known/api-catalog`: `{ href: "https://www.worldmonitor.app/openapi.json", type: "application/json" }`.

Once merged, this should turn `unit` green on `main` and unblock the other open PRs on rebase.

https://claude.ai/code/session_01H2659r23wy3sy9dEthwCzw