### PR TITLE
fix(auth): publish auth.md agent metadata

### DIFF
--- a/api/_agent-metadata.d.ts
+++ b/api/_agent-metadata.d.ts
@@ -1,0 +1,3 @@
+export function resolveMetadataOrigin(req: Request): string;
+
+export function guardMetadataMethod(req: Request): Response | null;

--- a/api/_agent-metadata.js
+++ b/api/_agent-metadata.js
@@ -19,7 +19,7 @@
 const ALLOWED_HOST = /^(?:[a-z0-9-]+\.)?worldmonitor\.app$/;
 const FALLBACK_ORIGIN = 'https://worldmonitor.app';
 
-export function resolveMetadataOrigin(req: Request): string {
+export function resolveMetadataOrigin(req) {
   const url = new URL(req.url);
   const host = (req.headers.get('host') ?? url.host).toLowerCase();
   return ALLOWED_HOST.test(host) ? `https://${host}` : FALLBACK_ORIGIN;
@@ -30,9 +30,9 @@ export function resolveMetadataOrigin(req: Request): string {
  * reject everything else with a spec-correct 405 + Allow. Returns null when the
  * request should proceed to the metadata handler.
  */
-export function guardMetadataMethod(req: Request): Response | null {
+export function guardMetadataMethod(req) {
   if (req.method === 'GET' || req.method === 'HEAD') return null;
-  const cors: Record<string, string> = { 'Access-Control-Allow-Origin': '*' };
+  const cors = { 'Access-Control-Allow-Origin': '*' };
   if (req.method === 'OPTIONS') {
     return new Response(null, {
       status: 204,

--- a/api/oauth-authorization-server.ts
+++ b/api/oauth-authorization-server.ts
@@ -41,7 +41,7 @@
  * spoofed Host cannot be reflected into `issuer`/`token_endpoint`.
  */
 
-import { guardMetadataMethod, resolveMetadataOrigin } from './_agent-metadata.ts';
+import { guardMetadataMethod, resolveMetadataOrigin } from './_agent-metadata.js';
 
 export const config = { runtime: 'edge' };
 

--- a/api/oauth-authorization-server.ts
+++ b/api/oauth-authorization-server.ts
@@ -41,7 +41,7 @@
  * spoofed Host cannot be reflected into `issuer`/`token_endpoint`.
  */
 
-import { guardMetadataMethod, resolveMetadataOrigin } from './_agent-metadata';
+import { guardMetadataMethod, resolveMetadataOrigin } from './_agent-metadata.ts';
 
 export const config = { runtime: 'edge' };
 
@@ -65,10 +65,13 @@ export default function handler(req: Request): Response {
       skill: `${origin}/auth.md`,
       register_uri: `${origin}/oauth/register`,
       claim_uri: `${origin}/oauth/authorize`,
+      revocation_uri: `${origin}/developers`,
       identity_types_supported: ['anonymous'],
+      credential_types_supported: ['access_token'],
       anonymous: {
         credential_types_supported: ['access_token'],
         claim_uri: `${origin}/oauth/authorize`,
+        revocation_uri: `${origin}/developers`,
       },
     },
   });

--- a/api/oauth-protected-resource.ts
+++ b/api/oauth-protected-resource.ts
@@ -20,7 +20,7 @@
  * spoofed Host cannot be reflected into `resource`/`authorization_servers`.
  */
 
-import { guardMetadataMethod, resolveMetadataOrigin } from './_agent-metadata.ts';
+import { guardMetadataMethod, resolveMetadataOrigin } from './_agent-metadata.js';
 
 export const config = { runtime: 'edge' };
 

--- a/api/oauth-protected-resource.ts
+++ b/api/oauth-protected-resource.ts
@@ -20,7 +20,7 @@
  * spoofed Host cannot be reflected into `resource`/`authorization_servers`.
  */
 
-import { guardMetadataMethod, resolveMetadataOrigin } from './_agent-metadata';
+import { guardMetadataMethod, resolveMetadataOrigin } from './_agent-metadata.ts';
 
 export const config = { runtime: 'edge' };
 

--- a/public/auth.md
+++ b/public/auth.md
@@ -1,4 +1,6 @@
-# WorldMonitor — Agent Authentication (auth.md)
+# auth.md
+
+WorldMonitor agent authentication metadata and registration instructions.
 
 How agents authenticate with the WorldMonitor API and MCP server
 (`https://worldmonitor.app/mcp`), per the WorkOS **auth.md** spec:
@@ -28,9 +30,14 @@ chain:
        "skill": "https://worldmonitor.app/auth.md",
        "register_uri": "https://worldmonitor.app/oauth/register",
        "claim_uri": "https://worldmonitor.app/oauth/authorize",
+       "revocation_uri": "https://worldmonitor.app/developers",
        "identity_types_supported": ["anonymous"],
-       "anonymous": { "credential_types_supported": ["access_token"],
-                      "claim_uri": "https://worldmonitor.app/oauth/authorize" } } }
+       "credential_types_supported": ["access_token"],
+       "anonymous": {
+         "credential_types_supported": ["access_token"],
+         "claim_uri": "https://worldmonitor.app/oauth/authorize",
+         "revocation_uri": "https://worldmonitor.app/developers"
+       } } }
    ```
 
    Metadata is per-host: `issuer` and endpoints match the origin you fetched
@@ -69,9 +76,9 @@ POST /oauth/register  {"client_name":"My Agent","redirect_uris":["https://claude
 
 ## Claim
 
-Anonymous agents are claimed **at authorization time**, not via a separate
-endpoint — so `agent_auth.claim_uri` is the authorization endpoint itself. Start
-the authorization-code flow with a PKCE challenge:
+Anonymous agents are claimed **at authorization time**, using the `claim_uri`
+advertised in `agent_auth`, not via a separate `/agent/identity/claim` endpoint.
+Start the authorization-code flow with a PKCE challenge:
 
 ```
 GET /oauth/authorize?response_type=code&client_id=…&code_challenge=…&code_challenge_method=S256&scope=mcp
@@ -109,8 +116,8 @@ The same credentials authorize the REST API. Catalog:
 - **Expiry** — access tokens last 1 hour, refresh tokens 7 days; let them lapse
   to de-authorize an agent.
 - **User revoke** — a signed-in user revokes an agent from the dashboard
-  (<https://worldmonitor.app/developers>); the token is then rejected with `401`
-  / `invalid_grant`.
+  (`revocation_uri`: <https://worldmonitor.app/developers>); the token is then
+  rejected with `401` / `invalid_grant`.
 - **Refresh rotation** — refresh tokens rotate on every use with token-family
   revocation, so a stolen token dies once the real client next refreshes.
 

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -1378,7 +1378,10 @@ describe('agent readiness: MCP/OAuth origin alignment', () => {
       assert.ok(json.agent_auth, `agent_auth block present for ${host}`);
       assert.equal(json.agent_auth.skill, `https://${host}/auth.md`, `skill round-trips to /auth.md for ${host}`);
       assert.equal(json.agent_auth.register_uri, `https://${host}/oauth/register`);
+      assert.equal(json.agent_auth.claim_uri, `https://${host}/oauth/authorize`);
+      assert.equal(json.agent_auth.revocation_uri, `https://${host}/developers`);
       assert.deepEqual(json.agent_auth.identity_types_supported, ['anonymous']);
+      assert.deepEqual(json.agent_auth.credential_types_supported, ['access_token']);
       // Only `access_token` — an api_key is user-minted (carries a user
       // identity), so it is not an anonymous-registration credential.
       assert.deepEqual(
@@ -1401,6 +1404,7 @@ describe('agent readiness: MCP/OAuth origin alignment', () => {
         `https://${host}/oauth/authorize`,
         `anonymous method advertises claim_uri for ${host}`
       );
+      assert.equal(json.agent_auth.anonymous.revocation_uri, `https://${host}/developers`);
     }
   });
 
@@ -1426,6 +1430,8 @@ describe('agent readiness: MCP/OAuth origin alignment', () => {
       assert.equal(asJson.agent_auth.register_uri, 'https://worldmonitor.app/oauth/register');
       assert.equal(asJson.agent_auth.claim_uri, 'https://worldmonitor.app/oauth/authorize', `AS claim_uri must not carry spoofed host ${host}`);
       assert.equal(asJson.agent_auth.anonymous.claim_uri, 'https://worldmonitor.app/oauth/authorize');
+      assert.equal(asJson.agent_auth.revocation_uri, 'https://worldmonitor.app/developers');
+      assert.equal(asJson.agent_auth.anonymous.revocation_uri, 'https://worldmonitor.app/developers');
     }
 
     // Legit subdomain still self-describes.
@@ -1468,6 +1474,7 @@ describe('agent readiness: auth.md walkthrough', () => {
   const authMd = readFileSync(resolve(__dirname, '../public/auth.md'), 'utf-8');
 
   it('publishes /auth.md with the WorkOS-prescribed sections', () => {
+    assert.match(authMd, /^#\s+auth\.md\s*$/m, 'auth.md must have an H1 containing auth.md');
     for (const heading of ['Discover', 'Pick a method', 'Register', 'Claim', 'Use the credential', 'Errors', 'Revocation']) {
       assert.match(
         authMd,
@@ -1479,7 +1486,7 @@ describe('agent readiness: auth.md walkthrough', () => {
 
   it('references the auth.md spec and carries the spec anchor keywords', () => {
     assert.ok(authMd.includes('https://workos.com/auth-md'), 'auth.md must reference the WorkOS spec');
-    for (const keyword of ['agent_auth', 'register_uri', 'claim_uri', 'identity_assertion', 'id-jag', 'WWW-Authenticate']) {
+    for (const keyword of ['agent_auth', 'register_uri', 'claim_uri', 'revocation_uri', 'credential_types_supported', 'identity_assertion', 'id-jag', 'WWW-Authenticate']) {
       assert.ok(authMd.includes(keyword), `auth.md must mention spec keyword: ${keyword}`);
     }
   });

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -1409,7 +1409,7 @@ describe('agent readiness: MCP/OAuth origin alignment', () => {
   });
 
   // The Host header is client-controlled; both discovery handlers derive their
-  // origin through the shared allowlist (api/_agent-metadata.ts) so a spoofed
+  // origin through the shared allowlist (api/_agent-metadata.js) so a spoofed
   // Host cannot be reflected into issuer/resource/endpoints. They also guard the
   // HTTP method (read-only docs).
   it('discovery handlers reject spoofed Host (apex fallback) and non-GET methods', async () => {


### PR DESCRIPTION
## Summary

Agent registration discovery now publishes the full Auth.md metadata chain scanners expect: `/auth.md` has a direct `auth.md` H1, the authorization-server metadata advertises register, claim, revocation, identity, and credential details, and the markdown walkthrough mirrors those machine-readable fields.

The OAuth discovery documents remain host-derived through the existing allowlist, so scanner requests on apex, www, api, or variant subdomains continue to receive same-origin issuer/resource metadata without reflecting spoofed hosts.

## Validation

- `node --test tests/deploy-config.test.mjs`
- `npm run typecheck:api`
- Pre-push hook: full `npm run typecheck`, API typecheck, boundary/safe-html/rate-limit/premium checks, changed tests, edge function tests, markdown lint, proto freshness, and version sync all passed.

## Review

- CE code review: correctness, testing, maintainability, project standards, security, and API contract reviewers reported no findings.
- Applied the testing reviewer soft gap by pinning the new `/auth.md` scanner terms in the markdown contract test.
- Residual risk: live deployed Vercel/DNS routing was not externally re-scanned from production.
- Adversarial reviewer timed out and was closed as degraded coverage after the other review lenses and validation completed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5.5](https://img.shields.io/badge/GPT--5.5-000000)
