### PR TITLE
fix(security): harden blank window opens

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -1869,7 +1869,7 @@ export class App {
         .closest<HTMLElement>('[data-action]')
         ?.dataset.action;
       if (clickedAction === 'upgrade') {
-        window.open('/pro#pricing', '_blank', 'noopener');
+        window.open('/pro#pricing', '_blank', 'noopener,noreferrer');
         if (this.followedCountriesCapDropToastTimer !== null) {
           window.clearTimeout(this.followedCountriesCapDropToastTimer);
           this.followedCountriesCapDropToastTimer = null;

--- a/src/app/desktop-updater.ts
+++ b/src/app/desktop-updater.ts
@@ -201,10 +201,10 @@ export class DesktopUpdater implements AppModule {
         if (this.ctx.isDesktopApp) {
           void invokeTauri<void>('open_url', { url }).catch((error) => {
             this.logUpdaterOutcome('open_failed', { url, error: error instanceof Error ? error.message : String(error) });
-            window.open(url, '_blank', 'noopener');
+            window.open(url, '_blank', 'noopener,noreferrer');
           });
         } else {
-          window.open(url, '_blank', 'noopener');
+          window.open(url, '_blank', 'noopener,noreferrer');
         }
         dismissToast();
       } else if (action === 'dismiss') {

--- a/src/app/event-handlers.ts
+++ b/src/app/event-handlers.ts
@@ -702,7 +702,7 @@ export class EventHandlerManager implements AppModule {
         e.preventDefault();
         e.stopPropagation();
         void invokeTauri<void>('open_url', { url: url.toString() }).catch(() => {
-          window.open(url.toString(), '_blank');
+          window.open(url.toString(), '_blank', 'noopener,noreferrer');
         });
       };
       document.addEventListener('click', this.boundDesktopExternalLinkHandler, true);
@@ -1432,7 +1432,7 @@ export class EventHandlerManager implements AppModule {
           e.preventDefault();
           const plat = new URL(a.href, location.origin).searchParams.get('platform') || 'unknown';
           trackDownloadClicked(plat);
-          window.open(a.href, '_blank');
+          window.open(a.href, '_blank', 'noopener,noreferrer');
           dropdown.classList.remove('open');
         });
       });
@@ -1486,7 +1486,7 @@ export class EventHandlerManager implements AppModule {
       e.preventDefault();
       const plat = new URL(btn.href, location.origin).searchParams.get('platform') || 'unknown';
       trackDownloadClicked(plat);
-      window.open(btn.href, '_blank');
+      window.open(btn.href, '_blank', 'noopener,noreferrer');
     });
     mount.replaceWith(a);
   }

--- a/src/app/panel-layout.ts
+++ b/src/app/panel-layout.ts
@@ -532,7 +532,7 @@ export class PanelLayoutManager implements AppModule {
       case PanelGateReason.ANONYMOUS:
         return () => this.ctx.authModal?.open();
       case PanelGateReason.FREE_TIER:
-        return () => window.open('https://worldmonitor.app/pro', '_blank');
+        return () => window.open('https://worldmonitor.app/pro', '_blank', 'noopener,noreferrer');
       default:
         return () => {};
     }

--- a/src/components/LiveNewsPanel.ts
+++ b/src/components/LiveNewsPanel.ts
@@ -1690,10 +1690,10 @@ export class LiveNewsPanel extends Panel {
         const { tryInvokeTauri } = await import('@/services/tauri-bridge');
         await tryInvokeTauri('open_youtube_login');
       } catch {
-        window.open(youtubeLoginUrl, '_blank');
+        window.open(youtubeLoginUrl, '_blank', 'noopener,noreferrer');
       }
     } else {
-      window.open(youtubeLoginUrl, '_blank');
+      window.open(youtubeLoginUrl, '_blank', 'noopener,noreferrer');
     }
   }
 

--- a/src/components/Panel.ts
+++ b/src/components/Panel.ts
@@ -920,11 +920,11 @@ export class Panel {
 
     const ctaBtn = h('button', { type: 'button', className: 'panel-locked-cta' }, 'Upgrade to Pro');
     if (isDesktopRuntime()) {
-      ctaBtn.addEventListener('click', () => void invokeTauri<void>('open_url', { url: 'https://worldmonitor.app/pro' }).catch(() => window.open('https://worldmonitor.app/pro', '_blank')));
+      ctaBtn.addEventListener('click', () => void invokeTauri<void>('open_url', { url: 'https://worldmonitor.app/pro' }).catch(() => window.open('https://worldmonitor.app/pro', '_blank', 'noopener,noreferrer')));
     } else {
       ctaBtn.addEventListener('click', () => {
         import('@/services/checkout').then(m => import('@/config/products').then(p => m.startCheckout(p.DEFAULT_UPGRADE_PRODUCT))).catch(() => {
-          window.open('https://worldmonitor.app/pro', '_blank');
+          window.open('https://worldmonitor.app/pro', '_blank', 'noopener,noreferrer');
         });
       });
     }

--- a/src/components/ResilienceWidget.ts
+++ b/src/components/ResilienceWidget.ts
@@ -213,7 +213,7 @@ export class ResilienceWidget {
           return;
         }
         void this.openUpgradeFlow().catch(() => {
-          window.open('https://worldmonitor.app/pro', '_blank');
+          window.open('https://worldmonitor.app/pro', '_blank', 'noopener,noreferrer');
         });
       },
     }, cta) as HTMLButtonElement;
@@ -483,14 +483,14 @@ export class ResilienceWidget {
     if (isDesktopRuntime()) {
       const { invokeTauri } = await import('@/services/tauri-bridge');
       await invokeTauri<void>('open_url', { url: 'https://worldmonitor.app/pro' })
-        .catch(() => { window.open('https://worldmonitor.app/pro', '_blank'); });
+        .catch(() => { window.open('https://worldmonitor.app/pro', '_blank', 'noopener,noreferrer'); });
       return;
     }
 
     await import('@/services/checkout')
       .then((module) => module.startCheckout(DEFAULT_UPGRADE_PRODUCT))
       .catch(() => {
-        window.open('https://worldmonitor.app/pro', '_blank');
+        window.open('https://worldmonitor.app/pro', '_blank', 'noopener,noreferrer');
       });
   }
 }

--- a/src/components/RouteExplorer/RouteExplorer.ts
+++ b/src/components/RouteExplorer/RouteExplorer.ts
@@ -358,7 +358,7 @@ export class RouteExplorer {
         });
         void import('@/services/checkout')
           .then((m) => m.startCheckout('pro_monthly'))
-          .catch(() => window.open('https://worldmonitor.app/pro', '_blank'));
+          .catch(() => window.open('https://worldmonitor.app/pro', '_blank', 'noopener,noreferrer'));
       }, { once: true });
     }
   }

--- a/src/components/RuntimeConfigPanel.ts
+++ b/src/components/RuntimeConfigPanel.ts
@@ -361,9 +361,9 @@ export class RuntimeConfigPanel extends Panel {
         const url = link.dataset.signupUrl;
         if (!url) return;
         if (isDesktopRuntime()) {
-          void invokeTauri<void>('open_url', { url }).catch(() => window.open(url, '_blank'));
+          void invokeTauri<void>('open_url', { url }).catch(() => window.open(url, '_blank', 'noopener,noreferrer'));
         } else {
-          window.open(url, '_blank');
+          window.open(url, '_blank', 'noopener,noreferrer');
         }
       });
     });
@@ -374,9 +374,9 @@ export class RuntimeConfigPanel extends Panel {
       this.content.querySelector<HTMLButtonElement>('[data-early-access]')?.addEventListener('click', () => {
         const url = 'https://www.worldmonitor.app/pro';
         if (isDesktopRuntime()) {
-          void invokeTauri<void>('open_url', { url }).catch(() => window.open(url, '_blank'));
+          void invokeTauri<void>('open_url', { url }).catch(() => window.open(url, '_blank', 'noopener,noreferrer'));
         } else {
-          window.open(url, '_blank');
+          window.open(url, '_blank', 'noopener,noreferrer');
         }
       });
       return;

--- a/src/components/StoryModal.ts
+++ b/src/components/StoryModal.ts
@@ -157,18 +157,18 @@ async function shareWhatsApp(data: StoryData): Promise<void> {
     downloadStory();
     flashButton('.story-whatsapp', t('modals.story.saved'), t('modals.story.whatsapp'));
   }
-  window.open(urls.whatsapp, '_blank');
+  window.open(urls.whatsapp, '_blank', 'noopener,noreferrer');
 }
 
 async function shareTwitter(data: StoryData): Promise<void> {
   const urls = getShareUrls(data);
-  window.open(urls.twitter, '_blank');
+  window.open(urls.twitter, '_blank', 'noopener,noreferrer');
   flashButton('.story-twitter', t('modals.story.opening'), t('modals.story.twitter'));
 }
 
 async function shareLinkedIn(data: StoryData): Promise<void> {
   const urls = getShareUrls(data);
-  window.open(urls.linkedin, '_blank');
+  window.open(urls.linkedin, '_blank', 'noopener,noreferrer');
   flashButton('.story-linkedin', t('modals.story.opening'), t('modals.story.linkedin'));
 }
 

--- a/src/components/UnifiedSettings.ts
+++ b/src/components/UnifiedSettings.ts
@@ -176,7 +176,7 @@ export class UnifiedSettings {
       const panelItem = target.closest<HTMLElement>('.panel-toggle-item');
       if (panelItem?.dataset.panel) {
         if (panelItem.dataset.proLocked) {
-          window.open('/pro', '_blank');
+          window.open('/pro', '_blank', 'noopener,noreferrer');
           return;
         }
         this.toggleDraftPanel(panelItem.dataset.panel);
@@ -684,11 +684,11 @@ export class UnifiedSettings {
     }
     this.close();
     if (this.config.isDesktopApp) {
-      window.open('https://worldmonitor.app/pro', '_blank');
+      window.open('https://worldmonitor.app/pro', '_blank', 'noopener,noreferrer');
       return;
     }
     import('@/services/checkout').then(m => import('@/config/products').then(p => m.startCheckout(p.DEFAULT_UPGRADE_PRODUCT))).catch(() => {
-      window.open('https://worldmonitor.app/pro', '_blank');
+      window.open('https://worldmonitor.app/pro', '_blank', 'noopener,noreferrer');
     });
   }
 
@@ -975,7 +975,7 @@ export class UnifiedSettings {
         } else {
           this.close();
           import('@/services/checkout').then(m => import('@/config/products').then(p => m.startCheckout(p.DODO_PRODUCTS.API_STARTER_MONTHLY))).catch(() => {
-            window.open('https://worldmonitor.app/pro', '_blank');
+            window.open('https://worldmonitor.app/pro', '_blank', 'noopener,noreferrer');
           });
         }
       });

--- a/src/services/notifications-settings.ts
+++ b/src/services/notifications-settings.ts
@@ -96,12 +96,12 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
           upgradeBtn.addEventListener('click', () => {
             if (!host.isSignedIn) {
               import('@/services/clerk').then(m => m.openSignIn()).catch(() => {
-                window.open('https://worldmonitor.app/pro', '_blank');
+                window.open('https://worldmonitor.app/pro', '_blank', 'noopener,noreferrer');
               });
               return;
             }
             import('@/services/checkout').then(m => import('@/config/products').then(p => m.startCheckout(p.DEFAULT_UPGRADE_PRODUCT))).catch(() => {
-              window.open('https://worldmonitor.app/pro', '_blank');
+              window.open('https://worldmonitor.app/pro', '_blank', 'noopener,noreferrer');
             });
           }, { signal });
         }

--- a/src/settings-main.ts
+++ b/src/settings-main.ts
@@ -267,7 +267,7 @@ function initOverviewListeners(area: HTMLElement): void {
 
   area.querySelector('[data-wm-open-pro]')?.addEventListener('click', () => {
     const url = 'https://worldmonitor.app/pro';
-    void invokeTauri<void>('open_url', { url }).catch(() => window.open(url, '_blank'));
+    void invokeTauri<void>('open_url', { url }).catch(() => window.open(url, '_blank', 'noopener,noreferrer'));
   });
 
   area.querySelectorAll<HTMLButtonElement>('.settings-ov-cat[data-section]').forEach(btn => {
@@ -485,9 +485,9 @@ function initFeatureSectionListeners(area: HTMLElement): void {
       const url = link.dataset.signupUrl;
       if (!url) return;
       if (isDesktopRuntime()) {
-        void invokeTauri<void>('open_url', { url }).catch(() => window.open(url, '_blank'));
+        void invokeTauri<void>('open_url', { url }).catch(() => window.open(url, '_blank', 'noopener,noreferrer'));
       } else {
-        window.open(url, '_blank');
+        window.open(url, '_blank', 'noopener,noreferrer');
       }
     });
   });

--- a/src/utils/follow-button.ts
+++ b/src/utils/follow-button.ts
@@ -119,17 +119,17 @@ let _upgradeTrigger: UpgradeTrigger = (source) => {
                 product as Parameters<typeof checkout.startCheckout>[0],
               );
             } else {
-              window.open('/pro#pricing', '_blank');
+              window.open('/pro#pricing', '_blank', 'noopener,noreferrer');
             }
           }),
         )
         .catch(() => {
-          window.open('/pro#pricing', '_blank');
+          window.open('/pro#pricing', '_blank', 'noopener,noreferrer');
         });
     });
   } catch {
     try {
-      window.open('/pro#pricing', '_blank');
+      window.open('/pro#pricing', '_blank', 'noopener,noreferrer');
     } catch {
       /* swallow — non-browser env */
     }
@@ -148,7 +148,7 @@ export function _setUpgradeTriggerForTests(fn: UpgradeTrigger | null): void {
   _upgradeTrigger = fn ?? ((source) => {
     void source;
     try {
-      window.open('/pro#pricing', '_blank');
+      window.open('/pro#pricing', '_blank', 'noopener,noreferrer');
     } catch {
       /* swallow */
     }

--- a/tests/followed-countries-cap-drop-toast.test.mjs
+++ b/tests/followed-countries-cap-drop-toast.test.mjs
@@ -48,8 +48,8 @@ describe('followed countries cap-drop toast wiring', () => {
     );
     assert.match(
       appSrc,
-      /window\.open\('\/pro#pricing', '_blank', 'noopener'\)/,
-      'toast must give the user an upgrade action without exposing window.opener',
+      /window\.open\('\/pro#pricing', '_blank', 'noopener,noreferrer'\)/,
+      'toast must give the user an upgrade action without exposing window.opener or referrer',
     );
     assert.match(
       appSrc,

--- a/tests/window-open-noopener.test.mjs
+++ b/tests/window-open-noopener.test.mjs
@@ -16,7 +16,7 @@ function walkTsFiles(dir) {
     const stat = statSync(full);
     if (stat.isDirectory()) {
       files.push(...walkTsFiles(full));
-    } else if (entry.endsWith('.ts')) {
+    } else if (entry.endsWith('.ts') || entry.endsWith('.tsx')) {
       files.push(full);
     }
   }
@@ -48,8 +48,9 @@ function hasSafeBlankFeatures(node) {
 
 function collectUnsafeWindowOpenCalls(file) {
   const source = readFileSync(file, 'utf-8');
-  if (!source.includes('window.open(')) return [];
-  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  if (!source.includes('window.open')) return [];
+  const scriptKind = file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, scriptKind);
   const unsafe = [];
 
   function visit(node) {

--- a/tests/window-open-noopener.test.mjs
+++ b/tests/window-open-noopener.test.mjs
@@ -1,0 +1,76 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '..');
+const srcDir = join(root, 'src');
+
+function walkTsFiles(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const stat = statSync(full);
+    if (stat.isDirectory()) {
+      files.push(...walkTsFiles(full));
+    } else if (entry.endsWith('.ts')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function staticStringValue(node) {
+  if (!node) return null;
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) return node.text;
+  return null;
+}
+
+function isWindowOpenCall(node) {
+  return ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === 'open' &&
+    ts.isIdentifier(node.expression.expression) &&
+    node.expression.expression.text === 'window';
+}
+
+function hasSafeBlankFeatures(node) {
+  const target = staticStringValue(node.arguments[1]);
+  if (target !== '_blank') return true;
+  const features = staticStringValue(node.arguments[2]);
+  if (!features) return false;
+  const tokens = new Set(features.split(',').map((token) => token.trim().toLowerCase()).filter(Boolean));
+  return tokens.has('noopener') && tokens.has('noreferrer');
+}
+
+function collectUnsafeWindowOpenCalls(file) {
+  const source = readFileSync(file, 'utf-8');
+  if (!source.includes('window.open(')) return [];
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const unsafe = [];
+
+  function visit(node) {
+    if (isWindowOpenCall(node) && !hasSafeBlankFeatures(node)) {
+      const { line, character } = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+      unsafe.push(`${relative(root, file)}:${line + 1}:${character + 1}`);
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return unsafe;
+}
+
+describe('window.open reverse-tabnabbing guard', () => {
+  it('requires noopener,noreferrer for _blank browser windows', () => {
+    const unsafe = walkTsFiles(srcDir).flatMap(collectUnsafeWindowOpenCalls);
+    assert.deepEqual(
+      unsafe,
+      [],
+      `window.open(..., '_blank') calls must pass 'noopener,noreferrer':\n${unsafe.join('\n')}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Browser tabs opened with `_blank` now consistently opt out of opener access, closing the reverse-tabnabbing gap in fallback upgrade, sharing, download, and external-link paths. Native Tauri `open_url` behavior is unchanged; only browser `window.open` fallbacks and direct browser opens gained `noopener,noreferrer`.

## Problem
Several `window.open(url, '_blank')` call sites lacked a feature string, which can leave `window.opener` exposed in browsers or embedded environments that still preserve it. An opened third-party page could then navigate the original WorldMonitor window.

## Fix
Added `noopener,noreferrer` to every `_blank` browser `window.open` call in `src/`, including places that previously had only `noopener`. Added an AST-based regression test that scans TypeScript sources and fails on any future `window.open(..., '_blank')` without both tokens.

## Validation
- `node --test tests/window-open-noopener.test.mjs`
- `npm run typecheck`
- Pre-push hook passed: source/API typecheck, Convex audit, CJS syntax, Unicode, architectural boundaries, safe HTML, rate-limit policies, premium-fetch parity, edge bundle check, changed test files, edge function tests, version sync.

## Known exceptions
No justified `_blank` browser exceptions remain. Named OAuth popup windows are unchanged because they are not `_blank` calls, and native Tauri `open_url` paths were intentionally left intact.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)