### PR TITLE
feat(payments): reconcile stuck pending payments

### DIFF
--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -1,9 +1,13 @@
 import { convexTest } from "convex-test";
+import { readFileSync } from "node:fs";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import schema from "../schema";
 import { api, internal } from "../_generated/api";
 import { PRODUCT_CATALOG } from "../config/productCatalog";
-import { PENDING_PAYMENT_BLOCK_WINDOW_MS } from "../payments/billing";
+import {
+  PENDING_PAYMENT_BLOCK_WINDOW_MS,
+  STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS,
+} from "../payments/billing";
 import { getFeaturesForPlan } from "../lib/entitlements";
 import { signAnonClaimToken } from "../lib/identitySigning";
 
@@ -785,6 +789,260 @@ describe("payments pending-payment dedup guard", () => {
     );
 
     expect(result).toMatchObject({ planKey: "pro_annual" });
+  });
+});
+
+describe("payments stuck-pending reconciliation", () => {
+  test("finds stale unresolved pending payments but skips recent, terminal, and already-marked rows", async () => {
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+
+    await seedPaymentEvent(t, {
+      status: "requires_customer_action",
+      planKey: "pro_monthly",
+      occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      suffix: "stale_candidate",
+      dodoPaymentId: "pay_reconcile_candidate",
+    });
+    await seedPaymentEvent(t, {
+      status: "processing",
+      planKey: "pro_monthly",
+      occurredAt: NOW - 5 * MIN_MS,
+      suffix: "recent_pending",
+      dodoPaymentId: "pay_reconcile_recent",
+    });
+    await seedPaymentEvent(t, {
+      status: "requires_customer_action",
+      planKey: "pro_monthly",
+      occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - 2 * MIN_MS,
+      suffix: "terminal_pending",
+      dodoPaymentId: "pay_reconcile_terminal",
+    });
+    await seedPaymentEvent(t, {
+      status: "failed",
+      planKey: "pro_monthly",
+      occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      suffix: "terminal_failed",
+      dodoPaymentId: "pay_reconcile_terminal",
+    });
+    await seedPaymentEvent(t, {
+      status: "requires_customer_action",
+      planKey: "pro_monthly",
+      occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - 3 * MIN_MS,
+      suffix: "marked_pending",
+      dodoPaymentId: "pay_reconcile_marked",
+    });
+    await t.run(async (ctx) => {
+      await ctx.db.insert("paymentReconciliationAttempts", {
+        dodoPaymentId: "pay_reconcile_marked",
+        userId: TEST_USER_ID,
+        planKey: "pro_monthly",
+        action: "ops_notified",
+        observedStatus: "requires_customer_action",
+        pendingOccurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - 3 * MIN_MS,
+        reconciledAt: NOW - MIN_MS,
+      });
+    });
+
+    const candidates = await t.query(
+      internal.payments.billing.listStuckPendingPaymentCandidates,
+      { thresholdMs: STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS, batchSize: 10 },
+    );
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      dodoPaymentId: "pay_reconcile_candidate",
+      planKey: "pro_monthly",
+      pendingStatus: "requires_customer_action",
+    });
+  });
+
+  test("candidate selection is bounded by batch size", async () => {
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+
+    for (let i = 0; i < 3; i++) {
+      await seedPaymentEvent(t, {
+        status: "processing",
+        planKey: "pro_monthly",
+        occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - (i + 1) * MIN_MS,
+        suffix: `batch_${i}`,
+        dodoPaymentId: `pay_reconcile_batch_${i}`,
+      });
+    }
+
+    const candidates = await t.query(
+      internal.payments.billing.listStuckPendingPaymentCandidates,
+      { thresholdMs: STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS, batchSize: 2 },
+    );
+
+    expect(candidates).toHaveLength(2);
+  });
+
+  test("records a dropped-webhook terminal payment once", async () => {
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+
+    await seedPaymentEvent(t, {
+      status: "requires_customer_action",
+      planKey: "pro_monthly",
+      occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      suffix: "terminal_record",
+      dodoPaymentId: "pay_reconcile_terminal_record",
+    });
+
+    const payload = {
+      userId: TEST_USER_ID,
+      dodoPaymentId: "pay_reconcile_terminal_record",
+      dodoSubscriptionId: "sub_reconcile_terminal_record",
+      planKey: "pro_monthly",
+      amount: 3999,
+      currency: "USD",
+      pendingOccurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      observedStatus: "succeeded",
+      rawPayload: { status: "succeeded", payment_id: "pay_reconcile_terminal_record" },
+    };
+    const first = await t.mutation(
+      internal.payments.billing.recordStuckPaymentReconciliationOutcome,
+      payload,
+    );
+    const second = await t.mutation(
+      internal.payments.billing.recordStuckPaymentReconciliationOutcome,
+      payload,
+    );
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db
+        .query("paymentEvents")
+        .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", "pay_reconcile_terminal_record"))
+        .collect(),
+    );
+    const markers = await t.run(async (ctx) =>
+      ctx.db
+        .query("paymentReconciliationAttempts")
+        .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", "pay_reconcile_terminal_record"))
+        .collect(),
+    );
+
+    expect(first).toEqual({ action: "terminal_reconciled" });
+    expect(second).toEqual({ action: "already_marked" });
+    expect(rows.map((row) => row.status).sort()).toEqual(["requires_customer_action", "succeeded"]);
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toMatchObject({ action: "terminal_reconciled", observedStatus: "succeeded" });
+  });
+
+  test("marks a still-pending stale payment once for ops follow-up", async () => {
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+
+    await seedPaymentEvent(t, {
+      status: "processing",
+      planKey: "pro_monthly",
+      occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      suffix: "ops_marker",
+      dodoPaymentId: "pay_reconcile_ops_marker",
+    });
+
+    const payload = {
+      userId: TEST_USER_ID,
+      dodoPaymentId: "pay_reconcile_ops_marker",
+      planKey: "pro_monthly",
+      amount: 3999,
+      currency: "USD",
+      pendingOccurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      observedStatus: "requires_customer_action",
+      rawPayload: { status: "requires_customer_action", payment_id: "pay_reconcile_ops_marker" },
+    };
+    const first = await t.mutation(
+      internal.payments.billing.recordStuckPaymentReconciliationOutcome,
+      payload,
+    );
+    const second = await t.mutation(
+      internal.payments.billing.recordStuckPaymentReconciliationOutcome,
+      payload,
+    );
+
+    const rows = await t.run(async (ctx) =>
+      ctx.db
+        .query("paymentEvents")
+        .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", "pay_reconcile_ops_marker"))
+        .collect(),
+    );
+    const markers = await t.run(async (ctx) =>
+      ctx.db
+        .query("paymentReconciliationAttempts")
+        .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", "pay_reconcile_ops_marker"))
+        .collect(),
+    );
+
+    expect(first).toEqual({ action: "ops_notified" });
+    expect(second).toEqual({ action: "already_marked" });
+    expect(rows).toHaveLength(1);
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toMatchObject({
+      action: "ops_notified",
+      observedStatus: "requires_customer_action",
+    });
+  });
+
+  test("records a customer-notified stale payment marker once", async () => {
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+
+    await seedPaymentEvent(t, {
+      status: "processing",
+      planKey: "pro_monthly",
+      occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      suffix: "customer_notified",
+      dodoPaymentId: "pay_reconcile_customer_notified",
+    });
+
+    const payload = {
+      userId: TEST_USER_ID,
+      dodoPaymentId: "pay_reconcile_customer_notified",
+      planKey: "pro_monthly",
+      amount: 3999,
+      currency: "USD",
+      pendingOccurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      observedStatus: "requires_customer_action",
+      staleAction: "customer_notified" as const,
+      rawPayload: {
+        status: "requires_customer_action",
+        payment_id: "pay_reconcile_customer_notified",
+        payment_link: "https://checkout.dodopayments.com/session/test",
+      },
+    };
+
+    const first = await t.mutation(
+      internal.payments.billing.recordStuckPaymentReconciliationOutcome,
+      payload,
+    );
+    const second = await t.mutation(
+      internal.payments.billing.recordStuckPaymentReconciliationOutcome,
+      payload,
+    );
+
+    const markers = await t.run(async (ctx) =>
+      ctx.db
+        .query("paymentReconciliationAttempts")
+        .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", "pay_reconcile_customer_notified"))
+        .collect(),
+    );
+
+    expect(first).toEqual({ action: "customer_notified" });
+    expect(second).toEqual({ action: "already_marked" });
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toMatchObject({
+      action: "customer_notified",
+      observedStatus: "requires_customer_action",
+    });
+  });
+
+  test("registers the daily reconciliation cron", () => {
+    const source = readFileSync("convex/crons.ts", "utf8");
+
+    expect(source).toContain("payments-stuck-pending-reconciliation");
+    expect(source).toContain("internal.payments.billing.reconcileStuckPendingPayments");
   });
 });
 

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -974,6 +974,76 @@ describe("payments stuck-pending reconciliation", () => {
     expect(markers[0]).toMatchObject({ action: "terminal_reconciled", observedStatus: "succeeded" });
   });
 
+  test("terminal SUCCEEDED with no subscription row pages ops (dropped subscription.active guard)", async () => {
+    vi.setSystemTime(NOW);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const t = convexTest(schema, modules);
+
+    await seedPaymentEvent(t, {
+      status: "requires_customer_action",
+      planKey: "pro_monthly",
+      occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      suffix: "succeeded_nosub",
+      dodoPaymentId: "pay_succeeded_nosub",
+    });
+
+    const result = await t.mutation(internal.payments.billing.claimStuckPaymentReconciliation, {
+      userId: TEST_USER_ID,
+      dodoPaymentId: "pay_succeeded_nosub",
+      dodoSubscriptionId: "sub_never_activated",
+      planKey: "pro_monthly",
+      amount: 3999,
+      currency: "USD",
+      pendingOccurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      observedStatus: "succeeded",
+      rawPayload: {},
+    });
+
+    // Case is still closed (marker written) but ops is paged via console.error.
+    expect(result).toEqual({ action: "terminal_reconciled" });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("no subscription row"),
+    );
+  });
+
+  test("terminal SUCCEEDED with a matching subscription row does NOT page ops", async () => {
+    vi.setSystemTime(NOW);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const t = convexTest(schema, modules);
+
+    await seedPaymentEvent(t, {
+      status: "requires_customer_action",
+      planKey: "pro_monthly",
+      occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      suffix: "succeeded_withsub",
+      dodoPaymentId: "pay_succeeded_withsub",
+    });
+    await seedSubscription(t, {
+      planKey: "pro_monthly",
+      dodoProductId: PRODUCT_CATALOG.pro_monthly.dodoProductId!,
+      status: "active",
+      currentPeriodEnd: NOW + 30 * DAY_MS,
+      suffix: "reconcile_covered",
+    });
+    // seedSubscription names the row sub_billing_<suffix>; point the payment at it.
+    const result = await t.mutation(internal.payments.billing.claimStuckPaymentReconciliation, {
+      userId: TEST_USER_ID,
+      dodoPaymentId: "pay_succeeded_withsub",
+      dodoSubscriptionId: "sub_billing_reconcile_covered",
+      planKey: "pro_monthly",
+      amount: 3999,
+      currency: "USD",
+      pendingOccurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      observedStatus: "succeeded",
+      rawPayload: {},
+    });
+
+    expect(result).toEqual({ action: "terminal_reconciled" });
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("no subscription row"),
+    );
+  });
+
   test("claim returns already_terminal (no marker) when a terminal row already exists (race)", async () => {
     // A webhook delivered the terminal charge between candidate listing and the
     // claim. The claim must NOT insert a duplicate terminal row or a marker.
@@ -1281,6 +1351,83 @@ describe("payments stuck-pending reconciliation", () => {
     expect(marker).toMatchObject({ action: "ops_notified", observedStatus: "unknown" });
   });
 
+  test("action marks a non-null UNRECOGNISED status without emailing (F1)", async () => {
+    // Distinct from the null-status case: `requires_payment_method` is non-null,
+    // so it exercises the SECOND operand of the email gate
+    // (isPendingPaymentStatus). If that check regressed, this status would take
+    // the email path — the null test alone would not catch it.
+    vi.setSystemTime(NOW);
+    process.env.DODO_API_KEY = "test_dodo_key";
+    process.env.RESEND_API_KEY = "test_resend_key";
+    const t = convexTest(schema, modules);
+
+    await seedPaymentEvent(t, {
+      status: "requires_customer_action",
+      planKey: "pro_monthly",
+      occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      suffix: "unrecognised_status",
+      dodoPaymentId: "pay_unrecognised",
+    });
+
+    dodoRetrieveMock.mockResolvedValue({
+      payment_id: "pay_unrecognised",
+      status: "requires_payment_method",
+      customer: { email: "buyer@example.com" },
+      payment_link: "https://checkout.dodopayments.com/session/x",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("{}", { status: 200 }),
+    );
+
+    const summary = await t.action(internal.payments.billing.reconcileStuckPendingPayments, {});
+
+    expect(summary).toMatchObject({ candidates: 1, unknownStatus: 1, customerNotified: 0 });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const marker = await t.run(async (ctx) =>
+      ctx.db
+        .query("paymentReconciliationAttempts")
+        .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", "pay_unrecognised"))
+        .first(),
+    );
+    expect(marker).toMatchObject({ action: "ops_notified", observedStatus: "requires_payment_method" });
+  });
+
+  test("action emails a stuck payment at most once across repeated daily runs (F3)", async () => {
+    // The core idempotency guarantee stated end-to-end: two identical daily
+    // runs over the same still-pending payment send exactly ONE email — the
+    // marker claimed on run 1 removes the row from run 2's candidate set.
+    vi.setSystemTime(NOW);
+    process.env.DODO_API_KEY = "test_dodo_key";
+    process.env.RESEND_API_KEY = "test_resend_key";
+    const t = convexTest(schema, modules);
+
+    await seedPaymentEvent(t, {
+      status: "requires_customer_action",
+      planKey: "pro_monthly",
+      occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      suffix: "twice",
+      dodoPaymentId: "pay_twice",
+    });
+
+    dodoRetrieveMock.mockResolvedValue({
+      status: "requires_customer_action",
+      payment_id: "pay_twice",
+      customer: { email: "buyer@example.com" },
+      payment_link: "https://checkout.dodopayments.com/session/x",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ id: "email_1" }), { status: 200 }),
+    );
+
+    const first = await t.action(internal.payments.billing.reconcileStuckPendingPayments, {});
+    const second = await t.action(internal.payments.billing.reconcileStuckPendingPayments, {});
+
+    expect(first).toMatchObject({ candidates: 1, customerNotified: 1 });
+    expect(second).toMatchObject({ candidates: 0 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   test("action isolates a Resend failure to one candidate and still processes the rest (F6/F7)", async () => {
     // Fake timers so the failed candidate's fire-and-forget Sentry report
     // (a scheduled throwing mutation) is drained inside the test rather than
@@ -1351,11 +1498,17 @@ describe("payments stuck-pending reconciliation", () => {
     expect(markerB?.action).toBe("customer_notified");
   });
 
-  test("registers the daily reconciliation cron", () => {
+  test("registers the reconciliation cron on a 6-hourly cadence", () => {
     const source = readFileSync("convex/crons.ts", "utf8");
 
     expect(source).toContain("payments-stuck-pending-reconciliation");
     expect(source).toContain("internal.payments.billing.reconcileStuckPendingPayments");
+    // 6-hourly, not daily: keeps a payment's age at first scan under the 24h
+    // customer-email freshness gate (daily cadence silently dropped ~25% of
+    // stuck payments to ops-only). Anchored so a revert to crons.daily reds.
+    expect(source).toMatch(
+      /crons\.interval\(\s*"payments-stuck-pending-reconciliation",\s*\{\s*hours:\s*6\s*\}/,
+    );
   });
 });
 

--- a/convex/__tests__/billing.test.ts
+++ b/convex/__tests__/billing.test.ts
@@ -11,6 +11,18 @@ import {
 import { getFeaturesForPlan } from "../lib/entitlements";
 import { signAnonClaimToken } from "../lib/identitySigning";
 
+// Mock the Dodo REST SDK so the reconciliation action's `payments.retrieve`
+// is controllable per-test (no real network). billing.ts only news up
+// DodoPayments inside getDodoClient(), so a class stub is sufficient. No
+// other test in this file exercises the real SDK.
+const { dodoRetrieveMock } = vi.hoisted(() => ({ dodoRetrieveMock: vi.fn() }));
+vi.mock("dodopayments", () => ({
+  DodoPayments: class {
+    payments = { retrieve: dodoRetrieveMock };
+    customers = { customerPortal: { create: vi.fn() } };
+  },
+}));
+
 const modules = import.meta.glob("../**/*.ts");
 
 const TEST_USER_ID = "user_billing_test_001";
@@ -24,11 +36,14 @@ type PlanKey = keyof typeof PRODUCT_CATALOG;
 
 afterEach(() => {
   vi.restoreAllMocks();
+  dodoRetrieveMock.mockReset();
   vi.useRealTimers();
   delete process.env.DODO_IDENTITY_SIGNING_SECRET;
   delete process.env.DODO_ANON_CLAIM_TOKEN_TTL_MS;
   delete process.env.UPSTASH_REDIS_REST_URL;
   delete process.env.UPSTASH_REDIS_REST_TOKEN;
+  delete process.env.DODO_API_KEY;
+  delete process.env.RESEND_API_KEY;
 });
 
 async function seedSubscription(
@@ -879,7 +894,35 @@ describe("payments stuck-pending reconciliation", () => {
     expect(candidates).toHaveLength(2);
   });
 
-  test("records a dropped-webhook terminal payment once", async () => {
+  test("scans newest-first so freshly-stuck rows win a limited batch (F5)", async () => {
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+
+    // Three stale pending payments, increasing age (i=0 newest, i=2 oldest).
+    for (let i = 0; i < 3; i++) {
+      await seedPaymentEvent(t, {
+        status: "requires_customer_action",
+        planKey: "pro_monthly",
+        occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - (i + 1) * MIN_MS,
+        suffix: `scan_order_${i}`,
+        dodoPaymentId: `pay_scan_order_${i}`,
+      });
+    }
+
+    const candidates = await t.query(
+      internal.payments.billing.listStuckPendingPaymentCandidates,
+      { thresholdMs: STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS, batchSize: 2 },
+    );
+
+    // Descending scan yields the NEWEST two (0, 1), not the oldest two — the
+    // regression fix so newly-stuck rows don't fall off the end of the window.
+    expect(candidates.map((c) => c.dodoPaymentId)).toEqual([
+      "pay_scan_order_0",
+      "pay_scan_order_1",
+    ]);
+  });
+
+  test("claims a dropped-webhook terminal payment once, backfilling the terminal row", async () => {
     vi.setSystemTime(NOW);
     const t = convexTest(schema, modules);
 
@@ -903,11 +946,11 @@ describe("payments stuck-pending reconciliation", () => {
       rawPayload: { status: "succeeded", payment_id: "pay_reconcile_terminal_record" },
     };
     const first = await t.mutation(
-      internal.payments.billing.recordStuckPaymentReconciliationOutcome,
+      internal.payments.billing.claimStuckPaymentReconciliation,
       payload,
     );
     const second = await t.mutation(
-      internal.payments.billing.recordStuckPaymentReconciliationOutcome,
+      internal.payments.billing.claimStuckPaymentReconciliation,
       payload,
     );
 
@@ -931,7 +974,49 @@ describe("payments stuck-pending reconciliation", () => {
     expect(markers[0]).toMatchObject({ action: "terminal_reconciled", observedStatus: "succeeded" });
   });
 
-  test("marks a still-pending stale payment once for ops follow-up", async () => {
+  test("claim returns already_terminal (no marker) when a terminal row already exists (race)", async () => {
+    // A webhook delivered the terminal charge between candidate listing and the
+    // claim. The claim must NOT insert a duplicate terminal row or a marker.
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+
+    await seedPaymentEvent(t, {
+      status: "requires_customer_action",
+      planKey: "pro_monthly",
+      occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      suffix: "race_pending",
+      dodoPaymentId: "pay_reconcile_race",
+    });
+    await seedPaymentEvent(t, {
+      status: "succeeded",
+      planKey: "pro_monthly",
+      occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS + MIN_MS,
+      suffix: "race_terminal",
+      dodoPaymentId: "pay_reconcile_race",
+    });
+
+    const result = await t.mutation(internal.payments.billing.claimStuckPaymentReconciliation, {
+      userId: TEST_USER_ID,
+      dodoPaymentId: "pay_reconcile_race",
+      planKey: "pro_monthly",
+      amount: 3999,
+      currency: "USD",
+      pendingOccurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      observedStatus: "requires_customer_action",
+      rawPayload: {},
+    });
+
+    expect(result).toEqual({ action: "already_terminal" });
+    const markers = await t.run(async (ctx) =>
+      ctx.db
+        .query("paymentReconciliationAttempts")
+        .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", "pay_reconcile_race"))
+        .collect(),
+    );
+    expect(markers).toHaveLength(0);
+  });
+
+  test("claim writes a provisional ops marker for a recognised pending status", async () => {
     vi.setSystemTime(NOW);
     const t = convexTest(schema, modules);
 
@@ -953,14 +1038,8 @@ describe("payments stuck-pending reconciliation", () => {
       observedStatus: "requires_customer_action",
       rawPayload: { status: "requires_customer_action", payment_id: "pay_reconcile_ops_marker" },
     };
-    const first = await t.mutation(
-      internal.payments.billing.recordStuckPaymentReconciliationOutcome,
-      payload,
-    );
-    const second = await t.mutation(
-      internal.payments.billing.recordStuckPaymentReconciliationOutcome,
-      payload,
-    );
+    const first = await t.mutation(internal.payments.billing.claimStuckPaymentReconciliation, payload);
+    const second = await t.mutation(internal.payments.billing.claimStuckPaymentReconciliation, payload);
 
     const rows = await t.run(async (ctx) =>
       ctx.db
@@ -975,9 +1054,9 @@ describe("payments stuck-pending reconciliation", () => {
         .collect(),
     );
 
-    expect(first).toEqual({ action: "ops_notified" });
+    expect(first).toEqual({ action: "pending_claimed" });
     expect(second).toEqual({ action: "already_marked" });
-    expect(rows).toHaveLength(1);
+    expect(rows).toHaveLength(1); // no synthetic paymentEvents row for a non-terminal status
     expect(markers).toHaveLength(1);
     expect(markers[0]).toMatchObject({
       action: "ops_notified",
@@ -985,7 +1064,11 @@ describe("payments stuck-pending reconciliation", () => {
     });
   });
 
-  test("records a customer-notified stale payment marker once", async () => {
+  test("claim writes a marker recording the RAW status for an UNRECOGNISED non-terminal status (F1)", async () => {
+    // `requires_payment_method` is the typical abandoned-3DS end-state. The old
+    // fall-through returned `unknown_status` with NO marker, so the cron
+    // re-polled it daily for 14 days and starved batch slots. It must now be
+    // claimed with the raw status preserved.
     vi.setSystemTime(NOW);
     const t = convexTest(schema, modules);
 
@@ -993,49 +1076,279 @@ describe("payments stuck-pending reconciliation", () => {
       status: "processing",
       planKey: "pro_monthly",
       occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
-      suffix: "customer_notified",
-      dodoPaymentId: "pay_reconcile_customer_notified",
+      suffix: "unknown_status",
+      dodoPaymentId: "pay_reconcile_unknown",
     });
 
-    const payload = {
+    const result = await t.mutation(internal.payments.billing.claimStuckPaymentReconciliation, {
       userId: TEST_USER_ID,
-      dodoPaymentId: "pay_reconcile_customer_notified",
+      dodoPaymentId: "pay_reconcile_unknown",
+      planKey: "pro_monthly",
+      amount: 3999,
+      currency: "USD",
+      pendingOccurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      observedStatus: "requires_payment_method",
+      rawPayload: { status: "requires_payment_method", payment_id: "pay_reconcile_unknown" },
+    });
+
+    expect(result).toEqual({ action: "pending_claimed" });
+    const markers = await t.run(async (ctx) =>
+      ctx.db
+        .query("paymentReconciliationAttempts")
+        .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", "pay_reconcile_unknown"))
+        .collect(),
+    );
+    expect(markers).toHaveLength(1);
+    expect(markers[0]).toMatchObject({
+      action: "ops_notified",
+      observedStatus: "requires_payment_method",
+    });
+  });
+
+  test("finalize(notified) upgrades a claimed marker to customer_notified, and never downgrades", async () => {
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+
+    await seedPaymentEvent(t, {
+      status: "requires_customer_action",
+      planKey: "pro_monthly",
+      occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      suffix: "finalize_customer",
+      dodoPaymentId: "pay_reconcile_finalize_customer",
+    });
+    await t.mutation(internal.payments.billing.claimStuckPaymentReconciliation, {
+      userId: TEST_USER_ID,
+      dodoPaymentId: "pay_reconcile_finalize_customer",
       planKey: "pro_monthly",
       amount: 3999,
       currency: "USD",
       pendingOccurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
       observedStatus: "requires_customer_action",
-      staleAction: "customer_notified" as const,
-      rawPayload: {
-        status: "requires_customer_action",
-        payment_id: "pay_reconcile_customer_notified",
-        payment_link: "https://checkout.dodopayments.com/session/test",
-      },
-    };
+      rawPayload: {},
+    });
 
-    const first = await t.mutation(
-      internal.payments.billing.recordStuckPaymentReconciliationOutcome,
-      payload,
-    );
-    const second = await t.mutation(
-      internal.payments.billing.recordStuckPaymentReconciliationOutcome,
-      payload,
-    );
+    const upgrade = await t.mutation(internal.payments.billing.finalizeStuckPaymentReconciliation, {
+      dodoPaymentId: "pay_reconcile_finalize_customer",
+      notified: true,
+    });
+    expect(upgrade).toEqual({ action: "customer_notified" });
+
+    // A later ops finalize (notified:false) must be a no-op — never downgrade
+    // a customer who was already emailed.
+    const noDowngrade = await t.mutation(internal.payments.billing.finalizeStuckPaymentReconciliation, {
+      dodoPaymentId: "pay_reconcile_finalize_customer",
+      notified: false,
+    });
+    expect(noDowngrade).toEqual({ action: "customer_notified" });
 
     const markers = await t.run(async (ctx) =>
       ctx.db
         .query("paymentReconciliationAttempts")
-        .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", "pay_reconcile_customer_notified"))
+        .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", "pay_reconcile_finalize_customer"))
         .collect(),
     );
-
-    expect(first).toEqual({ action: "customer_notified" });
-    expect(second).toEqual({ action: "already_marked" });
     expect(markers).toHaveLength(1);
-    expect(markers[0]).toMatchObject({
-      action: "customer_notified",
-      observedStatus: "requires_customer_action",
+    expect(markers[0]).toMatchObject({ action: "customer_notified" });
+  });
+
+  test("finalize(ops) keeps the marker ops_notified", async () => {
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+
+    await seedPaymentEvent(t, {
+      status: "processing",
+      planKey: "pro_monthly",
+      occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      suffix: "finalize_ops",
+      dodoPaymentId: "pay_reconcile_finalize_ops",
     });
+    await t.mutation(internal.payments.billing.claimStuckPaymentReconciliation, {
+      userId: TEST_USER_ID,
+      dodoPaymentId: "pay_reconcile_finalize_ops",
+      planKey: "pro_monthly",
+      amount: 3999,
+      currency: "USD",
+      pendingOccurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      observedStatus: "processing",
+      rawPayload: {},
+    });
+
+    const result = await t.mutation(internal.payments.billing.finalizeStuckPaymentReconciliation, {
+      dodoPaymentId: "pay_reconcile_finalize_ops",
+      notified: false,
+    });
+    expect(result).toEqual({ action: "ops_notified" });
+
+    const markers = await t.run(async (ctx) =>
+      ctx.db
+        .query("paymentReconciliationAttempts")
+        .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", "pay_reconcile_finalize_ops"))
+        .collect(),
+    );
+    expect(markers[0]).toMatchObject({ action: "ops_notified" });
+  });
+
+  test("action claims the marker BEFORE sending the customer email (F3 idempotency)", async () => {
+    vi.setSystemTime(NOW);
+    process.env.DODO_API_KEY = "test_dodo_key";
+    process.env.RESEND_API_KEY = "test_resend_key";
+    const t = convexTest(schema, modules);
+
+    await seedPaymentEvent(t, {
+      status: "requires_customer_action",
+      planKey: "pro_monthly",
+      occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      suffix: "action_order",
+      dodoPaymentId: "pay_action_order",
+    });
+
+    dodoRetrieveMock.mockResolvedValue({
+      status: "requires_customer_action",
+      payment_id: "pay_action_order",
+      customer: { email: "buyer@example.com" },
+      payment_link: "https://checkout.dodopayments.com/session/x",
+    });
+
+    let markerExistedAtEmailTime = false;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: any) => {
+      if (String(input).includes("api.resend.com")) {
+        const marker = await t.run(async (ctx) =>
+          ctx.db
+            .query("paymentReconciliationAttempts")
+            .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", "pay_action_order"))
+            .first(),
+        );
+        markerExistedAtEmailTime = marker !== null;
+        return new Response(JSON.stringify({ id: "email_1" }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    const summary = await t.action(internal.payments.billing.reconcileStuckPendingPayments, {});
+
+    // The marker must already exist when the email is sent — that ordering is
+    // what makes a post-send failure NON-re-emailing on the next run.
+    expect(markerExistedAtEmailTime).toBe(true);
+    expect(summary).toMatchObject({ candidates: 1, customerNotified: 1 });
+
+    const marker = await t.run(async (ctx) =>
+      ctx.db
+        .query("paymentReconciliationAttempts")
+        .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", "pay_action_order"))
+        .first(),
+    );
+    expect(marker?.action).toBe("customer_notified");
+  });
+
+  test("action marks a payment whose Dodo status is NULL and never emails it (F1)", async () => {
+    vi.setSystemTime(NOW);
+    process.env.DODO_API_KEY = "test_dodo_key";
+    process.env.RESEND_API_KEY = "test_resend_key";
+    const t = convexTest(schema, modules);
+
+    await seedPaymentEvent(t, {
+      status: "requires_customer_action",
+      planKey: "pro_monthly",
+      occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      suffix: "null_status",
+      dodoPaymentId: "pay_null_status",
+    });
+
+    // Dodo returns a payment object with no `status` field at all.
+    dodoRetrieveMock.mockResolvedValue({
+      payment_id: "pay_null_status",
+      status: null,
+      customer: { email: "buyer@example.com" },
+      payment_link: "https://checkout.dodopayments.com/session/x",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("{}", { status: 200 }),
+    );
+
+    const summary = await t.action(internal.payments.billing.reconcileStuckPendingPayments, {});
+
+    // A marker is written (no 14-day re-poll), status recorded as the sentinel,
+    // and NO customer email is sent for an unrecognised status.
+    expect(summary).toMatchObject({ candidates: 1, unknownStatus: 1, customerNotified: 0 });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    const marker = await t.run(async (ctx) =>
+      ctx.db
+        .query("paymentReconciliationAttempts")
+        .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", "pay_null_status"))
+        .first(),
+    );
+    expect(marker).toMatchObject({ action: "ops_notified", observedStatus: "unknown" });
+  });
+
+  test("action isolates a Resend failure to one candidate and still processes the rest (F6/F7)", async () => {
+    // Fake timers so the failed candidate's fire-and-forget Sentry report
+    // (a scheduled throwing mutation) is drained inside the test rather than
+    // firing after teardown as an unhandled rejection.
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    process.env.DODO_API_KEY = "test_dodo_key";
+    process.env.RESEND_API_KEY = "test_resend_key";
+    const t = convexTest(schema, modules);
+
+    // Two stale pending payments; pay_iso_a is newer so it is scanned first.
+    await seedPaymentEvent(t, {
+      status: "requires_customer_action",
+      planKey: "pro_monthly",
+      occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - MIN_MS,
+      suffix: "iso_a",
+      dodoPaymentId: "pay_iso_a",
+    });
+    await seedPaymentEvent(t, {
+      status: "requires_customer_action",
+      planKey: "pro_monthly",
+      occurredAt: NOW - STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS - 2 * MIN_MS,
+      suffix: "iso_b",
+      dodoPaymentId: "pay_iso_b",
+    });
+
+    dodoRetrieveMock.mockImplementation(async (id: string) => ({
+      status: "requires_customer_action",
+      payment_id: id,
+      customer: { email: "buyer@example.com" },
+      payment_link: "https://checkout.dodopayments.com/session/x",
+    }));
+
+    // First Resend call throws (hung socket); the second succeeds. Proves the
+    // batch is not aborted by one candidate's email failure.
+    let resendCalls = 0;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input: any) => {
+      if (String(input).includes("api.resend.com")) {
+        resendCalls++;
+        if (resendCalls === 1) throw new Error("socket hang up");
+        return new Response(JSON.stringify({ id: "email_ok" }), { status: 200 });
+      }
+      return new Response("{}", { status: 200 });
+    });
+
+    const summary = await t.action(internal.payments.billing.reconcileStuckPendingPayments, {});
+    // Drain the scheduled email-failure report (throws internally, captured by
+    // Convex auto-Sentry in prod) so it doesn't leak past the test.
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+
+    expect(summary).toMatchObject({ candidates: 2, emailFailed: 1, customerNotified: 1 });
+
+    // The failed-email candidate still has its claim marker (ops_notified), so
+    // the next run skips it — no re-email. The other was notified.
+    const markerA = await t.run(async (ctx) =>
+      ctx.db
+        .query("paymentReconciliationAttempts")
+        .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", "pay_iso_a"))
+        .first(),
+    );
+    const markerB = await t.run(async (ctx) =>
+      ctx.db
+        .query("paymentReconciliationAttempts")
+        .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", "pay_iso_b"))
+        .first(),
+    );
+    expect(markerA?.action).toBe("ops_notified");
+    expect(markerB?.action).toBe("customer_notified");
   });
 
   test("registers the daily reconciliation cron", () => {

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -35,9 +35,16 @@ crons.daily(
   {},
 );
 
-crons.daily(
+// Every 6h, not daily: a payment becomes a reconciliation candidate at ~6h
+// pending, so on a daily cadence its age at first scan is uniformly 6h-30h and
+// anything landing in (24h, 30h] misses the 24h customer-email freshness gate
+// (STUCK_PAYMENT_CUSTOMER_EMAIL_MAX_AGE_MS) — ~25% of ordinary stuck payments
+// silently dropped to ops-only. At 6h cadence first-scan age stays <=~12h, so
+// every stuck payment gets its recovery email. Safe to run 4x/day: the action
+// is fully idempotent and marker-gated (already-handled payments are skipped).
+crons.interval(
   "payments-stuck-pending-reconciliation",
-  { hourUTC: 4, minuteUTC: 30 },
+  { hours: 6 },
   internal.payments.billing.reconcileStuckPendingPayments,
   {},
 );

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -35,6 +35,13 @@ crons.daily(
   {},
 );
 
+crons.daily(
+  "payments-stuck-pending-reconciliation",
+  { hourUTC: 4, minuteUTC: 30 },
+  internal.payments.billing.reconcileStuckPendingPayments,
+  {},
+);
+
 // Idempotent daily seed of the `followedCountriesShards` lock table
 // (Codex round-4 P0 v2). Skips existing shards; inserts any missing
 // shard ids in `[0, SHARD_COUNT)`. Defends against a deploy-time seed

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -815,6 +815,145 @@ export const getCheckoutBlockingSubscription = internalQuery({
  * err slightly long if tuning. Single source of truth: change it here only.
  */
 export const PENDING_PAYMENT_BLOCK_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+export const STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS = 6 * 60 * 60 * 1000; // 6 hours
+export const STUCK_PAYMENT_RECONCILIATION_LOOKBACK_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
+export const STUCK_PAYMENT_RECONCILIATION_BATCH_SIZE = 25;
+const MAX_STUCK_PAYMENT_RECONCILIATION_BATCH_SIZE = 100;
+const MAX_STUCK_PAYMENT_RECONCILIATION_SCAN_ROWS = 500;
+const RESEND_EMAILS_URL = "https://api.resend.com/emails";
+const STUCK_PAYMENT_EMAIL_FROM = "World Monitor <noreply@worldmonitor.app>";
+const STUCK_PAYMENT_SUPPORT_EMAIL = "support@worldmonitor.app";
+
+function isPendingPaymentStatus(status: string): boolean {
+  return status === "processing" || status === "requires_customer_action";
+}
+
+function isTerminalPaymentStatus(status: string): status is "succeeded" | "failed" | "cancelled" {
+  return status === "succeeded" || status === "failed" || status === "cancelled";
+}
+
+function boundedPositiveInteger(value: number | undefined, fallback: number, max: number): number {
+  if (!Number.isFinite(value) || value === undefined) return fallback;
+  return Math.max(1, Math.min(max, Math.floor(value)));
+}
+
+function boundedPositiveMs(value: number | undefined, fallback: number): number {
+  if (!Number.isFinite(value) || value === undefined) return fallback;
+  return Math.max(1, Math.floor(value));
+}
+
+type DodoPaymentLookup = {
+  status?: unknown;
+  payment_id?: unknown;
+  subscription_id?: unknown;
+  total_amount?: unknown;
+  amount?: unknown;
+  currency?: unknown;
+  payment_link?: unknown;
+  customer?: {
+    email?: unknown;
+    name?: unknown;
+  } | null;
+};
+
+type StuckPaymentCandidate = {
+  userId: string;
+  dodoPaymentId: string;
+  dodoSubscriptionId?: string;
+  planKey?: string;
+  amount: number;
+  currency: string;
+  pendingStatus: "processing" | "requires_customer_action";
+  pendingOccurredAt: number;
+};
+
+type ReconcileStuckPendingPaymentsSummary = {
+  candidates: number;
+  terminalReconciled: number;
+  customerNotified: number;
+  opsNotified: number;
+  alreadySkipped: number;
+  unknownStatus: number;
+  pollFailed: number;
+};
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function extractDodoPaymentStatus(payment: unknown): string | null {
+  if (!payment || typeof payment !== "object") return null;
+  const rawStatus = (payment as DodoPaymentLookup).status;
+  return typeof rawStatus === "string" && rawStatus.length > 0 ? rawStatus : null;
+}
+
+async function retrieveDodoPayment(dodoPaymentId: string): Promise<unknown> {
+  const client = getDodoClient();
+  return await client.payments.retrieve(dodoPaymentId);
+}
+
+async function sendStuckPaymentEmail(
+  payment: DodoPaymentLookup,
+  planKey: string | undefined,
+): Promise<"customer_notified" | "ops_notified"> {
+  const email = readString(payment.customer?.email);
+  const checkoutUrl = readString(payment.payment_link);
+  const apiKey = process.env.RESEND_API_KEY;
+
+  if (!email || !checkoutUrl) return "ops_notified";
+  if (!apiKey) {
+    console.warn("[billing/reconciliation] RESEND_API_KEY not set; skipping stuck-payment customer email.");
+    return "ops_notified";
+  }
+
+  const planName = planKey ? PRODUCT_CATALOG[planKey]?.displayName ?? "World Monitor" : "World Monitor";
+  const safePlanName = escapeHtml(planName);
+  const safeCheckoutUrl = escapeHtml(checkoutUrl);
+  const safeSupportEmail = escapeHtml(STUCK_PAYMENT_SUPPORT_EMAIL);
+  const html = `
+    <div style="font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #111; line-height: 1.5;">
+      <h1 style="font-size: 20px;">Your World Monitor checkout still needs action</h1>
+      <p>Your ${safePlanName} payment is still waiting for bank or card verification.</p>
+      <p>You can safely continue checkout here:</p>
+      <p><a href="${safeCheckoutUrl}" style="display: inline-block; background: #111; color: #fff; padding: 10px 14px; text-decoration: none;">Continue checkout</a></p>
+      <p>If you already completed payment, you can ignore this email or contact <a href="mailto:${safeSupportEmail}">${safeSupportEmail}</a>.</p>
+    </div>`;
+
+  const res = await fetch(RESEND_EMAILS_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      from: STUCK_PAYMENT_EMAIL_FROM,
+      to: [email],
+      subject: "Complete your World Monitor checkout",
+      html,
+      reply_to: STUCK_PAYMENT_SUPPORT_EMAIL,
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    console.warn(`[billing/reconciliation] Resend stuck-payment email ${res.status}: ${body}`);
+    return "ops_notified";
+  }
+
+  return "customer_notified";
+}
 
 /**
  * Internal query used by checkout creation to prevent DUPLICATE PENDING
@@ -895,6 +1034,240 @@ export const getBlockingPendingPayment = internalQuery({
       displayName: PRODUCT_CATALOG[blocking.planKey]?.displayName ?? blocking.planKey,
       occurredAt: blocking.occurredAt,
     };
+  },
+});
+
+export const listStuckPendingPaymentCandidates = internalQuery({
+  args: {
+    thresholdMs: v.optional(v.number()),
+    lookbackMs: v.optional(v.number()),
+    batchSize: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const thresholdMs = boundedPositiveMs(args.thresholdMs, STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS);
+    const lookbackMs = boundedPositiveMs(args.lookbackMs, STUCK_PAYMENT_RECONCILIATION_LOOKBACK_MS);
+    const batchSize = boundedPositiveInteger(
+      args.batchSize,
+      STUCK_PAYMENT_RECONCILIATION_BATCH_SIZE,
+      MAX_STUCK_PAYMENT_RECONCILIATION_BATCH_SIZE,
+    );
+
+    const now = Date.now();
+    const staleBefore = now - thresholdMs;
+    const lookbackStart = now - lookbackMs;
+    const paymentEvents = await ctx.db
+      .query("paymentEvents")
+      .withIndex("by_occurredAt", (q) =>
+        q.gt("occurredAt", lookbackStart).lt("occurredAt", staleBefore),
+      )
+      .take(MAX_STUCK_PAYMENT_RECONCILIATION_SCAN_ROWS);
+
+    const candidates: StuckPaymentCandidate[] = [];
+    const seenPaymentIds = new Set<string>();
+    for (const ev of paymentEvents) {
+      if (candidates.length >= batchSize) break;
+      if (ev.type !== "charge") continue;
+      if (!isPendingPaymentStatus(ev.status)) continue;
+      if (seenPaymentIds.has(ev.dodoPaymentId)) continue;
+      seenPaymentIds.add(ev.dodoPaymentId);
+
+      const marker = await ctx.db
+        .query("paymentReconciliationAttempts")
+        .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", ev.dodoPaymentId))
+        .first();
+      if (marker) continue;
+
+      const history = await ctx.db
+        .query("paymentEvents")
+        .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", ev.dodoPaymentId))
+        .collect();
+      if (history.some((row) => row.type === "charge" && isTerminalPaymentStatus(row.status))) {
+        continue;
+      }
+
+      candidates.push({
+        userId: ev.userId,
+        dodoPaymentId: ev.dodoPaymentId,
+        dodoSubscriptionId: ev.dodoSubscriptionId,
+        planKey: ev.planKey,
+        amount: ev.amount,
+        currency: ev.currency,
+        pendingStatus: ev.status as "processing" | "requires_customer_action",
+        pendingOccurredAt: ev.occurredAt,
+      });
+    }
+
+    return candidates;
+  },
+});
+
+export const recordStuckPaymentReconciliationOutcome = internalMutation({
+  args: {
+    userId: v.string(),
+    dodoPaymentId: v.string(),
+    dodoSubscriptionId: v.optional(v.string()),
+    planKey: v.optional(v.string()),
+    amount: v.number(),
+    currency: v.string(),
+    pendingOccurredAt: v.number(),
+    observedStatus: v.string(),
+    staleAction: v.optional(v.union(v.literal("customer_notified"), v.literal("ops_notified"))),
+    rawPayload: v.any(),
+  },
+  handler: async (ctx, args) => {
+    const existingMarker = await ctx.db
+      .query("paymentReconciliationAttempts")
+      .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", args.dodoPaymentId))
+      .first();
+    if (existingMarker) return { action: "already_marked" as const };
+
+    const history = await ctx.db
+      .query("paymentEvents")
+      .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", args.dodoPaymentId))
+      .collect();
+    if (history.some((row) => row.type === "charge" && isTerminalPaymentStatus(row.status))) {
+      return { action: "already_terminal" as const };
+    }
+
+    const now = Date.now();
+    if (isTerminalPaymentStatus(args.observedStatus)) {
+      await ctx.db.insert("paymentEvents", {
+        userId: args.userId,
+        dodoPaymentId: args.dodoPaymentId,
+        type: "charge",
+        amount: args.amount,
+        currency: args.currency,
+        status: args.observedStatus,
+        dodoSubscriptionId: args.dodoSubscriptionId,
+        planKey: args.planKey,
+        rawPayload: args.rawPayload,
+        occurredAt: now,
+      });
+      await ctx.db.insert("paymentReconciliationAttempts", {
+        dodoPaymentId: args.dodoPaymentId,
+        userId: args.userId,
+        planKey: args.planKey,
+        action: "terminal_reconciled",
+        observedStatus: args.observedStatus,
+        pendingOccurredAt: args.pendingOccurredAt,
+        reconciledAt: now,
+      });
+      return { action: "terminal_reconciled" as const };
+    }
+
+    if (isPendingPaymentStatus(args.observedStatus)) {
+      const action = args.staleAction ?? "ops_notified";
+      await ctx.db.insert("paymentReconciliationAttempts", {
+        dodoPaymentId: args.dodoPaymentId,
+        userId: args.userId,
+        planKey: args.planKey,
+        action,
+        observedStatus: args.observedStatus,
+        pendingOccurredAt: args.pendingOccurredAt,
+        reconciledAt: now,
+      });
+      console.warn(
+        `[billing/reconciliation] stale Dodo payment still pending after threshold: ` +
+        `paymentId=${args.dodoPaymentId} userId=${args.userId} status=${args.observedStatus} ` +
+        `pendingOccurredAt=${args.pendingOccurredAt}. Ops follow-up required.`,
+      );
+      return { action };
+    }
+
+    return { action: "unknown_status" as const };
+  },
+});
+
+export const reportPaymentReconciliationPollFailure = internalMutation({
+  args: {
+    dodoPaymentId: v.string(),
+    errorMessage: v.string(),
+  },
+  handler: async (_ctx, args) => {
+    throw new Error(
+      `[billing/reconciliation] Dodo payment poll failed paymentId=${args.dodoPaymentId}: ${args.errorMessage}`,
+    );
+  },
+});
+
+export const reconcileStuckPendingPayments = internalAction({
+  args: {
+    thresholdMs: v.optional(v.number()),
+    lookbackMs: v.optional(v.number()),
+    batchSize: v.optional(v.number()),
+  },
+  handler: async (ctx, args): Promise<ReconcileStuckPendingPaymentsSummary> => {
+    const candidates = await ctx.runQuery(
+      (internal as any).payments.billing.listStuckPendingPaymentCandidates,
+      args,
+    ) as StuckPaymentCandidate[];
+
+    const summary: ReconcileStuckPendingPaymentsSummary = {
+      candidates: candidates.length,
+      terminalReconciled: 0,
+      customerNotified: 0,
+      opsNotified: 0,
+      alreadySkipped: 0,
+      unknownStatus: 0,
+      pollFailed: 0,
+    };
+
+    for (const candidate of candidates) {
+      try {
+        const payment = await retrieveDodoPayment(candidate.dodoPaymentId);
+        const observedStatus = extractDodoPaymentStatus(payment);
+        if (!observedStatus) {
+          summary.unknownStatus++;
+          console.warn(
+            `[billing/reconciliation] Dodo payment ${candidate.dodoPaymentId} returned no status; skipping.`,
+          );
+          continue;
+        }
+
+        const dodoPayment = payment as DodoPaymentLookup;
+        const staleAction = isPendingPaymentStatus(observedStatus)
+          ? await sendStuckPaymentEmail(dodoPayment, candidate.planKey)
+          : undefined;
+        const outcome = await ctx.runMutation(
+          (internal as any).payments.billing.recordStuckPaymentReconciliationOutcome,
+          {
+            userId: candidate.userId,
+            dodoPaymentId: candidate.dodoPaymentId,
+            dodoSubscriptionId: readString(dodoPayment.subscription_id) ?? candidate.dodoSubscriptionId,
+            planKey: candidate.planKey,
+            amount: readNumber(dodoPayment.total_amount) ?? readNumber(dodoPayment.amount) ?? candidate.amount,
+            currency: readString(dodoPayment.currency) ?? candidate.currency,
+            pendingOccurredAt: candidate.pendingOccurredAt,
+            observedStatus,
+            staleAction,
+            rawPayload: payment,
+          },
+        );
+
+        if (outcome.action === "terminal_reconciled") summary.terminalReconciled++;
+        else if (outcome.action === "customer_notified") summary.customerNotified++;
+        else if (outcome.action === "ops_notified") summary.opsNotified++;
+        else if (outcome.action === "unknown_status") summary.unknownStatus++;
+        else summary.alreadySkipped++;
+      } catch (err) {
+        // sentry-coverage-ok: schedule a throwing mutation below so Convex auto-Sentry captures this payment without aborting the whole batch.
+        summary.pollFailed++;
+        const message = err instanceof Error ? err.message : String(err);
+        await ctx.scheduler.runAfter(
+          0,
+          (internal as any).payments.billing.reportPaymentReconciliationPollFailure,
+          { dodoPaymentId: candidate.dodoPaymentId, errorMessage: message },
+        );
+        console.warn(
+          `[billing/reconciliation] Failed to poll Dodo payment ${candidate.dodoPaymentId}: ${message}`,
+        );
+      }
+    }
+
+    if (summary.candidates > 0 || summary.pollFailed > 0) {
+      console.warn(`[billing/reconciliation] summary ${JSON.stringify(summary)}`);
+    }
+    return summary;
   },
 });
 

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -827,9 +827,14 @@ const MAX_STUCK_PAYMENT_RECONCILIATION_SCAN_ROWS = 500;
 const RESEND_EMAILS_URL = "https://api.resend.com/emails";
 const STUCK_PAYMENT_EMAIL_FROM = "World Monitor <noreply@worldmonitor.app>";
 const STUCK_PAYMENT_SUPPORT_EMAIL = "support@worldmonitor.app";
-// Bound the Resend POST so a hung socket can't stall the daily batch (a known
-// repo failure class — a network read with no timeout drains the event loop).
+// Bound the Resend POST so a hung socket can't stall the batch (a known repo
+// failure class — a network read with no timeout drains the event loop).
 const STUCK_PAYMENT_RESEND_TIMEOUT_MS = 10 * 1000;
+// Same bound for the Dodo poll — the highest-cardinality call (one per
+// candidate, up to the batch size sequentially). The SDK default is 60s x 2
+// retries (~180s), so one degraded response could otherwise burn the whole
+// action during exactly the Dodo outage this cron exists to survive.
+const STUCK_PAYMENT_DODO_RETRIEVE_TIMEOUT_MS = 10 * 1000;
 // Sentinel recorded on the marker when Dodo returns no status at all — keeps
 // the `observedStatus` field a non-empty string (v.string()) while preserving
 // "we polled but Dodo told us nothing" for triage.
@@ -914,7 +919,10 @@ function extractDodoPaymentStatus(payment: unknown): string | null {
 
 async function retrieveDodoPayment(dodoPaymentId: string): Promise<unknown> {
   const client = getDodoClient();
-  return await client.payments.retrieve(dodoPaymentId);
+  return await client.payments.retrieve(dodoPaymentId, {
+    timeout: STUCK_PAYMENT_DODO_RETRIEVE_TIMEOUT_MS,
+    maxRetries: 1,
+  });
 }
 
 async function sendStuckPaymentEmail(
@@ -1082,12 +1090,15 @@ export const listStuckPendingPaymentCandidates = internalQuery({
       .take(MAX_STUCK_PAYMENT_RECONCILIATION_SCAN_ROWS);
 
     if (paymentEvents.length >= MAX_STUCK_PAYMENT_RECONCILIATION_SCAN_ROWS) {
-      // Cap hit: rows older than the newest 500 in the window were not scanned
-      // this run. Surface it so ops can widen the cap / shorten the cadence
-      // before a sustained backlog hides stuck payments.
+      // Cap hit: only the newest 500 rows in the window were scanned. Because
+      // every run rescans newest-first, rows older than that frontier are NOT
+      // merely deferred to the next run — they stay invisible until the newer
+      // backlog clears. Surface it so ops widen the cap / shorten the cadence
+      // (a cursor/watermark would be the durable fix if this recurs).
       console.error(
         `[billing/reconciliation] scan cap hit: ${MAX_STUCK_PAYMENT_RECONCILIATION_SCAN_ROWS} rows in the ` +
-        `${Math.round(lookbackMs / (24 * 60 * 60 * 1000))}d window; older stale rows deferred to a later run.`,
+        `${Math.round(lookbackMs / (24 * 60 * 60 * 1000))}d window; rows older than the newest ` +
+        `${MAX_STUCK_PAYMENT_RECONCILIATION_SCAN_ROWS} stay unscanned until the backlog clears.`,
       );
     }
 
@@ -1204,6 +1215,28 @@ export const claimStuckPaymentReconciliation = internalMutation({
         pendingOccurredAt: args.pendingOccurredAt,
         reconciledAt: now,
       });
+
+      // Dropped-webhook guard: a payment webhook that never arrived may have
+      // travelled with a dropped `subscription.active` webhook — the customer
+      // is charged but never entitled, and no other reconciler catches a
+      // never-activated sub (#4794's renewal reconciler only scans active
+      // rows). Silently closing the case here would bury it. Page ops when a
+      // succeeded charge has a subscription id but no subscription row at all.
+      if (args.observedStatus === "succeeded" && args.dodoSubscriptionId) {
+        const sub = await ctx.db
+          .query("subscriptions")
+          .withIndex("by_dodoSubscriptionId", (q) =>
+            q.eq("dodoSubscriptionId", args.dodoSubscriptionId!),
+          )
+          .first();
+        if (!sub) {
+          console.error(
+            `[billing/reconciliation] reconciled a SUCCEEDED payment with no subscription row: ` +
+            `paymentId=${args.dodoPaymentId} userId=${args.userId} subscriptionId=${args.dodoSubscriptionId}. ` +
+            `Charged customer may lack entitlement (dropped subscription.active webhook) — ops follow-up required.`,
+          );
+        }
+      }
       return { action: "terminal_reconciled" as const };
     }
 

--- a/convex/payments/billing.ts
+++ b/convex/payments/billing.ts
@@ -818,11 +818,22 @@ export const PENDING_PAYMENT_BLOCK_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
 export const STUCK_PAYMENT_RECONCILIATION_THRESHOLD_MS = 6 * 60 * 60 * 1000; // 6 hours
 export const STUCK_PAYMENT_RECONCILIATION_LOOKBACK_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 export const STUCK_PAYMENT_RECONCILIATION_BATCH_SIZE = 25;
+// A stale pending payment older than this no longer gets a "continue checkout"
+// email — the Dodo hosted-checkout link expires, so a confident email with a
+// dead link is worse than none. Older candidates route to the ops path instead.
+export const STUCK_PAYMENT_CUSTOMER_EMAIL_MAX_AGE_MS = 24 * 60 * 60 * 1000; // 24 hours
 const MAX_STUCK_PAYMENT_RECONCILIATION_BATCH_SIZE = 100;
 const MAX_STUCK_PAYMENT_RECONCILIATION_SCAN_ROWS = 500;
 const RESEND_EMAILS_URL = "https://api.resend.com/emails";
 const STUCK_PAYMENT_EMAIL_FROM = "World Monitor <noreply@worldmonitor.app>";
 const STUCK_PAYMENT_SUPPORT_EMAIL = "support@worldmonitor.app";
+// Bound the Resend POST so a hung socket can't stall the daily batch (a known
+// repo failure class — a network read with no timeout drains the event loop).
+const STUCK_PAYMENT_RESEND_TIMEOUT_MS = 10 * 1000;
+// Sentinel recorded on the marker when Dodo returns no status at all — keeps
+// the `observedStatus` field a non-empty string (v.string()) while preserving
+// "we polled but Dodo told us nothing" for triage.
+const UNKNOWN_DODO_PAYMENT_STATUS = "unknown";
 
 function isPendingPaymentStatus(status: string): boolean {
   return status === "processing" || status === "requires_customer_action";
@@ -875,6 +886,8 @@ type ReconcileStuckPendingPaymentsSummary = {
   alreadySkipped: number;
   unknownStatus: number;
   pollFailed: number;
+  emailFailed: number;
+  recordFailed: number;
 };
 
 function readString(value: unknown): string | undefined {
@@ -944,11 +957,12 @@ async function sendStuckPaymentEmail(
       html,
       reply_to: STUCK_PAYMENT_SUPPORT_EMAIL,
     }),
+    signal: AbortSignal.timeout(STUCK_PAYMENT_RESEND_TIMEOUT_MS),
   });
 
   if (!res.ok) {
-    const body = await res.text();
-    console.warn(`[billing/reconciliation] Resend stuck-payment email ${res.status}: ${body}`);
+    // Log the status only — the response body can echo the recipient email.
+    console.warn(`[billing/reconciliation] Resend stuck-payment email failed with HTTP ${res.status}.`);
     return "ops_notified";
   }
 
@@ -1055,12 +1069,27 @@ export const listStuckPendingPaymentCandidates = internalQuery({
     const now = Date.now();
     const staleBefore = now - thresholdMs;
     const lookbackStart = now - lookbackMs;
+    // Scan NEWEST-first: past the scan cap, the freshly-stuck rows (the ones a
+    // customer might still act on) stay visible, while the oldest ops-only rows
+    // are the ones deferred to a later run. Ascending order did the opposite —
+    // fresh stuck payments could silently fall off the end of the window.
     const paymentEvents = await ctx.db
       .query("paymentEvents")
       .withIndex("by_occurredAt", (q) =>
         q.gt("occurredAt", lookbackStart).lt("occurredAt", staleBefore),
       )
+      .order("desc")
       .take(MAX_STUCK_PAYMENT_RECONCILIATION_SCAN_ROWS);
+
+    if (paymentEvents.length >= MAX_STUCK_PAYMENT_RECONCILIATION_SCAN_ROWS) {
+      // Cap hit: rows older than the newest 500 in the window were not scanned
+      // this run. Surface it so ops can widen the cap / shorten the cadence
+      // before a sustained backlog hides stuck payments.
+      console.error(
+        `[billing/reconciliation] scan cap hit: ${MAX_STUCK_PAYMENT_RECONCILIATION_SCAN_ROWS} rows in the ` +
+        `${Math.round(lookbackMs / (24 * 60 * 60 * 1000))}d window; older stale rows deferred to a later run.`,
+      );
+    }
 
     const candidates: StuckPaymentCandidate[] = [];
     const seenPaymentIds = new Set<string>();
@@ -1101,7 +1130,31 @@ export const listStuckPendingPaymentCandidates = internalQuery({
   },
 });
 
-export const recordStuckPaymentReconciliationOutcome = internalMutation({
+/**
+ * Claims a reconciliation marker for one stuck pending payment, recording the
+ * status Dodo reported when we polled it.
+ *
+ * This is the idempotency barrier for the whole flow: the action writes the
+ * marker HERE, before sending any customer email, so a transient failure after
+ * this point can never re-email the customer on the next daily run (the
+ * candidate query skips any payment that already has a marker).
+ *
+ * Outcomes:
+ *   - `already_marked` / `already_terminal` — a prior run or a webhook won;
+ *     nothing written.
+ *   - `terminal_reconciled` — Dodo now reports a terminal status (a dropped
+ *     webhook); backfill the missing paymentEvents row + a terminal marker.
+ *   - `pending_claimed` — any non-terminal status (recognised 3DS-pending,
+ *     an unrecognised IntentStatus like `requires_payment_method`, or the
+ *     `unknown` sentinel when Dodo returned no status). Writes a PROVISIONAL
+ *     `ops_notified` marker; the action later calls
+ *     `finalizeStuckPaymentReconciliation` to upgrade it to `customer_notified`
+ *     on a successful email, or to page ops. Mirrors
+ *     `derivePaymentEventStatus`'s collapse of non-terminal IntentStatus — a
+ *     stuck payment is NEVER dropped without a marker (its absence is what
+ *     causes daily re-polling for 14 days + batch-slot starvation).
+ */
+export const claimStuckPaymentReconciliation = internalMutation({
   args: {
     userId: v.string(),
     dodoPaymentId: v.string(),
@@ -1111,7 +1164,6 @@ export const recordStuckPaymentReconciliationOutcome = internalMutation({
     currency: v.string(),
     pendingOccurredAt: v.number(),
     observedStatus: v.string(),
-    staleAction: v.optional(v.union(v.literal("customer_notified"), v.literal("ops_notified"))),
     rawPayload: v.any(),
   },
   handler: async (ctx, args) => {
@@ -1155,37 +1207,83 @@ export const recordStuckPaymentReconciliationOutcome = internalMutation({
       return { action: "terminal_reconciled" as const };
     }
 
-    if (isPendingPaymentStatus(args.observedStatus)) {
-      const action = args.staleAction ?? "ops_notified";
-      await ctx.db.insert("paymentReconciliationAttempts", {
-        dodoPaymentId: args.dodoPaymentId,
-        userId: args.userId,
-        planKey: args.planKey,
-        action,
-        observedStatus: args.observedStatus,
-        pendingOccurredAt: args.pendingOccurredAt,
-        reconciledAt: now,
-      });
-      console.warn(
-        `[billing/reconciliation] stale Dodo payment still pending after threshold: ` +
-        `paymentId=${args.dodoPaymentId} userId=${args.userId} status=${args.observedStatus} ` +
-        `pendingOccurredAt=${args.pendingOccurredAt}. Ops follow-up required.`,
-      );
-      return { action };
-    }
-
-    return { action: "unknown_status" as const };
+    // Non-terminal (recognised pending OR unrecognised / `unknown`): claim a
+    // PROVISIONAL ops_notified marker. No console.error here — the true
+    // outcome (customer emailed vs ops paged) isn't known until the action
+    // finalizes, and paging ops for a customer we then successfully email
+    // would be a false alarm.
+    await ctx.db.insert("paymentReconciliationAttempts", {
+      dodoPaymentId: args.dodoPaymentId,
+      userId: args.userId,
+      planKey: args.planKey,
+      action: "ops_notified",
+      observedStatus: args.observedStatus,
+      pendingOccurredAt: args.pendingOccurredAt,
+      reconciledAt: now,
+    });
+    return { action: "pending_claimed" as const };
   },
 });
 
-export const reportPaymentReconciliationPollFailure = internalMutation({
+/**
+ * Finalizes a claimed (provisional `ops_notified`) marker once the action
+ * knows the email outcome.
+ *
+ * - `notified: true`  → the customer email was sent; upgrade the marker to
+ *   `customer_notified`. No ops page.
+ * - `notified: false` → ops follow-up (unrecognised status, stale checkout
+ *   link, missing email/link, RESEND_API_KEY unset, or a Resend non-2xx). The
+ *   marker stays `ops_notified` and we `console.error` — Convex auto-Sentry
+ *   forwards console.error (the refund-alert precedent in
+ *   subscriptionHelpers.ts), so ops is ACTUALLY paged instead of the
+ *   never-surfaced console.warn this replaced.
+ */
+export const finalizeStuckPaymentReconciliation = internalMutation({
   args: {
+    dodoPaymentId: v.string(),
+    notified: v.boolean(),
+  },
+  handler: async (ctx, args) => {
+    const marker = await ctx.db
+      .query("paymentReconciliationAttempts")
+      .withIndex("by_dodoPaymentId", (q) => q.eq("dodoPaymentId", args.dodoPaymentId))
+      .first();
+    if (!marker) {
+      // The claim always inserts a marker, so a missing one means a concurrent
+      // delete or a caller bug — surface it rather than silently no-op.
+      console.warn(
+        `[billing/reconciliation] finalize found no marker for paymentId=${args.dodoPaymentId}.`,
+      );
+      return { action: "marker_missing" as const };
+    }
+    // Idempotent: a re-run that already upgraded this marker must not downgrade.
+    if (marker.action === "customer_notified") {
+      return { action: "customer_notified" as const };
+    }
+
+    if (args.notified) {
+      await ctx.db.patch(marker._id, { action: "customer_notified", reconciledAt: Date.now() });
+      return { action: "customer_notified" as const };
+    }
+
+    console.error(
+      `[billing/reconciliation] stale Dodo payment still pending after threshold: ` +
+      `paymentId=${marker.dodoPaymentId} userId=${marker.userId} status=${marker.observedStatus} ` +
+      `pendingOccurredAt=${marker.pendingOccurredAt}. Ops follow-up required.`,
+    );
+    return { action: "ops_notified" as const };
+  },
+});
+
+export const reportPaymentReconciliationFailure = internalMutation({
+  args: {
+    phase: v.union(v.literal("poll"), v.literal("email"), v.literal("record")),
     dodoPaymentId: v.string(),
     errorMessage: v.string(),
   },
   handler: async (_ctx, args) => {
     throw new Error(
-      `[billing/reconciliation] Dodo payment poll failed paymentId=${args.dodoPaymentId}: ${args.errorMessage}`,
+      `[billing/reconciliation] ${args.phase} phase failed paymentId=${args.dodoPaymentId}: ${args.errorMessage}`,
     );
   },
 });
@@ -1210,26 +1308,79 @@ export const reconcileStuckPendingPayments = internalAction({
       alreadySkipped: 0,
       unknownStatus: 0,
       pollFailed: 0,
+      emailFailed: 0,
+      recordFailed: 0,
     };
 
-    for (const candidate of candidates) {
+    // Best-effort Sentry hand-off, labelled by phase (poll vs email vs record)
+    // so a mislabel can't hide the real failure. The scheduled mutation throws,
+    // which Convex auto-Sentry captures; wrapping runAfter in its own try/catch
+    // keeps a scheduler hiccup from aborting the day's batch (webhookHandlers.ts
+    // precedent).
+    const reportFailure = async (
+      phase: "poll" | "email" | "record",
+      dodoPaymentId: string,
+      message: string,
+    ): Promise<void> => {
       try {
-        const payment = await retrieveDodoPayment(candidate.dodoPaymentId);
-        const observedStatus = extractDodoPaymentStatus(payment);
-        if (!observedStatus) {
-          summary.unknownStatus++;
-          console.warn(
-            `[billing/reconciliation] Dodo payment ${candidate.dodoPaymentId} returned no status; skipping.`,
-          );
-          continue;
-        }
+        await ctx.scheduler.runAfter(
+          0,
+          (internal as any).payments.billing.reportPaymentReconciliationFailure,
+          { phase, dodoPaymentId, errorMessage: message },
+        );
+      } catch (scheduleErr) {
+        // sentry-coverage-ok: the scheduled report is a best-effort Sentry
+        // hand-off; the durable state is the reconciliation marker. A scheduler
+        // outage here must not abort the batch.
+        console.warn(
+          `[billing/reconciliation] failed to schedule ${phase} failure report for ${dodoPaymentId}: ` +
+          `${scheduleErr instanceof Error ? scheduleErr.message : String(scheduleErr)}`,
+        );
+      }
+    };
 
-        const dodoPayment = payment as DodoPaymentLookup;
-        const staleAction = isPendingPaymentStatus(observedStatus)
-          ? await sendStuckPaymentEmail(dodoPayment, candidate.planKey)
-          : undefined;
-        const outcome = await ctx.runMutation(
-          (internal as any).payments.billing.recordStuckPaymentReconciliationOutcome,
+    // Finalize a claimed marker as ops (notified: false). Swallows its own
+    // failure to a phase="record" Sentry report — the provisional ops_notified
+    // marker from the claim already stands, so the outcome is durable.
+    const finalizeOps = async (dodoPaymentId: string): Promise<void> => {
+      try {
+        await ctx.runMutation(
+          (internal as any).payments.billing.finalizeStuckPaymentReconciliation,
+          { dodoPaymentId, notified: false },
+        );
+      } catch (err) {
+        // sentry-coverage-ok: reportFailure schedules a throwing mutation.
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn(`[billing/reconciliation] finalize (ops) failed for ${dodoPaymentId}: ${message}`);
+        await reportFailure("record", dodoPaymentId, message);
+      }
+    };
+
+    const now = Date.now();
+
+    for (const candidate of candidates) {
+      // Phase — poll Dodo for the current payment status.
+      let payment: unknown;
+      try {
+        payment = await retrieveDodoPayment(candidate.dodoPaymentId);
+      } catch (err) {
+        // sentry-coverage-ok: reportFailure schedules a throwing mutation.
+        summary.pollFailed++;
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn(`[billing/reconciliation] poll failed for ${candidate.dodoPaymentId}: ${message}`);
+        await reportFailure("poll", candidate.dodoPaymentId, message);
+        continue;
+      }
+
+      const observedStatus = extractDodoPaymentStatus(payment); // string | null
+      const dodoPayment = payment as DodoPaymentLookup;
+      const recordedStatus = observedStatus ?? UNKNOWN_DODO_PAYMENT_STATUS;
+
+      // Phase — CLAIM the marker BEFORE any email (idempotency barrier).
+      let claim: { action: string };
+      try {
+        claim = await ctx.runMutation(
+          (internal as any).payments.billing.claimStuckPaymentReconciliation,
           {
             userId: candidate.userId,
             dodoPaymentId: candidate.dodoPaymentId,
@@ -1238,29 +1389,84 @@ export const reconcileStuckPendingPayments = internalAction({
             amount: readNumber(dodoPayment.total_amount) ?? readNumber(dodoPayment.amount) ?? candidate.amount,
             currency: readString(dodoPayment.currency) ?? candidate.currency,
             pendingOccurredAt: candidate.pendingOccurredAt,
-            observedStatus,
-            staleAction,
+            observedStatus: recordedStatus,
             rawPayload: payment,
           },
         );
-
-        if (outcome.action === "terminal_reconciled") summary.terminalReconciled++;
-        else if (outcome.action === "customer_notified") summary.customerNotified++;
-        else if (outcome.action === "ops_notified") summary.opsNotified++;
-        else if (outcome.action === "unknown_status") summary.unknownStatus++;
-        else summary.alreadySkipped++;
       } catch (err) {
-        // sentry-coverage-ok: schedule a throwing mutation below so Convex auto-Sentry captures this payment without aborting the whole batch.
-        summary.pollFailed++;
+        // sentry-coverage-ok: reportFailure schedules a throwing mutation.
+        summary.recordFailed++;
         const message = err instanceof Error ? err.message : String(err);
-        await ctx.scheduler.runAfter(
-          0,
-          (internal as any).payments.billing.reportPaymentReconciliationPollFailure,
-          { dodoPaymentId: candidate.dodoPaymentId, errorMessage: message },
-        );
-        console.warn(
-          `[billing/reconciliation] Failed to poll Dodo payment ${candidate.dodoPaymentId}: ${message}`,
-        );
+        console.warn(`[billing/reconciliation] claim failed for ${candidate.dodoPaymentId}: ${message}`);
+        await reportFailure("record", candidate.dodoPaymentId, message);
+        continue;
+      }
+
+      if (claim.action === "terminal_reconciled") {
+        summary.terminalReconciled++;
+        continue;
+      }
+      if (claim.action !== "pending_claimed") {
+        // already_marked / already_terminal — a prior run or a webhook won.
+        summary.alreadySkipped++;
+        continue;
+      }
+
+      // Marker is claimed as provisional ops_notified. Decide whether to email.
+      const recognizedPending = observedStatus != null && isPendingPaymentStatus(observedStatus);
+      const linkFresh = now - candidate.pendingOccurredAt < STUCK_PAYMENT_CUSTOMER_EMAIL_MAX_AGE_MS;
+
+      if (!recognizedPending) {
+        // Unrecognised IntentStatus (incl. null / requires_payment_method — the
+        // typical abandoned-3DS end-state). Ops path, marker already written.
+        summary.unknownStatus++;
+        await finalizeOps(candidate.dodoPaymentId);
+        continue;
+      }
+
+      if (!linkFresh) {
+        // Stale checkout link (Dodo links expire): a confident email with a
+        // dead link is worse than none. Ops path instead.
+        summary.opsNotified++;
+        await finalizeOps(candidate.dodoPaymentId);
+        continue;
+      }
+
+      // Phase — send the customer "continue checkout" email.
+      let emailResult: "customer_notified" | "ops_notified";
+      try {
+        emailResult = await sendStuckPaymentEmail(dodoPayment, candidate.planKey);
+      } catch (err) {
+        // sentry-coverage-ok: reportFailure schedules a throwing mutation. The
+        // claimed ops_notified marker stands, so the next run won't re-email.
+        summary.emailFailed++;
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn(`[billing/reconciliation] email failed for ${candidate.dodoPaymentId}: ${message}`);
+        await reportFailure("email", candidate.dodoPaymentId, message);
+        continue;
+      }
+
+      // Phase — finalize the marker to reflect the email outcome.
+      if (emailResult === "customer_notified") {
+        try {
+          await ctx.runMutation(
+            (internal as any).payments.billing.finalizeStuckPaymentReconciliation,
+            { dodoPaymentId: candidate.dodoPaymentId, notified: true },
+          );
+          summary.customerNotified++;
+        } catch (err) {
+          // sentry-coverage-ok: reportFailure schedules a throwing mutation. The
+          // marker stays ops_notified (safe default) — the ops path owns it.
+          summary.opsNotified++;
+          const message = err instanceof Error ? err.message : String(err);
+          console.warn(`[billing/reconciliation] finalize failed for ${candidate.dodoPaymentId}: ${message}`);
+          await reportFailure("record", candidate.dodoPaymentId, message);
+        }
+      } else {
+        // sendStuckPaymentEmail returned ops_notified (missing email/link,
+        // RESEND_API_KEY unset, or Resend non-2xx).
+        summary.opsNotified++;
+        await finalizeOps(candidate.dodoPaymentId);
       }
     }
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -648,11 +648,28 @@ export default defineSchema({
   })
     .index("by_userId", ["userId"])
     .index("by_dodoPaymentId", ["dodoPaymentId"])
+    .index("by_occurredAt", ["occurredAt"])
     // Time-bounded read for the duplicate-payment guard (#4438): it only needs
     // recent rows (within the staleness window), so it queries this index with a
     // range on occurredAt instead of collecting the user's whole (unbounded,
     // rawPayload-carrying) payment history — keeps the guard fail-open.
     .index("by_userId_occurredAt", ["userId", "occurredAt"]),
+
+  paymentReconciliationAttempts: defineTable({
+    dodoPaymentId: v.string(),
+    userId: v.string(),
+    planKey: v.optional(v.string()),
+    action: v.union(
+      v.literal("terminal_reconciled"),
+      v.literal("customer_notified"),
+      v.literal("ops_notified"),
+    ),
+    observedStatus: v.string(),
+    pendingOccurredAt: v.number(),
+    reconciledAt: v.number(),
+  })
+    .index("by_dodoPaymentId", ["dodoPaymentId"])
+    .index("by_reconciledAt", ["reconciledAt"]),
 
   productPlans: defineTable({
     dodoProductId: v.string(),


### PR DESCRIPTION
## Summary
Stuck Dodo payments now have a scheduled recovery path instead of aging forever after abandoned 3DS or dropped webhook flows. The cron finds stale unresolved pending charge events, polls Dodo for the authoritative status, appends missing terminal payment events when the webhook was lost, and marks still-pending payments once after attempting a customer continuation email.

The still-pending path falls back to an ops-visible marker and structured warning when email delivery is unavailable, so the job remains idempotent and does not re-nag on every run. Poll failures are also surfaced through a scheduled throwing mutation so Convex auto-Sentry captures them without aborting the whole batch.

Fixes #4470.

## Validation
- ./node_modules/.bin/vitest run --config vitest.config.mts convex/__tests__/billing.test.ts
- npm run test:convex
- npm run typecheck
- npm run typecheck:api
- node scripts/check-sentry-coverage.mjs
- git push pre-push hook: typecheck, API typecheck, Convex type check, CJS syntax, Unicode safety, architectural boundaries, safe HTML, Sentry coverage, rate-limit policy coverage, premium-fetch parity, edge bundle check, version sync

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5 Codex](https://img.shields.io/badge/GPT--5_Codex-000000)