### PR TITLE
docs(api): align idempotency contract

### DIFF
--- a/api/api-route-exceptions.json
+++ b/api/api-route-exceptions.json
@@ -406,8 +406,8 @@
     },
     {
       "path": "api/notify.ts",
-      "category": "ops-admin",
-      "reason": "Outbound notification dispatch (Slack/Discord/email) driven by cron. Internal, not a typed user API.",
+      "category": "internal-helper",
+      "reason": "Authenticated PRO event-publish endpoint that validates Clerk bearer auth, rejects relay-internal control events, and enqueues accepted events outside sebuf because it is queue plumbing rather than a typed domain RPC.",
       "owner": "@SebastienMelki",
       "removal_issue": null
     },

--- a/docs/api-commerce.mdx
+++ b/docs/api-commerce.mdx
@@ -17,6 +17,7 @@ Creates a Dodo checkout session and returns the hosted-checkout URL.
   { "productId": "pro-monthly", "returnUrl": "https://www.worldmonitor.app/pro/success" }
   ```
 - **Response**: `{ "checkoutUrl": "https://checkout.dodopayments.com/..." }`
+- **Idempotency**: optional `Idempotency-Key` supported for 10 minutes after a successful response. Retrying the same key with an identical body replays the original checkout response instead of creating another checkout attempt.
 - **returnUrl** is validated against an allowlist on the Convex side.
 
 ### `POST /api/customer-portal`
@@ -25,6 +26,7 @@ Creates a Dodo customer-portal session for an existing subscriber (update card, 
 
 - **Auth**: Clerk bearer + active entitlement
 - **Response**: `{ "portalUrl": "..." }`
+- **Idempotency**: optional `Idempotency-Key` supported. Retrying the same key replays the original portal response instead of creating another portal attempt.
 
 ## Product catalog
 
@@ -84,6 +86,7 @@ Returns the tier view-model used by the `/pro` pricing page. Cached in Redis und
 ```
 
 Notes:
+
 - Price fields are flat on the tier. Paid tiers expose `monthlyPrice` / `monthlyProductId` and `annualPrice` / `annualProductId`. Free uses `price: 0, period: "forever"`; Enterprise uses `price: null`.
 - Prices are dollars (Dodo returns cents; the handler divides by 100). Currency is implicit USD for the published catalog.
 
@@ -105,6 +108,7 @@ Returns the caller's deterministic referral code (an 8-char HMAC of the Clerk us
 ```
 
 Errors:
+
 - `401 UNAUTHENTICATED` — missing or invalid Clerk JWT.
 - `503 service_unavailable` — `BRIEF_URL_SIGNING_SECRET` not configured (the referral-code HMAC reuses that secret).
 

--- a/docs/api-notifications.mdx
+++ b/docs/api-notifications.mdx
@@ -42,6 +42,8 @@ Action-dispatched writer. The body's `action` field selects the mutation:
 
 All actions require Clerk bearer + PRO (`tier >= 1`). Invalid actions return `400 Unknown action`. Requests are forwarded to Convex via `RELAY_SHARED_SECRET`.
 
+- **Idempotency**: optional `Idempotency-Key` supported on `POST /api/notification-channels`. Retrying the same key with an identical body replays the original response instead of applying the channel action again.
+
 ## Webhook delivery contract
 
 When an alert fires, registered webhook URLs receive:
@@ -71,7 +73,9 @@ The envelope version is **shared across two producers** (`notification-relay`, `
 
 ### `POST /api/notify`
 
-Internal ingestion endpoint called by Railway producers to enqueue a notification. Requires `RELAY_SHARED_SECRET`. Not a public API.
+Authenticated event-publish endpoint for PRO callers. Requires Clerk bearer auth and an active PRO entitlement, then enqueues the accepted event into the notification queue. Relay-internal control events such as `flush_quiet_held` and `channel_welcome` are reserved and rejected.
+
+- **Idempotency**: optional `Idempotency-Key` supported. Retrying the same key with an identical body replays the original enqueue response instead of publishing the notification again.
 
 ## Telegram
 

--- a/docs/api-platform.mdx
+++ b/docs/api-platform.mdx
@@ -113,6 +113,8 @@ Per-user dashboard preferences (layout, toggles, filters). Clerk bearer required
 }
 ```
 
+- **Idempotency**: optional `Idempotency-Key` supported on `POST /api/user-prefs`. Retrying the same key with an identical body replays the original preferences response instead of applying the update again.
+
 ## API key cache invalidation
 
 ### `POST /api/invalidate-user-api-key-cache`

--- a/docs/usage-errors.mdx
+++ b/docs/usage-errors.mdx
@@ -35,7 +35,8 @@ OAuth endpoints follow [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rf
 | `403` | Authenticated but not entitled (usually `pro_required`) | No — upgrade |
 | `404` | Resource / tool / brief / entity not found | No |
 | `405` | Method not allowed | No |
-| `409` | Conflict (duplicate webhook registration, etc.) | No |
+| `409` | `Idempotency-Key` request still in progress, or another conflict such as duplicate webhook registration. | Yes for keyed in-flight requests - honor `Retry-After: 2`; otherwise no |
+| `422` | `Idempotency-Key` reused with a different request body. | No - resend the original body or use a new key |
 | `413` | Payload too large | No |
 | `429` | Rate limited | Yes — honor `Retry-After` |
 | `500` | Server bug | Yes — with backoff, then report |
@@ -56,12 +57,25 @@ OAuth endpoints follow [RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rf
 | `Service temporarily unavailable` | Upstash or another hard dependency missing at request time. |
 | `service_unavailable` | Signing secret / required env not configured. |
 | `Failed to enqueue scenario job` | Redis pipeline failure on `/api/scenario/v1/run-scenario`. |
+| `idempotency_conflict` | A POST with this `Idempotency-Key` is still processing. Retry after `Retry-After: 2`. |
+| `idempotency_key_reused` | The same `Idempotency-Key` was already used with a different request body. |
+| `invalid_idempotency_key` | The `Idempotency-Key` header is too long or contains non-printable characters. Generated OpenAPI POSTs also reject an empty key. |
+
+## Idempotency-Key
+
+All generated OpenAPI POST operations and these standalone write endpoints accept an optional `Idempotency-Key` request header: `POST /api/create-checkout`, `POST /api/customer-portal`, `POST /api/notify`, `POST /api/user-prefs`, and `POST /api/notification-channels`. Use a client-generated key for any POST that your client may retry after a network timeout or retryable 5xx.
+
+Retrying a POST with the same key and an identical request body replays the original completed response instead of re-executing the operation. The replay contract reproduces the original status, body, and Content-Type; success responses echo `Idempotency-Key` and set `Idempotent-Replayed: false` on the first response or `Idempotent-Replayed: true` on replay. Keys are scoped per authenticated caller, fall back to the source IP for unauthenticated endpoints, and are retained for 24 hours after a completed response unless the endpoint documents a shorter replay window.
+
+If the first request is still running, the retry returns `409 idempotency_conflict` with `Retry-After: 2`; retry after that delay with the same key and identical body. If the same key is reused with a different request body, the API returns `422 idempotency_key_reused`; do not retry unchanged, because the client must either send the original body or choose a new key for the new operation.
+
+For mutations this avoids duplicating the side effect, including async enqueues such as `POST /api/scenario/v1/run-scenario`. For batch-read POSTs, replay returns the cached snapshot and that snapshot can be up to 24 hours stale. A `409 idempotency_conflict` means the original keyed request is still running and keeps its in-flight lock until it completes. If the original execution itself returns a retryable status (`408`, `409`, `429`, or 5xx), that response is not cached and the processing lock is released, so a later retry may re-execute the operation and should only be sent when the endpoint contract is safe for that retry or the client can tolerate re-execution.
 
 ## Retry strategy
 
 **Idempotent reads** (`GET`): retry 429/5xx with exponential backoff (1s, 2s, 4s, cap 30s, 5 attempts). Most GET responses are cached at the edge, so the retry usually goes faster.
 
-**Writes**: never auto-retry 4xx. For 5xx on writes, inspect: `POST /api/brief/share-url` and `POST /api/v2/shipping/webhooks` are idempotent; `POST /api/scenario/v1/run-scenario` is **not** — it enqueues a new job on each call. Retrying a 5xx on `run-scenario` may double-charge the rate-limit counter.
+**Writes**: send `Idempotency-Key` on any POST you may retry. Never auto-retry most 4xx responses; the exception is `409 idempotency_conflict`, which means a keyed request is still in flight and can be retried after `Retry-After: 2` with the same key and identical body. 5xx responses are not cached for replay even when a key is present; retry with exponential backoff only when the endpoint contract is safe for a repeated execution or the client can tolerate that possibility. Without a key, inspect the endpoint contract before retrying because an unkeyed repeat can duplicate the side effect.
 
 **MCP**: the server returns tool errors in the JSON-RPC result with `isError: true` and a text explanation — those are not HTTP errors. Handle them at the tool-call layer.
 

--- a/tests/docs-idempotency-contract.test.mjs
+++ b/tests/docs-idempotency-contract.test.mjs
@@ -1,0 +1,191 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const read = (path) => readFileSync(resolve(root, path), 'utf8');
+
+const usageErrors = read('docs/usage-errors.mdx');
+const commerceDocs = read('docs/api-commerce.mdx');
+const notificationsDocs = read('docs/api-notifications.mdx');
+const platformDocs = read('docs/api-platform.mdx');
+const routeExceptions = JSON.parse(read('api/api-route-exceptions.json'));
+const scenarioOpenApi = JSON.parse(read('docs/api/ScenarioService.openapi.json'));
+const createCheckoutSource = read('api/create-checkout.ts');
+const notifySource = read('api/notify.ts');
+
+const standaloneWrites = [
+  {
+    doc: commerceDocs,
+    heading: 'POST /api/create-checkout',
+    path: '/api/create-checkout',
+    file: 'api/create-checkout.ts',
+  },
+  {
+    doc: commerceDocs,
+    heading: 'POST /api/customer-portal',
+    path: '/api/customer-portal',
+    file: 'api/customer-portal.ts',
+  },
+  {
+    doc: notificationsDocs,
+    heading: 'POST /api/notification-channels',
+    path: '/api/notification-channels',
+    file: 'api/notification-channels.ts',
+  },
+  {
+    doc: notificationsDocs,
+    heading: 'POST /api/notify',
+    path: '/api/notify',
+    file: 'api/notify.ts',
+  },
+  {
+    doc: platformDocs,
+    heading: 'POST /api/user-prefs',
+    path: '/api/user-prefs',
+    file: 'api/user-prefs.ts',
+  },
+];
+
+function idempotencyDescriptionFor(pathname) {
+  const operation = scenarioOpenApi.paths?.[pathname]?.post;
+  assert.ok(operation, `expected POST operation for ${pathname}`);
+  const param = (operation.parameters ?? []).find((p) => p?.name === 'Idempotency-Key');
+  assert.ok(param, `expected Idempotency-Key parameter for ${pathname}`);
+  return param.description ?? '';
+}
+
+function sectionForEndpoint(markdown, endpointHeading) {
+  const escapedEndpoint = endpointHeading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const heading = new RegExp(`^###\\s+\`${escapedEndpoint}\`\\s*$`, 'm');
+  const match = heading.exec(markdown);
+  assert.ok(match, `missing heading for ${endpointHeading}`);
+  const rest = markdown.slice(match.index + match[0].length);
+  const nextHeading = rest.search(/^#{1,3}\s+/m);
+  return nextHeading === -1 ? rest : rest.slice(0, nextHeading);
+}
+
+describe('docs Idempotency-Key prose contract', () => {
+  it('usage-errors mirrors the machine-readable idempotency source of truth', () => {
+    const openApiDescription = idempotencyDescriptionFor('/api/scenario/v1/run-scenario');
+
+    for (const phrase of [
+      'identical request body',
+      'status, body, and Content-Type',
+      '422',
+      'authenticated caller',
+      'source IP',
+      '24 hours',
+    ]) {
+      assert.match(
+        usageErrors,
+        new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'),
+        `usage-errors.mdx must mention "${phrase}" from the injector contract`,
+      );
+      assert.match(
+        openApiDescription,
+        new RegExp(phrase.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'i'),
+        `generated OpenAPI contract must continue to mention "${phrase}"`,
+      );
+    }
+
+    assert.doesNotMatch(
+      usageErrors,
+      /run-scenario` is \*\*not\*\*|may double-charge/i,
+      'run-scenario must not be documented as non-idempotent when keyed retries are supported',
+    );
+  });
+
+  it('usage-errors documents persistence limits for retryable statuses and checkout', () => {
+    assert.match(
+      usageErrors,
+      /5xx responses are not cached/i,
+      'usage-errors.mdx must state that keyed 5xx responses are not persisted for replay',
+    );
+    assert.match(
+      createCheckoutSource,
+      /completedTtlSeconds:\s*10\s*\*\s*60/,
+      'create-checkout must continue to declare its short checkout replay window',
+    );
+    assert.match(
+      sectionForEndpoint(commerceDocs, 'POST /api/create-checkout'),
+      /10 minutes/i,
+      'create-checkout docs must disclose its 10-minute replay window',
+    );
+  });
+
+  it('usage-errors documents retry guidance for in-flight and mismatched keys', () => {
+    assert.match(
+      usageErrors,
+      /\| `409` \|[^\n]*Idempotency-Key[^\n]*\| Yes[^\n]*Retry-After: 2/i,
+      '409 row must describe retryable in-flight keyed requests with Retry-After: 2',
+    );
+    assert.match(
+      usageErrors,
+      /\| `422` \|[^\n]*Idempotency-Key[^\n]*different request body[^\n]*\| No[^\n]*new key/i,
+      '422 row must describe mismatched-key reuse as non-retryable unchanged input',
+    );
+  });
+
+  it('standalone write endpoint docs mention Idempotency-Key support', () => {
+    for (const endpoint of standaloneWrites) {
+      assert.match(
+        usageErrors,
+        new RegExp(endpoint.heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+        `usage-errors.mdx must list ${endpoint.heading} as a standalone idempotent write`,
+      );
+      assert.match(
+        sectionForEndpoint(endpoint.doc, endpoint.heading),
+        /Idempotency-Key[\s\S]*same key[\s\S]*replays/i,
+        `${endpoint.heading} docs must mention Idempotency-Key replay support`,
+      );
+    }
+  });
+
+  it('standalone write endpoint docs are backed by handler idempotency wiring', () => {
+    for (const endpoint of standaloneWrites) {
+      const source = read(endpoint.file);
+      assert.match(source, /getIdempotencyKey/, `${endpoint.file} must read Idempotency-Key`);
+      assert.match(
+        source,
+        /beginStandaloneIdempotency/,
+        `${endpoint.file} must use the standalone idempotency helper`,
+      );
+      assert.match(
+        source,
+        new RegExp(`pathname:\\s*['"]${endpoint.path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"]`),
+        `${endpoint.file} must scope idempotency to ${endpoint.path}`,
+      );
+    }
+  });
+
+  it('notify docs match the standalone handler auth contract', () => {
+    const notifyDocs = sectionForEndpoint(notificationsDocs, 'POST /api/notify');
+    const notifyException = routeExceptions.exceptions.find((entry) => entry.path === 'api/notify.ts');
+    assert.match(notifySource, /validateBearerToken/, 'notify handler validates Clerk bearer tokens');
+    assert.match(notifySource, /features\.tier\s*<\s*1/, 'notify handler requires PRO entitlement');
+    assert.equal(notifyException?.category, 'internal-helper', 'notify route registry category');
+    assert.match(
+      notifyException?.reason ?? '',
+      /Clerk bearer auth/i,
+      'notify route registry must document Clerk bearer auth',
+    );
+    assert.match(
+      notifyException?.reason ?? '',
+      /PRO/i,
+      'notify route registry must document PRO entitlement',
+    );
+    assert.match(
+      notifyDocs,
+      /Clerk bearer[\s\S]*PRO/i,
+      'notify docs must document Clerk bearer auth and PRO entitlement',
+    );
+    assert.doesNotMatch(
+      `${notifyDocs}\n${notifyException?.reason ?? ''}`,
+      /RELAY_SHARED_SECRET|Not a public API/i,
+      'notify docs and route registry must not describe the old relay-secret/internal-only contract',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

WorldMonitor's API docs now describe `Idempotency-Key` the way the shipped OpenAPI contract and standalone handlers actually behave. `run-scenario` is documented as keyed-idempotent for retries, 409/422 guidance now matches the in-flight and payload-mismatch semantics, and the five standalone write endpoints from PR #4792 are called out in their API docs.

The docs also spell out the client-retry limits that matter: retryable 5xx responses are not cached for replay, checkout replays are retained for 10 minutes, and idempotency keys are scoped to the authenticated caller or source IP.

Closes #4828.

## Verification

- `/opt/homebrew/bin/gh-axi issue view 4828 --full`
- `/opt/homebrew/bin/gh-axi search prs "4828 OR idempotency OR Idempotency-Key"` -> `count: 0`
- `node --test tests/docs-idempotency-contract.test.mjs`
- `node --test tests/openapi-idempotency-contract.test.mjs`
- `npm run lint:api-contract`
- `npm run docs:check`
- `./node_modules/.bin/markdownlint-cli2 docs/usage-errors.mdx docs/api-commerce.mdx docs/api-notifications.mdx docs/api-platform.mdx`
- `git push -u origin codex/docs-idempotency-contract-4828` pre-push hook: typecheck, API typecheck, boundary/safe HTML/rate-limit/premium-fetch guards, edge bundle/tests, markdown/MDX lint, and version sync all passed

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![GPT_5](https://img.shields.io/badge/GPT_5-000000)