### PR TITLE
feat(shipping/webhooks): document signed delivery contract in OpenAPI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ generate: clean ## Generate code from proto definitions
 	@node scripts/openapi-inject-examples.mjs
 	@node scripts/openapi-inject-servers.mjs
 	@node scripts/openapi-inject-deprecated.mjs
+	@node scripts/openapi-inject-webhooks.mjs
 	@echo "Code generation complete!"
 
 breaking: ## Check for breaking changes against main

--- a/docs/api-shipping-v2.mdx
+++ b/docs/api-shipping-v2.mdx
@@ -153,7 +153,7 @@ Flips `active: true` on the record (use after investigating and fixing a deliver
 POST <callbackUrl>
 Content-Type: application/json
 X-WM-Signature: sha256=<HMAC-SHA256(body, secret)>
-X-WM-Delivery-Id: <ulid>
+X-WM-Delivery-Id: whd_<32 lowercase hex chars>
 X-WM-Event: chokepoint.disruption
 
 {
@@ -168,3 +168,24 @@ X-WM-Event: chokepoint.disruption
 ```
 
 The delivery worker re-resolves `callbackUrl` before each send and re-checks against `PRIVATE_HOSTNAME_PATTERNS` to mitigate DNS rebinding. Delivery is at-least-once — consumers must handle duplicates via `X-WM-Delivery-Id`.
+
+### Verifying deliveries
+
+Every delivery is signed so you can confirm it genuinely came from WorldMonitor. `X-WM-Signature` is `sha256=<hex>`, where `<hex>` is the lowercase-hex **HMAC-SHA256 of the exact raw request body**, keyed by the `secret` returned at registration.
+
+To verify: recompute `sha256=` + `hex(HMAC_SHA256(key=secret, message=rawBody))` over the bytes **exactly as received** (do not re-serialize the JSON), and compare against `X-WM-Signature` in constant time. Use the `secret` string **verbatim** as the HMAC key — do not hex-decode it. Reject the delivery if the signatures differ.
+
+```js
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+// rawBody: the exact request body bytes; header: the X-WM-Signature value;
+// secret: the value returned by RegisterWebhook (used verbatim as the key).
+function verifyWorldMonitorWebhook(rawBody, header, secret) {
+  const expected = 'sha256=' + createHmac('sha256', secret).update(rawBody).digest('hex');
+  const a = Buffer.from(header ?? '');
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+```
+
+The signature contract is also published machine-readably as the `chokepoint.disruption` entry under `webhooks` in the [OpenAPI spec](https://worldmonitor.app/openapi.json).

--- a/docs/api/worldmonitor.openapi.yaml
+++ b/docs/api/worldmonitor.openapi.yaml
@@ -13158,6 +13158,111 @@ paths:
                         application/json:
                             schema:
                                 $ref: '#/components/schemas/Error'
+webhooks:
+    chokepoint.disruption:
+        post:
+            tags:
+                - ShippingV2Service
+            summary: Chokepoint disruption alert (outbound, signed)
+            description: |-
+                WorldMonitor POSTs this event to the `callbackUrl` you register via
+                RegisterWebhook whenever a subscribed chokepoint's disruption score
+                crosses your `alertThreshold`. Every delivery is signed so you can
+                confirm it genuinely came from WorldMonitor.
+
+                Verification: the `X-WM-Signature` header is
+                `sha256=<hex>`, where `<hex>` is the lowercase hex HMAC-SHA256 of the
+                exact raw request body, keyed by the `secret` returned when you
+                registered the webhook. To verify, recompute
+                `sha256=` + hex(HMAC_SHA256(key=secret, message=rawRequestBody)) over
+                the bytes exactly as received (do not re-serialize the JSON) and
+                compare against `X-WM-Signature` in constant time. Use the
+                `secret` string verbatim as the HMAC key — do not hex-decode it.
+                Reject the delivery if the signatures differ.
+
+                Respond with any 2xx to acknowledge receipt; a non-2xx response or a
+                timeout marks the delivery failed. `X-WM-Delivery-Id` uniquely
+                identifies each delivery for idempotent processing.
+            operationId: ChokepointDisruptionWebhook
+            security: []
+            parameters:
+                - name: X-WM-Signature
+                  in: header
+                  required: true
+                  description: |-
+                      HMAC-SHA256 signature of the raw request body, keyed by the
+                      subscription `secret`, formatted as `sha256=<lowercase-hex>`.
+                  schema:
+                      type: string
+                      pattern: ^sha256=[0-9a-f]{64}$
+                      example: sha256=2b8c0d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c
+                - name: X-WM-Event
+                  in: header
+                  required: true
+                  description: Event type. Currently always `chokepoint.disruption`.
+                  schema:
+                      type: string
+                      example: chokepoint.disruption
+                - name: X-WM-Delivery-Id
+                  in: header
+                  required: true
+                  description: |-
+                      Unique delivery identifier (`whd_` + 32 hex chars). Use it to
+                      dedupe retries and process deliveries idempotently.
+                  schema:
+                      type: string
+                      example: whd_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            required:
+                                - subscriberId
+                                - chokepointId
+                                - score
+                                - alertThreshold
+                                - triggeredAt
+                                - reason
+                            properties:
+                                subscriberId:
+                                    type: string
+                                    description: The `wh_`-prefixed subscription receiving this alert.
+                                chokepointId:
+                                    type: string
+                                    description: Chokepoint that breached the threshold (e.g. `suez`).
+                                score:
+                                    type: number
+                                    description: Current disruption score of the chokepoint, 0-100.
+                                alertThreshold:
+                                    type: number
+                                    description: The subscription's configured alert threshold, 0-100.
+                                triggeredAt:
+                                    type: string
+                                    format: date-time
+                                    description: ISO-8601 timestamp when the alert fired.
+                                reason:
+                                    type: string
+                                    description: Human-readable explanation for the alert.
+                                details:
+                                    type: object
+                                    additionalProperties: true
+                                    description: Optional structured context for the disruption.
+                        example:
+                            "subscriberId": "wh_1a2b3c4d5e6f7a8b9c0d1e2f"
+                            "chokepointId": "suez"
+                            "score": 72
+                            "alertThreshold": 50
+                            "triggeredAt": "2026-07-04T12:34:56Z"
+                            "reason": "Disruption score 72 crossed alert threshold 50"
+                            "details":
+                                "trend": "rising"
+            responses:
+                "2XX":
+                    description: |-
+                        Any 2xx acknowledges receipt. A non-2xx response or a delivery
+                        timeout marks the delivery failed.
 components:
     securitySchemes:
         WorldMonitorKey:

--- a/docs/api/worldmonitor.openapi.yaml
+++ b/docs/api/worldmonitor.openapi.yaml
@@ -13211,6 +13211,7 @@ webhooks:
                       dedupe retries and process deliveries idempotently.
                   schema:
                       type: string
+                      pattern: ^whd_[0-9a-f]{32}$
                       example: whd_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
             requestBody:
                 required: true

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "gen:openapi:required": "node scripts/openapi-inject-required.mjs",
     "gen:openapi:servers": "node scripts/openapi-inject-servers.mjs",
     "gen:openapi:deprecated": "node scripts/openapi-inject-deprecated.mjs",
+    "gen:openapi:webhooks": "node scripts/openapi-inject-webhooks.mjs",
     "build:agent-skills": "node scripts/build-agent-skills-index.mjs",
     "prebuild": "npm run build:openapi && npm run build:agent-skills",
     "build": "npm run build:blog && tsc && vite build",

--- a/scripts/openapi-inject-webhooks.mjs
+++ b/scripts/openapi-inject-webhooks.mjs
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+/**
+ * Inject the outbound webhook-delivery contract into the OpenAPI bundle.
+ *
+ * The ShippingV2Service lets partners register a `callbackUrl` (RegisterWebhook)
+ * that WorldMonitor POSTs a signed chokepoint-disruption alert to. The delivery
+ * worker (server/worldmonitor/shipping/v2/deliver-webhook.ts) signs every POST
+ * with an HMAC-SHA256 over the raw body, keyed by the subscription `secret`, and
+ * sends it in a branded `X-WM-Signature` header (plus `X-WM-Event` /
+ * `X-WM-Delivery-Id`). The sebuf `protoc-gen-openapiv3` plugin only emits the
+ * *inbound* request/response shapes it can see in the proto; it has no way to
+ * describe an *outbound* callback, so the published spec references the HMAC
+ * secret (RegisterWebhookResponse.secret) without ever naming the signature
+ * header an agent needs to verify a delivery. Agent-readiness scanners
+ * (ora.ai / orank) flag this: "Webhook signing referenced ... but no branded
+ * signature header identified".
+ *
+ * OpenAPI 3.1 models exactly this with a top-level `webhooks` object (a map of
+ * named Path Item Objects describing requests the API *initiates*). This step
+ * injects one `chokepoint.disruption` webhook documenting the three branded
+ * headers, the payload schema, and — crucially — the verification recipe, so a
+ * consuming agent can confirm a delivery genuinely came from WorldMonitor.
+ *
+ * Only the bundle (docs/api/worldmonitor.openapi.yaml) is touched: it is copied
+ * to public/openapi.yaml and deserialized to public/openapi.json (the artifact
+ * orank fetches) at build time. The per-service ShippingV2Service spec is left
+ * alone — top-level `webhooks` is a bundle-level, cross-cutting concern and the
+ * Mintlify per-service renderer does not surface it.
+ *
+ * Like the sibling injectors this runs in the `make generate` codegen context
+ * (no npm deps guaranteed), so it has no external imports: the block is a static
+ * constant and the YAML write is a formatting-preserving surgical insertion.
+ * Wired into `make generate` (after the other OpenAPI injectors) and exposed as
+ * `npm run gen:openapi:webhooks`. Idempotent and order-independent: re-running,
+ * or a fresh regenerate followed by this step, yields byte-identical output.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const bundlePath = resolve(root, 'docs/api/worldmonitor.openapi.yaml');
+
+const CHECK = process.argv.includes('--check');
+
+// The webhook event name — matches the default `options.event` in
+// deliver-webhook.ts (the `X-WM-Event` header value).
+export const WEBHOOK_EVENT = 'chokepoint.disruption';
+
+// The branded delivery headers, verbatim from deliver-webhook.ts. Header names
+// are case-insensitive on the wire (the worker sends them lowercase); the spec
+// uses canonical casing. Kept here as the single source the contract test reads.
+export const SIGNATURE_HEADER = 'X-WM-Signature';
+export const EVENT_HEADER = 'X-WM-Event';
+export const DELIVERY_ID_HEADER = 'X-WM-Delivery-Id';
+
+// The 4-space-indented top-level `webhooks:` block. Authored by hand to match
+// the generator's bundle formatting (4-space steps; list items `- ` at +2) so
+// the injected diff reads cleanly alongside the generated paths.
+const WEBHOOKS_BLOCK = `webhooks:
+    ${WEBHOOK_EVENT}:
+        post:
+            tags:
+                - ShippingV2Service
+            summary: Chokepoint disruption alert (outbound, signed)
+            description: |-
+                WorldMonitor POSTs this event to the \`callbackUrl\` you register via
+                RegisterWebhook whenever a subscribed chokepoint's disruption score
+                crosses your \`alertThreshold\`. Every delivery is signed so you can
+                confirm it genuinely came from WorldMonitor.
+
+                Verification: the \`${SIGNATURE_HEADER}\` header is
+                \`sha256=<hex>\`, where \`<hex>\` is the lowercase hex HMAC-SHA256 of the
+                exact raw request body, keyed by the \`secret\` returned when you
+                registered the webhook. To verify, recompute
+                \`sha256=\` + hex(HMAC_SHA256(key=secret, message=rawRequestBody)) over
+                the bytes exactly as received (do not re-serialize the JSON) and
+                compare against \`${SIGNATURE_HEADER}\` in constant time. Use the
+                \`secret\` string verbatim as the HMAC key — do not hex-decode it.
+                Reject the delivery if the signatures differ.
+
+                Respond with any 2xx to acknowledge receipt; a non-2xx response or a
+                timeout marks the delivery failed. \`${DELIVERY_ID_HEADER}\` uniquely
+                identifies each delivery for idempotent processing.
+            operationId: ChokepointDisruptionWebhook
+            security: []
+            parameters:
+                - name: ${SIGNATURE_HEADER}
+                  in: header
+                  required: true
+                  description: |-
+                      HMAC-SHA256 signature of the raw request body, keyed by the
+                      subscription \`secret\`, formatted as \`sha256=<lowercase-hex>\`.
+                  schema:
+                      type: string
+                      pattern: ^sha256=[0-9a-f]{64}$
+                      example: sha256=2b8c0d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c
+                - name: ${EVENT_HEADER}
+                  in: header
+                  required: true
+                  description: Event type. Currently always \`${WEBHOOK_EVENT}\`.
+                  schema:
+                      type: string
+                      example: ${WEBHOOK_EVENT}
+                - name: ${DELIVERY_ID_HEADER}
+                  in: header
+                  required: true
+                  description: |-
+                      Unique delivery identifier (\`whd_\` + 32 hex chars). Use it to
+                      dedupe retries and process deliveries idempotently.
+                  schema:
+                      type: string
+                      example: whd_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
+            requestBody:
+                required: true
+                content:
+                    application/json:
+                        schema:
+                            type: object
+                            required:
+                                - subscriberId
+                                - chokepointId
+                                - score
+                                - alertThreshold
+                                - triggeredAt
+                                - reason
+                            properties:
+                                subscriberId:
+                                    type: string
+                                    description: The \`wh_\`-prefixed subscription receiving this alert.
+                                chokepointId:
+                                    type: string
+                                    description: Chokepoint that breached the threshold (e.g. \`suez\`).
+                                score:
+                                    type: number
+                                    description: Current disruption score of the chokepoint, 0-100.
+                                alertThreshold:
+                                    type: number
+                                    description: The subscription's configured alert threshold, 0-100.
+                                triggeredAt:
+                                    type: string
+                                    format: date-time
+                                    description: ISO-8601 timestamp when the alert fired.
+                                reason:
+                                    type: string
+                                    description: Human-readable explanation for the alert.
+                                details:
+                                    type: object
+                                    additionalProperties: true
+                                    description: Optional structured context for the disruption.
+                        example:
+                            "subscriberId": "wh_1a2b3c4d5e6f7a8b9c0d1e2f"
+                            "chokepointId": "suez"
+                            "score": 72
+                            "alertThreshold": 50
+                            "triggeredAt": "2026-07-04T12:34:56Z"
+                            "reason": "Disruption score 72 crossed alert threshold 50"
+                            "details":
+                                "trend": "rising"
+            responses:
+                "2XX":
+                    description: |-
+                        Any 2xx acknowledges receipt. A non-2xx response or a delivery
+                        timeout marks the delivery failed.`;
+
+// A top-level key is at column 0; its block extends until the next column-0
+// line. Mirrors findTopLevelBlock in openapi-inject-security.mjs /
+// openapi-inject-servers.mjs.
+function findTopLevelBlock(lines, key) {
+  const start = lines.indexOf(key + ':');
+  if (start === -1) return null;
+  let end = start + 1;
+  while (end < lines.length) {
+    const line = lines[end];
+    if (line && !line.startsWith(' ') && !line.startsWith('\t')) break;
+    end++;
+  }
+  return { start, end, text: lines.slice(start, end).join('\n') };
+}
+
+export function injectYamlWebhooks(text) {
+  const lines = text.split('\n');
+  const expected = WEBHOOKS_BLOCK.split('\n');
+
+  const block = findTopLevelBlock(lines, 'webhooks');
+  if (block) {
+    if (block.text === expected.join('\n')) return { text, changed: false };
+    lines.splice(block.start, block.end - block.start, ...expected);
+    return { text: lines.join('\n'), changed: true };
+  }
+
+  // Insert the top-level `webhooks:` block immediately before top-level
+  // `components:`. Both keys are always present and at column 0, so the anchor
+  // is stable regardless of which sibling injectors ran first — the diff is
+  // additions-only and order-independent.
+  const componentsIndex = lines.indexOf('components:');
+  if (componentsIndex === -1) {
+    throw new Error('yaml: could not find top-level `components:` anchor for webhooks block');
+  }
+  lines.splice(componentsIndex, 0, ...expected);
+  return { text: lines.join('\n'), changed: true };
+}
+
+// Only run the CLI (read/write/log/exit) when invoked directly — importing this
+// module for its exported constants + injectYamlWebhooks (the contract test does)
+// must be side-effect-free.
+const isEntryPoint =
+  process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isEntryPoint) {
+  const raw = readFileSync(bundlePath, 'utf8');
+  const result = injectYamlWebhooks(raw);
+
+  if (CHECK) {
+    if (result.changed) {
+      console.error('✗ bundle (worldmonitor.openapi.yaml) is missing the webhooks delivery contract');
+      console.error('  Run: npm run gen:openapi:webhooks');
+      process.exit(1);
+    }
+    console.log(`✓ bundle carries the ${WEBHOOK_EVENT} webhook with the ${SIGNATURE_HEADER} header`);
+  } else {
+    if (result.changed) writeFileSync(bundlePath, result.text);
+    console.log(
+      `openapi-inject-webhooks: ${result.changed ? 'injected' : 'already present'} — ${WEBHOOK_EVENT} webhook (${SIGNATURE_HEADER}) in worldmonitor.openapi.yaml`,
+    );
+  }
+}

--- a/scripts/openapi-inject-webhooks.mjs
+++ b/scripts/openapi-inject-webhooks.mjs
@@ -111,6 +111,7 @@ const WEBHOOKS_BLOCK = `webhooks:
                       dedupe retries and process deliveries idempotently.
                   schema:
                       type: string
+                      pattern: ^whd_[0-9a-f]{32}$
                       example: whd_1a2b3c4d5e6f7a8b9c0d1e2f3a4b5c6d
             requestBody:
                 required: true

--- a/tests/openapi-webhooks-contract.test.mjs
+++ b/tests/openapi-webhooks-contract.test.mjs
@@ -58,6 +58,11 @@ describe('OpenAPI webhooks contract', () => {
     assert.equal(sig.schema.pattern, '^sha256=[0-9a-f]{64}$');
   });
 
+  it('the delivery id header schema constrains the whd_<32hex> format', () => {
+    const deliveryId = webhook.parameters.find((p) => p.name === DELIVERY_ID_HEADER);
+    assert.equal(deliveryId.schema.pattern, '^whd_[0-9a-f]{32}$');
+  });
+
   it('documents a verification recipe (HMAC-SHA256, constant-time compare)', () => {
     const desc = webhook.description ?? '';
     for (const needle of ['HMAC-SHA256', 'constant time', 'secret', 'do not hex-decode']) {

--- a/tests/openapi-webhooks-contract.test.mjs
+++ b/tests/openapi-webhooks-contract.test.mjs
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { load as loadYaml } from 'js-yaml';
+
+import {
+  injectYamlWebhooks,
+  WEBHOOK_EVENT,
+  SIGNATURE_HEADER,
+  EVENT_HEADER,
+  DELIVERY_ID_HEADER,
+} from '../scripts/openapi-inject-webhooks.mjs';
+
+// Guards the outbound webhook-delivery contract injected into the OpenAPI bundle
+// by scripts/openapi-inject-webhooks.mjs (orank Access — "webhook signing
+// referenced but no branded signature header identified"). The published spec
+// (public/openapi.json ← docs/api/worldmonitor.openapi.yaml) must name the
+// branded X-WM-Signature header and describe how to verify it, and that
+// documented contract must not drift from what the delivery worker actually
+// sends (server/worldmonitor/shipping/v2/deliver-webhook.ts).
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const bundlePath = resolve(root, 'docs/api/worldmonitor.openapi.yaml');
+const deliverPath = resolve(root, 'server/worldmonitor/shipping/v2/deliver-webhook.ts');
+
+const bundleRaw = readFileSync(bundlePath, 'utf8');
+const bundle = loadYaml(bundleRaw);
+const deliverSrc = readFileSync(deliverPath, 'utf8');
+
+const webhook = bundle.webhooks?.[WEBHOOK_EVENT]?.post;
+
+describe('OpenAPI webhooks contract', () => {
+  it('bundle documents the chokepoint.disruption outbound webhook', () => {
+    assert.ok(bundle.webhooks, 'bundle must carry a top-level `webhooks` object');
+    assert.ok(webhook, `bundle.webhooks['${WEBHOOK_EVENT}'].post must exist`);
+    assert.equal(webhook.operationId, 'ChokepointDisruptionWebhook');
+    // The delivery is outbound (the consumer receives it), so it carries no API
+    // key — document it as unauthenticated to the consumer, authenticated by the
+    // signature instead.
+    assert.deepEqual(webhook.security, [], 'outbound webhook must document security: []');
+  });
+
+  it('documents the three branded delivery headers as required header params', () => {
+    const headerParams = (webhook.parameters ?? []).filter((p) => p.in === 'header');
+    const byName = new Map(headerParams.map((p) => [p.name, p]));
+    for (const name of [SIGNATURE_HEADER, EVENT_HEADER, DELIVERY_ID_HEADER]) {
+      const p = byName.get(name);
+      assert.ok(p, `missing header parameter ${name}`);
+      assert.equal(p.required, true, `${name} must be required`);
+      assert.equal(p.schema?.type, 'string', `${name} schema must be a string`);
+    }
+  });
+
+  it('the signature header schema constrains the sha256=<hex> format', () => {
+    const sig = webhook.parameters.find((p) => p.name === SIGNATURE_HEADER);
+    assert.equal(sig.schema.pattern, '^sha256=[0-9a-f]{64}$');
+  });
+
+  it('documents a verification recipe (HMAC-SHA256, constant-time compare)', () => {
+    const desc = webhook.description ?? '';
+    for (const needle of ['HMAC-SHA256', 'constant time', 'secret', 'do not hex-decode']) {
+      assert.ok(desc.includes(needle), `webhook description must mention "${needle}"`);
+    }
+  });
+
+  it('payload schema matches the WebhookDeliveryPayload interface exactly', () => {
+    const schema = webhook.requestBody.content['application/json'].schema;
+
+    // Parse the source-of-truth interface: `name: type;` (required) or
+    // `name?: type;` (optional).
+    const block = deliverSrc.match(/interface WebhookDeliveryPayload \{([\s\S]*?)\n\}/);
+    assert.ok(block, 'could not locate WebhookDeliveryPayload interface');
+    const fields = [...block[1].matchAll(/^\s*(\w+)(\??):/gm)].map((m) => ({
+      name: m[1],
+      optional: m[2] === '?',
+    }));
+    assert.ok(fields.length >= 6, 'expected the interface to parse at least 6 fields');
+
+    const documented = Object.keys(schema.properties).sort();
+    const expected = fields.map((f) => f.name).sort();
+    assert.deepEqual(documented, expected, 'documented payload properties must match the interface');
+
+    const requiredExpected = fields.filter((f) => !f.optional).map((f) => f.name).sort();
+    assert.deepEqual([...schema.required].sort(), requiredExpected, 'required set must match non-optional interface fields');
+  });
+
+  it('documented headers match what the delivery worker actually sends', () => {
+    // The worker sends header names lowercase; the spec uses canonical casing.
+    const sent = [...deliverSrc.matchAll(/'(x-wm-[a-z-]+)'\s*:/g)].map((m) => m[1].toLowerCase());
+    const sentSet = new Set(sent);
+    for (const name of [SIGNATURE_HEADER, EVENT_HEADER, DELIVERY_ID_HEADER]) {
+      assert.ok(sentSet.has(name.toLowerCase()), `worker must send the ${name} header it documents`);
+    }
+  });
+
+  it('the signing algorithm the worker uses backs the documented contract', () => {
+    assert.ok(/createHmac\(\s*'sha256'/.test(deliverSrc), 'worker must sign with HMAC-SHA256');
+    assert.ok(/`sha256=\$\{signature\}`/.test(deliverSrc), 'worker must prefix the signature with sha256=');
+    assert.ok(/\.digest\('hex'\)/.test(deliverSrc), 'worker must hex-encode the signature');
+  });
+
+  it('the worker defaults the event header to the documented event name', () => {
+    assert.ok(
+      deliverSrc.includes(`?? '${WEBHOOK_EVENT}'`),
+      `worker must default the event header to '${WEBHOOK_EVENT}'`,
+    );
+  });
+
+  it('the committed bundle is up to date with the injector (idempotent)', () => {
+    const result = injectYamlWebhooks(bundleRaw);
+    assert.equal(result.changed, false, 'run `npm run gen:openapi:webhooks` — committed bundle is stale');
+  });
+
+  it('webhooks live at the top level, not under paths (no phantom REST op)', () => {
+    assert.ok(!('/webhooks/chokepoint.disruption' in (bundle.paths ?? {})));
+    assert.equal(Object.keys(bundle.webhooks).length, 1);
+  });
+});


### PR DESCRIPTION
## Summary

The ShippingV2 delivery worker (`server/worldmonitor/shipping/v2/deliver-webhook.ts`) already signs **every** webhook — HMAC-SHA256 over the raw body, keyed by the subscription `secret`, sent as a branded `X-WM-Signature: sha256=<hex>` header — but the published `/openapi.json` only referenced the HMAC *secret* without ever naming the header. The orank Access scanner flagged exactly this (lost 1/2 pts):

> **Webhook signature verification** — Webhook signing referenced at `/openapi.json` but no branded signature header identified.

This closes the gap by making the signature contract **discoverable** and documenting how to verify it:

- **New post-generation injector** `scripts/openapi-inject-webhooks.mjs` (wired into `make generate` + `npm run gen:openapi:webhooks`) stamps an OpenAPI 3.1 top-level `webhooks` object onto the bundle for the `chokepoint.disruption` delivery: the three branded headers (`X-WM-Signature` with a `^sha256=[0-9a-f]{64}$` pattern, `X-WM-Event`, `X-WM-Delivery-Id`), the full payload schema, and the HMAC **verification recipe**. It flows to `public/openapi.json` (the artifact orank fetches) at build.
- **Human docs** (`docs/api-shipping-v2.mdx`): added a "Verifying deliveries" section with a Node `createHmac`/`timingSafeEqual` example, and fixed a delivery-id format drift (`<ulid>` → `whd_`+32 hex, matching `makeDeliveryId`).
- **Contract test** (`tests/openapi-webhooks-contract.test.mjs`, 10 assertions) ties the documented headers/payload/algorithm back to `deliver-webhook.ts` so the published spec can't drift from what the worker actually sends.

**Design notes:** bundle-only (per-service specs are Mintlify-rendered and don't surface top-level `webhooks`) · inline payload schema (zero touch to `components:`, no schema-count drift) · `security: []` (outbound — the consumer receives it, authenticated by the signature, not an API key, overriding the bundle's root API-key security) · injector is pure-node, idempotent, and order-independent (inserts before `components:`).

**Note:** effect is live only after the next prod build regenerates `public/openapi.json` — **rescan orank after deploy**. (`deliverShippingV2Webhook` is implemented + SSRF-hardened but not yet wired to a live trigger; the signature *contract* is real regardless.)

## Test plan

- [x] `npm run typecheck` + `typecheck:api` — pass (0)
- [x] Biome lint (new files clean) + `lint:md` (0 errors) + `version:check` — pass
- [x] **`test:data` full suite** (split for worktree) — **12,766 pass / 0 fail**
- [x] Edge-function bundle (19 fns) + `edge-functions.test.mjs` (208) — pass
- [x] New `openapi-webhooks-contract.test.mjs` — 10/10 (doc↔code parity)
- [x] Pre-push ran a full `make generate` (all injectors incl. this one) → **zero freshness drift**
- [x] `docs-stats --check` + sebuf API-contract enforcer — clean

https://claude.ai/code/session_01GVDoj1bPoR7wpzmDDDohAs