### PR TITLE
docs(sdk): cross-link the official Python/Ruby/Go SDKs from npm-only pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ World Monitor is built for agents and scripts as well as browsers:
   worldmonitor risk IR --api-key wm_xxx
   ```
 
+- **SDKs** — official zero-dependency client libraries mirroring the CLI: Python [`worldmonitor-sdk`](https://pypi.org/project/worldmonitor-sdk/) (source in [`sdk/python/`](sdk/python/)), Ruby [`worldmonitor`](https://rubygems.org/gems/worldmonitor) ([`sdk/ruby/`](sdk/ruby/)), Go [`github.com/koala73/worldmonitor/sdk/go`](https://pkg.go.dev/github.com/koala73/worldmonitor/sdk/go) ([`sdk/go/`](sdk/go/)). Guide: [worldmonitor.app/docs/sdks](https://www.worldmonitor.app/docs/sdks).
+
 Agent discovery files: [`llms.txt`](https://worldmonitor.app/llms.txt) · [agent-skills manifest](https://worldmonitor.app/.well-known/agent-skills/index.json) · [api-catalog](https://worldmonitor.app/.well-known/api-catalog). Get an API key at [worldmonitor.app/pro](https://worldmonitor.app/pro).
 
 ---

--- a/docs/agent-discovery.mdx
+++ b/docs/agent-discovery.mdx
@@ -67,7 +67,7 @@ npx @openapitools/openapi-generator-cli generate \
   -i worldmonitor.openapi.yaml -g typescript-fetch -o ./client
 ```
 
-The bundled spec covers all 35 services in a single document, so one codegen pass produces typed clients for everything.
+The bundled spec covers all 35 services in a single document, so one codegen pass produces typed clients for everything. Prefer a maintained package over codegen? [Official SDKs](/sdks) exist for Python, Ruby, Go, and JavaScript.
 
 ### Connect an MCP client to live data
 
@@ -114,7 +114,7 @@ The point isn't novelty — RFCs 8414, 8288, 9727, 9728 are old. The point is th
 - Discover the API without reading our docs.
 - Authenticate without us telling it which OAuth flow we use.
 - Pick the right transport (REST vs MCP) based on its own preferences.
-- Stay current — when we ship a new service, the bundled `/openapi.yaml` and the api-catalog reflect it on the next deploy. No version pinning, no client SDK release cycle.
+- Stay current — when we ship a new service, the bundled `/openapi.yaml` and the api-catalog reflect it on the next deploy. No version pinning, no waiting on an SDK release cycle (though [official SDKs](/sdks) exist when a maintained package fits better).
 
 ## Related
 

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -7,6 +7,7 @@ description: "Script country briefs, risk scores, and any of the 39 MCP tools fr
 
 The source lives in [`cli/`](https://github.com/koala73/worldmonitor/tree/main/cli) in the main repository and is published to npm on every `cli-v*` release tag.
 Maintainers can follow the [CLI release runbook](/releasing-cli) when cutting a new npm version.
+Prefer a library over a shell? The same client ships as [official SDKs](/sdks) for **Python**, **Ruby**, and **Go**.
 
 ## Install
 

--- a/docs/mcp-quickstart.mdx
+++ b/docs/mcp-quickstart.mdx
@@ -161,6 +161,7 @@ The `wm_…` user API key goes in `X-WorldMonitor-Key`, **not** as a `Bearer` to
 - **[MCP Tools Reference](/mcp-tools-reference)** — per-tool parameters, freshness budgets, API endpoint mapping, and `curl` examples for every tool.
 - **[MCP Server reference](/mcp-overview)** — auth modes, OAuth setup, plans & quotas, error codes, and freshness model.
 - **[Command-line client](/cli)** — prefer a shell? `npx worldmonitor tools` drives the same tools from your terminal or a script, no integration to write.
+- **[Official SDKs](/sdks)** — prefer a library? Zero-dependency clients for Python (`pip install worldmonitor-sdk`), Ruby (`gem install worldmonitor`), and Go (`go get github.com/koala73/worldmonitor/sdk/go`) call the same tools with language-native helpers.
 - **[Authentication overview](/authentication)** — when to use an API key in `X-WorldMonitor-Key` vs. OAuth vs. browser session.
 
 ## Operational note (for ops, not callers)

--- a/docs/releasing-cli.mdx
+++ b/docs/releasing-cli.mdx
@@ -3,6 +3,7 @@ title: "CLI Release Runbook"
 description: "How maintainers publish the worldmonitor npm CLI from cli/ with cli-v* tags and npm trusted publishing."
 ---
 This runbook covers maintainer releases of the official [`worldmonitor`](https://www.npmjs.com/package/worldmonitor) npm CLI from `cli/`. CLI releases are intentionally independent from desktop app releases: a `cli-vX.Y.Z` Git tag triggers `.github/workflows/publish-cli.yml`.
+The Python, Ruby, and Go SDKs release the same way with their own tags (`py-v*`, `gem-v*`, `sdk/go/v*`) — see [Official SDKs → Releasing](/sdks#releasing-maintainers).
 
 ## Prerequisites
 


### PR DESCRIPTION
Follow-up to #4817 (answers: "does our documentation point to the python, ruby and go sdks, or only npm?").

The dedicated surfaces already point at all four SDKs — [/docs/sdks](https://www.worldmonitor.app/docs/sdks), `llms.txt`, `api/llms.txt` — but the pages developers actually land on were still npm-only. One line each:

- **docs/cli.mdx** — "Prefer a library over a shell?" pointer to /sdks
- **docs/mcp-quickstart.mdx** — Official SDKs bullet in "Where to go next" (after the CLI bullet)
- **README.md** — SDKs bullet in Programmatic Access with all three registry links + source dirs
- **docs/releasing-cli.mdx** — SDK release tags (`py-v*`, `gem-v*`, `sdk/go/v*`) pointer to /sdks#releasing-maintainers
- **docs/agent-discovery.mdx** — codegen walkthrough now offers /sdks as the no-codegen path, and the "no client SDK release cycle" line (written before SDKs existed, now reads as denying them) reworded to keep the freshness argument without the contradiction

Verified: `lint:md` clean (89 files), `mdx-lint` 226/226, `docs:check` 73/73 claims.

https://claude.ai/code/session_01DJicKa3VSq7iwMk3E5nYyk