### PR TITLE
chore: bump app version 2.8.0 → 2.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "world-monitor",
-  "version": "2.8.0",
+  "version": "2.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "world-monitor",
-      "version": "2.8.0",
+      "version": "2.10.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "world-monitor",
   "private": true,
-  "version": "2.8.0",
+  "version": "2.10.0",
   "license": "AGPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5363,7 +5363,7 @@ dependencies = [
 
 [[package]]
 name = "world-monitor"
-version = "2.8.0"
+version = "2.10.0"
 dependencies = [
  "getrandom 0.2.17",
  "keyring",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "world-monitor"
-version = "2.8.0"
+version = "2.10.0"
 description = "World Monitor desktop application"
 authors = ["World Monitor"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "World Monitor",
   "mainBinaryName": "world-monitor",
-  "version": "2.8.0",
+  "version": "2.10.0",
   "identifier": "app.worldmonitor.desktop",
   "build": {
     "beforeDevCommand": "npm run build:sidecar-sebuf && node scripts/build-sidecar-handlers.mjs && npm run dev",


### PR DESCRIPTION
## Summary

- Bump the World Monitor app version **2.8.0 → 2.10.0** (semver minor +2, as requested — first root-app bump since 2.8.0 on 2026-04-27).
- Kept all version-of-record files in sync:
  - `package.json`
  - `package-lock.json` (top-level + root package entry)
  - `src-tauri/tauri.conf.json` (Tauri desktop)
  - `src-tauri/Cargo.toml` + `src-tauri/Cargo.lock` (Rust crate — keeps `cargo build --locked` green)
- Left third-party deps that coincidentally read `2.8.0` untouched (`domutils@2.8.0`, `tslib@^2.8.0`), and the `appVersion: '2.8.0'` test fixtures (arbitrary request payloads for the desktop-auth signature flow, not app-version assertions).
- The CLI (`cli/` at `0.1.2`) is a separate version track and was already bumped today — out of scope.

## Test plan

- [x] `npm run version:check` — package.json / tauri.conf.json / Cargo.toml all report `2.10.0`
- [x] `npm run typecheck` + `npm run typecheck:api`
- [x] `npm run lint` (biome) + `npm run lint:md` + CJS syntax check
- [x] `npm run test:data` — full suite green (the 2 dashboard critical-CSS built-output tests require a `VITE_VARIANT=full vite build` first; verified passing after building)
- [x] Edge function bundle check (`esbuild` over `api/*.js`) + `tests/edge-functions.test.mjs` (210/210)
- [x] Pre-push hook gate passed on push (typechecks, boundary/safe-html/sentry/rate-limit/premium-fetch lints, edge bundle)

https://claude.ai/code/session_014twyf1ZWQXndf7fRBeZWqh