### PR TITLE
refactor(a2a): review follow-ups — shared suggestTools helper, method-echo cap, text/plain output mode

### DIFF
--- a/api/_agent-tool-suggest.ts
+++ b/api/_agent-tool-suggest.ts
@@ -1,0 +1,53 @@
+// Shared concierge routing used by the A2A endpoint (api/a2a.ts) and the
+// NLWeb /ask endpoint (api/ask.ts). Deliberately not NLU — a transparent
+// token-overlap score over the same names + descriptions tools/list
+// publishes anonymously. Name hits outweigh description hits so
+// "chokepoint status" lands on get_chokepoint_status, not on every tool
+// whose prose mentions shipping.
+//
+// Kept as a route-less helper (underscore prefix, like api/_crypto.js) so
+// neither endpoint's cold-start depends on the OTHER endpoint's module-level
+// guards (Greptile review on #4838).
+
+import { TOOL_REGISTRY } from './mcp/registry/index';
+
+const QUERY_STOPWORDS = new Set([
+  'the', 'and', 'for', 'with', 'what', 'which', 'who', 'how', 'where', 'when',
+  'need', 'want', 'give', 'gives', 'get', 'show', 'find', 'tool', 'tools',
+  'data', 'live', 'about', 'from', 'that', 'this', 'can', 'you', 'your',
+  'right', 'now', 'best', 'please', 'worldmonitor', 'world', 'monitor',
+]);
+
+function tokenize(text: string): string[] {
+  return [
+    ...new Set(
+      text
+        .toLowerCase()
+        .split(/[^a-z0-9]+/)
+        .filter((t) => t.length >= 3 && !QUERY_STOPWORDS.has(t)),
+    ),
+  ];
+}
+
+export interface ToolSuggestion {
+  name: string;
+  description: string;
+  score: number;
+}
+
+export function suggestTools(query: string, limit = 5): ToolSuggestion[] {
+  const tokens = tokenize(query);
+  if (tokens.length === 0) return [];
+  const scored: ToolSuggestion[] = [];
+  for (const tool of TOOL_REGISTRY) {
+    const nameTokens = new Set(tool.name.toLowerCase().split(/[^a-z0-9]+/));
+    const descTokens = new Set(tokenize(tool.description));
+    let score = 0;
+    for (const token of tokens) {
+      if (nameTokens.has(token)) score += 3;
+      else if (descTokens.has(token)) score += 1;
+    }
+    if (score > 0) scored.push({ name: tool.name, description: tool.description, score });
+  }
+  return scored.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name)).slice(0, limit);
+}

--- a/api/a2a.ts
+++ b/api/a2a.ts
@@ -13,9 +13,13 @@
 // objects are ever created, so capabilities.streaming/pushNotifications
 // stay false and tasks/* methods answer TaskNotFound.
 
-import { TOOL_REGISTRY } from './mcp/registry/index';
+import { suggestTools } from './_agent-tool-suggest';
 import { PUBLIC_RESOURCE_REGISTRY } from './mcp/resources/index';
 import { ENDPOINT_RATE_POLICIES, checkScopedRateLimit, getClientIp } from '../server/_shared/rate-limit';
+
+// Re-exported so existing consumers (tests, api/ask.ts historically) keep a
+// stable import surface; the implementation lives in the route-less helper.
+export { suggestTools, type ToolSuggestion } from './_agent-tool-suggest';
 
 export const config = { runtime: 'edge' };
 
@@ -70,55 +74,6 @@ function rpcResult(id: JsonRpcId, result: unknown): Response {
     status: 200,
     headers: BASE_HEADERS,
   });
-}
-
-// ---------------------------------------------------------------------------
-// route-to-tool: keyword scoring over the live tool catalog
-// ---------------------------------------------------------------------------
-// Deliberately not NLU — a transparent token-overlap score over the same
-// names + descriptions tools/list publishes. Name hits outweigh description
-// hits so "chokepoint status" lands on get_chokepoint_status, not on every
-// tool whose prose mentions shipping.
-
-const QUERY_STOPWORDS = new Set([
-  'the', 'and', 'for', 'with', 'what', 'which', 'who', 'how', 'where', 'when',
-  'need', 'want', 'give', 'gives', 'get', 'show', 'find', 'tool', 'tools',
-  'data', 'live', 'about', 'from', 'that', 'this', 'can', 'you', 'your',
-  'right', 'now', 'best', 'please', 'worldmonitor', 'world', 'monitor',
-]);
-
-function tokenize(text: string): string[] {
-  return [
-    ...new Set(
-      text
-        .toLowerCase()
-        .split(/[^a-z0-9]+/)
-        .filter((t) => t.length >= 3 && !QUERY_STOPWORDS.has(t)),
-    ),
-  ];
-}
-
-export interface ToolSuggestion {
-  name: string;
-  description: string;
-  score: number;
-}
-
-export function suggestTools(query: string, limit = 5): ToolSuggestion[] {
-  const tokens = tokenize(query);
-  if (tokens.length === 0) return [];
-  const scored: ToolSuggestion[] = [];
-  for (const tool of TOOL_REGISTRY) {
-    const nameTokens = new Set(tool.name.toLowerCase().split(/[^a-z0-9]+/));
-    const descTokens = new Set(tokenize(tool.description));
-    let score = 0;
-    for (const token of tokens) {
-      if (nameTokens.has(token)) score += 3;
-      else if (descTokens.has(token)) score += 1;
-    }
-    if (score > 0) scored.push({ name: tool.name, description: tool.description, score });
-  }
-  return scored.sort((a, b) => b.score - a.score || a.name.localeCompare(b.name)).slice(0, limit);
 }
 
 // Deliberately narrow: "current"/"latest" appear in ordinary data queries
@@ -309,6 +264,8 @@ export default async function handler(req: Request): Promise<Response> {
         message: 'No authenticated extended card is configured; the public card at /.well-known/agent-card.json is complete.',
       });
     default:
-      return rpcError(id, { code: -32601, message: `Method not found: '${rpc.method}'.` });
+      // Cap the echoed method name — an arbitrarily long one would otherwise
+      // be reflected into every default-branch response body (Greptile #4824).
+      return rpcError(id, { code: -32601, message: `Method not found: '${rpc.method.slice(0, 100)}'.` });
   }
 }

--- a/api/ask.ts
+++ b/api/ask.ts
@@ -12,7 +12,7 @@
 // Accept: text/event-stream) emits SSE with the NLWeb event types
 // start → result (one per item) → complete.
 
-import { suggestTools } from './a2a';
+import { suggestTools } from './_agent-tool-suggest';
 import { ENDPOINT_RATE_POLICIES, checkScopedRateLimit, getClientIp } from '../server/_shared/rate-limit';
 
 export const config = { runtime: 'edge' };

--- a/public/.well-known/agent-card.json
+++ b/public/.well-known/agent-card.json
@@ -18,7 +18,7 @@
   },
   "supportsAuthenticatedExtendedCard": false,
   "defaultInputModes": ["text/plain"],
-  "defaultOutputModes": ["application/json"],
+  "defaultOutputModes": ["text/plain", "application/json"],
   "skills": [
     {
       "id": "route-to-tool",


### PR DESCRIPTION
Applies all three Greptile review findings from #4838 and #4824 (which auto-merged before the fixes could ride along):

1. **Hidden module coupling (P2, #4838):** `api/ask.ts` imported `suggestTools` from `api/a2a.ts`, so `/ask`'s cold-start executed a2a's module-level rate-limit guard — a future `'/api/a2a'` policy removal would break `/ask` with a misleading `[a2a]` error. Extracted to `api/_agent-tool-suggest.ts` (route-less underscore helper, same convention as `api/_crypto.js`); both endpoints import it, `a2a.ts` re-exports for a stable surface. Pure move — no behaviour change.
2. **Unbounded method echo (P2, #4824):** the `-32601` branch now caps the reflected method name at 100 chars, closing the response-amplification path.
3. **`defaultOutputModes` spec nit (P2, #4824):** added `text/plain` — `message/send` always emits a `kind:"text"` part, so A2A v0.3.0 §5 wants it enumerated.

## Verification

- `a2a` + `nlweb-ask` + `agent-mode-view` + `edge-functions` **245/245**
- `typecheck:api`, `lint:api-contract` (helper correctly treated as a non-route file), biome all clean; docs-stats unchanged (underscore helpers aren't endpoint entries)

https://claude.ai/code/session_016LG2b5W6EH7mEGSxuRGUry