### PR TITLE
feat(pro/welcome): register WebMCP tools on homepage (orank Access)

### DIFF
--- a/pro-test/welcome.html
+++ b/pro-test/welcome.html
@@ -16,17 +16,17 @@
          WITHOUT executing the dashboard SPA — the SPA registers its own richer
          WebMCP tools separately (src/services/webmcp.ts), but the apex serves
          this static welcome page, not the SPA. Spec:
-         https://webmachinelearning.github.io/webmcp/. Runs synchronously at
-         parse time so probes find the tools before the page settles, and is a
-         no-op in browsers without navigator.modelContext. The full 39-tool MCP
-         server is the remote HTTP (Streamable HTTP) transport at
-         https://worldmonitor.app/mcp — getWorldMonitorMcpEndpoint hands agents
-         that endpoint. The nonce is added by Vite (html.cspNonce) at build time,
-         so this inline script needs no CSP script-src hash (deploy-config.test). -->
+         https://webmachinelearning.github.io/webmcp/. Registers synchronously at
+         parse time when the provider is already present (native WebMCP), and
+         retries once on DOMContentLoaded/load for a provider installed later
+         (e.g. a scanner polyfill); the `registered` guard keeps it idempotent, and
+         it is a no-op in browsers without navigator.modelContext. The MCP server is
+         the remote HTTP (Streamable HTTP) transport at https://worldmonitor.app/mcp
+         — getWorldMonitorMcpEndpoint hands agents that endpoint. The nonce is added
+         by Vite (html.cspNonce) at build time, so this inline script needs no CSP
+         script-src hash (deploy-config.test). -->
     <script>
       (function () {
-        var provider = typeof navigator !== 'undefined' ? navigator.modelContext : null;
-        if (!provider) return;
         function text(t, isError) {
           return { content: [{ type: 'text', text: t }], isError: !!isError };
         }
@@ -55,7 +55,12 @@
             },
             execute: function (args) {
               var key = args && typeof args.monitor === 'string' ? args.monitor.toLowerCase() : 'world';
-              var url = MONITORS[key] || MONITORS.world;
+              // Own-property lookup only — self-validate here rather than trust the
+              // host to enforce inputSchema, so an off-enum key (incl. prototype
+              // keys like "constructor"/"__proto__") can never resolve into
+              // window.location. Unknown keys fall back to the world map.
+              var url = Object.prototype.hasOwnProperty.call(MONITORS, key) ? MONITORS[key] : MONITORS.world;
+              if (url === MONITORS.world) key = 'world';
               try {
                 window.location.assign(url);
               } catch (e) {
@@ -69,11 +74,12 @@
             description: "Return connection details for World Monitor's remote MCP server so an agent can pull live geopolitical, market, maritime, aviation, cyber and economic intelligence directly. Includes the Streamable HTTP endpoint, the discovery server card, supported auth modes, and docs.",
             inputSchema: { type: 'object', properties: {}, additionalProperties: false },
             execute: function () {
+              // No tool count here — the live server card is the source of truth
+              // (a hardcoded number would drift). Agents read the catalog from it.
               return Promise.resolve(text(JSON.stringify({
                 endpoint: 'https://worldmonitor.app/mcp',
                 transport: 'streamableHttp',
                 serverCard: 'https://worldmonitor.app/.well-known/mcp/server-card.json',
-                tools: 39,
                 auth: ['OAuth 2.1 bearer (Authorization: Bearer <token>)', 'API key (X-WorldMonitor-Key: wm_...)'],
                 publicDiscovery: 'initialize, tools/list and notifications/initialized are servable without credentials',
                 docs: 'https://worldmonitor.app/docs/mcp-server'
@@ -81,14 +87,32 @@
             }
           }
         ];
-        try {
-          if (typeof provider.registerTool === 'function') {
-            for (var i = 0; i < tools.length; i++) provider.registerTool(tools[i]);
-          } else if (typeof provider.provideContext === 'function') {
-            provider.provideContext({ tools: tools });
+        var registered = false;
+        function register() {
+          if (registered) return;
+          var provider = typeof navigator !== 'undefined' ? navigator.modelContext : null;
+          if (!provider) return;
+          try {
+            if (typeof provider.registerTool === 'function') {
+              for (var i = 0; i < tools.length; i++) provider.registerTool(tools[i]);
+              registered = true;
+            } else if (typeof provider.provideContext === 'function') {
+              provider.provideContext({ tools: tools });
+              registered = true;
+            }
+          } catch (e) {
+            /* Progressive enhancement — never break page load for an optional API. */
           }
-        } catch (e) {
-          /* Progressive enhancement — never break page load for an optional API. */
+        }
+        register();
+        // Retry once for a provider installed after this head script runs (e.g. a
+        // scanner polyfill injected around DOMContentLoaded). The `registered`
+        // guard keeps it idempotent — a present-at-parse provider never re-registers.
+        if (!registered && typeof document !== 'undefined' && document.addEventListener) {
+          document.addEventListener('DOMContentLoaded', register, { once: true });
+          if (typeof window !== 'undefined' && window.addEventListener) {
+            window.addEventListener('load', register, { once: true });
+          }
         }
       })();
     </script>

--- a/pro-test/welcome.html
+++ b/pro-test/welcome.html
@@ -9,6 +9,89 @@
          the same pattern in the SPA's index.html and /pro. -->
     <script>document.documentElement.classList.add('js')</script>
     <style>html.js #seo-prerender{position:absolute;left:-9999px;top:-9999px;width:1px;height:1px;overflow:hidden}</style>
+    <!-- WebMCP — in-page agent tools on the homepage (worldmonitor.app).
+         Registers a small tool set via navigator.modelContext.registerTool so
+         browser-based AI agents (Chrome/Edge WebMCP, agent-readiness scanners)
+         that land on the apex page can act on and discover World Monitor
+         WITHOUT executing the dashboard SPA — the SPA registers its own richer
+         WebMCP tools separately (src/services/webmcp.ts), but the apex serves
+         this static welcome page, not the SPA. Spec:
+         https://webmachinelearning.github.io/webmcp/. Runs synchronously at
+         parse time so probes find the tools before the page settles, and is a
+         no-op in browsers without navigator.modelContext. The full 39-tool MCP
+         server is the remote HTTP (Streamable HTTP) transport at
+         https://worldmonitor.app/mcp — getWorldMonitorMcpEndpoint hands agents
+         that endpoint. The nonce is added by Vite (html.cspNonce) at build time,
+         so this inline script needs no CSP script-src hash (deploy-config.test). -->
+    <script>
+      (function () {
+        var provider = typeof navigator !== 'undefined' ? navigator.modelContext : null;
+        if (!provider) return;
+        function text(t, isError) {
+          return { content: [{ type: 'text', text: t }], isError: !!isError };
+        }
+        var MONITORS = {
+          world: 'https://www.worldmonitor.app/dashboard',
+          tech: 'https://tech.worldmonitor.app/dashboard',
+          finance: 'https://finance.worldmonitor.app/dashboard',
+          commodity: 'https://commodity.worldmonitor.app/dashboard',
+          energy: 'https://energy.worldmonitor.app/dashboard',
+          happy: 'https://happy.worldmonitor.app/dashboard'
+        };
+        var tools = [
+          {
+            name: 'launchWorldMonitor',
+            description: 'Open the live World Monitor intelligence dashboard in this tab. Optionally choose a specialized monitor variant (world, tech, finance, commodity, energy, happy). Navigates to the real-time map — conflicts, markets, shipping chokepoints, flights and cyber on one surface.',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                monitor: {
+                  type: 'string',
+                  enum: ['world', 'tech', 'finance', 'commodity', 'energy', 'happy'],
+                  description: 'Which monitor to open. Defaults to "world".'
+                }
+              },
+              additionalProperties: false
+            },
+            execute: function (args) {
+              var key = args && typeof args.monitor === 'string' ? args.monitor.toLowerCase() : 'world';
+              var url = MONITORS[key] || MONITORS.world;
+              try {
+                window.location.assign(url);
+              } catch (e) {
+                return Promise.resolve(text('Could not open the dashboard: ' + ((e && e.message) || e), true));
+              }
+              return Promise.resolve(text('Opening the ' + key + ' monitor: ' + url));
+            }
+          },
+          {
+            name: 'getWorldMonitorMcpEndpoint',
+            description: "Return connection details for World Monitor's remote MCP server so an agent can pull live geopolitical, market, maritime, aviation, cyber and economic intelligence directly. Includes the Streamable HTTP endpoint, the discovery server card, supported auth modes, and docs.",
+            inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+            execute: function () {
+              return Promise.resolve(text(JSON.stringify({
+                endpoint: 'https://worldmonitor.app/mcp',
+                transport: 'streamableHttp',
+                serverCard: 'https://worldmonitor.app/.well-known/mcp/server-card.json',
+                tools: 39,
+                auth: ['OAuth 2.1 bearer (Authorization: Bearer <token>)', 'API key (X-WorldMonitor-Key: wm_...)'],
+                publicDiscovery: 'initialize, tools/list and notifications/initialized are servable without credentials',
+                docs: 'https://worldmonitor.app/docs/mcp-server'
+              }, null, 2)));
+            }
+          }
+        ];
+        try {
+          if (typeof provider.registerTool === 'function') {
+            for (var i = 0; i < tools.length; i++) provider.registerTool(tools[i]);
+          } else if (typeof provider.provideContext === 'function') {
+            provider.provideContext({ tools: tools });
+          }
+        } catch (e) {
+          /* Progressive enhancement — never break page load for an optional API. */
+        }
+      })();
+    </script>
     <title>World Monitor — Free Real-Time Global Intelligence Dashboard</title>
     <meta name="description" content="By the time it's news, you already knew. Conflicts, shipping chokepoints, military flights, markets and cyber on one free live world map, with AI analysis. No signup." />
     <meta name="keywords" content="global intelligence dashboard, real-time world map, geopolitical monitoring, conflict tracking, OSINT dashboard, market monitoring, shipping chokepoints, satellite tracking, situational awareness, free intelligence platform, world news dashboard, AI news analysis" />

--- a/public/pro/welcome.html
+++ b/public/pro/welcome.html
@@ -9,6 +9,89 @@
          the same pattern in the SPA's index.html and /pro. -->
     <script nonce="wm-static-bootstrap">document.documentElement.classList.add('js')</script>
     <style nonce="wm-static-bootstrap">html.js #seo-prerender{position:absolute;left:-9999px;top:-9999px;width:1px;height:1px;overflow:hidden}</style>
+    <!-- WebMCP — in-page agent tools on the homepage (worldmonitor.app).
+         Registers a small tool set via navigator.modelContext.registerTool so
+         browser-based AI agents (Chrome/Edge WebMCP, agent-readiness scanners)
+         that land on the apex page can act on and discover World Monitor
+         WITHOUT executing the dashboard SPA — the SPA registers its own richer
+         WebMCP tools separately (src/services/webmcp.ts), but the apex serves
+         this static welcome page, not the SPA. Spec:
+         https://webmachinelearning.github.io/webmcp/. Runs synchronously at
+         parse time so probes find the tools before the page settles, and is a
+         no-op in browsers without navigator.modelContext. The full 39-tool MCP
+         server is the remote HTTP (Streamable HTTP) transport at
+         https://worldmonitor.app/mcp — getWorldMonitorMcpEndpoint hands agents
+         that endpoint. The nonce is added by Vite (html.cspNonce) at build time,
+         so this inline script needs no CSP script-src hash (deploy-config.test). -->
+    <script nonce="wm-static-bootstrap">
+      (function () {
+        var provider = typeof navigator !== 'undefined' ? navigator.modelContext : null;
+        if (!provider) return;
+        function text(t, isError) {
+          return { content: [{ type: 'text', text: t }], isError: !!isError };
+        }
+        var MONITORS = {
+          world: 'https://www.worldmonitor.app/dashboard',
+          tech: 'https://tech.worldmonitor.app/dashboard',
+          finance: 'https://finance.worldmonitor.app/dashboard',
+          commodity: 'https://commodity.worldmonitor.app/dashboard',
+          energy: 'https://energy.worldmonitor.app/dashboard',
+          happy: 'https://happy.worldmonitor.app/dashboard'
+        };
+        var tools = [
+          {
+            name: 'launchWorldMonitor',
+            description: 'Open the live World Monitor intelligence dashboard in this tab. Optionally choose a specialized monitor variant (world, tech, finance, commodity, energy, happy). Navigates to the real-time map — conflicts, markets, shipping chokepoints, flights and cyber on one surface.',
+            inputSchema: {
+              type: 'object',
+              properties: {
+                monitor: {
+                  type: 'string',
+                  enum: ['world', 'tech', 'finance', 'commodity', 'energy', 'happy'],
+                  description: 'Which monitor to open. Defaults to "world".'
+                }
+              },
+              additionalProperties: false
+            },
+            execute: function (args) {
+              var key = args && typeof args.monitor === 'string' ? args.monitor.toLowerCase() : 'world';
+              var url = MONITORS[key] || MONITORS.world;
+              try {
+                window.location.assign(url);
+              } catch (e) {
+                return Promise.resolve(text('Could not open the dashboard: ' + ((e && e.message) || e), true));
+              }
+              return Promise.resolve(text('Opening the ' + key + ' monitor: ' + url));
+            }
+          },
+          {
+            name: 'getWorldMonitorMcpEndpoint',
+            description: "Return connection details for World Monitor's remote MCP server so an agent can pull live geopolitical, market, maritime, aviation, cyber and economic intelligence directly. Includes the Streamable HTTP endpoint, the discovery server card, supported auth modes, and docs.",
+            inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+            execute: function () {
+              return Promise.resolve(text(JSON.stringify({
+                endpoint: 'https://worldmonitor.app/mcp',
+                transport: 'streamableHttp',
+                serverCard: 'https://worldmonitor.app/.well-known/mcp/server-card.json',
+                tools: 39,
+                auth: ['OAuth 2.1 bearer (Authorization: Bearer <token>)', 'API key (X-WorldMonitor-Key: wm_...)'],
+                publicDiscovery: 'initialize, tools/list and notifications/initialized are servable without credentials',
+                docs: 'https://worldmonitor.app/docs/mcp-server'
+              }, null, 2)));
+            }
+          }
+        ];
+        try {
+          if (typeof provider.registerTool === 'function') {
+            for (var i = 0; i < tools.length; i++) provider.registerTool(tools[i]);
+          } else if (typeof provider.provideContext === 'function') {
+            provider.provideContext({ tools: tools });
+          }
+        } catch (e) {
+          /* Progressive enhancement — never break page load for an optional API. */
+        }
+      })();
+    </script>
     <title>World Monitor — Free Real-Time Global Intelligence Dashboard</title>
     <meta name="description" content="By the time it's news, you already knew. Conflicts, shipping chokepoints, military flights, markets and cyber on one free live world map, with AI analysis. No signup." />
     <meta name="keywords" content="global intelligence dashboard, real-time world map, geopolitical monitoring, conflict tracking, OSINT dashboard, market monitoring, shipping chokepoints, satellite tracking, situational awareness, free intelligence platform, world news dashboard, AI news analysis" />

--- a/public/pro/welcome.html
+++ b/public/pro/welcome.html
@@ -16,17 +16,17 @@
          WITHOUT executing the dashboard SPA — the SPA registers its own richer
          WebMCP tools separately (src/services/webmcp.ts), but the apex serves
          this static welcome page, not the SPA. Spec:
-         https://webmachinelearning.github.io/webmcp/. Runs synchronously at
-         parse time so probes find the tools before the page settles, and is a
-         no-op in browsers without navigator.modelContext. The full 39-tool MCP
-         server is the remote HTTP (Streamable HTTP) transport at
-         https://worldmonitor.app/mcp — getWorldMonitorMcpEndpoint hands agents
-         that endpoint. The nonce is added by Vite (html.cspNonce) at build time,
-         so this inline script needs no CSP script-src hash (deploy-config.test). -->
+         https://webmachinelearning.github.io/webmcp/. Registers synchronously at
+         parse time when the provider is already present (native WebMCP), and
+         retries once on DOMContentLoaded/load for a provider installed later
+         (e.g. a scanner polyfill); the `registered` guard keeps it idempotent, and
+         it is a no-op in browsers without navigator.modelContext. The MCP server is
+         the remote HTTP (Streamable HTTP) transport at https://worldmonitor.app/mcp
+         — getWorldMonitorMcpEndpoint hands agents that endpoint. The nonce is added
+         by Vite (html.cspNonce) at build time, so this inline script needs no CSP
+         script-src hash (deploy-config.test). -->
     <script nonce="wm-static-bootstrap">
       (function () {
-        var provider = typeof navigator !== 'undefined' ? navigator.modelContext : null;
-        if (!provider) return;
         function text(t, isError) {
           return { content: [{ type: 'text', text: t }], isError: !!isError };
         }
@@ -55,7 +55,12 @@
             },
             execute: function (args) {
               var key = args && typeof args.monitor === 'string' ? args.monitor.toLowerCase() : 'world';
-              var url = MONITORS[key] || MONITORS.world;
+              // Own-property lookup only — self-validate here rather than trust the
+              // host to enforce inputSchema, so an off-enum key (incl. prototype
+              // keys like "constructor"/"__proto__") can never resolve into
+              // window.location. Unknown keys fall back to the world map.
+              var url = Object.prototype.hasOwnProperty.call(MONITORS, key) ? MONITORS[key] : MONITORS.world;
+              if (url === MONITORS.world) key = 'world';
               try {
                 window.location.assign(url);
               } catch (e) {
@@ -69,11 +74,12 @@
             description: "Return connection details for World Monitor's remote MCP server so an agent can pull live geopolitical, market, maritime, aviation, cyber and economic intelligence directly. Includes the Streamable HTTP endpoint, the discovery server card, supported auth modes, and docs.",
             inputSchema: { type: 'object', properties: {}, additionalProperties: false },
             execute: function () {
+              // No tool count here — the live server card is the source of truth
+              // (a hardcoded number would drift). Agents read the catalog from it.
               return Promise.resolve(text(JSON.stringify({
                 endpoint: 'https://worldmonitor.app/mcp',
                 transport: 'streamableHttp',
                 serverCard: 'https://worldmonitor.app/.well-known/mcp/server-card.json',
-                tools: 39,
                 auth: ['OAuth 2.1 bearer (Authorization: Bearer <token>)', 'API key (X-WorldMonitor-Key: wm_...)'],
                 publicDiscovery: 'initialize, tools/list and notifications/initialized are servable without credentials',
                 docs: 'https://worldmonitor.app/docs/mcp-server'
@@ -81,14 +87,32 @@
             }
           }
         ];
-        try {
-          if (typeof provider.registerTool === 'function') {
-            for (var i = 0; i < tools.length; i++) provider.registerTool(tools[i]);
-          } else if (typeof provider.provideContext === 'function') {
-            provider.provideContext({ tools: tools });
+        var registered = false;
+        function register() {
+          if (registered) return;
+          var provider = typeof navigator !== 'undefined' ? navigator.modelContext : null;
+          if (!provider) return;
+          try {
+            if (typeof provider.registerTool === 'function') {
+              for (var i = 0; i < tools.length; i++) provider.registerTool(tools[i]);
+              registered = true;
+            } else if (typeof provider.provideContext === 'function') {
+              provider.provideContext({ tools: tools });
+              registered = true;
+            }
+          } catch (e) {
+            /* Progressive enhancement — never break page load for an optional API. */
           }
-        } catch (e) {
-          /* Progressive enhancement — never break page load for an optional API. */
+        }
+        register();
+        // Retry once for a provider installed after this head script runs (e.g. a
+        // scanner polyfill injected around DOMContentLoaded). The `registered`
+        // guard keeps it idempotent — a present-at-parse provider never re-registers.
+        if (!registered && typeof document !== 'undefined' && document.addEventListener) {
+          document.addEventListener('DOMContentLoaded', register, { once: true });
+          if (typeof window !== 'undefined' && window.addEventListener) {
+            window.addEventListener('load', register, { once: true });
+          }
         }
       })();
     </script>

--- a/tests/webmcp.test.mjs
+++ b/tests/webmcp.test.mjs
@@ -73,6 +73,74 @@ describe('webmcp.ts: draft-spec contract', () => {
   });
 });
 
+// Homepage WebMCP — the apex `/` serves the static pro-test welcome page
+// (public/pro/welcome.html), NOT the dashboard SPA, so App.ts's
+// registerWebMcpTools never runs there. The apex therefore inlines its own
+// synchronous WebMCP registration in the <head> (pro-test/welcome.html) so
+// browser agents and agent-readiness scanners that land on the homepage see
+// registered tools. These guards keep that signal from silently regressing.
+describe('homepage WebMCP registration (pro-test welcome)', () => {
+  const welcomeSrc = readFileSync(resolve(ROOT, 'pro-test/welcome.html'), 'utf-8');
+  const welcomeBuilt = readFileSync(resolve(ROOT, 'public/pro/welcome.html'), 'utf-8');
+
+  // Isolate the WebMCP inline <script> body (the one that touches the WebMCP
+  // provider) from both the source and the built HTML.
+  const scriptRe = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi;
+  const findWebMcpScript = (html) => {
+    for (const m of html.matchAll(scriptRe)) {
+      if (m[2].includes('navigator.modelContext')) return { attrs: m[1], body: m[2] };
+    }
+    return null;
+  };
+
+  it('source registers WebMCP tools synchronously in the homepage head', () => {
+    const script = findWebMcpScript(welcomeSrc);
+    assert.ok(script, 'welcome.html must inline a script that touches navigator.modelContext');
+    // Guards non-WebMCP browsers: bail before touching the provider.
+    assert.match(script.body, /if \(!provider\) return;/);
+    // Prefers the Chrome-implemented registerTool, with the legacy
+    // provideContext batch form as a fallback (mirrors src/services/webmcp.ts).
+    const registerIdx = script.body.indexOf('provider.registerTool');
+    const provideIdx = script.body.indexOf('provider.provideContext');
+    assert.ok(registerIdx >= 0, 'must call provider.registerTool');
+    assert.ok(provideIdx >= 0, 'must keep provider.provideContext fallback');
+    assert.ok(registerIdx < provideIdx, 'registerTool must be attempted before provideContext');
+  });
+
+  it('ships at least two homepage tools (act + discover)', () => {
+    const script = findWebMcpScript(welcomeSrc);
+    const toolNames = [...script.body.matchAll(/name: '([a-zA-Z]+)'/g)].map((m) => m[1]);
+    assert.ok(toolNames.length >= 2, `expected >=2 homepage tools, found ${toolNames.length}`);
+    assert.ok(toolNames.includes('launchWorldMonitor'), 'must expose launchWorldMonitor (act)');
+    assert.ok(
+      toolNames.includes('getWorldMonitorMcpEndpoint'),
+      'must expose getWorldMonitorMcpEndpoint (discovery bridge to the remote MCP transport)',
+    );
+  });
+
+  it('discovery tool points agents at the live remote MCP transport', () => {
+    const script = findWebMcpScript(welcomeSrc);
+    // The homepage WebMCP surface is a gateway to the full HTTP MCP server;
+    // the discovery tool must hand agents the real /mcp endpoint.
+    assert.match(script.body, /https:\/\/worldmonitor\.app\/mcp/);
+  });
+
+  it('the built homepage carries the WebMCP script under the static nonce (no CSP hash needed)', () => {
+    // deploy-config.test.mjs only exempts inline scripts that carry
+    // nonce="wm-static-bootstrap" from the exact CSP script-src hash set.
+    // If the build ever stops noncing this script, that test would demand a
+    // new hash; assert the invariant here at its source so the failure is
+    // legible rather than surfacing as an opaque CSP-hash mismatch.
+    const script = findWebMcpScript(welcomeBuilt);
+    assert.ok(script, 'built welcome.html must still contain the WebMCP script');
+    assert.match(
+      script.attrs,
+      /\bnonce="wm-static-bootstrap"/,
+      'built WebMCP script must carry the static bootstrap nonce so it needs no CSP hash',
+    );
+  });
+});
+
 // Behavioural tests against buildWebMcpTools() — we can exercise the pure
 // builder by re-implementing the minimal shape it needs. This is a sanity
 // check that the exported surface behaves the way the contract claims.

--- a/tests/webmcp.test.mjs
+++ b/tests/webmcp.test.mjs
@@ -141,6 +141,110 @@ describe('homepage WebMCP registration (pro-test welcome)', () => {
   });
 });
 
+// Runtime behaviour of the homepage WebMCP registration. The inline script is
+// plain ES5 with zero imports, so (unlike the TS module above) we execute it
+// directly against a stub provider to lock in behaviour, not just structure.
+describe('homepage WebMCP registration — runtime behaviour', () => {
+  const welcomeSrc = readFileSync(resolve(ROOT, 'pro-test/welcome.html'), 'utf-8');
+  const iifeMatch = welcomeSrc.match(/\(function \(\) \{[\s\S]*?\}\)\(\);/);
+  const IIFE = iifeMatch && iifeMatch[0];
+  // Inject navigator/window/document as params so they shadow the read-only globals.
+  const runInline = IIFE ? new Function('navigator', 'window', 'document', IIFE) : null;
+
+  // Execute the inline script with stub globals. providerFactory(registered,
+  // provided) returns the value of navigator.modelContext (or null for the
+  // no-provider case). Returns captured effects, any DOMContentLoaded handler
+  // armed for the late-provider retry, and the mutable navigator.
+  function run(providerFactory) {
+    const registered = [];
+    const provided = [];
+    let navigatedTo = null;
+    let domHandler = null;
+    const navigator = { modelContext: providerFactory ? providerFactory(registered, provided) : null };
+    const window = {
+      location: { assign: (u) => { navigatedTo = u; } },
+      addEventListener: () => {},
+    };
+    const document = {
+      addEventListener: (evt, fn) => { if (evt === 'DOMContentLoaded') domHandler = fn; },
+    };
+    runInline(navigator, window, document);
+    return { registered, provided, get navigatedTo() { return navigatedTo; }, domHandler, navigator };
+  }
+  const collectRegister = (registered) => ({ registerTool: (t) => registered.push(t) });
+  const collectProvide = (registered, provided) => ({ provideContext: (ctx) => provided.push(ctx) });
+
+  it('the inline IIFE is extractable and executable', () => {
+    assert.ok(runInline, 'could not extract the WebMCP IIFE from welcome.html');
+  });
+
+  it('registers both tools via registerTool when a provider is present', () => {
+    const r = run(collectRegister);
+    assert.deepEqual(r.registered.map((t) => t.name), ['launchWorldMonitor', 'getWorldMonitorMcpEndpoint']);
+    for (const t of r.registered) {
+      assert.equal(typeof t.description, 'string');
+      assert.equal(t.inputSchema.type, 'object');
+      assert.equal(typeof t.execute, 'function');
+    }
+  });
+
+  it('launchWorldMonitor navigates to the requested variant and defaults to world', async () => {
+    const finance = run(collectRegister);
+    const res = await finance.registered.find((t) => t.name === 'launchWorldMonitor').execute({ monitor: 'finance' });
+    assert.equal(res.isError, false);
+    assert.equal(finance.navigatedTo, 'https://finance.worldmonitor.app/dashboard');
+
+    const dflt = run(collectRegister);
+    await dflt.registered.find((t) => t.name === 'launchWorldMonitor').execute({});
+    assert.equal(dflt.navigatedTo, 'https://www.worldmonitor.app/dashboard');
+  });
+
+  it('launchWorldMonitor never resolves off-enum or prototype keys into navigation', async () => {
+    // "constructor"/"__proto__" are truthy on a plain object's prototype chain;
+    // an own-property guard must keep them (and any unknown key) on the world map.
+    for (const bad of ['xyz', 'constructor', '__proto__', 'toString', 'valueOf']) {
+      const r = run(collectRegister);
+      await r.registered.find((t) => t.name === 'launchWorldMonitor').execute({ monitor: bad });
+      assert.equal(
+        r.navigatedTo,
+        'https://www.worldmonitor.app/dashboard',
+        `monitor="${bad}" must fall back to the world dashboard, not a prototype value`,
+      );
+    }
+  });
+
+  it('getWorldMonitorMcpEndpoint returns the remote transport with no hardcoded tool count', async () => {
+    const r = run(collectRegister);
+    const res = await r.registered.find((t) => t.name === 'getWorldMonitorMcpEndpoint').execute({});
+    const payload = JSON.parse(res.content[0].text);
+    assert.equal(payload.endpoint, 'https://worldmonitor.app/mcp');
+    assert.equal(payload.transport, 'streamableHttp');
+    assert.equal(payload.tools, undefined, 'must not hardcode a tool count that drifts from the server card');
+  });
+
+  it('falls back to provideContext when registerTool is unavailable', () => {
+    const r = run(collectProvide);
+    assert.equal(r.registered.length, 0);
+    assert.equal(r.provided.length, 1);
+    assert.equal(r.provided[0].tools.length, 2);
+  });
+
+  it('is a clean no-op without a provider, and arms a DOMContentLoaded retry', () => {
+    const r = run(() => null);
+    assert.equal(r.registered.length, 0);
+    assert.equal(typeof r.domHandler, 'function', 'must arm a DOMContentLoaded retry when no provider is present at parse time');
+  });
+
+  it('registers on the retry when a provider is installed after head parse', () => {
+    const r = run(() => null); // no provider at parse time
+    assert.equal(r.registered.length, 0);
+    const late = [];
+    r.navigator.modelContext = { registerTool: (t) => late.push(t) }; // provider appears later
+    r.domHandler(); // DOMContentLoaded fires
+    assert.deepEqual(late.map((t) => t.name), ['launchWorldMonitor', 'getWorldMonitorMcpEndpoint']);
+  });
+});
+
 // Behavioural tests against buildWebMcpTools() — we can exercise the pure
 // builder by re-implementing the minimal shape it needs. This is a sanity
 // check that the exported surface behaves the way the contract claims.


### PR DESCRIPTION
## Summary

orank's **"WebMCP support"** check was **1/2** — *"WebMCP mentioned in documentation at /docs but not implemented on homepage."* This was the item PR #4698 explicitly **deferred**.

Root cause: the apex `/` serves the **static pro-welcome page** (`public/pro/welcome.html`), not the dashboard SPA — so the SPA's `navigator.modelContext` registration (`src/services/webmcp.ts`) never runs where an agent-readiness scanner looks.

Fix — a synchronous, CSP-nonce'd inline `<script>` in the homepage `<head>` (`pro-test/welcome.html`) registering two honest, self-contained WebMCP tools:
- **`launchWorldMonitor({monitor?})`** — opens the live dashboard (world/tech/finance/commodity/energy/happy).
- **`getWorldMonitorMcpEndpoint()`** — hands agents the remote MCP transport (`/mcp`, server card, auth modes) — the discovery bridge orank's recommendation asks for.

It mirrors the dashboard's `registerTool`→`provideContext` fallback and guards non-WebMCP browsers (`if (!provider) return`). Belt-and-suspenders: it **executes** at parse time (JS-scanner detectable) **and** is **statically present** in the HTML source (static-crawler detectable).

### Why it's low-risk
- Vite's `html.cspNonce` auto-adds `nonce="wm-static-bootstrap"` at build → `deploy-config.test.mjs` exempts nonce'd inline scripts from the CSP hash set, so **no CSP change needed**.
- Rebuilt `public/pro/` for the freshness gate; diff is purely additive (`+83` built lines, no asset-hash churn).
- Scoped to the apex (orank scans `/`, not `/pro`); the script also ships on every app-root host via the existing rewrite.
- The rescan is deploy-gated (scanner hits the live domain) — expect WebMCP 1/2 → 2/2, Access 129 → 130, overall 66 → 67 after deploy.

## Test plan

- [x] `typecheck` + `typecheck:api`
- [x] `biome lint`, `lint:md`, CJS syntax, `version:check`
- [x] `test:data` — full suite (691 files, run split to avoid worktree OOM) green, incl. `dashboard-critical-css` (after `VITE_VARIANT=full` build)
- [x] `edge-functions.test.mjs` + esbuild bundle check (19 fns)
- [x] New homepage-WebMCP guardrail tests in `tests/webmcp.test.mjs` (registration shape, ≥2 tools, points at `/mcp`, built HTML carries the nonce)
- [x] Runtime-simulated the registration with a stub `navigator.modelContext`: `registerTool` path (2 tools + shape), tool `execute()` outputs, `provideContext` fallback, and clean no-op when absent

https://claude.ai/code/session_01GVDoj1bPoR7wpzmDDDohAs