### PR TITLE
fix(api): add standalone write idempotency

### DIFF
--- a/api/_idempotency.d.ts
+++ b/api/_idempotency.d.ts
@@ -1,0 +1,47 @@
+export const IDEMPOTENCY_HEADER: 'Idempotency-Key';
+export const IDEMPOTENT_REPLAYED_HEADER: 'Idempotent-Replayed';
+
+export type StandaloneIdempotencyTerminal =
+  | { kind: 'disabled' }
+  | { kind: 'invalid'; response: Response }
+  | { kind: 'replay'; response: Response }
+  | { kind: 'conflict'; response: Response }
+  | { kind: 'mismatch'; response: Response };
+
+export type StandaloneIdempotencyOutcome =
+  | StandaloneIdempotencyTerminal
+  | {
+      kind: 'proceed';
+      key: string;
+      store: (status: number, body: ArrayBuffer, contentType: string | null) => Promise<void>;
+    };
+
+export type StandaloneIdempotencyPeekOutcome =
+  | StandaloneIdempotencyTerminal
+  | { kind: 'miss' };
+
+export function isValidIdempotencyKey(key: string): boolean;
+
+export function getIdempotencyKey(request: Request): string | null;
+
+export function peekStandaloneIdempotency(args: {
+  request: Request;
+  pathname: string;
+  scope: string | null;
+  idempotencyKey: string;
+  corsHeaders: Record<string, string>;
+}): Promise<StandaloneIdempotencyPeekOutcome>;
+
+export function beginStandaloneIdempotency(args: {
+  request: Request;
+  pathname: string;
+  scope: string | null;
+  idempotencyKey: string;
+  corsHeaders: Record<string, string>;
+  completedTtlSeconds?: number;
+}): Promise<StandaloneIdempotencyOutcome>;
+
+export function completeStandaloneIdempotency(
+  idempotency: StandaloneIdempotencyOutcome | null,
+  response: Response,
+): Promise<Response>;

--- a/api/_idempotency.js
+++ b/api/_idempotency.js
@@ -1,0 +1,263 @@
+import { redisPipeline } from './_upstash-json.js';
+
+export const IDEMPOTENCY_HEADER = 'Idempotency-Key';
+export const IDEMPOTENT_REPLAYED_HEADER = 'Idempotent-Replayed';
+
+const KEY_MAX_LENGTH = 255;
+const KEY_PATTERN = /^[\x21-\x7e]{1,255}$/;
+const PROCESSING_TTL_SECONDS = 180;
+const DEFAULT_COMPLETED_TTL_SECONDS = 24 * 60 * 60;
+const MAX_STORED_BODY_BYTES = 256 * 1024;
+const PROCESSING_MARKER = JSON.stringify({ state: 'processing' });
+
+export function isValidIdempotencyKey(key) {
+  return typeof key === 'string' && key.length <= KEY_MAX_LENGTH && KEY_PATTERN.test(key);
+}
+
+async function sha256Hex(input) {
+  const data = typeof input === 'string' ? new TextEncoder().encode(input) : input;
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+function anonScope(request) {
+  const ip =
+    request.headers.get('cf-connecting-ip') ||
+    request.headers.get('x-real-ip') ||
+    (request.headers.get('x-forwarded-for') || '').split(',')[0]?.trim() ||
+    'unknown';
+  return `ip:${ip}`;
+}
+
+function jsonResponse(status, body, corsHeaders, extraHeaders = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'no-store',
+      ...corsHeaders,
+      ...extraHeaders,
+    },
+  });
+}
+
+function isReplayableTextBody(contentType) {
+  if (!contentType) return false;
+  const ct = contentType.toLowerCase();
+  return ct.includes('json') || ct.startsWith('text/');
+}
+
+function isRetryableStatus(status) {
+  return status === 408 || status === 409 || status === 429 || status >= 500;
+}
+
+async function getRequestHashAndRedisKey(request, pathname, scope, idempotencyKey) {
+  try {
+    const bodyBuf = await request.clone().arrayBuffer();
+    const reqHash = await sha256Hex(bodyBuf);
+    const effectiveScope = scope || anonScope(request);
+    const redisKey = `idem:v1:${await sha256Hex(`${effectiveScope}\n${pathname}\n${idempotencyKey}`)}`;
+    return { reqHash, redisKey };
+  } catch {
+    return null;
+  }
+}
+
+function outcomeFromStoredRecord(raw, reqHash, idempotencyKey, corsHeaders) {
+  if (raw == null) return { kind: 'miss' };
+
+  let record = null;
+  if (typeof raw === 'string') {
+    try {
+      record = JSON.parse(raw);
+    } catch {
+      record = null;
+    }
+  }
+
+  if (!record || typeof record !== 'object') return { kind: 'disabled' };
+
+  if (record.state === 'processing') {
+    return {
+      kind: 'conflict',
+      response: jsonResponse(
+        409,
+        {
+          error: 'idempotency_conflict',
+          message: `A request with this ${IDEMPOTENCY_HEADER} is still being processed. Retry shortly.`,
+        },
+        corsHeaders,
+        { 'Retry-After': '2', [IDEMPOTENCY_HEADER]: idempotencyKey },
+      ),
+    };
+  }
+
+  if (record.state !== 'completed') return { kind: 'disabled' };
+
+  if (record.reqHash !== reqHash) {
+    return {
+      kind: 'mismatch',
+      response: jsonResponse(
+        422,
+        {
+          error: 'idempotency_key_reused',
+          message: `This ${IDEMPOTENCY_HEADER} was already used with a different request body.`,
+        },
+        corsHeaders,
+        { [IDEMPOTENCY_HEADER]: idempotencyKey },
+      ),
+    };
+  }
+
+  return {
+    kind: 'replay',
+    response: new Response(record.body, {
+      status: record.status,
+      headers: {
+        'Content-Type': record.contentType ?? 'application/json',
+        'Cache-Control': 'no-store',
+        ...corsHeaders,
+        [IDEMPOTENCY_HEADER]: idempotencyKey,
+        [IDEMPOTENT_REPLAYED_HEADER]: 'true',
+      },
+    }),
+  };
+}
+
+async function releaseProcessingLock(redisKey) {
+  await redisPipeline([['DEL', redisKey]]);
+}
+
+export async function peekStandaloneIdempotency({
+  request,
+  pathname,
+  scope,
+  idempotencyKey,
+  corsHeaders,
+}) {
+  if (!isValidIdempotencyKey(idempotencyKey)) {
+    return {
+      kind: 'invalid',
+      response: jsonResponse(
+        400,
+        {
+          error: 'invalid_idempotency_key',
+          message: `The ${IDEMPOTENCY_HEADER} header must be 1-${KEY_MAX_LENGTH} printable ASCII characters.`,
+        },
+        corsHeaders,
+      ),
+    };
+  }
+
+  const resolved = await getRequestHashAndRedisKey(request, pathname, scope, idempotencyKey);
+  if (!resolved) return { kind: 'disabled' };
+
+  const pipeline = await redisPipeline([['GET', resolved.redisKey]]);
+  if (!pipeline || pipeline.length < 1) return { kind: 'disabled' };
+
+  const entry = pipeline[0];
+  if (entry?.error) return { kind: 'disabled' };
+
+  return outcomeFromStoredRecord(entry?.result, resolved.reqHash, idempotencyKey, corsHeaders);
+}
+
+export async function beginStandaloneIdempotency({
+  request,
+  pathname,
+  scope,
+  idempotencyKey,
+  corsHeaders,
+  completedTtlSeconds = DEFAULT_COMPLETED_TTL_SECONDS,
+}) {
+  if (!isValidIdempotencyKey(idempotencyKey)) {
+    return {
+      kind: 'invalid',
+      response: jsonResponse(
+        400,
+        {
+          error: 'invalid_idempotency_key',
+          message: `The ${IDEMPOTENCY_HEADER} header must be 1-${KEY_MAX_LENGTH} printable ASCII characters.`,
+        },
+        corsHeaders,
+      ),
+    };
+  }
+
+  const resolved = await getRequestHashAndRedisKey(request, pathname, scope, idempotencyKey);
+  if (!resolved) return { kind: 'disabled' };
+
+  const pipeline = await redisPipeline([
+    ['SET', resolved.redisKey, PROCESSING_MARKER, 'NX', 'EX', String(PROCESSING_TTL_SECONDS)],
+    ['GET', resolved.redisKey],
+  ]);
+  if (!pipeline || pipeline.length < 2) return { kind: 'disabled' };
+
+  const claim = pipeline[0];
+  if (claim?.error) return { kind: 'disabled' };
+
+  if (claim?.result === 'OK') {
+    return {
+      kind: 'proceed',
+      key: idempotencyKey,
+      store: (status, body, contentType) =>
+        storeStandaloneResult(resolved.redisKey, status, body, contentType, resolved.reqHash, completedTtlSeconds),
+    };
+  }
+
+  const outcome = outcomeFromStoredRecord(pipeline[1]?.result, resolved.reqHash, idempotencyKey, corsHeaders);
+  return outcome.kind === 'miss' ? { kind: 'disabled' } : outcome;
+}
+
+export function getIdempotencyKey(request) {
+  return request.headers.get(IDEMPOTENCY_HEADER);
+}
+
+export async function completeStandaloneIdempotency(idempotency, response) {
+  if (!idempotency || idempotency.kind !== 'proceed') return response;
+
+  const body = await response.arrayBuffer();
+  await idempotency.store(response.status, body, response.headers.get('content-type'));
+
+  const headers = new Headers(response.headers);
+  headers.set(IDEMPOTENCY_HEADER, idempotency.key);
+  headers.set(IDEMPOTENT_REPLAYED_HEADER, 'false');
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+async function storeStandaloneResult(redisKey, status, body, contentType, reqHash, completedTtlSeconds) {
+  try {
+    if (
+      isRetryableStatus(status) ||
+      body.byteLength > MAX_STORED_BODY_BYTES ||
+      !isReplayableTextBody(contentType)
+    ) {
+      await releaseProcessingLock(redisKey);
+      return;
+    }
+
+    const record = {
+      state: 'completed',
+      status,
+      contentType,
+      reqHash,
+      body: new TextDecoder().decode(body),
+    };
+    const pipeline = await redisPipeline([
+      ['SET', redisKey, JSON.stringify(record), 'EX', String(completedTtlSeconds)],
+    ]);
+    const setResult = pipeline?.[0];
+    if (setResult?.error || setResult?.result !== 'OK') await releaseProcessingLock(redisKey);
+  } catch {
+    try {
+      await releaseProcessingLock(redisKey);
+    } catch {
+      // Ignore release failures; the processing marker has a short TTL.
+    }
+  }
+}

--- a/api/create-checkout.ts
+++ b/api/create-checkout.ts
@@ -15,6 +15,11 @@ export const config = { runtime: 'edge' };
 import { getCorsHeaders } from './_cors.js';
 // @ts-expect-error — JS module, no declaration file
 import { captureSilentError } from './_sentry-edge.js';
+import {
+  beginStandaloneIdempotency,
+  completeStandaloneIdempotency,
+  getIdempotencyKey,
+} from './_idempotency.js';
 import { validateBearerToken } from '../server/auth-session';
 
 const CONVEX_SITE_URL =
@@ -45,7 +50,7 @@ export default async function handler(
       headers: {
         ...cors,
         'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization, Idempotency-Key',
       },
     });
   }
@@ -63,6 +68,8 @@ export default async function handler(
   if (!session.valid || !session.userId) {
     return json({ error: 'Unauthorized' }, 401, cors);
   }
+
+  const idempotencyRequest = req.clone();
 
   // Parse request body
   let body: {
@@ -82,8 +89,27 @@ export default async function handler(
     return json({ error: 'productId is required' }, 400, cors);
   }
 
+  const idempotencyKey = getIdempotencyKey(req);
+  const idempotency = idempotencyKey
+    ? await beginStandaloneIdempotency({
+      request: idempotencyRequest,
+      pathname: '/api/create-checkout',
+      scope: `user:${session.userId}`,
+      idempotencyKey,
+      corsHeaders: cors,
+      completedTtlSeconds: 10 * 60,
+    })
+    : null;
+  if (
+    idempotency &&
+    idempotency.kind !== 'proceed' &&
+    idempotency.kind !== 'disabled'
+  ) {
+    return idempotency.response;
+  }
+
   if (!CONVEX_SITE_URL || !RELAY_SHARED_SECRET) {
-    return json({ error: 'Service unavailable' }, 503, cors);
+    return completeStandaloneIdempotency(idempotency, json({ error: 'Service unavailable' }, 503, cors));
   }
 
   // Relay to Convex
@@ -118,20 +144,20 @@ export default async function handler(
         // to ACTIVE_SUBSCRIPTION_EXISTS would silently misroute a PAYMENT_IN_PROGRESS
         // (or any future) block to the wrong dialog — so fall back to a generic
         // code that the client classifies as a neutral block, not a duplicate sub.
-        return json({
+        return completeStandaloneIdempotency(idempotency, json({
           error: data?.error ?? 'CHECKOUT_BLOCKED',
           message: data?.message ?? 'This checkout could not be started.',
           subscription: data?.subscription,
           pendingPayment: data?.pendingPayment,
-        }, 409, cors);
+        }, 409, cors));
       }
-      return json({ error: data?.error || 'Checkout creation failed' }, 502, cors);
+      return completeStandaloneIdempotency(idempotency, json({ error: data?.error || 'Checkout creation failed' }, 502, cors));
     }
 
-    return json(data, 200, cors);
+    return completeStandaloneIdempotency(idempotency, json(data, 200, cors));
   } catch (err) {
     console.error('[create-checkout] Relay failed:', (err as Error).message);
     captureSilentError(err, { tags: { route: 'api/create-checkout', step: 'relay' }, ctx });
-    return json({ error: 'Checkout service unavailable' }, 502, cors);
+    return completeStandaloneIdempotency(idempotency, json({ error: 'Checkout service unavailable' }, 502, cors));
   }
 }

--- a/api/customer-portal.ts
+++ b/api/customer-portal.ts
@@ -12,6 +12,11 @@ export const config = { runtime: 'edge' };
 import { getCorsHeaders } from './_cors.js';
 // @ts-expect-error — JS module, no declaration file
 import { captureSilentError } from './_sentry-edge.js';
+import {
+  beginStandaloneIdempotency,
+  completeStandaloneIdempotency,
+  getIdempotencyKey,
+} from './_idempotency.js';
 import { validateBearerToken } from '../server/auth-session';
 
 const CONVEX_SITE_URL =
@@ -42,7 +47,7 @@ export default async function handler(
       headers: {
         ...cors,
         'Access-Control-Allow-Methods': 'POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization, Idempotency-Key',
       },
     });
   }
@@ -60,8 +65,26 @@ export default async function handler(
     return json({ error: 'Unauthorized' }, 401, cors);
   }
 
+  const idempotencyKey = getIdempotencyKey(req);
+  const idempotency = idempotencyKey
+    ? await beginStandaloneIdempotency({
+      request: req,
+      pathname: '/api/customer-portal',
+      scope: `user:${session.userId}`,
+      idempotencyKey,
+      corsHeaders: cors,
+    })
+    : null;
+  if (
+    idempotency &&
+    idempotency.kind !== 'proceed' &&
+    idempotency.kind !== 'disabled'
+  ) {
+    return idempotency.response;
+  }
+
   if (!CONVEX_SITE_URL || !RELAY_SHARED_SECRET) {
-    return json({ error: 'Service unavailable' }, 503, cors);
+    return completeStandaloneIdempotency(idempotency, json({ error: 'Service unavailable' }, 503, cors));
   }
 
   try {
@@ -78,13 +101,16 @@ export default async function handler(
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok) {
       console.error('[customer-portal] Relay error:', resp.status, data);
-      return json({ error: data?.error || 'Customer portal unavailable' }, resp.status === 404 ? 404 : 502, cors);
+      return completeStandaloneIdempotency(
+        idempotency,
+        json({ error: data?.error || 'Customer portal unavailable' }, resp.status === 404 ? 404 : 502, cors),
+      );
     }
 
-    return json(data, 200, cors);
+    return completeStandaloneIdempotency(idempotency, json(data, 200, cors));
   } catch (err) {
     console.error('[customer-portal] Relay failed:', (err as Error).message);
     captureSilentError(err, { tags: { route: 'api/customer-portal', step: 'relay' }, ctx });
-    return json({ error: 'Customer portal unavailable' }, 502, cors);
+    return completeStandaloneIdempotency(idempotency, json({ error: 'Customer portal unavailable' }, 502, cors));
   }
 }

--- a/api/notification-channels.ts
+++ b/api/notification-channels.ts
@@ -15,6 +15,11 @@ export const config = { runtime: 'edge' };
 import { getCorsHeaders } from './_cors.js';
 // @ts-expect-error — JS module, no declaration file
 import { captureEdgeException, captureSilentError } from './_sentry-edge.js';
+import {
+  beginStandaloneIdempotency,
+  completeStandaloneIdempotency,
+  getIdempotencyKey,
+} from './_idempotency.js';
 import { blockedNotificationWebhookUrlReason } from './_notification-webhook-ssrf';
 import { validateBearerToken } from '../server/auth-session';
 import { getEntitlements } from '../server/_shared/entitlement-check';
@@ -183,7 +188,7 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
       headers: {
         ...corsHeaders,
         'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-        'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+        'Access-Control-Allow-Headers': 'Content-Type, Authorization, Idempotency-Key',
       },
     });
   }
@@ -194,6 +199,8 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
 
   const session = await validateBearerToken(token);
   if (!session.valid || !session.userId) return json({ error: 'Unauthorized' }, 401, corsHeaders);
+
+  const idempotencyRequest = req.method === 'POST' ? req.clone() : null;
 
   if (!CONVEX_SITE_URL || !RELAY_SHARED_SECRET) {
     return json({ error: 'Service unavailable' }, 503, corsHeaders);
@@ -233,6 +240,26 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
       return json({ error: 'Invalid JSON body' }, 400, corsHeaders);
     }
 
+    const idempotencyKey = getIdempotencyKey(req);
+    const idempotency = idempotencyKey
+      ? await beginStandaloneIdempotency({
+        request: idempotencyRequest ?? req,
+        pathname: '/api/notification-channels',
+        scope: `user:${session.userId}`,
+        idempotencyKey,
+        corsHeaders,
+      })
+      : null;
+    if (
+      idempotency &&
+      idempotency.kind !== 'proceed' &&
+      idempotency.kind !== 'disabled'
+    ) {
+      return idempotency.response;
+    }
+    const finish = (response: Response): Promise<Response> =>
+      completeStandaloneIdempotency(idempotency, response);
+
     const { action } = body;
 
     try {
@@ -242,19 +269,19 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
         const resp = await convexRelay(relayBody);
         if (!resp.ok) {
           console.error('[notification-channels] POST create-pairing-token relay error:', resp.status);
-          return json({ error: 'Operation failed' }, 500, corsHeaders);
+          return finish(json({ error: 'Operation failed' }, 500, corsHeaders));
         }
-        return json(await resp.json(), 200, corsHeaders);
+        return finish(json(await resp.json(), 200, corsHeaders));
       }
 
       if (action === 'set-channel') {
         const { channelType, email, webhookEnvelope, webhookLabel } = body;
-        if (!channelType) return json({ error: 'channelType required' }, 400, corsHeaders);
+        if (!channelType) return finish(json({ error: 'channelType required' }, 400, corsHeaders));
 
         if (channelType === 'webhook' && webhookEnvelope) {
           const blockedReason = blockedNotificationWebhookUrlReason(webhookEnvelope);
           if (blockedReason) {
-            return json({ error: blockedReason }, 400, corsHeaders);
+            return finish(json({ error: blockedReason }, 400, corsHeaders));
           }
         }
 
@@ -265,25 +292,25 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
           try {
             relayBody.webhookEnvelope = await encryptSlackWebhook(webhookEnvelope);
           } catch {
-            return json({ error: 'Encryption unavailable' }, 503, corsHeaders);
+            return finish(json({ error: 'Encryption unavailable' }, 503, corsHeaders));
           }
         }
         const resp = await convexRelay(relayBody);
         if (!resp.ok) {
           console.error('[notification-channels] POST set-channel relay error:', resp.status);
-          return json({ error: 'Operation failed' }, 500, corsHeaders);
+          return finish(json({ error: 'Operation failed' }, 500, corsHeaders));
         }
         const setResult = await resp.json() as { ok: boolean; isNew?: boolean };
         console.log(`[notification-channels] set-channel ${channelType}: isNew=${setResult.isNew}`);
         // Only send welcome on first connect, not re-links; use waitUntil so the edge isolate doesn't terminate early
         if (setResult.isNew) ctx.waitUntil(publishWelcome(session.userId, channelType));
-        return json({ ok: true }, 200, corsHeaders);
+        return finish(json({ ok: true }, 200, corsHeaders));
       }
 
       if (action === 'set-web-push') {
         const { endpoint, p256dh, auth, userAgent } = body;
         if (!endpoint || !p256dh || !auth) {
-          return json({ error: 'endpoint, p256dh, auth required' }, 400, corsHeaders);
+          return finish(json({ error: 'endpoint, p256dh, auth required' }, 400, corsHeaders));
         }
         // SSRF defence. The relay later POSTs to whatever endpoint we
         // persist here, so an unvalidated user-submitted URL is a
@@ -296,17 +323,17 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
         try {
           const u = new URL(endpoint);
           if (u.protocol !== 'https:') {
-            return json({ error: 'endpoint must be https' }, 400, corsHeaders);
+            return finish(json({ error: 'endpoint must be https' }, 400, corsHeaders));
           }
           if (!isAllowedPushEndpointHost(u.hostname)) {
-            return json(
+            return finish(json(
               { error: 'endpoint host is not a recognised push service' },
               400,
               corsHeaders,
-            );
+            ));
           }
         } catch {
-          return json({ error: 'invalid endpoint' }, 400, corsHeaders);
+          return finish(json({ error: 'invalid endpoint' }, 400, corsHeaders));
         }
         const resp = await convexRelay({
           action: 'set-web-push',
@@ -319,22 +346,22 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
         });
         if (!resp.ok) {
           console.error('[notification-channels] POST set-web-push relay error:', resp.status);
-          return json({ error: 'Operation failed' }, 500, corsHeaders);
+          return finish(json({ error: 'Operation failed' }, 500, corsHeaders));
         }
         const wpResult = await resp.json() as { ok: boolean; isNew?: boolean };
         if (wpResult.isNew) ctx.waitUntil(publishWelcome(session.userId, 'web_push'));
-        return json({ ok: true }, 200, corsHeaders);
+        return finish(json({ ok: true }, 200, corsHeaders));
       }
 
       if (action === 'delete-channel') {
         const { channelType } = body;
-        if (!channelType) return json({ error: 'channelType required' }, 400, corsHeaders);
+        if (!channelType) return finish(json({ error: 'channelType required' }, 400, corsHeaders));
         const resp = await convexRelay({ action: 'delete-channel', userId: session.userId, channelType });
         if (!resp.ok) {
           console.error('[notification-channels] POST delete-channel relay error:', resp.status);
-          return json({ error: 'Operation failed' }, 500, corsHeaders);
+          return finish(json({ error: 'Operation failed' }, 500, corsHeaders));
         }
-        return json({ ok: true }, 200, corsHeaders);
+        return finish(json({ ok: true }, 200, corsHeaders));
       }
 
       if (action === 'set-alert-rules') {
@@ -352,19 +379,19 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
         });
         if (!resp.ok) {
           console.error('[notification-channels] POST set-alert-rules relay error:', resp.status);
-          return json({ error: 'Operation failed' }, 500, corsHeaders);
+          return finish(json({ error: 'Operation failed' }, 500, corsHeaders));
         }
-        return json({ ok: true }, 200, corsHeaders);
+        return finish(json({ ok: true }, 200, corsHeaders));
       }
 
       if (action === 'set-quiet-hours') {
         const VALID_OVERRIDE = new Set(['critical_only', 'silence_all', 'batch_on_wake']);
         const { variant, quietHoursEnabled, quietHoursStart, quietHoursEnd, quietHoursTimezone, quietHoursOverride, countries } = body;
         if (!variant || quietHoursEnabled === undefined) {
-          return json({ error: 'variant and quietHoursEnabled required' }, 400, corsHeaders);
+          return finish(json({ error: 'variant and quietHoursEnabled required' }, 400, corsHeaders));
         }
         if (quietHoursOverride !== undefined && !VALID_OVERRIDE.has(quietHoursOverride)) {
-          return json({ error: 'invalid quietHoursOverride' }, 400, corsHeaders);
+          return finish(json({ error: 'invalid quietHoursOverride' }, 400, corsHeaders));
         }
         const resp = await convexRelay({
           action: 'set-quiet-hours',
@@ -379,20 +406,20 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
         });
         if (!resp.ok) {
           console.error('[notification-channels] POST set-quiet-hours relay error:', resp.status);
-          return json({ error: 'Operation failed' }, 500, corsHeaders);
+          return finish(json({ error: 'Operation failed' }, 500, corsHeaders));
         }
         // If quiet hours were disabled or override changed away from batch_on_wake,
         // flush any held events so they're delivered rather than expiring silently.
         const abandonsBatch = !quietHoursEnabled || quietHoursOverride !== 'batch_on_wake';
         if (abandonsBatch) ctx.waitUntil(publishFlushHeld(session.userId, variant));
-        return json({ ok: true }, 200, corsHeaders);
+        return finish(json({ ok: true }, 200, corsHeaders));
       }
 
       if (action === 'set-digest-settings') {
         const VALID_DIGEST_MODE = new Set(['realtime', 'daily', 'twice_daily', 'weekly']);
         const { variant, digestMode, digestHour, digestTimezone, countries } = body;
         if (!variant || !digestMode || !VALID_DIGEST_MODE.has(digestMode)) {
-          return json({ error: 'variant and valid digestMode required' }, 400, corsHeaders);
+          return finish(json({ error: 'variant and valid digestMode required' }, 400, corsHeaders));
         }
         const resp = await convexRelay({
           action: 'set-digest-settings',
@@ -405,9 +432,9 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
         });
         if (!resp.ok) {
           console.error('[notification-channels] POST set-digest-settings relay error:', resp.status);
-          return json({ error: 'Operation failed' }, 500, corsHeaders);
+          return finish(json({ error: 'Operation failed' }, 500, corsHeaders));
         }
-        return json({ ok: true }, 200, corsHeaders);
+        return finish(json({ ok: true }, 200, corsHeaders));
       }
 
       // Atomic update of (digestMode, sensitivity) and any subset of the alert-rule
@@ -420,15 +447,15 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
         const VALID_SENSITIVITY = new Set(['all', 'high', 'critical']);
         const VALID_DIGEST_MODE = new Set(['realtime', 'daily', 'twice_daily', 'weekly']);
         const { variant, enabled, eventTypes, sensitivity, channels, aiDigestEnabled, digestMode, digestHour, digestTimezone, countries } = body;
-        if (!variant) return json({ error: 'variant required' }, 400, corsHeaders);
+        if (!variant) return finish(json({ error: 'variant required' }, 400, corsHeaders));
         if (sensitivity !== undefined && !VALID_SENSITIVITY.has(sensitivity)) {
-          return json({ error: 'invalid sensitivity' }, 400, corsHeaders);
+          return finish(json({ error: 'invalid sensitivity' }, 400, corsHeaders));
         }
         if (digestMode !== undefined && !VALID_DIGEST_MODE.has(digestMode)) {
-          return json({ error: 'invalid digestMode' }, 400, corsHeaders);
+          return finish(json({ error: 'invalid digestMode' }, 400, corsHeaders));
         }
         if (countries !== undefined && !Array.isArray(countries)) {
-          return json({ error: 'COUNTRIES_MUST_BE_ARRAY' }, 400, corsHeaders);
+          return finish(json({ error: 'COUNTRIES_MUST_BE_ARRAY' }, 400, corsHeaders));
         }
         const resp = await convexRelay({
           action: 'set-notification-config',
@@ -456,19 +483,19 @@ export default async function handler(req: Request, ctx: { waitUntil: (p: Promis
             if (text) {
               try { payload = JSON.parse(text); } catch { /* keep default */ }
             }
-            return json(payload, resp.status, corsHeaders);
+            return finish(json(payload, resp.status, corsHeaders));
           }
           console.error('[notification-channels] POST set-notification-config relay error:', resp.status);
-          return json({ error: 'Operation failed' }, 500, corsHeaders);
+          return finish(json({ error: 'Operation failed' }, 500, corsHeaders));
         }
-        return json({ ok: true }, 200, corsHeaders);
+        return finish(json({ ok: true }, 200, corsHeaders));
       }
 
-      return json({ error: 'Unknown action' }, 400, corsHeaders);
+      return finish(json({ error: 'Unknown action' }, 400, corsHeaders));
     } catch (err) {
       console.error('[notification-channels] POST error:', err);
       captureEdgeException(err, { handler: 'notification-channels', method: 'POST' }, ctx);
-      return json({ error: 'Operation failed' }, 500, corsHeaders);
+      return finish(json({ error: 'Operation failed' }, 500, corsHeaders));
     }
   }
 

--- a/api/notify.ts
+++ b/api/notify.ts
@@ -13,6 +13,11 @@ export const config = { runtime: 'edge' };
 import { getCorsHeaders, isDisallowedOrigin } from './_cors.js';
 // @ts-expect-error — JS module, no declaration file
 import { jsonResponse } from './_json-response.js';
+import {
+  beginStandaloneIdempotency,
+  completeStandaloneIdempotency,
+  getIdempotencyKey,
+} from './_idempotency.js';
 import { validateBearerToken } from '../server/auth-session';
 import { getEntitlements } from '../server/_shared/entitlement-check';
 
@@ -44,6 +49,8 @@ export default async function handler(req: Request): Promise<Response> {
   if (!session.valid || !session.userId) {
     return jsonResponse({ error: 'UNAUTHENTICATED' }, 401, cors);
   }
+
+  const idempotencyRequest = req.clone();
 
   const ent = await getEntitlements(session.userId);
   if (!ent || ent.features.tier < 1) {
@@ -80,6 +87,24 @@ export default async function handler(req: Request): Promise<Response> {
     return jsonResponse({ error: 'Service unavailable' }, 503, cors);
   }
 
+  const idempotencyKey = getIdempotencyKey(req);
+  const idempotency = idempotencyKey
+    ? await beginStandaloneIdempotency({
+      request: idempotencyRequest,
+      pathname: '/api/notify',
+      scope: `user:${session.userId}`,
+      idempotencyKey,
+      corsHeaders: cors,
+    })
+    : null;
+  if (
+    idempotency &&
+    idempotency.kind !== 'proceed' &&
+    idempotency.kind !== 'disabled'
+  ) {
+    return idempotency.response;
+  }
+
   const { eventType } = body;
 
   // Strip relay-internal scoring fields from user-supplied payload. These are
@@ -109,8 +134,8 @@ export default async function handler(req: Request): Promise<Response> {
   );
 
   if (!res.ok) {
-    return jsonResponse({ error: 'Publish failed' }, 502, cors);
+    return completeStandaloneIdempotency(idempotency, jsonResponse({ error: 'Publish failed' }, 502, cors));
   }
 
-  return jsonResponse({ ok: true }, 200, cors);
+  return completeStandaloneIdempotency(idempotency, jsonResponse({ ok: true }, 200, cors));
 }

--- a/api/user-prefs.ts
+++ b/api/user-prefs.ts
@@ -18,6 +18,12 @@ import { jsonResponse } from './_json-response.js';
 import { captureSilentError } from './_sentry-edge.js';
 // @ts-expect-error — JS module, no declaration file
 import { extractConvexErrorKind, isOpaqueConvexServerError, readConvexErrorNumber } from './_convex-error.js';
+import {
+  beginStandaloneIdempotency,
+  completeStandaloneIdempotency,
+  getIdempotencyKey,
+  peekStandaloneIdempotency,
+} from './_idempotency.js';
 import { ConvexHttpClient } from 'convex/browser';
 import { validateBearerToken } from '../server/auth-session';
 import { checkScopedRateLimit } from '../server/_shared/rate-limit';
@@ -113,6 +119,20 @@ export default async function handler(
     return jsonResponse({ error: 'UNAUTHENTICATED' }, 401, cors);
   }
 
+  const idempotencyKey = req.method === 'POST' ? getIdempotencyKey(req) : null;
+  if (idempotencyKey) {
+    const peek = await peekStandaloneIdempotency({
+      request: req,
+      pathname: '/api/user-prefs',
+      scope: `user:${session.userId}`,
+      idempotencyKey,
+      corsHeaders: cors,
+    });
+    if (peek.kind !== 'miss' && peek.kind !== 'disabled') {
+      return peek.response;
+    }
+  }
+
   const convexUrl = process.env.CONVEX_URL;
   if (!convexUrl) {
     return jsonResponse({ error: 'Service unavailable' }, 503, cors);
@@ -147,6 +167,25 @@ export default async function handler(
       );
     }
   }
+
+  const idempotency = idempotencyKey
+    ? await beginStandaloneIdempotency({
+      request: req,
+      pathname: '/api/user-prefs',
+      scope: `user:${session.userId}`,
+      idempotencyKey,
+      corsHeaders: cors,
+    })
+    : null;
+  if (
+    idempotency &&
+    idempotency.kind !== 'proceed' &&
+    idempotency.kind !== 'disabled'
+  ) {
+    return idempotency.response;
+  }
+  const finish = (response: Response): Promise<Response> =>
+    completeStandaloneIdempotency(idempotency, response);
 
   // Bound the Convex round-trip below Vercel's 25s edge wall-clock so a
   // stalled platform aborts cleanly into the SERVICE_UNAVAILABLE → 503 +
@@ -227,7 +266,7 @@ export default async function handler(
   try {
     body = await req.json();
   } catch {
-    return jsonResponse({ error: 'Invalid JSON' }, 400, cors);
+    return finish(jsonResponse({ error: 'Invalid JSON' }, 400, cors));
   }
 
   if (
@@ -235,7 +274,7 @@ export default async function handler(
     body.data === undefined ||
     typeof body.expectedSyncVersion !== 'number'
   ) {
-    return jsonResponse({ error: 'MISSING_FIELDS' }, 400, cors);
+    return finish(jsonResponse({ error: 'MISSING_FIELDS' }, 400, cors));
   }
 
   try {
@@ -251,23 +290,23 @@ export default async function handler(
     // clients stays the same as the older thrown ConvexError paths below.
     if (result.ok === false) {
       if (result.reason === 'BLOB_TOO_LARGE') {
-        return jsonResponse({ error: 'BLOB_TOO_LARGE' }, 400, cors);
+        return finish(jsonResponse({ error: 'BLOB_TOO_LARGE' }, 400, cors));
       }
       if (result.reason === 'RATE_LIMITED') {
         console.warn('[user-prefs] POST convex write rate limit exceeded');
-        return jsonResponse(
+        return finish(jsonResponse(
           { error: 'RATE_LIMITED' },
           429,
           rateLimitHeaders(cors, result.limit, result.reset),
-        );
+        ));
       }
-      return jsonResponse(
+      return finish(jsonResponse(
         { error: 'CONFLICT', actualSyncVersion: result.actualSyncVersion },
         409,
         cors,
-      );
+      ));
     }
-    return jsonResponse({ syncVersion: result.syncVersion }, 200, cors);
+    return finish(jsonResponse({ syncVersion: result.syncVersion }, 200, cors));
   } catch (err: unknown) {
     const msg = err instanceof Error ? err.message : String(err);
     const kind = extractConvexErrorKind(err, msg);
@@ -278,7 +317,7 @@ export default async function handler(
     // have soaked on the new code, this branch is unreachable and can be
     // removed (along with handleConflictResponse).
     if (kind === 'CONFLICT') {
-      return handleConflictResponse(err, msg, {
+      return finish(handleConflictResponse(err, msg, {
         userId: session.userId,
         variant: body.variant,
         ctx,
@@ -286,20 +325,20 @@ export default async function handler(
         expectedSyncVersion: body.expectedSyncVersion,
         blobSize: body.data !== undefined ? JSON.stringify(body.data).length : 0,
         cors,
-      });
+      }));
     }
     if (kind === 'BLOB_TOO_LARGE') {
-      return jsonResponse({ error: 'BLOB_TOO_LARGE' }, 400, cors);
+      return finish(jsonResponse({ error: 'BLOB_TOO_LARGE' }, 400, cors));
     }
     if (kind === 'RATE_LIMITED') {
       const limit = readConvexErrorNumber(err, 'limit') ?? USER_PREFS_WRITE_RATE_LIMIT;
       const reset = readConvexErrorNumber(err, 'reset') ?? Date.now() + 60_000;
       console.warn('[user-prefs] POST convex write rate limit exceeded');
-      return jsonResponse(
+      return finish(jsonResponse(
         { error: 'RATE_LIMITED' },
         429,
         rateLimitHeaders(cors, limit, reset),
-      );
+      ));
     }
     if (kind === 'UNAUTHENTICATED') {
       // See GET branch above — UNAUTHENTICATED here means Clerk-vs-Convex
@@ -316,7 +355,7 @@ export default async function handler(
         blobSize: body.data !== undefined ? JSON.stringify(body.data).length : 0,
         level: 'warning',
       }));
-      return jsonResponse({ error: 'UNAUTHENTICATED' }, 401, cors);
+      return finish(jsonResponse({ error: 'UNAUTHENTICATED' }, 401, cors));
     }
     if (kind === 'SERVICE_UNAVAILABLE') {
       // See GET branch above — Convex 503, transient. 503 + Retry-After
@@ -332,7 +371,7 @@ export default async function handler(
         blobSize: body.data !== undefined ? JSON.stringify(body.data).length : 0,
         level: 'warning',
       }));
-      return jsonResponse({ error: 'SERVICE_UNAVAILABLE' }, 503, { ...cors, 'Retry-After': '5' });
+      return finish(jsonResponse({ error: 'SERVICE_UNAVAILABLE' }, 503, { ...cors, 'Retry-After': '5' }));
     }
     console.error('[user-prefs] POST error:', err);
     captureSilentError(err, buildSentryContext(err, msg, {
@@ -342,7 +381,7 @@ export default async function handler(
       expectedSyncVersion: body.expectedSyncVersion,
       blobSize: body.data !== undefined ? JSON.stringify(body.data).length : 0,
     }));
-    return jsonResponse({ error: 'Failed to save preferences' }, 500, cors);
+    return finish(jsonResponse({ error: 'Failed to save preferences' }, 500, cors));
   }
 }
 

--- a/tests/api-idempotency.test.mjs
+++ b/tests/api-idempotency.test.mjs
@@ -1,0 +1,284 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it, mock } from 'node:test';
+
+const originalEnv = { ...process.env };
+const originalFetch = globalThis.fetch;
+
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, originalEnv);
+  globalThis.fetch = originalFetch;
+}
+
+function makeRequest(body = JSON.stringify({ action: 'write' })) {
+  return new Request('https://worldmonitor.app/api/test-write', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Origin: 'https://worldmonitor.app',
+    },
+    body,
+  });
+}
+
+async function importFreshIdempotencyModule() {
+  return import(`../api/_idempotency.js?test=${Date.now()}-${Math.random()}`);
+}
+
+async function sha256Hex(input) {
+  const data = typeof input === 'string' ? new TextEncoder().encode(input) : input;
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+async function redisKeyFor({ scope = 'user:user_1', path = '/api/test-write', key = 'k1' } = {}) {
+  return `idem:v1:${await sha256Hex(`${scope}\n${path}\n${key}`)}`;
+}
+
+function installRedisPipelineMock(handler) {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'upstash-token';
+  const calls = [];
+
+  globalThis.fetch = mock.fn(async (url, init) => {
+    assert.match(String(url), /\/pipeline$/);
+    const commands = JSON.parse(String(init?.body ?? '[]'));
+    calls.push(commands);
+    return Response.json(handler(commands));
+  });
+
+  return calls;
+}
+
+afterEach(() => {
+  mock.restoreAll();
+  restoreEnv();
+});
+
+describe('api standalone Idempotency-Key helper', () => {
+  it('rejects malformed keys without touching Redis', async () => {
+    const { beginStandaloneIdempotency, IDEMPOTENCY_HEADER } = await importFreshIdempotencyModule();
+    const fetchMock = mock.method(globalThis, 'fetch', async () => {
+      throw new Error('Redis should not be called');
+    });
+
+    const out = await beginStandaloneIdempotency({
+      request: makeRequest(),
+      pathname: '/api/test-write',
+      scope: 'user:user_1',
+      idempotencyKey: '',
+      corsHeaders: {},
+    });
+
+    assert.equal(out.kind, 'invalid');
+    assert.equal(out.response.status, 400);
+    assert.equal((await out.response.json()).error, 'invalid_idempotency_key');
+    assert.equal(out.response.headers.has(IDEMPOTENCY_HEADER), false);
+    assert.equal(fetchMock.mock.calls.length, 0);
+  });
+
+  it('fails open when Redis credentials are absent', async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    const { beginStandaloneIdempotency } = await importFreshIdempotencyModule();
+
+    const out = await beginStandaloneIdempotency({
+      request: makeRequest(),
+      pathname: '/api/test-write',
+      scope: 'user:user_1',
+      idempotencyKey: 'k1',
+      corsHeaders: {},
+    });
+
+    assert.equal(out.kind, 'disabled');
+  });
+
+  it('claims a new key with SET NX EX and returns a store function', async () => {
+    const calls = installRedisPipelineMock((commands) => {
+      assert.deepEqual(commands[0].slice(0, 2), ['SET', commands[0][1]]);
+      assert.equal(commands[0][3], 'NX');
+      assert.equal(commands[0][4], 'EX');
+      assert.equal(commands[1][0], 'GET');
+      return [{ result: 'OK' }, { result: null }];
+    });
+    const { beginStandaloneIdempotency } = await importFreshIdempotencyModule();
+
+    const out = await beginStandaloneIdempotency({
+      request: makeRequest(),
+      pathname: '/api/test-write',
+      scope: 'user:user_1',
+      idempotencyKey: 'k1',
+      corsHeaders: {},
+    });
+
+    assert.equal(out.kind, 'proceed');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0][0][5], '180');
+  });
+
+  it('returns 409 while an identical keyed request is still processing', async () => {
+    installRedisPipelineMock(() => [
+      { result: null },
+      { result: JSON.stringify({ state: 'processing' }) },
+    ]);
+    const { beginStandaloneIdempotency, IDEMPOTENCY_HEADER } = await importFreshIdempotencyModule();
+
+    const out = await beginStandaloneIdempotency({
+      request: makeRequest(),
+      pathname: '/api/test-write',
+      scope: 'user:user_1',
+      idempotencyKey: 'k1',
+      corsHeaders: {},
+    });
+
+    assert.equal(out.kind, 'conflict');
+    assert.equal(out.response.status, 409);
+    assert.equal(out.response.headers.get('Retry-After'), '2');
+    assert.equal(out.response.headers.get(IDEMPOTENCY_HEADER), 'k1');
+  });
+
+  it('replays a completed same-body response without claiming', async () => {
+    const reqBody = JSON.stringify({ action: 'write' });
+    const reqHash = await sha256Hex(reqBody);
+    installRedisPipelineMock(() => [
+      { result: null },
+      {
+        result: JSON.stringify({
+          state: 'completed',
+          status: 201,
+          contentType: 'application/json',
+          reqHash,
+          body: JSON.stringify({ id: 'original' }),
+        }),
+      },
+    ]);
+    const { beginStandaloneIdempotency, IDEMPOTENT_REPLAYED_HEADER } = await importFreshIdempotencyModule();
+
+    const out = await beginStandaloneIdempotency({
+      request: makeRequest(reqBody),
+      pathname: '/api/test-write',
+      scope: 'user:user_1',
+      idempotencyKey: 'k1',
+      corsHeaders: {},
+    });
+
+    assert.equal(out.kind, 'replay');
+    assert.equal(out.response.status, 201);
+    assert.equal(out.response.headers.get(IDEMPOTENT_REPLAYED_HEADER), 'true');
+    assert.deepEqual(await out.response.json(), { id: 'original' });
+  });
+
+  it('returns 422 when the same key is reused with a different body', async () => {
+    installRedisPipelineMock(() => [
+      { result: null },
+      {
+        result: JSON.stringify({
+          state: 'completed',
+          status: 200,
+          contentType: 'application/json',
+          reqHash: 'different-hash',
+          body: '{}',
+        }),
+      },
+    ]);
+    const { beginStandaloneIdempotency } = await importFreshIdempotencyModule();
+
+    const out = await beginStandaloneIdempotency({
+      request: makeRequest(JSON.stringify({ action: 'changed' })),
+      pathname: '/api/test-write',
+      scope: 'user:user_1',
+      idempotencyKey: 'k1',
+      corsHeaders: {},
+    });
+
+    assert.equal(out.kind, 'mismatch');
+    assert.equal(out.response.status, 422);
+    assert.equal((await out.response.json()).error, 'idempotency_key_reused');
+  });
+
+  it('stores a completed JSON response with the supplied TTL', async () => {
+    const storedCommands = [];
+    installRedisPipelineMock((commands) => {
+      storedCommands.push(commands);
+      if (commands[0][0] === 'SET' && commands[0].includes('NX')) {
+        return [{ result: 'OK' }, { result: null }];
+      }
+      return [{ result: 'OK' }];
+    });
+    const { beginStandaloneIdempotency } = await importFreshIdempotencyModule();
+
+    const out = await beginStandaloneIdempotency({
+      request: makeRequest(),
+      pathname: '/api/test-write',
+      scope: 'user:user_1',
+      idempotencyKey: 'k1',
+      corsHeaders: {},
+      completedTtlSeconds: 600,
+    });
+    assert.equal(out.kind, 'proceed');
+
+    await out.store(200, new TextEncoder().encode('{"ok":true}').buffer, 'application/json');
+
+    assert.equal(storedCommands[1][0][0], 'SET');
+    assert.equal(storedCommands[1][0][3], 'EX');
+    assert.equal(storedCommands[1][0][4], '600');
+    assert.equal(JSON.parse(storedCommands[1][0][2]).state, 'completed');
+  });
+
+  it('releases the processing marker instead of caching retryable failures', async () => {
+    const redisKey = await redisKeyFor();
+    const commandsSeen = [];
+    installRedisPipelineMock((commands) => {
+      commandsSeen.push(commands);
+      if (commands[0][0] === 'SET' && commands[0].includes('NX')) {
+        return [{ result: 'OK' }, { result: null }];
+      }
+      return [{ result: 1 }];
+    });
+    const { beginStandaloneIdempotency } = await importFreshIdempotencyModule();
+
+    const out = await beginStandaloneIdempotency({
+      request: makeRequest(),
+      pathname: '/api/test-write',
+      scope: 'user:user_1',
+      idempotencyKey: 'k1',
+      corsHeaders: {},
+    });
+    assert.equal(out.kind, 'proceed');
+
+    await out.store(503, new TextEncoder().encode('{"error":"down"}').buffer, 'application/json');
+
+    assert.deepEqual(commandsSeen[1][0], ['DEL', redisKey]);
+  });
+
+  it('releases the processing marker when completed SET returns a command error', async () => {
+    const redisKey = await redisKeyFor();
+    const commandsSeen = [];
+    installRedisPipelineMock((commands) => {
+      commandsSeen.push(commands);
+      if (commands[0][0] === 'SET' && commands[0].includes('NX')) {
+        return [{ result: 'OK' }, { result: null }];
+      }
+      if (commands[0][0] === 'SET') return [{ error: 'WRONGTYPE' }];
+      return [{ result: 1 }];
+    });
+    const { beginStandaloneIdempotency } = await importFreshIdempotencyModule();
+
+    const out = await beginStandaloneIdempotency({
+      request: makeRequest(),
+      pathname: '/api/test-write',
+      scope: 'user:user_1',
+      idempotencyKey: 'k1',
+      corsHeaders: {},
+    });
+    assert.equal(out.kind, 'proceed');
+
+    await out.store(200, new TextEncoder().encode('{"ok":true}').buffer, 'application/json');
+
+    assert.deepEqual(commandsSeen[2][0], ['DEL', redisKey]);
+  });
+});

--- a/tests/user-prefs-rate-limit.test.mts
+++ b/tests/user-prefs-rate-limit.test.mts
@@ -13,8 +13,10 @@ import {
 } from '../convex/constants.ts';
 
 const originalConvexUrl = process.env.CONVEX_URL;
+const originalFetch = globalThis.fetch;
 const TEST_NOW = 1_700_000_000_000;
 const TEST_USER_ID = 'user_rate_limit_test';
+const IDEMPOTENCY_KEY = '4f8b9c2e-1a3d-4b6f-8e0a-2c5d7f9b1e34';
 
 type RateLimitResult = {
   allowed: boolean;
@@ -41,6 +43,16 @@ function expectExposedRateLimitHeaders(headers: Headers): void {
 function restoreEnv(): void {
   if (originalConvexUrl === undefined) delete process.env.CONVEX_URL;
   else process.env.CONVEX_URL = originalConvexUrl;
+  delete process.env.UPSTASH_REDIS_REST_URL;
+  delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  globalThis.fetch = originalFetch;
+}
+
+async function sha256Hex(str: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(str));
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
 }
 
 afterEach(() => {
@@ -53,16 +65,29 @@ function makePost(body: Record<string, unknown> = {
   variant: 'full',
   data: { theme: 'dark' },
   expectedSyncVersion: 1,
-}): Request {
+}, extraHeaders: Record<string, string> = {}): Request {
   return new Request('https://worldmonitor.app/api/user-prefs', {
     method: 'POST',
     headers: {
       Origin: 'https://worldmonitor.app',
       Authorization: 'Bearer test-token',
       'Content-Type': 'application/json',
+      ...extraHeaders,
     },
     body: JSON.stringify(body),
   });
+}
+
+function installRedisPipeline(handler: (commands: string[][]) => Array<{ result: unknown }>): string[][][] {
+  process.env.UPSTASH_REDIS_REST_URL = 'https://upstash.test';
+  process.env.UPSTASH_REDIS_REST_TOKEN = 'upstash-token';
+  const calls: string[][][] = [];
+  globalThis.fetch = mock.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+    const commands = JSON.parse(String(init?.body ?? '[]')) as string[][];
+    calls.push(commands);
+    return Response.json(handler(commands));
+  }) as typeof fetch;
+  return calls;
 }
 
 function installDeps(rateLimitResult: RateLimitResult): {
@@ -215,6 +240,105 @@ describe('user-prefs POST write rate limit', () => {
     assert.ok(calls.some((call) => call.kind === 'mutation'), 'degraded limiter should fail open to Convex');
     assert.equal(warnMock.mock.calls.length, 1);
     assert.match(String(warnMock.mock.calls[0].arguments[0]), /rate limit unavailable; failing open/);
+  });
+
+  it('replays a completed Idempotency-Key response before charging the scoped limiter', async () => {
+    process.env.CONVEX_URL = 'https://convex.test';
+    const body = {
+      variant: 'full',
+      data: { theme: 'dark' },
+      expectedSyncVersion: 1,
+    };
+    const reqHash = await sha256Hex(JSON.stringify(body));
+    installRedisPipeline(() => [
+      {
+        result: JSON.stringify({
+          state: 'completed',
+          status: 200,
+          contentType: 'application/json',
+          reqHash,
+          body: JSON.stringify({ syncVersion: 42 }),
+        }),
+      },
+    ]);
+
+    const { calls, rateLimitCalls } = installDeps({
+      allowed: true,
+      limit: USER_PREFS_WRITE_RATE_LIMIT,
+      reset: TEST_NOW + 60_000,
+      degraded: false,
+    });
+
+    const res = await handler(makePost(body, { 'Idempotency-Key': IDEMPOTENCY_KEY }));
+
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('Idempotent-Replayed'), 'true');
+    assert.deepEqual(await res.json(), { syncVersion: 42 });
+    assert.deepEqual(rateLimitCalls, []);
+    assert.equal(calls.some((call) => call.kind === 'client'), false, 'replay should not construct a Convex client');
+    assert.equal(calls.some((call) => call.kind === 'mutation'), false, 'replay should not reach Convex');
+  });
+
+  it('claims a fresh Idempotency-Key only after the scoped limiter allows the write', async () => {
+    process.env.CONVEX_URL = 'https://convex.test';
+    const redisCalls = installRedisPipeline((commands) => {
+      if (commands[0][0] === 'GET') return [{ result: null }];
+      if (commands[0][0] === 'SET' && commands[0].includes('NX')) {
+        return [{ result: 'OK' }, { result: null }];
+      }
+      return [{ result: 'OK' }];
+    });
+    const { calls, rateLimitCalls } = installDeps({
+      allowed: true,
+      limit: USER_PREFS_WRITE_RATE_LIMIT,
+      reset: TEST_NOW + 60_000,
+      degraded: false,
+    });
+
+    const res = await handler(makePost(undefined, { 'Idempotency-Key': IDEMPOTENCY_KEY }));
+
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('Idempotency-Key'), IDEMPOTENCY_KEY);
+    assert.equal(res.headers.get('Idempotent-Replayed'), 'false');
+    assert.deepEqual(await res.json(), { syncVersion: 7 });
+    assert.deepEqual(rateLimitCalls, [{
+      scope: USER_PREFS_WRITE_RATE_SCOPE,
+      limit: USER_PREFS_WRITE_RATE_LIMIT,
+      window: USER_PREFS_WRITE_RATE_WINDOW,
+      identifier: TEST_USER_ID,
+    }]);
+    assert.ok(calls.some((call) => call.kind === 'mutation'), 'allowed keyed write should reach Convex');
+    assert.equal(redisCalls[0][0][0], 'GET', 'completed replay lookup should happen before rate limiting');
+    assert.deepEqual(redisCalls[1][0].slice(0, 4), ['SET', redisCalls[1][0][1], redisCalls[1][0][2], 'NX']);
+    assert.equal(redisCalls[2][0][0], 'SET', 'successful response should be persisted for replay');
+  });
+
+  it('does not claim or cache a fresh Idempotency-Key when the scoped limiter rejects the write', async () => {
+    process.env.CONVEX_URL = 'https://convex.test';
+    mock.method(Date, 'now', () => TEST_NOW);
+    const warnMock = mock.method(console, 'warn', () => {});
+    const redisCalls = installRedisPipeline(() => [{ result: null }]);
+    const { calls, rateLimitCalls } = installDeps({
+      allowed: false,
+      limit: USER_PREFS_WRITE_RATE_LIMIT,
+      reset: TEST_NOW + 30_000,
+      degraded: false,
+    });
+
+    const res = await handler(makePost(undefined, { 'Idempotency-Key': IDEMPOTENCY_KEY }));
+
+    assert.equal(res.status, 429);
+    assert.deepEqual(await res.json(), { error: 'RATE_LIMITED' });
+    assert.equal(redisCalls.length, 1, 'rate-limited fresh keys should only perform the pre-limit replay lookup');
+    assert.equal(redisCalls[0][0][0], 'GET');
+    assert.deepEqual(rateLimitCalls, [{
+      scope: USER_PREFS_WRITE_RATE_SCOPE,
+      limit: USER_PREFS_WRITE_RATE_LIMIT,
+      window: USER_PREFS_WRITE_RATE_WINDOW,
+      identifier: TEST_USER_ID,
+    }]);
+    assert.equal(calls.some((call) => call.kind === 'mutation'), false, 'rate-limited requests must not reach Convex');
+    assert.equal(warnMock.mock.calls.length, 1);
   });
 
   it('maps Convex-side RATE_LIMITED to 429 with retry guidance', async () => {


### PR DESCRIPTION
## Summary

Standalone write functions now honor Idempotency-Key so client retries can replay completed writes instead of creating duplicate checkout, portal, notification, notify, or prefs side effects.

The helper is API-local for Edge function boundaries: it scopes keys by authenticated user, claims processing in Upstash, replays same-body completions, rejects in-flight or mismatched retries, fails open on Redis trouble, and releases retryable/5xx responses instead of caching transient failures. Checkout uses a short 10-minute completed replay window, while user-prefs peeks before the scoped write limiter so completed retries do not burn budget.

Fixes #4721.

## Validation

- node --test tests/api-idempotency.test.mjs
- ./node_modules/.bin/tsx --test tests/user-prefs-rate-limit.test.mts
- npm run typecheck:api
- node --test tests/edge-functions.test.mjs
- git diff --check
- Pre-push hook: npm run typecheck, npm run typecheck:api, Convex type check, boundary/safe-html/Sentry/rate-limit/premium-fetch checks, changed tests, edge tests, version check

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)