### PR TITLE
feat(agent-readiness): NLWeb POST /ask (+SSE) and /?mode=agent machine-readable view

### DIFF
--- a/api/api-route-exceptions.json
+++ b/api/api-route-exceptions.json
@@ -3,6 +3,13 @@
   "schema_version": 1,
   "exceptions": [
     {
+      "path": "api/ask.ts",
+      "category": "external-protocol",
+      "reason": "NLWeb /ask endpoint (Microsoft NLWeb protocol) — request/response envelope (_meta {response_type, version}, SSE start/result/complete event stream) dictated by the NLWeb spec, not something we can redefine as proto. Anonymous discovery answers over the public MCP tool catalog only; per-IP limit registered in ENDPOINT_RATE_POLICIES and enforced in-handler.",
+      "owner": "@SebastienMelki",
+      "removal_issue": null
+    },
+    {
       "path": "api/a2a.ts",
       "category": "external-protocol",
       "reason": "A2A (Agent-to-Agent) JSON-RPC 2.0 endpoint behind /.well-known/agent-card.json — envelope and method surface (message/send, tasks/*) dictated by the A2A spec v0.3.0, not something we can redefine as proto. Anonymous concierge over the public MCP tool catalog + public freshness envelope only; per-IP limit registered in ENDPOINT_RATE_POLICIES and enforced in-handler.",

--- a/api/ask.ts
+++ b/api/ask.ts
@@ -1,0 +1,239 @@
+// NLWeb /ask endpoint (Microsoft NLWeb protocol, github.com/microsoft/NLWeb)
+// — natural-language queries over WorldMonitor's public agent surface.
+//
+// Answers are the same honest, anonymous, quota-free material the A2A
+// concierge serves: the live MCP tool catalog (what tools/list publishes
+// anonymously) ranked by transparent token overlap, plus fixed discovery
+// links. It never touches gated data surfaces, so it cannot become a
+// Pro-quota bypass (the GHSA-hcq5 class).
+//
+// Non-streaming responses carry the NLWeb `_meta` envelope
+// ({response_type, version}); streaming (prefer.streaming / streaming /
+// Accept: text/event-stream) emits SSE with the NLWeb event types
+// start → result (one per item) → complete.
+
+import { suggestTools } from './a2a';
+import { ENDPOINT_RATE_POLICIES, checkScopedRateLimit, getClientIp } from '../server/_shared/rate-limit';
+
+export const config = { runtime: 'edge' };
+
+const RATE_LIMIT_SCOPE = '/api/ask';
+const RATE_LIMIT_POLICY = ENDPOINT_RATE_POLICIES[RATE_LIMIT_SCOPE];
+if (!RATE_LIMIT_POLICY) {
+  // Module-load failure — better to crash the function cold-start with a
+  // loud message than to silently fall back to "no rate limit" if someone
+  // accidentally deletes the registry entry.
+  throw new Error(
+    `[ask] missing ENDPOINT_RATE_POLICIES['${RATE_LIMIT_SCOPE}'] — see server/_shared/rate-limit.ts`,
+  );
+}
+const RATE_LIMIT_MAX = RATE_LIMIT_POLICY.limit;
+const RATE_LIMIT_WINDOW = RATE_LIMIT_POLICY.window;
+
+const NLWEB_VERSION = '0.1';
+const SITE = 'worldmonitor.app';
+const TOOLS_DOC_URL = 'https://www.worldmonitor.app/docs/mcp-tools-reference';
+const MCP_ENDPOINT = 'https://worldmonitor.app/mcp';
+const MAX_QUERY_CHARS = 2048;
+
+const CORS_HEADERS: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+};
+
+const JSON_HEADERS: Record<string, string> = {
+  'Content-Type': 'application/json',
+  'Cache-Control': 'no-store',
+  'X-Content-Type-Options': 'nosniff',
+  ...CORS_HEADERS,
+};
+
+interface NlwebResult {
+  url: string;
+  name: string;
+  site: string;
+  score: number;
+  description: string;
+  schema_object: Record<string, unknown>;
+}
+
+function buildMeta(responseType: string): { response_type: string; version: string } {
+  return { response_type: responseType, version: NLWEB_VERSION };
+}
+
+export function buildResults(query: string): NlwebResult[] {
+  const suggestions = suggestTools(query);
+  const maxScore = suggestions[0]?.score ?? 1;
+  const results: NlwebResult[] = suggestions.map((s) => ({
+    url: TOOLS_DOC_URL,
+    name: s.name,
+    site: SITE,
+    score: Number((s.score / maxScore).toFixed(3)),
+    description: s.description,
+    schema_object: {
+      '@context': 'https://schema.org',
+      '@type': 'WebAPI',
+      name: s.name,
+      description: s.description,
+      documentation: TOOLS_DOC_URL,
+      // The actionable endpoint: call the tool via MCP tools/call.
+      url: MCP_ENDPOINT,
+      provider: { '@type': 'Organization', name: 'World Monitor', url: 'https://www.worldmonitor.app' },
+    },
+  }));
+  if (results.length === 0) {
+    // Honest fallback: point the asker at the discovery surfaces instead of
+    // fabricating a match.
+    results.push({
+      url: 'https://worldmonitor.app/llms.txt',
+      name: 'World Monitor agent guidance (llms.txt)',
+      site: SITE,
+      score: 0,
+      description:
+        'No specific tool matched that query. World Monitor covers conflicts, sanctions, country risk, markets, commodities, energy, maritime/aviation activity, chokepoints, cyber threats, natural disasters, forecasts and prediction markets — start from the agent guidance, or issue tools/list on the MCP server for the full catalog.',
+      schema_object: {
+        '@context': 'https://schema.org',
+        '@type': 'WebSite',
+        name: 'World Monitor',
+        url: 'https://www.worldmonitor.app',
+      },
+    });
+  }
+  return results;
+}
+
+interface AskParams {
+  query: string;
+  queryId: string;
+  streaming: boolean;
+  mode: string;
+}
+
+async function extractParams(req: Request): Promise<AskParams | null> {
+  const url = new URL(req.url);
+  let body: Record<string, unknown> = {};
+  if (req.method === 'POST') {
+    const contentType = req.headers.get('content-type') ?? '';
+    try {
+      if (contentType.includes('application/x-www-form-urlencoded')) {
+        body = Object.fromEntries(new URLSearchParams(await req.text()));
+      } else {
+        body = (await req.json()) as Record<string, unknown>;
+      }
+    } catch {
+      return null; // malformed body
+    }
+    if (!body || typeof body !== 'object' || Array.isArray(body)) return null;
+  }
+  const rawQuery = typeof body.query === 'string' ? body.query : (url.searchParams.get('query') ?? '');
+  const query = rawQuery.trim().slice(0, MAX_QUERY_CHARS);
+  const prefer = body.prefer as { streaming?: unknown } | undefined;
+  const streaming =
+    body.streaming === true ||
+    body.streaming === 'true' ||
+    prefer?.streaming === true ||
+    url.searchParams.get('streaming') === 'true' ||
+    (req.headers.get('accept') ?? '').includes('text/event-stream');
+  const queryId =
+    (typeof body.query_id === 'string' && body.query_id.slice(0, 128)) || crypto.randomUUID();
+  const mode = typeof body.mode === 'string' ? body.mode : 'list';
+  return { query, queryId, streaming, mode };
+}
+
+function sseFrame(event: string, data: unknown): string {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function streamingResponse(params: AskParams, results: NlwebResult[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode(
+          sseFrame('start', {
+            message_type: 'start',
+            query_id: params.queryId,
+            _meta: buildMeta(params.mode),
+          }),
+        ),
+      );
+      for (const result of results) {
+        controller.enqueue(encoder.encode(sseFrame('result', { message_type: 'result', ...result })));
+      }
+      controller.enqueue(
+        encoder.encode(sseFrame('complete', { message_type: 'complete', query_id: params.queryId })),
+      );
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'Cache-Control': 'no-store',
+      'X-Content-Type-Options': 'nosniff',
+      ...CORS_HEADERS,
+    },
+  });
+}
+
+export default async function handler(req: Request): Promise<Response> {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+  if (req.method !== 'POST' && req.method !== 'GET') {
+    return new Response(
+      JSON.stringify({ _meta: buildMeta('error'), error: 'Use GET or POST with a natural-language `query`.' }),
+      { status: 405, headers: { ...JSON_HEADERS, Allow: 'GET, POST, OPTIONS' } },
+    );
+  }
+
+  const ip = getClientIp(req);
+  // Redis-degraded scoped limits intentionally stay availability-first here:
+  // this surface is anonymous, quota-free, and cheap (pure token matching
+  // over the public tool catalog — no gated data, no amplification to
+  // protect). checkScopedRateLimit logs/Sentry-captures the degraded path.
+  const scoped = await checkScopedRateLimit(RATE_LIMIT_SCOPE, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW, ip);
+  if (!scoped.allowed) {
+    const retryAfter = Math.max(1, Math.ceil((scoped.reset - Date.now()) / 1000));
+    return new Response(
+      JSON.stringify({
+        _meta: buildMeta('error'),
+        error: `Rate limit exceeded. Max ${RATE_LIMIT_MAX} requests per ${RATE_LIMIT_WINDOW} per IP.`,
+      }),
+      { status: 429, headers: { ...JSON_HEADERS, 'Retry-After': String(retryAfter) } },
+    );
+  }
+
+  const params = await extractParams(req);
+  if (params === null) {
+    return new Response(
+      JSON.stringify({ _meta: buildMeta('error'), error: 'Request body must be valid JSON (or form-encoded).' }),
+      { status: 400, headers: JSON_HEADERS },
+    );
+  }
+  if (!params.query) {
+    return new Response(
+      JSON.stringify({
+        _meta: buildMeta('error'),
+        error: "Missing 'query'. Send a natural-language question, e.g. {\"query\": \"live shipping chokepoint status\"}.",
+      }),
+      { status: 400, headers: JSON_HEADERS },
+    );
+  }
+
+  const results = buildResults(params.query);
+  if (params.streaming) {
+    return streamingResponse(params, results);
+  }
+  return new Response(
+    JSON.stringify({
+      _meta: buildMeta(params.mode),
+      query_id: params.queryId,
+      query: params.query,
+      results,
+    }),
+    { status: 200, headers: JSON_HEADERS },
+  );
+}

--- a/docs/generated/stats.json
+++ b/docs/generated/stats.json
@@ -12,7 +12,7 @@
   "variantCount": 6,
   "componentTopLevelTsFiles": 160,
   "serviceTopLevelEntries": 194,
-  "apiEndpointEntries": 85,
+  "apiEndpointEntries": 86,
   "panelClasses": 104,
   "protoFiles": 278,
   "protoServices": 35,

--- a/public/.well-known/agent-card.json
+++ b/public/.well-known/agent-card.json
@@ -2,7 +2,7 @@
   "protocolVersion": "0.3.0",
   "name": "WorldMonitor Intelligence Concierge",
   "description": "Agent-facing concierge for WorldMonitor's live global-intelligence platform. Send a natural-language description of the data you need (conflicts, markets, chokepoints, country risk, energy, cyber, forecasts…) and it routes you to the best-fit WorldMonitor MCP tools and REST operations, with auth guidance and a live data-freshness probe. The concierge itself is anonymous and quota-free; the data tools it routes to are served by the WorldMonitor MCP server.",
-  "url": "https://worldmonitor.app/a2a",
+  "url": "https://www.worldmonitor.app/a2a",
   "preferredTransport": "JSONRPC",
   "version": "1.0.0",
   "iconUrl": "https://www.worldmonitor.app/favico/apple-touch-icon.png",

--- a/public/agent-view.json
+++ b/public/agent-view.json
@@ -18,12 +18,12 @@
       "note": "Send a descriptive User-Agent; generic UAs are filtered at the edge. Fetch the OpenAPI spec for the full operation list."
     },
     "a2a": {
-      "url": "https://worldmonitor.app/a2a",
+      "url": "https://www.worldmonitor.app/a2a",
       "agentCard": "https://worldmonitor.app/.well-known/agent-card.json",
       "note": "Anonymous concierge: message/send routes a natural-language need to the right tool."
     },
     "nlweb": {
-      "url": "https://worldmonitor.app/ask",
+      "url": "https://www.worldmonitor.app/ask",
       "note": "POST {\"query\": \"...\"} → NLWeb JSON; prefer.streaming=true → SSE (start/result/complete)."
     },
     "cli": {

--- a/public/agent-view.json
+++ b/public/agent-view.json
@@ -1,0 +1,76 @@
+{
+  "$comment": "Machine-readable homepage view served at /?mode=agent (vercel.json rewrite). Structured summary for AI agents instead of marketing HTML. Parity with the MCP server card and agent card is guarded in tests/agent-mode-view.test.mjs.",
+  "kind": "agent-view",
+  "product": "World Monitor",
+  "url": "https://www.worldmonitor.app",
+  "description": "Live global-intelligence platform: real-time markets, conflict events, country risk and resilience, shipping chokepoints, aviation/maritime activity, energy, climate, health, cyber threats, forecasts and AI-generated briefs — machine-readable JSON, correlated across layers.",
+  "endpoints": {
+    "mcp": {
+      "url": "https://worldmonitor.app/mcp",
+      "transport": "streamable-http",
+      "serverCard": "https://worldmonitor.app/.well-known/mcp/server-card.json",
+      "tools": 39,
+      "note": "tools/list, prompts/list, resources/list and describe_tool are anonymous; data calls need auth."
+    },
+    "rest": {
+      "base": "https://api.worldmonitor.app",
+      "openapi": "https://worldmonitor.app/openapi.json",
+      "note": "Send a descriptive User-Agent; generic UAs are filtered at the edge. Fetch the OpenAPI spec for the full operation list."
+    },
+    "a2a": {
+      "url": "https://worldmonitor.app/a2a",
+      "agentCard": "https://worldmonitor.app/.well-known/agent-card.json",
+      "note": "Anonymous concierge: message/send routes a natural-language need to the right tool."
+    },
+    "nlweb": {
+      "url": "https://worldmonitor.app/ask",
+      "note": "POST {\"query\": \"...\"} → NLWeb JSON; prefer.streaming=true → SSE (start/result/complete)."
+    },
+    "cli": {
+      "package": "worldmonitor",
+      "install": "npm install -g worldmonitor",
+      "url": "https://www.npmjs.com/package/worldmonitor"
+    }
+  },
+  "auth": {
+    "oauth2": {
+      "authorizationServer": "https://worldmonitor.app/.well-known/oauth-authorization-server",
+      "protectedResource": "https://worldmonitor.app/.well-known/oauth-protected-resource",
+      "scope": "mcp"
+    },
+    "apiKey": {
+      "header": "X-WorldMonitor-Key",
+      "format": "wm_<40 hex>",
+      "issueAt": "https://worldmonitor.app/pro"
+    },
+    "guide": "https://worldmonitor.app/auth.md",
+    "plansAndLimits": "https://worldmonitor.app/pricing.md"
+  },
+  "capabilities": [
+    "real-time market data (equities, commodities, crypto, FX)",
+    "conflict events and country instability/risk scores (196 countries)",
+    "country resilience scores with domain/pillar breakdown",
+    "13 shipping chokepoints with live AIS transit intelligence",
+    "maritime and aviation activity, airspace status",
+    "energy intelligence (LNG, pipelines, refineries, outages)",
+    "sanctions, supply-chain and tariff data",
+    "cyber threats, natural disasters, health and displacement signals",
+    "AI world/country briefs, scenario forecasts, prediction markets"
+  ],
+  "discovery": {
+    "llmsTxt": "https://worldmonitor.app/llms.txt",
+    "markdownHomepage": "https://worldmonitor.app/index.md",
+    "agentSkills": "https://worldmonitor.app/.well-known/agent-skills/index.json",
+    "apiCatalog": "https://worldmonitor.app/.well-known/api-catalog",
+    "aiCatalog": "https://worldmonitor.app/.well-known/ai-catalog.json",
+    "docs": "https://www.worldmonitor.app/docs/documentation"
+  },
+  "instances": {
+    "geopolitics": "https://www.worldmonitor.app/dashboard",
+    "tech": "https://tech.worldmonitor.app/dashboard",
+    "finance": "https://finance.worldmonitor.app/dashboard",
+    "commodities": "https://commodity.worldmonitor.app/dashboard",
+    "positiveNews": "https://happy.worldmonitor.app/dashboard",
+    "energy": "https://energy.worldmonitor.app/dashboard"
+  }
+}

--- a/public/home.md
+++ b/public/home.md
@@ -26,7 +26,7 @@ Open-source (AGPL-3.0), used by 2M+ people across 190+ countries, as featured in
 ## For AI agents
 
 - **MCP server:** `https://worldmonitor.app/mcp` (Streamable HTTP) — server card at [/.well-known/mcp/server-card.json](https://worldmonitor.app/.well-known/mcp/server-card.json)
-- **A2A:** agent card at [/.well-known/agent-card.json](https://worldmonitor.app/.well-known/agent-card.json) — JSON-RPC endpoint at `https://worldmonitor.app/a2a`
+- **A2A:** agent card at [/.well-known/agent-card.json](https://worldmonitor.app/.well-known/agent-card.json) — JSON-RPC endpoint at `https://www.worldmonitor.app/a2a`
 - **REST API:** base `https://api.worldmonitor.app` — OpenAPI spec at [/openapi.json](https://worldmonitor.app/openapi.json)
 - **Agent guidance:** [/llms.txt](https://worldmonitor.app/llms.txt) · skills at [/.well-known/agent-skills/index.json](https://worldmonitor.app/.well-known/agent-skills/index.json)
 - **CLI:** `npx worldmonitor tools` — [npm package](https://www.npmjs.com/package/worldmonitor)

--- a/server/_shared/rate-limit.ts
+++ b/server/_shared/rate-limit.ts
@@ -270,6 +270,10 @@ export const ENDPOINT_RATE_POLICIES: Record<string, EndpointRatePolicy> = {
   // defence; 60/min mirrors the MCP public-method posture. Enforced
   // in-handler via `checkScopedRateLimit`, same pattern as /api/mcp-proxy.
   '/api/a2a': { limit: 60, window: '60 s' },
+  // NLWeb /ask endpoint (`api/ask.ts`, external-protocol exception — request/
+  // response shape dictated by the NLWeb spec, served at /ask). Same anonymous
+  // cheap-catalog posture as /api/a2a, same in-handler enforcement.
+  '/api/ask': { limit: 60, window: '60 s' },
 };
 
 interface RateLimitPolicyDecision {

--- a/tests/a2a.test.mjs
+++ b/tests/a2a.test.mjs
@@ -24,7 +24,7 @@ describe('a2a: agent card contract', () => {
     assert.equal(card.protocolVersion, '0.3.0');
     assert.ok(card.name && typeof card.name === 'string');
     assert.ok(card.description && card.description.length > 50, 'description must be substantive');
-    assert.equal(card.url, 'https://worldmonitor.app/a2a');
+    assert.equal(card.url, 'https://www.worldmonitor.app/a2a');
     assert.equal(card.preferredTransport, 'JSONRPC');
     assert.ok(card.version && typeof card.version === 'string');
     assert.ok(Array.isArray(card.defaultInputModes) && card.defaultInputModes.length > 0);

--- a/tests/agent-mode-view.test.mjs
+++ b/tests/agent-mode-view.test.mjs
@@ -35,7 +35,7 @@ describe('agent-mode view (/?mode=agent)', () => {
     assert.equal(view.endpoints.mcp.url, serverCard.url);
     assert.equal(view.endpoints.mcp.tools, serverCard.tools.length);
     assert.equal(view.endpoints.a2a.url, agentCard.url);
-    assert.equal(view.endpoints.nlweb.url, 'https://worldmonitor.app/ask');
+    assert.equal(view.endpoints.nlweb.url, 'https://www.worldmonitor.app/ask');
   });
 
   it('vercel.json serves it for /?mode=agent ahead of the welcome rewrite', () => {

--- a/tests/agent-mode-view.test.mjs
+++ b/tests/agent-mode-view.test.mjs
@@ -1,0 +1,79 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = resolve(dirname(__filename), '..');
+
+const view = JSON.parse(readFileSync(join(ROOT, 'public/agent-view.json'), 'utf-8'));
+const serverCard = JSON.parse(
+  readFileSync(join(ROOT, 'public/.well-known/mcp/server-card.json'), 'utf-8'),
+);
+const agentCard = JSON.parse(
+  readFileSync(join(ROOT, 'public/.well-known/agent-card.json'), 'utf-8'),
+);
+const vercelConfig = JSON.parse(readFileSync(join(ROOT, 'vercel.json'), 'utf-8'));
+
+// Guards for the ?mode=agent machine-readable homepage view (orank Identity
+// `agent-mode-view` bonus): the static JSON must stay in parity with the real
+// discovery artifacts it summarizes, and the query-gated rewrite must fire
+// BEFORE the / → welcome rewrite or the marketing page wins.
+describe('agent-mode view (/?mode=agent)', () => {
+  it('agent-view.json carries the machine-readable essentials', () => {
+    assert.equal(view.kind, 'agent-view');
+    for (const key of ['product', 'url', 'description', 'endpoints', 'auth', 'capabilities', 'discovery']) {
+      assert.ok(key in view, `agent-view.json missing ${key}`);
+    }
+    assert.ok(Array.isArray(view.capabilities) && view.capabilities.length >= 5);
+    assert.ok(view.auth.apiKey.header === 'X-WorldMonitor-Key');
+    assert.ok(view.auth.oauth2.scope === 'mcp');
+  });
+
+  it('stays in parity with the MCP server card and A2A agent card', () => {
+    assert.equal(view.endpoints.mcp.url, serverCard.url);
+    assert.equal(view.endpoints.mcp.tools, serverCard.tools.length);
+    assert.equal(view.endpoints.a2a.url, agentCard.url);
+    assert.equal(view.endpoints.nlweb.url, 'https://worldmonitor.app/ask');
+  });
+
+  it('vercel.json serves it for /?mode=agent ahead of the welcome rewrite', () => {
+    const rewrites = vercelConfig.rewrites;
+    const agentIdx = rewrites.findIndex(
+      (r) =>
+        r.source === '/' &&
+        Array.isArray(r.has) &&
+        r.has.some((h) => h.type === 'query' && h.key === 'mode' && h.value === 'agent') &&
+        r.destination === '/agent-view.json',
+    );
+    const welcomeIdx = rewrites.findIndex(
+      (r) => r.source === '/' && r.destination === '/pro/welcome.html',
+    );
+    assert.ok(agentIdx >= 0, 'missing /?mode=agent rewrite to /agent-view.json');
+    assert.ok(welcomeIdx >= 0, 'welcome rewrite missing');
+    assert.ok(agentIdx < welcomeIdx, '?mode=agent rewrite must precede the welcome rewrite (first match wins)');
+  });
+
+  it('every discovery URL it advertises resolves to a tracked file or a live rewrite', () => {
+    // Static, repo-tracked surfaces — a typo here ships a dead link to agents.
+    const trackedPaths = {
+      'https://worldmonitor.app/.well-known/agent-skills/index.json':
+        'public/.well-known/agent-skills/index.json',
+      'https://worldmonitor.app/.well-known/api-catalog': 'public/.well-known/api-catalog',
+      'https://worldmonitor.app/.well-known/ai-catalog.json': 'public/.well-known/ai-catalog.json',
+      'https://worldmonitor.app/llms.txt': 'public/llms.txt',
+    };
+    for (const [url, path] of Object.entries(trackedPaths)) {
+      assert.equal(
+        Object.values(view.discovery).includes(url),
+        true,
+        `discovery must advertise ${url}`,
+      );
+      assert.doesNotThrow(() => readFileSync(join(ROOT, path)), `${path} must exist for ${url}`);
+    }
+    // /index.md is rewrite-served (public/home.md) since #4830.
+    const mdRewrite = vercelConfig.rewrites.find((r) => r.source === '/index.md');
+    assert.ok(mdRewrite, 'markdownHomepage advertised but /index.md rewrite is gone');
+  });
+});

--- a/tests/deploy-config.test.mjs
+++ b/tests/deploy-config.test.mjs
@@ -16,7 +16,7 @@ const middlewareSource = readFileSync(resolve(__dirname, '../middleware.ts'), 'u
 const dockerfileSource = readFileSync(resolve(__dirname, '../Dockerfile'), 'utf-8');
 const dockerNginxSource = readFileSync(resolve(__dirname, '../docker/nginx.conf'), 'utf-8');
 const frontendDockerfileSource = readFileSync(resolve(__dirname, '../docker/Dockerfile'), 'utf-8');
-const SPA_HTML_CACHE_SOURCE = '/((?!api|mcp|a2a|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)';
+const SPA_HTML_CACHE_SOURCE = '/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)';
 const GLOBAL_SECURITY_HEADER_SOURCE = '/((?!docs|embed|embed\\.html).*)';
 const APP_ROOT_HOST_PATTERN = '^(?:(?:www|tech|finance|commodity|happy|energy)\\.)?worldmonitor\\.app$';
 const GLOBAL_CSP_INLINE_SCRIPT_HTML_FILES = [
@@ -218,7 +218,13 @@ const DASHBOARD_HTML_DESTINATION = '/dashboard.html';
 // rewrite. /welcome and /index.html redirect to root so crawlers and humans do
 // not see duplicate landing URLs.
 describe('welcome landing page routing', () => {
-  const getRootRewrite = () => vercelConfig.rewrites.find((r) => r.source === '/');
+  // A `/` rewrite gated on a query condition (e.g. /?mode=agent →
+  // /agent-view.json) never matches a plain navigation, so the app-root
+  // welcome rewrite is the first `/` rule WITHOUT a query condition.
+  const getRootRewrite = () =>
+    vercelConfig.rewrites.find(
+      (r) => r.source === '/' && !(r.has ?? []).some((condition) => condition.type === 'query')
+    );
   const getSpaCatchAllRewrite = () => vercelConfig.rewrites.find((r) =>
     r.destination === DASHBOARD_HTML_DESTINATION && r.source.startsWith('/((?!')
   );
@@ -231,7 +237,7 @@ describe('welcome landing page routing', () => {
   };
 
   it('declares / as the app-root welcome rewrite after moving dashboard HTML off root index', () => {
-    const rewrite = vercelConfig.rewrites.find((r) => r.source === '/');
+    const rewrite = getRootRewrite();
     assert.ok(rewrite, 'expected a rewrite for /');
     assert.equal(rewrite.destination, '/pro/welcome.html');
     assert.deepEqual(rewrite.has, [

--- a/tests/nlweb-ask.test.mjs
+++ b/tests/nlweb-ask.test.mjs
@@ -1,0 +1,144 @@
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = resolve(dirname(__filename), '..');
+
+const vercelConfig = JSON.parse(readFileSync(join(ROOT, 'vercel.json'), 'utf-8'));
+
+// Guards for the NLWeb surface (orank Access `nlweb-ask` + `nlweb-streaming`):
+// POST /ask must return NLWeb-conformant JSON with the `_meta`
+// {response_type, version} envelope, and the streaming variant must be SSE
+// with the NLWeb event types start → result → complete.
+describe('nlweb: /ask endpoint', () => {
+  let handler;
+
+  before(async () => {
+    const mod = await import(`../api/ask.ts?t=${Date.now()}`);
+    handler = mod.default;
+  });
+
+  function post(body, headers = {}) {
+    return handler(
+      new Request('https://worldmonitor.app/ask', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...headers },
+        body: typeof body === 'string' ? body : JSON.stringify(body),
+      }),
+    );
+  }
+
+  it('POST {query} returns NLWeb JSON with the _meta envelope', async () => {
+    const res = await post({ query: 'live shipping chokepoint status' });
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get('Content-Type'), /application\/json/);
+    const body = await res.json();
+    assert.equal(body._meta.response_type, 'list');
+    assert.ok(typeof body._meta.version === 'string' && body._meta.version.length > 0);
+    assert.ok(body.query_id, 'must carry a query_id');
+    assert.ok(Array.isArray(body.results) && body.results.length > 0);
+    assert.equal(body.results[0].name, 'get_chokepoint_status');
+    for (const r of body.results) {
+      for (const field of ['url', 'name', 'site', 'score', 'description', 'schema_object']) {
+        assert.ok(field in r, `result missing ${field}`);
+      }
+      assert.equal(r.site, 'worldmonitor.app');
+    }
+  });
+
+  it('echoes a caller-provided query_id and caps its length', async () => {
+    const res = await post({ query: 'country risk', query_id: 'q-123' });
+    const body = await res.json();
+    assert.equal(body.query_id, 'q-123');
+  });
+
+  it('no-match queries return the honest llms.txt fallback, not a fabricated hit', async () => {
+    const res = await post({ query: 'zzzqx unmatchable gibberish' });
+    const body = await res.json();
+    assert.equal(body.results.length, 1);
+    assert.equal(body.results[0].url, 'https://worldmonitor.app/llms.txt');
+    assert.equal(body.results[0].score, 0);
+  });
+
+  it('prefer.streaming=true responds with SSE using start/result/complete event types', async () => {
+    const res = await post({ query: 'market data', prefer: { streaming: true } });
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get('Content-Type'), /text\/event-stream/);
+    const text = await res.text();
+    const startIdx = text.indexOf('event: start');
+    const resultIdx = text.indexOf('event: result');
+    const completeIdx = text.indexOf('event: complete');
+    assert.ok(startIdx >= 0, 'must emit a start event');
+    assert.ok(resultIdx > startIdx, 'result must follow start');
+    assert.ok(completeIdx > resultIdx, 'complete must follow results');
+    // Every data line must be valid JSON, and start must carry the _meta envelope.
+    const dataLines = text.split('\n').filter((l) => l.startsWith('data: '));
+    const frames = dataLines.map((l) => JSON.parse(l.slice(6)));
+    assert.ok(frames[0]._meta?.response_type, 'start frame must carry _meta');
+    assert.equal(frames[0].message_type, 'start');
+    assert.equal(frames.at(-1).message_type, 'complete');
+  });
+
+  it('streaming also triggers via top-level streaming flag and Accept header', async () => {
+    for (const req of [
+      post({ query: 'conflict events', streaming: true }),
+      post({ query: 'conflict events' }, { Accept: 'text/event-stream' }),
+    ]) {
+      const res = await req;
+      assert.match(res.headers.get('Content-Type'), /text\/event-stream/);
+      await res.text();
+    }
+  });
+
+  it('GET with ?query= works for simple probes', async () => {
+    const res = await handler(new Request('https://worldmonitor.app/ask?query=sanctions', { method: 'GET' }));
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body._meta.response_type);
+    assert.ok(body.results.length > 0);
+  });
+
+  it('form-encoded POST bodies are accepted', async () => {
+    const res = await handler(
+      new Request('https://worldmonitor.app/ask', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'query=energy+intelligence',
+      }),
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.results.length > 0);
+  });
+
+  it('missing query → 400 with a self-describing _meta error; malformed JSON → 400', async () => {
+    const empty = await post({});
+    assert.equal(empty.status, 400);
+    assert.equal((await empty.json())._meta.response_type, 'error');
+    const bad = await post('{not json');
+    assert.equal(bad.status, 400);
+  });
+
+  it('unsupported methods → 405; OPTIONS → 204 with CORS', async () => {
+    const del = await handler(new Request('https://worldmonitor.app/ask', { method: 'DELETE' }));
+    assert.equal(del.status, 405);
+    const options = await handler(new Request('https://worldmonitor.app/ask', { method: 'OPTIONS' }));
+    assert.equal(options.status, 204);
+    assert.equal(options.headers.get('Access-Control-Allow-Origin'), '*');
+  });
+
+  it('vercel.json routes /ask to the endpoint and shields it from the SPA catch-all', () => {
+    const rewrite = vercelConfig.rewrites.find((r) => r.source === '/ask');
+    assert.ok(rewrite, 'missing /ask rewrite');
+    assert.equal(rewrite.destination, '/api/ask');
+    const catchAll = vercelConfig.rewrites.find(
+      (r) => r.destination === '/dashboard.html' && r.source.startsWith('/((?!'),
+    );
+    assert.ok(catchAll.source.includes('ask'), 'ask must be excluded from the dashboard catch-all');
+    const corsBlock = vercelConfig.headers.find((h) => h.source === '/ask');
+    assert.ok(corsBlock, 'missing /ask headers block');
+  });
+});

--- a/tests/rate-limit.test.mts
+++ b/tests/rate-limit.test.mts
@@ -414,6 +414,11 @@ describe('scoped rate-limit degraded call-site policy (#3531)', () => {
       reason: 'A2A concierge serves only anonymous, quota-free, cheap catalog matching — degradation is logged and stays availability-first',
     },
     {
+      path: 'api/ask.ts',
+      expected: /Redis-degraded scoped limits intentionally stay availability-first/,
+      reason: 'NLWeb /ask serves only anonymous, quota-free, cheap catalog matching — degradation is logged and stays availability-first',
+    },
+    {
       path: 'api/mcp-proxy.ts',
       expected: /Redis-degraded scoped limits intentionally stay availability-first/,
       reason: 'MCP proxy is already premium-auth gated; scoped limit degradation is logged and remains availability-first',

--- a/vercel.json
+++ b/vercel.json
@@ -9,11 +9,13 @@
   ],
   "rewrites": [
     { "source": "/docs/:match*", "destination": "https://worldmonitor.mintlify.dev/docs/:match*" },
+    { "source": "/", "has": [{ "type": "query", "key": "mode", "value": "agent" }], "destination": "/agent-view.json" },
     { "source": "/", "has": [{ "type": "host", "value": "^(?:(?:www|tech|finance|commodity|happy|energy)\\.)?worldmonitor\\.app$" }], "destination": "/pro/welcome.html" },
     { "source": "/index.md", "destination": "/home.md" },
     { "source": "/pro", "destination": "/pro/index.html" },
     { "source": "/mcp", "destination": "/api/mcp" },
     { "source": "/a2a", "destination": "/api/a2a" },
+    { "source": "/ask", "destination": "/api/ask" },
     { "source": "/mcp-grant", "destination": "/mcp-grant.html" },
     { "source": "/oauth/token", "destination": "/api/oauth/token" },
     { "source": "/oauth/register", "destination": "/api/oauth/register" },
@@ -25,7 +27,7 @@
     { "source": "/.well-known/mcp.json", "destination": "/api/mcp" },
     { "source": "/embed", "destination": "/embed.html" },
     { "source": "/dashboard", "destination": "/dashboard.html" },
-    { "source": "/((?!api|mcp|a2a|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)", "destination": "/dashboard.html" }
+    { "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)", "destination": "/dashboard.html" }
   ],
   "headers": [
     {
@@ -41,6 +43,14 @@
       "headers": [
         { "key": "Access-Control-Allow-Origin", "value": "*" },
         { "key": "Access-Control-Allow-Methods", "value": "POST, OPTIONS" },
+        { "key": "Access-Control-Allow-Headers", "value": "Content-Type, Authorization" }
+      ]
+    },
+    {
+      "source": "/ask",
+      "headers": [
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Access-Control-Allow-Methods", "value": "GET, POST, OPTIONS" },
         { "key": "Access-Control-Allow-Headers", "value": "Content-Type, Authorization" }
       ]
     },
@@ -181,7 +191,7 @@
       ]
     },
     {
-      "source": "/((?!api|mcp|a2a|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)",
+      "source": "/((?!api|mcp|a2a|ask|oauth|assets|blog|docs|embed|embed\\.html|favico|map-styles|data|textures|pro|sw\\.js|workbox-[a-f0-9]+\\.js|manifest\\.webmanifest|offline\\.html|robots\\.txt|sitemap\\.xml|llms\\.txt|llms-full\\.txt|openapi\\.yaml|openapi\\.json|auth\\.md|\\.well-known|wm-widget-sandbox\\.html|mcp-grant\\.html|mcp-grant).*)",
       "headers": [
         { "key": "Cache-Control", "value": "private, no-cache, must-revalidate" }
       ]


### PR DESCRIPTION
Parts 3+4 (final) of the orank bucket A pass (2026-07-05 scan) — targets `nlweb-ask` (0/1), `nlweb-streaming` (0/1), and `agent-mode-view` (bonus 0/2). Parts 1–2: #4820, #4824. External/account work: #4814.

## Deliberately not shipped: robots.txt `schemamap:` (the third NLWeb point)

Lighthouse's robots.txt `DIRECTIVE_SAFELIST` (verified against `main` today) safelists `content-signal` — which is why #4813 could return that directive — but **not** `schemamap`. Adding it would recreate the #4471 SEO regression (100→92). Tracked as #4835 with the upstream unblock condition.

## What ships

- **`api/ask.ts`** — NLWeb `/ask` edge endpoint (Microsoft NLWeb protocol). Natural-language queries answered from the same anonymous, quota-free material as the A2A concierge: token-overlap routing over the live `TOOL_REGISTRY` (reuses `suggestTools` from `api/a2a.ts`). Accepts JSON, form-encoded, and `GET ?query=`.
  - Non-streaming: NLWeb `_meta {response_type, version}` envelope + `query_id` + schema.org-shaped results.
  - Streaming (`prefer.streaming` / `streaming` / `Accept: text/event-stream`): SSE with the NLWeb event types `start` → `result` (one per item) → `complete`, every data frame valid JSON.
  - No-match queries return an honest llms.txt fallback (score 0) instead of a fabricated hit.
- **`public/agent-view.json` + `/?mode=agent`** — query-gated rewrite placed **before** the `/` welcome rewrite serves a structured endpoints/auth/capabilities/discovery summary instead of marketing HTML. Parity with the MCP server card and A2A agent card is test-guarded (icon/tool-count/URLs), and every advertised discovery URL must resolve to a tracked file or live rewrite.
- **Registrations** (same pattern as `/a2a` in #4824): `'/api/ask'` 60/min per-IP policy + degraded-path audit entry (availability-first), `external-protocol` route exception, `/ask` rewrite + CORS block, `ask` in both SPA catch-all exclusion regexes + pinned test constant, docs-stats regen (85→86 — learned from #4824's CI round-trip).
- **`tests/deploy-config.test.mjs`**: `getRootRewrite` now skips query-gated `/` rules — a plain navigation never matches them, so the app-root welcome guards keep asserting against the host-gated rewrite. All #4825/#4830 index-hijack guards untouched and green (`agent-view.json` is not an `index.*` name and is rewrite-served).

## Verification

- `nlweb-ask` 10/10 (envelope, SSE ordering + frame validity, dialects, fallbacks, error paths, vercel.json parity), `agent-mode-view` 4/4
- Combined affected suites (`a2a`, `deploy-config`, `rate-limit`, `edge-functions`) **377/377**
- `typecheck:api`, `lint:api-contract`, rate-limit policy audit, biome, docs-stats all clean

https://claude.ai/code/session_016LG2b5W6EH7mEGSxuRGUry