### PR TITLE
docs: simplify README credential note

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ npm run dev
 
 Open [localhost:3000](http://localhost:3000) (override the port with `DEV_PORT` in `.env.local`). The app runs with no environment variables.
 
-Feature-specific data sources may require credentials — for example, the flight-price command (`fly LON DXB`) needs `TRAVELPAYOUTS_API_TOKEN` to return live quotes; without it the command shows a "credentials required" message rather than synthetic data. See `.env.example` for the full list.
+Feature-specific data sources may require credentials. See `.env.example` for the full list.
 
 For variant-specific development:
 


### PR DESCRIPTION
## Summary

The README now keeps local setup guidance easy to scan: optional provider credentials are mentioned generically, and `.env.example` remains the detailed source of truth.

## Validation

- Pre-push gate ran during `git push`: typecheck, API typecheck, Convex typecheck, CJS syntax, Unicode safety, boundary/safe-html/Sentry/rate-limit/premium-fetch checks, edge bundle check, markdown lint, proto/pro-test freshness skips, and version sync.
- Unit and edge tests were skipped by the hook because this only changed README copy.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5_Codex-000000)
