### PR TITLE
fix(prefs): preserve monitor edits across reload

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -264,6 +264,8 @@ export class App {
 
     if (keySet.has(STORAGE_KEYS.monitors)) {
       this.state.monitors = loadFromStorage<Monitor[]>(STORAGE_KEYS.monitors, []);
+      const monitorPanel = this.state.panels['monitors'] as { setMonitors?: (monitors: Monitor[]) => void } | undefined;
+      monitorPanel?.setMonitors?.(this.state.monitors);
       this.dataLoader.updateMonitorResults();
     }
   }

--- a/src/App.ts
+++ b/src/App.ts
@@ -41,6 +41,7 @@ import { BreakingNewsBanner } from '@/components/BreakingNewsBanner';
 import { initBreakingNewsAlerts, destroyBreakingNewsAlerts } from '@/services/breaking-news-alerts';
 import { markLcpDebug } from '@/utils/lcp-debug';
 import type { ServiceStatusPanel } from '@/components/ServiceStatusPanel';
+import type { MonitorPanel } from '@/components/MonitorPanel';
 import type { StablecoinPanel } from '@/components/StablecoinPanel';
 import type { EnergyCrisisPanel } from '@/components/EnergyCrisisPanel';
 import type { ETFFlowsPanel } from '@/components/ETFFlowsPanel';
@@ -264,8 +265,8 @@ export class App {
 
     if (keySet.has(STORAGE_KEYS.monitors)) {
       this.state.monitors = loadFromStorage<Monitor[]>(STORAGE_KEYS.monitors, []);
-      const monitorPanel = this.state.panels['monitors'] as { setMonitors?: (monitors: Monitor[]) => void } | undefined;
-      monitorPanel?.setMonitors?.(this.state.monitors);
+      const monitorPanel = this.state.panels['monitors'] as MonitorPanel | undefined;
+      monitorPanel?.setMonitors(this.state.monitors);
       this.dataLoader.updateMonitorResults();
     }
   }

--- a/src/utils/cloud-prefs-migrations.ts
+++ b/src/utils/cloud-prefs-migrations.ts
@@ -102,6 +102,35 @@ export function settledDirtyKeys(
   return settled;
 }
 
+export function parsePersistedDirtyKeys(
+  raw: string | null,
+  allowedKeys: Iterable<string>,
+  expectedUserId: string,
+): string[] {
+  if (!raw) return [];
+
+  let parsed: unknown;
+  try { parsed = JSON.parse(raw); } catch { return []; }
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    (parsed as { userId?: unknown }).userId !== expectedUserId ||
+    !Array.isArray((parsed as { keys?: unknown }).keys)
+  ) {
+    return [];
+  }
+
+  const allowed = new Set(allowedKeys);
+  const seen = new Set<string>();
+  const keys: string[] = [];
+  for (const key of (parsed as { keys: unknown[] }).keys) {
+    if (typeof key !== 'string' || !allowed.has(key) || seen.has(key)) continue;
+    seen.add(key);
+    keys.push(key);
+  }
+  return keys;
+}
+
 /**
  * Schema-2 migrations map. Used both inline by cloud-prefs-sync.ts (against
  * the variant-aware FEEDS) and by tests (against fixture FEEDS).

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -20,6 +20,7 @@ import {
   applyMigrationChain,
   buildMigrations,
   mergeCloudWithLocalDirty,
+  parsePersistedDirtyKeys,
   settledDirtyKeys,
 } from './cloud-prefs-migrations';
 import {
@@ -45,6 +46,7 @@ const KEY_SYNC_VERSION = 'wm-cloud-sync-version';
 const KEY_LAST_SYNC_AT = 'wm-last-sync-at';
 const KEY_SYNC_STATE = 'wm-cloud-sync-state';
 const KEY_LAST_SIGNED_IN_AS = 'wm-last-signed-in-as';
+const KEY_DIRTY_KEYS = 'wm-cloud-prefs-dirty-keys';
 // Tracks the schema version of the LOCAL blob (i.e. what's in localStorage
 // right now). Distinct from the cloud row's schemaVersion. Required because
 // uploads can post local data without first fetching cloud (uploadNow,
@@ -92,6 +94,41 @@ let _cachedToken: string | null = null; // synchronous token cache for flush()
 // install() setItem/removeItem patch records them; a clean upload clears the
 // SETTLED ones. See resolveConflictWithMerge + mergeCloudWithLocalDirty.
 const _dirtyKeys = new Set<CloudSyncKey>();
+let _dirtyKeysUserId: string | null = null;
+
+function persistDirtyKeys(): void {
+  try {
+    if (_dirtyKeys.size === 0 || !_dirtyKeysUserId) {
+      Storage.prototype.removeItem.call(localStorage, KEY_DIRTY_KEYS);
+      return;
+    }
+    Storage.prototype.setItem.call(localStorage, KEY_DIRTY_KEYS, JSON.stringify({
+      userId: _dirtyKeysUserId,
+      keys: [..._dirtyKeys],
+    }));
+  } catch {
+    // localStorage unavailable: keep the in-memory guard for this page view.
+  }
+}
+
+function hydrateDirtyKeysFromStorage(userId: string): void {
+  try {
+    _dirtyKeys.clear();
+    _dirtyKeysUserId = userId;
+    const raw = localStorage.getItem(KEY_DIRTY_KEYS);
+    for (const key of parsePersistedDirtyKeys(raw, CLOUD_SYNC_KEYS, userId)) {
+      _dirtyKeys.add(key as CloudSyncKey);
+    }
+    if (raw !== null && _dirtyKeys.size === 0) persistDirtyKeys();
+  } catch {
+    // localStorage unavailable: the in-memory set remains the best effort.
+  }
+}
+
+function markDirtyKey(key: CloudSyncKey): void {
+  _dirtyKeys.add(key);
+  persistDirtyKeys();
+}
 
 /**
  * Clear dirty keys that a just-succeeded upload actually durably synced —
@@ -107,9 +144,11 @@ const _dirtyKeys = new Set<CloudSyncKey>();
  * current local value.
  */
 function clearSettledDirtyKeys(postedBlob: Record<string, string>): void {
+  let changed = false;
   for (const key of settledDirtyKeys(postedBlob, buildCloudBlob(), _dirtyKeys)) {
-    _dirtyKeys.delete(key as CloudSyncKey);
+    changed = _dirtyKeys.delete(key as CloudSyncKey) || changed;
   }
+  if (changed) persistDirtyKeys();
 }
 
 // ── 503 retry tracking ───────────────────────────────────────────────────────
@@ -401,6 +440,7 @@ export async function onSignIn(userId: string, variant: string): Promise<void> {
   clearRetryTimer();
   _authGeneration += 1;
   const myGeneration = _authGeneration;
+  hydrateDirtyKeysFromStorage(userId);
 
   _currentVariant = variant;
   setState('syncing');
@@ -525,6 +565,8 @@ export function onSignOut(): void {
   // Dirty-key tracking is per-user session state — drop it so edits made by
   // the next signed-in user don't merge against the prior user's pending set.
   _dirtyKeys.clear();
+  _dirtyKeysUserId = null;
+  persistDirtyKeys();
 
   // Preserve prefs; only clear sync metadata
   localStorage.removeItem(KEY_SYNC_VERSION);
@@ -638,7 +680,7 @@ export function install(variant: string): void {
   Storage.prototype.setItem = function setItem(key: string, value: string) {
     originalSetItem.call(this, key, value);
     if (this === localStorage && !_suppressPatch && CLOUD_SYNC_KEYS.includes(key as CloudSyncKey)) {
-      _dirtyKeys.add(key as CloudSyncKey);
+      markDirtyKey(key as CloudSyncKey);
       schedulePrefUpload(_currentVariant);
     }
   };
@@ -647,7 +689,7 @@ export function install(variant: string): void {
   Storage.prototype.removeItem = function removeItem(key: string) {
     originalRemoveItem.call(this, key);
     if (this === localStorage && !_suppressPatch && CLOUD_SYNC_KEYS.includes(key as CloudSyncKey)) {
-      _dirtyKeys.add(key as CloudSyncKey);
+      markDirtyKey(key as CloudSyncKey);
       schedulePrefUpload(_currentVariant);
     }
   };

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -98,10 +98,11 @@ let _dirtyKeysUserId: string | null = null;
 
 function persistDirtyKeys(): void {
   try {
-    if (_dirtyKeys.size === 0 || !_dirtyKeysUserId) {
+    if (_dirtyKeys.size === 0) {
       Storage.prototype.removeItem.call(localStorage, KEY_DIRTY_KEYS);
       return;
     }
+    if (!_dirtyKeysUserId) return;
     Storage.prototype.setItem.call(localStorage, KEY_DIRTY_KEYS, JSON.stringify({
       userId: _dirtyKeysUserId,
       keys: [..._dirtyKeys],
@@ -565,8 +566,8 @@ export function onSignOut(): void {
   // Dirty-key tracking is per-user session state — drop it so edits made by
   // the next signed-in user don't merge against the prior user's pending set.
   _dirtyKeys.clear();
-  _dirtyKeysUserId = null;
   persistDirtyKeys();
+  _dirtyKeysUserId = null;
 
   // Preserve prefs; only clear sync metadata
   localStorage.removeItem(KEY_SYNC_VERSION);

--- a/src/utils/cloud-prefs-sync.ts
+++ b/src/utils/cloud-prefs-sync.ts
@@ -408,7 +408,7 @@ async function postCloudPrefs(
  * the post body — silently discarding the edit the user had just made (e.g. a
  * watchlist typed seconds earlier, then lost on the debounced upload's 409).
  */
-async function resolveConflictWithMerge(token: string, variant: string): Promise<boolean> {
+async function resolveConflictWithMerge(token: string, variant: string, callerGeneration: number): Promise<boolean> {
   const fresh = await fetchCloudPrefs(token, variant);
   if (!fresh) {
     setState('error');
@@ -424,6 +424,11 @@ async function resolveConflictWithMerge(token: string, variant: string): Promise
     setState('conflict');
     return false;
   }
+  // Generation guard (same vector as uploadNow's success branch): if the
+  // signed-in user switched during the awaits above, do not clear/persist
+  // settled dirty keys — _dirtyKeys now belongs to another user and the
+  // write would durably corrupt their persisted dirty-key entry.
+  if (_authGeneration !== callerGeneration) return false;
   setSyncVersion(retry.syncVersion);
   clearSettledDirtyKeys(merged);
   Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));
@@ -497,7 +502,7 @@ export async function onSignIn(userId: string, variant: string): Promise<void> {
         // Merge instead of clobber — see resolveConflictWithMerge. The old
         // path here applied the cloud blob over localStorage and stopped,
         // discarding the local edits this branch was trying to upload.
-        await resolveConflictWithMerge(token, variant);
+        await resolveConflictWithMerge(token, variant, myGeneration);
       } else {
         setSyncVersion(result.syncVersion);
         clearSettledDirtyKeys(blob);
@@ -601,8 +606,15 @@ async function uploadNow(variant: string): Promise<void> {
       // of overwriting localStorage with cloud (the old path did
       // applyCloudBlob(cloud) then re-posted buildCloudBlob() — which by then
       // WAS the cloud blob, so the user's just-made edit was silently lost).
-      await resolveConflictWithMerge(token, variant);
+      await resolveConflictWithMerge(token, variant, myGeneration);
     } else {
+      // Generation guard: a sign-out / account-switch during the awaits above
+      // repoints _dirtyKeys and _dirtyKeysUserId to a different user. Clearing
+      // (and now persisting) settled keys here would durably corrupt that
+      // user's dirty-key entry using this upload's stale postedBlob. Match the
+      // 503 retry branch and the flush-success path — bail if the generation
+      // moved.
+      if (_authGeneration !== myGeneration) return;
       setSyncVersion(result.syncVersion);
       clearSettledDirtyKeys(postedBlob);
       Storage.prototype.setItem.call(localStorage, KEY_LAST_SYNC_AT, String(Date.now()));

--- a/tests/cloud-prefs-conflict-merge.test.mts
+++ b/tests/cloud-prefs-conflict-merge.test.mts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 
-import { mergeCloudWithLocalDirty, settledDirtyKeys } from '../src/utils/cloud-prefs-migrations.ts';
+import {
+  mergeCloudWithLocalDirty,
+  parsePersistedDirtyKeys,
+  settledDirtyKeys,
+} from '../src/utils/cloud-prefs-migrations.ts';
 
 describe('mergeCloudWithLocalDirty', () => {
   it('with no dirty keys, returns the cloud blob verbatim (string values only)', () => {
@@ -57,6 +61,17 @@ describe('mergeCloudWithLocalDirty', () => {
     const local = { 'worldmonitor-theme': 'dark', 'wm-market-watchlist-v1': '["TSLA"]' };
     const merged = mergeCloudWithLocalDirty(cloud, local, ['wm-market-watchlist-v1']);
     assert.equal(merged['wm-market-watchlist-v1'], '["TSLA"]');
+  });
+
+  it('REGRESSION: a locally dirty My Monitors edit survives a reload before upload', () => {
+    const monitors = JSON.stringify([
+      { id: 'monitor-1', keywords: ['iran', 'hormuz'], color: '#44ff88' },
+    ]);
+    const cloud = { 'worldmonitor-theme': 'dark' };
+    const local = { 'worldmonitor-theme': 'dark', 'worldmonitor-monitors': monitors };
+    const merged = mergeCloudWithLocalDirty(cloud, local, ['worldmonitor-monitors']);
+    assert.equal(merged['worldmonitor-monitors'], monitors);
+    assert.equal(merged['worldmonitor-theme'], 'dark');
   });
 
   it('drops non-string cloud values', () => {
@@ -118,5 +133,40 @@ describe('settledDirtyKeys', () => {
     const posted = { 'worldmonitor-theme': 'dark' };
     const local = { 'worldmonitor-theme': 'light' };
     assert.deepEqual(settledDirtyKeys(posted, local, []), []);
+  });
+});
+
+describe('parsePersistedDirtyKeys', () => {
+  const allowed = ['worldmonitor-monitors', 'worldmonitor-theme', 'wm-market-watchlist-v1'];
+
+  it('restores a deduped allow-listed dirty key set after reload', () => {
+    const raw = JSON.stringify({
+      userId: 'user-a',
+      keys: [
+        'worldmonitor-monitors',
+        'not-a-sync-key',
+        'worldmonitor-monitors',
+        42,
+        'wm-market-watchlist-v1',
+      ],
+    });
+    assert.deepEqual(
+      parsePersistedDirtyKeys(raw, allowed, 'user-a'),
+      ['worldmonitor-monitors', 'wm-market-watchlist-v1'],
+    );
+  });
+
+  it('rejects persisted dirty keys owned by another signed-in user', () => {
+    const raw = JSON.stringify({
+      userId: 'user-a',
+      keys: ['worldmonitor-monitors'],
+    });
+    assert.deepEqual(parsePersistedDirtyKeys(raw, allowed, 'user-b'), []);
+  });
+
+  it('treats corrupt persisted dirty state as empty', () => {
+    assert.deepEqual(parsePersistedDirtyKeys('{bad json', allowed, 'user-a'), []);
+    assert.deepEqual(parsePersistedDirtyKeys(JSON.stringify({ key: 'worldmonitor-monitors' }), allowed, 'user-a'), []);
+    assert.deepEqual(parsePersistedDirtyKeys(JSON.stringify(['worldmonitor-monitors']), allowed, 'user-a'), []);
   });
 });

--- a/tests/cloud-prefs-panel-sync-guard.test.mjs
+++ b/tests/cloud-prefs-panel-sync-guard.test.mjs
@@ -67,6 +67,11 @@ describe('cloud prefs panel sync guardrails', () => {
     );
     assert.match(
       appSrc,
+      /monitorPanel\?\.setMonitors\?\.\(this\.state\.monitors\)/,
+      'App must update an already-mounted My Monitors panel when cloud prefs change monitors',
+    );
+    assert.match(
+      appSrc,
       /const panelOrderKey = this\.state\.PANEL_ORDER_KEY;/,
       'App must derive the panel order key from PANEL_ORDER_KEY',
     );
@@ -79,6 +84,41 @@ describe('cloud prefs panel sync guardrails', () => {
       appSrc,
       /keySet\.has\('panel-order'\)/,
       'App must not hard-code the panel-order key in the cloud apply path',
+    );
+  });
+
+  it('persists dirty cloud preference keys across reloads until upload settles', () => {
+    const cloudSyncSrc = readSrc('src/utils/cloud-prefs-sync.ts');
+
+    assert.match(
+      cloudSyncSrc,
+      /const KEY_DIRTY_KEYS = 'wm-cloud-prefs-dirty-keys'/,
+      'cloud prefs sync must store pending dirty-key metadata outside the uploaded blob',
+    );
+    assert.match(
+      cloudSyncSrc,
+      /hydrateDirtyKeysFromStorage\(userId\);/,
+      'cloud prefs sync must restore dirty keys for the signed-in user before resolving sign-in conflicts',
+    );
+    assert.match(
+      cloudSyncSrc,
+      /userId: _dirtyKeysUserId,[\s\S]*keys: \[\.\.\._dirtyKeys\]/,
+      'persisted dirty-key metadata must be scoped to the user that made the edit',
+    );
+    assert.doesNotMatch(
+      cloudSyncSrc,
+      /export function install[\s\S]*hydrateDirtyKeysFromStorage\(/,
+      'cloud prefs sync must not restore ownerless dirty keys at install time',
+    );
+    assert.match(
+      cloudSyncSrc,
+      /markDirtyKey\(key as CloudSyncKey\);/,
+      'local pref writes must persist their dirty-key marker before debounce upload',
+    );
+    assert.match(
+      cloudSyncSrc,
+      /if \(changed\) persistDirtyKeys\(\);/,
+      'successful uploads must clear only the dirty keys that actually settled',
     );
   });
 });

--- a/tests/cloud-prefs-panel-sync-guard.test.mjs
+++ b/tests/cloud-prefs-panel-sync-guard.test.mjs
@@ -120,5 +120,15 @@ describe('cloud prefs panel sync guardrails', () => {
       /if \(changed\) persistDirtyKeys\(\);/,
       'successful uploads must clear only the dirty keys that actually settled',
     );
+    assert.match(
+      cloudSyncSrc,
+      /if \(_dirtyKeys\.size === 0\) \{[\s\S]*Storage\.prototype\.removeItem\.call\(localStorage, KEY_DIRTY_KEYS\);[\s\S]*return;[\s\S]*\}[\s\S]*if \(!_dirtyKeysUserId\) return;/,
+      'ownerless dirty writes before sign-in must not delete the previous persisted dirty-key marker',
+    );
+    assert.match(
+      cloudSyncSrc,
+      /_dirtyKeys\.clear\(\);\s*persistDirtyKeys\(\);\s*_dirtyKeysUserId = null;/,
+      'sign-out must clear the persisted dirty-key marker before dropping the current user id',
+    );
   });
 });

--- a/tests/cloud-prefs-panel-sync-guard.test.mjs
+++ b/tests/cloud-prefs-panel-sync-guard.test.mjs
@@ -67,7 +67,7 @@ describe('cloud prefs panel sync guardrails', () => {
     );
     assert.match(
       appSrc,
-      /monitorPanel\?\.setMonitors\?\.\(this\.state\.monitors\)/,
+      /monitorPanel\?\.setMonitors\(this\.state\.monitors\)/,
       'App must update an already-mounted My Monitors panel when cloud prefs change monitors',
     );
     assert.match(
@@ -129,6 +129,21 @@ describe('cloud prefs panel sync guardrails', () => {
       cloudSyncSrc,
       /_dirtyKeys\.clear\(\);\s*persistDirtyKeys\(\);\s*_dirtyKeysUserId = null;/,
       'sign-out must clear the persisted dirty-key marker before dropping the current user id',
+    );
+  });
+
+  it('does not clear/persist settled dirty keys after a mid-upload account switch', () => {
+    const cloudSyncSrc = readSrc('src/utils/cloud-prefs-sync.ts');
+
+    assert.match(
+      cloudSyncSrc,
+      /if \(_authGeneration !== myGeneration\) return;[\s\S]*clearSettledDirtyKeys\(postedBlob\)/,
+      'uploadNow success branch must bail before clearing settled dirty keys when the auth generation advanced (sign-out / account switch mid-upload)',
+    );
+    assert.match(
+      cloudSyncSrc,
+      /if \(_authGeneration !== callerGeneration\) return false;[\s\S]*clearSettledDirtyKeys\(merged\)/,
+      'resolveConflictWithMerge must bail before clearing settled dirty keys when the caller auth generation advanced',
     );
   });
 });


### PR DESCRIPTION
## Summary

My Monitors entries now survive the reload window between a local edit and the debounced Convex preference upload. Signed-in users keep their local monitor edit during the next cloud merge, and the pending dirty marker is scoped to the Clerk user that made the edit so shared-browser account switches cannot leak one account's monitors into another account's preferences.

The running dashboard also refreshes an already-mounted My Monitors panel when cloud-applied preferences change `worldmonitor-monitors`, so the visible chips match the state that will be saved and restored.

## Validation

- `./node_modules/.bin/tsx --test tests/cloud-prefs-conflict-merge.test.mts`
- `node --test tests/cloud-prefs-panel-sync-guard.test.mjs`
- `npm run typecheck`
- `git diff --check`
- Pre-push hook passed: API typecheck, Convex typecheck, boundary lint, safe HTML, rate-limit and premium-fetch audits, changed tests, edge function tests, markdown/MDX skips, proto/pro-test skips, and version sync check.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5](https://img.shields.io/badge/GPT--5-000000)
