### PR TITLE
fix(deploy): stop deploying api/**/*.test.mjs as live production functions (WORLDMONITOR-VD)

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -18,3 +18,9 @@ target/
 
 # Common local artifacts
 .DS_Store
+
+# Never deploy api test files: every non-underscore file under api/ becomes a
+# live serverless function, and a deployed *.test.mjs executes its whole
+# node:test suite (production env + Sentry) on every request (WORLDMONITOR-VD).
+# Guarded by tests/deploy-config.test.mjs.
+api/**/*.test.mjs

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import { readFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -1681,5 +1681,48 @@ describe('agent readiness: Content-Signal declarations', () => {
       headerValue(),
       'robots.txt Content-Signal must match the vercel.json header value'
     );
+  });
+});
+
+describe('vercel deployment excludes api test files', () => {
+  // Vercel deploys every non-underscore file under api/ as a live serverless
+  // function. A deployed *.test.mjs is a public endpoint that executes its
+  // whole node:test suite (with production env + Sentry) on every request —
+  // WORLDMONITOR-VD flooded Sentry with "Upstash Redis is not configured"
+  // because wm-session.test.mjs deletes the Upstash env vars to exercise the
+  // fail-closed path, and something polls /api/wm-session.test every ~2 min.
+  const vercelignore = readFileSync(resolve(__dirname, '../.vercelignore'), 'utf-8');
+  const ignoreRules = vercelignore
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+
+  const collectApiTestFiles = (dir) => {
+    const found = [];
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = resolve(dir, entry.name);
+      if (entry.isDirectory()) found.push(...collectApiTestFiles(full));
+      else if (/\.test\.[cm]?[jt]sx?$/.test(entry.name)) found.push(full);
+    }
+    return found;
+  };
+  const apiTestFiles = collectApiTestFiles(resolve(__dirname, '../api'));
+
+  it('.vercelignore excludes api/**/*.test.mjs', () => {
+    assert.ok(
+      ignoreRules.includes('api/**/*.test.mjs'),
+      '.vercelignore must contain "api/**/*.test.mjs" — without it every api test file deploys as a live production function'
+    );
+  });
+
+  it('every api test file uses the .test.mjs extension the ignore rule covers', () => {
+    assert.ok(apiTestFiles.length > 0, 'expected api test files to exist (walker broke?)');
+    for (const file of apiTestFiles) {
+      assert.match(
+        file,
+        /\.test\.mjs$/,
+        `${file}: api test files must end in .test.mjs so the .vercelignore rule excludes them from deployment — extend both if introducing a new extension`
+      );
+    }
   });
 });


### PR DESCRIPTION
## What

Adds `api/**/*.test.mjs` to `.vercelignore` plus a guard test, so api test files stop deploying as live production serverless functions.

Closes #4821. Fixes Sentry [WORLDMONITOR-VD](https://elie-habib.sentry.io/issues/7593804998/) ("Error: Upstash Redis is not configured", 860+ error events since Jul 4).

## Why

Vercel routes every non-underscore file under `api/` as a function — including the 10 `*.test.mjs` files. A request to `/api/wm-session.test` executes the whole node:test suite in the production runtime (verified live: HTTP 500 `FUNCTION_INVOCATION_FAILED` after 5.8s). The suite deletes the Upstash env vars to test the fail-closed path from #4775 — whose (correct) error-level reporting turned an invisible problem into a Sentry flood, because something polls that URL every ~2 minutes.

## How verified

- Bug-fix protocol: guard test written first, confirmed failing on the exact assertion, passes after the one-line ignore rule.
- Glob semantics proven with `git check-ignore` in a scratch repo: matches `api/wm-session.test.mjs` + nested `api/security/report.test.mjs` / `api/youtube/embed.test.mjs`; does NOT match `api/wm-session.js`.
- Full `tests/deploy-config.test.mjs`: 96 pass + 2 new pass; the 3 failures (`oauth-*` / agent-readiness) are pre-existing environmental (`node --test` can't resolve the extensionless `_agent-metadata` TS import; identical failures on a clean tree).
- Build safety: `build:blog && tsc && vite build` reads none of the excluded files; no prod code imports them (comment references only).

## Post-deploy note

The ~2-min poller of `/api/wm-session.test` (66 rotating AWS IPs) will start getting JSON 404s. If that's an uptime monitor, it will go red — repoint it at `/api/health`.

https://claude.ai/code/session_019Ec6Arn7rfLnQrVj8qpjFm
