### PR TITLE
fix(orank): remove remaining phantom-MCP candidate sources (round 2 of mcp-server 3/6)

### DIFF
--- a/docs/mcp-overview.mdx
+++ b/docs/mcp-overview.mdx
@@ -1,5 +1,5 @@
 ---
-title: "MCP Server Guide"
+title: "MCP Overview"
 description: "Connect Claude, Cursor, and other MCP-compatible clients to WorldMonitor's live global-intelligence data via the Model Context Protocol."
 ---
 

--- a/pro-test/welcome.html
+++ b/pro-test/welcome.html
@@ -71,7 +71,7 @@
           },
           {
             name: 'getWorldMonitorMcpEndpoint',
-            description: "Return connection details for World Monitor's remote MCP server so an agent can pull live geopolitical, market, maritime, aviation, cyber and economic intelligence directly. Includes the Streamable HTTP endpoint, the discovery server card, supported auth modes, and docs.",
+            description: "Return connection details for World Monitor's remote MCP server so an agent can pull live geopolitical, market, maritime, aviation, cyber and economic intelligence directly. Includes the Streamable HTTP endpoint, the discovery server card, and supported auth modes.",
             inputSchema: { type: 'object', properties: {}, additionalProperties: false },
             execute: function () {
               // No tool count here — the live server card is the source of truth
@@ -81,8 +81,7 @@
                 transport: 'streamableHttp',
                 serverCard: 'https://worldmonitor.app/.well-known/mcp/server-card.json',
                 auth: ['OAuth 2.1 bearer (Authorization: Bearer <token>)', 'API key (X-WorldMonitor-Key: wm_...)'],
-                publicDiscovery: 'initialize, tools/list and notifications/initialized are servable without credentials',
-                docs: 'https://worldmonitor.app/docs/mcp-overview'
+                publicDiscovery: 'initialize, tools/list and notifications/initialized are servable without credentials'
               }, null, 2)));
             }
           }

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -204,7 +204,7 @@
     ]
   },
   "documentation": {
-    "overview": "https://www.worldmonitor.app/docs/mcp-overview",
+    "guide": "https://www.worldmonitor.app/docs/mcp-overview",
     "toolReference": "https://www.worldmonitor.app/docs/mcp-tools-reference",
     "apiReference": "https://www.worldmonitor.app/docs/api-reference",
     "support": "https://www.worldmonitor.app/docs/getting-started"

--- a/public/pro/welcome.html
+++ b/public/pro/welcome.html
@@ -71,7 +71,7 @@
           },
           {
             name: 'getWorldMonitorMcpEndpoint',
-            description: "Return connection details for World Monitor's remote MCP server so an agent can pull live geopolitical, market, maritime, aviation, cyber and economic intelligence directly. Includes the Streamable HTTP endpoint, the discovery server card, supported auth modes, and docs.",
+            description: "Return connection details for World Monitor's remote MCP server so an agent can pull live geopolitical, market, maritime, aviation, cyber and economic intelligence directly. Includes the Streamable HTTP endpoint, the discovery server card, and supported auth modes.",
             inputSchema: { type: 'object', properties: {}, additionalProperties: false },
             execute: function () {
               // No tool count here — the live server card is the source of truth
@@ -81,8 +81,7 @@
                 transport: 'streamableHttp',
                 serverCard: 'https://worldmonitor.app/.well-known/mcp/server-card.json',
                 auth: ['OAuth 2.1 bearer (Authorization: Bearer <token>)', 'API key (X-WorldMonitor-Key: wm_...)'],
-                publicDiscovery: 'initialize, tools/list and notifications/initialized are servable without credentials',
-                docs: 'https://worldmonitor.app/docs/mcp-overview'
+                publicDiscovery: 'initialize, tools/list and notifications/initialized are servable without credentials'
               }, null, 2)));
             }
           }


### PR DESCRIPTION
## Round 2 — the rename in #4803 moved the flag instead of killing it

Post-deploy rescan after #4803 still scored `mcp-server` 3/6, and the smoking-gun check now names the **renamed** URL:

> `mcp-multi-surface-coverage => warning 1/2 | Both MCPs detected (https://worldmonitor.app/mcp, https://worldmonitor.app/docs/mcp-overview) but one is unhealthy`

So orank's harvester followed the rename — the endpoint-shaped slug wasn't the trigger. Three published surfaces carried the docs URL in an MCP-endpoint context, and all three were renamed in lockstep in #4803 (which is exactly why the phantom persisted). This PR removes each candidate source:

1. **`pro-test/welcome.html` + `public/pro/welcome.html`** (the apex homepage orank scans): drop the `docs:` field from the `getWorldMonitorMcpEndpoint` WebMCP tool payload. The flagged URL is **byte-exact** with this value (apex host, no `.md` — unlike the card's www URL or llms.txt's `.md` form), and it sits next to `endpoint:`/`transport:` inside an MCP-connection JSON blob — prime harvest material. Tool description updated to match. `tests/webmcp.test.mjs` never asserted the field (29 pass).
2. **`docs/mcp-overview.mdx`**: retitle "MCP Server Guide" → "MCP Overview". The Mintlify-generated `docs/llms.txt` link inherits the page title; the only docs link ever flagged was titled "MCP Server…", while "MCP Quickstart" / "MCP Tools Reference" / "MCP Error Catalog" never were.
3. **`public/.well-known/mcp/server-card.json`**: rename the documentation key `overview` → `guide` (same URL), in case the parser special-cases that key name; sibling `toolReference`/`apiReference`/`support` values were never flagged.

## Verification

- webmcp (29 pass), mcp-capability-parity + pro-welcome-prerender (11 pass), docs:check — green
- Post-deploy: rescan `POST https://ora.ai/api/scan {"url":"worldmonitor.app"}`; expect `mcp-server` 6/6 (direct-URL scan already proves the endpoint scores 6/6) and Experience recovery (`mcp-app-registry` 4/4 etc.)

Follow-up to #4803; related #4802.

https://claude.ai/code/session_01W6vnHud5pFcLvZQsnmkq4S