### PR TITLE
fix(docker): make the frontend GHCR image build (npm ci gyp + build:blog latent failures) (#4839)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,11 @@ WORKDIR /app
 COPY . .
 
 # Install all dependencies (including devDependencies for tsc, vite, etc.).
-RUN npm ci --include=dev
+# --ignore-scripts matches the sidecar image's proven install: it skips
+# node-gyp postinstalls (bufferutil/utf-8-validate have no prebuilt binary for
+# every buildx platform and the image carries no compiler toolchain) — those
+# are optional ws accelerators the frontend build never loads.
+RUN npm ci --include=dev --ignore-scripts
 
 # Build-time configuration. Pass via --build-arg. Other VITE_* vars (e.g. VITE_PMTILES_URL)
 # can be added here or via --build-arg for custom builds; see .env.example for the full list.
@@ -21,8 +25,10 @@ ARG VITE_WS_API_URL=https://api.worldmonitor.app
 ENV VITE_VARIANT=${VITE_VARIANT}
 ENV VITE_WS_API_URL=${VITE_WS_API_URL}
 
-# tsc + vite build (see package.json "build" script)
-RUN npm run build
+# tsc + vite build, invoked directly like the sidecar image's builder:
+# `npm run build` would chain build:blog (blog-site has its own lockfile,
+# not installed here) and the prebuild openapi/agent-skills generators.
+RUN npx tsc && npx vite build
 
 
 # Stage 2: Serve the built assets from nginx.


### PR DESCRIPTION
Closes #4839. `ghcr.io/koala73/worldmonitor` has never been published — the repo's Packages sidebar is empty — because `docker/Dockerfile` had two latent failures (the workflow only ever ran once, via manual dispatch while investigating that sidebar):

1. `npm ci --include=dev` compiles `bufferutil` with node-gyp when no prebuilt binary matches the buildx platform; `node:22-alpine` has no python3/make/g++ → hard failure (run 28738351765).
2. Had install passed, `npm run build` chains `build:blog`, whose `blog-site/` deps aren't installed in this image.

Fix mirrors the root sidecar Dockerfile's builder — the recipe CI already exercises on every PR (`sidecar` check): `npm ci --include=dev --ignore-scripts` (bufferutil/utf-8-validate are optional `ws` accelerators the frontend build never loads) and direct `npx tsc && npx vite build`.

After merge I'll re-dispatch `docker-publish.yml`; the package publishes via `GITHUB_TOKEN` from this public repo, so it should auto-link to the repo and populate the Packages sidebar.

https://claude.ai/code/session_01DJicKa3VSq7iwMk3E5nYyk