### PR TITLE
fix(orank): declare MCP Apps extension capability in initialize handshake (Experience 0/4)

### DIFF
--- a/api/mcp/constants.ts
+++ b/api/mcp/constants.ts
@@ -216,11 +216,14 @@ export const SERVER_NAME = 'worldmonitor';
 //     and streams the tool result in via postMessage. resources/read of a
 //     ui:// URI is public + quota-exempt (static, data-free template); DATA
 //     reads (worldmonitor://…) stay gated + Pro-quota-symmetric.
-//   - Additive on the wire: `_meta` appears only on the linked tool; no new
-//     server capability key (the extension defines none — the signal is the
-//     ui:// resource + tool `_meta`). Clients that don't speak MCP Apps
-//     ignore the extra resource + the reserved `_meta` field. No input/output
-//     schema change to any existing tool.
+//   - Additive on the wire: `_meta` appears only on the linked tool. Clients
+//     that don't speak MCP Apps ignore the extra resource + the reserved
+//     `_meta` field. No input/output schema change to any existing tool.
+//     (NOTE: 1.11.0 shipped WITHOUT declaring the extension's initialize
+//     capability key — an incomplete handshake corrected in 1.13.0 below.
+//     Agent-readiness scanners classify an MCP-App surface off the negotiated
+//     `capabilities.extensions` key, so ui:// + `_meta` alone did not register
+//     as MCP Apps support.)
 // Bumped 1.11.0 → 1.12.0 (2026-07-04) reflecting:
 //   - Data resources split into two tiers by sensitivity, and a new
 //     `resources/templates/list` method:
@@ -247,9 +250,22 @@ export const SERVER_NAME = 'worldmonitor';
 //   - No initialize capability key added — resources/templates/list is
 //     covered by the existing `resources` capability (the spec has no
 //     separate templates capability flag).
+// Bumped 1.12.0 → 1.13.0 (2026-07-04) reflecting:
+//   - MCP Apps handshake completion: initialize.result.capabilities now
+//     declares `extensions: { 'io.modelcontextprotocol/ui': {} }` (spec
+//     2026-01-26). 1.11.0 shipped the ui:// app-shell resource + tool
+//     `_meta.ui.resourceUri` (the CONTENT of the extension) but never
+//     declared the extension in the capability handshake (the SIGNAL). Hosts
+//     and agent-readiness scanners negotiate/detect MCP Apps off this
+//     `capabilities.extensions` key, so the surface read as a plain MCP server
+//     despite carrying every ui:// artifact. Purely additive: clients that
+//     don't speak the extension ignore the extra capability key; no schema,
+//     envelope, or auth change. Mirrored into
+//     public/.well-known/mcp/server-card.json::capabilities.extensions so the
+//     static card and the live wire stay in parity.
 // Keep aligned with public/.well-known/mcp/server-card.json::serverInfo.version
 // — discovery scanners cross-check both values.
-export const SERVER_VERSION = '1.12.0';
+export const SERVER_VERSION = '1.13.0';
 
 // MCP logging capability — valid severity levels per the 2025-03-26 spec
 // (RFC 5424 subset). Stateless HTTP transport: we ACK the level but do not

--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -431,11 +431,22 @@ export async function mcpHandler(
         // `notifications/resources/list_changed`, so advertising `true`
         // would be a wire lie. `resources.subscribe: false` because
         // resources/subscribe is not implemented.
+        //
+        // `extensions['io.modelcontextprotocol/ui']` declares MCP Apps support
+        // (spec 2026-01-26). This is the extension's negotiation signal: a host
+        // (or agent-readiness scanner) reads it off `initialize.capabilities`
+        // to classify the server as an MCP-App surface — the ui:// app-shell
+        // resource + the tool `_meta.ui.resourceUri` are the content, this key
+        // is the handshake. Declared unconditionally: our ui:// shells
+        // and tool `_meta` are static and always present, so there is nothing
+        // to gate on the client advertising the extension. Value is an empty
+        // object per spec (extension carries no negotiation parameters here).
         capabilities: {
           tools: {},
           logging: {},
           prompts: { listChanged: false },
           resources: { subscribe: false, listChanged: false },
+          extensions: { 'io.modelcontextprotocol/ui': {} },
         },
         serverInfo: { name: SERVER_NAME, version: SERVER_VERSION },
         instructions: SERVER_INSTRUCTIONS,

--- a/docs/mcp-server.mdx
+++ b/docs/mcp-server.mdx
@@ -28,7 +28,7 @@ Pro subscribers can connect Claude Desktop / Cursor / claude.ai without ever pas
 | `https://api.worldmonitor.app/.well-known/oauth-authorization-server` | AS metadata (RFC 8414) |
 | `https://worldmonitor.app/.well-known/oauth-protected-resource` | Resource server metadata (RFC 9728) |
 
-Server identifier: `worldmonitor` v1.11.0.
+Server identifier: `worldmonitor` v1.13.0.
 
 ### Protocol negotiation
 
@@ -378,8 +378,9 @@ Resources come in two tiers. **Concrete resources** are surfaced by `resources/l
 
 ### MCP Apps (interactive UI)
 
-The server supports [MCP Apps](https://modelcontextprotocol.io/extensions/apps/build) (extension `io.modelcontextprotocol/ui`, spec `2026-01-26`) — interactive views a host renders in a sandboxed iframe when a linked tool is called. Two wire signals drive it:
+The server supports [MCP Apps](https://modelcontextprotocol.io/extensions/apps/build) (extension `io.modelcontextprotocol/ui`, spec `2026-01-26`) — interactive views a host renders in a sandboxed iframe when a linked tool is called. Three wire signals drive it:
 
+- **`initialize`** declares support in the handshake. The response's `capabilities.extensions` names the extension: `{"io.modelcontextprotocol/ui": {}}`. This is the negotiation signal a host (or agent-readiness scanner) reads to classify the endpoint as an MCP-App surface — the `tools/list` and `resources/list` entries below are the content it then renders.
 - **`tools/list`** advertises the linkage on the tool. `get_country_risk` carries `_meta.ui.resourceUri` (and the deprecated flat `ui/resourceUri` alias) pointing at its UI resource.
 - **`resources/list`** surfaces the UI resource itself, alongside the concrete data resource (the parameterised data templates live in `resources/templates/list`):
 

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -1,11 +1,11 @@
 {
   "name": "worldmonitor",
   "description": "WorldMonitor's live global-intelligence stack as an MCP server: real-time markets, conflict events, aviation, maritime, energy, climate, health, displacement, supply chain, and AI-generated regional briefs.",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "serverUrl": "https://worldmonitor.app/mcp",
   "serverInfo": {
     "name": "worldmonitor",
-    "version": "1.12.0",
+    "version": "1.13.0",
     "description": "WorldMonitor's live global-intelligence stack as an MCP server: real-time markets, conflict events, aviation, maritime, energy, climate, health, displacement, supply chain, and AI-generated regional briefs.",
     "vendor": "WorldMonitor",
     "homepage": "https://www.worldmonitor.app"
@@ -19,7 +19,8 @@
     "tools": true,
     "logging": true,
     "resources": true,
-    "prompts": true
+    "prompts": true,
+    "extensions": true
   },
   "tools": [
     {

--- a/tests/mcp-capability-parity.test.mjs
+++ b/tests/mcp-capability-parity.test.mjs
@@ -37,13 +37,23 @@ const originalEnv = { ...process.env };
 
 const VALID_KEY = 'wm_test_key_capability_parity';
 
-// Capabilities that are structurally registry-less. `logging` is a passive
-// receive-side capability — the handler ACKs `logging/setLevel` but the
-// stateless edge transport can't push `notifications/message` (same reason
-// `listChanged: false` on prompts/resources). Future passive-ACK additions
-// require an explicit edit to this allowlist AND a positive assertion in
-// the "structurally exempt" test below.
-const LOGGING_HAS_NO_REGISTRY = new Set(['logging']);
+// Capabilities that are structurally registry-less — advertised, but with no
+// `<cap>/list` method or backing registry to be non-empty.
+//   - `logging`: a passive receive-side capability — the handler ACKs
+//     `logging/setLevel` but the stateless edge transport can't push
+//     `notifications/message` (same reason `listChanged: false` on
+//     prompts/resources).
+//   - `extensions`: the MCP-Apps negotiation key
+//     (`extensions['io.modelcontextprotocol/ui']`, spec 2026-01-26). It is a
+//     handshake declaration, not a listable collection — the extension's
+//     CONTENT (ui:// app-shell resources, tool `_meta.ui.resourceUri`) is
+//     enumerated via resources/list + tools/list under the existing
+//     `resources`/`tools` capabilities, and is asserted directly in
+//     tests/mcp-resources.test.mjs. Non-emptiness of `extensions` itself is
+//     guarded below (the declared value must name the ui extension).
+// Future passive/declaration-only additions require an explicit edit to this
+// allowlist AND a positive assertion in the "structurally exempt" tests below.
+const REGISTRYLESS_CAPABILITIES = new Set(['logging', 'extensions']);
 
 // Mapping from advertised-capability name → (list-method, response-key,
 // __testing__ registry name). Three entries; an abstraction would obscure
@@ -147,7 +157,7 @@ describe('api/mcp.ts — capability parity (advertised AND non-empty)', () => {
     const advertised = advertisedFromCard(cardCaps);
 
     for (const cap of advertised) {
-      if (LOGGING_HAS_NO_REGISTRY.has(cap)) continue;
+      if (REGISTRYLESS_CAPABILITIES.has(cap)) continue;
       const wire = CAPABILITY_WIRE[cap];
       assert.ok(wire,
         `capability "${cap}" is advertised but has no CAPABILITY_WIRE mapping — ` +
@@ -171,7 +181,7 @@ describe('api/mcp.ts — capability parity (advertised AND non-empty)', () => {
     const advertised = advertisedFromCard(cardCaps);
 
     for (const cap of advertised) {
-      if (LOGGING_HAS_NO_REGISTRY.has(cap)) continue;
+      if (REGISTRYLESS_CAPABILITIES.has(cap)) continue;
       const wire = CAPABILITY_WIRE[cap];
       assert.ok(wire,
         `capability "${cap}" is advertised but has no CAPABILITY_WIRE mapping — see sibling test`,
@@ -192,8 +202,39 @@ describe('api/mcp.ts — capability parity (advertised AND non-empty)', () => {
       `'logging' must remain advertised — removing it requires editing this test deliberately ` +
       `(advertised: [${[...advertised].sort().join(', ')}])`,
     );
-    assert.ok(LOGGING_HAS_NO_REGISTRY.has('logging'),
-      `'logging' must remain in LOGGING_HAS_NO_REGISTRY — removing it requires editing this test deliberately`,
+    assert.ok(REGISTRYLESS_CAPABILITIES.has('logging'),
+      `'logging' must remain in REGISTRYLESS_CAPABILITIES — removing it requires editing this test deliberately`,
+    );
+  });
+
+  it('extensions capability (MCP Apps) is advertised, structurally exempt, AND names the ui extension on the wire', async () => {
+    const advertised = advertisedFromCard(cardCaps);
+    assert.ok(advertised.has('extensions'),
+      `'extensions' must remain advertised on the server-card — the MCP-Apps ` +
+      `negotiation key is how hosts/scanners classify an MCP-App surface ` +
+      `(advertised: [${[...advertised].sort().join(', ')}])`,
+    );
+    assert.ok(REGISTRYLESS_CAPABILITIES.has('extensions'),
+      `'extensions' must remain in REGISTRYLESS_CAPABILITIES — it is a handshake ` +
+      `declaration, not a listable registry`,
+    );
+
+    // Advertised-but-empty guard, extensions edition: the initialize wire must
+    // declare the ui extension key, not just an empty `extensions: {}` object.
+    // An empty extensions map reads (to a scanner) as "no MCP Apps support",
+    // the exact failure this capability exists to prevent.
+    const res = await handler(makeReq({
+      jsonrpc: '2.0', id: 3, method: 'initialize',
+      params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'test', version: '1.0' } },
+    }));
+    const body = await res.json();
+    const extensions = body.result?.capabilities?.extensions;
+    assert.ok(extensions && typeof extensions === 'object',
+      'initialize.result.capabilities.extensions must be an object');
+    assert.ok(
+      Object.prototype.hasOwnProperty.call(extensions, 'io.modelcontextprotocol/ui'),
+      `initialize must declare the MCP Apps extension key 'io.modelcontextprotocol/ui'; ` +
+      `got extensions=${JSON.stringify(extensions)}`,
     );
   });
 

--- a/tests/mcp-jmespath.test.mjs
+++ b/tests/mcp-jmespath.test.mjs
@@ -300,12 +300,12 @@ describe('api/mcp.ts — JMESPath projection (v1.7.0)', () => {
   // Initialize handshake — version + instructions
   // ============================================================
   describe('initialize handshake', () => {
-    it('serverInfo.version === "1.12.0"', async () => {
+    it('serverInfo.version === "1.13.0"', async () => {
       // Tracks current SERVER_VERSION. Each minor bump needs to update
       // this assertion + the cross-check at line 327 below.
       const res = await mod.default(makeReq(initBody(1)));
       const body = await res.json();
-      assert.equal(body.result?.serverInfo?.version, '1.12.0');
+      assert.equal(body.result?.serverInfo?.version, '1.13.0');
     });
 
     it('result.instructions is present and mentions jmespath', async () => {
@@ -326,12 +326,12 @@ describe('api/mcp.ts — JMESPath projection (v1.7.0)', () => {
       assert.ok(/daily quota/i.test(inst), 'missing quota note');
     });
 
-    it('server-card.json version matches SERVER_VERSION (currently 1.12.0)', () => {
+    it('server-card.json version matches SERVER_VERSION (currently 1.13.0)', () => {
       // Cross-check the comment at api/mcp.ts:~56 — discovery scanners
       // verify both values; a future bump that misses one would break
       // discovery. This is the test that prevents that drift.
       const card = JSON.parse(readFileSync(new URL('../public/.well-known/mcp/server-card.json', import.meta.url), 'utf8'));
-      assert.equal(card.serverInfo.version, '1.12.0');
+      assert.equal(card.serverInfo.version, '1.13.0');
       assert.equal(card.features?.responseProjection, 'jmespath');
     });
 
@@ -344,6 +344,7 @@ describe('api/mcp.ts — JMESPath projection (v1.7.0)', () => {
         logging: {},
         prompts: { listChanged: false },
         resources: { subscribe: false, listChanged: false },
+        extensions: { 'io.modelcontextprotocol/ui': {} },
       });
       assert.equal(body.result?.serverInfo?.name, 'worldmonitor');
     });

--- a/tests/mcp-resources.test.mjs
+++ b/tests/mcp-resources.test.mjs
@@ -207,6 +207,32 @@ describe('api/mcp.ts — resources capability + stability + auth-symmetry', () =
   });
 
   // -------------------------------------------------------------------------
+  // MCP Apps handshake — initialize declares the extension (the SIGNAL that
+  // pairs with the ui:// resource + tool `_meta` CONTENT asserted below).
+  // Hosts and agent-readiness scanners classify an MCP-App surface off this
+  // `capabilities.extensions` key; 1.11.0 shipped the ui:// artifacts but not
+  // this declaration, so the surface read as a plain MCP server. Guarding it
+  // here keeps the full MCP Apps triad (capability + resource + tool meta)
+  // enforced in one file.
+  // -------------------------------------------------------------------------
+  it('initialize declares the MCP Apps extension capabilities.extensions["io.modelcontextprotocol/ui"]', async () => {
+    const res = await handler(envKeyReq({
+      jsonrpc: '2.0', id: 1, method: 'initialize',
+      params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'test', version: '1.0' } },
+    }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    const extensions = body.result?.capabilities?.extensions;
+    assert.ok(extensions && typeof extensions === 'object',
+      'capabilities.extensions must be an object declaring supported MCP extensions');
+    assert.deepEqual(
+      extensions['io.modelcontextprotocol/ui'], {},
+      "capabilities.extensions['io.modelcontextprotocol/ui'] must be declared (empty object — the " +
+      'extension carries no negotiation parameters), signalling MCP Apps support to hosts/scanners',
+    );
+  });
+
+  // -------------------------------------------------------------------------
   // resources/list shape
   // -------------------------------------------------------------------------
   it('resources/list returns only concrete anon-readable resources: DATA freshness probe + ui:// shell, no {template} URIs', async () => {

--- a/tests/mcp-tools-list-compression.test.mjs
+++ b/tests/mcp-tools-list-compression.test.mjs
@@ -402,14 +402,14 @@ describe('api/mcp.ts — tools/list description compression (v1.7.0)', () => {
     // ============================================================
     // U4: Version bump + SERVER_INSTRUCTIONS + server-card sync
     // ============================================================
-    it('serverInfo.version === "1.12.0"', async () => {
+    it('serverInfo.version === "1.13.0"', async () => {
       const res = await mod.default(new Request('https://worldmonitor.app/mcp', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-WorldMonitor-Key': VALID_KEY },
         body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 't', version: '1' } } }),
       }));
       const body = await res.json();
-      assert.equal(body.result?.serverInfo?.version, '1.12.0');
+      assert.equal(body.result?.serverInfo?.version, '1.13.0');
     });
 
     it('initialize.result.instructions mentions describe_tool AND the TOOL_DESCRIPTION_MAX_BYTES cap value', async () => {
@@ -426,9 +426,9 @@ describe('api/mcp.ts — tools/list description compression (v1.7.0)', () => {
         'instructions should mention the TOOL_DESCRIPTION_MAX_BYTES cap');
     });
 
-    it('server-card.json version matches SERVER_VERSION (1.12.0) AND tools[] length matches (39)', () => {
+    it('server-card.json version matches SERVER_VERSION (1.13.0) AND tools[] length matches (39)', () => {
       const card = JSON.parse(readFileSync(new URL('../public/.well-known/mcp/server-card.json', import.meta.url), 'utf8'));
-      assert.equal(card.serverInfo.version, '1.12.0');
+      assert.equal(card.serverInfo.version, '1.13.0');
       // orank (ora.ai) agent-readiness scanner reads the card's `tools` as an
       // ARRAY (tools[]) for pre-connection preview — not the old {count,categories}
       // object. Keep it an array; the count now derives from the length.


### PR DESCRIPTION
## What

Declares the MCP Apps extension in the `initialize` handshake so agent hosts and readiness scanners (orank/ora.ai) detect our MCP Apps support.

```diff
  capabilities: {
    tools: {},
    logging: {},
    prompts: { listChanged: false },
    resources: { subscribe: false, listChanged: false },
+   extensions: { 'io.modelcontextprotocol/ui': {} },
  },
```

## Why

orank scored **Experience 0/4 — "No MCP Apps support detected"** even though prod already served every ui:// artifact shipped in #4761 (1.11.0):

- `get_country_risk` carries `_meta.ui.resourceUri`
- `resources/list` surfaces `ui://worldmonitor/country-risk.html` (mimeType `text/html;profile=mcp-app`, public + quota-exempt read)
- the HTML carries uppercase DOCTYPE, `color-scheme: light dark`, and a scoped CSP meta

I verified all of that on live prod over orank's exact transport (streamable-http/SSE, every protocol version). The score still would not move.

The missing piece is the extension's **negotiation signal**. Per the MCP Apps spec (2026-01-26) a server declares support in the initialize response:

```json
"capabilities": { "extensions": { "io.modelcontextprotocol/ui": {} } }
```

Our initialize response advertised **no** `extensions` key. orank classifies an MCP-App surface off this negotiated capability — its OpenAPI defines `urlKind: "mcp-app"` as *"MCP server negotiating the MCP Apps extension `io.modelcontextprotocol/ui`"*. So the ui:// resource + tool `_meta` alone read as a plain MCP server. This is exactly why an earlier registry-only pass "already did that & didn't fix it" — it shipped the content but never the handshake. The 1.11.0 code comment even asserted *"the extension defines none [server capability key]"*, which the current spec contradicts.

## Changes (SERVER_VERSION 1.12.0 → 1.13.0, purely additive on the wire)

- **`api/mcp/handler.ts`** — declare `extensions: { 'io.modelcontextprotocol/ui': {} }` in `initialize.result.capabilities`, unconditionally (our ui:// shells + tool `_meta` are static, so there is nothing to gate on client advertisement).
- **`api/mcp/constants.ts`** — bump `SERVER_VERSION`, correct the stale 1.11.0 comment, add a 1.13.0 version-history entry.
- **`public/.well-known/mcp/server-card.json`** — mirror `capabilities.extensions: true` + version bump so the static card and live wire stay in parity.
- **`docs/mcp-server.mdx`** — document the initialize handshake as the third (primary) MCP Apps wire signal; fix the stale version line.
- **tests** — extend capability-parity (registry-less exemption + a positive advertised-but-empty guard that the ui extension key is named on the wire), add a wire assertion in `mcp-resources`, update the capabilities snapshot in `mcp-jmespath`, and the four `SERVER_VERSION` pins.

## Verification

- `initialize` now returns `capabilities.extensions['io.modelcontextprotocol/ui']` ✅
- `tsc --noEmit -p tsconfig.api.json` clean (0 errors) ✅
- 301 MCP unit tests green (capability-parity, jmespath, resources, tools-list-compression, transport/protocol conformance, presets, api-parity, telemetry) ✅

⚠️ **Must merge + deploy** — orank rescans live `worldmonitor.app`, not the branch. Once deployed, rescan via `POST https://ora.ai/api/scan {"url":"worldmonitor.app"}`; Experience should move 0/4 → 4/4 (and the `na` view-domain/view-csp/ui-quality checks, gated behind detection, unlock the already-present ui:// signals).

https://claude.ai/code/session_01CtBBAck2mVcW83R4nFJ6Pi