### PR TITLE
ci(cli): OIDC trusted publishing for the npm CLI + npm badges

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -44,7 +44,9 @@ jobs:
 
       # Trusted publishing (OIDC) requires npm >= 11.5.1; Node 22 ships npm 10.x.
       - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: |
+          npm install -g npm@11
+          npm --version
 
       - name: Test
         run: node --test 'test/**/*.test.mjs'
@@ -59,9 +61,9 @@ jobs:
             exit 1
           fi
 
-      - name: Publish (dry run)
+      - name: Validate package tarball
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run
-        run: npm publish --dry-run --access public
+        run: npm pack --dry-run
 
       # No NODE_AUTH_TOKEN: with a configured Trusted Publisher, npm mints a
       # short-lived token from the GitHub OIDC identity and attaches provenance

--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,9 +1,18 @@
 name: Publish CLI to npm
 
-# Publishes the `worldmonitor` npm package from cli/. Triggered by a
-# CLI-specific tag (cli-v1.2.3) so it is independent of desktop app releases,
-# or manually via workflow_dispatch (with a dry-run option). Requires an
-# `NPM_TOKEN` repository secret (an npm automation token with publish rights).
+# Publishes the `worldmonitor` npm package from cli/ via npm OIDC trusted
+# publishing — NO `NPM_TOKEN` secret required. Auth is a short-lived OIDC token
+# minted by GitHub Actions (`id-token: write`) and exchanged by npm (>= 11.5.1),
+# which also attaches a provenance attestation automatically.
+#
+# One-time prerequisite: a Trusted Publisher must be configured on npm
+# (npmjs.com -> worldmonitor -> Settings -> Trusted Publishing) pointing at this
+# repository and this workflow file (publish-cli.yml). Until that exists the
+# Publish step fails auth. The npm package must already exist to register it,
+# which is why v0.1.0 was published manually to bootstrap.
+#
+# Triggered by a CLI-specific tag (cli-v1.2.3) so it is independent of desktop
+# app releases, or manually via workflow_dispatch (with a dry-run option).
 
 on:
   push:
@@ -17,7 +26,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write # npm provenance
+  id-token: write # OIDC trusted publishing + provenance
 
 jobs:
   publish:
@@ -32,6 +41,10 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing (OIDC) requires npm >= 11.5.1; Node 22 ships npm 10.x.
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
 
       - name: Test
         run: node --test 'test/**/*.test.mjs'
@@ -48,10 +61,11 @@ jobs:
 
       - name: Publish (dry run)
         if: github.event_name == 'workflow_dispatch' && inputs.dry_run
-        run: npm publish --dry-run --provenance --access public
+        run: npm publish --dry-run --access public
 
+      # No NODE_AUTH_TOKEN: with a configured Trusted Publisher, npm mints a
+      # short-lived token from the GitHub OIDC identity and attaches provenance
+      # automatically.
       - name: Publish
         if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.dry_run)
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -371,7 +371,7 @@ Runs before every `git push`:
 | `deploy-worker.yml` | Push to main (worker paths), manual | Deploys the `api-cors-preflight` Cloudflare Worker |
 | `build-desktop.yml` | Release tag, push, manual | Multi-platform Tauri build, code signing (macOS), AppImage library stripping (Linux), smoke test |
 | `docker-publish.yml` | Release, manual | Multi-arch image (amd64, arm64) pushed to GHCR |
-| `publish-cli.yml` | `cli-v*` tag, manual | Tests and publishes the `worldmonitor` npm CLI (`cli/`) with provenance |
+| `publish-cli.yml` | `cli-v*` tag, manual | Tests and publishes the `worldmonitor` npm CLI (`cli/`) via OIDC trusted publishing (no token) with provenance |
 | `test-linux-app.yml` | Manual | Linux AppImage build + headless smoke test with screenshot verification |
 
 **Source files**: `.github/workflows/`, `.husky/pre-push`. The workflow list is CI-checked against `.github/workflows/*.yml` by `npm run docs:check` — a new workflow file must be added to this table.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-007ACC?style=flat&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![Last commit](https://img.shields.io/github/last-commit/koala73/worldmonitor)](https://github.com/koala73/worldmonitor/commits/main)
 [![Latest release](https://img.shields.io/github/v/release/koala73/worldmonitor?style=flat)](https://github.com/koala73/worldmonitor/releases/latest)
+[![npm: worldmonitor](https://img.shields.io/npm/v/worldmonitor?logo=npm&label=npm)](https://www.npmjs.com/package/worldmonitor)
 
 <p align="center">
   <a href="https://worldmonitor.app"><img src="https://img.shields.io/badge/Web_App-worldmonitor.app-blue?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Web App"></a>&nbsp;

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,5 +1,9 @@
 # worldmonitor
 
+[![npm version](https://img.shields.io/npm/v/worldmonitor?logo=npm)](https://www.npmjs.com/package/worldmonitor)
+[![npm downloads](https://img.shields.io/npm/dm/worldmonitor)](https://www.npmjs.com/package/worldmonitor)
+[![license](https://img.shields.io/npm/l/worldmonitor)](https://github.com/koala73/worldmonitor/blob/main/cli/LICENSE)
+
 Official command-line client for the [World Monitor](https://worldmonitor.app)
 global-intelligence API. Script country briefs, risk scores, and
 conflict / cyber / market / news feeds — plus any of the 39 MCP tools — from


### PR DESCRIPTION
Follow-up to #4745 (which shipped the CLI docs + REST 401 fix). `worldmonitor@0.1.0` is now live on npm — published **manually** because CI couldn't. This PR fixes CI so `0.1.1+` publishes automatically, and exposes the package on the repo.

## Why CI couldn't publish
The `publish-cli.yml` run for `cli-v0.1.0` passed tests, version-check, tarball, and provenance signing, then **`EOTP`'d on the registry write** — 3× in a row. Root cause: [npm/cli#8869](https://github.com/npm/cli/issues/8869) — granular access tokens fail to bypass 2FA even with the account 2FA level at "Authorization only," and npm **removed classic automation tokens** in Dec 2025. There is no working CI **token** path today.

## Fix: OIDC trusted publishing (token-free)
- **Drop `NODE_AUTH_TOKEN` / `NPM_TOKEN`** — auth is now the short-lived GitHub OIDC identity (`id-token: write`, already granted). Immune to the 2FA-token bug.
- **Upgrade npm** to ≥ 11.5.1 (trusted publishing requirement; Node 22 ships npm 10.x).
- **Provenance is automatic** for trusted publishers — dropped the explicit `--provenance` flag.

### ⚠️ One-time prerequisite before this works
Configure a Trusted Publisher on npm — **worldmonitor package → Settings → Trusted Publishing → GitHub Actions**, repo `koala73/worldmonitor`, workflow `publish-cli.yml`. (Only possible now that the package exists — that chicken-and-egg is why 0.1.0 was bootstrapped by hand.) The workflow header documents this.

## Expose on GitHub (badge + provenance)
- **npm version badge** added to the main `README.md` badge row → links the repo to the npm page.
- **version / downloads / license** badges on the npm package page (`cli/README.md`).
- `ARCHITECTURE.md` CI-table row updated to note OIDC (no token).

## Validation
- CLI tests: **41/41** on this branch.
- Workflow YAML: no `NODE_AUTH_TOKEN`/token refs (only the explanatory comment), `id-token: write` present, npm-upgrade step present.

## Suggested rollout
1. Merge this.
2. Add the Trusted Publisher on npm (30-second form).
3. Bump `cli/package.json` to `0.1.1`, tag `cli-v0.1.1` → first fully-automated, provenance-signed release. This also validates the OIDC pipeline end-to-end.

Closes the CI half of #4743 (release automation). Landing-page exposure remains #4744.

https://claude.ai/code/session_016rAsBK7otTWGcCcQHmTLjk