### PR TITLE
feat(mcp): /.well-known/mcp dual-role — manifest GET + live Streamable HTTP endpoint (orank mcp-server, round 3)

### DIFF
--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -283,6 +283,44 @@ function handleSseReplay(req: Request, corsHeaders: Record<string, string>): Res
 }
 
 // ---------------------------------------------------------------------------
+// /.well-known/mcp dual-role support
+// ---------------------------------------------------------------------------
+// vercel.json rewrites /.well-known/mcp into this handler so ONE URL is both
+// the discovery manifest (plain GET → static server card) and a live
+// Streamable HTTP endpoint (POST initialize etc.). Agent-readiness scanners
+// (orank `mcp-server`) POST `initialize` AT the well-known URL; when a static
+// file answered that with a bodyless 405 the check scored "MCP manifest found
+// at /.well-known/mcp but protocol handshake failed" (3/6) even though /mcp
+// itself handshakes cleanly.
+const WELL_KNOWN_MCP_PATH = '/.well-known/mcp';
+// Module-scope cache: the card is a static asset, immutable per deployment.
+let serverCardCache: string | null = null;
+async function serveServerCard(req: Request, corsHeaders: Record<string, string>): Promise<Response> {
+  if (serverCardCache === null) {
+    try {
+      const res = await fetch(new URL('/.well-known/mcp/server-card.json', req.url));
+      if (!res.ok) throw new Error(`server-card fetch ${res.status}`);
+      serverCardCache = await res.text();
+    } catch {
+      // Self-fetch failed (deploy skew / transient) — point the fetcher at the
+      // canonical static path instead of caching a failure.
+      return new Response(null, {
+        status: 302,
+        headers: { Location: '/.well-known/mcp/server-card.json', ...corsHeaders },
+      });
+    }
+  }
+  return new Response(serverCardCache, {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+      ...corsHeaders,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Main handler
 // ---------------------------------------------------------------------------
 export async function mcpHandler(
@@ -298,6 +336,21 @@ export async function mcpHandler(
   }
   if (req.method === 'HEAD') {
     return new Response(null, { status: 200, headers: withMcpNoStore({ 'Content-Type': 'application/json', ...corsHeaders }) });
+  }
+
+  // /.well-known/mcp manifest GET — served BEFORE Origin validation: the card
+  // is public static data, and browser-context fetchers (WebMCP agents) send
+  // an Origin header the gate below would 403. A GET that asks for
+  // `text/event-stream` (an SDK opening the optional standalone stream) or
+  // carries `Last-Event-ID` (SSE replay) falls through to the normal endpoint
+  // GET handling so transport semantics stay identical to /mcp.
+  if (
+    req.method === 'GET' &&
+    new URL(req.url).pathname === WELL_KNOWN_MCP_PATH &&
+    !req.headers.get('last-event-id') &&
+    !(req.headers.get('accept') ?? '').includes('text/event-stream')
+  ) {
+    return serveServerCard(req, corsHeaders);
   }
 
   // Origin validation: allow claude.ai/claude.com web clients; allow absent origin (desktop/CLI)

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -15,6 +15,9 @@
     "type": "streamableHttp",
     "endpoint": "https://worldmonitor.app/mcp"
   },
+  "remotes": [
+    { "type": "streamable-http", "url": "https://worldmonitor.app/mcp" }
+  ],
   "capabilities": {
     "tools": true,
     "logging": true,

--- a/tests/mcp-transport-conformance.test.mjs
+++ b/tests/mcp-transport-conformance.test.mjs
@@ -4,6 +4,7 @@
 
 import { describe, it, beforeEach, afterEach } from 'node:test';
 import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
 import { createServer } from 'node:http';
 import { Readable } from 'node:stream';
 
@@ -372,5 +373,86 @@ describe('api/mcp.ts — transport conformance over real HTTP', () => {
     const errorBody = JSON.parse(events[0].data);
     assert.equal(errorBody.id, 21);
     assert.equal(errorBody.error?.code, -32601);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /.well-known/mcp dual-role (manifest GET + live Streamable HTTP endpoint)
+// ---------------------------------------------------------------------------
+// vercel.json rewrites /.well-known/mcp into the same handler. Agent-readiness
+// scanners (orank `mcp-server`) POST `initialize` AT the well-known URL — when
+// a static file answered that with a bodyless 405, the check scored "MCP
+// manifest found at /.well-known/mcp but protocol handshake failed" (3/6).
+// GET keeps serving the server card so manifest fetchers are unaffected, and
+// an SSE-flavored GET falls through to the endpoint's standalone-stream 405.
+describe('api/mcp.ts — /.well-known/mcp dual-role alias', () => {
+  let mcpHandler;
+  let deps;
+  let server;
+  let aliasUrl;
+  const realFetch = globalThis.fetch;
+  const cardText = readFileSync(new URL('../public/.well-known/mcp/server-card.json', import.meta.url), 'utf8');
+
+  beforeEach(async () => {
+    process.env.MCP_INTERNAL_HMAC_SECRET = HMAC_SECRET;
+    process.env.MCP_TELEMETRY = 'false';
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+
+    const mod = await import(`../api/mcp.ts?t=${Date.now()}-${Math.random()}-wk`);
+    mcpHandler = mod.mcpHandler;
+    deps = makeProDeps().deps;
+    server = await startMcpServer(mcpHandler, deps);
+    aliasUrl = server.url.replace('/mcp', '/.well-known/mcp');
+    // The handler self-fetches the static card asset; the localhost harness
+    // has no static file server, so serve the on-disk card for that one URL
+    // and delegate everything else (including the test's own requests).
+    globalThis.fetch = (input, init) => {
+      const href = typeof input === 'string' ? input : input.url ?? String(input);
+      if (href.endsWith('/.well-known/mcp/server-card.json')) {
+        return Promise.resolve(new Response(cardText, { status: 200, headers: { 'Content-Type': 'application/json' } }));
+      }
+      return realFetch(input, init);
+    };
+  });
+
+  afterEach(async () => {
+    globalThis.fetch = realFetch;
+    if (server) await server.close();
+    Object.keys(process.env).forEach((k) => {
+      if (!(k in originalEnv)) delete process.env[k];
+    });
+    Object.assign(process.env, originalEnv);
+  });
+
+  it('plain GET serves the server card (manifest role), even with a foreign Origin', async () => {
+    const res = await fetch(aliasUrl, {
+      headers: { Accept: 'application/json', Origin: 'https://ora.ai' },
+    });
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get('content-type') ?? '', /application\/json/i);
+    const card = await res.json();
+    assert.equal(card.serverUrl, 'https://worldmonitor.app/mcp');
+    assert.equal(card.remotes?.[0]?.url, 'https://worldmonitor.app/mcp');
+  });
+
+  it('POST initialize completes the live Streamable HTTP handshake at the well-known URL', async () => {
+    const res = await fetch(aliasUrl, {
+      method: 'POST',
+      headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+      body: JSON.stringify(initBody(31)),
+    });
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.result?.serverInfo?.name, 'worldmonitor');
+    assert.ok(res.headers.get('mcp-session-id'), 'well-known endpoint role must mint a session like /mcp');
+  });
+
+  it('GET asking for text/event-stream falls through to the standalone-stream 405', async () => {
+    const res = await fetch(aliasUrl, {
+      headers: { Accept: 'text/event-stream' },
+    });
+    assert.equal(res.status, 405);
+    assert.match(res.headers.get('allow') ?? '', /\bPOST\b/);
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -19,7 +19,7 @@
     { "source": "/oauth/authorize-pro", "destination": "/api/oauth/authorize-pro" },
     { "source": "/.well-known/oauth-protected-resource", "destination": "/api/oauth-protected-resource" },
     { "source": "/.well-known/oauth-authorization-server", "destination": "/api/oauth-authorization-server" },
-    { "source": "/.well-known/mcp", "destination": "/.well-known/mcp/server-card.json" },
+    { "source": "/.well-known/mcp", "destination": "/api/mcp" },
     { "source": "/embed", "destination": "/embed.html" },
     { "source": "/dashboard", "destination": "/dashboard.html" },
     { "source": "/((?!api|mcp|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)", "destination": "/dashboard.html" }


### PR DESCRIPTION
## The isolation experiment

Round 2 (#4804) removed the phantom docs-URL candidate (multi-surface now reports a single surface) but `mcp-server` still scored 3/6. Decisive control: a domain scan with the endpoint pinned via orank's `mcp` param passes —

> `mcp-server => pass 6/6 | MCP server connected via Streamable HTTP - worldmonitor v1.13.0`
> `mcp-app-registry => pass 4/4`

— so their client connects fine from their infra; only unassisted domain-mode endpoint resolution fails. orank's own recommendation text (webmcp check) states the expectation: *"an HTTP-based MCP transport **at /.well-known/mcp** or /mcp"*. Their `mcp-server` check POSTs `initialize` **at the well-known URL**; our static server card there answered with a bodyless 405 → "MCP manifest found at /.well-known/mcp but protocol handshake failed".

## Fix

`vercel.json` now rewrites `/.well-known/mcp` into the MCP handler, which is dual-role **at that path only**:

- **Plain GET** (no `Last-Event-ID`, no `text/event-stream` Accept) serves the static server card via a module-cached self-fetch (302 to `/.well-known/mcp/server-card.json` on fetch failure). Manifest fetchers see identical bytes — and the card is served **before** the Origin gate, since browser-context fetchers send Origin headers the gate would 403 (#4802).
- **POST** speaks the live Streamable HTTP protocol — `initialize` at `/.well-known/mcp` completes the handshake with a session ID.
- **GET asking for `text/event-stream`** falls through to the endpoint's standalone-stream 405, preserving #4711's hard-won SDK semantics for clients that treat the well-known URL as their endpoint.
- `server-card.json` gains a registry-style `remotes` array (`streamable-http` → `https://worldmonitor.app/mcp`) as parser insurance alongside `serverUrl`/`transport.endpoint`.

`/mcp` behavior is byte-identical (the alias is path-keyed; test BASE_URL uses `/mcp`).

## Verification

- 3 new transport-conformance tests: card GET (incl. foreign `Origin`), POST initialize handshake, SSE-GET 405 — plus deploy-config 95, capability-parity 8, resources 38, protocol-version 8, tools-list-compression 37, typecheck:api — all green
- Post-deploy: `curl -X POST https://worldmonitor.app/.well-known/mcp` with an initialize body must return the JSON-RPC result; then rescan `POST https://ora.ai/api/scan {"url":"worldmonitor.app"}` expecting `mcp-server` 6/6 + Experience recovery

Follow-up to #4803 / #4804; related #4802.

https://claude.ai/code/session_01W6vnHud5pFcLvZQsnmkq4S