### PR TITLE
fix(observability): de-group Sentry WORLDMONITOR-T8 api/mcp catch-all

### DIFF
--- a/api/api-route-exceptions.json
+++ b/api/api-route-exceptions.json
@@ -38,6 +38,13 @@
       "removal_issue": null
     },
     {
+      "path": "api/mcp/error-fingerprint.ts",
+      "category": "external-protocol",
+      "reason": "MCP Sentry grouping helper for tools/call capture sites. Keeps MCP external-protocol failures grouped by step, tool, and stable inner error signature without introducing a sebuf product API.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
       "path": "api/mcp/registry/cache-tools.ts",
       "category": "external-protocol",
       "reason": "MCP TOOL_REGISTRY cache-tool entries (no _execute). Extracted from api/mcp.ts during the structural split; same external-protocol constraint as the parent shim.",

--- a/api/mcp/dispatch.ts
+++ b/api/mcp/dispatch.ts
@@ -6,6 +6,7 @@ import {
   PRO_DAILY_QUOTA_LIMIT,
   secondsUntilUtcMidnight,
 } from '../../server/_shared/pro-mcp-token';
+import { mcpErrorFingerprint } from './error-fingerprint';
 import { argBool, summarizeData } from './filters';
 import { evaluateFreshness } from './freshness';
 import { applyJmespath } from './jmespath';
@@ -85,7 +86,13 @@ export async function executeTool(
     try {
       result = tool._postFilter(structuredClone(data), params);
     } catch (err) {
-      captureSilentError(err, { tags: { route: 'api/mcp', step: 'post-filter', tool: tool.name } });
+      // Same minified-frame over-grouping guard as the tool-execution catch
+      // below — key on step + tool + error type so a post-filter bug in one
+      // tool doesn't merge into the shared api/mcp catch-all (WORLDMONITOR-T8).
+      captureSilentError(err, {
+        tags: { route: 'api/mcp', step: 'post-filter', tool: tool.name },
+        fingerprint: mcpErrorFingerprint('post-filter', tool.name, err),
+      });
       result = data;
     }
   }
@@ -251,6 +258,9 @@ export async function dispatchToolsCall(
     captureSilentError(err, {
       tags: { route: 'api/mcp', step: 'tool-execution', tool: tool.name },
       ctx,
+      // Split the api/mcp catch-all (WORLDMONITOR-T8) into per-tool,
+      // per-status groups — see api/mcp/error-fingerprint.ts.
+      fingerprint: mcpErrorFingerprint('tool-execution', tool.name, err),
       ...(isClient4xx ? { level: 'warning' as const } : {}),
     });
     emitTelemetry('mcp.toolcall', {

--- a/api/mcp/error-fingerprint.ts
+++ b/api/mcp/error-fingerprint.ts
@@ -17,7 +17,7 @@
  *    `HTTP 401: invalid_internal_mcp_signature` coalesce into one group rather
  *    than fragmenting on the variable reason token.
  *  - Any other failure (timeout, abort, TypeError from a bad _postFilter) keys
- *    on the error constructor name so distinct runtime faults stay separable.
+ *    on the stable error name so distinct runtime faults stay separable.
  *
  * The `step` distinguishes the two capture sites in dispatch.ts (`tool-execution`
  * vs `post-filter`) so a post-filter bug never re-merges with the fetch path.
@@ -31,7 +31,7 @@ export function mcpErrorFingerprint(step: string, toolName: string, err: unknown
   const signature = siblingHttp
     ? `${siblingHttp[1]}:${siblingHttp[2]}`
     : err instanceof Error
-      ? err.constructor.name
+      ? err.name || err.constructor.name
       : 'non-error';
   return [`mcp-${step}`, toolName, signature];
 }

--- a/api/mcp/error-fingerprint.ts
+++ b/api/mcp/error-fingerprint.ts
@@ -27,7 +27,7 @@
  */
 export function mcpErrorFingerprint(step: string, toolName: string, err: unknown): string[] {
   const message = err instanceof Error ? err.message : String(err);
-  const siblingHttp = message.match(/^([A-Za-z0-9-]+) HTTP (\d{3})\b/);
+  const siblingHttp = message.match(/^([A-Za-z0-9_-]+) HTTP (\d{3})\b/);
   const signature = siblingHttp
     ? `${siblingHttp[1]}:${siblingHttp[2]}`
     : err instanceof Error

--- a/api/mcp/error-fingerprint.ts
+++ b/api/mcp/error-fingerprint.ts
@@ -1,0 +1,37 @@
+/**
+ * Stable Sentry grouping fingerprint for an `api/mcp` error capture.
+ *
+ * Why this exists: the minified edge bundle gives every tool-execution error
+ * identical anonymous frames (`(vc/edge/function`, no source map, in_app=false),
+ * so Sentry's default stack-based grouping merges ALL api/mcp failures — across
+ * every tool AND every status code — into ONE catch-all issue (WORLDMONITOR-T8)
+ * whose title only reflects the newest event. That masks a real 5xx spike in one
+ * tool behind low-grade auth drift in another. Supplying an explicit fingerprint
+ * overrides the stack grouping and splits each failure mode into its own
+ * trackable group.
+ *
+ * Signature derivation:
+ *  - Sibling-fetch failures are thrown as `<inner-endpoint> HTTP <status>`
+ *    (see api/mcp/registry/rpc-tools.ts). Key on `<endpoint>:<status>` and drop
+ *    any trailing `: <reason>` so `HTTP 401` and
+ *    `HTTP 401: invalid_internal_mcp_signature` coalesce into one group rather
+ *    than fragmenting on the variable reason token.
+ *  - Any other failure (timeout, abort, TypeError from a bad _postFilter) keys
+ *    on the error constructor name so distinct runtime faults stay separable.
+ *
+ * The `step` distinguishes the two capture sites in dispatch.ts (`tool-execution`
+ * vs `post-filter`) so a post-filter bug never re-merges with the fetch path.
+ *
+ * Pure + zero-import by design so it is unit-testable from the `tests/*.test.mjs`
+ * runner without a Sentry DSN or a full dispatch harness.
+ */
+export function mcpErrorFingerprint(step: string, toolName: string, err: unknown): string[] {
+  const message = err instanceof Error ? err.message : String(err);
+  const siblingHttp = message.match(/^([A-Za-z0-9-]+) HTTP (\d{3})\b/);
+  const signature = siblingHttp
+    ? `${siblingHttp[1]}:${siblingHttp[2]}`
+    : err instanceof Error
+      ? err.constructor.name
+      : 'non-error';
+  return [`mcp-${step}`, toolName, signature];
+}

--- a/tests/mcp-error-fingerprint.test.mjs
+++ b/tests/mcp-error-fingerprint.test.mjs
@@ -45,11 +45,16 @@ describe('mcpErrorFingerprint', () => {
     assert.notDeepEqual(a, b);
   });
 
-  it('keys non-HTTP failures on the error constructor name', () => {
+  it('keys non-HTTP failures on the stable error name', () => {
     const timeout = new DOMException('The operation timed out', 'TimeoutError');
+    const abort = new DOMException('The operation was aborted', 'AbortError');
     assert.deepEqual(
       mcpErrorFingerprint('tool-execution', 'get_world_brief', timeout),
-      ['mcp-tool-execution', 'get_world_brief', 'DOMException'],
+      ['mcp-tool-execution', 'get_world_brief', 'TimeoutError'],
+    );
+    assert.deepEqual(
+      mcpErrorFingerprint('tool-execution', 'get_world_brief', abort),
+      ['mcp-tool-execution', 'get_world_brief', 'AbortError'],
     );
     assert.deepEqual(
       mcpErrorFingerprint('post-filter', 'get_market_data', new TypeError('x is not a function')),

--- a/tests/mcp-error-fingerprint.test.mjs
+++ b/tests/mcp-error-fingerprint.test.mjs
@@ -1,0 +1,74 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import { mcpErrorFingerprint } from '../api/mcp/error-fingerprint.ts';
+
+// Regression guard for WORLDMONITOR-T8: the minified edge bundle gives every
+// api/mcp error identical anonymous frames, so without an explicit fingerprint
+// Sentry merges all tool 4xx/5xx sibling-fetch failures into one catch-all
+// issue. These assertions pin the grouping so a future regex edit can't
+// silently re-merge the groups.
+describe('mcpErrorFingerprint', () => {
+  it('keys a sibling-fetch HTTP error on <endpoint>:<status>', () => {
+    assert.deepEqual(
+      mcpErrorFingerprint('tool-execution', 'get_world_brief', new Error('feed-digest HTTP 404')),
+      ['mcp-tool-execution', 'get_world_brief', 'feed-digest:404'],
+    );
+  });
+
+  it('drops a trailing `: <reason>` so HTTP 401 variants coalesce', () => {
+    const plain = mcpErrorFingerprint(
+      'tool-execution',
+      'get_country_brief',
+      new Error('get-country-intel-brief HTTP 401'),
+    );
+    const withReason = mcpErrorFingerprint(
+      'tool-execution',
+      'get_country_brief',
+      new Error('get-country-intel-brief HTTP 401: invalid_internal_mcp_signature'),
+    );
+    assert.deepEqual(plain, withReason);
+    assert.deepEqual(plain, ['mcp-tool-execution', 'get_country_brief', 'get-country-intel-brief:401']);
+  });
+
+  it('separates the same tool by status class (401 auth vs 502 upstream)', () => {
+    const four = mcpErrorFingerprint('tool-execution', 't', new Error('feed-digest HTTP 401'));
+    const five = mcpErrorFingerprint('tool-execution', 't', new Error('feed-digest HTTP 502'));
+    assert.notDeepEqual(four, five);
+    assert.equal(four[2], 'feed-digest:401');
+    assert.equal(five[2], 'feed-digest:502');
+  });
+
+  it('separates different tools that hit the same inner endpoint', () => {
+    const a = mcpErrorFingerprint('tool-execution', 'get_world_brief', new Error('summarize-article HTTP 401'));
+    const b = mcpErrorFingerprint('tool-execution', 'get_country_brief', new Error('summarize-article HTTP 401'));
+    assert.notDeepEqual(a, b);
+  });
+
+  it('keys non-HTTP failures on the error constructor name', () => {
+    const timeout = new DOMException('The operation timed out', 'TimeoutError');
+    assert.deepEqual(
+      mcpErrorFingerprint('tool-execution', 'get_world_brief', timeout),
+      ['mcp-tool-execution', 'get_world_brief', 'DOMException'],
+    );
+    assert.deepEqual(
+      mcpErrorFingerprint('post-filter', 'get_market_data', new TypeError('x is not a function')),
+      ['mcp-post-filter', 'get_market_data', 'TypeError'],
+    );
+  });
+
+  it('handles a thrown non-Error value without crashing', () => {
+    assert.deepEqual(
+      mcpErrorFingerprint('tool-execution', 'get_world_brief', 'boom'),
+      ['mcp-tool-execution', 'get_world_brief', 'non-error'],
+    );
+  });
+
+  it('distinguishes the two capture steps', () => {
+    const exec = mcpErrorFingerprint('tool-execution', 't', new Error('feed-digest HTTP 404'));
+    const post = mcpErrorFingerprint('post-filter', 't', new Error('feed-digest HTTP 404'));
+    assert.equal(exec[0], 'mcp-tool-execution');
+    assert.equal(post[0], 'mcp-post-filter');
+    assert.notDeepEqual(exec, post);
+  });
+});

--- a/tests/mcp-error-fingerprint.test.mjs
+++ b/tests/mcp-error-fingerprint.test.mjs
@@ -45,6 +45,13 @@ describe('mcpErrorFingerprint', () => {
     assert.notDeepEqual(a, b);
   });
 
+  it('keeps underscore sibling endpoints on the HTTP grouping path', () => {
+    assert.deepEqual(
+      mcpErrorFingerprint('tool-execution', 'get_world_brief', new Error('feed_digest HTTP 404')),
+      ['mcp-tool-execution', 'get_world_brief', 'feed_digest:404'],
+    );
+  });
+
   it('keys non-HTTP failures on the stable error name', () => {
     const timeout = new DOMException('The operation timed out', 'TimeoutError');
     const abort = new DOMException('The operation was aborted', 'AbortError');


### PR DESCRIPTION
## What

Splits the over-grouped Sentry issue **WORLDMONITOR-T8** into per-tool, per-status groups. Fixes #4723.

T8 is not one error — the minified edge bundle gives every `api/mcp` tool-execution error identical anonymous frames (`(vc/edge/function`, no source map), so Sentry's default stack grouping merged **all** tool 4xx/5xx sibling-fetch failures into one catch-all whose title only shows the newest event (a 90d sample held 7 distinct messages across 4 tools). Because it was resolved `inNextRelease`, a real 5xx spike could hide inside it, resolved and un-alerted.

## Change

- **`api/mcp/error-fingerprint.ts`** (new, pure, zero-import): `mcpErrorFingerprint(step, tool, err)` → `['mcp-<step>', tool, '<inner-endpoint>:<status>']`. Drops any trailing `: <reason>` so `HTTP 401` and `HTTP 401: invalid_internal_mcp_signature` coalesce; non-HTTP faults (timeout/abort/TypeError) key on the error constructor name.
- **`api/mcp/dispatch.ts`**: supply that fingerprint at both capture sites — the `tool-execution` catch and the `post-filter` catch.
- **`tests/mcp-error-fingerprint.test.mjs`** (new): 7 cases pinning the grouping so a future regex edit can't silently re-merge.

`level: warning` for 4xx sibling fetches (dispatch.ts:239) is unchanged — these stay non-alerting but are now queryable per-tool. A 5xx in any one tool now surfaces as its own group.

## Verification

- `tsc --noEmit -p tsconfig.api.json` → clean
- `tsx --test tests/mcp-error-fingerprint.test.mjs` → 7/7 pass
- `tsx --test tests/mcp.test.mjs` (exercises the same catch block) → 127/127 pass

## Follow-ups (tracked in #4723, not in this PR)

- Cross-origin `feed-digest 404`: whether internal sibling fetches should pin the canonical origin instead of echoing `req.url`'s origin (`base = new URL(req.url).origin`).
- `inNextRelease` + raw-SHA releases: no semver ordering → auto-reopen may never fire.

https://claude.ai/code/session_0184o5xz8VH8hHqPpbM5jFKi