### PR TITLE
docs(readme): SDK registry badges (PyPI, RubyGems, Go) next to the npm badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/worldmonitor"><img src="https://img.shields.io/npm/v/worldmonitor?style=for-the-badge&logo=npm&logoColor=white&label=npm%20i%20worldmonitor&color=CB3837" alt="npm i worldmonitor"></a>&nbsp;
-  <a href="https://www.npmjs.com/package/worldmonitor"><img src="https://img.shields.io/badge/CLI-npx%20worldmonitor-CB3837?style=for-the-badge&logo=npm&logoColor=white" alt="npx worldmonitor"></a>
+  <a href="https://www.npmjs.com/package/worldmonitor"><img src="https://img.shields.io/badge/CLI-npx%20worldmonitor-CB3837?style=for-the-badge&logo=npm&logoColor=white" alt="npx worldmonitor"></a>&nbsp;
+  <a href="https://pypi.org/project/worldmonitor-sdk/"><img src="https://img.shields.io/pypi/v/worldmonitor-sdk?style=for-the-badge&logo=pypi&logoColor=white&label=pip%20install%20worldmonitor-sdk&color=3775A9" alt="pip install worldmonitor-sdk"></a>&nbsp;
+  <a href="https://rubygems.org/gems/worldmonitor"><img src="https://img.shields.io/gem/v/worldmonitor?style=for-the-badge&logo=rubygems&logoColor=white&label=gem%20install%20worldmonitor&color=E9573F" alt="gem install worldmonitor"></a>&nbsp;
+  <a href="https://pkg.go.dev/github.com/koala73/worldmonitor/sdk/go"><img src="https://img.shields.io/badge/go%20get-sdk%2Fgo-00ADD8?style=for-the-badge&logo=go&logoColor=white" alt="go get github.com/koala73/worldmonitor/sdk/go"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Follow-up to #4817/#4833 — the README badge row (the visible top of the repo) showed npm only; the three new SDK registries now sit beside it with live version shields:

- `pip install worldmonitor-sdk` → pypi.org/project/worldmonitor-sdk (live `pypi/v` shield)
- `gem install worldmonitor` → rubygems.org/gems/worldmonitor (live `gem/v` shield)
- `go get …/sdk/go` → pkg.go.dev (static shield — Go modules have no registry version endpoint on shields)

`lint:md` clean.

https://claude.ai/code/session_01DJicKa3VSq7iwMk3E5nYyk