### PR TITLE
docs(readme): make the npm CLI prominent on the repo landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@
 </p>
 
 <p align="center">
+  <a href="https://www.npmjs.com/package/worldmonitor"><img src="https://img.shields.io/npm/v/worldmonitor?style=for-the-badge&logo=npm&logoColor=white&label=npm%20i%20worldmonitor&color=CB3837" alt="npm i worldmonitor"></a>&nbsp;
+  <a href="https://www.npmjs.com/package/worldmonitor"><img src="https://img.shields.io/badge/CLI-npx%20worldmonitor-CB3837?style=for-the-badge&logo=npm&logoColor=white" alt="npx worldmonitor"></a>
+</p>
+
+<p align="center">
   <a href="https://worldmonitor.app/api/download?platform=windows-exe"><img src="https://img.shields.io/badge/Download-Windows_(.exe)-0078D4?style=for-the-badge&logo=windows&logoColor=white" alt="Download Windows"></a>&nbsp;
   <a href="https://worldmonitor.app/api/download?platform=macos-arm64"><img src="https://img.shields.io/badge/Download-macOS_Apple_Silicon-000000?style=for-the-badge&logo=apple&logoColor=white" alt="Download macOS ARM"></a>&nbsp;
   <a href="https://worldmonitor.app/api/download?platform=macos-x64"><img src="https://img.shields.io/badge/Download-macOS_Intel-555555?style=for-the-badge&logo=apple&logoColor=white" alt="Download macOS Intel"></a>&nbsp;


### PR DESCRIPTION
The npm package is published (`worldmonitor@0.1.1`, with provenance), but it wasn't *visible* on the repo landing page — the badge from #4747 was the 7th flat badge in the top row, easy to miss, and GitHub had camo-cached a blank version of the image from before the package existed.

This adds a **dedicated centered `for-the-badge` row** (matching the existing web-variant buttons):
- **`npm i worldmonitor`** — live version badge, links to the npm page
- **`npx worldmonitor`** — CLI call-to-action

Both shields.io endpoints verified (HTTP 200, SVG). Nothing else touched.

> Note: GitHub's "Packages" sidebar stays empty by design — that reflects **GitHub Packages** only, not npmjs. Publishing there would require a scoped `@koala73/worldmonitor` mirror that needs auth even to install; deliberately not doing that. Repo↔package linkage is the badge + npm provenance ("Built and signed on GitHub Actions").

https://claude.ai/code/session_016rAsBK7otTWGcCcQHmTLjk