### PR TITLE
fix(seed): seed-military-maritime warm-ping exits 0 (best-effort)

### DIFF
--- a/scripts/seed-military-maritime-news.mjs
+++ b/scripts/seed-military-maritime-news.mjs
@@ -81,7 +81,17 @@ async function main() {
   const duration = Date.now() - start;
 
   console.log(`\n=== Done: ${ok}/${total} warm-pings OK (${duration}ms) ===`);
-  process.exit(ok > 0 ? 0 : 1);
+  if (ok === 0) {
+    // Distinct, grep-able marker so persistent auth/gateway breakage stays
+    // visible in Railway logs even though we exit 0. Set up a Railway log
+    // alert on this string instead of relying on container exit codes.
+    console.log('WARN: all warm-pings failed — cache is cold (check WORLDMONITOR_RELAY_KEY and gateway auth)');
+  }
+  // Best-effort cache warmer: a missed warm-ping is not a failure worth paging on.
+  // Upstream timeouts and transient 5xx happen routinely; exiting non-zero turned
+  // every blip into a Railway "Deploy crashed" email. Logs above still surface
+  // partial failures for investigation.
+  process.exit(0);
 }
 
 main();

--- a/tests/seed-warm-ping-origin.test.mjs
+++ b/tests/seed-warm-ping-origin.test.mjs
@@ -31,17 +31,24 @@ describe('warm-ping seed scripts', () => {
   for (const script of ['scripts/seed-infra.mjs', 'scripts/seed-military-maritime-news.mjs']) {
     it(`${script} exits 0 (best-effort) and never hard-crashes on total warm-ping failure`, () => {
       const src = readScript(script);
-      assert.match(src, /process\.exit\(0\)/, 'must end with a best-effort exit(0)');
       assert.match(
         src,
         /WARN: all warm-pings failed/,
         'must emit a grep-able WARN marker so persistent breakage is caught via log alert, not exit code',
       );
-      assert.doesNotMatch(
-        src,
-        /exit\(\s*ok\s*>\s*0\s*\?\s*0\s*:\s*1\s*\)/,
-        'must not hard-crash (exit 1) when all warm-pings fail',
-      );
+      // Durable invariant: the script must call process.exit, and EVERY call
+      // must be exit(0). Extracting the literal arg catches exit(1), the old
+      // `exit(ok > 0 ? 0 : 1)` ternary, exit(143), etc. — not just one spelling —
+      // so no refactor can quietly re-introduce a hard crash on total failure.
+      const exitArgs = [...src.matchAll(/process\.exit\(([^)]*)\)/g)].map((m) => m[1].trim());
+      assert.ok(exitArgs.length > 0, 'must call process.exit');
+      for (const arg of exitArgs) {
+        assert.equal(
+          arg,
+          '0',
+          `warm-ping seeders must never exit non-zero (best-effort cache warmer — a missed ping loses no data); found process.exit(${arg})`,
+        );
+      }
     });
   }
 });

--- a/tests/seed-warm-ping-origin.test.mjs
+++ b/tests/seed-warm-ping-origin.test.mjs
@@ -23,4 +23,25 @@ describe('warm-ping seed scripts', () => {
     assert.match(src, /Origin:\s*'https:\/\/worldmonitor\.app'/);
     assert.match(src, /method:\s*'POST'/);
   });
+
+  // A warm-ping seeder is a best-effort cache warmer: it owns no Redis keys to
+  // extend, so a missed ping loses no data and must NOT hard-crash Railway.
+  // The fleet convention (see seed-infra.mjs) is exit(0) + a grep-able WARN
+  // marker for log-alerting, NOT a non-zero exit on total failure.
+  for (const script of ['scripts/seed-infra.mjs', 'scripts/seed-military-maritime-news.mjs']) {
+    it(`${script} exits 0 (best-effort) and never hard-crashes on total warm-ping failure`, () => {
+      const src = readScript(script);
+      assert.match(src, /process\.exit\(0\)/, 'must end with a best-effort exit(0)');
+      assert.match(
+        src,
+        /WARN: all warm-pings failed/,
+        'must emit a grep-able WARN marker so persistent breakage is caught via log alert, not exit code',
+      );
+      assert.doesNotMatch(
+        src,
+        /exit\(\s*ok\s*>\s*0\s*\?\s*0\s*:\s*1\s*\)/,
+        'must not hard-crash (exit 1) when all warm-pings fail',
+      );
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- `seed-military-maritime` was the **only** warm-ping seeder that hard-crashed Railway: `process.exit(ok > 0 ? 0 : 1)` turned any transient double-outage of its two Vercel RPC endpoints (`/api/military/v1/get-usni-fleet-report`, `/api/maritime/v1/list-navigational-warnings`) into a red *"Deploy crashed"* badge.
- A warm-ping seeder is a **best-effort cache warmer** — it owns no Redis keys, so a missed ping loses no data. A non-zero exit is the wrong signal.
- Its own header comment says *"see seed-infra.mjs for the same pattern"*, but the exit logic had **drifted** from that sibling. This realigns it: emit a grep-able `WARN: all warm-pings failed` marker (wire Railway log alerts to that string) and `exit(0)`.
- Added a source-text invariant test covering **both** warm-ping seeders (`seed-infra`, `seed-military-maritime`) so neither can regress back to a hard crash.

### Not changed (deliberate)
Publish/bundle seeders (e.g. `seed-bundle-market-backup`) that fail gracefully with `exit 75` are left as-is — they extend the last-good TTL (no data lost) and the red-but-graceful badge is an intentional "data going stale, investigate if sustained" signal.

## Test plan
- [x] New `tests/seed-warm-ping-origin.test.mjs` invariant fails on old code, passes after fix (4/4)
- [x] `test:data` full suite green except 2 pre-existing `dashboard-critical-css` built-output artifacts (unrelated; need a prior vite build)
- [x] typecheck, typecheck:api, biome lint, edge bundle (19), edge-functions test (209), markdown lint, version:check — all PASS
- [ ] Post-deploy: on the next transient double-404, Railway shows the container **green** with a `WARN: all warm-pings failed` log line instead of a crash

https://claude.ai/code/session_01GivdTptXnLqe2oRW3c2Zzv