### PR TITLE
docs(mcp): registry backlinks + sync server.json with the published entry

### DIFF
--- a/docs/mcp-overview.mdx
+++ b/docs/mcp-overview.mdx
@@ -30,6 +30,8 @@ Pro subscribers can connect Claude Desktop / Cursor / claude.ai without ever pas
 
 Server identifier: `worldmonitor` v1.13.0.
 
+Registry listing: the server is published in the [official MCP registry](https://registry.modelcontextprotocol.io/v0/servers?search=worldmonitor) as `app.worldmonitor/mcp` — a domain-verified namespace, so clients that resolve servers through the registry get the same endpoint and metadata as the server card above.
+
 ### Protocol negotiation
 
 WorldMonitor's static server card at `/.well-known/mcp/server-card.json` advertises protocol version `2025-06-18`, and the live `initialize` handshake negotiates it by default — so the advertised floor and the negotiated version stay in lock-step:

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -23,7 +23,7 @@ Reach for World Monitor when a task needs live, correlated, machine-readable glo
 
 **How an agent should call it:**
 
-- **MCP server (recommended):** `https://worldmonitor.app/mcp` — Streamable HTTP, 39 tools; issue `tools/list` for the live inventory. Auth: OAuth2 (`scope=mcp`) or an API key header `X-WorldMonitor-Key: wm_<40-hex>`. Server card: https://worldmonitor.app/.well-known/mcp/server-card.json
+- **MCP server (recommended):** `https://worldmonitor.app/mcp` — Streamable HTTP, 39 tools; issue `tools/list` for the live inventory. Auth: OAuth2 (`scope=mcp`) or an API key header `X-WorldMonitor-Key: wm_<40-hex>`. Server card: https://worldmonitor.app/.well-known/mcp/server-card.json · Registry entry: `app.worldmonitor/mcp` in the official MCP registry (registry.modelcontextprotocol.io)
 - **REST API:** base `https://api.worldmonitor.app`; OpenAPI spec at https://worldmonitor.app/openapi.yaml; same `X-WorldMonitor-Key` header.
 - **CLI:** `npx worldmonitor tools` lists every tool (public, no key); `npm install -g worldmonitor` installs the `worldmonitor` command. A zero-dependency, MCP-first client for the tools and REST API above — pass `--api-key` for data calls. https://www.npmjs.com/package/worldmonitor
 - **Agent Skills:** discovery manifest at https://worldmonitor.app/.well-known/agent-skills/index.json

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -23,7 +23,7 @@ Reach for World Monitor when a task needs live, correlated, machine-readable glo
 
 **How an agent should call it:**
 
-- **MCP server (recommended):** `https://worldmonitor.app/mcp` — Streamable HTTP, 39 tools; issue `tools/list` for the live inventory. Auth: OAuth2 (`scope=mcp`) or an API key header `X-WorldMonitor-Key: wm_<40-hex>`. Server card: https://worldmonitor.app/.well-known/mcp/server-card.json
+- **MCP server (recommended):** `https://worldmonitor.app/mcp` — Streamable HTTP, 39 tools; issue `tools/list` for the live inventory. Auth: OAuth2 (`scope=mcp`) or an API key header `X-WorldMonitor-Key: wm_<40-hex>`. Server card: https://worldmonitor.app/.well-known/mcp/server-card.json · Registry entry: `app.worldmonitor/mcp` in the official MCP registry (registry.modelcontextprotocol.io)
 - **REST API:** base `https://api.worldmonitor.app`; OpenAPI spec at https://worldmonitor.app/openapi.yaml; same `X-WorldMonitor-Key` header.
 - **CLI:** `npx worldmonitor tools` lists every tool (public, no key); `npm install -g worldmonitor` installs the `worldmonitor` command. A zero-dependency, MCP-first client for the tools and REST API above — pass `--api-key` for data calls. https://www.npmjs.com/package/worldmonitor
 - **SDKs:** official zero-dependency client libraries — Python `pip install worldmonitor-sdk` (https://pypi.org/project/worldmonitor-sdk/), Ruby `gem install worldmonitor` (https://rubygems.org/gems/worldmonitor), Go `go get github.com/koala73/worldmonitor/sdk/go` (https://pkg.go.dev/github.com/koala73/worldmonitor/sdk/go), JavaScript via the npm package above. Guide: https://www.worldmonitor.app/docs/sdks

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "app.worldmonitor/mcp",
   "title": "World Monitor",
-  "description": "WorldMonitor's live global-intelligence stack as an MCP server: real-time markets, conflict events, aviation, maritime, energy, climate, health, displacement, supply chain, and AI-generated regional briefs. 39 tools with JMESPath projection; discovery methods are anonymous.",
+  "description": "Live global intelligence: real-time markets, conflicts, country risk, chokepoints, energy. 39 tools.",
   "websiteUrl": "https://www.worldmonitor.app",
   "repository": {
     "url": "https://github.com/koala73/worldmonitor",


### PR DESCRIPTION
Follow-up to #4849. **`app.worldmonitor/mcp` v1.13.0 is now LIVE in the official MCP registry** — published from this session via HTTP domain verification, confirmed `status: active` through the public API:

```
GET https://registry.modelcontextprotocol.io/v0/servers?search=worldmonitor
→ { name: "app.worldmonitor/mcp", version: "1.13.0", status: "active",
    website: "https://www.worldmonitor.app", remote: "https://worldmonitor.app/mcp" }
```

This PR closes the loop:
- **server.json** — description shortened to the registry's 100-char cap (learned from a 422 on the first publish attempt); the committed file now matches the published entry byte-for-byte.
- **docs/mcp-overview.mdx + llms.txt + llms-full.txt** — registry-entry backlink next to the server card reference (the "link the registry entry from your homepage or docs" half of orank's `mcp-registry-listed` check; the domain namespace itself is the verified half).

Verification: `mcp-registry-artifacts` 3/3, `docs:check` clean, biome clean.

Part of #4814. Smithery (the other registry orank names) remains login-gated — instructions posted on the issue.

https://claude.ai/code/session_016LG2b5W6EH7mEGSxuRGUry