### PR TITLE
feat(api): add Dodo overage event contract

### DIFF
--- a/docs/plans/2026-07-04-001-dodo-overage-event-contract-plan.md
+++ b/docs/plans/2026-07-04-001-dodo-overage-event-contract-plan.md
@@ -14,7 +14,7 @@ created_at: 2026-07-04
 - **Objective:** Prepare the smallest production-ready #4560 increment by defining a disabled-by-default billable API usage event contract that can feed future Dodo overage ingestion without putting Dodo calls on the request hot path.
 - **Authority:** Issue #4560 and overlapping issue #3117 define the target architecture; current `origin/main` source is the executable Phase 1 contract because the issue-referenced Phase 1 plan path is not present in this checkout.
 - **Scope:** Add a typed builder and focused tests around eligible billable usage events. Do not configure Dodo meters, send events, set prices, create spend caps, or subscribe to webhooks.
-- **Stop condition:** The code exposes a tested payload contract that separates commercial overage eligibility from the existing per-minute burst and 10x ceiling limiter.
+- **Stop condition:** The code exposes a tested payload contract that separates commercial overage eligibility from the existing per-minute burst limiter and daily allowance enforcement.
 
 ---
 
@@ -22,11 +22,13 @@ created_at: 2026-07-04
 
 ### Summary
 
-Phase 1 already meters per-account REST API usage and enforces only burst plus runaway ceiling behavior. Phase 2 needs that metered allowance to become billable overage through Dodo, but the epic still has unresolved commercial decisions. This increment creates the event contract that future async ingestion can consume once pricing and Dodo catalog decisions are resolved.
+Phase 1 meters per-account REST API usage and enforces per-minute burst plus a daily allowance policy. PR #4684 removes the earlier 10x runaway-ceiling multiplier in favor of a hard daily cap in enforce mode; shadow mode still serves over-allowance requests uncounted-against-a-ceiling. Phase 2 needs that metered allowance to become billable overage through Dodo, but the epic still has unresolved commercial decisions. This increment creates the event contract that future async ingestion can consume once pricing and Dodo catalog decisions are resolved.
+
+Sequencing note: the overage event fires only for *served* over-allowance requests (the shadow-mode path). It is therefore incompatible with #4684's hard-cap enforce mode, which refuses over-allowance requests with a 429 and rolls back the meter increment — the builder excludes those refusals (401/403/429 and 5xx are never billable). Reconciling billable overage with hard-cap enforcement needs an explicit opt-in overage mechanism and is tracked at the product level (epics #4560 / #4635), not in this slice.
 
 ### Requirements
 
-- R1. A billable event candidate MUST represent only commercial overage usage and MUST stay separate from the existing per-minute burst hard 429 and daily safety ceiling.
+- R1. A billable event candidate MUST represent only commercial overage usage and MUST stay separate from the existing per-minute burst hard 429 and daily-allowance enforcement (the #4684 hard cap).
 - R2. The event contract MUST include stable idempotency material so future Dodo ingestion can create deterministic `event_id` values.
 - R3. The event contract MUST carry customer lookup inputs without requiring the gateway to know a Dodo customer id synchronously.
 - R4. The event contract MUST reject unbillable outcomes, including 5xx handler failures, because #4560 flags billable 5xx treatment as a gating decision for live charging.
@@ -35,7 +37,7 @@ Phase 1 already meters per-account REST API usage and enforces only burst plus r
 ### Scope Boundaries
 
 - Deferred for later: Dodo meter creation, Dodo `POST /events/ingest`, customer-id resolution action, cron or `waitUntil` batching, 80%/100% credit balance emails, and customer spend caps.
-- Outside this slice: changing `apiDailyAllowance` values, changing the 10x ceiling multiplier, or changing per-IP/per-account enforcement behavior.
+- Outside this slice: changing `apiDailyAllowance` values, changing the daily-cap / enforce-mode behavior (owned by #4684), or changing per-IP/per-account enforcement behavior.
 
 ### Sources
 
@@ -53,7 +55,7 @@ Phase 1 already meters per-account REST API usage and enforces only burst plus r
 
 - KTD1. Keep the increment pure and disabled. A pure builder can be validated without credentials and cannot accidentally bill customers.
 - KTD2. Use userId as the customer lookup input. The gateway already has Clerk user identity for user API keys, while Convex owns the Dodo customer mapping.
-- KTD3. Exclude failed server responses at the contract layer. Even if the final product decision evolves, this prevents future ingestion from billing 5xx by default.
+- KTD3. Exclude non-billable outcomes at the contract layer: 5xx handler failures, 401/403 (no authorized work), and the enforce-mode 429 refusal (whose meter INCR is rolled back). Even if the final product decision evolves, this prevents future ingestion from billing refused or failed requests by default.
 - KTD4. Keep idempotency deterministic from user, UTC day, route, status, and observed count. Future batching can replay safely without duplicate event identity drift.
 
 ### High-Level Design
@@ -83,13 +85,16 @@ The current PR stops at `Candidate event or null`. Future work can enqueue or ba
 - **Patterns:**
   - `server/_shared/api-key-rate-limit.ts` for pure, injectable, no-Response helpers.
   - `tests/api-key-rate-limit.test.mts` for focused node:test coverage without live Redis or Dodo credentials.
-- **Approach:** Export a typed `buildApiOverageUsageEvent` function that returns `null` unless the request is for an eligible paid user API key, the daily meter actually counted, the count is above the included allowance, and the terminal status is below 500. Include `meterId: "api.request"`, `eventId`, `userId`, `route`, `method`, `status`, `usageDate`, `quantity`, `dailyCount`, `includedAllowance`, and `idempotencyKey`.
+- **Approach:** Export a typed `buildApiOverageUsageEvent` function that returns `null` unless the request is for an eligible paid user API key, the daily meter actually counted, the count is above the included allowance, and the terminal status is a billable code (100–499, excluding 401/403 auth failures and the enforce-mode 429 refusal). The event's `usageDate` is sourced from the meter's own UTC day (not a build-time clock read) so it cannot desync from the count. Include `meterId: "api.request"`, `eventId`, `userId`, `route`, `method`, `status`, `usageDate`, `quantity`, `dailyCount`, `includedAllowance`, and `idempotencyKey`.
 - **Test Scenarios:**
   - Count at or below allowance returns `null`.
-  - Count above allowance returns quantity equal to the overage delta for that request.
-  - 5xx status returns `null`.
-  - Missing user id or unmetered result returns `null`.
-  - Idempotency material is stable for the same user, date, route, method, status, and count.
+  - Count above allowance returns a single billable unit (`quantity: 1`).
+  - 5xx, 401/403, and the enforce-mode 429 return `null`; other 4xx (400/404) are billable.
+  - Status outside the 100–499 range returns `null`.
+  - Missing user id, unmetered result, or an invalid meter usage day returns `null`.
+  - `usageDate` binds to the meter's UTC day, not a build-time clock read (UTC-rollover determinism).
+  - Route is canonicalized to the matched path (query string stripped).
+  - Idempotency material is stable for the same user, day, route, method, status, and count.
 - **Verification:** Run `./node_modules/.bin/tsx --test tests/api-overage-billing.test.mts tests/api-key-rate-limit.test.mts`.
 
 ---

--- a/docs/plans/2026-07-04-001-dodo-overage-event-contract-plan.md
+++ b/docs/plans/2026-07-04-001-dodo-overage-event-contract-plan.md
@@ -1,0 +1,110 @@
+---
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+title: Dodo Overage Billable Usage Event Contract
+created_at: 2026-07-04
+---
+
+# Dodo Overage Billable Usage Event Contract
+
+## Goal Capsule
+
+- **Objective:** Prepare the smallest production-ready #4560 increment by defining a disabled-by-default billable API usage event contract that can feed future Dodo overage ingestion without putting Dodo calls on the request hot path.
+- **Authority:** Issue #4560 and overlapping issue #3117 define the target architecture; current `origin/main` source is the executable Phase 1 contract because the issue-referenced Phase 1 plan path is not present in this checkout.
+- **Scope:** Add a typed builder and focused tests around eligible billable usage events. Do not configure Dodo meters, send events, set prices, create spend caps, or subscribe to webhooks.
+- **Stop condition:** The code exposes a tested payload contract that separates commercial overage eligibility from the existing per-minute burst and 10x ceiling limiter.
+
+---
+
+## Product Contract
+
+### Summary
+
+Phase 1 already meters per-account REST API usage and enforces only burst plus runaway ceiling behavior. Phase 2 needs that metered allowance to become billable overage through Dodo, but the epic still has unresolved commercial decisions. This increment creates the event contract that future async ingestion can consume once pricing and Dodo catalog decisions are resolved.
+
+### Requirements
+
+- R1. A billable event candidate MUST represent only commercial overage usage and MUST stay separate from the existing per-minute burst hard 429 and daily safety ceiling.
+- R2. The event contract MUST include stable idempotency material so future Dodo ingestion can create deterministic `event_id` values.
+- R3. The event contract MUST carry customer lookup inputs without requiring the gateway to know a Dodo customer id synchronously.
+- R4. The event contract MUST reject unbillable outcomes, including 5xx handler failures, because #4560 flags billable 5xx treatment as a gating decision for live charging.
+- R5. The increment MUST NOT send events to Dodo or introduce live overage charges before model, pricing, cycle, alerting, and spend-cap decisions are resolved.
+
+### Scope Boundaries
+
+- Deferred for later: Dodo meter creation, Dodo `POST /events/ingest`, customer-id resolution action, cron or `waitUntil` batching, 80%/100% credit balance emails, and customer spend caps.
+- Outside this slice: changing `apiDailyAllowance` values, changing the 10x ceiling multiplier, or changing per-IP/per-account enforcement behavior.
+
+### Sources
+
+- Issue #4560: usage-based overage billing epic.
+- Issue #3117: older Dodo metered billing tracker.
+- `server/_shared/api-key-rate-limit.ts`: Phase 1 per-account burst and daily meter.
+- `server/gateway.ts`: gateway chokepoint where Phase 1 meter is invoked before handler execution.
+- `convex/payments/billing.ts`: existing userId to Dodo customer id resolver pattern for billing actions.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Keep the increment pure and disabled. A pure builder can be validated without credentials and cannot accidentally bill customers.
+- KTD2. Use userId as the customer lookup input. The gateway already has Clerk user identity for user API keys, while Convex owns the Dodo customer mapping.
+- KTD3. Exclude failed server responses at the contract layer. Even if the final product decision evolves, this prevents future ingestion from billing 5xx by default.
+- KTD4. Keep idempotency deterministic from user, UTC day, route, status, and observed count. Future batching can replay safely without duplicate event identity drift.
+
+### High-Level Design
+
+```mermaid
+flowchart TB
+  A["Phase 1 daily meter result"] --> B["Billable usage event builder"]
+  C["Gateway terminal response status"] --> B
+  D["User API key identity"] --> B
+  B --> E["Candidate event or null"]
+  E --> F["Future async Dodo ingestion"]
+```
+
+The current PR stops at `Candidate event or null`. Future work can enqueue or batch this object after Dodo catalog decisions are complete.
+
+---
+
+## Implementation Units
+
+### U1. Add billable API usage event builder
+
+- **Goal:** Create a pure helper that turns Phase 1 meter context plus terminal response status into a future Dodo overage event candidate or `null`.
+- **Requirements:** R1, R2, R3, R4, R5
+- **Files:**
+  - Create: `server/_shared/api-overage-billing.ts`
+  - Test: `tests/api-overage-billing.test.mts`
+- **Patterns:**
+  - `server/_shared/api-key-rate-limit.ts` for pure, injectable, no-Response helpers.
+  - `tests/api-key-rate-limit.test.mts` for focused node:test coverage without live Redis or Dodo credentials.
+- **Approach:** Export a typed `buildApiOverageUsageEvent` function that returns `null` unless the request is for an eligible paid user API key, the daily meter actually counted, the count is above the included allowance, and the terminal status is below 500. Include `meterId: "api.request"`, `eventId`, `userId`, `route`, `method`, `status`, `usageDate`, `quantity`, `dailyCount`, `includedAllowance`, and `idempotencyKey`.
+- **Test Scenarios:**
+  - Count at or below allowance returns `null`.
+  - Count above allowance returns quantity equal to the overage delta for that request.
+  - 5xx status returns `null`.
+  - Missing user id or unmetered result returns `null`.
+  - Idempotency material is stable for the same user, date, route, method, status, and count.
+- **Verification:** Run `./node_modules/.bin/tsx --test tests/api-overage-billing.test.mts tests/api-key-rate-limit.test.mts`.
+
+---
+
+## Verification Contract
+
+| Gate | Command | Done signal |
+|---|---|---|
+| Focused unit tests | `./node_modules/.bin/tsx --test tests/api-overage-billing.test.mts tests/api-key-rate-limit.test.mts` | New builder tests and existing meter tests pass. |
+| API typecheck | `npm run typecheck:api` | Shared server helper compiles under API tsconfig. |
+
+---
+
+## Definition of Done
+
+- U1 is implemented with focused tests and no live Dodo network calls.
+- The PR body uses `Related to #4560`, not `Fixes #4560`, because this does not close the epic.
+- The diff does not touch secrets, Dodo product pricing, live webhook handlers, or generated Convex artifacts.

--- a/docs/plans/2026-07-04-001-dodo-overage-event-contract-plan.md
+++ b/docs/plans/2026-07-04-001-dodo-overage-event-contract-plan.md
@@ -22,9 +22,9 @@ created_at: 2026-07-04
 
 ### Summary
 
-Phase 1 meters per-account REST API usage and enforces per-minute burst plus a daily allowance policy. PR #4684 removes the earlier 10x runaway-ceiling multiplier in favor of a hard daily cap in enforce mode; shadow mode still serves over-allowance requests uncounted-against-a-ceiling. Phase 2 needs that metered allowance to become billable overage through Dodo, but the epic still has unresolved commercial decisions. This increment creates the event contract that future async ingestion can consume once pricing and Dodo catalog decisions are resolved.
+Phase 1 meters per-account REST API usage and enforces per-minute burst plus a daily allowance policy. PR #4684 (open at the time of writing) would replace the earlier 10x runaway-ceiling multiplier with a hard daily cap in enforce mode; shadow mode would continue to serve over-allowance requests uncounted-against-a-ceiling. Phase 2 needs that metered allowance to become billable overage through Dodo, but the epic still has unresolved commercial decisions. This increment creates the event contract that future async ingestion can consume once pricing and Dodo catalog decisions are resolved.
 
-Sequencing note: the overage event fires only for *served* over-allowance requests (the shadow-mode path). It is therefore incompatible with #4684's hard-cap enforce mode, which refuses over-allowance requests with a 429 and rolls back the meter increment — the builder excludes those refusals (401/403/429 and 5xx are never billable). Reconciling billable overage with hard-cap enforcement needs an explicit opt-in overage mechanism and is tracked at the product level (epics #4560 / #4635), not in this slice.
+Sequencing note: the overage event fires only for *served* over-allowance requests (the shadow-mode path). It is therefore incompatible with #4684's proposed hard-cap enforce mode, which would refuse over-allowance requests with a 429 and roll back the meter increment — the builder excludes those refusals (401/403/429 and 5xx are never billable). Reconciling billable overage with hard-cap enforcement needs an explicit opt-in overage mechanism and is tracked at the product level (epics #4560 / #4635), not in this slice.
 
 ### Requirements
 
@@ -38,6 +38,8 @@ Sequencing note: the overage event fires only for *served* over-allowance reques
 
 - Deferred for later: Dodo meter creation, Dodo `POST /events/ingest`, customer-id resolution action, cron or `waitUntil` batching, 80%/100% credit balance emails, and customer spend caps.
 - Outside this slice: changing `apiDailyAllowance` values, changing the daily-cap / enforce-mode behavior (owned by #4684), or changing per-IP/per-account enforcement behavior.
+- Merge-order note: PR #4684 is not yet merged and edits the same `MeterResult` interface and `tests/api-key-rate-limit.test.mts` this PR touches. This PR's change there is additive (a new `usageDay` field + `apiKeyUsageDay` helper + one test), so whichever lands second resolves a textual, not semantic, conflict — the meter's UTC-day accessor is orthogonal to #4684's cap enforcement.
+- When wired: once the builder is called from `server/gateway.ts`, the `server/__tests__/*` meter mocks that hand-build a `MeterResult` (`reserveDailyMeter.mockResolvedValue(...)`) must add `usageDay` to stay representative. They are excluded from `typecheck:api`, so the omission is invisible until the gateway consumes the field.
 
 ### Sources
 

--- a/server/_shared/api-key-rate-limit.ts
+++ b/server/_shared/api-key-rate-limit.ts
@@ -98,16 +98,23 @@ export async function checkBurst(perMinute: number, identity: string): Promise<B
   }
 }
 
-/** Plain (un-prefixed) daily-meter key — `runRedisPipeline` applies the
- *  deployment/env prefix. UTC calendar day so the ceiling resets at midnight.
- *  `date` is injectable for deterministic tests. */
-export function apiKeyDailyKey(userId: string, date?: Date): string {
-  if (!userId) return '';
+/** The meter's authoritative UTC calendar day (`yyyy-mm-dd`). The daily key,
+ *  its INCR count, and any downstream usage stamp all derive from this single
+ *  read so a request straddling UTC midnight cannot desync its day from its
+ *  count. `date` is injectable for deterministic tests. */
+export function apiKeyUsageDay(date?: Date): string {
   const d = date ?? new Date();
   const yyyy = d.getUTCFullYear();
   const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
   const dd = String(d.getUTCDate()).padStart(2, '0');
-  return `rl:apikey:day:${userId}:${yyyy}-${mm}-${dd}`;
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+/** Plain (un-prefixed) daily-meter key — `runRedisPipeline` applies the
+ *  deployment/env prefix. UTC calendar day so the ceiling resets at midnight. */
+export function apiKeyDailyKey(userId: string, date?: Date): string {
+  if (!userId) return '';
+  return `rl:apikey:day:${userId}:${apiKeyUsageDay(date)}`;
 }
 
 /** 48h TTL: covers UTC-midnight rollover + an inspection window. Mirrors
@@ -124,6 +131,11 @@ export type RateLimitPipeline = (
 export interface MeterResult {
   /** Post-INCR count for this UTC day (0 when not metered). */
   count: number;
+  /** The UTC calendar day (`yyyy-mm-dd`) this count belongs to — the same day
+   *  embedded in the meter key. Downstream billing must stamp usage from this,
+   *  never a fresh clock read, or a midnight-straddling request desyncs its day
+   *  from its count. */
+  usageDay: string;
   /** True when count exceeded CEILING_MULTIPLIER × allowance. */
   overCeiling: boolean;
   /** False when Redis was unavailable (fail-open: serve uncounted). */
@@ -154,18 +166,19 @@ export async function reserveDailyMeter(opts: {
   const { userId, allowance, pipeline, date } = opts;
   const noop = async (): Promise<void> => {};
   const retryAfterSec = secondsUntilUtcMidnight(date);
+  const usageDay = apiKeyUsageDay(date);
 
   // No daily limit: `-1` is unlimited (enterprise); `0` is a misconfiguration
   // (positive burst but zero allowance) that we fail OPEN on rather than
   // ceiling-429 every request (ceiling would be 0×10 = 0, so request #1 trips).
   // Callers already gate eligibility on apiRateLimit > 0, so this is defensive.
   if (allowance <= 0) {
-    return { count: 0, overCeiling: false, metered: false, retryAfterSec, rollback: noop };
+    return { count: 0, usageDay, overCeiling: false, metered: false, retryAfterSec, rollback: noop };
   }
 
   const key = apiKeyDailyKey(userId, date);
   if (!key) {
-    return { count: 0, overCeiling: false, metered: false, retryAfterSec, rollback: noop };
+    return { count: 0, usageDay, overCeiling: false, metered: false, retryAfterSec, rollback: noop };
   }
 
   let pipeResult: Array<{ result?: unknown }> | null;
@@ -181,13 +194,13 @@ export async function reserveDailyMeter(opts: {
   // Fail-open: couldn't meter → serve uncounted (never punish a paying
   // customer for our Redis outage).
   if (!pipeResult || !Array.isArray(pipeResult) || pipeResult.length === 0) {
-    return { count: 0, overCeiling: false, metered: false, retryAfterSec, rollback: noop };
+    return { count: 0, usageDay, overCeiling: false, metered: false, retryAfterSec, rollback: noop };
   }
 
   const incrRaw = pipeResult[0]?.result;
   const count = typeof incrRaw === 'number' ? incrRaw : Number(incrRaw);
   if (!Number.isFinite(count) || count < 1) {
-    return { count: 0, overCeiling: false, metered: false, retryAfterSec, rollback: noop };
+    return { count: 0, usageDay, overCeiling: false, metered: false, retryAfterSec, rollback: noop };
   }
 
   let rolledBack = false;
@@ -203,7 +216,7 @@ export async function reserveDailyMeter(opts: {
   };
 
   const ceiling = allowance * CEILING_MULTIPLIER;
-  return { count, overCeiling: count > ceiling, metered: true, retryAfterSec, rollback };
+  return { count, usageDay, overCeiling: count > ceiling, metered: true, retryAfterSec, rollback };
 }
 
 /**

--- a/server/_shared/api-overage-billing.ts
+++ b/server/_shared/api-overage-billing.ts
@@ -1,0 +1,87 @@
+import type { MeterResult } from './api-key-rate-limit';
+
+export const API_OVERAGE_METER_ID = 'api.request' as const;
+
+export interface ApiOverageUsageEvent {
+  meterId: typeof API_OVERAGE_METER_ID;
+  eventId: string;
+  idempotencyKey: string;
+  userId: string;
+  route: string;
+  method: string;
+  status: number;
+  usageDate: string;
+  quantity: number;
+  dailyCount: number;
+  includedAllowance: number;
+}
+
+export function buildApiOverageUsageEvent(input: {
+  userId: string | null | undefined;
+  route: string;
+  method: string;
+  status: number;
+  includedAllowance: number;
+  meter: Pick<MeterResult, 'count' | 'metered'> | null | undefined;
+  date?: Date;
+  isUserApiKey: boolean;
+}): ApiOverageUsageEvent | null {
+  const userId = normalizeNonEmpty(input.userId);
+  const route = normalizeNonEmpty(input.route);
+  const method = normalizeNonEmpty(input.method)?.toUpperCase() ?? null;
+  const status = Number(input.status);
+  const allowance = Number(input.includedAllowance);
+  const dailyCount = Number(input.meter?.count);
+
+  if (!input.isUserApiKey || !userId || !route || !method) return null;
+  if (!Number.isInteger(status) || status >= 500) return null;
+  if (!input.meter?.metered || !Number.isSafeInteger(dailyCount) || dailyCount < 1) return null;
+  if (!Number.isSafeInteger(allowance) || allowance <= 0) return null;
+  if (dailyCount <= allowance) return null;
+
+  const usageDate = formatUsageDate(input.date);
+  const idempotencyKey = [
+    API_OVERAGE_METER_ID,
+    userId,
+    usageDate,
+    method,
+    route,
+    String(status),
+    String(dailyCount),
+  ].join(':');
+
+  return {
+    meterId: API_OVERAGE_METER_ID,
+    eventId: `wm_api_request_${stableHash(idempotencyKey)}`,
+    idempotencyKey,
+    userId,
+    route,
+    method,
+    status,
+    usageDate,
+    quantity: 1,
+    dailyCount,
+    includedAllowance: allowance,
+  };
+}
+
+function normalizeNonEmpty(value: string | null | undefined): string | null {
+  const normalized = typeof value === 'string' ? value.trim() : '';
+  return normalized.length > 0 ? normalized : null;
+}
+
+function formatUsageDate(date?: Date): string {
+  const d = date && Number.isFinite(date.valueOf()) ? date : new Date();
+  return d.toISOString().slice(0, 10);
+}
+
+function stableHash(value: string): string {
+  let hash = 0xcbf29ce484222325n;
+  const prime = 0x100000001b3n;
+  const mask = 0xffffffffffffffffn;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= BigInt(value.charCodeAt(i));
+    hash = (hash * prime) & mask;
+  }
+  return hash.toString(36);
+}

--- a/server/_shared/api-overage-billing.ts
+++ b/server/_shared/api-overage-billing.ts
@@ -2,6 +2,15 @@ import type { MeterResult } from './api-key-rate-limit';
 
 export const API_OVERAGE_METER_ID = 'api.request' as const;
 
+/** Statuses that are never billable overage even when the daily count is over
+ *  allowance:
+ *   - 401 / 403 — unauthenticated / unauthorized; no metered work was performed.
+ *   - 429 — the enforce-mode daily refusal (#4684). That request is rejected
+ *     AFTER the INCR and its meter increment is rolled back, so billing it would
+ *     both charge a refused call and alias the rolled-back count onto the next
+ *     served request's idempotency key. */
+const NON_BILLABLE_STATUSES: ReadonlySet<number> = new Set([401, 403, 429]);
+
 export interface ApiOverageUsageEvent {
   meterId: typeof API_OVERAGE_METER_ID;
   eventId: string;
@@ -16,30 +25,43 @@ export interface ApiOverageUsageEvent {
   includedAllowance: number;
 }
 
+/**
+ * Pure, disabled-by-default builder for a future Dodo overage event candidate
+ * (#4560). Returns `null` unless the request is an eligible, served, over-
+ * allowance paid user-API-key call. Does no I/O and never bills.
+ */
 export function buildApiOverageUsageEvent(input: {
   userId: string | null | undefined;
+  /** Router-matched request path with NO query string (e.g.
+   *  `/api/news/v1/list-feed-digest`). A trailing `?...` is stripped
+   *  defensively, but callers should pass the matched route so the idempotency
+   *  identity stays stable across query variants. */
   route: string;
   method: string;
+  /** Terminal HTTP status of the served request. */
   status: number;
   includedAllowance: number;
-  meter: Pick<MeterResult, 'count' | 'metered'> | null | undefined;
-  date?: Date;
+  /** Phase 1 daily meter result. `usageDay` (not a fresh clock read) is the
+   *  authoritative day for this event, so the day and the count come from one
+   *  meter snapshot and cannot desync across a UTC-midnight boundary. */
+  meter: Pick<MeterResult, 'count' | 'metered' | 'usageDay'> | null | undefined;
   isUserApiKey: boolean;
 }): ApiOverageUsageEvent | null {
   const userId = normalizeNonEmpty(input.userId);
-  const route = normalizeNonEmpty(input.route);
+  const route = normalizeRoute(input.route);
   const method = normalizeNonEmpty(input.method)?.toUpperCase() ?? null;
+  const usageDate = normalizeUsageDay(input.meter?.usageDay);
   const status = Number(input.status);
   const allowance = Number(input.includedAllowance);
   const dailyCount = Number(input.meter?.count);
 
-  if (!input.isUserApiKey || !userId || !route || !method) return null;
-  if (!Number.isInteger(status) || status >= 500) return null;
+  if (!input.isUserApiKey || !userId || !route || !method || !usageDate) return null;
+  if (!Number.isInteger(status) || status < 100 || status >= 500) return null;
+  if (NON_BILLABLE_STATUSES.has(status)) return null;
   if (!input.meter?.metered || !Number.isSafeInteger(dailyCount) || dailyCount < 1) return null;
   if (!Number.isSafeInteger(allowance) || allowance <= 0) return null;
   if (dailyCount <= allowance) return null;
 
-  const usageDate = formatUsageDate(input.date);
   const idempotencyKey = [
     API_OVERAGE_METER_ID,
     userId,
@@ -70,9 +92,18 @@ function normalizeNonEmpty(value: string | null | undefined): string | null {
   return normalized.length > 0 ? normalized : null;
 }
 
-function formatUsageDate(date?: Date): string {
-  const d = date && Number.isFinite(date.valueOf()) ? date : new Date();
-  return d.toISOString().slice(0, 10);
+/** Router-matched path only: strip any query string and surrounding space. */
+function normalizeRoute(value: string | null | undefined): string | null {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  const q = trimmed.indexOf('?');
+  const path = (q >= 0 ? trimmed.slice(0, q) : trimmed).trim();
+  return path.length > 0 ? path : null;
+}
+
+/** Accept only a strict `yyyy-mm-dd` UTC day stamp sourced from the meter. */
+function normalizeUsageDay(value: string | null | undefined): string | null {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  return /^\d{4}-\d{2}-\d{2}$/.test(trimmed) ? trimmed : null;
 }
 
 function stableHash(value: string): string {

--- a/server/_shared/api-overage-billing.ts
+++ b/server/_shared/api-overage-billing.ts
@@ -1,4 +1,5 @@
 import type { MeterResult } from './api-key-rate-limit';
+import { hashString64 } from './hash';
 
 export const API_OVERAGE_METER_ID = 'api.request' as const;
 
@@ -56,6 +57,12 @@ export function buildApiOverageUsageEvent(input: {
   const dailyCount = Number(input.meter?.count);
 
   if (!input.isUserApiKey || !userId || !route || !method || !usageDate) return null;
+  // The idempotency key is ':'-delimited. A ':' inside any free-form segment
+  // (userId, method, route) would shift the key's fields and could collapse two
+  // distinct requests onto one billing identity — reject rather than emit an
+  // ambiguous key. usageDate/status/dailyCount are validated numeric/date shapes
+  // and meterId is a constant, so they cannot introduce a delimiter.
+  if (userId.includes(':') || method.includes(':') || route.includes(':')) return null;
   if (!Number.isInteger(status) || status < 100 || status >= 500) return null;
   if (NON_BILLABLE_STATUSES.has(status)) return null;
   if (!input.meter?.metered || !Number.isSafeInteger(dailyCount) || dailyCount < 1) return null;
@@ -74,7 +81,10 @@ export function buildApiOverageUsageEvent(input: {
 
   return {
     meterId: API_OVERAGE_METER_ID,
-    eventId: `wm_api_request_${stableHash(idempotencyKey)}`,
+    // A compact, stable id derived from the key. It is a 64-bit hash and can
+    // collide in principle, so downstream dedupe MUST key on `idempotencyKey`,
+    // never on `eventId`.
+    eventId: `wm_api_request_${hashString64(idempotencyKey)}`,
     idempotencyKey,
     userId,
     route,
@@ -104,15 +114,4 @@ function normalizeRoute(value: string | null | undefined): string | null {
 function normalizeUsageDay(value: string | null | undefined): string | null {
   const trimmed = typeof value === 'string' ? value.trim() : '';
   return /^\d{4}-\d{2}-\d{2}$/.test(trimmed) ? trimmed : null;
-}
-
-function stableHash(value: string): string {
-  let hash = 0xcbf29ce484222325n;
-  const prime = 0x100000001b3n;
-  const mask = 0xffffffffffffffffn;
-  for (let i = 0; i < value.length; i += 1) {
-    hash ^= BigInt(value.charCodeAt(i));
-    hash = (hash * prime) & mask;
-  }
-  return hash.toString(36);
 }

--- a/server/_shared/hash.ts
+++ b/server/_shared/hash.ts
@@ -19,6 +19,26 @@ export function hashString(input: string): string {
 }
 
 /**
+ * FNV-1a 64-bit hash — the same algorithm as hashString() but with a full
+ * 64-bit mask (vs. 52-bit) for extra collision headroom when the hash tags a
+ * high-cardinality identity, e.g. a per-request billing event id. Returns
+ * base36. Non-cryptographic; the same WARNING as hashString() applies — never
+ * use it for a security-sensitive cache key derived from attacker input.
+ */
+export function hashString64(input: string): string {
+  let h = 0xcbf29ce484222325n;
+  const FNV_PRIME = 0x100000001b3n;
+  const MASK_64 = (1n << 64n) - 1n;
+
+  for (let i = 0; i < input.length; i++) {
+    h ^= BigInt(input.charCodeAt(i));
+    h = (h * FNV_PRIME) & MASK_64;
+  }
+
+  return h.toString(36);
+}
+
+/**
  * SHA-256 hex digest via Web Crypto (available in Edge/Vercel/Node 18+).
  * Use for all server-side cache keys derived from user-controlled input.
  */

--- a/tests/api-key-rate-limit.test.mts
+++ b/tests/api-key-rate-limit.test.mts
@@ -13,6 +13,7 @@ import assert from 'node:assert/strict';
 
 import {
   apiKeyDailyKey,
+  apiKeyUsageDay,
   reserveDailyMeter,
   rateLimitHeaders,
   checkBurst,
@@ -131,6 +132,21 @@ describe('#3199 U3 — reserveDailyMeter', () => {
     const date = new Date(Date.UTC(2026, 5, 30, 23, 0, 0)); // 1h before midnight
     const r = await reserveDailyMeter({ userId: 'u', allowance: STARTER_ALLOWANCE, pipeline: makePipeline(0).pipeline, date });
     assert.equal(r.retryAfterSec, 3600);
+  });
+
+  it('reports the meter UTC day as usageDay on both served and fail-open paths', async () => {
+    const date = D(2026, 5, 30); // 2026-06-30 UTC
+    // Served (metered) path — the day the INCR is keyed to.
+    const served = await reserveDailyMeter({ userId: 'u', allowance: STARTER_ALLOWANCE, pipeline: makePipeline(0).pipeline, date });
+    assert.equal(served.metered, true);
+    assert.equal(served.usageDay, apiKeyUsageDay(date));
+    assert.equal(served.usageDay, '2026-06-30');
+    // Fail-open early return (empty pipeline result) must STILL carry the day —
+    // a future edit that forgets usageDay on one of the 4 fail-open returns
+    // would otherwise pass every existing assertion.
+    const failOpen = await reserveDailyMeter({ userId: 'u', allowance: STARTER_ALLOWANCE, pipeline: async () => [], date });
+    assert.equal(failOpen.metered, false);
+    assert.equal(failOpen.usageDay, apiKeyUsageDay(date));
   });
 });
 

--- a/tests/api-overage-billing.test.mts
+++ b/tests/api-overage-billing.test.mts
@@ -6,26 +6,30 @@ import {
   buildApiOverageUsageEvent,
 } from '../server/_shared/api-overage-billing.ts';
 
-const DAY = new Date(Date.UTC(2026, 6, 4, 15, 30, 0));
+type MeterOverride = { count?: number; metered?: boolean; usageDay?: string };
 
-function build(overrides: Partial<Parameters<typeof buildApiOverageUsageEvent>[0]> = {}) {
+function build(
+  overrides: Partial<Omit<Parameters<typeof buildApiOverageUsageEvent>[0], 'meter'>> & {
+    meter?: MeterOverride;
+  } = {},
+) {
+  const { meter, ...rest } = overrides;
   return buildApiOverageUsageEvent({
     userId: 'user_123',
     route: '/api/news/v1/list-feed-digest',
     method: 'get',
     status: 200,
     includedAllowance: 1000,
-    meter: { count: 1001, metered: true },
-    date: DAY,
     isUserApiKey: true,
-    ...overrides,
+    ...rest,
+    meter: { count: 1001, metered: true, usageDay: '2026-07-04', ...(meter ?? {}) },
   });
 }
 
 describe('#4560 — API overage billable usage event contract', () => {
   it('returns null while the daily count is at or below the included allowance', () => {
-    assert.equal(build({ meter: { count: 1000, metered: true } }), null);
-    assert.equal(build({ meter: { count: 999, metered: true } }), null);
+    assert.equal(build({ meter: { count: 1000 } }), null);
+    assert.equal(build({ meter: { count: 999 } }), null);
   });
 
   it('creates one billable api.request event for an over-allowance request', () => {
@@ -53,19 +57,73 @@ describe('#4560 — API overage billable usage event contract', () => {
     assert.equal(build({ status: 503 }), null);
   });
 
+  it('bounds status to the 100–499 range', () => {
+    assert.equal(build({ status: 0 }), null);
+    assert.equal(build({ status: 99 }), null);
+    assert.equal(build({ status: -1 }), null);
+    assert.equal(build({ status: 500 }), null);
+    assert.ok(build({ status: 499 }));
+  });
+
+  it('bills work-performed 4xx but not auth failures or the enforced 429', () => {
+    // Policy: 401/403 = no authorized work performed → not billable. 429 =
+    // enforce-mode daily refusal (#4684) whose INCR is rolled back → billing it
+    // would charge a refused call and alias the rolled-back count onto the next
+    // served request. Other 4xx reflect work the gateway did perform → billable.
+    assert.equal(build({ status: 401 }), null);
+    assert.equal(build({ status: 403 }), null);
+    assert.equal(build({ status: 429 }), null);
+    assert.ok(build({ status: 400 }));
+    assert.ok(build({ status: 404 }));
+  });
+
   it('requires a counted user API-key request', () => {
     assert.equal(build({ userId: '' }), null);
     assert.equal(build({ isUserApiKey: false }), null);
-    assert.equal(build({ meter: { count: 1001, metered: false } }), null);
-    assert.equal(build({ meter: { count: 1001.5, metered: true } }), null);
+    assert.equal(build({ meter: { metered: false } }), null);
+    assert.equal(build({ meter: { count: 1001.5 } }), null);
     assert.equal(build({ includedAllowance: -1 }), null);
     assert.equal(build({ includedAllowance: 1000.5 }), null);
+  });
+
+  it('requires a valid yyyy-mm-dd meter usage day', () => {
+    assert.equal(build({ meter: { usageDay: '' } }), null);
+    assert.equal(build({ meter: { usageDay: '2026-7-4' } }), null);
+    assert.equal(build({ meter: { usageDay: 'not-a-day' } }), null);
+  });
+
+  it('binds usageDate to the meter day, never a wall-clock read (UTC rollover)', () => {
+    // The meter INCRs against a UTC day; the event must stamp THAT day, not a
+    // second clock read at build time. Otherwise a request straddling midnight
+    // emits day D+1 carrying a day-D count, and a genuine D+1 request at the
+    // same count aliases onto it — silently dropping a billable unit downstream.
+    const dayD = build({ meter: { usageDay: '2026-07-04', count: 1001 } });
+    const dayNext = build({ meter: { usageDay: '2026-07-05', count: 1001 } });
+
+    assert.ok(dayD);
+    assert.ok(dayNext);
+    assert.equal(dayD.usageDate, '2026-07-04');
+    assert.equal(dayNext.usageDate, '2026-07-05');
+    assert.notEqual(dayD.idempotencyKey, dayNext.idempotencyKey);
+    assert.notEqual(dayD.eventId, dayNext.eventId);
+  });
+
+  it('canonicalizes route to the matched path, stripping any query string', () => {
+    const event = build({ route: '/api/news/v1/list-feed-digest?cursor=abc&limit=50' });
+    const baseline = build();
+
+    assert.ok(event);
+    assert.ok(baseline);
+    assert.equal(event.route, '/api/news/v1/list-feed-digest');
+    assert.ok(!event.idempotencyKey.includes('?'));
+    // Query variants of one route must share identity so they dedupe as one unit.
+    assert.equal(event.idempotencyKey, baseline.idempotencyKey);
   });
 
   it('uses stable idempotency material for the same request count', () => {
     const first = build();
     const second = build();
-    const nextCount = build({ meter: { count: 1002, metered: true } });
+    const nextCount = build({ meter: { count: 1002 } });
 
     assert.ok(first);
     assert.ok(second);

--- a/tests/api-overage-billing.test.mts
+++ b/tests/api-overage-billing.test.mts
@@ -1,0 +1,77 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  API_OVERAGE_METER_ID,
+  buildApiOverageUsageEvent,
+} from '../server/_shared/api-overage-billing.ts';
+
+const DAY = new Date(Date.UTC(2026, 6, 4, 15, 30, 0));
+
+function build(overrides: Partial<Parameters<typeof buildApiOverageUsageEvent>[0]> = {}) {
+  return buildApiOverageUsageEvent({
+    userId: 'user_123',
+    route: '/api/news/v1/list-feed-digest',
+    method: 'get',
+    status: 200,
+    includedAllowance: 1000,
+    meter: { count: 1001, metered: true },
+    date: DAY,
+    isUserApiKey: true,
+    ...overrides,
+  });
+}
+
+describe('#4560 — API overage billable usage event contract', () => {
+  it('returns null while the daily count is at or below the included allowance', () => {
+    assert.equal(build({ meter: { count: 1000, metered: true } }), null);
+    assert.equal(build({ meter: { count: 999, metered: true } }), null);
+  });
+
+  it('creates one billable api.request event for an over-allowance request', () => {
+    const event = build();
+
+    assert.ok(event);
+    assert.equal(event.meterId, API_OVERAGE_METER_ID);
+    assert.equal(event.userId, 'user_123');
+    assert.equal(event.route, '/api/news/v1/list-feed-digest');
+    assert.equal(event.method, 'GET');
+    assert.equal(event.status, 200);
+    assert.equal(event.usageDate, '2026-07-04');
+    assert.equal(event.quantity, 1);
+    assert.equal(event.dailyCount, 1001);
+    assert.equal(event.includedAllowance, 1000);
+    assert.match(event.eventId, /^wm_api_request_[0-9a-z]+$/);
+    assert.match(
+      event.idempotencyKey,
+      /^api\.request:user_123:2026-07-04:GET:\/api\/news\/v1\/list-feed-digest:200:1001$/,
+    );
+  });
+
+  it('does not bill 5xx responses', () => {
+    assert.equal(build({ status: 500 }), null);
+    assert.equal(build({ status: 503 }), null);
+  });
+
+  it('requires a counted user API-key request', () => {
+    assert.equal(build({ userId: '' }), null);
+    assert.equal(build({ isUserApiKey: false }), null);
+    assert.equal(build({ meter: { count: 1001, metered: false } }), null);
+    assert.equal(build({ meter: { count: 1001.5, metered: true } }), null);
+    assert.equal(build({ includedAllowance: -1 }), null);
+    assert.equal(build({ includedAllowance: 1000.5 }), null);
+  });
+
+  it('uses stable idempotency material for the same request count', () => {
+    const first = build();
+    const second = build();
+    const nextCount = build({ meter: { count: 1002, metered: true } });
+
+    assert.ok(first);
+    assert.ok(second);
+    assert.ok(nextCount);
+    assert.equal(first.eventId, second.eventId);
+    assert.equal(first.idempotencyKey, second.idempotencyKey);
+    assert.notEqual(first.eventId, nextCount.eventId);
+  });
+});

--- a/tests/api-overage-billing.test.mts
+++ b/tests/api-overage-billing.test.mts
@@ -79,11 +79,36 @@ describe('#4560 — API overage billable usage event contract', () => {
 
   it('requires a counted user API-key request', () => {
     assert.equal(build({ userId: '' }), null);
+    assert.equal(build({ route: '' }), null);
+    assert.equal(build({ method: '' }), null);
     assert.equal(build({ isUserApiKey: false }), null);
     assert.equal(build({ meter: { metered: false } }), null);
     assert.equal(build({ meter: { count: 1001.5 } }), null);
     assert.equal(build({ includedAllowance: -1 }), null);
     assert.equal(build({ includedAllowance: 1000.5 }), null);
+  });
+
+  it('returns null when the meter is null or undefined', () => {
+    // The build() helper always synthesizes a meter, so exercise the
+    // null/undefined branch directly through the real entry point.
+    const baseInput = {
+      userId: 'user_123',
+      route: '/api/news/v1/list-feed-digest',
+      method: 'get',
+      status: 200,
+      includedAllowance: 1000,
+      isUserApiKey: true,
+    };
+    assert.equal(buildApiOverageUsageEvent({ ...baseInput, meter: null }), null);
+    assert.equal(buildApiOverageUsageEvent({ ...baseInput, meter: undefined }), null);
+  });
+
+  it('rejects a colon in any free-form idempotency segment (delimiter safety)', () => {
+    // The idempotency key is ':'-joined; a ':' in userId/method/route could
+    // shift segments and alias two distinct requests onto one billing identity.
+    assert.equal(build({ userId: 'user:123' }), null);
+    assert.equal(build({ route: '/api/x:y/v1/z' }), null);
+    assert.equal(build({ method: 'GE:T' }), null);
   });
 
   it('requires a valid yyyy-mm-dd meter usage day', () => {


### PR DESCRIPTION
## Summary
API overage billing now has a safe event contract to build on: eligible over-allowance user-key requests produce deterministic `api.request` candidates, while burst/ceiling rejection and live Dodo ingestion remain untouched. The contract rejects 5xx terminal responses and unmetered/unlimited cases, so future batching starts from a no-charge-by-default boundary.

## Validation
- `./node_modules/.bin/tsx --test tests/api-overage-billing.test.mts tests/api-key-rate-limit.test.mts`
- `npm run typecheck:api`
- Pre-push hook: full `npm run typecheck`, `npm run typecheck:api`, boundary/safe HTML/rate-limit/premium-fetch checks, server handler tests, changed test files, markdown lint, version sync

## Related
Related: #4560, #3117

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5_Codex](https://img.shields.io/badge/GPT--5_Codex-000000)