### PR TITLE
fix(convex): converge api key cap overflow

### DIFF
--- a/convex/__tests__/apiKeys.test.ts
+++ b/convex/__tests__/apiKeys.test.ts
@@ -123,6 +123,43 @@ describe("createApiKey", () => {
     await expect(
       asApiUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(6)),
     ).rejects.toThrow(/KEY_LIMIT_REACHED/);
+
+    const keys = await asApiUser.query(api.apiKeys.listApiKeys, {});
+    expect(keys.filter((k: any) => !k.revokedAt)).toHaveLength(5);
+    expect(keys.filter((k: any) => k.revokedAt)).toHaveLength(0);
+  });
+
+  test("race-leftover overflow converges back to 5 active keys while creating", async () => {
+    // Models the post-race state: concurrent create calls left 6 active keys.
+    // convex-test serializes mutations, so seed the over-cap state directly.
+    const t = convexTest(schema, modules);
+    await seedApiEntitlement(t, "user-api");
+
+    await t.run(async (ctx) => {
+      const now = Date.now();
+      for (let i = 1; i <= 6; i++) {
+        const args = makeKeyArgs(i);
+        await ctx.db.insert("userApiKeys", {
+          userId: "user-api",
+          name: args.name,
+          keyPrefix: args.keyPrefix,
+          keyHash: args.keyHash,
+          createdAt: now - (6 - i) * 1000,
+        });
+      }
+    });
+
+    const asApiUser = t.withIdentity(API_USER);
+    const created = await asApiUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(7));
+    expect(created.name).toBe("test-key-7");
+
+    const keys = await asApiUser.query(api.apiKeys.listApiKeys, {});
+    const active = keys.filter((k: any) => !k.revokedAt);
+    const revoked = keys.filter((k: any) => k.revokedAt);
+    expect(active).toHaveLength(5);
+    expect(revoked).toHaveLength(2);
+    expect(revoked.map((k: any) => k.name).sort()).toEqual(["test-key-1", "test-key-2"]);
+    expect(active.some((k: any) => k.name === "test-key-7")).toBe(true);
   });
 
   test("revoked keys do not count toward the limit", async () => {

--- a/convex/__tests__/apiKeys.test.ts
+++ b/convex/__tests__/apiKeys.test.ts
@@ -46,6 +46,26 @@ async function seedApiEntitlement(
   });
 }
 
+async function seedActiveApiKeys(
+  t: ReturnType<typeof convexTest>,
+  userId: string,
+  count: number,
+) {
+  await t.run(async (ctx) => {
+    const now = Date.now();
+    for (let i = 1; i <= count; i++) {
+      const args = makeKeyArgs(i);
+      await ctx.db.insert("userApiKeys", {
+        userId,
+        name: args.name,
+        keyPrefix: args.keyPrefix,
+        keyHash: args.keyHash,
+        createdAt: now - (count - i) * 1000,
+      });
+    }
+  });
+}
+
 /** Seed entitlement with apiAccess=false (Pro plan, tier 1). */
 async function seedProEntitlement(
   t: ReturnType<typeof convexTest>,
@@ -129,38 +149,36 @@ describe("createApiKey", () => {
     expect(keys.filter((k: any) => k.revokedAt)).toHaveLength(0);
   });
 
-  test("race-leftover overflow converges back to 5 active keys while creating", async () => {
-    // Models the post-race state: concurrent create calls left 6 active keys.
-    // convex-test serializes mutations, so seed the over-cap state directly.
-    const t = convexTest(schema, modules);
-    await seedApiEntitlement(t, "user-api");
+  for (const overflow of [
+    { seededActive: 6, nextKey: 7, revokedNames: ["test-key-1", "test-key-2"] },
+    {
+      seededActive: 8,
+      nextKey: 9,
+      revokedNames: ["test-key-1", "test-key-2", "test-key-3", "test-key-4"],
+    },
+  ]) {
+    test(`race-leftover overflow from ${overflow.seededActive} active keys converges back to 5 active keys while creating`, async () => {
+      // convex-test serializes mutations, so seed the post-race over-cap state directly.
+      const t = convexTest(schema, modules);
+      await seedApiEntitlement(t, "user-api");
+      await seedActiveApiKeys(t, "user-api", overflow.seededActive);
 
-    await t.run(async (ctx) => {
-      const now = Date.now();
-      for (let i = 1; i <= 6; i++) {
-        const args = makeKeyArgs(i);
-        await ctx.db.insert("userApiKeys", {
-          userId: "user-api",
-          name: args.name,
-          keyPrefix: args.keyPrefix,
-          keyHash: args.keyHash,
-          createdAt: now - (6 - i) * 1000,
-        });
-      }
+      const asApiUser = t.withIdentity(API_USER);
+      const created = await asApiUser.mutation(
+        api.apiKeys.createApiKey,
+        makeKeyArgs(overflow.nextKey),
+      );
+      expect(created.name).toBe(`test-key-${overflow.nextKey}`);
+
+      const keys = await asApiUser.query(api.apiKeys.listApiKeys, {});
+      const active = keys.filter((k: any) => !k.revokedAt);
+      const revoked = keys.filter((k: any) => k.revokedAt);
+      expect(active).toHaveLength(5);
+      expect(revoked).toHaveLength(overflow.revokedNames.length);
+      expect(revoked.map((k: any) => k.name).sort()).toEqual(overflow.revokedNames);
+      expect(active.some((k: any) => k.name === `test-key-${overflow.nextKey}`)).toBe(true);
     });
-
-    const asApiUser = t.withIdentity(API_USER);
-    const created = await asApiUser.mutation(api.apiKeys.createApiKey, makeKeyArgs(7));
-    expect(created.name).toBe("test-key-7");
-
-    const keys = await asApiUser.query(api.apiKeys.listApiKeys, {});
-    const active = keys.filter((k: any) => !k.revokedAt);
-    const revoked = keys.filter((k: any) => k.revokedAt);
-    expect(active).toHaveLength(5);
-    expect(revoked).toHaveLength(2);
-    expect(revoked.map((k: any) => k.name).sort()).toEqual(["test-key-1", "test-key-2"]);
-    expect(active.some((k: any) => k.name === "test-key-7")).toBe(true);
-  });
+  }
 
   test("revoked keys do not count toward the limit", async () => {
     const t = convexTest(schema, modules);

--- a/convex/apiKeys.ts
+++ b/convex/apiKeys.ts
@@ -71,7 +71,8 @@ export const createApiKey = mutation({
       for (const key of toRevoke) {
         await ctx.db.patch(key._id, { revokedAt: now });
       }
-      activeCount = active.length - toRevoke.length;
+      // After revoking overflow keys there is always exactly one slot free.
+      activeCount = MAX_KEYS_PER_USER - 1;
     }
     if (activeCount >= MAX_KEYS_PER_USER) {
       throw new ConvexError("KEY_LIMIT_REACHED");

--- a/convex/apiKeys.ts
+++ b/convex/apiKeys.ts
@@ -53,12 +53,26 @@ export const createApiKey = mutation({
       throw new ConvexError("INVALID_HASH");
     }
 
-    // Enforce per-user key limit (count only non-revoked keys)
+    // Enforce per-user key limit (count only non-revoked keys).
+    //
+    // API keys intentionally reject at the cap instead of silently rotating a
+    // valid key. If a prior race left too many active rows, converge by
+    // revoking enough oldest overflow rows to make room for this create.
     const existing = await ctx.db
       .query("userApiKeys")
       .withIndex("by_userId", (q) => q.eq("userId", userId))
       .collect();
-    const activeCount = existing.filter((k) => !k.revokedAt).length;
+    const active = existing.filter((k) => !k.revokedAt);
+    let activeCount = active.length;
+    if (active.length > MAX_KEYS_PER_USER) {
+      active.sort((a, b) => a.createdAt - b.createdAt);
+      const toRevoke = active.slice(0, active.length - (MAX_KEYS_PER_USER - 1));
+      const now = Date.now();
+      for (const key of toRevoke) {
+        await ctx.db.patch(key._id, { revokedAt: now });
+      }
+      activeCount = active.length - toRevoke.length;
+    }
     if (activeCount >= MAX_KEYS_PER_USER) {
       throw new ConvexError("KEY_LIMIT_REACHED");
     }


### PR DESCRIPTION
## Summary

Concurrent API-key creates could leave a user above the five-active-key invariant because each mutation checked the active count before inserting. API-key creation now keeps the existing `KEY_LIMIT_REACHED` behavior for normal five-key accounts, while accounts already left in an invalid over-cap state converge on the next unique create by revoking enough oldest keys to finish at five active keys.

## Fix

- Preserves entitlement, validation, duplicate-hash, ownership, and revoked-key semantics in `createApiKey`.
- Revokes only race-leftover overflow rows, never a valid exactly-at-cap account.
- Keeps revoked rows visible for audit history instead of deleting them.

## Validation

- `./node_modules/.bin/vitest run --config vitest.config.mts convex/__tests__/apiKeys.test.ts`
- `npm run typecheck:api`
- Pre-push hook: root typecheck, API typecheck, Convex type check, CJS/Unicode/boundary/safe-HTML/Sentry/rate-limit/premium-fetch/edge bundle/version gates

## Concurrency Caveat

`convex-test` serializes mutations, so the regression seeds the post-race overflow state deterministically instead of trying to assert true parallel Convex execution. Also, Convex rolls back writes when a mutation throws; because of that, over-cap convergence must complete a unique create instead of revoking rows and then throwing `KEY_LIMIT_REACHED`.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
