### PR TITLE
Fail closed wm-session issuance rate limiting

### DIFF
--- a/api/_rate-limit.js
+++ b/api/_rate-limit.js
@@ -20,21 +20,36 @@ export {
 // REDIS_TEST_RETRY_OPTS in server/_shared/rate-limit.ts and PR #3963.
 const REDIS_TEST_RETRY_OPTS = process.env.NODE_TEST_CONTEXT ? { retry: false } : {};
 
-let ratelimit = null;
+const DEFAULT_RATE_LIMIT_SCOPE = 'global';
+const DEFAULT_RATE_LIMIT = 600;
+const DEFAULT_RATE_LIMIT_WINDOW = '60 s';
 
-function getRatelimit() {
-  if (ratelimit) return ratelimit;
+let ratelimits = new Map();
+
+function getRateLimitPolicy(opts = {}) {
+  return {
+    scope: opts.scope ?? DEFAULT_RATE_LIMIT_SCOPE,
+    limit: opts.limit ?? DEFAULT_RATE_LIMIT,
+    window: opts.window ?? DEFAULT_RATE_LIMIT_WINDOW,
+  };
+}
+
+function getRatelimit(policy) {
+  const cacheKey = `${policy.scope}|${policy.limit}|${policy.window}`;
+  const cached = ratelimits.get(cacheKey);
+  if (cached) return cached;
 
   const url = process.env.UPSTASH_REDIS_REST_URL;
   const token = process.env.UPSTASH_REDIS_REST_TOKEN;
   if (!url || !token) return null;
 
-  ratelimit = new Ratelimit({
+  const ratelimit = new Ratelimit({
     redis: new Redis({ url, token, ...REDIS_TEST_RETRY_OPTS }),
-    limiter: Ratelimit.slidingWindow(600, '60 s'),
-    prefix: 'rl',
+    limiter: Ratelimit.slidingWindow(policy.limit, policy.window),
+    prefix: policy.scope === DEFAULT_RATE_LIMIT_SCOPE ? 'rl' : `rl:${policy.scope}`,
     analytics: false,
   });
+  ratelimits.set(cacheKey, ratelimit);
 
   return ratelimit;
 }
@@ -82,7 +97,7 @@ function rateLimitDegradedResponse(corsHeaders) {
 /**
  * @param {Request} request
  * @param {Record<string, string>} corsHeaders
- * @param {{ failClosed?: boolean, ctx?: { waitUntil: (p: Promise<unknown>) => void } }} [opts]
+ * @param {{ failClosed?: boolean, ctx?: { waitUntil: (p: Promise<unknown>) => void }, scope?: string, limit?: number, window?: import('@upstash/ratelimit').Duration }} [opts]
  *   When `failClosed` is true and Redis is unavailable, return a 503 with
  *   the `X-RateLimit-Mode: degraded` marker instead of allowing the
  *   request through. Pass `true` for endpoints where the rate-limit IS
@@ -90,10 +105,13 @@ function rateLimitDegradedResponse(corsHeaders) {
  *   availability-first posture for general traffic so a Redis blip
  *   doesn't black-hole the whole site. `ctx` is the Vercel handler
  *   context — passing it lets the Sentry envelope dispatch survive
- *   isolate teardown. (#3531)
+ *   isolate teardown. Top-level Edge handlers may pass `scope`, `limit`,
+ *   and `window` for explicit endpoint budgets while retaining the shared
+ *   degraded/429 response semantics. (#3531)
  */
 export async function checkRateLimit(request, corsHeaders, opts = {}) {
-  const rl = getRatelimit();
+  const policy = getRateLimitPolicy(opts);
+  const rl = getRatelimit(policy);
   if (!rl) {
     if (opts.failClosed) {
       logRateLimitDegraded('checkRateLimit:missing-config', new Error('Upstash Redis is not configured'), opts.ctx);
@@ -122,4 +140,8 @@ export async function checkRateLimit(request, corsHeaders, opts = {}) {
     if (opts.failClosed) return rateLimitDegradedResponse(corsHeaders);
     return null;
   }
+}
+
+export function __resetRateLimitForTest() {
+  ratelimits = new Map();
 }

--- a/api/_rate-limit.test.mjs
+++ b/api/_rate-limit.test.mjs
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, it } from 'node:test';
 import {
   RATE_LIMIT_DEGRADED_HEADERS,
   UNKNOWN_CLIENT_IP,
+  __resetRateLimitForTest,
   checkRateLimit,
   getClientIp,
 } from './_rate-limit.js';
@@ -114,6 +115,7 @@ describe('api/_rate-limit checkRateLimit fail-open / fail-closed (#3531 M9)', ()
   afterEach(() => {
     globalThis.fetch = originalFetch;
     console.error = originalConsoleError;
+    __resetRateLimitForTest();
     restoreEnv();
   });
 
@@ -161,6 +163,52 @@ describe('api/_rate-limit checkRateLimit fail-open / fail-closed (#3531 M9)', ()
     assert.equal(res.status, 503);
     assert.equal(res.headers.get('X-RateLimit-Mode'), 'degraded');
     assert.equal(res.headers.get('Retry-After'), '5');
+    assert.equal(
+      res.headers.get('Access-Control-Allow-Origin'),
+      'https://worldmonitor.app',
+    );
+  });
+
+  it('custom scoped policy uses the caller-supplied lower limit', async () => {
+    const redisBodies = [];
+    globalThis.fetch = async (_input, init) => {
+      redisBodies.push(String(init?.body ?? ''));
+      return new Response(
+        JSON.stringify([{ result: [29, 30] }]),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    };
+
+    const res = await checkRateLimit(
+      makeRequest({ 'cf-connecting-ip': '203.0.113.7' }),
+      {},
+      { scope: 'wm-session', limit: 30, window: '60 s', failClosed: true },
+    );
+
+    assert.equal(res, null);
+    assert.ok(
+      redisBodies.some((body) => body.includes('rl:wm-session') && body.includes('30')),
+      `expected scoped 30/min limiter command, got: ${redisBodies.join('\n')}`,
+    );
+  });
+
+  it('custom scoped policy returns 429 with the configured lower limit when exhausted', async () => {
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify([{ result: [-1, 30] }]),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+
+    const res = await checkRateLimit(
+      makeRequest({ 'cf-connecting-ip': '203.0.113.7' }),
+      { 'Access-Control-Allow-Origin': 'https://worldmonitor.app' },
+      { scope: 'wm-session', limit: 30, window: '60 s', failClosed: true },
+    );
+
+    assert.ok(res, 'expected a Response when the scoped policy is exhausted');
+    assert.equal(res.status, 429);
+    assert.equal(res.headers.get('X-RateLimit-Limit'), '30');
+    assert.equal(res.headers.get('X-RateLimit-Remaining'), '0');
     assert.equal(
       res.headers.get('Access-Control-Allow-Origin'),
       'https://worldmonitor.app',

--- a/api/wm-session.js
+++ b/api/wm-session.js
@@ -97,7 +97,7 @@ async function readBody(req) {
   }
 }
 
-export default async function handler(req) {
+export default async function handler(req, ctx) {
   if (isDisallowedOrigin(req)) {
     return new Response('Forbidden', { status: 403 });
   }
@@ -117,6 +117,7 @@ export default async function handler(req) {
   // instead of inheriting the availability-first global fallback.
   const rl = await checkRateLimit(req, cors, {
     failClosed: true,
+    ctx,
     scope: SESSION_RATE_LIMIT_SCOPE,
     limit: SESSION_RATE_LIMIT_PER_MINUTE,
     window: SESSION_RATE_LIMIT_WINDOW,

--- a/api/wm-session.js
+++ b/api/wm-session.js
@@ -15,6 +15,9 @@ const WIDGET_KEY_COOKIE = 'wm-widget-key';
 const PRO_KEY_COOKIE = 'wm-pro-key';
 const COOKIE_MAX_AGE_SECONDS = 12 * 60 * 60;
 const LEGACY_KEY_MAX_LEN = 512;
+const SESSION_RATE_LIMIT_SCOPE = 'wm-session';
+const SESSION_RATE_LIMIT_PER_MINUTE = 30;
+const SESSION_RATE_LIMIT_WINDOW = '60 s';
 
 function jsonResponse(body, status, headers) {
   const out = headers instanceof Headers ? headers : new Headers(headers);
@@ -110,9 +113,14 @@ export default async function handler(req) {
   }
 
   // Rate-limit per IP. Without this, an attacker can farm tokens cheaply.
-  // Token TTL is 12h, so a sustained ~1 RPS yields 86400 tokens/day per IP —
-  // the existing IP cap (600/min) keeps that bounded.
-  const rl = await checkRateLimit(req, cors);
+  // Token TTL is 12h, so this route uses a lower, fail-closed issuance budget
+  // instead of inheriting the availability-first global fallback.
+  const rl = await checkRateLimit(req, cors, {
+    failClosed: true,
+    scope: SESSION_RATE_LIMIT_SCOPE,
+    limit: SESSION_RATE_LIMIT_PER_MINUTE,
+    window: SESSION_RATE_LIMIT_WINDOW,
+  });
   if (rl) return rl;
 
   let issued;

--- a/api/wm-session.test.mjs
+++ b/api/wm-session.test.mjs
@@ -1,14 +1,54 @@
 import { strict as assert } from 'node:assert';
-import test from 'node:test';
+import { afterEach, beforeEach, test } from 'node:test';
 
 const SECRET = 'test-secret-must-be-at-least-32-chars-long-xxx';
-process.env.WM_SESSION_SECRET = SECRET;
-process.env.WIDGET_AGENT_KEY = 'widget-secret';
-process.env.PRO_WIDGET_KEY = 'pro-secret';
-process.env.WORLDMONITOR_VALID_KEYS = 'enterprise-secret';
+const originalFetch = globalThis.fetch;
+const originalEnv = { ...process.env };
 
 const { default: handler } = await import('./wm-session.js');
 const { validateSessionToken } = await import('./_session.js');
+const { __resetRateLimitForTest } = await import('./_rate-limit.js');
+
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, originalEnv);
+}
+
+function configureDefaultEnv() {
+  process.env.WM_SESSION_SECRET = SECRET;
+  process.env.WIDGET_AGENT_KEY = 'widget-secret';
+  process.env.PRO_WIDGET_KEY = 'pro-secret';
+  process.env.WORLDMONITOR_VALID_KEYS = 'enterprise-secret';
+  process.env.UPSTASH_REDIS_REST_URL = 'https://fake.upstash.io';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'fake-token';
+}
+
+function mockUpstashRateLimit({ remaining = 29, limit = 30 } = {}) {
+  globalThis.fetch = async (input, init) => {
+    const url = input instanceof URL ? input.href : typeof input === 'string' ? input : input.url;
+    if (url.includes('fake.upstash.io')) {
+      return new Response(
+        JSON.stringify([{ result: [remaining, limit] }]),
+        { status: 200, headers: { 'Content-Type': 'application/json' } },
+      );
+    }
+    return originalFetch(input, init);
+  };
+}
+
+beforeEach(() => {
+  configureDefaultEnv();
+  __resetRateLimitForTest();
+  mockUpstashRateLimit();
+});
+
+afterEach(() => {
+  __resetRateLimitForTest();
+  globalThis.fetch = originalFetch;
+  restoreEnv();
+});
 
 function makeReq(method, { origin } = {}) {
   const headers = new Headers();
@@ -77,6 +117,9 @@ test('localhost session cookie remains host-only for dev', async () => {
 });
 
 test('OPTIONS preflight returns 204 with CORS', async () => {
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  __resetRateLimitForTest();
   const resp = await handler(makeReq('OPTIONS', { origin: 'https://worldmonitor.app' }));
   assert.equal(resp.status, 204);
   assert.equal(resp.headers.get('access-control-allow-methods'), 'POST, OPTIONS');
@@ -99,6 +142,34 @@ test('No origin (curl) is allowed (rate limit + token TTL are the throttles)', a
   const body = await resp.json();
   assert.equal(body.token, undefined);
   assert.match(cookieValue(setCookies(resp), 'wm-session'), /^wms_/);
+});
+
+test('POST returns degraded 503 without issuing a token when Redis limiter config is missing', async () => {
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  __resetRateLimitForTest();
+
+  const resp = await handler(makeReq('POST', { origin: 'https://worldmonitor.app' }));
+
+  assert.equal(resp.status, 503);
+  assert.equal(resp.headers.get('X-RateLimit-Mode'), 'degraded');
+  assert.equal(resp.headers.get('Retry-After'), '5');
+  assert.equal(resp.headers.get('access-control-allow-origin'), 'https://worldmonitor.app');
+  assert.equal(cookieValue(setCookies(resp), 'wm-session'), '');
+  const body = await resp.json();
+  assert.match(body.error, /rate-limit service temporarily unavailable/i);
+});
+
+test('POST returns 429 without issuing a token when the wm-session issuance budget is exhausted', async () => {
+  mockUpstashRateLimit({ remaining: -1, limit: 30 });
+  const resp = await handler(makeReq('POST', { origin: 'https://worldmonitor.app' }));
+
+  assert.equal(resp.status, 429);
+  assert.equal(resp.headers.get('X-RateLimit-Limit'), '30');
+  assert.equal(resp.headers.get('X-RateLimit-Remaining'), '0');
+  assert.equal(cookieValue(setCookies(resp), 'wm-session'), '');
+  const body = await resp.json();
+  assert.equal(body.error, 'Too many requests');
 });
 
 test('no-key session refresh preserves existing HttpOnly key cookies', async () => {

--- a/api/wm-session.test.mjs
+++ b/api/wm-session.test.mjs
@@ -1,4 +1,5 @@
 import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
 import { afterEach, beforeEach, test } from 'node:test';
 
 const SECRET = 'test-secret-must-be-at-least-32-chars-long-xxx';
@@ -124,6 +125,17 @@ test('OPTIONS preflight returns 204 with CORS', async () => {
   assert.equal(resp.status, 204);
   assert.equal(resp.headers.get('access-control-allow-methods'), 'POST, OPTIONS');
   assert.equal(resp.headers.get('access-control-allow-credentials'), 'true');
+});
+
+test('POST fail-closed limiter receives Vercel ctx for degraded telemetry', () => {
+  const src = readFileSync(new URL('./wm-session.js', import.meta.url), 'utf8');
+
+  assert.match(src, /export\s+default\s+async\s+function\s+handler\s*\(\s*req\s*,\s*ctx\s*\)/);
+  assert.match(
+    src,
+    /checkRateLimit\(req,\s*cors,\s*\{[\s\S]*?failClosed:\s*true,[\s\S]*?ctx,/,
+    'wm-session must pass Vercel ctx to the fail-closed rate limiter so Sentry delivery can use waitUntil',
+  );
 });
 
 test('GET method is rejected with 405', async () => {


### PR DESCRIPTION
## Summary
- Add scoped rate-limit policy support to the Edge helper while preserving the 600/min global fallback for existing callers.
- Move /api/wm-session token issuance to a 30/min/IP scoped limiter with failClosed enabled.
- Cover missing Redis config, normal issuance, over-limit, and CORS/OPTIONS behavior in wm-session and helper tests.

## Verification
- node --test api/wm-session.test.mjs api/_rate-limit.test.mjs
- node --import ./node_modules/tsx/dist/esm/index.mjs --test tests/rate-limit.test.mts
- node scripts/enforce-rate-limit-policies.mjs
- npm run typecheck:api
- git push pre-push hook: full typecheck, API typecheck, Convex type check, CJS syntax, Unicode, boundaries, safe HTML, Sentry coverage, rate-limit policy, premium-fetch parity, edge bundle/tests, version sync

## Operational notes
- Anonymous session issuance now returns the existing degraded 503 marker instead of issuing tokens when Redis limiter config/runtime is unavailable.
- The endpoint-specific budget is 30/min/IP under the wm-session scope.