### PR TITLE
docs(mcp): document MCP Apps + bump server version to 1.11.0

### DIFF
--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -28,7 +28,7 @@ Pro subscribers can connect Claude Desktop / Cursor / claude.ai without ever pas
 | `https://api.worldmonitor.app/.well-known/oauth-authorization-server` | AS metadata (RFC 8414) |
 | `https://worldmonitor.app/.well-known/oauth-protected-resource` | Resource server metadata (RFC 9728) |
 
-Server identifier: `worldmonitor` v1.10.0.
+Server identifier: `worldmonitor` v1.11.0.
 
 ### Protocol negotiation
 
@@ -367,7 +367,20 @@ In addition to the 39 tools, WorldMonitor exposes MCP prompts and resources so c
 | `worldmonitor://seed-meta/freshness` | Market-data bootstrap freshness envelope only: `cached_at` and `stale`. |
 | `worldmonitor://markets/{symbol}/quote` | Single-symbol market quote slice. `{symbol}` is uppercase, for example `AAPL`, `GC=F`, or `BTC-USD`. |
 
-`resources/list` is metadata and does not consume the Pro daily quota. `resources/read` intentionally does consume the same daily quota slot as the equivalent `tools/call`; it routes through the same dispatcher so resources cannot bypass the Pro cap. As with every MCP method, both `resources/list` and `resources/read` still count toward the 60/minute limiter. For the exact `-32029` status/header differences between per-minute throttling and daily quota exhaustion, see the [MCP Error Catalog](/mcp-error-catalog#-32029--rate-limited-per-minute-or-daily).
+`resources/list` is metadata and does not consume the Pro daily quota. `resources/read` on a `worldmonitor://` data URI intentionally does consume the same daily quota slot as the equivalent `tools/call`; it routes through the same dispatcher so resources cannot bypass the Pro cap. As with every MCP method, both `resources/list` and `resources/read` still count toward the 60/minute limiter. For the exact `-32029` status/header differences between per-minute throttling and daily quota exhaustion, see the [MCP Error Catalog](/mcp-error-catalog#-32029--rate-limited-per-minute-or-daily).
+
+### MCP Apps (interactive UI)
+
+The server supports [MCP Apps](https://modelcontextprotocol.io/extensions/apps/build) (extension `io.modelcontextprotocol/ui`, spec `2026-01-26`) — interactive views a host renders in a sandboxed iframe when a linked tool is called. Two wire signals drive it:
+
+- **`tools/list`** advertises the linkage on the tool. `get_country_risk` carries `_meta.ui.resourceUri` (and the deprecated flat `ui/resourceUri` alias) pointing at its UI resource.
+- **`resources/list`** surfaces the UI resource itself, after the four data URIs:
+
+| UI resource URI | mimeType | Renders |
+|-----------------|----------|---------|
+| `ui://worldmonitor/country-risk.html` | `text/html;profile=mcp-app` | The `get_country_risk` result as an interactive card: CII score, unrest/conflict/security/news component breakdown, travel-advisory level, and OFAC sanctions exposure. |
+
+`resources/read` on a `ui://` URI returns the self-contained HTML view. Unlike the data resources, a `ui://` read is **public and quota-exempt** — the template carries no data and spends no upstream call, so a host can preload it (and an agent-readiness scanner can fetch it) without credentials and without touching the Pro daily cap. The view is fully self-contained (no external assets) and communicates with the host over the standard MCP Apps `postMessage` bridge (`ui/initialize` → `ui/notifications/tool-result` → `ui/notifications/size-changed`).
 
 ## JSON-RPC example
 


### PR DESCRIPTION
## Summary

Documentation follow-up to **#4761** (which shipped MCP Apps support — `ui://` resources + tool `_meta` — and bumped `SERVER_VERSION` + server-card to `1.11.0`, but left `docs/mcp-server.mdx` stale).

This PR was originally a parallel MCP Apps implementation; **#4761 merged the same (more complete) code first**, so the redundant code/tests/server-card changes have been dropped. What remains is the one gap #4761 left — the docs:

- `Server identifier: worldmonitor v1.10.0 → v1.11.0` (matches `SERVER_VERSION` + server-card).
- New **"MCP Apps (interactive UI)"** section under Resources: the two wire signals (`tools/list` `_meta.ui.resourceUri` + deprecated flat `ui/resourceUri` alias, `resources/list` `ui://` entry after the four data URIs), the `ui://worldmonitor/country-risk.html` resource (`text/html;profile=mcp-app`), and the **public + quota-exempt** `ui://` read.

Every claim was verified against the merged #4761 code: the registry emits both `_meta` forms, and the handler concats `UI_RESOURCE_LIST_RESPONSE` after the data URIs and promotes `ui://` reads to the public, quota-exempt path.

## Test plan

- [x] `docs:check` (docs-stats) — OK, 73 claims match code
- [x] `lint:md` — 0 errors
- [x] Rebased onto current `main` (incl. #4761); docs-only diff, **no code conflicts**

_(Separately filed #4764 — an unrelated flaky-test race surfaced during this work.)_