### PR TITLE
fix(security): require auth for detailed health metadata

### DIFF
--- a/api/health.js
+++ b/api/health.js
@@ -1,5 +1,6 @@
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { jsonResponse } from './_json-response.js';
+import { USER_API_KEY_GATEWAY_VALIDATION_ERROR, validateApiKey } from './_api-key.js';
 // Seed-envelope helper. PR 1 imports it here so PR 2 can wire envelope-aware
 // reads at specific call sites without further plumbing. It's a no-op on
 // legacy-shape seed-meta values (they have no `_seed` wrapper and pass through
@@ -777,6 +778,20 @@ export default async function handler(req, ctx) {
     return new Response(null, { status: 204, headers });
   }
 
+  const url = new URL(req.url);
+  const compact = url.searchParams.get('compact') === '1';
+  const wantsHistory = url.searchParams.get('history') === '1';
+
+  if (!compact || wantsHistory) {
+    const keyCheck = await validateApiKey(req, { forceKey: true });
+    if (keyCheck.required && !keyCheck.valid) {
+      const error = keyCheck.error === USER_API_KEY_GATEWAY_VALIDATION_ERROR
+        ? 'Invalid API key'
+        : keyCheck.error;
+      return jsonResponse({ error }, 401, headers);
+    }
+  }
+
   // ?history=1 — fast read of the failure-log persisted by previous /api/health
   // probes. Skips the full freshness check (which is expensive — fetches every
   // bootstrap key) and returns only the last-failure snapshot + the deduped
@@ -786,31 +801,28 @@ export default async function handler(req, ctx) {
   //   health:failure-log    — last 50 deduped incidents (7-day TTL)
   // See WM 2026-05-10 — added after a night of UptimeRobot flips that needed
   // direct Upstash inspection to diagnose.
-  {
-    const earlyUrl = new URL(req.url);
-    if (earlyUrl.searchParams.get('history') === '1') {
-      const results = await redisPipeline(
-        [
-          ['GET', 'health:last-failure'],
-          ['LRANGE', 'health:failure-log', '0', '-1'],
-        ],
-        4_000,
-      );
-      const parseJson = (raw) => {
-        if (typeof raw !== 'string') return null;
-        try { return JSON.parse(raw); } catch { return null; }
-      };
-      const lastFailureRaw = results?.[0]?.result;
-      const failureLogRaw = results?.[1]?.result;
-      const body = {
-        lastFailure: parseJson(lastFailureRaw),
-        failureLog: Array.isArray(failureLogRaw)
-          ? failureLogRaw.map(parseJson).filter((e) => e !== null)
-          : [],
-        checkedAt: new Date().toISOString(),
-      };
-      return new Response(JSON.stringify(body, null, 2), { status: 200, headers });
-    }
+  if (wantsHistory) {
+    const results = await redisPipeline(
+      [
+        ['GET', 'health:last-failure'],
+        ['LRANGE', 'health:failure-log', '0', '-1'],
+      ],
+      4_000,
+    );
+    const parseJson = (raw) => {
+      if (typeof raw !== 'string') return null;
+      try { return JSON.parse(raw); } catch { return null; }
+    };
+    const lastFailureRaw = results?.[0]?.result;
+    const failureLogRaw = results?.[1]?.result;
+    const body = {
+      lastFailure: parseJson(lastFailureRaw),
+      failureLog: Array.isArray(failureLogRaw)
+        ? failureLogRaw.map(parseJson).filter((e) => e !== null)
+        : [],
+      checkedAt: new Date().toISOString(),
+    };
+    return new Response(JSON.stringify(body, null, 2), { status: 200, headers });
   }
 
   const now = Date.now();
@@ -953,9 +965,6 @@ export default async function handler(req, ctx) {
     const clear = redisPipeline([['DEL', 'health:failure-log-sig']], 4_000).catch(() => {});
     if (ctx && typeof ctx.waitUntil === 'function') ctx.waitUntil(clear);
   }
-
-  const url = new URL(req.url);
-  const compact = url.searchParams.get('compact') === '1';
 
   const body = {
     status: overall,

--- a/docs/api-platform.mdx
+++ b/docs/api-platform.mdx
@@ -68,7 +68,7 @@ Aggregated freshness report for **all registered seed keys**. Returns `HEALTHY`,
 
 All states except `REDIS_DOWN` return HTTP 200; `REDIS_DOWN` returns HTTP 503 because Redis was unreachable and the endpoint could not assess seed state. Responses are not cached (`private, no-store, max-age=0` plus `CDN-Cache-Control: no-store`).
 
-Monitor via UptimeRobot / Better Stack — alert on any status other than `HEALTHY`.
+Monitor via UptimeRobot / Better Stack with `?compact=1` — alert on any status other than `HEALTHY`. The full detailed view requires an operator/enterprise API key because it includes canonical cache key names and freshness thresholds.
 
 ```json
 {

--- a/docs/health-endpoints.mdx
+++ b/docs/health-endpoints.mdx
@@ -7,7 +7,7 @@ description: "World Monitor exposes two health endpoints for monitoring data pip
 
 Primary health endpoint. Checks all Redis-backed data keys and seed freshness metadata in a single pipeline call.
 
-**Authentication:** None required. Browser origins must still pass the CORS allowlist in `api/_cors.js`; requests with no `Origin` header, such as server-side monitors, are allowed. Health responses are never cached (`Cache-Control: private, no-store, max-age=0` and `CDN-Cache-Control: no-store`).
+**Authentication:** Compact health (`?compact=1`) is public for uptime and keyword monitors. Detailed health (`/api/health` without `compact=1`) and the operator history view (`?history=1`) require a valid operator/enterprise API key because they expose canonical Redis key names, record counts, and freshness thresholds. Browser origins must still pass the CORS allowlist in `api/_cors.js`; requests with no `Origin` header, such as server-side monitors, are allowed only for compact health unless they include an operator key. Health responses are never cached (`Cache-Control: private, no-store, max-age=0` and `CDN-Cache-Control: no-store`).
 
 **HTTP Method:** `GET`
 
@@ -25,6 +25,7 @@ Primary health endpoint. Checks all Redis-backed data keys and seed freshness me
 | `200` | `WARNING` | Some keys stale or on-demand keys empty, but no critical failures |
 | `200` | `DEGRADED` | Critical keys empty, but ≤3% of all probed keys |
 | `200` | `UNHEALTHY` | Critical keys empty, >3% of all probed keys |
+| `401` | - | Detailed health or history requested without a valid operator/enterprise API key |
 | `503` | `REDIS_DOWN` | Could not connect to Redis — the **only** state that returns a non-200 code |
 
 > The overall health verdict lives in the JSON `status` field, not the HTTP code. Every state except `REDIS_DOWN` returns `200` so warn-level seed jitter doesn't flap HTTP-status monitors (see PR #2699). `REDIS_DOWN` returns `503` because with Redis unreachable the endpoint can assess nothing, so a plain HTTP probe must see a failure.
@@ -126,14 +127,15 @@ Selected thresholds from `SEED_META`:
 ### Example Requests
 
 ```bash
-# Full health check
-curl -s https://api.worldmonitor.app/api/health | jq .
+# Full health check (requires an operator API key)
+curl -s https://api.worldmonitor.app/api/health \
+  -H "X-WorldMonitor-Key: $WORLDMONITOR_API_KEY" | jq .
 
 # Compact (problems only)
 curl -s "https://api.worldmonitor.app/api/health?compact=1" | jq .
 
 # UptimeRobot / monitoring: check HTTP status code
-curl -o /dev/null -s -w "%{http_code}" https://api.worldmonitor.app/api/health
+curl -o /dev/null -s -w "%{http_code}" "https://api.worldmonitor.app/api/health?compact=1"
 # Returns 503 only when Redis is unreachable (REDIS_DOWN); 200 for every other
 # state — the verdict (HEALTHY/WARNING/DEGRADED/UNHEALTHY) is in the body's `status`.
 ```
@@ -217,7 +219,7 @@ curl -s https://api.worldmonitor.app/api/seed-health \
 
 ### UptimeRobot
 
-Use `/api/health` as the monitor URL. The HTTP status code only distinguishes a total Redis outage from everything else:
+Use `/api/health?compact=1` as the public monitor URL. The HTTP status code only distinguishes a total Redis outage from everything else:
 
 - `503` = `REDIS_DOWN` (Redis unreachable — a true hard outage)
 - `200` = every other state, including `DEGRADED` and `UNHEALTHY`
@@ -226,7 +228,7 @@ So an HTTP-status-only monitor catches a full backend outage but **not** degrade
 
 Point the keyword monitor at `https://api.worldmonitor.app/api/health?compact=1` and alert when the compact token `"status":"HEALTHY"` (no space after the colon) is **absent** from the response body. Compact mode serializes with no indentation, so this exact token is stable regardless of formatting.
 
-> The bare `/api/health` URL pretty-prints the body, so the healthy token there is `"status": "HEALTHY"` **with a space** after the colon. If you monitor the non-compact URL, match that spaced token instead — the no-space `"status":"HEALTHY"` is absent even when healthy and will false-alert. Prefer `?compact=1`, or parse `summary.crit > 0`.
+> The bare `/api/health` URL is now an operator view and returns `401` without an API key. Public monitoring should always use `?compact=1`.
 
 ### Custom Alerting
 

--- a/tests/health-history-endpoint.test.mjs
+++ b/tests/health-history-endpoint.test.mjs
@@ -22,9 +22,12 @@ describe('api/health ?history=1', () => {
     // gracefully degrade to empty arrays/null when Upstash is unreachable.
     delete process.env.UPSTASH_REDIS_REST_URL;
     delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    process.env.WORLDMONITOR_VALID_KEYS = 'test-health-admin-key';
 
     const { default: handler } = await import('../api/health.js');
-    const req = new Request('https://api.worldmonitor.app/api/health?history=1');
+    const req = new Request('https://api.worldmonitor.app/api/health?history=1', {
+      headers: { 'x-worldmonitor-key': 'test-health-admin-key' },
+    });
     const res = await handler(req);
 
     assert.equal(res.status, 200);

--- a/tests/health-redis-down-status.test.mjs
+++ b/tests/health-redis-down-status.test.mjs
@@ -16,13 +16,55 @@ for (const k of [
   'UPSTASH_REDIS_REST_URL', 'KV_REST_API_URL', 'REDIS_REST_URL',
   'UPSTASH_REDIS_REST_TOKEN', 'KV_REST_API_TOKEN', 'REDIS_REST_TOKEN',
 ]) delete process.env[k];
+process.env.WORLDMONITOR_VALID_KEYS = 'test-health-admin-key';
 
 const { default: handler } = await import('../api/health.js');
 
-test('REDIS_DOWN returns HTTP 503 with status REDIS_DOWN', async () => {
+test('detailed health requires an operator API key before Redis is queried', async () => {
   // Real Request (no Origin header) — the handler reads req.headers.get('origin')
   // via isDisallowedOrigin/getCorsHeaders, so a plain object would crash.
   const req = new Request('https://api.worldmonitor.app/api/health');
+  const res = await handler(req);
+  assert.equal(res.status, 401);
+  const body = await res.json();
+  assert.equal(body.error, 'API key required');
+  assert.equal(res.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app');
+});
+
+test('health history requires an operator API key before Redis is queried', async () => {
+  const req = new Request('https://api.worldmonitor.app/api/health?history=1');
+  const res = await handler(req);
+  assert.equal(res.status, 401);
+  const body = await res.json();
+  assert.equal(body.error, 'API key required');
+});
+
+test('detailed health does not expose user-key gateway fallback internals', async () => {
+  const req = new Request('https://api.worldmonitor.app/api/health', {
+    headers: { 'x-worldmonitor-key': 'wm_user_abc123' },
+  });
+  const res = await handler(req);
+  assert.equal(res.status, 401);
+  const body = await res.json();
+  assert.equal(body.error, 'Invalid API key');
+});
+
+test('compact health remains public and REDIS_DOWN returns HTTP 503', async () => {
+  const req = new Request('https://api.worldmonitor.app/api/health?compact=1');
+  const res = await handler(req);
+  assert.equal(res.status, 503);
+  const body = await res.json();
+  assert.equal(body.status, 'REDIS_DOWN');
+  assert.ok('checkedAt' in body, 'snapshot must carry checkedAt');
+  // No Origin → getCorsHeaders falls back to the canonical app origin (the
+  // origin-gated handler does not emit ACAO:* for unknown/absent origins).
+  assert.equal(res.headers.get('Access-Control-Allow-Origin'), 'https://worldmonitor.app');
+});
+
+test('authenticated detailed health can reach the Redis-down probe', async () => {
+  const req = new Request('https://api.worldmonitor.app/api/health', {
+    headers: { 'x-worldmonitor-key': 'test-health-admin-key' },
+  });
   const res = await handler(req);
   assert.equal(res.status, 503);
   const body = await res.json();


### PR DESCRIPTION
## Summary
Unauthenticated health probes can still check compact status, but they can no longer retrieve the full operational inventory of cache keys, record counts, and freshness thresholds. Detailed `/api/health` responses and `?history=1` now require an operator/enterprise API key, while `?compact=1` remains public for UptimeRobot and keyword monitors.

The endpoint also normalizes user-key gateway fallback failures to `Invalid API key`, so standalone detailed-health auth does not expose internal validation plumbing. The docs now point public monitors at the compact URL and describe the keyed operator view explicitly.

## Validation
- `node --test tests/health-redis-down-status.test.mjs api/health-cors.test.mjs`
- `npm run typecheck:api`
- `npm run lint:mintlify-slugs`
- `npm run lint:unicode:staged`
- `git push --force-with-lease` pre-push guardrails passed, including full typecheck, API typecheck, Convex/CJS/unicode/boundary checks, safe HTML, rate-limit policy, premium-fetch parity, edge function bundle/tests, markdown lint, MDX lint, and version sync

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)