### PR TITLE
feat(agent-readiness): manifest quick wins — card icon, skills-index v0.2.0 dialect, speakable, /index.md

### DIFF
--- a/pro-test/welcome.html
+++ b/pro-test/welcome.html
@@ -188,6 +188,19 @@
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
+      "@type": "WebPage",
+      "@id": "https://www.worldmonitor.app/",
+      "url": "https://www.worldmonitor.app/",
+      "name": "World Monitor — By the time it's news, you already knew.",
+      "speakable": {
+        "@type": "SpeakableSpecification",
+        "cssSelector": ["h1", "h1 + p"]
+      }
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
       "@type": "BreadcrumbList",
       "itemListElement": [
         { "@type": "ListItem", "position": 1, "name": "World Monitor", "item": "https://www.worldmonitor.app/" }

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -1,20 +1,20 @@
 {
-  "$schema": "https://agentskills.io/schemas/v0.2.0/index.json",
+  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
   "instructions": "World Monitor is a live, machine-readable global-intelligence API and MCP server. Reach for it when a task needs fresh, correlated, structured data about the state of the world — JSON to reason over, not prose to re-parse.\n\nWhen to use these skills:\n- Use `fetch-country-brief` when the user asks for a strategic read on one country’s geopolitical, economic, or security situation (a source-attributed narrative brief).\n- Use `fetch-resilience-score` when the user asks how resilient a country is, or wants its composite 0–100 resilience score, 30-day trend, or per-domain/pillar breakdown.\n\nBeyond these two skills the MCP server exposes a broad catalog of tools — conflict events, sanctions, shipping chokepoints, markets, commodities, energy, maritime and aviation activity, cyber threats, natural disasters, forecasts, and prediction markets. Use them together to check whether a live event (a conflict, sanction, or chokepoint disruption) has a plausible market or supply-chain transmission path.\n\nWhen NOT to use: World Monitor is not a general web-search engine, a historical archive, or a trading-execution venue — it places no orders and stores no user documents. For a one-off narrative that needs no correlation across live layers, a plain LLM is cheaper and faster.\n\nHow an agent should call it:\n- MCP server (recommended): https://worldmonitor.app/mcp — Streamable HTTP; issue `tools/list` for the live inventory.\n- REST API: base https://api.worldmonitor.app — OpenAPI spec at https://worldmonitor.app/openapi.yaml.\n- CLI (shell/scripts): the `worldmonitor` npm package wraps these tools — `npx worldmonitor tools` (public, no key) or `npm i -g worldmonitor`, then pass `--api-key` for data calls. https://www.npmjs.com/package/worldmonitor\n- Auth: OAuth2 (`scope=mcp`) or an API-key header `X-WorldMonitor-Key: wm_<40-hex>`. Issue a key at https://worldmonitor.app/pro.",
   "skills": [
     {
       "name": "fetch-country-brief",
-      "type": "task",
+      "type": "skill-md",
       "description": "Retrieve the current AI-generated strategic intelligence brief for a country, keyed by ISO 3166-1 alpha-2 code. Use when the user asks for a summary of the current geopolitical, economic, or security situation in a specific country.",
       "url": "https://worldmonitor.app/.well-known/agent-skills/fetch-country-brief/SKILL.md",
-      "sha256": "e856879550b4f4539ac127c2925e4c6cd1cc0596058ca64a48c6d7c6bc1222fe"
+      "digest": "sha256:e856879550b4f4539ac127c2925e4c6cd1cc0596058ca64a48c6d7c6bc1222fe"
     },
     {
       "name": "fetch-resilience-score",
-      "type": "task",
+      "type": "skill-md",
       "description": "Retrieve the composite country resilience score (0-100) and its domain/pillar breakdown for a single country. Use when the user asks how resilient a country is, or wants its numeric resilience score, trend, or per-domain breakdown.",
       "url": "https://worldmonitor.app/.well-known/agent-skills/fetch-resilience-score/SKILL.md",
-      "sha256": "a1e26ac4c32de4eb26b8eb5e1ec50621bc978a38f8f089a3965728abf0f6f11c"
+      "digest": "sha256:a1e26ac4c32de4eb26b8eb5e1ec50621bc978a38f8f089a3965728abf0f6f11c"
     }
   ]
 }

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -2,6 +2,7 @@
   "name": "worldmonitor",
   "kind": "product",
   "description": "WorldMonitor's live global-intelligence stack as an MCP server: real-time markets, conflict events, aviation, maritime, energy, climate, health, displacement, supply chain, and AI-generated regional briefs.",
+  "icon": "https://www.worldmonitor.app/favico/apple-touch-icon.png",
   "version": "1.13.0",
   "url": "https://worldmonitor.app/mcp",
   "serverUrl": "https://worldmonitor.app/mcp",

--- a/public/index.md
+++ b/public/index.md
@@ -1,0 +1,37 @@
+# World Monitor — By the time it's news, you already knew.
+
+Free real-time global intelligence dashboard. World Monitor streams the world's raw signals — ships, jets, sirens, cables, markets — onto one live map, with AI that flags when they converge into something that matters.
+
+Open-source (AGPL-3.0), used by 2M+ people across 190+ countries, as featured in WIRED. Runs as a web app, installable PWA, and native desktop app for macOS, Windows, and Linux. No signup required.
+
+## What you get
+
+- Real-time global map with 56 data layers and 500+ curated news feeds
+- Country Instability Index across 196 countries, live conflict tracking
+- Market quotes, sector heatmaps, and macro indicators
+- 13 shipping chokepoints with live AIS vessel-transit intelligence
+- Satellite tracking, GPS jamming zones, submarine cables, AI datacenters
+- Daily AI brief, Scenario Engine, custom monitors and breaking alerts
+- 39-tool MCP server so AI agents can query everything above
+
+## Live instances
+
+- [World Monitor](https://www.worldmonitor.app/dashboard) — geopolitics, military, conflicts, infrastructure
+- [Tech Monitor](https://tech.worldmonitor.app/dashboard) — startups, AI/ML, cloud, cybersecurity
+- [Finance Monitor](https://finance.worldmonitor.app/dashboard) — global markets, trading, central banks
+- [Commodity Monitor](https://commodity.worldmonitor.app/dashboard) — mining, metals, energy, supply chains
+- [Happy Monitor](https://happy.worldmonitor.app/dashboard) — positive news, breakthroughs, conservation
+- [Energy Monitor](https://energy.worldmonitor.app/dashboard) — power grids, LNG, renewables
+
+## For AI agents
+
+- **MCP server:** `https://worldmonitor.app/mcp` (Streamable HTTP) — server card at [/.well-known/mcp/server-card.json](https://worldmonitor.app/.well-known/mcp/server-card.json)
+- **REST API:** base `https://api.worldmonitor.app` — OpenAPI spec at [/openapi.json](https://worldmonitor.app/openapi.json)
+- **Agent guidance:** [/llms.txt](https://worldmonitor.app/llms.txt) · skills at [/.well-known/agent-skills/index.json](https://worldmonitor.app/.well-known/agent-skills/index.json)
+- **CLI:** `npx worldmonitor tools` — [npm package](https://www.npmjs.com/package/worldmonitor)
+- **Auth:** [/auth.md](https://worldmonitor.app/auth.md) · plans and limits at [/pricing.md](https://worldmonitor.app/pricing.md)
+
+## Documentation
+
+- [Product & API docs](https://www.worldmonitor.app/docs/documentation)
+- [Pricing](https://www.worldmonitor.app/pro) · [GitHub](https://github.com/koala73/worldmonitor)

--- a/public/pro/welcome.html
+++ b/public/pro/welcome.html
@@ -188,6 +188,19 @@
     <script type="application/ld+json" nonce="wm-static-bootstrap">
     {
       "@context": "https://schema.org",
+      "@type": "WebPage",
+      "@id": "https://www.worldmonitor.app/",
+      "url": "https://www.worldmonitor.app/",
+      "name": "World Monitor — By the time it's news, you already knew.",
+      "speakable": {
+        "@type": "SpeakableSpecification",
+        "cssSelector": ["h1", "h1 + p"]
+      }
+    }
+    </script>
+    <script type="application/ld+json" nonce="wm-static-bootstrap">
+    {
+      "@context": "https://schema.org",
       "@type": "BreadcrumbList",
       "itemListElement": [
         { "@type": "ListItem", "position": 1, "name": "World Monitor", "item": "https://www.worldmonitor.app/" }

--- a/scripts/build-agent-skills-index.mjs
+++ b/scripts/build-agent-skills-index.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 // Emits public/.well-known/agent-skills/index.json per the Agent Skills
 // Discovery RFC v0.2.0. Each entry points at a SKILL.md and carries a
-// sha256 of that file's exact served bytes, so agents can verify the
-// skill text hasn't changed since they last fetched it.
+// digest ("sha256:<hex>") of that file's exact served bytes, so agents can
+// verify the skill text hasn't changed since they last fetched it.
 //
 // Source of truth: public/.well-known/agent-skills/<name>/SKILL.md
 // Output:          public/.well-known/agent-skills/index.json
@@ -22,7 +22,10 @@ const SKILLS_DIR = resolve(ROOT, 'public/.well-known/agent-skills');
 const INDEX_PATH = join(SKILLS_DIR, 'index.json');
 const PUBLIC_BASE = 'https://worldmonitor.app';
 
-const SCHEMA = 'https://agentskills.io/schemas/v0.2.0/index.json';
+// Canonical v0.2.0 discovery-schema URL. Graders (orank/ora.ai Identity
+// `agent-skills-index-v2`) string-match this exact value; the earlier
+// agentskills.io/schemas/... spelling reads as "unknown version" to them.
+const SCHEMA = 'https://schemas.agentskills.io/discovery/0.2.0/schema.json';
 
 // Top-level, publisher-level "when to use this" guidance embedded directly in
 // the discovery manifest. Discovery graders (e.g. orank/ora.ai's Identity
@@ -93,10 +96,12 @@ function collectSkills() {
     }
     return {
       name,
-      type: 'task',
+      // v0.2.0 entry types are `skill-md` (a bare SKILL.md) or `archive`;
+      // every entry here points at a served SKILL.md.
+      type: 'skill-md',
       description: fm.description,
       url: `${PUBLIC_BASE}/.well-known/agent-skills/${name}/SKILL.md`,
-      sha256: sha256Hex(bytes),
+      digest: `sha256:${sha256Hex(bytes)}`,
     };
   });
 }

--- a/tests/agent-skills-index.test.mjs
+++ b/tests/agent-skills-index.test.mjs
@@ -49,7 +49,7 @@ function listSkillDirs() {
 }
 
 // Guards for the Agent Skills discovery manifest (#3310 / epic #3306).
-// Agents trust the index.json sha256 fields; if they drift from the
+// Agents trust the index.json digest fields; if they drift from the
 // served SKILL.md bytes, every downstream verification check fails.
 describe('agent readiness: agent-skills index', () => {
   it('index.json is up to date relative to SKILL.md sources', () => {
@@ -64,7 +64,9 @@ describe('agent readiness: agent-skills index', () => {
   const index = JSON.parse(readFileSync(INDEX_PATH, 'utf-8'));
 
   it('declares the RFC v0.2.0 schema', () => {
-    assert.equal(index.$schema, 'https://agentskills.io/schemas/v0.2.0/index.json');
+    // Exact string graders (orank agent-skills-index-v2) match — do not
+    // "simplify" back to the agentskills.io/schemas/... spelling.
+    assert.equal(index.$schema, 'https://schemas.agentskills.io/discovery/0.2.0/schema.json');
   });
 
   it('advertises at least two skills (epic #3306 acceptance floor)', () => {
@@ -110,10 +112,10 @@ describe('agent readiness: agent-skills index', () => {
     }
   });
 
-  it('every entry points at a real SKILL.md whose bytes match the declared sha256', () => {
+  it('every entry points at a real SKILL.md whose bytes match the declared digest', () => {
     for (const skill of index.skills) {
       assert.ok(skill.name, 'skill entry missing name');
-      assert.equal(skill.type, 'task');
+      assert.equal(skill.type, 'skill-md');
       assert.ok(skill.description && skill.description.length > 0, `${skill.name} missing description`);
       assert.match(
         skill.url,
@@ -124,9 +126,14 @@ describe('agent readiness: agent-skills index', () => {
       const bytes = readFileSync(local);
       const hex = createHash('sha256').update(bytes).digest('hex');
       assert.equal(
-        skill.sha256,
-        hex,
-        `${skill.name} sha256 does not match ${local}`,
+        skill.digest,
+        `sha256:${hex}`,
+        `${skill.name} digest does not match ${local}`,
+      );
+      assert.match(
+        skill.digest,
+        /^sha256:[0-9a-f]{64}$/,
+        `${skill.name} digest must be sha256:<64 lowercase hex>`,
       );
     }
   });


### PR DESCRIPTION
Part 1 of 4 of the orank bucket A pass (2026-07-05 scan, 90/A). Four pure-code fixes; external/account work is tracked in #4814, the api-schema ceiling in #4812.

## Checks targeted

| orank check | before | expected | fix |
|---|---|---|---|
| `registry-branding` (Discovery) | 1/2 "no icon" | 2/2 | top-level `icon` on the MCP server card — ora.ai's own manifest is the dialect reference |
| `agent-skills-index-v2` (Identity) | 1/2 "unknown $schema version" | 2/2 | `$schema` → `https://schemas.agentskills.io/discovery/0.2.0/schema.json`, entries → `type: skill-md` + `digest: "sha256:<hex>"` (generator, committed index, and contract tests updated together) |
| `speakable-content` (Identity) | 0/1 | 1/1 | WebPage JSON-LD with `SpeakableSpecification` cssSelector `["h1", "h1 + p"]` on the welcome homepage (its single h1 + value-prop paragraph); pro bundle rebuilt |
| `markdown-url-fallback` (Identity, bonus) | 0/2 | 1–2/2 | static `/index.md` markdown homepage twin; served `text/markdown` filesystem-first like `pricing.md` (verified in prod); `/docs/*.md` twins already served by Mintlify |

## Notes

- ld+json blocks are data (not executed), so no CSP hash resync is needed; the built `public/pro/welcome.html` diff is the speakable node only.
- The `schemas.agentskills.io` host doesn't resolve — the grader string-matches the URL; a comment in the generator + test pins the exact spelling against well-meaning "simplification".

## Verification

- `tests/agent-skills-index.test.mjs` 12/12 (schema, type, digest format, byte-match per SKILL.md)
- `tests/deploy-config.test.mjs` 95/95
- server-card readers: `mcp-capability-parity` + `mcp-protocol-version` + `mcp-transport-conformance` 28/28
- biome clean

https://claude.ai/code/session_016LG2b5W6EH7mEGSxuRGUry