### PR TITLE
fix(agent-auth): add claim_uri to anonymous agent_auth method (orank readiness)

### DIFF
--- a/api/oauth-authorization-server.ts
+++ b/api/oauth-authorization-server.ts
@@ -26,6 +26,16 @@
  * not implement ID-JAG identity assertion endpoints, so only `anonymous` is
  * advertised. The `skill` field round-trips to the published /auth.md.
  *
+ * `claim_uri` completes the anonymous method: an anonymously-registered agent's
+ * credential is *claimed* (bound to a human owner) at authorization time — the
+ * interactive `/oauth/authorize` consent ties the issued token to whoever signs
+ * in. WM has no standalone claim endpoint, so the claim URI is the authorization
+ * endpoint (the actual claim ceremony). Agent-readiness scanners (isitagentready
+ * / ora.ai) require a `claim_uri` for the anonymous registration method; we
+ * advertise it both at the `agent_auth` top level (parallel to `register_uri`)
+ * and inside the `anonymous` method object so a validator that looks in either
+ * location resolves it. See public/auth.md "## Claim".
+ *
  * The Host is client-controlled, so the origin is derived through
  * `resolveMetadataOrigin` (apex + subdomain allowlist, apex fallback) so a
  * spoofed Host cannot be reflected into `issuer`/`token_endpoint`.
@@ -54,9 +64,11 @@ export default function handler(req: Request): Response {
     agent_auth: {
       skill: `${origin}/auth.md`,
       register_uri: `${origin}/oauth/register`,
+      claim_uri: `${origin}/oauth/authorize`,
       identity_types_supported: ['anonymous'],
       anonymous: {
         credential_types_supported: ['access_token'],
+        claim_uri: `${origin}/oauth/authorize`,
       },
     },
   });

--- a/public/auth.md
+++ b/public/auth.md
@@ -27,8 +27,10 @@ chain:
      "agent_auth": {
        "skill": "https://worldmonitor.app/auth.md",
        "register_uri": "https://worldmonitor.app/oauth/register",
+       "claim_uri": "https://worldmonitor.app/oauth/authorize",
        "identity_types_supported": ["anonymous"],
-       "anonymous": { "credential_types_supported": ["access_token"] } } }
+       "anonymous": { "credential_types_supported": ["access_token"],
+                      "claim_uri": "https://worldmonitor.app/oauth/authorize" } } }
    ```
 
    Metadata is per-host: `issuer` and endpoints match the origin you fetched
@@ -68,7 +70,8 @@ POST /oauth/register  {"client_name":"My Agent","redirect_uris":["https://claude
 ## Claim
 
 Anonymous agents are claimed **at authorization time**, not via a separate
-endpoint. Start the authorization-code flow with a PKCE challenge:
+endpoint — so `agent_auth.claim_uri` is the authorization endpoint itself. Start
+the authorization-code flow with a PKCE challenge:
 
 ```
 GET /oauth/authorize?response_type=code&client_id=…&code_challenge=…&code_challenge_method=S256&scope=mcp

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -1424,6 +1424,8 @@ describe('agent readiness: MCP/OAuth origin alignment', () => {
       assert.equal(asJson.issuer, 'https://worldmonitor.app', `AS must not reflect spoofed host ${host}`);
       assert.equal(asJson.token_endpoint, 'https://worldmonitor.app/oauth/token', `AS token_endpoint must not carry spoofed host ${host}`);
       assert.equal(asJson.agent_auth.register_uri, 'https://worldmonitor.app/oauth/register');
+      assert.equal(asJson.agent_auth.claim_uri, 'https://worldmonitor.app/oauth/authorize', `AS claim_uri must not carry spoofed host ${host}`);
+      assert.equal(asJson.agent_auth.anonymous.claim_uri, 'https://worldmonitor.app/oauth/authorize');
     }
 
     // Legit subdomain still self-describes.
@@ -1479,6 +1481,25 @@ describe('agent readiness: auth.md walkthrough', () => {
     assert.ok(authMd.includes('https://workos.com/auth-md'), 'auth.md must reference the WorkOS spec');
     for (const keyword of ['agent_auth', 'register_uri', 'claim_uri', 'identity_assertion', 'id-jag', 'WWW-Authenticate']) {
       assert.ok(authMd.includes(keyword), `auth.md must mention spec keyword: ${keyword}`);
+    }
+  });
+
+  it('keeps every section header within the scanner read budget (~5 KB truncation)', () => {
+    // isitagentready / ora.ai reads only the first ~5 KB of auth.md; any `## `
+    // section header past that byte offset is dropped and the section reported
+    // missing (regressing auth-md-structure). This has bitten us before, so
+    // guard with a conservative ceiling — an edit that bloats an earlier
+    // section fails HERE instead of silently regressing the live scan.
+    const HEADER_BUDGET = 4800;
+    let offset = 0;
+    for (const line of authMd.split('\n')) {
+      if (line.startsWith('## ')) {
+        assert.ok(
+          offset < HEADER_BUDGET,
+          `"${line.trim()}" starts at byte ${offset}; must be < ${HEADER_BUDGET} to survive the ~5 KB scanner truncation`
+        );
+      }
+      offset += Buffer.byteLength(line, 'utf8') + 1; // + the newline that split() dropped
     }
   });
 

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -1386,6 +1386,21 @@ describe('agent readiness: MCP/OAuth origin alignment', () => {
         ['access_token'],
         `anonymous sibling block enumerates credential types for ${host}`
       );
+      // The anonymous registration method requires a claim URI (readiness
+      // scanners reject the method without it). Anonymous credentials are
+      // claimed at authorization time, so claim_uri == the authorization
+      // endpoint. Advertised both at the agent_auth top level (parallel to
+      // register_uri) and inside the anonymous method object.
+      assert.equal(
+        json.agent_auth.claim_uri,
+        `https://${host}/oauth/authorize`,
+        `agent_auth.claim_uri = authorization endpoint for ${host}`
+      );
+      assert.equal(
+        json.agent_auth.anonymous.claim_uri,
+        `https://${host}/oauth/authorize`,
+        `anonymous method advertises claim_uri for ${host}`
+      );
     }
   });
 
@@ -1462,7 +1477,7 @@ describe('agent readiness: auth.md walkthrough', () => {
 
   it('references the auth.md spec and carries the spec anchor keywords', () => {
     assert.ok(authMd.includes('https://workos.com/auth-md'), 'auth.md must reference the WorkOS spec');
-    for (const keyword of ['agent_auth', 'register_uri', 'identity_assertion', 'id-jag', 'WWW-Authenticate']) {
+    for (const keyword of ['agent_auth', 'register_uri', 'claim_uri', 'identity_assertion', 'id-jag', 'WWW-Authenticate']) {
       assert.ok(authMd.includes(keyword), `auth.md must mention spec keyword: ${keyword}`);
     }
   });


### PR DESCRIPTION
## Problem

The isitagentready / ora.ai agent-readiness scanner tightened its `auth.md` validator. It now runs:

> **Validate agent_auth registration methods** → `anonymous registration requires claim_uri`

Our `/.well-known/oauth-authorization-server` `agent_auth` block had `skill`, `register_uri`, `identity_types_supported`, and `anonymous.credential_types_supported` — but **no `claim_uri`**. So the scan concludes *"auth.md exists but agent_auth metadata was not found"* even though #4717 and #4760 already built the block. `claim_uri` is a **new** requirement, not a mis-placed field from a prior PR.

The scanner uses its own `_uri` naming convention (it already accepts `register_uri` + `anonymous.credential_types_supported`, neither of which is the canonical WorkOS `registration_endpoint`/`claim_endpoint`), so the fix must add a field literally named `claim_uri`.

## Fix

Add `claim_uri` = `${origin}/oauth/authorize`.

- **Why that URL:** WorldMonitor has no standalone claim endpoint. An anonymously-registered OAuth credential is *claimed* at authorization time — the interactive `/oauth/authorize` consent binds the issued token to the human who signs in. `auth.md`'s `## Claim` section already documents exactly this, so the claim URI honestly points at the authorization endpoint (which is already known-reachable, so the scanner's endpoint-reachability probe passes). No fabricated `revocation_uri` — the scanner doesn't require one and WM revokes via the dashboard only.
- **Placement (belt-and-braces):** the scanner's field-name list is ambiguous about nesting (`anonymous.credential_types_supported` carries the prefix, `claim_uri` doesn't; yet `register_uri` is top-level). So `claim_uri` is advertised **both** at the `agent_auth` top level and inside the `anonymous` method object — same URL, harmless — resolving whichever location the validator inspects.

## Changes

- `api/oauth-authorization-server.ts` — `claim_uri` in both spots + rationale comment.
- `public/auth.md` — Discover JSON example + Claim sentence updated to match the served metadata; kept within the scanner's ~5 KB truncation budget (total 4888 B, last `##` header at 4330 B).
- `tests/deploy-config.test.mjs` — 2 new asserts on `agent_auth.claim_uri` / `anonymous.claim_uri`, plus `claim_uri` added to the auth.md keyword guard.

## Verification

- All 26 agent-readiness guardrail tests pass (`npx tsx --test tests/deploy-config.test.mjs`).
- Rendered `agent_auth` JSON confirmed correct per host; no stale duplicate of the block anywhere in the repo.
- Final scanner confirmation is **deploy-gated** (it reads production only), so it lands after merge + deploy.

https://claude.ai/code/session_018FBmQG921WC4s3qLmuEKoQ