### PR TITLE
fix(security): prevent client env secret bundling

### DIFF
--- a/src/bootstrap/secondary-startup.ts
+++ b/src/bootstrap/secondary-startup.ts
@@ -46,7 +46,7 @@ const DASHBOARD_FONT_LOADERS: Record<DashboardFontFamily, () => Promise<unknown>
 
 function getBuildVariant(): string {
   try {
-    return import.meta.env?.VITE_VARIANT || 'full';
+    return import.meta.env.VITE_VARIANT || 'full';
   } catch {
     return 'full';
   }

--- a/src/components/EnergyRiskOverviewPanel.ts
+++ b/src/components/EnergyRiskOverviewPanel.ts
@@ -39,9 +39,13 @@ const BRENT_META = [{ symbol: BRENT_SYMBOL, name: 'Brent Crude', display: 'BRENT
 // via VITE_HORMUZ_CRISIS_START_DATE so the date can be re-pinned without a
 // redeploy when the editorial framing shifts.
 const DEFAULT_CRISIS_START_DATE = '2026-02-23';
-const CRISIS_START_DATE: string =
-  (import.meta.env?.VITE_HORMUZ_CRISIS_START_DATE as string | undefined) ||
-  DEFAULT_CRISIS_START_DATE;
+const CRISIS_START_DATE: string = (() => {
+  try {
+    return import.meta.env.VITE_HORMUZ_CRISIS_START_DATE || DEFAULT_CRISIS_START_DATE;
+  } catch {
+    return DEFAULT_CRISIS_START_DATE;
+  }
+})();
 const CRISIS_START_MS = Date.parse(`${CRISIS_START_DATE}T00:00:00Z`);
 
 // Map Hormuz status enum → severity color. Values come from

--- a/src/config/variant.ts
+++ b/src/config/variant.ts
@@ -1,6 +1,6 @@
 const buildVariant = (() => {
   try {
-    return import.meta.env?.VITE_VARIANT || 'full';
+    return import.meta.env.VITE_VARIANT || 'full';
   } catch {
     return 'full';
   }

--- a/src/services/clerk.ts
+++ b/src/services/clerk.ts
@@ -26,7 +26,15 @@ import { enqueueSentryCall } from '@/bootstrap/sentry-defer';
 
 type ClerkInstance = Clerk;
 
-const PUBLISHABLE_KEY = (typeof import.meta !== 'undefined' && import.meta.env?.VITE_CLERK_PUBLISHABLE_KEY) as string | undefined;
+function readPublishableKey(): string | undefined {
+  try {
+    return import.meta.env.VITE_CLERK_PUBLISHABLE_KEY;
+  } catch {
+    return undefined;
+  }
+}
+
+const PUBLISHABLE_KEY = readPublishableKey();
 
 let clerkInstance: ClerkInstance | null = null;
 let loadPromise: Promise<void> | null = null;

--- a/src/services/followed-countries.ts
+++ b/src/services/followed-countries.ts
@@ -415,7 +415,7 @@ function isFeatureFlagEnabled(): boolean {
   // Default ON in dev/preview; OFF only when explicitly set to '0'.
   // Plan U2: use `!== '0'` (default-on).
   try {
-    const flag = import.meta.env?.VITE_FOLLOW_COUNTRIES_ENABLED;
+    const flag = import.meta.env.VITE_FOLLOW_COUNTRIES_ENABLED;
     return flag !== '0';
   } catch {
     return true;

--- a/src/services/notifications-settings.ts
+++ b/src/services/notifications-settings.ts
@@ -67,6 +67,14 @@ function appendNotificationError(rowEl: HTMLElement, message: string): void {
   rowEl.appendChild(errorEl);
 }
 
+function getTelegramBotUsername(): string {
+  try {
+    return import.meta.env.VITE_TELEGRAM_BOT_USERNAME || 'WorldMonitorBot';
+  } catch {
+    return 'WorldMonitorBot';
+  }
+}
+
 export function renderNotificationsSettings(host: NotificationsSettingsHost): NotificationsSettingsResult {
   const isPro = !!host.isSignedIn && hasTier(1);
   const preselectCountry = normalizePreselectCountry(host.preselectCountry);
@@ -793,7 +801,7 @@ export function renderNotificationsSettings(host: NotificationsSettingsHost): No
           setTrustedHtml(rowEl, trustedHtml(`<div class="us-notif-ch-icon">${channelIcon('telegram')}</div><div class="us-notif-ch-body"><div class="us-notif-ch-name">Telegram</div><div class="us-notif-ch-sub">Generating code…</div></div>`, "legacy direct innerHTML migration"));
           createPairingToken().then(({ token, expiresAt }) => {
             if (signal.aborted) return;
-            const botUsername = (typeof import.meta !== 'undefined' && import.meta.env?.VITE_TELEGRAM_BOT_USERNAME as string | undefined) ?? 'WorldMonitorBot';
+            const botUsername = getTelegramBotUsername();
             const deepLink = `https://t.me/${String(botUsername)}?start=${token}`;
             const startCmd = `/start ${token}`;
             const secsLeft = Math.max(0, Math.floor((expiresAt - Date.now()) / 1000));

--- a/src/services/runtime-config.ts
+++ b/src/services/runtime-config.ts
@@ -295,8 +295,20 @@ export const RUNTIME_FEATURES: RuntimeFeatureDefinition[] = [
   },
 ];
 
+function readClientEnvOpenskyRelayUrl(): string {
+  try {
+    return typeof import.meta.env.VITE_OPENSKY_RELAY_URL === 'string'
+      ? import.meta.env.VITE_OPENSKY_RELAY_URL.trim()
+      : '';
+  } catch {
+    return '';
+  }
+}
+
 function readEnvSecret(key: RuntimeSecretKey): string {
-  const envValue = (import.meta as { env?: Record<string, unknown> }).env?.[key];
+  const envValue = key === 'VITE_OPENSKY_RELAY_URL'
+    ? readClientEnvOpenskyRelayUrl()
+    : '';
   return typeof envValue === 'string' ? envValue.trim() : '';
 }
 

--- a/src/services/runtime-config.ts
+++ b/src/services/runtime-config.ts
@@ -306,10 +306,9 @@ function readClientEnvOpenskyRelayUrl(): string {
 }
 
 function readEnvSecret(key: RuntimeSecretKey): string {
-  const envValue = key === 'VITE_OPENSKY_RELAY_URL'
+  return key === 'VITE_OPENSKY_RELAY_URL'
     ? readClientEnvOpenskyRelayUrl()
     : '';
-  return typeof envValue === 'string' ? envValue.trim() : '';
 }
 
 function readStoredToggles(): Record<RuntimeFeatureId, boolean> {

--- a/src/services/runtime.ts
+++ b/src/services/runtime.ts
@@ -3,7 +3,13 @@ import { getClerkToken } from '@/services/clerk';
 
 const ENV = (() => {
   try {
-    return import.meta.env ?? {};
+    return {
+      VITE_DESKTOP_RUNTIME: import.meta.env.VITE_DESKTOP_RUNTIME,
+      VITE_TAURI_API_BASE_URL: import.meta.env.VITE_TAURI_API_BASE_URL,
+      VITE_TAURI_REMOTE_API_BASE_URL: import.meta.env.VITE_TAURI_REMOTE_API_BASE_URL,
+      VITE_WS_API_URL: import.meta.env.VITE_WS_API_URL,
+      VITE_WS_RELAY_URL: import.meta.env.VITE_WS_RELAY_URL,
+    };
   } catch {
     return {} as Record<string, string | undefined>;
   }

--- a/tests/browser-bundle-secret-guard.test.mts
+++ b/tests/browser-bundle-secret-guard.test.mts
@@ -33,6 +33,7 @@ import assert from 'node:assert/strict';
 import { readdir, readFile, stat } from 'node:fs/promises';
 import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import * as ts from 'typescript';
 
 // Server-side secrets that MUST NOT cross into the browser bundle. Each
 // of these grants access to worldmonitor.app infrastructure. They are
@@ -143,10 +144,29 @@ async function listFiles(root: string, extensions: Set<string>): Promise<string[
 
 function extractViteEnvNames(source: string): string[] {
   const keys = new Set<string>();
-  const directEnvRef = /\.env(?:\?)?\.(VITE_[A-Z0-9_]+)/g;
-  for (const match of source.matchAll(directEnvRef)) {
-    keys.add(match[1]);
+  const sourceFile = ts.createSourceFile('client-source.ts', source, ts.ScriptTarget.Latest, true);
+
+  function isImportMetaEnvExpression(expression: ts.Expression): boolean {
+    if (!ts.isPropertyAccessExpression(expression) || expression.name.text !== 'env') {
+      return false;
+    }
+    const receiver = expression.expression;
+    return ts.isMetaProperty(receiver)
+      && receiver.keywordToken === ts.SyntaxKind.ImportKeyword
+      && receiver.name.text === 'meta';
   }
+
+  function visit(node: ts.Node): void {
+    if (ts.isPropertyAccessExpression(node)) {
+      const envName = node.name.text;
+      if (/^VITE_[A-Z0-9_]+$/.test(envName) && isImportMetaEnvExpression(node.expression)) {
+        keys.add(envName);
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
   return [...keys].sort();
 }
 

--- a/tests/browser-bundle-secret-guard.test.mts
+++ b/tests/browser-bundle-secret-guard.test.mts
@@ -30,7 +30,9 @@
 
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // Server-side secrets that MUST NOT cross into the browser bundle. Each
 // of these grants access to worldmonitor.app infrastructure. They are
@@ -52,15 +54,165 @@ const PLATFORM_ONLY_SECRETS = [
   'MCP_PRO_GRANT_HMAC_SECRET',
 ] as const;
 
+// Server/provider credentials that must never be made reachable from browser
+// bundles. The VITE_* aliases are deliberately listed because a client prefix
+// on a server credential is still a server credential exposure.
+const SERVER_OR_PROVIDER_SECRET_ENV_NAMES = [
+  ...PLATFORM_ONLY_SECRETS,
+  'AISSTREAM_API_KEY',
+  'VITE_AISSTREAM_API_KEY',
+  'CLOUDFLARE_API_TOKEN',
+  'VITE_CLOUDFLARE_API_TOKEN',
+  'CLOUDFLARE_R2_TOKEN',
+  'VITE_CLOUDFLARE_R2_TOKEN',
+  'CLOUDFLARE_R2_SECRET_ACCESS_KEY',
+  'VITE_CLOUDFLARE_R2_SECRET_ACCESS_KEY',
+  'CLOUDFLARE_R2_ACCESS_KEY_ID',
+  'VITE_CLOUDFLARE_R2_ACCESS_KEY_ID',
+  'RELAY_SHARED_SECRET',
+  'VITE_RELAY_SHARED_SECRET',
+  'UPSTASH_REDIS_REST_TOKEN',
+  'VITE_UPSTASH_REDIS_REST_TOKEN',
+  'DODO_API_KEY',
+  'VITE_DODO_API_KEY',
+] as const;
+
+// Client-readable env names currently used by browser source. This list is
+// intentionally explicit so a future VITE_* provider token must be reviewed
+// instead of quietly joining the bundle.
+const CLIENT_ENV_ALLOWLIST = new Set([
+  'VITE_CLERK_PUBLISHABLE_KEY',
+  'VITE_CLOUD_PREFS_ENABLED',
+  'VITE_CONVEX_URL',
+  'VITE_DESKTOP_RUNTIME',
+  'VITE_DIGEST_CRON_ENABLED',
+  'VITE_DODO_ENVIRONMENT',
+  'VITE_E2E',
+  'VITE_ENABLE_AIS',
+  'VITE_ENABLE_CYBER_LAYER',
+  'VITE_FOLLOW_COUNTRIES_ENABLED',
+  'VITE_HORMUZ_CRISIS_START_DATE',
+  'VITE_MAP_INTERACTION_MODE',
+  'VITE_OPENSKY_RELAY_URL',
+  'VITE_PMTILES_URL',
+  'VITE_PMTILES_URL_PUBLIC',
+  'VITE_QUIET_HOURS_BATCH_ENABLED',
+  'VITE_RELAY_GATES_READY',
+  'VITE_RSS_DIRECT_TO_RELAY',
+  'VITE_SENTRY_DSN',
+  'VITE_TAURI_API_BASE_URL',
+  'VITE_TAURI_REMOTE_API_BASE_URL',
+  'VITE_TELEGRAM_BOT_USERNAME',
+  'VITE_VAPID_PUBLIC_KEY',
+  'VITE_VARIANT',
+  'VITE_WS_API_URL',
+  'VITE_WS_RELAY_URL',
+]);
+
 // Safe envPrefix entries — anything else exposes unprefixed env vars to
 // the browser bundle. Keep this list narrow.
 const SAFE_ENV_PREFIXES = ['VITE_', 'PUBLIC_'];
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..');
+const CLIENT_SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mts', '.mjs']);
+const BUILT_ASSET_EXTENSIONS = new Set(['.html', '.js', '.css', '.json', '.map']);
 
 async function readRepoFile(relPath: string): Promise<string> {
   return readFile(new URL(`../${relPath}`, import.meta.url), 'utf8');
 }
 
+async function listFiles(root: string, extensions: Set<string>): Promise<string[]> {
+  const entries = await readdir(root, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (entry.name === 'node_modules' || entry.name === '.git' || entry.name === 'dist') {
+      continue;
+    }
+    const fullPath = resolve(root, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await listFiles(fullPath, extensions));
+      continue;
+    }
+    const dot = entry.name.lastIndexOf('.');
+    const ext = dot >= 0 ? entry.name.slice(dot) : '';
+    if (extensions.has(ext)) files.push(fullPath);
+  }
+  return files;
+}
+
+function extractViteEnvNames(source: string): string[] {
+  const keys = new Set<string>();
+  const directEnvRef = /\.env(?:\?)?\.(VITE_[A-Z0-9_]+)/g;
+  for (const match of source.matchAll(directEnvRef)) {
+    keys.add(match[1]);
+  }
+  return [...keys].sort();
+}
+
 describe('browser bundle secret guard (#3704)', () => {
+  it('tracks Cloudflare and AISStream provider secret classes, including unsafe VITE aliases', () => {
+    for (const envName of [
+      'CLOUDFLARE_API_TOKEN',
+      'VITE_CLOUDFLARE_API_TOKEN',
+      'AISSTREAM_API_KEY',
+      'VITE_AISSTREAM_API_KEY',
+    ]) {
+      assert.ok(
+        SERVER_OR_PROVIDER_SECRET_ENV_NAMES.includes(envName as (typeof SERVER_OR_PROVIDER_SECRET_ENV_NAMES)[number]),
+        `${envName} must stay in the browser-bundle prohibited secret set`,
+      );
+    }
+  });
+
+  it('runtime env readers do not make the full Vite env object reachable', async () => {
+    for (const relPath of ['src/services/runtime.ts', 'src/services/runtime-config.ts']) {
+      const source = await readRepoFile(relPath);
+      assert.doesNotMatch(
+        source,
+        /return\s+import\.meta\.env\b/,
+        `${relPath} must not return import.meta.env wholesale`,
+      );
+      assert.doesNotMatch(
+        source,
+        /\b(?:const|let|var)\s+\w+\s*=\s*import\.meta\.env\b/,
+        `${relPath} must not snapshot import.meta.env into a local object`,
+      );
+      assert.doesNotMatch(
+        source,
+        /\.env\??\.\[[^\]]+\]/,
+        `${relPath} must not dynamically index import.meta.env`,
+      );
+    }
+  });
+
+  it('client source uses only reviewed VITE_* browser env names', async () => {
+    const sourceFiles = await listFiles(resolve(repoRoot, 'src'), CLIENT_SOURCE_EXTENSIONS);
+    const seen = new Map<string, string[]>();
+
+    for (const file of sourceFiles) {
+      const source = await readFile(file, 'utf8');
+      assert.doesNotMatch(
+        source,
+        /import\.meta\.env\?\./,
+        `${relative(repoRoot, file)} must not optional-chain import.meta.env; ` +
+          `Vite may preserve the full env object instead of inlining one key.`,
+      );
+      for (const key of extractViteEnvNames(source)) {
+        const relPath = relative(repoRoot, file);
+        seen.set(key, [...(seen.get(key) ?? []), relPath]);
+      }
+    }
+
+    for (const [key, paths] of seen) {
+      assert.ok(
+        CLIENT_ENV_ALLOWLIST.has(key),
+        `${key} is read by browser source but is not in the reviewed client env allowlist. ` +
+          `First seen in ${paths[0]}. Server/provider secrets must not use VITE_ aliases.`,
+      );
+    }
+  });
+
   it('runtime-config.ts does not list a platform-only secret as a required feature secret', async () => {
     const source = await readRepoFile('src/services/runtime-config.ts');
     // `requiredSecrets: [...]` literals are what seedSecretsFromEnvironment iterates.
@@ -93,12 +245,41 @@ describe('browser bundle secret guard (#3704)', () => {
     // guard. Only validate contents when the block is present.
     const defineMatch = source.match(/define:\s*\{[\s\S]{0,2000}?\n\s*\},/);
     if (!defineMatch) return;
-    for (const secret of PLATFORM_ONLY_SECRETS) {
+    for (const secret of SERVER_OR_PROVIDER_SECRET_ENV_NAMES) {
       assert.ok(
         !defineMatch[0].includes(secret),
         `${secret} appears inside the vite.config.ts define: block. ` +
           `That inlines the literal value into the browser bundle. See issue #3704.`,
       );
+    }
+  });
+
+  it('built browser assets do not contain configured server/provider secret values when dist exists', async () => {
+    const distDir = process.env.WM_BROWSER_BUNDLE_GUARD_DIST_DIR || resolve(repoRoot, 'dist');
+    try {
+      if (!(await stat(distDir)).isDirectory()) return;
+    } catch {
+      return;
+    }
+
+    const configuredSecrets = SERVER_OR_PROVIDER_SECRET_ENV_NAMES
+      .map((envName) => [envName, process.env[envName]] as const)
+      .filter((entry): entry is readonly [string, string] => (
+        typeof entry[1] === 'string' && entry[1].length >= 12
+      ));
+
+    if (configuredSecrets.length === 0) return;
+
+    const assetFiles = await listFiles(distDir, BUILT_ASSET_EXTENSIONS);
+    for (const file of assetFiles) {
+      const source = await readFile(file, 'utf8');
+      for (const [envName, value] of configuredSecrets) {
+        assert.ok(
+          !source.includes(value),
+          `${envName} value was found in built browser asset ${relative(repoRoot, file)}. ` +
+            `Rotate the credential and remove any client-prefixed copy from deployment env.`,
+        );
+      }
     }
   });
 

--- a/tests/runtime-env-guards.test.mjs
+++ b/tests/runtime-env-guards.test.mjs
@@ -9,10 +9,37 @@ const runtimeSrc = readFileSync(resolve(__dirname, '../src/services/runtime.ts')
 const variantSrc = readFileSync(resolve(__dirname, '../src/config/variant.ts'), 'utf-8');
 
 describe('runtime env guards', () => {
-  it('reads import.meta.env through a guarded ENV wrapper', () => {
-    assert.match(
+  it('reads only explicit import.meta.env properties through a guarded ENV wrapper', () => {
+    assert.doesNotMatch(
       runtimeSrc,
-      /const ENV = \(\(\) => \{\s*try \{\s*return import\.meta\.env \?\? \{\};\s*\} catch \{\s*return \{\} as Record<string, string \| undefined>;/s,
+      /return\s+import\.meta\.env\b/,
+      'runtime.ts must not return the whole Vite env object to client code',
+    );
+    assert.doesNotMatch(
+      runtimeSrc,
+      /\b(?:const|let|var)\s+\w+\s*=\s*import\.meta\.env\b/,
+      'runtime.ts must not snapshot import.meta.env into a local object',
+    );
+    for (const key of [
+      'VITE_DESKTOP_RUNTIME',
+      'VITE_TAURI_API_BASE_URL',
+      'VITE_TAURI_REMOTE_API_BASE_URL',
+      'VITE_WS_API_URL',
+      'VITE_WS_RELAY_URL',
+    ]) {
+      assert.ok(
+        runtimeSrc.includes(`${key}: import.meta.env.${key}`),
+        `runtime ENV wrapper must explicitly allow ${key}`,
+      );
+    }
+  });
+
+  it('runtime-config.ts does not dynamically read the Vite env object for secrets', () => {
+    const runtimeConfigSrc = readFileSync(resolve(__dirname, '../src/services/runtime-config.ts'), 'utf-8');
+    assert.doesNotMatch(
+      runtimeConfigSrc,
+      /\.env\?\.\[[^\]]+\]/,
+      'runtime-config.ts must not dynamically index import.meta.env for runtime secrets',
     );
   });
 
@@ -29,7 +56,7 @@ describe('variant env guards', () => {
   it('computes the build variant through a guarded import.meta.env access', () => {
     assert.match(
       variantSrc,
-      /const buildVariant = \(\(\) => \{\s*try \{\s*return import\.meta\.env\?\.VITE_VARIANT \|\| 'full';\s*\} catch \{\s*return 'full';\s*\}\s*\}\)\(\);/s,
+      /const buildVariant = \(\(\) => \{\s*try \{\s*return import\.meta\.env\.VITE_VARIANT \|\| 'full';\s*\} catch \{\s*return 'full';\s*\}\s*\}\)\(\);/s,
     );
   });
 


### PR DESCRIPTION
## Summary
Browser builds no longer make the full Vite env object reachable from client code. Runtime/config env access now uses reviewed direct property reads only, including replacing optional-chained env reads that Vite can preserve as a full env object.

The browser bundle guard now covers Cloudflare and AISStream provider-secret classes, unsafe client-prefixed aliases, reviewed client env names, and built asset scans for configured secret values. The dist proof uses synthetic values only.

Operator follow-up: rotate any exposed provider credentials and remove any client-prefixed copies of server/provider secrets from deployment env.

## Validation
- Focused guard tests: `tsx --test tests/browser-bundle-secret-guard.test.mts tests/runtime-env-guards.test.mjs`
- TypeScript: `tsc --noEmit --pretty false`
- Temporary production build with synthetic prohibited env aliases, followed by browser bundle secret guard scan against the temporary dist output
- Pre-push hook: typecheck, API typecheck, boundary/safe-HTML checks, rate-limit and premium-fetch audits, edge bundle check, changed tests, edge tests, and version check

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)