### PR TITLE
feat(discovery): publish /.well-known/ai-catalog.json ARD manifest (ora ard-catalog bonus)

### DIFF
--- a/public/.well-known/ai-catalog.json
+++ b/public/.well-known/ai-catalog.json
@@ -1,0 +1,82 @@
+{
+  "specVersion": "1.0",
+  "host": {
+    "displayName": "World Monitor",
+    "identifier": "did:web:worldmonitor.app",
+    "documentationUrl": "https://worldmonitor.app/docs/documentation"
+  },
+  "entries": [
+    {
+      "identifier": "urn:air:worldmonitor.app:mcp:worldmonitor",
+      "displayName": "World Monitor MCP server",
+      "type": "application/mcp-server-card+json",
+      "url": "https://worldmonitor.app/.well-known/mcp/server-card.json",
+      "description": "Live global-intelligence MCP server: real-time markets, conflict events, aviation, maritime, energy, climate, health, displacement, supply chain, and AI-generated regional briefs.",
+      "tags": [
+        "news-and-intelligence",
+        "news",
+        "intelligence",
+        "geopolitics",
+        "global-risk",
+        "mcp"
+      ],
+      "capabilities": [
+        "get_world_brief",
+        "get_country_brief",
+        "get_country_risk",
+        "get_conflict_events",
+        "get_market_data",
+        "get_energy_intelligence",
+        "get_maritime_activity",
+        "get_chokepoint_status",
+        "get_supply_chain_data",
+        "analyze_situation",
+        "generate_forecasts"
+      ],
+      "representativeQueries": [
+        "what is happening in the Red Sea right now",
+        "country risk briefing for Egypt",
+        "global markets and conflict overview this morning",
+        "which shipping chokepoints are disrupted",
+        "forecast the impact of a Strait of Hormuz closure"
+      ],
+      "trustManifest": {
+        "identity": "did:web:worldmonitor.app",
+        "identityType": "did"
+      }
+    },
+    {
+      "identifier": "urn:air:worldmonitor.app:api:worldmonitor",
+      "displayName": "World Monitor REST API",
+      "type": "application/vnd.oai.openapi+json;version=3.1",
+      "url": "https://worldmonitor.app/openapi.json",
+      "description": "World Monitor's public REST API: 190+ documented operations across conflict, markets, energy, maritime, aviation, climate, health, and supply-chain intelligence, with API-key and OAuth access.",
+      "tags": [
+        "news-and-intelligence",
+        "api",
+        "rest",
+        "openapi"
+      ],
+      "trustManifest": {
+        "identity": "did:web:worldmonitor.app",
+        "identityType": "did"
+      }
+    },
+    {
+      "identifier": "urn:air:worldmonitor.app:skills:index",
+      "displayName": "World Monitor agent skills",
+      "type": "application/json",
+      "url": "https://worldmonitor.app/.well-known/agent-skills/index.json",
+      "description": "Self-published agent skills for common World Monitor workflows (country briefings, market prep, conflict monitoring, route risk).",
+      "tags": [
+        "news-and-intelligence",
+        "agent-skills",
+        "skills"
+      ],
+      "trustManifest": {
+        "identity": "did:web:worldmonitor.app",
+        "identityType": "did"
+      }
+    }
+  ]
+}

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -1726,3 +1726,79 @@ describe('vercel deployment excludes api test files', () => {
     }
   });
 });
+
+// Registry branding + ARD catalog (ora.ai Discovery checks). The MCP
+// server-card must carry the full branding trio (name, icon, description —
+// `registry-branding`), and /.well-known/ai-catalog.json publishes the ARD
+// manifest (`ard-catalog` bonus): host identity plus domain-anchored
+// urn:air: entries, each with a media type, URL, and trust manifest —
+// mirroring ora's own /api/ard/catalog dialect, which is what their parser
+// reads.
+describe('agent readiness: registry branding + ARD catalog', () => {
+  const serverCard = JSON.parse(
+    readFileSync(resolve(__dirname, '../public/.well-known/mcp/server-card.json'), 'utf-8')
+  );
+  const aiCatalog = JSON.parse(
+    readFileSync(resolve(__dirname, '../public/.well-known/ai-catalog.json'), 'utf-8')
+  );
+
+  it('server-card carries the full branding trio and the icon asset exists', () => {
+    assert.ok(serverCard.name, 'server-card must have a name');
+    assert.ok(serverCard.description, 'server-card must have a description');
+    assert.match(
+      serverCard.icon ?? '',
+      /^https:\/\/(www\.)?worldmonitor\.app\//,
+      'server-card icon must be an absolute worldmonitor.app URL'
+    );
+    const iconPath = new URL(serverCard.icon).pathname;
+    assert.ok(
+      existsSync(resolve(__dirname, `../public${iconPath}`)),
+      `server-card icon must point at a real public asset (public${iconPath})`
+    );
+  });
+
+  it('ai-catalog.json declares the World Monitor host identity', () => {
+    assert.strictEqual(aiCatalog.specVersion, '1.0');
+    assert.strictEqual(aiCatalog.host?.displayName, 'World Monitor');
+    assert.strictEqual(aiCatalog.host?.identifier, 'did:web:worldmonitor.app');
+    assert.ok(Array.isArray(aiCatalog.entries) && aiCatalog.entries.length >= 2);
+  });
+
+  it('every ai-catalog entry is domain-anchored and complete', () => {
+    for (const entry of aiCatalog.entries) {
+      const label = `ai-catalog entry ${entry.identifier}`;
+      assert.match(
+        entry.identifier ?? '',
+        /^urn:air:worldmonitor\.app:[a-z-]+:[a-z0-9-]+$/,
+        `${label} must be a domain-anchored urn:air URN`
+      );
+      assert.ok(entry.displayName, `${label} needs a displayName`);
+      assert.ok(entry.type, `${label} needs a media type`);
+      assert.ok(entry.description, `${label} needs a description`);
+      assert.match(
+        entry.url ?? '',
+        /^https:\/\/(www\.)?worldmonitor\.app\//,
+        `${label} URL must be same-origin`
+      );
+      assert.strictEqual(
+        entry.trustManifest?.identity,
+        'did:web:worldmonitor.app',
+        `${label} trust identity must be the domain DID`
+      );
+    }
+  });
+
+  it('the ai-catalog MCP entry points at the real server-card path', () => {
+    const mcpEntry = aiCatalog.entries.find((e) => e.type === 'application/mcp-server-card+json');
+    assert.ok(mcpEntry, 'ai-catalog must list the MCP server');
+    assert.ok(
+      mcpEntry.url.endsWith('/.well-known/mcp/server-card.json'),
+      'MCP entry URL must target the published server-card'
+    );
+    assert.ok(
+      existsSync(resolve(__dirname, '../public/.well-known/agent-skills/index.json')) ===
+        aiCatalog.entries.some((e) => e.url.endsWith('/.well-known/agent-skills/index.json')),
+      'agent-skills entry must exist iff the skills index is published'
+    );
+  });
+});


### PR DESCRIPTION
## Why

Two asks from the ora.ai Discovery layer, one already handled:

1. **registry-branding (1/2)** — the MCP server-card lacked an icon. **Landed separately in #4820** (identical fix, concurrent session); this PR adds the guard test that pins the branding trio + verifies the icon URL points at a real `public/` asset.
2. **ard-catalog (bonus, 0/3, currently n/a)** — no `/.well-known/ai-catalog.json`. This PR publishes it.

## What

`public/.well-known/ai-catalog.json`, modeled on **ora's own `/api/ard/catalog`** (their parser is the scorer — same lesson as the #4806 server-card dialect fix): `specVersion 1.0`, host identity **"World Monitor"** / `did:web:worldmonitor.app`, and three domain-anchored `urn:air:worldmonitor.app:*` entries:

- **MCP server** → `/.well-known/mcp/server-card.json` (`application/mcp-server-card+json`), real tool names as capabilities, representative queries
- **REST API** → `/openapi.json` (`application/vnd.oai.openapi+json;version=3.1`)
- **Agent skills** → `/.well-known/agent-skills/index.json`

Every entry carries `news-and-intelligence` category tags and a `did:web` trust manifest — this also states the product identity machine-readably (groundwork for the ora leaderboard row that currently falls back to "worldmonitor.app / Community").

## Tests

New deploy-config describe (4 tests, 101/101 suite green): branding trio + icon asset existence, catalog host identity, URN anchoring + same-origin URLs + trust identity per entry, MCP entry ↔ published server-card path, skills entry ↔ published index parity. MCP card-consuming suites re-run green (28/28).

Static file served via `public/` (SPA rewrite already excludes `.well-known`). Rescan after deploy should flip `ard-catalog` n/a → up to +3 bonus.

https://claude.ai/code/session_0186WURs7MeJHGdJRmZ3e6r7