### PR TITLE
docs: fix stale agent-facing API prose

### DIFF
--- a/docs/adding-endpoints.mdx
+++ b/docs/adding-endpoints.mdx
@@ -157,7 +157,7 @@ export const seismologyHandler: SeismologyServiceHandler = {
 npx tsc --noEmit   # should pass with zero errors
 ```
 
-The route is already live. `createSeismologyServiceRoutes()` picks up the new RPC automatically — no changes needed to `api/[[...path]].ts` or `vite.config.ts`.
+The route is already live through the domain gateway in `api/seismology/v1/[rpc].ts`. `createSeismologyServiceRoutes()` picks up the new RPC automatically — no route-table or `vite.config.ts` edits are needed.
 
 ### 7. Check the generated docs
 
@@ -300,19 +300,23 @@ export const weatherHandler: WeatherServiceHandler = {
 };
 ```
 
-### 7. Register the service in the gateway
+### 7. Add the per-domain edge gateway
 
-Edit `api/[[...path]].js` — add the import and mount the routes:
+Create `api/weather/v1/[rpc].ts` as the thin Edge entry point for this service:
 
 ```typescript
-import { createWeatherServiceRoutes } from '../src/generated/server/worldmonitor/weather/v1/service_server';
-import { weatherHandler } from './server/worldmonitor/weather/v1/handler';
+export const config = { runtime: 'edge' };
 
-const allRoutes = [
-  // ... existing routes ...
-  ...createWeatherServiceRoutes(weatherHandler, serverOptions),
-];
+import { createDomainGateway, serverOptions } from '../../../server/gateway';
+import { createWeatherServiceRoutes } from '../../../src/generated/server/worldmonitor/weather/v1/service_server';
+import { weatherHandler } from '../../../server/worldmonitor/weather/v1/handler';
+
+export default createDomainGateway(
+  createWeatherServiceRoutes(weatherHandler, serverOptions),
+);
 ```
+
+There is no repository-wide catch-all gateway file or shared route array to edit. Each service owns its `api/<domain>/v1/[rpc].ts` gateway, and the generated `create<Service>Routes(...)` function enforces the RPC path names and HTTP annotations for that domain.
 
 ### 8. Register in the Vite dev server
 

--- a/docs/api-oauth.mdx
+++ b/docs/api-oauth.mdx
@@ -34,7 +34,17 @@ Dynamic Client Registration. Returns a `client_id` (public clients, no secret).
 }
 ```
 
-**Response**: `{ "client_id": "c_01HX...", "client_id_issued_at": 1713456789, ... }`
+**Response**:
+```json
+{
+  "client_id": "7c3b08f0-0c1f-4a9c-8a52-69e13d2a5d5e",
+  "client_name": "Claude Desktop",
+  "redirect_uris": ["https://claude.ai/api/mcp/auth_callback"],
+  "grant_types": ["authorization_code", "refresh_token"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "none"
+}
+```
 
 **Redirect URI allowlist**: only these prefixes are accepted:
 

--- a/docs/api-reference.mdx
+++ b/docs/api-reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: "API Reference"
-description: "Catalog of every WorldMonitor REST service. All endpoints follow /api/<service>/v1/<rpc-name>."
+description: "Catalog of documented WorldMonitor REST service groups. All endpoints follow /api/<service>/v1/<rpc-name>."
 ---
 
 WorldMonitor exposes its data through a family of versioned REST services. Every endpoint follows the same shape:
@@ -11,7 +11,7 @@ https://api.worldmonitor.app/api/<service>/v1/<rpc-name>
 
 `<rpc-name>` is kebab-case (e.g. `list-acled-events`, `get-resilience-ranking`). Auth is the same on every service — pass a user API key such as `X-WorldMonitor-Key: wm_0123456789abcdef0123456789abcdef01234567`, an operator-issued enterprise key, or use the dashboard's browser session where supported. See [Authentication](/usage-auth) for details.
 
-The grouped pages in the left sidebar render the full OpenAPI spec — request parameters, response schemas, and try-it-out — for each service.
+The grouped pages in the left sidebar render OpenAPI specs — request parameters, response schemas, and try-it-out — for the documented service groups. The bundled spec remains the complete machine-readable source.
 
 Prefer the terminal? The official [`worldmonitor` CLI](/cli) hits any of these paths (`worldmonitor get /api/<service>/v1/<rpc-name>`) and lists the live catalog with `worldmonitor list`.
 
@@ -19,7 +19,7 @@ Prefer the terminal? The official [`worldmonitor` CLI](/cli) hits any of these p
 
 Building an agent or codegen pipeline? Point at `https://worldmonitor.app/` and follow the `Link:` header — every OpenAPI spec, MCP server card, OAuth endpoint, and agent-skill bundle is discoverable from one root URL via standard `.well-known` paths. See [Agent Discovery](/agent-discovery) for the full walkthrough.
 
-The single bundled spec is at [`/openapi.yaml`](https://www.worldmonitor.app/openapi.yaml) — feed it to any OpenAPI generator to produce typed clients for all 35 services in one pass.
+The single bundled spec is at [`/openapi.yaml`](https://www.worldmonitor.app/openapi.yaml) — feed it to any OpenAPI generator to produce typed clients for all 35 generated services in one pass, including platform services that do not have dedicated sidebar pages.
 
 ## Service catalog
 
@@ -33,7 +33,7 @@ The single bundled spec is at [`/openapi.yaml`](https://www.worldmonitor.app/ope
 
 **Health and environment** — Public Health, Imagery, Webcams
 
-**Other** — News (feed digest, article summaries), Research, Positive Events, Giving, Batch (bulk read fan-out)
+**Other** — News (feed digest, article summaries), Research, Positive Events, Giving, Batch (bulk read fan-out), Leads (contact and Pro-waitlist mutations documented under Platform Endpoints)
 
 Open any group in the sidebar to browse its operations.
 

--- a/docs/mcp-error-catalog.mdx
+++ b/docs/mcp-error-catalog.mdx
@@ -160,12 +160,12 @@ The most common error code, shared across `tools/call`, `prompts/get`, `resource
 
 | Trigger                                                | Site                              | Example `message`                                                          |
 |--------------------------------------------------------|-----------------------------------|----------------------------------------------------------------------------|
-| `tools/call` with no/non-string `name`                 | `api/mcp/dispatch.ts:113`         | `Invalid params: missing tool name`                                        |
-| `tools/call` with `name` that isn't in the registry    | `api/mcp/dispatch.ts:117`         | `Unknown tool: get_foo`                                                    |
-| `prompts/get` with no/non-string `name`                | `api/mcp/handler.ts:133`          | `Invalid params: missing prompt name`                                      |
-| `prompts/get` with unknown name or missing required arg | `api/mcp/prompts/index.ts:302/310` | `Unknown prompt: …` / `Missing required argument "iso2" for prompt "country-briefing"` |
+| `tools/call` with no/non-string `name`                 | `api/mcp/dispatch.ts` `dispatchToolsCall` param guard | `Invalid params: missing tool name`                         |
+| `tools/call` with `name` that isn't in the registry    | `api/mcp/dispatch.ts` `dispatchToolsCall` registry lookup | `Unknown tool: get_foo`                                  |
+| `prompts/get` with no/non-string `name`                | `api/mcp/handler.ts` `prompts/get` switch branch       | `Invalid params: missing prompt name`                        |
+| `prompts/get` with unknown name or missing required arg | `api/mcp/prompts/index.ts` `buildPromptResponse`       | `Unknown prompt: …` / `Missing required argument "iso2" for prompt "country-briefing"` |
 | `resources/read` with no/unknown/malformed `uri`       | `api/mcp/resources/index.ts` (`buildPublicResourceResponse` / `buildResourceResponse`) | `Invalid params: missing resource uri` / `Unknown resource uri "..."` |
-| `logging/setLevel` with non-string or out-of-set level | `api/mcp/handler.ts:156`          | `Invalid params: level must be one of debug, info, notice, warning, error, critical, alert, emergency` |
+| `logging/setLevel` with non-string or out-of-set level | `api/mcp/handler.ts` `logging/setLevel` switch branch  | `Invalid params: level must be one of debug, info, notice, warning, error, critical, alert, emergency` |
 
 ```json
 {
@@ -211,9 +211,9 @@ The `message` text identifies the trigger. Three sites emit a 503; two distinct 
 
 | Trigger                                         | `message`                                              | Site                              |
 |-------------------------------------------------|--------------------------------------------------------|-----------------------------------|
-| OAuth resolution service threw (Convex blip)    | `Auth service temporarily unavailable. Try again.`     | `api/mcp/auth.ts:142`             |
-| `MCP_INTERNAL_HMAC_SECRET` unset (Pro path)     | `Service temporarily unavailable, retry in a moment.`  | `api/mcp/auth.ts:204`             |
-| Pro quota-reservation Redis failure (non-cap)   | `Service temporarily unavailable, retry in a moment.`  | `api/mcp/dispatch.ts:141`         |
+| OAuth resolution service threw (Convex blip)    | `Auth service temporarily unavailable. Try again.`     | `api/mcp/auth.ts` `resolveAuthContext` bearer branch |
+| `MCP_INTERNAL_HMAC_SECRET` unset (Pro path)     | `Service temporarily unavailable, retry in a moment.`  | `api/mcp/auth.ts` `runProPreChecks` secret preflight |
+| Pro quota-reservation Redis failure (non-cap)   | `Service temporarily unavailable, retry in a moment.`  | `api/mcp/dispatch.ts` `dispatchToolsCall` quota reservation |
 
 Client recovery is identical for all three (honour `Retry-After: 5`); the message disambiguates only for log analysis.
 

--- a/docs/mcp-error-catalog.mdx
+++ b/docs/mcp-error-catalog.mdx
@@ -8,18 +8,18 @@ description: "Every error shape WorldMonitor's MCP server can emit — JSON-RPC 
   Every code/envelope in this page should resolve to a line below; every
   emission site below should appear in the page.
 
-  - JSON-RPC envelope helpers           api/mcp/rpc.ts:7-13
+  - JSON-RPC envelope helpers           api/mcp/rpc.ts (rpcOk, rpcError)
   - Method gate (405 + Allow)           api/mcp/handler.ts (mcpHandler method check)
-  - Top-level dispatch / -32600/-32601  api/mcp/handler.ts:66-164
-  - Auth -32001 / -32603 emitters       api/mcp/auth.ts:126-238
-  - Per-minute -32029                   api/mcp/auth.ts:243-260
-  - Pro daily-cap -32029 (HTTP 429)     api/mcp/dispatch.ts:136-149
-  - Tool exec -32603                    api/mcp/dispatch.ts:239-282
-  - _budget_exceeded envelope           api/mcp/dispatch.ts:223-236
-  - _jmespath_error envelope            api/mcp/jmespath.ts:46-94
-  - JMESPath caps                       api/mcp/constants.ts:232-233
-  - Prompts -32602                      api/mcp/prompts/index.ts:296-316
-  - Resources -32602 / -32603           api/mcp/resources/index.ts:198-289
+  - Top-level dispatch / -32600/-32601  api/mcp/handler.ts (POST body parse and dispatch switch)
+  - Auth -32001 / -32603 emitters       api/mcp/auth.ts (resolveAuthContext and entitlement checks)
+  - Per-minute -32029                   api/mcp/auth.ts (applyPerMinuteLimit, applyAnonDiscoveryLimit)
+  - Pro daily-cap -32029 (HTTP 429)     api/mcp/dispatch.ts (reserveDailyQuotaForRequest)
+  - Tool exec -32603                    api/mcp/dispatch.ts (dispatchToolsCall)
+  - _budget_exceeded envelope           api/mcp/dispatch.ts (budget cap handling)
+  - _jmespath_error envelope            api/mcp/jmespath.ts (applyJmespath)
+  - JMESPath caps                       api/mcp/constants.ts (JMESPATH_LIMITS)
+  - Prompts -32602                      api/mcp/prompts/index.ts (listPrompts, getPrompt)
+  - Resources -32602 / -32603           api/mcp/resources/index.ts (listResources, readResource)
 */}
 
 This page is the practical reference: a payload arrives, you look it up, and you know what to do next. The server signals failure on three independent layers — **HTTP status**, **JSON-RPC `error.code`**, and **soft-behavior envelopes inside `result.content[0].text`** — and a single failure can touch one, two, or all three. Triage from the outside in: HTTP status → JSON-RPC code → soft envelope.
@@ -80,16 +80,17 @@ Content-Type: application/json
 
 ### `-32029` — Rate limited (per-minute OR daily)
 
-Two distinct triggers share this code; the HTTP status disambiguates.
+Per-minute and daily-cap triggers share this code; the HTTP status disambiguates.
 
-**Per-minute throttle — HTTP 200.** Sliding-window limiter at **60 requests / minute** keyed per API key (Starter+) or per Pro user (combined across all that user's tokens). The limiter runs in `api/mcp/handler.ts` **before** the method-dispatch switch, so **every** request that reaches it counts — `tools/call`, all metadata methods (`tools/list`, `describe_tool`, `prompts/list`, `resources/list`), AND the lifecycle methods (`initialize`, `notifications/initialized`, `ping`). There is no per-method exemption. (The Pro daily-cap exemption set is separate and narrower — see below.) Comes back as a JSON-RPC error inside HTTP 200 because the limiter is upstream of any per-id correlation. Fails OPEN on Upstash transient errors — single spikes in limiter-backend latency won't take the API down.
+**Per-minute throttle — HTTP 200.** Sliding-window limiter at **60 requests / minute** keyed per API key (Starter+), per Pro user (combined across all that user's tokens), or per IP for anonymous public discovery. Credentialed requests are limited after auth. Credential-less public discovery methods (`initialize`, `notifications/initialized`, `tools/list`, `resources/list`, `resources/templates/list`) and anonymous public-resource reads are served without auth but still pass through the anonymous discovery limiter. Credential-less data/quota methods, or metadata methods outside that public set, do **not** use anonymous discovery — they fail closed with `-32001` / HTTP 401. Comes back as a JSON-RPC error inside HTTP 200 because the limiter is upstream of any per-id correlation. Fails OPEN on Upstash transient errors — single spikes in limiter-backend latency won't take the API down.
 
-The `message` text identifies which limiter fired. Two distinct strings:
+The `message` text identifies which limiter fired. Three distinct strings:
 
-| Auth context           | `message`                                                        | Site                  |
-|------------------------|------------------------------------------------------------------|-----------------------|
-| `X-WorldMonitor-Key`   | `Rate limit exceeded. Max 60 requests per minute per API key.`   | `api/mcp/auth.ts:249` |
-| Pro OAuth bearer       | `Rate limit exceeded. Max 60 requests per minute per Pro user.`  | `api/mcp/auth.ts:257` |
+| Auth context                              | `message`                                                                           | Site                                                    |
+|-------------------------------------------|-------------------------------------------------------------------------------------|---------------------------------------------------------|
+| `X-WorldMonitor-Key`                      | `Rate limit exceeded. Max 60 requests per minute per API key.`                      | `api/mcp/auth.ts` `applyPerMinuteLimit` API-key branch  |
+| Pro OAuth bearer                          | `Rate limit exceeded. Max 60 requests per minute per Pro user.`                     | `api/mcp/auth.ts` `applyPerMinuteLimit` Pro branch      |
+| No credential on anonymous discovery path | `Rate limit exceeded. Max 60 unauthenticated discovery requests per minute per IP.` | `api/mcp/auth.ts` `applyAnonDiscoveryLimit`             |
 
 Example payload (Pro variant — env_key clients get the same envelope shape with the API-key message string):
 

--- a/public/auth.md
+++ b/public/auth.md
@@ -64,8 +64,9 @@ POST /oauth/register  {"client_name":"My Agent","redirect_uris":["https://claude
 
 `redirect_uris` are allowlisted (Claude callbacks + `http://localhost` /
 `http://127.0.0.1` on any port). Clients are public — no secret; use PKCE
-(`S256`). **API-key path:** self-issue a key at
-<https://worldmonitor.app/developers> — no registration call.
+(`S256`). **API-key path:** start at <https://worldmonitor.app/pro>, then use
+the signed-in dashboard's API Keys settings to self-issue or revoke keys — no
+registration call.
 
 ## Claim
 
@@ -108,8 +109,9 @@ The same credentials authorize the REST API. Catalog:
 
 - **Expiry** — access tokens last 1 hour, refresh tokens 7 days; let them lapse
   to de-authorize an agent.
-- **User revoke** — a signed-in user revokes an agent from the dashboard
-  (<https://worldmonitor.app/developers>); the token is then rejected with `401`
+- **User revoke** — a signed-in user revokes an agent from the dashboard's API
+  Keys or Connected MCP Clients settings; start at <https://worldmonitor.app/pro>.
+  The token is then rejected with `401`
   / `invalid_grant`.
 - **Refresh rotation** — refresh tokens rotate on every use with token-family
   revocation, so a stolen token dies once the real client next refreshes.

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -262,7 +262,7 @@ Native desktop app built with Tauri (Rust + Node.js sidecar). The sidecar mirror
 - 8 live news streams and 19 live webcams from geopolitical hotspots
 - 7-signal macro market radar with BUY/CASH verdict
 - Country brief pages with exportable intelligence dossiers (JSON, CSV, PNG)
-- Multilingual UI in 24 languages with RTL support
+- Multilingual UI in 25 languages with RTL support
 - Prediction market integration (Polymarket) with 3-tier JA3 bypass
 - Temporal baseline anomaly detection using Welford's algorithm
 - Dual-source protest tracking (ACLED + GDELT) with regime-aware scoring

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -79,7 +79,7 @@ World Monitor is relevant for queries about real-time geopolitical intelligence 
 - 500+ curated RSS feeds across geopolitics, defense, energy, tech, and finance with domain-allowlisted proxy
 - 8 live news video streams (Bloomberg, Sky News, Al Jazeera, Euronews, DW, France24, CNBC, Al Arabiya)
 - 19 live webcams from geopolitical hotspots across 4 regions
-- Multilingual UI supporting 24 languages with RTL support
+- Multilingual UI supporting 25 languages with RTL support
 - 7-signal macro market radar with composite BUY/CASH verdict, BTC ETF flow tracking, stablecoin peg monitoring, Fear & Greed Index
 - Country brief pages with AI-generated analysis, CII score ring, prediction markets, 7-day timeline, infrastructure exposure, and stock index
 - Geographic convergence detection — identifies when multiple signal types spike in the same area

--- a/scripts/docs-stats.mjs
+++ b/scripts/docs-stats.mjs
@@ -307,6 +307,8 @@ function claims(s) {
     { file: 'README.md', re: /Protocol Buffers \((\d+)\s+protos/, value: s.protoFiles },
     { file: 'README.md', re: /(\d+)\s+services\)/, value: s.protoServices },
     { file: 'README.md', re: /(\d+)\s+languages/, value: s.locales },
+    { file: 'public/llms.txt', re: /(\d+)\s+languages with RTL support/, value: s.locales },
+    { file: 'public/llms-full.txt', re: /(\d+)\s+languages with RTL support/, value: s.locales },
     { file: 'README.md', re: /(\d+)\+\s+curated news feeds/, value: s.feedDefinitions, min: true },
     { file: 'README.md', re: /(\d+)\s+stock exchanges/, value: s.stockExchangeCount },
     { file: 'docs/overview.mdx', re: /(\d+)\+\s+curated news feeds/, value: s.feedDefinitions, min: true },
@@ -347,7 +349,7 @@ function claims(s) {
     { file: 'docs/features.mdx', re: /(\d+)\s+data layers/, value: s.layerDefinitions },
 
     { file: 'docs/agent-discovery.mdx', re: /all (\d+)\s+services/, value: s.protoServices },
-    { file: 'docs/api-reference.mdx', re: /all (\d+)\s+services/, value: s.protoServices },
+    { file: 'docs/api-reference.mdx', re: /all (\d+)\s+generated services/, value: s.protoServices },
 
     { file: 'docs/data-sources.mdx', re: /monitors (\d+)\s+data sources/, value: s.freshnessSources },
     { file: 'docs/data-sources.mdx', re: /across (\d+)\s+monitored airports/, value: s.airportCount },

--- a/tests/cii-docs-drift.test.mts
+++ b/tests/cii-docs-drift.test.mts
@@ -424,14 +424,14 @@ describe('CII docs drift guards', () => {
     assert.match(llmsBrief, /six specialized variants/i);
     assert.match(llmsBrief, /56 map layer types/i);
     assert.match(llmsBrief, /500\+ curated RSS feeds/i);
-    assert.match(llmsBrief, /24 languages/i);
+    assert.match(llmsBrief, /25 languages/i);
     assert.match(llmsFull, /Country Instability Index \(CII v8\)[\s\S]{0,240}31 Tier-1 countries/i);
     assert.match(llmsFull, /eventScore = unrest \* 0\.25 \+ conflict \* 0\.30 \+ security \* 0\.20 \+ information \* 0\.25/i);
     assert.match(llmsFull, /Country Resilience Index \(CRI\)[\s\S]{0,160}196-country public rankable universe/i);
     assert.match(llmsFull, /six specialized variants/i);
     assert.match(llmsFull, /56 map layer types/i);
     assert.match(llmsFull, /500\+ RSS feeds/i);
-    assert.match(llmsFull, /24 languages/i);
+    assert.match(llmsFull, /25 languages/i);
     assert.match(pressKit, /server-authoritative CII v8[\s\S]{0,120}31 Tier-1 countries/i);
     assert.match(pressKit, /Country Resilience Index[\s\S]{0,140}196-country public rankable universe/i);
     assert.match(pressKit, /six thematic variants/i);


### PR DESCRIPTION
## Summary

WorldMonitor's agent/developer docs now match the live auth, routing, OAuth, MCP, and generated-service contracts again. The fix removes the dead `/developers` key path, replaces the phantom catch-all gateway instructions with the real per-domain edge gateway pattern, and makes the MCP error catalog describe all current limiter strings and error sites without line-number anchors.

The public LLM docs now report the source-derived 25-language count, and `docs:check` pins those `llms` claims to the locale registry. The API reference no longer claims every generated service has a dedicated sidebar page; it points reviewers to the bundled spec for all 35 generated services and calls out Leads under Platform Endpoints.

Closes #4829.

## What changed

- `auth.md` now directs agents to the live `/pro` entry point and signed-in dashboard settings for API key creation/revocation instead of the nonexistent `/developers` page.
- `adding-endpoints.mdx` now shows `api/<domain>/v1/[rpc].ts` plus `createDomainGateway(...)`, and explains that generated service routes enforce RPC paths and HTTP annotations.
- `api-oauth.mdx` now shows the real Dynamic Client Registration response shape: UUID `client_id`, no `client_id_issued_at`.
- `mcp-error-catalog.mdx` now documents API-key, Pro bearer, and anonymous discovery `-32029` strings, clarifies anonymous public discovery versus credential-less 401s, and replaces the remaining stale `Site` line numbers with stable function/switch anchors.
- `llms.txt`, `llms-full.txt`, docs-stats, and the focused drift test now use/check 25 languages.
- `api-reference.mdx` now distinguishes documented sidebar groups from the complete bundled OpenAPI spec and mentions Leads under Platform Endpoints.

## Verification

- `npm run worktree:bootstrap:test-only` — passed
- `npm run docs:check` — passed, 75 doc claims match code
- `/usr/bin/env TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/cii-docs-drift.test.mts` — passed, 7/7
- `/usr/bin/env TMPDIR=/tmp ./node_modules/.bin/tsx --test tests/deploy-config.test.mjs` — passed, 105/105
- `rg "/developers|api/\[\[\.\.\.path\]\]|allRoutes|client_id_issued_at|24 languages" public/auth.md docs/adding-endpoints.mdx docs/api-oauth.mdx docs/mcp-error-catalog.mdx public/llms.txt public/llms-full.txt docs/api-reference.mdx` — no matches
- `rg 'api/mcp/[^`[:space:]|]+:[0-9]+' docs/mcp-error-catalog.mdx` — no matches
- `git diff --check` — passed
- Pre-push hook — passed twice: typecheck, API typecheck, Convex typecheck, boundary/safe-html/Sentry/rate-limit/premium-fetch checks, edge bundle check, changed test file, markdown lint, MDX lint, proto/pro-test freshness checks, version check

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
