### PR TITLE
fix(webcams): validate embed message origins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Agent entry point for WorldMonitor. Read this first, then follow links for depth
 
 ## What This Project Is
 
-Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 159 top-level TypeScript component files, 80+ Vercel Edge API endpoint entries, a Tauri desktop app with Node.js sidecar, and a Railway relay service. Aggregates geopolitics, military, finance, climate, cyber, maritime, and aviation data across 35 freshness-tracked source groups.
+Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 160 top-level TypeScript component files, 80+ Vercel Edge API endpoint entries, a Tauri desktop app with Node.js sidecar, and a Railway relay service. Aggregates geopolitics, military, finance, climate, cyber, maritime, and aviation data across 35 freshness-tracked source groups.
 
 ## Repository Map
 
@@ -13,7 +13,7 @@ Real-time global intelligence dashboard. TypeScript SPA (Vite + Preact) with 159
 ├── src/                    # Browser SPA (TypeScript, class-based components)
 │   ├── app/                # App orchestration (data-loader, refresh-scheduler, panel-layout)
 │   ├── bootstrap/          # Startup/recovery (chunk reload, deferred Sentry, SW update)
-│   ├── components/         # 159 top-level TypeScript component files
+│   ├── components/         # 160 top-level TypeScript component files
 │   ├── config/             # Variant configs, panel/layer definitions, market symbols
 │   ├── services/           # Business logic (193 service modules and domain directories)
 │   ├── shared/             # Cross-cutting helpers (premium paths, registries, staleness)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Variants share all code but differ in default panels, map layers, and RSS feeds.
 
 | Directory | Purpose |
 |---|---|
-| `src/components/` | UI components — 159 top-level TypeScript component files |
+| `src/components/` | UI components — 160 top-level TypeScript component files |
 | `src/services/` | Data fetching modules — sebuf client wrappers, AI, signal analysis |
 | `src/config/` | Static data and variant configs (feeds, geo, military, pipelines, ports) |
 | `src/generated/` | Auto-generated sebuf client + server stubs (**do not edit by hand**) |

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -10,7 +10,7 @@
     "energy": 18
   },
   "variantCount": 6,
-  "componentTopLevelTsFiles": 159,
+  "componentTopLevelTsFiles": 160,
   "serviceTopLevelEntries": 193,
   "apiEndpointEntries": 83,
   "panelClasses": 104,

--- a/src/components/LiveWebcamsPanel.ts
+++ b/src/components/LiveWebcamsPanel.ts
@@ -9,6 +9,7 @@ import { isMobileDevice, loadFromStorage, saveToStorage } from '@/utils';
 import { playAllLiveMedia, registerLiveMediaStarter, unregisterLiveMediaStarter, type LiveMediaStopReason } from '@/services/live-media-controller';
 import { getLiveStreamsAlwaysOn, subscribeLiveStreamsSettingsChange } from '@/services/live-stream-settings';
 import { setTrustedHtml, trustedHtml } from '@/utils/dom-utils';
+import { isAllowedWebcamEmbedMessageOrigin } from './_live-webcams-origin';
 
 
 type WebcamRegion = 'middle-east' | 'europe' | 'asia' | 'americas' | 'space';
@@ -598,6 +599,7 @@ export class LiveWebcamsPanel extends Panel {
   private handleEmbedMessage(e: MessageEvent): void {
     const iframe = this.findIframeBySource(e.source);
     if (!iframe) return;
+    if (!isAllowedWebcamEmbedMessageOrigin(e.origin, iframe.src)) return;
 
     // Desktop sidecar posts { type: 'yt-ready' | 'yt-state' | 'yt-error' }
     const msg = e.data as { type?: string; state?: number; code?: number; event?: string; info?: unknown } | string | null;

--- a/src/components/_live-webcams-origin.ts
+++ b/src/components/_live-webcams-origin.ts
@@ -1,0 +1,37 @@
+const YOUTUBE_EMBED_ORIGINS = new Set([
+  'https://www.youtube.com',
+  'https://www.youtube-nocookie.com',
+]);
+
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
+}
+
+function parseAbsoluteUrl(value: string): URL | null {
+  try {
+    return new URL(value);
+  } catch {
+    return null;
+  }
+}
+
+export function isAllowedWebcamEmbedMessageOrigin(eventOrigin: string, iframeSrc: string): boolean {
+  if (!eventOrigin || eventOrigin === 'null') return false;
+
+  const iframeUrl = parseAbsoluteUrl(iframeSrc);
+  if (!iframeUrl) return false;
+
+  if (YOUTUBE_EMBED_ORIGINS.has(iframeUrl.origin) && iframeUrl.pathname.startsWith('/embed/')) {
+    return eventOrigin === iframeUrl.origin;
+  }
+
+  if (
+    iframeUrl.protocol === 'http:' &&
+    iframeUrl.pathname === '/api/youtube-embed' &&
+    isLoopbackHostname(iframeUrl.hostname)
+  ) {
+    return eventOrigin === iframeUrl.origin;
+  }
+
+  return false;
+}

--- a/tests/live-webcams-origin.test.mts
+++ b/tests/live-webcams-origin.test.mts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { isAllowedWebcamEmbedMessageOrigin } from '../src/components/_live-webcams-origin.ts';
+
+describe('LiveWebcamsPanel postMessage origin guard', () => {
+  it('accepts YouTube iframe API messages from the iframe embed origin', () => {
+    const src = 'https://www.youtube.com/embed/e34xb-Fbl0U?enablejsapi=1&origin=https://worldmonitor.app';
+
+    assert.equal(isAllowedWebcamEmbedMessageOrigin('https://www.youtube.com', src), true);
+  });
+
+  it('accepts YouTube nocookie messages only when the iframe uses nocookie', () => {
+    const src = 'https://www.youtube-nocookie.com/embed/e34xb-Fbl0U?enablejsapi=1&origin=https://worldmonitor.app';
+
+    assert.equal(isAllowedWebcamEmbedMessageOrigin('https://www.youtube-nocookie.com', src), true);
+    assert.equal(isAllowedWebcamEmbedMessageOrigin('https://www.youtube.com', src), false);
+  });
+
+  it('accepts the desktop localhost sidecar origin for the youtube embed bridge', () => {
+    const src = 'http://localhost:14567/api/youtube-embed?videoId=e34xb-Fbl0U&autoplay=1&mute=1';
+
+    assert.equal(isAllowedWebcamEmbedMessageOrigin('http://localhost:14567', src), true);
+  });
+
+  it('rejects same-window messages after a child frame navigates to an unexpected origin', () => {
+    const originalSrc = 'https://www.youtube.com/embed/e34xb-Fbl0U?enablejsapi=1&origin=https://worldmonitor.app';
+
+    assert.equal(isAllowedWebcamEmbedMessageOrigin('https://evil.example', originalSrc), false);
+    assert.equal(isAllowedWebcamEmbedMessageOrigin('https://www.youtube.com.evil.example', originalSrc), false);
+    assert.equal(isAllowedWebcamEmbedMessageOrigin('null', originalSrc), false);
+  });
+
+  it('rejects non-embed YouTube pages even on an allowed YouTube origin', () => {
+    const watchPage = 'https://www.youtube.com/watch?v=e34xb-Fbl0U';
+
+    assert.equal(isAllowedWebcamEmbedMessageOrigin('https://www.youtube.com', watchPage), false);
+  });
+
+  it('rejects loopback messages that do not match the expected sidecar endpoint and port', () => {
+    const sidecarSrc = 'http://localhost:14567/api/youtube-embed?videoId=e34xb-Fbl0U';
+    const otherLocalEndpoint = 'http://localhost:14567/api/hls-proxy?url=https%3A%2F%2Fexample.com%2Fstream.m3u8';
+
+    assert.equal(isAllowedWebcamEmbedMessageOrigin('http://localhost:9999', sidecarSrc), false);
+    assert.equal(isAllowedWebcamEmbedMessageOrigin('http://localhost:14567', otherLocalEndpoint), false);
+  });
+});


### PR DESCRIPTION
## Problem

LiveWebcamsPanel trusted webcam iframe messages after matching only the `contentWindow` source. A child frame that navigated away, or a compromised embedded frame, could still send YouTube-looking control/status messages into the panel without an `event.origin` check.

## Fix

Webcam embed messages now pass through an origin predicate before the panel parses or acts on the payload. The predicate accepts only the expected YouTube `/embed/...` origins that match the iframe source, plus the local loopback `/api/youtube-embed` sidecar origin used by the desktop bridge.

## Validation

- `node --experimental-strip-types --test tests/live-webcams-origin.test.mts`
- `TMPDIR=/tmp /Users/eliehabib/Documents/GitHub/worldmonitor/node_modules/.bin/tsx --test tests/live-webcams-origin.test.mts` outside the sandbox because `tsx` IPC pipe creation is sandbox-blocked locally
- `npm run typecheck`
- Push preflight passed: app typecheck, API typecheck, Convex check, CJS syntax, Unicode safety, architectural boundaries, safe HTML, Sentry coverage, rate-limit policy coverage, premium-fetch parity, edge bundle check, changed test files, edge function tests, markdown/MDX skips, proto/pro-test skips, and version sync
- Requested code-review-expert pass completed; the one actionable hardening tweak was applied by requiring YouTube URLs to be `/embed/...`

## Residual Risk

No browser smoke was needed for this pure predicate change. The remaining risk is limited to future embed providers or sidecar URL shapes; those should add explicit predicate coverage before being accepted.

## Post-Deploy Monitoring & Validation

Watch Sentry and user reports for `LiveWebcamsPanel`, `webcam`, `postMessage`, `yt-ready`, `yt-state`, and embed fallback/timeout signals for 24 hours after deploy. Healthy behavior is normal webcam readiness with no spike in blocked overlays or message parsing errors. Failure signal is a sudden increase in webcam fallback overlays or YouTube iframe readiness failures, in which case revert this PR or add the missing expected origin with focused coverage.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
