### PR TITLE
feat(seo): link the Wikidata item (Q140439514) from the homepage sameAs

### DIFF
--- a/pro-test/welcome.html
+++ b/pro-test/welcome.html
@@ -167,7 +167,7 @@
       "operatingSystem": "Web, Windows, macOS, Linux, Android TV",
       "url": "https://worldmonitor.app",
       "description": "Free real-time global intelligence dashboard. 500+ news feeds, conflict tracking, market data, shipping chokepoints, satellite passes and cyber signals fused into one live map of the world, with AI analysis layered on top.",
-      "sameAs": ["https://github.com/koala73/worldmonitor", "https://www.npmjs.com/package/worldmonitor"],
+      "sameAs": ["https://www.wikidata.org/wiki/Q140439514", "https://github.com/koala73/worldmonitor", "https://www.npmjs.com/package/worldmonitor"],
       "author": {
         "@type": "Person",
         "name": "Elie Habib",

--- a/public/pro/welcome.html
+++ b/public/pro/welcome.html
@@ -167,7 +167,7 @@
       "operatingSystem": "Web, Windows, macOS, Linux, Android TV",
       "url": "https://worldmonitor.app",
       "description": "Free real-time global intelligence dashboard. 500+ news feeds, conflict tracking, market data, shipping chokepoints, satellite passes and cyber signals fused into one live map of the world, with AI analysis layered on top.",
-      "sameAs": ["https://github.com/koala73/worldmonitor", "https://www.npmjs.com/package/worldmonitor"],
+      "sameAs": ["https://www.wikidata.org/wiki/Q140439514", "https://github.com/koala73/worldmonitor", "https://www.npmjs.com/package/worldmonitor"],
       "author": {
         "@type": "Person",
         "name": "Elie Habib",


### PR DESCRIPTION
Elie created the World Monitor Wikidata item today (Q140439514 — label, description, aliases live, statements being added incl. P856=worldmonitor.app). This adds it to the homepage `SoftwareApplication` `sameAs` array, giving knowledge graphs a resolvable authority profile. Targets orank `json-ld-entity-linking` (1/2 → 2/2, its recommendation literally names Wikidata) and complements `wikipedia-presence` (bonus 0/4, est 1.3). Pro bundle rebuilt — the diff is one JSON-LD line in source + built output. ld+json is data (no CSP hash impact). Part of #4814.

https://claude.ai/code/session_016LG2b5W6EH7mEGSxuRGUry