### PR TITLE
fix(payments): reconcile missed Dodo renewals

### DIFF
--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -7,6 +7,7 @@ import { PRODUCT_CATALOG } from "../config/productCatalog";
 import {
   PENDING_PAYMENT_BLOCK_WINDOW_MS,
   STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS,
+  safeMarkReconcileAttempt,
 } from "../payments/billing";
 import { getFeaturesForPlan } from "../lib/entitlements";
 import { signAnonClaimToken } from "../lib/identitySigning";
@@ -3170,6 +3171,26 @@ describe("payments billing missed renewal reconciliation", () => {
     sub = await readSub(t, "backoff");
     expect(sub?.reconcileFailureCount).toBe(2);
     expect(sub?.lastReconcileAttemptAt).toBe(now3);
+
+    // At failureCount 2 the exponential base (2 days) kicks in: NOT eligible the
+    // next day...
+    const s4 = await t.action(internal.payments.billing.reconcileMissedDodoRenewals, {
+      now: now3 + DAY_MS,
+      remoteSubscriptionsForTest: [],
+    });
+    expect(s4).toMatchObject({ inspected: 0, failed: 0, reconciled: 0 });
+    sub = await readSub(t, "backoff");
+    expect(sub?.reconcileFailureCount).toBe(2); // untouched
+
+    // ...but eligible again once the 2-day window elapses.
+    const now5 = now3 + 2 * DAY_MS;
+    const s5 = await t.action(internal.payments.billing.reconcileMissedDodoRenewals, {
+      now: now5,
+      remoteSubscriptionsForTest: [],
+    });
+    expect(s5).toMatchObject({ inspected: 1, failed: 1, reconciled: 0 });
+    sub = await readSub(t, "backoff");
+    expect(sub?.reconcileFailureCount).toBe(3);
   });
 
   test("bails out of the batch when the wall-clock time budget is exhausted", async () => {
@@ -3303,5 +3324,90 @@ describe("payments billing missed renewal reconciliation", () => {
     expect(healthyEnt?.validUntil).toBe(healthyRenewedEnd);
 
     vi.useRealTimers();
+  });
+
+  test("downgrades to expired only after a CONFIRMED (repeated) Dodo not-found", async () => {
+    const t = convexTest(schema, modules);
+    await seedStaleActiveForReconcile(t, {
+      suffix: "gone",
+      currentPeriodEnd: NOW - DAY_MS,
+      // entitlement seeded so we can prove the downgrade
+    });
+
+    // First 404: unconfirmed (reconcileFailureCount 0) -> treated as transient,
+    // row stays active + backed off. A single flaky 404 must NOT downgrade.
+    const s1 = await t.action(internal.payments.billing.reconcileMissedDodoRenewals, {
+      now: NOW,
+      errorInjectionForTest: { sub_gone: "not_found" },
+    });
+    expect(s1).toMatchObject({ inspected: 1, failed: 1, expiredMissing: 0, reconciled: 0 });
+    let sub = await readSub(t, "gone");
+    expect(sub?.status).toBe("active");
+    expect(sub?.reconcileFailureCount).toBe(1);
+    let ent = await readEntitlement(t, TEST_USER_ID);
+    expect(ent?.planKey).toBe("pro_monthly"); // still entitled
+
+    // Second 404 the next day: now confirmed (failureCount 1 >= threshold) ->
+    // downgrade the local row to expired and recompute the entitlement.
+    const s2 = await t.action(internal.payments.billing.reconcileMissedDodoRenewals, {
+      now: NOW + DAY_MS,
+      errorInjectionForTest: { sub_gone: "not_found" },
+    });
+    expect(s2).toMatchObject({ inspected: 1, expiredMissing: 1, failed: 0, reconciled: 0 });
+    sub = await readSub(t, "gone");
+    expect(sub?.status).toBe("expired");
+    ent = await readEntitlement(t, TEST_USER_ID);
+    expect(ent?.planKey).toBe("free"); // downgraded
+  });
+
+  test("keeps a subscription active and backed off on a transient 5xx (never downgrades)", async () => {
+    const t = convexTest(schema, modules);
+    await seedStaleActiveForReconcile(t, {
+      suffix: "flaky",
+      currentPeriodEnd: NOW - DAY_MS,
+      seedEntitlement: false,
+    });
+
+    // Two consecutive 5xx errors across two daily runs: the row is backed off
+    // both times but NEVER expired — a transient error must not downgrade even
+    // once the failure count passes the not-found confirmation threshold.
+    const s1 = await t.action(internal.payments.billing.reconcileMissedDodoRenewals, {
+      now: NOW,
+      errorInjectionForTest: { sub_flaky: "server_error" },
+    });
+    expect(s1).toMatchObject({ inspected: 1, failed: 1, expiredMissing: 0 });
+    let sub = await readSub(t, "flaky");
+    expect(sub?.status).toBe("active");
+    expect(sub?.reconcileFailureCount).toBe(1);
+
+    const s2 = await t.action(internal.payments.billing.reconcileMissedDodoRenewals, {
+      now: NOW + DAY_MS,
+      errorInjectionForTest: { sub_flaky: "server_error" },
+    });
+    expect(s2).toMatchObject({ inspected: 1, failed: 1, expiredMissing: 0 });
+    sub = await readSub(t, "flaky");
+    expect(sub?.status).toBe("active"); // still active, never downgraded on 5xx
+    expect(sub?.reconcileFailureCount).toBe(2);
+  });
+
+  test("safeMarkReconcileAttempt swallows a throwing bookkeeping mutation", async () => {
+    // Reliability P1-1: a failed best-effort backoff write must never propagate
+    // out of the per-row loop (which would abort the batch AND skip continuation
+    // scheduling). A fake ctx whose runMutation throws must resolve, not reject.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const throwingCtx = {
+      runMutation: async () => {
+        throw new Error("simulated OCC write conflict");
+      },
+    };
+    await expect(
+      safeMarkReconcileAttempt(
+        throwingCtx as never,
+        "sub_placeholder" as never,
+        NOW,
+      ),
+    ).resolves.toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
   });
 });

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -2950,6 +2950,19 @@ describe("payments billing missed renewal reconciliation", () => {
       updatedAt: NOW + DAY_MS, // newer than observedAt
       seedEntitlement: false,
     });
+    // Map the REMOTE product id to pro_monthly so that IF the ordering guard
+    // were removed, apply would fall through and resolvePlanKey would clobber
+    // planKey enterprise -> pro_monthly. This makes the planKey assertion
+    // below load-bearing (proves no-clobber) instead of coincidentally passing
+    // via the unknown-product enterprise fallback.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("productPlans", {
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        planKey: "pro_monthly",
+        displayName: "Pro Monthly",
+        isActive: true,
+      });
+    });
 
     const result = await t.mutation(
       internal.payments.billing.applyDodoSubscriptionReconciliation,
@@ -2971,7 +2984,7 @@ describe("payments billing missed renewal reconciliation", () => {
     expect(result).toEqual({ kind: "skipped", reason: "local_updated_concurrently" });
 
     const sub = await readSub(t, "concurrent");
-    expect(sub?.planKey).toBe("enterprise");
+    expect(sub?.planKey).toBe("enterprise"); // not clobbered to pro_monthly
     expect(sub?.dodoProductId).toBe(PRODUCT_CATALOG.enterprise.dodoProductId);
     expect(sub?.updatedAt).toBe(NOW + DAY_MS);
   });
@@ -3109,6 +3122,185 @@ describe("payments billing missed renewal reconciliation", () => {
       const sub = await readSub(t, suffix);
       expect(sub?.currentPeriodEnd).toBe(renewedEnd);
     }
+
+    vi.useRealTimers();
+  });
+
+  test("backs a failed row off within the cycle but retries it at the next daily run", async () => {
+    const t = convexTest(schema, modules);
+    await seedStaleActiveForReconcile(t, {
+      suffix: "backoff",
+      currentPeriodEnd: NOW - DAY_MS,
+      seedEntitlement: false,
+    });
+
+    // Invocation 1: no remote for this sub -> Dodo lookup fails -> row is
+    // marked (reconcileFailureCount 1, short first-failure backoff).
+    const s1 = await t.action(internal.payments.billing.reconcileMissedDodoRenewals, {
+      now: NOW,
+      remoteSubscriptionsForTest: [],
+    });
+    expect(s1).toMatchObject({ inspected: 1, failed: 1, reconciled: 0 });
+    let sub = await readSub(t, "backoff");
+    expect(sub?.reconcileFailureCount).toBe(1);
+    expect(sub?.lastReconcileAttemptAt).toBe(NOW);
+
+    // A few minutes later (same cron cycle): still inside the first-failure
+    // backoff -> ineligible, never attempted, bookkeeping unchanged. This is
+    // what stops a poison row hogging a slot across a cycle's continuations.
+    const s2 = await t.action(internal.payments.billing.reconcileMissedDodoRenewals, {
+      now: NOW + 5 * 60 * 1000,
+      remoteSubscriptionsForTest: [],
+    });
+    expect(s2).toMatchObject({ inspected: 0, failed: 0, reconciled: 0 });
+    sub = await readSub(t, "backoff");
+    expect(sub?.reconcileFailureCount).toBe(1);
+    expect(sub?.lastReconcileAttemptAt).toBe(NOW);
+
+    // The NEXT daily run (>= 1 day later) is past the short first-failure
+    // backoff -> eligible again -> re-attempted so a transient error is not
+    // over-delayed. It fails again here, so the failure count climbs (and the
+    // backoff now grows exponentially).
+    const now3 = NOW + DAY_MS;
+    const s3 = await t.action(internal.payments.billing.reconcileMissedDodoRenewals, {
+      now: now3,
+      remoteSubscriptionsForTest: [],
+    });
+    expect(s3).toMatchObject({ inspected: 1, failed: 1, reconciled: 0 });
+    sub = await readSub(t, "backoff");
+    expect(sub?.reconcileFailureCount).toBe(2);
+    expect(sub?.lastReconcileAttemptAt).toBe(now3);
+  });
+
+  test("bails out of the batch when the wall-clock time budget is exhausted", async () => {
+    const t = convexTest(schema, modules);
+    await seedStaleActiveForReconcile(t, {
+      suffix: "budget",
+      currentPeriodEnd: NOW - DAY_MS,
+      seedEntitlement: false,
+    });
+
+    // Each Date.now() call jumps forward by more than the 8-minute budget, so
+    // the first in-loop budget check (relative to startedAtWallClock, an earlier
+    // Date.now() call) trips before any row is attempted — robust to however
+    // many internal Date.now() calls happen in between.
+    let clock = 1_000_000;
+    const step = 9 * 60 * 1000; // > DODO_RENEWAL_RECONCILIATION_TIME_BUDGET_MS
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => {
+      const t0 = clock;
+      clock += step;
+      return t0;
+    });
+
+    let summary;
+    try {
+      summary = await t.action(internal.payments.billing.reconcileMissedDodoRenewals, {
+        now: NOW,
+        remoteSubscriptionsForTest: [
+          {
+            subscription_id: "sub_budget",
+            product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+            status: "active",
+            previous_billing_date: new Date(NOW).toISOString(),
+            next_billing_date: new Date(NOW + 30 * DAY_MS).toISOString(),
+          },
+        ],
+      });
+    } finally {
+      nowSpy.mockRestore();
+    }
+
+    expect(summary).toMatchObject({
+      inspected: 0, // bailed before attempting the row
+      reconciled: 0,
+      timeBudgetExhausted: true,
+      hasMore: true,
+      continuationScheduled: false, // attempted 0 -> no chain
+    });
+
+    // Row untouched (not reconciled).
+    const sub = await readSub(t, "budget");
+    expect(sub?.currentPeriodEnd).toBe(NOW - DAY_MS);
+  });
+
+  test("advances the scan cursor past a backoff-saturated window to reach healthy rows behind it", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const healthyRenewedEnd = NOW + 30 * DAY_MS;
+
+    await t.run(async (ctx) => {
+      // Poison row sorts FIRST (stalest) but is already backed off
+      // (failureCount 3 -> 8-day backoff, last attempted 1 day ago), so it is
+      // ineligible now and, with scanLimit 1, fully saturates the first window.
+      await ctx.db.insert("subscriptions", {
+        userId: "user_saturate_poison",
+        dodoSubscriptionId: "sub_saturate_poison",
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: NOW - 33 * DAY_MS,
+        currentPeriodEnd: NOW - 3 * DAY_MS,
+        rawPayload: { subscription_id: "sub_saturate_poison" },
+        updatedAt: NOW - 5 * DAY_MS,
+        lastReconcileAttemptAt: NOW - DAY_MS,
+        reconcileFailureCount: 3,
+      });
+      // Healthy row sorts behind the poison window.
+      await ctx.db.insert("subscriptions", {
+        userId: "user_saturate_healthy",
+        dodoSubscriptionId: "sub_saturate_healthy",
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: NOW - 31 * DAY_MS,
+        currentPeriodEnd: NOW - DAY_MS,
+        rawPayload: { subscription_id: "sub_saturate_healthy" },
+        updatedAt: NOW - 5 * DAY_MS,
+      });
+      await ctx.db.insert("entitlements", {
+        userId: "user_saturate_healthy",
+        planKey: "pro_monthly",
+        features: getFeaturesForPlan("pro_monthly"),
+        validUntil: NOW - DAY_MS,
+        updatedAt: NOW - 5 * DAY_MS,
+      });
+    });
+
+    // scanLimit 1 => the first window is exactly the (ineligible) poison row.
+    const summary = await t.action(internal.payments.billing.reconcileMissedDodoRenewals, {
+      now: NOW,
+      scanLimit: 1,
+      remoteSubscriptionsForTest: [
+        {
+          subscription_id: "sub_saturate_healthy",
+          product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+          status: "active",
+          previous_billing_date: new Date(NOW).toISOString(),
+          next_billing_date: new Date(healthyRenewedEnd).toISOString(),
+        },
+      ],
+    });
+
+    // First window was entirely backed off -> flagged saturated, and a
+    // continuation was scheduled with an advanced cursor (attempted was 0).
+    expect(summary).toMatchObject({
+      inspected: 0,
+      windowSaturated: true,
+      hasMore: true,
+      continuationScheduled: true,
+    });
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    // The healthy row behind the poison window was reconciled via the
+    // cursor-advanced continuation; the poison row was left untouched.
+    const poison = await readSub(t, "saturate_poison");
+    const healthy = await readSub(t, "saturate_healthy");
+    const healthyEnt = await readEntitlement(t, "user_saturate_healthy");
+    expect(poison?.currentPeriodEnd).toBe(NOW - 3 * DAY_MS);
+    expect(poison?.reconcileFailureCount).toBe(3); // untouched
+    expect(healthy?.currentPeriodEnd).toBe(healthyRenewedEnd);
+    expect(healthyEnt?.validUntil).toBe(healthyRenewedEnd);
 
     vi.useRealTimers();
   });

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -2514,3 +2514,155 @@ describe("payments billing backfillSubscriptionDodoCustomerId", () => {
     });
   });
 });
+
+describe("payments billing missed renewal reconciliation", () => {
+  test("extends a stale local active subscription from active Dodo truth and recomputes entitlement", async () => {
+    const t = convexTest(schema, modules);
+    const stalePeriodEnd = NOW - DAY_MS;
+    const remotePeriodStart = NOW;
+    const remotePeriodEnd = NOW + 30 * DAY_MS;
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: TEST_USER_ID,
+        dodoSubscriptionId: "sub_missed_renewal",
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: NOW - 31 * DAY_MS,
+        currentPeriodEnd: stalePeriodEnd,
+        dodoCustomerId: "cus_missed_renewal",
+        rawPayload: { subscription_id: "sub_missed_renewal" },
+        updatedAt: NOW - DAY_MS,
+      });
+      await ctx.db.insert("entitlements", {
+        userId: TEST_USER_ID,
+        planKey: "pro_monthly",
+        features: getFeaturesForPlan("pro_monthly"),
+        validUntil: stalePeriodEnd,
+        updatedAt: NOW - DAY_MS,
+      });
+    });
+
+    const summary = await t.action(
+      internal.payments.billing.reconcileMissedDodoRenewals,
+      {
+        now: NOW,
+        remoteSubscriptionsForTest: [
+          {
+            subscription_id: "sub_missed_renewal",
+            product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+            status: "active",
+            previous_billing_date: new Date(remotePeriodStart).toISOString(),
+            next_billing_date: new Date(remotePeriodEnd).toISOString(),
+            customer: {
+              customer_id: "cus_missed_renewal",
+              email: "renewal@example.com",
+            },
+            metadata: { wm_user_id: TEST_USER_ID },
+            recurring_pre_tax_amount: 1200,
+            currency: "USD",
+            tax_inclusive: false,
+          },
+        ],
+      },
+    );
+
+    expect(summary).toMatchObject({
+      inspected: 1,
+      reconciled: 1,
+      failed: 0,
+      skipped: 0,
+    });
+
+    const rows = await t.run(async (ctx) => {
+      const [sub, entitlement] = await Promise.all([
+        ctx.db
+          .query("subscriptions")
+          .withIndex("by_dodoSubscriptionId", (q) =>
+            q.eq("dodoSubscriptionId", "sub_missed_renewal"),
+          )
+          .unique(),
+        ctx.db
+          .query("entitlements")
+          .withIndex("by_userId", (q) => q.eq("userId", TEST_USER_ID))
+          .first(),
+      ]);
+      return { sub, entitlement };
+    });
+
+    expect(rows.sub?.currentPeriodStart).toBe(remotePeriodStart);
+    expect(rows.sub?.currentPeriodEnd).toBe(remotePeriodEnd);
+    expect(rows.sub?.updatedAt).toBe(NOW);
+    expect(rows.entitlement?.planKey).toBe("pro_monthly");
+    expect(rows.entitlement?.validUntil).toBe(remotePeriodEnd);
+    expect(rows.entitlement?.updatedAt).toBe(NOW);
+  });
+
+  test("continues reconciling other stale subscriptions when one Dodo lookup fails", async () => {
+    const t = convexTest(schema, modules);
+    const stalePeriodEnd = NOW - DAY_MS;
+    const remotePeriodEnd = NOW + 14 * DAY_MS;
+
+    await t.run(async (ctx) => {
+      for (const suffix of ["ok", "missing"]) {
+        const userId = `user_reconcile_${suffix}`;
+        await ctx.db.insert("subscriptions", {
+          userId,
+          dodoSubscriptionId: `sub_reconcile_${suffix}`,
+          dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+          planKey: "pro_monthly",
+          status: "active",
+          currentPeriodStart: NOW - 31 * DAY_MS,
+          currentPeriodEnd: stalePeriodEnd,
+          rawPayload: { subscription_id: `sub_reconcile_${suffix}` },
+          updatedAt: NOW - DAY_MS,
+        });
+        await ctx.db.insert("entitlements", {
+          userId,
+          planKey: "pro_monthly",
+          features: getFeaturesForPlan("pro_monthly"),
+          validUntil: stalePeriodEnd,
+          updatedAt: NOW - DAY_MS,
+        });
+      }
+    });
+
+    const summary = await t.action(
+      internal.payments.billing.reconcileMissedDodoRenewals,
+      {
+        now: NOW,
+        remoteSubscriptionsForTest: [
+          {
+            subscription_id: "sub_reconcile_ok",
+            product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+            status: "active",
+            previous_billing_date: new Date(NOW).toISOString(),
+            next_billing_date: new Date(remotePeriodEnd).toISOString(),
+          },
+        ],
+      },
+    );
+
+    expect(summary).toMatchObject({
+      inspected: 2,
+      reconciled: 1,
+      failed: 1,
+      skipped: 0,
+    });
+    expect(summary.failures).toEqual([
+      {
+        dodoSubscriptionId: "sub_reconcile_missing",
+        error: "missing test remote subscription",
+      },
+    ]);
+
+    const okEntitlement = await t.run(async (ctx) =>
+      ctx.db
+        .query("entitlements")
+        .withIndex("by_userId", (q) => q.eq("userId", "user_reconcile_ok"))
+        .first(),
+    );
+    expect(okEntitlement?.validUntil).toBe(remotePeriodEnd);
+  });
+});

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -3390,6 +3390,113 @@ describe("payments billing missed renewal reconciliation", () => {
     expect(sub?.reconcileFailureCount).toBe(2);
   });
 
+  test("a single 404 after an unrelated prior failure does NOT downgrade (needs consecutive 404s)", async () => {
+    const t = convexTest(schema, modules);
+    // The row already has a prior NON-404 failure (a 5xx yesterday): failureCount
+    // 1 but the consecutive-404 streak (reconcileNotFoundCount) is 0.
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: TEST_USER_ID,
+        dodoSubscriptionId: "sub_mixed",
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: NOW - 31 * DAY_MS,
+        currentPeriodEnd: NOW - DAY_MS,
+        rawPayload: { subscription_id: "sub_mixed" },
+        updatedAt: NOW - 5 * DAY_MS,
+        lastReconcileAttemptAt: NOW - DAY_MS,
+        reconcileFailureCount: 1,
+        reconcileNotFoundCount: 0,
+      });
+    });
+
+    // First 404: because the prior failure was NOT a 404, the streak is still 0
+    // -> must be treated as unconfirmed (no downgrade), even though failureCount
+    // already >= 1. This is the fix for conflating 404s with other failures.
+    const s1 = await t.action(internal.payments.billing.reconcileMissedDodoRenewals, {
+      now: NOW,
+      errorInjectionForTest: { sub_mixed: "not_found" },
+    });
+    expect(s1).toMatchObject({ inspected: 1, failed: 1, expiredMissing: 0 });
+    let sub = await readSub(t, "mixed");
+    expect(sub?.status).toBe("active");
+    expect(sub?.reconcileNotFoundCount).toBe(1); // streak now started
+
+    // Second consecutive 404 -> confirmed -> downgrade. (failureCount is now 2,
+    // so wait past the 2-day backoff before the row is eligible again.)
+    const s2 = await t.action(internal.payments.billing.reconcileMissedDodoRenewals, {
+      now: NOW + 3 * DAY_MS,
+      errorInjectionForTest: { sub_mixed: "not_found" },
+    });
+    expect(s2).toMatchObject({ inspected: 1, expiredMissing: 1 });
+    sub = await readSub(t, "mixed");
+    expect(sub?.status).toBe("expired");
+  });
+
+  test("mass-404 circuit breaker caps downgrades per run and halts the rest", async () => {
+    const t = convexTest(schema, modules);
+    const N = 10;
+    // All 10 rows are already confirmed (reconcileNotFoundCount 1) and eligible,
+    // so every one is a confirmed-404 downgrade candidate this run — the shape a
+    // wrong-environment misconfig would produce.
+    await t.run(async (ctx) => {
+      for (let i = 0; i < N; i++) {
+        await ctx.db.insert("subscriptions", {
+          userId: `user_mass_${i}`,
+          dodoSubscriptionId: `sub_mass_${i}`,
+          dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+          planKey: "pro_monthly",
+          status: "active",
+          currentPeriodStart: NOW - 31 * DAY_MS,
+          currentPeriodEnd: NOW - (i + 1) * DAY_MS,
+          rawPayload: { subscription_id: `sub_mass_${i}` },
+          updatedAt: NOW - 10 * DAY_MS,
+          lastReconcileAttemptAt: NOW - 10 * DAY_MS,
+          reconcileFailureCount: 1,
+          reconcileNotFoundCount: 1,
+        });
+      }
+    });
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const summary = await t.action(internal.payments.billing.reconcileMissedDodoRenewals, {
+      now: NOW,
+      errorInjectionForTest: Object.fromEntries(
+        Array.from({ length: N }, (_, i) => [`sub_mass_${i}`, "not_found" as const]),
+      ),
+    });
+
+    // Threshold = min(5, ceil(min(limit, eligible)/2)) = min(5, ceil(10/2)) = 5.
+    expect(summary.expiredMissing).toBe(5);
+    expect(summary.inspected).toBe(N);
+    // The 5 halted rows are routed to the backoff (failed) path.
+    expect(summary.failed).toBe(N - 5);
+
+    const statuses = await t.run(async (ctx) => {
+      const rows = await Promise.all(
+        Array.from({ length: N }, (_, i) =>
+          ctx.db
+            .query("subscriptions")
+            .withIndex("by_dodoSubscriptionId", (q) =>
+              q.eq("dodoSubscriptionId", `sub_mass_${i}`),
+            )
+            .unique(),
+        ),
+      );
+      return rows.map((r) => r?.status);
+    });
+    expect(statuses.filter((s) => s === "expired").length).toBe(5);
+    expect(statuses.filter((s) => s === "active").length).toBe(5);
+
+    // The mass-404 alert fired.
+    const massLogged = errorSpy.mock.calls.some((c) =>
+      String(c[0]).includes("mass Dodo 404s"),
+    );
+    expect(massLogged).toBe(true);
+    errorSpy.mockRestore();
+  });
+
   test("safeMarkReconcileAttempt swallows a throwing bookkeeping mutation", async () => {
     // Reliability P1-1: a failed best-effort backoff write must never propagate
     // out of the per-row loop (which would abort the batch AND skip continuation
@@ -3405,6 +3512,7 @@ describe("payments billing missed renewal reconciliation", () => {
         throwingCtx as never,
         "sub_placeholder" as never,
         NOW,
+        false,
       ),
     ).resolves.toBeUndefined();
     expect(errorSpy).toHaveBeenCalledTimes(1);

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -3497,6 +3497,66 @@ describe("payments billing missed renewal reconciliation", () => {
     errorSpy.mockRestore();
   });
 
+  test("mass-404 breaker is per cron cycle: halt latches across continuations", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const N = 12;
+    await t.run(async (ctx) => {
+      for (let i = 0; i < N; i++) {
+        await ctx.db.insert("subscriptions", {
+          userId: `user_cycle_${i}`,
+          dodoSubscriptionId: `sub_cycle_${i}`,
+          dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+          planKey: "pro_monthly",
+          status: "active",
+          currentPeriodStart: NOW - 31 * DAY_MS,
+          currentPeriodEnd: NOW - (i + 1) * DAY_MS,
+          rawPayload: { subscription_id: `sub_cycle_${i}` },
+          updatedAt: NOW - 10 * DAY_MS,
+          lastReconcileAttemptAt: NOW - 10 * DAY_MS,
+          reconcileFailureCount: 1,
+          reconcileNotFoundCount: 1,
+        });
+      }
+    });
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // limit 3 -> the per-invocation majority cap is ceil(3/2)=2, so the FIRST
+    // invocation downgrades 2 then latches the halt. If the breaker state did NOT
+    // thread through continuations, each of the ~4 continuations would downgrade
+    // another 2 (~8 total). With per-cycle threading, the whole cycle stops at 2.
+    await t.action(internal.payments.billing.reconcileMissedDodoRenewals, {
+      now: NOW,
+      limit: 3,
+      errorInjectionForTest: Object.fromEntries(
+        Array.from({ length: N }, (_, i) => [`sub_cycle_${i}`, "not_found" as const]),
+      ),
+    });
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    errorSpy.mockRestore();
+
+    const statuses = await t.run(async (ctx) => {
+      const rows = await Promise.all(
+        Array.from({ length: N }, (_, i) =>
+          ctx.db
+            .query("subscriptions")
+            .withIndex("by_dodoSubscriptionId", (q) =>
+              q.eq("dodoSubscriptionId", `sub_cycle_${i}`),
+            )
+            .unique(),
+        ),
+      );
+      return rows.map((r) => r?.status);
+    });
+    // At most the absolute per-cycle cap, and specifically 2 here (majority cap
+    // latched in invocation 1). NOT 2-per-continuation.
+    const expiredCount = statuses.filter((s) => s === "expired").length;
+    expect(expiredCount).toBe(2);
+    expect(statuses.filter((s) => s === "active").length).toBe(N - 2);
+
+    vi.useRealTimers();
+  });
+
   test("safeMarkReconcileAttempt swallows a throwing bookkeeping mutation", async () => {
     // Reliability P1-1: a failed best-effort backoff write must never propagate
     // out of the per-row loop (which would abort the batch AND skip continuation

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -2665,4 +2665,451 @@ describe("payments billing missed renewal reconciliation", () => {
     );
     expect(okEntitlement?.validUntil).toBe(remotePeriodEnd);
   });
+
+  async function seedStaleActiveForReconcile(
+    t: ReturnType<typeof convexTest>,
+    opts: {
+      suffix: string;
+      userId?: string;
+      planKey?: string;
+      dodoProductId?: string;
+      currentPeriodEnd?: number;
+      updatedAt?: number;
+      dodoCustomerId?: string;
+      seedEntitlement?: boolean;
+    },
+  ) {
+    const userId = opts.userId ?? TEST_USER_ID;
+    const planKey = opts.planKey ?? "pro_monthly";
+    const currentPeriodEnd = opts.currentPeriodEnd ?? NOW - DAY_MS;
+    const updatedAt = opts.updatedAt ?? NOW - DAY_MS;
+    const id = await t.run(async (ctx) => {
+      const subId = await ctx.db.insert("subscriptions", {
+        userId,
+        dodoSubscriptionId: `sub_${opts.suffix}`,
+        dodoProductId: opts.dodoProductId ?? PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        planKey,
+        status: "active",
+        currentPeriodStart: NOW - 31 * DAY_MS,
+        currentPeriodEnd,
+        ...(opts.dodoCustomerId ? { dodoCustomerId: opts.dodoCustomerId } : {}),
+        rawPayload: { subscription_id: `sub_${opts.suffix}` },
+        updatedAt,
+      });
+      if (opts.seedEntitlement !== false) {
+        await ctx.db.insert("entitlements", {
+          userId,
+          planKey,
+          features: getFeaturesForPlan(planKey),
+          validUntil: currentPeriodEnd,
+          updatedAt,
+        });
+      }
+      return subId;
+    });
+    return id;
+  }
+
+  const readSub = (t: ReturnType<typeof convexTest>, suffix: string) =>
+    t.run(async (ctx) =>
+      ctx.db
+        .query("subscriptions")
+        .withIndex("by_dodoSubscriptionId", (q) =>
+          q.eq("dodoSubscriptionId", `sub_${suffix}`),
+        )
+        .unique(),
+    );
+
+  const readEntitlement = (t: ReturnType<typeof convexTest>, userId: string) =>
+    t.run(async (ctx) =>
+      ctx.db
+        .query("entitlements")
+        .withIndex("by_userId", (q) => q.eq("userId", userId))
+        .first(),
+    );
+
+  test("maps a remote `failed` status to local expired and downgrades entitlement", async () => {
+    const t = convexTest(schema, modules);
+    const stalePeriodEnd = NOW - DAY_MS;
+    await seedStaleActiveForReconcile(t, { suffix: "failed", currentPeriodEnd: stalePeriodEnd });
+
+    const summary = await t.action(
+      internal.payments.billing.reconcileMissedDodoRenewals,
+      {
+        now: NOW,
+        remoteSubscriptionsForTest: [
+          {
+            subscription_id: "sub_failed",
+            product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+            status: "failed",
+            previous_billing_date: new Date(NOW - 31 * DAY_MS).toISOString(),
+            next_billing_date: new Date(stalePeriodEnd).toISOString(),
+          },
+        ],
+      },
+    );
+
+    expect(summary).toMatchObject({ inspected: 1, reconciled: 1, skipped: 0, failed: 0 });
+
+    const sub = await readSub(t, "failed");
+    const entitlement = await readEntitlement(t, TEST_USER_ID);
+    expect(sub?.status).toBe("expired");
+    expect(entitlement?.planKey).toBe("free");
+  });
+
+  test("marks a remote-cancelled subscription cancelled and downgrades once the period has ended", async () => {
+    const t = convexTest(schema, modules);
+    const stalePeriodEnd = NOW - DAY_MS;
+    await seedStaleActiveForReconcile(t, { suffix: "cancelled", currentPeriodEnd: stalePeriodEnd });
+
+    const summary = await t.action(
+      internal.payments.billing.reconcileMissedDodoRenewals,
+      {
+        now: NOW,
+        remoteSubscriptionsForTest: [
+          {
+            subscription_id: "sub_cancelled",
+            product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+            status: "cancelled",
+            previous_billing_date: new Date(NOW - 31 * DAY_MS).toISOString(),
+            next_billing_date: new Date(stalePeriodEnd).toISOString(),
+            cancelled_at: new Date(NOW - 2 * DAY_MS).toISOString(),
+          },
+        ],
+      },
+    );
+
+    expect(summary).toMatchObject({ inspected: 1, reconciled: 1, skipped: 0, failed: 0 });
+
+    const sub = await readSub(t, "cancelled");
+    const entitlement = await readEntitlement(t, TEST_USER_ID);
+    expect(sub?.status).toBe("cancelled");
+    expect(sub?.cancelledAt).toBe(NOW - 2 * DAY_MS);
+    expect(entitlement?.planKey).toBe("free");
+  });
+
+  test("falls back to an enterprise entitlement for an unknown Dodo product id", async () => {
+    const t = convexTest(schema, modules);
+    const remotePeriodEnd = NOW + 30 * DAY_MS;
+    await seedStaleActiveForReconcile(t, { suffix: "unknown_product" });
+
+    const summary = await t.action(
+      internal.payments.billing.reconcileMissedDodoRenewals,
+      {
+        now: NOW,
+        remoteSubscriptionsForTest: [
+          {
+            subscription_id: "sub_unknown_product",
+            product_id: "pdt_unknown_reconcile_fallback",
+            status: "active",
+            previous_billing_date: new Date(NOW).toISOString(),
+            next_billing_date: new Date(remotePeriodEnd).toISOString(),
+          },
+        ],
+      },
+    );
+
+    expect(summary).toMatchObject({ inspected: 1, reconciled: 1, skipped: 0, failed: 0 });
+
+    const sub = await readSub(t, "unknown_product");
+    const entitlement = await readEntitlement(t, TEST_USER_ID);
+    expect(sub?.dodoProductId).toBe("pdt_unknown_reconcile_fallback");
+    expect(sub?.planKey).toBe("enterprise");
+    expect(entitlement?.planKey).toBe("enterprise");
+  });
+
+  test("skips an unsupported remote status, escalates, and backs the row off", async () => {
+    const t = convexTest(schema, modules);
+    const stalePeriodEnd = NOW - DAY_MS;
+    await seedStaleActiveForReconcile(t, { suffix: "paused", currentPeriodEnd: stalePeriodEnd });
+
+    const summary = await t.action(
+      internal.payments.billing.reconcileMissedDodoRenewals,
+      {
+        now: NOW,
+        remoteSubscriptionsForTest: [
+          {
+            subscription_id: "sub_paused",
+            product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+            status: "paused",
+            previous_billing_date: new Date(NOW - 31 * DAY_MS).toISOString(),
+            next_billing_date: new Date(stalePeriodEnd).toISOString(),
+          },
+        ],
+      },
+    );
+
+    expect(summary).toMatchObject({ inspected: 1, reconciled: 0, skipped: 1, failed: 0 });
+
+    const sub = await readSub(t, "paused");
+    expect(sub?.status).toBe("active");
+    expect(sub?.currentPeriodEnd).toBe(stalePeriodEnd);
+    expect(sub?.reconcileFailureCount).toBe(1);
+    expect(sub?.lastReconcileAttemptAt).toBe(NOW);
+  });
+
+  test("skips a remote `pending` status and backs the row off", async () => {
+    const t = convexTest(schema, modules);
+    const stalePeriodEnd = NOW - DAY_MS;
+    await seedStaleActiveForReconcile(t, { suffix: "pending", currentPeriodEnd: stalePeriodEnd });
+
+    const summary = await t.action(
+      internal.payments.billing.reconcileMissedDodoRenewals,
+      {
+        now: NOW,
+        remoteSubscriptionsForTest: [
+          {
+            subscription_id: "sub_pending",
+            product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+            status: "pending",
+            previous_billing_date: new Date(NOW - 31 * DAY_MS).toISOString(),
+            next_billing_date: new Date(stalePeriodEnd).toISOString(),
+          },
+        ],
+      },
+    );
+
+    expect(summary).toMatchObject({ inspected: 1, reconciled: 0, skipped: 1, failed: 0 });
+
+    const sub = await readSub(t, "pending");
+    expect(sub?.status).toBe("active");
+    expect(sub?.reconcileFailureCount).toBe(1);
+  });
+
+  test("mutation skips when the local row is no longer stale", async () => {
+    const t = convexTest(schema, modules);
+    const subId = await seedStaleActiveForReconcile(t, {
+      suffix: "no_longer_stale",
+      currentPeriodEnd: NOW + DAY_MS, // already renewed by a concurrent webhook
+      seedEntitlement: false,
+    });
+
+    const result = await t.mutation(
+      internal.payments.billing.applyDodoSubscriptionReconciliation,
+      {
+        subscriptionId: subId,
+        dodoSubscriptionId: "sub_no_longer_stale",
+        observedAt: NOW,
+        remote: {
+          dodoSubscriptionId: "sub_no_longer_stale",
+          productId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+          status: "active",
+          currentPeriodStart: NOW,
+          currentPeriodEnd: NOW + 30 * DAY_MS,
+          rawPayload: {},
+        },
+      },
+    );
+
+    expect(result).toEqual({ kind: "skipped", reason: "local_no_longer_stale" });
+  });
+
+  test("mutation skips when remote is not newer than the stale local row", async () => {
+    const t = convexTest(schema, modules);
+    const staleEnd = NOW - DAY_MS;
+    const subId = await seedStaleActiveForReconcile(t, {
+      suffix: "not_newer",
+      currentPeriodEnd: staleEnd,
+      updatedAt: NOW - 2 * DAY_MS,
+      dodoCustomerId: "cus_not_newer",
+      seedEntitlement: false,
+    });
+
+    const result = await t.mutation(
+      internal.payments.billing.applyDodoSubscriptionReconciliation,
+      {
+        subscriptionId: subId,
+        dodoSubscriptionId: "sub_not_newer",
+        observedAt: NOW,
+        remote: {
+          dodoSubscriptionId: "sub_not_newer",
+          productId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+          status: "active",
+          currentPeriodStart: NOW - 31 * DAY_MS,
+          currentPeriodEnd: staleEnd - DAY_MS, // <= existing, nothing newer
+          dodoCustomerId: "cus_not_newer",
+          rawPayload: {},
+        },
+      },
+    );
+
+    expect(result).toEqual({ kind: "skipped", reason: "remote_not_newer" });
+  });
+
+  test("mutation refuses to clobber a concurrently-updated row (ordering guard)", async () => {
+    const t = convexTest(schema, modules);
+    // A subscription.plan_changed webhook landed AFTER the cron's stale read:
+    // it patched planKey → enterprise and bumped updatedAt past observedAt, but
+    // left currentPeriodEnd stale. The cron holds a stale snapshot and must not
+    // overwrite the newer plan.
+    const subId = await seedStaleActiveForReconcile(t, {
+      suffix: "concurrent",
+      planKey: "enterprise",
+      dodoProductId: PRODUCT_CATALOG.enterprise.dodoProductId!,
+      currentPeriodEnd: NOW - DAY_MS,
+      updatedAt: NOW + DAY_MS, // newer than observedAt
+      seedEntitlement: false,
+    });
+
+    const result = await t.mutation(
+      internal.payments.billing.applyDodoSubscriptionReconciliation,
+      {
+        subscriptionId: subId,
+        dodoSubscriptionId: "sub_concurrent",
+        observedAt: NOW,
+        remote: {
+          dodoSubscriptionId: "sub_concurrent",
+          productId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+          status: "active",
+          currentPeriodStart: NOW,
+          currentPeriodEnd: NOW + 30 * DAY_MS,
+          rawPayload: {},
+        },
+      },
+    );
+
+    expect(result).toEqual({ kind: "skipped", reason: "local_updated_concurrently" });
+
+    const sub = await readSub(t, "concurrent");
+    expect(sub?.planKey).toBe("enterprise");
+    expect(sub?.dodoProductId).toBe(PRODUCT_CATALOG.enterprise.dodoProductId);
+    expect(sub?.updatedAt).toBe(NOW + DAY_MS);
+  });
+
+  test("does not let a permanently-failing row starve a healthy row sorted behind it", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const poisonPeriodEnd = NOW - 3 * DAY_MS; // stalest → sorts FIRST in the scan
+    const healthyStaleEnd = NOW - DAY_MS;
+    const healthyRenewedEnd = NOW + 30 * DAY_MS;
+
+    await t.run(async (ctx) => {
+      await ctx.db.insert("subscriptions", {
+        userId: "user_poison",
+        dodoSubscriptionId: "sub_poison",
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: NOW - 33 * DAY_MS,
+        currentPeriodEnd: poisonPeriodEnd,
+        rawPayload: { subscription_id: "sub_poison" },
+        updatedAt: NOW - DAY_MS,
+      });
+      await ctx.db.insert("subscriptions", {
+        userId: "user_healthy",
+        dodoSubscriptionId: "sub_healthy",
+        dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+        planKey: "pro_monthly",
+        status: "active",
+        currentPeriodStart: NOW - 31 * DAY_MS,
+        currentPeriodEnd: healthyStaleEnd,
+        rawPayload: { subscription_id: "sub_healthy" },
+        updatedAt: NOW - DAY_MS,
+      });
+      await ctx.db.insert("entitlements", {
+        userId: "user_healthy",
+        planKey: "pro_monthly",
+        features: getFeaturesForPlan("pro_monthly"),
+        validUntil: healthyStaleEnd,
+        updatedAt: NOW - DAY_MS,
+      });
+    });
+
+    // limit 1 forces the poison row (sorted first) to consume the only batch
+    // slot on the first invocation; a continuation must reach the healthy row.
+    const summary = await t.action(
+      internal.payments.billing.reconcileMissedDodoRenewals,
+      {
+        now: NOW,
+        limit: 1,
+        remoteSubscriptionsForTest: [
+          {
+            subscription_id: "sub_healthy",
+            product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+            status: "active",
+            previous_billing_date: new Date(NOW).toISOString(),
+            next_billing_date: new Date(healthyRenewedEnd).toISOString(),
+          },
+        ],
+      },
+    );
+
+    expect(summary).toMatchObject({
+      inspected: 1,
+      failed: 1,
+      reconciled: 0,
+      hasMore: true,
+      continuationScheduled: true,
+    });
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    const poison = await readSub(t, "poison");
+    const healthy = await readSub(t, "healthy");
+    const healthyEnt = await readEntitlement(t, "user_healthy");
+
+    // Poison row was backed off (marked), not reconciled.
+    expect(poison?.status).toBe("active");
+    expect(poison?.currentPeriodEnd).toBe(poisonPeriodEnd);
+    expect(poison?.reconcileFailureCount).toBe(1);
+    expect(poison?.lastReconcileAttemptAt).toBe(NOW);
+
+    // Healthy row sorted behind it still reconciled within the same cron cycle.
+    expect(healthy?.currentPeriodEnd).toBe(healthyRenewedEnd);
+    expect(healthy?.reconcileFailureCount).toBeUndefined();
+    expect(healthyEnt?.validUntil).toBe(healthyRenewedEnd);
+
+    vi.useRealTimers();
+  });
+
+  test("drains a backlog larger than the per-invocation batch across continuations", async () => {
+    vi.useFakeTimers();
+    const t = convexTest(schema, modules);
+    const renewedEnd = NOW + 30 * DAY_MS;
+    const suffixes = ["drain_a", "drain_b", "drain_c"];
+
+    await t.run(async (ctx) => {
+      let i = 0;
+      for (const suffix of suffixes) {
+        await ctx.db.insert("subscriptions", {
+          userId: `user_${suffix}`,
+          dodoSubscriptionId: `sub_${suffix}`,
+          dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+          planKey: "pro_monthly",
+          status: "active",
+          currentPeriodStart: NOW - 31 * DAY_MS,
+          currentPeriodEnd: NOW - (i + 1) * DAY_MS,
+          rawPayload: { subscription_id: `sub_${suffix}` },
+          updatedAt: NOW - 5 * DAY_MS,
+        });
+        i++;
+      }
+    });
+
+    const summary = await t.action(
+      internal.payments.billing.reconcileMissedDodoRenewals,
+      {
+        now: NOW,
+        limit: 1,
+        remoteSubscriptionsForTest: suffixes.map((suffix) => ({
+          subscription_id: `sub_${suffix}`,
+          product_id: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+          status: "active",
+          previous_billing_date: new Date(NOW).toISOString(),
+          next_billing_date: new Date(renewedEnd).toISOString(),
+        })),
+      },
+    );
+
+    expect(summary).toMatchObject({ reconciled: 1, hasMore: true, continuationScheduled: true });
+
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    for (const suffix of suffixes) {
+      const sub = await readSub(t, suffix);
+      expect(sub?.currentPeriodEnd).toBe(renewedEnd);
+    }
+
+    vi.useRealTimers();
+  });
 });

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -102,4 +102,15 @@ crons.daily(
   {},
 );
 
+// Missed-renewal reconciliation (#4765): a renewal that succeeded at Dodo
+// but whose webhook was lost leaves the local sub with a lapsed period —
+// wrongly cutting off a paying customer. Daily sweep refreshes those from
+// Dodo's authoritative state and recomputes entitlements.
+crons.daily(
+  "dodo-renewal-reconciliation",
+  { hourUTC: 3, minuteUTC: 17 },
+  internal.payments.billing.reconcileMissedDodoRenewals,
+  {},
+);
+
 export default crons;

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -19,7 +19,12 @@ import { resolveUserId, requireUserId } from "../lib/auth";
 import { getFeaturesForPlan } from "../lib/entitlements";
 import { ANON_ID_V4_REGEX, verifyAnonClaimToken } from "../lib/identitySigning";
 import { PRODUCT_CATALOG, resolveProductToPlan } from "../config/productCatalog";
-import { isNewerEvent, recomputeEntitlementFromAllSubs, resolvePlanKey } from "./subscriptionHelpers";
+import {
+  isNewerEvent,
+  recomputeEntitlementFromAllSubs,
+  resolvePlanKey,
+  type SubscriptionStatus,
+} from "./subscriptionHelpers";
 
 // ---------------------------------------------------------------------------
 // Shared SDK config (direct REST SDK, not the Convex component from lib/dodo.ts)
@@ -106,6 +111,28 @@ function isReconcileEligible(
   return now - candidate.lastReconcileAttemptAt >= reconcileBackoffMs(candidate.reconcileFailureCount ?? 0);
 }
 
+// Confirmation threshold before a definitive Dodo not-found downgrades the local
+// row: only when the row ALREADY has >= this many recorded failures (i.e. this
+// is at least the 2nd consecutive definitive 404, across >= 2 daily runs) do we
+// expire it. Blocks a single flaky 404 from revoking a paying customer. NOTE the
+// residual: a sustained wrong-environment/API-key misconfig that 404s every live
+// sub would still downgrade the base after two runs — that is a sev1 the
+// per-expiry error logs surface loudly.
+const DODO_RENEWAL_TERMINAL_NOTFOUND_MIN_PRIOR_FAILURES = 1;
+
+// A definitive "this subscription does not exist in Dodo" — the SDK throws
+// `NotFoundError extends APIError<404>` (a `.status` of 404). Transient failures
+// (network, timeout, 5xx, 429) carry a different/absent status and must stay on
+// the backoff-and-retry path, never downgrade.
+function isDefinitiveDodoNotFound(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "status" in err &&
+    (err as { status?: unknown }).status === 404
+  );
+}
+
 const dodoReconciliationRemoteSubscriptionValidator = v.object({
   subscription_id: v.string(),
   product_id: v.string(),
@@ -139,8 +166,6 @@ type DodoReconciliationRemoteSubscription = {
   cancelled_at?: string | number | null;
 };
 
-type LocalSubscriptionStatus = "active" | "on_hold" | "cancelled" | "expired";
-
 type StaleActiveSubscriptionForRenewalReconciliation = {
   _id: Id<"subscriptions">;
   userId: string;
@@ -159,7 +184,7 @@ type ReconciliationSkipReason =
 type ReconciliationMutationResult =
   | {
       kind: "reconciled";
-      status: LocalSubscriptionStatus;
+      status: SubscriptionStatus;
       planKey: string;
       currentPeriodEnd: number;
     }
@@ -168,6 +193,10 @@ type ReconciliationMutationResult =
 type ReconciliationSummary = {
   inspected: number;
   reconciled: number;
+  // Rows the reconciler downgraded to `expired` because a CONFIRMED terminal
+  // Dodo not-found (>= 2 consecutive definitive 404s) proved the subscription no
+  // longer exists — distinct from a transient lookup `failed`.
+  expiredMissing: number;
   skipped: number;
   failed: number;
   limit: number;
@@ -184,7 +213,7 @@ type ReconciliationSummary = {
   failures: Array<{ dodoSubscriptionId: string; error: string }>;
 };
 
-function normalizeDodoStatus(status: string): LocalSubscriptionStatus | null {
+function normalizeDodoStatus(status: string): SubscriptionStatus | null {
   switch (status) {
     case "active":
     case "on_hold":
@@ -523,7 +552,7 @@ export const listStaleActiveSubscriptionsForRenewalReconciliation = internalQuer
     // are returned, so a continuation can page PAST a window already drained or
     // saturated by backoff instead of re-scanning the same stalest rows. Omitted
     // (undefined) on the first invocation of a cron cycle. Uses the same
-    // `by_status_period_end` index — the currentPeriodEnd range is just
+    // `by_status_currentPeriodEnd` index — the currentPeriodEnd range is just
     // lower-bounded when the cursor is set.
     cursorPeriodEnd: v.optional(v.number()),
   },
@@ -670,6 +699,14 @@ export const applyDodoSubscriptionReconciliation = internalMutation({
       planKey = await resolvePlanKey(ctx, args.remote.productId);
     }
 
+    // Does this patch actually move the row OUT of the stale-active set? It does
+    // unless the remote is still active with a period end that is itself still
+    // in the past (Dodo hasn't renewed either). When it does NOT, treat this as
+    // a no-progress attempt: record a backoff instead of clearing the
+    // bookkeeping, so the still-stale row isn't re-fetched (and re-reconciled)
+    // every cycle with a fresh clean slate.
+    const stillStaleAfterPatch =
+      args.remote.status === "active" && args.remote.currentPeriodEnd < args.observedAt;
     await ctx.db.patch(existing._id, {
       status: args.remote.status,
       dodoProductId: args.remote.productId,
@@ -679,10 +716,17 @@ export const applyDodoSubscriptionReconciliation = internalMutation({
       dodoCustomerId: args.remote.dodoCustomerId ?? existing.dodoCustomerId,
       rawPayload: args.remote.rawPayload,
       updatedAt: args.observedAt,
-      // Clear reconcile bookkeeping — this row made progress and (usually)
-      // leaves the stale-active set; a later miss starts from a clean slate.
-      lastReconcileAttemptAt: undefined,
-      reconcileFailureCount: undefined,
+      ...(stillStaleAfterPatch
+        ? {
+            lastReconcileAttemptAt: args.observedAt,
+            reconcileFailureCount: (existing.reconcileFailureCount ?? 0) + 1,
+          }
+        : {
+            // Row left the stale-active set — clear bookkeeping so a later miss
+            // starts from a clean slate.
+            lastReconcileAttemptAt: undefined,
+            reconcileFailureCount: undefined,
+          }),
       ...(args.remote.status === "cancelled"
         ? { cancelledAt: args.remote.cancelledAt ?? existing.cancelledAt ?? args.observedAt }
         : {}),
@@ -697,6 +741,188 @@ export const applyDodoSubscriptionReconciliation = internalMutation({
     };
   },
 });
+
+/**
+ * Downgrades a stale-active local row to `expired` after the reconciler
+ * confirmed the subscription no longer exists in Dodo (a definitive, repeated
+ * 404 — see `isDefinitiveDodoNotFound` + the confirmation threshold). This is
+ * the terminal counterpart to the backoff path: instead of retrying a row that
+ * will never resolve, it moves it OUT of the active set, which simultaneously
+ * frees its scan slot, ends the entitlement over-grant, and lets the entitlement
+ * recompute downgrade the user.
+ *
+ * Guards mirror `applyDodoSubscriptionReconciliation`: skip if the row already
+ * left the stale-active set or a concurrent webhook wrote a newer state.
+ */
+export const expireMissingDodoSubscription = internalMutation({
+  args: {
+    subscriptionId: v.id("subscriptions"),
+    dodoSubscriptionId: v.string(),
+    observedAt: v.number(),
+  },
+  handler: async (
+    ctx,
+    args,
+  ): Promise<{ kind: "expired" } | { kind: "skipped"; reason: ReconciliationSkipReason }> => {
+    const existing = await ctx.db.get(args.subscriptionId);
+    if (!existing) {
+      return { kind: "skipped", reason: "local_missing" };
+    }
+    if (existing.dodoSubscriptionId !== args.dodoSubscriptionId) {
+      throw new Error(
+        `[billing/reconcile] subscription id mismatch: expected ${existing.dodoSubscriptionId}, got ${args.dodoSubscriptionId}`,
+      );
+    }
+    if (existing.status !== "active" || existing.currentPeriodEnd >= args.observedAt) {
+      return { kind: "skipped", reason: "local_no_longer_stale" };
+    }
+    if (!isNewerEvent(existing.updatedAt, args.observedAt)) {
+      return { kind: "skipped", reason: "local_updated_concurrently" };
+    }
+
+    await ctx.db.patch(existing._id, {
+      status: "expired",
+      updatedAt: args.observedAt,
+      lastReconcileAttemptAt: undefined,
+      reconcileFailureCount: undefined,
+    });
+    await recomputeEntitlementFromAllSubs(ctx, existing.userId, args.observedAt);
+    return { kind: "expired" };
+  },
+});
+
+type StaleRowOutcome =
+  | { kind: "reconciled" }
+  | { kind: "expired" }
+  | { kind: "skipped" }
+  | { kind: "failed"; error: string };
+
+// Best-effort backoff bookkeeping for the paths that never reach
+// `applyDodoSubscriptionReconciliation` (Dodo lookup failure, unsupported/pending
+// status). Swallows its own error so a bookkeeping OCC conflict can never abort
+// the batch or skip continuation scheduling.
+export async function safeMarkReconcileAttempt(
+  ctx: Pick<ActionCtx, "runMutation">,
+  subscriptionId: Id<"subscriptions">,
+  observedAt: number,
+): Promise<void> {
+  try {
+    await ctx.runMutation(internal.payments.billing.markDodoReconcileAttempt, {
+      subscriptionId,
+      observedAt,
+    });
+  } catch (markErr) {
+    // sentry-coverage-ok: structured console.error is forwarded by Convex
+    // auto-Sentry. Deliberately swallowed (not re-thrown): a failed best-effort
+    // backoff write must never abort the batch or skip continuation scheduling —
+    // the row simply isn't backed off this once and is re-attempted next run.
+    console.error(
+      `[billing/reconcile] markDodoReconcileAttempt failed for ${subscriptionId}: ${markErr instanceof Error ? markErr.message : String(markErr)}`,
+    );
+  }
+}
+
+// Reconcile a single stale-active row against Dodo truth. Fetch → normalize →
+// apply mutation → interpret, with the transient-vs-terminal error split. Never
+// throws — one bad row must not block the rest of the batch; returns the outcome
+// for the caller to fold into the summary.
+async function reconcileOneStaleRow(
+  ctx: Pick<ActionCtx, "runMutation">,
+  sub: StaleActiveSubscriptionForRenewalReconciliation,
+  opts: {
+    now: number;
+    useTestRemotes: boolean;
+    remoteById: Map<string, DodoReconciliationRemoteSubscription>;
+    errorInjection: Map<string, "not_found" | "server_error">;
+    client: DodoPayments | null;
+  },
+): Promise<StaleRowOutcome> {
+  const { now, useTestRemotes, remoteById, errorInjection, client } = opts;
+  try {
+    let remote: DodoSubscription | DodoReconciliationRemoteSubscription | undefined;
+    if (useTestRemotes) {
+      const injected = errorInjection.get(sub.dodoSubscriptionId);
+      if (injected === "not_found") {
+        throw Object.assign(new Error("simulated Dodo not found"), { status: 404 });
+      }
+      if (injected === "server_error") {
+        throw Object.assign(new Error("simulated Dodo server error"), { status: 500 });
+      }
+      remote = remoteById.get(sub.dodoSubscriptionId);
+    } else {
+      remote = await client!.subscriptions.retrieve(sub.dodoSubscriptionId);
+    }
+    if (!remote) {
+      throw new Error("missing test remote subscription");
+    }
+
+    const normalized = normalizeRemoteSubscription(remote);
+    if (normalized.kind === "skip") {
+      // sentry-coverage-ok: escalated to error (Convex auto-Sentry captures
+      // error, not warn) so a `pending`/unknown remote status that a
+      // local-active row is stuck on gets triaged rather than silently skipped
+      // daily.
+      console.error(
+        `[billing/reconcile] Skipping subscription ${normalized.dodoSubscriptionId}: ${normalized.reason} Dodo status "${normalized.status}"`,
+      );
+      // Row is still stale-active — back it off.
+      await safeMarkReconcileAttempt(ctx, sub._id, now);
+      return { kind: "skipped" };
+    }
+
+    const result = (await ctx.runMutation(
+      internal.payments.billing.applyDodoSubscriptionReconciliation,
+      {
+        subscriptionId: sub._id,
+        dodoSubscriptionId: sub.dodoSubscriptionId,
+        observedAt: now,
+        remote: normalized.value,
+      },
+    )) as ReconciliationMutationResult;
+    // `apply` records its own backoff for the still-stale skip reasons.
+    return result.kind === "reconciled" ? { kind: "reconciled" } : { kind: "skipped" };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // Confirmed terminal not-found: the subscription no longer exists in Dodo.
+    // Only after >= the confirmation threshold of prior failures so a single
+    // flaky 404 can't downgrade a paying customer. Downgrade the row to expired
+    // so it leaves the active set permanently.
+    if (
+      isDefinitiveDodoNotFound(err) &&
+      (sub.reconcileFailureCount ?? 0) >= DODO_RENEWAL_TERMINAL_NOTFOUND_MIN_PRIOR_FAILURES
+    ) {
+      const expireResult = (await ctx.runMutation(
+        internal.payments.billing.expireMissingDodoSubscription,
+        {
+          subscriptionId: sub._id,
+          dodoSubscriptionId: sub.dodoSubscriptionId,
+          observedAt: now,
+        },
+      )) as { kind: "expired" } | { kind: "skipped"; reason: ReconciliationSkipReason };
+      if (expireResult.kind === "expired") {
+        // sentry-coverage-ok: structured console.error is forwarded by Convex
+        // auto-Sentry so ops sees confirmed-gone subscriptions being downgraded
+        // (also the signal that would spike on a wrong-environment misconfig).
+        console.error(
+          `[billing/reconcile] dodoSubscriptionId=${sub.dodoSubscriptionId} userId=${sub.userId} confirmed not-found in Dodo after ${(sub.reconcileFailureCount ?? 0) + 1} attempts; downgraded local row to expired.`,
+        );
+        return { kind: "expired" };
+      }
+      // A concurrent webhook already moved the row out of the stale-active set.
+      return { kind: "skipped" };
+    }
+    // Transient (5xx / network / timeout) OR an unconfirmed first 404 → back off
+    // and retry; never downgrade on an ambiguous signal.
+    // sentry-coverage-ok: structured console.error is forwarded by Convex
+    // auto-Sentry. We intentionally do not re-throw here because one bad Dodo
+    // lookup must not block reconciliation for other stale subscribers.
+    console.error(
+      `[billing/reconcile] Failed to reconcile dodoSubscriptionId=${sub.dodoSubscriptionId} userId=${sub.userId}: ${message}`,
+    );
+    await safeMarkReconcileAttempt(ctx, sub._id, now);
+    return { kind: "failed", error: message };
+  }
+}
 
 export const reconcileMissedDodoRenewals = internalAction({
   args: {
@@ -718,11 +944,23 @@ export const reconcileMissedDodoRenewals = internalAction({
     remoteSubscriptionsForTest: v.optional(
       v.array(dodoReconciliationRemoteSubscriptionValidator),
     ),
+    // Test-only: simulate a Dodo `subscriptions.retrieve` error per subscription
+    // id ("not_found" -> definitive 404, "server_error" -> transient 5xx) so the
+    // terminal-vs-transient split is exercised without a live client.
+    errorInjectionForTest: v.optional(
+      v.record(
+        v.string(),
+        v.union(v.literal("not_found"), v.literal("server_error")),
+      ),
+    ),
   },
   handler: async (ctx, args): Promise<ReconciliationSummary> => {
-    if (args.remoteSubscriptionsForTest && process.env.NODE_ENV !== "test") {
+    const usesTestInjection =
+      args.remoteSubscriptionsForTest !== undefined ||
+      args.errorInjectionForTest !== undefined;
+    if (usesTestInjection && process.env.NODE_ENV !== "test") {
       throw new Error(
-        "[billing/reconcile] remoteSubscriptionsForTest is only allowed under test",
+        "[billing/reconcile] test injection args are only allowed under test",
       );
     }
 
@@ -769,16 +1007,24 @@ export const reconcileMissedDodoRenewals = internalAction({
         remote,
       ]),
     );
-    const client = args.remoteSubscriptionsForTest
+    const errorInjection = new Map<string, "not_found" | "server_error">(
+      Object.entries(args.errorInjectionForTest ?? {}),
+    );
+    const client = usesTestInjection
       ? null
       : getDodoClient({
           timeout: DODO_RENEWAL_RECONCILIATION_TIMEOUT_MS,
-          maxRetries: 1,
+          // No SDK-level retry: a rate-limited/incident retry honors a server
+          // Retry-After VERBATIM and could sleep minutes, blowing the Convex
+          // 10-min action cap. Our row-level backoff + continuation IS the retry
+          // mechanism, so each lookup stays bounded by `timeout`.
+          maxRetries: 0,
         });
 
     const summary: ReconciliationSummary = {
       inspected: 0,
       reconciled: 0,
+      expiredMissing: 0,
       skipped: 0,
       failed: 0,
       limit,
@@ -787,29 +1033,6 @@ export const reconcileMissedDodoRenewals = internalAction({
       windowSaturated: false,
       continuationScheduled: false,
       failures: [],
-    };
-
-    // Bookkeeping-only patch for a still-stale row we couldn't advance. Never
-    // let a failed bookkeeping write (OCC conflict, row deleted mid-cycle) abort
-    // the whole batch or the continuation scheduling — swallow + log. Used only
-    // for the two no-progress paths that don't reach `apply` (Dodo lookup
-    // failure, unsupported/pending status); `apply` records its own.
-    const markAttempt = async (subscriptionId: Id<"subscriptions">) => {
-      try {
-        await ctx.runMutation(internal.payments.billing.markDodoReconcileAttempt, {
-          subscriptionId,
-          observedAt: now,
-        });
-      } catch (markErr) {
-        // sentry-coverage-ok: structured console.error is forwarded by Convex
-        // auto-Sentry. Deliberately swallowed (not re-thrown): a failed
-        // best-effort backoff write must never abort the batch or skip
-        // continuation scheduling — the row simply isn't backed off this once
-        // and is re-attempted next run.
-        console.error(
-          `[billing/reconcile] markDodoReconcileAttempt failed for ${subscriptionId}: ${markErr instanceof Error ? markErr.message : String(markErr)}`,
-        );
-      }
     };
 
     let attempted = 0;
@@ -825,62 +1048,30 @@ export const reconcileMissedDodoRenewals = internalAction({
       }
       attempted++;
       summary.inspected++;
-      try {
-        const remote = args.remoteSubscriptionsForTest
-          ? remoteById.get(sub.dodoSubscriptionId)
-          : await client!.subscriptions.retrieve(sub.dodoSubscriptionId);
-        if (!remote) {
-          throw new Error("missing test remote subscription");
-        }
-
-        const normalized = normalizeRemoteSubscription(remote);
-        if (normalized.kind === "skip") {
-          summary.skipped++;
-          // sentry-coverage-ok: escalated to error (Convex auto-Sentry captures
-          // error, not warn) so a `pending`/unknown remote status that a
-          // local-active row is stuck on gets triaged rather than silently
-          // skipped daily.
-          console.error(
-            `[billing/reconcile] Skipping subscription ${normalized.dodoSubscriptionId}: ${normalized.reason} Dodo status "${normalized.status}"`,
-          );
-          // Row is still stale-active — back it off.
-          await markAttempt(sub._id);
-          continue;
-        }
-
-        const result = (await ctx.runMutation(
-          internal.payments.billing.applyDodoSubscriptionReconciliation,
-          {
-            subscriptionId: sub._id,
-            dodoSubscriptionId: sub.dodoSubscriptionId,
-            observedAt: now,
-            remote: normalized.value,
-          },
-        )) as ReconciliationMutationResult;
-        if (result.kind === "reconciled") {
+      const outcome = await reconcileOneStaleRow(ctx, sub, {
+        now,
+        useTestRemotes: usesTestInjection,
+        remoteById,
+        errorInjection,
+        client,
+      });
+      switch (outcome.kind) {
+        case "reconciled":
           summary.reconciled++;
-        } else {
-          // `apply` already recorded a backoff attempt for the still-stale skip
-          // reasons (remote_not_newer / local_updated_concurrently) inside its
-          // own transaction; `local_missing` / `local_no_longer_stale` left the
-          // set. Nothing more to do here.
+          break;
+        case "expired":
+          summary.expiredMissing++;
+          break;
+        case "skipped":
           summary.skipped++;
-        }
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        summary.failed++;
-        summary.failures.push({
-          dodoSubscriptionId: sub.dodoSubscriptionId,
-          error: message,
-        });
-        // sentry-coverage-ok: structured console.error is forwarded by Convex
-        // auto-Sentry. We intentionally do not re-throw here because one bad
-        // Dodo lookup must not block reconciliation for other stale subscribers.
-        console.error(
-          `[billing/reconcile] Failed to reconcile dodoSubscriptionId=${sub.dodoSubscriptionId} userId=${sub.userId}: ${message}`,
-        );
-        // Poison row (e.g. test-mode-era sub 404ing the live client) — back off.
-        await markAttempt(sub._id);
+          break;
+        case "failed":
+          summary.failed++;
+          summary.failures.push({
+            dodoSubscriptionId: sub.dodoSubscriptionId,
+            error: outcome.error,
+          });
+          break;
       }
     }
 
@@ -948,11 +1139,20 @@ export const reconcileMissedDodoRenewals = internalAction({
           ...(args.remoteSubscriptionsForTest
             ? { remoteSubscriptionsForTest: args.remoteSubscriptionsForTest }
             : {}),
+          ...(args.errorInjectionForTest
+            ? { errorInjectionForTest: args.errorInjectionForTest }
+            : {}),
         },
       );
       summary.continuationScheduled = true;
     }
 
+    // No run-lock guards a still-draining continuation chain against the next
+    // daily cron tick (the two could overlap). Left intentionally: every write
+    // path is idempotent under overlap — the per-row mutations re-check
+    // staleness + `isNewerEvent(updatedAt, observedAt)` and Convex OCC serializes
+    // conflicting writes, so a duplicate pass at worst re-marks a backoff (benign)
+    // and never double-applies a reconcile.
     return summary;
   },
 });

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -580,6 +580,7 @@ export const listStaleActiveSubscriptionsForRenewalReconciliation = internalQuer
       // (position-based), so the index range is just the stale-active window.
       .withIndex("by_status_currentPeriodEnd", (q) =>
         q.eq("status", "active").lt("currentPeriodEnd", args.now),
+      )
       .order("asc")
       .paginate({ cursor: args.cursor ?? null, numItems: args.scanLimit });
     // Slim projection — the action only needs identity + the reconcile
@@ -958,6 +959,10 @@ export const reconcileMissedDodoRenewals = internalAction({
     // forward by document position — see the scheduling block. Omitted on a
     // fresh cron tick.
     cursor: v.optional(v.union(v.string(), v.null())),
+    // Mass-404 circuit-breaker state threaded through continuations so the bound
+    // is per cron CYCLE, not per invocation. Omitted on a fresh cron tick.
+    notFoundDowngradesSoFar: v.optional(v.number()),
+    massNotFoundHalted: v.optional(v.boolean()),
     // Per-query scan window size, clamped to the const ceiling. Defaults to the
     // ceiling; a smaller value is an ops knob (and the test seam that exercises
     // the window-paging / saturation logic without seeding 500 rows). Threaded
@@ -1056,16 +1061,20 @@ export const reconcileMissedDodoRenewals = internalAction({
       failures: [],
     };
 
-    // Mass-404 circuit breaker budget, sized to the work we plan to attempt this
-    // invocation: a genuine handful of deleted subs downgrades; a batch that is
-    // mostly/entirely 404 (a probable misconfig) self-halts at the threshold.
+    // Mass-404 circuit breaker. The running downgrade count and the halt latch
+    // are threaded through continuations so the bound is PER CRON CYCLE, not per
+    // invocation: a genuine handful of deleted subs downgrades; a batch/cycle
+    // that is mostly/entirely 404 (a probable misconfig) self-halts.
+    //   - Per-cycle: at most DODO_RENEWAL_MASS_NOTFOUND_ABSOLUTE_CAP downgrades
+    //     total across the whole continuation chain.
+    //   - Per-invocation: if downgrades in a single invocation reach a majority
+    //     of what it planned to attempt, latch the halt for the rest of the cycle
+    //     (a mostly-404 batch is a strong misconfig signal even under the cap).
     const plannedAttempts = Math.min(limit, eligible.length);
-    const maxNotFoundDowngrades = Math.min(
-      DODO_RENEWAL_MASS_NOTFOUND_ABSOLUTE_CAP,
-      Math.ceil(plannedAttempts / 2),
-    );
-    let notFoundDowngrades = 0;
-    let massNotFoundHalted = false;
+    const perInvocationMajorityCap = Math.ceil(plannedAttempts / 2);
+    let notFoundDowngrades = args.notFoundDowngradesSoFar ?? 0;
+    let massNotFoundHalted = args.massNotFoundHalted ?? false;
+    let downgradesThisInvocation = 0;
 
     let attempted = 0;
     for (const sub of eligible) {
@@ -1102,9 +1111,13 @@ export const reconcileMissedDodoRenewals = internalAction({
           });
           break;
         case "terminal_not_found": {
-          if (notFoundDowngrades >= maxNotFoundDowngrades) {
-            // Circuit breaker tripped — too many confirmed 404s this run. Treat
-            // this (and every subsequent 404) as a transient failure: keep the
+          const breakerTripped =
+            massNotFoundHalted ||
+            notFoundDowngrades >= DODO_RENEWAL_MASS_NOTFOUND_ABSOLUTE_CAP ||
+            downgradesThisInvocation >= perInvocationMajorityCap;
+          if (breakerTripped) {
+            // Circuit breaker tripped — too many confirmed 404s. Treat this (and
+            // every subsequent 404 this cycle) as a transient failure: keep the
             // row active and on backoff instead of downgrading a possibly-live
             // customer during a suspected wrong-environment/API-key misconfig.
             if (!massNotFoundHalted) {
@@ -1113,7 +1126,7 @@ export const reconcileMissedDodoRenewals = internalAction({
               // this is the page that must fire BEFORE a second daily run could
               // downgrade the base under a config error.
               console.error(
-                `[billing/reconcile] mass Dodo 404s (${notFoundDowngrades + 1}/${attempted} attempted) — possible wrong-environment/API-key misconfig; further downgrades halted this run.`,
+                `[billing/reconcile] mass Dodo 404s (${notFoundDowngrades} downgraded this cycle) — possible wrong-environment/API-key misconfig; further downgrades halted for the rest of this cycle.`,
               );
             }
             summary.failed++;
@@ -1126,16 +1139,40 @@ export const reconcileMissedDodoRenewals = internalAction({
             await safeMarkReconcileAttempt(ctx, sub._id, now, true);
             break;
           }
-          const expireResult = (await ctx.runMutation(
-            internal.payments.billing.expireMissingDodoSubscription,
-            {
-              subscriptionId: sub._id,
+          // Guard the downgrade mutation: an OCC rejection (concurrent webhook on
+          // the same sub/entitlement) or a recompute error must NOT propagate out
+          // of the loop — that would abort the batch AND skip the continuation
+          // scheduling below. Route a failed downgrade to the backoff path.
+          let expireResult:
+            | { kind: "expired" }
+            | { kind: "skipped"; reason: ReconciliationSkipReason };
+          try {
+            expireResult = (await ctx.runMutation(
+              internal.payments.billing.expireMissingDodoSubscription,
+              {
+                subscriptionId: sub._id,
+                dodoSubscriptionId: sub.dodoSubscriptionId,
+                observedAt: now,
+              },
+            )) as { kind: "expired" } | { kind: "skipped"; reason: ReconciliationSkipReason };
+          } catch (expireErr) {
+            const expireMsg =
+              expireErr instanceof Error ? expireErr.message : String(expireErr);
+            // sentry-coverage-ok: Convex auto-Sentry captures console.error.
+            console.error(
+              `[billing/reconcile] expireMissingDodoSubscription failed for dodoSubscriptionId=${sub.dodoSubscriptionId} userId=${sub.userId}: ${expireMsg}`,
+            );
+            summary.failed++;
+            summary.failures.push({
               dodoSubscriptionId: sub.dodoSubscriptionId,
-              observedAt: now,
-            },
-          )) as { kind: "expired" } | { kind: "skipped"; reason: ReconciliationSkipReason };
+              error: expireMsg,
+            });
+            await safeMarkReconcileAttempt(ctx, sub._id, now, true);
+            break;
+          }
           if (expireResult.kind === "expired") {
             notFoundDowngrades++;
+            downgradesThisInvocation++;
             summary.expiredMissing++;
             // sentry-coverage-ok: Convex auto-Sentry captures console.error so
             // ops sees confirmed-gone subscriptions being downgraded.
@@ -1204,6 +1241,9 @@ export const reconcileMissedDodoRenewals = internalAction({
           scanLimit,
           continuationBudget: continuationBudget - 1,
           cursor: nextCursor ?? null,
+          // Carry the mass-404 breaker state so the cap is per cron cycle.
+          notFoundDowngradesSoFar: notFoundDowngrades,
+          massNotFoundHalted,
           ...(args.remoteSubscriptionsForTest
             ? { remoteSubscriptionsForTest: args.remoteSubscriptionsForTest }
             : {}),

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -13,6 +13,8 @@ import { ConvexError, v } from "convex/values";
 import { action, mutation, query, internalAction, internalMutation, internalQuery, type ActionCtx } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { DodoPayments } from "dodopayments";
+import type { Subscription as DodoSubscription } from "dodopayments/resources/subscriptions";
+import type { Id } from "../_generated/dataModel";
 import { resolveUserId, requireUserId } from "../lib/auth";
 import { getFeaturesForPlan } from "../lib/entitlements";
 import { ANON_ID_V4_REGEX, verifyAnonClaimToken } from "../lib/identitySigning";
@@ -33,7 +35,9 @@ import { recomputeEntitlementFromAllSubs } from "./subscriptionHelpers";
  *
  * Canonical env var: DODO_API_KEY.
  */
-function getDodoClient(): DodoPayments {
+function getDodoClient(
+  options: { timeout?: number; maxRetries?: number } = {},
+): DodoPayments {
   const apiKey = process.env.DODO_API_KEY;
   if (!apiKey) {
     // Structured throw (object-typed `data`) so the client receives
@@ -46,7 +50,129 @@ function getDodoClient(): DodoPayments {
   return new DodoPayments({
     bearerToken: apiKey,
     ...(isLive ? {} : { environment: "test_mode" as const }),
+    ...options,
   });
+}
+
+const DODO_RENEWAL_RECONCILIATION_BATCH_SIZE = 50;
+const DODO_RENEWAL_RECONCILIATION_TIMEOUT_MS = 10_000;
+const DODO_RECONCILIATION_FALLBACK_PLAN_KEY = "enterprise";
+
+const dodoReconciliationRemoteSubscriptionValidator = v.object({
+  subscription_id: v.string(),
+  product_id: v.string(),
+  status: v.string(),
+  previous_billing_date: v.union(v.string(), v.number()),
+  next_billing_date: v.union(v.string(), v.number()),
+  customer: v.optional(v.object({
+    customer_id: v.optional(v.string()),
+    email: v.optional(v.string()),
+  })),
+  metadata: v.optional(v.record(v.string(), v.string())),
+  recurring_pre_tax_amount: v.optional(v.number()),
+  currency: v.optional(v.string()),
+  tax_inclusive: v.optional(v.boolean()),
+  discount_id: v.optional(v.union(v.string(), v.null())),
+  cancelled_at: v.optional(v.union(v.string(), v.number(), v.null())),
+});
+
+type DodoReconciliationRemoteSubscription = {
+  subscription_id: string;
+  product_id: string;
+  status: string;
+  previous_billing_date: string | number;
+  next_billing_date: string | number;
+  customer?: { customer_id?: string; email?: string };
+  metadata?: Record<string, string>;
+  recurring_pre_tax_amount?: number;
+  currency?: string;
+  tax_inclusive?: boolean;
+  discount_id?: string | null;
+  cancelled_at?: string | number | null;
+};
+
+type LocalSubscriptionStatus = "active" | "on_hold" | "cancelled" | "expired";
+
+type StaleActiveSubscriptionForRenewalReconciliation = {
+  _id: Id<"subscriptions">;
+  userId: string;
+  dodoSubscriptionId: string;
+};
+
+type ReconciliationMutationResult =
+  | {
+      kind: "reconciled";
+      status: LocalSubscriptionStatus;
+      planKey: string;
+      currentPeriodEnd: number;
+    }
+  | { kind: "skipped"; reason: string };
+
+type ReconciliationSummary = {
+  inspected: number;
+  reconciled: number;
+  skipped: number;
+  failed: number;
+  limit: number;
+  hasMore: boolean;
+  failures: Array<{ dodoSubscriptionId: string; error: string }>;
+};
+
+function normalizeDodoStatus(status: string): LocalSubscriptionStatus | null {
+  switch (status) {
+    case "active":
+    case "on_hold":
+    case "cancelled":
+    case "expired":
+      return status;
+    default:
+      return null;
+  }
+}
+
+function toReconciliationEpochMs(value: string | number, fieldName: string): number {
+  const ms = typeof value === "number" ? value : new Date(value).getTime();
+  if (!Number.isFinite(ms)) {
+    throw new Error(`[billing/reconcile] invalid Dodo ${fieldName}: ${String(value)}`);
+  }
+  return ms;
+}
+
+function normalizeRemoteSubscription(
+  remote: DodoSubscription | DodoReconciliationRemoteSubscription,
+) {
+  const status = normalizeDodoStatus(remote.status);
+  if (!status) {
+    return {
+      kind: "unsupported-status" as const,
+      status: remote.status,
+      dodoSubscriptionId: remote.subscription_id,
+    };
+  }
+
+  const cancelledAt = remote.cancelled_at == null
+    ? undefined
+    : toReconciliationEpochMs(remote.cancelled_at, "cancelled_at");
+
+  return {
+    kind: "supported" as const,
+    value: {
+      dodoSubscriptionId: remote.subscription_id,
+      productId: remote.product_id,
+      status,
+      currentPeriodStart: toReconciliationEpochMs(
+        remote.previous_billing_date,
+        "previous_billing_date",
+      ),
+      currentPeriodEnd: toReconciliationEpochMs(
+        remote.next_billing_date,
+        "next_billing_date",
+      ),
+      dodoCustomerId: remote.customer?.customer_id,
+      cancelledAt,
+      rawPayload: remote,
+    },
+  };
 }
 
 /**
@@ -308,6 +434,223 @@ export const getDodoCustomerIdForUserPortal = internalQuery({
     }
 
     return null;
+  },
+});
+
+export const listStaleActiveSubscriptionsForRenewalReconciliation = internalQuery({
+  args: {
+    now: v.number(),
+    limit: v.number(),
+  },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("subscriptions")
+      // Reuses the by_status_currentPeriodEnd index added by the dunning/
+      // winback work (#4935) — same ["status","currentPeriodEnd"] shape, so
+      // no duplicate index is needed for renewal reconciliation.
+      .withIndex("by_status_currentPeriodEnd", (q) =>
+        q.eq("status", "active").lt("currentPeriodEnd", args.now),
+      )
+      .order("asc")
+      .take(args.limit);
+  },
+});
+
+export const applyDodoSubscriptionReconciliation = internalMutation({
+  args: {
+    subscriptionId: v.id("subscriptions"),
+    dodoSubscriptionId: v.string(),
+    observedAt: v.number(),
+    remote: v.object({
+      dodoSubscriptionId: v.string(),
+      productId: v.string(),
+      status: v.union(
+        v.literal("active"),
+        v.literal("on_hold"),
+        v.literal("cancelled"),
+        v.literal("expired"),
+      ),
+      currentPeriodStart: v.number(),
+      currentPeriodEnd: v.number(),
+      dodoCustomerId: v.optional(v.string()),
+      cancelledAt: v.optional(v.number()),
+      rawPayload: v.any(),
+    }),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.get(args.subscriptionId);
+    if (!existing) {
+      return { kind: "skipped", reason: "local_missing" };
+    }
+    if (existing.dodoSubscriptionId !== args.dodoSubscriptionId) {
+      throw new Error(
+        `[billing/reconcile] subscription id mismatch: expected ${existing.dodoSubscriptionId}, got ${args.dodoSubscriptionId}`,
+      );
+    }
+
+    if (existing.status !== "active" || existing.currentPeriodEnd >= args.observedAt) {
+      return { kind: "skipped", reason: "local_no_longer_stale" };
+    }
+
+    if (
+      args.remote.status === existing.status &&
+      args.remote.productId === existing.dodoProductId &&
+      args.remote.currentPeriodEnd <= existing.currentPeriodEnd &&
+      (args.remote.dodoCustomerId ?? existing.dodoCustomerId) === existing.dodoCustomerId
+    ) {
+      return { kind: "skipped", reason: "remote_not_newer" };
+    }
+
+    let planKey = existing.planKey;
+    if (args.remote.productId !== existing.dodoProductId) {
+      const mapping = await ctx.db
+        .query("productPlans")
+        .withIndex("by_dodoProductId", (q) =>
+          q.eq("dodoProductId", args.remote.productId),
+        )
+        .first();
+      const mappedPlanKey =
+        mapping?.planKey ?? resolveProductToPlan(args.remote.productId);
+      if (mappedPlanKey) {
+        planKey = mappedPlanKey;
+      } else {
+        planKey = DODO_RECONCILIATION_FALLBACK_PLAN_KEY;
+        console.error(
+          `[billing/reconcile] Unknown Dodo product ID "${args.remote.productId}" for subscription ${args.remote.dodoSubscriptionId}; falling back to "${DODO_RECONCILIATION_FALLBACK_PLAN_KEY}" so a paid customer is not under-granted while catalog mapping is fixed.`,
+        );
+      }
+    }
+
+    await ctx.db.patch(existing._id, {
+      status: args.remote.status,
+      dodoProductId: args.remote.productId,
+      planKey,
+      currentPeriodStart: args.remote.currentPeriodStart,
+      currentPeriodEnd: args.remote.currentPeriodEnd,
+      dodoCustomerId: args.remote.dodoCustomerId ?? existing.dodoCustomerId,
+      rawPayload: args.remote.rawPayload,
+      updatedAt: args.observedAt,
+      ...(args.remote.status === "cancelled"
+        ? { cancelledAt: args.remote.cancelledAt ?? existing.cancelledAt ?? args.observedAt }
+        : {}),
+    });
+
+    await recomputeEntitlementFromAllSubs(ctx, existing.userId, args.observedAt);
+    return {
+      kind: "reconciled",
+      status: args.remote.status,
+      planKey,
+      currentPeriodEnd: args.remote.currentPeriodEnd,
+    };
+  },
+});
+
+export const reconcileMissedDodoRenewals = internalAction({
+  args: {
+    now: v.optional(v.number()),
+    limit: v.optional(v.number()),
+    remoteSubscriptionsForTest: v.optional(
+      v.array(dodoReconciliationRemoteSubscriptionValidator),
+    ),
+  },
+  handler: async (ctx, args): Promise<ReconciliationSummary> => {
+    if (args.remoteSubscriptionsForTest && process.env.NODE_ENV !== "test") {
+      throw new Error(
+        "[billing/reconcile] remoteSubscriptionsForTest is only allowed under test",
+      );
+    }
+
+    const now = args.now ?? Date.now();
+    const limit = Math.max(
+      1,
+      Math.min(
+        args.limit ?? DODO_RENEWAL_RECONCILIATION_BATCH_SIZE,
+        DODO_RENEWAL_RECONCILIATION_BATCH_SIZE,
+      ),
+    );
+    const stale = (await ctx.runQuery(
+      internal.payments.billing.listStaleActiveSubscriptionsForRenewalReconciliation,
+      { now, limit },
+    )) as StaleActiveSubscriptionForRenewalReconciliation[];
+
+    const remoteById = new Map(
+      (args.remoteSubscriptionsForTest ?? []).map((remote) => [
+        remote.subscription_id,
+        remote,
+      ]),
+    );
+    const client = args.remoteSubscriptionsForTest
+      ? null
+      : getDodoClient({
+          timeout: DODO_RENEWAL_RECONCILIATION_TIMEOUT_MS,
+          maxRetries: 1,
+        });
+
+    const summary = {
+      inspected: stale.length,
+      reconciled: 0,
+      skipped: 0,
+      failed: 0,
+      limit,
+      hasMore: stale.length === limit,
+      failures: [] as Array<{ dodoSubscriptionId: string; error: string }>,
+    };
+
+    for (const sub of stale) {
+      try {
+        const remote = args.remoteSubscriptionsForTest
+          ? remoteById.get(sub.dodoSubscriptionId)
+          : await client!.subscriptions.retrieve(sub.dodoSubscriptionId);
+        if (!remote) {
+          throw new Error("missing test remote subscription");
+        }
+
+        const normalized = normalizeRemoteSubscription(remote);
+        if (normalized.kind === "unsupported-status") {
+          summary.skipped++;
+          console.warn(
+            `[billing/reconcile] Skipping subscription ${normalized.dodoSubscriptionId}: unsupported Dodo status "${normalized.status}"`,
+          );
+          continue;
+        }
+
+        const result = (await ctx.runMutation(
+          internal.payments.billing.applyDodoSubscriptionReconciliation,
+          {
+            subscriptionId: sub._id,
+            dodoSubscriptionId: sub.dodoSubscriptionId,
+            observedAt: now,
+            remote: normalized.value,
+          },
+        )) as ReconciliationMutationResult;
+        if (result.kind === "reconciled") {
+          summary.reconciled++;
+        } else {
+          summary.skipped++;
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        summary.failed++;
+        summary.failures.push({
+          dodoSubscriptionId: sub.dodoSubscriptionId,
+          error: message,
+        });
+        // sentry-coverage-ok: structured console.error is forwarded by Convex
+        // auto-Sentry. We intentionally do not re-throw here because one bad
+        // Dodo lookup must not block reconciliation for other stale subscribers.
+        console.error(
+          `[billing/reconcile] Failed to reconcile dodoSubscriptionId=${sub.dodoSubscriptionId} userId=${sub.userId}: ${message}`,
+        );
+      }
+    }
+
+    if (summary.failed > 0) {
+      console.error(
+        `[billing/reconcile] ${summary.failed}/${summary.inspected} stale active subscriptions failed reconciliation`,
+      );
+    }
+
+    return summary;
   },
 });
 

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -114,11 +114,19 @@ function isReconcileEligible(
 // Confirmation threshold before a definitive Dodo not-found downgrades the local
 // row: only when the row ALREADY has >= this many recorded failures (i.e. this
 // is at least the 2nd consecutive definitive 404, across >= 2 daily runs) do we
-// expire it. Blocks a single flaky 404 from revoking a paying customer. NOTE the
-// residual: a sustained wrong-environment/API-key misconfig that 404s every live
-// sub would still downgrade the base after two runs — that is a sev1 the
-// per-expiry error logs surface loudly.
+// expire it. Blocks a single flaky 404 from revoking a paying customer. The
+// batch-level mass-404 circuit breaker (below) bounds the correlated case where
+// a misconfig makes every live sub 404 at once.
 const DODO_RENEWAL_TERMINAL_NOTFOUND_MIN_PRIOR_FAILURES = 1;
+
+// Mass-404 circuit breaker: the max confirmed-not-found DOWNGRADES a single
+// invocation will perform. Beyond `min(this, ceil(plannedAttempts / 2))` the run
+// stops downgrading and routes the rest to the backoff path, on the theory that
+// a whole batch 404ing is far more likely a wrong-environment/API-key misconfig
+// than that many subscriptions genuinely vanishing at once. A real handful of
+// deleted subs still gets cleaned; a config error downgrades at most the
+// threshold before self-halting (and the loud console.error pages ops first).
+const DODO_RENEWAL_MASS_NOTFOUND_ABSOLUTE_CAP = 5;
 
 // A definitive "this subscription does not exist in Dodo" — the SDK throws
 // `NotFoundError extends APIError<404>` (a `.status` of 404). Transient failures
@@ -173,6 +181,13 @@ type StaleActiveSubscriptionForRenewalReconciliation = {
   currentPeriodEnd: number;
   lastReconcileAttemptAt?: number;
   reconcileFailureCount?: number;
+  reconcileNotFoundCount?: number;
+};
+
+type StaleActiveSubscriptionsPage = {
+  page: StaleActiveSubscriptionForRenewalReconciliation[];
+  continueCursor: string;
+  isDone: boolean;
 };
 
 type ReconciliationSkipReason =
@@ -548,41 +563,41 @@ export const listStaleActiveSubscriptionsForRenewalReconciliation = internalQuer
   args: {
     now: v.number(),
     scanLimit: v.number(),
-    // Resume cursor: only rows with currentPeriodEnd strictly greater than this
-    // are returned, so a continuation can page PAST a window already drained or
-    // saturated by backoff instead of re-scanning the same stalest rows. Omitted
-    // (undefined) on the first invocation of a cron cycle. Uses the same
-    // `by_status_currentPeriodEnd` index — the currentPeriodEnd range is just
-    // lower-bounded when the cursor is set.
-    cursorPeriodEnd: v.optional(v.number()),
+    // Opaque Convex pagination cursor threaded through continuations so a cron
+    // cycle pages forward by DOCUMENT POSITION rather than by currentPeriodEnd.
+    // Position-based paging is why >scanLimit rows sharing one currentPeriodEnd
+    // (a tie) can't strand rows behind them, and why a page fully consumed or
+    // fully backed-off is skipped without re-scanning. `null` (or omitted)
+    // starts from the beginning of the stale set.
+    cursor: v.optional(v.union(v.string(), v.null())),
   },
   handler: async (ctx, args) => {
-    const rows = await ctx.db
+    const result = await ctx.db
       .query("subscriptions")
       // Reuses the by_status_currentPeriodEnd index added by the dunning/
       // winback work (#4935) — same ["status","currentPeriodEnd"] shape, so
-      // no duplicate index is needed for renewal reconciliation.
+      // no duplicate index is needed. The cron pages by opaque Convex cursor
+      // (position-based), so the index range is just the stale-active window.
       .withIndex("by_status_currentPeriodEnd", (q) =>
-        args.cursorPeriodEnd === undefined
-          ? q.eq("status", "active").lt("currentPeriodEnd", args.now)
-          : q
-              .eq("status", "active")
-              .gt("currentPeriodEnd", args.cursorPeriodEnd)
-              .lt("currentPeriodEnd", args.now),
-      )
+        q.eq("status", "active").lt("currentPeriodEnd", args.now),
       .order("asc")
-      .take(args.scanLimit);
+      .paginate({ cursor: args.cursor ?? null, numItems: args.scanLimit });
     // Slim projection — the action only needs identity + the reconcile
     // bookkeeping fields to decide eligibility. Dropping `rawPayload` (v.any(),
     // potentially large) keeps the query→action transfer bounded.
-    return rows.map((row) => ({
-      _id: row._id,
-      userId: row.userId,
-      dodoSubscriptionId: row.dodoSubscriptionId,
-      currentPeriodEnd: row.currentPeriodEnd,
-      lastReconcileAttemptAt: row.lastReconcileAttemptAt,
-      reconcileFailureCount: row.reconcileFailureCount,
-    }));
+    return {
+      page: result.page.map((row) => ({
+        _id: row._id,
+        userId: row.userId,
+        dodoSubscriptionId: row.dodoSubscriptionId,
+        currentPeriodEnd: row.currentPeriodEnd,
+        lastReconcileAttemptAt: row.lastReconcileAttemptAt,
+        reconcileFailureCount: row.reconcileFailureCount,
+        reconcileNotFoundCount: row.reconcileNotFoundCount,
+      })),
+      continueCursor: result.continueCursor,
+      isDone: result.isDone,
+    };
   },
 });
 
@@ -607,6 +622,10 @@ export const markDodoReconcileAttempt = internalMutation({
   args: {
     subscriptionId: v.id("subscriptions"),
     observedAt: v.number(),
+    // Whether THIS attempt was a definitive Dodo 404. Advances the
+    // consecutive-not-found counter that gates the terminal downgrade; a
+    // non-404 attempt resets that streak (a 404 must REPEAT consecutively).
+    notFound: v.boolean(),
   },
   handler: async (ctx, args) => {
     const existing = await ctx.db.get(args.subscriptionId);
@@ -614,6 +633,9 @@ export const markDodoReconcileAttempt = internalMutation({
     await ctx.db.patch(args.subscriptionId, {
       lastReconcileAttemptAt: args.observedAt,
       reconcileFailureCount: (existing.reconcileFailureCount ?? 0) + 1,
+      reconcileNotFoundCount: args.notFound
+        ? (existing.reconcileNotFoundCount ?? 0) + 1
+        : 0,
     });
   },
 });
@@ -665,6 +687,9 @@ export const applyDodoSubscriptionReconciliation = internalMutation({
       await ctx.db.patch(existing._id, {
         lastReconcileAttemptAt: args.observedAt,
         reconcileFailureCount: (existing.reconcileFailureCount ?? 0) + 1,
+        // These skips prove the sub still EXISTS in Dodo, so any prior 404
+        // streak is broken.
+        reconcileNotFoundCount: 0,
       });
     };
 
@@ -716,16 +741,20 @@ export const applyDodoSubscriptionReconciliation = internalMutation({
       dodoCustomerId: args.remote.dodoCustomerId ?? existing.dodoCustomerId,
       rawPayload: args.remote.rawPayload,
       updatedAt: args.observedAt,
+      // A successful lookup proves the sub EXISTS in Dodo → any 404 streak is
+      // broken (reset to 0 while still stale, cleared once it leaves the set).
       ...(stillStaleAfterPatch
         ? {
             lastReconcileAttemptAt: args.observedAt,
             reconcileFailureCount: (existing.reconcileFailureCount ?? 0) + 1,
+            reconcileNotFoundCount: 0,
           }
         : {
             // Row left the stale-active set — clear bookkeeping so a later miss
             // starts from a clean slate.
             lastReconcileAttemptAt: undefined,
             reconcileFailureCount: undefined,
+            reconcileNotFoundCount: undefined,
           }),
       ...(args.remote.status === "cancelled"
         ? { cancelledAt: args.remote.cancelledAt ?? existing.cancelledAt ?? args.observedAt }
@@ -785,6 +814,7 @@ export const expireMissingDodoSubscription = internalMutation({
       updatedAt: args.observedAt,
       lastReconcileAttemptAt: undefined,
       reconcileFailureCount: undefined,
+      reconcileNotFoundCount: undefined,
     });
     await recomputeEntitlementFromAllSubs(ctx, existing.userId, args.observedAt);
     return { kind: "expired" };
@@ -793,9 +823,13 @@ export const expireMissingDodoSubscription = internalMutation({
 
 type StaleRowOutcome =
   | { kind: "reconciled" }
-  | { kind: "expired" }
   | { kind: "skipped" }
-  | { kind: "failed"; error: string };
+  | { kind: "failed"; error: string }
+  // Confirmed terminal not-found (definitive 404 past the confirmation
+  // threshold). The row is NOT downgraded here — the action loop decides,
+  // gated by the mass-404 circuit breaker, whether to expire it or route it to
+  // the backoff path.
+  | { kind: "terminal_not_found"; error: string };
 
 // Best-effort backoff bookkeeping for the paths that never reach
 // `applyDodoSubscriptionReconciliation` (Dodo lookup failure, unsupported/pending
@@ -805,11 +839,13 @@ export async function safeMarkReconcileAttempt(
   ctx: Pick<ActionCtx, "runMutation">,
   subscriptionId: Id<"subscriptions">,
   observedAt: number,
+  notFound: boolean,
 ): Promise<void> {
   try {
     await ctx.runMutation(internal.payments.billing.markDodoReconcileAttempt, {
       subscriptionId,
       observedAt,
+      notFound,
     });
   } catch (markErr) {
     // sentry-coverage-ok: structured console.error is forwarded by Convex
@@ -865,8 +901,8 @@ async function reconcileOneStaleRow(
       console.error(
         `[billing/reconcile] Skipping subscription ${normalized.dodoSubscriptionId}: ${normalized.reason} Dodo status "${normalized.status}"`,
       );
-      // Row is still stale-active — back it off.
-      await safeMarkReconcileAttempt(ctx, sub._id, now);
+      // Row is still stale-active — back it off (not a 404, resets the streak).
+      await safeMarkReconcileAttempt(ctx, sub._id, now, false);
       return { kind: "skipped" };
     }
 
@@ -883,43 +919,29 @@ async function reconcileOneStaleRow(
     return result.kind === "reconciled" ? { kind: "reconciled" } : { kind: "skipped" };
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    // Confirmed terminal not-found: the subscription no longer exists in Dodo.
-    // Only after >= the confirmation threshold of prior failures so a single
-    // flaky 404 can't downgrade a paying customer. Downgrade the row to expired
-    // so it leaves the active set permanently.
+    const notFound = isDefinitiveDodoNotFound(err);
+    // Confirmed terminal not-found: a definitive 404 AND the row already has
+    // >= the confirmation threshold of CONSECUTIVE prior 404s (so a single
+    // flaky 404 — or a 404 preceded by an unrelated 5xx — can't downgrade a
+    // paying customer). Hand it to the loop, which applies the mass-404 circuit
+    // breaker before actually downgrading. Do NOT back it off here — the loop
+    // either downgrades it or routes it to backoff.
     if (
-      isDefinitiveDodoNotFound(err) &&
-      (sub.reconcileFailureCount ?? 0) >= DODO_RENEWAL_TERMINAL_NOTFOUND_MIN_PRIOR_FAILURES
+      notFound &&
+      (sub.reconcileNotFoundCount ?? 0) >= DODO_RENEWAL_TERMINAL_NOTFOUND_MIN_PRIOR_FAILURES
     ) {
-      const expireResult = (await ctx.runMutation(
-        internal.payments.billing.expireMissingDodoSubscription,
-        {
-          subscriptionId: sub._id,
-          dodoSubscriptionId: sub.dodoSubscriptionId,
-          observedAt: now,
-        },
-      )) as { kind: "expired" } | { kind: "skipped"; reason: ReconciliationSkipReason };
-      if (expireResult.kind === "expired") {
-        // sentry-coverage-ok: structured console.error is forwarded by Convex
-        // auto-Sentry so ops sees confirmed-gone subscriptions being downgraded
-        // (also the signal that would spike on a wrong-environment misconfig).
-        console.error(
-          `[billing/reconcile] dodoSubscriptionId=${sub.dodoSubscriptionId} userId=${sub.userId} confirmed not-found in Dodo after ${(sub.reconcileFailureCount ?? 0) + 1} attempts; downgraded local row to expired.`,
-        );
-        return { kind: "expired" };
-      }
-      // A concurrent webhook already moved the row out of the stale-active set.
-      return { kind: "skipped" };
+      return { kind: "terminal_not_found", error: message };
     }
-    // Transient (5xx / network / timeout) OR an unconfirmed first 404 → back off
-    // and retry; never downgrade on an ambiguous signal.
+    // Transient (5xx / network / timeout) OR an unconfirmed 404 → back off and
+    // retry; never downgrade on an ambiguous signal. Pass `notFound` so a 404
+    // advances the consecutive-404 streak while any other failure resets it.
     // sentry-coverage-ok: structured console.error is forwarded by Convex
     // auto-Sentry. We intentionally do not re-throw here because one bad Dodo
     // lookup must not block reconciliation for other stale subscribers.
     console.error(
       `[billing/reconcile] Failed to reconcile dodoSubscriptionId=${sub.dodoSubscriptionId} userId=${sub.userId}: ${message}`,
     );
-    await safeMarkReconcileAttempt(ctx, sub._id, now);
+    await safeMarkReconcileAttempt(ctx, sub._id, now, notFound);
     return { kind: "failed", error: message };
   }
 }
@@ -932,10 +954,10 @@ export const reconcileMissedDodoRenewals = internalAction({
     // fresh cron tick omits it (defaults to the max) and each continuation
     // passes one fewer. Bounds total work + guarantees termination.
     continuationBudget: v.optional(v.number()),
-    // Scan resume cursor (currentPeriodEnd) threaded through continuations to
-    // page PAST a window already drained or saturated by backoff — see the
-    // scheduling block. Omitted on a fresh cron tick.
-    cursorPeriodEnd: v.optional(v.number()),
+    // Opaque Convex pagination cursor threaded through continuations to page
+    // forward by document position — see the scheduling block. Omitted on a
+    // fresh cron tick.
+    cursor: v.optional(v.union(v.string(), v.null())),
     // Per-query scan window size, clamped to the const ceiling. Defaults to the
     // ceiling; a smaller value is an ops knob (and the test seam that exercises
     // the window-paging / saturation logic without seeding 500 rows). Threaded
@@ -986,20 +1008,19 @@ export const reconcileMissedDodoRenewals = internalAction({
     const continuationBudget =
       args.continuationBudget ?? DODO_RENEWAL_RECONCILIATION_MAX_CONTINUATIONS;
 
-    const scanned = (await ctx.runQuery(
+    const scanResult = (await ctx.runQuery(
       internal.payments.billing.listStaleActiveSubscriptionsForRenewalReconciliation,
       {
         now,
         scanLimit,
-        ...(args.cursorPeriodEnd !== undefined
-          ? { cursorPeriodEnd: args.cursorPeriodEnd }
-          : {}),
+        ...(args.cursor !== undefined ? { cursor: args.cursor } : {}),
       },
-    )) as StaleActiveSubscriptionForRenewalReconciliation[];
+    )) as StaleActiveSubscriptionsPage;
+    const page = scanResult.page;
 
     // Skip rows still inside their post-failure backoff window so a
     // permanently-failing (poison) row can't re-occupy a scan slot every run.
-    const eligible = scanned.filter((sub) => isReconcileEligible(sub, now));
+    const eligible = page.filter((sub) => isReconcileEligible(sub, now));
 
     const remoteById = new Map(
       (args.remoteSubscriptionsForTest ?? []).map((remote) => [
@@ -1035,6 +1056,17 @@ export const reconcileMissedDodoRenewals = internalAction({
       failures: [],
     };
 
+    // Mass-404 circuit breaker budget, sized to the work we plan to attempt this
+    // invocation: a genuine handful of deleted subs downgrades; a batch that is
+    // mostly/entirely 404 (a probable misconfig) self-halts at the threshold.
+    const plannedAttempts = Math.min(limit, eligible.length);
+    const maxNotFoundDowngrades = Math.min(
+      DODO_RENEWAL_MASS_NOTFOUND_ABSOLUTE_CAP,
+      Math.ceil(plannedAttempts / 2),
+    );
+    let notFoundDowngrades = 0;
+    let massNotFoundHalted = false;
+
     let attempted = 0;
     for (const sub of eligible) {
       if (attempted >= limit) {
@@ -1059,9 +1091,6 @@ export const reconcileMissedDodoRenewals = internalAction({
         case "reconciled":
           summary.reconciled++;
           break;
-        case "expired":
-          summary.expiredMissing++;
-          break;
         case "skipped":
           summary.skipped++;
           break;
@@ -1072,41 +1101,82 @@ export const reconcileMissedDodoRenewals = internalAction({
             error: outcome.error,
           });
           break;
+        case "terminal_not_found": {
+          if (notFoundDowngrades >= maxNotFoundDowngrades) {
+            // Circuit breaker tripped — too many confirmed 404s this run. Treat
+            // this (and every subsequent 404) as a transient failure: keep the
+            // row active and on backoff instead of downgrading a possibly-live
+            // customer during a suspected wrong-environment/API-key misconfig.
+            if (!massNotFoundHalted) {
+              massNotFoundHalted = true;
+              // sentry-coverage-ok: Convex auto-Sentry captures console.error —
+              // this is the page that must fire BEFORE a second daily run could
+              // downgrade the base under a config error.
+              console.error(
+                `[billing/reconcile] mass Dodo 404s (${notFoundDowngrades + 1}/${attempted} attempted) — possible wrong-environment/API-key misconfig; further downgrades halted this run.`,
+              );
+            }
+            summary.failed++;
+            summary.failures.push({
+              dodoSubscriptionId: sub.dodoSubscriptionId,
+              error: outcome.error,
+            });
+            // Still a 404 — keep the streak so it downgrades once the breaker
+            // clears (config fixed), rather than resetting confirmation.
+            await safeMarkReconcileAttempt(ctx, sub._id, now, true);
+            break;
+          }
+          const expireResult = (await ctx.runMutation(
+            internal.payments.billing.expireMissingDodoSubscription,
+            {
+              subscriptionId: sub._id,
+              dodoSubscriptionId: sub.dodoSubscriptionId,
+              observedAt: now,
+            },
+          )) as { kind: "expired" } | { kind: "skipped"; reason: ReconciliationSkipReason };
+          if (expireResult.kind === "expired") {
+            notFoundDowngrades++;
+            summary.expiredMissing++;
+            // sentry-coverage-ok: Convex auto-Sentry captures console.error so
+            // ops sees confirmed-gone subscriptions being downgraded.
+            console.error(
+              `[billing/reconcile] dodoSubscriptionId=${sub.dodoSubscriptionId} userId=${sub.userId} confirmed not-found in Dodo after ${(sub.reconcileFailureCount ?? 0) + 1} attempts; downgraded local row to expired.`,
+            );
+          } else {
+            // A concurrent webhook already moved the row out of the stale set.
+            summary.skipped++;
+          }
+          break;
+        }
       }
     }
 
-    const scanWasFull = scanned.length >= scanLimit;
-    // Every eligible row in this window has been attempted (we didn't stop on
-    // the batch/time budget), but the window was full so more rows — eligible or
-    // not — may sort beyond it. Also fires the "saturated" case (eligible was
-    // empty: all scanned rows are inside their backoff window).
-    const windowDrainedButFull = scanWasFull && eligible.length <= attempted;
-    summary.windowSaturated = scanWasFull && eligible.length === 0;
+    // Did we finish this page's eligible rows (none left un-attempted due to the
+    // batch/time budget)? If so, and more pages exist, page forward via the
+    // opaque cursor. Otherwise keep the cursor so the continuation re-fetches
+    // this page and finishes draining it — the rows we just attempted are backed
+    // off now, so the eligible set strictly shrinks.
+    const pageDrained = eligible.length <= attempted;
+    const advanceToNextPage = pageDrained && !scanResult.isDone;
+    // Whole non-empty page was ineligible (all inside their backoff window) and
+    // more pages remain — surfaced so an operator can tell "cooldown-saturated"
+    // from "nothing stale". Position-based paging advances past it regardless,
+    // so it never strands the rows behind it.
+    summary.windowSaturated = page.length > 0 && eligible.length === 0 && !scanResult.isDone;
 
     if (summary.windowSaturated) {
-      // Distinguishable from an idle cron: the read budget was spent but every
-      // stale row in the window is cooling down. The cursor advances past it
-      // below so healthy rows sorted behind the poison window still get reached.
+      // sentry-coverage-ok: Convex auto-Sentry captures console.error.
       console.error(
-        `[billing/reconcile] scan window saturated: all ${scanned.length} scanned stale rows are within their reconcile backoff window; advancing scan cursor past currentPeriodEnd<=${scanned[scanned.length - 1]?.currentPeriodEnd} to reach rows behind them.`,
+        `[billing/reconcile] scan page saturated: all ${page.length} scanned stale rows are within their reconcile backoff window; paging forward to reach rows behind them.`,
       );
     }
 
-    // Cursor advance: page PAST this window (its eligible rows are all attempted
-    // or it's fully backed-off) so the next invocation reads new rows instead of
-    // re-scanning the same stalest window. When there are still un-attempted
-    // eligible rows in THIS window (we stopped on the batch/time budget), keep
-    // the cursor so the continuation re-scans and finishes draining it — those
-    // rows are backed off now, so the eligible set strictly shrinks.
-    // `scanned` is currentPeriodEnd-ascending, so its last element is the max.
-    const nextCursorPeriodEnd = windowDrainedButFull
-      ? scanned[scanned.length - 1]!.currentPeriodEnd
-      : args.cursorPeriodEnd;
-    const cursorAdvanced = nextCursorPeriodEnd !== args.cursorPeriodEnd;
+    const nextCursor = advanceToNextPage ? scanResult.continueCursor : args.cursor;
+    const cursorAdvanced = advanceToNextPage;
 
-    // More work remains if we couldn't attempt every eligible row in this
-    // window, or the window was full (rows may sort beyond it).
-    summary.hasMore = eligible.length > attempted || scanWasFull;
+    // More work remains if we couldn't attempt every eligible row on this page,
+    // or more pages exist beyond it.
+    summary.hasMore = eligible.length > attempted || !scanResult.isDone;
 
     if (summary.failed > 0) {
       console.error(
@@ -1116,10 +1186,10 @@ export const reconcileMissedDodoRenewals = internalAction({
 
     // Chain a continuation when work remains AND we are guaranteed to make
     // progress next invocation: either we attempted rows this pass (the current
-    // window's eligible set shrank) or the cursor advanced (the next scan reads
-    // a strictly higher currentPeriodEnd range). Advancing on a saturated window
-    // is what stops a fully-backed-off window from silently stranding the
-    // healthy rows behind it. `continuationBudget` is the hard termination cap.
+    // page's eligible set shrank) or the cursor advanced to a new page.
+    // Advancing on a saturated page is what stops a fully-backed-off page from
+    // silently stranding the healthy rows behind it. `continuationBudget` is the
+    // hard termination cap.
     if (
       summary.hasMore &&
       continuationBudget > 0 &&
@@ -1133,9 +1203,7 @@ export const reconcileMissedDodoRenewals = internalAction({
           limit,
           scanLimit,
           continuationBudget: continuationBudget - 1,
-          ...(nextCursorPeriodEnd !== undefined
-            ? { cursorPeriodEnd: nextCursorPeriodEnd }
-            : {}),
+          cursor: nextCursor ?? null,
           ...(args.remoteSubscriptionsForTest
             ? { remoteSubscriptionsForTest: args.remoteSubscriptionsForTest }
             : {}),

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -19,7 +19,7 @@ import { resolveUserId, requireUserId } from "../lib/auth";
 import { getFeaturesForPlan } from "../lib/entitlements";
 import { ANON_ID_V4_REGEX, verifyAnonClaimToken } from "../lib/identitySigning";
 import { PRODUCT_CATALOG, resolveProductToPlan } from "../config/productCatalog";
-import { recomputeEntitlementFromAllSubs } from "./subscriptionHelpers";
+import { isNewerEvent, recomputeEntitlementFromAllSubs, resolvePlanKey } from "./subscriptionHelpers";
 
 // ---------------------------------------------------------------------------
 // Shared SDK config (direct REST SDK, not the Convex component from lib/dodo.ts)
@@ -54,9 +54,47 @@ function getDodoClient(
   });
 }
 
+// Max Dodo lookups attempted per action INVOCATION (each retrieve is a paid
+// REST round-trip). The daily cron drains a larger backlog across continuation
+// invocations (see MAX_CONTINUATIONS).
 const DODO_RENEWAL_RECONCILIATION_BATCH_SIZE = 50;
+// Max candidate rows the stale-scan query returns per call. Bounds the query's
+// read cost and, more importantly, must comfortably exceed the number of
+// permanently-failing (poison) rows so healthy stale rows ordered behind them
+// are still within the scanned window. Realistic poison volume (test-mode-era
+// subs) is far under this; a backlog that ever exceeds it is drained across
+// daily runs as reconciled rows leave the set.
+const DODO_RENEWAL_RECONCILIATION_SCAN_LIMIT = 500;
 const DODO_RENEWAL_RECONCILIATION_TIMEOUT_MS = 10_000;
-const DODO_RECONCILIATION_FALLBACK_PLAN_KEY = "enterprise";
+// Wall-clock budget per invocation. Worst case a full batch of slow Dodo
+// lookups (retry/timeout) could exceed Convex's 10-min action cap, so we bail
+// with a summary and continuation-schedule the remainder well before it.
+const DODO_RENEWAL_RECONCILIATION_TIME_BUDGET_MS = 8 * 60 * 1000;
+// Hard ceiling on self-scheduled continuations per cron cycle. Bounds total
+// Dodo calls to MAX_CONTINUATIONS * BATCH_SIZE and guarantees termination.
+const DODO_RENEWAL_RECONCILIATION_MAX_CONTINUATIONS = 25;
+// Exponential backoff applied to a row after a failed/no-progress reconcile
+// attempt so a permanently-failing row is retried geometrically less often
+// (base after the 1st failure, doubling, capped) instead of every run.
+const DODO_RENEWAL_RECONCILIATION_BACKOFF_BASE_MS = 2 * 24 * 60 * 60 * 1000;
+const DODO_RENEWAL_RECONCILIATION_BACKOFF_MAX_MS = 30 * 24 * 60 * 60 * 1000;
+
+function reconcileBackoffMs(failureCount: number): number {
+  if (failureCount <= 0) return 0;
+  const exponent = Math.min(failureCount - 1, 5);
+  return Math.min(
+    DODO_RENEWAL_RECONCILIATION_BACKOFF_BASE_MS * 2 ** exponent,
+    DODO_RENEWAL_RECONCILIATION_BACKOFF_MAX_MS,
+  );
+}
+
+function isReconcileEligible(
+  candidate: { lastReconcileAttemptAt?: number; reconcileFailureCount?: number },
+  now: number,
+): boolean {
+  if (candidate.lastReconcileAttemptAt == null) return true;
+  return now - candidate.lastReconcileAttemptAt >= reconcileBackoffMs(candidate.reconcileFailureCount ?? 0);
+}
 
 const dodoReconciliationRemoteSubscriptionValidator = v.object({
   subscription_id: v.string(),
@@ -97,6 +135,9 @@ type StaleActiveSubscriptionForRenewalReconciliation = {
   _id: Id<"subscriptions">;
   userId: string;
   dodoSubscriptionId: string;
+  currentPeriodEnd: number;
+  lastReconcileAttemptAt?: number;
+  reconcileFailureCount?: number;
 };
 
 type ReconciliationMutationResult =
@@ -115,6 +156,8 @@ type ReconciliationSummary = {
   failed: number;
   limit: number;
   hasMore: boolean;
+  timeBudgetExhausted: boolean;
+  continuationScheduled: boolean;
   failures: Array<{ dodoSubscriptionId: string; error: string }>;
 };
 
@@ -125,7 +168,18 @@ function normalizeDodoStatus(status: string): LocalSubscriptionStatus | null {
     case "cancelled":
     case "expired":
       return status;
+    case "failed":
+      // Dodo `failed` = the subscription's mandate/payment permanently failed.
+      // The SDK `SubscriptionStatus` union carries it separately from `expired`,
+      // but locally it means the same thing: no longer covering. Map to
+      // `expired` so `recomputeEntitlementFromAllSubs` downgrades the user
+      // (a local-active row would otherwise keep full entitlement forever via
+      // `isCoveringAt`).
+      return "expired";
     default:
+      // `pending` and any unknown status → caller skips + escalates. `pending`
+      // is a real SDK status (initial payment in flight) but not a state we act
+      // on from the reconciler.
       return null;
   }
 }
@@ -144,7 +198,8 @@ function normalizeRemoteSubscription(
   const status = normalizeDodoStatus(remote.status);
   if (!status) {
     return {
-      kind: "unsupported-status" as const,
+      kind: "skip" as const,
+      reason: remote.status === "pending" ? ("pending" as const) : ("unsupported-status" as const),
       status: remote.status,
       dodoSubscriptionId: remote.subscription_id,
     };
@@ -440,10 +495,10 @@ export const getDodoCustomerIdForUserPortal = internalQuery({
 export const listStaleActiveSubscriptionsForRenewalReconciliation = internalQuery({
   args: {
     now: v.number(),
-    limit: v.number(),
+    scanLimit: v.number(),
   },
   handler: async (ctx, args) => {
-    return await ctx.db
+    const rows = await ctx.db
       .query("subscriptions")
       // Reuses the by_status_currentPeriodEnd index added by the dunning/
       // winback work (#4935) — same ["status","currentPeriodEnd"] shape, so
@@ -452,7 +507,46 @@ export const listStaleActiveSubscriptionsForRenewalReconciliation = internalQuer
         q.eq("status", "active").lt("currentPeriodEnd", args.now),
       )
       .order("asc")
-      .take(args.limit);
+      .take(args.scanLimit);
+    // Slim projection — the action only needs identity + the reconcile
+    // bookkeeping fields to decide eligibility. Dropping `rawPayload` (v.any(),
+    // potentially large) keeps the query→action transfer bounded.
+    return rows.map((row) => ({
+      _id: row._id,
+      userId: row.userId,
+      dodoSubscriptionId: row.dodoSubscriptionId,
+      currentPeriodEnd: row.currentPeriodEnd,
+      lastReconcileAttemptAt: row.lastReconcileAttemptAt,
+      reconcileFailureCount: row.reconcileFailureCount,
+    }));
+  },
+});
+
+/**
+ * Marks a reconcile attempt on a stale-active subscription row: bumps
+ * `reconcileFailureCount` and stamps `lastReconcileAttemptAt`. Called for every
+ * NO-PROGRESS outcome (failed Dodo lookup, unsupported/pending remote status,
+ * remote-not-newer on a still-stale row) so the exponential backoff in
+ * `isReconcileEligible` de-prioritises permanently-failing rows and they stop
+ * hogging the scan window.
+ *
+ * Deliberately does NOT touch `updatedAt` — that field carries webhook
+ * ordering semantics (`isNewerEvent`) and must not be perturbed by a
+ * bookkeeping write. Skips rows a concurrent webhook already moved out of the
+ * active set.
+ */
+export const markDodoReconcileAttempt = internalMutation({
+  args: {
+    subscriptionId: v.id("subscriptions"),
+    observedAt: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const existing = await ctx.db.get(args.subscriptionId);
+    if (!existing || existing.status !== "active") return;
+    await ctx.db.patch(args.subscriptionId, {
+      lastReconcileAttemptAt: args.observedAt,
+      reconcileFailureCount: (existing.reconcileFailureCount ?? 0) + 1,
+    });
   },
 });
 
@@ -488,6 +582,16 @@ export const applyDodoSubscriptionReconciliation = internalMutation({
       );
     }
 
+    // Out-of-order guard, identical to every webhook handler. Between the
+    // stale-scan read and this mutation a concurrent lifecycle webhook (e.g.
+    // `subscription.plan_changed`, which patches planKey/productId but NOT
+    // currentPeriodEnd) may have written a newer state. Our `observedAt` is the
+    // cron's read time; if the row was updated at/after it, the cron holds a
+    // stale snapshot and must not clobber the webhook's write.
+    if (!isNewerEvent(existing.updatedAt, args.observedAt)) {
+      return { kind: "skipped", reason: "local_updated_concurrently" };
+    }
+
     if (existing.status !== "active" || existing.currentPeriodEnd >= args.observedAt) {
       return { kind: "skipped", reason: "local_no_longer_stale" };
     }
@@ -501,24 +605,13 @@ export const applyDodoSubscriptionReconciliation = internalMutation({
       return { kind: "skipped", reason: "remote_not_newer" };
     }
 
+    // Reuse the shared webhook resolver so reconciliation and organic webhook
+    // ingestion resolve a Dodo product ID to a plan key IDENTICALLY —
+    // productPlans table → LEGACY_PRODUCT_ALIASES → enterprise over-grant
+    // fallback (with the same structured console.error escalation).
     let planKey = existing.planKey;
     if (args.remote.productId !== existing.dodoProductId) {
-      const mapping = await ctx.db
-        .query("productPlans")
-        .withIndex("by_dodoProductId", (q) =>
-          q.eq("dodoProductId", args.remote.productId),
-        )
-        .first();
-      const mappedPlanKey =
-        mapping?.planKey ?? resolveProductToPlan(args.remote.productId);
-      if (mappedPlanKey) {
-        planKey = mappedPlanKey;
-      } else {
-        planKey = DODO_RECONCILIATION_FALLBACK_PLAN_KEY;
-        console.error(
-          `[billing/reconcile] Unknown Dodo product ID "${args.remote.productId}" for subscription ${args.remote.dodoSubscriptionId}; falling back to "${DODO_RECONCILIATION_FALLBACK_PLAN_KEY}" so a paid customer is not under-granted while catalog mapping is fixed.`,
-        );
-      }
+      planKey = await resolvePlanKey(ctx, args.remote.productId);
     }
 
     await ctx.db.patch(existing._id, {
@@ -530,6 +623,10 @@ export const applyDodoSubscriptionReconciliation = internalMutation({
       dodoCustomerId: args.remote.dodoCustomerId ?? existing.dodoCustomerId,
       rawPayload: args.remote.rawPayload,
       updatedAt: args.observedAt,
+      // Clear reconcile bookkeeping — this row made progress and (usually)
+      // leaves the stale-active set; a later miss starts from a clean slate.
+      lastReconcileAttemptAt: undefined,
+      reconcileFailureCount: undefined,
       ...(args.remote.status === "cancelled"
         ? { cancelledAt: args.remote.cancelledAt ?? existing.cancelledAt ?? args.observedAt }
         : {}),
@@ -549,6 +646,10 @@ export const reconcileMissedDodoRenewals = internalAction({
   args: {
     now: v.optional(v.number()),
     limit: v.optional(v.number()),
+    // Remaining self-scheduled continuations this cron cycle. Internal — a
+    // fresh cron tick omits it (defaults to the max) and each continuation
+    // passes one fewer. Bounds total work + guarantees termination.
+    continuationBudget: v.optional(v.number()),
     remoteSubscriptionsForTest: v.optional(
       v.array(dodoReconciliationRemoteSubscriptionValidator),
     ),
@@ -560,7 +661,11 @@ export const reconcileMissedDodoRenewals = internalAction({
       );
     }
 
+    // Logical clock for staleness + backoff (threaded unchanged through
+    // continuations so a cycle stays coherent). Wall-clock is tracked
+    // separately below for the action-runtime budget.
     const now = args.now ?? Date.now();
+    const startedAtWallClock = Date.now();
     const limit = Math.max(
       1,
       Math.min(
@@ -568,10 +673,17 @@ export const reconcileMissedDodoRenewals = internalAction({
         DODO_RENEWAL_RECONCILIATION_BATCH_SIZE,
       ),
     );
-    const stale = (await ctx.runQuery(
+    const continuationBudget =
+      args.continuationBudget ?? DODO_RENEWAL_RECONCILIATION_MAX_CONTINUATIONS;
+
+    const scanned = (await ctx.runQuery(
       internal.payments.billing.listStaleActiveSubscriptionsForRenewalReconciliation,
-      { now, limit },
+      { now, scanLimit: DODO_RENEWAL_RECONCILIATION_SCAN_LIMIT },
     )) as StaleActiveSubscriptionForRenewalReconciliation[];
+
+    // Skip rows still inside their post-failure backoff window so a
+    // permanently-failing (poison) row can't re-occupy a scan slot every run.
+    const eligible = scanned.filter((sub) => isReconcileEligible(sub, now));
 
     const remoteById = new Map(
       (args.remoteSubscriptionsForTest ?? []).map((remote) => [
@@ -586,17 +698,37 @@ export const reconcileMissedDodoRenewals = internalAction({
           maxRetries: 1,
         });
 
-    const summary = {
-      inspected: stale.length,
+    const summary: ReconciliationSummary = {
+      inspected: 0,
       reconciled: 0,
       skipped: 0,
       failed: 0,
       limit,
-      hasMore: stale.length === limit,
-      failures: [] as Array<{ dodoSubscriptionId: string; error: string }>,
+      hasMore: false,
+      timeBudgetExhausted: false,
+      continuationScheduled: false,
+      failures: [],
     };
 
-    for (const sub of stale) {
+    const markAttempt = (subscriptionId: Id<"subscriptions">) =>
+      ctx.runMutation(internal.payments.billing.markDodoReconcileAttempt, {
+        subscriptionId,
+        observedAt: now,
+      });
+
+    let attempted = 0;
+    for (const sub of eligible) {
+      if (attempted >= limit) {
+        summary.hasMore = true;
+        break;
+      }
+      if (Date.now() - startedAtWallClock >= DODO_RENEWAL_RECONCILIATION_TIME_BUDGET_MS) {
+        summary.timeBudgetExhausted = true;
+        summary.hasMore = true;
+        break;
+      }
+      attempted++;
+      summary.inspected++;
       try {
         const remote = args.remoteSubscriptionsForTest
           ? remoteById.get(sub.dodoSubscriptionId)
@@ -606,11 +738,17 @@ export const reconcileMissedDodoRenewals = internalAction({
         }
 
         const normalized = normalizeRemoteSubscription(remote);
-        if (normalized.kind === "unsupported-status") {
+        if (normalized.kind === "skip") {
           summary.skipped++;
-          console.warn(
-            `[billing/reconcile] Skipping subscription ${normalized.dodoSubscriptionId}: unsupported Dodo status "${normalized.status}"`,
+          // sentry-coverage-ok: escalated to error (Convex auto-Sentry captures
+          // error, not warn) so a `pending`/unknown remote status that a
+          // local-active row is stuck on gets triaged rather than silently
+          // skipped daily.
+          console.error(
+            `[billing/reconcile] Skipping subscription ${normalized.dodoSubscriptionId}: ${normalized.reason} Dodo status "${normalized.status}"`,
           );
+          // Row is still stale-active — back it off.
+          await markAttempt(sub._id);
           continue;
         }
 
@@ -627,6 +765,12 @@ export const reconcileMissedDodoRenewals = internalAction({
           summary.reconciled++;
         } else {
           summary.skipped++;
+          // `remote_not_newer` / `local_updated_concurrently` leave the row
+          // stale-active with no change — back off so it doesn't hog a slot
+          // every run. `local_no_longer_stale` already left the set.
+          if (result.reason !== "local_no_longer_stale") {
+            await markAttempt(sub._id);
+          }
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -641,13 +785,38 @@ export const reconcileMissedDodoRenewals = internalAction({
         console.error(
           `[billing/reconcile] Failed to reconcile dodoSubscriptionId=${sub.dodoSubscriptionId} userId=${sub.userId}: ${message}`,
         );
+        // Poison row (e.g. test-mode-era sub 404ing the live client) — back off.
+        await markAttempt(sub._id);
       }
+    }
+
+    // More work remains if we couldn't attempt every eligible row, or the scan
+    // hit its cap (rows may exist beyond the window). We only chain when we made
+    // forward progress this invocation (attempted > 0) to guarantee termination.
+    if (eligible.length > attempted || scanned.length >= DODO_RENEWAL_RECONCILIATION_SCAN_LIMIT) {
+      summary.hasMore = true;
     }
 
     if (summary.failed > 0) {
       console.error(
-        `[billing/reconcile] ${summary.failed}/${summary.inspected} stale active subscriptions failed reconciliation`,
+        `[billing/reconcile] ${summary.failed}/${summary.inspected} attempted stale active subscriptions failed reconciliation`,
       );
+    }
+
+    if (summary.hasMore && attempted > 0 && continuationBudget > 0) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.payments.billing.reconcileMissedDodoRenewals,
+        {
+          now,
+          limit,
+          continuationBudget: continuationBudget - 1,
+          ...(args.remoteSubscriptionsForTest
+            ? { remoteSubscriptionsForTest: args.remoteSubscriptionsForTest }
+            : {}),
+        },
+      );
+      summary.continuationScheduled = true;
     }
 
     return summary;

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -58,30 +58,40 @@ function getDodoClient(
 // REST round-trip). The daily cron drains a larger backlog across continuation
 // invocations (see MAX_CONTINUATIONS).
 const DODO_RENEWAL_RECONCILIATION_BATCH_SIZE = 50;
-// Max candidate rows the stale-scan query returns per call. Bounds the query's
-// read cost and, more importantly, must comfortably exceed the number of
-// permanently-failing (poison) rows so healthy stale rows ordered behind them
-// are still within the scanned window. Realistic poison volume (test-mode-era
-// subs) is far under this; a backlog that ever exceeds it is drained across
-// daily runs as reconciled rows leave the set.
+// Max candidate rows the stale-scan query returns per call. Bounds each query's
+// read cost. Continuations page forward via a currentPeriodEnd cursor (see the
+// scheduling block), so a backlog larger than this — or a window fully within
+// its backoff — no longer strands healthy rows behind it: the cursor advances
+// past a drained/saturated window to the next one. The only repeated scan is
+// re-reading the SAME window while draining its eligible rows in batches of
+// `limit` (bounded by that window's eligible count), after which the cursor
+// moves on.
 const DODO_RENEWAL_RECONCILIATION_SCAN_LIMIT = 500;
 const DODO_RENEWAL_RECONCILIATION_TIMEOUT_MS = 10_000;
 // Wall-clock budget per invocation. Worst case a full batch of slow Dodo
 // lookups (retry/timeout) could exceed Convex's 10-min action cap, so we bail
 // with a summary and continuation-schedule the remainder well before it.
 const DODO_RENEWAL_RECONCILIATION_TIME_BUDGET_MS = 8 * 60 * 1000;
-// Hard ceiling on self-scheduled continuations per cron cycle. Bounds total
-// Dodo calls to MAX_CONTINUATIONS * BATCH_SIZE and guarantees termination.
+// Hard ceiling on self-scheduled continuations per cron cycle. The chain is the
+// initial invocation plus continuations at budget MAX_CONTINUATIONS-1..0, so it
+// bounds total Dodo calls to (MAX_CONTINUATIONS + 1) * BATCH_SIZE and guarantees
+// termination.
 const DODO_RENEWAL_RECONCILIATION_MAX_CONTINUATIONS = 25;
-// Exponential backoff applied to a row after a failed/no-progress reconcile
-// attempt so a permanently-failing row is retried geometrically less often
-// (base after the 1st failure, doubling, capped) instead of every run.
+// Backoff after a failed/no-progress reconcile attempt. The FIRST failure backs
+// off only a few hours — enough to skip the rest of the current cron cycle's
+// continuations (same `now`) but short enough that a transient Dodo error still
+// gets retried at the very next daily run, so it does not over-delay a
+// legitimate downgrade of a lapsed sub. Repeated failures then back off
+// exponentially (2d, 4d, 8d, … capped) so a permanently-failing row is retried
+// geometrically less often instead of hogging a scan slot every run.
+const DODO_RENEWAL_RECONCILIATION_BACKOFF_FIRST_MS = 6 * 60 * 60 * 1000;
 const DODO_RENEWAL_RECONCILIATION_BACKOFF_BASE_MS = 2 * 24 * 60 * 60 * 1000;
 const DODO_RENEWAL_RECONCILIATION_BACKOFF_MAX_MS = 30 * 24 * 60 * 60 * 1000;
 
 function reconcileBackoffMs(failureCount: number): number {
   if (failureCount <= 0) return 0;
-  const exponent = Math.min(failureCount - 1, 5);
+  if (failureCount === 1) return DODO_RENEWAL_RECONCILIATION_BACKOFF_FIRST_MS;
+  const exponent = Math.min(failureCount - 2, 5);
   return Math.min(
     DODO_RENEWAL_RECONCILIATION_BACKOFF_BASE_MS * 2 ** exponent,
     DODO_RENEWAL_RECONCILIATION_BACKOFF_MAX_MS,
@@ -140,6 +150,12 @@ type StaleActiveSubscriptionForRenewalReconciliation = {
   reconcileFailureCount?: number;
 };
 
+type ReconciliationSkipReason =
+  | "local_missing"
+  | "local_updated_concurrently"
+  | "local_no_longer_stale"
+  | "remote_not_newer";
+
 type ReconciliationMutationResult =
   | {
       kind: "reconciled";
@@ -147,7 +163,7 @@ type ReconciliationMutationResult =
       planKey: string;
       currentPeriodEnd: number;
     }
-  | { kind: "skipped"; reason: string };
+  | { kind: "skipped"; reason: ReconciliationSkipReason };
 
 type ReconciliationSummary = {
   inspected: number;
@@ -155,8 +171,15 @@ type ReconciliationSummary = {
   skipped: number;
   failed: number;
   limit: number;
+  // hasMore can be true while continuationScheduled is false only in the
+  // degenerate case handled by `windowSaturated` below (documented at the
+  // scheduling guard in the action).
   hasMore: boolean;
   timeBudgetExhausted: boolean;
+  // The scanned window was entirely within its reconcile backoff (all rows
+  // ineligible). Surfaced so an operator can tell "cooldown-saturated" from
+  // "nothing stale"; the action advances its scan cursor past the window.
+  windowSaturated: boolean;
   continuationScheduled: boolean;
   failures: Array<{ dodoSubscriptionId: string; error: string }>;
 };
@@ -496,6 +519,13 @@ export const listStaleActiveSubscriptionsForRenewalReconciliation = internalQuer
   args: {
     now: v.number(),
     scanLimit: v.number(),
+    // Resume cursor: only rows with currentPeriodEnd strictly greater than this
+    // are returned, so a continuation can page PAST a window already drained or
+    // saturated by backoff instead of re-scanning the same stalest rows. Omitted
+    // (undefined) on the first invocation of a cron cycle. Uses the same
+    // `by_status_period_end` index — the currentPeriodEnd range is just
+    // lower-bounded when the cursor is set.
+    cursorPeriodEnd: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const rows = await ctx.db
@@ -504,7 +534,12 @@ export const listStaleActiveSubscriptionsForRenewalReconciliation = internalQuer
       // winback work (#4935) — same ["status","currentPeriodEnd"] shape, so
       // no duplicate index is needed for renewal reconciliation.
       .withIndex("by_status_currentPeriodEnd", (q) =>
-        q.eq("status", "active").lt("currentPeriodEnd", args.now),
+        args.cursorPeriodEnd === undefined
+          ? q.eq("status", "active").lt("currentPeriodEnd", args.now)
+          : q
+              .eq("status", "active")
+              .gt("currentPeriodEnd", args.cursorPeriodEnd)
+              .lt("currentPeriodEnd", args.now),
       )
       .order("asc")
       .take(args.scanLimit);
@@ -524,11 +559,15 @@ export const listStaleActiveSubscriptionsForRenewalReconciliation = internalQuer
 
 /**
  * Marks a reconcile attempt on a stale-active subscription row: bumps
- * `reconcileFailureCount` and stamps `lastReconcileAttemptAt`. Called for every
- * NO-PROGRESS outcome (failed Dodo lookup, unsupported/pending remote status,
- * remote-not-newer on a still-stale row) so the exponential backoff in
- * `isReconcileEligible` de-prioritises permanently-failing rows and they stop
- * hogging the scan window.
+ * `reconcileFailureCount` and stamps `lastReconcileAttemptAt` so the
+ * exponential backoff in `isReconcileEligible` de-prioritises permanently-
+ * failing rows and they stop hogging the scan window.
+ *
+ * Used ONLY for no-progress outcomes that never reach
+ * `applyDodoSubscriptionReconciliation` — a failed Dodo lookup and an
+ * unsupported/pending remote status. The remote-not-newer and
+ * concurrently-updated skips record their own attempt inside `apply`'s
+ * transaction (no separate round-trip).
  *
  * Deliberately does NOT touch `updatedAt` — that field carries webhook
  * ordering semantics (`isNewerEvent`) and must not be perturbed by a
@@ -571,7 +610,7 @@ export const applyDodoSubscriptionReconciliation = internalMutation({
       rawPayload: v.any(),
     }),
   },
-  handler: async (ctx, args) => {
+  handler: async (ctx, args): Promise<ReconciliationMutationResult> => {
     const existing = await ctx.db.get(args.subscriptionId);
     if (!existing) {
       return { kind: "skipped", reason: "local_missing" };
@@ -582,18 +621,34 @@ export const applyDodoSubscriptionReconciliation = internalMutation({
       );
     }
 
+    // A concurrent webhook may have already moved the row out of the
+    // stale-active set (renewed / cancelled-with-future-period / expired). No
+    // work and it left the reconciliation set, so no backoff bookkeeping.
+    if (existing.status !== "active" || existing.currentPeriodEnd >= args.observedAt) {
+      return { kind: "skipped", reason: "local_no_longer_stale" };
+    }
+
+    // Fold the backoff bookkeeping into the no-progress skip branches so a
+    // still-stale row that we won't advance is recorded in the SAME transaction
+    // that read it — no second `markDodoReconcileAttempt` round-trip. Never
+    // touches `updatedAt` (that carries webhook ordering semantics).
+    const recordAttempt = async (): Promise<void> => {
+      await ctx.db.patch(existing._id, {
+        lastReconcileAttemptAt: args.observedAt,
+        reconcileFailureCount: (existing.reconcileFailureCount ?? 0) + 1,
+      });
+    };
+
     // Out-of-order guard, identical to every webhook handler. Between the
     // stale-scan read and this mutation a concurrent lifecycle webhook (e.g.
     // `subscription.plan_changed`, which patches planKey/productId but NOT
     // currentPeriodEnd) may have written a newer state. Our `observedAt` is the
     // cron's read time; if the row was updated at/after it, the cron holds a
-    // stale snapshot and must not clobber the webhook's write.
+    // stale snapshot and must not clobber the webhook's write. The row is still
+    // stale-active (checked above), so back it off.
     if (!isNewerEvent(existing.updatedAt, args.observedAt)) {
+      await recordAttempt();
       return { kind: "skipped", reason: "local_updated_concurrently" };
-    }
-
-    if (existing.status !== "active" || existing.currentPeriodEnd >= args.observedAt) {
-      return { kind: "skipped", reason: "local_no_longer_stale" };
     }
 
     if (
@@ -602,6 +657,7 @@ export const applyDodoSubscriptionReconciliation = internalMutation({
       args.remote.currentPeriodEnd <= existing.currentPeriodEnd &&
       (args.remote.dodoCustomerId ?? existing.dodoCustomerId) === existing.dodoCustomerId
     ) {
+      await recordAttempt();
       return { kind: "skipped", reason: "remote_not_newer" };
     }
 
@@ -650,6 +706,15 @@ export const reconcileMissedDodoRenewals = internalAction({
     // fresh cron tick omits it (defaults to the max) and each continuation
     // passes one fewer. Bounds total work + guarantees termination.
     continuationBudget: v.optional(v.number()),
+    // Scan resume cursor (currentPeriodEnd) threaded through continuations to
+    // page PAST a window already drained or saturated by backoff — see the
+    // scheduling block. Omitted on a fresh cron tick.
+    cursorPeriodEnd: v.optional(v.number()),
+    // Per-query scan window size, clamped to the const ceiling. Defaults to the
+    // ceiling; a smaller value is an ops knob (and the test seam that exercises
+    // the window-paging / saturation logic without seeding 500 rows). Threaded
+    // through continuations so a whole cycle uses a consistent window.
+    scanLimit: v.optional(v.number()),
     remoteSubscriptionsForTest: v.optional(
       v.array(dodoReconciliationRemoteSubscriptionValidator),
     ),
@@ -673,12 +738,25 @@ export const reconcileMissedDodoRenewals = internalAction({
         DODO_RENEWAL_RECONCILIATION_BATCH_SIZE,
       ),
     );
+    const scanLimit = Math.max(
+      1,
+      Math.min(
+        args.scanLimit ?? DODO_RENEWAL_RECONCILIATION_SCAN_LIMIT,
+        DODO_RENEWAL_RECONCILIATION_SCAN_LIMIT,
+      ),
+    );
     const continuationBudget =
       args.continuationBudget ?? DODO_RENEWAL_RECONCILIATION_MAX_CONTINUATIONS;
 
     const scanned = (await ctx.runQuery(
       internal.payments.billing.listStaleActiveSubscriptionsForRenewalReconciliation,
-      { now, scanLimit: DODO_RENEWAL_RECONCILIATION_SCAN_LIMIT },
+      {
+        now,
+        scanLimit,
+        ...(args.cursorPeriodEnd !== undefined
+          ? { cursorPeriodEnd: args.cursorPeriodEnd }
+          : {}),
+      },
     )) as StaleActiveSubscriptionForRenewalReconciliation[];
 
     // Skip rows still inside their post-failure backoff window so a
@@ -706,15 +784,33 @@ export const reconcileMissedDodoRenewals = internalAction({
       limit,
       hasMore: false,
       timeBudgetExhausted: false,
+      windowSaturated: false,
       continuationScheduled: false,
       failures: [],
     };
 
-    const markAttempt = (subscriptionId: Id<"subscriptions">) =>
-      ctx.runMutation(internal.payments.billing.markDodoReconcileAttempt, {
-        subscriptionId,
-        observedAt: now,
-      });
+    // Bookkeeping-only patch for a still-stale row we couldn't advance. Never
+    // let a failed bookkeeping write (OCC conflict, row deleted mid-cycle) abort
+    // the whole batch or the continuation scheduling — swallow + log. Used only
+    // for the two no-progress paths that don't reach `apply` (Dodo lookup
+    // failure, unsupported/pending status); `apply` records its own.
+    const markAttempt = async (subscriptionId: Id<"subscriptions">) => {
+      try {
+        await ctx.runMutation(internal.payments.billing.markDodoReconcileAttempt, {
+          subscriptionId,
+          observedAt: now,
+        });
+      } catch (markErr) {
+        // sentry-coverage-ok: structured console.error is forwarded by Convex
+        // auto-Sentry. Deliberately swallowed (not re-thrown): a failed
+        // best-effort backoff write must never abort the batch or skip
+        // continuation scheduling — the row simply isn't backed off this once
+        // and is re-attempted next run.
+        console.error(
+          `[billing/reconcile] markDodoReconcileAttempt failed for ${subscriptionId}: ${markErr instanceof Error ? markErr.message : String(markErr)}`,
+        );
+      }
+    };
 
     let attempted = 0;
     for (const sub of eligible) {
@@ -764,13 +860,11 @@ export const reconcileMissedDodoRenewals = internalAction({
         if (result.kind === "reconciled") {
           summary.reconciled++;
         } else {
+          // `apply` already recorded a backoff attempt for the still-stale skip
+          // reasons (remote_not_newer / local_updated_concurrently) inside its
+          // own transaction; `local_missing` / `local_no_longer_stale` left the
+          // set. Nothing more to do here.
           summary.skipped++;
-          // `remote_not_newer` / `local_updated_concurrently` leave the row
-          // stale-active with no change — back off so it doesn't hog a slot
-          // every run. `local_no_longer_stale` already left the set.
-          if (result.reason !== "local_no_longer_stale") {
-            await markAttempt(sub._id);
-          }
         }
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -790,12 +884,38 @@ export const reconcileMissedDodoRenewals = internalAction({
       }
     }
 
-    // More work remains if we couldn't attempt every eligible row, or the scan
-    // hit its cap (rows may exist beyond the window). We only chain when we made
-    // forward progress this invocation (attempted > 0) to guarantee termination.
-    if (eligible.length > attempted || scanned.length >= DODO_RENEWAL_RECONCILIATION_SCAN_LIMIT) {
-      summary.hasMore = true;
+    const scanWasFull = scanned.length >= scanLimit;
+    // Every eligible row in this window has been attempted (we didn't stop on
+    // the batch/time budget), but the window was full so more rows — eligible or
+    // not — may sort beyond it. Also fires the "saturated" case (eligible was
+    // empty: all scanned rows are inside their backoff window).
+    const windowDrainedButFull = scanWasFull && eligible.length <= attempted;
+    summary.windowSaturated = scanWasFull && eligible.length === 0;
+
+    if (summary.windowSaturated) {
+      // Distinguishable from an idle cron: the read budget was spent but every
+      // stale row in the window is cooling down. The cursor advances past it
+      // below so healthy rows sorted behind the poison window still get reached.
+      console.error(
+        `[billing/reconcile] scan window saturated: all ${scanned.length} scanned stale rows are within their reconcile backoff window; advancing scan cursor past currentPeriodEnd<=${scanned[scanned.length - 1]?.currentPeriodEnd} to reach rows behind them.`,
+      );
     }
+
+    // Cursor advance: page PAST this window (its eligible rows are all attempted
+    // or it's fully backed-off) so the next invocation reads new rows instead of
+    // re-scanning the same stalest window. When there are still un-attempted
+    // eligible rows in THIS window (we stopped on the batch/time budget), keep
+    // the cursor so the continuation re-scans and finishes draining it — those
+    // rows are backed off now, so the eligible set strictly shrinks.
+    // `scanned` is currentPeriodEnd-ascending, so its last element is the max.
+    const nextCursorPeriodEnd = windowDrainedButFull
+      ? scanned[scanned.length - 1]!.currentPeriodEnd
+      : args.cursorPeriodEnd;
+    const cursorAdvanced = nextCursorPeriodEnd !== args.cursorPeriodEnd;
+
+    // More work remains if we couldn't attempt every eligible row in this
+    // window, or the window was full (rows may sort beyond it).
+    summary.hasMore = eligible.length > attempted || scanWasFull;
 
     if (summary.failed > 0) {
       console.error(
@@ -803,14 +923,28 @@ export const reconcileMissedDodoRenewals = internalAction({
       );
     }
 
-    if (summary.hasMore && attempted > 0 && continuationBudget > 0) {
+    // Chain a continuation when work remains AND we are guaranteed to make
+    // progress next invocation: either we attempted rows this pass (the current
+    // window's eligible set shrank) or the cursor advanced (the next scan reads
+    // a strictly higher currentPeriodEnd range). Advancing on a saturated window
+    // is what stops a fully-backed-off window from silently stranding the
+    // healthy rows behind it. `continuationBudget` is the hard termination cap.
+    if (
+      summary.hasMore &&
+      continuationBudget > 0 &&
+      (attempted > 0 || cursorAdvanced)
+    ) {
       await ctx.scheduler.runAfter(
         0,
         internal.payments.billing.reconcileMissedDodoRenewals,
         {
           now,
           limit,
+          scanLimit,
           continuationBudget: continuationBudget - 1,
+          ...(nextCursorPeriodEnd !== undefined
+            ? { cursorPeriodEnd: nextCursorPeriodEnd }
+            : {}),
           ...(args.remoteSubscriptionsForTest
             ? { remoteSubscriptionsForTest: args.remoteSubscriptionsForTest }
             : {}),

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -196,12 +196,15 @@ export async function upsertEntitlements(
 // Coverage helpers
 // ---------------------------------------------------------------------------
 
+/** The local `subscriptions.status` union (mirrors `subscriptionStatus` in schema.ts). */
+export type SubscriptionStatus = "active" | "on_hold" | "cancelled" | "expired";
+
 type SubscriptionRow = {
   _id: import("../_generated/dataModel").Id<"subscriptions">;
   userId: string;
   dodoSubscriptionId: string;
   planKey: string;
-  status: "active" | "on_hold" | "cancelled" | "expired";
+  status: SubscriptionStatus;
   currentPeriodEnd: number;
 };
 

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -366,7 +366,7 @@ const FALLBACK_PLAN_KEY = "enterprise";
  * runs on a schedule and detects "Dodo has products our catalog doesn't"
  * BEFORE a webhook arrives, so most cases are caught proactively.
  */
-async function resolvePlanKey(
+export async function resolvePlanKey(
   ctx: MutationCtx,
   dodoProductId: string,
 ): Promise<string> {

--- a/convex/payments/subscriptionHelpers.ts
+++ b/convex/payments/subscriptionHelpers.ts
@@ -566,6 +566,13 @@ export async function handleSubscriptionActive(
       dodoCustomerId: incomingDodoCustomerId ?? existing.dodoCustomerId,
       rawPayload: data,
       updatedAt: eventTimestamp,
+      // A live webhook proves the sub exists and (re)activates it — clear the
+      // renewal-reconciliation bookkeeping so a future stale episode starts
+      // from a clean slate (esp. the consecutive-404 streak). See
+      // payments/billing:reconcileMissedDodoRenewals.
+      lastReconcileAttemptAt: undefined,
+      reconcileFailureCount: undefined,
+      reconcileNotFoundCount: undefined,
     });
   } else {
     await ctx.db.insert("subscriptions", {
@@ -716,6 +723,12 @@ export async function handleSubscriptionRenewed(
     dodoCustomerId: mergeDodoCustomerId(data, existing),
     rawPayload: data,
     updatedAt: eventTimestamp,
+    // Renewal proves the sub exists — clear renewal-reconciliation bookkeeping
+    // so a future stale episode starts from a clean slate (esp. the
+    // consecutive-404 streak). See payments/billing:reconcileMissedDodoRenewals.
+    lastReconcileAttemptAt: undefined,
+    reconcileFailureCount: undefined,
+    reconcileNotFoundCount: undefined,
   });
 
   // Recompute from ALL subs — a renewal on a lower-tier sub must NOT

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -547,6 +547,15 @@ export default defineSchema({
     onHoldAt: v.optional(v.number()),
     rawPayload: v.any(),
     updatedAt: v.number(),
+    // Renewal-reconciliation bookkeeping (see
+    // `payments/billing:reconcileMissedDodoRenewals`). Orthogonal to
+    // `updatedAt` — these are NEVER bumped on a webhook state change, only
+    // when the reconciliation cron attempts (and fails/skips) a row. Used to
+    // back off permanently-failing rows (e.g. test-mode-era subs that 404
+    // against the live Dodo client) so they stop starving the batch's scan
+    // slots. Cleared on a successful reconcile.
+    lastReconcileAttemptAt: v.optional(v.number()),
+    reconcileFailureCount: v.optional(v.number()),
   })
     .index("by_userId", ["userId"])
     .index("by_dodoSubscriptionId", ["dodoSubscriptionId"])

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -553,9 +553,15 @@ export default defineSchema({
     // when the reconciliation cron attempts (and fails/skips) a row. Used to
     // back off permanently-failing rows (e.g. test-mode-era subs that 404
     // against the live Dodo client) so they stop starving the batch's scan
-    // slots. Cleared on a successful reconcile.
+    // slots. Cleared on a successful reconcile AND on a webhook that renews the
+    // sub (so a new stale episode starts from a clean slate).
     lastReconcileAttemptAt: v.optional(v.number()),
     reconcileFailureCount: v.optional(v.number()),
+    // Count of CONSECUTIVE definitive Dodo 404s (reset by any non-404 reconcile
+    // outcome). Distinct from `reconcileFailureCount` (which counts all failure
+    // kinds for backoff) so the terminal "subscription deleted in Dodo"
+    // downgrade requires repeated 404s specifically, not just any prior failure.
+    reconcileNotFoundCount: v.optional(v.number()),
   })
     .index("by_userId", ["userId"])
     .index("by_dodoSubscriptionId", ["dodoSubscriptionId"])


### PR DESCRIPTION
## Summary

Missed Dodo renewal webhooks no longer leave paying subscribers stuck behind stale local entitlement periods. A daily Convex reconciliation now finds active local subscriptions whose period has passed, checks Dodo for authoritative subscription state, refreshes the local period/status/product projection, and recomputes entitlements through the existing multi-subscription precedence helper.

The reconciliation runs in bounded batches, uses a `(status, currentPeriodEnd)` subscription index instead of scanning every row, and treats per-subscription Dodo failures as isolated operational failures so one bad lookup does not block other stale subscribers. Unknown paid product IDs follow the existing webhook fail-open posture by over-granting `enterprise` while logging for catalog repair.

## Validation

- `npm run test:convex -- convex/__tests__/billing.test.ts`
- `npm run typecheck`
- `npm run typecheck:api`
- `git diff --check`
- pre-push hook: typecheck, API typecheck, Convex type check, CJS syntax, Unicode safety, boundary lint, safe HTML, Sentry coverage, rate-limit policy coverage, premium-fetch parity, version sync

Fixes #4765

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT--5](https://img.shields.io/badge/GPT--5-000000)