### PR TITLE
feat(discovery): official MCP registry publication artifacts (app.worldmonitor namespace)

### DIFF
--- a/public/.well-known/mcp-registry-auth
+++ b/public/.well-known/mcp-registry-auth
@@ -1,0 +1,1 @@
+v=MCPv1; k=ed25519; p=EUgwVTuEiv/4mN4PCxtoKJZgE4dPWOjozRqP896BmZo=

--- a/server.json
+++ b/server.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "app.worldmonitor/mcp",
+  "title": "World Monitor",
+  "description": "WorldMonitor's live global-intelligence stack as an MCP server: real-time markets, conflict events, aviation, maritime, energy, climate, health, displacement, supply chain, and AI-generated regional briefs. 39 tools with JMESPath projection; discovery methods are anonymous.",
+  "websiteUrl": "https://www.worldmonitor.app",
+  "repository": {
+    "url": "https://github.com/koala73/worldmonitor",
+    "source": "github"
+  },
+  "version": "1.13.0",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://worldmonitor.app/mcp"
+    }
+  ]
+}

--- a/tests/mcp-registry-artifacts.test.mjs
+++ b/tests/mcp-registry-artifacts.test.mjs
@@ -1,0 +1,53 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const ROOT = resolve(dirname(__filename), '..');
+
+// Guards for the official MCP registry publication artifacts
+// (registry.modelcontextprotocol.io, namespace app.worldmonitor):
+// - public/.well-known/mcp-registry-auth is the HTTP domain-verification
+//   surface. If it 404s or its format drifts, every future `mcp-publisher
+//   login http` fails and the namespace is unrecoverable without DNS access.
+// - server.json is the published registry entry. Its version/remote must
+//   track the MCP server card; on a SERVER_VERSION bump, bump server.json
+//   too and republish (`mcp-publisher publish` with the domain key at
+//   ~/.config/worldmonitor/mcp-registry-ed25519.pem).
+describe('mcp registry publication artifacts', () => {
+  const authFile = readFileSync(join(ROOT, 'public/.well-known/mcp-registry-auth'), 'utf-8');
+  const serverJson = JSON.parse(readFileSync(join(ROOT, 'server.json'), 'utf-8'));
+  const serverCard = JSON.parse(
+    readFileSync(join(ROOT, 'public/.well-known/mcp/server-card.json'), 'utf-8'),
+  );
+
+  it('mcp-registry-auth carries a single MCPv1 ed25519 key line', () => {
+    assert.match(
+      authFile,
+      /^v=MCPv1; k=ed25519; p=[A-Za-z0-9+/]{43}=\n$/,
+      'format must stay `v=MCPv1; k=ed25519; p=<base64>` — the registry parses it verbatim',
+    );
+  });
+
+  it('server.json stays in the app.worldmonitor namespace with the canonical remote', () => {
+    assert.equal(serverJson.name, 'app.worldmonitor/mcp');
+    assert.equal(serverJson.remotes.length, 1);
+    assert.equal(serverJson.remotes[0].type, 'streamable-http');
+    assert.equal(
+      serverJson.remotes[0].url,
+      serverCard.url,
+      'registry remote must match the server card MCP endpoint',
+    );
+    assert.equal(serverJson.websiteUrl, 'https://www.worldmonitor.app');
+  });
+
+  it('server.json version tracks the server card (bump both + republish on SERVER_VERSION change)', () => {
+    assert.equal(
+      serverJson.version,
+      serverCard.version,
+      'SERVER_VERSION bumped without bumping server.json — update it and republish to registry.modelcontextprotocol.io (see test header)',
+    );
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -71,6 +71,14 @@
       ]
     },
     {
+      "source": "/.well-known/mcp-registry-auth",
+      "headers": [
+        { "key": "Content-Type", "value": "text/plain; charset=utf-8" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Cache-Control", "value": "public, max-age=3600" }
+      ]
+    },
+    {
       "source": "/.well-known/(.*)",
       "headers": [
         { "key": "Access-Control-Allow-Origin", "value": "*" },


### PR DESCRIPTION
Bucket B item 1 from #4814 (`mcp-registry-listed` 0/1, est **+1.2** — the best external ROI on the board). orank's check accepts "publish the server under your own domain" — the official MCP registry (registry.modelcontextprotocol.io) domain namespace is exactly that, and it's bi-directionally verified by construction (namespace = proven domain ownership). No account needed: the registry supports **HTTP domain verification** via a well-known file, so this is fully automatable.

## What ships

- **`public/.well-known/mcp-registry-auth`** — Ed25519 public key in the `v=MCPv1; k=ed25519; p=…` format the registry's verifier fetches. The private key lives only at `~/.config/worldmonitor/mcp-registry-ed25519.pem` (0600, outside any repo).
- **`server.json`** — the registry entry: `app.worldmonitor/mcp`, remote `streamable-http https://worldmonitor.app/mcp` (same apex dialect the server card proves against orank, #4806), `websiteUrl`, repository, version 1.13.0.
- **vercel.json** — explicit `text/plain` for the well-known auth file (extensionless).
- **`tests/mcp-registry-artifacts.test.mjs`** — format guard on the auth file (a 404 or drift bricks future `mcp-publisher login http`), name/remote parity with the server card, and version parity so a SERVER_VERSION bump also bumps `server.json` (+ republish, one command, documented in the test header).

## After merge + deploy

`mcp-publisher login http --domain=worldmonitor.app` + `mcp-publisher publish` runs from this session; then a follow-up adds the registry backlink to docs and the orank rescan verifies the flip.

Part of #4814.

https://claude.ai/code/session_016LG2b5W6EH7mEGSxuRGUry