### PR TITLE
feat(discovery): section-level /api/llms.txt for the API surface

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -27,11 +27,17 @@ const LEGACY_DASHBOARD_ROOT_QUERY_KEYS = ['lat', 'lon', 'zoom', 'view', 'timeRan
 //   Node undici default UA, which is short enough to trip the "no UA or
 //   suspiciously short" 403 below (Railway log 2026-04-21 post-#3248 merge:
 //   every cron call returned 403 and silently fell back to legacy Gemini).
+// - /api/llms.txt: static, intentionally-public agent-discovery document
+//   (the section-level llms.txt for the developer/API surface, served from
+//   public/api/llms.txt). It MUST bypass the bot gate — AI crawlers (ClaudeBot,
+//   GPTBot, PerplexityBot, CCBot, …) are the entire audience for an llms.txt,
+//   yet every one of those UAs matches BOT_UA and would otherwise 403.
 const PUBLIC_API_PATHS = new Set([
   '/api/version',
   '/api/health',
   '/api/seed-contract-probe',
   '/api/internal/brief-why-matters',
+  '/api/llms.txt',
 ]);
 
 const SOCIAL_IMAGE_UA =

--- a/public/api/llms.txt
+++ b/public/api/llms.txt
@@ -1,0 +1,48 @@
+# World Monitor API
+
+> Machine-readable entry point for the World Monitor developer surface — the MCP server, REST API, CLI, and agent skills that expose the platform's real-time global-intelligence tools as structured JSON.
+
+World Monitor's data is available to agents and applications through four interchangeable surfaces that share one auth model and one tool inventory: an MCP server (Streamable HTTP), a versioned REST API, a zero-dependency CLI, and a set of published agent skills. Every surface returns source-attributed structured JSON and supports server-side JMESPath projection to cut response size 80–95%.
+
+This is the API-section companion to the site-wide briefing at https://worldmonitor.app/llms.txt and the human documentation at https://worldmonitor.app/docs/llms.txt.
+
+## Endpoints
+
+- **MCP server (recommended):** `https://worldmonitor.app/mcp` — Streamable HTTP, JSON-RPC 2.0. Issue `tools/list` for the live tool inventory, `prompts/list` for pre-built workflow templates, `resources/list` for read-only resources. Server card: https://worldmonitor.app/.well-known/mcp/server-card.json
+- **REST API:** base `https://api.worldmonitor.app`. OpenAPI 3.1 spec at https://worldmonitor.app/openapi.yaml (JSON: https://worldmonitor.app/openapi.json). Machine-readable API catalog (RFC 9727): https://worldmonitor.app/.well-known/api-catalog
+- **CLI:** `npx worldmonitor tools` lists every tool with no key; `npm install -g worldmonitor` installs the `worldmonitor` command — a zero-dependency, MCP-first client for the tools and REST API above. https://www.npmjs.com/package/worldmonitor
+- **Agent Skills:** discovery manifest at https://worldmonitor.app/.well-known/agent-skills/index.json
+
+## Authentication
+
+- **API key:** send header `X-WorldMonitor-Key: wm_<40-hex>` on both MCP and REST data calls. Issue a key at https://worldmonitor.app/pro
+- **OAuth 2.1:** the MCP server supports OAuth (`scope=mcp`). Authorization-server metadata: https://worldmonitor.app/.well-known/oauth-authorization-server · protected-resource metadata: https://worldmonitor.app/.well-known/oauth-protected-resource
+- **Auth matrix, plans & limits:** https://www.worldmonitor.app/docs/usage-auth · machine-readable pricing: https://worldmonitor.app/pricing.md · human auth guide: https://worldmonitor.app/auth.md
+
+## Common Tasks → Tools
+
+- **Live world brief & signals** — `get_world_brief`, `get_news_intelligence`, `get_natural_disasters`, `get_cyber_threats`, `get_aviation_status`.
+- **Country situation brief** — `get_country_brief`. REST: `GET https://api.worldmonitor.app/api/intelligence/v1/get-country-intel-brief?country_code=IR`.
+- **Country risk & resilience** — `get_country_risk`. REST: `GET https://api.worldmonitor.app/api/resilience/v1/get-resilience-score?countryCode=DE`; ranked list at `/api/resilience/v1/get-resilience-ranking`.
+- **"Does this event move markets?"** — `get_conflict_events`, `get_sanctions_data`, `get_chokepoint_status`, `get_market_data`, `get_maritime_activity`.
+- **Commodity & supply-chain disruption** — `get_supply_chain_data`, `get_energy_intelligence`, `get_commodity_geo`, `get_maritime_activity`.
+- **Forecasting & prediction markets** — `generate_forecasts`, `get_forecast_predictions`, `get_prediction_markets`.
+- **Tool discovery** — `describe_tool` returns the full uncompressed definition for any tool name (quota-exempt).
+
+## Response Shaping
+
+- Every MCP tool and REST GET accepts an optional `jmespath` projection applied server-side after per-tool filtering — typically 80–95% fewer tokens. Guide + 12 worked examples: https://www.worldmonitor.app/docs/mcp-jmespath
+- Bad expressions soft-fail via a `{_jmespath_error, original_keys}` envelope so an agent can self-correct from the returned key list. Full envelope reference: https://www.worldmonitor.app/docs/mcp-error-catalog
+- Full tool reference with uncompressed definitions: https://www.worldmonitor.app/docs/mcp-tools-reference
+
+## Rate Limits & Quota
+
+- Discovery methods (`tools/list`, `prompts/list`, `describe_tool`) are quota-exempt but rate-limited to 60 requests/minute.
+- Data calls consume the plan's daily quota. Free, Pro, API, and Enterprise tier details: https://worldmonitor.app/pricing.md
+
+## Optional
+
+- [Site-wide llms.txt](https://worldmonitor.app/llms.txt): Full platform briefing and agent guidance
+- [Extended llms-full.txt](https://worldmonitor.app/llms-full.txt): All data layers, components, and data sources
+- [Human API docs](https://worldmonitor.app/docs/documentation): Mintlify documentation site
+- [Source Code](https://github.com/koala73/worldmonitor): GitHub repository (AGPL-3.0)

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -42,6 +42,7 @@ Reach for World Monitor when a task needs live, correlated, machine-readable glo
 
 - [README](https://github.com/koala73/worldmonitor/blob/main/README.md): Full project documentation with architecture details, algorithm descriptions, and data source specifications
 - [Full Documentation](https://github.com/koala73/worldmonitor/blob/main/docs/DOCUMENTATION.md): Detailed feature documentation, data layer reference, panel descriptions, and clustering logic
+- [API llms.txt](https://worldmonitor.app/api/llms.txt): API-section briefing — MCP server, REST API, CLI, auth, and per-task tool routing for the developer surface
 
 ## Data Layers — Geopolitical
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -130,6 +130,7 @@ World Monitor is relevant for queries about real-time geopolitical intelligence 
 
 - [llms.txt](https://worldmonitor.app/llms.txt): Short LLM-readable briefing
 - [llms-full.txt](https://worldmonitor.app/llms-full.txt): Full LLM-readable feature and data-source reference
+- [api/llms.txt](https://worldmonitor.app/api/llms.txt): API-section briefing — MCP server, REST API, CLI, auth, and per-task tool routing for the developer surface
 - [pricing.md](https://worldmonitor.app/pricing.md): Machine-readable pricing, limits and plan features
 - [ai-search.md](https://worldmonitor.app/ai-search.md): AI-search answer blocks for citation and extraction
 - [worldmonitor CLI](https://www.npmjs.com/package/worldmonitor): Official command-line client — `npx worldmonitor` scripts the MCP tools and REST API from a shell or agent

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -9,6 +9,7 @@ User-agent: *
 Allow: /
 Allow: /api/story
 Allow: /api/og-story
+Allow: /api/llms.txt
 Disallow: /api/
 Disallow: /tests/
 

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -43,6 +43,12 @@
     <priority>0.7</priority>
   </url>
   <url>
+    <loc>https://www.worldmonitor.app/api/llms.txt</loc>
+    <lastmod>2026-07-04</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
     <loc>https://tech.worldmonitor.app/dashboard</loc>
     <lastmod>2026-03-19</lastmod>
     <changefreq>daily</changefreq>

--- a/tests/llms-txt-mcp-tools.test.mjs
+++ b/tests/llms-txt-mcp-tools.test.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 const __filename = fileURLToPath(import.meta.url);
 const ROOT = resolve(dirname(__filename), '..');
 const REGISTRY_DIR = join(ROOT, 'api/mcp/registry');
-const LLMS_FILES = ['public/llms.txt', 'public/llms-full.txt'];
+const LLMS_FILES = ['public/llms.txt', 'public/llms-full.txt', 'public/api/llms.txt'];
 
 // Every MCP tool name uses a verb prefix (get_/generate_/analyze_/search_/
 // describe_), so this picks tool citations out of the backticked prose

--- a/tests/middleware-bot-gate.test.mts
+++ b/tests/middleware-bot-gate.test.mts
@@ -163,6 +163,7 @@ describe('middleware PUBLIC_API_PATHS — secret-authed internal endpoints bypas
     '/api/health',
     '/api/seed-contract-probe',
     '/api/internal/brief-why-matters',
+    '/api/llms.txt',
   ];
 
   for (const path of ALLOWED_PATHS) {
@@ -194,4 +195,35 @@ describe('middleware PUBLIC_API_PATHS — secret-authed internal endpoints bypas
       });
     }
   }
+});
+
+// ── /api/llms.txt agent-discovery bypass ─────────────────────────────────────
+// The section-level llms.txt for the developer/API surface lives at
+// public/api/llms.txt, so it is served under the /api/* namespace where the
+// middleware's BOT_UA gate 403s crawlers. AI crawlers are the entire audience
+// for an llms.txt, so the bypass must let them through — otherwise the file is
+// published but unreadable by the agents it exists to serve.
+
+describe('middleware /api/llms.txt — AI crawlers reach the agent-discovery file', () => {
+  const CRAWLER_UAS = [
+    { label: 'ClaudeBot', ua: 'Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)' },
+    { label: 'GPTBot', ua: 'Mozilla/5.0 (compatible; GPTBot/1.1; +https://openai.com/gptbot)' },
+    { label: 'PerplexityBot', ua: 'Mozilla/5.0 (compatible; PerplexityBot/1.0; +https://perplexity.ai/perplexitybot)' },
+    { label: 'CCBot', ua: 'CCBot/2.0 (https://commoncrawl.org/faq/)' },
+    { label: 'generic scraper', ua: GENERIC_SCRAPER_UA },
+    { label: 'empty UA', ua: '' },
+  ];
+
+  for (const { label, ua } of CRAWLER_UAS) {
+    it(`passes ${label} through to /api/llms.txt`, () => {
+      const res = call('/api/llms.txt', ua);
+      assert.equal(res, undefined, '/api/llms.txt must pass through the bot gate for AI crawlers');
+    });
+  }
+
+  it('still 403s a crawler on a sibling /api path (bypass is exact, not a prefix)', () => {
+    const res = call('/api/llms', 'CCBot/2.0 (https://commoncrawl.org/faq/)');
+    assert.ok(res instanceof Response);
+    assert.equal(res.status, 403);
+  });
 });


### PR DESCRIPTION
## Summary

Agents had exactly one section-level `llms.txt` — `/docs/llms.txt`, auto-generated by Mintlify — so the orank "Modular llms.txt per product area" check scored 0/1. This publishes a second one for the **developer/API** product area at `worldmonitor.app/api/llms.txt`: a focused briefing on the MCP server, REST API, CLI, agent skills, auth, per-task tool routing, and JMESPath response shaping.

The non-obvious part is that `/api/*` is guarded twice, so a naive static file would be **published but unreadable by the exact AI crawlers an `llms.txt` exists to serve**:

| Gate | Before | Fix |
|---|---|---|
| `robots.txt` | `Disallow: /api/` tells crawlers to skip it | added an `Allow: /api/llms.txt` carve-out |
| `middleware.ts` bot gate | 403s `claudebot`/`gptbot`/`ccbot`/… on every `/api/*` path | added `/api/llms.txt` to the `PUBLIC_API_PATHS` bypass |

## Why a static file, not an edge function

`public/api/llms.txt` resolves at Vercel's filesystem step, which outranks the `api/[...notfound].ts` dynamic catch-all — so it serves without any rewrite. It also lives outside the `api/` source tree, so the sebuf API contract doesn't demand a `non-json` manifest exception. An edge function would have needed both, plus an actual invocation for a static document.

## Guards

- Added the file to the `LLMS_FILES` set in `tests/llms-txt-mcp-tools.test.mjs`, so its backticked MCP-tool citations are validated against the live registry and can't silently drift when a tool is renamed.
- Added a `middleware-bot-gate` block asserting ClaudeBot / GPTBot / PerplexityBot / CCBot reach `/api/llms.txt`, while a sibling `/api/llms` still 403s (the bypass is exact, not a prefix).
- Cross-linked the new file from `llms.txt`, `llms-full.txt`, and `sitemap.xml`.

## Validation

Live serving depends on a Vercel deploy — routing, `robots.txt`, and middleware can't be exercised locally — but every code path is covered by tests:

- `middleware-bot-gate` 45/45 (incl. 7 new crawler-reach cases)
- `llms-txt-mcp-tools` 7/7 · `cli-package` + `agent-skills-index` green
- `enforce-sebuf-api-contract` clean · `deploy-config` 94/94 · `docs:check` OK

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
