### PR TITLE
fix(mcp): keep the /.well-known/mcp server card cacheable (max-age=3600)

### DIFF
--- a/api/mcp/handler.ts
+++ b/api/mcp/handler.ts
@@ -315,10 +315,16 @@ async function serveServerCard(req: Request, corsHeaders: Record<string, string>
   }
   return new Response(serverCardCache, {
     status: 200,
+    // Cache-Control comes AFTER the ...corsHeaders spread: getMcpCorsHeaders()
+    // carries MCP_CACHE_CONTROL (`no-store`) for the live JSON-RPC/SSE endpoint,
+    // but the manifest is a static, immutable-per-deploy asset that must stay
+    // cacheable (it was `public, max-age=3600` as a static file). Spreading last
+    // would clobber that back to no-store and re-hit the function on every
+    // discovery fetch.
     headers: {
       'Content-Type': 'application/json; charset=utf-8',
-      'Cache-Control': 'public, max-age=3600',
       ...corsHeaders,
+      'Cache-Control': 'public, max-age=3600',
     },
   });
 }

--- a/tests/mcp-transport-conformance.test.mjs
+++ b/tests/mcp-transport-conformance.test.mjs
@@ -509,6 +509,13 @@ describe('api/mcp.ts — /.well-known/mcp dual-role alias', () => {
     assert.equal(card.kind, 'product');
     assert.equal(card.serverUrl, 'https://worldmonitor.app/mcp');
     assert.equal(card.remotes?.[0]?.url, 'https://worldmonitor.app/mcp');
+    // The manifest is a static, immutable-per-deploy asset — it must stay
+    // cacheable (it was `public, max-age=3600` as a static file). The MCP
+    // no-store CORS bundle must NOT clobber that on the manifest GET, or every
+    // discovery fetch (orank + every MCP client) re-hits the function.
+    assert.match(res.headers.get('cache-control') ?? '', /max-age=3600/,
+      'server card GET must be cacheable, not the endpoint no-store');
+    assert.doesNotMatch(res.headers.get('cache-control') ?? '', /no-store/);
   });
 
   it('serves the card at the /.well-known/mcp.json alias too', async () => {


### PR DESCRIPTION
## Problem

`serveServerCard` set `Cache-Control: public, max-age=3600` **before** spreading `...corsHeaders`, and `getMcpCorsHeaders()` carries `Cache-Control: no-store` (correct for the live JSON-RPC/SSE endpoint). The later object key wins, so the manifest was served `no-store`. Verified live:

```
$ curl -sI https://worldmonitor.app/.well-known/mcp | grep -i cache-control
cache-control: no-store, no-transform
```

The card is a static, immutable-per-deploy asset — it was `public, max-age=3600` as a static file before #4805 made the `/.well-known/mcp` path dynamic. With `no-store`, every discovery fetch (orank on each scan, and every MCP client's manifest read) needlessly re-hits the function.

## Fix

Move `Cache-Control` **after** the `...corsHeaders` spread so the manifest's cacheable value wins over the endpoint `no-store`. Regression test asserts the server-card GET is `max-age=3600` and not `no-store`.

Pre-existing since #4805/#4806; surfaced by the #4808 correctness review. `mcp-transport-conformance` 12 pass, `typecheck:api` clean.

https://claude.ai/code/session_01W6vnHud5pFcLvZQsnmkq4S