### PR TITLE
fix(mcp): require HTTPS proxy targets

### DIFF
--- a/api/mcp-proxy.ts
+++ b/api/mcp-proxy.ts
@@ -208,7 +208,7 @@ function buildInitPayload() {
 async function validateServerUrl(raw) {
   let url;
   try { url = new URL(raw); } catch { return null; }
-  if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+  if (url.protocol !== 'https:') return null;
   try {
     return (await assertServerUrlSafe(url)).url;
   } catch {

--- a/tests/mcp-proxy.test.mjs
+++ b/tests/mcp-proxy.test.mjs
@@ -330,40 +330,59 @@ describe('api/mcp-proxy', () => {
       assert.match(data.error, /serverUrl/i);
     });
 
-    it('returns 400 for non-http(s) protocol', async () => {
+    it('returns 400 for non-HTTPS protocol', async () => {
       const res = await handler(makeGetRequest({ serverUrl: 'ftp://mcp.example.com/mcp' }));
       assert.equal(res.status, 400);
       const data = await res.json();
       assert.match(data.error, /invalid serverUrl/i);
     });
 
+    it('returns 400 for plain HTTP public upstreams before DNS or fetch', async () => {
+      let resolverCalled = false;
+      let fetchCalled = false;
+      setResolveHostnameForTest(async () => {
+        resolverCalled = true;
+        return [PUBLIC_TEST_ADDRESS];
+      });
+      globalThis.fetch = async () => {
+        fetchCalled = true;
+        return new Response('{}', { status: 200 });
+      };
+      const res = await handler(makeGetRequest({ serverUrl: 'http://public-mcp.example/mcp' }));
+      assert.equal(res.status, 400);
+      const data = await res.json();
+      assert.match(data.error, /invalid serverUrl/i);
+      assert.equal(resolverCalled, false, 'HTTP upstream validation must reject before DNS resolution');
+      assert.equal(fetchCalled, false, 'HTTP upstream validation must reject before upstream fetch');
+    });
+
     it('returns 400 for localhost', async () => {
-      const res = await handler(makeGetRequest({ serverUrl: 'http://localhost/mcp' }));
+      const res = await handler(makeGetRequest({ serverUrl: 'https://localhost/mcp' }));
       assert.equal(res.status, 400);
     });
 
     it('returns 400 for 127.x.x.x', async () => {
-      const res = await handler(makeGetRequest({ serverUrl: 'http://127.0.0.1:8080/mcp' }));
+      const res = await handler(makeGetRequest({ serverUrl: 'https://127.0.0.1:8080/mcp' }));
       assert.equal(res.status, 400);
     });
 
     it('returns 400 for 10.x.x.x (RFC1918)', async () => {
-      const res = await handler(makeGetRequest({ serverUrl: 'http://10.0.0.1/mcp' }));
+      const res = await handler(makeGetRequest({ serverUrl: 'https://10.0.0.1/mcp' }));
       assert.equal(res.status, 400);
     });
 
     it('returns 400 for 192.168.x.x (RFC1918)', async () => {
-      const res = await handler(makeGetRequest({ serverUrl: 'http://192.168.1.1/mcp' }));
+      const res = await handler(makeGetRequest({ serverUrl: 'https://192.168.1.1/mcp' }));
       assert.equal(res.status, 400);
     });
 
     it('returns 400 for 172.16.x.x (RFC1918)', async () => {
-      const res = await handler(makeGetRequest({ serverUrl: 'http://172.16.0.1/mcp' }));
+      const res = await handler(makeGetRequest({ serverUrl: 'https://172.16.0.1/mcp' }));
       assert.equal(res.status, 400);
     });
 
     it('returns 400 for link-local 169.254.x.x (cloud metadata)', async () => {
-      const res = await handler(makeGetRequest({ serverUrl: 'http://169.254.169.254/latest/meta-data/' }));
+      const res = await handler(makeGetRequest({ serverUrl: 'https://169.254.169.254/latest/meta-data/' }));
       assert.equal(res.status, 400);
     });
 
@@ -597,10 +616,32 @@ describe('api/mcp-proxy', () => {
 
     it('returns 400 for blocked host in POST body', async () => {
       const res = await handler(makePostRequest({
-        serverUrl: 'http://localhost/mcp',
+        serverUrl: 'https://localhost/mcp',
         toolName: 'search',
       }));
       assert.equal(res.status, 400);
+    });
+
+    it('returns 400 for plain HTTP public upstreams in POST before DNS or fetch', async () => {
+      let resolverCalled = false;
+      let fetchCalled = false;
+      setResolveHostnameForTest(async () => {
+        resolverCalled = true;
+        return [PUBLIC_TEST_ADDRESS];
+      });
+      globalThis.fetch = async () => {
+        fetchCalled = true;
+        return new Response('{}', { status: 200 });
+      };
+      const res = await handler(makePostRequest({
+        serverUrl: 'http://public-mcp.example/mcp',
+        toolName: 'search',
+      }));
+      assert.equal(res.status, 400);
+      const data = await res.json();
+      assert.match(data.error, /invalid serverUrl/i);
+      assert.equal(resolverCalled, false, 'HTTP upstream validation must reject before DNS resolution');
+      assert.equal(fetchCalled, false, 'HTTP upstream validation must reject before upstream fetch');
     });
 
     it('returns 200 with result on successful tool call', async () => {
@@ -1069,7 +1110,7 @@ describe('api/mcp-proxy', () => {
 
     it('emits audit log on validation failure (status: 400)', async () => {
       const res = await handler(makeGetRequest(
-        { serverUrl: 'http://localhost/mcp' },
+        { serverUrl: 'https://localhost/mcp' },
         'https://worldmonitor.app',
         { extra: { 'cf-connecting-ip': uniqueCallerIp(), 'x-real-ip': uniqueCallerIp() } },
       ));


### PR DESCRIPTION
## Summary

The hosted MCP proxy now rejects plain HTTP upstream MCP server URLs before DNS resolution or outbound fetch. This keeps the existing Edge-layer SSRF defenses in place while removing the residual unencrypted probing path left after the prior DNS/private-target hardening.

The regression suite now proves both GET list-tools and POST tool-call paths reject `http:` public upstreams before using the resolver or `fetch()`. Existing private/reserved-host tests were kept meaningful by moving their fixtures to `https://`, so they still exercise hostname/IP classification, DNS fail-closed behavior, revalidation, manual redirects, metadata-header stripping, auth, and rate limiting.

Related: #4674

## Validation

- `TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/mcp-proxy.test.mjs`
- `TMPDIR=/tmp npm run typecheck:api`
- `git diff --check`
- Pre-push hook: full `npm run typecheck`, `npm run typecheck:api`, Convex type check, architectural/safe HTML/rate-limit/premium-fetch guardrails, changed test files, edge function tests, version sync

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)