### PR TITLE
fix(payments): expire anonymous claim tokens

### DIFF
--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -22,6 +22,7 @@ afterEach(() => {
   vi.restoreAllMocks();
   vi.useRealTimers();
   delete process.env.DODO_IDENTITY_SIGNING_SECRET;
+  delete process.env.DODO_ANON_CLAIM_TOKEN_TTL_MS;
   delete process.env.UPSTASH_REDIS_REST_URL;
   delete process.env.UPSTASH_REDIS_REST_TOKEN;
 });
@@ -78,7 +79,7 @@ async function seedAnonClaimState(
       status: "active",
       currentPeriodStart: NOW - DAY_MS,
       currentPeriodEnd: NOW + 30 * DAY_MS,
-      rawPayload: { metadata: { wm_anon_claim: "v1" } },
+      rawPayload: { metadata: { wm_anon_claim: "v2" } },
       updatedAt: NOW,
     });
     await ctx.db.insert("entitlements", {
@@ -105,7 +106,7 @@ async function seedAnonClaimState(
       status: "succeeded",
       dodoSubscriptionId: "sub_anon_claim_001",
       planKey,
-      rawPayload: { metadata: { wm_anon_claim: "v1" } },
+      rawPayload: { metadata: { wm_anon_claim: "v2" } },
       occurredAt: NOW,
     });
 
@@ -158,6 +159,28 @@ describe("claimSubscription anonymous ownership proof", () => {
       t.withIdentity(CLAIMANT_B).mutation(api.payments.billing.claimSubscription, {
         anonId: ANON_USER_ID,
         claimToken: wrongToken,
+      }),
+    ).rejects.toThrow(/ANON_CLAIM_PROOF_REQUIRED/);
+
+    const realSub = await t.run(async (ctx) =>
+      ctx.db.query("subscriptions").withIndex("by_userId", (q) => q.eq("userId", CLAIMANT_B.subject)).first(),
+    );
+    expect(realSub).toBeNull();
+  });
+
+  test("rejects an expired proof token and leaves rows on the anon owner", async () => {
+    vi.useFakeTimers();
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    const t = convexTest(schema, modules);
+    await seedAnonClaimState(t);
+    vi.setSystemTime(NOW - 31 * DAY_MS);
+    const expiredToken = await signAnonClaimToken(ANON_USER_ID);
+    vi.setSystemTime(NOW);
+
+    await expect(
+      t.withIdentity(CLAIMANT_B).mutation(api.payments.billing.claimSubscription, {
+        anonId: ANON_USER_ID,
+        claimToken: expiredToken,
       }),
     ).rejects.toThrow(/ANON_CLAIM_PROOF_REQUIRED/);
 
@@ -258,6 +281,19 @@ describe("claimSubscription anonymous ownership proof", () => {
     ).resolves.toEqual({
       claimed: { subscriptions: 0, entitlements: 0, customers: 0, payments: 0 },
     });
+  });
+
+  test("rejects an invalid proof token even when there are no payment rows", async () => {
+    process.env.DODO_IDENTITY_SIGNING_SECRET = SIGNING_SECRET;
+    const t = convexTest(schema, modules);
+    const wrongToken = await signAnonClaimToken("22222222-2222-4222-8222-222222222222");
+
+    await expect(
+      t.withIdentity(CLAIMANT_B).mutation(api.payments.billing.claimSubscription, {
+        anonId: ANON_USER_ID,
+        claimToken: wrongToken,
+      }),
+    ).rejects.toThrow(/ANON_CLAIM_PROOF_REQUIRED/);
   });
 });
 

--- a/convex/lib/identitySigning.ts
+++ b/convex/lib/identitySigning.ts
@@ -11,7 +11,10 @@
  */
 
 export const ANON_ID_V4_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
-const ANON_CLAIM_TOKEN_PREFIX = "v1.";
+const ANON_CLAIM_TOKEN_VERSION = "v2";
+const DEFAULT_ANON_CLAIM_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+const MIN_ANON_CLAIM_TOKEN_TTL_MS = 60 * 60 * 1000;
+const MAX_ANON_CLAIM_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
 function getSigningKey(): string {
   const key = process.env.DODO_IDENTITY_SIGNING_SECRET;
@@ -57,6 +60,17 @@ function timingSafeEqualHex(expected: string, actual: string): boolean {
   return result === 0;
 }
 
+function getAnonClaimTokenTtlMs(): number {
+  const raw = process.env.DODO_ANON_CLAIM_TOKEN_TTL_MS;
+  if (!raw) return DEFAULT_ANON_CLAIM_TOKEN_TTL_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return DEFAULT_ANON_CLAIM_TOKEN_TTL_MS;
+  return Math.min(
+    Math.max(Math.trunc(parsed), MIN_ANON_CLAIM_TOKEN_TTL_MS),
+    MAX_ANON_CLAIM_TOKEN_TTL_MS,
+  );
+}
+
 /**
  * Creates an HMAC-SHA256 signature of the userId.
  * Returns a hex-encoded string suitable for metadata values.
@@ -84,28 +98,36 @@ export async function verifyUserId(
 /**
  * Creates a server-verifiable proof token for migrating anonymous checkout
  * records into a real Clerk account. The token is domain-separated from
- * wm_user_id_sig so it cannot be replayed as checkout identity metadata.
+ * wm_user_id_sig so it cannot be replayed as checkout identity metadata, and
+ * expires after the checkout-to-sign-in linking window.
  */
 export async function signAnonClaimToken(anonId: string): Promise<string> {
   if (!ANON_ID_V4_REGEX.test(anonId)) {
     throw new Error("[identity-signing] anonymous claim token requires a UUID-v4 anonId");
   }
-  const signature = await signPayload(`anon-claim:v1:${anonId}`);
-  return `${ANON_CLAIM_TOKEN_PREFIX}${signature}`;
+  const expiresAt = Date.now() + getAnonClaimTokenTtlMs();
+  const signature = await signPayload(`anon-claim:${ANON_CLAIM_TOKEN_VERSION}:${anonId}:${expiresAt}`);
+  return `${ANON_CLAIM_TOKEN_VERSION}.${expiresAt}.${signature}`;
 }
 
 /**
  * Verifies a browser-held anonymous claim token without trusting the bare UUID.
+ * Expired, malformed, legacy static, or wrong-anon tokens fail closed.
  */
 export async function verifyAnonClaimToken(
   anonId: string,
   claimToken: string | undefined,
 ): Promise<boolean> {
   if (!claimToken || !ANON_ID_V4_REGEX.test(anonId)) return false;
-  if (!claimToken.startsWith(ANON_CLAIM_TOKEN_PREFIX)) return false;
+  const [version, expiresAtRaw, signature, ...extra] = claimToken.split(".");
+  if (version !== ANON_CLAIM_TOKEN_VERSION || extra.length > 0) return false;
+  if (typeof expiresAtRaw !== "string" || typeof signature !== "string") return false;
+  if (!/^\d+$/.test(expiresAtRaw) || !signature) return false;
+  const expiresAt = Number(expiresAtRaw);
+  if (!Number.isSafeInteger(expiresAt) || expiresAt <= Date.now()) return false;
   try {
-    const expected = await signPayload(`anon-claim:v1:${anonId}`);
-    return timingSafeEqualHex(expected, claimToken.slice(ANON_CLAIM_TOKEN_PREFIX.length));
+    const expected = await signPayload(`anon-claim:${ANON_CLAIM_TOKEN_VERSION}:${anonId}:${expiresAt}`);
+    return timingSafeEqualHex(expected, signature);
   } catch {
     return false;
   }

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -962,6 +962,10 @@ export const claimSubscription = mutation({
       return { claimed: { subscriptions: 0, entitlements: 0, customers: 0, payments: 0 } };
     }
 
+    if (args.claimToken !== undefined && !(await verifyAnonClaimToken(args.anonId, args.claimToken))) {
+      throw new ConvexError({ kind: "ANON_CLAIM_PROOF_REQUIRED" });
+    }
+
     // Parallel reads for all anonId data — bounded to prevent runaway memory
     const [subs, anonEntitlement, customers, payments] = await Promise.all([
       ctx.db.query("subscriptions").withIndex("by_userId", (q) => q.eq("userId", args.anonId)).take(50),
@@ -979,7 +983,7 @@ export const claimSubscription = mutation({
       return { claimed: { subscriptions: 0, entitlements: 0, customers: 0, payments: 0 } };
     }
 
-    if (!(await verifyAnonClaimToken(args.anonId, args.claimToken))) {
+    if (args.claimToken === undefined) {
       throw new ConvexError({ kind: "ANON_CLAIM_PROOF_REQUIRED" });
     }
 

--- a/convex/payments/checkout.ts
+++ b/convex/payments/checkout.ts
@@ -196,7 +196,7 @@ async function _createCheckoutSession(
     ? await signAnonClaimToken(user.userId)
     : null;
   if (anonymousClaimToken) {
-    metadata.wm_anon_claim = "v1";
+    metadata.wm_anon_claim = "v2";
   }
   // Tier-group bridge for the duplicate-payment guard (#4438): the pending
   // `payment.processing` webhook echoes `data.metadata.wm_plan_key` and persists

--- a/src/App.ts
+++ b/src/App.ts
@@ -129,7 +129,7 @@ import {
 } from '@/services/checkout';
 import {
   clearStoredAnonIdentity,
-  getStoredAnonClaimToken,
+  getFreshStoredAnonClaimToken,
   getStoredAnonId,
 } from '@/services/anonymous-identity-storage';
 import { captureReferralFromUrl } from '@/services/referral-capture';
@@ -1425,7 +1425,7 @@ export class App {
               console.warn('[billing] claimSubscription skipped — Convex auth not ready');
               return;
             }
-            const claimToken = getStoredAnonClaimToken() ?? undefined;
+            const claimToken = getFreshStoredAnonClaimToken() ?? undefined;
             const result = await client.mutation(api.payments.billing.claimSubscription, {
               anonId,
               ...(claimToken ? { claimToken } : {}),

--- a/src/services/anonymous-identity-storage.ts
+++ b/src/services/anonymous-identity-storage.ts
@@ -1,5 +1,7 @@
 const ANON_KEY = 'wm-anon-id';
 const ANON_CLAIM_TOKEN_KEY = 'wm-anon-claim-token';
+const ANON_CLAIM_TOKEN_VERSION = 'v2';
+const HMAC_SHA256_HEX = /^[0-9a-f]{64}$/;
 
 export function getStoredAnonId(): string | null {
   try {
@@ -21,6 +23,23 @@ export function getStoredAnonClaimToken(): string | null {
   }
 }
 
+function isFreshAnonClaimToken(token: string): boolean {
+  const [version, expiresAtRaw, signature, ...extra] = token.split('.');
+  if (version !== ANON_CLAIM_TOKEN_VERSION || extra.length > 0) return false;
+  if (!expiresAtRaw || !signature || !/^\d+$/.test(expiresAtRaw)) return false;
+  if (!HMAC_SHA256_HEX.test(signature)) return false;
+  const expiresAt = Number(expiresAtRaw);
+  return Number.isSafeInteger(expiresAt) && expiresAt > Date.now();
+}
+
+export function getFreshStoredAnonClaimToken(): string | null {
+  const token = getStoredAnonClaimToken();
+  if (!token) return null;
+  if (isFreshAnonClaimToken(token)) return token;
+  clearStoredAnonClaimToken();
+  return null;
+}
+
 export function saveAnonClaimToken(token: string): void {
   try {
     localStorage.setItem(ANON_CLAIM_TOKEN_KEY, token);
@@ -30,10 +49,18 @@ export function saveAnonClaimToken(token: string): void {
   }
 }
 
+export function clearStoredAnonClaimToken(): void {
+  try {
+    localStorage.removeItem(ANON_CLAIM_TOKEN_KEY);
+  } catch {
+    // Ignore restricted storage cleanup failures.
+  }
+}
+
 export function clearStoredAnonIdentity(): void {
   try {
     localStorage.removeItem(ANON_KEY);
-    localStorage.removeItem(ANON_CLAIM_TOKEN_KEY);
+    clearStoredAnonClaimToken();
   } catch {
     // Ignore restricted storage cleanup failures.
   }

--- a/src/services/user-identity.ts
+++ b/src/services/user-identity.ts
@@ -31,6 +31,7 @@ import { migrateLegacyKeysToHttpOnlySession, readLegacySessionKey } from './brow
 import { getStoredAnonId, saveAnonId } from './anonymous-identity-storage';
 export {
   clearStoredAnonIdentity,
+  getFreshStoredAnonClaimToken,
   getStoredAnonClaimToken,
   getStoredAnonId,
   saveAnonClaimToken,


### PR DESCRIPTION
## Summary

Follow-up to review comments on #4785.

- Replace static anonymous claim proofs with expiring v2 tokens.
- Sign the expiry into the HMAC payload and bound the server TTL to 1 hour through 30 days, defaulting to 30 days.
- Reject supplied malformed, wrong-anon, legacy static, or expired tokens before scanning anonymous payment rows.
- Drop stale or malformed locally cached claim tokens before sign-in claim attempts, while preserving the anon ID for fail-closed support paths.
- Keep the compatibility path where sign-in with a bare anon UUID and no payment rows returns a quiet zero claim.
- Add regression coverage for expired tokens and invalid-token/no-rows behavior.

## Validation

- ./node_modules/.bin/vitest run --config vitest.config.mts convex/__tests__/billing.test.ts
- npm run typecheck
- npm run typecheck:api
- pre-push hook
- code-review-expert pass: no blocking findings after TTL/client stale-token fixes