### PR TITLE
fix(test): simulate CF edge-proof in bootstrap IP-scoped rate-limit test

### DIFF
--- a/api/_user-api-key.test.mjs
+++ b/api/_user-api-key.test.mjs
@@ -33,6 +33,7 @@ async function withMockedConvex(fn, options = {}) {
     'UPSTASH_REDIS_REST_TOKEN',
     'VERCEL_ENV',
     'VERCEL_GIT_COMMIT_SHA',
+    'CF_EDGE_PROOF_SECRET',
   ]);
   const originalFetch = globalThis.fetch;
   const calls = [];
@@ -409,8 +410,17 @@ test('rate limit accepts a request landing in the final sub-second of the window
 
 test('user-key validation rate limit uses IP-scoped keys and never raw API key material', async () => {
   await withMockedConvex(async (calls) => {
+    // getClientIp only trusts cf-connecting-ip when the request proves it
+    // transited Cloudflare (GHSA-c267): x-wm-edge-proof must match
+    // CF_EDGE_PROOF_SECRET. Simulate a genuine CF-proxied request so the bucket
+    // is IP-scoped rather than the shared `unknown` fallback.
+    process.env.CF_EDGE_PROOF_SECRET = 'edge-secret-xyz';
     const req = new Request('https://api.worldmonitor.app/api/bootstrap', {
-      headers: { 'cf-connecting-ip': '203.0.113.7', 'X-WorldMonitor-Key': USER_KEY },
+      headers: {
+        'cf-connecting-ip': '203.0.113.7',
+        'x-wm-edge-proof': 'edge-secret-xyz',
+        'X-WorldMonitor-Key': USER_KEY,
+      },
     });
     const result = await checkBootstrapUserApiKeyRateLimit(req);
 


### PR DESCRIPTION
## Fixes the red `sidecar` job on `main`

`main` went red at ~12:30 today when the GHSA security advisory fork-merges landed. The single failing test is:

```
not ok - user-key validation rate limit uses IP-scoped keys and never raw API key material
  expected /rl:bootstrap-user-api-key:203\.0\.113\.7/
  actual   rl:bootstrap-user-api-key:unknown
```

Every open PR (e.g. #4747, #4748) has been inheriting this red.

## Root cause — the hardening is correct, the test wasn't updated
The **GHSA-c267** fix hardened `getClientIp` (`api/_client-ip.js`) to trust `cf-connecting-ip` **only** when the request proves Cloudflare transit — an `x-wm-edge-proof` header matching `CF_EDGE_PROOF_SECRET`. Without proof it falls back to `x-real-ip` → the shared `unknown` bucket (so a direct-to-origin attacker can't rotate the rate-limit bucket by spoofing `cf-connecting-ip`).

The `_user-api-key.test.mjs` rate-limit test predates that change: it sent `cf-connecting-ip: 203.0.113.7` with **no proof**, so `getClientIp` now correctly returns `unknown` and the IP-scoped-key assertion fails. **The production behavior is right** — Cloudflare injects the proof header on real traffic, so bootstrap rate-limiting stays IP-scoped.

## Fix (test-only)
Simulate a genuine CF-proxied request, matching the pattern already used in `api/_rate-limit.test.mjs`:
- Set `CF_EDGE_PROOF_SECRET` and send a matching `x-wm-edge-proof` header.
- Register `CF_EDGE_PROOF_SECRET` in `withMockedConvex`'s env snapshot so it's restored after the test.

No production code changed — the security hardening stays intact.

## Validation
`node --test api/_user-api-key.test.mjs` → **24/24 pass** (was 23/24). Scanned the other `api/*.test.mjs` — no sibling test has the same latent `cf-connecting-ip`-without-proof assertion.

https://claude.ai/code/session_016rAsBK7otTWGcCcQHmTLjk