### PR TITLE
fix(mcp): drop /mcp Origin allowlist so browser MCP clients connect (closes #4802)

### DIFF
--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -341,12 +341,10 @@ export async function mcpHandler(
     return new Response(null, { status: 200, headers: withMcpNoStore({ 'Content-Type': 'application/json', ...corsHeaders }) });
   }
 
-  // /.well-known/mcp manifest GET — served BEFORE Origin validation: the card
-  // is public static data, and browser-context fetchers (WebMCP agents) send
-  // an Origin header the gate below would 403. A GET that asks for
-  // `text/event-stream` (an SDK opening the optional standalone stream) or
-  // carries `Last-Event-ID` (SSE replay) falls through to the normal endpoint
-  // GET handling so transport semantics stay identical to /mcp.
+  // /.well-known/mcp manifest GET: the card is public static data. A GET that
+  // asks for `text/event-stream` (an SDK opening the optional standalone
+  // stream) or carries `Last-Event-ID` (SSE replay) falls through to the
+  // normal endpoint GET handling so transport semantics stay identical to /mcp.
   if (
     req.method === 'GET' &&
     WELL_KNOWN_MCP_PATHS.has(new URL(req.url).pathname) &&
@@ -356,11 +354,12 @@ export async function mcpHandler(
     return serveServerCard(req, corsHeaders);
   }
 
-  // Origin validation: allow claude.ai/claude.com web clients; allow absent origin (desktop/CLI)
-  const origin = req.headers.get('Origin');
-  if (origin && origin !== 'https://claude.ai' && origin !== 'https://claude.com') {
-    return new Response('Forbidden', { status: 403, headers: withMcpNoStore(corsHeaders) });
-  }
+  // No Origin gate (issue #4802): the endpoint advertises CORS `*`, auth is
+  // API-key/Bearer (no cookies → no CSRF surface), and MCP-spec Origin
+  // validation targets DNS rebinding against localhost servers — not a public
+  // HTTPS endpoint. A claude.ai-only allowlist here 403'd ChatGPT web
+  // connectors, MCP Inspector (localhost origin), and every other
+  // browser-context client AFTER their preflight had already succeeded.
 
   if (req.method !== 'POST' && req.method !== 'GET') {
     return new Response(null, { status: 405, headers: withMcpNoStore({ Allow: 'POST, GET, HEAD, OPTIONS', ...corsHeaders }) });

--- a/docs/mcp-error-catalog.mdx
+++ b/docs/mcp-error-catalog.mdx
@@ -9,7 +9,7 @@ description: "Every error shape WorldMonitor's MCP server can emit — JSON-RPC 
   emission site below should appear in the page.
 
   - JSON-RPC envelope helpers           api/mcp/rpc.ts:7-13
-  - Origin / method gates               api/mcp/handler.ts:35-49
+  - Method gate (405 + Allow)           api/mcp/handler.ts (mcpHandler method check)
   - Top-level dispatch / -32600/-32601  api/mcp/handler.ts:66-164
   - Auth -32001 / -32603 emitters       api/mcp/auth.ts:126-238
   - Per-minute -32029                   api/mcp/auth.ts:243-260
@@ -230,15 +230,13 @@ Every status the MCP handler can return. Most JSON-RPC replies — including mos
 | **202** | empty                     | n/a              | `notifications/initialized` — JSON-RPC notifications take no response body, per spec |
 | **204** | empty                     | n/a              | `OPTIONS` preflight                                                  |
 | **401** | JSON-RPC envelope         | `-32001`         | Missing/invalid/expired credentials, revoked Pro MCP token, inactive subscription. `WWW-Authenticate` header set. |
-| **403** | plain `"Forbidden"`       | n/a (NOT JSON-RPC)| `Origin` header is present and is not `https://claude.ai` or `https://claude.com`. Server-to-server callers (no `Origin`) are exempt. |
-| **405** | empty                     | n/a              | Request method is not `POST`, `HEAD`, or `OPTIONS`. `Allow: POST, HEAD, OPTIONS` header set. |
+| **405** | empty                     | n/a              | Request method is not `POST`, `GET`, `HEAD`, or `OPTIONS` (or a bare `GET` with no `Last-Event-ID`). `Allow: POST, GET, HEAD, OPTIONS` header set. |
 | **429** | JSON-RPC envelope         | `-32029`         | **Pro daily cap exceeded only.** `Retry-After: <seconds-until-UTC-midnight>` set. (Per-minute throttle returns `-32029` inside HTTP 200 — see `-32029` above.) |
 | **503** | JSON-RPC envelope         | `-32603`         | Auth service unavailable, `MCP_INTERNAL_HMAC_SECRET` misconfigured, or quota-reservation Redis failure. `Retry-After: 5`. |
 
-Two HTTP statuses appear that aren't JSON-RPC errors:
+One HTTP status appears that isn't a JSON-RPC error:
 
-- **403 with a plain `Forbidden` body** comes from origin-validation BEFORE the JSON-RPC layer runs. Don't try to `JSON.parse` the body. This is only relevant to browser-origin clients; CLI clients, Claude Desktop, and `curl` send no `Origin` header and are exempt.
-- **405 with an empty body** comes from method-validation BEFORE JSON-RPC. The handler accepts `POST` (the JSON-RPC path), `HEAD` (a 200 ack with `Content-Type: application/json`, used by uptime probes), and `OPTIONS` (CORS preflight). Anything else gets 405 + `Allow: POST, HEAD, OPTIONS`.
+- **405 with an empty body** comes from method-validation BEFORE JSON-RPC. The handler accepts `POST` (the JSON-RPC path), `GET` (the standalone SSE stream / `Last-Event-ID` replay channel), `HEAD` (a 200 ack with `Content-Type: application/json`, used by uptime probes), and `OPTIONS` (CORS preflight). A bare `GET` with no `Last-Event-ID` also returns 405 (no standalone stream is offered). Anything else gets 405 + `Allow: POST, GET, HEAD, OPTIONS`. The endpoint enforces no `Origin` allowlist: it advertises wildcard CORS and authenticates by explicit `Authorization` / `X-WorldMonitor-Key` header, so browser-origin clients (any origin) are accepted.
 
 ## Soft-behavior envelopes
 

--- a/tests/mcp-transport-conformance.test.mjs
+++ b/tests/mcp-transport-conformance.test.mjs
@@ -341,6 +341,76 @@ describe('api/mcp.ts — transport conformance over real HTTP', () => {
     assert.equal(replayed.length, 0, 'resume after the sole follow-up event replays nothing');
   });
 
+  it('completes the handshake for browser clients from ANY origin (issue #4802)', async () => {
+    // The endpoint advertises `access-control-allow-origin: *`, so the preflight
+    // succeeds for every origin — the actual POST must not then be rejected by an
+    // Origin allowlist. Auth is API-key/Bearer (no cookies), so a cross-origin
+    // browser request carries no ambient credentials and there is no CSRF surface;
+    // MCP-spec Origin validation targets DNS rebinding against localhost servers,
+    // not public HTTPS endpoints. Regression: a claude.ai/claude.com-only allowlist
+    // 403'd ChatGPT web connectors, MCP Inspector (localhost origin), and every
+    // other browser-context client AFTER their preflight had already succeeded.
+    for (const origin of ['https://chatgpt.com', 'http://localhost:3000', 'https://ora.ai']) {
+      // The exact browser flow the bug broke: preflight succeeds (204 + wildcard),
+      // then the actual POST must succeed too — not 403 after a green preflight.
+      const preflight = await fetch(server.url, {
+        method: 'OPTIONS',
+        headers: {
+          Origin: origin,
+          'Access-Control-Request-Method': 'POST',
+          'Access-Control-Request-Headers': 'content-type,authorization',
+        },
+      });
+      assert.equal(preflight.status, 204, `OPTIONS preflight from ${origin} must be 204`);
+      assert.equal(preflight.headers.get('access-control-allow-origin'), '*');
+
+      // Accept: application/json returns a single complete JSON-RPC body (no open
+      // SSE stream to drain), so the response settles immediately.
+      const res = await fetch(server.url, {
+        method: 'POST',
+        headers: mcpHeaders({ Origin: origin, Accept: 'application/json' }),
+        body: JSON.stringify(initBody(40)),
+      });
+      assert.equal(res.status, 200, `POST initialize with Origin: ${origin} must be 200, got ${res.status}`);
+      assert.equal(res.headers.get('access-control-allow-origin'), '*',
+        'CORS wildcard must hold on the actual response, not just preflight');
+      // Load-bearing invariant that makes wildcard CORS safe here: /mcp must NEVER
+      // pair `ACAO: *` with credentialed CORS. If a refactor swapped /mcp onto the
+      // reflected-origin + Allow-Credentials helper, ambient-credential CSRF would
+      // reopen on a now-gateless endpoint — pin it closed.
+      assert.equal(res.headers.get('access-control-allow-credentials'), null,
+        '/mcp must not emit Access-Control-Allow-Credentials alongside wildcard ACAO');
+      assert.equal((await res.json()).result?.serverInfo?.name, 'worldmonitor',
+        'foreign-origin POST must complete a real initialize, not just return 200');
+    }
+  });
+
+  it('does not 403 the GET branches for a foreign origin either (issue #4802)', async () => {
+    // The removed allowlist sat before method dispatch, so it previously 403'd GET
+    // as well as POST. Both GET sub-paths must now reach their normal handling for
+    // a browser origin — never the old pre-auth 403.
+    const bareGet = await fetch(server.url, {
+      method: 'GET',
+      headers: { Accept: 'text/event-stream', Origin: 'https://chatgpt.com' },
+    });
+    assert.equal(bareGet.status, 405, 'bare GET from a foreign origin must be 405 (no standalone stream), not 403');
+    assert.match(bareGet.headers.get('allow') ?? '', /\bPOST\b/);
+
+    // A GET+Last-Event-ID without the required Accept is a replay header error
+    // (406) — the point is it reaches replay validation instead of the old 403.
+    const replay = await fetch(server.url, {
+      method: 'GET',
+      headers: {
+        Origin: 'https://chatgpt.com',
+        Authorization: `Bearer ${PRO_BEARER}`,
+        'Mcp-Session-Id': crypto.randomUUID(),
+        'Last-Event-ID': 'stream:0',
+      },
+    });
+    assert.notEqual(replay.status, 403, 'foreign-origin SSE replay must reach the authed replay path, not a pre-auth 403');
+    assert.equal(replay.status, 406, 'replay without Accept: text/event-stream is a 406 header error');
+  });
+
   it('honors Accept q=0 and preserves CORS on streamed JSON-RPC errors', async () => {
     const initialize = await fetch(server.url, {
       method: 'POST',


### PR DESCRIPTION
Closes #4802.

## Problem

`/mcp` rejected any `Origin` other than `https://claude.ai` / `https://claude.com` with a bare `403 Forbidden` — **after** advertising wildcard CORS (`access-control-allow-origin: *`) and returning a green `204` OPTIONS preflight. Browser-context MCP clients (ChatGPT web connectors, MCP Inspector at a `localhost` origin, any WebMCP agent) preflight-succeed and then 403 on the actual POST — the most confusing failure mode a browser client can hit.

## Why removing the gate is safe

A dedicated security review (plus an independent adversarial pass) cleared it:
- **No CSRF / ambient-credential abuse.** `/mcp` uses `getPublicCorsHeaders` (`ACAO: *`, **no** `Access-Control-Allow-Credentials`) and authenticates only via explicit `Authorization` / `X-WorldMonitor-Key` headers. A cross-origin browser request carries no cookies, so it cannot forge an authenticated `tools/call`; gated methods fail closed with 401.
- **The former gate protected nothing.** Non-browser attackers spoof `Origin` freely (an `Origin`-less curl always passed it), and browser attackers hold no ambient credentials.
- **DNS rebinding N/A.** MCP-spec Origin validation targets plaintext localhost servers; rebinding to a public HTTPS endpoint fails TLS/cert validation.

## Changes

- **`api/mcp/handler.ts`** — remove the claude.ai-only Origin 403. The `/.well-known/mcp` manifest GET no longer needs its "served before Origin validation" carve-out (comment updated).
- **`tests/mcp-transport-conformance.test.mjs`** — regression coverage: foreign-origin `OPTIONS → POST initialize` (chatgpt.com / localhost / ora.ai) returns 200; the **load-bearing invariant** that `/mcp` never pairs `ACAO: *` with `Allow-Credentials` (review flagged this as what keeps wildcard CORS safe — a future helper swap would reopen CSRF); and the GET branches (bare-GET → 405, `Last-Event-ID` replay) reach normal handling instead of the old pre-auth 403.
- **`docs/mcp-error-catalog.mdx`** — the published catalog (advertised to live MCP clients via `llms.txt`) still documented the now-unreachable 403; removed that row/prose and corrected the stale 405 `Allow` list to `POST, GET, HEAD, OPTIONS` (a pre-existing drift in the same section).

## Verification

`mcp` (130), `mcp-transport-conformance` (12, incl. the new #4802 cases), `deploy-config` (95), `typecheck:api` — all green. Post-deploy probe: `curl -X POST https://worldmonitor.app/mcp -H "Origin: https://chatgpt.com"` with an initialize body must return 200 (was 403).

Found while diagnosing the orank `mcp-server` score (#4803–#4806); tracked separately as it's a distinct browser-client bug, not the orank cause.

https://claude.ai/code/session_01W6vnHud5pFcLvZQsnmkq4S