### PR TITLE
fix(orank): speak orank's manifest dialect — top-level url/kind + /.well-known/mcp.json alias (round 4)

### DIFF
--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -292,7 +292,10 @@ function handleSseReplay(req: Request, corsHeaders: Record<string, string>): Res
 // file answered that with a bodyless 405 the check scored "MCP manifest found
 // at /.well-known/mcp but protocol handshake failed" (3/6) even though /mcp
 // itself handshakes cleanly.
-const WELL_KNOWN_MCP_PATH = '/.well-known/mcp';
+// Two manifest aliases: bare `/.well-known/mcp` (SEP-1649 server-card style)
+// and `/.well-known/mcp.json` (the ora.ai/registry convention whose schema
+// keys the endpoint as top-level `url`). Both rewrite here via vercel.json.
+const WELL_KNOWN_MCP_PATHS = new Set(['/.well-known/mcp', '/.well-known/mcp.json']);
 // Module-scope cache: the card is a static asset, immutable per deployment.
 let serverCardCache: string | null = null;
 async function serveServerCard(req: Request, corsHeaders: Record<string, string>): Promise<Response> {
@@ -346,7 +349,7 @@ export async function mcpHandler(
   // GET handling so transport semantics stay identical to /mcp.
   if (
     req.method === 'GET' &&
-    new URL(req.url).pathname === WELL_KNOWN_MCP_PATH &&
+    WELL_KNOWN_MCP_PATHS.has(new URL(req.url).pathname) &&
     !req.headers.get('last-event-id') &&
     !(req.headers.get('accept') ?? '').includes('text/event-stream')
   ) {

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -1,7 +1,9 @@
 {
   "name": "worldmonitor",
+  "kind": "product",
   "description": "WorldMonitor's live global-intelligence stack as an MCP server: real-time markets, conflict events, aviation, maritime, energy, climate, health, displacement, supply chain, and AI-generated regional briefs.",
   "version": "1.13.0",
+  "url": "https://worldmonitor.app/mcp",
   "serverUrl": "https://worldmonitor.app/mcp",
   "serverInfo": {
     "name": "worldmonitor",

--- a/tests/mcp-transport-conformance.test.mjs
+++ b/tests/mcp-transport-conformance.test.mjs
@@ -432,8 +432,20 @@ describe('api/mcp.ts — /.well-known/mcp dual-role alias', () => {
     assert.equal(res.status, 200);
     assert.match(res.headers.get('content-type') ?? '', /application\/json/i);
     const card = await res.json();
+    // Endpoint must be readable under EVERY manifest dialect scanners parse:
+    // top-level `url` + `kind` (ora.ai /.well-known/mcp.json convention),
+    // `serverUrl` (SEP-1649 server card), and registry-style `remotes`.
+    assert.equal(card.url, 'https://worldmonitor.app/mcp');
+    assert.equal(card.kind, 'product');
     assert.equal(card.serverUrl, 'https://worldmonitor.app/mcp');
     assert.equal(card.remotes?.[0]?.url, 'https://worldmonitor.app/mcp');
+  });
+
+  it('serves the card at the /.well-known/mcp.json alias too', async () => {
+    const res = await fetch(`${aliasUrl}.json`, { headers: { Accept: 'application/json' } });
+    assert.equal(res.status, 200);
+    const card = await res.json();
+    assert.equal(card.url, 'https://worldmonitor.app/mcp');
   });
 
   it('POST initialize completes the live Streamable HTTP handshake at the well-known URL', async () => {

--- a/vercel.json
+++ b/vercel.json
@@ -20,6 +20,7 @@
     { "source": "/.well-known/oauth-protected-resource", "destination": "/api/oauth-protected-resource" },
     { "source": "/.well-known/oauth-authorization-server", "destination": "/api/oauth-authorization-server" },
     { "source": "/.well-known/mcp", "destination": "/api/mcp" },
+    { "source": "/.well-known/mcp.json", "destination": "/api/mcp" },
     { "source": "/embed", "destination": "/embed.html" },
     { "source": "/dashboard", "destination": "/dashboard.html" },
     { "source": "/((?!api|mcp|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)", "destination": "/dashboard.html" }


### PR DESCRIPTION
## Ground truth, finally

Rounds 1-3 (#4803, #4804, #4805) eliminated the phantom docs-URL candidate and made `/.well-known/mcp` a live dual-role endpoint — the domain scan still reported "MCP manifest found at /.well-known/mcp but protocol handshake failed", while a scan with the endpoint pinned via orank's `mcp` param scores 6/6. So their parser never extracts our endpoint from the manifest.

The reference schema is published by orank themselves — their docs llms.txt links `https://ora.ai/.well-known/mcp.json` as "machine-readable discovery":

```json
{
  "name": "ora",
  "kind": "product",
  "url": "https://ora.ai/api/mcp",
  "transport": "streamable-http",
  "capabilities": { "tools": true, ... },
  "tools": [ ... ]
}
```

The endpoint field is top-level **`url`**. Our card exposed `serverUrl` / `transport.endpoint` / `remotes` — none of which that parser reads. They also fetch `/.well-known/mcp.json`, which 404'd on our side.

## Changes

- `server-card.json`: add top-level `url` (endpoint) + `kind: "product"` (their kind-aware MCP rubric distinguishes product vs docs MCPs) — purely additive next to the SEP-1649-style fields, so every known manifest dialect can now extract the endpoint
- `vercel.json` + handler: serve the card at `/.well-known/mcp.json` too, through the same dual-role alias shipped in #4805 (GET → card, POST → live Streamable HTTP)
- tests: card must expose the endpoint under all dialects (`url`, `kind`, `serverUrl`, `remotes[0].url`), plus the `.json` alias

## Verification

- transport-conformance 10, deploy-config 95, capability-parity 8, typecheck:api — green
- Post-deploy: `curl https://worldmonitor.app/.well-known/mcp.json` → card with `url`; rescan expecting `mcp-server` 6/6 + Experience recovery

https://claude.ai/code/session_01W6vnHud5pFcLvZQsnmkq4S