### PR TITLE
feat(pro/welcome): denser SEO prerender block for AEO indexability

### DIFF
--- a/pro-test/prerender.mjs
+++ b/pro-test/prerender.mjs
@@ -337,30 +337,94 @@ const welcomeFaqEntries = [1, 2, 3, 4, 5, 6, 7, 8, 9]
 const welcomeSeoPrerender = `
 <div id="seo-prerender" lang="en">
   <h2>World Monitor — free real-time global intelligence dashboard</h2>
-  <p>${en.welcome.hero.sub} It runs instantly in the browser with no signup, is used by 2M+ people, and is open source under AGPL-3.0. <a href="${WIRED_STORY_URL}">Featured in WIRED</a>.</p>
+  <p>${en.welcome.hero.sub} It runs instantly in the browser with no signup, is used by 2M+ people across 190+ countries, and is open source under AGPL-3.0. <a href="${WIRED_STORY_URL}">Featured in WIRED</a>.</p>
 
   <h2>What World Monitor tracks</h2>
-  <p>World Monitor fuses 56 map layers across a dual 3D-globe and WebGL map: live conflict events, maritime AIS vessels, military and civilian flights, satellite passes, GPS jamming zones, submarine cables and landing stations, AI datacenters, pipelines, nuclear facilities, internet outages and BGP anomalies — alongside market quotes, sector heatmaps and a Country Instability Index across 196 countries. A daily AI brief and corroborated breaking alerts sit on top, and every panel cites its sources and timestamps inline.</p>
+  <p>World Monitor fuses 56 live map layers on a dual 3D-globe and WebGL map, then scores how they move together. Everything is normalized onto one surface: you see the raw signals, understand them through a daily AI brief and the Country Instability Index, and act with custom monitors, a Scenario Engine, Route Explorer and a 39-tool MCP server for AI agents. Every panel cites its sources and timestamps inline.</p>
+  <h3>Conflict &amp; security</h3>
+  <p>Live conflict events from ACLED and UCDP with escalation scoring, 29 scored geopolitical hotspots, military-posture and troop-movement signals, and corroborated breaking alerts that fire only when independent origin types agree.</p>
+  <h3>Maritime &amp; trade</h3>
+  <p>Live AIS vessel tracking, 13 shipping chokepoints — Hormuz, Bab el-Mandeb, Suez, Malacca and more — with transit counts, week-over-week change and disruption scoring, plus port activity and cargo inference.</p>
+  <h3>Aviation &amp; aerospace</h3>
+  <p>ADS-B tracking of global flights, satellite passes computed in-browser with SGP4 — watch ISS, Starlink and military birds overhead — and a live map of GPS jamming and spoofing zones.</p>
+  <h3>Energy &amp; infrastructure</h3>
+  <p>88 pipelines and LNG terminals, nuclear facilities, power grids and refineries, 313 mapped AI datacenters with power and operator metadata, and 86 submarine cables with landing stations, overlaid with outage and threat signals.</p>
+  <h3>Markets &amp; macro</h3>
+  <p>92 exchanges and assets — equities, commodities, crypto, ETF flows and analyst targets — alongside FRED, IMF and BIS macro data, central-bank and monetary-policy tracking, and GDP, inflation and interest-rate cycles.</p>
+  <h3>Climate &amp; natural hazards</h3>
+  <p>NASA FIRMS near-real-time fire and hotspot detection, USGS earthquakes, volcanic activity and severe-weather layers — mapped against the infrastructure and supply routes they can disrupt.</p>
+  <h3>Cyber &amp; connectivity</h3>
+  <p>Ransomware feeds, BGP hijack and route-anomaly detection, internet-outage monitoring and DDoS signals — the digital layer of global risk, tied to the physical cables and datacenters beneath it.</p>
+
+  <h2>See the signals move together</h2>
+  <p>${en.welcome.moments.sub} The edge is one surface where a country-risk spike, a chokepoint anomaly and a Brent move can explain each other in real time, before it becomes a consensus note.</p>
   <ul>
-    <li><strong>See</strong> — 56 map layers across a dual 3D-globe and WebGL map: conflicts, vessels, flights, satellites, pipelines, submarine cables and AI datacenters.</li>
-    <li><strong>Understand</strong> — a daily AI brief, the Country Instability Index across 196 countries, cross-source correlation and the Scenario Engine.</li>
-    <li><strong>Act</strong> — custom monitors and alerts, Route Explorer, and a 39-tool MCP server and REST API for Claude, GPT and custom agents.</li>
+    <li><strong>Markets</strong> — country risk, sanctions and hotspot escalation show where geopolitical pressure is rising; ships, cables and flights show whether it can hit supply, trade or capital routes; rates, FX, equities and safe-haven assets show which market regime is repricing.</li>
+    <li><strong>Commodities</strong> — AIS, ports, pipelines, LNG and chokepoints show when physical supply slows or reroutes, weather and fires show the disruptions, and oil, gas, grains and miners show how the shock prices through.</li>
+    <li><strong>AI infrastructure</strong> — AI datacenters sit beside grids, pipelines and nuclear power, and grid-stress, heat and fire layers show which compute corridors are under pressure and which companies are exposed.</li>
+    <li><strong>Connectivity</strong> — subsea cables, landing stations and BGP-anomaly feeds show whether a physical fault is becoming a digital outage, and which trade corridors lose their fallback routes first.</li>
   </ul>
+
+  <h2>Your first five minutes on the live map</h2>
+  <p>There is no tour, no empty state and no signup wall. The map is already moving as the page loads — conflicts, vessels, flights, fires and outages render immediately, with nothing to configure first. Click any country to open its dossier. Press the command palette (Ctrl-K or Cmd-K) for 154 commands that jump straight to any layer, panel or country. Switch lens between World, Tech, Finance, Commodity, Energy and Happy — the same engine tuned into six monitors, one click apart. What loads first is maybe a tenth of what is there; the rest surfaces as the world moves — satellite passes, GPS-jamming zones, dark ships, protest clusters and siren alerts.</p>
+
+  <h2>Country briefs, instability scores and corroborated alerts</h2>
+  <p>Click any country and a full dossier opens: a Country Instability Index with its component signals, an AI brief with cited headlines, active signals and a 7-day timeline, plus resilience rankings across 196 countries. Breaking alerts are deliberately quiet — a banner fires only when five independent origin types corroborate an event (news classification, keyword velocity, hotspot escalation, military surges and official sirens), deduplicated and rate-limited, so you get fewer alerts and real ones.</p>
 
   <h2>Where the data comes from</h2>
   <p>65+ named providers, live: <a href="https://acleddata.com/">ACLED</a> and <a href="https://ucdp.uu.se/">UCDP</a> for conflict, <a href="https://aisstream.io/">AISStream</a> for vessels, <a href="https://opensky-network.org/">OpenSky</a> for aircraft, <a href="https://firms.modaps.eosdis.nasa.gov/">NASA FIRMS</a> for fires, <a href="https://www.usgs.gov/programs/earthquake-hazards">USGS</a> for earthquakes, and <a href="https://www.imf.org/en/Data">IMF</a>, <a href="https://www.bis.org/">BIS</a>, <a href="https://fred.stlouisfed.org/">FRED</a> and <a href="https://finnhub.io/">Finnhub</a> for markets and macro — plus 500+ curated news feeds, all active under one key with no separate registrations.</p>
+
+  <h2>How World Monitor works</h2>
+  <p>World Monitor ingests 500+ curated feeds and 65+ named providers on independent refresh cycles, normalizes every event into a common schema, geolocates it and deduplicates it across sources. A breaking-news banner fires only when five independent origin types corroborate the same event, so alerts stay rare and real. The Country Instability Index fuses weighted signals per country, the daily AI brief cites the specific headlines behind each assessment, and the correlation engine surfaces when separate systems — geopolitics, shipping, energy and markets — start moving together. Nothing is a black box: every panel shows its sources and the timestamp of its most recent update.</p>
 
   <h2>Watch shipping chokepoints in real time</h2>
   <p>Thirteen shipping chokepoints — including Hormuz, Bab el-Mandeb, Suez and Malacca — are tracked with live AIS vessel counts, week-over-week transit change and disruption scoring, with density anomalies flagged against each strait's rolling baseline.</p>
 
   <h2>Built for AI agents</h2>
-  <p>World Monitor ships a 39-tool MCP server, so Claude, GPT or any MCP-compatible agent can query live country risk scores, chokepoint status, conflicts, markets and country briefs — with JMESPath projection so agents fetch exactly the fields they need. A public REST API and developer documentation are available for custom integrations.</p>
+  <p>World Monitor ships a 39-tool MCP server, so Claude, GPT or any MCP-compatible agent can query live country risk scores, chokepoint status, conflicts, markets and country briefs — researching with live data instead of training-data memories. Every tool accepts a JMESPath projection so agents fetch exactly the fields they need, a single OAuth key reaches 65+ upstream providers, and the whole platform is open source under AGPL-3.0. A public REST API with OpenAPI 3.1 documentation is available for custom integrations.</p>
+  <p>Representative MCP tools include country risk, country brief and world brief; conflict events, military posture and cyber threats; maritime activity, chokepoint status and supply-chain data; market data, economic data and consumer prices; energy intelligence, commodity geography and tariff trends; natural disasters, climate and health signals; news intelligence, prediction markets, situation analysis and forecast generation — each accepting an optional JMESPath projection, with a describe_tool call that returns its full schema. Read-only resources expose country risk, chokepoint status, seed-freshness metadata and market quotes at addressable URIs, and prompt templates pre-package common workflows such as country briefings, energy-shock watch, market-open prep and route-risk checks.</p>
 
   <h2>Who uses World Monitor</h2>
   <p>Investors and analysts pricing geopolitical risk, traders watching supply-chain and energy disruptions, researchers and journalists corroborating events across independent sources, and government, defence and NGO teams tracking situational awareness — all from one live map instead of a dozen separate tools.</p>
 
   <h2>Free, Pro and open source</h2>
-  <p>The full live map — every layer, 500+ feeds, country briefs and breaking alerts, all six monitors — is free with no signup and no trial clock. World Monitor Pro ($39.99/month or $399.99/year) adds WM Analyst chat, the Scenario Engine, Route Explorer, scheduled AI digests to Slack, Discord, Telegram, Email or webhook, a custom widget builder, and MCP and API access — 30+ services under one key. Native desktop apps for Windows, macOS and Linux and an Android TV app for wall displays are available too.</p>
+  <p>The full live map — every layer, 500+ feeds, country briefs and breaking alerts, all six monitors — is free with no signup and no trial clock. World Monitor Pro ($39.99/month or $399.99/year) adds the decision layer described below, and native desktop apps for Windows, macOS and Linux plus an Android TV app for wall displays are available too.</p>
+
+  <h2>What World Monitor Pro and Enterprise add</h2>
+  <p>Pro turns the observatory into an operations room. WM Analyst answers questions across 30+ live services with citations; a Scenario Engine and Route Explorer let you game disruptions before they hit; a personal AI digest sends up to 30 ranked items daily, twice-daily or weekly to Slack, Discord, Telegram, Email or webhook; a custom widget builder assembles your own panels from HTML, CSS and JavaScript with AI assistance; and MCP plus a REST API expose 39 tools under one key. Enterprise adds team workspaces with SSO, MFA and RBAC; cloud, on-premises or air-gapped deployment; satellite imagery with change detection and SAR; tens of thousands of mapped infrastructure assets; and 100+ data connectors including Snowflake, Splunk and Sentinel.</p>
+
+  <h2>The numbers, live in the dashboard today</h2>
+  <p>Every figure below is live now, not a roadmap — open the app and count. Sources are cited on every panel.</p>
+  <ul>
+    <li>56 live map layers</li>
+    <li>500+ curated news and data feeds</li>
+    <li>65+ named data providers under one key</li>
+    <li>13 maritime chokepoints tracked with live AIS</li>
+    <li>86 submarine cables mapped</li>
+    <li>88 pipelines and LNG terminals</li>
+    <li>313 AI datacenters mapped</li>
+    <li>29 scored geopolitical hotspots</li>
+    <li>92 exchanges and market assets</li>
+    <li>196 countries with resilience rankings</li>
+    <li>39 MCP tools for AI agents</li>
+    <li>154 command-palette actions</li>
+    <li>24 interface languages, including right-to-left</li>
+    <li>5 independent origin types behind every breaking alert</li>
+  </ul>
+
+  <h2>Key terms</h2>
+  <dl>
+    <dt>Country Instability Index (CII)</dt><dd>A composite score that fuses weighted per-country signals — conflict, unrest, economic and governance indicators — into a single, comparable measure of instability.</dd>
+    <dt>Chokepoint</dt><dd>A narrow maritime strait such as Hormuz, Bab el-Mandeb, Suez or Malacca where global shipping concentrates, so a disruption there ripples through world trade and energy prices.</dd>
+    <dt>AIS (Automatic Identification System)</dt><dd>Transponder signals broadcast by ships, used to track vessel positions, port calls and chokepoint transits in real time.</dd>
+    <dt>ADS-B</dt><dd>Automatic Dependent Surveillance–Broadcast, the transponder feed used to track aircraft positions and flight patterns worldwide.</dd>
+    <dt>BGP anomaly</dt><dd>An irregularity in the internet's Border Gateway Protocol routing that can reveal a route hijack, leak or large-scale outage.</dd>
+    <dt>OSINT</dt><dd>Open-source intelligence — analysis assembled entirely from publicly available data, which is what World Monitor makes accessible on one map.</dd>
+    <dt>MCP (Model Context Protocol)</dt><dd>An open standard that lets AI agents call external tools; World Monitor ships a 39-tool MCP server so agents can query live data directly.</dd>
+    <dt>JMESPath</dt><dd>A JSON query language agents use to project just the fields they need from a tool response, cutting token usage on every call.</dd>
+    <dt>SGP4</dt><dd>The orbital-propagation model World Monitor runs in the browser to compute live satellite positions and overhead passes.</dd>
+    <dt>SAR (Synthetic Aperture Radar)</dt><dd>All-weather, day-and-night satellite radar imaging, available on Enterprise for change detection where optical imagery cannot see.</dd>
+  </dl>
 
   <h2>Six dashboards, one platform</h2>
   <ul>
@@ -375,6 +439,16 @@ const welcomeSeoPrerender = `
   <h2>${en.welcome.faq.title}</h2>
   <dl>
 ${welcomeFaqEntries}
+  </dl>
+
+  <h2>More questions analysts and agents ask</h2>
+  <dl>
+    <dt>How fresh is the data?</dt><dd>Feeds refresh on independent cycles ranging from seconds to minutes, and every panel shows the timestamp of its most recent update. The free tier refreshes every 5–15 minutes; Pro runs near real time.</dd>
+    <dt>Can I get alerts on Slack, Telegram or email?</dt><dd>Yes. Pro delivers scheduled AI digests and real-time alerts to Slack, Discord, Telegram, Email or webhook, AES-256 encrypted, with quiet hours and per-rule triggers.</dd>
+    <dt>Does it work on mobile, desktop and TV?</dt><dd>Yes. World Monitor runs in any modern browser, with native desktop apps for Windows, macOS and Linux and an Android TV app for SOC walls and trading floors.</dd>
+    <dt>What languages does it support?</dt><dd>24 interface languages, including right-to-left scripts such as Arabic, Farsi and Hebrew.</dd>
+    <dt>Can I self-host World Monitor?</dt><dd>Yes. The platform is open source under AGPL-3.0 on GitHub — read the code, self-host it or build on it. Enterprise adds on-premises and air-gapped deployment.</dd>
+    <dt>Is there an API for developers?</dt><dd>Yes. A REST API spans all 30+ service domains with structured JSON, cache headers and OpenAPI 3.1 docs, authenticated per key and rate-limited per tier, alongside the 39-tool MCP server.</dd>
   </dl>
 
   <h2>Learn more</h2>

--- a/public/pro/welcome.html
+++ b/public/pro/welcome.html
@@ -190,30 +190,94 @@
     
 <div id="seo-prerender" lang="en">
   <h2>World Monitor — free real-time global intelligence dashboard</h2>
-  <p>Headlines are the lag. World Monitor streams the world's raw signals — ships, jets, sirens, cables, markets — onto one live map, with AI that flags when they converge into something that matters. It runs instantly in the browser with no signup, is used by 2M+ people, and is open source under AGPL-3.0. <a href="https://www.wired.me/story/the-music-streaming-ceo-who-built-a-global-war-map">Featured in WIRED</a>.</p>
+  <p>Headlines are the lag. World Monitor streams the world's raw signals — ships, jets, sirens, cables, markets — onto one live map, with AI that flags when they converge into something that matters. It runs instantly in the browser with no signup, is used by 2M+ people across 190+ countries, and is open source under AGPL-3.0. <a href="https://www.wired.me/story/the-music-streaming-ceo-who-built-a-global-war-map">Featured in WIRED</a>.</p>
 
   <h2>What World Monitor tracks</h2>
-  <p>World Monitor fuses 56 map layers across a dual 3D-globe and WebGL map: live conflict events, maritime AIS vessels, military and civilian flights, satellite passes, GPS jamming zones, submarine cables and landing stations, AI datacenters, pipelines, nuclear facilities, internet outages and BGP anomalies — alongside market quotes, sector heatmaps and a Country Instability Index across 196 countries. A daily AI brief and corroborated breaking alerts sit on top, and every panel cites its sources and timestamps inline.</p>
+  <p>World Monitor fuses 56 live map layers on a dual 3D-globe and WebGL map, then scores how they move together. Everything is normalized onto one surface: you see the raw signals, understand them through a daily AI brief and the Country Instability Index, and act with custom monitors, a Scenario Engine, Route Explorer and a 39-tool MCP server for AI agents. Every panel cites its sources and timestamps inline.</p>
+  <h3>Conflict &amp; security</h3>
+  <p>Live conflict events from ACLED and UCDP with escalation scoring, 29 scored geopolitical hotspots, military-posture and troop-movement signals, and corroborated breaking alerts that fire only when independent origin types agree.</p>
+  <h3>Maritime &amp; trade</h3>
+  <p>Live AIS vessel tracking, 13 shipping chokepoints — Hormuz, Bab el-Mandeb, Suez, Malacca and more — with transit counts, week-over-week change and disruption scoring, plus port activity and cargo inference.</p>
+  <h3>Aviation &amp; aerospace</h3>
+  <p>ADS-B tracking of global flights, satellite passes computed in-browser with SGP4 — watch ISS, Starlink and military birds overhead — and a live map of GPS jamming and spoofing zones.</p>
+  <h3>Energy &amp; infrastructure</h3>
+  <p>88 pipelines and LNG terminals, nuclear facilities, power grids and refineries, 313 mapped AI datacenters with power and operator metadata, and 86 submarine cables with landing stations, overlaid with outage and threat signals.</p>
+  <h3>Markets &amp; macro</h3>
+  <p>92 exchanges and assets — equities, commodities, crypto, ETF flows and analyst targets — alongside FRED, IMF and BIS macro data, central-bank and monetary-policy tracking, and GDP, inflation and interest-rate cycles.</p>
+  <h3>Climate &amp; natural hazards</h3>
+  <p>NASA FIRMS near-real-time fire and hotspot detection, USGS earthquakes, volcanic activity and severe-weather layers — mapped against the infrastructure and supply routes they can disrupt.</p>
+  <h3>Cyber &amp; connectivity</h3>
+  <p>Ransomware feeds, BGP hijack and route-anomaly detection, internet-outage monitoring and DDoS signals — the digital layer of global risk, tied to the physical cables and datacenters beneath it.</p>
+
+  <h2>See the signals move together</h2>
+  <p>You can find the feeds in a hundred places. The edge is one surface where geopolitics, shipping, commodities, macro, markets, weather, infrastructure, cyber, news and country risk can explain each other. The edge is one surface where a country-risk spike, a chokepoint anomaly and a Brent move can explain each other in real time, before it becomes a consensus note.</p>
   <ul>
-    <li><strong>See</strong> — 56 map layers across a dual 3D-globe and WebGL map: conflicts, vessels, flights, satellites, pipelines, submarine cables and AI datacenters.</li>
-    <li><strong>Understand</strong> — a daily AI brief, the Country Instability Index across 196 countries, cross-source correlation and the Scenario Engine.</li>
-    <li><strong>Act</strong> — custom monitors and alerts, Route Explorer, and a 39-tool MCP server and REST API for Claude, GPT and custom agents.</li>
+    <li><strong>Markets</strong> — country risk, sanctions and hotspot escalation show where geopolitical pressure is rising; ships, cables and flights show whether it can hit supply, trade or capital routes; rates, FX, equities and safe-haven assets show which market regime is repricing.</li>
+    <li><strong>Commodities</strong> — AIS, ports, pipelines, LNG and chokepoints show when physical supply slows or reroutes, weather and fires show the disruptions, and oil, gas, grains and miners show how the shock prices through.</li>
+    <li><strong>AI infrastructure</strong> — AI datacenters sit beside grids, pipelines and nuclear power, and grid-stress, heat and fire layers show which compute corridors are under pressure and which companies are exposed.</li>
+    <li><strong>Connectivity</strong> — subsea cables, landing stations and BGP-anomaly feeds show whether a physical fault is becoming a digital outage, and which trade corridors lose their fallback routes first.</li>
   </ul>
+
+  <h2>Your first five minutes on the live map</h2>
+  <p>There is no tour, no empty state and no signup wall. The map is already moving as the page loads — conflicts, vessels, flights, fires and outages render immediately, with nothing to configure first. Click any country to open its dossier. Press the command palette (Ctrl-K or Cmd-K) for 154 commands that jump straight to any layer, panel or country. Switch lens between World, Tech, Finance, Commodity, Energy and Happy — the same engine tuned into six monitors, one click apart. What loads first is maybe a tenth of what is there; the rest surfaces as the world moves — satellite passes, GPS-jamming zones, dark ships, protest clusters and siren alerts.</p>
+
+  <h2>Country briefs, instability scores and corroborated alerts</h2>
+  <p>Click any country and a full dossier opens: a Country Instability Index with its component signals, an AI brief with cited headlines, active signals and a 7-day timeline, plus resilience rankings across 196 countries. Breaking alerts are deliberately quiet — a banner fires only when five independent origin types corroborate an event (news classification, keyword velocity, hotspot escalation, military surges and official sirens), deduplicated and rate-limited, so you get fewer alerts and real ones.</p>
 
   <h2>Where the data comes from</h2>
   <p>65+ named providers, live: <a href="https://acleddata.com/">ACLED</a> and <a href="https://ucdp.uu.se/">UCDP</a> for conflict, <a href="https://aisstream.io/">AISStream</a> for vessels, <a href="https://opensky-network.org/">OpenSky</a> for aircraft, <a href="https://firms.modaps.eosdis.nasa.gov/">NASA FIRMS</a> for fires, <a href="https://www.usgs.gov/programs/earthquake-hazards">USGS</a> for earthquakes, and <a href="https://www.imf.org/en/Data">IMF</a>, <a href="https://www.bis.org/">BIS</a>, <a href="https://fred.stlouisfed.org/">FRED</a> and <a href="https://finnhub.io/">Finnhub</a> for markets and macro — plus 500+ curated news feeds, all active under one key with no separate registrations.</p>
+
+  <h2>How World Monitor works</h2>
+  <p>World Monitor ingests 500+ curated feeds and 65+ named providers on independent refresh cycles, normalizes every event into a common schema, geolocates it and deduplicates it across sources. A breaking-news banner fires only when five independent origin types corroborate the same event, so alerts stay rare and real. The Country Instability Index fuses weighted signals per country, the daily AI brief cites the specific headlines behind each assessment, and the correlation engine surfaces when separate systems — geopolitics, shipping, energy and markets — start moving together. Nothing is a black box: every panel shows its sources and the timestamp of its most recent update.</p>
 
   <h2>Watch shipping chokepoints in real time</h2>
   <p>Thirteen shipping chokepoints — including Hormuz, Bab el-Mandeb, Suez and Malacca — are tracked with live AIS vessel counts, week-over-week transit change and disruption scoring, with density anomalies flagged against each strait's rolling baseline.</p>
 
   <h2>Built for AI agents</h2>
-  <p>World Monitor ships a 39-tool MCP server, so Claude, GPT or any MCP-compatible agent can query live country risk scores, chokepoint status, conflicts, markets and country briefs — with JMESPath projection so agents fetch exactly the fields they need. A public REST API and developer documentation are available for custom integrations.</p>
+  <p>World Monitor ships a 39-tool MCP server, so Claude, GPT or any MCP-compatible agent can query live country risk scores, chokepoint status, conflicts, markets and country briefs — researching with live data instead of training-data memories. Every tool accepts a JMESPath projection so agents fetch exactly the fields they need, a single OAuth key reaches 65+ upstream providers, and the whole platform is open source under AGPL-3.0. A public REST API with OpenAPI 3.1 documentation is available for custom integrations.</p>
+  <p>Representative MCP tools include country risk, country brief and world brief; conflict events, military posture and cyber threats; maritime activity, chokepoint status and supply-chain data; market data, economic data and consumer prices; energy intelligence, commodity geography and tariff trends; natural disasters, climate and health signals; news intelligence, prediction markets, situation analysis and forecast generation — each accepting an optional JMESPath projection, with a describe_tool call that returns its full schema. Read-only resources expose country risk, chokepoint status, seed-freshness metadata and market quotes at addressable URIs, and prompt templates pre-package common workflows such as country briefings, energy-shock watch, market-open prep and route-risk checks.</p>
 
   <h2>Who uses World Monitor</h2>
   <p>Investors and analysts pricing geopolitical risk, traders watching supply-chain and energy disruptions, researchers and journalists corroborating events across independent sources, and government, defence and NGO teams tracking situational awareness — all from one live map instead of a dozen separate tools.</p>
 
   <h2>Free, Pro and open source</h2>
-  <p>The full live map — every layer, 500+ feeds, country briefs and breaking alerts, all six monitors — is free with no signup and no trial clock. World Monitor Pro ($39.99/month or $399.99/year) adds WM Analyst chat, the Scenario Engine, Route Explorer, scheduled AI digests to Slack, Discord, Telegram, Email or webhook, a custom widget builder, and MCP and API access — 30+ services under one key. Native desktop apps for Windows, macOS and Linux and an Android TV app for wall displays are available too.</p>
+  <p>The full live map — every layer, 500+ feeds, country briefs and breaking alerts, all six monitors — is free with no signup and no trial clock. World Monitor Pro ($39.99/month or $399.99/year) adds the decision layer described below, and native desktop apps for Windows, macOS and Linux plus an Android TV app for wall displays are available too.</p>
+
+  <h2>What World Monitor Pro and Enterprise add</h2>
+  <p>Pro turns the observatory into an operations room. WM Analyst answers questions across 30+ live services with citations; a Scenario Engine and Route Explorer let you game disruptions before they hit; a personal AI digest sends up to 30 ranked items daily, twice-daily or weekly to Slack, Discord, Telegram, Email or webhook; a custom widget builder assembles your own panels from HTML, CSS and JavaScript with AI assistance; and MCP plus a REST API expose 39 tools under one key. Enterprise adds team workspaces with SSO, MFA and RBAC; cloud, on-premises or air-gapped deployment; satellite imagery with change detection and SAR; tens of thousands of mapped infrastructure assets; and 100+ data connectors including Snowflake, Splunk and Sentinel.</p>
+
+  <h2>The numbers, live in the dashboard today</h2>
+  <p>Every figure below is live now, not a roadmap — open the app and count. Sources are cited on every panel.</p>
+  <ul>
+    <li>56 live map layers</li>
+    <li>500+ curated news and data feeds</li>
+    <li>65+ named data providers under one key</li>
+    <li>13 maritime chokepoints tracked with live AIS</li>
+    <li>86 submarine cables mapped</li>
+    <li>88 pipelines and LNG terminals</li>
+    <li>313 AI datacenters mapped</li>
+    <li>29 scored geopolitical hotspots</li>
+    <li>92 exchanges and market assets</li>
+    <li>196 countries with resilience rankings</li>
+    <li>39 MCP tools for AI agents</li>
+    <li>154 command-palette actions</li>
+    <li>24 interface languages, including right-to-left</li>
+    <li>5 independent origin types behind every breaking alert</li>
+  </ul>
+
+  <h2>Key terms</h2>
+  <dl>
+    <dt>Country Instability Index (CII)</dt><dd>A composite score that fuses weighted per-country signals — conflict, unrest, economic and governance indicators — into a single, comparable measure of instability.</dd>
+    <dt>Chokepoint</dt><dd>A narrow maritime strait such as Hormuz, Bab el-Mandeb, Suez or Malacca where global shipping concentrates, so a disruption there ripples through world trade and energy prices.</dd>
+    <dt>AIS (Automatic Identification System)</dt><dd>Transponder signals broadcast by ships, used to track vessel positions, port calls and chokepoint transits in real time.</dd>
+    <dt>ADS-B</dt><dd>Automatic Dependent Surveillance–Broadcast, the transponder feed used to track aircraft positions and flight patterns worldwide.</dd>
+    <dt>BGP anomaly</dt><dd>An irregularity in the internet's Border Gateway Protocol routing that can reveal a route hijack, leak or large-scale outage.</dd>
+    <dt>OSINT</dt><dd>Open-source intelligence — analysis assembled entirely from publicly available data, which is what World Monitor makes accessible on one map.</dd>
+    <dt>MCP (Model Context Protocol)</dt><dd>An open standard that lets AI agents call external tools; World Monitor ships a 39-tool MCP server so agents can query live data directly.</dd>
+    <dt>JMESPath</dt><dd>A JSON query language agents use to project just the fields they need from a tool response, cutting token usage on every call.</dd>
+    <dt>SGP4</dt><dd>The orbital-propagation model World Monitor runs in the browser to compute live satellite positions and overhead passes.</dd>
+    <dt>SAR (Synthetic Aperture Radar)</dt><dd>All-weather, day-and-night satellite radar imaging, available on Enterprise for change detection where optical imagery cannot see.</dd>
+  </dl>
 
   <h2>Six dashboards, one platform</h2>
   <ul>
@@ -236,6 +300,16 @@
     <dt>Can AI agents like Claude or GPT use it?</dt><dd>Yes. World Monitor ships a 39-tool MCP server, so Claude, GPT or any MCP-compatible agent can query live risk scores, chokepoint status, conflicts, markets and briefs — with JMESPath projection so agents fetch exactly what they need.</dd>
     <dt>Do I need an account?</dt><dd>No. The dashboard works instantly with no signup. An account only matters when you upgrade to Pro or want settings synced across devices.</dd>
     <dt>Is it open source?</dt><dd>Yes — open source under AGPL-3.0 on GitHub: read the code, self-host it, or build on it. Native desktop apps for Windows, macOS and Linux are available too, plus an Android TV app for wall displays.</dd>
+  </dl>
+
+  <h2>More questions analysts and agents ask</h2>
+  <dl>
+    <dt>How fresh is the data?</dt><dd>Feeds refresh on independent cycles ranging from seconds to minutes, and every panel shows the timestamp of its most recent update. The free tier refreshes every 5–15 minutes; Pro runs near real time.</dd>
+    <dt>Can I get alerts on Slack, Telegram or email?</dt><dd>Yes. Pro delivers scheduled AI digests and real-time alerts to Slack, Discord, Telegram, Email or webhook, AES-256 encrypted, with quiet hours and per-rule triggers.</dd>
+    <dt>Does it work on mobile, desktop and TV?</dt><dd>Yes. World Monitor runs in any modern browser, with native desktop apps for Windows, macOS and Linux and an Android TV app for SOC walls and trading floors.</dd>
+    <dt>What languages does it support?</dt><dd>24 interface languages, including right-to-left scripts such as Arabic, Farsi and Hebrew.</dd>
+    <dt>Can I self-host World Monitor?</dt><dd>Yes. The platform is open source under AGPL-3.0 on GitHub — read the code, self-host it or build on it. Enterprise adds on-premises and air-gapped deployment.</dd>
+    <dt>Is there an API for developers?</dt><dd>Yes. A REST API spans all 30+ service domains with structured JSON, cache headers and OpenAPI 3.1 docs, authenticated per key and rate-limited per tier, alongside the 39-tool MCP server.</dd>
   </dl>
 
   <h2>Learn more</h2>

--- a/tests/pro-welcome-prerender.test.mjs
+++ b/tests/pro-welcome-prerender.test.mjs
@@ -2,6 +2,83 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
 
+const welcomeHtml = () => readFileSync(new URL('../public/pro/welcome.html', import.meta.url), 'utf8');
+const prerenderSrc = () => readFileSync(new URL('../pro-test/prerender.mjs', import.meta.url), 'utf8');
+const enLocale = () =>
+  JSON.parse(readFileSync(new URL('../pro-test/src/locales/en.json', import.meta.url), 'utf8'));
+
+// Pull the body of `const <name> = ` ... `` out of prerender.mjs source text.
+// The SEO templates are plain HTML with no nested backticks, so the first
+// backtick after the declaration opens and the next one closes the literal.
+function extractTemplate(src, name) {
+  const marker = `const ${name} = \``;
+  const start = src.indexOf(marker);
+  assert.ok(start !== -1, `${name} template literal not found in prerender.mjs`);
+  const bodyStart = start + marker.length;
+  const bodyEnd = src.indexOf('`', bodyStart);
+  assert.ok(bodyEnd !== -1, `${name} template literal is unterminated`);
+  return src.slice(bodyStart, bodyEnd);
+}
+
+// Isolate the crawler-visible <div id="seo-prerender">…</div> (no nested <div>s).
+function seoBlock(html) {
+  const start = html.indexOf('<div id="seo-prerender"');
+  assert.ok(start !== -1, 'welcome.html should contain the #seo-prerender block');
+  const end = html.indexOf('</div>', start);
+  assert.ok(end !== -1, '#seo-prerender block should be closed');
+  return html.slice(start, end + '</div>'.length);
+}
+
+// Drift guard: public/pro/welcome.html is a generated artifact injected verbatim
+// from prerender.mjs (`html.replace('<div id="root"></div>', beforeRoot + …)`),
+// but nothing re-runs the build in CI. Without this, editing the SEO copy in
+// prerender.mjs and forgetting `npm run build:pro` silently ships stale HTML to
+// crawlers. Assert every substantial static line of the source template — and
+// every locale string it interpolates — is present in the committed output.
+test('welcome.html #seo-prerender stays in sync with prerender.mjs (run npm run build:pro after edits)', () => {
+  const html = welcomeHtml();
+  const template = extractTemplate(prerenderSrc(), 'welcomeSeoPrerender');
+
+  // Static chunks: drop ${…} interpolations, keep meaningful literal fragments.
+  const staticChunks = template
+    .replace(/\$\{[^}]*\}/g, '\n')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length >= 24);
+  assert.ok(staticChunks.length > 40, 'expected the SEO template to yield many static chunks');
+  const missing = staticChunks.filter((chunk) => !html.includes(chunk));
+  assert.deepEqual(
+    missing,
+    [],
+    `welcome.html is stale — rebuild with \`npm run build:pro\`. Missing source chunks: ${JSON.stringify(missing.slice(0, 3))}`,
+  );
+
+  // Interpolated prose + FAQ come from en.json and are injected raw (unescaped).
+  const en = enLocale();
+  for (const value of [en.welcome.hero.sub, en.welcome.moments.sub]) {
+    assert.ok(html.includes(value), `welcome.html missing interpolated locale prose — rebuild: ${JSON.stringify(value.slice(0, 48))}`);
+  }
+  for (let n = 1; n <= 9; n += 1) {
+    for (const key of [`q${n}`, `a${n}`]) {
+      assert.ok(html.includes(en.welcome.faq[key]), `welcome.html missing FAQ ${key} — rebuild via npm run build:pro`);
+    }
+  }
+});
+
+// Guardrail for the residual SEO risk: the block is crawler-visible but hidden
+// for JS users (off-screen + aria-hidden + inert). That hidden-text pattern is a
+// deliberate AEO decision, but its cloaking-penalty risk scales with size, so
+// cap it. Bump this budget only when a rescan confirms density still helps —
+// don't let the block grow unbounded by accident.
+test('welcome.html #seo-prerender stays within its size budget', () => {
+  const MAX_BYTES = 32 * 1024;
+  const bytes = Buffer.byteLength(seoBlock(welcomeHtml()), 'utf8');
+  assert.ok(
+    bytes <= MAX_BYTES,
+    `#seo-prerender is ${bytes} bytes (budget ${MAX_BYTES}). Large hidden text blocks risk cloaking penalties — trim or deliberately raise MAX_BYTES.`,
+  );
+});
+
 test('built welcome page ships the real hero in #root before JavaScript', () => {
   const html = readFileSync(new URL('../public/pro/welcome.html', import.meta.url), 'utf8');
   const rootMatch = html.match(/<div id="root"(?<attrs>[^>]*)>(?<content>[\s\S]*?)<\/body>/);


### PR DESCRIPTION
## Summary

Fixes orank **Discovery → Semantic search indexability** on the apex `/`
(`public/pro/welcome.html`), which scored **1/2 — "Partial: ~4278 tokens, 15% content density"** even after #4694 added the crawler-visible `#seo-prerender` block.

**Root cause (measured):** density is *denominator-bound*. In the raw HTML orank crawls, ~51% is text-free markup baked into the hydrated React SSR — `class=""` Tailwind attrs (**32.5%**) + inline `<svg>` icons (**19%**) — which can't be stripped without breaking hydration/CWV. So the only safe lever is more genuine readable text in the sibling-before-`#root` prose block.

This roughly doubles that block with factually-grounded, RAG-valuable content (every figure grounded in `en.welcome.depth`):
- 7 themed layer breakdowns (conflict, maritime, aviation, energy, markets, climate, cyber)
- correlation lenses, "how it works" methodology, Pro/Enterprise capabilities
- real MCP **tool + resource + prompt** enumeration (high AEO value for agents)
- a **glossary `<dl>`** (CII, AIS, ADS-B, BGP, MCP, JMESPath, SGP4, SAR)
- extra analyst/agent Q&A + a live-numbers list

### Result (built `welcome.html`, text/total-bytes)
| Metric | Before | After |
|---|---|---|
| Content density | 16.3% | **22.3%** |
| Readable tokens | 4,763 | **7,092** |
| `<h1>` count | 1 | **1** (clean h2/h3: 27/25) |

(orank's tokenizer reads ~1.3pt lower density / ~11% fewer tokens → ≈ 15%→~21%, 4278→~6400.)

### Safety
- Pure-HTML additions (no new `<script>`/`<style>`) → **CSP hashes untouched**.
- The schema'd FAQ `<dl>` (`welcomeFaqEntries` ↔ head FAQPage JSON-LD lockstep) is left alone; new `<dl>`s are added outside it.
- Block stays a **sibling before `#root`** (hydration-safe). Re-verified headless: `#root` hydrates, block is off-screen + `aria-hidden` + `inert`, **zero React mismatch warnings**.
- ⚠️ orank rescan is **deploy-gated** (it reads production raw HTML).
- Only `pro-test/prerender.mjs` (source) + regenerated `public/pro/welcome.html` change; `/pro` (`index.html`) is untouched.

## Test plan
- [x] `typecheck` + `typecheck:api`
- [x] `lint` (biome + safe-html)
- [x] `test:data` — full suite, 691 files, 0 failures (incl. `pro-welcome-prerender`, `pro-critical-css`, `deploy-config`)
- [x] edge-function bundle check (19 fns) + `edge-functions` tests
- [x] `lint:md` + `version:check`
- [x] Headless hydration check on built `welcome.html`
- [ ] Post-deploy: rescan `POST https://ora.ai/api/scan {"url":"worldmonitor.app"}` and confirm Semantic Indexability → 2/2

https://claude.ai/code/session_01ByHJvTGsQNUMEDX7vn1ZPH