### PR TITLE
docs(cli): first-class CLI docs coverage + REST 401 auth hint

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -386,6 +386,7 @@ Runs before every `git push`:
 │   ├── _*.js               Shared helpers (CORS, rate-limit, API key, relay, Sentry, session)
 │   └── <domain>/           Domain endpoints (aviation/, climate/, conflict/, ...)
 ├── blog-site/              Static blog (built into public/blog/)
+├── cli/                    Official `worldmonitor` npm CLI (zero-dep ESM, MCP-first; published via cli-v* tag)
 ├── consumer-prices-core/   Consumer-price collection service (Playwright scrapers, per-country baskets; Railway/Docker)
 ├── convex/                 Convex backend (contact form, waitlist)
 ├── data/                   Static data (telegram channels, OREF threat translations, gamma irradiators)

--- a/README.md
+++ b/README.md
@@ -115,8 +115,9 @@ World Monitor is built for agents and scripts as well as browsers:
 - **CLI** — the official [`worldmonitor`](https://www.npmjs.com/package/worldmonitor) npm package (source in [`cli/`](cli/)):
 
   ```sh
-  npx worldmonitor tools          # list every MCP tool (no key needed)
-  npx worldmonitor risk IR --api-key wm_xxx
+  npx worldmonitor tools          # run ad-hoc — list every MCP tool (no key needed)
+  npm install -g worldmonitor     # or install the `worldmonitor` (alias `wm`) command
+  worldmonitor risk IR --api-key wm_xxx
   ```
 
 Agent discovery files: [`llms.txt`](https://worldmonitor.app/llms.txt) · [agent-skills manifest](https://worldmonitor.app/.well-known/agent-skills/index.json) · [api-catalog](https://worldmonitor.app/.well-known/api-catalog). Get an API key at [worldmonitor.app/pro](https://worldmonitor.app/pro).

--- a/cli/README.md
+++ b/cli/README.md
@@ -55,7 +55,7 @@ MCP and REST:
 - `tools` — list every MCP tool (public — no key needed)
 - `call <tool> [--arg val]` — call any MCP tool (`--args '<json>'` for typed args)
 - `prompts` / `resources` — list MCP prompt / resource templates
-- `health` — API status / health check
+- `health` — API status / health check (requires `--api-key`)
 - `get <path> [--param val]` — call a raw REST path (host-relative `/api/…`)
 - `list [service]` — list documented REST operations from the live OpenAPI spec
 

--- a/cli/src/core.mjs
+++ b/cli/src/core.mjs
@@ -25,6 +25,11 @@ export const API_KEY_HEADER = 'X-WorldMonitor-Key';
 // JSON-RPC error code the MCP server returns when a call needs authentication.
 export const MCP_AUTH_ERROR_CODE = -32001;
 
+// Shown on any auth failure (MCP -32001 or a REST 401) so the fix is always one
+// hint away, whichever surface the user hit.
+export const AUTH_HINT =
+  'Hint: this call needs a key — pass --api-key or set WORLDMONITOR_API_KEY (get one at https://worldmonitor.app/pro).';
+
 // Thrown for bad invocations so run.mjs can exit with a distinct status (2) and
 // print usage rather than a stack trace.
 export class UsageError extends Error {
@@ -360,7 +365,7 @@ MCP
   prompts | resources      List MCP prompt / resource templates
 
 REST
-  health                   API status / health check
+  health                   API status / health check (needs --api-key)
   get <path> [--param val] Call a raw REST path (host-relative /api/…)
   list [service]           List documented REST operations (from the live spec)
 

--- a/cli/src/run.mjs
+++ b/cli/src/run.mjs
@@ -3,6 +3,7 @@
 // tests, and returns a numeric exit code:
 //   0 success · 1 request/transport error · 2 usage error
 import {
+  API_KEY_HEADER,
   AUTH_HINT,
   DEFAULT_SPEC_URL,
   HELP,
@@ -75,12 +76,16 @@ export async function run(argv, io = {}) {
       throw new Error('global fetch is unavailable — Node 18+ is required');
     }
 
-    const plan = planRequest(parsed, resolveConfig(env));
+    const config = resolveConfig(env);
+    const plan = planRequest(parsed, config);
 
     if (plan.kind === 'list') {
       const specUrl = plan.specUrl || DEFAULT_SPEC_URL;
+      const headers = { 'user-agent': USER_AGENT, accept: 'application/json' };
+      const apiKey = options.apiKey || config.apiKey;
+      if (apiKey) headers[API_KEY_HEADER] = apiKey;
       const res = await withTimeout(options.timeout, (signal) =>
-        fetchImpl(specUrl, { headers: { 'user-agent': USER_AGENT, accept: 'application/json' }, signal }),
+        fetchImpl(specUrl, { headers, signal }),
       );
       const spec = parseBody(await res.text(), res.headers);
       if (!res.ok) {
@@ -98,7 +103,7 @@ export async function run(argv, io = {}) {
     const value = parseBody(await res.text(), res.headers);
 
     if (plan.kind === 'mcp') {
-      if (value && typeof value === 'object' && value.error) {
+      if (value && typeof value === 'object' && value.error && typeof value.error === 'object') {
         stderr(`${formatOutput(value.error, options)}\n`);
         if (value.error.code === MCP_AUTH_ERROR_CODE) {
           stderr(`${AUTH_HINT}\n`);
@@ -107,6 +112,7 @@ export async function run(argv, io = {}) {
       }
       if (!res.ok) {
         stderr(`${formatOutput(value, options)}\n`);
+        if (res.status === 401) stderr(`${AUTH_HINT}\n`);
         return 1;
       }
       const result = value && typeof value === 'object' && 'result' in value ? value.result : value;

--- a/cli/src/run.mjs
+++ b/cli/src/run.mjs
@@ -3,6 +3,7 @@
 // tests, and returns a numeric exit code:
 //   0 success · 1 request/transport error · 2 usage error
 import {
+  AUTH_HINT,
   DEFAULT_SPEC_URL,
   HELP,
   MCP_AUTH_ERROR_CODE,
@@ -84,6 +85,7 @@ export async function run(argv, io = {}) {
       const spec = parseBody(await res.text(), res.headers);
       if (!res.ok) {
         stderr(`${formatOutput(spec, options)}\n`);
+        if (res.status === 401) stderr(`${AUTH_HINT}\n`);
         return 1;
       }
       stdout(`${renderListing(summarizeSpec(spec, plan.service))}\n`);
@@ -99,7 +101,7 @@ export async function run(argv, io = {}) {
       if (value && typeof value === 'object' && value.error) {
         stderr(`${formatOutput(value.error, options)}\n`);
         if (value.error.code === MCP_AUTH_ERROR_CODE) {
-          stderr('Hint: this call needs a key — pass --api-key or set WORLDMONITOR_API_KEY (get one at https://worldmonitor.app/pro).\n');
+          stderr(`${AUTH_HINT}\n`);
         }
         return 1;
       }
@@ -115,6 +117,7 @@ export async function run(argv, io = {}) {
     // plan.kind === 'rest'
     if (!res.ok) {
       stderr(`${formatOutput(value, options)}\n`);
+      if (res.status === 401) stderr(`${AUTH_HINT}\n`);
       return 1;
     }
     stdout(`${formatOutput(value, options)}\n`);

--- a/cli/test/core.test.mjs
+++ b/cli/test/core.test.mjs
@@ -284,6 +284,17 @@ describe('run', () => {
     const code = await run(['get', '/api/nope'], { ...io, fetch: fetchImpl, env: {} });
     assert.equal(code, 1);
     assert.match(io.err, /not found/);
+    // A non-auth failure must NOT suggest a key — the hint is 401-scoped.
+    assert.doesNotMatch(io.err, /--api-key/);
+  });
+
+  it('hints to pass a key on a REST 401 (e.g. `health` with no key)', async () => {
+    const io = collect();
+    const { fetchImpl } = stubFetch({ ok: false, status: 401, body: '{"error":"API key required"}' });
+    const code = await run(['health'], { ...io, fetch: fetchImpl, env: {} });
+    assert.equal(code, 1);
+    assert.match(io.err, /API key required/);
+    assert.match(io.err, /--api-key/);
   });
 
   it('returns exit 2 on a usage error', async () => {

--- a/cli/test/core.test.mjs
+++ b/cli/test/core.test.mjs
@@ -267,6 +267,16 @@ describe('run', () => {
     assert.equal(code, 1);
     assert.equal(io.out, '');
     assert.match(io.err, /challenge/);
+    assert.doesNotMatch(io.err, /--api-key/);
+  });
+
+  it('hints to pass a key on MCP HTTP 401 transport errors', async () => {
+    const io = collect();
+    const { fetchImpl } = stubFetch({ ok: false, status: 401, body: '{"error":"API key required"}' });
+    const code = await run(['tools'], { ...io, fetch: fetchImpl, env: {} });
+    assert.equal(code, 1);
+    assert.match(io.err, /API key required/);
+    assert.match(io.err, /--api-key/);
   });
 
   it('performs a REST health check', async () => {
@@ -312,5 +322,23 @@ describe('run', () => {
     assert.equal(code, 0);
     assert.equal(calls[0].init.headers['user-agent'], USER_AGENT);
     assert.match(io.out, /list-cyber-threats/);
+  });
+
+  it('passes the API key when listing operations from a protected spec URL', async () => {
+    const io = collect();
+    const spec = JSON.stringify({ paths: { '/api/cyber/v1/list-cyber-threats': { get: { summary: 'x' } } } });
+    const { fetchImpl, calls } = stubFetch({ body: spec });
+    const code = await run(['list', 'cyber', '--api-key', 'wm_k'], { ...io, fetch: fetchImpl, env: {} });
+    assert.equal(code, 0);
+    assert.equal(calls[0].init.headers[API_KEY_HEADER], 'wm_k');
+  });
+
+  it('hints to pass a key on a protected spec listing 401', async () => {
+    const io = collect();
+    const { fetchImpl } = stubFetch({ ok: false, status: 401, body: '{"error":"API key required"}' });
+    const code = await run(['list'], { ...io, fetch: fetchImpl, env: {} });
+    assert.equal(code, 1);
+    assert.match(io.err, /API key required/);
+    assert.match(io.err, /--api-key/);
   });
 });

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -13,6 +13,8 @@ https://api.worldmonitor.app/api/<service>/v1/<rpc-name>
 
 The grouped pages in the left sidebar render the full OpenAPI spec — request parameters, response schemas, and try-it-out — for each service.
 
+Prefer the terminal? The official [`worldmonitor` CLI](/cli) hits any of these paths (`worldmonitor get /api/<service>/v1/<rpc-name>`) and lists the live catalog with `worldmonitor list`.
+
 ## Machine-readable discovery
 
 Building an agent or codegen pipeline? Point at `https://worldmonitor.app/` and follow the `Link:` header — every OpenAPI spec, MCP server card, OAuth endpoint, and agent-skill bundle is discoverable from one root URL via standard `.well-known` paths. See [Agent Discovery](/agent-discovery) for the full walkthrough.

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -1,0 +1,141 @@
+---
+title: "Command-Line Client"
+description: "Script country briefs, risk scores, and any of the 39 MCP tools from your shell with the official worldmonitor npm CLI — no API integration to write."
+---
+
+[`worldmonitor`](https://www.npmjs.com/package/worldmonitor) is the official command-line client for the World Monitor global-intelligence API. It's a thin, **dependency-free** wrapper over the [MCP server](/mcp-server) (the recommended agent surface) with a REST escape hatch, so you can pull briefs, risk scores, and conflict / cyber / market / news feeds from a shell script or an agent without writing a single line of HTTP plumbing. It ships as ESM and runs on **Node 18+**.
+
+The source lives in [`cli/`](https://github.com/koala73/worldmonitor/tree/main/cli) in the main repository and is published to npm on every `cli-v*` release tag.
+
+## Install
+
+```sh
+npm install -g worldmonitor    # installs the `worldmonitor` command (alias: `wm`)
+# or run ad-hoc without installing:
+npx worldmonitor tools
+```
+
+## First call — no key needed
+
+`tools` lists every MCP tool and is **public**, so it's the fastest way to confirm the CLI reaches the API:
+
+```sh
+worldmonitor tools
+```
+
+You'll get all 39 tool definitions back as JSON. Everything else that returns *data* is a `tools/call` and needs a user API key.
+
+## Authenticate
+
+Data commands map to MCP `tools/call` and require a user API key. Grab one at [worldmonitor.app/pro](https://www.worldmonitor.app/pro), then either pass it per-call or export it once:
+
+```sh
+export WORLDMONITOR_API_KEY=wm_xxxxxxxx
+worldmonitor risk IR                       # reads the key from the environment
+# — or —
+worldmonitor risk IR --api-key wm_xxxxxxxx # pass it explicitly
+```
+
+The key is sent as the `X-WorldMonitor-Key` header. See [Authentication](/usage-auth) for how keys, OAuth, and browser sessions differ, and [Rate Limits](/usage-rate-limits) for the per-plan allowances. If you call a data command with no key, the CLI exits `1` and prints a hint telling you exactly which flag to pass.
+
+## Data commands
+
+Ergonomic shortcuts over the highest-traffic tools. Positional arguments (like an ISO country code) and any `--key value` pair flow straight through as tool arguments:
+
+| Command | MCP tool | Notes |
+|---|---|---|
+| `world` | `get_world_brief` | Live global situation brief |
+| `country <ISO>` | `get_country_brief` | AI strategic brief (ISO 3166-1 alpha-2) |
+| `risk <ISO>` | `get_country_risk` | Country risk / resilience scores |
+| `markets` | `get_market_data` | Equities, commodities, crypto, FX |
+| `conflicts` | `get_conflict_events` | `--country`, `--min_fatalities`, `--limit` |
+| `cyber` | `get_cyber_threats` | `--min_severity`, `--threat_type`, `--country` |
+| `news` | `get_news_intelligence` | `--topic`, `--country`, `--alerts_only` |
+| `disasters` | `get_natural_disasters` | `--dataset`, `--active_only`, `--min_magnitude` |
+| `sanctions` | `get_sanctions_data` | `--country`, `--entity_type`, `--query` |
+| `forecasts` | `get_forecast_predictions` | `--domain`, `--region` |
+| `maritime <ISO>` | `get_maritime_activity` | Port / vessel activity for a country |
+
+```sh
+worldmonitor country IR                              # AI strategic brief
+worldmonitor conflicts --country IR --limit 5        # recent conflict events
+worldmonitor markets --asset_class crypto            # crypto quotes
+```
+
+## Any tool, any argument
+
+The curated table stays small on purpose — every one of the 39 tools is reachable via `call`, and any unrecognised `--key value` becomes a tool argument, so nothing needs special wiring:
+
+```sh
+worldmonitor call get_cyber_threats --min_severity 7
+worldmonitor call get_market_data --args '{"symbols":["AAPL","MSFT"]}'   # typed JSON args
+worldmonitor prompts        # list pre-built workflow prompt templates
+worldmonitor resources      # list addressable resource URIs
+```
+
+Use `--args '<json>'` when you need typed (non-string) arguments; otherwise `--key value` pairs are collected as strings.
+
+<Tip>
+Every tool accepts a universal `jmespath` argument that projects the response **server-side** before it crosses the wire — typically 80–95% smaller. The CLI forwards it like any other argument:
+
+```sh
+worldmonitor markets --jmespath 'data."stocks-bootstrap".quotes[?symbol==`AAPL`].{s:symbol,p:price}'
+```
+
+See the [JMESPath guide](/mcp-jmespath) for 12 worked examples.
+</Tip>
+
+## REST escape hatch
+
+For host-relative paths, self-hosted deployments, or the OpenAPI catalog:
+
+```sh
+worldmonitor health --api-key wm_xxx      # API status / health check (needs a key)
+worldmonitor get /api/cyber/v1/list-cyber-threats --api-key wm_xxx
+worldmonitor list cyber                   # list documented REST operations from the live spec
+```
+
+`health` maps to the auth-gated [platform health endpoint](/health-endpoints), so it requires `--api-key`. `list` reads the public [OpenAPI spec](/api-reference) and needs no key.
+
+## Flags
+
+| Flag | Purpose |
+|---|---|
+| `--api-key <key>` | User API key (or env `WORLDMONITOR_API_KEY`) |
+| `--mcp-url <url>` | MCP endpoint (default `https://worldmonitor.app/mcp`) |
+| `--base-url <url>` | REST base (default `https://api.worldmonitor.app`) |
+| `--args <json>` | Typed arguments object for a tool call |
+| `--timeout <ms>` | Request timeout (default `30000`) |
+| `--raw` | Print the response body verbatim |
+| `--compact` | Print single-line JSON |
+| `-h, --help` · `-v, --version` | Help / version |
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Success |
+| `1` | Request or transport error (response body written to stderr) |
+| `2` | Usage error (bad command or missing required argument) |
+
+Predictable exit codes make the CLI safe to drive from shell pipelines and CI.
+
+## Programmatic use
+
+The same logic is importable — handy for embedding in a Node script without shelling out:
+
+```js
+import { run } from 'worldmonitor/run';
+
+const code = await run(['risk', 'IR'], { env: process.env });
+```
+
+`run()` takes an injectable IO bag (`fetch`, `env`, `stdout`, `stderr`), so it's fully testable offline, and returns the numeric exit code.
+
+## Where to go next
+
+- **[MCP Quickstart](/mcp-quickstart)** — connect Claude Desktop and make your first tool call over the Model Context Protocol.
+- **[MCP Tools Reference](/mcp-tools-reference)** — per-tool parameters, freshness budgets, and examples for all 39 tools.
+- **[JMESPath guide](/mcp-jmespath)** — projection grammar to shrink responses by 80–95%.
+- **[Authentication](/usage-auth)** — API keys vs. OAuth vs. browser session.
+- **[API Reference](/api-reference)** — the full REST service catalog behind the `get` and `list` commands.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -187,6 +187,7 @@
             "pages": [
               "agent-discovery",
               "mcp-quickstart",
+              "cli",
               "mcp-server",
               "mcp-tools-reference",
               "mcp-jmespath",

--- a/docs/mcp-quickstart.mdx
+++ b/docs/mcp-quickstart.mdx
@@ -160,6 +160,7 @@ The `wm_…` user API key goes in `X-WorldMonitor-Key`, **not** as a `Bearer` to
 - **[JMESPath guide](/mcp-jmespath)** — projection grammar with 12 worked examples against real response shapes. Read this before your second day of MCP use; it will pay for itself in saved tokens within an hour.
 - **[MCP Tools Reference](/mcp-tools-reference)** — per-tool parameters, freshness budgets, API endpoint mapping, and `curl` examples for every tool.
 - **[MCP Server reference](/mcp-server)** — auth modes, OAuth setup, plans & quotas, error codes, and freshness model.
+- **[Command-line client](/cli)** — prefer a shell? `npx worldmonitor tools` drives the same tools from your terminal or a script, no integration to write.
 - **[Authentication overview](/authentication)** — when to use an API key in `X-WorldMonitor-Key` vs. OAuth vs. browser session.
 
 ## Operational note (for ops, not callers)


### PR DESCRIPTION
Pre-publish polish for the official `worldmonitor` npm CLI (0.1.0, added in #4727) so it launches **fully documented** and with a consistent auth-failure UX. No npm publish has happened yet — this lands the fixed 0.1.0 on `main` before the `cli-v0.1.0` tag is cut.

## Fix — REST 401 key hint
`worldmonitor health` (and any REST call) hitting a `401` now prints the same "pass `--api-key`" hint the MCP path already emits on `-32001`. Previously a keyless `health` returned a bare `{"error":"API key required"}` with no guidance.

- Extracted the hint into a shared `AUTH_HINT` constant (`core.mjs`); reused on both the MCP and REST paths.
- Scoped to **401 only** — a Cloudflare WAF `403` must never get a misleading "needs a key" hint.
- `HELP` + `cli/README.md` now mark `health` as requiring `--api-key`.
- **+1 regression test** (REST 401 → hint) and a guard that a 404 does *not* over-hint. **38/38 pass.**

## Docs — CLI is now discoverable
- **New `docs/cli.mdx`** — first-class docs-site page: install, auth, all commands, JMESPath passthrough, exit codes, programmatic use. Wired into the **MCP & Integrations** nav group.
- **Cross-links** added from `mcp-quickstart.mdx` and `api-reference.mdx`.
- `README.md` — added `npm install -g` + `wm` alias (was `npx`-only).
- `ARCHITECTURE.md` §12 — added the missing `cli/` directory-tree entry.

## Validation
- CLI tests: **38/38** (packed tarball installed & exercised like a real `npm i -g`; live `tools` → 39 tools, `health` no-key → body + hint + exit 1).
- `npm run docs:check` green (73 claims); `docs.json` valid JSON; all 8 internal links in the new page resolve.

## Follow-ups
- #4743 — human-facing CLI release runbook
- #4744 — surface the CLI on a landing page

## Ship order ⚠️
Merge this first, **then** cut `cli-v0.1.0` off the updated `main` so the publish includes the health fix + accurate README.

https://claude.ai/code/session_016rAsBK7otTWGcCcQHmTLjk