### PR TITLE
fix(seeders): guard S3-mode R2 ops + runSeed fetch-phase deadline (graceful degradation, #4786)

### DIFF
--- a/scripts/_r2-storage.mjs
+++ b/scripts/_r2-storage.mjs
@@ -11,6 +11,36 @@ async function loadS3SDK() {
   return { S3Client: _S3Client, PutObjectCommand: _PutObjectCommand, GetObjectCommand: _GetObjectCommand };
 }
 
+// ── S3-mode timeout guards (issue #4786) ─────────────────────────────────
+// The Cloudflare-R2-API branches below bound every request with
+// AbortSignal.timeout(30_000). The S3-SDK branches historically did NOT: a
+// stalled `client.send`, or a `Body.transformToString()` whose socket is
+// silently reaped by the keep-alive agent, leaves a promise that NEVER
+// settles — no rejection for a try/catch to catch, and no open handle to
+// keep the event loop alive. In a seeder that awaits R2 at the top level
+// (e.g. seed-forecasts reading prior trace state) that drains the loop and
+// Node exits 13 with "Detected unsettled top-level await" — a red Railway
+// badge that is neither a graceful skip nor a catchable failure.
+const R2_S3_TIMEOUT_MS = 30_000;
+let _s3TimeoutMs = R2_S3_TIMEOUT_MS;   // overridable in tests
+let _s3ClientOverride = null;          // test hook: inject a fake S3 client
+
+function __setS3ClientForTests(client) { _s3ClientOverride = client; }
+function __setR2S3TimeoutForTests(ms) { _s3TimeoutMs = ms == null ? R2_S3_TIMEOUT_MS : ms; }
+
+// Guarantees the returned promise settles: rejects if `promise` has not
+// settled within `ms`. clearTimeout in finally so a fast-settling call
+// leaves no pending timer holding the event loop open.
+function withSettleTimeout(promise, ms, label) {
+  let timer;
+  const guard = new Promise((_, reject) => {
+    // "timed out" keeps isRetryableR2Error treating a transient stall as
+    // retryable, mirroring the api-mode AbortSignal.timeout failures.
+    timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms (S3 op did not settle)`)), ms);
+  });
+  return Promise.race([promise, guard]).finally(() => clearTimeout(timer));
+}
+
 function getEnvValue(env, keys) {
   for (const key of keys) {
     if (env[key]) return env[key];
@@ -127,6 +157,7 @@ function resolveR2StorageConfig(env = process.env, options = {}) {
 const CLIENT_CACHE = new Map();
 
 async function getR2StorageClient(config) {
+  if (_s3ClientOverride) return _s3ClientOverride;
   const cacheKey = JSON.stringify({
     endpoint: config.endpoint,
     region: config.region,
@@ -142,6 +173,9 @@ async function getR2StorageClient(config) {
       region: config.region,
       credentials: config.credentials,
       forcePathStyle: config.forcePathStyle,
+      // Bound connection + socket-inactivity so a stalled R2 socket fails
+      // fast (→ withR2Retry → caller fallback) rather than hanging the run.
+      requestHandler: { requestTimeout: R2_S3_TIMEOUT_MS, connectionTimeout: 10_000 },
     });
     CLIENT_CACHE.set(cacheKey, client);
   }
@@ -179,14 +213,18 @@ async function putR2JsonObject(config, key, payload, metadata = {}) {
   return withR2Retry(async () => {
     const { PutObjectCommand } = await loadS3SDK();
     const client = await getR2StorageClient(config);
-    await client.send(new PutObjectCommand({
-      Bucket: config.bucket,
-      Key: key,
-      Body: body,
-      ContentType: 'application/json; charset=utf-8',
-      CacheControl: 'no-store',
-      Metadata: metadata,
-    }));
+    await withSettleTimeout(
+      client.send(new PutObjectCommand({
+        Bucket: config.bucket,
+        Key: key,
+        Body: body,
+        ContentType: 'application/json; charset=utf-8',
+        CacheControl: 'no-store',
+        Metadata: metadata,
+      }), { abortSignal: AbortSignal.timeout(_s3TimeoutMs) }),
+      _s3TimeoutMs,
+      `R2 s3 put ${key}`,
+    );
     return { bucket: config.bucket, key, bytes: Buffer.byteLength(body, 'utf8') };
   }, {
     op: 'put',
@@ -223,11 +261,17 @@ async function getR2JsonObject(config, key) {
     const { GetObjectCommand } = await loadS3SDK();
     const client = await getR2StorageClient(config);
     try {
-      const response = await client.send(new GetObjectCommand({
-        Bucket: config.bucket,
-        Key: key,
-      }));
-      const body = await response.Body?.transformToString?.();
+      const response = await withSettleTimeout(
+        client.send(new GetObjectCommand({
+          Bucket: config.bucket,
+          Key: key,
+        }), { abortSignal: AbortSignal.timeout(_s3TimeoutMs) }),
+        _s3TimeoutMs,
+        `R2 s3 get ${key} send`,
+      );
+      const body = response.Body
+        ? await withSettleTimeout(response.Body.transformToString(), _s3TimeoutMs, `R2 s3 get ${key} body`)
+        : null;
       if (!body) return null;
       return JSON.parse(body);
     } catch (err) {
@@ -245,4 +289,7 @@ export {
   getR2StorageClient,
   getR2JsonObject,
   putR2JsonObject,
+  withSettleTimeout,
+  __setS3ClientForTests,
+  __setR2S3TimeoutForTests,
 };

--- a/scripts/_seed-utils.mjs
+++ b/scripts/_seed-utils.mjs
@@ -1232,6 +1232,33 @@ export function shouldSkipEmptyExtraKey(ek, recordCount) {
   return Boolean(ek && ek.skipWhenEmpty) && recordCount === 0;
 }
 
+// Fleet-wide graceful-degradation backstop (issue #4786). A non-settling
+// await inside a seeder's fetchFn — e.g. an unguarded R2/S3 body stream whose
+// socket is silently reaped — never rejects, so the Phase-1 try/catch can't
+// catch it; the event loop drains and Node exits 13 ("Detected unsettled
+// top-level await"), painting a red Railway badge that is neither a graceful
+// skip nor a catchable failure. Racing the fetch against a wall-clock deadline
+// converts that hang into a normal rejection, which the existing graceful path
+// turns into exit 75 (TTL extended, last-good served, no data lost).
+//
+// The deadline is tied to lockTtlMs — never a fixed value — because seeders
+// legitimately run from ~1min to 40min. A healthy seeder is designed never to
+// outlive its own lock, so lockTtlMs + margin exceeds any legitimate run; the
+// only thing that trips it is a genuine hang. A false trip is itself graceful
+// (exit 75), so the margin errs generous.
+export const FETCH_PHASE_DEADLINE_MARGIN_MS = 120_000;
+
+export function raceFetchDeadline(promise, ms, label) {
+  let timer;
+  const guard = new Promise((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`${label} fetch phase exceeded ${ms}ms deadline (likely a non-settling await — see issue #4786)`)),
+      ms,
+    );
+  });
+  return Promise.race([promise, guard]).finally(() => clearTimeout(timer));
+}
+
 export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}) {
   const {
     validateFn,
@@ -1248,6 +1275,7 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
     zeroIsValid = false,   // new — when true, recordCount=0 is OK_ZERO, not RETRY
     contentMeta,           // (rawData) => {newestItemAt, oldestItemAt} | null
     maxContentAgeMin,      // positive integer minutes — opts in together with contentMeta
+    fetchPhaseTimeoutMs,   // hard ceiling on the fetch phase; defaults to lockTtlMs + margin (#4786)
   } = opts;
   const contractMode = typeof declareRecords === 'function';
   if (contractMode) {
@@ -1338,10 +1366,16 @@ export async function runSeed(domain, resource, canonicalKey, fetchFn, opts = {}
   };
   process.once('SIGTERM', sigTermHandler);
 
-  // Phase 1: Fetch data (graceful on failure — extend TTL on stale data)
+  // Phase 1: Fetch data (graceful on failure — extend TTL on stale data).
+  // Raced against a wall-clock deadline so a non-settling await inside fetchFn
+  // (see raceFetchDeadline above, issue #4786) surfaces as a catchable
+  // rejection instead of hanging the process into an exit-13 red badge.
+  const fetchDeadlineMs = Number.isFinite(fetchPhaseTimeoutMs) && fetchPhaseTimeoutMs > 0
+    ? fetchPhaseTimeoutMs
+    : lockTtlMs + FETCH_PHASE_DEADLINE_MARGIN_MS;
   let data;
   try {
-    data = await withRetry(fetchFn);
+    data = await raceFetchDeadline(withRetry(fetchFn), fetchDeadlineMs, `${domain}:${resource}`);
   } catch (err) {
     // Keep the SIGTERM handler installed across the fetch-failure
     // cleanup. Earlier code did `process.off('SIGTERM', sigTermHandler)`

--- a/tests/r2-storage-s3-timeout.test.mjs
+++ b/tests/r2-storage-s3-timeout.test.mjs
@@ -1,0 +1,85 @@
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  getR2JsonObject,
+  putR2JsonObject,
+  withSettleTimeout,
+  __setS3ClientForTests,
+  __setR2S3TimeoutForTests,
+} from '../scripts/_r2-storage.mjs';
+
+// s3-mode config (mode !== 'api' → S3-SDK branch). getR2StorageClient returns
+// the injected fake client, so no real network / credentials are touched.
+const S3_CONFIG = { mode: 's3', bucket: 'test-bucket', endpoint: 'https://x.r2', region: 'auto', credentials: { accessKeyId: 'k', secretAccessKey: 's' }, forcePathStyle: true };
+
+const hang = () => new Promise(() => {});
+
+afterEach(() => {
+  __setS3ClientForTests(null);
+  __setR2S3TimeoutForTests(null);
+});
+
+// ── withSettleTimeout helper ────────────────────────────────────────────────
+describe('withSettleTimeout', () => {
+  it('resolves with the value when the promise settles in time', async () => {
+    const v = await withSettleTimeout(Promise.resolve(42), 1000, 'x');
+    assert.equal(v, 42);
+  });
+
+  it('rejects with a "timed out" error when the promise never settles', async () => {
+    await assert.rejects(() => withSettleTimeout(hang(), 20, 'x'), /timed out after 20ms/);
+  });
+
+  it('propagates the underlying rejection unchanged', async () => {
+    await assert.rejects(() => withSettleTimeout(Promise.reject(new Error('boom')), 1000, 'x'), /boom/);
+  });
+});
+
+// ── getR2JsonObject (S3 mode) — issue #4786 regression ──────────────────────
+describe('getR2JsonObject s3-mode does not hang on a stalled read', () => {
+  it('reproduces the exit-13 bug: a never-settling transformToString() now REJECTS instead of hanging', async () => {
+    __setR2S3TimeoutForTests(10);
+    // Pre-fix: `await response.Body.transformToString()` never settled → the
+    // top-level await drained the loop → Node exit 13. Now it must reject.
+    __setS3ClientForTests({ send: async () => ({ Body: { transformToString: hang } }) });
+    await assert.rejects(() => getR2JsonObject(S3_CONFIG, 'k'), /timed out/);
+  });
+
+  it('rejects when client.send() itself never settles', async () => {
+    __setR2S3TimeoutForTests(10);
+    __setS3ClientForTests({ send: hang });
+    await assert.rejects(() => getR2JsonObject(S3_CONFIG, 'k'), /timed out/);
+  });
+
+  it('still returns the parsed object on the happy path (wrapper is transparent)', async () => {
+    __setS3ClientForTests({ send: async () => ({ Body: { transformToString: async () => JSON.stringify({ ok: 1 }) } }) });
+    assert.deepEqual(await getR2JsonObject(S3_CONFIG, 'k'), { ok: 1 });
+  });
+
+  it('still maps NoSuchKey / 404 to null', async () => {
+    __setS3ClientForTests({ send: async () => { throw Object.assign(new Error('missing'), { name: 'NoSuchKey' }); } });
+    assert.equal(await getR2JsonObject(S3_CONFIG, 'k'), null);
+  });
+
+  it('returns null when the object body is empty', async () => {
+    __setS3ClientForTests({ send: async () => ({ Body: { transformToString: async () => '' } }) });
+    assert.equal(await getR2JsonObject(S3_CONFIG, 'k'), null);
+  });
+});
+
+// ── putR2JsonObject (S3 mode) ───────────────────────────────────────────────
+describe('putR2JsonObject s3-mode does not hang on a stalled write', () => {
+  it('rejects when client.send() never settles instead of hanging the run', async () => {
+    __setR2S3TimeoutForTests(10);
+    __setS3ClientForTests({ send: hang });
+    await assert.rejects(() => putR2JsonObject(S3_CONFIG, 'k', { a: 1 }), /timed out/);
+  });
+
+  it('still resolves with byte count on the happy path', async () => {
+    __setS3ClientForTests({ send: async () => ({}) });
+    const res = await putR2JsonObject(S3_CONFIG, 'k', { a: 1 });
+    assert.equal(res.bucket, 'test-bucket');
+    assert.ok(res.bytes > 0);
+  });
+});

--- a/tests/seed-runseed-fetch-deadline.test.mjs
+++ b/tests/seed-runseed-fetch-deadline.test.mjs
@@ -1,0 +1,95 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  runSeed,
+  raceFetchDeadline,
+  GRACEFUL_FETCH_FAILURE_EXIT_CODE,
+} from '../scripts/_seed-utils.mjs';
+
+const hang = () => new Promise(() => {});
+
+// ── raceFetchDeadline helper ────────────────────────────────────────────────
+describe('raceFetchDeadline', () => {
+  it('resolves with the fetch value when it settles in time (transparent on success)', async () => {
+    assert.deepEqual(await raceFetchDeadline(Promise.resolve({ ok: 1 }), 1000, 'd:r'), { ok: 1 });
+  });
+
+  it('rejects with the #4786 deadline error when the fetch never settles', async () => {
+    await assert.rejects(() => raceFetchDeadline(hang(), 20, 'd:r'), /exceeded 20ms deadline .*#4786/);
+  });
+
+  it('passes an underlying rejection straight through', async () => {
+    await assert.rejects(() => raceFetchDeadline(Promise.reject(new Error('upstream 500')), 1000, 'd:r'), /upstream 500/);
+  });
+});
+
+// ── runSeed: a non-settling fetch degrades gracefully instead of exit 13 ─────
+describe('runSeed fetch-phase deadline (issue #4786)', () => {
+  const realExit = process.exit;
+  const realFetch = globalThis.fetch;
+  const realLog = console.log;
+  const realErr = console.error;
+  let prevUrl, prevTok;
+
+  before(() => {
+    prevUrl = process.env.UPSTASH_REDIS_REST_URL;
+    prevTok = process.env.UPSTASH_REDIS_REST_TOKEN;
+    process.env.UPSTASH_REDIS_REST_URL = 'https://redis.test';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'tok';
+  });
+  after(() => {
+    process.exit = realExit;
+    globalThis.fetch = realFetch;
+    console.log = realLog;
+    console.error = realErr;
+    if (prevUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL; else process.env.UPSTASH_REDIS_REST_URL = prevUrl;
+    if (prevTok === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN; else process.env.UPSTASH_REDIS_REST_TOKEN = prevTok;
+  });
+
+  // Permissive Upstash mock: lock SET-NX → OK, EXPIRE pipeline → all-extended,
+  // everything else → 1. Lets runSeed acquire the lock and run its graceful
+  // cleanup without touching a real Redis.
+  function mockRedis() {
+    globalThis.fetch = async (url, init) => {
+      const u = String(url);
+      const body = init?.body ? JSON.parse(init.body) : null;
+      if (u.endsWith('/pipeline') && Array.isArray(body)) {
+        return { ok: true, status: 200, json: async () => body.map(() => ({ result: 1 })), text: async () => '' };
+      }
+      const cmd = Array.isArray(body) ? String(body[0]).toUpperCase() : '';
+      return { ok: true, status: 200, json: async () => ({ result: cmd === 'SET' ? 'OK' : 1 }), text: async () => '' };
+    };
+  }
+
+  // Drive runSeed with a fetchFn that never settles; capture the exit code the
+  // graceful path calls process.exit() with (stubbed to throw so it unwinds).
+  async function exitCodeFor(fetchFn, opts) {
+    mockRedis();
+    console.log = () => {};
+    console.error = () => {};
+    process.exit = (code) => { throw Object.assign(new Error('__EXIT__'), { __exit: true, code }); };
+    try {
+      await runSeed('test', 'deadline', 'test:deadline:v1', fetchFn, opts);
+      return null; // returned without exiting — unexpected
+    } catch (err) {
+      if (err?.__exit) return err.code;
+      throw err;
+    } finally {
+      process.exit = realExit;
+      globalThis.fetch = realFetch;
+      console.log = realLog;
+      console.error = realErr;
+    }
+  }
+
+  it('a hanging fetchFn exits 75 (graceful) rather than hanging into an exit-13 red badge', async () => {
+    const code = await exitCodeFor(hang, { ttlSeconds: 600, validateFn: () => true, fetchPhaseTimeoutMs: 50 });
+    assert.equal(code, GRACEFUL_FETCH_FAILURE_EXIT_CODE);
+  });
+
+  it('an ordinary fetch rejection still takes the same graceful exit-75 path (deadline is not in the way)', async () => {
+    const code = await exitCodeFor(() => Promise.reject(new Error('upstream 500')), { ttlSeconds: 600, validateFn: () => true, fetchPhaseTimeoutMs: 50_000 });
+    assert.equal(code, GRACEFUL_FETCH_FAILURE_EXIT_CODE);
+  });
+});


### PR DESCRIPTION
Closes #4786. Fixes the observed `seed-forecasts` crash **and** the whole class of "non-settling await → exit 13" failures fleet-wide, both in **shared** modules so all ~70 seeders benefit.

## Problem

S3-mode `getR2JsonObject` / `putR2JsonObject` (`scripts/_r2-storage.mjs`) had **no request timeout**, while their Cloudflare-R2-API siblings bound every request with `AbortSignal.timeout(30s)`. A stalled `client.send`, or a `Body.transformToString()` whose socket is silently reaped by the keep-alive agent, leaves a promise that **never settles** — no rejection for a `try/catch` to catch, no open handle to keep the loop alive. A seeder awaiting R2 at the top level (`seed-forecasts` reading prior trace state) then drains the event loop and Node exits **13** (`Detected unsettled top-level await`) — a red Railway badge that is neither a graceful skip nor a catchable failure. Production runs S3 mode (`[Trace] Storage mode=s3`).

## Fix — two layers

**1. `_r2-storage.mjs` — close the specific holes (every R2-reading seeder):**
- Wrap both S3 `client.send` calls **and** `Body.transformToString()` in a `withSettleTimeout` (+ per-call `abortSignal`). A stall now rejects → `withR2Retry` → the caller's existing `.catch(() => fallback)`, so `seed-forecasts` degrades to "no priors this run" and still publishes.
- Give the cached `S3Client` a client-level `requestTimeout: 30s` / `connectionTimeout: 10s` (verified retained by `@aws-sdk/client-s3@3.1017.0`).

**2. `_seed-utils.mjs` `runSeed` — fleet-wide graceful-degradation backstop:**
- Race the Phase-1 fetch against a wall-clock deadline (`lockTtlMs + margin`, **per-seed — never a fixed value**, since seeders run from ~1min to 40min). Any non-settling await now routes into the **existing** graceful **exit-75** path (TTL extended, last-good served, no data lost) instead of hanging into exit 13. Catches R2 *and* any future unguarded await.

## Tests (reproduce-first)

- `tests/r2-storage-s3-timeout.test.mjs` — never-settling `send`/`transformToString` now reject; happy path + 404/empty-body unchanged; `putR2JsonObject` covered.
- `tests/seed-runseed-fetch-deadline.test.mjs` — a hanging `fetchFn` exits **75** (not 13) in ~55ms; an ordinary rejection still takes the same graceful path.
- All new + existing `_seed-utils`/`_r2-storage`/`seed-contract` tests pass (147 tests) under `tsx --test`.

## Blast radius

Both edits are additive (new exports, one optional opt, transparent wrappers) — no existing signature changes. Happy paths and the pre-existing graceful/SIGTERM paths are unchanged and covered.

https://claude.ai/code/session_01HUHf9mxHGA2ujGvBAQ8m2v