### PR TITLE
fix(nlweb): honour streaming on query-less probes + accept ?prefer.streaming=

### DIFF
--- a/api/ask.ts
+++ b/api/ask.ts
@@ -134,6 +134,7 @@ async function extractParams(req: Request): Promise<AskParams | null> {
     body.streaming === 'true' ||
     prefer?.streaming === true ||
     url.searchParams.get('streaming') === 'true' ||
+    url.searchParams.get('prefer.streaming') === 'true' ||
     (req.headers.get('accept') ?? '').includes('text/event-stream');
   const queryId =
     (typeof body.query_id === 'string' && body.query_id.slice(0, 128)) || crypto.randomUUID();
@@ -217,7 +218,13 @@ export default async function handler(req: Request): Promise<Response> {
     // A query-less probe gets a 200 with a conformant, self-describing NLWeb
     // envelope (empty results + usage) rather than a 4xx — scanners and
     // agents doing a bare existence check read a 4xx as "no endpoint here"
-    // (orank's nlweb-ask detector did exactly that).
+    // (orank's nlweb-ask detector did exactly that). When the probe asks for
+    // streaming, honour it: the same usage envelope goes out as SSE
+    // (start → complete) so a query-less streaming capability check sees
+    // text/event-stream, not JSON.
+    if (params.streaming) {
+      return streamingResponse(params, []);
+    }
     return new Response(
       JSON.stringify({
         _meta: buildMeta(params.mode),

--- a/tests/nlweb-ask.test.mjs
+++ b/tests/nlweb-ask.test.mjs
@@ -82,15 +82,25 @@ describe('nlweb: /ask endpoint', () => {
     assert.equal(frames.at(-1).message_type, 'complete');
   });
 
-  it('streaming also triggers via top-level streaming flag and Accept header', async () => {
+  it('streaming also triggers via top-level flag, Accept header, and ?prefer.streaming=', async () => {
     for (const req of [
       post({ query: 'conflict events', streaming: true }),
       post({ query: 'conflict events' }, { Accept: 'text/event-stream' }),
+      handler(new Request('https://worldmonitor.app/ask?query=markets&prefer.streaming=true', { method: 'GET' })),
     ]) {
       const res = await req;
       assert.match(res.headers.get('Content-Type'), /text\/event-stream/);
       await res.text();
     }
+  });
+
+  it('query-less streaming probes get the usage envelope as SSE, not JSON', async () => {
+    const res = await post({ prefer: { streaming: true } });
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get('Content-Type'), /text\/event-stream/);
+    const text = await res.text();
+    assert.ok(text.includes('event: start'), 'must open with a start event');
+    assert.ok(text.includes('event: complete'), 'must close with a complete event');
   });
 
   it('GET with ?query= works for simple probes', async () => {


### PR DESCRIPTION
Final rescan follow-up (after #4846 flipped `nlweb-ask` to pass): `nlweb-streaming` still failed because orank's streaming capability probe is **also query-less** — it fell into the JSON usage-envelope branch and saw `application/json`. A query-less streaming request now gets the same usage envelope as SSE (`start` → `complete` events), and `?prefer.streaming=true` joins the accepted flag spellings. Real streamed queries were already working (verified live pre-fix).

Verified: `nlweb-ask` 11/11, `typecheck:api` + biome clean. Will rescan after deploy.

https://claude.ai/code/session_016LG2b5W6EH7mEGSxuRGUry