### PR TITLE
fix(mcp): anon-readable resources for orank mcp-resource-quality

### DIFF
--- a/api/api-route-exceptions.json
+++ b/api/api-route-exceptions.json
@@ -138,7 +138,7 @@
     {
       "path": "api/mcp/resources/index.ts",
       "category": "external-protocol",
-      "reason": "MCP RESOURCE_REGISTRY + buildResourceResponse + resources/list public-shape projection. Read-only addressable URIs surfaced via resources/list + resources/read JSON-RPC methods, shape dictated by the MCP spec. Routes resources/read through dispatchToolsCall for auth-symmetric Pro daily-quota deduction.",
+      "reason": "MCP resource registries (PUBLIC_RESOURCE_REGISTRY + TEMPLATE_RESOURCE_REGISTRY) + buildResourceResponse/buildPublicResourceResponse + resources/list + resources/templates/list public-shape projections. Read-only addressable URIs surfaced via the resources/list, resources/templates/list, and resources/read JSON-RPC methods, shape dictated by the MCP spec. Concrete public resources (metadata-only freshness probes) read anonymously + quota-free; data-bearing template instantiations route resources/read through dispatchToolsCall for auth-symmetric Pro daily-quota deduction.",
       "owner": "@SebastienMelki",
       "removal_issue": null
     },

--- a/api/mcp.ts
+++ b/api/mcp.ts
@@ -67,20 +67,37 @@ export type {
 export { compressDescription, utf8ByteLength } from './mcp/utils';
 
 export { buildPromptResponse, PROMPT_LIST_RESPONSE, PROMPT_REGISTRY } from './mcp/prompts/index';
-export { buildResourceResponse, RESOURCE_LIST_RESPONSE, RESOURCE_REGISTRY } from './mcp/resources/index';
+export {
+  buildPublicResourceResponse,
+  buildResourceResponse,
+  isPublicResourceUri,
+  PUBLIC_RESOURCE_REGISTRY,
+  RESOURCE_LIST_RESPONSE,
+  RESOURCE_TEMPLATE_LIST_RESPONSE,
+  TEMPLATE_RESOURCE_REGISTRY,
+} from './mcp/resources/index';
 export { CHOKEPOINT_SLUGS } from './mcp/resources/slugs';
 
 // Test-only escape hatch. Exposes the TOOL_REGISTRY by REFERENCE so mutations
 // inside `tests/mcp-tool-output-contracts.test.mjs` (which monkey-patches
 // `_execute` on individual RPC tools) propagate through the live binding.
-// PROMPT_REGISTRY + RESOURCE_REGISTRY follow the same live-binding contract
-// so tests that monkey-patch one (e.g. sabotage cases) observe the same
-// array the handler dispatches against.
+// PROMPT_REGISTRY + the resource registries follow the same live-binding
+// contract so tests that monkey-patch one (e.g. sabotage cases) observe the
+// same array the handler dispatches against. `RESOURCE_REGISTRY` maps to what
+// `resources/list` surfaces (the concrete PUBLIC_RESOURCE_REGISTRY) so the
+// capability-parity test's "advertised → non-empty registry" check stays
+// aligned with the wire; the data-bearing URI templates are exposed
+// separately as TEMPLATE_RESOURCE_REGISTRY.
 import { PROMPT_REGISTRY as __PROMPT_REGISTRY } from './mcp/prompts/index';
-import { RESOURCE_REGISTRY as __RESOURCE_REGISTRY } from './mcp/resources/index';
+import {
+  PUBLIC_RESOURCE_REGISTRY as __PUBLIC_RESOURCE_REGISTRY,
+  TEMPLATE_RESOURCE_REGISTRY as __TEMPLATE_RESOURCE_REGISTRY,
+} from './mcp/resources/index';
 import { TOOL_REGISTRY as __TOOL_REGISTRY } from './mcp/registry/index';
 export const __testing__ = {
   TOOL_REGISTRY: __TOOL_REGISTRY,
   PROMPT_REGISTRY: __PROMPT_REGISTRY,
-  RESOURCE_REGISTRY: __RESOURCE_REGISTRY,
+  RESOURCE_REGISTRY: __PUBLIC_RESOURCE_REGISTRY,
+  PUBLIC_RESOURCE_REGISTRY: __PUBLIC_RESOURCE_REGISTRY,
+  TEMPLATE_RESOURCE_REGISTRY: __TEMPLATE_RESOURCE_REGISTRY,
 };

--- a/api/mcp/constants.ts
+++ b/api/mcp/constants.ts
@@ -221,9 +221,35 @@ export const SERVER_NAME = 'worldmonitor';
 //     ui:// resource + tool `_meta`). Clients that don't speak MCP Apps
 //     ignore the extra resource + the reserved `_meta` field. No input/output
 //     schema change to any existing tool.
+// Bumped 1.11.0 → 1.12.0 (2026-07-04) reflecting:
+//   - Data resources split into two tiers by sensitivity, and a new
+//     `resources/templates/list` method:
+//       * `resources/list` now surfaces ONLY concrete, metadata-only DATA
+//         resources that are anonymously readable + quota-exempt (v1:
+//         `worldmonitor://seed-meta/freshness`, a market-bootstrap freshness
+//         probe returning only {cached_at, stale}). Alongside the v1.11.0
+//         ui:// app-shell resource, every `resources/list` entry now reads
+//         cleanly for an anonymous agent (or agent-readiness scanner) — a
+//         literal `{iso2}` template URI can never resolve, so the data
+//         templates no longer appear here.
+//       * `resources/templates/list` (new, in PUBLIC_MCP_METHODS, metadata-
+//         class, quota-exempt) surfaces the three data-bearing URI templates
+//         (country risk, chokepoint status, market quote). A concrete
+//         instantiation `resources/read` STILL routes through
+//         dispatchToolsCall and consumes the Pro daily quota symmetrically
+//         with the equivalent tools/call — the data-leak / quota-bypass
+//         protection is unchanged; only its discovery surface moved from
+//         resources/list to resources/templates/list.
+//   - `resources/read` of a PUBLIC (metadata-only) DATA resource is promoted
+//     to the anonymous + quota-exempt path per-request via
+//     `isPublicResourceUri` (parallel to the v1.11.0 `isUiResourceUri`
+//     promotion); data-bearing template reads stay fully gated.
+//   - No initialize capability key added — resources/templates/list is
+//     covered by the existing `resources` capability (the spec has no
+//     separate templates capability flag).
 // Keep aligned with public/.well-known/mcp/server-card.json::serverInfo.version
 // — discovery scanners cross-check both values.
-export const SERVER_VERSION = '1.11.0';
+export const SERVER_VERSION = '1.12.0';
 
 // MCP logging capability — valid severity levels per the 2025-03-26 spec
 // (RFC 5424 subset). Stateless HTTP transport: we ACK the level but do not
@@ -275,7 +301,7 @@ export const SERVER_INSTRUCTIONS = [
   '',
   'Issue prompts/list to discover pre-built workflow templates (country-briefing, energy-shock-watch, market-open-prep, conflict-pulse, route-risk-check, freshness-audit). Each prompt pre-bakes a JMESPath projection per step so the first execution lands on the right shape. prompts/list + prompts/get are quota-exempt (per-minute limit only).',
   '',
-  'Issue resources/list to discover four read-only addressable resource URIs (country risk, chokepoint status, seed-meta freshness, market quote). resources/read consumes the Pro daily quota IDENTICALLY to the equivalent tools/call — there is no free path around the cap via resources.',
+  'Issue resources/list for concrete read-only resources (v1: seed-meta freshness — anonymous + quota-free) and resources/templates/list for parameterised URI templates (country risk, chokepoint status, market quote). Substitute the template placeholder, then resources/read the concrete URI; a template read consumes the Pro daily quota IDENTICALLY to the equivalent tools/call — there is no free path around the cap via those resources.',
 ].join('\n');
 
 // Country-code whitelist for get_consumer_prices. The consumer-prices seeder

--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -18,7 +18,13 @@ import {
 import { dispatchToolsCall } from './dispatch';
 import { buildPromptResponse, PROMPT_LIST_RESPONSE } from './prompts/index';
 import { TOOL_LIST_BYTES, TOOL_LIST_RESPONSE } from './registry/index';
-import { buildResourceResponse, RESOURCE_LIST_RESPONSE } from './resources/index';
+import {
+  buildPublicResourceResponse,
+  buildResourceResponse,
+  isPublicResourceUri,
+  RESOURCE_LIST_RESPONSE,
+  RESOURCE_TEMPLATE_LIST_RESPONSE,
+} from './resources/index';
 import { rpcError, rpcOk, withMcpNoStore } from './rpc';
 import { buildUiResourceRead, isUiResourceUri, UI_RESOURCE_LIST_RESPONSE } from './ui/registry';
 import { emitTelemetry, principalIdForLog } from './telemetry';
@@ -28,21 +34,28 @@ import type { McpAuthContext, McpHandlerDeps } from './types';
 // discovery surface an agent (or an agent-readiness scanner) needs to learn
 // what this server is and what it exposes BEFORE authenticating — exactly the
 // metadata already published in the static server-card.json and the public
-// docs. `tools/list` and `resources/list` are BOTH catalog-enumeration methods
-// that return only public metadata (names, descriptions, URIs — no data, no
-// quota), so both are anonymously servable: a scanner that reads the
-// `resources` capability from `initialize` MUST be able to enumerate it, or the
-// capability reads as advertised-but-empty. Everything that returns DATA or
-// spends quota (`tools/call`, `resources/read`) — and the metadata methods the
-// product keeps gated (`prompts/list`, `logging/setLevel`) — still requires
-// credentials. `notifications/initialized` is the client's post-`initialize`
-// handshake notification (carries no data); leaving it public lets a strict MCP
-// client complete the handshake before calling `tools/list`.
+// docs. `tools/list`, `resources/list`, and `resources/templates/list` are all
+// catalog-enumeration methods that return only public metadata (names,
+// descriptions, URIs / URI templates — no data, no quota), so all are
+// anonymously servable: a scanner that reads the `resources` capability from
+// `initialize` MUST be able to enumerate it, or the capability reads as
+// advertised-but-empty. `resources/read` of a PUBLIC resource (a concrete,
+// metadata-only freshness/health probe — see PUBLIC_RESOURCE_REGISTRY) is
+// ALSO anonymously servable + quota-exempt; it is promoted to the public path
+// per-request via `isPublicResourceUri` below because it carries no billable
+// data. Everything that returns DATA or spends quota (`tools/call`, and
+// `resources/read` of a data-bearing TEMPLATE instantiation) — plus the
+// metadata methods the product keeps gated (`prompts/list`,
+// `logging/setLevel`) — still requires credentials. `notifications/initialized`
+// is the client's post-`initialize` handshake notification (carries no data);
+// leaving it public lets a strict MCP client complete the handshake before
+// calling `tools/list`.
 const PUBLIC_MCP_METHODS: ReadonlySet<string> = new Set([
   'initialize',
   'notifications/initialized',
   'tools/list',
   'resources/list',
+  'resources/templates/list',
 ]);
 
 // Mirror of resolveAuthContext's credential-header contract: does the request
@@ -55,10 +68,12 @@ function hasCredentials(req: Request): boolean {
 }
 
 // Spec-correct 401 for the fail-closed guards on data methods. These guards are
-// unreachable today (tools/call / resources/read are never PUBLIC_MCP_METHODS,
-// so `context` is always resolved), but if that invariant is ever broken this
-// fails closed with the SAME 401 + WWW-Authenticate shape resolveAuthContext
-// emits — not a soft 200 JSON-RPC error.
+// unreachable today (tools/call always runs the gated path, and a data-bearing
+// resources/read reaches its `!context` guard only AFTER the public-read branch
+// has already returned — so `context` is always resolved when the guard runs),
+// but if that invariant is ever broken this fails closed with the SAME 401 +
+// WWW-Authenticate shape resolveAuthContext emits — not a soft 200 JSON-RPC
+// error.
 function authRequiredResponse(id: unknown, resourceMetadataUrl: string, corsHeaders: Record<string, string>): Response {
   return new Response(
     JSON.stringify({ jsonrpc: '2.0', id: id ?? null, error: { code: -32001, message: 'Authentication required.' } }),
@@ -341,25 +356,31 @@ export async function mcpHandler(
 
   const { id, method } = body;
 
-  // MCP Apps (`io.modelcontextprotocol/ui`) gate promotion. A resources/read of
-  // a `ui://` resource returns a STATIC, data-free HTML app shell (the live
-  // data arrives later via host postMessage after a normal gated tools/call),
-  // so it carries no data and spends no quota — exactly like tools/list and
-  // resources/list. Promote it onto the anonymous discovery path so an
-  // unauthenticated MCP-Apps host (or agent-readiness scanner) can fetch the
-  // shell to render it. DATA reads (worldmonitor://…) stay fully gated +
+  // Anonymous-servable resources/read promotions. Two kinds of resource carry
+  // NO data and spend NO quota, so they are served on the anonymous discovery
+  // path (like tools/list / resources/list) — an unauthenticated MCP-Apps host
+  // or agent-readiness scanner can read them cleanly:
+  //   1. MCP Apps (`io.modelcontextprotocol/ui`): a `ui://` read returns a
+  //      STATIC, data-free HTML app shell (live data arrives later via host
+  //      postMessage after a normal gated tools/call).
+  //   2. PUBLIC data resources: a concrete, metadata-only freshness/health
+  //      probe (see PUBLIC_RESOURCE_REGISTRY) — exact-matched, so a data-
+  //      bearing template instantiation never qualifies.
+  // DATA reads (a `worldmonitor://…` template instantiation) stay fully gated +
   // Pro-quota-symmetric via the protected branch below.
-  const uiResourceReadUri = method === 'resources/read'
-    ? (() => {
-        const uri = (body.params as { uri?: unknown } | null)?.uri;
-        return typeof uri === 'string' && isUiResourceUri(uri) ? uri : null;
-      })()
+  const resourceReadUri = method === 'resources/read'
+    ? ((body.params as { uri?: unknown } | null)?.uri)
+    : undefined;
+  const uiResourceReadUri = typeof resourceReadUri === 'string' && isUiResourceUri(resourceReadUri)
+    ? resourceReadUri
     : null;
+  const isPublicResourceRead = typeof resourceReadUri === 'string' && isPublicResourceUri(resourceReadUri);
+  const isAnonResourceRead = uiResourceReadUri !== null || isPublicResourceRead;
 
   // Auth gate. `context` is null only on the anonymous discovery path; every
   // data/quota method below runs the full protected path and always sets it.
   let context: McpAuthContext | null = null;
-  if (PUBLIC_MCP_METHODS.has(method) || uiResourceReadUri !== null) {
+  if (PUBLIC_MCP_METHODS.has(method) || isAnonResourceRead) {
     if (hasCredentials(req)) {
       // Credentials presented on a public method are still validated so a
       // present-but-invalid key surfaces a 401 instead of a silent anon
@@ -447,32 +468,46 @@ export async function mcpHandler(
       if (!built.ok) return maybeStreamJsonRpcResponse(req, rpcError(id, built.code, built.message, corsHeaders));
       return maybeStreamJsonRpcResponse(req, rpcOk(id, { description: built.description, messages: built.messages }, corsHeaders));
     }
-    // Resources surface DATA — unlike prompts (metadata-class, quota-exempt)
-    // and describe_tool (metadata-class, quota-exempt), resources/read MUST
-    // consume the Pro daily quota IDENTICALLY to a tools/call to the
-    // equivalent tool. Asymmetric auth here is a known MCP data-leak
-    // vector (a Pro user at the daily cap could otherwise keep reading
-    // data via resources for free). The symmetry is structural:
-    // buildResourceResponse synthesizes a tools/call body and routes
-    // through dispatchToolsCall, inheriting the reservation + telemetry
-    // path. resources/list is metadata-class — a public catalog-enumeration
-    // method (in PUBLIC_MCP_METHODS, quota-exempt, anon-rate-limited) that
-    // returns only URIs/names/descriptions, never data. It uses no `context`.
+    // Resources split by data sensitivity. resources/list + the new
+    // resources/templates/list are metadata-class — public catalog-enumeration
+    // methods (in PUBLIC_MCP_METHODS, quota-exempt, anon-rate-limited) that
+    // return only URIs / URI templates + names + descriptions, never data.
+    // They use no `context`. resources/list surfaces the concrete PUBLIC
+    // resources (metadata-only, anon-readable); resources/templates/list
+    // surfaces the data-bearing URI templates.
     case 'resources/list':
-      // DATA resources (worldmonitor://…) lead; the MCP Apps `ui://` app-shell
-      // resources follow. Both are metadata-class (URIs/names/descriptions,
-      // no data) — anonymously enumerable so a scanner reading the `resources`
-      // capability sees the full catalog, including the ui:// surface that
-      // signals MCP Apps support.
+      // Concrete DATA resources (worldmonitor://…, the metadata-only PUBLIC
+      // freshness probe) lead; the MCP Apps `ui://` app-shell resources follow.
+      // Both are metadata-class (URIs/names/descriptions, no data) and read
+      // cleanly for an anonymous scanner reading the `resources` capability —
+      // including the ui:// surface that signals MCP Apps support. The
+      // data-bearing URI templates are surfaced separately via
+      // resources/templates/list (a literal `{iso2}` URI can't resolve, so it
+      // must not appear in a list an anonymous validator reads back).
       return maybeStreamJsonRpcResponse(req, rpcOk(id, { resources: [...RESOURCE_LIST_RESPONSE, ...UI_RESOURCE_LIST_RESPONSE] }, corsHeaders));
+    case 'resources/templates/list':
+      return maybeStreamJsonRpcResponse(req, rpcOk(id, { resourceTemplates: RESOURCE_TEMPLATE_LIST_RESPONSE }, corsHeaders));
     case 'resources/read':
       // MCP Apps `ui://` read: a static, data-free HTML app shell served on the
       // public path (no context, no quota, no dispatch). Resolved above into
-      // `uiResourceReadUri`; DATA reads fall through to the gated dispatcher.
+      // `uiResourceReadUri`.
       if (uiResourceReadUri) {
         return maybeStreamJsonRpcResponse(req, buildUiResourceRead(id, uiResourceReadUri, corsHeaders));
       }
-      // context is always set for DATA reads — those are never public.
+      // A PUBLIC data resource read (concrete, metadata-only freshness/health
+      // probe) is likewise served anonymously + quota-exempt via its direct
+      // reader — no data, no dispatchToolsCall, no Pro reservation.
+      if (isPublicResourceRead) {
+        return maybeStreamJsonRpcResponse(req, await buildPublicResourceResponse(body, corsHeaders));
+      }
+      // A data-bearing TEMPLATE instantiation MUST consume the Pro daily quota
+      // IDENTICALLY to a tools/call to the equivalent tool. Asymmetric auth
+      // here is a known MCP data-leak vector (a Pro user at the daily cap could
+      // otherwise keep reading data via resources for free). The symmetry is
+      // structural: buildResourceResponse synthesizes a tools/call body and
+      // routes through dispatchToolsCall, inheriting the reservation +
+      // telemetry path. `context` is always set here — a non-public
+      // resources/read runs the gated path above; the guard fails closed.
       if (!context) return authRequiredResponse(id, resourceMetadataUrl, corsHeaders);
       return maybeStreamJsonRpcResponse(req, await buildResourceResponse(req, context, deps, body, corsHeaders, ctx));
     case 'logging/setLevel': {

--- a/api/mcp/resources/index.ts
+++ b/api/mcp/resources/index.ts
@@ -1,11 +1,27 @@
-// MCP resources registry — four read-only addressable URIs surfaced via
-// resources/list + resources/read. Each entry routes through the SAME
-// dispatchToolsCall path the tools/call method uses, so auth, Pro daily
-// quota, telemetry, and per-tool budget gating are inherited unchanged —
-// asymmetric auth between resources and the equivalent tools/call is a
-// known MCP data-leak vector (a Pro user at the daily cap could otherwise
-// keep reading data through resources for free), so the symmetry is
-// load-bearing and proven by tests/mcp-resources.test.mjs.
+// MCP resources registry — split into two tiers by data sensitivity:
+//
+//   1. PUBLIC_RESOURCE_REGISTRY (surfaced via `resources/list`) — concrete,
+//      anonymously-readable, quota-exempt resources that return ONLY
+//      non-sensitive freshness / health metadata (never billable data). An
+//      anonymous agent (or an agent-readiness scanner) MUST be able to
+//      `resources/read` every entry `resources/list` advertises, so these
+//      are served without auth and without spending quota — the same public
+//      posture as `prompts/list` and `describe_tool`. Their `read()` runs a
+//      direct cache probe (no `dispatchToolsCall`, no Pro reservation).
+//
+//   2. TEMPLATE_RESOURCE_REGISTRY (surfaced via `resources/templates/list`) —
+//      data-bearing URI templates. A concrete instantiation `resources/read`
+//      routes through the SAME `dispatchToolsCall` path `tools/call` uses, so
+//      auth, Pro daily quota, telemetry, and per-tool budget gating are
+//      inherited unchanged. Asymmetric auth between resources and the
+//      equivalent `tools/call` is a known MCP data-leak / quota-bypass vector
+//      (a Pro user at the daily cap could otherwise keep reading data through
+//      resources for free), so the symmetry is load-bearing and proven by
+//      tests/mcp-resources.test.mjs. Templates live in
+//      `resources/templates/list` (NOT `resources/list`) because a literal
+//      `{iso2}` URI can never resolve to data — surfacing a template in
+//      `resources/list` would break an anonymous validator's `resources/read`
+//      probe of it.
 //
 // Stability contract:
 //   - URIs use canonical kebab-case slugs (CHOKEPOINT_SLUGS in ./slugs.ts)
@@ -15,23 +31,20 @@
 //   - Every resources/read response carries `cached_at` + `stale` in the
 //     content payload. Cache-tool-backed resources already have this from
 //     the cacheEnvelope shape; RPC-tool-backed resources (just country
-//     risk in v1) get the envelope explicitly wrapped here.
-//
-// Spec-shape note: resources/list returns the four template-shaped URIs
-// (e.g. `worldmonitor://countries/{iso2}/risk`) verbatim. Strict 2025-06-18
-// reading would route templates through resources/templates/list, but
-// surfacing them via resources/list is the pragmatic posture (Claude
-// Desktop / MCP Inspector both render the literal URI; the user / model
-// substitutes the placeholder before issuing resources/read). If a future
-// client complains, splitting out a templates/list method is a
-// non-breaking additive change.
+//     risk in v1) get the envelope explicitly wrapped here; the public
+//     seed-meta freshness resource IS the envelope.
 //
 // resources/read response shape (per MCP spec):
 //   { contents: [{ uri, mimeType, text }] }
 // where `text` is the JSON-stringified payload INCLUDING `cached_at` and
 // `stale`. mimeType is `application/json` for every resource here.
 
-import type { McpAuthContext, McpHandlerDeps, McpResourceDef } from '../types';
+import type {
+  McpAuthContext,
+  McpHandlerDeps,
+  PublicResourceDef,
+  TemplateResourceDef,
+} from '../types';
 import { dispatchToolsCall } from '../dispatch';
 import { evaluateFreshness } from '../freshness';
 import { rpcError, rpcOk, withMcpNoStore } from '../rpc';
@@ -40,16 +53,50 @@ import { readJsonFromUpstash } from '../../_upstash-json.js';
 import { CHOKEPOINT_SLUGS } from './slugs';
 
 // ---------------------------------------------------------------------------
-// Registry
+// Public resource freshness reader
 // ---------------------------------------------------------------------------
-// URI parsing is hand-rolled: four resources don't justify a URI-template
+// Market-data bootstrap freshness is a single seed-meta key at the same
+// 30-minute budget the get_market_data cache tool uses (api/mcp/registry/
+// cache-tools.ts `_seedMetaKey` / `_maxStaleMin`), so the envelope this
+// resource emits is identical to the freshness portion of a
+// get_market_data call — but computed WITHOUT dispatching the tool (no
+// data fetch, no Pro reservation), because the resource surfaces only the
+// envelope. Robust by construction: a missing/unreachable cache yields a
+// valid `{cached_at: null, stale: true}` envelope rather than an error,
+// so the anonymous read never surfaces empty content.
+const MARKET_FRESHNESS_CHECK = { key: 'seed-meta:market:stocks', maxStaleMin: 30 } as const;
+
+async function readMarketFreshness(): Promise<string> {
+  const meta = await readJsonFromUpstash(MARKET_FRESHNESS_CHECK.key).catch(() => null);
+  const { cached_at, stale } = evaluateFreshness([MARKET_FRESHNESS_CHECK], [meta]);
+  return JSON.stringify({ cached_at, stale });
+}
+
+// ---------------------------------------------------------------------------
+// Public (concrete, anon-readable, quota-exempt) resources → resources/list
+// ---------------------------------------------------------------------------
+export const PUBLIC_RESOURCE_REGISTRY: PublicResourceDef[] = [
+  {
+    uri: 'worldmonitor://seed-meta/freshness',
+    name: 'Seed-Meta Freshness',
+    description: 'Cache-freshness probe for the high-cadence market-data bootstrap pipeline. Returns ONLY the envelope (cached_at + stale) — no quote payload, no auth, no quota. Use this as a cheap health check to detect a stuck seeder. v1 covers market freshness only; an aggregate freshness resource spanning energy + maritime + risk feeds is a follow-up if customers ask.',
+    mimeType: 'application/json',
+    read: readMarketFreshness,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Template (data-bearing, gated, quota-symmetric) resources
+//   → resources/templates/list
+// ---------------------------------------------------------------------------
+// URI parsing is hand-rolled: three templates don't justify a URI-template
 // library. Each paramExtractor returns null when the URI doesn't even start
 // with the right prefix (cheap reject), an {ok: false, reason} when the
 // shape matches but a component is invalid, or an {ok: true, args} when
 // the URI resolves cleanly to synthetic tools/call arguments.
-export const RESOURCE_REGISTRY: McpResourceDef[] = [
+export const TEMPLATE_RESOURCE_REGISTRY: TemplateResourceDef[] = [
   {
-    uri: 'worldmonitor://countries/{iso2}/risk',
+    uriTemplate: 'worldmonitor://countries/{iso2}/risk',
     name: 'Country Risk',
     description: 'Composite Instability Index (CII) score 0–100 with unrest/conflict/security/news components, travel-advisory level, and OFAC sanctions exposure for a single ISO 3166-1 alpha-2 country. URI param {iso2} is lowercase alpha-2 (e.g. "de", "us", "ir").',
     mimeType: 'application/json',
@@ -71,7 +118,7 @@ export const RESOURCE_REGISTRY: McpResourceDef[] = [
     },
   },
   {
-    uri: 'worldmonitor://chokepoints/{slug}/status',
+    uriTemplate: 'worldmonitor://chokepoints/{slug}/status',
     name: 'Chokepoint Status',
     description: 'Maritime chokepoint transit summary: today total / tanker / cargo counts, week-over-week change, risk level, incident count, disruption percentage, and risk narrative. URI param {slug} is one of the hand-curated kebab-case identifiers (suez, strait-of-malacca, strait-of-hormuz, bab-el-mandeb, panama-canal, taiwan-strait, cape-of-good-hope, strait-of-gibraltar, bosphorus, korea-strait, dover-strait, kerch-strait, lombok-strait).',
     mimeType: 'application/json',
@@ -99,27 +146,7 @@ export const RESOURCE_REGISTRY: McpResourceDef[] = [
     },
   },
   {
-    uri: 'worldmonitor://seed-meta/freshness',
-    name: 'Seed-Meta Freshness',
-    description: 'Cache-freshness audit for the high-cadence market-data bootstrap pipeline. Returns only the envelope (cached_at + stale) — no quote payload. Use this as a cheap probe to detect a stuck seeder. v1 covers market freshness only; an aggregate freshness resource spanning energy + maritime + risk feeds is a follow-up if customers ask.',
-    mimeType: 'application/json',
-    tool: 'get_market_data',
-    paramExtractor: (uri: string) => {
-      if (uri !== 'worldmonitor://seed-meta/freshness') {
-        if (uri.startsWith('worldmonitor://seed-meta/')) {
-          return { ok: false, reason: 'Expected worldmonitor://seed-meta/freshness (no further path segments).' };
-        }
-        return null;
-      }
-      // summary: true collapses the payload to counts + samples (cheap
-      // wire shape); the jmespath projection then strips data entirely and
-      // emits only the envelope. The dispatcher's per-budget gate runs
-      // against the projected size — well under 1 KB.
-      return { ok: true, args: { summary: true, jmespath: '{cached_at: cached_at, stale: stale}' } };
-    },
-  },
-  {
-    uri: 'worldmonitor://markets/{symbol}/quote',
+    uriTemplate: 'worldmonitor://markets/{symbol}/quote',
     name: 'Market Quote',
     description: 'Single-symbol quote slice from the market-data bootstrap cache. URI param {symbol} is the uppercase ticker (e.g. "AAPL", "GC=F", "BTC-USD"). Matches equity / commodity / crypto / Gulf / sector / ETF-flow tickers — same case-insensitive matcher as get_market_data({symbols: [...]}).',
     mimeType: 'application/json',
@@ -144,11 +171,12 @@ export const RESOURCE_REGISTRY: McpResourceDef[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// resources/list public shape
+// Public list shapes
 // ---------------------------------------------------------------------------
 // Per MCP spec, resources/list entries carry {uri, name, description,
-// mimeType}. Internal authoring fields (tool, paramExtractor,
-// freshnessWrap) stay internal.
+// mimeType} and resources/templates/list entries carry {uriTemplate, name,
+// description, mimeType}. Internal authoring fields (tool, paramExtractor,
+// freshnessWrap, read) stay internal.
 export interface PublicResourceShape {
   uri: string;
   name: string;
@@ -156,22 +184,78 @@ export interface PublicResourceShape {
   mimeType: string;
 }
 
-export const RESOURCE_LIST_RESPONSE: PublicResourceShape[] = RESOURCE_REGISTRY.map((r) => ({
+export interface ResourceTemplateShape {
+  uriTemplate: string;
+  name: string;
+  description: string;
+  mimeType: string;
+}
+
+export const RESOURCE_LIST_RESPONSE: PublicResourceShape[] = PUBLIC_RESOURCE_REGISTRY.map((r) => ({
   uri: r.uri,
   name: r.name,
   description: r.description,
   mimeType: r.mimeType,
 }));
 
+export const RESOURCE_TEMPLATE_LIST_RESPONSE: ResourceTemplateShape[] = TEMPLATE_RESOURCE_REGISTRY.map((r) => ({
+  uriTemplate: r.uriTemplate,
+  name: r.name,
+  description: r.description,
+  mimeType: r.mimeType,
+}));
+
+// Exact-match set of the concrete public URIs. The handler consults this to
+// decide whether a `resources/read` is anonymously servable — ONLY the exact
+// concrete URIs in PUBLIC_RESOURCE_REGISTRY qualify; a template
+// instantiation (country risk, chokepoint, market quote) never does, so the
+// data-leak / quota-bypass protection on those is untouched.
+const PUBLIC_RESOURCE_URIS: ReadonlySet<string> = new Set(PUBLIC_RESOURCE_REGISTRY.map((r) => r.uri));
+
+export function isPublicResourceUri(uri: unknown): boolean {
+  return typeof uri === 'string' && PUBLIC_RESOURCE_URIS.has(uri);
+}
+
 // ---------------------------------------------------------------------------
-// resources/read dispatcher
+// resources/read — public (anonymous, quota-exempt) dispatcher
 // ---------------------------------------------------------------------------
-// Resolves a URI to its content by synthesizing a tools/call body and
-// invoking dispatchToolsCall — that path runs the same Pro daily-quota
-// reservation, telemetry emission, and per-tool budget gate the tools/call
-// surface does, so auth + quota symmetry is structural rather than
-// duplicated. Resource-shape wrapping happens AFTER dispatch returns:
-//   1. Match the URI; -32602 on no-match or malformed component.
+// Serves a concrete PUBLIC_RESOURCE_REGISTRY entry via its direct `read()`.
+// No auth context, no dispatchToolsCall, no Pro reservation — the content is
+// metadata-only (a freshness envelope), so this is safe to serve to an
+// anonymous caller, mirroring `prompts/list` / `describe_tool`. The handler
+// only routes a request here when `isPublicResourceUri(uri)` is true, so the
+// `-32602` fallback below is a fail-explicit guard for a broken invariant.
+export async function buildPublicResourceResponse(
+  body: { id?: unknown; params?: unknown },
+  corsHeaders: Record<string, string>,
+): Promise<Response> {
+  const outerId = body.id ?? null;
+  const params = body.params as { uri?: unknown } | null;
+  if (!params || typeof params.uri !== 'string') {
+    return rpcError(outerId, -32602, 'Invalid params: missing resource uri', corsHeaders);
+  }
+  const def = PUBLIC_RESOURCE_REGISTRY.find((r) => r.uri === params.uri);
+  if (!def) {
+    return rpcError(outerId, -32602, `Unknown public resource uri "${params.uri}".`, corsHeaders);
+  }
+  const text = await def.read();
+  return rpcOk(
+    outerId,
+    { contents: [{ uri: def.uri, mimeType: def.mimeType, text }] },
+    corsHeaders,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// resources/read — gated (auth + quota-symmetric) template dispatcher
+// ---------------------------------------------------------------------------
+// Resolves a concrete template instantiation to its content by synthesizing a
+// tools/call body and invoking dispatchToolsCall — that path runs the same
+// Pro daily-quota reservation, telemetry emission, and per-tool budget gate
+// the tools/call surface does, so auth + quota symmetry is structural rather
+// than duplicated. Resource-shape wrapping happens AFTER dispatch returns:
+//   1. Match the URI against a template; -32602 on no-match or malformed
+//      component.
 //   2. Synthesize a tools/call JSON-RPC body with the matched tool +
 //      extracted args.
 //   3. Await dispatchToolsCall — Response back is the standard JSON-RPC
@@ -183,7 +267,7 @@ export const RESOURCE_LIST_RESPONSE: PublicResourceShape[] = RESOURCE_REGISTRY.m
 //      `{cached_at, stale, data}`. For RPC-tool-backed resources (just
 //      country risk), read the configured seed-meta key and wrap with
 //      `{cached_at, stale, ...rawPayload}` so the freshness contract
-//      holds uniformly across all four resources.
+//      holds uniformly.
 //   5. Re-emit as resources/read shape: `{contents: [{uri, mimeType, text}]}`
 //      under the outer id, preserving the standard rpcOk envelope.
 export async function buildResourceResponse(
@@ -201,12 +285,12 @@ export async function buildResourceResponse(
   }
   const uri = params.uri;
 
-  // Find the first registry entry whose paramExtractor returns non-null.
+  // Find the first template entry whose paramExtractor returns non-null.
   // null = prefix mismatch (try next entry). ok:false = prefix matched but
   // component invalid (terminate with -32602). ok:true = resolved.
-  let matched: { def: McpResourceDef; args: Record<string, unknown> } | null = null;
+  let matched: { def: TemplateResourceDef; args: Record<string, unknown> } | null = null;
   let lastReason: string | null = null;
-  for (const def of RESOURCE_REGISTRY) {
+  for (const def of TEMPLATE_RESOURCE_REGISTRY) {
     const r = def.paramExtractor(uri);
     if (r === null) continue;
     if (!r.ok) {
@@ -221,7 +305,7 @@ export async function buildResourceResponse(
   }
   if (!matched) {
     const msg = lastReason
-      ?? `Unknown resource uri "${uri}". Issue resources/list to discover the four supported URI shapes.`;
+      ?? `Unknown resource uri "${uri}". Issue resources/list (concrete resources) and resources/templates/list (parameterised URI templates) to discover the supported URI shapes.`;
     return rpcError(outerId, -32602, msg, corsHeaders);
   }
 

--- a/api/mcp/resources/index.ts
+++ b/api/mcp/resources/index.ts
@@ -238,7 +238,17 @@ export async function buildPublicResourceResponse(
   if (!def) {
     return rpcError(outerId, -32602, `Unknown public resource uri "${params.uri}".`, corsHeaders);
   }
-  const text = await def.read();
+  // `read()` is documented "MUST be robust", but enforce it at the boundary so
+  // a future PUBLIC_RESOURCE_REGISTRY entry whose reader throws surfaces a clean
+  // -32603 (mirroring the sibling fail-explicit guards in buildResourceResponse)
+  // instead of bubbling an unhandled rejection through mcpHandler to the edge
+  // runtime. The current reader (readMarketFreshness) already catches internally.
+  let text: string;
+  try {
+    text = await def.read();
+  } catch {
+    return rpcError(outerId, -32603, 'Internal error: resource reader failed', corsHeaders);
+  }
   return rpcOk(
     outerId,
     { contents: [{ uri: def.uri, mimeType: def.mimeType, text }] },

--- a/api/mcp/types.ts
+++ b/api/mcp/types.ts
@@ -295,8 +295,34 @@ export type McpResourceExtractResult =
   | { ok: true; args: Record<string, unknown> }
   | { ok: false; reason: string };
 
-export interface McpResourceDef {
+// Concrete, anonymously-readable, quota-exempt resource surfaced via
+// `resources/list`. Its `read()` returns ONLY non-sensitive freshness /
+// health metadata (never billable data), so an anonymous agent (or an
+// agent-readiness scanner) can `resources/read` it cleanly — the same
+// public + quota-exempt posture as `prompts/list` and `describe_tool`.
+// `read` returns the wire-ready `content[0].text` and MUST be robust:
+// it returns a valid envelope even when the upstream cache read fails, so
+// the read never surfaces empty content or a 5xx to the caller.
+export interface PublicResourceDef {
   uri: string;
+  name: string;
+  description: string;
+  mimeType: string;
+  read: () => Promise<string>;
+}
+
+// Data-bearing URI TEMPLATE surfaced via `resources/templates/list`. A
+// concrete instantiation `resources/read` routes through
+// `dispatchToolsCall`, inheriting Pro daily-quota symmetry with the
+// equivalent `tools/call` — asymmetric auth here is a known MCP data-leak /
+// quota-bypass vector (a Pro user at the daily cap could otherwise keep
+// reading data through resources for free), so these stay gated. Templates
+// live in `resources/templates/list` (NOT `resources/list`) because a
+// literal `{iso2}` URI can never resolve to data; only the substituted form
+// reads — surfacing a template in `resources/list` breaks an anonymous
+// validator's `resources/read` probe.
+export interface TemplateResourceDef {
+  uriTemplate: string;
   name: string;
   description: string;
   mimeType: string;

--- a/docs/mcp-error-catalog.mdx
+++ b/docs/mcp-error-catalog.mdx
@@ -104,7 +104,7 @@ Example payload (Pro variant — env_key clients get the same envelope shape wit
 }
 ```
 
-**Pro/OAuth daily cap — HTTP 429 + `Retry-After`.** Hard daily cap (default **50 quota-consuming calls / UTC day**) enforced by an atomic Redis reservation BEFORE the tool runs, so the exact call that crosses the boundary rejects. Only `tools/call` and `resources/read` (the auth-symmetric resources path) count. `wm_…` API-key MCP callers do not enter this MCP daily reservation path; they are protected here by the 60 requests/minute/key limiter, while broader REST/API plan allowances are enforced outside the MCP handler. **Exempt from the Pro/OAuth daily cap:** `describe_tool`, `tools/list`, `prompts/list`, `prompts/get`, `resources/list`, `logging/setLevel`, `initialize`, `notifications/initialized`, `ping`. (These methods still count toward the per-minute limit above — daily and per-minute exemption sets are different.)
+**Pro/OAuth daily cap — HTTP 429 + `Retry-After`.** Hard daily cap (default **50 quota-consuming calls / UTC day**) enforced by an atomic Redis reservation BEFORE the tool runs, so the exact call that crosses the boundary rejects. Only `tools/call` and `resources/read` of a data-bearing **URI-template instantiation** (the auth-symmetric resources path) count. `wm_…` API-key MCP callers do not enter this MCP daily reservation path; they are protected here by the 60 requests/minute/key limiter, while broader REST/API plan allowances are enforced outside the MCP handler. **Exempt from the Pro/OAuth daily cap:** `describe_tool`, `tools/list`, `prompts/list`, `prompts/get`, `resources/list`, `resources/templates/list`, `logging/setLevel`, `initialize`, `notifications/initialized`, `ping`, and `resources/read` of a **public** (concrete, metadata-only) resource such as `worldmonitor://seed-meta/freshness`. (These methods still count toward the per-minute limit above — daily and per-minute exemption sets are different.)
 
 ```json
 {
@@ -141,7 +141,7 @@ Fires when the request body either isn't valid JSON or is valid JSON without a s
 
 ### `-32601` — Method not found
 
-The `method` field was a string but didn't match any handler. Methods this server speaks: `initialize`, `notifications/initialized`, `ping`, `tools/list`, `tools/call`, `prompts/list`, `prompts/get`, `resources/list`, `resources/read`, `logging/setLevel`.
+The `method` field was a string but didn't match any handler. Methods this server speaks: `initialize`, `notifications/initialized`, `ping`, `tools/list`, `tools/call`, `prompts/list`, `prompts/get`, `resources/list`, `resources/templates/list`, `resources/read`, `logging/setLevel`.
 
 ```json
 {
@@ -163,7 +163,7 @@ The most common error code, shared across `tools/call`, `prompts/get`, `resource
 | `tools/call` with `name` that isn't in the registry    | `api/mcp/dispatch.ts:117`         | `Unknown tool: get_foo`                                                    |
 | `prompts/get` with no/non-string `name`                | `api/mcp/handler.ts:133`          | `Invalid params: missing prompt name`                                      |
 | `prompts/get` with unknown name or missing required arg | `api/mcp/prompts/index.ts:302/310` | `Unknown prompt: …` / `Missing required argument "iso2" for prompt "country-briefing"` |
-| `resources/read` with no/unknown/malformed `uri`       | `api/mcp/resources/index.ts:200/223` | `Invalid params: missing resource uri` / `Unknown resource uri "..."` |
+| `resources/read` with no/unknown/malformed `uri`       | `api/mcp/resources/index.ts` (`buildPublicResourceResponse` / `buildResourceResponse`) | `Invalid params: missing resource uri` / `Unknown resource uri "..."` |
 | `logging/setLevel` with non-string or out-of-set level | `api/mcp/handler.ts:156`          | `Invalid params: level must be one of debug, info, notice, warning, error, critical, alert, emergency` |
 
 ```json
@@ -174,7 +174,7 @@ The most common error code, shared across `tools/call`, `prompts/get`, `resource
 }
 ```
 
-**What to do.** Read the `message` — it always tells you what was missing or wrong. For tools, names are in `tools/list`. For prompts, names + argument schemas are in `prompts/list`. For resources, the four supported URI shapes are in `resources/list`. For `logging/setLevel`, valid levels are the [RFC 5424 subset](https://www.rfc-editor.org/rfc/rfc5424#section-6.2.1) listed above.
+**What to do.** Read the `message` — it always tells you what was missing or wrong. For tools, names are in `tools/list`. For prompts, names + argument schemas are in `prompts/list`. For resources, the concrete URIs are in `resources/list` and the parameterised URI templates are in `resources/templates/list`. For `logging/setLevel`, valid levels are the [RFC 5424 subset](https://www.rfc-editor.org/rfc/rfc5424#section-6.2.1) listed above.
 
 ### `-32603` — Internal error
 

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -54,7 +54,7 @@ The replay buffer is in-memory and bounded per edge instance. Treat `Last-Event-
 
 ## Authentication
 
-**Discovery is public.** `initialize`, `tools/list`, `resources/list`, and the `notifications/initialized` handshake are servable **without credentials**, so any agent (or agent-readiness scanner) can connect to `https://worldmonitor.app/mcp`, read the server identity, and enumerate the full tool and resource catalogs before authenticating — the same metadata already published in the static [server card](https://worldmonitor.app/.well-known/mcp/server-card.json). Both `tools/list` and `resources/list` return only public catalog metadata (names, descriptions, URIs — no data, no quota). Anonymous discovery is rate-limited to 60 requests/minute per client IP. Everything that returns data or spends quota (`tools/call`, `resources/read`) — and the gated metadata methods `prompts/list` and `logging/setLevel` — still requires one of the two auth modes below. A credential presented on a discovery method is still validated (a bad key returns `401`, never a silent anonymous downgrade).
+**Discovery is public.** `initialize`, `tools/list`, `resources/list`, `resources/templates/list`, and the `notifications/initialized` handshake are servable **without credentials**, so any agent (or agent-readiness scanner) can connect to `https://worldmonitor.app/mcp`, read the server identity, and enumerate the full tool and resource catalogs before authenticating — the same metadata already published in the static [server card](https://worldmonitor.app/.well-known/mcp/server-card.json). `tools/list`, `resources/list`, and `resources/templates/list` return only public catalog metadata (names, descriptions, URIs / URI templates — no data, no quota). `resources/read` of a **public** resource (a concrete, metadata-only freshness/health probe surfaced by `resources/list`, such as `worldmonitor://seed-meta/freshness`) is **also public and quota-free** — an anonymous agent can read it cleanly. Anonymous discovery is rate-limited to 60 requests/minute per client IP. Everything that returns data or spends quota (`tools/call`, and `resources/read` of a data-bearing **URI-template instantiation** — country risk, chokepoint status, market quote) — plus the gated metadata methods `prompts/list` and `logging/setLevel` — still requires one of the two auth modes below. A credential presented on a discovery method is still validated (a bad key returns `401`, never a silent anonymous downgrade).
 
 The MCP handler accepts two auth modes, in priority order:
 
@@ -103,8 +103,8 @@ If you'd rather paste an API key (Starter+ / scripted clients), expand "Use API 
 ### Daily limit (Pro tier)
 
 - **50 quota-consuming calls per UTC day**, reset at 00:00 UTC.
-- `tools/call` and `resources/read` consume the Pro daily quota, except the metadata helper `describe_tool`.
-- `initialize`, `tools/list`, `prompts/list`, `prompts/get`, `resources/list`, `logging/setLevel`, `notifications/initialized`, `ping`, and `describe_tool` do **not** count against the daily cap.
+- `tools/call` and `resources/read` of a data-bearing **URI-template instantiation** consume the Pro daily quota, except the metadata helper `describe_tool`.
+- `initialize`, `tools/list`, `prompts/list`, `prompts/get`, `resources/list`, `resources/templates/list`, `logging/setLevel`, `notifications/initialized`, `ping`, and `describe_tool` do **not** count against the daily cap. `resources/read` of a **public** resource (a metadata-only freshness/health probe, e.g. `worldmonitor://seed-meta/freshness`) is likewise exempt — it carries no billable data.
 - Hitting the cap returns JSON-RPC error `-32029` plus HTTP `429` with a `Retry-After` header pointing at the next UTC midnight.
 - The cap is hard: concurrent `tools/call` or `resources/read` requests near the boundary use an atomic Redis reservation, so exactly the call that crosses 50 rejects.
 
@@ -358,23 +358,30 @@ In addition to the 39 tools, WorldMonitor exposes MCP prompts and resources so c
 
 ### Resources
 
-`resources/list` returns four read-only URI shapes:
+Resources come in two tiers. **Concrete resources** are surfaced by `resources/list` and read anonymously and quota-free; **URI templates** (parameterised, data-bearing) are surfaced by `resources/templates/list` and each concrete instantiation reads under auth + the Pro daily quota.
 
-| Resource URI shape | Backing data |
-|--------------------|--------------|
+`resources/list` — concrete, anonymously readable, quota-free:
+
+| Resource URI | Backing data |
+|--------------|--------------|
+| `worldmonitor://seed-meta/freshness` | Market-data bootstrap freshness envelope only: `cached_at` and `stale`. A cheap health probe to detect a stuck seeder — no auth, no quota. |
+
+`resources/templates/list` — parameterised URI templates. Substitute the placeholder, then `resources/read` the concrete URI (auth required; consumes the Pro daily quota symmetrically with the equivalent `tools/call`):
+
+| Resource URI template | Backing data |
+|-----------------------|--------------|
 | `worldmonitor://countries/{iso2}/risk` | Country risk score, component breakdown, travel advisory, and sanctions exposure. `{iso2}` is lowercase alpha-2, for example `de` or `us`. |
 | `worldmonitor://chokepoints/{slug}/status` | Chokepoint transit summary and risk narrative. `{slug}` is one of the published kebab-case chokepoint slugs, such as `suez`, `strait-of-hormuz`, or `bab-el-mandeb`. |
-| `worldmonitor://seed-meta/freshness` | Market-data bootstrap freshness envelope only: `cached_at` and `stale`. |
 | `worldmonitor://markets/{symbol}/quote` | Single-symbol market quote slice. `{symbol}` is uppercase, for example `AAPL`, `GC=F`, or `BTC-USD`. |
 
-`resources/list` is metadata and does not consume the Pro daily quota. `resources/read` on a `worldmonitor://` data URI intentionally does consume the same daily quota slot as the equivalent `tools/call`; it routes through the same dispatcher so resources cannot bypass the Pro cap. As with every MCP method, both `resources/list` and `resources/read` still count toward the 60/minute limiter. For the exact `-32029` status/header differences between per-minute throttling and daily quota exhaustion, see the [MCP Error Catalog](/mcp-error-catalog#-32029--rate-limited-per-minute-or-daily).
+`resources/list` and `resources/templates/list` are metadata and do not consume the Pro daily quota. `resources/read` of a template instantiation intentionally consumes the same daily quota slot as the equivalent `tools/call`; it routes through the same dispatcher so a data-bearing resource cannot bypass the Pro cap. `resources/read` of a public (concrete) resource is quota-free — it returns only metadata. As with every MCP method, all of these still count toward the 60/minute limiter. For the exact `-32029` status/header differences between per-minute throttling and daily quota exhaustion, see the [MCP Error Catalog](/mcp-error-catalog#-32029--rate-limited-per-minute-or-daily).
 
 ### MCP Apps (interactive UI)
 
 The server supports [MCP Apps](https://modelcontextprotocol.io/extensions/apps/build) (extension `io.modelcontextprotocol/ui`, spec `2026-01-26`) — interactive views a host renders in a sandboxed iframe when a linked tool is called. Two wire signals drive it:
 
 - **`tools/list`** advertises the linkage on the tool. `get_country_risk` carries `_meta.ui.resourceUri` (and the deprecated flat `ui/resourceUri` alias) pointing at its UI resource.
-- **`resources/list`** surfaces the UI resource itself, after the four data URIs:
+- **`resources/list`** surfaces the UI resource itself, alongside the concrete data resource (the parameterised data templates live in `resources/templates/list`):
 
 | UI resource URI | mimeType | Renders |
 |-----------------|----------|---------|

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -1,11 +1,11 @@
 {
   "name": "worldmonitor",
   "description": "WorldMonitor's live global-intelligence stack as an MCP server: real-time markets, conflict events, aviation, maritime, energy, climate, health, displacement, supply chain, and AI-generated regional briefs.",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "serverUrl": "https://worldmonitor.app/mcp",
   "serverInfo": {
     "name": "worldmonitor",
-    "version": "1.11.0",
+    "version": "1.12.0",
     "description": "WorldMonitor's live global-intelligence stack as an MCP server: real-time markets, conflict events, aviation, maritime, energy, climate, health, displacement, supply chain, and AI-generated regional briefs.",
     "vendor": "WorldMonitor",
     "homepage": "https://www.worldmonitor.app"
@@ -216,7 +216,7 @@
       "apiBusiness": null,
       "enterprise": null
     },
-    "notes": "MCP hard daily reservation is currently enforced for Pro/OAuth contexts only: tools/call and resources/read reserve against the 50/day Pro counter, except describe_tool. API-key (env_key, wm_...) MCP callers do not use this MCP daily reservation path; they are protected here by the 60/min per-key limiter, while broader REST/API plan allowances are enforced outside the MCP handler. Exempt Pro/OAuth daily-quota methods: initialize, tools/list, prompts/list, prompts/get, resources/list, logging/setLevel, notifications/initialized, and ping. The describe_tool tools/call is also exempt (v1.5.0 metadata escape hatch; SERVER_INSTRUCTIONS encourages calling it freely while exploring). resources/read intentionally counts toward the Pro/OAuth cap symmetrically with the equivalent tools/call. Per-minute (60/min, per-user on OAuth contexts, per-key on API-key contexts) counts ALL methods, so a tight discovery probe loop on tools/list or logging/setLevel will still trip the throttle."
+    "notes": "MCP hard daily reservation is currently enforced for Pro/OAuth contexts only: tools/call and resources/read of a data-bearing URI-template instantiation reserve against the 50/day Pro counter, except describe_tool. API-key (env_key, wm_...) MCP callers do not use this MCP daily reservation path; they are protected here by the 60/min per-key limiter, while broader REST/API plan allowances are enforced outside the MCP handler. Exempt Pro/OAuth daily-quota methods: initialize, tools/list, prompts/list, prompts/get, resources/list, resources/templates/list, logging/setLevel, notifications/initialized, and ping. The describe_tool tools/call is also exempt (v1.5.0 metadata escape hatch; SERVER_INSTRUCTIONS encourages calling it freely while exploring). resources/read of a public (concrete, metadata-only) resource such as worldmonitor://seed-meta/freshness is also exempt and anonymously readable; resources/read of a template instantiation intentionally counts toward the Pro/OAuth cap symmetrically with the equivalent tools/call. Per-minute (60/min, per-user on OAuth contexts, per-key on API-key contexts) counts ALL methods, so a tight discovery probe loop on tools/list or logging/setLevel will still trip the throttle."
   },
   "tags": [
     "geopolitical-intelligence",

--- a/tests/live-api-cache-auth-regression.test.mjs
+++ b/tests/live-api-cache-auth-regression.test.mjs
@@ -192,6 +192,30 @@ describe(`live API cache/auth regression sweep (${LIVE ? 'ENABLED' : 'SKIPPED - 
       'anonymous resources/list must enumerate a non-empty resource catalog',
     );
 
+    // orank mcp-resource-quality: EVERY resources/list entry must resources/read
+    // cleanly for an anonymous caller. The catalog is now all concrete,
+    // metadata-only resources, so an anonymous resources/read of each must
+    // return a non-empty application/json content payload — not a 401.
+    for (const resource of resourceBody.result.resources) {
+      const read = await fetchText(`${WEB_BASE}/mcp`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 4, method: 'resources/read', params: { uri: resource.uri } }),
+      });
+      assert.equal(read.resp.status, 200,
+        `anonymous resources/read ${resource.uri} must be public (orank mcp-resource-quality)`);
+      assertNoStore(read.resp, `MCP anonymous resources/read ${resource.uri}`);
+      const readBody = JSON.parse(read.bodyText);
+      assert.equal(readBody.error, undefined,
+        `anonymous resources/read ${resource.uri} must not error: ${JSON.stringify(readBody.error)}`);
+      const content = readBody.result?.contents?.[0];
+      assert.equal(content?.mimeType, 'application/json',
+        `resources/read ${resource.uri} must declare a valid mimeType`);
+      assert.ok(typeof content?.text === 'string' && content.text.length > 0,
+        `resources/read ${resource.uri} must return non-empty content`);
+      JSON.parse(content.text); // valid JSON for the declared mimeType
+    }
+
     // A DATA/quota method stays gated: unauthenticated `tools/call` must be a
     // no-store, dynamic 401 carrying the OAuth resource_metadata hint.
     const post = await fetchText(`${WEB_BASE}/mcp`, {

--- a/tests/mcp-capability-parity.test.mjs
+++ b/tests/mcp-capability-parity.test.mjs
@@ -224,6 +224,7 @@ describe('api/mcp.ts — capability parity (advertised AND non-empty)', () => {
       'prompts/list',
       'prompts/get',
       'resources/list',
+      'resources/templates/list',
       'logging/setLevel',
       'notifications/initialized',
       'ping',

--- a/tests/mcp-jmespath.test.mjs
+++ b/tests/mcp-jmespath.test.mjs
@@ -300,12 +300,12 @@ describe('api/mcp.ts — JMESPath projection (v1.7.0)', () => {
   // Initialize handshake — version + instructions
   // ============================================================
   describe('initialize handshake', () => {
-    it('serverInfo.version === "1.11.0"', async () => {
+    it('serverInfo.version === "1.12.0"', async () => {
       // Tracks current SERVER_VERSION. Each minor bump needs to update
       // this assertion + the cross-check at line 327 below.
       const res = await mod.default(makeReq(initBody(1)));
       const body = await res.json();
-      assert.equal(body.result?.serverInfo?.version, '1.11.0');
+      assert.equal(body.result?.serverInfo?.version, '1.12.0');
     });
 
     it('result.instructions is present and mentions jmespath', async () => {
@@ -326,12 +326,12 @@ describe('api/mcp.ts — JMESPath projection (v1.7.0)', () => {
       assert.ok(/daily quota/i.test(inst), 'missing quota note');
     });
 
-    it('server-card.json version matches SERVER_VERSION (currently 1.11.0)', () => {
+    it('server-card.json version matches SERVER_VERSION (currently 1.12.0)', () => {
       // Cross-check the comment at api/mcp.ts:~56 — discovery scanners
       // verify both values; a future bump that misses one would break
       // discovery. This is the test that prevents that drift.
       const card = JSON.parse(readFileSync(new URL('../public/.well-known/mcp/server-card.json', import.meta.url), 'utf8'));
-      assert.equal(card.serverInfo.version, '1.11.0');
+      assert.equal(card.serverInfo.version, '1.12.0');
       assert.equal(card.features?.responseProjection, 'jmespath');
     });
 

--- a/tests/mcp-resources.test.mjs
+++ b/tests/mcp-resources.test.mjs
@@ -49,6 +49,16 @@ function envKeyReq(body, headers = {}) {
   });
 }
 
+// Anonymous request (NO credentials) — exercises the public-discovery /
+// public-resource-read path an agent-readiness scanner (orank) uses.
+function anonReq(body, headers = {}) {
+  return new Request(BASE_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
 // resources/read JSON-RPC body factory.
 function readBody(uri, id = 100) {
   return { jsonrpc: '2.0', id, method: 'resources/read', params: { uri } };
@@ -143,7 +153,8 @@ function installMockFetch({ riskPayload = null } = {}) {
 
 let handler;
 let mcpHandler;
-let RESOURCE_REGISTRY;
+let PUBLIC_RESOURCE_REGISTRY;
+let TEMPLATE_RESOURCE_REGISTRY;
 let TOOL_REGISTRY;
 let CHOKEPOINT_SLUGS;
 
@@ -160,7 +171,8 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
     const mod = await import(`../api/mcp.ts?t=${Date.now()}-resources`);
     handler = mod.default;
     mcpHandler = mod.mcpHandler;
-    RESOURCE_REGISTRY = mod.__testing__.RESOURCE_REGISTRY;
+    PUBLIC_RESOURCE_REGISTRY = mod.__testing__.PUBLIC_RESOURCE_REGISTRY;
+    TEMPLATE_RESOURCE_REGISTRY = mod.__testing__.TEMPLATE_RESOURCE_REGISTRY;
     TOOL_REGISTRY = mod.__testing__.TOOL_REGISTRY;
     CHOKEPOINT_SLUGS = mod.CHOKEPOINT_SLUGS;
   });
@@ -197,28 +209,25 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
   // -------------------------------------------------------------------------
   // resources/list shape
   // -------------------------------------------------------------------------
-  it('resources/list leads with the four DATA URIs, then the ui:// MCP-Apps shell', async () => {
+  it('resources/list returns only concrete anon-readable resources: DATA freshness probe + ui:// shell, no {template} URIs', async () => {
     const res = await handler(envKeyReq({ jsonrpc: '2.0', id: 2, method: 'resources/list', params: {} }));
     assert.equal(res.status, 200);
     const body = await res.json();
     assert.ok(Array.isArray(body.result?.resources), 'result.resources must be an array');
-    // Four DATA resources + one MCP Apps ui:// app-shell resource (v1.11.0).
-    assert.equal(body.result.resources.length, 5, `Expected 5 resources, got ${body.result.resources.length}`);
-
-    // DATA URIs lead, in documented order; the ui:// shell follows.
-    const expectedUris = [
-      'worldmonitor://countries/{iso2}/risk',
-      'worldmonitor://chokepoints/{slug}/status',
-      'worldmonitor://seed-meta/freshness',
-      'worldmonitor://markets/{symbol}/quote',
-      'ui://worldmonitor/country-risk.html',
-    ];
+    // resources/list = concrete DATA resource(s) (metadata-only, anon-readable)
+    // + the MCP Apps ui:// app-shell (v1.11.0). NO {placeholder} templates —
+    // those moved to resources/templates/list (a literal {iso2} can't resolve,
+    // which would break an anonymous validator's resources/read probe).
     const actualUris = body.result.resources.map((r) => r.uri);
-    assert.deepEqual(actualUris, expectedUris, 'resource URIs and order must match the documented set (DATA first, ui:// last)');
-
+    assert.deepEqual(actualUris, [
+      'worldmonitor://seed-meta/freshness',
+      'ui://worldmonitor/country-risk.html',
+    ], 'resources/list = concrete DATA freshness probe then ui:// shell, in order');
     for (const r of body.result.resources) {
       assert.equal(typeof r.uri, 'string', `resource ${r.uri}: uri must be a string`);
       assert.ok(r.uri.length > 0, `resource ${r.uri}: uri must be non-empty`);
+      assert.doesNotMatch(r.uri, /[{}]/,
+        `resource ${r.uri}: resources/list must not contain template {placeholder} URIs (use resources/templates/list)`);
       assert.equal(typeof r.name, 'string', `resource ${r.uri}: name must be a string`);
       assert.equal(typeof r.description, 'string', `resource ${r.uri}: description must be a string`);
       // Per-uri mimeType: DATA resources are application/json; the MCP Apps
@@ -226,6 +235,7 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
       const expectedMime = r.uri.startsWith('ui://') ? 'text/html;profile=mcp-app' : 'application/json';
       assert.equal(r.mimeType, expectedMime, `resource ${r.uri}: mimeType must be ${expectedMime}`);
       // Internal authoring fields must NOT leak via resources/list.
+      assert.equal(r.read, undefined, `resource ${r.uri}: internal "read" must not leak via resources/list`);
       assert.equal(r.tool, undefined, `resource ${r.uri}: internal "tool" must not leak via resources/list`);
       assert.equal(r.paramExtractor, undefined, `resource ${r.uri}: internal "paramExtractor" must not leak via resources/list`);
       assert.equal(r.freshnessWrap, undefined, `resource ${r.uri}: internal "freshnessWrap" must not leak via resources/list`);
@@ -350,6 +360,64 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
     for (const uri of listedUiUris) {
       assert.ok(linkedByTools.has(uri),
         `ui:// resource "${uri}" is advertised but no tool references it via _uiResourceUri`);
+    }
+  });
+
+  it('resources/templates/list returns the three data-bearing URI templates', async () => {
+    const res = await handler(envKeyReq({ jsonrpc: '2.0', id: 3, method: 'resources/templates/list', params: {} }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(Array.isArray(body.result?.resourceTemplates), 'result.resourceTemplates must be an array');
+
+    const expectedTemplates = [
+      'worldmonitor://countries/{iso2}/risk',
+      'worldmonitor://chokepoints/{slug}/status',
+      'worldmonitor://markets/{symbol}/quote',
+    ];
+    const actualTemplates = body.result.resourceTemplates.map((r) => r.uriTemplate);
+    assert.deepEqual(actualTemplates, expectedTemplates,
+      'resource template URIs and order must match the documented set');
+
+    for (const r of body.result.resourceTemplates) {
+      assert.equal(typeof r.uriTemplate, 'string', `template ${r.uriTemplate}: uriTemplate must be a string`);
+      assert.match(r.uriTemplate, /\{[a-z0-9]+\}/i, `template ${r.uriTemplate}: must contain a {placeholder}`);
+      assert.equal(typeof r.name, 'string', `template ${r.uriTemplate}: name must be a string`);
+      assert.equal(typeof r.description, 'string', `template ${r.uriTemplate}: description must be a string`);
+      assert.equal(r.mimeType, 'application/json', `template ${r.uriTemplate}: mimeType must be application/json`);
+      // Internal authoring fields must NOT leak via resources/templates/list.
+      assert.equal(r.tool, undefined, `template ${r.uriTemplate}: internal "tool" must not leak`);
+      assert.equal(r.paramExtractor, undefined, `template ${r.uriTemplate}: internal "paramExtractor" must not leak`);
+      assert.equal(r.freshnessWrap, undefined, `template ${r.uriTemplate}: internal "freshnessWrap" must not leak`);
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // orank mcp-resource-quality — every resources/list entry must resources/read
+  // cleanly for an ANONYMOUS caller (no credentials). This is the exact probe
+  // an agent-readiness scanner runs; a 401 here is the failure it reports.
+  // -------------------------------------------------------------------------
+  it('ANON: every resources/list entry reads cleanly without credentials (orank mcp-resource-quality)', async () => {
+    const listRes = await handler(anonReq({ jsonrpc: '2.0', id: 1, method: 'resources/list', params: {} }));
+    assert.equal(listRes.status, 200, 'anonymous resources/list must be public');
+    const listBody = await listRes.json();
+    const uris = listBody.result.resources.map((r) => r.uri);
+    assert.ok(uris.length >= 1, 'resources/list must advertise at least one resource');
+
+    for (const uri of uris) {
+      const res = await handler(anonReq(readBody(uri)));
+      assert.equal(res.status, 200, `anonymous resources/read ${uri} must return 200, got ${res.status}`);
+      const body = await res.json();
+      assert.equal(body.error, undefined,
+        `anonymous resources/read ${uri} must not error, got ${JSON.stringify(body.error)}`);
+      const c = body.result?.contents?.[0];
+      assert.ok(c, `resources/read ${uri} must return a content entry`);
+      // Mixed catalog: concrete DATA resources are application/json; the ui://
+      // shell is text/html;profile=mcp-app. orank requires a valid declared
+      // mimeType + non-empty content for every entry.
+      assert.ok(typeof c.mimeType === 'string' && c.mimeType.length > 0,
+        `resources/read ${uri}: must declare a mimeType`);
+      assert.ok(typeof c.text === 'string' && c.text.length > 0, `resources/read ${uri}: content must be non-empty`);
+      if (c.mimeType === 'application/json') JSON.parse(c.text); // valid JSON for the declared type
     }
   });
 
@@ -549,11 +617,10 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
       `auth symmetry: tools/call counter delta (${pipeT.count}) must equal resources/read counter delta (${pipeR.count})`);
   });
 
-  it('Pro resources/read on cache-tool-backed URIs (markets, chokepoints, seed-meta) also increments counter by 1 each', async () => {
+  it('Pro resources/read on data-bearing template URIs (markets, chokepoints) increments counter by 1 each', async () => {
     const uris = [
       'worldmonitor://markets/AAPL/quote',
       'worldmonitor://chokepoints/suez/status',
-      'worldmonitor://seed-meta/freshness',
     ];
     for (const uri of uris) {
       const { deps, pipe } = makeProDeps({ pipelineOpts: { initialCount: 0 } });
@@ -564,6 +631,40 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
       assert.equal(pipe.count, 1,
         `${uri} MUST increment Pro counter by exactly 1, got ${pipe.count}`);
     }
+  });
+
+  it('PUBLIC seed-meta/freshness resources/read is quota-exempt (metadata-class, mirrors resources/list) even for Pro', async () => {
+    const { deps, pipe } = makeProDeps({ pipelineOpts: { initialCount: 0 } });
+    const res = await mcpHandler(proReq('POST', readBody('worldmonitor://seed-meta/freshness')), deps);
+    const body = await res.json();
+    assert.equal(body.error, undefined, `should succeed, got error: ${JSON.stringify(body.error)}`);
+    assert.equal(pipe.count, 0,
+      'seed-meta/freshness is a metadata-only freshness probe — it must NOT consume the Pro daily quota');
+    // Envelope-only content survives the public direct-read path.
+    const payload = JSON.parse(body.result.contents[0].text);
+    assert.equal(Object.keys(payload).sort().join(','), 'cached_at,stale',
+      'public freshness read must return exactly {cached_at, stale}');
+  });
+
+  it('ANON seed-meta/freshness resources/read succeeds (no credentials, no quota)', async () => {
+    const res = await handler(anonReq(readBody('worldmonitor://seed-meta/freshness')));
+    assert.equal(res.status, 200, 'anonymous public-resource read must return 200');
+    const body = await res.json();
+    assert.equal(body.error, undefined, `anonymous read must not error: ${JSON.stringify(body.error)}`);
+    const payload = JSON.parse(body.result.contents[0].text);
+    assert.equal(typeof payload.stale, 'boolean');
+    assert.equal(typeof payload.cached_at === 'string' || payload.cached_at === null, true);
+  });
+
+  it('ANON resources/read of a data-bearing TEMPLATE instantiation stays gated (401 — no quota bypass)', async () => {
+    // The data-leak / quota-bypass protection: only concrete PUBLIC resources
+    // are anon-readable. A template instantiation (country risk) requires auth.
+    const res = await handler(anonReq(readBody('worldmonitor://countries/de/risk')));
+    assert.equal(res.status, 401, 'anonymous read of a data-bearing template must be 401');
+    assert.ok(
+      res.headers.get('WWW-Authenticate')?.includes('Bearer'),
+      'gated resource read must advertise WWW-Authenticate: Bearer',
+    );
   });
 
   it('env-key resources/read on countries/de/risk does NOT touch the Pro quota path (env-key tier is its own quota)', async () => {
@@ -703,13 +804,21 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
   // -------------------------------------------------------------------------
   // Tool-existence parity (every resource.tool exists in TOOL_REGISTRY)
   // -------------------------------------------------------------------------
-  it('every RESOURCE_REGISTRY entry references a tool that exists in TOOL_REGISTRY', () => {
+  it('every TEMPLATE_RESOURCE_REGISTRY entry references a tool that exists in TOOL_REGISTRY', () => {
     const toolNames = new Set(TOOL_REGISTRY.map((t) => t.name));
-    for (const r of RESOURCE_REGISTRY) {
+    for (const r of TEMPLATE_RESOURCE_REGISTRY) {
       assert.ok(
         toolNames.has(r.tool),
-        `resource "${r.uri}" references unknown tool "${r.tool}". Known: [${[...toolNames].sort().join(', ')}]`,
+        `resource "${r.uriTemplate}" references unknown tool "${r.tool}". Known: [${[...toolNames].sort().join(', ')}]`,
       );
+    }
+  });
+
+  it('PUBLIC_RESOURCE_REGISTRY entries are concrete (no {template}) and expose a read() function', () => {
+    assert.ok(PUBLIC_RESOURCE_REGISTRY.length >= 1, 'at least one public resource must exist');
+    for (const r of PUBLIC_RESOURCE_REGISTRY) {
+      assert.doesNotMatch(r.uri, /[{}]/, `public resource ${r.uri} must be a concrete URI`);
+      assert.equal(typeof r.read, 'function', `public resource ${r.uri} must expose a read() function`);
     }
   });
 

--- a/tests/mcp-resources.test.mjs
+++ b/tests/mcp-resources.test.mjs
@@ -667,6 +667,24 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
     );
   });
 
+  it('a PUBLIC resource whose read() throws surfaces a clean -32603 (contract enforced at the dispatcher boundary)', async () => {
+    // The PublicResourceDef `read` "MUST be robust" contract is documentation;
+    // the dispatcher enforces it so a future non-robust reader returns -32603
+    // rather than bubbling an unhandled rejection through mcpHandler to the edge.
+    const def = PUBLIC_RESOURCE_REGISTRY[0];
+    const originalRead = def.read;
+    def.read = async () => { throw new Error('simulated reader failure'); };
+    try {
+      const res = await handler(anonReq(readBody(def.uri)));
+      assert.equal(res.status, 200, 'JSON-RPC errors ride inside HTTP 200');
+      const body = await res.json();
+      assert.equal(body.error?.code, -32603,
+        'a throwing public reader must surface -32603, not an unhandled rejection');
+    } finally {
+      def.read = originalRead;
+    }
+  });
+
   it('env-key resources/read on countries/de/risk does NOT touch the Pro quota path (env-key tier is its own quota)', async () => {
     // env-key auth path uses X-WorldMonitor-Key. The dispatcher's INCR
     // reservation only fires for context.kind === 'pro'. This test asserts

--- a/tests/mcp-tools-list-compression.test.mjs
+++ b/tests/mcp-tools-list-compression.test.mjs
@@ -402,14 +402,14 @@ describe('api/mcp.ts — tools/list description compression (v1.7.0)', () => {
     // ============================================================
     // U4: Version bump + SERVER_INSTRUCTIONS + server-card sync
     // ============================================================
-    it('serverInfo.version === "1.11.0"', async () => {
+    it('serverInfo.version === "1.12.0"', async () => {
       const res = await mod.default(new Request('https://worldmonitor.app/mcp', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-WorldMonitor-Key': VALID_KEY },
         body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 't', version: '1' } } }),
       }));
       const body = await res.json();
-      assert.equal(body.result?.serverInfo?.version, '1.11.0');
+      assert.equal(body.result?.serverInfo?.version, '1.12.0');
     });
 
     it('initialize.result.instructions mentions describe_tool AND the TOOL_DESCRIPTION_MAX_BYTES cap value', async () => {
@@ -426,9 +426,9 @@ describe('api/mcp.ts — tools/list description compression (v1.7.0)', () => {
         'instructions should mention the TOOL_DESCRIPTION_MAX_BYTES cap');
     });
 
-    it('server-card.json version matches SERVER_VERSION (1.11.0) AND tools[] length matches (39)', () => {
+    it('server-card.json version matches SERVER_VERSION (1.12.0) AND tools[] length matches (39)', () => {
       const card = JSON.parse(readFileSync(new URL('../public/.well-known/mcp/server-card.json', import.meta.url), 'utf8'));
-      assert.equal(card.serverInfo.version, '1.11.0');
+      assert.equal(card.serverInfo.version, '1.12.0');
       // orank (ora.ai) agent-readiness scanner reads the card's `tools` as an
       // ARRAY (tools[]) for pre-connection preview — not the old {count,categories}
       // object. Keep it an array; the count now derives from the length.

--- a/tests/mcp.test.mjs
+++ b/tests/mcp.test.mjs
@@ -139,6 +139,55 @@ describe('api/mcp.ts — PRO MCP Server', () => {
       'anonymous resources/list must expose a non-empty resource catalog (advertised `resources` capability)');
   });
 
+  it('resources/templates/list succeeds WITHOUT credentials (public discovery) and returns URI templates', async () => {
+    // The data-bearing URI templates (country risk, chokepoint, market quote)
+    // moved from resources/list to resources/templates/list — this metadata
+    // method is public so agents can still discover them without auth.
+    const req = new Request(BASE_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 5, method: 'resources/templates/list', params: {} }),
+    });
+    const res = await handler(req);
+    assert.equal(res.status, 200, 'unauthenticated resources/templates/list must be public');
+    const body = await res.json();
+    assert.ok(Array.isArray(body.result?.resourceTemplates) && body.result.resourceTemplates.length >= 1,
+      'anonymous resources/templates/list must expose the URI-template catalog');
+    assert.ok(body.result.resourceTemplates.every((r) => typeof r.uriTemplate === 'string'),
+      'each template entry must carry a uriTemplate field');
+  });
+
+  it('resources/read of a PUBLIC resource succeeds WITHOUT credentials + never touches quota (orank mcp-resource-quality)', async () => {
+    // orank reads every resources/list entry via resources/read anonymously.
+    // The concrete PUBLIC resources (freshness/health probes) return
+    // metadata-only content, so they read cleanly without auth or quota.
+    const req = new Request(BASE_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 6, method: 'resources/read', params: { uri: 'worldmonitor://seed-meta/freshness' } }),
+    });
+    const res = await handler(req);
+    assert.equal(res.status, 200, 'anonymous resources/read of a public resource must be 200');
+    const body = await res.json();
+    assert.equal(body.error, undefined, `must not error: ${JSON.stringify(body.error)}`);
+    const c = body.result?.contents?.[0];
+    assert.equal(c?.mimeType, 'application/json');
+    assert.ok(typeof c?.text === 'string' && c.text.length > 0, 'content must be non-empty');
+    assertNoStore(res, 'anonymous public resources/read');
+  });
+
+  it('resources/read of a data-bearing TEMPLATE instantiation still requires credentials (no quota bypass)', async () => {
+    const req = new Request(BASE_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 7, method: 'resources/read', params: { uri: 'worldmonitor://countries/de/risk' } }),
+    });
+    const res = await handler(req);
+    assert.equal(res.status, 401, 'resources/read of a data-bearing template is a data/quota method — must stay gated');
+    const body = await res.json();
+    assert.equal(body.error?.code, -32001);
+  });
+
   it('tools/call still requires credentials even though discovery is public', async () => {
     const req = new Request(BASE_URL, {
       method: 'POST',


### PR DESCRIPTION
## Summary

orank's `mcp-resource-quality` check scans the MCP server **anonymously**: it reads `resources/list`, then `resources/read`s every entry. All four returned `-32001 Authentication required` (**0/3**) because `resources/read` was fully gated **and** three of the four were URI templates whose literal `{placeholder}` can never resolve to data.

**Fix — split resources by data sensitivity (`SERVER_VERSION` 1.10.0 → 1.11.0):**

- **`resources/list`** now surfaces only concrete, metadata-only resources that read **anonymously and quota-free** — v1 is `worldmonitor://seed-meta/freshness` (a market-bootstrap freshness probe returning `{cached_at, stale}`), served by a direct reader (no `dispatchToolsCall`, no Pro reservation; robust even when the cache is unreachable).
- **`resources/templates/list`** (new public metadata method) surfaces the three data-bearing URI templates (country risk, chokepoint status, market quote). Each concrete instantiation's `resources/read` **stays gated and Pro-quota-symmetric** — the data-leak / quota-bypass protection is unchanged; only the discovery surface moved.

Once deployed: anon `resources/list` → `[seed-meta/freshness]` → anon `resources/read` → 200 valid JSON → 1/1 = 100% ⇒ **`mcp-resource-quality` 0/3 → 3/3**. orank has no template check (verified in its methodology), so `resources/templates/list` isn't counted against the ratio.

Docs (`mcp-server`, `mcp-error-catalog`), the static server-card, and the route-exception note are updated in lockstep.

### Not addressed (deliberate)

The other flagged gap, `api-schema-analysis` (1/2, "partially documented"), is already at its honest ceiling: the OpenAPI spec is 100% documented on every conventional axis (operationId, description, typed params, response schemas, examples), and the prior `?jmespath=` work (#4722) already moved the sibling `function-calling-compat` check to full pass (192/192 typed). The residual is orank's opaque *complexity* heuristic on a legitimately 192-operation API — no honest documentation lever remains, and padding params would be actively harmful.

## Test plan

- [x] `tests/mcp*.test.mjs` — 530/530 pass, incl. new tests for the anonymous read path (the exact orank probe) **and** the quota-bypass protection (anon read of a template → 401)
- [x] `tsc --noEmit` (full) + `typecheck:api` + convex tsc — clean (verified via pre-push hook)
- [x] `biome lint`, `lint:api-contract`, `lint:md`, `version:check`, boundary check — clean
- [x] `test:data` — 12825 pass; the only 2 failures were the known fresh-worktree `dashboard-critical-css` built-output tests (need `vite build` first — unrelated to this diff; confirmed green after building `dist/`)
- [x] edge-function bundle + `tests/edge-functions.test.mjs` (211/211)
- [x] Rebased onto current `origin/main` (picks up #4754 mcp-proxy Edge revert + #4760 protocol default-on); no conflicts, all suites re-verified green
- [ ] **Post-deploy:** `POST https://ora.ai/api/scan {"url":"worldmonitor.app"}` → expect `mcp-resource-quality` 0/3 → 3/3

> ⚠️ **Version note:** a concurrent branch is adding `ui://` MCP-Apps also targeting `1.11.0`. `origin/main` is still `1.10.0`, so `1.11.0` is the correct next bump here; whichever PR merges second must move to `1.12.0` and resync the version pins.

https://claude.ai/code/session_015RBAd1fRuWxPTk3PEBRjjh
