### PR TITLE
feat(seo): declare Content-Signal AI-usage preferences in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,11 +1,15 @@
 # World Monitor - protect API routes from crawlers
 
-# AI content-usage preferences (contentsignals.org draft RFC) are served as the
-# origin-wide `Content-Signal` HTTP response header (see vercel.json), NOT as a
-# robots.txt body directive — Lighthouse's robots.txt validator rejects unknown
-# directives and would drop the SEO score (#4471). Do not re-add it here.
+# AI content-usage preferences (contentsignals.org draft RFC) are declared BOTH
+# as the Content-Signal group directive below (what agent-readiness scanners
+# read) and as the origin-wide `Content-Signal` HTTP response header
+# (vercel.json) — keep the two values in sync (guarded in
+# tests/deploy-config.test.mjs). Lighthouse's robots.txt validator now
+# safelists `content-signal`, so the #4471 SEO regression that once forced the
+# header-only placement no longer applies.
 
 User-agent: *
+Content-Signal: ai-train=no, search=yes, ai-input=yes
 Allow: /
 Allow: /api/story
 Allow: /api/og-story

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -1635,3 +1635,51 @@ describe('agent readiness: homepage Link headers', () => {
     assert.strictEqual(dashboard.value, dashboardHtml.value);
   });
 });
+
+// Content-Signal (contentsignals.org draft RFC) is declared in TWO places:
+// the robots.txt group directive (what agent-readiness scanners read) and the
+// origin-wide HTTP response header in vercel.json. The two values must never
+// drift apart, and the robots.txt line must live inside the `User-agent: *`
+// group (a blank line would end the group and orphan the directive).
+// Lighthouse's robots.txt validator safelists `content-signal`, so the
+// directive no longer costs SEO points (#4471 history).
+describe('agent readiness: Content-Signal declarations', () => {
+  const robotsSource = readFileSync(resolve(__dirname, '../public/robots.txt'), 'utf-8');
+
+  const headerValue = () => {
+    for (const block of vercelConfig.headers ?? []) {
+      const hit = (block.headers ?? []).find((h) => h.key === 'Content-Signal');
+      if (hit) return hit.value;
+    }
+    return null;
+  };
+
+  it('vercel.json serves an origin-wide Content-Signal header', () => {
+    const value = headerValue();
+    assert.ok(value, 'vercel.json must carry a Content-Signal response header');
+    assert.match(value, /ai-train=(yes|no)/);
+    assert.match(value, /search=(yes|no)/);
+    assert.match(value, /ai-input=(yes|no)/);
+  });
+
+  it('robots.txt declares the same Content-Signal inside the User-agent group', () => {
+    const lines = robotsSource.split('\n');
+    const uaIndex = lines.findIndex((l) => l.trim().toLowerCase() === 'user-agent: *');
+    assert.ok(uaIndex !== -1, 'robots.txt must have a `User-agent: *` group');
+    const signalIndex = lines.findIndex((l) => l.startsWith('Content-Signal:'));
+    assert.ok(signalIndex > uaIndex, 'Content-Signal directive must appear after `User-agent: *`');
+    for (let i = uaIndex + 1; i < signalIndex; i++) {
+      assert.notStrictEqual(
+        lines[i].trim(),
+        '',
+        'Content-Signal must not be separated from its User-agent group by a blank line'
+      );
+    }
+    const robotsValue = lines[signalIndex].slice('Content-Signal:'.length).trim();
+    assert.strictEqual(
+      robotsValue,
+      headerValue(),
+      'robots.txt Content-Signal must match the vercel.json header value'
+    );
+  });
+});


### PR DESCRIPTION
## Why

Agent-readiness scanners (isitagentready.com content-signals check) read AI content-usage preferences from the **robots.txt body** — WM currently declares them only as the origin-wide `Content-Signal` HTTP response header (vercel.json), which those scanners can't see: *"No Content Signals found in robots.txt"*.

The directive used to live in robots.txt but was removed in #4471: Lighthouse's robots.txt validator rejected the unknown directive and dropped SEO 100→92. **That conflict is resolved upstream** — Lighthouse now safelists `content-signal` in its robots.txt audit (`DIRECTIVE_SAFELIST`, tagged "used in the wild"), so the directive can return without the regression.

## What

- `public/robots.txt`: `Content-Signal: ai-train=no, search=yes, ai-input=yes` inside the `User-agent: *` group (spec-canonical placement), same value as the live header; stale "do not re-add" comment replaced with the both-places-in-sync rule.
- The vercel.json header stays (both placements are valid per the draft RFC; the header covers non-robots consumers).
- `tests/deploy-config.test.mjs`: new guard — header exists with all three signals, robots.txt value **must equal** the vercel.json header value, directive sits inside the `User-agent: *` group with no blank line detaching it (a blank line ends a robots.txt group).

## Validation

- `tsx --test tests/deploy-config.test.mjs`: 97/97 pass (2 new).
- biome lint clean on the touched file (2 pre-existing warnings at lines 856/861 untouched).
- Docs: contentsignals.org / draft-romm-aipref-contentsignals; Lighthouse core/audits/seo/robots-txt.js safelist.

https://claude.ai/code/session_0186WURs7MeJHGdJRmZ3e6r7