### PR TITLE
fix(api): unshadow dynamic [rpc].ts gateways via filesystem catch-all (#4724)

### DIFF
--- a/api/[...notfound].ts
+++ b/api/[...notfound].ts
@@ -1,0 +1,20 @@
+// Filesystem catch-all for otherwise-unmatched `/api/*` paths.
+//
+// Serves the structured JSON 404 from `./not-found`. As a root-level catch-all
+// (`[...slug]`) this has the LOWEST dynamic-route precedence, so concrete
+// functions (`api/health.ts`) and nested dynamic gateways
+// (`api/<service>/v1/[rpc].ts`, `api/v2/shipping/[rpc].ts`) always resolve
+// FIRST — only a path with no more-specific match falls through to here.
+//
+// It replaces the `{ "source": "/api/:path*", "destination": "/api/not-found" }`
+// rewrite added in #4698. That was an afterFiles rewrite, which Vercel applies
+// BEFORE resolving dynamic filesystem routes: concrete functions survived but
+// every dynamic `[rpc].ts` gateway was shadowed → HTTP 404 for the entire
+// versioned REST surface (#4724). A filesystem catch-all runs AFTER all
+// more-specific routes, fixing the shadow while preserving the JSON 404 body.
+
+import handler from './not-found';
+
+export const config = { runtime: 'edge' };
+
+export default handler;

--- a/api/api-route-exceptions.json
+++ b/api/api-route-exceptions.json
@@ -344,7 +344,14 @@
     {
       "path": "api/not-found.ts",
       "category": "ops-admin",
-      "reason": "Structured JSON 404 responder for unmatched /api/* paths (via a vercel.json rewrite). Fixed-shape error envelope for agents/scanners in place of Vercel's native text/plain NOT_FOUND; not a product API.",
+      "reason": "Structured JSON 404 responder for unmatched /api/* paths (mounted by api/[...notfound].ts). Fixed-shape error envelope for agents/scanners in place of Vercel's native text/plain NOT_FOUND; not a product API.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
+      "path": "api/[...notfound].ts",
+      "category": "ops-admin",
+      "reason": "Filesystem catch-all mount for api/not-found.ts. Exists solely to preserve the structured JSON 404 for genuinely unmatched /api/* paths without using an afterFiles rewrite that can shadow dynamic sebuf gateways; not a product API.",
       "owner": "@SebastienMelki",
       "removal_issue": null
     },

--- a/api/not-found.ts
+++ b/api/not-found.ts
@@ -2,14 +2,16 @@
 //
 // Vercel serves its native `text/plain` "NOT_FOUND" body for any `/api/...`
 // path that doesn't resolve to a function. Agents (and agent-readiness
-// scanners) can't parse an HTML/plain error page, so a `vercel.json` rewrite
-// funnels every otherwise-unmatched `/api/*` request here to return a
+// scanners) can't parse an HTML/plain error page, so this handler returns a
 // machine-readable JSON error with a code, a message, and a resolution hint.
 //
-// Filesystem precedence guarantees this only ever runs for paths with NO real
-// function: Vercel matches concrete + dynamic function routes before applying
-// `rewrites` (verified against production), so a live endpoint is never
-// shadowed by this catch-all.
+// It is mounted as the filesystem catch-all `api/[...notfound].ts`, which
+// re-exports this handler. A root-level catch-all (`[...slug]`) has the LOWEST
+// dynamic-route precedence, so concrete functions AND nested dynamic gateways
+// (`api/<service>/v1/[rpc].ts`) resolve first — a live endpoint is never
+// shadowed. It was previously wired via a `/api/:path*` rewrite, an afterFiles
+// rewrite that Vercel applied BEFORE dynamic routes, which shadowed every
+// `[rpc].ts` gateway and 404'd the whole versioned REST surface (#4724).
 
 export const config = { runtime: 'edge' };
 

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -12,7 +12,7 @@
   "variantCount": 6,
   "componentTopLevelTsFiles": 159,
   "serviceTopLevelEntries": 193,
-  "apiEndpointEntries": 82,
+  "apiEndpointEntries": 83,
   "panelClasses": 104,
   "protoFiles": 276,
   "protoServices": 34,

--- a/tests/api-notfound-catchall.test.mjs
+++ b/tests/api-notfound-catchall.test.mjs
@@ -5,6 +5,11 @@ import { readFileSync } from 'node:fs';
 import catchAll, { config } from '../api/[...notfound].ts';
 import notFound from '../api/not-found.ts';
 
+function isShadowingApiNotFoundRewrite(rewrite) {
+  if (rewrite?.destination !== '/api/not-found') return false;
+  return /^\/api\/(?::[^/]*\*|\(\.\*\))$/.test(rewrite.source ?? '');
+}
+
 // Regression guard for #4724: the `/api/:path*` -> /api/not-found rewrite (#4698)
 // was an afterFiles rewrite that shadowed every dynamic `api/<svc>/v1/[rpc].ts`
 // gateway, 404ing the entire versioned REST surface in production. The fix moves
@@ -27,13 +32,22 @@ describe('api/[...notfound].ts — filesystem catch-all replaces the shadowing r
     assert.ok(body.error.message.includes('/api/seismology/v1/list-earthquakes'), 'message must echo the requested path');
   });
 
-  it('vercel.json no longer contains the /api/:path* rewrite that shadowed dynamic gateways', () => {
+  it('detects equivalent broad API rewrites that would shadow dynamic gateways', () => {
+    for (const source of ['/api/:path*', '/api/:slug*', '/api/(.*)']) {
+      assert.equal(isShadowingApiNotFoundRewrite({ source, destination: '/api/not-found' }), true, `${source} must be blocked`);
+    }
+
+    assert.equal(isShadowingApiNotFoundRewrite({ source: '/api/health', destination: '/api/not-found' }), false);
+    assert.equal(isShadowingApiNotFoundRewrite({ source: '/mcp', destination: '/api/mcp' }), false);
+  });
+
+  it('vercel.json no longer contains a broad API rewrite that shadows dynamic gateways', () => {
     const vercel = JSON.parse(readFileSync(new URL('../vercel.json', import.meta.url), 'utf8'));
-    const shadow = (vercel.rewrites ?? []).find((r) => r.source === '/api/:path*');
+    const shadow = (vercel.rewrites ?? []).find(isShadowingApiNotFoundRewrite);
     assert.equal(
       shadow,
       undefined,
-      'do not reintroduce the /api/:path* -> /api/not-found rewrite; it shadows dynamic [rpc].ts gateways (#4724). Use the api/[...notfound].ts filesystem catch-all instead.',
+      'do not reintroduce a broad /api/* -> /api/not-found rewrite; it shadows dynamic [rpc].ts gateways (#4724). Use the api/[...notfound].ts filesystem catch-all instead.',
     );
   });
 });

--- a/tests/api-notfound-catchall.test.mjs
+++ b/tests/api-notfound-catchall.test.mjs
@@ -1,0 +1,39 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+
+import catchAll, { config } from '../api/[...notfound].ts';
+import notFound from '../api/not-found.ts';
+
+// Regression guard for #4724: the `/api/:path*` -> /api/not-found rewrite (#4698)
+// was an afterFiles rewrite that shadowed every dynamic `api/<svc>/v1/[rpc].ts`
+// gateway, 404ing the entire versioned REST surface in production. The fix moves
+// the JSON-404 handler to a filesystem catch-all (`api/[...notfound].ts`), which
+// has the lowest dynamic-route precedence and so cannot shadow real endpoints.
+describe('api/[...notfound].ts — filesystem catch-all replaces the shadowing rewrite (#4724)', () => {
+  it('delegates to the shared api/not-found.ts handler', () => {
+    assert.equal(catchAll, notFound, 'catch-all must re-export the shared not-found handler (single source of truth)');
+  });
+
+  it('runs on the edge runtime', () => {
+    assert.equal(config?.runtime, 'edge');
+  });
+
+  it('returns the structured JSON 404 envelope for an unmatched path', async () => {
+    const res = catchAll(new Request('https://worldmonitor.app/api/seismology/v1/list-earthquakes', { method: 'GET' }));
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.equal(body.error?.code, 'not_found');
+    assert.ok(body.error.message.includes('/api/seismology/v1/list-earthquakes'), 'message must echo the requested path');
+  });
+
+  it('vercel.json no longer contains the /api/:path* rewrite that shadowed dynamic gateways', () => {
+    const vercel = JSON.parse(readFileSync(new URL('../vercel.json', import.meta.url), 'utf8'));
+    const shadow = (vercel.rewrites ?? []).find((r) => r.source === '/api/:path*');
+    assert.equal(
+      shadow,
+      undefined,
+      'do not reintroduce the /api/:path* -> /api/not-found rewrite; it shadows dynamic [rpc].ts gateways (#4724). Use the api/[...notfound].ts filesystem catch-all instead.',
+    );
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -22,7 +22,6 @@
     { "source": "/.well-known/mcp", "destination": "/.well-known/mcp/server-card.json" },
     { "source": "/embed", "destination": "/embed.html" },
     { "source": "/dashboard", "destination": "/dashboard.html" },
-    { "source": "/api/:path*", "destination": "/api/not-found" },
     { "source": "/((?!api|mcp|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)", "destination": "/dashboard.html" }
   ],
   "headers": [


### PR DESCRIPTION
## Problem — production dashboard data panels are 404ing (P0)

Every dynamic versioned REST route (`/api/<service>/v1/<op>`, plus `api/v2/shipping/*`) returns **HTTP 404** in production. This is **#4724**, and DebugBear field data shows it is now breaking the **production consumer dashboard's own data fetches**, not just external/API-doc consumers.

**Field evidence (DebugBear, worldmonitor.app dashboard):**
- `console.errors` was **0** on every snapshot 06-30 → 07-03, then spiked to **48** on the `2026-07-04 07:05Z` snapshot.
- **34** of those 48 are `404`s on the dashboard's own `api.worldmonitor.app/api/<svc>/v1/<rpc>` calls: `intelligence` (get-risk-scores, get-pizzint-status, get-gdelt-topic-timeline, classify-event), `news` (list-feed-digest, summarize-article, summarize-article-cache), `infrastructure` (list-temporal-anomalies), `conflict` (list-iran-events), `seismology` (list-earthquakes), `wildfire` (list-fire-detections), `natural` (list-natural-events).
- Panels dead: earthquakes, wildfires, natural disasters, Iran conflict feed, risk scores, PIZZINT, GDELT timeline, news digest + all article summaries.

**Timeline is exact:** last clean snapshot `07-03 07:04Z` (0 errors) → **#4698 merged `07-04 04:34Z`** (added the `/api/:path*` rewrite) → regression snapshot `07-04 07:05Z` (48 errors), ~2.5h later.

## Root cause

`vercel.json`:
```json
{ "source": "/api/:path*", "destination": "/api/not-found" }
```
This is an **afterFiles rewrite**, which Vercel applies **before** resolving dynamic filesystem routes. Concrete function files (`api/health.ts`) resolve first and survive; **dynamic `api/<svc>/v1/[rpc].ts` gateways resolve *after* the rewrite**, so the catch-all swallows all of them → `api/not-found.ts` 404. Confirmed live: the 404 body is that handler's JSON (`"No API endpoint matches …"`). The header comment in `api/not-found.ts` claimed this "never shadows a live endpoint (verified against production)" — that verification only exercised concrete routes.

## Fix

- **Remove** the `/api/:path*` rewrite.
- **Add `api/[...notfound].ts`** — a filesystem catch-all that re-exports the same JSON-404 handler. A root-level catch-all (`[...slug]`) has the **lowest** dynamic-route precedence, so concrete functions and every nested `[rpc].ts` gateway resolve first; only genuinely-unmatched `/api/*` paths fall through. Preserves the machine-readable JSON 404 that #4698 wanted.
- Correct the misleading comment in `api/not-found.ts`.
- Add a regression test (`tests/api-notfound-catchall.test.mjs`) that verifies the catch-all delegates to the shared handler + returns the JSON envelope, and **guards against reintroducing the rewrite**.

**Why not #4724's proposed regex** (`{ "source": "/api/((?!.*/v1/).*)" }`)? It excludes only `/v1/` paths, so it would **still shadow `api/v2/shipping/[rpc].ts`** (no `/v1/` segment — confirmed 404 in prod today). The filesystem catch-all is path-shape-agnostic and future-proof.

## Verification

- `tests/api-not-found.test.mjs` + `tests/api-notfound-catchall.test.mjs` — **8/8 pass**.
- `tests/deploy-config.test.mjs` (vercel.json guardrail) — **94/94 pass**.

⚠️ **Routing precedence needs Vercel preview/deploy verification before merge** (the bug was itself a wrong Vercel-routing assumption, so verify empirically). On the preview deployment, confirm:
```
# real dynamic gateway — expect 200/401 (NOT 404)
curl -s -o /dev/null -w '%{http_code}\n' -A 'Mozilla/5.0 (wm-verify)' https://<preview>/api/seismology/v1/list-earthquakes
# non-v1 gateway that #4724's regex would miss — expect 200/401 (NOT 404)
curl -s -o /dev/null -w '%{http_code}\n' -A 'Mozilla/5.0 (wm-verify)' https://<preview>/api/v2/shipping/list-vessels
# genuinely-unknown path — expect the JSON 404 body
curl -s -A 'Mozilla/5.0 (wm-verify)' https://<preview>/api/does-not-exist
```

Fixes #4724

https://claude.ai/code/session_01GkijjkTczivJxdRx111jPM