### PR TITLE
fix(api): suppress sentry delivery during node tests

### DIFF
--- a/api/_sentry-common.js
+++ b/api/_sentry-common.js
@@ -16,6 +16,10 @@ let _key = '';
 let _envelopeUrl = '';
 
 (function parseDsn() {
+  // Node's test runner can inherit production Vercel/Sentry env when tests run
+  // in deployment-like shells. Never let regression tests emit real events.
+  if (process.env.NODE_TEST_CONTEXT) return;
+
   const dsn = process.env.VITE_SENTRY_DSN ?? '';
   if (!dsn) return;
   try {

--- a/api/_sentry-common.test.mjs
+++ b/api/_sentry-common.test.mjs
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+
+const originalEnv = { ...process.env };
+const originalFetch = globalThis.fetch;
+
+function restoreEnv() {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) delete process.env[key];
+  }
+  Object.assign(process.env, originalEnv);
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  restoreEnv();
+});
+
+test('custom API Sentry transport is disabled under node:test even with a DSN', async (t) => {
+  if (!process.env.NODE_TEST_CONTEXT) {
+    t.skip('NODE_TEST_CONTEXT is not set by this test runner mode');
+    return;
+  }
+
+  process.env.VITE_SENTRY_DSN = 'https://public@example.ingest.sentry.io/12345';
+
+  let fetchCalls = 0;
+  globalThis.fetch = async () => {
+    fetchCalls += 1;
+    return new Response(null, { status: 200 });
+  };
+
+  const { makeCaptureSilentError } = await import(`./_sentry-common.js?test=${Date.now()}-${Math.random()}`);
+  const captureSilentError = makeCaptureSilentError({
+    runtime: 'edge',
+    platform: 'javascript',
+    logPrefix: '[sentry-test]',
+  });
+
+  await captureSilentError(new Error('test-only failure'));
+
+  assert.equal(fetchCalls, 0);
+});
+
+test('custom API Sentry transport can be exercised by clearing NODE_TEST_CONTEXT', async () => {
+  delete process.env.NODE_TEST_CONTEXT;
+  process.env.VITE_SENTRY_DSN = 'https://public@example.ingest.sentry.io/12345';
+
+  const fetchCalls = [];
+  globalThis.fetch = async (input, init) => {
+    fetchCalls.push({ input, init });
+    return new Response(null, { status: 200 });
+  };
+
+  const { makeCaptureSilentError } = await import(`./_sentry-common.js?test=${Date.now()}-${Math.random()}`);
+  const captureSilentError = makeCaptureSilentError({
+    runtime: 'edge',
+    platform: 'javascript',
+    logPrefix: '[sentry-test]',
+  });
+
+  await captureSilentError(new Error('test-only failure'));
+
+  assert.equal(fetchCalls.length, 1);
+  const [{ input, init }] = fetchCalls;
+  assert.equal(String(input), 'https://example.ingest.sentry.io/api/12345/envelope/');
+  assert.equal(init?.headers?.['X-Sentry-Auth'], 'Sentry sentry_version=7, sentry_key=public');
+});

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "dryrun:resilience": "node --import tsx/esm scripts/dry-run-resilience-rebalance.mjs",
     "test:feeds": "node scripts/validate-rss-feeds.mjs",
     "test:feeds:ci": "node scripts/validate-rss-feeds.mjs --ci",
-    "test:sidecar": "node --test src-tauri/sidecar/local-api-server.test.mjs src-tauri/open-url-safety.test.mjs api/_cors.test.mjs api/_session.test.mjs api/_api-key.test.mjs api/_user-api-key.test.mjs api/bootstrap-auth.test.mjs api/wm-session.test.mjs api/product-catalog.test.mjs api/youtube/embed.test.mjs api/cyber-threats.test.mjs api/usni-fleet.test.mjs scripts/ais-relay-rss.test.cjs api/loaders-xml-wms-regression.test.mjs api/security/report.test.mjs",
+    "test:sidecar": "node --test src-tauri/sidecar/local-api-server.test.mjs src-tauri/open-url-safety.test.mjs api/_cors.test.mjs api/_session.test.mjs api/_api-key.test.mjs api/_user-api-key.test.mjs api/_sentry-common.test.mjs api/bootstrap-auth.test.mjs api/wm-session.test.mjs api/product-catalog.test.mjs api/youtube/embed.test.mjs api/cyber-threats.test.mjs api/usni-fleet.test.mjs scripts/ais-relay-rss.test.cjs api/loaders-xml-wms-regression.test.mjs api/security/report.test.mjs",
     "test:e2e:visual:full": "cross-env VITE_VARIANT=full playwright test -g \"matches golden screenshots per layer and zoom\"",
     "test:e2e:visual:tech": "cross-env VITE_VARIANT=tech playwright test -g \"matches golden screenshots per layer and zoom\"",
     "test:e2e:visual": "npm run test:e2e:visual:full && npm run test:e2e:visual:tech",

--- a/tests/symbol-search-sentry-capture.test.mts
+++ b/tests/symbol-search-sentry-capture.test.mts
@@ -25,6 +25,9 @@ import { after, describe, it } from 'node:test';
 
 const TEST_KEY = 'wm-test-enterprise-key';
 
+const previousNodeTestContext = process.env.NODE_TEST_CONTEXT;
+delete process.env.NODE_TEST_CONTEXT;
+
 // Set before the dynamic import so parseDsn() wires up the envelope transport.
 process.env.VITE_SENTRY_DSN = 'https://testpublickey@sentry.test/12345';
 process.env.WORLDMONITOR_VALID_KEYS = TEST_KEY;
@@ -40,7 +43,11 @@ const ENVELOPE_URL_PREFIX = 'https://sentry.test/api/12345/envelope';
 const { default: handler } = await import('../api/symbol-search.ts');
 
 const originalFetch = globalThis.fetch;
-after(() => { globalThis.fetch = originalFetch; });
+after(() => {
+  globalThis.fetch = originalFetch;
+  if (previousNodeTestContext === undefined) delete process.env.NODE_TEST_CONTEXT;
+  else process.env.NODE_TEST_CONTEXT = previousNodeTestContext;
+});
 
 function makeReq(q = 'nvidia'): Request {
   return new Request(


### PR DESCRIPTION
## Summary

Node test runs no longer report expected API failure-path assertions into the production Sentry project when deployment-like shells inherit a real DSN. The custom API Sentry transport now stays disabled under Node's test runner, so tests that intentionally clear Upstash config can keep exercising degraded rate-limit behavior without manufacturing `Upstash Redis is not configured` incidents.

This is scoped to the custom API envelope helper; browser/runtime production captures still initialize from `VITE_SENTRY_DSN` outside `NODE_TEST_CONTEXT`.

Related: Sentry WORLDMONITOR-VD

## Validation

- `node --test api/_sentry-common.test.mjs api/wm-session.test.mjs`
- `npx tsx --test tests/symbol-search-sentry-capture.test.mts`
- `node scripts/check-sentry-coverage.mjs --all`
- `npm run test:sidecar`
- pre-push hook: package lock sync, `npm run typecheck`, `npm run typecheck:api`, Convex type check, CJS syntax, Unicode safety, boundary/safe-html/rate-limit/premium-fetch lint, Sentry coverage, edge bundle check, edge function tests, markdown/MDX lint, pro-test bundle freshness, version sync

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT-5 Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
