### PR TITLE
fix(mcp): 405 on bare GET /mcp so the Streamable HTTP handshake completes (orank Access)

### DIFF
--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -280,9 +280,28 @@ export async function mcpHandler(
   const requestHost = req.headers.get('host') ?? new URL(req.url).host;
   const resourceMetadataUrl = `https://${requestHost}/.well-known/oauth-protected-resource`;
 
-  // GET is the SSE-replay path — it re-serves previously-streamed (Pro) tool
-  // result data, so it stays fully authenticated (never a discovery surface).
+  // GET has two roles on the MCP endpoint:
+  //   1. A bare GET (no `Last-Event-ID`) is a client opening the OPTIONAL
+  //      server->client SSE stream of the Streamable HTTP transport. This
+  //      stateless edge route offers no server-initiated stream, so the MCP
+  //      spec requires HTTP 405 Method Not Allowed here — and MCP SDK clients
+  //      treat 405 as the graceful "no standalone stream" signal, completing
+  //      the handshake cleanly. Answering 401/400 instead makes a strict
+  //      client's `connect()` raise `Failed to open SSE stream` and an
+  //      agent-readiness scanner (orank) report "protocol handshake failed".
+  //      This 405 precedes auth so an UNauthenticated discovery client sees the
+  //      same spec-correct signal (405 leaks nothing). RFC 9110 §15.5.6 requires
+  //      the 405 to advertise `Allow`.
+  //   2. A GET WITH `Last-Event-ID` is our authenticated SSE-replay channel —
+  //      it re-serves previously-streamed (Pro) tool-result data, so it stays
+  //      fully authenticated (never a discovery surface).
   if (req.method === 'GET') {
+    if (!req.headers.get('last-event-id')) {
+      return new Response(null, {
+        status: 405,
+        headers: withMcpNoStore({ Allow: 'POST, GET, HEAD, OPTIONS', ...corsHeaders }),
+      });
+    }
     const auth = await resolveAuthContext(req, deps, resourceMetadataUrl, corsHeaders);
     if (!auth.ok) return auth.response;
     if (auth.context.kind === 'pro') {

--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -209,6 +209,12 @@ function handleSseReplay(req: Request, corsHeaders: Record<string, string>): Res
       { status: 406, headers: withMcpNoStore({ 'Content-Type': 'application/json', ...corsHeaders }) },
     );
   }
+  // Defensive + type-narrowing guard. The sole caller (the GET branch) now
+  // answers a bare GET without `Last-Event-ID` with 405 BEFORE reaching here, so
+  // this 400 is unreachable in practice — but the check is retained because it
+  // narrows `lastEventId` from `string | null` to `string` for
+  // `replayEventsAfter` below (whose `parseEventCursor` would TypeError on null),
+  // and keeps `handleSseReplay` independently safe if a future caller is added.
   if (!lastEventId) {
     return new Response(
       JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32600, message: 'Missing Last-Event-ID for SSE replay' } }),

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -49,6 +49,7 @@ WorldMonitor supports the Streamable HTTP POST flow with either JSON or SSE resp
 - Clients that send `Accept: application/json, text/event-stream` can receive a `text/event-stream` response for successful JSON-RPC POSTs.
 - `initialize` SSE responses include `Mcp-Session-Id`; follow-up POSTs should send that same `Mcp-Session-Id` header.
 - Each SSE response starts with an empty priming event that has an event `id`, followed by the JSON-RPC response event. If the client disconnects after an event, it can resume by sending `GET /mcp` with `Accept: text/event-stream`, the same `Mcp-Session-Id`, and `Last-Event-ID`.
+- A **bare `GET /mcp`** — one **without** `Last-Event-ID` — is a client opening the optional standalone server→client SSE stream. This stateless edge route offers no server-initiated stream, so it answers `405 Method Not Allowed` (advertising `Allow`), which the MCP spec defines as the graceful "no standalone stream" signal. MCP SDK clients handle this transparently and complete the handshake; the `GET` verb itself is reserved for the authenticated `Last-Event-ID` replay above.
 
 The replay buffer is in-memory and bounded per edge instance. Treat `Last-Event-ID` resume as loss-tolerant transport recovery, not durable message storage.
 

--- a/tests/live-api-cache-auth-regression.test.mjs
+++ b/tests/live-api-cache-auth-regression.test.mjs
@@ -136,6 +136,19 @@ describe(`live API cache/auth regression sweep (${LIVE ? 'ENABLED' : 'SKIPPED - 
     assert.match(options.resp.headers.get('access-control-allow-methods') || '', /\bPOST\b/);
     assertNoStore(options.resp, 'MCP OPTIONS');
 
+    // A bare GET (no Last-Event-ID) is a client opening the OPTIONAL standalone
+    // server->client SSE stream. This stateless route offers none, so the MCP
+    // Streamable HTTP spec requires 405 (SDK clients treat it as the graceful
+    // "no standalone stream" signal). Returning 401 here surfaces to a strict
+    // client as `Failed to open SSE stream: Unauthorized` and is scored as a
+    // failed protocol handshake by agent-readiness scanners.
+    const bareGet = await fetchText(`${WEB_BASE}/mcp`, {
+      method: 'GET',
+      headers: { Accept: 'text/event-stream' },
+    });
+    assert.equal(bareGet.resp.status, 405, 'unauthenticated standalone SSE-stream open must be 405, never 401');
+    assert.match(bareGet.resp.headers.get('allow') || '', /\bPOST\b/, '405 must advertise Allow (RFC 9110 §15.5.6)');
+
     // Discovery is public: unauthenticated `initialize` succeeds (200) and must
     // still be no-store (the #4497 cached-200 hazard applies to any 200).
     const discover = await fetchText(`${WEB_BASE}/mcp`, {

--- a/tests/mcp-transport-conformance.test.mjs
+++ b/tests/mcp-transport-conformance.test.mjs
@@ -256,7 +256,13 @@ describe('api/mcp.ts — transport conformance over real HTTP', () => {
     assert.equal(missingAccept.headers.get('allow'), null, 'GET replay header errors must not advertise Allow');
     assert.match((await missingAccept.json()).error?.message ?? '', /Accept: text\/event-stream/);
 
-    const missingLastEventId = await fetch(server.url, {
+    // A GET WITHOUT Last-Event-ID is NOT a malformed replay — it is a client
+    // opening the OPTIONAL standalone server->client SSE stream. This route
+    // offers none, so the MCP Streamable HTTP spec requires 405 Method Not
+    // Allowed (MCP SDK clients treat 405 as the graceful "no standalone stream"
+    // signal and complete the handshake). Unlike the replay-specific 400/406
+    // header errors, a 405 MUST advertise Allow (RFC 9110 §15.5.6).
+    const bareGetNoStream = await fetch(server.url, {
       method: 'GET',
       headers: {
         Accept: 'text/event-stream',
@@ -265,9 +271,24 @@ describe('api/mcp.ts — transport conformance over real HTTP', () => {
       },
     });
 
-    assert.equal(missingLastEventId.status, 400);
-    assert.equal(missingLastEventId.headers.get('allow'), null, 'GET replay header errors must not advertise Allow');
-    assert.match((await missingLastEventId.json()).error?.message ?? '', /Missing Last-Event-ID/);
+    assert.equal(bareGetNoStream.status, 405);
+    assert.match(bareGetNoStream.headers.get('allow') ?? '', /\bPOST\b/, '405 must advertise Allow (RFC 9110 §15.5.6)');
+  });
+
+  it('answers a bare GET (standalone SSE stream open) with 405 even when unauthenticated', async () => {
+    // The exact agent-readiness-scanner / SDK path: the transport opens the
+    // optional standalone GET SSE stream with `resumptionToken: undefined` (no
+    // Last-Event-ID) and no credentials during connect(). It MUST see 405, not
+    // 401 — a 401 here surfaces as `Failed to open SSE stream: Unauthorized` and
+    // is reported as a failed protocol handshake.
+    const bareGet = await fetch(server.url, {
+      method: 'GET',
+      headers: { Accept: 'text/event-stream' },
+    });
+
+    assert.equal(bareGet.status, 405, 'unauthenticated standalone SSE-stream open must be 405, never 401');
+    assert.match(bareGet.headers.get('allow') ?? '', /\bPOST\b/, '405 must advertise Allow (RFC 9110 §15.5.6)');
+    assert.equal(bareGet.headers.get('access-control-allow-origin'), '*', 'CORS preserved on the 405');
   });
 
   it('accepts the initialized Mcp-Session-Id on a follow-up POST stream', async () => {


### PR DESCRIPTION
## What

Fixes the orank (ora.ai) Access-layer gap **"MCP server / manifest" — 3/6 (warning): _"MCP manifest found at /.well-known/mcp but protocol handshake failed"_**.

## Root cause (reproduced live, not theorized)

The finding was self-contradictory: `mcp-server-identity` and `mcp-transport-modern` both **pass** (orank successfully reads our `initialize` response and confirms Streamable HTTP), yet the main `mcp-server` check says the handshake **failed**.

Running the real `@modelcontextprotocol/sdk` client against production surfaced the exact cause:

```
[transport.onerror] Streamable HTTP error: Failed to open SSE stream: Unauthorized
```

During `connect()`, the SDK opens the **optional standalone server→client SSE stream** with a **bare `GET /mcp`** (`resumptionToken: undefined` → no `Last-Event-ID`). Our handler ran that GET straight into the auth gate and returned **401 Unauthorized**. The SDK converts any non-`405` status on that GET into a transport error (`streamableHttp.js`):

```js
// 405 indicates that the server does not offer an SSE stream at GET endpoint
if (response.status === 405) { return; }               // graceful — no error
throw new StreamableHTTPError(response.status, `Failed to open SSE stream: ${response.statusText}`);
```

The MCP Streamable HTTP spec requires a server that offers **no** standalone GET stream to answer **405 Method Not Allowed** — the signal every SDK client swallows silently. `initialize` → `notifications/initialized` (202) → `tools/list` all already worked; the 401 on that lone GET was the only failure a scanner sees.

## Fix

`api/mcp/handler.ts`: a `GET /mcp` **without** `Last-Event-ID` now returns **405** (advertising `Allow`, per RFC 9110 §15.5.6) **before** the auth gate, so unauthenticated discovery clients get the same spec-correct signal. A `GET` **with** `Last-Event-ID` remains the authenticated SSE-replay channel, unchanged. No new data is exposed — `tools/call` / `resources/read` stay gated.

## Verification

- **Before:** real SDK vs production → `Failed to open SSE stream: Unauthorized`.
- **After (local, fixed handler):** real SDK `connect()` + `tools/list` → **clean handshake, 0 transport errors, 39 tools**.
- `tests/mcp-transport-conformance.test.mjs` — retargeted the "malformed GET replay" case to the 405 semantics + added an **unauthenticated bare-GET → 405** regression (on-the-wire).
- `tests/live-api-cache-auth-regression.test.mjs` — added a prod contract assertion (deploy-gated).
- Docs: `docs/mcp-server.mdx` now describes the bare-GET → 405 behavior.
- Full local runs green: `mcp.test.mjs` (126), transport-conformance (5), protocol-conformance (1), webmcp (17), deploy-config (87).

## Notes

orank rescans the **live** domain, so the score flip is confirmable only after deploy: `POST https://ora.ai/api/scan {"url":"worldmonitor.app"}`. Expect `mcp-server` 3/6 → 6/6 (Access +3, overall 66 → ~69).

https://claude.ai/code/session_012hP77CNJ9RpxDk17bPVmpg
