### PR TITLE
docs(api): fix shipping webhook registration docs

### DIFF
--- a/docs/api-shipping-v2.mdx
+++ b/docs/api-shipping-v2.mdx
@@ -76,7 +76,7 @@ GET /api/v2/shipping/route-intelligence?fromIso2=AE&toIso2=NL&cargoType=tanker&h
 
 ### `POST /api/v2/shipping/webhooks`
 
-Registers a webhook for chokepoint disruption alerts. Returns `201 Created`.
+Registers a webhook for chokepoint disruption alerts. Returns `200 OK`.
 
 **Request**:
 ```json
@@ -89,9 +89,9 @@ Registers a webhook for chokepoint disruption alerts. Returns `201 Created`.
 
 - `callbackUrl` — required, HTTPS only, must not resolve to a private/loopback address (SSRF guard at registration).
 - `chokepointIds` — optional. Omitting or passing an empty array subscribes to **all** registered chokepoints. Unknown IDs return `400`.
-- `alertThreshold` — numeric 0-100 (default `50`). Values outside that range return `400 "alertThreshold must be a number between 0 and 100"`.
+- `alertThreshold` — numeric 0-100 (default `50`). Values outside that range return a `400` validation response with description `alertThreshold must be between 0 and 100`.
 
-**Response (`201`)**:
+**Response (`200`)**:
 ```json
 {
   "subscriberId": "wh_a1b2c3d4e5f6a7b8c9d0e1f2",


### PR DESCRIPTION
## Summary
The curated shipping v2 docs now match the register-webhook contract: successful webhook registration is documented as `200 OK`, and `alertThreshold` validation now names the real `violations[].description` returned by the handler.

No generated API spec changes are needed because the generated server and bundled OpenAPI spec already document the successful response as `200`.

## Validation
- `npm run lint` (exits 0; reports existing warnings outside this docs change, then safe HTML guard passes)
- `./node_modules/.bin/markdownlint-cli2 docs/api-shipping-v2.mdx`
- `npm run docs:check`
- `git diff --check`
- Source parity checked against `src/generated/server/worldmonitor/shipping/v2/service_server.ts`, `server/worldmonitor/shipping/v2/register-webhook.ts`, and `docs/api/worldmonitor.openapi.yaml`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required; this is a curated docs-only correction with no runtime behavior change. After deploy, verify the published `/api/v2/shipping/webhooks` docs show `200 OK` and `alertThreshold must be between 0 and 100`; a stale `201 Created` or fabricated validation string would indicate the docs deploy did not pick up this change.

## Related
Fixes #4733
Related: #4599

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
