### PR TITLE
fix(mcp-proxy): pin the resolved IP into the socket + strip metadata headers (GHSA-887j)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -91,9 +91,13 @@ npm run lint:premium-fetch || exit 1
 
 echo "Running edge function bundle check..."
 while IFS= read -r f; do
-  npx esbuild "$f" --bundle --format=esm --platform=browser --outfile=/dev/null 2>/dev/null || {
+  platform="browser"
+  if grep -Eq "runtime[[:space:]]*:[[:space:]]*['\"]nodejs['\"]" "$f"; then
+    platform="node"
+  fi
+  npx esbuild "$f" --bundle --format=esm --platform="$platform" --outfile=/dev/null 2>/dev/null || {
     echo "ERROR: esbuild failed to bundle $f — this will break Vercel deployment"
-    npx esbuild "$f" --bundle --format=esm --platform=browser --outfile=/dev/null
+    npx esbuild "$f" --bundle --format=esm --platform="$platform" --outfile=/dev/null
     exit 1
   }
 done < <(find api/ -name "*.js" -not -name "_*"; find api/ -maxdepth 1 -name "*.ts" -not -name "_*")

--- a/api/mcp-proxy.ts
+++ b/api/mcp-proxy.ts
@@ -87,6 +87,19 @@ const FORBIDDEN_CUSTOM_HEADER_NAMES = new Set([
   'upgrade',
 ]);
 
+// Cloud-metadata gate headers (GHSA-887j defence-in-depth on top of the socket
+// pin): GCP `Metadata-Flavor: Google`, Azure `Metadata: true`, AWS IMDSv2
+// `X-aws-ec2-metadata-token[-ttl-seconds]`. The pin already stops a DNS rebind
+// from reaching 169.254.169.254; never forwarding these is the belt to that
+// suspenders, so a credential-less metadata request can't be constructed even
+// if the pin were ever bypassed. Matched case-insensitively.
+const DENIED_FORWARD_HEADERS = new Set([
+  'metadata-flavor',
+  'metadata',
+  'x-aws-ec2-metadata-token',
+  'x-aws-ec2-metadata-token-ttl-seconds',
+]);
+
 function withProxyNoStore(headers: Record<string, string> = {}): Record<string, string> {
   return { ...headers, 'Cache-Control': 'no-store' };
 }
@@ -337,7 +350,8 @@ function buildHeaders(customHeaders) {
         // Strip CRLF to prevent header injection
         const safeKey = k.replace(/[\r\n]/g, '');
         const safeVal = v.replace(/[\r\n]/g, '');
-        if (FORBIDDEN_CUSTOM_HEADER_NAMES.has(safeKey.toLowerCase())) continue;
+        const lowerKey = safeKey.toLowerCase();
+        if (FORBIDDEN_CUSTOM_HEADER_NAMES.has(lowerKey) || DENIED_FORWARD_HEADERS.has(lowerKey)) continue;
         if (safeKey) h[safeKey] = safeVal;
       }
     }

--- a/api/mcp-proxy.ts
+++ b/api/mcp-proxy.ts
@@ -2,13 +2,16 @@
 // `isCallerPremium` import from server/ (PR #3768 review). Body remains
 // JS-shaped; not annotating types in this commit. Future PR can add
 // types incrementally; behaviour is unchanged.
+import http from 'node:http';
+import https from 'node:https';
+import { Readable } from 'node:stream';
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 import { jsonResponse } from './_json-response.js';
 import { isCallerPremium } from '../server/_shared/premium-check';
 import { isBlockedResolvedAddress } from '../server/_shared/ip-address-classification';
 import { ENDPOINT_RATE_POLICIES, checkScopedRateLimit, getClientIp } from '../server/_shared/rate-limit';
 
-export const config = { runtime: 'edge' };
+export const config = { runtime: 'nodejs' };
 
 // Per-IP rate limit for the MCP proxy (issue #3805 defense-in-depth).
 // 30/min/IP is generous for normal MCP polling (most clients refresh every
@@ -18,7 +21,7 @@ export const config = { runtime: 'edge' };
 //
 // PR #3821 r2: source the limit from ENDPOINT_RATE_POLICIES so the
 // `enforce-rate-limit-policies` audit can see this endpoint. mcp-proxy is a
-// top-level Vercel Edge Function (not gateway-routed), so it can't use
+// top-level Vercel Function (not gateway-routed), so it can't use
 // `checkEndpointRateLimit`; we keep `checkScopedRateLimit` for in-handler
 // enforcement but the *policy* lives in the registry. Single source of
 // truth — tweak the limit there, this handler picks it up.
@@ -67,6 +70,22 @@ const DNS_JSON_ENDPOINT = 'https://cloudflare-dns.com/dns-query';
 // exercise the timeout→reject (504) path, just without the wall-clock stall.
 const SSE_RPC_TIMEOUT_MS = process.env.NODE_TEST_CONTEXT ? 200 : 12_000;
 const MCP_PROTOCOL_VERSION = '2025-03-26';
+const DEFAULT_HTTPS_PORT = 443;
+const DEFAULT_HTTP_PORT = 80;
+const TEST_NODE_REQUEST_KEY = Symbol.for('worldmonitor.mcpProxy.nodeRequestForTest');
+const DEFAULT_FETCH = globalThis.fetch;
+const FORBIDDEN_CUSTOM_HEADER_NAMES = new Set([
+  'connection',
+  'content-length',
+  'host',
+  'keep-alive',
+  'proxy-authenticate',
+  'proxy-authorization',
+  'te',
+  'trailer',
+  'transfer-encoding',
+  'upgrade',
+]);
 
 function withProxyNoStore(headers: Record<string, string> = {}): Record<string, string> {
   return { ...headers, 'Cache-Control': 'no-store' };
@@ -180,16 +199,106 @@ async function assertServerUrlSafe(url) {
   return { url, resolvedAddresses };
 }
 
-// Vercel Edge fetch does not expose a Node-style lookup/socket hook, so this
-// proxy CANNOT pin the TLS connection to a previously vetted address. There is
-// no way to guarantee that the IP we validated is the IP fetch() ultimately
-// connects to; a DNS answer can change between our resolve and fetch's own
-// resolve. This re-resolve-and-recheck immediately before every outbound
-// dispatch NARROWS that DNS-rebinding window but does not close it. The
-// residual rebind window is an ACCEPTED limitation of the Edge runtime (no
-// socket-level pin available) — documented, not fixed here (P1, issue #4674).
 async function revalidateBeforeFetch(url) {
-  await assertServerUrlSafe(url);
+  return assertServerUrlSafe(url);
+}
+
+function getFetchForTest() {
+  if (!process.env.NODE_TEST_CONTEXT) return null;
+  return globalThis.fetch !== DEFAULT_FETCH ? globalThis.fetch : null;
+}
+
+function getNodeRequestForTest() {
+  if (!process.env.NODE_TEST_CONTEXT) return null;
+  const requestForTest = globalThis[TEST_NODE_REQUEST_KEY];
+  return typeof requestForTest === 'function' ? requestForTest : null;
+}
+
+function choosePinnedAddress(resolvedAddresses) {
+  const pinnedAddress = resolvedAddresses.find(address => address.includes('.')) || resolvedAddresses[0];
+  if (!pinnedAddress) {
+    throw new McpProxySsrfError('serverUrl DNS resolution returned no addresses');
+  }
+  if (isBlockedResolvedAddress(pinnedAddress)) {
+    throwBlockedAddress(pinnedAddress);
+  }
+  return pinnedAddress;
+}
+
+function responseHeadersFromNode(headers) {
+  const responseHeaders = new Headers();
+  for (const [key, value] of Object.entries(headers || {})) {
+    if (value === undefined) continue;
+    responseHeaders.set(key, Array.isArray(value) ? value.join(', ') : String(value));
+  }
+  return responseHeaders;
+}
+
+function nodeStreamResponse(res) {
+  return new Response(Readable.toWeb(res), {
+    status: res.statusCode || 502,
+    statusText: res.statusMessage,
+    headers: responseHeadersFromNode(res.headers),
+  });
+}
+
+async function nodePinnedFetch(url, init, resolvedAddresses) {
+  const pinnedAddress = choosePinnedAddress(resolvedAddresses);
+  const family = pinnedAddress.includes(':') ? 6 : 4;
+  const body = init?.body;
+  const bodyBuffer = body === undefined || body === null
+    ? null
+    : Buffer.isBuffer(body)
+      ? body
+      : Buffer.from(String(body));
+  const headers = { ...(init?.headers || {}) };
+  if (bodyBuffer && headers['content-length'] === undefined && headers['Content-Length'] === undefined) {
+    headers['content-length'] = String(bodyBuffer.length);
+  }
+  const requestOptions = {
+    hostname: url.hostname,
+    port: url.port || (url.protocol === 'https:' ? DEFAULT_HTTPS_PORT : DEFAULT_HTTP_PORT),
+    path: `${url.pathname}${url.search}`,
+    method: init?.method || 'GET',
+    headers,
+    family,
+    lookup: (_hostname, _options, callback) => callback(null, pinnedAddress, family),
+  };
+  const requestFn = getNodeRequestForTest() || (url.protocol === 'https:' ? https.request : http.request);
+
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const settle = (fn, value) => {
+      if (settled) return;
+      settled = true;
+      init?.signal?.removeEventListener?.('abort', onAbort);
+      fn(value);
+    };
+    const onAbort = () => {
+      req.destroy(new DOMException('The operation was aborted.', 'AbortError'));
+    };
+    const req = requestFn(requestOptions, (res) => {
+      res.on('error', error => settle(reject, error));
+      settle(resolve, nodeStreamResponse(res));
+    });
+    req.on('error', error => settle(reject, error));
+    if (init?.signal) {
+      if (init.signal.aborted) {
+        req.destroy(new DOMException('The operation was aborted.', 'AbortError'));
+      } else {
+        init.signal.addEventListener('abort', onAbort, { once: true });
+      }
+    }
+    if (bodyBuffer) req.write(bodyBuffer);
+    req.end();
+  });
+}
+
+async function pinnedFetch(url, init = {}) {
+  const { resolvedAddresses } = await revalidateBeforeFetch(url);
+  const fetchForTest = getFetchForTest();
+  if (fetchForTest) return fetchForTest(url.toString(), init);
+  return nodePinnedFetch(url, init, resolvedAddresses);
 }
 
 function buildInitPayload() {
@@ -228,6 +337,7 @@ function buildHeaders(customHeaders) {
         // Strip CRLF to prevent header injection
         const safeKey = k.replace(/[\r\n]/g, '');
         const safeVal = v.replace(/[\r\n]/g, '');
+        if (FORBIDDEN_CUSTOM_HEADER_NAMES.has(safeKey.toLowerCase())) continue;
         if (safeKey) h[safeKey] = safeVal;
       }
     }
@@ -240,8 +350,7 @@ function buildHeaders(customHeaders) {
 async function postJson(url, body, headers, sessionId) {
   const h = { ...headers };
   if (sessionId) h['Mcp-Session-Id'] = sessionId;
-  await revalidateBeforeFetch(url);
-  const resp = await fetch(url.toString(), {
+  const resp = await pinnedFetch(url, {
     method: 'POST',
     headers: h,
     body: JSON.stringify(body),
@@ -348,8 +457,7 @@ class SseSession {
   }
 
   async connect() {
-    await revalidateBeforeFetch(new URL(this._sseUrl));
-    const resp = await fetch(this._sseUrl, {
+    const resp = await pinnedFetch(new URL(this._sseUrl), {
       headers: { ...this._headers, Accept: 'text/event-stream', 'Cache-Control': 'no-cache' },
       redirect: 'manual',
       signal: AbortSignal.timeout(SSE_CONNECT_TIMEOUT_MS),
@@ -445,8 +553,7 @@ class SseSession {
       }
     }, SSE_RPC_TIMEOUT_MS);
     try {
-      await revalidateBeforeFetch(new URL(this._endpointUrl));
-      const postResp = await fetch(this._endpointUrl, {
+      const postResp = await pinnedFetch(new URL(this._endpointUrl), {
         method: 'POST',
         headers: { ...this._headers, 'Content-Type': 'application/json' },
         body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
@@ -464,8 +571,7 @@ class SseSession {
   }
 
   async notify(method, params) {
-    await revalidateBeforeFetch(new URL(this._endpointUrl));
-    await fetch(this._endpointUrl, {
+    await pinnedFetch(new URL(this._endpointUrl), {
       method: 'POST',
       headers: { ...this._headers, 'Content-Type': 'application/json' },
       body: JSON.stringify({ jsonrpc: '2.0', method, params }),

--- a/tests/edge-functions.test.mjs
+++ b/tests/edge-functions.test.mjs
@@ -10,6 +10,7 @@ const apiDir = join(root, 'api');
 const apiOauthDir = join(root, 'api', 'oauth');
 const sharedDir = join(root, 'shared');
 const scriptsSharedDir = join(root, 'scripts', 'shared');
+const prePushHookPath = join(root, '.husky', 'pre-push');
 
 // All .js files in api/ except underscore-prefixed helpers (_cors.js, _api-key.js)
 const edgeFunctions = readdirSync(apiDir)
@@ -23,11 +24,10 @@ const oauthEdgeFunctions = readdirSync(apiOauthDir)
 
 const allEdgeFunctions = [...edgeFunctions, ...oauthEdgeFunctions];
 
-// ALL .js AND .ts files under api/ (recursively) — used for node: built-in checks.
+// ALL .js AND .ts files under api/ (recursively) — used for runtime/built-in checks.
 // Note: .ts edge functions are intentionally excluded from the
 // module-isolation describe below because Vercel bundles them at build time, so
-// imports from '../server/' are valid. The node: built-in check still applies
-// regardless of depth, since Vercel Edge Runtime rejects node: imports at runtime.
+// imports from '../server/' are valid.
 function walkApi(dir, relPrefix = '') {
   const out = [];
   for (const entry of readdirSync(dir)) {
@@ -44,6 +44,10 @@ function walkApi(dir, relPrefix = '') {
 }
 
 const allApiFiles = walkApi(apiDir);
+
+function declaresNodeRuntime(src) {
+  return /runtime\s*:\s*['"]nodejs['"]/.test(src);
+}
 
 describe('scripts/shared/ stays in sync with shared/', () => {
   // Historical scope: .json (data) + .cjs (helpers).
@@ -84,15 +88,28 @@ describe('Edge Function shared helpers resolve', () => {
 
 describe('Edge Function no node: built-ins', () => {
   for (const { name, path } of allApiFiles) {
-    it(`${name} does not import node: built-ins (unsupported in Vercel Edge Runtime)`, () => {
+    it(`${name} does not import node: built-ins unless it declares Node runtime`, () => {
       const src = readFileSync(path, 'utf-8');
       const match = src.match(/from\s+['"]node:(\w+)['"]/);
+      if (declaresNodeRuntime(src)) {
+        return;
+      }
       assert.ok(
         !match,
-        `${name}: imports node:${match?.[1]} — Vercel Edge Runtime does not support node: built-in modules. Use an edge-compatible alternative.`,
+        `${name}: imports node:${match?.[1]} without runtime: 'nodejs' — Vercel Edge Runtime does not support node: built-in modules. Use an edge-compatible alternative or declare Node runtime deliberately.`,
       );
     });
   }
+});
+
+describe('pre-push API bundle check', () => {
+  it('bundles explicit Node runtime routes with esbuild platform=node', () => {
+    const src = readFileSync(prePushHookPath, 'utf-8');
+    assert.match(src, /platform="browser"/);
+    assert.match(src, /runtime\[\[:space:\]\]\*:\[\[:space:\]\]\*\['\\?"\]nodejs\['\\?"\]/);
+    assert.match(src, /platform="node"/);
+    assert.match(src, /--platform="\$platform"/);
+  });
 });
 
 // The legacy api/*.js allowlist that previously lived here was replaced by

--- a/tests/mcp-proxy.test.mjs
+++ b/tests/mcp-proxy.test.mjs
@@ -305,6 +305,49 @@ describe('api/mcp-proxy', () => {
     // path is exercised in tests/chat-analyst.test.mts / production E2E.
   });
 
+  // ── SSRF defence-in-depth: cloud-metadata header stripping (GHSA-887j) ─────
+
+  describe('customHeaders — cloud-metadata header stripping (GHSA-887j)', () => {
+    function captureForwardedHeaders() {
+      const captured = { headers: null };
+      globalThis.fetch = async (_url, opts) => {
+        captured.headers = opts?.headers ?? {};
+        const body = opts?.body ? JSON.parse(opts.body) : {};
+        if (body.method === 'tools/list') {
+          return new Response(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { tools: [] } }), {
+            status: 200, headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response(JSON.stringify({ jsonrpc: '2.0', id: body.id, result: { protocolVersion: '2025-03-26', capabilities: {}, serverInfo: { name: 't', version: '1' } } }), {
+          status: 200, headers: { 'Content-Type': 'application/json' },
+        });
+      };
+      return captured;
+    }
+
+    it('drops Metadata-Flavor / X-aws-ec2-metadata-token but forwards legit headers (pin + strip)', async () => {
+      const captured = captureForwardedHeaders();
+      const res = await handler(makeGetRequest({
+        serverUrl: 'https://mcp.example.com/mcp',
+        headers: JSON.stringify({
+          'Metadata-Flavor': 'Google',
+          'metadata': 'true',
+          'X-aws-ec2-metadata-token': 'stolen-token',
+          'X-aws-ec2-metadata-token-ttl-seconds': '21600',
+          'Authorization': 'Bearer legit-mcp-token',
+        }),
+      }));
+      assert.equal(res.status, 200);
+      assert.ok(captured.headers, 'target fetch must have been called');
+      const lowerKeys = Object.keys(captured.headers).map((k) => k.toLowerCase());
+      assert.ok(!lowerKeys.includes('metadata-flavor'), 'Metadata-Flavor must be stripped');
+      assert.ok(!lowerKeys.includes('metadata'), 'Azure Metadata header must be stripped');
+      assert.ok(!lowerKeys.includes('x-aws-ec2-metadata-token'), 'AWS IMDSv2 token header must be stripped');
+      assert.ok(!lowerKeys.includes('x-aws-ec2-metadata-token-ttl-seconds'), 'AWS IMDSv2 ttl header must be stripped');
+      assert.ok(lowerKeys.includes('authorization'), 'legitimate Authorization must pass through');
+    });
+  });
+
   // ── CORS / method guards ──────────────────────────────────────────────────
 
   describe('CORS and method handling', () => {

--- a/tests/mcp-proxy.test.mjs
+++ b/tests/mcp-proxy.test.mjs
@@ -5,6 +5,8 @@
 // this is expected; use tsx (the project's standard test runner).
 import { strict as assert } from 'node:assert';
 import { describe, it, beforeEach, afterEach, before } from 'node:test';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
 
 // validateApiKey runs with forceKey:true on this endpoint (PR #3768 review
 // finding — wms_ session tokens are anonymous and freely mintable via
@@ -119,8 +121,60 @@ function makeMcpFetch({ initStatus = 200, listStatus = 200, callStatus = 200, to
   };
 }
 
+function makeMcpNodeRequest({ tools = [], callResult = { content: [] }, seen = [] } = {}) {
+  return (options, onResponse) => {
+    let body = '';
+    const req = new EventEmitter();
+    req.write = (chunk) => { body += chunk.toString(); };
+    req.setTimeout = () => req;
+    req.destroy = (error) => {
+      if (error) queueMicrotask(() => req.emit('error', error));
+    };
+    req.end = () => {
+      options.lookup(options.hostname, {}, (error, address, family) => {
+        if (error) {
+          req.destroy(error);
+          return;
+        }
+        seen.push({ options, address, family });
+        const jsonBody = body ? JSON.parse(body) : {};
+        const res = new PassThrough();
+        res.statusCode = 200;
+        res.statusMessage = 'OK';
+        res.headers = { 'content-type': 'application/json' };
+        queueMicrotask(() => {
+          onResponse(res);
+          if (jsonBody.method === 'initialize') {
+            res.end(JSON.stringify({
+              jsonrpc: '2.0',
+              id: jsonBody.id,
+              result: {
+                protocolVersion: '2025-03-26',
+                capabilities: {},
+                serverInfo: { name: 'test', version: '1' },
+              },
+            }));
+            return;
+          }
+          if (jsonBody.method === 'tools/list') {
+            res.end(JSON.stringify({ jsonrpc: '2.0', id: jsonBody.id, result: { tools } }));
+            return;
+          }
+          if (jsonBody.method === 'tools/call') {
+            res.end(JSON.stringify({ jsonrpc: '2.0', id: jsonBody.id, result: callResult }));
+            return;
+          }
+          res.end('{}');
+        });
+      });
+    };
+    return req;
+  };
+}
+
 let handler;
 const TEST_RESOLVER_KEY = Symbol.for('worldmonitor.mcpProxy.resolveHostnameForTest');
+const TEST_NODE_REQUEST_KEY = Symbol.for('worldmonitor.mcpProxy.nodeRequestForTest');
 
 const PUBLIC_TEST_ADDRESS = '93.184.216.34';
 
@@ -129,6 +183,14 @@ function setResolveHostnameForTest(resolver) {
     globalThis[TEST_RESOLVER_KEY] = resolver;
   } else {
     delete globalThis[TEST_RESOLVER_KEY];
+  }
+}
+
+function setNodeRequestForTest(request) {
+  if (typeof request === 'function') {
+    globalThis[TEST_NODE_REQUEST_KEY] = request;
+  } else {
+    delete globalThis[TEST_NODE_REQUEST_KEY];
   }
 }
 
@@ -155,6 +217,7 @@ describe('api/mcp-proxy', () => {
 
   afterEach(() => {
     setResolveHostnameForTest?.(null);
+    setNodeRequestForTest?.(null);
     globalThis.fetch = originalFetch;
   });
 
@@ -375,19 +438,19 @@ describe('api/mcp-proxy', () => {
     it('ignores the test resolver outside NODE_TEST_CONTEXT', async () => {
       const previousNodeTestContext = process.env.NODE_TEST_CONTEXT;
       delete process.env.NODE_TEST_CONTEXT;
-      setResolvedAddresses(['10.0.0.5']);
-      globalThis.fetch = async (url, opts) => {
+      setResolvedAddresses([PUBLIC_TEST_ADDRESS]);
+      globalThis.fetch = async (url) => {
         const u = new URL(url.toString());
         if (u.hostname === 'cloudflare-dns.com') {
           const type = u.searchParams.get('type');
-          if (type === 'A') return dnsJsonResponse([{ type: 1, data: PUBLIC_TEST_ADDRESS }]);
+          if (type === 'A') return dnsJsonResponse([{ type: 1, data: '10.0.0.5' }]);
           if (type === 'AAAA') return dnsJsonResponse([]);
         }
-        return makeMcpFetch({ tools: [] })(url, opts);
+        throw new Error(`unexpected fetch to ${url}`);
       };
       try {
         const res = await handler(makeGetRequest({ serverUrl: 'https://public-mcp.example/mcp' }));
-        assert.equal(res.status, 200);
+        assert.equal(res.status, 400);
       } finally {
         if (previousNodeTestContext === undefined) delete process.env.NODE_TEST_CONTEXT;
         else process.env.NODE_TEST_CONTEXT = previousNodeTestContext;
@@ -473,6 +536,36 @@ describe('api/mcp-proxy', () => {
       assert.equal(capturedHeaders['Authorization'], 'Bearer test-key');
     });
 
+    it('does not pass authority or hop-by-hop custom headers to upstream', async () => {
+      let capturedHeaders = {};
+      globalThis.fetch = async (url, opts) => {
+        capturedHeaders = Object.fromEntries(Object.entries(opts?.headers || {}));
+        return makeMcpFetch({ tools: [] })(url, opts);
+      };
+      const res = await handler(makeGetRequest({
+        serverUrl: 'https://mcp.example.com/mcp',
+        headers: JSON.stringify({
+          Authorization: 'Bearer test-key',
+          Host: 'internal.example',
+          'Content-Length': '999',
+          Connection: 'upgrade',
+          'Proxy-Authorization': 'Basic secret',
+          TE: 'trailers',
+          Trailer: 'x-extra',
+          Upgrade: 'websocket',
+        }),
+      }));
+      assert.equal(res.status, 200);
+      assert.equal(capturedHeaders['Authorization'], 'Bearer test-key');
+      assert.equal(capturedHeaders.Host, undefined);
+      assert.equal(capturedHeaders['Content-Length'], undefined);
+      assert.equal(capturedHeaders.Connection, undefined);
+      assert.equal(capturedHeaders['Proxy-Authorization'], undefined);
+      assert.equal(capturedHeaders.TE, undefined);
+      assert.equal(capturedHeaders.Trailer, undefined);
+      assert.equal(capturedHeaders.Upgrade, undefined);
+    });
+
     it('strips CRLF from injected headers', async () => {
       let capturedHeaders = {};
       globalThis.fetch = async (url, opts) => {
@@ -500,13 +593,27 @@ describe('api/mcp-proxy', () => {
       assert.deepEqual(redirectModes, ['manual', 'manual', 'manual']);
     });
 
-    // NOTE: this validates the per-dispatch re-resolve + classifier path, NOT
-    // true socket-level rebind prevention. Vercel Edge fetch cannot pin the
-    // connection to a vetted IP (P1, issue #4674), so a residual rebind window
-    // between our resolve and fetch's own resolve is an accepted limitation.
-    // What this asserts: when a subsequent re-resolution returns a blocked
-    // address, revalidateBeforeFetch rejects it before the next upstream fetch,
-    // and the caller sees the GENERIC SSRF message (never the internal IP).
+    it('pins streamable HTTP upstream requests to the vetted resolver address', async () => {
+      const seen = [];
+      setResolvedAddresses([PUBLIC_TEST_ADDRESS]);
+      setNodeRequestForTest(makeMcpNodeRequest({ tools: [], seen }));
+
+      const res = await handler(makeGetRequest({ serverUrl: 'https://mcp.example.com/mcp' }));
+
+      assert.equal(res.status, 200);
+      assert.equal(seen.length, 3, 'initialize, initialized notification, and tools/list should each use pinned transport');
+      for (const entry of seen) {
+        assert.equal(entry.options.hostname, 'mcp.example.com');
+        assert.equal(entry.address, PUBLIC_TEST_ADDRESS);
+        assert.equal(entry.family, 4);
+        assert.equal(entry.options.family, 4);
+      }
+    });
+
+    // This validates the per-dispatch re-resolve + classifier path: when a
+    // subsequent re-resolution returns a blocked address, revalidateBeforeFetch
+    // rejects it before the next upstream dispatch, and the caller sees the
+    // GENERIC SSRF message (never the internal IP).
     it('re-resolves and re-checks the same host before each streamable HTTP dispatch (classifier/revalidation path)', async () => {
       const resolutions = [
         [PUBLIC_TEST_ADDRESS], // request validation


### PR DESCRIPTION
Completes the fix for **GHSA-887j-p88r-qmm9** (MCP-proxy SSRF, CWE-918) — the socket-pin that fully closes resolve≠connect, plus the cloud-metadata header defence-in-depth.

Opened on the real repo (not the advisory fork) specifically to get **CI + a Vercel preview**, because this one **switches the runtime `edge` → `nodejs`** and that can't be validated by the mocked-`fetch` unit tests. **Please smoke-test the preview before merging** (see checklist below).

## What it does
- **Pins the vetted IP into the outbound socket** — resolves+validates `serverUrl` via DoH, then dispatches through Node's built-in `http/https.request` with a custom `lookup` that returns **only** the DoH-vetted address. TLS SNI stays the hostname, so certs still validate. This closes the resolve≠connect gap the code previously accepted as a limitation (mcp-proxy.ts:194-201 / #4674) — no `undici` dependency needed.
- **Streaming preserved** via `Readable.toWeb(res)`; all four fetch sites (`postJson` + SSE `connect`/endpoint POSTs) go through the pinned path.
- **Cloud-metadata header strip (defence-in-depth):** `buildHeaders` drops `Metadata-Flavor` / `Metadata` / `X-aws-ec2-metadata-token[-ttl-seconds]` (belt-and-suspenders on top of the pin), plus the existing hop-by-hop filter.
- `runtime: 'edge'` → `'nodejs'`; `.husky/pre-push` updated to esbuild nodejs-runtime files with `--platform=node`; test seams added so the mocked-fetch suite still exercises the logic.

## Verification so far
- `tests/mcp-proxy.test.mjs` + `tests/edge-functions.test.mjs`: **268/268 pass**.
- **NOT yet verified:** the real Vercel Node runtime + live socket + SSE streaming under load — that's what this PR's preview is for.

## ⚠️ Preview smoke-test before merge
On the preview URL's `/api/mcp-proxy`, with a Pro/enterprise credential:
- [ ] Streamable-HTTP MCP server → `list` + `call` return tools/results
- [ ] SSE MCP server → `list` + `call` stream correctly (the `Readable.toWeb` path)
- [ ] A private/loopback `serverUrl` is still blocked (SSRF guard intact)
- [ ] (ideal) a rebinding target (public A-record, private on connect) is refused at connect time
- [ ] cold-start latency acceptable for the endpoint

Supersedes the Edge-only mitigation PR on the advisory fork (now closed). Refs: GHSA-887j-p88r-qmm9, #4674.

https://claude.ai/code/session_01MWkSosWKsTysN9SvadamyV
